### PR TITLE
improve error message on requiring module from the context it was defined in

### DIFF
--- a/lib/elixir/src/elixir_aliases.erl
+++ b/lib/elixir/src/elixir_aliases.erl
@@ -81,7 +81,11 @@ ensure_loaded(Meta, Ref, E) ->
   catch
     error:undef ->
       Kind = case lists:member(Ref, ?m(E, context_modules)) of
-        true  -> scheduled_module;
+        true  ->
+                 case ?m(E, module) of
+                   Ref -> circular_module;
+                   _ -> scheduled_module
+                 end;
         false -> unloaded_module
       end,
       elixir_errors:form_error(Meta, ?m(E, file), ?MODULE, {Kind, Ref})
@@ -141,4 +145,8 @@ format_error({unloaded_module, Module}) ->
 
 format_error({scheduled_module, Module}) ->
   io_lib:format("module ~ts is not loaded but was defined. This happens because you are trying to use a module in the same context it is defined. Try defining the module outside the context that requires it.",
+    [inspect(Module)]);
+
+format_error({circular_module, Module}) ->
+  io_lib:format("you are trying to use/require the same module that is being currently defined. The current module is ~ts",
     [inspect(Module)]).

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -579,7 +579,7 @@ defmodule Kernel.ErrorsTest do
       'import Certainly.Doesnt.Exist'
   end
 
-  test "scheduled module" do
+  test "module imported from the context it was defined in" do
     assert_compile_fail CompileError,
       "nofile:4: module Kernel.ErrorsTest.ScheduledModule.Hygiene is not loaded but was defined. " <>
       "This happens because you are trying to use a module in the same context it is defined. " <>
@@ -589,6 +589,19 @@ defmodule Kernel.ErrorsTest do
         defmodule Hygiene do
         end
         import Kernel.ErrorsTest.ScheduledModule.Hygiene
+      end
+      '''
+  end
+
+  test "module imported from the same module" do
+    assert_compile_fail CompileError,
+      "nofile:3: you are trying to use/require the same module that is being currently defined. " <>
+      "The current module is Kernel.ErrorsTest.ScheduledModule.Hygiene",
+      '''
+      defmodule Kernel.ErrorsTest.ScheduledModule do
+        defmodule Hygiene do
+          import Kernel.ErrorsTest.ScheduledModule.Hygiene
+        end
       end
       '''
   end


### PR DESCRIPTION
Issue: https://github.com/elixir-lang/elixir/issues/3881

I think there are two slightly related cases, that may share the same explanation. I tried to make it as clear as possible with wording, but if you do have better idea please let me know and I can amend.