### PR TITLE
Add some tests for dialyzer warnings and silence remote call warnings

### DIFF
--- a/lib/elixir/src/elixir_translator.erl
+++ b/lib/elixir/src/elixir_translator.erl
@@ -236,19 +236,22 @@ translate({{'.', _, [Left, Right]}, Meta, []}, S)
       {atom, Line, term},
       TVar}]},
 
+  %% TODO: there is a bug in dialyzer that warns about generated matches that
+  %% can never match on line 0. The is_map/1 guard is used instead of a matching
+  %% against an empty map to avoid the warning.
   {{'case', ?generated, TLeft, [
     {clause, ?generated,
       [{map, Line, [{map_field_exact, Line, TRight, TVar}]}],
       [],
       [TVar]},
     {clause, ?generated,
-      [{match, Line, TVar, {map, Line, []}}],
-      [],
+      [TVar],
+      [[elixir_utils:erl_call(?generated, erlang, is_map, [TVar])]],
       [elixir_utils:erl_call(Line, erlang, error, [TMap])]},
     {clause, ?generated,
       [TVar],
       [],
-      [{call, Line, {remote, Line, TVar, TRight}, []}]}
+      [{call, ?generated, {remote, Line, TVar, TRight}, []}]}
   ]}, SV};
 
 translate({{'.', _, [Left, Right]}, Meta, Args}, S)

--- a/lib/elixir/test/elixir/dialyzer_test.exs
+++ b/lib/elixir/test/elixir/dialyzer_test.exs
@@ -1,0 +1,58 @@
+Code.require_file "test_helper.exs", __DIR__
+
+defmodule DialyzerTest do
+  use ExUnit.Case, async: true
+  import PathHelpers
+
+  @moduletag :dialyzer
+
+  setup_all do
+    dir = tmp_path("dialyzer")
+    File.mkdir_p!(dir)
+    plt = Path.join(dir, "base_plt") |> String.to_char_list()
+    :dialyzer.run([analysis_type: :plt_build, output_plt: plt, apps: [:erts]])
+    {:ok, [base_dir: dir, base_plt: plt]}
+  end
+
+  setup context do
+    # Set up a per-test temporary directory, so we can run these with async: true.
+    # We use the test's line number as the directory name, so they won't conflict.
+    dir = context[:base_dir]
+      |> Path.join("line#{context[:line]}")
+      |> String.to_char_list()
+    File.mkdir_p!(dir)
+
+    base_plt = context[:base_plt]
+    plt = dir
+      |> Path.join("plt")
+      |> String.to_char_list()
+    File.cp!(base_plt, plt)
+
+    dialyzer = [analysis_type: :succ_typings, check_plt: false,
+      files_rec: [dir], plts: [plt]]
+
+    {:ok, [outdir: dir, dialyzer: dialyzer]}
+  end
+
+  test "No warnings on valid remote calls", context do
+    fixture = fixture_path("dialyzer/remote_call.ex")
+    assert '' = elixirc("#{fixture} -o #{context[:outdir]}")
+    case :dialyzer.run(context[:dialyzer]) do
+      [] ->
+        :ok
+      warnings ->
+        flunk IO.chardata_to_string(for warn <- warnings, do: [:dialyzer.format_warning(warn), ?\n])
+    end
+  end
+
+  test "No warnings on valid raise", context do
+    fixture = fixture_path("dialyzer/raise.ex")
+    assert '' = elixirc("#{fixture} -o #{context[:outdir]}")
+    case :dialyzer.run(context[:dialyzer]) do
+      [] ->
+        :ok
+      warnings ->
+        flunk IO.chardata_to_string(for warn <- warnings, do: [:dialyzer.format_warning(warn), ?\n])
+    end
+  end
+end

--- a/lib/elixir/test/elixir/fixtures/dialyzer/raise.ex
+++ b/lib/elixir/test/elixir/fixtures/dialyzer/raise.ex
@@ -1,0 +1,23 @@
+defmodule DialyzerRaise do
+
+  @dialyzer :no_undefined_callbacks
+  defexception [:message]
+
+  def exception_var() do
+    e = %DialyzerRaise{}
+    raise e
+  end
+
+  def exception_var(e = %DialyzerRaise{}) do
+    raise e
+  end
+
+  def string_var() do
+    string = "hello"
+    raise string
+  end
+
+  def string_var(string) when is_binary(string) do
+    raise string
+  end
+end

--- a/lib/elixir/test/elixir/fixtures/dialyzer/remote_call.ex
+++ b/lib/elixir/test/elixir/fixtures/dialyzer/remote_call.ex
@@ -1,0 +1,20 @@
+defmodule DialyzerRemoteCall do
+
+  def map_var() do
+    map = %{a: 1}
+    map.key
+  end
+
+  def map_var(map) when is_map(map) do
+    map.key
+  end
+
+  def mod_var() do
+    module = Hello
+    module.fun
+  end
+
+  def mod_var(module) when is_atom(module) or is_atom(elem(module, 0)) do
+    module.fun
+  end
+end


### PR DESCRIPTION
The raise test fails for two reasons:
* Generated `exception/1` specs are too complex
* Missing feature to mark quoted AST as generated

We should report/fix the issue upstream in the TODO comment in elixir_translator.erl about generated matches.
