### PR TITLE
Add some docs to `defstruct/1`

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3015,6 +3015,15 @@ defmodule Kernel do
         defstruct name: nil, age: 10 + 11
       end
 
+  The `fields` argument is usually a keyword list with fields as keys and
+  default values as corresponding values. `defstruct/1` also supports a list of
+  atoms as its argument: in that case, the atoms in the list will be used as
+  the struct's fields and they will all default to `nil`.
+
+      defmodule Post do
+        defstruct [:title, :content, :author]
+      end
+
   ## Deriving
 
   Although structs are maps, by default structs do not implement


### PR DESCRIPTION
The documentation for `defstruct/1` didn't mention that a list of atoms can be passed as an argument instead of a keyword list. I added the missing documentation.