### PR TITLE
made Float.parse() support complete scientific notation

### DIFF
--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -37,27 +37,31 @@ defmodule Float do
     end
   end
 
+  def parse("+" <> binary) do
+    parse_unsigned(binary)
+  end
+
   def parse(binary) do
     parse_unsigned(binary)
   end
 
-  defp parse_unsigned(<<char, rest::binary>>) when char in ?0..?9, do:
-    parse_unsigned(rest, false, false, <<char>>)
+  defp parse_unsigned(<<digit, rest::binary>>) when digit in ?0..?9, do:
+    parse_unsigned(rest, false, false, <<digit>>)
 
   defp parse_unsigned(binary) when is_binary(binary), do:
     :error
 
-  defp parse_unsigned(<<char, rest :: binary>>, dot?, e?, acc) when char in ?0..?9, do:
-    parse_unsigned(rest, dot?, e?, <<acc::binary, char>>)
+  defp parse_unsigned(<<digit, rest :: binary>>, dot?, e?, acc) when digit in ?0..?9, do:
+    parse_unsigned(rest, dot?, e?, <<acc::binary, digit>>)
 
-  defp parse_unsigned(<<?., char, rest :: binary>>, false, false, acc) when char in ?0..?9, do:
-    parse_unsigned(rest, true, false, <<acc::binary, ?., char>>)
+  defp parse_unsigned(<<?., digit, rest :: binary>>, false, false, acc) when digit in ?0..?9, do:
+    parse_unsigned(rest, true, false, <<acc::binary, ?., digit>>)
 
-  defp parse_unsigned(<<?e, char, rest :: binary>>, dot?, false, acc) when char in ?0..?9, do:
-    parse_unsigned(rest, true, true, <<add_dot(acc, dot?)::binary, ?e, char>>)
+  defp parse_unsigned(<<exp_marker, digit, rest :: binary>>, dot?, false, acc) when exp_marker in 'eE' and  digit in ?0..?9, do:
+    parse_unsigned(rest, true, true, <<add_dot(acc, dot?)::binary, ?e, digit>>)
 
-  defp parse_unsigned(<<?e, ?-, char, rest :: binary>>, dot?, false, acc) when char in ?0..?9, do:
-    parse_unsigned(rest, true, true, <<add_dot(acc, dot?)::binary, ?e, ?-, char>>)
+  defp parse_unsigned(<<exp_marker, sign, digit, rest :: binary>>, dot?, false, acc) when exp_marker in 'eE' and sign in '-+' and digit in ?0..?9, do:
+    parse_unsigned(rest, true, true, <<add_dot(acc, dot?)::binary, ?e, sign, digit>>)
 
   defp parse_unsigned(rest, dot?, _e?, acc), do:
     {:erlang.binary_to_float(add_dot(acc, dot?)), rest}

--- a/lib/elixir/test/elixir/float_test.exs
+++ b/lib/elixir/test/elixir/float_test.exs
@@ -24,6 +24,11 @@ defmodule FloatTest do
     assert Float.parse("1.32453e-10") === {1.32453e-10, ""}
     assert Float.parse("1.32.45") === {1.32, ".45"}
     assert Float.parse("1.o") === {1.0, ".o"}
+    assert Float.parse("+12.3E+4") === {1.23e5, ""}
+    assert Float.parse("+12.3E-4x") === {0.00123, "x"}
+    assert Float.parse("-1.23e-0xFF") === {-1.23, "xFF"}
+    assert Float.parse("-1.e2") === {-1.0, ".e2"}
+    assert Float.parse(".12") === :error
     assert Float.parse("--1.2") === :error
     assert Float.parse("++1.2") === :error
     assert Float.parse("pi") === :error


### PR DESCRIPTION
New version can parse "+digit" like "+1.0, and supports E as exponent markter as well as e. + after the exponent marker is legitimate too.
So, Float.parse("+1.0E+2x") returns {100.0, "x"} now.