### PR TITLE
Added a blub about underscore names to the `import` documentation

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -586,6 +586,14 @@ defmodule Kernel.SpecialForms do
   After the two import calls above, only `List.keyfind/3` will be
   imported.
 
+  ## Underscore functions
+
+  By default functions starting with `_` are not imported. If you really want
+  to import a function starting with `_` you must explicitly include it in the
+  `:only` selector.
+
+      import File.Stream, only: [__build__: 3]
+
   ## Lexical scope
 
   It is important to notice that `import` is lexical. This means you


### PR DESCRIPTION
Noticed this behaviour, found issue #482 stating it was intentional, decided to document it.