### PR TITLE
Fix a typo in `for/1` docs

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1310,7 +1310,7 @@ defmodule Kernel.SpecialForms do
       ...>   do: {:ok, width * height}
       :error
 
-  Similarly to `for`/1, variables bound inside `with/1` won't leak,
+  Similarly to `for/1`, variables bound inside `with/1` won't leak,
   and also it allows "bare expressions":
 
       iex> width = nil


### PR DESCRIPTION
Hello.
I've noticed wrong formatting in the docs.

![screen shot 2016-01-12 at 10 28 08](https://cloud.githubusercontent.com/assets/1541059/12259715/e3953aa8-b917-11e5-8e86-5cee2709e6a7.png)
