### PR TITLE
Improved docs for Process

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -38,7 +38,7 @@ defmodule Process do
   end
 
   @doc """
-  Returns the value for the given `key`.
+  Returns the value for the given `key` or `default` if `key` is not set.
   """
   @spec get(term) :: term
   @spec get(term, default :: term) :: term
@@ -91,23 +91,27 @@ defmodule Process do
   end
 
   @doc """
-  Sends an exit signal with the given reason to the pid.
+  Sends an exit signal with the given `reason` to the `pid`.
 
-  The following behaviour applies if reason is any term except `:normal` or `:kill`:
+  The following behaviour applies if `reason` is any term except `:normal`
+  or `:kill`:
 
-    1. If pid is not trapping exits, pid will exit with the given reason.
+    1. If `pid` is not trapping exits, `pid` will exit with the given
+       `reason`.
 
-    2. If pid is trapping exits, the exit signal is transformed into a message
-       `{:EXIT, from, reason}` and delivered to the message queue of pid.
+    2. If `pid` is trapping exits, the exit signal is transformed into a
+       message `{:EXIT, from, reason}` and delivered to the message queue
+       of `pid`.
 
-    3. If reason is the atom `:normal`, pid will not exit (unless it is the calling
-       process's pid, in which case it will exit with the reason `:normal`).
-       If it is trapping exits, the exit signal is transformed into a message
-       `{:EXIT, from, :normal}` and delivered to its message queue.
+    3. If `reason` is the atom `:normal`, `pid` will not exit (unless it
+       is the calling process's pid, in which case it will exit with the
+       reason `:normal`). If it is trapping exits, the exit signal is
+       transformed into a message `{:EXIT, from, :normal}` and delivered
+       to its message queue.
 
-    4. If reason is the atom `:kill`, that is if `exit(pid, :kill)` is called,
-       an untrappable exit signal is sent to pid which will unconditionally
-       exit with exit reason `:killed`.
+    4. If `reason` is the atom `:kill`, that is if `exit(pid, :kill)` is
+       called, an untrappable exit signal is sent to `pid` which will
+       unconditionally exit with exit reason `:killed`.
 
   Inlined by the compiler.
 


### PR DESCRIPTION
-Added backticks appropriately in docs for Process.exit
-Mentioned default behaviour for Process.get