### PR TITLE
Fix type of executable passed to Port.open in IEx.CLI.tty_works/0

### DIFF
--- a/lib/iex/lib/iex/cli.ex
+++ b/lib/iex/lib/iex/cli.ex
@@ -65,7 +65,7 @@ defmodule IEx.CLI do
   # to do it just once.
   defp tty_works? do
     try do
-      port = Port.open { :spawn, :"tty_sl -c -e" }, [:eof]
+      port = Port.open { :spawn, 'tty_sl -c -e' }, [:eof]
       Port.close(port)
     catch
       _, _ -> false


### PR DESCRIPTION
It should be `Port.open({:spawn, charlist}, ...)` not `Port.open({:spawn, atom}, ...)`. Found by the following dialyzer warning from #1569:

```
lib/iex/lib/iex/cli.ex:68: The call 'Elixir.Port':open({'spawn', 'tty_sl -c -e'},['eof',...]) will never return since it differs in the 1st argument from the success typing arguments: ({'spawn',string()} | {'spawn_driver',[byte()]} | {'spawn_executable',atom() | [atom() | [any()] | char()]} | {'fd',non_neg_integer(),non_neg_integer()},['binary' | 'eof' | 'exit_status' | 'hide' | 'in' | 'nouse_stdio' | 'out' | 'stderr_to_stdout' | 'stream' | 'use_stdio' | {'arg0' | 'args' | 'cd' | 'env' | 'line' | 'packet' | 'parallelism',boolean() | binary() | [binary() | [any()] | char() | {_,_}] | non_neg_integer()}])
```
