### PR TITLE
Use reliable home directory source

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -122,13 +122,9 @@ defmodule System do
   User home directory.
 
   Returns the user home directory (platform independent).
-  Returns `nil` if no user home is set.
   """
   def user_home do
-    case :os.type() do
-      {:win32, _} -> get_windows_home
-      _             -> get_unix_home
-    end
+    :elixir_config.get(:home)
   end
 
   @doc """
@@ -140,20 +136,6 @@ defmodule System do
   def user_home! do
     user_home ||
       raise RuntimeError, message: "could not find the user home, please set the HOME environment variable"
-  end
-
-  defp get_unix_home do
-    get_env("HOME")
-  end
-
-  defp get_windows_home do
-    :filename.absname(
-      get_env("USERPROFILE") || (
-        hd = get_env("HOMEDRIVE")
-        hp = get_env("HOMEPATH")
-        hd && hp && hd <> hp
-      )
-    )
   end
 
   @doc ~S"""

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -36,7 +36,8 @@ start(_Type, _Args) ->
     {error, _} -> io:setopts(standard_error, [{unicode, true}]) %% OTP 17.3 and earlier
   end,
 
-  case file:native_name_encoding() of
+  Encoding = file:native_name_encoding(),
+  case Encoding of
     latin1 ->
       io:format(standard_error,
         "warning: the VM is running with native name encoding of latin1 which may cause "
@@ -54,7 +55,9 @@ start(_Type, _Args) ->
           {<<"ldap">>, 389}],
   URIConfig = [{{uri, Scheme}, Port} || {Scheme, Port} <- URIs],
   CompilerOpts = [{docs, true}, {debug_info, true}, {warnings_as_errors, false}],
+  {ok, [[Home] | _]} = init:get_argument(home),
   Config = [{at_exit, []},
+            {home, unicode:characters_to_binary(Home, Encoding, Encoding)},
             {compiler_options, orddict:from_list(CompilerOpts)}
             | URIConfig],
   Tab = elixir_config:new(Config),


### PR DESCRIPTION
This is the intended way to get the home directory in Erlang, is there a reason we don't use it?

http://www.erlang.org/documentation/doc-6.4/erts-6.4/doc/html/init.html#get_argument-1