### PR TITLE
Update base.ex doc

### DIFF
--- a/lib/elixir/lib/base.ex
+++ b/lib/elixir/lib/base.ex
@@ -255,8 +255,6 @@ defmodule Base do
   @doc """
   Decodes a base 64 encoded string into a binary string.
 
-  The following alphabet is used both for encoding and decoding:
-
   An `ArgumentError` exception is raised if the padding is incorrect or
   a non-alphabet character is present in the string.
 


### PR DESCRIPTION
Clean up base64 doc, probably left from previous docstring. Alphabets are presented in module doc.