### PR TITLE
String.slice docs: codepoints -> graphemes

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1306,8 +1306,8 @@ defmodule String do
 
   If the offset is greater than string length, then it returns `""`.
 
-  Remember this function works with Unicode codepoints and considers
-  the slices to represent codepoint offsets. If you want to split
+  Remember this function works with Unicode graphemes and considers
+  the slices to represent grapheme offsets. If you want to split
   on raw bytes, check `Kernel.binary_part/3` instead.
 
   ## Examples


### PR DESCRIPTION
Looks like this uses graphemes, not codepoints: https://github.com/elixir-lang/elixir/compare/master...henrik:patch-6#diff-22d92528e5319c6e47e28d62cbff5be7R1347

``` elixir
iex> string = "\u0065\u0301"
"é"
iex> String.codepoints(string)
["e", "́"]
iex> String.slice(string, 0, 1)
"é"
```