### PR TITLE
Format EXIT signals consistently

### DIFF
--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -44,6 +44,8 @@ defmodule Kernel.ExceptionTest do
 
   test "normalize" do
     assert Exception.normalize(:throw, :badarg) == :badarg
+    assert Exception.normalize(:exit, :badarg) == :badarg
+    assert Exception.normalize(:EXIT, :badarg) == :badarg
     assert Record.record? Exception.normalize(:error, :badarg), ArgumentError
     assert Record.record? Exception.normalize(:error, ArgumentError[]), ArgumentError
   end
@@ -52,6 +54,7 @@ defmodule Kernel.ExceptionTest do
     assert Exception.format_banner(:error, :badarg) == "** (ArgumentError) argument error"
     assert Exception.format_banner(:throw, :badarg) == "** (throw) :badarg"
     assert Exception.format_banner(:exit, :badarg) == "** (exit) :badarg"
+    assert Exception.format_banner(:EXIT, :badarg) == "** (EXIT) :badarg"
   end
 
   test "format without stacktrace" do
@@ -62,6 +65,11 @@ defmodule Kernel.ExceptionTest do
 
   test "format with empty stacktrace" do
     assert Exception.format(:error, :badarg, []) == "** (ArgumentError) argument error"
+  end
+
+  test "format wih EXIT has no stacktrace" do
+    try do throw(:stack) catch :stack -> System.stacktrace() end
+    assert Exception.format(:EXIT, :badarg) == "** (EXIT) :badarg"
   end
 
   test "format_exit" do

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -223,7 +223,10 @@ defmodule ExUnit.Formatter do
   defp test_location(msg, nil),       do: "     " <> msg <> "\n"
   defp test_location(msg, formatter), do: test_location(formatter.(:location_info, msg), nil)
 
-  defp error_info(msg, nil),       do: "     " <> msg <> "\n"
+  defp error_info(msg, nil) do
+    "     " <> String.replace(msg, "\n", "\n     ") <> <<"\n">>
+  end
+
   defp error_info(msg, formatter), do: error_info(formatter.(:error_info, msg), nil)
 
   defp extra_info(msg, nil),       do: "     " <> msg <> "\n"

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -51,12 +51,31 @@ defmodule ExUnit.FormatterTest do
     """
   end
 
+  test "formats test exits with mfa" do
+    failure = {:exit, {:bye, {:m, :f, []}}, []}
+    assert format_test_failure(test(), failure, 1, 80, &formatter/2) == """
+      1) world (Hello)
+         test/ex_unit/formatter_test.exs:1
+         ** (exit) exited in: :m.f()
+             ** (EXIT) :bye
+    """
+  end
+
   test "formats test throws" do
     failure = {:throw, 1, []}
     assert format_test_failure(test(), failure, 1, 80, &formatter/2) == """
       1) world (Hello)
          test/ex_unit/formatter_test.exs:1
          ** (throw) 1
+    """
+  end
+
+  test "formats test EXITs" do
+    failure = {:EXIT, 1, []}
+    assert format_test_failure(test(), failure, 1, 80, &formatter/2) == """
+      1) world (Hello)
+         test/ex_unit/formatter_test.exs:1
+         ** (EXIT) 1
     """
   end
 

--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -209,7 +209,7 @@ defmodule IEx.Server do
   defp handle_take_over({:DOWN, evaluator_ref, :process, evaluator,  reason},
                         evaluator, evaluator_ref, input, _callback) do
     try do
-      io_error "** (EXIT from #{inspect(evaluator)}) #{Exception.format_exit(reason)}"
+      io_error Exception.format_banner(:EXIT, reason)
     catch
       type, detail ->
         io_error "** (IEx.Error) #{type} when printing EXIT message: #{inspect detail}"

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -163,9 +163,9 @@ defmodule IEx.InteractionTest do
 
   test "receive exit" do
     assert capture_iex("spawn_link(fn -> exit(:bye) end)") =~
-           ~r"\*\* \(EXIT from #PID<\d+\.\d+\.\d+>\) :bye"
+           ~r"\*\* \(EXIT\) :bye"
     assert capture_iex("spawn_link(fn -> exit({:bye, [:world]}) end)") =~
-           ~r"\*\* \(EXIT from #PID<\d+\.\d+\.\d+>\) {:bye, \[:world\]}"
+           ~r"\*\* \(EXIT\) {:bye, \[:world\]}"
   end
 
   test "receive exit from exception" do
@@ -173,7 +173,7 @@ defmodule IEx.InteractionTest do
     # is not sent to the error logger.
     content = capture_iex("spawn_link(fn -> exit({ArgumentError[],
                            [{:not_a_real_module, :function, 0, []}]}) end)")
-    assert content =~ ~r"\*\* \(EXIT from #PID<\d+\.\d+\.\d+>\) an exception was raised:\n"
+    assert content =~ ~r"\*\* \(EXIT\) an exception was raised:\n"
     assert content =~ ~r"\s{4}\*\* \(ArgumentError\) argument error\n"
     assert content =~ ~r"\s{8}:not_a_real_module\.function/0"
   end


### PR DESCRIPTION
Adds support for formatting an `:EXIT` reason using `Exception` functions:

```
** (EXIT) normal
```
