### PR TITLE
Fix capture_io behaviour when receiving :stdio or :standard_io

### DIFF
--- a/lib/ex_unit/lib/ex_unit/capture_io.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_io.ex
@@ -49,7 +49,7 @@ defmodule ExUnit.CaptureIO do
   defp map_dev(:stderr), do: :standard_error
   defp map_dev(other),   do: other
 
-  defp do_capture_io(:group_leader, fun) do
+  defp do_capture_io(device, fun) when device in [:group_leader, :standard_io] do
     original_gl = :erlang.group_leader
     capture_gl = new_group_leader(self)
     :erlang.group_leader(capture_gl, self)

--- a/lib/ex_unit/test/ex_unit/capture_io_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_io_test.exs
@@ -41,6 +41,12 @@ defmodule ExUnit.CaptureIOTest do
     end)
   end
 
+  test :capture_io_with_put_chars_to_stdio do
+    assert capture_io(:stdio, fn ->
+      :io.put_chars(:standard_io, "a")
+    end) == "a"
+  end
+
   test :capture_io_with_put_chars_to_stderr do
     assert capture_io(:stderr, fn ->
       :io.put_chars(:standard_error, "a")


### PR DESCRIPTION
`:erlang.whereis(:standard_io)` returns `:undefined` and the io lib of erlang replaces `:standard_io` with `group_leader()`(see https://github.com/erlang/otp/blob/maint/lib/stdlib/src/io.erl#L553).
So `capture_io` should treat `:standard_io` in the same way as `:group_leader`.
