### PR TITLE
Add default function to Agent.get/3

### DIFF
--- a/lib/elixir/lib/agent.ex
+++ b/lib/elixir/lib/agent.ex
@@ -58,7 +58,7 @@ defmodule Agent do
 
       # Compute in the agent/client
       def get_something(agent) do
-        Agent.get(agent, &(&1)) |> do_something_expensive()
+        Agent.get(agent) |> do_something_expensive()
       end
 
   The first function blocks the agent. The second function copies

--- a/lib/elixir/lib/agent.ex
+++ b/lib/elixir/lib/agent.ex
@@ -194,12 +194,13 @@ defmodule Agent do
 
   The function `fun` is sent to the `agent` which invokes the function
   passing the agent state. The result of the function invocation is
-  returned.
+  returned. The default function is &(&1), which simply returns the
+  agent's state.
 
   A timeout can also be specified (it has a default value of 5000).
   """
   @spec get(agent, (state -> a), timeout) :: a when a: var
-  def get(agent, fun, timeout \\ 5000) when is_function(fun, 1) do
+  def get(agent, fun \\ &(&1), timeout \\ 5000) when is_function(fun, 1) do
     GenServer.call(agent, {:get, fun}, timeout)
   end
 

--- a/lib/elixir/test/elixir/agent_test.exs
+++ b/lib/elixir/test/elixir/agent_test.exs
@@ -16,7 +16,7 @@ defmodule AgentTest do
     assert Agent.update(pid, &Map.put(&1, :hello, :world)) == :ok
     assert Agent.get(pid, &Map.get(&1, :hello), 3000) == :world
     assert Agent.get_and_update(pid, &Map.pop(&1, :hello), 3000) == :world
-    assert Agent.get(pid, &(&1)) == %{}
+    assert Agent.get(pid) == %{}
     assert Agent.stop(pid) == :ok
     wait_until_dead(pid)
   end
@@ -48,7 +48,7 @@ defmodule AgentTest do
     mfa = { :erlang, :error, [] }
     assert match?({ :error, _ }, :sys.change_code(pid, __MODULE__, "vsn", mfa))
     :ok = :sys.resume(pid)
-    assert Agent.get(pid, &(&1)) == %{}
+    assert Agent.get(pid) == %{}
     assert Agent.stop(pid) == :ok
   end
 

--- a/lib/mix/lib/mix/config/agent.ex
+++ b/lib/mix/lib/mix/config/agent.ex
@@ -15,7 +15,7 @@ defmodule Mix.Config.Agent do
 
   @spec get(pid) :: config
   def get(agent) do
-    Agent.get(agent, &(&1))
+    Agent.get(agent)
   end
 
   @spec merge(pid, config) :: config


### PR DESCRIPTION
The most common use of Agent.get/3 is usually to simply grab the agent state like this:

    Agent.get(agent, &(&1))

This PR adds a default of &(&1) to the "fun" parameter, allowing this shorter version to retrieve the state:

    Agent.get(agent)