### PR TITLE
Cut off "Elixir." prefix for modules in Logger metadata

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2310,7 +2310,7 @@ defmodule Kernel do
 
   defp build_if(_condition, _arguments) do
     raise(ArgumentError, "invalid or duplicate keys for if, only `do` " <>
-    "and an optional `else` are permitted")
+      "and an optional `else` are permitted")
   end
 
   @doc """

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -511,8 +511,8 @@ defmodule KernelTest do
       end
 
       assert_raise ArgumentError, error_message, fn ->
-          Code.eval_string("if true, do: 6, boo: 7")
-        end
+        Code.eval_string("if true, do: 6, boo: 7")
+      end
 
       assert_raise ArgumentError, error_message, fn ->
         Code.eval_string("if true, do: 7, do: 6")

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -518,8 +518,12 @@ defmodule Logger do
 
   defp macro_log(level, data, metadata, caller) do
     %{module: module, function: fun, line: line} = caller
-    app = Application.get_env(:logger, :compile_time_application)
-    caller = [application: app, module: module, function: form_fa(fun), line: line]
+
+    caller = [module: module, function: form_fa(fun), line: line]
+    if app = Application.get_env(:logger, :compile_time_application) do
+      caller = [application: app] ++ caller
+    end
+
     quote do
       Logger.bare_log(unquote(level), unquote(data), unquote(caller) ++ unquote(metadata))
     end

--- a/lib/logger/lib/logger/formatter.ex
+++ b/lib/logger/lib/logger/formatter.ex
@@ -121,8 +121,8 @@ defmodule Logger.Formatter do
   defp metadata(pid) when is_pid(pid) do
     :erlang.pid_to_list(pid)
   end
-  defp metadata(pid) when is_reference(pid) do
-    '#Ref' ++ rest = :erlang.ref_to_list(pid)
+  defp metadata(ref) when is_reference(ref) do
+    '#Ref' ++ rest = :erlang.ref_to_list(ref)
     rest
   end
   defp metadata(atom) when is_atom(atom) do

--- a/lib/logger/lib/logger/formatter.ex
+++ b/lib/logger/lib/logger/formatter.ex
@@ -125,5 +125,12 @@ defmodule Logger.Formatter do
     '#Ref' ++ rest = :erlang.ref_to_list(pid)
     rest
   end
+  defp metadata(atom) when is_atom(atom) do
+    case Atom.to_string(atom) do
+      "Elixir." <> rest -> rest
+      "nil" -> ""
+      binary -> binary
+    end
+  end
   defp metadata(other), do: to_string(other)
 end

--- a/lib/logger/test/logger/backends/console_test.exs
+++ b/lib/logger/test/logger/backends/console_test.exs
@@ -55,7 +55,7 @@ defmodule Logger.Backends.ConsoleTest do
 
     assert capture_log(fn ->
       Logger.debug("hello")
-    end) =~ "line=#{line + 3} module=#{mod} function=#{name}/#{arity}"
+    end) =~ "line=#{line + 3} module=#{inspect(mod)} function=#{name}/#{arity}"
   end
 
   test "can configure level" do

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -10,7 +10,7 @@ defmodule LoggerTest do
   end
 
   defp msg_with_meta(text) do
-    msg("application= module=#{LoggerTest} #{text}")
+    msg("module=#{LoggerTest} #{text}")
   end
 
   test "add_translator/1 and remove_translator/1" do
@@ -92,7 +92,7 @@ defmodule LoggerTest do
 
     assert capture_log(fn ->
       assert Logger.bare_log(:info, "ok", [application: nil, module: LoggerTest]) == :ok
-    end) =~ msg_with_meta("[info]  ok")
+    end) =~ msg("application= module=#{LoggerTest} [info]  ok")
   end
 
   test "enable/1 and disable/1" do
@@ -198,7 +198,7 @@ defmodule LoggerTest do
 
     assert capture_log(fn ->
       assert Sample.info == :ok
-    end) =~ msg("application= module=#{LoggerTest}.Sample [info]  hello")
+    end) =~ msg("module=#{LoggerTest}.Sample [info]  hello")
   after
     Logger.configure(compile_time_purge_level: :debug)
   end
@@ -213,7 +213,7 @@ defmodule LoggerTest do
 
     assert capture_log(fn ->
       assert SampleNoApp.info == :ok
-    end) =~ msg("application= module=#{LoggerTest}.SampleNoApp [info]  hello")
+    end) =~ msg("module=#{LoggerTest}.SampleNoApp [info]  hello")
 
     Logger.configure(compile_time_application: :sample_app)
     defmodule SampleApp do

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -10,7 +10,7 @@ defmodule LoggerTest do
   end
 
   defp msg_with_meta(text) do
-    msg("module=#{LoggerTest} #{text}")
+    msg("module=LoggerTest #{text}")
   end
 
   test "add_translator/1 and remove_translator/1" do
@@ -92,7 +92,7 @@ defmodule LoggerTest do
 
     assert capture_log(fn ->
       assert Logger.bare_log(:info, "ok", [application: nil, module: LoggerTest]) == :ok
-    end) =~ msg("application= module=#{LoggerTest} [info]  ok")
+    end) =~ msg("application= module=LoggerTest [info]  ok")
   end
 
   test "enable/1 and disable/1" do
@@ -198,7 +198,7 @@ defmodule LoggerTest do
 
     assert capture_log(fn ->
       assert Sample.info == :ok
-    end) =~ msg("module=#{LoggerTest}.Sample [info]  hello")
+    end) =~ msg("module=LoggerTest.Sample [info]  hello")
   after
     Logger.configure(compile_time_purge_level: :debug)
   end
@@ -213,7 +213,7 @@ defmodule LoggerTest do
 
     assert capture_log(fn ->
       assert SampleNoApp.info == :ok
-    end) =~ msg("module=#{LoggerTest}.SampleNoApp [info]  hello")
+    end) =~ msg("module=LoggerTest.SampleNoApp [info]  hello")
 
     Logger.configure(compile_time_application: :sample_app)
     defmodule SampleApp do
@@ -224,7 +224,7 @@ defmodule LoggerTest do
 
     assert capture_log(fn ->
       assert SampleApp.info == :ok
-    end) =~ msg("application=sample_app module=#{LoggerTest}.SampleApp [info]  hello")
+    end) =~ msg("application=sample_app module=LoggerTest.SampleApp [info]  hello")
   after
     Logger.configure(compile_time_application: nil)
   end


### PR DESCRIPTION
And do not inject `:application` key in metadata if it has `nil` value.