### PR TITLE
Use werl instead of erl when executing iex.bat

### DIFF
--- a/bin/elixir.bat
+++ b/bin/elixir.bat
@@ -45,6 +45,9 @@ set originPath=%~dp0
 rem Optional parameters before the "-extra" parameter
 set beforeExtra=
 
+rem Flag which determines whether or not to use werl vs erl
+set useWerl=0
+
 rem Recursive loop called for each parameter that parses the cmd line parameters
 :startloop
 set par="%1"
@@ -57,6 +60,8 @@ if "%par%"=="""" (
   rem if no parameters defined - special case for parameter that is already quoted
   goto :expand_erl_libs
 )
+rem ******* EXECUTION OPTIONS **********************
+IF NOT "%par%"=="%par:+iex" (Set useWerl=1)
 rem ******* ERLANG PARAMETERS **********************
 IF NOT "%par%"=="%par:--detached=%" (Set parsErlang=%parsErlang% -detached) 
 IF NOT "%par%"=="%par:--hidden=%"   (Set parsErlang=%parsErlang% -hidden)
@@ -87,8 +92,7 @@ for  /d %%d in ("%originPath%..\lib\*.") do (
 SETLOCAL disabledelayedexpansion
 :run
 IF %useWerl% EQU 1 (
-    werl %ext_libs% %ELIXIR_ERL_OPTS% %parsErlang% -s elixir start_cli %beforeExtra% -extra %*
+    werl %ext_libs% -noshell %ELIXIR_ERL_OPTS% %parsErlang% -s elixir start_cli %beforeExtra% -extra %*
 ) ELSE (
     erl %ext_libs% -noshell %ELIXIR_ERL_OPTS% %parsErlang% -s elixir start_cli %beforeExtra% -extra %*
 )
-

--- a/bin/iex.bat
+++ b/bin/iex.bat
@@ -1,3 +1,2 @@
 @echo off
-SET useWerl=1
-call "%~dp0\elixir.bat" +iex --no-halt -e "IEx.start" %*
+call "%~dp0\elixir.bat" +iex --erl "-user Elixir.IEx.CLI" --no-halt %


### PR DESCRIPTION
This is more to start some discussion around this than necessarily the final solution for the problem. This commit sets an environment variable `useWerl`, which is then checked prior to executing `erl` in `elixir.bat`. If it is set to 1, `werl` is used instead of `erl`. This allows someone to override it and use `erl` for iex if they just want to use their native shell for `iex` (which still works, it's just missing some features like the CTRL+C and CTRL+G menus).

Thoughts?
