### PR TITLE
fix failing test on erlang 18 release candidate

### DIFF
--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -295,7 +295,7 @@ defmodule Kernel.ExceptionTest do
 
   test "format_fa" do
     assert Exception.format_fa(fn -> end, 1) =~
-           ~r"#Function<\d\.\d+/0 in Kernel\.ExceptionTest\.test format_fa/1>/1"
+           ~r"#Function<\d+\.\d+/0 in Kernel\.ExceptionTest\.test format_fa/1>/1"
   end
 
   import Exception, only: [message: 1]


### PR DESCRIPTION
```elixir
  1) test format_fa (Kernel.ExceptionTest)
     test/elixir/exception_test.exs:296
     Assertion with =~ failed
     code: Exception.format_fa(fn -> nil end, 1) =~ ~r"#Function<\\d\\.\\d+/0 in Kernel\\.ExceptionTest\\.test format_fa/1>/1"
     lhs:  "#Function<20.127479888/0 in Kernel.ExceptionTest.test format_fa/1>/1"
     rhs:  ~r/#Function<\d\.\d+\/0 in Kernel\.ExceptionTest\.test format_fa\/1>\/1/
     stacktrace:
       test/elixir/exception_test.exs:297
```