### PR TITLE
Fix some docs in the `Atom` module

### DIFF
--- a/lib/elixir/lib/atom.ex
+++ b/lib/elixir/lib/atom.ex
@@ -1,12 +1,20 @@
 defmodule Atom do
-  @doc """
+  @moduledoc """
   Convenience functions for working with atoms.
+
+  See also `Kernel.is_atom/1`.
   """
 
   @doc """
-  Converts an atom to string.
+  Converts an atom to a string.
 
   Inlined by the compiler.
+
+  ## Examples
+
+      iex> Atom.to_string(:foo)
+      "foo"
+
   """
   @spec to_string(atom) :: String.t
   def to_string(atom) do
@@ -17,6 +25,12 @@ defmodule Atom do
   Converts an atom to a char list.
 
   Inlined by the compiler.
+
+  ## Examples
+
+      iex> Atom.to_char_list(:"An atom")
+      'An atom'
+
   """
   @spec to_char_list(atom) :: char_list
   def to_char_list(atom) do


### PR DESCRIPTION
- Changed a `@doc` to `@moduledoc` so that the `Atom` module has a module documentation
- Added examples to both `Atom.to_string/1` and `Atom.to_char_list/1`