### PR TITLE
RFC: Add a mix generate task (proof of concept)

### DIFF
--- a/lib/mix/lib/mix/generator.ex
+++ b/lib/mix/lib/mix/generator.ex
@@ -58,7 +58,7 @@ defmodule Mix.Generator do
         end
 
       require EEx
-      EEx.function_from_string :defp, :"#{name}_template", "<% _ = assigns %>" <> contents, [:assigns]
+      EEx.function_from_string :def, :"#{name}_template", "<% _ = assigns %>" <> contents, [:assigns]
     end
   end
 

--- a/lib/mix/lib/mix/tasks/generate.ex
+++ b/lib/mix/lib/mix/tasks/generate.ex
@@ -4,6 +4,21 @@ defmodule Mix.Tasks.Generate do
   import Mix.Generator
   import Mix.Templates
 
+  @shortdoc "Generate boilerplate code from templates"
+
+  @moduledoc """
+  Generate boilerplate code from templates
+
+    mix generate GENERATOR CAMELISED_NAME
+
+  Where GENERATOR is one of:
+
+    module   Generate a module
+
+  And CAMELISED_NAME is a module name like MyModuleName or
+  MyNameSpace.MyModuleName.
+  """
+
   def run(["module", module_name]) do
     create_file module_file_path(module_name), lib_template([mod: module_name])
   end

--- a/lib/mix/lib/mix/tasks/generate.ex
+++ b/lib/mix/lib/mix/tasks/generate.ex
@@ -1,0 +1,14 @@
+defmodule Mix.Tasks.Generate do
+  use Mix.Task
+
+  import Mix.Generator
+  import Mix.Templates
+
+  def run(["module", module_name]) do
+    create_file module_file_path(module_name), lib_template([mod: module_name])
+  end
+
+  defp module_file_path(module_name) do
+    Path.join("lib", "#{Mix.Utils.underscore(module_name)}.ex")
+  end
+end

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -89,7 +89,7 @@ defmodule Mix.Tasks.New do
     if opts[:sup] do
       create_file "lib/#{app}.ex", lib_sup_template(assigns)
     else
-      create_file "lib/#{app}.ex", lib_template(assigns)
+      create_file "lib/#{app}.ex", Mix.Templates.lib_template(assigns)
     end
 
     create_directory "test"
@@ -372,11 +372,6 @@ defmodule Mix.Tasks.New do
   #       level: :info,
   #       format: "$date $time [$level] $metadata$message\n",
   #       metadata: [:user_id]
-  """
-
-  embed_template :lib, """
-  defmodule <%= @mod %> do
-  end
   """
 
   embed_template :lib_sup, """

--- a/lib/mix/lib/mix/templates.ex
+++ b/lib/mix/lib/mix/templates.ex
@@ -1,0 +1,12 @@
+defmodule Mix.Templates do
+  import Mix.Generator
+
+  @moduledoc """
+  Defines shared templates for use by tasks that generate files.
+  """
+
+  embed_template :lib, """
+  defmodule <%= @mod %> do
+  end
+  """
+end

--- a/lib/mix/test/mix/tasks/generate_test.exs
+++ b/lib/mix/test/mix/tasks/generate_test.exs
@@ -1,0 +1,17 @@
+Code.require_file "../../test_helper.exs", __DIR__
+
+defmodule Mix.Tasks.GenerateTest do
+  use MixTest.Case
+
+  test "generate module: creates new module file" do
+    in_tmp "generate_module", fn ->
+      Mix.Tasks.Generate.run ["module", "ModName"]
+
+      assert_file "lib/mod_name.ex"
+
+      assert_file "lib/mod_name.ex", fn (file) ->
+        assert file =~ "defmodule ModName do"
+      end
+    end
+  end
+end

--- a/lib/mix/test/mix/tasks/new_test.exs
+++ b/lib/mix/test/mix/tasks/new_test.exs
@@ -152,18 +152,4 @@ defmodule Mix.Tasks.NewTest do
       end
     end
   end
-
-  defp assert_file(file) do
-    assert File.regular?(file), "Expected #{file} to exist, but does not"
-  end
-
-  defp assert_file(file, match) do
-    cond do
-      Regex.regex?(match) ->
-        assert_file file, &(assert &1 =~ match)
-      is_function(match, 1) ->
-        assert_file(file)
-        match.(File.read!(file))
-    end
-  end
 end

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -34,6 +34,20 @@ defmodule MixTest.Case do
     :ok
   end
 
+  def assert_file(file) do
+    assert File.regular?(file), "Expected #{file} to exist, but does not"
+  end
+
+  def assert_file(file, match) do
+    cond do
+      Regex.regex?(match) ->
+        assert_file file, &(assert &1 =~ match)
+      is_function(match, 1) ->
+        assert_file(file)
+        match.(File.read!(file))
+    end
+  end
+
   def fixture_path do
     Path.expand("fixtures", __DIR__)
   end


### PR DESCRIPTION
Hi

This is a proof of concept of adding a `mix generate` task that reuses some of the templates from the `new` task.

It's incomplete as I wanted to see how easy it would be to do and get some early feedback on whether this task would be useful.

The interface would be something like:

```
$ mix generate module MyApp.MyModule
$ mix generate test MyApp.MyModuleTest
...
```

And so on, depending on what else would be useful (e.g. maybe a combined `module_with_test` option).

The only thing implemented at this moment is `mix generate module`.

Looking forward to hearing your thoughts.

Thanks :)