### PR TITLE
Allow Macro.escape([1|2])

### DIFF
--- a/lib/elixir/src/elixir_quote.erl
+++ b/lib/elixir/src/elixir_quote.erl
@@ -195,8 +195,18 @@ do_quote(Tuple, #elixir_quote{escape=true} = Q, S) when is_tuple(Tuple) ->
   { TT, TQ } = do_quote(tuple_to_list(Tuple), Q, S),
   { { '{}', [], TT }, TQ };
 
+do_quote(List, #elixir_quote{escape=true} = Q, S) when is_list(List) ->
+  % The improper case is pretty inefficient, but improper lists are hopefully
+  % rare.
+  case reverse_improper(List) of
+    { L }       -> do_splice(L, Q, S);
+    { L, R }    ->
+      { TL, QL } = do_splice(L, Q, S, [], []),
+      { TR, QR } = do_quote(R, QL, S),
+      { update_last(TL, fun(X) -> { '|', [], [X, TR] } end), QR }
+  end;
 do_quote(List, Q, S) when is_list(List) ->
-  do_splice(lists:reverse(List), Q, S);
+    do_splice(lists:reverse(List), Q, S);
 
 do_quote(Other, Q, _) ->
   { Other, Q }.
@@ -228,6 +238,16 @@ meta(Meta, #elixir_quote{line=nil}) ->
   keydelete(line, Meta);
 meta(Meta, #elixir_quote{line=Line}) ->
   keystore(line, Meta, Line).
+
+reverse_improper(L) -> reverse_improper(L, []).
+
+reverse_improper([], Acc) -> { Acc };
+reverse_improper([H|T], Acc) when is_list(T) -> reverse_improper(T, [H|Acc]);
+reverse_improper([H|T], Acc) -> { [H|Acc], T }.
+
+update_last([], _) -> [];
+update_last([H], F) -> [F(H)];
+update_last([H|T], F) -> [H|update_last(T,F)].
 
 keyfind(Key, Meta) ->
   lists:keyfind(Key, 1, Meta).

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -39,6 +39,11 @@ defmodule MacroTest do
   test :escape_works_recursively do
     assert [1,{:{}, [], [:a,:b,:c]}, 3] == Macro.escape([1, { :a, :b, :c }, 3])
   end
+  
+  test :escape_improper do
+    assert [{:|, [], [1,2]}] == Macro.escape([1|2])
+    assert [1,{:|, [], [2,3]}] == Macro.escape([1,2|3])
+  end
 
   test :escape_with_unquote do
     contents = quote unquote: false, do: unquote(1)


### PR DESCRIPTION
This fixes #1646

I'm not 100% happy with this change, it adds one list traversal in the common case and another in the uncommon case (improper list). However I couldn't see a better way. I suspect a more elegant solution would involve rewriting do_splice to not use a reversed list as input.
