### PR TITLE
update anchor portion of link to erlang docs

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -302,7 +302,7 @@ defmodule Module do
 
   In addition to the above, you may also pass to `__info__/1` any atom supported
   by Erlang's `module_info` function which also gets defined for each compiled
-  module. See http://erlang.org/doc/reference_manual/modules.html#id69430 for
+  module. See http://erlang.org/doc/reference_manual/modules.html#id75777 for
   more information.
   """
   def __info__(kind)


### PR DESCRIPTION
Minor documentation tweak: the [doc for `Module.__info__/1`](http://elixir-lang.org/docs/v1.0/elixir/Module.html#__info__/1) has a link to the Erlang doc for `module_info`; however the anchor (`#`) portion of the URL was out of date and no longer jumped the browser to the `model_info` section of the doc.

Is there a more future-proof way of keeping links like this up-to-date?