### PR TITLE
Run all tests with +T 9 to get a better chance at finding races.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ otp_release:
 
 sudo: false
 
+env:
+  - ELIXIR_ERL_OPTIONS=""
+  - ELIXIR_ERL_OPTIONS="+T 9"
+
 script: "make compile && rm -rf .git && make test"
 
 notifications:

--- a/lib/elixir/test/elixir/gen_event/stream_test.exs
+++ b/lib/elixir/test/elixir/gen_event/stream_test.exs
@@ -155,11 +155,11 @@ defmodule GenEvent.StreamTest do
     stream = GenEvent.stream(:does_not_exit)
 
     parent = self()
+    Process.flag(:trap_exit, true)
     child = spawn_link fn ->
       send parent, Enum.to_list(stream)
     end
 
-    Process.flag(:trap_exit, true)
     assert_receive {:EXIT, ^child,
                      {:noproc, {Enumerable.GenEvent.Stream, :start, [_]}}}, @receive_timeout
   end


### PR DESCRIPTION
> +T Level
> Enables modified timing and sets the modified timing level. Currently valid range is 0-9. The timing of the runtime system will change. A high level usually means a greater change than a low level. Changing the timing can be very useful for finding timing related bugs.

We enabled that after seeing [jlouis' tweet](https://twitter.com/jlouis666/status/574685606703398913) and actually caught one bug.

http://erlang.org/doc/man/erl.html