### PR TITLE
Check mix path deps to see if we need recompile project

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -227,7 +227,7 @@ defmodule IO do
   Here is an example on how we mimic an echo server
   from the command line:
 
-    Enum.each IO.stream(:stdio), IO.write(&1)
+      Enum.each IO.stream(:stdio), IO.write(&1)
 
   """
   def stream(device) do

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -113,4 +113,22 @@ defmodule Mix.Tasks.Compile.ElixirTest do
   after
     purge [A, B, C]
   end
+
+  test "recompile after path dependency changed" do
+    in_fixture("umbrella_dep/deps/umbrella/apps", fn ->
+      Mix.Project.in_project(:bar, "bar", fn _ ->
+        Mix.Tasks.Deps.Compile.run []
+        Mix.Tasks.Compile.Elixir.run []
+
+        assert :noop == Mix.Tasks.Compile.Elixir.run []
+        purge [Bar]
+
+        future = { { 2020, 1, 1 }, { 0, 0, 0 } }
+        File.touch!("../foo/ebin/.compile.elixir", future)
+        assert :ok == Mix.Tasks.Compile.Elixir.run []
+      end)
+    end)
+  after
+    purge [Bar.Mix, Foo.Mix, Bar, Foo]
+  end
 end

--- a/lib/mix/test/mix/umbrella_test.exs
+++ b/lib/mix/test/mix/umbrella_test.exs
@@ -44,7 +44,7 @@ defmodule Mix.UmbrellaTest do
       end)
     end)
   after
-    purge [UmbrellaDep.Mixfile, Umbrella.Mixfile]
+    purge [UmbrellaDep.Mixfile, Umbrella.Mixfile, Bar.Mix, Foo.Mix]
   end
 
   test "compile for umbrella as dependency" do
@@ -55,7 +55,6 @@ defmodule Mix.UmbrellaTest do
       end)
     end
   after
-    Mix.Project.pop
     purge [UmbrellaDep.Mixfile, Umbrella.Mixfile, Foo, Foo.Mix, Bar, Bar.Mix]
   end
 end


### PR DESCRIPTION
'mix compile' will check the manifest files' mtime of all mix path
dependencies - if they are newer then the local .compile.elixir file
we need to recompile.
