### PR TITLE
Add cover directory from 'mix test --cover' to default .gitignore

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -197,6 +197,7 @@ defmodule Mix.Tasks.New do
    /deps
    erl_crash.dump
    *.ez
+   /cover
    """
 
   embed_template :mixfile, """


### PR DESCRIPTION
Notice this directory gets created in the root of the project when the --cover option is used with mix test. 

These are generated files, dependent on the specific time you run the command, so it doesn't seem like most  users would want to check them in. 
