### PR TITLE
Don't ignore nil during aliasing. Attempt to fix #1159

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * bug fix
   * [IEx] Do not interpret ANSI codes in IEx results
   * [Mix] Fix usage of shell expressions in `Mix.Shell.cmd`
+  * [Kernel] Don't ignore :nil when dispatching protocols to avoid infinite loops.
 
 * deprecations
 

--- a/lib/elixir/src/elixir_aliases.erl
+++ b/lib/elixir/src/elixir_aliases.erl
@@ -137,7 +137,7 @@ raw_concat(['Elixir'|Args]) -> do_concat(Args);
 raw_concat(Args)            -> do_concat(Args).
 
 do_concat(Args) ->
-  Aliases = [to_partial(Arg) || Arg <- Args, Arg /= nil],
+  Aliases = [to_partial(Arg) || Arg <- Args],
   "Elixir" ++ lists:concat(Aliases).
 
 to_partial(Arg) when is_binary(Arg) -> to_partial(binary_to_list(Arg));

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -161,6 +161,7 @@ defmodule ModuleTest do
     assert Module.concat(Foo, 'Bar') == Foo.Bar
     assert Module.concat(Foo, Bar.Baz) == Foo.Bar.Baz
     assert Module.concat(Foo, "Bar.Baz") == Foo.Bar.Baz
+    assert Module.concat(Bar, :nil) == :"Elixir.Bar.nil"
   end
 
   test :safe_concat do

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -104,6 +104,12 @@ defmodule ProtocolTest do
     false = ProtocolTest.WithAll.blank(ProtocolTest.Foo.new(a: 1))
   end
 
+  test :protocol_with_nil_record do
+    assert_raise UndefinedFunctionError, fn ->
+      ProtocolTest.WithOnly.blank({:nil})
+    end
+  end
+
   test :protocol_for do
     assert_protocol_for(ProtocolTest.WithAll, Atom, :foo)
     assert_protocol_for(ProtocolTest.WithAll, Function, fn(x) -> x end)


### PR DESCRIPTION
Attempting to fix https://github.com/elixir-lang/elixir/issues/1159.

I'm not sure if this is the right fix because I don't know the logic why `:nil` was ignored during aliasing. It passes all the tests with this change and now `Enum.reverse {nil}` results in the error `(UndefinedFunctionError) undefined function: :"Elixir.Enumerable.nil".reduce/3  like any other {:atom} passes to reverse.`

Also, I added a test case (although its not a perfect test since it will detect an infinite loop by hanging rather than playing with something more sophisticated which terminates).
