### PR TITLE
Add option to ignore whitespace to base64 decoding. Close #4186.

### DIFF
--- a/lib/elixir/lib/base.ex
+++ b/lib/elixir/lib/base.ex
@@ -246,8 +246,9 @@ defmodule Base do
 
   """
   @spec decode64(binary) :: {:ok, binary} | :error
-  def decode64(string) when is_binary(string) do
-    {:ok, decode64!(string)}
+  @spec decode64(binary, Keyword.t) :: {:ok, binary} | :error
+  def decode64(string, opts \\ []) when is_binary(string) do
+    {:ok, decode64!(string, opts)}
   rescue
     ArgumentError -> :error
   end
@@ -265,12 +266,9 @@ defmodule Base do
 
   """
   @spec decode64!(binary) :: binary
-  def decode64!(string) when is_binary(string) and rem(byte_size(string), 4) == 0 do
-    do_decode64(string)
-  end
-
-  def decode64!(string) when is_binary(string) do
-    raise ArgumentError, "incorrect padding"
+  @spec decode64!(binary, Keyword.t) :: binary
+  def decode64!(string, opts \\ []) when is_binary(string) do
+    string |> filter_ignored(opts[:ignore]) |> do_decode64()
   end
 
   @doc """
@@ -299,8 +297,9 @@ defmodule Base do
 
   """
   @spec url_decode64(binary) :: {:ok, binary} | :error
-  def url_decode64(string) when is_binary(string) do
-    {:ok, url_decode64!(string)}
+  @spec url_decode64(binary, Keyword.t) :: {:ok, binary} | :error
+  def url_decode64(string, opts \\ []) when is_binary(string) do
+    {:ok, url_decode64!(string, opts)}
   rescue
     ArgumentError -> :error
   end
@@ -319,12 +318,9 @@ defmodule Base do
 
   """
   @spec url_decode64!(binary) :: binary
-  def url_decode64!(string) when is_binary(string) and rem(byte_size(string), 4) == 0 do
-    do_decode64url(string)
-  end
-
-  def url_decode64!(string) when is_binary(string) do
-    raise ArgumentError, "incorrect padding"
+  @spec url_decode64!(binary, Keyword.t) :: binary
+  def url_decode64!(string, opts \\ []) when is_binary(string)  do
+    string |> filter_ignored(opts[:ignore]) |> do_decode64url()
   end
 
   @doc """
@@ -498,6 +494,11 @@ defmodule Base do
     raise ArgumentError, "incorrect padding"
   end
 
+  defp filter_ignored(string, nil), do: string
+  defp filter_ignored(string, :whitespace) do
+    for <<c::8 <- string>>, not c in '\s\t\r\n', into: <<>>, do: <<c::8>>
+  end
+
   defp do_encode16(_, <<>>), do: <<>>
   defp do_encode16(:upper, data) do
     for <<c::4 <- data>>, into: <<>>, do: <<enc16(c)::8>>
@@ -539,7 +540,7 @@ defmodule Base do
   end
 
   defp do_decode64(<<>>), do: <<>>
-  defp do_decode64(string) do
+  defp do_decode64(string) when rem(byte_size(string), 4) == 0 do
     split = byte_size(string) - 4
     <<main::size(split)-binary, rest::binary>> = string
     main = for <<c::8 <- main>>, into: <<>>, do: <<dec64(c)::6>>
@@ -553,6 +554,9 @@ defmodule Base do
       <<>> ->
         main
     end
+  end
+  defp do_decode64(_) do
+    raise ArgumentError, "incorrect padding"
   end
 
   defp do_encode64url(<<>>), do: <<>>
@@ -571,7 +575,7 @@ defmodule Base do
   end
 
   defp do_decode64url(<<>>), do: <<>>
-  defp do_decode64url(string) do
+  defp do_decode64url(string) when rem(byte_size(string), 4) == 0 do
     split = byte_size(string) - 4
     <<main::size(split)-binary, rest::binary>> = string
     main = for <<c::8 <- main>>, into: <<>>, do: <<dec64url(c)::6>>
@@ -586,8 +590,9 @@ defmodule Base do
         main
     end
   end
-
-
+  defp do_decode64url(_) do
+    raise ArgumentError, "incorrect padding"
+  end
 
   defp do_encode32(_, <<>>), do: <<>>
 

--- a/lib/elixir/test/elixir/base_test.exs
+++ b/lib/elixir/test/elixir/base_test.exs
@@ -135,6 +135,18 @@ defmodule BaseTest do
     end
   end
 
+  test "decode64 whitespace" do
+    assert :error == decode64("\nQWxhZGRp bjpvcGVu\sIHNlc2Ft\t")
+    assert {:ok, "Aladdin:open sesam"} == decode64("\nQWxhZGRp bjpvcGVu\sIHNlc2Ft\t", ignore: :whitespace)
+  end
+
+  test "decode64! whitespace" do
+    assert_raise ArgumentError, "non-alphabet digit found: \"\\n\" (byte 10)", fn ->
+      decode64!("\nQWxhZGRp bjpvcGVu\sIHNlc2Ft\t")
+    end
+    assert "Aladdin:open sesam" == decode64!("\nQWxhZGRp bjpvcGVu\sIHNlc2Ft\t", ignore: :whitespace)
+  end
+
   test "decode64 incorrect padding" do
     assert :error == decode64("SGVsbG8gV29ybGQ")
   end
@@ -198,6 +210,19 @@ defmodule BaseTest do
   test "url_decode64! no pad" do
     assert "Aladdin:open sesam" == url_decode64!("QWxhZGRpbjpvcGVuIHNlc2Ft")
   end
+
+  test "url_decode64 whitespace" do
+    assert :error == url_decode64("\nQWxhZGRp bjpvcGVu\sIHNlc2Ft\t")
+    assert {:ok, "Aladdin:open sesam"} == url_decode64("\nQWxhZGRp bjpvcGVu\sIHNlc2Ft\t", ignore: :whitespace)
+  end
+
+  test "url_decode64! whitespace" do
+    assert_raise ArgumentError, "non-alphabet digit found: \"\\n\" (byte 10)", fn ->
+      url_decode64!("\nQWxhZGRp bjpvcGVu\sIHNlc2Ft\t")
+    end
+    assert "Aladdin:open sesam" == url_decode64!("\nQWxhZGRp bjpvcGVu\sIHNlc2Ft\t", ignore: :whitespace)
+  end
+
 
   test "url_decode64 non-alphabet digit" do
     assert :error == url_decode64("Zm9)")


### PR DESCRIPTION
As discussed in #4186, I added `ignore: :whitespace` option to `Base.decode64` and `Base.url_decode64`.