### PR TITLE
Improve error message in case of lockfile eval failure

### DIFF
--- a/lib/mix/lib/mix/dep/lock.ex
+++ b/lib/mix/lib/mix/dep/lock.ex
@@ -61,7 +61,7 @@ defmodule Mix.Dep.Lock do
   def read() do
     case File.read(lockfile) do
       {:ok, info} ->
-        case Code.eval_string(info) do
+        case Code.eval_string(info, [], file: lockfile) do
           # lock could be a keyword list
           {lock, _binding} when is_list(lock) -> Enum.into(lock, %{})
           {lock, _binding} when is_map(lock)  -> lock


### PR DESCRIPTION
From
```
** (SyntaxError) nofile:9: syntax error before: ','
    (elixir) lib/code.ex:168: Code.eval_string/3
    ...
```
to
```
** (SyntaxError) mix.lock:9: syntax error before: ','
    (elixir) lib/code.ex:168: Code.eval_string/3
    ...
```
This kind of errors might happen in case of bad git conflict resolution.

On a slightly different note, I've spotted double output on master branch:

```
% mix deps
** (SyntaxError) mix.lock:9: syntax error before: ','
    (elixir) lib/code.ex:168: Code.eval_string/3
    (mix) lib/mix/dep/lock.ex:65: Mix.Dep.Lock.read/0
    (mix) lib/mix/tasks/deps.ex:110: Mix.Tasks.Deps.run/1
    (mix) lib/mix/cli.ex:60: Mix.CLI.run_task/2


22:03:02.042 [error] Process #PID<0.47.0> raised an exception
** (SyntaxError) mix.lock:9: syntax error before: ','
    (elixir) src/elixir.erl:156: :elixir.eval/3
    (elixir) lib/code.ex:168: Code.eval_string/3
```
Don't think it's intentional, right? @josevalim, @ericmj 