### PR TITLE
Give a good name (range) to the second param of String.slice/2

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -888,18 +888,18 @@ defmodule String do
   """
   @spec slice(t, Range.t) :: t | nil
 
-  def slice(string, Range[first: first, last: last]) when first >= 0 and last >= 0 do
+  def slice(string, Range[first: first, last: last] = range) when first >= 0 and last >= 0 do
     do_slice(next_grapheme(string), first, last, 0, "")
   end
 
-  def slice(string, Range[first: first, last: last]) when first < 0 and last >= 0 do
+  def slice(string, Range[first: first, last: last] = range) when first < 0 and last >= 0 do
     real_first = do_length(next_grapheme(string)) - abs(first)
     if real_first >= 0 do
       do_slice(next_grapheme(string), real_first, last, 0, "")
     end
   end
 
-  def slice(string, Range[first: first, last: last]) when first < 0 and last < 0 do
+  def slice(string, Range[first: first, last: last] = range) when first < 0 and last < 0 do
     real_first = do_length(next_grapheme(string)) - abs(first)
     real_last = do_length(next_grapheme(string)) - abs(last)
     if real_first >= 0 do


### PR DESCRIPTION
I checked the generated docs and realized that it was just showing `String.slice(string, arg2)` instead of something more helpful like `String.slice(string, range)`, so I gave the range param a name and now the docs look better. Sorry for missing that earlier!
