### PR TITLE
Allow deep linking and handle CDPATH issues

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -17,6 +17,16 @@ if [ $# -eq 0 ]; then
   exit 1
 fi
 
-SELF=`readlink $0 || echo $0`
+readlink_f () {
+  cd `dirname $1` > /dev/null
+  local filename=`basename $1`
+  if [ -h "$filename" ]; then
+    readlink_f `readlink $filename`
+  else
+    echo "`pwd -P`/$filename"
+  fi
+}
+
+SELF=`readlink_f $0`
 SCRIPT_PATH=`dirname $SELF`
 erl -pa $SCRIPT_PATH/../ebin $SCRIPT_PATH/../exbin -noshell -noinput $ELIXIR_ERL_OPTS -s elixir start -extra "$@"

--- a/bin/elixirc
+++ b/bin/elixirc
@@ -17,6 +17,16 @@ if [ $# -eq 0 ]; then
   exit 1
 fi
 
-SELF=`readlink $0 || echo $0`
+readlink_f () {
+  cd `dirname $1` > /dev/null
+  local filename=`basename $1`
+  if [ -h "$filename" ]; then
+    readlink_f `readlink $filename`
+  else
+    echo "`pwd -P`/$filename"
+  fi
+}
+
+SELF=`readlink_f $0`
 SCRIPT_PATH=`dirname $SELF`
 $SCRIPT_PATH/elixir +compile "$@"

--- a/bin/iex
+++ b/bin/iex
@@ -1,4 +1,14 @@
 #!/bin/sh
-SELF=`readlink $0 || echo $0`
+readlink_f () {
+  cd `dirname $1` > /dev/null
+  local filename=`basename $1`
+  if [ -h "$filename" ]; then
+    readlink_f `readlink $filename`
+  else
+    echo "`pwd -P`/$filename"
+  fi
+}
+
+SELF=`readlink_f $0`
 SCRIPT_PATH=`dirname $SELF`
 $SCRIPT_PATH/elixir --no-stop -e "Elixir::IEx.start" "$@"


### PR DESCRIPTION
This patch allows the scripts to be deep-linked anywhere. The `readlink_f` function emulates GNU `readlink -f` functionality, navigating through the link chain and returning an absolute path.

Also, the `cd` command output is nullified to avoid interference from user's `CDPATH` environment variable, which makes `cd` always print the new working directory.
