### PR TITLE
Fix link to Kernel.<=/2 in Enum.sort_by/3 @doc

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1909,7 +1909,7 @@ defmodule Enum do
 
   This function maps each element of the enumerable using the `mapper`
   function.  The enumerable is then sorted by the mapped elements
-  using the `sorter` function, which defaults to `<=/2`
+  using the `sorter` function, which defaults to `Kernel.<=/2`
 
   `sort_by/3` differs from `sort/2` in that it only calculates the
   comparison value for each element in the enumerable once instead of


### PR DESCRIPTION
When I first wrote the docs, I didn't know I had to include the `Kernel.` to make the automatic linking work.  I double checked after reading the documentation guide for Elixir 1.2 and noticed that the
`<=/2` wasn't linking.