### PR TITLE
Mix new --umbrella: use only umbrella template for config.exs, not both umbrella and normal

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -127,7 +127,7 @@ defmodule Mix.Tasks.New do
 
     create_directory "config"
     create_file "config/config.exs",
-      config_template(assigns) <> config_umbrella_template(assigns)
+      config_umbrella_template(assigns)
 
     Mix.shell.info """
 


### PR DESCRIPTION
In 88be750a the `config_umbrella` template was changed to work on its own, not as an addendum to the config template. But the create_file call still concatenated them together, giving redundant text and two `use Mix.Config` calls (see below).
```
# This file is responsible for configuring your application
# and its dependencies with the aid of the Mix.Config module.
use Mix.Config

# This configuration is loaded before any dependency and is restricted
# to this project. If another project depends on this project, this
# file won't be loaded nor affect the parent project. For this reason,
# if you want to provide default values for your application for third-
# party users, it should be done in your mix.exs file.

# Sample configuration:
#
#     config :logger, :console,
#       level: :info,
#       format: "$date $time [$level] $metadata$message\n",
#       metadata: [:user_id]

# It is also possible to import configuration files, relative to this
# directory. For example, you can emulate configuration per environment
# by uncommenting the line below and defining dev.exs, test.exs and such.
# Configuration from the imported file will override the ones defined
# here (which is why it is important to import them last).
#
#     import_config "#{Mix.env}.exs"
# This file is responsible for configuring your application
# and its dependencies with the aid of the Mix.Config module.
use Mix.Config

# The configuration defined here will only affect the dependencies
# in the apps directory when commands are executed from the umbrella
# project. For this reason, it is preferred to configure each child
# application directly and import its configuration, as done below.
import_config "../apps/*/config/config.exs"

# Sample configuration (overrides the imported configuration above):
#
#     config :logger, :console,
#       level: :info,
#       format: "$date $time [$level] $metadata$message\n",
#       metadata: [:user_id]
```