### PR TITLE
Fix typo s/Mix.Shell.error/Mix.shell.error/

### DIFF
--- a/lib/mix/lib/mix/rebar.ex
+++ b/lib/mix/lib/mix/rebar.ex
@@ -140,8 +140,8 @@ defmodule Mix.Rebar do
         config
       { :error, error } ->
         reason = :file.format_error(error)
-        Mix.Shell.error("Error evaluating rebar config script #{script_path}: #{reason}")
-        Mix.Shell.error("Any dependency defined in the script won't be available " <>
+        Mix.shell.error("Error evaluating rebar config script #{script_path}: #{reason}")
+        Mix.shell.error("Any dependency defined in the script won't be available " <>
           "unless you add them to your Mix project")
         config
     end


### PR DESCRIPTION
Resolves the following dialyzer warning from #1569:

```
lib/mix/lib/mix/rebar.ex:142: Call to missing or unexported function 'Elixir.Mix.Shell':error/1
```
