### PR TITLE
Add file to logger metadata

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -517,9 +517,9 @@ defmodule Logger do
   end
 
   defp macro_log(level, data, metadata, caller) do
-    %{module: module, function: fun, line: line} = caller
+    %{module: module, function: fun, file: file, line: line} = caller
 
-    caller = [module: module, function: form_fa(fun), line: line]
+    caller = [module: module, function: form_fa(fun), file: file, line: line]
     if app = Application.get_env(:logger, :compile_time_application) do
       caller = [application: app] ++ caller
     end

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -172,6 +172,19 @@ defmodule Logger do
 
     * `:colors` - a keyword list of coloring options.
 
+  In addition to the keys provided by the user via `Logger.metadata/1`,
+  the following default keys available in the `:metadata` list:
+
+    * `:application` - the current application
+
+    * `:module` - the current module
+
+    * `:function` - the current function
+
+    * `:file` - the current file
+
+    * `:line` - the current line
+
   The supported keys in the `:colors` keyword list are:
 
     * `:enabled` - boolean value that allows for switching the

--- a/lib/logger/test/logger/backends/console_test.exs
+++ b/lib/logger/test/logger/backends/console_test.exs
@@ -49,13 +49,13 @@ defmodule Logger.Backends.ConsoleTest do
 
   test "metadata defaults" do
     Logger.configure_backend(:console,
-      format: "$metadata", metadata: [:line, :module, :function])
+      format: "$metadata", metadata: [:file, :line, :module, :function])
 
-    %{module: mod, function: {name, arity}, line: line} = __ENV__
+    %{module: mod, function: {name, arity}, file: file, line: line} = __ENV__
 
     assert capture_log(fn ->
       Logger.debug("hello")
-    end) =~ "line=#{line + 3} module=#{inspect(mod)} function=#{name}/#{arity}"
+    end) =~ "file=#{file} line=#{line + 3} module=#{inspect(mod)} function=#{name}/#{arity}"
   end
 
   test "can configure level" do


### PR DESCRIPTION
In [this StackOverflow question](https://stackoverflow.com/questions/33540776/how-to-get-line-numbers-in-console-outputs-in-elixir), José said it would be possible to add the current file to the logger format, but not all keys from `__CALLER__` are available.

I added the `:file` key since I think it is a useful addition. I also added a list of available keys to the docs, because I was missing them when I researched. Let me know what you think!