### PR TITLE
Makefile: shorten tip about Unicode embedding time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ $(KERNEL): lib/elixir/lib/*.ex lib/elixir/lib/*/*.ex lib/elixir/lib/*/*/*.ex
 unicode: $(UNICODE)
 $(UNICODE): lib/elixir/unicode/*
 	@ echo "==> unicode (compile)";
-	@ echo "This step can take up to a minute to compile in order to embed the Unicode database"
+	@ echo "Embedding the Unicode database... (this may take a while)"
 	$(Q) cd lib/elixir && ../../$(ELIXIRC) unicode/unicode.ex -o ebin;
 
 $(eval $(call APP_TEMPLATE,ex_unit,ExUnit))


### PR DESCRIPTION
The estimate about this step taking "up to a minute" really depends on
the machine we're compiling on.  For example, on an old or underpowered
machine, it may take _longer_ than a minute.  So this patch changes the
wording accordingly and puts the reason for the delay at the beginning.
