### PR TITLE
mix escriptize: Support escript_path to specify the path on disk to write the escript to.

### DIFF
--- a/lib/mix/lib/mix/tasks/escriptize.ex
+++ b/lib/mix/lib/mix/tasks/escriptize.ex
@@ -12,6 +12,9 @@ defmodule Mix.Tasks.Escriptize do
   * `escript_name` - the name of the generated escript
      Defaults to project name
 
+  * `escript_path` - the path to write the escript to
+     Defaults to project name
+
   * `escript_main_module` - the module containing the main/1 function.
      Defaults to `Project`
 
@@ -42,7 +45,7 @@ defmodule Mix.Tasks.Escriptize do
 
   defp escriptize(project) do
     script_name  = project[:escript_name] || project[:app]
-    filename     = atom_to_binary(script_name)
+    filename     = project[:escript_path] || atom_to_binary(script_name)
     compile_path = project[:compile_path] || "ebin"
 
     files = gen_main(script_name, project[:escript_main_module])
@@ -64,7 +67,10 @@ defmodule Mix.Tasks.Escriptize do
         shebang  = project[:escript_shebang]  || "#! /usr/bin/env escript\n"
         comment  = project[:escript_comment]  || "%%\n"
         emu_args = project[:escript_emu_args] || "%%!\n"
+
         script = iolist_to_binary([shebang, comment, emu_args, zip])
+
+        File.mkdir_p!(File.dirname(filename))
         File.write!(filename, script)
       {:error, error} ->
         Mix.shell.error "Error creating escript: #{error}"

--- a/lib/mix/test/fixtures/escripttestwithpath/lib/escripttestwithpath.ex
+++ b/lib/mix/test/fixtures/escripttestwithpath/lib/escripttestwithpath.ex
@@ -1,0 +1,9 @@
+defmodule Escripttestwithpath do
+  def start do
+    :ok = :application.start(:escripttestwithpath)
+  end
+  
+  def main(_args) do
+    IO.puts "TEST_WITH_PATH"
+  end
+end

--- a/lib/mix/test/fixtures/escripttestwithpath/mix.exs
+++ b/lib/mix/test/fixtures/escripttestwithpath/mix.exs
@@ -1,0 +1,11 @@
+defmodule Escripttestwithpath.Mixfile do
+  use Mix.Project
+
+  def project do
+    [ app: :escripttestwithpath,
+      version: "0.0.1",
+      escript_embed_elixir: true,
+      escript_name: :escripttestwithpath,
+      escript_path: File.join("ebin", "escripttestwithpath") ]
+  end
+end

--- a/lib/mix/test/mix/escriptize_test.exs
+++ b/lib/mix/test/mix/escriptize_test.exs
@@ -10,4 +10,12 @@ defmodule Mix.EscriptizeTest do
       assert System.cmd("escript escripttest") == "TEST\n"
     end
   end
+
+  test "generate simple escript with path" do
+    in_fixture "escripttestwithpath", fn ->
+      output = mix "escriptize"
+      assert output =~ %r/Generated escript ebin(\/|\\)escripttestwithpath/
+      assert System.cmd("escript " <> File.join("ebin", "escripttestwithpath")) == "TEST_WITH_PATH\n"
+    end
+  end
 end


### PR DESCRIPTION
Fixes #714.
