### PR TITLE
Better handling of elixirc_paths in compilation

### DIFF
--- a/lib/mix/test/mix/tasks/deps.git_test.exs
+++ b/lib/mix/test/mix/tasks/deps.git_test.exs
@@ -147,7 +147,7 @@ defmodule Mix.Tasks.DepsGitTest do
 
       # Clear up to prepare for the update
       File.rm("_build/dev/lib/git_repo/ebin/Elixir.GitRepo.beam")
-      File.rm("_build/dev/lib/git_repo/.compile.elixir")
+      File.rm("_build/dev/lib/git_repo/.compile.elixir.lib")
       File.rm("deps/git_repo/.fetch")
       Mix.Task.clear
       Mix.shell.flush


### PR DESCRIPTION
Fixes issue where manifest would be updated by compiling
a subset of the project. This would prevent the rest of the
project from being compiled at a later date.

This is still a bit rough, but ready for feedback.