### PR TITLE
Update definition of Unicode Whitespace

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -238,10 +238,11 @@ defmodule String do
   def printable?(<<>>), do: true
   def printable?(binary) when is_binary(binary), do: false
 
-  @doc """
+  @doc ~S"""
   Divides a string into substrings at each Unicode whitespace
   occurrence with leading and trailing whitespace ignored. Groups
-  of whitespace are treated as a single occurrence.
+  of whitespace are treated as a single occurrence. Divisions do
+  not occur on non-breaking whitespace.
 
   ## Examples
 
@@ -253,6 +254,9 @@ defmodule String do
 
       iex> String.split(" foo   bar ")
       ["foo", "bar"]
+
+      iex> String.split("no\u00a0break")
+      ["no\u00a0break"]
 
   """
   @spec split(t) :: [t]

--- a/lib/elixir/unicode/WhiteSpace.txt
+++ b/lib/elixir/unicode/WhiteSpace.txt
@@ -1,0 +1,11 @@
+0009..000D    ; White_Space # Cc   [5] <control-0009>..<control-000D>
+0020          ; White_Space # Zs       SPACE
+0085          ; White_Space # Cc       <control-0085>
+00A0          ; White_Space # Zs       NO-BREAK SPACE
+1680          ; White_Space # Zs       OGHAM SPACE MARK
+2000..200A    ; White_Space # Zs  [11] EN QUAD..HAIR SPACE
+2028          ; White_Space # Zl       LINE SEPARATOR
+2029          ; White_Space # Zp       PARAGRAPH SEPARATOR
+202F          ; White_Space # Zs       NARROW NO-BREAK SPACE
+205F          ; White_Space # Zs       MEDIUM MATHEMATICAL SPACE
+3000          ; White_Space # Zs       IDEOGRAPHIC SPACE


### PR DESCRIPTION
We have been using BiDi character types to determine which unicode characters to consider as whitespace (looking at `B`, `S` and `WS`). By some reason the character set of BiDi whitespace is different than the set for the unicode `White_Space` property. This difference causes surprise in users since the docs for `String.strip/1` and `String.split/1` refer to "unicode whitespace" (the main concern expressed so far is the exclusion of the no-break space `0x0020` from the BiDi set, see #4300).

This PR swaps the use of BiDi character types by the use of the `White_Space` property by adding a subset of a new Unicode table (`PropList.txt`) and a parser for it. This makes the implementation better match the documentation.

Additionally, the no-break characters are excluded from `split` (since splitting on a no-break character seems contradictory) and its documentation is updated to document this.

