### PR TITLE
Cleanup the Process module

### DIFF
--- a/lib/process.ex
+++ b/lib/process.ex
@@ -21,7 +21,7 @@ defmodule Process do
   Returns the current process.
   """
   def self do
-    :erlang.self
+    :erlang.self()
   end
 
   @doc """
@@ -46,9 +46,7 @@ defmodule Process do
   @doc """
   Returns all keys that have the given `value`.
   """
-  def get_keys(value) do
-    :erlang.get_keys(value)
-  end
+  defdelegate [get_keys: 1], to: :erlang
 
   @doc """
   Stores the given key-value in the process dictionary.
@@ -75,18 +73,14 @@ defmodule Process do
   Returns the pid of a new process started by the application of `fun` to the
   empty list []. Otherwise works like spawn/3.
   """
-  def spawn(fun) do
-    :erlang.spawn fun
-  end
+  defdelegate [spawn: 1], to: :erlang
 
   @doc """
   Returns the pid of a new process started by the application of `fun` to the
   empty list [] on `node`. If `node` does not exist, a useless pid is returned.
   Otherwise works like spawn/3.
   """
-  def spawn(node, fun) do
-    :erlang.spawn node, fun
-  end
+  defdelegate [spawn: 2], to: :erlang
 
   @doc """
   Returns the pid of a new process started by the application of
@@ -95,27 +89,21 @@ defmodule Process do
 
   See http://www.erlang.org/doc/man/erlang.html#spawn-3 for more info.
   """
-  def spawn(module, function, args) do
-    :erlang.spawn module, function, args
-  end
+  defdelegate [spawn: 3], to: :erlang
 
   @doc """
   Returns the pid of a new process started by the application of
   `module.function` to `args` on `node`. If `node` does not exists, a useless
   pid is returned. Otherwise works like spawn/3.
   """
-  def spawn(node, module, function, args) do
-    :erlang.spawn node, module, function, args
-  end
+  defdelegate [spawn: 4], to: :erlang
 
   @doc """
   Returns the pid of a new process started by the application of `fun` to the
   empty list []. A link is created between the calling process and the new
   process, atomically. Otherwise works like spawn/3.
   """
-  def spawn_link(fun) do
-    :erlang.spawn_link fun
-  end
+  defdelegate [spawn_link: 1], to: :erlang
 
   @doc """
   Returns the pid of a new process started by the application of `fun` to the
@@ -124,18 +112,14 @@ defmodule Process do
   (and due to the link, an exit signal with exit reason :noconnection will be
   received). Otherwise works like spawn/3.
   """
-  def spawn_link(node, fun) do
-    :erlang.spawn_link node, fun
-  end
+  defdelegate [spawn_link: 2], to: :erlang
 
   @doc """
   Returns the pid of a new process started by the application of
   `module.function` to `args`. A link is created between the calling process
   and the new process, atomically. Otherwise works like spawn/3.
   """
-  def spawn_link(module, function, args) do
-    :erlang.spawn_link module, function, args
-  end
+  defdelegate [spawn_link: 3], to: :erlang
 
   @doc """
   Returns the pid of a new process started by the application of
@@ -144,9 +128,7 @@ defmodule Process do
   pid is returned (and due to the link, an exit signal with exit reason
   :noconnection will be received). Otherwise works like spawn/3.
   """
-  def spawn_link(node, module, function, args) do
-    :erlang.spawn_link node, module, function, args
-  end
+  defdelegate [spawn_link: 4], to: :erlang
 
   @doc """
   The calling process starts monitoring the item given.
@@ -180,7 +162,7 @@ defmodule Process do
   See http://www.erlang.org/doc/man/erlang.html#processes-0 for more info.
   """
   def list do
-    :erlang.processes
+    :erlang.processes()
   end
 
   @doc """
@@ -189,9 +171,7 @@ defmodule Process do
 
   See http://www.erlang.org/doc/man/erlang.html#link-1 for more info.
   """
-  def link(pid) do
-    :erlang.link(pid)
-  end
+  defdelegate [link: 1], to: :erlang
 
   @doc """
   Removes the link, if there is one, between the calling process and
@@ -200,9 +180,7 @@ defmodule Process do
 
   See http://www.erlang.org/doc/man/erlang.html#unlink-1 for more info.
   """
-  def unlink(pid) do
-    :erlang.unlink(pid)
-  end
+  defdelegate [unlink: 1], to: :erlang
 
   @doc """
   Associates the name with a pid or a port identifier. name, which must
@@ -211,18 +189,14 @@ defmodule Process do
 
   See http://www.erlang.org/doc/man/erlang.html#register-2 for more info.
   """
-  def register(name, pid) do
-    :erlang.register(name, pid)
-  end
+  defdelegate [register: 2], to: :erlang
 
   @doc """
   Removes the registered name, associated with a pid or a port identifier.
 
   See http://www.erlang.org/doc/man/erlang.html#unregister-1 for more info.
   """
-  def unregister(name) do
-    :erlang.unregister(name)
-  end
+  defdelegate [unregister: 1], to: :erlang
 
   @doc """
   Returns the pid or port identifier with the registered name.
@@ -230,15 +204,13 @@ defmodule Process do
 
   See http://www.erlang.org/doc/man/erlang.html#whereis-1 for more info.
   """
-  def whereis(name) do
-    :erlang.whereis(name)
-  end
+  defdelegate [whereis: 1], to: :erlang
 
   @doc """
   Returns a list of names which have been registered using register/2.
   """
-  def registered() do
-    :erlang.registered
+  def registered do
+    :erlang.registered()
   end
 
   @doc """


### PR DESCRIPTION
I have also added `spawn` and `spawn_link` functions. Those were the remaining functions that used `:erlang` reference in my demo app, so I thought we might as well Elixirize them.

Should I also add the `spawn/2` and `spawn/4` flavours?
