### PR TITLE
removed obsolete type option from the GenEvent handler type

### DIFF
--- a/lib/elixir/lib/gen_event.ex
+++ b/lib/elixir/lib/gen_event.ex
@@ -290,7 +290,7 @@ defmodule GenEvent do
   @type manager :: pid | name | {atom, node}
 
   @typedoc "Supported values for new handlers"
-  @type handler :: atom | {atom, term} | {pid, reference}
+  @type handler :: atom | {atom, term}
 
   @doc false
   defmacro __using__(_) do


### PR DESCRIPTION
I think as the documentation is generated from the type spec that this is the only reference that needs removing