### PR TITLE
Tests on windows now intercept stderr from elixir(c) invocations

### DIFF
--- a/lib/elixir/test/elixir/test_helper.exs
+++ b/lib/elixir/test/elixir/test_helper.exs
@@ -18,14 +18,20 @@ defmodule PathHelpers do
     Path.join(tmp_path, extra)
   end
 
+  def elixirc(args) do
+    runcmd(elixirc_executable,args)
+  end
+  
+  def elixir(args) do
+    runcmd(elixir_executable,args)
+  end
+  
   if match? { :win32, _ }, :os.type do
     def executable_extension, do: ".bat"
-    def elixirc(args), do: :os.cmd binary_to_list("#{elixirc_executable} #{:unicode.characters_to_binary(args)} 2>&1")
-    def elixir(args), do: :os.cmd binary_to_list("#{elixir_executable} #{:unicode.characters_to_binary(args)} 2>&1")
+    defp runcmd(executable,args), do: :os.cmd binary_to_list("#{executable} #{:unicode.characters_to_binary(args)} 2>&1")
   else
     def executable_extension, do: ""
-    def elixirc(args), do: :os.cmd binary_to_list("#{elixirc_executable} #{:unicode.characters_to_binary(args)}")
-    def elixir(args), do: :os.cmd binary_to_list("#{elixir_executable} #{:unicode.characters_to_binary(args)}")
+    defp runcmd(executable,args), do: :os.cmd binary_to_list("#{executable} #{:unicode.characters_to_binary(args)}")
   end
 
   def elixir_executable do
@@ -35,7 +41,6 @@ defmodule PathHelpers do
   def elixirc_executable do
     Path.expand("../../../../../bin/elixirc#{executable_extension}", __FILE__)
   end
-
 end
 
 defmodule CompileAssertion do


### PR DESCRIPTION
Previously tests on windows did not intercept stderr when they were
invoked through `:os.cmd`, so we now add a pipe redirect from `stderr`
to `stdout` when invoking elixir(c) on windows.
![image](https://f.cloud.github.com/assets/155977/694658/2774182a-dcb6-11e2-97f2-5a6cabd53c92.png)

Fixes some more issues from #1280.
