### PR TITLE
Add a --force option to `mix local.install`.

### DIFF
--- a/lib/mix/lib/mix/tasks/local.install.ex
+++ b/lib/mix/lib/mix/tasks/local.install.ex
@@ -17,26 +17,31 @@ defmodule Mix.Tasks.Local.Install do
 
       mix some_task
 
+  ## Command line options
+
+  * `--force` forces installation without a shell prompt. Primarily
+    intended for automation in build systems like Make.
+
   """
 
   def run(argv) do
-    { _, argv } = OptionParser.parse(argv)
+    { opts, argv } = OptionParser.parse(argv, switches: [force: :boolean])
     case argv do
       [] ->
         raise Mix.Error, message: "expected PATH to be given, please use `mix local.install PATH`"
       [path|_] ->
-        do_install path
+        do_install path, opts
     end
   end
 
-  defp do_install(path) do
+  defp do_install(path, opts) do
     beam = Mix.Utils.read_path(path)
     { :module, module } = get_module(path, beam)
 
     validate_module_name!(path, module)
     task_name = Mix.Task.task_name(module)
 
-    if Mix.shell.yes?("Are you sure you want to install task #{inspect task_name}?") do
+    if opts[:force] || Mix.shell.yes?("Are you sure you want to install task #{inspect task_name}?") do
       tasks = Mix.Local.tasks_path
       File.mkdir_p! tasks
       create_file Path.join(tasks, "#{module}.beam"), beam


### PR DESCRIPTION
Useful for makefiles and such where automation is desired. While it would be possible to just pipe a `Y` value into the Mix process, that ends up in shell-specific land. Easier to just have a portable `--force`.
