### PR TITLE
Fix SupervisorTest :push handle_cast method

### DIFF
--- a/lib/elixir/test/elixir/supervisor_test.exs
+++ b/lib/elixir/test/elixir/supervisor_test.exs
@@ -25,7 +25,7 @@ defmodule SupervisorTest do
       {:stop, :normal, :ok, stack}
     end
 
-    def handle_cast({:push, h}, _from, t) do
+    def handle_cast({:push, h}, t) do
       {:noreply, [h|t]}
     end
   end


### PR DESCRIPTION
- handle_cast/2 does not take 'from' param
