### PR TITLE
introduce Enum.reverse/3

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1419,6 +1419,34 @@ defmodule Enum do
   end
 
   @doc """
+  Reverses the collection in the range from initial position `first` 
+  through `count` elements. If `count` is greater than the size of
+  the rest of the collection, then this function will reverse the rest
+  of the collection.
+
+  ## Examples
+
+      iex> Enum.reverse_slice([1, 2, 3, 4, 5, 6], 2, 4)
+      [1, 2, 6, 5, 4, 3]
+
+  """
+  def reverse_slice(coll, first, count) when first >= 0 and count >= 0 do
+    {_, _, acc1, acc2, acc3} = 
+      reduce(coll, {first, count, [], [], []}, fn(entry, {first, count, acc1, acc2, acc3}) ->
+        cond do
+          first > 0 ->
+            {first - 1, count, [entry|acc1], acc2, acc3}
+          first == 0 and count > 0 ->
+            {0, count - 1, acc1, [entry|acc2], acc3}
+          true ->
+            {0, 0, acc1, acc2, [entry|acc3]}
+        end
+      end)
+
+    :lists.reverse(acc1, acc2 ++ :lists.reverse(acc3))
+  end
+
+  @doc """
   Returns a random element of a collection.
 
   Notice that you need to explicitly call `:random.seed/1` and

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -256,6 +256,14 @@ defmodule EnumTest.List do
     assert Enum.reverse([1, 2, 3], [4, 5, 6]) == [3, 2, 1, 4, 5, 6]
   end
 
+  test :reverse_slice do
+    assert Enum.reverse_slice([1, 2, 3], 0, 0) == [1, 2, 3]
+    assert Enum.reverse_slice([1, 2, 3], 0, 1) == [1, 2, 3]
+    assert Enum.reverse_slice([1, 2, 3], 0, 2) == [2, 1, 3]
+    assert Enum.reverse_slice([1, 2, 3], 0, 20000000) == [3, 2, 1]
+    assert Enum.reverse_slice([1, 2, 3], 100, 2) == [1, 2, 3]
+  end
+
   test :sample_1 do
     # corner cases, independent of the seed
     assert Enum.sample([]) == nil
@@ -825,6 +833,14 @@ defmodule EnumTest.Range do
     assert Enum.reverse(1..3, 4..6) == [3, 2, 1, 4, 5, 6]
     assert Enum.reverse([1, 2, 3], 4..6) == [3, 2, 1, 4, 5, 6]
     assert Enum.reverse(1..3, [4, 5, 6]) == [3, 2, 1, 4, 5, 6]
+  end
+
+  test :reverse_slice do
+    assert Enum.reverse_slice(1..6, 2, 0) == [1, 2, 3, 4, 5, 6]
+    assert Enum.reverse_slice(1..6, 2, 2) == [1, 2, 4, 3, 5, 6]
+    assert Enum.reverse_slice(1..6, 2, 4) == [1, 2, 6, 5, 4, 3]
+    assert Enum.reverse_slice(1..6, 2, 10000000) == [1, 2, 6, 5, 4, 3]
+    assert Enum.reverse_slice(1..6, 10000000, 4) == [1, 2, 3, 4, 5, 6]
   end
 
   test :sample_1 do


### PR DESCRIPTION
Enum.reverse/3 reverses the given enum from the given starting and ending indices.

Example usage would be:

```
iex(1)> Enum.reverse('abcdef', 0, 2)
'cbadef'
iex(2)> Enum.reverse([1, 2, 3, 4, 5], 1, 2)
[1, 3, 2, 4, 5]
iex(3)> Enum.reverse(1..5, 1, 2)           
[1, 3, 2, 4, 5]
```
