### PR TITLE
Showing example of timeout for Task.await

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -187,7 +187,18 @@ defmodule Task do
   Awaits a task reply.
 
   A timeout, in milliseconds, can be given with default value
-  of `5000`. In case the task process dies, this function will
+  of `5000`. In the event of a timeout handle it with try 
+  catch statement. 
+  
+      timeout = 10
+      try do
+        Task.await(search_task, timeout)
+      catch
+        :exit, {:timeout, {Task, :await, [_, timeout]}} -> 
+          raise "task timed out"
+      end
+  
+  In case the task process dies, this function will
   exit with the same reason as the task.
   """
   @spec await(t, timeout) :: term | no_return


### PR DESCRIPTION
It took me a bit of time to figure out how to handle a timeout. Figured I'd add an example here for future reference. 

I wasn't sure if I should include this near the module doc or in the function doc. I figured it would be best near the function. 

Let me know what you think!