### PR TITLE
Fix Regex specs

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -44,7 +44,7 @@ defmodule Regex do
   """
 
   defrecordp :regex, Regex, [:re_pattern, :source, :options, :groups]
-  @type t :: { Regex, term, binary, binary, [atom] }
+  @type t :: { Regex, term, binary, binary, [atom] | nil }
 
   defexception CompileError, message: "regex could not be compiled"
 
@@ -66,7 +66,7 @@ defmodule Regex do
       {:error, {'nothing to repeat', 0}}
 
   """
-  @spec compile(binary, binary | [term]) :: t
+  @spec compile(binary, binary | [term]) :: { :ok, t } | { :error, any }
   def compile(source, options // "")
 
   def compile(source, options) when is_binary(options) do


### PR DESCRIPTION
A couple of errors in the specs in the `Regex` module were found by the dialyzer warnings in #1569. A warning was:

```
ib/elixir/lib/regex.ex:69: Invalid type specification for function 'Elixir.Regex':compile/2. The success typing is (_,binary() | [any()]) -> {'error',{'invalid_option' | string(),binary() | non_neg_integer()}} | {'ok',{'Elixir.Regex',{'re_pattern',_,_,_},binary(),binary(),'nil' | [atom()]}}
```
