### PR TITLE
Add floor and ceil functions to Float

### DIFF
--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -80,4 +80,49 @@ defmodule Float do
       result
     end
   end
+
+  @doc """
+  Round a float to the largest integer less than or equal to `num`
+
+  ## Examples
+      iex> Float.floor(34)
+      34
+      iex> Float.floor(34.25)
+      34
+      iex> Float.floor(-56.5)
+      -57
+
+  """
+  @spec floor(float | integer) :: integer
+  def floor(num) when is_integer(num), do: num
+  def floor(num) when is_float(num) do
+    truncated = :erlang.trunc(num)
+    case :erlang.abs(num - truncated) do
+      x when x > 0 and num < 0 -> truncated - 1
+      x -> truncated
+    end
+  end
+
+  @doc """
+  Round a float to the largest integer greater than or equal to `num`
+
+  ## Examples
+      iex> Float.ceil(34)
+      34
+      iex> Float.ceil(34.25)
+      35
+      iex> Float.ceil(-56.5)
+      -56
+
+  """
+  @spec ceil(float | integer) :: integer
+  def ceil(num) when is_integer(num), do: num
+  def ceil(num) when is_float(num) do
+    truncated = :erlang.trunc(num)
+    case :erlang.abs(num - truncated) do
+      x when x > 0 and num > 0 -> truncated + 1
+      x -> truncated
+    end
+  end
+
 end

--- a/lib/elixir/test/elixir/float_test.exs
+++ b/lib/elixir/test/elixir/float_test.exs
@@ -25,4 +25,36 @@ defmodule FloatTest do
     assert Float.parse("++1.2") === :error
     assert Float.parse("pi") === :error
   end
+
+  test :floor do
+    assert Float.floor(12) === 12
+    assert Float.floor(-12) === -12
+    assert Float.floor(12.524235) === 12
+    assert Float.floor(-12.5) === -13
+    assert Float.floor(-12.524235) === -13
+    assert Float.floor(7.5e3) === 7500
+    assert Float.floor(7.5432e3) === 7543
+    assert Float.floor(7.5e-3) === 0
+    assert Float.floor(-12.32453e4) === -123246
+    assert Float.floor(-12.32453e-10) === -1
+    assert Float.floor(0.32453e-10) === 0
+    assert Float.floor(-0.32453e-10) === -1
+    assert Float.floor(1.32453e-10) === 0
+  end
+
+  test :ceil do
+    assert Float.ceil(12) === 12
+    assert Float.ceil(-12) === -12
+    assert Float.ceil(12.524235) === 13
+    assert Float.ceil(-12.5) === -12
+    assert Float.ceil(-12.524235) === -12
+    assert Float.ceil(7.5e3) === 7500
+    assert Float.ceil(7.5432e3) === 7544
+    assert Float.ceil(7.5e-3) === 1
+    assert Float.ceil(-12.32453e4) === -123245
+    assert Float.ceil(-12.32453e-10) === 0
+    assert Float.ceil(0.32453e-10) === 1
+    assert Float.ceil(-0.32453e-10) === 0
+    assert Float.ceil(1.32453e-10) === 1
+  end
 end


### PR DESCRIPTION
Let me know if you spot anything wrong with this, I think the tests are fairly comprehensive, but if you can think of any edge cases I may have missed, I'll certainly add tests for them.

Right now this will take either an integer or a float, truncate it as part of the floor/ceil operation, then convert it back to a float. The result of calling Float.floor or Float.ceil will always be a float this way. I think that makes more sense than returning an integer, but let me know if that's an incorrect assumption.
