### PR TITLE
Print help when --help, -h, or /h are given on windows

### DIFF
--- a/bin/elixir.bat
+++ b/bin/elixir.bat
@@ -1,11 +1,14 @@
 @echo off
 set argc=0
-for %%x in (%*) do set /A argc+=1
-if  %argc%== 0 (
-  goto documentation
-) else (
-  goto parseopts
+for %%A in (%*) do (
+    if "%%A"=="--help" goto documentation
+    if "%%A"=="-h"     goto documentation
+    if "%%A"=="/h"     goto documentation
+    set /A argc+=1
 )
+if %argc%==0 goto documentation
+goto parseopts
+
 :documentation
 echo Usage: %~nx0 [options] [.exs file] [data]
 echo.

--- a/bin/elixirc.bat
+++ b/bin/elixirc.bat
@@ -1,11 +1,14 @@
 @echo off
 set argc=0
-for %%x in (%*) do set /A argc+=1
-if %argc% == 0 (
-  goto documentation
-) else (
-  goto run
+for %%A in (%*) do (
+    if "%%A"=="--help" goto documentation
+    if "%%A"=="-h"     goto documentation
+    if "%%A"=="/h"     goto documentation
+    set /A argc+=1
 )
+if %argc%==0 goto documentation
+goto run
+
 :documentation
 echo Usage: %~nx0 [elixir switches] [compiler switches] [.ex files]
 echo.


### PR DESCRIPTION
This will make sure that all the common help flags work properly on windows for iex, mix, elixirc, and elixir commands.
