### PR TITLE
ExUnit: Add note in docs about `:include` ignored without `:exclude`

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -193,7 +193,8 @@ defmodule ExUnit do
     * `:autorun` - if ExUnit should run by default on exit; defaults to `true`
 
     * `:include` - specify which tests are run by skipping tests that do not
-      match the filter
+      match the filter. Keep in mind that all tests are included by default, so unless they are
+      excluded first, the `:include` option has no effect.
 
     * `:exclude` - specify which tests are run by skipping tests that match the
       filter


### PR DESCRIPTION
This is a reminder from https://github.com/elixir-lang/elixir/blob/v1.2.2/lib/ex_unit/lib/ex_unit/case.ex#L162:L163

I was a bit on a fence if I should submit this PR or not because it's a repetition. However, it would have saved me some time because I happened to read that doc first and got confused why just running  `mix test --include focus` was running all tests for me.