### PR TITLE
Spelling & Resolve dialyzer warnings:  no local return and only terminates with explicit exception

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -58,7 +58,7 @@ defmodule Integer do
       [1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1]
 
   """
-  @spec digits(non_neg_integer, pos_integer) :: [non_neg_integer]
+  @spec digits(non_neg_integer, pos_integer) :: [non_neg_integer, ...]
   def digits(n, base \\ 10) when is_integer(n)    and n >= 0
                             and  is_integer(base) and base >= 2 do
     do_digits(n, base, [])

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1331,7 +1331,7 @@ defmodule Kernel do
   defmacro raise(msg) do
     # Try to figure out the type at compilation time
     # to avoid dead code and make Dialyzer happy.
-    msg = case not is_binary(msg) and bootstraped?(Macro) do
+    msg = case not is_binary(msg) and bootstrapped?(Macro) do
       true  -> Macro.expand(msg, __CALLER__)
       false -> msg
     end
@@ -2278,7 +2278,7 @@ defmodule Kernel do
 
   defmacro @({name, _, args}) do
     # Check for Module as it is compiled later than Kernel
-    case bootstraped?(Module) do
+    case bootstrapped?(Module) do
       false -> nil
       true  ->
         assert_module_scope(__CALLER__, :@, 1)
@@ -2295,7 +2295,7 @@ defmodule Kernel do
           false ->
             do_at(args, name, function?, __CALLER__)
           macro ->
-            case bootstraped?(Kernel.Typespec) do
+            case bootstrapped?(Kernel.Typespec) do
               false -> nil
               true  -> quote do: Kernel.Typespec.unquote(macro)(unquote(hd(args)))
             end
@@ -2797,7 +2797,7 @@ defmodule Kernel do
   defmacro left in right do
     in_module? = (__CALLER__.context == nil)
 
-    right = case bootstraped?(Macro) and not in_module? do
+    right = case bootstrapped?(Macro) and not in_module? do
       true  -> Macro.expand(right, __CALLER__)
       false -> right
     end
@@ -3003,7 +3003,7 @@ defmodule Kernel do
   """
   defmacro defmodule(alias, do: block) do
     env   = __CALLER__
-    boot? = bootstraped?(Macro)
+    boot? = bootstrapped?(Macro)
 
     expanded =
       case boot? do
@@ -4101,9 +4101,9 @@ defmodule Kernel do
   # Once Kernel is loaded and we recompile, it is a no-op.
   case :code.ensure_loaded(Kernel) do
     {:module, _} ->
-      defp bootstraped?(_), do: true
+      defp bootstrapped?(_), do: true
     {:error, _} ->
-      defp bootstraped?(module), do: :code.ensure_loaded(module) == {:module, module}
+      defp bootstrapped?(module), do: :code.ensure_loaded(module) == {:module, module}
   end
 
   defp assert_module_scope(env, fun, arity) do
@@ -4121,7 +4121,7 @@ defmodule Kernel do
   end
 
   defp env_stacktrace(env) do
-    case bootstraped?(Path) do
+    case bootstrapped?(Path) do
       true  -> Macro.Env.stacktrace(env)
       false -> []
     end

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -70,8 +70,7 @@ defmodule Range do
       false
 
   """
-  @spec range?(%Range{}) :: true
-  @spec range?(term) :: false
+  @spec range?(term) :: boolean
   def range?(term)
   def range?(%Range{}), do: true
   def range?(_), do: false

--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -80,7 +80,7 @@ defmodule ExUnit.Filters do
       {:error, "due to foo filter"}
 
   """
-  @spec eval(t, t, map, [ExUnit.Test.t]) :: :ok | {:error, atom}
+  @spec eval(t, t, map, [ExUnit.Test.t]) :: :ok | {:error, binary}
   def eval(include, exclude, tags, collection) when is_map(tags) do
     case Map.fetch(tags, :skip) do
       {:ok, msg} when is_binary(msg) ->

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -269,6 +269,7 @@ defmodule Mix do
   @doc """
   Raises a Mix error that is nicely formatted.
   """
+  @spec raise(binary) :: no_return
   def raise(message) when is_binary(message) do
     Kernel.raise Mix.Error, mix: true, message: message
   end

--- a/lib/mix/lib/mix/scm/path.ex
+++ b/lib/mix/lib/mix/scm/path.ex
@@ -46,6 +46,7 @@ defmodule Mix.SCM.Path do
     []
   end
 
+  @spec checkout(list) :: no_return
   def checkout(opts) do
     path = Path.relative_to_cwd opts[:dest]
     Mix.raise "Cannot checkout path dependency, expected a dependency at #{path}"


### PR DESCRIPTION
- Function checkout/1 has no local return
- Function raise/1 only terminates with explicit exception
- lib/ex_unit/filters.ex:83: The specification for 'Elixir.ExUnit.Filters':eval/4 states that the function might also return {'error',atom()} but the inferred return is 'ok' | {'error',binary()}
- lib/range.ex:73: Overloaded contract for 'Elixir.Range':'range?'/1 has overlapping domains; such contracts are currently unsupported and are simply ignored
- lib/integer.ex:61: Type specification 'Elixir.Integer':digits(non_neg_integer(),pos_integer()) -> [non_neg_integer()] is a supertype of the success typing: 'Elixir.Integer':digits(non_neg_integer(),pos_integer()) -> [non_neg_integer(),...]

