### PR TITLE
Add environment variable to iex.bat so user can default to --werl.

### DIFF
--- a/bin/iex.bat
+++ b/bin/iex.bat
@@ -1,2 +1,2 @@
 @if defined ELIXIR_CLI_ECHO (@echo on) else  (@echo off)
-call "%~dp0\elixir.bat" +iex --erl "-user Elixir.IEx.CLI" --no-halt %*
+call "%~dp0\elixir.bat" +iex --erl "-user Elixir.IEx.CLI" --no-halt %ELIXIR_IEX_FLAGS% %*

--- a/bin/iex.bat
+++ b/bin/iex.bat
@@ -1,2 +1,4 @@
 @if defined ELIXIR_CLI_ECHO (@echo on) else  (@echo off)
-call "%~dp0\elixir.bat" +iex --erl "-user Elixir.IEx.CLI" --no-halt %ELIXIR_IEX_FLAGS% %*
+@if defined IEX_WITH_WERL (@set __ELIXIR_IEX_FLAGS=--werl) else (set __ELIXIR_IEX_FLAGS=)
+call "%~dp0\elixir.bat" +iex --erl "-user Elixir.IEx.CLI" --no-halt %__ELIXIR_IEX_FLAGS% %*
+@set __ELIXIR_IEX_FLAGS=


### PR DESCRIPTION
Allow the user to set an environment variable on Windows so --werl can be the default:

```bat
C:\Users\user>set ELIXIR_IEX_FLAGS=

C:\Users\user>iex
Eshell V7.2.1  (abort with ^G)
Interactive Elixir (1.2.0-rc.1) - press Ctrl+C to exit (type h() ENTER for help)

iex(1)> Terminate batch job (Y/N)? y

C:\Users\user>set ELIXIR_IEX_FLAGS=--werl

C:\Users\user>iex

C:\Users\user>REM IEx window opens instead.
```