### PR TITLE
Use Title Case and backticks for Erlang and Elixir applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ and is using Erlang 17.1, remember to update to at least Erlang 17.3.
 #### Logger
 
   * [Logger] Support printing pids and refs in Logger metadata
-  * [Logger] Allow logger metadata to be removed from pdict by setting it to `nil`
+  * [Logger] Allow Logger metadata to be removed from pdict by setting it to `nil`
   * [Logger] Add application configuration `translator_inspect_opts` for logger to customize how state and message are formatted when translating OTP errors and reports
   * [Logger] Automatically include the current application in metadata when compiled via Mix
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,6 +267,6 @@ you are looking for some examples:
 
 * [Implement Enum.member? – Pull Request](https://github.com/elixir-lang/elixir/pull/992)
 * [Add String.valid? – Pull Request](https://github.com/elixir-lang/elixir/pull/1058)
-* [Implement capture_io for ex_unit – Pull Request](https://github.com/elixir-lang/elixir/pull/1059)
+* [Implement capture_io for ExUnit – Pull Request](https://github.com/elixir-lang/elixir/pull/1059)
 
 Thank you for your contributions!

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you have the correct version and tests still fail, feel free to [open an issu
 
 ## Building documentation
 
-Building the documentation requires [ex_doc](https://github.com/elixir-lang/ex_doc) to be installed and built in the same containing folder as elixir.
+Building the documentation requires [ExDoc](https://github.com/elixir-lang/ex_doc) to be installed and built in the same containing folder as elixir.
 
 ```sh
 # After cloning and compiling Elixir

--- a/bin/elixir
+++ b/bin/elixir
@@ -10,7 +10,7 @@ if [ $# -eq 0 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
   -pa \"path\"        Prepends the given path to Erlang code path (*)
   -pz \"path\"        Appends the given path to Erlang code path (*)
   --app \"app\"       Start the given app and its dependencies (*)
-  --erl \"switches\"  Switches to be passed down to erlang (*)
+  --erl \"switches\"  Switches to be passed down to Erlang (*)
   --name \"name\"     Makes and assigns a name to the distributed node
   --sname \"name\"    Makes and assigns a short name to the distributed node
   --cookie \"cookie\" Sets a cookie for this distributed node
@@ -21,7 +21,7 @@ if [ $# -eq 0 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
 
 ** Options marked with (*) can be given more than once
 ** Options given after the .exs file or -- are passed down to the executed code
-** Options can be passed to the erlang runtime using ELIXIR_ERL_OPTIONS or --erl" >&2
+** Options can be passed to the Erlang runtime using ELIXIR_ERL_OPTIONS or --erl" >&2
   exit 1
 fi
 

--- a/bin/elixirc.bat
+++ b/bin/elixirc.bat
@@ -20,7 +20,7 @@ echo  --warnings-as-errors Treat warnings as errors and return non-zero exit cod
 echo  --verbose        Print informational messages.
 echo.
 echo ** Options given after -- are passed down to the executed code
-echo ** Options can be passed to the erlang runtime using ELIXIR_ERL_OPTIONS
-echo ** Options can be passed to the erlang compiler using ERL_COMPILER_OPTIONS >&2
+echo ** Options can be passed to the Erlang runtime using ELIXIR_ERL_OPTIONS
+echo ** Options can be passed to the Erlang compiler using ERL_COMPILER_OPTIONS >&2
 :run
 call "%~dp0\elixir.bat" +elixirc %*

--- a/bin/iex
+++ b/bin/iex
@@ -10,7 +10,7 @@ if [ $# -gt 0 ] && ([ "$1" = "--help" ] || [ "$1" = "-h" ]); then
   -pa \"path\"        Prepends the given path to Erlang code path (*)
   -pz \"path\"        Appends the given path to Erlang code path (*)
   --app \"app\"       Start the given app and its dependencies (*)
-  --erl \"switches\"  Switches to be passed down to erlang (*)
+  --erl \"switches\"  Switches to be passed down to Erlang (*)
   --name \"name\"     Makes and assigns a name to the distributed node
   --sname \"name\"    Makes and assigns a short name to the distributed node
   --cookie \"cookie\" Sets a cookie for this distributed node

--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -37,7 +37,7 @@ defmodule Kernel.CLI do
     if ok_or_shutdown == :shutdown or halt do
       {_, status} = at_exit({ok_or_shutdown, status})
 
-      # Ensure logger messages are flushed before halting
+      # Ensure Logger messages are flushed before halting
       case :erlang.whereis(Logger) do
         pid when is_pid(pid) -> Logger.flush()
         _ -> :ok

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -325,7 +325,7 @@ defmodule System do
     * If `:abort`, the runtime system aborts producing a core dump, if that is
       enabled in the operating system.
 
-    * If a string, an erlang crash dump is produced with status as slogan,
+    * If a string, an Erlang crash dump is produced with status as slogan,
       and then the runtime system exits with status code 1.
 
   Note that on many platforms, only the status codes 0-255 are supported

--- a/lib/elixir/test/elixir/file_test.exs
+++ b/lib/elixir/test/elixir/file_test.exs
@@ -22,7 +22,7 @@ defmodule FileTest do
   import Regex, only: [escape: 1]
 
   defmodule Rename do
-    # Following erlang's underlying implementation
+    # Following Erlang's underlying implementation
     #
     # Renaming files
     # :ok               -> rename file to existing file default behaviour

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -71,7 +71,7 @@ defmodule ExUnit.DocTest do
   example above) or when the result is a complicated data structure and you
   don't want to show it all, but just parts of it or some of its properties.
 
-  Similarly to iex you can use numbers in your "prompts":
+  Similarly to IEx you can use numbers in your "prompts":
 
       iex(1)> [1 + 2,
       ...(1)>  3]
@@ -80,7 +80,7 @@ defmodule ExUnit.DocTest do
   This is useful in two use cases:
 
     * being able to refer to specific numbered scenarios
-    * copy-pasting examples from an actual iex session
+    * copy-pasting examples from an actual IEx session
 
   We also allow you to select or skip some functions when calling
   `doctest`. See the documentation for more info.
@@ -97,7 +97,7 @@ defmodule ExUnit.DocTest do
 
       %{users: #HashSet<[:foo, :bar]>}
 
-  If you try to match on such expression, doctest will fail to compile.
+  If you try to match on such expression, `doctest` will fail to compile.
   You have two options to solve this.
 
   The first one is to rely on the fact that doctest can compare internal
@@ -107,7 +107,7 @@ defmodule ExUnit.DocTest do
       iex> map.users
       #HashSet<[:foo, :bar]>
 
-  Whenever a doctest starts with "#Name<", doctest will perform a string
+  Whenever a doctest starts with "#Name<", `doctest` will perform a string
   comparison. For example, the above test will perform the following match:
 
       inspect(map.users) == "#HashSet<[:foo, :bar]>"
@@ -135,10 +135,10 @@ defmodule ExUnit.DocTest do
   or a no-op line with documentation. Thus, multiline messages are not
   supported.
 
-  ## When not to use doctest
+  ## When not to use `doctest`
 
   In general, doctests are not recommended when your code examples contain
-  side effects. For example, if a doctest prints to standard output, doctest
+  side effects. For example, if a doctest prints to standard output, `doctest`
   will not try to capture the output.
 
   Similarly, doctests do not run in any kind of sandbox. So any module

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -113,9 +113,9 @@ defmodule IEx do
 
   Where "remsh" means "remote shell". In general, Elixir supports:
 
-    * remsh from an elixir node to an elixir node
-    * remsh from a plain erlang node to an elixir node (through the ^G menu)
-    * remsh from an elixir node to a plain erlang node (and get an erl shell there)
+    * remsh from an Elixir node to an Elixir node
+    * remsh from a plain Erlang node to an Elixir node (through the ^G menu)
+    * remsh from an Elixir node to a plain Erlang node (and get an `erl` shell there)
 
   Connecting an Elixir shell to a remote node without Elixir is
   **not** supported.

--- a/lib/iex/lib/iex/cli.ex
+++ b/lib/iex/lib/iex/cli.ex
@@ -15,7 +15,7 @@
 #    bug has arisen;
 #
 # 2. In some situations, connecting to a remote node via --remsh
-#    is not possible. This can be tested by starting two iex nodes:
+#    is not possible. This can be tested by starting two IEx nodes:
 #
 #      $ iex --sname foo
 #      $ iex --sname bar --remsh foo@localhost

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -516,7 +516,7 @@ defmodule IEx.Helpers do
     raise ArgumentError, "import_file/1 expects a literal binary as its argument"
   end
 
-  # Compiles and loads an erlang source file, returns {module, binary}
+  # Compiles and loads an Erlang source file, returns {module, binary}
   defp compile_erlang(source) do
     source = Path.relative_to_cwd(source) |> String.to_char_list
     case :compile.file(source, [:binary, :report]) do

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -10,7 +10,7 @@ defmodule Logger do
       supervised when plugged into Logger.
 
     * Formats and truncates messages on the client
-      to avoid clogging logger backends.
+      to avoid clogging Logger backends.
 
     * Alternates between sync and async modes to remain
       performant when required but also apply backpressure
@@ -34,10 +34,10 @@ defmodule Logger do
 
   This configuration is split in three categories:
 
-    * Application configuration - must be set before the logger
+    * Application configuration - must be set before the Logger
       application is started
 
-    * Runtime configuration - can be set before the logger
+    * Runtime configuration - can be set before the Logger
       application is started, but may be changed during runtime
 
     * Error logger configuration - configuration for the
@@ -46,7 +46,7 @@ defmodule Logger do
   ### Application configuration
 
   The following configuration must be set via config files
-  before the logger application is started.
+  before the Logger application is started.
 
     * `:backends` - the backends to be used. Defaults to `[:console]`.
       See the "Backends" section for more information.
@@ -87,7 +87,7 @@ defmodule Logger do
       to 8192 bytes. Note this configuration is approximate. Truncated
       messages will have `" (truncated)"` at the end.
 
-    * `:sync_threshold` - if the logger manager has more than
+    * `:sync_threshold` - if the Logger manager has more than
       `sync_threshold` messages in its queue, Logger will change
       to sync mode, to apply backpressure to the clients.
       Logger will return to async mode once the number of messages
@@ -106,11 +106,11 @@ defmodule Logger do
         level: :warn,
         truncate: 4096
 
-  ### Error logger configuration
+  ### Error Logger configuration
 
   The following configuration applies to the Logger wrapper around
   Erlang's `error_logger`. All the configurations below must be set
-  before the logger application starts.
+  before the Logger application starts.
 
     * `:handle_otp_reports` - redirects OTP reports to Logger so
       they are formatted in Elixir terms. This uninstalls Erlang's
@@ -153,7 +153,7 @@ defmodule Logger do
   is explored with detail below.
 
   The initial backends are loaded via the `:backends` configuration,
-  which must be set before the logger application is started.
+  which must be set before the Logger application is started.
 
   ### Console backend
 
@@ -303,9 +303,9 @@ defmodule Logger do
   end
 
   @doc """
-  Retrieves the logger level.
+  Retrieves the Logger level.
 
-  The logger level can be changed via `configure/1`.
+  The Logger level can be changed via `configure/1`.
   """
   @spec level() :: level
   def level() do

--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -219,7 +219,7 @@ defmodule Mix.Dep do
   end
 
   def format_status(%Mix.Dep{status: {:elixirlock, _}}),
-    do: "the dependency was built with an out-of-date elixir version, run `#{mix_env_var}mix deps.compile`"
+    do: "the dependency was built with an out-of-date Elixir version, run `#{mix_env_var}mix deps.compile`"
 
   def format_status(%Mix.Dep{status: {:scmlock, _}}),
     do: "the dependency was built with another SCM, run `#{mix_env_var}mix deps.compile`"

--- a/lib/mix/lib/mix/tasks/app.start.ex
+++ b/lib/mix/lib/mix/tasks/app.start.ex
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.App.Start do
     * `--no-compile` - do not compile even if files require compilation
     * `--no-protocols` - do not load consolidated protocols
     * `--no-deps-check` - do not check dependencies
-    * `--no-elixir-version-check` - do not check elixir version
+    * `--no-elixir-version-check` - do not check `elixir` version
     * `--no-start` - do not start applications after compilation
 
   """

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Compile.Elixir do
     * `--debug-info` (`--no-debug-info`) - attach (or not) debug info to compiled modules
     * `--ignore-module-conflict` - do not emit warnings if a module was previously defined
     * `--warnings-as-errors` - treat warnings as errors and return a non-zero exit code
-    * `--elixirc-paths` - restrict the original elixirc paths to
+    * `--elixirc-paths` - restrict the original `elixirc` paths to
       a subset of the ones specified. Can be given multiple times.
 
   ## Configuration

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -45,7 +45,7 @@ defmodule Mix.Tasks.Escript.Build do
       Defaults to app name. Set it to `nil` if no application should
       be started.
 
-    * `:embed_elixir` - if `true` embed elixir and its children apps
+    * `:embed_elixir` - if `true` embed `elixir` and its children apps
       (`ex_unit`, `mix`, etc.) mentioned in the `:applications` list inside the
       `application` function in `mix.exs`.
 

--- a/lib/mix/lib/mix/tasks/loadpaths.ex
+++ b/lib/mix/lib/mix/tasks/loadpaths.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.Loadpaths do
   ## Command line options
 
     * `--no-deps-check` - do not check dependencies
-    * `--no-elixir-version-check` - do not check elixir version
+    * `--no-elixir-version-check` - do not check `elixir` version
 
   """
 

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -167,15 +167,15 @@ defmodule Mix.Tasks.Test do
     Mix.shell.print_app
     Mix.Task.run "app.start", args
 
-    # Ensure ex_unit is loaded.
+    # Ensure ExUnit is loaded.
     case Application.load(:ex_unit) do
       :ok -> :ok
       {:error, {:already_loaded, :ex_unit}} -> :ok
     end
 
-    # Configure ex_unit with command line options before requiring
+    # Configure ExUnit with command line options before requiring
     # test helpers so that the configuration is available in helpers.
-    # Then configure ex_unit again so command line options override
+    # Then configure ExUnit again so command line options override
     opts = ex_unit_opts(opts)
     ExUnit.configure(opts)
 

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -467,7 +467,7 @@ defmodule Mix.Tasks.DepsTest do
       File.write!("_build/dev/lib/ok/.compile.lock", ~s({v1, <<\"the_future\">>, scm}.))
       Mix.Task.clear
 
-      msg = "  the dependency was built with an out-of-date elixir version, run `mix deps.compile`"
+      msg = "  the dependency was built with an out-of-date Elixir version, run `mix deps.compile`"
 
       Mix.Tasks.Deps.run []
       assert_received {:mix_shell, :info, [^msg]}


### PR DESCRIPTION
It includes Erlang, Elixir, ExUnit, ExDoc, Logger, IEx, elixirc

It leaves Mix for a different PR.

Command to spot these words:

    ag -s '(?<!(\`))(?<!(\.))(?<!(/))(?<!(:))(?<!(_))(erlang|elixir|eex|iex|ex_unit|ex_doc|logger|elixirc)(?!(:))(?!(\?))(?!(_))(?!(-))(?!(\.))(?!(\`))(?!(/))(?!(>))' \
    --ignore "*.erl" --ignore "*.yrl" --ignore "*.src"