### PR TITLE
Added first draft of File.mv for moving files around

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -389,6 +389,42 @@ defmodule File do
   end
 
   @doc """
+  Moves the contents in `source` to `destination` preseving its mode.
+
+  If a file already exists in the destination, it invokes a
+  callback which should return `true` if the existing file
+  should be overwritten, `false` otherwise.  It defaults to return `true`.
+
+  It returns `:ok` in case of success, returns
+  `{:error, reason}` otherwise
+
+  Note: current implementation allows you to copy a file to a directory
+   (and it will keep the same basename from the original file).  This
+   differs from erlang's base implementation
+   http://www.erlang.org/doc/man/file.html#rename-2
+   This functionality might change, as this is my first pull request
+  """
+  @spec mv(Path.t, Path.t, (Path.t, Path.t -> boolean)) :: :ok | {:error, posix}
+  def mv(source, destination, callback \\ fn(_, _) -> true end) do
+    source = IO.chardata_to_string(source)
+    destination = IO.chardata_to_string(destination)
+    do_mv_file(source, destination, callback)
+  end
+
+  @doc """
+  The same as `mv/3`, but raises `File.CopyError` if it fails.
+  Returns :ok otherwise
+  """
+  def mv!(source, destination, callback \\ fn(_,_) -> true end) do
+    case mv(source, destination, callback) do
+      :ok -> :ok
+      {:error, reason} ->
+        raise File.CopyError, reason: reason, action: "move",
+          source: source, destination: destination
+    end
+  end
+
+  @doc """
   Copies the contents in `source` to `destination` preserving its mode.
 
   If a file already exists in the destination, it invokes a
@@ -542,6 +578,28 @@ defmodule File do
 
   defp copy_file_mode!(src, dest) do
     write_stat!(dest, %{stat!(dest) | mode: stat!(src).mode})
+  end
+
+  # Most of the underlying move functionality delgated
+  # to elrang's rename function
+  # http://www.erlang.org/doc/man/file.html#rename-2
+  defp do_mv_file(src, dest, callback) do
+    if File.exists?(dest) && !callback.(src,dest) do
+      {:error, :eexist}
+    else
+      case F.rename(src, dest) do
+        {:error, :eisdir} ->
+          mv(src, Path.join(dest, Path.basename(src)), callback)
+        {:error, :eexist} ->
+          if callback.(src, dest) do
+            _ = rm_rf(dest)
+            mv(src, dest)
+          else
+            {:error, :eexist}
+          end
+        other -> other
+      end
+    end
   end
 
   # Both src and dest are files.

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -398,11 +398,11 @@ defmodule File do
   It returns `:ok` in case of success, returns
   `{:error, reason}` otherwise
 
-  Note: current implementation allows you to copy a file to a directory
-   (and it will keep the same basename from the original file).  This
-   differs from erlang's base implementation
-   http://www.erlang.org/doc/man/file.html#rename-2
-   This functionality might change, as this is my first pull request
+  Note: we are following the erlang rename semantics and you are
+  unable to copy a file into directory, and instead must explicitly
+  set the destination file location.
+
+  http://www.erlang.org/doc/man/file.html#rename-2
   """
   @spec mv(Path.t, Path.t, (Path.t, Path.t -> boolean)) :: :ok | {:error, posix}
   def mv(source, destination, callback \\ fn(_, _) -> true end) do
@@ -587,18 +587,17 @@ defmodule File do
     if File.exists?(dest) && !callback.(src,dest) do
       {:error, :eexist}
     else
-      case F.rename(src, dest) do
-        {:error, :eisdir} ->
-          mv(src, Path.join(dest, Path.basename(src)), callback)
-        {:error, :eexist} ->
-          if callback.(src, dest) do
-            _ = rm_rf(dest)
-            mv(src, dest)
-          else
-            {:error, :eexist}
-          end
-        other -> other
-      end
+      F.rename(src, dest)
+      # case F.rename(src, dest) do
+      #   {:error, :eexist} ->
+      #     if callback.(src, dest) do
+      #       _ = rm_rf(dest)
+      #       mv(src, dest)
+      #     else
+      #       {:error, :eexist}
+      #     end
+      #   other -> other
+      # end
     end
   end
 

--- a/lib/elixir/test/elixir/test_helper.exs
+++ b/lib/elixir/test/elixir/test_helper.exs
@@ -13,6 +13,13 @@ defmodule PathHelpers do
     Path.expand("fixtures", __DIR__)
   end
 
+  def tmp_fixture_path(extra) do
+    src = fixture_path(extra)
+    dest = tmp_path(extra)
+    File.cp_r(src,dest)
+    dest
+  end
+
   def tmp_path() do
     Path.expand("../../tmp", __DIR__)
   end


### PR DESCRIPTION
--- first pull request, apologies for any naive mistakes ---

I am working on file sync application and noticed that File.mv (or rename) was not available.  Maybe it is (regardless it was good to dive into the edges of Elixir; still trying to wrap my head around quote / unquote :-))

The implementation delegates mostly to erlang's rename function; but I wanted to be able to 

mv /some/random/file.txt /some/other/dir

And if /some/other/dir was a dir then the resulting mv would be synonymous to 

mv /some/random/file.txt /some/other/dir/file.txt

There's a comment in the "cp" that leads me to believe this will probably be rejected in favour of being explicit; but I thought I would try.

"make test" passees, let me know what it will take to push this in and what I am doing incorrectly.