### PR TITLE
change irc:// URI to freenode's webchat

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ We usually keep a list of features and bugs [in the issue tracker][2].
   [2]: https://github.com/elixir-lang/elixir/issues
   [3]: https://groups.google.com/group/elixir-lang-talk
   [4]: https://groups.google.com/group/elixir-lang-core
-  [5]: irc://chat.freenode.net/elixir-lang
+  [5]: https://webchat.freenode.net/?channels=#elixir-lang
   [6]: http://www.freenode.net
   [7]: http://elixir-lang.org/docs.html
 


### PR DESCRIPTION
most IRC clients don't seem to support irc://, obviously not the command-line ones. additionally, GitHub doesn't consider irc:// a hyperlink so that's less useful but it does hyperlink this (and we're on freenode)