### PR TITLE
Update example code to use correct method name

### DIFF
--- a/lib/mix/lib/mix/config.ex
+++ b/lib/mix/lib/mix/config.ex
@@ -26,7 +26,7 @@ defmodule Mix.Config do
   For example, the `:key1` value from application `:plug` (see above) can be
   retrieved with:
 
-      "value1" = Application.fetch!(:plug, :key1)
+      "value1" = Application.fetch_env!(:plug, :key1)
 
   """
 


### PR DESCRIPTION
*   The example code is using the old name of
    `Application.fetch!/2`, change to the new, more clear name:
    `Application.fetch_env!/2`.