### PR TITLE
Range Literal syntax for BitStrings and CharLists

### DIFF
--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -143,6 +143,28 @@ defimpl Range.Iterator, for: BitString do
   end
 end
 
+defimpl Range.Iterator, for: List do
+  def next([first], _ .. [last]) when is_integer(last) do
+    if last >= first do
+      fn([x]) ->
+        [x + 1]
+      end
+    else
+      fn([x]) ->
+        [x - 1]
+      end
+    end
+  end
+
+  def count([first], _ .. [last]) when is_integer(last) do
+    if last >= first do
+      last - first + 1
+    else
+      first - last + 1
+    end
+  end
+end
+
 defimpl Inspect, for: Range do
   import Inspect.Algebra
 

--- a/lib/elixir/test/elixir/range_test.exs
+++ b/lib/elixir/test/elixir/range_test.exs
@@ -13,6 +13,8 @@ defmodule RangeTest do
     assert (1..3).last  == 3
     assert ("a".."z").first == "a"
     assert ("a".."z").last == "z"
+    assert ('a'..'z').first == 'a'
+    assert ('a'..'z').last == 'z'
   end
 
   test :range? do
@@ -34,12 +36,21 @@ defmodule RangeTest do
     refute Enum.member?("a".."z", "A")
     refute Enum.member?("a".."z", "é")
 
+    assert Enum.member?('a'..'z', 'd')
+    assert Enum.member?('z'..'a', 'x')
+    refute Enum.member?('a'..'z', 'A')
+    refute Enum.member?('a'..'z', 'é')
+
     assert Enum.count(1..3) == 3
     assert Enum.count(3..1) == 3
 
     assert Enum.count("a".."z") == 26
     assert Enum.count("A".."Z") == 26
     assert Enum.count("a".."é") == 137
+
+    assert Enum.count('a'..'z') == 26
+    assert Enum.count('A'..'Z') == 26
+    assert Enum.count('a'..'é') == 137
 
     assert Enum.map(1..3, &(&1 * 2)) == [2, 4, 6]
     assert Enum.map(3..1, &(&1 * 2)) == [6, 4, 2]


### PR DESCRIPTION
This is a first stab at being able to do `"a".."é"` and `'a'..'é'`.
