### PR TITLE
Add has_keys? to Keyword

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -342,6 +342,33 @@ defmodule Keyword do
   end
 
   @doc """
+  Returns whether a list of given keys exists in the given keywords.
+
+  ## Examples
+      iex> Keyword.has_keys?([a: 1, b: 2], [:a, :b])
+      true
+      iex> Keyword.has_keys?([a: 1, b: 2], [:a])
+      true
+      iex> Keyword.has_keys?([a: 1], [:b])
+      false
+
+  """
+  @spec has_keys?(t, [atom]) :: boolean
+  def has_keys?(keywords, keys) do
+    has_keys?(keywords, keys, true)
+  end
+
+  defp has_keys?(keywords, [k | keys], true) do
+    has_keys?(keywords, keys, Keyword.has_key?(keywords, k))
+  end
+  defp has_keys?(keywords, _, false) do
+    false
+  end
+  defp has_keys?(keywords, [], acc) do
+    acc
+  end
+
+  @doc """
   Updates the key with the given function. If the key does
   not exist, raises `KeyError`.
 

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -110,6 +110,13 @@ defmodule KeywordTest do
     assert Keyword.has_key?([a: 1], :b) == false
   end
 
+  test :keys? do
+    assert Keyword.has_keys?([a: 1, b: 2], [:a, :b]) == true
+    assert Keyword.has_keys?([a: 1, b: 2], [:a]) == true
+    assert Keyword.has_keys?([a: 1, b: 2], []) == true
+    assert Keyword.has_keys?([a: 1], [:b]) == false
+  end
+
   test :update do
     assert Keyword.update([a: 1], :a, &1 * 2) == [a: 2]
     assert_raise KeyError, fn ->


### PR DESCRIPTION
This pull request add a function to answer if a list of keys are defined in a Keyword list.

This is useful when you need to know if a list of properties is defined, for example on a keyword configuration list:

``` elixir
if Keyword.has_keys?(config, [:facebook_appid, :facebook_secret]), do: something(config),
else: log(:error, "Configuration)
```
