### PR TITLE
Adds `List.combinations/2`

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -466,6 +466,20 @@ defmodule List do
   end
 
   @doc """
+  Returns a list of all possible `k` length combinations
+
+  ## Examples
+
+      iex> List.combinations([1, 2, 3], 2)
+      [[1, 2], [1, 3], [2, 3]]
+
+  """
+  @spec combinations(list, non_neg_integer) :: list
+  def combinations(collection, k) do
+    List.last(do_combinations(collection, k))
+  end
+
+  @doc """
   Converts a char list to an atom.
 
   Currently Elixir does not support conversions from char lists
@@ -695,6 +709,18 @@ defmodule List do
 
   defp do_zip_each([], _) do
     {nil, nil}
+  end
+
+  # combinations
+
+  defp do_combinations(list, k) do
+    combinations_by_length = [[[]]|List.duplicate([], k)]
+
+    List.foldr list, combinations_by_length, fn x, next ->
+      sub = :lists.droplast(next)
+      step = [[]|(for l <- sub, do: (for s <- l, do: [x|s]))]
+      :lists.zipwith(&:lists.append/2, step, next)
+    end
   end
 
   defp to_list(tuple) when is_tuple(tuple), do: Tuple.to_list(tuple)

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -148,6 +148,16 @@ defmodule ListTest do
     assert List.delete_at([1, 2, 3], -4) == [1, 2, 3]
   end
 
+  test :combinations do
+    list = [1,2,3,4]
+    assert List.combinations(list, 0) == [[]]
+    assert List.combinations(list, 1) == [[1], [2], [3], [4]]
+    assert List.combinations(list, 2) == [[1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]
+    assert List.combinations(list, 3) == [[1, 2, 3], [1, 2, 4], [1, 3, 4], [2, 3, 4]]
+    assert List.combinations(list, 4) == [[1,2,3,4]]
+    assert List.combinations(list, 5) == []
+  end
+
   test :to_string do
     assert List.to_string([?æ, ?ß]) == "æß"
     assert List.to_string([?a, ?b, ?c]) == "abc"


### PR DESCRIPTION
This adds `List.combinations/2`, which behaves similarly to ruby's [Array#combination](http://ruby-doc.org/core-2.2.0/Array.html#method-i-combination)

The implementation is a port from an erlang one [here](http://rosettacode.org/wiki/Combinations#Dynamic_Programming). It's slightly complex because the naive approach gets pathologically slow for large lists.

Thank you in advance for any feedback!