### PR TITLE
Clarify instructions for building the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,16 @@ If you have the correct version and tests still fail, feel free to
 
 Building the documentation requires
 [ExDoc](https://github.com/elixir-lang/ex_doc) to be installed and built
-in the same containing folder as Elixir.
+alongside Elixir.
 
 ```sh
-# After cloning and compiling Elixir
+# After cloning and compiling Elixir, in its parent directory:
 git clone git://github.com/elixir-lang/ex_doc.git
 cd ex_doc && ../elixir/bin/mix do deps.get, compile
 cd ../elixir && make docs
 ```
+
+This will produce documentation sets for `elixir`, `mix`, etc., under the `doc` directory.
 
 ## Contributing
 


### PR DESCRIPTION
This just tripped me up.  If you follow the instructions above for building elixir itself, you're already *in* the elixir directory, so ex_doc gets cloned inside it, which arguably _is_ what "containing folder" means... but then the paths don't work.

Looks like ex_doc needs to be alongside / in a sibling folder / to have the same parent, for it to work.

Also mention where to look for the results.