### PR TITLE
Add function(Module.fun/arity) and function(fun/arity) syntax

### DIFF
--- a/lib/elixir/src/elixir_macros.erl
+++ b/lib/elixir/src/elixir_macros.erl
@@ -56,6 +56,12 @@ translate({ function, Line, [[{do,{ '->',_,Pairs}}]] }, S) ->
   assert_no_assign_or_guard_scope(Line, 'function', S),
   elixir_translator:translate_fn(Line, Pairs, S);
 
+translate({ function, Line, [{ '/', _, [{{ '.', _ ,[M, F] }, _ , [] }, A]}] }, S) ->
+  translate({ function, Line, [M, F, A] }, S);
+
+translate({ function, Line, [{ '/', _, [{F, _, Q}, A]}] }, S) when is_atom(Q) ->
+  translate({ function, Line, [F, A] }, S);
+
 translate({ function, Line, [_] }, S) ->
   assert_no_assign_or_guard_scope(Line, 'function', S),
   syntax_error(Line, S#elixir_scope.file, "invalid args for function");

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -96,11 +96,22 @@ defmodule KernelTest do
       assert function(:erlang, :atom_to_list, 1).(:a) == 'a'
     end
 
+    test :remote_syntax_function do
+      assert function(:erlang.atom_to_list/1) ==
+             function(:erlang, :atom_to_list, 1)
+      assert function(Enum.map/2) == function(Enum, :map, 2)
+    end
+
     test :retrieve_local_function do
       assert is_function(function(:atl, 1))
       assert :erlang.fun_info(function(:atl, 1), :arity) == {:arity, 1}
       assert function(:atl, 1).(:a) == 'a'
     end
+
+    test :local_syntax_function do
+      assert function(atl/1).(:a) == 'a'
+    end
+
 
     test :retrieve_imported_function do
       assert is_function(function(:atom_to_list, 1))


### PR DESCRIPTION
These are equivalent to function(Module, :fun, arity) and function(:fun, arity) constructs, respectively
