### PR TITLE
Fix some documentation errors for String.at.

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -447,11 +447,11 @@ defmodule String do
 
   ## Examples
 
-      String.at("elixir", 0) #=> "1"
+      String.at("elixir", 0) #=> "e"
       String.at("elixir", 1) #=> "l"
       String.at("elixir", 10) #=> nil
       String.at("elixir", -1) #=> "r"
-      String.at("elixir", -10) #=> nil
+      String.at("elixir", -10) #=> ""
 
   """
   @spec at(t, integer) :: grapheme | nil


### PR DESCRIPTION
The change for String.at("elixir", -10) #=> "" makes the example match what the
code actually does.  However, should the code actually return nil in this case?
See line 466.
