### PR TITLE
Return value of RHS when matching with `_` on LHS

### DIFF
--- a/lib/elixir/src/elixir_translator.erl
+++ b/lib/elixir/src/elixir_translator.erl
@@ -10,7 +10,7 @@
 
 translate({'=', Meta, [Left, Right]}, S) ->
   Return = case Left of
-    {'_', _, Atom} when is_atom(Atom) -> false;
+    {'_', _, Atom} when is_atom(Atom) -> S#elixir_scope.return;
     _ -> true
   end,
 

--- a/lib/elixir/test/elixir/kernel/comprehension_test.exs
+++ b/lib/elixir/test/elixir/kernel/comprehension_test.exs
@@ -147,6 +147,12 @@ defmodule Kernel.ComprehensionTest do
     assert for({_,x} <- [1, 2, a: 3, b: 4, c: 5], do: x * 2) == [6, 8, 10]
   end
 
+  test "list for comprehension matched to '_' on last line of block" do
+    assert (if true do
+      _ = for x <- [1, 2, 3], do: x * 2
+    end) == [2, 4, 6]
+  end
+
   test "list for comprehensions with filters" do
     assert for(x <- [1, 2, 3], x > 1, x < 3, do: x * 2) == [4]
   end


### PR DESCRIPTION
Closes #3125 

I'm not sure whether this is all that was intended or whether the idea was to remove the `Return` option entirely (not sure if it is being used for anything else).  If it should be removed, I can give it a shot and add a commit to this PR.

[Updated: now that I think about it, I didn't take into account the 'on the last line' part in what you wrote.  Should this be done differently to include that?]