### PR TITLE
Fix doc comment for File.cp_r

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -531,7 +531,7 @@ defmodule File do
 
       # Same as before, but asks the user how to proceed in case of conflicts
       File.cp_r "samples", "tmp", fn(source, destination) ->
-        IO.gets("Overwriting #{destination} by #{source}. Type y to confirm.") == "y"
+        IO.gets("Overwriting #{destination} by #{source}. Type y to confirm. ") == "y\n"
       end
 
   """


### PR DESCRIPTION
In fact IO.gets always returns a line ended by a LF symbol in such the cases. So we have to take this into account when comparing user input with a target string.