### PR TITLE
Add note to Enum to clarify what's returned

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -63,6 +63,10 @@ defmodule Enum do
   Depending on the type of the collection, the user-provided function will
   accept a certain type of argument. For dicts, the argument is always a
   `{ key, value }` tuple.
+
+  Note that all functions that return a collection return a list regardless of
+  what the type of the input collection was and that many functions will not
+  work with infinite streams.
   """
 
   @compile :inline_list_funcs


### PR DESCRIPTION
In particular clarify that infinite streams don't work with many of the functions.

The documentation didn't mention that very clearly yet and it's an easy mistake to make.
