### PR TITLE
Make Exception.exception/1 support binary argument in default impl.

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -486,28 +486,10 @@ end
 
 defmodule RuntimeError do
   defexception message: "runtime error"
-
-  @spec exception(String.t) :: Exception.t
-  def exception(msg) when is_binary(msg) do
-    %RuntimeError{message: msg}
-  end
-
-  def exception(arg) do
-    super(arg)
-  end
 end
 
 defmodule ArgumentError do
   defexception message: "argument error"
-
-  @spec exception(String.t) :: Exception.t
-  def exception(msg) when is_binary(msg) do
-    %ArgumentError{message: msg}
-  end
-
-  def exception(arg) do
-    super(arg)
-  end
 end
 
 defmodule ArithmeticError do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3102,8 +3102,8 @@ defmodule Kernel do
 
     * `exception/1` - receives the arguments given to `raise/2`
        and returns the exception struct. The default implementation
-       accepts a set of keyword arguments that is merged into the
-       struct.
+       accepts either a set of keyword arguments that is merged into
+       the struct or a string to be used as the exception's message.
 
     * `message/1` - receives the exception struct and must return its
       message. Most commonly exceptions have a message field which
@@ -3154,6 +3154,11 @@ defmodule Kernel do
     quote do
       @behaviour Exception
       fields = defstruct unquote(fields)
+
+      @spec exception(String.t) :: Exception.t
+      def exception(msg) when is_binary(msg) do
+        exception(message: msg)
+      end
 
       @spec exception(Keyword.t) :: Exception.t
       def exception(args) when is_list(args) do


### PR DESCRIPTION
Closes #2961 (I think)

The functionality in question is covered by tests in `raise_test.exs` (e.g. `raise message`).

[ADDED] Note that for the others which override `exception/1`, passing a string (e.g. `raise UnicodeConversionError, "foo"`) leads to a `FunctionClauseError`, but this is how it was before and I figure it's not an acceptable way to call them and so the error is not a concern.