### PR TITLE
Add String.valid?

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -459,6 +459,34 @@ defmodule String do
   defdelegate next_codepoint(string), to: String.Unicode
 
   @doc %B"""
+  Checks whether `str` is a valid UTF-8 string.
+
+  ## Examples
+
+      iex> String.valid?("a")
+      true
+      iex> String.valid?("ø")
+      true
+      iex> String.valid?(<<0xffff :: 16>>)
+      false
+      iex> String.valid?("asd" <> <<0xffff :: 16>>)
+      false
+
+  """
+  @spec valid?(t) :: boolean
+  def valid?(<<_ :: utf8, t :: binary>>) do
+    valid?(t)
+  end
+
+  def valid?(<<>>) do
+    true
+  end
+
+  def valid?(_) do
+    false
+  end
+
+  @doc %B"""
   Checks whether `str` is a valid codepoint.
 
   Note that the empty string is considered invalid, as are

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -228,6 +228,15 @@ defmodule StringTest do
     assert String.slice("", 0, 1) == nil
   end
 
+  test :valid? do
+    assert String.valid?("afds")
+    assert String.valid?("øsdfh")
+    assert String.valid?("dskfjあska")
+
+    refute String.valid?(<<0xffff :: 16>>)
+    refute String.valid?("asd" <> <<0xffff :: 16>>)
+  end
+
   test :valid_codepoint? do
     assert String.valid_codepoint?("a")
     assert String.valid_codepoint?("ø")


### PR DESCRIPTION
Added `String.valid?` and fixed `String.valid_codepoint?` tests.
