### PR TITLE
Use quotes to avoid space-in-path issues with cygpath

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -81,7 +81,7 @@ done
 SELF=$(readlink_f "$0")
 SCRIPT_PATH=$(dirname "$SELF")
 
-if [ "$OSTYPE" = "cygwin" ]; then SCRIPT_PATH=$(cygpath -m $SCRIPT_PATH); fi
+if [ "$OSTYPE" = "cygwin" ]; then SCRIPT_PATH=$(cygpath -m "SCRIPT_PATH"); fi
 if [ "$MODE" != "iex" ]; then ERL="-noshell -s elixir start_cli $ERL"; fi
 
 # Check for terminal support


### PR DESCRIPTION
This commit ensures that if `$SCRIPT_PATH` has spaces in it, `cygpath` will still treat it as one path.

@josevalim I found this through testing shell redirection (calling the batch files at the beginning of the bash files if in Cygwin).  That approach introduces issues with using Ctrl+C whereas what we have currently works great.
