### PR TITLE
Add Range.Iterator for BitString

### DIFF
--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -1,5 +1,5 @@
 defmodule Range do
-  @moduledoc """
+  @moduledoc ~S(
   Defines a Range.
 
   A Range is represented internally as a struct. However,
@@ -14,7 +14,12 @@ defmodule Range do
       iex> last
       3
 
-  """
+      iex> first .. last = "a".."z"
+      "a".."z"
+      iex> "#{first} - #{last}"
+      "a - z"
+
+  )
 
   defstruct first: nil, last: nil
 
@@ -34,6 +39,9 @@ defmodule Range do
   ## Examples
 
       iex> Range.range?(1..3)
+      true
+
+      iex Range.range?("a".."z")
       true
 
       iex> Range.range?(0)
@@ -108,6 +116,24 @@ defimpl Range.Iterator, for: Integer do
   end
 
   def count(first, _ .. last) when is_integer(last) do
+    if last >= first do
+      last - first + 1
+    else
+      first - last + 1
+    end
+  end
+end
+
+defimpl Range.Iterator, for: BitString do
+  def next(<< first :: utf8 >>, _ .. << last :: utf8 >>) do
+    if last >= first do
+      fn << char :: utf8 >> -> << char + 1 :: utf8 >> end
+    else
+      fn << char :: utf8 >> -> << char - 1 :: utf8 >> end
+    end
+  end
+
+  def count(<< first :: utf8 >>, _ .. << last :: utf8 >>) do
     if last >= first do
       last - first + 1
     else

--- a/lib/elixir/test/elixir/range_test.exs
+++ b/lib/elixir/test/elixir/range_test.exs
@@ -6,20 +6,28 @@ defmodule RangeTest do
   test :precedence do
     assert Enum.to_list(1..3+2) == [1, 2, 3, 4, 5]
     assert 1..3 |> Enum.to_list == [1, 2, 3]
+    assert "a".."c" |> Enum.to_list == ["a", "b", "c"]
   end
 
   test :op do
     assert (1..3).first == 1
     assert (1..3).last  == 3
+
+    assert ("a".."z").first == "a"
+    assert ("a".."z").last  == "z"
   end
 
   test :range? do
     assert Range.range?(1..3)
     refute Range.range?(0)
+
+    assert Range.range?("a".."z")
+    refute Range.range?("a")
   end
 
   test :enum do
     refute Enum.empty?(1..1)
+    refute Enum.empty?("a".."a")
 
     assert Enum.member?(1..3, 2)
     refute Enum.member?(1..3, 0)
@@ -27,15 +35,34 @@ defmodule RangeTest do
     refute Enum.member?(3..1, 0)
     refute Enum.member?(3..1, 4)
 
+    assert Enum.member?("a".."z", "n")
+    refute Enum.member?("a".."z", "A")
+    refute Enum.member?("a".."z", "Z")
+    refute Enum.member?("a".."z", "`")
+    refute Enum.member?("a".."z", "{")
+    refute Enum.member?("z".."a", "A")
+    refute Enum.member?("z".."a", "Z")
+    refute Enum.member?("z".."a", "`")
+    refute Enum.member?("z".."a", "{")
+
     assert Enum.count(1..3) == 3
     assert Enum.count(3..1) == 3
 
+    assert Enum.count("a".."z") == 26
+    assert Enum.count("z".."a") == 26
+
     assert Enum.map(1..3, &(&1 * 2)) == [2, 4, 6]
     assert Enum.map(3..1, &(&1 * 2)) == [6, 4, 2]
+
+    assert Enum.map("a".."c", &("<#{&1}>")) == ["<a>", "<b>", "<c>"]
+    assert Enum.map("c".."a", &("<#{&1}>")) == ["<c>", "<b>", "<a>"]
   end
 
   test :inspect do
     assert inspect(1..3) == "1..3"
     assert inspect(3..1) == "3..1"
+
+    assert inspect("a".."z") == ~s("a".."z")
+    assert inspect("z".."a") == ~s("z".."a")
   end
 end


### PR DESCRIPTION
This will add a [Range.Iterator][1] implementation for (Bit)Strings. The next logic is very simple, but it should follow the same behaviour as the `<` et al operators does for strings.

I wrote this because of #2912, since I would like for strings/characters/graphemes/runes to be included in that set. But I didn't want to change to much, like #3374, to ensure ranges are still usable in guards. Luckily the strings in Elixir can be compared with `<` et al, and this follows that logic.

[1]: https://github.com/elixir-lang/elixir/blob/99cb66d5ec25d80ae67d88da1db6055b6d0be572/lib/elixir/lib/range.ex#L47-L61