### PR TITLE
Support maps and fix structs in `Module.simplify_signature/2`

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -532,10 +532,9 @@ defmodule Module do
     {:\\, [], [simplify_signature(left, i), right]}
   end
 
-  defp simplify_signature({:%, _, [left, _]}, _i) when is_atom(left) do
-    last = List.last(String.split(Atom.to_string(left), "."))
-    atom = String.to_atom(downcase(last))
-    {atom, [], nil}
+  defp simplify_signature({:%, _, [left, _]}, i) when is_atom(left) do
+    struct_name = camelcase_to_underscore(List.last(split(left)))
+    {:"#{struct_name}#{i}", [], nil}
   end
 
   defp simplify_signature({:=, _, [_, right]}, i) do
@@ -561,17 +560,14 @@ defmodule Module do
   defp simplify_signature(other, i) when is_binary(other),  do: {:"binary#{i}", [], Elixir}
   defp simplify_signature(_, i), do: {:"arg#{i}", [], Elixir}
 
-  defp downcase(<<c :: utf8, rest :: binary>>) when c >= ?A and c <= ?Z do
-    <<c + 32 :: utf8, downcase(rest) :: binary>>
-  end
-
-  defp downcase(<<c, rest :: binary>>) do
-    <<c, downcase(rest) :: binary>>
-  end
-
-  defp downcase(<<>>) do
-    <<>>
-  end
+  defp camelcase_to_underscore(<<c :: utf8, rest :: binary>>) when c >= ?A and c <= ?Z,
+    do: do_camelcase_to_underscore(rest, <<c + 32 :: utf8>>)
+  defp do_camelcase_to_underscore(<<c :: utf8, rest :: binary>>, acc) when c >= ?A and c <= ?Z,
+    do: do_camelcase_to_underscore(rest, <<acc :: binary, ?_, c + 32 :: utf8>>)
+  defp do_camelcase_to_underscore(<<c :: utf8, rest :: binary>>, acc),
+    do: do_camelcase_to_underscore(rest, <<acc :: binary, c>>)
+  defp do_camelcase_to_underscore(<<>>, acc),
+    do: acc
 
   # Merge
 
@@ -872,11 +868,15 @@ defmodule Module do
     pair   = {name, arity}
     doc    = get_attribute(module, :doc)
 
-    # Arguments are not expanded for the docs, but we make
-    # an exception for module attributes.
+    # Arguments are not expanded for the docs, but we make an exception for
+    # module attributes and for structs (aliases to be precise).
     args = Macro.prewalk args, fn
-      {:@,  _, _} = attr -> Macro.expand_once(attr, env)
-      x -> x
+      {:@,  _, _} = attr ->
+        Macro.expand_once(attr, env)
+      {:%, meta, [aliases, fields]} ->
+        {:%, meta, [Macro.expand_once(aliases, env), fields]}
+      x ->
+        x
     end
 
     case add_doc(module, line, kind, pair, args, doc) do

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -549,6 +549,10 @@ defmodule Module do
     end
   end
 
+  defp simplify_signature({:%{}, _, _}, i) do
+    {:"map#{i}", [], Elixir}
+  end
+
   defp simplify_signature(other, i) when is_integer(other), do: {:"int#{i}", [], Elixir}
   defp simplify_signature(other, i) when is_boolean(other), do: {:"bool#{i}", [], Elixir}
   defp simplify_signature(other, i) when is_atom(other),    do: {:"atom#{i}", [], Elixir}


### PR DESCRIPTION
`Module.simplify_signature/2` didn't support maps (easy to guess since they're represented as `{:%{}, _, _}`) or structs.

With the changes introduced in this PR, it should support maps:

```elixir
def foo(%{}) #=> def foo(map1)
```

as well as structs:

```elixir
def cast(%Ecto.Changeset{}) #=> def cast(changeset1)
def cast(%MyStruct{}) #=> def cast(my_struct1)
```

In order to handle structs, I matched on `{:%, _, [struct, fields]}` asts and expanded `struct` with `Macro.expand/2` in `Module.compile_doc/6` instead of passing the env down to `simplify_signature/2`. 

Let me know if everything is fine!

(edit: I overwrote the commits since the tests were failing cause you can't use `|>` in the `Module` module, now everything is green)