### PR TITLE
Defining arg0 for System.cmd tests so it can work with busybox

### DIFF
--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -66,7 +66,7 @@ defmodule SystemTest do
   test "cmd/3 (with options)" do
     assert {["hello\n"], 0} = System.cmd "echo", ["hello"],
                                 into: [], cd: System.cwd!, env: %{"foo" => "bar"},
-                                arg0: "hecho", stderr_to_stdout: true, parallelism: true
+                                arg0: "echo", stderr_to_stdout: true, parallelism: true
   end
 
   @echo "echo-elixir-test"
@@ -84,7 +84,7 @@ defmodule SystemTest do
         assert :enoent = catch_error(System.cmd(@echo, ["hello"]))
       end
 
-      assert {"hello\n", 0} = System.cmd(Path.join(System.cwd!, @echo), ["hello"])
+      assert {"hello\n", 0} = System.cmd(Path.join(System.cwd!, @echo), ["hello"], [{:arg0, "echo"}])
     end
   after
     File.rm_rf! tmp_path(@echo)


### PR DESCRIPTION
On Busybox based linux distributions the `echo` command is just a link to the `busybox` executable. 
In order to execute the right command (applet), busybox depends on `arg0`, which should be the link's name.

How to simulate:

```
docker run --rm -it msaraiva/build-elixir

$ git clone https://github.com/elixir-lang/elixir.git
$ cd elixir
$ make test
```
Two tests should fail:

```
  1) test cmd/2 with absolute and relative paths (SystemTest)
     test/elixir/system_test.exs:74
     match (=) failed
     code: {"hello\n", 0} = System.cmd(Path.join(System.cwd!(), @echo), ["hello"])
     rhs:  {"", 1}
     stacktrace:
       test/elixir/system_test.exs:87: anonymous fn/0 in SystemTest.test cmd/2 with absolute and relative paths/1
       (elixir) lib/file.ex:1105: File.cd!/2
       test/elixir/system_test.exs:79

  2) test cmd/3 (with options) (SystemTest)
     test/elixir/system_test.exs:66
     match (=) failed
     code: {["hello\n"], 0} = System.cmd("echo", ["hello"], into: [], cd: System.cwd!(), env: %{"foo" => "bar"}, arg0: "hecho", stderr_to_stdout: true, parallelism: true)
     rhs:  {["hecho: applet not found\n"], 1}
     stacktrace:
       test/elixir/system_test.exs:67
```

Defining arg0 properly fix the problem.
