### PR TITLE
Fixed some incorrect markdown in binary_to_list/3's documentation.

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -488,7 +488,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Like binary_to_list/1, but returns a list of integers corresponding to the bytes
+  Like `binary_to_list/1`, but returns a list of integers corresponding to the bytes
   from position `start` to position `stop` in `binary`. Positions in the binary
   are numbered starting from 1.
   """


### PR DESCRIPTION
The docs for binary_to_list/3 weren't monospacing their reference to binary_to_list/1, which resulted in some bad italicization.
