### PR TITLE
Fix pruning IEx stacktraces too aggressively

### DIFF
--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -204,10 +204,14 @@ defmodule IEx.Evaluator do
     end
   end
 
-  defp prune_stacktrace([{:erl_eval, _, _, _}|_]),  do: []
-  defp prune_stacktrace([{__MODULE__, _, _, _}|_]), do: []
-  defp prune_stacktrace([h|t]), do: [h|prune_stacktrace(t)]
-  defp prune_stacktrace([]), do: []
+  defp prune_stacktrace(stacktrace) do
+    stacktrace
+      |> Enum.reverse()
+      |> Enum.drop_while(&(elem(&1, 0) == __MODULE__))
+      |> Enum.drop_while(&(elem(&1, 0) == :elixir))
+      |> Enum.drop_while(&(elem(&1, 0) in [:erl_eval, :eval_bits]))
+      |> Enum.reverse()
+  end
 
   @doc false
   def format_stacktrace(trace) do


### PR DESCRIPTION
Wrote this while trying to find a test case for https://github.com/elixir-lang/elixir/pull/2216

Before:

```
iex(1)> Code.eval_quoted(quote(do: <<((fn() -> :error end).())>>))  
** (ArgumentError) argument error
```

After:

```
iex(1)> Code.eval_quoted(quote(do: <<((fn() -> :error end).())>>))  
** (ArgumentError) argument error
    (stdlib) :erl_eval.expr/3
    (elixir) src/elixir.erl:157: :elixir.erl_eval/2
    (elixir) src/elixir.erl:150: :elixir.eval_forms/4
    (elixir) lib/code.ex:159: Code.eval_quoted/3
```
