### PR TITLE
Add IO.ANSI.clear_line

### DIFF
--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -131,6 +131,9 @@ defmodule IO.ANSI do
 
   @doc "Clears screen"
   defsequence :clear, "2", "J"
+  
+  @doc "Clears line"
+  defsequence :clear_line, "2", "K"
 
   defp format_sequence(other) do
     raise ArgumentError, "invalid ANSI sequence specification: #{other}"


### PR DESCRIPTION
My use case: printing a progress bar type thing where sometimes, the just-printed line is shorter than the previous one. Then you first need to clear out the line, or the old line shows through.

Worked around this with `"\e[2K"` but it would be nice to have this built in.

http://ascii-table.com/ansi-escape-sequences-vt-100.php