### PR TITLE
Fix implementation of Stack module which doesn't fit to the Supervisor implementation

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -20,7 +20,7 @@ defmodule Supervisor do
       defmodule Stack do
         use GenServer
 
-        def start_link(state, opts) do
+        def start_link(state, opts \\ []) do
           GenServer.start_link(__MODULE__, state, opts)
         end
 


### PR DESCRIPTION
Supervisor uses Stack implementation where exists start_link/1 function but at the top of this documentation page there is no impelementation of that function so we have to make second parameter of start_link/2 function optional