### PR TITLE
Added assert_same_elements to ExUnit.Assertions

### DIFF
--- a/lib/ex_unit/examples/one_of_each.exs
+++ b/lib/ex_unit/examples/one_of_each.exs
@@ -122,6 +122,10 @@ defmodule TestOneOfEach do
     end
   end
 
+  test "26. assert two Enumerables have the same elements" do
+    assert_same_elements [1, 2], [1, 2, 3]
+  end
+
   defp blows_up do
     ignite(0) + 1
   end

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -602,6 +602,42 @@ defmodule ExUnit.Assertions do
   end
 
   @doc """
+  Asserts that `expected` and `actual` have the same elements, in any order.
+
+  The `expected` and `actual` can be any `Enumerable` collection.  
+  This function ignores the collection type.  For example, you can compare
+  a List and a Map.  
+
+  ## Examples
+
+      assert_same_elements [1, 2], [2, 1]
+
+  """
+  def assert_same_elements(expected, actual, message \\ nil) do
+    expected = Enum.to_list(expected)
+    actual = Enum.to_list(actual)
+
+    same_elements = true
+    default_msg = "Expected #{inspect actual} to have the same elements as #{inspect expected}"
+
+    missing = expected -- actual
+    if Enum.any?(missing) do
+      same_elements = false
+      default_msg = default_msg <>
+        "\nMissing: #{inspect missing}"
+    end
+
+    extra = actual -- expected
+    if Enum.any?(extra) do
+      same_elements = false
+      default_msg = default_msg <>
+        "\nExtra: #{inspect extra}"
+    end
+
+    assert same_elements, (message || default_msg)
+  end
+
+  @doc """
   Fails with a message.
 
   ## Examples

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -410,6 +410,42 @@ defmodule ExUnit.AssertionsTest do
       "test message (difference between 10 and 11 is less than 2)" = error.message
   end
 
+  test "assert_same_elements success" do
+    true = assert_same_elements([1,2], [2,1])
+  end
+
+  test "assert_same_elements failure with missing elements" do
+    "This should never be tested" = assert_same_elements([1,2], [1])
+  rescue
+    error in [ExUnit.AssertionError] ->
+      "Expected [1] to have the same elements as [1, 2]" <>
+        "\nMissing: [2]" = error.message
+  end
+
+  test "assert_same_elements failure with extra elements" do
+    "This should never be tested" = assert_same_elements([1,2], [1,2,3])
+  rescue
+    error in [ExUnit.AssertionError] ->
+      "Expected [1, 2, 3] to have the same elements as [1, 2]" <>
+        "\nExtra: [3]" = error.message
+  end
+
+  test "assert_same_elements failure with missing and extra elements" do
+    "This should never be tested" = assert_same_elements([1,2], [1,3])
+  rescue
+    error in [ExUnit.AssertionError] ->
+      "Expected [1, 3] to have the same elements as [1, 2]" <>
+        "\nMissing: [2]" <>
+        "\nExtra: [3]" = error.message
+  end
+
+  test "assert_same_elements failure with a message" do
+    "This should never be tested" = assert_same_elements([1,2], [1], "a message")
+  rescue
+    error in [ExUnit.AssertionError] ->
+      "a message" = error.message
+  end
+
   test "catch_throw with no throw" do
     catch_throw(1)
   rescue


### PR DESCRIPTION
This function provides an order-independent comparison of two Enumerables.  