### PR TITLE
Map pretty printer re-nesting

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -360,7 +360,9 @@ defimpl Inspect, for: Map do
 
   def inspect(map, name, opts) do
     map = :maps.to_list(map)
-    surround_many("%" <> name <> "{", map, "}", opts.limit, traverse_fun(map, opts))
+    left  = concat(["%", name, "{", "\n", " "])
+    right = concat(["\n", "}"])
+    surround_many(left, map, right, opts.limit, traverse_fun(map, opts))
   end
 
   defp traverse_fun(list, opts) do


### PR DESCRIPTION
A small interim fix for the issue discussed here elixir-lang/elixir#2165 . Ultimately the code may have to be rewritten not to rely upon `surround_many()`
