### PR TITLE
Support dialyzer attribute

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -261,6 +261,29 @@ defmodule Module do
       Tools like Mix may use this information to ensure the module is
       recompiled in case any of the external resources change.
 
+    * `@dialyzer`
+
+      Defines warnings to request or suppress when using a version of
+      `dialyzer` that supports module attributes.
+
+      Accepts an atom, a tuple, or a list of atoms and tuples.
+
+      See http://www.erlang.org/doc/man/dialyzer.html for the list of supported
+      warnings.
+
+      Several uses of `@dialyzer` will accumulate instead of overriding
+      previous ones.
+
+      ### Example
+
+            defmodule M do
+              @dialyzer {:nowarn_function, myfun: 1}
+
+              def myfun(arg) do
+                M.not_a_function(arg)
+              end
+            end
+
   The following attributes are part of typespecs and are also reserved by
   Elixir (see `Kernel.Typespec` for more information about typespecs):
 

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -150,7 +150,7 @@ build(Line, File, Module, Docs, Lexical) ->
     end,
   ets:insert(Data, {on_definition, OnDefinition}),
 
-  Attributes = [behaviour, on_load, compile, external_resource],
+  Attributes = [behaviour, on_load, compile, external_resource, dialyzer],
   ets:insert(Data, {?acc_attr, [before_compile, after_compile, on_definition, derive,
                                 spec, type, typep, opaque, callback|Attributes]}),
   ets:insert(Data, {?persisted_attr, [vsn|Attributes]}),


### PR DESCRIPTION
18.0 adds support for `dialyzer` module attribute http://www.erlang.org/doc/man/dialyzer.html#suppression. I think we are ok to merge this to master but am unsure on the requirements, versus waiting for 1.2.

* Just a module attribute so it does not require 18.0
* Attribute warning suppression will only work when using dialyzer from 18.0+
* Can compile a project on 17.* and use dialyzer from 18.0+