### PR TITLE
System.cmd path resolution

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -437,7 +437,7 @@ defmodule System do
       if Path.type(command) == :absolute do
         command
       else
-        :os.find_executable(command) || command
+        :os.find_executable(command)
       end
 
     {into, opts} = cmd_opts(opts, [:use_stdio, :exit_status, :binary, :hide, args: args], "")

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -69,10 +69,11 @@ defmodule SystemTest do
     with_tmp_dir(fn dir ->
       new_path = Path.join([dir, "echo2"])
       File.cp!(System.find_executable("echo"), new_path)
-      assert {"hello\n", 0} = System.cmd(new_path, ["hello"])
+      assert :enoent = catch_error(System.cmd(new_path, ["hello"]))
 
       File.cd!(dir)
-      assert {"hello\n", 0} = System.cmd("echo2", ["hello"])
+      assert :enoent = catch_error(System.cmd("echo2", ["hello"]))
+      assert {"hello\n", 0} = System.cmd(Path.join([System.cwd, "echo2"]), ["hello"])
     end)
   end
 


### PR DESCRIPTION
The way `System.cmd` finds executables right now does not match the description in the docs.

This PR has 3 commits.
1. In the first commit I simply added tests for the current behaviour.
2. In the second commit I have changed the implementation to match the docs.
3. In the third commit I have proposed a new way for `System.cmd` to look for executables.

The reason I'm proposing a breaking change is because the proposed behaviour matches how shells find executables. It also resolves the issue of passing relative paths as commands: according to current docs it should result in an error (or it can be interpreted as unspecified behaviour which is not good either).
