### PR TITLE
Add Enum.reduce/2 that sets initial value of acc to the first element of collection

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -707,6 +707,39 @@ defmodule Enum do
   end
 
   @doc """
+  Invokes `fun` for each element in the collection passing that element and the
+  accumulator `acc` as arguments. `fun`'s return value is stored in `acc`.
+  The first element of collection is used as the initial value of `acc`.
+  Returns the accumulator.
+
+  ## Examples
+
+      iex> Enum.reduce([1, 2, 3, 4], fn(x, acc) -> x * acc end)
+      24
+
+  """
+  @spec reduce(t, (element, any -> any)) :: any
+  def reduce([h|t], fun) do
+    Enum.reduce(t, h, fun)
+  end
+
+  def reduce([], _fun) do
+    raise Enum.EmptyError
+  end
+
+  def reduce(collection, fun) do
+    result = Enumerable.reduce(collection, :first, fn
+      entry, :first -> entry
+      entry, acc -> fun.(entry, acc)
+    end)
+
+    case result do
+      :first -> raise Enum.EmptyError
+      acc -> acc
+    end
+  end
+
+  @doc """
   Returns elements of collection for which `fun` returns false.
 
   ## Examples

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -134,6 +134,11 @@ defmodule EnumTest.List do
   test :reduce do
     assert Enum.reduce([], 1, fn(x, acc) -> x + acc end) == 1
     assert Enum.reduce([1, 2, 3], 1, fn(x, acc) -> x + acc end) == 7
+
+    assert Enum.reduce([1, 2, 3], fn(x, acc) -> x + acc end) == 6
+    assert_raise Enum.EmptyError, fn ->
+      assert Enum.reduce([], fn(x, acc) -> x + acc end)
+    end
   end
 
   test :join_with_bin do
@@ -477,6 +482,9 @@ defmodule EnumTest.Range do
 
     range = Range.new(first: 1, last: 3)
     assert Enum.reduce(range, 1, fn(x, acc) -> x + acc end) == 7
+
+    range = Range.new(first: 1, last: 3)
+    assert Enum.reduce(range, fn(x, acc) -> x + acc end) == 6
   end
 
   test :reject do


### PR DESCRIPTION
Example:

``` elixir
1..3 |> Enum.reduce(&1 + &2)  #=> 6
```

Similar in other langs:

Scala:

``` scala
(1 to 3).reduce(_ * _)
```

F#:

``` fsharp
[1..3] |> List.reduce(*)
```

Haskell:

``` haskell
foldl1 (*) [1, 2, 3]
```

Ruby:

``` ruby
(1..3).reduce(:*)
```
