### PR TITLE
Grammar fix for error message returned by :elixir_aliases.format_error/2

### DIFF
--- a/lib/elixir/src/elixir_aliases.erl
+++ b/lib/elixir/src/elixir_aliases.erl
@@ -167,7 +167,7 @@ format_error({scheduled_module, Module}) ->
 
 format_error({circular_module, Module}) ->
   io_lib:format(
-    "you are trying to use the module ~ts which is being currently defined.\n"
+    "you are trying to use the module ~ts which is currently being defined.\n"
     "\n"
     "This may happen if you accidentally override the module you want to use. For example:\n"
     "\n"

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -593,7 +593,7 @@ defmodule Kernel.ErrorsTest do
 
   test "module imported from the same module" do
     assert_compile_fail CompileError,
-      ~r"nofile:3: you are trying to use the module Kernel.ErrorsTest.ScheduledModule.Hygiene which is being currently defined",
+      ~r"nofile:3: you are trying to use the module Kernel.ErrorsTest.ScheduledModule.Hygiene which is currently being defined",
       '''
       defmodule Kernel.ErrorsTest.ScheduledModule do
         defmodule Hygiene do


### PR DESCRIPTION
Minor grammar fix for an error message in compile-time.