### PR TITLE
Fix doctest :only, so it accepts multiple functions

### DIFF
--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -179,7 +179,7 @@ defmodule ExUnit.DocTest do
 
     Stream.filter(tests, fn(test) ->
       fa = test.fun_arity
-      Enum.all?(except, &(&1 != fa)) and Enum.all?(only, &(&1 == fa))
+      Enum.all?(except, &(&1 != fa)) and (Enum.empty?(only) or Enum.any?(only, &(&1 == fa)))
     end)
   end
 

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -198,6 +198,15 @@ defmodule ExUnit.DocTestTest do
 
   import ExUnit.CaptureIO
 
+  test "multiple functions filtered with :only" do
+    defmodule MultipleOnly do
+      use ExUnit.Case
+      doctest ExUnit.DocTestTest.SomewhatGoodModuleWithOnly, only: [test_fun: 0, test_fun1: 0], import: true
+    end
+
+    assert capture_io(fn -> ExUnit.run end) =~ "2 tests, 1 failure"
+  end
+
   test "doctest failures" do
     defmodule ActuallyCompiled do
       use ExUnit.Case
@@ -212,7 +221,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       1) test moduledoc at ExUnit.DocTestTest.Invalid (1) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:204
+         test/ex_unit/doc_test_test.exs:213
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:112: syntax error before: '*'
          code: 1 + * 1
          stacktrace:
@@ -221,7 +230,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       2) test moduledoc at ExUnit.DocTestTest.Invalid (2) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:204
+         test/ex_unit/doc_test_test.exs:213
          Doctest failed
          code: 1 + hd(List.flatten([1])) === 3
          lhs:  2
@@ -231,7 +240,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       3) test moduledoc at ExUnit.DocTestTest.Invalid (3) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:204
+         test/ex_unit/doc_test_test.exs:213
          Doctest failed
          code: inspect(:oops) === "#HashDict<[]>"
          lhs:  ":oops"
@@ -241,7 +250,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       4) test moduledoc at ExUnit.DocTestTest.Invalid (4) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:204
+         test/ex_unit/doc_test_test.exs:213
          Doctest failed: got UndefinedFunctionError with message undefined function: Hello.world/0 (module Hello is not available)
          code:  Hello.world
          stacktrace:
@@ -250,7 +259,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       5) test moduledoc at ExUnit.DocTestTest.Invalid (5) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:204
+         test/ex_unit/doc_test_test.exs:213
          Doctest failed: expected exception WhatIsThis with message "oops" but got RuntimeError with message "oops"
          code: raise "oops"
          stacktrace:
@@ -259,7 +268,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       6) test moduledoc at ExUnit.DocTestTest.Invalid (6) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:204
+         test/ex_unit/doc_test_test.exs:213
          Doctest failed: expected exception RuntimeError with message "hello" but got RuntimeError with message "oops"
          code: raise "oops"
          stacktrace:


### PR DESCRIPTION
There is a bug in `doctest` with the `:only` option, such that it only works if the list is of size 1. If you pass two functions to the option, `filter_by_opts` will always be empty, since we check with `Enum.all?`. I've changed to `Enum.any?`.

`Enum.any?` returns false for an empty list. Thus the extra `Enum.empty?` check.

Adding a test case to `DocTestTest` is made difficult by the fact there are tests asserting on line numbers in the runner output. I've replaced line numbers in these tests with `x`, and changed the assertions to make them less brittle. It is unrelated to the bugfix above, but was prompted by my frustrations when writing a test case. If you would like, I can separate these into two pull requests.