### PR TITLE
mix.bat changed to emulate mix script on Unix-like systems. Solves #4075

### DIFF
--- a/bin/mix.bat
+++ b/bin/mix.bat
@@ -1,2 +1,2 @@
 @if defined ELIXIR_CLI_ECHO (@echo on) else  (@echo off)
-call "%~dp0\elixir.bat" -e Mix.start -e Mix.CLI.main %*
+call "%~dp0\elixir.bat" "%~dp0\mix" %*


### PR DESCRIPTION
On Unix-like systems, the mix command is implemented as an elixir script that runs 
```
Mix.start
Mix.CLI.main
```

On Windows mix.bat it runs something like
```
elixir -e Mix.start -e Mix.CLI.main
```
that is a bit different.

On both systems, if you run 
```
elixir -e Mix.start -e Mix.CLI.main --version
```
you get
```
Elixir x.y.z
```
instead of
```
Mix x.y.z
```