### PR TITLE
Mix.Tasks.Help.run([]) outputs information about current default task

### DIFF
--- a/lib/mix/lib/mix/tasks/help.ex
+++ b/lib/mix/lib/mix/tasks/help.ex
@@ -31,6 +31,8 @@ defmodule Mix.Tasks.Help do
       max(size(task), acc)
     end
 
+    display_default_task_doc(max)
+
     sorted = Enum.sort(docs)
 
     Enum.each sorted, fn({ task, doc }) ->
@@ -61,5 +63,11 @@ defmodule Mix.Tasks.Help do
 
   defp format(expression, args) do
     :io_lib.format(expression, args) |> iolist_to_binary
+  end
+
+  defp display_default_task_doc(indention) do
+    Mix.shell.info format("mix ~-#{indention}s # ~ts",
+                          ["",
+                          "Run the default task (current: mix #{Mix.project[:default_task]})"])
   end
 end

--- a/lib/mix/test/mix/tasks/help_test.exs
+++ b/lib/mix/test/mix/tasks/help_test.exs
@@ -6,8 +6,19 @@ defmodule Mix.Tasks.HelpTest do
   test "help lists all tasks" do
     in_fixture "only_mixfile", fn ->
       Mix.Tasks.Help.run []
+      assert_received { :mix_shell, :info, ["mix" <> _] }
       assert_received { :mix_shell, :info, ["mix help" <> _] }
       assert_received { :mix_shell, :info, ["mix compile" <> _] }
+    end
+  end
+
+  test "help list default task" do
+    in_fixture "only_mixfile", fn ->
+      Mix.Tasks.Help.run []
+
+      { _, _, [output] } =
+        assert_received { :mix_shell, :info, [_] }
+      assert output =~ %r/^mix\s+# Run the default task \(current: mix run\)/m
     end
   end
 


### PR DESCRIPTION
Hi,

`mix help` now outputs information about the current default mix task.

Cheers
