### PR TITLE
Return an empty string from slice with valid index

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -807,6 +807,13 @@ defmodule String do
   """
   @spec slice(t, integer, integer) :: grapheme | nil
 
+  def slice(string, start, 0) do
+    case abs(start) <= String.length(string) do
+      true -> ""
+      false -> nil
+    end
+  end
+
   def slice(string, start, len) when start >= 0 do
     do_slice(next_grapheme(string), start, start + len - 1, 0, "")
   end

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -249,6 +249,9 @@ defmodule StringTest do
     assert String.slice("あいうえお", 6, 2) == nil
     assert String.slice("ειξήριολ", 8, 1) == ""
     assert String.slice("ειξήριολ", 9, 1) == nil
+    assert String.slice("elixir", 0, 0) == ""
+    assert String.slice("elixir", 5, 0) == ""
+    assert String.slice("elixir", -5, 0) == ""
     assert String.slice("", 0, 1) == ""
     assert String.slice("", 1, 1) == nil
   end


### PR DESCRIPTION
To keep in line with ruby semantics of
[`String#slice`](http://ruby-doc.org/core-2.0/String.html#method-i-slice)
slice should return an empty string instead of nil when the starting
index is valid even if the length is 0.

Fixes #1591
