### PR TITLE
Make Dict not to work for lists

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -747,11 +747,26 @@ defmodule Keyword do
 
   @doc false
   def size(keyword) do
-    length(keyword)
+    do_size(keyword, 0)
   end
+
+  defp do_size([{key, _value} | rest], acc) when is_atom(key) do
+    do_size(rest, acc + 1)
+  end
+
+  defp do_size([], acc), do: acc
+  defp do_size(other, _acc), do: bad_keyword(other)
 
   @doc false
   def to_list(keyword) do
-    keyword
+    if keyword?(keyword) do
+      keyword
+    else
+      bad_keyword(keyword)
+    end
+  end
+
+  defp bad_keyword(keyword) do
+    raise ArgumentError, "expected keyword list, got: #{inspect keyword}"
   end
 end

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -277,6 +277,24 @@ defmodule Keyword.DuplicatedTest do
     end
   end
 
+  test "size/1" do
+    assert Keyword.size([]) == 0
+    assert Keyword.size([a: 0, b: 1, a: 2]) == 3
+
+    assert_raise ArgumentError, fn ->
+      Keyword.size([1, 2 ,3])
+    end
+  end
+
+  test "to_list/1" do
+    assert Keyword.to_list([]) == []
+    assert Keyword.to_list([a: 0, b: 1, a: 2]) == [a: 0, b: 1, a: 2]
+
+    assert_raise ArgumentError, fn ->
+      Keyword.to_list([1, 2 ,3])
+    end
+  end
+
   defp create_empty_keywords, do: []
   defp create_keywords, do: [first_key: 1, first_key: 2, second_key: 2]
 end


### PR DESCRIPTION
Adding this additional check will impact performance when using the `Dict` module on keyword lists, but is the only safe way I found to check that.

This change won't stop you doing:
```elixir
iex> Keyword.size([1,2,3])
3
```
Because, `Keyword.size` just uses `length`. We could make the check all over the `Keyword` module, but I am not sure we want that, as it will affect performance.

fixes #3853 
