### PR TITLE
Validate git options and warn on conflicting ref, branch or tags

### DIFF
--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -27,9 +27,13 @@ defmodule Mix.SCM.Git do
   def accepts_options(_app, opts) do
     cond do
       gh = opts[:github] ->
-        opts |> Keyword.delete(:github) |> Keyword.put(:git, "https://github.com/#{gh}.git")
+        opts
+        |> Keyword.delete(:github)
+        |> Keyword.put(:git, "https://github.com/#{gh}.git")
+        |> validate_git_options
       opts[:git] ->
         opts
+        |> validate_git_options
       true ->
         nil
     end
@@ -103,6 +107,15 @@ defmodule Mix.SCM.Git do
   end
 
   ## Helpers
+
+  # TODO: make it raise (at v2.0?)
+  defp validate_git_options(opts) do
+    if Enum.count(opts, fn({key, _}) -> key in [:branch, :ref, :tag] end) > 1 do
+      Mix.shell.error "warning: you should specify only one of branch, ref or tag, and only once." <>
+        "Error on git dependency: #{opts[:git]}"
+    end
+    opts
+  end
 
   defp do_checkout(opts) do
     ref = get_lock_rev(opts[:lock]) || get_opts_rev(opts)

--- a/lib/mix/test/mix/scm/git_test.exs
+++ b/lib/mix/test/mix/scm/git_test.exs
@@ -34,6 +34,20 @@ defmodule Mix.SCM.GitTest do
     assert Mix.SCM.Git.equal?([git: "foo", lock: 1], [git: "foo", lock: 2])
   end
 
+  test "warns about conflicting git checkout options" do
+    msg = "warning: you should specify only one of branch, ref or tag, and only once. " <>
+      "Error on git dependency: /repo"
+
+    Mix.SCM.Git.accepts_options(nil, [git: "/repo", branch: "master", tag: "0.1.0"])
+    assert_received {:mix_shell, :error, [msg]}
+
+    Mix.SCM.Git.accepts_options(nil, [git: "/repo", branch: "master", branch: "develop"])
+    assert_received {:mix_shell, :error, [msg]}
+
+    Mix.SCM.Git.accepts_options(nil, [git: "/repo", ref: "abcdef01234", branch: "develop"])
+    assert_received {:mix_shell, :error, [msg]}
+  end
+
   defp lock(opts \\ []) do
     [lock: {:git, "/repo", "abcdef0123456789", opts}]
   end


### PR DESCRIPTION
https://github.com/elixir-lang/elixir/issues/3885 is the relevant issue. This commit warns user about invalid git options, but does not break existing apps for now. Added todo that this will need to be changed at 2.0 to raise.