### PR TITLE
Deprecate IO.getb in favor of IO.getn

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -147,7 +147,10 @@ defmodule IO do
   end
 
   @doc """
-  Gets `count` bytes from the IO device. It returns:
+  Gets a number of bytes from the io device. If the
+  io device is an unicode device, count implies
+  the number of unicode codepoints to be retrieved.
+  Otherwise, the number of raw bytes. It returns:
 
   * `data` - The input characters.
 
@@ -157,21 +160,43 @@ defmodule IO do
     for instance {:error, :estale} if reading from an
     NFS file system.
   """
-  def getb(prompt, count // 1)
+  def getn(prompt, count // 1)
 
-  def getb(prompt, count) when is_integer(count) do
-    getb(group_leader, prompt, count)
+  def getn(prompt, count) when is_integer(count) do
+    getn(group_leader, prompt, count)
   end
 
-  def getb(device, prompt) do
-    getb(device, prompt, 1)
+  def getn(device, prompt) do
+    getn(device, prompt, 1)
   end
 
   @doc """
-  Gets `count` bytes from the chosen IO device.
+  Gets a number of bytes from the io device. If the
+  io device is an unicode device, count implies
+  the number of unicode codepoints to be retrieved.
+  Otherwise, the number of raw bytes.
   """
-  def getb(device, prompt, count) do
+  def getn(device, prompt, count) do
     :io.get_chars(map_dev(device), to_iodata(prompt), count)
+  end
+
+  @doc false
+  def getb(prompt, count // 1)
+
+  def getb(prompt, count) when is_integer(count) do
+    IO.write "[WARNING] IO.getb is deprecated, please use IO.getn instead\n#{Exception.format_stacktrace}"
+    getn(prompt, count)
+  end
+
+  def getb(device, prompt) do
+    IO.write "[WARNING] IO.getb is deprecated, please use IO.getn instead\n#{Exception.format_stacktrace}"
+    getn(device, prompt)
+  end
+
+  @doc false
+  def getb(device, prompt, count) do
+    IO.write "[WARNING] IO.getb is deprecated, please use IO.getn instead\n#{Exception.format_stacktrace}"
+    getn(device, prompt, count)
   end
 
   @doc """

--- a/lib/elixir/test/elixir/io_test.exs
+++ b/lib/elixir/test/elixir/io_test.exs
@@ -21,25 +21,25 @@ defmodule IOTest do
     assert File.close(file) == :ok
   end
 
-  test :getb do
+  test :getn do
     { :ok, file } = File.open(Path.expand('../fixtures/file.txt', __FILE__))
-    assert "F" == IO.getb(file, "")
-    assert "O" == IO.getb(file, "")
-    assert "O" == IO.getb(file, "")
-    assert "\n" == IO.getb(file, "")
-    assert :eof == IO.getb(file, "")
+    assert "F" == IO.getn(file, "")
+    assert "O" == IO.getn(file, "")
+    assert "O" == IO.getn(file, "")
+    assert "\n" == IO.getn(file, "")
+    assert :eof == IO.getn(file, "")
     assert File.close(file) == :ok
   end
 
-  test :getb_with_count do
+  test :getn_with_count do
     { :ok, file } = File.open(Path.expand('../fixtures/file.txt', __FILE__), [:charlist])
-    assert 'FOO' == IO.getb(file, "", 3)
+    assert 'FOO' == IO.getn(file, "", 3)
     assert File.close(file) == :ok
   end
 
-  test :getb_with_utf8_and_binary do
+  test :getn_with_utf8_and_binary do
     { :ok, file } = File.open(Path.expand('../fixtures/utf8.txt', __FILE__), [:utf8])
-    assert "Русский" == IO.getb(file, "", 7)
+    assert "Русский" == IO.getn(file, "", 7)
     assert File.close(file) == :ok
   end
 


### PR DESCRIPTION
Closes #1091
