### PR TITLE
Warn when test files have incorrect extension

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -229,7 +229,16 @@ defmodule Mix.Tasks.Test do
   end
 
   defp parse_files([], test_paths) do
+    warn_about_incorrect_extensions_in(test_paths)
+
     test_paths
+  end
+
+  defp warn_about_incorrect_extensions_in(test_paths) do
+    for file <- Mix.Utils.extract_files(test_paths, "*_test.ex") do
+      IO.puts "Warning: #{file} has incorrect extension and won't be run. " <>
+        "It should end in \"_test.exs\""
+    end
   end
 
   defp parse_files([single_file], _test_paths) do


### PR DESCRIPTION
[ExUnit: Raise or warn if there are files in the test directory that end in `_test.ex` - in Google groups](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/elixir-lang-core/yfWemHZfiq0/Dj5NBuILDAAJ)

I believe this will work, but I couldn't figure out how to test it. It seems that `make test` does not use the mix task. I'm opening this up and hoping someone could offer some guidance on how to test this. I can finish it up tomorrow once I know how to check if it's working :)