### PR TITLE
Add Enum.group

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -565,26 +565,6 @@ defmodule Enum do
   end
 
   @doc """
-  Returns a new collection with elements grouped into smaller
-  collections of a given number of elements.
-  
-  ## Examples
-
-      iex> Enum.group([:a, :b, :c, :d], 2)
-      [[:a, :b], [:c, :d]]
-
-  """
-  @spec group(t, index, h) :: list
-  def group(collection, number, init // []) do
-    {part, rest} = Enum.split(collection, number)
-    group(rest, number, List.concat(init, [part]))
-  end
-
-  def group([], number, init // []) do
-    init
-  end
-
-  @doc """
   Joins the given `collection` according to `joiner`.
   `joiner` can be either a binary or a list and the
   result will be of the same type as `joiner`. If
@@ -847,6 +827,21 @@ defmodule Enum do
       [{ :random.uniform, x }|acc]
     end)
     unwrap(:lists.keysort(1, randomized), [])
+  end
+
+  @doc """
+  Returns a new collection with elements sliced into smaller
+  collections of a given size.
+  
+  ## Examples
+
+      iex> Enum.slice([:a, :b, :c, :d], 2)
+      [[:a, :b], [:c, :d]]
+
+  """
+  @spec slice(t, index) :: list
+  def slice(collection, size) do
+    do_slice(collection, size, [])
   end
 
   @doc """
@@ -1460,6 +1455,16 @@ defmodule Enum do
 
   defp reverse_sort_merge([], acc, fun, bool), do:
     sort_merge(acc, [], fun, bool)
+
+
+  defp do_slice([], size, acc) do
+    acc
+  end
+
+  defp do_slice(list, size, acc) do
+    {part, rest} = Enum.split(list, size)
+    do_slice(rest, size, List.concat(acc, [part]))
+  end
 
 
   defp sort_merge_1([h1 | t1], h2, t2, m, fun, bool) do

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -136,16 +136,6 @@ defmodule EnumTest.List do
     assert Enum.flat_map([1, 2, 3], fn(x) -> [x, x] end) == [1, 1, 2, 2, 3, 3]
   end
 
-  test :group do
-    assert Enum.group([[], 2) == []
-    assert Enum.group([[1,2], 1) == [[1],[2]]
-    assert Enum.group([[1,2], 2) == [[1,2]]
-    assert Enum.group([[1,2,3], 2) == [[1,2],[3]]
-    
-    assert Enum.group([[], 2, [6]) == [6]
-    assert Enum.group([1,2], 2, [6]) == [6,[1,2]]
-  end
-
   test :reduce do
     assert Enum.reduce([], 1, fn(x, acc) -> x + acc end) == 1
     assert Enum.reduce([1, 2, 3], 1, fn(x, acc) -> x + acc end) == 7
@@ -204,6 +194,13 @@ defmodule EnumTest.List do
     # set a fixed seed so the test can be deterministic
     :random.seed(1374, 347975, 449264)
     assert Enum.shuffle([1, 2, 3, 4, 5]) == [2, 4, 1, 5, 3]
+  end
+
+  test :slice do
+    assert Enum.slice([], 2) == []
+    assert Enum.slice([1,2], 1) == [[1],[2]]
+    assert Enum.slice([1,2], 2) == [[1,2]]
+    assert Enum.slice([1,2,3], 2) == [[1,2],[3]]
   end
 
   test :sort do


### PR DESCRIPTION
Enum lacks a function for slicing a list up into equally sized sublists. I had need of such a function so I wrote it. I originally called the method `group` as given here, but now I think `slice` might be better, but I leave that up to others to decide.

NOTE: Since I am new to Elixir, I do not pretend that this pull request is as polished as it needs to be. But I think this function is a needed one and my code is far enough along that I require feedback in order to be able to finish it. Thanks.
