### PR TITLE
Add IEx width option for larger terminal screens.

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -212,8 +212,8 @@ defmodule IEx do
   @doc """
   Configures IEx.
 
-  The supported options are: `:colors`, `:inspect`,
-  `:default_prompt`, `:alive_prompt` and `:history_size`.
+  The supported options are: `:colors`, `:inspect`, `:width`,
+  `:history_size`, `:default_prompt` and `:alive_prompt`.
 
   ## Colors
 
@@ -249,6 +249,15 @@ defmodule IEx do
   pretty formatting with a limit of 50 entries.
 
   See `Inspect.Opts` for the full list of options.
+
+  ## Width
+
+  An integer indicating the number of columns to use in documentation
+  output. Default is 80 columns or result of `:io.columns`, whichever
+  is smaller. The configured value will be used unless it is too large,
+  which in that case `:io.columns` is used. This way you can configure
+  IEx to be your largest screen size and it should always take up the
+  full width of your terminal screen.
 
   ## History size
 

--- a/lib/iex/lib/iex/config.ex
+++ b/lib/iex/lib/iex/config.ex
@@ -3,7 +3,7 @@ defmodule IEx.Config do
 
   @table __MODULE__
   @agent __MODULE__
-  @keys [:colors, :inspect, :history_size, :default_prompt, :alive_prompt]
+  @keys [:colors, :inspect, :history_size, :default_prompt, :alive_prompt, :width]
   @colors [:eval_interrupt, :eval_result, :eval_error, :eval_info, :stack_app,
     :stack_info, :ls_directory, :ls_device]
 
@@ -46,6 +46,7 @@ defmodule IEx.Config do
   defp merge_option(:history_size, _old, new) when is_integer(new), do: new
   defp merge_option(:default_prompt, _old, new) when is_binary(new), do: new
   defp merge_option(:alive_prompt, _old, new) when is_binary(new), do: new
+  defp merge_option(:width, _old, new) when is_integer(new), do: new
 
   defp merge_option(k, _old, new) do
     raise ArgumentError, "invalid configuration or value for pair #{inspect k} - #{inspect new}"
@@ -136,8 +137,14 @@ defmodule IEx.Config do
   end
 
   def width() do
+    columns = columns()
+    value = Application.get_env(:iex, :width) || min(columns, 80)
+    min(value, columns)
+  end
+
+  defp columns() do
     case :io.columns() do
-      {:ok, width} -> min(width, 80)
+      {:ok, width} -> width
       {:error, _}  -> 80
     end
   end


### PR DESCRIPTION
Would be nice to be able to change the column width in the `.iex.exs` file to allow for custom width output of documentation. This PR should allow that customization while still falling back to `:io.columns` when the terminal window is smaller.