### PR TITLE
No longer translate arguments to `@on_definition`

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -170,11 +170,11 @@ defmodule Module do
         - the module environment
         - kind: `:def`, `:defp`, `:defmacro`, or `:defmacrop`
         - function/macro name
-        - list of expanded arguments
-        - list of expanded guards
-        - expanded function body
+        - list of quoted arguments
+        - list of quoted guards
+        - quoted function body
 
-      Note the hook receives the expanded arguments and it is invoked before
+      Note the hook receives the quoted arguments and it is invoked before
       the function is stored in the module. So `Module.defines?/2` will return
       `false` for the first clause of every function.
 
@@ -867,6 +867,13 @@ defmodule Module do
     arity  = length(args)
     pair   = {name, arity}
     doc    = get_attribute(module, :doc)
+
+    # Arguments are not expanded for the docs, but we make
+    # an exception for module attributes.
+    args = Macro.prewalk args, fn
+      {:@,  _, _} = attr -> Macro.expand_once(attr, env)
+      x -> x
+    end
 
     case add_doc(module, line, kind, pair, args, doc) do
       :ok ->

--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -79,7 +79,8 @@ store_definition(Line, Kind, CheckClauses, Name, Args, Guards, Body, KeepLocatio
   elixir_locals:record_definition(Tuple, Kind, Module),
 
   Location = retrieve_location(KeepLocation, Module),
-  {Function, Defaults, Super} = translate_definition(Kind, Line, Module, Name, Args, Guards, Body, E),
+  {Function, Defaults, Super} = translate_definition(Kind, Line, Name, Args, Guards, Body, E),
+  run_on_definition_callbacks(Kind, Line, Module, Name, Args, Guards, expr_from_body(Line, Body), E),
 
   DefaultsLength = length(Defaults),
   elixir_locals:record_defaults(Tuple, Kind, Module, DefaultsLength),
@@ -154,7 +155,7 @@ compile_super(_Module, _, _E) -> ok.
 %% Translate the given call and expression given
 %% and then store it in memory.
 
-translate_definition(Kind, Line, Module, Name, Args, Guards, Body, E) when is_integer(Line) ->
+translate_definition(Kind, Line, Name, Args, Guards, Body, E) when is_integer(Line) ->
   Arity = length(Args),
 
   {EArgs, EGuards, EBody, _} = elixir_exp_clauses:def(fun elixir_def_defaults:expand/2,
@@ -166,7 +167,6 @@ translate_definition(Kind, Line, Module, Name, Args, Guards, Body, E) when is_in
   {Unpacked, Defaults} = elixir_def_defaults:unpack(Kind, Name, EArgs, S),
   {Clauses, Super} = translate_clause(Body, Line, Kind, Unpacked, EGuards, EBody, S),
 
-  run_on_definition_callbacks(Kind, Line, Module, Name, EArgs, EGuards, EBody, E),
   Function = {function, Line, Name, Arity, Clauses},
   {Function, Defaults, Super}.
 

--- a/lib/elixir/test/elixir/kernel/docs_test.exs
+++ b/lib/elixir/test/elixir/kernel/docs_test.exs
@@ -10,7 +10,12 @@ defmodule Kernel.DocsTest do
     assert [{{:__behaviour__, 1}, _, :def, [{:atom1, [], Elixir}], false},
             {{:fun, 2}, _, :def, [{:x, [], nil}, {:y, [], nil}], "This is fun!\n"},
             {{:nofun, 0}, _, :def, [], nil},
-            {{:sneaky, 1}, _, :def, [{:bool1, [], Elixir}], false}] = docs[:docs]
+            {{:sneaky, 1}, _, :def, [{:bool1, [], Elixir}], false},
+            {{:with_defaults, 4}, _, :def,
+             [{:int1, [], Elixir},
+              {:\\, [], [{:x, [], nil}, 0]},
+              {:\\, [], [{:y, [], nil}, 2015]},
+              {:\\, [], [{:f, [], nil}, {:&, _, [{:/, _, [{:>=, _, _}, 2]}]}]}], nil}] = docs[:docs]
     assert {_, "Hello, I am a module"} = docs[:moduledoc]
     assert [{{:bar, 1}, _, :def, false}, {{:baz, 2}, _, :def, nil},
             {{:first, 0}, _, :def, "I should be first."},
@@ -77,6 +82,11 @@ defmodule Kernel.DocsTest do
 
       def nofun() do
         'not fun at all'
+      end
+
+      @year 2015
+      def with_defaults(@year, x \\ 0, y \\ @year, f \\ &>=/2) do
+        {f, x + y}
       end
     end)
   end

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -98,7 +98,7 @@ defmodule ModuleTest do
     assert name == :hello
     assert [{:foo, _, _}, {:bar, _, _}] = args
     assert [] = guards
-    assert {{:., _, [:erlang, :+]}, _, [{:foo, _, nil}, {:bar, _, nil}]} = expr
+    assert {:+, _, [{:foo, _, nil}, {:bar, _, nil}]} = expr
   end
 
   test :overridable_inside_before_compile do


### PR DESCRIPTION
Breaking change: the arguments to the `@on_definition` hook are no
longer expanded and translated, but are passed in their original quoted
form.  The only exception is module attributes (e.g. `@my_constant`),
which are expanded.

The reason for this change is that this hook is used for generating
functions' documentation, and the previous behavior was causing
incorrect signatures in the documentation.  See #3143 for details.

Closes #3143

Some additional comments:
- For the `Body` argument, I am just passing the expression, rather than `[do: expr]`.  This seemed like the more reasonable thing to do.
- `run_on_definition_callbacks` is being called after the translation (but with the untranslated values).  The reason is that if it's called before, it messes up the `bad_unquoting` test in `errors_test.exs`.  Breaking a test in and of itself is not so bad, but does so while resulting in a much less useful error from `Macro.pre_walk`, compared to the current message of `invalid quoted expression`.  Calling it after the translation lets us detect the error as before and have the clearer message.
- Besides the added tests, I built the docs, verified that the cases here are fixed, and scanned through some of the other signatures with `\\` using an `ag` search, and it looked fine.  But this was by no means a comprehensive check.