### PR TITLE
Fix Version.parse/1 specs

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -118,7 +118,7 @@ defmodule Version do
   @doc """
   Parse a version into a matchable value.
   """
-  @spec parse(String.t) :: { :ok, Schema.t } | { :error, term }
+  @spec parse(String.t) :: Schema.t
   def parse(string) when is_binary(string) do
     case Version.Parser.parse_version(string) do
       { :ok, matchable } -> from_matchable(matchable).source(string).build(get_build(string))


### PR DESCRIPTION
This resolves some dialyzer warnings from #1569, an example is:

```
lib/elixir/lib/version.ex:95: The call 'Elixir.Version':'match?'({'error',_} | {'ok',{'Elixir.Version.Schema',_,_,_,_,_,_}},requirement::any()) will never return since the success typing is ({'Elixir.Version.Schema',_,_,_,_,_,_},binary() | {'Elixir.Version.Requirement',_,[{atom() | tuple(),[any()],[any()]}]}) -> boolean() and the contract is (t(),requirement()) -> boolean()
```
