### PR TITLE
Fix the description of the timeout

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -123,7 +123,7 @@ defmodule ExUnit.Case do
 
     * `:capture_log` - see the "Log Capture" section below
     * `:skip` - skips the test with the given reason
-    * `:timeout` - customizes the test timeout in milliseconds (defaults to 30000)
+    * `:timeout` - customizes the test timeout in milliseconds (defaults to 60000)
     * `:report` - include the given tags on error reports, see the "Reporting tags" section
 
   ### Reporting tags


### PR DESCRIPTION
Default timeout is 60000 milliseconds.

```elixir
# File: /tmp/timeout_test.exs
ExUnit.start

defmodule TimeoutTest do
  use ExUnit.Case, async: true

  test "timeout" do; :timer.sleep 100_000 end
end
```

```bash
$ elixir /tmp/timeout_test.exs


  1) test timeout (TimeoutTest)
     /tmp/timeout_test.exs:6
     ** (ExUnit.TimeoutError) test timed out after 60000ms. You can change the timeout:

       1. per test by setting "@tag timeout: x"
       2. per case by setting "@moduletag timeout: x"
       3. globally via "ExUnit.start(timeout: x)" configuration
       4. or set it to infinity per run by calling "mix test --trace"
          (useful when using IEx.pry)

     Timeouts are given as integers in milliseconds.

     stacktrace:
       (stdlib) timer.erl:153: :timer.sleep/1
       /tmp/timeout_test.exs:6
       (ex_unit) lib/ex_unit/runner.ex:293: ExUnit.Runner.exec_test/1
       (stdlib) timer.erl:166: :timer.tc/1
       (ex_unit) lib/ex_unit/runner.ex:242: anonymous fn/3 in ExUnit.Runner.spawn_test/3



Finished in 60.0 seconds (0.08s on load, 60.0s on tests)
1 test, 1 failure

Randomized with seed 801571
```
