### PR TITLE
Document limits of `Float.parse/1`.

### DIFF
--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -9,7 +9,10 @@ defmodule Float do
   Parses a binary into a float.
 
   If successful, returns a tuple of the form `{float, remainder_of_binary}`;
-  otherwise, `:error`.
+  when the binary cannot be coerced into a valid float, the atom `:error` is
+  returned; otherwise, the exception `ArgumentError` is raised by erlang (for
+  example, when the size of the float exceeds the maximum size of
+  `1.7976931348623157e+308`).
 
   If a float formatted string wants to be directly converted to a float,
   `String.to_float/1` can be used instead.

--- a/lib/elixir/test/elixir/float_test.exs
+++ b/lib/elixir/test/elixir/float_test.exs
@@ -32,6 +32,10 @@ defmodule FloatTest do
     assert Float.parse("--1.2") === :error
     assert Float.parse("++1.2") === :error
     assert Float.parse("pi") === :error
+    assert Float.parse("1.7976931348623157e308") === {1.7976931348623157e308, ""}
+    assert_raise ArgumentError, fn ->
+      Float.parse("1.7976931348623159e308")
+    end
   end
 
   test "floor" do


### PR DESCRIPTION
This PR clarifies the documentation for `Float.parse/1` and adds test assertions to demonstrate the limits enforced by erlang/IEEE 754-1985 double precision floats. See #3862 for more context. /cc @josevalim 