### PR TITLE
Adds support for optionalcallback and optionalmacrocallback

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2231,13 +2231,15 @@ defmodule Kernel do
     raise ArgumentError, "expected 0 or 1 argument for @#{name}, got: #{length(args)}"
   end
 
-  defp typespec(:type),          do: :deftype
-  defp typespec(:typep),         do: :deftypep
-  defp typespec(:opaque),        do: :defopaque
-  defp typespec(:spec),          do: :defspec
-  defp typespec(:callback),      do: :defcallback
-  defp typespec(:macrocallback), do: :defmacrocallback
-  defp typespec(_),              do: false
+  defp typespec(:type),                  do: :deftype
+  defp typespec(:typep),                 do: :deftypep
+  defp typespec(:opaque),                do: :defopaque
+  defp typespec(:spec),                  do: :defspec
+  defp typespec(:callback),              do: :defcallback
+  defp typespec(:macrocallback),         do: :defmacrocallback
+  defp typespec(:optionalcallback),      do: :defoptionalcallback
+  defp typespec(:optionalmacrocallback), do: :defoptionalmacrocallback
+  defp typespec(_),                      do: false
 
   @doc """
   Returns the binding for the given context as a keyword list.

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -245,7 +245,6 @@ defmodule Kernel.Typespec do
     end
   end
 
-
   @doc """
   Defines a macro callback.
   This macro is responsible for handling the attribute `@macrocallback`.
@@ -258,6 +257,36 @@ defmodule Kernel.Typespec do
   defmacro defmacrocallback(spec) do
     quote do
       Kernel.Typespec.defspec(:macrocallback, unquote(Macro.escape(spec, unquote: true)), __ENV__)
+    end
+  end
+
+  @doc """
+  Defines an optional callback.
+  This macro is responsible for handling the attribute `@optionalcallback`.
+
+  ## Examples
+
+      @optionalcallback add(number, number) :: number
+
+  """
+  defmacro defoptionalcallback(spec) do
+    quote do
+      Kernel.Typespec.defspec(:optionalcallback, unquote(Macro.escape(spec, unquote: true)), __ENV__)
+    end
+  end
+
+  @doc """
+  Defines an optional macro callback.
+  This macro is responsible for handling the attribute `@optionalmacrocallback`.
+
+  ## Examples
+
+      @optionalmacrocallback add(number, number) :: Macro.t
+
+  """
+  defmacro defoptionalmacrocallback(spec) do
+    quote do
+      Kernel.Typespec.defspec(:optionalmacrocallback, unquote(Macro.escape(spec, unquote: true)), __ENV__)
     end
   end
 
@@ -439,6 +468,19 @@ defmodule Kernel.Typespec do
     from_abstract_code(module, :callback)
   end
 
+  @doc """
+  Returns all optional callbacks available from the module's beam code.
+
+  The result is returned as a list of name and arity tuples.
+
+  The module must have a corresponding beam file
+  which can be located by the runtime system.
+  """
+  @spec beam_optional_callbacks(module | binary) :: [[{atom, arity}]] | nil
+  def beam_optional_callbacks(module) when is_atom(module) or is_binary(module) do
+    from_abstract_code(module, :optional_callbacks)
+  end
+
   defp from_abstract_code(module, kind) do
     case abstract_code(module) do
       {:ok, abstract_code} ->
@@ -487,7 +529,8 @@ defmodule Kernel.Typespec do
   ## Macro callbacks
 
   @doc false
-  def defspec(kind, expr, caller) when kind in [:callback, :macrocallback] do
+  def defspec(kind, expr, caller) when kind in [:callback, :macrocallback,
+                                                :optionalcallback, :optionalmacrocallback] do
     case spec_to_signature(expr) do
       {name, arity} ->
         store_callbackdoc(caller, caller.module, kind, name, arity)
@@ -593,6 +636,12 @@ defmodule Kernel.Typespec do
 
     if kind == :macrocallback do
       kind = :callback
+      name = :"MACRO-#{name}"
+      args = [quote(do: env :: Macro.Env.t)|args]
+    end
+
+    if kind == :optionalmacrocallback do
+      kind = :optionalcallback
       name = :"MACRO-#{name}"
       args = [quote(do: env :: Macro.Env.t)|args]
     end

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -80,7 +80,7 @@ do_compile(Line, Module, Block, Vars, E) ->
 
     {All, Forms0} = functions_form(Line, File, Module, Def, Defp,
                                    Defmacro, Defmacrop, Exports, Functions),
-    Forms1 = specs_form(Data, Defmacro, Defmacrop, Unreachable, Forms0),
+    Forms1 = specs_form(File, Data, Defmacro, Defmacrop, Unreachable, Forms0),
     Forms2 = types_form(Line, File, Data, Forms1),
     Forms3 = attributes_form(Line, File, Data, Forms2),
 
@@ -164,7 +164,8 @@ build(Line, File, Module, Docs, Lexical) ->
 
   Attributes = [behaviour, on_load, compile, external_resource, dialyzer],
   ets:insert(Data, {?acc_attr, [before_compile, after_compile, on_definition, derive,
-                                spec, type, typep, opaque, callback, macrocallback|Attributes]}),
+                                spec, type, typep, opaque, callback, macrocallback, optionalcallback,
+                                optionalmacrocallback|Attributes]}),
   ets:insert(Data, {?persisted_attr, [vsn|Attributes]}),
   ets:insert(Data, {?lexical_attr, Lexical}),
 
@@ -276,12 +277,14 @@ export_types_attributes(Types, Forms) ->
 
 %% Specs
 
-specs_form(Data, Defmacro, Defmacrop, Unreachable, Forms) ->
+specs_form(File, Data, Defmacro, Defmacrop, Unreachable, Forms) ->
   case elixir_compiler:get_opt(internal) of
     false ->
       Specs0 = get_typespec(Data, spec) ++
                get_typespec(Data, callback) ++
-               get_typespec(Data, macrocallback),
+               get_typespec(Data, macrocallback) ++
+               get_typespec(Data, optionalcallback) ++
+               get_typespec(Data, optionalmacrocallback),
       Specs1 = ['Elixir.Kernel.Typespec':translate_spec(Kind, Expr, Caller) ||
                 {Kind, Expr, Caller} <- Specs0],
       Specs2 = lists:flatmap(fun(Spec) ->
@@ -290,20 +293,47 @@ specs_form(Data, Defmacro, Defmacrop, Unreachable, Forms) ->
       Specs3 = lists:filter(fun({{_Kind, NameArity, _Spec}, _Line}) ->
                                 not lists:member(NameArity, Unreachable)
                             end, Specs2),
-      specs_attributes(Forms, Specs3);
+      specs_attributes(File, Forms, Specs3);
     true ->
       Forms
   end.
 
-specs_attributes(Forms, Specs) ->
+specs_attributes(File, Forms, Specs) ->
   Dict = lists:foldl(fun({{Kind, NameArity, Spec}, Line}, Acc) ->
                        dict:append({Kind, NameArity}, {Spec, Line}, Acc)
                      end, dict:new(), Specs),
   dict:fold(fun({Kind, NameArity}, ExprsLines, Acc) ->
     {Exprs, Lines} = lists:unzip(ExprsLines),
     Line = lists:min(Lines),
-    [{attribute, Line, Kind, {NameArity, Exprs}}|Acc]
+    case Kind of
+      callback ->
+        add_callback(File, Line, NameArity, Exprs, Acc, []);
+      optionalcallback ->
+        Acc2 = [{attribute, Line, optional_callbacks, [NameArity]}|Acc],
+        add_callback(File, Line, NameArity, Exprs, Acc2, []);
+      _ ->
+        [{attribute, Line, Kind, {NameArity, Exprs}}|Acc]
+    end
   end, Forms, Dict).
+
+add_callback(_File, Line, NameArity, Exprs, [], Acc) ->
+  [{attribute, Line, callback, {NameArity, Exprs}}|lists:reverse(Acc)];
+
+add_callback(File, Line, NameArity, Exprs, [{attribute, Line2, callback, {NameArity, Exprs2}}|Rest], Acc) ->
+  WarnLine = max(Line, Line2),
+  elixir_errors:form_warn([{line, WarnLine}], File, ?MODULE, callback_defined(NameArity)),
+  ActualLine = min(Line, Line2),
+  ActualExprs = Exprs ++ Exprs2,
+  lists:reverse(Acc, [{attribute, ActualLine, callback, {NameArity, ActualExprs}}|Rest]);
+
+add_callback(File, Line, NameArity, Exprs, [Head|Rest], Acc) ->
+  add_callback(File, Line, NameArity, Exprs, Rest, [Head|Acc]).
+
+callback_defined({Name, Arity}) ->
+  case atom_to_list(Name) of
+    "MACRO-" ++ Name2 -> {macrocallback_defined, {list_to_atom(Name2), Arity-1}};
+    _ -> {callback_defined, {Name, Arity}}
+  end.
 
 translate_macro_spec({{spec, NameArity, Spec}, Line}, Defmacro, Defmacrop) ->
   case lists:member(NameArity, Defmacrop) of
@@ -319,7 +349,10 @@ translate_macro_spec({{spec, NameArity, Spec}, Line}, Defmacro, Defmacrop) ->
   end;
 
 translate_macro_spec({{callback, NameArity, Spec}, Line}, _Defmacro, _Defmacrop) ->
-  [{{callback, NameArity, Spec}, Line}].
+  [{{callback, NameArity, Spec}, Line}];
+
+translate_macro_spec({{optionalcallback, NameArity, Spec}, Line}, _Defmacro, _Defmacrop) ->
+  [{{optionalcallback, NameArity, Spec}, Line}].
 
 spec_for_macro({type, Line, 'fun', [{type, _, product, Args}|T]}) ->
   NewArgs = [{type, Line, term, []}|Args],
@@ -529,6 +562,10 @@ format_error({unused_doc, typedoc}) ->
   "@typedoc provided but no type follows it";
 format_error({unused_doc, doc}) ->
   "@doc provided but no definition follows it";
+format_error({callback_defined, {Name, Arity}}) ->
+  io_lib:format("callback ~ts/~B defined as optionalcallback and callback", [Name, Arity]);
+format_error({macrocallback_defined, {Name, Arity}}) ->
+  io_lib:format("macrocallback ~ts/~B defined as optionalmacrocallback and macrocallback", [Name, Arity]);
 format_error({internal_function_overridden, {Name, Arity}}) ->
   io_lib:format("function ~ts/~B is internal and should not be overridden", [Name, Arity]);
 format_error({invalid_module, Module}) ->

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -39,6 +39,11 @@ defmodule Kernel.TypespecTest do
     |> Enum.sort
   end
 
+  defp optional_callbacks(module) do
+    Kernel.Typespec.beam_optional_callbacks(module)
+    |> Enum.sort
+  end
+
   test "invalid type specification" do
     assert_raise CompileError, ~r"invalid type specification: mytype = 1", fn ->
       test_module do
@@ -616,14 +621,58 @@ defmodule Kernel.TypespecTest do
     @callback guarded(my_var) :: my_var when my_var: binary
     @callback orr(atom | integer) :: atom
     @callback literal(123, {atom}, :atom, [integer], true) :: atom
+    @optionalcallback optional() :: atom
     @macrocallback last(integer) :: Macro.t
   end
 
   test "callbacks" do
     assert Sample.behaviour_info(:callbacks) ==
-           [first: 1, guarded: 1, "MACRO-last": 2, literal: 5, orr: 1, foo: 2, bar: 2]
+           [first: 1, guarded: 1, "MACRO-last": 2, literal: 5, optional: 0, orr: 1, foo: 2, bar: 2]
+
+    assert Sample.behaviour_info(:optional_callbacks) ==
+           [optional: 0]
   end
 
+  test "warns when optionalcallback has callback defined with same name and arity" do
+    output = ExUnit.CaptureIO.capture_io :stderr, fn ->
+      module = test_module do
+        @callback myfun(integer) :: integer
+        @optionalcallback myfun(char_list) :: char_list
+      end
+
+      assert [[myfun: 1]] == optional_callbacks(module)
+      
+      assert [{{:myfun, 1}, [
+             {:type, _, :fun, [{:type, _, :product, [
+               {:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :char_list}, []]}]},
+               {:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :char_list}, []]}]},
+             {:type, _, :fun, [{:type, _, :product, [{:type, _, :integer, []}]}, {:type, _, :integer, []}]}]}] =
+           callbacks(module)
+    end
+
+    assert output =~ "warning: callback myfun/1 defined as optionalcallback and callback"
+  end
+
+  test "warns when optionalmacrocallback has macrocallback defined with same name and arity" do
+    output = ExUnit.CaptureIO.capture_io :stderr, fn ->
+      module = test_module do
+        @macrocallback myfun(integer) :: Macro.t
+        @optionalmacrocallback myfun(char_list) :: Macro.t
+      end
+
+      assert [["MACRO-myfun": 2]] == optional_callbacks(module)
+      assert [{{:"MACRO-myfun", 2},
+             [{:type, _, :fun, [{:type, _, :product,
+                 [{:ann_type, _, [{:var, _, :env}, {:remote_type, _, [{:atom, _, Macro.Env}, {:atom, _, :t}, []]}]},
+                  {:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :char_list}, []]}]}, {:remote_type, _, [{:atom, _, Macro}, {:atom, _, :t}, []]}]},
+              {:type, 659, :fun,
+               [{:type, _, :product, [{:ann_type, _, [{:var, _, :env}, {:remote_type, _, [{:atom, _, Macro.Env}, {:atom, _, :t}, []]}]}, {:type, _, :integer, []}]},
+                {:remote_type, _, [{:atom, _, Macro}, {:atom, _, :t}, []]}]}]}] =
+            callbacks(module)
+    end
+
+    assert output =~ "warning: macrocallback myfun/1 defined as optionalmacrocallback and macrocallback"
+  end
   test "default is not supported" do
     assert_raise ArgumentError, fn ->
       defmodule WithDefault do


### PR DESCRIPTION
The optionalcallback or optionalmacrocallback attribute also defines the
Erlang optional_callbacks attribute.

If a (macro)callback has been defined as optional(macro)callback and
(macro)callback we emit a warning and defines the optional_callbacks
attribute.

http://www.erlang.org/doc/design_principles/spec_proc.html#id74952

Fixes https://github.com/elixir-lang/elixir/issues/3980