### PR TITLE
Improve efficiency of HashDict contract

### DIFF
--- a/lib/elixir/test/elixir/hash_dict_test.exs
+++ b/lib/elixir/test/elixir/hash_dict_test.exs
@@ -258,6 +258,12 @@ defmodule HashDictTest do
     assert HashDict.size(dict) == 122
   end
 
+  test :trie_contract do
+    dict = filled_dict(120)
+    dict = Enum.reduce 16..120, dict, fn(x, acc) -> HashDict.delete(acc, x) end
+    assert (Enum.filter 1..120, fn(x) -> HashDict.get(dict, x) == x end) == (Enum.sort 1..15)
+  end
+
   defp smoke_test(range) do
     { dict, _ } = Enum.reduce range, { HashDict.new, 1 }, fn(x, { acc, i }) ->
       acc = HashDict.put(acc, x, x)


### PR DESCRIPTION
When contracting in size the HashDict does not need to relocate (re-hash) key-value pairs. It is not required because each of the deepest nodes (8 element tuples) in the trie become a bucket (list) on contraction. This bucket contains all the key-value pairs in that node (8 element tuple).

Discovered while porting hashdict to erlang's dict API (see https://github.com/fishcakez/hashdict).
