### PR TITLE
Specify syntax highlighting for README.md template in mix

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -203,15 +203,19 @@ defmodule Mix.Tasks.New do
 
     1. Add <%= @app %> to your list of dependencies in `mix.exs`:
 
-          def deps do
-            [{:<%= @app %>, "~> 0.0.1"}]
-          end
+      ```elixir
+      def deps do
+        [{:<%= @app %>, "~> 0.0.1"}]
+      end
+      ```
 
     2. Ensure <%= @app %> is started before your application:
 
-          def application do
-            [applications: [:<%= @app %>]]
-          end
+      ```elixir
+      def application do
+        [applications: [:<%= @app %>]]
+      end
+      ```
   <% end %>
   """
 


### PR DESCRIPTION
The `mix new` task generates README.md with code markdown that isn't highlighted by github. 
I've specified elixir syntax highlighting in README.md template for the `mix new` task.