### PR TITLE
Handle :undefined in Exception.format_arity/1

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -446,10 +446,6 @@ defmodule Exception do
     "/" <> Integer.to_string(arity)
   end
 
-  defp format_arity(:undefined) do
-    "/?"
-  end
-
   @doc """
   Formats the given file and line as shown in stacktraces.
   If any of the values are `nil`, they are omitted.

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -446,6 +446,10 @@ defmodule Exception do
     "/" <> Integer.to_string(arity)
   end
 
+  defp format_arity(:undefined) do
+    "/?"
+  end
+
   @doc """
   Formats the given file and line as shown in stacktraces.
   If any of the values are `nil`, they are omitted.

--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -165,12 +165,12 @@ defmodule Logger.Translator do
   defp sup_context(:shutdown_error), do: "shutdown abnormally"
 
   defp child_info(min_level, [{:mfargs, {mod, fun, args}} | debug]) do
-    ["Start Call: ", Exception.format_mfa(mod, fun, args) |
+    ["Start Call: ", format_mfa(mod, fun, args) |
       child_debug(min_level, debug)]
   end
 
   defp child_info(min_level, [{:mfa, {mod, fun, args}} | debug]) do
-    ["Start Call: ", Exception.format_mfa(mod, fun, args) |
+    ["Start Call: ", format_mfa(mod, fun, args) |
       child_debug(min_level, debug)]
   end
 
@@ -251,11 +251,11 @@ defmodule Logger.Translator do
   end
 
   defp crash_call(mod, fun, arity) when is_integer(arity) do
-    Exception.format_mfa(mod, fun, arity)
+    format_mfa(mod, fun, arity)
   end
 
   defp crash_call(mod, fun, args) do
-    Exception.format_mfa(mod, fun, length(args))
+    format_mfa(mod, fun, length(args))
   end
 
   defp crash_debug(:debug,
@@ -354,4 +354,7 @@ defmodule Logger.Translator do
     exception = UndefinedFunctionError.exception(opts)
     Exception.format_banner(:error, exception, stacktrace)
   end
+
+  defp format_mfa(mod, fun, :undefined), do: [inspect(mod), ?., to_string(fun) | "/?"]
+  defp format_mfa(mod, fun, args), do: Exception.format_mfa(mod, fun, args)
 end

--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -31,6 +31,12 @@ defmodule Logger.TranslatorTest do
     end
   end
 
+  defmodule MyTemporaryWorker do
+    use GenServer
+    def start_link, do: GenServer.start_link(__MODULE__, [], [])
+    def init([]), do: 1 / 0
+  end
+
   setup_all do
     sasl_reports? = Application.get_env(:logger, :handle_sasl_reports, false)
     Application.put_env(:logger, :handle_sasl_reports, true)
@@ -540,6 +546,15 @@ defmodule Logger.TranslatorTest do
     Start Module: Logger.TranslatorTest.MyBridge
     \*\* \(exit\) :stop
     """
+  end
+
+  test "handles :undefined MFA properly" do
+    children = [Supervisor.Spec.worker(MyTemporaryWorker, [], restart: :temporary)]
+    opts = [strategy: :simple_one_for_one]
+    {:ok, sup} = Supervisor.start_link(children, opts)
+    assert capture_log(:info, fn ->
+      {:error, {:badarith, _}} = Supervisor.start_child(sup, [])
+    end) =~ "Start Call: Logger.TranslatorTest.MyTemporaryWorker.start_link/?"
   end
 
   def task(parent, fun \\ (fn() -> raise "oops" end)) do


### PR DESCRIPTION
We get :undefined when a temporary worker of a simple_one_for_one supervisor crashes.

This PR fixes the following error.

```
18:19:15.088 [error] GenEvent handler Logger.ErrorHandler installed at :error_logger
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in Exception.format_arity/1
        (elixir) lib/exception.ex:431: Exception.format_arity(:undefined)
        (elixir) lib/exception.ex:427: Exception.format_mfa/3
        (logger) lib/logger/translator.ex:165: Logger.Translator.child_info/2
        (logger) lib/logger/translator.ex:90: Logger.Translator.translate_supervisor/2
        (logger) lib/logger/error_handler.ex:116: Logger.ErrorHandler.translate/6
        (logger) lib/logger/error_handler.ex:62: Logger.ErrorHandler.log_event/5
        (logger) lib/logger/error_handler.ex:27: Logger.ErrorHandler.handle_event/2
        (stdlib) gen_event.erl:525: :gen_event.server_update/4
```

To reproduce the error, create a new application with `mix new --sup arity`, add the following code to it:

```elixir
defmodule Worker do
  use GenServer
  def start_link, do: GenServer.start_link(__MODULE__, [], [])
  def init([]), do: 1 / 0
end

defmodule Arity do
  use Application

  def start(_type, _args) do
    import Supervisor.Spec
    children = [worker(Worker, [], restart: :temporary)]
    opts = [strategy: :simple_one_for_one, name: __MODULE__]
    Supervisor.start_link(children, opts)
  end

  def start_child do
    Supervisor.start_child(__MODULE__, [])
    receive do end
  end
end
```

And configure `:logger` as follows:

```elixir
config :logger, [
  handle_sasl_reports: true,
]
```

Finally, run

```sh
$ mix run -e Arity.start_child
```