### PR TITLE
Mix.Dep: show instructions on :nolock and :lockoutdated

### DIFF
--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -167,10 +167,10 @@ defmodule Mix.Dep do
     do: "lock mismatch: the dependency is out of date (run \"mix deps.get\" to fetch locked version)"
 
   def format_status(%Mix.Dep{status: :lockoutdated}),
-    do: "lock outdated: the lock is outdated compared to the options in your mixfile"
+    do: "lock outdated: the lock is outdated compared to the options in your mixfile (run \"mix deps.get\" to fetch locked version)"
 
   def format_status(%Mix.Dep{status: :nolock}),
-    do: "the dependency is not locked"
+    do: "the dependency is not locked (run \"mix deps.get\" to generate \"mix.lock\" file)"
 
   def format_status(%Mix.Dep{status: :compile}),
     do: "the dependency build is outdated, please run \"#{mix_env_var}mix deps.compile\""

--- a/lib/mix/test/mix/tasks/deps.git_test.exs
+++ b/lib/mix/test/mix/tasks/deps.git_test.exs
@@ -268,7 +268,7 @@ defmodule Mix.Tasks.DepsGitTest do
       refresh deps: [{:git_repo, "0.1.0", git: fixture_path("git_repo"), ref: last}]
 
       Mix.Tasks.Deps.run []
-      msg = "  lock outdated: the lock is outdated compared to the options in your mixfile"
+      msg = "  lock outdated: the lock is outdated compared to the options in your mixfile (run \"mix deps.get\" to fetch locked version)"
       assert_received {:mix_shell, :info, [^msg]}
 
       # Check an update was triggered

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -104,7 +104,7 @@ defmodule Mix.Tasks.DepsTest do
 
       Mix.Tasks.Deps.run []
       assert_received {:mix_shell, :info, ["* ok (https://github.com/elixir-lang/ok.git)"]}
-      assert_received {:mix_shell, :info, ["  the dependency is not locked"]}
+      assert_received {:mix_shell, :info, ["  the dependency is not locked (run \"mix deps.get\" to generate \"mix.lock\" file)"]}
 
       Mix.Dep.Lock.write %{ok: {:git, "git://github.com/elixir-lang/ok.git", "abcdefghi", []}}
       Mix.Tasks.Deps.run []
@@ -117,7 +117,7 @@ defmodule Mix.Tasks.DepsTest do
       Mix.Tasks.Deps.run []
 
       assert_received {:mix_shell, :info, ["* ok (https://github.com/elixir-lang/ok.git)"]}
-      assert_received {:mix_shell, :info, ["  lock outdated: the lock is outdated compared to the options in your mixfile"]}
+      assert_received {:mix_shell, :info, ["  lock outdated: the lock is outdated compared to the options in your mixfile (run \"mix deps.get\" to fetch locked version)"]}
     end
   end
 


### PR DESCRIPTION
Fixes additional issue found in https://github.com/elixir-lang/elixir/issues/3038#issuecomment-139882118