### PR TITLE
Remove unnecessary Mix test output

### DIFF
--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -38,7 +38,7 @@ defmodule Mix.SCM.Git do
   def checkout(opts) do
     path     = opts[:dest]
     location = opts[:git]
-    command  = %b[git clone --no-checkout "#{location}" "#{path}"]
+    command  = %b[git clone --no-checkout --progress "#{location}" "#{path}"]
 
     run_cmd_or_raise(command)
     File.cd! path, fn -> do_checkout(opts) end
@@ -46,7 +46,7 @@ defmodule Mix.SCM.Git do
 
   def update(opts) do
     File.cd! opts[:dest], fn ->
-      command = "git fetch --force"
+      command = "git fetch --force --progress"
       if opts[:tag] do
         command = command <> " --tags"
       end

--- a/lib/mix/lib/mix/shell.ex
+++ b/lib/mix/lib/mix/shell.ex
@@ -39,7 +39,7 @@ defmodule Mix.Shell do
   """
   def cmd(command, callback) do
     port = Port.open({ :spawn, to_char_list(command) },
-      [:stream, :binary, :exit_status, :hide])
+      [:stream, :binary, :exit_status, :hide, :use_stdio, :stderr_to_stdout])
     do_cmd(port, callback)
   end
 

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -7,7 +7,6 @@ System.put_env("EXUNIT_CONFIG", "none")
 target = Path.expand("../fixtures/git_repo", __FILE__)
 
 unless File.dir?(target) do
-  IO.puts "Creating git repo for tests"
   File.mkdir_p!(Path.join(target, "lib"))
 
   File.write!(Path.join(target, "mix.exs"), """)


### PR DESCRIPTION
Removes the "fatal: repository '...' does not exist" output.
Also removes the "Creating git repo for tests" output which I feel is unnecessary, or does anyone think this is needed?
