### PR TITLE
fix defrecord doc error

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1330,7 +1330,7 @@ defmodule Kernel do
       user = User[]
       #=> User[name: nil, age: 0]
 
-      User[user, name: "José", age: 25]
+      User[name: "José", age: 25]
       #=> User[name: "José", age: 25]
 
   And also a set of functions for working with the record


### PR DESCRIPTION
The defrecord documentation had an errant "user," which was apparently left over from a proposed but never accepted feature. 
