### PR TITLE
added an IEx.Helper to start the Erlang/OTP observer

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -20,6 +20,7 @@ defmodule IEx.Helpers do
     * `l/1`           — loads the given module's beam code
     * `ls/0`          — lists the contents of the current directory
     * `ls/1`          — lists the contents of the specified directory
+    * `o/0`          —  start the Erlang/OTP observer application
     * `pwd/0`         — prints the current working directory
     * `r/1`           — recompiles and reloads the given module's source file
     * `respawn/0`     — respawns the current shell
@@ -380,6 +381,11 @@ defmodule IEx.Helpers do
       source -> List.to_string(source)
     end
   end
+
+  @doc """
+  Start the Erlang/OTP observer application.
+  """
+  def o, do: :observer.start()
 
   @doc """
   Prints the current working directory.

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -123,6 +123,15 @@ defmodule IEx.HelpersTest do
     assert capture_io(fn -> send self(), :hello; flush end) == ":hello\n"
   end
 
+  test "observer helper" do
+    # this is the actual test case
+    assert capture_iex("o") == ":ok"
+    # needed to prevent a wx error
+    :timer.sleep(5000)
+    # needed to prevent a segfault during "make test"
+    assert :observer.stop() == :ok
+  end
+
   test "pwd helper" do
     File.cd! iex_path, fn ->
       assert capture_io(fn -> pwd end) =~ ~r"lib[\\/]iex\n$"


### PR DESCRIPTION
I am not sure if anyone else needs this, but I couldn't find an easier way to invoke Erlang's observer.

Thanks to the help from `voltone` and `Papipo` on the IRC channel, I got some ideas about using `.iex.exs` and command line options, but somehow it was easier for me to modify `IEx.Helpers`.

Just two more __notes__: without the two additional lines - within the test case - I got two errors when running `make test`:
 * without the `:observer.stop/0` the tests **segfaulted**!
 * without the `:timer.sleep/1` the `wx` application generated an error, but this error did **not** interrupt the tests in any way

Are those two observations worth to be traced down?!