### PR TITLE
use $REBAR on mix tests

### DIFF
--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -129,7 +129,8 @@ end
 
 home = MixTest.Case.tmp_path(".mix")
 File.mkdir_p!(home)
-File.cp!(Path.expand("../../../rebar", __DIR__), Path.join(home, "rebar"))
+rebar = System.get_env("REBAR") || Path.expand("../../../rebar", __DIR__)
+File.cp!(rebar, Path.join(home, "rebar"))
 System.put_env("MIX_HOME", home)
 
 ## Copy fixtures to tmp


### PR DESCRIPTION
In an official Debian package I wont't ship a sourceless binary (rebar)
but instead use the one already packaged in Debian. This should have no
effect on users building manually from source though.