### PR TITLE
Fixed a badmatch error in IEX

### DIFF
--- a/lib/iex.ex
+++ b/lib/iex.ex
@@ -27,7 +27,7 @@ module IEX
       code = @codecache + IO.gets(prompt)
 
       { b, c } = try
-        {result, new_binding} = Module.eval(code.to_char_list, @binding)
+        {result, new_binding} = Erlang.elixir.eval(code.to_char_list, @binding)
         IO.puts Code::Formatter.format_object(result)
         { new_binding, "" }
       catch 'error: {'badsyntax, {_, _, _, []}}


### PR DESCRIPTION
This fixes a weird bug introduced in fe63706b21c284fa4a0a776dd9a63dd500f230ea.

Basically whatever you do in iex, you get a badmatch error.

```
iex> 2
** error {'badmatch,2}
    IEX::Behavior#loop/0
iex> 2 + 2
** error {'badmatch,4}
    IEX::Behavior#loop/0
iex> 2 = 2
** error {'badmatch,2}
    IEX::Behavior#loop/0
```
