### PR TITLE
Tweak the docs for the Inspect protocol

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -41,7 +41,8 @@ defprotocol Inspect do
   ## Error handling
 
   In case there is an error while your structure is being inspected,
-  Elixir will automatically fall back to a raw representation.
+  Elixir will raise an `ArgumentError` error and will automatically fall back
+  to a raw representation for printing the structure.
 
   You can however access the underlying error by invoking the Inspect
   implementation directly. For example, to test Inspect.HashSet above,


### PR DESCRIPTION
The docs for the Inspect protocol mentioned that if there's an error while inspecting a struct (for which the Inspect protocol has been implemented), then the struct is printed with a raw representation.

This PR makes it clear that an `ArgumentError` is raised and the struct is printed raw in the error message. I'm adding this note as I was bitten by this earlier today, thinking I could rely on `inspect/2` printing my struct as `%MyStruct{...}` in case of errors (I wanted to print it as `#MyStruct<...>` only for some cases).

On a related note, yes, I came to the conclusion that printing a struct differently based on its content is probably a bad idea. Nonetheless, maybe these changes in the docs make this clearer :)