### PR TITLE
Support specs for unreachable private functions

### DIFF
--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -272,8 +272,8 @@ split_definition([{Tuple, defmacrop, _Line, _Location, _Body}|T], Unreachable,
   split_definition(T, Unreachable, Def, Defp, Defmacro, [Tuple|Defmacrop],
                    Exports, Functions);
 
-split_definition([], _Unreachable, Def, Defp, Defmacro, Defmacrop, Exports, {Head, Tail}) ->
-  {Def, Defp, Defmacro, Defmacrop, Exports, Head ++ Tail}.
+split_definition([], Unreachable, Def, Defp, Defmacro, Defmacrop, Exports, {Head, Tail}) ->
+  {Def, Defp, Defmacro, Defmacrop, Exports, Head ++ Tail, Unreachable}.
 
 %% Helpers
 

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -442,6 +442,21 @@ defmodule Kernel.TypespecTest do
            specs(module)
   end
 
+  test "@spec(spec) for unreachable private function" do
+    # Run it inside capture_io/2 so that the "myfun/1 is unused"
+    # warning doesn't get printed among the ExUnit test results.
+    output = ExUnit.CaptureIO.capture_io :stderr, fn ->
+      module = test_module do
+        defp myfun(x), do: x
+        @spec myfun(integer) :: integer
+      end
+
+      assert [] == specs(module)
+    end
+
+    assert output =~ "warning: function myfun/1 is unused"
+  end
+
   test "@spec(spec) with guards" do
     module = test_module do
       def myfun1(x), do: x


### PR DESCRIPTION
Closes #3144

If the order of arguments for some of these functions (i.e. the position in which I inserted `Unreachable`) isn't quite right, let me know where it should be instead.  Otherwise, not too much going on here... at least as far I can tell.

I did check that capturing `stderr` doesn't interfere with when this test fails (e.g. when I run it with `elixir` rather than `bin/elixir`).  It gives the `CompileError` as expected:

```
  1) test @spec(spec) for unreachable private function (Kernel.TypespecTest)
     lib/elixir/test/elixir/kernel/typespec_test.exs:445
     ** (CompileError) lib/elixir/test/elixir/kernel/typespec_test.exs:451: spec for undefined function Kernel.TypespecTest.TestTypespec.myfun/1
     stacktrace:
       (stdlib) lists.erl:1336: :lists.foreach/2
```