### PR TITLE
Raise an appropriate error when raise/1 is called with an invalid arg

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1301,7 +1301,7 @@ defmodule Kernel do
   If `msg` is an atom, it just calls `raise/2` with the atom as the first
   argument and `[]` as the second argument.
 
-  If `msg` is anything else, the given exception is raised.
+  If `msg` is anything else, raises an `ArgumentError` exception.
 
   ## Examples
 
@@ -1347,6 +1347,8 @@ defmodule Kernel do
               :erlang.error atom.exception([])
             %{__struct__: struct, __exception__: true} = other when is_atom(struct) ->
               :erlang.error other
+            _ ->
+              :erlang.error ArgumentError.exception("raise/1 expects an alias or a string as the first argument")
           end
         end
     end
@@ -1426,6 +1428,8 @@ defmodule Kernel do
               :erlang.raise :error, atom.exception([]), stacktrace
             %{__struct__: struct, __exception__: true} = other when is_atom(struct) ->
               :erlang.raise :error, other, stacktrace
+            _ ->
+              :erlang.error ArgumentError.exception("reraise/2 expects an alias or a string as the first argument")
           end
         end
     end


### PR DESCRIPTION
When `raise/1` (or `reraise/2`) is called with an invalid argument (not a module name neither a binary message), a cryptic `CaseClauseError` is raised. This behaviour exposes the underlying implementation details of the `raise/1` (or `reraise/2`) macro. I'm not sure this is a good thing since when I'm using native language "constructs" (I know they're macro, but still) I generally would like clear error messages that show me where I messed things up.

This PR makes `raise/1` and `reraise/2` raise an `ArgumentError` when the `msg` argument isn't a binary or a module name.

I kind of know that it's not the coolest thing ever to raise an error if you mess up trying to *raise an error*, but at the current state you still *get an error*, just not an easy one to mentally debug.

I did not make the same changes to `raise/2` and `reraise/3` since the error messages there are way more easy to understand:

```iex
iex> raise 3, message: "foo"
** (CompileError) iex:1: invalid call 3.exception(message: "foo")
iex> raise nil, message: "foo"
** (UndefinedFunctionError) undefined function: nil.exception/1
```

I'm not sure about the exception *message*, I just wrote the first thing I found decent :smile: Let me know what you think.

Thanks!