### PR TITLE
Simplify Enum.Iterator, second round

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -64,6 +64,89 @@ defprotocol Enum.Iterator do
   def count(collection)
 end
 
+defmodule Enum.Iterator.Defaults do
+  @moduledoc %B"""
+  This is a helper to define unimplemented default protocol functions, these
+  are `count/1`, `empty?/1` and `member?/2`.
+
+  To use it just `use Enum.Iterator.Defaults` in the protocol implementation.
+  """
+
+  @doc false
+  defmacro __using__(_opts) do
+    quote do
+      @before_compile Enum.Iterator.Defaults
+    end
+  end
+
+  @doc false
+  defmacro __before_compile__(_) do
+    quote do
+      unless Module.defines? __MODULE__, { :count, 1 } do
+        def count(coll) do
+          case Enum.Iterator.iterator(coll) do
+            { iterator, pointer } ->
+              do_count(pointer, iterator, 0)
+
+            list ->
+              length list
+          end
+        end
+
+        defp do_count(:stop, _, acc) do
+          acc
+        end
+
+        defp do_count({ _, next }, iterator, acc) do
+          do_count(iterator.(next), iterator, acc + 1)
+        end
+      end
+
+      unless Module.defines? __MODULE__, { :member?, 2 } do
+        def member?(coll, term) do
+          case Enum.Iterator.iterator(coll) do
+            { iterator, pointer } ->
+              do_member?(pointer, iterator, term)
+
+            list ->
+              List.member?(list, term)
+          end
+        end
+
+        defp do_member?(:stop, _, term) do
+          false
+        end
+
+        defp do_member?({ h, _ }, iterator, term) when h == term do
+          true
+        end
+
+        defp do_member?({ _, next }, iterator, term) do
+          do_member?(iterator.(next), iterator, term)
+        end
+      end
+
+      unless Module.defines? __MODULE__, { :empty?, 1 } do
+        def empty?(coll) do
+          case Enum.Iterator.iterator(coll) do
+            { _, :stop } ->
+              true
+
+            { _, _ } ->
+              false
+
+            [] ->
+              true
+
+            _ ->
+              false
+          end
+        end
+      end
+    end
+  end
+end
+
 defmodule Enum do
   alias Enum.Iterator, as: I
 


### PR DESCRIPTION
I feel this is very important, so I made what @yrashk proposed, it works although the documentation there would need some love, but this is just a draft to have an actual proposal with code backing it up, so the same goes for missing tests.

So yeah, I want this, anything against it that isn't code _complexity_ (it's less than 100 lines which would make implementing iterators way easier)?

Here's a stupid example:

``` elixir
defrecord LOL, [] do

end

defimpl Enum.Iterator, for: LOL do
  use Enum.Iterator.Defaults

  def iterator(_) do
    { fn _ -> :stop end, { 1, nil } }
  end
end

IO.inspect Enum.count(LOL[])      # => 1
IO.inspect Enum.member?(LOL[], 1) # => true
IO.inspect Enum.member?(LOL[], 2) # => false
IO.inspect Enum.empty?(LOL[])     # => false
```
