### PR TITLE
add parens for function calls in examples

### DIFF
--- a/lib/elixir/lib/binary/chars.ex
+++ b/lib/elixir/lib/binary/chars.ex
@@ -51,9 +51,9 @@ defimpl Binary.Chars, for: List do
 
   ## Examples
 
-      iex> to_binary 'foo'
+      iex> to_binary('foo')
       "foo"
-      iex> to_binary ["foo", 'bar']
+      iex> to_binary(["foo", 'bar'])
       "foobar"
 
   """

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -84,14 +84,14 @@ defmodule Code do
 
   ## Examples
 
-      iex> Code.eval "a + b", [a: 1, b: 2], file: __ENV__.file, line: __ENV__.line
+      iex> Code.eval("a + b", [a: 1, b: 2], file: __ENV__.file, line: __ENV__.line)
       { 3, [ {:a, 1}, {:b, 2} ] }
 
   For convenience, you can my pass `__ENV__` as argument and
   all imports, requires and aliases will be automatically carried
   over:
 
-      iex> Code.eval "a + b", [a: 1, b: 2], __ENV__
+      iex> Code.eval("a + b", [a: 1, b: 2], __ENV__)
       { 3, [ {:a, 1}, {:b, 2} ] }
 
   """
@@ -115,15 +115,15 @@ defmodule Code do
 
   ## Examples
 
-      iex> contents = quote hygiene: [vars: false], do: a + b
-      ...> Code.eval_quoted contents, [a: 1, b: 2], file: __ENV__.file, line: __ENV__.line
+      iex> contents = quote(hygiene: [vars: false], do: a + b)
+      ...> Code.eval_quoted(contents, [a: 1, b: 2], file: __ENV__.file, line: __ENV__.line)
       { 3, [ {:a, 1}, {:b, 2} ] }
 
   For convenience, you can my pass `__ENV__` as argument and
   all options will be automatically extracted from the environment:
 
-      iex> contents = quote hygiene: [vars: false], do: a + b
-      ...> Code.eval_quoted contents, [a: 1, b: 2], __ENV__
+      iex> contents = quote(hygiene: [vars: false], do: a + b)
+      ...> Code.eval_quoted(contents, [a: 1, b: 2], __ENV__)
       { 3, [ {:a, 1}, {:b, 2} ] }
 
   """

--- a/lib/elixir/lib/dict.ex
+++ b/lib/elixir/lib/dict.ex
@@ -25,15 +25,15 @@ defmodule Dict do
   protocol:
 
       iex> dict = HashDict.new
-      ...> dict = Dict.put dict, :hello, :world
+      ...> dict = Dict.put(dict, :hello, :world)
       ...> dict[:hello]
       :world
 
   And also the `Enum.Iterator` protocol, allowing one to write:
 
-      Enum.each dict, fn { k, v } ->
+      Enum.each(dict, fn ({ k, v }) ->
         IO.puts "#{k}: #{v}"
-      end
+      end)
 
   """
 
@@ -78,8 +78,8 @@ defmodule Dict do
 
   ## Examples
 
-      iex> d = HashDict.new [a: 1, b: 2]
-      ...> Enum.sort Dict.keys d
+      iex> d = HashDict.new([a: 1, b: 2])
+      ...> Enum.sort(Dict.keys(d))
       [:a,:b]
 
   """
@@ -93,8 +93,8 @@ defmodule Dict do
 
   ## Examples
 
-      iex> d = HashDict.new [a: 1, b: 2]
-      ...> Enum.sort Dict.values d
+      iex> d = HashDict.new([a: 1, b: 2])
+      ...> Enum.sort(Dict.values(d))
       [1,2]
 
   """
@@ -108,8 +108,8 @@ defmodule Dict do
 
   ## Examples
 
-      iex> d = HashDict.new [a: 1, b: 2]
-      ...> Dict.size d
+      iex> d = HashDict.new([a: 1, b: 2])
+      ...> Dict.size(d)
       2
 
   """
@@ -123,11 +123,11 @@ defmodule Dict do
 
   ## Examples
 
-      iex> d = HashDict.new [a: 1]
+      iex> d = HashDict.new([a: 1])
       ...> Dict.has_key?(d, :a)
       true
 
-      iex> d = HashDict.new [a: 1]
+      iex> d = HashDict.new([a: 1])
       ...> Dict.has_key?(d, :b)
       false
 
@@ -143,16 +143,16 @@ defmodule Dict do
 
   ## Examples
 
-      iex> d = HashDict.new [a: 1]
-      ...> Dict.get d, :a
+      iex> d = HashDict.new([a: 1])
+      ...> Dict.get(d, :a)
       1
 
-      iex> d = HashDict.new [a: 1]
-      ...> Dict.get d, :b
+      iex> d = HashDict.new([a: 1])
+      ...> Dict.get(d, :b)
       nil
 
-      iex> d = HashDict.new [a: 1]
-      ...> Dict.get d, :b, 3
+      iex> d = HashDict.new([a: 1])
+      ...> Dict.get(d, :b, 3)
       3
   """
   @spec get(t, key, value) :: value
@@ -166,11 +166,11 @@ defmodule Dict do
 
   ## Examples
 
-      iex> d = HashDict.new [a: 1]
-      ...> Dict.get d, :a
+      iex> d = HashDict.new([a: 1])
+      ...> Dict.get(d, :a)
       1
-      iex> d = HashDict.new [a: 1]
-      ...> Dict.get! d, :b
+      iex> d = HashDict.new([a: 1])
+      ...> Dict.get!(d, :b)
       ** (KeyError) key not found: :b
 
   """
@@ -185,9 +185,9 @@ defmodule Dict do
 
   ## Examples
 
-      iex> d = HashDict.new [a: 1, b: 2]
-      ...> d = Dict.put d, :a, 3
-      ...> Dict.get d, :a
+      iex> d = HashDict.new([a: 1, b: 2])
+      ...> d = Dict.put(d, :a, 3)
+      ...> Dict.get(d, :a)
       3
 
   """
@@ -201,9 +201,9 @@ defmodule Dict do
 
   ## Examples
 
-      iex> d = HashDict.new [a: 1, b: 2]
-      ...> d = Dict.put_new d, :a, 3
-      ...> Dict.get d, :a
+      iex> d = HashDict.new([a: 1, b: 2])
+      ...> d = Dict.put_new(d, :a, 3)
+      ...> Dict.get(d, :a)
       1
 
   """
@@ -218,12 +218,12 @@ defmodule Dict do
 
   ## Examples
 
-      iex> d = HashDict.new [a: 1, b: 2]
-      ...> d = Dict.delete d, :a
-      ...> Dict.get d, :a
+      iex> d = HashDict.new([a: 1, b: 2])
+      ...> d = Dict.delete(d, :a)
+      ...> Dict.get(d, :a)
       nil
 
-      iex> d = HashDict.new [b: 2]
+      iex> d = HashDict.new([b: 2])
       ...> Dict.delete(d, :a) == d
       true
 
@@ -239,9 +239,9 @@ defmodule Dict do
 
   ## Examples
 
-      iex> d1 = HashDict.new [a: 1, b: 2]
-      ...> d2 = HashDict.new [a: 3, d: 4]
-      ...> d = Dict.merge d1, d2
+      iex> d1 = HashDict.new([a: 1, b: 2])
+      ...> d2 = HashDict.new([a: 3, d: 4])
+      ...> d = Dict.merge(d1, d2)
       ...> [a: Dict.get(d, :a), b: Dict.get(d, :b), d: Dict.get(d, :d)]
       [a: 3, b: 2, d: 4]
 
@@ -258,11 +258,11 @@ defmodule Dict do
 
   ## Examples
 
-      iex> d1 = HashDict.new [a: 1, b: 2]
-      ...> d2 = HashDict.new [a: 3, d: 4]
-      ...> d = Dict.merge d1, d2, fn _k, v1, v2 ->
+      iex> d1 = HashDict.new([a: 1, b: 2])
+      ...> d2 = HashDict.new([a: 3, d: 4])
+      ...> d = Dict.merge(d1, d2, fn(_k, v1, v2) ->
       ...>   v1 + v2
-      ...> end
+      ...> end)
       ...> [a: Dict.get(d, :a), b: Dict.get(d, :b), d: Dict.get(d, :d)]
       [a: 4, b: 2, d: 4]
 
@@ -278,9 +278,9 @@ defmodule Dict do
 
   ## Examples
 
-      iex> d = HashDict.new [a: 1, b: 2]
-      ...> d = Dict.update d, :a, fn val -> -val end
-      ...> Dict.get d, :a
+      iex> d = HashDict.new([a: 1, b: 2])
+      ...> d = Dict.update(d, :a, fn(val) -> -val end)
+      ...> Dict.get(d, :a)
       -1
 
   """
@@ -296,9 +296,9 @@ defmodule Dict do
 
   ## Examples
 
-      iex> d = HashDict.new [a: 1, b: 2]
-      ...> d = Dict.update d, :c, 3, fn val -> -val end
-      ...> Dict.get d, :c
+      iex> d = HashDict.new([a: 1, b: 2])
+      ...> d = Dict.update(d, :c, 3, fn(val) -> -val end)
+      ...> Dict.get(d, :c)
       3
 
   """

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -8,7 +8,7 @@ defprotocol Enum.Iterator do
 
   For example, in the expression
 
-      Enum.map [1,2,3], &1 * 2
+      Enum.map([1,2,3], &1 * 2)
 
   `Enum.map` invokes `Enum.Iterator.iterator([1,2,3])` to retrieve the iterator
   function that will drive the iteration process.
@@ -63,7 +63,7 @@ defmodule Enum do
   flavours. If a given collection implements the mentioned protocol (like
   list, for instance), you can do:
 
-      Enum.map [1,2,3], fn(x) -> x * 2 end
+      Enum.map([1,2,3], fn(x) -> x * 2 end)
 
   Depending on the type of the collection, the user-provided function will
   accept a certain type of argument. For dicts, the argument is always a
@@ -81,18 +81,18 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.all? [2,4,6], fn(x) -> rem(x, 2) == 0 end
+      iex> Enum.all?([2,4,6], fn(x) -> rem(x, 2) == 0 end)
       true
 
-      iex> Enum.all? [2,3,4], fn(x) -> rem(x, 2) == 0 end
+      iex> Enum.all?([2,3,4], fn(x) -> rem(x, 2) == 0 end)
       false
 
   If no function is given, it defaults to checking if
   all items in the collection evaluate to true.
 
-      iex> Enum.all? [1,2,3]
+      iex> Enum.all?([1,2,3])
       true
-      iex> Enum.all? [1,nil,3]
+      iex> Enum.all?([1,nil,3])
       false
 
   """
@@ -120,18 +120,18 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.any? [2,4,6], fn(x) -> rem(x, 2) == 1 end
+      iex> Enum.any?([2,4,6], fn(x) -> rem(x, 2) == 1 end)
       false
 
-      iex> Enum.any? [2,3,4], fn(x) -> rem(x, 2) == 1 end
+      iex> Enum.any?([2,3,4], fn(x) -> rem(x, 2) == 1 end)
       true
 
   If no function is given, it defaults to checking if
   at least one item in the collection evaluates to true.
 
-      iex> Enum.any? [false,false,false]
+      iex> Enum.any?([false,false,false])
       false
-      iex> Enum.any? [false,true,false]
+      iex> Enum.any?([false,true,false])
       true
 
   """
@@ -162,11 +162,11 @@ defmodule Enum do
 
     ## Examples
 
-        iex> Enum.at! [2,4,6], 0
+        iex> Enum.at!([2,4,6], 0)
         2
-        iex> Enum.at! [2,4,6], 2
+        iex> Enum.at!([2,4,6], 2)
         6
-        iex> Enum.at! [2,4,6], 4
+        iex> Enum.at!([2,4,6], 4)
         ** (Enum.OutOfBoundsError) out of bounds error
 
   """
@@ -189,7 +189,7 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.count [1,2,3]
+      iex> Enum.count([1,2,3])
       3
 
   """
@@ -221,11 +221,11 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.drop [1,2,3], 2
+      iex> Enum.drop([1,2,3], 2)
       [3]
-      iex> Enum.drop [1,2,3], 10
+      iex> Enum.drop([1,2,3], 10)
       []
-      iex> Enum.drop [1,2,3], 0
+      iex> Enum.drop([1,2,3], 0)
       [1,2,3]
 
   """
@@ -254,7 +254,7 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.drop_while [1,2,3,4,5], fn(x) -> x < 3 end
+      iex> Enum.drop_while([1,2,3,4,5], fn(x) -> x < 3 end)
       [3,4,5]
   """
   @spec drop_while(t, (element -> as_boolean(term))) :: list
@@ -278,7 +278,7 @@ defmodule Enum do
 
   ## Examples
 
-      Enum.each ['some', 'example'], fn(x) -> IO.puts x end
+      Enum.each(['some', 'example'], fn(x) -> IO.puts x end)
 
   """
   @spec each(t, (element -> any) | (element, index -> any)) :: :ok
@@ -310,9 +310,9 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.empty? []
+      iex> Enum.empty?([])
       true
-      iex> Enum.empty? [1,2,3]
+      iex> Enum.empty?([1,2,3])
       false
 
   """
@@ -334,7 +334,7 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.filter [1, 2, 3], fn(x) -> rem(x, 2) == 0 end
+      iex> Enum.filter([1, 2, 3], fn(x) -> rem(x, 2) == 0 end)
       [2]
 
   """
@@ -357,7 +357,7 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.filter_map [1, 2, 3], fn(x) -> rem(x, 2) == 0 end, &1 * 2
+      iex> Enum.filter_map([1, 2, 3], fn(x) -> rem(x, 2) == 0 end, &1 * 2)
       [4]
 
   """
@@ -381,13 +381,13 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.find [2,4,6], fn(x) -> rem(x, 2) == 1 end
+      iex> Enum.find([2,4,6], fn(x) -> rem(x, 2) == 1 end)
       nil
 
-      iex> Enum.find [2,4,6], 0, fn(x) -> rem(x, 2) == 1 end
+      iex> Enum.find([2,4,6], 0, fn(x) -> rem(x, 2) == 1 end)
       0
 
-      iex> Enum.find [2,3,4], fn(x) -> rem(x, 2) == 1 end
+      iex> Enum.find([2,3,4], fn(x) -> rem(x, 2) == 1 end)
       3
 
   """
@@ -415,10 +415,10 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.find_value [2,4,6], fn(x) -> rem(x, 2) == 1 end
+      iex> Enum.find_value([2,4,6], fn(x) -> rem(x, 2) == 1 end)
       nil
 
-      iex> Enum.find_value [2,3,4], fn(x) -> rem(x, 2) == 1 end
+      iex> Enum.find_value([2,3,4], fn(x) -> rem(x, 2) == 1 end)
       true
 
   """
@@ -448,10 +448,10 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.find_index [2,4,6], fn(x) -> rem(x, 2) == 1 end
+      iex> Enum.find_index([2,4,6], fn(x) -> rem(x, 2) == 1 end)
       nil
 
-      iex> Enum.find_index [2,3,4], fn(x) -> rem(x, 2) == 1 end
+      iex> Enum.find_index([2,3,4], fn(x) -> rem(x, 2) == 1 end)
       1
 
   """
@@ -474,9 +474,9 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.first []
+      iex> Enum.first([])
       nil
-      iex> Enum.first [1,2,3]
+      iex> Enum.first([1,2,3])
       1
 
   """
@@ -543,10 +543,10 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.map [1, 2, 3], fn(x) -> x * 2 end
+      iex> Enum.map([1, 2, 3], fn(x) -> x * 2 end)
       [2, 4, 6]
 
-      iex> Enum.map [a: 1, b: 2], fn({k, v}) -> { k, -v } end
+      iex> Enum.map([a: 1, b: 2], fn({k, v}) -> { k, -v } end)
       [a: -1, b: -2]
 
   """
@@ -622,7 +622,7 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.map_reduce [1, 2, 3], 0, fn(x, acc) -> { x * 2, x + acc } end
+      iex> Enum.map_reduce([1, 2, 3], 0, fn(x, acc) -> { x * 2, x + acc } end)
       { [2, 4, 6], 6 }
 
   """
@@ -647,7 +647,7 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.partition [1, 2, 3], fn(x) -> rem(x, 2) == 0 end
+      iex> Enum.partition([1, 2, 3], fn(x) -> rem(x, 2) == 0 end)
       { [2], [1,3] }
 
   """
@@ -672,7 +672,7 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.reduce [1, 2, 3], 0, fn(x, acc) -> x + acc end
+      iex> Enum.reduce([1, 2, 3], 0, fn(x, acc) -> x + acc end)
       6
 
   """
@@ -695,7 +695,7 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.reverse [1, 2, 3]
+      iex> Enum.reverse([1, 2, 3])
       [3, 2, 1]
 
   """
@@ -716,7 +716,7 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.sort [3,2,1]
+      iex> Enum.sort([3,2,1])
       [1,2,3]
 
   """
@@ -739,7 +739,7 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.sort [1,2,3], &1 > &2
+      iex> Enum.sort([1,2,3], &1 > &2)
       [3,2,1]
 
   """
@@ -769,15 +769,15 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.split [1,2,3], 2
+      iex> Enum.split([1,2,3], 2)
       { [1,2], [3] }
-      iex> Enum.split [1,2,3], 10
+      iex> Enum.split([1,2,3], 10)
       { [1,2,3], [] }
-      iex> Enum.split [1,2,3], 0
+      iex> Enum.split([1,2,3], 0)
       { [], [1,2,3] }
-      iex> Enum.split [1,2,3], -1
+      iex> Enum.split([1,2,3], -1)
       { [1,2], [3] }
-      iex> Enum.split [1,2,3], -5
+      iex> Enum.split([1,2,3], -5)
       { [], [1,2,3] }
 
   """
@@ -805,7 +805,7 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.split_while [1,2,3,4], fn(x) -> x < 3 end
+      iex> Enum.split_while([1,2,3,4], fn(x) -> x < 3 end)
       { [1, 2], [3, 4] }
   """
   @spec split_while(t, (element -> as_boolean(term))) :: {list, list}
@@ -828,11 +828,11 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.take [1,2,3], 2
+      iex> Enum.take([1,2,3], 2)
       [1,2]
-      iex> Enum.take [1,2,3], 10
+      iex> Enum.take([1,2,3], 10)
       [1,2,3]
-      iex> Enum.take [1,2,3], 0
+      iex> Enum.take([1,2,3], 0)
       []
 
   """
@@ -866,7 +866,7 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.take_while [1,2,3], fn(x) -> x < 3 end
+      iex> Enum.take_while([1,2,3], fn(x) -> x < 3 end)
       [1, 2]
 
   """
@@ -889,7 +889,7 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.uniq [1,2,3,2,1]
+      iex> Enum.uniq([1,2,3,2,1])
       [1, 2, 3]
 
   """

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -166,7 +166,7 @@ defmodule IO.ANSI do
 
   ## Example
 
-    iex> IO.ANSI.escape "Hello %{red,bright,green}yes"
+    iex> IO.ANSI.escape("Hello %{red,bright,green}yes")
     "Hello \e[31m\e[1m\e[32myes\e[0m"
   """
   @spec escape(String.t, emit :: boolean) :: String.t
@@ -192,7 +192,7 @@ defmodule IO.ANSI do
 
   ## Example
 
-    iex> IO.ANSI.escape "Hello %{red,bright,green}yes"
+    iex> IO.ANSI.escape("Hello %{red,bright,green}yes")
     "Hello \e[31m\e[1m\e[32myes\e[0m"
 
   """

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -296,7 +296,7 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> apply fn x -> x * 2 end, [2]
+      iex> apply(fn x -> x * 2 end, [2])
       4
 
   """
@@ -307,7 +307,7 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> apply Enum, :reverse, [[1,2,3]]
+      iex> apply(Enum, :reverse, [[1,2,3]])
       [3,2,1]
 
   """
@@ -373,12 +373,12 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> binary_part "foo", 1, 2
+      iex> binary_part("foo", 1, 2)
       "oo"
 
   A negative length can be used to extract bytes at the end of a binary:
 
-      iex> binary_part "foo", 3, -1
+      iex> binary_part("foo", 3, -1)
       "o"
 
   """
@@ -2009,7 +2009,7 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> div 5, 2
+      iex> div(5, 2)
       2
 
   """
@@ -2024,7 +2024,7 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> rem 5, 2
+      iex> rem(5, 2)
       1
 
   """
@@ -2038,9 +2038,9 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> nil? 1
+      iex> nil?(1)
       false
-      iex> nil? nil
+      iex> nil?(nil)
       true
 
   """
@@ -2533,7 +2533,7 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> destructure [x,y,z], [1,2,3,4,5]
+      iex> destructure([x,y,z], [1,2,3,4,5])
       ...> {x, y, z}
       {1, 2, 3}
 
@@ -2542,7 +2542,7 @@ defmodule Kernel do
   fine. If the right size is smaller, the remaining items
   are simply assigned to nil:
 
-      iex> destructure [x,y,z], [1]
+      iex> destructure([x,y,z], [1])
       ...> {x, y, z}
       {1, nil, nil}
 
@@ -2550,7 +2550,7 @@ defmodule Kernel do
   on the left side of a match:
 
       x = 1
-      destructure [^x,y,z], [1,2,3]
+      destructure([^x,y,z], [1,2,3])
 
   The example above will only work if x matches
   the first value from the right side. Otherwise,
@@ -2574,7 +2574,7 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> binary_to_integer "123"
+      iex> binary_to_integer("123")
       123
 
   """
@@ -2613,7 +2613,7 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> binary_to_float "2.2017764e+0"
+      iex> binary_to_float("2.2017764e+0")
       2.2017764
 
   """
@@ -2633,7 +2633,7 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> integer_to_binary 123
+      iex> integer_to_binary(123)
       "123"
 
   """
@@ -2653,7 +2653,7 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> integer_to_binary 77
+      iex> integer_to_binary(77)
       "77"
 
   """
@@ -2673,7 +2673,7 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> float_to_binary 7.0
+      iex> float_to_binary(7.0)
       "7.00000000000000000000e+00"
 
   """
@@ -2728,7 +2728,7 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> binary_to_atom "my_atom"
+      iex> binary_to_atom("my_atom")
       :my_atom
 
   """
@@ -2744,10 +2744,10 @@ defmodule Kernel do
   ## Examples
 
       iex> :my_atom
-      ...> binary_to_existing_atom "my_atom"
+      ...> binary_to_existing_atom("my_atom")
       :my_atom
 
-      iex> binary_to_existing_atom "this_atom_will_never_exist"
+      iex> binary_to_existing_atom("this_atom_will_never_exist")
       ** (ArgumentError) argument error
 
   """
@@ -2763,7 +2763,7 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> atom_to_binary :my_atom
+      iex> atom_to_binary(:my_atom)
       "my_atom"
 
   """
@@ -3030,7 +3030,7 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> raise ArgumentError, message: "Sample"
+      iex> raise(ArgumentError, message: "Sample")
       ** (ArgumentError) Sample
 
   """
@@ -3346,7 +3346,7 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> Regex.match? %r(foo), "foo"
+      iex> Regex.match?(%r(foo), "foo")
       true
 
   """
@@ -3367,7 +3367,7 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> Regex.match? %R(f\#{1,3}o), "f\#o"
+      iex> Regex.match?(%R(f\#{1,3}o), "f\#o")
       true
 
   """

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -59,7 +59,7 @@ defmodule Keyword do
 
   ## Examples
 
-      iex> Keyword.new [{:b,1},{:a,2}]
+      iex> Keyword.new([{:b,1},{:a,2}])
       [a: 2, b: 1]
 
   """
@@ -77,7 +77,7 @@ defmodule Keyword do
 
   ## Examples
 
-      iex> Enum.sort Keyword.new [:a, :b], fn x -> {x,x} end
+      iex> Keyword.new([:a, :b], fn (x) -> {x,x} end) |> Enum.sort
       [a: :a, b: :b]
 
   """
@@ -100,11 +100,11 @@ defmodule Keyword do
 
   ## Examples
 
-      iex> Keyword.get [a: 1], :a
+      iex> Keyword.get([a: 1], :a)
       1
-      iex> Keyword.get [a: 1], :b
+      iex> Keyword.get([a: 1], :b)
       nil
-      iex> Keyword.get [a: 1], :b, 3
+      iex> Keyword.get([a: 1], :b, 3)
       3
 
   """
@@ -123,9 +123,9 @@ defmodule Keyword do
 
   ## Examples
 
-      iex> Keyword.get! [a: 1], :a
+      iex> Keyword.get!([a: 1], :a)
       1
-      iex> Keyword.get! [a: 1], :b
+      iex> Keyword.get!([a: 1], :b)
       ** (KeyError) key not found: :b
 
   """
@@ -142,7 +142,7 @@ defmodule Keyword do
 
   ## Examples
 
-      iex> Keyword.get_values [a: 1, a: 2], :a
+      iex> Keyword.get_values([a: 1, a: 2], :a)
       [1,2]
 
   """
@@ -157,7 +157,7 @@ defmodule Keyword do
 
   ## Examples
 
-      iex> Keyword.keys [a: 1, b: 2]
+      iex> Keyword.keys([a: 1, b: 2])
       [:a,:b]
 
   """
@@ -171,7 +171,7 @@ defmodule Keyword do
 
   ## Examples
 
-      iex> Keyword.values [a: 1, b: 2]
+      iex> Keyword.values([a: 1, b: 2])
       [1,2]
 
   """
@@ -188,9 +188,9 @@ defmodule Keyword do
 
   ## Examples
 
-      iex> Keyword.delete [a: 1, b: 2], :a
+      iex> Keyword.delete([a: 1, b: 2], :a)
       [b: 2]
-      iex> Keyword.delete [b: 2], :a
+      iex> Keyword.delete([b: 2], :a)
       [b: 2]
 
   """
@@ -207,7 +207,7 @@ defmodule Keyword do
 
   ## Examples
 
-      iex> Keyword.put [a: 1, b: 2], :a, 3
+      iex> Keyword.put([a: 1, b: 2], :a, 3)
       [a: 3, b: 2]
 
   """
@@ -222,7 +222,7 @@ defmodule Keyword do
 
   ## Examples
 
-      iex> Keyword.put_new [a: 1, b: 2], :a, 3
+      iex> Keyword.put_new([a: 1, b: 2], :a, 3)
       [a: 1, b: 2]
 
   """
@@ -240,7 +240,7 @@ defmodule Keyword do
 
   ## Examples
 
-      iex> Keyword.equal? [a: 1, b: 2], [b: 2, a: 1]
+      iex> Keyword.equal?([a: 1, b: 2], [b: 2, a: 1])
       true
 
   """
@@ -255,7 +255,7 @@ defmodule Keyword do
 
   ## Examples
 
-      iex> Enum.sort Keyword.merge [a: 1, b: 2], [a: 3, d: 4]
+      iex> Keyword.merge([a: 1, b: 2], [a: 3, d: 4]) |> Enum.sort
       [a: 3, b: 2, d: 4]
 
   """
@@ -270,9 +270,9 @@ defmodule Keyword do
 
   ## Examples
 
-      iex> Keyword.merge [a: 1, b: 2], [a: 3, d: 4], fn _k, v1, v2 ->
+      iex> Keyword.merge([a: 1, b: 2], [a: 3, d: 4], fn (_k, v1, v2) ->
       ...>  v1 + v2
-      iex> end
+      iex> end)
       [a: 4, b: 2, d: 4]
 
   """

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -15,7 +15,7 @@ defmodule List do
 
   ## Examples
 
-      iex> List.concat [[1,[2],3], [4], [5,6]]
+      iex> List.concat([[1,[2],3], [4], [5,6]])
       [1,[2],3,4,5,6]
 
   """
@@ -32,7 +32,7 @@ defmodule List do
 
   ## Examples
 
-      iex> List.concat [1,2,3], [4,5,6]
+      iex> List.concat([1,2,3], [4,5,6])
       [1,2,3,4,5,6]
 
   """
@@ -60,10 +60,10 @@ defmodule List do
 
   ## Examples
 
-      iex> List.duplicate "hello", 3
+      iex> List.duplicate("hello", 3)
       ["hello","hello","hello"]
 
-      iex> List.duplicate [1,2], 2
+      iex> List.duplicate([1,2], 2)
       [[1,2],[1,2]]
   """
   def duplicate(elem, n) do
@@ -77,10 +77,10 @@ defmodule List do
 
   ## Examples
 
-      iex> List.flatten [1,[[2],3]]
+      iex> List.flatten([1,[[2],3]])
       [1,2,3]
 
-      iex> List.flatten [1,[[2],3]], [4,5]
+      iex> List.flatten([1,[[2],3]], [4,5])
       [1,2,3,4,5]
 
   """
@@ -98,10 +98,10 @@ defmodule List do
 
   ## Examples
 
-      iex> List.foldl [5,5], 10, fn x, acc -> x + acc end
+      iex> List.foldl([5,5], 10, fn (x, acc) -> x + acc end)
       20
 
-      iex> List.foldl [1,2,3,4], 0, fn x, acc -> x - acc end
+      iex> List.foldl([1,2,3,4], 0, fn (x, acc) -> x - acc end)
       2
 
   """
@@ -115,7 +115,7 @@ defmodule List do
 
   ## Examples
 
-      iex> List.foldr [1,2,3,4], 0, fn x, acc -> x - acc end
+      iex> List.foldr([1,2,3,4], 0, fn (x, acc) -> x - acc end)
       -2
 
   """
@@ -128,11 +128,11 @@ defmodule List do
 
   ## Examples
 
-      iex> List.last []
+      iex> List.last([])
       nil
-      iex> List.last [1]
+      iex> List.last([1])
       1
-      iex> List.last [1, 2, 3]
+      iex> List.last([1, 2, 3])
       3
 
   """
@@ -149,10 +149,10 @@ defmodule List do
 
   ## Examples
 
-      iex> List.member? [1,2,3], 1
+      iex> List.member?([1,2,3], 1)
       true
 
-      iex> List.member? [1,2,3], 0
+      iex> List.member?([1,2,3], 0)
       false
 
   """
@@ -259,7 +259,7 @@ defmodule List do
 
   ## Examples
 
-      iex> List.wrap [1,2,3]
+      iex> List.wrap([1,2,3])
       [1,2,3]
 
   """
@@ -280,10 +280,10 @@ defmodule List do
 
   ## Examples
 
-      iex> List.zip [[1, 2], [3, 4], [5, 6]]
+      iex> List.zip([[1, 2], [3, 4], [5, 6]])
       [{1, 3, 5}, {2, 4, 6}]
 
-      iex> List.zip [[1, 2], [3], [5, 6]]
+      iex> List.zip([[1, 2], [3], [5, 6]])
       [{1, 3, 5}]
 
   """
@@ -298,10 +298,10 @@ defmodule List do
 
   ## Examples
 
-      iex> List.unzip [{1, 2}, {3, 4}]
+      iex> List.unzip([{1, 2}, {3, 4}])
       [[1, 3], [2, 4]]
 
-      iex> List.unzip [{1, :a, "apple"}, {2, :b, "banana"}, {3, :c}]
+      iex> List.unzip([{1, :a, "apple"}, {2, :b, "banana"}, {3, :c}])
       [[1, 2, 3], [:a, :b, :c]]
 
   """

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -152,7 +152,7 @@ defmodule Macro do
 
   ## Examples
 
-      iex> Macro.unescape_binary "example\\n"
+      iex> Macro.unescape_binary("example\\n")
       "example\n"
 
   In the example above, we pass a string with `\n` escaped

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -116,11 +116,11 @@ defmodule Module do
 
   ## Examples
 
-      iex> Module.concat [Foo, Bar]
+      iex> Module.concat([Foo, Bar])
       Foo.Bar
-      iex> Module.concat [Foo, "Bar"]
+      iex> Module.concat([Foo, "Bar"])
       Foo.Bar
-      iex> Module.concat [Foo, 'Bar']
+      iex> Module.concat([Foo, 'Bar'])
       Foo.Bar
 
   """
@@ -134,11 +134,11 @@ defmodule Module do
 
   ## Examples
 
-      iex> Module.concat Foo, Bar
+      iex> Module.concat(Foo, Bar)
       Foo.Bar
-      iex> Module.concat Foo, "Bar"
+      iex> Module.concat(Foo, "Bar")
       Foo.Bar
-      iex> Module.concat Foo, 'Bar'
+      iex> Module.concat(Foo, 'Bar')
       Foo.Bar
 
   """
@@ -154,10 +154,10 @@ defmodule Module do
 
   ## Examples
 
-      iex> Module.safe_concat [Unknown, Module]
+      iex> Module.safe_concat([Unknown, Module])
       ** (ArgumentError) argument error
 
-      iex> Module.safe_concat [List, Chars]
+      iex> Module.safe_concat([List, Chars])
       List.Chars
 
   """
@@ -173,10 +173,10 @@ defmodule Module do
 
   ## Examples
 
-      iex> Module.safe_concat Unknown, Module
+      iex> Module.safe_concat(Unknown, Module)
       ** (ArgumentError) argument error
 
-      iex> Module.safe_concat List, Chars
+      iex> Module.safe_concat(List, Chars)
       List.Chars
 
   """

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -86,9 +86,9 @@ defmodule Regex do
 
   ## Examples
 
-      iex> Regex.index %r/c(d)/, "abcd"
+      iex> Regex.index(%r/c(d)/, "abcd")
       2
-      iex> Regex.index %r/e/, "abcd"
+      iex> Regex.index(%r/e/, "abcd")
       nil
 
   """
@@ -104,9 +104,9 @@ defmodule Regex do
 
   ## Examples
 
-      iex> Regex.match? %r/foo/, "foo"
+      iex> Regex.match?(%r/foo/, "foo")
       true
-      iex> Regex.match? %r/foo/, "bar"
+      iex> Regex.match?(%r/foo/, "bar")
       false
 
   """
@@ -120,9 +120,9 @@ defmodule Regex do
 
   ## Examples
 
-      iex> Regex.run %r/c(d)/, "abcd"
+      iex> Regex.run(%r/c(d)/, "abcd")
       ["cd", "d"]
-      iex> Regex.run %r/e/, "abcd"
+      iex> Regex.run(%r/e/, "abcd")
       nil
 
   """
@@ -149,7 +149,7 @@ defmodule Regex do
 
   ## Examples
 
-      iex> Regex.captures %r/c(?<foo>d)/g, "abcd"
+      iex> Regex.captures(%r/c(?<foo>d)/g, "abcd")
       [foo: "d"]
 
   """
@@ -178,7 +178,7 @@ defmodule Regex do
 
   ## Examples
 
-      iex> Regex.source %r(foo)
+      iex> Regex.source(%r(foo))
       "foo"
 
   """
@@ -191,7 +191,7 @@ defmodule Regex do
 
   ## Examples
 
-      iex> Regex.opts %r(foo)m
+      iex> Regex.opts(%r(foo)m)
       "m"
 
   """
@@ -204,7 +204,7 @@ defmodule Regex do
 
   ## Examples
 
-      iex> Regex.groups %r/(?<foo>foo)/g
+      iex> Regex.groups(%r/(?<foo>foo)/g)
       [:foo]
 
   """
@@ -220,11 +220,11 @@ defmodule Regex do
 
   ## Examples
 
-      iex> Regex.scan %r/c(d|e)/, "abcd abce"
+      iex> Regex.scan(%r/c(d|e)/, "abcd abce")
       [["d"], ["e"]]
-      iex> Regex.scan %r/c(?:d|e)/, "abcd abce"
+      iex> Regex.scan(%r/c(?:d|e)/, "abcd abce")
       ["cd", "ce"]
-      iex> Regex.scan %r/e/, "abcd"
+      iex> Regex.scan(%r/e/, "abcd")
       []
 
   """

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -62,7 +62,7 @@ defmodule String do
   Although codepoints could be represented as integers, this
   module represents all codepoints as strings. For example:
 
-      iex> String.codepoints "josé"
+      iex> String.codepoints("josé")
       ["j", "o", "s", "é"]
 
   There are a couple of ways to retrieve a character integer


### PR DESCRIPTION
As discussed in the mail list today: update examples to use parens for function application in most cases.
