### PR TITLE
[security] Verify dowloaded `rebar` over http with sha256 hash

### DIFF
--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -1,8 +1,10 @@
 defmodule Mix.Tasks.Local.Rebar do
   use Mix.Task
 
-  @rebar_url "http://s3.hex.pm/rebar"
-  @shortdoc  "Install rebar locally"
+  # @rebar_url should be moved to "http://s3.hex.pm/rebar/1/rebar"
+  @rebar_url         "http://s3.hex.pm/rebar"
+  @rebar_sha256_hash "c6108ac609f4e675fcfc3c57a5c791838faf82f017ff9325d0022c972649dd86"
+  @shortdoc          "Install rebar locally"
 
   @moduledoc """
   Fetch a copy of rebar from the given path or url. It defaults to a
@@ -25,13 +27,28 @@ defmodule Mix.Tasks.Local.Rebar do
       []       -> @rebar_url
       [path|_] -> path
     end
+
     do_install(path, opts)
   end
 
   defp do_install(path, opts) do
     local_rebar_path = Mix.Rebar.local_rebar_path
+    tmp_local_rebar_path = local_rebar_path <> ".tmp"
 
-    if Mix.Utils.copy_path!(path, local_rebar_path, opts) do
+    File.rm(tmp_local_rebar_path)
+
+    if Mix.Utils.copy_path!(path, tmp_local_rebar_path, opts) do
+      if path == @rebar_url do
+        try do
+          downloaded_hash = (:crypto.hash(:sha256, File.read!(tmp_local_rebar_path)) |> Base.encode16 |> String.downcase)
+          if (@rebar_sha256_hash != downloaded_hash), do:
+            throw(downloaded_hash)
+        catch
+          hash -> raise "SHA256 hash did not match for `#{tmp_local_rebar_path}` [#{@rebar_url}].\nExpected: #{@rebar_sha256_hash}\nGot:      #{hash}"
+        end
+      end
+
+      :ok = :file.rename tmp_local_rebar_path, local_rebar_path
       :ok = :file.change_mode local_rebar_path, 0o755
       Mix.shell.info [:green, "* creating ", :reset, Path.relative_to_cwd(local_rebar_path)]
     end


### PR DESCRIPTION
First stab at solving https://github.com/elixir-lang/elixir/issues/3423 https://github.com/hexpm/hex_web/pull/127
Since we cannot validate the ssl certificates, then what we can do is hardcode the sha256 hash of the file , and verify its validity.
when `rebar` is updated, we should update it to a different location, so we can still keep old copies, that's why i propose instead of locating it in `/rebar` use `/rebar/[n]/rebar` instead.

@ericmj is there any advantage using https://s3.amazonaws.com/s3.hex.pm/ instead of plain http:// for this case? as you recommended in https://github.com/elixir-lang/elixir-lang.github.com/issues/566

please let me know what you think, and if I should add a test, and/or document or at least with comments what the new code is doing.

/cc @bgentry