### PR TITLE
Fix functions as default values in records

### DIFF
--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -916,6 +916,7 @@ defmodule Record do
       raise ArgumentError, message: "record field default value #{inspect atom} can only contain " <>
                                     "functions that point to an existing &Mod.fun/arity"
     end
+    other
   end
 
   defp check_value(atom, other) when is_reference(other) or is_pid(other) or is_port(other) do


### PR DESCRIPTION
successful check_value/2 needs to return its second argument

before:

iex(1)> defrecord Baz, foo: &Dict.get/1, bar: 4711
iex(2)> IO.puts inspect Baz[]
Baz[foo: nil, bar: 4711]
:ok
iex(3)> 

after:

iex(4)> defrecord Baz, foo: &Dict.get/1, bar: 4711  
iex(5)> IO.puts inspect Baz[]  
Baz[foo: &Dict.get/1, bar: 4711]
:ok
iex(6)> 
