### PR TITLE
Slight imporvement in doctest error line numbers

### DIFF
--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -392,7 +392,8 @@ defmodule ExUnit.DocTest do
   defp extract_from_moduledoc({_, doc}) when doc in [false, nil], do: []
 
   defp extract_from_moduledoc({line, doc}) do
-    for test <- extract_tests(line, doc) do
+    # Line number will be accurate if moduledoc is on first line.
+    for test <- extract_tests(line + 1, doc, false) do
       %{test | fun_arity: :moduledoc}
     end
   end
@@ -400,35 +401,39 @@ defmodule ExUnit.DocTest do
   defp extract_from_doc({_, _, _, _, doc}) when doc in [false, nil], do: []
 
   defp extract_from_doc({fa, line, _, _, doc}) do
-    for test <- extract_tests(line, doc) do
+    # Line numbers will be accurate if there are no blank lines between
+    # the doc and function definition.
+    for test <- extract_tests(line - 1, doc, true) do
       %{test | fun_arity: fa}
     end
   end
 
-  defp extract_tests(line, doc) do
-    lines = String.split(doc, ~r/\n/, trim: false) |> adjust_indent
-    extract_tests(lines, line, "", "", [], true)
+  defp extract_tests(line_no, doc, subtract) do
+    all_lines = String.split(doc, ~r/\n/, trim: false)  
+    starting_line = if subtract, do: line_no - length(all_lines), else: line_no
+    lines = adjust_indent(all_lines, starting_line)
+    extract_tests(lines, "", "", [], true)
   end
 
-  defp adjust_indent(lines) do
-    adjust_indent(lines, [], 0, :text)
+  defp adjust_indent(lines, line_no) do
+    adjust_indent(lines, line_no, [], 0, :text)
   end
 
-  defp adjust_indent([], adjusted_lines, _indent, _) do
+  defp adjust_indent([], _line_no, adjusted_lines, _indent, _) do
     Enum.reverse adjusted_lines
   end
 
   @iex_prompt ["iex>", "iex("]
   @dot_prompt ["...>", "...("]
 
-  defp adjust_indent([line|rest], adjusted_lines, indent, :text) do
+  defp adjust_indent([line|rest], line_no, adjusted_lines, indent, :text) do
     case String.starts_with?(String.lstrip(line), @iex_prompt) do
-      true  -> adjust_indent([line|rest], adjusted_lines, get_indent(line, indent), :prompt)
-      false -> adjust_indent(rest, adjusted_lines, indent, :text)
+      true  -> adjust_indent([line|rest], line_no + 1, adjusted_lines, get_indent(line, indent), :prompt)
+      false -> adjust_indent(rest, line_no + 1, adjusted_lines, indent, :text)
     end
   end
 
-  defp adjust_indent([line|rest], adjusted_lines, indent, check) when check in [:prompt, :after_prompt] do
+  defp adjust_indent([line|rest], line_no, adjusted_lines, indent, check) when check in [:prompt, :after_prompt] do
     stripped_line = strip_indent(line, indent)
 
     case String.lstrip(line) do
@@ -441,22 +446,22 @@ defmodule ExUnit.DocTest do
     end
 
     if String.starts_with?(stripped_line, @iex_prompt ++ @dot_prompt) do
-      adjust_indent(rest, [stripped_line|adjusted_lines], indent, :after_prompt)
+      adjust_indent(rest, line_no + 1, [{stripped_line, line_no}|adjusted_lines], indent, :after_prompt)
     else
       next = if check == :prompt, do: :after_prompt, else: :code
-      adjust_indent(rest, [stripped_line|adjusted_lines], indent, next)
+      adjust_indent(rest, line_no + 1, [{stripped_line, line_no}|adjusted_lines], indent, next)
     end
   end
 
-  defp adjust_indent([line|rest], adjusted_lines, indent, :code) do
+  defp adjust_indent([line|rest], line_no, adjusted_lines, indent, :code) do
     stripped_line = strip_indent(line, indent)
     cond do
       stripped_line == "" ->
-        adjust_indent(rest, [stripped_line|adjusted_lines], 0, :text)
+        adjust_indent(rest, line_no + 1, [{stripped_line, line_no}|adjusted_lines], 0, :text)
       String.starts_with?(String.lstrip(line), @iex_prompt) ->
-        adjust_indent([line|rest], adjusted_lines, indent, :prompt)
+        adjust_indent([line|rest], line_no + 1, adjusted_lines, indent, :prompt)
       true ->
-        adjust_indent(rest, [stripped_line|adjusted_lines], indent, :code)
+        adjust_indent(rest, line_no + 1, [{stripped_line, line_no}|adjusted_lines], indent, :code)
     end
   end
 
@@ -476,83 +481,83 @@ defmodule ExUnit.DocTest do
     end
   end
 
-  defp extract_tests([], _line, "", "", [], _) do
+  defp extract_tests([], "", "", [], _) do
     []
   end
 
-  defp extract_tests([], _line, "", "", acc, _) do
+  defp extract_tests([], "", "", acc, _) do
     Enum.reverse(reverse_last_test(acc))
   end
 
   # End of input and we've still got a test pending.
-  defp extract_tests([], _, expr_acc, expected_acc, [test=%{exprs: exprs}|t], _) do
+  defp extract_tests([], expr_acc, expected_acc, [test=%{exprs: exprs}|t], _) do
     test = %{test | exprs: [{expr_acc, {:test, expected_acc}} | exprs]}
     Enum.reverse(reverse_last_test([test|t]))
   end
 
   # We've encountered the next test on an adjacent line. Put them into one group.
-  defp extract_tests([<< "iex>", _ :: binary>>|_] = list, line, expr_acc, expected_acc, [test=%{exprs: exprs}|t], newtest) when expr_acc != "" and expected_acc != "" do
+  defp extract_tests([{<< "iex>", _ :: binary>>,_}|_] = list, expr_acc, expected_acc, [test=%{exprs: exprs}|t], newtest) when expr_acc != "" and expected_acc != "" do
     test = %{test | exprs: [{expr_acc, {:test, expected_acc}} | exprs]}
-    extract_tests(list, line, "", "", [test|t], newtest)
+    extract_tests(list, "", "", [test|t], newtest)
   end
 
   # Store expr_acc and start a new test case.
-  defp extract_tests([<< "iex>", string :: binary>>|lines], line, "", expected_acc, acc, true) do
+  defp extract_tests([{<< "iex>", string :: binary>>, line}|lines], "", expected_acc, acc, true) do
     acc = reverse_last_test(acc)
     test = %{line: line, fun_arity: nil, exprs: []}
-    extract_tests(lines, line, string, expected_acc, [test|acc], false)
+    extract_tests(lines, string, expected_acc, [test|acc], false)
   end
 
   # Store expr_acc.
-  defp extract_tests([<< "iex>", string :: binary>>|lines], line, "", expected_acc, acc, false) do
-    extract_tests(lines, line, string, expected_acc, acc, false)
+  defp extract_tests([{<< "iex>", string :: binary>>, _}|lines], "", expected_acc, acc, false) do
+    extract_tests(lines, string, expected_acc, acc, false)
   end
 
   # Still gathering expr_acc. Synonym for the next clause.
-  defp extract_tests([<< "iex>", string :: binary>>|lines], line, expr_acc, expected_acc, acc, newtest) do
-    extract_tests(lines, line, expr_acc <> "\n" <> string, expected_acc, acc, newtest)
+  defp extract_tests([{<< "iex>", string :: binary>>, _}|lines], expr_acc, expected_acc, acc, newtest) do
+    extract_tests(lines, expr_acc <> "\n" <> string, expected_acc, acc, newtest)
   end
 
   # Still gathering expr_acc. Synonym for the previous clause.
-  defp extract_tests([<< "...>", string :: binary>>|lines], line, expr_acc, expected_acc, acc, newtest) when expr_acc != "" do
-    extract_tests(lines, line, expr_acc <> "\n" <> string, expected_acc, acc, newtest)
+  defp extract_tests([{<< "...>", string :: binary>>, _}|lines], expr_acc, expected_acc, acc, newtest) when expr_acc != "" do
+    extract_tests(lines, expr_acc <> "\n" <> string, expected_acc, acc, newtest)
   end
 
   # Expression numbers are simply skipped.
-  defp extract_tests([<< "iex(", _ :: 8, string :: binary>>|lines], line, expr_acc, expected_acc, acc, newtest) do
-    extract_tests(["iex" <> skip_iex_number(string)|lines], line, expr_acc, expected_acc, acc, newtest)
+  defp extract_tests([{<< "iex(", _ :: 8, string :: binary>>, _}|lines], expr_acc, expected_acc, acc, newtest) do
+    extract_tests(["iex" <> skip_iex_number(string)|lines], expr_acc, expected_acc, acc, newtest)
   end
 
   # Expression numbers are simply skipped redux.
-  defp extract_tests([<< "...(", _ :: 8, string :: binary>>|lines], line, expr_acc, expected_acc, acc, newtest) do
-    extract_tests(["..." <> skip_iex_number(string)|lines], line, expr_acc, expected_acc, acc, newtest)
+  defp extract_tests([{<< "...(", _ :: 8, string :: binary>>, _}|lines], expr_acc, expected_acc, acc, newtest) do
+    extract_tests(["..." <> skip_iex_number(string)|lines], expr_acc, expected_acc, acc, newtest)
   end
 
   # Skip empty or documentation line.
-  defp extract_tests([_|lines], line, "", "", acc, _) do
-    extract_tests(lines, line, "", "", acc, true)
+  defp extract_tests([_|lines], "", "", acc, _) do
+    extract_tests(lines, "", "", acc, true)
   end
 
   # Encountered an empty line, store pending test
-  defp extract_tests([""|lines], line, expr_acc, expected_acc, [test=%{exprs: exprs}|t], _) do
+  defp extract_tests([{"",_}|lines], expr_acc, expected_acc, [test=%{exprs: exprs}|t], _) do
     test = %{test | exprs: [{expr_acc, {:test, expected_acc}} | exprs]}
-    extract_tests(lines, line,  "", "", [test|t], true)
+    extract_tests(lines, "", "", [test|t], true)
   end
 
   # Exception test.
-  defp extract_tests([<< "** (", string :: binary >>|lines], line, expr_acc, "", [test=%{exprs: exprs}|t], newtest) do
+  defp extract_tests([{<< "** (", string :: binary >>, _}|lines], expr_acc, "", [test=%{exprs: exprs}|t], newtest) do
     test = %{test | exprs: [{expr_acc, extract_error(string, "")} | exprs]}
-    extract_tests(lines, line,  "", "", [test|t], newtest)
+    extract_tests(lines, "", "", [test|t], newtest)
   end
 
   # Finally, parse expected_acc.
-  defp extract_tests([expected|lines], line, expr_acc, expected_acc, [test=%{exprs: exprs}|t]=acc, newtest) do
+  defp extract_tests([{expected, _}|lines], expr_acc, expected_acc, [test=%{exprs: exprs}|t]=acc, newtest) do
     if expected =~ ~r/^#[A-Z][\w\.]*<.*>$/ do
       expected = expected_acc <> "\n" <> inspect(expected)
       test = %{test | exprs: [{expr_acc, {:inspect, expected}} | exprs]}
-      extract_tests(lines, line,  "", "", [test|t], newtest)
+      extract_tests(lines, "", "", [test|t], newtest)
     else
-      extract_tests(lines, line, expr_acc, expected_acc <> "\n" <> expected, acc, newtest)
+      extract_tests(lines, expr_acc, expected_acc <> "\n" <> expected, acc, newtest)
     end
   end
 

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -227,10 +227,10 @@ defmodule ExUnit.DocTestTest do
     assert output =~ """
       1) test moduledoc at ExUnit.DocTestTest.Invalid (1) (ExUnit.DocTestTest.ActuallyCompiled)
          test/ex_unit/doc_test_test.exs:218
-         Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:117: syntax error before: '*'
+         Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:120: syntax error before: '*'
          code: 1 + * 1
          stacktrace:
-           test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
+           test/ex_unit/doc_test_test.exs:120: ExUnit.DocTestTest.Invalid (module)
     """
 
     assert output =~ """
@@ -240,7 +240,7 @@ defmodule ExUnit.DocTestTest do
          code: 1 + hd(List.flatten([1])) === 3
          lhs:  2
          stacktrace:
-           test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
+           test/ex_unit/doc_test_test.exs:123: ExUnit.DocTestTest.Invalid (module)
     """
 
     assert output =~ """
@@ -250,7 +250,7 @@ defmodule ExUnit.DocTestTest do
          code: inspect(:oops) === "#HashDict<[]>"
          lhs:  ":oops"
          stacktrace:
-           test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
+           test/ex_unit/doc_test_test.exs:127: ExUnit.DocTestTest.Invalid (module)
     """
 
     # The stacktrace points to the cause of the error
@@ -261,7 +261,7 @@ defmodule ExUnit.DocTestTest do
          code:  Hello.world
          stacktrace:
            Hello.world()
-           (for doctest at) test/ex_unit/doc_test_test.exs:117
+           (for doctest at) test/ex_unit/doc_test_test.exs:130
     """
 
     assert output =~ """
@@ -270,7 +270,7 @@ defmodule ExUnit.DocTestTest do
          Doctest failed: expected exception WhatIsThis with message "oops" but got RuntimeError with message "oops"
          code: raise "oops"
          stacktrace:
-           test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
+           test/ex_unit/doc_test_test.exs:133: ExUnit.DocTestTest.Invalid (module)
     """
 
     assert output =~ """
@@ -279,7 +279,7 @@ defmodule ExUnit.DocTestTest do
          Doctest failed: expected exception RuntimeError with message "hello" but got RuntimeError with message "oops"
          code: raise "oops"
          stacktrace:
-           test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
+           test/ex_unit/doc_test_test.exs:136: ExUnit.DocTestTest.Invalid (module)
     """
   end
 


### PR DESCRIPTION
Can't get fully functional yet because the line numbers returned from `:beam_lib.chunks` are not
accurate. For docs it refers to the first line of the function, for moduledocs it refers
to the first line of the module. I'll look into that soon.

The hack I've written here only works if the docstring ends right before the function head and if the moduledoc is on the first line. Otherwise it will be of; but so is the current implementation.