### PR TITLE
fix broken system path test

### DIFF
--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -73,7 +73,12 @@ defmodule SystemTest do
     File.cp! System.find_executable("echo"), echo2
 
     relative = Path.relative_to_cwd(echo2)
-    assert :enoent = catch_error(System.cmd(relative, ["hello"]))
+
+    if Path.absname(relative) == relative do
+      assert {"hello\n", 0} = System.cmd(relative, ["hello"])
+    else
+      assert :enoent = catch_error(System.cmd(relative, ["hello"]))
+    end
 
     File.cd! dir, fn ->
       assert :enoent = catch_error(System.cmd("echo2", ["hello"]))


### PR DESCRIPTION
Fix https://github.com/elixir-lang/elixir/issues/3044.

The reasoning is described in the issue comment. The essence is according to Path module spec, relative_to_cwd can return the passed in path somehow if it fails to get the relative path.