### PR TITLE
Fix innacurate iex output

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -95,8 +95,8 @@ defmodule Kernel.SpecialForms do
   always represented internally as a list of two-items tuples
   for simplicity:
 
-      iex> quote do: %{:a => :b, c: :d}
-      {:%{}, [], [{:a, :b}, {:c, :d}]}
+      iex> quote do: %{"a" => :b, c: :d}
+      {:%{}, [], [{"a", :b}, {:c, :d}]}
 
   """
   defmacro unquote(:%{})(args)


### PR DESCRIPTION
Uses a string key instead of an atom key in order to force the iex
output to show the list of tuples rather than a keyword list.

The current documentation example shows an output that is equivalent to the actual output of iex, but is not the literal output. That is, if you run: `quote do: %{:a => :b, c: :d}` in iex, the literal output is `{:%{}, [], [a: :b, c: :d]}`. The keyword list is the same as `[{:a, :b}, {:c, :d}]` in meaning but the output looks different.

This change uses a string as the key for the first item in the map, which will output a list of tuples rather than a keyword list.