### PR TITLE
reverse @__behaviour_docs__

### DIFF
--- a/lib/elixir/lib/behaviour.ex
+++ b/lib/elixir/lib/behaviour.ex
@@ -109,7 +109,7 @@ defmodule Behaviour do
       end
 
       def __behaviour__(:docs) do
-        @__behaviour_docs__
+         Enum.reverse(@__behaviour_docs__)
       end
     end
   end

--- a/lib/elixir/test/elixir/behaviour_test.exs
+++ b/lib/elixir/test/elixir/behaviour_test.exs
@@ -6,27 +6,35 @@ defmodule BehaviourTest do
   defmodule Sample do
     use Behaviour
 
+    @doc "I should be first."
+    defcallback first(integer) :: integer
+
     @doc "Foo"
     defcallback foo(atom, binary) :: binary
 
     @doc "Bar"
     defcallback bar(External.hello, my_var :: binary) :: binary
+
+    @doc "I should be last."
+    defcallback last(integer) :: integer
   end
 
   test :docs do
-    docs = Enum.sort(Sample.__behaviour__(:docs))
+    docs = Sample.__behaviour__(:docs)
     assert docs == [
-      {{:bar, 2}, 13, "Bar"},
-      {{:foo, 2}, 10, "Foo"}
+      {{:first, 1}, 10, "I should be first."},
+      {{:foo, 2}, 13, "Foo"},
+      {{:bar, 2}, 16, "Bar"},
+      {{:last, 1}, 19, "I should be last."}
     ]
   end
 
   test :callbacks do
-    assert Sample.__behaviour__(:callbacks) == [foo: 2, bar: 2]
+    assert Sample.__behaviour__(:callbacks) == [first: 1, foo: 2, bar: 2, last: 1]
   end
 
   test :specs do
-    assert length(Keyword.get_values(Sample.module_info[:attributes], :callback)) == 2
+    assert length(Keyword.get_values(Sample.module_info[:attributes], :callback)) == 4
   end
 
   test :default_is_not_supported do


### PR DESCRIPTION
Behaviour callback docs are top accumulated as module attributes, so are therefore stored internally in reverse order to how they were added.

However, they weren't being reversed again when being accessed, so ended up backwards. 

Fix is to just reverse them when we get them back out to put them in the right order.

This is used by ex_doc, and callbacks are listed backwards otherwise (e.g. see http://elixir-lang.org/docs/stable/Dict.html )

Raised initially as https://github.com/elixir-lang/ex_doc/pull/47 , but made fix here instead as recommended by @josevalim
