### PR TITLE
purge erlang modules on recompilation

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -80,6 +80,12 @@ defmodule Mix.Tasks.Compile.Erlang do
 
     Mix.Compilers.Erlang.compile(manifest(), tuples, fn
       input, _output ->
+        # We're purging the module because a previous compiler (e.g. Phoenix)
+        # might have already loaded the previous version of it.
+        module = Path.basename(input, ".erl") |> String.to_atom
+        :code.purge(module)
+        :code.delete(module)
+
         file = to_erl_file(Path.rootname(input, ".erl"))
         :compile.file(file, erlc_options)
     end)


### PR DESCRIPTION
The issue is described [here](https://groups.google.com/forum/#!topic/elixir-lang-talk/2qvsQ9A2-6g)

tl;dr of it is that a situation can happen that a mix task works with an older version of the module written in Erlang. This can occur if some previous task, (e.g. Phoenix compiler) loaded the module before the Erlang compiler recompiled the code. The agreed solution is to make the Erlang compiler purge the module if it is about to be compiled.
