### PR TITLE
Added the ability to toggle bolean fields in Records

### DIFF
--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -318,5 +318,17 @@ defmodule Record.Definition do
     end
   end
 
+  def extension_for(key, default, i) when is_boolean(default) do
+    bin_key = atom_to_binary(key)
+    toggle = :"toggle_#{bin_key}"
+
+    quote do
+      def unquote(toggle).(value // false, record) do
+        current = :erlang.element(unquote(i), record)
+        :erlang.setelement(unquote(i), record, not current)
+       end
+    end
+  end
+
   def extension_for(_, _, _), do: nil
 end

--- a/lib/elixir/test/erlang/record_test.erl
+++ b/lib/elixir/test/erlang/record_test.erl
@@ -59,3 +59,11 @@ record_increment_test() ->
     { { '__MAIN__-Foo', -2 }, _ } = eval("Foo.new.increment_a -2")
   end,
   test_helper:run_and_remove(F, ['__MAIN__-Foo']).
+
+record_toggle_test() ->
+  F = fun() ->
+    eval("defrecord Foo, a: false, b: true"),
+	{ { '__MAIN__-Foo', true, true }, _ } = eval("Foo.new.toggle_a"),
+	{ { '__MAIN__-Foo', false, false }, _ } = eval("Foo.new.toggle_b")
+  end,
+  test_helper:run_and_remove(F, ['__MAIN__-Foo']).


### PR DESCRIPTION
Introduced an extension that allows to toggle fields easily in records

```
defrecord Config, allow_override: false
Config.new.toggle_allow_override
```
