### PR TITLE
The default formatter of ex_unit should not prints unneeded stacktraces.

### DIFF
--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -71,10 +71,19 @@ defmodule ExUnit.CLIFormatter do
 
   defp print_failure({test_case, test, { kind, reason, stacktrace }}, acc) do
     IO.puts "#{acc}) #{test} (#{inspect test_case})"
-    IO.puts "  ** #{format_catch(kind, reason)}\n  stacktrace:"
-    Enum.each filter_stacktrace(stacktrace), fn(s) -> IO.puts "    #{format_stacktrace(s)}" end
+    IO.puts "  ** #{format_catch(kind, reason)}"
+    print_stacktrace(stacktrace)
     IO.write "\n"
     acc + 1
+  end
+
+  defp print_stacktrace([{ ExUnit.Assertions, _, _, _ }, { _, _, _, [ file: file, line: line ] }|_]) do
+    IO.puts "     at #{file}:#{line}"
+  end
+
+  defp print_stacktrace(stacktrace) do
+    IO.puts "  stacktrace:"
+    Enum.each stacktrace, fn(s) -> IO.puts "    #{format_stacktrace(s)}" end
   end
 
   defp format_catch(:error, exception) do
@@ -84,8 +93,4 @@ defmodule ExUnit.CLIFormatter do
   defp format_catch(kind, reason) do
     "(#{kind}) #{inspect(reason)}"
   end
-
-  defp filter_stacktrace([{ ExUnit.Assertions, _, _, _ }|t]), do: filter_stacktrace(t)
-  defp filter_stacktrace([h|t]), do: [h|filter_stacktrace(t)]
-  defp filter_stacktrace([]), do: []
 end

--- a/lib/ex_unit/test/ex_unit/cli_formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/cli_formatter_test.exs
@@ -1,0 +1,66 @@
+Code.require_file "../../test_helper.exs", __FILE__
+
+defmodule ExUnit.CLIFormatterTest do
+  use ExUnit.Case, sync: false
+
+  defp exec_test(file) do
+    cmd("#{elixir_path} #{file}")
+  end
+
+  defp elixir_path do
+    File.expand_path("../../../../../bin/elixir", __FILE__)
+  end
+
+  defp cmd(command) do
+    port = Port.open({ :spawn, to_char_list(command) },
+      [:stream, :binary, :exit_status, :hide])
+    do_cmd(port, "")
+  end
+
+  defp do_cmd(port, acc) do
+    receive do
+      { ^port, { :data, data } } ->
+        do_cmd(port, acc <> data)
+      { ^port, { :exit_status, status } } ->
+        acc
+    end
+  end
+
+  test :ptint_stacktrace_when_raising_not_at_assertion do
+    File.write "raising_test.exs", """
+    ExUnit.start
+    defmodule RaisingTest do
+      use ExUnit.Case
+      ExUnit.configure formatter: ExUnit.CLIFormatter
+
+      test :raise do
+        assert raise("raise")
+      end
+    end
+    """
+
+    out_put = exec_test("raising_test.exs")
+    assert out_put =~ %r/stacktrace:/
+  after
+    File.rm("raising_test.exs")
+  end
+
+  test :hide_stacktrace_when_raising_at_assertion do
+    File.write "failure_test.exs", """
+    ExUnit.start
+    defmodule FailureTest do
+      use ExUnit.Case
+      ExUnit.configure formatter: ExUnit.CLIFormatter
+
+      test :fail do
+        assert false
+      end
+    end
+    """
+
+    out_put = exec_test("failure_test.exs")
+    assert out_put =~ %r/at\ #{File.expand_path("failure_test.exs")}:7/
+  after
+    File.rm("failure_test.exs")
+  end
+end


### PR DESCRIPTION
The default formatter of ex_unit should not prints unneeded stacktraces.

The formatter prints stacktraces when tests fail.
And, Most of the stacktraces show inside of ex_unit module.
They are same all the time when test fail at assertions, in most cases, they are not needed.
So I modified the formatter to prints the filename and line number instead of the stacktrace when tests fails at assertion.

sample_test.exs

```
$ cat simple_test.exs
ExUnit.start
defmodule SampleTest do
  use ExUnit.Case

  test :fail do
    assert false
  end
end
```

before

```
$ elixir simple_test.exs
F

1) test_fail (SampleTest)
  ** (ExUnit.AssertionError) Expected false to be true
  stacktrace:
    /Users/yuki_ito/simple_test.exs:6: SampleTest.test_fail/0
    /Users/yuki_ito/.exenv/versions/master/lib/ex_unit/lib/ex_unit/runner.ex:85: ExUnit.Runner.run_test/5
    lists.erl:1262: :lists.foreach/2
    /Users/yuki_ito/.exenv/versions/master/lib/elixir/lib/enum.ex:271: Enum.each/2
    /Users/yuki_ito/.exenv/versions/master/lib/ex_unit/lib/ex_unit/runner.ex:71: ExUnit.Runner.run_tests/3

1 tests, 1 failures.
```

after

```
$ elixir simple_test.exs
F

1) test_fail (SampleTest)
  ** (ExUnit.AssertionError) Expected false to be true
     at /Users/yuki_ito/simple_test.exs:6

1 tests, 1 failures.
```
