### PR TITLE
Access protocol for all lists of tuples

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -31,8 +31,13 @@ defimpl Access, for: List do
 
   """
 
-  def access(list, atom) when is_atom(atom) do
-    Keyword.get(list, atom)
+  def access([], _key), do: nil
+
+  def access(list, key) do
+    case :lists.keyfind(key, 1, list) do
+      { ^key, value } -> value
+      false -> nil
+    end
   end
 
 end

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -7,6 +7,9 @@ defmodule AccessTest do
     assert [foo: :bar][:foo] == :bar
     assert [foo: [bar: :baz]][:foo][:bar] == :baz
     assert [foo: [bar: :baz]][:fuu][:bar] == nil
+    assert [{"foo", :bar}]["foo"] == :bar
+    assert [{"foo", [{"bar", :baz}]}]["foo"]["bar"] == :baz
+    assert [{"foo", [{"bar", :baz}]}]["fuu"]["bar"] == nil
   end
 
   test :nil do


### PR DESCRIPTION
This is incredibly useful for dealing with things like JSON.

For example, in my app I assumed this would work:

``` elixir
rpc = JsonRpc[jsonrpc: json["jsonrpc"],
              id: json["id"],
              method: json["method"],
              params: json["params"]]
```

Other possibilities:

``` elixir
star_ratings = [{1.0, "★"}, {1.5, "★☆"}, {2.0, "★★"}]
star_ratings[1.5] #=> "★☆"
```
