### PR TITLE
Use Command Prompt for stdlib test on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,11 @@ test_doc_test: compile
 test_stdlib: compile
 	@ echo "==> elixir (exunit)"
 	$(Q) exec epmd & exit
-	$(Q) cd lib/elixir && ../../bin/elixir -r "test/elixir/test_helper.exs" -pr "test/elixir/**/*_test.exs";
+	$(Q) if [ $(OS) = Windows_NT ]; then \
+		cd lib/elixir && cmd //C call ../../bin/elixir.bat -r "test/elixir/test_helper.exs" -pr "test/elixir/**/*_test.exs"; \
+	else \
+		cd lib/elixir && ../../bin/elixir -r "test/elixir/test_helper.exs" -pr "test/elixir/**/*_test.exs"; \
+	fi
 
 #==> Dialyzer tasks
 


### PR DESCRIPTION
This is to ensure that tests are run via `elixir.bat` rather than the bash script, so that we can catch test failures specific to the environment (one has already come up.)
