### PR TITLE
Improve Map.take/2

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -211,12 +211,13 @@ defmodule Map do
   """
   @spec take(map, [key]) :: map
   def take(map, keys) do
-    Enum.reduce(keys, new, fn key, acc ->
+    Enum.reduce(keys, [], fn key, acc ->
       case fetch(map, key) do
-        {:ok, value} -> put(acc, key, value)
+        {:ok, value} -> [{key, value} | acc]
         :error -> acc
       end
     end)
+    |> :maps.from_list
   end
 
   @doc """


### PR DESCRIPTION
Based on the discussion here: https://github.com/erlang/otp/pull/959 it was determined that building a list and then using :maps.from_list had superior performance characteristics, and would also generate less garbage