### PR TITLE
Raise if piping into binary operator with 2 args already

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -78,6 +78,12 @@ defmodule Macro do
     bad_pipe(expr, call_args)
   end
 
+  def pipe(expr, {call, _, [_, _]} = call_args, _integer)
+      when call in @binary_ops do
+    raise ArgumentError, "cannot pipe #{to_string expr} into #{to_string call_args}, " <>
+      "the #{to_string call} operator can only take two arguments"
+  end
+
   def pipe(expr, {call, line, atom}, integer) when is_atom(atom) do
     {call, line, List.insert_at([], integer, expr)}
   end

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -527,6 +527,10 @@ defmodule MacroTest do
     assert_raise ArgumentError, ~r"cannot pipe 1 into 2", fn ->
       Macro.pipe(1, 2, 0)
     end
+
+    assert_raise ArgumentError, ~r"cannot pipe 1 into 1 \+ 1", fn ->
+      Macro.pipe(1, quote(do: 1 + 1), 0) == quote(do: foo(1))
+    end
   end
 
   test :unpipe do


### PR DESCRIPTION
Github issue #3483
Simple enough - added a clause to the `pipe` function that matches a binary operator with 2 arguments and raises an error

(I'm new so I welcome suggestions & criticism of all kinds)