### PR TITLE
Macro.to_binary should correctly process expressions involving regular a...

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -238,9 +238,20 @@ defmodule Macro do
   end
   defp is_kw_blocks?(_),          do: false
 
+  defp module_to_binary(atom) when is_atom(atom) do
+    b = atom_to_binary(atom, :utf8)
+    first = String.at(b, 0)
+    if String.upcase(first) == first do # "big" atom"
+      b
+    else # regular atom
+      ":" <> b
+    end
+  end
+  defp module_to_binary(other), do: call_to_binary(other)
+
   defp call_to_binary(atom) when is_atom(atom),  do: atom_to_binary(atom, :utf8)
-  defp call_to_binary({ :., _, [arg] }),         do: call_to_binary(arg) <> "."
-  defp call_to_binary({ :., _, [left, right] }), do: call_to_binary(left) <> "." <> call_to_binary(right)
+  defp call_to_binary({ :., _, [arg] }),         do: module_to_binary(arg) <> "."
+  defp call_to_binary({ :., _, [left, right] }), do: module_to_binary(left) <> "." <> call_to_binary(right)
   defp call_to_binary(other),                    do: to_binary(other)
 
   defp call_to_binary_with_args(target, args) do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -128,6 +128,14 @@ defmodule MacroTest do
     assert Macro.to_binary(quote do: foo.bar([1, 2, 3])) == "foo.bar([1, 2, 3])"
   end
 
+  test :low_atom_remote_call_to_binary do
+    assert Macro.to_binary(quote do: :foo.bar(1, 2, 3)) == ":foo.bar(1, 2, 3)"
+  end
+
+  test :big_atom_remote_call_to_binary do
+    assert Macro.to_binary(quote do: Foo.Bar.bar(1, 2, 3)) == "Foo.Bar.bar(1, 2, 3)"
+  end
+
   test :remote_and_fun_call_to_binary do
     assert Macro.to_binary(quote do: foo.bar.(1, 2, 3)) == "foo.bar().(1, 2, 3)"
     assert Macro.to_binary(quote do: foo.bar.([1, 2, 3])) == "foo.bar().([1, 2, 3])"


### PR DESCRIPTION
...tom module names (e.g. :lists.seq(1,100))
