### PR TITLE
Add last history value helper to IEx

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -20,6 +20,7 @@ defmodule IEx.Helpers do
     * `l/1`           — loads the given module's beam code
     * `ls/0`          — lists the contents of the current directory
     * `ls/1`          — lists the contents of the specified directory
+    * `p/0`           — retrieves the last value from the history
     * `pwd/0`         — prints the current working directory
     * `r/1`           — recompiles and reloads the given module's source file
     * `respawn/0`     — respawns the current shell
@@ -299,6 +300,11 @@ defmodule IEx.Helpers do
   def v(n) do
     IEx.History.nth(n) |> elem(2)
   end
+
+  @doc """
+  Retrieves the last evaluated expression's value from the history.
+  """
+  def p, do: v(-1)
 
   @doc """
   Recompiles and reloads the given `module`.

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -130,6 +130,10 @@ defmodule IEx.HelpersTest do
            """
   end
 
+  test "p helper" do
+    assert capture_iex("1\n2\np") == capture_iex("1\n2\nv(-1)")
+  end
+
   test "flush helper" do
     assert capture_io(fn -> send self(), :hello; flush end) == ":hello\n"
   end


### PR DESCRIPTION
A lot of other language's interpreters (e.g. ruby, node, off the top of my head) allow you to use the result of the last evaluated expression via a (very short) shortcut such as `_`. This commit adds a helper `p/0` to `IEx.Helpers` which allows you to do the same in IEx. `_` would have been cool but of course that is not available.

I think this would be cool because v(-1) is kind of a pain in the butt to type every time you want to use the previous value in a subsequent expression.