### PR TITLE
Add `Version.parse!/1`

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -234,6 +234,28 @@ defmodule Version do
   end
 
   @doc """
+  Parses a version string into a `Version`.
+
+  If `string` is an invalid version, an `InvalidVersionError` is raised.
+
+  ## Examples
+
+      iex> Version.parse!("2.0.1-alpha1")
+      #Version<2.0.1-alpha1>
+
+      iex> Version.parse!("2.0-alpha1")
+      ** (Version.InvalidVersionError) 2.0-alpha1
+
+  """
+  @spec parse!(String.t) :: t | no_return
+  def parse!(string) when is_binary(string) do
+    case parse(string) do
+      {:ok, version} -> version
+      :error -> raise InvalidVersionError, message: string
+    end
+  end
+
+  @doc """
   Parses a version requirement string into a `Version.Requirement`.
 
   ## Examples

--- a/lib/elixir/test/elixir/version_test.exs
+++ b/lib/elixir/test/elixir/version_test.exs
@@ -72,12 +72,12 @@ defmodule VersionTest do
   end
 
   test "to_string" do
-    assert V.parse("1.0.0") |> elem(1) |> to_string == "1.0.0"
-    assert V.parse("1.0.0-dev") |> elem(1) |> to_string == "1.0.0-dev"
-    assert V.parse("1.0.0+lol") |> elem(1) |> to_string == "1.0.0+lol"
-    assert V.parse("1.0.0-dev+lol") |> elem(1) |> to_string == "1.0.0-dev+lol"
-    assert V.parse("1.0.0-0") |> elem(1) |> to_string == "1.0.0-0"
-    assert V.parse("1.0.0-rc.0") |> elem(1) |> to_string == "1.0.0-rc.0"
+    assert V.parse!("1.0.0") |> to_string == "1.0.0"
+    assert V.parse!("1.0.0-dev") |> to_string == "1.0.0-dev"
+    assert V.parse!("1.0.0+lol") |> to_string == "1.0.0+lol"
+    assert V.parse!("1.0.0-dev+lol") |> to_string == "1.0.0-dev+lol"
+    assert V.parse!("1.0.0-0") |> to_string == "1.0.0-0"
+    assert V.parse!("1.0.0-rc.0") |> to_string == "1.0.0-rc.0"
   end
 
   test "invalid match" do


### PR DESCRIPTION
I was recently working with versions a bit, and `Version.parse!` would be really handy in iex and tests. For now, I'm manually pattern matching in iex, and have a `version!` helper function in tests.