### PR TITLE
Only mix compile -q recompiles unnecessarly

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -85,6 +85,7 @@ defmodule Mix.Tasks.Compile.Elixir do
     Code.compiler_options(opts)
     to_compile = lc f inlist to_compile, f in stale, do: f
     compile_files(to_compile, compile_path)
+    File.touch! Path.join(compile_path, @manifest)
   end
 
   defp compile_files(false, project, compile_path, to_compile, _stale) do

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -105,6 +105,10 @@ defmodule Mix.Tasks.Compile.ElixirTest do
 
       assert_received { :mix_shell, :info, ["Compiled lib/a.ex"] }
       refute_received { :mix_shell, :info, ["Compiled lib/b.ex"] }
+
+      File.touch!("ebin/.compile.elixir", future)
+
+      assert Mix.Tasks.Compile.Elixir.run(["--quick"]) == :noop
     end
   after
     purge [A, B, C]


### PR DESCRIPTION
mix compile --quick was recompiling previously compiled files even when nothing had changed

Fixes #1061
