### PR TITLE
Make Application.app_dir/2 accept a list as path argument.

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -376,9 +376,12 @@ defmodule Application do
   @doc """
   Returns the given path inside `app_dir/1`.
   """
-  @spec app_dir(app, String.t) :: String.t
+  @spec app_dir(app, String.t | [String.t]) :: String.t
   def app_dir(app, path) when is_binary(path) do
     Path.join(app_dir(app), path)
+  end
+  def app_dir(app, path) when is_list(path) do
+    Path.join([app_dir(app)|path])
   end
 
   @doc """

--- a/lib/elixir/test/elixir/application_test.exs
+++ b/lib/elixir/test/elixir/application_test.exs
@@ -56,6 +56,8 @@ defmodule ApplicationTest do
            String.downcase(Path.join(root, "bin/../lib/elixir"))
     assert String.downcase(Application.app_dir(:elixir, "priv")) ==
            String.downcase(Path.join(root, "bin/../lib/elixir/priv"))
+    assert String.downcase(Application.app_dir(:elixir, ["priv", "foo"])) ==
+           String.downcase(Path.join(root, "bin/../lib/elixir/priv/foo"))
 
     assert_raise ArgumentError, fn ->
       Application.app_dir(:unknown)


### PR DESCRIPTION
As Path.join is able to accept a list as argument, it seems logical that Application.app_dir should be able to do so as well.