### PR TITLE
Fixing the crash in Macro.to_binary when it receives a list. 

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -147,7 +147,9 @@ defmodule Macro do
   # Block keywords
   defmacrop kw_keywords, do: [:do, :catch, :rescue, :after, :else]
 
-  defp is_kw_blocks?([_|_] = kw), do: Enum.all?(kw, fn({x,_}) -> x in kw_keywords end)
+  defp is_kw_blocks?([_|_] = kw) do
+    Enum.all?(kw, match?({x, _} when x in kw_keywords, &1))
+  end
   defp is_kw_blocks?(_),          do: false
 
   defp call_to_binary(atom) when is_atom(atom),  do: atom_to_binary(atom, :utf8)

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -119,18 +119,22 @@ defmodule MacroTest do
 
   test :local_call_to_binary do
     assert Macro.to_binary(quote do: foo(1, 2, 3)) == "foo(1, 2, 3)"
+    assert Macro.to_binary(quote do: foo([1, 2, 3])) == "foo([1, 2, 3])"
   end
 
   test :remote_call_to_binary do
     assert Macro.to_binary(quote do: foo.bar(1, 2, 3)) == "foo.bar(1, 2, 3)"
+    assert Macro.to_binary(quote do: foo.bar([1, 2, 3])) == "foo.bar([1, 2, 3])"
   end
 
   test :remote_and_fun_call_to_binary do
     assert Macro.to_binary(quote do: foo.bar.(1, 2, 3)) == "foo.bar().(1, 2, 3)"
+    assert Macro.to_binary(quote do: foo.bar.([1, 2, 3])) == "foo.bar().([1, 2, 3])"
   end
 
   test :aliases_call_to_binary do
     assert Macro.to_binary(quote do: Foo.Bar.baz(1, 2, 3)) == "Foo.Bar.baz(1, 2, 3)"
+    assert Macro.to_binary(quote do: Foo.Bar.baz([1, 2, 3])) == "Foo.Bar.baz([1, 2, 3])"
   end
 
   test :blocks_to_binary do


### PR DESCRIPTION
I.e. something like (quote do: foo([1, 2, 3])).
