### PR TITLE
Support printing pids in Logger metadata.

### DIFF
--- a/lib/logger/lib/logger/formatter.ex
+++ b/lib/logger/lib/logger/formatter.ex
@@ -104,7 +104,7 @@ defmodule Logger.Formatter do
   defp output(:metadata, _, _, _, []),        do: ""
   defp output(:metadata, _, _, _, meta) do
     Enum.map(meta, fn {key, val} ->
-      [to_string(key), ?=, to_string(val), ?\s]
+      [to_string(key), ?=, metadata(val), ?\s]
     end)
   end
 
@@ -118,4 +118,13 @@ defmodule Logger.Formatter do
   defp levelpad(:info), do: " "
   defp levelpad(:warn), do: " "
   defp levelpad(:error), do: ""
+
+  defp metadata(pid) when is_pid(pid) do
+    :erlang.pid_to_list(pid)
+  end
+  defp metadata(pid) when is_reference(pid) do
+    '#Ref' ++ rest = :erlang.ref_to_list(pid)
+    rest
+  end
+  defp metadata(other), do: to_string(other)
 end

--- a/lib/logger/test/logger/formatter_test.exs
+++ b/lib/logger/test/logger/formatter_test.exs
@@ -43,6 +43,15 @@ defmodule Logger.FormatterTest do
     compiled = compile("$metadata")
     assert IO.chardata_to_string(format(compiled, :error, nil, nil, [meta: :data])) ==
            "meta=data "
+    assert IO.chardata_to_string(format(compiled, :error, nil, nil,
+           [meta: :data, pid: :erlang.list_to_pid('<0.123.4>')])) == "meta=data pid=<0.123.4> "
+
+    # Hack to get the same predictable reference for every test run.
+    ref = <<131, 114, 0, 3, 100, 0, 13, 110, 111, 110, 111, 100, 101, 64, 110, 111, 104, 111, 115, 116, 0, 0, 0, 0, 80, 0, 0, 0, 0, 0, 0, 0, 0>> |> :erlang.binary_to_term
+    assert "#Reference<0.0.0.80>" == inspect(ref) # ensure the deserialization worked correctly
+    assert IO.chardata_to_string(format(compiled, :error, nil, nil,
+           [meta: :data, ref: ref])) == "meta=data ref=<0.0.0.80> "
+
     assert IO.chardata_to_string(format(compiled, :error, nil, nil, [])) ==
            ""
 


### PR DESCRIPTION
Fixes #3336.

This _only_ supports printing metadata that conforms to `String.Chars` or is a pid. I'm not sure if that's what we want, I'd like to also be able to have refs as metadata for example.

Also please backport to 1.0