### PR TITLE
ExUnit: Show skipped tests as "S" and invalid in red in test output

### DIFF
--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -47,7 +47,11 @@ defmodule ExUnit.CLIFormatter do
   end
 
   def handle_event({:test_finished, %ExUnit.Test{state: {:skip, _}} = test}, config) do
-    if config.trace, do: IO.puts trace_test_skip(test)
+    if config.trace do
+      IO.puts skipped(trace_test_skip(test), config)
+    else
+      IO.write skipped("S", config)
+    end
     {:ok, %{config | tests_counter: config.tests_counter + 1,
                      skipped_counter: config.skipped_counter + 1}}
   end
@@ -145,6 +149,7 @@ defmodule ExUnit.CLIFormatter do
     cond do
       config.failures_counter > 0 -> IO.puts failure(message, config)
       config.invalids_counter > 0 -> IO.puts invalid(message, config)
+      config.skipped_counter  > 0 -> IO.puts skipped(message, config)
       true                        -> IO.puts success(message, config)
     end
 
@@ -186,8 +191,12 @@ defmodule ExUnit.CLIFormatter do
     colorize([:green], msg, config)
   end
 
-  defp invalid(msg, config) do
+  defp skipped(msg, config) do
     colorize([:yellow], msg, config)
+  end
+
+  defp invalid(msg, config) do
+    colorize([:red], msg, config)
   end
 
   defp failure(msg, config) do


### PR DESCRIPTION
Lately I noticed that I kept forgetting to re-enable tests that I previously marked as skipped. The total count and skipped count shows up at the bottom but I keep missing it and I wouldn't be surprised if other developers have the same problem. Here I propose a simple change that would make it obvious that a test was skipped. The "S" is stolen from minitest; a yellow "*" from RSpec or anything else, really, would work too. I also changed invalid to red.

Since it's a pretty trivial change I wasn't sure if it was worth discussing in elixir-lang-core, so I just went ahead and tried it out, but of course I can open up a thread.

Example run:
![example](https://www.evernote.com/shard/s91/sh/31fdf457-48ed-45bb-9bf2-454f29c2f173/c119347285c62261/res/7b9cfc86-ce8b-49ae-b6ee-e670a8c4bc26/skitch.png?resizeSmall&width=832)

Example run with trace:
![with trace](https://www.evernote.com/shard/s91/sh/9e954ba4-78dd-473d-b5b0-8020d51ef7df/f95bbb783abd9659/res/ef3221eb-1e6d-448d-b6ff-bdf4f324002e/skitch.png?resizeSmall&width=832)

When some tests are skipped:
![skipped](https://www.evernote.com/shard/s91/sh/fddf6d06-fc78-4989-bb6e-709d4770c292/af422b8ea751e9a9/res/047ed619-3118-4349-afb8-06f97fa2fdef/skitch.png?resizeSmall&width=832)