### PR TITLE
rename :shell option to :system in mix

### DIFF
--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -28,7 +28,7 @@ defmodule Mix.Tasks.Archive.Install do
   """
   @spec run(OptionParser.argv) :: boolean
   def run(argv) do
-    {opts, argv, _} = OptionParser.parse(argv, switches: [force: :boolean, shell: :boolean])
+    {opts, argv, _} = OptionParser.parse(argv, switches: [force: :boolean, system: :boolean])
 
     if src = List.first(argv) do
       %URI{path: path} = URI.parse(src)

--- a/lib/mix/lib/mix/tasks/local.hex.ex
+++ b/lib/mix/lib/mix/tasks/local.hex.ex
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.Local.Hex do
     version = get_matching_version()
     url = String.replace(@hex_archive_url, "[VERSION]", version)
 
-    Mix.Tasks.Archive.Install.run [url, "--shell" | args]
+    Mix.Tasks.Archive.Install.run [url, "--system" | args]
   end
 
   @doc false

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -353,12 +353,12 @@ defmodule Mix.Utils do
 
   ## Options
 
-    * `:shell` - Forces the use of `wget` or `curl` to fetch the file if the
-      given path is a URL.
+    * `:system` - Boolean value forces the use of `wget` or `curl`
+      to fetch the file if the given path is a URL.
   """
   def read_path!(path, opts \\ []) do
     cond do
-      url?(path) && opts[:shell] ->
+      url?(path) && opts[:system] ->
         read_shell(path, nil)
       url?(path) ->
         read_httpc(path, nil)
@@ -381,15 +381,15 @@ defmodule Mix.Utils do
 
   ## Options
 
-    * `:shell` - Forces the use of `wget` or `curl` to fetch the file if the
-      given path is a URL.
+    * `:system` - Boolean value forces the use of `wget` or `curl`
+      to fetch the file if the given path is a URL.
 
     * `:force` - Forces overwriting target file without a shell prompt.
   """
   def copy_path!(source, target, opts \\ []) when is_binary(source) and is_binary(target) do
     if opts[:force] || overwriting?(target) do
       cond do
-        url?(source) && opts[:shell] ->
+        url?(source) && opts[:system] ->
           read_shell(source, target)
         url?(source) ->
           read_httpc(source, target)


### PR DESCRIPTION
in `Mix.Utils.read_path!`, `Mix.Utils.copy_path!` and `mix archive`

resolves #3219 