### PR TITLE
Fix command_to_module_name not converting snakecased names properly

### DIFF
--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -270,7 +270,7 @@ defmodule Mix.Utils do
 
   def module_name_to_command(module, nesting) do
     t = Regex.split(~r/\./, to_string(module))
-    t |> Enum.drop(nesting) |> Enum.map(&first_to_lower(&1)) |> Enum.join(".")
+    t |> Enum.drop(nesting) |> Enum.map(&underscore(&1)) |> Enum.join(".")
   end
 
   @doc """
@@ -287,12 +287,6 @@ defmodule Mix.Utils do
       Enum.map(&camelize(&1)) |>
       Enum.join(".")
   end
-
-  defp first_to_upper(<<s, t :: binary>>), do: <<to_upper_char(s)>> <> t
-  defp first_to_upper(<<>>), do: <<>>
-
-  defp first_to_lower(<<s, t :: binary>>), do: <<to_lower_char(s)>> <> t
-  defp first_to_lower(<<>>), do: <<>>
 
   defp to_upper_char(char) when char in ?a..?z, do: char - 32
   defp to_upper_char(char), do: char

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -16,6 +16,8 @@ defmodule Mix.UtilsTest do
     assert Mix.Utils.module_name_to_command(Mix.Tasks.Foo, 2)       == "foo"
     assert Mix.Utils.module_name_to_command("Mix.Tasks.Foo", 2)     == "foo"
     assert Mix.Utils.module_name_to_command("Mix.Tasks.Foo.Bar", 2) == "foo.bar"
+    assert Mix.Utils.module_name_to_command("Mix.Tasks.FooBar.Bing", 2) == "foo_bar.bing"
+    assert Mix.Utils.module_name_to_command("Mix.Tasks.FooBar.BingBang", 2) == "foo_bar.bing_bang"
   end
 
   test :command_to_module_name do


### PR DESCRIPTION
Currently, snake cased project names did not get converted properly into modules from `Mix.Utils.command_to_module_name`, i.e.:

``` elixir
Mix.Utils.command_to_module_name "my_app.task"
=> "My_app.Task"
```

This PR uses `camelize` to properly convert the commands to module namespaces.
