### PR TITLE
Remove some dead code in Mix.Dep

### DIFF
--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -245,15 +245,15 @@ defmodule Mix.Dep do
       case scm.lock_status(opts) do
         :mismatch ->
           status = if rev = opts[:lock], do: {:lockmismatch, rev}, else: :nolock
-          %{dep | status: status, opts: opts}
+          %{dep | status: status}
         :outdated ->
           # Don't include the lock in the dependency if it is outdated
           %{dep | status: :lockoutdated}
         :ok ->
-          check_manifest(%{dep | opts: opts}, opts[:build])
+          check_manifest(dep, opts[:build])
       end
     else
-      %{dep | opts: opts}
+      dep
     end
   end
 


### PR DESCRIPTION
I am fairly sure the code I removed in this PR is dead code; it did something before 2c5c53834f7adb0cf9526003450981545ef61766, but it can't do anything right now (since data is immutable in Elixir :smiley_cat:). Tests confirm this as they all pass without the removed code, this helps my confidence here :).