### PR TITLE
Implementation of `Dict.drop`, `Dict.take`, and `Dict.split` (proposal #1069)

### DIFF
--- a/lib/elixir/lib/dict.ex
+++ b/lib/elixir/lib/dict.ex
@@ -44,6 +44,7 @@ defmodule Dict do
   @type t :: tuple | list
 
   defcallback delete(t, key) :: t
+  defcallback drop(t, [key]) :: t
   defcallback empty(t) :: t
   defcallback equal?(t, t) :: boolean
   defcallback get(t, key) :: value
@@ -58,6 +59,8 @@ defmodule Dict do
   defcallback put(t, key, value) :: t
   defcallback put_new(t, key, value) :: t
   defcallback size(t) :: non_neg_integer()
+  defcallback split(t, [key]) :: {t,t}
+  defcallback take(t, [key]) :: t
   defcallback to_list(t) :: list()
   defcallback update(t, key, (value -> value)) :: t | no_return
   defcallback update(t, key, value, (value -> value)) :: t
@@ -325,6 +328,67 @@ defmodule Dict do
   @spec pop(t, key, value) :: {value, t}
   def pop(dict, key, default // nil) do
     target(dict).pop(dict, key, default)
+  end
+
+  @doc """
+  Returns an equivalent dict, except with the given keys removed.
+
+  ## Examples
+
+      iex> Dict.drop([a: 1, b: 2], [:a])
+      [b: 2]
+
+      iex> Dict.drop([a: 1, b: 2], []) |> Enum.sort
+      [a: 1, b: 2]
+
+      iex> Dict.drop([a: 1, b: 2], [:a, :b])
+      []
+
+      iex> Dict.drop([a: 1, b: 2], [:c]) |> Enum.sort
+      [a: 1, b: 2]
+  """
+  @spec drop(t, [key]) :: t
+  def drop(dict, keys) do
+    target(dict).drop(dict, keys)
+  end
+
+  @doc """
+  Returns an equivalent dict, except with only the given keys.
+
+  ## Examples
+
+      iex> Dict.take([a: 1, b: 2], [:a])
+      [a: 1]
+
+      iex> Dict.take([a: 1, b: 2], [])
+      []
+
+      iex> Dict.take([a: 1, b: 2], [:a, :b]) |> Enum.sort
+      [a: 1, b: 2]
+
+      iex> Dict.take([a: 1, b: 2], [:c])
+      []
+
+  """
+  @spec take(t, [key]) :: t
+  def take(dict, keys) do
+    target(dict).take(dict, keys)
+  end
+
+  @doc """
+  Returns a tuple with two dicts where the first dict is `Dict.take`
+  of the given dict and keys, and the second is `Dict.drop`.
+
+      iex> Dict.split([a: 1, b: 2], [:a])
+      { [a: 1], [b: 2] }
+
+      iex> {take, drop} = Dict.split([a: 1, b: 2], [:c])
+      ...> { take, Enum.sort(drop) }
+      { [], [a: 1, b: 2] }
+  """
+  @spec split(t, [key]) :: {t,t}
+  def split(dict, keys) do
+    target(dict).split(dict, keys)
   end
 
   @doc """

--- a/lib/elixir/lib/hash_dict.ex
+++ b/lib/elixir/lib/hash_dict.ex
@@ -197,6 +197,31 @@ defmodule HashDict do
   end
 
   @doc """
+  Returns an equivalent dict, except with the given keys removed.
+  """
+  def drop(dict, []), do: dict
+
+  def drop(dict, [key|keys]) do
+    drop(delete(dict, key), keys)
+  end
+
+  @doc """
+  Returns an equivalent dict, except with only the given keys.
+  """
+  def take(dict, keys) do
+    keys_to_drop = Enum.filter(Dict.keys(dict), (fn(k) -> not Enum.member? keys, k end))
+    drop(dict, keys_to_drop)
+  end
+
+  @doc """
+  Returns a tuple with two dicts where the first dict is `Dict.take`
+  of the given dict and keys, and the second is `Dict.drop`.
+  """
+  def split(dict, keys) do
+    { take(dict, keys), drop(dict, keys) }
+  end
+
+  @doc """
   Deletes a value from the dict.
   """
   def delete(dict, key) do

--- a/lib/elixir/lib/list_dict.ex
+++ b/lib/elixir/lib/list_dict.ex
@@ -123,6 +123,28 @@ defmodule ListDict do
   end
 
   @doc """
+  Returns an equivalent dict, except with the given keys removed.
+  """
+  def drop(dict, keys) do
+    lc { k, _ } = tuple inlist dict, not Enum.member?(keys, k), do: tuple
+  end
+
+  @doc """
+  Returns an equivalent dict, except with only the given keys.
+  """
+  def take(dict, keys) do
+    lc { k, _ } = tuple inlist dict, Enum.member?(keys, k), do: tuple
+  end
+
+  @doc """
+  Returns a tuple with two dicts where the first dict is `Dict.take`
+  of the given dict and keys, and the second is `Dict.drop`.
+  """
+  def split(dict, keys) do
+    { take(dict, keys), drop(dict, keys) }
+  end
+
+  @doc """
   Deletes the entry under the given key from the dict.
   """
   def delete(dict, key) do

--- a/lib/elixir/test/elixir/dict_test.exs
+++ b/lib/elixir/test/elixir/dict_test.exs
@@ -164,6 +164,72 @@ defmodule DictTest.Common do
         assert empty_dict == Dict.empty new_dict
       end
 
+      test :drop do
+        d = Dict.drop(new_dict, [])
+        assert dicts_equal d, new_dict
+
+        d = Dict.drop(new_dict, ["first_key"])
+        assert dicts_equal d, new_dict([{"second_key", 2}])
+
+        d = Dict.drop(new_dict, ["second_key"])
+        assert dicts_equal d, new_dict([{"first_key", 1}])
+
+        d = Dict.drop(new_dict, ["first_key", "second_key"])
+        assert dicts_equal d, new_dict([])
+
+        d = Dict.drop(new_dict, ["other_key"])
+        assert dicts_equal d, new_dict
+
+        d = Dict.drop(empty_dict, ["other_key"])
+        assert dicts_equal d, empty_dict
+      end
+
+      test :take do
+        d = Dict.take(new_dict, [])
+        assert dicts_equal d, empty_dict
+
+        d = Dict.take(new_dict, ["first_key"])
+        assert dicts_equal d, new_dict([{"first_key", 1}])
+
+        d = Dict.take(new_dict, ["second_key"])
+        assert dicts_equal d, new_dict([{"second_key", 2}])
+
+        d = Dict.take(new_dict, ["first_key", "second_key"])
+        assert dicts_equal d, new_dict
+
+        d = Dict.take(new_dict, ["other_key"])
+        assert dicts_equal d, empty_dict
+
+        d = Dict.take(empty_dict, ["other_key"])
+        assert dicts_equal d, empty_dict
+      end
+
+      test :split do
+        { take, drop } = Dict.split(new_dict, [])
+        assert dicts_equal take, empty_dict
+        assert dicts_equal drop, new_dict
+
+        { take, drop } = Dict.split(new_dict, ["first_key"])
+        assert dicts_equal take, new_dict([{"first_key", 1}])
+        assert dicts_equal drop, new_dict([{"second_key", 2}])
+
+        { take, drop } = Dict.split(new_dict, ["second_key"])
+        assert dicts_equal take, new_dict([{"second_key", 2}])
+        assert dicts_equal drop, new_dict([{"first_key", 1}])
+
+        { take, drop } = Dict.split(new_dict, ["first_key", "second_key"])
+        assert dicts_equal take, new_dict
+        assert dicts_equal drop, empty_dict
+
+        { take, drop } = Dict.split(new_dict, ["other_key"])
+        assert dicts_equal take, empty_dict
+        assert dicts_equal drop, new_dict
+
+        { take, drop } = Dict.split(empty_dict, [])
+        assert dicts_equal take, empty_dict
+        assert dicts_equal drop, empty_dict
+      end
+
       defp empty_dict, do: unquote(module).new
 
       defp new_dict(list // [{"first_key", 1}, {"second_key", 2}]) do


### PR DESCRIPTION
Methods in `Dict`, `ListDict`, and `HashDict`. Includes both doctests and unit tests.

Implementation of `drop` and `take` in `HashDict` achieved using `Dict` API rather than using low-level internal methods.  (I haven't delved into `HashDict`'s internals yet.)  This may be ripe for optimization, but now we have an initial working implementation with tests.
