### PR TITLE
Default args in defdelegate

### DIFF
--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -22,6 +22,8 @@ defmodule Kernel.Utils do
         _ -> raise ArgumentError, "invalid syntax in defdelegate #{Macro.to_string(fun)}"
       end
 
+    check_defdelegate_args(args)
+
     as_args =
       case append_first and args != [] do
         true  -> tl(args) ++ [hd(args)]
@@ -31,6 +33,13 @@ defmodule Kernel.Utils do
     as = Keyword.get(opts, :as, name)
     {name, args, as, as_args}
   end
+
+  defp check_defdelegate_args([]),
+    do: :ok
+  defp check_defdelegate_args([{var, _, mod}|rest]) when is_atom(var) and is_atom(mod),
+    do: check_defdelegate_args(rest)
+  defp check_defdelegate_args([code|_]),
+    do: raise(ArgumentError, "defdelegate/2 only accepts variable names, got: #{Macro.to_string(code)}")
 
   def defstruct(module, fields) do
     case fields do

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -298,6 +298,26 @@ defmodule KernelTest do
     assert dynamic_flatten([[1]]) == [1]
   end
 
+  test "defdelegate/2 raises with non-variable arguments" do
+    code = quote do
+      defmodule Foo do
+        defdelegate foo(1), to: List
+      end
+    end
+
+    msg = "defdelegate/2 only accepts variable names, got: 1"
+    assert_raise ArgumentError, msg, fn -> Code.compile_quoted(code) end
+
+    code = quote do
+      defmodule Foo do
+        defdelegate foo(a \\ 1), to: List
+      end
+    end
+
+    msg = "defdelegate/2 only accepts variable names, got: a \\\\ 1"
+    assert_raise ArgumentError, msg, fn -> Code.compile_quoted(code) end
+  end
+
   test "get_in/2" do
     users = %{"john" => %{age: 27}, "meg" => %{age: 23}}
     assert get_in(users, ["john", :age]) == 27


### PR DESCRIPTION
Right now, using default args (`\\`) with `defdelegate` results in an error that looks like this:

    ** (CompileError) iex:2: function '\\\\'/2 undefined
        (stdlib) lists.erl:1337: :lists.foreach/2
        (stdlib) erl_eval.erl:669: :erl_eval.do_apply/6
           (iex) lib/iex/evaluator.ex:117: IEx.Evaluator.handle_eval/5

The error is not very clear. I added some code that raises clearly when default arguments are used with `defdelegate`. Ideally, `\\` should be supported in `defdelegate`? If it should I can give it a shot later this week, but this seems like a good fix in the meantime.
