### PR TITLE
Support for proxy auth with mix calls to httpc

### DIFF
--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -363,17 +363,15 @@ defmodule Mix.Utils do
     headers = [{'user-agent', 'Mix/#{System.version}'}]
     request = {:binary.bin_to_list(path), headers}
 
-    # If a proxy environment variable was supplied add a proxy to httpc
-    http_proxy  = System.get_env("HTTP_PROXY")  || System.get_env("http_proxy")
-    https_proxy = System.get_env("HTTPS_PROXY") || System.get_env("https_proxy")
-    if http_proxy,  do: proxy(:proxy, http_proxy)
-    if https_proxy, do: proxy(:https_proxy, https_proxy)
-
     # We are using relaxed: true because some servers is returning a Location
     # header with relative paths, which does not follow the spec. This would
     # cause the request to fail with {:error, :no_scheme} unless :relaxed
     # is given.
-    case :httpc.request(:get, request, [relaxed: true], [body_format: :binary], :mix) do
+    #
+    # If a proxy environment variable was supplied add a proxy to httpc.
+    http_options = [relaxed: true] ++ proxy_config(path)
+
+    case :httpc.request(:get, request, http_options, [body_format: :binary], :mix) do
       {:ok, {{_, status, _}, _, body}} when status in 200..299 ->
         {:ok, body}
       {:ok, {{_, status, _}, _, _}} ->
@@ -393,12 +391,52 @@ defmodule Mix.Utils do
     URI.parse(path).scheme in ["http", "https"]
   end
 
-  defp proxy(proxy_scheme, proxy) do
-    uri  = URI.parse(proxy)
+  def proxy_config(url) do
+    {http_proxy, https_proxy} = proxy_env
+
+    proxy_auth(URI.parse(url), http_proxy, https_proxy)
+  end
+
+  defp proxy_env do
+    http_proxy  = System.get_env("HTTP_PROXY")  || System.get_env("http_proxy")
+    https_proxy = System.get_env("HTTPS_PROXY") || System.get_env("https_proxy")
+
+    {proxy_setup(:http, http_proxy), proxy_setup(:https, https_proxy)}
+  end
+
+  defp proxy_setup(scheme, proxy) do
+    uri = URI.parse(proxy || "")
 
     if uri.host && uri.port do
       host = String.to_char_list(uri.host)
-      :httpc.set_options([{proxy_scheme, {{host, uri.port}, []}}], :mix)
+      :httpc.set_options([{proxy_scheme(scheme), {{host, uri.port}, []}}], :mix)
     end
+
+    uri
+  end
+
+  defp proxy_scheme(scheme) do
+    case scheme do
+      :http  -> :proxy
+      :https -> :https_proxy
+    end
+  end
+
+  defp proxy_auth(%URI{scheme: "http"}, http_proxy, _https_proxy),
+    do: proxy_auth(http_proxy)
+  defp proxy_auth(%URI{scheme: "https"}, _http_proxy, https_proxy),
+    do: proxy_auth(https_proxy)
+
+  defp proxy_auth(nil),
+    do: []
+  defp proxy_auth(%URI{userinfo: nil}),
+    do: []
+  defp proxy_auth(%URI{userinfo: auth}) do
+    destructure [user, pass], String.split(auth, ":", parts: 2)
+
+    user = String.to_char_list(user)
+    pass = String.to_char_list(pass || "")
+
+    [proxy_auth: {user, pass}]
   end
 end

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -68,6 +68,22 @@ defmodule Mix.UtilsTest do
     end
   end
 
+  test "proxy_config reads from env and returns credentials" do
+    assert Mix.Utils.proxy_config("http://example.com") == []
+
+    System.put_env("http_proxy", "http://nopass@example.com")
+    assert Mix.Utils.proxy_config("http://example.com") == [proxy_auth: {'nopass', ''}]
+
+    System.put_env("HTTP_PROXY", "http://my:proxy@example.com")
+    assert Mix.Utils.proxy_config("http://example.com") == [proxy_auth: {'my', 'proxy'}]
+
+    System.put_env("https_proxy", "https://another:proxy@example.com")
+    assert Mix.Utils.proxy_config("https://example.com") == [proxy_auth: {'another', 'proxy'}]
+
+    System.put_env("HTTPS_PROXY", "https://example.com")
+    assert Mix.Utils.proxy_config("https://example.com") == []
+  end
+
   defp assert_ebin_symlinked_or_copied(result) do
     case result do
       {:ok, paths} -> assert Path.expand("_build/archive/ebin") in paths


### PR DESCRIPTION
This PR ensures that calls to `:httpc.request` using the `:mix` profile supply proxy authentication if they can be read from environment variables.

My use case is deploying elixir apps to an internal deployment of Cloud Foundry behind a firewall, limiting external connections to proxies. Hopefully others will find this useful!