### PR TITLE
fix wrong String.split_at/2 output when second arg is not an integer

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -368,10 +368,10 @@ defmodule String do
   def split_at(binary, index) when index == 0, do:
     {"", binary}
 
-  def split_at(binary, index) when index > 0, do:
+  def split_at(binary, index) when is_integer(index) and index > 0, do:
     do_split_at(next_grapheme(binary), 0, index, "")
 
-  def split_at(binary, index) when index < 0, do:
+  def split_at(binary, index) when is_integer(index) and index < 0, do:
     do_split_at(next_grapheme(binary), 0, max(0, byte_size(binary)+index), "")
 
   defp do_split_at(nil, _, _, acc), do:

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -83,6 +83,14 @@ defmodule StringTest do
     assert String.split_at("abc", -3) == {"", "abc"}
     assert String.split_at("abc", -4) == {"", "abc"}
     assert String.split_at("abc", -1000) == {"", "abc"}
+
+    assert_raise FunctionClauseError, fn ->
+      String.split_at("abc", 0.1)
+    end
+    
+    assert_raise FunctionClauseError, fn ->
+      String.split_at("abc", -0.1)
+    end
   end
 
   test :upcase do


### PR DESCRIPTION
This fixed issue #2874.
