### PR TITLE
Allow empty except option in import statements

### DIFF
--- a/lib/elixir/src/elixir_import.erl
+++ b/lib/elixir/src/elixir_import.erl
@@ -79,6 +79,7 @@ calculate(Line, Key, Opts, Old, AvailableFun, S) ->
       end;
     error ->
       case orddict:find(except, Opts) of
+        { ok, [] } -> AvailableFun();
         { ok, RawExcept } ->
           Except = expand_fun_arity(Line, except, RawExcept, S),
           case keyfind(Key, Old) of


### PR DESCRIPTION
This fixes things like `use Bitwise` that are broken when called without option
