### PR TITLE
Raise right away for Mix tasks with slashes

### DIFF
--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -50,6 +50,7 @@ defmodule Mix.CLI do
 
   defp run_task(name, args) do
     try do
+      ensure_no_slashes(name)
       Mix.Task.run "loadconfig"
       Mix.Task.run name, args
     rescue
@@ -72,6 +73,12 @@ defmodule Mix.CLI do
     do: :ok
   defp ensure_hex(_task),
     do: Mix.Hex.ensure_updated?()
+
+  defp ensure_no_slashes(task) do
+    if String.contains?(task, "/") do
+      Mix.raise Mix.NoTaskError, task: task
+    end
+  end
 
   defp change_env(task) do
     if is_nil(System.get_env("MIX_ENV")) &&

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -60,6 +60,13 @@ defmodule Mix.CLITest do
     end
   end
 
+  test "tasks with slashes in them raise a NoTaskError right away" do
+    in_fixture "no_mixfile", fn ->
+      contents = mix ~w[my/task]
+      assert contents =~ "** (Mix) The task my/task could not be found"
+    end
+  end
+
   test "--help smoke test" do
     in_fixture "no_mixfile", fn ->
       output = mix ~w[--help]


### PR DESCRIPTION
This should be a fix for #3715, but I have a feeling that building the exception with `Mix.NoTaskError.exception/2` is a hack at best. If I do `Mix.raise Mix.NoTaskError, task: task`, however, the error message turns out to be

```
** (Mix.NoTaskError) ...
```

instead of

```
** (Mix) ...
```

which is what something like `mix non_existing_task` raises.