### PR TITLE
Updated 'make docs' to latest ex_doc cli args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ docs: compile ../ex_doc/bin/ex_doc
 	mkdir -p ebin
 	rm -rf docs
 	cp -R -f lib/*/ebin/*.beam ./ebin
-	bin/elixir ../ex_doc/bin/ex_doc "Elixir" "$(VERSION)" -m Kernel -u "https://github.com/elixir-lang/elixir" --source-ref "$(call SOURCE_REF)"
+	bin/elixir ../ex_doc/bin/ex_doc "Elixir" "$(VERSION)" "./ebin" -m Kernel -u "https://github.com/elixir-lang/elixir" --source-ref "$(call SOURCE_REF)"
 	rm -rf ebin
 
 ../ex_doc/bin/ex_doc:


### PR DESCRIPTION
`ex_doc` wants the path to the `.beam` files on the command line
