### PR TITLE
Escape invalid characters in the docstring for String.chunk

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -767,7 +767,7 @@ defmodule String do
   def valid_character?(<<_ :: utf8>> = codepoint), do: valid?(codepoint)
   def valid_character?(_), do: false
 
-  @doc """
+  @doc ~S"""
   Splits the string into chunks of characters that share a common trait.
 
   The trait can be one of two options:


### PR DESCRIPTION
This cost me at least a couple of hours trying to feed the extracted docstrings to another tool :rage: :sob:
