### PR TITLE
Improve Process.register/2 docs

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -326,6 +326,10 @@ defmodule Process do
   be an atom, can be used instead of the pid / port identifier with the
   `Kernel.send/2` function.
 
+  `Process.register/2` will fail if the pid supplied is no longer alive,
+  (check with `Process.alive?`) or if the name is already registered
+  (check with `Process.registered?`).
+
   See http://www.erlang.org/doc/man/erlang.html#register-2 for more info.
   """
   @spec register(pid | port, atom) :: true


### PR DESCRIPTION
Had an issue in which the result of calling Process.register/2 with a dead or previously registered pid resulted in an ArgumentError with a vague stack trace.  Added documentation to clarify that the call will fail in these two conditions.
