### PR TITLE
Make @doc, @doc(value) and get_attribute/2, put_attribute/3 consistent

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2276,9 +2276,8 @@ defmodule Kernel do
   """
   defmacro @(expr)
 
-  # Typespecs attributes are special cased by the compiler so far
   defmacro @({name, _, args}) do
-    # Check for Macro as it is compiled later than Module
+    # Check for Module as it is compiled later than Kernel
     case bootstraped?(Module) do
       false -> nil
       true  ->
@@ -2291,6 +2290,7 @@ defmodule Kernel do
             raise ArgumentError, "invalid write attribute syntax, you probably meant to use: @#{name} expression"
         end
 
+        # Typespecs attributes are special cased by the compiler so far
         case is_list(args) and length(args) == 1 and typespec(name) do
           false ->
             do_at(args, name, function?, __CALLER__)

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1059,7 +1059,7 @@ defmodule Module do
 
     case :ets.lookup(table, key) do
       [{^key, val}] ->
-        postprocess_attribute(key, val)
+        val
       [] ->
         acc = :ets.lookup_element(table, {:elixir, :acc_attributes}, 2)
 
@@ -1086,6 +1086,13 @@ defmodule Module do
   end
 
   ## Helpers
+
+  defp preprocess_attribute(key, value) when key in [:moduledoc, :typedoc, :doc] do
+    unless match?({line, _} when is_integer(line), value) do
+      raise ArgumentError, "expected #{key} attribute given in the {line, doc} format, got: #{inspect(value)}"
+    end
+    value
+  end
 
   defp preprocess_attribute(:on_load, atom) when is_atom(atom) do
     {atom, 0}
@@ -1116,11 +1123,6 @@ defmodule Module do
   defp preprocess_attribute(_key, value) do
     value
   end
-
-  defp postprocess_attribute(:doc, {_line, doc}), do: doc
-  defp postprocess_attribute(:typedoc, {_line, doc}), do: doc
-  defp postprocess_attribute(:moduledoc, {_line, doc}), do: doc
-  defp postprocess_attribute(_, value), do: value
 
   defp get_doc_info(table, env) do
     case :ets.take(table, :doc) do

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -663,6 +663,18 @@ defmodule Kernel.ErrorsTest do
       'Module.eval_quoted Record, quote(do: 1), [], file: __ENV__.file'
   end
 
+  test "doc attributes format" do
+    message = "expected moduledoc attribute given " <>
+      "in the {line, doc} format, got: \"Other\""
+    assert_raise ArgumentError, message, fn ->
+      defmodule DocAttributesFormat do
+        @moduledoc "ModuleTest"
+        {671, "ModuleTest"} = Module.get_attribute(__MODULE__, :moduledoc)
+        Module.put_attribute(__MODULE__, :moduledoc, "Other")
+      end
+    end
+  end
+
   test "interpolation error" do
     assert_compile_fail SyntaxError,
       "nofile:1: unexpected token: \")\". \"do\" starting at line 1 is missing terminator \"end\"",

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -98,6 +98,8 @@ defmodule KernelTest do
 
   @at_list  [4, 5]
   @at_range 6..8
+  @doc "fun_in/1"
+  "fun_in/1" = @doc
   def fun_in(x) when x in [0],       do: :list
   def fun_in(x) when x in 1..3,      do: :range
   def fun_in(x) when x in @at_list,  do: :at_list

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -45,7 +45,9 @@ defmodule ModuleTest do
   @register_example :it_works
   @register_example :still_works
 
-  contents = quote do: (def eval_quoted_info, do: {__MODULE__, __ENV__.file, __ENV__.line})
+  contents = quote do
+    def eval_quoted_info, do: {__MODULE__, __ENV__.file, __ENV__.line}
+  end
   Module.eval_quoted __MODULE__, contents, [], file: "sample.ex", line: 13
 
   defmacrop in_module(block) do


### PR DESCRIPTION
At (@) syntax works with doc value, Module functions with actual representation.

Closes #4418.