### PR TITLE
Add support for loading erlang configuration files

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1093,6 +1093,37 @@ defmodule File do
     end
   end
 
+  @doc """
+   Loads an erlang configuration, given by `file`, into the application
+   environment. Returns `{:ok, result}` on success,
+   or `{:error, reason}` in case of failure.
+  """
+  def load_config(file) do
+    case :file.consult(file |> to_char_list) do
+      { :ok, module_config } ->
+        Enum.each module_config, fn([{module, config}]) ->
+          Enum.each config, fn({key, value}) ->
+            :application.set_env(module, key, value)
+          end
+        end
+
+        { :ok, module_config }
+      { :error, reason } -> { :error, reason }
+    end
+  end
+
+  @doc """
+    Same as `load_config/1`, but raises an exception in case of failure.
+    Otherwise returns the configuration terms.
+  """
+  def load_config!(file) do
+    case load_config(file) do
+      { :ok, module_config } -> module_config
+      { :error, reason } ->
+        raise File.Error, reason: reason, action: "load config for", path: to_string(file)
+    end
+  end
+
   ## Helpers
 
   defp open_defaults([:charlist|t], _add_binary) do

--- a/lib/elixir/test/elixir/file_test.exs
+++ b/lib/elixir/test/elixir/file_test.exs
@@ -1285,6 +1285,42 @@ defmodule FileTest do
     end
   end
 
+  defmodule Config do
+    use Elixir.FileCase
+
+    test :load_config_valid do
+      fixture = tmp_path("conf")
+      File.write(fixture, "[{baz, [ {foo, <<\"bar\">>} ]}].")
+
+      assert File.load_config(fixture) == { :ok, [[baz: [foo: "bar"]]] }
+
+      assert :application.get_env(:baz, :foo) == {:ok, "bar"}
+    end
+
+    test :load_config_nonexistent_file do
+      fixture = tmp_path("conf")
+
+      message = %r"could not load config for #{escape fixture}: no such file or directory"
+
+      assert_raise File.Error, message, fn ->
+        File.load_config!(fixture)
+      end
+
+      assert File.load_config(fixture) == {:error, :enoent}
+    end
+
+    test :load_config_invalid do
+      fixture = tmp_path("conf")
+      File.write(fixture, "[{baz, [ {foo, <<bar\">>} ]}].")
+
+      assert_raise(File.Error, fn -> File.load_config!(fixture) end)
+
+      { status, result } = File.load_config(fixture)
+
+      assert status == :error
+    end
+  end
+
   defp last_year do
     last_year :calendar.local_time
   end


### PR DESCRIPTION
Today, if you want to load an erlang configuration file when running an application, you need to specify the erl option: e.g. `elixir --erl "-config config" -S mix run --no-halt`.

This Pull Request add the functions `File.load_config/1` and `File.load_config!/1` that perform the same behaviour.

If this is accepted, it would be possible to do: `mix run --no-halt -c config`.
