### PR TITLE
Unify Keyword.merge/2 and Keyword.merge/3 behaviour

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -386,14 +386,13 @@ defmodule Keyword do
 
   ## Examples
 
-      iex> Keyword.merge([a: 1, b: 2], [a: 3, d: 4]) |> Enum.sort
+      iex> Keyword.merge([a: 1, b: 2], [d: 4, a: 3])
       [a: 3, b: 2, d: 4]
 
   """
   @spec merge(t, t) :: t
   def merge(d1, d2) when is_list(d1) and is_list(d2) do
-    fun = fn {k, _v} -> not has_key?(d2, k) end
-    d2 ++ :lists.filter(fun, d1)
+    merge(d1, d2, fn _k, _v1, v2 -> v2 end)
   end
 
   @doc """

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -240,7 +240,7 @@ defmodule Kernel.TypespecTest do
 
     assert [type: {:mytype,
              {:type, _, :tuple, [
-               {:atom, 0, :timestamp}, {:atom, 0, :foo}, {:type, 0, :term, []}
+               {:atom, 0, :timestamp}, {:type, 0, :term, []}, {:atom, 0, :foo}
              ]},
             []}] = types(module)
   end
@@ -254,7 +254,7 @@ defmodule Kernel.TypespecTest do
 
     assert [type: {:mytype,
              {:type, _, :tuple, [
-               {:atom, 0, :timestamp}, {:atom, 0, :foo}, {:type, 0, :term, []}
+               {:atom, 0, :timestamp}, {:type, 0, :term, []}, {:atom, 0, :foo}
              ]},
             []}] = types(module)
   end

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -213,12 +213,12 @@ defmodule Keyword.DuplicatedTest do
   end
 
   test "merge/2" do
-    assert Keyword.merge(create_empty_keywords, create_keywords) == create_keywords
+    assert Keyword.merge(create_empty_keywords, create_keywords) == [first_key: 2, second_key: 2]
     assert Keyword.merge(create_keywords, create_empty_keywords) == create_keywords
-    assert Keyword.merge(create_keywords, create_keywords) == create_keywords
+    assert Keyword.merge(create_keywords, create_keywords) == [first_key: 2, second_key: 2]
     assert Keyword.merge(create_empty_keywords, create_empty_keywords) == []
     assert Keyword.merge(create_keywords, [first_key: 0]) == [first_key: 0, second_key: 2]
-    assert Keyword.merge(create_keywords, [first_key: 0, first_key: 3]) == [first_key: 0, first_key: 3, second_key: 2]
+    assert Keyword.merge(create_keywords, [first_key: 0, first_key: 3]) == [first_key: 3, second_key: 2]
   end
 
   test "merge/3" do


### PR DESCRIPTION
This PR normalizes keyword reordering between `merge/2` and `merge/3`

While not necessarily a bug, I noticed that calling `Keyword.merge/2` did not preserve the ordering of the keywords in the first list.

This made it exceptionally hard to re-define erlang records with new defaults per Elixir.Record documentation, [as is necessary when the erlang record has an anonymous function as its default](http://elixir-lang.org/docs/master/elixir/) because it potentially changed the ordering of the fields in the tuple.

An example, working with [inaka's apns4erl library](/inaka/apns4erl)
```elixir
  Record.defrecord :apns_connection,
    Record.Extractor.extract(:apns_connection, from_lib: "apns/include/apns.hrl")
    |> Keyword.merge([
      error_fun: &__MODULE__.error_fun/2,
      feedback_fun: &__MODULE__.feedback_fun/1,
    ])
```
The defined `apns_connection` can have fields in the incorrect order. Currently the only workaround is to use `merge/3`, reimplementing the desired behaviour of `merge/2` but without reordering
```elixir
  Record.defrecord :apns_connection,
    Record.Extractor.extract(:apns_connection, from_lib: "apns/include/apns.hrl")
    |> Keyword.merge([
      error_fun: &__MODULE__.error_fun/2,
      feedback_fun: &__MODULE__.feedback_fun/1,
    ], fn _k, _v1, v2 -> v2 end)
```
This PR fixes the need to call `merge/3` in this scenario