### PR TITLE
Raise error if another capture_io process already captured the device

### DIFF
--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -119,7 +119,7 @@ defmodule Inspect.NumberTest do
 end
 
 defmodule Inspect.TupleTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   test :basic do
     assert inspect({ 1, "b", 3 }) == "{1, \"b\", 3}"
@@ -247,7 +247,7 @@ defmodule Inspect.ListTest do
 end
 
 defmodule Inspect.MapTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   test :basic do
     assert inspect(%{ 1 => "b" }) == "%{1 => \"b\"}"

--- a/lib/ex_unit/lib/ex_unit/capture_io.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_io.ex
@@ -105,6 +105,10 @@ defmodule ExUnit.CaptureIO do
       raise "could not find IO device registered at #{inspect device}"
     end
 
+    unless ExUnit.Server.add_device(device) do
+      raise "IO device registered at #{inspect device} is already captured"
+    end
+
     input = Keyword.get(options, :input, "")
 
     Process.unregister(device)
@@ -121,6 +125,7 @@ defmodule ExUnit.CaptureIO do
         ArgumentError -> nil
       end
       Process.register(original_io, device)
+      ExUnit.Server.remove_device(device)
     end
   end
 end

--- a/lib/ex_unit/test/ex_unit/capture_io_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_io_test.exs
@@ -31,7 +31,7 @@ end
 alias ExUnit.CaptureIOTest.GetUntil
 
 defmodule ExUnit.CaptureIOTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   doctest ExUnit.CaptureIO, import: true
 
@@ -324,6 +324,15 @@ defmodule ExUnit.CaptureIOTest do
 
     # Ensure no leakage on failures
     assert group_leader == :erlang.group_leader
+  end
+
+  test "capture :stderr by two processes" do
+    spawn(fn -> capture_io(:stderr, fn -> :timer.sleep(100) end) end)
+    :timer.sleep(10)
+    assert_raise RuntimeError, "IO device registered at :standard_error is already captured", fn ->
+      capture_io(:stderr, fn -> end)
+    end
+    :timer.sleep(100)
   end
 
   defp send_and_receive_io(req) do

--- a/lib/mix/test/mix/shell/io_test.exs
+++ b/lib/mix/test/mix/shell/io_test.exs
@@ -1,7 +1,7 @@
 Code.require_file "../../test_helper.exs", __DIR__
 
 defmodule Mix.Shell.IOTest do
-  use MixTest.Case, async: true
+  use MixTest.Case
 
   import ExUnit.CaptureIO
   import Mix.Shell.IO


### PR DESCRIPTION
closes #2066
