### PR TITLE
Support rebar3 style git refs in rebar.config files

### DIFF
--- a/lib/mix/lib/mix/rebar.ex
+++ b/lib/mix/lib/mix/rebar.ex
@@ -101,6 +101,7 @@ defmodule Mix.Rebar do
         [""|_]                -> [branch: "HEAD"]
         [{:branch, branch}|_] -> [branch: to_string(branch)]
         [{:tag, tag}|_]       -> [tag: to_string(tag)]
+        [{:ref, ref}|_]       -> [ref: to_string(ref)]
         [ref|_]               -> [ref: to_string(ref)]
         _                     -> []
       end

--- a/lib/mix/test/mix/rebar_test.exs
+++ b/lib/mix/test/mix/rebar_test.exs
@@ -43,6 +43,11 @@ defmodule Mix.RebarTest do
     config = [deps: [{:git_rebar, '0.1..*', {:git, '../../test/fixtures/git_rebar'}, [:raw]}]]
     assert [{:git_rebar, ~r"0.1..*", [git: "../../test/fixtures/git_rebar", compile: false]}] ==
            Mix.Rebar.deps(config)
+
+    config = [deps: [{:git_rebar, '', {:git, '../../test/fixtures/git_rebar', {:ref, '64691eb'}}}]]
+    assert [{:git_rebar, ~r"", [git: "../../test/fixtures/git_rebar", ref: "64691eb"]}] ==
+           Mix.Rebar.deps(config)
+
   end
 
   test "parse rebar dependencies from rebar.config" do


### PR DESCRIPTION
Rebar3 uses a slightly different style for specifying specific refs when
defining dependencies. http://www.rebar3.org/v3.0/docs/dependencies