### PR TITLE
Format exceptions consistently

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -309,4 +309,86 @@ defmodule Application do
   def app_dir(app, path) when is_binary(path) do
     Path.join(app_dir(app), path)
   end
+
+  @doc """
+  Formats the error reason returned by `start/2`,
+  `ensure_started/2, `stop/1`, `load/1` and `unload/1`,
+  returns a string.
+  """
+  @spec format_reason(any) :: String.t
+  def format_reason(reason) do
+    try do
+      impl_format_reason(reason)
+    catch
+      # A user could create an error that looks like a builtin one
+      # causing an error.
+      :error, _ ->
+        inspect(reason)
+    end
+  end
+
+  # exit(:normal) call is special cased, undo the special case.
+  def impl_format_reason({{:EXIT, :normal}, {mod, :start, args}}) do
+    Exception.format_reason({:normal, {mod, :start, args}})
+  end
+
+  # {:error, reason} return value
+  def impl_format_reason({reason, {mod, :start, args}}) do
+    Exception.format_reason({reason, {mod, :start, args}})
+  end
+
+  # error or exit(reason) call, use exit reason as reason.
+  def impl_format_reason({:bad_return, {{mod, :start, args}, {:EXIT, reason}}}) do
+    Exception.format_reason({reason, {mod, :start, args}})
+  end
+
+  # bad return value
+  def impl_format_reason({:bad_return, {{mod, :start, args}, return}}) do
+    Exception.format_mfa(mod, :start, args) <> " had bad return: " <>
+      inspect(return)
+  end
+
+  def impl_format_reason({:already_started, app}) when is_atom(app) do
+    "already started application #{app}"
+  end
+
+  def impl_format_reason({:not_started, app}) when is_atom(app) do
+    "not started application #{app}"
+  end
+
+  def impl_format_reason({:bad_application, app}) do
+    "bad application: #{inspect(app)}"
+  end
+
+  def impl_format_reason({:already_loaded, app}) when is_atom(app) do
+    "already loaded application #{app}"
+  end
+
+  def impl_format_reason({:not_loaded, app}) when is_atom(app) do
+    "not loaded application #{app}"
+  end
+
+  def impl_format_reason({:invalid_restart_type, restart}) do
+    "invalid application restart type: #{inspect(restart)}"
+  end
+
+  def impl_format_reason({:invalid_name, name}) do
+    "invalid application name: #{inspect(name)}"
+  end
+
+  def impl_format_reason({:invalid_options, opts}) do
+    "invalid application name: #{inspect(opts)}"
+  end
+
+  def impl_format_reason({:badstartspec, spec}) do
+    "bad application start specs: #{inspect(spec)}"
+  end
+
+  def impl_format_reason({'no such file or directory', file}) do
+    "could not find application file: #{file}"
+  end
+
+  def impl_format_reason(reason) do
+    Exception.format_reason(reason)
+  end
 end

--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -208,7 +208,12 @@ defmodule IEx.Server do
 
   defp handle_take_over({:DOWN, evaluator_ref, :process, evaluator,  reason},
                         evaluator, evaluator_ref, input, _callback) do
-    io_error "** (EXIT from #{inspect evaluator}) #{inspect(reason)}"
+    try do
+      io_error "** (EXIT from #{inspect(evaluator)}) #{Exception.format_reason(reason)}"
+    catch
+      type, detail ->
+        io_error "** (IEx.Error) #{type} when printing EXIT message: #{inspect detail, records: false, structs: false}"
+    end
     kill_input(input)
     reset_loop([], evaluator, evaluator_ref)
   end
@@ -216,6 +221,7 @@ defmodule IEx.Server do
   defp handle_take_over(_, _evaluator, _evaluator_ref, _input, callback) do
     callback.()
   end
+
 
   defp kill_input(nil),   do: :ok
   defp kill_input(input), do: Process.exit(input, :kill)

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -113,6 +113,19 @@ defmodule IEx.InteractionTest do
   end
 
   test "receive exit" do
-    assert capture_iex("spawn_link(fn -> exit(:bye) end)") =~ ~r"EXIT from #PID"
+    assert capture_iex("spawn_link(fn -> exit(:bye) end)") =~ ~r"\*\* \(EXIT from #PID<\d+\.\d+\.\d+>\) :bye"
+    assert capture_iex("spawn_link(fn -> exit({:bye, [:world]}) end)") =~ ~r"\*\* \(EXIT from #PID<\d+\.\d+\.\d+>\) {:bye, \[:world\]}"
   end
+
+  test "receive exit from exception" do
+    # use exit/1 to fake an error so that an error message is not sent to the
+    # error logger.
+    assert capture_iex("spawn_link(fn -> exit({ArgumentError[],
+      [{:not_a_real_module, :function, 0, []}]}) end)") =~ ~r"\*\* \(EXIT from #PID<\d+\.\d+\.\d+>\) an exception was raised:\n\s{4}\*\* \(ArgumentError\) argument error\n\s{8}:not_a_real_module\.function/0"
+  end
+
+  test "exit due to failed call" do
+    assert capture_iex("exit({:bye, {:gen_server, :call, [self(), :hello]}})") =~ ~r"\*\* \(exit\) exited in: :gen_server\.call\(#PID<\d+\.\d+\.\d+>, :hello\)\n\s{4}\*\* \(EXIT\) :bye"
+  end
+
 end

--- a/lib/mix/lib/mix/tasks/app.start.ex
+++ b/lib/mix/lib/mix/tasks/app.start.ex
@@ -36,10 +36,9 @@ defmodule Mix.Tasks.App.Start do
     if app do
       case :application.ensure_all_started(app) do
         {:ok, _} -> :ok
-        {:error, {app, {:bad_return, _}}} ->
-          raise Mix.Error, message: "Could not start application #{app}, please see report above"
         {:error, {app, reason}} ->
-          raise Mix.Error, message: "Could not start application #{app}: #{inspect reason}"
+          raise Mix.Error, message: "Could not start application #{app}: " <>
+            Application.format_reason(reason)
       end
     else
       :error

--- a/lib/mix/lib/mix/tasks/escriptize.ex
+++ b/lib/mix/lib/mix/tasks/escriptize.ex
@@ -169,7 +169,7 @@ defmodule Mix.Tasks.Escriptize do
               args = Enum.map(args, &String.from_char_data!(&1))
               Kernel.CLI.run fn -> @module.main(args) end, true
             _   ->
-              IO.puts :stderr, IO.ANSI.escape("%{red, bright} Elixir is not in the code path, aborting.")
+              io_error "Elixir is not in the code path, aborting."
               System.halt(1)
           end
         end
@@ -181,10 +181,15 @@ defmodule Mix.Tasks.Escriptize do
         defp start_app(app) do
           case :application.ensure_all_started(app) do
             {:ok, _} -> :ok
-            {:error, reason} ->
-              IO.puts :stderr, IO.ANSI.escape("%{red, bright} Could not start application #{app}: #{inspect reason}.")
+            {:error, {app, reason}} ->
+              io_error "Could not start application #{app}: " <>
+                Application.format_reason(reason)
               System.halt(1)
           end
+        end
+
+        defp io_error(message) do
+           IO.puts :stderr, IO.ANSI.escape("%{red, bright} " <> message)
         end
       end
 


### PR DESCRIPTION
The first commit resolves #2231 and introduces `Exception.format_message` and `Exception.format` to format exceptions. It also fixes:
- A slight bug in the displaying of stacktraces in `IEx` when an entry has no application.
- Insures that exception messages and stacktrace are sent in one io request so that they always appears together.

The second commit is quite cheeky and could do the wrong thing in an edge case:

```
Interactive Elixir (0.13.2-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> spawn_link(fn() -> exit(:bye) end)                                                   
** (EXIT) #PID<0.49.0> exited: :bye

Interactive Elixir (0.13.2-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> spawn_link(fn() -> raise(ArgumentError, []) end)                                     
** (EXIT) #PID<0.55.0> exited: (ArgumentError) argument error
    :erlang.apply/2
```
