### PR TITLE
Fix "case" tag filtering doesn't work

### DIFF
--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -140,7 +140,7 @@ defmodule ExUnit.Runner do
     exclude = config.exclude
 
     for test <- tests do
-      tags = Map.put(test.tags, :test, test.name)
+      tags = Map.merge(test.tags, %{test: test.name, case: test.case})
       case ExUnit.Filters.eval(include, exclude, tags, tests) do
         :ok           -> %{test | tags: tags}
         {:error, msg} -> %{test | state: {:skip, msg}}

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -250,6 +250,31 @@ defmodule ExUnitTest do
     assert output =~ "2 tests, 0 failures, 2 skipped"
   end
 
+  test "filtering cases with :case tag" do
+    defmodule FirstTestCase do
+      use ExUnit.Case
+      test "ok", do: :ok
+    end
+
+    defmodule SecondTestCase do
+      use ExUnit.Case
+      test "false", do: assert false
+    end
+
+    test_cases = ExUnit.Server.start_run
+
+    {result, output} = run_with_filter([exclude: :case], test_cases)
+    assert result == %{failures: 0, skipped: 2, total: 2}
+    assert output =~ "2 tests, 0 failures, 2 skipped"
+
+    {result, output} =
+      [exclude: :test, include: [case: "ExUnitTest.SecondTestCase"]]
+      |> run_with_filter(test_cases)
+    assert result == %{failures: 1, skipped: 1, total: 2}
+    assert output =~ "1) test false (ExUnitTest.SecondTestCase)"
+    assert output =~ "2 tests, 1 failure, 1 skipped"
+  end
+
   test "raises on reserved tag in module" do
     assert_raise RuntimeError, "cannot set tag :file because it is reserved by ExUnit", fn ->
       defmodule ReservedTag do


### PR DESCRIPTION
It seem that the "case" tag doesn't work.

http://elixir-lang.org/docs/v1.2/ex_unit/ExUnit.Case.html:
> The following tags are set automatically by ExUnit and are therefore reserved:
>
> * :case - the test case module

For example, the following test:

```elixir
# File sample_test.exs
ExUnit.start
ExUnit.configure [exclude: :case]

defmodule SampleTest do
  use ExUnit.Case
  test "this is sample" do; :ok end
end
```

expected (skip all cases)
```
$ elixir sample_test.exs
Excluding tags: [:case]



Finished in 0.08 seconds (0.08s on load, 0.00s on tests)
1 test, 0 failures, 1 skipped
```

actual

```
$ elixir sample_test.exs
Excluding tags: [:case]

.

Finished in 0.07 seconds (0.07s on load, 0.00s on tests)
1 test, 0 failures
```