### PR TITLE
Fix bug in Macro.to_string. Fix #4065.

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -585,6 +585,11 @@ defmodule Macro do
   end
 
   # Access
+  def to_string({{:., _, [Access, :get]}, _, [{op, _, [_|_]} = left, right]} = ast, fun)
+      when op in unquote(@binary_ops) do
+    fun.(ast, "(" <> to_string(left, fun) <> ")" <> to_string([right], fun))
+  end
+
   def to_string({{:., _, [Access, :get]}, _, [left, right]} = ast, fun) do
     fun.(ast, to_string(left, fun) <> to_string([right], fun))
   end

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -428,6 +428,8 @@ defmodule MacroTest do
   test "access to string" do
     assert Macro.to_string(quote do: a[b]) == "a[b]"
     assert Macro.to_string(quote do: a[1 + 2]) == "a[1 + 2]"
+    assert Macro.to_string(quote do: (a || [a: 1])[:a]) == "(a || [a: 1])[:a]"
+    assert Macro.to_string(quote do: Dict.put(%{}, :a, 1)[:a]) == "Dict.put(%{}, :a, 1)[:a]"
   end
 
   test "kw list to string" do


### PR DESCRIPTION
This fixes the `Access.get` case in `Macro.to_string` to put parenthesis when the left hand side operand is an application.
This fixes #4065.
It does add unneeded parentheses for cases like

```elixir
Macro.to_string(quote do: Dict.put(%{}, "foo", "bar")["foo"])
```

If this is an issue, I can work on it.