### PR TITLE
Fix error documentation for Kernel.hd/1

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -240,7 +240,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns the head of a list, raises `badarg` if the list is empty.
+  Returns the head of a list, raises `ArgumentError` if the list is empty.
 
   Inlined by the compiler.
   """


### PR DESCRIPTION
I'm brand new to Elixir, so I was going through the Getting Started guide and noticed a discrepancy between the documentation of the Kernel.hd function and its actual results in the interactive shell.

When I call Kernel.hd on an empty list, it throws an ArgumentError, which mirrors the Kernel.tl function.

That being said, I'm brand new here so I might be missing something.