### PR TITLE
Add Mix recompilation from IEx

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -51,7 +51,6 @@ defmodule IEx.Helpers do
   To learn more about IEx as a whole, just type `h(IEx)`.
   """
 
-  require Logger
   import IEx, only: [dont_display_result: 0]
 
   @doc """
@@ -79,11 +78,12 @@ defmodule IEx.Helpers do
     if mix_started? do
       config = Mix.Project.config
       reenable_tasks(config)
-      stop_apps(config)
+      apps = stop_apps(config)
       Mix.Task.run("app.start")
+      {:restarted, apps}
     else
       IO.puts IEx.color(:eval_error, "Mix is not running. Please start IEx with: iex -S mix")
-      dont_display_result
+      :error
     end
   end
 
@@ -109,7 +109,8 @@ defmodule IEx.Helpers do
         true ->
           []
       end
-    Enum.each apps, &Application.stop/1
+    apps |> Enum.reverse |> Enum.each(&Application.stop/1)
+    apps
   end
 
   @doc """


### PR DESCRIPTION
Because this is asked in the mailing list every other week,
I have decided to take a stab at it.

I went with the more conservative approach of always restarting
the application so users don't see errors from their processes.

There are a bunch of disclaimers to consider which have been
documented. For this reason, the helper has been marked as
experimental so we see how often folks will run into corner cases.

@ericmj, @fishcakez and @alco: careful review and feedback is
appreciated. I was also torn between calling it restart and recompile
but went with the latter as the need for restarting is a side-effect
of compilation.

Thoughts?