### PR TITLE
Fix IEx.Instrospection.beam_specs/1 when no abstract code in beam

### DIFF
--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -269,9 +269,14 @@ defmodule IEx.Introspection do
   end
 
   defp beam_specs(module) do
-    specs = Enum.map(Kernel.Typespec.beam_specs(module), &{:spec, &1})
-    callbacks = Enum.map(Kernel.Typespec.beam_callbacks(module), &{:callback, &1})
+    specs = beam_specs_tag(Kernel.Typespec.beam_specs(module), :spec)
+    callbacks = beam_specs_tag(Kernel.Typespec.beam_callbacks(module), :callback)
     specs && callbacks && Enum.concat(specs, callbacks)
+  end
+
+  defp beam_specs_tag(nil, _), do: nil
+  defp beam_specs_tag(specs, tag) do
+    Enum.map(specs, &{ tag, &1 })
   end
 
   defp print_type({ kind, type }) do


### PR DESCRIPTION
Previously `IEx.Introspection.beam_specs/1` would raise an error when a beam did not contain abstract code. This was found due to the following dialyzer warnings from #1569:

```
lib/iex/lib/iex/introspection.ex:225: The pattern 'nil' can never match the type maybe_improper_list()
lib/iex/lib/iex/introspection.ex:236: The pattern 'nil' can never match the type maybe_improper_list()
lib/iex/lib/iex/introspection.ex:255: The pattern 'nil' can never match the type maybe_improper_list()
```
