### PR TITLE
Downcase host and scheme in URIs

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -131,8 +131,16 @@ defmodule URI do
     destructure [_, _, scheme, _, authority, path, _, query, _, fragment], parts
     { userinfo, host, port } = split_authority(authority)
 
+    if authority do
+      authority = ""
+
+      if userinfo, do: authority = authority <> userinfo <> "@"
+      if host, do: authority = authority <> host
+      if port, do: authority = authority <> ":" <> integer_to_binary(port)
+    end
+
     info = URI.Info[
-      scheme: scheme, path: path, query: query,
+      scheme: scheme && String.downcase(scheme), path: path, query: query,
       fragment: fragment, authority: authority,
       userinfo: userinfo, host: host, port: port
     ]
@@ -169,7 +177,7 @@ defmodule URI do
     components = Regex.run %r/(^(.*)@)?([^:]*)(:(\d*))?/, s
     destructure [_, _, userinfo, host, _, port], nillify(components)
     port = if port, do: binary_to_integer(port)
-    { userinfo, host, port }
+    { userinfo, host && String.downcase(host), port }
   end
 
   # Regex.run returns empty strings sometimes. We want

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -123,4 +123,10 @@ defmodule URITest do
     assert URI.parse(":https")
     assert URI.parse("https")
   end
+
+  test :downcase_properly do
+    assert URI.parse("hTtP://google.com").scheme == "http"
+    assert URI.parse("http://GoOgLe.CoM").host == "google.com"
+    assert URI.parse("http://LOL:wut@GoOgLe.CoM").authority == "LOL:wut@google.com"
+  end
 end


### PR DESCRIPTION
They're treated as case insensitive anyway and it makes your matching life easier.
