### PR TITLE
fix Kernel.=~/2 for "" =~ ""

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1476,7 +1476,14 @@ defmodule Kernel do
       iex> "abcd" =~ "ad"
       false
 
+      iex> "abcd" =~ ""
+      true
+
   """
+
+  @spec (String.t =~ (String.t | Regex.t)) :: boolean
+  def left =~ "" when is_binary(left), do: true
+
   def left =~ right when is_binary(left) and is_binary(right) do
     :binary.match(left, right) != :nomatch
   end

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -6,10 +6,24 @@ defmodule KernelTest do
   test "=~/2" do
     assert ("abcd" =~ ~r/c(d)/) == true
     assert ("abcd" =~ ~r/e/) == false
+    assert ("abcd" =~ ~R/c(d)/) == true
+    assert ("abcd" =~ ~R/e/) == false
 
     string = "^ab+cd*$"
     assert (string =~ "ab+") == true
     assert (string =~ "bb") == false
+
+    assert ("abcd" =~ ~r//) == true
+    assert ("abcd" =~ ~R//) == true
+    assert ("abcd" =~ "") == true
+
+    assert ("" =~ ~r//) == true
+    assert ("" =~ ~R//) == true
+    assert ("" =~ "") == true
+
+    assert ("" =~ "abcd") == false
+    assert ("" =~ ~r/abcd/) == false
+    assert ("" =~ ~R/abcd/) == false
 
     assert_raise FunctionClauseError, "no function clause matching in Kernel.=~/2", fn ->
       1234 =~ "hello"
@@ -17,6 +31,34 @@ defmodule KernelTest do
 
     assert_raise FunctionClauseError, "no function clause matching in Kernel.=~/2", fn ->
       1234 =~ ~r"hello"
+    end
+
+    assert_raise FunctionClauseError, "no function clause matching in Kernel.=~/2", fn ->
+      1234 =~ ~R"hello"
+    end
+
+    assert_raise FunctionClauseError, "no function clause matching in Kernel.=~/2", fn ->
+      ~r"hello" =~ "hello"
+    end
+
+    assert_raise FunctionClauseError, "no function clause matching in Kernel.=~/2", fn ->
+      ~r"hello" =~ ~r"hello"
+    end
+
+    assert_raise FunctionClauseError, "no function clause matching in Kernel.=~/2", fn ->
+      :abcd =~ ~r//
+    end
+
+    assert_raise FunctionClauseError, "no function clause matching in Kernel.=~/2", fn ->
+      :abcd =~ ""
+    end
+
+    assert_raise FunctionClauseError, "no function clause matching in Regex.match?/2", fn ->
+      "abcd" =~ nil
+    end
+
+    assert_raise FunctionClauseError, "no function clause matching in Regex.match?/2", fn ->
+      "abcd" =~ :abcd
     end
   end
 


### PR DESCRIPTION
fix `Kernel.=~/2` for `"" =~ ""`

```elixir
iex> "" =~ ~r//               
true
iex> "" =~ ""  
false
```

:binary.match("", "") doesn't deal with this situation. should this be reported to the erlang repository?