### PR TITLE
Avoid config_test to depend on terminal size

### DIFF
--- a/lib/iex/test/iex/config_test.exs
+++ b/lib/iex/test/iex/config_test.exs
@@ -4,6 +4,6 @@ defmodule IEx.ConfigTest do
   use ExUnit.Case, async: true
 
   test "configuration sets a default for width" do
-    assert IEx.Config.configuration[:width] == 80
+    assert is_integer(IEx.Config.configuration[:width])
   end
 end


### PR DESCRIPTION
`config_test` fails if my terminal is less than 80 chars wide.

```
$ make test_iex
==> elixir (compile)
==> iex (exunit)


  1) test configuration sets a default for width (IEx.ConfigTest)
     test/iex/config_test.exs:6
     Assertion with == failed
     code: IEx.Config.configuration()[:width] == 80
     lhs:  61
     rhs:  80
     stacktrace:
       test/iex/config_test.exs:7

....................................................................................................

Finished in 1.4 seconds (0.5s on load, 0.8s on tests)
101 tests, 1 failure

Randomized with seed 298890
Makefile:95: recipe for target 'test_iex' failed
make: *** [test_iex] Error 1
```

While it is not really a big issue, simply checking for an integer should be enough here and avoid to depend on the terminal being more than 80 chars.