### PR TITLE
Use agents to store Mix config

### DIFF
--- a/lib/mix/lib/mix/config/agent.ex
+++ b/lib/mix/lib/mix/config/agent.ex
@@ -1,0 +1,25 @@
+defmodule Mix.Config.Agent do
+  @moduledoc false
+
+  @typep config :: Keyword.t
+
+  @spec start_link() :: {:ok, pid}
+  def start_link do
+    Agent.start_link fn -> [] end
+  end
+
+  @spec stop(pid) :: :ok
+  def stop(agent) do
+    Agent.stop(agent)
+  end
+
+  @spec get(pid) :: config
+  def get(agent) do
+    Agent.get(agent, &(&1))
+  end
+
+  @spec merge(pid, config) :: config
+  def merge(agent, new_config) do
+    Agent.update(agent, &Mix.Config.merge(&1, new_config))
+  end
+end

--- a/lib/mix/test/mix/config_test.exs
+++ b/lib/mix/test/mix/config_test.exs
@@ -5,58 +5,73 @@ defmodule Mix.ConfigTest do
 
   doctest Mix.Config
 
+  defmacrop config do
+    quote do
+      Mix.Config.Agent.get(var!(config_agent, Mix.Config))
+    end
+  end
+
   test "config/2" do
     use Mix.Config
-    assert var!(config, Mix.Config) == []
+    assert config() == []
 
     config :lager, key: :value
-    assert var!(config, Mix.Config) == [lager: [key: :value]]
+    assert config() == [lager: [key: :value]]
 
     config :lager, other: :value
-    assert var!(config, Mix.Config) == [lager: [key: :value, other: :value]]
+    assert config() == [lager: [key: :value, other: :value]]
 
     config :lager, key: :other
-    assert var!(config, Mix.Config) == [lager: [key: :other, other: :value]]
+    assert config() == [lager: [key: :other, other: :value]]
+
+    # Works inside functions too...
+    f = fn -> config(:lager, key: :fn) end
+    f.()
+    assert config() == [lager: [key: :fn, other: :value]]
+
+    # ...and in for comprehensions.
+    for _ <- 0..0, do: config(:lager, key: :for)
+    assert config() == [lager: [key: :for, other: :value]]
   end
 
   test "config/3" do
     use Mix.Config
 
     config :app, Repo, key: :value
-    assert var!(config, Mix.Config) == [app: [{Repo, key: :value}]]
+    assert config() == [app: [{Repo, key: :value}]]
 
     config :app, Repo, other: :value
-    assert var!(config, Mix.Config) == [app: [{Repo, key: :value, other: :value}]]
+    assert config() == [app: [{Repo, key: :value, other: :value}]]
 
     config :app, Repo, key: :other
-    assert var!(config, Mix.Config) == [app: [{Repo, key: :other, other: :value}]]
+    assert config() == [app: [{Repo, key: :other, other: :value}]]
 
     config :app, Repo, key: [nested: false]
-    assert var!(config, Mix.Config) == [app: [{Repo, key: [nested: false], other: :value}]]
+    assert config() == [app: [{Repo, key: [nested: false], other: :value}]]
 
     config :app, Repo, key: [nested: true]
-    assert var!(config, Mix.Config) == [app: [{Repo, key: [nested: true], other: :value}]]
+    assert config() == [app: [{Repo, key: [nested: true], other: :value}]]
 
     config :app, Repo, key: :other
-    assert var!(config, Mix.Config) == [app: [{Repo, key: :other, other: :value}]]
+    assert config() == [app: [{Repo, key: :other, other: :value}]]
   end
 
   test "import_config/1" do
     use Mix.Config
     import_config fixture_path("configs/good_config.exs")
-    assert var!(config, Mix.Config) == [my_app: [key: :value]]
+    assert config() == [my_app: [key: :value]]
   end
 
   test "import_config/1 with wildcards" do
     use Mix.Config
     import_config fixture_path("configs/good_*.exs")
-    assert var!(config, Mix.Config) == [my_app: [key: :value]]
+    assert config() == [my_app: [key: :value]]
   end
 
   test "import_config/1 with wildcard with no matches" do
     use Mix.Config
     import_config fixture_path("configs/nonexistent_*.exs")
-    assert var!(config, Mix.Config) == []
+    assert config() == []
   end
 
   test "import_config/1 with nested" do
@@ -64,7 +79,7 @@ defmodule Mix.ConfigTest do
     config :app, Repo, key: [nested: false, other: true]
 
     import_config fixture_path("configs/nested.exs")
-    assert var!(config, Mix.Config) == [app: [{Repo, key: [nested: true, other: true]}]]
+    assert config() == [app: [{Repo, key: [nested: true, other: true]}]]
   end
 
   test "import_config/1 with bad path" do


### PR DESCRIPTION
Mix config was stored in a variable (`var!(config, Mix.Config)`) which was initialized at every `use Mix.Config`. Using a variable worked well but didn't allow pretty much anything outside "straight" code. For example, you could do this:

```elixir
config :foo, bar: :baz

if 3 + 2 == 5
  config :foo, [math: :check]
end
```

but you could not do this:

```elixir
f = fn ->
  config :foo, bar: :baz
end
f.()
```

since functions can't leak their scope into the outside scope, so changes to the `config` variable were not "persisted". `for` comprehensions were not allowed in the same way.

This commit introduces a `Mix.ConfigAgent` module so that configuration can be stored inside an agent. An agent is started every time that `use Mix.Config` is called, and is stopped by `Mix.Config.read!/1` (which is the basic unit for reading configuration; everything else should use it). By the way, we're still using a "global" variable (`var!(config_agent, Mix.Config)`) for the pid of the agent but that's fine since we only **read** its value.

I'm not 100% sure that going with a separate `Mix.ConfigAgent` module is a good idea. We could easily put the (very little) logic that now is in `Mix.ConfigAgent` right inside `Mix.Config`. Let me know what you think!

**Edit** Also, I'm not sure if stopping agents inside `Mix.Config.read!/1` is fine, but I think the only place where you don't put config in a file and you directly call `use Mix.Config` is in tests, so it should be fine.