### PR TITLE
Small fixes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ Currently, functions do not support partial applications or pipes, but such feat
 
 ## Variables and Pattern Matching
 
-Variables in Elixir work differently from Erlang. You can assigned to them several times:
+Variables in Elixir work differently from Erlang. You can assign values to the same variable several times:
 
     x = 1
     x = 2


### PR DESCRIPTION
I'm reading through the README trying to learn Elixir properly :) and I stumbled across a few typos and style issues.

They are all in different commits but I can squash them into one, the question is should all of them be applied (for example I'm not sure about the .beam file part)
