### PR TITLE
Add vsn to the local_sample.app

### DIFF
--- a/lib/mix/test/fixtures/archive/ebin/local_sample.app
+++ b/lib/mix/test/fixtures/archive/ebin/local_sample.app
@@ -1,3 +1,4 @@
 {application,local_sample,
              [{modules,['Elixir.Mix.Tasks.Local.Sample']},
+              {vsn, "0.1"},
               {applications,[kernel,stdlib,elixir]}]}.


### PR DESCRIPTION
Hello,

During working on exrm, I've got:

```
{rlx_app_discovery,
      [{unversioned_app,
           <<"/home/alex/work/elixir/bin/../lib/mix/test/fixtures/archive">>,
           local_sample},
       {unversioned_app,
           <<"/home/alex/work/elixir/lib/mix/test/fixtures/archive">>,
           local_sample}]}
```

I've added `vsn` to the `lib/mix/test/fixtures/archive/ebin/local_sample.app` and this fixed it.