### PR TITLE
Specify error from node/1 as an atom

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -500,7 +500,7 @@ defmodule Kernel do
   @doc """
   Returns the node where the given argument is located.
   The argument can be a pid, a reference, or a port.
-  If the local node is not alive, `nonode@nohost` is returned.
+  If the local node is not alive, `:nonode@nohost` is returned.
 
   Allowed in guard tests. Inlined by the compiler.
   """


### PR DESCRIPTION
This is a small documentation patch, error returned from node/1 when node is not alive does not have the atom identifier