### PR TITLE
Docs: change Dict.merge description to read more naturally

### DIFF
--- a/lib/elixir/lib/dict.ex
+++ b/lib/elixir/lib/dict.ex
@@ -456,8 +456,8 @@ defmodule Dict do
   @doc """
   Merges the dict `dict2` into dict `dict1`.
 
-  If one of the dict `dict2` entries already exists in the `dict`,
-  the functions in entries in `dict2` have higher precedence unless a
+  If one of the `dict2` entries already exists in `dict1`, the
+  functions in entries in `dict2` have higher precedence unless a
   function is given to resolve conflicts.
 
   Notice this function is polymorphic as it merges dicts of any


### PR DESCRIPTION
Previously there was an additional "dict" - this is as a result of it
previously saying "dict `a`"

Apologies for the small pull request - this issue came up when being reviewed. @khia - could you just leave a note on this pull request to confirm there are no other documentation issues in the https://github.com/elixir-lang/elixir/pull/2575 pull request?
