### PR TITLE
Allow to pass :infinity to Logger.Utils.truncate.

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -94,6 +94,7 @@ defmodule Logger do
     * `:truncate` - the maximum message size to be logged. Defaults
       to 8192 bytes. Note this configuration is approximate. Truncated
       messages will have `" (truncated)"` at the end.
+      The atom `:infinity` can be passed to disable this behavior.
 
     * `:sync_threshold` - if the Logger manager has more than
       `sync_threshold` messages in its queue, Logger will change

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -9,6 +9,9 @@ defmodule Logger.Utils do
   codepoint. For this reason, truncation is not exact.
   """
   @spec truncate(IO.chardata, non_neg_integer) :: IO.chardata
+  def truncate(chardata, :infinity) do
+    chardata
+  end
   def truncate(chardata, n) when n >= 0 do
     {chardata, n} = truncate_n(chardata, n)
     if n >= 0, do: chardata, else: [chardata, " (truncated)"]

--- a/lib/logger/test/logger/utils_test.exs
+++ b/lib/logger/test/logger/utils_test.exs
@@ -28,6 +28,10 @@ defmodule Logger.UtilsTest do
     assert truncate('ol' ++ "á", 2) == ['ol' ++ "", " (truncated)"]
     assert truncate('ol' ++ "á", 3) == ['ol' ++ "", " (truncated)"]
     assert truncate('ol' ++ "á", 4) == 'ol' ++ "á"
+
+    # :infinity
+    long_string = String.duplicate("foo", 10_000)
+    assert truncate(long_string, :infinity) == long_string
   end
 
   test "inspect/2 formats" do


### PR DESCRIPTION
I added the possibility to pass `:infinity` to `Logger.Utils.truncate` to disable truncating logs.

My use case is the following:

* I execute an external command (with a pretty long input)
* When it fails, I log the output into a file to know what happened

The error is normally at the end of the log, which makes it useless when truncated.
I can pass a very large value to `truncate` for this logger, but I thought that being
able to simply disable truncating would be a nicer way to do it.

As the change is quite minimal, I opened a PR directly, but let me know if you would rather
want me to post to the ML.