### PR TITLE
Introduce `MapSet` data type

### DIFF
--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -1,0 +1,116 @@
+defmodule MapSet do
+  @moduledoc """
+  A set store.
+
+  The `MapSet` is represented internally as a struct, therefore
+  `%MapSet{}` can be used whenever there is a need to match
+  on any `MapSet`. Note though the struct fields are private and
+  must not be accessed directly. Instead, use the functions on this
+  or in the `Set` module.
+
+  The `MapSet` is implemented using `Map` data type.
+  For more information about the functions
+  and their APIs, please consult the `Set` module.
+  """
+
+  @behaviour Set
+
+  defstruct map: %{}
+
+  def new(), do: %MapSet{}
+
+  def delete(%MapSet{map: map} = set, term) do
+    %{set | map: Map.delete(map, term)}
+  end
+
+  def difference(%MapSet{} = set1, %MapSet{} = set2) do
+    reduce(set2, {:cont, set1}, fn value, acc ->
+      {:cont, delete(acc, value)}
+    end) |> elem(1)
+  end
+
+  def disjoint?(%MapSet{} = set1, %MapSet{} = set2) do
+    if size(set1) > size(set2), do: {set1, set2} = {set2, set1}
+    reduce(set1, {:cont, true}, fn value, _ ->
+      if member?(set2, value) do
+        {:halt, false}
+      else
+        {:cont, true}
+      end
+    end) |> elem(1)
+  end
+
+  def equal?(%MapSet{map: map1}, %MapSet{map: map2}) do
+    Map.equal?(map1, map2)
+  end
+
+  def intersection(%MapSet{} = set1, %MapSet{} = set2) do
+    if size(set1) > size(set2), do: {set1, set2} = {set2, set1}
+    reduce(set1, {:cont, new}, fn value, acc ->
+      if member?(set2, value) do
+        {:cont, put(acc, value)}
+      else
+        {:cont, acc}
+      end
+    end) |> elem(1)
+  end
+
+  def member?(%MapSet{map: map}, value) do
+    Map.has_key?(map, value)
+  end
+
+  def put(%MapSet{map: map} = set, value) do
+    %{set | map: Map.put(map, value, nil)}
+  end
+
+  def size(%MapSet{map: map}) do
+    map_size(map)
+  end
+
+  def subset?(%MapSet{} = set1, %MapSet{} = set2) do
+    if size(set1) <= size(set2) do
+      reduce(set1, {:cont, true}, fn value, _ ->
+        if member?(set2, value), do: {:cont, true}, else: {:halt, false}
+      end) |> elem(1)
+    else
+      false
+    end
+  end
+
+  @doc false
+  def reduce(%MapSet{} = set, acc, fun) do
+    Enumerable.List.reduce(to_list(set), acc, fun)
+  end
+
+  def to_list(%MapSet{map: map}) do
+    Map.keys(map)
+  end
+
+  def union(%MapSet{map: map1}, %MapSet{map: map2}) do
+    %MapSet{map: Map.merge(map1, map2)}
+  end
+
+  defimpl Enumerable do
+    def reduce(set, acc, fun), do: MapSet.reduce(set, acc, fun)
+    def member?(set, val),     do: {:ok, MapSet.member?(set, val)}
+    def count(set),            do: {:ok, MapSet.size(set)}
+  end
+
+  defimpl Collectable do
+    def into(original) do
+      {original, fn
+        set, {:cont, x} -> MapSet.put(set, x)
+        set, :done -> set
+        _, :halt -> :ok
+      end}
+    end
+  end
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(set, opts) do
+      concat ["#MapSet<", Inspect.List.inspect(MapSet.to_list(set), opts), ">"]
+    end
+  end
+end

--- a/lib/elixir/test/elixir/hash_set_test.exs
+++ b/lib/elixir/test/elixir/hash_set_test.exs
@@ -3,53 +3,76 @@ Code.require_file "test_helper.exs", __DIR__
 defmodule HashSetTest do
   use ExUnit.Case, async: true
 
+  alias HashSet, as: S
+
+  test "put" do
+    assert S.equal?(S.put(S.new, 1), make([1]))
+    assert S.equal?(S.put(make([1, 3, 4]), 2), make(1..4))
+    assert S.equal?(S.put(make(5..100), 10), make(5..100))
+  end
+
   test "union" do
-    assert HashSet.union(filled_set(21), filled_set(22)) == filled_set(22)
-    assert HashSet.union(filled_set(121), filled_set(120)) == filled_set(121)
+    assert S.equal?(S.union(make([1, 3, 4]), S.new), make([1, 3, 4]))
+    assert S.equal?(S.union(make(5..15), make(10..25)), make(5..25))
+    assert S.equal?(S.union(make(1..120), make(1..100)), make(1..120))
   end
 
   test "intersection" do
-    assert HashSet.intersection(filled_set(21), filled_set(20)) == filled_set(20)
-    assert HashSet.equal?(HashSet.intersection(filled_set(120), filled_set(121)), filled_set(120))
+    assert S.equal?(S.intersection(S.new, make(1..21)), S.new)
+    assert S.equal?(S.intersection(make(1..21), make(4..24)), make(4..21))
+    assert S.equal?(S.intersection(make(2..100), make(1..120)), make(2..100))
   end
 
   test "difference" do
-    assert HashSet.equal?(HashSet.difference(filled_set(20), filled_set(21)), HashSet.new)
+    assert S.equal?(S.difference(make(2..20), S.new), make(2..20))
+    assert S.equal?(S.difference(make(2..20), make(1..21)), S.new)
+    assert S.equal?(S.difference(make(1..101), make(2..100)), make([1, 101]))
+  end
 
-    diff = HashSet.difference(filled_set(9000), filled_set(9000))
-    assert HashSet.equal?(diff, HashSet.new)
-    assert HashSet.size(diff) == 0
+  test "disjoint?" do
+    assert S.disjoint?(S.new, S.new)
+    assert S.disjoint?(make(1..6), make(8..20))
+    refute S.disjoint?(make(1..6), make(5..15))
+    refute S.disjoint?(make(1..120), make(1..6))
   end
 
   test "subset?" do
-    assert HashSet.subset?(HashSet.new, HashSet.new)
-    assert HashSet.subset?(filled_set(6), filled_set(10))
-    assert HashSet.subset?(filled_set(6), filled_set(120))
-    refute HashSet.subset?(filled_set(120), filled_set(6))
+    assert S.subset?(S.new, S.new)
+    assert S.subset?(make(1..6), make(1..10))
+    assert S.subset?(make(1..6), make(1..120))
+    refute S.subset?(make(1..120), make(1..6))
   end
 
   test "equal?" do
-    assert HashSet.equal?(HashSet.new, HashSet.new)
-    assert HashSet.equal?(filled_set(20), HashSet.delete(filled_set(21), 21))
-    assert HashSet.equal?(filled_set(120), filled_set(120))
+    assert S.equal?(S.new, S.new)
+    refute S.equal?(make(1..20), make(2..21))
+    assert S.equal?(make(1..120), make(1..120))
+  end
+
+  test "delete" do
+    assert S.equal?(S.delete(S.new, 1), S.new)
+    assert S.equal?(S.delete(make(1..4), 5), make(1..4))
+    assert S.equal?(S.delete(make(1..4), 1), make(2..4))
+    assert S.equal?(S.delete(make(1..4), 2), make([1, 3, 4]))
+  end
+
+  test "size" do
+    assert S.size(S.new) == 0
+    assert S.size(make(5..15)) == 11
+    assert S.size(make(2..100)) == 99
   end
 
   test "to_list" do
-    set = filled_set(20)
-    list = HashSet.to_list(set)
-    assert length(list) == 20
-    assert 1 in list
-    assert Enum.sort(list) == Enum.sort(1..20)
+    assert S.to_list(S.new) == []
 
-    set = filled_set(120)
-    list = HashSet.to_list(set)
-    assert length(list) == 120
-    assert 1 in list
-    assert Enum.sort(list) == Enum.sort(1..120)
+    list = S.to_list(make(1..20))
+    assert Enum.sort(list) == Enum.to_list(1..20)
+
+    list = S.to_list(make(5..120))
+    assert Enum.sort(list) == Enum.to_list(5..120)
   end
 
-  defp filled_set(range) do
-    Enum.into 1..range, HashSet.new
+  defp make(collection) do
+    Enum.into(collection, S.new)
   end
 end
-

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -368,6 +368,10 @@ defmodule Inspect.OthersTest do
     assert "#HashSet<" <> _ = inspect(HashSet.new)
   end
 
+  test :map_set do
+    assert "#MapSet<" <> _ = inspect(MapSet.new)
+  end
+
   test :pids do
     assert "#PID<" <> _ = inspect(self)
   end

--- a/lib/elixir/test/elixir/map_set_test.exs
+++ b/lib/elixir/test/elixir/map_set_test.exs
@@ -1,0 +1,78 @@
+Code.require_file "test_helper.exs", __DIR__
+
+defmodule MapSetTest do
+  use ExUnit.Case, async: true
+
+  alias MapSet, as: S
+
+  test "put" do
+    assert S.equal?(S.put(S.new, 1), make([1]))
+    assert S.equal?(S.put(make([1, 3, 4]), 2), make(1..4))
+    assert S.equal?(S.put(make(5..100), 10), make(5..100))
+  end
+
+  test "union" do
+    assert S.equal?(S.union(make([1, 3, 4]), S.new), make([1, 3, 4]))
+    assert S.equal?(S.union(make(5..15), make(10..25)), make(5..25))
+    assert S.equal?(S.union(make(1..120), make(1..100)), make(1..120))
+  end
+
+  test "intersection" do
+    assert S.equal?(S.intersection(S.new, make(1..21)), S.new)
+    assert S.equal?(S.intersection(make(1..21), make(4..24)), make(4..21))
+    assert S.equal?(S.intersection(make(2..100), make(1..120)), make(2..100))
+  end
+
+  test "difference" do
+    assert S.equal?(S.difference(make(2..20), S.new), make(2..20))
+    assert S.equal?(S.difference(make(2..20), make(1..21)), S.new)
+    assert S.equal?(S.difference(make(1..101), make(2..100)), make([1, 101]))
+  end
+
+  test "disjoint?" do
+    assert S.disjoint?(S.new, S.new)
+    assert S.disjoint?(make(1..6), make(8..20))
+    refute S.disjoint?(make(1..6), make(5..15))
+    refute S.disjoint?(make(1..120), make(1..6))
+  end
+
+  test "subset?" do
+    assert S.subset?(S.new, S.new)
+    assert S.subset?(make(1..6), make(1..10))
+    assert S.subset?(make(1..6), make(1..120))
+    refute S.subset?(make(1..120), make(1..6))
+  end
+
+  test "equal?" do
+    assert S.equal?(S.new, S.new)
+    refute S.equal?(make(1..20), make(2..21))
+    assert S.equal?(make(1..120), make(1..120))
+  end
+
+  test "delete" do
+    assert S.equal?(S.delete(S.new, 1), S.new)
+    assert S.equal?(S.delete(make(1..4), 5), make(1..4))
+    assert S.equal?(S.delete(make(1..4), 1), make(2..4))
+    assert S.equal?(S.delete(make(1..4), 2), make([1, 3, 4]))
+  end
+
+  test "size" do
+    assert S.size(S.new) == 0
+    assert S.size(make(5..15)) == 11
+    assert S.size(make(2..100)) == 99
+  end
+
+  test "to_list" do
+    assert S.to_list(S.new) == []
+
+    list = S.to_list(make(1..20))
+    assert Enum.sort(list) == Enum.to_list(1..20)
+
+    list = S.to_list(make(5..120))
+    assert Enum.sort(list) == Enum.to_list(5..120)
+  end
+
+  defp make(collection) do
+    Enum.into(collection, S.new)
+  end
+end

--- a/lib/elixir/test/elixir/set_test.exs
+++ b/lib/elixir/test/elixir/set_test.exs
@@ -186,3 +186,11 @@ defmodule Set.HashSetTest do
   doctest Set
   def set_impl, do: HashSet
 end
+
+defmodule Set.MapSetTest do
+  use ExUnit.Case, async: true
+  use SetTest.Common
+
+  doctest Set
+  def set_impl, do: MapSet
+end

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -43,7 +43,7 @@ defmodule IEx.AutocompleteTest do
 
   test :elixir_completion_on_modules_from_load_path do
     assert expand('Str') == {:yes, [], ['Stream', 'String', 'StringIO']}
-    assert expand('Ma') == {:yes, '', ['Macro', 'Map', 'MatchError']}
+    assert expand('Ma') == {:yes, '', ['Macro', 'Map', 'MapSet', 'MatchError']}
     assert expand('Dic') == {:yes, 't.', []}
     assert expand('Ex')  == {:yes, [], ['ExUnit', 'Exception']}
   end


### PR DESCRIPTION
Closes #3242.

__Erlang/OTP 18 RC-1__

* [x] new
* [x] put

  - 100 elements
  ``` 
  MapSet:    10000000   0.16 µs/op
  HashSet:   10000000   0.37 µs/op
  ```
  - 200 elements
  ```
  MapSet:    10000000   0.16 µs/op
  HashSet:   10000000   0.42 µs/op
  ```
  - 1000 elements
  ```
  MapSet:    10000000   0.21 µs/op
  HashSet:   10000000   0.51 µs/op
  ```
  - 5000 elements
  ```
  MapSet:    10000000   0.26 µs/op
  HashSet:   10000000   0.60 µs/op
  ```

* [x] delete

  - 100 elements
  ```
  MapSet:   100000000   0.11 µs/op
  HashSet:   10000000   0.17 µs/op
  ```
  - 200 elements
  ```
  MapSet:    10000000   0.11 µs/op
  HashSet:   10000000   0.19 µs/op
  ```
  - 1000 elements
  ```
  MapSet:    10000000   0.11 µs/op
  HashSet:   10000000   0.31 µs/op
  ```
  - 5000 elements
  ```
  MapSet:    10000000   0.13 µs/op
  HashSet:   10000000   0.33 µs/op
  ```

* [x] difference

  - 200 elements
  ```
  MapSet:       50000   42.51 µs/op
  HashSet:      20000   98.89 µs/op
  ```

* [x] disjoint?

  - 200 elements (unequal)
  ```
  MapSet:      500000   2.28 µs/op
  HashSet:   10000000   0.51 µs/op
  ```
  where the `:maps.to_list` itself is taking `2.03 µs/op`
  - 200 elements (equal)
  ```
  MapSet:      100000   28.80 µs/op
  HashSet:      10000   126.70 µs/op
  ```

* [x] equal?

  - 200 elements
  ```
  MapSet:   100000000   0.07 µs/op
  HashSet:      10000   128.45 µs/op
  ```
  - 1000 elements (equal)
  ```
  MapSet:   100000000   0.07 µs/op
  HashSet:       5000   704.84 µs/op
  ```
  - 1000 elements (unequal)
  ```
  MapSet:   100000000   0.09 µs/op
  HashSet:   10000000   0.71 µs/op
  ```

* [x] intersection

  - 200 elements
  ```
  MapSet:       50000   34.56 µs/op
  HashSet:      20000   83.33 µs/op
  ```

* [x] member?

  - 200 elements
  ```
  MapSet:   100000000   0.07 µs/op
  HashSet:   10000000   0.20 µs/op
  ```
  - 1000 elements
  ```
  MapSet:   100000000   0.07 µs/op
  HashSet:   10000000   0.22 µs/op
  ```
  - 5000 elements
  ```
  MapSet:   100000000   0.08 µs/op
  HashSet:   10000000   0.26 µs/op
  ```

* [x] size
* [x] subset?

  same as for `disjoint?`

* [x] to_list

  - 200 elements
  ```
  MapSet:     1000000   2.05 µs/op
  HashSet:      50000   38.05 µs/op
  ```
  - 1000 elements
  ```
  MapSet:      100000   12.33 µs/op
  HashSet:      10000   209.33 µs/op
  ```
  - 5000 elements
  ```
  MapSet:       50000   70.11 µs/op
  HashSet:       2000   939.45 µs/op
  ```

* [x] union

  - 200 elements
  ```
  MapSet:      200000   7.21 µs/op
  HashSet:      10000   159.85 µs/op
  ```
  - 1000 elements
  ```
  MapSet:      100000   27.98 µs/op
  HashSet:       2000   850.68 µs/op
  ```
  - 5000 elements
  ```
  MapSet:       10000   207.84 µs/op
  HashSet:        500   4208.29 µs/op
  ```