### PR TITLE
Add System.get_env/2 to provide and return a default value

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -257,6 +257,21 @@ defmodule System do
   end
 
   @doc """
+  Environment variable value or default value.
+
+  Returns the value of the environment variable
+  `varname` as a binary if set, or `default` if the environment
+  variable is undefined.
+  """
+  @spec get_env(binary, binary) :: binary
+  def get_env(varname, default) when is_binary(varname) and is_binary(default) do
+    case get_env(varname) do
+      nil -> default
+      other -> other
+    end
+  end
+
+  @doc """
   Erlang VM process identifier.
 
   Returns the process identifier of the current Erlang emulator

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -51,9 +51,11 @@ defmodule SystemTest do
     System.put_env(@test_var, "SAMPLE")
     assert System.get_env(@test_var) == "SAMPLE"
     assert System.get_env()[@test_var] == "SAMPLE"
+    assert System.get_env(@test_var, "DEFAULT") == "SAMPLE"
 
     System.delete_env(@test_var)
     assert System.get_env(@test_var) == nil
+    assert System.get_env(@test_var, "DEFAULT") == "DEFAULT"
 
     System.put_env(%{@test_var => "OTHER_SAMPLE"})
     assert System.get_env(@test_var) == "OTHER_SAMPLE"


### PR DESCRIPTION
We ran into a situation where we wanted to get either the value of an environment variable - if set - or a default value if the variable is not set.

Instead of implementing it in our application, we thought it might be useful as a general solution. So you can call `System.get_env("VAR", "DEFAULT")`.

Pair: @felipesere