### PR TITLE
Add explicit sort of map to Mix.Dep.Lock.write/1

### DIFF
--- a/lib/mix/lib/mix/dep/lock.ex
+++ b/lib/mix/lib/mix/dep/lock.ex
@@ -79,7 +79,7 @@ defmodule Mix.Dep.Lock do
   def write(map) do
     unless map == read do
       lines =
-        for {app, rev} <- map, rev != nil do
+        for {app, rev} <- Enum.sort(map), rev != nil do
           ~s("#{app}": #{inspect rev, limit: :infinity})
         end
       File.write! lockfile, "%{" <> Enum.join(lines, ",\n  ") <> "}\n"


### PR DESCRIPTION
Adds an explicit sort of the input map to Mix.Dep.Lock.write/1 since maps do not explicitly have an order.

@ericmj 