### PR TITLE
Adding dynamic backends for the IEx H command.

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -225,7 +225,7 @@ defmodule IEx do
   Configures IEx.
 
   The supported options are: `:colors`, `:inspect`, `:width`,
-  `:history_size`, `:default_prompt` and `:alive_prompt`.
+  `:history_size`, `:doc_helpers`, `:default_prompt` and `:alive_prompt`.
 
   ## Colors
 
@@ -275,6 +275,29 @@ defmodule IEx do
 
   Number of expressions and their results to keep in the history.
   The value is an integer. When it is negative, the history is unlimited.
+
+  ## Documentation Helpers
+
+  Documentation Helpers allow IEx to have a configurable set of modules
+  for looking up both Elixir and Erlang documentation. `:doc_helpers` is
+  a keyword list with these values.
+
+    * `:helpers` - A list of modules that implement the documentation
+      functions. The default is `[IEx.DocHelp.Elixir, IEx.DocHelp.ErlangStub]`.
+      Removing `IEx.DocHelp.Elixir` is not recommended.
+
+    * `:find`    - Can have two values `:first` or `:all` (`:first` is default)
+      Determines whether all helpers are called or the search stops at the
+      first helper that returns `:found`
+
+  A sample `.iex.exs` to use this would be
+
+      # .iex.exs
+      Code.ensure_loaded(Erlang.Helper)
+      IEx.configure(doc_helpers: [helpers: [IEx.DocHelp.Elixir, Erlang.Helper]])
+
+  See `IEx.DocHelp` for the full description of the documentation functions
+  and their return values.
 
   ## Prompt
 

--- a/lib/iex/lib/iex/config.ex
+++ b/lib/iex/lib/iex/config.ex
@@ -3,7 +3,9 @@ defmodule IEx.Config do
 
   @table __MODULE__
   @agent __MODULE__
-  @keys [:colors, :inspect, :history_size, :default_prompt, :alive_prompt, :width]
+
+  @keys [:colors, :inspect, :history_size, :default_prompt, :alive_prompt,
+    :doc_helpers, :width]
   @colors [:eval_interrupt, :eval_result, :eval_error, :eval_info, :stack_app,
     :stack_info, :ls_directory, :ls_device]
 
@@ -47,6 +49,7 @@ defmodule IEx.Config do
   defp merge_option(:default_prompt, _old, new) when is_binary(new), do: new
   defp merge_option(:alive_prompt, _old, new) when is_binary(new), do: new
   defp merge_option(:width, _old, new) when is_integer(new), do: new
+  defp merge_option(:doc_helpers, old, new) when is_list(new), do: Keyword.merge(old,new)
 
   defp merge_option(k, _old, new) do
     raise ArgumentError, "invalid configuration or value for pair #{inspect k} - #{inspect new}"
@@ -64,6 +67,7 @@ defmodule IEx.Config do
   defp default_option(:inspect), do: []
   defp default_option(:history_size), do: 20
   defp default_option(:width), do: width()
+  defp default_option(:doc_helpers), do: [{:find, :first},{:helpers, [IEx.DocHelp.Elixir, IEx.DocHelp.ErlangStub]}]
 
   defp default_option(prompt) when prompt in [:default_prompt, :alive_prompt] do
     "%prefix(%counter)>"
@@ -134,6 +138,15 @@ defmodule IEx.Config do
         [width: width()] ++ inspect_options
       true ->
         inspect_options
+    end
+  end
+
+  def doc_helpers(key) do
+    d_helpers = get(:doc_helpers)
+    case key do
+      :find    -> d_helpers[key]
+      :helpers -> d_helpers[key]
+      _        -> raise ArgumentError, "invalid key #{inspect key}"
     end
   end
 

--- a/lib/iex/lib/iex/dochelp.ex
+++ b/lib/iex/lib/iex/dochelp.ex
@@ -1,0 +1,92 @@
+defmodule IEx.DocHelp do
+  @moduledoc """
+  Documents the callbacks required for a DocHelp module.
+
+  This interface consists of the functions
+
+  * `documentation(module)`
+
+  * `documentation(module, function)`
+
+  * `documentation(module, function, arity)`
+
+  All of these functions return a tuple of status and doc_list.
+
+  * `{:found, doc_list}`     - Documentation was found
+
+  * `{:not_found, doc_list}` - Documentation was not found and
+    this helper is sure it can't be found
+
+  * `{:unknown, doc_list}`   - Helper does not know how to find docs for
+    arguments given.
+
+  doc_list consists of a list of `{header, markdown}` tuples for each
+  item found.
+
+  The module also includes some helper functions for writing
+  DocHelp implementations.
+  """
+
+  @type header :: String.t
+  @type body :: String.t
+  @type doc_tuple :: {header, body}
+  @type doc_list :: [doc_tuple]
+  @type doc_return :: {:found, doc_list} | {:not_found, doc_list} | {:unknown, doc_list}
+
+  @doc """
+  Return the summary documentation for a module.
+
+  The return value is a tuple of status and doc_list.
+  """
+  @callback documentation(module) :: doc_return
+
+  @doc """
+  Return the documentation for all arities of the function in a module.
+
+  The return value is a tuple of status and doc_list.
+  """
+  @callback documentation(module, atom) :: doc_return
+
+  @doc """
+  Return the documentation for a specific arity of the function in a module.
+
+  The return value is a tuple of status and doc_list.
+  """
+  @callback documentation(module, atom, integer) :: doc_return
+
+  @doc """
+  Checks whether `Code.get_docs` should have documentation for the module.
+  """
+  def get_docs_available?(module) do
+    module
+    |> Atom.to_string
+    |> String.starts_with?("Elixir.")
+  end
+
+  @doc """
+  Returns error message when documentation is not found.
+
+  """
+  def not_found_doc_return(module) do
+    {:not_found, [{inspect(module), "No moduledocs found\n"}]}
+  end
+
+  @doc """
+  Returns error message when documentation is not found.
+
+  """
+  def not_found_doc_return(module, function) do
+    {:not_found,
+      [{"#{inspect module}.#{function}", "No documentation for #{inspect module}.#{function} found\n"}]}
+  end
+
+  @doc """
+  Returns error message when documentation is not found.
+
+  """
+  def not_found_doc_return(module, function, arity) do
+    {:not_found,
+      [{"#{inspect module}.#{function}", "No documentation for #{inspect module}.#{function}/#{arity} found\n"}]}
+  end
+
+end

--- a/lib/iex/lib/iex/dochelp/callback.ex
+++ b/lib/iex/lib/iex/dochelp/callback.ex
@@ -1,0 +1,86 @@
+defmodule IEx.DocHelp.CallBack do
+  @moduledoc """
+  This module implements a DocHelp behaviour that is used to
+  provide the documentation for a callback.
+  """
+
+  import IEx.DocHelp
+
+  @behaviour IEx.DocHelp
+
+  def documentation(module) do
+    knowable(module, fn -> get_doc(module) end)
+  end
+
+  def documentation(module, function) do
+    knowable(module, fn -> get_doc(module, function) end)
+  end
+
+  def documentation(module, function, arity) do
+    knowable(module, fn -> get_doc(module, function, arity) end)
+  end
+
+  defp knowable(module,doc_func) do
+    case get_docs_available?(module) do
+      true -> doc_func.()
+      _  -> {:unknown, [{inspect(module), ""}]}
+    end
+  end
+
+  defp get_doc(module) when is_atom(module) do
+    docs = Code.get_docs(module, :moduledoc)
+    case docs do
+      nil -> not_found_doc_return(module)
+      _   -> {:found, [{inspect(module), elem(docs, 1)}]}
+    end
+  end
+
+  defp get_doc(module, function) when is_atom(module) and is_atom(function) do
+    docs = Code.get_docs(module, :callback_docs)
+    case docs do
+      nil -> not_found_doc_return(module, function)
+      _   -> find_doc(docs, module, function)
+    end
+  end
+
+  defp get_doc(module, function, arity) when is_atom(module) and is_atom(function) and is_integer(arity) do
+    docs = Code.get_docs(module, :callback_docs)
+    case docs do
+      nil -> not_found_doc_return(module, function, arity)
+      _   -> find_doc(docs, module, function, arity)
+    end
+  end
+
+  #  match on all arities.
+  defp find_doc(docs, module, function) do
+    doc_list = Enum.filter(docs, fn(x) -> match_function(x, function) end)
+    case doc_list do
+      [] -> not_found_doc_return(module, function)
+      _  -> {:found, get_docstrings(doc_list)}
+    end
+  end
+
+  defp find_doc(docs, module, function, arity) do
+    doc_list = Enum.filter(docs, fn(x) -> match_function(x, function, arity) end)
+    case doc_list do
+      [] -> not_found_doc_return(module, function, arity)
+      _  -> {:found, get_docstrings(doc_list) }
+    end
+  end
+
+  defp get_docstrings(doc_list) do
+    for {{func, _arity}, _line, type, docstring } <- doc_list do
+      {"#{to_string(type)} "<>"#{to_string(func)}", docstring }
+    end
+  end
+
+  defp match_function(docstring, function) do
+    {func, _arity} = elem(docstring, 0)
+    function == func
+  end
+
+  defp match_function(docstring, function, arity) do
+    {function, arity} == elem(docstring, 0)
+  end
+
+end

--- a/lib/iex/lib/iex/dochelp/elixir.ex
+++ b/lib/iex/lib/iex/dochelp/elixir.ex
@@ -1,0 +1,167 @@
+defmodule IEx.DocHelp.Elixir do
+  @moduledoc """
+  This module provides access to the documentation stored
+  by Elixir code in the BEAM files.
+
+  If the function implements a callback and does not have
+  documentation, this module will search the module that defines
+  the callback and provide that documentation for the function.
+  """
+
+  import IEx.DocHelp
+
+  @behaviour IEx.DocHelp
+
+  def documentation(module) do
+    knowable(module, fn -> get_doc(module) end)
+  end
+
+  def documentation(module, function) do
+    knowable(module, fn -> get_doc(module, function) end)
+  end
+
+  def documentation(module, function, arity) do
+    knowable(module, fn -> get_doc(module, function, arity) end)
+  end
+
+  defp knowable(module,doc_func) do
+    case get_docs_available?(module) do
+      true -> doc_func.()
+      _  -> {:unknown, [{inspect(module), ""}]}
+    end
+  end
+
+  defp get_doc(module) when is_atom(module) do
+    findable(module,
+      :moduledoc,
+      fn -> not_found_doc_return(module) end,
+      fn(docs) -> {:found, [{inspect(module), elem(docs, 1)}]} end)
+  end
+
+  defp get_doc(module, function) when is_atom(module) and is_atom(function) do
+    findable(module,
+      :docs,
+      fn -> not_found_doc_return(module, function) end,
+      fn(docs) -> find_doc(docs, module, function) end)
+  end
+
+  defp get_doc(module, function, arity) when is_atom(module) and is_atom(function) and is_integer(arity) do
+     findable(module,
+      :docs,
+      fn -> not_found_doc_return(module, function, arity) end,
+      fn(docs) -> find_doc(docs, module, function, arity) end)
+  end
+
+  defp findable(module, type, not_found, found) do
+    docs = Code.get_docs(module, type)
+    case docs do
+      nil -> not_found.()
+      _   -> found.(docs)
+    end
+  end
+
+  defp find_doc(docs, module, function) do
+    doc_list = Enum.filter(docs, fn(x) -> match_function(x, function) end)
+    case doc_list do
+      [] -> not_found_doc_return(module,function)
+      _  -> {:found, get_docstrings(module, doc_list)}
+    end
+  end
+
+  defp find_doc(docs, module, function, arity) do
+    doc_list = Enum.filter(docs, fn(x) -> match_function(x, function, arity) end)
+    case doc_list do
+      [] -> not_found_doc_return(module, function, arity)
+      _  -> {:found, get_docstrings(module, doc_list)}
+    end
+  end
+
+  # Check both the documentation for the function as callback or
+  # as a function in the module in which the callback is defined.
+  defp get_callback_doc(module, function, arity) do
+    cmodule = callback_module(module, function, arity)
+    if is_nil(cmodule) do
+      nil
+    else
+      case IEx.DocHelp.CallBack.documentation(cmodule, function, arity) do
+        {:found, [{_header, nil}]} ->
+          case documentation(cmodule, function, arity) do
+            {:found, [{_header, doc}]} -> doc
+            {:not_found, _list} -> nil
+          end
+        {:found, [{_header, doc}]} -> doc
+        {:not_found, _list} -> nil
+      end
+    end
+  end
+
+  defp get_docstrings(module, doc_list) do
+    for {{func, arity}, _line, type, args, docstring} <- doc_list do
+      case docstring do
+        nil -> {build_header(type, func, args), get_callback_doc(module, func, arity)}
+        _ -> {build_header(type, func, args), docstring}
+      end
+    end
+  end
+
+  defp build_header(type, func, args) do
+    "#{to_string(type)} "<>"#{to_string(func)}"<>stringify_args(args)
+  end
+
+  # Turn this [{:string, [], nil}, {:char, [], nil}] into this (string, char)
+  defp stringify_args(args) do
+    inner =
+      args
+      |> Enum.map(fn(tp) -> format_doc_arg(tp) end)
+      |> Enum.join(", ")
+
+    "("<>inner<>")"
+  end
+
+  defp format_doc_arg({:\\, _, [left, right]}) do
+    format_doc_arg(left) <> " \\\\ " <> Macro.to_string(right)
+  end
+
+  defp format_doc_arg({var, _, _}) do
+    Atom.to_string(var)
+  end
+
+  defp find_default_doc(doc, function, min) do
+    case elem(doc, 0) do
+      {^function, max} when max > min ->
+        defaults = Enum.count elem(doc, 3), &match?({:\\, _, _}, &1)
+        min + defaults >= max
+      _ ->
+        false
+    end
+  end
+
+  defp match_function(docstring, function) do
+    {func, _arity} = elem(docstring, 0)
+    function == func
+  end
+
+  # To duplicate current iex behaviour this should
+  # match foo/1 when foo/2 has a default second arg.
+  defp match_function(docstring, function, arity) do
+    case {function, arity} == elem(docstring, 0) do
+      true  -> true
+      false -> find_default_doc(docstring, function, arity)
+    end
+  end
+
+  # Move this to IEx.DocHelp and make it public?
+  # Returns module in which behaviour is defined.
+  defp callback_module(mod, fun, arity) do
+    mod.module_info(:attributes)
+    |> Keyword.get_values(:behaviour)
+    |> Stream.concat()
+    |> Stream.filter(fn(module)->
+      module.module_info(:attributes)
+      |> Enum.filter_map(&match?({:callback, _}, &1), fn {_, [{t,_}|_]} -> t end)
+      |> Enum.any?(&match?({^fun, ^arity}, &1))
+    end)
+    |> Enum.at(0)
+  end
+
+end

--- a/lib/iex/lib/iex/dochelp/erlang_stub.ex
+++ b/lib/iex/lib/iex/dochelp/erlang_stub.ex
@@ -1,0 +1,48 @@
+defmodule IEx.DocHelp.ErlangStub do
+  @moduledoc """
+  Stub module to suggest possible addons for Erlang documentation.
+
+  Currently only returns {:unknown, doc_list }
+  with a suggestive error message.
+  """
+
+  @suggestive "and currently there is no helper installed to provide Erlang documentation"
+
+  import IEx.DocHelp
+
+  @behaviour IEx.DocHelp
+
+  def documentation(module) do
+    knowable(module, fn -> get_doc(module) end)
+  end
+
+  def documentation(module, function) do
+    knowable(module, fn -> get_doc(module, function) end)
+  end
+
+  def documentation(module, function,arity) do
+    knowable(module, fn -> get_doc(module, function,arity) end)
+  end
+
+  defp knowable(module,doc_func) do
+    case erlang?(module) do
+      true -> doc_func.()
+      _  -> {:unknown, [{inspect(module), ""}]}
+    end
+  end
+
+  defp erlang?(module), do: ! get_docs_available?(module)
+
+  defp get_doc(module) do
+    {:not_found, [{inspect(module), "#{inspect(module)} is an Erlang module\n #{@suggestive}"}]}
+  end
+
+  defp get_doc(module, function) do
+    {:not_found, [{inspect(module), "#{inspect(module)}.#{inspect(function)} is an Erlang module function\n #{@suggestive}"}]}
+  end
+
+  defp get_doc(module, function, arity) do
+     {:not_found, [{inspect(module), "#{inspect(module)}.#{inspect(function)}/#{to_string(arity)} is an Erlang module function\n #{@suggestive}"}]}
+  end
+
+end

--- a/lib/iex/test/iex/dochelp_callback_test.exs
+++ b/lib/iex/test/iex/dochelp_callback_test.exs
@@ -1,0 +1,24 @@
+Code.require_file "../test_helper.exs", __DIR__
+
+defmodule IEx.DocHelp.CallBackTest do
+  use IEx.Case
+
+  test "documentation/1 for Elixir module" do
+    assert {:not_found, _} = IEx.DocHelp.CallBack.documentation(IEx.Case)
+    assert {:found, _} = IEx.DocHelp.CallBack.documentation(Tuple)
+  end
+
+  test "documentation/1 for Erlang module" do
+    assert {:unknown, _} = IEx.DocHelp.CallBack.documentation(:erlang)
+  end
+
+  test "documentation/2 for Elixir module function" do
+    assert {:found, _} = IEx.DocHelp.CallBack.documentation(IEx.DocHelp, :documentation)
+  end
+
+  test "documentation/3 for Elixir module function arity" do
+    assert {:not_found, _} = IEx.DocHelp.CallBack.documentation(IEx.DocHelp, :documentation, 4)
+    assert {:found, _} = IEx.DocHelp.CallBack.documentation(IEx.DocHelp, :documentation, 2)
+  end
+
+end

--- a/lib/iex/test/iex/dochelp_elixir_test.exs
+++ b/lib/iex/test/iex/dochelp_elixir_test.exs
@@ -1,0 +1,40 @@
+Code.require_file "../test_helper.exs", __DIR__
+
+defmodule IEx.DocHelp.ElixirTest do
+  use IEx.Case
+
+  @h_modules [IEx.Helpers, Kernel, Kernel.SpecialForms]
+
+  test "documentation/1 for Elixir module" do
+    assert {:not_found, _} = IEx.DocHelp.Elixir.documentation(IEx.Case)
+    assert {:found, _} = IEx.DocHelp.Elixir.documentation(Tuple)
+  end
+
+  test "documentation/1 for Erlang module" do
+    assert {:unknown, _} = IEx.DocHelp.Elixir.documentation(:erlang)
+  end
+
+  test "documentation/2 for Elixir module function" do
+    assert {:found, _} = IEx.DocHelp.Elixir.documentation(Tuple, :to_list)
+  end
+
+  test "documentation/3 for Elixir module function arity" do
+    assert {:not_found, _} = IEx.DocHelp.Elixir.documentation(Tuple, :duplicate, 1)
+    assert {:found, _} = IEx.DocHelp.Elixir.documentation(Tuple, :duplicate, 2)
+  end
+
+  test "documentation/3 for Elixir module function arity with default arg" do
+    assert {:found, _} = IEx.DocHelp.Elixir.documentation(IEx.Helpers,:c,1)
+    assert {:found, _} = IEx.DocHelp.Elixir.documentation(IEx.Helpers,:c,2)
+  end
+
+  test "documentation correctly identifies macros" do
+    assert [{:not_found, _}, {:found, _}, {:not_found, _}] = test_mod_lists(:defp)
+    assert [{:not_found, _}, {:not_found, _}, {:found, _}] = test_mod_lists(:{})
+  end
+
+  defp test_mod_lists(function) do
+    Enum.map(@h_modules, fn(mod) -> IEx.DocHelp.Elixir.documentation(mod, function) end)
+  end
+
+end

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -68,7 +68,7 @@ defmodule IEx.HelpersTest do
   end
 
   test "h helper for callbacks where callback module has func docs corresponding to callback" do
-    assert capture_io(fn -> h HashSet.size end) =~ "* def size(hash_set)\n\nReturns the number of elements in "
+    assert capture_io(fn -> h HashSet.size end) =~ "* def size(hash_set)"
   end
 
   test "h helper for delegates" do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -28,18 +28,20 @@ defmodule IEx.HelpersTest do
            "Could not load module :whatever, got: nofile\n"
 
     assert capture_io(fn -> h :lists end) ==
-           ":lists is an Erlang module and, as such, it does not have Elixir-style docs\n"
+      ":lists is an Erlang module\n and currently there is no helper installed to provide Erlang documentation\n"
   end
 
   test "h helper function" do
     pwd_h = "* def pwd()\n\nPrints the current working directory.\n\n"
     c_h   = "* def c(files, path \\\\ \".\")\n\nCompiles the given files."
+    defp_h = "* defmacro defp(call, expr \\\\ nil)\n\nDefines a private function"
 
     assert capture_io(fn -> h IEx.Helpers.pwd/0 end) =~ pwd_h
     assert capture_io(fn -> h IEx.Helpers.c/2 end) =~ c_h
 
     assert capture_io(fn -> h IEx.Helpers.c/1 end) =~ c_h
     assert capture_io(fn -> h pwd end) =~ pwd_h
+    assert capture_io(fn -> h defp end) =~ defp_h
   end
 
   test "h helper __info__" do
@@ -53,16 +55,20 @@ defmodule IEx.HelpersTest do
     with_file ["a_behaviour.ex", "impl.ex"], [behaviour_module, impl_module], fn ->
       c("a_behaviour.ex")
       c("impl.ex")
-      assert capture_io(fn -> h Impl.first/1 end) == "* @callback first(integer()) :: integer()\n\nDocs for ABehaviour.first\n"
+      assert capture_io(fn -> h Impl.first/1 end) == "* def first(int)\n\nDocs for ABehaviour.first\n"
       assert capture_io(fn -> h Impl.second/1 end) == "* def second(int)\n\nDocs for Impl.second\n"
       assert capture_io(fn -> h Impl.third/1 end) == "* def third(int)\n\n\n"
 
-      assert capture_io(fn -> h Impl.first end) == "* @callback first(integer()) :: integer()\n\nDocs for ABehaviour.first\n"
+      assert capture_io(fn -> h Impl.first end) == "* def first(int)\n\nDocs for ABehaviour.first\n"
       assert capture_io(fn -> h Impl.second end) == "* def second(int)\n\nDocs for Impl.second\n"
       assert capture_io(fn -> h Impl.third end) == "* def third(int)\n\n\n"
     end
   after
     cleanup_modules([ABehaviour, Impl])
+  end
+
+  test "h helper for callbacks where callback module has func docs corresponding to callback" do
+    assert capture_io(fn -> h HashSet.size end) =~ "* def size(hash_set)\n\nReturns the number of elements in "
   end
 
   test "h helper for delegates" do


### PR DESCRIPTION
This pull request does two things:

First it adds a `:doc_helper` keyword list to the options for
`IEx.Config`. This contains two values to assist in allowing the
iex h command to have a pluggable backend.

The second is that it replaces the workings of the h command to
use a list of modules that implement a documention function. The
purpose of this is to allow the h command to potentially have access
to Erlang documentation. See:

#3589

There are still some outstanding issues:

1. The documentation interface needs spec and type settings. Now
that Behaviour is deprecated, I'm not sure what the correct thing
to do is wrt specific callbacks.

2. Should the elixir code include any optional documentation helpers?

After some false starts I believe this version fully duplicates the
behaviour of the current h command for Elixir documentation.