### PR TITLE
Correct descriptions in docs to use Present Continuous (2)

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -362,7 +362,7 @@ defmodule Macro do
   defp find_invalid(other), do: {:error, other}
 
   @doc ~S"""
-  Unescape the given chars.
+  Unescapes the given chars.
 
   This is the unescaping behaviour used by default in Elixir
   single- and double-quoted strings. Check `unescape_string/2`

--- a/lib/mix/lib/mix/tasks/deps.ex
+++ b/lib/mix/lib/mix/tasks/deps.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Deps do
   @shortdoc "Lists dependencies and their status"
 
   @moduledoc ~S"""
-  List all dependencies and their status.
+  Lists all dependencies and their status.
 
   Dependencies must be specified in the `mix.exs` file in one of
   the following formats:

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -42,7 +42,7 @@ defmodule Mix.Utils do
   end
 
   @doc """
-  Take a `command` name and attempts to load a module
+  Takes a `command` name and attempts to load a module
   with the command name converted to a module name
   in the given `at` scope.
 
@@ -281,7 +281,7 @@ defmodule Mix.Utils do
   defp to_lower_char(char), do: char
 
   @doc """
-  Symlink directory `source` to `target` or copy it recursively
+  Symlinks directory `source` to `target` or copies it recursively
   in case symlink fails.
 
   Expects source and target to be absolute paths as it generates


### PR DESCRIPTION
Corrects a few more cases that were not caught by the previous PR
https://github.com/elixir-lang/elixir/pull/3682

Command:

    ignore_words="a|an|the|in|exception|helper|callback|front-end|same|when|where|what|functionality|elixir|erlang|eex|iex|logger|environment|module|similar|\w+-like|opposite|boolean|current|information|basic|public|if|unless|otherwise|regular|internal|convenience|given|welcome to|shortcut to|writable|user|system|low-level|pipe operator|supervisor|administrator"
    ag "(@(module|short)?doc)\s+(~[Ss])?([\"']{3})(\r|\n|.)\s*+((?!((?i)${ignore_words}(?-i)))[\w'-]+)(?<!(s))(?<!(ed))(?<!(ity))(?<!(ally))(?<!(ily))(?<!(ely))(?=[\s\r\n,:.])"