### PR TITLE
Fix a possible binary leak in Integer.parse/1

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -167,11 +167,11 @@ defmodule Integer do
 
   defp do_parse(_, _), do: :error
 
-  defp do_parse(<<char, rest::binary>>, base, acc) do
+  defp do_parse(<<char, rest::binary>> = bin, base, acc) do
     if valid_digit_in_base?(char, base) do
       do_parse(rest, base, base * acc + parse_digit(char, base))
     else
-      {acc, <<char, rest::binary>>}
+      {acc, bin}
     end
   end
 


### PR DESCRIPTION
Integer.parse/1 followed this pattern:

```elixir
defp do_parse(<<char, rest :: binary>>, ...) do
  ...
  # instead of re-using the original binary, we do this
  {..., <<char, rest :: binary>>}
end
```

This causes a new binary to be created instead of `rest` just being a sub-binary. I tested this with a memory leak I was experiencing in Redix and this seems to fix it. I also did a slightly more scientific experiment with refc binaries:

```elixir
input = "42" <> String.duplicate("a", 10_000)
:erlang.process_info(self(), :binary)
#=> {:binary, [{..., 10002, ...}, ...]}

{int, bin} = Integer.parse(input)
:erlang.process_info(self(), :binary)
#=> {:binary, [{..., 10002, ...}, {..., 10000, ...}, ...]}
```

Still, unrelated from the memory leak, I think the change in the PR is good style anyways :) What do you think?