### PR TITLE
Change references or invocations of Process.self to Kernel.self

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -69,7 +69,7 @@ defmodule Kernel do
 
   ## Examples
 
-      process = Process.self
+      process = Kernel.self
       process <- { :ok, "Sending myself a message" }
 
   """
@@ -1023,8 +1023,8 @@ defmodule Kernel do
 
   ## Examples
 
-      current = Process.self
-      child   = spawn(fn -> current <- { Process.self, 1 + 2 } end)
+      current = Kernel.self
+      child   = spawn(fn -> current <- { Kernel.self, 1 + 2 } end)
 
       receive
         { ^child, 3 } -> IO.puts "Received 3 back"
@@ -1061,8 +1061,8 @@ defmodule Kernel do
 
   ## Examples
 
-      current = Process.self
-      child   = spawn_link(fn -> current <- { Process.self, 1 + 2 } end)
+      current = Kernel.self
+      child   = spawn_link(fn -> current <- { Kernel.self, 1 + 2 } end)
 
       receive
         { ^child, 3 } ->

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -116,7 +116,7 @@ defmodule ProtocolTest do
     assert_protocol_for(ProtocolTest.WithAll, Tuple, {Bar,2,3})
     assert_protocol_for(ProtocolTest.WithAll, BitString, "foo")
     assert_protocol_for(ProtocolTest.WithAll, BitString, <<1>>)
-    assert_protocol_for(ProtocolTest.WithAll, PID, Process.self)
+    assert_protocol_for(ProtocolTest.WithAll, PID, Kernel.self)
     assert_protocol_for(ProtocolTest.WithAll, Port, hd(:erlang.ports))
     assert_protocol_for(ProtocolTest.WithAll, Reference, make_ref)
   end


### PR DESCRIPTION
I noticed some comments in kernel.ex still referred to Process.self and one of the unit tests, in protocol_test.exs, still invoked Process.self.
