### PR TITLE
Also test using OTP 17.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ otp_release:
   - 17.0
   - 17.3
   - 17.4
+  - 17.5
 
 sudo: false
 


### PR DESCRIPTION
This requires Travis CI to release their new server image with support for OTP 17.5.

https://github.com/travis-ci/travis-build/pull/422#issuecomment-90949420