### PR TITLE
Use Title Case and backtick for: Mix, rebar, and others

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@ and is using Erlang 17.1, remember to update to at least Erlang 17.3.
   * [Mix] Allow rebar dependencies to be specified via `:path`
   * [Mix] Also consider subdirectories in `config` directory for `Mix.Project.config_files/0`
   * [Mix] Allow dynamic configuration in Mix projects by storing config in an agent
-  * [Mix] Support rebar3 style git refs in `rebar.config` files
+  * [Mix] Support rebar3 style Git refs in `rebar.config` files
   * [Mix] Only recompile compile time dependencies in mix projects. This should considerably speed up recompilation times in Elixir projects
   * [Mix] Warn when configuring an application that is not available
   * [Mix] Add `mix profile.fprof` for easy code profiling

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,7 +190,7 @@ not want to merge into the project.
 
 Please adhere to the coding conventions in the project (indentation,
 accurate comments, etc.) and don't forget to add your own tests and
-documentation. When working with git, we recommend the following process
+documentation. When working with Git, we recommend the following process
 in order to craft an excellent pull request:
 
 1. [Fork](https://help.github.com/fork-a-repo/) the project, clone your fork,

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ make clean test
 
 > Note: if you are running on Windows, [this article includes important notes for compiling Elixir from source on Windows](https://github.com/elixir-lang/elixir/wiki/Windows).
 
-If Elixir fails to build (specifically when pulling in a new version via git), be sure to remove any previous build artifacts by running `make clean`, then `make test`.
+If Elixir fails to build (specifically when pulling in a new version via `git`), be sure to remove any previous build artifacts by running `make clean`, then `make test`.
 
 If tests pass, you are ready to move on to the [Getting Started guide][1] or to try Interactive Elixir by running: `bin/iex` in your terminal.
 
@@ -28,7 +28,7 @@ If you have the correct version and tests still fail, feel free to [open an issu
 
 ## Building documentation
 
-Building the documentation requires [ExDoc](https://github.com/elixir-lang/ex_doc) to be installed and built in the same containing folder as elixir.
+Building the documentation requires [ExDoc](https://github.com/elixir-lang/ex_doc) to be installed and built in the same containing folder as Elixir.
 
 ```sh
 # After cloning and compiling Elixir

--- a/lib/eex/lib/eex/tokenizer.ex
+++ b/lib/eex/lib/eex/tokenizer.ex
@@ -94,9 +94,9 @@ defmodule EEx.Tokenizer do
   # Receive an expression content and check
   # if it is a start, middle or an end token.
   #
-  # Start tokens finish with `do` and `fn ->`
-  # Middle tokens are marked with `->` or keywords
-  # End tokens contain only the end word and optionally `)`
+  # Start tokens finish with "do" and "fn ->"
+  # Middle tokens are marked with "->" or keywords
+  # End tokens contain only the end word and optionally ")"
 
   defp token_name([h|t]) when h in [?\s, ?\t, ?)] do
     token_name(t)

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -49,12 +49,14 @@ defmodule Exception do
       module.message(exception)
     rescue
       e ->
-        "got #{inspect e.__struct__} with message `#{message(e)}` " <>
+        "got #{inspect e.__struct__} with message #{inspect message(e)} " <>
         "while retrieving Exception.message/1 for #{inspect(exception)}"
     else
       x when is_binary(x) -> x
-      x -> "got #{inspect(x)} while retrieving Exception.message/1 for #{inspect(exception)} " <>
-           "(expected a string)"
+      x ->
+        "got #{inspect(x)} " <>
+        "while retrieving Exception.message/1 for #{inspect(exception)} " <>
+        "(expected a string)"
     end
   end
 
@@ -481,9 +483,9 @@ defmodule Exception do
   end
 end
 
-# Some exceptions implement `message/1` instead of `exception/1` mostly
+# Some exceptions implement "message/1" instead of "exception/1" mostly
 # for bootstrap reasons. It is recommended for applications to implement
-# `exception/1` instead of `message/1` as described in `defexception/1`
+# "exception/1" instead of "message/1" as described in "defexception/1"
 # docs.
 
 defmodule RuntimeError do

--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -12,7 +12,7 @@ defmodule Float do
   otherwise, `:error`.
 
   If a float formatted string wants to be directly converted to a float,
-  `String.to_float/1" can be used instead.
+  `String.to_float/1` can be used instead.
 
   ## Examples
 

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -408,7 +408,7 @@ defmodule GenServer do
 
       @doc false
       def handle_call(msg, _from, state) do
-        # We do this to trick dialyzer to not complain about non-local returns.
+        # We do this to trick Dialyzer to not complain about non-local returns.
         case :random.uniform(1) do
           1 -> exit({:bad_call, msg})
           2 -> {:noreply, state}
@@ -422,7 +422,7 @@ defmodule GenServer do
 
       @doc false
       def handle_cast(msg, state) do
-        # We do this to trick dialyzer to not complain about non-local returns.
+        # We do this to trick Dialyzer to not complain about non-local returns.
         case :random.uniform(1) do
           1 -> exit({:bad_cast, msg})
           2 -> {:noreply, state}

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -407,7 +407,7 @@ defimpl Inspect, for: Regex do
   defp escape(<<term>> <> rest, buf, term),
     do: escape(rest, buf <> <<?\\, term>>, term)
 
-  # the list of characters is from `String.printable?` impl
+  # the list of characters is from "String.printable?" impl
   # minus characters treated specially by regex: \s, \d, \b, \e
 
   defp escape(<<?\n>> <> rest, buf, term),

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -143,7 +143,7 @@ defmodule Inspect.Algebra do
   @nesting 1
   @break " "
 
-  # Functional interface to `doc` records
+  # Functional interface to "doc" records
 
   @type t :: :doc_nil | :doc_line | doc_cons | doc_nest | doc_break | doc_group | binary
 
@@ -218,7 +218,7 @@ defmodule Inspect.Algebra do
 
               exception = Inspect.Error.exception(
                 message: "got #{inspect e.__struct__} with message " <>
-                         "`#{Exception.message(e)}` while inspecting #{res}"
+                         "#{inspect Exception.message(e)} while inspecting #{res}"
               )
 
               if opts.safe do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1319,7 +1319,7 @@ defmodule Kernel do
   """
   defmacro raise(msg) do
     # Try to figure out the type at compilation time
-    # to avoid dead code and make dialyzer happy.
+    # to avoid dead code and make Dialyzer happy.
     msg = case not is_binary(msg) and bootstraped?(Macro) do
       true  -> Macro.expand(msg, __CALLER__)
       false -> msg
@@ -1404,7 +1404,7 @@ defmodule Kernel do
   """
   defmacro reraise(msg, stacktrace) do
     # Try to figure out the type at compilation time
-    # to avoid dead code and make dialyzer happy.
+    # to avoid dead code and make Dialyzer happy.
 
     case Macro.expand(msg, __CALLER__) do
       msg when is_binary(msg) ->
@@ -2309,8 +2309,8 @@ defmodule Kernel do
   end
 
   defp build_if(_condition, _arguments) do
-    raise(ArgumentError, "invalid or duplicate keys for if, only `do` " <>
-      "and an optional `else` are permitted")
+    raise(ArgumentError, "invalid or duplicate keys for if, only \"do\" " <>
+      "and an optional \"else\" are permitted")
   end
 
   @doc """
@@ -2353,8 +2353,8 @@ defmodule Kernel do
   end
 
   defp build_unless(_condition, _arguments) do
-    raise(ArgumentError, "invalid or duplicate keys for unless, only `do` " <>
-      "and an optional `else` are permitted")
+    raise(ArgumentError, "invalid or duplicate keys for unless, only \"do\" " <>
+      "and an optional \"else\" are permitted")
   end
 
   @doc """
@@ -2822,7 +2822,7 @@ defmodule Kernel do
 
       defmodule Foo do
         alias Foo.Bar
-        # code here can refer to `Foo.Bar` as just `Bar`
+        # code here can refer to "Foo.Bar" as just "Bar"
       end
 
   ## Module names
@@ -3327,7 +3327,7 @@ defmodule Kernel do
         def blank?(_),  do: false
       end
 
-      # The only blank atoms are `false` and `nil`
+      # The only blank atoms are "false" and "nil"
       defimpl Blank, for: Atom do
         def blank?(false), do: true
         def blank?(nil),   do: true

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1692,7 +1692,7 @@ defmodule Kernel.SpecialForms do
         _, _ -> :failed
       end
 
-      x #=> unbound variable `x`
+      x #=> unbound variable "x"
 
   In the example above, `x` cannot be accessed since it was defined
   inside the `try` clause. A common practice to address this issue

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -601,10 +601,10 @@ defmodule Kernel.SpecialForms do
 
       defmodule Math do
         def some_function do
-          # 1) Disable `if/2` from Kernel
+          # 1) Disable "if/2" from Kernel
           import Kernel, except: [if: 2]
 
-          # 2) Require the new `if` macro from MyMacros
+          # 2) Require the new "if" macro from MyMacros
           import MyMacros
 
           # 3) Use the new macro

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -256,7 +256,7 @@ defmodule Process do
   the process or port referred to by `pid`. Returns `true` and does not
   fail, even if there is no link or `id` does not exist
 
-  See [`:erlang.unlink/1`](http://www.erlang.org/doc/man/erlang.html#unlink-1] for more info.
+  See [`:erlang.unlink/1`](http://www.erlang.org/doc/man/erlang.html#unlink-1) for more info.
 
   Inlined by the compiler.
   """

--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -32,7 +32,7 @@ defmodule Record do
         Record.defrecord :user, name: "john", age: 25
 
         @type user :: record(:user, name: String.t, age: integer)
-        # expands to: `@type user :: {:user, String.t, integer}`
+        # expands to: "@type user :: {:user, String.t, integer}"
       end
   """
 

--- a/lib/elixir/lib/record/extractor.ex
+++ b/lib/elixir/lib/record/extractor.ex
@@ -70,7 +70,7 @@ defmodule Record.Extractor do
 
   # Read a file and return its abstract syntax form that also
   # includes record but with macros and other attributes expanded,
-  # such as `-include(...)` and `-include_lib(...)`. This is done
+  # such as "-include(...)" and "-include_lib(...)". This is done
   # by using Erlang's epp.
   defp read_file(file) do
     case :epp.parse_file(file, []) do

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -17,7 +17,7 @@ defmodule System do
     end
   end
 
-  # Read and strip the version from the `VERSION` file.
+  # Read and strip the version from the VERSION file.
   defmacrop get_version do
     case read_stripped(:filename.join(__DIR__, "../../../VERSION")) do
       ""   -> raise RuntimeError, message: "could not read the version number from VERSION"
@@ -25,7 +25,7 @@ defmodule System do
     end
   end
 
-  # Tries to run `git describe --always --tags`. In the case of success returns
+  # Tries to run "git describe --always --tags". In the case of success returns
   # the most recent tag. If that is not available, tries to read the commit hash
   # from .git/HEAD. If that fails, returns an empty string.
   defmacrop get_describe do

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -28,7 +28,7 @@ defmodule Task do
   with the result.
 
   `Task.await/2` is used to read the message sent by the task.
-  `await` will check the monitor setup by the call to `async/1' to
+  `await` will check the monitor setup by the call to `async/1` to
   verify if the process exited for any abnormal reason (or in case
   exits are being trapped by the caller).
 

--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -26,7 +26,7 @@ defmodule Task.Supervised do
 
     ref =
       # There is a race condition on this operation when working across
-      # node that manifests if a `Task.Supervisor.async/1` call is made
+      # node that manifests if a "Task.Supervisor.async/1" call is made
       # while the supervisor is busy spawning previous tasks.
       #
       # Imagine the following workflow:

--- a/lib/elixir/src/elixir_exp_clauses.erl
+++ b/lib/elixir/src/elixir_exp_clauses.erl
@@ -138,7 +138,7 @@ expand_rescue(Meta, [Arg], E) ->
       {[EArg], EA};
     false ->
       compile_error(Meta, ?m(E, file), "invalid rescue clause. The clause should "
-        "match on an alias, a variable or be in the `var in [alias]` format")
+        "match on an alias, a variable or be in the \"var in [alias]\" format")
   end;
 expand_rescue(Meta, _, E) ->
   compile_error(Meta, ?m(E, file), "expected one arg for rescue clauses (->) in try").

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -681,7 +681,7 @@ extract_heredoc(Line0, Column0, Rest0, Marker) ->
   case extract_heredoc_header(Rest0) of
     {ok, Rest1} ->
       %% We prepend a new line so we can transparently remove
-      %% spaces later. This new line is removed by calling `tl`
+      %% spaces later. This new line is removed by calling "tl"
       %% in the final heredoc body three lines below.
       case extract_heredoc_body(Line0, Column0, Marker, [$\n|Rest1], []) of
         {ok, Line1, Body, Rest2, Spaces} ->

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -32,7 +32,7 @@ defmodule ExceptionTest do
     end
 
     assert Exception.message(%{__struct__: BadException, __exception__: true, raise: true}) =~
-           "got RuntimeError with message `oops` while retrieving Exception.message/1 " <>
+           "got RuntimeError with message \"oops\" while retrieving Exception.message/1 " <>
            "for %{__exception__: true, __struct__: ExceptionTest.BadException, raise: true}"
 
     assert Exception.message(%{__struct__: BadException, __exception__: true, raise: false}) =~

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -292,8 +292,8 @@ defmodule Inspect.MapTest do
   end
 
   test "bad implementation unsafe" do
-    msg = "got KeyError with message `key :unknown not found in: " <>
-          "%{__struct__: Inspect.MapTest.Failing, key: 0}` while " <>
+    msg = "got KeyError with message \"key :unknown not found in: " <>
+          "%{__struct__: Inspect.MapTest.Failing, key: 0}\" while " <>
           "inspecting %{__struct__: Inspect.MapTest.Failing, key: 0}"
 
     assert_raise Inspect.Error, msg, fn ->
@@ -304,12 +304,12 @@ defmodule Inspect.MapTest do
   end
 
   test "bad implementation safe" do
-    msg = "got KeyError with message `key :unknown not found in: " <>
-          "%{__struct__: Inspect.MapTest.Failing, key: 0}` while " <>
+    msg = "got KeyError with message \"key :unknown not found in: " <>
+          "%{__struct__: Inspect.MapTest.Failing, key: 0}\" while " <>
           "inspecting %{__struct__: Inspect.MapTest.Failing, key: 0}"
 
     assert inspect(%Failing{}) ==
-           "%Inspect.Error{message: \"#{msg}\"}"
+           inspect(%Inspect.Error{message: "#{msg}"})
   end
 
   test "exception" do

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -676,7 +676,7 @@ defmodule Kernel.ErrorsTest do
 
   test "invalid rescue clause" do
     assert_compile_fail CompileError,
-      "nofile:4: invalid rescue clause. The clause should match on an alias, a variable or be in the `var in [alias]` format",
+      "nofile:4: invalid rescue clause. The clause should match on an alias, a variable or be in the \"var in [alias]\" format",
       'try do\n1\nrescue\n%UndefinedFunctionError{arity: 1} -> false\nend'
   end
 

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -516,8 +516,8 @@ defmodule KernelTest do
     end
 
     test "calling if with invalid keys" do
-      error_message = "invalid or duplicate keys for if, only `do` " <>
-      "and an optional `else` are permitted"
+      error_message = "invalid or duplicate keys for if, only \"do\" " <>
+      "and an optional \"else\" are permitted"
       assert_raise ArgumentError, error_message, fn ->
         Code.eval_string("if true, foo: 7")
       end
@@ -544,8 +544,8 @@ defmodule KernelTest do
     end
 
     test "calling unless with invalid keys" do
-      error_message = "invalid or duplicate keys for unless, only `do` " <>
-        "and an optional `else` are permitted"
+      error_message = "invalid or duplicate keys for unless, only \"do\" " <>
+        "and an optional \"else\" are permitted"
       assert_raise ArgumentError, error_message, fn ->
         Code.eval_string("unless true, foo: 7")
       end

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -11,13 +11,13 @@ defmodule ExUnit do
       # 1) Start ExUnit.
       ExUnit.start
 
-      # 2) Create a new test module (test case) and use `ExUnit.Case`.
+      # 2) Create a new test module (test case) and use "ExUnit.Case".
       defmodule AssertionTest do
-        # 3) Notice we pass `async: true`, this runs the test case
+        # 3) Notice we pass "async: true", this runs the test case
         #    concurrently with other test cases
         use ExUnit.Case, async: true
 
-        # 4) Use the `test` macro instead of `def` for clarity.
+        # 4) Use the "test" macro instead of "def" for clarity.
         test "the truth" do
           assert true
         end

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -47,7 +47,7 @@ defmodule ExUnit.Callbacks do
       defmodule AssertionTest do
         use ExUnit.Case, async: true
 
-        # `setup_all` is called once to setup the case before any test is run
+        # "setup_all" is called once to setup the case before any test is run
         setup_all do
           IO.puts "Starting AssertionTest"
 
@@ -55,7 +55,7 @@ defmodule ExUnit.Callbacks do
           :ok
         end
 
-        # `setup` is called before each test is run
+        # "setup" is called before each test is run
         setup do
           IO.puts "This is a setup callback"
 
@@ -67,7 +67,7 @@ defmodule ExUnit.Callbacks do
           {:ok, hello: "world"}
         end
 
-        # Same as `setup`, but receives the context
+        # Same as "setup", but receives the context
         # for the current test
         setup context do
           IO.puts "Setting up: #{context[:test]}"

--- a/lib/ex_unit/lib/ex_unit/capture_io.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_io.ex
@@ -20,7 +20,7 @@ defmodule ExUnit.CaptureIO do
             assert Enum.each(["some", "example"], &(IO.puts &1)) == :ok
           end
           assert capture_io(fun) == "some\nexample\n"
-          # tip: or use only: `capture_io(fun)` to silence the IO output (so only assert the return value)
+          # tip: or use only: "capture_io(fun)" to silence the IO output (so only assert the return value)
         end
       end
 

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -21,7 +21,7 @@ defmodule ExUnit.Case do
          # Use the module
          use ExUnit.Case, async: true
 
-         # The `test` macro is imported by ExUnit.Case
+         # The "test" macro is imported by ExUnit.Case
          test "always pass" do
            assert true
          end

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -135,10 +135,10 @@ defmodule ExUnit.DocTest do
   or a no-op line with documentation. Thus, multiline messages are not
   supported.
 
-  ## When not to use `doctest`
+  ## When not to use doctest
 
   In general, doctests are not recommended when your code examples contain
-  side effects. For example, if a doctest prints to standard output, `doctest`
+  side effects. For example, if a doctest prints to standard output, doctest
   will not try to capture the output.
 
   Similarly, doctests do not run in any kind of sandbox. So any module

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -158,8 +158,8 @@ defmodule ExUnit.FormatterTest do
   test "inspect failure" do
     failure = {:error, catch_assertion(assert :will_fail == %BadInspect{}), []}
 
-    message = "got FunctionClauseError with message `no function clause matching " <>
-              "in Inspect.ExUnit.FormatterTest.BadInspect.inspect/2` while inspecting " <>
+    message = "got FunctionClauseError with message \"no function clause matching " <>
+              "in Inspect.ExUnit.FormatterTest.BadInspect.inspect/2\" while inspecting " <>
               "%{__struct__: ExUnit.FormatterTest.BadInspect, key: 0}"
 
     assert format_test_failure(test(), failure, 1, 80, &formatter/2) =~ """
@@ -168,7 +168,7 @@ defmodule ExUnit.FormatterTest do
          Assertion with == failed
          code: :will_fail == %BadInspect{}
          lhs:  :will_fail
-         rhs:  %Inspect.Error{message: \"#{message}\"}
+         rhs:  %Inspect.Error{message: #{inspect message}}
     """
   end
 
@@ -182,7 +182,7 @@ defmodule ExUnit.FormatterTest do
 
   test "message failure" do
     failure = {:error, catch_error(raise BadMessage), []}
-    message = "got RuntimeError with message `oops` while retrieving Exception.message/1 " <>
+    message = "got RuntimeError with message \"oops\" while retrieving Exception.message/1 " <>
               "for %ExUnit.FormatterTest.BadMessage{key: 0}"
     assert format_test_failure(test(), failure, 1, 80, &formatter/2) =~ """
       1) world (Hello)

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -131,7 +131,7 @@ defmodule IEx do
 
   Sample contents of a local .iex.exs file:
 
-      # source another `.iex.exs` file
+      # source another ".iex.exs" file
       import_file "~/.iex.exs"
 
       # print something before the shell starts
@@ -225,20 +225,20 @@ defmodule IEx do
 
     * `:enabled`      - boolean value that allows for switching the coloring on and off
     * `:eval_result`  - color for an expression's resulting value
-    * `:eval_info`    - … various informational messages
-    * `:eval_error`   - … error messages
-    * `:stack_app`    - … the app in stack traces
-    * `:stack_info`   - … the remaining info in stacktraces
-    * `:ls_directory` - … for directory entries (ls helper)
-    * `:ls_device`    - … device entries (ls helper)
+    * `:eval_info`    - ... various informational messages
+    * `:eval_error`   - ... error messages
+    * `:stack_app`    - ... the app in stack traces
+    * `:stack_info`   - ... the remaining info in stacktraces
+    * `:ls_directory` - ... for directory entries (ls helper)
+    * `:ls_device`    - ... device entries (ls helper)
 
   When printing documentation, IEx will convert the markdown
   documentation to ANSI as well. Those can be configured via:
 
-    * `:doc_code`        — the attributes for code blocks (cyan, bright)
+    * `:doc_code`        - the attributes for code blocks (cyan, bright)
     * `:doc_inline_code` - inline code (cyan)
     * `:doc_headings`    - h1 and h2 (yellow, bright)
-    * `:doc_title`       — the overall heading for the output (reverse, yellow, bright)
+    * `:doc_title`       - the overall heading for the output (reverse, yellow, bright)
     * `:doc_bold`        - (bright)
     * `:doc_underline`   - (underline)
 

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -70,7 +70,7 @@ defmodule IEx.Evaluator do
     end
   end
 
-  # Instead of doing just `:elixir.eval`, we first parse the expression to see
+  # Instead of doing just :elixir.eval, we first parse the expression to see
   # if it's well formed. If parsing succeeds, we evaluate the AST as usual.
   #
   # If parsing fails, this might be a TokenMissingError which we treat in
@@ -125,7 +125,7 @@ defmodule IEx.Evaluator do
 
   defp handle_eval({:error, {_, _, ""}}, code, _line, state, history) do
     # Update state.cache so that IEx continues to add new input to
-    # the unfinished expression in `code`
+    # the unfinished expression in "code"
     {%{state | cache: code}, history}
   end
 

--- a/lib/iex/lib/iex/history.ex
+++ b/lib/iex/lib/iex/history.ex
@@ -29,7 +29,7 @@ defmodule IEx.History.State do
   # Traverses the queue front-to-back, dropping items as we go
   # until its size is within the specified limit.
   #
-  # The `start` value contains the index of the expression at the head
+  # The "start" value contains the index of the expression at the head
   # of the queue.
   def prune(%{start: start} = state, limit),
     do: prune(state, start, limit, false)

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -177,7 +177,7 @@ defmodule Mix do
   end
 
   @doc """
-  Returns the mix environment.
+  Returns the Mix environment.
   """
   def env do
     # env is not available on bootstrapping, so set a :dev default
@@ -185,7 +185,7 @@ defmodule Mix do
   end
 
   @doc """
-  Changes the current mix env.
+  Changes the current Mix environment to `env`.
 
   Be careful when invoking this function as any project
   configuration won't be reloaded.
@@ -229,16 +229,16 @@ defmodule Mix do
   end
 
   @doc """
-  Raises a mix error that is nicely formatted.
+  Raises a Mix error that is nicely formatted.
   """
   def raise(message) when is_binary(message) do
     Kernel.raise Mix.Error, mix: true, message: message
   end
 
   @doc """
-  Raises a mix compatible exception.
+  Raises a Mix compatible exception.
 
-  A mix compatible exception has a `mix` field which mix
+  A Mix compatible exception has a `:mix` field which Mix
   uses to store the project or application name which is
   automatically by the formatting tools.
   """

--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -35,8 +35,8 @@ defmodule Mix.CLI do
   end
 
   defp get_task(["-" <> _|_]) do
-    Mix.shell.error "** (Mix) Cannot implicitly pass flags to default mix task, " <>
-                    "please invoke instead: mix #{Mix.Project.config[:default_task]}"
+    Mix.shell.error "** (Mix) Cannot implicitly pass flags to default Mix task, " <>
+                    "please invoke instead \"mix #{Mix.Project.config[:default_task]}\""
     exit({:shutdown, 1})
   end
 
@@ -53,7 +53,7 @@ defmodule Mix.CLI do
       Mix.Task.run "loadconfig"
       Mix.Task.run name, args
     rescue
-      # We only rescue exceptions in the mix namespace, all
+      # We only rescue exceptions in the Mix namespace, all
       # others pass through and will explode on the users face
       exception ->
         stacktrace = System.stacktrace

--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -164,7 +164,7 @@ defmodule Mix.Dep do
     do: "the dependency does not match the requirement #{inspect req}, got #{inspect vsn}"
 
   def format_status(%Mix.Dep{status: {:lockmismatch, _}}),
-    do: "lock mismatch: the dependency is out of date (run `mix deps.get` to fetch locked version)"
+    do: "lock mismatch: the dependency is out of date (run \"mix deps.get\" to fetch locked version)"
 
   def format_status(%Mix.Dep{status: :lockoutdated}),
     do: "lock outdated: the lock is outdated compared to the options in your mixfile"
@@ -173,14 +173,14 @@ defmodule Mix.Dep do
     do: "the dependency is not locked"
 
   def format_status(%Mix.Dep{status: :compile}),
-    do: "the dependency build is outdated, please run `#{mix_env_var}mix deps.compile`"
+    do: "the dependency build is outdated, please run \"#{mix_env_var}mix deps.compile\""
 
   def format_status(%Mix.Dep{app: app, status: {:divergedreq, other}} = dep) do
     "the dependency #{app}\n" <>
     "#{dep_status(dep)}" <>
     "\n  does not match the requirement specified\n" <>
     "#{dep_status(other)}" <>
-    "\n  Ensure they match or specify one of the above in your deps and set `override: true`"
+    "\n  Ensure they match or specify one of the above in your deps and set \"override: true\""
   end
 
   def format_status(%Mix.Dep{app: app, status: {:divergedonly, other}} = dep) do
@@ -201,28 +201,28 @@ defmodule Mix.Dep do
   def format_status(%Mix.Dep{app: app, status: {:diverged, other}} = dep) do
     "different specs were given for the #{app} app:\n" <>
     "#{dep_status(dep)}#{dep_status(other)}" <>
-    "\n  Ensure they match or specify one of the above in your deps and set `override: true`"
+    "\n  Ensure they match or specify one of the above in your deps and set \"override: true\""
   end
 
   def format_status(%Mix.Dep{app: app, status: {:overridden, other}} = dep) do
     "the dependency #{app} in #{Path.relative_to_cwd(dep.from)} is overriding a child dependency:\n" <>
     "#{dep_status(dep)}#{dep_status(other)}" <>
-    "\n  Ensure they match or specify one of the above in your deps and set `override: true`"
+    "\n  Ensure they match or specify one of the above in your deps and set \"override: true\""
   end
 
   def format_status(%Mix.Dep{status: {:unavailable, _}, scm: scm}) do
     if scm.fetchable? do
-      "the dependency is not available, run `mix deps.get`"
+      "the dependency is not available, run \"mix deps.get\""
     else
       "the dependency is not available"
     end
   end
 
   def format_status(%Mix.Dep{status: {:elixirlock, _}}),
-    do: "the dependency was built with an out-of-date Elixir version, run `#{mix_env_var}mix deps.compile`"
+    do: "the dependency was built with an out-of-date Elixir version, run \"#{mix_env_var}mix deps.compile\""
 
   def format_status(%Mix.Dep{status: {:scmlock, _}}),
-    do: "the dependency was built with another SCM, run `#{mix_env_var}mix deps.compile`"
+    do: "the dependency was built with another SCM, run \"#{mix_env_var}mix deps.compile\""
 
   defp dep_status(%Mix.Dep{app: app, requirement: req, opts: opts, from: from}) do
     info = {app, req, Dict.drop(opts, [:dest, :lock, :env, :build])}
@@ -312,7 +312,7 @@ defmodule Mix.Dep do
   Returns all source paths.
 
   Source paths are the directories that contains ebin files for a given
-  dependency. All managers, except rebar, have only one source path.
+  dependency. All managers, except `:rebar`, have only one source path.
   """
   def source_paths(%Mix.Dep{manager: :rebar, opts: opts, extra: extra}) do
     # Add root dir and all sub dirs with ebin/ directory
@@ -331,7 +331,7 @@ defmodule Mix.Dep do
   end
 
   @doc """
-  Returns `true` if dependency is a mix project.
+  Returns `true` if dependency is a Mix project.
   """
   def mix?(%Mix.Dep{manager: manager}) do
     manager == :mix

--- a/lib/mix/lib/mix/dep/converger.ex
+++ b/lib/mix/lib/mix/dep/converger.ex
@@ -77,7 +77,7 @@ defmodule Mix.Dep.Converger do
     # dependencies had no conflicts, they are removed now.
     {deps, _} = Mix.Dep.Loader.partition_by_env(deps, opts)
 
-    # Run remote converger if one is available and rerun mix's
+    # Run remote converger if one is available and rerun Mix's
     # converger with the new information
     if converger = Mix.RemoteConverger.get do
       # If there is a lock, it means we are doing a get/update
@@ -115,7 +115,7 @@ defmodule Mix.Dep.Converger do
   # fashion. The reason for this is that we converge
   # dependencies, but allow the parent to override any
   # dependency in the child. Consider this tree with
-  # dependencies `a`, `b`, etc and the order they are
+  # dependencies "a", "b", etc and the order they are
   # converged:
   #
   #     * project
@@ -127,10 +127,10 @@ defmodule Mix.Dep.Converger do
   #         6) f
   #           7) d
   #
-  # Notice that the `d` dependency exists as a child of `b`
-  # and child of `f`. In case the dependency is the same,
+  # Notice that the "d" dependency exists as a child of "b"
+  # and child of "f". In case the dependency is the same,
   # we proceed. However, if there is a conflict, for instance
-  # different git repositories is used as source in each, we
+  # different Git repositories are used as source in each, we
   # raise an exception.
   #
   # In order to solve such dependencies, we allow the project
@@ -147,7 +147,7 @@ defmodule Mix.Dep.Converger do
   #           8) d
   #       4) d
   #
-  # Now, since `d` was specified in a parent project, no
+  # Now, since "d" was specified in a parent project, no
   # exception is going to be raised since d is considered
   # to be the authoritative source.
   defp all([dep|t], acc, upper_breadths, current_breadths, callback, rest, lock, cache) do

--- a/lib/mix/lib/mix/dep/loader.ex
+++ b/lib/mix/lib/mix/dep/loader.ex
@@ -50,7 +50,7 @@ defmodule Mix.Dep.Loader do
         mix?(dest) ->
           mix_dep(dep, children)
 
-        # If not an explicit rebar or mix dependency
+        # If not an explicit rebar or Mix dependency
         # but came from rebar, assume to be a rebar dep.
         rebar?(dest) or manager == :rebar ->
           rebar_dep(dep, children)

--- a/lib/mix/lib/mix/exceptions.ex
+++ b/lib/mix/lib/mix/exceptions.ex
@@ -7,10 +7,10 @@ defmodule Mix.NoTaskError do
   end
 
   defp msg(task) do
-    msg = "The task #{task} could not be found"
+    msg = "The task #{inspect task} could not be found"
     case did_you_mean(task) do
       {similar, score} when score > 0.8 ->
-        msg <> ". Did you mean '#{similar}'?"
+        msg <> ". Did you mean #{inspect similar}?"
 
       _otherwise -> msg
     end
@@ -34,7 +34,7 @@ defmodule Mix.InvalidTaskError do
 
   def exception(opts) do
     task = opts[:task]
-    %Mix.InvalidTaskError{task: task, message: "The task #{task} does not export run/1"}
+    %Mix.InvalidTaskError{task: task, message: "The task #{inspect task} does not export run/1"}
   end
 end
 

--- a/lib/mix/lib/mix/hex.ex
+++ b/lib/mix/lib/mix/hex.ex
@@ -54,7 +54,7 @@ defmodule Mix.Hex do
       kind, reason ->
         stacktrace = System.stacktrace
         Mix.shell.error "Could not start Hex. Try fetching a new version with " <>
-                        "`mix local.hex` or uninstalling it with `mix archive.uninstall hex.ez`"
+                        "\"mix local.hex\" or uninstalling it with \"mix archive.uninstall hex.ez\""
         :erlang.raise(kind, reason, stacktrace)
     end
   end

--- a/lib/mix/lib/mix/local.ex
+++ b/lib/mix/lib/mix/local.ex
@@ -21,7 +21,7 @@ defmodule Mix.Local do
   end
 
   @doc """
-  Appends mix paths into Erlang code path.
+  Appends Mix paths into Erlang code path.
   """
   def append_paths do
     Enum.each(Mix.Utils.mix_paths, &Code.append_path(&1))

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -17,7 +17,7 @@ defmodule Mix.Project do
 
   After being defined, the configuration for this project can be read
   as `Mix.Project.config/0`. Notice that `config/0` won't fail if a
-  project is not defined; this allows many mix tasks to work
+  project is not defined; this allows many Mix tasks to work
   without a project.
 
   In case the developer needs a project or wants to access a special
@@ -28,7 +28,7 @@ defmodule Mix.Project do
   ## Erlang projects
 
   Mix can be used to manage Erlang projects that don't have any Elixir code. To
-  ensure mix tasks work correctly for an Erlang project, `language: :erlang`
+  ensure Mix tasks work correctly for an Erlang project, `language: :erlang`
   has to be added to `project`.
 
   The setting also makes sure Elixir is not added as a dependency to the
@@ -121,7 +121,7 @@ defmodule Mix.Project do
   Returns the project configuration.
 
   If there is no project defined, it still returns a keyword
-  list with default values. This allows many mix tasks to work
+  list with default values. This allows many Mix tasks to work
   without the need for an underlying project.
 
   Note this configuration is cached once the project is
@@ -310,13 +310,13 @@ defmodule Mix.Project do
 
   It will run the compile task unless the project
   is in build embedded mode, which may fail as a
-  explicit command to "mix compile" is required.
+  explicit command to `mix compile` is required.
   """
   def compile(args, config \\ config()) do
     if config[:build_embedded] do
       if not File.exists?(compile_path(config)) do
         Mix.raise "Cannot execute task because the project was not yet compiled. " <>
-                  "When build_embedded is set to true, `MIX_ENV=#{Mix.env} mix compile` " <>
+                  "When build_embedded is set to true, \"MIX_ENV=#{Mix.env} mix compile\" " <>
                   "must be explicitly executed"
       end
 

--- a/lib/mix/lib/mix/rebar.ex
+++ b/lib/mix/lib/mix/rebar.ex
@@ -7,14 +7,14 @@ defmodule Mix.Rebar do
   def local_rebar_path, do: Path.join(Mix.Utils.mix_home, "rebar")
 
   @doc """
-  Returns the path to the global copy of rebar, if one exists.
+  Returns the path to the global copy of `rebar`, if one exists.
   """
   def global_rebar_cmd do
     wrap_cmd System.find_executable("rebar")
   end
 
   @doc """
-  Returns the path to the local copy of rebar, if one exists.
+  Returns the path to the local copy of `rebar`, if one exists.
   """
   def local_rebar_cmd do
     rebar = local_rebar_path
@@ -22,14 +22,14 @@ defmodule Mix.Rebar do
   end
 
   @doc """
-  Returns the path to the available rebar command.
+  Returns the path to the available `rebar` command.
   """
   def rebar_cmd do
     global_rebar_cmd || local_rebar_cmd
   end
 
   @doc """
-  Loads the rebar.config and evaluates rebar.config.script if it
+  Loads `rebar.config` and evaluates `rebar.config.script` if it
   exists in the given directory.
   """
   def load_config(dir) do
@@ -43,7 +43,7 @@ defmodule Mix.Rebar do
         []
       {:error, error} ->
         reason = :file.format_error(error)
-        Mix.raise "Error consulting rebar config #{config_path}: #{reason}"
+        Mix.raise "Error consulting rebar config #{inspect config_path}: #{reason}"
     end
 
     if File.exists?(script_path) do
@@ -54,7 +54,7 @@ defmodule Mix.Rebar do
   end
 
   @doc """
-  Parses the dependencies in given rebar.config to Mix's dependency format.
+  Parses the dependencies in given `rebar.config` to Mix's dependency format.
   """
   def deps(config) do
     if deps = config[:deps] do
@@ -124,7 +124,7 @@ defmodule Mix.Rebar do
       {:ok, re} ->
         re
       {:error, reason} ->
-        Mix.raise "Unable to compile version regex: \"#{req}\", #{reason}"
+        Mix.raise "Unable to compile version regex: #{inspect req}, #{reason}"
     end
   end
 
@@ -140,8 +140,7 @@ defmodule Mix.Rebar do
         config
       {:error, error} ->
         reason = :file.format_error(error)
-        Mix.shell.error("Error evaluating rebar config script #{script_path}: #{reason}")
-        Mix.shell.error("You may solve this issue by adding rebar as a dependency to your project")
+        Mix.shell.error("Error evaluating rebar config script #{inspect script_path}: #{reason}")
         Mix.shell.error("Any dependency defined in the script won't be available " <>
                         "unless you add them to your Mix project")
         config

--- a/lib/mix/lib/mix/remote_converger.ex
+++ b/lib/mix/lib/mix/remote_converger.ex
@@ -2,7 +2,7 @@ defmodule Mix.RemoteConverger do
   @moduledoc false
 
   # A remote converger returns updated dependencies with
-  # extra information that can be used during mix's converging.
+  # extra information that can be used during Mix's converging.
   # Useful for things like external package managers
 
   @doc """

--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -156,7 +156,7 @@ defmodule Mix.SCM.Git do
 
   defp git!(command) do
     if Mix.shell.cmd("git " <> command) != 0 do
-      Mix.raise "Command `git #{command}` failed"
+      Mix.raise "Command \"git #{command}\" failed"
     end
     :ok
   end
@@ -169,7 +169,7 @@ defmodule Mix.SCM.Git do
         if System.find_executable("git") do
           Mix.State.put(:git_available, true)
         else
-          Mix.raise "Error fetching/updating Git repository: the `git` "  <>
+          Mix.raise "Error fetching/updating Git repository: the \"git\" "  <>
             "executable is not available in your PATH. Please install "   <>
             "Git on this machine or pass --no-deps-check if you want to " <>
             "run a previously built application on a system without Git."

--- a/lib/mix/lib/mix/tasks/app.start.ex
+++ b/lib/mix/lib/mix/tasks/app.start.ex
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.App.Start do
     * `--no-compile` - do not compile even if files require compilation
     * `--no-protocols` - do not load consolidated protocols
     * `--no-deps-check` - do not check dependencies
-    * `--no-elixir-version-check` - do not check `elixir` version
+    * `--no-elixir-version-check` - do not check Elixir version
     * `--no-start` - do not start applications after compilation
 
   """

--- a/lib/mix/lib/mix/tasks/archive.build.ex
+++ b/lib/mix/lib/mix/tasks/archive.build.ex
@@ -21,7 +21,7 @@ defmodule Mix.Tasks.Archive.Build do
   ## Command line options
 
     * `-o` - specify output file name.
-      If there is a `mix.exs`, defaults to `APP-VERSION.ez`.
+      If there is a `mix.exs`, defaults to "APP-VERSION.ez".
 
     * `-i` - specify the input directory to archive.
       If there is a `mix.exs`, defaults to the current application build.
@@ -73,7 +73,7 @@ defmodule Mix.Tasks.Archive.Build do
 
     Mix.Archive.create(source, target)
 
-    Mix.shell.info "Generated archive #{target} with MIX_ENV=#{Mix.env}"
+    Mix.shell.info "Generated archive #{inspect target} with MIX_ENV=#{Mix.env}"
     :ok
   end
 end

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.Archive.Install do
   Installs an archive locally.
 
   If no argument is supplied but there is an archive in the root
-  (created with mix archive), then the archive will be installed
+  (created with `mix archive`), then the archive will be installed
   locally. For example:
 
       mix do archive.build, archive.install
@@ -25,7 +25,7 @@ defmodule Mix.Tasks.Archive.Install do
     * `--sha512` - checks the archive matches the given sha512 checksum
 
     * `--force` - forces installation without a shell prompt; primarily
-      intended for automation in build systems like make
+      intended for automation in build systems like `make`
 
   """
   @switches [force: :boolean, sha512: :string]
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Archive.Install do
 
       case Path.extname(path) do
         ".ez" -> install_archive(src, opts)
-        _     -> Mix.raise "mix archive.install doesn't know how to install #{path}"
+        _     -> Mix.raise "\"mix archive.install\" doesn't know how to install #{inspect path}"
       end
     else
       src = Mix.Archive.name(Mix.Project.config[:app], Mix.Project.config[:version])
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.Archive.Install do
         install_archive(src, opts)
       else
         Mix.raise "Expected local archive to exist or PATH to be given, " <>
-                  "please use `mix archive.install PATH`"
+                  "please use \"mix archive.install PATH\""
       end
     end
   end
@@ -100,7 +100,7 @@ defmodule Mix.Tasks.Archive.Install do
   end
 
   defp should_install?(src, []) do
-    Mix.shell.yes?("Are you sure you want to install archive #{src}?")
+    Mix.shell.yes?("Are you sure you want to install archive #{inspect src}?")
   end
 
   defp should_install?(_src, previous_files) do

--- a/lib/mix/lib/mix/tasks/compile.all.ex
+++ b/lib/mix/lib/mix/tasks/compile.all.ex
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Compile.All do
   @moduledoc false
   @recursive true
 
-  # This is an internal task used by mix compile which
+  # This is an internal task used by "mix compile" which
   # is meant to be recursive and be invoked for each child
   # project.
 

--- a/lib/mix/lib/mix/tasks/deps.clean.ex
+++ b/lib/mix/lib/mix/tasks/deps.clean.ex
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.Deps.Clean do
       apps != [] ->
         do_clean(apps, build, deps)
       true ->
-        Mix.raise "mix deps.clean expects dependencies as arguments or " <>
+        Mix.raise "\"mix deps.clean\" expects dependencies as arguments or " <>
                   "a flag indicating which dependencies to clean. " <>
                   "The --all option will clean all dependencies while " <>
                   "the --unused option cleans unused dependencies"

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -63,8 +63,8 @@ defmodule Mix.Tasks.Deps.Compile do
           make?(dep) ->
             do_make dep, config
           true ->
-            shell.error "Could not compile #{app}, no mix.exs, rebar.config or Makefile " <>
-              "(pass :compile as an option to customize compilation, set it to false to do nothing)"
+            shell.error "Could not compile #{inspect app}, no \"mix.exs\", \"rebar.config\" or \"Makefile\" " <>
+              "(pass :compile as an option to customize compilation, set it to \"false\" to do nothing)"
         end
 
         unless mix?(dep), do: build_structure(dep, config)
@@ -83,8 +83,8 @@ defmodule Mix.Tasks.Deps.Compile do
   end
 
   defp check_unavailable!(app, {:unavailable, _}) do
-    Mix.raise "Cannot compile dependency #{app} because " <>
-      "it isn't available, run `mix deps.get` first"
+    Mix.raise "Cannot compile dependency #{inspect app} because " <>
+      "it isn't available, run \"mix deps.get\" first"
   end
 
   defp check_unavailable!(_, _) do
@@ -94,7 +94,7 @@ defmodule Mix.Tasks.Deps.Compile do
   defp do_mix(dep, _config) do
     Mix.Dep.in_dependency dep, fn _ ->
       if req = old_elixir_req(Mix.Project.config) do
-        Mix.shell.error "warning: the dependency #{dep.app} requires Elixir #{inspect req} " <>
+        Mix.shell.error "warning: the dependency #{inspect dep.app} requires Elixir #{inspect req} " <>
                         "but you are running on v#{System.version}"
       end
 
@@ -105,9 +105,9 @@ defmodule Mix.Tasks.Deps.Compile do
         kind, reason ->
           stacktrace = System.stacktrace
           app = dep.app
-          Mix.shell.error "could not compile dependency #{app}, mix compile failed. " <>
-            "You can recompile this dependency with `mix deps.compile #{app}` or " <>
-            "update it with `mix deps.update #{app}`"
+          Mix.shell.error "could not compile dependency #{inspect app}, \"mix compile\" failed. " <>
+            "You can recompile this dependency with \"mix deps.compile #{app}\" or " <>
+            "update it with \"mix deps.update #{app}\""
           :erlang.raise(kind, reason, stacktrace)
       end
     end
@@ -125,16 +125,16 @@ defmodule Mix.Tasks.Deps.Compile do
 
   defp handle_rebar_not_found(app) do
     shell = Mix.shell
-    shell.info "Could not find rebar, which is needed to build dependency #{inspect app}"
-    shell.info "I can install a local copy which is just used by mix"
+    shell.info "Could not find \"rebar\", which is needed to build dependency #{inspect String.to_atom(app)}"
+    shell.info "I can install a local copy which is just used by Mix"
 
     unless shell.yes?("Shall I install rebar?") do
-      Mix.raise "Could not find rebar to compile " <>
-        "dependency #{app}, please ensure rebar is available"
+      Mix.raise "Could not find \"rebar\" to compile " <>
+        "dependency #{inspect String.to_atom(app)}, please ensure \"rebar\" is available"
     end
 
     (Mix.Tasks.Local.Rebar.run([]) && Mix.Rebar.local_rebar_cmd) ||
-      Mix.raise "rebar installation failed"
+      Mix.raise "\"rebar\" installation failed"
   end
 
   defp do_make(dep, config) do
@@ -158,8 +158,8 @@ defmodule Mix.Tasks.Deps.Compile do
     Mix.Dep.in_dependency dep, fn _ ->
       env = [{"ERL_LIBS", Path.join(config[:build_path], "lib")}]
       if Mix.shell.cmd("#{command} #{extra}", print_app: print_app?, env: env) != 0 do
-        Mix.raise "Could not compile dependency #{app}, #{command} command failed. " <>
-          "If you want to recompile this dependency, please run: mix deps.compile #{app}"
+        Mix.raise "Could not compile dependency #{inspect String.to_atom(app)}, \"#{command}\" command failed. " <>
+          "If you want to recompile this dependency, please run: \"mix deps.compile #{app}\""
       end
     end
     true

--- a/lib/mix/lib/mix/tasks/deps.ex
+++ b/lib/mix/lib/mix/tasks/deps.ex
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.Deps do
 
   Path and in umbrella dependencies are automatically recompiled by
   the parent project whenever they change. While fetchable dependencies
-  like git are recompiled only when fetched/updated.
+  like the ones using `:git` are recompiled only when fetched/updated.
 
   The dependencies versions are expected to follow Semantic Versioning
   and the requirements must be specified as defined in the `Version`
@@ -55,8 +55,8 @@ defmodule Mix.Tasks.Deps do
 
     * `:env` - the environment to run the dependency on, defaults to :prod
 
-    * `:compile` - a command to compile the dependency, defaults to a mix,
-      rebar or make command
+    * `:compile` - a command to compile the dependency, defaults to a `mix`,
+      `rebar` or `make` command
 
     * `:optional` - the dependency is optional and used only to specify
       requirements
@@ -82,9 +82,9 @@ defmodule Mix.Tasks.Deps do
     * `:in_umbrella` - when `true`, sets a path dependency pointing to
       "../#{app}", sharing the same environment as the current application
 
-  ## mix deps task
+  ## Deps task
 
-  This task lists all dependencies in the following format:
+  `mix deps` task lists all dependencies in the following format:
 
       APP VERSION (SCM)
       [locked at REF]

--- a/lib/mix/lib/mix/tasks/deps.unlock.ex
+++ b/lib/mix/lib/mix/tasks/deps.unlock.ex
@@ -44,7 +44,7 @@ defmodule Mix.Tasks.Deps.Unlock do
         Mix.Dep.Lock.write(lock)
 
       true ->
-        Mix.raise "mix deps.unlock expects dependencies as arguments or " <>
+        Mix.raise "\"mix deps.unlock\" expects dependencies as arguments or " <>
                   "the --all option to unlock all dependencies"
     end
   end

--- a/lib/mix/lib/mix/tasks/deps.update.ex
+++ b/lib/mix/lib/mix/tasks/deps.update.ex
@@ -31,7 +31,7 @@ defmodule Mix.Tasks.Deps.Update do
         {old, new} = Dict.split(Mix.Dep.Lock.read, to_app_names(rest))
         Mix.Dep.Fetcher.by_name(rest, old, new, fetch_opts)
       true ->
-        Mix.raise "mix deps.update expects dependencies as arguments or " <>
+        Mix.raise "\"mix deps.update\" expects dependencies as arguments or " <>
                                   "the --all option to update all dependencies"
     end
   end

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -45,7 +45,7 @@ defmodule Mix.Tasks.Escript.Build do
       Defaults to app name. Set it to `nil` if no application should
       be started.
 
-    * `:embed_elixir` - if `true` embed `elixir` and its children apps
+    * `:embed_elixir` - if `true` embed elixir and its children apps
       (`ex_unit`, `mix`, etc.) mentioned in the `:applications` list inside the
       `application` function in `mix.exs`.
 
@@ -120,7 +120,7 @@ defmodule Mix.Tasks.Escript.Build do
 
       !main or !Code.ensure_loaded?(main)->
         Mix.raise "Could not generate escript, please set :main_module " <>
-          "in your project configuration (under `:escript` option) to a module that implements main/1"
+          "in your project configuration (under :escript option) to a module that implements main/1"
 
       force || Mix.Utils.stale?(files, [filename]) ->
         beam_paths =

--- a/lib/mix/lib/mix/tasks/help.ex
+++ b/lib/mix/lib/mix/tasks/help.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Help do
 
   The available color options are:
 
-    * `:enabled`         - show ANSI formatting (defaults to `IO.ANSI.enabled?`)
+    * `:enabled`         - shows ANSI formatting (defaults to `IO.ANSI.enabled?`)
     * `:doc_code`        — the attributes for code blocks (cyan, bright)
     * `:doc_inline_code` - inline code (cyan)
     * `:doc_headings`    - h1 and h2 (yellow, bright)
@@ -82,7 +82,7 @@ defmodule Mix.Tasks.Help do
   end
 
   def run(["--search"]) do
-    Mix.raise "Unexpected arguments, expected `mix help --search PATTERN`"
+    Mix.raise "Unexpected arguments, expected \"mix help --search PATTERN\""
   end
 
   def run([task]) do
@@ -105,7 +105,7 @@ defmodule Mix.Tasks.Help do
   end
 
   def run(_) do
-    Mix.raise "Unexpected arguments, expected `mix help` or `mix help TASK`"
+    Mix.raise "Unexpected arguments, expected \"mix help\" or \"mix help TASK\""
   end
 
   # Loadpaths without checks because tasks may be defined in deps.
@@ -147,12 +147,12 @@ defmodule Mix.Tasks.Help do
 
   defp display_default_task_doc(max) do
     Mix.shell.info format_task("mix", max,
-                    "Run the default task (current: mix #{Mix.Project.config[:default_task]})")
+                    "Runs the default task (current: \"mix #{Mix.Project.config[:default_task]}\")")
   end
 
   defp display_iex_task_doc(max) do
     Mix.shell.info format_task("iex -S mix", max,
-                    "Start IEx and run the default task")
+                    "Starts IEx and run the default task")
   end
 
   defp display_task_doc_list(docs, max) do

--- a/lib/mix/lib/mix/tasks/iex.ex
+++ b/lib/mix/lib/mix/tasks/iex.ex
@@ -7,6 +7,6 @@ defmodule Mix.Tasks.Iex do
 
   @spec run(OptionParser.argv) :: no_return
   def run(_) do
-    Mix.raise "To use IEx with Mix, please run: iex -S mix"
+    Mix.raise "To use IEx with Mix, please run: \"iex -S mix\""
   end
 end

--- a/lib/mix/lib/mix/tasks/loadpaths.ex
+++ b/lib/mix/lib/mix/tasks/loadpaths.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.Loadpaths do
   ## Command line options
 
     * `--no-deps-check` - do not check dependencies
-    * `--no-elixir-version-check` - do not check `elixir` version
+    * `--no-elixir-version-check` - do not check Elixir version
 
   """
 

--- a/lib/mix/lib/mix/tasks/local.hex.ex
+++ b/lib/mix/lib/mix/tasks/local.hex.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Local.Hex do
   ## Command line options
 
     * `--force` - forces installation without a shell prompt; primarily
-      intended for automation in build systems like make
+      intended for automation in build systems like `make`
   """
   @spec run(OptionParser.argv) :: boolean
   def run(args) do

--- a/lib/mix/lib/mix/tasks/local.public_keys.ex
+++ b/lib/mix/lib/mix/tasks/local.public_keys.ex
@@ -30,7 +30,7 @@ defmodule Mix.Tasks.Local.PublicKeys do
   ## Command line options
 
     * `--force` - forces installation without a shell prompt; primarily
-      intended for automation in build systems like make
+      intended for automation in build systems like `make`
   """
   @spec run(OptionParser.argv) :: true
   def run(argv) do

--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -8,20 +8,21 @@ defmodule Mix.Tasks.Local.Rebar do
   @shortdoc  "Installs rebar locally"
 
   @moduledoc """
-  Fetches a copy of rebar from the given path or url.
+  Fetches a copy of `rebar` from the given path or url.
 
-  It defaults to safely download a rebar copy from S3. However, a URL
-  can be given as argument, usually from an existing local copy of rebar.
+  It defaults to safely download a `rebar` copy from
+  [Amazon S3](https://aws.amazon.com/s3/). However, a URL
+  can be given as argument, usually from an existing local copy of `rebar`.
 
-  The local copy is stored in your MIX_HOME (defaults to ~/.mix).
-  This version of rebar will be used as required by `mix deps.compile`.
+  The local copy is stored in your `MIX_HOME` (defaults to `~/.mix`).
+  This version of `rebar` will be used as required by `mix deps.compile`.
 
   ## Command line options
 
     * `--sha512` - checks the archive matches the given sha512 checksum
 
     * `--force` - forces installation without a shell prompt; primarily
-      intended for automation in build systems like make
+      intended for automation in build systems like `make`
   """
   @switches [force: :boolean, sha512: :string]
   @spec run(OptionParser.argv) :: true

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -49,7 +49,7 @@ defmodule Mix.Tasks.New do
 
     case argv do
       [] ->
-        Mix.raise "Expected PATH to be given, please use `mix new PATH`"
+        Mix.raise "Expected PATH to be given, please use \"mix new PATH\""
       [path|_] ->
         app = opts[:app] || Path.basename(Path.expand(path))
         check_application_name!(app, !!opts[:app])
@@ -98,13 +98,13 @@ defmodule Mix.Tasks.New do
 
     Mix.shell.info """
 
-    Your mix project was created successfully.
-    You can use mix to compile it, test it, and more:
+    Your Mix project was created successfully.
+    You can use "mix" to compile it, test it, and more:
 
         cd #{path}
         mix test
 
-    Run `mix help` for more commands.
+    Run "mix help" for more commands.
     """
   end
 
@@ -139,7 +139,7 @@ defmodule Mix.Tasks.New do
         cd apps
         mix new my_app
 
-    Commands like `mix compile` and `mix test` when executed
+    Commands like "mix compile" and "mix test" when executed
     in the umbrella project root will automatically run
     for each application in the apps/ directory.
     """
@@ -151,7 +151,7 @@ defmodule Mix.Tasks.New do
                 "letters, numbers and underscore, got: #{inspect name}" <>
                 (if !from_app_flag do
                   ". The application name is inferred from the path, if you'd like to " <>
-                  "explicitly name the application then use the `--app APP` option."
+                  "explicitly name the application then use the \"--app APP\" option."
                 else
                   ""
                 end)
@@ -202,7 +202,7 @@ defmodule Mix.Tasks.New do
 
   If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
 
-    1. Add <%= @app %> to your list of dependencies in mix.exs:
+    1. Add <%= @app %> to your list of dependencies in `mix.exs`:
 
           def deps do
             [{:<%= @app %>, "~> 0.0.1"}]
@@ -238,7 +238,7 @@ defmodule Mix.Tasks.New do
 
     # Configuration for the OTP application
     #
-    # Type `mix help compile.app` for more information
+    # Type "mix help compile.app" for more information
     def application do
   <%= @otp_app %>
     end
@@ -251,7 +251,7 @@ defmodule Mix.Tasks.New do
     #
     #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
     #
-    # Type `mix help deps` for more examples and options
+    # Type "mix help deps" for more examples and options
     defp deps do
       []
     end
@@ -275,7 +275,7 @@ defmodule Mix.Tasks.New do
 
     # Configuration for the OTP application
     #
-    # Type `mix help compile.app` for more information
+    # Type "mix help compile.app" for more information
     def application do
   <%= @otp_app %>
     end
@@ -292,7 +292,7 @@ defmodule Mix.Tasks.New do
     #
     #   {:myapp, in_umbrella: true}
     #
-    # Type `mix help deps` for more examples and options
+    # Type "mix help deps" for more examples and options
     defp deps do
       []
     end
@@ -318,7 +318,7 @@ defmodule Mix.Tasks.New do
     #
     #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
     #
-    # Type `mix help deps` for more examples and options.
+    # Type "mix help deps" for more examples and options.
     #
     # Dependencies listed here are available only for this project
     # and cannot be accessed from applications inside the apps folder
@@ -337,7 +337,7 @@ defmodule Mix.Tasks.New do
   # to this project. If another project depends on this project, this
   # file won't be loaded nor affect the parent project. For this reason,
   # if you want to provide default values for your application for
-  # 3rd-party users, it should be done in your mix.exs file.
+  # 3rd-party users, it should be done in your "mix.exs" file.
 
   # You can configure for your application as:
   #

--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -102,14 +102,14 @@ defmodule Mix.Tasks.Profile.Fprof do
   this should give you a more correct insight into your real bottlenecks.
   Profiling with other environments might produce some false bottlenecks, such as
   protocol dispatches, which perform much faster with the `prod` environment when
-  `build_embedded` is `true` (which is the default for production).
+  `:build_embedded` is `true` (which is the default for production).
   """
 
   @spec run(OptionParser.argv) :: :ok
   def run(args) do
     unless Mix.Project.config[:build_embedded] do
-      Mix.shell.error "Warning: It's advised to run this task when build_embedded is set " <>
-                      "to true (usually the prod environment). Otherwise the results may " <>
+      Mix.shell.error "Warning: It's advised to run this task when :build_embedded is set " <>
+                      "to \"true\" (usually the prod environment). Otherwise the results may " <>
                       "contain false bottlenecks which will not appear in production."
     end
 
@@ -259,7 +259,7 @@ defmodule Mix.Tasks.Profile.Fprof do
     print_row(["s", "B", ".3f", ".3f", "s"], ["Total", count, acc, own, ""])
   end
 
-  # Represents the `pid` entry
+  # Represents the "pid" entry
   defp print_analysis_result([{pid_atom, count, :undefined, own} | info]) do
     print_process(pid_atom, count, own)
 

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -82,7 +82,7 @@ defmodule Mix.Tasks.Test do
   first (either in the test helper or via the `--exclude` option), the
   `--include` flag has no effect.
 
-  For this reason, mix also provides an `--only` option that excludes all
+  For this reason, Mix also provides an `--only` option that excludes all
   tests and includes only the given ones:
 
       mix test --only external
@@ -141,7 +141,7 @@ defmodule Mix.Tasks.Test do
     {opts, files, _} = OptionParser.parse(args, switches: @switches)
 
     unless System.get_env("MIX_ENV") || Mix.env == :test do
-      Mix.raise "mix test is running on environment #{Mix.env}. If you are " <>
+      Mix.raise "\"mix test\" is running on environment \"#{Mix.env}\". If you are " <>
                                 "running tests along another task, please set MIX_ENV explicitly"
     end
 
@@ -234,7 +234,7 @@ defmodule Mix.Tasks.Test do
 
   defp parse_files([single_file], _test_paths) do
     # Check if the single file path matches test/path/to_test.exs:123, if it does
-    # apply `--only line:123` and trim the trailing :123 part.
+    # apply "--only line:123" and trim the trailing :123 part.
     {single_file, opts} = ExUnit.Filters.parse_path(single_file)
     ExUnit.configure(opts)
     [single_file]

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -4,7 +4,7 @@ defmodule Mix.Utils do
   """
 
   @doc """
-  Gets the mix home.
+  Gets the Mix home.
 
   It defaults to `~/.mix` unless the `MIX_HOME`
   environment variable is set.

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -56,7 +56,7 @@ defmodule Mix.CLITest do
   test "no task error" do
     in_fixture "no_mixfile", fn ->
       contents = mix ~w[no_task]
-      assert contents =~ "** (Mix) The task no_task could not be found"
+      assert contents =~ "** (Mix) The task \"no_task\" could not be found"
     end
   end
 

--- a/lib/mix/test/mix/rebar_test.exs
+++ b/lib/mix/test/mix/rebar_test.exs
@@ -113,10 +113,10 @@ defmodule Mix.RebarTest do
     end
   end
 
-  test "get and compile dependencies for rebar with mix" do
+  test "get and compile dependencies for rebar with Mix" do
     Mix.Project.push(RebarAsDep)
 
-    in_tmp "get and compile dependencies for rebar with mix", fn ->
+    in_tmp "get and compile dependencies for rebar with Mix", fn ->
       File.write! MixTest.Case.tmp_path("rebar_dep/mix.exs"), """
       defmodule RebarDep.Mixfile do
         use Mix.Project

--- a/lib/mix/test/mix/task_test.exs
+++ b/lib/mix/test/mix/task_test.exs
@@ -13,15 +13,15 @@ defmodule Mix.TaskTest do
     assert Mix.Task.run("hello") == "Hello, World!"
     assert Mix.Task.run("hello") == :noop
 
-    assert_raise Mix.NoTaskError, "The task unknown could not be found", fn ->
+    assert_raise Mix.NoTaskError, "The task \"unknown\" could not be found", fn ->
       Mix.Task.run("unknown")
     end
 
-    assert_raise Mix.NoTaskError, "The task helli could not be found. Did you mean 'hello'?", fn ->
+    assert_raise Mix.NoTaskError, "The task \"helli\" could not be found. Did you mean \"hello\"?", fn ->
       Mix.Task.run("helli")
     end
 
-    assert_raise Mix.InvalidTaskError, "The task invalid does not export run/1", fn ->
+    assert_raise Mix.InvalidTaskError, "The task \"invalid\" does not export run/1", fn ->
       Mix.Task.run("invalid")
     end
   end
@@ -107,11 +107,11 @@ defmodule Mix.TaskTest do
   test "get!" do
     assert Mix.Task.get!("hello") == Mix.Tasks.Hello
 
-    assert_raise Mix.NoTaskError, "The task unknown could not be found", fn ->
+    assert_raise Mix.NoTaskError, "The task \"unknown\" could not be found", fn ->
       Mix.Task.get!("unknown")
     end
 
-    assert_raise Mix.InvalidTaskError, "The task invalid does not export run/1", fn ->
+    assert_raise Mix.InvalidTaskError, "The task \"invalid\" does not export run/1", fn ->
       Mix.Task.get!("invalid")
     end
   end

--- a/lib/mix/test/mix/tasks/archive_test.exs
+++ b/lib/mix/test/mix/tasks/archive_test.exs
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.ArchiveTest do
       # Build and install archive
       Mix.Tasks.Archive.Build.run ["--no-elixir-version-check"]
       assert File.regular? "archive-0.1.0.ez"
-      assert_received {:mix_shell, :info, ["Generated archive archive-0.1.0.ez with MIX_ENV=dev"]}
+      assert_received {:mix_shell, :info, ["Generated archive \"archive-0.1.0.ez\" with MIX_ENV=dev"]}
 
       send self, {:mix_shell_input, :yes?, true}
       Mix.Tasks.Archive.Install.run []
@@ -71,7 +71,7 @@ defmodule Mix.Tasks.ArchiveTest do
       Mix.Project.push(ArchiveProject2)
       Mix.Tasks.Archive.Build.run ["--no-compile"]
       assert File.regular? "archive-0.2.0.ez"
-      assert_received {:mix_shell, :info, ["Generated archive archive-0.2.0.ez with MIX_ENV=dev"]}
+      assert_received {:mix_shell, :info, ["Generated archive \"archive-0.2.0.ez\" with MIX_ENV=dev"]}
 
       # Install new version
       send self, {:mix_shell_input, :yes?, true}

--- a/lib/mix/test/mix/tasks/deps.git_test.exs
+++ b/lib/mix/test/mix/tasks/deps.git_test.exs
@@ -160,7 +160,7 @@ defmodule Mix.Tasks.DepsGitTest do
 
       # mix deps.compile is required...
       Mix.Tasks.Deps.run []
-      msg = "  the dependency build is outdated, please run `mix deps.compile`"
+      msg = "  the dependency build is outdated, please run \"mix deps.compile\""
       assert_received {:mix_shell, :info, [^msg]}
 
       # But also ran automatically
@@ -292,7 +292,7 @@ defmodule Mix.Tasks.DepsGitTest do
       exception = assert_raise Mix.Error, fn ->
         Mix.Tasks.Deps.Get.run []
       end
-      assert Exception.message(exception) =~ "Command `git clone"
+      assert Exception.message(exception) =~ "Command \"git clone"
     end
   end
 

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.DepsTest do
       Mix.Tasks.Deps.run []
 
       assert_received {:mix_shell, :info, ["* ok (https://github.com/elixir-lang/ok.git)"]}
-      assert_received {:mix_shell, :info, ["  the dependency is not available, run `mix deps.get`"]}
+      assert_received {:mix_shell, :info, ["  the dependency is not available, run \"mix deps.get\""]}
       assert_received {:mix_shell, :info, ["* invalidvsn (deps/invalidvsn)"]}
       assert_received {:mix_shell, :info, ["  the app file contains an invalid version: :ok"]}
       assert_received {:mix_shell, :info, ["* invalidapp (deps/invalidapp)"]}
@@ -88,7 +88,7 @@ defmodule Mix.Tasks.DepsTest do
 
       Mix.Tasks.Deps.Compile.run [:ok]
 
-      msg = "warning: the dependency ok requires Elixir \"~> 0.1.0\" " <>
+      msg = "warning: the dependency :ok requires Elixir \"~> 0.1.0\" " <>
             "but you are running on v#{System.version}"
       assert_received {:mix_shell, :error, [^msg]}
 
@@ -111,7 +111,7 @@ defmodule Mix.Tasks.DepsTest do
 
       assert_received {:mix_shell, :info, ["* ok (https://github.com/elixir-lang/ok.git)"]}
       assert_received {:mix_shell, :info, ["  locked at abcdefg"]}
-      assert_received {:mix_shell, :info, ["  lock mismatch: the dependency is out of date (run `mix deps.get` to fetch locked version)"]}
+      assert_received {:mix_shell, :info, ["  lock mismatch: the dependency is out of date (run \"mix deps.get\" to fetch locked version)"]}
 
       Mix.Dep.Lock.write %{ok: {:git, "git://github.com/elixir-lang/another.git", "abcdefghi", []}}
       Mix.Tasks.Deps.run []
@@ -140,7 +140,7 @@ defmodule Mix.Tasks.DepsTest do
       end
 
       assert_received {:mix_shell, :error, ["* ok (https://github.com/elixir-lang/ok.git)"]}
-      assert_received {:mix_shell, :error, ["  the dependency is not available, run `mix deps.get`"]}
+      assert_received {:mix_shell, :error, ["  the dependency is not available, run \"mix deps.get\""]}
       assert_received {:mix_shell, :error, ["* invalidvsn (deps/invalidvsn)"]}
       assert_received {:mix_shell, :error, ["  the app file contains an invalid version: :ok"]}
       assert_received {:mix_shell, :error, ["* invalidapp (deps/invalidapp)"]}
@@ -467,7 +467,7 @@ defmodule Mix.Tasks.DepsTest do
       File.write!("_build/dev/lib/ok/.compile.lock", ~s({v1, <<\"the_future\">>, scm}.))
       Mix.Task.clear
 
-      msg = "  the dependency was built with an out-of-date Elixir version, run `mix deps.compile`"
+      msg = "  the dependency was built with an out-of-date Elixir version, run \"mix deps.compile\""
 
       Mix.Tasks.Deps.run []
       assert_received {:mix_shell, :info, [^msg]}
@@ -491,7 +491,7 @@ defmodule Mix.Tasks.DepsTest do
       File.write!("_build/dev/lib/ok/.compile.lock", ~s({v1, <<"#{System.version}">>, scm}.))
       Mix.Task.clear
 
-      msg = "  the dependency was built with another SCM, run `mix deps.compile`"
+      msg = "  the dependency was built with another SCM, run \"mix deps.compile\""
 
       Mix.Tasks.Deps.run []
       assert_received {:mix_shell, :info, [^msg]}
@@ -575,7 +575,7 @@ defmodule Mix.Tasks.DepsTest do
       File.mkdir_p!("_build/dev/lib/git_repo")
       File.mkdir_p!("_build/test/lib/git_repo")
 
-      message = "mix deps.clean expects dependencies as arguments or " <>
+      message = "\"mix deps.clean\" expects dependencies as arguments or " <>
                 "a flag indicating which dependencies to clean. " <>
                 "The --all option will clean all dependencies while " <>
                 "the --unused option cleans unused dependencies"

--- a/lib/mix/test/mix/tasks/help_test.exs
+++ b/lib/mix/test/mix/tasks/help_test.exs
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.HelpTest do
 
       {_, _, [output]} =
         assert_received {:mix_shell, :info, [_]}
-      assert output =~ ~r/^mix\s+# Run the default task \(current: mix run\)/m
+      assert output =~ ~r/^mix\s+# Runs the default task \(current: \"mix run\"\)/m
     end
   end
 
@@ -65,7 +65,7 @@ defmodule Mix.Tasks.HelpTest do
   end
 
   test "help --search without pattern" do
-    assert_raise Mix.Error, "Unexpected arguments, expected `mix help --search PATTERN`", fn ->
+    assert_raise Mix.Error, "Unexpected arguments, expected \"mix help --search PATTERN\"", fn ->
       Mix.Tasks.Help.run ["--search"]
     end
   end
@@ -82,7 +82,7 @@ defmodule Mix.Tasks.HelpTest do
   end
 
   test "bad arguments" do
-    assert_raise Mix.Error, "Unexpected arguments, expected `mix help` or `mix help TASK`", fn ->
+    assert_raise Mix.Error, "Unexpected arguments, expected \"mix help\" or \"mix help TASK\"", fn ->
       Mix.Tasks.Help.run ["foo", "bar"]
     end
   end

--- a/lib/mix/test/mix/tasks/iex_test.exs
+++ b/lib/mix/test/mix/tasks/iex_test.exs
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.IexTest do
 
   test "raises error message about correct usage" do
     in_fixture "no_mixfile", fn ->
-      msg = "To use IEx with Mix, please run: iex -S mix"
+      msg = "To use IEx with Mix, please run: \"iex -S mix\""
       assert_raise Mix.Error, msg, fn ->
         Mix.Tasks.Iex.run []
       end

--- a/lib/mix/test/mix/tasks/new_test.exs
+++ b/lib/mix/test/mix/tasks/new_test.exs
@@ -147,7 +147,7 @@ defmodule Mix.Tasks.NewTest do
     end
 
     in_tmp "new without a specified path", fn ->
-      assert_raise Mix.Error, "Expected PATH to be given, please use `mix new PATH`", fn ->
+      assert_raise Mix.Error, "Expected PATH to be given, please use \"mix new PATH\"", fn ->
         Mix.Tasks.New.run []
       end
     end

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -137,7 +137,7 @@ defmodule MixTest.Case do
   end
 end
 
-## Set up mix home with rebar
+## Set up Mix home with rebar
 
 home = MixTest.Case.tmp_path(".mix")
 File.mkdir_p!(home)
@@ -152,7 +152,7 @@ dest = MixTest.Case.tmp_path("rebar_dep")
 File.mkdir_p!(dest)
 File.cp_r!(source, dest)
 
-## Generate git repo fixtures
+## Generate Git repo fixtures
 
 # Git repo
 target = Path.expand("fixtures/git_repo", __DIR__)
@@ -204,7 +204,7 @@ unless File.dir?(target) do
   end
 end
 
-# Deps on git repo
+# Deps on Git repo
 target = Path.expand("fixtures/deps_on_git_repo", __DIR__)
 
 unless File.dir?(target) do

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-%% Using elixir as a rebar dependency
+%% Using Elixir as a rebar dependency
 
 %% This configuration file only exists so Elixir can be used
 %% as a rebar dependency, the same happens for the file
@@ -14,7 +14,7 @@
 %%   ]}.
 %%
 
-%% Run make as the proper compilation step
+%% Run "make" as the proper compilation step
 {post_hooks, [{compile, "make compile"}]}.
 
 %% This prevents rebar_elixir_plugin from recompiling Elixir


### PR DESCRIPTION
Properly use Title Case for Mix, or backticks when it's refering
to the `mix` command

Since rebar name is in lowercase, I only added backticks when it was
refering to the `rebar` command itself.

I consider commands to be surrounded by backticks when they are used as nouns,
such as, or literally refered as commands,
but not when refered as adjectives, such as "a rebar dependency", "a make project"

I have ignored the test names when doing these changes.

Also fixes for other commands such as: `git`, `make`

when given in message such as exceptions, I only surround commands in backticks,
and arguments/values in single-quotes.

The following commands were used to find mentions on running a command that is not using backticks:

    commands="elixir|elixirc|mix|iex|ex_doc|git|make|rebar|dialyzer|erl|rm|cd|mkdir|rmdir|ln|ls|pwd"
    actions="runs?|running|executes?|executing|types?|typing|enters?|entering|calls?|calling"
    ag '(?i)('${actions}')(?-i)\b[^`\r\n/]+[\ \t]+(?!(`))('${commands}')'
    ag '(?-i)\b(?!(`))('${commands}')[\ \t]+[^`\r\n/]+(?i)(commands?)'

and this one to find where the commands were mentioned

    #commands="erlang|elixir|eex|iex|ex_unit|ex_doc|logger|elixirc|git|make|rebar|dialyzer|erl|rm|cd|mkdir|rmdir|ln|ls|pwd"
    commands="mix|elixirc|git|make|rebar|dialyzer|erl|rm|cd|mkdir|rmdir|ln|ls|pwd"
    ag -s '(?<!(\`))(?<!(\.))(?<!(/))(?<!(:))(?<!(_))\b('${commands}')\b(?!(:))(?!(\?))(?!(_))(?!(-))(?!(\.))(?!(\`))(?!(/))(?!(>))' \
    --ignore "*.erl" --ignore "*.yrl" --ignore "*.src"