### PR TITLE
Add --gen-debug

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -17,6 +17,7 @@ if [ $# -eq 0 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
   --hidden          Makes a hidden node
   --detached        Starts the Erlang VM detached from console
   --no-halt         Does not halt the Erlang VM after execution
+  --gen-debug       Turns on default debugging for all GenServers
 
 ** Options marked with (*) can be given more than once
 ** Options given after the .exs file or -- are passed down to the executed code
@@ -63,6 +64,9 @@ while [ $I -le $# ]; do
         I=$(expr $I + 1)
         eval "VAL=\${$I}"
         ERL="$ERL "$VAL""
+        ;;
+    --gen-debug)
+        ERL="$ERL -generic_debug"
         ;;
     *)
         break

--- a/bin/elixir.bat
+++ b/bin/elixir.bat
@@ -24,6 +24,7 @@ echo   --cookie cookie   Sets a cookie for this distributed node
 echo   --hidden          Makes a hidden node
 echo   --detached        Starts the Erlang VM detached from console
 echo   --no-halt         Does not halt the Erlang VM after execution
+echo   --gen-debug       Turns on default debugging for all GenServers
 echo.
 echo ** Options marked with (*) can be given more than once
 echo ** Options given after the .exs file or -- are passed down to the executed code
@@ -63,6 +64,7 @@ IF NOT "%par%"=="%par:--cookie=%"   (Set parsErlang=%parsErlang% -setcookie %1 &
 IF NOT "%par%"=="%par:--sname=%"    (Set parsErlang=%parsErlang% -sname %1 && shift) 
 IF NOT "%par%"=="%par:--name=%"     (Set parsErlang=%parsErlang% -name %1 && shift) 
 IF NOT "%par%"=="%par:--erl=%"      (Set beforeExtra=%beforeExtra% %~1 && shift) 
+IF NOT "%par%"=="%par:--gen-debug=%" (Set parsErlang=%parsErlang% -generic_debug)
 rem ******* elixir parameters **********************
 rem Note: we don't have to do anything with options that don't take an argument
 IF NOT "%par%"=="%par:-e=%"      (shift) 

--- a/bin/iex
+++ b/bin/iex
@@ -16,6 +16,7 @@ if [ $# -gt 0 ] && ([ "$1" = "--help" ] || [ "$1" = "-h" ]); then
   --cookie \"cookie\" Sets a cookie for this distributed node
   --hidden          Makes a hidden node
   --detached        Starts the Erlang VM detached from console
+  --gen-debug       Turns on default debugging for all GenServers
   --remsh \"name\"    Connects to a node using a remote shell
   --dot-iex \"path\"  Overrides default .iex.exs file and uses path instead;
                     path can be empty, then no file will be loaded

--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -157,7 +157,7 @@ defmodule Kernel.CLI do
     process_shared t, config
   end
 
-  defp process_shared([erl|t], config) when erl in ["--detached", "--hidden"] do
+  defp process_shared([erl|t], config) when erl in ["--detached", "--hidden", "--gen-debug"] do
     process_shared t, config
   end
 


### PR DESCRIPTION
Uses `-generic_debug` to add `[:log, :statistics]` to all `GenServers`. It can be useful for dev/debug cycle. It will print out some nice info to the shell when a `GenServer` exits abnormally.

I am unsure if this patch should make it in as `-generic_debug` is not documented and only works on `GenServers`, especially when one can do `--erl -generic_debug`.

NB: not tested on windows.
