### PR TITLE
Explain IO devices maintain position

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -27,6 +27,11 @@ defmodule IO do
     * `:stderr` - a shortcut for the named process `:standard_error`
       provided in Erlang
 
+  IO devices maintain their position, that means subsequent calls to any
+  reading or writing functions will start from the place when the device
+  was last accessed. Position of files can be changed using the
+  `:file.position/2` function.
+
   """
 
   @type device :: atom | pid


### PR DESCRIPTION
This adds information to the `IO` docs about devices maintaining the position, and a way to change it for files (e.g. rewind):

```
  IO devices maintain their position, that means subsequent calls to any
  reading or writing functions will strart from the place when the device
  was last accessed. Position of files can be changed using the
  `:file.position/2` function.
```