### PR TITLE
Fixed doc typos in Enum

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -277,7 +277,7 @@ defmodule Enum do
 
   @doc """
   Invokes the given `fun` for each item in the `collection`.
-  Returns the `collection` itself. `fun` can take two parameters,
+  Returns `:ok`. `fun` can take two parameters,
   in which case the second parameter will be the iteration index.
 
   ## Examples


### PR DESCRIPTION
Adding examples in doc for `Enum.each` generates string output during `make test` (during the doctest phase). Since `each` is used for its side effects, I couldn't think of a simple example that generated usable output and didn't put something on stdout.
