### PR TITLE
Implement `Tuple.append/2`

### DIFF
--- a/lib/elixir/lib/tuple.ex
+++ b/lib/elixir/lib/tuple.ex
@@ -49,6 +49,25 @@ defmodule Tuple do
   end
 
   @doc """
+  Inserts an element into the end of a tuple.
+
+  Returns a new tuple which has one element more than `tuple`, and contains
+  the elements in `tuple` followed by `value` as the last element.
+
+  Inlined by the compiler.
+
+  ## Examples
+      iex> tuple = {:foo, :bar}
+      iex> Tuple.append(tuple, :baz)
+      {:foo, :bar, :baz}
+
+  """
+  @spec append(tuple, term) :: tuple
+  def append(tuple, value) do
+    :erlang.append_element(tuple, value)
+  end
+
+  @doc """
   Removes an element from a tuple.
 
   Deletes the element at the zero-based `index` from `tuple`.

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -142,6 +142,7 @@ inline(?string, to_integer, 1) -> {erlang, binary_to_integer};
 inline(?string, to_integer, 2) -> {erlang, binary_to_integer};
 inline(?system, stacktrace, 0) -> {erlang, get_stacktrace};
 inline(?tuple, to_list, 1) -> {erlang, tuple_to_list};
+inline(?tuple, append, 2) -> {erlang, append_element};
 
 inline(_, _, _) -> false.
 

--- a/lib/elixir/test/elixir/tuple_test.exs
+++ b/lib/elixir/test/elixir/tuple_test.exs
@@ -45,6 +45,13 @@ defmodule TupleTest do
     assert mod.insert_at({:bar, :baz}, 0, :foo) == {:foo, :bar, :baz}
   end
 
+  test :append do
+    assert Tuple.append({:foo, :bar}, :baz) == {:foo, :bar, :baz}
+
+    mod = Tuple
+    assert mod.append({:foo, :bar}, :baz) == {:foo, :bar, :baz}
+  end
+
   test :delete_at do
     assert Tuple.delete_at({:foo, :bar, :baz}, 0) == {:bar, :baz}
 


### PR DESCRIPTION
`Tuple.append/2` adds an element to the end of a tuple, which
mirrors what Erlang's `append_element/2` does. Therefore,
`Tuple.append/2` is implemented to maintain consistency of the API.