### PR TITLE
change comments to match the code

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -795,7 +795,7 @@ defmodule File do
 
   ## Examples
 
-      File.open!("file.txt", [:read, :write], fn(file) ->
+      File.open("file.txt", [:read, :write], fn(file) ->
         IO.readline(file)
       end)
 
@@ -928,7 +928,8 @@ defmodule File do
   quotes per single quotes and write each line to a target file
   is shown below:
 
-      source = File.iterator("README.md")
+      { :ok, device } = File.open("README.md")
+      source = File.iterator(device)
       File.open "NEWREADME.md", [:write], fn(target) ->
         Enum.each source, fn(line) ->
           IO.write target, Regex.replace(%r/"/, line, "'")


### PR DESCRIPTION
The example for the open/3 function called open! instead of open.

For the iterator/1 function, if you pass in a string instead of a device, the return value is
{ :ok, iterator_fn } instead of just iterator_fn, which breaks the example.  Since the comment
talks about converting a device to an iterator, it seemed appropriate to change to comment
to:

```
{ :ok, device } = File.open("README.md")
source = File.iterator(device)
```

instead of changing it to:

```
{ :ok, source } = File.iterator("README.md")
```
