### PR TITLE
Enum.take_every/1: remove unnecesary Module reference

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2038,7 +2038,7 @@ defmodule Enum do
 
   """
   @spec take_every(t, non_neg_integer) :: list
-  def take_every(collection, 1), do: Enum.to_list(collection)
+  def take_every(collection, 1), do: to_list(collection)
   def take_every(_collection, 0), do: []
   def take_every([], _nth), do: []
 


### PR DESCRIPTION
as suggested by @lexmag in https://github.com/elixir-lang/elixir/pull/3489/files#r34588122