### PR TITLE
Fix warning in mix test.

### DIFF
--- a/lib/mix/test/mix/tasks/deps.tree_test.exs
+++ b/lib/mix/test/mix/tasks/deps.tree_test.exs
@@ -46,6 +46,8 @@ defmodule Mix.Tasks.Deps.TreeTest do
       assert_received {:mix_shell, :info, ["└── deps_on_git_repo 0.2.0 (" <> _]}
       assert_received {:mix_shell, :info, ["    └── git_repo (" <> _]}
     end
+  after
+    purge [DepsOnGitRepo.Mixfile, GitRepo.Mixfile]
   end
 
   test "show the dependency tree for umbrella apps" do


### PR DESCRIPTION
I got

```
mix.exs:2: warning: redefining module GitRepo.Mixfile (current version defined in memory)
```

when running the tests in master.
I used [@lexmag trick](https://github.com/elixir-lang/elixir/issues/3911#issuecomment-167453067) to find the culprit.