### PR TITLE
add exit function to IEx.Helpers

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -460,6 +460,11 @@ defmodule IEx.Helpers do
   end
 
   @doc """
+  Cleanly exit the current iex session
+  """
+  def exit, do: System.halt
+
+  @doc """
   Evaluates the contents of the file at `path` as if it were directly typed into
   the shell. `path` has to be a literal binary.
 


### PR DESCRIPTION
I'm constantly wanting to type exit, and I discovered
System.halt and it seems so much nicer than a double control-c
