### PR TITLE
Add demonstration for Enum.shuffle's randomness

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1716,6 +1716,9 @@ defmodule Enum do
 
       :random.seed(:os.timestamp)
 
+  To see what happens if you don't do this, shuffle the same list
+  in two separate IEx sessions. The results will be the same.
+
   ## Examples
 
       iex> Enum.shuffle([1, 2, 3])


### PR DESCRIPTION
Disclaimer: I have no idea what I'm doing when it comes to Elixir.

But! Today I ran `Enum.shuffle` without first running `:random.seed` and it shuffled an array correctly a couple of times, _not_ returning the same value each time.

```
iex(1)> list = [1,2,3,4,5]
[1, 2, 3, 4, 5]
iex(2)> Enum.shuffle(list)
[3, 2, 4, 1, 5]
iex(3)> Enum.shuffle(list)
[2, 3, 1, 5, 4]
iex(4)> Enum.shuffle(list)
[3, 5, 2, 4, 1]
```

So... I don't think we need to run `:random.seed()` here? I'm quite happy to be proven wrong here and learn something from the experience!