### PR TITLE
Rescue inspect failures in Formatter (#2959)

### DIFF
--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -97,8 +97,8 @@ defmodule ExUnit.Formatter do
   @spec format_filters(Keyword.t, atom) :: String.t
   def format_filters(filters, type) do
     case type do
-      :include -> "Including tags: #{inspect filters}"
-      :exclude -> "Excluding tags: #{inspect filters}"
+      :include -> "Including tags: #{safe_inspect filters}"
+      :exclude -> "Excluding tags: #{safe_inspect filters}"
     end
   end
 
@@ -107,7 +107,7 @@ defmodule ExUnit.Formatter do
   """
   def format_test_failure(test, {kind, reason, stack}, counter, width, formatter) do
     %ExUnit.Test{name: name, case: case, tags: tags} = test
-    test_info(with_counter(counter, "#{name} (#{inspect case})"), formatter)
+    test_info(with_counter(counter, "#{name} (#{safe_inspect case})"), formatter)
       <> test_location(with_location(tags), formatter)
       <> format_kind_reason(kind, reason, width, formatter)
       <> format_stacktrace(stack, case, name, formatter)
@@ -118,7 +118,7 @@ defmodule ExUnit.Formatter do
   """
   def format_test_case_failure(test_case, {kind, reason, stacktrace}, counter, width, formatter) do
     %ExUnit.TestCase{name: name} = test_case
-    test_case_info(with_counter(counter, "#{inspect name}: "), formatter)
+    test_case_info(with_counter(counter, "#{safe_inspect name}: "), formatter)
       <> format_kind_reason(kind, reason, width, formatter)
       <> format_stacktrace(stacktrace, name, nil, formatter)
   end
@@ -186,8 +186,16 @@ defmodule ExUnit.Formatter do
 
   defp inspect_multiline(expr, width) do
     expr
-    |> inspect(pretty: true, width: width)
+    |> safe_inspect(pretty: true, width: width)
     |> String.replace("\n", "\n" <> @inspect_padding)
+  end
+
+  defp safe_inspect(expr, opts \\ []) do
+    try do
+      inspect(expr, opts)
+    rescue
+      e -> "inspect failed: #{inspect e}"
+    end
   end
 
   defp make_into_lines(reasons, padding) do

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -191,11 +191,7 @@ defmodule ExUnit.Formatter do
   end
 
   defp safe_inspect(expr, opts \\ []) do
-    try do
-      inspect(expr, opts)
-    rescue
-      e -> "inspect failed: #{inspect e}"
-    end
+    inspect(expr, Keyword.put(opts, :safe, true))
   end
 
   defp make_into_lines(reasons, padding) do

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -33,7 +33,7 @@ defmodule ExUnit.FormatterTest do
     end
 
     defimpl Inspect do
-      def inspect(struct, _) do
+      def inspect(struct, opts) when is_atom(opts) do
         struct.unknown
       end
     end
@@ -120,7 +120,7 @@ defmodule ExUnit.FormatterTest do
          Assertion with == failed
          code: :will_fail == %Failing{}
          lhs:  :will_fail
-         rhs:  inspect failed: %ArgumentError{message: \"Got KeyError with message \\\"key :unknown not found in: %{__struct__: ExUnit.FormatterTest.Failing, key: 0}\\\" while inspecting %{__struct__: ExUnit.FormatterTest.Failing, key: 0}\"}
+         rhs:  %Inspect.Error{message: \"got FunctionClauseError with message `no function clause matching in Inspect.ExUnit.FormatterTest.Failing.inspect/2` while inspecting %{__struct__: ExUnit.FormatterTest.Failing, key: 0}\"}
     """
   end
 


### PR DESCRIPTION
I took a quick shot at this. Are there any other failure case to account for?