### PR TITLE
Fix IEx's module source lookup

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -286,8 +286,8 @@ defmodule IEx.Helpers do
     source = module.module_info(:compile)[:source]
 
     case source do
-      { :source, source } -> list_to_binary(source)
-      _ -> nil
+      nil -> nil
+      source -> list_to_binary(source)
     end
   end
 


### PR DESCRIPTION
`Module.module_info(:compile)[:source]` returns the value, not a tuple
as the code was expecting, making r/1 think that no module has a
source. Fix this expectation.
