### PR TITLE
Reduce time complexity of Enum.uniq and Stream.uniq

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2035,13 +2035,12 @@ defmodule Enum do
   @spec uniq(t, (element -> term)) :: list
   def uniq(collection, fun \\ fn x -> x end)
 
-  # TODO: Use a HashSet
   def uniq(collection, fun) when is_list(collection) do
-    do_uniq(collection, [], fun)
+    do_uniq(collection, HashSet.new, fun)
   end
 
   def uniq(collection, fun) do
-    {list, _} = reduce(collection, {[], []}, R.uniq(fun))
+    {list, _} = reduce(collection, {[], HashSet.new}, R.uniq(fun))
     :lists.reverse(list)
   end
 
@@ -2437,9 +2436,10 @@ defmodule Enum do
 
   defp do_uniq([h|t], acc, fun) do
     fun_h = fun.(h)
-    case :lists.member(fun_h, acc) do
-      true  -> do_uniq(t, acc, fun)
-      false -> [h|do_uniq(t, [fun_h|acc], fun)]
+    if HashSet.member?(acc, fun_h) do
+      do_uniq(t, acc, fun)
+    else
+      [h|do_uniq(t, HashSet.put(acc, fun_h), fun)]
     end
   end
 

--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -382,7 +382,10 @@ defmodule Kernel.CLI do
   end
 
   defp filter_patterns(pattern) do
-    Enum.filter(Enum.uniq(Path.wildcard(pattern)), &File.regular?(&1))
+    pattern
+    |> Path.wildcard
+    |> :lists.usort
+    |> Enum.filter(&File.regular?/1)
   end
 
   defp filter_multiple_patterns(patterns) do
@@ -402,9 +405,9 @@ defmodule Kernel.CLI do
        &elem(&1, 1)
 
     if missing_patterns == [] do
-      {:ok, Enum.uniq(Enum.concat(files))}
+      {:ok, :lists.usort(Enum.concat(files))}
     else
-      {:missing,  Enum.uniq(missing_patterns)}
+      {:missing,  :lists.usort(missing_patterns)}
     end
   end
 

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -724,7 +724,7 @@ defmodule Stream do
   @spec uniq(Enumerable.t) :: Enumerable.t
   @spec uniq(Enumerable.t, (element -> term)) :: Enumerable.t
   def uniq(enum, fun \\ fn x -> x end) do
-    lazy enum, [], fn f1 -> R.uniq(fun, f1) end
+    lazy enum, HashSet.new, fn f1 -> R.uniq(fun, f1) end
   end
 
   @doc """

--- a/lib/elixir/lib/stream/reducers.ex
+++ b/lib/elixir/lib/stream/reducers.ex
@@ -169,10 +169,10 @@ defmodule Stream.Reducers do
     quote do
       fn(entry, acc(h, prev, t) = acc) ->
         value = unquote(callback).(entry)
-        if :lists.member(value, prev) do
+        if HashSet.member?(prev, value) do
           skip(acc)
         else
-          next_with_acc(unquote(f), entry, h, [value|prev], t)
+          next_with_acc(unquote(f), entry, h, HashSet.put(prev, value), t)
         end
       end
     end


### PR DESCRIPTION
Instead of searching already accumulated list for next value use separate HashSet to check if element was already seen.

Changes in Kernel.CLI are necessary because we don't have access to HashSet while bootstrapping.