### PR TITLE
Omit `else` option in `if` and `unless` clauses if it returns `nil`

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -320,7 +320,7 @@ defmodule Protocol do
   end
 
   defp change_impl_for([{:function, line, :impl_for, 1, _}|t], protocol, types, structs, is_protocol, acc) do
-    fallback = if Any in types, do: load_impl(protocol, Any), else: nil
+    fallback = if Any in types, do: load_impl(protocol, Any)
 
     clauses = for {guard, mod} <- builtin,
                   mod in types,
@@ -334,7 +334,7 @@ defmodule Protocol do
   end
 
   defp change_impl_for([{:function, line, :struct_impl_for, 1, _}|t], protocol, types, structs, is_protocol, acc) do
-    fallback = if Any in types, do: load_impl(protocol, Any), else: nil
+    fallback = if Any in types, do: load_impl(protocol, Any)
     clauses = for struct <- structs, do: each_struct_clause_for(struct, protocol, line)
     clauses = clauses ++ [fallback_clause_for(fallback, protocol, line)]
 

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -339,7 +339,7 @@ defmodule URI do
   # to replace those with nil for consistency.
   defp nillify(l) do
     for s <- l do
-      if byte_size(s) > 0, do: s, else: nil
+      if byte_size(s) > 0, do: s
     end
   end
 

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -805,9 +805,9 @@ defmodule StreamTest do
   end
 
   test "unfold/2" do
-    stream = Stream.unfold(10, fn x -> if x > 0, do: {x, x-1}, else: nil end)
+    stream = Stream.unfold(10, fn x -> if x > 0, do: {x, x-1} end)
     assert Enum.take(stream, 5) == [10, 9, 8, 7, 6]
-    stream = Stream.unfold(5, fn x -> if x > 0, do: {x, x-1}, else: nil end)
+    stream = Stream.unfold(5, fn x -> if x > 0, do: {x, x-1} end)
     assert Enum.to_list(stream) == [5, 4, 3, 2, 1]
   end
 
@@ -815,12 +815,12 @@ defmodule StreamTest do
     stream = Stream.unfold(1, fn x -> if x > 0, do: {x, x-1}, else: throw(:boom) end)
     assert Enum.take(stream, 1) == [1]
 
-    stream = Stream.unfold(5, fn x -> if x > 0, do: {x, x-1}, else: nil end)
+    stream = Stream.unfold(5, fn x -> if x > 0, do: {x, x-1} end)
     assert Enum.to_list(Stream.take(stream, 2)) == [5, 4]
   end
 
   test "unfold/2 is zippable" do
-    stream = Stream.unfold(10, fn x -> if x > 0, do: {x, x-1}, else: nil end)
+    stream = Stream.unfold(10, fn x -> if x > 0, do: {x, x-1} end)
     list   = Enum.to_list(stream)
     assert Enum.zip(list, list) == Enum.zip(stream, stream)
   end


### PR DESCRIPTION
Disclosure: working on a comprehensive style guide.