### PR TITLE
Map.take/2, Map.drop/2, Map.split/2 missing spec

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -422,6 +422,7 @@ defmodule Map do
       %{a: 1, c: 3}
 
   """
+  @spec drop(map, [key]) :: map
   def drop(map, keys) do
     Enum.reduce(keys, map, &delete(&2, &1))
   end
@@ -440,6 +441,7 @@ defmodule Map do
       {%{a: 1, c: 3}, %{b: 2}}
 
   """
+  @spec split(map, [key]) :: {map, map}
   def split(map, keys) do
     Enum.reduce(keys, {new, map}, fn key, {inc, exc} = acc ->
       case fetch(exc, key) do

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -209,6 +209,7 @@ defmodule Map do
       %{a: 1, c: 3}
 
   """
+  @spec take(map, [key]) :: map
   def take(map, keys) do
     Enum.reduce(keys, new, fn key, acc ->
       case fetch(map, key) do


### PR DESCRIPTION
Maybe `[key]` should be `Enum.t` since that is what would actually be accepted?