### PR TITLE
Update doc to use the correct format

### DIFF
--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -179,7 +179,7 @@ defmodule Record do
 
   ## Defining extracted records with anonymous functions
 
-  If a record defines an anonymous function, an ArgumentError
+  If a record defines an anonymous function, an `ArgumentError`
   will occur if you attempt to create a record with it.
   This can occur unintentionally when defining a record after extracting
   it from an Erlang library that uses anonymous functions for defaults.


### PR DESCRIPTION
Hi,

I like to read the docs through the source code and the markup helps to identify what is code and what is text. I noticed that in `ArgumentError` wasn't formatted like all other places over the doc.