### PR TITLE
Upgrade travis to check against Erlang 17.5 and 18.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ otp_release:
   - 17.0
   - 17.3
   - 17.4
+  - 17.5
+  - 18.0
 
 sudo: false
 


### PR DESCRIPTION
Minor travis tweak to support newer versions of erlang including 17.5, 17.5.3 and 18.0

Here is where I located the latest versions

https://packages.erlang-solutions.com/erlang/