### PR TITLE
Travis-Ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-target: erlang
+language: erlang
 notifications:
   email: false
 otp_release:


### PR DESCRIPTION
Hi Jose,

Travis-CI support for Erlang is live. You can use this .travis.yml and add Elixer to http://travis-ci.org (for docs about this process, see http://about.travis-ci.org/docs/user/getting-started/)

Let me know if you have any questions.
