### PR TITLE
Specs for functions in Mix.Project and a couple of docs polishings

### DIFF
--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -173,7 +173,7 @@ defmodule Mix.Project do
     config[:apps_path] != nil
   end
 
-  @doc """
+  @doc ~S"""
   Runs the given `fun` inside the given project.
 
   This function changes the current working directory and
@@ -182,6 +182,18 @@ defmodule Mix.Project do
 
   A `post_config` can be passed that will be merged into
   the project configuration.
+
+  `fun` is called with the `Mixfile` of the given project as
+  its argument. The return value of this function is the return
+  value of `fun`.
+
+  ## Examples
+
+      Mix.Project.in_project :my_app, "/path/to/my_app", fn mixfile ->
+        "Mixfile is: #{inspect mixfile}"
+      end
+      #=> "Mixfile is: MyApp.Mixfile"
+
   """
   @spec in_project(atom, Path.t, Keyword.t, (module -> result)) :: result when result: term
   def in_project(app, path, post_config \\ [], fun)

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -94,6 +94,7 @@ defmodule Mix.Project do
   requirement of the current task, you should call
   `get!/0` instead.
   """
+  @spec get() :: module | nil
   def get do
     case Mix.ProjectStack.peek do
       %{name: name} -> name
@@ -110,6 +111,7 @@ defmodule Mix.Project do
   function raises `Mix.NoProjectError` in case no project
   is available.
   """
+  @spec get!() :: module | no_return
   def get! do
     get || Mix.raise Mix.NoProjectError, []
   end
@@ -129,6 +131,7 @@ defmodule Mix.Project do
   Use it only to configure aspects of your project (like
   compilation directories) and not your application runtime.
   """
+  @spec config() :: Keyword.t
   def config do
     case Mix.ProjectStack.peek do
       %{config: config} -> config
@@ -145,6 +148,7 @@ defmodule Mix.Project do
   By default it includes the mix.exs file, the lock manifest and
   all config files in the `config` directory.
   """
+  @spec config_files() :: [Path.t]
   def config_files do
     [Mix.Dep.Lock.manifest] ++
       case Mix.ProjectStack.peek do
@@ -164,6 +168,7 @@ defmodule Mix.Project do
   @doc """
   Returns `true` if project is an umbrella project.
   """
+  @spec umbrella?() :: boolean
   def umbrella?(config \\ config()) do
     config[:apps_path] != nil
   end
@@ -178,6 +183,7 @@ defmodule Mix.Project do
   A `post_config` can be passed that will be merged into
   the project configuration.
   """
+  @spec in_project(atom, Path.t, Keyword.t, (module -> result)) :: result when result: term
   def in_project(app, path, post_config \\ [], fun)
 
   def in_project(app, ".", post_config, fun) do
@@ -213,6 +219,7 @@ defmodule Mix.Project do
       #=> "/path/to/project/deps"
 
   """
+  @spec deps_path(Keyword.t) :: Path.t
   def deps_path(config \\ config()) do
     Path.expand config[:deps_path]
   end
@@ -236,6 +243,7 @@ defmodule Mix.Project do
       #=> "/path/to/project/_build/dev"
 
   """
+  @spec build_path(Keyword.t) :: Path.t
   def build_path(config \\ config()) do
     config[:env_path] || env_path(config)
   end
@@ -266,6 +274,7 @@ defmodule Mix.Project do
       #=> "/path/to/project/_build/shared/lib/app"
 
   """
+  @spec manifest_path(Keyword.t) :: Path.t
   def manifest_path(config \\ config()) do
     config[:app_path] ||
       if app = config[:app] do
@@ -286,6 +295,7 @@ defmodule Mix.Project do
       #=> "/path/to/project/_build/shared/lib/app"
 
   """
+  @spec app_path(Keyword.t) :: Path.t
   def app_path(config \\ config()) do
     config[:app_path] || cond do
       app = config[:app] ->
@@ -310,6 +320,7 @@ defmodule Mix.Project do
       #=> "/path/to/project/_build/shared/lib/app/ebin"
 
   """
+  @spec compile_path(Keyword.t) :: Path.t
   def compile_path(config \\ config()) do
     Path.join(app_path(config), "ebin")
   end
@@ -321,6 +332,7 @@ defmodule Mix.Project do
   is in build embedded mode, which may fail as a
   explicit command to `mix compile` is required.
   """
+  @spec compile([term], Keyword.t) :: term
   def compile(args, config \\ config()) do
     if config[:build_embedded] do
       path = if umbrella?(config), do: build_path(config), else: compile_path(config)
@@ -345,6 +357,7 @@ defmodule Mix.Project do
     * `:symlink_ebin` - symlink ebin instead of copying it
 
   """
+  @spec build_structure(Keyword.t, Keyword.t) :: :ok
   def build_structure(config \\ config(), opts \\ []) do
     app = app_path(config)
     File.mkdir_p!(app)
@@ -383,6 +396,7 @@ defmodule Mix.Project do
 
   In case it does exist, it is a no-op. Otherwise, it is built.
   """
+  @spec ensure_structure(Keyword.t, Keyword.t) :: :ok
   def ensure_structure(config \\ config(), opts \\ []) do
     if File.exists?(app_path(config)) do
       :ok
@@ -394,6 +408,7 @@ defmodule Mix.Project do
   @doc """
   Returns all load paths for this project.
   """
+  @spec load_paths(Keyword.t) :: [Path.t]
   def load_paths(config \\ config()) do
     if umbrella?(config) do
       []

--- a/lib/mix/test/mix/project_test.exs
+++ b/lib/mix/test/mix/project_test.exs
@@ -90,10 +90,13 @@ defmodule Mix.ProjectTest do
 
   test "in_project pushes given configuration", context do
     in_tmp context.test, fn ->
-      Mix.Project.in_project :foo, ".", [hello: :world], fn _ ->
+      result = Mix.Project.in_project :foo, ".", [hello: :world], fn _ ->
         assert Mix.Project.config[:app] == :foo
         assert Mix.Project.config[:hello] == :world
+        :result
       end
+
+      assert result == :result
     end
   end
 


### PR DESCRIPTION
I added `@spec`s to all the public functions in `Mix.Project`; I did this because I was confused about how `Mix.Project.in_project/3-4` works and I had to read the source to understand it (specifically, what the `fun` argument takes as the only argument). I think specs can make things clearer overall - that is, if there was no particular reason not to have them here :).

Also, I enhanced the docs for `Mix.Project.in_project/3-4` for the reasons described above and added a test for this same function to test that the result of the function is indeed the result of the invocation of the argument `fun`.

Let me know if I can do anything else!
