### PR TITLE
Ensures Enum.slice always returns a list.

### DIFF
--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -426,11 +426,12 @@ defmodule EnumTest.List do
     assert Enum.slice([1,2,3,4,5], 1, 2) == [2, 3]
     assert Enum.slice([1,2,3,4,5], 1, 0) == []
     assert Enum.slice([1,2,3,4,5], 2, 5) == [3, 4, 5]
+    assert Enum.slice([1,2,3,4,5], 2, 6) == [3, 4, 5]
     assert Enum.slice([1,2,3,4,5], 5, 5) == []
-    assert Enum.slice([1,2,3,4,5], 6, 5) == nil
-    assert Enum.slice([1,2,3,4,5], 6, 0) == nil
-    assert Enum.slice([1,2,3,4,5], -6, 0) == nil
-    assert Enum.slice([1,2,3,4,5], -6, 5) == nil
+    assert Enum.slice([1,2,3,4,5], 6, 5) == []
+    assert Enum.slice([1,2,3,4,5], 6, 0) == []
+    assert Enum.slice([1,2,3,4,5], -6, 0) == []
+    assert Enum.slice([1,2,3,4,5], -6, 5) == []
     assert Enum.slice([1,2,3,4,5], -2, 5) == [4, 5]
     assert Enum.slice([1,2,3,4,5], -3, 1) == [3]
   end
@@ -440,18 +441,19 @@ defmodule EnumTest.List do
     assert Enum.slice([1,2,3,4,5], 0..1) == [1, 2]
     assert Enum.slice([1,2,3,4,5], 0..2) == [1, 2, 3]
     assert Enum.slice([1,2,3,4,5], 1..2) == [2, 3]
-    assert Enum.slice([1,2,3,4,5], 1..0) == nil
+    assert Enum.slice([1,2,3,4,5], 1..0) == []
     assert Enum.slice([1,2,3,4,5], 2..5) == [3, 4, 5]
+    assert Enum.slice([1,2,3,4,5], 2..6) == [3, 4, 5]
     assert Enum.slice([1,2,3,4,5], 4..4) == [5]
     assert Enum.slice([1,2,3,4,5], 5..5) == []
-    assert Enum.slice([1,2,3,4,5], 6..5) == nil
-    assert Enum.slice([1,2,3,4,5], 6..0) == nil
-    assert Enum.slice([1,2,3,4,5], -6..0) == nil
-    assert Enum.slice([1,2,3,4,5], -6..5) == nil
+    assert Enum.slice([1,2,3,4,5], 6..5) == []
+    assert Enum.slice([1,2,3,4,5], 6..0) == []
+    assert Enum.slice([1,2,3,4,5], -6..0) == []
+    assert Enum.slice([1,2,3,4,5], -6..5) == []
     assert Enum.slice([1,2,3,4,5], -5..-1) == [1, 2, 3, 4, 5]
     assert Enum.slice([1,2,3,4,5], -5..-3) == [1, 2, 3]
-    assert Enum.slice([1,2,3,4,5], -6..-1) == nil
-    assert Enum.slice([1,2,3,4,5], -6..-3) == nil
+    assert Enum.slice([1,2,3,4,5], -6..-1) == []
+    assert Enum.slice([1,2,3,4,5], -6..-3) == []
   end
 end
 
@@ -759,11 +761,12 @@ defmodule EnumTest.Range do
     assert Enum.slice(1..5, 1, 2) == [2, 3]
     assert Enum.slice(1..5, 1, 0) == []
     assert Enum.slice(1..5, 2, 5) == [3, 4, 5]
+    assert Enum.slice(1..5, 2, 6) == [3, 4, 5]
     assert Enum.slice(1..5, 5, 5) == []
-    assert Enum.slice(1..5, 6, 5) == nil
-    assert Enum.slice(1..5, 6, 0) == nil
-    assert Enum.slice(1..5, -6, 0) == nil
-    assert Enum.slice(1..5, -6, 5) == nil
+    assert Enum.slice(1..5, 6, 5) == []
+    assert Enum.slice(1..5, 6, 0) == []
+    assert Enum.slice(1..5, -6, 0) == []
+    assert Enum.slice(1..5, -6, 5) == []
     assert Enum.slice(1..5, -2, 5) == [4, 5]
     assert Enum.slice(1..5, -3, 1) == [3]
   end
@@ -773,18 +776,19 @@ defmodule EnumTest.Range do
     assert Enum.slice(1..5, 0..1) == [1, 2]
     assert Enum.slice(1..5, 0..2) == [1, 2, 3]
     assert Enum.slice(1..5, 1..2) == [2, 3]
-    assert Enum.slice(1..5, 1..0) == nil
+    assert Enum.slice(1..5, 1..0) == []
     assert Enum.slice(1..5, 2..5) == [3, 4, 5]
+    assert Enum.slice(1..5, 2..6) == [3, 4, 5]
     assert Enum.slice(1..5, 4..4) == [5]
     assert Enum.slice(1..5, 5..5) == []
-    assert Enum.slice(1..5, 6..5) == nil
-    assert Enum.slice(1..5, 6..0) == nil
-    assert Enum.slice(1..5, -6..0) == nil
-    assert Enum.slice(1..5, -6..5) == nil
+    assert Enum.slice(1..5, 6..5) == []
+    assert Enum.slice(1..5, 6..0) == []
+    assert Enum.slice(1..5, -6..0) == []
+    assert Enum.slice(1..5, -6..5) == []
     assert Enum.slice(1..5, -5..-1) == [1, 2, 3, 4, 5]
     assert Enum.slice(1..5, -5..-3) == [1, 2, 3]
-    assert Enum.slice(1..5, -6..-1) == nil
-    assert Enum.slice(1..5, -6..-3) == nil
+    assert Enum.slice(1..5, -6..-1) == []
+    assert Enum.slice(1..5, -6..-3) == []
   end
 
   test :sort do


### PR DESCRIPTION
Both Enum.slice/3 and Enum.slice/2 now will return empty lists for
impossible or out of bound ranges, rather than `nil`.

Fixes #2410.
