### PR TITLE
Enum: corrections in  private functions

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2484,8 +2484,8 @@ defmodule Enum do
 
   ## shuffle
 
-  defp unwrap([{_, h} | collection], t) do
-    unwrap(collection, [h|t])
+  defp unwrap([{_, h} | enumerable], t) do
+    unwrap(enumerable, [h|t])
   end
 
   defp unwrap([], t), do: t


### PR DESCRIPTION
this is the second part of changes introduced in commit ced1095e177c71b4022c1dc1cd209673b2f872d0

this one does:
- rename collection with enumerable.
- line wrapping so the whole file (with the exceptions of the docs examples) fit in 72 chars.

------
second part of https://github.com/elixir-lang/elixir/pull/3792
which I didn't include originally to reduce the size of the commit.. 