### PR TITLE
fix documentation for Record Types

### DIFF
--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -29,7 +29,7 @@ defmodule Record do
 
       defmodule MyModule do
         require Record
-        Record.defrecord :user name: "john", age: 25
+        Record.defrecord :user, name: "john", age: 25
 
         @type user :: record(:user, name: String.t, age: integer)
         # expands to: `@type user :: {:user, String.t, integer}`


### PR DESCRIPTION
Previously the documentation for `Record` included an example usage of
`Record.defrecord` that was missing a comma after the `name` argument.
This has been updated.
