### PR TITLE
Proposal: Added PID sigil

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3842,6 +3842,21 @@ defmodule Kernel do
   ## Sigils
 
   @doc ~S"""
+  Handles the sigil `~P`.
+
+  It converts a string to a pid.
+
+  ## Examples
+      iex> ~P<0.118.0>
+      #PID<0.118.0>
+
+  """
+  defmacro sigil_P(term, modifiers)
+  defmacro sigil_P({:<<>>, _line, [string]}, []) when is_binary(string) do
+    :erlang.list_to_pid( String.to_char_list("<#{string}>") )
+  end
+
+  @doc ~S"""
   Handles the sigil `~S`.
 
   It simply returns a string without escaping characters and without


### PR DESCRIPTION
There's no easy way (like a pid literal) in Elixir or Erlang to type in a pid to the console - I added a pid sigil to the Kernel so that programmers can easily get a pid from a string.  

This is especially handy when testing and debugging - I can easily print a pid to IO or logs and then manipulate it in IEx without having to figure out how to get a function to return it, then store it in a variable.