### PR TITLE
Add deprecation for defdelegate list arguments and append_first option

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3711,6 +3711,17 @@ defmodule Kernel do
       target = Keyword.get(opts, :to) ||
         raise ArgumentError, "expected to: to be given as argument"
 
+      %{file: file, line: line} = __ENV__
+      if is_list(funs) do
+        :elixir_errors.warn(line, file,"passing a list to Kernel.defdelegate/2 is deprecated, " <>
+                                       "please define each delegate separately\n")
+      end
+
+      if Keyword.has_key?(opts, :append_first) do
+        :elixir_errors.warn(line, file, "Kernel.defdelegate/2 append_first " <>
+                                        "option is deprecated.\n")
+      end
+
       for fun <- List.wrap(funs),
         {name, args, as, as_args} <- Kernel.Utils.defdelegate(fun, opts) do
           unless Module.get_attribute(__MODULE__, :doc) do


### PR DESCRIPTION
As discussed in #4199, I added a deprecation warning for `defdelegate` with lists and `append_first` option.

Would it be better to remove the examples from the doc, or should they stay until these features are actually removed?

/cc @josevalim @lexmag 