### PR TITLE
Line numbers for doctest errors. Fixes issue #3592

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2161,12 +2161,13 @@ defmodule Kernel do
       true ->
         raise ArgumentError, "cannot set attribute @#{name} inside function/macro"
       false ->
-        case name do
+        arg = case name do
           :behavior ->
             :elixir_errors.warn env.line, env.file,
                                 "@behavior attribute is not supported, please use @behaviour instead"
-          _ ->
-            :ok
+          :doc       -> {env.line, arg}
+          :moduledoc -> {env.line, arg}
+          _          -> arg
         end
 
         quote do: Module.put_attribute(__MODULE__, unquote(name), unquote(arg))

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -505,10 +505,19 @@ defmodule Kernel.Typespec do
   end
 
   defp store_callbackdoc(caller, module, kind, name, arity) do
-    doc = Module.get_attribute(module, :doc)
-    Module.delete_attribute(module, :doc)
+    {line, doc} = get_doc_info(module, caller)
     :ets.insert(:elixir_module.data_table(module),
-                {{:callbackdoc, {name, arity}}, caller.line, kind, doc})
+                {{:callbackdoc, {name, arity}}, line, kind, doc})
+  end
+
+  defp get_doc_info(module, caller) do
+    case Module.get_attribute(module, :doc) do
+      nil         ->
+        {caller.line, nil}
+      {line, doc} ->
+        Module.delete_attribute(module, :doc)
+        {line, doc}
+    end
   end
 
   @doc false

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -921,11 +921,13 @@ defmodule Module do
   # Used internally to compile documentation. This function
   # is private and must be used only internally.
   def compile_doc(env, kind, name, args, _guards, _body) do
-    module = env.module
-    line   = env.line
-    arity  = length(args)
-    pair   = {name, arity}
-    doc    = get_attribute(module, :doc)
+    module      = env.module
+    arity       = length(args)
+    pair        = {name, arity}
+    {line, doc} = case get_attribute(module, :doc) do
+      nil         -> {env.line, nil}
+      {line, doc} -> {line, doc}
+    end
 
     # Arguments are not expanded for the docs, but we make an exception for
     # module attributes and for structs (aliases to be precise).

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -362,7 +362,10 @@ get_docs(Data) ->
                                  [], [{{'$1', '$2', '$3', '$4', '$5'}}]}])).
 
 get_moduledoc(Line, Data) ->
-  {Line, ets:lookup_element(Data, moduledoc, 2)}.
+  case ets:lookup_element(Data, moduledoc, 2) of
+    nil -> {Line, nil};
+    {DocLine, Doc} -> {DocLine, Doc}
+  end.
 
 get_callback_docs(Data) ->
   lists:usort(ets:select(Data, [{{{callbackdoc, '$1'}, '$2', '$3', '$4'},

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -136,6 +136,19 @@ defmodule ExUnit.DocTestTest.Invalid do
       ** (RuntimeError) hello
 
   """
+
+  @doc """
+      iex> 1 + * 1
+      1
+  """
+  def a(), do: :ok
+
+  @doc """
+      iex> 1 + * 1
+      1
+  """
+  defmacro b()
+
 end |> write_beam
 
 defmodule ExUnit.DocTestTest.IndentationHeredocs do
@@ -226,60 +239,78 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       1) test moduledoc at ExUnit.DocTestTest.Invalid (1) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:218
-         Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:117: syntax error before: '*'
+         test/ex_unit/doc_test_test.exs:231
+         Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:120: syntax error before: '*'
          code: 1 + * 1
          stacktrace:
-           test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
+           test/ex_unit/doc_test_test.exs:120: ExUnit.DocTestTest.Invalid (module)
     """
 
     assert output =~ """
       2) test moduledoc at ExUnit.DocTestTest.Invalid (2) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:218
+         test/ex_unit/doc_test_test.exs:231
          Doctest failed
          code: 1 + hd(List.flatten([1])) === 3
          lhs:  2
          stacktrace:
-           test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
+           test/ex_unit/doc_test_test.exs:123: ExUnit.DocTestTest.Invalid (module)
     """
 
     assert output =~ """
       3) test moduledoc at ExUnit.DocTestTest.Invalid (3) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:218
+         test/ex_unit/doc_test_test.exs:231
          Doctest failed
          code: inspect(:oops) === "#HashDict<[]>"
          lhs:  ":oops"
          stacktrace:
-           test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
+           test/ex_unit/doc_test_test.exs:126: ExUnit.DocTestTest.Invalid (module)
     """
 
     # The stacktrace points to the cause of the error
     assert output =~ """
       4) test moduledoc at ExUnit.DocTestTest.Invalid (4) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:218
+         test/ex_unit/doc_test_test.exs:231
          Doctest failed: got UndefinedFunctionError with message undefined function: Hello.world/0 (module Hello is not available)
          code:  Hello.world
          stacktrace:
            Hello.world()
-           (for doctest at) test/ex_unit/doc_test_test.exs:117
+           (for doctest at) test/ex_unit/doc_test_test.exs:129
     """
 
     assert output =~ """
       5) test moduledoc at ExUnit.DocTestTest.Invalid (5) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:218
+         test/ex_unit/doc_test_test.exs:231
          Doctest failed: expected exception WhatIsThis with message "oops" but got RuntimeError with message "oops"
          code: raise "oops"
          stacktrace:
-           test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
+           test/ex_unit/doc_test_test.exs:132: ExUnit.DocTestTest.Invalid (module)
     """
 
     assert output =~ """
       6) test moduledoc at ExUnit.DocTestTest.Invalid (6) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:218
+         test/ex_unit/doc_test_test.exs:231
          Doctest failed: expected exception RuntimeError with message "hello" but got RuntimeError with message "oops"
          code: raise "oops"
          stacktrace:
-           test/ex_unit/doc_test_test.exs:117: ExUnit.DocTestTest.Invalid (module)
+           test/ex_unit/doc_test_test.exs:135: ExUnit.DocTestTest.Invalid (module)
+    """
+
+    assert output =~ """
+      7) test doc at ExUnit.DocTestTest.Invalid.a/0 (7) (ExUnit.DocTestTest.ActuallyCompiled)
+         test/ex_unit/doc_test_test.exs:231
+         Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:141: syntax error before: '*'
+         code: 1 + * 1
+         stacktrace:
+           test/ex_unit/doc_test_test.exs:141: ExUnit.DocTestTest.Invalid (module)
+    """
+
+    assert output =~ """
+      8) test doc at ExUnit.DocTestTest.Invalid.b/0 (8) (ExUnit.DocTestTest.ActuallyCompiled)
+         test/ex_unit/doc_test_test.exs:231
+         Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:147: syntax error before: '*'
+         code: 1 + * 1
+         stacktrace:
+           test/ex_unit/doc_test_test.exs:147: ExUnit.DocTestTest.Invalid (module)
     """
   end
 


### PR DESCRIPTION
Note that this will change line numbers `Code.get_docs` returns for `:docs` and `:moduledoc` sections.