### PR TITLE
Format raise message consistently

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1305,8 +1305,8 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> raise "Oops"
-      ** (RuntimeError) Oops
+      iex> raise "oops"
+      ** (RuntimeError) oops
 
       try do
         1 + :foo
@@ -1393,11 +1393,11 @@ defmodule Kernel do
   ## Examples
 
       try do
-        raise "Oops"
+        raise "oops"
       rescue
         exception ->
           stacktrace = System.stacktrace
-          if Exception.message(exception) == "Oops" do
+          if Exception.message(exception) == "oops" do
             reraise exception, stacktrace
           end
       end
@@ -1446,7 +1446,7 @@ defmodule Kernel do
   ## Examples
 
       try do
-        raise "Oops"
+        raise "oops"
       rescue
         exception ->
           stacktrace = System.stacktrace

--- a/lib/elixir/unicode/unicode.ex
+++ b/lib/elixir/unicode/unicode.ex
@@ -223,8 +223,8 @@ defmodule String.Graphemes do
 
   # There is no codepoint marked as Prepend by Unicode 6.3.0
   if cluster["Prepend"] do
-    raise "It seems this new unicode version has added Prepend items. " <>
-          "Please remove this error and uncomment the code below."
+    raise "it seems this new unicode version has added Prepend items. " <>
+          "Please remove this error and uncomment the code below"
   end
 
   # Don't break CRLF

--- a/lib/ex_unit/test/ex_unit/callbacks_test.exs
+++ b/lib/ex_unit/test/ex_unit/callbacks_test.exs
@@ -245,10 +245,10 @@ defmodule ExUnit.CallbacksNoTests do
   use ExUnit.Case, async: true
 
   setup_all do
-    raise "Never run"
+    raise "never run"
   end
 
   setup do
-    raise "Never run"
+    raise "never run"
   end
 end

--- a/lib/mix/lib/mix/compilers/erlang.ex
+++ b/lib/mix/lib/mix/compilers/erlang.ex
@@ -90,7 +90,7 @@ defmodule Mix.Compilers.Erlang do
 
       # Raise if any error, return :ok otherwise
       if :error in results do
-        Mix.raise "Encountered compilation errors."
+        Mix.raise "Encountered compilation errors"
       end
       :ok
     end

--- a/lib/mix/lib/mix/dep/converger.ex
+++ b/lib/mix/lib/mix/dep/converger.ex
@@ -26,7 +26,7 @@ defmodule Mix.Dep.Converger do
           Enum.find(deps, fn(%Mix.Dep{app: other_app}) -> app == other_app end)
         end)
       else
-        Mix.raise "Could not sort dependencies. There are cycles in the dependency graph."
+        Mix.raise "Could not sort dependencies. There are cycles in the dependency graph"
       end
     after
       :digraph.delete(graph)

--- a/lib/mix/lib/mix/shell/process.ex
+++ b/lib/mix/lib/mix/shell/process.ex
@@ -97,7 +97,7 @@ defmodule Mix.Shell.Process do
     receive do
       {:mix_shell_input, :prompt, response} -> response
     after
-      0 -> raise "No shell process input given for prompt/1"
+      0 -> raise "no shell process input given for prompt/1"
     end
   end
 
@@ -117,7 +117,7 @@ defmodule Mix.Shell.Process do
     receive do
       {:mix_shell_input, :yes?, response} -> response
     after
-      0 -> raise "No shell process input given for yes?/1"
+      0 -> raise "no shell process input given for yes?/1"
     end
   end
 end

--- a/lib/mix/lib/mix/tasks/deps.clean.ex
+++ b/lib/mix/lib/mix/tasks/deps.clean.ex
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.Deps.Clean do
         Mix.raise "mix deps.clean expects dependencies as arguments or " <>
                   "a flag indicating which dependencies to clean. " <>
                   "The --all option will clean all dependencies while " <>
-                  "the --unused option cleans unused dependencies."
+                  "the --unused option cleans unused dependencies"
     end
 
     if opts[:unlock] do

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -578,7 +578,7 @@ defmodule Mix.Tasks.DepsTest do
       message = "mix deps.clean expects dependencies as arguments or " <>
                 "a flag indicating which dependencies to clean. " <>
                 "The --all option will clean all dependencies while " <>
-                "the --unused option cleans unused dependencies."
+                "the --unused option cleans unused dependencies"
 
       assert_raise Mix.Error, message, fn ->
         Mix.Tasks.Deps.Clean.run []


### PR DESCRIPTION
Kernel.raise messages should not start with uppercase, and should not
have trailing punctuation.

Mix.raise messages should start with uppercase, and should not have a trailing
puntuation.

    # starting with uppercase
    # exclude (Mix.raise, and any message that starts with all uppecase such as: I or IO
    ag '(?<!Mix\.)raise\s+\"+(?!([A-Z]+\b))[A-Z]'

    # Mix.raise should start with upper case
    # except when `mix` or `rebar` are mentioned
    ag 'Mix\.raise\s+\"(?!(mix|rebar))+[a-z]'

    # ending in period
    ag "raise\s+\"+.+\.\"\s*\n"