### PR TITLE
With the new elixir.bat version the batch script only worked from the ./bin folder on windows

### DIFF
--- a/bin/elixir.bat
+++ b/bin/elixir.bat
@@ -32,6 +32,9 @@ set parsErlang=
 rem Make sure we keep a copy of all parameters
 set allPars=%*
 
+rem Get the original path name from the batch file
+set originPath=%~dp0
+
 rem Optional parameters before the "-extra" parameter
 set beforeExtra=
 
@@ -108,4 +111,4 @@ REM Others should give a problem
 echo ERROR: Parameter %par% is not allowed before the .ex file
 exit /B -1
 :run
-erl -env ERL_LIBS %ERL_LIBS%;"%~dp0\..\lib" -noshell %ELIXIR_ERL_OPTS% %parsErlang% -s elixir start_cli %beforeExtra% -extra %*
+erl -env ERL_LIBS %ERL_LIBS%;"%originPath%\..\lib" -noshell %ELIXIR_ERL_OPTS% %parsErlang% -s elixir start_cli %beforeExtra% -extra %*


### PR DESCRIPTION
Apparently, when shifting parameters, the %~dp0 is not preserved, 
so it needs to keep this value. This will fix things like iex on Windows, which just crashed with the version I just committed; my apologies !
