### PR TITLE
Code.get_docs/2: check for valid kinds in public function + set :all as default value for kind

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -588,7 +588,10 @@ defmodule Code do
     * `:type_docs` - list of all docstrings attached to
       `@type` callbacks using the `@typedoc` attribute
 
-    * `:all` - a keyword list with both `:docs` and `:moduledoc`
+    * `:all` - a keyword list with `:docs` and `:moduledoc`, `:callback_docs`,
+      and `:type_docs`.
+
+  If the module cannot be found, it returns `nil`.
 
   ## Examples
 
@@ -598,8 +601,14 @@ defmodule Code do
       iex> String.split(text, "\n") |> Enum.at(0)
       "Converts an atom to a char list."
 
+      # Module doesn't exist
+      iex> docs = Code.get_docs(ModuleNotGood, :all)
+      nil
+
   """
-  def get_docs(module, kind) when is_atom(module) do
+  @doc_kinds [:docs, :moduledoc, :callback_docs, :type_docs, :all]
+
+  def get_docs(module, kind) when is_atom(module) and kind in @doc_kinds do
     case :code.get_object_code(module) do
       {_module, bin, _beam_path} ->
         do_get_docs(bin, kind)
@@ -608,7 +617,7 @@ defmodule Code do
     end
   end
 
-  def get_docs(binpath, kind) when is_binary(binpath) do
+  def get_docs(binpath, kind) when is_binary(binpath) and kind in @doc_kinds do
     do_get_docs(String.to_char_list(binpath), kind)
   end
 
@@ -629,10 +638,8 @@ defmodule Code do
   # unsupported chunk version
   defp lookup_docs(_, _), do: nil
 
-  @doc_sections [:docs, :moduledoc, :callback_docs, :type_docs]
-
   defp do_lookup_docs(docs, :all), do: docs
-  defp do_lookup_docs(docs, kind) when kind in @doc_sections,
+  defp do_lookup_docs(docs, kind),
     do: Keyword.get(docs, kind)
 
   ## Helpers


### PR DESCRIPTION
I was getting a really long cyptic message showing the whole list of docs, but for a private function,

```
** (FunctionClauseError) no function clause matching in Code.do_lookup_docs/2
    (elixir) lib/code.ex:634: Code.do_lookup_docs([docs: [{{:%, 2}, 105, :defmacro, [{:struct, [], nil}, {:map, [], nil}], "Creates a struct.\n\nA struct is a tagged map that allows developers to provide\ndefault values for keys, tags to be used in polymorphic\ndispatches and compile time assertions.\n\nTo define a 
```

It also add :all as the default value for kind