### PR TITLE
add backticks to a massive amount of true, false and nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Erlang 17.1, remember to update to at least Erlang 17.3.
   * [ExUnit] Fix a bug where failures when inspecting data structure or retrieving error messages could bring the whole ExUnit runner down
   * [ExUnit] Ensure the Logger is flushed when running ExUnit via Mix
   * [Mix] Ensure changes in child dependencies for the parent one to recompile
-  * [Regex] Fix splitting of empty strings with regexes when trim is set to true. Now both `String.split/3` and `Regex.split/3` return an empty list when called with an empty string and trim is enabled
+  * [Regex] Fix splitting of empty strings with regexes when trim is set to `true`. Now both `String.split/3` and `Regex.split/3` return an empty list when called with an empty string and trim is enabled
   * [Regex] Fix `Regex.replace/4` so it doesn't discard escape characters
 
 ### 3. Soft deprecations (no warnings emitted)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ something like:
 
 ```elixir
 @doc """
-Returns only those elements for which `fun` is true.
+Returns only those elements for which `fun` is `true`.
 
 ...
 """
@@ -153,7 +153,7 @@ example:
 
 ```elixir
 @doc """
-Return only those elements for which `fun` is true.
+Return only those elements for which `fun` is `true`.
 
 ## Examples
 

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -159,7 +159,7 @@ defmodule Application do
   environment values specified in the `.app` file will override the ones
   previously set.
 
-  The persistent option can be set to true when there is a need to guarantee
+  The persistent option can be set to `true` when there is a need to guarantee
   parameters set with this function will not be overridden by the ones defined
   in the application resource file on load. This means persistent values will
   stick after the application is loaded and also on application reload.

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -448,7 +448,7 @@ defmodule Exception do
 
   @doc """
   Formats the given file and line as shown in stacktraces.
-  If any of the values are nil, they are omitted.
+  If any of the values are `nil`, they are omitted.
 
   ## Examples
 

--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -183,7 +183,7 @@ defmodule Float do
 
     * `:decimals`   — number of decimal points to show
     * `:scientific` — number of decimal points to show, in scientific format
-    * `:compact`    — when true, use the most compact representation (ignored
+    * `:compact`    — when `true`, use the most compact representation (ignored
                       with the `scientific` option)
 
   ## Examples

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -4,8 +4,8 @@ defmodule Inspect.Opts do
 
   The following fields are available:
 
-    * `:structs` - when false, structs are not formatted by the inspect
-      protocol, they are instead printed as maps, defaults to true.
+    * `:structs` - when `false`, structs are not formatted by the inspect
+      protocol, they are instead printed as maps, defaults to `true`.
 
     * `:binaries` - when `:as_strings` all binaries will be printed as strings,
       non-printable bytes will be escaped.
@@ -27,15 +27,15 @@ defmodule Inspect.Opts do
       bitstrings, and lists, does not apply to strings nor char lists, defaults
       to 50.
 
-    * `:pretty` - if set to true enables pretty printing, defaults to false.
+    * `:pretty` - if set to `true` enables pretty printing, defaults to `false`.
 
-    * `:width` - defaults to the 80 characters, used when pretty is true or
+    * `:width` - defaults to the 80 characters, used when pretty is `true` or
       when printing to IO devices.
 
     * `:base` - print integers as :binary, :octal, :decimal, or :hex, defaults
       to :decimal
 
-    * `:safe` - when false, failures while inspecting structs will be raised
+    * `:safe` - when `false`, failures while inspecting structs will be raised
       as errors instead of being wrapped in the Inspect.Error exception. This
       is useful when debugging failures and crashes for custom inspect
       implementations

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -33,7 +33,7 @@ defmodule IO.ANSI do
 
   This function simply reads the configuration value for
   `:ansi_enabled` in the `:elixir` application. The value is by
-  default false unless Elixir can detect during startup that
+  default `false` unless Elixir can detect during startup that
   both `stdout` and `stderr` are terminals.
   """
   @spec enabled? :: boolean

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1639,7 +1639,7 @@ defmodule Kernel do
       iex> get_in(users, [all, :age])
       [27, 23]
 
-  If the previous value before invoking the function is nil,
+  If the previous value before invoking the function is `nil`,
   the function *will* receive nil as a value and must handle it
   accordingly.
   """
@@ -1745,7 +1745,7 @@ defmodule Kernel do
       iex> get_and_update_in(users, [all, :age], &{&1, &1 + 1})
       {[27, 23], [%{name: "john", age: 28}, %{name: "meg", age: 24}]}
 
-  If the previous value before invoking the function is nil,
+  If the previous value before invoking the function is `nil`,
   the function *will* receive `nil` as a value and must handle it
   accordingly (be it by failing or providing a sane default).
   """
@@ -1856,7 +1856,7 @@ defmodule Kernel do
   followed by one or more:
 
     * `foo[bar]` - access a field; in case an intermediate field is not
-      present or returns nil, an empty map is used
+      present or returns `nil`, an empty map is used
 
     * `foo.bar` - access a map/struct field; in case the field is not
       present, an error is raised
@@ -3194,7 +3194,7 @@ defmodule Kernel do
   ## Examples
 
   In Elixir, only `false` and `nil` are considered falsy values.
-  Everything else evaluates to true in `if` clauses. Depending
+  Everything else evaluates to `true` in `if` clauses. Depending
   on the application, it may be important to specify a `blank?`
   protocol that returns a boolean for other data types that should
   be considered "blank". For instance, an empty list or an empty
@@ -3203,7 +3203,7 @@ defmodule Kernel do
   Such protocol could be implemented as follows:
 
       defprotocol Blank do
-        @doc "Returns true if `data` is considered blank/empty"
+        @doc "Returns `true` if `data` is considered blank/empty"
         def blank?(data)
       end
 
@@ -3334,7 +3334,7 @@ defmodule Kernel do
   In order to speed up dispatching in production environments, where
   all implementations are known up-front, Elixir provides a feature
   called protocol consolidation. For this reason, all protocols are
-  compiled with `debug_info` set to true, regardless of the option
+  compiled with `debug_info` set to `true`, regardless of the option
   set by `elixirc` compiler. The debug info though may be removed
   after consolidation.
 

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -455,7 +455,7 @@ defmodule Kernel.SpecialForms do
   was not explicitly defined.
 
   Both warning behaviours could be changed by explicitly
-  setting the `:warn` option to true or `false`.
+  setting the `:warn` option to `true` or `false`.
   """
   defmacro alias(module, opts)
 
@@ -1613,7 +1613,7 @@ defmodule Kernel.SpecialForms do
   This means the VM no longer needs to keep the stacktrace once inside
   an else clause and so tail recursion is possible when using a `try`
   with a tail call as the final call inside an else clause. The same
-  is true for rescue and catch clauses.
+  is `true` for `rescue` and `catch` clauses.
 
   ## Variable handling
 

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -176,7 +176,7 @@ defmodule Module do
 
       Note the hook receives the expanded arguments and it is invoked before
       the function is stored in the module. So `Module.defines?/2` will return
-      false for the first clause of every function.
+      `false` for the first clause of every function.
 
       If the function/macro being defined has multiple clauses, the hook will
       be called for each clause.

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -27,7 +27,7 @@ defmodule OptionParser do
 
   By default, Elixir will try to automatically parse switches.
   Switches without an argument, like `--debug` will automatically
-  be set to true. Switches followed by a value will be assigned
+  be set to `true`. Switches followed by a value will be assigned
   to the value, always as strings.
 
   Note Elixir also converts the switches to underscore atoms, as
@@ -92,7 +92,7 @@ defmodule OptionParser do
   ## Negation switches
 
   In case a switch is declared as boolean, it may be passed as `--no-SWITCH`
-  which will set the option to false:
+  which will set the option to `false`:
 
       iex> OptionParser.parse(["--no-op", "path/to/file"], switches: [op: :boolean])
       {[op: false], ["path/to/file"], []}

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -15,8 +15,8 @@ defmodule Process do
   """
 
   @doc """
-  Returns true if the process exists and is alive, that is,
-  is not exiting and has not exited. Otherwise, returns false.
+  Returns `true` if the process exists and is alive, that is,
+  is not exiting and has not exited. Otherwise, returns `false`.
 
   `pid` must refer to a process at the local node.
   """

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -227,7 +227,7 @@ defmodule Protocol do
   end
 
   @doc """
-  Returns true if the protocol was consolidated.
+  Returns `true` if the protocol was consolidated.
   """
   @spec consolidated?(module) :: boolean
   def consolidated?(protocol) do
@@ -250,7 +250,7 @@ defmodule Protocol do
 
       Protocol.consolidated?(Enumerable)
 
-  If the first element of the tuple is true, it means
+  If the first element of the tuple is `true`, it means
   the protocol was consolidated.
 
   This function does not load the protocol at any point

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -29,7 +29,7 @@ defmodule Range do
   end
 
   @doc """
-  Returns true if the given argument is a range.
+  Returns `true` if the given argument is a range.
 
   ## Examples
 

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -160,7 +160,7 @@ defmodule Regex do
   end
 
   @doc """
-  Returns true if the given argument is a regex.
+  Returns `true` if the given argument is a regex.
 
   ## Examples
 
@@ -337,7 +337,7 @@ defmodule Regex do
       split the string into the maximum number of parts possible based on the
       given pattern.
 
-    * `:trim` - when true, remove blank strings from the result.
+    * `:trim` - when `true`, remove blank strings from the result.
 
     * `:on` - specifies which captures and order to split the string
       on. Check the moduledoc for `Regex` to see the possible capture
@@ -437,7 +437,7 @@ defmodule Regex do
   ## Options
 
     * `:global` - when `false`, replaces only the first occurrence
-      (defaults to true)
+      (defaults to `true`)
 
   ## Examples
 

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -402,9 +402,9 @@ defmodule System do
     * `:cd` - the directory to run the command in
     * `:env` - an enumerable of tuples containing environment key-value as binary
     * `:arg0` - set the command arg0
-    * `:stderr_to_stdout` - redirects stderr to stdout when true
-    * `:parallelism` - when true, the VM will schedule port tasks to improve
-      parallelism in the system. If set to false, the VM will try to perform
+    * `:stderr_to_stdout` - redirects stderr to stdout when `true`
+    * `:parallelism` - when `true`, the VM will schedule port tasks to improve
+      parallelism in the system. If set to `false`, the VM will try to perform
       commands immediately, improving latency at the expense of parallelism.
       The default can be set on system startup by passing the "+spp" argument
       to `--erl`.

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -36,7 +36,7 @@ defmodule ExUnit.Assertions do
   """
 
   @doc """
-  Asserts its argument is true.
+  Asserts its argument is `true`.
 
   `assert` tries to be smart and provide good
   reporting whenever there is a failure. In particular, if
@@ -191,7 +191,7 @@ defmodule ExUnit.Assertions do
   ## END HELPERS
 
   @doc """
-  Asserts `value` is true, displaying the given `message` otherwise.
+  Asserts `value` is `true`, displaying the given `message` otherwise.
 
   ## Examples
 
@@ -208,7 +208,7 @@ defmodule ExUnit.Assertions do
   end
 
   @doc """
-  Asserts `value` is true.
+  Asserts `value` is `true`.
   If it fails, it raises an expectation error
   using the given `left` and `right` values.
 

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -134,7 +134,7 @@ defmodule ExUnit.Case do
       ExUnit.configure(exclude: [external: true])
 
   From now on, ExUnit will not run any test that has the `external` flag
-  set to true. This behaviour can be reversed with the `:include` option
+  set to `true`. This behaviour can be reversed with the `:include` option
   which is usually passed through the command line:
 
       mix test --include external:true

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -130,7 +130,7 @@ defmodule ExUnit.DocTest do
     * `:only` — generate tests only for functions listed
       (list of `{function, arity}` tuples, and/or `:moduledoc`).
 
-    * `:import` — when true, one can test a function defined in the module
+    * `:import` — when `true`, one can test a function defined in the module
       without referring to the module name. However, this is not feasible when
       there is a clash with a module like Kernel. In these cases, `import`
       should be set to `false` and a full `M.f` construct should be used.

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -262,8 +262,8 @@ defmodule IEx do
 
   The value is a keyword list. Two prompt types:
 
-    * `:default_prompt` - used when `Node.alive?` returns false
-    * `:alive_prompt`   - used when `Node.alive?` returns true
+    * `:default_prompt` - used when `Node.alive?` returns `false`
+    * `:alive_prompt`   - used when `Node.alive?` returns `true`
 
   The part of the listed in the following of the prompt string is replaced.
 
@@ -340,7 +340,7 @@ defmodule IEx do
   This is useful for debugging a particular chunk of code
   and inspect the state of a particular process. The process
   is temporarily changed to trap exits (i.e. the process flag
-  `:trap_exit` is set to true) and has the `group_leader` changed
+  `:trap_exit` is set to `true`) and has the `group_leader` changed
   to support ANSI escape codes. Those values are reverted by
   calling `respawn`, which starts a new IEx shell, freeing up
   the pried one.

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -463,7 +463,7 @@ defmodule IEx.Helpers do
   @doc """
   Respawns the current shell by starting a new shell process.
 
-  Returns true if it worked.
+  Returns `true` if it worked.
   """
   def respawn do
     if whereis = IEx.Server.whereis do

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -324,7 +324,7 @@ defmodule Logger do
 
   ## Options
 
-    * `:flush` - when true, guarantees all messages currently sent
+    * `:flush` - when `true`, guarantees all messages currently sent
       to both Logger and Erlang's `error_logger` are processed before
       the backend is added
 
@@ -345,7 +345,7 @@ defmodule Logger do
 
   ## Options
 
-    * `:flush` - when true, guarantees all messages currently sent
+    * `:flush` - when `true`, guarantees all messages currently sent
       to both Logger and Erlang's `error_logger` are processed before
       the backend is removed
   """

--- a/lib/mix/lib/mix/compilers/erlang.ex
+++ b/lib/mix/lib/mix/compilers/erlang.ex
@@ -4,7 +4,7 @@ defmodule Mix.Compilers.Erlang do
   @doc """
   Compiles the files in `src_dirs` with given extensions into
   the destination, automatically invoking the callback for each
-  stale input and output pair (or for all if `force` is true) and
+  stale input and output pair (or for all if `force` is `true`) and
   removing files that no longer have a source, while keeping the
   manifest up to date.
 
@@ -27,7 +27,7 @@ defmodule Mix.Compilers.Erlang do
     1. look for files ending with the `lfe` extension in `src`
        and their `beam` counterpart in `ebin`
 
-    2. for each stale file (or for all if `force` is true),
+    2. for each stale file (or for all if `force` is `true`),
        invoke the callback passing the calculated input
        and output
 
@@ -51,7 +51,7 @@ defmodule Mix.Compilers.Erlang do
   Compiles the given src/dest tuples.
 
   A manifest file and a callback to be invoked for each src/dest pair
-  must be given. A src/dest pair where destination is nil is considered
+  must be given. A src/dest pair where destination is `nil` is considered
   to be up to date and won't be (re-)compiled.
   """
   def compile(manifest, tuples, callback) do

--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -238,7 +238,7 @@ defmodule Mix.Dep do
   end
 
   @doc """
-  Returns true if the dependency is ok.
+  Returns `true` if the dependency is ok.
   """
   def ok?(%Mix.Dep{status: {:ok, _}}), do: true
   def ok?(%Mix.Dep{}), do: false

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -228,7 +228,7 @@ defmodule Mix.Project do
       Mix.Project.build_path
       #=> "/path/to/project/_build/shared"
 
-  If :build_per_environment is set to true (the default), it
+  If :build_per_environment is set to `true` (the default), it
   will create a new build per environment:
 
       Mix.env

--- a/lib/mix/lib/mix/project_stack.ex
+++ b/lib/mix/lib/mix/project_stack.ex
@@ -86,7 +86,7 @@ defmodule Mix.ProjectStack do
 
   @doc """
   Enables the recursion for the project at the top of the stack.
-  Returns true if recursion was enabled or false if the project
+  Returns `true` if recursion was enabled or `false` if the project
   already had recursion enabled or there is no project in the stack.
   """
   @spec enable_recursion :: boolean
@@ -103,7 +103,7 @@ defmodule Mix.ProjectStack do
 
   @doc """
   Disables the recursion for the project in the stack.
-  Returns true if recursion was disabled or false if there
+  Returns `true` if recursion was disabled or `false` if there
   is no project or recursion was not enabled.
   """
   @spec disable_recursion :: boolean

--- a/lib/mix/lib/mix/scm.ex
+++ b/lib/mix/lib/mix/scm.ex
@@ -47,7 +47,7 @@ defmodule Mix.SCM do
   Each registered SCM will be asked if they consume this dependency,
   receiving `[github: "foo/bar"]` as argument. Since this option makes
   sense for the Git SCM, it will return an update list of options
-  while other SCMs would simply return nil.
+  while other SCMs would simply return `nil`.
   """
   defcallback accepts_options(app :: atom, opts) :: opts | nil
 
@@ -105,7 +105,7 @@ defmodule Mix.SCM do
   defcallback lock_status(opts) :: :mismatch | :outdated | :ok
 
   @doc """
-  Receives two options and must return true if they refer to the
+  Receives two options and must return `true` if they refer to the
   same repository. The options are guaranteed to belong to the
   same SCM.
   """

--- a/lib/mix/lib/mix/shell.ex
+++ b/lib/mix/lib/mix/shell.ex
@@ -35,13 +35,13 @@ defmodule Mix.Shell do
 
   ## Options
 
-    * `:print_app` - when false, does not print the app name
+    * `:print_app` - when `false`, does not print the app name
       when the command outputs something
 
-    * `:stderr_to_stdout` - when false, does not redirect
+    * `:stderr_to_stdout` - when `false`, does not redirect
       stderr to stdout
 
-    * `:quiet` - when true, do not print the command output
+    * `:quiet` - when `true`, do not print the command output
 
   """
   defcallback cmd(command :: String.t, options :: Keyword.t) :: integer
@@ -59,7 +59,7 @@ defmodule Mix.Shell do
   but only if the application name should be printed.
 
   Calling this function automatically toggles its value
-  to false until the current project is re-entered. The
+  to `false` until the current project is re-entered. The
   goal is to exactly avoid printing the application name
   multiple times.
   """

--- a/lib/mix/lib/mix/tasks/deps.ex
+++ b/lib/mix/lib/mix/tasks/deps.ex
@@ -50,7 +50,7 @@ defmodule Mix.Tasks.Deps do
 
   ## Mix options
 
-    * `:app` - when set to false, does not read the app file for this
+    * `:app` - when set to `false`, does not read the app file for this
       dependency
 
     * `:env` - the environment to run the dependency on, defaults to :prod
@@ -64,7 +64,7 @@ defmodule Mix.Tasks.Deps do
     * `:only` - the dependency will belong only to the given environments,
       useful when declaring dev- or test-only dependencies
 
-    * `:override` - if set to true the dependency will override any other
+    * `:override` - if set to `true` the dependency will override any other
       definitions of itself by other dependencies
 
   ## Git options (`:git`)
@@ -74,12 +74,12 @@ defmodule Mix.Tasks.Deps do
     * `:ref`        - the reference to checkout (may be a branch, a commit sha or a tag)
     * `:branch`     - the git branch to checkout
     * `:tag`        - the git tag to checkout
-    * `:submodules` - when true, initialize submodules for the repo
+    * `:submodules` - when ` true`, initialize submodules for the repo
 
   ## Path options (`:path`)
 
     * `:path`        - the path for the dependency
-    * `:in_umbrella` - when true, sets a path dependency pointing to
+    * `:in_umbrella` - when `true`, sets a path dependency pointing to
       "../#{app}", sharing the same environment as the current application
 
   ## mix deps task

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -73,7 +73,7 @@ defmodule Mix.Tasks.Test do
       mix test --include external:true
 
   The example above will run all tests that have the external flag set to
-  true. It is also possible to include all examples that have a given tag,
+  `true`. It is also possible to include all examples that have a given tag,
   regardless of its value:
 
       mix test --include external
@@ -126,7 +126,7 @@ defmodule Mix.Tasks.Test do
   `CoverModule` can be any module that exports `start/2`, receiving the
   compilation path and the `test_coverage` options as arguments. It must
   return an anonymous function of zero arity that will be run after the
-  test suite is done or nil.
+  test suite is done or `nil`.
   """
 
   @switches [force: :boolean, color: :boolean, cover: :boolean,


### PR DESCRIPTION
I have added backticks to `true`, `false` and `nil`, 
using the following regular expressions to detect them.

```bash
ag -i "\W(is|are|was|were|to|or|and|nor|when|returns?|defaults?|otherwise|\.)\s+(true|false|nil)" -l
```

if some more patterns can be added, please let me know.