### PR TITLE
Load both global and local .iex.exs

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -122,12 +122,13 @@ defmodule IEx do
 
   ## The .iex.exs file
 
-  When starting IEx, it will look for a local `.iex.exs` file (located in the current
-  working directory), then a global one (located at `~/.iex.exs`) and will load the
-  first one it finds (if any). The code in the chosen .iex.exs file will be
-  evaluated in the shell's context. So, for instance, any modules that are
-  loaded or variables that are bound in the .iex.exs file will be available in the
-  shell after it has booted.
+  When starting IEx, it will look for a global `.iex.exs` (located at `~/.iex.exs`),
+  then a local one (located in the current working directory) and will load any
+  it finds (if any). The code in both .iex.exs file(s) will be evaluated in the
+  shell's context. So, for instance, any modules that are loaded or variables
+  that are bound in the .iex.exs file(s) will be available in the shell after
+  it has booted. Since the local is run second, any conflicts in variables bound
+  will be the result of the local `.iex.exs` file.
 
   Sample contents of a local .iex.exs file:
 

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -40,16 +40,11 @@ defmodule IEx.Evaluator do
     candidates = if path do
       [path]
     else
-      Enum.map [".iex.exs", "~/.iex.exs"], &Path.expand/1
+      Enum.map ["~/.iex.exs", ".iex.exs"], &Path.expand/1
     end
 
-    path = Enum.find candidates, &File.regular?/1
-
-    if is_nil(path) do
-      state
-    else
-      eval_dot_iex(state, path)
-    end
+    Stream.filter(candidates, &File.regular?/1)
+    |> Enum.reduce(state, &(eval_dot_iex(&2, &1)))
   end
 
   defp eval_dot_iex(state, path) do


### PR DESCRIPTION
I found myself, as well as this being mentioned in a elixir-sip videocast not too long ago, having to put a file exists check in all my project `.iex.exs` files so that it would load both files. I can't think of any reason why it should not already load both files, so I submitted this PR.

The following is becoming boilerplate in `.iex.exs` for projects with multiple people:
```
if File.exists?(Path.expand("~/.iex.exs")), do: import_file "~/.iex.exs"
```