### PR TITLE
fix --no-color / --color option for `mix test`

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -200,10 +200,17 @@ defmodule Mix.Tasks.Test do
            |> filter_opts(:exclude)
            |> filter_only_opts()
 
+    default_opts(opts) ++
+      Dict.take(opts, [:trace, :max_cases, :include, :exclude, :seed])
+  end
+
+  defp default_opts(opts) do
     # Set autorun to false because Mix
     # automatically runs the test suite for us.
-    [autorun: false] ++
-      Dict.take(opts, [:trace, :max_cases, :color, :include, :exclude, :seed])
+    case Dict.get(opts, :color) do
+      nil -> [autorun: false]
+      enabled? -> [autorun: false, colors: [enabled: enabled?]]
+    end
   end
 
   defp parse_files([], test_paths) do

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -25,4 +25,9 @@ defmodule Mix.Tasks.TestTest do
     assert ex_unit_opts([only: "focus", include: "special"]) ==
            [autorun: false, exclude: [:test], include: [:focus, :special]]
   end
+
+  test "ex_unit_opts translates :color into list containing an enabled key/value pair" do
+    assert ex_unit_opts([color: false]) == [autorun: false, colors: [enabled: false]]
+    assert ex_unit_opts([color: true]) == [autorun: false, colors: [enabled: true]]
+  end
 end


### PR DESCRIPTION
The `--no-color` flag builds up an options hash to include `[color: false]` which is then passed to `ExUnit.configure/1`. The ExUnit application isn't aware of a `:color` attribute, but it does know of a `:colors` attribute which takes a list of colors to be used by formatters.

This PR will convert the `:color` flag given to the `mix test` task into the proper option format that `ExUnit.configure/1` expects.
