### PR TITLE
Bugfix to syntax error before sigil

### DIFF
--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -57,8 +57,12 @@ parse_error(Line, File, <<"syntax error before: ">>, <<"'end'">>) ->
 
 %% Produce a human-readable message for errors before a sigil
 parse_error(Line, File, <<"syntax error before: ">>, <<"{sigil,", _Rest/binary>> = Full) ->
-  {sigil, _, Sigil, [Content], _} = parse_erl_term(Full),
-  Message = <<"syntax error before: sigil ~", Sigil," with content '", Content/binary, "'">>,
+  {sigil, _, Sigil, [Content|_], _} = parse_erl_term(Full),
+  Content2 = case is_binary(Content) of
+    true -> Content;
+    false -> <<>>
+  end,
+  Message = <<"syntax error before: sigil ~", Sigil," starting with content '", Content2/binary, "'">>,
   do_raise(Line, File, 'Elixir.SyntaxError', Message);
 
 %% Aliases are wrapped in ['']

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -107,9 +107,12 @@ defmodule Kernel.ErrorsTest do
   end
 
   test :syntax_error_before_sigil do
-    assert_compile_fail SyntaxError,
-      "nofile:1: syntax error before: sigil ~s with content 'bar baz'",
-      '~s(foo) ~s(bar baz)'
+    msg = fn x -> "nofile:1: syntax error before: sigil ~s starting with content '#{x}'" end
+
+    assert_compile_fail SyntaxError, msg.("bar baz"), '~s(foo) ~s(bar baz)'
+    assert_compile_fail SyntaxError, msg.(""), '~s(foo) ~s()'
+    assert_compile_fail SyntaxError, msg.("bar "), '~s(foo) ~s(bar \#{:baz})'
+    assert_compile_fail SyntaxError, msg.(""), '~s(foo) ~s(\#{:bar} baz)'
   end
 
   test :compile_error_on_op_ambiguity do


### PR DESCRIPTION
Closes #3324

This extends the nice error to cover more cases.  The message itself is altered a bit (added "starting" to it) since this is no longer giving the content but just the first part of it which is binary.  In cases where the first part isn't binary, this isn't ideal, but I didn't know of a reasonably simple alternative.