### PR TITLE
More Enum.equal? stuff

### DIFF
--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -88,6 +88,18 @@ defmodule EnumTest.List do
     assert Enum.equal?(1 .. 3, 1 .. 3)
     refute Enum.equal?(1 .. 3, 1 .. 10)
     refute Enum.equal?(1 .. 3, [])
+    assert Enum.equal?([1, 2, 3], 1 .. 3)
+    assert Enum.equal?(1 .. 3, 1 .. 3)
+    refute Enum.equal?(1 .. 3, 1 .. 10)
+    refute Enum.equal?(1 .. 3, [])
+    refute Enum.equal?([], 1 .. 3)
+
+    refute Enum.equal?(1 .. 3, [1.0, 2.0, 3.0], &1 === &2)
+    refute Enum.equal?(1 .. 3, [], &1 === &2)
+    refute Enum.equal?([], 1 .. 3, &1 === &2)
+    refute Enum.equal?(1 .. 3, 1 .. 5, &1 == &2)
+    assert Enum.equal?(1 .. 3, [1, 2, 3], &1 === &2)
+    assert Enum.equal?([1, 2, 3], [1, 2, 3], &1 === &2)
   end
 
   test :each do


### PR DESCRIPTION
Added a specialization for Range, because it could do a lot of useless work when comparing two ranges.

Also added `Enum.equal?/3` with an additional function to check for equality, useful in many situation, and also to easily compare with `===` instead of `==`.
