### PR TITLE
Add prompt option for IEx

### DIFF
--- a/lib/iex/lib/iex/options.ex
+++ b/lib/iex/lib/iex/options.ex
@@ -33,7 +33,7 @@ defmodule IEx.Options do
 
   """
 
-  @supported_options ~w(colors inspect history_size)a
+  @supported_options ~w(colors inspect history_size prompt)a
 
   @doc """
   Returns all supported IEx options with their respective values as a keyword
@@ -110,6 +110,14 @@ defmodule IEx.Options do
     raise_value("an integer")
   end
 
+  def set(:prompt, prompts) when is_list(prompts) do
+    filter_and_merge(:prompt, prompts)
+  end
+
+  def set(:prompt, _) do
+    raise_value("a keyword list")
+  end
+
   def set(name, _) do
     raise_option(name)
   end
@@ -155,6 +163,22 @@ defmodule IEx.Options do
   Number of expressions and their results to keep in the history.
 
   The value is an integer. When it is negative, the history is unlimited.
+  """
+
+  def help(:prompt), do: """
+  This is an option determining the prompt displayed to the user
+  when awaiting input.
+
+  The value is a keyword list. Two prompt types:
+
+  * `:default` - used when `Node.alive?` returns false
+  * `:alive`   - used when `Node.alive?` returns true
+
+  The part of the listed in the following of the prompt string is replaced.
+
+  * `%counter` - the index of the history
+  * `%prefix`  - a prefix given by `IEx.Server`
+  * `%node`    - the name of the local node
   """
 
   @doc """

--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -241,14 +241,24 @@ defmodule IEx.Server do
   ## IO
 
   defp io_get(pid, prefix, counter) do
-    prompt =
+    prompt = prompt(prefix, counter)
+    send pid, { :input, self, IO.gets(:stdio, prompt) }
+  end
+
+  defp prompt(prefix, counter) do
+    { mode, prefix } =
       if Node.alive? do
-        "#{prefix || remote_prefix}(#{node})#{counter}> "
+        { :alive, prefix || remote_prefix }
       else
-        "#{prefix || "iex"}(#{counter})> "
+        { :default, prefix || "iex" }
       end
 
-    send pid, { :input, self, IO.gets(:stdio, prompt) }
+    prompt = IEx.Options.get(:prompt)[mode]
+             |> String.replace("%counter", to_string(counter))
+             |> String.replace("%prefix", to_string(prefix))
+             |> String.replace("%node", to_string(node))
+
+    prompt <> " "
   end
 
   defp io_error(result) do

--- a/lib/iex/mix.exs
+++ b/lib/iex/mix.exs
@@ -10,7 +10,8 @@ defmodule IEx.Mixfile do
         after_spawn: [],
         colors: colors,
         inspect: [limit: 50, records: true, pretty: true],
-        history_size: 20 ] ]
+        history_size: 20,
+        prompt: [default: "%prefix(%counter)>", alive: "%prefix(%node)%counter>" ] ] ]
   end
 
   defp colors do

--- a/lib/iex/test/iex/options_test.exs
+++ b/lib/iex/test/iex/options_test.exs
@@ -51,6 +51,11 @@ defmodule IEx.OptionsTest do
     assert "1\n2\n3\n4\n2\n** (RuntimeError) v(2) is out of bounds" <> _ = capture_iex("1\n2\n3\n4\nv(2)\nv(2)", opts)
   end
 
+  test "prompt" do
+    opts = [prompt: [default: "prompt(%counter)>", alive: "prompt(%counter)"]]
+    assert capture_iex("1\n", opts, [], true) == "prompt(1)> 1\nprompt(2)>"
+  end
+
   test "bad option" do
     assert_raise ArgumentError, fn ->
       IEx.Options.set :nonexistent_option, nil

--- a/lib/iex/test/test_helper.exs
+++ b/lib/iex/test/test_helper.exs
@@ -53,12 +53,12 @@ defmodule IEx.Case do
   If you provide server options, it will be passed to
   IEx.Server.start to be used in the normal .iex loading process.
   """
-  def capture_iex(input, options \\ [], server_options \\ []) do
+  def capture_iex(input, options \\ [], server_options \\ [], capture_prompt \\ false) do
     Enum.each options, fn { opt, value } ->
       IEx.Options.set(opt, value)
     end
 
-    ExUnit.CaptureIO.capture_io([input: input, capture_prompt: false], fn ->
+    ExUnit.CaptureIO.capture_io([input: input, capture_prompt: capture_prompt], fn ->
       server_options = Keyword.put_new(server_options, :dot_iex_path, "")
       IEx.Server.start(server_options, fn -> end)
     end) |> strip_iex


### PR DESCRIPTION
closes #1946
I am thinking about the API.
What do you think about it? I would be grateful for any feedback. :)
(Maybe I should post to the mailling list?)
## API

The prompt options has two types.
- `:default` - used when `Node.alive?` returns false
- `:alive`    - used when `Node.alive?` returns true

The part of the listed in the following of the prompt string is replaced.
- `%counter` - the index of the history
- `%prefix`    - a prefix given by `IEx.Server`, for now "iex", "rem" or "pry"
- `%node`     - the name of the local node
### Examples
- `prompt: [default: "%prefix(%counter)>", alive: "%prefix(%node)%counter>"]`

this is same with the current prompt

```
iex(1)> :a
:a
iex(2)> :b
:b

iex(name@yuki_ito)1> :a
:a
iex(name@yuki_ito)2> :b
:b
```
- `prompt: [default: "iex>", arive: "iex>"]`

the prompt is always "iex>"

```
iex> :a
:a
iex> :b
:b

iex> :a
:a
iex> :b
:b
```
