### PR TITLE
add escape for closing brackets

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -625,7 +625,7 @@ defmodule Regex do
     [get_index(string, h)|get_indexes(string, t, arity - 1)]
   end
 
-  {:ok, pattern} = :re.compile(~S"[.^$*+?()[{\\\|\s#]", [:unicode])
+  {:ok, pattern} = :re.compile(~S"[.^$*+?()\[\]{}\\\|\s#]", [:unicode])
   @escape_pattern pattern
 
   @doc ~S"""

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -247,6 +247,12 @@ defmodule RegexTest do
     assert matches_escaped?("# lol")
 
     assert matches_escaped?("\\A.^$*+?()[{\\| \t\n\x20\\z #hello\u202F\u205F")
+
+    assert Regex.escape("{}") == "\\{\\}"
+    assert Regex.escape("[]") == "\\[\\]"
+
+    assert Regex.escape("{foo}") == "\\{foo\\}"
+    assert Regex.escape("[foo]") == "\\[foo\\]"
   end
 
   defp matches_escaped?(string) do


### PR DESCRIPTION
Hi,

I came across the #4220 while messing with Regex stuff in a custom inflector and decided to go ahead a fix because I was enjoying elixir so much.

Anyway after looking and testing, it seems to be a matter of the closing brackets not being in the compiled escape pattern.

If you'd like me to change anything or write more tests, I'd be happy to do so.