### PR TITLE
More helpful List.to_string/1 error

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -621,7 +621,19 @@ defmodule List do
        :unicode.characters_to_binary(list)
     rescue
       ArgumentError ->
-        raise ArgumentError, "cannot convert list to string. The list must contain only integers, strings or nested such lists; got: #{inspect list}"
+        raise ArgumentError, """
+        Cannot convert this list to a string.
+
+        `List.to_string/1` (which is also called, indirectly, when you interpolate a list into a string) only accepts so called chardata lists. Chardata lists represent a string as a list containing strings, integers representing Unicode codepoints, or nested such lists.
+
+        The list you provided is not a valid chardata list. This is your list:
+
+        #{inspect(list)}
+
+        If you wanted to show a representation of the list like the one just above, use `Kernel.inspect/2`. For example:
+
+        "… \#{inspect(the_list)} …"
+        """
     else
       result when is_binary(result) ->
         result

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -626,13 +626,11 @@ defmodule List do
 
         `List.to_string/1` (which is also called, indirectly, when you interpolate a list into a string) only accepts so called chardata lists. Chardata lists represent a string as a list containing strings, integers representing Unicode codepoints, or nested such lists.
 
-        The list you provided is not a valid chardata list. This is your list:
+        The list you provided is not a valid chardata list.
 
-        #{inspect(list)}
+        If you wanted a code-like representation of the list, use `Kernel.inspect/2`. For example:
 
-        If you wanted to show a representation of the list like the one just above, use `Kernel.inspect/2`. For example:
-
-        "… \#{inspect(the_list)} …"
+        "… \#{inspect([:a, :b])} …" # => "… [:a, :b] …"
         """
     else
       result when is_binary(result) ->

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -622,7 +622,7 @@ defmodule List do
     rescue
       ArgumentError ->
         raise ArgumentError, """
-        Cannot convert this list to a string.
+        cannot convert this list to a string.
 
         `List.to_string/1` (which is also called, indirectly, when you interpolate a list into a string) only accepts so called chardata lists. Chardata lists represent a string as a list containing strings, integers representing Unicode codepoints, or nested such lists.
 

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -624,13 +624,13 @@ defmodule List do
         raise ArgumentError, """
         cannot convert this list to a string.
 
-        `List.to_string/1` (which is also called, indirectly, when you interpolate a list into a string) only accepts so called chardata lists. Chardata lists represent a string as a list containing strings, integers representing Unicode codepoints, or nested such lists.
+        The only lists that can be directly converted into a string are so-called chardata lists. Those represent a string as a list of strings, integers representing Unicode codepoints, or nested such lists.
 
         The list you provided is not a valid chardata list.
 
-        If you wanted a code-like representation of the list, use `Kernel.inspect/2`. For example:
+        If you wanted a code-like string representation of the list, use `Kernel.inspect/2`. For example:
 
-        "… \#{inspect([:a, :b])} …" # => "… [:a, :b] …"
+        inspect([:a, :b]) # => "[:a, :b]"
         """
     else
       result when is_binary(result) ->

--- a/lib/elixir/lib/string/chars.ex
+++ b/lib/elixir/lib/string/chars.ex
@@ -41,7 +41,24 @@ defimpl String.Chars, for: BitString do
 end
 
 defimpl String.Chars, for: List do
-  def to_string(char_list), do: List.to_string(char_list)
+  def to_string(char_list) do
+    try do
+       List.to_string(char_list)
+    rescue
+      ArgumentError ->
+        raise ArgumentError, """
+        cannot convert this list to a string.
+
+        The only lists that can be directly converted into a string are so-called chardata lists. Those represent a string as a list of strings, integers representing Unicode codepoints, or nested such lists.
+
+        The list you provided is not a valid chardata list.
+
+        If you wanted a code-like string representation of the list, use `Kernel.inspect/2`. For example:
+
+        "… \#{inspect([:a, :b])} …" # => "… [:a, :b] …"
+        """
+    end
+  end
 end
 
 defimpl String.Chars, for: Integer do

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -164,7 +164,7 @@ defmodule ListTest do
     end
 
     assert_raise ArgumentError,
-                 ~r/Cannot convert this list to a string.*\[:a, :b\]/s, fn ->
+                 ~r/cannot convert this list to a string.*\[:a, :b\]/s, fn ->
       List.to_string([:a, :b])
     end
   end

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -164,7 +164,7 @@ defmodule ListTest do
     end
 
     assert_raise ArgumentError,
-                 ~r/cannot convert this list to a string.*\[:a, :b\]/s, fn ->
+                 ~r/cannot convert this list to a string/, fn ->
       List.to_string([:a, :b])
     end
   end

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -164,7 +164,7 @@ defmodule ListTest do
     end
 
     assert_raise ArgumentError,
-                 "cannot convert list to string. The list must contain only integers, strings or nested such lists; got: [:a, :b]", fn ->
+                 ~r/Cannot convert this list to a string.*\[:a, :b\]/s, fn ->
       List.to_string([:a, :b])
     end
   end

--- a/lib/elixir/test/elixir/string/chars_test.exs
+++ b/lib/elixir/test/elixir/string/chars_test.exs
@@ -87,6 +87,12 @@ defmodule String.Chars.ErrorsTest do
     end
   end
 
+  test "non-char list" do
+    assert_raise ArgumentError, ~r/cannot convert this list to a string.*#\{inspect/s, fn ->
+      to_string([:a, :b])
+    end
+  end
+
   test "tuple" do
     assert_raise Protocol.UndefinedError, "protocol String.Chars not implemented for {1, 2, 3}", fn ->
       to_string({1, 2, 3})


### PR DESCRIPTION
In #3865, we replaced a super-cryptic error with a more helpful one.

But I haven't quite been happy with it – I still imagine a beginner running into this issue for the first time, and being confused. We say what kind of list we expect, but not why. We don't suggest an alternative action. Perhaps we could be more helpful.

Inspired by Elm's human friendly error messages, this is one idea for how we could be super helpful. I'd love to see more error messages in this style in Elixir – I'm really looking forward to the discussion on this PR.

In that previous pull request, we [intentionally](https://github.com/elixir-lang/elixir/pull/3865#discussion_r41989115) did not mention `inspect`, because that might not be what the user wanted. But since this error message uses more words to make it clear that you *can* use `inspect` *if* you wanted a certain representation, I think it makes sense to include it. If we still think there is some assumption we shouldn't make, maybe we could try to solve that by making the text even more helpful, rather than by leaving out something that might help.

Would love to hear your thoughts on this.