### PR TITLE
Rename groups to names in Regex

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -193,25 +193,25 @@ defmodule Regex do
   end
 
   @doc """
-  Returns the given captures as a keyword list or `nil` if no captures
-  are found. The option `:return` can be set to `:index` to get indexes
+  Returns the given captures as a map or `nil` if no captures are
+  found. The option `:return` can be set to `:index` to get indexes
   back.
 
   ## Examples
 
       iex> Regex.named_captures(~r/c(?<foo>d)/, "abcd")
-      [foo: "d"]
+      %{ "foo" => "d" }
       iex> Regex.named_captures(~r/a(?<foo>b)c(?<bar>d)/, "abcd")
-      [bar: "d", foo: "b"]
+      %{ "bar" => "d", "foo" => "b" }
       iex> Regex.named_captures(~r/a(?<foo>b)c(?<bar>d)/, "efgh")
       nil
 
   """
   def named_captures(regex, string, options \\ []) when is_binary(string) do
-    names = lc name inlist names(regex), do: binary_to_atom(name)
+    names = names(regex)
     options = Keyword.put_new(options, :capture, names)
     results = run(regex, string, options)
-    if results, do: Enum.zip(names, results)
+    if results, do: Enum.zip(names, results) |> Map.new
   end
 
   @doc """

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -72,11 +72,11 @@ defmodule RegexTest do
   end
 
   test :named_captures do
-    assert Keyword.equal? Regex.named_captures(~r/(?<foo>c)(?<bar>d)/, "abcd"), [bar: "d", foo: "c"]
-    assert Regex.named_captures(~r/c(?<foo>d)/, "abcd") == [foo: "d"]
+    assert Regex.named_captures(~r/(?<foo>c)(?<bar>d)/, "abcd") == %{ "bar" => "d", "foo" => "c" }
+    assert Regex.named_captures(~r/c(?<foo>d)/, "abcd") == %{ "foo" => "d" }
     assert Regex.named_captures(~r/c(?<foo>d)/, "no_match") == nil
-    assert Regex.named_captures(~r/c(?<foo>d|e)/, "abcd abce") == [foo: "d"]
-    assert Regex.named_captures(~r/c(.)/, "cat") == []
+    assert Regex.named_captures(~r/c(?<foo>d|e)/, "abcd abce") == %{ "foo" => "d" }
+    assert Regex.named_captures(~r/c(.)/, "cat") == %{}
   end
 
   test :sigil_R do


### PR DESCRIPTION
closes #2043.
This PR includes a commit "`Regex.names/1` returns a list of binary instead of a list of atom".
If it is not good, please say to me, I'll remove it.
