### PR TITLE
On Windows Erlang parameters were not getting passed to elixir.bat in a proper way

### DIFF
--- a/bin/elixir.bat
+++ b/bin/elixir.bat
@@ -108,4 +108,4 @@ REM Others should give a problem
 echo ERROR: Parameter %par% is not allowed before the .ex file
 exit /B -1
 :run
-echo erl -env ERL_LIBS %ERL_LIBS%;"%~dp0\..\lib" -noshell %ELIXIR_ERL_OPTS% %parsErlang% -s elixir start_cli %beforeExtra% -extra %*
+erl -env ERL_LIBS %ERL_LIBS%;"%~dp0\..\lib" -noshell %ELIXIR_ERL_OPTS% %parsErlang% -s elixir start_cli %beforeExtra% -extra %*


### PR DESCRIPTION
I altered the batch file so it parses, translates some and validates parameters that need to be fed into the Erlang run-time.

It might not look nice, but it works.

Fixes issue #1149 
