### PR TITLE
Add ANSI escape sequences for extended colors

### DIFF
--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -42,6 +42,14 @@ defmodule IO.ANSI do
     Application.get_env(:elixir, :ansi_enabled, false)
   end
 
+  @doc "Sets foreground color"
+  @spec color(0..255) :: String.t
+  def color(code) when code in 0..255, do: "\e[38;5;#{code}m"
+
+  @doc "Sets background color"
+  @spec color_background(0..255) :: String.t
+  def color_background(code) when code in 0..255, do: "\e[48;5;#{code}m"
+
   @doc "Resets all attributes"
   defsequence :reset, 0
 

--- a/lib/elixir/test/elixir/io/ansi_test.exs
+++ b/lib/elixir/test/elixir/io/ansi_test.exs
@@ -86,6 +86,13 @@ defmodule IO.ANSITest do
            "#{IO.ANSI.red}Hello!"
   end
 
+  test "format with color number" do
+    data = [IO.ANSI.color(111), "Hello", IO.ANSI.color_background(222), "World"]
+
+    assert IO.chardata_to_string(IO.ANSI.format(data, true)) ==
+           "\e[38;5;111mHello\e[48;5;222mWorld"
+  end
+
   test "format invalid sequence" do
     assert_raise ArgumentError, "invalid ANSI sequence specification: :brigh", fn ->
       IO.ANSI.format([:brigh, "Hello!"], true)


### PR DESCRIPTION
https://en.wikipedia.org/wiki/ANSI_escape_code#graphics

![](https://dl.dropboxusercontent.com/s/9qfjbknezk41t49/2015-11-11%20at%2017.23.png)