### PR TITLE
Switch mix to using https:// instead of git:// in GitHub URLs

### DIFF
--- a/lib/mix/test/mix/scm/git_test.exs
+++ b/lib/mix/test/mix/scm/git_test.exs
@@ -10,12 +10,24 @@ defmodule Mix.SCM.GitTest do
     assert Mix.SCM.Git.format_lock(lock(ref: "abcdef0"))   == "abcdef0 (ref)"
   end
 
-  test "considers to dep equals if the have the same git and the same opts" do
+  test "considers two dep equals if the have the same git and the same opts" do
     assert Mix.SCM.Git.equal?([git: "foo"], [git: "foo"])
     refute Mix.SCM.Git.equal?([git: "foo"], [git: "bar"])
 
     assert Mix.SCM.Git.equal?([git: "foo", branch: "master"], [git: "foo", branch: "master"])
     refute Mix.SCM.Git.equal?([git: "foo", branch: "master"], [git: "foo", branch: "other"])
+  end
+
+  # TODO: remove this in Elixir v2.0 when this functionality is removed
+  test "considers two GitHub dep equals if they are the same repo and opts match, just different protocols" do
+    git_url = "git://github.com/elixir-lang/elixir.git"
+    https_url = "https://github.com/elixir-lang/elixir.git"
+
+    assert Mix.SCM.Git.equal?([git: git_url], [git: https_url])
+    refute Mix.SCM.Git.equal?([git: "git@github.com:elixir-lang/ecto.git"], [git: https_url])
+
+    assert Mix.SCM.Git.equal?([git: git_url, branch: "master"], [git: https_url, branch: "master"])
+    refute Mix.SCM.Git.equal?([git: git_url, branch: "master"], [git: https_url, branch: "other"])
   end
 
   test "lock should not be taken into account when considering deps equal as the lock is shared" do

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -44,7 +44,7 @@ defmodule Mix.Tasks.DepsTest do
     in_fixture "deps_status", fn ->
       Mix.Tasks.Deps.run []
 
-      assert_received {:mix_shell, :info, ["* ok (git://github.com/elixir-lang/ok.git)"]}
+      assert_received {:mix_shell, :info, ["* ok (https://github.com/elixir-lang/ok.git)"]}
       assert_received {:mix_shell, :info, ["  the dependency is not available, run `mix deps.get`"]}
       assert_received {:mix_shell, :info, ["* invalidvsn (deps/invalidvsn)"]}
       assert_received {:mix_shell, :info, ["  the app file contains an invalid version: :ok"]}
@@ -101,20 +101,20 @@ defmodule Mix.Tasks.DepsTest do
       File.cd!("deps/ok", fn -> System.cmd("git", ["init"]) end)
 
       Mix.Tasks.Deps.run []
-      assert_received {:mix_shell, :info, ["* ok (git://github.com/elixir-lang/ok.git)"]}
+      assert_received {:mix_shell, :info, ["* ok (https://github.com/elixir-lang/ok.git)"]}
       assert_received {:mix_shell, :info, ["  the dependency is not locked"]}
 
       Mix.Dep.Lock.write %{ok: {:git, "git://github.com/elixir-lang/ok.git", "abcdefghi", []}}
       Mix.Tasks.Deps.run []
 
-      assert_received {:mix_shell, :info, ["* ok (git://github.com/elixir-lang/ok.git)"]}
+      assert_received {:mix_shell, :info, ["* ok (https://github.com/elixir-lang/ok.git)"]}
       assert_received {:mix_shell, :info, ["  locked at abcdefg"]}
       assert_received {:mix_shell, :info, ["  lock mismatch: the dependency is out of date (run `mix deps.get` to fetch locked version)"]}
 
       Mix.Dep.Lock.write %{ok: {:git, "git://github.com/elixir-lang/another.git", "abcdefghi", []}}
       Mix.Tasks.Deps.run []
 
-      assert_received {:mix_shell, :info, ["* ok (git://github.com/elixir-lang/ok.git)"]}
+      assert_received {:mix_shell, :info, ["* ok (https://github.com/elixir-lang/ok.git)"]}
       assert_received {:mix_shell, :info, ["  lock outdated: the lock is outdated compared to the options in your mixfile"]}
     end
   end
@@ -135,7 +135,7 @@ defmodule Mix.Tasks.DepsTest do
         Mix.Tasks.Deps.Check.run []
       end
 
-      assert_received {:mix_shell, :error, ["* ok (git://github.com/elixir-lang/ok.git)"]}
+      assert_received {:mix_shell, :error, ["* ok (https://github.com/elixir-lang/ok.git)"]}
       assert_received {:mix_shell, :error, ["  the dependency is not available, run `mix deps.get`"]}
       assert_received {:mix_shell, :error, ["* invalidvsn (deps/invalidvsn)"]}
       assert_received {:mix_shell, :error, ["  the app file contains an invalid version: :ok"]}


### PR DESCRIPTION
This is a proposal solution for problem described here:
https://github.com/elixir-lang/elixir/issues/3424

I am not 100% sure if the solution is correct. I have implemented it in the way that the check is performed on dependency resolution, where git repo urls are compared. The URL is normalized to be https:// before comparing old one and new one.

I have checked that works as expected on my projects. It does not prompt for update dependencies when upgrading to use Elixir with this change. The mix.lock file was also *not* changed. Only on the next `mix deps.update --all`, the `git://` protocol in mix.lock is replaced with `https://` and new mix.lock file is being saved.