### PR TITLE
Change default mix.exs files so that it is easier to add and remove dependencies

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -205,7 +205,9 @@ defmodule Mix.Tasks.New do
 
       ```elixir
       def deps do
-        [{:<%= @app %>, "~> 0.0.1"}]
+        [
+          {:<%= @app %>, "~> 0.0.1"},
+        ]
       end
       ```
 
@@ -249,15 +251,16 @@ defmodule Mix.Tasks.New do
 
     # Dependencies can be Hex packages:
     #
-    #   {:mydep, "~> 0.3.0"}
+    #   {:mydep, "~> 0.3.0"},
     #
     # Or git/path repositories:
     #
-    #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
+    #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"},
     #
     # Type "mix help deps" for more examples and options
     defp deps do
-      []
+      [
+      ]
     end
   end
   """
@@ -288,11 +291,11 @@ defmodule Mix.Tasks.New do
 
     # Dependencies can be Hex packages:
     #
-    #   {:mydep, "~> 0.3.0"}
+    #   {:mydep, "~> 0.3.0"},
     #
     # Or git/path repositories:
     #
-    #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
+    #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"},
     #
     # To depend on another app inside the umbrella:
     #
@@ -300,7 +303,8 @@ defmodule Mix.Tasks.New do
     #
     # Type "mix help deps" for more examples and options
     defp deps do
-      []
+      [
+      ]
     end
   end
   """
@@ -318,18 +322,19 @@ defmodule Mix.Tasks.New do
 
     # Dependencies can be Hex packages:
     #
-    #   {:mydep, "~> 0.3.0"}
+    #   {:mydep, "~> 0.3.0"},
     #
     # Or git/path repositories:
     #
-    #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
+    #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"},
     #
     # Type "mix help deps" for more examples and options.
     #
     # Dependencies listed here are available only for this project
     # and cannot be accessed from applications inside the apps folder
     defp deps do
-      []
+      [
+      ]
     end
   end
   """


### PR DESCRIPTION
This is a style change to the default mix file. If people do like this:
```elixir
[{:my_dep, "~> 0.0.1"}]
```

Then to add the dependency to another file, you have to:

- Select a subset of the above line - just the curly brackets and everything in between, which are right next to the outside brackets, so it is not super easy to select with a mouse/trackpad.
- Paste it into your existing list of deps
- Mentally parse the existing list to see if you have to add commas
- Add commas if necessary
- If the line of dependencies is long, maybe you have to add another lines of deps. Maybe you want to adjust the length of the lines after adding or removing a dep, somewhere in the middle.

To remove a dependency you have to mentally parse the existing list in order to see if you have to
add or remove commas.

I propose a style like the following:

```elixir
   [
     {:dep1, "~> 0.0.1"},
     {:dep2, "~> 0.0.2"},
     {:dep3, "~> 0.0.3"},
   ]
```

Notice the trailing commas on every line. With this style, to add a dependency you simply add or remove an entire line. That's it.