### PR TITLE
Fixes the problem with skewed error logger's output in IEx

### DIFF
--- a/lib/elixir/iex.ex
+++ b/lib/elixir/iex.ex
@@ -40,7 +40,12 @@ defmodule Elixir.IEx do
 
   def start(binding // [], io // Elixir.IEx.UnicodeIO) do
     config = boot_config(binding, io)
-    function = fn -> do_loop(config) end
+    function = fn ->   
+      :error_logger.delete_report_handler(:error_logger_tty_h)
+      :error_logger.add_report_handler(:error_logger_tty_h)  
+      do_loop(config) 
+    end
+    if is_pid(Process.whereis(:user)), do: Process.unregister :user
     Erlang.user_drv.start([:"tty_sl -c -e", {:erlang, :spawn, [function]}])
   end
 


### PR DESCRIPTION
Before this patch:

``` erlang
iex> :application.start :sasl

=PROGRESS REPORT==== 2-Jun-2012::18:05:48 ===
                                                       supervisor: {local,sasl_safe_sup}
                                                                                                     started: [{pid,<0.41.0>},
                                                                                                                                                     {name,alarm_handler},
                                                                                                                                                                                                 {mfargs,{alarm_handler,start_link,[]}},
                                                                                                                                                                                                                                                               {restart_type,permanent},
                                                                                                                                                                                                                                                                                                               {shutdown,2000},
                         {child_type,worker}]

                                             =PROGRESS REPORT==== 2-Jun-2012::18:05:48 ===
                                                                                                    supervisor: {local,sasl_safe_sup}
                                                                                                                                                  started: [{pid,<0.42.0>},
                                                                                                                                                                                                  {name,overload},
                                                                                                                                                                                                                                         {mfargs,{overload,start_link,[]}},
                                                                                                                                                                                                                                                                                                  {restart_type,permanent},
                                                                                                                                                                                                                                                                                                                                                  {shutdown,2000},
                                                            {child_type,worker}]

                                                                                =PROGRESS REPORT==== 2-Jun-2012::18:05:48 ===
                                                                                                                                       supervisor: {local,sasl_sup}
                                                                                                                                                                                started: [{pid,<0.40.0>},
                                                                                                                                                                                                                                {name,sasl_safe_sup},
                                                                                                                                                                                                                                                                            {mfargs,
                                                                                                                                                                                                                                                                                                               {supervisor,start_link,
                                        [{local,sasl_safe_sup},sasl,safe]}},
                                                                                                   {restart_type,permanent},
                                                                                                                                                   {shutdown,infinity},
                                                                                                                                                                                              {child_type,supervisor}]
                                                                                                                                                                                                                      :ok
                                                                                                                                                                                                                         =PROGRESS REPORT==== 2-Jun-2012::18:05:48 ===
                                                                                                                                                                                                                                                                                supervisor: {local,sasl_sup}
                                                                                                                                                                                                                                                                                                                         started: [{pid,<0.43.0>},
                                            {name,release_handler},
                                                                                          {mfargs,{release_handler,start_link,[]}},
                                                                                                                                                          {restart_type,permanent},
                                                                                                                                                                                                          {shutdown,2000},
                                                                                                                                                                                                                                                 {child_type,worker}]

iex> 
     =PROGRESS REPORT==== 2-Jun-2012::18:05:48 ===
                                                           application: sasl
                                                                                      started_at: nonode@nohost
```

After this patch:

``` erlang
iex> :application.start(:sasl)

=PROGRESS REPORT==== 2-Jun-2012::18:39:03 ===
          supervisor: {local,sasl_safe_sup}
             started: [{pid,<0.42.0>},
                       {name,alarm_handler},
                       {mfargs,{alarm_handler,start_link,[]}},
                       {restart_type,permanent},
                       {shutdown,2000},
                       {child_type,worker}]
:ok
iex> 
=PROGRESS REPORT==== 2-Jun-2012::18:39:03 ===
          supervisor: {local,sasl_safe_sup}
             started: [{pid,<0.43.0>},
                       {name,overload},
                       {mfargs,{overload,start_link,[]}},
                       {restart_type,permanent},
                       {shutdown,2000},
                       {child_type,worker}]

=PROGRESS REPORT==== 2-Jun-2012::18:39:03 ===
          supervisor: {local,sasl_sup}
             started: [{pid,<0.41.0>},
                       {name,sasl_safe_sup},
                       {mfargs,
                           {supervisor,start_link,
                               [{local,sasl_safe_sup},sasl,safe]}},
                       {restart_type,permanent},
                       {shutdown,infinity},
                       {child_type,supervisor}]

=PROGRESS REPORT==== 2-Jun-2012::18:39:03 ===
          supervisor: {local,sasl_sup}
             started: [{pid,<0.44.0>},
                       {name,release_handler},
                       {mfargs,{release_handler,start_link,[]}},
                       {restart_type,permanent},
                       {shutdown,2000},
                       {child_type,worker}]

=PROGRESS REPORT==== 2-Jun-2012::18:39:03 ===
         application: sasl
          started_at: nonode@nohost

```
