### PR TITLE
Added a note about dialyzer not using map pair type information

### DIFF
--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -142,3 +142,5 @@ Specifications can be overloaded just like ordinary functions.
 Elixir discourages the use of type `string` as it might be confused with binaries which are referred to as "strings" in Elixir (as opposed to character lists). In order to use the type that is called `string` in Erlang, one has to use the `char_list` type which is a synonym for `string`. If you use `string`, you'll get a warning from the compiler.
 
 If you want to refer to the "string" type (the one operated on by functions in the `String` module), use `String.t` type instead.
+
+In map and struct type declarations such as `%{key: value}` or `%Struct{key: value}`, the key, value pair type information is not used by the current version of dialyzer.


### PR DESCRIPTION
See a similar note in the [Erlang reference
manual](http://erlang.org/doc/reference_manual/typespec.html#id77939)
and [Björn-Egil's answer on the erlang-questions mailing
list](http://erlang.org/pipermail/erlang-questions/2016-March/088139.html)