### PR TITLE
GenServer docs fix: missing {:ok, state, :hibernate} for init callback

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -69,6 +69,7 @@ defmodule GenServer do
 
       -  `{:ok, state}`
       -  `{:ok, state, timeout}`
+      -  `{:ok, state, :hibernate}`
       -  `:ignore`
       -  `{:stop, reason}`
 


### PR DESCRIPTION
According to  [erlang documentation for gen_server module](http://erlang.org/doc/man/gen_server.html#Module:init-1) init callback can return ```{ok, State, hibernate}``` tuple. It was missing in elixir docs and this PR fixes this.