### PR TITLE
Add namespace macro to ExUnit.

### DIFF
--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -36,4 +36,18 @@ defmodule ExUnit.CaseTest do
   test "module tags can be overridden", context do
     assert context[:moduletag] == :overridden
   end
+
+  namespace "outer" do
+    namespace "middle" do
+      test "inner" do
+        name = __ENV__.function |> elem(0)
+        assert name == :"test outer middle inner"
+      end
+    end
+
+    test "other" do
+      name = __ENV__.function |> elem(0)
+      assert name == :"test outer other"
+    end
+  end
 end


### PR DESCRIPTION
## Description

Something that has bugged me for a while about ExUnit is the inability to effectively group tests that exercise the same function. I wanted something similar to rspec's context[1]. However, `context` is an overloaded term in ExUnit, so I picked the equally overloaded term `namespace` :) Suggestions on the name are welcome.

Essentially, all a namespace does is append to the name of tests defined within it. Namespaces can be nested. For example:

``` elixir
namespace "outer" do
  namespace "middle" do
    test "inner" do
      name = __ENV__.function |> elem(0)
      assert name == :"test outer middle inner"
    end
  end

  test "other" do
    name = __ENV__.function |> elem(0)
    assert name == :"test outer other"
  end
end
```
## Caveats
- I'm very new to Module attributes. It's likely I did something wrong.
- I don't really love the name `namespace`. I'm open to suggestions.
- I'm not sure if others see this as a problem and want it solved.
- It might make sense to make namespaces more powerful, allowing nesting of setups, teardowns, etc.
## Wrap Up

Read over the code and let me know what you think. If this seems crazy, no harm. There's very little code and I'm happy to throw it away.

[1] - https://www.relishapp.com/rspec/rspec-core/docs/example-groups/basic-structure-describe-it#nested-example-groups-(using-`context`)
