### PR TITLE
remove dependency on bash in shell scripts

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -26,7 +26,7 @@ fi
 
 readlink_f () {
   cd "$(dirname "$1")" > /dev/null
-  local filename="$(basename "$1")"
+  filename="$(basename "$1")"
   if [ -h "$filename" ]; then
     readlink_f "$(readlink "$filename")"
   else

--- a/bin/elixirc
+++ b/bin/elixirc
@@ -14,7 +14,7 @@ fi
 
 readlink_f () {
   cd "$(dirname "$1")" > /dev/null
-  local filename="$(basename "$1")"
+  filename="$(basename "$1")"
   if [ -h "$filename" ]; then
     readlink_f "$(readlink "$filename")"
   else

--- a/bin/iex
+++ b/bin/iex
@@ -25,7 +25,7 @@ fi
 
 readlink_f () {
   cd "$(dirname "$1")" > /dev/null
-  local filename="$(basename "$1")"
+  filename="$(basename "$1")"
   if [ -h "$filename" ]; then
     readlink_f "$(readlink "$filename")"
   else


### PR DESCRIPTION
Elixir currently doesn't build on SmartOS (Illumos/OpenSolaris based OS), because it evaluates shell scripts defined as #!/bin/sh in strict sh mode, but Elixir's shell scripts are actually not sh compliant because of the use of the Bash specific 'local' keyword.

The above means that Elixir almost certainly won't build on any platform that doesn't use bash.

This Pull request simply removes the use of the local keyword, since it's use doesn't seem to have any significant meaning in Elixir's shell scripts, which makes it now possible to build Elixir on SmartOS and probably any other platform with strict shell evaluating behaviour, or without bash at all.
