### PR TITLE
highlight differences between assertion LHS & RHS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ $(1): lib/$(1)/ebin/Elixir.$(2).beam lib/$(1)/ebin/$(1).app
 lib/$(1)/ebin/$(1).app: lib/$(1)/mix.exs
 	$(Q) mkdir -p lib/$(1)/_build/shared/lib/$(1)
 	$(Q) cp -R lib/$(1)/ebin lib/$(1)/_build/shared/lib/$(1)/
-	$(Q) cd lib/$(1) && ../../bin/elixir -e 'Mix.start(:permanent, [])' -r mix.exs -e 'Mix.Task.run("compile.app")'
+	$(Q) cd lib/$(1) && ../../bin/elixir -e 'Mix.start(:permanent, [])' -r mix.exs -e 'Mix.Task.run("deps.get")' -e 'Mix.Task.run("deps.compile")' -e 'Mix.Task.run("compile.app")'
 	$(Q) cp lib/$(1)/_build/shared/lib/$(1)/ebin/$(1).app lib/$(1)/ebin/$(1).app
 	$(Q) rm -rf lib/$(1)/_build
 
@@ -44,7 +44,7 @@ lib/$(1)/ebin/Elixir.$(2).beam: $(wildcard lib/$(1)/lib/*.ex) $(wildcard lib/$(1
 
 test_$(1): $(1)
 	@ echo "==> $(1) (exunit)"
-	$(Q) cd lib/$(1) && ../../bin/elixir -r "test/test_helper.exs" -pr "test/**/*_test.exs";
+	$(Q) cd lib/$(1) && ../../bin/elixir -pz deps/*/ebin -r "test/test_helper.exs" -pr "test/**/*_test.exs";
 endef
 
 #==> Compilation tasks

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -198,6 +198,8 @@ defmodule ExUnit do
     * `:seed` - an integer seed value to randomize the test suite
 
     * `:timeout` - set the timeout for the tests (default 60_000 ms)
+
+    * `:diff` - additional command-line options for the git-diff(1) program
   """
   def configure(options) do
     Enum.each options, fn {k, v} ->

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -198,8 +198,6 @@ defmodule ExUnit do
     * `:seed` - an integer seed value to randomize the test suite
 
     * `:timeout` - set the timeout for the tests (default 60_000 ms)
-
-    * `:diff` - additional command-line options for the git-diff(1) program
   """
   def configure(options) do
     Enum.each options, fn {k, v} ->

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -132,7 +132,12 @@ defmodule ExUnit.Formatter do
       [note: if_value(struct.message, &format_banner(&1, formatter)),
        code: if_value(struct.expr, &code_multiline(&1, width)),
        lhs:  if_value(struct.left,  &inspect_multiline(&1, width)),
-       rhs:  if_value(struct.right, &inspect_multiline(&1, width))]
+       rhs:  if_value(struct.right, &inspect_multiline(&1, width)),
+       diff: if_value(struct.left, fn left ->
+               if_value(struct.right, fn right ->
+                 highlight_differences(left, right)
+               end)
+             end)]
 
     fields
     |> filter_interesting_fields
@@ -142,6 +147,41 @@ defmodule ExUnit.Formatter do
 
   defp format_kind_reason(kind, reason, _width, formatter) do
     error_info Exception.format_banner(kind, reason), formatter
+  end
+
+  defp highlight_differences(left, right) do
+    temporary_diff_input_file(left, fn left_file ->
+      temporary_diff_input_file(right, fn right_file ->
+        System.cmd("git", List.flatten(["diff", "--no-index", "--exit-code",
+          "--color-words=\\w+|\\S", Application.get_env(:ex_unit, :diff, []),
+          "--", left_file, right_file]), stderr_to_stdout: true)
+        |> format_diff_output
+      end)
+    end)
+  end
+
+  defp temporary_diff_input_file(input, fun) do
+    temp_file = :test_server.temp_name('.ex_unit_diff') |> to_string
+    try do
+      File.write! temp_file, format_diff_input(input)
+      fun.(temp_file)
+    after
+      File.rm! temp_file
+    end
+  end
+
+  defp format_diff_input(term) do
+    :io_lib.format("~p.~n", [term])
+  end
+
+  defp format_diff_output({_stdout, 0}) do # git-diff(1) found no differences
+    ExUnit.AssertionError.no_value
+  end
+  defp format_diff_output({stdout, 1}) do # git-diff(1) found some differences
+    stdout
+    |> String.replace(~r/\A(?:.*\n){5}/, "") # drop diff and first hunk header
+    |> String.replace(~r/\e\[3\d(?=m)/, "\\0;7", global: true) # reverse video
+    |> String.rstrip(?\n) # chomp the trailing newline from git-diff(1) output
   end
 
   defp filter_interesting_fields(fields) do

--- a/lib/ex_unit/mix.exs
+++ b/lib/ex_unit/mix.exs
@@ -4,7 +4,8 @@ defmodule ExUnit.Mixfile do
   def project do
     [app: :ex_unit,
      version: System.version,
-     build_per_environment: false]
+     build_per_environment: false,
+     deps: deps]
   end
 
   def application do
@@ -24,5 +25,9 @@ defmodule ExUnit.Mixfile do
        refute_receive_timeout: 100,
        timeout: 60_000,
        trace: false]]
+  end
+
+  defp deps do
+    [{:tdiff, git: "https://github.com/tomas-abrahamsson/tdiff.git"}]
   end
 end

--- a/lib/ex_unit/mix.lock
+++ b/lib/ex_unit/mix.lock
@@ -1,0 +1,1 @@
+%{"tdiff": {:git, "https://github.com/tomas-abrahamsson/tdiff.git", "6209eb5bb217cfec4c50f1b07d5b4b2757e84ca4", []}}

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -120,7 +120,7 @@ defmodule ExUnit.FormatterTest do
          code: [1, 2, 3] == [4, 5, 6]
          lhs:  [1, 2, 3]
          rhs:  [4, 5, 6]
-         diff: [#{diff_change(1, 4)},#{diff_change(2, 5)},#{diff_change(3, 6)}].
+         diff: [#{diff_change(1, 4)},#{diff_change(2, 5)},#{diff_change(3, 6)}]
     """
   end
 
@@ -136,7 +136,7 @@ defmodule ExUnit.FormatterTest do
          rhs:  [4,
                 5,
                 6]
-         diff: [#{diff_change(1, 4)},#{diff_change(2, 5)},#{diff_change(3, 6)}].
+         diff: [#{diff_change(1, 4)},#{diff_change(2, 5)},#{diff_change(3, 6)}]
     """
   end
 
@@ -159,12 +159,12 @@ defmodule ExUnit.FormatterTest do
          code: [1, 2, 3] == [4, 2, 6]
          lhs:  [1, 2, 3]
          rhs:  [4, 2, 6]
-         diff: [#{diff_change(1, 4)},2,#{diff_change(3, 6)}].
+         diff: [#{diff_change(1, 4)},2,#{diff_change(3, 6)}]
     """
   end
 
-  test "annotates assertions with highlighted differences only when different" do
-    # this failure is a lie, constructed to make git-diff(1) exit with status 0
+  test "annotates assertions with highlighted differences when LHS != RHS" do
+    # this is a lie, blatantly constructed to give diff the same LHS and RHS
     failure = {:error, %ExUnit.AssertionError{
       message: "Assertion with == failed",
       expr: {:==, [line: 167], [[1, 2, 3], [1, 2, 3]]},
@@ -178,6 +178,7 @@ defmodule ExUnit.FormatterTest do
          lhs:  [1, 2, 3]
          rhs:  [1, 2, 3]
     """
+    # notice that there is no `diff:` section in the message above
   end
 
   defmodule BadInspect do


### PR DESCRIPTION
This patch enhances ExUnit.Formatter.format_kind_reason/4 by adding a
new `diff:` indicator that visually highlights the differences between
the left- and right-hand sides of a failed assertion using git-diff(1).

It also registers a new `:diff` configuration option, which lets users
specify _additional_ command-line options for the git-diff(1) program.

To see this patch in action, try running the following assertions:

    assert "hello world" == "world wide web"
    assert %{a: 1, b: 2} == %{b: 2}
    assert [1, 2, 3] == [4, 2, 6]
    assert :hello == :world
    assert 123 == 426

Although these examples are trivial, this functionality is indispensable
when comparing complex data structures found in real-world test suites.

:camera: Here are some screenshots of the functionality this patch provides:

![selection_057](https://cloud.githubusercontent.com/assets/9863/8290168/13df2026-18d6-11e5-9ff0-bc44d634b85a.png)
![selection_056](https://cloud.githubusercontent.com/assets/9863/8290167/13def772-18d6-11e5-8f80-680d6ed9ceee.png)
![selection_055](https://cloud.githubusercontent.com/assets/9863/8290170/13e29ae4-18d6-11e5-960d-37e86f5b8712.png)

See also https://sunaku.github.io/minitest-colordiff.html#bin-gdiff