### PR TITLE
Fix exit signal race condition in logger tests

### DIFF
--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -351,6 +351,7 @@ defmodule Logger.TranslatorTest do
       trap = Process.flag(:trap_exit, true)
       Supervisor.start_link([worker(__MODULE__, [], [function: :error])],
         [strategy: :one_for_one])
+      receive do: ({:EXIT, _, {:shutdown, {:failed_to_start_child, _, _}}} -> :ok)
       Process.flag(:trap_exit, trap)
     end) =~ ~r"""
     \[error\] Child Logger.TranslatorTest of Supervisor #PID<\d+\.\d+\.\d+> \(Supervisor\.Default\) failed to start
@@ -364,6 +365,7 @@ defmodule Logger.TranslatorTest do
       trap = Process.flag(:trap_exit, true)
       Supervisor.start_link([worker(__MODULE__, [], [function: :undef])],
         [strategy: :one_for_one])
+      receive do: ({:EXIT, _, {:shutdown, {:failed_to_start_child, _, _}}} -> :ok)
       Process.flag(:trap_exit, trap)
     end) =~ ~r"""
     \[error\] Child Logger.TranslatorTest of Supervisor #PID<\d+\.\d+\.\d+> \(Supervisor\.Default\) failed to start


### PR DESCRIPTION
Test process must wait for exit signal before untrapping exits, otherwise exit signal may cause it to exit.

An example of this race condition: https://travis-ci.org/elixir-lang/elixir/jobs/33988884#L292
