### PR TITLE
fix(Kernel): check arguments on if

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2292,7 +2292,7 @@ defmodule Kernel do
   In order to compare more than two clauses, the `cond/1` macro has to be used.
   """
   defmacro if(condition, clauses) do
-    {do_clause, else_clause} = extract_do_else(clauses)
+    {do_clause, else_clause} = extract_do_else(clauses, "if")
     optimize_boolean(quote do
       case unquote(condition) do
         x when x in [false, nil] -> unquote(else_clause)
@@ -2328,8 +2328,7 @@ defmodule Kernel do
 
   """
   defmacro unless(clause, options) do
-    do_clause   = Keyword.get(options, :do, nil)
-    else_clause = Keyword.get(options, :else, nil)
+    {do_clause, else_clause} = extract_do_else(options, "unless")
     quote do
       if(unquote(clause), do: unquote(else_clause), else: unquote(do_clause))
     end
@@ -3872,36 +3871,46 @@ defmodule Kernel do
     end
   end
 
-  defp extract_do_else(clauses), do: extract_do_else(clauses, :missing, :missing)
+  defp extract_do_else(clauses, type) do
+    case extract_do_else(clauses, :missing, :missing) do
+      {:ok, do_else_clauses} ->
+        do_else_clauses
+      {:error, :duplicate_do} ->
+        raise(ArgumentError, "duplicate `do` key in #{type}")
+      {:error, :duplicate_else} ->
+        raise(ArgumentError, "duplicate `else` key in #{type}")
+      {:error, :missing_do} ->
+        raise(ArgumentError, "#{type} clauses must contain `do` key")
+      {:error, {:invalid_key, key}} ->
+        raise(ArgumentError, "invalid key `#{key}` in #{type}, valid keys are `do` and `else`")
+    end
+  end
 
   defp extract_do_else([{:do, _} = do_block | tail], :missing, else_block) do
     extract_do_else(tail, do_block, else_block)
   end
   defp extract_do_else([{:do, _} | _t], _, _) do
-    raise(ArgumentError, "duplicate `do` key in if")
+    {:error, :duplicate_do}
   end
 
   defp extract_do_else([{:else, _} = else_block | tail], do_block, :missing) do
     extract_do_else(tail, do_block, else_block)
   end
   defp extract_do_else([{:else, _} | _t], _, _) do
-    raise(ArgumentError, "duplicate `else` key in if")
+    {:error, :duplicate_else}
   end
 
   defp extract_do_else([{key, _} | _t], _, _) do
-    raise(ArgumentError, "invalid key `#{key}` in if, valid keys are `do` and `else`")
+    {:error, {:invalid_key, key}}
   end
 
   defp extract_do_else([], {:do, do_block}, {:else, else_block}) do
-    {do_block, else_block}
+    {:ok, {do_block, else_block}}
   end
   defp extract_do_else([], {:do, do_block}, :missing) do
-    {do_block, nil}
+    {:ok, {do_block, nil}}
   end
-  defp extract_do_else([], :missing, {:else, else_block}) do
-    {nil, else_block}
-  end
-  defp extract_do_else([], :missing, :missing) do
-    raise(ArgumentError, "if clauses must contain `do`, `else` or both")
+  defp extract_do_else([], :missing, _) do
+    {:error, :missing_do}
   end
 end

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -517,11 +517,41 @@ defmodule KernelTest do
       end
 
       assert_raise ArgumentError, "duplicate `else` key in if", fn ->
-        Code.eval_string("if true, else: 7, else: 6")
+        Code.eval_string("if true, do: 8, else: 7, else: 6")
       end
 
-      assert_raise ArgumentError, "if clauses must contain `do`, `else` or both", fn ->
+      assert_raise ArgumentError, "if clauses must contain `do` key", fn ->
+        Code.eval_string("if true, else: 6")
+      end
+
+      assert_raise ArgumentError, "if clauses must contain `do` key", fn ->
         Code.eval_string("if true, []")
+      end
+    end
+
+    test "calling unless with invalid keys" do
+      assert_raise ArgumentError, "invalid key `foo` in unless, valid keys are `do` and `else`", fn ->
+        Code.eval_string("unless true, foo: 7")
+      end
+
+      assert_raise ArgumentError, "invalid key `boo` in unless, valid keys are `do` and `else`", fn ->
+        Code.eval_string("unless true, do: 6, boo: 7")
+      end
+
+      assert_raise ArgumentError, "duplicate `do` key in unless", fn ->
+        Code.eval_string("unless true, do: 7, do: 6")
+      end
+
+      assert_raise ArgumentError, "duplicate `else` key in unless", fn ->
+        Code.eval_string("unless true, else: 7, else: 6")
+      end
+
+      assert_raise ArgumentError, "unless clauses must contain `do` key", fn ->
+        Code.eval_string("unless true, else: 6")
+      end
+
+      assert_raise ArgumentError, "unless clauses must contain `do` key", fn ->
+        Code.eval_string("unless true, []")
       end
     end
   end

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -502,6 +502,28 @@ defmodule KernelTest do
 
       assert r == 0
     end
+
+    test "calling if with invalid keys" do
+      assert_raise ArgumentError, "invalid key `foo` in if, valid keys are `do` and `else`", fn ->
+        Code.eval_string("if true, foo: 7")
+      end
+
+      assert_raise ArgumentError, "invalid key `boo` in if, valid keys are `do` and `else`", fn ->
+          Code.eval_string("if true, do: 6, boo: 7")
+        end
+
+      assert_raise ArgumentError, "duplicate `do` key in if", fn ->
+        Code.eval_string("if true, do: 7, do: 6")
+      end
+
+      assert_raise ArgumentError, "duplicate `else` key in if", fn ->
+        Code.eval_string("if true, else: 7, else: 6")
+      end
+
+      assert_raise ArgumentError, "if clauses must contain `do`, `else` or both", fn ->
+        Code.eval_string("if true, []")
+      end
+    end
   end
 
   defmodule Destructure do


### PR DESCRIPTION
The following things are now checked when using `Kernel.if`:

 * There is only one `do` key
 * Only `do` and `else` keys exist

Any calls to the if macro that do not satisfy these conditions raise an
ArgumentError.

This fixes 3 of the 5 examples posted in #3614 