### PR TITLE
Added verbose pry functionality

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -424,6 +424,9 @@ defmodule IEx do
   def pry(binding, env, timeout) do
     meta = "#{inspect self} at #{Path.relative_to_cwd(env.file)}:#{env.line}"
     opts = [binding: binding, dot_iex_path: "", env: env, prefix: "pry"]
+    if env.line > 2 do
+      puts_pry_call_info(env)
+    end
     res  = IEx.Server.take_over("Request to pry #{meta}", opts, timeout)
 
     # We cannot use colors because IEx may be off.
@@ -502,5 +505,10 @@ defmodule IEx do
   defp run_after_spawn do
     _ = for fun <- Enum.reverse(after_spawn), do: fun.()
     :ok
+  end
+
+  defp puts_pry_call_info(env) do
+    file = File.stream!(Path.relative_to_cwd(env.file))
+    Enum.slice(file, env.line - 3, 5) |> IO.puts
   end
 end


### PR DESCRIPTION
Showing place in code where `IEx.pry` was invoked

![314133a5db](https://cloud.githubusercontent.com/assets/1163074/11252653/fdf5b038-8e3f-11e5-9b10-fa8df96e0e61.png)

After debugging some code, i felt that it would be greate to see where `IEx.pry` was invoked like ruby pry doing.
