### PR TITLE
Improved RFC compliance for URI to_string

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -349,12 +349,20 @@ defimpl String.Chars, for: URI do
       if uri.port == port, do: uri = %{uri | port: nil}
     end
 
+    # Based on http://tools.ietf.org/html/rfc3986#section-5.3
+
+    if uri.host do
+      authority = uri.host
+      if uri.userinfo, do: authority = uri.userinfo <> "@" <> authority
+      if uri.port, do: authority = authority <> ":" <> Integer.to_string(uri.port)
+    else
+      authority = uri.authority
+    end
+
     result = ""
 
-    if uri.scheme,   do: result = result <> uri.scheme <> "://"
-    if uri.userinfo, do: result = result <> uri.userinfo <> "@"
-    if uri.host,     do: result = result <> uri.host
-    if uri.port,     do: result = result <> ":" <> Integer.to_string(uri.port)
+    if uri.scheme,   do: result = result <> uri.scheme <> ":"
+    if authority,    do: result = result <> "//" <> authority
     if uri.path,     do: result = result <> uri.path
     if uri.query,    do: result = result <> "?" <> uri.query
     if uri.fragment, do: result = result <> "#" <> uri.fragment

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -198,5 +198,8 @@ defmodule URITest do
     assert to_string(URI.parse("http://google.com/elixir")) == "http://google.com/elixir"
     assert to_string(URI.parse("http://google.com?q=lol")) == "http://google.com?q=lol"
     assert to_string(URI.parse("http://google.com?q=lol#omg")) == "http://google.com?q=lol#omg"
+    assert to_string(URI.parse("//google.com/elixir")) == "//google.com/elixir"
+    assert to_string(URI.parse("//google.com:8080/elixir")) == "//google.com:8080/elixir"
+    assert to_string(URI.parse("//user:password@google.com/")) == "//user:password@google.com/"
   end
 end


### PR DESCRIPTION
URI.parse works according to RFC 3986 Appendix B, but to_string is a simplification that can lead to illegal URIs. In particular, it does not handle URIs without a schema (e.g. "//example.net/path") correctly.

Compare Elixir 0.15.0:

```
iex(1)> to_string URI.parse("//example.net/path")
"example.net/path"
```

To Ruby:

```
irb :001 > URI.parse("//example.net/path").to_s
 => "//example.net/path" 
```

This PR implements the URI recomposition according to section 5.3 of the RFC.
