### PR TITLE
Add to assert_receive(d) better expectation error message

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -298,6 +298,8 @@ defmodule ExUnit.Assertions do
     quote do
       receive do
         unquote(expected) = received -> received
+        unexpected ->
+          flunk unquote(message) || "Expected to have received message matching #{unquote binary}, got #{Macro.to_string(unexpected)}"
       after
         unquote(timeout) ->
           flunk unquote(message) || "Expected to have received message matching #{unquote binary}"

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -92,9 +92,29 @@ defmodule ExUnit.AssertionsTest do
     :hello = assert_receive :hello
   end
 
+  test "assert receive when does not match" do
+    self <- :world
+    try do
+      "This should never be tested" = assert_receive :hello
+    rescue
+      error in [ExUnit.AssertionError] ->
+        "Expected to have received message matching :hello, got :world" = error.message
+    end
+  end
+
   test "assert received does not wait" do
     self <- :hello
     :hello = assert_received :hello
+  end
+
+  test "assert received when does not match" do
+    self <- :world
+    try do
+      "This should never be tested" = assert_received :hello
+    rescue
+      error in [ExUnit.AssertionError] ->
+        "Expected to have received message matching :hello, got :world" = error.message
+    end
   end
 
   test "assert received when different" do


### PR DESCRIPTION
This PR adds a better expectation error on assert_receive(d). Ex_unit tests are OK, but I don't know why mix tests are failing.

Can anyone help me here? :)
