### PR TITLE
aliased Object#__parent__ and Object#__parent_name__ as Object#parent and Object#class respectively

### DIFF
--- a/lib/object.ex
+++ b/lib/object.ex
@@ -33,6 +33,14 @@ object Object
       Erlang.elixir_object_methods.parent_name(self)
     end
 
+    def class
+      __parent_name__
+    end
+ 
+    def parent
+      __parent__
+    end
+
     def __parent__
       Erlang.elixir_object_methods.parent(self)
     end

--- a/test/elixir/object_test.ex
+++ b/test/elixir/object_test.ex
@@ -68,6 +68,10 @@ object ObjectTest
 
     parent = child.__parent__
     [] = child.__parent_name__
+
+    'List = [].class
+    [] = Object.class
+    [] = Object.parent
   end
 
   def inspect_test


### PR DESCRIPTION
This makes it much more concise to find classes and parents.
    [].class % 'List
    Object.parent % []
