### PR TITLE
Doctest except/only moduledoc

### DIFF
--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -178,7 +178,7 @@ defmodule ExUnit.DocTest do
     except = opts[:except] || []
 
     Stream.filter(tests, fn(test) ->
-      fa = test.fun_arity
+      fa = test.fun_arity || :moduledoc # moduledoc's fun_arity is nil
       !Enum.member?(except, fa) and (Enum.empty?(only) or Enum.member?(only, fa))
     end)
   end

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -179,7 +179,7 @@ defmodule ExUnit.DocTest do
 
     Stream.filter(tests, fn(test) ->
       fa = test.fun_arity
-      Enum.all?(except, &(&1 != fa)) and (Enum.empty?(only) or Enum.any?(only, &(&1 == fa)))
+      !Enum.member?(except, fa) and (Enum.empty?(only) or Enum.member?(only, fa))
     end)
   end
 

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -125,10 +125,10 @@ defmodule ExUnit.DocTest do
   Options can also be supplied:
 
     * `:except` — generate tests for all functions except those listed
-      (list of `{function, arity}` tuples).
+      (list of `{function, arity}` tuples, and/or `:moduledoc`).
 
     * `:only` — generate tests only for functions listed
-      (list of `{function, arity}` tuples).
+      (list of `{function, arity}` tuples, and/or `:moduledoc`).
 
     * `:import` — when true, one can test a function defined in the module
       without referring to the module name. However, this is not feasible when
@@ -137,7 +137,7 @@ defmodule ExUnit.DocTest do
 
   ## Examples
 
-      doctest MyModule, except: [trick_fun: 1]
+      doctest MyModule, except: [:moduledoc, trick_fun: 1]
 
   This macro is auto-imported with every `ExUnit.Case`.
   """

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -84,6 +84,11 @@ defmodule ExUnit.DocTestTest.SomewhatGoodModuleWithOnly do
 end |> write_beam
 
 defmodule ExUnit.DocTestTest.SomewhatGoodModuleWithExcept do
+  @moduledoc """
+  iex> 1 + 1
+  1
+  """
+
   @doc """
   iex> test_fun
   1
@@ -192,7 +197,7 @@ defmodule ExUnit.DocTestTest do
 
   doctest ExUnit.DocTestTest.GoodModule, import: true
   doctest ExUnit.DocTestTest.SomewhatGoodModuleWithOnly, only: [test_fun: 0], import: true
-  doctest ExUnit.DocTestTest.SomewhatGoodModuleWithExcept, except: [test_fun1: 0], import: true
+  doctest ExUnit.DocTestTest.SomewhatGoodModuleWithExcept, except: [:moduledoc, test_fun1: 0], import: true
   doctest ExUnit.DocTestTest.NoImport
   doctest ExUnit.DocTestTest.IndentationHeredocs
 
@@ -221,58 +226,58 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       1) test moduledoc at ExUnit.DocTestTest.Invalid (1) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:213
-         Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:112: syntax error before: '*'
+         test/ex_unit/doc_test_test.exs:218
+         Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:117: syntax error before: '*'
          code: 1 + * 1
          stacktrace:
-           test/ex_unit/doc_test_test.exs:112: ExUnit.DocTestTest.Invalid (module)
+           test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
     """
 
     assert output =~ """
       2) test moduledoc at ExUnit.DocTestTest.Invalid (2) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:213
+         test/ex_unit/doc_test_test.exs:218
          Doctest failed
          code: 1 + hd(List.flatten([1])) === 3
          lhs:  2
          stacktrace:
-           test/ex_unit/doc_test_test.exs:112: ExUnit.DocTestTest.Invalid (module)
+           test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
     """
 
     assert output =~ """
       3) test moduledoc at ExUnit.DocTestTest.Invalid (3) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:213
+         test/ex_unit/doc_test_test.exs:218
          Doctest failed
          code: inspect(:oops) === "#HashDict<[]>"
          lhs:  ":oops"
          stacktrace:
-           test/ex_unit/doc_test_test.exs:112: ExUnit.DocTestTest.Invalid (module)
+           test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
     """
 
     assert output =~ """
       4) test moduledoc at ExUnit.DocTestTest.Invalid (4) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:213
+         test/ex_unit/doc_test_test.exs:218
          Doctest failed: got UndefinedFunctionError with message undefined function: Hello.world/0 (module Hello is not available)
          code:  Hello.world
          stacktrace:
-           test/ex_unit/doc_test_test.exs:112: ExUnit.DocTestTest.Invalid (module)
+           test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
     """
 
     assert output =~ """
       5) test moduledoc at ExUnit.DocTestTest.Invalid (5) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:213
+         test/ex_unit/doc_test_test.exs:218
          Doctest failed: expected exception WhatIsThis with message "oops" but got RuntimeError with message "oops"
          code: raise "oops"
          stacktrace:
-           test/ex_unit/doc_test_test.exs:112: ExUnit.DocTestTest.Invalid (module)
+           test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
     """
 
     assert output =~ """
       6) test moduledoc at ExUnit.DocTestTest.Invalid (6) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:213
+         test/ex_unit/doc_test_test.exs:218
          Doctest failed: expected exception RuntimeError with message "hello" but got RuntimeError with message "oops"
          code: raise "oops"
          stacktrace:
-           test/ex_unit/doc_test_test.exs:112: ExUnit.DocTestTest.Invalid (module)
+           test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
     """
   end
 


### PR DESCRIPTION
It isn't obvious how to filter moduledocs from your doctests. Doctests can be filtered with the `:only` and `:except` options. They accept a list of `{function, arity}` tuples, but the documentation doesn't really suggest what to include in this keyword list in order to include or exclude `@moduledoc`.

It turns out, instead of a `{fun, arity}` tuple, `test.fun_arity` for the moduledoc is `nil`. We can thus exclude it from the doctests:

```elixir
defmodule SomeModuleTest do
  use ExUnit.Case
  doctest SomeModule, except: [nil]
end
```

This works, but is obviously not very friendly. There should be a better way to exclude/include a moduledoc in your doctests. This PR implements one way, but I only picked what seemed least intrusive. It has it's drawbacks.

In essance, it puts a name to moduledoc's `test.fun_arity`, locally for the filtering. this lets you filter moduledocs thus:

```elixir
defmodule SomeModuleTest do
  use ExUnit.Case
  doctest SomeModule, except: [:moduledoc]
end
```

Not too bad, right? Only if we want to filter `:moduledoc` and some other function, we don't have a nice keyword list anymore. We have to do something like `[:moduledoc, {my_function: 1}]`. We lose keyword list sugar.

An alternative is to add another option, `:moduledoc` and default it to `true`. It could be used like so:

```elixir
defmodule SomeModuleTest do
  use ExUnit.Case
  doctest SomeModule, except: [my_function: 1], moduledoc: false
end
```

But then, if this option defaults to true, how do we treat `doctest SomeModule only: [my_function: 1]`. It leaves out `:moduledoc`, so there's the default true, but it's also specifically whitelisting some functions. If we add `:moduledoc` to the whitelist, because of its default value, we are changing behaviour. If we leave it out, then how do we add it to the whitelist? By explicitly setting it to `true`? This seems way to complicated, compared to including it in the current filter options. 

Any other ideas? Thoughts? Whatever we do, it should be documented, but I've held off adding to DocTest's moduledoc until we know what option we like best. 