### PR TITLE
fix deprication message typo

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -184,7 +184,7 @@ defmodule File do
 
   @doc false
   def wildcard(glob) do
-    IO.puts "Fild.wildcard is deprecated, please use Path.wildcard instead"
+    IO.puts "File.wildcard is deprecated, please use Path.wildcard instead"
     Exception.print_stacktrace
     Path.wildcard(glob)
   end


### PR DESCRIPTION
Fixes a minor typo in the deprecation message, Fild -> File.
