### PR TITLE
Don't load dependencies in remote converger

### DIFF
--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -26,7 +26,7 @@ defmodule Mix.CLI do
     run_task(task, args)
   end
 
-  @hex_requirement ">= 0.1.0-dev"
+  @hex_requirement ">= 0.1.1-dev"
 
   defp load_remote do
     if Code.ensure_loaded?(Hex) do

--- a/lib/mix/lib/mix/dep/converger.ex
+++ b/lib/mix/lib/mix/dep/converger.ex
@@ -76,8 +76,8 @@ defmodule Mix.Dep.Converger do
              |> Enum.into(HashDict.new, &{&1.app, &1})
 
       # In case there is no lock, we will read the current lock
-      # which is potentially stale. So converger.deps needs to
-      # always check if the data it finds on the lock is actually
+      # which is potentially stale. So converger.deps/2 needs to
+      # always check if the data it finds in the lock is actually
       # valid.
       lock_for_converger = lock || Mix.Dep.Lock.read
 
@@ -148,7 +148,8 @@ defmodule Mix.Dep.Converger do
               # After we invoke the callback (which may actually check out the
               # dependency), we load the dependency including its latest info
               # and children information.
-              Mix.Dep.Loader.load(dep, children)
+              dep = Mix.Dep.Loader.load(dep)
+              %{dep | deps: Enum.filter(dep.deps, &(!children || &1.app in children))}
           end
 
         dep = %{dep | deps: reject_non_fullfilled_optional(dep.deps, current_breadths)}

--- a/lib/mix/lib/mix/dep/umbrella.ex
+++ b/lib/mix/lib/mix/dep/umbrella.ex
@@ -29,7 +29,7 @@ defmodule Mix.Dep.Umbrella do
     apps = Enum.map(deps, &(&1.app))
 
     Enum.map(deps, fn umbrella_dep ->
-      umbrella_dep = Mix.Dep.Loader.load(umbrella_dep, nil)
+      umbrella_dep = Mix.Dep.Loader.load(umbrella_dep)
       deps = Enum.filter(umbrella_dep.deps, fn dep ->
         Mix.Dep.available?(dep) and dep.app in apps
       end)

--- a/lib/mix/lib/mix/remote_converger.ex
+++ b/lib/mix/lib/mix/remote_converger.ex
@@ -20,11 +20,10 @@ defmodule Mix.RemoteConverger do
   defcallback converge([Mix.Dep.t], map) :: map
 
   @doc """
-  Returns a loaded list of child dependencies the converger has
-  for the dependency. This list should override what is specified
-  in mix.exs or rebar.config.
+  Returns a child dependencies the converger has  for the
+  dependency. This list should filter the loaded children.
   """
-  defcallback deps(Mix.Dep.t, map) :: [Mix.Dep.t]
+  defcallback deps(Mix.Dep.t, map) :: [atom]
 
 
   @doc """


### PR DESCRIPTION
Remote converger returns list of names that filters children returned
from Mix.Dep.Loader.load/1.
