### PR TITLE
Add TypeError and Keyword.boolean/3 method

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -689,6 +689,24 @@ defmodule KeyError do
   end
 end
 
+defmodule TypeError do
+  defexception key: nil, value: nil, term: nil, expected_type: nil
+  def message(exception) do
+    msg = "value: #{inspect exception.value}"
+    if exception.key != nil do
+      msg = msg <> " for key: #{inspect exception.key}"
+    end
+    if exception.term != nil do
+      msg = msg <> " in: #{inspect exception.term}"
+    end
+    if exception.expected_type != nil do
+      msg <> " is not of type: #{exception.expected_type}"
+    else
+      msg
+    end
+  end
+end
+
 defmodule UnicodeConversionError do
   defexception [:encoded, :message]
 

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -768,21 +768,21 @@ defmodule Keyword do
 
   ## Examples
 
-    iex> Keyword.bool [a: false], :b, true
+    iex> Keyword.boolean [a: false], :b, true
     true
 
-    iex> Keyword.bool [a: false], :b
+    iex> Keyword.boolean [a: false], :b
     false
 
-    iex> Keyword.bool [a: false], :a, true
+    iex> Keyword.boolean [a: false], :a, true
     false
 
-    iex> Keyword.bool [a: 1], :a, false
+    iex> Keyword.boolean [a: 1], :a, false
     ** (TypeError) value: 1 for key: :a in: [a: 1] is not of type: boolean
 
   """
-  @spec bool(t, key, boolean) :: boolean
-  def bool(dict, key, default \\ false) when is_boolean(default) do
+  @spec boolean(t, key, boolean) :: boolean
+  def boolean(dict, key, default \\ false) when is_boolean(default) do
     value = get(dict, key, default)
     case is_boolean(value) do
       true -> value

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -756,4 +756,38 @@ defmodule Keyword do
   def size(keyword) do
     length(keyword)
   end
+
+  @doc """
+  Retrieves a boolean value for `key` from `dict`.
+
+  In case there is no such key, `default` is returned
+  (`default` defaults to `false`).
+
+  In case there is a key and the value is not a boolean,
+  an error is raised.
+
+  ## Examples
+
+    iex> Keyword.bool [a: false], :b, true
+    true
+
+    iex> Keyword.bool [a: false], :b
+    false
+
+    iex> Keyword.bool [a: false], :a, true
+    false
+
+    iex> Keyword.bool [a: 1], :a, false
+    ** (TypeError) value: 1 for key: :a in: [a: 1] is not of type: boolean
+
+  """
+  @spec bool(t, key, boolean) :: boolean
+  def bool(dict, key, default \\ false) when is_boolean(default) do
+    value = get(dict, key, default)
+    case is_boolean(value) do
+      true -> value
+      false -> raise TypeError, key: key, value: value, term: dict, expected_type: "boolean"
+    end
+  end
+
 end


### PR DESCRIPTION
This is a partial fix for #2497 implementing Keyword.bool/3. It adds the Keyword.boolean/3 method as well as a TypeError, which may be appropriate for other uses.