### PR TITLE
Fix type of name passed to :code.lib_dir

### DIFF
--- a/lib/elixir/lib/record/extractor.ex
+++ b/lib/elixir/lib/record/extractor.ex
@@ -19,7 +19,7 @@ defmodule Record.Extractor do
   def retrieve(name, from_lib: file) when is_binary(file) do
     [app|path] = :filename.split(String.to_char_list!(file))
 
-    case :code.lib_dir(app) do
+    case :code.lib_dir(list_to_atom(app)) do
       { :error, _ } ->
         raise ArgumentError, message: "lib file #{file} could not be found"
       libpath ->


### PR DESCRIPTION
`:code.lib_dir/1` may only accept an atom in the future, and should only
be passed an atom according to the spec. Found from the following dialyzer warning from #1569:

```
lib/elixir/lib/record/extractor.ex:22: The call code:lib_dir(app::binary() | string()) breaks the contract (Name) -> file:filename() | {'error','bad_name'} when is_subtype(Name,atom())
```

Edit: Note warning at http://www.erlang.org/doc/man/code.html#lib_dir-1

Edit2: This is broken sorry.
