### PR TITLE
Error out when passing :__aliases__ to Macro.pipe/3

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -153,6 +153,11 @@ defmodule Macro do
     raise ArgumentError, bad_pipe(expr, call_args)
   end
 
+  # Without this, `Macro |> Env == Macro.Env`.
+  def pipe(expr, {:__aliases__, _, _} = call_args, _integer) do
+    raise ArgumentError, bad_pipe(expr, call_args)
+  end
+
   def pipe(expr, {call, _, [_, _]} = call_args, _integer)
       when call in unquote(@binary_ops) do
     raise ArgumentError, "cannot pipe #{to_string expr} into #{to_string call_args}, " <>

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -561,6 +561,10 @@ defmodule MacroTest do
     # assert_raise ArgumentError, ~r"cannot pipe 1 into \+1", fn ->
     #   Macro.pipe(1, quote(do: + 1), 0)
     # end
+
+    assert_raise ArgumentError, ~r"cannot pipe Macro into Env", fn ->
+      Macro.pipe(Macro, quote(do: Env), 0)
+    end
   end
 
   test "unpipe" do


### PR DESCRIPTION
Right now, this funny thing happens:

```elixir
iex> Macro |> Env
Macro.Env
```

This happens because `|>/2` calls `Macro.pipe/3` under the hood, and `Macro.pipe/3` inserts the left-hand side at the beginning of the list of arguments in the AST for the function call on the right-hand
side. Aliases, however, look exactly like a call to the` __aliases__` function:

```elixir
iex> quote do: Macro.Env
{:__aliases__, [alias: false], [:Macro, :Env]}
```

and that's why `Macro |> Env` becomes `Macro.Env`. With this commit, we explicitly take care of `:__aliases__` in a `Macro.pipe/3` call, so that we can error out in such cases:

```elixir
iex> Macro |> Env
** (ArgumentError) cannot pipe Macro into Env, ...
```

Let me know what you think and most of all, if you can think of any other corner cases like this :)

Oh and btw, I assumed this was incorrect behaviour, but I may of course be wrong :smiley: 