### PR TITLE
Add a note to the docs for Enum.reduce/2

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1407,6 +1407,10 @@ defmodule Enum do
   This function won't call the specified function for enumerables that are 1-element long.
   Returns the accumulator.
 
+  Note that since the first element of the enumerable is used as the initial
+  value of the accumulator, `fun` will only be executed `n - 1` times where `n`
+  is the length of the enumerable.
+
   ## Examples
 
       iex> Enum.reduce([1, 2, 3, 4], fn(x, acc) -> x * acc end)


### PR DESCRIPTION
I added a note that clarifies that `Enum.reduce/2` calls the reducer function `n - 1` times where `n` is the length of the enumerable. [This StackOverflow question](http://stackoverflow.com/questions/31836820/enum-reduce-2-doesnt-output-io/31837323#31837323) lead to this PR. Let me know what you think!