### PR TITLE
underlines within links have to be escaped

### DIFF
--- a/lib/iex/lib/iex/ansi_docs.ex
+++ b/lib/iex/lib/iex/ansi_docs.ex
@@ -253,6 +253,21 @@ defmodule IEx.ANSIDocs do
   end
 
   defp handle_links(text) do
+    text
+    |> remove_square_brackets_in_link
+    |> escape_underlines_in_link
+  end
+
+  defp escape_underlines_in_link(text) do
+    case Regex.match?(%r{.*(https?\S*)}, text) do
+      true ->
+        Regex.replace(%r{_}, text, "\\\\_")
+      _ ->
+        text
+    end
+  end
+
+  defp remove_square_brackets_in_link(text) do
     Regex.replace(%r{\[(.*?)\]\((.*?)\)}, text, "\\1 (\\2)")
   end
 

--- a/lib/iex/test/iex/ansi_docs_test.exs
+++ b/lib/iex/test/iex/ansi_docs_test.exs
@@ -194,4 +194,11 @@ defmodule IEx.AnsiDocsTest do
     result = format("(`hello world`)")
     assert result == "(\e[36mhello world\e[0m)\n\e[0m"
   end
+
+  test "escaping of underlines within links" do
+    result = format("(http://en.wikipedia.org/wiki/ANSI_escape_code)")
+    assert result == "(http://en.wikipedia.org/wiki/ANSI_escape_code)\n\e[0m"
+    result = format("[ANSI escape code](http://en.wikipedia.org/wiki/ANSI_escape_code)")
+    assert result == "ANSI escape code (http://en.wikipedia.org/wiki/ANSI_escape_code)\n\e[0m"
+  end
 end


### PR DESCRIPTION
@josevalim That's a first attempt to fix the issue.

In links the underline will be escaped with the ansi escape sequence code `4` (underline).
To avoid this behavior it have to be properly escaped.

cheers

PS: I couldn't add the pull-request to the already open issue, so I had to make a separat PR. https://github.com/elixir-lang/elixir/issues/1811
