### PR TITLE
default // nil for HashDict.get

### DIFF
--- a/lib/elixir/lib/hash_dict.ex
+++ b/lib/elixir/lib/hash_dict.ex
@@ -33,7 +33,7 @@ defmodule HashDict do
     :dict.is_key key, data
   end
 
-  def get(dict(data), key, default) do
+  def get(dict(data), key, default // nil) do
     case :dict.find(key, data) do
       {:ok, value} -> value
       :error       -> default


### PR DESCRIPTION
This is my first time trying the pull request on github, forgive me if I didn't do it right. (I know now I should have made a separate branch first, but let me know if there are also other things to do better).

The 3rd parameter, called default, in HashDict.get did not have a // nil after it.  I added the // nil to make it consistent with Dict.get.

Thanks,
Jason
