### PR TITLE
Added ./bin/elixir --info option #3947

### DIFF
--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -146,7 +146,8 @@ defmodule Kernel.CLI do
   # Parse shared options
 
   defp parse_shared([opt|_t], _config) when opt in ["-v", "--version"] do
-    IO.puts "Elixir #{System.version}"
+    IO.puts :erlang.system_info(:system_version)
+    IO.puts "Elixir #{System.version} (#{System.build_info().revision})"
     System.halt 0
   end
 

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -25,15 +25,15 @@ defmodule System do
     end
   end
 
-  # Tries to run "git describe --always --tags". In the case of success returns
-  # the most recent tag. If that is not available, tries to read the commit hash
+  # Tries to run "git rev-parse --short HEAD". In the case of success returns
+  # the short revision hash. If that is not available, tries to read the commit hash
   # from .git/HEAD. If that fails, returns an empty string.
-  defmacrop get_describe do
+  defmacrop get_revision do
     dirpath = :filename.join(__DIR__, "../../../.git")
     case :file.read_file_info(dirpath) do
       {:ok, _} ->
         if :os.find_executable('git') do
-          data = :os.cmd('git describe --always --tags')
+          data = :os.cmd('git rev-parse --short HEAD')
           strip_re(data, "\n")
         else
           read_stripped(:filename.join(".git", "HEAD"))
@@ -73,11 +73,11 @@ defmodule System do
   @doc """
   Elixir build information.
 
-  Returns a keyword list with Elixir version, git tag info and compilation date.
+  Returns a keyword list with Elixir version, git short revision hash and compilation date.
   """
   @spec build_info() :: map
   def build_info do
-    %{version: version, tag: get_describe, date: get_date}
+    %{version: version, date: get_date, revision: get_revision}
   end
 
   @doc """

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -7,7 +7,7 @@ defmodule SystemTest do
   test "build_info/0" do
     assert is_map System.build_info
     assert not is_nil(System.build_info[:version])
-    assert not is_nil(System.build_info[:tag])
+    assert not is_nil(System.build_info[:revision])
     assert not is_nil(System.build_info[:date])
   end
 


### PR DESCRIPTION
With erlang version, elixir version, elixir revision short hash.
Also added elixir revision short hash to System.build_info().
```
$ ./bin/elixir --version        
Erlang/OTP 18 [erts-7.1] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false]

Elixir 1.2.0-dev (6b14048)
```
Resolves #3947 