### PR TITLE
Adds nl to IEx.Helpers

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -34,6 +34,7 @@ defmodule IEx.Helpers do
     * `l/1`           - loads the given module's beam code
     * `ls/0`          - lists the contents of the current directory
     * `ls/1`          - lists the contents of the specified directory
+    * `nl/2`          - deploys local beam code to a list of connected nodes
     * `pid/3`         — creates a PID with the 3 integer arguments passed
     * `pwd/0`         — prints the current working directory
     * `r/1`           — recompiles and reloads the given module's source file
@@ -642,5 +643,43 @@ defmodule IEx.Helpers do
              Integer.to_char_list(y) ++ '.' ++
              Integer.to_char_list(z) ++ '>'
     )
+  end
+
+  @doc """
+  Deloys a given module's beam code to a list of connected nodes.
+
+  This function is useful for development and debugging when you have code that
+  has been compiled or updated locally that you want to run on other nodes.
+  
+  The node list defaults to a list of all connected nodes.
+
+  Returns `{:error, :nofile}` if the object code (i.e. ".beam" file) for the module
+  could not be found locally.
+
+  ## Examples
+
+      nl(HelloWorld)
+      #=> {:ok, [{:node1@easthost, :loaded, HelloWorld},
+                 {:node1@westhost, :loaded, HelloWorld}]}
+
+      nl(NoSuchModuleExists)
+      #=> {:error, :nofile}
+      
+  """
+  def nl(nodes \\ Node.list, module) when is_list(nodes) and is_atom(module) do
+    case :code.get_object_code(module) do
+      {^module, bin, beam_path} ->
+        results = 
+          for node <- nodes do
+            case :rpc.call(node, :code, :load_binary, [module, beam_path, bin]) do
+              {:module, _} -> {node, :loaded, module}
+              {:badrpc, message} -> {node, :badrpc, message}
+              {:error, message} -> {node, :error, message}
+              unexpected -> {node, :error, unexpected}
+            end
+          end
+        {:ok, results}
+      _otherwise -> {:error, :nofile}
+    end
   end
 end

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -372,6 +372,15 @@ defmodule IEx.HelpersTest do
     cleanup_modules([Sample])
   end
 
+  test "nl helper" do
+    assert nl(:non_existent_module) == {:error, :nofile}
+    assert nl([node], Enum) == {:ok, [{:nonode@nohost, :loaded, Enum}]}    
+    assert nl([:nosuchnode@badhost], Enum) == {:ok, [{:nosuchnode@badhost, :badrpc, :nodedown}]}
+    capture_log fn -> 
+      assert nl([node], :lists) == {:ok, [{:nonode@nohost, :error, :sticky_directory}]} 
+    end
+  end
+
   test "r helper unavailable" do
     assert_raise ArgumentError, "could not load nor find module: :non_existent_module", fn ->
       r :non_existent_module

--- a/lib/iex/test/test_helper.exs
+++ b/lib/iex/test/test_helper.exs
@@ -27,6 +27,7 @@ defmodule IEx.Case do
   using do
     quote do
       import ExUnit.CaptureIO
+      import ExUnit.CaptureLog
       import unquote(__MODULE__)
     end
   end


### PR DESCRIPTION
Erlang's `c` module is a jumbled sock-drawer of commonly used commands. Inside it is a powerful (but obscure) feature `c:nl(modulename)` that will deploy the object code for a locally compiled module to all connected nodes. This makes deploying code to a newly connected cluster simple, and allows easy redeployment of updated/recompiled code. The Erlang implementation of `c:nil` ([doc](http://erlang.org/doc/man/c.html#nl-1)) glues together `code:ensure_loaded` ([doc](http://erlang.org/doc/man/code.html#ensure_loaded-1)) and `rpc:eval_everywhere` ([doc](http://erlang.org/doc/man/rpc.html#eval_everywhere-4)). 

This pull request give the functionality of `nl` a better home: `Node.load_module`
