### PR TITLE
Raise on multiple clauses with default arg

### DIFF
--- a/lib/elixir/src/elixir_def_overridable.erl
+++ b/lib/elixir/src/elixir_def_overridable.erl
@@ -36,7 +36,7 @@ store(Module, Function, GenerateName) ->
     {_Count, _Clause, _Neighbours, true} -> ok;
     {Count, Clause, Neighbours, false} ->
       overridable(Module, orddict:store(Function, {Count, Clause, Neighbours, true}, Overridable)),
-      {{{Name, Arity}, Kind, Line, File, _Check, Location, Defaults}, Clauses} = Clause,
+      {{{Name, Arity}, Kind, Line, File, _Check, Location, {Defaults, _HasBody, _LastDefaults}}, Clauses} = Clause,
 
       {FinalKind, FinalName} = case GenerateName of
         true  -> {defp, name(Module, Function, Overridable)};

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -137,6 +137,19 @@ defmodule Kernel.ErrorsTest do
         def hello(arg \\ 1), do: nil
       end
       '''
+
+    assert_compile_fail CompileError,
+      "nofile:6: def hello/1 has default values and multiple clauses, " <>
+      "define a function head with the defaults",
+      ~C'''
+      defmodule ErrorsTest do
+        def bye(arg \\ 0)
+        def bye(arg), do: arg
+
+        def hello(arg \\ 0), do: nil
+        def hello(arg), do: arg
+      end
+      '''
   end
 
   test :invalid_match_pattern do


### PR DESCRIPTION
I decided to raise instead of warn because the resulting code is very confusing (arguably even wrong). From @josevalim's stackoverflow answer:

``` elixlir
def sum([], total \\ 0), do: total
# becomes
def sum(list), do: sum(list, 0)
```

Adding another element to the function definitions table was quite scary since it's a big a tuple used in many places. I may have missed a place if it was not tested, so please take a closer look. Maybe it's time to make it a map?

Closes #2078.
