### PR TITLE
Add timeout option for tests

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -188,6 +188,8 @@ defmodule ExUnit do
       filter
 
     * `:seed` - an integer seed value to randomize the test suite
+
+    * `:timeout` - set the timeout for the tests
   """
   def configure(options) do
     Enum.each options, fn {k, v} ->

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -12,14 +12,15 @@ defmodule ExUnit.Runner do
     Enum.each formatters, &(:ok = EM.add_handler(pid, &1, opts))
 
     config = %{
-      seed: opts[:seed],
-      max_cases: opts[:max_cases],
-      sync_cases: [],
       async_cases: [],
-      taken_cases: 0,
-      include: opts[:include],
       exclude: opts[:exclude],
-      manager: pid
+      include: opts[:include],
+      manager: pid,
+      max_cases: opts[:max_cases],
+      seed: opts[:seed],
+      sync_cases: [],
+      taken_cases: 0,
+      timeout: opts[:timeout]
     }
 
     {run_us, _} =
@@ -188,7 +189,7 @@ defmodule ExUnit.Runner do
     EM.test_finished(config.manager, test)
   end
 
-  defp spawn_test(_config, test, context) do
+  defp spawn_test(config, test, context) do
     parent = self()
 
     {test_pid, test_ref} =
@@ -209,7 +210,7 @@ defmodule ExUnit.Runner do
         exit(:shutdown)
       end)
 
-    timeout = Map.get(test.tags, :timeout, 30_000)
+    timeout = Map.get(test.tags, :timeout, config.timeout)
 
     test =
       receive do

--- a/lib/ex_unit/mix.exs
+++ b/lib/ex_unit/mix.exs
@@ -17,9 +17,10 @@ defmodule ExUnit.Mixfile do
 
        autorun: true,
        colors: [],
-       trace: false,
-       formatters: [ExUnit.CLIFormatter],
+       exclude: [],
        include: [],
-       exclude: []]]
+       formatters: [ExUnit.CLIFormatter],
+       timeout: 30_000,
+       trace: false]]
   end
 end

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -55,6 +55,23 @@ defmodule ExUnitTest do
     assert output =~ ~r"\(stdlib\) timer\.erl:\d+: :timer\.sleep/1"
   end
 
+  test "it supports configured timeout" do
+    defmodule ConfiguredTimeoutTest do
+      use ExUnit.Case
+
+      test "ok" do
+        :timer.sleep(:infinity)
+      end
+    end
+
+    ExUnit.configure(timeout: 5)
+    output = capture_io(fn -> ExUnit.run end)
+    assert output =~ "** (ExUnit.TimeoutError) test timed out after 5ms"
+
+  after
+    ExUnit.configure(timeout: 30_000)
+  end
+
   test "filtering cases with tags" do
     defmodule ParityTest do
       use ExUnit.Case

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -56,6 +56,7 @@ defmodule Mix.Tasks.Test do
     * `--exclude`    - exclude tests that match the filter
     * `--only`       - run only tests that match the filter
     * `--seed`       - seeds the random number generator used to randomize tests order
+    * `--timeout`    - set the timeout for the tests
 
   ## Filters
 
@@ -131,7 +132,7 @@ defmodule Mix.Tasks.Test do
   @switches [force: :boolean, color: :boolean, cover: :boolean,
              trace: :boolean, max_cases: :integer, include: :keep,
              exclude: :keep, seed: :integer, only: :keep, compile: :boolean,
-             start: :boolean]
+             start: :boolean, timeout: :integer]
 
   @cover [output: "cover", tool: Cover]
 
@@ -206,7 +207,7 @@ defmodule Mix.Tasks.Test do
            |> filter_only_opts()
 
     default_opts(opts) ++
-      Dict.take(opts, [:trace, :max_cases, :include, :exclude, :seed])
+      Dict.take(opts, [:trace, :max_cases, :include, :exclude, :seed, :timeout])
   end
 
   defp default_opts(opts) do


### PR DESCRIPTION
Add support for timeout configuration for tests.

It can be done by setting the `timeout` option inside the `test_helper` file.

Example: 

```elixir
  ExUnit.start(timeout: 60_000)
```

Also it enables the timeout with the command line option.

Example:

```
  mix test --timeout 60000
```

@josevalim Thanks for the help with this patch :heart: 