### PR TITLE
Rename Application.format_reason/1 to format_error

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -323,10 +323,10 @@ defmodule Application do
   `ensure_started/2, `stop/1`, `load/1` and `unload/1`,
   returns a string.
   """
-  @spec format_reason(any) :: String.t
-  def format_reason(reason) do
+  @spec format_error(any) :: String.t
+  def format_error(reason) do
     try do
-      impl_format_reason(reason)
+      impl_format_error(reason)
     catch
       # A user could create an error that looks like a builtin one
       # causing an error.
@@ -336,68 +336,68 @@ defmodule Application do
   end
 
   # exit(:normal) call is special cased, undo the special case.
-  defp impl_format_reason({{:EXIT, :normal}, {mod, :start, args}}) do
+  defp impl_format_error({{:EXIT, :normal}, {mod, :start, args}}) do
     Exception.format_exit({:normal, {mod, :start, args}})
   end
 
   # {:error, reason} return value
-  defp impl_format_reason({reason, {mod, :start, args}}) do
+  defp impl_format_error({reason, {mod, :start, args}}) do
     Exception.format_mfa(mod, :start, args) <> " returned an error: " <>
       Exception.format_exit(reason)
   end
 
   # error or exit(reason) call, use exit reason as reason.
-  defp impl_format_reason({:bad_return, {{mod, :start, args}, {:EXIT, reason}}}) do
+  defp impl_format_error({:bad_return, {{mod, :start, args}, {:EXIT, reason}}}) do
     Exception.format_exit({reason, {mod, :start, args}})
   end
 
   # bad return value
-  defp impl_format_reason({:bad_return, {{mod, :start, args}, return}}) do
+  defp impl_format_error({:bad_return, {{mod, :start, args}, return}}) do
     Exception.format_mfa(mod, :start, args) <>
       " returned a bad value: " <> inspect(return)
   end
 
-  defp impl_format_reason({:already_started, app}) when is_atom(app) do
+  defp impl_format_error({:already_started, app}) when is_atom(app) do
     "already started application #{app}"
   end
 
-  defp impl_format_reason({:not_started, app}) when is_atom(app) do
+  defp impl_format_error({:not_started, app}) when is_atom(app) do
     "not started application #{app}"
   end
 
-  defp impl_format_reason({:bad_application, app}) do
+  defp impl_format_error({:bad_application, app}) do
     "bad application: #{inspect(app)}"
   end
 
-  defp impl_format_reason({:already_loaded, app}) when is_atom(app) do
+  defp impl_format_error({:already_loaded, app}) when is_atom(app) do
     "already loaded application #{app}"
   end
 
-  defp impl_format_reason({:not_loaded, app}) when is_atom(app) do
+  defp impl_format_error({:not_loaded, app}) when is_atom(app) do
     "not loaded application #{app}"
   end
 
-  defp impl_format_reason({:invalid_restart_type, restart}) do
+  defp impl_format_error({:invalid_restart_type, restart}) do
     "invalid application restart type: #{inspect(restart)}"
   end
 
-  defp impl_format_reason({:invalid_name, name}) do
+  defp impl_format_error({:invalid_name, name}) do
     "invalid application name: #{inspect(name)}"
   end
 
-  defp impl_format_reason({:invalid_options, opts}) do
+  defp impl_format_error({:invalid_options, opts}) do
     "invalid application options: #{inspect(opts)}"
   end
 
-  defp impl_format_reason({:badstartspec, spec}) do
+  defp impl_format_error({:badstartspec, spec}) do
     "bad application start specs: #{inspect(spec)}"
   end
 
-  defp impl_format_reason({'no such file or directory', file}) do
+  defp impl_format_error({'no such file or directory', file}) do
     "could not find application file: #{file}"
   end
 
-  defp impl_format_reason(reason) do
+  defp impl_format_error(reason) do
     Exception.format_exit(reason)
   end
 end

--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -281,7 +281,7 @@ defmodule Kernel.CLI do
     case Application.ensure_all_started(binary_to_atom(app)) do
       {:error, {app, reason}} ->
         {:error, "--app : Could not start application #{app}: " <>
-          Application.format_reason(reason)}
+          Application.format_error(reason)}
       {:ok, _} ->
         :ok
     end

--- a/lib/mix/lib/mix/tasks/app.start.ex
+++ b/lib/mix/lib/mix/tasks/app.start.ex
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.App.Start do
         {:ok, _} -> :ok
         {:error, {app, reason}} ->
           raise Mix.Error, message: "Could not start application #{app}: " <>
-            Application.format_reason(reason)
+            Application.format_error(reason)
       end
     else
       :error

--- a/lib/mix/lib/mix/tasks/escriptize.ex
+++ b/lib/mix/lib/mix/tasks/escriptize.ex
@@ -183,7 +183,7 @@ defmodule Mix.Tasks.Escriptize do
             {:ok, _} -> :ok
             {:error, {app, reason}} ->
               io_error "Could not start application #{app}: " <>
-                Application.format_reason(reason)
+                Application.format_error(reason)
               System.halt(1)
           end
         end


### PR DESCRIPTION
Makes the function name consistent with OTP modules, which all use `format_error` to format `reason` in `{:error, reason}`.

Examples:
- `:inet.format_error/1`
- `:file.format_error/1`
- `:ssl.format_error/1`

There are many more but they are all called `format_error/1`.
