### PR TITLE
Fix mix dependency format error string

### DIFF
--- a/lib/mix/lib/mix/deps/project.ex
+++ b/lib/mix/lib/mix/deps/project.ex
@@ -58,7 +58,7 @@ defmodule Mix.Deps.Project do
 
   defp with_scm_and_status(other, _scms) do
     raise Mix.Error, message: %b(dependency specified in the wrong format: #{inspect other}, ) <>
-      %b(expected { "app", "requirement", scm: "location" })
+      %b(expected { :app, scm: "location" } | { :app, "requirement", scm: "location" })
   end
 
   defp status(scm, app, req, opts) do


### PR DESCRIPTION
The app name is an atom, but the error message says it should be a
binary, which causes confusion.

Fix that and also add a version without the "requirement" field, which
is optional.
