### PR TITLE
Fix some tests to be compatible with `warn_missing_spec`

### DIFF
--- a/lib/elixir/test/elixir/fixtures/at_exit.exs
+++ b/lib/elixir/test/elixir/fixtures/at_exit.exs
@@ -1,4 +1,5 @@
 defmodule AtExit do
+  @spec at_exit(String.t) :: :ok
   def at_exit(str) do
     System.at_exit fn(_) -> IO.write(str) end
   end

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -89,6 +89,7 @@ defmodule Kernel.WarningTest do
     assert capture_err(fn ->
       Code.eval_string """
       defmodule Sample do
+        @spec test(any) :: any
         def test(x) do
           case x do
             {:file, fid} -> fid
@@ -106,6 +107,7 @@ defmodule Kernel.WarningTest do
     assert capture_err(fn ->
       Code.eval_string ~S"""
       defmodule Sample1 do
+        @spec a() :: list
         def a, do: b(1, 2, 3)
         defp b(arg1 \\ 1, arg2 \\ 2, arg3 \\ 3), do: [arg1, arg2, arg3]
       end
@@ -115,6 +117,7 @@ defmodule Kernel.WarningTest do
     assert capture_err(fn ->
       Code.eval_string ~S"""
       defmodule Sample2 do
+        @spec a() :: list
         def a, do: b(1, 2)
         defp b(arg1 \\ 1, arg2 \\ 2, arg3 \\ 3), do: [arg1, arg2, arg3]
       end
@@ -124,6 +127,7 @@ defmodule Kernel.WarningTest do
     assert capture_err(fn ->
       Code.eval_string ~S"""
       defmodule Sample3 do
+        @spec a() :: list
         def a, do: b(1)
         defp b(arg1 \\ 1, arg2 \\ 2, arg3 \\ 3), do: [arg1, arg2, arg3]
       end
@@ -133,6 +137,7 @@ defmodule Kernel.WarningTest do
     assert capture_err(fn ->
       Code.eval_string ~S"""
       defmodule Sample4 do
+        @spec a() :: list
         def a, do: b(1)
         defp b(arg1 \\ 1, arg2, arg3 \\ 3), do: [arg1, arg2, arg3]
       end
@@ -240,6 +245,7 @@ defmodule Kernel.WarningTest do
       defmodule Sample1 do
         import List, only: [flatten: 1]
 
+        @spec generate() :: list
         defmacro generate do
           List.duplicate(quote(do: flatten([1,2,3])), 100)
         end
@@ -300,6 +306,7 @@ defmodule Kernel.WarningTest do
     assert capture_err(fn ->
       Code.eval_string """
       defmodule Sample do
+        @spec hello() :: :ok
         def hello, do: world
         defp world, do: :ok
         defoverridable [hello: 0, world: 0]

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -327,6 +327,7 @@ defmodule IEx.HelpersTest do
   defp test_module_code do
     """
     defmodule Sample do
+      @spec run() :: :run
       def run do
         :run
       end


### PR DESCRIPTION
If `warn_missing_spec` is set then `make test` will fail with errors like:

``` elixir
  3) test used_with_local_with_reattached_overridable (Kernel.WarningTest)
     test/elixir/kernel/warning_test.exs:299
     Assertion with == failed
     code: capture_err(fn -> Code.eval_string("defmodule Sample do\n  def hello, do: world\n  defp world, do: :ok\n  defoverridable [hello: 0, world: 0]\nend\n") end) == ""
     lhs:  "nofile:2: warning: missing specification for function hello/0\n"
     rhs:  ""
     stacktrace:
       test/elixir/kernel/warning_test.exs:300

```
