### PR TITLE
Fixed typos in Kernel

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2701,7 +2701,7 @@ defmodule Kernel do
 
   An else option can be given to specify the opposite:
 
-      if(foo, do: bar, else: bar)
+      if(foo, do: bar, else: baz)
 
   ## Blocks examples
 


### PR DESCRIPTION
This line of code is referenced from the blog post by the following link: https://peepcode.com/blog/2013/elixir-is-for-programmers
