### PR TITLE
Improve error message when no return value specified in func spec

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -613,6 +613,11 @@ defmodule Kernel.Typespec do
     {{kind, {name, arity}, spec}, caller.line}
   end
 
+  defp translate_spec(_kind, {_name, _meta, _args} = spec, _guard, caller) do
+    spec = Macro.to_string(spec)
+    compile_error caller, "function type specification missing return type: #{spec}"
+  end
+
   defp translate_spec(_kind, spec, _guard, caller) do
     spec = Macro.to_string(spec)
     compile_error caller, "invalid function type specification: #{spec}"

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -598,7 +598,7 @@ defmodule Kernel.Typespec do
 
     unless Keyword.keyword?(guard) do
       guard = Macro.to_string(guard)
-      compile_error caller, "expected keywords as guard in function type specification, got: #{guard}"
+      compile_error caller, "expected keywords as guard in type specification, got: #{guard}"
     end
 
     vars = Keyword.keys(guard)
@@ -613,14 +613,14 @@ defmodule Kernel.Typespec do
     {{kind, {name, arity}, spec}, caller.line}
   end
 
-  defp translate_spec(_kind, {_name, _meta, _args} = spec, _guard, caller) do
+  defp translate_spec(_kind, {name, _meta, _args} = spec, _guard, caller) when is_atom(name) and name != ::: do
     spec = Macro.to_string(spec)
-    compile_error caller, "function type specification missing return type: #{spec}"
+    compile_error caller, "type specification missing return type: #{spec}"
   end
 
   defp translate_spec(_kind, spec, _guard, caller) do
     spec = Macro.to_string(spec)
-    compile_error caller, "invalid function type specification: #{spec}"
+    compile_error caller, "invalid type specification: #{spec}"
   end
 
   defp ensure_no_defaults!(args) do

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -56,9 +56,15 @@ defmodule Kernel.TypespecTest do
   end
 
   test "invalid function specification" do
-    assert_raise CompileError, ~r"invalid function type specification: \"not a spec\"", fn ->
+    assert_raise CompileError, ~r"invalid type specification: \"not a spec\"", fn ->
       test_module do
         @spec "not a spec"
+      end
+    end
+
+    assert_raise CompileError, ~r"invalid type specification: 1 :: 2", fn ->
+      test_module do
+        @spec 1 :: 2
       end
     end
   end
@@ -675,7 +681,7 @@ defmodule Kernel.TypespecTest do
   end
 
   test "@spec gives a nice error message when return type is missing" do
-    assert_raise CompileError, ~r"function type specification missing return type: myfun\(integer\)", fn ->
+    assert_raise CompileError, ~r"type specification missing return type: myfun\(integer\)", fn ->
       test_module do
         @spec myfun(integer)
       end

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -56,9 +56,9 @@ defmodule Kernel.TypespecTest do
   end
 
   test "invalid function specification" do
-    assert_raise CompileError, ~r"invalid function type specification: myfun = 1", fn ->
+    assert_raise CompileError, ~r"invalid function type specification: \"not a spec\"", fn ->
       test_module do
-        @spec myfun = 1
+        @spec "not a spec"
       end
     end
   end
@@ -670,6 +670,14 @@ defmodule Kernel.TypespecTest do
     assert_raise ArgumentError, fn ->
       defmodule WithDefault do
         @spec hello(num :: integer \\ 0) :: integer
+      end
+    end
+  end
+
+  test "@spec gives a nice error message when return type is missing" do
+    assert_raise CompileError, ~r"function type specification missing return type: myfun\(integer\)", fn ->
+      test_module do
+        @spec myfun(integer)
       end
     end
   end


### PR DESCRIPTION
Addresses #3598 

Since assignments (and everything else) are just application, I had to change a test that previously returned a generic error that was now returning the more specific error. Not sure if this should still be done or not due to that, but here's the code if people think it's a good idea having seen the impact of the change.