### PR TITLE
WiP for compiling of erlang/leex/yecc source files

### DIFF
--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -134,6 +134,8 @@ defmodule Mix.Project do
       default_task: "compile",
       deps_path: "deps",
       erlc_paths: ["src"],
+      erlc_include_path: "include",
+      erlc_options: [:debug_info],
       lockfile: "mix.lock",
       prepare_task: "app.start",
       elixirc_paths: ["lib"],

--- a/lib/mix/lib/mix/tasks/clean.ex
+++ b/lib/mix/lib/mix/tasks/clean.ex
@@ -14,6 +14,11 @@ defmodule Mix.Tasks.Clean do
   def run(args) do
     { opts, _ } = OptionParser.parse(args)
     File.rm_rf Mix.project[:compile_path]  || "ebin"
+
+    generated_source = lc source_path inlist Mix.project[:erlc_paths] do
+                         Mix.Utils.check_files(source_path, [:yrl, :xrl], source_path, :erl)
+                       end |> List.flatten
+    lc {_, output} inlist generated_source, do: File.rm_rf output
     if opts[:all], do: Mix.Task.run("deps.clean")
   end
 end

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -1,4 +1,11 @@
 defmodule Mix.Tasks.Compile.Erlang do
+
+  alias :epp, as: Epp
+  alias :digraph, as: Graph
+  alias :digraph_utils, as: GraphUtils
+  alias :code, as: Code
+  alias :compile, as: Compiler
+  alias Mix.Utils
   use Mix.Task
 
   @hidden true
@@ -7,57 +14,175 @@ defmodule Mix.Tasks.Compile.Erlang do
   @moduledoc """
   A task to compile Erlang source files.
 
+  When this task runs, it will first check the mod times of
+  all of the files. Every file will checked, if file or
+  file dependencies, like include files, was changed.
+  If file of his dependencies haven't been changed since the
+  last compilation, it will not compile. If file or one of his
+  dependency has changed, it will compile.
+
+  For this reason, this task touches your `:compile_path`
+  directory and sets the modification time to the current
+  time and date at the end of each compilation. You can
+  force compilation regardless of mod times by passing
+  the `--force` option.
+
   ## Command line options
+
+  * `--force` - forces compilation regardless of module times;
+
+  ## Configuration
 
   * `ERL_COMPILER_OPTIONS` - can be used to give default compile options.
      It's value must be a valid Erlang term. If the value is a list, it will
      be used as is. If it is not a list, it will be put into a list.
 
-  ## Configuration
+  * `:erlc_paths` - directories to find source files.
+    Defaults to `["src"]`, can be configured as:
 
-  * `:erlc_options` - compilation options that applies to Erlang compiler
-     By default, the following options are on: `[:verbose, :report_errors, :report_warnings]`
+        [erlc_paths: ["src", "other"]]
+
+  * `:erlc_include_path` - directory for adding include files.
+    Defaults to `"include"`, can be configured as:
+
+        [`erlc_include_path`: "other"]
+
+  * `:erlc_options` - compilation options that applies
+     to Erlang's compiler.
+     This options are setted:
+
+     :outdir to a configured :compile_path
+     :i to a configured :include_path
+     :report
+
+     and :debug_info in project configuration
+
+     There are many other available options here:
+     http://www.erlang.org/doc/man/compile.html#file-2
 
   """
-  def run(_) do
-    project = Mix.project
 
-    files        = Mix.Utils.extract_files(project[:erlc_paths], [:erl])
-    compile_path = project[:compile_path]
+  defrecord Erl, file: nil, module: nil, behaviours: [], compile: [],
+    includes: [], mtime: nil, invalid: false
+
+  def run(args) do
+    { opts, _ } = OptionParser.parse(args, switches: [force: :boolean])
+
+    project = Mix.project
+    source_paths = project[:erlc_paths]
+    files        = Mix.Utils.extract_files(source_paths, [:erl])
+    compile_path = to_erl_file project[:compile_path]
+    include_path = to_erl_file project[:erlc_include_path]
+
+    erlc_options = [{:outdir, compile_path}, {:i, include_path}, :report
+                    | project[:erlc_options] || []]
+    erlc_options = Enum.map erlc_options, fn(opt) ->
+      case opt do
+        { :i, dir } -> { :i, to_erl_file(dir) }
+        _           -> opt
+      end
+    end
+
+    files = files |> scan_sources(include_path, source_paths) |> sort_dependency
+    unless opts[:force], do: files = Enum.filter(files, check_file(compile_path, &1))
 
     if files == [] do
       :noop
     else
-      Mix.Utils.preserving_mtime(compile_path, fn ->
+      Utils.preserving_mtime(compile_path, fn ->
         File.mkdir_p! compile_path
-        compile_files project, files, compile_path
+        compile_files files, compile_path, erlc_options
       end)
 
       :ok
     end
   end
 
-  defp compile_files(project, files, compile_path) do
-    erlc_options = project[:erlc_options] || []
+  defp scan_sources(files, include_path, source_paths) do
+    include_pathes = [include_path | source_paths]
+    List.foldl(files, [], fn(file, acc) -> scan_source(acc, file, include_pathes) end) |> Enum.reverse
+  end
 
-    erlc_options = Enum.map erlc_options, fn(opt) ->
-      case opt do
-        { :i, dir } -> { :i, Path.expand(dir) |> binary_to_list }
-        _           -> opt
-      end
-    end
-
-    compile_path = compile_path |> Path.expand |> binary_to_list
-    erlc_options = [{:outdir, compile_path}] ++ erlc_options
-    File.mkdir_p!(compile_path)
-
-    Enum.each files, fn(file) ->
-      file = Path.rootname(file, ".erl") |> Path.expand |> binary_to_list
-
-      case :compile.file(file, erlc_options) do
-        { :ok, _ } -> Mix.shell.info  "Compiled #{file}.erl"
-        :error     -> Mix.shell.error "== Compilation error on file #{file}.erl =="
-      end
+  defp scan_source(acc, file, include_pathes) do
+    erl_file = Erl[mtime: Utils.last_modified(file),
+                   file: file,
+                   module: Path.basename(file, ".erl")]
+    case Epp.parse_file(to_erl_file(file), include_pathes, []) do
+      {:ok, forms} ->
+        [List.foldl(tl(forms), erl_file, fn(f, acc) -> do_form(file, f, acc) end) | acc]
+      {:error, _error} ->
+        acc
     end
   end
+
+  defp do_form(file, form, erl) do
+    case form do
+      {:attribute, _, :file, {include_file, _}} when file != include_file ->
+        erl.update(includes: [include_file | erl.includes])
+      {:attribute, _, :behaviour, behaviour} ->
+        erl.update(behaviour: [behaviour | erl.behaviours])
+      {:attribute, _, :compile, value} ->
+        erl.update(compile: [value | erl.compile])
+      _ ->
+        erl
+    end
+  end
+
+  defp sort_dependency(erls) do
+    graph = Graph.new
+    lc erl inlist erls do
+      Graph.add_vertex(graph, erl.module, erl)
+    end
+    lc erl inlist erls do
+      lc b inlist erl.behaviours, do: Graph.add_edge(graph, b, erl.module)
+      lc a inlist erl.compile do
+        case a do
+          {:parse_transform, transform} -> Graph.add_edge(graph, transform, erl.module);
+          _ -> :ok
+        end
+      end
+    end
+    result =
+      case GraphUtils.topsort(graph) do
+        :false -> erls;
+        mods   ->
+          lc m inlist mods, do: elem(Graph.vertex(graph, m), 1)
+      end
+    Graph.delete(graph)
+    result
+  end
+
+  defp check_file(compile_path, erl) do
+    beam = Path.join(compile_path, "#{erl.module}#{Code.objfile_extension}")
+    case File.regular?(beam) do
+      :false -> :true
+      :true  ->
+        beammtime = Utils.last_modified(beam)
+        (beammtime <= erl.mtime) or Utils.check_mtime(beammtime, erl.includes)
+    end
+  end
+
+  defp compile_files(files, compile_path, erlc_options) do
+    File.mkdir_p!(compile_path)
+    Enum.each files, compile_file(&1, erlc_options)
+  end
+
+  defp compile_file(erl, erlc_options) do
+    file = to_erl_file Path.rootname(erl.file, ".erl")
+    interpret_result file, :compile.file(file, erlc_options), ".erl"
+  end
+
+  def interpret_result(file, result, ext // "") do
+    case result do
+      { :ok, _} ->
+        Mix.shell.info  "Compiled #{file}#{ext}"
+      :error     ->
+        :ok
+    end
+  end
+
+  def to_erl_file file do
+    to_char_list(file)
+  end
+
 end

--- a/lib/mix/lib/mix/tasks/compile.ex
+++ b/lib/mix/lib/mix/tasks/compile.ex
@@ -80,9 +80,9 @@ defmodule Mix.Tasks.Compile do
 
   defp get_compilers do
     Mix.project[:compilers] || if Mix.Project.get do
-      [:erlang, :elixir, :app]
+      [:yecc, :leex, :erlang, :elixir, :app]
     else
-      [:erlang, :elixir]
+      [:yecc, :leex, :erlang, :elixir]
     end
   end
 

--- a/lib/mix/lib/mix/tasks/compile.leex.ex
+++ b/lib/mix/lib/mix/tasks/compile.leex.ex
@@ -1,0 +1,79 @@
+defmodule Mix.Tasks.Compile.Leex do
+
+  alias :compile, as: Compiler
+  alias :leex, as: Leex
+  alias Mix.Utils
+  alias Mix.Tasks.Compile.Erlang
+  use Mix.Task
+
+  @hidden true
+  @shortdoc "Compile Leex source files"
+
+  @moduledoc """
+  A task to compile Leex source files.
+
+  When this task runs, it will check the mod time of every file, and
+  if it has changed, then file will be compiled. Files will be
+  compiled in the same source directory with .erl extension.
+  You can force compilation regardless of mod times by passing
+  the `--force` option.
+
+  ## Command line options
+
+  * `--force` - forces compilation regardless of module times;
+
+  ## Configuration
+
+  * `:erlc_paths` - directories to find source files.
+    Defaults to `["src"]`, can be configured as:
+
+        [erlc_paths: ["src", "other"]]
+
+  * `:leex_options` - compilation options that applies
+     to Leex's compiler.
+     This options are setted:
+
+     :scannerfile
+     {:report, true}
+
+     There are many other available options here:
+     http://www.erlang.org/doc/man/leex.html#file-2
+
+  """
+
+  def run(args) do
+    { opts, _ } = OptionParser.parse(args, switches: [force: :boolean])
+
+    project = Mix.project
+    source_paths = project[:erlc_paths]
+
+    checkfun = if opts[:force] do
+        fn(_, _) -> true end
+      else
+        fn(f1, f2) ->
+          mtime = Utils.last_modified(f2)
+          Utils.check_mtime(mtime, [f1])
+        end
+      end
+
+    files = lc source_path inlist source_paths do
+              Utils.check_files(source_path, :xrl, source_path, :erl, checkfun)
+            end |> List.flatten
+    if files == [] do
+      :noop
+    else
+      compile_files(files, project[:leex_options] || [])
+      :ok
+    end
+  end
+
+  def compile_files(files, options) do
+    lc {input, output} inlist files do
+      Erlang.interpret_result(input, Leex.file(Erlang.to_erl_file(input),
+                                               [{:scannerfile, Erlang.to_erl_file(output)},
+                                                {:report, true} | options]))
+    end
+  end
+
+end
+

--- a/lib/mix/lib/mix/tasks/compile.yecc.ex
+++ b/lib/mix/lib/mix/tasks/compile.yecc.ex
@@ -1,0 +1,78 @@
+defmodule Mix.Tasks.Compile.Yecc do
+
+  alias :compile, as: Compiler
+  alias :yecc, as: Yecc
+  alias Mix.Utils
+  alias Mix.Tasks.Compile.Erlang
+  use Mix.Task
+
+  @hidden true
+  @shortdoc "Compile Yecc source files"
+
+  @moduledoc """
+  A task to compile Yecc source files.
+
+  When this task runs, it will check the mod time of every file, and
+  if it has changed, then file will be compiled. Files will be
+  compiled in the same source directory with .erl extension.
+  You can force compilation regardless of mod times by passing
+  the `--force` option.
+
+  ## Command line options
+
+  * `--force` - forces compilation regardless of module times;
+
+  ## Configuration
+
+  * `:erlc_paths` - directories to find source files.
+    Defaults to `["src"]`, can be configured as:
+
+        [erlc_paths: ["src", "other"]]
+
+  * `:yecc_options` - compilation options that applies
+     to Yecc's compiler.
+     This options are setted:
+
+     {:scannerfile, file}
+     {:report, true}
+
+     There are many other available options here:
+     http://www.erlang.org/doc/man/yecc.html#file-1
+
+  """
+
+  def run(args) do
+    { opts, _ } = OptionParser.parse(args, switches: [force: :boolean])
+
+    project = Mix.project
+    source_paths = project[:erlc_paths]
+
+    checkfun = if opts[:force] do
+        fn(_, _) -> true end
+      else
+        fn(f1, f2) ->
+          mtime = Utils.last_modified(f2)
+          Utils.check_mtime(mtime, [f1])
+        end
+      end
+
+    files = lc source_path inlist source_paths do
+              Utils.check_files(source_path, :yrl, source_path, :erl, checkfun)
+            end |> List.flatten
+    if files == [] do
+      :noop
+    else
+      compile_files(files, project[:yecc_options] || [])
+      :ok
+    end
+  end
+
+  def compile_files(files, options) do
+    lc {input, output} inlist files do
+      Erlang.interpret_result(input, Yecc.file(Erlang.to_erl_file(input),
+                                               [{:parserfile, Erlang.to_erl_file(output)},
+                                                {:report, true} | options]))
+    end
+  end
+
+end

--- a/lib/mix/test/fixtures/compile_leex/mix.exs
+++ b/lib/mix/test/fixtures/compile_leex/mix.exs
@@ -1,0 +1,11 @@
+defmodule MyProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :my_project,
+      version: "0.1.0",
+      compilers: [:leex],
+    ]
+  end
+end

--- a/lib/mix/test/fixtures/compile_leex/src/test_fail.xrl
+++ b/lib/mix/test/fixtures/compile_leex/src/test_fail.xrl
@@ -1,0 +1,21 @@
+Definitions.
+
+Add         = (\+|-)
+Mul         = (\*|//|/|%)
+
+Number      = [0-9]
+
+Rules.
+
+{Add}                    : make_token(add_op,  TokenLine, TokenChars).
+{Mul}                    : make_token(mul_op,  TokenLine, TokenChars).
+
+{Number}+                : make_token(integer, TokenLine, TokenChars, fun erlang:list_to_integer/1).
+
+make_token(Name, Line, Chars) when is_list(Chars) ->
+    {token, {Name, Line, list_to_atom(Chars)}};
+make_token(Name, Line, Chars) ->
+    {token, {Name, Line, Chars}}.
+
+make_token(Name, Line, Chars, Fun) ->
+    {token, {Name, Line, Fun(Chars)}}.

--- a/lib/mix/test/fixtures/compile_leex/src/test_ok.xrl
+++ b/lib/mix/test/fixtures/compile_leex/src/test_ok.xrl
@@ -1,0 +1,27 @@
+Definitions.
+
+Add         = (\+|-)
+
+Number      = [0-9]
+
+Rules.
+
+{Add}                    : make_token(add_op,  TokenLine, TokenChars).
+
+{Number}+                : make_token(integer, TokenLine, TokenChars, fun erlang:list_to_integer/1).
+
+Erlang code.
+
+make_token(Name, Line, Chars) when is_list(Chars) ->
+    {token, {Name, Line, list_to_atom(Chars)}};
+make_token(Name, Line, Chars) ->
+    {token, {Name, Line, Chars}}.
+
+make_token(Name, Line, Chars, Fun) ->
+    {token, {Name, Line, Fun(Chars)}}.
+
+endls(Chars) ->
+    lists:filter(fun (C) -> C == $\n orelse C == $; end, Chars).
+
+is_reserved("if")      -> true;
+is_reserved(_)         -> false.

--- a/lib/mix/test/fixtures/compile_yecc/mix.exs
+++ b/lib/mix/test/fixtures/compile_yecc/mix.exs
@@ -1,0 +1,11 @@
+defmodule MyProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :my_project,
+      version: "0.1.0",
+      compilers: [:yecc],
+    ]
+  end
+end

--- a/lib/mix/test/fixtures/compile_yecc/src/test.yrl
+++ b/lib/mix/test/fixtures/compile_yecc/src/test.yrl
@@ -1,0 +1,11 @@
+Nonterminals
+  grammar expr_list
+  expr paren_expr block_expr fn_expr bracket_expr call_expr bracket_at_expr max_expr
+  .
+
+Terminals
+  'not' 'and' 'or' 'xor' 'when' 'in' 'inlist' 'inbits' 'do'
+  .
+
+Rootsymbol
+    Elements.

--- a/lib/mix/test/fixtures/compile_yecc/src/test_ok.yrl
+++ b/lib/mix/test/fixtures/compile_yecc/src/test_ok.yrl
@@ -1,0 +1,36 @@
+Nonterminals
+    Elements
+    Value
+    IfBlock
+    IfBraced
+    IfExpression
+    ElseBraced
+    EndIfBraced.
+
+Terminals
+    close_tag
+    endif_keyword
+    if_keyword
+    else_keyword
+    open_tag
+    not_keyword
+    text.
+
+Rootsymbol
+    Elements.
+
+Value -> '$empty' : [].
+
+Elements -> '$empty' : [].
+Elements -> Elements text : '$1' ++ ['$2'].
+Elements -> Elements IfBlock : '$1' ++ ['$2'].
+
+IfBlock -> IfBraced Elements ElseBraced Elements EndIfBraced : {ifelse, '$1', '$2', '$4'}.
+IfBlock -> IfBraced Elements EndIfBraced : {'if', '$1', '$2'}.
+
+IfBraced -> open_tag if_keyword IfExpression close_tag : '$3'.
+IfExpression -> not_keyword IfExpression : {'not', '$2'}.
+IfExpression -> Value : '$1'.
+
+ElseBraced -> open_tag else_keyword close_tag.
+EndIfBraced -> open_tag endif_keyword close_tag.

--- a/lib/mix/test/mix/tasks/compile.erlang_test.exs
+++ b/lib/mix/test/mix/tasks/compile.erlang_test.exs
@@ -3,12 +3,11 @@ Code.require_file "../../../test_helper.exs", __FILE__
 defmodule Mix.Tasks.Compile.ErlangTest do
   use MixTest.Case
 
-
   test "tries to compile src/a.erl" do
     in_fixture "compile_erlang", fn ->
       output = mix "compile"
 
-      assert output =~ %r"Compilation error on file /.+a\.erl"
+      assert output =~ %r"src/a.erl.+syntax error"
     end
   end
 
@@ -16,11 +15,25 @@ defmodule Mix.Tasks.Compile.ErlangTest do
     in_fixture "compile_erlang", fn ->
       output = mix "compile"
 
-      assert output =~ %r"Compiled /.+b\.erl"
-      assert output =~ %r"Compiled /.+c\.erl"
+      assert output =~ %r"Compiled .+c\.erl"
+      assert output =~ %r"Compiled .+b\.erl"
 
       assert File.regular?("ebin/b.beam")
       assert File.regular?("ebin/c.beam")
     end
   end
+
+  test "compiles with --force src/b.erl and src/c.erl" do
+    in_fixture "compile_erlang", fn ->
+      mix "compile"
+      output = mix "compile --force"
+
+      assert output =~ %r"Compiled .+c\.erl"
+      assert output =~ %r"Compiled .+b\.erl"
+
+      assert File.regular?("ebin/b.beam")
+      assert File.regular?("ebin/c.beam")
+    end
+  end
+
 end

--- a/lib/mix/test/mix/tasks/compile.leex_test.exs
+++ b/lib/mix/test/mix/tasks/compile.leex_test.exs
@@ -1,0 +1,34 @@
+Code.require_file "../../../test_helper.exs", __FILE__
+
+defmodule Mix.Tasks.Compile.LeexTest do
+  use MixTest.Case
+
+  test "tries to compile src/test_fail.xrl" do
+    in_fixture "compile_leex", fn ->
+      output = mix "compile"
+
+      assert output =~ %r"src/test_fail.xrl.+bad rule"
+
+    end
+  end
+
+  test "compiles src/test_ok.xrl" do
+    in_fixture "compile_leex", fn ->
+      output = mix "compile"
+
+      assert output =~ %r"Compiled .+test_ok\.xrl"
+      assert File.regular?("src/test_ok.erl")
+    end
+  end
+
+  test "compiles with --force src/test_ok.xrl" do
+    in_fixture "compile_leex", fn ->
+      mix "compile"
+      output = mix "compile --force"
+
+      assert output =~ %r"Compiled .+test_ok\.xrl"
+      assert File.regular?("src/test_ok.erl")
+    end
+  end
+
+end

--- a/lib/mix/test/mix/tasks/compile.yecc_test.exs
+++ b/lib/mix/test/mix/tasks/compile.yecc_test.exs
@@ -1,0 +1,34 @@
+Code.require_file "../../../test_helper.exs", __FILE__
+
+defmodule Mix.Tasks.Compile.YeccTest do
+  use MixTest.Case
+
+  test "tries to compile src/test_fail.yrl" do
+    in_fixture "compile_yecc", fn ->
+      output = mix "compile"
+
+      assert output =~ %r"src/test.yrl.+grammar rules are missing"
+
+    end
+  end
+
+  test "compiles src/test_ok.yrl" do
+    in_fixture "compile_yecc", fn ->
+      output = mix "compile"
+
+      assert output =~ %r"Compiled .+test_ok\.yrl"
+      assert File.regular?("src/test_ok.erl")
+    end
+  end
+
+  test "compiles with --force src/test_ok.yrl" do
+    in_fixture "compile_yecc", fn ->
+      mix "compile"
+      output = mix "compile --force"
+
+      assert output =~ %r"Compiled .+test_ok\.yrl"
+      assert File.regular?("src/test_ok.erl")
+    end
+  end
+
+end

--- a/lib/mix/test/mix/tasks/compile_test.exs
+++ b/lib/mix/test/mix/tasks/compile_test.exs
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.CompileTest do
   test "mix compile --list without mixfile" do
     in_fixture "no_mixfile", fn ->
       Mix.Tasks.Compile.run ["--list"]
-      assert_received { :mix_shell, :info, ["\nEnabled compilers: erlang, elixir"] }
+      assert_received { :mix_shell, :info, ["\nEnabled compilers: yecc, leex, erlang, elixir"] }
     end
   end
 
@@ -25,7 +25,7 @@ defmodule Mix.Tasks.CompileTest do
   test "mix compile --list with mixfile" do
     Mix.Project.push CustomApp
     Mix.Tasks.Compile.run ["--list"]
-    assert_received { :mix_shell, :info, ["\nEnabled compilers: erlang, elixir, app"] }
+    assert_received { :mix_shell, :info, ["\nEnabled compilers: yecc, leex, erlang, elixir, app"] }
     assert_received { :mix_shell, :info, ["mix compile.elixir # " <> _] }
   after
     Mix.Project.pop


### PR DESCRIPTION
This is (WiP)work in progress, but I would like to get a feedback and review, how one or other thing better to do. Because this is my second or third pull request, and first "not a simple bug fix" commit to a big open source project.

This change has:
- checking of erlang source file and dependencies(like .hrl files) for changes before compiling
- error and warning output messages by erlang compiling(if you have an error, you will see, which one in a readable way) with relative path to your project
- compiling of leex and yecc files too(with error and warning output too)

This comment has some code duplication, that I personaly don't like. And I want to remove it in a beautifull and understandable way(like in leex, yecc compilers, that do the same work with two changes). May be move code in Mix.Tasks.Compile with this arguments and simply call from leex and yecc compile tasks a generic task?

This commit doesn't have:
1) there are some code duplication, that I want to eliminate in a beautiful way, and may be I have rewritten some existing functionality?

I will be very happy for review and feedback!
