### PR TITLE
Add support for a default value in System.get_env/1

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -427,8 +427,8 @@ defmodule System do
   Returns the value of the given environment variable.
 
   The returned value of the environment variable
-  `varname` is a string, or `nil` if the environment
-  variable is not set.
+  `varname` is a string. If the environment variable
+  is undefined, returns default (or `nil` if not provided)
 
   ## Examples
 
@@ -438,11 +438,16 @@ defmodule System do
       iex> System.get_env("NOT_SET")
       nil
 
+      iex> System.get_env("NOT_SET", "4001")
+      "4001"
+
   """
-  @spec get_env(String.t()) :: String.t() | nil
-  def get_env(varname) when is_binary(varname) do
+  @spec get_env(String.t(), String.t() | nil) :: String.t() | nil
+  def get_env(varname, default \\ nil)
+      when is_binary(varname) and
+             (is_binary(default) or is_nil(default)) do
     case :os.getenv(String.to_charlist(varname)) do
-      false -> nil
+      false -> default
       other -> List.to_string(other)
     end
   end

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -428,7 +428,8 @@ defmodule System do
 
   The returned value of the environment variable
   `varname` is a string. If the environment variable
-  is undefined, returns default (or `nil` if not provided)
+  is not set, returns the string specified in `default` or
+  `nil` if none is specified.
 
   ## Examples
 

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -442,6 +442,7 @@ defmodule System do
       "4001"
 
   """
+  @doc since: "1.9.0"
   @spec get_env(String.t(), String.t() | nil) :: String.t() | nil
   def get_env(varname, default \\ nil)
       when is_binary(varname) and

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -52,6 +52,7 @@ defmodule SystemTest do
 
   test "*_env/*" do
     assert System.get_env(@test_var) == nil
+    assert System.get_env(@test_var, "SAMPLE") == "SAMPLE"
     assert System.fetch_env(@test_var) == :error
 
     message = "could not fetch environment variable #{inspect(@test_var)} because it is not set"


### PR DESCRIPTION
Similarly to Erlang `os:getenv/2` this allow to return a default value in `System.get_env` when the environment variable is undefined.
