### PR TITLE
Skip test that depends on read-only file when running as root

### DIFF
--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -109,16 +109,19 @@ defmodule Kernel.CLI.CompileTest do
     refute File.exists?(context[:beam_file_path]), "expected the sample to not be compiled"
   end
 
-  if !System.get_env("FAKEROOTKEY") do
-    test "fails on missing write access to .beam file", context do
-      compilation_args = '#{context[:fixture]} -o #{context[:tmp_dir_path]}'
+  test "fails on missing write access to .beam file", context do
+    compilation_args = '#{context[:fixture]} -o #{context[:tmp_dir_path]}'
 
-      assert elixirc(compilation_args) == ''
-      assert File.regular?(context[:beam_file_path])
+    assert elixirc(compilation_args) == ''
+    assert File.regular?(context[:beam_file_path])
 
-      # Set the .beam file to read-only
-      File.chmod!(context[:beam_file_path], 4)
-
+    # Set the .beam file to read-only
+    File.chmod!(context[:beam_file_path], 4)
+        
+    {:ok, %{access: access}} = File.stat(context[:beam_file_path])
+    
+    # Can only assert when read-only applies to the user
+    if access != :read_write do
       output = elixirc(compilation_args)
       expected = '(File.Error) could not write to ' ++ String.to_char_list(context[:beam_file_path]) ++ ': permission denied'
       assert :string.str(output, expected) > 0, "expected compilation error message due to not having write access"


### PR DESCRIPTION
This test should not run when running as `root`, since read-only does not apply to root users. Issue #3380. 