### PR TITLE
Fix edge case when piping in unary operators.

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2703,7 +2703,15 @@ defmodule Kernel do
   """
   defmacro left |> right do
     [{h, _}|t] = Macro.unpipe({:|>, [], [left, right]})
-    :lists.foldl fn {x, pos}, acc -> Macro.pipe(acc, x, pos) end, h, t
+    :lists.foldl fn {x, pos}, acc ->
+      # TODO: raise an error in `Macro.pipe` when we drop unary operator support in pipes
+      case Macro.pipe_warning(x) do
+        nil -> :ok
+        message ->
+          :elixir_errors.warn(__CALLER__.line, __CALLER__.file, message)
+      end
+      Macro.pipe(acc, x, pos)
+    end, h, t
   end
 
   @doc """

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -153,6 +153,12 @@ defmodule Macro do
     "can only pipe into local calls foo(), remote calls Foo.bar() or anonymous functions calls foo.()"
   end
 
+  @doc false
+  def pipe_warning({call, _, _}) when call in unquote(@unary_ops) do
+    "piping into a unary operator is deprecated"
+  end
+  def pipe_warning(_), do: nil
+
   @doc """
   Applies the given function to the node metadata if it contains one.
 

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -556,6 +556,11 @@ defmodule MacroTest do
     assert_raise ArgumentError, ~r"cannot pipe 1 into 1 \+ 1", fn ->
       Macro.pipe(1, quote(do: 1 + 1), 0) == quote(do: foo(1))
     end
+
+    # TODO: restore this test when we drop unary operator support in pipes
+    # assert_raise ArgumentError, ~r"cannot pipe 1 into \+1", fn ->
+    #   Macro.pipe(1, quote(do: + 1), 0)
+    # end
   end
 
   test "unpipe" do


### PR DESCRIPTION
The following question has been asked in Slack.

> pdilyard [12:08 PM] 
> why does this work:
> ```
> iex> 2 |> + 2
> 4
> ```
> but this doesn’t?
> ```
> iex> 2 |> * 2
> ** (SyntaxError) iex:2: syntax error before: '*'

https://elixir-lang.slack.com/archives/general/p1458184122001480


I believe this is an edge case with operators that work as both unary and binary,
but it should fail.
I therefore modified `Macro.pipe` to fail when the operator is unary.