### PR TITLE
Added -v --version option to all elixir commands.

### DIFF
--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -102,9 +102,9 @@ defmodule Kernel.CLI do
 
   # Process shared options
 
-  defp process_shared(["-v"|t], config) do
+  defp process_shared([opt|t], config) when opt in ["-v", "--version"] do
     IO.puts "Elixir #{System.version}"
-    process_shared t, config
+    System.halt 0
   end
 
   defp process_shared(["-pa",h|t], config) do

--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -5,10 +5,13 @@ defmodule Mix.CLI do
   Runs Mix according to the command line arguments.
   """
   def run(args // System.argv) do
-    if help?(args) do
-      display_banner()
-    else
-      proceed(args)
+    case check_for_shortcuts(args) do
+      :help ->
+        display_banner()
+      :version ->
+        display_version()
+      nil ->
+        proceed(args)
     end
   end
 
@@ -68,6 +71,16 @@ defmodule Mix.CLI do
     run_task "help", []
   end
 
-  defp help?([first_arg|_]) when first_arg in ["--help", "-h", "-help"], do: true
-  defp help?(_), do: false
+  defp display_version() do
+    IO.puts "Elixir #{System.version}"
+  end
+
+  # Check for --help or --version in the args
+  defp check_for_shortcuts([first_arg|_]) when first_arg in
+      ["--help", "-h", "-help"], do: :help
+
+  defp check_for_shortcuts([first_arg|_]) when first_arg in
+      ["--version", "-v"], do: :version
+
+  defp check_for_shortcuts(_), do: nil
 end

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -58,6 +58,22 @@ defmodule Mix.CLITest do
     end
   end
 
+  test "--help smoke test" do
+    in_fixture "only_mixfile", fn ->
+      output = mix "--help"
+      assert output =~ %r"mix compile\s+# Compile source files"
+      refute output =~ %r"mix invalid"
+    end
+  end
+
+  test "--version smoke test" do
+    in_fixture "only_mixfile", fn ->
+      output = mix "--version"
+      assert output =~ %r"Elixir [0-9\.a-z]+"
+      refute output =~ %r"Something silly"
+    end
+  end
+
   test "help TASK smoke test" do
     in_fixture "only_mixfile", fn ->
       output = mix "help compile"


### PR DESCRIPTION
Fixes #1178

This adds support for `-v` and `--version` to all command line entry points into elixir.

It still has the problem that @alco pointed out with `iex` there is an extra header printed out above.
