### PR TITLE
Do not test System.pwd return value.

### DIFF
--- a/test/elixir/system_test.exs
+++ b/test/elixir/system_test.exs
@@ -33,6 +33,5 @@ defmodule SystemTest do
 
   test :pwd do
     assert is_binary(System.pwd)
-    assert_equal Regex.replace_all(%r/\n/, OS.cmd('pwd'), ""), binary_to_list(System.pwd)
   end
 end


### PR DESCRIPTION
The function relies on Erlang's filename:abs function, so we're
basically testing Erlang here. There is no straightforward way to obtain
current directory by other means that'll work seamlessly on all OSes.
So we'll better not check the return value.
