### PR TITLE
Add ANSI support to console logger

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -138,12 +138,30 @@ defmodule Logger do
     * `:metadata` - the metadata to be printed by `$metadata`.
       Defaults to an empty list (no metadata)
 
+    * `:colors` - a keyword list of coloring options.
+
+  The supported keys in the `:colors` keyword list are:
+
+    * `:enabled` - boolean value that allows for switching the
+    coloring on and off. Defaults to: `false`
+
+    * `:debug` - color for debug messages. Defaults to: `:magenta`
+
+    * `:info` - color for info messages. Defaults to: `:normal`
+
+    * `:warn` - color for warn messages. Defaults to: `:yellow`
+
+    * `:error` - color for error messages. Defaults to: `:red`
+
+  See the `IO.ANSI` module for a list of colors and attributes.
+
   Here is an example on how to configure the `:console` in a
   `config/config.exs` file:
 
       config :logger, :console,
         format: "$date $time [$level] $metadata$message\n",
-        metadata: [:user_id]
+        metadata: [:user_id],
+        colors: [enabled: true]
 
   You can read more about formatting in `Logger.Formatter`.
 

--- a/lib/logger/test/logger/backends/console_test.exs
+++ b/lib/logger/test/logger/backends/console_test.exs
@@ -4,7 +4,8 @@ defmodule Logger.Backends.ConsoleTest do
 
   setup do
     on_exit fn ->
-      :ok = Logger.configure_backend(:console, [format: nil, level: nil, metadata: []])
+      :ok = Logger.configure_backend(:console,
+          [format: nil, level: nil, metadata: [], colors: [enabled: false]])
     end
   end
 
@@ -48,5 +49,49 @@ defmodule Logger.Backends.ConsoleTest do
     assert capture_log(fn ->
       Logger.debug("hello")
     end) == ""
+  end
+
+  test "can configure colors" do
+    Logger.configure_backend(:console, [format: "$message", colors: [enabled: true]])
+
+    assert capture_log(fn ->
+      Logger.debug("hello")
+    end) == IO.ANSI.magenta() <> "hello" <> IO.ANSI.reset()
+
+    Logger.configure_backend(:console, [colors: [debug: :cyan]])
+
+    assert capture_log(fn ->
+      Logger.debug("hello")
+    end) == IO.ANSI.cyan() <> "hello" <> IO.ANSI.reset()
+
+    assert capture_log(fn ->
+      Logger.info("hello")
+    end) == IO.ANSI.normal() <> "hello" <> IO.ANSI.reset()
+
+    Logger.configure_backend(:console, [colors: [info: :cyan]])
+
+    assert capture_log(fn ->
+      Logger.info("hello")
+    end) == IO.ANSI.cyan() <> "hello" <> IO.ANSI.reset()
+
+    assert capture_log(fn ->
+      Logger.warn("hello")
+    end) == IO.ANSI.yellow() <> "hello" <> IO.ANSI.reset()
+
+    Logger.configure_backend(:console, [colors: [warn: :cyan]])
+
+    assert capture_log(fn ->
+      Logger.warn("hello")
+    end) == IO.ANSI.cyan() <> "hello" <> IO.ANSI.reset()
+
+    assert capture_log(fn ->
+      Logger.error("hello")
+    end) == IO.ANSI.red() <> "hello" <> IO.ANSI.reset()
+
+    Logger.configure_backend(:console, [colors: [error: :cyan]])
+
+    assert capture_log(fn ->
+      Logger.error("hello")
+    end) == IO.ANSI.cyan() <> "hello" <> IO.ANSI.reset()
   end
 end


### PR DESCRIPTION
- Coloring is off by default because I could not think of a way to choose a default with `IO.ANSI.terminal?/1`
- Advanced coloring can be done by the formatter for `:console` backend because the formatter can return a value that is passed to `IO.ANSI.format/2` (chardata with ANSI atoms)
- `:console` backend does smart options merging so the old `:colors` options are not lost
