### PR TITLE
Fix Version.match? with ~> and -dev versions

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -404,16 +404,16 @@ defmodule Version do
     defp approximate(version) do
       Version.from_matchable(case Regex.run(@version_regex, version) do
         [_, major] ->
-          { binary_to_integer(major) + 1, 0, 0, [] }
+          { binary_to_integer(major) + 1, 0, 0, [0] }
 
         [_, major, _] ->
-          { binary_to_integer(major) + 1, 0, 0, [] }
+          { binary_to_integer(major) + 1, 0, 0, [0] }
 
         [_, major, minor, _] ->
-          { binary_to_integer(major), binary_to_integer(minor) + 1, 0, [] }
+          { binary_to_integer(major), binary_to_integer(minor) + 1, 0, [0] }
 
         [_, major, minor, _, _] ->
-          { binary_to_integer(major), binary_to_integer(minor) + 1, 0, [] }
+          { binary_to_integer(major), binary_to_integer(minor) + 1, 0, [0] }
       end)
     end
 

--- a/lib/elixir/test/elixir/version_test.exs
+++ b/lib/elixir/test/elixir/version_test.exs
@@ -114,6 +114,8 @@ defmodule VersionTest do
 
     assert V.match?("0.9.3", "~> 0.9.3-dev")
     refute V.match?("0.10.0", "~> 0.9.3-dev")
+
+    refute V.match?("0.3.0-dev", "~> 0.2.0")
   end
 
   test :and do


### PR DESCRIPTION
Fixes #1918.
