### PR TITLE
Proposal: Stream.chunk_by_with_size/2

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -205,6 +205,30 @@ defmodule Stream do
     next_with_acc(f1, :lists.reverse(buffer), h, nil, t)
   end
 
+  @doc """
+  Works just like `Stream.chunk_by/2`, but emits a 2-element tuple
+  where the first element is the chunk, and the second is the count
+  of elements inside the chunk.
+
+  ## Examples
+
+      iex> stream = Stream.chunk_by_with_size([1, 2, 2, 3, 4, 4, 6, 7, 7], &(rem(&1, 2) == 1))
+      iex> Enum.to_list(stream)
+      [{[1], 1}, {[2, 2], 2}, {[3], 1}, {[4, 4, 6], 3}, {[7, 7], 2}]
+  """
+  def chunk_by_with_size(enum, fun) do
+    lazy enum, nil,
+         fn(f1) -> R.chunk_by_with_size(fun, f1) end,
+         &do_chunk_by_with_size(&1, &2)
+  end
+
+  defp do_chunk_by_with_size(acc(_, nil, _) = acc, _f1) do
+    {:cont, acc}
+  end
+
+  defp do_chunk_by_with_size(acc(h, {buffer, _, size}, t), f1) do
+    next_with_acc(f1, {:lists.reverse(buffer), size}, h, nil, t)
+  end
 
   @doc """
   Creates a stream that only emits elements if they are different from the last emitted element.

--- a/lib/elixir/lib/stream/reducers.ex
+++ b/lib/elixir/lib/stream/reducers.ex
@@ -41,6 +41,22 @@ defmodule Stream.Reducers do
     end
   end
 
+  defmacro chunk_by_with_size(callback, f \\ nil) do
+    quote do
+      fn
+        entry, acc(h, {buffer, value, size}, t) ->
+          new_value = unquote(callback).(entry)
+          if new_value == value do
+            skip(acc(h, {[entry|buffer], value, size + 1}, t))
+          else
+            next_with_acc(unquote(f), {:lists.reverse(buffer), size}, h, {[entry], new_value, 1}, t)
+          end
+        entry, acc(h, nil, t) ->
+          skip(acc(h, {[entry], unquote(callback).(entry), 1}, t))
+      end
+    end
+  end
+
   defmacro dedup(callback, f \\ nil) do
     quote do
       fn(entry, acc(h, prev, t) = acc) ->

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -96,6 +96,16 @@ defmodule StreamTest do
     assert Enum.zip(list, list) == Enum.zip(stream, stream)
   end
 
+  test "chunk_by_with_size/2" do
+    stream = Stream.chunk_by_with_size([1,2,2,3,4,4,6,7,7], &(rem(&1, 2) == 1))
+
+    assert is_lazy(stream)
+    assert Enum.to_list(stream) ==
+           [{[1], 1}, {[2, 2], 2}, {[3], 1}, {[4, 4, 6], 3}, {[7, 7], 2}]
+    assert stream |> Stream.take(3) |> Enum.to_list ==
+           [{[1], 1}, {[2, 2], 2}, {[3], 1}]
+  end
+
   test "concat/1" do
     stream = Stream.concat([1..3, [], [4, 5, 6], [], 7..9])
     assert is_function(stream)


### PR DESCRIPTION
When using `Stream.chunk_by/2` sometimes it's useful to get the size of each chunk. An inefficient way to do that is to keep calling `length` on each chunk. This means that you are iterating through all the emitted elements twice. A more efficient way would be to maintain the count inside the `chunk_by` function, since it walks each element anyway. This is exactly what this function does.

```elixir
Stream.chunk_by_with_size([1, 2, 2, 3, 4, 4, 6, 7, 7], &(rem(&1, 2) == 1))
|> Enum.to_list(stream)
# => [{[1], 1}, {[2, 2], 2}, {[3], 1}, {[4, 4, 6], 3}, {[7, 7], 2}]
```

My use case for this is to calculate percentiles of a sorted stream of numbers, where I need to get the frequency of occurrence for each number. This function allows me to efficiently receive this frequency as part of the emitted tuple. I'm sure there are more use cases out there.

If we like this, we could also rewrite the old `chunk_by` in terms of this function, to avoid code duplication. If we don't like this I won't be mad. :)