### PR TITLE
Fix wording in the docs for case and cond

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1489,7 +1489,7 @@ defmodule Kernel.SpecialForms do
   that matches.
 
   If no clause matches, an error is raised.
-  For this reason, it may be necessary to add a final clause, equal to `_`,
+  For this reason, it may be necessary to add a final catch-all clause (like `_`)
   which will always match.
 
       x = 10
@@ -1556,7 +1556,8 @@ defmodule Kernel.SpecialForms do
       #=> "1 is considered as true"
 
   Raises an error if all conditions evaluate to `nil` or `false`.
-  For this reason, it may be necessary to add a final condition, equal to `true`, which will always match.
+  For this reason, it may be necessary to add a final always-truthy condition
+  (anything non-`false` and non-`nil`), which will always match.
 
   ## Examples
 


### PR DESCRIPTION
The docs for `case` said to

> add a final clause, equal to `_`

as if only `_` would work; the docs now make it clearer that any catch-all clause is fine. Similar changes were made to the docs for `cond`.

(the previous phrasing was introduced in #4285, /cc @eksperimental who submitted that PR)