### PR TITLE
use parenthesis in `fun` in function definitions

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -407,7 +407,7 @@ defmodule Stream do
   is delayed until the stream is executed. See `run/1` for an example.
   """
   @spec into(Enumerable.t, Collectable.t) :: Enumerable.t
-  def into(enum, collectable, transform \\ fn x -> x end) do
+  def into(enum, collectable, transform \\ fn(x) -> x end) do
     &do_into(enum, collectable, transform, &1, &2)
   end
 
@@ -769,7 +769,7 @@ defmodule Stream do
   """
   @spec uniq(Enumerable.t) :: Enumerable.t
   @spec uniq(Enumerable.t, (element -> term)) :: Enumerable.t
-  def uniq(enum, fun \\ fn x -> x end) do
+  def uniq(enum, fun \\ fn(x) -> x end) do
     lazy enum, HashSet.new, fn f1 -> R.uniq(fun, f1) end
   end
 


### PR DESCRIPTION
Just to be consistent with the other function definitions.

Not trying to fall into style-editing, but just to standardize the format in the documentation.

```bash
$ ag  "def[^\n]+\\\\\s*fn\("
lib/elixir/lib/dict.ex
245:      def merge(dict1, dict2, fun \\ fn(_k, _v1, v2) -> v2 end) do

lib/elixir/lib/file.ex
464:  def cp(source, destination, callback \\ fn(_, _) -> true end) do
486:  def cp!(source, destination, callback \\ fn(_, _) -> true end) do
539:  def cp_r(source, destination, callback \\ fn(_, _) -> true end) when is_function(callback) do
554:  def cp_r!(source, destination, callback \\ fn(_, _) -> true end) do

lib/elixir/lib/enum.ex
226:  def all?(collection, fun \\ fn(x) -> x end)
263:  def any?(collection, fun \\ fn(x) -> x end)

lib/elixir/lib/macro.ex
454:  def to_string(tree, fun \\ fn(_ast, string) -> string end)

lib/mix/lib/mix/shell/process.ex
29:  def flush(callback \\ fn(x) -> x end) do
```