### PR TITLE
Fix compiler_options docblock formatting errors

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -251,13 +251,13 @@ defmodule Code do
 
   Available options are:
 
-  * docs       - when true, retain documentation in the compiled module.
-                 True by default;
-  * debug_info - when true, retain debug information in the compiled module.
-                 This allows a developer to reconstruct the original source
-                 code, for such reasons, false by default;
-  * ignore_module_conflict - when true, override modules that were already defined
-                             without raising errors, false by default;
+  * `:docs`       - when true, retain documentation in the compiled module.
+                    True by default;
+  * `:debug_info` - when true, retain debug information in the compiled module.
+                    This allows a developer to reconstruct the original source
+                    code, for such reasons, false by default;
+  * `:ignore_module_conflict` - when true, override modules that were already defined
+                                without raising errors, false by default;
 
   """
   def compiler_options(opts) do


### PR DESCRIPTION
This fixes markdown formatting errors with a few options in Code.compiler_options(opts)
