### PR TITLE
[WIP] Improve OTP behaviour error formatting

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -334,7 +334,8 @@ defmodule Application do
 
   # {:error, reason} return value
   defp impl_format_reason({reason, {mod, :start, args}}) do
-    Exception.format_exit({reason, {mod, :start, args}})
+    Exception.format_mfa(mod, :start, args) <> " returned an error: " <>
+      Exception.format_exit(reason)
   end
 
   # error or exit(reason) call, use exit reason as reason.
@@ -344,8 +345,8 @@ defmodule Application do
 
   # bad return value
   defp impl_format_reason({:bad_return, {{mod, :start, args}, return}}) do
-    Exception.format_mfa(mod, :start, args) <> " had bad return: " <>
-      inspect(return)
+    Exception.format_mfa(mod, :start, args) <>
+      " returned a bad value: " <> inspect(return)
   end
 
   defp impl_format_reason({:already_started, app}) when is_atom(app) do
@@ -377,7 +378,7 @@ defmodule Application do
   end
 
   defp impl_format_reason({:invalid_options, opts}) do
-    "invalid application name: #{inspect(opts)}"
+    "invalid application options: #{inspect(opts)}"
   end
 
   defp impl_format_reason({:badstartspec, spec}) do


### PR DESCRIPTION
More improvements are required to format application errors nicely. Master currently formats like this when a `:gen_server` down the tree fails to start due to error in `:init/1`. Note that `Ppp.Worker` is a child of `Ppp.Supervisor2`, `Ppp.Supervisor2` is a child of `Ppp.Supervisor`, and `Ppp.Supervisor.start_link/0` is called in the tail of `Ppp.start/2`:

```
** (Mix) Could not start application ppp: exited in: Ppp.start(:normal, [])
    ** (EXIT) shutdown: {:failed_to_start_child, Ppp.Supervisor2, {:shutdown, {:failed_to_start_child, Ppp.Worker, {:badarg, [{Ppp.Worker, :init, 1, [file: 'lib/ppp/supervisor.ex', line: 30]}, {:gen_server, :init_it, 6, [file: 'gen_server.erl', line: 306]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 239]}]}}}}
```

This change will format it like (you may need to scroll to the right to see that you can follow the errors down the supervision tree nicely):

```
** (Mix) Could not start application ppp: Ppp.start(:normal, []) returned an error: shutdown: failed to start child: Ppp.Supervisor2
    ** (EXIT) shutdown: failed to start child: Ppp.Worker
        ** (EXIT) an exception was raised:
            ** (ArgumentError) argument error
                (ppp) lib/ppp/supervisor.ex:30: Ppp.Worker.init/1
                (stdlib) gen_server.erl:306: :gen_server.init_it/6
                (stdlib) proc_lib.erl:239: :proc_lib.init_p_do_apply/3
```

The `:gen_server` reason formatting will also be useful for error loggers (e.g. `Logger`), and will also work for `:gen_fsm`'s used in erlang land.

```
** (Mix) Could not start application ppp: Ppp.start(:normal, []) returned an error: shutdown: failed to start child: Ppp.Supervisor2
    ** (EXIT) shutdown: failed to start child: Ppp.Worker
        ** (EXIT) bad return value: :oops
```

Are there any other OTP behaviour reasons we want to handle? 
Should also add a few tests before this is merged for the OTP behaviour (`:application`, `:supervisor` and `:gen_server`) exit formatting.
