### PR TITLE
Fix invalid raises in Code

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -169,7 +169,7 @@ defmodule Code do
     valid = is_list(requires) and Enum.all?(requires, &is_atom(&1))
 
     unless valid do
-      raise ArgumentError, "expected :#{kind} option given to eval in the format: [module]"
+      raise ArgumentError, message: "expected :#{kind} option given to eval in the format: [module]"
     end
   end
 
@@ -179,7 +179,7 @@ defmodule Code do
     end)
 
     unless valid do
-      raise ArgumentError, "expected :#{kind} option given to eval in the format: [{ module, module }]"
+      raise ArgumentError, message: "expected :#{kind} option given to eval in the format: [{ module, module }]"
     end
   end
 
@@ -191,7 +191,7 @@ defmodule Code do
     end)
 
     unless valid do
-      raise ArgumentError, "expected :#{kind} option given to eval in the format: [{ module, [{ name, arity }] }]"
+      raise ArgumentError, message: "expected :#{kind} option given to eval in the format: [{ module, [{ name, arity }] }]"
     end
   end
 


### PR DESCRIPTION
`ArgumentError` were raised with incorrect arguments. Found by dialyzer warnings in #1569. An example of the warning was:

```
lib/elixir/lib/code.ex:172: The call 'Elixir.ArgumentError':exception(<<_:8,_:_*1>>) will never return since it differs in the 1st argument from the success typing arguments: ([{'__exception__' | 'message' | binary(),_}])
```
