### PR TITLE
Stream.repeat/[1,2] function

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -996,6 +996,22 @@ defmodule Stream do
   end
 
   @doc """
+  Returns an infinite stream of xs.
+  """
+  @spec repeat(element) :: Enumerable.t
+  def repeat(x) do
+    Stream.repeatedly fn -> x end
+  end
+
+  @doc """
+  Returns a stream of length n of xs.
+  """
+  @spec repeat(element, integer) :: Enumerable.t
+  def repeat(x, n) when n >= 0 do
+    Stream.take(repeat(x), n)
+  end
+
+  @doc """
   Emits a sequence of values for the given resource.
 
   Similar to `transform/2` but the initial accumulated value is

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -997,6 +997,11 @@ defmodule Stream do
 
   @doc """
   Returns an infinite stream of xs.
+
+  ## Examples
+
+      iex> Stream.repeat(:hello) |> Enum.take(5)
+      [:hello, :hello, :hello, :hello, :hello]
   """
   @spec repeat(element) :: Enumerable.t
   def repeat(x) do
@@ -1005,6 +1010,11 @@ defmodule Stream do
 
   @doc """
   Returns a stream of length n of xs.
+
+  ## Examples
+
+      iex> Enum.flat_map([a: 1, b: 2, c: 3], fn {x, n} -> Stream.repeat(x, n) end)
+      [:a, :b, :b, :c, :c, :c]
   """
   @spec repeat(element, integer) :: Enumerable.t
   def repeat(x, n) when n >= 0 do

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -453,6 +453,24 @@ defmodule StreamTest do
     assert r1 != r2
   end
 
+  test "repeat/1" do
+    stream = Stream.repeat(1)
+    assert Enum.take(stream, 5) == [1, 1, 1, 1, 1]
+    stream = Stream.repeat(:a)
+    assert Enum.take(stream, 10) == [:a, :a, :a, :a, :a, :a, :a, :a, :a, :a]
+  end
+
+  test "repeat/2" do
+    stream = Stream.repeat(:hello, 0)
+    assert Enum.take(stream, 5) == []
+    stream = Stream.repeat("Hi!", 2)
+    assert Enum.take(stream, 5) == ["Hi!", "Hi!"]
+    assert Enum.take(stream, 42) == ["Hi!", "Hi!"]
+
+    assert_raise FunctionClauseError, fn -> Stream.repeat(:boom!, -1) end
+  end
+
+
   test "resource/3 closes on errors" do
     stream = Stream.resource(fn -> 1 end,
                              fn acc -> {[acc], acc + 1} end,


### PR DESCRIPTION
This function is analogous to Clojure's [repeat](http://clojuredocs.org/clojure.core/repeat). Even though this is an awfully simple and short function, I think it would be extremely useful if it was part of the standard `Stream` module. This would avoid having it reimplemented a bunch of times in different projects.