### PR TITLE
Default ports for WebSocket

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -15,6 +15,8 @@ defmodule URI do
     "ftp"   => 21,
     "http"  => 80,
     "https" => 443,
+    "ws"    => 80,
+    "wss"   => 443,
     "ldap"  => 389,
     "sftp"  => 22,
     "tftp"  => 69,


### PR DESCRIPTION
Added default ports for WebSocket according to http://tools.ietf.org/html/rfc6455#section-3
