### PR TITLE
Raise if heredic terminator in invalid location

### DIFF
--- a/lib/elixir/test/elixir/kernel/binary_test.exs
+++ b/lib/elixir/test/elixir/kernel/binary_test.exs
@@ -13,7 +13,7 @@ bar
     assert 13 == __ENV__.line
     assert "foo\nbar \"\"\"\n" == """
 foo
-bar """
+bar \"""
 """
   end
 

--- a/lib/elixir/test/elixir/kernel/char_list_test.exs
+++ b/lib/elixir/test/elixir/kernel/char_list_test.exs
@@ -13,7 +13,7 @@ bar
     assert __ENV__.line == 13
     assert 'foo\nbar \'\'\'\n' == '''
 foo
-bar '''
+bar \'\'\'
 '''
   end
 

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -92,6 +92,9 @@ defmodule Kernel.ErrorsTest do
     assert_compile_fail TokenMissingError,
       "nofile:2: missing terminator: \"\"\" (for heredoc starting at line 1)",
       '"""\nbar'
+    assert_compile_fail SyntaxError,
+      "nofile:2: invalid location for heredoc terminator, please escape token or move to its own line: \"\"\"",
+      '"""\nbar"""'
   end
 
   test "unexpected end" do


### PR DESCRIPTION
issue #3503

This will raise:
```elixir
foo = """
this """
```

This will not:
```elixir
foo = """
this \"\"\"
"""
```