### PR TITLE
Use short filenames to handle spaces in path to bin\mix

### DIFF
--- a/bin/mix.bat
+++ b/bin/mix.bat
@@ -1,2 +1,2 @@
 @echo off
-call "%~dp0\elixir.bat" "%~dp0\mix" %*
+call "%~dp0\elixir.bat" "%~dps0\mix" %*


### PR DESCRIPTION
The extra `s` modifier denotes that the path should be expanded using short (8.3) names.  This removes spaces and therefore fixes the issue of paths with spaces breaking `call`.
