### PR TITLE
Remove minor ambiguity in Enum.sort/2 doc

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1891,8 +1891,8 @@ defmodule Enum do
   @doc """
   Sorts the enumerable by the given function.
 
-  This function uses the merge sort algorithm. The given function
-  must return `false` if the first argument is smaller than second one.
+  This function uses the merge sort algorithm. The given function should compare
+  two arguments, and return `false` if the first argument follows the second one.
 
   ## Examples
 


### PR DESCRIPTION
> The given function must return false if the first argument is smaller than second one.

could be misunderstood as "the function should return false if the _literal_ value of first argument is smaller than the second". This is resolved with the examples, but it would be more eloquent just to explain it in the function description.