### PR TITLE
URI.parse supports IPv6 addresses

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -192,7 +192,7 @@ defmodule URI do
   # Split an authority into its userinfo, host and port parts.
   defp split_authority(s) do
     s = s || ""
-    components = Regex.run %r/(^(.*)@)?(\[[a-zA-Z0-9:]*\]|[^:]*)(:(\d*))?/, s
+    components = Regex.run %r/(^(.*)@)?(\[[a-zA-Z0-9:.]*\]|[^:]*)(:(\d*))?/, s
 
     destructure [_, _, userinfo, host, _, port], nillify(components)
     port = if port, do: binary_to_integer(port)

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -134,9 +134,14 @@ defmodule URITest do
 
   test :ipv6_addresses do
     addrs = [
-      "::1",
-      "2607:f3f0:2:0:216:3cff:fef0:174a",
-      "2051:0db8:2d5a:3521:8313:ffad:1242:8e2e"
+      "::",                                      # undefined
+      "::1",                                     # loopback
+      "1080::8:800:200C:417A",                   # unicast
+      "FF01::101",                               # multicast
+      "2607:f3f0:2:0:216:3cff:fef0:174a",        # abbreviated
+      "2607:f3F0:2:0:216:3cFf:Fef0:174A",        # mixed hex case
+      "2051:0db8:2d5a:3521:8313:ffad:1242:8e2e", # complete
+      "::00:192.168.10.184"                      # embedded IPv4
     ]
 
     Enum.each addrs, fn(addr) ->


### PR DESCRIPTION
Solves https://github.com/elixir-lang/elixir/issues/1663

Using a very simplified regex for IPv6 addresses, should we go for something more precise such as http://vernon.mauery.com/content/projects/linux/ipv6_regex ?
