### PR TITLE
Issue #1448, Mix.Tasks.Compiler.*.manifests returns complete path

### DIFF
--- a/lib/mix/lib/mix/tasks/clean.ex
+++ b/lib/mix/lib/mix/tasks/clean.ex
@@ -17,16 +17,13 @@ defmodule Mix.Tasks.Clean do
   def run(args) do
     { opts, _ } = OptionParser.parse(args)
 
-    compile_path = Mix.project[:compile_path]
-
     manifests = Mix.Tasks.Compile.manifests
     Enum.each(manifests, fn(manifest) ->
-      manifest_path = Path.join(compile_path, manifest)
-      Mix.Utils.read_manifest(manifest_path) |> Enum.each(File.rm(&1))
-      File.rm(manifest_path)
+      Mix.Utils.read_manifest(manifest) |> Enum.each(File.rm(&1))
+      File.rm(manifest)
     end)
 
-    File.rm_rf(compile_path)
+    File.rm_rf(Mix.project[:compile_path])
 
     if opts[:all], do: Mix.Task.run("deps.clean")
   end

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -107,7 +107,7 @@ defmodule Mix.Tasks.Compile.Elixir do
   end
 
   def manifest do
-    @manifest
+    Path.join(Mix.project[:compile_path], @manifest)
   end
 
   defp compile_files(true, project, compile_path, to_compile, stale, opts) do
@@ -151,14 +151,8 @@ defmodule Mix.Tasks.Compile.Elixir do
 
     Enum.any?(deps, fn(dep) ->
       Mix.Deps.in_dependency(dep, fn(_) ->
-        Mix.Utils.stale?(collect_manifests, [manifest])
+        Mix.Utils.stale?(Mix.Tasks.Compile.manifests, [manifest])
       end)
     end)
-  end
-
-  defp collect_manifests do
-    manifests = Mix.Tasks.Compile.manifests
-    compile_path = Mix.project[:compile_path]
-    Enum.map(manifests, Path.join(compile_path, &1))
   end
 end

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -95,7 +95,7 @@ defmodule Mix.Tasks.Compile.Erlang do
   end
 
   def manifest do
-    @manifest
+    Path.join(Mix.project[:compile_path], @manifest)
   end
 
   defp scan_sources(files, include_path, source_paths) do

--- a/lib/mix/lib/mix/tasks/compile.leex.ex
+++ b/lib/mix/lib/mix/tasks/compile.leex.ex
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.Compile.Leex do
   end
 
   def manifest do
-    @manifest
+    Path.join(Mix.project[:compile_path], @manifest)
   end
 
   defp compile_files(files, compile_path, options) do

--- a/lib/mix/lib/mix/tasks/compile.yecc.ex
+++ b/lib/mix/lib/mix/tasks/compile.yecc.ex
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.Compile.Yecc do
   end
 
   def manifest do
-    @manifest
+    Path.join(Mix.project[:compile_path], @manifest)
   end
 
   defp compile_files(files, compile_path, options) do


### PR DESCRIPTION
Proposed fix for Issue #1448

Updated places where external tasks were prepending the `compile_path` to the manifest name. Did not update internal instances on `Path.join(compile_path, manifest)`, but that would be straightforward.

Assuming that's what you had in mind.
