### PR TITLE
Make GenServer.cast/2 always return :ok. Closes #4251

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -570,16 +570,10 @@ defmodule GenServer do
   @doc """
   Sends an asynchronous request to the `server`.
 
-  This function returns `:ok` without waiting for the
-  destination `server` to handle the message. Therefore it
+  This function always returns `:ok` regardless of whether
+  the destination `server` (or node) exists. Therefore it
   is unknown whether the destination `server` successfully
-  handled the message. If the `server` is an atom without
-  an associated process an `ArgumentError` is raised. In
-  all other cases the function returns `:ok` regardless of
-  whether the destination `server` (or node) exists. Note
-  that `{name, node()}` can be used when an exception is
-  not desired if no process is locally associated with the
-  atom `name`.
+  handled the message.
 
   `handle_cast/2` will be called on the server to handle
   the request. In case the `server` is on a node which is
@@ -636,8 +630,12 @@ defmodule GenServer do
   end
 
   defp do_send(dest, msg) do
-    send(dest, msg)
-    :ok
+    try do
+      send(dest, msg)
+      :ok
+    catch
+      _, _ -> :ok
+    end
   end
 
   @doc """

--- a/lib/elixir/test/elixir/gen_server_test.exs
+++ b/lib/elixir/test/elixir/gen_server_test.exs
@@ -47,9 +47,7 @@ defmodule GenServerTest do
 
     assert GenServer.cast({:global, :foo}, {:push, :world}) == :ok
     assert GenServer.cast({:via, :foo, :bar}, {:push, :world}) == :ok
-    assert_raise ArgumentError, fn ->
-      GenServer.cast(:foo, {:push, :world})
-    end
+    assert GenServer.cast(:foo, {:push, :world}) == :ok
   end
 
   test "nil name" do


### PR DESCRIPTION
This unifies the behavior of `GenServer.cast/2` to always
return :ok and never raise an `ArgumentError`, regardless
of how it is called.

Previously an `ArgumentError` would be be raised only when
called with a nonexistant local process name. In all other cases
which are calling using `:global`, `:via` or `{name, node}`
it would previously always return `:ok`.

The new behavior is now constistant with `:gen_server.cast/2`.

This reverts the change partially introduced in 0d4af57abead1c4dfdc2f71fe198ae539f6eceab.

See #4251 for the full discussion.