### PR TITLE
fix previous commit typo bug in bin/elixir

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -81,7 +81,7 @@ done
 SELF=$(readlink_f "$0")
 SCRIPT_PATH=$(dirname "$SELF")
 
-if [ "$OSTYPE" = "cygwin" ]; then SCRIPT_PATH=$(cygpath -m "SCRIPT_PATH"); fi
+if [ "$OSTYPE" = "cygwin" ]; then SCRIPT_PATH=$(cygpath -m "$SCRIPT_PATH"); fi
 if [ "$MODE" != "iex" ]; then ERL="-noshell -s elixir start_cli $ERL"; fi
 
 # Check for terminal support


### PR DESCRIPTION
#2670 There is a typo, `cygpath -m "SCRIPT_PATH"` missed a `$` .
