### PR TITLE
Add support for --werl in Windows bash-like shells

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -16,6 +16,7 @@ if [ $# -eq 0 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
   --cookie \"cookie\" Sets a cookie for this distributed node
   --hidden          Makes a hidden node
   --detached        Starts the Erlang VM detached from console
+  --werl            Uses Erlang's Windows shell GUI (Windows only)
   --no-halt         Does not halt the Erlang VM after execution
 
 ** Options marked with (*) can be given more than once
@@ -35,6 +36,7 @@ readlink_f () {
 }
 
 MODE="elixir"
+ERL_EXEC="erl"
 ERL=""
 I=1
 
@@ -71,6 +73,9 @@ while [ $I -le $# ]; do
         eval "VAL=\${$I}"
         ERL="$ERL "$VAL""
         ;;
+    --werl)
+        USE_WERL=true
+        ;;
     *)
         break
         ;;
@@ -89,11 +94,15 @@ if [ "$OS" != "Windows_NT" ]; then
   if test -t 1 -a -t 2; then ERL="-elixir ansi_enabled true $ERL"; fi
 fi
 
+if [ "$OS" = "Windows_NT" ] && [ $USE_WERL ]; then
+    ERL_EXEC="werl"
+fi
+
 if [ -z "$ERL_PATH" ]; then
   if [ -f "$SCRIPT_PATH/../releases/RELEASES" ] && [ -f "$SCRIPT_PATH/erl" ]; then
-    ERL_PATH="$SCRIPT_PATH"/erl
+    ERL_PATH="$SCRIPT_PATH"/"$ERL_EXEC"
   else
-    ERL_PATH=erl
+    ERL_PATH="$ERL_EXEC"
   fi
 fi
 

--- a/bin/iex
+++ b/bin/iex
@@ -15,6 +15,7 @@ if [ $# -gt 0 ] && ([ "$1" = "--help" ] || [ "$1" = "-h" ]); then
   --sname \"name\"    Makes and assigns a short name to the distributed node
   --cookie \"cookie\" Sets a cookie for this distributed node
   --hidden          Makes a hidden node
+  --werl            Uses Erlang's Windows shell GUI (Windows only)
   --detached        Starts the Erlang VM detached from console
   --remsh \"name\"    Connects to a node using a remote shell
   --dot-iex \"path\"  Overrides default .iex.exs file and uses path instead;


### PR DESCRIPTION
As per discussion on [elixir-lang-talk](https://groups.google.com/forum/?fromgroups=#!topic/elixir-lang-talk/bBiMB3hNJ8w). Only tested on Windows, but _should_ not interfere on other OS-es.

TODO:
- [x] Test on a *nix (will test on my Mac)
- [x] Add doc to `bin/iex`
- [x] Add doc to `bin/elixir`
