### PR TITLE
Allow dots in the metadata info in Version.parse/1

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -365,7 +365,7 @@ defmodule Version do
       (?:\.(\d+))?          # minor
       (?:\.(\d+))?          # patch
       (?:\-([\d\w\.\-]+))?  # pre
-      (?:\+([\d\w\-]+))?    # build
+      (?:\+([\d\w\.\-]+))?  # build
       $/x
 
     @spec parse_requirement(String.t) :: {:ok, term} | :error

--- a/lib/elixir/test/elixir/version_test.exs
+++ b/lib/elixir/test/elixir/version_test.exs
@@ -60,6 +60,7 @@ defmodule VersionTest do
   test "parse" do
     assert {:ok, %V{major: 1, minor: 2, patch: 3}} = V.parse("1.2.3")
     assert {:ok, %V{major: 1, minor: 4, patch: 5}} = V.parse("1.4.5+ignore")
+    assert {:ok, %V{major: 0, minor: 0, patch: 1}} = V.parse("0.0.1+sha.0702245")
     assert {:ok, %V{major: 1, minor: 4, patch: 5, pre: ["6-g3318bd5"]}} = V.parse("1.4.5-6-g3318bd5")
     assert {:ok, %V{major: 1, minor: 4, patch: 5, pre: [6, 7, "eight"]}} = V.parse("1.4.5-6.7.eight")
     assert {:ok, %V{major: 1, minor: 4, patch: 5, pre: ["6-g3318bd5"]}} = V.parse("1.4.5-6-g3318bd5+ignore")


### PR DESCRIPTION
Should close #4407.

According to the SEMVER spec (http://semver.org/#spec-item-10):

  > Build metadata MAY be denoted by appending a plus sign and a series
  > of dot separated identifiers [...].

The dot was not previously allowed, with this commit it is.