### PR TITLE
Fix warning in warning_test.exs

### DIFF
--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -52,8 +52,6 @@ defmodule Kernel.WarningTest do
   end
 
   test "useless attr" do
-    message = "warning: module attribute @foo in code block has no effect as it is never returned "
-
     message = capture_err(fn ->
       Code.eval_string """
       defmodule Sample do


### PR DESCRIPTION
This was the warning:
> test/elixir/kernel/warning_test.exs:55: warning: variable message is unused