### PR TITLE
Revert "Don't ignore escape characters in regex"

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -491,13 +491,18 @@ defmodule Regex do
     [List.to_integer(ns) | precompile_replacement(rest)]
   end
 
-  defp precompile_replacement(<<?\\, ?\\, rest :: binary>>) do
-    [<<?\\>> | precompile_replacement(rest)]
+  defp precompile_replacement(<<?\\, x, rest :: binary>>) when x < ?0 or x > ?9 do
+    case precompile_replacement(rest) do
+      [head | t] when is_binary(head) ->
+        [<<x, head :: binary>> | t]
+      other ->
+        [<<x>> | other]
+    end
   end
 
-  defp precompile_replacement(<<?\\, x, rest :: binary>>) when x in ?0..?9 do
+  defp precompile_replacement(<<?\\, rest :: binary>>) when byte_size(rest) > 0 do
     {ns, rest} = pick_int(rest)
-    [List.to_integer([x|ns]) | precompile_replacement(rest)]
+    [List.to_integer(ns) | precompile_replacement(rest)]
   end
 
   defp precompile_replacement(<<x, rest :: binary>>) do

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -198,11 +198,6 @@ defmodule RegexTest do
     assert Regex.replace(~r(b), "abcbe", "d") == "adcde"
     assert Regex.replace(~r(b), "abcbe", "d", global: false) == "adcbe"
 
-    assert Regex.replace(~r/ /, "first third", "\\second\\") ==
-           "first\\second\\third"
-    assert Regex.replace(~r/ /, "first third", "\\\\second\\\\") ==
-           "first\\second\\third"
-
     assert Regex.replace(~r[a(b)c], "abcabc", fn -> "ac" end) == "acac"
     assert Regex.replace(~r[a(b)c], "abcabc", fn "abc" -> "ac" end) == "acac"
     assert Regex.replace(~r[a(b)c], "abcabc", fn "abc", "b" -> "ac" end) == "acac"


### PR DESCRIPTION
This reverts commit af9a69dadd9d68abcf9e01db86e8ffe180f937ce.
which this bug: https://github.com/elixir-lang/ex_doc/commit/5b520c4cad67c3a4b55042ca588ecfb5bea0b41f#commitcomment-9521480

There is nothing wrong with: https://github.com/elixir-lang/ex_doc/commit/5b520c4cad67c3a4b55042ca588ecfb5bea0b41f
and no need to fix anything in: https://github.com/elixir-lang/ex_doc/pull/184

I have run `git bisect` to identify the buggy commit,
```
git bisect start
# bad: [278e5c7e8720bbb6ba073329e0f069682b75c27b] Use :application.info[:loaded] to avoid races
git bisect bad 278e5c7e8720bbb6ba073329e0f069682b75c27b
# good: [34df8176385200d483ab483a973c498ffa62e580] Release v1.0.2
git bisect good 34df8176385200d483ab483a973c498ffa62e580
# good: [52ff7e96867c027745d29f5d3feb77f546f22c4f] Release v1.0.0
git bisect good 52ff7e96867c027745d29f5d3feb77f546f22c4f
# good: [588fc32484c3feb8af08402c93f50c1ff2e95de1] Merge pull request #2906 from eugmes/empty-string-split-fix
git bisect good 588fc32484c3feb8af08402c93f50c1ff2e95de1
# good: [150a8a1dcd3610d5ff875e00a1c8779894456ca6] Fix bootstrap issues
git bisect good 150a8a1dcd3610d5ff875e00a1c8779894456ca6
# good: [62220546630f3781d09fb30e49f34b84dd420a32] add missing assert call
git bisect good 62220546630f3781d09fb30e49f34b84dd420a32
# bad: [af9a69dadd9d68abcf9e01db86e8ffe180f937ce] Don't ignore escape characters in regex
git bisect bad af9a69dadd9d68abcf9e01db86e8ffe180f937ce
# good: [e1711f6a6302625a2e1d249664797424df70e540] Optimize common flat_map_reduce paths
git bisect good e1711f6a6302625a2e1d249664797424df70e540
# good: [c09225073d0e60e475c005c97d2db63a6008e584] Merge pull request #3015 from indiejames/master
git bisect good c09225073d0e60e475c005c97d2db63a6008e584
# good: [1a3bca6726ae2b8fc464e559ae450d3a4562c9b3] Add test for metadata defaults
git bisect good 1a3bca6726ae2b8fc464e559ae450d3a4562c9b3
# good: [a99206b3b0e690cb131e9e8041706d1129ff2610] Merge pull request #3018 from lexmag/logger-metadata-fix
git bisect good a99206b3b0e690cb131e9e8041706d1129ff2610
# good: [26291179130268373c9e4a392d3e8f0d0d93380b] Remove unused umbrella flag
git bisect good 26291179130268373c9e4a392d3e8f0d0d93380b
# first bad commit: [af9a69dadd9d68abcf9e01db86e8ffe180f937ce] Don't ignore escape characters in regex
```

the testing script  would search for 
`cat test_error/doc/TE.html | grep '>iex\\&gt;'`
in the generated docs