### PR TITLE
String.split docs: codepoints -> graphemes

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -294,7 +294,7 @@ defmodule String do
       iex> String.split(" a b c ", ~r{\s}, trim: true)
       ["a", "b", "c"]
 
-  Splitting on empty patterns returns codepoints:
+  Splitting on empty patterns returns graphemes:
 
       iex> String.split("abc", ~r{})
       ["a", "b", "c", ""]


### PR DESCRIPTION
``` elixir
iex> string = "\u0065\u0301"
"é"
iex> String.codepoints(string)
["e", "́"]
iex> String.split(string, "", trim: true)
["é"]
```