### PR TITLE
Update exunit match operator and match? to show pinned variables.

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -97,6 +97,7 @@ defmodule ExUnit.Assertions do
 
     left = Macro.expand(left, __CALLER__)
     vars = collect_vars_from_pattern(left)
+    pins = collect_pins_from_pattern(left)
 
     # If the match works, we need to check if the value
     # is not nil nor false. We need to rewrite the if
@@ -124,7 +125,8 @@ defmodule ExUnit.Assertions do
             raise ExUnit.AssertionError,
               right: right,
               expr: expr,
-              message: "match (=) failed"
+              message: "match (=) failed" <>
+                       ExUnit.Assertions.__pins__(unquote(pins))
         end
       right
     end
@@ -133,12 +135,15 @@ defmodule ExUnit.Assertions do
   defmacro assert({:match?, meta, [left, right]} = assertion) do
     code   = Macro.escape(assertion)
     match? = {:match?, meta, [left, Macro.var(:right, __MODULE__)]}
+    pins   = collect_pins_from_pattern(left)
+
     quote do
       right = unquote(right)
       assert unquote(match?),
         right: right,
         expr: unquote(code),
-        message: "match (match?) failed"
+        message: "match (match?) failed" <>
+                 ExUnit.Assertions.__pins__(unquote(pins))
     end
   end
 
@@ -186,12 +191,15 @@ defmodule ExUnit.Assertions do
   defmacro refute({:match?, meta, [left, right]} = assertion) do
     code   = Macro.escape(assertion)
     match? = {:match?, meta, [left, Macro.var(:right, __MODULE__)]}
+    pins   = collect_pins_from_pattern(left)
+
     quote do
       right = unquote(right)
       refute unquote(match?),
         right: right,
         expr: unquote(code),
-        message: "match (match?) succeeded, but should have failed"
+        message: "match (match?) succeeded, but should have failed" <>
+                 ExUnit.Assertions.__pins__(unquote(pins))
     end
   end
 

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -85,6 +85,21 @@ defmodule ExUnit.AssertionsTest do
     {2, 1} = (assert {2, 1} = Value.tuple)
   end
 
+  test "assert match with pinned variable" do
+    a = 1
+    {2, 1} = (assert {2, ^a} = Value.tuple)
+
+    try do
+      assert {^a, 1} = Value.tuple
+    rescue
+      error in [ExUnit.AssertionError] ->
+        "match (=) failed\n" <>
+        "The following variables were pinned:\n" <>
+        "  a = 1" = error.message
+        "{^a, 1} = Value.tuple()" = Macro.to_string(error.expr)
+    end
+  end
+
   test "assert match?" do
     true = assert match?({2, 1}, Value.tuple)
 
@@ -108,6 +123,32 @@ defmodule ExUnit.AssertionsTest do
         "match (match?) succeeded, but should have failed" = error.message
         "match?({:error, _}, error(true))" = Macro.to_string(error.expr)
         "{:error, true}" = Macro.to_string(error.right)
+    end
+  end
+
+  test "assert match? with pinned variable" do
+    a = 1
+    try do
+      "This should never be tested" = assert(match?({^a, 1}, Value.tuple))
+    rescue
+      error in [ExUnit.AssertionError] ->
+        "match (match?) failed\n" <>
+        "The following variables were pinned:\n" <>
+        "  a = 1" = error.message
+        "match?({^a, 1}, Value.tuple())" = Macro.to_string(error.expr)
+    end
+  end
+
+  test "refute match? with pinned variable" do
+    a = 2
+    try do
+      "This should never be tested" = refute(match?({^a, 1}, Value.tuple))
+    rescue
+      error in [ExUnit.AssertionError] ->
+        "match (match?) succeeded, but should have failed\n" <>
+        "The following variables were pinned:\n" <>
+        "  a = 2" = error.message
+        "match?({^a, 1}, Value.tuple())" = Macro.to_string(error.expr)
     end
   end
 


### PR DESCRIPTION
I reused the logic used in `assert_received` to show the pinned variables when using the match operator and `match?`.