### PR TITLE
Optimize Keyword.new/1,2 functions

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -68,7 +68,10 @@ defmodule Keyword do
   """
   @spec new(Enum.t) :: t
   def new(pairs) do
-    Enum.uniq_by(Enum.reverse(pairs), fn {x, _} when is_atom(x) -> x end)
+    fun = fn {k, v}, acc ->
+      put_new(acc, k, v)
+    end
+    :lists.foldr(fun, [], Enum.reverse(pairs))
   end
 
   @doc """

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -87,7 +87,7 @@ defmodule Keyword do
       [a: :a, b: :b]
 
   """
-  @spec new(Enum.t, ({key, value} -> {key, value})) :: t
+  @spec new(Enum.t, (term -> {key, value})) :: t
   def new(pairs, transform) do
     Enum.reduce pairs, [], fn i, keywords ->
       {k, v} = transform.(i)

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -68,10 +68,7 @@ defmodule Keyword do
   """
   @spec new(Enum.t) :: t
   def new(pairs) do
-    fun = fn {k, v}, acc ->
-      put_new(acc, k, v)
-    end
-    :lists.foldr(fun, [], Enum.reverse(pairs))
+    new(pairs, fn pair -> pair end)
   end
 
   @doc """
@@ -83,16 +80,17 @@ defmodule Keyword do
 
   ## Examples
 
-      iex> Keyword.new([:a, :b], fn (x) -> {x, x} end) |> Enum.sort
-      [a: :a, b: :b]
+      iex> Keyword.new([:a, :b], fn (x) -> {x, x} end)
+      [b: :b, a: :a]
 
   """
   @spec new(Enum.t, (term -> {key, value})) :: t
-  def new(pairs, transform) do
-    Enum.reduce pairs, [], fn i, keywords ->
-      {k, v} = transform.(i)
-      put(keywords, k, v)
+  def new(pairs, transform) when is_function(transform, 1) do
+    fun = fn el, acc ->
+      {k, v} = transform.(el)
+      put_new(acc, k, v)
     end
+    :lists.foldr(fun, [], Enum.reverse(pairs))
   end
 
   @doc """


### PR DESCRIPTION
Follow-up on https://github.com/elixir-lang/elixir/pull/3176#discussion_r26907713.
I think we do not need hand-written implementation, the `put_new` is well suited.
The timings for 200 elements enum:
`Keyword.new/1`:
```
new:      50000   60.69 µs/op
old:      10000   124.75 µs/op
```
`Keyword.new/2`:
```
new:      50000   55.86 µs/op
old:       1000   1113.29 µs/op
```