### PR TITLE
Warn on unused imports

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -30,7 +30,7 @@ defmodule Protocol do
         ]
 
         # Import the new dsl that holds the new def
-        import :macros, Protocol.DSL, warn: false
+        import :macros, Protocol.DSL
 
         # Set up a clear slate to store defined functions
         @functions []

--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -29,7 +29,7 @@ defmodule Record do
     quote do
       defmodule unquote(name) do
         @moduledoc false
-        import Record.DSL, warn: false
+        import Record.DSL
 
         @record_fields []
         @record_types  []

--- a/lib/elixir/src/elixir_macros.erl
+++ b/lib/elixir/src/elixir_macros.erl
@@ -213,7 +213,7 @@ translate({defmodule, Meta, [Ref, KV]}, S) ->
       { TRef, S }
   end,
 
-  MS = FS#elixir_scope{check_clauses=true,local=nil},
+  MS = FS#elixir_scope{local=nil},
   { elixir_module:translate(Meta, FRef, Block, MS), FS };
 
 translate({Kind, Meta, [Call]}, S) when ?FUNS(Kind) ->

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -47,7 +47,7 @@ defmodule ExUnit.Callbacks do
       @exunit_teardown_all []
 
       @before_compile unquote(__MODULE__)
-      import unquote(__MODULE__), warn: false
+      import unquote(__MODULE__)
 
       def __exunit__(:parent) do
         unquote(parent)

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -38,9 +38,9 @@ defmodule ExUnit.Case do
 
       use ExUnit.Callbacks, parent: unquote(parent)
 
-      import ExUnit.Assertions, warn: false
-      import ExUnit.Case, warn: false
-      import ExUnit.DocTest, only: [doctest: 1, doctest: 2], warn: false
+      import ExUnit.Assertions
+      import ExUnit.Case
+      import ExUnit.DocTest, only: [doctest: 1, doctest: 2]
     end
   end
 


### PR DESCRIPTION
This is a pull request to solve issue #821. After this pull request is merged, an unused import is going to trigger a warn. This warning is not per function but per module. So if you import any number of functions from a module `Foo`, as long as you use one of those functions, you won't get a warning.

There are two "issues" with this patch:
1. We only warn missing imports inside a module.
2. It is common in Elixir code to provide "DSLs". For example, in ExUnit, we provide both `setup` and `teardown` macros that you may or may not use. Since this is part of ExUnit's DSL, we don't want to emit warnings. I have originally fixed this issue by passing a `warn: false` argument to those imports. However, [in a later commit](https://github.com/elixir-lang/elixir/commit/7bae0029f274f2a8398160d9567c31cc93e58a3f) I changed the code to automatically detect if the import should warn or not. Basically, if the import is explicit (i.e. it is not generated by a macro), it warns by default. The logic is simple but it is code complexity regardless.

Yay or nay (and why)?
