### PR TITLE
always remove unmatched beam files when compiling

### DIFF
--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -37,13 +37,8 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       assert Mix.Tasks.Compile.Elixir.run([]) == :ok
       assert File.regular?("ebin/Elixir.A.beam")
 
-      # Now we have a noop
       File.rm!("lib/a.ex")
-      assert Mix.Tasks.Compile.Elixir.run([]) == :noop
-
-      # --force
-      purge [A, B, C]
-      assert Mix.Tasks.Compile.Elixir.run(["--force"]) == :ok
+      assert Mix.Tasks.Compile.Elixir.run([]) == :ok
       refute File.regular?("ebin/Elixir.A.beam")
     end
   end


### PR DESCRIPTION
I ran into a problem where I had a test file that was still passing after removing the corresponding source code. This commit makes the compile task always remove unmatched beam files without having to use the `--force` option. Let me know if this looks good and there wasn't some rationale for not removing unmatched beams automatically.
