### PR TITLE
Minor consistency update to Dict.values doc

### DIFF
--- a/lib/elixir/lib/dict.ex
+++ b/lib/elixir/lib/dict.ex
@@ -102,7 +102,7 @@ defmodule Dict do
   end
 
   @doc """
-  Returns a list of all values in `dict`
+  Returns a list of all values in `dict`.
   The values are not guaranteed to be in any order.
 
   ## Examples


### PR DESCRIPTION
Adds a period to the end of the first line in the doc, for consistency
with the rest of the module

I am aware that it is trivial, but the generated doc looked a bit silly and I figured I might as well fix it, since I was going through the module anyway :)
