### PR TITLE
Updated specs in Version

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -68,7 +68,7 @@ defmodule Version do
   Returns `true` if `version` satisfies `requirement`, `false` otherwise.
   Raises a `Version.InvalidRequirement` exception if `requirement` is not
   parseable, or `Version.InvalidVersion` if `version` is not parseable.
-  If given an already parsed version and requirement this function wont
+  If given an already parsed version and requirement this function won't
   raise.
 
   ## Examples
@@ -107,7 +107,7 @@ defmodule Version do
   is returned
 
   Raises a `Version.InvalidVersion` exception if `version` is not parseable.
-  If given an already parsed version this function wont raise.
+  If given an already parsed version this function won't raise.
 
   ## Examples
 


### PR DESCRIPTION
Addressing these dialyzer warnings:

```
version.ex:283: Invalid type specification for function 'Elixir.Version.Parser':parse_requirement/1. The success typing is (binary()) -> 'error' | {'o    k',[{{_,_,_,_},[any(),...],[any(),...]},...]}                                                                                                         
version.ex:292: Invalid type specification for function 'Elixir.Version.Parser':parse_version/1. The success typing is (binary()) -> 'error' | {'ok',{    integer(),integer(),'nil' | integer(),[any()]}}
version.ex:476: Clause guard cannot succeed. The variable _@1 was matched against the type integer()
```

The first two were caused by new return values (`:error` or `{:ok, value}`). The third by the fact that preceding functions guaranteed that the `minor` version value was always defined.

Also fixed some simple doc typos in a separate commit.
