### PR TITLE
default extracted record vals to :undefined instead of :nil

### DIFF
--- a/lib/elixir/lib/record/extractor.ex
+++ b/lib/elixir/lib/record/extractor.ex
@@ -70,7 +70,7 @@ defmodule Record.Extractor do
   end
 
   defp parse_field({ :record_field, _, key }) do
-    { :tuple, 0, [key, {:atom, 0, :nil}] }
+    { :tuple, 0, [key, {:atom, 0, :undefined}] }
   end
 
   defp parse_field({ :record_field, _, key, value }) do

--- a/lib/elixir/test/elixir/record_test.exs
+++ b/lib/elixir/test/elixir/record_test.exs
@@ -71,7 +71,7 @@ defmodule RecordTest do
   test :record_constructor_with_dict do
     record   = RecordTest.FileInfo.new(type: :regular)
     assert record.type == :regular
-    assert record.access == nil
+    assert record.access == :undefined
   end
 
   test :record_accessors do


### PR DESCRIPTION
When translating erlang records into elixir records, use :undefined
as the default record value since that's what erlang uses, and
presumably you're going to be using these records with erlang apis.

Ran into an issue trying to use [erlcloud](https://github.com/gleber/erlcloud/blob/master/include/erlcloud_ec2.hrl#L11) records. Since the api expects the undefined atom, when it see the nil atom, it thinks it's data and tries to pass it along to the EC2 api, which bombs out on it.
