### PR TITLE
Regex.regex?/1: name unnamed argument and improve docs

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -160,7 +160,8 @@ defmodule Regex do
   end
 
   @doc """
-  Returns `true` if the given argument is a regex.
+  Returns `true` if the given `term` is a regex.
+  Otherwise returns `false`.
 
   ## Examples
 
@@ -173,6 +174,7 @@ defmodule Regex do
   """
   @spec regex?(t) :: true
   @spec regex?(any) :: false
+  def regex?(term)
   def regex?(%Regex{}), do: true
   def regex?(_), do: false
 


### PR DESCRIPTION
Functions with unnamed arguments: When not giving a variable with a name, the parser will choose the name: "arg1" , "arg2", etc. This command will search for the ex_doc generated documentation.
`ag "(?<=signature\"><strong>).*\W(arg|atom|binary|bool|float|int|list)\d+.*\)" ./doc`