### PR TITLE
Improve tokenization of identifiers and `k: v` keys

### DIFF
--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -55,7 +55,8 @@
 -define(is_atom_start(S), (?is_quote(S) orelse ?is_upcase(S) orelse ?is_downcase(S) orelse (S == $_))).
 -define(is_atom(S), (?is_identifier(S) orelse (S == $@))).
 
--define(is_identifier(S), (?is_digit(S) orelse ?is_upcase(S) orelse ?is_downcase(S) orelse (S == $_))).
+-define(is_identifier_start(S), (?is_upcase(S) orelse ?is_downcase(S) orelse (S == $_))).
+-define(is_identifier(S), (?is_digit(S) orelse ?is_identifier_start(S))).
 -define(is_sigil(S), ((S == $/) orelse (S == $<) orelse (S == $") orelse (S == $') orelse
                       (S == $[) orelse (S == $() orelse (S == ${) orelse (S == $|))).
 

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -37,6 +37,23 @@ defmodule Kernel.ErrorsTest do
       'Foo.:"\#{:bar}"'
   end
 
+  test :invalid_identifier do
+    msg = fn char, name -> "nofile:1: invalid character '#{char}' in name: #{name}" end
+
+    assert_compile_fail SyntaxError, msg.(:@, "foo@"), 'foo@'
+    assert_compile_fail SyntaxError, msg.(:@, "foo@"), 'foo@ '
+    assert_compile_fail SyntaxError, msg.(:@, "foo@bar"), 'foo@bar'
+    assert_compile_fail SyntaxError, msg.(:!, "Foo!"), 'Foo!'
+  end
+
+  test :kw_missing_space do
+    msg = "nofile:1: keyword argument must be followed by space after: foo:"
+
+    assert_compile_fail SyntaxError, msg, "foo:bar"
+    assert_compile_fail SyntaxError, msg, "foo:+"
+    assert_compile_fail SyntaxError, msg, "foo:+1"
+  end
+
   test :invalid_or_reserved_codepoint do
     assert_compile_fail ArgumentError,
       "invalid or reserved unicode codepoint 55296",

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -51,7 +51,12 @@ op_atom_test() ->
   [{atom,{1,1,6},f0_1}] = tokenize(":f0_1").
 
 kw_test() ->
-  [{kw_identifier, {1,1,3}, do}] = tokenize("do: "),
+  [{kw_identifier, {1,1,4}, do}] = tokenize("do: "),
+  [{kw_identifier, {1,1,4}, a@}] = tokenize("a@: "),
+  [{kw_identifier, {1,1,4}, 'A@'}] = tokenize("A@: "),
+  [{kw_identifier, {1,1,5}, a@b}] = tokenize("a@b: "),
+  [{kw_identifier, {1,1,5}, 'A@!'}] = tokenize("A@!: "),
+  [{kw_identifier, {1,1,5}, 'a@!'}] = tokenize("a@!: "),
   [{kw_identifier_unsafe, {1, 1, 10}, [<<"foo bar">>]}] = tokenize("\"foo bar\": ").
 
 integer_test() ->


### PR DESCRIPTION
Closes #3113:
- Fix tokenization of `a@b: ` and `A!: `
- Add error for `a@b` (previously tokenized like `a @b`)
- Unify tokenization of upper- and lower-case `k: v` keys
- Fix end-column value for `a: `

Some of the names are admittedly a bit awkward (e.g. for `HasEnding` I couldn't think of a simple term or phrase for "question mark or exclamation point", and some others).  The end-column change wasn't mentioned in the issue, but it was a bug that surfaced when unifying the tokenization of kv keys starting with upper- and lower-case.  Previously, the end-column for `a:` would have been 2 and for `A:` it would have been 3, and I figured they both should be 3.  I changed the value in the test accordingly (from 3 to 4 for `do:`).