### PR TITLE
Add integer base support to inspect

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -377,8 +377,45 @@ defimpl Inspect, for: Map do
 end
 
 defimpl Inspect, for: Integer do
-  def inspect(thing, _opts) do
-    Integer.to_string(thing)
+  @doc ~S"""
+  Represents an integer, printing in decimal format by default.
+  Other formats include :binary, :octal, and :hex.
+
+  ## Examples
+
+      iex> inspect(86, base: :binary)
+      "0b1010110"
+
+      iex> inspect(100, base: :octal)
+      "0o144"
+
+      iex> inspect(100, base: :hex)
+      "0x64"
+
+  """
+
+  def inspect(thing, %Inspect.Opts{base: base}) do
+    Integer.to_string(thing, base_to_value(base))
+      |> prepend_prefix(base)
+  end
+
+  defp base_to_value(base) do
+    case base do
+      :binary  -> 2
+      :decimal -> 10
+      :octal   -> 8
+      :hex     -> 16
+    end
+  end
+
+  defp prepend_prefix(value, :decimal), do: value
+  defp prepend_prefix(value, base) do
+    prefix = case base do
+      :binary -> "0b"
+      :octal  -> "0o"
+      :hex    -> "0x"
+    end
+    prefix <> value
   end
 end
 

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -31,6 +31,10 @@ defmodule Inspect.Opts do
 
     * `:width` - defaults to the 80 characters, used when pretty is true or
       when printing to IO devices.
+
+    * `:base` - print integers as :binary, :octal, :decimal, or :hex, defaults
+      to :decimal
+
   """
 
   defstruct structs: true,
@@ -38,6 +42,7 @@ defmodule Inspect.Opts do
             char_lists: :infer,
             limit: 50,
             width: 80,
+            base: :decimal,
             pretty: false
 
   @type t :: %__MODULE__{
@@ -46,6 +51,7 @@ defmodule Inspect.Opts do
                char_lists: :infer | :as_lists | :as_char_lists,
                limit: pos_integer,
                width: pos_integer | :infinity,
+               base: :decimal | :binary | :hex | :octal,
                pretty: boolean}
 end
 
@@ -428,7 +434,6 @@ defmodule Inspect.Algebra do
       ...>         %Inspect.Opts{limit: 3}, fn i, _opts -> to_string(i) end, "!")
       iex> Inspect.Algebra.format(doc, 20) |> IO.iodata_to_binary
       "[1! 2! 3! ...]"
-
   """
   @spec surround_many(binary, [any], binary, integer | :infinity, (term -> t), binary) :: t
   def surround_many(left, docs, right, opts, fun, separator \\ @surround_separator) do

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -121,6 +121,22 @@ defmodule Inspect.NumberTest do
     assert inspect(100) == "100"
   end
 
+  test :decimal do
+    assert inspect(100, base: :decimal) == "100"
+  end
+
+  test :hex do
+    assert inspect(100, base: :hex) == "0x64"
+  end
+
+  test :octal do
+    assert inspect(100, base: :octal) == "0o144"
+  end
+
+  test :binary do
+    assert inspect(86, base: :binary) == "0b1010110"
+  end
+
   test :float do
     assert inspect(1.0) == "1.0"
     assert inspect(1.0E10) == "1.0e10"


### PR DESCRIPTION
Option :base for inspect/2 supports :binary, :octal, :decimal, :hex.
Includes tests and documentation. Completes #2583
