### PR TITLE
Remove unnecessary Integer.parse/1

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -99,19 +99,19 @@ defmodule Integer do
       iex> Integer.parse("three")
       :error
 
-      iex > Integer.parse("34", 10)
+      iex> Integer.parse("34", 10)
       {34, ""}
 
-      iex > Integer.parse("f4", 16)
+      iex> Integer.parse("f4", 16)
       {244, ""}
 
-      iex > Integer.parse("Awww++", 36)
+      iex> Integer.parse("Awww++", 36)
       {509216, "++"}
 
-      iex > Integer.parse("fab", 10)
+      iex> Integer.parse("fab", 10)
       :error
 
-      iex > Integer.parse("a2", 38)
+      iex> Integer.parse("a2", 38)
       ** (ArgumentError) invalid base 38
 
   """


### PR DESCRIPTION
Now that we have introduced Integer.parse/2 a few days ago, we can get rid of Integer.parse/1. Instead, we can specify a default base, just as we only have Integer.do_digits/2 and Integer.do_undigits/2 with default base.

This PR may have a merge conflict with PR https://github.com/elixir-lang/elixir/pull/2971 if both look good.
