### PR TITLE
Add text to all links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,8 +263,8 @@ in order to craft an excellent pull request:
 We have saved some excellent pull requests we have received in the past in case
 you are looking for some examples:
 
-* https://github.com/elixir-lang/elixir/pull/992
-* https://github.com/elixir-lang/elixir/pull/1058
-* https://github.com/elixir-lang/elixir/pull/1059
+* [Implement Enum.member? – Pull Request](https://github.com/elixir-lang/elixir/pull/992)
+* [Add String.valid? – Pull Request](https://github.com/elixir-lang/elixir/pull/1058)
+* [Implement capture_io for ex_unit – Pull Request](https://github.com/elixir-lang/elixir/pull/1059)
 
 Thank you for your contributions!

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -84,8 +84,8 @@ defmodule Application do
   This particular aspect of applications is explained in more detail in the
   OTP documentation:
 
-    * http://www.erlang.org/doc/man/application.html
-    * http://www.erlang.org/doc/design_principles/applications.html
+    * [`:application` module](http://www.erlang.org/doc/man/application.html)
+    * [Applications – OTP Design Principles](http://www.erlang.org/doc/design_principles/applications.html)
 
   A developer may also implement the `stop/1` callback (automatically defined
   by `use Application`) which does any application cleanup. It receives the

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -2,7 +2,7 @@ defmodule Code do
   @moduledoc """
   Utilities for managing code compilation, code evaluation and code loading.
 
-  This module complements [Erlang's code module](http://www.erlang.org/doc/man/code.html)
+  This module complements Erlang's [`:code` module](http://www.erlang.org/doc/man/code.html)
   to add behaviour which is specific to Elixir. Almost all of the functions in this module
   have global side effects on the behaviour of Elixir.
   """

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -66,7 +66,7 @@ defmodule File do
   and `:delayed_write` are also useful when operating large files or
   working with files in tight loops.
 
-  Check http://www.erlang.org/doc/man/file.html#open-2 for more information
+  Check [`:file.open/2`](http://www.erlang.org/doc/man/file.html#open-2) for more information
   about such options and other performance considerations.
   """
 
@@ -292,8 +292,9 @@ defmodule File do
   @doc """
   Returns information about the `path`. If the file is a symlink sets
   the `type` to `:symlink` and returns `File.Stat` for the link. For any
-  other file, returns exactly the same values as `stat/2`. For more details
-  see http://www.erlang.org/doc/man/file.html#read_link_info-2
+  other file, returns exactly the same values as `stat/2`.
+
+  For more details, see [`:file.read_link_info/2`](http://www.erlang.org/doc/man/file.html#read_link_info-2).
 
   ## Options
 
@@ -955,8 +956,8 @@ defmodule File do
       cannot cope with the character range of the data, an error occurs and the
       file will be closed.
 
-  Check http://www.erlang.org/doc/man/file.html#open-2 for more information about
-  other options like `:read_ahead` and `:delayed_write`.
+  For more information about other options like `:read_ahead` and `:delayed_write`,
+  see [`:file.open/2`](http://www.erlang.org/doc/man/file.html#open-2).
 
   This function returns:
 

--- a/lib/elixir/lib/gen_event.ex
+++ b/lib/elixir/lib/gen_event.ex
@@ -144,9 +144,9 @@ defmodule GenEvent do
   guides provide a tutorial-like introduction. The documentation and links
   in Erlang can also provide extra insight.
 
-    * http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html
-    * http://www.erlang.org/doc/man/gen_event.html
-    * http://learnyousomeerlang.com/event-handlers
+    * [Introduction to Mix – Elixir's Getting Started Guide](http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html)
+    * [`:gen_event` module documentation](http://www.erlang.org/doc/man/gen_event.html)
+    * [Event Handlers – Learn You Some Erlang for Great Good!](http://learnyousomeerlang.com/event-handlers)
 
   Keep in mind though Elixir and Erlang gen events are not 100% compatible.
   The `:gen_event.add_sup_handler/3` is not supported by Elixir's GenEvent,

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -162,10 +162,10 @@ defmodule GenServer do
   guide provides a tutorial-like introduction. The documentation and links
   in Erlang can also provide extra insight.
 
-    * http://elixir-lang.org/getting-started/mix-otp/genserver.html
-    * http://www.erlang.org/doc/man/gen_server.html
-    * http://www.erlang.org/doc/design_principles/gen_server_concepts.html
-    * http://learnyousomeerlang.com/clients-and-servers
+    * [GenServer – Elixir's Getting Started Guide](http://elixir-lang.org/getting-started/mix-otp/genserver.html)
+    * [`:gen_server` module documentation](http://www.erlang.org/doc/man/gen_server.html)
+    * [gen_server Behaviour – OTP Design Principles](http://www.erlang.org/doc/design_principles/gen_server_concepts.html)
+    * [Clients and Servers – Learn You Some Erlang for Great Good!](http://learnyousomeerlang.com/clients-and-servers)
     """
 
   @doc """

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -15,8 +15,8 @@ defmodule Kernel.Typespec do
 
   ## Types and their syntax
 
-  The type syntax provided by Elixir is fairly similar to the one in
-  [Erlang](http://www.erlang.org/doc/reference_manual/typespec.html).
+  The type syntax provided by Elixir is fairly similar to [the one in
+  Erlang](http://www.erlang.org/doc/reference_manual/typespec.html).
 
   Most of the built-in types provided in Erlang (for example, `pid()`) are
   expressed the same way: `pid()` or simply `pid`. Parameterized types are also

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -578,7 +578,7 @@ defmodule List do
 
   Notice that this function expects a list of integers representing
   UTF-8 codepoints. If you have a list of bytes, you must instead use
-  [the `:binary` module](http://www.erlang.org/doc/man/binary.html).
+  the [`:binary` module](http://www.erlang.org/doc/man/binary.html).
 
   ## Examples
 

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -82,8 +82,8 @@ defmodule Module do
 
       Accepts an atom, a tuple, or a list of atoms and tuples.
 
-      See http://www.erlang.org/doc/man/compile.html for the list of supported
-      options.
+      For the list of supported options, see Erlang's
+      [`:compile` module](http://www.erlang.org/doc/man/compile.html).
 
       Several uses of `@compile` will accumulate instead of overriding
       previous ones.
@@ -264,12 +264,12 @@ defmodule Module do
     * `@dialyzer`
 
       Defines warnings to request or suppress when using a version of
-      `dialyzer` that supports module attributes.
+      `:dialyzer` that supports module attributes.
 
       Accepts an atom, a tuple, or a list of atoms and tuples.
 
-      See http://www.erlang.org/doc/man/dialyzer.html for the list of supported
-      warnings.
+      For the list of supported warnings, see
+      [`:dialyzer` module](http://www.erlang.org/doc/man/dialyzer.html).
 
       Several uses of `@dialyzer` will accumulate instead of overriding
       previous ones.
@@ -325,9 +325,10 @@ defmodule Module do
     * `:module`     - module name (`Module == Module.__info__(:module)`)
 
   In addition to the above, you may also pass to `__info__/1` any atom supported
-  by Erlang's `module_info` function which also gets defined for each compiled
-  module. See http://www.erlang.org/doc/reference_manual/modules.html#id75777 for
-  more information.
+  by [`:erlang.module_info/0`](http://www.erlang.org/doc/man/erlang.html#module_info.html) which also gets defined for each compiled
+  module.
+
+  For more information, see [Modules – Erlang Reference Manual](http://www.erlang.org/doc/reference_manual/modules.html).
   """
   def __info__(kind)
 

--- a/lib/elixir/lib/node.ex
+++ b/lib/elixir/lib/node.ex
@@ -72,7 +72,8 @@ defmodule Node do
   The result returned when the argument is a list, is the list of nodes
   satisfying the disjunction(s) of the list elements.
 
-  See http://www.erlang.org/doc/man/erlang.html#nodes-1 for more info.
+  For more information, see
+  [`:erlang.nodes/1`](http://www.erlang.org/doc/man/erlang.html#nodes-1).
   """
   @typep state :: :visible | :hidden | :connected | :this | :known
   @spec list(state | [state]) :: [t]
@@ -86,7 +87,8 @@ defmodule Node do
   If `flag` is `true`, monitoring is turned on.
   If `flag` is `false`, monitoring is turned off.
 
-  See http://www.erlang.org/doc/man/erlang.html#monitor_node-2 for more info.
+  For more information, see
+  [`:erlang.monitor_node/2`](http://www.erlang.org/doc/man/erlang.html#monitor_node-2).
   """
   @spec monitor(t, boolean) :: true
   def monitor(node, flag) do
@@ -97,7 +99,8 @@ defmodule Node do
   Behaves as `monitor/2` except that it allows an extra
   option to be given, namely `:allow_passive_connect`.
 
-  See http://www.erlang.org/doc/man/erlang.html#monitor_node-3 for more info.
+  For more information, see
+  [`:erlang.monitor_node/3`](http://www.erlang.org/doc/man/erlang.html#monitor_node-3).
   """
   @spec monitor(t, boolean, [:allow_passive_connect]) :: true
   def monitor(node, flag, options) do
@@ -128,7 +131,8 @@ defmodule Node do
   protocols. Returns `true` if disconnection succeeds, otherwise `false`.
   If the local node is not alive, the function returns `:ignored`.
 
-  See http://www.erlang.org/doc/man/erlang.html#disconnect_node-1 for more info.
+  For more information, see
+  [`:erlang.disconnect_node/1`](http://www.erlang.org/doc/man/erlang.html#disconnect_node-1).
   """
   @spec disconnect(t) :: boolean | :ignored
   def disconnect(node) do
@@ -141,7 +145,8 @@ defmodule Node do
   Returns `true` if successful, `false` if not, and the atom
   `:ignored` if the local node is not alive.
 
-  See http://www.erlang.org/doc/man/net_kernel.html#connect_node-1 for more info.
+  For more information, see
+  [`:erlang.connect_node/1`](http://www.erlang.org/doc/man/net_kernel.html#connect_node-1).
   """
   @spec connect(t) :: boolean | :ignored
   def connect(node) do
@@ -152,8 +157,8 @@ defmodule Node do
   Returns the pid of a new process started by the application of `fun`
   on `node`. If `node` does not exist, a useless pid is returned.
 
-  Check http://www.erlang.org/doc/man/erlang.html#spawn-2 for
-  the list of available options.
+  For the list of available options, see
+  [`:erlang.spawn/2`](http://www.erlang.org/doc/man/erlang.html#spawn-2).
 
   Inlined by the compiler.
   """
@@ -166,9 +171,10 @@ defmodule Node do
   Returns the pid of a new process started by the application of `fun`
   on `node`.
 
-  If `node` does not exist, a useless pid is returned. Check
-  http://www.erlang.org/doc/man/erlang.html#spawn_opt-3 for the list of
-  available options.
+  If `node` does not exist, a useless pid is returned.
+
+  For the list of available options, see
+  [`:erlang.spawn_opt/3`](http://www.erlang.org/doc/man/erlang.html#spawn_opt-3).
 
   Inlined by the compiler.
   """
@@ -181,9 +187,10 @@ defmodule Node do
   Returns the pid of a new process started by the application of
   `module.function(args)` on `node`.
 
-  If `node` does not exist, a useless pid is returned. Check
-  http://www.erlang.org/doc/man/erlang.html#spawn-4 for the list of
-  available options.
+  If `node` does not exist, a useless pid is returned.
+
+  For the list of available options, see
+  [`:erlang.spawn/4`](http://www.erlang.org/doc/man/erlang.html#spawn-4).
 
   Inlined by the compiler.
   """
@@ -196,9 +203,10 @@ defmodule Node do
   Returns the pid of a new process started by the application of
   `module.function(args)` on `node`.
 
-  If `node` does not exist, a useless pid is returned. Check
-  http://www.erlang.org/doc/man/erlang.html#spawn_opt-5 for the list of
-  available options.
+  If `node` does not exist, a useless pid is returned.
+
+  For the list of available options, see
+  [`:erlang.spawn/5`](http://www.erlang.org/doc/man/erlang.html#spawn_opt-5).
 
   Inlined by the compiler.
   """

--- a/lib/elixir/lib/port.ex
+++ b/lib/elixir/lib/port.ex
@@ -4,7 +4,7 @@ defmodule Port do
   """
 
   @doc """
-  See http://www.erlang.org/doc/man/erlang.html#open_port-2
+  See [`:erlang.open_port/2`](http://www.erlang.org/doc/man/erlang.html#open_port-2)
 
   Inlined by the compiler.
   """
@@ -13,7 +13,7 @@ defmodule Port do
   end
 
   @doc """
-  See http://www.erlang.org/doc/man/erlang.html#port_close-1
+  See [`:erlang.port_close/1`](http://www.erlang.org/doc/man/erlang.html#port_close-1)
 
   Inlined by the compiler.
   """
@@ -22,7 +22,7 @@ defmodule Port do
   end
 
   @doc """
-  See http://www.erlang.org/doc/man/erlang.html#port_command-2
+  See [`:erlang.port_command/2`](http://www.erlang.org/doc/man/erlang.html#port_command-2)
 
   Inlined by the compiler.
   """
@@ -31,7 +31,7 @@ defmodule Port do
   end
 
   @doc """
-  See http://www.erlang.org/doc/man/erlang.html#port_connect-2
+  See [`:erlang.port_connect/2`](http://www.erlang.org/doc/man/erlang.html#port_connect-2)
 
   Inlined by the compiler.
   """
@@ -40,7 +40,7 @@ defmodule Port do
   end
 
   @doc """
-  See http://www.erlang.org/doc/man/erlang.html#port_control-3
+  See [`:erlang.port_control/3`](http://www.erlang.org/doc/man/erlang.html#port_control-3)
 
   Inlined by the compiler.
   """
@@ -49,7 +49,7 @@ defmodule Port do
   end
 
   @doc """
-  See http://www.erlang.org/doc/man/erlang.html#port_call-3
+  See [`:erlang.port_call/3`](http://www.erlang.org/doc/man/erlang.html#port_call-3)
 
   Inlined by the compiler.
   """
@@ -61,7 +61,7 @@ defmodule Port do
   Returns information about the `port`
   or `nil` if the port is closed.
 
-  See http://www.erlang.org/doc/man/erlang.html#port_info-1
+  See [`:erlang.port_info/1`](http://www.erlang.org/doc/man/erlang.html#port_info-1)
   """
   def info(port) do
     nillify :erlang.port_info(port)
@@ -71,7 +71,7 @@ defmodule Port do
   Returns information about the `port`
   or `nil` if the port is closed.
 
-  See http://www.erlang.org/doc/man/erlang.html#port_info-2
+  See [`:erlang.port_info/2`](http://www.erlang.org/doc/man/erlang.html#port_info-2)
   """
   @spec info(port, atom) :: {atom, term} | nil
   def info(port, spec)
@@ -88,7 +88,7 @@ defmodule Port do
   end
 
   @doc """
-  See http://www.erlang.org/doc/man/erlang.html#ports-0
+  See [`:erlang.ports/0`](http://www.erlang.org/doc/man/erlang.html#ports-0)
 
   Inlined by the compiler.
   """

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -167,7 +167,7 @@ defmodule Process do
   just the spawned process pid.
 
   It also accepts extra options, for the list of available options
-  check http://www.erlang.org/doc/man/erlang.html#spawn_opt-4
+  check [`:erlang.spawn_opt/4`](http://www.erlang.org/doc/man/erlang.html#spawn_opt-4).
 
   Inlined by the compiler.
   """
@@ -186,7 +186,7 @@ defmodule Process do
   just the spawned process pid.
 
   It also accepts extra options, for the list of available options
-  check http://www.erlang.org/doc/man/erlang.html#spawn_opt-4
+  check [`:erlang.spawn_opt/4`](http://www.erlang.org/doc/man/erlang.html#spawn_opt-4).
 
   Inlined by the compiler.
   """
@@ -199,7 +199,7 @@ defmodule Process do
   The calling process starts monitoring the item given.
   It returns the monitor reference.
 
-  See http://www.erlang.org/doc/man/erlang.html#monitor-2 for more info.
+  See [`:erlang.monitor/2`](http://www.erlang.org/doc/man/erlang.html#monitor-2) for more info.
 
   Inlined by the compiler.
   """
@@ -213,7 +213,7 @@ defmodule Process do
   obtained by calling `monitor/1`, this monitoring is turned off.
   If the monitoring is already turned off, nothing happens.
 
-  See http://www.erlang.org/doc/man/erlang.html#demonitor-2 for more info.
+  See [`:erlang.demonitor/2`](http://www.erlang.org/doc/man/erlang.html#demonitor-2) for more info.
 
   Inlined by the compiler.
   """
@@ -231,7 +231,7 @@ defmodule Process do
   `alive?/1` will return `false` for a process that is exiting,
   but its process identifier will be part of the result returned.
 
-  See http://www.erlang.org/doc/man/erlang.html#processes-0 for more info.
+  See [`:erlang.processes/0`](http://www.erlang.org/doc/man/erlang.html#processes-0) for more info.
   """
   @spec list :: [pid]
   def list do
@@ -242,7 +242,7 @@ defmodule Process do
   Creates a link between the calling process and another process
   (or port) `pid`, if there is not such a link already.
 
-  See http://www.erlang.org/doc/man/erlang.html#link-1 for more info.
+  See [`:erlang.link/1`](http://www.erlang.org/doc/man/erlang.html#link-1) for more info.
 
   Inlined by the compiler.
   """
@@ -256,7 +256,7 @@ defmodule Process do
   the process or port referred to by `pid`. Returns `true` and does not
   fail, even if there is no link or `id` does not exist
 
-  See http://www.erlang.org/doc/man/erlang.html#unlink-1 for more info.
+  See [`:erlang.unlink/1`](http://www.erlang.org/doc/man/erlang.html#unlink-1] for more info.
 
   Inlined by the compiler.
   """
@@ -282,7 +282,7 @@ defmodule Process do
   @doc """
   Removes the registered name, associated with a pid or a port identifier.
 
-  See http://www.erlang.org/doc/man/erlang.html#unregister-1 for more info.
+  See [`:erlang.unregister/1`](http://www.erlang.org/doc/man/erlang.html#unregister-1) for more info.
   """
   @spec unregister(atom) :: true
   def unregister(name) do
@@ -293,7 +293,7 @@ defmodule Process do
   Returns the pid or port identifier with the registered name.
   Returns `nil` if the name is not registered.
 
-  See http://www.erlang.org/doc/man/erlang.html#whereis-1 for more info.
+  See [`:erlang.whereis/1`](http://www.erlang.org/doc/man/erlang.html#whereis-1) for more info.
   """
   @spec whereis(atom) :: pid | port | nil
   def whereis(name) do
@@ -332,7 +332,7 @@ defmodule Process do
   Sets certain flags for the process which calls this function.
   Returns the old value of the flag.
 
-  See http://www.erlang.org/doc/man/erlang.html#process_flag-2 for more info.
+  See [`:erlang.process_flag/2`](http://www.erlang.org/doc/man/erlang.html#process_flag-2) for more info.
   """
   @spec flag(process_flag, term) :: term
   def flag(flag, value) do
@@ -344,7 +344,7 @@ defmodule Process do
   Returns the old value of the flag. The allowed values for `flag` are
   only a subset of those allowed in `flag/2`, namely: `save_calls`.
 
-  See http://www.erlang.org/doc/man/erlang.html#process_flag-3 for more info.
+  See [`:erlang.process_flag/3`](http://www.erlang.org/doc/man/erlang.html#process_flag-3) for more info.
   """
   @spec flag(pid, :save_calls, non_neg_integer) :: non_neg_integer
   def flag(pid, flag, value) do
@@ -356,7 +356,7 @@ defmodule Process do
   is not alive.
   Use this only for debugging information.
 
-  See http://www.erlang.org/doc/man/erlang.html#process_info-1 for more info.
+  See [`:erlang.process_info/1`](http://www.erlang.org/doc/man/erlang.html#process_info-1) for more info.
   """
   @spec info(pid) :: Keyword.t
   def info(pid) do
@@ -367,7 +367,7 @@ defmodule Process do
   Returns information about the process identified by `pid`
   or `nil` if the process is not alive.
 
-  See http://www.erlang.org/doc/man/erlang.html#process_info-2 for more info.
+  See [`:erlang.process_info/2`](http://www.erlang.org/doc/man/erlang.html#process_info-2) for more info.
   """
   @spec info(pid, atom) :: {atom, term} | nil
   def info(pid, spec)
@@ -390,7 +390,7 @@ defmodule Process do
   which is useful if the process does not expect to receive any messages
   in the near future.
 
-  See http://www.erlang.org/doc/man/erlang.html#hibernate-3 for more info.
+  See [`:erlang.hibernate/3`](http://www.erlang.org/doc/man/erlang.html#hibernate-3) for more info.
 
   Inlined by the compiler.
   """

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -1,10 +1,10 @@
 defmodule Regex do
   @moduledoc ~S"""
-  Regular expressions for Elixir built on top of Erlang's `re` module.
+  Regular expressions for Elixir built on top of Erlang's `:re` module.
 
-  As the `re` module, Regex is based on PCRE
+  As the `:re` module, Regex is based on PCRE
   (Perl Compatible Regular Expressions). More information can be
-  found in the [`re` documentation](http://www.erlang.org/doc/man/re.html).
+  found in the [`:re` module documentation](http://www.erlang.org/doc/man/re.html).
 
   Regular expressions in Elixir can be created using `Regex.compile!/2`
   or using the special form with [`~r`](Kernel.html#sigil_r/2) or [`~R`](Kernel.html#sigil_R/2):
@@ -90,7 +90,7 @@ defmodule Regex do
 
   The given options can either be a binary with the characters
   representing the same regex options given to the `~r` sigil,
-  or a list of options, as expected by the [Erlang `re` docs](http://www.erlang.org/doc/man/re.html).
+  or a list of options, as expected by the Erlang's [`:re` module](http://www.erlang.org/doc/man/re.html).
 
   It returns `{:ok, regex}` in case of success,
   `{:error, reason}` otherwise.

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -67,7 +67,7 @@ defmodule String do
     * `Kernel.bit_size/1` and `Kernel.byte_size/1` - size related functions
     * `Kernel.is_bitstring/1` and `Kernel.is_binary/1` - type checking function
     * Plus a number of functions for working with binaries (bytes)
-      [in the `:binary` module](http://www.erlang.org/doc/man/binary.html)
+      in the [`:binary` module](http://www.erlang.org/doc/man/binary.html)
 
   There are many situations where using the `String` module can
   be avoided in favor of binary functions or pattern matching.
@@ -870,7 +870,7 @@ defmodule String do
   are not valid characters. They may be reserved, private,
   or other.
 
-  More info at: https://en.wikipedia.org/wiki/Universal_Character_Set_characters#Non-characters
+  More info at: [Non-characters – Wikipedia](https://en.wikipedia.org/wiki/Universal_Character_Set_characters#Non-characters)
 
   ## Examples
 

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -262,7 +262,7 @@ defmodule System do
   Returns the process identifier of the current Erlang emulator
   in the format most commonly used by the operating system environment.
 
-  See http://www.erlang.org/doc/man/os.html#getpid-0 for more info.
+  For more information, see [`:os.getpid/0`](http://www.erlang.org/doc/man/os.html#getpid-0).
   """
   @spec get_pid() :: binary
   def get_pid, do: IO.iodata_to_binary(:os.getpid)
@@ -331,7 +331,7 @@ defmodule System do
   Note that on many platforms, only the status codes 0-255 are supported
   by the operating system.
 
-  For more information, check: http://www.erlang.org/doc/man/erlang.html#halt-1
+  For more information, see [`:erlang.halt/1`](http://www.erlang.org/doc/man/erlang.html#halt-1).
 
   ## Examples
 
@@ -421,7 +421,7 @@ defmodule System do
 
   If you desire to execute a trusted command inside a shell, with pipes,
   redirecting and so on, please check
-  [Erlang's :os.cmd/1 function](http://www.erlang.org/doc/man/os.html#cmd-1).
+  [`:os.cmd/1`](http://www.erlang.org/doc/man/os.html#cmd-1).
   """
   @spec cmd(binary, [binary], Keyword.t) ::
         {Collectable.t, exit_status :: non_neg_integer}

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -39,8 +39,8 @@ defmodule Mix.Tasks.Compile.Erlang do
     * `:erlc_options` - compilation options that apply to Erlang's compiler.
       `:debug_info` is enabled by default.
 
-      There are many available options here:
-      http://www.erlang.org/doc/man/compile.html#file-2
+      For a list of the many more available options,
+      see [`:compile.file/2`](http://www.erlang.org/doc/man/compile.html#file-2).
   """
 
   @doc """

--- a/lib/mix/lib/mix/tasks/compile.leex.ex
+++ b/lib/mix/lib/mix/tasks/compile.leex.ex
@@ -23,9 +23,10 @@ defmodule Mix.Tasks.Compile.Leex do
     * `:erlc_paths` - directories to find source files. Defaults to `["src"]`.
 
     * `:leex_options` - compilation options that apply
-      to Leex's compiler. There are many available options
-      here: http://www.erlang.org/doc/man/leex.html#file-2
+      to Leex's compiler.
 
+      For a list of the many more available options,
+      see [`:leex.file/2`](http://www.erlang.org/doc/man/leex.html#file-2).
   """
 
   @doc """

--- a/lib/mix/lib/mix/tasks/compile.yecc.ex
+++ b/lib/mix/lib/mix/tasks/compile.yecc.ex
@@ -23,9 +23,10 @@ defmodule Mix.Tasks.Compile.Yecc do
     * `:erlc_paths` - directories to find source files. Defaults to `["src"]`.
 
     * `:yecc_options` - compilation options that apply
-      to Yecc's compiler. There are many other available
-      options here: http://www.erlang.org/doc/man/yecc.html#file-1
+      to Yecc's compiler.
 
+      For a list of the many more available options,
+      see [`:yecc.file/1`](http://www.erlang.org/doc/man/yecc.html#file-1).
   """
 
   @doc """


### PR DESCRIPTION
This commits covers 100% of all links in the documentation,
using a words to describe what the page is about.

It users the `:module.function/arity` format for erlang functions that
link to the earlang docs.

I also changed some of the sentnces using the link from
- See [:erlang.function/2](http://...) for a list of available options.

to
- For a list of available options, see [:erlang.function/2](http://...)

The reasoning behind is that I think it's better to have an link at the end of the sentence
and not in the middle, so the reades doesn't need to finish the sentence to know what is it about and go back
and find the link. This way all the information is given before the link, so the users stops reading and can
click directly.