### PR TITLE
Fix doc example for exception/1

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2970,8 +2970,8 @@ defmodule Kernel do
         defexception [:message]
 
         def exception(value) do
-          msg = "did not get what was expected, got: #{inspect opts[:actual]}"
-          %MyException%{message: msg}
+          msg = "did not get what was expected, got: #{inspect value}"
+          %MyAppError{message: msg}
         end
       end
 


### PR DESCRIPTION
- Use value instead of opts to generate message
- Remove extra %
- Use %MyAppError instead of %MyException 
