### PR TITLE
[Feature Request]Makes executable works when not in Elixir's directory. 

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -1,2 +1,7 @@
 #!/bin/sh
-erl -I include -noshell -pa ebin -eval "elixir:boot(), elixir:require_file(\"$1\", [\".\"]), halt()."
+
+SCRIPT=$(readlink -f $0)
+SCRIPT_PATH=`dirname $SCRIPT`
+ELIXIR_PATH=`cd $SCRIPT_PATH; cd ..; pwd` 
+
+ELIXIR_PATH=$ELIXIR_PATH erl -I $ELIXIR_PATH/include -noshell -pa $ELIXIR_PATH/ebin -eval "elixir:boot(), elixir:require_file(\"$1\", [\".\"]), halt()."

--- a/src/elixir.erl
+++ b/src/elixir.erl
@@ -12,7 +12,10 @@ boot() ->
 % the default binding is Object, which at this point is not defined.
 load_core_classes() ->
   Dirname = filename:dirname(?FILE),
-  Basepath = filename:join([Dirname, "..", "lib"]),
+  Basepath = case os:getenv("ELIXIR_PATH") of
+    false -> filename:join([Dirname, "..", "lib"]);
+    Path -> filename:join([Path, "lib"])
+  end,
   Loader = fun(Class) ->
     Filepath = filename:join(Basepath, Class),
     {ok, Binary} = file:read_file(Filepath),
@@ -41,7 +44,8 @@ require_file(Path) ->
   Dirname = filename:dirname(?FILE),
   Paths = [
     filename:join([Dirname, "..", "lib"]),
-    filename:join([Dirname, "..", "test", "elixir"])
+    filename:join([Dirname, "..", "test", "elixir"]),
+    "."
   ],
   require_file(Path ++ ".ex", Paths).
 


### PR DESCRIPTION
Not really a pull request, just code snippets for discussion. 

My scenario is: 
- The elixir repository is in `~/work/elixir`
- The elixir programs is in `~/work/elixir-testbed`
- A elixir file required another elixir file inside elixir-testbed [Example](https://github.com/gaagaaga/elixir-testbed/blob/f8b7341bcda3bdcdec1d88ff2614666be0d1b119/bf_hello.ex#L1)

And type

```
cd ~/work/elixir-testbed
~/work/elixir/bin/elixir bf_hello.ex
```

to run the Elixir program. 

Currently, here are two problems to be solved: 
- `?FILE` macro cannot detect absolute directory, so the stdlib can't be loaded successfully. 
- `bf_hello` cannot require `brainfuck` because current directory is not in require path list by default. 

I made a quick and dirty fix. It enables me to write Elixir code in another repository, but I think it's not good enough to be commit. 

This is a low priority feature request, welcome to discuss, or give me some implementation comment. 
