### PR TITLE
Clarify which call sets up the Task monitor

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -27,10 +27,10 @@ defmodule Task do
   the task action finishes, a message will be sent to the caller
   with the result.
 
-  `Task.await/2` is used to read the message sent by the task. On
-  `await`, Elixir will also setup a monitor to verify if the process
-  exited for any abnormal reason (or in case exits are being
-  trapped by the caller).
+  `Task.await/2` is used to read the message sent by the task.
+  `await` will check the monitor setup by the call to `async/1' to
+  verify if the process exited for any abnormal reason (or in case
+  exits are being trapped by the caller).
 
   ## Supervised tasks
 


### PR DESCRIPTION
Just thought I'd check how Elixir implemented monitoring for Task and noticed this in the documentation. This brings it in line with what I see in the code.