### PR TITLE
Remote converger should receive and update lock

### DIFF
--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -57,7 +57,7 @@ defmodule Mix.Dep do
   provided in the project are in the wrong format.
   """
   def loaded(opts) do
-    { deps, _ } = Mix.Dep.Converger.all(nil, opts, fn(dep, acc) -> { dep, acc } end)
+    { deps, _, _ } = Mix.Dep.Converger.all(nil, nil, opts, &{ &1, &2, &3 })
     Mix.Dep.Converger.topsort(deps)
   end
 
@@ -106,9 +106,9 @@ defmodule Mix.Dep do
   This function raises an exception if any of the dependencies
   provided in the project are in the wrong format.
   """
-  def unloaded(acc, opts, callback) do
-    { deps, acc } = Mix.Dep.Converger.all(acc, opts, callback)
-    { Mix.Dep.Converger.topsort(deps), acc }
+  def unloaded(acc, lock, opts, callback) do
+    { deps, acc, lock } = Mix.Dep.Converger.all(acc, lock, opts, callback)
+    { Mix.Dep.Converger.topsort(deps), acc, lock }
   end
 
   @doc """
@@ -120,14 +120,14 @@ defmodule Mix.Dep do
   This function raises an exception if any of the dependencies
   provided in the project are in the wrong format.
   """
-  def unloaded_by_name(given, acc, opts, callback) do
+  def unloaded_by_name(given, acc, lock, opts, callback) do
     names = to_app_names(given)
 
-    unloaded(acc, opts, fn(dep, acc) ->
+    unloaded(acc, lock, opts, fn dep, acc, lock ->
       if dep.app in names do
-        callback.(dep, acc)
+        callback.(dep, acc, lock)
       else
-        { dep, acc }
+        { dep, acc, lock }
       end
     end)
   end

--- a/lib/mix/lib/mix/remote_converger.ex
+++ b/lib/mix/lib/mix/remote_converger.ex
@@ -15,9 +15,9 @@ defmodule Mix.RemoteConverger do
   @doc """
   Run the remote converger.
 
-  Return the converged deps.
+  Return updated lock.
   """
-  defcallback converge([Mix.Dep.t]) :: [Mix.Dep.t]
+  defcallback converge([Mix.Dep.t], map) :: map
 
   @doc """
   Get registered remote converger.

--- a/lib/mix/test/mix/dep_test.exs
+++ b/lib/mix/test/mix/dep_test.exs
@@ -74,10 +74,10 @@ defmodule Mix.DepTest do
     # the proper manager.
     Mix.Project.push DepsApp
 
-    { _, true } =
-      Mix.Dep.unloaded(false, [], fn dep, acc ->
+    { _, true, _ } =
+      Mix.Dep.unloaded(false, [], nil, fn dep, acc, lock ->
         assert nil?(dep.manager)
-        { dep, acc or true }
+        { dep, acc or true, lock }
       end)
   end
 
@@ -185,9 +185,9 @@ defmodule Mix.DepTest do
 
     def remote?(_app), do: true
 
-    def converge(deps) do
+    def converge(_deps, lock) do
       Process.put(:remote_converger, true)
-      deps
+      lock
     end
   end
 
@@ -218,13 +218,13 @@ defmodule Mix.DepTest do
     Mix.Project.push OnlyDeps
 
     in_fixture "deps_status", fn ->
-      { deps, _acc } = Mix.Dep.unloaded([], [env: :other_env], &{ &1, &2 })
+      { deps, _acc, _lock } = Mix.Dep.unloaded([], nil, [env: :other_env], &{ &1, &2, &3 })
       assert length(deps) == 2
 
-      { deps, _acc } = Mix.Dep.unloaded([], [], &{ &1, &2 })
+      { deps, _acc, _lock } = Mix.Dep.unloaded([], nil, [], &{ &1, &2, &3 })
       assert length(deps) == 2
 
-      { deps, _acc } = Mix.Dep.unloaded([], [env: :prod], &{ &1, &2 })
+      { deps, _acc, _lock } = Mix.Dep.unloaded([], nil, [env: :prod], &{ &1, &2, &3 })
       assert length(deps) == 1
       assert Enum.find deps, &match?(%Mix.Dep{app: :foo}, &1)
     end


### PR DESCRIPTION
Confirmed that it works with hex and that `mix deps.update` works as expected.
