### PR TITLE
Implement Dict.equal?

### DIFF
--- a/lib/elixir/lib/dict.ex
+++ b/lib/elixir/lib/dict.ex
@@ -45,6 +45,7 @@ defmodule Dict do
 
   defcallback delete(t, key) :: t
   defcallback empty(t) :: t
+  defcallback equal?(t, t) :: boolean
   defcallback get(t, key) :: value
   defcallback get(t, key, value) :: value
   defcallback get!(t, key) :: value | no_return
@@ -313,6 +314,32 @@ defmodule Dict do
   @spec empty(t) :: t
   def empty(dict) do
     target(dict).empty(dict)
+  end
+
+  @doc """
+  Check if two dicts are equal, if the dicts are of different types they're
+  first converted to lists.
+
+  ## Examples
+
+      iex> a = HashDict.new(a: 2, b: 3, f: 5, c: 123)
+      ...> b = List.Dict.new(a: 2, b: 3, f: 5, c: 123)
+      ...> Dict.equal?(a, b)
+      true
+
+      iex> a = HashDict.new(a: 2, b: 3, f: 5, c: 123)
+      ...> b = []
+      ...> Dict.equal?(a, b)
+      false
+
+  """
+  @spec equal?(t, t) :: boolean
+  def equal?(a, b) do
+    if target(a) == target(b) do
+      target(a).equal?(a, b)
+    else
+      List.Dict.equal?(target(a).to_list(a), target(b).to_list(b))
+    end
   end
 
   @doc """

--- a/lib/elixir/lib/hash_dict.ex
+++ b/lib/elixir/lib/hash_dict.ex
@@ -215,6 +215,26 @@ defmodule HashDict do
     ordered()
   end
 
+  def equal?(ordered(bucket: a, size: size), ordered(bucket: b, size: ^size)) do
+    a == b
+  end
+
+  def equal?(trie(size: size) = a, trie(size: ^size) = b) do
+    a == b
+  end
+
+  def equal?(ordered() = a, trie() = b) do
+    equal?(b, a)
+  end
+
+  def equal?(trie(size: size) = a, ordered(bucket: b, size: ^size)) do
+    :lists.keysort(1, to_list(a)) == :lists.keysort(1, b)
+  end
+
+  def equal?(_, _) do
+    false
+  end
+
   @doc """
   Converts the dict to a list.
   """

--- a/lib/elixir/lib/list/dict.ex
+++ b/lib/elixir/lib/list/dict.ex
@@ -149,6 +149,13 @@ defmodule List.Dict do
   def empty(_dict), do: []
 
   @doc """
+  Check if the List.Dict is equal to another List.Dict.
+  """
+  def equal?(dict, other) do
+    :lists.keysort(1, dict) == :lists.keysort(1, other)
+  end
+
+  @doc """
   Converts the dict to a list.
   """
   def to_list(dict), do: dict

--- a/lib/elixir/test/elixir/dict_test.exs
+++ b/lib/elixir/test/elixir/dict_test.exs
@@ -145,6 +145,15 @@ defmodule DictTest.Common do
       defp new_dict(list, transform) do
         unquote(module).new list, transform
       end
+
+      test :equal? do
+        dict1 = HashDict.new(a: 2, b: 3, f: 5, c: 123)
+        dict2 = List.Dict.new(a: 2, b: 3, f: 5, c: 123)
+        assert Dict.equal?(dict1, dict2)
+
+        dict2 = Dict.put(dict2, :a, 3)
+        refute Dict.equal?(dict1, dict2)
+      end
     end
   end
 end


### PR DESCRIPTION
This is initial work to verify the logic pleases the astral beast, I'm using `function_exported?` to allow optional more performant implementation of dict equality.

So it's optional and fallbacks to using `List.Dict.equal?` which just sorts by key, and checks for equality with `==`.

Thoughts?
