### PR TITLE
Fix example in config/config.exs that's created for new projects.

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -299,9 +299,10 @@ defmodule Mix.Tasks.New do
 
   # Sample configuration:
   #
-  #     config :logger,
+  #     config :logger, :console,
   #       level: :info,
-  #       format: "$time $metadata[$level] $levelpad$message\n"
+  #       format: "$date $time [$level] $metadata$message\n",
+  #       metadata: [:user_id]
 
   # It is also possible to import configuration files, relative to this
   # directory. For example, you can emulate configuration per environment


### PR DESCRIPTION
The example in `config/config.exs` got out of date.
