### PR TITLE
Fix Mix and Keyword Dialyzer warnings

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -71,7 +71,7 @@ defmodule Keyword do
       []
 
   """
-  @spec new :: t
+  @spec new :: []
   def new, do: []
 
   @doc """

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -282,6 +282,7 @@ defmodule Mix do
   name. This information is used by modules like `Mix.CLI` to
   properly format and show information to the user.
   """
+  @spec raise(atom, list) :: no_return
   def raise(exception, opts) when is_atom(exception) do
     Kernel.raise %{exception.exception(opts) | mix: true}
   end


### PR DESCRIPTION
- lib/keyword.ex:74: Type specification 'Elixir.Keyword':new() -> t() is a supertype of the success typing: 'Elixir.Keyword':new() -> []
- lib/mix.ex:285: Function raise/2 only terminates with explicit exception