### PR TITLE
Fix whitespace errors in Integer source file

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -59,13 +59,13 @@ defmodule Integer do
 
   An optional base value may be provided representing the radix for the digits.
 
-   ## Examples
+  ## Examples
 
-       iex> Integer.undigits([1, 0, 1])
-       101
+      iex> Integer.undigits([1, 0, 1])
+      101
 
-       iex> Integer.undigits([1, 4], 16)
-       20
+      iex> Integer.undigits([1, 4], 16)
+      20
   """
   @spec undigits([integer], integer) :: integer
   def undigits(digits, base \\ 10) when is_integer(base) do
@@ -117,7 +117,7 @@ defmodule Integer do
   """
   @spec parse(binary, 2..36) :: {integer, binary} | :error | no_return
   def parse(binary, base \\ 10)
-  
+
   def parse(binary, base) when is_integer(base) and base in 2..36 do
     parse_in_base(binary, base)
   end


### PR DESCRIPTION
I had left in (e8cd5baf) an extraneous space causing the rendered markdown to be incorrectly displayed. Fixed now :smiley:

Screenshot [from the docs](http://elixir-lang.org/docs/master/elixir/Integer.html#undigits/2) showing the error:

![image](https://cloud.githubusercontent.com/assets/613821/7105569/369d9d60-e120-11e4-9689-c01882491c4b.png)