### PR TITLE
Correct the type definition of ExUnit.state for the failed state

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -58,7 +58,7 @@ defmodule ExUnit do
 
   @typedoc "The error state returned by ExUnit.Test and ExUnit.TestCase"
   @type state  :: nil | {:failed, failed} | {:skip, binary} | {:invalid, module}
-  @type failed :: {Exception.kind, reason :: term, stacktrace :: [tuple]}
+  @type failed :: [{Exception.kind, reason :: term, stacktrace :: [tuple]}]
 
   defmodule Test do
     @moduledoc """


### PR DESCRIPTION
The new payload returned by the ExUnit.Runner module for the failed state does not match its type specification declared in ExUnit module since Elixir 1.2.0.

https://github.com/elixir-lang/elixir/blob/v1.2.0/lib/ex_unit/lib/ex_unit/runner.ex#L353

This fix change the type definition to support multiple errors.