### PR TITLE
Handle chars literals in the parser for better syntax errors

### DIFF
--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -88,6 +88,15 @@ parse_error(Line, File, {ErrorPrefix, ErrorSuffix}, Token) when is_binary(ErrorP
   Message = <<ErrorPrefix/binary, Token/binary, ErrorSuffix/binary >>,
   do_raise(Line, File, 'Elixir.SyntaxError', Message);
 
+%% Misplaced char tokens (e.g., {char, _, 97}) are translated by Erlang into
+%% the char literal (i.e., the token in the previous example becomes $a),
+%% because {char, _, _} is a valid Erlang token for an Erlang char literal. We
+%% want to represent that token as ?a in the error, according to the Elixir
+%% syntax.
+parse_error(Line, File, <<"syntax error before: ">>, <<$$, Char/binary>>) ->
+  Message = <<"syntax error before: ?", Char/binary>>,
+  do_raise(Line, File, 'Elixir.SyntaxError', Message);
+
 %% Everything else is fine as is
 parse_error(Line, File, Error, Token) when is_binary(Error), is_binary(Token) ->
   Message = <<Error/binary, Token/binary >>,

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -14,6 +14,7 @@ Nonterminals
   bit_string open_bit close_bit
   map map_op map_close map_args map_expr struct_op
   assoc_op_eol assoc_expr assoc_base assoc_update assoc_update_kw assoc
+  number_or_char
   container_args_base container_args
   call_args_parens_expr call_args_parens_base call_args_parens parens_call
   call_args_no_parens_one call_args_no_parens_ambig call_args_no_parens_expr
@@ -31,7 +32,7 @@ Terminals
   identifier kw_identifier kw_identifier_safe kw_identifier_unsafe bracket_identifier
   paren_identifier do_identifier block_identifier
   fn 'end' aliases
-  number atom atom_safe atom_unsafe bin_string list_string sigil
+  number char atom atom_safe atom_unsafe bin_string list_string sigil
   dot_call_op op_identifier
   comp_op at_op unary_op and_op or_op arrow_op match_op in_op in_match_op
   type_op dual_op add_op mult_op two_op three_op pipe_op stab_op when_op assoc_op
@@ -233,9 +234,9 @@ no_parens_zero_expr -> dot_identifier : build_identifier('$1', nil).
 %% marks identifiers followed by brackets as bracket_identifier.
 access_expr -> bracket_at_expr : '$1'.
 access_expr -> bracket_expr : '$1'.
-access_expr -> at_op_eol number : build_unary_op('$1', ?exprs('$2')).
-access_expr -> unary_op_eol number : build_unary_op('$1', ?exprs('$2')).
-access_expr -> capture_op_eol number : build_unary_op('$1', ?exprs('$2')).
+access_expr -> at_op_eol number_or_char : build_unary_op('$1', '$2').
+access_expr -> unary_op_eol number_or_char : build_unary_op('$1', '$2').
+access_expr -> capture_op_eol number_or_char : build_unary_op('$1', '$2').
 access_expr -> fn_eoe stab end_eoe : build_fn('$1', reverse('$2')).
 access_expr -> open_paren stab close_paren : build_stab(reverse('$2')).
 access_expr -> open_paren stab ';' close_paren : build_stab(reverse('$2')).
@@ -243,7 +244,7 @@ access_expr -> open_paren ';' stab ';' close_paren : build_stab(reverse('$3')).
 access_expr -> open_paren ';' stab close_paren : build_stab(reverse('$3')).
 access_expr -> open_paren ';' close_paren : build_stab([]).
 access_expr -> empty_paren : nil.
-access_expr -> number : ?exprs('$1').
+access_expr -> number_or_char : '$1'.
 access_expr -> list : element(1, '$1').
 access_expr -> map : '$1'.
 access_expr -> tuple : '$1'.
@@ -591,6 +592,9 @@ struct_op -> '%' : '$1'.
 map -> map_op map_args : '$2'.
 map -> struct_op map_expr map_args : {'%', meta_from_token('$1'), ['$2', '$3']}.
 map -> struct_op map_expr eol map_args : {'%', meta_from_token('$1'), ['$2', '$4']}.
+
+number_or_char -> number : ?exprs('$1').
+number_or_char -> char : ?exprs('$1').
 
 Erlang code.
 

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -175,9 +175,15 @@ tokenize([$~, S, H|T] = Original, Line, Column, Scope, Tokens) when ?is_sigil(H)
 
 % Char tokens
 
+% We tokenize char literals (?a) as {char, _, CharInt} instead of {number, _,
+% CharInt}. This is exactly what Erlang does with Erlang char literals
+% ($a). This means we'll have to adjust the error message for char literals in
+% elixir_errors.erl as by default {char, _, _} tokens are "hijacked" by Erlang
+% and printed with Erlang syntax ($a) in the parser's error messages.
+
 tokenize([$?, $\\, H|T], Line, Column, Scope, Tokens) ->
   Char = elixir_interpolation:unescape_map(H),
-  tokenize(T, Line, Column + 3, Scope, [{number, {Line, Column, Column + 3}, Char}|Tokens]);
+  tokenize(T, Line, Column + 3, Scope, [{char, {Line, Column, Column + 3}, Char}|Tokens]);
 
 tokenize([$?, Char|T], Line, Column, Scope, Tokens) ->
   case handle_char(Char) of
@@ -188,7 +194,7 @@ tokenize([$?, Char|T], Line, Column, Scope, Tokens) ->
     false ->
       ok
   end,
-  tokenize(T, Line, Column + 2, Scope, [{number, {Line, Column, Column + 2}, Char}|Tokens]);
+  tokenize(T, Line, Column + 2, Scope, [{char, {Line, Column, Column + 2}, Char}|Tokens]);
 
 % Heredocs
 

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -830,6 +830,20 @@ defmodule Kernel.ErrorsTest do
       'if true do\n  foo = [],\n  baz\nend'
   end
 
+  # As reported and discussed in
+  # https://github.com/elixir-lang/elixir/issues/4419.
+  test "characters literal are printed correctly in syntax errors" do
+    assert_compile_fail SyntaxError,
+      "nofile:1: syntax error before: ?a",
+      ':ok ?a'
+    assert_compile_fail SyntaxError,
+      "nofile:1: syntax error before: ?\\s",
+      ':ok ?\\s'
+    assert_compile_fail SyntaxError,
+      "nofile:1: syntax error before: ?す"
+      ':ok ?す'
+  end
+
   test "invalid var or function on guard" do
     assert_compile_fail CompileError,
       "nofile:4: unknown variable something_that_does_not_exist or " <>

--- a/lib/elixir/test/erlang/string_test.erl
+++ b/lib/elixir/test/erlang/string_test.erl
@@ -72,7 +72,7 @@ extract_interpolations_with_less_than_operation_inside_interpolation_test() ->
 
 extract_interpolations_with_an_escaped_character_test() ->
   [<<"f">>,
-   {{1,2,17}, [{number, {1,4,7}, 7}, {rel_op, {1,8,9}, '>'}, {number, {1,10,13}, 7}]}
+   {{1,2,17}, [{char, {1,4,7}, 7}, {rel_op, {1,8,9}, '>'}, {char, {1,10,13}, 7}]}
    ] = extract_interpolations("f#{?\\a > ?\\a   }").
 
 extract_interpolations_with_invalid_expression_inside_interpolation_test() ->

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -147,12 +147,12 @@ space_test() ->
   [{op_identifier, {1,1,4}, foo}, {dual_op, {1,6,7}, '-'}, {number, {1,7,8}, 2}] = tokenize("foo  -2").
 
 chars_test() ->
-  [{number, {1,1,3}, 97}]      = tokenize("?a"),
-  [{number, {1,1,3}, 99}]      = tokenize("?c"),
-  [{number, {1,1,4}, 0}]       = tokenize("?\\0"),
-  [{number, {1,1,4}, 7}]       = tokenize("?\\a"),
-  [{number, {1,1,4}, 10}]      = tokenize("?\\n"),
-  [{number, {1,1,4}, 92}]      = tokenize("?\\\\").
+  [{char, {1,1,3}, 97}] = tokenize("?a"),
+  [{char, {1,1,3}, 99}] = tokenize("?c"),
+  [{char, {1,1,4}, 0}]  = tokenize("?\\0"),
+  [{char, {1,1,4}, 7}]  = tokenize("?\\a"),
+  [{char, {1,1,4}, 10}] = tokenize("?\\n"),
+  [{char, {1,1,4}, 92}] = tokenize("?\\\\").
 
 interpolation_test() ->
   [{bin_string, {1,1,9}, [<<"f">>,


### PR DESCRIPTION
This PR hopes to solve #4419.

Before this PR, we handled char literals (like `?a`) in the tokenizer, turning a literal like `?a` into the token `{:number, _, 97}` (thus indistinguishable from the literal `97` at the parsing stage). This led to error messages with the integer for the character instead of the character literal, e.g.:

```elixir
iex> :ok ?a
** (SyntaxError) iex:11: syntax error before: 97
```

With this PR, we now turn `?a` into the token `{:char, _, 97}` (which is the same token used by Erlang for Erlang char literals like `$a`); since it's the same token as in Erlang, the parser will now output the char literal as an Erlang char (`?a` would be printed as `$a`). We hijack the error message in `elixir_errors.erl` to end up with the correct message:

```elixir
iex> :ok ?a
** (SyntaxError) iex:11: syntax error before: ?a
```

@josevalim and I briefly discussed this on IRC and another possible solution came up: tokenize `?a` chars as `{'?', _, [$?, $a]}` tokens so that they'd be printed as `"?a"` in error messages and extracting the char integer in the parser would be a matter of getting the second element of the list. However, this doesn't play too nice with escaped chars (e.g., `?\s` would be printed as `"? "`) and also adds double quotes around the literal in parser error messages (which I personally don't like).

Let me know what you think and if this took the right direction after all :).