### PR TITLE
Set timeout to infinity with trace enabled

### DIFF
--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -38,6 +38,7 @@ defmodule ExUnit.Runner do
     opts =
       if opts[:trace] do
         Keyword.put_new(opts, :max_cases, 1)
+        |> Keyword.put(:timeout, :infinity)
       else
         Keyword.put(opts, :trace, false)
       end
@@ -49,6 +50,7 @@ defmodule ExUnit.Runner do
     |> Keyword.put(:include, include)
     |> Keyword.put_new(:max_cases, :erlang.system_info(:schedulers_online))
     |> Keyword.put_new(:seed, :erlang.now |> elem(2))
+    |> Keyword.put_new(:timeout, 30_000)
   end
 
   defp loop(config) do

--- a/lib/ex_unit/mix.exs
+++ b/lib/ex_unit/mix.exs
@@ -14,13 +14,13 @@ defmodule ExUnit.Mixfile do
        # Calculated on demand
        # max_cases: :erlang.system_info(:schedulers_online),
        # seed: rand(),
+       # timeout: 30_000
 
        autorun: true,
        colors: [],
        exclude: [],
        include: [],
        formatters: [ExUnit.CLIFormatter],
-       timeout: 30_000,
        trace: false]]
   end
 end

--- a/lib/ex_unit/test/ex_unit/runner_test.exs
+++ b/lib/ex_unit/test/ex_unit/runner_test.exs
@@ -1,0 +1,23 @@
+Code.require_file "../test_helper.exs", __DIR__
+
+defmodule ExUnit.RunnerTest do
+  use ExUnit.Case
+
+  test "it set the timeout to infinity and max cases to one with trace enabled" do
+    opts = Keyword.merge(ExUnit.configuration, trace: true)
+
+    {_, config} = ExUnit.Runner.configure(opts)
+
+    assert config[:timeout] == :infinity
+    assert config[:max_cases] == 1
+  end
+
+  test "it does not set timeout to infinity and the max cases to 1 with trace disabled" do
+    opts = Keyword.merge(ExUnit.configuration, trace: false)
+
+    {_, config} = ExUnit.Runner.configure(opts)
+
+    assert config[:max_cases] != 1
+    assert config[:timeout] == 30_000
+  end
+end


### PR DESCRIPTION
Automatically set the `:timeout` to `:infinity` when trace is enabled.

Also I extracted some logic from the `run` function in the `Runner` module to a new function so it could be tested.

@josevalim thanks again for the help with this patch :)