### PR TITLE
Add String.split_at

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -250,6 +250,53 @@ defmodule String do
   end
 
   @doc """
+  Splits a string into two at the specified offset. When the offset given is
+  negative, location is counted from the end of the string.
+
+  The offset is capped to the length of the string.
+
+  Returns a tuple with two elements.
+
+  ## Examples
+
+      iex> String.split_at "sweetelixir", 5
+      {"sweet", "elixir"}
+
+      iex> String.split_at "sweetelixir", -6
+      {"sweet", "elixir"}
+
+      iex> String.split_at "abc", 0
+      {"", "abc"}
+
+      iex> String.split_at "abc", 1000
+      {"abc", ""}
+
+      iex> String.split_at "abc", -1000
+      {"", "abc"}
+
+  """
+  @spec split_at(t, integer) :: {t, t}
+  def split_at(string, offset)
+
+  def split_at(binary, index) when index == 0, do:
+    {"", binary}
+
+  def split_at(binary, index) when index > 0, do:
+    do_split_at(next_grapheme(binary), 0, index, "")
+
+  def split_at(binary, index) when index < 0, do:
+    do_split_at(next_grapheme(binary), 0, max(0, byte_size(binary)+index), "")
+
+  defp do_split_at(nil, _, _, acc), do:
+    {acc, ""}
+
+  defp do_split_at({grapheme, rest}, current_pos, target_pos, acc) when current_pos < target_pos, do:
+    do_split_at(next_grapheme(rest), current_pos+1, target_pos, acc <> grapheme)
+
+  defp do_split_at({grapheme, rest}, pos, pos, acc), do:
+    {acc, grapheme <> rest}
+
+  @doc """
   Convert all characters on the given string to uppercase.
 
   ## Examples

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -65,6 +65,23 @@ defmodule StringTest do
     assert String.split("a,b", ~r{\.}) == ["a,b"]
   end
 
+  test :split_at do
+    assert String.split_at("", 0) == {"", ""}
+    assert String.split_at("", -1) == {"", ""}
+    assert String.split_at("", 1) == {"", ""}
+
+    assert String.split_at("abc", 0) == {"", "abc"}
+    assert String.split_at("abc", 2) == {"ab", "c"}
+    assert String.split_at("abc", 3) == {"abc", ""}
+    assert String.split_at("abc", 4) == {"abc", ""}
+    assert String.split_at("abc", 1000) == {"abc", ""}
+
+    assert String.split_at("abc", -1) == {"ab", "c"}
+    assert String.split_at("abc", -3) == {"", "abc"}
+    assert String.split_at("abc", -4) == {"", "abc"}
+    assert String.split_at("abc", -1000) == {"", "abc"}
+  end
+
   test :upcase do
     assert String.upcase("123 abcd 456 efg hij ( %$#) kl mnop @ qrst = -_ uvwxyz") == "123 ABCD 456 EFG HIJ ( %$#) KL MNOP @ QRST = -_ UVWXYZ"
     assert String.upcase("") == ""


### PR DESCRIPTION
While it is straightforward to split a string given
an offset in bytes from its beginning like this

```
<<left::[binary, size(offset)], right::binary>> = string
```

splitting at grapheme boundary or using negative offset
is not so simple. Hence this function.
