### PR TITLE
Throw syntax error for `:foo.Bar`

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -596,6 +596,9 @@ build_block(Exprs)                                      -> {'__block__', [], Exp
 build_dot_alias(Dot, {'__aliases__', _, Left}, {'aliases', _, Right}) ->
   {'__aliases__', meta(Dot), Left ++ Right};
 
+build_dot_alias(_Dot, Atom, {'aliases', {Line, _, _}, _}) when is_atom(Atom) ->
+  throw_bad_atom(Line);
+
 build_dot_alias(Dot, Other, {'aliases', _, Right}) ->
   {'__aliases__', meta(Dot), [Other|Right]}.
 
@@ -744,3 +747,7 @@ throw_no_parens_many_strict(Token) ->
 
   throw(Line, "unexpected comma. Parentheses are required to solve ambiguity "
     "in nested calls. Syntax error before: ", "','").
+
+throw_bad_atom(Line) ->
+  throw(Line, "atom cannot be followed by an alias. If the '.' was meant to be "
+    "part of the atom's name, the name must be quoted. Syntax error before: ", "'.'").

--- a/lib/elixir/test/erlang/atom_test.erl
+++ b/lib/elixir/test/erlang/atom_test.erl
@@ -39,3 +39,7 @@ atom_with_interpolation_test() ->
 
 quoted_atom_chars_are_escaped_test() ->
   {'"',[]} = eval(":\"\\\"\"").
+
+atom_dot_alias_test() ->
+  ?assertError(#{'__struct__' := 'Elixir.SyntaxError'}, eval(":foo.Bar")),
+  ?assertError(#{'__struct__' := 'Elixir.SyntaxError'}, eval(":\"foo\".Bar")).


### PR DESCRIPTION
Closes #2986 (I think)

I wasn't too sure if this was the right place for the test, and whether to include both tests or just one (or more than two).