### PR TITLE
Fix some String.Unicord functions behavior.

### DIFF
--- a/lib/elixir/priv/unicode.ex
+++ b/lib/elixir/priv/unicode.ex
@@ -87,7 +87,7 @@ defmodule String.Unicode do
 
   def rstrip(""), do: ""
 
-  def rstrip(string) do
+  def rstrip(string) when is_binary(string) do
     do_rstrip(string, "")
   end
 


### PR DESCRIPTION
1.　String.Unicode.lstrip raise error when an argument is not binary.

```
#before
iex(1)> String.lstrip 'a'
'a'

#after
iex(1)> String.lstrip 'a'
** (FunctionClauseError) no function clause matching: String.Unicode.lstrip('a')
    /Users/yuki_ito/.exenv/versions/master/lib/elixir/priv/unicode.ex:78: String.Unicode.lstrip('a')
    erl_eval.erl:572: :erl_eval.do_apply/6
    src/elixir.erl:127: :elixir.eval_forms/3
    /Users/yuki_ito/.exenv/versions/master/lib/iex/lib/iex/server.ex:19: IEx.Server.do_loop/1
```

2.　String.Unicode.rstrip raise error at there when an argument is not binary.

```
#before
iex(1)> String.rstrip 'a'
** (FunctionClauseError) no function clause matching: String.Unicode.rstrip('a')
    /Users/yuki_ito/.exenv/versions/master/lib/elixir/priv/unicode.ex:88: String.Unicode.rstrip('a')
    erl_eval.erl:572: :erl_eval.do_apply/6
    src/elixir.erl:127: :elixir.eval_forms/3
    /Users/yuki_ito/.exenv/versions/master/lib/iex/lib/iex/server.ex:19: IEx.Server.do_loop/1

#after
iex(1)> String.rstrip 'a'
** (FunctionClauseError) no function clause matching: String.Unicode.do_rstrip('a', "")
    /Users/yuki_ito/.exenv/versions/master/lib/elixir/priv/unicode.ex:97: String.Unicode.do_rstrip('a', "")
    erl_eval.erl:572: :erl_eval.do_apply/6
    src/elixir.erl:127: :elixir.eval_forms/3
    /Users/yuki_ito/.exenv/versions/master/lib/iex/lib/iex/server.ex:19: IEx.Server.do_loop/1
```
