### PR TITLE
Improve error message when asserting or refuting a statement that evaluates to a boolean

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -53,7 +53,16 @@ defmodule ExUnit.Assertions do
     translate_assertion(expected, fn ->
       quote do
         value = unquote(expected)
-        assert value, "Expected #{unquote(Macro.to_string(expected))} to be true"
+
+        unless value do
+          raise ExUnit.ExpectationError,
+            description: unquote(Macro.to_string(expected)),
+            reason: "be",
+            expected: "true",
+            actual: inspect(value)
+        end
+
+        value
       end
     end)
   end
@@ -73,7 +82,16 @@ defmodule ExUnit.Assertions do
     contents = translate_assertion({ :!, [], [expected] }, fn ->
       quote do
         value = unquote(expected)
-        assert !value, "Expected #{unquote(Macro.to_string(expected))} to be false"
+
+        if value do
+          raise ExUnit.ExpectationError,
+            description: unquote(Macro.to_string(expected)),
+            reason: "be",
+            expected: "false",
+            actual: inspect(value)
+        end
+
+        true
       end
     end)
 

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -19,8 +19,8 @@ defmodule ExUnit.AssertionsTest do
     try do
       "This should never be tested" = assert false
     rescue
-      error in [ExUnit.AssertionError] ->
-        "Expected false to be true" = error.message
+      error in [ExUnit.ExpectationError] ->
+        "Expected false to be true. Instead got false" = error.message
     end
   end
 
@@ -37,8 +37,8 @@ defmodule ExUnit.AssertionsTest do
     try do
       "This should never be tested" = assert Value.happy?
     rescue
-      error in [ExUnit.AssertionError] ->
-        "Expected Value.happy?() to be true" = error.message
+      error in [ExUnit.ExpectationError] ->
+        "Expected Value.happy?() to be true. Instead got false" = error.message
     end
   end
 
@@ -68,8 +68,8 @@ defmodule ExUnit.AssertionsTest do
     try do
       "This should never be tested" = refute true
     rescue
-      error in [ExUnit.AssertionError] ->
-        "Expected true to be false" = error.message
+      error in [ExUnit.ExpectationError] ->
+        "Expected true to be false. Instead got true" = error.message
     end
   end
 
@@ -86,8 +86,8 @@ defmodule ExUnit.AssertionsTest do
     try do
       "This should never be tested" = refute Value.sad?
     rescue
-      error in [ExUnit.AssertionError] ->
-        "Expected Value.sad?() to be false" = error.message
+      error in [ExUnit.ExpectationError] ->
+        "Expected Value.sad?() to be false. Instead got true" = error.message
     end
   end
 

--- a/lib/ex_unit/test/ex_unit/capture_io_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_io_test.exs
@@ -280,8 +280,8 @@ defmodule ExUnit.CaptureIOTest do
         assert false
       end)
     rescue
-      error in [ExUnit.AssertionError] ->
-        "Expected false to be true" = error.message
+      error in [ExUnit.ExpectationError] ->
+        "Expected false to be true. Instead got false" = error.message
     end
 
     # Ensure no leakage on failures


### PR DESCRIPTION
Here's the follow up of https://github.com/elixir-lang/elixir/pull/1299 with improvements to failed assertion error messages. This switches from `AssertionError` to `ExpectationError` for improved formatting and support for a description (the evaluated result).

There were a few instances of `assert false` and `refute true` in the tests, which now seem pretty verbose. Although, I couldn't think of a good reason you would actually want to write that outside of a test specifically for `ExUnit`. Let me know if you think that should be fixed up at all though.
