### PR TITLE
Add Keyword.slice to filter keywords by a list of keys.

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -14,6 +14,7 @@ defmodule Keyword do
   """
 
   @type key :: atom
+  @type keys :: list(atom)
   @type value :: any
   @type t :: [{key, value}]
 
@@ -412,5 +413,22 @@ defmodule Keyword do
 
   def update([], key, initial, _fun) when is_atom(key) do
     [{key, initial}]
+  end
+
+  @doc """
+  Filters the keywords to include only the given keys.
+
+  ## Examples
+
+      iex> Keyword.slice([a: 1, b: 2, c: 3], [:a, :c])
+      [a: 1, c: 3]
+
+      iex> Keyword.slice([a: 1, b: 2], [:a, :x, :y, :z])
+      [a: 1]
+
+  """
+  @spec slice(t, keys) :: t
+  def slice(keywords, keys) do
+    Enum.filter keywords, fn {key, _val} -> Enum.member?(keys, key) end
   end
 end

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -122,6 +122,13 @@ defmodule KeywordTest do
     assert Keyword.update([a: 1], :b, 11, &1 * 2) == [a: 1, b: 11]
   end
 
+  test :slice do
+    assert Keyword.slice([a: 1, b: 2, c: 3], [:a, :c]) == [a: 1, c: 3]
+    assert Keyword.slice([a: 1, b: 2, c: 3], [:a]) == [a: 1]
+    assert Keyword.slice([a: 1, b: 2, c: 3], [:a, :c, :z]) == [a: 1, c: 3]
+    assert Keyword.slice([a: 1, b: 2, c: 3], []) == []
+  end
+
   defp create_empty_keywords, do: []
   defp create_keywords, do: [first_key: 1, second_key: 2]
 end


### PR DESCRIPTION
This is useful for limiting a keyword list to contain only valid keys. I find myself needing this for model field protection from an arbitrary keyword list, but I think general use cases to trim down a keyword list to only desired keys is a good fit for the standard lib. Thoughts?

Examples

``` elixir
iex> Keyword.slice([name: "Elixir", age: 2, admin: true], [:name, :age])
[name: "Elixir", age: 2]

iex> Keyword.slice([name: "Elixir", age: 2, admin: true], [:name, :age, :email, :newsletter])
[name: "Elixir", age: 2]
```
