### PR TITLE
Make elixir source $HOME/.elixirrc if it exists

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -63,6 +63,8 @@ done
 SELF=$(readlink_f "$0")
 SCRIPT_PATH=$(dirname "$SELF")
 
+if [ -f "$HOME/.elixirrc" ]; then . "$HOME/.elixirrc"; fi
+
 if [ -f "$SCRIPT_PATH/../releases/RELEASES" ] && [ -f "$SCRIPT_PATH/erl" ]
 then
   "$SCRIPT_PATH"/erl -env ERL_LIBS $ERL_LIBS:"$SCRIPT_PATH/../lib" -boot elixir -noshell $ELIXIR_ERL_OPTS $ERL -s elixir start_cli -extra "$@"


### PR DESCRIPTION
This allows to set ELIXIR_ERL_OPTS easily.

Here's an example .elixirrc to have iex play nice with @ferd's [erlang-history](https://github.com/ferd/erlang-history):
`ELIXIR_ERL_OPTS="-kernel hist_file \"$HOME/.iex-history\""`
