### PR TITLE
deprecated char_list from Regex module

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -37,9 +37,7 @@ defmodule Regex do
   * `newline` - not available, use `(*CR)` or `(*LF)` or `(*CRLF)` or `(*ANYCRLF)`
     or `(*ANY)` at the beginning of the regexp according to the re documentation
 
-  Most of the functions in this module accept either a binary or a char list
-  as subject. The result is based on the argument (a binary will return
-  a binary, a char list will return a char list).
+  Most functions return a binary.
   """
 
   defrecordp :regex, Regex, [:re_pattern, :source, :options, :groups]
@@ -80,7 +78,7 @@ defmodule Regex do
     end
   end
 
-  def compile(source, options) when is_list(options) do
+  def compile(source, options) do
     compile(source, options, "")
   end
 
@@ -346,7 +344,7 @@ defmodule Regex do
       "\\\\what\\ if"
 
   """
-  @spec escape(String.t | char_list) :: String.t | char_list
+  @spec escape(String.t) :: String.t 
   def escape(string) do
     :re.replace(string, @escape_pattern, "\\\\&", [:global, { :return, return_for(string) }])
   end
@@ -366,7 +364,6 @@ defmodule Regex do
   # Private Helpers
 
   defp return_for(element) when is_binary(element), do: :binary
-  defp return_for(element) when is_list(element),   do: :list
 
   defp translate_options(<<?u, t :: binary>>) do
     IO.write "The /u flag for regular expressions is no longer needed\n#{Exception.format_stacktrace}"

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -70,12 +70,12 @@ defmodule Regex.BinaryTest do
   end
 
   test :named_captures do
-    assert Keyword.equal? Regex.named_captures(~r/(?<foo>c)(?<bar>d)/g, 'abcd'), [bar: 'd', foo: 'c']
-    assert Regex.named_captures(~r/c(?<foo>d)/g, 'abcd') == [foo: 'd']
-    assert Regex.named_captures(~r/c(?<foo>d)/g, 'no_match') == nil
-    assert Regex.named_captures(~r/c(?<foo>d|e)/g, 'abcd abce') == [foo: 'd']
-    assert Regex.named_captures(~r/c(?<foo>d)/g, 'abcd', return: :binary) == [foo: "d"]
-    assert Regex.named_captures(~r/c(.)/g, 'cat') == []
+    assert Keyword.equal? Regex.named_captures(~r/(?<foo>c)(?<bar>d)/g, "abcd"), [bar: "d", foo: "c"]
+    assert Regex.named_captures(~r/c(?<foo>d)/g, "abcd") == [foo: "d"]
+    assert Regex.named_captures(~r/c(?<foo>d)/g, "no_match") == nil
+    assert Regex.named_captures(~r/c(?<foo>d|e)/g, "abcd abce") == [foo: "d"]
+    assert Regex.named_captures(~r/c(?<foo>d)/g, "abcd", return: :binary) == [foo: "d"]
+    assert Regex.named_captures(~r/c(.)/g, "cat") == []
   end
 
   test :sigil_R do
@@ -89,10 +89,10 @@ defmodule Regex.BinaryTest do
   end
 
   test :run_with_groups do
-    assert Regex.run(~r/c(?<foo>d)/g, 'abcd', capture: :groups) == ['d']
-    assert Regex.run(~r/c(?<foo>d)/g, 'no_match', capture: :groups) == nil
-    assert Regex.run(~r/c(?<foo>d|e)/g, 'abcd abce', capture: :groups) == ['d']
-    assert Regex.run(~r/c(?<foo>d)/g, 'abcd', return: :binary, capture: :groups) == ["d"]
+    assert Regex.run(~r/c(?<foo>d)/g, "abcd", capture: :groups) == ["d"]
+    assert Regex.run(~r/c(?<foo>d)/g, "no_match", capture: :groups) == nil
+    assert Regex.run(~r/c(?<foo>d|e)/g, "abcd abce", capture: :groups) == ["d"]
+    assert Regex.run(~r/c(?<foo>d)/g, "abcd", return: :binary, capture: :groups) == ["d"]
   end
 
   test :run_with_indexes do
@@ -108,11 +108,11 @@ defmodule Regex.BinaryTest do
   end
 
   test :scan_with_groups do
-    assert Regex.scan(~r/cd/g, 'abcd', capture: :groups) == []
-    assert Regex.scan(~r/c(?<foo>d)/g, 'abcd', capture: :groups) == [['d']]
-    assert Regex.scan(~r/c(?<foo>d)/g, 'no_match', capture: :groups) == []
-    assert Regex.scan(~r/c(?<foo>d|e)/g, 'abcd abce', capture: :groups) == [['d'], ['e']]
-    assert Regex.scan(~r/c(?<foo>d)/g, 'abcd', return: :binary, capture: :groups) == [["d"]]
+    assert Regex.scan(~r/cd/g, "abcd", capture: :groups) == []
+    assert Regex.scan(~r/c(?<foo>d)/g, "abcd", capture: :groups) == [["d"]]
+    assert Regex.scan(~r/c(?<foo>d)/g, "no_match", capture: :groups) == []
+    assert Regex.scan(~r/c(?<foo>d|e)/g, "abcd abce", capture: :groups) == [["d"], ["e"]]
+    assert Regex.scan(~r/c(?<foo>d)/g, "abcd", return: :binary, capture: :groups) == [["d"]]
   end
 
   test :split do
@@ -190,40 +190,40 @@ defmodule Regex.ListTest do
   end
 
   test :run do
-    assert Regex.run(~r'c(d)', 'abcd') == ['cd', 'd']
-    assert Regex.run(~r'e', 'abcd') == nil
+    assert Regex.run(~r"c(d)", "abcd") == ["cd", "d"]
+    assert Regex.run(~r'e', "abcd") == nil
     assert Regex.run(~r"c(d)", "abcd", return: :binary) == ["cd", "d"]
   end
 
   test :indexes do
-    assert Regex.run(~r'c(d)', 'abcd', return: :index) == [{2, 2}, {3, 1}]
-    assert Regex.run(~r'e', 'abcd', return: :index) == nil
+    assert Regex.run(~r'c(d)', "abcd", return: :index) == [{2, 2}, {3, 1}]
+    assert Regex.run(~r'e', "abcd", return: :index) == nil
   end
 
   test :scan do
-    assert Regex.scan(~r'c(d|e)', 'abcd abce') == [['cd', 'd'], ['ce', 'e']]
-    assert Regex.scan(~r'c(?:d|e)', 'abcd abce') == [['cd'], ['ce']]
-    assert Regex.scan(~r'e', 'abcd') == []
-    assert Regex.scan(~r'c(d|e)', 'abcd abce', return: :binary) == [["cd", "d"], ["ce", "e"]]
+    assert Regex.scan(~r"c(d|e)", "abcd abce") == [["cd", "d"], ["ce", "e"]]
+    assert Regex.scan(~r"c(?:d|e)", "abcd abce") == [["cd"], ["ce"]]
+    assert Regex.scan(~r'e', "abcd") == []
+    assert Regex.scan(~r'c(d|e)', "abcd abce", return: :binary) == [["cd", "d"], ["ce", "e"]]
   end
 
   test :split do
-    assert Regex.split(~r' ', 'foo bar baz') == ['foo', 'bar', 'baz']
-    assert Regex.split(~r' ', 'foo bar baz', parts: 2) == ['foo', 'bar baz']
-    assert Regex.split(~r'\s', 'foobar') == ['foobar']
+    assert Regex.split(~r' ', "foo bar baz") == ["foo", "bar", "baz"]
+    assert Regex.split(~r' ', "foo bar baz", parts: 2) == ["foo", "bar baz"]
+    assert Regex.split(~r'\s', "foobar") == ["foobar"]
   end
 
   test :replace do
-    assert Regex.replace(~r(d), 'abc', 'd') == 'abc'
-    assert Regex.replace(~r(b), 'abc', 'd') == 'adc'
-    assert Regex.replace(~r(b), 'abc', '[&]') == 'a[b]c'
-    assert Regex.replace(~r(b), 'abc', '[\\&]') == 'a[&]c'
-    assert Regex.replace(~r[(b)], 'abc', '[\\1]') == 'a[b]c'
+    assert Regex.replace(~r(d), "abc", "d") == "abc"
+    assert Regex.replace(~r(b), "abc", "d") == "adc"
+    assert Regex.replace(~r(b), "abc", "[&]") == "a[b]c"
+    assert Regex.replace(~r(b), "abc", "[\\&]") == "a[&]c"
+    assert Regex.replace(~r[(b)], "abc", "[\\1]") == "a[b]c"
 
-    assert Regex.replace(~r(d), 'abcbe', 'd') == 'abcbe'
-    assert Regex.replace(~r(b), 'abcbe', 'd') == 'adcde'
-    assert Regex.replace(~r(b), 'abcbe', '[&]') == 'a[b]c[b]e'
-    assert Regex.replace(~r(b), 'abcbe', '[\\&]') == 'a[&]c[&]e'
-    assert Regex.replace(~r[(b)], 'abcbe', '[\\1]') == 'a[b]c[b]e'
+    assert Regex.replace(~r(d), "abcbe", "d") == "abcbe"
+    assert Regex.replace(~r(b), "abcbe", "d") == "adcde"
+    assert Regex.replace(~r(b), "abcbe", "[&]") == "a[b]c[b]e"
+    assert Regex.replace(~r(b), "abcbe", "[\\&]") == "a[&]c[&]e"
+    assert Regex.replace(~r[(b)], "abcbe", "[\\1]") == "a[b]c[b]e"
   end
 end


### PR DESCRIPTION
Removed all traces of a char_list in `Regex` module.
I changed the failing tests to not expect a char_list.
