### PR TITLE
Fallback to no tab expansion if not supported

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -486,8 +486,11 @@ defmodule IEx do
       else
         &IEx.Autocomplete.expand(&1)
       end
-
-    :io.setopts gl, [expand_fun: expand_fun, binary: true, encoding: :unicode]
+    
+    case (:io.setopts gl, [expand_fun: expand_fun, binary: true, encoding: :unicode]) do
+      :ok -> :ok
+      _ -> :io.setopts gl, [binary: true, encoding: :unicode]
+    end
   end
 
   defp ensure_module_exists(node, mod) do


### PR DESCRIPTION
`:io.setops` returns `{error, enotsup}` for those terminals which don't support tab expansion.  We should instead be falling back silently (or we could add a warning) when this happens.
