### PR TITLE
Faster compilation with maps instead of function heads

### DIFF
--- a/lib/elixir/unicode/unicode.ex
+++ b/lib/elixir/unicode/unicode.ex
@@ -309,18 +309,17 @@ defmodule String.Graphemes do
 
   # Handle Hangul L
 
-  @cluster_reverse_map (for {class, list} <- cluster, codepoint <- list do
-    {codepoint, class}
-  end
-  |> Map.new)
+  @cluster_reverse_map (for {class, list} <- cluster, class == "L" or class == "LV" or class == "LVT", codepoint <- list, into: %{} do
+    {codepoint, String.to_atom(class)}
+  end)
 
-  defp next_hangul_l_size(string, size) do
-    {codepoint, rest} = String.next_codepoint(string)
-    class_for_codepoint = @cluster_reverse_map[codepoint]
+  defp next_hangul_l_size(<<unicode_cp::utf8, rest::binary>> = string, size) do
+    codepoint = <<unicode_cp::utf8>>
+    class_for_codepoint = Map.get(@cluster_reverse_map, codepoint)
     case class_for_codepoint do
-      "L" ->   next_hangul_l_size(rest, size + byte_size(codepoint))
-      "LV" ->  next_hangul_v_size(rest, size + byte_size(codepoint))
-      "LVT" -> next_hangul_t_size(rest, size + byte_size(codepoint))
+      :L ->   next_hangul_l_size(rest, size + byte_size(codepoint))
+      :LV ->  next_hangul_v_size(rest, size + byte_size(codepoint))
+      :LVT -> next_hangul_t_size(rest, size + byte_size(codepoint))
       _ ->     next_hangul_v_size(string, size)
     end
   end

--- a/lib/elixir/unicode/unicode.ex
+++ b/lib/elixir/unicode/unicode.ex
@@ -308,26 +308,21 @@ defmodule String.Graphemes do
   end
 
   # Handle Hangul L
-  for codepoint <- cluster["L"] do
-    defp next_hangul_l_size(<<unquote(codepoint), rest::binary>>, size) do
-      next_hangul_l_size(rest, size + unquote(byte_size(codepoint)))
-    end
-  end
 
-  for codepoint <- cluster["LV"] do
-    defp next_hangul_l_size(<<unquote(codepoint), rest::binary>>, size) do
-      next_hangul_v_size(rest, size + unquote(byte_size(codepoint)))
-    end
+  @cluster_reverse_map (for {class, list} <- cluster, codepoint <- list do
+    {codepoint, class}
   end
+  |> Map.new)
 
-  for codepoint <- cluster["LVT"] do
-    defp next_hangul_l_size(<<unquote(codepoint), rest::binary>>, size) do
-      next_hangul_t_size(rest, size + unquote(byte_size(codepoint)))
+  defp next_hangul_l_size(string, size) do
+    {codepoint, rest} = String.next_codepoint(string)
+    class_for_codepoint = @cluster_reverse_map[codepoint]
+    case class_for_codepoint do
+      "L" ->   next_hangul_l_size(rest, size + byte_size(codepoint))
+      "LV" ->  next_hangul_v_size(rest, size + byte_size(codepoint))
+      "LVT" -> next_hangul_t_size(rest, size + byte_size(codepoint))
+      _ ->     next_hangul_v_size(string, size)
     end
-  end
-
-  defp next_hangul_l_size(rest, size) do
-    next_hangul_v_size(rest, size)
   end
 
   # Handle Hangul V


### PR DESCRIPTION
Speed up compilation of the unicode module by switching `next_hangul_l_size`
from using many function heads to doing lookups in a map.

As of Elixir 1.2.3 / Erlang 18, map performance is much improved. In my
experiments, in cases where we associate static keys and values, looking up a
key in a map performs just as well as finding a matching function head for the
static key, but compilation time grows much more slowly as the number of keys
increases.

Compile time is obviously much less important than run time performance, however. Here's what and how I've measured - **please tell me if I'm missing something**:

- `time (cd lib/elixir &&
 \ ../../bin/elixirc --verbose --ignore-module-conflict unicode/unicode.ex -o ebin)`
 \ to measure compile time on both master and this feature branch
- `elixir speed_test.exs` to see the runtime for calculating string graphemes

My results were:

     -------------------------------------------------------
     |                        | master      | PR           |
     -------------------------------------------------------
     | compile `unicode.ex`   | 23s         | 9s           |
     -------------------------------------------------------
     | `speed_test.exs`       | 0.6 μs/call | 0.6 μs/call  |
     -------------------------------------------------------
     | mem for speed test     | 30MB        | 30 MB        |
     -------------------------------------------------------

I used this script for timing the runtime execution:

     # speed_test.exs
     IO.inspect ["working correctly?", String.graphemes("\u1100\u115D\uB4A4") == ["ᄀᅝ뒤"]]

     some_func = fn ->
       String.graphemes("\u1100\u115D\uB4A4")
     end

     run_n_times = fn (count, func) ->
       Enum.each(1..count, fn (_i) ->
         func.()
       end)
     end

     n = 800_000

     {microseconds, :ok} = :timer.tc(run_n_times, [n, some_func])
     IO.puts "#{microseconds / n} microseconds per call (#{microseconds} total for #{n} calls)"

See also: [an earlier (and simpler) experiment I tried comparing maps and function heads](https://gist.github.com/nathanl/27e19896bba489799804).