### PR TITLE
elixir.bat defers to mix for handling help options

### DIFF
--- a/bin/elixir.bat
+++ b/bin/elixir.bat
@@ -1,16 +1,9 @@
 @echo off
 
-rem Mix handles its own help options (as when called by mix.bat)
-if not "%1"=="%1:mix%" goto parseopts
-
-set argc=0
-for %%A in (%*) do (
-    if "%%A"=="--help" goto documentation
-    if "%%A"=="-h"     goto documentation
-    if "%%A"=="/h"     goto documentation
-    set /A argc+=1
-)
-if %argc%==0 goto documentation
+if "%*"==""       goto documentation
+if "%1"=="--help" goto documentation
+if "%1"=="-h"     goto documentation
+if "%1"=="/h"     goto documentation
 goto parseopts
 
 :documentation


### PR DESCRIPTION
On a Windows cmd, calling `mix --help` currently causes `elixir.bat` to interpret the `--help` argument as applying to elixir itself.  This ensures if mix is being called, then mix will handle arguments on its own.
