### PR TITLE
Remove custom dispatch to records in Binary.Inspect.Tuple

### DIFF
--- a/lib/elixir/lib/binary/inspect.ex
+++ b/lib/elixir/lib/binary/inspect.ex
@@ -11,8 +11,6 @@ defprotocol Binary.Inspect do
   printing.
   """
 
-  @only [BitString, List, Tuple, Atom, Number, Function, PID, Port, Reference]
-
   def inspect(thing, opts)
 end
 
@@ -34,15 +32,15 @@ defmodule Binary.Inspect.Utils do
   end
 
   defp do_container_join([h], opts, _counter) do
-    Binary.Inspect.inspect(h, opts)
+    Kernel.inspect(h, opts)
   end
 
   defp do_container_join([h|t], opts, counter) when is_list(t) do
-    Binary.Inspect.inspect(h, opts) <> "," <> do_container_join(t, opts, decrement(counter))
+    Kernel.inspect(h, opts) <> "," <> do_container_join(t, opts, decrement(counter))
   end
 
   defp do_container_join([h|t], opts, _counter) do
-    Binary.Inspect.inspect(h, opts) <> "|" <> Binary.Inspect.inspect(t, opts)
+    Kernel.inspect(h, opts) <> "|" <> Kernel.inspect(t, opts)
   end
 
   defp do_container_join([], _opts, _counter) do
@@ -285,7 +283,7 @@ defimpl Binary.Inspect, for: List do
 
   defp join_keywords(thing, opts) do
     Enum.join(lc {key, value} inlist thing do
-      key_to_binary(key, opts) <> ": " <> Binary.Inspect.inspect(value, opts)
+      key_to_binary(key, opts) <> ": " <> Kernel.inspect(value, opts)
     end, ", ")
   end
 
@@ -317,28 +315,11 @@ defimpl Binary.Inspect, for: Tuple do
 
   def inspect(tuple, opts) do
     unless opts[:raw] do
-      record_protocol(tuple, opts)
+      record_inspect(tuple, opts)
     end || container_join(tuple, "{", "}", opts)
   end
 
   ## Helpers
-
-  defp record_protocol(tuple, opts) do
-    name = elem(tuple, 0)
-
-    if is_atom(name) and match?("Elixir-" <> _, atom_to_binary(name)) do
-      unless name in [BitString, List, Tuple, Atom, Number, Any] do
-        target = Module.concat(Binary.Inspect, name)
-        try do
-          target.inspect(tuple, opts)
-        catch
-          :error, :undef, [[{ ^target, :inspect, args, _ } | _] | _]
-              when length(args) == 2  ->
-            record_inspect(tuple, opts)
-        end
-      end
-    end
-  end
 
   defp record_inspect(record, opts) do
     list = tuple_to_list(record)
@@ -368,12 +349,12 @@ defimpl Binary.Inspect, for: Tuple do
   end
 
   defp record_join([f], [v], opts) do
-    atom_to_binary(f, :utf8) <> ": " <> Binary.Inspect.inspect(v, opts)
+    atom_to_binary(f, :utf8) <> ": " <> Kernel.inspect(v, opts)
   end
 
   defp record_join([fh|ft], [vh|vt], opts) do
     atom_to_binary(fh, :utf8) <> ": " <>
-      Binary.Inspect.inspect(vh, opts) <> ", " <>
+      Kernel.inspect(vh, opts) <> ", " <>
       record_join(ft, vt, opts)
   end
 
@@ -414,11 +395,11 @@ defimpl Binary.Inspect, for: Regex do
   """
 
   def inspect(regex, _opts) when size(regex) == 5 do
-    "%r" <> Binary.Inspect.inspect(Regex.source(regex), []) <> Regex.opts(regex)
+    "%r" <> Kernel.inspect(Regex.source(regex), []) <> Regex.opts(regex)
   end
 
   def inspect(other, opts) do
-    Binary.Inspect.inspect other, Keyword.put(opts, :raw, true)
+    Kernel.inspect other, Keyword.put(opts, :raw, true)
   end
 end
 

--- a/lib/elixir/lib/hash_dict.ex
+++ b/lib/elixir/lib/hash_dict.ex
@@ -512,6 +512,6 @@ defimpl Binary.Inspect, for: HashDict do
   import Kernel, except: [inspect: 2]
 
   def inspect(dict, opts) do
-    "#HashDict<" <> Binary.Inspect.inspect(HashDict.to_list(dict), opts) <> ">"
+    "#HashDict<" <> Kernel.inspect(HashDict.to_list(dict), opts) <> ">"
   end
 end

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -142,7 +142,7 @@ defmodule IO do
   Inspects the item with options using the given device.
   """
   def inspect(device, item, opts) do
-    puts device, Binary.Inspect.inspect(item, opts)
+    puts device, Kernel.inspect(item, opts)
     item
   end
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1880,7 +1880,14 @@ defmodule Kernel do
 
   """
   defmacro inspect(arg, opts // []) do
-    quote do: Binary.Inspect.inspect(unquote(arg), unquote(opts))
+    quote do
+      arg = unquote(arg)
+      opts = unquote(opts)
+      case is_tuple(arg) && Keyword.get(opts, :raw, false) do
+        true  -> Binary.Inspect.Tuple.inspect(arg, opts)
+        false -> Binary.Inspect.inspect(arg, opts)
+      end
+    end
   end
 
   @doc """

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -336,7 +336,7 @@ defmodule Macro do
   end
 
   # All other structures
-  def to_binary(other), do: Binary.Inspect.inspect(other, raw: true)
+  def to_binary(other), do: inspect(other, raw: true)
 
   # Block keywords
   defmacrop kw_keywords, do: [:do, :catch, :rescue, :after, :else]
@@ -346,7 +346,7 @@ defmodule Macro do
   end
   defp is_kw_blocks?(_), do: false
 
-  defp module_to_binary(atom) when is_atom(atom), do: Binary.Inspect.inspect(atom, raw: true)
+  defp module_to_binary(atom) when is_atom(atom), do: inspect(atom, raw: true)
   defp module_to_binary(other), do: call_to_binary(other)
 
   defp call_to_binary(atom) when is_atom(atom),  do: atom_to_binary(atom, :utf8)

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -57,6 +57,6 @@ defimpl Binary.Inspect, for: Range do
   import Kernel, except: [inspect: 2]
 
   def inspect(Range[first: first, last: last], opts) do
-    Binary.Inspect.inspect(first, opts) <> ".." <> Binary.Inspect.inspect(last, opts)
+    Kernel.inspect(first, opts) <> ".." <> Kernel.inspect(last, opts)
   end
 end

--- a/lib/elixir/test/elixir/binary/inspect_test.exs
+++ b/lib/elixir/test/elixir/binary/inspect_test.exs
@@ -131,6 +131,12 @@ defmodule Binary.Inspect.TupleTest do
     assert inspect(RuntimeError.new) == "RuntimeError[message: \"runtime error\"]"
   end
 
+  defrecord :something, [:a, :b]
+
+  test :non_module_record do
+    assert inspect(:something.new) == ":something[a: nil, b: nil]"
+  end
+
   test :empty do
     assert inspect({}) == "{}"
   end


### PR DESCRIPTION
Removes unnecessary code in Binary.Inspect.Tuple and prepares the code so we can use the performance improvements in #950.

Also fixes #997.
