### PR TITLE
Register test with duplicate names only once

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -218,7 +218,7 @@ defmodule ExUnit.Case do
     contents = Macro.escape(contents, unquote: true)
 
     quote bind_quoted: binding do
-      test = :"test #{message}"
+      test = ExUnit.Case.test_name(__MODULE__, message)
       ExUnit.Case.__on_definition__(__ENV__, test)
       def unquote(test)(unquote(var)), do: unquote(contents)
     end
@@ -243,6 +243,12 @@ defmodule ExUnit.Case do
       %ExUnit.Test{name: name, case: mod, tags: tags})
 
     Module.delete_attribute(mod, :tag)
+  end
+
+  @doc false
+  def test_name(mod, message) do
+    index = length(Module.get_attribute(mod, :ex_unit_tests)) + 1
+    String.to_atom("test ##{index} #{message}")
   end
 
   defp normalize_tags(tags) do

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -207,8 +207,10 @@ defmodule ExUnit.DocTestTest do
     ExUnit.configure(seed: 0, colors: [enabled: false])
     output = capture_io(fn -> ExUnit.run end)
 
+    # Test order is not guaranteed, we can't match this as a string for each failing doctest
+    assert output =~ ~r/\d+\) test moduledoc at ExUnit\.DocTestTest\.Invalid \(\d+\) \(ExUnit\.DocTestTest\.ActuallyCompiled\)/
+
     assert output =~ """
-      1) test #1 moduledoc at ExUnit.DocTestTest.Invalid (1) (ExUnit.DocTestTest.ActuallyCompiled)
          test/ex_unit/doc_test_test.exs:204
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:112: syntax error before: '*'
          code: 1 + * 1
@@ -217,7 +219,6 @@ defmodule ExUnit.DocTestTest do
     """
 
     assert output =~ """
-      2) test #2 moduledoc at ExUnit.DocTestTest.Invalid (2) (ExUnit.DocTestTest.ActuallyCompiled)
          test/ex_unit/doc_test_test.exs:204
          Doctest failed
          code: 1 + hd(List.flatten([1])) === 3
@@ -227,7 +228,6 @@ defmodule ExUnit.DocTestTest do
     """
 
     assert output =~ """
-      3) test #3 moduledoc at ExUnit.DocTestTest.Invalid (3) (ExUnit.DocTestTest.ActuallyCompiled)
          test/ex_unit/doc_test_test.exs:204
          Doctest failed
          code: inspect(:oops) === "#HashDict<[]>"
@@ -237,7 +237,6 @@ defmodule ExUnit.DocTestTest do
     """
 
     assert output =~ """
-      4) test #4 moduledoc at ExUnit.DocTestTest.Invalid (4) (ExUnit.DocTestTest.ActuallyCompiled)
          test/ex_unit/doc_test_test.exs:204
          Doctest failed: got UndefinedFunctionError with message undefined function: Hello.world/0 (module Hello is not available)
          code:  Hello.world
@@ -246,7 +245,6 @@ defmodule ExUnit.DocTestTest do
     """
 
     assert output =~ """
-      5) test #5 moduledoc at ExUnit.DocTestTest.Invalid (5) (ExUnit.DocTestTest.ActuallyCompiled)
          test/ex_unit/doc_test_test.exs:204
          Doctest failed: expected exception WhatIsThis with message "oops" but got RuntimeError with message "oops"
          code: raise "oops"
@@ -255,7 +253,6 @@ defmodule ExUnit.DocTestTest do
     """
 
     assert output =~ """
-      6) test #6 moduledoc at ExUnit.DocTestTest.Invalid (6) (ExUnit.DocTestTest.ActuallyCompiled)
          test/ex_unit/doc_test_test.exs:204
          Doctest failed: expected exception RuntimeError with message "hello" but got RuntimeError with message "oops"
          code: raise "oops"

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -208,7 +208,7 @@ defmodule ExUnit.DocTestTest do
     output = capture_io(fn -> ExUnit.run end)
 
     assert output =~ """
-      1) test moduledoc at ExUnit.DocTestTest.Invalid (1) (ExUnit.DocTestTest.ActuallyCompiled)
+      1) test #1 moduledoc at ExUnit.DocTestTest.Invalid (1) (ExUnit.DocTestTest.ActuallyCompiled)
          test/ex_unit/doc_test_test.exs:204
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:112: syntax error before: '*'
          code: 1 + * 1
@@ -217,7 +217,7 @@ defmodule ExUnit.DocTestTest do
     """
 
     assert output =~ """
-      2) test moduledoc at ExUnit.DocTestTest.Invalid (2) (ExUnit.DocTestTest.ActuallyCompiled)
+      2) test #2 moduledoc at ExUnit.DocTestTest.Invalid (2) (ExUnit.DocTestTest.ActuallyCompiled)
          test/ex_unit/doc_test_test.exs:204
          Doctest failed
          code: 1 + hd(List.flatten([1])) === 3
@@ -227,7 +227,7 @@ defmodule ExUnit.DocTestTest do
     """
 
     assert output =~ """
-      3) test moduledoc at ExUnit.DocTestTest.Invalid (3) (ExUnit.DocTestTest.ActuallyCompiled)
+      3) test #3 moduledoc at ExUnit.DocTestTest.Invalid (3) (ExUnit.DocTestTest.ActuallyCompiled)
          test/ex_unit/doc_test_test.exs:204
          Doctest failed
          code: inspect(:oops) === "#HashDict<[]>"
@@ -237,7 +237,7 @@ defmodule ExUnit.DocTestTest do
     """
 
     assert output =~ """
-      4) test moduledoc at ExUnit.DocTestTest.Invalid (4) (ExUnit.DocTestTest.ActuallyCompiled)
+      4) test #4 moduledoc at ExUnit.DocTestTest.Invalid (4) (ExUnit.DocTestTest.ActuallyCompiled)
          test/ex_unit/doc_test_test.exs:204
          Doctest failed: got UndefinedFunctionError with message undefined function: Hello.world/0 (module Hello is not available)
          code:  Hello.world
@@ -246,7 +246,7 @@ defmodule ExUnit.DocTestTest do
     """
 
     assert output =~ """
-      5) test moduledoc at ExUnit.DocTestTest.Invalid (5) (ExUnit.DocTestTest.ActuallyCompiled)
+      5) test #5 moduledoc at ExUnit.DocTestTest.Invalid (5) (ExUnit.DocTestTest.ActuallyCompiled)
          test/ex_unit/doc_test_test.exs:204
          Doctest failed: expected exception WhatIsThis with message "oops" but got RuntimeError with message "oops"
          code: raise "oops"
@@ -255,7 +255,7 @@ defmodule ExUnit.DocTestTest do
     """
 
     assert output =~ """
-      6) test moduledoc at ExUnit.DocTestTest.Invalid (6) (ExUnit.DocTestTest.ActuallyCompiled)
+      6) test #6 moduledoc at ExUnit.DocTestTest.Invalid (6) (ExUnit.DocTestTest.ActuallyCompiled)
          test/ex_unit/doc_test_test.exs:204
          Doctest failed: expected exception RuntimeError with message "hello" but got RuntimeError with message "oops"
          code: raise "oops"

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -101,4 +101,22 @@ defmodule ExUnitTest do
     end
     {Process.get(:capture_result), output}
   end
+
+  test "it executes different tests having the same name" do
+    defmodule TestWithSameNames do
+      use ExUnit.Case, async: false
+
+      test "same name, different outcome" do
+        assert 1 == 1
+      end
+
+      test "same name, different outcome" do
+        assert 1 == 2
+      end
+    end
+
+    assert capture_io(fn ->
+      assert ExUnit.run == %{failures: 1, skipped: 0, total: 2}
+    end) =~ "2 tests, 1 failure"
+  end
 end

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -102,7 +102,7 @@ defmodule ExUnitTest do
     {Process.get(:capture_result), output}
   end
 
-  test "it executes different tests having the same name" do
+  test "it registers only the first test with any given name" do
     defmodule TestWithSameNames do
       use ExUnit.Case, async: false
 
@@ -116,7 +116,7 @@ defmodule ExUnitTest do
     end
 
     assert capture_io(fn ->
-      assert ExUnit.run == %{failures: 1, skipped: 0, total: 2}
-    end) =~ "2 tests, 1 failure"
+      assert ExUnit.run == %{failures: 0, skipped: 0, total: 1}
+    end) =~ "1 tests, 0 failure"
   end
 end


### PR DESCRIPTION
Currently, if several tests have the same name (it can very easily happen accidentally), only the first test is executed and other tests are silently ignored, leaving the user with a false sense of security.

For instance, if you run the test added to `ex_unit_test.exs` on master, it will fail as follow:

```
  1) test it executes different tests having the same name (ExUnitTest)
     test/ex_unit_test.exs:105
     Assertion with == failed
     code: ExUnit.run() == %{failures: 1, skipped: 0, total: 2}
     lhs:  %{failures: 0, skipped: 0, total: 2}
     rhs:  %{failures: 1, skipped: 0, total: 2}
     stacktrace:
       (ex_unit) lib/ex_unit/capture_io.ex:99: ExUnit.CaptureIO.do_capture_io/3
       test/ex_unit_test.exs:118
```

Two tests were added to the list but only the first one got executed (twice, because of the pattern matching rules).

To solve this issue, this patch ensures that all tests (and thus the generated test functions) have a unique name.

Note: It's a bit unfortunate that this small internal change has a (limited) visible effect to the user (see changes in `doc_test_test.exs`). But I'm afraid that completely decoupling the displayed test name from the function name would have been a change with a much larger impact than this.