### PR TITLE
Update Application docs to make them more accurate.

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -123,8 +123,8 @@ defmodule Application do
   @doc """
   Returns the value for `key` in `app`'s environment.
 
-  If the specified application is not loaded, or the configuration parameter
-  does not exist, the function returns the `default` value.
+  If the configuration parameter does not exist, the function returns the
+  `default` value.
   """
   @spec get_env(app, key, value) :: value
   def get_env(app, key, default \\ nil) do
@@ -134,8 +134,7 @@ defmodule Application do
   @doc """
   Returns the value for `key` in `app`'s environment in a tuple.
 
-  If the specified application is not loaded, or the configuration parameter
-  does not exist, the function returns `:error`.
+  If the configuration parameter does not exist, the function returns `:error`.
   """
   @spec fetch_env(app, key) :: {:ok, value} | :error
   def fetch_env(app, key) do
@@ -148,8 +147,7 @@ defmodule Application do
   @doc """
   Returns the value for `key` in `app`'s environment.
 
-  If the specified application is not loaded, or the configuration parameter
-  does not exist, raises `ArgumentError`.
+  If the configuration parameter does not exist, raises `ArgumentError`.
   """
   @spec fetch_env!(app, key) :: value | no_return
   def fetch_env!(app, key) do


### PR DESCRIPTION
The docs claimed that `get_env`/`fetch_env`/`fetch_env!` return
a default value/return :error/raise an exception when passed an
application that is not loaded. However, this is not the observed
behavior:

``` elixir
iex(1)> Application.put_env :foo, :bar, :baz
:ok
iex(2)> Application.get_env :foo, :bar
:baz
```

See https://groups.google.com/forum/#!topic/elixir-lang-talk/5yX9hBNEXe0 for background.

@josevalim, as discussed I didn't mention the exrm issue I ran into but tried to put a general warning that will hopefully help others avoid the issue I ran into.  Let me know if you have any suggestions!