### PR TITLE
Allow OptionParser to parse negative numbers

### DIFF
--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -446,11 +446,11 @@ defmodule OptionParser do
     {value, kinds, t}
   end
 
-  defp value_in_tail?(["-"|_]),       do: true
-  defp value_in_tail?(["- " <> _|_]), do: true
-  defp value_in_tail?(["-" <> _|_]),  do: false
-  defp value_in_tail?([]),            do: false
-  defp value_in_tail?(_),             do: true
+  defp value_in_tail?(["-"|_]),         do: true
+  defp value_in_tail?(["- " <> _|_]),   do: true
+  defp value_in_tail?(["-" <> arg|_]),  do: is_negative_number("-" <> arg)
+  defp value_in_tail?([]),              do: false
+  defp value_in_tail?(_),               do: true
 
   defp split_option(option) do
     case :binary.split(option, "=") do

--- a/lib/elixir/test/elixir/option_parser_test.exs
+++ b/lib/elixir/test/elixir/option_parser_test.exs
@@ -212,6 +212,11 @@ defmodule OptionParserTest do
            == {[foo: true, boo: "-"], ["-"], []}
   end
 
+  test "correctly handles negative numbers" do
+    assert OptionParser.parse(["arg1", "-43"])
+      == {[], ["arg1", "-43"], []}
+  end
+
   test "multi-word option" do
     config = [switches: [hello_world: :boolean]]
     assert OptionParser.next(["--hello-world"], config)

--- a/lib/elixir/test/elixir/option_parser_test.exs
+++ b/lib/elixir/test/elixir/option_parser_test.exs
@@ -215,6 +215,9 @@ defmodule OptionParserTest do
   test "correctly handles negative numbers" do
     assert OptionParser.parse(["arg1", "-43"])
       == {[], ["arg1", "-43"], []}
+
+      assert OptionParser.parse(["arg1", "-o", "-43"], switches: [option: :integer], aliases: [o: :option])
+      == {[option: -43], ["arg1"], []}
   end
 
   test "multi-word option" do

--- a/lib/elixir/test/elixir/option_parser_test.exs
+++ b/lib/elixir/test/elixir/option_parser_test.exs
@@ -212,12 +212,20 @@ defmodule OptionParserTest do
            == {[foo: true, boo: "-"], ["-"], []}
   end
 
-  test "correctly handles negative numbers" do
+  test "correctly handles negative integers" do
     assert OptionParser.parse(["arg1", "-43"])
       == {[], ["arg1", "-43"], []}
 
       assert OptionParser.parse(["arg1", "-o", "-43"], switches: [option: :integer], aliases: [o: :option])
       == {[option: -43], ["arg1"], []}
+  end
+
+  test "correctly handles negative floating point numbers" do
+    assert OptionParser.parse(["arg1", "-43.2"])
+      == {[], ["arg1", "-43.2"], []}
+
+      assert OptionParser.parse(["arg1", "-o", "-43.2"], switches: [option: :float], aliases: [o: :option])
+      == {[option: -43.2], ["arg1"], []}
   end
 
   test "multi-word option" do

--- a/lib/elixir/test/elixir/option_parser_test.exs
+++ b/lib/elixir/test/elixir/option_parser_test.exs
@@ -218,6 +218,9 @@ defmodule OptionParserTest do
 
       assert OptionParser.parse(["arg1", "-o", "-43"], switches: [option: :integer], aliases: [o: :option])
       == {[option: -43], ["arg1"], []}
+
+      assert OptionParser.parse(["arg1", "--option=-43"], switches: [option: :integer])
+      == {[option: -43], ["arg1"], []}
   end
 
   test "correctly handles negative floating point numbers" do
@@ -225,6 +228,9 @@ defmodule OptionParserTest do
       == {[], ["arg1", "-43.2"], []}
 
       assert OptionParser.parse(["arg1", "-o", "-43.2"], switches: [option: :float], aliases: [o: :option])
+      == {[option: -43.2], ["arg1"], []}
+
+      assert OptionParser.parse(["arg1", "--option=-43.2"], switches: [option: :float])
       == {[option: -43.2], ["arg1"], []}
   end
 


### PR DESCRIPTION
This pull request changes the way OptionParser handles negative numbers, so that it can parse them as arguments or option values:

```
iex(1)> OptionParser.parse(["-43"])
old version: {[], [], [{"-43", nil}]}
new version: {[], ["-43"], []}
```

and

```
iex(2)> OptionParser.parse(["-f", "-43"], strict: [flag: :integer], aliases: [f: :flag])
old version: {[], [], [{"-f", nil}, {"-43", nil}]}
new version: {[flag: -43], [], []}
```

The new version assumes that any input consisting of a dash followed by a string completely parseable as a float (i.e., no remainder at the end) is a negative number, not an option flag.