### PR TITLE
Enum.take_every/2 should throw an exception when the second argument is not positive

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1747,15 +1747,17 @@ defmodule Enum do
   Returns a collection of every `nth` item in the collection,
   starting with the first element.
 
+  The second argument specifying every `nth` item must be non-negative.
+
   ## Examples
 
       iex> Enum.take_every(1..10, 2)
       [1, 3, 5, 7, 9]
 
   """
-  @spec take_every(t, integer) :: list
+  @spec take_every(t, non_neg_integer) :: list
   def take_every(_collection, 0), do: []
-  def take_every(collection, nth) do
+  def take_every(collection, nth) when nth > 0 do
     {_, {res, _}} =
       Enumerable.reduce(collection, {:cont, {[], :first}}, R.take_every(nth))
     :lists.reverse(res)

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -349,6 +349,9 @@ defmodule EnumTest.List do
     assert Enum.take_every([], 2) == []
     assert Enum.take_every([1, 2], 2) == [1]
     assert Enum.take_every([1, 2, 3], 0) == []
+    assert_raise FunctionClauseError, fn ->
+      Enum.take_every([1, 2, 3], -1)
+    end
   end
 
   test :take_while do
@@ -865,6 +868,9 @@ defmodule EnumTest.Range do
     assert Enum.take_every(1..10, 2) == [1, 3, 5, 7, 9]
     assert Enum.take_every(1..2, 2) == [1]
     assert Enum.take_every(1..3, 0) == []
+    assert_raise FunctionClauseError, fn ->
+      Enum.take_every(1..3, -1)
+    end
   end
 
   test :take_while do


### PR DESCRIPTION
Fixed issue #2850.
