### PR TITLE
Enum.sample/1, 2 should raise if the collection size is smaller than the sample size

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1445,6 +1445,7 @@ defmodule Enum do
 
   @doc """
   Returns a random element of a collection.
+  Raises `EmptyError` if the collection is empty.
 
   Notice that you need to explicitly call `:random.seed/1` and
   set a seed value for the random algorithm. Otherwise, the
@@ -1468,13 +1469,21 @@ defmodule Enum do
       2
 
   """
-  @spec sample(t) :: element | nil
+  @spec sample(t) :: element
   def sample(collection) do
-    sample(collection, 1) |> List.first
+    case sample(collection, 1) do
+      [] -> raise Enum.EmptyError
+      [e] -> e
+    end
   end
 
   @doc """
   Returns a random sublist of a collection.
+
+  Notice this function will traverse the whole collection to
+  get the random sublist of collection. If you want the random
+  number between two integers, the best option is to use the
+  :random module.
 
   See `sample/1` for notes on implementation and random seed.
 

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -266,8 +266,9 @@ defmodule EnumTest.List do
 
   test :sample_1 do
     # corner cases, independent of the seed
-    assert Enum.sample([]) == nil
+    assert_raise Enum.EmptyError, fn -> Enum.sample([]) end
     assert Enum.sample([1]) == 1
+    
     # set a fixed seed so the test can be deterministic
     # please note the order of following assertions is important
     seed1 = {1406, 407414, 139258}
@@ -846,6 +847,7 @@ defmodule EnumTest.Range do
   test :sample_1 do
     # corner cases, independent of the seed
     assert Enum.sample(1..1) == 1
+
     # set a fixed seed so the test can be deterministic
     # please note the order of following assertions is important
     seed1 = {1406, 407414, 139258}
@@ -876,6 +878,7 @@ defmodule EnumTest.Range do
     assert Enum.sample(1..1, 0) == []
     assert Enum.sample(1..1, 2) == [1]
     assert Enum.sample(1..2, 0) == []
+
     # set a fixed seed so the test can be deterministic
     # please note the order of following assertions is important
     seed1 = {1406, 407414, 139258}


### PR DESCRIPTION
This fixes the Enum.sample/1 issue discussed in the issue #2916.

And addresses @lexmag's comment in the closed PR #2917.
