### PR TITLE
Use a gen_server for exunit formatter dispatch

### DIFF
--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -1,41 +1,12 @@
 defmodule ExUnit.CLIFormatter do
   @moduledoc false
-  @timeout 30_000
-  @behaviour ExUnit.Formatter
 
-  use GenServer.Behaviour
+  use GenEvent.Behaviour
 
   import ExUnit.Formatter, only: [format_time: 2, format_filters: 2, format_test_failure: 5, format_test_case_failure: 4]
 
   defrecord Config, tests_counter: 0, invalids_counter: 0, failures_counter: 0,
                     skips_counter: 0, trace: false, color: true, previous: nil
-
-  ## Behaviour
-
-  def suite_started(opts) do
-    { :ok, pid } = :gen_server.start_link(__MODULE__, opts, [])
-    pid
-  end
-
-  def suite_finished(id, run_us, load_us) do
-    :gen_server.call(id, { :suite_finished, run_us, load_us }, @timeout)
-  end
-
-  def case_started(id, test_case) do
-    :gen_server.cast(id, { :case_started, test_case })
-  end
-
-  def case_finished(id, test_case) do
-    :gen_server.cast(id, { :case_finished, test_case })
-  end
-
-  def test_started(id, test) do
-    :gen_server.cast(id, { :test_started, test })
-  end
-
-  def test_finished(id, test) do
-    :gen_server.cast(id, { :test_finished, test })
-  end
 
   ## Callbacks
 
@@ -44,72 +15,68 @@ defmodule ExUnit.CLIFormatter do
     { :ok, Config.new(opts) }
   end
 
-  def handle_call({ :suite_finished, run_us, load_us }, _from, config = Config[]) do
+  def handle_event({ :suite_finished, run_us, load_us }, config = Config[]) do
     print_suite(config, run_us, load_us)
-    { :stop, :normal, config.failures_counter, config }
+    { :ok, config }
   end
 
-  def handle_call(reqest, from, config) do
-    super(reqest, from, config)
-  end
-
-  def handle_cast({ :test_started, ExUnit.Test[] = test }, config) do
+  def handle_event({ :test_started, ExUnit.Test[] = test }, config = Config[]) do
     if config.trace, do: IO.write("  * #{trace_test_name test}")
-    { :noreply, config }
+    { :ok, config }
   end
 
-  def handle_cast({ :test_finished, ExUnit.Test[state: :passed] = test }, config = Config[]) do
+  def handle_event({ :test_finished, ExUnit.Test[state: :passed] = test }, config = Config[]) do
     if config.trace do
       IO.puts success(trace_test_result(test), config)
     else
       IO.write success(".", config)
     end
-    { :noreply, config.previous(:passed).update_tests_counter(&(&1 + 1)) }
+    { :ok, config.previous(:passed).update_tests_counter(&(&1 + 1)) }
   end
 
-  def handle_cast({ :test_finished, ExUnit.Test[state: { :invalid, _ }] = test }, config = Config[]) do
+  def handle_event({ :test_finished, ExUnit.Test[state: { :invalid, _ }] = test }, config = Config[]) do
     if config.trace do
       IO.puts invalid(trace_test_result(test), config)
     else
       IO.write invalid("?", config)
     end
 
-    { :noreply, config.previous(:invalid).update_tests_counter(&(&1 + 1))
-                      .update_invalids_counter(&(&1 + 1)) }
+    { :ok, config.previous(:invalid).update_tests_counter(&(&1 + 1))
+                 .update_invalids_counter(&(&1 + 1)) }
   end
 
-  def handle_cast({ :test_finished, ExUnit.Test[state: { :skip, _ }] }, config = Config[]) do
-    { :noreply, config.previous(:skip).update_skips_counter(&(&1 + 1)) }
+  def handle_event({ :test_finished, ExUnit.Test[state: { :skip, _ }] }, config = Config[]) do
+    { :ok, config.previous(:skip).update_skips_counter(&(&1 + 1)) }
   end
 
-  def handle_cast({ :test_finished, test }, config) do
+  def handle_event({ :test_finished, test }, config = Config[]) do
     if config.trace do
       IO.puts failure(trace_test_result(test), config)
     end
 
     config = print_test_failure(test, config)
-    { :noreply, config.update_tests_counter(&(&1 + 1)) }
+    { :ok, config.update_tests_counter(&(&1 + 1)) }
   end
 
-  def handle_cast({ :case_started, ExUnit.TestCase[name: name] }, config) do
+  def handle_event({ :case_started, ExUnit.TestCase[name: name] }, config = Config[]) do
     if config.trace do
       IO.puts("\n#{inspect name}")
     end
 
-    { :noreply, config }
+    { :ok, config }
   end
 
-  def handle_cast({ :case_finished, test_case }, config) do
+  def handle_event({ :case_finished, test_case }, config = Config[]) do
     if test_case.state != :passed do
       config = print_test_case_failure(test_case, config)
-      { :noreply, config }
+      { :ok, config }
     else
-      { :noreply, config }
+      { :ok, config }
     end
   end
 
-  def handle_cast(request, config) do
-    super(request, config)
+  def handle_event(_, config) do
+    { :ok, config }
   end
 
   defp trace_test_result(test) do

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -1,25 +1,34 @@
 defmodule ExUnit.Formatter do
   @moduledoc """
-  This module simply defines the callbacks
-  expected by an ExUnit.Formatter.
-  """
+  This module holds helper functions related to formatting and contains
+  documentation about the formatting protocol.
 
-  use Behaviour
+  Formatters are registered at the `ExUnit.Formatter.Manager` event manager and
+  will be send events by the runner.
+
+  The following events are possible:
+
+  * `{ :suite_started, opts }` - The suite has started with the specified
+                                 options to the runner.
+  * `{ :suite_finished, run_us, load_us }` - The suite has finished. `run_us` and
+                                             `load_us` are the run and load
+                                             times in microseconds respectively.
+  * `{ :case_started, test_case }` - A test case has started. See
+                                     `ExUnit.TestCase` for details.
+  * `{ :case_finished, test_case }` - A test case has finished. See
+                                      `ExUnit.TestCase` for details.
+  * `{ :test_started, test_case }` - A test case has started. See
+                                     `ExUnit.Test` for details.
+  * `{ :test_finished, test_case }` - A test case has finished. See
+                                     `ExUnit.Test` for details.
+
+  """
 
   @type id :: term
   @type test_case :: ExUnit.TestCase.t
   @type test :: ExUnit.Test.t
   @type run_us :: pos_integer
   @type load_us :: pos_integer | nil
-
-  defcallback suite_started(opts :: list) :: id
-  defcallback suite_finished(id, run_us, load_us) :: non_neg_integer
-
-  defcallback case_started(id, test_case) :: any
-  defcallback case_finished(id, test_case) :: any
-
-  defcallback test_started(id, test) :: any
-  defcallback test_finished(id, test) :: any
 
   import Exception, only: [format_stacktrace_entry: 1]
 

--- a/lib/ex_unit/lib/ex_unit/formatter/manager.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter/manager.ex
@@ -1,0 +1,91 @@
+defmodule ExUnit.Formatter.Manager do
+  @moduledoc """
+  Event manager that formatters can register at.
+
+  See `ExUnit.Formatter` for the events formatters are expected to handle.
+
+  This module also contains some wrapper functions for calling the local
+  formatter manager. These translate to simple calls to `:gen_event` but they
+  are somewhat shorter.
+  """
+  def start_link() do
+    :gen_event.start_link({ :local, __MODULE__ })
+  end
+
+  @moduledoc """
+  See `:gen_event.add_handler/3`.
+  """
+  def add_handler(handler, args) do
+    :gen_event.add_handler(__MODULE__, handler, args)
+  end
+  
+  @moduledoc """
+  See `:gen_event.delete_handler/3`.
+  """
+  def delete_handler(handler, args) do
+    :gen_event.delete_handler(__MODULE__, handler, args)
+  end
+
+  @moduledoc """
+  See `:gen_event.call/3`.
+  """
+  def call(handler, request) do
+    :gen_event.call(__MODULE__, handler, request)
+  end
+
+  @moduledoc """
+  See `:gen_event.call/4`.
+  """
+  def call(handler, request, timeout) do
+    :gen_event.call(__MODULE__, handler, request, timeout)
+  end
+  
+  @moduledoc """
+  See `:gen_event.which_handlers/1`.
+  """
+  def which_handlers() do
+    :gen_event.which_handlers(__MODULE__)
+  end
+
+  @moduledoc """
+  Send a notify with `:suite_started`.
+  """
+  def suite_started(opts) do
+    :gen_event.notify(__MODULE__, { :suite_started, opts })
+  end
+  
+  @moduledoc """
+  Send a notify with `:suite_finished`.
+  """
+  def suite_finished(load_us, run_us) do
+    :gen_event.notify(__MODULE__, { :suite_finished, load_us, run_us })
+  end
+  
+  @moduledoc """
+  Send a notify with `:case_started`.
+  """
+  def case_started(test_case) do
+    :gen_event.notify(__MODULE__, { :case_started, test_case })
+  end
+  
+  @moduledoc """
+  Send a notify with `:case_finished`.
+  """
+  def case_finished(test_case) do
+    :gen_event.notify(__MODULE__, { :case_finished, test_case })
+  end
+  
+  @moduledoc """
+  Send a notify with `:test_started`.
+  """
+  def test_started(test) do
+    :gen_event.notify(__MODULE__, { :test_started, test })
+  end
+  
+  @moduledoc """
+  Send a notify with `:test_finished`.
+  """
+  def test_finished(test) do
+    :gen_event.notify(__MODULE__, { :test_finished, test })
+  end
+end

--- a/lib/ex_unit/lib/ex_unit/sup.ex
+++ b/lib/ex_unit/lib/ex_unit/sup.ex
@@ -8,7 +8,7 @@ defmodule ExUnit.Sup do
   end
 
   def init(:ok) do
-    tree = [ worker(ExUnit.Server, []) ]
-    supervise(tree, strategy: :one_for_one)
+    tree = [ worker(ExUnit.Server, []), worker(ExUnit.Formatter.Manager, []) ]
+    supervise(tree, strategy: :one_for_all)
   end
 end

--- a/lib/ex_unit/mix.exs
+++ b/lib/ex_unit/mix.exs
@@ -11,7 +11,7 @@ defmodule ExUnit.Mixfile do
       env: [
         autorun: true,
         trace: false,
-        formatter: ExUnit.CLIFormatter,
+        formatters: [ExUnit.CLIFormatter],
         include: [],
         exclude: [] ] ]
   end


### PR DESCRIPTION
This is a fairly big patch and I'm not 100% of some details (such as the CounterFormatter returning the number of tests just to satisfy the test suite if a particular option to ExUnit.Runner.run is used).
