### PR TITLE
Support interpolation in keyword list atoms

### DIFF
--- a/lib/elixir/test/erlang/atom_test.erl
+++ b/lib/elixir/test/erlang/atom_test.erl
@@ -22,6 +22,11 @@ atom_quoted_call_test() ->
 kv_with_quotes_test() ->
   {'foo bar',[]} = eval(":atom_test.kv(\"foo bar\": nil)").
 
+kv_with_interpolation_test() ->
+  {'foo',[]} = eval(":atom_test.kv(\"#{\"foo\"}\": nil)"),
+  {'foo',[]} = eval(":atom_test.kv(\"#{\"fo\"}o\": nil)"),
+  {'foo',_} = eval("a = \"f\"; :atom_test.kv(\"#{a}#{\"o\"}o\": nil)").
+
 quoted_atom_test() ->
   {foo,[]} = eval(":\"foo\""),
   {foo,[]} = eval(":'foo'").

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -55,7 +55,8 @@ op_atom_test() ->
   [{atom,1,f0_1}] = tokenize(":f0_1").
 
 kw_test() ->
-  [{kw_identifier,1,do}] = tokenize("do: ").
+  [{kw_identifier, 1, do}] = tokenize("do: "),
+  [{kw_identifier_string, 1, false, [<<"foo bar">>]}] = tokenize("\"foo bar\": ").
 
 integer_test() ->
   [{number, 1, 123}] = tokenize("123"),


### PR DESCRIPTION
``` elixir
key = "foo"
["#{key}": :value]
```
