### PR TITLE
.gitignore (mix new): move rules starting with "*" to the top

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -217,8 +217,8 @@ defmodule Mix.Tasks.New do
   /_build
   /cover
   /deps
-  erl_crash.dump
   *.ez
+  erl_crash.dump
   """
 
   embed_template :mixfile, """


### PR DESCRIPTION
Just to be consistent with the order we maintain in elixir .gitignore file,
"*" should go first