### PR TITLE
Update license year in NOTICE, README, LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2012 Plataformatec
+Copyright 2015 Plataformatec
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,7 @@
 LEGAL NOTICE INFORMATION
 ------------------------
 
-All the files in this distribution are copyright (c) 2012 Plataformatec
+All the files in this distribution are copyright (c) 2015 Plataformatec
 covered under Elixir's license (see the file LICENSE) except the cases
 below.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ We usually keep a list of features and bugs [in the issue tracker][2].
 
 ## License
 
-"Elixir" and the Elixir logo are copyright (c) 2012 Plataformatec.
+"Elixir" and the Elixir logo are copyright (c) 2015 Plataformatec.
 
 Elixir source code is released under Apache 2 License.
 


### PR DESCRIPTION
Looks like the LICENSE had a 2012 copyright- shouldn't that be modified to 2015?