### PR TITLE
Fix default shutdown of child supervisors to infinity

### DIFF
--- a/lib/elixir/lib/supervisor/behaviour.ex
+++ b/lib/elixir/lib/supervisor/behaviour.ex
@@ -103,7 +103,7 @@ defmodule Supervisor.Behaviour do
     Defaults to `:permanent`;
 
   * `:shutdown` - defines how a child process should be terminated.
-    Defaults to `5000`;
+    Defaults to `5000` for a worker and `:infinity` for a supervisor;
 
   * `:modules` - it should be a list with one element `[module]`,
     where module is the name of the callback module only if the
@@ -167,6 +167,7 @@ defmodule Supervisor.Behaviour do
   #{@child_doc}
   """
   def supervisor(module, args, options // []) do
+    options = Keyword.update(options, :shutdown, :infinity, fn(x) -> x end)
     child(:supervisor, module, args, options)
   end
 

--- a/lib/elixir/test/elixir/supervisor/behaviour_test.exs
+++ b/lib/elixir/test/elixir/supervisor/behaviour_test.exs
@@ -59,7 +59,7 @@ defmodule Supervisor.BehaviourTest do
       Foo,
       { Foo, :start_link, [1, 2, 3] },
       :permanent,
-      5000,
+      :infinity,
       :supervisor,
       [Foo]
     }


### PR DESCRIPTION
A supervisor should wait for a child supervisor to shutdown its
children, and not kill it. By killing a supervisor you may prevent the
correct termination of processes further down the supervision tree.
