### PR TITLE
feat(Kernel): raise when defstruct is called more than once

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3210,6 +3210,10 @@ defmodule Kernel do
   """
   defmacro defstruct(fields) do
     quote bind_quoted: [fields: fields] do
+      if Module.get_attribute(__MODULE__, :struct) do
+        raise ArgumentError, "defstruct has already been called for " <>
+          "#{inspect(__MODULE__)}, defstruct can only be called once per module"
+      end
       fields = Kernel.Utils.defstruct(__MODULE__, fields)
       @struct fields
 

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -115,6 +115,19 @@ defmodule MapTest do
     end) == {:%, [], [User, {:%{}, [], [{:foo, 1}]}]}
   end
 
+  test "defstruct can only be used once in a module" do
+    message = "defstruct has already been called for TestMod, " <>
+      "defstruct can only be called once per module"
+    assert_raise ArgumentError, message, fn ->
+      Code.eval_string("""
+        defmodule TestMod do
+          defstruct [:foo]
+          defstruct [:foo]
+        end
+        """)
+    end
+  end
+
   defmodule LocalUser do
     defmodule NestedUser do
       defstruct []


### PR DESCRIPTION
Previously `defstruct` could be called multiple times. This could be
particularly confusing is `defstruct` is called by an external library
such as the Ecto `schema` macro.

Calling `defstruct` when the `@struct` module attribute already exists
will now cause a `CompileError`

This closes #4155