### PR TITLE
Helpful undefined function errors

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -627,12 +627,20 @@ defmodule UndefinedFunctionError do
   end
 
   def message(%{reason: :"module could not be loaded", module: module, function: function, arity: arity}) do
-    "undefined function " <> Exception.format_mfa(module, function, arity) <>
+    msg = "undefined function " <> Exception.format_mfa(module, function, arity) <>
       " (module #{inspect module} is not available)"
+
+    matches = ExceptionHelpers.find_modules(module, function, arity)
+
+    ExceptionHelpers.perhaps(msg, module, matches)
   end
 
   def message(%{reason: :"function not exported",  module: module, function: function, arity: arity}) do
-    "undefined function " <> Exception.format_mfa(module, function, arity)
+    msg = "undefined function " <> Exception.format_mfa(module, function, arity)
+
+    matches = ExceptionHelpers.find_functions(module, function, arity)
+
+    ExceptionHelpers.perhaps(msg, module, matches)
   end
 
   def message(%{reason: :"function not available", module: module, function: function, arity: arity}) do

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -630,17 +630,17 @@ defmodule UndefinedFunctionError do
     msg = "undefined function " <> Exception.format_mfa(module, function, arity) <>
       " (module #{inspect module} is not available)"
 
-    matches = ExceptionHelpers.find_modules(module, function, arity)
+    matches = Exception.Helpers.find_modules(module, function, arity)
 
-    ExceptionHelpers.perhaps(msg, module, matches)
+    Exception.Helpers.perhaps(msg, module, matches)
   end
 
   def message(%{reason: :"function not exported",  module: module, function: function, arity: arity}) do
     msg = "undefined function " <> Exception.format_mfa(module, function, arity)
 
-    matches = ExceptionHelpers.find_functions(module, function, arity)
+    matches = Exception.Helpers.find_functions(module, function, arity)
 
-    ExceptionHelpers.perhaps(msg, module, matches)
+    Exception.Helpers.perhaps(msg, module, matches)
   end
 
   def message(%{reason: :"function not available", module: module, function: function, arity: arity}) do

--- a/lib/elixir/lib/exception_helpers.ex
+++ b/lib/elixir/lib/exception_helpers.ex
@@ -1,4 +1,4 @@
-defmodule ExceptionHelpers do
+defmodule Exception.Helpers do
   @function_similarity_threshold 1.5
   @module_similarity_threshold   1.5
 

--- a/lib/elixir/lib/exception_helpers.ex
+++ b/lib/elixir/lib/exception_helpers.ex
@@ -54,19 +54,6 @@ defmodule Exception.Helpers do
     end
   end
 
-  def function_signatures(module, function, arity) do
-    case Code.get_docs(module, :docs) do
-      nil -> []
-      docs ->
-        docs
-        |> Enum.filter(fn {{name, arty}, _doc_line, _type, _signature, _doc} ->
-          name == function and arty == arity
-        end)
-        |> Enum.map(fn {{name, _arity}, _doc_line, _type, signature, _doc} ->
-          get_call_signature(module, name, signature)
-        end)
-    end
-  end
 
   def within_distance_from(list, min_distance, atom) do
     name = Atom.to_string(atom)

--- a/lib/elixir/lib/exception_helpers.ex
+++ b/lib/elixir/lib/exception_helpers.ex
@@ -60,13 +60,11 @@ defmodule Exception.Helpers do
   end
 
   def within_distance_from(list, min_distance, name) do
-    list
-    |> Enum.map(fn(str) ->
-      { str, compare(name, str) }
-    end)
-    |> Enum.filter(fn({ _func, dist }) ->
-      dist >= min_distance
-    end)
+    for str <- list,
+        {str, distance} = { str, compare(name, str) },
+        distance >= min_distance do
+      {str, distance}
+    end
     |> Enum.sort_by(fn { _func, dist } ->
       dist
     end, &>=/2)

--- a/lib/elixir/lib/exception_helpers.ex
+++ b/lib/elixir/lib/exception_helpers.ex
@@ -1,6 +1,6 @@
 defmodule Exception.Helpers do
-  @function_similarity_threshold 1.5
-  @module_similarity_threshold   1.5
+  @function_similarity_threshold 0.77
+  @module_similarity_threshold   0.9
 
   def module_functions(module) do
     try do
@@ -73,10 +73,10 @@ defmodule Exception.Helpers do
 
     list
     |> Enum.map(fn(mod) ->
-      { mod, edit_distance(name, mod) }
+      { mod, String.jaro_distance(name, (mod)) }
     end)
     |> Enum.filter(fn({ _func, dist }) ->
-      dist <= min_distance
+      dist >= min_distance
     end)
     |> Keyword.keys
   end
@@ -95,50 +95,6 @@ defmodule Exception.Helpers do
 
     [msg, "\n\n    ", IO.ANSI.bright, "Perhaps you meant one of:", IO.ANSI.reset, "\n", indent, extra, "\n"]
     |> Enum.join
-  end
-
-  # ================================================================
-  # = Edit distance using levenshtein, taken from discussion here: =
-  # = https://github.com/elixir-lang/elixir/issues/672             =
-  # ================================================================
-  defp store_result(key, result, cache) do
-    {result, Dict.put(cache, key, result)}
-  end
-
-  defp edit_distance(string_1, string_2) when is_binary(string_1) and is_binary(string_2) do
-    string_1 = String.to_char_list(string_1)
-    string_2 = String.to_char_list(string_2)
-    edit_distance(string_1, string_2)
-  end
-
-  defp edit_distance(string_1, string_2) do
-    {list, _} = edit_distance(string_1, string_2, HashDict.new)
-    list
-  end
-
-  defp edit_distance(string_1, []=string_2, cache) do
-    store_result({string_1, string_2}, length(string_1), cache)
-  end
-
-  defp edit_distance([]=string_1, string_2, cache) do
-    store_result({string_1, string_2}, length(string_2), cache)
-  end
-
-  defp edit_distance([x|rest1], [x|rest2], cache) do
-    edit_distance(rest1, rest2, cache)
-  end
-
-  defp edit_distance([_|rest1]=string_1, [_|rest2]=string_2, cache) do
-    case Dict.has_key?(cache, {string_1, string_2}) do
-      true -> {Dict.get(cache, {string_1, string_2}), cache}
-      false ->
-        {l1, c1} = edit_distance(string_1, rest2, cache)
-        {l2, c2} = edit_distance(rest1, string_2, c1)
-        {l3, c3} = edit_distance(rest1, rest2, c2)
-
-        min = :lists.min([l1, l2, l3]) + 1
-        {min, Dict.put(c3, {string_1,string_2}, min)}
-    end
   end
 
   # =========================

--- a/lib/elixir/lib/exception_helpers.ex
+++ b/lib/elixir/lib/exception_helpers.ex
@@ -1,0 +1,160 @@
+defmodule ExceptionHelpers do
+  def module_functions(module) do
+    try do
+      module.module_info(:exports)
+    rescue UndefinedFunctionError ->
+      []
+    end
+  end
+
+  def find_functions(nil, _function, _arity), do: []
+
+  def find_functions(module, function, _arity) do
+    # Check for a function with the same name but different signature
+    matches = module_functions(module) |> Keyword.take([function])
+
+    if Enum.empty?(matches) do
+      # No function with this name, check for a typo
+      matches = similar_functions(module, function)
+    end
+
+    matches |> Enum.take(6)
+  end
+
+  def similar_functions(module, function) do
+    functions = module_functions(module)
+
+    matching_names = functions
+                |> Keyword.keys
+                |> within_distance_from(2, function)
+    functions |> Keyword.take(matching_names)
+  end
+
+  def find_modules(module, _function, _arity) do
+    :code.all_loaded
+    |> Enum.map(&elem(&1, 0))
+    |> within_distance_from(2, module)
+  end
+
+  def get_call_signature(module, name, args) do
+    cond do
+      name in [:__aliases__, :__block__] ->
+        "#{name}(args)"
+      name in [:__ENV__, :__MODULE__, :__DIR__, :__CALLER__, :"%", :"%{}"] ->
+        "#{name}"
+      true ->
+        call = String.to_atom("#{inspect module}.#{name}")
+        Macro.to_string({ call, [], args })
+    end
+  end
+
+  def function_signatures(module, function, arity) do
+    case Code.get_docs(module, :docs) do
+      nil -> []
+      docs ->
+        docs
+        |> Enum.filter(fn {{name, arty}, _doc_line, _type, _signature, _doc} ->
+          name == function and arty == arity
+        end)
+        |> Enum.map(fn {{name, _arity}, _doc_line, _type, signature, _doc} ->
+          get_call_signature(module, name, signature)
+        end)
+    end
+  end
+
+  def within_distance_from(list, max_distance, atom) do
+    name = Atom.to_string(atom)
+
+    list
+    |> Enum.map(fn(mod) ->
+      { mod, edit_distance(name, Atom.to_string(mod)) }
+    end)
+    |> Enum.sort_by(fn({ _func, dist }) ->
+      dist
+    end)
+    |> Enum.filter(fn({ _func, dist }) ->
+      dist <= max_distance
+    end)
+    |> Keyword.keys
+  end
+
+  defp pad_string(s, pad_len) do
+    length = String.length(s)
+    if length >= pad_len do
+      s
+    else
+      s <> String.duplicate(" ", pad_len - length)
+    end
+  end
+
+  def perhaps(msg, _, []), do: msg
+
+  def perhaps(msg, module, list) do
+    indent = "\n       "
+    extra = list
+            |> Enum.map(fn
+              { fun, arity } -> function_line(module, fun, arity)
+              module         -> inspect(module)
+            end)
+            |> Enum.join(indent)
+
+    [msg, "\n\n    ", IO.ANSI.bright, "Perhaps you meant one of:", IO.ANSI.reset, "\n", indent, extra, "\n"]
+    |> Enum.join
+  end
+
+  defp function_line(module, fun, arity) do
+    call = Exception.format_mfa(module, fun, arity)
+    signatures = function_signatures(module, fun, arity)
+    if not Enum.empty?(signatures) do
+      # call <> String.duplicate(" ", 30 - String.length(call)) <> Enum.join(signatures, ", ")
+      pad_string(call, 30) <> Enum.join(signatures, ", ")
+    else
+      call
+    end
+  end
+
+
+  # ================================================================
+  # = Edit distance using levenshtein, taken from discussion here: =
+  # = https://github.com/elixir-lang/elixir/issues/672             =
+  # ================================================================
+  defp store_result(key, result, cache) do
+    {result, Dict.put(cache, key, result)}
+  end
+
+  defp edit_distance(string_1, string_2) when is_binary(string_1) and is_binary(string_2) do
+    string_1 = String.to_char_list(string_1)
+    string_2 = String.to_char_list(string_2)
+    edit_distance(string_1, string_2)
+  end
+
+  defp edit_distance(string_1, string_2) do
+    {list, _} = edit_distance(string_1, string_2, HashDict.new)
+    list
+  end
+
+  defp edit_distance(string_1, []=string_2, cache) do
+    store_result({string_1, string_2}, length(string_1), cache)
+  end
+
+  defp edit_distance([]=string_1, string_2, cache) do
+    store_result({string_1, string_2}, length(string_2), cache)
+  end
+
+  defp edit_distance([x|rest1], [x|rest2], cache) do
+    edit_distance(rest1, rest2, cache)
+  end
+
+  defp edit_distance([_|rest1]=string_1, [_|rest2]=string_2, cache) do
+    case Dict.has_key?(cache, {string_1, string_2}) do
+      true -> {Dict.get(cache, {string_1, string_2}), cache}
+      false ->
+        {l1, c1} = edit_distance(string_1, rest2, cache)
+        {l2, c2} = edit_distance(rest1, string_2, c1)
+        {l3, c3} = edit_distance(rest1, rest2, c2)
+
+        min = :lists.min([l1, l2, l3]) + 1
+        {min, Dict.put(c3, {string_1,string_2}, min)}
+    end
+  end
+end

--- a/lib/elixir/lib/exception_helpers.ex
+++ b/lib/elixir/lib/exception_helpers.ex
@@ -25,12 +25,15 @@ defmodule Exception.Helpers do
 
   def similar_functions(module, function) do
     functions = module_functions(module)
-    matching_names = functions
-                |> Keyword.keys
-                |> Enum.map(&Atom.to_string/1)
-                |> within_distance_from(@function_similarity_threshold, function)
-                |> Enum.map(&String.to_atom/1)
-    functions |> Keyword.take(matching_names)
+
+    functions
+    |> Keyword.keys
+    |> Enum.uniq
+    |> Enum.map(&Atom.to_string/1)
+    |> within_distance_from(@function_similarity_threshold, function)
+    |> Enum.flat_map(fn name ->
+      Keyword.take(functions, [String.to_atom(name)])
+    end)
   end
 
   def find_modules(module, _function, _arity) do

--- a/lib/elixir/lib/exception_helpers.ex
+++ b/lib/elixir/lib/exception_helpers.ex
@@ -26,14 +26,14 @@ defmodule ExceptionHelpers do
 
     matching_names = functions
                 |> Keyword.keys
-                |> within_distance_from(2, function)
+                |> within_distance_from(0.8, function)
     functions |> Keyword.take(matching_names)
   end
 
   def find_modules(module, _function, _arity) do
     :code.all_loaded
     |> Enum.map(&elem(&1, 0))
-    |> within_distance_from(2, module)
+    |> within_distance_from(0.8, module)
   end
 
   def get_call_signature(module, name, args) do
@@ -62,29 +62,17 @@ defmodule ExceptionHelpers do
     end
   end
 
-  def within_distance_from(list, max_distance, atom) do
+  def within_distance_from(list, min_distance, atom) do
     name = Atom.to_string(atom)
 
     list
     |> Enum.map(fn(mod) ->
-      { mod, edit_distance(name, Atom.to_string(mod)) }
-    end)
-    |> Enum.sort_by(fn({ _func, dist }) ->
-      dist
+      { mod, String.jaro_distance(name, Atom.to_string(mod)) }
     end)
     |> Enum.filter(fn({ _func, dist }) ->
-      dist <= max_distance
+      dist >= min_distance
     end)
     |> Keyword.keys
-  end
-
-  defp pad_string(s, pad_len) do
-    length = String.length(s)
-    if length >= pad_len do
-      s
-    else
-      s <> String.duplicate(" ", pad_len - length)
-    end
   end
 
   def perhaps(msg, _, []), do: msg
@@ -93,68 +81,12 @@ defmodule ExceptionHelpers do
     indent = "\n       "
     extra = list
             |> Enum.map(fn
-              { fun, arity } -> function_line(module, fun, arity)
+              { fun, arity } -> Exception.format_mfa(module, fun, arity)
               module         -> inspect(module)
             end)
             |> Enum.join(indent)
 
     [msg, "\n\n    ", IO.ANSI.bright, "Perhaps you meant one of:", IO.ANSI.reset, "\n", indent, extra, "\n"]
     |> Enum.join
-  end
-
-  defp function_line(module, fun, arity) do
-    call = Exception.format_mfa(module, fun, arity)
-    signatures = function_signatures(module, fun, arity)
-    if not Enum.empty?(signatures) do
-      # call <> String.duplicate(" ", 30 - String.length(call)) <> Enum.join(signatures, ", ")
-      pad_string(call, 30) <> Enum.join(signatures, ", ")
-    else
-      call
-    end
-  end
-
-
-  # ================================================================
-  # = Edit distance using levenshtein, taken from discussion here: =
-  # = https://github.com/elixir-lang/elixir/issues/672             =
-  # ================================================================
-  defp store_result(key, result, cache) do
-    {result, Dict.put(cache, key, result)}
-  end
-
-  defp edit_distance(string_1, string_2) when is_binary(string_1) and is_binary(string_2) do
-    string_1 = String.to_char_list(string_1)
-    string_2 = String.to_char_list(string_2)
-    edit_distance(string_1, string_2)
-  end
-
-  defp edit_distance(string_1, string_2) do
-    {list, _} = edit_distance(string_1, string_2, HashDict.new)
-    list
-  end
-
-  defp edit_distance(string_1, []=string_2, cache) do
-    store_result({string_1, string_2}, length(string_1), cache)
-  end
-
-  defp edit_distance([]=string_1, string_2, cache) do
-    store_result({string_1, string_2}, length(string_2), cache)
-  end
-
-  defp edit_distance([x|rest1], [x|rest2], cache) do
-    edit_distance(rest1, rest2, cache)
-  end
-
-  defp edit_distance([_|rest1]=string_1, [_|rest2]=string_2, cache) do
-    case Dict.has_key?(cache, {string_1, string_2}) do
-      true -> {Dict.get(cache, {string_1, string_2}), cache}
-      false ->
-        {l1, c1} = edit_distance(string_1, rest2, cache)
-        {l2, c2} = edit_distance(rest1, string_2, c1)
-        {l3, c3} = edit_distance(rest1, rest2, c2)
-
-        min = :lists.min([l1, l2, l3]) + 1
-        {min, Dict.put(c3, {string_1,string_2}, min)}
-    end
   end
 end

--- a/lib/elixir/lib/exception_helpers.ex
+++ b/lib/elixir/lib/exception_helpers.ex
@@ -85,15 +85,24 @@ defmodule Exception.Helpers do
 
   def perhaps(msg, module, list) do
     indent = "\n       "
-    extra = list
-            |> Enum.take(6)
-            |> Enum.map(fn
-              { fun, arity } -> Exception.format_mfa(module, fun, arity)
-              module         -> module
-            end)
-            |> Enum.join(indent)
 
-    [msg, "\n\n    ", IO.ANSI.bright, "Perhaps you meant one of:", IO.ANSI.reset, "\n", indent, extra, "\n"]
+    extra =
+      list
+      |> Enum.take(6)
+      |> Enum.map(fn
+        { fun, arity } -> Exception.format_mfa(module, fun, arity)
+        module         -> module
+      end)
+      |> Enum.join(indent)
+
+    [
+      msg,
+      "\n\n    ",
+      IO.ANSI.bright, "Perhaps you meant one of:", IO.ANSI.reset, "\n",
+      indent,
+      extra,
+      "\n"
+    ]
     |> Enum.join
   end
 

--- a/lib/elixir/test/elixir/exception_helpers_test.exs
+++ b/lib/elixir/test/elixir/exception_helpers_test.exs
@@ -35,4 +35,8 @@ defmodule ExceptionHelpersTest do
              File
       """
   end
+
+  test "will find unloaded modules" do
+    assert "OptionParser" in ExceptionHelpers.find_modules(OptionParse, :foo, 1)
+  end
 end

--- a/lib/elixir/test/elixir/exception_helpers_test.exs
+++ b/lib/elixir/test/elixir/exception_helpers_test.exs
@@ -36,6 +36,10 @@ defmodule ExceptionHelpersTest do
       """
   end
 
+  test "works with Erlang modules" do
+    assert ":file" in ExceptionHelpers.find_modules(:filr, :open, 1)
+  end
+
   test "will find unloaded modules" do
     assert "OptionParser" in ExceptionHelpers.find_modules(OptionParse, :foo, 1)
   end

--- a/lib/elixir/test/elixir/exception_helpers_test.exs
+++ b/lib/elixir/test/elixir/exception_helpers_test.exs
@@ -20,8 +20,8 @@ defmodule ExceptionHelpersTest do
           \e[1mPerhaps you meant one of:\e[0m
 
              File.open/1
-             File.open/3                   File.open(path, modes, function)
-             File.open/2                   File.open(path, modes \\\\ [])
+             File.open/3
+             File.open/2
       """
   end
 

--- a/lib/elixir/test/elixir/exception_helpers_test.exs
+++ b/lib/elixir/test/elixir/exception_helpers_test.exs
@@ -13,6 +13,10 @@ defmodule ExceptionHelpersTest do
     assert_found &String.capitalise/1, [capitalize: 1]
   end
 
+  test "sorts matches based on similarity" do
+    assert_found &IO.binred/1, [binread: 2, binread: 1, binwrite: 2, binwrite: 1, binstream: 2]
+  end
+
   test "undefined function exception message" do
     assert %UndefinedFunctionError{module: File, function: :open, arity: 0}
       |> Exception.message =~ """

--- a/lib/elixir/test/elixir/exception_helpers_test.exs
+++ b/lib/elixir/test/elixir/exception_helpers_test.exs
@@ -9,7 +9,7 @@ defmodule ExceptionHelpersTest do
 
   test "finds similar functions when no name matches" do
     assert_found &IO.put/1, [puts: 1, puts: 2]
-    assert_found &Enum.man/0, [max: 1, map: 2]
+    assert_found &Enum.man/0, [min: 1, max: 1, map: 2]
     assert_found &String.capitalise/1, [capitalize: 1]
   end
 

--- a/lib/elixir/test/elixir/exception_helpers_test.exs
+++ b/lib/elixir/test/elixir/exception_helpers_test.exs
@@ -9,7 +9,7 @@ defmodule ExceptionHelpersTest do
 
   test "finds similar functions when no name matches" do
     assert_found &IO.put/1, [puts: 1, puts: 2]
-    assert_found &Enum.man/0, [min: 1, max: 1, map: 2]
+    assert_found &Enum.man/0, [max: 1, map: 2]
     assert_found &String.capitalise/1, [capitalize: 1]
   end
 

--- a/lib/elixir/test/elixir/exception_helpers_test.exs
+++ b/lib/elixir/test/elixir/exception_helpers_test.exs
@@ -2,7 +2,7 @@ Code.require_file "test_helper.exs", __DIR__
 
 defmodule ExceptionHelpersTest do
   use ExUnit.Case, async: true
-  import ExceptionHelpers
+  import Exception.Helpers
 
   test "finds functions of the same name with different arity" do
     assert find_functions(IO, :puts, 0) == [puts: 1, puts: 2]
@@ -37,10 +37,10 @@ defmodule ExceptionHelpersTest do
   end
 
   test "works with Erlang modules" do
-    assert ":file" in ExceptionHelpers.find_modules(:filr, :open, 1)
+    assert ":file" in Exception.Helpers.find_modules(:filr, :open, 1)
   end
 
   test "will find unloaded modules" do
-    assert "OptionParser" in ExceptionHelpers.find_modules(OptionParse, :foo, 1)
+    assert "OptionParser" in Exception.Helpers.find_modules(OptionParse, :foo, 1)
   end
 end

--- a/lib/elixir/test/elixir/exception_helpers_test.exs
+++ b/lib/elixir/test/elixir/exception_helpers_test.exs
@@ -15,7 +15,7 @@ defmodule ExceptionHelpersTest do
 
   test "undefined function exception message" do
     assert %UndefinedFunctionError{module: File, function: :open, arity: 0}
-      |> Exception.message == """
+      |> Exception.message =~ """
       undefined function File.open/0
 
           \e[1mPerhaps you meant one of:\e[0m
@@ -28,7 +28,7 @@ defmodule ExceptionHelpersTest do
 
   test "undefined module exception message" do
     assert %UndefinedFunctionError{module: Filr, function: :open, arity: 1}
-      |> Exception.message == """
+      |> Exception.message =~ """
       undefined function Filr.open/1 (module Filr is not available)
 
           \e[1mPerhaps you meant one of:\e[0m

--- a/lib/elixir/test/elixir/exception_helpers_test.exs
+++ b/lib/elixir/test/elixir/exception_helpers_test.exs
@@ -1,0 +1,38 @@
+Code.require_file "test_helper.exs", __DIR__
+
+defmodule ExceptionHelpersTest do
+  use ExUnit.Case, async: true
+  import ExceptionHelpers
+
+  test "finds functions of the same name with different arity" do
+    assert find_functions(IO, :puts, 0) == [puts: 1, puts: 2]
+  end
+
+  test "finds similar functions when no name matches" do
+    assert find_functions(IO, :put, 0) == [puts: 1, puts: 2]
+  end
+
+  test "undefined function exception message" do
+    assert %UndefinedFunctionError{module: File, function: :open, arity: 0}
+      |> Exception.message == """
+      undefined function File.open/0
+
+          \e[1mPerhaps you meant one of:\e[0m
+
+             File.open/1
+             File.open/3                   File.open(path, modes, function)
+             File.open/2                   File.open(path, modes \\\\ [])
+      """
+  end
+
+  test "undefined module exception message" do
+    assert %UndefinedFunctionError{module: Filr, function: :open, arity: 1}
+      |> Exception.message == """
+      undefined function Filr.open/1 (module Filr is not available)
+
+          \e[1mPerhaps you meant one of:\e[0m
+
+             File
+      """
+  end
+end

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -331,8 +331,8 @@ defmodule ExceptionTest do
 
   test "undefined function message" do
     assert %UndefinedFunctionError{} |> message == "undefined function"
-    assert %UndefinedFunctionError{module: Kernel, function: :bar, arity: 1} |> message ==
-           "undefined function Kernel.bar/1"
+    assert %UndefinedFunctionError{module: Kernel, function: :bar, arity: 1} |> message =~
+           ~r{^undefined function Kernel\.bar/1}
     assert %UndefinedFunctionError{module: Foo, function: :bar, arity: 1} |> message ==
            "undefined function Foo.bar/1 (module Foo is not available)"
     assert %UndefinedFunctionError{module: nil, function: :bar, arity: 0} |> message ==
@@ -342,7 +342,7 @@ defmodule ExceptionTest do
   test "function clause message" do
     assert %FunctionClauseError{} |> message ==
            "no function clause matches"
-    assert %FunctionClauseError{module: Foo, function: :bar, arity: 1} |> message ==
+    assert %FunctionClauseError{module: Foo, function: :bar, arity: 1} |> message =~
            "no function clause matching in Foo.bar/1"
   end
 

--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -222,7 +222,7 @@ defmodule IEx.Autocomplete do
     end
   end
 
-  defp get_modules_from_applications do
+  def get_modules_from_applications do
     for [app] <- loaded_applications(),
         {:ok, modules} = :application.get_key(app, :modules),
         module <- modules do

--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -222,7 +222,7 @@ defmodule IEx.Autocomplete do
     end
   end
 
-  def get_modules_from_applications do
+  defp get_modules_from_applications do
     for [app] <- loaded_applications(),
         {:ok, modules} = :application.get_key(app, :modules),
         module <- modules do

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -46,7 +46,7 @@ defmodule IEx.AutocompleteTest do
     assert expand('Str') == {:yes, [], ['Stream', 'String', 'StringIO']}
     assert expand('Ma') == {:yes, '', ['Macro', 'Map', 'MapSet', 'MatchError']}
     assert expand('Dic') == {:yes, 't.', []}
-    assert expand('Ex')  == {:yes, [], ['ExUnit', 'Exception']}
+    assert expand('Ex')  == {:yes, [], ['ExUnit', 'Exception', 'ExceptionHelpers']}
   end
 
   test "elixir no completion" do


### PR DESCRIPTION
When compile fails due to use of an undefined function, attempt to help the user by showing what they may have intended.

Checks for arity mistakes (function name exists but called with wrong argument count), and looks for modules/functions with a similar name that may have been mistyped.


I hope to add further compiler changes with similar intentions of helping the user.