### PR TITLE
Add defdelegate optional parameters. Close #4196.

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3711,14 +3711,14 @@ defmodule Kernel do
       target = Keyword.get(opts, :to) ||
         raise ArgumentError, "expected to: to be given as argument"
 
-      for fun <- List.wrap(funs) do
-        {name, args, as, as_args} = Kernel.Utils.defdelegate(fun, opts)
-        unless Module.get_attribute(__MODULE__, :doc) do
-          @doc "See `#{inspect target}.#{as}/#{:erlang.length as_args}`."
-        end
-        def unquote(name)(unquote_splicing(args)) do
-          unquote(target).unquote(as)(unquote_splicing(as_args))
-        end
+      for fun <- List.wrap(funs),
+        {name, args, as, as_args} <- Kernel.Utils.defdelegate(fun, opts) do
+          unless Module.get_attribute(__MODULE__, :doc) do
+            @doc "See `#{inspect target}.#{as}/#{:erlang.length args}`."
+          end
+          def unquote(name)(unquote_splicing(args)) do
+            unquote(target).unquote(as)(unquote_splicing(as_args))
+          end
       end
     end
   end


### PR DESCRIPTION
As discussed in #4196, I added the possibility to pass optional parameters to `defdelegate`.
It works by generating all the possible heads for the function, and passing the optional arguments to the delegated function in the body.

```elixir
defdelegate fun(arg1, arg2 \\ []), to: Mod
# will generate more or less
def fun(arg1), do: Mod.fun(arg1, [])
def fun(arg1, arg2), do: Mod.fun(arg1, arg2)
```