### PR TITLE
Fix Kernel.Typespec.to_binary for tuple() type (with no element type spe...

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -172,6 +172,10 @@ defmodule Kernel.Typespec do
     quote do: @opaque unquote(name)(unquote_splicing(args)) :: unquote(typespec_to_ast(type))
   end
 
+  defp typespec_to_ast({:type, line, :tuple, :any}) do
+    typespec_to_ast({:type, line, :tuple, []})
+  end
+
   defp typespec_to_ast({:type, line, :tuple, args}) do
     args = lc arg inlist args, do: typespec_to_ast(arg)
     { :{}, line, args }

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -288,6 +288,7 @@ defmodule Typespec.Test.Type do
 
   test "to_binary types" do
     types = [
+      (quote do: @type empty_tuple_type() :: {}),    
       (quote do: @type imm_type_1() :: 1),
       (quote do: @type imm_type_2() :: :atom),
       (quote do: @type simple_type() :: integer()),


### PR DESCRIPTION
...cified)
