### PR TITLE
Add a :make compiler

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.make.ex
+++ b/lib/mix/lib/mix/tasks/compile.make.ex
@@ -44,16 +44,18 @@ defmodule Mix.Tasks.Compile.Make do
     exec      = executable_for_current_os()
 
     args = args_for_makefile(exec, makefile) ++ targets
-
-    exit_status = File.cd!(cwd, fn -> cmd(exec, args) end)
+    exit_status = cmd(exec, args, cwd)
 
     if exit_status == 0, do: :ok, else: build_error(exec, exit_status, error_msg)
   end
 
-  # Runs `exec [args]` and prints the stdout and stderr in real time, as soon as
-  # `exec` prints them (using `IO.Stream`).
-  defp cmd(exec, args) do
-    opts = [into: IO.stream(:stdio, :line), stderr_to_stdout: true]
+  # Runs `exec [args]` in `cwd` and prints the stdout and stderr in real time,
+  # as soon as `exec` prints them (using `IO.Stream`).
+  defp cmd(exec, args, cwd) do
+    opts = [into: IO.stream(:stdio, :line),
+            stderr_to_stdout: true,
+            cd: cwd]
+
     {%IO.Stream{}, status} = System.cmd(executable(exec), args, opts)
     status
   end

--- a/lib/mix/lib/mix/tasks/compile.make.ex
+++ b/lib/mix/lib/mix/tasks/compile.make.ex
@@ -1,0 +1,53 @@
+defmodule Mix.Tasks.Compile.Make do
+  use Mix.Task
+
+  @shortdoc "Runs `make` in the current project"
+
+  @moduledoc """
+  Runs `make` in the current project.
+
+  This task runs `make` in the current project; any output coming from `make` is
+  printed in real-time on stdout. `make` will be called without specifying a
+  Makefile, so there has to be a `Makefile` in the current working directory.
+
+  ## Configuration
+
+    * `:make_targets` - it's a list of binaries. It's the list of Make targets
+      that should be run. Defaults to `[]`, meaning `make` will run the first
+      target.
+
+    * `:make_cwd` - it's a binary. It's the directory where `make` will be run,
+      relative to the root of the project.
+
+  """
+
+  @spec run([binary]) :: :ok | no_return
+  def run(_args) do
+    config  = Mix.Project.config()
+    targets = Keyword.get(config, :make_targets, [])
+    cwd     = Keyword.get(config, :make_cwd, ".")
+
+    exit_status = File.cd!(cwd, fn -> cmd("make", targets) end)
+
+    if exit_status == 0 do
+      :ok
+    else
+      Mix.raise "`make` exited with a non-zero status (#{exit_status})"
+    end
+  end
+
+  defp cmd(exec, args) do
+    opts = [into: IO.stream(:stdio, :line), stderr_to_stdout: true]
+    {%IO.Stream{}, status} = System.cmd(executable(exec), args, opts)
+    status
+  end
+
+  defp executable(exec) do
+    if found = System.find_executable(exec) do
+      found
+    else
+      Mix.raise "`#{exec}` not found in the current path. It was needed by the"
+                <> " :make compiler."
+    end
+  end
+end

--- a/lib/mix/test/mix/tasks/compile.make_test.exs
+++ b/lib/mix/test/mix/tasks/compile.make_test.exs
@@ -10,8 +10,8 @@ defmodule Mix.Tasks.Compile.MakeTest do
   end
 
   test "running without a makefile" do
-    msg             = ~r/`make` exited with a non-zero status \(\d+\)/
-    expected_output = "make: *** No targets specified and no makefile found.  Stop.\n"
+    msg             = ~r/^Could not compile with/
+    expected_output = "*** No targets specified and no makefile found.  Stop.\n"
 
     in_fixture "compile_make", fn ->
       File.rm_rf!("Makefile")
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.Compile.MakeTest do
         assert_raise Mix.Error, msg, fn -> run() end
       end
 
-      assert expected_output == output
+      assert output =~ expected_output
     end
   end
 
@@ -65,6 +65,19 @@ defmodule Mix.Tasks.Compile.MakeTest do
 
       with_project_config [make_cwd: "subdir"], fn ->
         assert capture_io(&run/0) == "subdir\n"
+      end
+    end
+  end
+
+  test "specifying a makefile" do
+    in_fixture "compile_make", fn ->
+      File.write "MyMakefile", """
+      all:
+      \t@echo "my makefile"
+      """
+
+      with_project_config [make_makefile: "MyMakefile"], fn ->
+        assert capture_io(&run/0) == "my makefile\n"
       end
     end
   end

--- a/lib/mix/test/mix/tasks/compile.make_test.exs
+++ b/lib/mix/test/mix/tasks/compile.make_test.exs
@@ -1,0 +1,79 @@
+Code.require_file "../../test_helper.exs", __DIR__
+
+defmodule Mix.Tasks.Compile.MakeTest do
+  use MixTest.Case
+  import ExUnit.CaptureIO
+
+  setup do
+    Mix.Project.push MixTest.Case.Sample
+    :ok
+  end
+
+  test "running without a makefile" do
+    msg             = ~r/`make` exited with a non-zero status \(\d+\)/
+    expected_output = "make: *** No targets specified and no makefile found.  Stop.\n"
+
+    in_fixture "compile_make", fn ->
+      File.rm_rf!("Makefile")
+
+      output = capture_io fn ->
+        assert_raise Mix.Error, msg, fn -> run() end
+      end
+
+      assert expected_output == output
+    end
+  end
+
+  test "running with a makefile" do
+    in_fixture "compile_make", fn ->
+      File.write! "Makefile", """
+      my_target:
+      \t@echo "hello"
+      """
+
+      assert capture_io(fn -> run() end) =~ "hello\n"
+    end
+  end
+
+  test "specifying targets" do
+    in_fixture "compile_make", fn ->
+      File.write! "Makefile", """
+      useless_target:
+      \t@echo "nope"
+      my_target:
+      \t@echo "target"
+      my_other_target:
+      \t@echo "other target"
+      """
+
+      with_project_config [make_targets: ~w(my_target my_other_target)], fn ->
+        output = capture_io(fn -> run() end)
+        assert output =~ "target\n"
+        assert output =~ "other target\n"
+        refute output =~ "nope"
+      end
+    end
+  end
+
+  test "specifying a cwd" do
+    in_fixture "compile_make", fn ->
+      File.mkdir_p!("subdir")
+      File.write! "subdir/Makefile", """
+      all:
+      \t@echo "subdir"
+      """
+
+      with_project_config [make_cwd: "subdir"], fn ->
+        assert capture_io(&run/0) == "subdir\n"
+      end
+    end
+  end
+
+  defp with_project_config(config, fun) do
+    Mix.Project.in_project(:sample, ".", config, fn(_) -> fun.() end)
+  end
+
+  defp run(args \\ []) do
+    Mix.Tasks.Compile.Make.run(args)
+  end
+end

--- a/lib/mix/test/mix/tasks/compile.make_test.exs
+++ b/lib/mix/test/mix/tasks/compile.make_test.exs
@@ -9,8 +9,18 @@ defmodule Mix.Tasks.Compile.MakeTest do
     :ok
   end
 
+  test "running with a specific executable" do
+    in_fixture "compile_make", fn ->
+      with_project_config [make_executable: "nonexistentmake"], fn ->
+        assert_raise Mix.Error, "`nonexistentmake` not found in the current path", fn ->
+          run()
+        end
+      end
+    end
+  end
+
   test "running without a makefile" do
-    msg = ~r/^Could not compile with/
+    msg = ~r/\ACould not compile with/
 
     in_fixture "compile_make", fn ->
       File.rm_rf!("Makefile")
@@ -24,7 +34,7 @@ defmodule Mix.Tasks.Compile.MakeTest do
   test "running with a makefile" do
     in_fixture "compile_make", fn ->
       File.write! "Makefile", """
-      my_target:
+      target:
       \t@echo "hello"
       """
 
@@ -37,13 +47,13 @@ defmodule Mix.Tasks.Compile.MakeTest do
       File.write! "Makefile", """
       useless_target:
       \t@echo "nope"
-      my_target:
+      target:
       \t@echo "target"
-      my_other_target:
+      other_target:
       \t@echo "other target"
       """
 
-      with_project_config [make_targets: ~w(my_target my_other_target)], fn ->
+      with_project_config [make_targets: ~w(target other_target)], fn ->
         output = capture_io(fn -> run() end)
         assert output =~ "target\n"
         assert output =~ "other target\n"

--- a/lib/mix/test/mix/tasks/compile.make_test.exs
+++ b/lib/mix/test/mix/tasks/compile.make_test.exs
@@ -10,17 +10,14 @@ defmodule Mix.Tasks.Compile.MakeTest do
   end
 
   test "running without a makefile" do
-    msg             = ~r/^Could not compile with/
-    expected_output = "*** No targets specified and no makefile found.  Stop.\n"
+    msg = ~r/^Could not compile with/
 
     in_fixture "compile_make", fn ->
       File.rm_rf!("Makefile")
 
-      output = capture_io fn ->
+      capture_io fn ->
         assert_raise Mix.Error, msg, fn -> run() end
       end
-
-      assert output =~ expected_output
     end
   end
 
@@ -64,7 +61,7 @@ defmodule Mix.Tasks.Compile.MakeTest do
       """
 
       with_project_config [make_cwd: "subdir"], fn ->
-        assert capture_io(&run/0) == "subdir\n"
+        assert capture_io(fn -> run() end) == "subdir\n"
       end
     end
   end
@@ -77,7 +74,17 @@ defmodule Mix.Tasks.Compile.MakeTest do
       """
 
       with_project_config [make_makefile: "MyMakefile"], fn ->
-        assert capture_io(&run/0) == "my makefile\n"
+        assert capture_io(fn -> run() end) == "my makefile\n"
+      end
+    end
+  end
+
+  test "specifying a custom error message" do
+    in_fixture "compile_make", fn ->
+      with_project_config [make_error_message: "try harder"], fn ->
+        capture_io fn ->
+          assert_raise Mix.Error, ~r/try harder/, fn -> run() end
+        end
       end
     end
   end


### PR DESCRIPTION
I'm opening this PR to test the water regarding the make compiler mentioned by #4082. It doesn't support `nmake` and it's pretty barebones, but it could be a starting point. Here, just a couple of options are configurable: `:make_cwd` to choose the cwd for running `make`, and `:make_targets` for the list of make targets to be run. We could make other options configurable, like specifying a `Makefile`. Also, right now everything that `make` outputs is streamed to stdout, we could make that configurable as well (e.g., `:make_report_only_errors` or something similar).

Wdyt?