### PR TITLE
Ensure even a greater level of quiteness when --quiet is used in deps

### DIFF
--- a/lib/mix/lib/mix/tasks/deps.get.ex
+++ b/lib/mix/lib/mix/tasks/deps.get.ex
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.Deps.Get do
 
   * `--no-compile` - skip compilation of dependencies
   * `--no-deps-check` - skip dependency check
-  * `--quiet` - do not output success message
+  * `--quiet` - do not output verbose messages
 
   """
 
@@ -43,7 +43,12 @@ defmodule Mix.Tasks.Deps.Get do
       Mix.Deps.Lock.write(lock)
 
       unless opts[:no_compile] do
-        Mix.Task.run("deps.compile", apps)
+        case opts[:quiet] do
+          true ->
+            Mix.Task.run("deps.compile", ["--quiet"|apps])
+          _ ->
+            Mix.Task.run("deps.compile", apps)
+        end
         unless opts[:no_deps_check], do: Mix.Task.run("deps.check", [])
       end
     end

--- a/lib/mix/lib/mix/tasks/deps.update.ex
+++ b/lib/mix/lib/mix/tasks/deps.update.ex
@@ -17,6 +17,8 @@ defmodule Mix.Tasks.Deps.Update do
   * `--all` - update all dependencies
   * `--no-compile` - skip compilation of dependencies
   * `--no-deps-check` - skip dependency check
+  * `--quiet` - do not output verbose messages
+
   """
 
   import Mix.Deps, only: [ all: 0, all: 2, available?: 1, by_name: 2,
@@ -49,7 +51,12 @@ defmodule Mix.Tasks.Deps.Update do
   defp finalize_update({ apps, lock }, opts) do
     Mix.Deps.Lock.write(lock)
     unless opts[:no_compile] do
-      Mix.Task.run("deps.compile", apps)
+      case opts[:quiet] do
+        true ->
+          Mix.Task.run("deps.compile", ["--quiet"|apps])
+        _ ->
+          Mix.Task.run("deps.compile", apps)
+      end
       unless opts[:no_deps_check], do: Mix.Task.run("deps.check", [])
     end
   end

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -280,6 +280,25 @@ defmodule Mix.Tasks.DepsTest do
     Mix.Project.pop
   end
 
+  test "respects --quiet in deps.compile" do
+    Mix.Project.push NestedDepsApp
+
+    in_fixture "deps_status", fn ->
+      Mix.Tasks.Deps.Get.run ["--quiet"]
+      message = "* Getting git_repo [git: #{inspect fixture_path("git_repo")}]"
+      assert_received { :mix_shell, :info, [^message] }
+      refute_received { :mix_shell, :info, ["* Compiling deps_repo"] }
+      assert_received { :mix_shell, :info, ["Generated git_repo.app"] }
+
+      Mix.Tasks.Deps.Update.run ["--all"]
+      assert_received { :mix_shell, :info, ["* Updating deps_repo (0.1.0) [path: \"custom/deps_repo\"]"] }
+      refute_received { :mix_shell, :info, ["* Compiling deps_repo"] }
+    end
+  after
+    Mix.Project.pop
+  end
+
+
   test "fails on diverged dependencies" do
     Mix.Project.push DivergedDepsApp
 


### PR DESCRIPTION
Before (on deps.get --quiet):

```
==> project
* Compiling project_p1
==> project_p2
* Compiling project_p1
* Compiling project
* Compiling project
==> project_p3
* Compiling project_p1
* Compiling project
* Compiling project
==> project_p4
* Compiling project_p1
* Compiling project
* Compiling project
==> project_p5
* Compiling project_p1
* Compiling project
* Compiling project
```

Now:

(empty)

And yet when there's something to compile, it prints enough to know what app is compiled, etc.
