### PR TITLE
Implement format functions for String and IO

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -177,6 +177,28 @@ defmodule IO do
   end
 
   @doc """
+  Writes the items in data to the given device in in accordance
+  with `format_string`.
+
+  ## Examples
+
+    IO.format "Number ~b", [13]
+    #=> "Number 13"
+  """
+  def format(format_string, data \\ []) do
+    erl_dev = map_dev(group_leader())
+    IO.format(erl_dev, format_string, data)
+  end
+
+  @doc """
+  Writes the items in data to the given device in in accordance
+  with `format_string`.
+  """
+  def format(device, format_string, data) do
+    :io.format device, format_string, data
+  end
+
+  @doc """
   Inspects and writes the given argument to the device.
 
   It enables pretty printing by default with width of

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -185,6 +185,7 @@ defmodule IO do
     IO.format "Number ~b", [13]
     #=> "Number 13"
   """
+  @spec format(iodata, list) :: :ok
   def format(format_string, data \\ []) do
     erl_dev = map_dev(group_leader())
     IO.format(erl_dev, format_string, data)
@@ -194,6 +195,7 @@ defmodule IO do
   Writes the items in data to the given device in in accordance
   with `format_string`.
   """
+  @spec format(device, iodata, list) :: :ok
   def format(device, format_string, data) do
     :io.format device, format_string, data
   end

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -518,6 +518,23 @@ defmodule String do
   defdelegate rstrip(binary), to: String.Unicode
 
   @doc """
+  Returns a string which represents `data` formatted
+  in accordance with `format_string`
+
+  ## Examples
+
+    iex> String.format("hello")
+    "hello"
+
+    iex> String.format("elixir of ~s", ["life"])
+    "elixir of life"
+  """
+  @spec format(t, list) :: t
+  def format(format_string, data \\ []) do
+    IO.iodata_to_binary :io_lib.format(format_string, data)
+  end
+
+  @doc """
   Returns a string where trailing `char` have been removed.
 
   ## Examples

--- a/lib/elixir/test/elixir/io_test.exs
+++ b/lib/elixir/test/elixir/io_test.exs
@@ -120,6 +120,16 @@ defmodule IOTest do
     assert capture_io(fn -> IO.write(13) end) == "13"
   end
 
+  test "format" do
+    assert capture_io(fn -> IO.format("hello") end) == "hello"
+    assert capture_io(fn -> IO.format('hello') end) == "hello"
+  end
+
+  test "format with control characters" do
+    assert capture_io(fn -> IO.format("hello ~s", ["world"]) end) == "hello world"
+    assert capture_io(fn -> IO.format("number ~B", [13]) end) == "number 13"
+  end
+
   test "gets with chardata" do
     assert capture_io("foo\n", fn -> IO.gets("hello") end) == "hello"
     assert capture_io("foo\n", fn -> IO.gets('hello') end) == "hello"

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -156,6 +156,11 @@ defmodule StringTest do
     assert String.capitalize("ﬁn") == "Fin"
   end
 
+  test "format" do
+    assert String.format("Hello") == "Hello"
+    assert String.format("Number ~b", [13]) == "Number 13"
+  end
+
   test "rstrip" do
     assert String.rstrip("") == ""
     assert String.rstrip("1\n") == "1"


### PR DESCRIPTION
`IO.format` corresponds to Erlang's `:io.format` [see docs](http://erlang.org/doc/man/io.html#format-1),
and `String.format` corresponds to Erlang's `io_lib.format`  [also see docs](http://www.erlang.org/doc/man/io_lib.html#format-2)

The documentation included in this PR is incomplete, and I need to flesh it out before merger, but I wanted to put this up to gauge interest in this before writing it up.