### PR TITLE
Add System.os_time/0,1 and update time-related docs in System

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -628,6 +628,40 @@ defmodule System do
   end
 
   @doc """
+  Returns the current OS time.
+
+  The result is returned in the `:native` time unit.
+
+  This time **does not** increase monotonically.
+
+  For more information, see the [chapter on time and time
+  correction](http://www.erlang.org/doc/apps/erts/time_correction.html) in the
+  Erlang docs.
+
+  Inlined by the compiler into `:os.system_time/0`.
+  """
+  @spec os_time() :: integer
+  def os_time do
+    :os.system_time()
+  end
+
+  @doc """
+  Returns the current OS time in the given time `unit`.
+
+  This time **does not** increase monotonically.
+
+  For more information, see the [chapter on time and time
+  correction](http://www.erlang.org/doc/apps/erts/time_correction.html) in the
+  Erlang docs.
+
+  Inlined by the compiler into `:os.system_time/1`.
+  """
+  @spec os_time(:erlang.time_unit) :: integer
+  def os_time(unit) do
+    :os.system_time(unit)
+  end
+
+  @doc """
   Generates and returns an integer that is unique in the current runtime
   instance.
 

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -5,6 +5,30 @@ defmodule System do
   with the VM or the host system.
   """
 
+  @typedoc """
+  The time unit that can be passed to functions like `System.system_time/1`
+  and similar.
+
+  The `:seconds`, `:milli_seconds`, `:micro_seconds`, and `:nano_seconds` time
+  units are self-explanatory: the return value of the functions that accept a
+  time unit will be in the given time unit.
+
+  A time unit can also be a strictly positive integer. In this case, it
+  represents the "parts per second": the time will be returned in `1 /
+  parts_per_second` seconds. For example, using the `:milli_seconds` time unit
+  is equivalent to using `1000` as the time unit (as the time will be returned
+  in 1/1000 seconds - milliseconds).
+
+  See also the [documentation on the `time_unit` Erlang
+  type](http://erlang.org/doc/man/erlang.html#type-time_unit).
+  """
+  @type time_unit ::
+    :seconds
+    | :milli_seconds
+    | :micro_seconds
+    | :nano_seconds
+    | pos_integer
+
   @base_dir     :filename.join(__DIR__, "../../..")
   @version_file :filename.join(@base_dir, "VERSION")
 
@@ -549,7 +573,7 @@ defmodule System do
 
   Inlined by the compiler into `:erlang.monotonic_time/1`.
   """
-  @spec monotonic_time(:erlang.time_unit) :: integer
+  @spec monotonic_time(time_unit) :: integer
   def monotonic_time(unit) do
     :erlang.monotonic_time(unit)
   end
@@ -577,7 +601,7 @@ defmodule System do
 
   Inlined by the compiler into `:erlang.system_time/1`.
   """
-  @spec system_time(:erlang.time_unit) :: integer
+  @spec system_time(time_unit) :: integer
   def system_time(unit) do
     :erlang.system_time(unit)
   end
@@ -586,9 +610,16 @@ defmodule System do
   Converts `time` from time unit `from_unit` to time unit `to_unit`. The result
   is rounded via the floor function.
 
+  `convert_time_unit/3` accepts an additional time unit (other than the ones in
+  the `time_unit` type): `:native`. `:native` is the time unit used by the
+  Erlang runtime system. It's determined when the runtime starts and stays the
+  same until the runtime is stopped. To determine what the `:native` unit
+  amounts to in a system, you can call this function to convert 1 second to the
+  `:native` time unit (i.e., `System.convert_time_unit(1, :seconds, :native)`).
+
   Inlined by the compiler into `:erlang.convert_time_unit/3`.
   """
-  @spec convert_time_unit(integer, :erlang.time_unit, :erlang.time_unit) :: integer
+  @spec convert_time_unit(integer, time_unit | :native, time_unit | :native) :: integer
   def convert_time_unit(time, from_unit, to_unit) do
     :erlang.convert_time_unit(time, from_unit, to_unit)
   end
@@ -622,7 +653,7 @@ defmodule System do
 
   Inlined by the compiler into `:erlang.time_offset/1`.
   """
-  @spec time_offset(:erlang.time_unit) :: integer
+  @spec time_offset(time_unit) :: integer
   def time_offset(unit) do
     :erlang.time_offset(unit)
   end
@@ -656,7 +687,7 @@ defmodule System do
 
   Inlined by the compiler into `:os.system_time/1`.
   """
-  @spec os_time(:erlang.time_unit) :: integer
+  @spec os_time(time_unit) :: integer
   def os_time(unit) do
     :os.system_time(unit)
   end

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -153,6 +153,8 @@ inline(?system, stacktrace, 0) -> {erlang, get_stacktrace};
 inline(?system, convert_time_unit, 3) -> {erlang, convert_time_unit};
 inline(?system, monotonic_time, 0) -> {erlang, monotonic_time};
 inline(?system, monotonic_time, 1) -> {erlang, monotonic_time};
+inline(?system, os_time, 0) -> {os, system_time};
+inline(?system, os_time, 1) -> {os, system_time};
 inline(?system, system_time, 0) -> {erlang, system_time};
 inline(?system, system_time, 1) -> {erlang, system_time};
 inline(?system, time_offset, 0) -> {erlang, time_offset};

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -135,6 +135,15 @@ defmodule SystemTest do
     assert is_integer(System.time_offset(:seconds))
   end
 
+  test "os_time/0" do
+    assert is_integer(System.os_time())
+  end
+
+  test "os_time/1" do
+    assert is_integer(System.os_time(:nano_seconds))
+    assert abs(System.os_time(:micro_seconds)) < abs(System.os_time(:nano_seconds))
+  end
+
   test "unique_integer/0 and unique_integer/1" do
     assert is_integer(System.unique_integer())
     assert System.unique_integer([:positive]) > 0


### PR DESCRIPTION
Implementation of #4454. 

I did the rest of the `System.*time` a while back so I figured I would implement these as well :smile:.

@josevalim I didn't touch the docs on time; what do you think should be improved? We already link to http://erlang.org/doc/apps/erts/time_correction.html (in all the `System.*time` functions), which as a lot of info around this stuff.