### PR TITLE
Adds support for partial clause definition

### DIFF
--- a/lib/module.ex
+++ b/lib/module.ex
@@ -33,7 +33,6 @@ defmodule Module do
     assert_not_compiled!(:eval_quoted, module)
 
     { binding, scope } = Erlang.elixir_module.binding_and_scope_for_eval(opts, module, binding)
-    Erlang.elixir_def.reset_last(module)
 
     line = Keyword.get opts, :line, 1
     { value, binding, _scope } = Erlang.elixir.eval_quoted([quoted], binding, line, scope)

--- a/src/elixir_def.erl
+++ b/src/elixir_def.erl
@@ -3,7 +3,6 @@
 -export([table/1,
   build_table/1,
   delete_table/1,
-  reset_last/1,
   wrap_definition/7,
   store_definition/8,
   store_each/6,
@@ -17,16 +16,11 @@ table(Module) -> ?ELIXIR_ATOM_CONCAT([f, Module]).
 
 build_table(Module) ->
   FunctionTable = table(Module),
-  ets:new(FunctionTable, [set, named_table, public]),
-  ets:insert(FunctionTable, { last, [] }),
+  ets:new(FunctionTable, [ordered_set, named_table, public]),
   FunctionTable.
 
 delete_table(Module) ->
   ets:delete(table(Module)).
-
-%% Reset the last item. Useful when evaling code.
-reset_last(Module) ->
-  ets:insert(table(Module), { last, [] }).
 
 %% Wraps the function into a call to store_definition once the function
 %% definition is read. The function is compiled into a meta tree to ensure
@@ -144,7 +138,6 @@ translate_definition(Kind, Line, Name, Args, Guards, Expr, S) ->
 % and the body of all functions.
 unwrap_stored_definitions(Module) ->
   Table = table(Module),
-  ets:delete(Table, last),
   unwrap_stored_definition(ets:tab2list(Table), [], [], [], [], [], []).
 
 unwrap_stored_definition([Fun|T], Exports, Private, Def, Defmacro, Defmacrop, Functions) when element(4, Fun) == def ->
@@ -197,11 +190,11 @@ store_each(Check, Kind, Filename, Table, Defaults, {function, Line, Name, Arity,
       FinalClauses  = Clauses ++ StoredClauses,
       check_valid_kind(Line, Filename, Name, Arity, Kind, StoredKind),
       check_valid_defaults(Line, Filename, Name, Arity, Defaults),
-      Check andalso check_valid_clause(Line, Filename, Name, Arity, Table);
+      Check;
     [] ->
       FinalDefaults = Defaults,
       FinalClauses  = Clauses,
-      Check andalso ets:insert(Table, { last, { Name, Arity } })
+      Check
   end,
   ets:insert(Table, {{Name, Arity}, Line, Filename, Kind, FinalDefaults, FinalClauses}).
 
@@ -210,14 +203,6 @@ store_each(Check, Kind, Filename, Table, Defaults, {function, Line, Name, Arity,
 check_valid_kind(_Line, _Filename, _Name, _Arity, Kind, Kind) -> [];
 check_valid_kind(Line, Filename, Name, Arity, Kind, StoredKind) ->
   elixir_errors:form_error(Line, Filename, ?MODULE, {changed_kind, {Name, Arity, StoredKind, Kind}}).
-
-check_valid_clause(Line, Filename, Name, Arity, Table) ->
-  case ets:lookup_element(Table, last, 2) of
-    {Name,Arity} -> [];
-    [] -> [];
-    {ElseName, ElseArity} -> elixir_errors:form_error(Line, Filename, ?MODULE,
-      { changed_clause, { {Name, Arity}, {ElseName, ElseArity} } })
-  end.
 
 check_valid_defaults(_Line, _Filename, _Name, _Arity, 0) -> [];
 check_valid_defaults(Line, Filename, Name, Arity, _) ->
@@ -233,9 +218,6 @@ format_error({private_doc,{Name,Arity}}) ->
 
 format_error({existing_doc,{Name,Arity}}) ->
   io_lib:format("@doc's for function ~s/~B have been given more than once, the first version is being kept", [Name, Arity]);
-
-format_error({changed_clause,{{Name,Arity},{ElseName,ElseArity}}}) ->
-  io_lib:format("function ~s/~B does not match previous clause ~s/~B", [Name, Arity, ElseName, ElseArity]);
 
 format_error({changed_kind,{Name,Arity,Previous,Current}}) ->
   io_lib:format("~s ~s/~B already defined as ~s", [Current, Name, Arity, Previous]).

--- a/test/elixir/elixir/errors_test.exs
+++ b/test/elixir/elixir/errors_test.exs
@@ -94,16 +94,6 @@ defmodule Elixir.ErrorsTest do
       format_rescue 'defmodule Foo do\nElixir.ErrorsTest.UnproperMacro.unproper([])\nend'
   end
 
-  test :def_defmacro_clause_change do
-    assert "nofile:3: defmacro foo/1 already defined as def" ==
-      format_rescue 'defmodule Foo do\ndef foo(1), do: 1\ndefmacro foo(x), do: x\nend'
-  end
-
-  test :clause_change do
-    assert "nofile:4: function foo/1 does not match previous clause bar/1" ==
-      format_rescue 'defmodule Foo do\ndef foo(1), do: 1\ndef bar(x), do: x\ndef foo(x), do: x\nend'
-  end
-
   test :internal_function_overriden do
     assert "nofile:1: function __info__/1 is internal and should not be overriden" ==
       format_rescue 'defmodule Foo do\ndef __info__(_), do: []\nend'


### PR DESCRIPTION
Admittedly, the implementation might seem naive, but it seems to work just fine (so far!). And if there are some cases, it can be improved.

This, combined with macros, allows to intermittently generate clauses regardless of the order.
