### PR TITLE
Use file alias 'F' for consistency

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -187,7 +187,7 @@ defmodule File do
         {:error, :einval}
       else
         _ = do_mkdir_p(parent)
-        case :file.make_dir(path) do
+        case F.make_dir(path) do
           {:error, :eexist} = error ->
             if dir?(path), do: :ok, else: error
           other ->


### PR DESCRIPTION
The do_mkdir_p function uses :file, which is alias to 'F' at the top of the file.  'F' is used everywhere else.