### PR TITLE
String.strip should strip other whitespace characters

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -262,7 +262,11 @@ defmodule String do
   """
   @spec strip(t), do: t
   @spec strip(t, char), do: t  
-  def strip(string, char // ?\s) do
+  def strip(string) do
+    rstrip(lstrip(string))
+  end
+
+  def strip(string, char) do
     rstrip(lstrip(string, char), char)
   end
 

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -63,6 +63,8 @@ defmodule StringTest do
   test :strip do
     assert String.strip("") == ""
     assert String.strip("   abc  ") == "abc"
+    assert String.strip("a  abc  a\n\n") == "a  abc  a"
+    assert String.strip("a  abc  a\t\n\v\f\r\s") == "a  abc  a"
     assert String.strip("___  abc  ___", ?_) == "  abc  "
   end
 


### PR DESCRIPTION
Fixes #655

Not sure if rstrip is done correctly.
