### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ sudo: false
 
 script: "make compile && rm -rf .git && make test"
 
-matrix:
-  allow_failures:
-    - otp_release: 17.3
-
 notifications:
   irc: "irc.freenode.org#elixir-lang"
   recipients:


### PR DESCRIPTION
OTP 17.3 is now working on the new build environment on travis, so I think we should require the tests to pass again ...

Hope they can have 17.4 soon...
