### PR TITLE
elixir.bat fixed to prevent eating quotes

### DIFF
--- a/bin/elixir.bat
+++ b/bin/elixir.bat
@@ -1,6 +1,5 @@
 @echo off
-
-if "%*"==""       goto documentation
+if "%1"==""       goto documentation
 if "%1"=="--help" goto documentation
 if "%1"=="-h"     goto documentation
 if "%1"=="/h"     goto documentation


### PR DESCRIPTION
The expression `"%*"==""` doesn't work if an argument contains quotes.  Work around this by using `%1` instead.
