### PR TITLE
Add String.t() and char_list() types, discourage use of string() because...

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -543,7 +543,7 @@ defmodule Kernel do
       #=> '7.00000000000000000000e+00'
 
   """
-  @spec float_to_list(number), do: string
+  @spec float_to_list(number), do: char_list
   def float_to_list(number) do
     :erlang.float_to_list(number)
   end
@@ -559,7 +559,7 @@ defmodule Kernel do
   @doc """
   The same as halt(status, []).
   """
-  @spec halt(non_neg_integer | string | :abort), do: no_return
+  @spec halt(non_neg_integer | char_list | :abort), do: no_return
   def halt(status) do
     :erlang.halt(status)
   end
@@ -591,7 +591,7 @@ defmodule Kernel do
       halt(:abort)
 
   """
-  @spec halt(non_neg_integer | string | :abort, [] | [flush: false]), do: no_return
+  @spec halt(non_neg_integer | char_list | :abort, [] | [flush: false]), do: no_return
   def halt(status, options) do
     :erlang.halt(status, options)
   end
@@ -613,7 +613,7 @@ defmodule Kernel do
       #=> '7'
 
   """
-  @spec integer_to_list(integer), do: string
+  @spec integer_to_list(integer), do: char_list
   def integer_to_list(number) do
     :erlang.integer_to_list(number)
   end
@@ -628,7 +628,7 @@ defmodule Kernel do
       #=> "3FF"
 
   """
-  @spec integer_to_list(integer, pos_integer), do: string
+  @spec integer_to_list(integer, pos_integer), do: char_list
   def integer_to_list(number, base) do
     :erlang.integer_to_list(number, base)
   end
@@ -840,7 +840,7 @@ defmodule Kernel do
 
       list_to_atom('elixir') #=> :elixir
   """
-  @spec list_to_atom(string), do: atom
+  @spec list_to_atom(char_list), do: atom
   def list_to_atom(char_list) do
     :erlang.list_to_atom(char_list)
   end
@@ -880,7 +880,7 @@ defmodule Kernel do
   Returns the atom whose text representation is `char_list`, but only if there already
   exists such atom.
   """
-  @spec list_to_existing_atom(string), do: atom
+  @spec list_to_existing_atom(char_list), do: atom
   def list_to_existing_atom(char_list) do
     :erlang.list_to_existing_atom(char_list)
   end
@@ -892,7 +892,7 @@ defmodule Kernel do
 
       list_to_float('2.2017764e+0') #=> 2.2017764
   """
-  @spec list_to_float(string), do: float
+  @spec list_to_float(char_list), do: float
   def list_to_float(char_list) do
     :erlang.list_to_float(char_list)
   end
@@ -904,7 +904,7 @@ defmodule Kernel do
 
       list_to_integer('123') #=> 123
   """
-  @spec list_to_integer(string), do: integer
+  @spec list_to_integer(char_list), do: integer
   def list_to_integer(char_list) do
     :erlang.list_to_integer(char_list)
   end
@@ -916,7 +916,7 @@ defmodule Kernel do
 
       list_to_integer('3FF', 16) #=> 1023
   """
-  @spec list_to_integer(string, non_neg_integer), do: integer
+  @spec list_to_integer(char_list, non_neg_integer), do: integer
   def list_to_integer(char_list, base) do
     :erlang.list_to_integer(char_list, base)
   end
@@ -934,7 +934,7 @@ defmodule Kernel do
   ## Examples
       list_to_pid('<0.41>') #=> <0.4.1>
   """
-  @spec list_to_pid(string), do: pid
+  @spec list_to_pid(char_list), do: pid
   def list_to_pid(char_list) do
     :erlang.list_to_pid(char_list)
   end

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -23,6 +23,8 @@ defmodule String do
       String.printable?("abc") #=> true
 
   """
+  
+  @type t :: binary
 
   # Allow basic ascii chars
   def printable?(<<c, t :: binary>>) when c in ?\s..?~ do

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -7,6 +7,11 @@
 -include("elixir.hrl").
 -compile({parse_transform, elixir_transform}).
 
+%% Top level types
+-export_type([char_list/0]).
+
+-type char_list() :: string().
+
 % OTP APPLICATION API
 
 -export([start/2, stop/1, config_change/3]).

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -155,11 +155,11 @@ defmodule Typespec.Test.Type do
 
   test "@type with a union" do
     spec = test_module do
-      @type mytype :: integer | string
+      @type mytype :: integer | char_list
                     | atom
     end
     assert {:type,{:mytype,{:type,_,:union, [{:type, _, :integer, []},
-                         {:type, _, :string, []},
+                         {:remote_type, _, [{:atom, _, :elixir},{:atom, _, :char_list}, []]},
                          {:type, _, :atom, []}]}, []}} = spec
   end
 
@@ -234,7 +234,7 @@ defmodule Typespec.Test.Type do
       import Kernel.Typespec
       def myfun(x), do: x
       @spec myfun(integer), do: integer
-      @spec myfun(string),  do: string
+      @spec myfun(char_list),  do: char_list
       callback_from_spec(__MODULE__, :myfun, 1)
       get_specs(__MODULE__)
     end
@@ -242,10 +242,10 @@ defmodule Typespec.Test.Type do
     assert [
       {{:callback, {:myfun,1}},[
         {:type,_,:fun,[{:type,_,:product,[{:type,_,:integer,[]}]},{:type,_,:integer,[]}]},
-        {:type,_,:fun,[{:type,_,:product,[{:type,_,:string,[]}]},{:type,_,:string,[]}]}]},
+        {:type,_,:fun,[{:type,_,:product,[{:remote_type, _, [{:atom, _, :elixir},{:atom, _, :char_list}, []]}]},{:remote_type, _, [{:atom, _, :elixir},{:atom, _, :char_list}, []]}]}]},
       {{:spec, {:myfun,1}},[
         {:type,_,:fun,[{:type,_,:product,[{:type,_,:integer,[]}]},{:type,_,:integer,[]}]},
-        {:type,_,:fun,[{:type,_,:product,[{:type,_,:string,[]}]},{:type,_,:string,[]}]}]}
+        {:type,_,:fun,[{:type,_,:product,[{:remote_type, _, [{:atom, _, :elixir},{:atom, _, :char_list}, []]}]},{:remote_type, _, [{:atom, _, :elixir},{:atom, _, :char_list}, []]}]}]}
     ] = List.sort(specs)
   end
 
@@ -254,7 +254,7 @@ defmodule Typespec.Test.Type do
       import Kernel.Typespec
       def myfun(x), do: x
       @spec myfun(integer), do: integer
-      @spec myfun(string),  do: string
+      @spec myfun(char_list),  do: char_list
       @callback cb(integer), do: integer
       get_specs(__MODULE__)
     end
@@ -265,7 +265,7 @@ defmodule Typespec.Test.Type do
       ]},
       {{:spec, {:myfun,1}},[
         {:type,_,:fun,[{:type,_,:product,[{:type,_,:integer,[]}]},{:type,_,:integer,[]}]},
-        {:type,_,:fun,[{:type,_,:product,[{:type,_,:string,[]}]},{:type,_,:string,[]}]}]}
+        {:type,_,:fun,[{:type,_,:product,[{:remote_type, _, [{:atom, _, :elixir},{:atom, _, :char_list}, []]}]},{:remote_type, _, [{:atom, _, :elixir},{:atom, _, :char_list}, []]}]}]}
     ] = List.sort(specs)
   end
 end


### PR DESCRIPTION
... it might lead to confusion.

Note, however, that dialyzer will often talk about string() anyway.

Addresses #588
