### PR TITLE
Support :base option when inspecting binaries

### DIFF
--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -34,7 +34,8 @@ defmodule Inspect.Opts do
       own line.
 
     * `:base` - print integers as :binary, :octal, :decimal, or :hex, defaults
-      to :decimal
+      to :decimal. When inspecting binaries any `:base` other than `:decimal`
+      implies `binaries: :as_binaries`.
 
     * `:safe` - when `false`, failures while inspecting structs will be raised
       as errors instead of being wrapped in the Inspect.Error exception. This
@@ -78,7 +79,7 @@ defmodule Inspect.Algebra do
   This module implements the functionality described in
   ["Strictly Pretty" (2000) by Christian Lindig][0] with small
   additions, like support for String nodes, and a custom
-  rendering function that maximises horizontal space use. 
+  rendering function that maximises horizontal space use.
 
       iex> Inspect.Algebra.empty
       :doc_nil

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -115,6 +115,13 @@ defmodule Inspect.BitStringTest do
     assert inspect(<<"john", 193, "doe">>, binaries: :as_binaries) == "<<106, 111, 104, 110, 193, 100, 111, 101>>"
     assert inspect(<<"john">>, binaries: :as_binaries) == "<<106, 111, 104, 110>>"
     assert inspect(<<193>>, binaries: :as_binaries) == "<<193>>"
+    # base: :hex is recognized
+    assert inspect("abc", binaries: :as_binary, base: :hex) == "<<0x61, 0x62, 0x63>>"
+    # any base other than :decimal implies binaries: :as_binaries
+    assert inspect("abc", base: :hex) == "<<0x61, 0x62, 0x63>>"
+    assert inspect("abc", base: :octal) == "<<0o141, 0o142, 0o143>>"
+    # size is still represented as decimal
+    assert inspect(<<10, 11, 12::4>>, base: :hex) == "<<0xA, 0xB, 0xC::size(4)>>"
   end
 
   test "unprintable with opts" do


### PR DESCRIPTION
Allow inspecting binaries as :hex or :octal.

Examples:

```
# as before
iex> inspect("abc")
"\"abc\""

# as before
iex> inspect("abc", binaries: :as_binary)
"<<97, 98, 99>>"

# NEW: base: :hex is recognized
iex> inspect("abc", binaries: :as_binary, base: :hex)
"<<0x61, 0x62, 0x63>>"

# NEW: any base other than :decimal implies binaries: :as_binaries
iex> inspect("abc", base: :hex)
"<<0x61, 0x62, 0x63>>"
iex> inspect("abc", base: :octal)
"<<0o141, 0o142, 0o143>>"

# NOTE: size is still represented as decimal
iex> inspect(<< 10, 11, 12::4 >>, base: :hex)
"<<0xA, 0xB, 0xC::size(4)>>"
```