### PR TITLE
Added .gitattribute for fixtures in tests, so CRLF is not autoconverted

### DIFF
--- a/lib/elixir/test/elixir/fixtures/.gitattributes
+++ b/lib/elixir/test/elixir/fixtures/.gitattributes
@@ -1,0 +1,1 @@
+*.txt text eol=lf


### PR DESCRIPTION
This should fix the issues @AlbertMoscow has with the line endings.

It a partial fix  for #1280.
