### PR TITLE
Show syntax for function capture in a pipeline

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -113,7 +113,7 @@ defmodule Macro do
 
   defp bad_pipe(expr, call_args) do
     raise ArgumentError, "cannot pipe #{to_string expr} into #{to_string call_args}, " <>
-      "can only pipe into local calls foo(), remote calls Foo.bar() or anonymous functions calls foo.()"
+      "can only pipe into local calls foo(), remote calls Foo.bar(), or anonymous function calls foo.() or (&(&1 + 1)).()"
   end
 
   @doc """


### PR DESCRIPTION
I tried to use function capture syntax in a pipeline `|> &(&1 != Empty)` and got the error message

`** (ArgumentError) cannot pipe Agent.get(Process.whereis(agent_name(@last_row, col)), &&1) into &&1 != Empty.(), can only pipe into local calls foo(), remote calls Foo.bar() or anonymous functions calls foo.()`

I tried surrounding it with parentheses thinking it was just a problem with `|>` binding more tightly than something else, and that didn't work either. Stack Overflow [1] solved it with even _more_ parentheses: `(&(&1 != Empty)).()`. (See [2].)

Assuming this is something reasonable to do in a pipeline, this adds an example of the function capture syntax to the list of possibilities in the error message.

[1] http://stackoverflow.com/questions/24593967/how-to-pass-an-anonymous-function-to-the-pipe-in-elixir
[2] https://github.com/wsmoak/connect_four/blob/master/lib/connect_four/board.ex#L121