### PR TITLE
Update a map for non existent key will raise a KeyError, not ArgumentError

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -88,7 +88,7 @@ defmodule Kernel.SpecialForms do
       %{:a => :c}
 
   Notice the update syntax requires the given keys to exist.
-  Trying to update a key that does not exist will raise an `ArgumentError`.
+  Trying to update a key that does not exist will raise an `KeyError`.
 
   ## AST representation
 


### PR DESCRIPTION
```
iex(7)> map = %{:a => 1, 2 => :b}
%{2 => :b, :a => 1}
iex(8)> %{map | :c => 3}
** (KeyError) key :c not found in: %{2 => :b, :a => 1}
```