### PR TITLE
Polish the documentation for Mix.Task.alias?/1

### DIFF
--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -149,7 +149,10 @@ defmodule Mix.Task do
   end
 
   @doc """
-  Checks if exists an alias with the given task name.
+  Checks if an alias called `task` exists.
+
+  For more information about task aliasing, take a look at the "Aliasing"
+  section in the docs for `Mix`.
   """
   @spec alias?(task_name) :: boolean
   def alias?(task) when is_binary(task) do


### PR DESCRIPTION
I added a link to the documentation for the Mix module, in particular to the section that talks about aliasing.