### PR TITLE
[#3707] Warn when @attributes are redefined

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2176,17 +2176,17 @@ defmodule Kernel do
       true ->
         raise ArgumentError, "cannot set attribute @#{name} inside function/macro"
       false ->
-        arg = case name do
-          :behavior ->
+        cond do
+          name == :behavior ->
             :elixir_errors.warn env.line, env.file,
                                 "@behavior attribute is not supported, please use @behaviour instead"
-          :doc       -> {env.line, arg}
-          :typedoc   -> {env.line, arg}
-          :moduledoc -> {env.line, arg}
-          _          -> arg
+          :lists.member(name, [:moduledoc, :typedoc, :doc]) ->
+            {stack, _} = :elixir_quote.escape(env_stacktrace(env), false)
+            arg = {env.line, arg}
+            quote do: Module.put_attribute(__MODULE__, unquote(name), unquote(arg), unquote(stack))
+          true ->
+            quote do: Module.put_attribute(__MODULE__, unquote(name), unquote(arg))
         end
-
-        quote do: Module.put_attribute(__MODULE__, unquote(name), unquote(arg))
     end
   end
 

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -786,11 +786,17 @@ defmodule Module do
       end
 
   """
-  def put_attribute(module, key, value) when is_atom(key) do
+  def put_attribute(module, key, value) do
+    put_attribute(module, key, value, nil)
+  end
+
+  @doc false
+  def put_attribute(module, key, value, warn) when is_atom(key) do
     assert_not_compiled!(:put_attribute, module)
     table = data_table_for(module)
     value = preprocess_attribute(key, value)
     acc   = :ets.lookup_element(table, {:elixir, :acc_attributes}, 2)
+    warn_if_redefining_attribute(warn, table, key)
 
     new =
       if :lists.member(key, acc) do
@@ -1058,4 +1064,15 @@ defmodule Module do
       raise ArgumentError,
         "could not call #{fun} on module #{inspect module} because it was already compiled"
   end
+
+  defp warn_if_redefining_attribute(warn, table, key) when 
+       key in [:moduledoc, :typedoc, :doc] and is_list(warn) do
+    case :ets.lookup(table, key) do
+      [{_, val}] when val != nil ->
+        :elixir_errors.warn warn_info(warn), "redefining @#{Atom.to_string(key)} attribute"
+      _other -> 
+        false
+    end
+  end
+  defp warn_if_redefining_attribute(_caller, _table, _key), do: false
 end


### PR DESCRIPTION
Attributes such as `@doc` and `@moduledoc` should emit warnings when they
are redefined. For example:

```elixir
@doc "first"
@doc "second"
```

This should emit a warning to the user, because the doc tag will be
overwritten with the value “second”.

This implementation throws a lot of false positives during Elixir’s
bootstrap compile phase. I’ve had trouble debugging it. I think it may
be happening because `@attributes` are treated differently during the
bootstrap phase. Any help would be appreciated.

See #3707 for more details.