### PR TITLE
Don't swallow UndefinedFunctionError in Binary.Inspect

### DIFF
--- a/lib/elixir/lib/binary/inspect.ex
+++ b/lib/elixir/lib/binary/inspect.ex
@@ -328,11 +328,12 @@ defimpl Binary.Inspect, for: Tuple do
 
     if is_atom(name) and match?("Elixir-" <> _, atom_to_binary(name)) do
       unless name in [BitString, List, Tuple, Atom, Number, Any] do
+        target = Module.concat(Binary.Inspect, name)
         try do
-          target = Module.concat(Binary.Inspect, name)
           target.inspect(tuple, opts)
-        rescue
-          UndefinedFunctionError ->
+        catch
+          :error, :undef, [[{ ^target, :inspect, args, _ } | _] | _]
+              when length(args) == 2  ->
             record_inspect(tuple, opts)
         end
       end


### PR DESCRIPTION
When Binary.Inspect.Tuple tries to dispatch to a record implement it swallows all UndefinedFunctionError. 

Fixes #960
