### PR TITLE
Fix error in EEx docstring ("a macro" to "an expression")

### DIFF
--- a/lib/eex/lib/eex.ex
+++ b/lib/eex/lib/eex.ex
@@ -62,7 +62,7 @@ defmodule EEx do
 
   All expressions that output something to the template
   **must** use the equals sign (`=`). Since everything in
-  Elixir is a macro, there are no exceptions for this rule.
+  Elixir is an expression, there are no exceptions for this rule.
   For example, while some template languages would special-
   case `if` clauses, they are treated the same in EEx and
   also require `=` in order to have their result printed:


### PR DESCRIPTION
Wasn't sure about convention on line wrapping there.  That line is now longer than where the ones immediately surrounding it are broken up, but there are other lines in the vicinity which are of this length, so I figured it's probably ok this way.