### PR TITLE
Ensure we can only use variables and `\\` as arguments of bodyless clause

### DIFF
--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -600,6 +600,17 @@ defmodule Kernel.ErrorsTest do
       '''
   end
 
+  test :invalid_args_for_bodyless_clause do
+    assert_compile_fail CompileError,
+      "nofile:2: can use only variables and \\\\ as arguments of bodyless clause",
+      '''
+      defmodule ErrorsTest do
+        def foo(arg // nil)
+        def foo(_), do: :ok
+      end
+      '''
+  end
+
   test :invalid_function_on_match do
     assert_compile_fail CompileError,
       "nofile:1: cannot invoke function something_that_does_not_exist/0 inside match",


### PR DESCRIPTION
closes #2374

I'm not sure this error message is proper.
