### PR TITLE
added power operator to kernel module

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -100,6 +100,23 @@ defmodule Kernel do
   end
 
   @doc """
+  Raise a number to a power. Result is a float.
+
+  ## Examples
+  
+      iex> 2 ** 8
+      256.0
+      iex> 100 ** 0
+      1.0
+      iex> 10 ** -1
+      0.1
+
+  """
+  def left ** right do
+    :math.pow(left, right)
+  end
+
+  @doc """
   Sends a message to the process identified on the left.
   A process can be identified by its PID or, if it is registered,
   by an atom.

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -239,6 +239,7 @@ defmodule KernelTest do
       assert kernel.-(2, 2) == 0
       assert kernel.*(2, 2) == 4
       assert kernel./(2, 2) == 1.0
+      assert kernel.**(2, 8) == 256.0
     end
 
     test :unary do


### PR DESCRIPTION
I was playing with some math/stats functions and missing the power operator `**` that I am familiar with from python/ruby.

This pr contains one commit which adds the `**` operator to kernel module and one test case.
