### PR TITLE
Fix some dialyzer warnings

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -524,7 +524,7 @@ defmodule File do
   The same as `cp/3`, but raises `File.CopyError` if it fails.
   Returns the list of copied files otherwise.
   """
-  @spec cp(Path.t, Path.t, (Path.t, Path.t -> boolean)) :: :ok | no_return
+  @spec cp!(Path.t, Path.t, (Path.t, Path.t -> boolean)) :: :ok | no_return
   def cp!(source, destination, callback \\ fn(_, _) -> true end) do
     source = String.from_char_data!(source)
     destination = String.from_char_data!(destination)

--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -511,7 +511,7 @@ defmodule Path do
       Path.wildcard("projects/*/ebin/**/*.{beam,app}")
 
   """
-  @spec basename(t) :: [binary]
+  @spec wildcard(t) :: [binary]
   def wildcard(glob) do
     glob
     |> List.from_char_data!

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -42,7 +42,7 @@ compile_error(Meta, File, Format, Args) when is_list(Format)  ->
 
 %% Raised on tokenizing/parsing
 
--spec parse_error(line_or_meta(), binary(), iolist() | atom(), binary()) -> no_return().
+-spec parse_error(line_or_meta(), binary(), binary(), binary()) -> no_return().
 
 parse_error(Meta, File, Error, <<>>) ->
   Message = case Error of

--- a/lib/mix/lib/mix/archive.ex
+++ b/lib/mix/lib/mix/archive.ex
@@ -63,7 +63,7 @@ defmodule Mix.Archive do
     source_path = Path.expand(source)
     target_path = Path.expand(target)
     dir = dir(target_path) |> List.from_char_data!
-    {:ok, _} = :zip.create(target_path,
+    {:ok, _} = :zip.create(List.from_char_data!(target_path),
                   files_to_add(source_path, dir),
                   uncompress: ['.beam', '.app'])
   end


### PR DESCRIPTION
Remaing warnings:

```
behaviour.ex:108: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
code.ex:121: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
code.ex:153: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
compiler.ex:24: The call _@1:'engine'() requires that _@1 is of type atom() | tuple() not #{}
compiler.ex:29: The call _@1:'file'() requires that _@1 is of type atom() | tuple() not #{}
compiler.ex:30: The call _@2:'engine'() requires that _@2 is of type atom() | tuple() not #{}
compiler.ex:38: The call _@1:'engine'() requires that _@1 is of type atom() | tuple() not #{}
compiler.ex:49: The call _@2:'file'() requires that _@2 is of type atom() | tuple() not #{}
compiler.ex:49: The call _@1:'start_line'() requires that _@1 is of type atom() | tuple() not #{}
compiler.ex:50: The call _@3:'quoted'() requires that _@3 is of type atom() | tuple() not #{}
compiler.ex:59: The call _@1:'engine'() requires that _@1 is of type atom() | tuple() not #{}
compiler.ex:69: The call _@1:'line'() requires that _@1 is of type atom() | tuple() not #{}
compiler.ex:70: The call _@2:'quoted'() requires that _@2 is of type atom() | tuple() not #{}
compiler.ex:73: The call _@3:'quoted'() requires that _@3 is of type atom() | tuple() not #{}
assertions.ex:335: Guard test is_binary(_@5::atom() | tuple()) can never succeed
assertions.ex:337: Guard test is_map(_@4::atom() | tuple()) can never succeed
cli_formatter.ex:26: Guard test is_map(_@1::{'Elixir.ExUnit.CLIFormatter.Config',_,_,_,_,_,_,_,_}) can never succeed
cli_formatter.ex:31: Guard test is_map(_@1::{'Elixir.ExUnit.CLIFormatter.Config',_,_,_,_,_,_,_,_}) can never succeed
cli_formatter.ex:40: Guard test is_map(_@1::{'Elixir.ExUnit.CLIFormatter.Config',_,_,_,_,_,_,_,_}) can never succeed
cli_formatter.ex:55: Guard test is_map(_@1::{'Elixir.ExUnit.CLIFormatter.Config',_,_,_,_,_,_,_,_}) can never succeed
cli_formatter.ex:64: Guard test is_map(_@1::{'Elixir.ExUnit.CLIFormatter.Config',_,_,_,_,_,_,_,_}) can never succeed
cli_formatter.ex:114: Guard test is_map(_@2::{'Elixir.ExUnit.CLIFormatter.Config',_,_,_,_,_,_,_,_}) can never succeed
cli_formatter.ex:114: Guard test is_map(_@1::{'Elixir.ExUnit.CLIFormatter.Config',_,_,_,_,_,_,_,_}) can never succeed
cli_formatter.ex:116: Guard test is_map(_@3::{'Elixir.ExUnit.CLIFormatter.Config',_,_,_,_,_,_,_,_}) can never succeed
cli_formatter.ex:117: Guard test is_map(_@4::{'Elixir.ExUnit.CLIFormatter.Config',_,_,_,_,_,_,_,_}) can never succeed
cli_formatter.ex:121: Guard test is_map(_@5::{'Elixir.ExUnit.CLIFormatter.Config',_,_,_,_,_,_,_,_}) can never succeed
cli_formatter.ex:122: Guard test is_map(_@6::{'Elixir.ExUnit.CLIFormatter.Config',_,_,_,_,_,_,_,_}) can never succeed
cli_formatter.ex:126: Guard test is_map(_@7::{'Elixir.ExUnit.CLIFormatter.Config',_,_,_,_,_,_,boolean(),_}) can never succeed
cli_formatter.ex:141: Guard test is_map(_@1::{'Elixir.ExUnit.CLIFormatter.Config',_,_,_,_,_,_,_,_}) can never succeed
cli_formatter.ex:142: Guard test is_map(_@2::{'Elixir.ExUnit.CLIFormatter.Config',_,_,_,_,_,_,_,_}) can never succeed
cli_formatter.ex:147: Guard test is_map(_@1::{'Elixir.ExUnit.CLIFormatter.Config',_,_,_,_,_,_,_,_}) can never succeed
cli_formatter.ex:148: Guard test is_map(_@2::{'Elixir.ExUnit.CLIFormatter.Config',_,_,_,_,_,_,_,_}) can never succeed
cli_formatter.ex:154: Guard test is_map(_@1::{'Elixir.ExUnit.CLIFormatter.Config',_,_,_,_,_,_,_,_}) can never succeed
doc_test.ex:328: Guard test is_map(_@2::atom() | tuple()) can never succeed
doc_test.ex:359: The created fun has no local return
filters.ex:93: The variable _ can never match since previous clauses completely covered the type {'ok',_}
formatter.ex:122: Guard test is_map(_@1::{'Elixir.ExUnit.AssertionError',_,_,_,_,_}) can never succeed
formatter.ex:123: Guard test is_map(_@2::{'Elixir.ExUnit.AssertionError',_,_,_,_,_}) can never succeed
formatter.ex:124: Guard test is_map(_@3::{'Elixir.ExUnit.AssertionError',_,_,_,_,_}) can never succeed
formatter.ex:125: Guard test is_map(_@4::{'Elixir.ExUnit.AssertionError',_,_,_,_,_}) can never succeed
formatter.ex:134: Guard test is_map(_@1::atom() | tuple()) can never succeed
runner.ex:48: Guard test is_map(_@2::{'Elixir.ExUnit.Runner.Config',_,_,_,_,_,_,_,_}) can never succeed
runner.ex:48: Guard test is_map(_@1::{'Elixir.ExUnit.Runner.Config',_,_,_,_,_,_,_,_}) can never succeed
runner.ex:61: Guard test is_map(_@4::{'Elixir.ExUnit.Runner.Config',_,_,_,_,_,_,_,_}) can never succeed
runner.ex:103: Guard test is_map(_@2::{'Elixir.ExUnit.TestCase',_,_,_}) can never succeed
runner.ex:116: Guard test is_map(_@4::{'Elixir.ExUnit.Runner.Config',_,_,_,integer(),_,_,_,_}) can never succeed
runner.ex:122: Guard test is_map(_@1::{'Elixir.ExUnit.Runner.Config',_,_,_,integer(),_,_,_,_}) can never succeed
runner.ex:123: Guard test is_map(_@2::{'Elixir.ExUnit.Runner.Config',_,_,_,integer(),_,_,_,_}) can never succeed
runner.ex:125: The created fun has no local return
runner.ex:176: Guard test is_map(_@1::{'Elixir.ExUnit.Runner.Config',_,_,_,integer(),_,_,_,_}) can never succeed
runner.ex:182: Guard test is_map(_@4::{'Elixir.ExUnit.Runner.Config',_,_,_,integer(),_,_,_,_}) can never succeed
runner.ex:194: Guard test is_map(_@1::{'Elixir.ExUnit.Test',_,_,_,_,_}) can never succeed
runner.ex:215: Guard test is_map(_@1::{'Elixir.ExUnit.Test',_,_,_,_,_}) can never succeed
runner.ex:223: Guard test is_map(_@2::{'Elixir.ExUnit.Test',_,_,_,_,_}) can never succeed
runner.ex:223: Guard test is_map(_@1::{'Elixir.ExUnit.Test',_,_,_,_,_}) can never succeed
runner.ex:231: Guard test is_map(_@1::{'Elixir.ExUnit.Test',_,_,_,_,_}) can never succeed
runner.ex:235: Guard test is_map(_@2::{'Elixir.ExUnit.Test',_,_,_,_,_}) can never succeed
runner.ex:254: Guard test is_map(_@1::{'Elixir.ExUnit.Runner.Config',_,_,_,_,_,_,_,_}) can never succeed
runner.ex:263: Guard test is_map(_@1::{'Elixir.ExUnit.Runner.Config',_,_,_,_,_,_,_,_}) can never succeed
file.ex:646: The call _@1:'mode'() requires that _@1 is of type atom() | tuple() not #{}
autocomplete.ex:209: Clause guard cannot succeed. The variable _@3 was matched against the type binary()
cli.ex:127: The created fun has no local return
evaluator.ex:163: Guard test is_map(_@1::atom() | tuple()) can never succeed
inspect.ex:226: Guard test is_map(_@1::{'Elixir.Inspect.Opts',_,_,_,_,_,_,_}) can never succeed
inspect.ex:282: Guard test is_map(_@4::{'Elixir.Inspect.Opts',_,_,_,_,_,_,_}) can never succeed
inspect.ex:284: Guard test is_map(_@3::{'Elixir.Inspect.Opts',_,_,_,_,_,_,_}) can never succeed
inspect.ex:317: Guard test is_map(_@1::{'Elixir.Inspect.Opts',_,_,_,_,_,_,_}) can never succeed
inspect.ex:320: Guard test is_map(_@3::{'Elixir.Inspect.Opts',_,_,_,_,_,_,_}) can never succeed
inspect.ex:332: Guard test is_map(_@4::{'Elixir.Inspect.Opts',_,_,_,_,_,_,_}) can never succeed
inspect.ex:351: Guard test is_map(_@1::{'Elixir.Inspect.Opts',_,_,_,_,_,_,_}) can never succeed
inspect.ex:426: Guard test is_map(_@2::atom()) can never succeed
algebra.ex:105: Function do_is_doc/1 will never be called
algebra.ex:120: Guard test is_map(_@1::tuple()) can never succeed
algebra.ex:127: Guard test is_map(_@5::tuple()) can never succeed
algebra.ex:127: Guard test is_map(_@4::atom() | tuple()) can never succeed
algebra.ex:136: Guard test is_map(_@1::tuple()) can never succeed
algebra.ex:143: Guard test is_map(_@5::tuple()) can never succeed
algebra.ex:143: Guard test is_map(_@4::atom() | tuple()) can never succeed
io.ex:248: Overloaded contract for 'Elixir.IO':getn/2 has overlapping domains; such contracts are currently unsupported and are simply ignored
kernel.ex:1740: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:1770: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:1789: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:1891: Guard test is_map(_@1::{'Elixir.Inspect.Opts',_,_,_,_,_,_,_}) can never succeed
kernel.ex:1892: Guard test is_map(_@2::{'Elixir.Inspect.Opts',_,_,_,_,_,_,_}) can never succeed
kernel.ex:2094: The pattern 'false' can never match the type 'true'
kernel.ex:2102: The pattern 'true' can never match the type 'false'
kernel.ex:2108: The pattern 'true' can never match the type 'false'
kernel.ex:2186: Guard test is_map(_@2::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:2186: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:2205: Guard test is_map(_@2::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:2205: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:2209: Guard test is_map(_@2::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:2209: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:2231: Guard test is_map(_@2::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:2231: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:2644: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:2655: Guard test is_map(_@3::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:2663: Guard test is_map(_@5::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:2663: Guard test is_map(_@4::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:2715: The pattern 'false' can never match the type 'true'
kernel.ex:2885: The pattern 'false' can never match the type 'true'
kernel.ex:2922: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:2926: Guard test is_map(_@3::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:2926: Guard test is_map(_@2::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:2926: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:2930: Guard test is_map(_@4::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:2936: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:3532: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:3913: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
kernel.ex:3914: The pattern 'false' can never match the type 'true'
cli.ex:37: Function run/1 has no local return
cli.ex:37: The call 'Elixir.Kernel.CLI':run(_@D0::any(),'true') will never return since it differs in the 2nd argument from the success typing arguments: (fun(() -> any()),'false' | 'nil')
cli.ex:88: Guard test is_map(_@1::atom() | tuple()) can never succeed
typespec.ex:769: The created fun has no local return
cli.ex:79: Guard test is_map(_@6::atom() | tuple()) can never succeed
dep.ex:166: The call _@1:'from'() requires that _@1 is of type atom() | tuple() not #{}
converger.ex:159: The call _@2:'deps'() requires that _@2 is of type atom() | tuple() not #{}
converger.ex:164: The call _@5:'deps'() requires that _@5 is of type atom() | tuple() not #{}
converger.ex:164: The call _@4:'deps'() requires that _@4 is of type atom() | tuple() not #{}
converger.ex:217: The call _@1:'status'() requires that _@1 is of type atom() | tuple() not #{}
converger.ex:219: The call _@3:'app'() requires that _@3 is of type atom() | tuple() not #{}
converger.ex:219: The call _@2:'requirement'() requires that _@2 is of type atom() | tuple() not #{}
loader.ex:46: The call _@1:'status'() requires that _@1 is of type atom() | tuple() not #{}
loader.ex:208: The call _@3:'app'() requires that _@3 is of type atom() | tuple() not #{}
loader.ex:236: The call _@1:'app'() requires that _@1 is of type atom() | tuple() not #{}
umbrella.ex:33: The call _@1:'deps'() requires that _@1 is of type atom() | tuple() not #{}
umbrella.ex:34: The call _@2:'app'() requires that _@2 is of type atom() | tuple() not #{}
project.ex:347: Guard test is_map(_@1::atom()) can never succeed
project_stack.ex:101: Guard test is_map(_@1::{'Elixir.Mix.ProjectStack.State',_,_,_}) can never succeed
project_stack.ex:129: Guard test is_map(_@1::{'Elixir.Mix.ProjectStack.Project',_,_,_,_,_,_}) can never succeed
project_stack.ex:139: Guard test is_map(_@1::{'Elixir.Mix.ProjectStack.Project',_,_,_,_,_,_}) can never succeed
project_stack.ex:148: Guard test is_map(_@1::{'Elixir.Mix.ProjectStack.Project',_,_,_,_,_,_}) can never succeed
compile.app.ex:85: Guard test is_map(_@7::atom() | tuple()) can never succeed
compile.elixir.ex:102: The created fun has no local return
compile.erlang.ex:188: The created fun has no local return
compile.erlang.ex:193: The created fun has no local return
compile.erlang.ex:206: The created fun has no local return
compile.erlang.ex:230: The created fun has no local return
compile.erlang.ex:267: Fun application will fail since _callback :: none() is not a function of arity 2
compile.ex:33: Clause guard cannot succeed. The variable _@3 was matched against the type binary()
compile.ex:82: Guard test is_map(_@2::atom() | tuple()) can never succeed
deps.compile.ex:101: The call _@1:'app'() requires that _@1 is of type atom() | tuple() not #{}
deps.ex:102: The call _@2:'opts'() requires that _@2 is of type atom() | tuple() not #{}
escriptize.ex:126: Clause guard cannot succeed. The variable _@1 was matched against the type [any()]
escriptize.ex:134: The call _@1:'mode'() requires that _@1 is of type atom() | tuple() not #{}
utils.ex:428: The call _@1:'scheme'() requires that _@1 is of type atom() | tuple() not #{}
module.ex:348: Guard test is_map(_@2::tuple()) can never succeed
module.ex:348: Guard test is_map(_@1::tuple()) can never succeed
module.ex:352: Guard test is_map(_@1::tuple()) can never succeed
module.ex:395: Guard test is_map(_@1::tuple()) can never succeed
locals_tracker.ex:147: Clause guard cannot succeed. The variable _@3 was matched against the type [any()]
locals_tracker.ex:264: The created fun has no local return
consolidation.ex:127: Function apply_to/2 has no local return
consolidation.ex:137: Function ensure_protocol/1 will never be called
consolidation.ex:152: Function beam_file/1 will never be called
consolidation.ex:161: Function change_debug_info/2 will never be called
consolidation.ex:168: Function change_impl_for/6 will never be called
consolidation.ex:190: The created fun has no local return
consolidation.ex:209: Function builtin_clause_for/4 will never be called
consolidation.ex:219: Function struct_clause_for/1 will never be called
consolidation.ex:233: Function each_struct_clause_for/3 will never be called
consolidation.ex:238: Function fallback_clause_for/3 will never be called
consolidation.ex:244: Function compile/1 will never be called
record.ex:60: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
record.ex:91: Guard test is_map(_@1::{'Elixir.Macro.Env',_,_,_,_,_,_,_,_,_,_,_,_,_,_,_}) can never succeed
deprecated.ex:269: The call 'Elixir.Record.Deprecated':find_index(values::atom() | binary() | fun() | pid() | number() | {atom() | binary() | fun() | pid() | [atom() | binary() | fun() | pid() | [any()] | number() | {_,_} | {_,_,_}] | number() | {atom() | binary() | fun() | pid() | [any()] | number() | {_,_} | {_,_,_},atom() | binary() | fun() | pid() | [any()] | number() | {_,_} | {_,_,_}} | {atom() | {_,_,_},[any()],atom() | [any()]},atom() | binary() | fun() | pid() | [atom() | binary() | fun() | pid() | [any()] | number() | {_,_} | {_,_,_}] | number() | {atom() | binary() | fun() | pid() | [any()] | number() | {_,_} | {_,_,_},atom() | binary() | fun() | pid() | [any()] | number() | {_,_} | {_,_,_}} | {atom() | {_,_,_},[any()],atom() | [any()]}} | {atom() | {_,_,_},[{_,_}],atom() | [any()]},k::any(),0) will never return since it differs in the 1st argument from the success typing arguments: (maybe_improper_list(),any(),non_neg_integer())
deprecated.ex:484: The created fun has no local return
string_io.ex:279: Function do_get_until/6 will never be called
system.ex:8: Function strip_re/2 will never be called
system.ex:12: Function read_stripped/1 will never be called
system.ex:194: The call _@2:'access'() requires that _@2 is of type atom() | tuple() not #{}
system.ex:194: The call _@1:'type'() requires that _@1 is of type atom() | tuple() not #{}
elixir.erl:24: The created fun has no local return
elixir.erl:26: The call io:setopts('standard_error',[{'unicode','true'},...]) breaks the contract (IoDevice,Opts) -> 'ok' | {'error',Reason} when is_subtype(IoDevice,device()), is_subtype(Opts,[setopt()]), is_subtype(Reason,term())
elixir_parser.erl:2914: Function yeccpars2_192/7 has no local return
elixir_parser.erl:4066: Function yeccpars2_305/7 has no local return
elixir_parser.erl:4098: Function yeccpars2_311/7 has no local return
elixir_parser.erl:4103: Function yeccpars2_312/7 has no local return
elixir_parser.erl:4288: Function yeccpars2_328/7 has no local return
elixir_parser.yrl:375: Function yeccpars2_192_/1 has no local return
elixir_parser.yrl:392: Function yeccpars2_305_/1 has no local return
elixir_parser.yrl:393: Function yeccpars2_311_/1 has no local return
elixir_parser.yrl:394: Function yeccpars2_312_/1 has no local return
elixir_parser.yrl:405: Function yeccpars2_318_/1 has no local return
elixir_parser.yrl:405: Function yeccpars2_328_/1 has no local return
elixir_parser.yrl:707: Function throw_no_parens_strict/1 has no local return
elixir_parser.yrl:712: Function throw_no_parens_many_strict/1 has no local return
```

This could use a comment in the code because its not documented/speced:

```
elixir.erl:26: The call io:setopts('standard_error',[{'unicode','true'},...]) breaks the contract (IoDevice,Opts) -> 'ok' | {'error',Reason} when is_subtype(IoDevice,device()), is_subtype(Opts,[setopt()]), is_subtype(Reason,term())
```

Confused about this one:

```
compile.erlang.ex:267: Fun application will fail since _callback :: none() is not a function of arity 2
```

There seems to be a few warnings with the `for` comprehensions, I think this is due to the way they are expanded but need to investigate:

```
compile.elixir.ex:102: The created fun has no local return
```

Can't find `String.Chars.t` but surely this is a subset of `char_data`:

```
io.ex:248: Overloaded contract for 'Elixir.IO':getn/2 has overlapping domains; such contracts are currently unsupported and are simply ignored
```

Unused private functions - once private macros have been evaluated - could be removed by compiler at some point?

```
system.ex:8: Function strip_re/2 will never be called
system.ex:12: Function read_stripped/1 will never be called
```
