### PR TITLE
Move Mix.Version to Version in kernel.

### DIFF
--- a/lib/elixir/test/elixir/version_test.exs
+++ b/lib/elixir/test/elixir/version_test.exs
@@ -1,9 +1,9 @@
-Code.require_file "../test_helper.exs", __DIR__
+Code.require_file "test_helper.exs", __DIR__
 
-defmodule Mix.VersionTest do
+defmodule VersionTest do
   use   ExUnit.Case, async: true
-  alias Mix.Version.Parser, as: P
-  alias Mix.Version, as: V
+  alias Version.Parser, as: P
+  alias Version, as: V
 
   test "lexes specifications properly" do
     assert P.lexer("== != > >= < <= ~>", []) == [:'==', :'!=', :'>', :'>=', :'<', :'<=', :'~>']

--- a/lib/mix/lib/mix/deps.ex
+++ b/lib/mix/lib/mix/deps.ex
@@ -29,7 +29,7 @@ defmodule Mix.Deps do
       { app :: atom, requirement :: String.t, opts :: Keyword.t }
 
   The application name must be an atom, the version requirement must
-  be a string according to the specification outline in `Mix.Version`
+  be a string according to the specification outline in `Version`
   and opts is a keyword lists that may include options for the underlying
   SCM or options used by Mix. Each set of options is documented below.
 

--- a/lib/mix/lib/mix/deps/retriever.ex
+++ b/lib/mix/lib/mix/deps/retriever.ex
@@ -208,7 +208,7 @@ defmodule Mix.Deps.Retriever do
   defp vsn_match?(nil, _actual), do: true
   defp vsn_match?(req, actual) when is_regex(req),  do: actual =~ req
   defp vsn_match?(req, actual) when is_binary(req) do
-    Mix.Version.match?(actual, req)
+    Version.match?(actual, req)
   end
 
   defp mixfile?(dep) do

--- a/lib/mix/lib/mix/tasks/loadpaths.ex
+++ b/lib/mix/lib/mix/tasks/loadpaths.ex
@@ -31,7 +31,7 @@ defmodule Mix.Tasks.Loadpaths do
       config = Mix.project
 
       if requirement = config[:elixir] do
-        unless Mix.Version.match?(System.version, requirement) do
+        unless Version.match?(System.version, requirement) do
           raise Mix.ElixirVersionError, target: config[:app] || Mix.Project.get,
                                         expected: requirement,
                                         actual: System.version


### PR DESCRIPTION
I need to write a package manager for my language, and it would really be a shame if I had to reinvent all of this glorious stuff just because it sits in Mix.
