### PR TITLE
Add number of skipped tests to ExUnit output

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -206,8 +206,8 @@ defmodule ExUnit do
   API used to run the tests. It is invoked automatically
   if ExUnit is started via `ExUnit.start/1`.
 
-  Returns a map containing the number of tests and the number
-  of failures.
+  Returns a map containing the total number of tests, the number
+  of failures and the number of skipped tests.
   """
   def run do
     {async, sync, load_us} = ExUnit.Server.start_run

--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -17,6 +17,7 @@ defmodule ExUnit.CLIFormatter do
       width: get_terminal_width(),
       tests_counter: 0,
       failures_counter: 0,
+      skipped_counter: 0,
       invalids_counter: 0
     }
     {:ok, config}
@@ -43,7 +44,8 @@ defmodule ExUnit.CLIFormatter do
 
   def handle_event({:test_finished, %ExUnit.Test{state: {:skip, _}} = test}, config) do
     if config.trace, do: IO.puts trace_test_skip(test)
-    {:ok, config}
+    {:ok, %{config | tests_counter: config.tests_counter + 1,
+                     skipped_counter: config.skipped_counter + 1}}
   end
 
   def handle_event({:test_finished, %ExUnit.Test{state: {:invalid, _}} = test}, config) do
@@ -131,6 +133,10 @@ defmodule ExUnit.CLIFormatter do
     IO.puts format_time(run_us, load_us)
 
     message = "#{config.tests_counter} tests, #{config.failures_counter} failures"
+
+    if config.skipped_counter > 0 do
+      message = message <> ", #{config.skipped_counter} skipped"
+    end
 
     if config.invalids_counter > 0 do
       message = message <>  ", #{config.invalids_counter} invalid"

--- a/lib/ex_unit/lib/ex_unit/runner_stats.ex
+++ b/lib/ex_unit/lib/ex_unit/runner_stats.ex
@@ -5,7 +5,7 @@ defmodule ExUnit.RunnerStats do
   use GenEvent
 
   def init(_opts) do
-    {:ok, %{total: 0, failures: 0}}
+    {:ok, %{total: 0, failures: 0, skipped: 0}}
   end
 
   def handle_call(:stop, map) do
@@ -17,8 +17,9 @@ defmodule ExUnit.RunnerStats do
     {:ok, %{map | total: total + 1, failures: failures + 1}}
   end
 
-  def handle_event({:test_finished, %ExUnit.Test{state: {:skip, _}}}, map) do
-    {:ok, map}
+  def handle_event({:test_finished, %ExUnit.Test{state: {:skip, _}}},
+                   %{total: total, skipped: skipped} = map) do
+    {:ok, %{map | total: total + 1, skipped: skipped + 1}}
   end
 
   def handle_event({:test_finished, _}, %{total: total} = map) do


### PR DESCRIPTION
Based on [discussion on elixir-lang-talk](https://groups.google.com/forum/#!topic/elixir-lang-talk/5lZnUIO3YDw). When running ExUnit, it shows the number of skipped tests:

```
Finished in 4.8 seconds (3.1s on load, 1.7s on tests)
138 tests, 0 failures, 1 skipped
```

Since this output is not tested in any current unit tests, I decided not to write any new tests. Let me know if you want me to write automated tests as well.

I couldn't find any places in the documentation that need updating because of this change, but I might have missed something.

Currently, `ExUnit.run/0` returns the number of tests and number of failures. Should I update it to return all three numbers?

**TODOs**
- [x] Only show number of skipped tests when there are any.
- [x] Return `skipped` tests from `ExUnit.run/0`.
- [x] Update tests to verify added output.
- [x] Update tests to verify return value of `ExUnit.run/0`.
- [x] Update docs for `ExUnit.run/0`.
- [x] Make `tests` total, instead of excluding skipped.
