### PR TITLE
Don't print the result of the 'pwd' helper.

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -459,6 +459,7 @@ defmodule IEx.Helpers do
   """
   def pwd do
     IO.puts IEx.color(:eval_info, System.cwd!)
+    dont_display_result
   end
 
   @doc """


### PR DESCRIPTION
This would previously print the 'pwd' string followed by the command's `:ok`
result. This change suppresses the `:ok:` in the same way as similar helpers.