### PR TITLE
Allow compilation in R17A

### DIFF
--- a/lib/elixir/rebar.config
+++ b/lib/elixir/rebar.config
@@ -24,4 +24,4 @@
             {verbose, false}
            ]}.
 
-{require_otp_vsn,"(R16B).*"}.
+{require_otp_vsn,"(R16B|R17A).*"}.


### PR DESCRIPTION
Allow elixir to be compiled using R17A as well. Fixes #1854.
