### PR TITLE
Add implementation of Integer.undigits

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -55,6 +55,29 @@ defmodule Integer do
   end
 
   @doc """
+  Returns the integer represented by the ordered digits.
+
+  An optional base value may be provided representing the radix for the digits.
+
+   ## Examples
+
+       iex> Integer.undigits([1, 0, 1])
+       101
+
+       iex> Integer.undigits([1, 4], 16)
+       20
+  """
+  @spec undigits([integer], integer) :: integer
+  def undigits(digits, base \\ 10) when is_integer(base) do
+    do_undigits(:lists.reverse(digits), base, 1)
+  end
+
+  defp do_undigits([], _base, _acc), do: 0
+  defp do_undigits([digit | tail], base, acc) do
+    digit * acc + do_undigits(tail, base, acc * base)
+  end
+
+  @doc """
   Converts a binary to an integer.
 
   If successful, returns a tuple of the form `{integer, remainder_of_binary}`.

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -32,6 +32,19 @@ defmodule IntegerTest do
     assert Integer.digits(58127,2) == [1,1,1,0,0,0,1,1,0,0,0,0,1,1,1,1]
   end
 
+  test :undigits do
+    assert Integer.undigits([1, 0, 1]) == 101
+    assert Integer.undigits([1]) == 1
+    assert Integer.undigits([0]) == 0
+    assert Integer.undigits([]) == 0
+    assert Integer.undigits([1,4], 16) == 0x14
+    assert Integer.undigits([1,4], 8) == 0o14
+    assert Integer.undigits([1,1], 2) == 0b11
+    assert Integer.undigits([1, 2, 3, 4, 5]) == 12345
+    assert Integer.undigits([1, 0, -5]) == 95
+    assert Integer.undigits([-1, -1, -5]) == -115
+  end
+
   test :parse do
     assert Integer.parse("12") === {12, ""}
     assert Integer.parse("-12") === {-12, ""}


### PR DESCRIPTION
Implements `Integer.undigits`, which is the counterpart to `Integer.digits`.

I made two different implementations. The first one (4d43155) uses `Enum.reverse/1` and is a bit neater, but I'm not sure if we want to depend on the `Enum` module here?

The second option (edc0a0c) constructs the number in natural ordering, and then uses `pow` to give it the correct value. I believe this is slightly more efficient than the `reverse` option, but the code is less clean.

Which alternative do we want?

A few more things:
- Is there a nicer way to ensure the result is an integer, than using `:erlang.trunc/1`?
- Is there a way to use guards to ensure the input list consists of integers only? (I presume not.) Should we handle it in any way, or take the happy path?
- If we decide to go for the non-`reverse` option, I will test it more thoroughly to ensure correct behavior for all kinds of input. I'm currently more confident in the `reverse` implementation.
- The implementations support [Signed-digit representation](http://en.wikipedia.org/wiki/Signed-digit_representation), which is intentional. Doing anything else would be less efficient.

Any other input or feedback is of course welcome too.
