### PR TITLE
Support String.split with an empty binary as the pattern.

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -184,6 +184,12 @@ defmodule String do
       ["a", "b,c"]
       iex> String.split("a,b", %r{\\.})
       ["a,b"]
+      iex> String.split("abc", "")
+      ["a", "b", "c", ""]
+      iex> String.split("abc", "", trim: true)
+      ["a", "b", "c"]
+      iex> String.split("abc", "", global: false)
+      ["a", "bc"]
 
   """
   @spec split(t, t | [t] | Regex.t) :: [t]
@@ -191,6 +197,8 @@ defmodule String do
   def split(binary, pattern, options // [])
 
   def split("", _pattern, _options), do: [""]
+
+  def split(binary, "", options), do: split(binary, %r"", options)
 
   def split(binary, pattern, options) when is_regex(pattern) do
     Regex.split(pattern, binary, options)

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -36,6 +36,10 @@ defmodule StringTest do
 
     assert String.split(" a b c ", " ", trim: true) == ["a", "b", "c"]
     assert String.split(" a b c ", " ", trim: true, global: false) == ["a b c "]
+
+    assert String.split("abc", "") == ["a", "b", "c", ""]
+    assert String.split("abc", "", global: false) == ["a", "bc"]
+    assert String.split("abc", "", trim: true) == ["a", "b", "c"]
   end
 
   test :split_with_regex do


### PR DESCRIPTION
As discussed in #1688, currently the following fails:

```
iex> String.split "abc", ""
** (ArgumentError) argument error
    binary.erl:242: :binary.split/3
```

These changes add support for an empty binary pattern, piggybacking on
the empty regular expression split (vs using `String.graphemes`,
notably) so that the function continues to support the `:global`
option.

Users should probably be using `String.graphemes` for splitting, but
this keeps the API consistent while fixing this exception.

Closes #1688.
