### PR TITLE
Enum: several fixes

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3,14 +3,14 @@ defprotocol Enumerable do
   Enumerable protocol used by `Enum` and `Stream` modules.
 
   When you invoke a function in the `Enum` module, the first argument
-  is usually a collection that must implement this protocol. For example,
-  the expression
+  is usually a collection that must implement this protocol.
+  For example, the expression:
 
       Enum.map([1, 2, 3], &(&1 * 2))
 
   invokes underneath `Enumerable.reduce/3` to perform the reducing
   operation that builds a mapped list by calling the mapping function
-  `&(&1 * 2)` on every element in the collection and cons'ing the
+  `&(&1 * 2)` on every element in the collection and consuming the
   element with an accumulated list.
 
   Internally, `Enum.map/2` is implemented as follows:
@@ -20,18 +20,18 @@ defprotocol Enumerable do
         Enumerable.reduce(enum, {:cont, []}, reducer) |> elem(1) |> :lists.reverse()
       end
 
-  Notice the user given function is wrapped into a `reducer` function.
-  The `reducer` function must return a tagged tuple after each step,
-  as described in the `acc/0` type.
+  Notice the user given function is wrapped into a `t:reducer/0` function.
+  The `t:reducer/0` function must return a tagged tuple after each step,
+  as described in the `t:acc/0` type.
 
   The reason the accumulator requires a tagged tuple is to allow the
-  reducer function to communicate to the underlying enumerable the end
-  of enumeration, allowing any open resource to be properly closed. It
-  also allows suspension of the enumeration, which is useful when
+  `t:reducer/0` function to communicate to the underlying enumerable the
+  end of enumeration, allowing any open resource to be properly closed.
+  It also allows suspension of the enumeration, which is useful when
   interleaving between many enumerables is required (as in zip).
 
   Finally, `Enumerable.reduce/3` will return another tagged tuple,
-  as represented by the `result/0` type.
+  as represented by the `t:result/0` type.
   """
 
   @typedoc """
@@ -44,10 +44,10 @@ defprotocol Enumerable do
     * `:suspend` - the enumeration should be suspended immediately
 
   Depending on the accumulator value, the result returned by
-  `Enumerable.reduce/3` will change. Please check the `result`
-  type docs for more information.
+  `Enumerable.reduce/3` will change. Please check the `t:result/0`
+  type documentation for more information.
 
-  In case a reducer function returns a `:suspend` accumulator,
+  In case a `t:reducer/0` function returns a `:suspend` accumulator,
   it must be explicitly handled by the caller and never leak.
   """
   @type acc :: {:cont, term} | {:halt, term} | {:suspend, term}
@@ -55,9 +55,10 @@ defprotocol Enumerable do
   @typedoc """
   The reducer function.
 
-  Should be called with the collection element and the
-  accumulator contents. Returns the accumulator for
-  the next enumeration step.
+  Should be called with the enumerable element and the
+  accumulator contents.
+
+  Returns the accumulator for the next enumeration step.
   """
   @type reducer :: (term, term -> acc)
 
@@ -66,9 +67,9 @@ defprotocol Enumerable do
 
   It may be *done* when the enumeration is finished by reaching
   its end, or *halted*/*suspended* when the enumeration was halted
-  or suspended by the reducer function.
+  or suspended by the `t:reducer/0` function.
 
-  In case a reducer function returns the `:suspend` accumulator, the
+  In case a `t:reducer/0` function returns the `:suspend` accumulator, the
   `:suspended` tuple must be explicitly handled by the caller and
   never leak. In practice, this means regular enumeration functions
   just need to be concerned about `:done` and `:halted` results.
@@ -76,7 +77,9 @@ defprotocol Enumerable do
   Furthermore, a `:suspend` call must always be followed by another call,
   eventually halting or continuing until the end.
   """
-  @type result :: {:done, term} | {:halted, term} | {:suspended, term, continuation}
+  @type result :: {:done, term} |
+                  {:halted, term} |
+                  {:suspended, term, continuation}
 
   @typedoc """
   A partially applied reduce function.
@@ -94,11 +97,12 @@ defprotocol Enumerable do
   @type continuation :: (acc -> result)
 
   @doc """
-  Reduces the collection into a value.
+  Reduces the enumerable into an element.
 
   Most of the operations in `Enum` are implemented in terms of reduce.
-  This function should apply the given `reducer` function to each
-  item in the collection and proceed as expected by the returned accumulator.
+  This function should apply the given `t:reducer/0` function to each
+  item in the enumerable and proceed as expected by the returned
+  accumulator.
 
   As an example, here is the implementation of `reduce` for lists:
 
@@ -109,43 +113,45 @@ defprotocol Enumerable do
 
   """
   @spec reduce(t, acc, reducer) :: result
-  def reduce(collection, acc, fun)
+  def reduce(enumerable, acc, fun)
 
   @doc """
-  Checks if a value exists within the collection.
+  Checks if an element exists within the enumerable.
 
   It should return `{:ok, boolean}`.
 
-  If `{:error, __MODULE__}` is returned a default algorithm using `reduce` and
-  the match (`===`) operator is used. This algorithm runs in linear time.
+  If `{:error, __MODULE__}` is returned a default algorithm using
+  `reduce` and the match (`===`) operator is used. This algorithm runs
+  in linear time.
 
-  Please force use of the default algorithm unless you can implement an
-  algorithm that is significantly faster.
+  _Please force use of the default algorithm unless you can implement an
+  algorithm that is significantly faster._
   """
   @spec member?(t, term) :: {:ok, boolean} | {:error, module}
-  def member?(collection, value)
+  def member?(enumerable, element)
 
   @doc """
-  Retrieves the collection's size.
+  Retrieves the enumerable's size.
 
   It should return `{:ok, size}`.
 
-  If `{:error, __MODULE__}` is returned a default algorithm using `reduce` and
-  the match (`===`) operator is used. This algorithm runs in linear time.
+  If `{:error, __MODULE__}` is returned a default algorithm using
+  `reduce` and the match (`===`) operator is used. This algorithm runs
+  in linear time.
 
-  Please force use of the default algorithm unless you can implement an
-  algorithm that is significantly faster.
+  _Please force use of the default algorithm unless you can implement an
+  algorithm that is significantly faster._
   """
   @spec count(t) :: {:ok, non_neg_integer} | {:error, module}
-  def count(collection)
+  def count(enumerable)
 end
 
 defmodule Enum do
   import Kernel, except: [max: 2, min: 2]
 
   @moduledoc """
-  Provides a set of algorithms that enumerate over collections according to the
-  `Enumerable` protocol.
+  Provides a set of algorithms that enumerate over enumerables according
+  to the `Enumerable` protocol.
 
       iex> Enum.map([1, 2, 3], fn(x) -> x * 2 end)
       [2, 4, 6]
@@ -157,12 +163,12 @@ defmodule Enum do
       iex> Enum.map(dict, fn {k, v} -> {k, v * 2} end)
       [a: 2, b: 4]
 
-  Note that the functions in the `Enum` module are eager: they always start
-  the enumeration of the given collection. The `Stream` module allows
-  lazy enumeration of collections and provides infinite streams.
+  Note that the functions in the `Enum` module are eager: they always
+  start the enumeration of the given enumerable. The `Stream` module
+  allows lazy enumeration of enumerables and provides infinite streams.
 
   Since the majority of the functions in `Enum` enumerate the whole
-  collection and return a list as result, infinite streams need to
+  enumerable and return a list as result, infinite streams need to
   be carefully used with such functions, as they can potentially run
   forever. For example:
 
@@ -199,8 +205,9 @@ defmodule Enum do
   end
 
   @doc """
-  Invokes the given `fun` for each item in the `collection` and returns `false`
-  if at least one invocation returns `false` or `nil`. Otherwise returns `true`.
+  Invokes the given `fun` for each item in the enumerable and returns
+  `false` if at least one invocation returns `false` or `nil`.
+  Otherwise returns `true`.
 
   ## Examples
 
@@ -211,7 +218,7 @@ defmodule Enum do
       false
 
   If no function is given, it defaults to checking if
-  all items in the collection are truthy values.
+  all items in the enumerable are truthy values.
 
       iex> Enum.all?([1, 2, 3])
       true
@@ -223,21 +230,22 @@ defmodule Enum do
   @spec all?(t) :: boolean
   @spec all?(t, (element -> as_boolean(term))) :: boolean
 
-  def all?(collection, fun \\ fn(x) -> x end)
+  def all?(enumerable, fun \\ fn(x) -> x end)
 
-  def all?(collection, fun) when is_list(collection) do
-    do_all?(collection, fun)
+  def all?(enumerable, fun) when is_list(enumerable) do
+    do_all?(enumerable, fun)
   end
 
-  def all?(collection, fun) do
-    Enumerable.reduce(collection, {:cont, true}, fn(entry, _) ->
+  def all?(enumerable, fun) do
+    Enumerable.reduce(enumerable, {:cont, true}, fn(entry, _) ->
       if fun.(entry), do: {:cont, true}, else: {:halt, false}
     end) |> elem(1)
   end
 
   @doc """
-  Invokes the given `fun` for each item in the `collection` and returns `true` if
-  at least one invocation returns a truthy value. Returns `false` otherwise.
+  Invokes the given `fun` for each item in the enumerable and returns
+  `true` if at least one invocation returns a truthy value.
+  Returns `false` otherwise.
 
   ## Examples
 
@@ -247,8 +255,8 @@ defmodule Enum do
       iex> Enum.any?([2, 3, 4], fn(x) -> rem(x, 2) == 1 end)
       true
 
-  If no function is given, it defaults to checking if
-  at least one item in the collection is a truthy value.
+  If no function is given, it defaults to checking if at least one item
+  in the enumerable is a truthy value.
 
       iex> Enum.any?([false, false, false])
       false
@@ -260,25 +268,25 @@ defmodule Enum do
   @spec any?(t) :: boolean
   @spec any?(t, (element -> as_boolean(term))) :: boolean
 
-  def any?(collection, fun \\ fn(x) -> x end)
+  def any?(enumerable, fun \\ fn(x) -> x end)
 
-  def any?(collection, fun) when is_list(collection) do
-    do_any?(collection, fun)
+  def any?(enumerable, fun) when is_list(enumerable) do
+    do_any?(enumerable, fun)
   end
 
-  def any?(collection, fun) do
-    Enumerable.reduce(collection, {:cont, false}, fn(entry, _) ->
+  def any?(enumerable, fun) do
+    Enumerable.reduce(enumerable, {:cont, false}, fn(entry, _) ->
       if fun.(entry), do: {:halt, true}, else: {:cont, false}
     end) |> elem(1)
   end
 
   @doc """
-  Finds the element at the given index (zero-based).
+  Finds the element at the given `index` (zero-based).
 
-  Returns `default` if index is out of bounds.
+  Returns `default` if `index` is out of bounds.
 
   Note this operation takes linear time. In order to access
-  the element at index `n`, it will need to traverse `n`
+  the element at index `index`, it will need to traverse `index`
   previous elements.
 
   ## Examples
@@ -297,31 +305,34 @@ defmodule Enum do
 
   """
   @spec at(t, integer, default) :: element | default
-  def at(collection, n, default \\ nil) do
-    case fetch(collection, n) do
+  def at(enumerable, index, default \\ nil) do
+    case fetch(enumerable, index) do
       {:ok, h} -> h
-      :error     -> default
+      :error   -> default
     end
   end
 
   @doc """
-  Shortcut to `chunk(collection, n, n)`.
+  Shortcut to `chunk(enumerable, count, count)`.
   """
   @spec chunk(t, pos_integer) :: [list]
-  def chunk(collection, n), do: chunk(collection, n, n, nil)
+  def chunk(enumerable, count), do: chunk(enumerable, count, count, nil)
 
   @doc """
-  Returns a collection of lists containing `n` items each, where
-  each new chunk starts `step` elements into the collection.
+  Returns list of lists containing `count` items each, where
+  each new chunk starts `step` elements into the enumerable.
 
-  `step` is optional and, if not passed, defaults to `n`, i.e.
-  chunks do not overlap. If the final chunk does not have `n`
-  elements to fill the chunk, elements are taken as necessary
-  from `pad` if it was passed. If `pad` is passed and does not
-  have enough elements to fill the chunk, then the chunk is
-  returned anyway with less than `n` elements. If `pad` is not
-  passed at all or is `nil`, then the partial chunk is discarded
-  from the result.
+  `step` is optional and, if not passed, defaults to `count`, i.e.
+  chunks do not overlap.
+
+  If the final chunk does not have `count` elements to fill the chunk,
+  elements are taken as necessary from `pad` if it was passed.
+
+  If `pad` is passed and does not have enough elements to fill the
+  chunk, then the chunk is returned anyway with less than `count`
+  elements.
+  If `pad` is not passed at all or is `nil`, then the partial chunk is
+  discarded from the result.
 
   ## Examples
 
@@ -339,22 +350,26 @@ defmodule Enum do
 
   """
   @spec chunk(t, pos_integer, pos_integer, t | nil) :: [list]
-  def chunk(collection, n, step, pad \\ nil) when n > 0 and step > 0 do
-    limit = :erlang.max(n, step)
+  def chunk(enumerable, count, step, pad \\ nil) when count > 0
+  and step > 0 do
+    limit = :erlang.max(count, step)
 
     {acc, {buffer, i}} =
-      reduce(collection, {[], {[], 0}}, R.chunk(n, step, limit))
+      reduce(enumerable, {[], {[], 0}}, R.chunk(count, step, limit))
 
     if is_nil(pad) || i == 0 do
       :lists.reverse(acc)
     else
-      buffer = :lists.reverse(buffer, take(pad, n - i))
+      buffer = :lists.reverse(buffer, take(pad, count - i))
       :lists.reverse([buffer|acc])
     end
   end
 
   @doc """
-  Splits `collection` on every element for which `fun` returns a new value.
+  Splits enumerable on every element for which `fun` returns a new
+  value.
+
+  Returns a list of lists.
 
   ## Examples
 
@@ -363,8 +378,8 @@ defmodule Enum do
 
   """
   @spec chunk_by(t, (element -> any)) :: [list]
-  def chunk_by(collection, fun) do
-    {acc, res} = reduce(collection, {[], nil}, R.chunk_by(fun))
+  def chunk_by(enumerable, fun) do
+    {acc, res} = reduce(enumerable, {[], nil}, R.chunk_by(fun))
 
     case res do
       {buffer, _} ->
@@ -375,7 +390,8 @@ defmodule Enum do
   end
 
   @doc """
-  Given an enumerable of enumerables, concatenates the enumerables into a single list.
+  Given an enumerable of enumerables, concatenates the enumerables into
+  a single list.
 
   ## Examples
 
@@ -392,9 +408,11 @@ defmodule Enum do
   end
 
   @doc """
-  Concatenates the enumerable on the right with the enumerable on the left.
+  Concatenates the enumerable on the right with the enumerable on the
+  left.
 
-  This function produces the same result as the `Kernel.++/2` operator for lists.
+  This function produces the same result as the `Kernel.++/2` operator
+  for lists.
 
   ## Examples
 
@@ -420,7 +438,7 @@ defmodule Enum do
   end
 
   @doc """
-  Returns the collection's size.
+  Returns the size of the enumerable.
 
   ## Examples
 
@@ -429,24 +447,24 @@ defmodule Enum do
 
   """
   @spec count(t) :: non_neg_integer
-  def count(collection) when is_list(collection) do
-    :erlang.length(collection)
+  def count(enumerable) when is_list(enumerable) do
+    :erlang.length(enumerable)
   end
 
-  def count(collection) do
-    case Enumerable.count(collection) do
+  def count(enumerable) do
+    case Enumerable.count(enumerable) do
       {:ok, value} when is_integer(value) ->
         value
       {:error, module} ->
-        module.reduce(collection, {:cont, 0}, fn
+        module.reduce(enumerable, {:cont, 0}, fn
           _, acc -> {:cont, acc + 1}
         end) |> elem(1)
     end
   end
 
   @doc """
-  Returns the count of items in the collection for which
-  `fun` returns a truthy value.
+  Returns the count of items in the enumerable for which `fun` returns
+  a truthy value.
 
   ## Examples
 
@@ -455,15 +473,15 @@ defmodule Enum do
 
   """
   @spec count(t, (element -> as_boolean(term))) :: non_neg_integer
-  def count(collection, fun) do
-    Enumerable.reduce(collection, {:cont, 0}, fn(entry, acc) ->
+  def count(enumerable, fun) do
+    Enumerable.reduce(enumerable, {:cont, 0}, fn(entry, acc) ->
       {:cont, if(fun.(entry), do: acc + 1, else: acc)}
     end) |> elem(1)
   end
 
 
   @doc """
-  Enumerates the collection, returning a list where all consecutive
+  Enumerates the `enumerable`, returning a list where all consecutive
   duplicated elements are collapsed to a single element.
 
   Elements are compared using `===`.
@@ -473,14 +491,17 @@ defmodule Enum do
       iex> Enum.dedup([1, 2, 3, 3, 2, 1])
       [1, 2, 3, 2, 1]
 
+      iex> Enum.dedup([1, 1, 2, 2.0, :three, :"three"])
+      [1, 2, 2.0, :three]
+
   """
   @spec dedup(t) :: list
-  def dedup(collection) do
-    dedup_by(collection, fn x -> x end)
+  def dedup(enumerable) do
+    dedup_by(enumerable, fn x -> x end)
   end
 
   @doc """
-  Enumerates the collection, returning a list where all consecutive
+  Enumerates the `enumerable`, returning a list where all consecutive
   duplicated elements are collapsed to a single element.
 
   The function `fun` maps every element to a term which is used to
@@ -488,26 +509,26 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.dedup_by([{1, :x}, {2, :y}, {2, :z}, {1, :x}], fn {x, _} -> x end)
-      [{1, :x}, {2, :y}, {1, :x}]
+      iex> Enum.dedup_by([{1, :a}, {2, :b}, {2, :c}, {1, :a}], fn {x, _} -> x end)
+      [{1, :x}, {2, :y}, {1, :a}]
 
       iex> Enum.dedup_by([5, 1, 2, 3, 2, 1], fn x -> x > 2 end)
       [5, 1, 3, 2]
 
   """
   @spec dedup_by(t, (element -> term)) :: list
-  def dedup_by(collection, fun) when is_function(fun, 1) do
-    {list, _} = reduce(collection, {[], []}, R.dedup(fun))
+  def dedup_by(enumerable, fun) when is_function(fun, 1) do
+    {list, _} = reduce(enumerable, {[], []}, R.dedup(fun))
     :lists.reverse(list)
   end
 
   @doc """
-  Drops the first `count` items from `collection`.
+  Drops the first `n` items from then enumerable.
 
-  If a negative value `count` is given, the last `count`
-  values will be dropped. The collection is enumerated
-  once to retrieve the proper index and the remaining
-  calculation is performed from the end.
+  If a negative value `n` is given, the last `n` values will be dropped.
+
+  The `enumerable` is enumerated once to retrieve the proper index and
+  the remaining calculation is performed from the end.
 
   ## Examples
 
@@ -525,13 +546,13 @@ defmodule Enum do
 
   """
   @spec drop(t, integer) :: list
-  def drop(collection, count) when is_list(collection) and count >= 0 do
-    do_drop(collection, count)
+  def drop(enumerable, n) when is_list(enumerable) and n >= 0 do
+    do_drop(enumerable, n)
   end
 
-  def drop(collection, count) when count >= 0 do
+  def drop(enumerable, n) when n >= 0 do
     res =
-      reduce(collection, count, fn
+      reduce(enumerable, n, fn
         x, acc when is_list(acc) -> [x|acc]
         x, 0                     -> [x]
         _, acc when acc > 0      -> acc - 1
@@ -539,12 +560,13 @@ defmodule Enum do
     if is_list(res), do: :lists.reverse(res), else: []
   end
 
-  def drop(collection, count) when count < 0 do
-    do_drop(reverse(collection), abs(count)) |> :lists.reverse
+  def drop(enumerable, n) when n < 0 do
+    do_drop(reverse(enumerable), abs(n)) |> :lists.reverse
   end
 
   @doc """
-  Drops items at the beginning of `collection` while `fun` returns a truthy value.
+  Drops items at the beginning of the enumerable while `fun` returns a
+  truthy value.
 
   ## Examples
 
@@ -553,17 +575,18 @@ defmodule Enum do
 
   """
   @spec drop_while(t, (element -> as_boolean(term))) :: list
-  def drop_while(collection, fun) when is_list(collection) do
-    do_drop_while(collection, fun)
+  def drop_while(enumerable, fun) when is_list(enumerable) do
+    do_drop_while(enumerable, fun)
   end
 
-  def drop_while(collection, fun) do
-    {res, _} = reduce(collection, {[], true}, R.drop_while(fun))
+  def drop_while(enumerable, fun) do
+    {res, _} = reduce(enumerable, {[], true}, R.drop_while(fun))
     :lists.reverse(res)
   end
 
   @doc """
-  Invokes the given `fun` for each item in the `collection`.
+  Invokes the given `fun` for each item in the enumerable.
+
   Returns `:ok`.
 
   ## Examples
@@ -575,13 +598,13 @@ defmodule Enum do
 
   """
   @spec each(t, (element -> any)) :: :ok
-  def each(collection, fun) when is_list(collection) do
-    :lists.foreach(fun, collection)
+  def each(enumerable, fun) when is_list(enumerable) do
+    :lists.foreach(fun, enumerable)
     :ok
   end
 
-  def each(collection, fun) do
-    reduce(collection, nil, fn(entry, _) ->
+  def each(enumerable, fun) do
+    reduce(enumerable, nil, fn(entry, _) ->
       fun.(entry)
       nil
     end)
@@ -589,7 +612,9 @@ defmodule Enum do
   end
 
   @doc """
-  Returns `true` if the collection is empty, otherwise `false`.
+  Determines if the enumerable is empty.
+
+  Returns `true` if `enumerable` is empty, otherwise `false`.
 
   ## Examples
 
@@ -601,25 +626,27 @@ defmodule Enum do
 
   """
   @spec empty?(t) :: boolean
-  def empty?(collection) when is_list(collection) do
-    collection == []
+  def empty?(enumerable) when is_list(enumerable) do
+    enumerable == []
   end
 
-  def empty?(collection) do
-    Enumerable.reduce(collection, {:cont, true}, fn(_, _) -> {:halt, false} end) |> elem(1)
+  def empty?(enumerable) do
+    Enumerable.reduce(enumerable, {:cont, true},
+      fn(_, _) -> {:halt, false} end)
+    |> elem(1)
   end
 
   @doc """
-  Finds the element at the given index (zero-based).
+  Finds the element at the given `index` (zero-based).
 
   Returns `{:ok, element}` if found, otherwise `:error`.
 
-  A negative index can be passed, which means the collection is
-  enumerated once and the index is counted from the end (i.e.
+  A negative `index` can be passed, which means the `enumerable` is
+  enumerated once and the `index` is counted from the end (e.g.
   `-1` fetches the last element).
 
   Note this operation takes linear time. In order to access
-  the element at index `n`, it will need to traverse `n`
+  the element at index `index`, it will need to traverse `index`
   previous elements.
 
   ## Examples
@@ -635,14 +662,15 @@ defmodule Enum do
 
   """
   @spec fetch(t, integer) :: {:ok, element} | :error
-  def fetch(collection, n) when is_list(collection) and is_integer(n) and n >= 0 do
-    do_fetch(collection, n)
+  def fetch(enumerable, index) when is_list(enumerable)
+  and is_integer(index) and index >= 0 do
+    do_fetch(enumerable, index)
   end
 
-  def fetch(collection, n) when is_integer(n) and n >= 0 do
+  def fetch(enumerable, index) when is_integer(index) and index >= 0 do
     res =
-      Enumerable.reduce(collection, {:cont, 0}, fn(entry, acc) ->
-        if acc == n do
+      Enumerable.reduce(enumerable, {:cont, 0}, fn(entry, acc) ->
+        if acc == index do
           {:halt, entry}
         else
           {:cont, acc + 1}
@@ -655,19 +683,18 @@ defmodule Enum do
     end
   end
 
-  def fetch(collection, n) when is_integer(n) and n < 0 do
-    do_fetch(reverse(collection), abs(n + 1))
+  def fetch(enumerable, index) when is_integer(index) and index < 0 do
+    do_fetch(reverse(enumerable), abs(index + 1))
   end
 
   @doc """
-  Finds the element at the given index (zero-based).
+  Finds the element at the given `index` (zero-based).
 
-  Raises `OutOfBoundsError` if the given position
-  is outside the range of the collection.
+  Raises `OutOfBoundsError` if the given `index` is outside the range of
+  the enumerable.
 
-  Note this operation takes linear time. In order to access
-  the element at index `n`, it will need to traverse `n`
-  previous elements.
+  Note this operation takes linear time. In order to access the element
+  at index `index`, it will need to traverse `index` previous elements.
 
   ## Examples
 
@@ -682,15 +709,15 @@ defmodule Enum do
 
   """
   @spec fetch!(t, integer) :: element | no_return
-  def fetch!(collection, n) do
-    case fetch(collection, n) do
+  def fetch!(enumerable, index) do
+    case fetch(enumerable, index) do
       {:ok, h} -> h
       :error     -> raise Enum.OutOfBoundsError
     end
   end
 
   @doc """
-  Filters the collection, i.e. returns only those elements
+  Filters the enumerable, i.e. returns only those elements
   for which `fun` returns a truthy value.
 
   ## Examples
@@ -700,16 +727,16 @@ defmodule Enum do
 
   """
   @spec filter(t, (element -> as_boolean(term))) :: list
-  def filter(collection, fun) when is_list(collection) do
-    for item <- collection, fun.(item), do: item
+  def filter(enumerable, fun) when is_list(enumerable) do
+    for item <- enumerable, fun.(item), do: item
   end
 
-  def filter(collection, fun) do
-    reduce(collection, [], R.filter(fun)) |> :lists.reverse
+  def filter(enumerable, fun) do
+    reduce(enumerable, [], R.filter(fun)) |> :lists.reverse
   end
 
   @doc """
-  Filters the collection and maps its values in one pass.
+  Filters the enumerable and maps its elements in one pass.
 
   ## Examples
 
@@ -717,18 +744,21 @@ defmodule Enum do
       [4]
 
   """
-  @spec filter_map(t, (element -> as_boolean(term)), (element -> element)) :: list
-  def filter_map(collection, filter, mapper) when is_list(collection) do
-    for item <- collection, filter.(item), do: mapper.(item)
+  @spec filter_map(t, (element -> as_boolean(term)),
+    (element -> element)) :: list
+
+  def filter_map(enumerable, filter, mapper) when is_list(enumerable) do
+    for item <- enumerable, filter.(item), do: mapper.(item)
   end
 
-  def filter_map(collection, filter, mapper) do
-    reduce(collection, [], R.filter_map(filter, mapper)) |> :lists.reverse
+  def filter_map(enumerable, filter, mapper) do
+    reduce(enumerable, [], R.filter_map(filter, mapper))
+    |> :lists.reverse
   end
 
   @doc """
-  Returns the first item for which `fun` returns a truthy value. If no such
-  item is found, returns `default`.
+  Returns the first item for which `fun` returns a truthy value.
+  If no such item is found, returns `default`.
 
   ## Examples
 
@@ -743,14 +773,14 @@ defmodule Enum do
 
   """
   @spec find(t, default, (element -> any)) :: element | default
-  def find(collection, default \\ nil, fun)
+  def find(enumerable, default \\ nil, fun)
 
-  def find(collection, default, fun) when is_list(collection) do
-    do_find(collection, default, fun)
+  def find(enumerable, default, fun) when is_list(enumerable) do
+    do_find(enumerable, default, fun)
   end
 
-  def find(collection, default, fun) do
-    Enumerable.reduce(collection, {:cont, default}, fn(entry, default) ->
+  def find(enumerable, default, fun) do
+    Enumerable.reduce(enumerable, {:cont, default}, fn(entry, default) ->
       if fun.(entry), do: {:halt, entry}, else: {:cont, default}
     end) |> elem(1)
   end
@@ -772,14 +802,14 @@ defmodule Enum do
 
   """
   @spec find_value(t, any, (element -> any)) :: any | :nil
-  def find_value(collection, default \\ nil, fun)
+  def find_value(enumerable, default \\ nil, fun)
 
-  def find_value(collection, default, fun) when is_list(collection) do
-    do_find_value(collection, default, fun)
+  def find_value(enumerable, default, fun) when is_list(enumerable) do
+    do_find_value(enumerable, default, fun)
   end
 
-  def find_value(collection, default, fun) do
-    Enumerable.reduce(collection, {:cont, default}, fn(entry, default) ->
+  def find_value(enumerable, default, fun) do
+    Enumerable.reduce(enumerable, {:cont, default}, fn(entry, default) ->
       fun_entry = fun.(entry)
       if fun_entry, do: {:halt, fun_entry}, else: {:cont, default}
     end) |> elem(1)
@@ -799,13 +829,13 @@ defmodule Enum do
 
   """
   @spec find_index(t, (element -> any)) :: index | :nil
-  def find_index(collection, fun) when is_list(collection) do
-    do_find_index(collection, 0, fun)
+  def find_index(enumerable, fun) when is_list(enumerable) do
+    do_find_index(enumerable, 0, fun)
   end
 
-  def find_index(collection, fun) do
+  def find_index(enumerable, fun) do
     res =
-      Enumerable.reduce(collection, {:cont, 0}, fn(entry, acc) ->
+      Enumerable.reduce(enumerable, {:cont, 0}, fn(entry, acc) ->
         if fun.(entry), do: {:halt, acc}, else: {:cont, acc + 1}
       end)
 
@@ -816,10 +846,10 @@ defmodule Enum do
   end
 
   @doc """
-  Returns a new collection appending the result of invoking `fun`
-  on each corresponding item of `collection`.
+  Returns a new enumerable appending the result of invoking `fun` on
+  each corresponding item of `enumerable`.
 
-  The given function should return an enumerable.
+  The given function must return an enumerable.
 
   ## Examples
 
@@ -831,19 +861,19 @@ defmodule Enum do
 
   """
   @spec flat_map(t, (element -> t)) :: list
-  def flat_map(collection, fun) do
-    reduce(collection, [], fn(entry, acc) ->
+  def flat_map(enumerable, fun) do
+    reduce(enumerable, [], fn(entry, acc) ->
       reduce(fun.(entry), acc, &[&1|&2])
     end) |> :lists.reverse
   end
 
   @doc """
-  Maps and reduces a collection, flattening the given results.
+  Maps and reduces an enumerable, flattening the given results.
 
-  It expects an accumulator and a function that receives each stream item
-  and an accumulator, and must return a tuple containing a new stream
-  (often a list) with the new accumulator or a tuple with `:halt` as first
-  element and the accumulator as second.
+  It expects an accumulator and a function that receives each stream
+  item, and must return a tuple containing a new stream (often a list)
+  with the new accumulator or a tuple with `:halt` as first element and
+  the accumulator as second.
 
   ## Examples
 
@@ -858,19 +888,20 @@ defmodule Enum do
   @spec flat_map_reduce(t, acc, fun) :: {[any], any} when
         fun: (element, acc -> {t, acc} | {:halt, acc}),
         acc: any
-  def flat_map_reduce(collection, acc, fun) do
+  def flat_map_reduce(enumerable, acc, fun) do
     {_, {list, acc}} =
-      Enumerable.reduce(collection, {:cont, {[], acc}}, fn(entry, {list, acc}) ->
-        case fun.(entry, acc) do
-          {:halt, acc} ->
-            {:halt, {list, acc}}
-          {[], acc} ->
-            {:cont, {list, acc}}
-          {[entry], acc} ->
-            {:cont, {[entry|list], acc}}
-          {entries, acc} ->
-            {:cont, {reduce(entries, list, &[&1|&2]), acc}}
-        end
+      Enumerable.reduce(enumerable, {:cont, {[], acc}},
+        fn(entry, {list, acc}) ->
+          case fun.(entry, acc) do
+            {:halt, acc} ->
+              {:halt, {list, acc}}
+            {[], acc} ->
+              {:cont, {list, acc}}
+            {[entry], acc} ->
+              {:cont, {[entry|list], acc}}
+            {entries, acc} ->
+              {:cont, {reduce(entries, list, &[&1|&2]), acc}}
+          end
       end)
 
     {:lists.reverse(list), acc}
@@ -879,7 +910,7 @@ defmodule Enum do
   @doc """
   Intersperses `element` between each element of the enumeration.
 
-  Complexity: O(n)
+  Complexity: O(n).
 
   ## Examples
 
@@ -894,9 +925,9 @@ defmodule Enum do
 
   """
   @spec intersperse(t, element) :: list
-  def intersperse(collection, element) do
+  def intersperse(enumerable, element) do
     list =
-      reduce(collection, [], fn(x, acc) ->
+      reduce(enumerable, [], fn(x, acc) ->
         [x, element | acc]
       end) |> :lists.reverse()
 
@@ -907,7 +938,7 @@ defmodule Enum do
   end
 
   @doc """
-  Inserts the given enumerable into a collectable.
+  Inserts the given `enumerable` into a `collectable`.
 
   ## Examples
 
@@ -919,46 +950,46 @@ defmodule Enum do
 
   """
   @spec into(Enumerable.t, Collectable.t) :: Collectable.t
-  def into(collection, list) when is_list(list) do
-    list ++ to_list(collection)
+  def into(enumerable, collectable) when is_list(collectable) do
+    collectable ++ to_list(enumerable)
   end
 
-  def into(%{__struct__: _} = collection, collectable) do
-    do_into(collection, collectable)
+  def into(%{__struct__: _} = enumerable, collectable) do
+    do_into(enumerable, collectable)
   end
 
-  def into(collection, %{__struct__: _} = collectable) do
-    do_into(collection, collectable)
+  def into(enumerable, %{__struct__: _} = collectable) do
+    do_into(enumerable, collectable)
   end
 
-  def into(%{} = collection, %{} = collectable) do
-    Map.merge(collectable, collection)
+  def into(%{} = enumerable, %{} = collectable) do
+    Map.merge(collectable, enumerable)
   end
 
-  def into(collection, %{} = collectable) when is_list(collection) do
-    Map.merge(collectable, :maps.from_list(collection))
+  def into(enumerable, %{} = collectable) when is_list(enumerable) do
+    Map.merge(collectable, :maps.from_list(enumerable))
   end
 
-  def into(collection, %{} = collectable) do
-    reduce(collection, collectable, fn {k, v}, acc ->
+  def into(enumerable, %{} = collectable) do
+    reduce(enumerable, collectable, fn {k, v}, acc ->
       Map.put(acc, k, v)
     end)
   end
 
-  def into(collection, collectable) do
-    do_into(collection, collectable)
+  def into(enumerable, collectable) do
+    do_into(enumerable, collectable)
   end
 
-  defp do_into(collection, collectable) do
+  defp do_into(enumerable, collectable) do
     {initial, fun} = Collectable.into(collectable)
-    into(collection, initial, fun, fn x, acc ->
+    into(enumerable, initial, fun, fn x, acc ->
       fun.(acc, {:cont, x})
     end)
   end
 
   @doc """
-  Inserts the given enumerable into a collectable
-  according to the transformation function.
+  Inserts the given `enumerable` into a `collectable` according to the
+  transformation function.
 
   ## Examples
 
@@ -966,22 +997,25 @@ defmodule Enum do
       [3, 6, 9]
 
   """
-  @spec into(Enumerable.t, Collectable.t, (term -> term)) :: Collectable.t
+  @spec into(Enumerable.t, Collectable.t, (term -> term))
+    :: Collectable.t
 
-  def into(collection, list, transform) when is_list(list) and is_function(transform, 1) do
-    list ++ map(collection, transform)
+  def into(enumerable, collectable, transform) when is_list(collectable)
+    and is_function(transform, 1) do
+    collectable ++ map(enumerable, transform)
   end
 
-  def into(collection, collectable, transform) when is_function(transform, 1) do
+  def into(enumerable, collectable, transform)
+  when is_function(transform, 1) do
     {initial, fun} = Collectable.into(collectable)
-    into(collection, initial, fun, fn x, acc ->
+    into(enumerable, initial, fun, fn x, acc ->
       fun.(acc, {:cont, transform.(x)})
     end)
   end
 
-  defp into(collection, initial, fun, callback) do
+  defp into(enumerable, initial, fun, callback) do
     try do
-      reduce(collection, initial, callback)
+      reduce(enumerable, initial, callback)
     catch
       kind, reason ->
         stacktrace = System.stacktrace
@@ -993,11 +1027,13 @@ defmodule Enum do
   end
 
   @doc """
-  Joins the given `collection` into a binary using `joiner` as a separator.
+  Joins the given enumerable into a binary using `joiner` as a
+  separator.
+
   If `joiner` is not passed at all, it defaults to the empty binary.
 
-  All items in the collection must be convertible
-  to a binary, otherwise an error is raised.
+  All items in the enumerable must be convertible to a binary,
+  otherwise an error is raised.
 
   ## Examples
 
@@ -1009,10 +1045,10 @@ defmodule Enum do
 
   """
   @spec join(t, String.t) :: String.t
-  def join(collection, joiner \\ "")
+  def join(enumerable, joiner \\ "")
 
-  def join(collection, joiner) when is_binary(joiner) do
-    reduced = reduce(collection, :first, fn
+  def join(enumerable, joiner) when is_binary(joiner) do
+    reduced = reduce(enumerable, :first, fn
       entry, :first -> enum_to_string(entry)
       entry, acc -> [acc, joiner|enum_to_string(entry)]
     end)
@@ -1024,8 +1060,8 @@ defmodule Enum do
   end
 
   @doc """
-  Returns a new collection, where each item is the result
-  of invoking `fun` on each corresponding item of `collection`.
+  Returns a list where each item is the result of invoking
+  `fun` on each corresponding item of `enumerable`.
 
   For dicts, the function expects a key-value tuple.
 
@@ -1039,23 +1075,23 @@ defmodule Enum do
 
   """
   @spec map(t, (element -> any)) :: list
-  def map(collection, fun) when is_list(collection) do
-    for item <- collection, do: fun.(item)
+  def map(enumerable, fun) when is_list(enumerable) do
+    for item <- enumerable, do: fun.(item)
   end
 
-  def map(collection, fun) do
-    reduce(collection, [], R.map(fun)) |> :lists.reverse
+  def map(enumerable, fun) do
+    reduce(enumerable, [], R.map(fun)) |> :lists.reverse
   end
 
   @doc """
-  Maps and joins the given `collection` in one pass.
-  `joiner` can be either a binary or a list and the
-  result will be of the same type as `joiner`. If
-  `joiner` is not passed at all, it defaults to an
-  empty binary.
+  Maps and joins the given enumerable in one pass.
 
-  All items in the collection must be convertible
-  to a binary, otherwise an error is raised.
+  `joiner` can be either a binary or a list and the result will be of
+  the same type as `joiner`.
+  If `joiner` is not passed at all, it defaults to an empty binary.
+
+  All items in the enumerable must be convertible to a binary,
+  otherwise an error is raised.
 
   ## Examples
 
@@ -1067,10 +1103,10 @@ defmodule Enum do
 
   """
   @spec map_join(t, String.t, (element -> any)) :: String.t
-  def map_join(collection, joiner \\ "", mapper)
+  def map_join(enumerable, joiner \\ "", mapper)
 
-  def map_join(collection, joiner, mapper) when is_binary(joiner) do
-    reduced = reduce(collection, :first, fn
+  def map_join(enumerable, joiner, mapper) when is_binary(joiner) do
+    reduced = reduce(enumerable, :first, fn
       entry, :first -> enum_to_string(mapper.(entry))
       entry, acc    -> [acc, joiner|enum_to_string(mapper.(entry))]
     end)
@@ -1083,13 +1119,17 @@ defmodule Enum do
   end
 
   @doc """
-  Invokes the given `fun` for each item in the `collection`
-  while also keeping an accumulator. Returns a tuple where
-  the first element is the mapped collection and the second
-  one is the final accumulator.
+  Invokes the given function to each item in the enumerable to reduce
+  it to a sigle element, while keeping an accumulator.
 
-  For dicts, the first tuple element must be a `{key, value}`
-  tuple.
+  Returns a tuple where the first element is the mapped enumerable and
+  the second one is the final accumulator.
+
+  The function `fun` receives two arguments, the first one is the
+  element, and the second one is the accumulator; and it must return a
+  a tuple with two elements in the form of `{result, accumulator}`.
+
+  For dicts, the first tuple element must be a `{key, value}` tuple.
 
   ## Examples
 
@@ -1098,21 +1138,27 @@ defmodule Enum do
 
   """
   @spec map_reduce(t, any, (element, any -> {any, any})) :: {any, any}
-  def map_reduce(collection, acc, fun) when is_list(collection) do
-    :lists.mapfoldl(fun, acc, collection)
+  def map_reduce(enumerable, acc, fun) when is_list(enumerable) do
+    :lists.mapfoldl(fun, acc, enumerable)
   end
 
-  def map_reduce(collection, acc, fun) do
-    {list, acc} = reduce(collection, {[], acc}, fn(entry, {list, acc}) ->
-      {new_entry, acc} = fun.(entry, acc)
-      {[new_entry|list], acc}
+  def map_reduce(enumerable, acc, fun) do
+    {list, acc} = reduce(enumerable, {[], acc},
+      fn(entry, {list, acc}) ->
+        {new_entry, acc} = fun.(entry, acc)
+        {[new_entry|list], acc}
     end)
     {:lists.reverse(list), acc}
   end
 
   @doc """
-  Returns the maximum value.
-  Raises `EmptyError` if the collection is empty.
+  Returns the biggest of the elements in the enumerable according
+  to Erlang's term ordering.
+
+  If more than one elements compare equal, the first one that was found
+  is returned.
+
+  Raises `Enum.EmptyError` if `enumerable` is empty.
 
   ## Examples
 
@@ -1121,13 +1167,18 @@ defmodule Enum do
 
   """
   @spec max(t) :: element | no_return
-  def max(collection) do
-    reduce(collection, &Kernel.max(&1, &2))
+  def max(enumerable) do
+    reduce(enumerable, &Kernel.max(&1, &2))
   end
 
   @doc """
-  Returns the maximum value as calculated by the given function.
-  Raises `EmptyError` if the collection is empty.
+  Returns the biggest of the elements in the enumerable as calculated
+  by the given function.
+
+  If more than one elements compare equal, the first one that was found
+  is returned.
+
+  Raises `Enum.EmptyError` if `enumerable` is empty.
 
   ## Examples
 
@@ -1147,9 +1198,9 @@ defmodule Enum do
     raise Enum.EmptyError
   end
 
-  def max_by(collection, fun) do
+  def max_by(enumerable, fun) do
     result =
-      reduce(collection, :first, fn
+      reduce(enumerable, :first, fn
         entry, {_, fun_max} = old ->
           fun_entry = fun.(entry)
           if(fun_entry > fun_max, do: {entry, fun_entry}, else: old)
@@ -1164,15 +1215,20 @@ defmodule Enum do
   end
 
   @doc """
-  Checks if `value` exists within the `collection`.
+  Checks if `element` exists within the enumerable.
 
-  Membership is tested with the match (`===`) operator, although
-  enumerables like ranges may include floats inside the given
-  range.
+  Membership is tested with the match (`===`) operator.
 
   ## Examples
 
       iex> Enum.member?(1..10, 5)
+      true
+      ...> Enum.member?(1..10, 5.0)
+      false
+
+      iex> Enum.member?([1.0, 2.0, 3.0], 2)
+      false
+      ...> Enum.member?([1.0, 2.0, 3.0], 2.000)
       true
 
       iex> Enum.member?([:a, :b, :c], :d)
@@ -1180,25 +1236,30 @@ defmodule Enum do
 
   """
   @spec member?(t, element) :: boolean
-  def member?(collection, value) when is_list(collection) do
-    :lists.member(value, collection)
+  def member?(enumerable, element) when is_list(enumerable) do
+    :lists.member(element, enumerable)
   end
 
-  def member?(collection, value) do
-    case Enumerable.member?(collection, value) do
-      {:ok, value} when is_boolean(value) ->
-        value
+  def member?(enumerable, element) do
+    case Enumerable.member?(enumerable, element) do
+      {:ok, element} when is_boolean(element) ->
+        element
       {:error, module} ->
-        module.reduce(collection, {:cont, false}, fn
-          v, _ when v === value -> {:halt, true}
+        module.reduce(enumerable, {:cont, false}, fn
+          v, _ when v === element -> {:halt, true}
           _, _                  -> {:cont, false}
         end) |> elem(1)
     end
   end
 
   @doc """
-  Returns the minimum value.
-  Raises `EmptyError` if the collection is empty.
+  Returns the smallest of the elements in the enumerable according
+  to Erlang's term ordering.
+
+  If more than one elements compare equal, the first one that was found
+  is returned.
+
+  Raises `Enum.EmptyError` if `enumerable` is empty.
 
   ## Examples
 
@@ -1207,13 +1268,18 @@ defmodule Enum do
 
   """
   @spec min(t) :: element | no_return
-  def min(collection) do
-    reduce(collection, &Kernel.min(&1, &2))
+  def min(enumerable) do
+    reduce(enumerable, &Kernel.min(&1, &2))
   end
 
   @doc """
-  Returns the minimum value as calculated by the given function.
-  Raises `EmptyError` if the collection is empty.
+  Returns the smallest of the elements in the enumerable as calculated
+  by the given function.
+
+  If more than one elements compare equal, the first one that was found
+  is returned.
+
+  Raises `Enum.EmptyError` if `enumerable` is empty.
 
   ## Examples
 
@@ -1233,9 +1299,9 @@ defmodule Enum do
     raise Enum.EmptyError
   end
 
-  def min_by(collection, fun) do
+  def min_by(enumerable, fun) do
     result =
-      reduce(collection, :first, fn
+      reduce(enumerable, :first, fn
         entry, {_, fun_min} = old ->
           fun_entry = fun.(entry)
           if(fun_entry < fun_min, do: {entry, fun_entry}, else: old)
@@ -1250,8 +1316,13 @@ defmodule Enum do
   end
 
   @doc """
-  Returns a tuple with the minimum and maximum values.
-  Raises `EmptyError` if the collection is empty.
+  Returns a tuple with the smallest and the biggest elements in the
+  enumerable according to Erlang's term ordering.
+
+  If more than one elements compare equal, the first one that was found
+  is picked.
+
+  Raises `Enum.EmptyError` if `enumerable` is empty.
 
   ## Examples
 
@@ -1259,10 +1330,10 @@ defmodule Enum do
       {1, 3}
 
   """
-  @spec min_max(t) :: element | no_return
-  def min_max(collection) do
+  @spec min_max(t) :: {element, element} | no_return
+  def min_max(enumerable) do
     result =
-      Enum.reduce(collection, :first, fn
+      Enum.reduce(enumerable, :first, fn
         entry, {min_value, max_value} ->
           {Kernel.min(entry, min_value), Kernel.max(entry, max_value)}
         entry, :first ->
@@ -1276,8 +1347,13 @@ defmodule Enum do
   end
 
   @doc """
-  Returns a tuple with the minimum and maximum values as calculated by the given function.
-  Raises `EmptyError` if the collection is empty.
+  Returns a tuple with the smallest and the biggest elements in the
+  enumerable as calculated by the given function.
+
+  If more than one elements compare equal, the first one that was found
+  is picked.
+
+  Raises `Enum.EmptyError` if `enumerable` is empty.
 
   ## Examples
 
@@ -1285,10 +1361,10 @@ defmodule Enum do
       {"c", "aaa"}
 
   """
-  @spec min_max_by(t, (element -> any)) :: element | no_return
-  def min_max_by(collection, fun) do
+  @spec min_max_by(t, (element -> any)) :: {element, element} | no_return
+  def min_max_by(enumerable, fun) do
     result =
-      Enum.reduce(collection, :first, fn
+      Enum.reduce(enumerable, :first, fn
         entry, {{_, fun_min} = acc_min, {_, fun_max} = acc_max} ->
           fun_entry = fun.(entry)
           if fun_entry < fun_min, do: acc_min = {entry, fun_entry}
@@ -1308,9 +1384,9 @@ defmodule Enum do
   end
 
   @doc """
-  Returns the sum of all values.
+  Returns the sum of all elements.
 
-  Raises `ArithmeticError` if collection contains a non-numeric value.
+  Raises `ArithmeticError` if `enumerable` contains a non-numeric value.
 
   ## Examples
 
@@ -1319,14 +1395,14 @@ defmodule Enum do
 
   """
   @spec sum(t) :: number
-  def sum(collection) do
-    reduce(collection, 0, &+/2)
+  def sum(enumerable) do
+    reduce(enumerable, 0, &+/2)
   end
 
   @doc """
-  Partitions `collection` into two collections, where the first one contains elements
-  for which `fun` returns a truthy value, and the second one -- for which `fun`
-  returns `false` or `nil`.
+  Partitions `enumerable` into two enumerables, where the first one
+  contains elements for which `fun` returns a truthy value, and the
+  second one – for which `fun` returns `false` or `nil`.
 
   ## Examples
 
@@ -1335,9 +1411,9 @@ defmodule Enum do
 
   """
   @spec partition(t, (element -> any)) :: {list, list}
-  def partition(collection, fun) do
+  def partition(enumerable, fun) do
     {acc1, acc2} =
-      reduce(collection, {[], []}, fn(entry, {acc1, acc2}) ->
+      reduce(enumerable, {[], []}, fn(entry, {acc1, acc2}) ->
         if fun.(entry) do
           {[entry|acc1], acc2}
         else
@@ -1349,10 +1425,10 @@ defmodule Enum do
   end
 
   @doc """
-  Splits `collection` into groups based on `fun`.
+  Splits the enumerable into groups based on `fun`.
 
   The result is a dict (by default a map) where each key is
-  a group and each value is a list of elements from `collection`
+  a group and each value is a list of elements from enumerable
   for which `fun` returned that group. Ordering is not necessarily
   preserved.
 
@@ -1363,15 +1439,17 @@ defmodule Enum do
 
   """
   @spec group_by(t, dict, (element -> any)) :: dict when dict: Dict.t
-  def group_by(collection, dict \\ %{}, fun) do
-    reduce(collection, dict, fn(entry, categories) ->
+  def group_by(enumerable, dict \\ %{}, fun) do
+    reduce(enumerable, dict, fn(entry, categories) ->
       Dict.update(categories, fun.(entry), [entry], &[entry|&1])
     end)
   end
 
   @doc """
-  Invokes `fun` for each element in the collection passing that element and the
-  accumulator `acc` as arguments. `fun`'s return value is stored in `acc`.
+  Invokes `fun` for each element in the `enumerable`, passing that
+  element and the accumulator `acc` as arguments. `fun`'s return value
+  is stored in `acc`.
+
   Returns the accumulator.
 
   ## Examples
@@ -1381,35 +1459,41 @@ defmodule Enum do
 
   """
   @spec reduce(t, any, (element, any -> any)) :: any
-  def reduce(collection, acc, fun) when is_list(collection) do
-    :lists.foldl(fun, acc, collection)
+  def reduce(enumerable, acc, fun) when is_list(enumerable) do
+    :lists.foldl(fun, acc, enumerable)
   end
 
-  def reduce(%{__struct__: _} = collection, acc, fun) do
-    Enumerable.reduce(collection, {:cont, acc},
+  def reduce(%{__struct__: _} = enumerable, acc, fun) do
+    Enumerable.reduce(enumerable, {:cont, acc},
                       fn x, acc -> {:cont, fun.(x, acc)} end) |> elem(1)
   end
 
-  def reduce(%{} = collection, acc, fun) do
-    :maps.fold(fn k, v, acc -> fun.({k, v}, acc) end, acc, collection)
+  def reduce(%{} = enumerable, acc, fun) do
+    :maps.fold(fn k, v, acc -> fun.({k, v}, acc) end, acc, enumerable)
   end
 
-  def reduce(collection, acc, fun) do
-    Enumerable.reduce(collection, {:cont, acc},
+  def reduce(enumerable, acc, fun) do
+    Enumerable.reduce(enumerable, {:cont, acc},
                       fn x, acc -> {:cont, fun.(x, acc)} end) |> elem(1)
   end
 
   @doc """
-  Invokes `fun` for each element in the collection passing that element and the
-  accumulator `acc` as arguments. `fun`'s return value is stored in `acc`.
-  The first element of the collection is used as the initial value of `acc`.
-  If you wish to use another value for `acc`, use `Enumerable.reduce/3`.
-  This function won't call the specified function for enumerables that are 1-element long.
+  Invokes `fun` for each element in the `enumerable`, passing that
+  element and the accumulator as arguments. `fun`'s return value
+  is stored in the accumulator.
+
+  The first element of the enumerable is used as the initial value of
+  the accumulator.
+  If you wish to use another value for the accumulator, use
+  `Enumerable.reduce/3`.
+  This function won't call the specified function for enumerables that
+  are 1-element long.
+
   Returns the accumulator.
 
-  Note that since the first element of the enumerable is used as the initial
-  value of the accumulator, `fun` will only be executed `n - 1` times where `n`
-  is the length of the enumerable.
+  Note that since the first element of the enumerable is used as the
+  initial value of the accumulator, `fun` will only be executed `n - 1`
+  times where `n` is the length of the enumerable.
 
   ## Examples
 
@@ -1418,6 +1502,8 @@ defmodule Enum do
 
   """
   @spec reduce(t, (element, any -> any)) :: any
+  def reduce(enumerable, fun)
+
   def reduce([h|t], fun) do
     reduce(t, h, fun)
   end
@@ -1426,9 +1512,9 @@ defmodule Enum do
     raise Enum.EmptyError
   end
 
-  def reduce(collection, fun) do
+  def reduce(enumerable, fun) do
     result =
-      Enumerable.reduce(collection, {:cont, :first}, fn
+      Enumerable.reduce(enumerable, {:cont, :first}, fn
         x, :first ->
           {:cont, {:acc, x}}
         x, {:acc, acc} ->
@@ -1442,10 +1528,11 @@ defmodule Enum do
   end
 
   @doc """
-  Reduces the collection until halt is emitted.
+  Reduces the enumerable until `halt` is emitted.
 
-  The return value for `fun` is expected to be
-  `{:cont, acc}`, return `{:halt, acc}` to end the reduction early.
+  The return value for `fun` is expected to be `{:cont, acc}`, return
+  `{:halt, acc}` to end the reduction early.
+
   Returns the accumulator.
 
   ## Examples
@@ -1456,12 +1543,13 @@ defmodule Enum do
       3
 
   """
-  def reduce_while(collection, acc, fun) do
-    Enumerable.reduce(collection, {:cont, acc}, fun) |> elem(1)
+  def reduce_while(enumerable, acc, fun) do
+    Enumerable.reduce(enumerable, {:cont, acc}, fun) |> elem(1)
   end
 
   @doc """
-  Returns elements of collection for which `fun` returns `false` or `nil`.
+  Returns elements of `enumerable` for which the function `fun` returns
+  `false` or `nil`.
 
   ## Examples
 
@@ -1470,16 +1558,16 @@ defmodule Enum do
 
   """
   @spec reject(t, (element -> as_boolean(term))) :: list
-  def reject(collection, fun) when is_list(collection) do
-    for item <- collection, !fun.(item), do: item
+  def reject(enumerable, fun) when is_list(enumerable) do
+    for item <- enumerable, !fun.(item), do: item
   end
 
-  def reject(collection, fun) do
-    reduce(collection, [], R.reject(fun)) |> :lists.reverse
+  def reject(enumerable, fun) do
+    reduce(enumerable, [], R.reject(fun)) |> :lists.reverse
   end
 
   @doc """
-  Reverses the collection.
+  Returns a list of elements in `enumerable` in reverse order.
 
   ## Examples
 
@@ -1488,18 +1576,20 @@ defmodule Enum do
 
   """
   @spec reverse(t) :: list
-  def reverse(collection) when is_list(collection) do
-    :lists.reverse(collection)
+  def reverse(enumerable) when is_list(enumerable) do
+    :lists.reverse(enumerable)
   end
 
-  def reverse(collection) do
-    reverse(collection, [])
+  def reverse(enumerable) do
+    reverse(enumerable, [])
   end
 
   @doc """
-  Reverses the collection and appends the tail.
+  Reverses the elements in `enumerable`, appends the tail, and returns
+  it as a list.
+
   This is an optimization for
-  `Enum.concat(Enum.reverse(collection), tail)`.
+  `Enum.concat(Enum.reverse(enumerable), tail)`.
 
   ## Examples
 
@@ -1508,21 +1598,23 @@ defmodule Enum do
 
   """
   @spec reverse(t, t) :: list
-  def reverse(collection, tail) when is_list(collection) and is_list(tail) do
-    :lists.reverse(collection, tail)
+  def reverse(enumerable, tail) when is_list(enumerable)
+  and is_list(tail) do
+    :lists.reverse(enumerable, tail)
   end
 
-  def reverse(collection, tail) do
-    reduce(collection, to_list(tail), fn(entry, acc) ->
+  def reverse(enumerable, tail) do
+    reduce(enumerable, to_list(tail), fn(entry, acc) ->
       [entry|acc]
     end)
   end
 
   @doc """
-  Reverses the collection in the range from initial position `first`
-  through `count` elements. If `count` is greater than the size of
-  the rest of the collection, then this function will reverse the rest
-  of the collection.
+  Reverses the enumerable in the range from initial position `start`
+  through `count` elements.
+
+  If `count` is greater than the size of the rest of the enumerable,
+  then this function will reverse the rest of the enumerable.
 
   ## Examples
 
@@ -1531,8 +1623,9 @@ defmodule Enum do
 
   """
   @spec reverse_slice(t, non_neg_integer, non_neg_integer) :: list
-  def reverse_slice(collection, start, count) when start >= 0 and count >= 0 do
-    list = reverse(collection)
+  def reverse_slice(enumerable, start, count) when start >= 0
+  and count >= 0 do
+    list = reverse(enumerable)
     length = length(list)
     count = Kernel.min(count, length - start)
 
@@ -1544,8 +1637,9 @@ defmodule Enum do
   end
 
   @doc """
-  Returns a random element of a collection.
-  Raises `EmptyError` if the collection is empty.
+  Returns a random element of an enumerable.
+
+  Raises `Enum.EmptyError` if `enumerable` is empty.
 
   Notice that you need to explicitly call `:random.seed/1` and
   set a seed value for the random algorithm. Otherwise, the
@@ -1559,7 +1653,7 @@ defmodule Enum do
   [reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling#Relation_to_Fisher-Yates_shuffle)
   algorithm.
   It assumes that the sample being returned can fit into memory;
-  the input collection doesn't have to - it is traversed just once.
+  the input `enumerable` doesn't have to, as it is traversed just once.
 
   ## Examples
 
@@ -1569,16 +1663,16 @@ defmodule Enum do
       2
 
   """
-  @spec random(t) :: element
-  def random(collection) do
-    case take_random(collection, 1) do
+  @spec random(t) :: element | no_return
+  def random(enumerable) do
+    case take_random(enumerable, 1) do
       [] -> raise Enum.EmptyError
       [e] -> e
     end
   end
 
   @doc """
-  Applies the given function to each element in the collection,
+  Applies the given function to each element in the enumerable,
   storing the result in a list and passing it as the accumulator
   for the next computation.
 
@@ -1589,13 +1683,13 @@ defmodule Enum do
 
   """
   @spec scan(t, (element, any -> any)) :: list
-  def scan(enum, fun) do
-    {res, _} = reduce(enum, {[], :first}, R.scan_2(fun))
+  def scan(enumerable, fun) do
+    {res, _} = reduce(enumerable, {[], :first}, R.scan_2(fun))
     :lists.reverse(res)
   end
 
   @doc """
-  Applies the given function to each element in the collection,
+  Applies the given function to each element in the enumerable,
   storing the result in a list and passing it as the accumulator
   for the next computation. Uses the given `acc` as the starting value.
 
@@ -1606,13 +1700,13 @@ defmodule Enum do
 
   """
   @spec scan(t, any, (element, any -> any)) :: list
-  def scan(enum, acc, fun) do
-    {res, _} = reduce(enum, {[], acc}, R.scan_3(fun))
+  def scan(enumerable, acc, fun) do
+    {res, _} = reduce(enumerable, {[], acc}, R.scan_3(fun))
     :lists.reverse(res)
   end
 
   @doc """
-  Returns a list of collection elements shuffled.
+  Returns a list with the elements of `enumerable` shuffled.
 
   Notice that you need to explicitly call `:random.seed/1` and
   set a seed value for the random algorithm. Otherwise, the
@@ -1631,19 +1725,19 @@ defmodule Enum do
 
   """
   @spec shuffle(t) :: list
-  def shuffle(collection) do
-    randomized = reduce(collection, [], fn x, acc ->
+  def shuffle(enumerable) do
+    randomized = reduce(enumerable, [], fn x, acc ->
       [{:random.uniform, x}|acc]
     end)
     unwrap(:lists.keysort(1, randomized), [])
   end
 
   @doc """
-  Returns a subset list of the given collection. Drops elements
+  Returns a subset list of the given enumerable. Drops elements
   until element position `start`, then takes `count` elements.
 
-  If the count is greater than collection length, it returns as
-  much as possible. If zero, then it returns `[]`.
+  If the count is greater than `enumerable` length, it returns as
+  many as possible. If zero, then it returns `[]`.
 
   ## Examples
 
@@ -1659,10 +1753,11 @@ defmodule Enum do
   """
   @spec slice(t, integer, non_neg_integer) :: list
 
-  def slice(_collection, start, 0) when is_integer(start), do: []
+  def slice(_enumerable, start, 0) when is_integer(start), do: []
 
-  def slice(collection, start, count) when is_integer(start) and start < 0 and is_integer(count) and count >= 0 do
-    {list, new_start} = enumerate_and_count(collection, start)
+  def slice(enumerable, start, count) when is_integer(start)
+  and start < 0 and is_integer(count) and count >= 0 do
+    {list, new_start} = enumerate_and_count(enumerable, start)
     if new_start >= 0 do
       slice(list, new_start, count)
     else
@@ -1670,37 +1765,41 @@ defmodule Enum do
     end
   end
 
-  def slice(collection, start, count) when is_list(collection) and is_integer(start) and start >= 0 and is_integer(count) and count > 0 do
-    do_slice(collection, start, count)
+  def slice(enumerable, start, count) when is_list(enumerable)
+  and is_integer(start) and start >= 0 and is_integer(count)
+  and count > 0 do
+    do_slice(enumerable, start, count)
   end
 
-  def slice(collection, start, count) when is_integer(start) and start >= 0 and is_integer(count) and count > 0 do
-    {_, _, list} = Enumerable.reduce(collection, {:cont, {start, count, []}}, fn
-      _entry, {start, count, _list} when start > 0 ->
-        {:cont, {start-1, count, []}}
-      entry, {start, count, list} when count > 1 ->
-        {:cont, {start, count-1, [entry|list]}}
-      entry, {start, count, list} ->
-        {:halt, {start, count, [entry|list]}}
+  def slice(enumerable, start, count) when is_integer(start)
+  and start >= 0 and is_integer(count) and count > 0 do
+    {_, _, list} = Enumerable.reduce(enumerable,
+      {:cont, {start, count, []}}, fn
+        _entry, {start, count, _list} when start > 0 ->
+          {:cont, {start-1, count, []}}
+        entry, {start, count, list} when count > 1 ->
+          {:cont, {start, count-1, [entry|list]}}
+        entry, {start, count, list} ->
+          {:halt, {start, count, [entry|list]}}
     end) |> elem(1)
 
     :lists.reverse(list)
   end
 
   @doc """
-  Returns a subset list of the given collection. Drops elements
-  until element position `range.first`, then takes elements until element
-  position `range.last` (inclusive).
+  Returns a subset list of the given enumerable. Drops elements
+  until element position `range.first`, then takes elements until
+  element position `range.last` (inclusive).
 
-  Positions are calculated by adding the number of items in the collection to
-  negative positions (so position -3 in a collection with count 5 becomes
-  position 2).
+  Positions are calculated by adding the number of items in the
+  enumerable to negative positions (e.g. position -3 in an
+  enumerable with count 5 becomes position 2).
 
-  The first position (after adding count to negative positions) must be smaller
-  or equal to the last position.
+  The first position (after adding count to negative positions) must be
+  smaller or equal to the last position.
 
   If the start of the range is not a valid offset for the given
-  collection or if the range is in reverse order, returns `[]`.
+  enumerable or if the range is in reverse order, returns `[]`.
 
   ## Examples
 
@@ -1718,19 +1817,21 @@ defmodule Enum do
 
   """
   @spec slice(t, Range.t) :: list
-  def slice(collection, range)
+  def slice(enumerable, range)
 
-  def slice(collection, first..last) when is_integer(first) and first >= 0 and is_integer(last) and last >= 0 do
-    # Simple case, which works on infinite collections
+  def slice(enumerable, first..last) when is_integer(first)
+  and first >= 0 and is_integer(last) and last >= 0 do
+    # Simple case, which works on infinite enumerables
     if last - first >= 0 do
-      slice(collection, first, last - first + 1)
+      slice(enumerable, first, last - first + 1)
     else
       []
     end
   end
 
-  def slice(collection, first..last) when is_integer(first) and is_integer(last) do
-    {list, count} = enumerate_and_count(collection, 0)
+  def slice(enumerable, first..last) when is_integer(first)
+  and is_integer(last) do
+    {list, count} = enumerate_and_count(enumerable, 0)
     corr_first = if first >= 0, do: first, else: first + count
     corr_last = if last >= 0, do: last, else: last + count
     length = corr_last - corr_first + 1
@@ -1742,7 +1843,7 @@ defmodule Enum do
   end
 
   @doc """
-  Sorts the collection according to Elixir's term ordering.
+  Sorts the enumerable according to Erlang's term ordering.
 
   Uses the merge sort algorithm.
 
@@ -1753,19 +1854,19 @@ defmodule Enum do
 
   """
   @spec sort(t) :: list
-  def sort(collection) when is_list(collection) do
-    :lists.sort(collection)
+  def sort(enumerable) when is_list(enumerable) do
+    :lists.sort(enumerable)
   end
 
-  def sort(collection) do
-    sort(collection, &(&1 <= &2))
+  def sort(enumerable) do
+    sort(enumerable, &(&1 <= &2))
   end
 
   @doc """
-  Sorts the collection by the given function.
+  Sorts the enumerable by the given function.
 
   This function uses the merge sort algorithm. The given function
-  must return `false` if the first argument is less than right one.
+  must return `false` if the first argument is smaller than second one.
 
   ## Examples
 
@@ -1778,40 +1879,44 @@ defmodule Enum do
       iex> Enum.sort ["some", "kind", "of", "monster"], &(byte_size(&1) <= byte_size(&2))
       ["of", "some", "kind", "monster"]
 
-  If the function does not return `true` for equal values, the sorting is not stable and
-  the order of equal terms may be shuffled:
+  If the function does not return `true` for equal values, the sorting
+  is not stable and the order of equal terms may be shuffled.
+  For example:
 
       iex> Enum.sort ["some", "kind", "of", "monster"], &(byte_size(&1) < byte_size(&2))
       ["of", "kind", "some", "monster"]
 
   """
   @spec sort(t, (element, element -> boolean)) :: list
-  def sort(collection, fun) when is_list(collection) do
-    :lists.sort(fun, collection)
+  def sort(enumerable, fun) when is_list(enumerable) do
+    :lists.sort(fun, enumerable)
   end
 
-  def sort(collection, fun) do
-    reduce(collection, [], &sort_reducer(&1, &2, fun)) |> sort_terminator(fun)
+  def sort(enumerable, fun) do
+    reduce(enumerable, [], &sort_reducer(&1, &2, fun))
+    |> sort_terminator(fun)
   end
 
   @doc """
-  Sorts the mapped results of the `collection` according to the `sorter` function.
+  Sorts the mapped results of the enumerable according to the `sorter`
+  function.
 
-  This function maps each element of the collection using the `mapper`
-  function.  The collection is then sorted by the mapped elements using the
-  `sorter` function, which defaults to `<=/2`
+  This function maps each element of the enumerable using the `mapper`
+  function.  The enumerable is then sorted by the mapped elements
+  using the `sorter` function, which defaults to `<=/2`
 
-  `sort_by/3` differs from `sort/2` in that it only calculates the comparison
-  value for each element in the collection once instead of once for each
-  element in each comparison.  If the same function is being called on both
-  element, it's also more compact to use `sort_by/3`.
+  `sort_by/3` differs from `sort/2` in that it only calculates the
+  comparison value for each element in the enumerable once instead of
+  once for each element in each comparison.
+  If the same function is being called on both element, it's also more
+  compact to use `sort_by/3`.
 
   This technique is also known as a
-  [Schwartzian Transform](https://en.wikipedia.org/wiki/Schwartzian_transform),
-  or the Lisp decorate-sort-undecorate idiom as the `mapper` is decorating the
-  original `collection`, then `sorter` is sorting the decorations, and finally
-  the `collection` is being undecorated so only the original elements remain,
-  but now in sorted order.
+  _[Schwartzian Transform](https://en.wikipedia.org/wiki/Schwartzian_transform)_,
+  or the _Lisp decorate-sort-undecorate idiom_ as the `mapper`
+  is decorating the original `enumerable`; then `sorter` is sorting the
+  decorations; and finally the enumerable is being undecorated so only
+  the original elements remain, but now in sorted order.
 
   ## Examples
 
@@ -1826,21 +1931,24 @@ defmodule Enum do
       ["monster", "some", "kind", "of"]
 
   """
-  @spec sort_by(t, (element -> mapped_element), (mapped_element, mapped_element -> boolean)) :: list when mapped_element: element
-  def sort_by(collection, mapper, sorter \\ &<=/2) do
-    collection
+  @spec sort_by(t, (element -> mapped_element),
+    (mapped_element, mapped_element -> boolean))
+    :: list when mapped_element: element
+
+  def sort_by(enumerable, mapper, sorter \\ &<=/2) do
+    enumerable
     |> map(&{&1, mapper.(&1)})
     |> sort(&sorter.(elem(&1, 1), elem(&2, 1)))
     |> map(&elem(&1, 0))
   end
 
   @doc """
-  Splits the enumerable into two collections, leaving `count`
+  Splits the `enumerable` into two enumerables, leaving `count`
   elements in the first one. If `count` is a negative number,
   it starts counting from the back to the beginning of the
-  collection.
+  enumerable.
 
-  Be aware that a negative `count` implies the collection
+  Be aware that a negative `count` implies the `enumerable`
   will be enumerated twice: once to calculate the position, and
   a second time to do the actual splitting.
 
@@ -1863,30 +1971,31 @@ defmodule Enum do
 
   """
   @spec split(t, integer) :: {list, list}
-  def split(collection, count) when is_list(collection) and count >= 0 do
-    do_split(collection, count, [])
+  def split(enumerable, count) when is_list(enumerable) and count >= 0 do
+    do_split(enumerable, count, [])
   end
 
-  def split(collection, count) when count >= 0 do
+  def split(enumerable, count) when count >= 0 do
     {_, list1, list2} =
-      reduce(collection, {count, [], []}, fn(entry, {counter, acc1, acc2}) ->
-        if counter > 0 do
-          {counter - 1, [entry|acc1], acc2}
-        else
-          {counter, acc1, [entry|acc2]}
-        end
+      reduce(enumerable, {count, [], []},
+        fn(entry, {counter, acc1, acc2}) ->
+          if counter > 0 do
+            {counter - 1, [entry|acc1], acc2}
+          else
+            {counter, acc1, [entry|acc2]}
+          end
       end)
 
     {:lists.reverse(list1), :lists.reverse(list2)}
   end
 
-  def split(collection, count) when count < 0 do
-    do_split_reverse(reverse(collection), abs(count), [])
+  def split(enumerable, count) when count < 0 do
+    do_split_reverse(reverse(enumerable), abs(count), [])
   end
 
   @doc """
-  Splits `collection` in two at the position of the element for which `fun` returns `false` for the
-  first time.
+  Splits enumerable in two at the position of the element for which
+  `fun` returns `false` for the first time.
 
   ## Examples
 
@@ -1895,13 +2004,13 @@ defmodule Enum do
 
   """
   @spec split_while(t, (element -> as_boolean(term))) :: {list, list}
-  def split_while(collection, fun) when is_list(collection) do
-    do_split_while(collection, fun, [])
+  def split_while(enumerable, fun) when is_list(enumerable) do
+    do_split_while(enumerable, fun, [])
   end
 
-  def split_while(collection, fun) do
+  def split_while(enumerable, fun) do
     {list1, list2} =
-      reduce(collection, {[], []}, fn
+      reduce(enumerable, {[], []}, fn
         entry, {acc1, []} ->
           if(fun.(entry), do: {[entry|acc1], []}, else: {acc1, [entry]})
         entry, {acc1, acc2} ->
@@ -1912,11 +2021,12 @@ defmodule Enum do
   end
 
   @doc """
-  Takes the first `count` items from the collection.
+  Takes the first `count` items from the enumerable.
 
-  `count` must be an integer. If a negative `count` is given, the last `count` values will
-  be taken. For such, the collection is fully enumerated keeping up
-  to `2 * count` elements in memory. Once the end of the collection is
+  `count` must be an integer. If a negative `count` is given, the last
+  `count` values will be taken.
+  For such, the enumerable is fully enumerated keeping up
+  to `2 * count` elements in memory. Once the end of the enumerable is
   reached, the last `count` elements are returned.
 
   ## Examples
@@ -1935,31 +2045,34 @@ defmodule Enum do
 
   """
   @spec take(t, integer) :: list
+  def take(enumerable, count)
 
-  def take(_collection, 0), do: []
+  def take(_enumerable, 0), do: []
   def take([], _count), do: []
 
-  def take(collection, count) when is_list(collection) and is_integer(count) and count > 0 do
-    do_take(collection, count)
+  def take(enumerable, count) when is_list(enumerable)
+  and is_integer(count) and count > 0 do
+    do_take(enumerable, count)
   end
 
-  def take(collection, count) when is_integer(count) and count > 0 do
+  def take(enumerable, count) when is_integer(count) and count > 0 do
     {_, {res, _}} =
-      Enumerable.reduce(collection, {:cont, {[], count}}, fn(entry, {list, n}) ->
-        case n do
-          0 -> {:halt, {list, n}}
-          1 -> {:halt, {[entry|list], n - 1}}
-          _ -> {:cont, {[entry|list], n - 1}}
-        end
+      Enumerable.reduce(enumerable, {:cont, {[], count}},
+        fn(entry, {list, n}) ->
+          case n do
+            0 -> {:halt, {list, n}}
+            1 -> {:halt, {[entry|list], n - 1}}
+            _ -> {:cont, {[entry|list], n - 1}}
+          end
       end)
     :lists.reverse(res)
   end
 
-  def take(collection, count) when is_integer(count) and count < 0 do
+  def take(enumerable, count) when is_integer(count) and count < 0 do
     count = abs(count)
 
     {_count, buf1, buf2} =
-      reduce(collection, {0, [], []}, fn entry, {n, buf1, buf2} ->
+      reduce(enumerable, {0, [], []}, fn entry, {n, buf1, buf2} ->
         buf1  = [entry|buf1]
         n = n + 1
         if n == count do
@@ -1982,13 +2095,13 @@ defmodule Enum do
     do: do_take_last(t, buf2, count-1, [h|acc])
 
   @doc """
-  Returns a collection of every `nth` item in the collection,
+  Returns a list of every `nth` item in the enumerable,
   starting with the first element.
 
   The first item is always included, unless `nth` is 0.
 
-  The second argument specifying every `nth` item must be a non-negative integer,
-  otherwise `FunctionClauseError` will be thrown.
+  The second argument specifying every `nth` item must be a non-negative
+  integer, otherwise `FunctionClauseError` will be raised.
 
   ## Examples
 
@@ -2002,23 +2115,25 @@ defmodule Enum do
       [1, 2, 3]
 
   """
-  @spec take_every(t, non_neg_integer) :: list
-  def take_every(collection, 1), do: to_list(collection)
-  def take_every(_collection, 0), do: []
+  @spec take_every(t, non_neg_integer) :: list | no_return
+  def take_every(enumerable, nth)
+
+  def take_every(enumerable, 1), do: to_list(enumerable)
+  def take_every(_enumerable, 0), do: []
   def take_every([], _nth), do: []
 
-  def take_every(collection, nth) when is_integer(nth) and nth > 0 do
-    {res, _} = reduce(collection, {[], :first}, R.take_every(nth))
+  def take_every(enumerable, nth) when is_integer(nth) and nth > 0 do
+    {res, _} = reduce(enumerable, {[], :first}, R.take_every(nth))
     :lists.reverse(res)
   end
 
   @doc """
-  Takes random items from a collection.
+  Takes random items from the enumerable.
 
-  Notice this function will traverse the whole collection to
-  get the random sublist of collection. If you want the random
+  Notice this function will traverse the whole enumerable to
+  get the random sublist of `enumerable`. If you want the random
   number between two integers, the best option is to use the
-  `:random` module.
+  [`:random`](http://www.erlang.org/doc/man/random.html) module.
 
   See `random/1` for notes on implementation and random seed.
 
@@ -2031,9 +2146,9 @@ defmodule Enum do
 
   """
   @spec take_random(t, integer) :: list
-  def take_random(_collection, 0), do: []
+  def take_random(_enumerable, 0), do: []
 
-  def take_random(collection, count) when count > 128 do
+  def take_random(enumerable, count) when count > 128 do
     reducer = fn(elem, {idx, sample}) ->
       jdx = random_index(idx)
       cond do
@@ -2047,11 +2162,11 @@ defmodule Enum do
       end
     end
 
-    {size, sample} = reduce(collection, {0, %{}}, reducer)
+    {size, sample} = reduce(enumerable, {0, %{}}, reducer)
     take_random(sample, Kernel.min(count, size), [])
   end
 
-  def take_random(collection, count) when count > 0 do
+  def take_random(enumerable, count) when count > 0 do
     sample = Tuple.duplicate(nil, count)
 
     reducer = fn(elem, {idx, sample}) ->
@@ -2067,7 +2182,7 @@ defmodule Enum do
       end
     end
 
-    {size, sample} = reduce(collection, {0, sample}, reducer)
+    {size, sample} = reduce(enumerable, {0, sample}, reducer)
     sample |> Tuple.to_list |> take(Kernel.min(count, size))
   end
 
@@ -2080,7 +2195,8 @@ defmodule Enum do
   end
 
   @doc """
-  Takes the items from the beginning of `collection` while `fun` returns a truthy value.
+  Takes the items from the beginning of the enumerable while `fun` returns
+  a truthy value.
 
   ## Examples
 
@@ -2089,13 +2205,13 @@ defmodule Enum do
 
   """
   @spec take_while(t, (element -> as_boolean(term))) :: list
-  def take_while(collection, fun) when is_list(collection) do
-    do_take_while(collection, fun)
+  def take_while(enumerable, fun) when is_list(enumerable) do
+    do_take_while(enumerable, fun)
   end
 
-  def take_while(collection, fun) do
+  def take_while(enumerable, fun) do
     {_, res} =
-      Enumerable.reduce(collection, {:cont, []}, fn(entry, acc) ->
+      Enumerable.reduce(enumerable, {:cont, []}, fn(entry, acc) ->
         if fun.(entry) do
           {:cont, [entry|acc]}
         else
@@ -2107,7 +2223,7 @@ defmodule Enum do
   end
 
   @doc """
-  Converts `collection` to a list.
+  Converts `enumerable` to a list.
 
   ## Examples
 
@@ -2115,17 +2231,17 @@ defmodule Enum do
       [1, 2, 3]
 
   """
-  @spec to_list(t) :: [term]
-  def to_list(collection) when is_list(collection) do
-    collection
+  @spec to_list(t) :: [element]
+  def to_list(enumerable) when is_list(enumerable) do
+    enumerable
   end
 
-  def to_list(collection) do
-    reverse(collection) |> :lists.reverse
+  def to_list(enumerable) do
+    reverse(enumerable) |> :lists.reverse
   end
 
   @doc """
-  Enumerates the collection, removing all duplicated elements.
+  Enumerates the `enumerable`, removing all duplicated elements.
 
   ## Examples
 
@@ -2134,44 +2250,53 @@ defmodule Enum do
 
   """
   @spec uniq(t) :: list
-  def uniq(collection) do
-    uniq_by(collection, fn x -> x end)
+  def uniq(enumerable) do
+    uniq_by(enumerable, fn x -> x end)
   end
 
   # TODO: Deprecate by 1.2
   # TODO: Remove by 2.0
   @doc false
-  def uniq(collection, fun) do
-    uniq_by(collection, fun)
+  def uniq(enumerable, fun) do
+    uniq_by(enumerable, fun)
   end
 
   @doc """
-  Enumerates the collection, removing all duplicated elements.
+  Enumerates the `enumerable`, by removing the elements for which
+  function `fun` returned duplicate items.
 
+  The function `fun` maps every element to a term which is used to
+  determine if two elements are duplicates.
   ## Example
 
       iex> Enum.uniq_by([{1, :x}, {2, :y}, {1, :z}], fn {x, _} -> x end)
       [{1, :x}, {2, :y}]
 
+      Enum.uniq_by([{a: {tea: 2}}, {b: {tea: 2}}, {c, {coffe: 1}}], fn {x, _} -> x end)
+      [a: [tea: 2], b: [tea: 2]]
+
   """
   @spec uniq_by(t, (element -> term)) :: list
 
-  def uniq_by(collection, fun) when is_list(collection) do
-    do_uniq(collection, %{}, fun)
+  def uniq_by(enumerable, fun) when is_list(enumerable) do
+    do_uniq(enumerable, %{}, fun)
   end
 
-  def uniq_by(collection, fun) do
-    {list, _} = reduce(collection, {[], %{}}, R.uniq(fun))
+  def uniq_by(enumerable, fun) do
+    {list, _} = reduce(enumerable, {[], %{}}, R.uniq(fun))
     :lists.reverse(list)
   end
 
   @doc """
-  Opposite of `Enum.zip/2`; takes a list of two-element tuples and returns a
-  tuple with two lists, each of which is formed by the first and second element
-  of each tuple, respectively.
+  Opposite of `Enum.zip/2`; extracts a two-element tuples from the
+  enumerable and groups them together.
 
-  This function fails unless `collection` is or can be converted into a list of
-  tuples with *exactly* two elements in each tuple.
+  It takes an enumerable with items being two-element tuples and returns
+  a tuple with two lists, each of which is formed by the first and
+  second element of each tuple, respectively.
+
+  This function fails unless `enumerable` is or can be converted into a
+  list of tuples with *exactly* two elements in each tuple.
 
   ## Examples
 
@@ -2182,17 +2307,18 @@ defmodule Enum do
       {[:a, :b], [1, 2]}
 
   """
-  @spec unzip(t) :: {list(element), list(element)}
-  def unzip(collection) do
-    {list1, list2} = reduce(collection, {[], []}, fn({el1, el2}, {list1, list2}) ->
-      {[el1|list1], [el2|list2]}
+  @spec unzip(t) :: {[element], [element]}
+  def unzip(enumerable) do
+    {list1, list2} = reduce(enumerable, {[], []},
+      fn({el1, el2}, {list1, list2}) ->
+        {[el1|list1], [el2|list2]}
     end)
 
     {:lists.reverse(list1), :lists.reverse(list2)}
   end
 
   @doc """
-  Zips corresponding elements from two collections into one list
+  Zips corresponding elements from two enumerables into one list
   of tuples.
 
   The zipping finishes as soon as any enumerable completes.
@@ -2207,27 +2333,30 @@ defmodule Enum do
 
   """
   @spec zip(t, t) :: [{any, any}]
-  def zip(collection1, collection2) when is_list(collection1) and is_list(collection2) do
-    do_zip(collection1, collection2)
+  def zip(enumerable1, enumerable2) when is_list(enumerable1)
+  and is_list(enumerable2) do
+    do_zip(enumerable1, enumerable2)
   end
 
-  def zip(collection1, collection2) do
-    Stream.zip(collection1, collection2).({:cont, []}, &{:cont, [&1|&2]}) |> elem(1) |> :lists.reverse
+  def zip(enumerable1, enumerable2) do
+    Stream.zip(enumerable1, enumerable2).({:cont, []}, &{:cont, [&1|&2]})
+    |> elem(1)
+    |> :lists.reverse
   end
 
   @doc """
-  Returns the collection with each element wrapped in a tuple
+  Returns the enumerable with each element wrapped in a tuple
   alongside its index.
 
   ## Examples
 
-      iex> Enum.with_index [1, 2, 3]
-      [{1, 0}, {2, 1}, {3, 2}]
+      iex> Enum.with_index [:a, :b, :c]
+      [a: 0, b: 1, c: 2]
 
   """
-  @spec with_index(t) :: list({element, non_neg_integer})
-  def with_index(collection) do
-    map_reduce(collection, 0, fn x, acc ->
+  @spec with_index(t) :: [{element, non_neg_integer}]
+  def with_index(enumerable) do
+    map_reduce(enumerable, 0, fn x, acc ->
       {{x, acc}, acc + 1}
     end) |> elem(0)
   end
@@ -2236,12 +2365,12 @@ defmodule Enum do
 
   @compile {:inline, enum_to_string: 1}
 
-  defp enumerate_and_count(collection, count) when is_list(collection) do
-    {collection, length(collection) - abs(count)}
+  defp enumerate_and_count(enumerable, count) when is_list(enumerable) do
+    {enumerable, length(enumerable) - abs(count)}
   end
 
-  defp enumerate_and_count(collection, count) do
-    map_reduce(collection, -abs(count), fn(x, acc) -> {x, acc + 1} end)
+  defp enumerate_and_count(enumerable, count) do
+    map_reduce(enumerable, -abs(count), fn(x, acc) -> {x, acc + 1} end)
   end
 
   defp enum_to_string(entry) when is_binary(entry), do: entry


### PR DESCRIPTION
- Updates the terminology: what it was refereed as `collection` is now `enumerable` and `collectable`
- text wrap to 72 chars
- backticks added to `enumerable` and other variables.
- specs fixed
- Summaries improved
  - try to avoid the use of what it returns in the summary. 
- documentation for several functions corrected and improved, as well as examples.
- some variables in functions renamed.
- I have changed the use of `value` when it actually refered to elements in the Enumerable to `element`, but i had kept it when it was used for tuples, refering to `key - value`, even though value could be an enumerable.