### PR TITLE
Added to tuple.ex module doc a see also note ...

### DIFF
--- a/lib/elixir/lib/tuple.ex
+++ b/lib/elixir/lib/tuple.ex
@@ -1,6 +1,9 @@
 defmodule Tuple do
   @moduledoc """
   Functions for working with tuples.
+
+  See also 'Kernel.elem/2', 'Kernel.is_tuple/1', 'Kernel.put_elem/3', and 
+  'Kernel.tuple_size/1'.
   """
 
   @doc """


### PR DESCRIPTION
...referencing the various Kernel functions dealing with tuples. The rationale for this is that its confusing for a newcomer to the language that these are not members of tuple and it provides a hint as to where these are actually found.

I should also mention that it seems to me a little bit of a smell that there are four functions in Tuple and four in Kernel dealing with tuples ... 