### PR TITLE
Allows underscores in binary, hex and octal literals (e.g, 0b0001_0010)

### DIFF
--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -775,15 +775,15 @@ tokenize_number(Rest, Acc, false) ->
   {Rest, list_to_integer(lists:reverse(Acc)), length(Acc)}.
 
 tokenize_hex([H|T], Acc) when ?is_hex(H) -> tokenize_hex(T, [H|Acc]);
-tokenize_hex([$_|T], Acc) -> tokenize_hex(T, Acc);
+tokenize_hex([$_, H|T], Acc) when ?is_hex(H) -> tokenize_hex(T, [H|Acc]);
 tokenize_hex(Rest, Acc) -> {Rest, list_to_integer(lists:reverse(Acc), 16), length(Acc)}.
 
 tokenize_octal([H|T], Acc) when ?is_octal(H) -> tokenize_octal(T, [H|Acc]);
-tokenize_octal([$_|T], Acc) -> tokenize_octal(T, Acc);
+tokenize_octal([$_, H|T], Acc) when ?is_octal(H) -> tokenize_octal(T, [H|Acc]);
 tokenize_octal(Rest, Acc) -> {Rest, list_to_integer(lists:reverse(Acc), 8), length(Acc)}.
 
 tokenize_bin([H|T], Acc) when ?is_bin(H) -> tokenize_bin(T, [H|Acc]);
-tokenize_bin([$_|T], Acc) -> tokenize_bin(T, Acc);
+tokenize_bin([$_, H|T], Acc) when ?is_bin(H) -> tokenize_bin(T, [H|Acc]);
 tokenize_bin(Rest, Acc) -> {Rest, list_to_integer(lists:reverse(Acc), 2), length(Acc)}.
 
 %% Comments

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -775,12 +775,15 @@ tokenize_number(Rest, Acc, false) ->
   {Rest, list_to_integer(lists:reverse(Acc)), length(Acc)}.
 
 tokenize_hex([H|T], Acc) when ?is_hex(H) -> tokenize_hex(T, [H|Acc]);
+tokenize_hex([$_|T], Acc) -> tokenize_hex(T, Acc);
 tokenize_hex(Rest, Acc) -> {Rest, list_to_integer(lists:reverse(Acc), 16), length(Acc)}.
 
 tokenize_octal([H|T], Acc) when ?is_octal(H) -> tokenize_octal(T, [H|Acc]);
+tokenize_octal([$_|T], Acc) -> tokenize_octal(T, Acc);
 tokenize_octal(Rest, Acc) -> {Rest, list_to_integer(lists:reverse(Acc), 8), length(Acc)}.
 
 tokenize_bin([H|T], Acc) when ?is_bin(H) -> tokenize_bin(T, [H|Acc]);
+tokenize_bin([$_|T], Acc) -> tokenize_bin(T, Acc);
 tokenize_bin(Rest, Acc) -> {Rest, list_to_integer(lists:reverse(Acc), 2), length(Acc)}.
 
 %% Comments

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -29,8 +29,11 @@ scientific_test() ->
 
 hex_bin_octal_test() ->
   [{number, {1,1,5}, 255}] = tokenize("0xFF"),
+  [{number, {1,1,5}, 255}] = tokenize("0xF_F"),
   [{number, {1,1,5}, 63}] = tokenize("0o77"),
-  [{number, {1,1,5}, 3}] = tokenize("0b11").
+  [{number, {1,1,5}, 63}] = tokenize("0o7_7"),
+  [{number, {1,1,5}, 3}] = tokenize("0b11"),
+  [{number, {1,1,5}, 3}] = tokenize("0b1_1").
 
 unquoted_atom_test() ->
   [{atom, {1,1,3}, '+'}] = tokenize(":+"),


### PR DESCRIPTION
Elixir currently only supports underscores in decimal numbers. This PR extends it to hex, octal and binary literals.