### PR TITLE
StringIO improvements

### DIFF
--- a/lib/elixir/test/elixir/string_io_test.exs
+++ b/lib/elixir/test/elixir/string_io_test.exs
@@ -85,7 +85,7 @@ defmodule StringIOTest do
     assert contents(pid) == { "", "" }
   end
 
-  test "IO.binread :line with \\rn" do
+  test "IO.binread :line with \\r\\n" do
     pid = start("abc\r\n")
     assert IO.binread(pid, :line) == "abc\n"
     assert IO.binread(pid, :line) == :eof


### PR DESCRIPTION
I've begun StringIO improvements, and I've had several rewrites (e.g. https://gist.github.com/devinus/c8fc12b63f1c73aedbae) that have all led me to question my own interpretation of the IO protocol and appreciate some design decisions that @mururu took.

However, there are several performance improvements we can still make. For example, @josevalim has confirmed that we only need to care about `:latin1` (terribly named, but this is what's used when using `binread`/`binwrite` because there's no concept of multibyte codepoints) and `:unicode` (which should only be UTF-8), but I wanted to go on a line by line basis with @mururu to confirm behaviour and maybe @josevalim can chime in when necessary.

I've already fixed several potential bugs that I'd like a second pair of eyes to double check.
