### PR TITLE
Fix unmatched returns dialyzer warnings

### DIFF
--- a/lib/elixir/lib/file/stream.ex
+++ b/lib/elixir/lib/file/stream.ex
@@ -57,10 +57,14 @@ defmodule File.Stream do
             false -> IO.write(device, x)
           end
         :ok, :done ->
-          :file.close(device)
+          # If delayed_write option is used and the last write failed will
+          # MatchError here as {:error, _} is returned.
+          :ok = :file.close(device)
           stream
         :ok, :halt ->
-          :file.close(device)
+          # If delayed_write option is used and the last write failed will
+          # MatchError here as {:error, _} is returned.
+          :ok = :file.close(device)
       end
     end
   end

--- a/lib/elixir/lib/gen_event.ex
+++ b/lib/elixir/lib/gen_event.ex
@@ -397,7 +397,7 @@ defmodule GenEvent do
   def cancel_streams(%GenEvent{manager: manager, id: id}) do
     handlers = :gen_event.which_handlers(manager)
 
-    for {Enumerable.GenEvent, {handler_id, _}} = ref <- handlers,
+    _ = for {Enumerable.GenEvent, {handler_id, _}} = ref <- handlers,
         handler_id === id do
       :gen_event.delete_handler(manager, ref, :remove_handler)
     end

--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -363,7 +363,8 @@ defmodule Kernel.CLI do
   end
 
   defp process_command({:compile, patterns}, config) do
-    :filelib.ensure_dir(:filename.join(config.output, "."))
+    # If ensuring the dir returns an error no files will be found.
+    _ = :filelib.ensure_dir(:filename.join(config.output, "."))
 
     case filter_multiple_patterns(patterns) do
       {:ok, []} ->

--- a/lib/elixir/lib/kernel/error_handler.ex
+++ b/lib/elixir/lib/kernel/error_handler.ex
@@ -25,7 +25,7 @@ defmodule Kernel.ErrorHandler do
 
   defp ensure_loaded(module) do
     case Code.ensure_loaded(module) do
-      {:module, _} -> []
+      {:module, _} -> :ok
       {:error, _} ->
         parent = :erlang.get(:elixir_compiler_pid)
         ref    = :erlang.make_ref

--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -43,7 +43,7 @@ defmodule Kernel.ParallelCompiler do
   end
 
   defp spawn_compilers(files, path, callbacks) do
-    Code.ensure_loaded(Kernel.ErrorHandler)
+    true = Code.ensure_loaded?(Kernel.ErrorHandler)
     compiler_pid = self()
     :elixir_code_server.cast({:reset_warnings, compiler_pid})
     schedulers = max(:erlang.system_info(:schedulers_online), 2)
@@ -87,7 +87,7 @@ defmodule Kernel.ParallelCompiler do
         :erlang.process_flag(:error_handler, Kernel.ErrorHandler)
 
         exit(try do
-          if output do
+          _ = if output do
             :elixir_compiler.file_to_path(h, output)
           else
             :elixir_compiler.file(h)

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -940,7 +940,8 @@ defmodule Module do
   end
 
   defp normalize_attribute(:behaviour, atom) when is_atom(atom) do
-    Code.ensure_compiled(atom)
+    # Attempt to compile behaviour but ignore failure (will warn later)
+    _ = Code.ensure_compiled(atom)
     atom
   end
 

--- a/lib/elixir/lib/module/locals_tracker.ex
+++ b/lib/elixir/lib/module/locals_tracker.ex
@@ -277,12 +277,12 @@ defmodule Module.LocalsTracker do
   end
 
   def handle_cast({:add_local, from, to}, {d, _} = state) do
-    handle_add_local(d, from, to)
+    _ = handle_add_local(d, from, to)
     {:noreply, state}
   end
 
   def handle_cast({:add_import, function, module, {name, arity}}, {d, _} = state) do
-    handle_import(d, function, module, name, arity)
+    _ = handle_import(d, function, module, name, arity)
     {:noreply, state}
   end
 
@@ -292,7 +292,7 @@ defmodule Module.LocalsTracker do
   end
 
   def handle_cast({:add_defaults, kind, {name, arity}, defaults}, {d, _} = state) do
-    for i <- :lists.seq(arity - defaults, arity - 1) do
+    _ = for i <- :lists.seq(arity - defaults, arity - 1) do
       handle_add_definition(d, kind, {name, i})
       handle_add_local(d, {name, i}, {name, i + 1})
     end
@@ -302,12 +302,12 @@ defmodule Module.LocalsTracker do
   def handle_cast({:reattach, kind, tuple, {in_neigh, out_neigh}}, {d, _} = state) do
     handle_add_definition(d, kind, tuple)
 
-    for from <- in_neigh do
+    _ = for from <- in_neigh do
       :digraph.add_vertex(d, from)
       replace_edge!(d, from, tuple)
     end
 
-    for to <- out_neigh do
+    _ = for to <- out_neigh do
       :digraph.add_vertex(d, to)
       replace_edge!(d, tuple, to)
     end
@@ -336,7 +336,7 @@ defmodule Module.LocalsTracker do
 
     tuple = {:import, name, arity}
     :digraph.add_vertex(d, tuple)
-    replace_edge!(d, tuple, module)
+    _ = replace_edge!(d, tuple, module)
 
     if function != nil do
       replace_edge!(d, function, tuple)

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -428,7 +428,7 @@ defmodule Stream do
   """
   @spec run(Enumerable.t) :: :ok
   def run(stream) do
-    Enumerable.reduce(stream, {:cont, nil}, fn(_, _) -> {:cont, nil} end)
+    _ = Enumerable.reduce(stream, {:cont, nil}, fn(_, _) -> {:cont, nil} end)
     :ok
   end
 

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -28,8 +28,10 @@ start(_Type, _Args) ->
       error   -> [binary]
     end,
 
-  io:setopts(standard_io, Opts),
-  io:setopts(standard_error, [{unicode,true}]),
+  ok = io:setopts(standard_io, Opts),
+  %% Must use undocument {unicode, true} to set unicode on standard_error, more
+  %% info: http://erlang.org/pipermail/erlang-bugs/2014-April/004310.html
+  ok = io:setopts(standard_error, [{unicode,true}]),
   case file:native_name_encoding() of
     latin1 ->
       io:format(standard_error,
@@ -51,13 +53,13 @@ config_change(_Changed, _New, _Remove) ->
 %% escript entry point
 
 main(Args) ->
-  application:start(?MODULE),
+  ok = application:start(?MODULE),
   'Elixir.Kernel.CLI':main(Args).
 
 %% Boot and process given options. Invoked by Elixir's script.
 
 start_cli() ->
-  application:start(?MODULE),
+  ok = application:start(?MODULE),
   'Elixir.Kernel.CLI':main(init:get_plain_arguments()).
 
 %% EVAL HOOKS

--- a/lib/elixir/src/elixir_code_server.erl
+++ b/lib/elixir/src/elixir_code_server.erl
@@ -28,9 +28,9 @@ start_link() ->
   gen_server:start_link({local, ?MODULE}, ?MODULE, ok, []).
 
 init(ok) ->
-  code:ensure_loaded('Elixir.Macro.Env'),
-  code:ensure_loaded('Elixir.Module.LocalsTracker'),
-  code:ensure_loaded('Elixir.Kernel.LexicalTracker'),
+  _ = code:ensure_loaded('Elixir.Macro.Env'),
+  _ = code:ensure_loaded('Elixir.Module.LocalsTracker'),
+  _ = code:ensure_loaded('Elixir.Kernel.LexicalTracker'),
   {ok, #elixir_code_server{}}.
 
 handle_call({acquire, Path}, From, Config) ->
@@ -120,7 +120,7 @@ handle_cast({loaded, Path}, Config) ->
     {ok, true} ->
       {noreply, Config};
     {ok, {Ref, List}} when is_list(List), is_reference(Ref) ->
-      [Pid ! {elixir_code_server, Ref, loaded} || {Pid, _Tag} <- lists:reverse(List)],
+      _ = [Pid ! {elixir_code_server, Ref, loaded} || {Pid, _Tag} <- lists:reverse(List)],
       Done = orddict:store(Path, true, Current),
       {noreply, Config#elixir_code_server{loaded=Done}};
     error ->

--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -40,7 +40,7 @@ file(Relative) when is_binary(Relative) ->
 
 file_to_path(File, Path) when is_binary(File), is_binary(Path) ->
   Lists = file(File),
-  [binary_to_path(X, Path) || X <- Lists],
+  _ = [binary_to_path(X, Path) || X <- Lists],
   Lists.
 
 %% Evaluation
@@ -144,7 +144,7 @@ module(Forms, File, Options, Bootstrap, Callback) when
   case compile:noenv_forms([no_auto_import()|Forms], [return,{source,Listname}|Options]) of
     {ok, ModuleName, Binary, Warnings} ->
       format_warnings(Bootstrap, Warnings),
-      code:load_binary(ModuleName, Listname, Binary),
+      {module, ModuleName} = code:load_binary(ModuleName, Listname, Binary),
       Callback(ModuleName, Binary);
     {error, Errors, Warnings} ->
       format_warnings(Bootstrap, Warnings),
@@ -157,14 +157,14 @@ no_auto_import() ->
 %% CORE HANDLING
 
 core() ->
-  application:start(elixir),
+  ok = application:start(elixir),
   elixir_code_server:cast({compiler_options, [{docs,false},{internal,true}]}),
   [core_file(File) || File <- core_main()].
 
 core_file(File) ->
   try
     Lists = file(File),
-    [binary_to_path(X, "lib/elixir/ebin") || X <- Lists],
+    _ = [binary_to_path(X, "lib/elixir/ebin") || X <- Lists],
     io:format("Compiled ~ts~n", [File])
   catch
     Kind:Reason ->

--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -83,13 +83,13 @@ store_definition(Line, Kind, CheckClauses, Name, Args, Guards, Body, MetaFile, #
   Arity = length(Args),
   Tuple = {Name, Arity},
   E = ER#{function := Tuple},
-  elixir_locals:record_definition(Tuple, Kind, Module),
+  _ = elixir_locals:record_definition(Tuple, Kind, Module),
 
   Location = retrieve_location(Line, MetaFile, Module),
   {Function, Defaults, Super} = translate_definition(Kind, Line, Module, Name, Args, Guards, Body, E),
 
   DefaultsLength = length(Defaults),
-  elixir_locals:record_defaults(Tuple, Kind, Module, DefaultsLength),
+  _ = elixir_locals:record_defaults(Tuple, Kind, Module, DefaultsLength),
 
   File   = ?m(E, file),
   Table  = table(Module),
@@ -115,13 +115,16 @@ run_on_definition_callbacks(Kind, Line, Module, Name, Args, Guards, Expr, E) ->
     _ ->
       Env = elixir_env:linify({Line, E}),
       Callbacks = 'Elixir.Module':get_attribute(Module, on_definition),
-      [Mod:Fun(Env, Kind, Name, Args, Guards, Expr) || {Mod, Fun} <- Callbacks]
+      _ = [Mod:Fun(Env, Kind, Name, Args, Guards, Expr) || {Mod, Fun} <- Callbacks],
+      ok
   end.
 
 make_struct_available(def, Module, '__struct__', []) ->
   case erlang:get(elixir_compiler_pid) of
     undefined -> ok;
-    Pid -> Pid ! {struct_available, Module}
+    Pid ->
+      Pid ! {struct_available, Module},
+      ok
   end;
 make_struct_available(_, _, _, _) ->
   ok.
@@ -304,7 +307,8 @@ warn_bodyless_function(_Line, _File, Special, _Kind, _Tuple)
     when Special == 'Elixir.Kernel.SpecialForms'; Special == 'Elixir.Module' ->
   ok;
 warn_bodyless_function(Line, File, _Module, Kind, Tuple) ->
-  elixir_errors:handle_file_warning(File, {Line, ?MODULE, {bodyless_fun, Kind, Tuple}}).
+  _ = elixir_errors:handle_file_warning(File, {Line, ?MODULE, {bodyless_fun, Kind, Tuple}}),
+  ok.
 
 %% Store each definition in the table.
 %% This function also checks and emit warnings in case

--- a/lib/elixir/src/elixir_def_overridable.erl
+++ b/lib/elixir/src/elixir_def_overridable.erl
@@ -58,8 +58,9 @@ store(Module, Function, GenerateName) ->
 %% Store pending declarations that were not manually made concrete.
 
 store_pending(Module) ->
-  [store(Module, X, false) || {X, {_, _, _, false}} <- overridable(Module),
-    not 'Elixir.Module':'defines?'(Module, X)].
+  _ = [store(Module, X, false) || {X, {_, _, _, false}} <- overridable(Module),
+    not 'Elixir.Module':'defines?'(Module, X)],
+  ok.
 
 %% Error handling
 

--- a/lib/elixir/src/elixir_dispatch.erl
+++ b/lib/elixir/src/elixir_dispatch.erl
@@ -37,11 +37,11 @@ find_import(Meta, Name, Arity, E) ->
   case find_dispatch(Meta, Tuple, [], E) of
     {function, Receiver} ->
       elixir_lexical:record_import(Receiver, ?m(E, lexical_tracker)),
-      elixir_locals:record_import(Tuple, Receiver, ?m(E, module), ?m(E, function)),
+      _ = elixir_locals:record_import(Tuple, Receiver, ?m(E, module), ?m(E, function)),
       Receiver;
     {macro, Receiver} ->
       elixir_lexical:record_import(Receiver, ?m(E, lexical_tracker)),
-      elixir_locals:record_import(Tuple, Receiver, ?m(E, module), ?m(E, function)),
+      _ = elixir_locals:record_import(Tuple, Receiver, ?m(E, module), ?m(E, function)),
       Receiver;
     _ ->
       false
@@ -54,7 +54,7 @@ import_function(Meta, Name, Arity, E) ->
   case find_dispatch(Meta, Tuple, [], E) of
     {function, Receiver} ->
       elixir_lexical:record_import(Receiver, ?m(E, lexical_tracker)),
-      elixir_locals:record_import(Tuple, Receiver, ?m(E, module), ?m(E, function)),
+      _ = elixir_locals:record_import(Tuple, Receiver, ?m(E, module), ?m(E, function)),
       remote_function(Meta, Receiver, Name, Arity, E);
     {macro, _Receiver} ->
       false;
@@ -64,7 +64,7 @@ import_function(Meta, Name, Arity, E) ->
       case elixir_import:special_form(Name, Arity) of
         true  -> false;
         false ->
-          elixir_locals:record_local(Tuple, ?m(E, module), ?m(E, function)),
+          _ = elixir_locals:record_local(Tuple, ?m(E, module), ?m(E, function)),
           {local, Name, Arity}
       end
   end.
@@ -139,7 +139,7 @@ expand_import(Meta, {Name, Arity} = Tuple, Args, E, Extra) ->
 
     %% Dispatch to the local.
     _ ->
-      elixir_locals:record_local(Tuple, Module, Function),
+      _ = elixir_locals:record_local(Tuple, Module, Function),
       {ok, Module, expand_macro_fun(Meta, Local(), Module, Name, Args, E)}
   end.
 
@@ -147,7 +147,7 @@ do_expand_import(Meta, {Name, Arity} = Tuple, Args, Module, E, Result) ->
   case Result of
     {function, Receiver} ->
       elixir_lexical:record_import(Receiver, ?m(E, lexical_tracker)),
-      elixir_locals:record_import(Tuple, Receiver, Module, ?m(E, function)),
+      _ = elixir_locals:record_import(Tuple, Receiver, Module, ?m(E, function)),
 
       case rewrite(Receiver, Name, Args, Arity) of
         {ok, _, _, _} = Res -> Res;
@@ -156,7 +156,7 @@ do_expand_import(Meta, {Name, Arity} = Tuple, Args, Module, E, Result) ->
     {macro, Receiver} ->
       check_deprecation(Meta, Receiver, Name, Arity, E),
       elixir_lexical:record_import(Receiver, ?m(E, lexical_tracker)),
-      elixir_locals:record_import(Tuple, Receiver, Module, ?m(E, function)),
+      _ = elixir_locals:record_import(Tuple, Receiver, Module, ?m(E, function)),
       {ok, Receiver, expand_macro_named(Meta, Receiver, Name, Arity, Args, E)};
     {import, Receiver} ->
       case expand_require([{require,false}|Meta], Receiver, Tuple, Args, E) of

--- a/lib/elixir/src/elixir_exp.erl
+++ b/lib/elixir/src/elixir_exp.erl
@@ -452,7 +452,7 @@ expand_local(Meta, Name, Args, #{local := nil, function := nil} = E) ->
   {EArgs, EA} = expand_args(Args, E),
   {{Name, Meta, EArgs}, EA};
 expand_local(Meta, Name, Args, #{local := nil, module := Module, function := Function} = E) ->
-  elixir_locals:record_local({Name, length(Args)}, Module, Function),
+  _ = elixir_locals:record_local({Name, length(Args)}, Module, Function),
   {EArgs, EA} = expand_args(Args, E),
   {{Name, Meta, EArgs}, EA};
 expand_local(Meta, Name, Args, E) ->

--- a/lib/elixir/src/elixir_lexical.erl
+++ b/lib/elixir/src/elixir_lexical.erl
@@ -64,14 +64,16 @@ if_tracker(Pid, Callback) when is_pid(Pid) -> Callback(Pid).
 %% ERROR HANDLING
 
 warn_unused_imports(File, Pid) ->
-  [ begin
+  _ = [ begin
       elixir_errors:handle_file_warning(File, {L, ?MODULE, {unused_import, M}})
-    end || {M, L} <- ?tracker:collect_unused_imports(Pid)].
+    end || {M, L} <- ?tracker:collect_unused_imports(Pid)],
+  ok.
 
 warn_unused_aliases(File, Pid) ->
-  [ begin
+  _ = [ begin
       elixir_errors:handle_file_warning(File, {L, ?MODULE, {unused_alias, M}})
-    end || {M, L} <- ?tracker:collect_unused_aliases(Pid)].
+    end || {M, L} <- ?tracker:collect_unused_aliases(Pid)],
+  ok.
 
 format_error({unused_alias, Module}) ->
   io_lib:format("unused alias ~ts", [elixir_aliases:inspect(Module)]);

--- a/lib/elixir/src/elixir_locals.erl
+++ b/lib/elixir/src/elixir_locals.erl
@@ -146,7 +146,7 @@ get_cached_env(Env) -> Env.
 ensure_no_import_conflict(_Line, _File, 'Elixir.Kernel', _All) ->
   ok;
 ensure_no_import_conflict(Line, File, Module, All) ->
-  if_tracker(Module, fun(Pid) ->
+  _ = if_tracker(Module, fun(Pid) ->
     [ begin
         elixir_errors:form_error(Line, File, ?MODULE, {function_conflict, Error})
       end || Error <- ?tracker:collect_imports_conflicts(Pid, All) ]
@@ -160,7 +160,7 @@ warn_unused_local(File, Module, Private) ->
 
     {Unreachable, Warnings} = ?tracker:collect_unused_locals(Pid, Args),
 
-    [ begin
+    _ = [ begin
         {_, _, Line, _, _} = lists:keyfind(element(2, Error), 1, Private),
         elixir_errors:handle_file_warning(File, {Line, ?MODULE, Error})
       end || Error <- Warnings ],

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -132,8 +132,7 @@ defmodule ExUnit do
   If you want to run tests manually, you can set `:autorun` to `false`.
   """
   def start(options \\ []) do
-    Application.start(:elixir)
-    Application.start(:ex_unit)
+    {:ok, _} = Application.ensure_all_started(:ex_unit)
 
     configure(options)
 

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -255,7 +255,7 @@ defmodule ExUnit.Runner do
   end
 
   defp shuffle(%{seed: seed}, list) do
-    :random.seed(3172, 9814, seed)
+    _ = :random.seed(3172, 9814, seed)
     Enum.shuffle(list)
   end
 

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -186,7 +186,7 @@ defmodule IEx.Introspection do
   Print types in module.
   """
   def t(module) when is_atom(module) do
-    case Kernel.Typespec.beam_types(module) do
+    _ = case Kernel.Typespec.beam_types(module) do
       nil   -> nobeam(module)
       []    -> notypes(inspect module)
       types -> for type <- types, do: print_type(type)

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -15,8 +15,8 @@ defmodule Mix do
 
   @doc false
   def start do
-    Application.start(:elixir)
-    Application.start(:mix)
+    {:ok, _} = Application.ensure_all_started(:mix)
+    :ok
   end
 
   @doc false

--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -19,7 +19,7 @@ defmodule Mix.CLI do
   end
 
   defp proceed(args) do
-    Mix.Tasks.Local.Hex.maybe_update()
+    _ = Mix.Tasks.Local.Hex.ensure_updated?()
     load_dot_config()
     args = load_mixfile(args)
     {task, args} = get_task(args)
@@ -29,7 +29,7 @@ defmodule Mix.CLI do
 
   defp load_mixfile(args) do
     file = System.get_env("MIX_EXS") || "mix.exs"
-    if File.regular?(file) do
+    _ = if File.regular?(file) do
       Code.load_file(file)
     end
     args

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -80,7 +80,7 @@ defmodule Mix.Compilers.Elixir do
     end)
 
     try do
-      Kernel.ParallelCompiler.files :lists.usort(stale),
+      _ = Kernel.ParallelCompiler.files :lists.usort(stale),
         each_module: &each_module(pid, dest, cwd, &1, &2, &3),
         each_file: &each_file(&1)
       Agent.cast pid, fn entries ->
@@ -140,7 +140,7 @@ defmodule Mix.Compilers.Elixir do
 
   defp remove_stale_entries([{beam, module, source, _d, _f} = entry|t], changed, removed, acc) do
     if source in changed do
-      File.rm(beam)
+      File.rm!(beam)
       remove_stale_entries(t, changed, [module|removed], acc)
     else
       remove_stale_entries(t, changed, removed, [entry|acc])

--- a/lib/mix/lib/mix/dep/fetcher.ex
+++ b/lib/mix/lib/mix/dep/fetcher.ex
@@ -27,7 +27,7 @@ defmodule Mix.Dep.Fetcher do
     {apps, deps} = do_finalize(result, old_lock, opts)
 
     # Check if all given dependencies are loaded or fail
-    Mix.Dep.loaded_by_name(names, deps, opts)
+    _ = Mix.Dep.loaded_by_name(names, deps, opts)
     apps
   end
 
@@ -117,9 +117,10 @@ defmodule Mix.Dep.Fetcher do
     # file to it. Each build, regardless of the environment and location,
     # will compared against this .fetch file to know if the depednency
     # needs recompiling.
-    for %Mix.Dep{scm: scm, opts: opts} <- deps, scm.fetchable? do
-      File.touch Path.join opts[:dest], ".fetch"
+    _ = for %Mix.Dep{scm: scm, opts: opts} <- deps, scm.fetchable? do
+      File.touch! Path.join opts[:dest], ".fetch"
     end
+    :ok
   end
 
   defp with_depending(deps, all_deps) do

--- a/lib/mix/lib/mix/dep/loader.ex
+++ b/lib/mix/lib/mix/dep/loader.ex
@@ -125,9 +125,8 @@ defmodule Mix.Dep.Loader do
 
     {scm, opts} = get_scm(app, opts)
 
-    unless scm do
-      Mix.Tasks.Local.Hex.maybe_install(app)
-      Mix.Tasks.Local.Hex.maybe_start()
+    if !scm && Mix.Tasks.Local.Hex.ensure_installed?(app) do
+      _ = Mix.Tasks.Local.Hex.start()
       {scm, opts} = get_scm(app, opts)
     end
 

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -302,18 +302,18 @@ defmodule Mix.Project do
     source = Path.expand("ebin")
     target = Path.join(app, "ebin")
 
-    cond do
+    _ = cond do
       opts[:symlink_ebin] ->
-        Mix.Utils.symlink_or_copy(source, target)
+        _ = Mix.Utils.symlink_or_copy(source, target)
       match?({:ok, _}, :file.read_link(target)) ->
-        File.rm_rf!(target)
+        _ = File.rm_rf!(target)
         File.mkdir_p!(target)
       true ->
         File.mkdir_p!(target)
     end
 
-    Mix.Utils.symlink_or_copy(Path.expand("include"), Path.join(app, "include"))
-    Mix.Utils.symlink_or_copy(Path.expand("priv"), Path.join(app, "priv"))
+    _ = Mix.Utils.symlink_or_copy(Path.expand("include"), Path.join(app, "include"))
+    _ = Mix.Utils.symlink_or_copy(Path.expand("priv"), Path.join(app, "priv"))
     :ok
   end
 
@@ -341,7 +341,7 @@ defmodule Mix.Project do
       file = Path.expand("mix.exs")
       old_proj = get
 
-      if File.regular?(file) do
+      _ = if File.regular?(file) do
         Code.load_file(file)
       end
 

--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -73,7 +73,7 @@ defmodule Mix.SCM.Git do
     path     = opts[:dest]
     location = opts[:git]
 
-    File.rm_rf!(path)
+    _ = File.rm_rf!(path)
     command  = ~s(git clone --no-checkout --progress "#{location}" "#{path}")
 
     run_cmd_or_raise(command)
@@ -151,7 +151,8 @@ defmodule Mix.SCM.Git do
   end
 
   defp update_origin(location) do
-    :os.cmd('git --git-dir=.git config remote.origin.url #{location}')
+    _ = :os.cmd('git --git-dir=.git config remote.origin.url #{location}')
+    :ok
   end
 
   defp run_cmd_or_raise(command) do

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -28,7 +28,7 @@ defmodule Mix.Tasks.Archive.Install do
       intended for automation in build systems like make
 
   """
-
+  @spec run(OptionParser.argv) :: boolean
   def run(argv) do
     {opts, argv, _} = OptionParser.parse(argv, switches: [force: :boolean])
 
@@ -59,7 +59,9 @@ defmodule Mix.Tasks.Archive.Install do
       File.mkdir_p!(dest)
       archive = Path.join(dest, basename(src))
       create_file archive, Mix.Utils.read_path!(src)
-      Code.append_path(Mix.Archive.ebin(archive))
+      true = Code.append_path(Mix.Archive.ebin(archive))
+    else
+      false
     end
   end
 

--- a/lib/mix/lib/mix/tasks/clean.ex
+++ b/lib/mix/lib/mix/tasks/clean.ex
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.Clean do
   def run(args) do
     {opts, _, _} = OptionParser.parse(args)
 
-    for compiler <- Mix.Tasks.Compile.compilers() do
+    _ = for compiler <- Mix.Tasks.Compile.compilers() do
       module = Mix.Task.get!("compile.#{compiler}")
       if function_exported?(module, :clean, 0) do
         module.clean

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -57,7 +57,7 @@ defmodule Mix.Tasks.Compile.Elixir do
               || Mix.Utils.stale?(configs, [manifest])
 
     result = Mix.Compilers.Elixir.compile(manifest, srcs, [:ex], dest, force, fn ->
-      Code.prepend_path(dest)
+      true = Code.prepend_path(dest)
       set_compiler_opts(project, opts, [])
     end)
 

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -127,18 +127,19 @@ defmodule Mix.Tasks.Compile.Erlang do
   defp sort_dependencies(erls) do
     graph = :digraph.new
 
-    for erl <- erls do
+    _ = for erl <- erls do
       :digraph.add_vertex(graph, erl.module, erl)
     end
 
-    for erl <- erls do
-      for b <- erl.behaviours, do: :digraph.add_edge(graph, b, erl.module)
-      for c <- erl.compile do
+    _ = for erl <- erls do
+      _ = for b <- erl.behaviours, do: :digraph.add_edge(graph, b, erl.module)
+      _ = for c <- erl.compile do
         case c do
           {:parse_transform, transform} -> :digraph.add_edge(graph, transform, erl.module)
           _ -> :ok
         end
       end
+      :ok
     end
 
     result =

--- a/lib/mix/lib/mix/tasks/compile.ex
+++ b/lib/mix/lib/mix/tasks/compile.ex
@@ -56,7 +56,7 @@ defmodule Mix.Tasks.Compile do
         List.wrap Mix.Task.run("compile.#{compiler}", args)
       end)
 
-    Code.prepend_path(Mix.Project.compile_path)
+    true = Code.prepend_path(Mix.Project.compile_path)
     unless "--no-readd" in args, do: Code.readd_paths()
     if Enum.any?(res, &(:ok in &1)), do: :ok, else: :noop
   end

--- a/lib/mix/lib/mix/tasks/compile.protocols.ex
+++ b/lib/mix/lib/mix/tasks/compile.protocols.ex
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.Compile.Protocols do
   defp consolidate(protocols, paths, output) do
     File.mkdir_p!(output)
 
-    for protocol <- protocols do
+    _ = for protocol <- protocols do
       impls = Protocol.extract_impls(protocol, paths)
       maybe_reload(protocol)
       {:ok, binary} = Protocol.consolidate(protocol, impls)

--- a/lib/mix/lib/mix/tasks/deps.check.ex
+++ b/lib/mix/lib/mix/tasks/deps.check.ex
@@ -21,7 +21,7 @@ defmodule Mix.Tasks.Deps.Check do
     lock = Mix.Dep.Lock.read
     all  = Enum.map(loaded(env: Mix.env), &check_lock(&1, lock))
 
-    prune_deps(all)
+    _ = prune_deps(all)
     {not_ok, compile} = partition_deps(all, [], [])
 
     cond do
@@ -79,9 +79,12 @@ defmodule Mix.Tasks.Deps.Check do
       to_prune = Enum.reduce(all, paths, &(&2 -- Mix.Dep.load_paths(&1)))
 
       Enum.map(to_prune, fn path ->
-        Code.delete_path(path)
+        # path may not be in code path
+        _ = Code.delete_path(path)
         File.rm_rf!(path |> Path.dirname)
       end)
+    else
+      []
     end
   end
 

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -119,8 +119,8 @@ defmodule Mix.Tasks.Deps.Compile do
         "dependency #{app}, please ensure rebar is available"
     end
 
-    Mix.Tasks.Local.Rebar.run []
-    Mix.Rebar.local_rebar_cmd || Mix.raise "rebar installation failed"
+    (Mix.Tasks.Local.Rebar.run([]) && Mix.Rebar.local_rebar_cmd) ||
+      Mix.raise "rebar installation failed"
   end
 
   defp do_make(dep) do

--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Local.Rebar do
   The local copy is stored in your MIX_HOME (defaults to ~/.mix).
   This version of rebar will be used as required by `mix deps.compile`.
   """
-
+  @spec run(OptionParser.argv) :: true
   def run(argv) do
     {_, argv, _} = OptionParser.parse(argv)
     do_install(case argv do
@@ -28,6 +28,7 @@ defmodule Mix.Tasks.Local.Rebar do
     local_rebar_path = Mix.Rebar.local_rebar_path
     File.mkdir_p! Path.dirname(local_rebar_path)
     create_file local_rebar_path, rebar
-    :file.change_mode local_rebar_path, 0755
+    :ok = :file.change_mode local_rebar_path, 0755
+    true
   end
 end

--- a/lib/mix/lib/mix/tasks/run.ex
+++ b/lib/mix/lib/mix/tasks/run.ex
@@ -56,7 +56,7 @@ defmodule Mix.Tasks.Run do
     Mix.Task.run "app.start", args
     process_load opts
 
-    if file do
+    _ = if file do
       if File.regular?(file) do
         Code.require_file(file)
       else

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -308,7 +308,7 @@ defmodule Mix.Utils do
         {:error, :enoent} ->
           do_symlink_or_copy(source, target)
         {:error, _} ->
-          File.rm_rf!(target)
+          _ = File.rm_rf!(target)
           do_symlink_or_copy(source, target)
       end
     else
@@ -367,8 +367,8 @@ defmodule Mix.Utils do
   end
 
   defp read_url(path) do
-    :ssl.start
-    :inets.start
+    :ok = :ssl.start
+    :ok = :inets.start
 
     # Starting a http client profile allows us to scope
     # the effects of using a http proxy to this function
@@ -399,8 +399,8 @@ defmodule Mix.Utils do
 
   defp proxy(proxy) do
      uri = URI.parse(proxy)
-     :httpc.set_options([{ proxy_scheme(uri.scheme),
-         { { uri.host |> String.to_char_list, uri.port }, [] } }], :mix)
+     :ok = :httpc.set_options([{ proxy_scheme(uri.scheme),
+          { { uri.host |> String.to_char_list, uri.port }, [] } }], :mix)
    end
 
    defp proxy_scheme(scheme) do


### PR DESCRIPTION
Fixes unmatched returns dialyzer warnings from #2478.

Generated erlang issues:
- There are still warnings for `for` comprehensions when matched against an empty variable.
- Unmatched returns for `cond` expressions report the wrong line (the line of the first clause).
