### PR TITLE
EEx doc: Prevent list from being rendered as code blocks

### DIFF
--- a/lib/eex/lib/eex.ex
+++ b/lib/eex/lib/eex.ex
@@ -19,19 +19,19 @@ defmodule EEx do
   This module provides 3 main APIs for you to use:
 
     1. Evaluate a string (`eval_string`) or a file (`eval_file`)
-       directly. This is the simplest API to use but also the
-       slowest, since the code is evaluated and not compiled before.
+    directly. This is the simplest API to use but also the slowest,
+    since the code is evaluated and not compiled before.
 
     2. Define a function from a string (`function_from_string`)
-       or a file (`function_from_file`). This allows you to embed
-       the template as a function inside a module which will then
-       be compiled. This is the preferred API if you have access
-       to the template at compilation time.
+    or a file (`function_from_file`). This allows you to embed the
+    template as a function inside a module which will then be
+    compiled. This is the preferred API if you have access to the
+    template at compilation time.
 
     3. Compile a string (`compile_string`) or a file (`compile_file`)
-       into Elixir syntax tree. This is the API used by both functions
-       above and is available to you if you want to provide your own
-       ways of handling the compiled template.
+    into Elixir syntax tree. This is the API used by both functions
+    above and is available to you if you want to provide your own
+    ways of handling the compiled template.
 
   ## Options
 


### PR DESCRIPTION
Hello! This should fix these paragraphs being displayed as code blocks. See attached screenshot.

![screen shot 2015-04-30 at 17 28 26](https://cloud.githubusercontent.com/assets/6134406/7417506/6d0adf9c-ef5e-11e4-848d-0177bc71e1a9.png)
