### PR TITLE
Enum.intersperse, change to join

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -632,6 +632,31 @@ defmodule Enum do
   end
 
   @doc """
+  Intersperses the `element` between each element of the enumeration.
+
+  Complexity: O(n)
+
+  ## Examples
+
+      iex> Enum.intersperse([1, 2, 3], 0)
+      [1, 0, 2, 0, 3]
+      iex> Enum.intersperse([1], 0)
+      [1]
+      iex> Enum.intersperse([], 0)
+      []
+
+  """
+  @spec intersperse(t, element) :: list 
+  def intersperse(collection, element) do
+    l = Enumerable.reduce(collection, [], fn(x, acc) -> [x | [element | acc]] end)
+        |> :lists.reverse()
+    case l do
+      []      -> []
+      [_ | t] -> t  # Head is a superfluous intersperser element
+    end
+  end
+  
+  @doc """
   Joins the given `collection` according to `joiner`.
   `joiner` can be either a binary or a list and the
   result will be of the same type as `joiner`. If

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -177,6 +177,12 @@ defmodule EnumTest.List do
     end
   end
 
+  test :intersperse do
+    assert Enum.intersperse([], true) == []
+    assert Enum.intersperse([1], true) == [1]
+    assert Enum.intersperse([1,2,3], true) == [1, true, 2, true, 3]
+  end
+
   test :join do
     assert Enum.join([], " = ") == ""
     assert Enum.join([1, 2, 3], " = ") == "1 = 2 = 3"
@@ -571,6 +577,14 @@ defmodule EnumTest.Range do
 
     range = Range.new(first: 1, last: 6)
     assert Enum.reject(range, fn(x) -> rem(x, 2) == 0 end) == [1, 3, 5]
+  end
+
+  test :intersperse do
+    range = Range.new(first: 1, last: 0)
+    assert Enum.intersperse(range, true) == [1, true, 0]
+
+    range = Range.new(first: 1, last: 3)
+    assert Enum.intersperse(range, false) == [1, false, 2, false, 3]
   end
 
   test :join do


### PR DESCRIPTION
Add an intersperse function and make join work with it (and with
iolist_to_binary). In theory that should be a minor performance improvement.

Not quite sure if the new join function is that much better in practice, it very much depends on how well iolist_to_binary performs, but that's a bif so it should be fairly fast.

Intersperse is different than join because join would (if the implementation actually obeyed the doc instead of failing when the joiner is a list) result in `[1, 0, 0, 2, 0, 0, 3]` for `Enum.join([1,2,3],[0,0])` whereas `Enum.intersperse([1,2,3],[0,0])` gives `[1, [0, 0], 2, [0, 0], 3]`.
