### PR TITLE
Clarify the return value of String.to_float on representations of integers

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -890,7 +890,7 @@ defmodule String do
   Converts a string to a float. If successful, returns a
   tuple of the form `{float, remainder of string}`. If unsuccessful,
   returns `:error`. If given an integer value, will return
-  the same value as `to_integer/1`.
+  it as a float.
 
   ## Examples
 


### PR DESCRIPTION
I found the current documentation a little misleading on String.to_float. [Discussion here](https://groups.google.com/forum/#!topic/elixir-lang-core/pDEDSNzDPy0).
