### PR TITLE
Don't escape underlines outside url in docs.

### DIFF
--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -407,10 +407,7 @@ defmodule IO.ANSI.Docs do
   end
 
   defp escape_underlines_in_link(text) do
-    case Regex.match?(~r{.*(https?\S*)}, text) do
-      true -> Regex.replace(~r{_}, text, "\\\\_")
-      _    -> text
-    end
+    Regex.replace(~r{https?\S*}, text, &String.replace(&1, "_", "\\_"))
   end
 
   defp remove_square_brackets_in_link(text) do

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -278,6 +278,11 @@ defmodule IO.ANSI.DocsTest do
     assert result == "ANSI escape code (https://en.wikipedia.org/wiki/ANSI_escape_code)\n\e[0m"
   end
 
+  test "escaping of underlines within links does not escape surrounding text" do
+    result = format("_emphasis_ (https://en.wikipedia.org/wiki/ANSI_escape_code) more _emphasis_")
+    assert result == "\e[4memphasis\e[0m (https://en.wikipedia.org/wiki/ANSI_escape_code) more \e[4memphasis\e[0m\n\e[0m"
+  end
+
   test "lone thing that looks like a table line isn't" do
     assert format("one\n2 | 3\ntwo\n") ==
            "one 2 | 3 two\n\e[0m"


### PR DESCRIPTION
I noticed there's a bug when escaping underlines in urls in docs. All underlines in the whole line would be escaped, including valid markdown \_italic_ outside the url.

```
iex> IO.ANSI.Docs.print "_click_ http://o_O.example.com" _bait_
_click_ http://o_O.example.com _bait_

:ok
```