### PR TITLE
Improve error message for IEx.Helpers.r when module does not exist.

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -309,7 +309,7 @@ defmodule IEx.Helpers do
 
   defp do_r(module) do
     unless Code.ensure_loaded?(module) do
-      raise ArgumentError, message: "The module is not loaded and it could not be found"
+      raise ArgumentError, message: "could not load nor find module: #{inspect module}"
     end
 
     source = source(module)

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -305,7 +305,7 @@ defmodule IEx.HelpersTest do
   end
 
   test "r helper unavailable" do
-    assert_raise ArgumentError, "The module is not loaded and it could not be found", fn ->
+    assert_raise ArgumentError, "could not load nor find module: :non_existent_module", fn ->
       r :non_existent_module
     end
   end


### PR DESCRIPTION
Fixes https://github.com/elixir-lang/elixir/issues/1968

Before this commit, when trying to reload an unloaded module, the
user would see an error like:

iex(1)> r InexistentModule
*\* (UndefinedFunctionError) undefined function: InexistentModule.module_info/1
    InexistentModule.module_info(:compile)
    lib/iex/lib/iex/helpers.ex:352: IEx.Helpers.source/1
    lib/iex/lib/iex/helpers.ex:311: IEx.Helpers.do_r/1
    lib/iex/lib/iex/helpers.ex:304: IEx.Helpers.r/1

After this commit, the user should see

iex(1)> r InexistentModule
*\* (ArgumentError) Unloaded module Elixir.InexistentModule. Try loading the module's beam file with `IEx.Helpers.l\1`
    lib/iex/lib/iex/helpers.ex:312: IEx.Helpers.do_r/1
    lib/iex/lib/iex/helpers.ex:304: IEx.Helpers.r/1

Which is more informative.
