### PR TITLE
Remove non-existing from argument from handle_cast

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -28,7 +28,7 @@ defmodule Supervisor do
           {:reply, h, t}
         end
 
-        def handle_cast({:push, h}, _from, t) do
+        def handle_cast({:push, h}, t) do
           {:noreply, [h|t]}
         end
       end


### PR DESCRIPTION
`handle_cast` does not support a `from` argument and this example will crash if it has one.
