### PR TITLE
Allowing path: for erlang projects

### DIFF
--- a/lib/mix/lib/mix/dep/loader.ex
+++ b/lib/mix/lib/mix/dep/loader.ex
@@ -237,8 +237,7 @@ defmodule Mix.Dep.Loader do
 
   defp validate_path(%Mix.Dep{scm: scm, manager: manager} = dep) do
     if scm == Mix.SCM.Path and not manager in [:mix, nil] do
-      Mix.raise ":path option can only be used with mix projects, " <>
-                                "invalid path dependency for #{inspect dep.app}"
+      dep
     else
       dep
     end

--- a/lib/mix/test/mix/tasks/deps.path_test.exs
+++ b/lib/mix/test/mix/tasks/deps.path_test.exs
@@ -34,21 +34,4 @@ defmodule Mix.Tasks.DepsPathTest do
       assert_received {:mix_shell, :info, ["world"]}
     end
   end
-
-  defmodule InvalidPathDepsApp do
-    def project do
-      [
-        app: :rebar_as_dep,
-        version: "0.1.0",
-        deps: [{:rebar_dep, path: MixTest.Case.tmp_path("rebar_dep")}]
-      ]
-    end
-  end
-
-  test "raises on non-mix path deps" do
-    Mix.Project.push InvalidPathDepsApp
-    assert_raise Mix.Error, ~r/:path option can only be used with mix projects/, fn ->
-      Mix.Tasks.Deps.Get.run []
-    end
-  end
 end


### PR DESCRIPTION
Allowing non-mix projects (erlang projects) to be used with path.
