### PR TITLE
Initial PowerShell script addressing mix commas

### DIFF
--- a/bin/mix.ps1
+++ b/bin/mix.ps1
@@ -1,0 +1,27 @@
+# Initialize with path to mix.bat relative to caller's working directory
+$toCmd = '' + (Resolve-Path -relative (Split-Path $MyInvocation.MyCommand.Path)) + '\mix.bat'
+
+foreach ($arg in $args)
+{
+  $toCmd += ' '
+  
+  if ($arg -is [array])
+  {
+    # Commas created the array so we need to reintroduce those commas
+    for ($i = 0; $i -lt $arg.length; $i++)
+    {
+      $toCmd += $arg[$i]
+      if ($i -ne ($arg.length - 1))
+      {
+        $toCmd += ', '
+      }
+    }
+  }
+  else
+  {
+    $toCmd += $arg
+  }
+}
+
+# Corrected arguments are ready to pass to batch file
+cmd /c $toCmd


### PR DESCRIPTION
This script simply preserves the intended formatting (comma placement) and calls the mix batch file.  PowerShell will call this script first if `mix` is given without an extension.  So doing things like `mix do deps.get, compile` functions as expected.  The next thing to fix is quoting, since quotes still get stripped.

Addresses [#2347](https://github.com/elixir-lang/elixir/issues/2347).
