### PR TITLE
Make `URI.encode/1` to conform to RFC 3986. Introduce `URI.encode/2` function.

### DIFF
--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -5,7 +5,8 @@ defmodule URITest do
 
   test :encode do
     assert URI.encode("4_test.is-s~") == "4_test.is-s~"
-    assert URI.encode("\r\n&<%>\" ゆ") == "%0D%0A%26%3C%25%3E%22%20%E3%82%86"
+    assert URI.encode("\r\n&<%>\" ゆ", &URI.char_unreserved?/1) ==
+           "%0D%0A%26%3C%25%3E%22%20%E3%82%86"
   end
 
   test :encode_query do


### PR DESCRIPTION
- According to RFC 3986 the space character should be escaped as `%20`, not `+` (it is behaviour of  very early version of the URI percent-encoding rules).
- `URI.encode/2`
