### PR TITLE
 Add OTP 17.3 to run on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ notifications:
 otp_release:
   - 17.0
   - 17.1
+  - 17.3


### PR DESCRIPTION
http://blog.travis-ci.com/2014-10-08-october-2014-build-environment-update/
