### PR TITLE
Add example to Enum.take docs using negative count.

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -951,6 +951,8 @@ defmodule Enum do
       [1,2,3]
       iex> Enum.take([1, 2, 3], 0)
       []
+      iex> Enum.take([1, 2, 3], -1)
+      [1,2]
 
   """
   @spec take(t, integer) :: list


### PR DESCRIPTION
Outside of experimenting/viewing the `Enum.take` source, the Enum.take docs don't mention being able to use a negative count to exclude the last n items. A simple example in the docs should be helpful to those using `h Enum.take` from iex.
