### PR TITLE
Correct Enum.take, Enum.take_every, Stream.take, Stream.take_every

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1696,7 +1696,7 @@ defmodule Enum do
   @doc """
   Takes the first `count` items from the collection.
 
-  If a negative `count` is given, the last `count` values will
+  `count` must be an integer. If a negative `count` is given, the last `count` values will
   be taken. For such, the collection is fully enumerated keeping up
   to `2 * count` elements in memory. Once the end of the collection is
   reached, the last `count` elements are returned.
@@ -1718,15 +1718,14 @@ defmodule Enum do
   """
   @spec take(t, integer) :: list
 
-  def take(_collection, 0) do
-    []
-  end
+  def take(_collection, 0), do: []
+  def take([], _count), do: []
 
-  def take(collection, count) when is_list(collection) and count > 0 do
+  def take(collection, count) when is_list(collection) and is_integer(count) and count > 0 do
     do_take(collection, count)
   end
 
-  def take(collection, count) when count > 0 do
+  def take(collection, count) when is_integer(count) and count > 0 do
     {_, {res, _}} =
       Enumerable.reduce(collection, {:cont, {[], count}}, fn(entry, {list, count}) ->
         if count > 1 do
@@ -1738,7 +1737,7 @@ defmodule Enum do
     :lists.reverse(res)
   end
 
-  def take(collection, count) when count < 0 do
+  def take(collection, count) when is_integer(count) and count < 0 do
     Stream.take(collection, count).({:cont, []}, &{:cont, [&1|&2]})
     |> elem(1) |> :lists.reverse
   end
@@ -1747,7 +1746,7 @@ defmodule Enum do
   Returns a collection of every `nth` item in the collection,
   starting with the first element.
 
-  The second argument specifying every `nth` item must be non-negative.
+  The second argument specifying every `nth` item must be a non-negative integer.
 
   ## Examples
 
@@ -1757,7 +1756,9 @@ defmodule Enum do
   """
   @spec take_every(t, non_neg_integer) :: list
   def take_every(_collection, 0), do: []
-  def take_every(collection, nth) when nth > 0 do
+  def take_every([], _nth), do: []
+  
+  def take_every(collection, nth) when is_integer(nth) and nth > 0 do
     {_, {res, _}} =
       Enumerable.reduce(collection, {:cont, {[], :first}}, R.take_every(nth))
     :lists.reverse(res)

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -515,14 +515,15 @@ defmodule Stream do
       [1,2,3,1,2]
 
   """
-  @spec take(Enumerable.t, non_neg_integer) :: Enumerable.t
+  @spec take(Enumerable.t, integer) :: Enumerable.t
   def take(_enum, 0), do: %Stream{enum: []}
+  def take([], _n), do: %Stream{enum: []}
 
-  def take(enum, n) when n > 0 do
+  def take(enum, n) when is_integer(n) and n > 0 do
     lazy enum, n, fn(f1) -> R.take(f1) end
   end
 
-  def take(enum, n) when n < 0 do
+  def take(enum, n) when is_integer(n) and n < 0 do
     &do_take(enum, abs(n), &1, &2)
   end
 
@@ -556,7 +557,7 @@ defmodule Stream do
 
   The first item is always included, unless `n` is 0.
 
-  `n` must be non-negative, or `FunctionClauseError` will be thrown.
+  `n` must be a non-negative integer, or `FunctionClauseError` will be thrown.
 
   ## Examples
 
@@ -566,7 +567,7 @@ defmodule Stream do
 
   """
   @spec take_every(Enumerable.t, non_neg_integer) :: Enumerable.t
-  def take_every(enum, n) when n > 0 do
+  def take_every(enum, n) when is_integer(n) and n > 0 do
     lazy enum, n, fn(f1) -> R.take_every(n, f1) end
   end
 

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -547,6 +547,7 @@ defmodule StreamTest do
     assert Enum.to_list(stream) == [1,2,3,4,5]
 
     assert Enum.to_list(Stream.take(1..1000, 0)) == []
+    assert Enum.to_list(Stream.take([], 5)) == []
     assert Enum.to_list(Stream.take(1..3, 5)) == [1,2,3]
 
     nats = Stream.iterate(1, &(&1 + 1))
@@ -590,8 +591,22 @@ defmodule StreamTest do
            |> Stream.drop(1)
            |> Enum.to_list == [5, 7, 9]
 
+    assert 1..10
+           |> Stream.take_every(0)
+           |> Enum.to_list == []
+
+    assert []
+           |> Stream.take_every(10)
+           |> Enum.to_list == []
+  end
+
+  test "take_every/2 without non-negative integer" do
     assert_raise FunctionClauseError, fn ->
       Stream.take_every(1..10, -1)
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Stream.take_every(1..10, 3.33)
     end
   end
 


### PR DESCRIPTION
Correct Enum.take, Enum.take_every, Stream.take, Stream.take_every to accept proper nth/count values.

Make these functions deal with:
- empty collections directly return an empty list
- non-integer values for Enum.take and Stream.take
- negative and non-integer values for Enum.take_ever and Stream.take_every
