### PR TITLE
Limit capture parameter to 128 to avoid compile bug. Fix #4213.

### DIFF
--- a/lib/elixir/src/elixir_fn.erl
+++ b/lib/elixir/src/elixir_fn.erl
@@ -128,7 +128,7 @@ validate(Meta, [{Pos, _}|_], Expected, E) ->
 validate(_Meta, [], _Pos, _E) ->
   [].
 
-do_escape({'&', _, [Pos]}, Counter, _E, Dict) when is_integer(Pos), Pos > 0 ->
+do_escape({'&', _, [Pos]}, Counter, _E, Dict) when is_integer(Pos), Pos > 0, Pos =< 128 ->
   Var = {list_to_atom([$x, $@+Pos]), [{counter, Counter}], elixir_fn},
   {Var, orddict:store(Pos, Var, Dict)};
 

--- a/lib/elixir/test/elixir/kernel/fn_test.exs
+++ b/lib/elixir/test/elixir/kernel/fn_test.exs
@@ -127,6 +127,7 @@ defmodule Kernel.FnTest do
   test "failure on integers" do
     assert_compile_fail CompileError, "nofile:1: unhandled &1 outside of a capture", "&1"
     assert_compile_fail CompileError, "nofile:1: capture &0 is not allowed", "&foo(&0)"
+    assert_compile_fail CompileError, "nofile:1: capture &129 is not allowed", "&foo(&129)"
   end
 
   test "failure on block" do


### PR DESCRIPTION
I limited the capture argument to 128, as it seemed to be an issue with arguments `>= 192`.
I do not think it would be very useful to add a more explicit error message for this case,
but let me know if you think it would.