### PR TITLE
abbreviations -> acronyms

### DIFF
--- a/lib/elixir/pages/Naming Conventions.md
+++ b/lib/elixir/pages/Naming Conventions.md
@@ -9,7 +9,7 @@ Elixir developers must use `snake_case` when defining variables, function names,
     some_map = %{this_is_a_key: "and a value"}
     is_map(some_map)
 
-Aliases, commonly used as module names, are an exception as they must be capitalized and written in `CamelCase`, like `OptionParser`. For aliases, capital letters are kept in abbreviations, like `ExUnit.CaptureIO` or `Mix.SCM`.
+Aliases, commonly used as module names, are an exception as they must be capitalized and written in `CamelCase`, like `OptionParser`. For aliases, capital letters are kept in acronyms, like `ExUnit.CaptureIO` or `Mix.SCM`.
 
 Atoms can be written either in `:snake_case` or `:CamelCase`, although the convention is to use the snake case version throughout Elixir.
 


### PR DESCRIPTION
Using all capitals is recommended only when you have an acronym
like HTTP, IO, SCM, etc. For an abbreviation like "Misc" or "Utils"
all caps should not be used.

I noticed this when #4137.

/cc @henrik 