### PR TITLE
Fix percent encoding algorithm used by URI.encode

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -81,14 +81,9 @@ defmodule URI do
     <<c>>
   end
 
-  defp percent(c), do: escape_byte(c)
-
-  defp escape_byte(c), do: "%" <> hex(c)
+  defp percent(c), do: "%" <> hex(bsr(c, 4)) <> hex(band(c, 15))
 
   defp hex(n) when n <= 9, do: <<n + ?0>>
-  defp hex(n) when n > 15 do
-    hex(bsr(n, 4)) <> hex(band(n, 15))
-  end
   defp hex(n), do: <<n + ?A - 10>>
 
   @doc """

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -4,8 +4,8 @@ defmodule URITest do
   use ExUnit.Case, async: true
 
   test :encode_with_binary do
-    raw = <<38,60,62,34,32,227,130,134,227,130,147,227,130,134,227,130,147>>
-    expected = "%26%3C%3E%22+%E3%82%86%E3%82%93%E3%82%86%E3%82%93"
+    raw = <<13,10,38,60,62,34,32,227,130,134,227,130,147,227,130,134,227,130,147>>
+    expected = "%0D%0A%26%3C%3E%22+%E3%82%86%E3%82%93%E3%82%86%E3%82%93"
     assert URI.encode(raw) == expected
   end
 


### PR DESCRIPTION
Expecting `URI.encode("\r\n")` to return `"%0D%0A"`

Currently returns `"%D%A"`
