### PR TITLE
Mention restart: :transient in Task moduledoc

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -59,6 +59,11 @@ defmodule Task do
   unlike `async/1`, returns `{:ok, pid}` (which is
   the result expected by supervision trees).
 
+  By default, most supervision strategies will try to restart
+  a worker after it exits regardless of reason. If you design the
+  task to terminate normally (as in the example with `IO.puts` above),
+  consider passing `restart: :transient` in the options to `worker/3`.
+
   ## Dynamically supervised tasks
 
   The `Task.Supervisor` module allows developers to dynamically


### PR DESCRIPTION
Per the discussion here: https://groups.google.com/forum/#!topic/elixir-lang-talk/SZSSPaLBX0s

The example as it stands in the doc will cause an application to fail to start, as it will keep retrying a worker that promptly exits. This PR clarifies the options one might need to run such a task successfully.