### PR TITLE
Add *.beam to generated .gitignore from mix

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -135,6 +135,7 @@ defmodule Mix.Tasks.New do
    /deps
    erl_crash.dump
    *.ez
+   *.beam
    """
 
   embed_template :mixfile, """


### PR DESCRIPTION
Currently the generated .gitignore does not include *.beam files. 

*.beam files are also excluded in Github: https://github.com/github/gitignore/blob/master/Erlang.gitignore
