### PR TITLE
fix for issue #1896

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1371,6 +1371,8 @@ defmodule Enum do
       [[1, 2, 3], [3, 4, 5]]
       iex> Enum.chunks([1, 2, 3, 4, 5, 6], 3, 2, [7])
       [[1, 2, 3], [3, 4, 5], [5, 6, 7]]
+      iex> Enum.chunks([1, 2, 3, 4, 5, 6], 3, 3, [])
+      [[1, 2, 3], [4, 5, 6]]
 
   """
   @spec chunks(t, non_neg_integer, non_neg_integer) :: [list]
@@ -1384,7 +1386,7 @@ defmodule Enum do
           chunks_step(acc, [x|buffer], i + 1, step)
       end)
 
-    if nil?(pad) do
+    if nil?(pad) || i == 0 do
       :lists.reverse(acc)
     else
       buffer = :lists.reverse(buffer) ++ take(pad, n - i)

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -351,6 +351,7 @@ defmodule EnumTest.List do
     assert Enum.chunks([1, 2, 3, 4, 5, 6], 3, 2) == [[1, 2, 3], [3, 4, 5]]
     assert Enum.chunks([1, 2, 3, 4, 5, 6], 2, 3) == [[1, 2], [4, 5]]
     assert Enum.chunks([1, 2, 3, 4, 5, 6], 3, 2, []) == [[1, 2, 3], [3, 4, 5], [5, 6]]
+    assert Enum.chunks([1, 2, 3, 4, 5, 6], 3, 3, []) == [[1, 2, 3], [4, 5, 6]]
     assert Enum.chunks([1, 2, 3, 4, 5], 4, 4, 6..10) == [[1, 2, 3, 4], [5, 6, 7, 8]]
   end
 


### PR DESCRIPTION
If the enumerable is an even multiple of the counter (n) and an explicit
pad is given, you get an extra element.

Enum.chunks([1,2,3], 3)
iex> [[1,2,3]]
as expected, but

Enum.chunks([1,2,3], 3, 3, [""])
iex> [[1,2,3],[""]]
as not expected
