### PR TITLE
fix issue with Float.round/3 (midpoint_rounding)

### DIFF
--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -141,27 +141,22 @@ defmodule Float do
 
   @doc """
   Rounds a floating point value to an arbitrary number of fractional digits
-  (between 0 and 15) with an optional midpoint rounding mode (:up or :down, 
-  defaults to :up).
+  (between 0 and 15).
 
   ## Examples
 
+      iex> Float.round(5.5674, 3)
+      5.567
       iex> Float.round(5.5675, 3)
       5.568
-      iex> Float.round(5.5675, 3, :down)
-      5.567
-      iex> Float.round(-5.5675, 3)
+      iex> Float.round(-5.5674, 3)
       -5.567
-      iex> Float.round(-5.5675, 3, :down)
+      iex> Float.round(-5.5675, 3)
       -5.568
   """
-  @spec round(float, integer, atom | nil) :: float
-  def round(number, precision, midpoint_rounding // :up) when is_float(number) and is_integer(precision) and precision in 0..15 do
-    # Default to :up if anything but :down is provided for midpoint rounding mode
-    case midpoint_rounding do
-      :down -> Kernel.round(Float.floor(number * :math.pow(10, precision))) / :math.pow(10, precision)
-      _     -> Kernel.round(Float.ceil(number * :math.pow(10, precision))) / :math.pow(10, precision)
-    end
+  @spec round(float, integer) :: float
+  def round(number, precision) when is_float(number) and is_integer(precision) and precision in 0..15 do
+    Kernel.round(number * :math.pow(10, precision)) / :math.pow(10, precision)
   end
 
 end

--- a/lib/elixir/test/elixir/float_test.exs
+++ b/lib/elixir/test/elixir/float_test.exs
@@ -61,14 +61,10 @@ defmodule FloatTest do
 
   test :round do
     assert Float.round(5.5675, 3) === 5.568
-    assert Float.round(5.5675, 3, :down) === 5.567
+    assert Float.round(-5.5674, 3) === -5.567
     assert Float.round(5.5, 3) === 5.5
     assert Float.round(5.5e-10, 10) === 6.0e-10
-    assert Float.round(5.5e-10, 10, :down) === 5.0e-10
-    assert Float.round(5.5e-10, 8) === 1.0e-8
-    assert Float.round(5.5e-10, 8, :down) === 0.0
+    assert Float.round(5.5e-10, 8) === 0.0
     assert Float.round(5.0, 0) === 5.0
-    assert Float.round(-1.3456, 3) === -1.345
-    assert Float.round(-1.3456, 3, :down) === -1.346
   end
 end


### PR DESCRIPTION
There is an issue in Float.round/3, where the midpoint rounding is causing the number to always round up by default or down if that option is passed.  This PR removes the midpoint_rounding option and will always midpoint round away from 0 (same as ruby).

Current: 

``` elixir
iex> Float.round(3.991, 2)
4.0 # incorrect, should round to 3.99
iex> Float.round(3.996, 2, :down)
3.99 # incorrect, should only round 3.995 down
```

After this change:

``` elixir
iex> Float.round(3.991, 2)
3.99
iex> Float.round(3.995, 2)
4.0
```
