### PR TITLE
Add --color option description to mix moduledoc.

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -51,6 +51,7 @@ defmodule Mix.Tasks.Test do
     * `--no-compile` - do not compile, even if files require compilation
     * `--no-start`   - do not start applications after compilation
     * `--no-color`   - disable color in the output
+    * `--color`      - enable color in the output
     * `--include`    - include tests that match the filter
     * `--exclude`    - exclude tests that match the filter
     * `--only`       - run only tests that match the filter


### PR DESCRIPTION
Didn't realize --color was an option since it is missing from the module doc (needed it when calling 'mix test' programmatically). Came across it in the github issues. Thought it should be added to save others time.