### PR TITLE
Improve iex expand to handle '&'.

### DIFF
--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -57,10 +57,13 @@ defmodule IEx.Autocomplete do
   end
 
   defp reduce(expr) do
-    Enum.reverse Enum.reduce ' ([{', expr, fn token, acc ->
+    Enum.reduce(' ([{', expr, fn token, acc ->
       hd(:string.tokens(acc, [token]))
-    end
+    end) |> Enum.reverse |> strip_ampersand
   end
+
+  defp strip_ampersand([?&|t]), do: t
+  defp strip_ampersand(expr), do: expr
 
   defp yes(hint, entries) do
     {:yes, String.to_char_list(hint), Enum.map(entries, &String.to_char_list/1)}

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -107,6 +107,12 @@ defmodule IEx.AutocompleteTest do
     assert expand('{:zl') == {:yes, 'ib.', []}
   end
 
+  test "ampersand completion" do
+    assert expand('&Enu') == {:yes, 'm', []}
+    assert expand('&Enum.a') == {:yes, [], ['all?/2', 'any?/2', 'at/3']}
+    assert expand('f = &Enum.a') == {:yes, [], ['all?/2', 'any?/2', 'at/3']}
+  end
+
   defmodule SublevelTest.LevelA.LevelB do
   end
 


### PR DESCRIPTION
I made a small improvement in Iex `expand` to handle cases where an expression starts with `&`.

For example

```elixir
Enum.map ~w(foo bar baz), &Str
```

did not yield any completion when pressing tab.
With this fix, it ignores the `&` to yield usual completions.

