### PR TITLE
Make ExUnit.Filters parse integers and match atoms to binaries.

### DIFF
--- a/lib/ex_unit/test/ex_unit/filters_test.exs
+++ b/lib/ex_unit/test/ex_unit/filters_test.exs
@@ -19,9 +19,22 @@ defmodule ExUnit.FiltersTest do
     assert ExUnit.Filters.eval([os: :win, os: :unix], [:os], [os: :win]) == :ok
   end
 
+  test "evaluating filters matches integers" do
+    assert ExUnit.Filters.eval([line: "1"], [], [line: 1])        == :ok
+    assert ExUnit.Filters.eval([line: "1"], [line: 5], [line: 1]) == :ok
+    assert ExUnit.Filters.eval([line: "1"], [:line], [line: 1])   == :ok
+  end
+
+  test "evaluating filter matches atoms" do
+    assert ExUnit.Filters.eval([os: "win"], [], [os: :win])          == :ok
+    assert ExUnit.Filters.eval([os: "win"], [os: :unix], [os: :win]) == :ok
+    assert ExUnit.Filters.eval([os: "win"], [:os], [os: :win])       == :ok
+  end
+
   test "parsing filters" do
     assert ExUnit.Filters.parse(["run"]) == [:run]
-    assert ExUnit.Filters.parse(["run:true"]) == [run: true]
+    assert ExUnit.Filters.parse(["run:true"]) == [run: "true"]
     assert ExUnit.Filters.parse(["run:test"]) == [run: "test"]
+    assert ExUnit.Filters.parse(["line:9"]) == [line: "9"]
   end
 end


### PR DESCRIPTION
Makes mix test --only line:9 or --only "test:Test Message" work. Fixes #2064.
