### PR TITLE
Do not escape new line when interpolation is disabled. Fix #4209.

### DIFF
--- a/lib/elixir/src/elixir_interpolation.erl
+++ b/lib/elixir/src/elixir_interpolation.erl
@@ -24,11 +24,11 @@ extract(Line, Column, _Scope, _Interpol, [Last|Remaining], Buffer, Output, Last)
 
 %% Going through the string
 
-extract(Line, _Column, Scope, Interpol, [$\\, $\n|Rest], Buffer, Output, Last) ->
-  extract(Line+1, 1, Scope, Interpol, Rest, Buffer, Output, Last);
+extract(Line, _Column, Scope, true, [$\\, $\n|Rest], Buffer, Output, Last) ->
+  extract(Line+1, 1, Scope, true, Rest, Buffer, Output, Last);
 
-extract(Line, _Column, Scope, Interpol, [$\\, $\r, $\n|Rest], Buffer, Output, Last) ->
-  extract(Line+1, 1, Scope, Interpol, Rest, Buffer, Output, Last);
+extract(Line, _Column, Scope, true, [$\\, $\r, $\n|Rest], Buffer, Output, Last) ->
+  extract(Line+1, 1, Scope, true, Rest, Buffer, Output, Last);
 
 extract(Line, _Column, Scope, Interpol, [$\n|Rest], Buffer, Output, Last) ->
   extract(Line+1, 1, Scope, Interpol, Rest, [$\n|Buffer], Output, Last);

--- a/lib/elixir/test/elixir/kernel/sigils_test.exs
+++ b/lib/elixir/test/elixir/kernel/sigils_test.exs
@@ -29,6 +29,8 @@ defmodule Kernel.SigilsTest do
     assert ~S(f\no) == "f\\no"
     assert ~S(foo\)) == "foo)"
     assert ~S[foo\]] == "foo]"
+    assert ~S(foo\
+bar) == "foo\\\nbar"
   end
 
   test "sigil S with heredoc" do


### PR DESCRIPTION
As discussed in #4209, the behavior of `~S` (and `~R`) is currently inconsistent.

```elxir
~S"foo\bar" # => "foo\\bar"
~S"foo\
bar" # => "foobar"
```

This fixes the behavior to avoid escaping newlines where it should not, so that the above becomes:

```elxir
~S"foo\bar" # => "foo\\bar"
~S"foo\
bar" # => "foo\\\nbar"
```
