### PR TITLE
Make IO.ANSI.Docs readable on white background

### DIFF
--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -25,10 +25,10 @@ defmodule IO.ANSI.Docs do
     [enabled:           true,
      doc_bold:          [:bright],
      doc_code:          [:cyan, :bright],
-     doc_headings:      [:yellow, :bright],
+     doc_headings:      [:yellow],
      doc_inline_code:   [:cyan],
      doc_table_heading: [:reverse],
-     doc_title:         [:reverse, :yellow, :bright],
+     doc_title:         [:reverse, :yellow],
      doc_underline:     [:underline],
      width:             80]
   end

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -14,24 +14,24 @@ defmodule IO.ANSI.DocsTest do
 
   test "heading is formatted" do
     result = format_heading("wibble")
-    assert String.starts_with?(result, "\e[0m\n\e[7m\e[33m\e[1m")
+    assert String.starts_with?(result, "\e[0m\n\e[7m\e[33m")
     assert String.ends_with?(result, "\e[0m\n\e[0m")
     assert String.contains?(result, " wibble ")
   end
 
   test "first level heading is converted" do
     result = format("# wibble\n\ntext\n")
-    assert result == "\e[33m\e[1mWIBBLE\e[0m\n\e[0m\ntext\n\e[0m"
+    assert result == "\e[33mWIBBLE\e[0m\n\e[0m\ntext\n\e[0m"
   end
 
   test "second level heading is converted" do
     result = format("## wibble\n\ntext\n")
-    assert result == "\e[33m\e[1mwibble\e[0m\n\e[0m\ntext\n\e[0m"
+    assert result == "\e[33mwibble\e[0m\n\e[0m\ntext\n\e[0m"
   end
 
   test "third level heading is converted" do
     result = format("## wibble\n\ntext\n")
-    assert result == "\e[33m\e[1mwibble\e[0m\n\e[0m\ntext\n\e[0m"
+    assert result == "\e[33mwibble\e[0m\n\e[0m\ntext\n\e[0m"
   end
 
   test "code block is converted" do


### PR DESCRIPTION
The `default_options` for `IO.ANSI.Docs` uses bright yellow for
documentation headers and titles.

This is very nice and readable when using a terminal with a dark
background. However, when using a terminal with a bright (e.g. white)
background, those parts are unfortunately illegible.

This patch removes the `:bright` part from the `default_options`, to
make the defaults better suited to those of us who uses white terminals.

I have seen the issues and thread about adding an `.iex` file for having
local settings, and I think that's a great idea, but I still think that having
defaults that work for a wider group of developers is a good idea.

Below is a couple of screenshots on the before and after.

![iex_diff_dark_terminal](https://cloud.githubusercontent.com/assets/2308/4952583/60529ff4-6676-11e4-834e-490adff6c46f.png)
![iex_diff_white_background](https://cloud.githubusercontent.com/assets/2308/4952585/631b32d2-6676-11e4-9ff1-f9623680fc1d.png)
