### PR TITLE
Tiny typo in IEx.Helpers.h/1

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -190,7 +190,7 @@ defmodule IEx.Helpers do
       if doc do
         IO.write "\n" <> print_signature(doc)
       else
-        IO.puts "No docs for #{inspect module}#.{function}/#{arity} have been found"
+        IO.puts "No docs for #{inspect module}.#{function}/#{arity} have been found"
       end
     else
       IO.puts "#{inspect module} was not compiled with docs"


### PR DESCRIPTION
The typo leads to output like this:

```
iex(1)> h(Enum.map/3)
No docs for Enum#.{function}/3 have been found
:ok
```
