### PR TITLE
Fix for batch file misbehaving with parenthetical arguments

### DIFF
--- a/bin/elixir.bat
+++ b/bin/elixir.bat
@@ -62,20 +62,20 @@ rem ******* EXECUTION OPTIONS **********************
 IF "%par%"==""+iex"" (Set useWerl=1)
 rem ******* elixir parameters **********************
 rem Note: we don't have to do anything with options that don't take an argument
-IF NOT "%par%"=="%par:-e=%"      (shift) 
-IF NOT "%par%"=="%par:-r=%"      (shift) 
-IF NOT "%par%"=="%par:-pr=%"     (shift) 
-IF NOT "%par%"=="%par:-pa=%"     (shift) 
-IF NOT "%par%"=="%par:-pz=%"     (shift) 
-IF NOT "%par%"=="%par:--app=%"   (shift) 
-IF NOT "%par%"=="%par:--remsh=%" (shift) 
+IF """"=="%par:-e=%"      (shift) 
+IF """"=="%par:-r=%"      (shift) 
+IF """"=="%par:-pr=%"     (shift) 
+IF """"=="%par:-pa=%"     (shift) 
+IF """"=="%par:-pz=%"     (shift) 
+IF """"=="%par:--app=%"   (shift) 
+IF """"=="%par:--remsh=%" (shift) 
 rem ******* ERLANG PARAMETERS **********************
-IF NOT "%par%"=="%par:--detached=%" (Set parsErlang=%parsErlang% -detached) 
-IF NOT "%par%"=="%par:--hidden=%"   (Set parsErlang=%parsErlang% -hidden)
-IF NOT "%par%"=="%par:--cookie=%"   (Set parsErlang=%parsErlang% -setcookie %1 && shift)
-IF NOT "%par%"=="%par:--sname=%"    (Set parsErlang=%parsErlang% -sname %1 && shift) 
-IF NOT "%par%"=="%par:--name=%"     (Set parsErlang=%parsErlang% -name %1 && shift) 
-IF NOT "%par%"=="%par:--erl=%"      (Set beforeExtra=%beforeExtra% %~1 && shift) 
+IF """"=="%par:--detached=%" (Set parsErlang=%parsErlang% -detached) 
+IF """"=="%par:--hidden=%"   (Set parsErlang=%parsErlang% -hidden)
+IF """"=="%par:--cookie=%"   (Set parsErlang=%parsErlang% -setcookie %1 && shift)
+IF """"=="%par:--sname=%"    (Set parsErlang=%parsErlang% -sname %1 && shift) 
+IF """"=="%par:--name=%"     (Set parsErlang=%parsErlang% -name %1 && shift) 
+IF """"=="%par:--erl=%"      (Set beforeExtra=%beforeExtra% %~1 && shift) 
 goto:startloop
 
 rem ******* assume all pre-params are parsed ********************


### PR DESCRIPTION
This fixes an issue where parentheses in arguments were interpreted by `cmd` as closing IF blocks.  In these commits, we have a kind of short-circuiting (for lack of a better term), by moving the simpler Elixir arguments first in the loop.  I've also changed the conditions to check against an empty string (that's what the hideous `""""` garbage is) rather than just check if the string changed.  This mainly avoids `--erl` being interpreted from `-e`, since `-e` is a substring of `--erl`.

It's basically witchcraft that I can't quite explain, but this does fix the test in question (Kernel.CLI.ErrorTest "properly format errors") and causes no other failures.
