### PR TITLE
Introduce :capture_log ExUnit configuration.

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -170,6 +170,10 @@ defmodule ExUnit do
     * `:assert_receive_timeout` - the timeout to be used on `assert_receive`
       calls. Defaults to 100ms.
 
+    * `:capture_log` - if ExUnit should default to keeping track of log messages
+      and print them on test failure. Can be overriden for individual tests via
+      `@tag capture_log: false`. Defaults to `false`.
+
     * `:colors` - a keyword list of colors to be used by some formatters.
       The only option so far is `[enabled: boolean]` which defaults to `IO.ANSI.enabled?/0`
 

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -121,6 +121,7 @@ defmodule ExUnit.Case do
 
   The following tags customize how tests behaves:
 
+    * `:capture_log` - see Log Capture below.
     * `:skip` - skips the test with the given reason
     * `:timeout` - customizes the test timeout in milliseconds (defaults to 30000)
 
@@ -150,6 +151,25 @@ defmodule ExUnit.Case do
 
   Keep in mind that all tests are included by default, so unless they are
   excluded first, the `include` option has no effect.
+
+  ## Log Capture
+
+  ExUnit can optionally supress printing of log messages that are generated during a test. Log
+  messages generated while running a test are captured and only if the test fails are they printed
+  to aid with debugging.
+
+  You can opt into this behavior for individual tests by tagging them with `:capture_log` or enable
+  log capture for all tests in the ExUnit configuration:
+
+      config :ex_unit, capture_log: true
+
+  This default can be overriden by `@tag capture_log: false` or `@moduletag capture_log: false`.
+
+  Since `setup_all` blocks don't belong to a specific test, log messages generated in them (or 
+  between tests) are never captured. If you want to supress these messages as well, remove the
+  console backend globally:
+
+      config :logger, backends: []
   """
 
   @doc false

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -26,6 +26,7 @@ defmodule ExUnit.Runner do
 
     config = %{
       async_cases: [],
+      capture_log: opts[:capture_log],
       exclude: opts[:exclude],
       include: opts[:include],
       manager: pid,
@@ -220,7 +221,7 @@ defmodule ExUnit.Runner do
     EM.test_started(config.manager, test)
 
     if is_nil(test.state) do
-      capture_log? = Map.get(tags, :capture_log, false)
+      capture_log? = Map.get(tags, :capture_log, config.capture_log)
       test = run_test(capture_log?, config, test, Map.merge(tags, context))
     end
 

--- a/lib/ex_unit/mix.exs
+++ b/lib/ex_unit/mix.exs
@@ -17,6 +17,7 @@ defmodule ExUnit.Mixfile do
 
        assert_receive_timeout: 100,
        autorun: true,
+       capture_log: false,
        colors: [],
        exclude: [],
        include: [],


### PR DESCRIPTION
Follow up to https://github.com/elixir-lang/elixir/pull/3390#issuecomment-129831660

I've made it into a separate ExUnit configuration because I couldn't think of any other use cases for default tags, except for setting the `timeout` tag, but that's already a separate ExUnit configuration. If you want configurable default tags instead I'll change it.

/cc @josevalim 