### PR TITLE
Remove mention to dict in `ExUnit.Callbacks example`

### DIFF
--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -63,7 +63,7 @@ defmodule ExUnit.Callbacks do
             IO.puts "This is invoked once the test is done"
           end
 
-          # Returns extra metadata, it must be a dict
+          # Returns extra metadata to be merged into context
           {:ok, hello: "world"}
         end
 


### PR DESCRIPTION
Left-over from previous versions