### PR TITLE
add docs for :keep option in OptionParser module

### DIFF
--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -89,6 +89,9 @@ defmodule OptionParser do
       ...>                    switches: [limit: :integer])
       {[limit: 3, unknown: "xyz"], [], []}
 
+      iex> OptionParser.parse(["--unlock", "path/to/file", "--unlock", "path/to/another/file"], strict: [unlock: :keep])
+      {[unlock: "path/to/file", unlock: "path/to/another/file"], [], []}
+
   ## Negation switches
 
   In case a switch is declared as boolean, it may be passed as `--no-SWITCH`


### PR DESCRIPTION
While reading the docs for the [OptionParser.parse/2 function](http://elixir-lang.org/docs/v1.0/elixir/OptionParser.html#parse/2) I found that no code examples was given for the :keep switch. So I thought to write an example and open this pr.

Let me know if something is missing. The test suite is green.
