### PR TITLE
Add feature h(Module, "*") to list all functions in a module

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -109,6 +109,12 @@ defmodule IEx.Helpers do
     end
   end
 
+  defmacro h({ { :., _, [mod, :*] }, _, [] }) do
+    quote do
+      h(unquote(mod), "*")
+    end
+  end
+
   defmacro h({ { :., _, [mod, fun] }, _, [] }) do
     quote do
       h(unquote(mod), unquote(fun))


### PR DESCRIPTION
Sometimes I need the documentation on a function, but I don't remember which module it's in. By saying `h(modulename, "*")` I can get a listing of all that module's functions and their arity, and proceed from there.
