### PR TITLE
Use absolute symbolic links on windows

### DIFF
--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -317,14 +317,16 @@ defmodule Mix.Utils do
   end
 
   defp do_symlink_or_copy(source, target) do
-    if match? {:win32, _}, :os.type do
-      {:ok, File.cp_r!(source, target)}
-    else
-      symlink_source = make_relative_path(source, target)
-      case :file.make_symlink(symlink_source, target) do
-        :ok -> :ok
-        {:error, _} -> {:ok, File.cp_r!(source, target)}
-      end
+   
+    # relative symbolic links on windows are broken
+    source_path = case :os.type do
+      {:win32, _} -> source
+      _ -> make_relative_path(source, target)
+    end
+    
+    case :file.make_symlink(source_path, target) do
+      :ok -> :ok
+      {:error, _} -> {:ok, File.cp_r!(source, target)}
     end
   end
 


### PR DESCRIPTION
This re-adds support for doing symlinks inside of _build instead of copying on Windows.  This helps greatly when dealing with static content inside of the "priv" directory.

The fundamental bug is that file:make_symlink() is creating a symbolic link for a file instead of a directory (they are different on Windows).  The Erlang code responsible for making the decision (file or directory) is only looking at the source path, which causes it to not find the correct source location (relative symbolic links in windows are relative to the the link, not to the current working directory).

This patch works around the issue by creating an absolute link (Windows only).  This causes the Erlang code to find the directory and make the correct type of link.
