### PR TITLE
Allow string interpolation and other rewrites in map keys. Fix #4428.

### DIFF
--- a/lib/elixir/src/elixir_translator.erl
+++ b/lib/elixir/src/elixir_translator.erl
@@ -187,7 +187,7 @@ translate({'^', Meta, [{Name, VarMeta, Kind}]}, #elixir_scope{context=match, fil
       compile_error(Meta, S#elixir_scope.file, "unbound variable ^~ts", [Name])
   end;
 
-translate({Name, Meta, Kind}, #elixir_scope{extra=map_key, context=match} = S) when is_atom(Name), is_atom(Kind) ->
+translate({Name, Meta, Kind}, #elixir_scope{extra=map_key, context=match} = S) when is_atom(Name), is_atom(Kind), Kind /= 'Elixir' ->
   Message = "illegal use of variable ~ts as map key inside match, "
             "maps can only match on existing variable by using ^~ts",
   compile_error(Meta, S#elixir_scope.file, Message, [Name, Name]);

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -28,6 +28,12 @@ defmodule MapTest do
     assert a == 1
   end
 
+  test "maps with string interpolation" do
+    a = 0
+    assert %{"foo#{0}" => "bar"} == %{"foo0" => "bar"}
+    assert %{"foo#{a}" => "bar"} == %{"foo0" => "bar"}
+  end
+
   test "is_map/1" do
     assert is_map(Map.new)
     refute is_map(Enum.to_list(%{}))


### PR DESCRIPTION
I know @lexmag was assigned to this one, but after answering a comment I got a bit curious and gave it a try.
If I understand, compiler rewrites have the Kind `Elixir`, so avoiding checking for these should fix the issue.
I am not sure is this is the way to go to solve it, but if it is not I would love to have a little explanation about it.
Thanks!