### PR TITLE
Stop GenServer on unknown call/cast request

### DIFF
--- a/lib/elixir/lib/gen_server/behaviour.ex
+++ b/lib/elixir/lib/gen_server/behaviour.ex
@@ -94,8 +94,8 @@ defmodule GenServer.Behaviour do
       end
 
       @doc false
-      def handle_call(_request, _from, state) do
-        { :noreply, state }
+      def handle_call(request, _from, state) do
+        { :stop, { :bad_call, request }, state }
       end
 
       @doc false
@@ -104,8 +104,8 @@ defmodule GenServer.Behaviour do
       end
 
       @doc false
-      def handle_cast(_msg, state) do
-        { :noreply, state }
+      def handle_cast(msg, state) do
+        { :stop, { :bad_call, msg }, state }
       end
 
       @doc false

--- a/lib/elixir/test/elixir/gen_server/behaviour_test.exs
+++ b/lib/elixir/test/elixir/gen_server/behaviour_test.exs
@@ -35,4 +35,18 @@ defmodule GenServer.BehaviourTest do
     assert :gen_server.cast(pid, { :push, :world }) == :ok
     assert :gen_server.call(pid, :pop) == :world
   end
+
+  test "call stops server on unknown requests" do
+    assert { :ok, pid } = :gen_server.start_link(Sample, [:hello], [])
+    Process.unlink(pid)
+    assert {{:bad_call, :unknown_request}, _} = catch_exit(:gen_server.call(pid, :unknown_request))
+  end
+
+  test "cast stops server on unknown requests" do
+    assert { :ok, pid } = :gen_server.start_link(Sample, [:hello], [])
+    Process.unlink(pid)
+    # Won't notice the server is stopped till we next send it a (valid) message
+    assert :gen_server.cast(pid, :unknown_request) == :ok
+    assert {{:bad_call, :unknown_request}, _} = catch_exit(:gen_server.call(pid, :pop))
+  end
 end


### PR DESCRIPTION
This references #1962.

No tests failed when I changed the behaviour.ex file. I'm new to Elixir / Erlang / OTP so unsure if the way I've gone about the tests is correct. The ones below unfortunately output too the error logger which dirties up the test output. I couldn't see a way around it but will happily change the tests if there's a better way.
