### PR TITLE
Add `System.delete_env/1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * [Map] Add a Map module and support R17 maps and structs
   * [Regex] Regexes no longer needs the "g" option when there is a need to use named captures
   * [StringIO] Add a `StringIO` module that allows a String to be used as IO device
+  * [System] Add `System.delete_env/1` to remove a variable from the environment
 
 * Bug fixes
   * [Mix] Automatically recompile on outdated Elixir version and show proper error messages

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -332,6 +332,17 @@ defmodule System do
   end
 
   @doc """
+  Deletes an environment variable.
+
+  Removes the variable `varname` from the environment.
+  """
+  @spec delete_env(String.t) :: :ok
+  def delete_env(varname) do
+    :os.unsetenv(String.to_char_list!(varname))
+    :ok
+  end
+
+  @doc """
   Last exception stacktrace.
 
   Note that the Erlang VM (and therefore this function) does not

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -4,19 +4,19 @@ defmodule SystemTest do
   use ExUnit.Case, async: true
   import PathHelpers
 
-  test :build_info do
+  test "build_info" do
     assert not nil?(System.build_info[:version])
     assert not nil?(System.build_info[:tag])
     assert not nil?(System.build_info[:date])
   end
 
-  test :cwd do
+  test "cwd" do
     assert is_binary System.cwd
     assert is_binary System.cwd!
   end
 
   if :file.native_name_encoding == :utf8 do
-    test :cwd_with_utf8 do
+    test "cwd_with_utf8" do
       File.mkdir_p(tmp_path("héllò"))
 
       File.cd!(tmp_path("héllò"), fn ->
@@ -27,40 +27,49 @@ defmodule SystemTest do
     end
   end
 
-  test :user_home do
+  test "user_home" do
     assert is_binary System.user_home
     assert is_binary System.user_home!
   end
 
-  test :tmp_dir do
+  test "tmp_dir" do
     assert is_binary System.tmp_dir
     assert is_binary System.tmp_dir!
   end
 
-  test :argv do
+  test "argv" do
     list = elixir('-e "IO.inspect System.argv" -- -o opt arg1 arg2 --long-opt 10')
     { args, _ } = Code.eval_string list, []
     assert args == ["-o", "opt", "arg1", "arg2", "--long-opt", "10"]
   end
 
-  test :env do
-    assert System.get_env("SYSTEM_ELIXIR_ENV_TEST_VAR") == nil
-    System.put_env("SYSTEM_ELIXIR_ENV_TEST_VAR", "SAMPLE")
-    assert System.get_env("SYSTEM_ELIXIR_ENV_TEST_VAR") == "SAMPLE"
+  @test_var "SYSTEM_ELIXIR_ENV_TEST_VAR"
+
+  test "env" do
+    assert System.get_env(@test_var) == nil
+    System.put_env(@test_var, "SAMPLE")
+    assert System.get_env(@test_var) == "SAMPLE"
+    assert System.get_env()[@test_var] == "SAMPLE"
+
+    System.delete_env(@test_var)
+    assert System.get_env(@test_var) == nil
+
+    System.put_env([{ @test_var, "OTHER_SAMPLE" }])
+    assert System.get_env(@test_var) == "OTHER_SAMPLE"
   end
 
-  test :cmd do
+  test "cmd" do
     assert is_binary(System.cmd "echo hello")
     assert is_list(System.cmd 'echo hello')
   end
 
-  test :find_executable_with_binary do
+  test "find_executable with binary" do
     assert System.find_executable("erl")
     assert is_binary System.find_executable("erl")
     assert !System.find_executable("does-not-really-exist-from-elixir")
   end
 
-  test :find_executable_with_list do
+  test "find_executable with list" do
     assert System.find_executable('erl')
     assert is_list System.find_executable('erl')
     assert !System.find_executable('does-not-really-exist-from-elixir')


### PR DESCRIPTION
@josevalim I am sending this as a PR because I also changed a few places to use `String.to_char_list!` and `String.from_char_list!` instead of `iolist_to_binary` and `:binary.bin_to_list`. But I'm not sure if the changes are correct because a few other places in `system.ex` had the following comment:

```
# Notice we don't use unicode for conversion
# because the OS is expecting and returning raw bytes
```

Or if the current behaviour was because of performance reasons.
