### PR TITLE
Fenced code blocks support on IO.ANSI.Docs

### DIFF
--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -94,6 +94,14 @@ defmodule IO.ANSI.Docs do
     process_code(rest, [line], indent, options)
   end
 
+  defp process(["```" <> _line | rest], text, indent, options) do
+    process_fenced_code_block(rest, text, indent, options, _delimiter = "```")
+  end
+
+  defp process(["~~~" <> _line | rest], text, indent, options) do
+    process_fenced_code_block(rest, text, indent, options, _delimiter = "~~~")
+  end
+
   defp process(all=[line | rest], text, indent, options) do
     {stripped, count} = strip_spaces(line, 0, :infinity)
     if is_table_line?(stripped) and rest != [] and is_table_line?(hd(rest)) do
@@ -219,6 +227,23 @@ defmodule IO.ANSI.Docs do
   defp process_code(rest, code, indent, options) do
     write_code(code, indent, options)
     process(rest, [], indent, options)
+  end
+
+  defp process_fenced_code_block(rest, text, indent, options, delimiter) do
+    write_text(text, indent, options)
+    process_fenced_code(rest, [], indent, options, delimiter)
+  end
+
+  defp process_fenced_code([], code, indent, options, _delimiter) do
+    write_code(code, indent, options)
+  end
+
+  defp process_fenced_code([line | rest], code, indent, options, delimiter) do
+    if line === delimiter do
+      process_code(rest, code, indent, options)
+    else
+      process_fenced_code(rest, [line|code], indent, options, delimiter)
+    end
   end
 
   defp write_code(code, indent, options) do

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -39,6 +39,15 @@ defmodule IO.ANSI.DocsTest do
     assert result == "line\n\e[0m\n\e[36m\e[1m┃ code\n┃ code2\e[0m\n\e[0m\nline2\n\e[0m"
   end
 
+  test "fenced code block is converted" do
+    result = format("line\n```\ncode\ncode2\n```\nline2\n")
+    assert result == "line\n\e[0m\n\e[36m\e[1m┃ code\n┃ code2\e[0m\n\e[0m\nline2\n\e[0m"
+    result = format("line\n```elixir\ncode\ncode2\n```\nline2\n")
+    assert result == "line\n\e[0m\n\e[36m\e[1m┃ code\n┃ code2\e[0m\n\e[0m\nline2\n\e[0m"
+    result = format("line\n~~~elixir\ncode\n```\n~~~\nline2\n")
+    assert result == "line\n\e[0m\n\e[36m\e[1m┃ code\n┃ ```\e[0m\n\e[0m\nline2\n\e[0m"
+  end
+
   test "* list is converted" do
     result = format("* one\n* two\n* three\n")
     assert result == "  • one\n  • two\n  • three\n\e[0m"


### PR DESCRIPTION
Added support for fenced code blocks on `IO.ANSI.Docs`. In this case, the fenced code block begins with a delimiter of three tildes (~) or backticks (`) and end with a row of tildes or backticks that must be equal as the starting row. Everything between these delimiters are treated as source code and no indentation is required as in the case of *verbatim code blocks* (4 spaces).

@josevalim suggested to add this [feature](https://github.com/elixir-lang/ex_doc/pull/211#issuecomment-104319002) to allow fenced blocks in Elixir's documentation.

![markdown_fenced_code_blocks](https://cloud.githubusercontent.com/assets/34700/7835052/68d403e4-043b-11e5-9ecb-274eecd25991.png)

Please let me know what do you think