### PR TITLE
Add support for %w and %W (words) sigils with return type modifiers

### DIFF
--- a/lib/elixir/test/elixir/kernel/sigils_test.exs
+++ b/lib/elixir/test/elixir/kernel/sigils_test.exs
@@ -48,4 +48,39 @@ defmodule Kernel.SigilsTest do
     assert %C(f#{o}o) == 'f\#{o}o'
     assert %C(f\no) == 'f\\no'
   end
+
+  test :__w__ do
+    assert %w(foo bar baz) == ["foo", "bar", "baz"]
+    assert %w(foo #{:bar} baz) == ["foo", "bar", "baz"]
+
+    assert %w(
+      foo
+      bar
+      baz
+    ) == ["foo", "bar", "baz"]
+
+    assert %w(foo bar baz)b == ["foo", "bar", "baz"]
+    assert %w(foo bar baz)a == [:foo, :bar, :baz]
+    assert %w(foo bar baz)c == ['foo', 'bar', 'baz']
+
+    bad_modifier = quote do: %w(foo bar baz)x
+    assert ArgumentError[] = catch_error(Code.eval_quoted(bad_modifier))
+  end
+
+  test :__W__ do
+    assert %W(foo #{bar} baz) == ["foo", "\#{bar}", "baz"]
+
+    assert %W(
+      foo
+      bar
+      baz
+    ) == ["foo", "bar", "baz"]
+
+    assert %W(foo bar baz)b == ["foo", "bar", "baz"]
+    assert %W(foo bar baz)a == [:foo, :bar, :baz]
+    assert %W(foo bar baz)c == ['foo', 'bar', 'baz']
+
+    bad_modifier = quote do: %W(foo bar baz)x
+    assert ArgumentError[] = catch_error(Code.eval_quoted(bad_modifier))
+  end
 end


### PR DESCRIPTION
As discussed previously in #501, %w can now return a few core data types other than just binaries (extendible to support further types in the future without breaking backwards compatibility). My enthusiasm for this jumped ten-fold now that I'm writing things that could be written like this:

``` elixir
fields %w(
  contact_id
  contact_guid
  brand_id
  title
  first_name
  middle_name
  last_name
  suffix
  eligibility_mask
  username
  user_password
  dob
  gender
  passport_country
  password_number
)a
```
