### PR TITLE
elixir_code_server should not trap exits and should not log on terminate

### DIFF
--- a/lib/elixir/src/elixir_code_server.erl
+++ b/lib/elixir/src/elixir_code_server.erl
@@ -15,7 +15,6 @@ start_link() ->
   { ok, _ } = gen_server:start_link({local, elixir_code_server}, ?MODULE, [], []).
 
 init(_args) ->
-  process_flag(trap_exit, true),
   { ok, #elixir_code_server{} }.
 
 handle_call({ acquire, Path }, From, Config) ->
@@ -96,9 +95,7 @@ handle_cast(_Request, Config) ->
 handle_info(_Request, Config) ->
   { noreply, Config }.
 
-terminate(Reason, Config) ->
-  io:format("[FATAL] ~p crashed:\n~p~n", [?MODULE, Reason]),
-  io:format("[FATAL] ~p snapshot:\n~p~n", [?MODULE, Config]),
+terminate(_Reason, _Config) ->
   ok.
 
 code_change(_Old, Config, _Extra) ->


### PR DESCRIPTION
The behaviour removed in this commit is wrong on many levels:
1. It logs using io:format (not using actual OTP error log mechanism)
2. It logs errors in any case, even if it was a legitimate shutdown
3. It doesn't do any cleanup in terminate (and it doesn't need to)
4. Crash reporting is done using SASL and there's no need for elixir_code_server to do its own reporting
