### PR TITLE
Informative error message when passing a non atom value to use

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3627,7 +3627,7 @@ defmodule Kernel do
           unquote(expanded).__using__(unquote(opts))
         end
       _otherwise ->
-        raise ArgumentError, "invalid arguments for use, expected an atom or alias as argument"
+        raise ArgumentError, "invalid arguments for use, expected a compile time atom or alias, got: #{Macro.to_string(module)}"
     end)
     quote(do: (unquote_splicing calls))
   end

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -660,10 +660,17 @@ defmodule KernelTest do
       end
     end
 
-    test "invalid argument" do
-      message = "invalid arguments for use, expected an atom or alias as argument"
+    test "invalid argument is literal" do
+      message = "invalid arguments for use, expected a compile time atom or alias, got: 42"
       assert_raise ArgumentError, message, fn ->
         Code.eval_string("use 42")
+      end
+    end
+
+    test "invalid argument is variable" do
+      message = "invalid arguments for use, expected a compile time atom or alias, got: variable"
+      assert_raise ArgumentError, message, fn ->
+        Code.eval_string("use variable")
       end
     end
 


### PR DESCRIPTION
I was stuck with an unhelpful error this morning. It was unhelpful because I was passing a variable that clearly referred to an atom. I realise now that this is due to it working at compile time but I only realised because the error message for require was much more helpful

**use error**
> (ArgumentError) invalid arguments for use, expected an atom or alias as argument

**require error**
(CompileError) meta.exs:2: invalid argument for require, expected a compile time atom or alias, got: 42

This pull request makes the use error also ask for a compile time atom, instead of just an atom.

