### PR TITLE
(possible) fix for the unit test problem of Erlang maps in R18.0

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -555,6 +555,14 @@ defmodule BadStructError do
   end
 end
 
+defmodule BadMapError do
+  defexception [map: nil]
+  
+  def message(exception) do
+    "expected a map, got: #{inspect(exception.map)}"
+  end
+end
+
 defmodule MatchError do
   defexception [term: nil]
 
@@ -672,7 +680,12 @@ defmodule KeyError do
   defexception key: nil, term: nil
 
   def message(exception) do
-    "key #{inspect exception.key} not found in: #{inspect exception.term}"
+    msg = "key #{inspect exception.key} not found"
+    if exception.term != nil do
+      msg <> " in: #{inspect exception.term}"
+    else
+      msg
+    end
   end
 end
 
@@ -769,6 +782,20 @@ defmodule ErlangError do
 
   def normalize({:badmatch, term}, _stacktrace) do
     %MatchError{term: term}
+  end
+  
+  # Erlang R18.0 changed this for various functions in the maps module
+  def normalize({:badmap, map}, _stacktrace) do
+    %BadMapError{map: map}
+  end
+  
+  # Erlang R18.0 changed this for various functions in the maps module
+  def normalize({:badkey, key}, stacktrace) do
+    term = case stacktrace do
+      [{:maps, :update, [_, _, map], []}|_] -> map
+      _                                     -> nil
+    end
+    %KeyError{key: key, term: term }
   end
 
   def normalize({:case_clause, term}, _stacktrace) do

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -84,9 +84,17 @@ defmodule MapTest do
 
   test "update maps" do
     assert %{two_items_map | a: 3} == %{a: 3, b: 2}
-
-    assert_raise ArgumentError, fn ->
-      %{two_items_map | c: 3}
+    
+    # TODO: proper handling of API changes in different Erlang/OTP releases
+    case :erlang.system_info(:otp_release) do
+      '17' ->
+        assert_raise ArgumentError, fn ->
+          %{two_items_map | c: 3}
+        end
+      _ ->
+        assert_raise KeyError, fn ->
+          %{two_items_map | c: 3}
+        end
     end
   end
 


### PR DESCRIPTION
This is a _possible_ fix for the failing test *update maps* with Erlang R18.0. I also tested it with Erlang R17.5.6.

```
> make clean test
==> elixir (exunit)

  1) test update maps (MapTest)
     test/elixir/map_test.exs:85
     Expected exception ArgumentError but got ErlangError (erlang error: {:badkey, :c})
     stacktrace:
       test/elixir/map_test.exs:88
```

I call it "_possible_" because it is based on hints from _James Fish_ (Slacker: @fishcakez) and I am not 100% sure, that it is the _right_ way to do it.