### PR TITLE
make manager calls nmake /F Makefile.win on Windows

### DIFF
--- a/lib/mix/lib/mix/dep/loader.ex
+++ b/lib/mix/lib/mix/dep/loader.ex
@@ -175,7 +175,7 @@ defmodule Mix.Dep.Loader do
   end
 
   defp make?(dest) do
-    File.regular? Path.join(dest, "Makefile")
+    (File.regular? Path.join(dest, "Makefile")) or (File.regular? Path.join(dest, "Makefile.win"))
   end
 
   defp invalid_dep_format(dep) do

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -14,7 +14,8 @@ defmodule Mix.Tasks.Deps.Compile do
 
     * `mix.exs`      - if so, invokes `mix compile`
     * `rebar.config` - if so, invokes `rebar compile`
-    * `Makefile`     - if so, invokes `make`
+    * `Makefile.win` - if so, invokes `nmake /F Makefile.win` (only on Windows)
+    * `Makefile`     - if so, invokes `make` (except on Windows)
 
   The compilation can be customized by passing a `compile` option
   in the dependency:
@@ -123,7 +124,11 @@ defmodule Mix.Tasks.Deps.Compile do
   end
 
   defp do_make(dep) do
-    do_command(dep, "make")
+    if match? {:win32, _}, :os.type do
+      do_command(dep, "nmake /F Makefile.win")
+    else
+      do_command(dep, "make")
+    end
   end
 
   defp do_compile(%Mix.Dep{app: app, opts: opts} = dep) do


### PR DESCRIPTION
Dependencies on Windows should compile with `nmake /F Makefile.win`.  So these commits set `:make` as the manager if either `Makefile` OR `Makefile.win` exist, then makes the platform-appropriate call.
