### PR TITLE
Add Range.Iterator for floats

### DIFF
--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -36,6 +36,9 @@ defmodule Range do
       iex> Range.range?(1..3)
       true
 
+      iex> Range.range?(1.0..1.5)
+      true
+
       iex> Range.range?(0)
       false
 
@@ -113,6 +116,39 @@ defimpl Range.Iterator, for: Integer do
     else
       first - last + 1
     end
+  end
+end
+
+defimpl Range.Iterator, for: Float do
+
+  def next(first, _ .. last) when is_float(last) do
+    { increment, p } = precision last
+
+    if last >= first do
+      &(&1 + increment) |> Float.round p
+    else
+      &(&1 - increment) |> Float.round p
+    end
+  end
+
+  def count(first, _ .. last) when is_float(last) do
+    { increment, _ } = precision last
+
+    if last >= first do
+      (last - first + increment) / increment |> Kernel.round
+    else
+      (first - last + increment) / increment |> Kernel.round
+    end
+  end
+
+  defp precision(n) do
+    [_, p] = String.split("#{n}", ".")
+    length = String.length p
+    power  = Enum.reduce 1..length, 1, fn(_, acc) ->
+      acc * 10
+    end
+
+    { 1 / power, length }
   end
 end
 

--- a/lib/elixir/test/elixir/range_test.exs
+++ b/lib/elixir/test/elixir/range_test.exs
@@ -5,16 +5,22 @@ defmodule RangeTest do
 
   test :precedence do
     assert Enum.to_list(1..3+2) == [1, 2, 3, 4, 5]
+    assert Enum.to_list(1.0..1.5+0.2) == [1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7]
     assert 1..3 |> Enum.to_list == [1, 2, 3]
+    assert 1.0..1.5 |> Enum.to_list == [1.0, 1.1, 1.2, 1.3, 1.4, 1.5]
   end
 
   test :op do
     assert (1..3).first == 1
     assert (1..3).last  == 3
+
+    assert (1.0..1.5).first == 1.0
+    assert (1.0..1.5).last == 1.5
   end
 
   test :range? do
     assert Range.range?(1..3)
+    assert Range.range?(1.0..1.527)
     refute Range.range?(0)
   end
 
@@ -27,15 +33,25 @@ defmodule RangeTest do
     refute Enum.member?(3..1, 0)
     refute Enum.member?(3..1, 4)
 
+    assert Enum.member?(1.0..1.5, 1.4)
+    refute Enum.member?(1.0..1.5, 0.6)
+    refute Enum.member?(1.0..1.5, 1.6)
+
     assert Enum.count(1..3) == 3
     assert Enum.count(3..1) == 3
 
+    assert Enum.count(1.0..1.5) == 6
+    assert Enum.count(1.5..1.0) == 6
+
     assert Enum.map(1..3, &(&1 * 2)) == [2, 4, 6]
     assert Enum.map(3..1, &(&1 * 2)) == [6, 4, 2]
+
+    assert Enum.map(1.0..1.5, &(&1 * 2)) == [2.0, 2.2, 2.4, 2.6, 2.8, 3.0]
   end
 
   test :inspect do
     assert inspect(1..3) == "1..3"
     assert inspect(3..1) == "3..1"
+    assert inspect(1.0..1.5) == "1.0..1.5"
   end
 end


### PR DESCRIPTION
I have added a new Range.Iterator for floating point numbers. This provides an additional level of precision for ranges. 

``` elixir
iex> Enum.count(1..3)
3
iex> Enum.count(1.0..3.0)
21
```

The number is incremented based on the precision of the greatest number so `1.0..1.25` would be incremented by `0.01` and `1.0..1.25678` would be incremented by `0.00001`.

Tests are included.
