### PR TITLE
Improve error message for when the named mix task cannot be found.

### DIFF
--- a/lib/mix/test/mix/task_test.exs
+++ b/lib/mix/test/mix/task_test.exs
@@ -24,6 +24,15 @@ defmodule Mix.TaskTest do
     assert_raise Mix.InvalidTaskError, "The task \"invalid\" does not export run/1", fn ->
       Mix.Task.run("invalid")
     end
+
+    misnamed_message = """
+    The task "acronym.http" could not be found because the module is named
+    `Mix.Tasks.Acronym.HTTP` instead of `Mix.Tasks.Acronym.Http` as expected.
+    Please rename it and try again.
+    """ |> String.replace("\n", " ") |> String.rstrip
+    assert_raise Mix.NoTaskError, misnamed_message, fn ->
+      Mix.Task.run("acronym.http")
+    end
   end
 
   test "output task debug info if Mix.debug? is true" do

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -310,3 +310,8 @@ end |> write_beam.()
 
 defmodule Mix.Tasks.Invalid do
 end |> write_beam.()
+
+defmodule Mix.Tasks.Acronym.HTTP do
+  use Mix.Task
+  def run(_), do: "An HTTP Task"
+end |> write_beam.()


### PR DESCRIPTION
Previously, you could get the incredibly confusing error:

> The task "acronym.http" could not be found. Did you mean "acronym.http"?

This happened when you named your module `Mix.Tasks.Acronym.HTTP` rather
than `Mix.Tasks.Acronym.Http` as expected. Since we can detect this
situation, it's helpful to give the user a clear explanation of the
problem.

(For context: this is a follow up to a [conversation I had with José earlier today](https://github.com/elixir-lang/elixir/pull/4137/files#r48686720)).