### PR TITLE
Add special case for lists in Stream.cycle

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -882,6 +882,15 @@ defmodule Stream do
 
   """
   @spec cycle(Enumerable.t) :: Enumerable.t
+  def cycle(enumerable)
+
+  def cycle(enumerable) when is_list(enumerable) do
+    Stream.unfold {enumerable, enumerable}, fn
+      ({source, [h | t]}) -> {h, {source, t}}
+      ({source = [h | t], []}) -> {h, {source, t}}
+    end
+  end
+
   def cycle(enumerable) do
     fn acc, fun ->
       inner = &do_cycle_each(&1, &2, fun)


### PR DESCRIPTION
Performance improvement demonstrated:

``` elixir
iex(5)> :timer.tc fn -> Stream.cycle(1..3) |> Enum.take(1_000_000) end
{387861,
 [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2,
  3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, ...]}
iex(6)> :timer.tc fn -> Stream.cycle([1,2,3]) |> Enum.take(1_000_000) end
{145768,
 [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2,
  3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, ...]}
iex(7)> Protocol.consolidated?(Enumerable)
true
```
