### PR TITLE
Added faster implementation of Enum.sum that works on Ranges. 

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1408,7 +1408,17 @@ defmodule Enum do
 
   """
   @spec sum(t) :: number
-  def sum(enumerable) do
+  def sum(enumerable)
+
+  def sum(first..last) when last > first do
+    ((last * (last + 1)) / 2) - ((first * (first - 1)) / 2)    
+  end
+  
+  def sum(first..last) do
+    ((first * (first + 1)) / 2) - ((last * (last - 1)) / 2)
+  end
+
+  def sum(enumerable) do      
     reduce(enumerable, 0, &+/2)
   end
 

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -423,6 +423,12 @@ defmodule EnumTest do
     assert_raise ArithmeticError, fn ->
       Enum.sum([1, {}])
     end
+    assert Enum.sum(0..0) == 0
+    assert Enum.sum(0..100) == 5050
+    assert Enum.sum(10..100) == 5005
+    assert Enum.sum(100..10) == 5005
+    assert Enum.sum(-10..-20) == -165
+    assert Enum.sum(-10..2) == -52
   end
 
   test "take" do


### PR DESCRIPTION
As described in the [mailing list topic](https://groups.google.com/forum/#!topic/elixir-lang-core/iIDFkQUiXIs), I've wanted to create a faster implementation of *Enum.sum* that is used for Ranges instead. This implementation runs in **O(1)** instead of **O(n)**, which is why I think it was worth the change.

As this is my first contribution to the Elixir project, I fully expect that I might have missed some important part of the guidelines. In that case, please tell me and I will happily improve my coding efforts.