### PR TITLE
Remove unneeded `case`

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -385,10 +385,7 @@ defmodule Path do
     join(left, atom_to_binary(right))
 
   defp major_os_type do
-    case :os.type do
-      { maj, _ } -> maj
-      maj -> maj
-    end
+    :os.type |> elem(0)
   end
 
   defp do_join(<<uc_letter, ?:, rest :: binary>>, relativename, [], :win32) when uc_letter in ?A..?Z, do:


### PR DESCRIPTION
`:os.type/0` always returns a tuple in R16B
