### PR TITLE
The OptionParser parses options, not argumemnts

### DIFF
--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -1,6 +1,6 @@
 defmodule OptionParser do
   @moduledoc """
-  This module contains functions to parse command line arguments.
+  This module contains functions to parse command line options.
   """
 
   @type argv    :: [String.t]


### PR DESCRIPTION
Fixed the docs of the OptionParser module. 

In the first line was written, the OptionParser [...] parse command line arguments, which is a imprecise term. More precise is, the OptionParser [...] parse command line options.