### PR TITLE
Add File.walk/3

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1314,6 +1314,40 @@ defmodule File do
     end
   end
 
+  @doc """
+  Walk the specified path recursively calling `callback` for each item found.
+
+  The `callback` will be called with the full path and the current accumulator.
+
+  The items will include the root path itself. The tree is walked directly as
+  it is visited by the function, leaving no guarantees of what happens if any
+  files or folders are changed while walking. This means you might receive
+  callbacks for paths that no longer exists, possibly with even a valid.
+
+  ## Examples
+
+      File.walk("/test/path", 0, fn(_path, count) -> count + 1 end)
+      #=> 19
+
+      File.walk("/home/user", [], &([&1|&2]))
+      #=> ["/home/user/Docs/todo.txt", "/home/user/Docs", "/home/user/.ssh"]
+
+  """
+  @spec walk(Path.t, any, (Path.t, any -> any)) :: any
+  def walk(path, acc, callback) do
+    acc = callback.(path, acc)
+    if File.dir?(path) do
+      case File.ls(path) do
+        {:ok, files} ->
+          Enum.reduce(files, acc, &(walk(Path.join(path, &1), &2, callback)))
+        other ->
+          acc
+      end
+    else
+      acc
+    end
+  end
+
   ## Helpers
 
   @read_ahead 64*1024

--- a/lib/elixir/test/elixir/file_test.exs
+++ b/lib/elixir/test/elixir/file_test.exs
@@ -1181,6 +1181,71 @@ defmodule FileTest do
     end
   end
 
+  defmodule Walk do
+    use Elixir.FileCase
+
+    @tree [
+      da: [
+        a: "content_a",
+        b: "content_b",
+      ],
+      db: [
+        c: "content_c",
+        dc: [
+          d: "content_d",
+        ],
+      ],
+    ]
+
+    test "error" do
+      fixture = fixture_path "non_existent"
+      assert {fixture, nil} == File.walk(fixture, nil, &({&1, &2}))
+    end
+
+    test "walk empty" do
+      fixture = tmp_path
+      assert [fixture] == File.walk(fixture, [], &([&1|&2]))
+    end
+
+    test "walk names" do
+      fixture = tmp_path
+      paths = create_tree(fixture, @tree)
+      assert paths == File.walk(fixture, [], &([&1|&2]))
+    end
+
+    test "walk count" do
+      fixture = tmp_path
+      paths = create_tree(fixture, @tree)
+      assert length(paths) == File.walk(fixture, 0, fn(_, acc) -> acc + 1 end)
+    end
+
+    test "walk" do
+      fixture = tmp_path
+      paths = create_tree(fixture, @tree)
+      count = %{directory: 4, regular: 4}
+      collect = fn(p, {paths, count}) ->
+        {[p|paths], Dict.update(count, File.stat!(p).type, 1, &(&1 + 1))}
+      end
+      assert {paths, count} == File.walk(fixture, {[], %{}}, collect)
+    end
+
+    defp create_tree(root, tree), do: create_tree(root, tree, [root])
+    defp create_tree(root, tree, names) when is_list(tree) do
+      Enum.reduce(tree, names, &(create_tree(root, &1, &2)))
+    end
+    defp create_tree(root, {name, contents}, names) do
+      path = Path.join(root, Atom.to_string(name))
+      if is_list(contents) do
+        File.mkdir!(path)
+        create_tree(path, contents, [path|names])
+      else
+        File.write!(path, contents)
+        [path|names]
+      end
+    end
+
+  end
+
   test "stat" do
     {:ok, info} = File.stat(__ENV__.file)
     assert info.mtime


### PR DESCRIPTION
Walk the specified path recursively calling `callback` for each item found.

The `callback` will be called with the full path and the current accumulator.

The items will include the root path itself. The tree is walked directly as
it is visited by the function, leaving no guarantees of what happens if any
files or folders are changed while walking. This means you might receive
callbacks for paths that no longer exists, possibly with even a valid.

## Examples

```elixir
File.walk("/test/path", 0, fn(_path, count) -> count + 1 end)
#=> 19

File.walk("/home/user", [], &([&1|&2]))
#=> ["/home/user/Docs/todo.txt", "/home/user/Docs", "/home/user/.ssh"]
```

## Ideas

This is a first pull request for a basic File.walk implementation. The inspiration was taken from Python's [`os.walk`](https://docs.python.org/2/library/os.html#os.walk) (if there's anything from there that is missing, I'd appreciate the feedback).

Future ideas:

* [ ] `only: :regular` or `only: :directory` option
* [ ] Optional accumulator like in `Enum.reduce/2` if possible