### PR TITLE
singular/plural issue with `mix test`

### DIFF
--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -132,7 +132,20 @@ defmodule ExUnit.CLIFormatter do
     IO.write "\n\n"
     IO.puts format_time(run_us, load_us)
 
-    message = "#{config.tests_counter} tests, #{config.failures_counter} failures"
+    # singular/plural
+    if config.tests_counter == 1 do
+      test_pl = "test"
+    else
+      test_pl = "tests"
+    end
+
+    if config.failures_counter == 1 do
+      failure_pl = "failure"
+    else
+      failure_pl = "failures"
+    end
+
+    message = "#{config.tests_counter} #{test_pl}, #{config.failures_counter} #{failure_pl}"
 
     if config.skipped_counter > 0 do
       message = message <> ", #{config.skipped_counter} skipped"

--- a/lib/ex_unit/test/ex_unit/callbacks_test.exs
+++ b/lib/ex_unit/test/ex_unit/callbacks_test.exs
@@ -29,7 +29,7 @@ defmodule ExUnit.CallbacksTest do
     end
 
     assert capture_io(fn -> ExUnit.run end) =~
-           "1 tests, 0 failures"
+           "1 test, 0 failures"
   end
 
   test "doesn't choke on setup errors" do
@@ -139,7 +139,7 @@ defmodule ExUnit.CallbacksTest do
 
     output = capture_io(fn -> ExUnit.run end)
     assert output =~ "on_exit run"
-    assert output =~ "1 tests, 0 failures"
+    assert output =~ "1 test, 0 failures"
   end
 
   test "runs multiple on_exit exits and overrides by ref" do

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -278,7 +278,7 @@ defmodule ExUnit.DocTestTest do
       end
     end
 
-    assert capture_io(fn -> ExUnit.run end) =~ "1 tests, 0 failures"
+    assert capture_io(fn -> ExUnit.run end) =~ "1 test, 0 failures"
   end
 
   test "multiple exceptions in one test case is not supported" do

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -37,7 +37,7 @@ defmodule ExUnitTest do
 
     assert capture_io(fn ->
       assert ExUnit.run == %{failures: 1, skipped: 0, total: 1}
-    end) =~ "1 tests, 1 failures"
+    end) =~ "1 test, 1 failure"
   end
 
   test "it supports timeouts" do
@@ -92,7 +92,7 @@ defmodule ExUnitTest do
 
     {result, output} = run_with_filter([], test_cases)
     assert result == %{failures: 1, skipped: 0, total: 4}
-    assert output =~ "4 tests, 1 failures"
+    assert output =~ "4 tests, 1 failure"
 
     {result, output} = run_with_filter([exclude: [even: true]], test_cases)
     assert result == %{failures: 0, skipped: 1, total: 4}
@@ -104,11 +104,11 @@ defmodule ExUnitTest do
 
     {result, output} = run_with_filter([exclude: :even, include: [even: true]], test_cases)
     assert result == %{failures: 1, skipped: 2, total: 4}
-    assert output =~ "4 tests, 1 failures, 2 skipped"
+    assert output =~ "4 tests, 1 failure, 2 skipped"
 
     {result, output} = run_with_filter([exclude: :test, include: [even: true]], test_cases)
     assert result == %{failures: 1, skipped: 3, total: 4}
-    assert output =~ "4 tests, 1 failures, 3 skipped"
+    assert output =~ "4 tests, 1 failure, 3 skipped"
   end
 
   defp run_with_filter(filters, {async, sync, load_us}) do
@@ -136,6 +136,6 @@ defmodule ExUnitTest do
 
     assert capture_io(fn ->
       assert ExUnit.run == %{failures: 0, skipped: 0, total: 1}
-    end) =~ "1 tests, 0 failure"
+    end) =~ "1 test, 0 failure"
   end
 end

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -128,7 +128,7 @@ defmodule Mix.CLITest do
 
       output = mix ~w[test test/new_with_tests_test.exs --cover]
       assert File.regular?("_build/test/lib/new_with_tests/ebin/Elixir.NewWithTests.beam")
-      assert output =~ "1 tests, 0 failures"
+      assert output =~ "1 test, 0 failures"
       assert output =~ "Generating cover results ..."
       assert File.regular?("cover/Elixir.NewWithTests.html")
     end
@@ -141,7 +141,7 @@ defmodule Mix.CLITest do
 
       output = mix ~w[test]
       assert File.regular?("_build/test/lib/sup_with_tests/ebin/Elixir.SupWithTests.beam")
-      assert output =~ "1 tests, 0 failures"
+      assert output =~ "1 test, 0 failures"
     end
   end
 


### PR DESCRIPTION
```
  1) test removes buckets on exit (KV.RegistryTest)
     test/kv/registry_test.exs:19
     ** (exit) exited in: GenServer.call(#PID<0.115.0>, :stop, 5000)
         ** (EXIT) no process
     stacktrace:
       (elixir) lib/gen_server.ex:357: GenServer.call/3
       test/kv/registry_test.exs:23

..

Finished in 0.4 seconds (0.4s on load, 0.06s on tests)
1 tests, 1 failures
```
**1 tests, 1 failures**