### PR TITLE
Add :allow_pre option to Version.match?

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -160,8 +160,7 @@ defmodule Version do
 
   def match?(version, %Requirement{matchspec: spec}, opts) do
     allow_pre = Keyword.get(opts, :allow_pre, true)
-    {:ok, result} = :ets.test_ms(to_matchable(version, allow_pre), spec)
-    result != false
+    :ets.match_spec_run([to_matchable(version, allow_pre)], spec) != []
   end
 
   @doc """
@@ -243,7 +242,7 @@ defmodule Version do
   def parse_requirement(string) when is_binary(string) do
     case Version.Parser.parse_requirement(string) do
       {:ok, spec} ->
-        {:ok, %Requirement{source: string, matchspec: spec}}
+        {:ok, %Requirement{source: string, matchspec: :ets.match_spec_compile(spec)}}
       :error ->
         :error
     end

--- a/lib/elixir/test/elixir/version_test.exs
+++ b/lib/elixir/test/elixir/version_test.exs
@@ -196,8 +196,11 @@ defmodule VersionTest do
     refute V.match?("1.1.0-beta", "~> 1.0", allow_pre: false)
     assert V.match?("1.0.1-beta", "~> 1.0.0-beta", allow_pre: false)
 
+    assert V.match?("1.1.0", ">= 1.0.0", allow_pre: true)
     assert V.match?("1.1.0", ">= 1.0.0", allow_pre: false)
-    assert V.match?("1.1.0-beta", ">= 1.0.0", allow_pre: false)
+    assert V.match?("1.1.0-beta", ">= 1.0.0", allow_pre: true)
+    refute V.match?("1.1.0-beta", ">= 1.0.0", allow_pre: false)
+    assert V.match?("1.1.0-beta", ">= 1.0.0-beta", allow_pre: false)
   end
 
   test "and" do

--- a/lib/elixir/test/elixir/version_test.exs
+++ b/lib/elixir/test/elixir/version_test.exs
@@ -189,6 +189,17 @@ defmodule VersionTest do
     end
   end
 
+  test "allow_pre" do
+    assert V.match?("1.1.0", "~> 1.0", allow_pre: true)
+    assert V.match?("1.1.0", "~> 1.0", allow_pre: false)
+    assert V.match?("1.1.0-beta", "~> 1.0", allow_pre: true)
+    refute V.match?("1.1.0-beta", "~> 1.0", allow_pre: false)
+    assert V.match?("1.0.1-beta", "~> 1.0.0-beta", allow_pre: false)
+
+    assert V.match?("1.1.0", ">= 1.0.0", allow_pre: false)
+    assert V.match?("1.1.0-beta", ">= 1.0.0", allow_pre: false)
+  end
+
   test "and" do
     assert V.match?("0.9.3", "> 0.9.0 and < 0.10.0")
     refute V.match?("0.10.2", "> 0.9.0 and < 0.10.0")

--- a/lib/elixir/test/elixir/version_test.exs
+++ b/lib/elixir/test/elixir/version_test.exs
@@ -212,4 +212,12 @@ defmodule VersionTest do
 
     refute V.match?("0.9.6", "0.9.1 or 0.9.3 or 0.9.5")
   end
+
+  test "compile requirement" do
+    {:ok, req} = V.parse_requirement("1.2.3")
+    req = V.compile_requirement(req)
+
+    assert V.match?("1.2.3", req)
+    refute V.match?("1.2.4", req)
+  end
 end


### PR DESCRIPTION
When `allow_pre: false` is set the `~>` operator will not match a pre-release version unless the operand is a pre-release version. The default is to allow always allow pre-releases but note that in Hex `:allow_pre` is set to `false.` See the table below for examples.