### PR TITLE
Handling of multiple heredocs on the same line

### DIFF
--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -658,6 +658,9 @@ remove_heredoc_spaces([], Buffer, _Spaces, _Original) ->
 %% the remaining of the document and the number of spaces the heredoc
 %% is aligned.
 
+extract_heredoc_body(_Line, Marker, [{line,NewLine}|Rest], Buffer) ->
+  extract_heredoc_body(NewLine, Marker, Rest, Buffer);
+
 extract_heredoc_body(Line, Marker, Rest, Buffer) ->
   case extract_heredoc_line(Marker, Rest, Buffer, 0) of
     { ok, NewBuffer, NewRest } ->

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -133,4 +133,19 @@ defmodule ListTest do
     assert List.replace_at([1, 2, 3], -1, 0) == [1, 2, 0]
     assert List.replace_at([1, 2, 3], -4, 0) == [1, 2, 3]
   end
+
+  test :heredoc do
+    assert [ "a\n" ] == [ """ ]
+      a
+      """
+
+    assert [ "a\n", "b\n", "c\n", 1 ] == [ """, """, """, 1 ]
+      a
+      """
+      b
+      """
+      c
+      """
+
+  end
 end


### PR DESCRIPTION
Fixes #1697.

Adds an ability to have multiple heredocs on the same line like this:

```
[ """, """, 1 ]
a
"""
b
"""
```

which results in:

```
[ "a\n", "b\n", 1 ]
```
