### PR TITLE
Set load paths for dependencies with Makefile

### DIFF
--- a/lib/mix/lib/mix/deps.ex
+++ b/lib/mix/lib/mix/deps.ex
@@ -255,7 +255,7 @@ defmodule Mix.Deps do
       |> Enum.filter(File.dir?(&1))
   end
 
-  def load_paths(Mix.Dep[manager: nil, opts: opts]) do
+  def load_paths(Mix.Dep[manager: manager, opts: opts]) when manager in [:make, nil] do
     [ Path.join(opts[:dest], "ebin") ]
   end
 


### PR DESCRIPTION
A recent update (036d016 2013-06-02; Rebar dep with no config is given rebar
as manager) introduced :make as a value for a dependency's manager, but
Mix.Deps.load_path has no function clause to handle this.

Add :make to the nil manager clause, as it seems the closest equivalent.
