### PR TITLE
Return error when tokenizing oversized atom

### DIFF
--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -6,6 +6,10 @@ tokenize(String) ->
   { ok, Result } = elixir_tokenizer:tokenize(String, 1, []),
   Result.
 
+tokenize_error(String) ->
+  { error, Error } = elixir_tokenizer:tokenize(String, 1, []),
+  Error.
+
 type_test() ->
   [{number,1,1},{type_op,1,'::'},{number,1,3}] = tokenize("1 :: 3"),
   [{identifier,1,foo},
@@ -39,6 +43,13 @@ unquoted_atom_test() ->
   [{atom, 1, '/'}] = tokenize(":/"),
   [{atom, 1, '='}] = tokenize(":="),
   [{atom, 1, '&&'}] = tokenize(":&&").
+
+quoted_atom_test() ->
+  [{atom, 1, 'foo bar'}] = tokenize(":\"foo bar\"").
+
+oversized_atom_test() ->
+  OversizedAtom = ":\"" ++ string:copies("a", 256) ++ "\"",
+  { 1, "atom length must be less than system limit", ":" } = tokenize_error(OversizedAtom).
 
 op_atom_test() ->
   [{atom,1,f0_1}] = tokenize(":f0_1").


### PR DESCRIPTION
When "atomizing" an unsafe string, we need to make sure the atom length
is going to be less than the system limit (255). Any function calling
`unsafe_to_atom` checks for an error and returns it if present.

Fixes #1384
