### PR TITLE
Serve logo image out of elixir-lang repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Elixir](https://github.com/tarcieri/elixir/raw/master/logo.png)
+![Elixir](https://github.com/elixir-lang/elixir/raw/master/logo.png)
 =========
 [![Build Status](https://secure.travis-ci.org/elixir-lang/elixir.png "Build Status")](http://travis-ci.org/josevalim/elixir)
 


### PR DESCRIPTION
I edited the original logo image off the web site to add a transparent background so it matches the Github color scheme and checked that into my repo.

Now that you've pulled that image you can serve it out of yours.
