### PR TITLE
Provide more information on the cause of exceptions (problems discussed in #3555)

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -356,7 +356,7 @@ defmodule ExUnit.Assertions do
           name == ExUnit.AssertionError ->
             reraise(error, stacktrace)
           true ->
-            flunk "Expected exception #{inspect exception} but got #{inspect name} (#{Exception.message(error)})"
+            reraise ExUnit.AssertionError, [message: "Expected exception #{inspect exception} but got #{inspect name} (#{Exception.message(error)})"], stacktrace
         end
     else
       _ -> flunk "Expected exception #{inspect exception} but nothing was raised"

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -272,10 +272,11 @@ defmodule ExUnit.DocTest do
           reraise e, stack
 
         error ->
+          original_stack = System.stacktrace
           reraise ExUnit.AssertionError,
             [message: "Doctest failed: got #{inspect(error.__struct__)} with message #{Exception.message(error)}",
              expr: unquote(whole_expr)],
-            stack
+            original_stack
       end
     end
   end

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -253,6 +253,16 @@ defmodule ExUnit.AssertionsTest do
       "(undefined function: Not.Defined.function/3 (module Not.Defined is not available))" = error.message
   end
 
+  test "assert raise with some other error includes stacktrace from original error" do
+    "This should never be tested" = assert_raise ArgumentError, fn ->
+      Not.Defined.function(1, 2, 3)
+    end
+  rescue
+    ExUnit.AssertionError ->
+      stacktrace = System.stacktrace
+      [{Not.Defined, :function, [1,2,3], _}|_] = stacktrace
+  end
+
   test "assert raise with erlang error" do
     assert_raise SyntaxError, fn ->
       List.flatten(1)

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -253,13 +253,15 @@ defmodule ExUnit.DocTestTest do
            test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
     """
 
+    # The stacktrace points to the cause of the error
     assert output =~ """
       4) test moduledoc at ExUnit.DocTestTest.Invalid (4) (ExUnit.DocTestTest.ActuallyCompiled)
          test/ex_unit/doc_test_test.exs:218
          Doctest failed: got UndefinedFunctionError with message undefined function: Hello.world/0 (module Hello is not available)
          code:  Hello.world
          stacktrace:
-           test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
+           Hello.world()
+           (for doctest at) test/ex_unit/doc_test_test.exs:117
     """
 
     assert output =~ """


### PR DESCRIPTION
After the discussion on #3555, I felt I need some easier to review code as examples.

This changes address both my initial issue on #3555 with doctest not providing much help in diagnosing runtime errors as well as @fishcakez concern on a similar issue for `assert_raise` (in two separate commits).

The code implements my solution of preserving the original stacktrace, since the error messages already preserve the original `Exception` and `message`. Both cases are resolved in a similar way, but there is no code reuse between them. 

Feel free to provide feedback on the code and general approach. I've been with Elixir for about 2 weeks, so it is quite possible that I am missing things both at the high and low level :-)