### PR TITLE
EEx: allow `)` after `end` in end tokens

### DIFF
--- a/lib/eex/lib/eex/tokenizer.ex
+++ b/lib/eex/lib/eex/tokenizer.ex
@@ -96,9 +96,9 @@ defmodule EEx.Tokenizer do
   #
   # Start tokens finish with `do` and `fn ->`
   # Middle tokens are marked with `->` or keywords
-  # End tokens contain only the end word
+  # End tokens contain only the end word and optionally `)`
 
-  defp token_name([h|t]) when h in [?\s, ?\t] do
+  defp token_name([h|t]) when h in [?\s, ?\t, ?)] do
     token_name(t)
   end
 

--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -98,6 +98,10 @@ defmodule EExTest do
     assert_eval "foo baz", "foo <%= if true do %><%= if false do %>bar<% else %>baz<% end %><% end %>"
   end
 
+  test "evaluates with parentheses after end in end token" do
+    assert_eval " 101  102  103 ", "<%= Enum.map([1,2,3], (fn x -> %> <%= 100 + x %> <% end) ) %>"
+  end
+
   test "evaluates with defined variable" do
     assert_eval "foo 1", "foo <% bar = 1 %><%= bar %>"
   end


### PR DESCRIPTION
Closes #3017

@josevalim Or at least it's a start.  I haven't used EEx much, so I'm not able identify additional use-cases we may want to cover (and I generally prefer to keep any logic in templates simpler than elsewhere).  If you know of others, I can look into them and see what it would take to support them.

The other thing to say is that this will also tokenize `else )`, etc. as `middle_expr`, whereas before it would've been `expr`.  But such cases are not valid in the first place and result in a `SyntaxError` as they should both before and after this patch, so I don't think it's a problem.  I also didn't think it called for additional tests about their error, since these are just invalid syntax not specific to EEx.