### PR TITLE
correct apply/3 example

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -316,7 +316,7 @@ defmodule Kernel do
 
   ## Examples
 
-      apply List, reverse, [[1,2,3]]
+      apply Enum, :reverse, [[1,2,3]]
       #=> [3,2,1]
 
   """


### PR DESCRIPTION
The example in the @doc for Kernel.apply is outdated or incorrect; please see commit.
