### PR TITLE
More helpful error for keyword list to_string

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -591,7 +591,12 @@ defmodule List do
   """
   @spec to_string(:unicode.charlist) :: String.t
   def to_string(list) when is_list(list) do
-    case :unicode.characters_to_binary(list) do
+    try do
+       :unicode.characters_to_binary(list)
+    rescue
+      ArgumentError ->
+        raise ArgumentError, "cannot convert list to string. The list must contain only integers, strings or nested such lists; got: #{inspect list}"
+    else
       result when is_binary(result) ->
         result
 

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -156,5 +156,10 @@ defmodule ListTest do
                  "invalid code point 57343", fn ->
       List.to_string([0xDFFF])
     end
+
+    assert_raise ArgumentError,
+                 "cannot convert list to string. The list must contain only integers, strings or nested such lists; got: [:a, :b]", fn ->
+      List.to_string([:a, :b])
+    end
   end
 end


### PR DESCRIPTION
Replaces the confusing ":unicode.characters_to_binary([a: 1])" error you would get when interpolating a keyword list. Developers used to Ruby may expect this to just work.

As discussed here: https://groups.google.com/forum/#!topic/elixir-lang-core/ZmxsVo4JO5E