### PR TITLE
update links to website

### DIFF
--- a/lib/elixir/lib/gen_event.ex
+++ b/lib/elixir/lib/gen_event.ex
@@ -155,7 +155,7 @@ defmodule GenEvent do
   guides provide a tutorial-like introduction. The documentation and links
   in Erlang can also provide extra insight.
 
-    * http://elixir-lang.org/getting_started/mix_otp/1.html
+    * http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html
     * http://www.erlang.org/doc/man/gen_event.html
     * http://learnyousomeerlang.com/event-handlers
 

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -198,7 +198,7 @@ defmodule GenServer do
   guides provide a tutorial-like introduction. The documentation and links
   in Erlang can also provide extra insight.
 
-    * http://elixir-lang.org/getting_started/mix_otp/1.html
+    * http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html
     * http://www.erlang.org/doc/man/gen_server.html
     * http://www.erlang.org/doc/design_principles/gen_server_concepts.html
     * http://learnyousomeerlang.com/clients-and-servers


### PR DESCRIPTION
just one question.
is it desired to link to 
http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html

or it's better to link directly to 
http://elixir-lang.org/getting-started/mix-otp/genserver.html
and
http://elixir-lang.org/getting-started/mix-otp/genevent.html

or have both links (introduction and genX)