### PR TITLE
Fix error assertion in the cmd/2 absolute & relative paths test

### DIFF
--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -74,8 +74,9 @@ defmodule SystemTest do
     File.mkdir_p! Path.dirname(echo2)
     File.cp! System.find_executable("echo"), echo2
 
+    assert :enoent = catch_error(System.cmd("echo2", ["hello"]))
+
     File.cd! Path.dirname(echo2), fn ->
-      assert :enoent = catch_error(System.cmd("echo2", ["hello"]))
       assert {"hello\n", 0} = System.cmd(Path.join(System.cwd!, "echo2"), ["hello"])
     end
   after


### PR DESCRIPTION
This is a fix for the `System.cmd/2` with absolute and relative paths test. The test was changing directories prior to the assertions. Changing directories caused the negative assertion to fail because the command was available. Also, there was a redundant call to change current working directory for the positive assertion.