### PR TITLE
Add support for Enum.categorize/2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   * [File] Add `File.stream_to!/3`
   * [Float] Add `Float.floor/1` and `Float.ceil/1`
   * [Kernel] Add `List.delete_at/2` and `List.updated_at/3`
-  * [Kernel] Add `Enum.reverse/2` and `Enum.categorize/2`
+  * [Kernel] Add `Enum.reverse/2` and `Enum.group_by/2`
   * [Kernel] Implement `defmodule/2`, `@/1`, `def/2` and friends in Elixir itself. `case/2`, `try/2` and `receive/1` have been made special forms. `var!/1`, `var!/2` and `alias!/1` have also been implemented in Elixir and demoted from special forms
   * [Record] Support dynamic fields in `defrecordp`
   * [Stream] Add `Stream.resource/3`

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1118,12 +1118,12 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.categorize(%w{ant buffalo cat dingo}, &String.length/1)
+      iex> Enum.group_by(%w{ant buffalo cat dingo}, &String.length/1)
       [ 3: ["cat" "ant"], 7: ["buffalo"] 5: ["dingo"] ]
 
   """
-  @spec categorize(t, (element -> any)) :: HashDict
-  def categorize(collection, fun) do
+  @spec group_by(t, (element -> any)) :: HashDict
+  def group_by(collection, fun) do
     reduce(collection, HashDict.new, fn(entry, categories) ->
       Dict.update(categories, fun.(entry), [ entry ], &[entry|&1])
     end)                                         

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -220,9 +220,9 @@ defmodule EnumTest.List do
     assert Enum.partition([2, 4, 6], fn(x) -> rem(x, 2) == 0 end) == { [2, 4, 6], [] }
   end
 
-  test :categorize do
-    assert Enum.categorize([], fn -> nil end) == HashDict.new
-    result = Enum.categorize(1..10, &rem(&1,3))
+  test :group_by do
+    assert Enum.group_by([], fn -> nil end) == HashDict.new
+    result = Enum.group_by(1..10, &rem(&1,3))
     Enum.each 0..2, &(assert HashDict.has_key?(result, &1))
     assert Enum.sort(result[0]) == [3,6,9]
     assert Enum.sort(result[1]) == [1,4,7,10]


### PR DESCRIPTION
Takes a collection and a function. The function takes a value and returns a category for that value. The result is a hash where the keys are categories and the values are a list of elements from the collection for which the function returned that particular category.
