### PR TITLE
Add message for failure due to `--warnings-as-errors`

### DIFF
--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -57,8 +57,11 @@ defmodule Kernel.ParallelCompiler do
     # In case --warning-as-errors is enabled and there was a warning,
     # compilation status will be set to error and we fail with CompileError
     case :elixir_code_server.call({:compilation_status, compiler_pid}) do
-      :ok    -> result
-      :error -> exit({:shutdown, 1})
+      :ok    ->
+        result
+      :error ->
+        IO.puts :stderr, "Compilation failed due to warnings while using the --warnings-as-errors option"
+        exit({:shutdown, 1})
     end
   end
 

--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -154,9 +154,11 @@ defmodule Kernel.CLI.ParallelCompilerTest do
     try do
       Code.compiler_options(warnings_as_errors: true)
 
-      capture_io :stderr, fn ->
+      msg = capture_io :stderr, fn ->
         assert catch_exit(Kernel.ParallelCompiler.files fixtures) == {:shutdown, 1}
       end
+
+      assert msg =~ "Compilation failed due to warnings while using the --warnings-as-errors option\n"
     after
       Code.compiler_options(warnings_as_errors: warnings_as_errors)
     end


### PR DESCRIPTION
This commits add a message output to stderr when compilation
fails due to the presence of warnings while using the
`--warnings-as-errors` option.

Closes #3222 

Sample output:

```
$ mix compile
lib/foo.ex:5: warning: this clause cannot match because a previous clause at line 4 always matches
Compiled lib/foo.ex
Generated foo app
```

```
$ mix compile --warnings-as-errors
lib/foo.ex:5: warning: this clause cannot match because a previous clause at line 4 always matches
Compiled lib/foo.ex
Compilation failed due to warnings while using the --warnings-as-errors option
```