### PR TITLE
fix wrong error message for `nil.func()` call

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -277,7 +277,7 @@ defmodule Exception do
       iex> Exception.format_mfa Foo, :bar, []
       "Foo.bar()"
       iex> Exception.format_mfa nil, :bar, []
-      "bar()"
+      "nil.bar()"
 
   """
   def format_mfa(module, fun, arity) do
@@ -295,7 +295,6 @@ defmodule Exception do
     end
   end
 
-  defp format_module(nil), do: ""
   defp format_module(mod), do: "#{inspect mod}."
 
   @doc """

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -54,6 +54,7 @@ defmodule Kernel.ExceptionTest do
     assert Exception.format_mfa(Foo, nil, 1) == "Foo.nil/1"
     assert Exception.format_mfa(Foo, :bar, 1) == "Foo.bar/1"
     assert Exception.format_mfa(Foo, :bar, []) == "Foo.bar()"
+    assert Exception.format_mfa(nil, :bar, []) == "nil.bar()"
     assert Exception.format_mfa(:foo, :bar, [1, 2]) == ":foo.bar(1, 2)"
     assert Exception.format_mfa(Foo, :"bar baz", 1) == "Foo.\"bar baz\"/1"
   end
@@ -76,6 +77,7 @@ defmodule Kernel.ExceptionTest do
   test :undefined_function_message do
     assert UndefinedFunctionError.new.message == "undefined function"
     assert UndefinedFunctionError.new(module: Foo, function: :bar, arity: 1).message == "undefined function: Foo.bar/1"
+    assert UndefinedFunctionError.new(module: nil, function: :bar, arity: 0).message == "undefined function: nil.bar/0"
   end
 
   test :function_clause_message do
@@ -97,7 +99,7 @@ defmodule Kernel.ExceptionTest do
     end
     file = to_char_list(__FILE__)
     assert {Kernel.ExceptionTest, :test_raise_preserves_the_stacktrace, _,
-           [file: ^file, line: 93]} = stacktrace # line is sensitive
+           [file: ^file, line: 95]} = stacktrace # line is sensitive
   end
 
   defp empty_tuple, do: {}

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -183,11 +183,20 @@ defmodule IEx.Evaluator do
   end
 
   defp normalize_exception(:undef, [{ IEx.Helpers, fun, arity, _ }|t]) do
-    { UndefinedFunctionError[function: fun, arity: arity], t }
+    { RuntimeError[message: "undefined function: #{format_function(fun, arity)}"], t }
   end
 
   defp normalize_exception(exception, stacktrace) do
     { Exception.normalize(:error, exception), stacktrace }
+  end
+
+  defp format_function(fun, arity) do
+    cond do
+      is_list(arity) ->
+        "#{fun}/#{Enum.count(arity)}"
+      true ->
+        "#{fun}/#{arity}"
+    end
   end
 
   defp print_stacktrace(trace, callback) do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -152,9 +152,9 @@ defmodule IEx.HelpersTest do
 
   test "import_file helper" do
     with_file "dot-iex", "variable = :hello\nimport IO", fn ->
-      assert "** (UndefinedFunctionError) undefined function: variable()" <> _
+      assert "** (RuntimeError) undefined function: variable/0" <> _
              = capture_iex("variable")
-      assert "** (UndefinedFunctionError) undefined function: puts(\"hi\")" <> _
+      assert "** (RuntimeError) undefined function: puts/1" <> _
              = capture_iex("puts \"hi\"")
 
       assert capture_iex("import_file \"dot-iex\"\nvariable\nputs \"hi\"")
@@ -167,11 +167,11 @@ defmodule IEx.HelpersTest do
     dot_1 = "variable = :hello\nimport IO"
 
     with_file ["dot-iex", "dot-iex-1"], [dot, dot_1], fn ->
-      assert "** (UndefinedFunctionError) undefined function: parent()" <> _
+      assert "** (RuntimeError) undefined function: parent/0" <> _
              = capture_iex("parent")
-      assert "** (UndefinedFunctionError) undefined function: variable()" <> _
+      assert "** (RuntimeError) undefined function: variable/0" <> _
              = capture_iex("variable")
-      assert "** (UndefinedFunctionError) undefined function: puts(\"hi\")" <> _
+      assert "** (RuntimeError) undefined function: puts/1" <> _
              = capture_iex("puts \"hi\"")
 
       assert capture_iex("import_file \"dot-iex\"\nvariable\nputs \"hi\"\nparent")

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -60,10 +60,16 @@ defmodule IEx.InteractionTest do
     assert capture_iex("if true do ) false end") =~ "** (SyntaxError) iex:1: \"do\" starting at"
   end
 
+  test "undefined function" do
+    assert "** (RuntimeError) undefined function: format/0"   <> _ = capture_iex("format")
+    assert "** (RuntimeError) undefined function: with_one/1" <> _ = capture_iex("with_one(22)")
+    assert "** (RuntimeError) undefined function: many/3"     <> _ = capture_iex("many(:ok, 22, \"hi\")")
+  end
+
   ## .iex file loading
 
   test "no .iex" do
-    assert "** (UndefinedFunctionError) undefined function: my_variable()" <> _ = capture_iex("my_variable")
+    assert "** (RuntimeError) undefined function: my_variable/0" <> _ = capture_iex("my_variable")
   end
 
   test ".iex" do


### PR DESCRIPTION
The expected behavior for `nil.func()` should be:

``` elixir
iex(1)> nil.test()
** (UndefinedFunctionError) undefined function: nil.test/0
   nil.test()
```

Also via cli `elixir -e`:

``` shell
$ elixir -e 'nil.test()'
** (UndefinedFunctionError) undefined function: nil.test/0
   nil.test()
   ....
```

@josevalim as you can see I explicit give an `:no_module` symbol as argument for the module inside of `normalize_exception/2` function to get around the problem that `nil` get in front of every function name inside of the `UndefinedFunctionError` exception.

Maybe it's not the nicest solution, I'm open for feedback and ideas. :)

reference: https://github.com/elixir-lang/elixir/issues/1823
