### PR TITLE
Explicitely declare argument names for functions with unnamed arguments.

### DIFF
--- a/lib/eex/lib/eex/engine.ex
+++ b/lib/eex/lib/eex/engine.ex
@@ -44,8 +44,8 @@ defmodule EEx.Engine do
         EEx.Engine.handle_text(buffer, text)
       end
 
-      def handle_expr(buffer, mark, expr) do
-        EEx.Engine.handle_expr(buffer, mark, expr)
+      def handle_expr(buffer, marker, expr) do
+        EEx.Engine.handle_expr(buffer, marker, expr)
       end
 
       defoverridable [handle_body: 1, handle_expr: 3, handle_text: 2]
@@ -96,6 +96,9 @@ defmodule EEx.Engine do
 
   All other markers are not implemented by this engine.
   """
+  @spec handle_expr(Macro.t, '' | '=', Macro.t) :: Macro.t
+  def handle_expr(buffer, marker, expr)
+
   def handle_expr(buffer, '=', expr) do
     quote do
       tmp = unquote(buffer)

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1730,6 +1730,8 @@ defmodule Enum do
 
   """
   @spec slice(t, Range.t) :: list
+  def slice(collection, range)
+
   def slice(collection, first..last) when first >= 0 and last >= 0 do
     # Simple case, which works on infinite collections
     if last - first >= 0 do

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -34,9 +34,13 @@ defmodule Exception do
   defcallback message(t) :: String.t
 
   @doc """
-  Returns true if the given argument is an exception.
+  Returns `true` if the given `term` is an exception.
   """
-  def exception?(%{__struct__: struct, __exception__: true}) when is_atom(struct), do: true
+  def exception?(term)
+
+  def exception?(%{__struct__: struct, __exception__: true}) when is_atom(struct),
+    do: true
+
   def exception?(_), do: false
 
   @doc """

--- a/lib/elixir/lib/file/stat.ex
+++ b/lib/elixir/lib/file/stat.ex
@@ -69,6 +69,7 @@ defmodule File.Stat do
   @doc """
   Converts a `:file_info` record into a `File.Stat`.
   """
+  def from_record(file_info)
   def from_record({:file_info, unquote_splicing(vals)}) do
     %File.Stat{unquote_splicing(pairs)}
   end

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -411,9 +411,10 @@ defmodule Inspect.Algebra do
 
   """
   @spec folddoc([t], ((t, t) -> t)) :: t
+  def folddoc(list, fun)
   def folddoc([], _), do: empty
   def folddoc([doc], _), do: doc
-  def folddoc([d|ds], f), do: f.(d, folddoc(ds, f))
+  def folddoc([d|ds], fun), do: fun.(d, folddoc(ds, fun))
 
   # Elixir conveniences
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3551,9 +3551,8 @@ defmodule Kernel do
       "f\#{o}o"
 
   """
-  defmacro sigil_S(string, []) do
-    string
-  end
+  defmacro sigil_S(term, modifiers)
+  defmacro sigil_S(string, []), do: string
 
   @doc ~S"""
   Handles the sigil `~s`.
@@ -3573,6 +3572,7 @@ defmodule Kernel do
       "f\#{:o}o"
 
   """
+  defmacro sigil_s(term, modifiers)
   defmacro sigil_s({:<<>>, line, pieces}, []) do
     {:<<>>, line, Macro.unescape_tokens(pieces)}
   end
@@ -3592,6 +3592,7 @@ defmodule Kernel do
       'f\#{o}o'
 
   """
+  defmacro sigil_C(term, modifiers)
   defmacro sigil_C({:<<>>, _line, [string]}, []) when is_binary(string) do
     String.to_char_list(string)
   end
@@ -3614,6 +3615,7 @@ defmodule Kernel do
       'f\#{:o}o'
 
   """
+  defmacro sigil_c(term, modifiers)
 
   # We can skip the runtime conversion if we are
   # creating a binary made solely of series of chars.
@@ -3643,6 +3645,7 @@ defmodule Kernel do
       true
 
   """
+  defmacro sigil_r(term, modifiers)
   defmacro sigil_r({:<<>>, _line, [string]}, options) when is_binary(string) do
     binary = Macro.unescape_string(string, fn(x) -> Regex.unescape_map(x) end)
     regex  = Regex.compile!(binary, :binary.list_to_bin(options))
@@ -3668,6 +3671,7 @@ defmodule Kernel do
       true
 
   """
+  defmacro sigil_R(term, modifiers)
   defmacro sigil_R({:<<>>, _line, [string]}, options) when is_binary(string) do
     regex = Regex.compile!(string, :binary.list_to_bin(options))
     Macro.escape(regex)
@@ -3697,7 +3701,7 @@ defmodule Kernel do
       [:foo, :bar, :baz]
 
   """
-
+  defmacro sigil_w(term, modifiers)
   defmacro sigil_w({:<<>>, _line, [string]}, modifiers) when is_binary(string) do
     split_words(Macro.unescape_string(string), modifiers)
   end
@@ -3725,6 +3729,7 @@ defmodule Kernel do
       ["foo", "\#{bar}", "baz"]
 
   """
+  defmacro sigil_W(term, modifiers)
   defmacro sigil_W({:<<>>, _line, [string]}, modifiers) when is_binary(string) do
     split_words(string, modifiers)
   end

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -335,6 +335,7 @@ defmodule Kernel.Typespec do
   @doc """
   Converts a spec clause back to Elixir AST.
   """
+  def spec_to_ast(name, spec)
   def spec_to_ast(name, {:type, line, :fun, [{:type, _, :product, args}, result]}) do
     meta = [line: line]
     body = {name, meta, Enum.map(args, &typespec_to_ast/1)}
@@ -382,6 +383,7 @@ defmodule Kernel.Typespec do
   @doc """
   Converts a type clause back to Elixir AST.
   """
+  def type_to_ast(type)
   def type_to_ast({{:record, record}, fields, args}) when is_atom(record) do
     fields = for field <- fields, do: typespec_to_ast(field)
     args = for arg <- args, do: typespec_to_ast(arg)

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -36,12 +36,13 @@ defmodule Keyword do
   @type t(value) :: [{key, value}]
 
   @doc """
-  Checks if the given argument is a keyword list or not.
+  Returns `true` if `term` is a keyword list; otherwise returns `false`.
   """
   @spec keyword?(term) :: boolean
-  def keyword?([{key, _value} | rest]) when is_atom(key) do
-    keyword?(rest)
-  end
+  def keyword?(term)
+
+  def keyword?([{key, _value} | rest]) when is_atom(key),
+    do: keyword?(rest)
 
   def keyword?([]),     do: true
   def keyword?(_other), do: false
@@ -50,9 +51,7 @@ defmodule Keyword do
   Returns an empty keyword list, i.e. an empty list.
   """
   @spec new :: t
-  def new do
-    []
-  end
+  def new, do: []
 
   @doc """
   Creates a keyword from an enumerable.
@@ -184,9 +183,8 @@ defmodule Keyword do
     {get, :lists.reverse(acc, [{key, new_value}|t])}
   end
 
-  defp get_and_update([h|t], acc, key, fun) do
-    get_and_update(t, [h|acc], key, fun)
-  end
+  defp get_and_update([h|t], acc, key, fun),
+    do: get_and_update(t, [h|acc], key, fun)
 
   defp get_and_update([], acc, key, fun) do
     {get, update} = fun.(nil)
@@ -453,9 +451,9 @@ defmodule Keyword do
 
   """
   @spec merge(t, t) :: t
-  def merge(d1, d2) when is_list(d1) and is_list(d2) do
-    fun = fn {k, _v} -> not has_key?(d2, k) end
-    d2 ++ :lists.filter(fun, d1)
+  def merge(keywords1, keywords2) when is_list(keywords1) and is_list(keywords2) do
+    fun = fn {k, _v} -> not has_key?(keywords2, k) end
+    keywords2 ++ :lists.filter(fun, keywords1)
   end
 
   @doc """
@@ -472,8 +470,8 @@ defmodule Keyword do
 
   """
   @spec merge(t, t, (key, value, value -> value)) :: t
-  def merge(d1, d2, fun) when is_list(d1) and is_list(d2) do
-    do_merge(d2, d1, fun)
+  def merge(keywords1, keywords2, fun) when is_list(keywords1) and is_list(keywords2) do
+    do_merge(keywords2, keywords1, fun)
   end
 
   defp do_merge([{k, v2}|t], acc, fun) do
@@ -536,7 +534,7 @@ defmodule Keyword do
   end
 
   @doc """
-  Updates the `key` with the given function.
+  Updates the `key` in `keywords` with the given function.
 
   If the `key` does not exist, inserts the given `initial` value.
 
@@ -553,6 +551,8 @@ defmodule Keyword do
 
   """
   @spec update(t, key, value, (value -> value)) :: t
+  def update(keywords, key, initial, fun)
+
   def update([{key, value}|keywords], key, _initial, fun) do
     [{key, fun.(value)}|delete(keywords, key)]
   end

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -269,6 +269,8 @@ defmodule Macro do
 
   """
   @spec decompose_call(Macro.t) :: {atom, [Macro.t]} | {Macro.t, atom, [Macro.t]} | :error
+  def decompose_call(ast)
+
   def decompose_call({{:., _, [remote, function]}, _, args}) when is_tuple(remote) or is_atom(remote),
     do: {remote, function, args}
 
@@ -620,6 +622,7 @@ defmodule Macro do
     false
   end
 
+  def interpolate(expr, fun)
   def interpolate({:<<>>, _, parts}, fun) do
     parts = Enum.map_join(parts, "", fn
       {:::, _, [{{:., _, [Kernel, :to_string]}, _, [arg]}, {:binary, _, _}]} ->

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -98,6 +98,8 @@ defmodule Macro.Env do
   Returns a keyword list containing the file and line
   information as keys.
   """
+  @spec location(t) :: Keyword.t
+  def location(env)
   def location(%{__struct__: Macro.Env, file: file, line: line}) do
     [file: file, line: line]
   end
@@ -106,17 +108,22 @@ defmodule Macro.Env do
   Returns whether the compilation environment is currently
   inside a guard.
   """
+  @spec in_guard?(t) :: boolean
+  def in_guard?(env)
   def in_guard?(%{__struct__: Macro.Env, context: context}), do: context == :guard
 
   @doc """
   Returns whether the compilation environment is currently
   inside a match clause.
   """
+  @spec in_match?(t) :: boolean
+  def in_match?(env)
   def in_match?(%{__struct__: Macro.Env, context: context}), do: context == :match
 
   @doc """
   Returns the environment stacktrace.
   """
+  @spec stacktrace(t) :: list
   def stacktrace(%{__struct__: Macro.Env} = env) do
     cond do
       is_nil(env.module) ->

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -75,5 +75,6 @@ defmodule Map do
     :maps.remove(:__struct__, struct)
   end
 
+  def equal?(map1, map2)
   def equal?(%{} = map1, %{} = map2), do: map1 === map2
 end

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -186,6 +186,7 @@ defmodule String do
 
   """
   @spec printable?(t) :: boolean
+  def printable?(string)
 
   def printable?(<< h :: utf8, t :: binary >>)
       when h in 0x20..0x7E
@@ -206,7 +207,7 @@ defmodule String do
   def printable?(<<?\a, t :: binary>>), do: printable?(t)
 
   def printable?(<<>>), do: true
-  def printable?(b) when is_binary(b), do: false
+  def printable?(binary) when is_binary(binary), do: false
 
   @doc """
   Divides a string into substrings at each Unicode whitespace
@@ -788,6 +789,7 @@ defmodule String do
 
   """
   @spec valid?(t) :: boolean
+  def valid?(string)
 
   noncharacters = Enum.to_list(?\x{FDD0}..?\x{FDEF}) ++
     [ ?\x{0FFFE}, ?\x{0FFFF}, ?\x{1FFFE}, ?\x{1FFFF}, ?\x{2FFFE}, ?\x{2FFFF},
@@ -804,7 +806,7 @@ defmodule String do
   def valid?(_), do: false
 
   @doc ~S"""
-  Checks whether `str` is a valid character.
+  Checks whether `string` is a valid character.
 
   All characters are codepoints, but some codepoints
   are not valid characters. They may be reserved, private,
@@ -1458,6 +1460,7 @@ defmodule String do
   """
 
   @spec jaro_distance(t, t) :: 0..1
+  def jaro_distance(str1, str2)
 
   def jaro_distance(str, str), do: 1.0
   def jaro_distance(_str, ""), do: 0.0

--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -125,12 +125,12 @@ defmodule Version do
 
   """
   @spec match?(version, requirement) :: boolean
-  def match?(vsn, req) when is_binary(req) do
-    case parse_requirement(req) do
-      {:ok, req} ->
-        match?(vsn, req)
+  def match?(version, requirement) when is_binary(requirement) do
+    case parse_requirement(requirement) do
+      {:ok, requirement} ->
+        match?(version, requirement)
       :error ->
-        raise InvalidRequirementError, message: req
+        raise InvalidRequirementError, message: requirement
     end
   end
 
@@ -160,8 +160,8 @@ defmodule Version do
 
   """
   @spec compare(version, version) :: :gt | :eq | :lt
-  def compare(vsn1, vsn2) do
-    do_compare(to_matchable(vsn1), to_matchable(vsn2))
+  def compare(version1, version2) do
+    do_compare(to_matchable(version1), to_matchable(version2))
   end
 
   defp do_compare({major1, minor1, patch1, pre1}, {major2, minor2, patch2, pre2}) do
@@ -193,9 +193,9 @@ defmodule Version do
   def parse(string) when is_binary(string) do
     case Version.Parser.parse_version(string) do
       {:ok, {major, minor, patch, pre}} ->
-        vsn = %Version{major: major, minor: minor, patch: patch,
+        version = %Version{major: major, minor: minor, patch: patch,
                        pre: pre, build: get_build(string)}
-        {:ok, vsn}
+        {:ok, version}
      :error ->
        :error
     end
@@ -230,7 +230,7 @@ defmodule Version do
 
   defp to_matchable(string) do
     case Version.Parser.parse_version(string) do
-      {:ok, vsn} -> vsn
+      {:ok, version} -> version
       :error -> raise InvalidVersionError, message: string
     end
   end

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -112,6 +112,7 @@ defmodule ExUnit do
   defmodule TimeoutError do
     defexception [:timeout]
 
+    def message(timeout)
     def message(%{timeout: timeout}) do
       "test timed out after #{timeout}ms (you can change the test timeout " <>
         "by setting \"@tag timeout: x\" where x is an integer in milliseconds)"

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -377,7 +377,7 @@ defmodule ExUnit.Assertions do
   end
 
   @doc """
-  Asserts that `val1` and `val2` differ by no more than `delta`.
+  Asserts that `value1` and `value2` differ by no more than `delta`.
 
 
   ## Examples
@@ -386,11 +386,11 @@ defmodule ExUnit.Assertions do
       assert_in_delta 10, 15, 4
 
   """
-  def assert_in_delta(val1, val2, delta, message \\ nil) do
-    diff = abs(val1 - val2)
+  def assert_in_delta(value1, value2, delta, message \\ nil) do
+    diff = abs(value1 - value2)
     message = message ||
-      "Expected the difference between #{inspect val1} and " <>
-      "#{inspect val2} (#{inspect diff}) to be less than #{inspect delta}"
+      "Expected the difference between #{inspect value1} and " <>
+      "#{inspect value2} (#{inspect diff}) to be less than #{inspect delta}"
     assert diff < delta, message
   end
 
@@ -523,7 +523,7 @@ defmodule ExUnit.Assertions do
   end
 
   @doc """
-  Asserts `val1` and `val2` are not within `delta`.
+  Asserts `value1` and `value2` are not within `delta`.
 
   If you supply `message`, information about the values will
   automatically be appended to it.
@@ -534,14 +534,14 @@ defmodule ExUnit.Assertions do
       refute_in_delta 10, 11, 2
 
   """
-  def refute_in_delta(val1, val2, delta, message \\ nil) do
-    diff = abs(val1 - val2)
+  def refute_in_delta(value1, value2, delta, message \\ nil) do
+    diff = abs(value1 - value2)
     message = if message do
-      message <> " (difference between #{inspect val1} " <>
-      "and #{inspect val2} is less than #{inspect delta})"
+      message <> " (difference between #{inspect value1} " <>
+      "and #{inspect value2} is less than #{inspect delta})"
     else
-      "Expected the difference between #{inspect val1} and " <>
-      "#{inspect val2} (#{inspect diff}) to be more than #{inspect delta}"
+      "Expected the difference between #{inspect value1} and " <>
+      "#{inspect value2} (#{inspect diff}) to be more than #{inspect delta}"
     end
     refute diff < delta, message
   end

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -105,6 +105,7 @@ defmodule ExUnit.Formatter do
   @doc """
   Receives a test and formats its failure.
   """
+  def format_test_failure(test, failure, counter, width, formatter)
   def format_test_failure(test, {kind, reason, stack}, counter, width, formatter) do
     %ExUnit.Test{name: name, case: case, tags: tags} = test
     test_info(with_counter(counter, "#{name} (#{inspect case})"), formatter)
@@ -116,6 +117,7 @@ defmodule ExUnit.Formatter do
   @doc """
   Receives a test case and formats its failure.
   """
+  def format_test_case_failure(test_case, failure, counter, width, formatter)
   def format_test_case_failure(test_case, {kind, reason, stacktrace}, counter, width, formatter) do
     %ExUnit.TestCase{name: name} = test_case
     test_case_info(with_counter(counter, "#{inspect name}: "), formatter)

--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -14,7 +14,7 @@ defmodule Logger.Translator do
     * `min_level` - the current Logger level
     * `level` - the level of the message being translator
     * `kind` - if the message is a report or a format
-    * `data` - the data to format. If it is a report, it is a tuple
+    * `message` - the message to format. If it is a report, it is a tuple
       with `{report_type, report_data}`, if it is a format, it is a
       tuple with `{format_message, format_args}`
 
@@ -27,6 +27,8 @@ defmodule Logger.Translator do
   See the function `translate/4` in this module for an example implementation
   and the default messages translated by Logger.
   """
+
+  def translate(min_level, level, kind, message)
 
   def translate(min_level, :error, :format, message) do
     case message do

--- a/lib/mix/lib/mix/tasks/help.ex
+++ b/lib/mix/lib/mix/tasks/help.ex
@@ -38,6 +38,8 @@ defmodule Mix.Tasks.Help do
   """
 
   @spec run(OptionParser.argv) :: :ok
+  def run(argv)
+
   def run([]) do
     loadpaths!
 

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -213,39 +213,35 @@ defmodule Mix.Utils do
       "FooBar"
 
   """
-  def camelize(""), do: ""
+  @spec camelize(String.t) :: String.t
+  def camelize(string)
 
-  def camelize(<<?_, t :: binary>>) do
-    camelize(t)
-  end
+  def camelize(""),
+    do: ""
 
-  def camelize(<<h, t :: binary>>) do
-    <<to_upper_char(h)>> <> do_camelize(t)
-  end
+  def camelize(<<?_, t :: binary>>),
+    do: camelize(t)
 
-  defp do_camelize(<<?_, ?_, t :: binary>>) do
-    do_camelize(<< ?_, t :: binary >>)
-  end
+  def camelize(<<h, t :: binary>>),
+    do: <<to_upper_char(h)>> <> do_camelize(t)
 
-  defp do_camelize(<<?_, h, t :: binary>>) when h in ?a..?z do
-    <<to_upper_char(h)>> <> do_camelize(t)
-  end
+  defp do_camelize(<<?_, ?_, t :: binary>>),
+    do: do_camelize(<< ?_, t :: binary >>)
 
-  defp do_camelize(<<?_>>) do
-    <<>>
-  end
+  defp do_camelize(<<?_, h, t :: binary>>) when h in ?a..?z,
+    do: <<to_upper_char(h)>> <> do_camelize(t)
 
-  defp do_camelize(<<?/, t :: binary>>) do
-    <<?.>> <> camelize(t)
-  end
+  defp do_camelize(<<?_>>),
+    do: <<>>
 
-  defp do_camelize(<<h, t :: binary>>) do
-    <<h>> <> do_camelize(t)
-  end
+  defp do_camelize(<<?/, t :: binary>>),
+    do: <<?.>> <> camelize(t)
 
-  defp do_camelize(<<>>) do
-    <<>>
-  end
+  defp do_camelize(<<h, t :: binary>>),
+    do: <<h>> <> do_camelize(t)
+
+  defp do_camelize(<<>>),
+    do: <<>>
 
   @doc """
   Takes a module and converts it to a command.


### PR DESCRIPTION
I noticed there were many functions that didn't have have a name when the function was defined, and the VM is assigning (not very descriptive) names according to their type, such as *list2* or `arg1`

I have removed every instance of these,
I have came up with a shell command to detect this,
(you need *[ag](https://github.com/ggreer/the_silver_searcher)* installed), and run it against the ./doc folder.

```bash
ag "(?<=signature\"><strong>).*\W(arg|atom|binary|bool|float|int|list)\d+\W.*\)" ./doc
```

I have made other small changes such as renaming some variables to be more consistent with the rest of the names, and added a few `@spec`s here and there.

I think it could be a good idea to give a warning, when names are not explicertly defined, but from what I could see in the code this is done by the VM, and it's not possible to tell whether it was assigned by the VM or by the user. We could use the list of names in the command above, but users can still use those, and thay will give a false warning.

Let me know what you think guys,