### PR TITLE
Added :friendly option Inspect.Options for char_lists.

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -276,7 +276,7 @@ defimpl Inspect, for: List do
 
   def inspect(thing, %Inspect.Opts{char_lists: lists} = opts) do
     cond do
-      lists == :as_char_lists or (lists == :infer and printable?(thing)) ->
+      lists == :as_char_lists or convertable?(thing, lists) ->
         << ?', Inspect.BitString.escape(IO.chardata_to_string(thing), ?') :: binary, ?' >>
       keyword?(thing) ->
         surround_many("[", thing, "]", opts, &keyword/2)
@@ -304,6 +304,18 @@ defimpl Inspect, for: List do
 
   ## Private
 
+  defp convertable?(thing,option) do
+    if(printable?(thing)) do
+      case option do
+        :infer -> true
+        :friendly -> readable?(thing)
+        _ -> false
+      end
+    else
+      false
+    end
+  end
+
   defp key_to_binary(key) do
     case Inspect.Atom.inspect(key) do
       ":" <> right -> right
@@ -322,6 +334,20 @@ defimpl Inspect, for: List do
   defp printable?([?\a|cs]), do: printable?(cs)
   defp printable?([]), do: true
   defp printable?(_), do: false
+
+  #@most_common_ascii [69, 84, 65, 79, 73, 101, 116, 97, 111, 105]
+  @ascii_version_number Enum.to_list(48..57) ++ [45, 46]
+  @ascii_lowercase Enum.to_list(97..122)
+  defp readable?(list) when is_list(list) and length(list) < 5 do
+   Enum.all?(list, fn(char) -> :lists.member(char, @ascii_version_number) end) or
+   Enum.all?(list, fn(char) -> :lists.member(char, @ascii_lowercase) end)
+  end
+
+  defp readable?(list) when is_list(list) do
+    true
+    #Enum.any?(@most_common_ascii, fn(char) -> :lists.member(char, list) end)
+  end
+
 end
 
 defimpl Inspect, for: Tuple do

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -336,8 +336,8 @@ defimpl Inspect, for: List do
   defp printable?(_), do: false
 
   #@most_common_ascii [69, 84, 65, 79, 73, 101, 116, 97, 111, 105]
-  @ascii_version_number Enum.to_list(48..57) ++ [45, 46]
-  @ascii_lowercase Enum.to_list(97..122)
+  @ascii_version_number [45, 46, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57]
+  @ascii_lowercase [97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122]
   defp readable?(list) when is_list(list) and length(list) < 5 do
    Enum.all?(list, fn(char) -> :lists.member(char, @ascii_version_number) end) or
    Enum.all?(list, fn(char) -> :lists.member(char, @ascii_lowercase) end)

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -23,6 +23,9 @@ defmodule Inspect.Opts do
       When the default `:infer`, the list will be printed as a char list if it
       is printable, otherwise as list.
 
+      When `:friendly`, the list will be printed as a char list if it is
+      printable and appears to be readable text, otherwise as a list.
+
     * `:limit` - limits the number of items that are printed for tuples,
       bitstrings, and lists, does not apply to strings nor char lists, defaults
       to 50.
@@ -54,7 +57,7 @@ defmodule Inspect.Opts do
   @type t :: %__MODULE__{
                structs: boolean,
                binaries: :infer | :as_binaries | :as_strings,
-               char_lists: :infer | :as_lists | :as_char_lists,
+               char_lists: :infer | :as_lists | :as_char_lists | :friendly,
                limit: pos_integer | :infinity,
                width: pos_integer | :infinity,
                base: :decimal | :binary | :hex | :octal,
@@ -77,7 +80,7 @@ defmodule Inspect.Algebra do
   This module implements the functionality described in
   ["Strictly Pretty" (2000) by Christian Lindig][0] with small
   additions, like support for String nodes, and a custom
-  rendering function that maximises horizontal space use. 
+  rendering function that maximises horizontal space use.
 
       iex> Inspect.Algebra.empty
       :doc_nil

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -196,6 +196,15 @@ defmodule Inspect.ListTest do
     assert inspect([0], char_lists: :infer) == "[0]"
   end
 
+  test "opt friendly" do
+    assert inspect('john' ++ [0] ++ 'doe', char_lists: :friendly) == "[106, 111, 104, 110, 0, 100, 111, 101]"
+    assert inspect('john', char_lists: :friendly) == "'john'"
+    assert inspect('1.3', char_lists: :friendly) == "'1.3'"
+    assert inspect([0], char_lists: :friendly) == "[0]"
+    assert inspect([64, 81, 100], char_lists: :friendly) == "[64, 81, 100]"
+  end
+
+
   test "opt as strings" do
     assert inspect('john' ++ [0] ++ 'doe', char_lists: :as_char_lists) == "'john\\0doe'"
     assert inspect('john', char_lists: :as_char_lists) == "'john'"


### PR DESCRIPTION
The `:friendly` option is exactly the same as `:infer` except when the list is
shorter than 5 elements. It then tests the list to be either
an all lowercase entry or a version number.

I believe this provides a nice compromise between the current
new user unfriendly default of `:infer` and making most interactions
with the erlang standard library unreadable.

I'm not sure of the exact number where this should kick in. 4 might be
too small, 8 is probably too large, but I think something like this could
eliminate most of the questions about why does `[80, 65, 102, 121]`
turn into 'PAfy', etc... 

If we can make this workable, then an additional patch to make 
`IEx.configure inspect: [char_lists: :friendly]`

the default for IEx only would go a long ways towards reducing the number of
times people run into this issue. 

