### PR TITLE
defmodule returns module name, binary and the result

### DIFF
--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -86,7 +86,7 @@ compile(Line, Module, Block, Vars, RawS) when is_atom(Module) ->
     ],
 
     Binary = load_form(Line, Final, S),
-    { Result, Binary }
+    { module, Module, Binary, Result }
   after
     ets:delete(data_table(Module)),
     ets:delete(docs_table(Module)),

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -165,7 +165,7 @@ defmodule ModuleTest do
   end
 
   test :defmodule do
-    assert match?({ 3, binary } when is_binary(binary), defmodule LOL do
+    assert match?({ :module, LOL, binary, 3 } when is_binary(binary), defmodule LOL do
       1 + 2
     end)
   end

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -8,7 +8,7 @@ defmodule Typespec.Test.Type do
   # module
   defmacro test_module([{:do, block}]) do
     quote do
-      { result, _binary } = defmodule T do
+      { :module, T, _binary, result } = defmodule T do
         unquote(block)
       end
       :code.delete(T)

--- a/lib/mix/lib/mix/tasks/escriptize.ex
+++ b/lib/mix/lib/mix/tasks/escriptize.ex
@@ -106,7 +106,7 @@ defmodule Mix.Tasks.Escriptize do
   end
 
   defp gen_main(name, module) do
-    { _, binary } =
+    { :module, ^name, binary, _ } =
       defmodule name do
         @module module
 


### PR DESCRIPTION
Previously, 58eea96fc22f2ba0527a699b3731c42af17e72f5 was
attempting to solve the ambiguity of records and defmodule result.

This solves the problem completely by tagging defmodule results with
the :module atom and it brings the module name back into the tuple
