### PR TITLE
Adds `to_keyword(record)` function to all records

### DIFF
--- a/lib/record.ex
+++ b/lib/record.ex
@@ -114,13 +114,13 @@ defmodule Record do
   #
   #     defrecord FileInfo, atime: nil, mtime: nil
   #
-  # It will define one method, to_keyword, which will return a Keyword
+  # It will define one method, to_keywords, which will return a Keyword
   # 
   #    [atime: nil, mtime: nil]
   #
   defp converters(values) do
     quote do
-      def to_keyword(record) do
+      def to_keywords(record) do
         fields = lc {field, _} in unquote(values), do: field
         Keyword.new(List.zip fields, lc i in :lists.seq(2, length(fields)+1), do: elem(record, i))
       end

--- a/test/elixir/record_test.exs
+++ b/test/elixir/record_test.exs
@@ -43,10 +43,10 @@ defmodule RecordTest do
     refute is_record(RecordTest.FileInfo.new, List)
   end
   
-  test :to_keyword do
+  test :to_keywords do
     record = RecordTest.DynamicName.new(a: "a", b: "b")
-    assert record.to_keyword[:a] == "a"
-    assert record.to_keyword[:b] == "b"
+    assert record.to_keywords[:a] == "a"
+    assert record.to_keywords[:b] == "b"
   end
 
   defp file_info do


### PR DESCRIPTION
This function can be used to convert any record to a Keyword:

``` elixir
    iex> defrecord A, a: 1, b: 2, c: nil
    nil
    iex> A.new
    A[a: 1, b: 2, c: nil]
    iex> A.new.to_keyword
    [{:a,1},{:b,2},{:c,nil}]
    iex> A.new(c: "a").to_keyword
    [{:a,1},{:b,2},{:c,"a"}]
```
