### PR TITLE
add octal and hex escapes for characters

### DIFF
--- a/lib/elixir/include/elixir.hrl
+++ b/lib/elixir/include/elixir.hrl
@@ -34,3 +34,17 @@
   marker=quoted,
   unquote=true
 }).
+
+%% used in tokinization and interpolation
+
+-define(is_digit(S), S >= $0 andalso S =< $9).
+-define(is_hex(S), ?is_digit(S) orelse (S >= $A andalso S =< $F) orelse (S >= $a andalso S =< $f)).
+-define(is_bin(S), S >= $0 andalso S =< $1).
+-define(is_octal(S), S >= $0 andalso S =< $7).
+-define(is_leading_octal(S), S >= $0 andalso S =< $3).
+-define(is_upcase(S), S >= $A andalso S =< $Z).
+-define(is_downcase(S), S >= $a andalso S =< $z).
+-define(is_word(S), ?is_digit(S) orelse ?is_upcase(S) orelse ?is_downcase(S)).
+-define(is_quote(S), S == $" orelse S == $').
+-define(is_space(S), S == $\s; S == $\r; S == $\t; S == $\n).
+

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -10,16 +10,6 @@
   existing_atoms_only=false
 }).
 
--define(is_digit(S), S >= $0 andalso S =< $9).
--define(is_hex(S), ?is_digit(S) orelse (S >= $A andalso S =< $F) orelse (S >= $a andalso S =< $f)).
--define(is_bin(S), S >= $0 andalso S =< $1).
--define(is_octal(S), S >= $0 andalso S =< $7).
--define(is_upcase(S), S >= $A andalso S =< $Z).
--define(is_downcase(S), S >= $a andalso S =< $z).
--define(is_word(S), ?is_digit(S) orelse ?is_upcase(S) orelse ?is_downcase(S)).
--define(is_quote(S), S == $" orelse S == $').
--define(is_space(S), S == $\s; S == $\r; S == $\t; S == $\n).
-
 -define(container2(T1, T2),
   T1 == ${, T2 == $};
   T1 == $[, T2 == $]
@@ -162,24 +152,48 @@ tokenize([$%,S,H|T], Line, #scope{file=File} = Scope, Tokens) when not(?is_word(
 
 % Char tokens
 
-tokenize([$?,$\\,C,H1,H2|T], Line, Scope, Tokens) when (C == $x orelse C == $X), ?is_hex(H1), ?is_hex(H2) ->
-  Char = list_to_integer([H1, H2], 16),
+tokenize([$?,$\\,P,${,A,B,C,D,E,F,$}|T], Line, Scope, Tokens) when (P == $x orelse P == $X), ?is_hex(A), ?is_hex(B), ?is_hex(C), ?is_hex(D), ?is_hex(E), ?is_hex(F) ->
+  [Char] = unicode:characters_to_list(elixir_interpolation:unescape_chars(list_to_binary([$\\,P,${,A,B,C,D,E,F,$}|T]))),
   tokenize(T, Line, Scope, [{ number, Line, Char }|Tokens]);
 
-tokenize([$?,$\\,C,H|T], Line, Scope, Tokens) when (C == $x orelse C == $X), ?is_hex(H) ->
-  Char = list_to_integer([H], 16),
+tokenize([$?,$\\,P,${,A,B,C,D,E,$}|T], Line, Scope, Tokens) when (P == $x orelse P == $X), ?is_hex(A), ?is_hex(B), ?is_hex(C), ?is_hex(D), ?is_hex(E) ->
+  [Char] = unicode:characters_to_list(elixir_interpolation:unescape_chars(list_to_binary([$\\,P,${,A,B,C,D,E,$}|T]))),
   tokenize(T, Line, Scope, [{ number, Line, Char }|Tokens]);
 
-tokenize([$?,$\\,C,O1,O2,O3|T], Line, Scope, Tokens) when (C == $o orelse C == $O), ?is_octal(O1), O1 =< $3, ?is_octal(O2), ?is_octal(O3) ->
-  Char = list_to_integer([O1, O2, O3], 8),
+tokenize([$?,$\\,P,${,A,B,C,D,$}|T], Line, Scope, Tokens) when (P == $x orelse P == $X), ?is_hex(A), ?is_hex(B), ?is_hex(C), ?is_hex(D) ->
+  [Char] = unicode:characters_to_list(elixir_interpolation:unescape_chars(list_to_binary([$\\,P,${,A,B,C,D,$}|T]))),
   tokenize(T, Line, Scope, [{ number, Line, Char }|Tokens]);
 
-tokenize([$?,$\\,C,O1,O2|T], Line, Scope, Tokens) when (C == $o orelse C == $O), ?is_octal(O1), ?is_octal(O2) ->
-  Char = list_to_integer([O1, O2], 8),
+tokenize([$?,$\\,P,${,A,B,C,$}|T], Line, Scope, Tokens) when (P == $x orelse P == $X), ?is_hex(A), ?is_hex(B), ?is_hex(C) ->
+  [Char] = unicode:characters_to_list(elixir_interpolation:unescape_chars(list_to_binary([$\\,P,${,A,B,C,$}|T]))),
   tokenize(T, Line, Scope, [{ number, Line, Char }|Tokens]);
 
-tokenize([$?,$\\,C,O|T], Line, Scope, Tokens) when (C == $o orelse C == $O), ?is_octal(O) ->
-  Char = list_to_integer([O], 8),
+tokenize([$?,$\\,P,${,A,B,$}|T], Line, Scope, Tokens) when (P == $x orelse P == $X), ?is_hex(A), ?is_hex(B) ->
+  [Char] = unicode:characters_to_list(elixir_interpolation:unescape_chars(list_to_binary([$\\,P,${,A,B,$}|T]))),
+  tokenize(T, Line, Scope, [{ number, Line, Char }|Tokens]);
+
+tokenize([$?,$\\,P,${,A,$}|T], Line, Scope, Tokens) when (P == $x orelse P == $X), ?is_hex(A) ->
+  [Char] = unicode:characters_to_list(elixir_interpolation:unescape_chars(list_to_binary([$\\,P,${,A,$}|T]))),
+  tokenize(T, Line, Scope, [{ number, Line, Char }|Tokens]);
+
+tokenize([$?,$\\,P,A,B|T], Line, Scope, Tokens) when (P == $x orelse P == $X), ?is_hex(A), ?is_hex(B) ->
+  [Char] = unicode:characters_to_list(elixir_interpolation:unescape_chars(list_to_binary([$\\,P,A,B|T]))),
+  tokenize(T, Line, Scope, [{ number, Line, Char }|Tokens]);
+
+tokenize([$?,$\\,P,A|T], Line, Scope, Tokens) when (P == $x orelse P == $X), ?is_hex(A) ->
+  [Char] = unicode:characters_to_list(elixir_interpolation:unescape_chars(list_to_binary([$\\,P,A|T]))),
+  tokenize(T, Line, Scope, [{ number, Line, Char }|Tokens]);
+
+tokenize([$?,$\\,P,A,B,C|T], Line, Scope, Tokens) when (P == $o orelse P == $O), ?is_octal(A), A =< $3,?is_octal(B), ?is_octal(C) ->
+  [Char] = unicode:characters_to_list(elixir_interpolation:unescape_chars(list_to_binary([$\\,P,A,B,C|T]))),
+  tokenize(T, Line, Scope, [{ number, Line, Char }|Tokens]);
+
+tokenize([$?,$\\,P,A,B|T], Line, Scope, Tokens) when (P == $o orelse P == $O), ?is_octal(A), ?is_octal(B) ->
+  [Char] = unicode:characters_to_list(elixir_interpolation:unescape_chars(list_to_binary([$\\,P,A,B|T]))),
+  tokenize(T, Line, Scope, [{ number, Line, Char }|Tokens]);
+
+tokenize([$?,$\\,P,A|T], Line, Scope, Tokens) when (P == $o orelse P == $O), ?is_octal(A) ->
+  [Char] = unicode:characters_to_list(elixir_interpolation:unescape_chars(list_to_binary([$\\,P,A|T]))),
   tokenize(T, Line, Scope, [{ number, Line, Char }|Tokens]);
 
 tokenize([$?,$\\,H|T], Line, Scope, Tokens) ->

--- a/lib/elixir/test/elixir/binary_test.exs
+++ b/lib/elixir/test/elixir/binary_test.exs
@@ -47,16 +47,24 @@ bar
   end
 
   test :octals do
-    assert "\123" == "S"
-    assert "\128" == "\n8"
-    assert "\18"  == <<1,?8>>
+    assert "\o1" == <<1>>
+    assert "\o12" == "\n"
+    assert "\o123" == "S"
+    assert "\O123" == "S"
+    assert "\o377" == "ÿ"
+    assert "\o128" == "\n8"
+    assert "\o18"  == <<1,?8>>
   end
 
   test :hex do
+    assert "\xa" == "\n"
     assert "\xE9" == "é"
     assert "\xFF" == "ÿ"
     assert "\x{A}"== "\n"
     assert "\x{E9}"== "é"
+    assert "\x{10F}" == <<196,143>>
+    assert "\x{10FF}" == <<225,131,191>>
+    assert "\x{10FFF}" == <<240,144,191,191>>
     assert "\x{10FFFF}" == <<244,143,191,191>>
   end
 

--- a/lib/elixir/test/elixir/char_list_test.exs
+++ b/lib/elixir/test/elixir/char_list_test.exs
@@ -22,8 +22,25 @@ bar '''
   end
 
   test :octals do
-    assert '\123' == 'S'
-    assert '\128' == '\n8'
-    assert '\18' == [1, ?8]
+    assert '\o1' == [1]
+    assert '\o12' == '\n'
+    assert '\o123' == 'S'
+    assert '\O123' == 'S'
+    assert '\o377' == 'ÿ'
+    assert '\o128' == '\n8'
+    assert '\o18' == [1, ?8]
   end
+
+  test :hex do
+    assert '\xa' == '\n'
+    assert '\xE9' == 'é'
+    assert '\xfF' == 'ÿ'
+    assert '\x{A}' == '\n'
+    assert '\x{e9}' == 'é'
+    assert '\x{10F}' == [196,143]
+    assert '\x{10FF}' == [225,131,191]
+    assert '\x{10FFF}' == [240,144,191,191]
+    assert '\x{10FFFF}' == [244,143,191,191]
+  end
+
 end

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -115,12 +115,18 @@ addadd_test() ->
   [{identifier,1,x},{'++',1},{identifier,1,y}] = tokenize("x ++ y").
 
 chars_test() ->
-  [{number,1,97}]  = tokenize("?a"),
-  [{number,1,99}]  = tokenize("?c"),
-  [{number,1,10}]  = tokenize("?\\n"),
-  [{number,1,92}]  = tokenize("?\\\\"),
-  [{number,1,10}]  = tokenize("?\\xa"),
-  [{number,1,26}]  = tokenize("?\\X1a"),
-  [{number,1,6}]   = tokenize("?\\o6"),
-  [{number,1,49}]  = tokenize("?\\O61"),
-  [{number,1,255}] = tokenize("?\\o377").
+  [{number,1,97}]      = tokenize("?a"),
+  [{number,1,99}]      = tokenize("?c"),
+  [{number,1,10}]      = tokenize("?\\n"),
+  [{number,1,92}]      = tokenize("?\\\\"),
+  [{number,1,10}]      = tokenize("?\\xa"),
+  [{number,1,26}]      = tokenize("?\\X1a"),
+  [{number,1,6}]       = tokenize("?\\o6"),
+  [{number,1,49}]      = tokenize("?\\O61"),
+  [{number,1,255}]     = tokenize("?\\o377"),
+  [{number,1,10}]      = tokenize("?\\x{a}"),
+  [{number,1,171}]     = tokenize("?\\x{ab}"),
+  [{number,1,2748}]    = tokenize("?\\x{abc}"),
+  [{number,1,43981}]   = tokenize("?\\x{abcd}"),
+  [{number,1,703710}]  = tokenize("?\\x{abcde}"),
+  [{number,1,1092557}] = tokenize("?\\x{10abcd}").


### PR DESCRIPTION
This implements the suggestion in issue 726.

Hex escapes can have 1 or 2 digits and the x can be upper or lower case.  Examples:

```
?\xA
?\X1b
```

Octal escapes can have 1, 2, or 3 digits and the o can be upper or lower case.  In addition, for 3 digit octal numbers, the first one must be =< 3.  Examples:

```
?\o1
?\O21
?\o377
```
