### PR TITLE
In response to "The string type is broken"

### DIFF
--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -15,7 +15,7 @@ defmodule StringTest do
     assert String.next_codepoint("") == :no_codepoint
   end
 
-  %% test cases described in http://mortoray.com/2013/11/27/the-string-type-is-broken/
+  # test cases described in http://mortoray.com/2013/11/27/the-string-type-is-broken/
   test :unicode do
     assert String.reverse("noël") == "lëon"
     assert String.slice("noël", 0..2) == "noë"


### PR DESCRIPTION
Since this blog post [1] caused some stir, I added
tests corresponding to how most languages referred
to are broken. Naturally, that's not the case for
Elixir.

[1] http://mortoray.com/2013/11/27/the-string-type-is-broken/
