### PR TITLE
add power operator to kernel module

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -83,6 +83,23 @@ defmodule Kernel do
   end
 
   @doc """
+  Raise a number to a power. Result is a float.
+
+  ## Examples
+  
+      iex> 2 ** 8
+      256.0
+      iex> 100 ** 0
+      1.0
+      iex> 10 ** -1
+      0.1
+
+  """
+  def left ** right do
+    :math.pow(left, right)
+  end
+
+  @doc """
   Arithmetic division. Unlike other languages,
   the result is always a float. Use `div` and `rem` if you want
   a natural division or the remainder. Allowed in guard clauses.

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -239,6 +239,7 @@ defmodule KernelTest do
       assert kernel.-(2, 2) == 0
       assert kernel.*(2, 2) == 4
       assert kernel./(2, 2) == 1.0
+      assert kernel.**(2, 8) == 256.0
     end
 
     test :unary do


### PR DESCRIPTION
I was creating some maths and stats functions and missed the `**` operator (from ruby and python).

This is one commit adding this operator and a test case.
