### PR TITLE
List `as_boolean/1` under `Kernel.Typespec` built-ins.

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -112,6 +112,7 @@ defmodule Kernel.Typespec do
   `no_return()`           | `none()`
   `fun()`                 | `(... -> any)`
   `struct()`              | `%{__struct__: atom()}`
+  `as_boolean(t)`         | `t`
 
   ### Remote types
 


### PR DESCRIPTION
Updates the `Kernel.Typespec` moduledoc to include `as_boolean/1` in the built-ins list.

Not 100% sure the definition is correct, if it is, then this closes #3788. 