### PR TITLE
Makefile: remove use of `cd` when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 REBAR ?= $(CURDIR)/rebar
 PREFIX ?= /usr/local
 DOCS := master
+ELIXIR := bin/elixir
 ELIXIRC := bin/elixirc --verbose --ignore-module-conflict
 ERLC := erlc -I lib/elixir/include
 ERL := erl -I lib/elixir/include -noshell -pa lib/elixir/ebin
@@ -44,7 +45,7 @@ lib/$(1)/ebin/Elixir.$(2).beam: $(wildcard lib/$(1)/lib/*.ex) $(wildcard lib/$(1
 
 test_$(1): $(1)
 	@ echo "==> $(1) (exunit)"
-	$(Q) cd lib/$(1) && ../../bin/elixir -r "test/test_helper.exs" -pr "test/**/*_test.exs";
+	$(Q) $(ELIXIR) -r "lib/$(1)/test/test_helper.exs" -pr "lib/$(1)/test/**/*_test.exs";
 endef
 
 #==> Compilation tasks
@@ -129,7 +130,7 @@ clean_exbeam:
 #==>  Create Documentation
 
 SOURCE_REF = $(shell head="$$(git rev-parse HEAD)" tag="$$(git tag --points-at $$head | tail -1)" ; echo "$${tag:-$$head}\c")
-COMPILE_DOCS = bin/elixir ../ex_doc/bin/ex_doc "$(1)" "$(VERSION)" "lib/$(2)/ebin" -m "$(3)" -u "https://github.com/elixir-lang/elixir" --source-ref "$(call SOURCE_REF)" -o doc/$(2) -p http://elixir-lang.org/docs.html
+COMPILE_DOCS = $(ELIXIR) ../ex_doc/bin/ex_doc "$(1)" "$(VERSION)" "lib/$(2)/ebin" -m "$(3)" -u "https://github.com/elixir-lang/elixir" --source-ref "$(call SOURCE_REF)" -o doc/$(2) -p http://elixir-lang.org/docs.html
 
 docs: compile ../ex_doc/bin/ex_doc docs_elixir docs_eex docs_mix docs_iex docs_ex_unit docs_logger
 
@@ -210,15 +211,15 @@ test_elixir: test_stdlib test_ex_unit test_logger test_doc_test test_mix test_ee
 
 test_doc_test: compile
 	@ echo "==> doctest (exunit)"
-	$(Q) cd lib/elixir && ../../bin/elixir -r "test/doc_test.exs";
+	$(Q) $(ELIXIR) -r "lib/elixir/test/doc_test.exs";
 
 test_stdlib: compile
 	@ echo "==> elixir (exunit)"
 	$(Q) exec epmd & exit
 	$(Q) if [ "$(OS)" = "Windows_NT" ]; then \
-		cd lib/elixir && cmd //C call ../../bin/elixir.bat -r "test/elixir/test_helper.exs" -pr "test/elixir/**/*_test.exs"; \
+		cmd //C call bin/elixir.bat -r "lib/elixir/test/elixir/test_helper.exs" -pr "lib/elixir/test/elixir/**/*_test.exs"; \
 	else \
-		cd lib/elixir && ../../bin/elixir -r "test/elixir/test_helper.exs" -pr "test/elixir/**/*_test.exs"; \
+		$(ELIXIR) -r "lib/elixir/test/elixir/test_helper.exs" -pr "lib/elixir/test/elixir/**/*_test.exs"; \
 	fi
 
 #==> Dialyzer tasks


### PR DESCRIPTION
Elixir failing tests don't give proper path, because of `cd`,
from Makefile we are running
`cd lib/elixir && ../../bin/elixir -r "test/elixir/test_helper.exs" -pr "test/elixir/**/*_test.exs"`
and when a test fails, we get.
`test/mix/tasks/new_test.exs:28`
when the path it should be
`lib/mix/test/mix/tasks/new_test.exs:28`

```sh
  1) test Sample (VersionTest)
     test/elixir/version_test.exs:7
     Assertion with == failed
     code: 1 == 2
     lhs:  1
     rhs:  2
     stacktrace:
       test/elixir/version_test.exs:8
```

with this PR it reads:

```sh
  1) test Sample (VersionTest)
     lib/elixir/test/elixir/version_test.exs:7
     Assertion with == failed
     code: 1 == 2
     lhs:  1
     rhs:  2
     stacktrace:
       lib/elixir/test/elixir/version_test.exs:8
```

with this PR we get away without changing directory in order to get the proper path of
the tests being executed
