### PR TITLE
Split handle_call and handle_cast callbacks in GenServer docs

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -73,8 +73,8 @@ defmodule GenServer do
       -  `:ignore`
       -  `{:stop, reason}`
 
-    * `handle_call(msg, {from, ref}, state)` and `handle_cast(msg, state)` -
-      invoked to handle call (sync) and cast (async) messages.
+    * `handle_call(msg, {from, ref}, state)` - invoked to handle call (sync)
+       messages.
 
       It must return:
 
@@ -86,6 +86,15 @@ defmodule GenServer do
       -  `{:noreply, new_state, :hibernate}`
       -  `{:stop, reason, new_state}`
       -  `{:stop, reason, reply, new_state}`
+
+    * `handle_cast(msg, state)` - invoked to handle cast (async) messages.
+
+      It must return:
+
+      -  `{:noreply, new_state}`
+      -  `{:noreply, new_state, timeout}`
+      -  `{:noreply, new_state, :hibernate}`
+      -  `{:stop, reason, new_state}`
 
     * `handle_info(msg, state)` - invoked to handle all other messages which
       are received by the process.


### PR DESCRIPTION
It's my understanding that the valid return values for handle_cast are different from the ones for handle_call.

The Erlang docs are not very clear on that matter but I gathered that form multiple source across the web (i.e http://learnyousomeerlang.com/clients-and-servers). If that's incorrect I'd love to understand why.

I find the current format not very clear anyway as it's easy to miss the `handle_cast`, so I'd probably be in favour of re-arranging it if possible.

