### PR TITLE
Fix markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,8 +94,10 @@ In case you are changing a single file, you can compile and run tests only
 for that particular file for fast development cycles. For example, if you
 are changing the String module, you can compile it and run its tests as:
 
-    $ bin/elixirc lib/elixir/lib/string.ex -o lib/elixir/ebin
-    $ bin/elixir lib/elixir/test/elixir/string_test.exs
+```sh
+bin/elixirc lib/elixir/lib/string.ex -o lib/elixir/ebin
+bin/elixir lib/elixir/test/elixir/string_test.exs
+```
 
 After your changes are done, please remember to run the full suite with
 `make test`.
@@ -192,73 +194,73 @@ documentation. When working with git, we recommend the following process
 in order to craft an excellent pull request:
 
 1. [Fork](https://help.github.com/fork-a-repo/) the project, clone your fork,
-   and configure the remotes:
+  and configure the remotes:
 
-   ```bash
-   # Clone your fork of the repo into the current directory
-   git clone https://github.com/<your-username>/elixir
-   # Navigate to the newly cloned directory
-   cd elixir
-   # Assign the original repo to a remote called "upstream"
-   git remote add upstream https://github.com/elixir-lang/elixir
-   ```
+  ```sh
+  # Clone your fork of the repo into the current directory
+  git clone https://github.com/<your-username>/elixir
+  # Navigate to the newly cloned directory
+  cd elixir
+  # Assign the original repo to a remote called "upstream"
+  git remote add upstream https://github.com/elixir-lang/elixir
+  ```
 
 2. If you cloned a while ago, get the latest changes from upstream:
 
-   ```bash
-   git checkout master
-   git pull upstream master
-   ```
+  ```sh
+  git checkout master
+  git pull upstream master
+  ```
 
 3. Create a new topic branch (off of `master`) to contain your feature, change,
-   or fix.
+  or fix.
 
-   **IMPORTANT**: Making changes in `master` is discouraged. You should always
-   keep your local `master` in sync with upstream `master` and make your
-   changes in topic branches.
+  **IMPORTANT**: Making changes in `master` is discouraged. You should always
+  keep your local `master` in sync with upstream `master` and make your
+  changes in topic branches.
 
-   ```bash
-   git checkout -b <topic-branch-name>
-   ```
+  ```sh
+  git checkout -b <topic-branch-name>
+  ```
 
 4. Commit your changes in logical chunks. Keep your commit messages organized,
-   with a short description in the first line and more detailed information on
-   the following lines. Feel free to use Git's
-   [interactive rebase](https://help.github.com/articles/interactive-rebase)
-   feature to tidy up your commits before making them public.
+  with a short description in the first line and more detailed information on
+  the following lines. Feel free to use Git's
+  [interactive rebase](https://help.github.com/articles/interactive-rebase)
+  feature to tidy up your commits before making them public.
 
 5. Make sure all the tests are still passing.
 
-   ```bash
-   make test
-   ```
+  ```sh
+  make test
+  ```
 
-   This command will compile the code in your branch and use that
-   version of Elixir to run the tests. This is needed to ensure your changes can
-   pass all the tests.
+  This command will compile the code in your branch and use that
+  version of Elixir to run the tests. This is needed to ensure your changes can
+  pass all the tests.
 
 6. Push your topic branch up to your fork:
 
-   ```bash
-   git push origin <topic-branch-name>
-   ```
+  ```sh
+  git push origin <topic-branch-name>
+  ```
 
 7. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/)
-    with a clear title and description.
+  with a clear title and description.
 
 8. If you haven't updated your pull request for a while, you should consider
-   rebasing on master and resolving any conflicts.
+  rebasing on master and resolving any conflicts.
 
-   **IMPORTANT**: _Never ever_ merge upstream `master` into your branches. You
-   should always `git rebase` on `master` to bring your changes up to date when
-   necessary.
+  **IMPORTANT**: _Never ever_ merge upstream `master` into your branches. You
+  should always `git rebase` on `master` to bring your changes up to date when
+  necessary.
 
-   ```bash
-   git checkout master
-   git pull upstream master
-   git checkout <your-topic-branch>
-   git rebase master
-   ```
+  ```sh
+  git checkout master
+  git pull upstream master
+  git checkout <your-topic-branch>
+  git rebase master
+  ```
 
 We have saved some excellent pull requests we have received in the past in case
 you are looking for some examples:

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ For more about Elixir, installation and documentation, [check Elixir's website](
 
 If you want to contribute to Elixir or run it from source, clone this repository to your machine, compile and test it:
 
-    $ git clone https://github.com/elixir-lang/elixir.git
-    $ cd elixir
-    $ make clean test
+```sh
+git clone https://github.com/elixir-lang/elixir.git
+cd elixir
+make clean test
+```
 
 > Note: if you are running on Windows, [this article includes important notes for compiling Elixir from source on Windows](https://github.com/elixir-lang/elixir/wiki/Windows).
 
@@ -20,7 +22,7 @@ If tests pass, you are ready to move on to the [Getting Started guide][1] or to 
 
 However, if tests fail, it is likely you have an outdated Erlang version (Elixir requires Erlang 17.0 or later). You can check your Erlang version by calling `erl` in the command line. You will see some information as follows:
 
-    Erlang/OTP 17 [erts-6.0] [source-07b8f44] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false]
+`Erlang/OTP 17 [erts-6.0] [source-07b8f44] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false]`
 
 If you have the correct version and tests still fail, feel free to [open an issue][2].
 
@@ -28,10 +30,12 @@ If you have the correct version and tests still fail, feel free to [open an issu
 
 Building the documentation requires [ex_doc](https://github.com/elixir-lang/ex_doc) to be installed and built in the same containing folder as elixir.
 
-    # After cloning and compiling Elixir
-    $ git clone git://github.com/elixir-lang/ex_doc.git
-    $ cd ex_doc && ../elixir/bin/mix do deps.get, compile
-    $ cd ../elixir && make docs
+```sh
+# After cloning and compiling Elixir
+git clone git://github.com/elixir-lang/ex_doc.git
+cd ex_doc && ../elixir/bin/mix do deps.get, compile
+cd ../elixir && make docs
+```
 
 ## Contributing
 


### PR DESCRIPTION
Corrects the indentation,
and change `bash` code blocks  to a more generic one: `sh`

actually, github doesn't show colors with bash but does now with sh