### PR TITLE
Mix.Utils.symlink_or_copy always copies on Windows

### DIFF
--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -343,14 +343,13 @@ defmodule Mix.Utils do
   end
 
   defp do_symlink_or_copy(source, target) do
-    symlink_source = make_relative_path(source, target)
     if match? {:win32, _}, :os.type do
-      File.cp_r!(source, target)
-      :ok
+      {:ok, File.cp_r!(source, target)}
     else
+      symlink_source = make_relative_path(source, target)
       case :file.make_symlink(symlink_source, target) do
         :ok -> :ok
-        {:error, _} -> File.cp_r!(source, target)
+        {:error, _} -> {:ok, File.cp_r!(source, target)}
       end
     end
   end

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -67,9 +67,11 @@ defmodule Mix.UtilsTest do
   test :symlink_or_copy do
     in_fixture "archive", fn ->
       File.mkdir_p!("_build/archive")
-      assert Mix.Utils.symlink_or_copy(Path.expand("ebin"), Path.expand("_build/archive/ebin")) == :ok
-      unless match? {:win32, _}, :os.type do
-        assert :file.read_link("_build/archive/ebin") == {:ok, '../../ebin'}
+      result = Mix.Utils.symlink_or_copy(Path.expand("ebin"), Path.expand("_build/archive/ebin"))
+      case result do
+        {:ok, paths} -> assert Path.expand("_build/archive/ebin") in paths
+        :ok -> assert :file.read_link("_build/archive/ebin") == {:ok, '../../ebin'}
+        _ -> flunk "expected symlink_or_copy to return :ok or {:ok, list_of_paths}, got: #{inspect result}"
       end
     end
   end
@@ -77,9 +79,11 @@ defmodule Mix.UtilsTest do
   test :symlink_or_copy_removes_previous_directories do
     in_fixture "archive", fn ->
       File.mkdir_p!("_build/archive/ebin")
-      assert Mix.Utils.symlink_or_copy(Path.expand("ebin"), Path.expand("_build/archive/ebin")) == :ok
-      unless match? {:win32, _}, :os.type do
-        assert :file.read_link("_build/archive/ebin") == {:ok, '../../ebin'}
+      result = Mix.Utils.symlink_or_copy(Path.expand("ebin"), Path.expand("_build/archive/ebin"))
+      case result do
+        {:ok, paths} -> assert Path.expand("_build/archive/ebin") in paths
+        :ok -> assert :file.read_link("_build/archive/ebin") == {:ok, '../../ebin'}
+        _ -> flunk "expected symlink_or_copy to return :ok or {:ok, list_of_paths}, got: #{inspect result}"
       end
     end
   end
@@ -88,9 +92,11 @@ defmodule Mix.UtilsTest do
     in_fixture "archive", fn ->
       File.mkdir_p!("_build/archive")
       Mix.Utils.symlink_or_copy(Path.expand("priv"), Path.expand("_build/archive/ebin"))
-      Mix.Utils.symlink_or_copy(Path.expand("ebin"), Path.expand("_build/archive/ebin"))
-      unless match? {:win32, _}, :os.type do
-        assert :file.read_link("_build/archive/ebin") == {:ok, '../../ebin'}
+      result = Mix.Utils.symlink_or_copy(Path.expand("ebin"), Path.expand("_build/archive/ebin"))
+      case result do
+        {:ok, paths} -> assert Path.expand("_build/archive/ebin") in paths
+        :ok -> assert :file.read_link("_build/archive/ebin") == {:ok, '../../ebin'}
+        _ -> flunk "expected symlink_or_copy to return :ok or {:ok, list_of_paths}, got: #{inspect result}"
       end
     end
   end


### PR DESCRIPTION
This is a start to avoiding symlinking on WIndows; fixing this method alone brings the number of test failures down from 13 to 8.  There are other uses of symlinks that need to be handled, namely [Mix.Project.build_structure/2](https://github.com/elixir-lang/elixir/blob/master/lib/mix/lib/mix/project.ex#L306).
