### PR TITLE
Better assert x = y reporting

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -77,8 +77,15 @@ defmodule ExUnit.Assertions do
     quote do: (var!(op) == :! or var!(op) == :not)
   end
 
-  defp translate_assertion({ :=, _, [_, _] } = expr, _else) do
-    expr
+  defp translate_assertion({ :=, _, [expected, actual] }, _else) do
+    quote do
+      try do
+        unquote(expected) = x = unquote(actual)
+      rescue
+        _ in [MatchError] ->
+          assert(false, unquote(Macro.to_binary expected), unquote(actual), reason: "a match for")
+      end
+    end
   end
 
   defp translate_assertion({ :==, _, [left, right] }, _else) do

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -75,6 +75,15 @@ defmodule ExUnit.AssertionsTest do
     { 2, 1 } = (assert { 2, 1 } = Value.tuple)
   end
 
+  test :assert_match_when_badmatch do
+    try do
+      assert { 3, _ } = Value.tuple
+    rescue
+      error in [ExUnit.ExpectationError] ->
+       %b[Expected "{3, _}" to be a match for {2,1}] = error.message
+    end
+  end
+
   test :assert_receive do
     parent = self
     spawn fn -> parent <- :hello end


### PR DESCRIPTION
Example:

```
   ** (ExUnit.ExpectationError)
                expected: "{1, _}"
       to be a match for: {2,1}
```

Closes #864
