### PR TITLE
Throw an error for -> with an empty left-hand side

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -394,7 +394,7 @@ defmodule Exception do
 
   ## Examples
 
-      Exception.format_fa(fn -> end, 1)
+      Exception.format_fa(fn -> nil end, 1)
       #=> "#Function<...>/1"
 
   """

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -129,7 +129,7 @@ defmodule ExceptionTest do
   end
 
   test "format_fa" do
-    assert Exception.format_fa(fn -> end, 1) =~
+    assert Exception.format_fa(fn -> nil end, 1) =~
            ~r"#Function<\d+\.\d+/0 in ExceptionTest\.test format_fa/1>/1"
   end
 

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -402,7 +402,7 @@ defmodule Kernel.ErrorsTest do
     msg = ~r"cannot inject attribute @foo into function/macro because cannot escape "
     assert_raise ArgumentError, msg, fn ->
       defmodule InvalidAttribute do
-        @foo fn -> end
+        @foo fn -> nil end
         def bar, do: @foo
       end
     end
@@ -412,7 +412,7 @@ defmodule Kernel.ErrorsTest do
     msg = ~r"invalid value for struct field baz, cannot escape "
     assert_raise ArgumentError, msg, fn ->
       defmodule InvaliadStructFieldValue do
-        defstruct baz: fn -> end
+        defstruct baz: fn -> nil end
       end
     end
   end

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -500,7 +500,7 @@ defmodule Kernel.ExpansionTest do
     end
 
     assert_raise CompileError, ~r"invalid quoted expression: #Function<", fn ->
-      expand(quote do: unquote({:sample, fn -> end}))
+      expand(quote do: unquote({:sample, fn -> nil end}))
     end
   end
 

--- a/lib/elixir/test/elixir/kernel/quote_test.exs
+++ b/lib/elixir/test/elixir/kernel/quote_test.exs
@@ -131,12 +131,6 @@ defmodule Kernel.QuoteTest do
   end
 
   test "stab" do
-    assert [{:->, _, [[], nil]}] = (quote do -> end)
-    assert [{:->, _, [[], nil]}] = (quote do: (->))
-
-    assert [{:->, _, [[1], nil]}] = (quote do 1 -> end)
-    assert [{:->, _, [[1], nil]}] = (quote do: (1 ->))
-
     assert [{:->, _, [[], 1]}] = (quote do -> 1 end)
     assert [{:->, _, [[], 1]}] = (quote do: (-> 1))
   end
@@ -222,7 +216,7 @@ defmodule Kernel.QuoteTest.ErrorsTest do
 
     mod  = Kernel.QuoteTest.ErrorsTest
     file = __ENV__.file |> Path.relative_to_cwd |> String.to_char_list
-    assert [{^mod, :add, 2, [file: ^file, line: 202]}|_] = System.stacktrace
+    assert [{^mod, :add, 2, [file: ^file, line: 196]}|_] = System.stacktrace
   end
 
   test "outside function error" do
@@ -232,7 +226,7 @@ defmodule Kernel.QuoteTest.ErrorsTest do
 
     mod  = Kernel.QuoteTest.ErrorsTest
     file = __ENV__.file |> Path.relative_to_cwd |> String.to_char_list
-    assert [{^mod, _, _, [file: ^file, line: 230]}|_] = System.stacktrace
+    assert [{^mod, _, _, [file: ^file, line: 224]}|_] = System.stacktrace
   end
 end
 

--- a/lib/elixir/test/elixir/process_test.exs
+++ b/lib/elixir/test/elixir/process_test.exs
@@ -38,7 +38,7 @@ defmodule ProcessTest do
   end
 
   test "info/2 with registered name" do
-    pid = spawn fn -> end
+    pid = spawn fn -> nil end
     Process.exit(pid, :kill)
     assert Process.info(pid, :registered_name) ==
            nil

--- a/lib/elixir/test/elixir/string/chars_test.exs
+++ b/lib/elixir/test/elixir/string/chars_test.exs
@@ -105,7 +105,7 @@ defmodule String.Chars.ErrorsTest do
 
   test "function" do
     assert_raise Protocol.UndefinedError, ~r"^protocol String\.Chars not implemented for #Function<.+?>$", fn ->
-      to_string(fn -> end)
+      to_string(fn -> nil end)
     end
   end
 

--- a/lib/elixir/test/erlang/function_test.erl
+++ b/lib/elixir/test/erlang/function_test.erl
@@ -10,10 +10,6 @@ function_arg_do_end_test() ->
   {nil, _} = eval("if true do end").
 
 function_stab_end_test() ->
-  {_, [{a, Fun1}]} = eval("a = fn -> end"),
-  nil = Fun1(),
-  {_, [{a, Fun2}]} = eval("a = fn() -> end"),
-  nil = Fun2(),
   {_, [{a, Fun3}]} = eval("a = fn -> 1 + 2 end"),
   3 = Fun3().
 

--- a/lib/ex_unit/examples/one_of_each.exs
+++ b/lib/ex_unit/examples/one_of_each.exs
@@ -63,7 +63,7 @@ defmodule TestOneOfEach do
   end
 
   test "13. assert an exception with a given message is raised, but no exception" do
-    assert_raise(SomeException, "some message", fn -> end)
+    assert_raise(SomeException, "some message", fn -> nil end)
   end
 
   test "14. assert an exception with a given message is raised" do
@@ -79,7 +79,7 @@ defmodule TestOneOfEach do
   end
 
   test "16. assert an exception is raised" do
-    assert_raise(SomeException, fn -> end)
+    assert_raise(SomeException, fn -> nil end)
   end
 
   test "17. assert two values are within some delta" do

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -332,7 +332,7 @@ defmodule ExUnit.AssertionsTest do
 
   test "assert raise with no error" do
     "This should never be tested" = assert_raise ArgumentError, fn ->
-      # nothing
+      nil
     end
   rescue
     error in [ExUnit.AssertionError] ->

--- a/lib/ex_unit/test/ex_unit/capture_io_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_io_test.exs
@@ -48,8 +48,7 @@ defmodule ExUnit.CaptureIOTest do
   end
 
   test "with no output" do
-    assert capture_io(fn ->
-    end) == ""
+    assert capture_io(fn -> nil end) == ""
   end
 
   test "with put chars" do
@@ -321,7 +320,7 @@ defmodule ExUnit.CaptureIOTest do
     # message from previous capture_io has been processed
     assert_receive {:DOWN, ^ref, _, _, :shutdown}
     _ = capture_io(fn -> "trigger" end)
-    assert capture_io(:stderr, fn -> end)
+    assert capture_io(:stderr, fn -> nil end)
   end
 
   test "with assert inside" do
@@ -339,7 +338,7 @@ defmodule ExUnit.CaptureIOTest do
     spawn(fn -> capture_io(:stderr, fn -> :timer.sleep(100) end) end)
     :timer.sleep(10)
     assert_raise RuntimeError, "IO device registered at :standard_error is already captured", fn ->
-      capture_io(:stderr, fn -> end)
+      capture_io(:stderr, fn -> nil end)
     end
     :timer.sleep(100)
   end

--- a/lib/ex_unit/test/ex_unit/capture_log_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_log_test.exs
@@ -13,7 +13,7 @@ defmodule ExUnit.CaptureLogTest do
   end
 
   test "no output" do
-    assert capture_log(fn -> end) == ""
+    assert capture_log(fn -> nil end) == ""
   end
 
   test "assert inside" do

--- a/lib/iex/test/iex/server_test.exs
+++ b/lib/iex/test/iex/server_test.exs
@@ -48,7 +48,7 @@ defmodule IEx.ServerTest do
 
   # Helpers
 
-  defp boot(opts, callback \\ fn -> end) do
+  defp boot(opts, callback \\ fn -> nil end) do
     IEx.Server.start(Keyword.merge([dot_iex_path: ""], opts),
                      {:erlang, :apply, [callback, []]})
   end


### PR DESCRIPTION
This is the PR related to #3931. It makes the parser throw a syntax error for stabs with an empty left-hand side. This means all of these will be invalid:

```elixir
fn -> end
fn() -> end
fn(_, _) -> end

cond do
  false -> "false"
  true ->
end

case Map.fetch(map, :a) do
  {:ok, a} -> a
  :empty ->
end
```

and so on. Most of the PR changes are related to fixing all the places where `fn -> end` is used. Let me know what you think!

/cc @lexmag 