### PR TITLE
Include underscore/1 and camelize/2 functions in the Macro module

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -373,6 +373,45 @@ defmodule Macro do
   end
 
   @doc ~S"""
+  Underscore the given value.
+
+  This behavior makes an underscored, lowercase form from a string
+  or atom.
+
+  ## Examples
+
+  iex> Macro.underscore("UpperCamelCase")
+  "upper_camel_case"
+
+  iex> Macro.underscore("pascalCase")
+  "pascal_case"
+
+  iex> Macro.underscore(UpperCamelCase)
+  "upper_camel_case"
+
+  iex> Macro.underscore(:pascalCase)
+  "pascal_case"
+
+  """
+  @spec underscore(Atom.t) :: Atom.t
+  def underscore(atom) when is_atom(atom) do
+    case Atom.to_string(atom) do
+      "Elixir." <> rest -> underscore(rest)
+      word -> underscore(word)
+    end
+  end
+
+  @spec underscore(String.t) :: String.t
+  def underscore(chars) do
+    chars
+      |> String.replace(~r/([A-Z]+)([A-Z][a-z])/, "\\1_\\2")
+      |> String.replace(~r/([a-z\d])([A-Z])/, "\\1_\\2")
+      |> String.replace(~r/-/, "_")
+      |> String.replace(~r/\s/, "_")
+      |> String.downcase
+  end
+
+  @doc ~S"""
   Unescapes the given chars according to the map given.
 
   Check `unescape_string/1` if you want to use the same map

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -412,6 +412,52 @@ defmodule Macro do
   end
 
   @doc ~S"""
+  Camelize the given value.
+
+  This behavior transforms a string, or atom, to a camel
+  cased string. If the `:lower` option is passed in then
+  the string will be returned in pascal case.
+
+  ## Examples
+
+  iex> Macro.camelize("text camel cased")
+  "TextCamelCased"
+
+  iex> Macro.camelize("text pascal cased", :lower)
+  "textPascalCased"
+
+  iex> Macro.camelize("hyphenated-text")
+  "HyphenatedText"
+
+  iex> Macro.camelize(:atom_camel_cased)
+  "AtomCamelCased"
+
+  """
+  def camelize(chars, option \\ :upper)
+
+  @spec camelize(Atom.t, Atom.t) :: String.t
+  def camelize(atom, option) when is_atom(atom) do
+    atom |> Atom.to_string |> camelize(option)
+  end
+
+  @spec camelize(String.t, Atom.t) :: String.t
+  def camelize(chars, option) when is_binary(chars) do
+    chars
+      |> String.split(~r/(?:^|[-_\s])|(?=[A-Z])/)
+      |> camelize_list(option)
+      |> Enum.join
+  end
+
+  defp camelize_list([], _), do: []
+  defp camelize_list([h|tail], option) do
+    word = case option do
+      :upper -> String.capitalize(h)
+      :lower -> String.downcase(h)
+    end
+    [word|camelize_list(tail, :upper)]
+  end
+
+  @doc ~S"""
   Unescapes the given chars according to the map given.
 
   Check `unescape_string/1` if you want to use the same map

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -618,4 +618,14 @@ defmodule MacroTest do
     assert "atom_underscored" == Macro.underscore(:atomUnderscored)
     assert "module_underscored" == Macro.underscore(ModuleUnderscored)
   end
+
+  # camelize
+
+  test "camelize" do
+    assert "TextCamelCased" == Macro.camelize("text camel cased")
+    assert "textCamelCased" == Macro.camelize("text camel cased", :lower)
+    assert "HyphenatedText" == Macro.camelize("hyphenated-text")
+    assert "UnderscoredText" == Macro.camelize("underscored_text")
+    assert "AtomCamelCased" == Macro.camelize(:atom_camel_cased)
+  end
 end

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -607,4 +607,15 @@ defmodule MacroTest do
   defp postwalk(ast) do
     Macro.postwalk(ast, [], &{&1, [&1|&2]}) |> elem(1) |> Enum.reverse
   end
+
+  # underscore
+
+  test "underscore" do
+    assert "&_%_#_àáâ_ãäå_1_2_ç_æ" == Macro.underscore("& % # ÀÁÂ ÃÄÅ 1 2 Ç Æ")
+    assert "text_underscored" == Macro.underscore("text underscored")
+    assert "camel_case_underscored" == Macro.underscore("CamelCaseUnderscored")
+    assert "pascal_case_underscored" == Macro.underscore("pascalCaseUnderscored")
+    assert "atom_underscored" == Macro.underscore(:atomUnderscored)
+    assert "module_underscored" == Macro.underscore(ModuleUnderscored)
+  end
 end


### PR DESCRIPTION
This is the pull request for https://github.com/elixir-lang/elixir/issues/3850

The following features are being added to the Macro module:

`underscore/1` - takes either a binary string or atom and returns an underscored lowercased string. 

`camelize/2` - takes either a binary string or atom and returns a camel cased string. The second argument is optional and uses either `:upper` or `:lower` to determine the case of the first word. 