### PR TITLE
Mix.CLITest: explicitly declare environment variables (Windows-friendly)

### DIFF
--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -11,10 +11,16 @@ defmodule Mix.CLITest do
         def project, do: [app: :p, version: "0.1.0"]
       end
       """
-
-      output = System.cmd ~s(MIX_ENV=prod MIX_EXS=custom.exs #{elixir_executable} #{mix_executable}) <>
+      
+      System.put_env("MIX_ENV", "prod")
+      System.put_env("MIX_EXS", "custom.exs")
+      
+      output = System.cmd ~s(#{elixir_executable} #{mix_executable}) <>
                           ~s( run -e "IO.inspect {Mix.env, System.argv}" -- 1 2 3)
-
+      
+      System.delete_env("MIX_ENV")
+      System.delete_env("MIX_EXS")
+      
       assert output =~ ~s({:prod, ["1", "2", "3"]})
       assert output =~ "Compiled lib/a.ex"
     end


### PR DESCRIPTION
Bash shell commands happily allow prefixing environment variable assignments for temporary use (i.e. MY_ENV="my_value" my_command --my-args), but Windows shells don't support this.  So, we need to use System.put_env/2 and System.delete_env/1 to mimic this behavior (which should also work in bash.)
