### PR TITLE
throws error for missing docs in DocTest

### DIFF
--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -340,8 +340,8 @@ defmodule ExUnit.DocTest do
   defp extract(module) do
     all_docs = Code.get_docs(module, :all)
     if all_docs[:moduledoc] == nil do
-      raise Error, message: "could not retrieve the documentation for module MODULENAME. "
-      <> "Or the module was not compiled with documentation or its beam file cannot be accessed."
+      raise Error, message: "could not retrieve the documentation for module #{module}. "
+      <> "The module was not compiled with documentation or its beam file cannot be accessed."
     end
     moduledocs = extract_from_moduledoc(all_docs[:moduledoc])
 


### PR DESCRIPTION
This fixes issue #2482.

Now the code in https://groups.google.com/forum/#!topic/elixir-lang-talk/BWnyrCRaqm4 referred in the issue will get an error message when module DNA is not compiled, and when module DNA is compiled we will have one passing test.
