### PR TITLE
Add an example of defining a `__using__/1` macro

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3249,6 +3249,16 @@ defmodule Kernel do
         end
       end
 
+  `__using__/1` is just a regular macro that can be defined in any module:
+
+      defmodule MyModule do
+        defmacro __using__(opts) do
+          quote do
+            # code that will run in the module that will `use MyModule`
+          end
+        end
+      end
+
   """
   defmacro use(module, opts \\ []) do
     expanded = Macro.expand(module, __CALLER__)


### PR DESCRIPTION
The behaviour was explained pretty clearly in the docs, but for example it was unclear that `__using__/1` has to be a macro. I added an example so that it's easier to understand how to use `use/1-2` and `__using__/2`.