### PR TITLE
Allow `false` value in env passed to `System.cmd/3`

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -493,6 +493,8 @@ defmodule System do
 
   defp validate_env(enum) do
     Enum.map enum, fn
+      {k, false} ->
+        {String.to_char_list(k), false}
       {k, v} ->
         {String.to_char_list(k), String.to_char_list(v)}
       other ->

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -70,7 +70,7 @@ defmodule SystemTest do
 
   test "cmd/3 (with options)" do
     assert {["hello\n"], 0} = System.cmd "echo", ["hello"],
-                                into: [], cd: System.cwd!, env: %{"foo" => "bar"},
+                                into: [], cd: System.cwd!, env: %{"foo" => "bar", "baz" => false},
                                 arg0: "echo", stderr_to_stdout: true, parallelism: true
   end
 


### PR DESCRIPTION
Previously only strings were accepted as valid env keys and values.
However, because the `env` option is eventually passed to
`:erlang.open_port`, `false` values, which remove existing environment
variables, should be allowed.

From the docs for [`erlang:open_port/2`](http://www.erlang.org/doc/man/erlang.html#open_port-2):

    {env, Env}
      This is only valid for {spawn, Command} and {spawn_executable,
      FileName}. The environment of the started process is extended using the
      environment specifications in Env.

      Env should be a list of tuples {Name, Val}, where Name is the name of an
      environment variable, and Val is the value it is to have in the spawned
      port process. Both Name and Val must be strings. The one exception is
      Val being the atom false (in analogy with os:getenv/1), which removes
      the environment variable.