### PR TITLE
Add String.category function

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -139,6 +139,32 @@ defmodule String do
   def printable?(_),    do: false
 
   @doc """
+  Get the Unicode general category of the codepoint, or nil if
+  the passed string does not represent a single valid code point.
+
+  The category is an atom like :Ll (for Letter, lowercase). For a complete list
+  of categories see the Unicode standard. [Wikipedia](https://en.wikipedia.org/wiki/Unicode_character_property#General_Category) also has a list.
+
+  ## Examples
+
+      iex> String.category("é")
+      :Ll
+      iex> String.category(" ")
+      :Zs
+      iex> String.category("")
+      nil
+      iex> String.category("ab")
+      nil
+  """
+  @spec category(t) :: { atom | binary }
+  def category(codepoint) do
+    case codepoint do
+      << cp :: utf8 >> -> String.Unicode.category_from_ordinal(cp)
+      _                -> nil
+    end
+  end
+
+  @doc """
   Splits a string on substrings at each Unicode whitespace
   occurrence with leading and trailing whitespace ignored.
 

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -455,4 +455,12 @@ defmodule StringTest do
       String.from_char_list!([0xDFFF])
     end
   end
+
+  test :category do
+    assert String.category("é")          == :Ll
+    assert String.category(" ")          == :Zs
+    assert String.category("")           == nil
+    assert String.category(<<255, 255>>) == nil
+    assert String.category("ab")         == nil
+  end
 end


### PR DESCRIPTION
It looks up the Unicode general category of a codepoint (whether it is a letter,
space, etc).

Unlike other functions in String.Unicode this uses a binary tree with ranges. Not sure whether that's the right approach but it seems better than having a huge list of cases because the tree only uses two comparisons per continuous range of categories and has the usual binary tree lookup complexity (O(log<sub>2</sub> n)). I'd expect the clauses to be checked one by one (though I could be wrong and Elixir or Erlang compiles them to very efficient code).
