### PR TITLE
Move application state out of application env

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -325,7 +325,7 @@ defmodule Code do
   Check `compiler_options/1` for more information.
   """
   def compiler_options do
-    :elixir_code_server.call :compiler_options
+    :elixir_config.get :compiler_options
   end
 
   @doc """
@@ -364,7 +364,8 @@ defmodule Code do
       bad = bad |> Keyword.keys |> Enum.join(", ")
       raise ArgumentError, message: "unknown compiler options: #{bad}"
     end
-    :elixir_code_server.cast {:compiler_options, opts}
+    update = &:orddict.merge(fn(_, _, value) -> value end, &1, opts)
+    :elixir_config.update :compiler_options, update
   end
 
   @doc """

--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -56,7 +56,7 @@ defmodule Kernel.CLI do
   ## Helpers
 
   defp at_exit(res) do
-    hooks = :elixir_code_server.call(:flush_at_exit)
+    hooks = :elixir_config.get_and_put(:at_exit, [])
     res = Enum.reduce(hooks, res, &exec_fun/2)
     if hooks == [], do: res, else: at_exit(res)
   end

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -72,7 +72,7 @@ defmodule System do
   """
   @spec argv() :: [String.t]
   def argv do
-    :elixir_code_server.call :argv
+    :elixir_config.get(:argv)
   end
 
   @doc """
@@ -83,7 +83,7 @@ defmodule System do
   """
   @spec argv([String.t]) :: :ok
   def argv(args) do
-    :elixir_code_server.cast({:argv, args})
+    :elixir_config.put(:argv, args)
   end
 
   @doc """
@@ -224,7 +224,7 @@ defmodule System do
   The function must receive the exit status code as an argument.
   """
   def at_exit(fun) when is_function(fun, 1) do
-    :elixir_code_server.cast {:at_exit, fun}
+    :elixir_config.update :at_exit, &[fun|&1]
   end
 
   @doc """

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -11,18 +11,17 @@ defmodule URI do
 
   import Bitwise
 
-  @ports %{
-    "ftp"   => 21,
-    "http"  => 80,
-    "https" => 443,
-    "ldap"  => 389,
-    "sftp"  => 22,
-    "tftp"  => 69,
-  }
+  @schemes [
+    "ftp",
+    "http",
+    "https",
+    "ldap",
+    "sftp",
+    "tftp",
+  ]
 
-  Enum.each @ports, fn {scheme, port} ->
+  Enum.each @schemes, fn scheme ->
     def normalize_scheme(unquote(scheme)), do: unquote(scheme)
-    def default_port(unquote(scheme)),     do: unquote(port)
   end
 
   @doc """
@@ -47,8 +46,7 @@ defmodule URI do
 
   """
   def default_port(scheme) when is_binary(scheme) do
-    {:ok, dict} = Application.fetch_env(:elixir, :uri)
-    Map.get(dict, scheme)
+    :elixir_config.get({:uri, scheme})
   end
 
   @doc """
@@ -59,8 +57,7 @@ defmodule URI do
   new URIs.
   """
   def default_port(scheme, port) when is_binary(scheme) and port > 0 do
-    {:ok, dict} = Application.fetch_env(:elixir, :uri)
-    Application.put_env(:elixir, :uri, Map.put(dict, scheme, port), persistent: true)
+    :elixir_config.put({:uri, scheme}, port)
   end
 
   @doc """

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -42,10 +42,29 @@ start(_Type, _Args) ->
       ok
   end,
 
-  elixir_sup:start_link().
+  URIs = [{<<"ftp">>, 21},
+          {<<"sftp">>, 22},
+          {<<"tftp">>, 69},
+          {<<"http">>, 80},
+          {<<"https">>, 443},
+          {<<"ldap">>, 389}],
+  URIConfig = [{{uri, Scheme}, Port} || {Scheme, Port} <- URIs],
+  CompilerOpts = [{docs,true},{debug_info,true},{warnings_as_errors,false}],
+  Config = [{at_exit, []},
+            {compiler_options, orddict:from_list(CompilerOpts)}
+            | URIConfig],
+  Tab = elixir_config:new(Config),
+  case elixir_sup:start_link() of
+    {ok, Sup} ->
+      {ok, Sup, Tab};
+    {error, _Reason} = Error ->
+      elixir_config:delete(Tab),
+      Error
+  end.
 
-stop(_S) ->
-  ok.
+stop(Tab) ->
+  elixir_config:delete(Tab).
+
 
 config_change(_Changed, _New, _Remove) ->
   ok.

--- a/lib/elixir/src/elixir_code_server.erl
+++ b/lib/elixir/src/elixir_code_server.erl
@@ -6,15 +6,11 @@
 
 -define(timeout, 30000).
 -record(elixir_code_server, {
-  argv=[],
   loaded=[],
-  at_exit=[],
   paths={[],[]},
   mod_pool={[],0},
   mod_ets=dict:new(),
-  compilation_status=[],
-  compiler_options=[{docs,true},{debug_info,true},{warnings_as_errors,false}],
-  erl_compiler_options=nil
+  compilation_status=[]
 }).
 
 call(Args) ->
@@ -61,18 +57,6 @@ handle_call({acquire, Path}, From, Config) ->
 handle_call(loaded, _From, Config) ->
   {reply, [F || {F, true} <- Config#elixir_code_server.loaded], Config};
 
-handle_call(at_exit, _From, Config) ->
-  {reply, Config#elixir_code_server.at_exit, Config};
-
-handle_call(flush_at_exit, _From, Config) ->
-  {reply, Config#elixir_code_server.at_exit, Config#elixir_code_server{at_exit=[]}};
-
-handle_call(argv, _From, Config) ->
-  {reply, Config#elixir_code_server.argv, Config};
-
-handle_call(compiler_options, _From, Config) ->
-  {reply, Config#elixir_code_server.compiler_options, Config};
-
 handle_call({compilation_status, CompilerPid}, _From, Config) ->
   CompilationStatusList    = Config#elixir_code_server.compilation_status,
   CompilationStatusListNew = orddict:erase(CompilerPid, CompilationStatusList),
@@ -88,35 +72,17 @@ handle_call(retrieve_module_name, _From, Config) ->
       {reply, module_tuple(Counter), Config#elixir_code_server{mod_pool={[],Counter+1}}}
   end;
 
-handle_call(erl_compiler_options, _From, Config) ->
-  case Config#elixir_code_server.erl_compiler_options of
-    nil ->
-      Opts = erl_compiler_options(),
-      {reply, Opts, Config#elixir_code_server{erl_compiler_options=Opts}};
-    Opts ->
-      {reply, Opts, Config}
-  end;
-
 handle_call(paths, _From, Config) ->
   {reply, Config#elixir_code_server.paths, Config};
 
 handle_call(Request, _From, Config) ->
   {stop, {badcall, Request}, Config}.
 
-handle_cast({at_exit, AtExit}, Config) ->
-  {noreply, Config#elixir_code_server{at_exit=[AtExit|Config#elixir_code_server.at_exit]}};
-
-handle_cast({argv, Argv}, Config) ->
-  {noreply, Config#elixir_code_server{argv=Argv}};
-
-handle_cast({compiler_options, Options}, Config) ->
-  Final = orddict:merge(fun(_,_,V) -> V end, Config#elixir_code_server.compiler_options, Options),
-  {noreply, Config#elixir_code_server{compiler_options=Final}};
-
 handle_cast({register_warning, CompilerPid}, Config) ->
   CompilationStatusCurrent = Config#elixir_code_server.compilation_status,
   CompilationStatusNew     = orddict:store(CompilerPid, error, CompilationStatusCurrent),
-  case orddict:find(warnings_as_errors, Config#elixir_code_server.compiler_options) of
+  CompilerOptions          = elixir_config:get(compiler_options),
+  case orddict:find(warnings_as_errors, CompilerOptions) of
     {ok, true} -> {noreply, Config#elixir_code_server{compilation_status=CompilationStatusNew}};
     _ -> {noreply, Config}
   end;
@@ -182,24 +148,4 @@ undefmodule(Ref, #elixir_code_server{mod_ets=ModEts} = Config) ->
       Config#elixir_code_server{mod_ets=dict:erase(Ref, ModEts)};
     error ->
       Config
-  end.
-
-erl_compiler_options() ->
-  Key = "ERL_COMPILER_OPTIONS",
-  case os:getenv(Key) of
-    false -> [];
-    Str when is_list(Str) ->
-      case erl_scan:string(Str) of
-        {ok,Tokens,_} ->
-          case erl_parse:parse_term(Tokens ++ [{dot, 1}]) of
-            {ok,List} when is_list(List) -> List;
-            {ok,Term} -> [Term];
-            {error,_Reason} ->
-              io:format("Ignoring bad term in ~ts\n", [Key]),
-              []
-          end;
-        {error, {_,_,_Reason}, _} ->
-          io:format("Ignoring bad term in ~ts\n", [Key]),
-          []
-      end
   end.

--- a/lib/elixir/src/elixir_config.erl
+++ b/lib/elixir/src/elixir_config.erl
@@ -1,0 +1,65 @@
+-module(elixir_config).
+-compile({no_auto_import, [get/1]}).
+-export([new/1, delete/1, put/2, get/1, update/2, get_and_put/2]).
+-export([start_link/0, init/1, handle_call/3, handle_cast/2,
+  handle_info/2, code_change/3, terminate/2]).
+-behaviour(gen_server).
+
+%% public api
+
+new(Opts) ->
+  Tab = ets:new(?MODULE, [named_table, public, {read_concurrency, true}]),
+  true = ets:insert_new(?MODULE, Opts),
+  Tab.
+
+delete(?MODULE) ->
+  ets:delete(?MODULE).
+
+put(Key, Value) ->
+  gen_server:call(?MODULE, {put, Key, Value}).
+
+get(Key) ->
+  case ets:lookup(?MODULE, Key) of
+    [{_, Value}] -> Value;
+    []          -> nil
+  end.
+
+update(Key, Fun) ->
+  gen_server:call(?MODULE, {update, Key, Fun}).
+
+get_and_put(Key, Value) ->
+  gen_server:call(?MODULE, {get_and_put, Key, Value}).
+
+start_link() ->
+  gen_server:start_link({local, ?MODULE}, ?MODULE, ?MODULE, []).
+
+%% gen_server api
+
+init(Tab) ->
+  %% Ets table must be writable
+  public = ets:info(Tab, protection),
+  {ok, Tab}.
+
+handle_call({put, Key, Value}, _From, Tab) ->
+  ets:insert(Tab, {Key, Value}),
+  {reply, ok, Tab};
+handle_call({update, Key, Fun}, _From, Tab) ->
+  Value = Fun(get(Key)),
+  ets:insert(Tab, {Key, Value}),
+  {reply, Value, Tab};
+handle_call({get_and_put, Key, Value}, _From, Tab) ->
+  OldValue = get(Key),
+  ets:insert(Tab, {Key, Value}),
+  {reply, OldValue, Tab}.
+
+handle_cast(Cast, Tab) ->
+  {stop, {bad_cast, Cast}, Tab}.
+
+handle_info(_Msg, Tab) ->
+  {noreply, Tab}.
+
+code_change(_OldVsn, Tab, _Extra) ->
+  {ok, Tab}.
+
+terminate(_Reason, _Tab) ->
+  ok.

--- a/lib/elixir/src/elixir_sup.erl
+++ b/lib/elixir/src/elixir_sup.erl
@@ -8,6 +8,16 @@ start_link() ->
 init(ok) ->
   Workers = [
     {
+      elixir_config,
+      {elixir_config, start_link, []},
+
+      permanent,                    % Restart  = permanent | transient | temporary
+      2000,                         % Shutdown = brutal_kill | int() >= 0 | infinity
+      worker,                       % Type     = worker | supervisor
+      [elixir_config]               % Modules  = [Module] | dynamic
+   },
+
+    {
       elixir_code_server,
       {elixir_code_server, start_link, []},
 

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -142,8 +142,14 @@ defmodule URITest do
 
   test :default_port do
     assert URI.default_port("http") == 80
-    assert URI.default_port("unknown") == nil
+    try do
+      URI.default_port("http", 8000)
+      assert URI.default_port("http") == 8000
+    after
+      URI.default_port("http", 80)
+    end
 
+    assert URI.default_port("unknown") == nil
     URI.default_port("unknown", 13)
     assert URI.default_port("unknown") == 13
   end

--- a/lib/iex/lib/iex/app.ex
+++ b/lib/iex/lib/iex/app.ex
@@ -1,0 +1,25 @@
+defmodule IEx.App do
+  @moduledoc false
+
+  use Application
+
+  def start(_type, _args) do
+    import Supervisor.Spec
+
+    children = [worker(IEx.Config, [])]
+    options = [strategy: :one_for_one, name: IEx.Supervisor]
+
+    tab = IEx.Config.new()
+    case Supervisor.start_link(children, options) do
+      {:ok, pid} ->
+        {:ok, pid, tab}
+      {:error, _} = error ->
+        IEx.Config.delete(tab)
+        error
+    end
+  end
+
+  def stop(tab) do
+    IEx.Config.delete(tab)
+  end
+end

--- a/lib/iex/lib/iex/cli.ex
+++ b/lib/iex/lib/iex/cli.ex
@@ -96,7 +96,7 @@ defmodule IEx.CLI do
   end
 
   def local_start do
-    IEx.start(config(), {:elixir, :start_cli, []})
+    IEx.start(options(), {:elixir, :start_cli, []})
   end
 
   def remote_start(parent, ref) do
@@ -110,7 +110,7 @@ defmodule IEx.CLI do
 
   defp remote_start_function do
     ref    = make_ref
-    config = config()
+    opts = options()
 
     parent = spawn_link fn ->
       receive do
@@ -121,11 +121,11 @@ defmodule IEx.CLI do
     end
 
     fn ->
-      IEx.start(config, {__MODULE__, :remote_start, [parent, ref]})
+      IEx.start(opts, {__MODULE__, :remote_start, [parent, ref]})
     end
   end
 
-  defp config do
+  defp options do
     [dot_iex_path: find_dot_iex(:init.get_plain_arguments)]
   end
 

--- a/lib/iex/lib/iex/config.ex
+++ b/lib/iex/lib/iex/config.ex
@@ -1,0 +1,184 @@
+defmodule IEx.Config do
+  @moduledoc false
+
+  @table __MODULE__
+  @agent __MODULE__
+  @keys [:colors, :inspect, :history_size, :default_prompt, :alive_prompt]
+  @colors [:eval_interrupt, :eval_result, :eval_error, :eval_info, :stack_app,
+    :stack_info, :ls_directory, :ls_device]
+
+  def new() do
+    tab = :ets.new(@table, [:named_table, :public])
+    true = :ets.insert_new(tab, [after_spawn: []])
+    tab
+  end
+
+  def delete(__MODULE__) do
+    :ets.delete(__MODULE__)
+  end
+
+  def configure(options) do
+    Agent.update(@agent, __MODULE__, :handle_configure, [options])
+  end
+
+  def handle_configure(tab, options) do
+    options = :lists.ukeysort(1, options)
+    get_config()
+    |> Keyword.merge(options, &merge_option/3)
+    |> put_config()
+    tab
+  end
+
+  defp get_config() do
+    Application.get_all_env(:iex)
+    |> Keyword.take(@keys)
+  end
+
+  defp put_config(config) do
+    put = fn({key, value}) when key in @keys ->
+      Application.put_env(:iex, key, value)
+    end
+    Enum.each(config, put)
+  end
+
+  defp merge_option(:colors, old, new) when is_list(new), do: Keyword.merge(old, new)
+  defp merge_option(:inspect, old, new) when is_list(new), do: Keyword.merge(old, new)
+  defp merge_option(:history_size, _old, new) when is_integer(new), do: new
+  defp merge_option(:default_prompt, _old, new) when is_binary(new), do: new
+  defp merge_option(:alive_prompt, _old, new) when is_binary(new), do: new
+
+  defp merge_option(k, _old, new) do
+    raise ArgumentError, "invalid configuration or value for pair #{inspect k} - #{inspect new}"
+  end
+
+  def configuration() do
+    Keyword.merge(default_config(), get_config(), &merge_option/3)
+  end
+
+  defp default_config() do
+    Enum.map(@keys, &{&1, default_option(&1)})
+  end
+
+  defp default_option(:colors), do: [{:enabled, IO.ANSI.enabled?} | default_colors()]
+  defp default_option(:inspect), do: []
+  defp default_option(:history_size), do: 20
+
+  defp default_option(prompt) when prompt in [:default_prompt, :alive_prompt] do
+    "%prefix(%counter)>"
+  end
+
+  defp default_colors() do
+    Enum.map(@colors, &{&1, default_color(&1)}) ++ default_doc_colors()
+  end
+
+  defp default_doc_colors() do
+    Keyword.drop(IO.ANSI.Docs.default_options(), [:enabled, :width])
+  end
+
+  # Used by default on evaluation cycle
+  defp default_color(:eval_interrupt), do: [:yellow]
+  defp default_color(:eval_result), do: [:yellow]
+  defp default_color(:eval_error), do: [:red]
+  defp default_color(:eval_info), do: [:normal]
+  defp default_color(:stack_app), do: [:red, :bright]
+  defp default_color(:stack_info), do: [:red]
+
+  # Used by ls
+  defp default_color(:ls_directory), do: [:blue]
+  defp default_color(:ls_device), do: [:green]
+
+  # Used by ansi docs
+  defp default_color(doc_color) do
+    IO.ANSI.Docs.default_options()
+    |> Keyword.fetch!(doc_color)
+  end
+
+  def color(color) do
+    colors = Application.get_env(:iex, :colors, [])
+    if colors_enabled?(colors) do
+      case Keyword.fetch(colors, color) do
+        {:ok, value} ->
+          value
+        :error ->
+          default_color(color)
+      end
+    else
+      nil
+    end
+  end
+
+  defp colors_enabled?(colors \\ Application.get_env(:iex, :colors, [])) do
+    case Keyword.fetch(colors, :enabled) do
+      {:ok, enabled} ->
+        enabled
+      :error ->
+        IO.ANSI.enabled?()
+    end
+  end
+
+  def ansi_docs() do
+    colors = Application.get_env(:iex, :colors, [])
+    if enabled = colors_enabled?(colors) do
+      [width: width(), enabled: enabled] ++ colors
+    end
+  end
+
+  def inspect_opts() do
+    inspect_options = Application.get_env(:iex, :inspect, []) ++ [pretty: true]
+    cond do
+      Keyword.has_key?(inspect_options, :width) ->
+        inspect_options
+      colors_enabled? ->
+        [width: width()] ++ inspect_options
+      true ->
+        inspect_options
+    end
+  end
+
+  def width() do
+    case :io.columns() do
+      {:ok, width} -> min(width, 80)
+      {:error, _}  -> 80
+    end
+  end
+
+  def after_spawn(fun) do
+    Agent.update(@agent, __MODULE__, :handle_after_spawn, [fun])
+  end
+
+  def handle_after_spawn(tab, fun) do
+    :ets.update_element(tab, :after_spawn, {2, [fun | after_spawn()]})
+  end
+
+  def after_spawn() do
+    :ets.lookup_element(@table, :after_spawn, 2)
+  end
+
+  def started?() do
+    Process.whereis(@agent) !== nil
+  end
+
+  def history_size(), do: get(:history_size)
+
+  def default_prompt(), do: get(:default_prompt)
+
+  def alive_prompt(), do: get(:alive_prompt)
+
+  defp get(key) do
+    case Application.fetch_env(:iex, key) do
+      {:ok, value} ->
+        value
+      :error ->
+        default_option(key)
+    end
+  end
+
+  def start_link() do
+    Agent.start_link(__MODULE__, :init, [@table], [name: @agent])
+  end
+
+  def init(tab) do
+    :public = :ets.info(tab, :protection)
+    tab
+  end
+end

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -175,14 +175,8 @@ defmodule IEx.Introspection do
   end
 
   defp ansi_docs() do
-    opts = Application.get_env(:iex, :colors)
-    if color_enabled?(opts[:enabled]) do
-      [width: IEx.width] ++ opts
-    end
+    IEx.Config.ansi_docs()
   end
-
-  defp color_enabled?(nil), do: IO.ANSI.enabled?
-  defp color_enabled?(bool) when is_boolean(bool), do: bool
 
   @doc """
   Print types in module.

--- a/lib/iex/mix.exs
+++ b/lib/iex/mix.exs
@@ -8,8 +8,9 @@ defmodule IEx.Mixfile do
   end
 
   def application do
-    [env: [
-       after_spawn: [],
+    [registered: [IEx.Supervisor, IEx.Config],
+     mod: {IEx.App, []},
+     env: [
        colors: [],
        inspect: [],
        history_size: 20,

--- a/lib/iex/test/test_helper.exs
+++ b/lib/iex/test/test_helper.exs
@@ -1,5 +1,5 @@
-Application.start(:iex)
-Application.put_env(:iex, :colors, [enabled: false])
+:ok = Application.start(:iex)
+IEx.configure([colors: [enabled: false]])
 ExUnit.start [trace: "--trace" in System.argv]
 
 defmodule IEx.Case do
@@ -31,11 +31,13 @@ defmodule IEx.Case do
     end
   end
 
+  @iex_app_env [:default_prompt, :alive_prompt, :inspect, :colors, :history_size]
   setup do
-    opts = IEx.configuration |>
-           Keyword.take([:default_prompt, :alive_prompt, :inspect, :colors, :history_size])
+    opts = Application.get_all_env(:iex)
+           |> Keyword.take(@iex_app_env)
     on_exit fn ->
-      Enum.each opts, fn {k, v} -> Application.put_env(:iex, k, v) end
+      Enum.each @iex_app_env, fn k -> Application.delete_env(:iex, k) end
+      IEx.configure(opts)
     end
     :ok
   end

--- a/lib/logger/lib/logger/app.ex
+++ b/lib/logger/lib/logger/app.ex
@@ -21,49 +21,59 @@ defmodule Logger.App do
                     {otp_reports?, sasl_reports?, threshold}, :link],
                   [id: Logger.ErrorHandler, function: :watcher])]
 
+    config = Logger.Config.new()
+
     case Supervisor.start_link(children, options) do
-      {:ok, _} = ok ->
-        deleted = delete_error_logger_handler(otp_reports?, :error_logger_tty_h, [])
-        deleted = delete_error_logger_handler(sasl_reports?, :sasl_report_tty_h, deleted)
-        store_deleted_handlers(deleted)
-        ok
+      {:ok, sup} ->
+        handlers = [error_logger_tty_h: otp_reports?,
+                    sasl_logger_tty_h: sasl_reports?]
+        delete_handlers(handlers)
+        {:ok, sup, config}
       {:error, _} = error ->
+        Logger.Config.delete(config)
         error
     end
   end
 
   @doc false
-  def stop(_) do
-    Application.get_env(:logger, :deleted_handlers)
-    |> Enum.each(&:error_logger.add_report_handler/1)
+  def stop(config) do
+    Logger.Config.deleted_handlers()
+    |> add_handlers()
+    Logger.Config.delete(config)
+  end
 
-    # We need to do this in another process as the Application
-    # Controller is currently blocked shutting down this app.
-    spawn_link(fn -> Logger.Config.clear_data end)
-
-    :ok
+  @doc false
+  def config_change(_changed, _new, _removed) do
+    Logger.Config.configure([])
   end
 
   @doc """
   Stops the application without sending messages to error logger.
   """
   def stop() do
-    set = Application.get_env(:logger, :deleted_handlers)
-    Application.put_env(:logger, :deleted_handlers, HashSet.new)
-    _ = Application.stop(:logger)
-    Enum.each(set, &:error_logger.add_report_handler/1)
-  end
-
-  defp store_deleted_handlers(list) do
-    Application.put_env(:logger, :deleted_handlers, Enum.into(list, HashSet.new))
-  end
-
-  defp delete_error_logger_handler(should_delete?, handler, deleted) do
-    if should_delete? and
-        :error_logger.delete_report_handler(handler) != {:error, :module_not_found} do
-      [handler|deleted]
+    try do
+      Logger.Config.deleted_handlers([])
+    catch
+      :exit, {:noproc, _} ->
+        {:error, {:not_started, :logger}}
     else
-      deleted
+      deleted_handlers ->
+        result = Application.stop(:logger)
+        add_handlers(deleted_handlers)
+        result
     end
+  end
+
+  defp delete_handlers(handlers) do
+    deleted? = fn({handler, delete?}) ->
+        delete? && :error_logger.delete_report_handler(handler) != {:error, :module_not_found}
+      end
+    [] = Enum.filter_map(handlers, deleted?, fn({handler, _}) -> handler end)
+        |> Logger.Config.deleted_handlers()
+    :ok
+  end
+
+  defp add_handlers(handlers) do
+    Enum.each(handlers, &:error_logger.add_report_handler/1)
   end
 end

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -234,4 +234,15 @@ defmodule LoggerTest do
     wait_for_handler(Logger, Logger.Config)
     wait_for_handler(:error_logger, Logger.ErrorHandler)
   end
+
+  test "Logger.Config updates config on config_change/3" do
+    :ok = Logger.configure([level: :debug])
+    try do
+      Application.put_env(:logger, :level, :error)
+      assert Logger.App.config_change([level: :error], [], []) === :ok
+      assert Logger.level() === :error
+    after
+      Logger.configure([level: :debug])
+    end
+  end
 end

--- a/lib/mix/lib/mix/remote_converger.ex
+++ b/lib/mix/lib/mix/remote_converger.ex
@@ -30,13 +30,13 @@ defmodule Mix.RemoteConverger do
   Get registered remote converger.
   """
   def get do
-    Application.get_env(:mix, :remote_converger)
+    Mix.State.get(:remote_converger)
   end
 
   @doc """
   Register a remote converger.
   """
   def register(mod) when is_atom(mod) do
-    Application.put_env(:mix, :remote_converger, mod)
+    Mix.State.put(:remote_converger, mod)
   end
 end

--- a/lib/mix/lib/mix/scm.ex
+++ b/lib/mix/lib/mix/scm.ex
@@ -116,7 +116,7 @@ defmodule Mix.SCM do
   until a matching one is found.
   """
   def available do
-    {:ok, scm} = Application.fetch_env(:mix, :scm)
+    {:ok, scm} = Mix.State.fetch(:scm)
     scm
   end
 
@@ -124,15 +124,13 @@ defmodule Mix.SCM do
   Prepend the given SCM module to the list of available SCMs.
   """
   def prepend(mod) when is_atom(mod) do
-    available = Enum.reject(available(), &(&1 == mod))
-    Application.put_env(:mix, :scm, [mod|available])
+    Mix.State.prepend(:scm, mod)
   end
 
   @doc """
   Append the given SCM module to the list of available SCMs.
   """
   def append(mod) when is_atom(mod) do
-    available = Enum.reject(available(), &(&1 == mod))
-    Application.put_env(:mix, :scm, available ++ [mod])
+    Mix.State.append(:scm, mod)
   end
 end

--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -163,12 +163,12 @@ defmodule Mix.SCM.Git do
   end
 
   defp assert_git do
-    case Application.fetch_env(:mix, :git_available) do
+    case Mix.State.fetch(:git_available) do
       {:ok, true} ->
         :ok
       :error ->
         if :os.find_executable('git') do
-          Application.put_env(:mix, :git_available, true)
+          Mix.State.put(:git_available, true)
         else
           Mix.raise "Error fetching/updating Git repository: the `git` "  <>
             "executable is not available in your PATH. Please install "   <>
@@ -179,7 +179,7 @@ defmodule Mix.SCM.Git do
   end
 
   defp git_version do
-    case Application.fetch_env(:mix, :git_version) do
+    case Mix.State.fetch(:git_version) do
       {:ok, version} ->
         version
       :error ->
@@ -189,7 +189,7 @@ defmodule Mix.SCM.Git do
           |> String.strip
           |> parse_version
 
-        Application.put_env(:mix, :git_version, version)
+        Mix.State.put(:git_version, version)
         version
     end
   end

--- a/lib/mix/lib/mix/state.ex
+++ b/lib/mix/lib/mix/state.ex
@@ -1,0 +1,79 @@
+defmodule Mix.State do
+  @moduledoc false
+
+  @table __MODULE__
+  @agent __MODULE__
+
+  def new(state) do
+    tab = :ets.new(@table, [:named_table, :public])
+    true = :ets.insert_new(@table, state)
+    tab
+  end
+
+  def delete(@table = tab) do
+    :ets.delete(tab)
+  end
+
+  def start_link(tab) do
+    Agent.start_link(__MODULE__, :init, [tab], [name: @agent])
+  end
+
+  def init(@table = tab) do
+    case :ets.info(tab, :protection) do
+      :public ->
+        tab
+      :undefined ->
+        raise "#{tab} does not exist"
+      _ ->
+        raise "#{tab} is not public"
+    end
+  end
+
+  def fetch(key) do
+    case :ets.lookup(@table, key) do
+      [{_, value}] ->
+        {:ok, value}
+      [] ->
+        :error
+    end
+  end
+
+  def get(key, default \\ nil) do
+    case fetch(key) do
+      {:ok, value} -> value
+      :error       -> default
+    end
+  end
+
+  def put(key, value) do
+    Agent.update(@agent, __MODULE__, :handle_put, [key, value])
+  end
+
+  def handle_put(tab, key, value) do
+    true = :ets.insert(tab, {key, value})
+    tab
+  end
+
+  def prepend(key, value) do
+    Agent.update(@agent, __MODULE__, :handle_prepend, [key, value])
+  end
+
+  def handle_prepend(tab, key, value) do
+    true = :ets.insert(tab, {key, [value | reject(key, value)]})
+    tab
+  end
+
+  def append(key, value) do
+    Agent.update(@agent, __MODULE__, :handle_append, [key, value])
+  end
+
+  def handle_append(tab, key, value) do
+    true = :ets.insert(tab, {key, reject(key, value) ++ [value]})
+    tab
+  end
+
+  defp reject(key, value) do
+    {:ok, list} = fetch(key)
+    Enum.reject(list, &(&1 === value))
+  end
+end

--- a/lib/mix/mix.exs
+++ b/lib/mix/mix.exs
@@ -9,11 +9,8 @@ defmodule Mix.Mixfile do
   end
 
   def application do
-    [registered: [Mix.TasksServer, Mix.ProjectStack],
+    [registered: [Mix.State, Mix.TasksServer, Mix.ProjectStack],
      mod: {Mix, []},
-     env: [shell: Mix.Shell.IO,
-           env: :dev,
-           scm: [Mix.SCM.Git, Mix.SCM.Path],
-           colors: []]]
+     env: [colors: []]]
   end
 end

--- a/lib/mix/test/mix/rebar_test.exs
+++ b/lib/mix/test/mix/rebar_test.exs
@@ -18,8 +18,8 @@ defmodule Mix.RebarTest do
 
   setup do
     available = Mix.SCM.available
-    Application.put_env(:mix, :scm, [Mix.SCM.Git, MyPath])
-    on_exit fn -> Application.put_env(:mix, :scm, available) end
+    Mix.State.put(:scm, [Mix.SCM.Git, MyPath])
+    on_exit fn -> Mix.State.put(:scm, available) end
     :ok
   end
 

--- a/lib/mix/test/mix/scm_test.exs
+++ b/lib/mix/test/mix/scm_test.exs
@@ -5,7 +5,7 @@ defmodule Mix.SCMTest do
 
   setup do
     available = Mix.SCM.available
-    on_exit fn -> Application.put_env(:mix, :scm, available) end
+    on_exit fn -> Mix.State.put(:scm, available) end
     :ok
   end
 

--- a/src/elixir.app.src
+++ b/src/elixir.app.src
@@ -4,8 +4,8 @@
  {modules, [
 	elixir
   ]},
- {registered, [elixir_code_server]},
+ {registered, [elixir_config, elixir_code_server]},
  {applications, [kernel,stdlib,crypto,compiler,syntax_tools]},
  {mod, {elixir,[]}},
- {env, [{uri, #{}},{ansi_enabled, false}]}
+ {env, [{ansi_enabled, false}]}
 ]}.


### PR DESCRIPTION
* Moves application state (that was not configuration or documented) from application env to separate ets tables for Elixir, IEx and Logger.
* Changes how IEx configuration works behind the scenes so that `config_change` causes a merge of config rather than overwrite. This also fixes potential race conditions where two process could configure IEx at the same time. If an application previously abused how IEx used to work behind the scenes it will nolonger work unless setting the config in config.exs when it will work.

Fixes #2779 for those on `1.0`.

Note this does not change Elixir's `ansi_enabled` getting turned to `false` or Logger's runtime configuration resetting on config_change (relup). These should be set in config.exs for a release. If these are set/changed in the config.exs between relups the changes will be reflected when downgrading/upgrading automatically. This is the correct behaviour.

/cc @bitwalker, @scrogson, @chvanikoff