### PR TITLE
Fix Integer.parse/1 to remove dead code

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -38,10 +38,8 @@ defmodule Integer do
   """
   @spec parse(binary) :: { integer, binary } | :error
   def parse(<< ?-, char, rest :: binary >>) when char in ?0..?9 do
-    case parse(<< char, rest :: binary >>, 0) do
-      :error -> :error
-      { number, remainder } -> { -number, remainder }
-    end
+    { number, remainder } = parse(<< char, rest :: binary >>, 0)
+    { -number, remainder }
   end
 
   def parse(<< ?+, char, rest :: binary >>) when char in ?0..?9 do


### PR DESCRIPTION
Found by the following dialyzer warning from #1569:

```
lib/elixir/lib/integer.ex:42: The pattern 'error' can never match the type {integer(),bitstring()}
```
