### PR TITLE
Make import with conflicting options to raise

### DIFF
--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -331,7 +331,7 @@ defmodule OptionParser do
 
     {switches, strict} = cond do
       opts[:switches] && opts[:strict] ->
-        raise ArgumentError, ":switches and :strict cannot be supplied together"
+        raise ArgumentError, ":switches and :strict cannot be given together"
       s = opts[:switches] ->
         {s, false}
       s = opts[:strict] ->

--- a/lib/elixir/src/elixir_import.erl
+++ b/lib/elixir/src/elixir_import.erl
@@ -54,7 +54,14 @@ record_warn(Meta, Ref, Opts, Added, E) ->
 calculate(Meta, Key, Opts, Old, File, Existing) ->
   New = case keyfind(only, Opts) of
     {only, Only} when is_list(Only) ->
-      ensure_keyword_list(Meta, File, Only, only),
+      ok = ensure_keyword_list(Meta, File, Only, only),
+      case keyfind(except, Opts) of
+        false -> ok;
+        _ ->
+          elixir_errors:compile_error(Meta, File,
+            ":only and :except can only be given together to import"
+            " when :only is either :functions or :macros")
+      end,
       case Only -- get_exports(Key) of
         [{Name, Arity}|_] ->
           Tuple = {invalid_import, {Key, Name, Arity}},
@@ -66,7 +73,7 @@ calculate(Meta, Key, Opts, Old, File, Existing) ->
       case keyfind(except, Opts) of
         false -> remove_underscored(Existing());
         {except, Except} when is_list(Except) ->
-          ensure_keyword_list(Meta, File, Except, except),
+          ok = ensure_keyword_list(Meta, File, Except, except),
           case keyfind(Key, Old) of
             false -> remove_underscored(Existing()) -- Except;
             {Key, OldImports} -> OldImports -- Except

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -538,6 +538,13 @@ defmodule Kernel.ErrorsTest do
       'import Kernel, except: [:invalid]'
   end
 
+  test "import with conflicting options" do
+    assert_compile_fail CompileError,
+      "nofile:1: :only and :except can only be given together to import" <>
+      " when :only is either :functions or :macros",
+      'import Kernel, only: [], except: []'
+  end
+
   test "unrequired macro" do
     assert_compile_fail CompileError,
       "nofile:2: you must require Kernel.ErrorsTest before invoking " <>

--- a/lib/elixir/test/elixir/option_parser_test.exs
+++ b/lib/elixir/test/elixir/option_parser_test.exs
@@ -199,7 +199,7 @@ defmodule OptionParserTest do
   end
 
   test ":switches with :strict raises" do
-    assert_raise ArgumentError, ":switches and :strict cannot be supplied together", fn ->
+    assert_raise ArgumentError, ":switches and :strict cannot be given together", fn ->
       OptionParser.parse([], strict: [], switches: [])
     end
   end

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -165,7 +165,7 @@ defmodule ExUnit.DocTest do
   Calling `doctest(Module)` will generate tests for all doctests found
   in the module `Module`
 
-  Options can also be supplied:
+  Options can also be given:
 
     * `:except` - generate tests for all functions except those listed
       (list of `{function, arity}` tuples, and/or `:moduledoc`).


### PR DESCRIPTION
Currently, `import` silently ignores `:except` option if `:only` as a keyword list is given:
```elixir
iex> import String, only: [starts_with?: 2], except: [starts_with?: 2]
nil
iex> starts_with?("a", "a")
true
```
Though `only: :functions` and `only: :macros` with `:except` are still valid.