### PR TITLE
rename Enum.minmax* and Inspect.Algebra.folddoc due to inconsitencies in their names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and is using Erlang 17.1, remember to update to at least Erlang 17.3.
   * [Dict] Add `Dict.get_and_update/3` which behaves similar to the now deprecated Access protocol
   * [Dict] Add `Dict.get_lazy/3`, `Dict.pop_lazy/3` and `Dict.put_new_lazy/3`
   * [EEx] Add `:trim` option to EEx that automatically trims the left side of `<%` and right side `%>` if only spaces and new lines preceed/follow them
-  * [Enum] Add `Enum.random/1`, `Enum.minmax/1`, `Enum.minmax_by/2`, `Enum.reverse_slice/3`, `Enum.dedup/1` and `Enum.dedup_by/2`
+  * [Enum] Add `Enum.random/1`, `Enum.min_max/1`, `Enum.min_max_by/2`, `Enum.reverse_slice/3`, `Enum.dedup/1` and `Enum.dedup_by/2`
   * [Enum] Inline common map usage in `Enum` functions for performance
   * [ExUnit] Add number of skipped tests to `ExUnit` output
   * [ExUnit] Make timeout configurable for the whole test suite via the `:timeout` configuration

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1255,12 +1255,12 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.minmax([2, 3, 1])
+      iex> Enum.min_max([2, 3, 1])
       {1, 3}
 
   """
-  @spec minmax(t) :: element | no_return
-  def minmax(collection) do
+  @spec min_max(t) :: element | no_return
+  def min_max(collection) do
     result =
       Enum.reduce(collection, :first, fn
         entry, {min_value, max_value} ->
@@ -1281,12 +1281,12 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.minmax_by(["aaa", "bb", "c"], fn(x) -> String.length(x) end)
+      iex> Enum.min_max_by(["aaa", "bb", "c"], fn(x) -> String.length(x) end)
       {"c", "aaa"}
 
   """
-  @spec minmax_by(t, (element -> any)) :: element | no_return
-  def minmax_by(collection, fun) do
+  @spec min_max_by(t, (element -> any)) :: element | no_return
+  def min_max_by(collection, fun) do
     result =
       Enum.reduce(collection, :first, fn
         entry, {{_, fun_min} = acc_min, {_, fun_max} = acc_max} ->

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -272,7 +272,7 @@ defmodule Inspect.Algebra do
   """
   @spec concat([t]) :: doc_cons
   def concat(docs) do
-    folddoc(docs, &concat(&1, &2))
+    fold_doc(docs, &concat(&1, &2))
   end
 
   @doc ~S"""
@@ -403,18 +403,18 @@ defmodule Inspect.Algebra do
   ## Examples
 
       iex> doc = ["A", "B"]
-      iex> doc = Inspect.Algebra.folddoc(doc, fn(x, y) ->
+      iex> doc = Inspect.Algebra.fold_doc(doc, fn(x, y) ->
       ...>   Inspect.Algebra.concat [x, "!", y]
       ...> end)
       iex> Inspect.Algebra.format(doc, 80)
       ["A", "!", "B"]
 
   """
-  @spec folddoc([t], ((t, t) -> t)) :: t
-  def folddoc(list, fun)
-  def folddoc([], _), do: empty
-  def folddoc([doc], _), do: doc
-  def folddoc([d|ds], fun), do: fun.(d, folddoc(ds, fun))
+  @spec fold_doc([t], ((t, t) -> t)) :: t
+  def fold_doc(list, fun)
+  def fold_doc([], _), do: empty
+  def fold_doc([doc], _), do: doc
+  def fold_doc([d|ds], fun), do: fun.(d, fold_doc(ds, fun))
 
   # Elixir conveniences
 

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -530,19 +530,19 @@ defmodule EnumTest.List do
     end
   end
 
-  test :minmax do
-    assert Enum.minmax([1]) == {1, 1}
-    assert Enum.minmax([2, 3, 1]) == {1, 3}
-    assert Enum.minmax([[], :a, {}]) == {:a, []}
+  test :min_max do
+    assert Enum.min_max([1]) == {1, 1}
+    assert Enum.min_max([2, 3, 1]) == {1, 3}
+    assert Enum.min_max([[], :a, {}]) == {:a, []}
     assert_raise Enum.EmptyError, fn ->
-      Enum.minmax([])
+      Enum.min_max([])
     end
   end
 
-  test :minmax_by do
-    assert Enum.minmax_by(["aaa", "a", "aa"], fn(x) -> String.length(x) end) == {"a", "aaa"}
+  test :min_max_by do
+    assert Enum.min_max_by(["aaa", "a", "aa"], fn(x) -> String.length(x) end) == {"a", "aaa"}
     assert_raise Enum.EmptyError, fn ->
-      Enum.minmax_by([], fn(x) -> String.length(x) end)
+      Enum.min_max_by([], fn(x) -> String.length(x) end)
     end
   end
 


### PR DESCRIPTION
as per discussed in the mailing list

Rename functions introduced in: https://github.com/elixir-lang/elixir/pull/2901, https://github.com/elixir-lang/elixir/pull/1047, https://github.com/elixir-lang/elixir/pull/1267
/cc @xavier, @manpages, @brunoro