### PR TITLE
:eaccess becomes :eacces

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -771,7 +771,7 @@ defmodule File do
     case F.delete(path) do
       :ok ->
         :ok
-      {:error, :eaccess} = e ->
+      {:error, :eacces} = e ->
         change_mode_windows(path) || e
       {:error, _} = e ->
         e


### PR DESCRIPTION
Why the POSIX people spelled it `eacces` with only one S is beyond me... :)
