### PR TITLE
Add `Macro.traverse/4` pre/post-order traversal at the same time

### DIFF
--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -550,7 +550,27 @@ defmodule MacroTest do
     assert Macro.unpipe(quote(do: foo |> bar |> baz)) == quote(do: [{foo, 0}, {bar, 0}, {baz, 0}])
   end
 
-  ## pre/postwalk
+  ## traverse/pre/postwalk
+
+  test "traverse" do
+    assert traverse({:foo, [], nil}) ==
+           [{:foo, [], nil}, {:foo, [], nil}]
+
+    assert traverse({:foo, [], [1, 2, 3]}) ==
+           [{:foo, [], [1, 2, 3]}, 1, 1, 2, 2, 3, 3, {:foo, [], [1, 2, 3]}]
+
+    assert traverse({{:., [], [:foo, :bar]}, [], [1, 2, 3]}) ==
+           [{{:., [], [:foo, :bar]}, [], [1, 2, 3]}, {:., [], [:foo, :bar]}, :foo, :foo, :bar, :bar, {:., [], [:foo, :bar]},
+            1, 1, 2, 2, 3, 3, {{:., [], [:foo, :bar]}, [], [1, 2, 3]}]
+
+    assert traverse({[1, 2, 3], [4, 5, 6]}) ==
+           [{[1, 2, 3], [4, 5, 6]}, [1, 2, 3], 1, 1, 2, 2, 3, 3, [1, 2, 3],
+            [4, 5, 6], 4, 4, 5, 5, 6, 6, [4, 5, 6], {[1, 2, 3], [4, 5, 6]}]
+  end
+
+  defp traverse(ast) do
+    Macro.traverse(ast, [], &{&1, [&1|&2]}, &{&1, [&1|&2]}) |> elem(1) |> Enum.reverse
+  end
 
   test "prewalk" do
     assert prewalk({:foo, [], nil}) ==


### PR DESCRIPTION
## Proposal

My proposal is the following:

```elixir
Macro.traverse(ast, accumulator, pre_function, post_function)
```

The specification almost is same as `Macro.prewalk/3` and `Macro.postwalk/3`, difference is that `Macro.traverse` is received both pre/post-order functions as arguments.
The third argument `pre_function` specification is same as `Macro.prewalk/3`'s third argument.
The forth argument `post_function` specification is same as `Macro.postwalk/3`'s third argument.

## Example

```iex
iex(1)> Macro.traverse(quote(do: :foo), 0,
...(1)>   fn (ast, acc) -> IO.puts "#{acc} pre"; IO.inspect ast; {ast, acc + 1} end,
...(1)>   fn (ast, acc) -> IO.puts "#{acc} post"; IO.inspect ast; {ast, acc - 1} end)
0 pre
:foo
1 post
:foo
{:foo, 0}
```

## References

https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/elixir-lang-core/IXNHMUh304Q

