### PR TITLE
Fix code example in the document for quote macro

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1032,54 +1032,54 @@ defmodule Kernel.SpecialForms do
   following code:
 
       defmodule Hygiene do
-        defmacrop get_size do
+        defmacrop get_length do
           quote do
-            size("hello")
+            length([1,2,3])
           end
         end
 
-        def return_size do
-          import Kernel, except: [size: 1]
-          get_size
+        def return_length do
+          import Kernel, except: [length: 1]
+          get_length
         end
       end
 
-      Hygiene.return_size #=> 5
+      Hygiene.return_length #=> 3
 
-  Notice how `return_size` returns 5 even though the `size/1`
-  function is not imported. In fact, even if `return_size` imported
-  a function from another module, it wouldn't affect the function
-  result:
+  Notice how `return_length` returns 5 even though the `length/1`
+  function is not imported. In fact, even if `return_length`
+  imported a function with the same name and arity from another
+  module, it wouldn't affect the function result:
 
-      def return_size do
-        import Dict, only: [size: 1]
-        get_size
+      def return_length do
+        import String, only: [length: 1]
+        get_length
       end
 
-  Calling this new `return_size` will still return 5 as result.
+  Calling this new `return_length` will still return 3 as result.
 
   Elixir is smart enough to delay the resolution to the latest
-  moment possible. So, if you call `size("hello")` inside quote,
-  but no `size/1` function is available, it is then expanded in
+  moment possible. So, if you call `length([1, 2, 3])` inside quote,
+  but no `length/1` function is available, it is then expanded in
   the caller:
 
       defmodule Lazy do
-        defmacrop get_size do
-          import Kernel, except: [size: 1]
+        defmacrop get_length do
+          import Kernel, except: [length: 1]
 
           quote do
-            size([a: 1, b: 2])
+            length("hello")
           end
         end
 
-        def return_size do
-          import Kernel, except: [size: 1]
-          import Dict, only: [size: 1]
-          get_size
+        def return_length do
+          import Kernel, except: [length: 1]
+          import String, only: [length: 1]
+          get_length
         end
       end
 
-      Lazy.return_size #=> 2
+      Lazy.return_length #=> 5
 
   ## Stacktrace information
 


### PR DESCRIPTION
The code example in section `Hygiene in imports` wouldn't compile, because `size/1` function was removed from `Kernel`. So I updated `Hygiene` with `length/1` defined in `Kennel` for lists.

The code example in `Lazy` can produce a correct result, but since `size/1` function is not available in `Kennel`, the `import Kernel, except: [size: 1]` statement would be redundant. So I updated `Lazy` with `length/1` function as well. Luckily since `length/1` is also define in `String` for strings,  this example still demonstrates the same behavior.