### PR TITLE
Mix.Utils handling empty strings

### DIFF
--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -238,6 +238,8 @@ defmodule Mix.Utils do
       Mix.Utils.camelize "foo_bar" #=> "FooBar"
 
   """
+  def camelize(""), do: ""
+
   def camelize(<<?_, t :: binary>>) do
     camelize(t)
   end

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -67,6 +67,7 @@ defmodule Mix.UtilsTest do
     assert Mix.Utils.camelize("_foo") == "Foo"
     assert Mix.Utils.camelize("foo__bar") == "FooBar"
     assert Mix.Utils.camelize("foo/bar") == "Foo.Bar"
+    assert Mix.Utils.camelize("") == ""
   end
 
   test :extract_files do


### PR DESCRIPTION
Made `Mix.Utils.underscore` and `Mix.Utils.camelize` handle empty string inputs (and `..` inputs for `underscore`). Ran into these bugs while passing filesystem paths to these functions in phoenix.
