### PR TITLE
Support :io.get_password in StringIO

### DIFF
--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -149,11 +149,15 @@ defmodule StringIO do
   end
 
   defp io_request({ :get_until, prompt, mod, fun, args }, s) do
-    io_request({ :get_until, :latin1, prompt, mod, fun, args}, s)
+    io_request({ :get_until, :latin1, prompt, mod, fun, args }, s)
   end
 
-  defp io_request({ :get_until, encoding, prompt, mod, fun, args}, s) do
+  defp io_request({ :get_until, encoding, prompt, mod, fun, args }, s) do
     get_until(encoding, prompt, mod, fun, args, s)
+  end
+
+  defp io_request({ :get_password, encoding }, s) do
+    get_line(encoding, "", s)
   end
 
   defp io_request({ :setopts, _opts }, s) do

--- a/lib/elixir/test/elixir/string_io_test.exs
+++ b/lib/elixir/test/elixir/string_io_test.exs
@@ -205,6 +205,12 @@ defmodule StringIOTest do
     assert contents(pid) == { "", ">" }
   end
 
+  test ":io.get_password" do
+    pid = start("abc\n")
+    assert :io.get_password(pid) == "abc\n"
+    assert contents(pid) == { "", "" }
+  end
+
   test "IO.stream" do
     pid = start("abc")
     assert IO.stream(pid, 2) |> Enum.to_list == ["ab", "c"]

--- a/lib/ex_unit/test/ex_unit/capture_io_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_io_test.exs
@@ -151,6 +151,43 @@ defmodule ExUnit.CaptureIOTest do
     end)
   end
 
+  test "with get password" do
+    capture_io(fn ->
+      assert :io.get_password() == :eof
+    end)
+
+    capture_io("", fn ->
+      assert :io.get_password() == :eof
+    end)
+
+    capture_io("abc", fn ->
+      assert :io.get_password() == "abc"
+      assert :io.get_password() == :eof
+    end)
+
+    capture_io("abc\n", fn ->
+      assert :io.get_password() == "abc\n"
+      assert :io.get_password() == :eof
+    end)
+
+    capture_io("\n", fn ->
+      assert :io.get_password() == "\n"
+      assert :io.get_password() == :eof
+    end)
+
+    capture_io("a\nb", fn ->
+      assert :io.get_password() == "a\n"
+      assert :io.get_password() == "b"
+      assert :io.get_password() == :eof
+    end)
+
+    capture_io("あい\nう", fn ->
+      assert :io.get_password() == "あい\n"
+      assert :io.get_password() == "う"
+      assert :io.get_password() == :eof
+    end)
+  end
+
   test "with get until" do
     assert capture_io(fn ->
       :io.scan_erl_form('>')


### PR DESCRIPTION
Do we want to add `IO.get_password` as well?
