### PR TITLE
Allow pipeline into anonymous functions

### DIFF
--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -319,6 +319,13 @@ defmodule KernelTest do
       assert_compile_fail ArgumentError, "unsupported expression in pipeline |> operator: 2", "1 |> 2"
     end
 
+    test "pipeline into function value" do
+      assert 1 |> &twice/1               == 2
+      assert 1 |> twice(&1)              == 2
+      assert 1 |> &twice(&1)             == 2
+      assert 1 |> fn (x) -> twice(x) end == 2
+    end
+
     defp twice(a), do: a * 2
 
     defp local(list) do


### PR DESCRIPTION
This allows the following forms of pipeline:

``` elixir
1 |> &twice/1
1 |> twice(&1)
1 |> &twice(&1)
1 |> fn x -> twice(x) end
```

In particular it makes pipelining to functions without the subject at the front easier.
