### PR TITLE
Fix the rebar wrapper on windows

### DIFF
--- a/lib/mix/lib/mix/rebar.ex
+++ b/lib/mix/lib/mix/rebar.ex
@@ -150,9 +150,10 @@ defmodule Mix.Rebar do
 
   defp wrap_cmd(nil), do: nil
   defp wrap_cmd(rebar) do
-    case :os.type do
-      { :win32, _ } -> "escript.exe #{rebar}"
-      _ -> rebar
+    if match?({ :win32, _ }, :os.type) and not String.ends_with?(rebar,".cmd") do
+      "escript.exe #{rebar}"
+    else
+      rebar
     end
   end
 end


### PR DESCRIPTION
System.find_executable for rebar returns a rebar.cmd file, which should not
be wrapped by escript. We now have an extra check that verifies whether the
invoked file is indeed a cmd file.
