### PR TITLE
Fix documentation wording on String.split/1

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -150,7 +150,7 @@ defmodule String do
   def printable?(_),    do: false
 
   @doc """
-  Splits a string on substrings at each Unicode whitespace
+  Divides a string into substrings at each Unicode whitespace
   occurrence with leading and trailing whitespace ignored.
 
   ## Examples


### PR DESCRIPTION
Make the beginning match String.split/3. The "on substrings" bit seemed odd and I liked how String.split/3 phrased it instead.
