### PR TITLE
mix.bat: Avoid space-in-path issue using pushd/popd

### DIFF
--- a/bin/mix
+++ b/bin/mix
@@ -1,3 +1,4 @@
 #!/usr/bin/env elixir
+if path = :os.getenv("MIXCALLERDIR"), do: File.cd path
 Mix.start
 Mix.CLI.main

--- a/bin/mix.bat
+++ b/bin/mix.bat
@@ -1,2 +1,16 @@
 @echo off
-call "%~dp0\elixir.bat" "%~dps0\mix" %*
+
+rem Set MIXCALLERDIR to the current directory for the life of the batch file
+setlocal
+set MIXCALLERDIR=%CD%
+
+rem Change into the bin directory
+pushd %~dp0
+
+rem Call elixir, using relative path to bin\mix
+call elixir.bat mix %*
+
+rem Return to original directory
+popd
+
+endlocal


### PR DESCRIPTION
This allows `bin\mix` to be called relative to `bin\elixir.bat`, by having `bin\mix` itself change into the original current directory, which gets stored in a local environment variable called `MIXCALLERDIR`.
