### PR TITLE
Add stream versions of codepoints and graphemes

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -571,6 +571,29 @@ defmodule String do
   """
   @spec codepoints(t) :: [codepoint]
   defdelegate codepoints(string), to: String.Unicode
+  
+  @doc """
+  Returns all codepoints in the string as a stream.
+
+  ## Examples
+
+      iex> String.codepoints_stream("josé") |> Enum.to_list()
+      ["j", "o", "s", "é"]
+      iex> String.codepoints_stream("оптими зации") |> Enum.to_list()
+      ["о","п","т","и","м","и"," ","з","а","ц","и","и"]
+      iex> String.codepoints_stream("ἅἪῼ") |> Enum.to_list()
+      ["ἅ","Ἢ","ῼ"]
+
+  """
+  @spec codepoints_stream(t) :: Stream.t 
+  def codepoints_stream(binary) when is_binary(binary) do
+    Stream.unfold(binary, fn bin ->
+        case String.Unicode.next_codepoint(bin) do
+          { c, rest }  -> { c, rest }
+          :no_codepoint -> nil
+        end
+      end)
+  end
 
   @doc """
   Returns the next codepoint in a String.
@@ -681,6 +704,26 @@ defmodule String do
   """
   @spec graphemes(t) :: [grapheme]
   defdelegate graphemes(string), to: String.Unicode
+
+  @doc """
+  Returns unicode graphemes in the string as a stream.
+
+  ## Examples
+
+      iex> String.graphemes_stream("Ā̀stute") |> Enum.to_list()
+      ["Ā̀","s","t","u","t","e"]
+
+  """
+  @spec graphemes_stream(t) :: Stream.t
+  def graphemes_stream(binary) when is_binary(binary) do
+    Stream.unfold(binary, fn bin ->
+        case String.Unicode.next_grapheme(bin) do
+          { c, rest }  -> { c, rest }
+          :no_grapheme -> nil
+        end
+      end)
+  end
+
 
   @doc """
   Returns the next grapheme in a String.

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -198,9 +198,32 @@ defmodule StringTest do
   test :mixed_codepoints do
     assert String.codepoints("ϖͲϥЫݎߟΈټϘለДШव׆ש؇؊صلټܗݎޥޘ߉ऌ૫ሏᶆ℆ℙℱ ⅚Ⅷ↠∈⌘①ﬃ") == ["ϖ", "Ͳ", "ϥ", "Ы", "ݎ", "ߟ", "Έ", "ټ", "Ϙ", "ለ", "Д", "Ш", "व", "׆", "ש", "؇", "؊", "ص", "ل", "ټ", "ܗ", "ݎ", "ޥ", "ޘ", "߉", "ऌ", "૫", "ሏ", "ᶆ", "℆", "ℙ", "ℱ", " ", "⅚", "Ⅷ", "↠", "∈", "⌘", "①", "ﬃ"]
   end
+  
+  test :codepoints_stream do
+    assert String.codepoints_stream("elixir") |> Enum.to_list() == ["e", "l", "i", "x", "i", "r"]
+    assert String.codepoints_stream("elixír") |> Enum.to_list() == ["e", "l", "i", "x", "í", "r"] # slovak
+    assert String.codepoints_stream("ոգելից ըմպելիք") |> Enum.to_list() == ["ո", "գ", "ե", "լ", "ի", "ց", " ", "ը", "մ", "պ", "ե", "լ", "ի", "ք"] # armenian
+    assert String.codepoints_stream("эліксір") |> Enum.to_list() == ["э", "л", "і", "к", "с", "і", "р"] # belarussian
+    assert String.codepoints_stream("ελιξήριο") |> Enum.to_list() == ["ε", "λ", "ι", "ξ", "ή", "ρ", "ι", "ο"] # greek
+    assert String.codepoints_stream("סם חיים") |> Enum.to_list() == ["ס", "ם", " ", "ח", "י", "י", "ם"] # hebraic
+    assert String.codepoints_stream("अमृत") |> Enum.to_list() == ["अ", "म", "ृ", "त"] # hindi
+    assert String.codepoints_stream("স্পর্শমণি") |> Enum.to_list() == ["স", "্", "প", "র", "্", "শ", "ম", "ণ", "ি"] # bengali
+    assert String.codepoints_stream("સર્વશ્રેષ્ઠ ઇલાજ") |> Enum.to_list() == ["સ", "ર", "્", "વ", "શ", "્", "ર", "ે", "ષ", "્", "ઠ", " ", "ઇ", "લ", "ા", "જ"] # gujarati
+    assert String.codepoints_stream("世界中の一番") |> Enum.to_list() == ["世", "界", "中", "の", "一", "番"] # japanese
+    assert String.codepoints_stream("がガちゃ") |> Enum.to_list() == ["が", "ガ", "ち", "ゃ"]
+    assert String.codepoints_stream("") |> Enum.to_list() == []
+  end
+
+  test :mixed_codepoints_stream do
+    assert String.codepoints_stream("ϖͲϥЫݎߟΈټϘለДШव׆ש؇؊صلټܗݎޥޘ߉ऌ૫ሏᶆ℆ℙℱ ⅚Ⅷ↠∈⌘①ﬃ") |> Enum.to_list() == ["ϖ", "Ͳ", "ϥ", "Ы", "ݎ", "ߟ", "Έ", "ټ", "Ϙ", "ለ", "Д", "Ш", "व", "׆", "ש", "؇", "؊", "ص", "ل", "ټ", "ܗ", "ݎ", "ޥ", "ޘ", "߉", "ऌ", "૫", "ሏ", "ᶆ", "℆", "ℙ", "ℱ", " ", "⅚", "Ⅷ", "↠", "∈", "⌘", "①", "ﬃ"]
+  end
 
   test :graphemes do
     assert String.graphemes("Ā̀stute") == ["Ā̀", "s", "t", "u", "t", "e"]
+  end
+  
+  test :graphemes_stream do
+    assert String.graphemes_stream("Ā̀stute") |> Enum.to_list() == ["Ā̀", "s", "t", "u", "t", "e"]
   end
 
   test :next_grapheme do


### PR DESCRIPTION
For many tasks (such as finding out if a string is all upper case)
the conversion to list is unnecessary.
