### PR TITLE
FIx(Kernel): check arguments on if and unless

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2292,15 +2292,33 @@ defmodule Kernel do
   In order to compare more than two clauses, the `cond/1` macro has to be used.
   """
   defmacro if(condition, clauses) do
+<<<<<<< Updated upstream
     do_clause = Keyword.get(clauses, :do, nil)
     else_clause = Keyword.get(clauses, :else, nil)
 
+=======
+    build_if(condition, clauses)
+  end
+
+  defp build_if(condition, do: do_clause) do
+    build_if(condition, do: do_clause, else: nil)
+  end
+
+  defp build_if(condition, do: do_clause, else: else_clause) do
+>>>>>>> Stashed changes
     optimize_boolean(quote do
       case unquote(condition) do
         x when x in [false, nil] -> unquote(else_clause)
         _ -> unquote(do_clause)
       end
     end)
+<<<<<<< Updated upstream
+=======
+  end
+
+  defp build_if(_condition, _keys) do
+    raise(ArgumentError, "invalid or duplicate keys for if")
+>>>>>>> Stashed changes
   end
 
   @doc """
@@ -2328,13 +2346,30 @@ defmodule Kernel do
       "Math still works"
 
   """
+<<<<<<< Updated upstream
   defmacro unless(clause, options) do
     do_clause   = Keyword.get(options, :do, nil)
     else_clause = Keyword.get(options, :else, nil)
+=======
+  defmacro unless(condition, clauses) do
+    build_unless(condition, clauses)
+  end
+
+  defp build_unless(condition, do: do_clause) do
+    build_unless(condition, do: do_clause, else: nil)
+  end
+
+  defp build_unless(condition, do: do_clause, else: else_clause) do
+>>>>>>> Stashed changes
     quote do
-      if(unquote(clause), do: unquote(else_clause), else: unquote(do_clause))
+      if(unquote(condition), do: unquote(else_clause), else: unquote(do_clause))
     end
   end
+
+  defp build_unless(_condition, keys) do
+    raise(ArgumentError, "invalid or duplicate keys for unless")
+  end
+
 
   @doc """
   Destructures two lists, assigning each term in the

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -502,6 +502,61 @@ defmodule KernelTest do
 
       assert r == 0
     end
+<<<<<<< Updated upstream
+=======
+
+    test "calling if with invalid keys" do
+      assert_raise ArgumentError, "invalid or duplicate keys for if", fn ->
+        Code.eval_string("if true, foo: 7")
+      end
+
+      assert_raise ArgumentError, "invalid or duplicate keys for if", fn ->
+          Code.eval_string("if true, do: 6, boo: 7")
+        end
+
+      assert_raise ArgumentError, "invalid or duplicate keys for if", fn ->
+        Code.eval_string("if true, do: 7, do: 6")
+      end
+
+      assert_raise ArgumentError, "invalid or duplicate keys for if", fn ->
+        Code.eval_string("if true, do: 8, else: 7, else: 6")
+      end
+
+      assert_raise ArgumentError, "invalid or duplicate keys for if", fn ->
+        Code.eval_string("if true, else: 6")
+      end
+
+      assert_raise ArgumentError, "invalid or duplicate keys for if", fn ->
+        Code.eval_string("if true, []")
+      end
+    end
+
+    test "calling unless with invalid keys" do
+      assert_raise ArgumentError, "invalid or duplicate keys for unless", fn ->
+        Code.eval_string("unless true, foo: 7")
+      end
+
+      assert_raise ArgumentError, "invalid or duplicate keys for unless", fn ->
+        Code.eval_string("unless true, do: 6, boo: 7")
+      end
+
+      assert_raise ArgumentError, "invalid or duplicate keys for unless", fn ->
+        Code.eval_string("unless true, do: 7, do: 6")
+      end
+
+      assert_raise ArgumentError, "invalid or duplicate keys for unless", fn ->
+        Code.eval_string("unless true, else: 7, else: 6")
+      end
+
+      assert_raise ArgumentError, "invalid or duplicate keys for unless", fn ->
+        Code.eval_string("unless true, else: 6")
+      end
+
+      assert_raise ArgumentError, "invalid or duplicate keys for unless", fn ->
+        Code.eval_string("unless true, []")
+      end
+    end
+>>>>>>> Stashed changes
   end
 
   defmodule Destructure do


### PR DESCRIPTION
The following things are now checked when using `Kernel.if`:

 * There is only one `do` key
 * Only `do` and `else` keys exist

Any calls to the if macro that do not satisfy these conditions raise an
ArgumentError.

This fixes 3 of the 5 examples posted in #3614 