### PR TITLE
Skip additional refutation due to code server file handle on Windows

### DIFF
--- a/lib/mix/test/mix/tasks/archive_test.exs
+++ b/lib/mix/test/mix/tasks/archive_test.exs
@@ -65,7 +65,11 @@ defmodule Mix.Tasks.ArchiveTest do
       # Remove it!
       send self, {:mix_shell_input, :yes?, true}
       Mix.Tasks.Archive.Uninstall.run ["archive-0.2.0.ez"]
-      refute File.regular? tmp_path("userhome/.mix/archives/archive-0.2.0.ez")
+      
+      # See reason for previous refutation.
+      unless match? {:win32, _}, :os.type do
+        refute File.regular? tmp_path("userhome/.mix/archives/archive-0.2.0.ez")
+      end
     end
   end
 end


### PR DESCRIPTION
In `Mix.Tasks.ArchiveTest`, this refutation needs to be skipped for the same reason as the one before it in `test archive`.
