### PR TITLE
Fix compiler abstract code

### DIFF
--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -140,7 +140,7 @@ module(Forms, File, RawOptions, Bootstrap, Callback) when
   Options = RawOptions ++ elixir_code_server:call(erl_compiler_options),
   Listname = elixir_utils:characters_to_list(File),
 
-  case compile:noenv_forms(Forms, [no_auto_import,return,{source,Listname}|Options]) of
+  case compile:noenv_forms([no_auto_import()|Forms], [return,{source,Listname}|Options]) of
     {ok, ModuleName, Binary, Warnings} ->
       format_warnings(Bootstrap, Warnings),
       code:load_binary(ModuleName, Listname, Binary),
@@ -149,6 +149,9 @@ module(Forms, File, RawOptions, Bootstrap, Callback) when
       format_warnings(Bootstrap, Warnings),
       format_errors(Errors)
   end.
+
+no_auto_import() ->
+  {attribute, 0, compile, no_auto_import}.
 
 %% CORE HANDLING
 

--- a/lib/elixir/src/elixir_utils.erl
+++ b/lib/elixir/src/elixir_utils.erl
@@ -31,7 +31,7 @@ file_type(File, Op) ->
 relative_to_cwd(Path) ->
   case elixir_compiler:get_opt(internal) of
     true  -> Path;
-    false -> 'Elixir.Path':relative_to_cwd(Path)
+    false -> 'Elixir.List':'from_char_data!'('Elixir.Path':relative_to_cwd(Path))
   end.
 
 characters_to_list(Data) when is_list(Data) ->


### PR DESCRIPTION
This makes the abstract code valid and ensures dialyzer works when a function clashes with an auto imported bif.

A PR should be done to OTP so that dialyzer reads the `options` from the `compile_info` chunk of a beam and uses them when creating core from a beam.
