### PR TITLE
Add test attributes

### DIFF
--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -2,6 +2,9 @@ Code.require_file "../test_helper.exs", __DIR__
 
 defmodule ExUnit.CaseTest do
   use ExUnit.Case, async: true
+  ExUnit.Case.register_attribute __MODULE__, :foo
+  ExUnit.Case.register_attribute __MODULE__, :bar
+  ExUnit.Case.register_attribute __MODULE__, :baz
 
   @moduletag :moduletag
 
@@ -37,4 +40,14 @@ defmodule ExUnit.CaseTest do
   test "module tags can be overridden", context do
     assert context[:moduletag] == :overridden
   end
+
+  @foo :hello
+  @bar :world
+  test "collects the declared test attributes and nests them into the context", context do
+    assert context.registered.foo == :hello
+    assert context.registered.bar == :world
+  end
+
+  @foo false
+  @bar false
 end


### PR DESCRIPTION
See #4232 

ExUnit.Case can register test attributes which are
accumulated per test run and injected into the `context.private` under the
attribute name:

```elixir
defmodule MyTest do
  use ExUnit.Case
  ExUnit.Case.register_attribute __MODULE__, :foo

  @foo hello: "world"
  test "can access @foo via `context`", context do
    assert context.private.foo.hello == "world"
  end
end
```