### PR TITLE
Fixing result handling of :file.consult

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -73,7 +73,7 @@ defmodule Mix.Tasks.Compile.App do
 
   defp modules_changed?(mods, target) do
     case :file.consult(target) do
-      { :ok, { :application, _app, properties } } ->
+      { :ok, [ { :application, _app, properties } ] } ->
         properties[:registered] == mods
       _ ->
         false


### PR DESCRIPTION
In `Mix.Tasks.Compile.App`, `modules_changed()` was calling `:file.consult()` and handling the result as a tuple. It actually returns a list of tuples (though the `.app` file only contains a single tuple). Updated the `case` statement to use the correct type.

Since `modules_changed()` is private, I don't see how to test that specific case. Too bad `ExUnit` can't test `defp` functions. Just saying.

Found via dialyzer warning:

```
compile.app.ex:76: The pattern {'ok', {'application', _app@1, _properties@1}} can never match the type {'error',atom() | {integer(),atom() | tuple(),_}} | {'ok',[any()]}
```
