### PR TITLE
Include underscore/1 & camelize/1 in the Macro module

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1251,7 +1251,7 @@ defmodule Kernel.SpecialForms do
   Note generators can also be used to filter as it removes any value
   that doesn't match the left side of `<-`:
 
-      iex> for {:user, name} <- [user: "john", admin: "john", user: "meg"] do
+      iex> for {:user, name} <- [user: "john", admin: "james", user: "meg"] do
       ...>   String.upcase(name)
       ...> end
       ["JOHN", "MEG"]

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1004,4 +1004,107 @@ defmodule Macro do
   defp expand_until({tree, false}, _env) do
     tree
   end
+
+  @doc """
+  Converts the given atom or binary to underscore format.
+
+  If an atom is given, it is assumed to be an Elixir module,
+  so it is converted to a binary and then processed.
+
+  ## Examples
+
+      iex> Macro.underscore "FooBar"
+      "foo_bar"
+
+      iex> Macro.underscore "Foo.Bar"
+      "foo/bar"
+
+      iex> Macro.underscore Foo.Bar
+      "foo/bar"
+
+  In general, `underscore` can be thought of as the reverse of
+  `camelize`, however, in some cases formatting may be lost:
+
+      iex> Macro.underscore "SAPExample"
+      "sap_example"
+
+      iex> Macro.camelize "sap_example"
+      "SapExample"
+
+  """
+  def underscore(atom) when is_atom(atom) do
+    "Elixir." <> rest = Atom.to_string(atom)
+    underscore(rest)
+  end
+
+  def underscore(""), do: ""
+
+  def underscore(<<h, t :: binary>>) do
+    <<to_lower_char(h)>> <> do_underscore(t, h)
+  end
+
+  defp do_underscore(<<h, t, rest :: binary>>, _) when h in ?A..?Z and not (t in ?A..?Z or t == ?.) do
+    <<?_, to_lower_char(h), t>> <> do_underscore(rest, t)
+  end
+
+  defp do_underscore(<<h, t :: binary>>, prev) when h in ?A..?Z and not prev in ?A..?Z do
+    <<?_, to_lower_char(h)>> <> do_underscore(t, h)
+  end
+
+  defp do_underscore(<<?., t :: binary>>, _) do
+    <<?/>> <> underscore(t)
+  end
+
+  defp do_underscore(<<h, t :: binary>>, _) do
+    <<to_lower_char(h)>> <> do_underscore(t, h)
+  end
+
+  defp do_underscore(<<>>, _) do
+    <<>>
+  end
+
+  @doc """
+  Converts the given string to CamelCase format.
+
+  ## Examples
+
+      iex> Macro.camelize "foo_bar"
+      "FooBar"
+
+  """
+  @spec camelize(String.t) :: String.t
+  def camelize(string)
+
+  def camelize(""),
+    do: ""
+
+  def camelize(<<?_, t :: binary>>),
+    do: camelize(t)
+
+  def camelize(<<h, t :: binary>>),
+    do: <<to_upper_char(h)>> <> do_camelize(t)
+
+  defp do_camelize(<<?_, ?_, t :: binary>>),
+    do: do_camelize(<< ?_, t :: binary >>)
+
+  defp do_camelize(<<?_, h, t :: binary>>) when h in ?a..?z,
+    do: <<to_upper_char(h)>> <> do_camelize(t)
+
+  defp do_camelize(<<?_>>),
+    do: <<>>
+
+  defp do_camelize(<<?/, t :: binary>>),
+    do: <<?.>> <> camelize(t)
+
+  defp do_camelize(<<h, t :: binary>>),
+    do: <<h>> <> do_camelize(t)
+
+  defp do_camelize(<<>>),
+    do: <<>>
+
+  defp to_upper_char(char) when char in ?a..?z, do: char - 32
+  defp to_upper_char(char), do: char
+
+  defp to_lower_char(char) when char in ?A..?Z, do: char + 32
+  defp to_lower_char(char), do: char
 end

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -607,4 +607,31 @@ defmodule MacroTest do
   defp postwalk(ast) do
     Macro.postwalk(ast, [], &{&1, [&1|&2]}) |> elem(1) |> Enum.reverse
   end
+
+  test "underscore" do
+    assert Macro.underscore("foo") == "foo"
+    assert Macro.underscore("foo_bar") == "foo_bar"
+    assert Macro.underscore("Foo") == "foo"
+    assert Macro.underscore("FooBar") == "foo_bar"
+    assert Macro.underscore("FOOBar") == "foo_bar"
+    assert Macro.underscore("FooBAR") == "foo_bar"
+    assert Macro.underscore("FoBaZa") == "fo_ba_za"
+    assert Macro.underscore("Foo.Bar") == "foo/bar"
+    assert Macro.underscore(Foo.Bar) == "foo/bar"
+    assert Macro.underscore("API.V1.User") == "api/v1/user"
+    assert Macro.underscore("") == ""
+  end
+
+  test "camelize" do
+    assert Macro.camelize("Foo") == "Foo"
+    assert Macro.camelize("FooBar") == "FooBar"
+    assert Macro.camelize("foo") == "Foo"
+    assert Macro.camelize("foo_bar") == "FooBar"
+    assert Macro.camelize("foo_") == "Foo"
+    assert Macro.camelize("_foo") == "Foo"
+    assert Macro.camelize("foo__bar") == "FooBar"
+    assert Macro.camelize("foo/bar") == "Foo.Bar"
+    assert Macro.camelize("") == ""
+  end
+
 end

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -163,35 +163,10 @@ defmodule Mix.Utils do
       "SapExample"
 
   """
-  def underscore(atom) when is_atom(atom) do
-    "Elixir." <> rest = Atom.to_string(atom)
-    underscore(rest)
-  end
-
-  def underscore(""), do: ""
-
-  def underscore(<<h, t :: binary>>) do
-    <<to_lower_char(h)>> <> do_underscore(t, h)
-  end
-
-  defp do_underscore(<<h, t, rest :: binary>>, _) when h in ?A..?Z and not (t in ?A..?Z or t == ?.) do
-    <<?_, to_lower_char(h), t>> <> do_underscore(rest, t)
-  end
-
-  defp do_underscore(<<h, t :: binary>>, prev) when h in ?A..?Z and not prev in ?A..?Z do
-    <<?_, to_lower_char(h)>> <> do_underscore(t, h)
-  end
-
-  defp do_underscore(<<?., t :: binary>>, _) do
-    <<?/>> <> underscore(t)
-  end
-
-  defp do_underscore(<<h, t :: binary>>, _) do
-    <<to_lower_char(h)>> <> do_underscore(t, h)
-  end
-
-  defp do_underscore(<<>>, _) do
-    <<>>
+  # TODO: Deprecate by 1.3
+  # TODO: Remove by 1.4
+  def underscore(value) do
+    Macro.underscore(value)
   end
 
   @doc """
@@ -203,35 +178,11 @@ defmodule Mix.Utils do
       "FooBar"
 
   """
-  @spec camelize(String.t) :: String.t
-  def camelize(string)
-
-  def camelize(""),
-    do: ""
-
-  def camelize(<<?_, t :: binary>>),
-    do: camelize(t)
-
-  def camelize(<<h, t :: binary>>),
-    do: <<to_upper_char(h)>> <> do_camelize(t)
-
-  defp do_camelize(<<?_, ?_, t :: binary>>),
-    do: do_camelize(<< ?_, t :: binary >>)
-
-  defp do_camelize(<<?_, h, t :: binary>>) when h in ?a..?z,
-    do: <<to_upper_char(h)>> <> do_camelize(t)
-
-  defp do_camelize(<<?_>>),
-    do: <<>>
-
-  defp do_camelize(<<?/, t :: binary>>),
-    do: <<?.>> <> camelize(t)
-
-  defp do_camelize(<<h, t :: binary>>),
-    do: <<h>> <> do_camelize(t)
-
-  defp do_camelize(<<>>),
-    do: <<>>
+  # TODO: Deprecate by 1.3
+  # TODO: Remove by 1.4
+  def camelize(value) do
+    Macro.camelize(value)
+  end
 
   @doc """
   Takes a module and converts it to a command.


### PR DESCRIPTION
Move underscore/1 and camelize/1 from the Mix.Utils module into the Macro module. The Mix.Utils functions have been noted for deprecation and call the Macro functions.