### PR TITLE
String docs: link codepoints/graphemes to details

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -988,6 +988,8 @@ defmodule String do
   @doc """
   Returns all codepoints in the string.
 
+  For details about codepoints and graphemes, see the `String` module documentation.
+
   ## Examples
 
       iex> String.codepoints("olá")
@@ -1148,6 +1150,8 @@ defmodule String do
   Returns Unicode graphemes in the string as per Extended Grapheme
   Cluster algorithm outlined in the [Unicode Standard Annex #29,
   Unicode Text Segmentation](http://www.unicode.org/reports/tr29/).
+
+  For details about codepoints and graphemes, see the `String` module documentation.
 
   ## Examples
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1001,6 +1001,12 @@ defmodule String do
       iex> String.codepoints("ἅἪῼ")
       ["ἅ", "Ἢ", "ῼ"]
 
+      iex> String.codepoints("\u00e9")
+      ["é"]
+
+      iex> String.codepoints("\u0065\u0301")
+      ["e", "́"]
+
   """
   @spec codepoints(t) :: [codepoint]
   defdelegate codepoints(string), to: String.Unicode
@@ -1157,6 +1163,12 @@ defmodule String do
 
       iex> String.graphemes("Ńaïve")
       ["Ń", "a", "ï", "v", "e"]
+
+      iex> String.graphemes("\u00e9")
+      ["é"]
+
+      iex> String.graphemes("\u0065\u0301")
+      ["é"]
 
   """
   @spec graphemes(t) :: [grapheme]


### PR DESCRIPTION
Currently, if you look at the docs of both functions, it's hard to tell what the difference is.

This should make it a bit better.

I'm not sure if this is the best way of linking to the module docs.

Another thing I considered but wasn't sure about (mostly because getting it right without ugly `\u…` values is a little fiddly): we could add the same example input, with different output, to the docs of both.