### PR TITLE
Add list version of Enum `max_by/2`, `min_by/2`, `min_max_by/2`

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1223,6 +1223,40 @@ defmodule Enum do
   end
 
   @doc """
+  Returns list of the biggest elements in the enumerable as calculated by the given function.
+
+  Returns empty list if the enumerable is empty.
+
+  ## Examples
+
+      iex> Enum.max_list_by(["a", "b", "aa", "bb", "bbb", "aaa"], fn(x) -> String.length(x) end)
+      ["bbb", "aaa"]
+
+      iex> Enum.max_list_by([], fn(x) -> String.length(x) end)
+      []
+
+  """
+  @spec max_list_by(t, (element -> any)) :: list
+  def max_list_by(enumerable, fun) do
+    result = enumerable |> reduce(:first, fn
+      entry, :first ->
+        fun_entry = fun.(entry)
+        {[entry], fun_entry}
+      entry, {acc_entries, acc_fun_entry} ->
+        fun_entry = fun.(entry)
+        cond do
+          fun_entry == acc_fun_entry -> {[entry|acc_entries], fun_entry}
+          fun_entry > acc_fun_entry -> {[entry], fun_entry}
+          true -> {acc_entries, acc_fun_entry}
+        end
+    end)
+    case result do
+      :first -> []
+      _ -> result |> elem(0) |> :lists.reverse
+    end
+  end
+
+  @doc """
   Checks if `element` exists within the enumerable.
 
   Membership is tested with the match (`===`) operator.
@@ -1324,6 +1358,40 @@ defmodule Enum do
   end
 
   @doc """
+  Returns list of the smallest elements in the enumerable as calculated by the given function.
+
+  Returns empty list if the enumerable is empty.
+
+  ## Examples
+
+      iex> Enum.min_list_by(["a", "b", "aa", "bb", "bbb", "aaa"], fn(x) -> String.length(x) end)
+      ["a", "b"]
+
+      iex> Enum.min_list_by([], fn(x) -> String.length(x) end)
+      []
+
+  """
+  @spec min_list_by(t, (element -> any)) :: list
+  def min_list_by(enumerable, fun) do
+    result = enumerable |> reduce(:first, fn
+      entry, :first ->
+        fun_entry = fun.(entry)
+        {[entry], fun_entry}
+      entry, {acc_entries, acc_fun_entry} ->
+        fun_entry = fun.(entry)
+        cond do
+          fun_entry == acc_fun_entry -> {[entry|acc_entries], fun_entry}
+          fun_entry < acc_fun_entry -> {[entry], fun_entry}
+          true -> {acc_entries, acc_fun_entry}
+        end
+    end)
+    case result do
+      :first -> []
+      _ -> result |> elem(0) |> :lists.reverse
+    end
+  end
+
+  @doc """
   Returns a tuple with the smallest and the biggest elements in the
   enumerable according to Erlang's term ordering.
 
@@ -1388,6 +1456,46 @@ defmodule Enum do
         raise Enum.EmptyError
       {{min_entry, _}, {max_entry, _}} ->
         {min_entry, max_entry}
+    end
+  end
+
+  @doc """
+  Returns a tuple with list of smallest elements and list of biggest elements in the enumerable as calculated by the given function.
+
+  Returns a tuple of two empty lists if the enumerable is empty.
+
+  ## Examples
+
+      iex> Enum.min_max_list_by(["a", "b", "aa", "bb", "bbb", "aaa"], fn(x) -> String.length(x) end)
+      {["a", "b"], ["bbb", "aaa"]}
+
+      iex> Enum.min_max_list_by([], fn(x) -> String.length(x) end)
+      {[], []}
+
+  """
+  @spec min_max_list_by(t, (element -> any)) :: {list, list}
+  def min_max_list_by(enumerable, fun) do
+    result = enumerable |> reduce(:first, fn
+      entry, :first ->
+        fun_entry = fun.(entry)
+        {{[entry], fun_entry}, {[entry], fun_entry}}
+      entry, {acc_min={acc_min_entries, acc_min_fun_entry}, acc_max={acc_max_entries, acc_max_fun_entry}} ->
+        fun_entry = fun.(entry)
+        acc_min = cond do
+          fun_entry == acc_min_fun_entry -> {[entry|acc_min_entries], fun_entry}
+          fun_entry < acc_min_fun_entry -> {[entry], fun_entry}
+          true -> acc_min
+        end
+        acc_max = cond do
+          fun_entry == acc_max_fun_entry -> {[entry|acc_max_entries], fun_entry}
+          fun_entry > acc_max_fun_entry -> {[entry], fun_entry}
+          true -> acc_max
+        end
+        {acc_min, acc_max}
+    end)
+    case result do
+      :first -> {[], []}
+      {result_min, result_max} -> {result_min |> elem(0) |> :lists.reverse, result_max |> elem(0) |> :lists.reverse}
     end
   end
 

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -512,6 +512,11 @@ defmodule EnumTest.List do
     end
   end
 
+  test "max list by" do
+    assert Enum.max_list_by(["a", "b", "aa", "bb", "bbb", "aaa"], fn(x) -> String.length(x) end) == ["bbb", "aaa"]
+    assert Enum.max_list_by([], fn(x) -> String.length(x) end) == []
+  end
+
   test "min" do
     assert Enum.min([1]) == 1
     assert Enum.min([1, 2, 3]) == 1
@@ -528,6 +533,11 @@ defmodule EnumTest.List do
     end
   end
 
+  test "min list by" do
+    assert Enum.min_list_by(["a", "b", "aa", "bb", "bbb", "aaa"], fn(x) -> String.length(x) end) == ["a", "b"]
+    assert Enum.min_list_by([], fn(x) -> String.length(x) end) == []
+  end
+
   test "min max" do
     assert Enum.min_max([1]) == {1, 1}
     assert Enum.min_max([2, 3, 1]) == {1, 3}
@@ -542,6 +552,11 @@ defmodule EnumTest.List do
     assert_raise Enum.EmptyError, fn ->
       Enum.min_max_by([], fn(x) -> String.length(x) end)
     end
+  end
+
+  test "min max list by" do
+    assert Enum.min_max_list_by(["a", "b", "aa", "bb", "bbb", "aaa"], fn(x) -> String.length(x) end) == {["a", "b"], ["bbb", "aaa"]}
+    assert Enum.min_max_list_by([], fn(x) -> String.length(x) end) == {[], []}
   end
 
   test "chunk" do


### PR DESCRIPTION
Often, we are also interested in all entries that produces the biggest or smallest value, not just one.

The list versions are especially useful when searching for all entries that matches minimum/maximum criteria. 

For example, given a collection of people profile which includes age and income, find all the youngest people with highest income.

Here's a reference to what it looks like. https://github.com/seantanly/elixir-minmaxlist#examples

Kindly consider the feature request, I have attached a pull request for adding `Enum.max_list_by/2`, `Enum.min_list_by/2` and `Enum.min_max_list_by/2`. Thanks.
