### PR TITLE
fix bug in code sample for Stream.resource

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -892,14 +892,14 @@ defmodule Stream do
 
   ## Examples
 
-      Stream.resource(fn -> File.open("sample") end,
+      Stream.resource(fn -> File.open!("sample") end,
                       fn file ->
                         case IO.read(file, :line) do
                           data when is_binary(data) -> { data, file }
                           _ -> nil
                         end
                       end,
-                      fn file -> File.close!(file) end)
+                      fn file -> File.close(file) end)
 
   """
   @spec resource((() -> acc), (acc -> { element, acc } | nil), (acc -> term)) :: Enumerable.t


### PR DESCRIPTION
In the documentation for Stream.resource there's a sample code that
makes a reference to "File.close!", which doesn't exist.

Also, the pattern matching in the function passed as second argument
doesn't match {:ok, file}, so it should use "File.open!" instead.

Errors:
*\* (UndefinedFunctionError) undefined function: File.close!/1

*\* (FunctionClauseError) no function clause matching in :io.request/2
    io.erl:553: :io.request({:ok, #PID<0.50.0>}, {:get_line, :unicode,
[]})
