### PR TITLE
Add the support for Process.get_keys/0 with :erlang.get_keys/0

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -48,6 +48,15 @@ defmodule Process do
   end
 
   @doc """
+  Returns all keys
+  """
+
+  @spec get_keys() :: [term]
+  def get_keys do
+    :erlang.get_keys()
+  end
+
+  @doc """
   Returns all keys that have the given `value`.
   """
   @spec get_keys(term) :: [term]


### PR DESCRIPTION
Tested with the last Erlang R18-rc1 and Kerl
```
bash-4.3$ ./iex
Erlang/OTP 18 [RELEASE CANDIDATE 1] [erts-7.0] [source-cc722af] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false]

Interactive Elixir (1.1.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> Process.get_keys
[:iex_history_start_counter, :iex_history_counter]
iex(2)> Process.get_keys()
[:iex_history_counter, {:iex_history, 1}, :iex_history_start_counter]
iex(3)>
```