### PR TITLE
Fix Macro.t spec to include Regex.t

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -6,7 +6,7 @@ defmodule Macro do
   """
 
   @typedoc "Abstract Syntax Tree (AST) node"
-  @type t :: { t, t } | { t, Keyword.t, t } | atom | number | binary | list
+  @type t :: { t, t } | { t, Keyword.t, t } | atom | number | binary | list | Regex.t
 
   @doc false
   defmacro binary_ops do


### PR DESCRIPTION
`Macro.t` was missing `Regex.t` from its list of possible types. Found by the following dialyzer warning from #1569:

```
lib/elixir/lib/kernel.ex:3426: The call 'Elixir.Macro':escape(regex::{'Elixir.Regex',{'re_pattern',_,_,_},binary(),binary(),'nil' | [atom()]}) will never return since the success typing is (atom() | binary() | [any()] | number() | {atom() | binary() | [any()] | number() | {atom() | binary() | [any()] | number() | {_,_} | {_,_,_},atom() | binary() | [any()] | number() | {_,_} | {_,_,_}} | {atom() | binary() | [any()] | number() | {_,_} | {_,_,_},[{_,_}],atom() | binary() | [any()] | number() | {_,_} | {_,_,_}},atom() | binary() | [any()] | number() | {atom() | binary() | [any()] | number() | {_,_} | {_,_,_},atom() | binary() | [any()] | number() | {_,_} | {_,_,_}} | {atom() | binary() | [any()] | number() | {_,_} | {_,_,_},[{_,_}],atom() | binary() | [any()] | number() | {_,_} | {_,_,_}}} | {atom() | binary() | [any()] | number() | {atom() | binary() | [any()] | number() | {_,_} | {_,_,_},atom() | binary() | [any()] | number() | {_,_} | {_,_,_}} | {atom() | binary() | [any()] | number() | {_,_} | {_,_,_},[{_,_}],atom() | binary() | [any()] | number() | {_,_} | {_,_,_}},[{atom(),_}],atom() | binary() | [any()] | number() | {atom() | binary() | [any()] | number() | {_,_} | {_,_,_},atom() | binary() | [any()] | number() | {_,_} | {_,_,_}} | {atom() | binary() | [any()] | number() | {_,_} | {_,_,_},[{_,_}],atom() | binary() | [any()] | number() | {_,_} | {_,_,_}}}) -> atom() | binary() | [any()] | number() | {atom() | binary() | [any()] | number() | {atom() | binary() | [any()] | number() | {_,_} | {_,_,_},atom() | binary() | [any()] | number() | {_,_} | {_,_,_}} | {atom() | binary() | [any()] | number() | {_,_} | {_,_,_},[{_,_}],atom() | binary() | [any()] | number() | {_,_} | {_,_,_}},atom() | binary() | [any()] | number() | {atom() | binary() | [any()] | number() | {_,_} | {_,_,_},atom() | binary() | [any()] | number() | {_,_} | {_,_,_}} | {atom() | binary() | [any()] | number() | {_,_} | {_,_,_},[{_,_}],atom() | binary() | [any()] | number() | {_,_} | {_,_,_}}} | {atom() | binary() | [any()] | number() | {atom() | binary() | [any()] | number() | {_,_} | {_,_,_},atom() | binary() | [any()] | number() | {_,_} | {_,_,_}} | {atom() | binary() | [any()] | number() | {_,_} | {_,_,_},[{_,_}],atom() | binary() | [any()] | number() | {_,_} | {_,_,_}},[{atom(),_}],atom() | binary() | [any()] | number() | {atom() | binary() | [any()] | number() | {_,_} | {_,_,_},atom() | binary() | [any()] | number() | {_,_} | {_,_,_}} | {atom() | binary() | [any()] | number() | {_,_} | {_,_,_},[{_,_}],atom() | binary() | [any()] | number() | {_,_} | {_,_,_}}} and the contract is ('Elixir.Macro':t()) -> 'Elixir.Macro':t()
```
