### PR TITLE
added Dict.Behaviour

### DIFF
--- a/lib/elixir/lib/dict.ex
+++ b/lib/elixir/lib/dict.ex
@@ -18,6 +18,9 @@ defmodule Dict do
   that the returned value is actually of the same dict type
   as the input one.
 
+  In the examples below, `dict_impl` means a specific
+  `Dict` implementation, for example `HashDict` or `ListDict`.
+
   ## Protocols
 
   Besides implementing the functions in this module, all
@@ -44,6 +47,8 @@ defmodule Dict do
   @type keys :: [ key ]
   @type t :: tuple | list
 
+  defcallback new :: t
+  defcallback new(Keyword.t) :: t
   defcallback delete(t, key) :: t
   defcallback drop(t, keys) :: t
   defcallback empty(t) :: t
@@ -67,6 +72,7 @@ defmodule Dict do
   defcallback update(t, key, (value -> value)) :: t | no_return
   defcallback update(t, key, value, (value -> value)) :: t
   defcallback values(t) :: list(value)
+  defcallback reduce(t, any, ({key, value}, any -> any)) :: any
 
   defmacrop target(dict) do
     quote do
@@ -364,10 +370,10 @@ defmodule Dict do
 
   ## Examples
 
-      iex> d = dict_impl.new([a: 1, b: 2])
-      ...> { d1, d2 } = Dict.split(d, [:a, :c])
+      iex> d = dict_impl.new([a: 1, b: 2, c: 3, d: 4])
+      ...> { d1, d2 } = Dict.split(d, [:a, :c, :e])
       ...> { Dict.to_list(d1), Dict.to_list(d2) }
-      { [a: 1], [b: 2] }
+      { [a: 1, c: 3], [b: 2, d: 4] }
 
       iex> d = dict_impl.new([])
       ...> { d1, d2 } = Dict.split(d, [:a, :c])

--- a/lib/elixir/lib/dict/behaviour.ex
+++ b/lib/elixir/lib/dict/behaviour.ex
@@ -6,7 +6,6 @@ defmodule Dict.Behaviour do
   Usage:
 
       defmodule MyDict do
-        @behaviour Dict
         use Dict.Behaviour
 
         # implement required functions (see below)
@@ -42,6 +41,8 @@ defmodule Dict.Behaviour do
 
   defmacro __using__(_) do
     quote do
+      @behaviour Dict
+      
       def get(dict, key, default // nil) do
         case fetch(dict, key) do
           { :ok, value } -> value

--- a/lib/elixir/lib/hash_dict.ex
+++ b/lib/elixir/lib/hash_dict.ex
@@ -8,7 +8,6 @@ defmodule HashDict do
   their APIs, please consult the `Dict` module.
   """
 
-  @behaviour Dict
   use Dict.Behaviour
 
   # A dictionary (key-value) implementation based on dynamic hashing.

--- a/lib/elixir/lib/list_dict.ex
+++ b/lib/elixir/lib/list_dict.ex
@@ -92,13 +92,15 @@ defmodule ListDict do
 
   def split(dict, keys) do
     acc = { new(), new() }
-    Enum.reduce dict, acc, fn({ k, v }, { take, drop }) ->
+    {take, drop} = Enum.reduce dict, acc, fn({ k, v }, { take, drop }) ->
       if :lists.member(k, keys) do
         { [{k, v}|take], drop }
       else
         { take, [{k, v}|drop] }
       end
     end
+    
+    {Enum.reverse(take), Enum.reverse(drop)}
   end
 
   def take(dict, keys) do

--- a/lib/elixir/test/doc_test.exs
+++ b/lib/elixir/test/doc_test.exs
@@ -13,7 +13,6 @@ defmodule KernelTest do
   doctest Inspect.Tuple
   doctest Bitwise
   doctest Code
-  doctest Dict; defp dict_impl, do: HashDict
   doctest Enum
   doctest IO.ANSI
   doctest Keyword

--- a/lib/elixir/test/elixir/dict_test.exs
+++ b/lib/elixir/test/elixir/dict_test.exs
@@ -3,7 +3,9 @@ Code.require_file "test_helper.exs", __DIR__
 defmodule DictTest.Common do
   defmacro __using__(module) do
     quote location: :keep do
-      use ExUnit.Case, async: true
+      use ExUnit.Case
+
+      doctest Dict; defp dict_impl, do: unquote(module)
 
       # Most underlying Dict implementations have no key order guarantees,
       # sort them before we compare:


### PR DESCRIPTION
Dict.Behaviour helper, as discussed [here](https://groups.google.com/forum/?fromgroups#!topic/elixir-lang-core/BBtbdOv5FcI)

A couple of poins/issues:
1. Perhaps it would be useful if `use Dict.Behaviour` automatically generates `@behaviour Dict`?
2. `Dict.Behaviour` relies on reduce. However, this is not required by the `@behaviour Dict`. Perhaps it would make sense to add this requirement to the behaviour.
3. `HashDict` now relies on `Dict.Behaviour`. This is mostly straightforward, except in `merge` which in `HashDict` has multiple clauses. I made only the last clause to call the default implementation.
4. The doctests rely on existence of `dict_impl`, as suggested in the mailing list thread. This will work only if the dict implementation contains `new/0` and `new/1`. This is again not enforced anywhere.
5. I didn't document the generated functions, because `HashDict` also doesn't document them. If this is needed let me know.
