### PR TITLE
Update Gen_FSM example to be more explicit, clear.

### DIFF
--- a/lib/elixir/lib/gen_fsm/behaviour.ex
+++ b/lib/elixir/lib/gen_fsm/behaviour.ex
@@ -31,15 +31,15 @@ defmodule GenFSM.Behaviour do
         # API functions
 
         def start_link() do
-          :gen_fsm.start_link({:local, :cvm}, __MODULE__, [], [])
+          :gen_fsm.start_link(__MODULE__, [], [])
         end
 
-        def insert_coin() do
-          :gen_fsm.send_event(:cvm, :coin)
+        def insert_coin(pid) do
+          :gen_fsm.send_event(pid, :coin)
         end
 
-        def request_coffee() do
-          :gen_fsm.send_event(:cvm, :request_coffee)
+        def request_coffee(pid) do
+          :gen_fsm.send_event(pid, :request_coffee)
         end
 
         # Callbacks
@@ -83,17 +83,17 @@ defmodule GenFSM.Behaviour do
         end
       end
 
-      { :ok, _pid } = MyFsm.start_link()
+      { :ok, pid } = MyFsm.start_link()
 
-      MyFsm.insert_coin
+      MyFsm.insert_coin(pid)
       #=> :ok
-      MyFsm.insert_coin
-      #=> :ok
-
-      MyFsm.request_coffee
+      MyFsm.insert_coin(pid)
       #=> :ok
 
-      MyFsm.insert_coin
+      MyFsm.request_coffee(pid)
+      #=> :ok
+
+      MyFsm.insert_coin(pid)
       #=> :ok
       #=> Here's your coffee!
 


### PR DESCRIPTION
By using a locally registered process name, this example has caused some initial confusion to new users of Elixir. Using explicit PIDs will more closely align with other examples, and reduce the number of things one must understand in order to understand this example.

I know this is a trivial change, but after hearing about at least two other cases where this example has caused some confusion for new users, I felt like it made sense to take the time to update it.
