### PR TITLE
Fixed path tests when running on Windows: removed drive prefixes from check

### DIFF
--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -81,9 +81,9 @@ defmodule PathTest do
   end
 
   test :absname_with_binary do
-    assert Path.absname("/foo/bar") == "/foo/bar"
-    assert Path.absname("/foo/bar/") == "/foo/bar"
-    assert Path.absname("/foo/bar/../bar") == "/foo/bar/../bar"
+    assert (Path.absname("/foo/bar") |> strip_drive_letter_if_windows) == "/foo/bar"
+    assert (Path.absname("/foo/bar/") |> strip_drive_letter_if_windows)  == "/foo/bar"
+    assert (Path.absname("/foo/bar/../bar")  |> strip_drive_letter_if_windows) == "/foo/bar/../bar"
 
     assert Path.absname("bar", "/foo") == "/foo/bar"
     assert Path.absname("bar/", "/foo") == "/foo/bar"
@@ -93,10 +93,10 @@ defmodule PathTest do
   end
 
   test :absname_with_list do
-    assert Path.absname('/foo/bar') == '/foo/bar'
-    assert Path.absname('/foo/bar/') == '/foo/bar'
-    assert Path.absname('/foo/bar/.') == '/foo/bar/.'
-    assert Path.absname('/foo/bar/../bar') == '/foo/bar/../bar'
+    assert (Path.absname('/foo/bar') |> strip_drive_letter_if_windows)  == '/foo/bar'
+    assert (Path.absname('/foo/bar/') |> strip_drive_letter_if_windows)  == '/foo/bar'
+    assert (Path.absname('/foo/bar/.')  |> strip_drive_letter_if_windows)  == '/foo/bar/.'
+    assert (Path.absname('/foo/bar/../bar')  |> strip_drive_letter_if_windows) == '/foo/bar/../bar'
   end
 
   test :expand_path_with_user_home do
@@ -115,26 +115,26 @@ defmodule PathTest do
   end
 
   test :expand_path_with_binary do
-    assert Path.expand("/foo/bar") == "/foo/bar"
-    assert Path.expand("/foo/bar/") == "/foo/bar"
-    assert Path.expand("/foo/bar/.") == "/foo/bar"
-    assert Path.expand("/foo/bar/../bar") == "/foo/bar"
+    assert (Path.expand("/foo/bar") |> strip_drive_letter_if_windows) == "/foo/bar"
+    assert (Path.expand("/foo/bar/")  |> strip_drive_letter_if_windows) == "/foo/bar"
+    assert (Path.expand("/foo/bar/.")  |> strip_drive_letter_if_windows)== "/foo/bar"
+    assert (Path.expand("/foo/bar/../bar")  |> strip_drive_letter_if_windows) == "/foo/bar"
 
-    assert Path.expand("bar", "/foo") == "/foo/bar"
-    assert Path.expand("bar/", "/foo") == "/foo/bar"
-    assert Path.expand("bar/.", "/foo") == "/foo/bar"
-    assert Path.expand("bar/../bar", "/foo") == "/foo/bar"
-    assert Path.expand("../bar/../bar", "/foo/../foo/../foo") == "/bar"
+    assert (Path.expand("bar", "/foo") |> strip_drive_letter_if_windows)== "/foo/bar"
+    assert (Path.expand("bar/", "/foo") |> strip_drive_letter_if_windows)== "/foo/bar"
+    assert (Path.expand("bar/.", "/foo") |> strip_drive_letter_if_windows)== "/foo/bar"
+    assert (Path.expand("bar/../bar", "/foo") |> strip_drive_letter_if_windows)== "/foo/bar"
+    assert (Path.expand("../bar/../bar", "/foo/../foo/../foo")|> strip_drive_letter_if_windows) == "/bar"
 
     full = Path.expand("foo/bar")
     assert Path.expand("bar/../bar", "foo") == full
   end
 
   test :expand_path_with_list do
-    assert Path.expand('/foo/bar') == '/foo/bar'
-    assert Path.expand('/foo/bar/') == '/foo/bar'
-    assert Path.expand('/foo/bar/.') == '/foo/bar'
-    assert Path.expand('/foo/bar/../bar') == '/foo/bar'
+    assert (Path.expand('/foo/bar')|> strip_drive_letter_if_windows)  == '/foo/bar'
+    assert (Path.expand('/foo/bar/')|> strip_drive_letter_if_windows)  == '/foo/bar'
+    assert (Path.expand('/foo/bar/.')|> strip_drive_letter_if_windows)  == '/foo/bar'
+    assert (Path.expand('/foo/bar/../bar')|> strip_drive_letter_if_windows)  == '/foo/bar'
   end
 
   test :relative_to_with_binary do
@@ -249,5 +249,12 @@ defmodule PathTest do
     assert Path.split('') == []
     assert Path.split('foo') == ['foo']
     assert Path.split('/foo/bar') == ['/', 'foo', 'bar']
+  end
+  
+  if match? { :win32, _ }, :os.type do
+    defp strip_drive_letter_if_windows([_d,?:|rest]), do: rest
+    defp strip_drive_letter_if_windows(<<_d,?:,rest::binary>>), do: rest
+  else
+    defp strip_drive_letter_if_windows(path), do: path
   end
 end


### PR DESCRIPTION
Fixes for #1280.

This gets the amount of errors down to 3 or 5 on my machine:

```
==> kernel (exunit)
................................................................................................................................................................
................................................................................................................................................................
................................................................................................................................................................
..................................................F................................................................................** (TokenMissingError) nofile
:1: missing terminator: ] (for "[" starting at line 1)
......................................** (throw) 1
............................................** (SyntaxError) nofile:1: unexpected token: end
.    :erlang.system_info({:purify,'Node: nonode@nohost'})
    init.erl:757: :init.do_boot/3

.........** (ErlangError) erlang error: 1
......    erl_eval.erl:569: :erl_eval.do_apply/6
    src/elixir.erl:152: :elixir.eval_forms/3
    c:/dev/elixir/elixir/lib/elixir/lib/code.ex:113: Code.do_eval_string/3
    c:/dev/elixir/elixir/lib/elixir/lib/kernel/cli.ex:264: Kernel.CLI.process_command/2
    c:/dev/elixir/elixir/lib/elixir/lib/enum.ex:604: Enum."-map/2-lc$^0/1-0-"/2
    c:/dev/elixir/elixir/lib/elixir/lib/kernel/cli.ex:18: Kernel.CLI."-main/1-fun-2-"/1
    c:/dev/elixir/elixir/lib/elixir/lib/kernel/cli.ex:39: Kernel.CLI.run/2
    init.erl:1054: :init.start_it/1

................................................................................................................................................................
...............................................................................................................** (SyntaxError) nofile:1: invalid token: \x{3042
}
.    :erlang.system_info({:purify,'Node: nonode@nohost'})
    init.erl:757: :init.do_boot/3

...** (SyntaxError) nofile:1: invalid token: µ
    :erlang.system_info({:purify,'Node: nonode@nohost'})
    init.erl:757: :init.do_boot/3

.F...........F...............................................................................................

Failures:

  1) test_argv (SystemTest)
     ** (SyntaxError) nofile:1: syntax error before: 'ERROR'
     stacktrace:

  2) test_possible_deadlock (Kernel.CLI.CompileTest)
     ** (ExUnit.AssertionError) expected foo.ex to miss module Bar
     at test/elixir/kernel/cli_test.exs:88

  3) test_rm_rf_with_symlink (FileTest.Rm)
     ** (ExUnit.AssertionError) Expected false to be true
     at test/elixir/file_test.exs:774

Finished in 8.3 seconds (5.2s on load, 3.1s on tests)
1093 tests, 3 failures
make: *** [test_kernel] Error 1

Tom@Jommeke /c/dev/elixir/elixir
$ make test
==> elixir (compile)
==> elixir (eunit)
  All 213 tests passed.

==> kernel (exunit)
................................................................................................................................................................
................................................................................................................................................................
................................................................................................................................................................
..............................................................................F................................** (TokenMissingError) nofile:1: missing terminat
or: ] (for "[" starting at line 1)
.    :erlang.system_info({:purify,'Node: nonode@nohost'})
    init.erl:757: :init.do_boot/3

........................F.** (throw) 1
......................................................................** (SyntaxError) nofile:1: unexpected token: end
.    :erlang.system_info({:purify,'Node: nonode@nohost'})
    init.erl:757: :init.do_boot/3

.........** (ErlangError) erlang error: 1
...................................................................................................................................F............................
..................................................................................................** (SyntaxError) nofile:1: invalid token: \x{3042}
..........................F..** (SyntaxError) nofile:1: invalid token: µ
    :erlang.system_info({:purify,'Node: nonode@nohost'})
    init.erl:757: :init.do_boot/3

............F...............................................................................................

Failures:

  1) test_argv (SystemTest)
     ** (SyntaxError) nofile:1: syntax error before: 'ERROR'
     stacktrace:

  2) test_at_exit (SystemTest)
     ** (ExUnit.ExpectationError)
                  expected: []
       to be equal to (==): '0\n'
     at test/elixir/system_test.exs:51

  3) test_at_exit (Kernel.CLI.AtExitTest)
     ** (ExUnit.ExpectationError)
                  expected: 'goodbye '
       to be equal to (==): 'goodbye cruel world with status 0\n'
     at test/elixir/kernel/cli_test.exs:39

  4) test_possible_deadlock (Kernel.CLI.CompileTest)
     ** (ExUnit.AssertionError) expected foo.ex to miss module Bar
     at test/elixir/kernel/cli_test.exs:88

  5) test_rm_rf_with_symlink (FileTest.Rm)
     ** (ExUnit.AssertionError) Expected false to be true
     at test/elixir/file_test.exs:774

Finished in 8.4 seconds (5.1s on load, 3.2s on tests)
1093 tests, 5 failures
make: *** [test_kernel] Error 1
```

Apparently the `test_at_exit` code does not work all the time...
