### PR TITLE
Documentation improvement to GenEvent

### DIFF
--- a/lib/elixir/lib/gen_event.ex
+++ b/lib/elixir/lib/gen_event.ex
@@ -422,6 +422,10 @@ defmodule GenEvent do
 
   If the given handler was previously installed at the manager, this
   function returns `{:error, :already_present}`.
+
+  For installing multiple instances of the same handler, `{Module, id}` instead
+  of `Module` must be used. The handler could be then referenced with 
+  `{Module, id}` instead of just `Module`.
   """
   @spec add_handler(manager, handler, term) :: :ok | {:error, term}
   def add_handler(manager, handler, args) do


### PR DESCRIPTION
Properly documented the possibility of adding an handler with an
unique id attached when multiple instances of the same module must
be attached.

Solve issue #3760