### PR TITLE
Rename `term` into `value` in `Tuple.insert_at`

### DIFF
--- a/lib/elixir/lib/tuple.ex
+++ b/lib/elixir/lib/tuple.ex
@@ -44,8 +44,8 @@ defmodule Tuple do
 
   """
   @spec insert_at(tuple, non_neg_integer, term) :: tuple
-  def insert_at(tuple, index, term) do
-    :erlang.insert_element(index + 1, tuple, term)
+  def insert_at(tuple, index, value) do
+    :erlang.insert_element(index + 1, tuple, value)
   end
 
   @doc """


### PR DESCRIPTION
In `Tuple.insert_at` documentation, a variable `value` was used
to represent a value to be inserted into a tuple. In the function
definition, however, it was represented as a variable `term`, which
was inconsistency and apparently a typo.