### PR TITLE
set null prompt function in dumb term mode

### DIFF
--- a/lib/iex/lib/iex/cli.ex
+++ b/lib/iex/lib/iex/cli.ex
@@ -53,12 +53,17 @@ defmodule IEx.CLI do
     if tty_works? do
       :user_drv.start([:"tty_sl -c -e", tty_args])
     else
-      :user.start
+      :application.set_env(:stdlib, :shell_prompt_func, 
+                           {__MODULE__, :prompt})
+      :user.start()
       unless match? {:win32, _}, :os.type do
         IO.puts "Warning: could not run smart terminal, falling back to dumb one"
       end
       local_start()
     end
+  end
+  def prompt(_n) do
+    []
   end
 
   # Check if tty works. If it does not, we fall back to the


### PR DESCRIPTION
The erl prompt is displayed when I start iex with dumb terminal mode.
I evaded it by changing a default prompt function of erlang.

before:
bash-3.2$ TERM=DUMB bin/iex
Warning: could not run smart terminal, falling back to dumb one
Eshell V6.2  (abort with ^G)
1> 1> 1> 1> Interactive Elixir (1.1.0-dev) - press Ctrl+C to exit (type h() ENT\
ER for help)
1> iex(1)> 1> 
after:
bash-3.2$ env TERM=DUMB bin/iex
Warning: could not run smart terminal, falling back to dumb one
Eshell V6.2  (abort with ^G)
Interactive Elixir (1.1.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> 
