### PR TITLE
Making tuples not raise 'badarg error when [] called with out ouf bounds index. Return nil instead.

### DIFF
--- a/lib/tuple.ex
+++ b/lib/tuple.ex
@@ -13,15 +13,20 @@ module Tuple
     %     {1,2,3}[0] % => 1
     %     {1,2,3}[1] % => 2
     %     {1,2,3}[2] % => 3
-    %     {1,2,3}[3] % => Raises 'badarg error
+    %     {1,2,3}[3] % => nil
     %
     %     {1,2,3}[-1] % => 3
     %     {1,2,3}[-2] % => 2
     %     {1,2,3}[-3] % => 1
-    %     {1,2,3}[-4] % => Raises 'badarg error
+    %     {1,2,3}[-4] % => nil
     %
     def [](number)
-      Erlang.element(erl_index(number), self)
+      index = erl_index(number)
+      if index > 0 && index <= self.length
+        Erlang.element(index, self)
+      else
+        nil
+      end
     end
 
     % Sets the given element in the tuple. Also accepts negative indexes

--- a/test/elixir/tuple_test.exs
+++ b/test/elixir/tuple_test.exs
@@ -4,22 +4,28 @@ module TupleTest
   mixin ExUnit::Case
 
   def brackets_test
-    1 = {1,2,3}[0]
-    2 = {1,2,3}[1]
-    3 = {1,2,3}[2]
+    1   = {1,2,3}[0]
+    2   = {1,2,3}[1]
+    3   = {1,2,3}[2]
+    nil = {1,2,3}[3]
 
-    assert_error 'badarg, do
-      {1,2,3}[3]
-    end
   end
 
   def brackets_negative_index_test
-    1 = {1,2,3}[-3]
-    2 = {1,2,3}[-2]
-    3 = {1,2,3}[-1]
+    1   = {1,2,3}[-3]
+    2   = {1,2,3}[-2]
+    3   = {1,2,3}[-1]
+    nil = {1,2,3}[-4]
 
+  end
+
+  def brackets_invalid_index_type_test
     assert_error 'badarg, do
-      {1,2,3}[-4]
+      {1,2,3}["somestring"]
+    end
+    % TODO: Fix this assertion when Tuple#[] raises 'badarg when atom is passed
+    assert_error 'undef, do
+      {1,2,3}['someatom]
     end
   end
 


### PR DESCRIPTION
In lists sending an out of bounds index to [] results in a nil

```
[1,2,3][3] # => nil
```

However in a tuple it raises a 'badarg error:

```
{1,2,3}[3] # => error 'badarg
```

In this pull request I corrected the behavior for Tuple, however I'm not sure whether the implementation is Elixir-ish enough - if not, could you give me pointers how it should be done?
