### PR TITLE
Mention the use of records in pattern matches

### DIFF
--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -158,6 +158,14 @@ defmodule Record do
       # Convert a record to a keyword list
       user(record) #=> [name: "meg", age: 26]
 
+  The generated macros can also be used in order to pattern match on records and
+  to bind variables during the match:
+
+      record = user() #=> {:user, "meg", 25}
+
+      user(name: name) = record
+      name #=> "meg"
+
   By default, Elixir uses the record name as the first element of
   the tuple (the tag). But it can be changed to something else:
 


### PR DESCRIPTION
The macros generated by `Record.defrecord/2` can be used in pattern matches to bind the fields of the record to variables. This wasn't mentioned in the docs (I don't know if this was on purpose).

I spotted this the first time in Plug ([here](https://github.com/elixir-lang/plug/blob/master/lib/plug/static.ex#L194)).