### PR TITLE
Fixes a bug that broke the correct behavior of the `in` guard

### DIFF
--- a/lib/elixir/src/elixir_macros.erl
+++ b/lib/elixir/src/elixir_macros.erl
@@ -40,9 +40,10 @@ translate_macro({ in, Line, [Left, Right] }, #elixir_scope{extra_guards=nil} = S
   Expr = case TRight of
     { cons, _, _, _ } ->
       [H|T] = elixir_tree_helpers:cons_to_list(TRight),
+      ProperT = lists:reverse(tl(lists:reverse(T))),                 
       lists:foldl(fun(X, Acc) ->
         { op, Line, 'orelse', Acc, { op, Line, '==', Var, X } }
-      end, { op, Line, '==', Var, H }, T);
+      end, { op, Line, '==', Var, H }, ProperT);
     { tuple, _, [{ atom, _, 'Elixir.Range' }, Start, End] } ->
       { op, Line, 'andalso',
         { op, Line, '>=', Var, Start },

--- a/lib/elixir/test/elixir/guard_test.exs
+++ b/lib/elixir/test/elixir/guard_test.exs
@@ -1,0 +1,11 @@
+Code.require_file "../test_helper", __FILE__
+
+defmodule GuardTest do
+  use ExUnit.Case
+
+  test :in do 
+   assert 1 in [1,2,3] == true
+   assert 4 in [1,2,3] == false
+   assert [] in [1,2,3] == false
+  end
+end


### PR DESCRIPTION
The correct behavior is:

> [] in [1,2,3] == false

However, recently introduced bug made this work like this:

> [] in [1,2,3] == true
