### PR TITLE
add sorted sets backed by red-black trees

### DIFF
--- a/lib/elixir/lib/red_black_tree.ex
+++ b/lib/elixir/lib/red_black_tree.ex
@@ -1,0 +1,630 @@
+defmodule RedBlackTree do
+  @moduledoc """
+  Red-black trees are key-value stores.
+  While not guaranteed to be perfectly balanced, they guarantee O(log(n)) search
+  time.
+
+  The RedBlackTree module contains an eponymous struct and various useful
+  functions.
+
+  Nodes know their depth (automatically updated on insert/delete)
+  """
+  alias RedBlackTree.Node
+  use Dict
+
+  defstruct root: nil, size: 0
+
+  @key_hash_bucket 4294967296
+
+  # Inline key hashing
+  @compile {:inline, key_less_than?: 2, hash_key: 1, fallback_key_hash: 1}
+
+  def new() do
+    %RedBlackTree{}
+  end
+
+  def new(values) when is_list(values) do
+    new(%RedBlackTree{}, values)
+  end
+
+  defp new(tree, []) do
+    tree
+  end
+
+  # Allow initialization with key/value tuples
+  defp new(tree, [{key, value}|tail]) do
+    new(RedBlackTree.insert(tree, key, value), tail)
+  end
+
+  # Allow initialization with individual values, in which case they will be both
+  # the key and the value
+  defp new(tree, [key|tail]) do
+    new(RedBlackTree.insert(tree, key, key), tail)
+  end
+
+  ## Dict behaviour functions
+  def size(%RedBlackTree{size: size}) do
+    size
+  end
+
+  def put(tree, key, value) do
+    insert(tree, key, value)
+  end
+
+  def fetch(tree, key) do
+    if has_key?(tree, key) do
+      {:ok, search(tree, key)}
+    else
+      :error
+    end
+  end
+
+  def reduce(tree, acc, fun) do
+    RedBlackTree.to_list(tree)
+    |> Enumerable.List.reduce(acc, fun)
+  end
+
+  def insert(%RedBlackTree{root: nil}, key, value) do
+    %RedBlackTree{root: Node.new(key, value), size: 1}
+  end
+
+  def insert(%RedBlackTree{root: root, size: size}=tree, key, value) do
+    {nodes_added, new_root} = do_insert(root, key, value, 1)
+    %RedBlackTree{
+      tree |
+      root: make_node_black(new_root),
+      size: size + nodes_added
+    }
+  end
+
+  def delete(%RedBlackTree{root: root, size: size}=tree, key) do
+    {nodes_removed, new_root} = do_delete(root, key)
+    %RedBlackTree{
+      tree |
+      root: new_root,
+      size: size - nodes_removed
+    }
+  end
+
+  def search(%RedBlackTree{root: root}, key) do
+    do_search(root, key)
+  end
+
+  defp do_search(nil, _key) do
+    nil
+  end
+
+  defp do_search(%Node{key: node_key, value: value}, search_key) when node_key === search_key do
+    value
+  end
+
+  defp do_search(%Node{key: node_key, left: left}, search_key) when search_key < node_key do
+    do_search(left, search_key)
+  end
+
+  defp do_search(%Node{key: node_key, right: right}, search_key) when search_key > node_key do
+    do_search(right, search_key)
+  end
+
+  # For cases when `insert_key !== node_key` but `insert_key == node_key` (e.g.
+  # `1` and `1.0`,) hash the keys to provide consistent ordering.
+  defp do_search(%Node{key: node_key, left: left, right: right}, search_key) when search_key == node_key do
+    if key_less_than?(search_key, node_key) do
+      do_search(left, search_key)
+    else
+      do_search(right, search_key)
+    end
+  end
+
+  def has_key?(%RedBlackTree{root: root}, key) do
+    do_has_key?(root, key)
+  end
+
+  defp do_has_key?(nil, _key) do
+    false
+  end
+
+  defp do_has_key?(%Node{key: node_key}, search_key) when node_key === search_key do
+    true
+  end
+
+  defp do_has_key?(%Node{key: node_key, left: left}, search_key) when search_key < node_key do
+    do_has_key?(left, search_key)
+  end
+
+  defp do_has_key?(%Node{key: node_key, right: right}, search_key) when search_key > node_key do
+    do_has_key?(right, search_key)
+  end
+
+  # For cases when `insert_key !== node_key` but `insert_key == node_key` (e.g.
+  # `1` and `1.0`,) hash the keys to provide consistent ordering.
+  defp do_has_key?(%Node{key: node_key, left: left, right: right}, search_key) when search_key == node_key do
+    if key_less_than?(search_key, node_key) do
+      do_has_key?(left, search_key)
+    else
+      do_has_key?(right, search_key)
+    end
+  end
+
+
+  @doc """
+  For each node, calls the provided function passing in (node, acc)
+  Optionally takes an order as the first argument which can be one of
+  `:in_order`, `:pre_order`, or `:post_order`.
+
+  Defaults to `:in_order` if no order is given.
+  """
+  def reduce_nodes(%RedBlackTree{}=tree, acc, fun) do
+    reduce_nodes(:in_order, tree, acc, fun)
+  end
+
+  def reduce_nodes(_order, %RedBlackTree{root: nil}, acc, _fun) do
+    acc
+  end
+
+  def reduce_nodes(order, %RedBlackTree{root: root}, acc, fun) do
+    do_reduce_nodes(order, root, acc, fun)
+  end
+
+  @doc """
+  Balances the supplied tree to adhere to the two rules of Red-Black trees:
+
+  1. Every red node must have two black child nodes (and therefore it must have a black parent).
+  2. Every path from a given node to any of its descendant NIL nodes contains the same number of black nodes.
+
+  """
+  def balance(%RedBlackTree{root: root}=tree) do
+    %RedBlackTree{tree | root: do_balance(root)}
+  end
+
+  def to_list(%RedBlackTree{}=tree) do
+    reduce_nodes(tree, [], fn (node, members) ->
+      [{node.key, node.value} | members]
+    end) |> Enum.reverse
+  end
+
+  ## Helpers
+
+  defp make_node_black(%Node{}=node) do
+    Node.color(node, :black)
+  end
+
+  # ¡This is only used as a tiebreaker!
+  # For cases when `insert_key !== node_key` but `insert_key == node_key` (e.g.
+  # `1` and `1.0`,) hash the keys to provide consistent ordering.
+  defp hash_key(key) do
+    :erlang.phash2(key, @key_hash_bucket)
+  end
+
+  # In the case that `hash_key(key1) == hash_key(key2)` we can fall back again
+  # to the slower phash function distributed over @key_hash_bucket integers.
+  # If these two collide, go home.
+  defp fallback_key_hash(key) do
+    :erlang.phash(key, @key_hash_bucket)
+  end
+
+  # Should only be used when `key1 !== key2 and key1 == key2`. In the case
+  defp key_less_than?(key1, key2) do
+    hashed_key1 = hash_key(key1)
+    hashed_key2 = hash_key(key2)
+    cond do
+      hashed_key1 === hashed_key2 ->
+        fallback_key_hash(key1) < fallback_key_hash(key2)
+      hashed_key1 < hashed_key2 -> true
+      true -> false
+    end
+  end
+
+  ### Operations
+
+  #### Insert
+
+  defp do_insert(nil, insert_key, insert_value, depth) do
+    {
+      1,
+      %Node{
+        Node.new(insert_key, insert_value, depth) |
+        color: :red
+      }
+    }
+
+  end
+
+  defp do_insert(%Node{key: node_key}=node, insert_key, insert_value, _depth) when node_key === insert_key do
+    {0, %Node{node | value: insert_value}}
+  end
+
+  defp do_insert(%Node{key: node_key}=node, insert_key, insert_value, depth) when insert_key < node_key do
+    do_insert_left(node, insert_key, insert_value, depth)
+  end
+
+  defp do_insert(%Node{key: node_key}=node, insert_key, insert_value, depth) when insert_key > node_key do
+    do_insert_right(node, insert_key, insert_value, depth)
+  end
+
+  # For cases when `insert_key !== node_key` but `insert_key == node_key` (e.g.
+  # `1` and `1.0`,) hash the keys to provide consistent ordering.
+  defp do_insert(%Node{key: node_key}=node, insert_key, insert_value, depth) when insert_key == node_key do
+    if key_less_than?(insert_key, node_key) do
+      do_insert_left(node, insert_key, insert_value, depth)
+    else
+      do_insert_right(node, insert_key, insert_value, depth)
+    end
+  end
+
+  defp do_insert_left(%Node{left: left}=node, insert_key, insert_value, depth) do
+    {nodes_added, new_left} = do_insert(left, insert_key, insert_value, depth + 1)
+    {nodes_added, %Node{node | left: do_balance(new_left)}}
+  end
+
+  defp do_insert_right(%Node{right: right}=node, insert_key, insert_value, depth) do
+    {nodes_added, new_right} = do_insert(right, insert_key, insert_value, depth + 1)
+    {nodes_added, %Node{node | right: do_balance(new_right)}}
+  end
+
+  #### Delete
+
+  # If we reach a leaf and the key never matched, do nothing
+  defp do_delete(nil, _key) do
+    {0, nil}
+  end
+
+  # If both the right and left are nil, the new tree is nil. For example,
+  # deleting A in the following tree results in B having no left
+  #
+  #        B
+  #       / \
+  #      A   C
+  #
+  defp do_delete(%Node{key: node_key, left: nil, right: nil}, delete_key) when node_key === delete_key do
+    {1, nil}
+  end
+
+  # If left is nil and there is a right, promote the right. For example,
+  # deleting C in the following tree results in B's right becoming D
+  #
+  #        B
+  #       / \
+  #      A   C
+  #           \
+  #            D
+  #
+  defp do_delete(%Node{key: node_key, left: nil, right: right}, delete_key) when node_key === delete_key do
+    {1, %Node{right | depth: right.depth - 1}}
+  end
+
+  # If there is a left promote it. For example,
+  # deleting B in the following tree results in C's left becoming A
+  #
+  #        C
+  #       / \
+  #      B   D
+  #     /
+  #    A
+  #
+  defp do_delete(%Node{key: node_key, left: left, right: nil}, delete_key) when node_key === delete_key do
+    {1, %Node{left | depth: left.depth - 1}}
+  end
+
+  # If there are both left and right nodes, recursively promote the left-most
+  # nodes. For example, deleting E below results in the following:
+  #
+  #        G      =>         G
+  #       / \               / \
+  #      E   H    =>       C   H
+  #     / \               / \
+  #    C   F      =>     B   D
+  #   / \               /     \
+  #  A   D        =>   A       F
+  #   \
+  #    B
+  #
+  #
+  defp do_delete(%Node{key: node_key, left: left, right: right}, delete_key) when node_key === delete_key do
+    {
+      1,
+      do_balance(%Node{
+        left |
+        depth: left.depth - 1,
+        left: do_balance(promote(left)),
+        right: right
+      })
+    }
+  end
+
+  defp do_delete(%Node{key: node_key}=node, delete_key) when delete_key < node_key do
+    do_delete_left(node, delete_key)
+  end
+
+  defp do_delete(%Node{key: node_key}=node, delete_key) when delete_key > node_key do
+    do_delete_right(node, delete_key)
+  end
+
+  # For cases when `delete_key !== node_key` but `delete_key == node_key` (e.g.
+  # `1` and `1.0`,) hash the keys to provide consistent ordering.
+  defp do_delete(%Node{key: node_key}=node, delete_key) when delete_key == node_key do
+    if key_less_than?(delete_key, node_key) do
+      do_delete_left(node, delete_key)
+    else
+      do_delete_right(node, delete_key)
+    end
+  end
+
+  defp do_delete_left(%Node{left: left}=node, delete_key) do
+    {nodes_removed, new_left} = do_delete(left, delete_key)
+    {
+      nodes_removed,
+      %Node{
+        node |
+        left: do_balance(new_left)
+      }
+    }
+  end
+
+  defp do_delete_right(%Node{right: right}=node, delete_key) do
+    {nodes_removed, new_right} = do_delete(right, delete_key)
+    {
+      nodes_removed,
+      %Node{
+        node |
+        right: do_balance(new_right)
+      }
+    }
+  end
+
+  defp promote(nil) do
+    nil
+  end
+
+  defp promote(%Node{left: nil, right: nil, depth: depth}=node) do
+    %Node{ node | color: :red, depth: depth - 1 }
+  end
+
+  defp promote(%Node{left: left, right: nil, depth: depth}) do
+    %Node{ left | color: :red, depth: depth - 1}
+  end
+
+  defp promote(%Node{left: nil, right: right, depth: depth}) do
+    %Node{ right | color: :red, depth: depth - 1}
+  end
+
+  defp promote(%Node{left: left, right: right, depth: depth}) do
+    balance(%Node{
+      left |
+      depth: depth - 1,
+      left: do_balance(promote(left)),
+      right: right
+    })
+  end
+
+  #### Balance
+
+  # If we have a tree that looks like this:
+  #              B (Black)
+  #             /         \
+  #            A          D (Red)
+  #                      /       \
+  #                     C         F (Red)
+  #                              /       \
+  #                             E         G
+  #
+  #
+  # Rotate to balance and look like this:
+  #
+  #                   D (Red)
+  #                 /         \
+  #          B (Black)        F (Black)
+  #         /        \       /         \
+  #        A          C     E           G
+  #
+  #
+  defp do_balance(
+    %Node{
+      color: :black,
+      left: a_node,
+      right: %Node{
+        color: :red,
+        left: c_node,
+        right: %Node{
+          color: :red,
+          left: e_node,
+          right: g_node
+        }=f_node
+      }=d_node
+    }=b_node) do
+
+    balanced_tree(a_node, b_node, c_node, d_node, e_node, f_node, g_node)
+  end
+
+  # If we have a tree that looks like this:
+  #
+  #         B (Black)
+  #        /         \
+  #       A       F (Red)
+  #              /       \
+  #           D (Red)     G
+  #          /       \
+  #         C         E
+  #
+  # Rotate to balance like so:
+  #
+  #                D (Red)
+  #               /       \
+  #        B (Black)       F (Black)
+  #       /         \     /         \
+  #      A           C   E           G
+  #
+  #
+  #
+  defp do_balance(
+    %Node{
+      color: :black,
+      left: a_node,
+      right: %Node{
+        color: :red,
+        left: %Node{
+          color: :red,
+          left: c_node,
+          right: e_node
+        }=d_node,
+        right: g_node
+      }=f_node
+    }=b_node) do
+
+    balanced_tree(a_node, b_node, c_node, d_node, e_node, f_node, g_node)
+  end
+
+  # If we have a tree that looks like this:
+  #
+  #
+  #                 F (Black)
+  #                /         \
+  #               D (Red)     G
+  #              /       \
+  #           B (Red)     E
+  #          /       \
+  #         A          C
+  #
+  #
+  # Rebalance to look like so:
+  #
+  #               D (Red)
+  #              /       \
+  #      B (Black)        F (Black)
+  #     /         \      /         \
+  #    A           C    E           G
+  #
+  defp do_balance(%Node{
+      color: :black,
+      left: %Node{
+        color: :red,
+        left: %Node{
+          color: :red,
+          left: a_node,
+          right: c_node
+        }=b_node,
+        right: e_node
+      }=d_node,
+      right: g_node
+    }=f_node) do
+
+    balanced_tree(a_node, b_node, c_node, d_node, e_node, f_node, g_node)
+  end
+
+  # If we have a tree that looks like this:
+  #
+  #               F (Black)
+  #              /         \
+  #          B (Red)        G
+  #         /       \
+  #        A         D (Red)
+  #                 /       \
+  #                C         E
+  #
+  # Rebalance to look like this:
+  #
+  #            D (Red)
+  #           /       \
+  #     B (Black)      F (Black)
+  #    /         \    /         \
+  #   A           C  E           G
+  #
+  defp do_balance(%Node{
+      color: :black,
+      left: %Node{
+        color: :red,
+        left: a_node,
+        right: %Node{
+          color: :red,
+          left: c_node,
+          right: e_node
+        }=d_node
+      }=b_node,
+      right: g_node
+    }=f_node) do
+
+    balanced_tree(a_node, b_node, c_node, d_node, e_node, f_node, g_node)
+  end
+
+
+  defp do_balance(node) do
+    node
+  end
+
+  defp balanced_tree(a_node, b_node, c_node, d_node, e_node, f_node, g_node) do
+    min_depth = min_depth([a_node, b_node, c_node, d_node, e_node, f_node, g_node])
+    %Node {
+      d_node |
+      color: :red,
+      depth: min_depth,
+      left: %Node{b_node | color: :black, depth: min_depth + 1,
+        left: %Node{a_node | depth: min_depth + 2},
+        right: %Node{c_node | depth: min_depth + 2}},
+      right: %Node{f_node | color: :black, depth: min_depth + 1,
+        left: %Node{e_node | depth: min_depth + 2},
+        right: %Node{g_node | depth: min_depth + 2},}
+    }
+  end
+
+  defp min_depth(list_of_nodes) do
+    Enum.reduce(list_of_nodes, -1, fn (node, acc) ->
+      if acc == -1 || node.depth < acc do
+        node.depth
+      else
+        acc
+      end
+    end)
+  end
+
+  defp do_reduce_nodes(_order, nil, acc, _fun) do
+    acc
+  end
+
+  # self, left, right
+  defp do_reduce_nodes(:pre_order, %Node{left: left, right: right}=node, acc, fun) do
+    acc_after_self = fun.(node, acc)
+    acc_after_left = do_reduce_nodes(:pre_order, left, acc_after_self, fun)
+    do_reduce_nodes(:pre_order, right, acc_after_left, fun)
+  end
+
+  # left, self, right
+  defp do_reduce_nodes(:in_order, %Node{left: left, right: right}=node, acc, fun) do
+    acc_after_left = do_reduce_nodes(:in_order, left, acc, fun)
+    acc_after_self = fun.(node, acc_after_left)
+    do_reduce_nodes(:in_order, right, acc_after_self, fun)
+  end
+
+  # left, right, self
+  defp do_reduce_nodes(:post_order, %Node{left: left, right: right}=node, acc, fun) do
+    acc_after_left = do_reduce_nodes(:post_order, left, acc, fun)
+    acc_after_right = do_reduce_nodes(:post_order, right, acc_after_left, fun)
+    fun.(node, acc_after_right)
+  end
+end
+
+defimpl Enumerable, for: RedBlackTree do
+  def count(%RedBlackTree{size: size}), do: size
+  def member?(%RedBlackTree{}=tree, key), do: RedBlackTree.has_key?(tree, key)
+  def reduce(tree, acc, fun), do: RedBlackTree.reduce(tree, acc, fun)
+end
+
+defimpl Access, for: RedBlackTree do
+  def get(tree, key) do
+    RedBlackTree.search(tree, key)
+  end
+
+  def get_and_update(tree, key, fun) do
+    {get, update} = fun.(RedBlackTree.search(tree, key))
+    {get, RedBlackTree.insert(tree, key, update)}
+  end
+end
+
+defimpl Collectable, for: RedBlackTree do
+  def into(original) do
+    {original, fn
+      tree, {:cont, {key, value}} -> RedBlackTree.insert(tree, key, value)
+      tree, :done -> tree
+      _, :halt -> :ok
+    end}
+  end
+end

--- a/lib/elixir/lib/red_black_tree/node.ex
+++ b/lib/elixir/lib/red_black_tree/node.ex
@@ -1,0 +1,18 @@
+defmodule RedBlackTree.Node do
+  defstruct(
+    color: :black,
+    depth: 1,
+    key: nil,
+    value: nil,
+    left: nil,
+    right: nil
+  )
+
+  def new(key, value, depth \\ 1) do
+    %__MODULE__{key: key, value: value, depth: depth}
+  end
+
+  def color(%__MODULE__{}=node, color) do
+    %__MODULE__{ node | color: color}
+  end
+end

--- a/lib/elixir/lib/sorted_set.ex
+++ b/lib/elixir/lib/sorted_set.ex
@@ -1,0 +1,316 @@
+defmodule SortedSet do
+  alias RedBlackTree
+  @moduledoc """
+    A Set implementation that always remains sorted.
+
+    SortedSet guarantees that no element appears more than once and that
+    enumerating over members happens in their sorted order.
+  """
+
+  @behaviour Set
+
+  # Define the type as opaque
+
+  @opaque t :: %__MODULE__{members: RedBlackTree, size: non_neg_integer}
+  @doc false
+  defstruct members: RedBlackTree.new, size: 0
+
+  @doc ~S"""
+  Returns a new `SortedSet`, initialized with the unique, sorted values of
+  `members`.
+
+  ## Examples
+
+      iex> inspect SortedSet.new()
+      "#SortedSet<[]>"
+
+      iex> inspect SortedSet.new([1,3,5])
+      "#SortedSet<[1, 3, 5]>"
+  """
+  def new(members \\ []) do
+    Enum.reduce(members, %SortedSet{}, fn(member, set) ->
+      put(set, member)
+    end)
+  end
+
+  @doc ~S"""
+  Returns the number of elements in a `SortedSet`.
+
+  ## Examples
+
+      iex> SortedSet.size SortedSet.new([1,3,5])
+      3
+  """
+  def size(%SortedSet{size: size}) do
+    size
+  end
+
+  @doc ~S"""
+  Returns a `List` with all of the members of `set`.
+
+  ## Examples
+
+      iex> SortedSet.to_list SortedSet.new([1,3,5])
+      [1,3,5]
+  """
+  def to_list(%SortedSet{members: members}) do
+    Enum.reduce(members, [], fn ({key, _value}, acc) ->
+      [key | acc]
+    end) |> Enum.reverse
+  end
+
+  @doc ~S"""
+  Returns a `SortedSet` with all of the members of `set` plus `element`.
+
+  ## Examples
+
+      iex> set = SortedSet.new([1,3,5])
+      iex> SortedSet.to_list SortedSet.put(set, 1)
+      [1,3,5]
+
+      iex> set = SortedSet.new([1,3,5])
+      iex> SortedSet.to_list SortedSet.put(set, 2)
+      [1,2,3,5]
+  """
+  def put(%SortedSet{members: members}, element) do
+    new_tree = RedBlackTree.insert members, element, element
+    %SortedSet{members: new_tree, size: new_tree.size}
+  end
+
+  @doc ~S"""
+  Returns a `SortedSet` with all of the members of `sortedset` except for `element`.
+
+  ## Examples
+
+      iex> set = SortedSet.new([1,3,5])
+      iex> SortedSet.to_list SortedSet.delete(set, 1)
+      [3,5]
+
+      iex> set = SortedSet.new([1,3,5])
+      iex> SortedSet.to_list SortedSet.delete(set, 2)
+      [1,3,5]
+
+      iex> set = SortedSet.new([])
+      iex> SortedSet.to_list SortedSet.delete(set, 2)
+      []
+  """
+  def delete(%SortedSet{members: members}, element) do
+    new_tree = RedBlackTree.delete members, element
+    %SortedSet{members: new_tree, size: new_tree.size}
+  end
+
+  ## SortedSet predicate methods
+
+  @doc ~S"""
+  Returns `true` if `set` contains `element`
+
+  ## Examples
+
+      iex> set = SortedSet.new([1,3,5])
+      iex> SortedSet.member?(set, 1)
+      true
+
+      iex> set = SortedSet.new([1,3,5])
+      iex> SortedSet.member?(set, 0)
+      false
+  """
+  def member?(%SortedSet{members: tree}, element) do
+    RedBlackTree.has_key? tree, element
+  end
+
+  # If the sizes are not equal, no need to check members
+  def equal?(%SortedSet{size: size1}, %SortedSet{size: size2}) when size1 != size2 do
+    false
+  end
+
+  @doc ~S"""
+  Returns `true` if all elements in `set1` are in `set2` and all elements in
+  `set2` are in `set1`
+
+  ## Examples
+
+      iex> set1 = SortedSet.new([1,3,5])
+      iex> set2 = SortedSet.new([1,3,5])
+      iex> SortedSet.equal?(set1, set2)
+      true
+
+      iex> set1 = SortedSet.new([1,3,5])
+      iex> set2 = SortedSet.new([1,2,3,4,5])
+      iex> SortedSet.equal?(set1, set2)
+      false
+  """
+  def equal?(%SortedSet{}=set1, %SortedSet{}=set2) do
+    Enum.all?(to_list(set1), fn(set1_member) ->
+      member? set2, set1_member
+    end)
+  end
+
+  def subset?(%SortedSet{size: size1}, %SortedSet{size: size2}) when size1 > size2 do
+    false
+  end
+
+  @doc ~S"""
+  Returns `true` if all elements in `set1` are in `set2`
+
+  ## Examples
+
+      iex> set1 = SortedSet.new([1,3,5])
+      iex> set2 = SortedSet.new([1,2,3,4,5])
+      iex> SortedSet.subset?(set1, set2)
+      true
+
+      iex> set1 = SortedSet.new([1,2,3,4,5])
+      iex> set2 = SortedSet.new([1,3,5])
+      iex> SortedSet.subset?(set1, set2)
+      false
+  """
+  # If set1 is larger than set2, it cannot be a subset of it
+  def subset?(%SortedSet{}=set1, %SortedSet{}=set2) do
+    Enum.all?(to_list(set1), fn(set1_member) ->
+      member? set2, set1_member
+    end)
+  end
+
+  @doc ~S"""
+  Returns `true` if no member of `set1` is in `set2`. Otherwise returns
+  `false`.
+
+  ## Examples
+
+      iex> set1 = SortedSet.new([1,2,3,4])
+      iex> set2 = SortedSet.new([5,6,7,8])
+      iex> SortedSet.disjoint?(set1, set2)
+      true
+
+      iex> set1 = SortedSet.new([1,2,3,4])
+      iex> set2 = SortedSet.new([4,5,6,7])
+      iex> SortedSet.disjoint?(set1, set2)
+      false
+  """
+  def disjoint?(%SortedSet{size: size1}=set1, %SortedSet{size: size2}=set2) when size1 <= size2 do
+    not Enum.any?(to_list(set1), fn(set1_member) ->
+      member?(set2, set1_member)
+    end)
+  end
+
+  def disjoint?(%SortedSet{}=set1, %SortedSet{}=set2) do
+    disjoint?(set2, set1)
+  end
+
+  ## SortedSet Operations
+
+  @doc ~S"""
+  Returns a `SortedSet` containing the items of both `set1` and `set2`.
+
+  ## Examples
+
+      iex> set1 = SortedSet.new([1,3,5,7])
+      iex> set2 = SortedSet.new([0,2,3,4,5])
+      iex> SortedSet.to_list SortedSet.union(set1, set2)
+      [0,1,2,3,4,5,7]
+  """
+  def union(%SortedSet{size: size1}=set1, %SortedSet{size: size2}=set2) when size1 <= size2  do
+    Enum.reduce(to_list(set1), set2, fn(member, new_set) ->
+      put(new_set, member)
+    end)
+  end
+
+  def union(%SortedSet{}=set1, %SortedSet{}=set2) do
+    union(set2, set1)
+  end
+
+  # If either set is empty, the intersection is the empty set
+  def intersection(%SortedSet{size: 0}=set1, _) do
+    set1
+  end
+
+  # If either set is empty, the intersection is the empty set
+  def intersection(_, %SortedSet{size: 0}=set2) do
+    set2
+  end
+
+  @doc ~S"""
+  Returns a `SortedSet` containing the items contained in both `set1` and
+  `set2`.
+
+  ## Examples
+
+      iex> set1 = SortedSet.new([1,3,5,7])
+      iex> set2 = SortedSet.new([0,2,3,4,5])
+      iex> SortedSet.to_list SortedSet.intersection(set1, set2)
+      [3,5]
+  """
+  def intersection(%SortedSet{size: size1}=set1, %SortedSet{size: size2}=set2) when size1 <= size2 do
+    Enum.reduce(to_list(set1), SortedSet.new, fn(set1_member, new_set) ->
+      if SortedSet.member?(set2, set1_member) do
+        SortedSet.put(new_set, set1_member)
+      else
+        new_set
+      end
+    end)
+  end
+
+  def intersection(%SortedSet{}=set1, %SortedSet{}=set2) do
+    intersection(set2, set1)
+  end
+
+  @doc ~S"""
+  Returns a `SortedSet` containing the items in `set1` that are not in `set2`.
+
+  ## Examples
+
+      iex> set1 = SortedSet.new([1,2,3,4])
+      iex> set2 = SortedSet.new([2,4,6,8])
+      iex> SortedSet.to_list SortedSet.difference(set1, set2)
+      [1,3]
+  """
+  def difference(%SortedSet{size: size1}=set1, %SortedSet{size: size2}=set2) when size1 > 0 and size2 > 0 do
+    Enum.reduce(to_list(set1), set1, fn(set1_member, new_set) ->
+      if SortedSet.member?(set2, set1_member) do
+        delete(new_set, set1_member)
+      else
+        new_set
+      end
+    end)
+  end
+
+  # When the first set is empty, the difference is the empty set
+  def difference(%SortedSet{size: 0}=empty_set, _) do
+    empty_set
+  end
+
+  # When the other set is empty, the difference is the first set
+  def difference(%SortedSet{}=set1, %SortedSet{size: 0}) do
+    set1
+  end
+end
+
+defimpl Enumerable, for: SortedSet do
+  def count(%SortedSet{size: size}), do: {:ok, size}
+  def member?(%SortedSet{}=set, element), do: {:ok, SortedSet.member?(set, element)}
+  def reduce(%SortedSet{}=set, acc, fun) do
+    SortedSet.to_list(set)
+    |> Enumerable.List.reduce(acc, fun)
+  end
+end
+
+defimpl Collectable, for: SortedSet do
+  def into(original) do
+    {original, fn
+      set, {:cont, new_member} -> SortedSet.put(set, new_member)
+      set, :done -> set
+      _, :halt -> :ok
+    end}
+  end
+end
+
+# We want our own inspect so that it will hide the underlying :members and :size
+# fields. Otherwise users may try to play with them directly.
+defimpl Inspect, for: SortedSet do
+  import Inspect.Algebra
+
+  def inspect(set, opts) do
+    concat ["#SortedSet<", Inspect.List.inspect(SortedSet.to_list(set), opts), ">"]
+  end
+end
+

--- a/lib/elixir/test/elixir/red_black_tree/node_test.exs
+++ b/lib/elixir/test/elixir/red_black_tree/node_test.exs
@@ -1,0 +1,19 @@
+defmodule RedBlackTree.NodeTest do
+  use ExUnit.Case, async: true
+  alias RedBlackTree.Node
+
+  test "#new" do
+    assert %Node{
+      key: :walrus,
+      value: :bubbles,
+      color: :black,
+      left: nil,
+      right: nil
+    } == Node.new(:walrus, :bubbles)
+  end
+
+  test "#color" do
+    assert :red == Node.color(%Node{color: :black}, :red).color
+    assert :black == Node.color(%Node{color: :red}, :black).color
+  end
+end

--- a/lib/elixir/test/elixir/red_black_tree_test.exs
+++ b/lib/elixir/test/elixir/red_black_tree_test.exs
@@ -1,0 +1,339 @@
+defmodule RedBlackTreeTest do
+  use ExUnit.Case, async: true
+  alias RedBlackTree.Node
+  doctest Dict
+  defp dict_impl, do: RedBlackTree
+
+  test "initializing a red black tree" do
+    assert %RedBlackTree{} == RedBlackTree.new
+    assert 0 == RedBlackTree.new.size
+
+    assert [{1,1}, {2,2}, {:c,:c}] == RedBlackTree.to_list RedBlackTree.new([1,2,:c])
+    assert [{1,1}, {2,2}, {:c,:c}] == RedBlackTree.to_list RedBlackTree.new([1,2,:c])
+  end
+
+  test "to_list" do
+    empty_tree = RedBlackTree.new
+    bigger_tree = RedBlackTree.new([d: 1, b: 2, c: 3, a: 4])
+    assert [] == RedBlackTree.to_list empty_tree
+
+    # It should return the elements in order
+    assert [{:a, 4}, {:b, 2}, {:c, 3}, {:d, 1}] == RedBlackTree.to_list bigger_tree
+    assert 4 == bigger_tree.size
+  end
+
+  test "insert" do
+    red_black_tree = RedBlackTree.insert RedBlackTree.new, 1, :bubbles
+    assert [{1, :bubbles}] == RedBlackTree.to_list red_black_tree
+    assert 1 == red_black_tree.size
+
+    red_black_tree = RedBlackTree.insert red_black_tree, 0, :walrus
+    assert [{0, :walrus}, {1, :bubbles}] == RedBlackTree.to_list red_black_tree
+    assert 2 == red_black_tree.size
+  end
+
+  test "strict equality" do
+    tree = RedBlackTree.new([{1, :bubbles}])
+    updated = RedBlackTree.insert(tree, 1.0, :walrus)
+
+    assert 2 == RedBlackTree.size(updated)
+
+    # Deletes
+    # We convert to lists so that the comparison ignores node colors
+    assert RedBlackTree.to_list(RedBlackTree.new([{1, :bubbles}])) ==
+           RedBlackTree.to_list(RedBlackTree.delete(updated, 1.0))
+    assert RedBlackTree.to_list(RedBlackTree.new([{1.0, :walrus}])) ==
+           RedBlackTree.to_list(RedBlackTree.delete(updated, 1))
+
+    # Search
+    assert :walrus == RedBlackTree.search(updated, 1.0)
+    assert :bubbles == RedBlackTree.search(updated, 1)
+
+    assert true == RedBlackTree.has_key?(updated, 1.0)
+    assert true == RedBlackTree.has_key?(updated, 1)
+  end
+
+  test "search" do
+    tree = RedBlackTree.new([d: 1, b: 2, f: 3, g: 4, c: 5, a: 6, e: 7])
+
+    assert 2 == RedBlackTree.search(tree, :b)
+    assert 6 == RedBlackTree.search(tree, :a)
+    assert 3 == RedBlackTree.search(tree, :f)
+    assert 1 == RedBlackTree.search(tree, :d)
+    assert 7 == RedBlackTree.search(tree, :e)
+    assert 4 == RedBlackTree.search(tree, :g)
+    assert 5 == RedBlackTree.search(tree, :c)
+  end
+
+  test "delete" do
+    initial_tree = RedBlackTree.new([d: 1, b: 2, c: 3, a: 4])
+    pruned_tree = RedBlackTree.delete(initial_tree, :c)
+
+    assert 3 == pruned_tree.size
+    assert [{:a, 4}, {:b, 2}, {:d, 1}] == RedBlackTree.to_list pruned_tree
+
+    assert 2 == RedBlackTree.delete(pruned_tree, :a).size
+    assert [{:b, 2}, {:d, 1}] == RedBlackTree.to_list RedBlackTree.delete(pruned_tree, :a)
+
+    assert [] == RedBlackTree.to_list RedBlackTree.delete RedBlackTree.new, :b
+  end
+
+  test "delete depth" do
+    initial_tree = RedBlackTree.new([d: 1, b: 2, f: 3, g: 4, c: 5, a: 6, e: 7])
+    depth_aggregator = fn(%Node{key: key, depth: depth}, acc) ->
+      Map.put(acc, key, depth)
+    end
+
+    altered_tree = RedBlackTree.delete(initial_tree, :b)
+    assert %{a: 2, c: 3, d: 1, e: 3, f: 2, g: 3} ==
+           RedBlackTree.reduce_nodes(altered_tree, %{}, depth_aggregator)
+
+    unchanged_tree = RedBlackTree.delete(initial_tree, :banana)
+    assert %{a: 3, b: 2, c: 3, d: 1, e: 3, f: 2, g: 3} ==
+           RedBlackTree.reduce_nodes(unchanged_tree, %{}, depth_aggregator)
+
+  end
+
+  test "reduce_nodes" do
+    initial_tree = RedBlackTree.new([d: 1, b: 2, f: 3, g: 4, c: 5, a: 6, e: 7])
+    aggregator = fn (%Node{key: key}, acc) ->
+      acc ++ [key]
+    end
+
+    # should default to in-order
+    no_order_members = RedBlackTree.reduce_nodes(initial_tree, [], aggregator)
+    in_order_members = RedBlackTree.reduce_nodes(:in_order, initial_tree, [], aggregator)
+    pre_order_members = RedBlackTree.reduce_nodes(:pre_order, initial_tree, [], aggregator)
+    post_order_members = RedBlackTree.reduce_nodes(:post_order, initial_tree, [], aggregator)
+
+    assert in_order_members == [:a, :b, :c, :d, :e, :f, :g]
+    assert no_order_members == in_order_members
+    assert pre_order_members == [:d, :b, :a, :c, :f, :e, :g]
+    assert post_order_members == [:a, :c, :b, :e, :g, :f, :d]
+  end
+
+  test "altering depth" do
+    tree = RedBlackTree.new()
+    depth_aggregator = fn(%Node{key: key, depth: depth}, acc) ->
+      Map.put(acc, key, depth)
+    end
+
+    one_level_tree = RedBlackTree.insert(tree, :a, 10)
+    assert one_level_tree.root.depth == 1
+
+    two_level_tree = RedBlackTree.insert(one_level_tree, :c, 20)
+    assert %{a: 1, c: 2} == RedBlackTree.reduce_nodes(two_level_tree, %{}, depth_aggregator)
+
+    three_level_tree = RedBlackTree.insert(two_level_tree, :d, 30)
+    assert %{a: 1, c: 2, d: 3} == RedBlackTree.reduce_nodes(three_level_tree, %{}, depth_aggregator)
+
+    still_three_level_tree = RedBlackTree.insert(three_level_tree, :b, 20)
+    assert %{a: 1, b: 3, c: 2, d: 3} == RedBlackTree.reduce_nodes(still_three_level_tree, %{}, depth_aggregator)
+  end
+
+  test "has_key?" do
+    assert RedBlackTree.has_key?(RedBlackTree.new([a: 1, b: 2]), :b)
+    assert not RedBlackTree.has_key?(RedBlackTree.new([a: 1, b: 2]), :c)
+  end
+
+  #
+  #              B (Black)
+  #             /         \
+  #            A          D (Red)
+  #                      /       \
+  #                     C         F (Red)
+  #                              /       \
+  #                             E         G
+  #
+  test "balancing a right-heavy red tree" do
+    unbalanced = %RedBlackTree{
+      size: 5,
+      root: %Node{
+        key: :b,
+        depth: 1,
+        color: :black,
+        left: %Node{key: :a, depth: 2},
+        right: %Node{
+          key: :d,
+          depth: 2,
+          color: :red,
+          left: %Node{key: :c, depth: 3},
+          right: %Node{
+            key: :f,
+            depth: 3,
+            color: :red,
+            left: %Node{key: :e, depth: 4},
+            right: %Node{key: :g, depth: 4}
+          }
+        }
+      }
+    }
+    balanced = RedBlackTree.balance(unbalanced)
+    assert balanced_tree() == balanced
+    assert RedBlackTree.to_list(unbalanced) == RedBlackTree.to_list(balanced)
+  end
+
+  #
+  #         B (Black)
+  #        /         \
+  #       A       F (Red)
+  #              /       \
+  #           D (Red)     G
+  #          /       \
+  #         C         E
+  #
+  test "balancing a center-right-heavy tree" do
+    unbalanced = %RedBlackTree{
+      size: 5,
+      root: %Node{
+        key: :b,
+        depth: 1,
+        color: :black,
+        left: %Node{key: :a, depth: 2},
+        right: %Node{
+          key: :f,
+          depth: 2,
+          color: :red,
+          left: %Node{
+            key: :d,
+            depth: 3,
+            color: :red,
+            left: %Node{key: :c, depth: 4},
+            right: %Node{key: :e, depth: 4}
+          },
+          right: %Node{key: :g, depth: 3}
+        }
+      }
+    }
+
+    balanced = RedBlackTree.balance(unbalanced)
+    assert balanced_tree() == balanced
+    assert RedBlackTree.to_list(unbalanced) == RedBlackTree.to_list(balanced)
+  end
+
+  #                 F (Black)
+  #                /         \
+  #               D (Red)     G
+  #              /       \
+  #           B (Red)     E
+  #          /       \
+  #         A          C
+  #
+  #
+  test "balancing a left-heavy tree" do
+    unbalanced = %RedBlackTree{
+      size: 5,
+      root: %Node{
+        key: :f,
+        depth: 1,
+        color: :black,
+        left: %Node{
+          key: :d,
+          depth: 2,
+          color: :red,
+          left: %Node{
+            key: :b,
+            depth: 3,
+            color: :red,
+            left: %Node{key: :a, depth: 4},
+            right: %Node{key: :c, depth: 4}
+          },
+          right: %Node{key: :e, depth: 3}
+        },
+        right: %Node{key: :g, depth: 2}
+      }
+    }
+
+    balanced = RedBlackTree.balance(unbalanced)
+    assert balanced_tree() == balanced
+    assert RedBlackTree.to_list(unbalanced) == RedBlackTree.to_list(balanced)
+  end
+
+  #
+  #               F (Black)
+  #              /         \
+  #          B (Red)        G
+  #         /       \
+  #        A         D (Red)
+  #                 /       \
+  #                C         E
+  #
+  test "balancing a center-left-heavy tree" do
+    unbalanced = %RedBlackTree{
+      size: 5,
+      root: %Node{
+        key: :f,
+        depth: 1,
+        color: :black,
+        left: %Node{
+          key: :b,
+          depth: 2,
+          color: :red,
+          left: %Node{key: :a, depth: 3},
+          right: %Node{
+            key: :d,
+            depth: 3,
+            color: :red,
+            left: %Node{key: :c, depth: 4},
+            right: %Node{key: :e, depth: 4}
+          },
+        },
+        right: %Node{key: :g, depth: 2}
+      }
+    }
+
+    balanced = RedBlackTree.balance(unbalanced)
+    assert balanced_tree() == balanced
+    assert RedBlackTree.to_list(unbalanced) == RedBlackTree.to_list(balanced)
+  end
+
+  test "implements Collectable" do
+    members = [d: 1, b: 2, f: 3, g: 4, c: 5, a: 6, e: 7]
+    assert Enum.into(members, RedBlackTree.new) == RedBlackTree.new(members)
+  end
+
+  test "implements Access" do
+    tree = RedBlackTree.new([d: 1, b: 2, f: 3, g: 4, c: 5, a: 6, e: 7])
+    assert 1 == tree[:d]
+    assert 2 == tree[:b]
+    assert 3 == tree[:f]
+    assert 4 == tree[:g]
+
+    {6, %{tree: new_tree}} = get_and_update_in(%{tree: tree}, [:tree, :a], fn (prev) ->
+      {prev, prev * 2}
+    end)
+    assert 12 == RedBlackTree.search(new_tree, :a)
+  end
+
+  #
+  #            D (Red)
+  #           /       \
+  #     B (Black)      F (Black)
+  #    /         \    /         \
+  #   A           C  E           G
+  #
+  defp balanced_tree do
+    %RedBlackTree{
+      size: 5,
+      root: %Node{
+        key: :d,
+        depth: 1,
+        color: :red,
+        left: %Node{
+          key: :b,
+          depth: 2,
+          color: :black,
+          left: %Node{ key: :a, depth: 3 },
+          right: %Node{ key: :c, depth: 3 }
+        },
+        right: %Node{
+          key: :f,
+          depth: 2,
+          color: :black,
+          left: %Node{ key: :e, depth: 3 },
+          right: %Node{ key: :g, depth: 3 }
+        }
+      }
+    }
+  end
+end

--- a/lib/elixir/test/elixir/sorted_set_test.exs
+++ b/lib/elixir/test/elixir/sorted_set_test.exs
@@ -1,0 +1,125 @@
+defmodule SortedSetTest do
+  use ExUnit.Case, async: true
+  doctest SortedSet
+
+
+  test "it creates an empty set with size 0" do
+    assert 0 == SortedSet.size SortedSet.new
+  end
+
+  test "it sorts an existing list on creation" do
+    assert [1,3,5] == SortedSet.to_list SortedSet.new [1,5,3]
+  end
+
+  test "it can put an element into the set" do
+    new_set = SortedSet.put SortedSet.new, 1
+    assert [1] == SortedSet.to_list new_set
+    assert 1 == SortedSet.size new_set
+  end
+
+  test "it puts elements in sorted order" do
+    set = SortedSet.put(SortedSet.new(), 2)
+    |> SortedSet.put(3)
+    |> SortedSet.put(1)
+    assert [1,2,3] == SortedSet.to_list(set)
+    assert 3 == SortedSet.size set
+  end
+
+  test "it can delete from the set" do
+    set = SortedSet.new([1,2,3,4,5])
+    new_set = SortedSet.delete(set, 3)
+    assert [1,2,4,5] == SortedSet.to_list new_set
+    assert 4 == SortedSet.size new_set
+
+    assert [] == SortedSet.to_list SortedSet.delete(SortedSet.new(), 1)
+  end
+
+  test "it can perform a union on two sorted sets" do
+    set1 = SortedSet.new([1,2,3,4,5])
+    set2 = SortedSet.new([1,3,5,7,9])
+    union = SortedSet.union(set1, set2)
+    assert [1,2,3,4,5,7,9] == SortedSet.to_list union
+    assert 7 == SortedSet.size union
+  end
+
+  test "it can tell if a set contains an item" do
+    assert SortedSet.member?(SortedSet.new([1,2,3]), 1)
+    assert not SortedSet.member?(SortedSet.new([1,2,3]), 4)
+    assert not SortedSet.member?(SortedSet.new([]), 4)
+  end
+
+  test "it can tell if two sets are equal" do
+    assert SortedSet.equal?(SortedSet.new, SortedSet.new)
+    assert SortedSet.equal?(SortedSet.new([1,2,3,4]), SortedSet.new([1,2,3,4]))
+    assert not SortedSet.equal?(SortedSet.new([1,2,3]), SortedSet.new([1,2,4]))
+
+    # Ensure it isn't confused by subsets
+    assert not SortedSet.equal?(SortedSet.new([1,2,3]), SortedSet.new([1,2]))
+    # Or supersets
+    assert not SortedSet.equal?(SortedSet.new([1,2]), SortedSet.new([1,2,3]))
+
+  end
+
+  test "it can tell if one set is the subset of another" do
+    assert SortedSet.subset?(SortedSet.new, SortedSet.new)
+
+    assert SortedSet.subset?(SortedSet.new([1,2,3]), SortedSet.new([1,2,3,4]))
+    assert not SortedSet.subset?(SortedSet.new([1,2,3,4]), SortedSet.new([1,2,3]))
+  end
+
+  test "it can return the intersection of two sets" do
+    intersection = SortedSet.intersection(SortedSet.new([1,2,3]), SortedSet.new([1,3,5,7,9]))
+    assert [1,3] == SortedSet.to_list(intersection)
+
+    intersection = SortedSet.intersection(SortedSet.new([1,3,5]), SortedSet.new([2,4,6]))
+    assert [] == SortedSet.to_list(intersection)
+
+    intersection = SortedSet.intersection(SortedSet.new, SortedSet.new([1,2,3]))
+    assert [] == SortedSet.to_list(intersection)
+  end
+
+  test "it can find the difference between two sets" do
+    # With members in common
+    difference = SortedSet.difference(SortedSet.new([1,2,3]), SortedSet.new([1,3,5,7,9]))
+    assert [2] == SortedSet.to_list(difference)
+
+    # With no members in common
+    difference = SortedSet.difference(SortedSet.new([1,2,3]), SortedSet.new([5,7,9]))
+    assert [1,2,3] == SortedSet.to_list(difference)
+
+    # When one set is empty
+    difference = SortedSet.difference(SortedSet.new([]), SortedSet.new([5,7,9]))
+    assert [] == SortedSet.to_list(difference)
+
+    # When the other set is empty
+    difference = SortedSet.difference(SortedSet.new([1,2,3]), SortedSet.new([]))
+    assert [1,2,3] == SortedSet.to_list(difference)
+  end
+
+  test "it can tell if two sets are disjointed" do
+    assert SortedSet.disjoint?(SortedSet.new([1,2,3]), SortedSet.new([4,5,6]))
+    assert SortedSet.disjoint?(SortedSet.new(), SortedSet.new([4,5,6]))
+    assert SortedSet.disjoint?(SortedSet.new([4,5,6]), SortedSet.new())
+    assert not SortedSet.disjoint?(SortedSet.new([1,2,3]), SortedSet.new([3,4,5]))
+  end
+
+  test "it adheres to the Enumerable protocol" do
+    assert Enum.member?(SortedSet.new([1,2]), 1)
+    assert not Enum.member?(SortedSet.new(), 1)
+
+    assert 3 == Enum.count(SortedSet.new([1,2,3]))
+    assert 0 == Enum.count(SortedSet.new())
+
+    assert 24 == Enum.reduce(SortedSet.new([1,2,3,4]), 1, fn (n, acc) -> n * acc end)
+  end
+
+  test "it adheres to the Collectable prototcol" do
+    assert [1,2,3,4] == SortedSet.to_list(Enum.into([1,3,4,2,3,4], %SortedSet{}))
+  end
+
+  test "it implements the Inspect protocol" do
+    assert "#SortedSet<[0, 1, 2, 5, 6]>" == inspect SortedSet.new [1,0,5,2,5,6,2]
+    assert "#SortedSet<[]>" == inspect SortedSet.new
+
+  end
+end


### PR DESCRIPTION
First off, thank you to everyone on the elixir-core mailing list for feedback!

This adds a `SortedSet` module to elixir that is much more efficient than the `ordset` data structure in Erlang. It accomplishes O(log(N)) lookup and insertion via red black trees.

While `RedBlackTree`, and the `SortedSet` module that builds on top of it, can accept polymorphic keys, there is a small performance cost when adding a key (`new_key`) there is an existing key (`existing_key`) and the following hold true:

1. `new_key !== existing_key`
2. `new_key == existing_key`

In this case, to guarantee ordering, `:erlang/phash2/2` is used to break the tie and insert the key. In the case that `:erlang/phash2/2` collides for the two keys, RedBlackTree will fall back to `:erlang/phash/2`.

If the key being inserted or searched for does not meet the above properties with an key already in the tree, there is no performance penalty.