### PR TITLE
Update Mix.Dep.Loader to reject dependencies with incompatible requirements

### DIFF
--- a/lib/mix/lib/mix/dep/loader.ex
+++ b/lib/mix/lib/mix/dep/loader.ex
@@ -313,10 +313,19 @@ defmodule Mix.Dep.Loader do
         %{dep | status: :compile}
       opts_app == false ->
         dep
+      incompatible_requirement?(dep) ->
+        %{dep | status: {:invalidvsn, opts[:lock]}}
       true ->
         path = if is_binary(opts_app), do: opts_app, else: "ebin/#{app}.app"
         path = Path.expand(path, opts[:build])
         %{dep | status: app_status(path, app, req)}
+    end
+  end
+
+  defp incompatible_requirement?(%Mix.Dep{opts: opts}) do
+    case opts[:lock] do
+      {scm, _, _, _} -> is_nil(opts[scm])
+      _ -> false
     end
   end
 


### PR DESCRIPTION
If a dependency lock is using git (or another scm)  and the current requirement does not,
the dependency is not up to date so I updated `Mix.Dep.Loader` to handle this case.
This fixes the bug described in #4026.