### PR TITLE
Allow mix to continue after updating Hex

### DIFF
--- a/lib/mix/lib/mix/tasks/local.hex.ex
+++ b/lib/mix/lib/mix/tasks/local.hex.ex
@@ -38,9 +38,11 @@ defmodule Mix.Tasks.Local.Hex do
       unless Version.match?(Hex.version, @hex_requirement) do
         Mix.shell.info "Mix requires hex #{@hex_requirement} but you have #{Hex.version}"
 
-        if Mix.shell.yes?("Shall I abort the current command and update hex?") do
-          run ["--force"]
-          exit(0)
+        if Mix.shell.yes?("Shall I update hex?") do
+          unless run ["--force"] do
+            Mix.shell.error "Hex update failed"
+            exit(-1)
+          end
         end
       end
     end


### PR DESCRIPTION
Instead of exiting after updating hex, allow the command to continue
(as long as the hex update succeeded).
