### PR TITLE
Makes Record's accessors and new/0,1 overridable

### DIFF
--- a/lib/record.ex
+++ b/lib/record.ex
@@ -107,6 +107,8 @@ defmodule Record do
       def new([]), do: { __MODULE__, unquote_splicing(defaults) }
       def new(opts) when is_list(opts), do: { __MODULE__, unquote_splicing(selective) }
       def new(tuple) when is_tuple(tuple), do: setelem(tuple, 1, __MODULE__)
+
+      defoverridable [new: 0, new: 1]
     end
   end
 
@@ -270,6 +272,7 @@ defmodule Record.Definition do
   def default_for(key, _default, i) do
     bin_update = "update_" <> atom_to_binary(key)
     update     = binary_to_atom(bin_update)
+    overridable = Keyword.from_enum([{key, 1}, {key, 2}, {update, 2}])
 
     quote do
       def unquote(key).(record) do
@@ -284,6 +287,8 @@ defmodule Record.Definition do
         current = :erlang.element(unquote(i), record)
         :erlang.setelement(unquote(i), record, function.(current))
       end
+
+      defoverridable unquote(overridable)
     end
   end
 
@@ -292,6 +297,7 @@ defmodule Record.Definition do
     bin_key = atom_to_binary(key)
     prepend = :"prepend_#{bin_key}"
     merge   = :"merge_#{bin_key}"
+    overridable = Keyword.from_enum([{prepend, 2}, {merge, 2}])
 
     quote do
       def unquote(prepend).(value, record) do
@@ -303,18 +309,23 @@ defmodule Record.Definition do
         current = :erlang.element(unquote(i), record)
         :erlang.setelement(unquote(i), record, Keyword.merge(current, value))
       end
+
+      defoverridable unquote(overridable)
     end
   end
 
   def extension_for(key, default, i) when is_number(default) do
     bin_key   = atom_to_binary(key)
     increment = :"increment_#{bin_key}"
+    overridable = Keyword.from_enum([{increment, 2}])
 
     quote do
       def unquote(increment).(value // 1, record) do
         current = :erlang.element(unquote(i), record)
         :erlang.setelement(unquote(i), record, current + value)
       end
+
+      defoverridable unquote(overridable)
     end
   end
 

--- a/test/elixir/record_test.exs
+++ b/test/elixir/record_test.exs
@@ -8,6 +8,38 @@ defrecord name, a: 0, b: 1
 
 defrecord RecordTest.WithNoField, []
 
+defrecord RecordTest.Override, a: 0 do
+
+  def new, do: new([a: 100])
+
+  def new(opts) do
+      opts = Keyword.put opts, :a, opts[:a] * 5
+      super(opts)
+  end
+
+  def a(value, r) do
+    super({value, :erlang.now}, r)
+  end
+  def a(r) do
+    {v, _} = super(r)
+    v
+  end
+  def update_a(fun, r) do
+    r.a(fun.(r.a))
+  end
+  def prepend_a(_, r) do
+    r.a(r.a)
+  end
+  def merge_a(_, r) do
+    r.a(r.a)
+  end
+  def increment_a(_, r) do
+      r
+  end
+
+  def raw_a(r), do: elem(r, 2)
+end
+
 defmodule RecordTest do
   use ExUnit.Case
 
@@ -47,6 +79,26 @@ defmodule RecordTest do
     record = RecordTest.DynamicName.new(a: "a", b: "b")
     assert record.to_keywords[:a] == "a"
     assert record.to_keywords[:b] == "b"
+  end
+
+  test :overridable do
+    record = RecordTest.Override.new
+    assert record.raw_a == 500
+    record = record.a(1)
+    assert {1, _} = record.raw_a
+    assert record.a == 1
+    record = record.update_a(fn(_) -> 2 end)
+    assert {2, _} = record.raw_a
+    assert record.a == 2
+    record = record.prepend_a(100)
+    assert {2, _} = record.raw_a
+    assert record.a == 2
+    record = record.merge_a(100)
+    assert {2, _} = record.raw_a
+    assert record.a == 2
+    record = record.increment_a(1)
+    assert {2, _} = record.raw_a
+    assert record.a == 2
   end
 
   defp file_info do


### PR DESCRIPTION
Hopefully self-explanatory?
