### PR TITLE
Add `b` IEx helper to display behaviour docs

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -177,6 +177,27 @@ defmodule IEx.Helpers do
   end
 
   @doc """
+  Prints the documentation for the given callback function.
+
+  ## Examples
+
+      b(Mix.Task.run/1)
+      b(Mix.Task.run)
+
+  """
+  defmacro b({:/, _, [{{:., _, [mod, fun]}, _, []}, arity]}) do
+    quote do
+      IEx.Introspection.b(unquote(mod), unquote(fun), unquote(arity))
+    end
+  end
+
+  defmacro b({{:., _, [mod, fun]}, _, []}) do
+    quote do
+      IEx.Introspection.b(unquote(mod), unquote(fun))
+    end
+  end
+
+  @doc """
   Prints the types for the given module or for the given function/arity pair.
 
   ## Examples

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -70,7 +70,7 @@ defmodule IEx.Introspection do
     dont_display_result
   end
 
-  defp h_mod_fun(mod, fun) when is_atom(mod) and is_atom(fun) do
+  defp h_mod_fun(mod, fun) when is_atom(mod) do
     if docs = Code.get_docs(mod, :docs) do
       result = for {{f, arity}, _line, _type, _args, doc} <- docs, fun == f, doc != false do
         h(mod, fun, arity)
@@ -111,7 +111,7 @@ defmodule IEx.Introspection do
     dont_display_result
   end
 
-  defp h_mod_fun_arity(mod, fun, arity) when is_atom(mod) and is_atom(fun) and is_integer(arity) do
+  defp h_mod_fun_arity(mod, fun, arity) when is_atom(mod) do
     if docs = Code.get_docs(mod, :docs) do
       doc =
         cond do

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -15,13 +15,7 @@ defmodule IEx.Introspection do
         if function_exported?(module, :__info__, 1) do
           case Code.get_docs(module, :moduledoc) do
             {_, binary} when is_binary(binary) ->
-              if opts = ansi_docs() do
-                IO.ANSI.Docs.print_heading(inspect(module), opts)
-                IO.ANSI.Docs.print(binary, opts)
-              else
-                IO.puts "* #{inspect(module)}\n"
-                IO.puts binary
-              end
+              print_doc(inspect(module), binary)
             {_, _} ->
               nodocs(inspect module)
             _ ->
@@ -145,11 +139,13 @@ defmodule IEx.Introspection do
   end
 
   defp print_doc({{fun, _}, _line, kind, args, doc}) do
-    args    = Enum.map_join(args, ", ", &format_doc_arg(&1))
-    heading = "#{kind} #{fun}(#{args})"
-    doc     = doc || ""
+    args = Enum.map_join(args, ", ", &format_doc_arg(&1))
 
-    if opts = ansi_docs() do
+    print_doc("#{kind} #{fun}(#{args})", doc || "")
+  end
+
+  defp print_doc(heading, doc) do
+    if opts = IEx.Config.ansi_docs do
       IO.ANSI.Docs.print_heading(heading, opts)
       IO.ANSI.Docs.print(doc, opts)
     else
@@ -164,10 +160,6 @@ defmodule IEx.Introspection do
 
   defp format_doc_arg({var, _, _}) do
     Atom.to_string(var)
-  end
-
-  defp ansi_docs() do
-    IEx.Config.ansi_docs()
   end
 
   @doc """

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -109,12 +109,8 @@ defmodule IEx.Introspection do
 
   defp h_mod_fun_arity(mod, fun, arity) when is_atom(mod) do
     if docs = Code.get_docs(mod, :docs) do
-      doc =
-        cond do
-          d = find_doc(docs, fun, arity)         -> d
-          d = find_default_doc(docs, fun, arity) -> d
-          true                                   -> nil
-        end
+      doc = find_doc(docs, fun, arity)
+            || find_default_doc(docs, fun, arity)
 
       if doc do
         print_doc(doc)

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -149,7 +149,7 @@ defmodule IEx.Introspection do
   end
 
   defp print_doc({{fun, _}, _line, kind, args, doc}) do
-    args    = Enum.map_join(args, ", ", &print_doc_arg(&1))
+    args    = Enum.map_join(args, ", ", &format_doc_arg(&1))
     heading = "#{kind} #{fun}(#{args})"
     doc     = doc || ""
 
@@ -162,11 +162,11 @@ defmodule IEx.Introspection do
     end
   end
 
-  defp print_doc_arg({:\\, _, [left, right]}) do
-    print_doc_arg(left) <> " \\\\ " <> Macro.to_string(right)
+  defp format_doc_arg({:\\, _, [left, right]}) do
+    format_doc_arg(left) <> " \\\\ " <> Macro.to_string(right)
   end
 
-  defp print_doc_arg({var, _, _}) do
+  defp format_doc_arg({var, _, _}) do
     Atom.to_string(var)
   end
 

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -6,8 +6,7 @@ defmodule IEx.Introspection do
   import IEx, only: [dont_display_result: 0]
 
   @doc """
-  Documentation for modules.
-  It has a fallback clauses
+  Prints the documentation for the given module.
   """
   def h(module) when is_atom(module) do
     case Code.ensure_loaded(module) do
@@ -36,7 +35,8 @@ defmodule IEx.Introspection do
   end
 
   @doc """
-  Docs for the given function, with any arity, in any of the modules.
+  Prints the documentation for the given function
+  with any arity in the list of modules.
   """
   def h(modules, function) when is_list(modules) and is_atom(function) do
     result =
@@ -75,7 +75,8 @@ defmodule IEx.Introspection do
   end
 
   @doc """
-  Documentation for the given function and arity in the list of modules.
+  Prints the documentation for the given function
+  and arity in the list of modules.
   """
   def h(modules, function, arity) when is_list(modules) and is_atom(function) and is_integer(arity) do
     result =
@@ -231,7 +232,7 @@ defmodule IEx.Introspection do
   end
 
   @doc """
-  Print types in module.
+  Prints the types for the given module.
   """
   def t(module) when is_atom(module) do
     _ = case Kernel.Typespec.beam_types(module) do
@@ -244,7 +245,7 @@ defmodule IEx.Introspection do
   end
 
   @doc """
-  Print the given type in module with any arity.
+  Prints the given type in module with any arity.
   """
   def t(module, type) when is_atom(module) and is_atom(type) do
     case Kernel.Typespec.beam_types(module) do
@@ -265,7 +266,7 @@ defmodule IEx.Introspection do
   end
 
   @doc """
-  Print type in module with given arity.
+  Prints the type in module with given arity.
   """
   def t(module, type, arity) when is_atom(module) and is_atom(type) and is_integer(arity) do
     case Kernel.Typespec.beam_types(module) do
@@ -286,7 +287,7 @@ defmodule IEx.Introspection do
   end
 
   @doc """
-  Print specs for given module.
+  Prints the specs for given module.
   """
   def s(module) when is_atom(module) do
     case beam_specs(module) do
@@ -305,7 +306,7 @@ defmodule IEx.Introspection do
   end
 
   @doc """
-  Print specs for given module and function.
+  Prints the specs for given module and function.
   """
   def s(module, function) when is_atom(module) and is_atom(function) do
     case beam_specs(module) do
@@ -326,7 +327,7 @@ defmodule IEx.Introspection do
   end
 
   @doc """
-  Print spec in given module, with arity.
+  Prints the spec in given module, with arity.
   """
   def s(module, function, arity) when is_atom(module) and is_atom(function) and is_integer(arity) do
     case beam_specs(module) do

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -25,19 +25,19 @@ defmodule IEx.Introspection do
             {_, _} ->
               nodocs(inspect module)
             _ ->
-              IO.puts IEx.color(:eval_error, "#{inspect module} was not compiled with docs")
+              puts_error("#{inspect module} was not compiled with docs")
           end
         else
-          IO.puts IEx.color(:eval_error, "#{inspect module} is an Erlang module and, as such, it does not have Elixir-style docs")
+          puts_error("#{inspect module} is an Erlang module and, as such, it does not have Elixir-style docs")
         end
       {:error, reason} ->
-        IO.puts IEx.color(:eval_error, "Could not load module #{inspect module}, got: #{reason}")
+        puts_error("Could not load module #{inspect module}, got: #{reason}")
     end
     dont_display_result
   end
 
   def h(_) do
-    IO.puts IEx.color(:eval_error, "Invalid arguments for h helper")
+    puts_error("Invalid arguments for h helper")
     dont_display_result
   end
 
@@ -60,7 +60,7 @@ defmodule IEx.Introspection do
       :ok ->
         :ok
       :no_docs ->
-        IO.puts IEx.color(:eval_error, "#{inspect module} was not compiled with docs")
+        puts_error("#{inspect module} was not compiled with docs")
       :not_found ->
         nodocs("#{inspect module}.#{function}")
     end
@@ -99,7 +99,7 @@ defmodule IEx.Introspection do
       :ok ->
         :ok
       :no_docs ->
-        IO.puts IEx.color(:eval_error, "#{inspect module} was not compiled with docs")
+        puts_error("#{inspect module} was not compiled with docs")
       :not_found ->
         nodocs("#{inspect module}.#{function}/#{arity}")
     end
@@ -324,9 +324,9 @@ defmodule IEx.Introspection do
   defp nobeam(module) do
     case Code.ensure_loaded(module) do
       {:module, _} ->
-        IO.puts IEx.color(:eval_error, "Beam code not available for #{inspect module} or debug info is missing, cannot load typespecs")
+        puts_error("Beam code not available for #{inspect module} or debug info is missing, cannot load typespecs")
       {:error, reason} ->
-        IO.puts IEx.color(:eval_error, "Could not load module #{inspect module}, got: #{reason}")
+        puts_error("Could not load module #{inspect module}, got: #{reason}")
     end
   end
 
@@ -335,6 +335,10 @@ defmodule IEx.Introspection do
   defp nodocs(for),  do: no(for, "documentation")
 
   defp no(for, type) do
-    IO.puts IEx.color(:eval_error, "No #{type} for #{for} was found")
+    puts_error("No #{type} for #{for} was found")
+  end
+
+  defp puts_error(string) do
+    IO.puts IEx.color(:eval_error, string)
   end
 end

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -46,13 +46,11 @@ defmodule IEx.Introspection do
   """
   def h(modules, function) when is_list(modules) and is_atom(function) do
     result =
-      Enum.reduce modules, :not_found, fn
-        module, :not_found -> h_mod_fun(module, function)
-        _module, acc -> acc
+      Enum.find_value modules, false, fn module ->
+        h_mod_fun(module, function) == :ok
       end
 
-    unless result == :ok, do:
-      nodocs(function)
+    unless result, do: nodocs(function)
 
     dont_display_result
   end
@@ -87,13 +85,11 @@ defmodule IEx.Introspection do
   """
   def h(modules, function, arity) when is_list(modules) and is_atom(function) and is_integer(arity) do
     result =
-      Enum.reduce modules, :not_found, fn
-        module, :not_found -> h_mod_fun_arity(module, function, arity)
-        _module, acc -> acc
+      Enum.find_value modules, false, fn module ->
+        h_mod_fun_arity(module, function, arity) == :ok
       end
 
-    unless result == :ok, do:
-      nodocs("#{function}/#{arity}")
+    unless result, do: nodocs("#{function}/#{arity}")
 
     dont_display_result
   end

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -49,6 +49,13 @@ defmodule IEx.HelpersTest do
     assert capture_io(fn -> h __info__ end) == "No documentation for __info__ was found\n"
   end
 
+  test "b helper" do
+    assert capture_io(fn -> b Mix.Task.stop end) == "No documentation for Mix.Task.stop was found\n"
+    assert capture_io(fn -> b Mix.Task.run end) =~ "* defcallback run([binary()]) :: any()\n\nA task needs to implement `run`"
+    assert capture_io(fn -> b NoMix.run end) =~ "Could not load module NoMix, got: nofile\n"
+    assert capture_io(fn -> b Exception.message/1 end) == "* defcallback message(t()) :: String.t()\n\n\n"
+  end
+
   test "t helper" do
     assert capture_io(fn -> t IEx end) == "No type information for IEx was found\n"
 


### PR DESCRIPTION
It introduces `b` helper to output behaviour docs as shown below:
```elixir
iex(1)> b Mix.SCM.fetchable?/0

                                def fetchable?/0                                

Returns a boolean if the dependency can be fetched or it is meant to be
previously available in the filesystem.

Local dependencies (i.e. non fetchable ones) are automatically recompiled every
time the parent project is compiled.

:ok
```
In contrast with regular docs currently we have no `args` stored in the behaviour docs.
I think it might be solved by some ways:
* adding it to the behaviour docs (breaking change)
* extracting it from the specs
* probably keep it as is

Another question is, shall we display it as `def fetchable?/0` like it has to be implemented or as it is defined `defcallback fetchable?/0`?