### PR TITLE
Issue 3339

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -123,8 +123,9 @@ defmodule IO do
     end
   end
 
+  @read_all_size 4096
   defp do_binread_all(mapped_dev, acc) do
-    case :file.read_line(mapped_dev) do
+    case :file.read(mapped_dev, @read_all_size) do
       {:ok, data} -> do_binread_all(mapped_dev, acc <> data)
       :eof -> acc
       other -> other

--- a/lib/elixir/test/elixir/fixtures/file.bin
+++ b/lib/elixir/test/elixir/fixtures/file.bin
@@ -1,0 +1,4 @@
+LF
+CRCRLF
+LFCR
+

--- a/lib/elixir/test/elixir/io_test.exs
+++ b/lib/elixir/test/elixir/io_test.exs
@@ -22,6 +22,12 @@ defmodule IOTest do
     assert File.close(file) == :ok
   end
 
+  test :binread_all do
+    {:ok, file} = File.open(Path.expand('fixtures/file.bin', __DIR__))
+    assert "LF\nCR\rCRLF\r\nLFCR\n\r" == IO.binread(file, :all)
+    assert File.close(file) == :ok
+  end
+
   test :getn do
     {:ok, file} = File.open(Path.expand('fixtures/file.txt', __DIR__))
     assert "F" == IO.getn(file, "")


### PR DESCRIPTION
Fixes for Issue #3339 

Replaced line-based reading in IO.binread(_, :all) by a 4K block read. Added appropriate unit test.