### PR TITLE
Implemented Mix.Shell.Quiet

### DIFF
--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -8,6 +8,8 @@ defmodule Mix.CLI do
     Mix.Local.append_archives
     Mix.Local.append_paths
 
+    if System.get_env("MIX_QUIET"), do: Mix.shell(Mix.Shell.Quiet)
+
     case check_for_shortcuts(args) do
       :help ->
         proceed(["help"])

--- a/lib/mix/lib/mix/shell/quiet.ex
+++ b/lib/mix/lib/mix/shell/quiet.ex
@@ -1,0 +1,46 @@
+defmodule Mix.Shell.Quiet do
+  @moduledoc """
+  This is Mix's default shell when the `MIX_QUIET` environment 
+  variable is set.
+
+  It's just like `Mix.Shell.IO' but print far less.
+  """
+
+  @behaviour Mix.Shell
+
+  @doc """
+  Prints the currently running application if it
+  was not printed yet.
+  """
+  defdelegate print_app, to: Mix.Shell.IO
+
+  @doc """
+  Executes the given command quietly without outputting anything.
+  """
+  def cmd(command, opts \\ []) do
+    Mix.Shell.cmd(command, opts, fn data -> data end)
+  end
+
+  @doc """
+  Writes nothing to the shell.
+  """
+  def info(_message), do: nil
+
+  @doc """
+  Writes an error message to the shell followed by new line.
+  """
+  defdelegate error(message), to: Mix.Shell.IO
+
+  @doc """
+  Writes a message shell followed by prompting the user for
+  input. Input will be consumed until enter is pressed.
+  """
+  defdelegate prompt(message), to: Mix.Shell.IO
+
+  @doc """
+  Receives a message and asks the user if they want to proceed.
+  The user must press enter or type anything that matches the "yes"
+  regex `~r/^Y(es)?$/i`.
+  """
+  defdelegate yes?(message), to: Mix.Shell.IO
+end

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -43,13 +43,15 @@ defmodule Mix.CLITest do
 
         def run(_) do
           IO.puts Mix.Project.get!.hello_world
+          Mix.shell.info("This won't appear")
         end
       end
       """
 
-      contents = mix ~w[my_hello]
+      contents = mix ~w[my_hello], [{"MIX_QUIET", "1"}]
+
       assert contents =~ "Hello from MyProject!\n"
-      assert contents =~ "Compiled lib/hello.ex\n"
+      refute contents =~ "This won't appear"
     end
   end
 
@@ -127,10 +129,11 @@ defmodule Mix.CLITest do
     end
   end
 
-  defp mix(args) when is_list(args) do
+  defp mix(args, envs \\ []) when is_list(args) do
     System.cmd(elixir_executable,
                ["-r", mix_executable, "--"|args],
-               [stderr_to_stdout: true]) |> elem(0)
+               stderr_to_stdout: true, 
+               env: envs) |> elem(0)
   end
 
   defp mix_executable do

--- a/lib/mix/test/mix/shell/quiet_test.exs
+++ b/lib/mix/test/mix/shell/quiet_test.exs
@@ -1,0 +1,44 @@
+Code.require_file "../../test_helper.exs", __DIR__
+
+defmodule Mix.Shell.QuietTest do
+  use MixTest.Case
+
+  import ExUnit.CaptureIO
+  import Mix.Shell.Quiet
+
+  test "prints nothing to stdio when info is invoked" do
+    assert capture_io(fn ->
+      info "hello"
+    end) == ""
+  end
+
+  test "prints error message to stderr" do
+    assert capture_io(:stderr, fn ->
+      error "hello"
+    end) =~ "hello"
+  end
+
+  test "asks the user with yes?" do
+    assert capture_io("\n", fn -> yes?("Ok?") end) == "Ok? [Yn] "
+    assert capture_io("\n", fn -> assert yes?("Ok?") end)
+    assert capture_io("Yes", fn -> assert yes?("Ok?") end)
+    assert capture_io("yes", fn -> assert yes?("Ok?") end)
+    assert capture_io("y", fn -> assert yes?("Ok?") end)
+
+    assert capture_io("n", fn -> refute yes?("Ok?") end)
+    assert capture_io("", fn -> refute yes?("Ok?") end)
+  end
+
+  test "runs a given command" do
+    assert capture_io("", fn -> assert cmd("echo hello") == 0 end) == ""
+
+    wont_print_sample()
+    assert capture_io("", fn -> assert cmd("echo hello", print_app: false) == 0 end) == ""
+    assert capture_io("", fn -> assert cmd("echo hello") == 0 end) == ""
+  end
+
+  defp wont_print_sample do
+    Mix.Project.push nil
+    Mix.Project.push MixTest.Case.Sample
+  end
+end


### PR DESCRIPTION
Mix.Shell.Quiet is like Mix.Shell.IO, but it prints much less information out. Useful when the output is not important.

Solves #3167.