### PR TITLE
Implement integer -> size(integer) syntax shortcut for bitsyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 * enhancements
   * [Binary] Support `<< "string" :: utf8 >>` as in Erlang
   * [Binary] Support `\a` escape character in binaries
+  * [Binary] Support syntax shortcut for specifying size in bit syntax
   * [CLI] Support `--app` option to start an application and its dependencies
   * [Dict] Support `put_new` in `Dict` and `Keyword`
   * [Dict] Add `List.Dict` and a faster `HashDict` implementation

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -154,6 +154,12 @@ defmodule Kernel.SpecialForms do
   have their size specified explicitly). Bitstrings do not have
   a default size.
 
+  Size can also be specified using a syntax shortcut. Instead of
+  writing `size(8)`, one can write just `8` and it will be interpreted
+  as `size(8)`
+
+      << 1 :: 3 >> == << 1 :: size(3) >> #=> true
+
   The default unit for integers, floats, and bitstrings is 1. For
   binaries, it is 8.
 

--- a/lib/elixir/src/elixir_literal.erl
+++ b/lib/elixir/src/elixir_literal.erl
@@ -171,6 +171,9 @@ extract_bit_values(Meta, [{ Value, CallMeta, [_] = Args }|T] = All, Size, Types,
       extract_bit_values(Meta, T, NewSize, NewTypes, S)
   end;
 
+extract_bit_values(Meta, [Size|T], default, Types, S) when is_integer(Size) andalso Size >= 0 ->
+  extract_bit_values(Meta, T, {integer, Meta, Size}, Types, S);
+
 extract_bit_values(Meta, [{ '|', _, [Left, Right] }], Size, Types, S) ->
   Expanded = 'Elixir.Macro':expand(Right, elixir_scope:to_ex_env({ ?line(Meta), S })),
   extract_bit_values(Meta, [Left|join_expansion(Expanded,[])], Size, Types, S);

--- a/lib/elixir/test/elixir/binary_test.exs
+++ b/lib/elixir/test/elixir/binary_test.exs
@@ -107,6 +107,11 @@ bar
        sec_data :: binary >>
   end
 
+  test :bitsyntax_size_shorcut do
+    assert << 1 :: 3 >> == << 1 :: size(3) >>
+    assert << 1 :: [unit(8), 3] >> == << 1 :: [unit(8), size(3)] >>
+  end
+
   defmacrop signed_16 do
     quote do
       [big, signed, integer, unit(16)]


### PR DESCRIPTION
Closes #795
