### PR TITLE
Properly pass command-line arguments to the app

### DIFF
--- a/lib/mix/lib/mix/tasks/run.ex
+++ b/lib/mix/lib/mix/tasks/run.ex
@@ -39,11 +39,14 @@ defmodule Mix.Tasks.Run do
     # Require the project to be available
     Mix.Project.get!
 
+    # Check if there is actually a file to run
+    run_file? = not match?({_, [], _}, OptionParser.parse_head(head))
+
     {file, argv} =
-      case {Keyword.has_key?(opts, :eval), head} do
-        {true, _}  -> {nil, head}
-        {_, [h|t]} -> {h, t}
-        {_, []}    -> {nil, []}
+      case {Keyword.has_key?(opts, :eval), run_file?, head} do
+        {true, _, _}      -> {nil, head}
+        {_, true, [h|t]}  -> {h, t}
+        {_, _, rest}      -> {nil, rest}
       end
 
     System.argv(argv)


### PR DESCRIPTION
This fixes the case when running with no file:

```
mix run --no-halt -- --opt val
```

However, it will interpret the first argument as a file name even after `--`:

```
mix run --no-halt -- file
#=> No such file: file
```

This is the case where `--` used to have overloaded meaning because of `mix run`'s argument handling. We might need to add an option to `OptionParser` that will preserve `--` in the argument list if we want to keep the previous behaviour.

/cc @josevalim @lexmag @ericmj

---

Not sure how to write tests for this. I want to start an app and get `System.argv` from it to verify it is correct.
