### PR TITLE
Add Record.extract_all/1 returning all records information

### DIFF
--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -57,6 +57,19 @@ defmodule Record do
   end
 
   @doc """
+  Extracts all records information from an Erlang file.
+
+  Returns a keyword list containing extracted record names as keys, and
+  lists of tuples describing the fields as values. It expects a named
+  argument :from or :from_lib, which correspond to *include* or
+  *include_lib* attribute from Erlang modules, respectively.
+
+  """
+  def extract_all(opts) when is_list(opts) do
+    Record.Extractor.extract_all(opts)
+  end
+
+  @doc """
   Checks if the given `data` is a record of `kind`.
 
   This is implemented as a macro so it can be used in guard clauses.

--- a/lib/elixir/test/elixir/record_test.exs
+++ b/lib/elixir/test/elixir/record_test.exs
@@ -28,6 +28,13 @@ defmodule RecordTest do
            StructExtract.__struct__
   end
 
+  test "extract_all/1 extracts all records information from an Erlang file" do
+    all_extract = Record.extract_all(from_lib: "kernel/include/file.hrl")
+    assert length(all_extract) == 2 # has been stable over the very long time
+    assert all_extract[:file_info]
+    assert all_extract[:file_descriptor]
+  end
+
   # We need indirection to avoid warnings
   defp record?(data, kind) do
     Record.is_record(data, kind)


### PR DESCRIPTION
`Record.extract_all/1` is to extract records information from a given file in one go. It can be useful in the following situations:
- you have several records to extract from single Erlang (.hrl) file
- records names are hard to predict if they origin from other sources like code generators (ASN.1 for example)
