### PR TITLE
workaround 'epmd -daemon' not working on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ test_doc_test: compile
 
 test_stdlib: compile
 	@ echo "==> elixir (exunit)"
-	$(Q) epmd -daemon
+	$(Q) exec epmd & exit
 	$(Q) cd lib/elixir && ../../bin/elixir -r "test/elixir/test_helper.exs" -pr "test/elixir/**/*_test.exs";
 
 .dialyzer.base_plt:


### PR DESCRIPTION
On Windows `epmd -daemon` doesn't work as expected, so this dirty trick makes sure it stays running for the test.  Travis will let us know if this fix affects Unix or not.
