### PR TITLE
Support for user defined read macro.

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2715,6 +2715,11 @@ defmodule Kernel do
     Macro.escape(regex)
   end
 
+  @doc """
+  Handles the sigil <% ... %>. It ignores input.
+  """
+  defmacro :"__%__".({ :<<>>, _line, _args }, options), do: nil
+
   ## Private functions
 
   # Extracts concatenations in order to optimize many

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -519,6 +519,8 @@ build_access(Expr, Access) ->
 
 %% Interpolation aware
 
+build_sigil({ sigil, Line, Sigil, Parts, Modifiers }) when is_list(Sigil) ->
+  { list_to_atom("__" ++ Sigil ++ "__"), Line, [ { '<<>>', Line, Parts }, Modifiers ] };
 build_sigil({ sigil, Line, Sigil, Parts, Modifiers }) ->
   { list_to_atom([$_,$_,Sigil,$_,$_]), Line, [ { '<<>>', Line, Parts }, Modifiers ] }.
 

--- a/lib/elixir/test/elixir/fixtures/with_read_macro.ex
+++ b/lib/elixir/test/elixir/fixtures/with_read_macro.ex
@@ -1,0 +1,45 @@
+defmodule WithReadMacro do
+  use Kernel.ReadMacroTest.Helper
+<%
+  def foo(false), do: 0
+%>
+
+<%:foo:
+  def foo(true),   do: 1
+:foo:%>
+
+<:ignore:
+  def bar(var // 0)
+  def bar(_), do: 2
+:ignore:>
+  def alpha() do
+    body = <:html:
+<html>
+     <head>
+          <title>
+               Example
+          </title>
+     </head>
+     <body>
+          <h1>
+               Hi!
+          </h1>
+     </body>
+</html>
+:html:>
+    body
+  end
+<%:not_used:
+  def nested(cond) do
+    case cond do
+      {true, 0} -> true
+      {true, non_zero} -> case non_zero < 5 do
+                            true -> :ok
+                            <%:false_branch:
+                            false -> :nok
+                            :false_branch:%>
+                          end
+    end
+  end
+:not_used:%>
+end

--- a/lib/elixir/test/elixir/kernel/read_macro_test.exs
+++ b/lib/elixir/test/elixir/kernel/read_macro_test.exs
@@ -1,0 +1,44 @@
+Code.require_file "../../test_helper", __FILE__
+
+#defrecord Kernel.ReadMacroTest.Helper, ignore: [], html: [] do
+defmodule Kernel.ReadMacroTest.Helper do
+  defmacro __using__(_) do
+    target = __CALLER__.module
+    Module.register_attribute target, :__ignore__
+    Module.register_attribute target, :__html__
+    quote do
+      import Kernel.ReadMacroTest.Helper
+    end
+  end
+
+  defmacro __ignore__({ :<<>>, line, body }, []) do
+    Module.add_attribute __CALLER__.module, :__ignore__, {line, body}
+  end
+
+  defmacro __html__({ :<<>>, line, body }, []) do
+    Module.add_attribute __CALLER__.module, :__html__, {line, body}
+  end
+end
+
+defmodule Kernel.ReadMacroTest do
+  use ExUnit.Case, async: true
+
+  test :with_read_macro do
+    path = File.expand_path("../../fixtures/with_read_macro.ex", __FILE__)
+
+    try do
+      Code.load_file path
+
+      attributes = Keyword.from_enum(WithReadMacro.__info__(:attributes))
+      expected_ignore = {11, "  def bar(var // 0)\n  def bar(_), do: 2\n"}
+      expected_html = {16, "<html>\n     <head>\n          <title>\n               Example\n          </title>\n     </head>\n     <body>\n          <h1>\n               Hi!\n          </h1>\n     </body>\n</html>\n"}
+      assert [expected_ignore] == attributes[:__ignore__]
+      assert [expected_html] == attributes[:__html__]
+    after
+      :code.purge WithReadMacro
+      :code.delete WithReadMacro
+    end
+  end
+
+
+end


### PR DESCRIPTION
User defined macro is called when tokenizer sees <:tag: ... :tag:>.
Nested multi-line comments are supported via <%some_tag ... some_tag%>
