### PR TITLE
Fixed spec for Enum.flat_map

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -781,7 +781,7 @@ defmodule Enum do
       { [1,2,3], 3 }
 
   """
-  @spec flat_map_reduce(t, acc, fun) :: list when
+  @spec flat_map_reduce(t, acc, fun) :: { [any], any } when
         fun: (element, acc -> { t, acc } | { :halt, acc }),
         acc: any
   def flat_map_reduce(collection, acc, fun) do


### PR DESCRIPTION
Dialyzer turned up this warning:

```
enum.ex:784: Invalid type specification for function 'Elixir.Enum':flat_map_reduce/3. The success typing is (_,_,_) -> {[any()],_}
```

Updated the spec to specify a tuple return value.
