### PR TITLE
Allow list of spec in Process.info/2

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -369,7 +369,7 @@ defmodule Process do
 
   See http://www.erlang.org/doc/man/erlang.html#process_info-2 for more info.
   """
-  @spec info(pid, atom) :: {atom, term} | nil
+  @spec info(pid, atom | [atom]) :: {atom, term} | [{atom, term}]  | nil
   def info(pid, spec)
 
   def info(pid, :registered_name) do
@@ -380,7 +380,7 @@ defmodule Process do
     end
   end
 
-  def info(pid, spec) when is_atom(spec) do
+  def info(pid, spec) when is_atom(spec) or is_list(spec) do
     nillify :erlang.process_info(pid, spec)
   end
 

--- a/lib/elixir/test/elixir/process_test.exs
+++ b/lib/elixir/test/elixir/process_test.exs
@@ -15,9 +15,13 @@ defmodule ProcessTest do
   end
 
   test "info/2" do
-    pid = spawn fn -> end
+    pid = spawn fn -> :timer.sleep(1000) end
+    assert Process.info(pid, :priority) == {:priority, :normal}
+    assert Process.info(pid, [:priority]) == [priority: :normal]
+
     Process.exit(pid, :kill)
     assert Process.info(pid, :backtrace) == nil
+    assert Process.info(pid, [:backtrace, :status]) == nil
   end
 
   test "info/2 with registered name" do
@@ -25,13 +29,19 @@ defmodule ProcessTest do
     Process.exit(pid, :kill)
     assert Process.info(pid, :registered_name) ==
            nil
+    assert Process.info(pid, [:registered_name]) ==
+           nil
 
     assert Process.info(self, :registered_name) ==
            {:registered_name, []}
+    assert Process.info(self, [:registered_name]) ==
+           [registered_name: []]
 
     Process.register(self, __MODULE__)
     assert Process.info(self, :registered_name) ==
            {:registered_name, __MODULE__}
+    assert Process.info(self, [:registered_name]) ==
+           [registered_name: __MODULE__]
   end
 
   test "exit(pid, :normal) does not cause the target process to exit" do


### PR DESCRIPTION
I was working on adding `regs()` helper to IEx and realised passing multiple items to `Process.info/2` wasn't available in Elixir.

There might be a good reason why it's not here in the first place but I figured it would be fairly quick to add so I might as well do it.

I'm not sure the typespec is correct, do I need to define a special type for `{atom, term}` and then use it in place of `{atom | term} | [{atom, term}]` ?