### PR TITLE
Call Logger.flush in System.at_exit when running mix test.

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -191,6 +191,13 @@ defmodule Mix.Tasks.Test do
     if cover, do: cover.()
 
     System.at_exit fn _ ->
+      # Make sure all messages the tests might have sent to the
+      # Logger are printed before we shut down the VM.
+      case Process.whereis(Logger) do
+        pid when is_pid(pid) -> Logger.flush()
+        nil -> :ok
+      end
+
       if failures > 0, do: exit({:shutdown, 1})
     end
   end


### PR DESCRIPTION
I ran into that today, took me a while to figure out why the errors that made my tests fail weren't printed. I only realized what was going on after the error was printed by chance.

I imagine this might be a pitfall especially for people new to Elixir.

I'm not sure how to test this.

/cc @fishcakez