### PR TITLE
Added a zen helper to IEx

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -284,6 +284,24 @@ defmodule IEx.Helpers do
   end
 
   @doc """
+  Prints the "Zen of Elixir".
+  """
+  def zen do
+    IO.puts IEx.color(:eval_info, """)
+    * Object-Orientation is not the only way to design code.
+    * Functional programming need not be complex or mathematical.
+    * The foundations of programming are not assignment, if statements, and loops.
+    * Concurrency does not need locks, semaphores, monitors, and the like.
+    * Processes are not necessarily expensive resources.
+    * Metaprogramming is not just something tacked onto a language.
+    * Even if it is work, programming should be fun.
+    
+      -- Dave Thomas in "Programming Elixir"
+    """
+    dont_display_result
+  end
+
+  @doc """
   Recompiles and reloads the specified module's source file.
 
   Please note that all the modules defined in the same file as `module`

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -129,6 +129,11 @@ defmodule IEx.HelpersTest do
            """
   end
 
+  test "zen helper" do
+    assert "* Object-Orientation is not the only way" <> _
+           = capture_iex("zen")
+  end
+
   test "flush helper" do
     assert capture_io(fn -> self() <- :hello; flush end) == ":hello\n"
   end


### PR DESCRIPTION
I was reading "Programming Elixir", and I was really inspired by Dave Thomas when he wrote:
- Object-Orientation is not the only way to design code.
- Functional programming need not be complex or mathematical.
- The foundations of programming are not assignment, if statements, and loops.
- Concurrency does not need locks, semaphores, monitors, and the like.
- Processes are not necessarily expensive resources.
- Metaprogramming is not just something tacked onto a language.
- Even if it is work, programming should be fun.
  
  -- Dave Thomas in "Programming Elixir"

This reminded me a lot of what happens when you write "import this" in Python. Hence, I added an IEx helper that outputs this message when you type zen.
