### PR TITLE
add integer and float conversion

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -358,6 +358,28 @@ defmodule String do
   end
 
   @doc """
+  Convert a string to an integer.
+
+  ## Examples
+
+      String.to_integer("111") #=> 111
+  """
+  def to_integer(string) do
+    binary_to_integer(string)
+  end
+
+  @doc """
+  Convert a string to a float.
+
+  ## Examples
+
+      String.to_float("1.03") #=> 1.03
+  """
+  def to_float(string) do
+    binary_to_float(string)
+  end
+
+  @doc """
   Returns all codepoints in the string.
 
   ## Examples

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -127,6 +127,18 @@ defmodule StringTest do
     assert String.duplicate("&ã$", 2) == "&ã$&ã$"
   end
 
+  test :to_integer do
+    assert String.to_integer("100") == 100
+    assert String.to_integer("32423") == 32423
+    assert String.to_integer("10000000000000") == 10000000000000
+  end
+
+  test :to_float do
+    assert String.to_float("1.0") == 1.0
+    assert String.to_float("1.0000") == 1.0
+    assert String.to_float("33.33333") == 33.33333
+  end
+
   test :codepoints do
     assert String.codepoints("elixir") == ["e","l","i","x","i","r"]
     assert String.codepoints("elixír") == ["e","l","i","x","í","r"] # slovak


### PR DESCRIPTION
Requiring binary_to_\* to convert an Elixir string to an integer or float is not intuitive for non-Erlang programmers.
