### PR TITLE
Fix #197. Add URI.url_decode

### DIFF
--- a/lib/uri.ex
+++ b/lib/uri.ex
@@ -61,10 +61,7 @@ defmodule URI do
   @doc """
   Unpercent (URL) decodes a URI.
   """
-  # TODO: should this return a binary, or a list of unicode charactesrs?
-  # list_to_binary(list)
-  # binary_to_list(:unicode.characters_to_binary(list_to_binary(list)))
-  def url_decode(s) when is_binary(s), do: url_decode binary_to_list(s)
+  def url_decode(s) when is_binary(s), do: :unicode.characters_to_binary(list_to_binary(url_decode(binary_to_list(s))))
   def url_decode([?%, hex1, hex2 | tail]), do: [:erlang.bsl(hex2dec(hex1), 4) + hex2dec(hex2) | url_decode(tail)]
   def url_decode([head | tail]), do: [check_plus(head) | url_decode(tail)]
   def url_decode([]), do: []

--- a/test/elixir/uri_test.exs
+++ b/test/elixir/uri_test.exs
@@ -26,7 +26,7 @@ defmodule URITest do
 
   test :url_decode do
     data_to_be_decoded = "%26%3C%3E%22+%E3%82%86%E3%82%93%E3%82%86%E3%82%93"
-    expected = [38,60,62,34,32,227,130,134,227,130,147,227,130,134,227,130,147]
+    expected = "&<>\" ゆんゆん"
     assert URI.url_decode(data_to_be_decoded) == expected
   end
 


### PR DESCRIPTION
Fix #197.

The return data type probably has to be changed.
Not sure if this is the right way of converting + to space when %20 is not used.

decode_query and other functions are not yet implemented.

p.s. I am new to erlang. :blush:
