### PR TITLE
Fix ExUnit.Assertions assertion fail doc example

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -25,10 +25,10 @@ defmodule ExUnit.Assertions do
   For example, `assert some_fun() == 10` will fail (assuming
   `some_fun()` returns 13):
 
-     Comparison (using ==) failed in:
-     code: some_fun() == 10
-     lhs:  13
-     rhs:  10
+      Comparison (using ==) failed in:
+      code: some_fun() == 10
+      lhs:  13
+      rhs:  10
 
   This module also provides other convenience functions
   like `assert_in_delta` and `assert_raise` to easily handle other


### PR DESCRIPTION
The comparison error code block was using a 3-space indentation instead
of 4. Due to this, the appearance of the example in the html generated
documentation looks broken.

This PR changes this:
![screenshot from 2015-03-05 00 19 33](https://cloud.githubusercontent.com/assets/4231743/6498659/52181442-c2cd-11e4-9c96-c2da3ac567e8.png)

To this:
![screenshot from 2015-03-05 00 27 48](https://cloud.githubusercontent.com/assets/4231743/6498754/77e946cc-c2ce-11e4-8f43-b09b3476e612.png)

Which I think is what was originally intended