### PR TITLE
@callback can now be used directly (without Behaviour). Add @macrocallback.

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2202,12 +2202,13 @@ defmodule Kernel do
     raise ArgumentError, "expected 0 or 1 argument for @#{name}, got: #{length(args)}"
   end
 
-  defp typespec(:type),     do: :deftype
-  defp typespec(:typep),    do: :deftypep
-  defp typespec(:opaque),   do: :defopaque
-  defp typespec(:spec),     do: :defspec
-  defp typespec(:callback), do: :defcallback
-  defp typespec(_),         do: false
+  defp typespec(:type),          do: :deftype
+  defp typespec(:typep),         do: :deftypep
+  defp typespec(:opaque),        do: :defopaque
+  defp typespec(:spec),          do: :defspec
+  defp typespec(:callback),      do: :defcallback
+  defp typespec(:macrocallback), do: :defmacrocallback
+  defp typespec(_),              do: false
 
   @doc """
   Returns the binding for the given context as a keyword list.

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -287,11 +287,12 @@ defmodule Module do
   The following attributes are part of typespecs and are also reserved by
   Elixir (see `Kernel.Typespec` for more information about typespecs):
 
-    * `@type`        - defines a type to be used in `@spec`
-    * `@typep`       - defines a private type to be used in `@spec`
-    * `@opaque`      - defines an opaque type to be used in `@spec`
-    * `@spec`        - provides a specification for a function
-    * `@callback`    - provides a specification for the behaviour callback
+    * `@type`          - defines a type to be used in `@spec`
+    * `@typep`         - defines a private type to be used in `@spec`
+    * `@opaque`        - defines an opaque type to be used in `@spec`
+    * `@spec`          - provides a specification for a function
+    * `@callback`      - provides a specification for a behaviour callback
+    * `@macrocallback` - provides a specification for a macro behaviour callback
 
   In addition to the built-in attributes outlined above, custom attributes may
   also be added. A custom attribute is any valid identifier prefixed with an
@@ -1020,8 +1021,8 @@ defmodule Module do
   defp normalize_attribute(:on_definition, atom) when is_atom(atom),
     do: {atom, :__on_definition__}
 
-  defp normalize_attribute(key, _value) when key in [:type, :typep, :export_type, :opaque, :callback] do
-    raise ArgumentError, "attributes type, typep, export_type, opaque and callback " <>
+  defp normalize_attribute(key, _value) when key in [:type, :typep, :export_type, :opaque, :callback, :macrocallback] do
+    raise ArgumentError, "attributes type, typep, export_type, opaque, callback and macrocallback " <>
       "must be set via Kernel.Typespec"
   end
 

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -152,7 +152,7 @@ build(Line, File, Module, Docs, Lexical) ->
 
   Attributes = [behaviour, on_load, compile, external_resource, dialyzer],
   ets:insert(Data, {?acc_attr, [before_compile, after_compile, on_definition, derive,
-                                spec, type, typep, opaque, callback|Attributes]}),
+                                spec, type, typep, opaque, callback, macrocallback|Attributes]}),
   ets:insert(Data, {?persisted_attr, [vsn|Attributes]}),
   ets:insert(Data, {?lexical_attr, Lexical}),
 
@@ -276,7 +276,7 @@ typedocs_attributes(Types, Forms) ->
 specs_form(Data, Defmacro, Defmacrop, Unreachable, Forms) ->
   case elixir_compiler:get_opt(internal) of
     false ->
-      Specs0 = get_typespec(Data, spec) ++ get_typespec(Data, callback),
+      Specs0 = get_typespec(Data, spec) ++ get_typespec(Data, callback) ++ get_typespec(Data, macrocallback),
       Specs1 = ['Elixir.Kernel.Typespec':translate_spec(Kind, Expr, Caller) ||
                 {Kind, Expr, Caller} <- Specs0],
       Specs2 = lists:flatmap(fun(Spec) ->

--- a/lib/elixir/test/elixir/kernel/docs_test.exs
+++ b/lib/elixir/test/elixir/kernel/docs_test.exs
@@ -7,8 +7,7 @@ defmodule Kernel.DocsTest do
     deftestmodule(SampleDocs)
     docs = Code.get_docs(SampleDocs, :all)
 
-    assert [{{:__behaviour__, 1}, _, :def, [{:atom, [], Elixir}], false},
-            {{:argnames, 5}, _, :def, [
+    assert [{{:argnames, 5}, _, :def, [
               {:list1, [], Elixir},
               {:list2, [], Elixir},
               {:map1, [], Elixir},
@@ -60,21 +59,19 @@ defmodule Kernel.DocsTest do
     write_beam(defmodule name do
       @moduledoc "Hello, I am a module"
 
-      use Behaviour
-
       @doc "I should be first."
-      defcallback first :: term
+      @callback first :: term
 
       @doc "Foo"
-      defcallback foo(any) :: any
+      @callback foo(any) :: any
 
       @doc false
-      defcallback bar(true) :: false
+      @callback bar(true) :: false
 
-      defcallback baz(1, binary) :: binary
+      @callback baz(1, binary) :: binary
 
       @doc "I should be last."
-      defmacrocallback last(integer) :: Macro.t
+      @macrocallback last(integer) :: Macro.t
 
       @doc """
       This is fun!

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -642,4 +642,62 @@ defmodule Kernel.TypespecTest do
     assert Kernel.Typespec.beam_types(Unknown) == nil
     assert Kernel.Typespec.beam_specs(Unknown) == nil
   end
+
+  defmodule Sample do
+    @callback first(integer) :: integer
+
+    @callback foo(atom(), binary) :: binary
+
+    @callback bar(External.hello, my_var :: binary) :: binary
+
+    @callback guarded(my_var) :: my_var when my_var: binary
+
+    @callback orr(atom | integer) :: atom
+
+    @callback literal(123, {atom}, :atom, [integer], true) :: atom
+
+    @macrocallback last(integer) :: Macro.t
+  end
+
+  test :callbacks do
+    assert Sample.behaviour_info(:callbacks) == [first: 1, guarded: 1, "MACRO-last": 2, literal: 5, orr: 1, foo: 2, bar: 2]
+  end
+
+  test :default_is_not_supported do
+    assert_raise ArgumentError, fn ->
+      defmodule WithDefault do
+        @callback hello(num \\ 0 :: integer) :: integer
+      end
+    end
+
+    assert_raise ArgumentError, fn ->
+      defmodule WithDefault do
+        @callback hello(num :: integer \\ 0) :: integer
+      end
+    end
+
+    assert_raise ArgumentError, fn ->
+      defmodule WithDefault do
+        @macrocallback hello(num \\ 0 :: integer) :: Macro.t
+      end
+    end
+
+    assert_raise ArgumentError, fn ->
+      defmodule WithDefault do
+        @macrocallback hello(num :: integer \\ 0) :: Macro.t
+      end
+    end
+
+    assert_raise ArgumentError, fn ->
+      defmodule WithDefault do
+        @spec hello(num \\ 0 :: integer) :: integer
+      end
+    end
+
+    assert_raise ArgumentError, fn ->
+      defmodule WithDefault do
+        @spec hello(num :: integer \\ 0) :: integer
+      end
+    end
+  end
 end


### PR DESCRIPTION
Implements (at least part of!) #3465.

* Updates existing `@callback` attr to attach `@doc` and raise on invalid use of defaults in typespec
* Adds new `@macrocallback` attr, which can be used to define behaviour macro callbacks. Also supports `@doc` and raise on invalid use of defaults in typespec
* Refactors `Behaviour` as a thin layer above the "new" `@callback` and `@macrocallback` attrs
* Adds `Kernel.Typespec.beam_callbackdocs/1`, which returns all callback docs from the given module's beam code.