### PR TITLE
`Dict.size` incorrectly returning `true` when left dict is subset of right dict

### DIFF
--- a/lib/elixir/lib/dict/behaviour.ex
+++ b/lib/elixir/lib/dict/behaviour.ex
@@ -99,7 +99,7 @@ defmodule Dict.Behaviour do
       defoverridable values: 1
  
       def equal?(dict1, dict2) do
-        case size(dict1) == size(dict2) do
+        case Dict.size(dict1) == Dict.size(dict2) do
           false -> false
           true -> 
             try do

--- a/lib/elixir/test/elixir/dict_test.exs
+++ b/lib/elixir/test/elixir/dict_test.exs
@@ -214,6 +214,10 @@ defmodule DictTest.Common do
 
         dict2 = Dict.put(dict2, :a, 3)
         refute Dict.equal?(dict1, dict2)
+
+        dict3 = HashDict.new(a: 2, b: 3, f: 5, c: 123, z: 666)
+        refute Dict.equal?(dict1, dict3)
+        refute Dict.equal?(dict3, dict1)
       end
 
       test "unsupported dict" do


### PR DESCRIPTION
Fixes bug where `true` was incorrectly returned for `Dict.equal?` when the 1st argument was a subset of the 2nd argument.

e.g:

``` elixir
iex> h1 = HashDict.new(foo: 1, bar: 2)
iex> h2 = HashDict.new(foo: 1, bar: 2, baz: 3)
iex> Dict.equal?(h1, h2)
true # OOPS
iex> Dict.equal?(h2, h1)
false # works as expected other way round
```

The code to check equality was checking size (incorrectly), and then checking to see if every element in the first dict was present in the 2nd.

However, `size` was being used instead of `Dict.size`. This ended up calling `Kernel.size` instead - and would always return `true` regardless of whever the actual size of the `Dict` arguments were the same or not.
