### PR TITLE
Fix spec for Enum.chunks/4

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1321,7 +1321,7 @@ defmodule Enum do
 
   """
   @spec chunks(t, non_neg_integer, non_neg_integer) :: [list]
-  @spec chunks(t, non_neg_integer, non_neg_integer, list) :: [list]
+  @spec chunks(t, non_neg_integer, non_neg_integer, list | nil) :: [list]
   def chunks(coll, n, step, pad // nil) when n > 0 and step > 0 do
     { acc, buffer, i } =
       Enumerable.reduce(coll, { [], [], 0 }, fn


### PR DESCRIPTION
Resolves the following dialyzer warnings from #1569:

```
lib/elixir/lib/enum.ex:1299: Function chunks/2 has no local return
lib/elixir/lib/enum.ex:1299: The call 'Elixir.Enum':chunks(coll::any(),n::any(),n::any(),'nil') breaks the contract (t(),non_neg_integer(),non_neg_integer(),[any()]) -> [[any()]]
lib/elixir/lib/enum.ex:1325: Function chunks/3 has no local return
lib/elixir/lib/enum.ex:1325: The call 'Elixir.Enum':chunks(_@D0::any(),_@D1::any(),_@D2::any(),'nil') breaks the contract (t(),non_neg_integer(),non_neg_integer(),[any()]) -> [[any()]]
```
