### PR TITLE
Update reference to Kernel.Typespec

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -722,7 +722,7 @@ defmodule Kernel.SpecialForms do
 
       <<int::integer-little, rest::bits>> = bits
 
-  Read the documentation for `Kernel.Typespec` and
+  Read the documentation on the `Typespec` page and
   `<<>>/1` for more information on typespecs and
   bitstrings respectively.
   """


### PR DESCRIPTION
Looks like the moduledoc flag was disabled in Kernel.Typespec Module [1]
and a page was created instead

[1] f1d4d5b034bd47d6488b808766f25a3f6fd82683