### PR TITLE
Add support for access macro in typespecs

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -106,6 +106,12 @@ defmodule Kernel.Typespec do
     { :op, line, op, {:integer, line, integer} }
   end
 
+  # Handle access macro
+  defp typespec({{:., line, [Kernel, :access]}, line1, [target, args]}, vars, caller) do
+    access = {{:., line, [Kernel, :access]}, line1, 
+              [target, args ++ [_: (quote hygiene: false, do: any)]]}
+    typespec(Macro.expand(access, caller), vars, caller)
+  end
   # Handle remote calls
   defp typespec({{:., line, [remote, name]}, _, args}, vars, caller) do
     remote = Macro.expand remote, caller

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -163,6 +163,14 @@ defmodule Typespec.Test.Type do
                          {:type, _, :atom, []}]}, []}} = spec
   end
 
+  test "@type with an access macro" do
+    spec = test_module do
+      @type mytype :: Range[first: integer]
+    end
+    assert {:type,{:mytype,{:type, _, :tuple, 
+              [{:atom, _, Range}, {:type, _, :integer, []}, {:type, _, :any, []}]}, []}} = spec
+  end
+
   test "@type with parameters" do
     {spec1, spec2, spec3} = test_module do
       t1 = @type mytype(x) :: x


### PR DESCRIPTION
Not sure it is complete, but it's a starter. Anything I might have missed?
