### PR TITLE
Fix ranges to only accept integers as first and last elements

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2442,17 +2442,35 @@ defmodule Kernel do
 
   """
   defmacro first .. last do
-    case is_float(first) or is_float(last) or
+    # require Logger
+    # Logger.debug inspect [first, last]
+    case is_tuple(first) and tuple_size(first) == 2 or
+         is_tuple(last) and tuple_size(last) == 2 or
+         is_float(first) or is_float(last) or
          is_atom(first) or is_atom(last) or
-         is_binary(first) or is_binary(last) do
+         is_binary(first) or is_binary(last) or
+         is_list(first) or is_list(last)
+         do
       true ->
-        raise ArgumentError,
-          "ranges (left .. right) expect both sides to be integers, " <>
-          "got: #{Macro.to_string({:.., [], [first, last]})}"
+        range_error(first, last)
       false ->
+        for val <- [first, last] do
+          case val do
+            {type, _, _} when type in [
+              :{}, :%{}, :.., :&, :., :fn, :__aliases__, ] ->
+              range_error(first, last)
+
+            {type, _, [number]} when type in [:-, :+] and is_float(number) ->
+              range_error(first, last)
+
+            _ ->
+              true
+          end
+        end
         {:%{}, [], [__struct__: Elixir.Range, first: first, last: last]}
     end
   end
+
 
   @doc """
   Provides a short-circuit operator that evaluates and returns
@@ -2677,7 +2695,7 @@ defmodule Kernel do
       {:%{}, [], [__struct__: Elixir.Range, first: first, last: last]} ->
         in_range(left, Macro.expand(first, __CALLER__), Macro.expand(last, __CALLER__))
       _ ->
-        raise ArgumentError, <<"invalid args for operator in, it expects a compile time list ",
+        raise ArgumentError, <<"invalid args for operator \"in\", it expects a compile time list ",
                                "or range on the right side when used in guard expressions, got: ",
                                Macro.to_string(right) :: binary>>
     end
@@ -3963,5 +3981,11 @@ defmodule Kernel do
       true  -> Macro.Env.stacktrace(env)
       false -> []
     end
+  end
+
+  defp range_error(first, last) do
+    raise ArgumentError,
+      "ranges (first .. last) expect both sides to be integers, " <>
+      "got: #{Macro.to_string({:.., [], [first, last]})}"
   end
 end

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -537,6 +537,12 @@ defmodule Macro do
     fun.(ast, "fn\n  " <> block <> "\nend")
   end
 
+  # Ranges
+  def to_string({:.., _, args} = ast, fun) do
+    range = Enum.map_join(args, "..", &to_string(&1, fun))
+    fun.(ast, range)
+  end
+
   # left -> right
   def to_string([{:->, _, _}|_] = ast, fun) do
     fun.(ast, "(" <> arrow_to_string(ast, fun, true) <> ")")

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -31,12 +31,13 @@ defmodule Range do
   @doc """
   Creates a new range.
   """
-  def new(first, last) do
+  @spec new(integer, integer) :: t
+  def new(first, last) when is_integer(first) and is_integer(last) do
     %Range{first: first, last: last}
   end
 
   @doc """
-  Returns `true` if the given argument is a range.
+  Returns `true` if the given `term` is a range.
 
   ## Examples
 
@@ -47,6 +48,12 @@ defmodule Range do
       false
 
   """
+  # @spec range?(term) :: boolean
+  @spec range?(arg) :: false when arg: %Range{first: nil, last: nil}
+  @spec range?(arg) :: true when arg: %Range{}
+  @spec range?(term) :: false 
+  def range?(term)
+  def range?(%Range{first: nil, last: nil}), do: false
   def range?(%Range{}), do: true
   def range?(_), do: false
 end
@@ -95,10 +102,14 @@ defimpl Enumerable, for: Range do
     end
   end
 
-  defp validate_range!(first, last) when is_integer(first) and is_integer(last), do: :ok
+  defp validate_range!(first, last) when is_integer(first)
+    and is_integer(last),
+    do: :ok
+
   defp validate_range!(first, last) do
     raise ArgumentError,
-          "ranges (left .. right) expect both sides to be integers, got: #{inspect first..last}"
+      "ranges (first .. last) expect both sides to be integers, " <>
+      "got: #{Macro.to_string({:.., [], [first, last]})}"
   end
 end
 

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -354,6 +354,11 @@ defmodule MacroTest do
     """
   end
 
+  test "range to string" do
+    assert Macro.to_string(quote do: (1 .. 2)) == "1..2"
+    assert Macro.to_string(quote do: unquote(-1 .. +2)) == "-1..2"
+  end
+
   test "when" do
     assert Macro.to_string(quote do: (() -> x)) == "(() -> x)"
     assert Macro.to_string(quote do: (x when y -> z)) == "(x when y -> z)"

--- a/lib/elixir/test/elixir/range_test.exs
+++ b/lib/elixir/test/elixir/range_test.exs
@@ -39,12 +39,80 @@ defmodule RangeTest do
     assert inspect(3..1) == "3..1"
   end
 
-  test "integer only" do
-    x = 1.0
-    y = 3.0
-    message = "ranges (left .. right) expect both sides to be integers, got: 1.0..3.0"
-    assert_raise ArgumentError, message, fn ->
-      Enum.map(x..y, &(&1 * 2))
+  test "assert ranges" do
+    assert 0..42  == 0..42
+    assert +0..42 == 0..42
+    assert -0..42 == 0..42
+    assert 1..42  == 1..42
+    assert +1..42 == 1..42
+    assert -1..42 == -1..42
+
+    defmodule A, do: def a, do:  1
+    assert (A.a)..42
+  end
+
+  test "raise error on invalid values" do
+    invalid_values = [
+      # atoms
+      :atom, nil, false, true,
+      # bitstrings
+      "", "bitstring",
+      # floats
+      0.0, +0.0, -0.0,
+      0.99, +0.99, -0.99,
+      1.0e3, +1.0e3, -1.0e3,
+      # tuples
+      {}, {1}, {1, 2}, {1, 2, 3},
+      # lists
+      [], [1], [1, 2, 3],
+      # maps
+      %{}, %{a: 1},
+      # charlists
+      '', 'a', 'abc',
+      # ranges
+      1..1, 2..10,
+    ]
+
+    ranges = for val <- invalid_values do
+      [{val, 42}, {42, val}, {val, val}]
+    end
+
+    require Logger
+
+    for range_set <- ranges, {first, last} <- range_set do
+      message = "ranges (first .. last) expect both sides to be integers, " <>
+        "got: #{Macro.to_string({:.., [], [first, last]})}"
+      assert_raise ArgumentError, message, fn ->
+        # Logger.debug inspect({first, last})
+        Macro.to_string(quote do: unquote(first)) <> ".." <>
+        Macro.to_string(quote do: unquote(last))
+        |> Code.eval_string
+      end
+    end
+  end
+
+  test "raise on special cases" do
+    assert_raise ArgumentError,
+      "ranges (first .. last) expect both sides to be integers, " <>
+      "got: #{Macro.to_string({:.., [], [1, 2..3]})}",
+      fn ->
+        Code.eval_string("1..2..3")
+    end
+
+    assert_raise ArgumentError, fn ->
+      Code.eval_string("42 .. File")
+    end
+
+    assert_raise ArgumentError, fn ->
+      Code.eval_string("42 .. &File.cwd/0")
+    end
+
+    assert_raise ArgumentError, fn ->
+      Code.eval_string("42 .. &(&1)")
+    end
+
+    assert_raise ArgumentError, fn ->
+      Code.eval_string("42 .. fn -> true end")
     end
   end
 end


### PR DESCRIPTION
This fixes the kernel module, when ranges are defined at compile time.
Thorough tests added

Here's a list of the tests that pass and should have failed: https://gist.github.com/eksperimental/aa7a8be5b8743a1629d3

and here's the full list of what should pass and what should not.
```elixir
## SHOULD FAIL
# atoms
:atom..42
nil..42
false..42
true..42

# bitstrings
""..42
"bitstring"..42

# floats
0.0..42
+0.0..42
-0.0..42
0.99..42
+0.99..42
-0.99..42
1.0e3..42
+1.0e3..42
-1.0e3..42

# tuples
{}..42
{1}..42
{1, 2}..42
{1, 2, 3}..42

# lists
[]..42
[1]..42
[1, 2, 3]..42

# maps
%{}..42
%{a: 1}..42

# charlists
''..42
'a'..42
'abc'..42

# ranges
1..1..42
1..-1..42

# functions
42 .. File
42 .. &File.cwd/0
42 .. &(&1)
42 .. fn -> true end


## SHOULD PASS
0..42
+0..42
-0..42
+1..42
-1..42
0..42
+0..42
-0..42
99..42
+99..42
-99..42
```

relevant discussion https://github.com/elixir-lang/elixir/commit/b205b0605bc4f353e3aa595fb1244c01ac9185a6#commitcomment-13454486