### PR TITLE
complete test coverage for Stream.take_every/2

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -556,6 +556,8 @@ defmodule Stream do
 
   The first item is always included, unless `n` is 0.
 
+  `n` must be non-negative, or `FunctionClauseError` will be thrown.
+
   ## Examples
 
       iex> stream = Stream.take_every(1..10, 2)

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -589,6 +589,10 @@ defmodule StreamTest do
            |> Stream.take_every(2)
            |> Stream.drop(1)
            |> Enum.to_list == [5, 7, 9]
+
+    assert_raise FunctionClauseError, fn ->
+      Stream.take_every(1..10, -1)
+    end
   end
 
   test "take_while/2" do


### PR DESCRIPTION
Like Enum.take_every/2, when the second argument of Stream.take_every/2 is negative, we should expect an FunctionClauseError.
