### PR TITLE
:ok should the default gen_fsm reply

### DIFF
--- a/lib/elixir/lib/gen_fsm/behaviour.ex
+++ b/lib/elixir/lib/gen_fsm/behaviour.ex
@@ -186,7 +186,7 @@ defmodule GenFSM.Behaviour do
 
       @doc false
       def handle_sync_event(_event, from, state_name, state_data) do
-        { :reply, :default_implementation, state_name, state_data }
+        { :reply, :ok, state_name, state_data }
       end
 
       @doc false


### PR DESCRIPTION
`:default_implementation` is a weird atom to use.
