### PR TITLE
add optional encoding param to codepoint functions

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -197,6 +197,7 @@ defmodule String do
   @type codepoint :: t
   @type grapheme :: t
   @type pattern :: t | [t] | :binary.cp
+  @type encoding :: :utf8 | :utf16 |:utf32
 
   @doc """
   Checks if a string is printable considering it is encoded
@@ -787,7 +788,8 @@ defmodule String do
   end
 
   @doc """
-  Returns all codepoints in the string.
+  Returns all codepoints in the string. Optional second argument specifies the
+  encoding (utf8, utf16, utf32), defaulting to `:utf8`.
 
   ## Examples
 
@@ -800,12 +802,22 @@ defmodule String do
       iex> String.codepoints("ἅἪῼ")
       ["ἅ", "Ἢ", "ῼ"]
 
+      iex> String.codepoints(<<"olá"::utf16>>, :utf16)
+      [<<0, 111>>, <<0, 108>>, <<0, 225>>]
+
+      iex> String.codepoints(<<"olá"::utf32>>, :utf32)
+      [<<0, 0, 0, 111>>, <<0, 0, 0, 108>>, <<0, 0, 0, 225>>]
+
   """
   @spec codepoints(t) :: [codepoint]
   defdelegate codepoints(string), to: String.Unicode
 
+  @spec codepoints(t, encoding) :: [codepoint]
+  defdelegate codepoints(string, encoding), to: String.Unicode
+
   @doc """
-  Returns the next codepoint in a String.
+  Returns the next codepoint in a String. Optional second argument specifies the
+  encoding (utf8, utf16, utf32), defaulting to `:utf8`
 
   The result is a tuple with the codepoint and the
   remainder of the string or `nil` in case
@@ -821,10 +833,19 @@ defmodule String do
       iex> String.next_codepoint("olá")
       {"o", "lá"}
 
+      iex> String.next_codepoint(<<"olá"::utf16>>, :utf16)
+      {<<0, 111>>, <<0, 108, 0, 225>>}
+
+      iex> String.next_codepoint(<<"olá"::utf32>>, :utf32)
+      {<<0, 0, 0, 111>>, <<0, 0, 0, 108, 0, 0, 0, 225>>}
+
   """
-  @compile {:inline, next_codepoint: 1}
+  @compile {:inline, next_codepoint: 1, next_codepoint: 2}
   @spec next_codepoint(t) :: {codepoint, t} | nil
   defdelegate next_codepoint(string), to: String.Unicode
+
+  @spec next_codepoint(t, encoding) :: {codepoint, t} | nil
+  defdelegate next_codepoint(string, encoding), to: String.Unicode
 
   @doc ~S"""
   Checks whether `str` contains only valid characters.

--- a/lib/elixir/unicode/unicode.ex
+++ b/lib/elixir/unicode/unicode.ex
@@ -170,27 +170,39 @@ defmodule String.Unicode do
 
   # Codepoints
 
-  def next_codepoint(<< cp :: utf8, rest :: binary >>) do
+
+
+  def next_codepoint(bin, encoding\\:utf8)
+  def next_codepoint(<< cp :: utf8, rest :: binary >>, :utf8) do
     {<<cp :: utf8>>, rest}
   end
 
-  def next_codepoint(<< cp, rest :: binary >>) do
+  def next_codepoint(<< cp :: utf16, rest :: binary >>, :utf16) do
+    {<<cp :: utf16>>, rest}
+  end
+
+  def next_codepoint(<< cp :: utf32, rest :: binary >>, :utf32) do
+    {<<cp :: utf32>>, rest}
+  end
+
+  def next_codepoint(<< cp, rest :: binary >>, _encoding) do
     {<<cp>>, rest}
   end
 
-  def next_codepoint(<<>>) do
+  def next_codepoint(<<>>, _encoding) do
     nil
   end
 
-  def codepoints(binary) when is_binary(binary) do
-    do_codepoints(next_codepoint(binary))
+  def codepoints(binary, encoding\\:utf8)
+  def codepoints(binary, encoding) when is_binary(binary) do
+    do_codepoints(next_codepoint(binary, encoding), encoding)
   end
 
-  defp do_codepoints({c, rest}) do
-    [c|do_codepoints(next_codepoint(rest))]
+  defp do_codepoints({c, rest}, encoding) do
+    [c|do_codepoints(next_codepoint(rest, encoding), encoding)]
   end
 
-  defp do_codepoints(nil) do
+  defp do_codepoints(nil, _encoding) do
     []
   end
 end


### PR DESCRIPTION
Currently, `String.codepoints` and `String.next_codepoint` assume UTF8. This adds an optional second parameter for the user to specify one of the supported encodings (utf8, utf16, utf32).