### PR TITLE
Fix markdown formatting of a code example in Bitwise module documentation

### DIFF
--- a/lib/elixir/lib/bitwise.ex
+++ b/lib/elixir/lib/bitwise.ex
@@ -16,6 +16,7 @@ defmodule Bitwise do
     * `:only_operators` - include only operators
     * `:skip_operators` - skip operators
 
+
       iex> use Bitwise, only_operators: true
       iex> 1 &&& 1
       1


### PR DESCRIPTION
Broken markdown formatting. The code example didn't render as a code block. Added a single newline to make a new paragraph, fixes it.

See:
https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/bitwise.ex#L19
http://elixir-lang.org/docs/v1.2/elixir/Bitwise.html