### PR TITLE
Display docs for types with t/1

### DIFF
--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -265,7 +265,7 @@ defmodule IEx.Introspection do
     _ = case Typespec.beam_types(module) do
       nil   -> nobeam(module)
       []    -> notypes(inspect module)
-      types -> for type <- types, do: print_type(type)
+      types -> Enum.each(types, &print_type/1)
     end
 
     dont_display_result
@@ -280,6 +280,7 @@ defmodule IEx.Introspection do
       types ->
         printed =
           for {_, {t, _, _args}} = typespec <- types, t == type do
+            print_type_doc(module, t)
             print_type(typespec)
             typespec
           end
@@ -301,6 +302,7 @@ defmodule IEx.Introspection do
       types ->
         printed =
           for {_, {t, _, args}} = typespec <- types, t == type, length(args) == arity do
+            print_type_doc(module, t)
             print_type(typespec)
             typespec
           end
@@ -311,6 +313,14 @@ defmodule IEx.Introspection do
     end
 
     dont_display_result
+  end
+
+  defp print_type_doc(module, type) do
+    docs  = Code.get_docs(module, :type_docs)
+    {{_, _}, _, _, description} = Enum.find(docs, fn({{name, _}, _, _, _}) ->
+      type == name
+    end)
+    if description, do: puts_info(description)
   end
 
   @doc """

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -79,6 +79,21 @@ defmodule IEx.HelpersTest do
 
     assert "@opaque t()\n" = capture_io(fn -> t HashDict.t end)
     assert capture_io(fn -> t HashDict.t end) == capture_io(fn -> t HashDict.t/0 end)
+
+    filename = "typesample.ex"
+    with_file filename, module_with_typespecs, fn ->
+      c(filename)
+      assert capture_io(fn -> t TypeSample.id_with_desc/0 end) == """
+      An id with description.
+      @type id_with_desc() :: {number(), String.t()}
+      """
+      assert capture_io(fn -> t TypeSample.id_with_desc end) == """
+      An id with description.
+      @type id_with_desc() :: {number(), String.t()}
+      """
+    end
+  after
+    cleanup_modules([TypeSample])
   end
 
   test "s helper" do
@@ -363,6 +378,15 @@ defmodule IEx.HelpersTest do
     -module(sample).
     -export([hello/0]).
     hello() -> bye.
+    """
+  end
+
+  def module_with_typespecs do
+    """
+    defmodule TypeSample do
+      @typedoc "An id with description."
+      @type id_with_desc :: {number, String.t}
+    end
     """
   end
 


### PR DESCRIPTION
This is for issue #3830 and a first attempt at displaying the type documentation with the `t` helper. It currently works for `t/1` and prints the module name after each type so I'm not sure if that's desired.

Looking for feedback on whether the direction I'm headed is correct. Thanks!