### PR TITLE
Stream.resource/3 @doc and @spec change

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1054,7 +1054,7 @@ defmodule Stream do
   @doc """
   Emits a sequence of values for the given resource.
 
-  Similar to `transform/2` but the initial accumulated value is
+  Similar to `transform/3` but the initial accumulated value is
   computed lazily via `start_fun` and executes an `after_fun` at
   the end of enumeration (both in cases of success and failure).
 
@@ -1079,7 +1079,7 @@ defmodule Stream do
                       fn file -> File.close(file) end)
 
   """
-  @spec resource((() -> acc), (acc -> {element, acc} | nil), (acc -> term)) :: Enumerable.t
+  @spec resource((() -> acc), (acc -> {element, acc} | {:halt, acc}), (acc -> term)) :: Enumerable.t
   def resource(start_fun, next_fun, after_fun) do
     &do_resource(start_fun.(), next_fun, &1, &2, after_fun)
   end


### PR DESCRIPTION
@doc change: there is no Stream.transform/2 and Stream.transform/4's
initial accumulated value is also computed lazily so the doc in
Stream.resource/3 must be referring to Stream.transform/3.

@spec change: I tried the example in Stream.resource/3 to use `nil`
instead of `{:halt, acc}`, as currently specified by the spec, and got:

** (CaseClauseError) no case clause matching: nil
    (elixir) lib/stream.ex:1099: Stream.do_resource/5
    (elixir) lib/enum.ex:1486: Enum.reduce/3
    (elixir) lib/enum.ex:2248: Enum.to_list/1

Besides, the doc and spec don't match (and the doc seems to be correct,
so I changed the spec).