### PR TITLE
Introduce `Enum.group_by/4` function

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1237,6 +1237,29 @@ defmodule Enum do
   end
 
   @doc """
+  Splits `collection` into groups based on `fun` invoking `fun_entry` for each entry.
+
+  The result is a dict (by default a map) where each key is
+  a group and each value is a list of elements from `collection`
+  for which `fun` returned that group. Ordering is not necessarily
+  preserved.
+
+  ## Examples
+
+      iex> Enum.group_by(~w{ant buffalo cat dingo}, %{}, &String.length/1, &String.capitalize/1)
+      %{3 => ["Cat", "Ant"], 5 => ["Dingo"], 7 => ["Buffalo"]}
+      iex> Enum.group_by([a: 1, b: 0, c: 4, d: 0, e: 1, f: 1], %{}, fn({_, v}) -> v end, fn({k, _}) -> to_string(k) end)
+      %{0 => ["d", "b"], 1 => ["f", "e", "a"], 4 => ["c"]}
+
+  """
+  @spec group_by(t, dict, (element -> any), (element -> any)) :: dict when dict: Dict.t
+  def group_by(collection, dict, fun, fun_entry) do
+    reduce(collection, dict, fn(entry, categories) ->
+      Dict.update(categories, fun.(entry), [fun_entry.(entry)], &[fun_entry.(entry)|&1])
+    end)
+  end
+
+  @doc """
   Invokes `fun` for each element in the collection passing that element and the
   accumulator `acc` as arguments. `fun`'s return value is stored in `acc`.
   Returns the accumulator.

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -182,6 +182,14 @@ defmodule EnumTest.List do
     result = Enum.group_by(1..6, %{3 => :default}, &rem(&1, 3))
     assert result[0] == [6, 3]
     assert result[3] == :default
+
+    assert Enum.group_by([a: 0, b: 1, c: 2, d: 0, e: 1, f: 4], %{}, fn {_, v} -> v end) ==
+           %{0 => [d: 0, a: 0], 1 => [e: 1, b: 1], 2 => [c: 2], 4 => [f: 4]}
+  end
+
+  test :group_by_4 do
+    assert Enum.group_by([a: 0, b: 1, c: 2, d: 0, e: 1, f: 4], %{}, fn({_, v}) -> v end, fn(x) -> elem(x,0) end) ==
+           %{0 => [:d, :a], 1 => [:e, :b], 2 => [:c], 4 => [:f]}
   end
 
   test :into do


### PR DESCRIPTION
I have an idea and it will be convenient for a lot of situations. Enum.group_by/4 acts like Enum.group_by/3, but it invokes additional function for each entry. I wrote two examples in the @doc section. Please check it out.
And I added tests not only about /4 but also /3. This aims to explain the differences between the two functions.
