### PR TITLE
Remove unused `escape_char/1` function

### DIFF
--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -475,10 +475,6 @@ handle_char($\t) -> {"\\t", "tab"};
 handle_char($\v) -> {"\\v", "vertical tab"};
 handle_char(_)  -> false.
 
-escape_char(List) ->
-  <<Char/utf8>> = elixir_interpolation:unescape_chars(list_to_binary(List)),
-  Char.
-
 %% Handlers
 
 handle_heredocs(T, Line, Column, H, Scope, Tokens) ->


### PR DESCRIPTION
I found this while compiling elixir master:

```
src/elixir_tokenizer.erl:478: Warning: function escape_char/1 is unused
```