### PR TITLE
Use List.foldr in Console metadata handling

### DIFF
--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -86,12 +86,12 @@ defmodule Logger.Backends.Console do
   end
 
   defp take_metadata(metadata, keys) do
-    Enum.reduce(keys, [], fn key, acc ->
+    List.foldr keys, [], fn key, acc ->
       case Keyword.fetch(metadata, key) do
         {:ok, val} -> [{key, val} | acc]
         :error     -> acc
       end
-    end) |> Enum.reverse()
+    end
   end
 
   defp color_event(data, _level, %{enabled: false}), do: data


### PR DESCRIPTION
This PR changes the `Logger.Backends.Console` private function `take_metadata`, which is a `Keyword.take` that keeps the same order as the keys passed in the args…

Instead of `reduce + reverse`, thought about using `List.foldr` instead. Seems legit?

[Tried some basic measure of the two approaches in this gist](https://gist.github.com/rodrigues/007aa9ff10a12bca4642). It's my first `profile.fprof` hehe… but if I'm not nuts, it reads easier and runs on ~70% of the original time 🤓 Didn't try many scenarios though.