### PR TITLE
Replace is_win?/0 with windows?/0 to follow consistency

### DIFF
--- a/lib/elixir/test/elixir/file_test.exs
+++ b/lib/elixir/test/elixir/file_test.exs
@@ -684,7 +684,7 @@ defmodule FileTest do
       assert File.rm(fixture) == :ok
       refute File.exists?(fixture)
     end
-    
+
     test :rm_read_only_file do
       fixture = tmp_path("tmp_test.txt")
       File.write(fixture, "test")
@@ -771,7 +771,7 @@ defmodule FileTest do
       File.write!(Path.join(to, "hello"), "world")
       :file.make_symlink(to, from)
 
-      if File.exists?(from) or not is_win? do
+      if File.exists?(from) or not windows? do
         assert File.exists?(from)
 
         {:ok, files} = File.rm_rf(from)
@@ -889,28 +889,28 @@ defmodule FileTest do
       File.lstat!(invalid_file)
     end
   end
-  
+
   test :lstat_with_dangling_symlink do
     invalid_file = tmp_path("invalid_file")
     dest = tmp_path("dangling_symlink")
     File.ln_s(invalid_file,dest)
-    try do 
+    try do
       assert {:ok, info } = File.lstat(dest)
-      assert info.type == :symlink 
+      assert info.type == :symlink
     after
       File.rm(dest)
-    end 
+    end
   end
 
   test :lstat_with_dangling_symlink! do
     invalid_file = tmp_path("invalid_file")
     dest = tmp_path("dangling_symlink")
     File.ln_s(invalid_file,dest)
-    try do 
-     assert File.lstat!(dest).type == :symlink 
-    after 
+    try do
+     assert File.lstat!(dest).type == :symlink
+    after
      File.rm(dest)
-    end 
+    end
   end
 
 
@@ -1244,7 +1244,7 @@ defmodule FileTest do
       stat = File.stat!(fixture)
       assert stat.mode == 0o100666
 
-      unless is_win? do
+      unless windows? do
         assert File.chmod(fixture, 0o100777) == :ok
         stat = File.stat!(fixture)
         assert stat.mode == 0o100777
@@ -1263,7 +1263,7 @@ defmodule FileTest do
       stat = File.stat!(fixture)
       assert stat.mode == 0o100666
 
-      unless is_win? do
+      unless windows? do
         assert File.chmod!(fixture, 0o100777) == :ok
         stat = File.stat!(fixture)
         assert stat.mode == 0o100777

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -29,7 +29,7 @@ defmodule PathTest do
     File.rm_rf tmp_path("wildcard")
   end
 
-  if is_win? do
+  if windows? do
     test :relative_win do
       assert Path.relative("C:/usr/local/bin")    == "usr/local/bin"
       assert Path.relative("C:\\usr\\local\\bin") == "usr\\local\\bin"
@@ -227,7 +227,7 @@ defmodule PathTest do
     assert Path.split([?/, "foo/bar"]) == ["/", "foo", "bar"]
   end
 
-  if is_win? do
+  if windows? do
     defp strip_drive_letter_if_windows([_d,?:|rest]), do: rest
     defp strip_drive_letter_if_windows(<<_d,?:,rest::binary>>), do: rest
   else

--- a/lib/elixir/test/elixir/test_helper.exs
+++ b/lib/elixir/test/elixir/test_helper.exs
@@ -57,11 +57,11 @@ defmodule PathHelpers do
   end
 
   if match? {:win32, _}, :os.type do
-    def is_win?, do: true
+    def windows?, do: true
     def executable_extension, do: ".bat"
     def redirect_std_err_on_win, do: " 2>&1"
   else
-    def is_win?, do: false
+    def windows?, do: false
     def executable_extension, do: ""
     def redirect_std_err_on_win, do: ""
   end


### PR DESCRIPTION
is_win?/0 is the only function in the family of is_* that ends with `?`. Eg., is_list/1, is_boolean/1 etc have no '?' at the end. 

Personally, however, I like the '?' at the end of any boolean method, but conventions used in the code seems to not use '?' for  'is_' methods.

This is a trivial change but still having the language follow a single standard in method signature helps devs not to wonder if it's is_list? or is_list or is_win? or is_win etc.