### PR TITLE
Check Elixir version right after archive installation

### DIFF
--- a/lib/mix/lib/mix/local.ex
+++ b/lib/mix/lib/mix/local.ex
@@ -16,7 +16,7 @@ defmodule Mix.Local do
   """
   def append_archives do
     archives = archives_ebin()
-    Enum.each(archives, &check_elixir_archive_vsn/1)
+    Enum.each(archives, &check_elixir_version_in_ebin/1)
     Enum.each(archives, &Code.append_path/1)
   end
 
@@ -31,7 +31,7 @@ defmodule Mix.Local do
   Returns all tasks in local archives.
   """
   def all_tasks do
-    Mix.Task.load_tasks(archives_ebin)
+    Mix.Task.load_tasks(archives_ebin())
   end
 
   @doc """
@@ -42,22 +42,29 @@ defmodule Mix.Local do
     archives(name, ".ez") ++ archives(name, "-*.ez")
   end
 
+  @doc """
+  Check Elixir version requirement stored in the archive and print a warning if it is not satisfied.
+  """
+  def check_archive_elixir_version(path) do
+    path |> Mix.Archive.ebin |> check_elixir_version_in_ebin()
+  end
+
   defp archives(name, suffix) do
-    Mix.Local.archives_path
+    archives_path()
     |> Path.join(name <> suffix)
     |> Path.wildcard
   end
 
   defp archives_ebin do
-    Path.join(archives_path, "*.ez") |> Path.wildcard |> Enum.map(&Mix.Archive.ebin/1)
+    Path.join(archives_path(), "*.ez") |> Path.wildcard |> Enum.map(&Mix.Archive.ebin/1)
   end
 
-  defp check_elixir_archive_vsn(ebin) do
-    elixir = ebin |> Path.dirname() |> Path.join(".elixir") |> String.to_char_list
+  defp check_elixir_version_in_ebin(ebin) do
+    elixir = ebin |> Path.dirname |> Path.join(".elixir") |> String.to_char_list
     case :erl_prim_loader.get_file(elixir) do
       {:ok, req, _} ->
         unless Version.match?(System.version, req) do
-          archive = ebin |> Path.dirname() |> Path.basename
+          archive = ebin |> Path.dirname |> Path.basename
           Mix.shell.error "warning: the archive #{archive} requires Elixir #{inspect req} " <>
                           "but you are running on v#{System.version}"
         end

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -59,6 +59,7 @@ defmodule Mix.Tasks.Archive.Install do
 
       if Mix.Utils.copy_path!(src, archive, opts) do
         Mix.shell.info [:green, "* creating ", :reset, Path.relative_to_cwd(archive)]
+        Mix.Local.check_archive_elixir_version archive
       end
 
       true = Code.append_path(Mix.Archive.ebin(archive))

--- a/lib/mix/test/mix/tasks/archive_test.exs
+++ b/lib/mix/test/mix/tasks/archive_test.exs
@@ -30,13 +30,16 @@ defmodule Mix.Tasks.ArchiveTest do
       Mix.Tasks.Archive.Install.run []
       assert File.regular? tmp_path("userhome/.mix/archives/archive-0.1.0.ez")
 
+      # Check that the version warning is printed after installation
+      version_error = "warning: the archive archive-0.1.0 requires Elixir \"~> 0.1.0\" but you are running on v#{System.version}"
+      assert_received {:mix_shell, :error, [^version_error]}
+
       archive = tmp_path("userhome/.mix/archives/archive-0.1.0.ez/archive-0.1.0/ebin")
       assert to_char_list(archive) in :code.get_path
 
       # Load it!
       Mix.Local.append_archives
-      error = "warning: the archive archive-0.1.0 requires Elixir \"~> 0.1.0\" but you are running on v#{System.version}"
-      assert_received {:mix_shell, :error, [^error]}
+      assert_received {:mix_shell, :error, [^version_error]}
 
       # List it!
       Mix.Tasks.Local.run []


### PR DESCRIPTION
This is more informative from the user experience point of view, than delaying the check until another mix task is executed in the future
