### PR TITLE
handle completion of erlang module aliases

### DIFF
--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -112,4 +112,27 @@ defmodule IEx.AutocompleteTest do
   test :elixir_completion_sublevel do
     assert expand('IEx.AutocompleteTest.SublevelTest.') == {:yes, 'LevelA.', []}
   end
+
+  defmodule MyServer do
+    def current_env do
+      %Macro.Env{aliases: [{MyList, List}, {EList, :lists}]}
+    end
+  end
+
+  test :complete_aliases_of_elixir_modules do
+    Application.put_env(:iex, :autocomplete_server, MyServer)
+
+    assert expand('MyL') == {:yes, 'ist.', []}
+    assert expand('MyList') == {:yes, '.', []}
+    assert expand('MyList.to_integer') == {:yes, [], ['to_integer/1', 'to_integer/2']}
+  end
+
+  test :complete_aliases_of_erlang_modules do
+    Application.put_env(:iex, :autocomplete_server, MyServer)
+
+    assert expand('EL') == {:yes, 'ist.', []}
+    assert expand('EList') == {:yes, '.', []}
+    assert expand('EList.map') == {:yes, [], ['map/2', 'mapfoldl/3', 'mapfoldr/3']}
+  end
+
 end


### PR DESCRIPTION
Hi,

### The case for complete aliases of Elixir modules works fine.

```elixir
iex(3)> alias List, as: MyList
nil
iex(4)> MyList.
Chars                 delete/2              delete_at/2
duplicate/2           first/1               flatten/1
flatten/2             foldl/3               foldr/3
insert_at/3           keydelete/3           keyfind/4
keymember?/3          keyreplace/4          keysort/2
keystore/4            last/1                replace_at/3
to_atom/1             to_existing_atom/1    to_float/1
to_integer/1          to_integer/2          to_string/1
to_tuple/1            update_at/3           wrap/1
zip/1
```

### The case for complete aliases of Erlang modules crashes.

```elixir
iex(4)> alias :lists, as: MyList
nil
iex(5)> MyList.*** ERROR: Shell process terminated! (^G to start new job) ***

08:16:31.447 [error] Error in process <0.25.0> with exit value: {function_clause,[{'Elixir.Module',split,[<<5 bytes>>],[{file,"lib/module.ex"},{line,888}]},{'Elixir.IEx.Autocomplete','-expand_alias/1-fun-0-',3,[{file,"lib/iex/autocomplete.ex"},{line,161}]},{'Elixir.Enum',do_find_value,3,[{file,"lib/enum...
```

### After fix

```elixir
iex(1)> alias :lists, as: MyList
nil
iex(2)> MyList.
all/2            any/2            append/1         append/2
concat/1         delete/2         droplast/1       dropwhile/2
duplicate/2      filter/2         filtermap/2      flatlength/1
flatmap/2        flatten/1        flatten/2        foldl/3
foldr/3          foreach/2        keydelete/3      keyfind/3
keymap/3         keymember/3      keymerge/3       keyreplace/4
keysearch/3      keysort/2        keystore/4       keytake/3
last/1           map/2            mapfoldl/3       mapfoldr/3
max/1            member/2         merge/1          merge/2
merge/3          merge3/3         min/1            module_info/0
module_info/1    nth/2            nthtail/2        partition/2
prefix/2         reverse/1        reverse/2        rkeymerge/3
rmerge/2         rmerge/3         rmerge3/3        rukeymerge/3
rumerge/2        rumerge/3        rumerge3/3       seq/2
seq/3            sort/1           sort/2           split/2
splitwith/2      sublist/2        sublist/3        subtract/2
suffix/2         sum/1            takewhile/2      ukeymerge/3
ukeysort/2       umerge/1         umerge/2         umerge/3
umerge3/3        unzip/1          unzip3/1         usort/1
usort/2          zf/2             zip/2            zip3/3
zipwith/3        zipwith3/4
```

I stumbled over that because my work with Alchemist. 

I'm not sure it's a proper solution, feedback is highly welcome and appreciated. :smile: 

Cheers

Samuel