### PR TITLE
Throw an error for -> with an empty right-hand side - take 2

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -394,7 +394,7 @@ defmodule Exception do
 
   ## Examples
 
-      Exception.format_fa(fn -> end, 1)
+      Exception.format_fa(fn -> nil end, 1)
       #=> "#Function<...>/1"
 
   """

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -19,7 +19,7 @@ Nonterminals
   call_args_no_parens_one call_args_no_parens_ambig call_args_no_parens_expr
   call_args_no_parens_comma_expr call_args_no_parens_all call_args_no_parens_many
   call_args_no_parens_many_strict
-  stab stab_eoe stab_expr stab_maybe_expr stab_parens_many
+  stab stab_eoe stab_expr stab_op_eol_and_expr stab_parens_many
   kw_eol kw_base kw call_args_no_parens_kw_expr call_args_no_parens_kw
   dot_op dot_alias dot_alias_container
   dot_identifier dot_op_identifier dot_do_identifier
@@ -294,19 +294,23 @@ stab -> stab eoe stab_expr : ['$3'|'$1'].
 stab_eoe -> stab : '$1'.
 stab_eoe -> stab eoe : '$1'.
 
-stab_expr -> expr : '$1'.
-stab_expr -> stab_op_eol stab_maybe_expr : build_op('$1', [], '$2').
-stab_expr -> empty_paren stab_op_eol stab_maybe_expr :
-               build_op('$2', [], '$3').
-stab_expr -> call_args_no_parens_all stab_op_eol stab_maybe_expr :
-               build_op('$2', unwrap_when(unwrap_splice('$1')), '$3').
-stab_expr -> stab_parens_many stab_op_eol stab_maybe_expr :
-               build_op('$2', unwrap_splice('$1'), '$3').
-stab_expr -> stab_parens_many when_op expr stab_op_eol stab_maybe_expr :
-               build_op('$4', [{'when', meta_from_token('$2'), unwrap_splice('$1') ++ ['$3']}], '$5').
+%% Here, `element(1, Token)` is the stab operator, while `element(2, Token)` is
+%% the expression.
+stab_expr -> expr :
+               '$1'.
+stab_expr -> stab_op_eol_and_expr :
+               build_op(element(1, '$1'), [], element(2, '$1')).
+stab_expr -> empty_paren stab_op_eol_and_expr :
+               build_op(element(1, '$2'), [], element(2, '$2')).
+stab_expr -> call_args_no_parens_all stab_op_eol_and_expr :
+               build_op(element(1, '$2'), unwrap_when(unwrap_splice('$1')), element(2, '$2')).
+stab_expr -> stab_parens_many stab_op_eol_and_expr :
+               build_op(element(1, '$2'), unwrap_splice('$1'), element(2, '$2')).
+stab_expr -> stab_parens_many when_op expr stab_op_eol_and_expr :
+               build_op(element(1, '$4'), [{'when', meta_from_token('$2'), unwrap_splice('$1') ++ ['$3']}], element(2, '$4')).
 
-stab_maybe_expr -> 'expr' : '$1'.
-stab_maybe_expr -> '$empty' : nil.
+stab_op_eol_and_expr -> stab_op_eol expr : {'$1', '$2'}.
+stab_op_eol_and_expr -> stab_op_eol : throw_empty_stab_clause('$1').
 
 block_item -> block_eoe stab_eoe : {?exprs('$1'), build_stab(reverse('$2'))}.
 block_item -> block_eoe : {?exprs('$1'), nil}.
@@ -813,3 +817,8 @@ throw_no_parens_container_strict(Node) ->
     "adding parentheses:\n\n"
     "    [one, two(three, four), five]\n\n"
     "Elixir cannot compile otherwise. Syntax error before: ", "','").
+
+throw_empty_stab_clause(StabOpToken) ->
+  throw(meta_from_token(StabOpToken),
+    "an expression is required on the right side of ->. Syntax error before: ",
+    "'->'").

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -129,7 +129,7 @@ defmodule ExceptionTest do
   end
 
   test "format_fa" do
-    assert Exception.format_fa(fn -> end, 1) =~
+    assert Exception.format_fa(fn -> nil end, 1) =~
            ~r"#Function<\d+\.\d+/0 in ExceptionTest\.test format_fa/1>/1"
   end
 

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -402,7 +402,7 @@ defmodule Kernel.ErrorsTest do
     msg = ~r"cannot inject attribute @foo into function/macro because cannot escape "
     assert_raise ArgumentError, msg, fn ->
       defmodule InvalidAttribute do
-        @foo fn -> end
+        @foo fn -> nil end
         def bar, do: @foo
       end
     end
@@ -412,7 +412,7 @@ defmodule Kernel.ErrorsTest do
     msg = ~r"invalid value for struct field baz, cannot escape "
     assert_raise ArgumentError, msg, fn ->
       defmodule InvaliadStructFieldValue do
-        defstruct baz: fn -> end
+        defstruct baz: fn -> nil end
       end
     end
   end

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -500,7 +500,7 @@ defmodule Kernel.ExpansionTest do
     end
 
     assert_raise CompileError, ~r"invalid quoted expression: #Function<", fn ->
-      expand(quote do: unquote({:sample, fn -> end}))
+      expand(quote do: unquote({:sample, fn -> nil end}))
     end
   end
 

--- a/lib/elixir/test/elixir/kernel/quote_test.exs
+++ b/lib/elixir/test/elixir/kernel/quote_test.exs
@@ -131,12 +131,6 @@ defmodule Kernel.QuoteTest do
   end
 
   test "stab" do
-    assert [{:->, _, [[], nil]}] = (quote do -> end)
-    assert [{:->, _, [[], nil]}] = (quote do: (->))
-
-    assert [{:->, _, [[1], nil]}] = (quote do 1 -> end)
-    assert [{:->, _, [[1], nil]}] = (quote do: (1 ->))
-
     assert [{:->, _, [[], 1]}] = (quote do -> 1 end)
     assert [{:->, _, [[], 1]}] = (quote do: (-> 1))
   end
@@ -222,7 +216,7 @@ defmodule Kernel.QuoteTest.ErrorsTest do
 
     mod  = Kernel.QuoteTest.ErrorsTest
     file = __ENV__.file |> Path.relative_to_cwd |> String.to_char_list
-    assert [{^mod, :add, 2, [file: ^file, line: 202]}|_] = System.stacktrace
+    assert [{^mod, :add, 2, [file: ^file, line: 196]}|_] = System.stacktrace
   end
 
   test "outside function error" do
@@ -232,7 +226,7 @@ defmodule Kernel.QuoteTest.ErrorsTest do
 
     mod  = Kernel.QuoteTest.ErrorsTest
     file = __ENV__.file |> Path.relative_to_cwd |> String.to_char_list
-    assert [{^mod, _, _, [file: ^file, line: 230]}|_] = System.stacktrace
+    assert [{^mod, _, _, [file: ^file, line: 224]}|_] = System.stacktrace
   end
 end
 

--- a/lib/elixir/test/elixir/process_test.exs
+++ b/lib/elixir/test/elixir/process_test.exs
@@ -38,7 +38,7 @@ defmodule ProcessTest do
   end
 
   test "info/2 with registered name" do
-    pid = spawn fn -> end
+    pid = spawn fn -> nil end
     Process.exit(pid, :kill)
     assert Process.info(pid, :registered_name) ==
            nil

--- a/lib/elixir/test/elixir/string/chars_test.exs
+++ b/lib/elixir/test/elixir/string/chars_test.exs
@@ -105,7 +105,7 @@ defmodule String.Chars.ErrorsTest do
 
   test "function" do
     assert_raise Protocol.UndefinedError, ~r"^protocol String\.Chars not implemented for #Function<.+?>$", fn ->
-      to_string(fn -> end)
+      to_string(fn -> nil end)
     end
   end
 

--- a/lib/elixir/test/erlang/function_test.erl
+++ b/lib/elixir/test/erlang/function_test.erl
@@ -10,10 +10,6 @@ function_arg_do_end_test() ->
   {nil, _} = eval("if true do end").
 
 function_stab_end_test() ->
-  {_, [{a, Fun1}]} = eval("a = fn -> end"),
-  nil = Fun1(),
-  {_, [{a, Fun2}]} = eval("a = fn() -> end"),
-  nil = Fun2(),
   {_, [{a, Fun3}]} = eval("a = fn -> 1 + 2 end"),
   3 = Fun3().
 

--- a/lib/ex_unit/examples/one_of_each.exs
+++ b/lib/ex_unit/examples/one_of_each.exs
@@ -63,7 +63,7 @@ defmodule TestOneOfEach do
   end
 
   test "13. assert an exception with a given message is raised, but no exception" do
-    assert_raise(SomeException, "some message", fn -> end)
+    assert_raise(SomeException, "some message", fn -> nil end)
   end
 
   test "14. assert an exception with a given message is raised" do
@@ -79,7 +79,7 @@ defmodule TestOneOfEach do
   end
 
   test "16. assert an exception is raised" do
-    assert_raise(SomeException, fn -> end)
+    assert_raise(SomeException, fn -> nil end)
   end
 
   test "17. assert two values are within some delta" do

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -332,7 +332,7 @@ defmodule ExUnit.AssertionsTest do
 
   test "assert raise with no error" do
     "This should never be tested" = assert_raise ArgumentError, fn ->
-      # nothing
+      nil
     end
   rescue
     error in [ExUnit.AssertionError] ->

--- a/lib/ex_unit/test/ex_unit/capture_io_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_io_test.exs
@@ -48,8 +48,7 @@ defmodule ExUnit.CaptureIOTest do
   end
 
   test "with no output" do
-    assert capture_io(fn ->
-    end) == ""
+    assert capture_io(fn -> nil end) == ""
   end
 
   test "with put chars" do
@@ -321,7 +320,7 @@ defmodule ExUnit.CaptureIOTest do
     # message from previous capture_io has been processed
     assert_receive {:DOWN, ^ref, _, _, :shutdown}
     _ = capture_io(fn -> "trigger" end)
-    assert capture_io(:stderr, fn -> end)
+    assert capture_io(:stderr, fn -> nil end)
   end
 
   test "with assert inside" do
@@ -339,7 +338,7 @@ defmodule ExUnit.CaptureIOTest do
     spawn(fn -> capture_io(:stderr, fn -> :timer.sleep(100) end) end)
     :timer.sleep(10)
     assert_raise RuntimeError, "IO device registered at :standard_error is already captured", fn ->
-      capture_io(:stderr, fn -> end)
+      capture_io(:stderr, fn -> nil end)
     end
     :timer.sleep(100)
   end

--- a/lib/ex_unit/test/ex_unit/capture_log_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_log_test.exs
@@ -13,7 +13,7 @@ defmodule ExUnit.CaptureLogTest do
   end
 
   test "no output" do
-    assert capture_log(fn -> end) == ""
+    assert capture_log(fn -> nil end) == ""
   end
 
   test "assert inside" do

--- a/lib/iex/test/iex/server_test.exs
+++ b/lib/iex/test/iex/server_test.exs
@@ -48,7 +48,7 @@ defmodule IEx.ServerTest do
 
   # Helpers
 
-  defp boot(opts, callback \\ fn -> end) do
+  defp boot(opts, callback \\ fn -> nil end) do
     IEx.Server.start(Keyword.merge([dot_iex_path: ""], opts),
                      {:erlang, :apply, [callback, []]})
   end


### PR DESCRIPTION
Alright @josevalim, here's the new PR (with the changed error message as well). Just a question: should we raise instead of warning? I chose to raise because there are no warnings in the parser and I wasn't sure about adding the first but I can change it if you want.