### PR TITLE
[SOLVED] #439

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ lib/$(1)/ebin/Elixir-$(2).beam: $(wildcard lib/$(1)/lib/*.ex) $(wildcard lib/$(1
 
 test_$(1): $(1)
 	@ echo "==> $(1) (exunit)"
-	@ cd lib/$(1) && time ../../bin/elixir -r "test/test_helper.exs" -pr "test/**/*_test.exs"
+	@ cd lib/$(1) && time ../../bin/elixir -r "test/test_helper.exs" -pr "test/**/*_test.exs";
 endef
 
 #==> Compilation tasks
@@ -95,11 +95,11 @@ test_erlang: compile
 	@ echo "==> elixir (eunit)"
 	@ mkdir -p lib/elixir/test/ebin
 	@ $(ERLC) -pa lib/elixir/ebin -o lib/elixir/test/ebin lib/elixir/test/erlang/*.erl
-	@ time $(ERL) -pa lib/elixir/test/ebin -s test_helper test -s erlang halt
+	@ time $(ERL) -pa lib/elixir/test/ebin -s test_helper test -s erlang halt;
 	@ echo
 
 test_elixir: test_kernel test_mix test_ex_unit test_eex
 
 test_kernel: compile
 	@ echo "==> kernel (exunit)"
-	@ cd lib/elixir && time ../../bin/elixir -r "test/elixir/test_helper.exs" -pr "test/elixir/**/*_test.exs"
+	@ cd lib/elixir && time ../../bin/elixir -r "test/elixir/test_helper.exs" -pr "test/elixir/**/*_test.exs";


### PR DESCRIPTION
Added `;`s to the end of the lines where calls to the `time` are made. Now correct performance is guaranteed if at least one of two instruments are avaliable:
- time shell builtin
- GNU time binary

That solves #439 properly (in terms of makefile shamanism), not with `eval` that was suggested.

The reason for such a strange `make` behaviour is optimization that refuses to run shell builtins.

Please note that if both GNU time and time builtin is present, builtin will be run with the highest priority and thus no additional output will be printed. Here is an example stderr diff for `$ make test` between builtin and GNU timex

``` diff
0a1,2
> 1.58user 0.25system 0:02.19elapsed 83%CPU (0avgtext+0avgdata 16252maxresident)k
> 0inputs+0outputs (0major+12503minor)pagefaults 0swaps
```

So now even if there are systems that have bash but no GNU time (for instance strangely packaged fresh Virtual Machine installations) make won't fail.

---

Jonn Mostovoy,
DA234FE7
