### PR TITLE
Better documentation for the GenServer terminate callback

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -107,6 +107,10 @@ defmodule GenServer do
 
     * `terminate(reason, state)` - called when the server is about to
       terminate, useful for cleaning up. It must return `:ok`.
+      If part of a supervision tree, terminate only gets called if the
+      GenServer is set to trap exits using `Process.flag/2` *and*
+      the shutdown strategy of the Supervisor is a timeout value,
+      not `:brutal_kill`.
 
     * `code_change(old_vsn, state, extra)` - called when the application
       code is being upgraded live (hot code swapping).


### PR DESCRIPTION
I'm an Elixir newbie and wanted to set up a cleanup for my supervised GenServer. However, it took me 2 hours to figure out, how to do this under a Supervisor and then another half hour to find the `Process.flag/2` method.
I'm not sure if the description is too long at this point but it would have saved me some time and wondering.