### PR TITLE
Mix: fix import_config with non-matching wildcard

### DIFF
--- a/lib/mix/lib/mix/config.ex
+++ b/lib/mix/lib/mix/config.ex
@@ -144,11 +144,14 @@ defmodule Mix.Config do
 
   @doc """
   Reads many configuration files given by wildcard into a single config.
+  Raises an error if `path` is a concrete filename (with no wildcards)
+  but the corresponding file does not exist.
   """
   def read_wildcard!(config, path) do
-    paths = case Path.wildcard(path) do
-      [] -> [path]
-      o  -> o
+    paths = if String.contains?(path, ~w(* ? [ {))do
+      Path.wildcard(path)
+    else
+      [path]
     end
     Enum.reduce(paths, config, &merge(&2, read!(&1)))
   end

--- a/lib/mix/test/mix/config_test.exs
+++ b/lib/mix/test/mix/config_test.exs
@@ -53,6 +53,12 @@ defmodule Mix.ConfigTest do
     assert var!(config, Mix.Config) == [my_app: [key: :value]]
   end
 
+  test "import_config/1 with wildcard with no matches" do
+    use Mix.Config
+    import_config fixture_path("configs/nonexistent_*.exs")
+    assert var!(config, Mix.Config) == []
+  end
+
   test "import_config/1 with nested" do
     use Mix.Config
     config :app, Repo, key: [nested: false, other: true]


### PR DESCRIPTION
Closes #3120

I'm not entirely sure about this.  It does fix the problem, while keeping the behavior of raising an error if a non-glob name of a non-existent file is received (as tested in `"import_config/1 with bad path"`).  But it seems less than ideal that a function called `read_wildcard!` handles the degenerate case of a concrete filename with no wildcards as a special case.  It would make more sense for it to treat it as a non-matching glob too (just using `Path.wildcard(path)` regardless of whether or not there are any results), but that would break the functionality of raising an error if called with a non-glob filename for a file that doesn't exist.  

There are other ways one could go (e.g. to modify `import_config` so it call either `read!` or `read_wildcard!` depending on whether or not it's a glob), but since these are public functions I figured it's best to start with the smallest change and get some feedback.