### PR TITLE
Set MIX_ARCHIVES in mix tasks archive tests

### DIFF
--- a/lib/mix/test/mix/tasks/archive_test.exs
+++ b/lib/mix/test/mix/tasks/archive_test.exs
@@ -17,7 +17,7 @@ defmodule Mix.Tasks.ArchiveTest do
 
   test "archive" do
     File.rm_rf! tmp_path("userhome")
-    System.put_env "MIX_HOME", tmp_path("userhome/.mix")
+    System.put_env "MIX_ARCHIVES", tmp_path("userhome/.mix/archives/")
     Mix.Project.push(ArchiveProject)
 
     in_fixture "archive", fn() ->


### PR DESCRIPTION
Previously archive tests would fail if MIX_ARCHIVES was set.

Partially resolves #3002.

I still get the warning printed to console:
```
warning: the archive archive-0.1.0 requires Elixir "~> 0.1.0" but you are running on v1.1.0-dev 
```