### PR TITLE
Warning in Enum.count should state that protocol requires an integer, not a boolean

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -414,7 +414,7 @@ defmodule Enum do
     case Enumerable.count(collection) do
       value when is_integer(value) ->
         IO.write "Expected #{inspect Enumerable.impl_for(collection)}.count/1 to return " <>
-                 "{ :ok, boolean } if pre-calculated, otherwise { :error, module }, got " <>
+                 "{ :ok, integer } if pre-calculated, otherwise { :error, module }, got " <>
                  "an integer\n#{Exception.format_stacktrace}"
         value
       { :ok, value } when is_integer(value) ->


### PR DESCRIPTION
I stumbled about this while upgrading a solution using ecto to the latest elixir code bits. If I'm not mistaken the boolean is wrong in the message, isn't it?
