### PR TITLE
delete_in

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -195,8 +195,10 @@ defmodule Access do
       :error -> nil
     end
 
-    {get, update} = fun.(current_value)
-    {get, :maps.put(key, update, map)}
+    case fun.(current_value) do
+      {:skip, _} -> {:ok, map}
+      {get, update} -> {get, :maps.put(key, update, map)}
+    end
   end
 
   def get_and_update(list, key, fun) when is_list(list) do
@@ -206,5 +208,18 @@ defmodule Access do
   def get_and_update(nil, key, _fun) do
     raise ArgumentError,
       "could not put/update key #{inspect key} on a nil value"
+  end
+
+  def delete(%{__struct__: struct} = container, key) do
+    struct.delete(container, key)
+  rescue
+    e in UndefinedFunctionError ->
+      raise_undefined_behaviour e, struct, {^struct, :delete, [^container, ^key], _}
+  end
+  def delete(%{} = map, key), do: :maps.remove(key, map)
+  def delete(list, key) when is_list(list), do: Keyword.delete(list, key)
+  def delete(nil, key) do
+    raise ArgumentError,
+      "could not delete key #{inspect key} on a nil value"
   end
 end

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1810,6 +1810,38 @@ defmodule Kernel do
     do: Access.get_and_update(data, h, &get_and_update_in(&1, t, fun))
 
   @doc """
+  Deletes a key in a nested structure.
+
+  Uses the `Access` protocol to traverse the structures
+  according to the given `keys`, unless the `key` is a
+  function. If the key is a function, it will be invoked
+  as specified in `get_and_update_in/3`.
+
+  ## Examples
+
+      iex> users = %{"john" => %{age: 27}, "meg" => %{age: 23}}
+      iex> delete_in(users, ["john", :age])
+      %{"john" => %{}, "meg" => %{age: 23}}
+
+  In case any entries in the middle returns `nil`,
+  the deletion will be considered a success.
+  """
+  @spec delete_in(Access.t, nonempty_list(term)) :: Access.t
+  def delete_in(data, keys) do
+    case do_delete_in(data, keys) do
+      {:skip, key} -> Access.delete(data, key)
+      {_, map} -> map
+    end
+  end
+
+  defp do_delete_in(nil, [h|_]),
+    do: {:skip, h}
+  defp do_delete_in(data, [h]),
+    do: {nil, Access.delete(data, h)}
+  defp do_delete_in(data, [h|t]),
+    do: Access.get_and_update(data, h, &do_delete_in(&1, t))
+
+  @doc """
   Puts a value in a nested structure via the given `path`.
 
   This is similar to `put_in/3`, except the path is extracted via
@@ -1842,6 +1874,43 @@ defmodule Kernel do
         nest_update_in(h, t, quote(do: fn _ -> unquote(value) end))
       {[h|t], false} ->
         expr = nest_get_and_update_in(h, t, quote(do: fn _ -> {nil, unquote(value)} end))
+        quote do: :erlang.element(2, unquote(expr))
+    end
+  end
+
+  @doc """
+  Deletes a key in a nested structure via the given `path`.
+
+  This is similar to `delete_in/2`, except the path is extracted via
+  a macro rather than passing a list. For example:
+
+      delete_in(opts[:foo][:bar])
+
+  Is equivalent to:
+
+      delete_in(opts, [:foo, :bar])
+
+  Note that in order for this macro to work, the complete path must always
+  be visible by this macro. For more information about the supported path
+  expressions, please check `get_and_update_in/2` docs.
+
+  ## Examples
+
+      iex> users = %{"john" => %{age: 27}, "meg" => %{age: 23}}
+      iex> delete_in(users["john"][:age])
+      %{"john" => %{}, "meg" => %{age: 23}}
+
+      iex> users = %{"john" => %{age: 27}, "meg" => %{age: 23}}
+      iex> delete_in(users["john"].age)
+      %{"john" => %{}, "meg" => %{age: 23}}
+
+  """
+  defmacro delete_in(path) do
+    case unnest(path, [], true, "delete_in/1") do
+      {[h|t], true} ->
+        nest_delete_in(h, t)
+      {[h|t], false} ->
+        expr = nest_delete_in_from_access(h, t)
         quote do: :erlang.element(2, unquote(expr))
     end
   end
@@ -1966,6 +2035,53 @@ defmodule Kernel do
   defp nest_get_and_update_in(h, [{:map, key}|t], fun) do
     quote do
       Map.get_and_update!(unquote(h), unquote(key), unquote(nest_get_and_update_in(t, fun)))
+    end
+  end
+
+  defp nest_delete_in(list) do
+    quote do
+      fn x -> unquote(nest_delete_in(quote(do: x), list)) end
+    end
+  end
+  defp nest_delete_in(h, [{:map, key}]) do
+    quote do
+      Map.delete(unquote(h), unquote(key))
+    end
+  end
+  defp nest_delete_in(h, [{:map, key}|t]) do
+    quote do
+      Map.update!(unquote(h), unquote(key), unquote(nest_delete_in(t)))
+    end
+  end
+
+  defp nest_delete_in_from_access(list) do
+    quote do
+      fn x -> unquote(nest_delete_in_from_access(quote(do: x), list)) end
+    end
+  end
+  defp nest_delete_in_from_access(h, [{:map, _key}]=list) do
+    {:ok, nest_delete_in(h, list)}
+  end
+  defp nest_delete_in_from_access(h, [{:access, key}]) do
+    quote do
+      case unquote(h) do
+        nil -> {:skip, nil}
+        h -> {:ok, Access.delete(h, unquote(key))}
+      end
+    end
+  end
+  defp nest_delete_in_from_access(nil=h, [{:access, key}|_]) do
+    quote do
+      Access.delete(unquote(h), unquote(key))
+    end
+  end
+  defp nest_delete_in_from_access(h, [{:access, key}|t]) do
+    quote do
+      Access.get_and_update(
+        unquote(h),
+        unquote(key),
+        unquote(nest_delete_in_from_access(t))
+      )
     end
   end
 

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -225,8 +225,10 @@ defmodule Keyword do
     do: get_and_update(t, [h|acc], key, fun)
 
   defp get_and_update([], acc, key, fun) do
-    {get, update} = fun.(nil)
-    {get, [{key, update}|:lists.reverse(acc)]}
+    case fun.(nil) do
+      {:skip, _} -> {:ok, acc}
+      {get, update} -> {get, [{key, update}|:lists.reverse(acc)]}
+    end
   end
 
   @doc """

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -26,6 +26,9 @@ defmodule AccessTest do
     assert_raise ArgumentError, "could not put/update key :foo on a nil value", fn ->
       Access.get_and_update(nil, :foo, fn nil -> {:ok, :bar} end)
     end
+    assert_raise ArgumentError, "could not delete key :foo on a nil value", fn ->
+      Access.delete(nil, :foo)
+    end
   end
 
   test "for keywords" do
@@ -44,6 +47,10 @@ defmodule AccessTest do
     assert Access.get([foo: :bar], :foo) == :bar
     assert Access.get_and_update([], :foo, fn nil -> {:ok, :baz} end) == {:ok, [foo: :baz]}
     assert Access.get_and_update([foo: :bar], :foo, fn :bar -> {:ok, :baz} end) == {:ok, [foo: :baz]}
+    assert Access.get_and_update([foo: :bar], :baz, fn nil -> {:skip, nil} end) == {:ok, [foo: :bar]}
+
+    assert Access.delete([foo: :bar], :foo) == []
+    assert Access.delete([], :foo) == []
   end
 
   test "for maps" do
@@ -58,6 +65,10 @@ defmodule AccessTest do
     assert Access.get(%{foo: :bar}, :foo) == :bar
     assert Access.get_and_update(%{}, :foo, fn nil -> {:ok, :baz} end) == {:ok, %{foo: :baz}}
     assert Access.get_and_update(%{foo: :bar}, :foo, fn :bar -> {:ok, :baz} end) == {:ok, %{foo: :baz}}
+    assert Access.get_and_update(%{foo: :bar}, :baz, fn nil -> {:skip, nil} end) == {:ok, %{foo: :bar}}
+
+    assert Access.delete(%{foo: :bar}, :foo) == %{}
+    assert Access.delete(%{}, :foo) == %{}
   end
 
   test "for struct" do
@@ -73,6 +84,11 @@ defmodule AccessTest do
     assert_raise UndefinedFunctionError,
                  "undefined function AccessTest.Sample.get_and_update/3 (AccessTest.Sample does not implement the Access behaviour)", fn ->
       Access.get_and_update(struct(Sample, []), :name, fn nil -> {:ok, :baz} end)
+    end
+
+    assert_raise UndefinedFunctionError,
+                "undefined function AccessTest.Sample.delete/2 (AccessTest.Sample does not implement the Access behaviour)", fn ->
+      Access.delete(struct(Sample, []), :name)
     end
   end
 end

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -388,6 +388,10 @@ defmodule KernelTest do
     assert_raise ArgumentError, "could not put/update key \"john\" on a nil value", fn ->
       update_in(nil, ["john", :age], fn _ -> %{} end)
     end
+
+    assert_raise UndefinedFunctionError, fn ->
+      delete_in(struct(Sample, []), [:name])
+    end
   end
 
   test "update_in/2" do
@@ -405,6 +409,10 @@ defmodule KernelTest do
 
     assert_raise KeyError, fn ->
       put_in(users["meg"].unknown, &(&1 + 1))
+    end
+
+    assert_raise UndefinedFunctionError, fn ->
+      delete_in(struct(Sample, []).name)
     end
   end
 
@@ -445,6 +453,46 @@ defmodule KernelTest do
 
     assert_raise KeyError, fn ->
       get_and_update_in(users["meg"].unknown, &{&1, &1 + 1})
+    end
+  end
+
+  test "delete_in/2" do
+    users = %{"john" => %{age: 27}, "meg" => %{age: 23}}
+
+    assert delete_in(users, ["john", :age]) ==
+           %{"john" => %{}, "meg" => %{age: 23}}
+
+    assert delete_in(users, ["bob", :age]) ==
+          %{"john" => %{age: 27}, "meg" => %{age: 23}}
+
+    assert delete_in([], [:foo, :bar]) == []
+
+    assert_raise FunctionClauseError, fn ->
+      delete_in(users, [])
+    end
+
+    assert_raise ArgumentError, "could not delete key \"john\" on a nil value", fn ->
+      delete_in(nil, ["john", :age])
+    end
+  end
+
+  test "delete_in/1" do
+    users = %{"john" => %{age: 27}, "meg" => %{age: 23}}
+
+    assert delete_in(users["john"][:age]) ==
+           %{"john" => %{}, "meg" => %{age: 23}}
+
+    assert delete_in(users["john"].age) ==
+           %{"john" => %{}, "meg" => %{age: 23}}
+
+    assert delete_in(users["bob"][:age]) ==
+          %{"john" => %{age: 27}, "meg" => %{age: 23}}
+
+    assert delete_in([][:foo][:bar]) == []
+
+
+    assert_raise ArgumentError, "could not delete key \"john\" on a nil value", fn ->
+      delete_in(nil["john"][:age])
     end
   end
 


### PR DESCRIPTION
Adds `Kernel.delete_in/2` and `Kernel.delete_in/1`

The two functions will delete the last key in either the key list or
path of a deeply nested object.