### PR TITLE
Fix invisible test location on dark terminals

### DIFF
--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -206,7 +206,7 @@ defmodule ExUnit.CLIFormatter do
 
   defp formatter(:error_info, msg, config),    do: colorize([:red], msg, config)
   defp formatter(:extra_info, msg, config),    do: colorize([:cyan], msg, config)
-  defp formatter(:location_info, msg, config), do: colorize([:bright, :black], msg, config)
+  defp formatter(:location_info, msg, config), do: colorize([:magenta], msg, config)
   defp formatter(_,  msg, _config),            do: msg
 
   defp get_terminal_width do


### PR DESCRIPTION
Or is it my terminal? The bright/black color was added [here](https://github.com/elixir-lang/elixir/blob/21f2f0f112ba873cb0b41a835ecf6aafacc1e140/lib/ex_unit/lib/ex_unit/cli_formatter.ex#L183).

![invisible-location](https://cloud.githubusercontent.com/assets/188809/7898212/1a38a8c8-06f9-11e5-83c7-3516b305404b.png)