### PR TITLE
Improve String.split and Regex.split docs for empty patterns.

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -266,6 +266,10 @@ defmodule Regex do
       ["a","b-c"]
       iex> Regex.split(%r/-/, "abc")
       ["abc"]
+      iex> Regex.split(%r//, "abc")
+      ["a", "b", "c", ""]
+      iex> Regex.split(%r//, "abc", trim: true)
+      ["a", "b", "c"]
   """
 
   def split(regex, string, options // [])

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -184,6 +184,12 @@ defmodule String do
       ["a", "b,c"]
       iex> String.split("a,b", %r{\\.})
       ["a,b"]
+      iex> String.split("abc", %r{c})
+      ["ab", ""]
+      iex> String.split("abc", %r{})
+      ["a", "b", "c", ""]
+      iex> String.split("abc", %r{}, trim: true)
+      ["a", "b", "c"]
 
   """
   @spec split(t, t | [t] | Regex.t) :: [t]


### PR DESCRIPTION
Include examples showing that splitting with an empty pattern results in a final (trim-able) empty string, as discussed in #1688.

This behavior is different than developers coming from Ruby, Perl, and other languages may initially expect.
