### PR TITLE
Correct indefinite article a/an

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -316,7 +316,7 @@ defmodule GenServer do
   The return value is ignored.
 
   `terminate/2` is called if a callback (except `init/1`) returns a `:stop`
-  tuple, raises, calls `Kernel.exit/1` or returns a invalid value. It may also
+  tuple, raises, calls `Kernel.exit/1` or returns an invalid value. It may also
   be called if the `GenServer` traps exits using `Process.flag/2` *and* the
   parent process sends an exit signal.
 

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -250,7 +250,7 @@ defmodule IO do
   Reads a line from the IO device. It returns:
 
     * `data` - the characters in the line terminated
-      by a LF (or end of file)
+      by a line-feed (LF) or end of file (EOF)
 
     * `:eof` - end of file was encountered
 

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -280,7 +280,7 @@ defmodule OptionParser do
     do_split(strip_leading_spaces(string), "", [], nil)
   end
 
-  # If we have a escaped quote, simply remove the escape
+  # If we have an escaped quote, simply remove the escape
   defp do_split(<<?\\, quote, t :: binary>>, buffer, acc, quote),
     do: do_split(t, <<buffer::binary, quote>>, acc, quote)
 
@@ -292,7 +292,7 @@ defmodule OptionParser do
   defp do_split(<<quote, t :: binary>>, buffer, acc, quote),
     do: do_split(t, buffer, acc, nil)
 
-  # If we have a escaped quote/space, simply remove the escape as long as we are not inside a quote
+  # If we have an escaped quote/space, simply remove the escape as long as we are not inside a quote
   defp do_split(<<?\\, h, t :: binary>>, buffer, acc, nil) when h in [?\s, ?', ?"],
     do: do_split(t, <<buffer::binary, h>>, acc, nil)
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -8,7 +8,7 @@ defmodule String do
 
   The functions in this module act according to the Unicode
   Standard, version 6.3.0. As per the standard, a codepoint is
-  an Unicode Character, which may be represented by one or more
+  a Unicode Character, which may be represented by one or more
   bytes. For example, the character "é" is represented with two
   bytes:
 

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -108,7 +108,7 @@ defmodule Supervisor do
   You may want to use a module-based supervisor if:
 
     * You need to do some particular action on supervisor
-      initialization, like setting up a ETS table.
+      initialization, like setting up an ETS table.
 
     * You want to perform partial hot-code swapping of the
       tree. For example, if you add or remove children,

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -478,7 +478,7 @@ defmodule ExUnit.Assertions do
 
       refute_receive :bye
 
-  Refute received with a explicit timeout:
+  Refute received with an explicit timeout:
 
       refute_receive :bye, 1000
 

--- a/lib/mix/lib/mix/dep/loader.ex
+++ b/lib/mix/lib/mix/dep/loader.ex
@@ -143,7 +143,7 @@ defmodule Mix.Dep.Loader do
     end
 
     unless scm do
-      Mix.raise "Could not find a SCM for dependency #{inspect app} from #{inspect Mix.Project.get}"
+      Mix.raise "Could not find an SCM for dependency #{inspect app} from #{inspect Mix.Project.get}"
     end
 
     %Mix.Dep{

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -65,7 +65,7 @@ defmodule Mix.Tasks.Archive.Install do
           File.mkdir_p!(dirname)
           File.write!(archive, binary)
         :badpath ->
-          Mix.raise "Expected #{inspect src} to be a url or a local file path"
+          Mix.raise "Expected #{inspect src} to be a URL or a local file path"
         {:local, message} ->
           Mix.raise message
         {kind, message} when kind in [:remote, :checksum] ->

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -409,8 +409,8 @@ defmodule Mix.Utils do
     {:ok, _} = Application.ensure_all_started(:ssl)
     {:ok, _} = Application.ensure_all_started(:inets)
 
-    # Starting a http client profile allows us to scope
-    # the effects of using a http proxy to this function
+    # Starting an http client profile allows us to scope
+    # the effects of using an http proxy to this function
     {:ok, _pid} = :inets.start(:httpc, [{:profile, :mix}])
 
     headers = [{'user-agent', 'Mix/#{System.version}'}]

--- a/lib/mix/test/mix/dep_test.exs
+++ b/lib/mix/test/mix/dep_test.exs
@@ -72,7 +72,7 @@ defmodule Mix.DepTest do
     with_deps [{:ok, "~> 0.1", not_really: :ok}], fn ->
       in_fixture "deps_status", fn ->
         send self, {:mix_shell_input, :yes?, false}
-        msg = "Could not find a SCM for dependency :ok from Mix.DepTest.ProcessDepsApp"
+        msg = "Could not find an SCM for dependency :ok from Mix.DepTest.ProcessDepsApp"
         assert_raise Mix.Error, msg, fn -> Mix.Dep.loaded([]) end
       end
     end

--- a/lib/mix/test/mix/scm_test.exs
+++ b/lib/mix/test/mix/scm_test.exs
@@ -9,12 +9,12 @@ defmodule Mix.SCMTest do
     :ok
   end
 
-  test "prepends a SCM" do
+  test "prepends an SCM" do
     Mix.SCM.prepend(Hello)
     assert Enum.at(Mix.SCM.available, 0) == Hello
   end
 
-  test "appends a SCM" do
+  test "appends an SCM" do
     Mix.SCM.append(Hello)
     assert Enum.at(Mix.SCM.available, -1) == Hello
   end


### PR DESCRIPTION
Run the following command, and reviewed the occurences one by one.
```sh
 # find words starting with vowels
ag -i '\ban?\s+[aeiou]\w+\b'

 # find acronyms
ag '\ban?\s+[BCDFGHJKLMNPQRSTVWXYZ][A-Z]+\b'

 # starting with "h"
ag -i '\ban?\s+[aeiou]\w+\b'
```