### PR TITLE
Implemented ability to skip individual unit tests.

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -1,5 +1,5 @@
 defmodule ExUnit do
-  defrecord Test, [:name, :case, :failure, :time] do
+  defrecord Test, [:name, :case, :skipped, :failure, :time] do
     @moduledoc """
     A record that keeps information about the test.
     It is received by formatters and also accessible

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -99,4 +99,31 @@ defmodule ExUnit.Case do
       def unquote(message)(unquote(var)), do: unquote(contents)
     end
   end
+
+  @doc """
+  Provides a macro to easily skip an entire test. The test
+  body will *not* be executed and will be reported as being
+  skipped by the test output formatter.
+
+  ## Examples
+
+      skip_test "skip this test" do
+        raise "this won't be executed."
+      end
+
+  """
+  defmacro skip_test(message, var // quote(do: _), contents) do
+    var      = Macro.escape(var)
+    contents = Macro.escape(contents, unquote: true)
+
+    quote bind_quoted: binding do
+      message = if is_binary(message) do
+        :"test #{message}"
+      else
+        :"test_#{message}"
+      end
+
+      def unquote(message)(unquote(var)), do: :skip
+    end
+  end
 end

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -19,6 +19,7 @@ defmodule ExUnit.Formatter do
   defcallback case_started(id, test_case) :: any
   defcallback case_finished(id, test_case) :: any
 
+  defcallback test_skipped(id, test) :: any
   defcallback test_started(id, test) :: any
   defcallback test_finished(id, test) :: any
 

--- a/lib/ex_unit/test/ex_unit/skip_test.exs
+++ b/lib/ex_unit/test/ex_unit/skip_test.exs
@@ -1,0 +1,10 @@
+Code.require_file "../test_helper.exs", __DIR__
+
+defmodule ExUnit.SkipTest do
+  use ExUnit.Case, async: true
+
+  skip_test "this test is skipped" do
+    raise "This should never be executed."
+  end
+
+end

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -23,6 +23,10 @@ defmodule ExUnit.NilFormatter do
     :ok
   end
 
+  def test_skipped(:ok, _test) do
+    :ok
+  end
+
   def test_finished(:ok, _test) do
     :ok
   end


### PR DESCRIPTION
Hi! Thanks for the wonderful work on elixir!

I am _very_ new to elixir, and as I was working through the elixir examples on [exercism.io](http://exercism.io/), I realized that there was no built-in way to skip individual `ex_unit` tests. I figured it would be a fun feature to try and add to elixir. I decided to take this on primarily to learn about the language and codebase, so **please be brutal** about both my approach and my implementation. I'm ready to learn!

In short, this PR adds the ability to skip an individual unit test by prefixing it with `skip_`. The following test now exists in the ex_unit test suite:

```
skip_test "this test is skipped" do
  raise "This should never be executed."
end
```

And it will result in the following output when tests are run:

![Skipped test console output](https://www.evernote.com/shard/s286/sh/70811928-c55f-42cb-8f62-1e6e5bfc802d/ce752518cf8b1a0ee0794351a6c64ee8/deep/0/1.%20Thanks%20for%20flying%20Vim%20(bash) 

Here's what I don't like about my approach:
- I don't like that a skipped test results in the `setup` and `teardown` callbacks being executed around the test, but I think removing that would require a lot more infrastructure in the runner to keep track of "real" tests and skipped tests differently.
- I feel like there's probably a pattern-matchy way to determine whether to respond with `:test_skipped` or `:test_finished`, but I resorted to explicit checks to make that determination.

Again, thanks for everything! Regardless of the outcome of this PR, I had a lot of fun digging into the `ExUnit` codebase, and I can't wait to do more elixir in the future!  
