### PR TITLE
add `preferred_cli_env` attribute to task definition

### DIFF
--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -100,11 +100,8 @@ defmodule Mix.CLI do
 
   defp preferred_cli_env(task) do
     task = String.to_atom(task)
-    Mix.Project.config[:preferred_cli_env][task] || default_cli_env(task)
+    Mix.Project.config[:preferred_cli_env][task] || Mix.Task.preferred_cli_env(task)
   end
-
-  defp default_cli_env(:test), do: :test
-  defp default_cli_env(_),     do: nil
 
   defp load_dot_config do
     path = Path.join(Mix.Utils.mix_home, "config.exs")

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -20,12 +20,14 @@ defmodule Mix.Task do
 
   ## Attributes
 
-  There are a couple attributes available in Mix tasks to
+  There are a few attributes available in Mix tasks to
   configure them in Mix:
 
     * `@shortdoc`  - makes the task public with a short description that appears
       on `mix help`
     * `@recursive` - run the task recursively in umbrella projects
+    * `@preferred_cli_env` - recommends environment to run task. It is used in absence of
+      mix project recommendation, or explicit MIX_ENV.
 
   ## Documentation
 
@@ -46,7 +48,7 @@ defmodule Mix.Task do
   @doc false
   defmacro __using__(_opts) do
     quote do
-      Enum.each [:shortdoc, :recursive],
+      Enum.each [:shortdoc, :recursive, :preferred_cli_env],
         &Module.register_attribute(__MODULE__, &1, persist: true)
       @behaviour Mix.Task
     end
@@ -140,6 +142,23 @@ defmodule Mix.Task do
     case List.keyfind module.__info__(:attributes), :recursive, 0 do
       {:recursive, [setting]} -> setting
       _ -> false
+    end
+  end
+
+  @doc """
+  Gets preferred cli environment for the task.
+
+  Returns environment (for example, `:test`, or `:prod`), or `nil`.
+  """
+  @spec preferred_cli_env(task_name) :: atom | nil
+  def preferred_cli_env(task) when is_atom(task) or is_binary(task) do
+    case get(task) do
+      nil -> nil
+      module ->
+        case List.keyfind module.__info__(:attributes), :preferred_cli_env, 0 do
+          {:preferred_cli_env, [setting]} -> setting
+          _ -> nil
+        end
     end
   end
 

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -29,6 +29,7 @@ defmodule Mix.Tasks.Test do
 
   @shortdoc "Runs a project's tests"
   @recursive true
+  @preferred_cli_env :test
 
   @moduledoc """
   Runs the tests for a project.

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -114,6 +114,33 @@ defmodule Mix.CLITest do
     System.delete_env("MIX_EXS")
   end
 
+  test "env config defaults to the tasks's preferred cli environment", context do
+    in_tmp context.test, fn ->
+      File.write! "custom.exs", """
+      defmodule P do
+        use Mix.Project
+        def project, do: [app: :p, version: "0.1.0"]
+      end
+
+      defmodule Mix.Tasks.TestTask do
+        use Mix.Task
+        @preferred_cli_env :prod
+
+        def run(args) do
+          IO.inspect {Mix.env, args}
+        end
+      end
+      """
+
+      System.put_env("MIX_EXS", "custom.exs")
+
+      output = mix ["test_task", "a", "b", "c"]
+      assert output =~ ~s({:prod, ["a", "b", "c"]})
+    end
+  after
+    System.delete_env("MIX_EXS")
+  end
+
   test "new with tests" do
     in_tmp "new_with_tests", fn ->
       output = mix ~w[new .]

--- a/lib/mix/test/mix/task_test.exs
+++ b/lib/mix/test/mix/task_test.exs
@@ -159,6 +159,18 @@ defmodule Mix.TaskTest do
     assert Mix.Task.moduledoc(Mix.Tasks.Hello) == "A test task.\n"
   end
 
+  test "preferred_cli_env/1 returns nil for missing task" do
+    assert Mix.Task.preferred_cli_env(:no_task) == nil
+  end
+
+  test "preferred_cli_env/1 returns nil when task does not have `preferred_cli_env` attribute" do
+    assert Mix.Task.preferred_cli_env(:deps) == nil
+  end
+
+  test "preferred_cli_env/1 returns specified `preferred_cli_env` attribute" do
+    assert Mix.Task.preferred_cli_env(:test) == :test
+  end
+
   test "shortdoc/1" do
     assert Mix.Task.shortdoc(Mix.Tasks.Hello) == "This is short documentation, see"
   end


### PR DESCRIPTION
If one develops a custom task, she might want it to run by default in particular environment, for example, `:prod`. 

She can do it by specifying `preferred_cli_env` in client mix file, but it means that every client should do it. OTOH, `preferred_cli_env` seems to be as natural attribute of the task, as `recursive`, or `shortdoc`. 

As a side effect, it would make `test` task less special (it would simply declare `:test` as a preferred environment).