### PR TITLE
print_doc_arg attempted to handle arguments with defaults. 

### DIFF
--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -178,7 +178,7 @@ defmodule IEx.Introspection do
   end
 
   defp print_doc_arg({ :\\, _, [left, right] }) do
-    print_doc_arg(left) <> " \\ " <> Macro.to_string(right)
+    print_doc_arg(left) <> " \\\\ " <> Macro.to_string(right)
   end
 
   defp print_doc_arg({ var, _, _ }) do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -13,7 +13,7 @@ defmodule IEx.HelpersTest do
   @doc """
   Test function 2
   """
-  def test_fun_1(arg), do: arg
+  def test_fun_1(arg \\ 99), do: arg
 
   test "clear helper" do
     assert "\e[H\e[2J" == capture_iex("clear")
@@ -37,7 +37,7 @@ defmodule IEx.HelpersTest do
 
   test "h helper function" do
     doc_1 = "* def test_fun_1()\n\nTest function 1\n\n"
-    doc_2 = "* def test_fun_1(arg)\n\nTest function 2\n\n"
+    doc_2 = "* def test_fun_1(arg \\\\ 99)\n\nTest function 2\n\n"
 
     assert capture_io(fn -> h IEx.HelpersTest.test_fun_1/0 end) == doc_1
     assert capture_io(fn -> h IEx.HelpersTest.test_fun_1/1 end) == doc_2


### PR DESCRIPTION
However, it added " \ " between them, which is actually the string " \ ".  This meant that (for example) 

```
h IO.puts
```

 displayed 

```
def puts(device \ group_leader(), item)
```

Changed `print_doc_arg` to escape both backslashes.
