### PR TITLE
Permit providing args to default_task in Mix.Project.

### DIFF
--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -44,7 +44,7 @@ defmodule Mix.CLI do
   end
 
   defp get_task([]) do
-    { Mix.project[:default_task], [] }
+    { Mix.project[:default_task], Mix.project[:default_task_args] }
   end
 
   defp run_task(name, args) do

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -331,6 +331,7 @@ defmodule Mix.Project do
   defp default_config do
     [ build_per_environment: true,
       default_task: "run",
+      default_task_args: [],
       deps: [],
       deps_path: "deps",
       elixirc_exts: [:ex],


### PR DESCRIPTION
In the event that you created special build instructions in a separate Mix task, it may be convenient to provide args to that mix task on a per project basis.
