### PR TITLE
Fix Macro.to_string/2 to print ranges

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -537,6 +537,12 @@ defmodule Macro do
     fun.(ast, "fn\n  " <> block <> "\nend")
   end
 
+  # Ranges
+  def to_string({:.., _, args} = ast, fun) do
+    range = Enum.map_join(args, "..", &to_string(&1, fun))
+    fun.(ast, range)
+  end
+
   # left -> right
   def to_string([{:->, _, _}|_] = ast, fun) do
     fun.(ast, "(" <> arrow_to_string(ast, fun, true) <> ")")

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -354,6 +354,11 @@ defmodule MacroTest do
     """
   end
 
+  test "range to string" do
+    assert Macro.to_string(quote do: (1 .. 2)) == "1..2"
+    assert Macro.to_string(quote do: unquote(-1 .. +2)) == "-1..2"
+  end
+
   test "when" do
     assert Macro.to_string(quote do: (() -> x)) == "(() -> x)"
     assert Macro.to_string(quote do: (x when y -> z)) == "(x when y -> z)"


### PR DESCRIPTION
this removes the spaces between the ranges and the periods

before:
iex> Macro.to_string(quote do: 1 .. 2 ) 
"1 .. 2"

now:
iex> Macro.to_string(quote do: 1 .. 2 ) 
"1..2"

consistent with Inspect
iex> inspect(1..2)   
"1..2"
