### PR TITLE
MapSet Optimizations

### DIFF
--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -38,6 +38,21 @@ defmodule MapTest do
     assert map_size(@sample) == 2
   end
 
+  test "take/2" do
+    assert Map.take(%{a: 1, b: 2, c: 3}, [:b, :c]) == %{b: 2, c: 3}
+    assert Map.take(%{a: 1, b: 2, c: 3}, MapSet.new([:b, :c])) == %{b: 2, c: 3}
+  end
+
+  test "drop/2" do
+    assert Map.drop(%{a: 1, b: 2, c: 3}, [:b, :c]) == %{a: 1}
+    assert Map.drop(%{a: 1, b: 2, c: 3}, MapSet.new([:b, :c])) == %{a: 1}
+  end
+
+  test "split/2" do
+    assert Map.split(%{a: 1, b: 2, c: 3}, [:b, :c]) == {%{b: 2, c: 3}, %{a: 1}}
+    assert Map.split(%{a: 1, b: 2, c: 3}, MapSet.new([:b, :c])) == {%{b: 2, c: 3}, %{a: 1}}
+  end
+
   test "maps with optional comma" do
     assert %{a: :b,} == %{a: :b}
     assert %{1 => 2,} == %{1 => 2}


### PR DESCRIPTION
# Overview

Hey folks!

Based upon discoveries made during my little foray into map performance characteristics a few weeks ago I thought I'd give `MapSet` a work over. I was also very curious about the circumstances under which `MapSet` out performs `:lists.subtract` 

Warning: Be careful when benchmarking `--` or `:lists.subtract`. The compiler (I think it's the compiler) does some crazy optimizations when operating on list literals. Always create a module / function like `MyList.subtract/2` and call that instead, otherwise the result will be pre-computed at compile time.

## General Changes

Many of the current functions use `:maps.fold`. Under the covers `:maps.fold` calls `:maps.to_list` first, and then `:lists.foldl`. In many cases `:maps.fold` uses `Map.put` to accumulate desired results in a new map.

This gives us three general opportunities for improvement.

- By far the largest improvement comes from first accumulating `{key, value}` pairs into a list, and then using `:maps.from_list` instead of consecutive calls to `Map.put/2`. This is not only faster, but (from what I've been told) produces less garbage for the GC. If anyone knows of a good way to quantify the amount of garbage produced I'd love to hear it.

- `:maps.to_list` can be improved upon by simply using `Map.keys`. Not only does `Map.keys` happen to be faster, it also improves code clarity because we only care about the keys anyway.

- `:lists.fold` can be improved upon by manually recursing through lists produced by `Map.keys` and calling other functions as needed. While this does make the code more verbose, it tends to get us about a 20% improvement.

# Functions

Benchmarking notes: Y axis is in micro seconds.

## `MapSet.difference/2`

Benchmark: https://github.com/benwilson512/elixir-profiling/blob/master/bench/mapset_difference_bench.exs

![image](https://cloud.githubusercontent.com/assets/247817/13906370/02cb018c-eeab-11e5-868b-5d53e6ad85d0.png)

`MapSet.difference(set1, set2)` is the only function that had any algorithmic changes. The current approach iterates through `set2` and deletes each item found from `set1`.

I realized that when `set2` is larger than `set1` this no longer makes any sense. Instead it is faster to iterate through each item in `set1` and only accumulate those items which do not also exist in `set2`.

After testing, I determined that it becomes faster to iterate through `set1` when `set2` is at least half the size of `set1`.

## `MapSet.intersection/2`

Benchmark: https://github.com/benwilson512/elixir-profiling/blob/master/bench/mapset_intersection_bench.exs

![image](https://cloud.githubusercontent.com/assets/247817/13909997/ddff8ffc-eef1-11e5-8775-c12a87795d47.png)

Accumulate in a list, manual recursion, Map.keys. These small changes produce a surprisngly substantial improvement.

## `MapSet.disjoint/2`

Benchmark: https://github.com/benwilson512/elixir-profiling/blob/master/bench/mapset_disjoint_bench.exs

![image](https://cloud.githubusercontent.com/assets/247817/13906418/ea27de2e-eeab-11e5-810a-040b345deb19.png)

The previous version iterated through the smallest set and would `throw` in the event that a given key was also found in the other set.

This version uses `Map.keys` and manual recursion to achieve functional flow control and superior performance.

## `MapSet.new`

Benchmark: https://github.com/benwilson512/elixir-profiling/blob/master/bench/mapset_new_bench.exs

![image](https://cloud.githubusercontent.com/assets/247817/13910215/de04a854-eef4-11e5-883e-28d33889bb6b.png)
![image](https://cloud.githubusercontent.com/assets/247817/13910222/057c4f5e-eef5-11e5-8bea-01b5b356724e.png)

Manual recursion, list accumulation.

While I was at it, I took a similar approach with `Map.new/1,2`.

## `MapSet.disjoint?`

![image](https://cloud.githubusercontent.com/assets/247817/13910047/76e2b578-eef2-11e5-94d9-10f332a038a7.png)

# Comparison to `--`

I'm still working on this, I figured I should get some feedback on my changes here before going further on this because any major changes we make have the potential to change my analysis here.