### PR TITLE
improve doc for restart of supervisor spec

### DIFF
--- a/lib/elixir/lib/supervisor/spec.ex
+++ b/lib/elixir/lib/supervisor/spec.ex
@@ -61,7 +61,7 @@ defmodule Supervisor.Spec do
 
     * `:function` - the function to invoke on the child to start it
 
-    * `:restart` - defines when the child process should restart
+    * `:restart` - defines when a terminated child process should be restarted
 
     * `:shutdown` - defines how a child process should be terminated
 


### PR DESCRIPTION
The reason I think this change is needed is that I'm not familiar with Erlang/OTP, so I was confused about the word `terminated` in `shutdown`. I wondered if it's termination before restart or just stop(will not restart). I looked up in [Erlang's doc](http://www.erlang.org/doc/man/supervisor.html), it says `restart defines when a terminated child process is to be restarted.`, which is more clear.