### PR TITLE
Add clarification to comprehension match example

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1251,7 +1251,7 @@ defmodule Kernel.SpecialForms do
   Note generators can also be used to filter as it removes any value
   that doesn't match the left side of `<-`:
 
-      iex> for {:user, name} <- [user: "john", admin: "john", user: "meg"] do
+      iex> for {:user, name} <- [user: "john", admin: "james", user: "meg"] do
       ...>   String.upcase(name)
       ...> end
       ["JOHN", "MEG"]


### PR DESCRIPTION
The current example is fine, especially with an understanding of the
matching that is happening. However, to make the example more explicit, the
name of the unmatched pair should be different.