### PR TITLE
allow binary_to(_existing)_atom uses :utf8 as default encoding, refs #221

### DIFF
--- a/lib/elixir/builtin.ex
+++ b/lib/elixir/builtin.ex
@@ -966,6 +966,32 @@ defmodule Elixir.Builtin do
   end
 
   @doc """
+  Returns the atom whose text representation is
+  `some_binary` in UTF8 encoding.
+
+      binary_to_atom "my_atom" #=> :my_atom
+
+  """
+  defmacro binary_to_atom(some_binary) do
+    quote do
+      binary_to_atom(unquote(some_binary), :utf8)
+    end
+  end
+
+  @doc """
+  Works like `binary_to_atom` but the atom must exist.
+
+      :my_atom                          #=> :my_atom
+      binary_to_existing_atom "my_atom" #=> :my_atom
+
+  """
+  defmacro binary_to_existing_atom(some_binary) do
+    quote do
+      binary_to_existing_atom(unquote(some_binary), :utf8)
+    end
+  end
+
+  @doc """
   Concatenates two binaries.
 
   ## Examples

--- a/test/elixir/kernel/binary_to_atom_test.exs
+++ b/test/elixir/kernel/binary_to_atom_test.exs
@@ -1,0 +1,29 @@
+Code.require_file "../../test_helper", __FILE__
+
+defmodule Kernel.BinaryToAtomTest do
+  use ExUnit.Case
+
+  test :default_to_utf8 do
+    expected  = binary_to_atom "some_binary", :utf8
+    actual    = binary_to_atom "some_binary"
+
+    assert_equal expected, actual
+    assert_equal :another_binary, binary_to_atom "another_binary"
+  end
+
+  test :default_to_utf8_existing do
+    expected = binary_to_atom "existing_atom", :utf8
+    actual   = binary_to_existing_atom "existing_atom"
+
+    assert_equal expected, actual
+    
+    :existing_atom
+    assert_equal :existing_atom, binary_to_existing_atom "existing_atom"
+    
+    assert_raises ArgumentError, fn ->
+      binary_to_existing_atom "nonexisting_atom"
+    end
+
+  end
+
+end


### PR DESCRIPTION
i'd like to know your opnions about this patch. Should I improve tests and docs? Should I test macro's arguments with `is_binary`? 

Let me know.

Thanks.
