### PR TITLE
Mix.Tasks.DepsGitTest: Write permissions for object database for Windows to clean

### DIFF
--- a/lib/mix/test/mix/tasks/deps.git_test.exs
+++ b/lib/mix/test/mix/tasks/deps.git_test.exs
@@ -171,6 +171,10 @@ defmodule Mix.Tasks.DepsGitTest do
       Mix.Tasks.Deps.Update.run ["git_repo"]
       assert File.exists?("deps/git_repo/lib/git_repo.ex")
       assert File.read!("mix.lock") =~ last
+    
+      if match? {:win32, _}, :os.type do
+        System.cmd("chmod -R u+w deps/git_repo/.git/objects")
+      end
 
       Mix.Tasks.Deps.Clean.run ["--all"]
       refute File.exists?("deps/git_repo/lib/git_repo.ex")


### PR DESCRIPTION
In `Mix.Tasks.DepsGitTest`, the "updates the lock when the repo updates" test would fail because:
1. The object database for Git repositories is read-only
2. Removing read-only files using `:file`'s functions returns `{:error, :eacces}`
3. `Mix.Tasks.Deps.Clean.run` would throw `File.Error` for these read-only files claiming "permission denied".

Issuing a `chmod` command on WIndows fixes this, but I don't know:
- why this only occurs on this one test,
- if there's a better method than issuing the `chmod` command, or
- whether it would be better to (a) modify `Mix.Tasks.Deps.Clean.run` to do this universally or (b) issue some git command that cleans its object database or make it writeable.

Hm... at least there's only one Mix test failure now! ("archive" in `Mix.Tasks.LocalTest`)
