### PR TITLE
One reference link label per line

### DIFF
--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -312,4 +312,9 @@ defmodule IO.ANSI.DocsTest do
     assert format("a | b | c\nd | e") ==
            "a | b | c\nd | e |  \n\e[0m"
   end
+
+  test "one reference link label per line" do
+    assert format("  [id]: http://example.com\n  [Elixir]:  http://elixir-lang.org") ==
+           "  [id]: http://example.com\n  [Elixir]:  http://elixir-lang.org"
+  end
 end


### PR DESCRIPTION
Now each reference link labels use one line between each other in IEx. Fixes #3960 