### PR TITLE
Improve error messages for `match?` assertions

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -101,6 +101,17 @@ defmodule ExUnit.Assertions do
     end
   end
 
+  defmacro assert({:match?, _, [left, right]} = assertion) do
+    code = Macro.escape(assertion)
+    quote do
+      right = unquote(right)
+      assert match?(unquote(left), right),
+        right: right,
+        expr: unquote(code),
+        message: "match (match?) failed"
+    end
+  end
+
   defmacro assert(assertion) do
     case translate_assertion(assertion) do
       nil ->
@@ -130,6 +141,17 @@ defmodule ExUnit.Assertions do
       refute age < 0
 
   """
+  defmacro refute({:match?, _, [left, right]} = assertion) do
+    code = Macro.escape(assertion)
+    quote do
+      right = unquote(right)
+      refute match?(unquote(left), right),
+        right: right,
+        expr: unquote(code),
+        message: "match (match?) succeeded, but should have failed"
+    end
+  end
+
   defmacro refute(assertion) do
     case translate_assertion({:!, [], [assertion]}) do
       nil ->

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -75,6 +75,32 @@ defmodule ExUnit.AssertionsTest do
     {2, 1} = (assert {2, 1} = Value.tuple)
   end
 
+  test "assert match?" do
+    true = assert match?({2, 1}, Value.tuple)
+
+    try do
+      "This should never be tested" = assert match?({:ok, _}, error(true))
+    rescue
+      error in [ExUnit.AssertionError] ->
+        "match (match?) failed" = error.message
+        "match?({:ok, _}, error(true))" = Macro.to_string(error.expr)
+        "{:error, true}" = Macro.to_string(error.right)
+    end
+  end
+
+  test "refute match?" do
+    false = refute match?({1, 1}, Value.tuple)
+
+    try do
+      "This should never be tested" = refute match?({:error, _}, error(true))
+    rescue
+      error in [ExUnit.AssertionError] ->
+        "match (match?) succeeded, but should have failed" = error.message
+        "match?({:error, _}, error(true))" = Macro.to_string(error.expr)
+        "{:error, true}" = Macro.to_string(error.right)
+    end
+  end
+
   test "assert receive waits" do
     parent = self
     spawn fn -> send parent, :hello end


### PR DESCRIPTION
Follow-up to https://github.com/elixir-lang/elixir/issues/3488#issuecomment-133423879.
* [x] `assert match?(..)`
* [x] `refute match?(..)`