### PR TITLE
Iex m command

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -22,6 +22,7 @@ defmodule IEx.Helpers do
     * `l/1`           - loads the given module's beam code
     * `ls/0`          - lists the contents of the current directory
     * `ls/1`          - lists the contents of the specified directory
+    * `m/0`           - list loaded modules and their BEAM file locations
     * `pid/3`         - creates a PID with the 3 integer arguments passed
     * `pwd/0`         - prints the current working directory
     * `r/1`           - recompiles and reloads the given module
@@ -337,6 +338,28 @@ defmodule IEx.Helpers do
     quote do
       IEx.Introspection.s(unquote_splicing(args))
     end
+  end
+
+  @doc """
+  Prints out a list of all modules loaded and their BEAM file path.
+
+  """
+  def m() do
+    :code.all_loaded |>
+    Enum.sort |>
+    Enum.map(fn {module, path} -> m_print(module, path) end)
+
+    dont_display_result
+  end
+
+  defp m_print(module, path) when is_atom(module) and is_atom(path) do
+    IO.puts IEx.color(:eval_result, inspect(module))
+    IO.puts IEx.color(:eval_info, "  #{inspect(path)}")
+  end
+
+  defp m_print(module, path) when is_atom(module) do
+    IO.puts IEx.color(:eval_result, inspect(module))
+    IO.puts IEx.color(:eval_info, "  #{Path.relative_to_cwd(path)}")
   end
 
   @doc """

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -22,16 +22,17 @@ defmodule IEx.Helpers do
     * `l/1`           - loads the given module's beam code
     * `ls/0`          - lists the contents of the current directory
     * `ls/1`          - lists the contents of the specified directory
-    * `m/0`           - list loaded modules and their BEAM file locations
-    * `pid/3`         - creates a PID with the 3 integer arguments passed
-    * `pwd/0`         - prints the current working directory
-    * `r/1`           - recompiles and reloads the given module
-    * `recompile/0`   - recompiles the current Mix project (requires iex -S mix)
-    * `respawn/0`     - respawns a new IEx shell
-    * `s/1`           - prints spec information
-    * `t/1`           - prints type information
-    * `v/0`           - retrieves the last value from the history
-    * `v/1`           - retrieves the nth value from the history
+    * `m/0`           — list loaded modules and their BEAM file locations
+    * `m/1`           — prints information for the given module
+    * `pid/3`         — creates a PID with the 3 integer arguments passed
+    * `pwd/0`         — prints the current working directory
+    * `r/1`           — recompiles and reloads the given module's source file
+    * `respawn/0`     — respawns the current shell
+    * `s/1`           — prints spec information
+    * `t/1`           — prints type information
+    * `v/0`           — retrieves the last value from the history
+    * `v/1`           — retrieves the nth value from the history
+    * `import_file/1` — evaluates the given file in the shell's context
 
   Help for functions in this module can be consulted
   directly from the command line, as an example, try:
@@ -340,26 +341,112 @@ defmodule IEx.Helpers do
     end
   end
 
-  @doc """
-  Prints out a list of all modules loaded and their BEAM file path.
+  @module_info_labels [module: "Module:",
+                       object_file: "Object File:",
+                       source: "Source File:",
+                       version: "Version:",
+                       compile_time: "Compile Time:",
+                       compile_options: "Compile Options:"]
 
+  @doc """
+  Prints out a list of all modules loaded and their BEAM file paths.
   """
   def m() do
-    :code.all_loaded |>
-    Enum.sort |>
-    Enum.map(fn {module, path} -> m_print(module, path) end)
+    :code.all_loaded
+    |> Enum.sort
+    |> Enum.map(fn {module, path} ->m_display(module, path) end)
 
     dont_display_result
   end
 
-  defp m_print(module, path) when is_atom(module) and is_atom(path) do
-    IO.puts IEx.color(:eval_result, inspect(module))
-    IO.puts IEx.color(:eval_info, "  #{inspect(path)}")
+  @doc """
+  Print out available information about a loaded module.
+
+  Includes compile time, object file path, source file path,
+  version number and compile options. More complete information
+  can be found using the Erlang `module_info` function.
+  See http://www.erlang.org/doc/reference_manual/modules.html for more
+  information.
+  """
+  def m(module) when is_atom(module) do
+    case Code.ensure_loaded?(module) do
+      true -> m_display_info(module)
+        _  -> IO.puts IEx.color(:eval_error, "#{inspect(module)} could not be loaded.")
+    end
+
+    dont_display_result
   end
 
-  defp m_print(module, path) when is_atom(module) do
-    IO.puts IEx.color(:eval_result, inspect(module))
-    IO.puts IEx.color(:eval_info, "  #{Path.relative_to_cwd(path)}")
+  # Erlang 18 defines :module, 17 does not.
+  defp m_display_info(module) do
+   info = module.module_info
+          |> Keyword.put(:object_file, :code.which(module))
+          |> Keyword.put_new(:module, module)
+
+   @module_info_labels
+   |> Keyword.keys
+   |> Enum.map(fn key -> m_print(m_label(key), m_info(info, key)) end)
+  end
+
+  defp m_label(key) do
+    Keyword.get(@module_info_labels, key)
+  end
+
+  defp m_info(info, :source) do
+    case info[:compile][:source] do
+      nil  -> "no value found"
+      path -> Path.relative_to_cwd(path)
+    end
+  end
+
+  defp m_info(info, :compile_options) do
+    case info[:compile][:options] do
+      nil -> "no value found"
+      _   -> inspect(info[:compile][:options])
+    end
+  end
+
+  defp m_info(info, :compile_time) do
+    case info[:compile][:time] do
+      nil       -> "no value found"
+      cmpl_time -> m_format_time(cmpl_time)
+    end
+  end
+
+  defp m_info(info, :version) do
+    case info[:attributes][:vsn] do
+      nil     -> "no value found"
+      version -> inspect version
+    end
+  end
+
+  defp m_info(info, :object_file) do
+    case info[:object_file] do
+      nil                     -> "no value found"
+      atom when is_atom(atom) -> inspect atom
+      path                    -> Path.relative_to_cwd(path)
+    end
+  end
+
+  defp m_info(info, key) do
+   inspect Keyword.get(info, key, "no value found")
+  end
+
+  defp m_format_time({year,month,day,hour,min,sec}) do
+    "#{year}-#{month}-#{day} #{hour}:#{min}:#{sec}"
+  end
+
+  defp m_display(module, path) when is_atom(module) and is_atom(path) do
+    m_print(inspect(module), inspect(path))
+  end
+
+  defp m_display(module, path) when is_atom(module) do
+    m_print(inspect(module), Path.relative_to_cwd(path))
+  end
+
+  defp m_print(subject, info) do
+    IO.puts IEx.color(:eval_result, subject)
+    IO.puts IEx.color(:eval_info, "  #{info}")
   end
 
   @doc """

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -379,6 +379,12 @@ defmodule IEx.HelpersTest do
     assert loaded =~ ~r/IEx\n.*\.beam/
   end
 
+  test "m module helper" do
+    assert capture_iex("m IEx") =~ ~r/Module\:\n  IEx/
+    assert capture_iex("m Atom") =~ ~r/Compile Time\:\n  \d*\-\d*\-\d* \d*\:\d*\:\d*/
+    assert capture_iex("m :erlang") =~ ~r/\Module\:\n  \:erlang/
+  end
+
   defp test_module_code do
     """
     defmodule Sample do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -373,6 +373,12 @@ defmodule IEx.HelpersTest do
       capture_iex("pid(0,6,-6)")
   end
 
+  test "m helper" do
+    loaded = capture_iex("m")
+    assert loaded =~ ":erlang\n  :preloaded"
+    assert loaded =~ ~r/IEx\n.*\.beam/
+  end
+
   defp test_module_code do
     """
     defmodule Sample do


### PR DESCRIPTION
This patch implements two helper commands 

m - lists all loaded modules and the file path to their object code. 

m/1 - Lists some of the available information about a module. For example: 


iex(2)> m Atom
:module
  Atom
:object_file
  bin/../lib/elixir/ebin/Elixir.Atom.beam
:source
  lib/elixir/lib/atom.ex
:version
  [297983237527422559469627991153554784472]
:compile_time
  2015-8-31 1:48:12
:compile_options
  [:debug_info]

I'm pretty sure that the atoms as labels isn't for everyone's taste, so the code can be easily changed
to better names for those labels. Just let me know. 