### PR TITLE
Add monotonic_time, system_time and unique_integer to System

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -382,13 +382,13 @@ defmodule System do
   and the command exit status.
 
   ## Examples
-  
+
       iex> System.cmd "echo", ["hello"]
       {"hello\n", 0}
 
       iex> System.cmd "echo", ["hello"], env: [{"MIX_ENV", "test"}]
       {"hello\n", 0}
-      
+
       iex> System.cmd "echo", ["hello"], into: IO.stream(:stdio, :line)
       hello
       {%IO.Stream{}, 0}
@@ -498,5 +498,92 @@ defmodule System do
       other ->
         raise ArgumentError, "invalid environment key-value #{inspect other}"
     end
+  end
+
+  @doc """
+  Returns the current monotonic time in the `:native` time unit.
+
+  This time is monotonically increasing and starts in an unspecified point in
+  time.
+
+  For more information, see the [chapter on time and time
+  correction](http://www.erlang.org/doc/apps/erts/time_correction.html) in the
+  Erlang docs.
+
+  Inlined by the compiler into `:erlang.monotonic_time/0`.
+  """
+  @spec monotonic_time() :: integer
+  def monotonic_time do
+    :erlang.monotonic_time()
+  end
+
+  @doc """
+  Returns the current monotonic time in the given time unit.
+
+  For more information, see the [chapter on time and time
+  correction](http://www.erlang.org/doc/apps/erts/time_correction.html) in the
+  Erlang docs.
+
+  Inlined by the compiler into `:erlang.monotonic_time/1`.
+  """
+  @spec monotonic_time(:erlang.time_unit) :: integer
+  def monotonic_time(unit) do
+    :erlang.monotonic_time(unit)
+  end
+
+  @doc """
+  Returns the current system time in the `:native` time unit.
+
+  For more information, see the [chapter on time and time
+  correction](http://www.erlang.org/doc/apps/erts/time_correction.html) in the
+  Erlang docs.
+
+  Inlined by the compiler into `:erlang.system_time/0`.
+  """
+  @spec system_time() :: integer
+  def system_time do
+    :erlang.system_time()
+  end
+
+  @doc """
+  Returns the current system time in the given time unit.
+
+  For more information, see the [chapter on time and time
+  correction](http://www.erlang.org/doc/apps/erts/time_correction.html) in the
+  Erlang docs.
+
+  Inlined by the compiler into `:erlang.system_time/1`.
+  """
+  @spec system_time(:erlang.time_unit) :: integer
+  def system_time(unit) do
+    :erlang.system_time(unit)
+  end
+
+  @doc """
+  Generates and returns an integer that is unique in the current runtime
+  instance.
+
+  "Unique" means that this function, called with the same list of `modifiers`,
+  will never return the same integer more than once on the current runtime
+  instance.
+
+  If `modifiers` is `[]`, then an unique integer (that can be positive or negative) is returned.
+  Other modifiers can be passed to change the properties of the returned integer:
+
+    * `:positive` - the returned integer is guaranteed to be positive.
+    * `:monotonic` - the returned integer is monotonically increasing. This
+      means that, on the same runtime instance (but even on different
+      processes), integers returned using the `:monotonic` modifier will always
+      be strictly less than integers returned by successive calls with the
+      `:monotonic` modifier.
+
+  All modifiers listed above can be combined; repeated modifiers in `modifiers`
+  will be ignored.
+
+  Inlined by the compiler into `:erlang.unique_integer/1`.
+  """
+  @spec unique_integer([:positive | :monotonic]) :: integer
+  def unique_integer(modifiers \\ []) do
+    :erlang.unique_integer(modifiers)
   end
 end

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -560,6 +560,17 @@ defmodule System do
   end
 
   @doc """
+  Converts `time` from time unit `from_unit` to time unit `to_unit`. The result
+  is rounded via the floor function.
+
+  Inlined by the compiler into `:erlang.convert_time_unit/3`.
+  """
+  @spec convert_time_unit(integer, :erlang.time_unit, :erlang.time_unit) :: integer
+  def convert_time_unit(time, from_unit, to_unit) do
+    :erlang.convert_time_unit(time, from_unit, to_unit)
+  end
+
+  @doc """
   Generates and returns an integer that is unique in the current runtime
   instance.
 

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -144,7 +144,15 @@ inline(?port, list, 0) -> {erlang, ports};
 inline(?string, to_float, 1) -> {erlang, binary_to_float};
 inline(?string, to_integer, 1) -> {erlang, binary_to_integer};
 inline(?string, to_integer, 2) -> {erlang, binary_to_integer};
+
 inline(?system, stacktrace, 0) -> {erlang, get_stacktrace};
+inline(?system, monotonic_time, 0) -> {erlang, monotonic_time};
+inline(?system, monotonic_time, 1) -> {erlang, monotonic_time};
+inline(?system, system_time, 0) -> {erlang, system_time};
+inline(?system, system_time, 1) -> {erlang, system_time};
+inline(?system, unique_integer, 0) -> {erlang, unique_integer};
+inline(?system, unique_integer, 1) -> {erlang, unique_integer};
+
 inline(?tuple, to_list, 1) -> {erlang, tuple_to_list};
 inline(?tuple, append, 2) -> {erlang, append_element};
 

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -146,6 +146,7 @@ inline(?string, to_integer, 1) -> {erlang, binary_to_integer};
 inline(?string, to_integer, 2) -> {erlang, binary_to_integer};
 
 inline(?system, stacktrace, 0) -> {erlang, get_stacktrace};
+inline(?system, convert_time_unit, 3) -> {erlang, convert_time_unit};
 inline(?system, monotonic_time, 0) -> {erlang, monotonic_time};
 inline(?system, monotonic_time, 1) -> {erlang, monotonic_time};
 inline(?system, system_time, 0) -> {erlang, system_time};

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -100,4 +100,33 @@ defmodule SystemTest do
     assert is_binary System.find_executable("erl")
     assert !System.find_executable("does-not-really-exist-from-elixir")
   end
+
+  test "monotonic_time/0" do
+    assert is_integer(System.monotonic_time())
+  end
+
+  test "monotonic_time/1" do
+    assert is_integer(System.monotonic_time(:nano_seconds))
+    assert abs(System.monotonic_time(:micro_seconds)) < abs(System.monotonic_time(:nano_seconds))
+  end
+
+  test "system_time/0" do
+    assert is_integer(System.system_time())
+  end
+
+  test "system_time/1" do
+    assert is_integer(System.system_time(:nano_seconds))
+    assert abs(System.system_time(:micro_seconds)) < abs(System.system_time(:nano_seconds))
+  end
+
+  test "unique_integer/0 and unique_integer/1" do
+    assert is_integer(System.unique_integer())
+    assert System.unique_integer([:positive]) > 0
+    assert System.unique_integer([:positive, :monotonic]) < System.unique_integer([:positive, :monotonic])
+  end
+
+  test "convert_time_unit/3" do
+    time = System.monotonic_time(:nano_seconds)
+    assert abs(System.convert_time_unit(time, :nano_seconds, :micro_seconds)) < abs(time)
+  end
 end


### PR DESCRIPTION
Implements #4018.

The implementation is pretty straightforward, I'm just not sure about the docs: should they be more specific? Should they just point to the docs of the functions in the `:erlang` module?

(also, is `:erlang.time_unit` ok in the `@spec` or should I replicate the type in the `System` module?)