### PR TITLE
Add String.starts_with? and String.ends_with?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.9.1.dev
 
 * enhancements
+  * [Kernel] Add `String.start_with?` and `String.end_with?`
 
 * bug fix
   * [Dict] `Enum.to_list` and `Dict.to_list` now return the same results for dicts

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -795,4 +795,50 @@ defmodule String do
     end
   end
 
+  @doc """
+  Returns true if `string` starts with any of the prefixes given, otherwise
+  false. `prefixes` can be either a single prefix or a list of prefixes.
+
+  ## Examples
+
+      iex> String.starts_with? "elixir", "eli"
+      true
+      iex> String.starts_with? "elixir", ["erlang", "elixir"]
+      true
+      iex> String.starts_with? "elixir", ["erlang", "ruby"]
+      false
+
+  """
+  @spec starts_with?(t, t | [t]) :: boolean
+
+  def starts_with?(string, prefixes) do
+    case :binary.match(string, prefixes) do
+      :nomatch -> false
+      {0, _}   -> true
+      _        -> false
+    end
+  end
+
+  @doc """
+  Returns true if `string` ends with any of the suffixes given, otherwise
+  false. `suffixes` can be either a single suffix or a list of suffixes.
+
+  ## Examples
+
+      iex> String.ends_with? "language", "age"
+      true
+      iex> String.ends_with? "language", ["youth", "age"]
+      true
+      iex> String.ends_with? "language", ["youth", "elixir"]
+      false
+
+  """
+  @spec ends_with?(t, t | [t]) :: boolean
+
+  def ends_with?(string, suffixes) do
+    string_size = size(string)
+    matches = :binary.matches(string, suffixes)
+    Enum.any? matches, fn({pos, len})-> pos + len == string_size end
+  end
+
 end

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -280,5 +280,26 @@ defmodule StringTest do
     assert String.to_float("pi") === :error
   end
 
-  
+  test :starts_with? do
+    assert String.starts_with? "hello", "he"
+    assert String.starts_with? "hello", "hello"
+    assert String.starts_with? "hello", ["hellö", "hell"]
+    assert String.starts_with? "エリクシア", "エリ"
+    refute String.starts_with? "hello", "lo"
+    refute String.starts_with? "hello", "hellö"
+    refute String.starts_with? "hello", ["hellö", "goodbye"]
+    refute String.starts_with? "エリクシア", "仙丹"
+  end
+
+  test :ends_with? do
+    assert String.ends_with? "hello", "lo"
+    assert String.ends_with? "hello", "hello"
+    assert String.ends_with? "hello", ["hellö", "lo"]
+    assert String.ends_with? "エリクシア", "シア"
+    refute String.ends_with? "hello", "he"
+    refute String.ends_with? "hello", "hellö"
+    refute String.ends_with? "hello", ["hel", "goodbye"]
+    refute String.ends_with? "エリクシア", "仙丹"
+  end
+
 end


### PR DESCRIPTION
Adds two new functions to the `String` module: `starts_with?` and `ends_with?`.
## starts_with?

Returns true if `string` starts with any of the prefixes given, otherwise false. `prefixes` can be either a single prefix or a list of prefixes.
### Examples

```
  iex> String.starts_with? "elixir", "eli"
  true
  iex> String.starts_with? "elixir", ["erlang", "elixir"]
  true
  iex> String.starts_with? "elixir", ["erlang", "ruby"]
  false
```
## ends_with?

Returns true if `string` ends with any of the suffixes given, otherwise false. `suffixes` can be either a single suffix or a list of suffixes.
### Examples

```
  iex> String.ends_with? "language", "age"
  true
  iex)> String.ends_with? "language", ["youth", "age"]
  true
  iex)> String.ends_with? "language", ["youth", "elixir"]
  false
```
## Notes
- I'm open to suggestions on names. Is it possible to create aliases which are then exported from a module (to have e.g. `start_with?` also available)?
- Would it be possible to implement these functions on the level of `Enumerable`? It would be cool to be able to run them on any collection (although it is not the first place you would look for such functions).
