### PR TITLE
Add missing character in delete_at code sample

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -449,7 +449,7 @@ defmodule List do
       iex> List.delete_at([1, 2, 3], 0)
       [2, 3]
 
-      iex List.delete_at([1, 2, 3], 10)
+      iex> List.delete_at([1, 2, 3], 10)
       [1, 2, 3]
 
       iex> List.delete_at([1, 2, 3], -1)


### PR DESCRIPTION
The delete_at code sample has an "iex" missing the ">" right afterwards . Wasn't sure if that might throw off some doctests or not, so better to be safe than sorry.