### PR TITLE
Clarify match?/2 docs.

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1893,8 +1893,8 @@ defmodule Kernel do
   end
 
   @doc """
-  A convenient macro that checks if the right side matches
-  the left side. The left side is allowed to be a match pattern.
+  A convenience macro that checks if the right side (an expression)
+  matches the left side (a pattern).
 
   ## Examples
 


### PR DESCRIPTION
I think because the subject usually is the first argument in Elixir, I expected the expression to be the left side. After looking at the implementation and realizing that it's supposed to mirror matching with `=`, it makes sense that the pattern is on the left side. However, I think it's worth it to make this a bit clearer in the docs.
