### PR TITLE
Remove support to MIX_GIT_FORCE_HTTPS environment option

### DIFF
--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -66,7 +66,7 @@ defmodule Mix.SCM.Git do
 
   def checkout(opts) do
     path     = opts[:dest]
-    location = location(opts[:git])
+    location = opts[:git]
     command  = ~s(git clone --no-checkout --progress "#{location}" "#{path}")
 
     run_cmd_or_raise(command)
@@ -76,7 +76,7 @@ defmodule Mix.SCM.Git do
   def update(opts) do
     File.cd! opts[:dest], fn ->
       # Ensures origin is set the lock repo
-      location = location(opts[:git])
+      location = opts[:git]
       update_origin(location)
 
       command = "git fetch --force --progress"
@@ -90,16 +90,6 @@ defmodule Mix.SCM.Git do
   end
 
   ## Helpers
-
-  defp location("git://github.com/" <> rest) do
-    if System.get_env("MIX_GIT_FORCE_HTTPS") == "1" do
-      "https://github.com/" <> rest
-    else
-      "git://github.com/" <> rest
-    end
-  end
-
-  defp location(other), do: other
 
   defp do_checkout(opts) do
     ref = get_lock_rev(opts[:lock]) || get_opts_rev(opts)


### PR DESCRIPTION
Fix https://github.com/elixir-lang/elixir/issues/2101

This used to be useful in case the git port was blocked, as stated in the [CHANGELOG entry](https://github.com/elixir-lang/elixir/blame/v0.13/CHANGELOG.md#L361) which added this feature.
