### PR TITLE
Add Enum.force/1

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -301,6 +301,22 @@ defmodule Enum do
   end
 
   @doc """
+  Forces the realization (evaluation) of a lazy enumerable.
+  It does this by calling Enum.each on the collection and
+  an identity function.
+
+  ## Examples
+
+      Enum.force(Stream.map(["foo", "bar"], IO.puts(&1)))
+      "foo"
+      "bar"
+      #=> :ok
+
+  """
+  @spec force(t) :: :ok
+  def force(collection), do: each(collection, &(&1))
+
+  @doc """
   Returns `true` if the collection is empty, otherwise `false`.
 
   ## Examples

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -104,6 +104,13 @@ defmodule EnumTest.List do
     Process.delete(:enum_test_each)
   end
 
+  test :force do
+    assert Enum.force(Stream.map([1, 2, 3], &Process.put(:enum_test_each, &1 * 2))) == :ok
+    assert Process.get(:enum_test_each) == 6
+  after
+    Process.delete(:enum_test_each)
+  end
+
   test :fetch do
     assert Enum.fetch([2, 4, 6], 0) == { :ok, 2 }
     assert Enum.fetch([2, 4, 6], 2) == { :ok, 6 }


### PR DESCRIPTION
Not sure if this will actually be taken or not since there is currently a bit of debate about it going on on IRC, but here it is in any case.

This is useful for forcing the realization of lazy enumerables (like
Streams!) without building a list such as would be the case if one used
Enum.to_list.
