### PR TITLE
Add OTP 17.1 to run on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ notifications:
     - eric.meadows.jonsson@gmail.com
 otp_release:
   - 17.0
+  - 17.1


### PR DESCRIPTION
It's now available: http://blog.travis-ci.com/2014-07-24-upcoming-build-environment-updates/
