### PR TITLE
Introduce an efficient implementation for Integer.digits/1

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -28,6 +28,33 @@ defmodule Integer do
   end
 
   @doc """
+  Returns the ordered digits for the given non-negative integer.
+
+  An optional base value may be provided representing the radix for the returned
+  digits.
+
+  ## Examples
+
+      iex> Integer.digits(101)
+      [1, 0, 1]
+
+      iex> Integer.digits(58127, 2)
+      [1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1]
+
+  """
+  @spec digits(non_neg_integer, non_neg_integer) :: [non_neg_integer]
+  def digits(n, base \\ 10) when is_integer(n)    and n >= 0
+                            and  is_integer(base) and base >= 2 do
+    do_digits(n, base, [])
+  end
+
+  defp do_digits(0, _base, []),  do: [0]
+  defp do_digits(0, _base, acc), do: acc
+  defp do_digits(n, base, acc)  do
+    do_digits div(n,base), base, [rem(n,base) | acc]
+  end
+
+  @doc """
   Converts a binary to an integer.
 
   If successful, returns a tuple of the form `{integer, remainder_of_binary}`.

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -24,6 +24,14 @@ defmodule IntegerTest do
     assert Integer.is_even(-3) == false
   end
 
+  test :digits do
+    assert Integer.digits(101) == [1,0,1]
+    assert Integer.digits(1) == [1]
+    assert Integer.digits(0) == [0]
+    assert Integer.digits(0,2) == [0]
+    assert Integer.digits(58127,2) == [1,1,1,0,0,0,1,1,0,0,0,0,1,1,1,1]
+  end
+
   test :parse do
     assert Integer.parse("12") === {12, ""}
     assert Integer.parse("-12") === {-12, ""}


### PR DESCRIPTION
Most programmers tend to implement the digits of an integer by converting to a string representation, splitting the string, and then converting each char back into an integer.  E.g. with code such as the following:

``` elixir
# BAD CODE - DONT DO THIS
def digits(n) when is_integer(n) and n>0 do
    n
    |> Integer.to_string
    |> String.graphemes
    |> Enum.map(&String.to_integer/1)
end
```

Which results in a lot of inefficient type conversion and memory allocations.

In contrast, this implementation is purely mathematical.  In informal benchmarks on my workstation, it performs at **0.9 μs/op** versus **4.8 μs/op** in the naïve implementation above. Plus, it will handle negative numbers properly, which most String solutions mess up.

While this is a pretty basic function, the way that 9/10 programmers tend to implement it is very inefficient and error prone, and it is in common usage.  Thus, I would suggest that having a proper and efficient implementation in the standard lib is desirable.
