### PR TITLE
Initial Digest implementation

### DIFF
--- a/lib/elixir/lib/digest.ex
+++ b/lib/elixir/lib/digest.ex
@@ -26,13 +26,13 @@ defmodule Digest do
     iex> Digest.to_hex("test")
     "74657374"
     iex> Digest.to_hex("æß")
-    "C3A6C39F"
+    "c3a6c39f"
 
   """
   @spec to_hex(String.t) :: String.t | no_return
   def to_hex(""), do: ""
   def to_hex(string) when is_binary(string) do
-    bc <<x :: size(4), y :: size(4)>> inbits string do <<hex_char(x), hex_char(y)>> end |> String.upcase
+    bc <<x :: size(4), y :: size(4)>> inbits string do <<hex_char(x), hex_char(y)>> end
   end
 
   @doc """
@@ -42,7 +42,7 @@ defmodule Digest do
 
     iex> Digest.from_hex("74657374")
     "test"
-    iex> Digest.from_hex("C3A6C39F")
+    iex> Digest.from_hex("c3a6c39f")
     "æß"
   """
   @spec from_hex(String.t) :: String.t | no_return

--- a/lib/elixir/test/elixir/digest_test.exs
+++ b/lib/elixir/test/elixir/digest_test.exs
@@ -10,9 +10,9 @@ defmodule DigestTest do
   end
 
   test :to_hex do
-    assert "6C6F72656D20697073756D20646F6C6F722073697420616D6574" = Digest.to_hex("lorem ipsum dolor sit amet")
+    assert "6c6f72656d20697073756d20646f6c6f722073697420616d6574" = Digest.to_hex("lorem ipsum dolor sit amet")
     assert "74657374" == Digest.to_hex("test")
-    assert "C3A6C39F" == Digest.to_hex("æß")
+    assert "c3a6c39f" == Digest.to_hex("æß")
     assert ""         == Digest.to_hex("")
   end
 end


### PR DESCRIPTION
Hey all,

So this is the barebones Digest implementation. I'm in the process of adding `from_hex`, but there are some subtleties around properly handling hex-encoded UTF-8 characters that I'm still trying to sort out. `crc32` and `adler32` are left out, because they are both functions in the `:erlang` module. I'm open to additional suggestions for functions to include here, but honestly it's starting to look like `md5`, `to_hex`, and `from_hex` are going to be it.

I wanted to get this up here for people to review while I continue working on things, and start collecting feedback.
