### PR TITLE
Remove dead @doc snippet

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2404,20 +2404,6 @@ defmodule Kernel do
   end
 
   @doc """
-  Access the given element using the qualifier according
-  to the `Access` protocol. All calls in the form `foo[bar]`
-  are translated to `access(foo, bar)`.
-
-  The usage of this protocol is to access a raw value in a
-  keyword list.
-
-      iex> sample = [a: 1, b: 2, c: 3]
-      iex> sample[:b]
-      2
-
-  """
-
-  @doc """
   Checks if the element on the left side is member of the
   collection on the right side.
 


### PR DESCRIPTION
Not sure where this comes from (I didn't dig into 'blame'), but I presume it's left-over documentation for a removed function. I did some quick searching, and I can't see the docs showing up anywhere, so I presume it should be cleaned up.
