### PR TITLE
fix floating point approximation error

### DIFF
--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -92,7 +92,19 @@ defmodule Float do
     final_decimal_places = decimal - exponential
     if final_decimal_places > 0 do
       decimal_power_round = :math.pow(10,  final_decimal_places)
-      trunc(result * decimal_power_round) / decimal_power_round
+      multiplied_result = result * decimal_power_round
+      epsilon = :math.pow(10, -final_decimal_places) * 5
+      closet_approximation = ceil_within_error_range(multiplied_result, epsilon)
+      trunc(closet_approximation) / decimal_power_round
+    else
+      result
+    end
+  end
+
+  defp ceil_within_error_range(result, epsilon) do
+    ceiled = ceil(result)
+    if ceiled - result <= epsilon do
+      ceiled
     else
       result
     end

--- a/lib/elixir/test/elixir/float_test.exs
+++ b/lib/elixir/test/elixir/float_test.exs
@@ -12,6 +12,8 @@ defmodule FloatTest do
     assert Float.parse("12.524235") === {12.524235, ""}
     assert Float.parse("-12.5") === {-12.5, ""}
     assert Float.parse("-12.524235") === {-12.524235, ""}
+    assert Float.parse("0.3534091") === {0.3534091, ""}
+    assert Float.parse("0.3534091elixir") === {0.3534091, "elixir"}
     assert Float.parse("7.5e3") === {7.5e3, ""}
     assert Float.parse("7.5e-3") === {7.5e-3, ""}
     assert Float.parse("12x") === {12.0, "x"}


### PR DESCRIPTION
This fixes issue #2867.

```
iex(11)> Float.parse("0.3534091")
{0.3534091, ""}
iex(12)> Float.parse("0.3534092")
{0.3534092, ""}
iex(13)> Float.parse("0.3534093")
{0.3534093, ""}
iex(14)> Float.parse("0.3534094")
{0.3534094, ""}
iex(15)> Float.parse("0.3534095")
{0.3534095, ""}
iex(16)> Float.parse("0.3534096")
{0.3534096, ""}
iex(17)> Float.parse("0.3534097")
{0.3534097, ""}
iex(18)> Float.parse("0.3534098")
{0.3534098, ""}
iex(19)> Float.parse("0.3534099")
{0.3534099, ""}
iex(20)> Float.parse("0.3534100")
{0.35341, ""}
```
