### PR TITLE
Add persistent history to iex (ie ~/.iex_history)

### DIFF
--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -114,6 +114,7 @@ defmodule IEx.Server do
 
         config = config.cache(code).scope(nil).result(result)
         update_history(config)
+        append_to_history_log(config)
         config.update_counter(&1+1).cache('').binding(new_binding).scope(scope).result(nil)
 
       { :error, { line_no, error, token } } ->
@@ -165,6 +166,10 @@ defmodule IEx.Server do
 
   defp update_history(config) do
     IEx.History.append(config, config.counter)
+  end
+
+  defp append_to_history_log(config, filename // "~/.iex_history") do
+    File.write(Path.expand(filename), config.cache, [:append])
   end
 
   defp input_loop(iex_pid) do


### PR DESCRIPTION
First off... :heart_eyes_cat: thanks for creating Elixir!

In the course of learning it, I miss not having a record of iex command entries.  So I added that feature :smiley_cat:.

Use case:
Having a persistent ~/.iex_history between sessions is helpful when actively using a repl for development.  It also allows replaying prior histories by using TMUX, Vim, and a plugin to pipe text into a live iex session.

Note: It's a private method so I'm not sure about the standard practice for testing, but please feel free to nudge me in the right direction.

:smile:

-Zander
