### PR TITLE
Fixed typo in Kernel.struct/2 documentation

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1599,7 +1599,7 @@ defmodule Kernel do
       user = struct(User, opts)
       #=> %User{name: "meg"}
 
-      struct(user, unknown: "value")
+      struct(User, unknown: "value")
       #=> %User{name: "meg"}
 
       struct(User, %{name: "meg"})


### PR DESCRIPTION
Browsing the doco and noticed a small typo that I fixed in the Kernel.struct/2 function.