### PR TITLE
Add the keyword/0 and keyword/1 built-in types

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -408,6 +408,8 @@ defmodule Kernel.Typespec do
   defp elixir_builtin_type?(:as_boolean, 1), do: true
   defp elixir_builtin_type?(:struct, 0), do: true
   defp elixir_builtin_type?(:char_list, 0), do: true
+  defp elixir_builtin_type?(:keyword, 0), do: true
+  defp elixir_builtin_type?(:keyword, 1), do: true
   defp elixir_builtin_type?(_, _), do: false
 
   @doc false
@@ -642,6 +644,10 @@ defmodule Kernel.Typespec do
 
   defp typespec_to_ast({:remote_type, line, [{:atom, _, :elixir}, {:atom, _, :as_boolean}, [arg]]}) do
     typespec_to_ast({:type, line, :as_boolean, [arg]})
+  end
+
+  defp typespec_to_ast({:remote_type, line, [{:atom, _, :elixir}, {:atom, _, :keyword}, args]}) do
+    typespec_to_ast({:type, line, :keyword, args})
   end
 
   defp typespec_to_ast({:remote_type, line, [mod, name, args]}) do
@@ -886,6 +892,10 @@ defmodule Kernel.Typespec do
 
   defp typespec({:as_boolean, _meta, [arg]}, vars, caller) do
     typespec((quote do: :elixir.as_boolean(unquote(arg))), vars, caller)
+  end
+
+  defp typespec({:keyword, _meta, args}, vars, caller) when length(args) <= 1 do
+    typespec((quote do: :elixir.keyword(unquote_splicing(args))), vars, caller)
   end
 
   defp typespec({:fun, meta, args}, vars, caller) do

--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -99,6 +99,8 @@ Built-in type           | Defined as
 `fun()`                 | `(... -> any)`
 `struct()`              | `%{__struct__: atom()}`
 `as_boolean(t)`         | `t`
+`keyword()`             | `[{atom(), any()}]`
+`keyword(t)`            | `[{atom(), t}]`
 
 ### Remote types
 

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -10,10 +10,12 @@
 -define(system, 'Elixir.System').
 
 %% Top level types
--export_type([char_list/0, struct/0, as_boolean/1]).
+-export_type([char_list/0, struct/0, as_boolean/1, keyword/0, keyword/1]).
 -type char_list() :: string().
 -type struct() :: #{'__struct__' => atom()}.
 -type as_boolean(T) :: T.
+-type keyword() :: [{atom(), any()}].
+-type keyword(T) :: [{atom(), T}].
 
 %% OTP Application API
 

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -553,6 +553,8 @@ defmodule Kernel.TypespecTest do
       (quote do: @type cl() :: char_list()),
       (quote do: @type st() :: struct()),
       (quote do: @type ab() :: as_boolean(term())),
+      (quote do: @type kw() :: keyword()),
+      (quote do: @type kwt() :: keyword(term())),
       (quote do: @type vaf() :: (... -> any())),
       (quote do: @type rng() :: 1..10),
       (quote do: @type opts() :: [first: integer(), step: integer(), last: integer()]),


### PR DESCRIPTION
I find the `keyword/0` and `keyword/1` types discussed in #3679 pretty convenient, so I took a shot at a PR that implements them. Not sure this is the correct way to solve that though, so any feedback is more than welcome :smiley_cat: 