### PR TITLE
Change Stream's struct to just %Stream{}

### DIFF
--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -579,7 +579,7 @@ defmodule StreamTest do
   end
 
   defp is_lazy(stream) do
-    match?(%Stream.Lazy{}, stream) or is_function(stream, 2)
+    match?(%Stream{}, stream) or is_function(stream, 2)
   end
 
   defp collectable_pdict do


### PR DESCRIPTION
I'm about to implement a `defimpl` specifically for Streams, and found it odd that the struct wasn't just called `%Stream{}`.
