### PR TITLE
Mix: add comma at the end of worker()

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -363,7 +363,7 @@ defmodule Mix.Tasks.New do
 
       children = [
         # Define workers and child supervisors to be supervised
-        # worker(<%= @mod %>.Worker, [arg1, arg2, arg3])
+        # worker(<%= @mod %>.Worker, [arg1, arg2, arg3]),
       ]
 
       # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html


### PR DESCRIPTION
make it easy to duplicate the worker line