### PR TITLE
add a few extra tests

### DIFF
--- a/lib/iex/lib/iex/ansi_docs.ex
+++ b/lib/iex/lib/iex/ansi_docs.ex
@@ -220,6 +220,10 @@ defmodule IEx.ANSIDocs do
     write_with_wrap(words, left_on_line - word_length - 1, max_columns, indent)
   end
 
+  defp look_for_markup(word) when size(word) < 2 do
+    { word, nil, nil, nil }
+  end
+
   defp look_for_markup(word) do
     if String.starts_with?(word, ["`", "_", "*"]) do
       <<first::utf8, word::binary>> = word

--- a/lib/iex/test/iex/ansi_docs_test.exs
+++ b/lib/iex/test/iex/ansi_docs_test.exs
@@ -79,5 +79,10 @@ defmodule IEx.AnsiDocsTest do
     assert result == "para1\n\n• one\n• two"
   end
 
+  test "star between words doesn't get interpreted as bold" do
+    result = format("unit * size")
+    assert result == "unit * size"
+  end
+
 
 end


### PR DESCRIPTION
I've added a few test for what follows. I'm having trouble testing the inline ones, because IO.ANSI.escape_fragment doesn't seem to return the leading escape sequence when testing. 

Anyway:
1. *, **, _ and so on are only considered delimiters if they are not followed by space:
   
   I believe the code already does this. Do you have an example where it doesn't?
2. Similar, a list is only marked as so if \* is followed by space;
   
   I think this is already there, too. 
3. The current implementation doesn't work with nested lists. Here is the expected result:
   
   iex(10)> Markdown.to_html "\* foo\n  \* bar"
   "<ul>\n<li>foo\n\n<ul>\n<li>bar</li>\n</ul></li>\n</ul>\n"
   
   That's a bug. I'll fix it
4. A paragraph is terminated when there are two new lines and any number of spaces in between those lines. We don't consider the spaces. I saw that when a list was not showing up:
   
   Do you have an example of this? It seems to work here.
5. Discussion: should we align the markdown paragraphs by default as we do here? That's because heredocs already do that in Elixir:
   
   """
   foo
   """
   # => "foo\n"

Elixir takes into account the closing """. If someone writes docs like this:

```
"""
    foo
"""
```

 I'd rather say they should fix their docs then silently accepting it (because other tools like ExDoc won't silently accept it).

That's easy to remove if you want.
