### PR TITLE
fix wrong String.at/2 output when second arg is not an integer

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1010,11 +1010,11 @@ defmodule String do
   """
   @spec at(t, integer) :: grapheme | nil
 
-  def at(string, position) when position >= 0 do
+  def at(string, position) when is_integer(position) and position >= 0 do
     do_at(next_grapheme(string), position, 0)
   end
 
-  def at(string, position) when position < 0 do
+  def at(string, position) when is_integer(position) and position < 0 do
     real_pos = length(string) - abs(position)
     case real_pos >= 0 do
       true  -> do_at(next_grapheme(string), real_pos, 0)

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -317,6 +317,14 @@ defmodule StringTest do
     assert String.at("л", -3) == nil
     assert String.at("Ā̀stute", 1) == "s"
     assert String.at("elixir", 6) == nil
+
+    assert_raise FunctionClauseError, fn ->
+      String.at("elixir", 0.1)
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      String.at("elixir", -0.1)
+    end
   end
 
   test :slice do


### PR DESCRIPTION
String.at/2 has the same issue as String.split_at/2 in issue #2874:  

```
iex(1)> String.at("elixir", 0.1)
** (FunctionClauseError) no function clause matching in String.do_at/3
    (elixir) lib/string.ex:1025: String.do_at({"l", "ixir"}, 0.1, 1)
iex(1)> String.at("elixir", -0.1)
nil
```

The fix is similar. 

---

I took a look at the other similar functions right now at String module expecting a second integer parameter, they all seem to be correctly using `is_integer` guards and I ran some random floating point inputs as tests and the tests are all passing, so hopefully there wouldn't need any similar patch regarding this kind of issue for the String module.
