### PR TITLE
Handle tilde in `Path.expand/1,2` properly

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -585,8 +585,20 @@ defmodule Path do
 
   defp expand_home(type) do
     case IO.chardata_to_string(type) do
-      "~" <> rest -> System.user_home! <> rest
+      "~" <> rest -> resolve_home(rest)
       rest        -> rest
+    end
+  end
+
+  defp resolve_home(""), do: System.user_home!
+
+  defp resolve_home(rest) do
+    case {rest, major_os_type} do
+      {"\\" <> _, :win32} ->
+        System.user_home! <> rest
+      {"/" <> _, _} ->
+        System.user_home! <> rest
+      _ -> rest
     end
   end
 

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -112,6 +112,7 @@ defmodule PathTest do
     assert Path.expand("~/file", "whatever") == Path.join(home, "file")
     assert Path.expand("file", Path.expand("~")) == Path.expand("~/file")
     assert Path.expand("file", "~") == Path.join(home, "file")
+    assert Path.expand("~file") == Path.join(System.cwd!, "file")
   end
 
   test :expand_path do


### PR DESCRIPTION
Closes #2579 
- `~`:

Ruby, Zsh, Python expand it to `HOME`
- `~/dir`:

Ruby, Zsh, Python expand it to `HOME` + `/dir`
- `~user`:

Ruby, Zsh, Python use `getpwnam` call but behave differently.
In case of `user` existence `user`'s dir will be returned, otherwise:
- Python returns path unchanged
- Ruby, Zsh raise
