### PR TITLE
Fix indentention inside lists

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -132,12 +132,12 @@ defmodule File do
   Typical error reasons are:
 
     * `:eacces`  - missing search or write permissions for the parent
-       directories of `path`
+      directories of `path`
     * `:eexist`  - there is already a file or directory named `path`
     * `:enoent`  - a component of `path` does not exist
     * `:enospc`  - there is a no space left on the device
     * `:enotdir` - a component of `path` is not a directory;
-       on some platforms, `:enoent` is returned instead
+      on some platforms, `:enoent` is returned instead
   """
   @spec mkdir(Path.t) :: :ok | {:error, posix}
   def mkdir(path) do
@@ -164,7 +164,7 @@ defmodule File do
   Typical error reasons are:
 
     * `:eacces`  - missing search or write permissions for the parent
-                   directories of `path`
+      directories of `path`
     * `:enospc`  - there is a no space left on the device
     * `:enotdir` - a component of `path` is not a directory
   """
@@ -218,10 +218,10 @@ defmodule File do
 
     * `:enoent`  - the file does not exist
     * `:eacces`  - missing permission for reading the file,
-                   or for searching one of the parent directories
+      or for searching one of the parent directories
     * `:eisdir`  - the named file is a directory
     * `:enotdir` - a component of the file name is not a directory;
-                   on some platforms, `:enoent` is returned instead
+      on some platforms, `:enoent` is returned instead
     * `:enomem`  - there is not enough memory for the contents of the file
 
   You can use `:file.format_error/1` to get a descriptive string of the error.
@@ -656,10 +656,10 @@ defmodule File do
 
     * `:enoent`  - a component of the file name does not exist
     * `:enotdir` - a component of the file name is not a directory;
-                   on some platforms, enoent is returned instead
+      on some platforms, enoent is returned instead
     * `:enospc`  - there is a no space left on the device
     * `:eacces`  - missing permission for writing the file or searching one of
-                   the parent directories
+      the parent directories
     * `:eisdir`  - the named file is a directory
 
   Check `File.open/2` for other available options.
@@ -695,7 +695,7 @@ defmodule File do
     * `:eacces`  - missing permission for the file or one of its parents
     * `:eperm`   - the file is a directory and user is not super-user
     * `:enotdir` - a component of the file name is not a directory;
-                   on some platforms, enoent is returned instead
+      on some platforms, enoent is returned instead
     * `:einval`  - filename had an improper type, such as tuple
 
   ## Examples

--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -184,7 +184,7 @@ defmodule Float do
     * `:decimals`   — number of decimal points to show
     * `:scientific` — number of decimal points to show, in scientific format
     * `:compact`    — when `true`, use the most compact representation (ignored
-                      with the `scientific` option)
+      with the `scientific` option)
 
   ## Examples
 

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -74,7 +74,7 @@ defmodule GenServer do
       -  `{:stop, reason}`
 
     * `handle_call(msg, {from, ref}, state)` - invoked to handle call (sync)
-       messages.
+      messages.
 
       It must return:
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3188,9 +3188,9 @@ defmodule Kernel do
   two functions to be implemented:
 
     * `exception/1` - receives the arguments given to `raise/2`
-       and returns the exception struct. The default implementation
-       accepts either a set of keyword arguments that is merged into
-       the struct or a string to be used as the exception's message.
+      and returns the exception struct. The default implementation
+      accepts either a set of keyword arguments that is merged into
+      the struct or a string to be used as the exception's message.
 
     * `message/1` - receives the exception struct and must return its
       message. Most commonly exceptions have a message field which

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -53,8 +53,8 @@ defmodule OptionParser do
   For each switch, the following types are supported:
 
     * `:boolean` - marks the given switch as a boolean. Boolean switches
-                   never consume the following value unless it is `true` or
-                   `false`.
+      never consume the following value unless it is `true` or
+      `false`.
     * `:integer` - parses the switch as an integer.
     * `:float`   - parses the switch as a float.
     * `:string`  - returns the switch as a string.

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -184,7 +184,7 @@ defmodule Regex do
 
     * `:return`  - set to `:index` to return indexes. Defaults to `:binary`.
     * `:capture` - what to capture in the result. Check the moduledoc for `Regex`
-                   to see the possible capture values.
+      to see the possible capture values.
 
   ## Examples
 

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -26,7 +26,7 @@ defmodule Mix.Task do
   configure them in Mix:
 
     * `@shortdoc`  - makes the task public with a short description that appears
-                     on `mix help`
+      on `mix help`
     * `@recursive` - run the task recursively in umbrella projects
 
   """


### PR DESCRIPTION
Closes: https://github.com/elixir-lang/ex_doc/issues/283
also [reported to earmark](https://github.com/pragdave/earmark/issues/27)

The following commands were used to find the buggy strings:
`ag "[\r\n]\ {4}\[*-]([^\r\n]+[\r\n])+\ {7,}"`
`ag "[\r\n]\ {4}[-*]([^\r\n]+[\r\n])(\ {4,}[^\r\n]+[\r\n])+\ {7,}"`
