### PR TITLE
Pass replacement functions from String.replace/4 through to Regex

### DIFF
--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -240,6 +240,11 @@ defmodule StringTest do
 
     assert String.replace("a,b,c", ~r/,(.)/, ",\\1\\1") == "a,bb,cc"
     assert String.replace("a,b,c", ~r/,(.)/, ",\\1\\1", global: false) == "a,bb,c"
+
+    assert String.replace("a,b,c", ~r/(b)/, fn _, x -> String.upcase(x) end) == "a,B,c"
+    assert_raise ArgumentError, fn ->
+      String.replace("a,b,c", "b", fn _, x -> String.upcase(x) end)
+    end
   end
 
   test :duplicate do


### PR DESCRIPTION
While `Regex.replace/4` has the ability to use a function for the replacement, `String.replace/4` does not. Since `String.replace/4` basically uses `Regex.replace/4` if the pattern is a Regex pattern, why not use the ability to use a function for the replacement as well?

I could use some feedback on the documentation especially. I wasn't quite sure the best way to indicate that further capture groups can be accessed with `x`, `y`, `z`, etc...