### PR TITLE
Fix sigil_r and sigil_R Regex.t dialyzer warnings

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3439,7 +3439,7 @@ defmodule Kernel do
   defmacro sigil_r({:<<>>, _line, [string]}, options) when is_binary(string) do
     binary = Macro.unescape_string(string, fn(x) -> Regex.unescape_map(x) end)
     regex  = Regex.compile!(binary, :binary.list_to_bin(options))
-    Macro.escape(regex)
+    quote do: Regex.inline(unquote(Macro.escape(regex)))
   end
 
   defmacro sigil_r({:<<>>, line, pieces}, options) do
@@ -3459,7 +3459,7 @@ defmodule Kernel do
   """
   defmacro sigil_R({:<<>>, _line, [string]}, options) when is_binary(string) do
     regex = Regex.compile!(string, :binary.list_to_bin(options))
-    Macro.escape(regex)
+    quote do: Regex.inline(unquote(Macro.escape(regex)))
   end
 
   @doc ~S"""

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -611,6 +611,10 @@ defmodule Regex do
   def unescape_map(?a), do: ?\a
   def unescape_map(_),  do: false
 
+  @doc false
+  @spec inline(%__MODULE__{re_pattern: term, source: binary, opts: binary}) :: t
+  def inline(%Regex{} = regex), do: regex
+
   # Private Helpers
 
   defp translate_options(<<?u, t :: binary>>, acc), do: translate_options(t, [:unicode, :ucp|acc])

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -208,7 +208,7 @@ defmodule ExUnit.AssertionsTest do
     rescue
       error in [ExUnit.AssertionError] ->
         "foo" = error.left
-        ~r{a} = error.right
+        true = (~r{a} == error.right)
     end
   end
 
@@ -222,7 +222,7 @@ defmodule ExUnit.AssertionsTest do
     rescue
       error in [ExUnit.AssertionError] ->
         "foo" = error.left
-        ~r"o" = error.right
+        true = (~r"o" == error.right)
     end
   end
 


### PR DESCRIPTION
Fixes #2750

Matching on `sigil_r` and `sigil_R` will nolonger work (see test changes). I am unsure if this is a problem or not.
