### PR TITLE
sync documentation with code

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.ex
+++ b/lib/mix/lib/mix/tasks/compile.ex
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.Compile do
   ## Configuration
 
     * `:compilers` - compilers to run, defaults to:
-      `[:leex, :yeec, :erlang, :elixir, :app]`
+      `[:yeec, :leex, :erlang, :elixir, :app]`
 
     * `:consolidate_protocols` - when true, runs protocol
       consolidation via the `compile.protocols` task


### PR DESCRIPTION
The return value of Mix.compilers() is `[:yecc, :leex, :erlang, :elixir, :app]`