### PR TITLE
Remove duplicate line in module IEx.Helpers doc

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -42,7 +42,6 @@ defmodule IEx.Helpers do
     * `t/1`           — prints type information
     * `v/0`           — retrieves the last value from the history
     * `v/1`           — retrieves the nth value from the history
-    * `import_file/1` — evaluates the given file in the shell's context
 
   Help for all of those functions can be consulted directly from
   the command line using the `h` helper itself. Try:


### PR DESCRIPTION
If in `iex`(elixir `1.2.0`) we list the available helpers by executing `h()`, we get the following list:

<img width="952" alt="screen shot 2016-01-09 at 19 46 50" src="https://cloud.githubusercontent.com/assets/4209616/12217806/34e62fba-b70c-11e5-91fd-3e605a03cbe1.png">

As shown in the picture, there are two identical items in the list.

This PR removes the second duplication, that happens to be the last item, not following the alphabetic sorting.
