### PR TITLE
Optimize Enum.random for ranges

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2157,9 +2157,7 @@ defmodule Enum do
   Takes random items from the enumerable.
 
   Notice this function will traverse the whole enumerable to
-  get the random sublist of `enumerable`. If you want the random
-  number between two integers, the best option is to use the
-  [`:rand`](http://www.erlang.org/doc/man/rand.html) module.
+  get the random sublist of `enumerable`.
 
   See `random/1` for notes on implementation and random seed.
 
@@ -2175,6 +2173,14 @@ defmodule Enum do
   """
   @spec take_random(t, integer) :: list
   def take_random(_enumerable, 0), do: []
+
+  def take_random(first..last, 1) when first > last do
+    take_random(last..first, 1)
+  end
+
+  def take_random(first..last, 1) do
+    [random_index(last - first) + first]
+  end
 
   def take_random(enumerable, count) when count > 128 do
     reducer = fn(elem, {idx, sample}) ->

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -940,10 +940,11 @@ defmodule EnumTest.Range do
     seed2 = {1306, 421106, 567597}
     :rand.seed(:exsplus, seed1)
     assert Enum.random(1..2) == 1
-    assert Enum.random(1..3) == 1
-    :rand.seed(:exsplus, seed2)
-    assert Enum.random(1..2) == 2
     assert Enum.random(1..3) == 2
+    assert Enum.random(3..1) == 3
+    :rand.seed(:exsplus, seed2)
+    assert Enum.random(1..2) == 1
+    assert Enum.random(1..3) == 3
   end
 
   test "take random" do
@@ -958,15 +959,16 @@ defmodule EnumTest.Range do
     seed1 = {1406, 407414, 139258}
     seed2 = {1406, 421106, 567597}
     :rand.seed(:exsplus, seed1)
-    assert Enum.take_random(1..3, 1) == [1]
-    assert Enum.take_random(1..3, 2) == [1, 3]
-    assert Enum.take_random(1..3, 3) == [2, 1, 3]
-    assert Enum.take_random(1..3, 4) == [3, 1, 2]
-    :rand.seed(:exsplus, seed2)
     assert Enum.take_random(1..3, 1) == [3]
+    assert Enum.take_random(1..3, 2) == [3, 1]
+    assert Enum.take_random(1..3, 3) == [3, 1, 2]
+    assert Enum.take_random(1..3, 4) == [1, 3, 2]
+    assert Enum.take_random(3..1, 1) == [2]
+    :rand.seed(:exsplus, seed2)
+    assert Enum.take_random(1..3, 1) == [1]
     assert Enum.take_random(1..3, 2) == [1, 2]
-    assert Enum.take_random(1..3, 3) == [1, 2, 3]
-    assert Enum.take_random(1..3, 4) == [1, 2, 3]
+    assert Enum.take_random(1..3, 3) == [1, 3, 2]
+    assert Enum.take_random(1..3, 4) == [3, 2, 1]
   end
 
   test "scan" do


### PR DESCRIPTION
This only applies when taking a single count, but drastically improves the performance of large ranges, such as `Enum.random(1..1_000_000)`, which is a common use-case.