### PR TITLE
Don't leak matched variables when calling `match?`

### DIFF
--- a/lib/mix/lib/mix/deps/converger.ex
+++ b/lib/mix/lib/mix/deps/converger.ex
@@ -67,7 +67,8 @@ defmodule Mix.Deps.Converger do
     cond do
       contains_dep?(upper_breadths, dep) ->
         all(t, acc, upper_breadths, current_breadths, config, callback, rest)
-      match?({ diverged_acc, true }, diverged_dep?(acc, dep)) ->
+      match?({ _, true }, diverged_dep?(acc, dep)) ->
+        { diverged_acc, true } = diverged_dep?(acc, dep)
         all(t, diverged_acc, upper_breadths, current_breadths, config, callback, rest)
       true ->
         { dep, rest } = callback.(dep, rest)


### PR DESCRIPTION
I wrapped up the `match?` macro in an IIFE and added a tiny test. The test is sorta weird so let me know if that needs to be improved at all.

Fixes https://github.com/elixir-lang/elixir/issues/1304
