### PR TITLE
Ignore build artifacts in _build folders.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 erl_crash.dump
 .dialyzer_plt
 .dialyzer.base_plt
+_build


### PR DESCRIPTION
It's been a while since I've worked on a PR to elixir itself, and I forgot to use `make test` instead of `mix test`, which failed and generated a `_build` folder.

Figured it'd be prudent to go ahead and ignore these to ease the lives of future developers who make the same command-line mishap.
