### PR TITLE
Document that ExUnit.Case :async defaults to false

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -9,7 +9,7 @@ defmodule ExUnit.Case do
 
     * :async - configure Elixir to run that specific test case in parallel with
       others. Must be used for performance when your test cases do not change
-      any global state.
+      any global state. It defaults to `false`.
 
   This module automatically includes all callbacks defined in
   `ExUnit.Callbacks`. See that module's documentation for more


### PR DESCRIPTION
I wanted to check my assumption that the `ExUnit.Case :async` option defaults to false. It does, but it wasn't explicit in the documentation. Hopefully, adding it will be helpful to others.