### PR TITLE
Fix type in File.cp_r when files involed (renamed tmp to b.txt)

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -523,8 +523,8 @@ defmodule File do
 
   ## Examples
 
-      # Copies "a.txt" to "tmp"
-      File.cp_r "a.txt", "tmp.txt"
+      # Copies file "a.txt" to "b.txt"
+      File.cp_r "a.txt", "b.txt"
 
       # Copies all files in "samples" to "tmp"
       File.cp_r "samples", "tmp"


### PR DESCRIPTION
When working on f/File.rename, noticed what I think is a small documentation typo.

I renamed "tmp" to "b.txt" to avoid confusion with "/tmp"

Here's the tests I did to manually ensure I had it the right way around.

```
iex(1)> File.cp_r "/tmp/aha/one/a.txt", "/tmp/aha/two"
{:error, :eisdir, "/tmp/aha/one/a.txt"}

iex(2)> File.cp_r "/tmp/aha/one/a.txt", "/tmp/aha/two/b.txt"
{:ok, ["/tmp/aha/two/b.txt"]}
```