### PR TITLE
Fix edge case in Path.expand. Fix #4050.

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -639,6 +639,10 @@ defmodule Path do
   defp expand_dot(path),
     do: expand_dot(:binary.split(path, "/", [:global]), [])
 
+  defp expand_dot([".."|t], ["/", ""] = acc) do
+    expand_dot t, acc
+  end
+
   defp expand_dot([".."|t], [_, _|acc]) do
     expand_dot t, acc
   end
@@ -651,6 +655,8 @@ defmodule Path do
     expand_dot t, ["/", h|acc]
   end
 
+  defp expand_dot([], ["/", ""]),
+    do: "/"
   defp expand_dot([], ["/"|acc]) do
     IO.iodata_to_binary(:lists.reverse(acc))
   end

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -127,6 +127,7 @@ defmodule PathTest do
 
   test "expand path" do
     assert (Path.expand("/") |> strip_drive_letter_if_windows) == "/"
+    assert (Path.expand("/foo/../..") |> strip_drive_letter_if_windows) == "/"
     assert (Path.expand("/foo") |> strip_drive_letter_if_windows) == "/foo"
     assert (Path.expand("/./foo") |> strip_drive_letter_if_windows) == "/foo"
     assert (Path.expand("/foo/bar") |> strip_drive_letter_if_windows) == "/foo/bar"


### PR DESCRIPTION
This patch handles cases such as

```elixir
Path.expand("/foo/../..")
```

which currently fail as described in #4050.
I also added a test for this particular case.