### PR TITLE
One liner in mix do_rebar in deps.compile

### DIFF
--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -139,7 +139,7 @@ defmodule Mix.Tasks.Deps.Compile do
   defp find_rebar(app) do
     cond do
       File.regular?("./rebar") ->
-        "./rebar"
+        Path.join(File.cwd!, "rebar")
 
       File.regular?(Mix.Tasks.Local.Rebar.local_rebar_path) ->
         Mix.Tasks.Local.Rebar.local_rebar_path


### PR DESCRIPTION
Fix problem with an in-dep rebar not being found—need to pass in the full path to it, and not just ./rebar
