### PR TITLE
Allow passing multiple files to elixir/iex

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -1,6 +1,6 @@
 #!/bin/sh
 if [ $# -eq 0 ]; then
-  echo "Usage: `basename $0` [options] [.exs file] [data]
+  echo "Usage: `basename $0` [options] [.exs files] [-- data]
 
   -v              Prints version and exit
   -e \"command\"    Evaluates the given command (*)
@@ -11,7 +11,7 @@ if [ $# -eq 0 ]; then
 
 ** Options marked with (*) can be given more than once;
 
-** Options given after the .exs file or -- are passed down to the executed code;
+** Options given after -- are passed down to the executed code;
 
 ** Options can be passed to the erlang runtime using ELIXIR_ERL_OPTS." >&2
   exit 1

--- a/lib/elixir/cli.ex
+++ b/lib/elixir/cli.ex
@@ -127,7 +127,8 @@ defmodule Elixir.CLI do
     match: '-' ++ _
       shared_option? list, config, process_options(&1, &2)
     else:
-      { config.prepend_commands([{:require, h}]), t }
+      # Allow requiring multiple files without the -r option
+      process_options t, config.prepend_commands([{:require, h}])
     end
   end
 


### PR DESCRIPTION
Previously, the following invocation

```
iex file1.exs file2.exs
```

would require file1.ex and pass file2.ex as an argument to the shell. In
order to require both files, we had to write

```
iex -r file1.exs file2.exs
# or
iex -r file1.exs -r file2.exs
```

This commit make it possible to invoke elixir in the following ways:

```
# both file1.exs and file2.exs are `require`d
iex file1.exs file2.exs

# files starting with '-' can still be required using '-r'
iex -r '-strange_name.exs' normal_name.exs

# to pass additional options to the shell, '--' must be used
# in this case, all .ex files are `require`d and the string
# 'this is passed to the shell' is passed as a single argument
iex file1.ex file2.ex fileN.ex -- 'this is passed to the shell'
```
