### PR TITLE
pass column data from tokenizer through parser

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -105,9 +105,9 @@ defmodule Macro do
   ## Examples
 
       iex> quoted = quote line: 10, do: sample()
-      {:sample, [line: 10], []}
+      {:sample, [line: 10, column_begin: 31, column_end: 37], []}
       iex> Macro.update_meta(quoted, &Keyword.delete(&1, :line))
-      {:sample, [], []}
+      {:sample, [column_begin: 31, column_end: 37], []}
 
   """
   @spec update_meta(t, (Keyword.t -> Keyword.t)) :: t

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -583,7 +583,7 @@ Erlang code.
 -import(lists, [reverse/1, reverse/2]).
 
 meta(Line, Counter) -> [{counter, Counter}|meta(Line)].
-meta({Line, Column, EndColumn}) when is_integer(Line), is_integer(Column), is_integer(EndColumn) -> [{line, Line}];
+meta({Line, Column, EndColumn}) when is_integer(Line), is_integer(Column), is_integer(EndColumn) -> [{line, Line}, {column_begin, Column}, {column_end, EndColumn}];
 meta(Node) -> meta(?line(Node)).
 
 %% Operators

--- a/lib/elixir/src/elixir_quote.erl
+++ b/lib/elixir/src/elixir_quote.erl
@@ -331,7 +331,9 @@ line(Meta, #elixir_quote{file=File}) when File /= nil ->
 line(Meta, #elixir_quote{line=true}) ->
   Meta;
 line(Meta, #elixir_quote{line=false}) ->
-  keydelete(line, Meta);
+  Meta1 = keydelete(line, Meta),
+  Meta2 = keydelete(column_begin, Meta1),
+  keydelete(column_end, Meta2);
 line(Meta, #elixir_quote{line=Line}) ->
   keystore(line, Meta, Line).
 

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -92,8 +92,8 @@ defmodule CodeTest do
   end
 
   test :string_to_quoted do
-    assert Code.string_to_quoted("1 + 2")  == {:ok, {:+, [line: 1], [1, 2]}}
-    assert Code.string_to_quoted!("1 + 2") == {:+, [line: 1], [1, 2]}
+    assert Code.string_to_quoted("1 + 2")  == {:ok, {:+, [line: 1, column_begin: 3, column_end: 4], [1, 2]}}
+    assert Code.string_to_quoted!("1 + 2") == {:+, [line: 1, column_begin: 3, column_end: 4], [1, 2]}
 
     assert Code.string_to_quoted("a.1") ==
            {:error, {1, "syntax error before: ", "1"}}
@@ -108,7 +108,7 @@ defmodule CodeTest do
   end
 
   test :string_to_quoted! do
-    assert Code.string_to_quoted!("1 + 2") == {:+, [line: 1], [1, 2]}
+    assert Code.string_to_quoted!("1 + 2") == {:+, [line: 1, column_begin: 3, column_end: 4], [1, 2]}
 
     assert_raise SyntaxError, fn ->
       Code.string_to_quoted!("a.1")

--- a/lib/elixir/test/elixir/kernel/quote_test.exs
+++ b/lib/elixir/test/elixir/kernel/quote_test.exs
@@ -14,17 +14,17 @@ defmodule Kernel.QuoteTest do
   test :keep_line do
     ## DO NOT MOVE THIS LINE
     assert quote(location: :keep, do: bar(1, 2, 3)) ==
-           {:bar, [file: Path.relative_to_cwd(__ENV__.file), keep: 16], [1, 2, 3]}
+           {:bar, [file: Path.relative_to_cwd(__ENV__.file), keep: 16, column_begin: 39, column_end: 42], [1, 2, 3]}
   end
 
   test :fixed_line do
-    assert quote(line: 3, do: bar(1, 2, 3)) == {:bar, [line: 3], [1, 2, 3]}
+    assert quote(line: 3, do: bar(1, 2, 3)) == {:bar, [line: 3, column_begin: 31, column_end: 34], [1, 2, 3]}
   end
 
   test :quote_line_var do
     ## DO NOT MOVE THIS LINE
     line = __ENV__.line
-    assert quote(line: line, do: bar(1, 2, 3)) == {:bar, [line: 26], [1, 2, 3]}
+    assert quote(line: line, do: bar(1, 2, 3)) == {:bar, [line: 26, column_begin: 34, column_end: 37], [1, 2, 3]}
   end
 
   test :unquote_call do
@@ -160,7 +160,7 @@ defmodule Kernel.QuoteTest do
   end
 
   test :with_dynamic_opts do
-    assert quote(dynamic_opts, do: bar(1, 2, 3)) == {:bar, [line: 3], [1, 2, 3]}
+    assert quote(dynamic_opts, do: bar(1, 2, 3)) == {:bar, [line: 3, column_begin: 36, column_end: 39], [1, 2, 3]}
   end
 
   test :unary_with_integer_precedence do


### PR DESCRIPTION
Just close this :)
Putting here for possible reference later. #3553 

Over in #elixir-emacs we were looking into using the Code.string_to_quoted for tooling.  We noticed column info is returned from :elixir_tokenizer.tokenize but gets lost in :elixir_parser.parse. 
This PR passes this data through.
