### PR TITLE
Correct n-element terminology in tuples

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1517,7 +1517,7 @@ defmodule Enum do
   If you wish to use another value for the accumulator, use
   `Enumerable.reduce/3`.
   This function won't call the specified function for enumerables that
-  are 1-element long.
+  are one-element long.
 
   Returns the accumulator.
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1575,7 +1575,7 @@ defmodule Kernel do
 
   The `struct` argument may be an atom (which defines `defstruct`)
   or a `struct` itself. The second argument is any `Enumerable` that
-  emits two-item tuples (key-value pairs) during enumeration.
+  emits two-element tuples (key-value pairs) during enumeration.
 
   Keys in the `Enumerable` that don't exist in the struct are automatically
   discarded. Note that keys must be atoms, as only atoms are allowed when

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -92,7 +92,7 @@ defmodule Kernel.SpecialForms do
   ## AST representation
 
   Regardless if `=>` or the keywords syntax is used, Maps are
-  always represented internally as a list of two-items tuples
+  always represented internally as a list of two-element tuples
   for simplicity:
 
       iex> quote do: %{"a" => :b, c: :d}

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -2,7 +2,7 @@ defmodule Keyword do
   @moduledoc """
   A set of functions for working with keywords.
 
-  A keyword is a list of 2-element tuples where the first
+  A keyword is a list of two-element tuples where the first
   element of the tuple is an atom and the second element
   can be any value.
 
@@ -191,7 +191,7 @@ defmodule Keyword do
   Gets the value from `key` and updates it, all in one pass.
 
   This `fun` argument receives the value of `key` (or `nil` if `key`
-  is not present) and must return a two-elements tuple: the "get" value (the
+  is not present) and must return a two-element tuple: the "get" value (the
   retrieved value, which can be operated on before being returned) and the new
   value to be stored under `key`.
 
@@ -245,7 +245,7 @@ defmodule Keyword do
   Gets the value from `key` and updates it. Raises if there is no `key`.
 
   This `fun` argument receives the value of `key` and must return a
-  two-elements tuple: the "get" value (the retrieved value, which can be
+  two-element tuple: the "get" value (the retrieved value, which can be
   operated on before being returned) and the new value to be stored under
   `key`.
 

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -669,7 +669,7 @@ defmodule Macro do
     end
   end
 
-  # Two-item tuples
+  # Two-element tuples
   def to_string({left, right}, fun) do
     to_string({:{}, [], [left, right]}, fun)
   end

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -29,8 +29,8 @@ defmodule Macro.Env do
       `nil` if not inside a function
     * `context` - the context of the environment; it can be `nil`
       (default context), inside a guard or inside a match
-    * `aliases` -  a list of two-item tuples, where the first
-      item is the aliased name and the second the actual name
+    * `aliases` -  a list of two-element tuples, where the first
+      element is the aliased name and the second one the actual name
     * `requires` - the list of required modules
     * `functions` - a list of functions imported from each module
     * `macros` - a list of macros imported from each module

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -484,7 +484,7 @@ defmodule Map do
   Gets the value from `key` and updates it, all in one pass.
 
   This `fun` argument receives the value of `key` (or `nil` if `key`
-  is not present) and must return a two-elements tuple: the "get" value (the
+  is not present) and must return a two-element tuple: the "get" value (the
   retrieved value, which can be operated on before being returned) and the new
   value to be stored under `key`.
 
@@ -532,7 +532,7 @@ defmodule Map do
   Gets the value from `key` and updates it. Raises if there is no `key`.
 
   This `fun` argument receives the value of `key` and must return a
-  two-elements tuple: the "get" value (the retrieved value, which can be
+  two-element tuple: the "get" value (the retrieved value, which can be
   operated on before being returned) and the new value to be stored under
   `key`.
 

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -44,7 +44,7 @@ defmodule URI do
   @doc """
   Encodes an enumerable into a query string.
 
-  Takes an enumerable (containing a sequence of two-item tuples)
+  Takes an enumerable (containing a sequence of two-element tuples)
   and returns a string in the form of `key1=value1&key2=value2...` where
   keys and values are URL encoded as per `encode_www_form/1`.
 


### PR DESCRIPTION
- "n-item" terminology was replaced by "n-element"
- replaced "two-elements" with "two-element" when used as an adjetive
- replaced numbers with words (as in 1-element)