### PR TITLE
Fix operator precedence bug in Mix.Compilers.Elixir.clean/1

### DIFF
--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -61,7 +61,7 @@ defmodule Mix.Compilers.Elixir do
       {:ok, contents} ->
         contents
         |> String.split("\n")
-        |> Enum.each(& &1 |> String.split("\t") |> hd |> File.rm)
+        |> Enum.each &(&1 |> String.split("\t") |> hd |> File.rm)
         File.rm(manifest)
       {:error, _} ->
         :ok


### PR DESCRIPTION
A wrong placement of a parentheses caused a operator precedence bug in Mix.Compilers.Elixir.clean/1
