### PR TITLE
Add/Correct arity in functions that are not being linked in html docs

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -4,7 +4,7 @@ defmodule Exception do
 
   Note that stacktraces in Elixir are updated on throw,
   errors and exits. For example, at any given moment,
-  `System.stacktrace` will return the stacktrace for the
+  `System.stacktrace/0` will return the stacktrace for the
   last throw/error/exit that occurred in the current process.
 
   Do not rely on the particular format returned by the `format`

--- a/lib/elixir/lib/gen_event.ex
+++ b/lib/elixir/lib/gen_event.ex
@@ -36,7 +36,7 @@ defmodule GenEvent do
         end
       end
 
-      {:ok, pid} = GenEvent.start_link()
+      {:ok, pid} = GenEvent.start_link([])
 
       GenEvent.add_handler(pid, LoggerHandler, [])
       #=> :ok
@@ -53,7 +53,7 @@ defmodule GenEvent do
       GenEvent.call(pid, LoggerHandler, :messages)
       #=> []
 
-  We start a new event manager by calling `GenEvent.start_link/0`.
+  We start a new event manager by calling `GenEvent.start_link/1`.
   Notifications can be sent to the event manager which will then
   invoke `handle_event/2` for each registered handler.
 
@@ -89,7 +89,7 @@ defmodule GenEvent do
       -  `{:stop, reason}` - monitored process terminated (for monitored handlers)
       -  `:remove_handler` - handler is being removed
       -  `{:error, term}` - handler crashed or returned a bad value
-      -  `term` - any term passed to functions like `GenEvent.remove_handler/2`
+      -  `term` - any term passed to functions like `GenEvent.remove_handler/3`
 
     * `code_change(old_vsn, state, extra)` - called when the application
       code is being upgraded live (hot code swapping).
@@ -251,7 +251,7 @@ defmodule GenEvent do
   Invoked when the server is about to exit. It should do any cleanup required.
 
   `reason` is removal reason and `state` is the current state of the handler.
-  The return value is returned to `GenEvent.remove_handler/2` or ignored if
+  The return value is returned to `GenEvent.remove_handler/3` or ignored if
   removing for another reason.
 
   `reason` is one of:
@@ -261,7 +261,7 @@ defmodule GenEvent do
   -  `:remove_handler` - handler is being removed
   -  `{:error, term}` - handler crashed or returned a bad value and an error is
   logged
-  -  `term` - any term passed to functions like `GenEvent.remove_handler/2`
+  -  `term` - any term passed to functions like `GenEvent.remove_handler/3`
 
   If part of a supervision tree, a `GenEvent`'s `Supervisor` will send an exit
   signal when shutting it down. The exit signal is based on the shutdown

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -22,7 +22,7 @@ defmodule IO do
   Elixir provides two shorcuts:
 
     * `:stdio` - a shortcut for `:standard_io`, which maps to
-      the current `Process.group_leader` in Erlang
+      the current `Process.group_leader/0` in Erlang
 
     * `:stderr` - a shortcut for the named process `:standard_error`
       provided in Erlang

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -141,7 +141,7 @@ defmodule IO.ANSI do
 
   The named sequences are represented by atoms.
 
-  It will also append an `IO.ANSI.reset` to the chardata when a conversion is
+  It will also append an `IO.ANSI.reset/0` to the chardata when a conversion is
   performed. If you don't want this behaviour, use `format_fragment/2`.
 
   An optional boolean parameter can be passed to enable or disable

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -580,10 +580,10 @@ defmodule Kernel.SpecialForms do
   Notice that calling `except` for a previously declared `import`
   simply filters the previously imported elements. For example:
 
-      import List, only: [flatten: 1, keyfind: 3]
+      import List, only: [flatten: 1, keyfind: 4]
       import List, except: [flatten: 1]
 
-  After the two import calls above, only `List.keyfind/3` will be
+  After the two import calls above, only `List.keyfind/4` will be
   imported.
 
   ## Underscore functions
@@ -1415,8 +1415,9 @@ defmodule Kernel.SpecialForms do
   defmacro __aliases__(args)
 
   @doc """
-  Calls the overriden function when overriding it with `defoverridable`.
-  See `Kernel.defoverridable` for more information and documentation.
+  Calls the overriden function when overriding it with `Kernel.defoverridable/1`.
+
+  See `Kernel.defoverridable/1` for more information and documentation.
   """
   defmacro super(args)
 

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -117,7 +117,7 @@ defmodule Macro do
   @doc """
   Applies the given function to the node metadata if it contains one.
 
-  This is often useful when used with `Macro.prewalk/1` to remove
+  This is often useful when used with `Macro.prewalk/2` to remove
   information like lines and hygienic counters from the expression
   for either storage or comparison.
 

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -405,13 +405,13 @@ defmodule Module do
 
   ## Differences from `defmodule`
 
-  `Module.create` works similarly to `defmodule` and
+  `Module.create/3` works similarly to `defmodule` and
   return the same results. While one could also use
   `defmodule` to define modules dynamically, this
   function is preferred when the module body is given
   by a quoted expression.
 
-  Another important distinction is that `Module.create`
+  Another important distinction is that `Module.create/3`
   allows you to control the environment variables used
   when defining the module, while `defmodule` automatically
   shares the same environment.

--- a/lib/elixir/lib/node.ex
+++ b/lib/elixir/lib/node.ex
@@ -239,7 +239,7 @@ defmodule Node do
   @doc """
   Sets the magic cookie of `node` to the atom `cookie`.
 
-  The default node is `Node.self`, the local node. If `node` is the local node,
+  The default node is `Node.self/0`, the local node. If `node` is the local node,
   the function also sets the cookie of all other unknown nodes to `cookie`.
 
   This function will raise `FunctionClauseError` if the given `node` is not alive.

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -74,7 +74,7 @@ defmodule Task do
 
   By default, most supervision strategies will try to restart
   a worker after it exits regardless of reason. If you design the
-  task to terminate normally (as in the example with `IO.puts` above),
+  task to terminate normally (as in the example with `IO.puts/2` above),
   consider passing `restart: :transient` in the options to `worker/3`.
 
   ## Dynamically supervised tasks

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -353,7 +353,7 @@ defmodule IEx do
   ## Examples
 
   Let's suppose you want to investigate what is happening
-  with some particular function. By invoking `IEx.pry` from
+  with some particular function. By invoking `IEx.pry/1` from
   the function, IEx will allow you to access its binding
   (variables), verify its lexical information and access
   the process information. Let's see an example:
@@ -378,7 +378,7 @@ defmodule IEx do
       2
       3
 
-  Keep in mind that `IEx.pry` runs in the caller process,
+  Keep in mind that `IEx.pry/1` runs in the caller process,
   blocking the caller during the evaluation cycle. The caller
   process can be freed by calling `respawn`, which starts a
   new IEx evaluation cycle, letting this one go:

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -55,12 +55,12 @@ defmodule Logger do
       lower than the configured value at compilation time. This means the
       Logger call will be completely removed at compile time, accruing
       no overhead at runtime. Defaults to `:debug` and only
-      applies to the `Logger.debug`, `Logger.info`, etc style of calls.
+      applies to the `Logger.debug/2`, `Logger.info/2`, etc style of calls.
 
     * `:compile_time_application` - sets the `:application` metadata value
       to the configured value at compilation time. This configuration is
       usually only useful for build tools to automatically add the
-      application to the metadata for `Logger.debug`, `Logger.info`, etc
+      application to the metadata for `Logger.debug/2`, `Logger.info/2`, etc
       style of calls.
 
   For example, to configure the `:backends` and `compile_time_purge_level`
@@ -244,7 +244,7 @@ defmodule Logger do
     * `format` - the logging format for that backend
     * `metadata` - the metadata to include the backend
 
-  Check the implementation for `Logger.Backends.Console` for
+  Check the implementation for `Logger.Backends.Console`, for
   examples on how to handle the recommendations in this section
   and how to process the existing options.
   """

--- a/lib/mix/lib/mix/generator.ex
+++ b/lib/mix/lib/mix/generator.ex
@@ -3,7 +3,7 @@ defmodule Mix.Generator do
   Conveniences for working with paths and generating content.
 
   All of those functions are verbose, in the sense they log
-  the action to be performed via `Mix.shell`.
+  the action to be performed via `Mix.shell/0`.
   """
 
   @doc """

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -128,7 +128,7 @@ defmodule Mix.Project do
   pushed into the stack. Calling it multiple times won't
   cause it to be recomputed.
 
-  Do not use `Mix.Project.config` to rely on runtime configuration.
+  Do not use `Mix.Project.config/0` to rely on runtime configuration.
   Use it only to configure aspects of your project (like
   compilation directories) and not your application runtime.
   """


### PR DESCRIPTION
original issue: https://github.com/elixir-lang/ex_doc/issues/321

I created a shell script that checks for anything references to Modules that are not actually linked
http://git.io/check_not_linked_exdoc.sh

You can see the output here:
https://gist.github.com/eksperimental/6dc9bce36710a3c8b1d9

I will update the script to work with regular elixir projects, so it can be used by other projects