### PR TITLE
fix(Mix.Dep.Umbrella): prevent error when app is missing mix.exs

### DIFF
--- a/lib/mix/lib/mix/dep/umbrella.ex
+++ b/lib/mix/lib/mix/dep/umbrella.ex
@@ -8,11 +8,10 @@ defmodule Mix.Dep.Umbrella do
     config = Mix.Project.config
 
     if apps_path = config[:apps_path] do
-      paths = Path.wildcard(Path.join(apps_path, "*"))
+      paths = Path.wildcard(Path.join(apps_path, "*/mix.exs")) |> Enum.map(&Path.dirname/1)
       build = Mix.Project.build_path
 
       paths
-      |> Enum.filter(&File.dir?(&1))
       |> extract_umbrella
       |> filter_umbrella(config[:apps])
       |> to_umbrella_dep(build)


### PR DESCRIPTION
Previously, when using an umbrella app, if a directory was empty when
running a mix task the following error was displayed:

 > ** (Mix) Could not find a Mix.Project, please ensure a mix.exs file
 > is available"

Since git does not keep directories, it is common to see this issue when
switching branches on an umbrella application where some branches have a
particular app inside `apps` and other branches don't.

This commit checks for the presence of `mix.exs` and uses directories
containing the file as an app in the umbrella application

Please note a `.gitkeep` file is used to allow for an empty directory in the fixtures.