### PR TITLE
Support line numbers in mix test, e.g. test/some/file_test.exs:12

### DIFF
--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -6,6 +6,21 @@ defmodule ExUnit.Filters do
   @type t :: list({atom, any} | atom)
 
   @doc """
+  Determines whether a given file path (supplied to ExUnit/Mix as arguments
+  on the command line) includes a line number filter, and if so returns the
+  appropriate ExUnit configuration options.
+  """
+  @spec parse_file_path(String.t) :: {String.t, any}
+  def parse_file_path(file) do
+    case Regex.run(~r/^(.+):(\d+)$/, file, capture: :all_but_first) do
+      [file, line_number] ->
+        {file, exclude: [:test], include: [line: line_number]}
+      nil ->
+        {file, []}
+    end
+  end
+
+  @doc """
   Normalizes include and excludes to remove duplicates
   and keep precedence.
 

--- a/lib/ex_unit/test/ex_unit/filters_test.exs
+++ b/lib/ex_unit/test/ex_unit/filters_test.exs
@@ -37,4 +37,24 @@ defmodule ExUnit.FiltersTest do
     assert ExUnit.Filters.parse(["run:test"]) == [run: "test"]
     assert ExUnit.Filters.parse(["line:9"]) == [line: "9"]
   end
+
+  test "file paths with line numbers" do
+    assert ExUnit.Filters.parse_file_path("test/some/path.exs:123") ==
+      {"test/some/path.exs", [exclude: [:test], include: [line: "123"]]}
+
+    assert ExUnit.Filters.parse_file_path("test/some/path.exs") ==
+      {"test/some/path.exs", []}
+
+    assert ExUnit.Filters.parse_file_path("test/some/path.exs:123notreallyalinenumber123") ==
+      {"test/some/path.exs:123notreallyalinenumber123", []}
+
+    assert ExUnit.Filters.parse_file_path("C:\\some\\path.exs:123") ==
+      {"C:\\some\\path.exs", [exclude: [:test], include: [line: "123"]]}
+
+    assert ExUnit.Filters.parse_file_path("C:\\some\\path.exs") ==
+      {"C:\\some\\path.exs", []}
+
+    assert ExUnit.Filters.parse_file_path("C:\\some\\path.exs:123notreallyalinenumber123") ==
+      {"C:\\some\\path.exs:123notreallyalinenumber123", []}
+  end
 end

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -86,6 +86,11 @@ defmodule Mix.Tasks.Test do
 
       mix test --include external --exclude test
 
+  When filtering tests by line number the following styles are equivalent:
+
+      mix test test/some/particular/file_test.exs:12
+      mix test --only line:12 test/some/particular/file_test.exs
+
   ## Configuration
 
   * `:test_paths` - list of paths containing test files, defaults to `["test"]`.
@@ -147,6 +152,16 @@ defmodule Mix.Tasks.Test do
     Enum.each(test_paths, &require_test_helper(&1))
 
     ExUnit.configure(opts)
+
+    files = case files do
+      [single_file] ->
+        # Check if the single file path matches test/path/to_test.exs:123, if it does
+        # apply `--only line:123` and trim the trailing :123 part.
+        {single_file, opts} = ExUnit.Filters.parse_file_path(single_file)
+        ExUnit.configure(opts)
+        [single_file]
+      _ -> files
+    end
 
     test_paths   = if files == [], do: test_paths, else: files
     test_pattern = project[:test_pattern] || "*_test.exs"


### PR DESCRIPTION
I'm not happy that there are no tests and I'm wondering if I should put the code in its own function (and return a tuple of the new file list and exunit options to apply) so I can unit test it separately.

/cc @josevalim
