### PR TITLE
Integer - is_odd/1 & is_even/1: Add own raise message + @specs

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -11,9 +11,35 @@ defmodule Integer do
   Returns `true` if `n` is an odd number, otherwise `false`.
 
   Allowed in guard clauses.
+
+  ## Examples
+
+      iex> Integer.is_odd(3)
+      true
+
+      iex> Integer.is_odd(4)
+      false
   """
+  @spec is_odd(integer) :: boolean
   defmacro is_odd(n) do
-    quote do: (unquote(n) &&& 1) == 1
+    case Macro.Env.in_guard?(__CALLER__) do
+      true ->
+        quote do: (unquote(n) &&& 1) == 1
+
+      false ->
+        quote bind_quoted: [n: n] do
+          number = fn -> n end
+          case is_integer(number.()) do
+            false ->
+              raise ArgumentError,
+                "Integer.is_odd/1 expects an integer as an argument, " <>
+                "got: #{Macro.to_string(n)}"
+
+            true ->
+              (n &&& 1) == 1
+          end
+        end
+    end
   end
 
   @doc """
@@ -22,9 +48,35 @@ defmodule Integer do
   Returns `true` if `n` is an even number, otherwise `false`.
 
   Allowed in guard clauses.
+
+  ## Examples
+
+      iex> Integer.is_even(10)
+      true
+
+      iex> Integer.is_even(5)
+      false
   """
+  @spec is_even(integer) :: boolean
   defmacro is_even(n) do
-    quote do: (unquote(n) &&& 1) == 0
+    case Macro.Env.in_guard?(__CALLER__) do
+      true ->
+        quote do: (unquote(n) &&& 1) == 0
+
+      false ->
+        quote bind_quoted: [n: n] do
+          number = fn -> n end
+          case is_integer(number.()) do
+            true ->
+              (n &&& 1) == 0
+
+            false ->
+              raise ArgumentError,
+                "Integer.is_even/1 expects an integer as an argument, " <>
+                "got: #{Macro.to_string(n)}"
+          end
+        end
+    end
   end
 
   @doc """

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -4,7 +4,17 @@ defmodule IntegerTest do
   use ExUnit.Case, async: true
   require Integer
 
-  test "odd?" do
+  def test_is_odd_in_guards(number) when Integer.is_odd(number),
+    do: number
+  def test_is_odd_in_guards(_number),
+    do: false
+
+  def test_is_even_in_guards(number) when Integer.is_even(number),
+    do: number
+  def test_is_even_in_guards(_number),
+    do: false
+
+  test "is_odd" do
     assert Integer.is_odd(0) == false
     assert Integer.is_odd(1) == true
     assert Integer.is_odd(2) == false
@@ -12,9 +22,16 @@ defmodule IntegerTest do
     assert Integer.is_odd(-1) == true
     assert Integer.is_odd(-2) == false
     assert Integer.is_odd(-3) == true
+    assert test_is_odd_in_guards(10) == false
+    assert test_is_odd_in_guards(11) == 11
+    assert_raise ArgumentError,
+      "Integer.is_odd/1 expects an integer as an argument, got: 1.0", fn ->
+        n = fn -> 1.0 end
+        Integer.is_odd n.()
+      end
   end
 
-  test "even?" do
+  test "is_even" do
     assert Integer.is_even(0) == true
     assert Integer.is_even(1) == false
     assert Integer.is_even(2) == true
@@ -22,6 +39,13 @@ defmodule IntegerTest do
     assert Integer.is_even(-1) == false
     assert Integer.is_even(-2) == true
     assert Integer.is_even(-3) == false
+    assert test_is_even_in_guards(10) == 10
+    assert test_is_even_in_guards(11) == false
+    assert_raise ArgumentError,
+      "Integer.is_even/1 expects an integer as an argument, got: 1.0", fn ->
+        n = fn -> 1.0 end
+        Integer.is_even n.()
+      end
   end
 
   test "digits" do


### PR DESCRIPTION
Integer: is_odd/1 & is_even/1:
- Adds @specs

- Adds examples to docs

- If given a wrong type, previous message was disguising:
  > iex> Integer.is_odd(1.0)
  > ** (ArithmeticError) bad argument in arithmetic expression
    :erlang.band(1.0, 1)
  
  Now is:
  > iex> Integer.is_odd(1.0)`
  > ** (ArgumentError) Integer.is_odd/1 expects an integer as an argument, got: 1.0