### PR TITLE
Improve UndefinedFunctionError

### DIFF
--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -85,11 +85,36 @@ do_compile(Line, Module, Block, Vars, E) ->
 
     Binary = load_form(Line, Final, compile_opts(Module), NE),
     {module, Module, Binary, Result}
+  catch
+    error:undef ->
+      case erlang:get_stacktrace() of
+        [{Module, Fun, Args, _Info} | _] = Stack when is_list(Args) ->
+          compile_undef(Module, Fun, length(Args), Stack);
+        [{Module, Fun, Arity, _Info} | _] = Stack ->
+          compile_undef(Module, Fun, Arity, Stack);
+        Stack ->
+          erlang:raise(error, undef, Stack)
+      end
   after
     elixir_locals:cleanup(Module),
     elixir_def:cleanup(Module),
     ets:delete(docs_table(Module)),
     ets:delete(data_table(Module))
+  end.
+
+%% An undef error for a function in the module being compiled might result in an
+%% exception message suggesting the current module is not loaded. This is
+%% misleading so use a custom reason.
+compile_undef(Module, Fun, Arity, Stack) ->
+  ExMod = 'Elixir.UndefinedFunctionError',
+  case code:is_loaded(ExMod) of
+    false ->
+      erlang:raise(error, undef, Stack);
+    _ ->
+      Opts = [{module, Module}, {function, Fun}, {arity, Arity},
+              {reason, 'function not available'}],
+      Exception = 'Elixir.UndefinedFunctionError':exception(Opts),
+      erlang:raise(error, Exception, Stack)
   end.
 
 %% Hook that builds both attribute and functions and set up common hooks.

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -400,7 +400,7 @@ defmodule Kernel.ErrorsTest do
 
   test :macro_with_undefined_local do
     assert_compile_fail UndefinedFunctionError,
-      "undefined function: ErrorsTest.unknown/1",
+      "undefined function: ErrorsTest.unknown/1 (function unknown/1 is not available from ErrorsTest)",
       '''
       defmodule ErrorsTest do
         defmacrop bar, do: unknown(1)
@@ -411,7 +411,7 @@ defmodule Kernel.ErrorsTest do
 
   test :private_macro do
     assert_compile_fail UndefinedFunctionError,
-      "undefined function: ErrorsTest.foo/0",
+      "undefined function: ErrorsTest.foo/0 (function foo/0 is not available from ErrorsTest)",
       '''
       defmodule ErrorsTest do
         defmacrop foo, do: 1

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -147,6 +147,22 @@ defmodule TaskTest do
            catch_exit(Task.await(task))
   end
 
+  test "await/1 exits on task undef module error" do
+    Process.flag(:trap_exit, true)
+    task = Task.async(&:module_does_not_exist.undef/0)
+    assert {{:undef, [{:module_does_not_exist, :undef, _, _} | _]},
+            {Task, :await, [^task, 5000]}} =
+           catch_exit(Task.await(task))
+  end
+
+  test "await/1 exits on task undef function error" do
+    Process.flag(:trap_exit, true)
+    task = Task.async(&TaskTest.undef/0)
+    assert {{:undef, [{TaskTest, :undef, _, _} | _]},
+            {Task, :await, [^task, 5000]}} =
+           catch_exit(Task.await(task))
+  end
+
   test "await/1 exits on task exit" do
     Process.flag(:trap_exit, true)
     task = Task.async(fn -> exit :unknown end)

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -284,7 +284,7 @@ defmodule IEx.HelpersTest do
   end
 
   test "r helper elixir" do
-    assert_raise UndefinedFunctionError, ~r"undefined function: Sample.run/0", fn ->
+    assert_raise UndefinedFunctionError, ~r"undefined function: Sample.run/0 \(module Sample is not available\)", fn ->
       Sample.run
     end
 


### PR DESCRIPTION
* Detect undefined errors for compiling modules
* Log undefined errors in Task's like other OTP processes
* Normalize undefined errors from OTP processes

It would be nice to add tests for the last two bullet points but wanted to check this is an acceptable approach first.