### PR TITLE
Raise error for incompatible OptionParser options

### DIFF
--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -51,7 +51,7 @@ defmodule OptionParser do
       in the list is returned in the invalid options list.
 
   Note that you should only supply the `:switches` or `:strict` option. If you
-  supply both, the `:strict` option will be ignored.
+  supply both, an error will be raised.
 
   For each switch, the following types are supported:
 
@@ -330,6 +330,8 @@ defmodule OptionParser do
     aliases = opts[:aliases] || []
 
     {switches, strict} = cond do
+      opts[:switches] && opts[:strict] ->
+        raise ArgumentError, ":switches and :strict cannot be supplied together"
       s = opts[:switches] ->
         {s, false}
       s = opts[:strict] ->

--- a/lib/elixir/test/elixir/option_parser_test.exs
+++ b/lib/elixir/test/elixir/option_parser_test.exs
@@ -198,6 +198,12 @@ defmodule OptionParserTest do
            == {[source: "from_docs/"], [], [{"--doc", nil}]}
   end
 
+  test ":switches with :strict raises" do
+    assert_raise ArgumentError, ":switches and :strict cannot be supplied together", fn ->
+      OptionParser.parse([], strict: [], switches: [])
+    end
+  end
+
   test "parses - as argument" do
     assert OptionParser.parse(["-a", "-", "-", "-b", "-"], aliases: [b: :boo])
            == {[boo: "-"], ["-"], [{"-a", "-"}]}


### PR DESCRIPTION
* supplying :switch together with :strict raises an error.
* closes #4035.