### PR TITLE
Add raw string compare in doctests for #Module<...>

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -140,7 +140,7 @@ defmodule Version do
 
   ## Examples
 
-      > Version.parse("2.0.1-alpha1")
+      iex> Version.parse("2.0.1-alpha1")
       #Version.Schema<2.0.1-alpha1>
 
   """
@@ -193,7 +193,7 @@ defmodule Version do
 
   ## Examples
 
-      > Version.from_matchable({2, 0, 1, ["alpha", 1]})
+      iex> Version.from_matchable({2, 0, 1, ["alpha", 1]})
       #Version.Schema<2.0.1-alpha.1>
 
   """

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -32,6 +32,19 @@ defmodule ExUnit.DocTestTest.GoodModule do
   ** (ArithmeticError) bad argument in arithmetic expression
   """
   def exception_test, do: :ok
+
+  @doc """
+  iex> HashDict.new a: 0, b: 1, c: 2
+  #HashDict<[a: 0, b: 1, c: 2]>
+  """
+  def inspect1_test, do: :ok
+
+  @doc """
+  iex> x = HashDict.new a: 0, b: 1, c: 2
+  ...> x
+  #HashDict<[a: 0, b: 1, c: 2]>
+  """
+  def inspect2_test, do: :ok
 end
 
 defmodule ExUnit.DocTestTest.ExceptionModule do


### PR DESCRIPTION
Will now do raw string compare for doctests of #Module<...> format:

``` iex
iex> HashDict.new a: 0, b: 1, c: 2
#HashDict<[a: 0, b: 1, c: 2]>
```
