### PR TITLE
Keep empty strings when splitting

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3659,15 +3659,15 @@ defmodule Kernel do
     case is_binary(string) do
       true ->
         case mod do
-          ?b -> String.split(string)
-          ?a -> lc p inlist String.split(string), do: binary_to_atom(p)
-          ?c -> lc p inlist String.split(string), do: String.to_char_list!(p)
+          ?b -> lc p inlist String.split(string), p != "", do: p
+          ?a -> lc p inlist String.split(string), p != "", do: binary_to_atom(p)
+          ?c -> lc p inlist String.split(string), p != "", do: String.to_char_list!(p)
         end
       false ->
         case mod do
-          ?b -> quote do: String.split(unquote(string))
-          ?a -> quote do: lc(p inlist String.split(unquote(string)), do: binary_to_atom(p))
-          ?c -> quote do: lc(p inlist String.split(unquote(string)), do: String.to_char_list!(p))
+          ?b -> quote do: lc(p inlist String.split(unquote(string)), p != "", do: p)
+          ?a -> quote do: lc(p inlist String.split(unquote(string)), p != "", do: binary_to_atom(p))
+          ?c -> quote do: lc(p inlist String.split(unquote(string)), p != "", do: String.to_char_list!(p))
         end
     end
   end

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -140,7 +140,7 @@ defmodule String do
 
   @doc """
   Splits a string on substrings at each Unicode whitespace
-  occurrence with leading and trailing whitespace ignored.
+  occurrence.
 
   ## Examples
 
@@ -149,7 +149,7 @@ defmodule String do
       iex> String.split("foo" <> <<194, 133>> <> "bar")
       ["foo", "bar"]
       iex> String.split(" foo bar ")
-      ["foo", "bar"]
+      ["", "foo", "bar", ""]
 
   """
   @spec split(t) :: [t]

--- a/lib/elixir/priv/unicode.ex
+++ b/lib/elixir/priv/unicode.ex
@@ -145,11 +145,7 @@ defmodule String.Unicode do
 
   lc codepoint inlist whitespace do
     defp do_split(unquote(codepoint) <> rest, buffer, acc) do
-      if buffer != "" do
-        do_split(rest, "", [buffer | acc])
-      else
-        do_split(rest, buffer, acc)
-      end
+      do_split(rest, "", [buffer | acc])
     end
   end
 
@@ -158,11 +154,7 @@ defmodule String.Unicode do
   end
 
   defp do_split(<<>>, buffer, acc) do
-    if buffer != "" do
-      [buffer | acc]
-    else
-      acc
-    end
+    [buffer | acc]
   end
 
   # Graphemes

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -18,10 +18,10 @@ defmodule StringTest do
   test :split do
     assert String.split("") == [""]
     assert String.split("foo bar") == ["foo", "bar"]
-    assert String.split(" foo bar") == ["foo", "bar"]
-    assert String.split("foo bar ") == ["foo", "bar"]
-    assert String.split(" foo bar ") == ["foo", "bar"]
-    assert String.split("foo\t\n\v\f\r\sbar\n") == ["foo", "bar"]
+    assert String.split(" foo bar") == ["", "foo", "bar"]
+    assert String.split("foo bar ") == ["foo", "bar", ""]
+    assert String.split(" foo bar ") == ["", "foo", "bar", ""]
+    assert String.split("foo\t\n\v\f\r\sbar\n") == ["foo", "", "", "", "", "",  "bar", ""]
     assert String.split("foo" <> <<31>> <> "bar") == ["foo", "bar"]
     assert String.split("foo" <> <<194, 133>> <> "bar") == ["foo", "bar"]
 

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -133,7 +133,7 @@ defmodule IEx.HelpersTest do
       assert ["ebin", "lib", "mix.exs", "test"]
              = capture_io(fn -> ls end)
                |> String.split
-               |> Enum.map(String.strip(&1))
+               |> Enum.filter(&(&1 != ""))
                |> Enum.sort
       assert capture_io(fn -> ls "~" end) == capture_io(fn -> ls System.user_home end)
     end


### PR DESCRIPTION
To stay consistent with both `String.split/2` and `:binary.split` we
need to keep around empty strings that are accumulated while splitting.
In the future we could support the `:trim` option to consistently remove
these in call calls to `String.split`.

Fixes #1636
