### PR TITLE
Map backend config for Logger

### DIFF
--- a/lib/logger/lib/logger/config.ex
+++ b/lib/logger/lib/logger/config.ex
@@ -41,6 +41,15 @@ defmodule Logger.Config do
   end
 
   def translate_backend(:console), do: Logger.Backends.Console
+  def translate_backend(map_cfg) when is_map(map_cfg) do
+    mod = map_cfg.mod
+    case map_cfg[:id] do
+      nil ->
+        mod
+      id ->
+        {mod, id}
+    end
+  end
   def translate_backend(other),    do: other
 
   def __data__() do


### PR DESCRIPTION
I want to write a file backend for the Logger.  
The backend config of Logger is a litte verbose. I must define a ID for backend and then use it to find out the specific config.

with this patch, I can do this

```
config Logger,
  backends: [
    %{mod: FileBackend, id: :error_log,  file: "error.log", size: 1024},
    %{mod: FileBackend, id: :debug_log, file: "debug.log", size: 10240},
  ]
```
