### PR TITLE
Add type and spec information to help function

### DIFF
--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -27,6 +27,8 @@ defmodule IEx.Introspection do
             _ ->
               IO.puts IEx.color(:eval_error, "#{inspect module} was not compiled with docs")
           end
+          t(module)
+          s(module)
         else
           IO.puts IEx.color(:eval_error, "#{inspect module} is an Erlang module and, as such, it does not have Elixir-style docs")
         end
@@ -122,6 +124,7 @@ defmodule IEx.Introspection do
 
       if doc do
         print_doc(doc)
+        s(mod, fun, arity)
         :ok
       else
         :not_found


### PR DESCRIPTION
This is just quickly hacked together, but should be enough for initial feedback. Today I played around with types and typespecs a bit, and thought it'd be nice to have them included in `iex`'s `h` helper. 

The final result looks like this:

![screen shot 2014-12-12 at 00 26 25](https://cloud.githubusercontent.com/assets/47985/5398506/8cf47502-8195-11e4-9117-7d3f03a40160.png)

And for functions:

![screen shot 2014-12-12 at 00 25 13](https://cloud.githubusercontent.com/assets/47985/5398491/65777312-8195-11e4-9df8-dbc11d45b648.png)

Before I spend any more time on this, I wanted to clarify a couple of things:
1. Does anyone besides me care for this functionality?
2. Is the current implementation sensible?

If the answer to the above questions is "yes", I can polish this off a bit, add specs etc. I'm also open to suggestions on how to change/improve this.
