### PR TITLE
Only expand Erlang modules when ':' is a prefix.

### DIFF
--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -7,9 +7,9 @@ defmodule IEx.Autocomplete do
 
   def expand([h|t]=expr) do
     cond do
-      h === ?. and t != []->
+      h === ?. and t != [] ->
         expand_dot(reduce(t))
-      h === ?: ->
+      h === ?: and t == [] ->
         expand_erlang_modules()
       identifier?(h) ->
         expand_expr(reduce(expr))

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -13,6 +13,7 @@ defmodule IEx.AutocompleteTest do
 
   test "erlang module no completion" do
     assert expand(':unknown') == {:no, '', []}
+    assert expand('Enum:') == {:no, '', []}
   end
 
   test "erlang module multiple values completion" do


### PR DESCRIPTION
Previously, inputs like 'Enum:' would trigger Erlang module expansion.