### PR TITLE
Make pipe indentation more consistent

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -341,9 +341,9 @@ defmodule Kernel.Typespec do
     body = {name, meta, Enum.map(args, &typespec_to_ast/1)}
 
     vars = args ++ [result]
-      |> Enum.flat_map(&collect_vars/1)
-      |> Enum.uniq
-      |> Enum.map(&{&1, {:var, meta, nil}})
+           |> Enum.flat_map(&collect_vars/1)
+           |> Enum.uniq
+           |> Enum.map(&{&1, {:var, meta, nil}})
 
     spec = {:::, meta, [body, typespec_to_ast(result)]}
 

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -482,9 +482,9 @@ defmodule Stream do
   without loading the whole file in memory:
 
       stream = File.stream!("code")
-      |> Stream.map(&String.replace(&1, "#", "%"))
-      |> Stream.into(File.stream!("new"))
-      |> Stream.run
+               |> Stream.map(&String.replace(&1, "#", "%"))
+               |> Stream.into(File.stream!("new"))
+               |> Stream.run
 
   No computation will be done until we call one of the Enum functions
   or `Stream.run/1`.

--- a/lib/logger/lib/logger/app.ex
+++ b/lib/logger/lib/logger/app.ex
@@ -69,7 +69,7 @@ defmodule Logger.App do
         delete? && :error_logger.delete_report_handler(handler) != {:error, :module_not_found}
       end
     [] = Enum.filter_map(handlers, deleted?, fn({handler, _}) -> handler end)
-        |> Logger.Config.deleted_handlers()
+         |> Logger.Config.deleted_handlers()
     :ok
   end
 

--- a/lib/mix/lib/mix/dep/fetcher.ex
+++ b/lib/mix/lib/mix/dep/fetcher.ex
@@ -98,7 +98,7 @@ defmodule Mix.Dep.Fetcher do
     if Enum.all?(all_deps, &available?/1) do
       deps = (with_depending(deps, all_deps) ++
               Enum.filter(all_deps, fn dep -> not ok?(dep) end))
-             |> Enum.uniq(&(&1.app))
+              |> Enum.uniq(&(&1.app))
     end
 
     # Merge the new lock on top of the old to guarantee we don't

--- a/lib/mix/lib/mix/rebar.ex
+++ b/lib/mix/lib/mix/rebar.ex
@@ -75,11 +75,11 @@ defmodule Mix.Rebar do
 
   def recur(config, fun) do
     subs = (config[:sub_dirs] || [])
-     |> Enum.map(&Path.wildcard(&1))
-     |> Enum.concat
-     |> Enum.filter(&File.dir?(&1))
-     |> Enum.map(&recur(&1, fun))
-     |> Enum.concat
+           |> Enum.map(&Path.wildcard(&1))
+           |> Enum.concat
+           |> Enum.filter(&File.dir?(&1))
+           |> Enum.map(&recur(&1, fun))
+           |> Enum.concat
 
     [fun.(config)|subs]
   end

--- a/lib/mix/lib/mix/shell.ex
+++ b/lib/mix/lib/mix/shell.ex
@@ -108,8 +108,8 @@ defmodule Mix.Shell do
     case :os.type do
       {:unix, _} ->
         command = command
-          |> String.replace("\"", "\\\"")
-          |> :binary.bin_to_list
+                  |> String.replace("\"", "\\\"")
+                  |> :binary.bin_to_list
         'sh -c "' ++ command ++ '"'
 
       {:win32, osname} ->

--- a/lib/mix/test/mix/rebar_test.exs
+++ b/lib/mix/test/mix/rebar_test.exs
@@ -97,8 +97,8 @@ defmodule Mix.RebarTest do
       assert :rebar_dep.any_function == :ok
 
       load_paths = Mix.Dep.loaded([])
-        |> Enum.map(&Mix.Dep.load_paths(&1))
-        |> Enum.concat
+                   |> Enum.map(&Mix.Dep.load_paths(&1))
+                   |> Enum.concat
 
       assert File.exists?("_build/dev/lib/rebar_dep/ebin/rebar_dep.beam")
       assert File.exists?("_build/dev/lib/git_rebar/ebin/git_rebar.beam")


### PR DESCRIPTION
Re-align some code to make pipe operator usage more consistent.

Generally, make sure pipes end up on the same indentation level as what they are
piping.

Examples:

Piping
```elixir
some_thing
|> foo
|> bar
|> baz
```

Assignment
```elixir
my_var = some_thing
         |> foo
         |> bar
         |> baz
```

Asserts
```elixir
assert some_thing
       |> foo
       |> bar
       |> baz
```