### PR TITLE
Make `import Foo, except: []` respect previous imports

### DIFF
--- a/lib/elixir/src/elixir_import.erl
+++ b/lib/elixir/src/elixir_import.erl
@@ -62,7 +62,6 @@ calculate(Meta, Key, Opts, Old, E, Existing) ->
     _ ->
       case keyfind(except, Opts) of
         false -> remove_underscored(Existing());
-        {except, []} -> remove_underscored(Existing());
         {except, Except} when is_list(Except) ->
           case keyfind(Key, Old) of
             false -> remove_underscored(Existing()) -- Except;

--- a/lib/elixir/test/elixir/kernel/import_test.exs
+++ b/lib/elixir/test/elixir/kernel/import_test.exs
@@ -20,8 +20,10 @@ defmodule Kernel.ImportTest do
   end
 
   test "import except one" do
-    import :lists, except: [each: 2]
+    import :lists, except: [duplicate: 2]
     assert flatten([1, [2], 3]) == [1, 2, 3]
+    # Buggy local duplicate is untouched
+    assert duplicate([1], 2) == [1]
   end
 
   test "import only via macro" do
@@ -42,6 +44,22 @@ defmodule Kernel.ImportTest do
   test "import with double except" do
     import :lists, except: [duplicate: 2]
     import :lists, except: [each: 2]
+    assert append([1], [2, 3]) == [1, 2, 3]
+    # Buggy local duplicate is untouched
+    assert duplicate([1], 2) == [1]
+  end
+
+  test "import except none respects previous import with except" do
+    import :lists, except: [duplicate: 2]
+    import :lists, except: []
+    assert append([1], [2, 3]) == [1, 2, 3]
+    # Buggy local duplicate is untouched
+    assert duplicate([1], 2) == [1]
+  end
+
+  test "import except none respects previous import with only" do
+    import :lists, only: [append: 2]
+    import :lists, except: []
     assert append([1], [2, 3]) == [1, 2, 3]
     # Buggy local duplicate is untouched
     assert duplicate([1], 2) == [1]


### PR DESCRIPTION
Closes #3121, aligning the behavior with what's described in the documentation (https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/kernel/special_forms.ex#L527-L531)

Besides adding tests for the corrected behavior I beefed up the test `"import except one"` so it also tests the function is excluded (a different test covered that indirectly, but it seemed reasonable to also do it in this test given its name).