### PR TITLE
R14B01 is temporarily not provided on travis-ci.org but we now have R14B04 ;)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ notifications:
 otp_release:
   - R14B03
   - R14B02
-  - R14B01
+  - R14B04


### PR DESCRIPTION
The issue is that R14B01 fails to compile on ubuntu 11.04 even after hours spent investigating.
