### PR TITLE
Pipe operator simplication

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -33,10 +33,10 @@ defmodule Stream do
   computations that are executed at a later moment. Let's see another
   example:
 
-      1..3 |>
-        Enum.map(&IO.inspect(&1)) |>
-        Enum.map(&(&1 * 2)) |>
-        Enum.map(&IO.inspect(&1))
+      1..3
+      |> Enum.map(&IO.inspect(&1))
+      |> Enum.map(&(&1 * 2))
+      |> Enum.map(&IO.inspect(&1))
       1
       2
       3
@@ -49,10 +49,10 @@ defmodule Stream do
   element by 2 and finally printed each new value. In this example, the list
   was enumerated three times. Let's see an example with streams:
 
-      stream = 1..3 |>
-        Stream.map(&IO.inspect(&1)) |>
-        Stream.map(&(&1 * 2)) |>
-        Stream.map(&IO.inspect(&1))
+      stream = 1..3
+      |> Stream.map(&IO.inspect(&1)) |>
+      |> Stream.map(&(&1 * 2)) |>
+      |> Stream.map(&IO.inspect(&1))
       Enum.to_list(stream)
       1
       2

--- a/lib/elixir/test/elixir/inspect/algebra_test.exs
+++ b/lib/elixir/test/elixir/inspect/algebra_test.exs
@@ -121,7 +121,7 @@ defmodule Inspect.AlgebraTest do
   test "formatting with infinity" do
     s = String.duplicate "x", 50
     g = ";"
-    doc = group(glue(s, g, s) |>  glue(g, s) |>  glue(g, s) |> glue(g, s))
+    doc = glue(s, g, s) |>  glue(g, s) |>  glue(g, s) |> glue(g, s) |> group
 
     assert render(doc, :infinity) == s <> g <> s <> g <> s <> g <> s <> g <> s
   end

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -137,8 +137,9 @@ defmodule PathTest do
     assert (Path.expand("bar/../bar", "/foo") |> strip_drive_letter_if_windows)== "/foo/bar"
     assert (Path.expand("../bar/../bar", "/foo/../foo/../foo") |> strip_drive_letter_if_windows) == "/bar"
 
-    assert (Path.expand(['..', ?/, "bar/../bar"], '/foo/../foo/../foo') |>
-            strip_drive_letter_if_windows) == "/bar"
+    assert "/bar" ==
+      (Path.expand(['..', ?/, "bar/../bar"], '/foo/../foo/../foo') |> strip_drive_letter_if_windows)
+
     assert (Path.expand("/..") |> strip_drive_letter_if_windows) == "/"
 
     assert Path.expand("bar/../bar", "foo") == Path.expand("foo/bar")

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -289,8 +289,10 @@ defmodule ExUnit.Case do
             "\"use ExUnit.Case\" in the current module"
     end
 
-    tags = tags ++ Module.get_attribute(mod, :tag) ++ moduletag
-    tags = tags |> normalize_tags |> Map.merge(%{line: env.line, file: env.file})
+    tags =
+      (tags ++ Module.get_attribute(mod, :tag) ++ moduletag)
+      |> normalize_tags
+      |> Map.merge(%{line: env.line, file: env.file})
 
     test = %ExUnit.Test{name: name, case: mod, tags: tags}
     test_names = Module.get_attribute(mod, :ex_unit_test_names)

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -153,9 +153,8 @@ defmodule IEx.Evaluator do
   ## Error handling
 
   defp print_error(kind, reason, stacktrace) do
-    message = Exception.format_banner(kind, reason, stacktrace)
-    io_error message
-    io_error (stacktrace |> prune_stacktrace |> format_stacktrace)
+    Exception.format_banner(kind, reason, stacktrace) |> io_error
+    stacktrace |> prune_stacktrace |> format_stacktrace |> io_error
   end
 
   @elixir_internals [:elixir, :elixir_exp, :elixir_compiler, :elixir_module, :elixir_clauses,

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -206,8 +206,10 @@ defmodule Mix.Utils do
   end
 
   def module_name_to_command(module, nesting) do
-    t = Regex.split(~r/\./, to_string(module))
-    t |> Enum.drop(nesting) |> Enum.map(&underscore(&1)) |> Enum.join(".")
+    Regex.split(~r/\./, to_string(module))
+    |> Enum.drop(nesting)
+    |> Enum.map(&underscore(&1))
+    |> Enum.join(".")
   end
 
   @doc """
@@ -220,9 +222,9 @@ defmodule Mix.Utils do
 
   """
   def command_to_module_name(s) do
-    Regex.split(~r/\./, to_string(s)) |>
-      Enum.map(&camelize(&1)) |>
-      Enum.join(".")
+    Regex.split(~r/\./, to_string(s))
+    |> Enum.map(&camelize(&1))
+    |> Enum.join(".")
   end
 
   @doc """


### PR DESCRIPTION
I have removed |>  at the end of the lines,
this only happened twice and one is an example, and I think it's inconsistent.

also code has been simplified using |>, avoiding creating unnecessary variables.

the last fix deals with some formatting issues in Path test: space missing before == , and lines over 100 chars