### PR TITLE
Docs: Using autocomplete for function discovery in IEx

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -40,6 +40,11 @@ defmodule IEx.Helpers do
 
       h(Enum)
       h(Enum.reverse/1)
+      
+  To discover all available functions for a module, type the module name
+  follow by a dot, then press tab to trigger autocomplete. For example:
+  
+      Enum.
 
   To learn more about IEx as a whole, just type `h(IEx)`.
   """


### PR DESCRIPTION
I had to go to the mailing list to discover this trick. Knowing it's autocomplete supplying the information makes it obvious in hindsight, but I had it in my head that it would be part of the h() command. It might also be worth adding a mention of autocomplete to the h(IEx) page, as well, but since this is likely first help page a new user would come across, this may be enough.
