### PR TITLE
Exception : fix CompileError to not to fail if no opts given

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -446,8 +446,9 @@ defmodule Exception do
 
   @doc """
   Formats the given `file` and `line` as shown in stacktraces.
-  If any `file` or `line` are `nil`, they are omitted.
-  Adds `suffix` at the end of the string, if a result is returned.
+  If `file` is falsey or an empty string, it returns an empty string.
+  If `line` is 0, falsey or an empty string, `line` is omitted.
+  Adds `suffix` at the end of the string, if a non-empty string is returned.
 
   ## Examples
 
@@ -457,19 +458,19 @@ defmodule Exception do
       iex> Exception.format_file_line("foo", nil)
       "foo:"
 
-      iex> Exception.format_file_line(nil, nil)
+      iex> Exception.format_file_line(nil, "bar")
       ""
 
   """
+  @spec format_file_line(term, term, term) :: String.t
   def format_file_line(file, line, suffix \\ "") do
-    if file do
-      if not line in [0, nil, ""] do
-        "#{file}:#{line}:#{suffix}"
-      else
+    cond do
+      file in [nil, false, ""] ->
+        ""
+      line in [0, nil, false, ""] ->
         "#{file}:#{suffix}"
-      end
-    else
-      ""
+      true ->
+        "#{file}:#{line}:#{suffix}"
     end
   end
 
@@ -480,7 +481,7 @@ defmodule Exception do
   @doc false
   # Make sure file name is not invalid, so we don't get an unexpected
   # error from Path.relative_to_cwd/1
-  def sanitize_file_name(file, line, suffix \\ "") do
+  def sanitize_file_line(file, line, suffix \\ "") do
     if is_bitstring(file) and file != "" do
       format_file_line(Path.relative_to_cwd(file), line, suffix)
     else
@@ -519,41 +520,49 @@ defmodule SystemLimitError do
 end
 
 defmodule SyntaxError do
-  defexception [file: nil, line: nil, description: "syntax error"]
+  defexception [file: nil, line: nil, description: "syntax error", message: nil]
 
   def message(exception) do
-    Exception.sanitize_file_name(exception.file, exception.line, " ")
-    <> exception.description
+    file_line = Exception.sanitize_file_line(exception.file, exception.line, " ")
+    cond do
+      exception.message ->
+        file_line <> "#{exception.message}"
+      true ->
+        file_line <> "#{exception.description}"
+    end
   end
 end
 
 defmodule TokenMissingError do
-  defexception [file: nil, line: nil, description: "expression is incomplete"]
+  defexception [file: nil, line: nil, description: "expression is incomplete", message: nil]
 
   def message(exception) do
-    Exception.sanitize_file_name(exception.file, exception.line, " ")
-    <> exception.description
+    file_line = Exception.sanitize_file_line(exception.file, exception.line, " ")
+    cond do
+      exception.message ->
+        file_line <> "#{exception.message}"
+      true ->
+        file_line <> "#{exception.description}"
+    end
   end
 end
 
 defmodule CompileError do
-  defexception [file: nil, line: nil, description: "compile error", message: nil, ]
+  defexception [file: nil, line: nil, description: "compile error", message: nil]
 
   def message(exception) do
-    file_line = Exception.sanitize_file_name(exception.file, exception.line, " ")
+    file_line = Exception.sanitize_file_line(exception.file, exception.line, " ")
     cond do
       exception.message ->
-        file_line <> exception.message
-
+        file_line <> "#{exception.message}"
       true ->
-        file_line <> exception.description
+        file_line <> "#{exception.description}"
     end
   end
 end
 
 defmodule BadFunctionError do
   defexception [term: nil]
-
   def message(exception) do
     "expected a function, got: #{inspect(exception.term)}"
   end
@@ -673,10 +682,8 @@ defmodule Code.LoadError do
     cond do
       exception.message ->
         exception.message
-
       not exception.file in [nil, ""]  ->
         "could not load #{exception.file}"
-
       true ->
         exception.description
     end

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -482,7 +482,7 @@ defmodule Exception do
   # Make sure file name is not invalid, so we don't get an unexpected
   # error from Path.relative_to_cwd/1
   def sanitize_file_line(file, line, suffix \\ "") do
-    if is_bitstring(file) and file != "" do
+    if is_binary(file) and file != "" do
       format_file_line(Path.relative_to_cwd(file), line, suffix)
     else
       ""
@@ -520,49 +520,35 @@ defmodule SystemLimitError do
 end
 
 defmodule SyntaxError do
-  defexception [file: nil, line: nil, description: "syntax error", message: nil]
+  defexception [file: nil, line: nil,  description: "syntax error"]
 
   def message(exception) do
-    file_line = Exception.sanitize_file_line(exception.file, exception.line, " ")
-    cond do
-      exception.message ->
-        file_line <> "#{exception.message}"
-      true ->
-        file_line <> "#{exception.description}"
-    end
+    Exception.sanitize_file_line(exception.file, exception.line, " ")
+    <> "#{exception.description}"
   end
 end
 
 defmodule TokenMissingError do
-  defexception [file: nil, line: nil, description: "expression is incomplete", message: nil]
+  defexception [file: nil, line: nil,  description: "expression is incomplete"]
 
   def message(exception) do
-    file_line = Exception.sanitize_file_line(exception.file, exception.line, " ")
-    cond do
-      exception.message ->
-        file_line <> "#{exception.message}"
-      true ->
-        file_line <> "#{exception.description}"
-    end
+    Exception.sanitize_file_line(exception.file, exception.line, " ")
+    <> "#{exception.description}"
   end
 end
 
 defmodule CompileError do
-  defexception [file: nil, line: nil, description: "compile error", message: nil]
+  defexception [file: nil, line: nil, description: "compile error"]
 
   def message(exception) do
-    file_line = Exception.sanitize_file_line(exception.file, exception.line, " ")
-    cond do
-      exception.message ->
-        file_line <> "#{exception.message}"
-      true ->
-        file_line <> "#{exception.description}"
-    end
+    Exception.sanitize_file_line(exception.file, exception.line, " ")
+    <> "#{exception.description}"
   end
 end
 
 defmodule BadFunctionError do
   defexception [term: nil]
+
   def message(exception) do
     "expected a function, got: #{inspect(exception.term)}"
   end

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3271,7 +3271,12 @@ defmodule Kernel do
       if Map.has_key?(fields, :message) do
         @spec message(Exception.t) :: String.t
         def message(exception) do
-          exception.message
+          cond do
+            is_nil(exception.message) ->
+              ""
+            true ->
+              exception.message
+          end
         end
 
         defoverridable message: 1

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -448,10 +448,8 @@ defmodule ExceptionTest do
   # TestEmptyError & TestNonEmptyError
 
   test "TestEmptyError" do
-    undefined_error_msg = "got nil while retrieving Exception.message/1 for %TestEmptyError{message: nil} (expected a string)"
-
     assert_raise TestEmptyError,
-      "got nil while retrieving Exception.message/1 for %TestEmptyError{message: nil} (expected a string)",
+      "",
       fn -> raise TestEmptyError
     end
 
@@ -461,7 +459,7 @@ defmodule ExceptionTest do
     end
 
     assert_raise TestEmptyError,
-      undefined_error_msg,
+      "",
       fn -> raise TestEmptyError, [description: "desc"]
     end
   end


### PR DESCRIPTION
initial fix for: https://github.com/elixir-lang/elixir/issues/3626
* Exception.format_file_line/2 refactored
* Exception.sanitize_file_name/3 added, to avoid UndefinedError when file is not a bitstring
* Applied sanitize_file_name/3 to everywhere a file path is required.
* test these Exceptions when called with no argument to not to fail