### PR TITLE
Draft implementation of custom inspect algorithm for regexes

### DIFF
--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -335,6 +335,8 @@ defmodule Inspect.OthersTest do
   end
 
   test :regex do
-    "~r\"foo\"m" = inspect(~r(foo)m)
+    "~r/foo/m" = inspect(~r(foo)m)
+    "~r/\\a\\010\\177\\033\\f\\n\\r \\t\\v\\//" = inspect(Regex.compile!("\a\b\d\e\f\n\r\s\t\v/"))
+    "~r/\\a\\b\\d\\e\\f\\n\\r\\s\\t\\v\\//" = inspect(~r<\a\b\d\e\f\n\r\s\t\v/>)
   end
 end

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -42,7 +42,34 @@ defmodule RegexTest do
   end
 
   test :source do
+    src = "foo"
+    assert Regex.source(Regex.compile!(src)) == src
+    assert Regex.source(~r/#{src}/) == src
+
+    src = "\a\b\d\e\f\n\r\s\t\v"
+    assert Regex.source(Regex.compile!(src)) == src
+    assert Regex.source(~r/#{src}/) == src
+
+    src = "\a\\b\\d\\e\f\n\r\\s\t\v"
+    assert Regex.source(Regex.compile!(src)) == src
+    assert Regex.source(~r/#{src}/) == src
+  end
+
+  test :literal_source do
     assert Regex.source(Regex.compile!("foo")) == "foo"
+    assert Regex.source(~r"foo") == "foo"
+    assert Regex.re_pattern(Regex.compile!("foo"))
+           == Regex.re_pattern(~r"foo")
+
+    assert Regex.source(Regex.compile!("\a\b\d\e\f\n\r\s\t\v")) == "\a\b\d\e\f\n\r\s\t\v"
+    assert Regex.source(~r<\a\b\d\e\f\n\r\s\t\v>) == "\a\\b\\d\\e\f\n\r\\s\t\v"
+    assert Regex.re_pattern(Regex.compile!("\a\b\d\e\f\n\r\s\t\v"))
+           == Regex.re_pattern(~r"\a\010\177\033\f\n\r \t\v")
+
+    assert Regex.source(Regex.compile!("\a\\b\\d\e\f\n\r\\s\t\v")) == "\a\\b\\d\e\f\n\r\\s\t\v"
+    assert Regex.source(~r<\a\\b\\d\\e\f\n\r\\s\t\v>) == "\a\\\\b\\\\d\\\\e\f\n\r\\\\s\t\v"
+    assert Regex.re_pattern(Regex.compile!("\a\\b\\d\e\f\n\r\\s\t\v"))
+           == Regex.re_pattern(~r"\a\b\d\e\f\n\r\s\t\v")
   end
 
   test :opts do


### PR DESCRIPTION
This is a sketch of my ideas for #2250.

Do we need it to be smarter? I.e., choose different delimiters based on the contents of the source.

```
iex(1)> ~r"\d+\n"
~r/\d+\n/

iex(2)> ~r"\d+/\n"
~r/\d+\/\n/

iex(3)> ~r"\a\d+/\n"
~r/\a\d+\/\n/

iex(4)> Regex.compile!("\a\\d+/\n")
~r/\a\d+\/\n/

iex(5)> Regex.compile!("\a\d+/\n") 
~r/\a\177+\/\n/

iex(6)> Regex.compile!("\a\x{fe34}+/\n")
~r/\a︴+\/\n/
```
