### PR TITLE
Completion of . (dot) terminates shell process

### DIFF
--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -51,7 +51,7 @@ defmodule IEx.Autocomplete do
 
   def expand([h|t]=expr) do
     cond do
-      h === ?. ->
+      h === ?. and t != []->
         expand_dot reduce(t)
       h === ?: ->
         expand_erlang_modules

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -21,7 +21,7 @@ defmodule IEx.AutocompleteTest do
   end
 
   test :erlang_module_multiple_values_completion do
-    {:yes, '', list} = expand(':user') 
+    {:yes, '', list} = expand(':user')
     assert length(list) > 1
   end
 
@@ -35,6 +35,7 @@ defmodule IEx.AutocompleteTest do
   end
 
   test :elixir_no_completion do
+    assert expand('.')   == {:no, '', []}
     assert expand('Xyz') == {:no, '', []}
   end
 
@@ -48,7 +49,7 @@ defmodule IEx.AutocompleteTest do
   end
 
   test :elixir_submodule_no_completion do
-    assert expand('IEx.Xyz') == {:no, '', []} 
+    assert expand('IEx.Xyz') == {:no, '', []}
   end
 
   test :elixir_function_completion do


### PR DESCRIPTION
Hi,

I run into an error when I try to complete (TAB) after a . (dot).

I use the elixir `HEAD` version https://github.com/elixir-lang/elixir/commit/7120a5e05053c83547c04187ceceb262a06fd023

``` shell
❯ iex
Erlang R16B01 (erts-5.10.2) [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Interactive Elixir (0.10.4-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> .*** ERROR: Shell process terminated! (^G to start new job) ***

=ERROR REPORT==== 30-Oct-2013::10:14:24 ===
Error in process <0.25.0> with exit value: {function_clause,[{string,tokens1,[nil,"(",[]],[{file,"string.erl"},{line,227}]},{'Elixir.IEx.Autocomplete',last_token,2,[{file,"/private/tmp/-1sUr/lib/iex/lib/iex/autocomplete.ex"},{line,112}]},{'Elixir.IEx.Autocomplete',expand...
```

cheers
