### PR TITLE
Add support for Enum.reduce_while/3

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1436,6 +1436,25 @@ defmodule Enum do
   end
 
   @doc """
+  Reduces the collection until halt is emitted.
+
+  The return value for `fun` is expected to be
+  `{:cont, acc}`, return `{:halt, acc}` to end the reduction early.
+  Returns the accumulator.
+
+  ## Examples
+
+      iex> Enum.reduce_while(1..100, 0, fn i, acc ->
+      ...>   if i <= 3, do: {:cont, acc + i}, else: {:halt, acc}
+      ...> end)
+      6
+
+  """
+  def reduce_while(collection, acc, fun) do
+    Enumerable.reduce(collection, {:cont, acc}, fun) |> elem(1)
+  end
+
+  @doc """
   Returns elements of collection for which `fun` returns `false` or `nil`.
 
   ## Examples

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -265,6 +265,12 @@ defmodule EnumTest.List do
     end
   end
 
+  test :reduce_while do
+    assert Enum.reduce_while(1..100, 0, fn i, acc ->
+      if i <= 3, do: {:cont, acc + i}, else: {:halt, acc}
+    end) == 6
+  end
+
   test :reject do
     assert Enum.reject([1, 2, 3], fn(x) -> rem(x, 2) == 0 end) == [1, 3]
     assert Enum.reject([2, 4, 6], fn(x) -> rem(x, 2) == 0 end) == []


### PR DESCRIPTION
RFC @josevalim — This adds support for `Enum.reduce_while/3` as you suggested, it closes #3402.

Thanks in advance for your feedback!