### PR TITLE
Implement a simple version of the t helper for the interactive shell

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -237,6 +237,83 @@ defmodule Kernel.Typespec do
     quote do: []
   end
 
+  @doc """
+  Retrieves all type specifications from a module. 
+
+  The module has to have a corresponding beam file on the file system.
+  """
+  def types(module) do
+    case abstract_code(module) do
+      {:ok, abstract_code} ->
+        lc {:attribute, _, :type, ti} inlist abstract_code, do: {:type, ti}
+      [] ->
+        []
+    end
+  end
+
+  @doc """
+  Retrieves all type specifications from a module with a given name and arity. 
+  
+  The module has to have a corresponding beam file on the file system.
+  """
+  def types(module, type, arity) do
+    case abstract_code(module) do
+      {:ok, abstract_code} ->
+        lc {:attribute, _, :type, {t, _, a} = ti} inlist abstract_code, t == type, length(a) == arity, do: {:type, ti}
+      _ ->
+        []
+    end
+  end
+
+
+  @doc """
+  Retrieves all functions specifications from a module. 
+  
+  The module has to have a corresponding beam file on the file system.
+  """
+  def specs(module) do
+    case abstract_code(module) do
+      {:ok, abstract_code} ->
+        lc {:attribute, _, :spec, {fa, s}} inlist abstract_code, do: {{:spec, fa}, s}
+      _ ->
+        []
+    end
+  end
+
+  @doc """
+  Retrieves all functions specifications from a module for a given name and arity. 
+  
+  The module has to have a corresponding beam file on the file system.
+  """
+  def specs(module, function, arity) do
+    case abstract_code(module) do
+      {:ok, abstract_code} ->
+        lc {:attribute, _, :spec, {{f,a}=fa, s}} inlist abstract_code, f == function, a == arity, do: {{:spec, fa}, s}
+      _ ->
+        []
+    end
+  end
+
+
+  defp abstract_code(module) do
+    case :beam_lib.chunks(abstract_code_beam(module), [:abstract_code]) do
+      {:ok, {_, [{:abstract_code, {raw_abstract_v1, abstract_code}}]}} ->
+        {:ok, abstract_code}
+      _ -> 
+        :error
+    end
+  end  
+
+  defp abstract_code_beam(module) when is_atom(module) do
+    case :code.which(module) do
+      :non_existing -> module
+      file -> file
+    end
+  end
+  defp abstract_code_beam(binary) when is_binary(binary) do
+    binary
+  end
+
   ## Typespec conversion
 
   # Handle unions

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -328,4 +328,32 @@ defmodule Typespec.Test.Type do
       assert Kernel.Typespec.to_binary(spec) == Macro.to_binary(definition)
     end
   end
+
+  # test/spec retrieval
+
+  test "specs retrieval" do
+    Code.compiler_options debug_info: true
+    { :module, T, binary, _ } = defmodule T do
+      @spec a, do: any
+      def a, do: nil
+    end
+    Code.compiler_options debug_info: false
+    :code.delete(T)
+    :code.purge(T)
+    assert [{{:spec,{:a,_}},[{:type,_,:fun,[{:type,_,:product,[]},{:type,_,:any,[]}]}]}] = Kernel.Typespec.specs(binary)
+    assert [{{:spec,{:a,_}},[{:type,_,:fun,[{:type,_,:product,[]},{:type,_,:any,[]}]}]}] = Kernel.Typespec.specs(binary, :a, 0)
+  end
+
+  test "types retrieval" do
+    Code.compiler_options debug_info: true
+    { :module, T, binary, _ } = defmodule T do
+      @type a :: any
+    end
+    Code.compiler_options debug_info: false
+    :code.delete(T)
+    :code.purge(T)
+    assert [{:type, {:a,{:type,_,:any,[]},[]}}] = Kernel.Typespec.types(binary)
+    assert [{:type, {:a,{:type,_,:any,[]},[]}}] = Kernel.Typespec.types(binary, :a, 0)
+  end
+
 end


### PR DESCRIPTION
Prints out type/spec information

(If Haskell has :t, why can't we have it, too?)
