### PR TITLE
Raise `CompileError` in case of duplicated clauses given for `try` and `receive`

### DIFF
--- a/lib/elixir/src/elixir_exp_clauses.erl
+++ b/lib/elixir/src/elixir_exp_clauses.erl
@@ -105,7 +105,7 @@ do_receive(Meta, {Key, _}, _Acc, E) ->
 'try'(Meta, [{do, _}], E) ->
   compile_error(Meta, ?m(E, file), "missing catch/rescue/after/else keyword in try");
 'try'(Meta, KV, E) when not is_list(KV) ->
-  elixir_errors:compile_error(Meta, ?m(E, file), "invalid arguments for try");
+  compile_error(Meta, ?m(E, file), "invalid arguments for try");
 'try'(Meta, KV, E) ->
   {lists:map(fun(X) -> do_try(Meta, X, E) end, KV), E}.
 

--- a/lib/elixir/src/elixir_exp_clauses.erl
+++ b/lib/elixir/src/elixir_exp_clauses.erl
@@ -47,6 +47,9 @@ guard(Other, E) ->
 'case'(Meta, KV, E) when not is_list(KV) ->
   compile_error(Meta, ?m(E, file), "invalid arguments for case");
 'case'(Meta, KV, E) ->
+  ok = assert_at_most_once('do', KV, 0, fun(Kind) ->
+    compile_error(Meta, ?m(E, file), "duplicated ~ts clauses given for case", [Kind])
+  end),
   EE = E#{export_vars := []},
   {EClauses, EVars} = lists:mapfoldl(fun(X, Acc) -> do_case(Meta, X, Acc, EE) end, [], KV),
   {EClauses, elixir_env:mergev(EVars, E)}.

--- a/lib/elixir/src/elixir_exp_clauses.erl
+++ b/lib/elixir/src/elixir_exp_clauses.erl
@@ -64,6 +64,9 @@ do_case(Meta, {Key, _}, _Acc, E) ->
 'cond'(Meta, KV, E) when not is_list(KV) ->
   compile_error(Meta, ?m(E, file), "invalid arguments for cond");
 'cond'(Meta, KV, E) ->
+  ok = assert_at_most_once('do', KV, 0, fun(Kind) ->
+    compile_error(Meta, ?m(E, file), "duplicated ~ts clauses given for cond", [Kind])
+  end),
   EE = E#{export_vars := []},
   {EClauses, EVars} = lists:mapfoldl(fun(X, Acc) -> do_cond(Meta, X, Acc, EE) end, [], KV),
   {EClauses, elixir_env:mergev(EVars, E)}.

--- a/lib/elixir/src/elixir_exp_clauses.erl
+++ b/lib/elixir/src/elixir_exp_clauses.erl
@@ -81,6 +81,11 @@ do_cond(Meta, {Key, _}, _Acc, E) ->
 'receive'(Meta, KV, E) when not is_list(KV) ->
   compile_error(Meta, ?m(E, file), "invalid arguments for receive");
 'receive'(Meta, KV, E) ->
+  RaiseError = fun(Kind) ->
+    compile_error(Meta, ?m(E, file), "duplicated ~ts clauses given for receive", [Kind])
+  end,
+  ok = assert_at_most_once('do', KV, 0, RaiseError),
+  ok = assert_at_most_once('after', KV, 0, RaiseError),
   EE = E#{export_vars := []},
   {EClauses, EVars} = lists:mapfoldl(fun(X, Acc) -> do_receive(Meta, X, Acc, EE) end, [], KV),
   {EClauses, elixir_env:mergev(EVars, E)}.

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -359,6 +359,12 @@ defmodule Kernel.ExpansionTest do
            quote do: (case w() do x -> x = x; y -> y = y end; :erlang.+(x, y))
   end
 
+  test "case: expects at most one do" do
+    assert_raise CompileError, ~r"duplicated do clauses given for case", fn ->
+      expand(quote(do: (case e, do: (x -> x), do: (y -> y))))
+    end
+  end
+
   ## Receive
 
   test "receive: expands each clause" do

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -326,6 +326,12 @@ defmodule Kernel.ExpansionTest do
            quote do: (cond do 1 -> x = 1; 2 -> y = 2 end; :erlang.+(x, y))
   end
 
+  test "cond: expects at most one do" do
+    assert_raise CompileError, ~r"duplicated do clauses given for cond", fn ->
+      expand(quote(do: (cond do: (x -> x), do: (y -> y))))
+    end
+  end
+
   ## Case
 
   test "case: expands each clause" do

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -413,6 +413,28 @@ defmodule Kernel.ExpansionTest do
     end
   end
 
+  test "try: expects at most one clause" do
+    assert_raise CompileError, ~r"duplicated do clauses given for try", fn ->
+      expand(quote(do: try(do: e, do: f)))
+    end
+
+    assert_raise CompileError, ~r"duplicated rescue clauses given for try", fn ->
+      expand(quote(do: (try do e rescue x -> x rescue y -> y end)))
+    end
+
+    assert_raise CompileError, ~r"duplicated after clauses given for try", fn ->
+      expand(quote(do: (try do e after x = y after x = y end)))
+    end
+
+    assert_raise CompileError, ~r"duplicated else clauses given for try", fn ->
+      expand(quote(do: (try do e else x -> x else y -> y end)))
+    end
+
+    assert_raise CompileError, ~r"duplicated catch clauses given for try", fn ->
+      expand(quote(do: (try do e catch x -> x catch y -> y end)))
+    end
+  end
+
   ## Binaries
 
   test "bitstrings: size * unit" do

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -385,6 +385,16 @@ defmodule Kernel.ExpansionTest do
            quote do: (receive do x -> x = x after y() -> y(); w = y() end; :erlang.+(x, w))
   end
 
+  test "receive: expects at most one clause" do
+    assert_raise CompileError, ~r"duplicated do clauses given for receive", fn ->
+      expand(quote(do: (receive do: (x -> x), do: (y -> y))))
+    end
+
+    assert_raise CompileError, ~r"duplicated after clauses given for receive", fn ->
+      expand(quote(do: (receive do x -> x after y -> y after z -> z end)))
+    end
+  end
+
   ## Try
 
   test "try: expands catch" do
@@ -415,7 +425,7 @@ defmodule Kernel.ExpansionTest do
 
   test "try: expects at most one clause" do
     assert_raise CompileError, ~r"duplicated do clauses given for try", fn ->
-      expand(quote(do: try(do: e, do: f)))
+      expand(quote(do: (try do: e, do: f)))
     end
 
     assert_raise CompileError, ~r"duplicated rescue clauses given for try", fn ->


### PR DESCRIPTION
There are good showcases for it:

```elixir
defmodule Qwe do
  def main(val) do
    try do
      1 / val
    rescue
      ArgumentError ->
        24
    rescue
      ArithmeticError ->
        42
    after
      IO.puts "1"
    after
      IO.puts "2"
    end
  end
end

defmodule Asd do
  def main() do
    receive do
      any -> any
    after 50 ->
      24
    after 0 ->
      42
    end
  end
end
```

Prior this patch duplicated clauses are simply ignored.
There is no practical reason to support this cases and thus `CompileError` will be raised.