### PR TITLE
Optimize `Keyword.new/2` function

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -91,10 +91,12 @@ defmodule Keyword do
   """
   @spec new(Enum.t, (term -> {key, value})) :: t
   def new(pairs, transform) do
-    Enum.reduce pairs, [], fn i, keywords ->
-      {k, v} = transform.(i)
-      put(keywords, k, v)
+    fun = fn el, acc ->
+      {k, v} = transform.(el)
+      put_new(acc, k, v)
     end
+    keywords = :lists.foldl(fun, [], Enum.reverse(pairs))
+    :lists.reverse(keywords)
   end
 
   @doc """


### PR DESCRIPTION
The timings for 200 elements enumerable:
```
new:      100000   73.76 µs/op
old:       10000   1085.19 µs/op
```

Apparently, [`:lists.foldr`](https://github.com/elixir-lang/elixir/pull/3218#discussion_r27350819) didn't go well for us last time, that's why `foldl` was used at first place and this time.