### PR TITLE
Fix elixir_errors.erl specs to include binary paths

### DIFF
--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -22,8 +22,8 @@ inspect(Atom) when is_atom(Atom) ->
 
 %% Raised during macros translation.
 
--spec syntax_error(non_neg_integer() | list(), file:filename(), binary() | string()) -> no_return().
--spec syntax_error(non_neg_integer() | list(), file:filename(), binary() | string(), list()) -> no_return().
+-spec syntax_error(non_neg_integer() | list(), file:filename_all(), binary() | string()) -> no_return().
+-spec syntax_error(non_neg_integer() | list(), file:filename_all(), binary() | string(), list()) -> no_return().
 
 syntax_error(Meta, File, Message) when is_list(Message) ->
   syntax_error(Meta, File, iolist_to_binary(Message));
@@ -47,7 +47,7 @@ compile_error(Meta, File, Format, Args)  ->
 
 %% Raised on tokenizing/parsing
 
--spec parse_error(non_neg_integer() | list(), file:filename(), iolist() | atom(), [] | iolist()) -> no_return().
+-spec parse_error(non_neg_integer() | list(), file:filename_all(), iolist() | atom(), [] | iolist()) -> no_return().
 
 parse_error(Meta, File, Error, []) ->
   Message = case Error of
@@ -75,7 +75,7 @@ parse_error(Meta, File, Error, Token) ->
 
 %% Raised during compilation
 
--spec form_error(non_neg_integer() | list(), file:filename(), module(), any()) -> no_return().
+-spec form_error(non_neg_integer() | list(), file:filename_all(), module(), any()) -> no_return().
 
 form_error(Meta, File, Module, Desc) ->
   Message = iolist_to_binary(format_error(Module, Desc)),
@@ -158,7 +158,7 @@ handle_file_warning(_, File, {Line,Module,Desc}) ->
 handle_file_warning(File, Desc) ->
   handle_file_warning(false, File, Desc).
 
--spec handle_file_error(file:filename(), {non_neg_integer(), module(), any()}) -> no_return().
+-spec handle_file_error(file:filename_all(), {non_neg_integer(), module(), any()}) -> no_return().
 
 handle_file_error(File, {Line,erl_lint,{unsafe_var,Var,{In,_Where}}}) ->
   Translated = case In of


### PR DESCRIPTION
Previously elixir_errors.erl did not allow binary paths according to its specs. Found by the following dialyzer warnings from #1569:

```
lib/iex/lib/iex/evaluator.ex:119: The call elixir_errors:parse_error(any(),#{#<105>(8, 1, 'integer', ['unsigned', 'big']), #<101>(8, 1, 'integer', ['unsigned', 'big']), #<120>(8, 1, 'integer', ['unsigned', 'big'])}#,"incomplete expression",[]) breaks the contract (non_neg_integer() | [any()],file:filename(),iolist() | atom(),[] | iolist()) -> no_return()
lib/iex/lib/iex/evaluator.ex:144: The call elixir_errors:parse_error(line@1::any(),#{#<105>(8, 1, 'integer', ['unsigned', 'big']), #<101>(8, 1, 'integer', ['unsigned', 'big']), #<120>(8, 1, 'integer', ['unsigned', 'big'])}#,error::any(),token::any()) breaks the contract (non_neg_integer() | [any()],file:filename(),iolist() | atom(),[] | iolist()) -> no_return()
```
