### PR TITLE
Fix issue #4081 UnicodeConversionError would generate invalid strings

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -704,8 +704,12 @@ defmodule UnicodeConversionError do
     "encoding starting at #{inspect rest}"
   end
 
-  defp detail([h|_]) do
+  defp detail([h|_]) when is_integer(h) do
     "code point #{h}"
+  end
+
+  defp detail([h|_]) do
+    detail(h)
   end
 end
 

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -158,6 +158,10 @@ defmodule ListTest do
                  "invalid code point 57343", fn ->
       List.to_string([0xDFFF])
     end
+    assert_raise UnicodeConversionError,
+                 "invalid encoding starting at <<216, 0>>", fn ->
+      List.to_string(["a", "b", <<0xD800 :: size(16)>>])
+    end
 
     assert_raise ArgumentError,
                  "cannot convert list to string. The list must contain only integers, strings or nested such lists; got: [:a, :b]", fn ->


### PR DESCRIPTION
previously assumed the head of the returned iolist would be an integer. This has been fixed with more recursion
fishcakez was right