### PR TITLE
Add a prefix in front of return value in iex

### DIFF
--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -74,7 +74,7 @@ defmodule IEx.Server do
   end
 
   defp io_put(result) do
-    IO.puts :stdio, IO.ANSI.escape("%{yellow}#{inspect(result, IEx.inspect_opts)}")
+    IO.puts :stdio, "=> " <> IO.ANSI.escape("%{yellow}#{inspect(result, IEx.inspect_opts)}")
   end
 
   defp io_error(result) do


### PR DESCRIPTION
I want a prefix like `=>` in Ruby in front of a return value in iex because this makes easy to distinguish the return value from io.

```
iex(1)> IO.puts "a"
a
:ok
```

```
iex(1)> IO.puts "a"
a
=> :ok
```
