### PR TITLE
update url to use https. standardize erlang.org/doc links to use www

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,11 @@ Use the issues tracker for:
 
 Please **do not** use the issue tracker for personal support requests nor feature requests. Support requests should be sent to:
 
-* [the elixir-talk mailing list](http://groups.google.com/group/elixir-lang-talk)
+* [the elixir-talk mailing list](https://groups.google.com/group/elixir-lang-talk)
 * [Stack Overflow](http://stackoverflow.com/questions/ask?tags=elixir)
 * **[#elixir-lang](irc://chat.freenode.net/elixir-lang)** IRC channel on [chat.freenode.net](http://www.freenode.net/)
 
-Feature requests can be discussed on [the elixir-core mailing list](http://groups.google.com/group/elixir-lang-core).
+Feature requests can be discussed on [the elixir-core mailing list](https://groups.google.com/group/elixir-lang-core).
 
 We do our best to keep the issue tracker tidy and organized, making it useful
 for everyone. For example, we classify open issues per application and perceived
@@ -64,7 +64,7 @@ Example:
 
 ## Feature requests
 
-Feature requests are welcome and should be discussed on [the elixir-core mailing list](http://groups.google.com/group/elixir-lang-core). But take a moment to find
+Feature requests are welcome and should be discussed on [the elixir-core mailing list](https://groups.google.com/group/elixir-lang-core). But take a moment to find
 out whether your idea fits with the scope and aims of the project. It's up to *you*
 to make a strong case to convince the community of the merits of this feature.
 Please provide as much detail and context as possible.
@@ -186,7 +186,7 @@ accurate comments, etc.) and don't forget to add your own tests and
 documentation. When working with git, we recommend the following process
 in order to craft an excellent pull request:
 
-1. [Fork](http://help.github.com/fork-a-repo/) the project, clone your fork,
+1. [Fork](https://help.github.com/fork-a-repo/) the project, clone your fork,
    and configure the remotes:
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Elixir](https://github.com/elixir-lang/elixir-lang.github.com/raw/master/images/logo/logo.png)
 =========
-[![Build Status](https://secure.travis-ci.org/elixir-lang/elixir.svg?branch=master "Build Status")](http://travis-ci.org/elixir-lang/elixir)
+[![Build Status](https://secure.travis-ci.org/elixir-lang/elixir.svg?branch=master "Build Status")](https://travis-ci.org/elixir-lang/elixir)
 
 For more about Elixir, installation and documentation, [check Elixir's website](http://elixir-lang.org/).
 
@@ -48,8 +48,8 @@ We appreciate any contribution to Elixir, so check out our [CONTRIBUTING.md](CON
 
   [1]: http://elixir-lang.org
   [2]: https://github.com/elixir-lang/elixir/issues
-  [3]: http://groups.google.com/group/elixir-lang-talk
-  [4]: http://groups.google.com/group/elixir-lang-core
+  [3]: https://groups.google.com/group/elixir-lang-talk
+  [4]: https://groups.google.com/group/elixir-lang-core
   [5]: irc://chat.freenode.net/elixir-lang
   [6]: http://www.freenode.net/
   [7]: http://elixir-lang.org/docs.html

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1552,7 +1552,7 @@ defmodule Enum do
       :random.seed(:os.timestamp)
 
   The implementation is based on the
-  [reservoir sampling](http://en.wikipedia.org/wiki/Reservoir_sampling#Relation_to_Fisher-Yates_shuffle)
+  [reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling#Relation_to_Fisher-Yates_shuffle)
   algorithm.
   It assumes that the sample being returned can fit into memory;
   the input collection doesn't have to - it is traversed just once.

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -17,7 +17,7 @@ end
 defmodule IO.ANSI do
   @moduledoc """
   Functionality to render ANSI escape sequences
-  (http://en.wikipedia.org/wiki/ANSI_escape_code) —  characters embedded
+  (https://en.wikipedia.org/wiki/ANSI_escape_code) —  characters embedded
   in text used to control formatting, color, and other output options
   on video text terminals.
   """

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -245,7 +245,7 @@ defmodule Kernel.SpecialForms do
   Sizes for types are a bit more nuanced. The default size for integers is 8.
 
   For floats, it is 64. For floats, `size * unit` must result in 32 or 64,
-  corresponding to [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point)
+  corresponding to [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point)
   binary32 and binary64, respectively.
 
   For binaries, the default is the size of the binary. Only the last binary in a

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -579,7 +579,7 @@ defmodule List do
 
   Notice that this function expects a list of integers representing
   UTF-8 codepoints. If you have a list of bytes, you must instead use
-  [the `:binary` module](http://erlang.org/doc/man/binary.html).
+  [the `:binary` module](http://www.erlang.org/doc/man/binary.html).
 
   ## Examples
 

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -325,7 +325,7 @@ defmodule Module do
 
   In addition to the above, you may also pass to `__info__/1` any atom supported
   by Erlang's `module_info` function which also gets defined for each compiled
-  module. See http://erlang.org/doc/reference_manual/modules.html#id75777 for
+  module. See http://www.erlang.org/doc/reference_manual/modules.html#id75777 for
   more information.
   """
   def __info__(kind)

--- a/lib/elixir/lib/node.ex
+++ b/lib/elixir/lib/node.ex
@@ -141,7 +141,7 @@ defmodule Node do
   Returns `true` if successful, `false` if not, and the atom
   `:ignored` if the local node is not alive.
 
-  See http://erlang.org/doc/man/net_kernel.html#connect_node-1 for more info.
+  See http://www.erlang.org/doc/man/net_kernel.html#connect_node-1 for more info.
   """
   @spec connect(t) :: boolean | :ignored
   def connect(node) do

--- a/lib/elixir/lib/port.ex
+++ b/lib/elixir/lib/port.ex
@@ -4,7 +4,7 @@ defmodule Port do
   """
 
   @doc """
-  See http://www.erlang.org/doc/man/erlang.html#open_port-2.
+  See http://www.erlang.org/doc/man/erlang.html#open_port-2
 
   Inlined by the compiler.
   """
@@ -13,7 +13,7 @@ defmodule Port do
   end
 
   @doc """
-  See http://www.erlang.org/doc/man/erlang.html#port_close-1.
+  See http://www.erlang.org/doc/man/erlang.html#port_close-1
 
   Inlined by the compiler.
   """
@@ -22,7 +22,7 @@ defmodule Port do
   end
 
   @doc """
-  See http://www.erlang.org/doc/man/erlang.html#port_command-2.
+  See http://www.erlang.org/doc/man/erlang.html#port_command-2
 
   Inlined by the compiler.
   """
@@ -31,7 +31,7 @@ defmodule Port do
   end
 
   @doc """
-  See http://www.erlang.org/doc/man/erlang.html#port_connect-2.
+  See http://www.erlang.org/doc/man/erlang.html#port_connect-2
 
   Inlined by the compiler.
   """
@@ -40,7 +40,7 @@ defmodule Port do
   end
 
   @doc """
-  See http://www.erlang.org/doc/man/erlang.html#port_control-3.
+  See http://www.erlang.org/doc/man/erlang.html#port_control-3
 
   Inlined by the compiler.
   """
@@ -49,7 +49,7 @@ defmodule Port do
   end
 
   @doc """
-  See http://www.erlang.org/doc/man/erlang.html#port_call-3.
+  See http://www.erlang.org/doc/man/erlang.html#port_call-3
 
   Inlined by the compiler.
   """
@@ -61,7 +61,7 @@ defmodule Port do
   Returns information about the `port`
   or `nil` if the port is closed.
 
-  See http://www.erlang.org/doc/man/erlang.html#port_info-1.
+  See http://www.erlang.org/doc/man/erlang.html#port_info-1
   """
   def info(port) do
     nillify :erlang.port_info(port)
@@ -71,7 +71,7 @@ defmodule Port do
   Returns information about the `port`
   or `nil` if the port is closed.
 
-  See http://www.erlang.org/doc/man/erlang.html#port_info-2.
+  See http://www.erlang.org/doc/man/erlang.html#port_info-2
   """
   @spec info(port, atom) :: {atom, term} | nil
   def info(port, spec)
@@ -88,7 +88,7 @@ defmodule Port do
   end
 
   @doc """
-  See http://www.erlang.org/doc/man/erlang.html#ports-0.
+  See http://www.erlang.org/doc/man/erlang.html#ports-0
 
   Inlined by the compiler.
   """

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -67,7 +67,7 @@ defmodule String do
     * `Kernel.bit_size/1` and `Kernel.byte_size/1` - size related functions
     * `Kernel.is_bitstring/1` and `Kernel.is_binary/1` - type checking function
     * Plus a number of functions for working with binaries (bytes)
-      [in the `:binary` module](http://erlang.org/doc/man/binary.html)
+      [in the `:binary` module](http://www.erlang.org/doc/man/binary.html)
 
   There are many situations where using the `String` module can
   be avoided in favor of binary functions or pattern matching.
@@ -1388,7 +1388,7 @@ defmodule String do
   strings.
 
   In case you need to work with bytes, take a look at the
-  [`:binary` module](http://erlang.org/doc/man/binary.html).
+  [`:binary` module](http://www.erlang.org/doc/man/binary.html).
 
   ## Examples
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -870,7 +870,7 @@ defmodule String do
   are not valid characters. They may be reserved, private,
   or other.
 
-  More info at: http://en.wikipedia.org/wiki/Mapping_of_Unicode_characters#Noncharacters
+  More info at: https://en.wikipedia.org/wiki/Universal_Character_Set_characters#Non-characters
 
   ## Examples
 
@@ -1509,7 +1509,7 @@ defmodule String do
 
   @doc """
   Returns a float value between 0 (equates to no similarity) and 1 (is an exact match)
-  representing [Jaro](http://en.wikipedia.org/wiki/Jaro–Winkler_distance)
+  representing [Jaro](https://en.wikipedia.org/wiki/Jaro–Winkler_distance)
   distance between `str1` and `str2`.
 
   The Jaro distance metric is designed and best suited for short strings such as person names.

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -272,10 +272,10 @@ defmodule IO.ANSI.DocsTest do
   end
 
   test "escaping of underlines within links" do
-    result = format("(http://en.wikipedia.org/wiki/ANSI_escape_code)")
-    assert result == "(http://en.wikipedia.org/wiki/ANSI_escape_code)\n\e[0m"
-    result = format("[ANSI escape code](http://en.wikipedia.org/wiki/ANSI_escape_code)")
-    assert result == "ANSI escape code (http://en.wikipedia.org/wiki/ANSI_escape_code)\n\e[0m"
+    result = format("(https://en.wikipedia.org/wiki/ANSI_escape_code)")
+    assert result == "(https://en.wikipedia.org/wiki/ANSI_escape_code)\n\e[0m"
+    result = format("[ANSI escape code](https://en.wikipedia.org/wiki/ANSI_escape_code)")
+    assert result == "ANSI escape code (https://en.wikipedia.org/wiki/ANSI_escape_code)\n\e[0m"
   end
 
   test "lone thing that looks like a table line isn't" do

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -1,7 +1,7 @@
 defmodule ExUnit.DocTest do
   @moduledoc """
   ExUnit.DocTest implements functionality similar to [Python's
-  doctest](http://docs.python.org/2/library/doctest.html).
+  doctest](https://docs.python.org/2/library/doctest.html).
 
   In a nutshell, it allows us to generate tests from the code
   examples existing in a module/function/macro's documentation.

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -56,7 +56,7 @@ defmodule Mix do
   ## Dependencies
 
   Another important feature in Mix is that it is able to manage your
-  dependencies and integrates nicely with [the Hex package manager](http://hex.pm).
+  dependencies and integrates nicely with [the Hex package manager](https://hex.pm).
 
   In order to use dependencies, you just need to add a `:deps` key
   to your project configuration. We often extract the dependencies

--- a/lib/mix/lib/mix/tasks/compile.leex.ex
+++ b/lib/mix/lib/mix/tasks/compile.leex.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Compile.Leex do
 
     * `:leex_options` - compilation options that apply
       to Leex's compiler. There are many available options
-      here: http://www.erlang.org/doc/man/leex.html#file-2.
+      here: http://www.erlang.org/doc/man/leex.html#file-2
 
   """
 

--- a/lib/mix/lib/mix/tasks/compile.yecc.ex
+++ b/lib/mix/lib/mix/tasks/compile.yecc.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Compile.Yecc do
 
     * `:yecc_options` - compilation options that apply
       to Yecc's compiler. There are many other available
-      options here: http://www.erlang.org/doc/man/yecc.html#file-1.
+      options here: http://www.erlang.org/doc/man/yecc.html#file-1
 
   """
 

--- a/man/elixir.1.in
+++ b/man/elixir.1.in
@@ -48,6 +48,6 @@ This manual page contributed by Evgeny Golyshev.
 .Bl -tag -width Ds
 .It Main website: http://elixir-lang.org
 .It Documentation: http://elixir-lang.org/docs.html
-.It General Mailing List: http://groups.google.com/group/elixir-lang-talk
-.It Development Mailing List: http://groups.google.com/group/elixir-lang-core
+.It General Mailing List: https://groups.google.com/group/elixir-lang-talk
+.It Development Mailing List: https://groups.google.com/group/elixir-lang-core
 .El

--- a/man/elixirc.1
+++ b/man/elixirc.1
@@ -49,6 +49,6 @@ This manual page contributed by Evgeny Golyshev.
 .Bl -tag -width Ds
 .It Main website: http://elixir-lang.org
 .It Documentation: http://elixir-lang.org/docs.html
-.It General Mailing List: http://groups.google.com/group/elixir-lang-talk
-.It Development Mailing List: http://groups.google.com/group/elixir-lang-core
+.It General Mailing List: https://groups.google.com/group/elixir-lang-talk
+.It Development Mailing List: https://groups.google.com/group/elixir-lang-core
 .El

--- a/man/iex.1.in
+++ b/man/iex.1.in
@@ -58,6 +58,6 @@ This manual page contributed by Evgeny Golyshev.
 .Bl -tag -width Ds
 .It Main website: http://elixir-lang.org
 .It Documentation: http://elixir-lang.org/docs.html
-.It General Mailing List: http://groups.google.com/group/elixir-lang-talk
-.It Development Mailing List: http://groups.google.com/group/elixir-lang-core
+.It General Mailing List: https://groups.google.com/group/elixir-lang-talk
+.It Development Mailing List: https://groups.google.com/group/elixir-lang-core
 .El

--- a/man/mix.1
+++ b/man/mix.1
@@ -127,8 +127,8 @@ Allows locking down the project dependencies with a proper version range before 
 .El
 .Sh REFERENCES
 .Bl -tag -width Ds
-.It [1] http://erlang.org/doc/man/code.html#id103620
-.It [2] http://erlang.org/doc/design_principles/applications.html
+.It [1] http://www.erlang.org/doc/man/code.html#id103620
+.It [2] http://www.erlang.org/doc/design_principles/applications.html
 .El
 .Sh SEE ALSO
 .Xr elixir 1 ,

--- a/man/mix.1
+++ b/man/mix.1
@@ -140,6 +140,6 @@ This manual page contributed by Evgeny Golyshev.
 .Bl -tag -width Ds
 .It Main website: http://elixir-lang.org
 .It Documentation: http://elixir-lang.org/docs.html
-.It General Mailing List: http://groups.google.com/group/elixir-lang-talk
-.It Development Mailing List: http://groups.google.com/group/elixir-lang-core
+.It General Mailing List: https://groups.google.com/group/elixir-lang-talk
+.It Development Mailing List: https://groups.google.com/group/elixir-lang-core
 .El


### PR DESCRIPTION
* update URL where the used http link redirects to https, and as well when a package is provided and the https link is available.
* remove period adjacent to URLs.
* standardize erlang.org/doc links to use www

* also update a wikipedia link that redirected to a different page ( https://en.wikipedia.org/wiki/Universal_Character_Set_characters#Non-characters)