### PR TITLE
Exceptions: Add message: and description: as default fields

### DIFF
--- a/lib/elixir/test/elixir/exception_all_modules_test.exs
+++ b/lib/elixir/test/elixir/exception_all_modules_test.exs
@@ -1,0 +1,86 @@
+Code.require_file "test_helper.exs", __DIR__
+
+defmodule ExceptionAllTest.Modules do
+  defmacro tests_all_modules() do
+    for module <- all_error_modules() do
+      quote do
+        # test "test #{unquote(module)} - no options" do
+        #   assert_raise unquote(module),
+        #     fn -> raise unquote(module)
+        #   end
+        # end
+
+        # test "test #{unquote(module)} - unknown option" do
+        #   assert_raise unquote(module),
+        #     fn ->
+        #       raise unquote(module), [unknown_option: ""] # ignore unknown options
+        #   end
+        # end
+
+        # test "test #{unquote(module)} - message:" do
+        #   assert_raise unquote(module),
+        #     "give me this message",
+        #     fn ->
+        #       raise unquote(module), [message: "give me this message"]
+        #   end
+        # end
+
+        # test "test #{unquote(module)} - description:" do
+        #   assert_raise unquote(module),
+        #     "error description",
+        #     fn ->
+        #       raise unquote(module), [description: "error description"]
+        #   end
+        # end
+
+      end
+    end
+  end
+
+  # TODO: load this list dinamically 
+  def all_error_modules() do
+    [
+      Elixir.ArgumentError,
+      Elixir.ArithmeticError, #Wrong message for ArithmeticError. Expected "give me this message", got "bad argument in arithmetic expression"
+      Elixir.BadArityError,
+      Elixir.BadFunctionError,
+      Elixir.BadMapError,
+      Elixir.BadStructError,
+      Elixir.CaseClauseError,
+      Elixir.Code.LoadError,
+      Elixir.CompileError,
+      Elixir.CondClauseError,
+      Elixir.Enum.EmptyError,
+      Elixir.Enum.OutOfBoundsError,
+      Elixir.ErlangError,
+      Elixir.File.CopyError,
+      Elixir.File.Error,
+      Elixir.FunctionClauseError,
+      Elixir.Inspect.Error,
+      Elixir.IO.StreamError,
+      Elixir.KeyError,
+      Elixir.MatchError,
+      Elixir.Protocol.UndefinedError,
+      Elixir.Regex.CompileError,
+      Elixir.RuntimeError,
+      Elixir.SyntaxError,
+      Elixir.SystemLimitError,
+      Elixir.TokenMissingError,
+      Elixir.TryClauseError,
+      Elixir.UndefinedFunctionError,
+      Elixir.UnicodeConversionError, #Expected exception UnicodeConversionError but got KeyError (key :encoded not found in: [])
+      Elixir.Version.InvalidRequirementError,
+      Elixir.Version.InvalidVersionError,
+    ]
+  end
+
+end
+
+defmodule ExceptionAllTest do
+  use ExUnit.Case, async: true
+
+  import ExceptionAllTest.Modules
+
+  tests_all_modules()
+
+end

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -309,12 +309,12 @@ defmodule Inspect.MapTest do
           "inspecting %{__struct__: Inspect.MapTest.Failing, key: 0}"
 
     assert inspect(%Failing{}) ==
-           "%Inspect.Error{message: \"#{msg}\"}"
+           "%Inspect.Error{description: nil, message: \"#{msg}\"}"
   end
 
   test "exception" do
     assert inspect(%RuntimeError{message: "runtime error"}) ==
-           "%RuntimeError{message: \"runtime error\"}"
+           "%RuntimeError{description: nil, message: \"runtime error\"}"
   end
 end
 

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -168,7 +168,8 @@ defmodule ExUnit.FormatterTest do
          Assertion with == failed
          code: :will_fail == %BadInspect{}
          lhs:  :will_fail
-         rhs:  %Inspect.Error{message: \"#{message}\"}
+         rhs:  %Inspect.Error{description: nil,
+                message: \"#{message}\"}
     """
   end
 
@@ -183,7 +184,7 @@ defmodule ExUnit.FormatterTest do
   test "message failure" do
     failure = {:error, catch_error(raise BadMessage), []}
     message = "got RuntimeError with message `oops` while retrieving Exception.message/1 " <>
-              "for %ExUnit.FormatterTest.BadMessage{key: 0}"
+              "for %ExUnit.FormatterTest.BadMessage{description: nil, key: 0, message: nil}"
     assert format_test_failure(test(), failure, 1, 80, &formatter/2) =~ """
       1) world (Hello)
          test/ex_unit/formatter_test.exs:1


### PR DESCRIPTION
This is an addition to the [first PR](#3647) trying to solve #3626 

Sorry for the poor write-up, but I'm trying to publish it, and then touch / document whatever necesssary

This commit does not affect any of the already defined exceptions. but it does simplifies the way new exceptions are defineds,

Since both `message` callback is required to create an exception, I have defined in the Exception struct, as defult the field :message, and :description

* the :description field defines de descpription of the error message (the default message) that we want to see when we call the raise the exception with no arguments.
* the :message field is defined by dinamically,

it is not longer necessary to define the fields when creating an exception

the following code will create the most basic exception
```elixir
defmodule SampleError do
  defexception []
end
```

which can be raise via:
`raise SampleError`
which will result in an error without any message,

If we want to pass define field,

we can do
```elixir
defmodule SampleError do
  defexception [description: "sample error"]
end
```

or we can simply it pass it as a string, and it will considered the description.

```elixir
defmodule SampleError do
  defexception "sample error"
end
```

```elixir
defmodule SampleError do
  defexception [description: "sample error", file: nil, line: nil]

  def message(exception) do
    file_line = Exception.sanitize_file_line(exception.file, exception.line, " ")
    cond do
      exception.message ->
        file_line <> "#{exception.message}"
      true ->
        file_line <> "#{exception.description}"
    end
  end
end
```

If the exception is raised, and it has not message, it will load the description, it available,
in the worst case scenario, it will not throw fail with another exception as before, but it raise with an empty message.

I have create a test called : exception_all_modules_test.exs which tries to call all the existing Exceptions, and call them withouth any fields, passing the description, and message.
Some are not easy to fix because the message it cannot be defined by the user, but its defined by the message callback, but many can be fixed allowing to pass a message dinamically. 

Aditionally if fixes the issues by calling an the functions defined in the exception module, to not to fail if not :file field is given. 

read the description of [first PR](https://github.com/elixir-lang/elixir/pull/3647) to see the other changes