### PR TITLE
Remove Enumerable.Range.reduce's dependency on >= <=

### DIFF
--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -62,26 +62,26 @@ end
 
 defimpl Enumerable, for: Range do
   def reduce(first .. last = range, acc, fun) do
-    reduce(first, last, acc, fun, Range.Iterator.next(first, range), last >= first)
+    reduce(first, last, acc, fun, Range.Iterator.next(first, range), false)
   end
 
-  defp reduce(_x, _y, {:halt, acc}, _fun, _next, _up) do
+  defp reduce(_current, _last, {:halt, acc}, _fun, _next, _done) do
     {:halted, acc}
   end
 
-  defp reduce(x, y, {:suspend, acc}, fun, next, up) do
-    {:suspended, acc, &reduce(x, y, &1, fun, next, up)}
+  defp reduce(current, last, {:suspend, acc}, fun, next, done) do
+    {:suspended, acc, &reduce(current, last, &1, fun, next, done)}
   end
 
-  defp reduce(x, y, {:cont, acc}, fun, next, true) when x <= y do
-    reduce(next.(x), y, fun.(x, acc), fun, next, true)
+  defp reduce(last, last, {:cont, acc}, fun, next, false) do
+    reduce(last, last, fun.(last, acc), fun, next, true)
   end
 
-  defp reduce(x, y, {:cont, acc}, fun, next, false) when x >= y do
-    reduce(next.(x), y, fun.(x, acc), fun, next, false)
+  defp reduce(current, last, {:cont, acc}, fun, next, false) do
+    reduce(next.(current), last, fun.(current, acc), fun, next, false)
   end
 
-  defp reduce(_, _, {:cont, acc}, _fun, _next, _up) do
+  defp reduce(_, _, {:cont, acc}, _fun, _next, true) do
     {:done, acc}
   end
 


### PR DESCRIPTION
First, let me state the problem I had that this PR helps solve. I was exploring `Range.Iterator`, implementing it for a struct `Weekday` in the hopes of doing something expressive like `monday..friday`. But because the Enumerable implementation for `Range` relies on comparisons using `>=` and `<=`, I was getting some unexpected behaviour when using my range with the Enum module. For example `monday..friday |> Enum.to_list` would result in an infinite loop.

Here is a [gist with my `Weekday`](https://gist.github.com/martinsvalin/6dad7c8182f846f772e7#file-weekday-ex) struct and `Range.Iterator` implementations.

This PR hopes to make `Range` more flexible, while preserving current behaviour for Integers. `Enumerable.Range.reduce/3` was using `>=` and `<=` to determine if the range was counting up or down, but `Range.Iterator.Integer.next/2` makes the same comparisons. I would argue that it is the job of `next` to know where we are going, so the knowledge belongs there.

I have changed the direction flag in the private `Enumerable.Range.reduce/6` to instead be a flag that signifies whether we've reached the last value in the range. We pattern match that we've reached the last value, and change the flag to true, making the next call end up returning `{:done, acc}` if `fun` returns a `:cont`.

I've tried to determine if the change affects performance by simply averaging timings with `:timer.tc(&Enum.reduce/3, [1..10_000_000, 0, &:erlang.+/2])`. On my machine, it stays consistent around 850ms, both before and after the change. Actually, it averaged around 870ms before and 830ms after, but I'm not comfortable making any performance claims.