### PR TITLE
Avoid splitting words that use hyphen

### DIFF
--- a/lib/eex/lib/eex.ex
+++ b/lib/eex/lib/eex.ex
@@ -63,8 +63,8 @@ defmodule EEx do
   All expressions that output something to the template
   **must** use the equals sign (`=`). Since everything in
   Elixir is an expression, there are no exceptions for this rule.
-  For example, while some template languages would special-
-  case `if` clauses, they are treated the same in EEx and
+  For example, while some template languages would special-case
+  `if` clauses, they are treated the same in EEx and
   also require `=` in order to have their result printed:
 
       <%= if true do %>

--- a/lib/mix/lib/mix/dep/converger.ex
+++ b/lib/mix/lib/mix/dep/converger.ex
@@ -111,8 +111,8 @@ defmodule Mix.Dep.Converger do
     end
   end
 
-  # We traverse the tree of dependencies in a breadth-
-  # first fashion. The reason for this is that we converge
+  # We traverse the tree of dependencies in a breadth-first
+  # fashion. The reason for this is that we converge
   # dependencies, but allow the parent to override any
   # dependency in the child. Consider this tree with
   # dependencies `a`, `b`, etc and the order they are

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -336,8 +336,8 @@ defmodule Mix.Tasks.New do
   # This configuration is loaded before any dependency and is restricted
   # to this project. If another project depends on this project, this
   # file won't be loaded nor affect the parent project. For this reason,
-  # if you want to provide default values for your application for 3rd-
-  # party users, it should be done in your mix.exs file.
+  # if you want to provide default values for your application for
+  # 3rd-party users, it should be done in your mix.exs file.
 
   # You can configure for your application as:
   #


### PR DESCRIPTION
Solves a bug in the docs, http://elixir-lang.org/docs/master/eex/EEx.html
search for "special- case"

For the ones in the documentation, a space will be added in after the hyphen.
Just for consistency and to ease detection, I have replaced the ones in
comments as well.

Command to detect these lines:

    ag "\w+-\n"