### PR TITLE
fix typo in def v(n \ -1) documentation

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -350,7 +350,7 @@ defmodule IEx.Helpers do
   @doc """
   Retrieves the nth expression's value from the history.
 
-  Use negative values to lookup expression values relative to the current one.
+  Use negative values to look up expression values relative to the current one.
   For instance, v(-1) returns the result of the last evaluated expression.
   """
   def v(n \\ -1) do


### PR DESCRIPTION
noticed a small typo in this documentation - "lookup" is a noun, so it should be "look up"