### PR TITLE
Add --logger-otp and --logger-sasl to the command-line args

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -68,6 +68,20 @@ while [ $I -le $# ]; do
         eval "VAL=\${$I}"
         ERL="$ERL `echo $PEEK | cut -c 2-` "$VAL""
         ;;
+    --logger-otp-reports)
+        I=$(expr $I + 1)
+        eval "VAL=\${$I}"
+        if [ "$VAL" == 'true' ] || [ "$VAL" == 'false' ]; then
+            ERL="$ERL -logger handle_otp_reports "$VAL""
+        fi
+        ;;
+    --logger-sasl-reports)
+        I=$(expr $I + 1)
+        eval "VAL=\${$I}"
+        if [ "$VAL" == 'true' ] || [ "$VAL" == 'false' ]; then
+            ERL="$ERL -logger handle_sasl_reports "$VAL""
+        fi
+        ;;
     --erl)
         I=$(expr $I + 1)
         eval "VAL=\${$I}"

--- a/bin/elixir.bat
+++ b/bin/elixir.bat
@@ -76,12 +76,14 @@ IF """"=="%par:-pz=%"     (shift)
 IF """"=="%par:--app=%"   (shift) 
 IF """"=="%par:--remsh=%" (shift) 
 rem ******* ERLANG PARAMETERS **********************
-IF """"=="%par:--detached=%" (Set parsErlang=%parsErlang% -detached) 
-IF """"=="%par:--hidden=%"   (Set parsErlang=%parsErlang% -hidden)
-IF """"=="%par:--cookie=%"   (Set parsErlang=%parsErlang% -setcookie %1 && shift)
-IF """"=="%par:--sname=%"    (Set parsErlang=%parsErlang% -sname %1 && shift) 
-IF """"=="%par:--name=%"     (Set parsErlang=%parsErlang% -name %1 && shift) 
-IF """"=="%par:--erl=%"      (Set beforeExtra=%beforeExtra% %~1 && shift) 
+IF """"=="%par:--detached=%"            (Set parsErlang=%parsErlang% -detached) 
+IF """"=="%par:--hidden=%"              (Set parsErlang=%parsErlang% -hidden)
+IF """"=="%par:--cookie=%"              (Set parsErlang=%parsErlang% -setcookie %1 && shift)
+IF """"=="%par:--sname=%"               (Set parsErlang=%parsErlang% -sname %1 && shift) 
+IF """"=="%par:--name=%"                (Set parsErlang=%parsErlang% -name %1 && shift) 
+IF """"=="%par:--logger-otp-reports=%"  (Set parsErlang=%parsErlang% -logger handle_otp_reports %1 && shift) 
+IF """"=="%par:--logger-sasl-reports=%" (Set parsErlang=%parsErlang% -logger handle_sasl_reports %1 && shift) 
+IF """"=="%par:--erl=%"                 (Set beforeExtra=%beforeExtra% %~1 && shift) 
 goto:startloop
 
 rem ******* assume all pre-params are parsed ********************

--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -187,7 +187,7 @@ defmodule Kernel.CLI do
     parse_shared t, %{config | commands: [{:parallel_require, h} | config.commands]}
   end
 
-  defp parse_shared([erl, _|t], config) when erl in ["--erl", "--sname", "--name", "--cookie"] do
+  defp parse_shared([erl, _|t], config) when erl in ["--erl", "--sname", "--name", "--cookie", "--logger-otp-reports", "--logger-sasl-reports"] do
     parse_shared t, config
   end
 


### PR DESCRIPTION
This PR should address #4355.

I added the following command-line arguments to the `elixir` binary:

  * `--logger-otp true|false` - to configure the `:handle_otp_reports`
    of the `:logger` application
  * `--logger-sasl true|false` - to configure the `:handle_sasl_reports`
    of the `:logger` application

Not sure this is the best way, consider this as an attempt :). Let me know if I can do anything else!