### PR TITLE
EEx: fix interpolation inside quotations

### DIFF
--- a/lib/eex/lib/eex/engine.ex
+++ b/lib/eex/lib/eex/engine.ex
@@ -96,14 +96,14 @@ defmodule EEx.Engine do
 
   All other markers are not implemented by this engine.
   """
-  def handle_expr(buffer, "=", expr) do
+  def handle_expr(buffer, '=', expr) do
     quote do
       tmp = unquote(buffer)
       tmp <> String.Chars.to_string(unquote(expr))
     end
   end
 
-  def handle_expr(buffer, "", expr) do
+  def handle_expr(buffer, '', expr) do
     quote do
       tmp = unquote(buffer)
       unquote(expr)

--- a/lib/eex/lib/eex/tokenizer.ex
+++ b/lib/eex/lib/eex/tokenizer.ex
@@ -23,11 +23,7 @@ defmodule EEx.Tokenizer do
   end
 
   defp tokenize('<%%' ++ t, line, buffer, acc) do
-    case expr(t, line, [?%, ?<|buffer]) do
-      {:error, _, _} = error -> error
-      {:ok, buffer, new_line, rest} ->
-        tokenize rest, new_line, [?>, ?%|buffer], acc
-    end
+    tokenize t, line, [?%, ?<|buffer], acc
   end
 
   defp tokenize('<%#' ++ t, line, buffer, acc) do

--- a/lib/eex/lib/eex/tokenizer.ex
+++ b/lib/eex/lib/eex/tokenizer.ex
@@ -62,11 +62,11 @@ defmodule EEx.Tokenizer do
   # Retrieve marker for <%
 
   defp retrieve_marker('=' ++ t) do
-    {"=", t}
+    {'=', t}
   end
 
   defp retrieve_marker(t) do
-    {"", t}
+    {'', t}
   end
 
   # Tokenize an expression until we find %>

--- a/lib/eex/test/eex/tokenizer_test.exs
+++ b/lib/eex/test/eex/tokenizer_test.exs
@@ -14,17 +14,17 @@ defmodule EEx.TokenizerTest do
 
   test "strings with embedded code" do
     assert T.tokenize('foo <% bar %>', 1) ==
-           {:ok, [{:text, 'foo '}, {:expr, 1, "", ' bar '}]}
+           {:ok, [{:text, 'foo '}, {:expr, 1, '', ' bar '}]}
   end
 
   test "strings with embedded equals code" do
     assert T.tokenize('foo <%= bar %>', 1) ==
-           {:ok, [{:text, 'foo '}, {:expr, 1, "=", ' bar '}]}
+           {:ok, [{:text, 'foo '}, {:expr, 1, '=', ' bar '}]}
   end
 
   test "strings with more than one line" do
     assert T.tokenize('foo\n<%= bar %>', 1) ==
-           {:ok, [{:text, 'foo\n'}, {:expr, 2, "=", ' bar '}]}
+           {:ok, [{:text, 'foo\n'}, {:expr, 2, '=', ' bar '}]}
   end
 
   test "strings with more than one line and expression with more than one line" do
@@ -37,9 +37,9 @@ baz %>
 
     assert T.tokenize(string, 1) == {:ok, [
       {:text, 'foo '},
-      {:expr, 1, "=", ' bar\n\nbaz '},
+      {:expr, 1, '=', ' bar\n\nbaz '},
       {:text, '\n'},
-      {:expr, 4, "", ' foo '},
+      {:expr, 4, '', ' foo '},
       {:text, '\n'}
     ]}
   end
@@ -59,9 +59,9 @@ baz %>
   test "quotation with interpolation" do
     assert T.tokenize('a <%% b <%= c %> <%= d %> e %> f', 1) == {:ok, [
       {:text, 'a <% b '},
-      {:expr, 1, "=", ' c '},
+      {:expr, 1, '=', ' c '},
       {:text, ' '},
-      {:expr, 1, "=", ' d '},
+      {:expr, 1, '=', ' d '},
       {:text, ' e %> f'}
     ]}
 
@@ -85,32 +85,32 @@ baz %>
   test "strings with embedded do end" do
     assert T.tokenize('foo <% if true do %>bar<% end %>', 1) == {:ok, [
       {:text, 'foo '},
-      {:start_expr, 1, "", ' if true do '},
+      {:start_expr, 1, '', ' if true do '},
       {:text, 'bar'},
-      {:end_expr, 1, "", ' end '}
+      {:end_expr, 1, '', ' end '}
     ]}
   end
 
   test "strings with embedded -> end" do
     assert T.tokenize('foo <% cond do %><% false -> %>bar<% true -> %>baz<% end %>', 1) == {:ok, [
       {:text, 'foo '},
-      {:start_expr, 1, "", ' cond do '},
-      {:middle_expr, 1, "", ' false -> '},
+      {:start_expr, 1, '', ' cond do '},
+      {:middle_expr, 1, '', ' false -> '},
       {:text, 'bar'},
-      {:middle_expr, 1, "", ' true -> '},
+      {:middle_expr, 1, '', ' true -> '},
       {:text, 'baz'},
-      {:end_expr, 1, "", ' end '}
+      {:end_expr, 1, '', ' end '}
     ]}
   end
 
   test "strings with embedded keywords blocks" do
     assert T.tokenize('foo <% if true do %>bar<% else %>baz<% end %>', 1) == {:ok, [
       {:text, 'foo '},
-      {:start_expr, 1, "", ' if true do '},
+      {:start_expr, 1, '', ' if true do '},
       {:text, 'bar'},
-      {:middle_expr, 1, "", ' else '},
+      {:middle_expr, 1, '', ' else '},
       {:text, 'baz'},
-      {:end_expr, 1, "", ' end '}
+      {:end_expr, 1, '', ' end '}
     ]}
   end
 

--- a/lib/eex/test/eex/tokenizer_test.exs
+++ b/lib/eex/test/eex/tokenizer_test.exs
@@ -56,6 +56,20 @@ baz %>
     ]}
   end
 
+  test "quotation with interpolation" do
+    assert T.tokenize('a <%% b <%= c %> <%= d %> e %> f', 1) == {:ok, [
+      {:text, 'a <% b '},
+      {:expr, 1, "=", ' c '},
+      {:text, ' '},
+      {:expr, 1, "=", ' d '},
+      {:text, ' e %> f'}
+    ]}
+
+    assert T.tokenize('<%%% a <%%= b %> c %>', 1) == {:ok, [
+      {:text, '<%% a <%= b %> c %>'}
+    ]}
+  end
+
   test "comments" do
     assert T.tokenize('foo <%# true %>', 1) == {:ok, [
       {:text, 'foo '}


### PR DESCRIPTION
Closes #3159.

I'm opening this in its current state since it resolves the issue as described and is self-contained.  

However, in thinking about this, I realized that the way `expr/3` finds the `%>` can be problematic (as shown in one of my comments on #3159).  In the end that turned out not to matter for quotations, since they don't need to use `expr/3`.  But it is a problem for comments, which I believe are the only other tag type that allows nested tags:

```
iex(1)> EEx.Tokenizer.tokenize("<%# <%= foo %> <%= bar %> %>", 1)
{:ok, [{:text, ' '}, {:expr, 1, "=", ' bar '}, {:text, ' %>'}]}
```

I assume this is something that should be supported, and will be happy to take care of it.  I already have the modified `expr/3` which matches the delimiters properly (I wrote it before realizing it wasn't needed for quotations).  I can do it in this PR or another one, I wasn't sure since it's related to the current issue, but not strictly speaking part of it.

On a more tangential note, there is the matter of non-delimiter appearances of `%>`.  For example, stand-alone ones now are just treated as text.  And if one appears in some Elixir code, it causes mayhem, e.g. 
```
iex(2)> EEx.Tokenizer.tokenize('<% "%>" %>', 1)                  
{:ok, [{:expr, 1, "", ' "'}, {:text, '" %>'}]}
```

Granted these are somewhat pathological cases, and the in-code case could be tricky to handle, so maybe this is something to discuss on the mailing list and take time to think about.  Just thought I'd mention it, since it involves some of the same code.