### PR TITLE
Allow not implemented tests in ExUnit

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -227,6 +227,27 @@ defmodule ExUnit.Case do
     end
   end
 
+  @doc """
+  Define a not implemented test with a string.
+
+  Provides a convenient macro that allows a test to be
+  defined with a string, but not yet implemented. The
+  resulting test will always fail and print "Not yet
+  implemented" error message.
+
+  ## Examples
+
+      test "this will be a test in future"
+
+  """
+  defmacro test(message) do
+    quote bind_quoted: binding do
+      test = :"test #{message}"
+      ExUnit.Case.__on_definition__(__ENV__, test)
+      def unquote(test)(_), do: flunk("Not yet implemented")
+    end
+  end
+
   @doc false
   defmacro __before_compile__(_) do
     quote do

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -233,7 +233,8 @@ defmodule ExUnit.Case do
   Provides a convenient macro that allows a test to be
   defined with a string, but not yet implemented. The
   resulting test will always fail and print "Not yet
-  implemented" error message.
+  implemented" error message. The resulting test case is
+  also tagged with :not_implemented.
 
   ## Examples
 
@@ -243,7 +244,7 @@ defmodule ExUnit.Case do
   defmacro test(message) do
     quote bind_quoted: binding do
       test = :"test #{message}"
-      ExUnit.Case.__on_definition__(__ENV__, test)
+      ExUnit.Case.__on_definition__(__ENV__, test, [:not_implemented])
       def unquote(test)(_), do: flunk("Not yet implemented")
     end
   end
@@ -258,9 +259,9 @@ defmodule ExUnit.Case do
   end
 
   @doc false
-  def __on_definition__(env, name) do
+  def __on_definition__(env, name, tags \\ []) do
     mod  = env.module
-    tags = Module.get_attribute(mod, :tag) ++ Module.get_attribute(mod, :moduletag)
+    tags = tags ++ Module.get_attribute(mod, :tag) ++ Module.get_attribute(mod, :moduletag)
     tags = tags |> normalize_tags |> Map.merge(%{line: env.line, file: env.file})
 
     test = %ExUnit.Test{name: name, case: mod, tags: tags}

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -138,4 +138,19 @@ defmodule ExUnitTest do
       assert ExUnit.run == %{failures: 0, skipped: 0, total: 1}
     end) =~ "1 test, 0 failure"
   end
+
+  test "it produces error on not implemented tests" do
+    defmodule TestNotImplemented do
+      use ExUnit.Case, async: false
+
+      test "this is not implemented yet"
+    end
+
+    output = capture_io(fn ->
+      assert ExUnit.run == %{failures: 1, skipped: 0, total: 1}
+    end)
+
+    assert output =~ "Not yet implemented"
+    assert output =~ "1 test, 1 failure"
+  end
 end


### PR DESCRIPTION
My usual workflow in, say Rails, is that I first define a bunch of stub tests that look like this:

    test "some behavior"
    test "some other behavior"
    test "something else, maybe"

I have tried that with ExUnit and it exploded with undefined method test/1

This code creates a macro, which handles this situation. Such defined tests will be skipped by the test runner, and appropriate "Not yet implemented" message should be shown.

Please note it is like my first Elixir code I have written, if this is stupid it's totally my fault.