### PR TITLE
Corrected docstring for Mix.Task.get/1

### DIFF
--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -161,10 +161,10 @@ defmodule Mix.Task do
   end
 
   @doc """
-  Receives a task name and returns `{:ok, module}` if a task is found.
+  Receives a task name and returns the task module if found.
 
-  Otherwise returns `{:error, :invalid}` in case the module
-  exists but it isn't a task or `{:error, :not_found}`.
+  Otherwise returns `nil` in case the module
+  exists but it isn't a task or cannot be found.
   """
   @spec get(task_name) :: task_module | nil
   def get(task) do


### PR DESCRIPTION
The docstring for Mix.Task.get/1 incorrectly referred to the return values of fetch/1.