### PR TITLE
Expand attributes and macros in record extractor

### DIFF
--- a/lib/elixir/lib/record/extractor.ex
+++ b/lib/elixir/lib/record/extractor.ex
@@ -45,10 +45,11 @@ defmodule Record.Extractor do
   end
 
   # Read a file and return its abstract syntax form that also
-  # includes record and other preprocessor modules. This is done
-  # by using Erlang's epp_dodger.
+  # includes record but with macros and other attributes expanded,
+  # such as `-include(...)` and `-include_lib(...)`. This is done
+  # by using Erlang's epp.
   defp read_file(file) do
-    case :epp_dodger.quick_parse_file(file) do
+    case :epp.parse_file(file, []) do
       {:ok, form} ->
         form
       other ->
@@ -80,11 +81,11 @@ defmodule Record.Extractor do
 
   defp eval_record(cons, form) do
     form = form ++
-      [ {:function, 0, :hello, 0, [
-          {:clause, 0, [], [], [ cons ]} ]} ]
+      [{:function, 0, :hello, 0, [
+         {:clause, 0, [], [], [cons]}]}]
 
     {:function, 0, :hello, 0, [
-      {:clause, 0, [], [], [ record_ast ]} ]} = :erl_expand_records.module(form, []) |> List.last
+      {:clause, 0, [], [], [record_ast]}]} = :erl_expand_records.module(form, []) |> List.last
 
     {:value, record, _} = :erl_eval.expr(record_ast, [])
     record

--- a/lib/elixir/test/elixir/record_test.exs
+++ b/lib/elixir/test/elixir/record_test.exs
@@ -52,7 +52,10 @@ defmodule RecordTest do
 
   Record.defrecord  :timestamp, [:date, :time]
   Record.defrecord  :user, __MODULE__, name: "john", age: 25
-  Record.defrecordp :file_info, Record.extract(:file_info, from_lib: "kernel/include/file.hrl")
+  Record.defrecordp :file_info,
+    Record.extract(:file_info, from_lib: "kernel/include/file.hrl")
+  Record.defrecordp :certificate, :OTPCertificate,
+    Record.extract(:OTPCertificate, from_lib: "public_key/include/public_key.hrl")
 
   test "records generates macros that generates tuples" do
     record = user()


### PR DESCRIPTION
Achieved by using :epp.parse_file/2 instead of
:epp_dodger.quick_parse_file/1.