### PR TITLE
EEx: Add trim option

### DIFF
--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -12,7 +12,8 @@ defmodule EEx.Compiler do
   def compile(source, opts) do
     file   = opts[:file] || "nofile"
     line   = opts[:line] || 1
-    case EEx.Tokenizer.tokenize(source, line) do
+    trim   = opts[:trim] || false
+    case EEx.Tokenizer.tokenize(source, line, trim: trim) do
       {:ok, tokens} ->
         state = %{engine: opts[:engine] || @default_engine,
                   file: file, line: line, quoted: [], start_line: nil}

--- a/lib/eex/test/eex/tokenizer_test.exs
+++ b/lib/eex/test/eex/tokenizer_test.exs
@@ -114,6 +114,37 @@ baz %>
     ]}
   end
 
+  test "trim mode" do
+    assert T.tokenize('\n \t <%= 12 %>  \n 34 <% 56 %>', 1, trim: true) == {:ok, [
+      {:text, '\n'},
+      {:expr, 2, '=', ' 12 '},
+      {:text, ' 34 '},
+      {:expr, 3, '', ' 56 '}
+    ]}
+  end
+
+  test "trim mode with comment" do
+    assert T.tokenize('0\n  <%# comment %>  \n12', 1, trim: true) == {:ok, [
+      {:text, '0\n12'}
+    ]}
+  end
+
+  test "trim mode with CR/LF" do
+    assert T.tokenize('0\r\n  <%= 12 %>  \r\n34', 1, trim: true) == {:ok, [
+      {:text, '0\r\n'},
+      {:expr, 2, '=', ' 12 '},
+      {:text, '34'}
+    ]}
+  end
+
+  test "trim mode no false positives" do
+    assert T.tokenize('  01\n 34 <%= 56 %> 78 \n\n ', 1, trim: true) == {:ok, [
+      {:text, '  01\n 34 '},
+      {:expr, 2, '=', ' 56 '},
+      {:text, ' 78 \n\n '}
+    ]}
+  end
+
   test "raise syntax error when there is start mark and no end mark" do
     assert T.tokenize('foo <% :bar', 1) == {:error, 1, "missing token '%>'"}
   end

--- a/lib/eex/test/eex/tokenizer_test.exs
+++ b/lib/eex/test/eex/tokenizer_test.exs
@@ -115,21 +115,23 @@ baz %>
   end
 
   test "trim mode" do
-    assert T.tokenize('\n \t <%= 12 %>  \n 34 <% 56 %>', 1, trim: true) == {:ok, [
-      {:text, '\n'},
-      {:expr, 2, '=', ' 12 '},
-      {:text, ' 34 '},
-      {:expr, 3, '', ' 56 '}
+    template = '\t<%= if true do %> \n TRUE \n  <% else %>\n FALSE \n  <% end %>  '
+    assert T.tokenize(template, 1, trim: true) == {:ok, [
+      {:start_expr, 1, '=', ' if true do '},
+      {:text, ' TRUE \n'},
+      {:middle_expr, 3, '', ' else '},
+      {:text, ' FALSE \n'},
+      {:end_expr, 5, '', ' end '}
     ]}
   end
 
   test "trim mode with comment" do
-    assert T.tokenize('0\n  <%# comment %>  \n12', 1, trim: true) == {:ok, [
-      {:text, '0\n12'}
+    assert T.tokenize('  <%# comment %>  \n123', 1, trim: true) == {:ok, [
+      {:text, '123'}
     ]}
   end
 
-  test "trim mode with CR/LF" do
+  test "trim mode with CRLF" do
     assert T.tokenize('0\r\n  <%= 12 %>  \r\n34', 1, trim: true) == {:ok, [
       {:text, '0\r\n'},
       {:expr, 2, '=', ' 12 '},
@@ -137,12 +139,21 @@ baz %>
     ]}
   end
 
-  test "trim mode no false positives" do
-    assert T.tokenize('  01\n 34 <%= 56 %> 78 \n\n ', 1, trim: true) == {:ok, [
-      {:text, '  01\n 34 '},
-      {:expr, 2, '=', ' 56 '},
-      {:text, ' 78 \n\n '}
+  test "trim mode set to false" do
+    assert T.tokenize(' <%= 12 %> \n', 1, trim: false) == {:ok, [
+      {:text, ' '},
+      {:expr, 1, '=', ' 12 '},
+      {:text, ' \n'}
     ]}
+  end
+
+  test "trim mode no false positives" do
+    assert_not_trimmed = fn x -> assert T.tokenize(x, 1, trim: true) == T.tokenize(x, 1) end
+
+    assert_not_trimmed.('foo <%= "bar" %>  ')
+    assert_not_trimmed.('\n  <%= "foo" %>bar')
+    assert_not_trimmed.('  <%% hello %>  ')
+    assert_not_trimmed.('  <%= 01 %><%= 23 %>\n')
   end
 
   test "raise syntax error when there is start mark and no end mark" do

--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -305,6 +305,12 @@ foo
     assert result == "  • • •\n  Jößé Vâlìm Jößé Vâlìm\n"
   end
 
+  test "trim mode" do
+    string = "<%= 123 %> \n456\n  <%= 789 %>"
+    expected = "123456\n789"
+    assert_eval expected, string, [], trim: true
+  end
+
   test "evaluates the source from a given file" do
     filename = Path.join(__DIR__, "fixtures/eex_template.eex")
     result = EEx.eval_file(filename)
@@ -387,8 +393,9 @@ foo
     assert {:wrapped, "foo"} = EEx.eval_string("foo", [], engine: TestEngine)
   end
 
-  defp assert_eval(expected, actual, binding \\ []) do
-    result = EEx.eval_string(actual, binding, file: __ENV__.file, engine: EEx.Engine)
+  defp assert_eval(expected, actual, binding \\ [], opts \\ []) do
+    opts = Enum.into [file: __ENV__.file, engine: EEx.Engine], opts
+    result = EEx.eval_string(actual, binding, opts)
     assert result == expected
   end
 end


### PR DESCRIPTION
If the `trim` option is used, trims around EEx tags:
- On left, up to the line break if all whitespace
- On right, up to and including the line break if all whitespace

Closes #3154

Initial attempt.  I think the behavior is ok, at least if I understood the idea correctly.  The only concern is that it also trims after `%>` even if it's not part of a tag (e.g. `%>  \nfoo` becomes `%>foo`).  This is a consequence of how the quotations are handled, and I don't know of a way to avoid it without redoing that using delimiter balancing.  If it's a problem, I could give it more thought.  Otherwise, some of the choices made:

- The trim option is passed inside `opts` rather than as a boolean flag (I figured this way it'd be easier to add more options later on)
- For whitespace it's tabs or spaces
- For newlines it's checking both LF and CRLF

I wasn't 100% sure about these, but I figured I might as well go ahead and I can change whatever is needed afterwards.