### PR TITLE
Correct descriptions in docs to use Present Continuous

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ example:
 
 ```elixir
 @doc """
-Return only those elements for which `fun` is `true`.
+Returns only those elements for which `fun` is `true`.
 
 ## Examples
 

--- a/lib/eex/lib/eex.ex
+++ b/lib/eex/lib/eex.ex
@@ -162,7 +162,7 @@ defmodule EEx do
   end
 
   @doc """
-  Get a string `source` and generate a quoted expression
+  Gets a string `source` and generate a quoted expression
   that can be evaluated by Elixir or compiled to a function.
   """
   def compile_string(source, options \\ []) do
@@ -170,7 +170,7 @@ defmodule EEx do
   end
 
   @doc """
-  Get a `filename` and generate a quoted expression
+  Gets a `filename` and generate a quoted expression
   that can be evaluated by Elixir or compiled to a function.
   """
   def compile_file(filename, options \\ []) do
@@ -179,7 +179,7 @@ defmodule EEx do
   end
 
   @doc """
-  Get a string `source` and evaluate the values using the `bindings`.
+  Gets a string `source` and evaluate the values using the `bindings`.
 
   ## Examples
 
@@ -193,7 +193,7 @@ defmodule EEx do
   end
 
   @doc """
-  Get a `filename` and evaluate the values using the `bindings`.
+  Gets a `filename` and evaluate the values using the `bindings`.
 
   ## Examples
 

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -442,7 +442,7 @@ defmodule File do
   end
 
   @doc """
-  Rename the `source` file to `destination` file.  If can be used to move files
+  Renames the `source` file to `destination` file.  If can be used to move files
   (and directories) between directories.  If moving a file, you must fully
   specify the `destination` filename, it is not sufficient to simply specify
   it's directory.

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3572,7 +3572,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Define a function that delegates to another module.
+  Defines a function that delegates to another module.
 
   Functions defined with `defdelegate/2` are public and can be invoked from
   outside the module they're defined in (like if they were defined using

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -118,7 +118,7 @@ defmodule Module do
               end
 
               @doc """
-              Sum.
+              Sums `a` to `b`.
               """
               def sum(a, b) do
                 a + b

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -377,7 +377,7 @@ defmodule Task do
   end
 
   @doc """
-  Unlink and shutdown the task then check for a reply.
+  Unlinks and shutdowns the task, and then checks for a reply.
 
   Returns `{:ok, reply}` if the reply is received while shutting down the task,
   otherwise `nil`.

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -207,7 +207,7 @@ defmodule ExUnit.Case do
   end
 
   @doc """
-  Define a test with a string.
+  Defines a test with a string.
 
   Provides a convenient macro that allows a test to be
   defined with a string. This macro automatically inserts
@@ -249,7 +249,7 @@ defmodule ExUnit.Case do
   end
 
   @doc """
-  Define a not implemented test with a string.
+  Defines a not implemented test with a string.
 
   Provides a convenient macro that allows a test to be
   defined with a string, but not yet implemented. The

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -314,7 +314,7 @@ defmodule Logger do
   end
 
   @doc """
-  Compare log levels.
+  Compares log levels.
 
   Receives two log levels and compares the `left`
   against `right` and returns `:lt`, `:eq` or `:gt`.

--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -331,21 +331,21 @@ defmodule Mix.Dep do
   end
 
   @doc """
-  Return `true` if dependency is a mix project.
+  Returns `true` if dependency is a mix project.
   """
   def mix?(%Mix.Dep{manager: manager}) do
     manager == :mix
   end
 
   @doc """
-  Return `true` if dependency is a rebar project.
+  Returns `true` if dependency is a rebar project.
   """
   def rebar?(%Mix.Dep{manager: manager}) do
     manager == :rebar
   end
 
   @doc """
-  Return `true` if dependency is a make project.
+  Returns `true` if dependency is a make project.
   """
   def make?(%Mix.Dep{manager: manager}) do
     manager == :make

--- a/lib/mix/lib/mix/dep/loader.ex
+++ b/lib/mix/lib/mix/dep/loader.ex
@@ -17,7 +17,7 @@ defmodule Mix.Dep.Loader do
   end
 
   @doc """
-  Partition loaded dependencies by environment.
+  Partitions loaded dependencies by environment.
   """
   def partition_by_env(deps, opts) do
     if env = opts[:env] do

--- a/lib/mix/lib/mix/dep/lock.ex
+++ b/lib/mix/lib/mix/dep/lock.ex
@@ -42,7 +42,7 @@ defmodule Mix.Dep.Lock do
   end
 
   @doc """
-  Read the lockfile, returns a map containing
+  Reads the lockfile, returns a map containing
   each app name and its current lock information.
   """
   @spec read() :: map

--- a/lib/mix/lib/mix/generator.ex
+++ b/lib/mix/lib/mix/generator.ex
@@ -32,7 +32,7 @@ defmodule Mix.Generator do
   end
 
   @doc """
-  Embed a template given by `contents` into the current module.
+  Embeds a template given by `contents` into the current module.
 
   It will define a private function with the `name` followed by
   `_template` that expects assigns as arguments.

--- a/lib/mix/lib/mix/hex.ex
+++ b/lib/mix/lib/mix/hex.ex
@@ -45,7 +45,7 @@ defmodule Mix.Hex do
   end
 
   @doc """
-  Ensure Hex is started.
+  Ensures Hex is started.
   """
   def start do
     try do

--- a/lib/mix/lib/mix/local.ex
+++ b/lib/mix/lib/mix/local.ex
@@ -12,7 +12,7 @@ defmodule Mix.Local do
   end
 
   @doc """
-  Append archives paths into Erlang code path.
+  Appends archives paths into Erlang code path.
   """
   def append_archives do
     archives = archives_ebin()
@@ -21,7 +21,7 @@ defmodule Mix.Local do
   end
 
   @doc """
-  Append mix paths into Erlang code path.
+  Appends mix paths into Erlang code path.
   """
   def append_paths do
     Enum.each(Mix.Utils.mix_paths, &Code.append_path(&1))
@@ -43,7 +43,7 @@ defmodule Mix.Local do
   end
 
   @doc """
-  Check Elixir version requirement stored in the archive and print a warning if it is not satisfied.
+  Checks Elixir version requirement stored in the archive and print a warning if it is not satisfied.
   """
   def check_archive_elixir_version(path) do
     path |> Mix.Archive.ebin |> check_elixir_version_in_ebin()

--- a/lib/mix/lib/mix/remote_converger.ex
+++ b/lib/mix/lib/mix/remote_converger.ex
@@ -6,13 +6,13 @@ defmodule Mix.RemoteConverger do
   # Useful for things like external package managers
 
   @doc """
-  Return `true` if given dependency is handled by
+  Returns `true` if given dependency is handled by
   remote converger.
   """
   @callback remote?(Mix.Dep.t) :: boolean
 
   @doc """
-  Run the remote converger.
+  Runs the remote converger.
 
   Return updated lock.
   """
@@ -25,14 +25,14 @@ defmodule Mix.RemoteConverger do
   @callback deps(Mix.Dep.t, map) :: [atom]
 
   @doc """
-  Get registered remote converger.
+  Gets registered remote converger.
   """
   def get do
     Mix.State.get(:remote_converger)
   end
 
   @doc """
-  Register a remote converger.
+  Registers a remote converger.
   """
   def register(mod) when is_atom(mod) do
     Mix.State.put(:remote_converger, mod)

--- a/lib/mix/lib/mix/scm.ex
+++ b/lib/mix/lib/mix/scm.ex
@@ -119,14 +119,14 @@ defmodule Mix.SCM do
   end
 
   @doc """
-  Prepend the given SCM module to the list of available SCMs.
+  Prepends the given SCM module to the list of available SCMs.
   """
   def prepend(mod) when is_atom(mod) do
     Mix.State.prepend(:scm, mod)
   end
 
   @doc """
-  Append the given SCM module to the list of available SCMs.
+  Appends the given SCM module to the list of available SCMs.
   """
   def append(mod) when is_atom(mod) do
     Mix.State.append(:scm, mod)

--- a/lib/mix/lib/mix/shell/process.ex
+++ b/lib/mix/lib/mix/shell/process.ex
@@ -18,7 +18,7 @@ defmodule Mix.Shell.Process do
   @behaviour Mix.Shell
 
   @doc """
-  Flush all `:mix_shell` and `:mix_shell_input` messages from the current process.
+  Flushes all `:mix_shell` and `:mix_shell_input` messages from the current process.
   If a callback is given, it is invoked for each received message.
 
   ## Examples

--- a/lib/mix/lib/mix/tasks/app.start.ex
+++ b/lib/mix/lib/mix/tasks/app.start.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.App.Start do
   use Mix.Task
 
-  @shortdoc "Start all registered apps"
+  @shortdoc "Starts all registered apps"
 
   @moduledoc """
   Starts all registered apps.

--- a/lib/mix/lib/mix/tasks/archive.build.ex
+++ b/lib/mix/lib/mix/tasks/archive.build.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Archive.Build do
   use Mix.Task
 
-  @shortdoc "Archive this project into a .ez file"
+  @shortdoc "Archives this project into a .ez file"
 
   @moduledoc """
   Builds an archive according to the specification of the

--- a/lib/mix/lib/mix/tasks/archive.ex
+++ b/lib/mix/lib/mix/tasks/archive.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Archive do
   use Mix.Task
 
-  @shortdoc "List all archives"
+  @shortdoc "Lists all archives"
 
   @moduledoc """
   Lists all installed archives.

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -1,10 +1,10 @@
 defmodule Mix.Tasks.Archive.Install do
   use Mix.Task
 
-  @shortdoc "Install an archive locally"
+  @shortdoc "Installs an archive locally"
 
   @moduledoc """
-  Install an archive locally.
+  Installs an archive locally.
 
   If no argument is supplied but there is an archive in the root
   (created with mix archive), then the archive will be installed

--- a/lib/mix/lib/mix/tasks/archive.uninstall.ex
+++ b/lib/mix/lib/mix/tasks/archive.uninstall.ex
@@ -1,10 +1,10 @@
 defmodule Mix.Tasks.Archive.Uninstall do
   use Mix.Task
 
-  @shortdoc "Uninstall archives"
+  @shortdoc "Uninstalls archives"
 
   @moduledoc """
-  Uninstall local archives:
+  Uninstalls local archives:
 
       mix archive.uninstall archive.ez
 

--- a/lib/mix/lib/mix/tasks/clean.ex
+++ b/lib/mix/lib/mix/tasks/clean.ex
@@ -1,11 +1,11 @@
 defmodule Mix.Tasks.Clean do
   use Mix.Task
 
-  @shortdoc "Delete generated application files"
+  @shortdoc "Deletes generated application files"
   @recursive true
 
   @moduledoc """
-  Delete generated application files.
+  Deletes generated application files.
 
   This command deletes all build artifacts for the current project.
   Dependencies' build files are cleaned if the `--deps` option is given.

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Compile.Erlang do
   @manifest ".compile.erlang"
 
   @moduledoc """
-  Compile Erlang source files.
+  Compiles Erlang source files.
 
   When this task runs, it will first check the modification times of
   all files to be compiled and if they haven't been

--- a/lib/mix/lib/mix/tasks/compile.ex
+++ b/lib/mix/lib/mix/tasks/compile.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Compile do
   use Mix.Task
 
-  @shortdoc "Compile source files"
+  @shortdoc "Compiles source files"
 
   @moduledoc """
   A meta task that compiles source files.

--- a/lib/mix/lib/mix/tasks/compile.leex.ex
+++ b/lib/mix/lib/mix/tasks/compile.leex.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Compile.Leex do
   @manifest ".compile.leex"
 
   @moduledoc """
-  Compile Leex source files.
+  Compiles Leex source files.
 
   When this task runs, it will check the modification time of every file, and
   if it has changed, the file will be compiled. Files will be

--- a/lib/mix/lib/mix/tasks/compile.yecc.ex
+++ b/lib/mix/lib/mix/tasks/compile.yecc.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Compile.Yecc do
   @manifest ".compile.yecc"
 
   @moduledoc """
-  Compile Yecc source files.
+  Compiles Yecc source files.
 
   When this task runs, it will check the modification time of every file, and
   if it has changed, the file will be compiled. Files will be

--- a/lib/mix/lib/mix/tasks/deps.clean.ex
+++ b/lib/mix/lib/mix/tasks/deps.clean.ex
@@ -1,10 +1,10 @@
 defmodule Mix.Tasks.Deps.Clean do
   use Mix.Task
 
-  @shortdoc "Remove the given dependencies' files"
+  @shortdoc "Removes the given dependencies' files"
 
   @moduledoc """
-  Remove the given dependencies' files, including build artifacts and fetched
+  Removes the given dependencies' files, including build artifacts and fetched
   sources.
 
   Since this is a destructive action, cleaning of dependencies

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -1,10 +1,10 @@
 defmodule Mix.Tasks.Deps.Compile do
   use Mix.Task
 
-  @shortdoc "Compile dependencies"
+  @shortdoc "Compiles dependencies"
 
   @moduledoc """
-  Compile dependencies.
+  Compiles dependencies.
 
   By default, compile all dependencies. A list of dependencies can
   be given to force the compilation of specific dependencies.

--- a/lib/mix/lib/mix/tasks/deps.ex
+++ b/lib/mix/lib/mix/tasks/deps.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.Deps do
 
   import Mix.Dep, only: [loaded: 1, format_dep: 1, format_status: 1, check_lock: 2]
 
-  @shortdoc "List dependencies and their status"
+  @shortdoc "Lists dependencies and their status"
 
   @moduledoc ~S"""
   List all dependencies and their status.

--- a/lib/mix/lib/mix/tasks/deps.get.ex
+++ b/lib/mix/lib/mix/tasks/deps.get.ex
@@ -1,10 +1,10 @@
 defmodule Mix.Tasks.Deps.Get do
   use Mix.Task
 
-  @shortdoc "Get all out of date dependencies"
+  @shortdoc "Gets all out of date dependencies"
 
   @moduledoc """
-  Get all out of date dependencies, i.e. dependencies
+  Gets all out of date dependencies, i.e. dependencies
   that are not available or have an invalid lock.
 
   ## Command line options

--- a/lib/mix/lib/mix/tasks/deps.unlock.ex
+++ b/lib/mix/lib/mix/tasks/deps.unlock.ex
@@ -1,10 +1,10 @@
 defmodule Mix.Tasks.Deps.Unlock do
   use Mix.Task
 
-  @shortdoc "Unlock the given dependencies"
+  @shortdoc "Unlocks the given dependencies"
 
   @moduledoc """
-  Unlock the given dependencies.
+  Unlocks the given dependencies.
 
   Since this is a destructive action, unlocking of dependencies
   can only happen by passing arguments/options:

--- a/lib/mix/lib/mix/tasks/deps.update.ex
+++ b/lib/mix/lib/mix/tasks/deps.update.ex
@@ -1,10 +1,10 @@
 defmodule Mix.Tasks.Deps.Update do
   use Mix.Task
 
-  @shortdoc "Update the given dependencies"
+  @shortdoc "Updates the given dependencies"
 
   @moduledoc """
-  Update the given dependencies.
+  Updates the given dependencies.
 
   Since this is a destructive action, update of all dependencies
   can only happen by passing the `--all` command line option.

--- a/lib/mix/lib/mix/tasks/help.ex
+++ b/lib/mix/lib/mix/tasks/help.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Help do
   use Mix.Task
 
-  @shortdoc "Print help information for tasks"
+  @shortdoc "Prints help information for tasks"
 
   @moduledoc """
   Lists all tasks or prints the documentation for a given task.

--- a/lib/mix/lib/mix/tasks/local.ex
+++ b/lib/mix/lib/mix/tasks/local.ex
@@ -1,10 +1,10 @@
 defmodule Mix.Tasks.Local do
   use Mix.Task
 
-  @shortdoc "List local tasks"
+  @shortdoc "Lists local tasks"
 
   @moduledoc """
-  List local tasks.
+  Lists local tasks.
   """
 
   @spec run([]) :: :ok

--- a/lib/mix/lib/mix/tasks/local.hex.ex
+++ b/lib/mix/lib/mix/tasks/local.hex.ex
@@ -5,10 +5,10 @@ defmodule Mix.Tasks.Local.Hex do
   @hex_list_url     @hex_s3 <> "/installs/hex-1.x.csv"
   @hex_archive_url  @hex_s3 <> "/installs/[VERSION]/hex.ez"
 
-  @shortdoc "Install hex locally"
+  @shortdoc "Installs hex locally"
 
   @moduledoc """
-  Install Hex locally.
+  Installs Hex locally.
 
       mix local.hex
 

--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -5,10 +5,10 @@ defmodule Mix.Tasks.Local.Rebar do
   @rebar_list_url     @rebar_s3 <> "/installs/rebar-1.x.csv"
   @rebar_escript_url  @rebar_s3 <> "/installs/[VERSION]/rebar"
 
-  @shortdoc  "Install rebar locally"
+  @shortdoc  "Installs rebar locally"
 
   @moduledoc """
-  Fetch a copy of rebar from the given path or url.
+  Fetches a copy of rebar from the given path or url.
 
   It defaults to safely download a rebar copy from S3. However, a URL
   can be given as argument, usually from an existing local copy of rebar.

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.New do
   import Mix.Generator
   import Mix.Utils, only: [camelize: 1, underscore: 1]
 
-  @shortdoc "Create a new Elixir project"
+  @shortdoc "Creates a new Elixir project"
 
   @moduledoc """
   Creates a new Elixir project.

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -27,11 +27,11 @@ defmodule Mix.Tasks.Test do
 
   use Mix.Task
 
-  @shortdoc "Run a project's tests"
+  @shortdoc "Runs a project's tests"
   @recursive true
 
   @moduledoc """
-  Run the tests for a project.
+  Runs the tests for a project.
 
   This task starts the current application, loads up
   `test/test_helper.exs` and then requires all files matching the

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -4,7 +4,7 @@ defmodule Mix.Utils do
   """
 
   @doc """
-  Get the mix home.
+  Gets the mix home.
 
   It defaults to `~/.mix` unless the `MIX_HOME`
   environment variable is set.
@@ -21,7 +21,7 @@ defmodule Mix.Utils do
   end
 
   @doc """
-  Get all paths defined in the MIX_PATH env variable.
+  Gets all paths defined in the MIX_PATH env variable.
 
   `MIX_PATH` may contain multiple paths. If on Windows, those
   paths should be separated by `;`, if on unix systems, use `:`.
@@ -69,7 +69,7 @@ defmodule Mix.Utils do
   end
 
   @doc """
-  Extract all stale `sources` compared to the given `targets`.
+  Extracts all stale `sources` compared to the given `targets`.
   """
   def extract_stale(_sources, []), do: []
   def extract_stale([], _targets), do: []
@@ -114,7 +114,7 @@ defmodule Mix.Utils do
   end
 
   @doc """
-  Extract files from a list of paths.
+  Extracts files from a list of paths.
 
   `exts_or_pattern` may be a list of extensions or a
   `Path.wildcard/1` pattern.
@@ -284,7 +284,7 @@ defmodule Mix.Utils do
   Symlink directory `source` to `target` or copy it recursively
   in case symlink fails.
 
-  Expect source and target to be absolute paths as it generates
+  Expects source and target to be absolute paths as it generates
   a relative symlink.
   """
   def symlink_or_copy(source, target) do

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -39,7 +39,7 @@ defmodule Mix.CLITest do
       defmodule Mix.Tasks.MyHello do
         use Mix.Task
 
-        @shortdoc "Hello"
+        @shortdoc "Says hello"
 
         def run(_) do
           IO.puts Mix.Project.get!.hello_world
@@ -63,7 +63,7 @@ defmodule Mix.CLITest do
   test "--help smoke test" do
     in_fixture "no_mixfile", fn ->
       output = mix ~w[--help]
-      assert output =~ ~r/mix compile\s+# Compile source files/
+      assert output =~ ~r/mix compile\s+# Compiles source files/
       refute output =~ "mix invalid"
     end
   end


### PR DESCRIPTION
It makes it consistent with the rest of the docs.

I have just looked for the first line in @doc, @moduledoc, so lines bellow it may still need
to be corrected.

@shortdoc all have been corrected.

Inspired by: https://github.com/elixir-lang/elixir/pull/2942

Command to list the first lines:

```sh
  # first line in @moduledoc / @doc
  ag '(@(module)?doc)\s+("{3})(\r|\n|.)\s*+[\w-]+(?<!s)\b'

  # also @shortdoc
  ag '(@shortdoc)\s+("{1,3})(\r|\n|.)\s*+[\w-]+(?<!s)\b'
```