### PR TITLE
Improve error message for invalid struct fields definition

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3068,6 +3068,12 @@ defmodule Kernel do
   """
   defmacro defstruct(fields) do
     quote bind_quoted: [fields: fields] do
+      case fields do
+        fs when is_list(fs) -> :ok
+        other ->
+          raise ArgumentError, "struct fields definition must be list, got: #{inspect other}"
+      end
+
       fields = :lists.map(fn
         {key, val} when is_atom(key) ->
           try do


### PR DESCRIPTION
From
```
** (FunctionClauseError) no function clause matching in :lists.map/2
    (stdlib) lists.erl:1236: :lists.map(#Function<0.4550704 in file:iex>, :name)
```
to
```
** (ArgumentError) struct fields definition must be list, got: :name
```