### PR TITLE
Add support for defining multiple protocol implementations in one go

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -50,6 +50,9 @@ defmodule Protocol do
   It also defines a `__impl__` function which
   returns the protocol being implemented.
   """
+  def defimpl(protocol, [do: block, for: for]) when is_list(for) do
+    lc f inlist for, do: Protocol.defimpl(protocol, [do: block, for: f])
+  end
   def defimpl(protocol, [do: block, for: for]) do
     quote do
       protocol = unquote(protocol)

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -47,6 +47,14 @@ defimpl ProtocolTest.Plus, for: Number do
   def plus(thing, other), do: thing + other
 end
 
+defprotocol ProtocolTest.Multi do
+  def test(a)
+end
+
+defimpl ProtocolTest.Multi, for: [Atom, Number] do
+  def test(a), do: a
+end
+
 defmodule ProtocolTest do
   use ExUnit.Case, async: true
 
@@ -124,6 +132,12 @@ defmodule ProtocolTest do
     assert_raise UndefinedFunctionError, fn ->
       ProtocolTest.WithAll.blank(ProtocolTest.Bar.new)
     end
+  end
+
+  test :multi_impl do
+    assert ProtocolTest.Multi.test(1) == 1
+    assert ProtocolTest.Multi.test(:a) == :a
+    assert catch_error(ProtocolTest.Multi.test("a")) == :undef
   end
 
   # Assert that the given protocol is going to be dispatched.


### PR DESCRIPTION
``` elixir
defimpl SomeProtocol, for: [Atom, Number, List] do
    ...
end
```
