### PR TITLE
Show original statement if assert or refute fails

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -53,7 +53,7 @@ defmodule ExUnit.Assertions do
     translate_assertion(expected, fn ->
       quote do
         value = unquote(expected)
-        assert value, "Expected #{inspect value} to be true"
+        assert value, "Expected #{unquote(Macro.to_string(expected))} to be true"
       end
     end)
   end
@@ -73,7 +73,7 @@ defmodule ExUnit.Assertions do
     contents = translate_assertion({ :!, [], [expected] }, fn ->
       quote do
         value = unquote(expected)
-        assert !value, "Expected #{inspect value} to be false"
+        assert !value, "Expected #{unquote(Macro.to_string(expected))} to be false"
       end
     end)
 

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -2,6 +2,8 @@ Code.require_file "../test_helper.exs", __DIR__
 
 defmodule ExUnit.AssertionsTest.Value do
   def tuple, do: { 2, 1 }
+  def happy?, do: false
+  def sad?, do: true
 end
 
 alias ExUnit.AssertionsTest.Value
@@ -28,6 +30,15 @@ defmodule ExUnit.AssertionsTest do
     rescue
       error in [ExUnit.AssertionError] ->
         "This should be true" = error.message
+    end
+  end
+
+  test :assert_when_value_evaluates_to_false do
+    try do
+      "This should never be tested" = assert Value.happy?
+    rescue
+      error in [ExUnit.AssertionError] ->
+        "Expected Value.happy?() to be true" = error.message
     end
   end
 
@@ -68,6 +79,15 @@ defmodule ExUnit.AssertionsTest do
     rescue
       error in [ExUnit.AssertionError] ->
         "This should be false" = error.message
+    end
+  end
+
+  test :refute_when_value_evaluates_to_true do
+    try do
+      "This should never be tested" = refute Value.sad?
+    rescue
+      error in [ExUnit.AssertionError] ->
+        "Expected Value.sad?() to be false" = error.message
     end
   end
 


### PR DESCRIPTION
If the asserted statement evaluates to false, show the unevaluated
statement in the assertion error output message for more context about
the failure. Refute also now follows similar semantics.

Fixes #1276
