### PR TITLE
Refine no parens parsing (#3074)

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -94,6 +94,20 @@ expr -> unmatched_expr : '$1'.
 %% In Elixir we have three main call syntaxes: with parentheses,
 %% without parentheses and with do blocks. They are represented
 %% in the AST as matched, no_parens and unmatched.
+%% 
+%% Calls without parentheses are further divided according to how
+%% problematic they are:
+%% (a) no_parens: a call with several arguments (e.g. `f a, b`)
+%% (b) no_parens_one_ambig: a call with one argument which is
+%%     itself a no_parens or no_parens_one_ambig (e.g. `f g a, b`
+%%     or `f g h a, b` and similar)
+%% (c) no_parens_one: a call with one unproblematic argument
+%%     (e.g. `f a` or `f g a` and similar)
+%%
+%% Note, in particular, that no_parens_one_ambig expressions are
+%% ambiguous and are interpreted such that the outer function has
+%% arity 1 (e.g. `f g a, b` is interpreted as `f(g(a, b))` rather
+%% than `f(g(a), b)`). Hence the name, no_parens_one_ambig.
 %%
 %% The distinction is required because we can't, for example, have
 %% a function call with a do block as argument inside another do

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -445,6 +445,7 @@ stab_parens_many -> open_paren call_args_no_parens_many close_paren : '$2'.
 
 container_expr -> matched_expr : '$1'.
 container_expr -> unmatched_expr : '$1'.
+container_expr -> no_parens_one_ambig_expr : throw_no_parens_many_strict('$1').
 container_expr -> no_parens_expr : throw_no_parens_many_strict('$1').
 
 container_args_base -> container_expr : ['$1'].

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -123,6 +123,7 @@ defmodule Kernel.ErrorsTest do
     assert is_list List.flatten [1]
     assert is_list Enum.reverse [3, 2, 1], [4, 5, 6]
     assert is_list(Enum.reverse [3, 2, 1], [4, 5, 6])
+    assert [List.flatten List.flatten [1]] == [[1]]
   end
 
   test :syntax_error_on_atom_dot_alias do

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -112,9 +112,11 @@ defmodule Kernel.ErrorsTest do
           "nested calls. Syntax error before: ','"
 
     assert_compile_fail SyntaxError, msg, '[foo 1, 2]'
+    assert_compile_fail SyntaxError, msg, '[foo bar 1, 2]'
     assert_compile_fail SyntaxError, msg, '[do: foo 1, 2]'
     assert_compile_fail SyntaxError, msg, 'foo(do: bar 1, 2)'
     assert_compile_fail SyntaxError, msg, '{foo 1, 2}'
+    assert_compile_fail SyntaxError, msg, '{foo bar 1, 2}'
     assert_compile_fail SyntaxError, msg, 'foo 1, foo 2, 3'
     assert_compile_fail SyntaxError, msg, 'foo(1, foo 2, 3)'
 


### PR DESCRIPTION
Resolves https://github.com/elixir-lang/elixir/issues/3074.

@josevalim I think this may not be quite what you had suggested, but it seemed to me necessary to have both `no_parens_one` and `no_parens_one_ambig` in order to have `[f g a, b]` and `[f g h a, b]` throw errors but not `[f g a]`.  I may be wrong on that though.

Also, if we want to emit a warning for `no_parens_one_ambig` calls such as `f g a, b` I'd be happy to look into it.  I personally like the idea of warning in such cases, and it would make take the steam out of https://github.com/elixir-lang/elixir-lang.github.com/issues/463, since the compiler would be doing the work for you there.  I haven't yet looked at the compiler downstream of the parser, so I expect I'd have a fair bit of digging to do before I'm able to add warnings and it'd probably be best to start another PR for it when the time comes.