### PR TITLE
Make unicode the default for regular expressions

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -10,13 +10,12 @@ defmodule Regex do
       # A simple regular expressions that matches foo anywhere in the string
       %r/foo/
 
-      # A regular expression with case insensitive options and handling for unicode chars
-      %r/foo/iu
+      # A regular expression with case insensitive options
+      %r/foo/i
 
   The `re` module provides several options, the ones available in Elixir, followed by
   their shortcut in parenthesis, are:
 
-  * `unicode` (u) - enables unicode specific patterns like \p
   * `caseless` (i) - add case insensitivity
   * `dotall` (s) - causes dot to match newlines and also set newline to anycrlf.
     The new line setting can be overridden by setting `(*CR)` or `(*LF)` or
@@ -75,7 +74,9 @@ defmodule Regex do
         { :error, { :invalid_option, rest } }
 
       translated_options ->
-        compile(source, translated_options, options)
+        # Always use the unicode option, we don't have a latin1 legacy like
+        # Erlang.
+        compile(source, [:unicode|translated_options], options)
     end
   end
 
@@ -367,7 +368,10 @@ defmodule Regex do
   defp return_for(element) when is_binary(element), do: :binary
   defp return_for(element) when is_list(element),   do: :list
 
-  defp translate_options(<<?u, t :: binary>>), do: [:unicode|translate_options(t)]
+  defp translate_options(<<?u, t :: binary>>) do
+    IO.write "The /u flag for regular expressions is no longer needed\n#{Exception.format_stacktrace}"
+    translate_options(t)
+  end
   defp translate_options(<<?i, t :: binary>>), do: [:caseless|translate_options(t)]
   defp translate_options(<<?x, t :: binary>>), do: [:extended|translate_options(t)]
   defp translate_options(<<?f, t :: binary>>), do: [:firstline|translate_options(t)]

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -222,7 +222,7 @@ defmodule String do
 
   def split("", _pattern, _options), do: [""]
 
-  def split(binary, "", options), do: split(binary, %r""u, options)
+  def split(binary, "", options), do: split(binary, %r"", options)
 
   def split(binary, pattern, options) when is_regex(pattern) do
     Regex.split(pattern, binary, options)

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -42,11 +42,12 @@ defmodule Regex.BinaryTest do
   end
 
   test :opts do
-    assert Regex.opts(Regex.compile!("foo", "u")) == "u"
+    assert Regex.opts(Regex.compile!("foo", "i")) == "i"
   end
 
-  test :unicode do
-    assert ("josé" =~ %r"\p{Latin}$"u)
+  test :unicode_by_default do
+    assert ("josé" =~ %r"\p{Latin}$")
+    refute ("£" =~ %r/\p{Lu}/) 
   end
 
   test :groups do
@@ -168,7 +169,7 @@ defmodule Regex.BinaryTest do
   end
 
   defp matches_escaped?(string, match) do
-    Regex.match? %r/#{Regex.escape(string)}/usimx, match
+    Regex.match? %r/#{Regex.escape(string)}/simx, match
   end
 end
 


### PR DESCRIPTION
This doesn't include an option to turn unicode off. Not sure if that's really needed.
