### PR TITLE
use pure erlang function to judge the erlang version, no shell function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ INSTALL_PROGRAM = $(INSTALL) -m755
 # This check should work for older versions like R16B
 # as well as new verions like 17.1 and 18
 define CHECK_ERLANG_RELEASE
-	$(Q) erl -noshell -eval 'io:fwrite("~s", [erlang:system_info(otp_release)])' -s erlang halt | grep -q '^1[789]'; \
+	$(Q) erl -noshell -eval 'case catch erlang:list_to_integer(erlang:system_info(otp_release)) of V when erlang:is_integer(V) andalso V >=17 -> erlang:halt(0); _O -> erlang:halt(1) end'; \
 		if [ $$? != 0 ]; then                                                                                        \
 		   echo "At least Erlang 17.0 is required to build Elixir";                                                  \
 		   exit 1;                                                                                                   \


### PR DESCRIPTION
it has been tested with r15b03 r16b02 17.1, all passed. sorry for the fault before.
