### PR TITLE
Provide tab-completion for aliases

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -453,10 +453,7 @@ defmodule IEx do
   ## Helpers
 
   defp start_iex() do
-    unless started? do
-      {:ok, _} = Application.ensure_all_started(:iex)
-    end
-
+    {:ok, _} = Application.ensure_all_started(:iex)
     :ok
   end
 

--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -102,7 +102,9 @@ defmodule IEx.Autocomplete do
 
   # Elixir.fun
   defp expand_call({:__aliases__, _, list}, hint) do
-    expand_require(Module.concat(list), hint)
+    expand_alias(list)
+    |> Module.concat()
+    |> expand_require(hint)
   end
 
   defp expand_call(_, _) do
@@ -134,22 +136,62 @@ defmodule IEx.Autocomplete do
 
   ## Elixir modules
 
-  defp expand_elixir_modules(list, hint) do
-    mod = Module.concat(list)
-    format_expansion match_elixir_modules(mod, hint, list == []) ++
-                     match_module_funs(mod, hint), hint
+  defp expand_elixir_modules([], hint) do
+    expand_elixir_modules(Elixir, hint, match_aliases(hint))
   end
 
-  defp match_elixir_modules(module, hint, root) do
-    module = Atom.to_string(module)
-    depth  = length(String.split(module, ".")) + 1
-    base   = module <> "." <> hint
+  defp expand_elixir_modules(list, hint) do
+    expand_alias(list)
+    |> Module.concat()
+    |> expand_elixir_modules(hint, [])
+  end
 
-    for mod <- match_modules(base, root),
-        tokens = String.split(mod, "."),
-        length(tokens) == depth do
-      name = List.last(tokens)
-      %{kind: :module, type: :elixir, name: name}
+  defp expand_elixir_modules(mod, hint, aliases) do
+    aliases
+    |> Kernel.++(match_elixir_modules(mod, hint))
+    |> Kernel.++(match_module_funs(mod, hint))
+    |> format_expansion(hint)
+  end
+
+  defp expand_alias([name | rest] = list) do
+    module = Module.concat(Elixir, name)
+    Enum.find_value env_aliases(), list, fn {alias, mod} ->
+      if alias === module do
+        Module.split(mod) ++ rest
+      end
+    end
+  end
+
+  defp env_aliases() do
+    case IEx.Server.whereis() do
+      nil -> []
+      server ->
+        send(server, {:peek_env, self()})
+        receive do
+          {:peek, %Macro.Env{} = env} -> env.aliases
+        after
+          5000 -> []
+        end
+    end
+  end
+
+  defp match_aliases(hint) do
+    for {alias, _mod} <- env_aliases(),
+        [name] = Module.split(alias),
+        String.starts_with?(name, hint) do
+      %{kind: :module, type: :alias, name: name}
+    end
+  end
+
+  defp match_elixir_modules(module, hint) do
+    name  = Atom.to_string(module)
+    depth = length(String.split(name, ".")) + 1
+    base  = name <> "." <> hint
+
+    for mod <- match_modules(base, module === Elixir),
+        parts = String.split(mod, "."),
+        depth == length(parts) do
+      %{kind: :module, type: :elixir, name: List.last(parts)}
     end
   end
 
@@ -167,12 +209,10 @@ defmodule IEx.Autocomplete do
   end
 
   defp get_modules(false) do
-    modules = Enum.map(:code.all_loaded, fn({m, _}) -> Atom.to_string(m) end)
-
-    if :code.get_mode() === :interactive do
-      modules ++ get_modules_from_applications()
-    else
-      modules
+    modules = Enum.map(:code.all_loaded(), &Atom.to_string(elem(&1, 0)))
+    case :code.get_mode() do
+      :interactive -> modules ++ get_modules_from_applications()
+      _otherwise -> modules
     end
   end
 
@@ -209,8 +249,8 @@ defmodule IEx.Autocomplete do
             String.starts_with?(name, hint) do
           %{kind: :function, name: name, arities: arities}
         end |> :lists.sort()
-      _ ->
-        []
+
+      _otherwise -> []
     end
   end
 
@@ -227,7 +267,8 @@ defmodule IEx.Autocomplete do
   end
 
   defp ensure_loaded(Elixir), do: {:error, :nofile}
-  defp ensure_loaded(mod),    do: Code.ensure_compiled(mod)
+  defp ensure_loaded(mod),
+    do: Code.ensure_compiled(mod)
 
   ## Ad-hoc conversions
 

--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -157,7 +157,9 @@ defmodule IEx.Server do
         exit_loop(evaluator, evaluator_ref)
       {:input, ^input, {:error, :terminated}} ->
         exit_loop(evaluator, evaluator_ref)
-
+      {:peek_env, receiver} ->
+        send receiver, {:peek, state.env}
+        wait_input(state, evaluator, evaluator_ref, input)
       msg ->
         handle_take_over(msg, evaluator, evaluator_ref, input, fn ->
           wait_input(state, evaluator, evaluator_ref, input)


### PR DESCRIPTION
Closes #2519.

It is based on `IEx.Server.whereis/0` usage, as there is no other way to reach current `%IEx.State{}`.
Probably we can use separate agent to track state, not sure if it worth it though; the current implementation might be OK for a first iteration.
I'd like to have any feedback or suggestions ot it. Just for reference: https://github.com/elixir-lang/elixir/issues/2519#issuecomment-48834111.

This also makes possible to add tab-completion for user imports.