### PR TITLE
Add normalize dispatch for Windows volume letters

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -552,7 +552,7 @@ defmodule Path do
     normalize t, acc
   end
 
-  defp normalize([".."|t], [<<_letter, ?:, relative :: binary>>|_] = acc) when relative == "/" do
+  defp normalize([".."|t], [<<_letter, ?:, ?/>>|_] = acc) when _letter in ?a..?z do
     normalize t, acc
   end
 


### PR DESCRIPTION
This fixes things like `Path.expand("/..")` not working on WIndows; in `Path.normalize` this extra dispatch treats volume letters as roots.
