### PR TITLE
Bring system.ex back to boostrap

### DIFF
--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -222,6 +222,7 @@ core_main() ->
     "lib/elixir/lib/binary/chars.ex",
     "lib/elixir/lib/io.ex",
     "lib/elixir/lib/path.ex",
+    "lib/elixir/lib/system.ex",
     "lib/elixir/lib/kernel/cli.ex",
     "lib/elixir/lib/kernel/error_handler.ex",
     "lib/elixir/lib/kernel/parallel_compiler.ex",


### PR DESCRIPTION
`System` is used extensively in `Kernel.CLI`, for instance. Apart from
that, it's also used by the ParallelCompiler, so if any error occurs
during compilation, we won't know about it if system.ex hasn't been compiled.

See an example of failing to report a build error -- https://travis-ci.org/elixir-lang/elixir/builds/7648053
