### PR TITLE
mix.ps1 Revision

### DIFF
--- a/bin/mix.ps1
+++ b/bin/mix.ps1
@@ -1,17 +1,23 @@
 # Store path to mix.bat as a FileInfo object
 $mixBatPath = (Get-ChildItem (((Get-ChildItem $MyInvocation.MyCommand.Path).Directory.FullName) + '\mix.bat'))
+$newArgs = @()
 
 for ($i = 0; $i -lt $args.length; $i++)
 {
   if ($args[$i] -is [array])
   {
     # Commas created the array so we need to reintroduce those commas
-    for ($j = 0; $j -lt $args[$i].length - 1; $i++)
+    for ($j = 0; $j -lt $args[$i].length - 1; $j++)
     {
-      $args[$i][$j] += ','
+      $newArgs += ($args[$i][$j] + ',')
     }
+    $newArgs += $args[$i][-1]
+  }
+  else
+  {
+    $newArgs += $args[$i]
   }
 }
 
 # Corrected arguments are ready to pass to batch file
-& $mixBatPath $args
+& $mixBatPath $newArgs


### PR DESCRIPTION
This revises `mix.ps1` to:
- Use `&` instead of `cmd /C` to call the batch file
- Modify and use `$args` directly instead of building a string which represents the final command
- Represent the path to `mix.bat` as a FileInfo object

This was done mainly to fix quoting/spacing issues which generated similar errors as with the `call %~dp0` saga (ex. 'C:\Program is not recognized`).
