### PR TITLE
Add :++, :-- and :** to Macro#binary_op_props

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -42,6 +42,7 @@ defmodule Macro do
       o when o in [:+, :-]                                      -> {:left, 210}
       o when o in [:*, :/]                                      -> {:left, 220}
       o when o in [:<>]                                         -> {:right, 230}
+      o when o in [:++, :--, :**]                               -> {:right, 240}
       :^^^                                                      -> {:left, 250}
       :.                                                        -> {:left, 310}
     end

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -333,6 +333,7 @@ defmodule MacroTest do
     assert Macro.to_string(quote do: 1 + 2)   == "1 + 2"
     assert Macro.to_string(quote do: [ 1, 2 | 3 ]) == "[1, 2 | 3]"
     assert Macro.to_string(quote do: [h|t] = [1, 2, 3]) == "[h | t] = [1, 2, 3]"
+    assert Macro.to_string(quote do: (x ++ y) ++ z) == "(x ++ y) ++ z"
   end
 
   test :unary_ops_to_string do


### PR DESCRIPTION
This is about Issue #1865.

Thank you for the reference to elixir_parser.yrl. I've included the :++, :-- and :*\*  in the table. I am leaving the other ones (the followings), as I could find specific error cases.
- :->  
  - "fn -> xxx end" seems working fine.
- :~~~
  - It seems like unary operator though it's in binary_ops macro.
- :,
  - The list representation [1,2,3] is working fine.
