### PR TITLE
Add support for ExUnit user configs

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -74,7 +74,7 @@ defmodule ExUnit do
   def user_options(user_config // nil) do
     user_config = user_config || System.get_env("EXUNIT_CONFIG") || File.join(System.get_env("HOME"),".ex_unit.exs")
     if File.exists?(user_config) do
-      {config, _} = Code.eval(File.read!(user_config))
+      {config, _} = Code.eval(File.read!(user_config), [], file: user_config)
       config
     else
       []

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -12,7 +12,7 @@ defmodule Mix.CLITest do
 
   test "default task" do
     in_fixture "custom_mixfile", fn ->
-      output = mix "", [{"EXUNIT_CONFIG","none"}]
+      output = mix ""
       assert File.regular?("ebin/Elixir-A.beam")
       assert output =~ %r"1 tests, 0 failures"
     end
@@ -20,13 +20,13 @@ defmodule Mix.CLITest do
 
   test "invoke simple task from CLI" do
     in_fixture "only_mixfile", fn ->
-      assert mix("hello", [{"EXUNIT_CONFIG","none"}]) == "Hello from MyProject!\n"
+      assert mix("hello") == "Hello from MyProject!\n"
     end
   end
 
   test "compile smoke test" do
     in_fixture "no_mixfile", fn ->
-      output = mix "compile", [{"EXUNIT_CONFIG","none"}]
+      output = mix "compile"
 
       assert File.regular?("ebin/Elixir-A.beam")
       assert File.regular?("ebin/Elixir-B.beam")
@@ -38,18 +38,18 @@ defmodule Mix.CLITest do
 
   test "test smoke test" do
     in_fixture "custom_mixfile", fn ->
-      output = mix "test", [{"EXUNIT_CONFIG","none"}]
+      output = mix "test"
       assert File.regular?("ebin/Elixir-A.beam")
       assert output =~ %r"1 tests, 0 failures"
 
-      output = mix "test test/hidden.ex", [{"EXUNIT_CONFIG","none"}]
+      output = mix "test test/hidden.ex"
       assert output =~ %r"1 tests, 1 failures"
     end
   end
 
   test "help smoke test" do
     in_fixture "only_mixfile", fn ->
-      output = mix "help", [{"EXUNIT_CONFIG","none"}]
+      output = mix "help"
       assert output =~ %r"mix compile\s+# Compile source files"
       assert output =~ %r"mix hello\s+# Hello"
       refute output =~ %r"mix invalid"
@@ -58,7 +58,7 @@ defmodule Mix.CLITest do
 
   test "help TASK smoke test" do
     in_fixture "only_mixfile", fn ->
-      output = mix "help compile", [{"EXUNIT_CONFIG","none"}]
+      output = mix "help compile"
       assert output =~ %r"# mix help compile"
       assert output =~ %r"## Command line options"
       assert output =~ %r"^Location:"m
@@ -67,7 +67,7 @@ defmodule Mix.CLITest do
 
   test "do smoke test" do
     in_fixture "only_mixfile", fn ->
-      output = mix "do compile --list, help compile", [{"EXUNIT_CONFIG","none"}]
+      output = mix "do compile --list, help compile"
       assert output =~ %r"# mix help compile"
       assert output =~ %r"mix compile.elixir #"
     end
@@ -75,10 +75,10 @@ defmodule Mix.CLITest do
 
   test "new with tests smoke test" do
     in_tmp "new_with_tests", fn ->
-      output = mix "new .", [{"EXUNIT_CONFIG","none"}]
+      output = mix "new ."
       assert output =~ %r(\* creating lib/new_with_tests.ex)
 
-      output = mix "test", [{"EXUNIT_CONFIG","none"}]
+      output = mix "test"
       assert File.regular?("ebin/Elixir-NewWithTests.beam")
       assert output =~ %r"1 tests, 0 failures"
     end

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -2,6 +2,7 @@ Mix.start()
 Mix.shell(Mix.Shell.Process)
 
 ExUnit.start []
+System.put_env("EXUNIT_CONFIG", "none")
 
 target = File.expand_path("../fixtures/git_repo", __FILE__)
 
@@ -64,9 +65,8 @@ defmodule MixTest.Case do
     end
   end
 
-  def mix(args, env // []) do
-    env_formatted = Enum.join(Enum.map(env, fn({name, val}) -> "#{name}=#{val}" end), " ")
-    System.cmd "#{env_formatted} #{elixir_executable} #{mix_executable} #{args}"
+  def mix(args) do
+    System.cmd "#{elixir_executable} #{mix_executable} #{args}"
   end
 
   def mix_executable do


### PR DESCRIPTION
Motivation:

![Motivation](https://dl.dropbox.com/u/923732/elixir_ansi.png)

(What this means is I can configure my ERL_LIBS and ~/.ex_unit.exs and have exunit tests for _any_ project formatted the way _I_ want)
