### PR TITLE
Produce clearer messages for syntax errors before a sigil

### DIFF
--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -106,6 +106,12 @@ defmodule Kernel.ErrorsTest do
       '+.foo'
   end
 
+  test :syntax_error_before_sigil do
+    assert_compile_fail SyntaxError,
+      "nofile:1: syntax error before: sigil ~s with content 'bar baz'",
+      '~s(foo) ~s(bar baz)'
+  end
+
   test :compile_error_on_op_ambiguity do
     msg = "nofile:1: \"a -1\" looks like a function call but there is a variable named \"a\", " <>
           "please use explicit parentheses or even spaces"


### PR DESCRIPTION
Closes #3130 

My apologies if this is needlessly ugly or generally wrong, I'm learning the erlang as I go :-)
Also, I wasn't sure if there was a clear way to avoid duplicating the `syntax error before: ` part, or whether 'content' is really the best term for what's inside the sigil (I noticed in the parser it's referred to as `Parts`, but that seemed less clear in this context).