### PR TITLE
Fix bug in Macro.to_string. Fix #4116.

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -483,10 +483,11 @@ defmodule Macro do
       fun.(ast, interpolate(ast, fun))
     else
       result = Enum.map_join(parts, ", ", fn(part) ->
-        case bitpart_to_string(part, fun) do
-          "<" <> rest ->
-            "(<" <> rest <> ")"
-          other -> other
+        str = bitpart_to_string(part, fun)
+        if String.first(str) == "<" or String.last(str) == ">" do
+          "(" <> str <> ")"
+        else
+          str
         end
       end)
       fun.(ast, "<<" <> result <> ">>")

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -449,6 +449,8 @@ defmodule MacroTest do
     assert Macro.to_string(ast) == "<<(<<65>>), 65>>"
     ast = quote(do: <<65, <<65>> >>)
     assert Macro.to_string(ast) == "<<65, (<<65>>)>>"
+    ast = quote do: for <<a::4 <- <<1, 2>> >>, do: a
+    assert Macro.to_string(ast) == "for(<<(a :: 4 <- <<1, 2>>)>>) do\n  a\nend"
   end
 
   test "charlist to string" do


### PR DESCRIPTION
This fixes `Macro.to_string` bit containers clause for cases like mentioned in #4116 
where the expression inside `<< >>` does not start by `<<` but ends by `>>`.

```
ast = quote do: for <<a::4 <- <<1, 2>> >>, do: a
```