### PR TITLE
Added @doc false to handle_call functions

### DIFF
--- a/lib/elixir/lib/kernel/lexical_tracker.ex
+++ b/lib/elixir/lib/kernel/lexical_tracker.ex
@@ -101,6 +101,7 @@ defmodule Kernel.LexicalTracker do
     {:ok, :ets.new(:lexical, [:protected])}
   end
 
+  @doc false
   def handle_call(:ets, _from, d) do
     {:reply, d, d}
   end

--- a/lib/elixir/lib/module/locals_tracker.ex
+++ b/lib/elixir/lib/module/locals_tracker.ex
@@ -242,6 +242,7 @@ defmodule Module.LocalsTracker do
     {:ok, {d, []}}
   end
 
+  @doc false
   def handle_call({:cache_env, env}, _from, {d, cache}) do
     case cache do
       [{i,^env}|_] ->


### PR DESCRIPTION
Added `@doc false` to handle_call functions as they do not have documentation and it appears that most functions in locals_tracker.ex have `@docs false`
