### PR TITLE
Correct usage of `ExUnit.Assertions.flunk` and add guard for it

### DIFF
--- a/lib/elixir/test/elixir/test_helper.exs
+++ b/lib/elixir/test/elixir/test_helper.exs
@@ -100,6 +100,6 @@ defmodule CompileAssertion do
       error -> {error.__struct__, Exception.message(error)}
     end
 
-    result || flunk(message: "Expected expression to fail")
+    result || flunk("Expected expression to fail")
   end
 end

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -556,7 +556,7 @@ defmodule ExUnit.Assertions do
   """
   @spec flunk :: no_return
   @spec flunk(String.t) :: no_return
-  def flunk(message \\ "Flunked!") do
+  def flunk(message \\ "Flunked!") when is_binary(message) do
     assert false, message: message
   end
 end

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -382,4 +382,11 @@ defmodule ExUnit.AssertionsTest do
     error in [ExUnit.AssertionError] ->
       "This should raise an error" = error.message
   end
+
+  test "flunk with wrong argument type" do
+    "This should never be tested" = flunk ["flunk takes a binary, not a list"]
+  rescue
+    error ->
+      "no function clause matching in ExUnit.Assertions.flunk/1" = FunctionClauseError.message error
+  end
 end


### PR DESCRIPTION
Closes #3083:
- Fix incorrect call to `flunk` in test_helper.exs
- Add a guard to `flunk` to check the argument is the right type

I figured it's ok for a single PR even though it touches both Elixir and ExUnit, since it's about the same thing and pretty trivial.