### PR TITLE
Add `:only` dep option to filter on environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * [IEx] Allow prompt configuration with the `:prompt` option
   * [Kernel] Support `ERL_PATH` in `bin/elixir`
   * [Map] Add a Map module and support R17 maps and structs
+  * [Mix] Add dependency option `:only` to specify its environment
   * [Regex] Regexes no longer need the "g" option when there is a need to use named captures
   * [StringIO] Add a `StringIO` module that allows a String to be used as IO device
   * [System] Add `System.delete_env/1` to remove a variable from the environment

--- a/lib/mix/lib/mix/deps/converger.ex
+++ b/lib/mix/lib/mix/deps/converger.ex
@@ -38,9 +38,11 @@ defmodule Mix.Deps.Converger do
   including nested dependencies. There is a callback
   that is invoked for each dependency and must return
   an updated dependency in case some processing is done.
+
+  See `Mix.Deps.Loader.children/1` for options.
   """
-  def all(rest, callback) do
-    main      = Mix.Deps.Loader.children
+  def all(rest, opts, callback) do
+    main      = Mix.Deps.Loader.children(opts)
     apps      = Enum.map(main, &(&1.app))
     converger = Mix.RemoteConverger.get
 

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -284,7 +284,7 @@ defmodule Mix.Tasks.Compile.Elixir do
   defp path_deps_changed?(manifest) do
     manifest = Path.absname(manifest)
 
-    deps = Enum.filter(Mix.Deps.children, fn(Mix.Dep[] = dep) ->
+    deps = Enum.filter(Mix.Deps.children([]), fn(Mix.Dep[] = dep) ->
       dep.scm == Mix.SCM.Path
     end)
 

--- a/lib/mix/lib/mix/tasks/deps.check.ex
+++ b/lib/mix/lib/mix/tasks/deps.check.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Deps.Check do
   use Mix.Task
 
-  import Mix.Deps, only: [loaded: 0, loaded_by_name: 1, format_dep: 1,
+  import Mix.Deps, only: [loaded: 1, loaded_by_name: 2, format_dep: 1,
                           format_status: 1, check_lock: 2, ok?: 1]
 
   @moduledoc """
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.Deps.Check do
   def run(args) do
     { opts, _, _ } = OptionParser.parse(args, switches: [quiet: :boolean])
     lock = Mix.Deps.Lock.read
-    all  = Enum.map loaded, &check_lock(&1, lock)
+    all  = Enum.map(loaded(env: Mix.env), &check_lock(&1, lock))
 
     prune_deps(all)
     { not_ok, compile } = partition_deps(all, [], [])
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Deps.Check do
         Mix.Tasks.Deps.Compile.compile(compile, opts)
         show_not_ok compile
                     |> Enum.map(& &1.app)
-                    |> loaded_by_name
+                    |> loaded_by_name(env: Mix.env)
                     |> Enum.filter(&(not ok?(&1)))
     end
   end

--- a/lib/mix/lib/mix/tasks/deps.clean.ex
+++ b/lib/mix/lib/mix/tasks/deps.clean.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Deps.Clean do
     Mix.Project.get! # Require the project to be available
 
     { opts, args, _ } = OptionParser.parse(args, switches: [unlock: :boolean, all: :boolean])
-    loaded = Mix.Deps.loaded
+    loaded = Mix.Deps.loaded(env: Mix.env)
 
     cond do
       opts[:all] ->

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Deps.Compile do
 
   """
 
-  import Mix.Deps, only: [loaded: 0, available?: 1, loaded_by_name: 1,
+  import Mix.Deps, only: [loaded: 1, available?: 1, loaded_by_name: 2,
                           format_dep: 1, make?: 1, mix?: 1, rebar?: 1]
 
   def run(args) do
@@ -35,9 +35,9 @@ defmodule Mix.Tasks.Deps.Compile do
 
     case OptionParser.parse(args, switches: [quiet: :boolean]) do
       { opts, [], _ } ->
-        compile(Enum.filter(loaded, &compilable?/1), opts)
+        compile(Enum.filter(loaded(env: Mix.env), &compilable?/1), opts)
       { opts, tail, _ } ->
-        compile(loaded_by_name(tail), opts)
+        compile(loaded_by_name(tail, env: Mix.env), opts)
     end
   end
 

--- a/lib/mix/lib/mix/tasks/deps.ex
+++ b/lib/mix/lib/mix/tasks/deps.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Deps do
   use Mix.Task
 
-  import Mix.Deps, only: [loaded: 0, format_dep: 1, format_status: 1, check_lock: 2]
+  import Mix.Deps, only: [loaded: 1, format_dep: 1, format_status: 1, check_lock: 2]
 
   @shortdoc "List dependencies and their status"
 
@@ -13,14 +13,24 @@ defmodule Mix.Tasks.Deps do
       [locked at REF]
       STATUS
 
+  ## Command line options
+
+  * `--all` - check all dependencies, regardless of specified environment
   """
-  def run(_) do
+  def run(args) do
     Mix.Project.get! # Require the project to be available
+    { opts, _, _ } = OptionParser.parse(args)
+
+    if opts[:all] do
+      loaded_opts = []
+    else
+      loaded_opts = [env: Mix.env]
+    end
 
     shell = Mix.shell
     lock  = Mix.Deps.Lock.read
 
-    Enum.each loaded, fn(Mix.Dep[scm: scm] = dep) ->
+    Enum.each loaded(loaded_opts), fn(Mix.Dep[scm: scm] = dep) ->
       dep = check_lock(dep, lock)
       shell.info "* #{format_dep(dep)}"
       if formatted = scm.format_lock(dep.opts) do

--- a/lib/mix/lib/mix/tasks/deps.get.ex
+++ b/lib/mix/lib/mix/tasks/deps.get.ex
@@ -10,16 +10,24 @@ defmodule Mix.Tasks.Deps.Get do
   ## Command line options
 
   * `--quiet` - do not output verbose messages
+  * `--only` - only fetch dependencies for given environment
   """
   def run(args) do
     Mix.Project.get! # Require the project to be available
-    { opts, rest, _ } = OptionParser.parse(args, switches: [no_compile: :boolean, quiet: :boolean])
+    { opts, rest, _ } = OptionParser.parse(args, switches: [quiet: :boolean])
+
+    # Fetch all deps by default unless --only is given
+    if only = opts[:only] do
+      fetcher_opts = [env: :"#{only}"]
+    else
+      fetcher_opts = []
+    end
 
     apps =
       if rest != [] do
-        Mix.Deps.Fetcher.by_name(rest, [], Mix.Deps.Lock.read)
+        Mix.Deps.Fetcher.by_name(rest, [], Mix.Deps.Lock.read, fetcher_opts)
       else
-        Mix.Deps.Fetcher.all([], Mix.Deps.Lock.read)
+        Mix.Deps.Fetcher.all([], Mix.Deps.Lock.read, fetcher_opts)
       end
 
     if apps == [] && !opts[:quiet] do

--- a/lib/mix/lib/mix/tasks/deps.update.ex
+++ b/lib/mix/lib/mix/tasks/deps.update.ex
@@ -21,10 +21,10 @@ defmodule Mix.Tasks.Deps.Update do
 
     cond do
       opts[:all] ->
-        Mix.Deps.Fetcher.all(Mix.Deps.Lock.read, [])
+        Mix.Deps.Fetcher.all(Mix.Deps.Lock.read, [], [])
       rest != [] ->
         { old, new } = Dict.split(Mix.Deps.Lock.read, to_app_names(rest))
-        Mix.Deps.Fetcher.by_name(rest, old, new)
+        Mix.Deps.Fetcher.by_name(rest, old, new, [])
       true ->
         raise Mix.Error, message: "mix deps.update expects dependencies as arguments or " <>
                                   "the --all option to update all dependencies"

--- a/lib/mix/lib/mix/tasks/escriptize.ex
+++ b/lib/mix/lib/mix/tasks/escriptize.ex
@@ -123,7 +123,7 @@ defmodule Mix.Tasks.Escriptize do
   end
 
   defp deps_tuples do
-    Enum.reduce Mix.Deps.loaded || [], [], fn(dep, acc) ->
+    Enum.reduce Mix.Deps.loaded(env: Mix.env) || [], [], fn(dep, acc) ->
       get_tuples(dep.opts[:build]) ++ acc
     end
   end

--- a/lib/mix/test/fixtures/only_deps/mix.exs
+++ b/lib/mix/test/fixtures/only_deps/mix.exs
@@ -1,0 +1,8 @@
+defmodule OnlyDeps.Mix do
+  use Mix.Project
+
+  def project do
+    [app: :only_deps, version: "0.1.0",
+     deps: [{ :git_repo, git: MixTest.Case.fixture_path("git_repo"), only: :other_env }] ]
+  end
+end

--- a/lib/mix/test/mix/deps_test.exs
+++ b/lib/mix/test/mix/deps_test.exs
@@ -38,7 +38,7 @@ defmodule Mix.DepsTest do
     Mix.Project.push DepsApp
 
     in_fixture "deps_status", fn ->
-      deps = Mix.Deps.loaded
+      deps = Mix.Deps.loaded([])
       assert length(deps) == 6
       assert Enum.find deps, &match?(Mix.Dep[app: :ok, status: { :ok, _ }], &1)
       assert Enum.find deps, &match?(Mix.Dep[app: :invalidvsn, status: { :invalidvsn, :ok }], &1)
@@ -53,7 +53,7 @@ defmodule Mix.DepsTest do
     Mix.Project.push MixVersionApp
 
     in_fixture "deps_status", fn ->
-      deps = Mix.Deps.loaded
+      deps = Mix.Deps.loaded([])
       assert Enum.find deps, &match?(Mix.Dep[app: :ok, status: { :ok, _ }], &1)
     end
   end
@@ -64,7 +64,7 @@ defmodule Mix.DepsTest do
     in_fixture "deps_status", fn ->
       msg = "Mix.DepsTest.NoSCMApp did not specify a supported scm for app :ok, " <>
             "expected one of :git, :path or :in_umbrella"
-      assert_raise Mix.Error, msg, fn -> Mix.Deps.loaded end
+      assert_raise Mix.Error, msg, fn -> Mix.Deps.loaded([]) end
     end
   end
 
@@ -75,7 +75,7 @@ defmodule Mix.DepsTest do
     Mix.Project.push DepsApp
 
     { _, true } =
-      Mix.Deps.unloaded(false, fn dep, acc ->
+      Mix.Deps.unloaded(false, [], fn dep, acc ->
         assert nil?(dep.manager)
         { dep, acc or true }
       end)
@@ -86,7 +86,7 @@ defmodule Mix.DepsTest do
 
     in_fixture "deps_status", fn ->
       assert_raise Mix.Error, ~r"Invalid requirement", fn ->
-        Mix.Deps.loaded
+        Mix.Deps.loaded([])
       end
     end
   end
@@ -107,7 +107,7 @@ defmodule Mix.DepsTest do
     Mix.Project.push NestedDepsApp
 
     in_fixture "deps_status", fn ->
-      assert Enum.map(Mix.Deps.loaded, &(&1.app)) == [:git_repo, :deps_repo]
+      assert Enum.map(Mix.Deps.loaded([]), &(&1.app)) == [:git_repo, :deps_repo]
     end
   end
 
@@ -131,7 +131,7 @@ defmodule Mix.DepsTest do
       end
       """
 
-      assert Enum.map(Mix.Deps.loaded, &(&1.app)) == [:deps_repo]
+      assert Enum.map(Mix.Deps.loaded([]), &(&1.app)) == [:deps_repo]
     end
   end
 
@@ -152,7 +152,7 @@ defmodule Mix.DepsTest do
     Mix.Project.push ConvergedDepsApp
 
     in_fixture "deps_status", fn ->
-      assert Enum.map(Mix.Deps.loaded, &(&1.app)) == [:git_repo, :deps_repo]
+      assert Enum.map(Mix.Deps.loaded([]), &(&1.app)) == [:git_repo, :deps_repo]
     end
   end
 
@@ -176,7 +176,7 @@ defmodule Mix.DepsTest do
       end
       """
 
-      assert Enum.map(Mix.Deps.loaded, &(&1.app)) == [:git_repo, :deps_repo]
+      assert Enum.map(Mix.Deps.loaded([]), &(&1.app)) == [:git_repo, :deps_repo]
     end
   end
 
@@ -205,5 +205,70 @@ defmodule Mix.DepsTest do
     end
   after
     Mix.RemoteConverger.register(nil)
+  end
+
+  defmodule OnlyDeps do
+    def project do
+      [ deps: [ { :foo, github: "elixir-lang/foo" },
+                { :bar, github: "elixir-lang/bar", only: :other_env }  ] ]
+    end
+  end
+
+  test "only extract deps matching environment" do
+    Mix.Project.push OnlyDeps
+
+    in_fixture "deps_status", fn ->
+      { deps, _acc } = Mix.Deps.unloaded([], [env: :other_env], &{ &1, &2 })
+      assert length(deps) == 2
+
+      { deps, _acc } = Mix.Deps.unloaded([], [], &{ &1, &2 })
+      assert length(deps) == 2
+
+      { deps, _acc } = Mix.Deps.unloaded([], [env: :prod], &{ &1, &2 })
+      assert length(deps) == 1
+      assert Enum.find deps, &match?(Mix.Dep[app: :foo], &1)
+    end
+  end
+
+  defmodule OnlyChildDeps do
+    def project do
+      [ app: :raw_sample,
+        version: "0.1.0",
+        deps: [ { :only_deps, path: fixture_path("only_deps") } ] ]
+    end
+  end
+
+  test "only fetch child deps matching prod env" do
+    Mix.Project.push OnlyChildDeps
+
+    in_fixture "deps_status", fn ->
+      Mix.Tasks.Deps.Get.run([])
+      message = "* Getting git_repo (#{fixture_path("git_repo")})"
+      refute_received { :mix_shell, :info, [^message] }
+    end
+  end
+
+  defmodule OnlyParentDeps do
+    def project do
+      [ app: :raw_sample,
+        version: "0.1.0",
+        deps: [ { :only, github: "elixir-lang/only", only: :dev } ] ]
+    end
+  end
+
+  test "only fetch parent deps matching specified env" do
+    Mix.Project.push OnlyParentDeps
+
+    in_fixture "deps_status", fn ->
+      Mix.Tasks.Deps.Get.run(["--only", "prod"])
+      refute_received { :mix_shell, :info, ["* Getting" <> _] }
+
+      assert_raise Mix.Error, "Can't continue due to errors on dependencies", fn ->
+        Mix.Tasks.Deps.Check.run([])
+      end
+
+      Mix.env(:prod)
+      Mix.Tasks.Deps.Check.run([])
+    end
   end
 end

--- a/lib/mix/test/mix/rebar_test.exs
+++ b/lib/mix/test/mix/rebar_test.exs
@@ -72,7 +72,7 @@ defmodule Mix.RebarTest do
   test "parse rebar dependencies from rebar.config" do
     Mix.Project.push(RebarAsDep)
 
-    deps = Mix.Deps.loaded
+    deps = Mix.Deps.loaded([])
     assert Enum.find(deps, &match?(Mix.Dep[app: :rebar_dep], &1))
 
     assert Enum.find(deps, fn dep ->
@@ -118,7 +118,7 @@ defmodule Mix.RebarTest do
       assert :git_rebar.any_function == :ok
       assert :rebar_dep.any_function == :ok
 
-      load_paths = Mix.Deps.loaded
+      load_paths = Mix.Deps.loaded([])
         |> Enum.map(&Mix.Deps.load_paths(&1))
         |> Enum.concat
 

--- a/lib/mix/test/mix/umbrella_test.exs
+++ b/lib/mix/test/mix/umbrella_test.exs
@@ -80,7 +80,7 @@ defmodule Mix.UmbrellaTest do
     Mix.Project.push CycleDeps
 
     in_fixture "umbrella_dep", fn ->
-      assert Enum.map(Mix.Deps.loaded, & &1.app) == [:foo, :bar, :umbrella]
+      assert Enum.map(Mix.Deps.loaded([]), & &1.app) == [:foo, :bar, :umbrella]
     end
   end
 
@@ -118,7 +118,7 @@ defmodule Mix.UmbrellaTest do
         end
         """
 
-        assert Enum.map(Mix.Deps.loaded, & &1.app) == [:a, :b, :bar, :foo]
+        assert Enum.map(Mix.Deps.loaded([]), & &1.app) == [:a, :b, :bar, :foo]
       end
     end
   end


### PR DESCRIPTION
mix deps.get will by default fetch all deps unless --only flag is given.

Closes https://github.com/elixir-lang/elixir/issues/2038.

We should update getting started guide with this.
