### PR TITLE
Support passing io_device to File.copy/3

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -748,8 +748,8 @@ defmodule File.CopyError do
   def message(exception) do
     formatted = IO.iodata_to_binary(:file.format_error(exception.reason))
     location  = if on = exception.on, do: ". #{on}", else: ""
-    "could not #{exception.action} from #{exception.source} to " <>
-      "#{exception.destination}#{location}: #{formatted}"
+    "could not #{exception.action} from #{inspect(exception.source)} to " <>
+    "#{inspect(exception.destination)}#{location}: #{formatted}"
   end
 end
 

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -430,22 +430,23 @@ defmodule File do
   Typical error reasons are the same as in `open/2`,
   `read/1` and `write/3`.
   """
-  @spec copy(Path.t, Path.t, pos_integer | :infinity) :: {:ok, non_neg_integer} | {:error, posix}
+  @spec copy(Path.t | io_device, Path.t | io_device, pos_integer | :infinity) :: {:ok, non_neg_integer} | {:error, posix}
   def copy(source, destination, bytes_count \\ :infinity) do
-    F.copy(IO.chardata_to_string(source), IO.chardata_to_string(destination), bytes_count)
+    F.copy(maybe_to_string(source), maybe_to_string(destination), bytes_count)
   end
 
   @doc """
   The same as `copy/3` but raises an `File.CopyError` if it fails.
   Returns the `bytes_copied` otherwise.
   """
-  @spec copy!(Path.t, Path.t, pos_integer | :infinity) :: non_neg_integer | no_return
+  @spec copy!(Path.t | io_device, Path.t | io_device, pos_integer | :infinity) :: non_neg_integer | no_return
   def copy!(source, destination, bytes_count \\ :infinity) do
     case copy(source, destination, bytes_count) do
       {:ok, bytes_count} -> bytes_count
       {:error, reason} ->
         raise File.CopyError, reason: reason, action: "copy",
-          source: IO.chardata_to_string(source), destination: IO.chardata_to_string(destination)
+          source: maybe_to_string(source),
+          destination: maybe_to_string(destination)
     end
   end
 
@@ -1335,4 +1336,9 @@ defmodule File do
 
   defp open_defaults([], true),  do: [:binary]
   defp open_defaults([], false), do: []
+
+  defp maybe_to_string(path) when is_pid(path),
+    do: path
+  defp maybe_to_string(path),
+    do: IO.chardata_to_string(path)
 end

--- a/lib/elixir/test/elixir/file_test.exs
+++ b/lib/elixir/test/elixir/file_test.exs
@@ -441,8 +441,8 @@ defmodule FileTest do
     test "cp! with src dir" do
       src   = fixture_path("cp_r")
       dest  = tmp_path("tmp.file")
-      assert_raise File.CopyError, "could not copy from #{src} to #{dest}: " <>
-          "illegal operation on a directory", fn ->
+      assert_raise File.CopyError, "could not copy from #{inspect(src)} " <>
+          "to #{inspect(dest)}: illegal operation on a directory", fn ->
         File.cp!(src, dest)
       end
     end
@@ -660,7 +660,7 @@ defmodule FileTest do
     test "cp_r with src_unknown!" do
       src  = fixture_path("unknown")
       dest = tmp_path("tmp")
-      assert_raise File.CopyError, "could not copy recursively from #{src} to #{dest}. #{src}: no such file or directory", fn ->
+      assert_raise File.CopyError, "could not copy recursively from #{inspect(src)} to #{inspect(dest)}. #{src}: no such file or directory", fn ->
         File.cp_r!(src, dest)
       end
     end
@@ -1429,6 +1429,19 @@ defmodule FileTest do
     end
   end
 
+  test "copy with an io_device" do
+    {:ok, src} = File.open(fixture_path("file.txt"))
+    dest = tmp_path("tmp_test.txt")
+    try do
+      refute File.exists?(dest)
+      assert File.copy(src, dest) == {:ok, 4}
+      assert File.read(dest) == {:ok, "FOO\n"}
+    after
+      File.close(src)
+      File.rm(dest)
+    end
+  end
+
   test "copy with bytes count" do
     src  = fixture_path("file.txt")
     dest = tmp_path("tmp_test.txt")
@@ -1474,7 +1487,7 @@ defmodule FileTest do
   test "copy! with invalid file" do
     src  = fixture_path("invalid.txt")
     dest = tmp_path("tmp_test.txt")
-    assert_raise File.CopyError, "could not copy from #{src} to #{dest}: no such file or directory", fn ->
+    assert_raise File.CopyError, "could not copy from #{inspect(src)} to #{inspect(dest)}: no such file or directory", fn ->
       File.copy!(src, dest, 2)
     end
   end


### PR DESCRIPTION
Technically it is possible to pass an io_device to File.copy/3 as either the source, destination, or both. However, all input was being converted to a string, which fails for any non-binary data and prevents `:file.copy` from being reached.

This updates the typespec and conditionally converts chardata to a string.