### PR TITLE
Fix Stream.take/2 and Stream.take_while/2 for Stream.Lazy

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -115,7 +115,10 @@ defmodule Stream do
     end
 
     defp do_reduce(Lazy[enumerable: enumerable, fun: f1, acc: side], acc, fun) do
-      do_reduce(enumerable, { acc, side }, f1.(fun)) |> elem(0)
+      case do_reduce(enumerable, { acc, side }, f1.(fun)) do
+        { acc, _ } -> acc
+        acc        -> acc
+      end
     end
 
     defp do_reduce(enumerable, acc, fun) do

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -153,6 +153,9 @@ defmodule StreamTest do
 
     nats = Stream.iterate(1, &(&1 + 1))
     assert Enum.to_list(Stream.take(nats, 5)) == [1,2,3,4,5]
+
+    stream = Stream.drop(1..100, 5)
+    assert Stream.take(stream, 5) |> Enum.to_list == [6,7,8,9,10]
   end
 
   test :take_while do
@@ -165,6 +168,9 @@ defmodule StreamTest do
 
     nats = Stream.iterate(1, &(&1 + 1))
     assert Enum.to_list(Stream.take_while(nats, &(&1 <= 5))) == [1,2,3,4,5]
+
+    stream = Stream.drop(1..100, 5)
+    assert Stream.take_while(stream, &(&1 < 11)) |> Enum.to_list == [6,7,8,9,10]
   end
 
   test :with_index do


### PR DESCRIPTION
When an accumulator is thrown from a `Stream.Lazy` fun, it doesn't get unwrapped correctly for nested `Stream.Lazy`s.

Fixes #1664
