### PR TITLE
Add support for %w and %W (words) sigils

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2672,7 +2672,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Handles the sigil %B. It simples returns a binary
+  Handles the sigil %B. It simply returns a binary
   without escaping characters and without interpolations.
 
   ## Examples
@@ -2757,7 +2757,7 @@ defmodule Kernel do
 
   @doc """
   Handles the sigil %R. It returns a Regex pattern without escaping
-  nor interpreating interpolations.
+  nor interpreting interpolations.
 
   ## Examples
 
@@ -2767,6 +2767,39 @@ defmodule Kernel do
   defmacro __R__({ :<<>>, _line, [string] }, options) when is_binary(string) do
     regex = Regex.compile!(string, options)
     Macro.escape(regex)
+  end
+
+  @doc """
+  Handles the sigil %w. It returns a list of words (binaries)
+  split by whitespace.
+
+  ## Examples
+
+      %w(foo \#{:bar} baz)            #=> ["foo", "bar", "baz"]
+      %w(--source test/enum_test.exs) #=> ["--source", "test/enum_test.exs"]
+
+  """
+
+  defmacro __w__({ :<<>>, _line, [string] }, []) when is_binary(string) do
+    String.split_words(Macro.unescape_binary(string))
+  end
+
+  defmacro __w__({ :<<>>, line, pieces }, []) do
+    binary = { :<<>>, line, Macro.unescape_tokens(pieces) }
+    quote do: String.split_words(unquote(binary))
+  end
+
+  @doc """
+  Handles the sigil %W. It returns a list of words (binaries)
+  split by whitespace without escaping nor interpreting interpolation.
+
+  ## Examples
+
+      %W(foo \#{bar} baz) #=> ["foo", "\\\#{bar}", "baz"]
+
+  """
+  defmacro __W__({ :<<>>, _line, [string] }, []) when is_binary(string) do
+    String.split_words(string)
   end
 
   ## Private functions

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -132,6 +132,14 @@ defmodule String do
     :binary.split(binary, pattern, options_list)
   end
 
+  @doc false
+  def split_words(string) do
+    case Regex.split(%r/\s+/, string, [parts: 0]) do
+      [ "" | tail ] -> tail
+      other -> other
+    end
+  end
+
   @doc """
   Convert all characters on the given string to upper case.
 
@@ -317,7 +325,7 @@ defmodule String do
 
   defp do_codepoints({char, rest}) do
     [char|do_codepoints(codepoint(rest))]
-  end  
+  end
 
   defp do_codepoints(:no_codepoint), do: []
 
@@ -428,9 +436,9 @@ defmodule String do
   defp codepoint(<<first, second, char, rest :: binary>>)
     when first in 225..239 and second in 128..191 and char in 128..191,
     do: { <<first, second, char>>, rest }
-  
+
   defp codepoint(<<other, rest :: binary>>), do: { <<other>>, rest }
-  
+
   defp codepoint(<<>>), do: :no_codepoint
 
 end

--- a/lib/elixir/test/elixir/kernel/sigils_test.exs
+++ b/lib/elixir/test/elixir/kernel/sigils_test.exs
@@ -48,4 +48,19 @@ defmodule Kernel.SigilsTest do
     assert %C(f#{o}o) == 'f\#{o}o'
     assert %C(f\no) == 'f\\no'
   end
+
+  test :__w__ do
+    assert %w(foo bar baz) == ["foo", "bar", "baz"]
+    assert %w(foo #{:bar} baz) == ["foo", "bar", "baz"]
+    assert %w( foo
+               bar
+               baz ) == ["foo", "bar", "baz"]
+  end
+
+  test :__W__ do
+    assert %W(foo #{bar} baz) == ["foo", "\#{bar}", "baz"]
+    assert %W( foo
+               bar
+               baz ) == ["foo", "bar", "baz"]
+  end
 end


### PR DESCRIPTION
Lists of binaries are incredibly common and introduce a lot of visual noise. Take for example package definitions for [EXPM](http://expm.co/):

```
["Elixir","Erlang","package","library","dependency","dependencies"]
```

Word sigils are for lists of files, command line options, and much more. Doing a `grep -R "\[\"" *` on the Elixir source will give you an idea of where %w could cleanup the code.

Examples:

```
File.join %w(var log alchemist alchemist.log)

OptionParser.parse_head %w(--source lib test/enum_test.exs --verbose)

[keywords: %w( Elixir Erlang package library dependency dependencies )]

%w( words
    are
    great )
```
