### PR TITLE
Raise when Access syntax used on non-keywords

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -53,7 +53,7 @@ defmodule Access do
     :maps.find(key, map)
   end
 
-  def fetch(list, key) when is_list(list) do
+  def fetch(list, key) when is_list(list) and is_atom(key) do
     case :lists.keyfind(key, 1, list) do
       {^key, value} -> {:ok, value}
       false -> :error

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -36,6 +36,10 @@ defmodule AccessTest do
     assert Access.fetch([foo: :bar], :foo) == {:ok, :bar}
     assert Access.fetch([foo: :bar], :bar) == :error
 
+    assert_raise FunctionClauseError, fn ->
+      Access.fetch([{"foo", :bar}], "foo")
+    end
+
     assert Access.get([foo: :bar], :foo) == :bar
     assert Access.get_and_update([], :foo, fn nil -> {:ok, :baz} end) == {:ok, [foo: :baz]}
     assert Access.get_and_update([foo: :bar], :foo, fn :bar -> {:ok, :baz} end) == {:ok, [foo: :baz]}

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -21,6 +21,7 @@ defmodule AccessTest do
 
   test "for nil" do
     assert nil[:foo] == nil
+    assert Access.fetch(nil, :foo) == :error
     assert Access.get(nil, :foo) == nil
     assert_raise ArgumentError, "could not put/update key :foo on a nil value", fn ->
       Access.get_and_update(nil, :foo, fn nil -> {:ok, :bar} end)
@@ -32,6 +33,9 @@ defmodule AccessTest do
     assert [foo: [bar: :baz]][:foo][:bar] == :baz
     assert [foo: [bar: :baz]][:fuu][:bar] == nil
 
+    assert Access.fetch([foo: :bar], :foo) == {:ok, :bar}
+    assert Access.fetch([foo: :bar], :bar) == :error
+
     assert Access.get([foo: :bar], :foo) == :bar
     assert Access.get_and_update([], :foo, fn nil -> {:ok, :baz} end) == {:ok, [foo: :baz]}
     assert Access.get_and_update([foo: :bar], :foo, fn :bar -> {:ok, :baz} end) == {:ok, [foo: :baz]}
@@ -42,6 +46,9 @@ defmodule AccessTest do
     assert %{1 => 1}[1] == 1
     assert %{1.0 => 1.0}[1.0] == 1.0
     assert %{1 => 1}[1.0] == nil
+
+    assert Access.fetch(%{foo: :bar}, :foo) == {:ok, :bar}
+    assert Access.fetch(%{foo: :bar}, :bar) == :error
 
     assert Access.get(%{foo: :bar}, :foo) == :bar
     assert Access.get_and_update(%{}, :foo, fn nil -> {:ok, :baz} end) == {:ok, %{foo: :baz}}


### PR DESCRIPTION
Closes #4071.