### PR TITLE
Allow overriding of undefined dependency SCM

### DIFF
--- a/lib/mix/lib/mix/dep/loader.ex
+++ b/lib/mix/lib/mix/dep/loader.ex
@@ -122,17 +122,12 @@ defmodule Mix.Dep.Loader do
       (new = scm.accepts_options(app, opts)) && { scm, new }
     end
 
-    if scm do
-      %Mix.Dep{
-        scm: scm,
-        app: app,
-        requirement: req,
-        status: scm_status(scm, opts),
-        opts: opts }
-    else
-      raise Mix.Error, message: "#{inspect Mix.Project.get} did not specify a supported scm " <>
-                                "for app #{inspect app}, expected one of :git, :path or :in_umbrella"
-    end
+    %Mix.Dep{
+      scm: scm,
+      app: app,
+      requirement: req,
+      status: scm_status(scm, opts),
+      opts: opts }
   end
 
   defp with_scm_and_app(other, _scms) do
@@ -140,10 +135,13 @@ defmodule Mix.Dep.Loader do
   end
 
   defp scm_status(scm, opts) do
-    if scm.checked_out?(opts) do
-      { :ok, nil }
-    else
-      { :unavailable, opts[:dest] }
+    cond do
+      nil?(scm) ->
+        :noscm
+      scm.checked_out?(opts) ->
+        { :ok, nil }
+      true ->
+        { :unavailable, opts[:dest] }
     end
   end
 

--- a/lib/mix/lib/mix/tasks/deps.ex
+++ b/lib/mix/lib/mix/tasks/deps.ex
@@ -99,7 +99,7 @@ defmodule Mix.Tasks.Deps do
     Enum.each loaded(loaded_opts), fn %Mix.Dep{scm: scm} = dep ->
       dep = check_lock(dep, lock)
       shell.info "* #{format_dep(dep)}"
-      if formatted = scm.format_lock(dep.opts) do
+      if scm && (formatted = scm.format_lock(dep.opts)) do
         shell.info "  locked at #{formatted}"
       end
       shell.info "  #{format_status dep}"

--- a/lib/mix/test/fixtures/deps_status/custom/noscm_repo/mix.exs
+++ b/lib/mix/test/fixtures/deps_status/custom/noscm_repo/mix.exs
@@ -1,0 +1,12 @@
+defmodule NoSCMRepo do
+  use Mix.Project
+
+  def project do
+    [ app: :noscm_repo,
+      version: "0.1.0",
+      deps: [
+        { :git_repo, "0.1.0" }
+      ]
+    ]
+  end
+end

--- a/lib/mix/test/mix/dep_test.exs
+++ b/lib/mix/test/mix/dep_test.exs
@@ -22,12 +22,6 @@ defmodule Mix.DepTest do
     end
   end
 
-  defmodule NoSCMApp do
-    def project do
-      [ deps: [ { :ok, "~> 0.1", not_really: :ok } ] ]
-    end
-  end
-
   defmodule InvalidDepsReq do
     def project do
       [ deps: [ { :ok, "+- 0.1.0", github: "elixir-lang/ok" } ] ]
@@ -55,16 +49,6 @@ defmodule Mix.DepTest do
     in_fixture "deps_status", fn ->
       deps = Mix.Dep.loaded([])
       assert Enum.find deps, &match?(%Mix.Dep{app: :ok, status: { :ok, _ }}, &1)
-    end
-  end
-
-  test "raises when no SCM is specified" do
-    Mix.Project.push NoSCMApp
-
-    in_fixture "deps_status", fn ->
-      msg = "Mix.DepTest.NoSCMApp did not specify a supported scm for app :ok, " <>
-            "expected one of :git, :path or :in_umbrella"
-      assert_raise Mix.Error, msg, fn -> Mix.Dep.loaded([]) end
     end
   end
 


### PR DESCRIPTION
This allows a developer to override an unrecognized SCM without Mix
raising.
