### PR TITLE
Track {module, function, arity} imports and warn on unused ones

### DIFF
--- a/lib/elixir/src/elixir_dispatch.erl
+++ b/lib/elixir/src/elixir_dispatch.erl
@@ -26,11 +26,11 @@ find_import(Meta, Name, Arity, E) ->
 
   case find_dispatch(Meta, Tuple, [], E) of
     {function, Receiver} ->
-      elixir_lexical:record_import(Receiver, ?m(E, lexical_tracker)),
+      elixir_lexical:record_import({Receiver, Name, Arity}, ?m(E, lexical_tracker)),
       %% elixir_locals:record_import(Tuple, Receiver, ?m(E, module), ?m(E, function)),
       Receiver;
     {macro, Receiver} ->
-      elixir_lexical:record_import(Receiver, ?m(E, lexical_tracker)),
+      elixir_lexical:record_import({Receiver, Name, Arity}, ?m(E, lexical_tracker)),
       %% elixir_locals:record_import(Tuple, Receiver, ?m(E, module), ?m(E, function)),
       Receiver;
     _ ->
@@ -43,7 +43,7 @@ import_function(Meta, Name, Arity, E) ->
   Tuple = {Name, Arity},
   case find_dispatch(Meta, Tuple, [], E) of
     {function, Receiver} ->
-      elixir_lexical:record_import(Receiver, ?m(E, lexical_tracker)),
+      elixir_lexical:record_import({Receiver, Name, Arity}, ?m(E, lexical_tracker)),
       elixir_locals:record_import(Tuple, Receiver, ?m(E, module), ?m(E, function)),
       remote_function(Meta, Receiver, Name, Arity, E);
     {macro, _Receiver} ->
@@ -137,12 +137,12 @@ expand_import(Meta, {Name, Arity} = Tuple, Args, E, Extra, External) ->
 do_expand_import(Meta, {Name, Arity} = Tuple, Args, Module, E, Result) ->
   case Result of
     {function, Receiver} ->
-      elixir_lexical:record_import(Receiver, ?m(E, lexical_tracker)),
+      elixir_lexical:record_import({Receiver, Name, Arity}, ?m(E, lexical_tracker)),
       elixir_locals:record_import(Tuple, Receiver, Module, ?m(E, function)),
       {ok, Receiver, Name, Args};
     {macro, Receiver} ->
       check_deprecation(Meta, Receiver, Name, Arity, E),
-      elixir_lexical:record_import(Receiver, ?m(E, lexical_tracker)),
+      elixir_lexical:record_import({Receiver, Name, Arity}, ?m(E, lexical_tracker)),
       elixir_locals:record_import(Tuple, Receiver, Module, ?m(E, function)),
       {ok, Receiver, expand_macro_named(Meta, Receiver, Name, Arity, Args, E)};
     {import, Receiver} ->

--- a/lib/elixir/src/elixir_import.erl
+++ b/lib/elixir/src/elixir_import.erl
@@ -47,7 +47,14 @@ record_warn(Meta, Ref, Opts, Added, E) ->
       {warn, true} -> true;
       false -> not lists:keymember(context, 1, Meta)
     end,
-  elixir_lexical:record_import(Ref, ?line(Meta), Added and Warn, ?m(E, lexical_tracker)).
+
+  case keyfind(only, Opts) of
+    {only, List} when is_list(List) ->
+      [elixir_lexical:record_import({Ref, Name, Arity}, ?line(Meta), Added and Warn, ?m(E, lexical_tracker)) || {Name, Arity} <- List ];
+
+    _ ->
+      elixir_lexical:record_import(Ref, ?line(Meta), Added and Warn, ?m(E, lexical_tracker))
+  end.
 
 %% Calculates the imports based on only and except
 

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -254,7 +254,7 @@ defmodule Kernel.WarningTest do
     assert capture_err(fn ->
       Code.compile_string """
       defmodule Sample do
-        import :lists, only: [flatten: 1]
+        import :lists
         def a, do: nil
       end
       """
@@ -262,9 +262,36 @@ defmodule Kernel.WarningTest do
 
     assert capture_err(fn ->
       Code.compile_string """
-      import :lists, only: [flatten: 1]
+      import :lists
       """
     end) =~ "warning: unused import :lists"
+  after
+    purge Sample
+  end
+
+  test "unused import of one of the functions in :only" do
+    assert capture_err(fn ->
+      Code.compile_string """
+      defmodule Sample do
+        import String, only: [upcase: 1, downcase: 1, strip: 1]
+        def a, do: upcase("hello")
+      end
+      """
+    end) == "nofile:2: warning: unused import String.downcase/1\n" <>
+            "nofile:2: warning: unused import String.strip/1\n"
+  after
+    purge Sample
+  end
+
+  test "unused import of any of the functions in :only" do
+    assert capture_err(fn ->
+      Code.compile_string """
+      defmodule Sample do
+        import String, only: [upcase: 1, downcase: 1]
+        def a, do: nil
+      end
+      """
+    end) == "nofile:2: warning: unused import String\n"
   after
     purge Sample
   end

--- a/lib/mix/lib/mix/dep/fetcher.ex
+++ b/lib/mix/lib/mix/dep/fetcher.ex
@@ -7,7 +7,7 @@
 defmodule Mix.Dep.Fetcher do
   @moduledoc false
 
-  import Mix.Dep, only: [format_dep: 1, check_lock: 1, available?: 1, ok?: 1]
+  import Mix.Dep, only: [format_dep: 1, check_lock: 1, available?: 1]
 
   @doc """
   Fetches all dependencies.

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -25,7 +25,7 @@ defmodule Mix.Tasks.Deps.Compile do
   """
 
   import Mix.Dep, only: [loaded: 1, available?: 1, loaded_by_name: 2,
-                         format_dep: 1, make?: 1, mix?: 1]
+                         make?: 1, mix?: 1]
 
   @spec run(OptionParser.argv) :: :ok
   def run(args) do

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.New do
   use Mix.Task
 
   import Mix.Generator
-  import Mix.Utils, only: [camelize: 1, underscore: 1]
+  import Mix.Utils, only: [camelize: 1]
 
   @shortdoc "Creates a new Elixir project"
 


### PR DESCRIPTION
Discussed briefly on: https://groups.google.com/forum/#!topic/elixir-lang-core/YFg07iq4l4Y but also spoken about some implementation details with @josevalim.

I'd appreciate feedback if this is going into the right direction, will be useful enough, and could be considered for merging after it's finished up.

## Example

Say, there's following file:

```elixir
 # example.exs
 import String, only: [upcase: 1, downcase: 1]
 import Enum

 IO.puts upcase("Hello")
 ```

Before this patch:

    # $ elixir example.exs
    # HELLO
    # warning.exs:2: warning: unused import Enum

After this patch:

    # $ elixir example.exs
    # HELLO
    # example.exs:1: warning: unused import String.downcase/1
    # example.exs:2: warning: unused import Enum