### PR TITLE
fix broken link in GenServer module

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -197,7 +197,7 @@ defmodule GenServer do
   guides provide a tutorial-like introduction. The documentation and links
   in Erlang can also provide extra insight.
 
-    * http://elixir-lang.org/getting_started/mix/1.html
+    * http://elixir-lang.org/getting_started/mix_otp/1.html
     * http://www.erlang.org/doc/man/gen_server.html
     * http://www.erlang.org/doc/design_principles/gen_server_concepts.html
     * http://learnyousomeerlang.com/clients-and-servers


### PR DESCRIPTION
Seeing sammyt's PR #2884, I wrote a script to hit all html links included in master branch's '.ex' source files.

It turns out there is one more link (which is the same link as the one discovered by sammyt in another file) that gives 404 response code.

Update: The rest of the urls all return 200 response code.

: )
