### PR TITLE
optional prefix message parameter for create_file and create_directory

### DIFF
--- a/lib/mix/lib/mix/generator.ex
+++ b/lib/mix/lib/mix/generator.ex
@@ -12,10 +12,12 @@ defmodule Mix.Generator do
 
   ## Options
 
-    * `:force` - forces installation without a shell prompt.
+    * `:force`   - forces installation without a shell prompt.
+    * `:message` - prefix output text before `path`. (default: "* creating ")
   """
   def create_file(path, contents, opts \\ []) when is_binary(path) do
-    Mix.shell.info [:green, "* creating ", :reset, Path.relative_to_cwd(path)]
+    message = opts[:message] || "* creating "
+    Mix.shell.info [:green, message, :reset, Path.relative_to_cwd(path)]
 
     if opts[:force] || Mix.Utils.overwriting?(path) do
       File.mkdir_p!(Path.dirname(path))
@@ -25,9 +27,14 @@ defmodule Mix.Generator do
 
   @doc """
   Creates a directory if one does not exist yet.
+
+  ## Options
+
+    * `:message` - prefix output text before `path`. (default: "* creating ")
   """
-  def create_directory(path) when is_binary(path) do
-    Mix.shell.info [:green, "* creating ", :reset, Path.relative_to_cwd(path)]
+  def create_directory(path, opts \\ []) when is_binary(path) do
+    message = opts[:message] || "* creating "
+    Mix.shell.info [:green, message, :reset, Path.relative_to_cwd(path)]
     File.mkdir_p! path
   end
 

--- a/lib/mix/test/mix/generator_test.exs
+++ b/lib/mix/test/mix/generator_test.exs
@@ -29,6 +29,14 @@ defmodule Mix.GeneratorTest do
     end
   end
 
+  test :create_file_with_different_prefix_message do
+    in_tmp "create_file", fn ->
+      create_file "foo", "HELLO", message: "    create "
+      assert File.read!("foo") == "HELLO"
+      assert_received {:mix_shell, :info, ["    create foo"]}
+    end
+  end
+
   test :force_create_file do
     in_tmp "create_file", fn ->
       File.write! "foo", "HELLO"
@@ -62,6 +70,22 @@ defmodule Mix.GeneratorTest do
       assert File.read!("foo") == "HELLO"
 
       assert_received {:mix_shell, :yes?, ["foo already exists, overwrite?"]}
+    end
+  end
+
+  test :create_directory do
+    in_tmp "create_directory", fn ->
+      create_directory "foo"
+      assert File.dir?("foo")
+      assert_received {:mix_shell, :info, ["* creating foo"]}
+    end
+  end
+
+  test :create_directory_with_different_prefix_message do
+    in_tmp "create_directory", fn ->
+      create_directory "foo", message: "    create "
+      assert File.dir?("foo")
+      assert_received {:mix_shell, :info, ["    create foo"]}
     end
   end
 end


### PR DESCRIPTION
Hi,

While working with `Mix.Generator` module I'm using the `create_file` and `create_directory` frequently. But lately I would like to output a different prefix message as the default `* creating`. 

So I added optional prefix message parameter for `Mix.Generator.create_file` and `Mix.Generator.create_directory`.

I would like to be able to use it that way, rather than implementing `create_file` and `create_directory` for my own codebase again.

Example `create_file`:

```ex
  create_file "foo", "HELLO"
  # * creating foo

  create_file "foo", "HELLO", message: "    create "
  #     create foo
```
Example `create_directory`:

```ex
  create_directory "foo"
  # * creating foo

  create_directory "foo", message: "    create "
  #     create foo
```

I also added an additional test for `create_directory` because it was missing.

Cheers