### PR TITLE
Optimize Enum.map/2 for lists

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1075,8 +1075,14 @@ defmodule Enum do
 
   """
   @spec map(t, (element -> any)) :: list
-  def map(enumerable, fun) when is_list(enumerable) do
-    for item <- enumerable, do: fun.(item)
+  def map(enumerable, fun)
+
+  def map([], _fun) do
+    []
+  end
+
+  def map([head | tail], fun) do
+    [fun.(head) | map(tail, fun)]
   end
 
   def map(enumerable, fun) do


### PR DESCRIPTION
When writing an article about lists I ventured into implementing couple of the core list functions myself. I was surprised when I discovered that the current implementation of `Enum.map/2` is not optimal.

I came up with 3 options:
* using for comprehensions (currently used)
* using explicit recursion with accumulator
* using simple consing

The third option seems to be the fastest. That's also the one that is used by `:lists.map/2`

Tested implementations:
```elixir
  def map_cons([head | tail], fun), do: [fun.(head) | map_cons(tail, fun)]
  def map_cons([], _fun), do: []

  def map_recurse(list, fun, acc \\ [])
  def map_recurse([head | tail], fun, acc), do: map_recurse(tail, fun, [fun.(head) | acc])
  def map_recurse([], _fun, acc), do: :lists.reverse(acc)

  def map_for(list, fun), do: for i <- list, do: fun.(i)
```

Results:
```
cons 100            500000   3.25 µs/op
recurse 100         500000   3.27 µs/op
for 100             500000   4.76 µs/op
cons 1000            50000   30.57 µs/op
recurse 1000         50000   32.59 µs/op
for 1000             50000   43.51 µs/op
cons 10000            5000   308.71 µs/op
recurse 10000         5000   339.36 µs/op
for 10000             5000   449.46 µs/op
cons 100000            500   3135.30 µs/op
recurse 100000         500   4178.06 µs/op
for 100000             500   5025.42 µs/op
```

[Full testing code](https://gist.github.com/michalmuskala/6a52648a72261220ccc8)

Performance gain is steadily around 30%. The difference is not huge (and probably less significant if you do any work inside the mapping function), but given how often `Enum.map/2` is used, I think this warrants the change.