### PR TITLE
Changes function type syntax in type specification adjusted according to...

### DIFF
--- a/lib/typespec.ex
+++ b/lib/typespec.ex
@@ -177,7 +177,7 @@ defmodule Typespec do
   defmacro deftypep({:"::", _, [name, definition]}), do: _deftype(name, definition, false, __CALLER__)
   defmacro deftypep(name), do: _deftype(name, (quote do: term), false, __CALLER__)
 
-  defmacro defspec({name, line, args},[{:returns, returns}]) do
+  defmacro defspec({name, line, args},[{:do, returns}]) do
     spec = typespec({{:fun, line, args}, returns}, [], __CALLER__)
     code = quote do: {{unquote(name), unquote(length(args))}, [unquote(spec)]}
     quote do

--- a/test/elixir/typespec_test.exs
+++ b/test/elixir/typespec_test.exs
@@ -209,9 +209,9 @@ defmodule Typespec.Test.Type do
       def myfun(x), do: x
       def myfun(), do: :ok
       def myfun(x,y), do: {x,y}
-      t1 = defspec myfun(integer), returns: integer
-      t2 = defspec myfun(), returns: integer
-      t3 = defspec myfun(integer, integer), returns: {integer, integer}
+      t1 = defspec myfun(integer), do: integer
+      t2 = defspec myfun(), do: integer
+      t3 = defspec myfun(integer, integer), do: {integer, integer}
       {t1,t2,t3}
     end
     assert {:spec,{{:myfun,1},[{:type,_,:fun,[{:type,_,:product,[{:type,_,:integer,[]}]},{:type,_,:integer,[]}]}]}} = spec1
@@ -223,8 +223,8 @@ defmodule Typespec.Test.Type do
     defmodule T do 
       use Typespec, keep_data: true
       def myfun(x), do: x
-      defspec myfun(integer), returns: integer
-      defspec myfun(string), returns: string
+      defspec myfun(integer), do: integer
+      defspec myfun(string), do: string
     end
     specs = T.__specs__
     assert [{{:myfun,1},[


### PR DESCRIPTION
... the plan outlined in #333

This is sort of WIP. 

So far:
1. Adopted new fun definition syntax (`fun(...args..., do: ...)

Working on @spec and @type, but I ran into a problem:

``` elixir
@type mytype
```

results in `function mytype/0 undefined`
