### PR TITLE
kwlist are inspected as a list of tuples with raw: true

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -215,7 +215,7 @@ defimpl Inspect, for: List do
     cond do
       :io_lib.printable_list(thing) ->
         << ?', String.escape(:unicode.characters_to_binary(thing), ?') :: binary, ?' >>
-      keyword?(thing) ->
+      keyword?(thing) && !opts.raw ->
         surround_many("[", thing, "]", opts.limit, keyword(&1, opts))
       true ->
         surround_many("[", thing, "]", opts.limit, Kernel.inspect(&1, opts))

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -180,6 +180,12 @@ defmodule Inspect.ListTest do
            "[foo: [1, 2, 3, :bar],\n bazzz: :bat]"
   end
 
+  test :keyword_with_raw do
+    assert inspect([a: 1], raw: true) == "[{:a, 1}]"
+    assert inspect([a: 1, b: 2], raw: true) == "[{:a, 1}, {:b, 2}]"
+    assert inspect([a: 1, a: 2, b: 2], raw: true) == "[{:a, 1}, {:a, 2}, {:b, 2}]"
+  end
+
   test :non_keyword do
     assert inspect([{ Regex, 1 }]) == "[{Regex, 1}]"
   end


### PR DESCRIPTION
As discussed on the elixir-talk list:

```
iex(1)> Kernel.inspect [a: 1,b: 2], raw: true
"[{:a, 1}, {:b, 2}]"
iex(2)> Kernel.inspect [a: 1,b: 2], raw: false
"[a: 1, b: 2]"
iex(3)> Kernel.inspect [a: 1,b: 2]            
"[a: 1, b: 2]"
```
