### PR TITLE
Make System/tmp_dir/0 care about Windows and add more dirs.

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -146,9 +146,9 @@ defmodule System do
   2. The directory named by the TEMP environment variable
   3. The directory named by the TMP environment variable
   4. A platform-specific location. On Windows, the directories
-     C:\TEMP, C:\TMP, \TEMP, and \TMP, in that order. On all
-     other platforms, the directories /tmp, /var/tmp, and
-     /usr/tmp, in that order.
+     C:\Windows\Temp, C:\TEMP, C:\TMP, \TEMP, and \TMP, in that
+     order. On all other platforms, the directories /tmp,
+     /var/tmp, and /usr/tmp, in that order.
   5.  As a last resort, the current working directory
 
   Returns `nil` if none of the above are writable.
@@ -159,9 +159,10 @@ defmodule System do
       write_env_tmp_dir('TMP')  ||
       case :os.type do
         { :win32, _ } ->
-          write_tmp_dir("C:\\TEMP") ||
-          write_tmp_dir("C:\\TMP")  ||
-          write_tmp_dir("\\TEMP")   ||
+          write_tmp_dir("C:\\Windows\\Temp") ||
+          write_tmp_dir("C:\\TEMP")          ||
+          write_tmp_dir("C:\\TMP")           ||
+          write_tmp_dir("\\TEMP")            ||
           write_tmp_dir("\\TMP")
         _ ->
           write_tmp_dir("/tmp")     ||


### PR DESCRIPTION
The documentation for this function said it looked for a temporary
directory on Windows as well as unix, but as you can see from the
original code it didn't do anything on Windows and only looked at one
directory on unix.

This function appeared to be trying to copy the Python version of this
function, but wasn't going to the same lengths to find a temporary
directory as it does. This commit makes it pay attention to Windows and
adds more directories to look for on other operating systems. It is more
or less the same as the Python version at this point.

http://docs.python.org/2/library/tempfile.html#tempfile.tempdir
