### PR TITLE
Add a :test_trace option to set default tracing mode for ExUnit.

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -109,6 +109,10 @@ defmodule Mix.Tasks.Test do
     * `:test_coverage` - a set of options to be passed down to the coverage
       mechanism.
 
+    * `:test_trace` - a Boolean value which, if present, specifies the default
+      behavior when neither `--trace` nor `--no-trace` have been passed on the
+      command line.
+
   ## Coverage
 
   The `:test_coverage` configuration accepts the following options:
@@ -171,6 +175,11 @@ defmodule Mix.Tasks.Test do
     end
 
     opts = ex_unit_opts(opts)
+
+    if project[:test_trace] != nil && opts[:trace] == nil do
+      opts = Keyword.put(opts, :trace, project[:test_trace])
+    end
+
     ExUnit.configure(opts)
 
     test_paths = project[:test_paths] || ["test"]


### PR DESCRIPTION
I really, really prefer to see the full list of tests on some of my projects. The output is much nicer when things fail, and the timing info has on several occasions helped me catch performance bugs where my code was doing something wonky causing massive slowdown (and thus a huge test time).

Typing out `mix test --trace` is cumbersome, especially because I usually get it wrong by just typing `mix test` and then have to type `mix test --trace` again.

It would be nice if I could just make trace mode the default.
