### PR TITLE
Fix to the error: unknown option points-at when invoking make docs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ clean_exbeam:
 
 #==> Release tasks
 
-SOURCE_REF = $(shell head="$$(git rev-parse HEAD)" tag="$$(git tag --points-at $$head | tail -1)" ; echo "$${tag:-$$head}\c")
+SOURCE_REF = $(shell head="$$(git rev-parse HEAD)" tag="$$(git tag --contains $$head | tail -1)" ; echo "$${tag:-$$head}\c")
 
 docs: compile ../ex_doc/bin/ex_doc
 	mkdir -p ebin


### PR DESCRIPTION
Before the fix:
elixir$ make docs
==> elixir (compile)
error: unknown option `points-at'
usage: git tag ...

After the fix:
elixir$ make docs
==> elixir (compile)
mkdir -p ebin
rm -rf docs
cp -R -f lib/_/ebin/_.beam ./ebin
bin/elixir ../ex_doc/bin/ex_doc "Elixir" "0.12.1-dev" "./ebin" -m Kernel -u "https://github.com/elixir-lang/elixir" --source-ref "349873ab633ae6a2646674073de90e808749c85c"
rm -rf ebin
elixir$ 
