### PR TITLE
Update the docs for "for" and "with" to showcase guards

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1253,9 +1253,10 @@ defmodule Kernel.SpecialForms do
       [2, 4, 6]
 
   Note generators can also be used to filter as it removes any value
-  that doesn't match the left side of `<-`:
+  that doesn't match the pattern on the left side of `<-`:
 
-      iex> for {:user, name} <- [user: "john", admin: "james", user: "meg"] do
+      iex> users = [user: "john", admin: "meg", guest: "barbara"]
+      iex> for {type, name} when type != :guest <- users do
       ...>   String.upcase(name)
       ...> end
       ["JOHN", "MEG"]
@@ -1313,6 +1314,13 @@ defmodule Kernel.SpecialForms do
       ...>      {:ok, height} <- Map.fetch(opts, :height),
       ...>   do: {:ok, width * height}
       :error
+
+  Guards can be used in patterns as well:
+
+      iex> users = %{"melany" => "guest", "bob" => :admin}
+      iex> with {:ok, role} when not is_binary(role) <- Map.fetch(users, "bob"),
+      ...>   do: {:ok, to_string(role)}
+      {:ok, "admin"}
 
   Similarly to `for/1`, variables bound inside `with/1` won't leak,
   and also it allows "bare expressions":


### PR DESCRIPTION
I used existing examples so that we don't add too much complexity and unnecessary volume to the documentation.

I think we can polish the docs for `with` a little bit further, but I'd rather do it in another PR :).