### PR TITLE
Call Mix.start, Mix.CLI.main directly in mix.bat

### DIFF
--- a/bin/mix.bat
+++ b/bin/mix.bat
@@ -1,2 +1,2 @@
 @echo off
-call "%~dp0\elixir.bat" "%~dp0\mix" %*
+call "%~dp0\elixir.bat" -e Mix.start -e Mix.CLI.main %*


### PR DESCRIPTION
If `"%~dp0\mix"` is passed to `elixir.bat` where `%~dp0` contains a space (such as in "C:\Program Files (x86)\Elixir\bin"), we get a failure (such as "Files was not expected at this time").  Since `"%~dp0\mix"` refers to [bin\mix](https://github.com/elixir-lang/elixir/blob/master/bin/mix), which simply contains:

```
#!/usr/bin/env elixir
Mix.start
Mix.CLI.main
```

we can just replace `"%~dp0\mix"` with `-e Mix.start -e Mix.CLI.main` for equivalent functionality and without running into this issue.
