### PR TITLE
Clarify Float.ceil/floor handling of decimals

### DIFF
--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -90,7 +90,7 @@ defmodule Float do
       iex> Float.floor(-56.5)
       -57.0
 
-      iex> Float.floor(34.253, 2)
+      iex> Float.floor(34.259, 2)
       34.25
 
   """
@@ -120,7 +120,7 @@ defmodule Float do
       iex> Float.ceil(-56.5)
       -56.0
 
-      iex> Float.ceil(34.253, 2)
+      iex> Float.ceil(34.251, 2)
       34.26
 
   """


### PR DESCRIPTION
The `floor` example was less helpful than it could be since it showed behaviour that was no different from what `round` would do.

Since I "maxed out" the `floor` example, I also "min'd out" the `ceil` example for good measure.