### PR TITLE
Suppress unused var warnings when removing Logger macros from the AST

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -56,6 +56,12 @@ defmodule Logger do
       Logger call will be completely removed at compile time, accruing
       no overhead at runtime. Defaults to `:debug` and only
       applies to the `Logger.debug/2`, `Logger.info/2`, etc style of calls.
+      Note that in calls are removed from the AST at compilation time, the
+      passed arguments are never evaluated, so any function call that occurs in
+      these arguments is never executed. As a consequence, avoid code that looks
+      like `Logger.debug("Cleanup: #{perform_cleanup()}")` as in the example
+      `perform_cleanup/0` won't be executed if the `:compile_time_purge_level`
+      is `:info` or higher.
 
     * `:compile_time_application` - sets the `:application` metadata value
       to the configured value at compilation time. This configuration is
@@ -78,7 +84,9 @@ defmodule Logger do
     * `:level` - the logging level. Attempting to log any message
       with severity less than the configured level will simply
       cause the message to be ignored. Keep in mind that each backend
-      may have its specific level, too.
+      may have its specific level, too. Note that, unlike what happens with the
+      `:compile_time_purge_level` option, the argument passed to `Logger` calls
+      is evaluated even if the level of the call is lower than `:level`.
 
     * `:utc_log` - when `true`, uses UTC in logs. By default it uses
       local time (i.e. it defaults to `false`).


### PR DESCRIPTION
Right now, code like this:

```elixir
defmodule MyMod do
  require Logger
  def my_fun(arg) do
    Logger.debug(arg)
    :ok
  end
end
```

will generate an unused variable warning for the `arg` variable in `my_fun/1` if the log level is higher than `:debug`, as discussed in #4417.This happens because in such cases, we completely remove the AST of the Logger call, so the `arg` variable is effectively never used. This may seem magical to the user.

With this PR, a `Logger` call which would have been removed from the AST before now generates a series of `_ = x` expressions, one for each variable passed to the `Logger` macro.

This will still not take care of private functions and unused imports (which will still warn if used in a `Logger` macro), but it's a step forward :). Let me know how it looks and if I can do anything else :heart_decoration: 