### PR TITLE
Do not remove dest file on File.cp error

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -607,8 +607,6 @@ defmodule File do
         [dest|acc]
       {:error, :eexist} ->
         if callback.(src, dest) do
-          # If rm/1 fails, copy/2 will fail
-          _ = rm(dest)
           case copy(src, dest) do
             {:ok, _} ->
               copy_file_mode!(src, dest)
@@ -629,8 +627,6 @@ defmodule File do
         [dest|acc]
       {:error, :eexist} ->
         if callback.(src, dest) do
-          # If rm/1 fails, iF.make_symlink/2 will fail
-          _ = rm(dest)
           case F.make_symlink(link, dest) do
             :ok -> [dest|acc]
             {:error, reason} -> {:error, reason, src}


### PR DESCRIPTION
Fixes https://github.com/elixir-lang/elixir/issues/3155

Actually I have removed the 'rm' calls in `do_cp_file` and `do_cp_link` as I believe erlang takes care of not creating a file residue in case of failure. However, if that's not the case, either a bug report in erlang should be created or we have to delete the file conditionally only when the dest is not the same as src.