### PR TITLE
Flexible formatters for ExUnit

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -80,9 +80,8 @@ defmodule ExUnit do
   need to call it directly.
   """
   def run do
-    config = ExUnit.Runner.Config.new ExUnit.Server.options
-    config = config.formatter(config.formatter.start)
-    failures = ExUnit.Runner.loop config
+    config   = ExUnit.Runner.Config.new ExUnit.Server.options
+    failures = ExUnit.Runner.run config
     if failures > 0, do: halt(1), else: halt(0)
   end
 end


### PR DESCRIPTION
Main goals:

1) The formatter is free to choose between cast and call messages (for example, an html formatter that generates an html file does not need to rely on call messages)
2) Expose also start and ending of each case and run

@yrashk: the motivation for this commit was `ex_unit_ansi` (great job!). The idea is to define a more robust API more unlikely to change and that will easily support more formatters, like HTML formatter in the future. Feedback is welcome.
