### PR TITLE
Add Enum.flat_map

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -540,6 +540,31 @@ defmodule Enum do
   end
 
   @doc """
+  Returns a new collection appending the result of invoking `fun`
+  on each corresponding item of `collection`.
+
+  Given function should return a list.
+
+  ## Examples
+
+      iex> Enum.flat_map([:a, :b, :c], fn(x) -> [x, x] end)
+      [:a, :a, :b, :b, :c, :c]
+
+  """
+  @spec flat_map(t, (element -> any)) :: list
+  def flat_map([], _fun), do: []
+
+  def flat_map(collection, fun) when is_list(collection) do
+    :lists.flatmap(fun, collection)
+  end
+
+  def flat_map(collection, fun) do
+    Enumerable.reduce(collection, [], fn(entry, acc) ->
+      acc ++ fun.(entry)
+    end)
+  end
+
+  @doc """
   Joins the given `collection` according to `joiner`.
   `joiner` can be either a binary or a list and the
   result will be of the same type as `joiner`. If

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -131,6 +131,11 @@ defmodule EnumTest.List do
     assert Enum.filter_map([2, 4, 6], fn(x) -> rem(x, 2) == 0 end, &1 * 2) == [4, 8, 12]
   end
 
+  test :flat_map do
+    assert Enum.flat_map([], fn(x) -> [x, x] end) == []
+    assert Enum.flat_map([1, 2, 3], fn(x) -> [x, x] end) == [1, 1, 2, 2, 3, 3]
+  end
+
   test :reduce do
     assert Enum.reduce([], 1, fn(x, acc) -> x + acc end) == 1
     assert Enum.reduce([1, 2, 3], 1, fn(x, acc) -> x + acc end) == 7
@@ -478,6 +483,11 @@ defmodule EnumTest.Range do
 
     range = Range.new(first: 2, last: 6)
     assert Enum.filter_map(range, fn(x) -> rem(x, 2) == 0 end, &1 * 2) == [4, 8, 12]
+  end
+
+  test :flat_map do
+    range = Range.new(first: 1, last: 3)
+    assert Enum.flat_map(range, fn(x) -> [x, x] end) == [1, 1, 2, 2, 3, 3]
   end
 
   test :reduce do


### PR DESCRIPTION
Returns a new collection appending the result of invoking `fun` on each corresponding item of `collection`.
Given function should return a list.

This similar to Scala's `flatMap`, Haskell's `>>=` and it uses Erlang's `lists:flatmap` when collection is a list.
