### PR TITLE
add shell completion script to mix

### DIFF
--- a/lib/mix/lib/mix/tasks/help.ex
+++ b/lib/mix/lib/mix/tasks/help.ex
@@ -40,22 +40,27 @@ defmodule Mix.Tasks.Help do
     shell   = Mix.shell
     modules = Mix.Task.all_modules
 
-    docs = for module <- modules,
-        doc = Mix.Task.shortdoc(module) do
-      {"mix " <> Mix.Task.task_name(module), doc}
+    if completion_env? do
+      tasks = for module <- modules, do: Mix.Task.task_name(module)
+      shell.info Enum.join(Enum.sort(tasks), "\n")
+    else
+      docs = for module <- modules,
+          doc = Mix.Task.shortdoc(module) do
+        {"mix " <> Mix.Task.task_name(module), doc}
+      end
+
+      max = Enum.reduce docs, 0, fn({task, _}, acc) ->
+        max(size(task), acc)
+      end
+
+      display_default_task_doc(max)
+
+      Enum.each Enum.sort(docs), fn({task, doc}) ->
+        shell.info format_task(task, max, doc)
+      end
+
+      display_iex_task_doc(max)
     end
-
-    max = Enum.reduce docs, 0, fn({task, _}, acc) ->
-      max(size(task), acc)
-    end
-
-    display_default_task_doc(max)
-
-    Enum.each Enum.sort(docs), fn({task, doc}) ->
-      shell.info format_task(task, max, doc)
-    end
-
-    display_iex_task_doc(max)
   end
 
   def run([task]) do
@@ -108,6 +113,12 @@ defmodule Mix.Tasks.Help do
         |> Path.expand
         |> Path.relative_to_cwd
     end
+  end
+
+  defp completion_env? do
+    keys = ["COMP_CWORD", "COMP_LINE", "COMP_POINT"]
+    vals = Enum.map(keys, &(System.get_env(&1)))
+    Enum.all?(vals, &(!nil?(&1)))
   end
 
   defp display_default_task_doc(max) do

--- a/lib/mix/shell_completion
+++ b/lib/mix/shell_completion
@@ -1,0 +1,47 @@
+# shamelessly taken from npm-completion-
+# 
+
+COMP_WORDBREAKS=${COMP_WORDBREAKS/=/}
+COMP_WORDBREAKS=${COMP_WORDBREAKS/@/}
+export COMP_WORDBREAKS
+
+if type complete &>/dev/null; then
+  _mix_completion () {
+    local si="$IFS"
+    IFS=$'\n' COMPREPLY=($(COMP_CWORD="$COMP_CWORD" \
+                           COMP_LINE="$COMP_LINE" \
+                           COMP_POINT="$COMP_POINT" \
+                           mix help \
+                           2>/dev/null)) || return $?
+    IFS="$si"
+  }
+  complete -F _mix_completion mix
+elif type compdef &>/dev/null; then
+  _mix_completion() {
+    si=$IFS
+    compadd -- $(COMP_CWORD=$((CURRENT-1)) \
+                 COMP_LINE=$BUFFER \
+                 COMP_POINT=0 \
+                 mix help \
+                 2>/dev/null)
+    IFS=$si
+  }
+  compdef _mix_completion mix
+elif type compctl &>/dev/null; then
+  _mix_completion () {
+    local cword line point words si
+    read -Ac words
+    read -cn cword
+    let cword-=1
+    read -l line
+    read -ln point
+    si="$IFS"
+    IFS=$'\n' reply=($(COMP_CWORD="$cword" \
+                       COMP_LINE="$line" \
+                       COMP_POINT="$point" \
+                       mix help \
+                       2>/dev/null)) || return $?
+    IFS="$si"
+  }
+  compctl -K _mix_completion mix
+fi


### PR DESCRIPTION
To install in the current running shell, run

  $ . <path to elixir>/lib/mix/shell_completion

To install permanently, add the above command to your ~/.{bash,zsh}rc file
