### PR TITLE
Remove empty/1 callback from Collectable implementations

### DIFF
--- a/lib/elixir/lib/file/stream.ex
+++ b/lib/elixir/lib/file/stream.ex
@@ -34,10 +34,6 @@ defmodule File.Stream do
   end
 
   defimpl Collectable do
-    def empty(stream) do
-      stream
-    end
-
     def into(%{path: path, modes: modes, raw: raw} = stream) do
       modes = for mode <- modes, not mode in [:read], do: mode
 

--- a/lib/elixir/lib/hash_dict.ex
+++ b/lib/elixir/lib/hash_dict.ex
@@ -245,10 +245,6 @@ defimpl Access, for: HashDict do
 end
 
 defimpl Collectable, for: HashDict do
-  def empty(_dict) do
-    HashDict.new
-  end
-
   def into(original) do
     {original, fn
       dict, {:cont, {k, v}} -> Dict.put(dict, k, v)

--- a/lib/elixir/lib/hash_set.ex
+++ b/lib/elixir/lib/hash_set.ex
@@ -253,10 +253,6 @@ defimpl Enumerable, for: HashSet do
 end
 
 defimpl Collectable, for: HashSet do
-  def empty(_dict) do
-    HashSet.new
-  end
-
   def into(original) do
     {original, fn
       set, {:cont, x} -> HashSet.put(set, x)

--- a/lib/elixir/lib/io/stream.ex
+++ b/lib/elixir/lib/io/stream.ex
@@ -30,10 +30,6 @@ defmodule IO.Stream do
   end
 
   defimpl Collectable do
-    def empty(stream) do
-      stream
-    end
-
     def into(%{device: device, raw: raw} = stream) do
       {:ok, into(stream, device, raw)}
     end

--- a/lib/elixir/test/elixir/kernel/comprehension_test.exs
+++ b/lib/elixir/test/elixir/kernel/comprehension_test.exs
@@ -10,10 +10,6 @@ defmodule Kernel.ComprehensionTest do
     defstruct []
 
     defimpl Collectable do
-      def empty(struct) do
-        struct
-      end
-
       def into(struct) do
         {struct,
          fn

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -7,10 +7,6 @@ defmodule StreamTest do
     defstruct []
 
     defimpl Collectable do
-      def empty(struct) do
-        struct
-      end
-
       def into(struct) do
         {struct,
          fn


### PR DESCRIPTION
The Collectable protocol does not contain this callback
anymore. Unused callbacks are confusing.
