### PR TITLE
Add some tests for dialyzer warnings and silence remote call warnings

### DIFF
--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -1,5 +1,7 @@
 -define(m(M, K), maps:get(K, M)).
+-define(ann(Opts), elixir_utils:get_ann(Opts)).
 -define(line(Opts), elixir_utils:get_line(Opts)).
+-define(generated, [{generated, true}, {location, 0}]).
 
 -record(elixir_scope, {
   context=nil,             %% can be match, guards or nil

--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -147,7 +147,7 @@ translate(Meta, Args, S) ->
 
 build_bitstr(Fun, Exprs, Meta, S) ->
   {Final, FinalS} = build_bitstr_each(Fun, Exprs, Meta, S, []),
-  {{bin, ?line(Meta), lists:reverse(Final)}, FinalS}.
+  {{bin, ?ann(Meta), lists:reverse(Final)}, FinalS}.
 
 build_bitstr_each(_Fun, [], _Meta, S, Acc) ->
   {Acc, S};
@@ -165,11 +165,11 @@ build_bitstr_each(Fun, T, Meta, S, Acc, H, default, Types) when is_binary(H) ->
       true ->
         %% See explanation in elixir_utils:elixir_to_erl/1 to know
         %% why we can simply convert the binary to a list.
-        {bin_element, ?line(Meta), {string, 0, binary_to_list(H)}, default, default};
+        {bin_element, ?ann(Meta), {string, 0, binary_to_list(H)}, default, default};
       false ->
         case types_require_conversion(Types) of
           true ->
-            {bin_element, ?line(Meta), {string, 0, elixir_utils:characters_to_list(H)}, default, Types};
+            {bin_element, ?ann(Meta), {string, 0, elixir_utils:characters_to_list(H)}, default, Types};
           false ->
             elixir_errors:compile_error(Meta, S#elixir_scope.file, "invalid types for literal string in <<>>. "
               "Accepted types are: little, big, utf8, utf16, utf32, bits, bytes, binary, bitstring")
@@ -192,10 +192,10 @@ build_bitstr_each(Fun, T, Meta, S, Acc, H, Size, Types) ->
     {bin, _, Elements} ->
       case (Size == default) andalso types_allow_splice(Types, Elements) of
         true  -> build_bitstr_each(Fun, T, Meta, NS, lists:reverse(Elements, Acc));
-        false -> build_bitstr_each(Fun, T, Meta, NS, [{bin_element, ?line(Meta), Expr, Size, Types}|Acc])
+        false -> build_bitstr_each(Fun, T, Meta, NS, [{bin_element, ?ann(Meta), Expr, Size, Types}|Acc])
       end;
     _ ->
-      build_bitstr_each(Fun, T, Meta, NS, [{bin_element, ?line(Meta), Expr, Size, Types}|Acc])
+      build_bitstr_each(Fun, T, Meta, NS, [{bin_element, ?ann(Meta), Expr, Size, Types}|Acc])
   end.
 
 types_require_conversion([End|T]) when End == little; End == big -> types_require_conversion(T);

--- a/lib/elixir/src/elixir_def_defaults.erl
+++ b/lib/elixir/src/elixir_def_defaults.erl
@@ -29,14 +29,14 @@ unpack_each(Kind, Name, [{'\\\\', DefMeta, [Expr, _]}|T] = List, Acc, Clauses, S
   {DefArgs, SA}  = elixir_clauses:match(fun elixir_translator:translate_args/2, Base ++ Args, S),
   {DefInvoke, _} = elixir_translator:translate_args(Base ++ Invoke, SA),
 
-  Line = ?line(DefMeta),
+  Ann = ?ann(DefMeta),
 
-  Call = {call, Line,
-    {atom, Line, name_for_kind(Kind, Name)},
+  Call = {call, Ann,
+    {atom, Ann, name_for_kind(Kind, Name)},
     DefInvoke
   },
 
-  Clause = {clause, Line, DefArgs, [], [Call]},
+  Clause = {clause, Ann, DefArgs, [], [Call]},
   unpack_each(Kind, Name, T, [Expr|Acc], [Clause|Clauses], S);
 
 unpack_each(Kind, Name, [H|T], Acc, Clauses, S) ->

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -99,7 +99,6 @@ parse_erl_term(Term) ->
   {ok, Parsed} = erl_parse:parse_term(Tokens ++ [{dot, 1}]),
   Parsed.
 
-
 %% Handle warnings and errors from Erlang land (called during module compilation)
 
 %% Ignore on bootstrap

--- a/lib/elixir/src/elixir_fn.erl
+++ b/lib/elixir/src/elixir_fn.erl
@@ -6,8 +6,8 @@
 translate(Meta, Clauses, S) ->
   Transformer = fun({'->', CMeta, [ArgsWithGuards, Expr]}, Acc) ->
     {Args, Guards} = elixir_clauses:extract_splat_guards(ArgsWithGuards),
-    {TClause, TS } = elixir_clauses:clause(?line(CMeta), fun translate_fn_match/2,
-                                             Args, Expr, Guards, Acc),
+    {TClause, TS } = elixir_clauses:clause(CMeta, fun translate_fn_match/2,
+                                            Args, Expr, Guards, Acc),
     {TClause, elixir_scope:mergef(S, TS)}
   end,
 
@@ -16,7 +16,7 @@ translate(Meta, Clauses, S) ->
 
   case lists:usort(Arities) of
     [_] ->
-      {{'fun', ?line(Meta), {clauses, TClauses}}, NS};
+      {{'fun', ?ann(Meta), {clauses, TClauses}}, NS};
     _ ->
       compile_error(Meta, S#elixir_scope.file,
                     "cannot mix clauses with different arities in function definition")

--- a/lib/elixir/src/elixir_for.erl
+++ b/lib/elixir/src/elixir_for.erl
@@ -53,16 +53,16 @@ translate(Meta, Args, Return, S) ->
   {AccName, _, SA} = elixir_scope:build_var('_', S),
   {VarName, _, SV} = elixir_scope:build_var('_', SA),
 
-  Line = ?line(Meta),
-  Acc  = {var, Line, AccName},
-  Var  = {var, Line, VarName},
+  Ann = ?ann(Meta),
+  Acc  = {var, Ann, AccName},
+  Var  = {var, Ann, VarName},
 
   {Cases, [{do, Expr}|Opts]} = elixir_utils:split_last(Args),
 
   {TInto, SI} =
     case lists:keyfind(into, 1, Opts) of
       {into, Into} -> elixir_translator:translate(Into, SV);
-      false when Return -> {{nil, Line}, SV};
+      false when Return -> {{nil, Ann}, SV};
       false -> {false, SV}
     end,
 
@@ -72,9 +72,9 @@ translate(Meta, Args, Return, S) ->
 
   case comprehension_expr(TInto, TExpr) of
     {inline, TIntoExpr} ->
-      {build_inline(Line, TCases, TIntoExpr, TInto, Var, Acc, SE), SF};
+      {build_inline(Ann, TCases, TIntoExpr, TInto, Var, Acc, SE), SF};
     {into, TIntoExpr} ->
-      build_into(Line, TCases, TIntoExpr, TInto, Var, Acc, SF)
+      build_into(Ann, TCases, TIntoExpr, TInto, Var, Acc, SF)
   end.
 
 translate_gen(ForMeta, [{'<-', Meta, [Left, Right]}|T], Acc, S) ->
@@ -125,56 +125,56 @@ collect_filters([H|T], Acc) ->
 collect_filters([], Acc) ->
   {Acc, []}.
 
-build_inline(Line, Clauses, Expr, Into, _Var, Acc, S) ->
+build_inline(Ann, Clauses, Expr, Into, _Var, Acc, S) ->
   case lists:all(fun(Clause) -> element(1, Clause) == bin end, Clauses) of
-    true  -> build_comprehension(Line, Clauses, Expr, Into);
+    true  -> build_comprehension(Ann, Clauses, Expr, Into);
     false -> build_reduce(Clauses, Expr, Into, Acc, S)
   end.
 
-build_into(Line, Clauses, Expr, Into, Fun, Acc, S) ->
-  {Kind, SK}   = build_var(Line, S),
-  {Reason, SR} = build_var(Line, SK),
-  {Stack, ST}  = build_var(Line, SR),
-  {Done, SD}   = build_var(Line, ST),
+build_into(Ann, Clauses, Expr, Into, Fun, Acc, S) ->
+  {Kind, SK}   = build_var(Ann, S),
+  {Reason, SR} = build_var(Ann, SK),
+  {Stack, ST}  = build_var(Ann, SR),
+  {Done, SD}   = build_var(Ann, ST),
 
-  IntoExpr  = {call, Line, Fun, [Acc, pair(Line, cont, Expr)]},
-  MatchExpr = {match, Line,
-    {tuple, Line, [Acc, Fun]},
-    elixir_utils:erl_call(Line, 'Elixir.Collectable', into, [Into])
+  IntoExpr  = {call, Ann, Fun, [Acc, pair(Ann, cont, Expr)]},
+  MatchExpr = {match, Ann,
+    {tuple, Ann, [Acc, Fun]},
+    elixir_utils:erl_call(Ann, 'Elixir.Collectable', into, [Into])
   },
 
   TryExpr =
-    {'try', Line,
+    {'try', Ann,
       [build_reduce_clause(Clauses, IntoExpr, Acc, Acc, SD)],
-      [{clause, Line,
+      [{clause, Ann,
         [Done],
         [],
-        [{call, Line, Fun, [Done, {atom, Line, done}]}]}],
-      [{clause, Line,
-        [{tuple, Line, [Kind, Reason, {var, Line, '_'}]}],
+        [{call, Ann, Fun, [Done, {atom, Ann, done}]}]}],
+      [{clause, Ann,
+        [{tuple, Ann, [Kind, Reason, {var, Ann, '_'}]}],
         [],
-        [{match, Line, Stack, elixir_utils:erl_call(Line, erlang, get_stacktrace, [])},
-         {call, Line, Fun, [Acc, {atom, Line, halt}]},
-         elixir_utils:erl_call(Line, erlang, raise, [Kind, Reason, Stack])]}],
+        [{match, Ann, Stack, elixir_utils:erl_call(Ann, erlang, get_stacktrace, [])},
+         {call, Ann, Fun, [Acc, {atom, Ann, halt}]},
+         elixir_utils:erl_call(Ann, erlang, raise, [Kind, Reason, Stack])]}],
       []},
 
-  {{block, Line, [MatchExpr, TryExpr]}, SD}.
+  {{block, Ann, [MatchExpr, TryExpr]}, SD}.
 
 %% Helpers
 
 build_reduce(Clauses, Expr, false, Acc, S) ->
   build_reduce_clause(Clauses, Expr, {nil, 0}, Acc, S);
-build_reduce(Clauses, Expr, {nil, Line} = Into, Acc, S) ->
-  ListExpr = {cons, Line, Expr, Acc},
-  elixir_utils:erl_call(Line, lists, reverse,
+build_reduce(Clauses, Expr, {nil, Ann} = Into, Acc, S) ->
+  ListExpr = {cons, Ann, Expr, Acc},
+  elixir_utils:erl_call(Ann, lists, reverse,
     [build_reduce_clause(Clauses, ListExpr, Into, Acc, S)]);
 build_reduce(Clauses, Expr, {bin, _, _} = Into, Acc, S) ->
-  {bin, Line, Elements} = Expr,
-  BinExpr = {bin, Line, [{bin_element, Line, Acc, default, [bitstring]}|Elements]},
+  {bin, Ann, Elements} = Expr,
+  BinExpr = {bin, Ann, [{bin_element, Ann, Acc, default, [bitstring]}|Elements]},
   build_reduce_clause(Clauses, BinExpr, Into, Acc, S).
 
 build_reduce_clause([{enum, Meta, Left, Right, Filters}|T], Expr, Arg, Acc, S) ->
-  Line  = ?line(Meta),
+  Ann  = ?ann(Meta),
   True  = build_reduce_clause(T, Expr, Acc, Acc, S),
   False = Acc,
 
@@ -182,23 +182,23 @@ build_reduce_clause([{enum, Meta, Left, Right, Filters}|T], Expr, Arg, Acc, S) -
     case is_var(Left) of
       true  -> [];
       false ->
-        [{clause, -1,
-          [{var, Line, '_'}, Acc], [],
+        [{clause, ?generated,
+          [{var, Ann, '_'}, Acc], [],
           [False]}]
     end,
 
   Clauses1 =
-    [{clause, Line,
+    [{clause, Ann,
       [Left, Acc], [],
-      [join_filters(Line, Filters, True, False)]}|Clauses0],
+      [join_filters(Ann, Filters, True, False)]}|Clauses0],
 
-  Args  = [Right, Arg, {'fun', Line, {clauses, Clauses1}}],
-  elixir_utils:erl_call(Line, 'Elixir.Enum', reduce, Args);
+  Args  = [Right, Arg, {'fun', Ann, {clauses, Clauses1}}],
+  elixir_utils:erl_call(Ann, 'Elixir.Enum', reduce, Args);
 
 build_reduce_clause([{bin, Meta, Left, Right, Filters}|T], Expr, Arg, Acc, S) ->
-  Line = ?line(Meta),
-  {Tail, ST} = build_var(Line, S),
-  {Fun, SF}  = build_var(Line, ST),
+  Ann = ?ann(Meta),
+  {Tail, ST} = build_var(Ann, S),
+  {Fun, SF}  = build_var(Ann, ST),
 
   True  = build_reduce_clause(T, Expr, Acc, Acc, SF),
   False = Acc,
@@ -206,26 +206,26 @@ build_reduce_clause([{bin, Meta, Left, Right, Filters}|T], Expr, Arg, Acc, S) ->
   {bin, _, Elements} = Left,
 
   BinMatch =
-    {bin, Line, Elements ++ [{bin_element, Line, Tail, default, [bitstring]}]},
+    {bin, Ann, Elements ++ [{bin_element, Ann, Tail, default, [bitstring]}]},
   NoVarMatch =
-    {bin, Line, no_var(Elements) ++ [{bin_element, Line, Tail, default, [bitstring]}]},
+    {bin, Ann, no_var(Elements) ++ [{bin_element, Ann, Tail, default, [bitstring]}]},
 
   Clauses =
-    [{clause, Line,
+    [{clause, Ann,
       [BinMatch, Acc], [],
-      [{call, Line, Fun, [Tail, join_filters(Line, Filters, True, False)]}]},
-     {clause, -1,
+      [{call, Ann, Fun, [Tail, join_filters(Ann, Filters, True, False)]}]},
+     {clause, ?generated,
       [NoVarMatch, Acc], [],
-      [{call, Line, Fun, [Tail, False]}]},
-     {clause, -1,
-      [{bin, Line, []}, Acc], [],
+      [{call, Ann, Fun, [Tail, False]}]},
+     {clause, ?generated,
+      [{bin, Ann, []}, Acc], [],
       [Acc]},
-     {clause, -1,
-      [Tail, {var, Line, '_'}], [],
-      [elixir_utils:erl_call(Line, erlang, error, [pair(Line, badarg, Tail)])]}],
+     {clause, ?generated,
+      [Tail, {var, Ann, '_'}], [],
+      [elixir_utils:erl_call(Ann, erlang, error, [pair(Ann, badarg, Tail)])]}],
 
-  {call, Line,
-    {named_fun, Line, element(3, Fun), Clauses},
+  {call, Ann,
+    {named_fun, Ann, element(3, Fun), Clauses},
     [Right, Arg]};
 
 build_reduce_clause([], Expr, _Arg, _Acc, _S) ->
@@ -234,31 +234,31 @@ build_reduce_clause([], Expr, _Arg, _Acc, _S) ->
 is_var({var, _, _}) -> true;
 is_var(_) -> false.
 
-pair(Line, Atom, Arg) ->
-  {tuple, Line, [{atom, Line, Atom}, Arg]}.
+pair(Ann, Atom, Arg) ->
+  {tuple, Ann, [{atom, Ann, Atom}, Arg]}.
 
-build_var(Line, S) ->
+build_var(Ann, S) ->
   {Name, _, ST} = elixir_scope:build_var('_', S),
-  {{var, Line, Name}, ST}.
+  {{var, Ann, Name}, ST}.
 
 no_var(Elements) ->
-  [{bin_element, Line, no_var_expr(Expr), Size, Types} ||
-    {bin_element, Line, Expr, Size, Types} <- Elements].
-no_var_expr({var, Line, _}) ->
-  {var, Line, '_'}.
+  [{bin_element, Ann, no_var_expr(Expr), Size, Types} ||
+    {bin_element, Ann, Expr, Size, Types} <- Elements].
+no_var_expr({var, Ann, _}) ->
+  {var, Ann, '_'}.
 
-build_comprehension(Line, Clauses, Expr, false) ->
-  {block, Line, [
-    build_comprehension(Line, Clauses, Expr, {nil, Line}),
-    {nil, Line}
+build_comprehension(Ann, Clauses, Expr, false) ->
+  {block, Ann, [
+    build_comprehension(Ann, Clauses, Expr, {nil, Ann}),
+    {nil, Ann}
   ]};
-build_comprehension(Line, Clauses, Expr, Into) ->
-  {comprehension_kind(Into), Line, Expr, comprehension_clause(Clauses)}.
+build_comprehension(Ann, Clauses, Expr, Into) ->
+  {comprehension_kind(Into), Ann, Expr, comprehension_clause(Clauses)}.
 
 comprehension_clause([{Kind, Meta, Left, Right, Filters}|T]) ->
-  Line = ?line(Meta),
-  [{comprehension_generator(Kind), Line, Left, Right}] ++
-    comprehension_filter(Line, Filters) ++
+  Ann = ?ann(Meta),
+  [{comprehension_generator(Kind), Ann, Left, Right}] ++
+    comprehension_filter(Ann, Filters) ++
     comprehension_clause(T);
 comprehension_clause([]) ->
   [].
@@ -271,8 +271,8 @@ comprehension_generator(bin) -> b_generate.
 
 comprehension_expr({bin, _, []}, {bin, _, _} = Expr) ->
   {inline, Expr};
-comprehension_expr({bin, Line, []}, Expr) ->
-  BinExpr = {bin, Line, [{bin_element, Line, Expr, default, [bitstring]}]},
+comprehension_expr({bin, Ann, []}, Expr) ->
+  BinExpr = {bin, Ann, [{bin_element, Ann, Expr, default, [bitstring]}]},
   {inline, BinExpr};
 comprehension_expr({nil, _}, Expr) ->
   {inline, Expr};
@@ -281,29 +281,29 @@ comprehension_expr(false, Expr) ->
 comprehension_expr(_, Expr) ->
   {into, Expr}.
 
-comprehension_filter(Line, Filters) ->
-  [join_filter(Line, Filter, {atom, Line, true}, {atom, Line, false}) ||
+comprehension_filter(Ann, Filters) ->
+  [join_filter(Ann, Filter, {atom, Ann, true}, {atom, Ann, false}) ||
    Filter <- lists:reverse(Filters)].
 
-join_filters(_Line, [], True, _False) ->
+join_filters(_Ann, [], True, _False) ->
   True;
-join_filters(Line, [H|T], True, False) ->
+join_filters(Ann, [H|T], True, False) ->
   lists:foldl(fun(Filter, Acc) ->
-    join_filter(Line, Filter, Acc, False)
-  end, join_filter(Line, H, True, False), T).
+    join_filter(Ann, Filter, Acc, False)
+  end, join_filter(Ann, H, True, False), T).
 
-join_filter(Line, {nil, Filter}, True, False) ->
-  {'case', Line, Filter, [
-    {clause, Line, [{atom, Line, true}], [], [True]},
-    {clause, Line, [{atom, Line, false}], [], [False]}
+join_filter(Ann, {nil, Filter}, True, False) ->
+  {'case', Ann, Filter, [
+    {clause, Ann, [{atom, Ann, true}], [], [True]},
+    {clause, Ann, [{atom, Ann, false}], [], [False]}
   ]};
-join_filter(Line, {Var, Filter}, True, False) ->
+join_filter(Ann, {Var, Filter}, True, False) ->
   Guard =
-    {op, Line, 'orelse',
-      {op, Line, '==', Var, {atom, Line, false}},
-      {op, Line, '==', Var, {atom, Line, nil}}},
+    {op, Ann, 'orelse',
+      {op, Ann, '==', Var, {atom, Ann, false}},
+      {op, Ann, '==', Var, {atom, Ann, nil}}},
 
-  {'case', Line, Filter, [
-    {clause, Line, [Var], [[Guard]], [False]},
-    {clause, Line, [{var, Line, '_'}], [], [True]}
+  {'case', Ann, Filter, [
+    {clause, Ann, [Var], [[Guard]], [False]},
+    {clause, Ann, [{var, Ann, '_'}], [], [True]}
   ]}.

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -67,20 +67,20 @@ translate_struct(Meta, Name, {'%{}', MapMeta, Args}, S) ->
 
   if
     TUpdate /= nil ->
-      Line  = ?line(Meta),
+      Ann = ?ann(Meta),
       {VarName, _, VS} = elixir_scope:build_var('_', US),
 
-      Var = {var, Line, VarName},
-      Map = {map, Line, [{map_field_exact, Line, {atom, Line, '__struct__'}, {atom, Line, Name}}]},
+      Var = {var, Ann, VarName},
+      Map = {map, Ann, [{map_field_exact, Ann, {atom, Ann, '__struct__'}, {atom, Ann, Name}}]},
 
-      Match = {match, Line, Var, Map},
-      Error = {tuple, Line, [{atom, Line, badstruct}, {atom, Line, Name}, Var]},
+      Match = {match, Ann, Var, Map},
+      Error = {tuple, Ann, [{atom, Ann, badstruct}, {atom, Ann, Name}, Var]},
 
       {TMap, TS} = translate_map(MapMeta, Assocs, Var, VS),
 
-      {{'case', Line, TUpdate, [
-        {clause, Line, [Match], [], [TMap]},
-        {clause, Line, [Var], [], [elixir_utils:erl_call(Line, erlang, error, [Error])]}
+      {{'case', Ann, TUpdate, [
+        {clause, Ann, [Match], [], [TMap]},
+        {clause, Ann, [Var], [], [elixir_utils:erl_call(Ann, erlang, error, [Error])]}
       ]}, TS};
     S#elixir_scope.context == match ->
       translate_map(MapMeta, Assocs ++ [{'__struct__', Name}], nil, US);
@@ -151,15 +151,15 @@ wait_for_struct(Module) ->
 translate_map(Meta, Assocs, TUpdate, #elixir_scope{extra=Extra} = S) ->
   {Op, KeyFun, ValFun} = extract_key_val_op(TUpdate, S),
 
-  Line = ?line(Meta),
+  Ann = ?ann(Meta),
 
   {TArgs, SA} = lists:mapfoldl(fun({Key, Value}, Acc) ->
     {TKey, Acc1}   = KeyFun(Key, Acc),
     {TValue, Acc2} = ValFun(Value, Acc1#elixir_scope{extra=Extra}),
-    {{Op, ?line(Meta), TKey, TValue}, Acc2}
+    {{Op, ?ann(Meta), TKey, TValue}, Acc2}
   end, S, Assocs),
 
-  build_map(Line, TUpdate, TArgs, SA).
+  build_map(Ann, TUpdate, TArgs, SA).
 
 extract_assoc_update([{'|', _Meta, [Update, Args]}], S) ->
   {TArg, SA} = elixir_translator:translate_arg(Update, S, S),
@@ -177,8 +177,8 @@ extract_key_val_op(TUpdate, S) ->
     fun(X, Acc) -> elixir_translator:translate_arg(X, Acc, KS) end,
     fun(X, Acc) -> elixir_translator:translate_arg(X, Acc, S) end}.
 
-build_map(Line, nil, TArgs, SA) -> {{map, Line, TArgs}, SA};
-build_map(Line, TUpdate, TArgs, SA) -> {{map, Line, TUpdate, TArgs}, SA}.
+build_map(Ann, nil, TArgs, SA) -> {{map, Ann, TArgs}, SA};
+build_map(Ann, TUpdate, TArgs, SA) -> {{map, Ann, TUpdate, TArgs}, SA}.
 
 assert_struct_keys(Meta, Name, Struct, Assocs, S) ->
   [begin

--- a/lib/elixir/src/elixir_quote.erl
+++ b/lib/elixir/src/elixir_quote.erl
@@ -52,10 +52,10 @@ do_linify_meta(Line, line, Meta) ->
     _ ->
       keystore(line, Meta, Line)
   end;
-do_linify_meta(Line, Key, Meta) ->
-  case keyfind(Key, Meta) of
-    {Key, Int} when is_integer(Int), Int /= 0 ->
-      keyreplace(Key, Meta, {line, Int});
+do_linify_meta(Line, keep, Meta) ->
+  case keyfind(keep, Meta) of
+    {keep, Int} when is_integer(Int), Int /= 0 ->
+      keyreplace(keep, keydelete(line, Meta), {line, Int});
     _ ->
       do_linify_meta(Line, line, Meta)
   end.

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -1,9 +1,8 @@
 -module(elixir_rewrite).
 -export([rewrite/5, inline/3]).
+-include("elixir.hrl").
 
 %% Convenience variables
-
--define(hidden, [{line, -1}]).
 
 -define(atom, 'Elixir.Atom').
 -define(enum, 'Elixir.Enum').
@@ -165,9 +164,9 @@ rewrite(?string_chars, DotMeta, 'to_string', Meta, [String]) ->
   Slow  = remote(?string_chars, DotMeta, 'to_string', Meta, [Var]),
   Fast  = Var,
 
-  {'case', ?hidden, [String, [{do,
-    [{'->', ?hidden, [[{'when', Meta, [Var, Guard]}], Fast]},
-     {'->', ?hidden, [[Var], Slow]}]
+  {'case', ?generated, [String, [{do,
+    [{'->', ?generated, [[{'when', Meta, [Var, Guard]}], Fast]},
+     {'->', ?generated, [[Var], Slow]}]
   }]]};
 
 rewrite(?enum, DotMeta, 'reverse', Meta, [List]) when is_list(List) ->
@@ -178,9 +177,9 @@ rewrite(?enum, DotMeta, 'reverse', Meta, [List]) ->
   Slow  = remote(?enum, DotMeta, 'reverse', Meta, [Var]),
   Fast  = remote(lists, Meta, 'reverse', Meta, [Var]),
 
-  {'case', ?hidden, [List, [{do,
-    [{'->', ?hidden, [[{'when', Meta, [Var, Guard]}], Fast]},
-     {'->', ?hidden, [[Var], Slow]}]
+  {'case', ?generated, [List, [{do,
+    [{'->', ?generated, [[{'when', Meta, [Var, Guard]}], Fast]},
+     {'->', ?generated, [[Var], Slow]}]
   }]]};
 
 rewrite(Receiver, DotMeta, Right, Meta, Args) ->

--- a/lib/elixir/src/elixir_translator.erl
+++ b/lib/elixir/src/elixir_translator.erl
@@ -236,19 +236,22 @@ translate({{'.', _, [Left, Right]}, Meta, []}, S)
       {atom, Line, term},
       TVar}]},
 
+  %% TODO: there is a bug in dialyzer that warns about generated matches that
+  %% can never match on line 0. The is_map/1 guard is used instead of matching
+  %% against an empty map to avoid the warning.
   {{'case', ?generated, TLeft, [
     {clause, ?generated,
       [{map, Line, [{map_field_exact, Line, TRight, TVar}]}],
       [],
       [TVar]},
     {clause, ?generated,
-      [{match, Line, TVar, {map, Line, []}}],
-      [],
+      [TVar],
+      [[elixir_utils:erl_call(?generated, erlang, is_map, [TVar])]],
       [elixir_utils:erl_call(Line, erlang, error, [TMap])]},
     {clause, ?generated,
       [TVar],
       [],
-      [{call, Line, {remote, Line, TVar, TRight}, []}]}
+      [{call, ?generated, {remote, Line, TVar, TRight}, []}]}
   ]}, SV};
 
 translate({{'.', _, [Left, Right]}, Meta, Args}, S)

--- a/lib/elixir/src/elixir_try.erl
+++ b/lib/elixir/src/elixir_try.erl
@@ -22,7 +22,7 @@ each_clause({'catch', Meta, Raw, Expr}, S) ->
   end,
 
   Condition = [{'{}', Meta, Final}],
-  {TC, TS} = elixir_clauses:clause(?line(Meta), fun elixir_translator:translate_args/2,
+  {TC, TS} = elixir_clauses:clause(Meta, fun elixir_translator:translate_args/2,
                                    Condition, Expr, Guards, S),
   {[TC], TS};
 
@@ -58,7 +58,7 @@ build_rescue(Meta, Parts, Body, S) ->
   Matches = [Match || {Match, _} <- Parts],
 
   {{clause, Line, TMatches, _, TBody}, TS} =
-    elixir_clauses:clause(?line(Meta), fun elixir_translator:translate_args/2,
+    elixir_clauses:clause(Meta, fun elixir_translator:translate_args/2,
                           Matches, Body, [], S),
 
   TClauses =

--- a/lib/elixir/src/elixir_utils.erl
+++ b/lib/elixir/src/elixir_utils.erl
@@ -1,11 +1,11 @@
 %% Convenience functions used throughout elixir source code
 %% for ast manipulation and querying.
 -module(elixir_utils).
--export([elixir_to_erl/1, get_line/1, split_last/1, meta_location/1,
+-export([elixir_to_erl/1, get_ann/1, get_line/1, split_last/1,
   characters_to_list/1, characters_to_binary/1, macro_name/1,
   convert_to_boolean/4, returns_boolean/1, atom_concat/1,
   read_file_type/1, read_link_type/1, relative_to_cwd/1,
-  change_universal_time/2, erl_call/4]).
+  change_universal_time/2, erl_call/4, meta_location/1]).
 -include("elixir.hrl").
 -include_lib("kernel/include/file.hrl").
 
@@ -15,9 +15,9 @@ macro_name(Macro) ->
 atom_concat(Atoms) ->
   list_to_atom(lists:concat(Atoms)).
 
-erl_call(Line, Module, Function, Args) ->
-  {call, Line,
-    {remote, Line, {atom, Line, Module}, {atom, Line, Function}},
+erl_call(Ann, Module, Function, Args) ->
+  {call, Ann,
+    {remote, Ann, {atom, Ann, Module}, {atom, Ann, Function}},
     Args
   }.
 
@@ -26,6 +26,14 @@ get_line(Opts) when is_list(Opts) ->
     {line, Line} when is_integer(Line) -> Line;
     false -> 0
   end.
+
+get_ann(Opts) when is_list(Opts) ->
+  get_ann(Opts, [], 0).
+
+get_ann([{generated,Gen}|T], Acc, Line) -> get_ann(T, [{generated,Gen}|Acc], Line);
+get_ann([{line,Line}|T], Acc, _) -> get_ann(T, Acc, Line);
+get_ann([_|T], Acc, Line) -> get_ann(T, Acc, Line);
+get_ann([], Acc, Line) -> [{location,Line}|Acc].
 
 split_last([])         -> {[], []};
 split_last(List)       -> split_last(List, []).
@@ -83,10 +91,11 @@ characters_to_binary(Data) ->
 meta_location(Meta) ->
   case lists:keyfind(file, 1, Meta) of
     {file, MetaFile} when is_binary(MetaFile) ->
-      case lists:keyfind(keep, 1, Meta) of
-        {keep, MetaLine} when is_integer(MetaLine) -> ok;
-        _ -> MetaLine = 0
-      end,
+      MetaLine =
+        case lists:keyfind(keep, 1, Meta) of
+          {keep, Keep} when is_integer(Keep) -> Keep;
+          _ -> 0
+        end,
       {MetaFile, MetaLine};
     _ ->
       nil

--- a/lib/elixir/test/elixir/dialyzer_test.exs
+++ b/lib/elixir/test/elixir/dialyzer_test.exs
@@ -1,0 +1,61 @@
+Code.require_file "test_helper.exs", __DIR__
+
+defmodule DialyzerTest do
+  use ExUnit.Case, async: true
+  import PathHelpers
+
+  @moduletag :dialyzer
+
+  setup_all do
+    dir = tmp_path("dialyzer")
+    File.mkdir_p!(dir)
+    plt = Path.join(dir, "base_plt") |> String.to_char_list()
+    # Add a few key elixir modules for types
+    files = Enum.map([Kernel, String, Keyword, Exception], &:code.which/1)
+    :dialyzer.run([analysis_type: :plt_build, output_plt: plt, apps: [:erts],
+      files: files])
+    {:ok, [base_dir: dir, base_plt: plt]}
+  end
+
+  setup context do
+    # Set up a per-test temporary directory, so we can run these with async: true.
+    # We use the test's line number as the directory name, so they won't conflict.
+    dir = context[:base_dir]
+      |> Path.join("line#{context[:line]}")
+      |> String.to_char_list()
+    File.mkdir_p!(dir)
+
+    base_plt = context[:base_plt]
+    plt = dir
+      |> Path.join("plt")
+      |> String.to_char_list()
+    File.cp!(base_plt, plt)
+
+    dialyzer = [analysis_type: :succ_typings, check_plt: false,
+      files_rec: [dir], plts: [plt]]
+
+    {:ok, [outdir: dir, dialyzer: dialyzer]}
+  end
+
+  test "no warnings on valid remote calls", context do
+    fixture = fixture_path("dialyzer/remote_call.ex")
+    assert '' = elixirc("#{fixture} -o #{context[:outdir]}")
+    case :dialyzer.run(context[:dialyzer]) do
+      [] ->
+        :ok
+      warnings ->
+        flunk IO.chardata_to_string(for warn <- warnings, do: [:dialyzer.format_warning(warn), ?\n])
+    end
+  end
+
+  test "no warnings on valid raise", context do
+    fixture = fixture_path("dialyzer/raise.ex")
+    assert '' = elixirc("#{fixture} -o #{context[:outdir]}")
+    case :dialyzer.run(context[:dialyzer]) do
+      [] ->
+        :ok
+      warnings ->
+        flunk IO.chardata_to_string(for warn <- warnings, do: [:dialyzer.format_warning(warn), ?\n])
+    end
+  end
+end

--- a/lib/elixir/test/elixir/fixtures/dialyzer/raise.ex
+++ b/lib/elixir/test/elixir/fixtures/dialyzer/raise.ex
@@ -1,0 +1,22 @@
+defmodule DialyzerRaise do
+
+  defexception [:message]
+
+  def exception_var() do
+    e = %DialyzerRaise{}
+    raise e
+  end
+
+  def exception_var(e = %DialyzerRaise{}) do
+    raise e
+  end
+
+  def string_var() do
+    string = "hello"
+    raise string
+  end
+
+  def string_var(string) when is_binary(string) do
+    raise string
+  end
+end

--- a/lib/elixir/test/elixir/fixtures/dialyzer/remote_call.ex
+++ b/lib/elixir/test/elixir/fixtures/dialyzer/remote_call.ex
@@ -1,0 +1,20 @@
+defmodule DialyzerRemoteCall do
+
+  def map_var() do
+    map = %{a: 1}
+    map.key
+  end
+
+  def map_var(map) when is_map(map) do
+    map.key
+  end
+
+  def mod_var() do
+    module = Hello
+    module.fun
+  end
+
+  def mod_var(module) when is_atom(module) or is_atom(elem(module, 0)) do
+    module.fun
+  end
+end


### PR DESCRIPTION
The raise test fails for two reasons:
* Generated `exception/1` specs are too complex
* Missing feature to mark quoted AST as generated

We should report/fix the issue upstream in the TODO comment in elixir_translator.erl about generated matches.