### PR TITLE
Allow to omit test task name when running mix test for file

### DIFF
--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -43,6 +43,9 @@ defmodule Mix.CLI do
     exit({:shutdown, 1})
   end
 
+  defp get_task([testfile = "test/" <> _|t]) do
+    {"test", [testfile|t]}
+  end
   defp get_task([h|t]) do
     {h, t}
   end

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -151,6 +151,10 @@ defmodule Mix.CLITest do
       assert output =~ "1 test, 0 failures"
       assert output =~ "Generating cover results ..."
       assert File.regular?("cover/Elixir.NewWithTests.html")
+
+      output = mix ~w[test/new_with_tests_test.exs --cover]
+      assert output =~ "1 test, 0 failures"
+      assert output =~ "Generating cover results ..."
     end
   end
 


### PR DESCRIPTION
This allows you to run a specific test by

    $ mix test/myserver_test.exs

as a short form of

    $ mix test test/myserver_test.exs

This is something that I've run into from time to time and I feel it would be nice if mix would handle it for me.

