### PR TITLE
Moved IEx.Config struct to separate file

### DIFF
--- a/lib/iex/lib/iex/config.ex
+++ b/lib/iex/lib/iex/config.ex
@@ -1,0 +1,4 @@
+defmodule IEx.Config do
+  @moduledoc false
+  defstruct binding: nil, cache: '', counter: 1, prefix: "iex", scope: nil, env: nil
+end

--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -1,8 +1,3 @@
-defmodule IEx.Config do
-  @moduledoc false
-  defstruct binding: nil, cache: '', counter: 1, prefix: "iex", scope: nil, env: nil
-end
-
 defmodule IEx.Server do
   @moduledoc false
 


### PR DESCRIPTION
I was getting a compilation error with the latest master (on a Mac with r17 installed via homebrew):

```
==> iex (compile)

== Compilation error on file lib/iex/evaluator.ex ==
** (CompileError) lib/iex/evaluator.ex:99: IEx.Config.__struct__/0 is undefined, cannot expand struct IEx.Config
    (elixir) src/elixir_map.erl:55: :elixir_map.translate_struct/4
    (stdlib) lists.erl:1352: :lists.mapfoldl/3
    (stdlib) lists.erl:1353: :lists.mapfoldl/3
    (elixir) src/elixir_clauses.erl:26: :elixir_clauses.match/3
    (elixir) src/elixir_clauses.erl:35: :elixir_clauses.clause/7
    (elixir) src/elixir_def.erl:182: :elixir_def.translate_clause/7
    (elixir) src/elixir.erl:157: :elixir.erl_eval/2

make: *** [lib/iex/ebin/Elixir.IEx.beam] Error 1
```

The `IEx.Config` struct was clearly defined in `server.ex`, but when compiling `evaluator.ex` it wasn't able to access it. Moving the `defstruct` to a separate file fixed the problem - though I wonder if it's indicative of a deeper problem with multiple module definitions within a file.
