### PR TITLE
Handle non-called anonymous functions in Macro.pipe/3

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -164,6 +164,16 @@ defmodule Macro do
                          "the #{to_string call} operator can only take two arguments"
   end
 
+  # {:fn, _, _} is what we get when we pipe into an anonymous function without
+  # calling it, e.g., `:foo |> (fn x -> x end)`.
+  def pipe(expr, {:fn, _, _} = call_args, _integer) do
+    expr_str = to_string(expr)
+    raise ArgumentError,
+      "cannot pipe #{expr_str} into an anonymous function without" <>
+      " calling the function; use something like (fn ... end).() or" <>
+      " define the anonymous function as a regular private function"
+  end
+
   def pipe(expr, {call, line, atom}, integer) when is_atom(atom) do
     {call, line, List.insert_at([], integer, expr)}
   end

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -565,6 +565,11 @@ defmodule MacroTest do
     assert_raise ArgumentError, ~r"cannot pipe Macro into Env", fn ->
       Macro.pipe(Macro, quote(do: Env), 0)
     end
+
+    message = ~r"cannot pipe :foo into an anonymous function without calling"
+    assert_raise ArgumentError, message, fn ->
+      Macro.pipe(:foo, quote(do: fn x -> x end), 0)
+    end
   end
 
   test "unpipe" do


### PR DESCRIPTION
This PR should solve #4435. Right now, this nasty error pops out:

```elixir
iex> :foo |> (fn x -> x end)
** (CompileError) iex:1: expected -> clauses in fn
```

This happens because of what we do in `Macro.pipe/3`, which is: we take the AST of a function call as the second argument and insert the first argument in the list of arguments for the function call, at the position specified by the third argument. The AST for a `fn` looks exactly like the AST of a function call (to the `:fn` function):

```elixir
iex> quote do: fn :ok -> :ok; :err -> :err end
{:fn, [], [{:->, [], [[:ok], :ok]}, {:->, [], [[:error], :error]}]}
```

It's easy to see that the "arguments" to `:fn` are the `->` clauses in the function. This means that doing `:foo |> (fn x -> x end)` basically adds another clause to the function:

```elixir
iex> Macro.pipe(:foo, quote(do: fn :ok -> :ok; :err -> :err end), 0)
{:fn, [], [:foo, {:->, [], [[:ok], :ok]}, {:->, [], [[:err], :err]}]}
```
and this makes `:elixir_fn.expand/3` blow up because it doesn't know how to handle the `:foo` clause (because it's not a clause!).

With this PR, we blow up early in `Macro.pipe/3` when we see a `{:fn, _, _}` call:

```elixir
iex> :foo |> (fn x -> x end)
** (ArgumentError) cannot pipe :foo into an anonymous function
without calling the function; use :foo |> (fn x -> x end).()
```

Let me know how it looks and if I can do anything else; I'm not 100% sure about the error message (e.g., should we print the `Macro.to_string/1` of the output?), so any input is welcome :smiley:.