### PR TITLE
String.duplicate/2 : make `n` default to 2

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -832,7 +832,12 @@ defmodule String do
   @doc """
   Returns a binary `subject` duplicated `n` times.
 
+  If `n` is not present, it defaults to 2.
+
   ## Examples
+
+      iex> String.duplicate("abc")
+      "abcabc"
 
       iex> String.duplicate("abc", 0)
       ""
@@ -840,12 +845,12 @@ defmodule String do
       iex> String.duplicate("abc", 1)
       "abc"
 
-      iex> String.duplicate("abc", 2)
-      "abcabc"
+      iex> String.duplicate("abc", 3)
+      "abcabcabc"
 
   """
   @spec duplicate(t, non_neg_integer) :: t
-  def duplicate(subject, n) when is_integer(n) and n >= 0 do
+  def duplicate(subject, n \\ 2) when is_integer(n) and n >= 0 do
     :binary.copy(subject, n)
   end
 


### PR DESCRIPTION
It's a bit too verbose to have to specify "2" when we just want to duplicate.

String.duplicate("some_string", 2)

http://www.merriam-webster.com/dictionary/duplicate
transitive verb
1
:  to make double or twofold
2
a :  to make a copy of <a cell duplicates itself when it divides>
b :  to produce something equal to <trying to duplicate last year's success>
c :  to do over or again often needlessly <duplicated effort>