### PR TITLE
fix inline documentation because of broken ansi representation in iex

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -11,24 +11,23 @@ defmodule IEx.Helpers do
 
   There are many other helpers available:
 
-    * `c/2`       — compiles a file at the given path
-    * `cd/1`      — changes the current directory
-    * `clear/0`   — clears the screen
-    * `flush/0`   — flushes all messages sent to the shell
-    * `h/0`       — prints this help message
-    * `h/1`       — prints help for the given module, function or macro
-    * `l/1`       — loads the given module's beam code and purges the current version
-    * `ls/0`      — lists the contents of the current directory
-    * `ls/1`      — lists the contents of the specified directory
-    * `pwd/0`     — prints the current working directory
-    * `r/1`       — recompiles and reloads the given module's source file
-    * `respawn/0` — respawns the current shell
-    * `s/1`       — prints spec information
-    * `t/1`       — prints type information
-    * `v/0`       — prints the history of commands evaluated in the session
-    * `v/1`       — retrieves the nth value from the history
-    * `import_file/1`
-                  — evaluates the given file in the shell's context
+    * `c/2`           — compiles a file at the given path
+    * `cd/1`          — changes the current directory
+    * `clear/0`       — clears the screen
+    * `flush/0`       — flushes all messages sent to the shell
+    * `h/0`           — prints this help message
+    * `h/1`           — prints help for the given module, function or macro
+    * `l/1`           — loads the given module's beam code
+    * `ls/0`          — lists the contents of the current directory
+    * `ls/1`          — lists the contents of the specified directory
+    * `pwd/0`         — prints the current working directory
+    * `r/1`           — recompiles and reloads the given module's source file
+    * `respawn/0`     — respawns the current shell
+    * `s/1`           — prints spec information
+    * `t/1`           — prints type information
+    * `v/0`           — prints the history of commands evaluated in the session
+    * `v/1`           — retrieves the nth value from the history
+    * `import_file/1` — evaluates the given file in the shell's context
 
   Help for functions in this module can be consulted
   directly from the command line, as an example, try:
@@ -40,10 +39,10 @@ defmodule IEx.Helpers do
 
       h(Enum)
       h(Enum.reverse/1)
-      
+
   To discover all available functions for a module, type the module name
   followed by a dot, then press tab to trigger autocomplete. For example:
-  
+
       Enum.
 
   To learn more about IEx as a whole, just type `h(IEx)`.


### PR DESCRIPTION
Hi,

I stumbled over a representation issue with the ansi doc inside `iex`.

before:

![BAD ANSI](http://i.imgur.com/tAvq7JL.png)

after:

![GOOD ANSI](http://i.imgur.com/ddbkIWS.png)

I also made the information about the `l/1` function shorter. The more precise information you get via `h(l/1)`.
