### PR TITLE
Fix a crash in Macro.to_string if a tree looks like a sigil but the function is not an atom

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -696,7 +696,7 @@ defmodule Macro do
   defp module_to_string(atom, _fun) when is_atom(atom), do: inspect(atom, [])
   defp module_to_string(other, fun), do: call_to_string(other, fun)
 
-  defp sigil_call({func, _, [{:<<>>, _, _} = bin, args]} = ast, fun) when is_list(args) do
+  defp sigil_call({func, _, [{:<<>>, _, _} = bin, args]} = ast, fun) when is_atom(func) and is_list(args) do
     sigil =
       case Atom.to_string(func) do
         <<"sigil_", name>> ->

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -290,6 +290,8 @@ defmodule MacroTest do
     assert Macro.to_string(quote do: ~R"123") == ~s/~R"123"/
     assert Macro.to_string(quote do: ~R"123"u) == ~s/~R"123"u/
     assert Macro.to_string(quote do: ~R"\n123") == ~s/~R"\\\\n123"/
+
+    assert Macro.to_string(quote do: Foo.bar(<<>>, [])) == "Foo.bar(<<>>, [])"
   end
 
   test "arrow to string" do


### PR DESCRIPTION
Fixes the following problem (reproduced in 1.2.0 and at head)

```
iex(1)> ast = quote do: :erlang.max(<<>>, [])
{{:., [], [:erlang, :max]}, [], [{:<<>>, [], []}, []]}
iex(2)> Macro.to_string(ast)
** (ArgumentError) argument error
             :erlang.atom_to_binary({:., [], [:erlang, :max]}, :utf8)
    (elixir) lib/macro.ex:696: Macro.sigil_call/2
    (elixir) lib/macro.ex:600: Macro.to_string/2
```
