### PR TITLE
Changed error message shown when escript_embed_elixir is incorrect

### DIFF
--- a/lib/mix/lib/mix/tasks/escriptize.ex
+++ b/lib/mix/lib/mix/tasks/escriptize.ex
@@ -77,7 +77,7 @@ defmodule Mix.Tasks.Escriptize do
         raise Mix.Error, message: "Could not generate escript, no name given, " <>
           "set :escript_name or :app in the project settings"
 
-      !main ->
+      !main or !Code.ensure_loaded?(main)->
         raise Mix.Error, message: "Could not generate escript, please set :escript_main_module " <>
           "in your project configuration to a module that implements main/1"
 


### PR DESCRIPTION
First attempt at a fix for #2232. This is my first Elixir contribution so I may be completely wrong :). I have two questions regarding this pull request:

1) I'm assuming that just changing the error message string is good enough to fix #2232. Is that assumption correct?

2) I've written a test which seems to work fine. However, the test is throwing `warning: redefining module :escripttest`. I'm going to investigate this further but if anyone can advise on writing a better test, that would be great!
