### PR TITLE
Add typespecs for builtins, __record__,  __struct__, exception

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3158,6 +3158,7 @@ defmodule Kernel do
           other -> raise ArgumentError, "struct field names must be atoms, got: #{inspect other}"
         end, fields)
 
+        @spec __struct__() :: t
         def __struct__() do
           %{unquote_splicing(Macro.escape(fields)), __struct__: __MODULE__}
         end
@@ -3274,6 +3275,7 @@ defmodule Kernel do
       @behaviour Exception
       fields = defstruct unquote(fields)
 
+      @spec exception([{atom, term}]) :: term
       def exception(args) when is_list(args) do
         Kernel.struct(__struct__, args)
       end

--- a/lib/elixir/lib/record/deprecated.ex
+++ b/lib/elixir/lib/record/deprecated.ex
@@ -166,6 +166,9 @@ defmodule Record.Deprecated do
 
   defmacro __before_compile__(_) do
     quote do
+      @spec __record__(atom) :: term
+      @spec __record__(atom, term) :: term
+      @spec __record__(atom, term, term) :: term
       def __record__(:optimizable), do: @record_optimizable
     end
   end

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -135,11 +135,11 @@ eval_form(Line, Module, Block, Vars, E) ->
 %% Return the form with exports and function declarations.
 
 functions_form(Line, File, Module, BaseAll, BaseExport, Def, Defmacro, BaseFunctions) ->
-  Info = add_info_function(Line, File, Module, BaseExport, Def, Defmacro),
+  {InfoSpec, Info} = add_info_function(Line, File, Module, BaseExport, Def, Defmacro),
 
   All       = [{'__info__', 1}|BaseAll],
   Export    = [{'__info__', 1}|BaseExport],
-  Functions = [Info|BaseFunctions],
+  Functions = [InfoSpec,Info|BaseFunctions],
 
   {All, [
     {attribute, Line, export, lists:sort(Export)} | Functions
@@ -312,14 +312,19 @@ add_info_function(Line, File, Module, Export, Def, Defmacro) ->
       elixir_errors:form_error(Line, File, ?MODULE, {internal_function_overridden, Pair});
     false ->
       Docs = elixir_compiler:get_opt(docs),
-      {function, 0, '__info__', 1, [
-        functions_clause(Def),
-        macros_clause(Defmacro),
-        docs_clause(Module, Docs),
-        moduledoc_clause(Line, Module, Docs),
-        module_clause(Module),
-        else_clause()
-      ]}
+      {
+        {attribute, Line, spec, {{'__info__', 1},
+          [{type, Line, 'fun', [{type, Line, product, [ {type, Line, atom, []}]}, {type, Line, term, []} ]}]
+        }},
+        {function, 0, '__info__', 1, [
+          functions_clause(Def),
+          macros_clause(Defmacro),
+          docs_clause(Module, Docs),
+          moduledoc_clause(Line, Module, Docs),
+          module_clause(Module),
+          else_clause()
+        ]}
+      }
   end.
 
 functions_clause(Def) ->

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -467,7 +467,8 @@ defmodule Kernel.TypespecTest do
     :code.delete(T)
     :code.purge(T)
 
-    assert [{{:a, _}, [{:type, _, :fun, [{:type, _, :product, []}, {:type, _, :any, []}]}]}] =
+    assert [{{:a, _}, [{:type, _, :fun, [{:type, _, :product, []}, {:type, _, :any, []}]}]},
+            {{:__info__, 1}, [{:type, _, :fun, [{:type, _, :product, [{:type, _, :atom, []}]}, {:type, _, :term, []}]}]}] =
            Kernel.Typespec.beam_specs(binary)
   end
 

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -244,7 +244,13 @@ defmodule IEx.Introspection do
     case beam_specs(module) do
       nil   -> nobeam(module)
       []    -> nospecs(inspect module)
-      specs -> for spec <- specs, do: print_spec(spec)
+      specs ->
+        printed = for {_kind, {{f, _arity}, _spec}} = spec <- specs, f != :"__info__" do
+          print_spec(spec)
+        end
+        if printed == [] do
+          nospecs(inspect module)
+        end
     end
 
     dont_display_result


### PR DESCRIPTION
I've been working with the erl compiler flag `warn_missing_spec`, and things get super noisy because a handful of builtin functions don't have typespecs. These specs aren't meant to be super useful, though they should be at least roughly accurate - they're mostly intended to silence the warnings and prevent dialyzer from complaining about their usages. If you'd like me to tighten up the specs, let me know which ones, and what specificity you'd like to see.

Good times learning about the deep underbelly of Elixir's compiler though :)

Added typespecs for:
- `__FILE__/1`
- `__MODULE__/1`
- `__info__/1`
- `__record__/1`, `__record__/2`, `__record__/3`
- `__struct__/0`
- `exception/1`, `exception/2`
