### PR TITLE
Improve Logger metadata handling

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -255,7 +255,12 @@ defmodule Logger do
   """
   def metadata(dict) do
     {enabled, metadata} = __metadata__()
-    Process.put(@metadata, {enabled, Keyword.merge(metadata, dict)})
+    metadata =
+      Enum.reduce(dict, metadata, fn
+        {key, nil}, acc -> Keyword.delete(acc, key)
+        {key, val}, acc -> Keyword.put(acc, key, val)
+      end)
+    Process.put(@metadata, {enabled, metadata})
     :ok
   end
 

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -422,8 +422,9 @@ defmodule Logger do
           level: min_level, utc_log: utc_log?} = Logger.Config.__data__
 
         if compare_levels(level, min_level) != :lt do
+          metadata = [pid: self()] ++ Keyword.merge(pdict, metadata)
           tuple = {Logger, truncate(chardata_or_fn, truncate),
-                   Logger.Utils.timestamp(utc_log?), [pid: self()] ++ metadata ++ pdict}
+                   Logger.Utils.timestamp(utc_log?), metadata}
           try do
             notify(mode, {level, Process.group_leader(), tuple})
             :ok

--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -81,8 +81,17 @@ defmodule Logger.Backends.Console do
     IO.write(state.device, output)
   end
 
-  defp format_event(level, msg, ts, md, %{format: format, metadata: metadata}) do
-    Logger.Formatter.format(format, level, msg, ts, Dict.take(md, metadata))
+  defp format_event(level, msg, ts, md, %{format: format, metadata: keys}) do
+    Logger.Formatter.format(format, level, msg, ts, take_metadata(md, keys))
+  end
+
+  defp take_metadata(metadata, keys) do
+    Enum.reduce(keys, [], fn key, acc ->
+      case Keyword.fetch(metadata, key) do
+        {:ok, val} -> [{key, val} | acc]
+        :error     -> acc
+      end
+    end) |> Enum.reverse()
   end
 
   defp color_event(data, _level, %{enabled: false}), do: data

--- a/lib/logger/test/logger/backends/console_test.exs
+++ b/lib/logger/test/logger/backends/console_test.exs
@@ -49,13 +49,13 @@ defmodule Logger.Backends.ConsoleTest do
 
   test "metadata defaults" do
     Logger.configure_backend(:console,
-      format: "$metadata", metadata: [:module, :function, :line])
+      format: "$metadata", metadata: [:line, :module, :function])
 
     %{module: mod, function: {name, arity}, line: line} = __ENV__
 
     assert capture_log(fn ->
       Logger.debug("hello")
-    end) =~ "module=#{mod} function=#{name}/#{arity} line=#{line + 3}"
+    end) =~ "line=#{line + 3} module=#{mod} function=#{name}/#{arity}"
   end
 
   test "can configure level" do

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -87,6 +87,14 @@ defmodule LoggerTest do
     assert Logger.metadata() == [meta: 1]
   end
 
+  test "metadata merge" do
+    assert Logger.metadata([module: Sample]) == :ok
+
+    assert capture_log(fn ->
+      assert Logger.bare_log(:info, "ok", [module: LoggerTest]) == :ok
+    end) =~ msg_with_meta("[info]  ok")
+  end
+
   test "enable/1 and disable/1" do
     assert Logger.metadata([]) == :ok
 

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -75,6 +75,18 @@ defmodule LoggerTest do
     assert Logger.level == :debug
   end
 
+  test "process metadata" do
+    assert Logger.metadata(data: true) == :ok
+    assert Logger.metadata() == [data: true]
+    assert Logger.metadata(data: true) == :ok
+    assert Logger.metadata() == [data: true]
+    assert Logger.metadata(meta: 1) == :ok
+    metadata = Logger.metadata()
+    assert Enum.sort(metadata) == [data: true, meta: 1]
+    assert Logger.metadata(data: nil) == :ok
+    assert Logger.metadata() == [meta: 1]
+  end
+
   test "enable/1 and disable/1" do
     assert Logger.metadata([]) == :ok
 


### PR DESCRIPTION
Closes #3502.

* [x] API to remove a metadata key from the pdict
* [x] log call replaces same metadata key in the pdict
* [x] preserve metadata order defined in the backend's configuration

/cc @MSch 