### PR TITLE
Optimize String.slice by using binary_part

### DIFF
--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -344,6 +344,7 @@ defmodule StringTest do
     assert String.slice("", 1..1) == ""
     assert String.slice("あいうえお", -2..-4) == ""
     assert String.slice("あいうえお", -10..-15) == ""
+    assert String.slice("hello あいうえお unicode", 8..-1) == "うえお unicode"
   end
 
   test :valid? do


### PR DESCRIPTION
This is not the actual optimization we've been discussing yet, but it was easier to get done. More to come tomorrow.

Some benchmarks (input string – `String.duplicate("hello world", 10000)`, full code – https://gist.github.com/alco/aea769ba02dce93de29f#file-slice_10000-ex). I've also tried strings duplicated 10 and 100000 times: the relative difference was mostly the same.

```
# master
StringSlice.slice left half:         100   20628.67 µs/op
StringSlice.slice right half:         50   33514.14 µs/op
StringSlice.slice almost all:         50   40865.84 µs/op
StringSlice.slice -1:                 50   63981.30 µs/op

# PR
StringSlice.slice -1:           10000000   0.60 µs/op
StringSlice.slice left half:         100   15272.15 µs/op
StringSlice.slice right half:         50   29207.42 µs/op
StringSlice.slice almost all:         50   30960.10 µs/op

# speedup
# This is the ratio of (PR execution time) / (master execution time)
StringSlice:slice -1:         0.0
StringSlice:slice left half:  0.76
StringSlice:slice almost all: 0.77
StringSlice:slice right half: 0.88

# same ratios expressed as percent
StringSlice:slice -1:         -100.00%
StringSlice:slice left half:  -24.22%
StringSlice:slice almost all: -22.77%
StringSlice:slice right half: -11.68%
```
