### PR TITLE
Manpage corrections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /rel/elixir
 erl_crash.dump
 .elixir.plt
+man/elixir.1
+man/iex.1

--- a/man/common
+++ b/man/common
@@ -26,7 +26,7 @@ Starts the specified application and all its dependencies.
 Serves the same purpose as ELIXIR_ERL_OPTIONS
 .Pq see the Sy ENVIRONMENT No section
 .It Fl -cookie Ar value
-Allows specifying the magic cookie value. If the value isn't specified via the option when the node starts, it will be taken from the file
+Specifies the magic cookie value. If the value isn't specified via the option when the node starts, it will be taken from the file
 .Pa ~/.erlang.cookie
 .Pq see the Sy FILES No section .
 Distributed nodes can interact with each other only when their magic cookies are equal.

--- a/man/elixir.1.in
+++ b/man/elixir.1.in
@@ -1,5 +1,5 @@
 .Dd April 10, 2015
-.Dt IEX 1
+.Dt ELIXIR 1
 .Os
 .Sh NAME
 .Nm elixir


### PR DESCRIPTION
Hi there,

I have three small tweaks related to the manpages.

1. `man elixir` should show `ELIXIR 1` on the top not `IEX 1`
1. More direct wording of the cookie option.
1. Ignore `man/elixir.1` and `man/iex.1` as they are build artifacts.