### PR TITLE
Fix a race condition in gen_event_test.exs. Fix #4131

### DIFF
--- a/lib/elixir/test/elixir/gen_event_test.exs
+++ b/lib/elixir/test/elixir/gen_event_test.exs
@@ -330,6 +330,7 @@ defmodule GenEventTest do
     GenEvent.add_handler(pid, ReplyHandler, {self(), false})
     assert GenEvent.notify(pid, :raise) == :ok
     assert_receive {:terminate, {:error, {%RuntimeError{}, _}}}
+    assert GenEvent.which_handlers(pid) == []
   after
     Logger.add_backend(:console, flush: true)
   end
@@ -364,6 +365,7 @@ defmodule GenEventTest do
     GenEvent.add_handler(pid, ReplyHandler, {self(), false})
     assert GenEvent.ack_notify(pid, :raise) == :ok
     assert_receive {:terminate, {:error, {%RuntimeError{}, _}}}
+    assert GenEvent.which_handlers(pid) == []
   after
     Logger.add_backend(:console, flush: true)
   end


### PR DESCRIPTION
The added calls make sure the generated log message is sent before
the :console backend is readded.

This was pretty much me channeling @fishcakez's knowledge into code :)