### PR TITLE
Remove reference to old `Inspect.Opts.new`

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -48,7 +48,7 @@ defprotocol Inspect do
   implementation directly. For example, to test Inspect.MapSet above,
   you can invoke it as:
 
-      Inspect.MapSet.inspect(MapSet.new, Inspect.Opts.new)
+      Inspect.MapSet.inspect(MapSet.new, %Inspect.Opts{})
 
   """
 


### PR DESCRIPTION
The previous code was erroring out:

```elixir
iex(1)> Inspect.MapSet.inspect(MapSet.new, Inspect.Opts.new)
** (UndefinedFunctionError) undefined function Inspect.Opts.new/0
    (elixir) Inspect.Opts.new()
```

Now it works:

```elixir
iex(1)> Inspect.MapSet.inspect(MapSet.new, %Inspect.Opts{})
{:doc_cons, "#MapSet<", {:doc_cons, "[]", ">"}}
```