### PR TITLE
.gitignore: add .exenv-version and create "third-party section" in file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,8 @@
 /v*.zip
 /.eunit
 /.release
-.elixir.plt
 erl_crash.dump
+
+# Third-party apps
+.elixir.plt
+.exenv-version


### PR DESCRIPTION
It happens that i want `exevn` to run always from  a local copy that my git repository of elixir.