### PR TITLE
Fix badmatch with Regex.captures(%r/(.)/g, "cat")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   * [ExUnit] Handle exit messages from in ExUnit
   * [Kernel] Ensure we don't splice keyword args unecessarily
   * [Kernel] Private functions used by private macros no longer emit an unused warning 
+  * [Regex]  Fix badmatch with Regex.captures(%r/(.)/g, "cat")
 
 * deprecations
   * [ExUnit] `assert left inlist right` is deprecated in favor of `assert left in right`

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -116,7 +116,8 @@ defmodule Regex do
 
   @doc """
   Runs the regular expression against the given string.
-  It returns a list with all matches or nil if no match ocurred.
+  It returns a list with all matches, nil if no match ocurred, or []
+  if it matched, /g was specified, but nothing was captured.
 
   ## Examples
 
@@ -139,6 +140,7 @@ defmodule Regex do
 
     case :re.run(string, compiled, [{ :capture, captures, return }]) do
       :nomatch -> nil
+      :match   -> []
       { :match, results } -> results
     end
   end

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -64,6 +64,7 @@ defmodule Regex.BinaryTest do
     assert Regex.captures(%r/c(?<foo>d)/g, 'no_match') == nil
     assert Regex.captures(%r/c(?<foo>d|e)/g, 'abcd abce') == [foo: 'd']
     assert Regex.captures(%r/c(?<foo>d)/g, 'abcd', return: :binary) == [foo: "d"]
+    assert Regex.captures(%r/c(.)/g, 'cat') == []
   end
 
   test :__R__ do


### PR DESCRIPTION
The above caused a badmatch because Regex.run didn't handle a return from re:run of just :match.

:match is returned if a pattern has /g but no captures are made. My fix was to have .run return [] in this case. The tests pass, but I'm a little nervous about compatibility in the field.

Dave
