### PR TITLE
Integer.parse/2 shouldn't parse when base is not an integer

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -128,7 +128,7 @@ defmodule Integer do
 
   """
   @spec parse(binary, integer) :: {integer, binary} | :error | no_return
-  def parse(binary, base) when base in 2..36 do
+  def parse(binary, base) when is_integer(base) and base in 2..36 do
     parse_in_base(binary, base)
   end
 

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -65,7 +65,12 @@ defmodule IntegerTest do
     assert Integer.parse("64eb", 10) === {64, "eb"}
     assert Integer.parse("10", 2) === {2, ""}
     assert Integer.parse("++4", 10) === :error
+
+    # Base should be in range 2..36
     assert_raise ArgumentError, "invalid base 0", fn -> Integer.parse("2", 0) end
     assert_raise ArgumentError, "invalid base 41", fn -> Integer.parse("2", 41) end
+
+    # Base should be an integer
+    assert_raise ArgumentError, "invalid base 10.2", fn -> Integer.parse("2", 10.2) end
   end
 end


### PR DESCRIPTION
Right now the spec of Integer.parse/2 correctly mentions the base of Integer.parse/2 should be an integer, but the code does not currently comply with it. That is because of bug https://github.com/elixir-lang/elixir/issues/2912 causes floating points like 10.2 be considered in range 2..32.

```
iex(1)> Integer.parse("34", 10.2)
{34.599999999999994, ""}
iex(2)> Integer.parse("34", 10.1231)
{34.3693, ""}
iex(3)> Integer.parse("34", 10.5)   
{35.5, ""}
```

Before issue https://github.com/elixir-lang/elixir/issues/2912 is fixed we should check if the given base is an integer.
