### PR TITLE
Move test for `:foo.Bar` syntax error

### DIFF
--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -125,6 +125,14 @@ defmodule Kernel.ErrorsTest do
     assert is_list(Enum.reverse [3, 2, 1], [4, 5, 6])
   end
 
+  test :syntax_error_on_atom_dot_alias do
+    msg = "nofile:1: atom cannot be followed by an alias. If the '.' was meant to be " <>
+          "part of the atom's name, the name must be quoted. Syntax error before: '.'"
+
+    assert_compile_fail SyntaxError, msg, ':foo.Bar'
+    assert_compile_fail SyntaxError, msg, ':"foo".Bar'
+  end
+
   test :syntax_error_with_no_token do
     assert_compile_fail TokenMissingError,
       "nofile:1: missing terminator: ) (for \"(\" starting at line 1)",

--- a/lib/elixir/test/erlang/atom_test.erl
+++ b/lib/elixir/test/erlang/atom_test.erl
@@ -40,7 +40,3 @@ atom_with_interpolation_test() ->
 
 quoted_atom_chars_are_escaped_test() ->
   {'"',[]} = eval(":\"\\\"\"").
-
-atom_dot_alias_test() ->
-  ?assertError(#{'__struct__' := 'Elixir.SyntaxError'}, eval(":foo.Bar")),
-  ?assertError(#{'__struct__' := 'Elixir.SyntaxError'}, eval(":\"foo\".Bar")).


### PR DESCRIPTION
Following up on https://github.com/elixir-lang/elixir/pull/3059, this is a better place to test that error.