### PR TITLE
assert_raise: document that message can be regex

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -376,12 +376,17 @@ defmodule ExUnit.Assertions do
 
   @doc """
   Asserts the `exception` is raised during `function` execution with
-  the `expected_message`. Returns the rescued exception, fails otherwise.
+  the expected `message`, which can be a `Regex` or an exact `String`.
+  Returns the rescued exception, fails otherwise.
 
   ## Examples
 
       assert_raise ArithmeticError, "bad argument in arithmetic expression", fn ->
         1 + "test"
+      end
+      
+      assert_raise RuntimeError, ~r/^Today's lucky number is 0\.\d+!$/, fn ->
+        raise "Today's lucky number is #{:random.uniform}!"
       end
   """
   def assert_raise(exception, message, function) when is_function(function) do


### PR DESCRIPTION
This patch documents the fact that assert_raise()
can also accept a Regex as the expected message.