### PR TITLE
Test git in dep folder to consider checked out

### DIFF
--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -36,7 +36,14 @@ defmodule Mix.SCM.Git do
   end
 
   def checked_out?(opts) do
-    File.dir?(Path.join(opts[:dest], ".git"))
+    if File.dir?(Path.join(opts[:dest], ".git")) do
+      File.cd! opts[:dest], fn ->
+        # Make sure git can read the dependency .git folder
+        opts[:dest] == String.strip System.cmd "git rev-parse --show-toplevel"
+      end
+    else
+      false
+    end
   end
 
   def lock_status(opts) do


### PR DESCRIPTION
If the .git folder of a dep becomes corrupted, any git command
issued by mix could find a parent .git folder and wipe the parent
tree.

This fix only consider a git dependency checked out if git is able
to read the .git folder.
