### PR TITLE
`surround_many/5` handles empty documents

### DIFF
--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -478,25 +478,32 @@ defmodule Inspect.Algebra do
     "..."
   end
 
-  defp do_surround_many([h], limit, opts, fun, _sep) do
+  defp do_surround_many([], _limit, _opts, _fun, _sep) do
+    :doc_nil
+  end
+
+  defp do_surround_many([h], limit, opts, fun, sep) do
     fun.(h, %{opts | limit: limit})
   end
 
   defp do_surround_many([h|t], limit, opts, fun, sep) when is_list(t) do
     limit = decrement(limit)
-    glue(
-      concat(fun.(h, %{opts | limit: limit}), sep),
-      do_surround_many(t, limit, opts, fun, sep)
-    )
+    h = fun.(h, %{opts | limit: limit})
+    t = do_surround_many(t, limit, opts, fun, sep)
+    do_join(h, t, sep)
   end
 
-  defp do_surround_many([h|t], limit, opts, fun, _sep) do
+  defp do_surround_many([h|t], limit, opts, fun, sep) do
     limit = decrement(limit)
-    glue(
-      concat(fun.(h, %{opts | limit: limit}), @tail_separator),
-      fun.(t, %{opts | limit: limit})
-    )
+    h = fun.(h, %{opts | limit: limit})
+    t = fun.(t, %{opts | limit: limit})
+    do_join(h, t, @tail_separator)
   end
+
+  defp do_join(:doc_nil, :doc_nil, _), do: :doc_nil
+  defp do_join(h, :doc_nil, _),        do: h
+  defp do_join(:doc_nil, t, _),        do: t
+  defp do_join(h, t, sep),             do: glue(concat(h, sep), t)
 
   defp decrement(:infinity), do: :infinity
   defp decrement(counter),   do: counter - 1

--- a/lib/elixir/test/elixir/inspect/algebra_test.exs
+++ b/lib/elixir/test/elixir/inspect/algebra_test.exs
@@ -125,4 +125,22 @@ defmodule Inspect.AlgebraTest do
 
     assert render(doc, :infinity) == s <> g <> s <> g <> s <> g <> s <> g <> s
   end
+
+  test "formatting surround_many with empty" do
+    sm = &surround_many("[", &1, "]", %Inspect.Opts{}, fn(d, _) -> d end, ",")
+
+    assert sm.([])                |> render(80) == "[]"
+    assert sm.([empty])           |> render(80) == "[]"
+    assert sm.([empty, empty])    |> render(80) == "[]"
+    assert sm.(["a"])             |> render(80) == "[a]"
+    assert sm.(["a", empty])      |> render(80) == "[a]"
+    assert sm.([empty, "a"])      |> render(80) == "[a]"
+    assert sm.(["a", empty, "b"]) |> render(80) == "[a, b]"
+    assert sm.([empty, "a", "b"]) |> render(80) == "[a, b]"
+    assert sm.(["a", "b", empty]) |> render(80) == "[a, b]"
+    assert sm.(["a", "b" | "c"])  |> render(80) == "[a, b | c]"
+    assert sm.(["a" | "b"])       |> render(80) == "[a | b]"
+    assert sm.(["a" | empty])     |> render(80) == "[a]"
+    assert sm.([empty | "b"])     |> render(80) == "[b]"
+  end
 end


### PR DESCRIPTION
`surround/3` correctly handles empty documents, ex

    iex> doc = Inspect.Algebra.surround "[", Inspect.Algebra.empty, "]"
    iex> Inspect.Algebra.format(doc, 80) |> IO.iodata_to_binary
    "[]"

But `surround_many/5` didn't

    iex> fun = fn(d, _) -> d end
    iex> opts = %Inspect.Opts{}
    iex> what = ["a", Inspect.Algebra.empty]
    iex> doc = Inspect.Algebra.surround_many("[", what, "]", opts, fun, ",")
    iex> Inspect.Algebra.format(doc, 80) |> IO.iodata_to_binary
    "[a, ]"

This is what I expect and what it does now

    iex> doc = Inspect.Algebra.surround_many("[", what, "]", opts, fun, ",")
    iex> Inspect.Algebra.format(doc, 80) |> IO.iodata_to_binary
    "[a]"