### PR TITLE
Fix typos in Stream.transform/3 docs

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -612,7 +612,7 @@ defmodule Stream do
 
   ## Examples
 
-  `Stream.transform/3` is a useful as it can be used as basis to implement
+  `Stream.transform/3` is useful as it can be used as the basis to implement
   many of the functions defined in this module. For example, we can implement
   `Stream.take(enum, n)` as follows:
 


### PR DESCRIPTION
Seems to read better to me.

"`Stream.transform/3` is a useful as it can be used as basis to implement"

vs

"`Stream.transform/3` is useful as it can be used as the basis to implement"
