### PR TITLE
fix escaped terminators in sigil

### DIFF
--- a/lib/elixir/src/elixir_interpolation.erl
+++ b/lib/elixir/src/elixir_interpolation.erl
@@ -33,6 +33,9 @@ extract(Line, Scope, Interpol, [$\\, $\r, $\n|Rest], Buffer, Output, Last) ->
 extract(Line, Scope, Interpol, [$\n|Rest], Buffer, Output, Last) ->
   extract(Line+1, Scope, Interpol, Rest, [$\n|Buffer], Output, Last);
 
+extract(Line, Scope, Interpol, [$\\, Last|Rest], Buffer, Output, Last) ->
+  extract(Line, Scope, Interpol, Rest, [Last|Buffer], Output, Last);
+
 extract(Line, Scope, true, [$\\, $#, ${|Rest], Buffer, Output, Last) ->
   extract(Line, Scope, true, Rest, [${,$#|Buffer], Output, Last);
 

--- a/lib/elixir/test/elixir/kernel/sigils_test.exs
+++ b/lib/elixir/test/elixir/kernel/sigils_test.exs
@@ -27,6 +27,8 @@ defmodule Kernel.SigilsTest do
     assert ~S(f#{o}o) == "f\#{o}o"
     assert ~S(f\#{o}o) == "f\\\#{o}o"
     assert ~S(f\no) == "f\\no"
+    assert ~S(foo\)) == "foo)"
+    assert ~S[foo\]] == "foo]"
   end
 
   test :sigil_S_with_heredoc do


### PR DESCRIPTION
This fixes #2840 

Now we have:

```
iex(1)> ~S(Interpolation?: #{3+0.14} ' '\))
"Interpolation?: \#{3+0.14} ' ')"
iex(2)> ~S(foo\))
"foo)"
```
