### PR TITLE
Doc: add examples using alternate capture/replace syntax, in replace/4

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -456,6 +456,9 @@ defmodule Regex do
       iex> Regex.replace(~r/a(b|d)c/, "abcadc", "[\\1]")
       "[b][d]"
 
+      iex> Regex.replace(~r/\.(\d)$/, "500.5", ".\\g{1}0")
+      "500.50"
+
       iex> Regex.replace(~r/a(b|d)c/, "abcadc", fn _, x -> "[#{x}]" end)
       "[b][d]"
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -703,7 +703,7 @@ defmodule String do
   `\g{N}` in the `replacement` string to access a specific capture in the
   regex:
 
-      iex> String.replace("a,b,c", ~r/,(.)/, ",\\1\\1")
+      iex> String.replace("a,b,c", ~r/,(.)/, ",\\1\\g{1}")
       "a,bb,cc"
 
   Notice we had to escape the escape character `\`. By giving `\0`,


### PR DESCRIPTION
While the docs do in fact explain that you can use \\g{n}, there is no examples using it. If you are like me, who starts off with the examples, this might easily be missed, so i added a example in Regex.replace/4, and modified one in String.replace/4. :smiley: 

Hopefully this is useful. 

