### PR TITLE
Invert the order of non matching token messages (closes #2993)

### DIFF
--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -220,7 +220,10 @@ string_to_quoted(String, StartLine, File, Opts) when is_integer(StartLine), is_b
         {error, {{Line, _, _}, _, [Error, Token]}} -> {error, {Line, to_binary(Error), to_binary(Token)}};
         {error, {Line, _, [Error, Token]}} -> {error, {Line, to_binary(Error), to_binary(Token)}}
       end;
-    {error, {Line, Error, Token}, _Rest, _SoFar} -> {error, {Line, to_binary(Error), to_binary(Token)}}
+    {error, {Line, {ErrorPrefix, ErrorSuffix}, Token}, _Rest, _SoFar} ->
+      {error, {Line, {to_binary(ErrorPrefix), to_binary(ErrorSuffix)}, to_binary(Token)}};
+    {error, {Line, Error, Token}, _Rest, _SoFar} ->
+      {error, {Line, to_binary(Error), to_binary(Token)}}
   end.
 
 'string_to_quoted!'(String, StartLine, File, Opts) ->

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -42,7 +42,7 @@ compile_error(Meta, File, Format, Args) when is_list(Format)  ->
 
 %% Tokenization parsing/errors.
 
--spec parse_error(non_neg_integer(), binary(), binary(), binary()) -> no_return().
+-spec parse_error(non_neg_integer(), binary() | {binary(), binary()}, binary(), binary()) -> no_return().
 
 parse_error(Line, File, Error, <<>>) ->
   Message = case Error of
@@ -78,10 +78,16 @@ parse_error(Line, File, Error, <<"[", _/binary>> = Full) when is_binary(Error) -
     end,
   do_raise(Line, File, 'Elixir.SyntaxError', <<Error/binary, Rest/binary >>);
 
+%% Given a string prefix and suffix to insert the token inside the error message rather than append it
+parse_error(Line, File, {ErrorPrefix, ErrorSuffix}, Token) when is_binary(ErrorPrefix), is_binary(ErrorSuffix), is_binary(Token) ->
+  Message = <<ErrorPrefix/binary, Token/binary, ErrorSuffix/binary >>,
+  do_raise(Line, File, 'Elixir.SyntaxError', Message);
+
 %% Everything else is fine as is
 parse_error(Line, File, Error, Token) when is_binary(Error), is_binary(Token) ->
   Message = <<Error/binary, Token/binary >>,
   do_raise(Line, File, 'Elixir.SyntaxError', Message).
+
 
 %% Handle warnings and errors from Erlang land (called during module compilation)
 

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -919,9 +919,10 @@ check_terminator({E, _}, [{S, _}|Terminators]) when
 check_terminator({E, {Line, _, _}}, [{Start, {StartLine, _, _}}|_]) when
     E == 'end'; E == ')'; E == ']'; E == '}'; E == '>>' ->
   End = terminator(Start),
-  Message = io_lib:format("\"~ts\" starting at line ~B is missing terminator \"~ts\". "
-                          "Unexpected token: ", [Start, StartLine, End]),
-  {error, {Line, Message, atom_to_list(E)}};
+  MessagePrefix = "unexpected token: \"",
+  MessageSuffix = io_lib:format("\". \"~ts\" starting at line ~B is missing terminator \"~ts\"",
+                                [Start, StartLine, End]),
+  {error, {Line, {MessagePrefix, MessageSuffix}, [atom_to_list(E)]}};
 
 check_terminator({E, Line}, []) when
     E == 'end'; E == ')'; E == ']'; E == '}'; E == '>>' ->

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -546,7 +546,7 @@ defmodule Kernel.ErrorsTest do
 
   test :interpolation_error do
     assert_compile_fail SyntaxError,
-      "nofile:1: \"do\" starting at line 1 is missing terminator \"end\". Unexpected token: )",
+      "nofile:1: unexpected token: \")\". \"do\" starting at line 1 is missing terminator \"end\"",
       '"foo\#{case 1 do )}bar"'
   end
 

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -73,7 +73,7 @@ defmodule IEx.InteractionTest do
   end
 
   test "invalid input" do
-    assert capture_iex("if true do ) false end") =~ "** (SyntaxError) iex:1: \"do\" starting at"
+    assert capture_iex("if true do ) false end") =~ "** (SyntaxError) iex:1: unexpected token: \")\". \"do\" starting at"
   end
 
   test "undefined function" do


### PR DESCRIPTION
Added a new way to return errors from the tokenizer by providing a prefix and suffix message to improve the flexibility of message formatting.