### PR TITLE
Don't mention default EEx engine twice; add a note about it in the code

### DIFF
--- a/lib/eex/lib/eex.ex
+++ b/lib/eex/lib/eex.ex
@@ -38,7 +38,6 @@ defmodule EEx do
               Defaults to the given file the template is read from
               or to "nofile" when compiling from a string;
   * `:engine` - the EEx engine to be used for compilation.
-                Defaults to `EEx.Engine`;
 
   ## Engine
 

--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -1,6 +1,9 @@
 defmodule EEx.Compiler do
   @moduledoc false
 
+  # when changing this setting, don't forget to update the docs for EEx
+  @default_engine EEx.SmartEngine
+
   @doc """
   This is the compilation entry point. It glues the tokenizer
   and the engine together by handling the tokens and invoking
@@ -10,7 +13,7 @@ defmodule EEx.Compiler do
     file   = opts[:file] || "nofile"
     line   = opts[:line] || 1
     tokens = EEx.Tokenizer.tokenize(source, line)
-    state  = %{engine: opts[:engine] || EEx.SmartEngine,
+    state  = %{engine: opts[:engine] || @default_engine,
                file: file, line: line, quoted: [], start_line: nil}
     generate_buffer(tokens, "", [], state)
   end


### PR DESCRIPTION
The docs mention default engine twice in the span of two paragraphs and the first mention is incorrect.
