### PR TITLE
Module.__info__ : correct links

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -325,10 +325,9 @@ defmodule Module do
     * `:module`     - module name (`Module == Module.__info__(:module)`)
 
   In addition to the above, you may also pass to `__info__/1` any atom supported
-  by [`:erlang.module_info/0`](http://www.erlang.org/doc/man/erlang.html#module_info.html) which also gets defined for each compiled
-  module.
+  by `:erlang.module_info/0` which also gets defined for each compiled module.
 
-  For more information, see [Modules – Erlang Reference Manual](http://www.erlang.org/doc/reference_manual/modules.html).
+  For a list of supported attributes and more information, see [Modules – Erlang Reference Manual](http://www.erlang.org/doc/reference_manual/modules.html#id77056).
   """
   def __info__(kind)
 


### PR DESCRIPTION
The link :erlang.module_info/0 doens't have an entry in the erlang docs.
And I found the correct link to the reference manual, (the previous one was removed bc it
was outdated)