### PR TITLE
Properly handle atom keys in kw_list_to_string

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -510,7 +510,11 @@ defmodule Macro do
 
   defp kw_list_to_string(list, fun) do
     Enum.map_join(list, ", ", fn {key, value} ->
-      atom_to_binary(key) <> ": " <> to_string(value, fun)
+      atom_name = case Inspect.Atom.inspect(key) do
+        ":" <> rest -> rest
+        other       -> other
+      end
+      atom_name <> ": " <> to_string(value, fun)
     end)
   end
 

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -399,6 +399,7 @@ defmodule MacroTest do
   test :kw_list do
     assert Macro.to_string(quote do: [a: a, b: b]) == "[a: a, b: b]"
     assert Macro.to_string(quote do: [a: 1, b: 1 + 2]) == "[a: 1, b: 1 + 2]"
+    assert Macro.to_string(quote do: ["a.b": 1, c: 1 + 2]) == "[\"a.b\": 1, c: 1 + 2]"
   end
 
   test :string_list do


### PR DESCRIPTION
If you have a keyword list, with an atom key like `["foo.bar": "baz"]`, previously, Macro.to_string would render it as `"[foo.bar: \"baz\"]"`. This is incorrect, instead it should be `"[\"foo.bar\": \"baz\"]"`. This change fixes that.
