### PR TITLE
Enable String.replace to use multiple values

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -918,13 +918,29 @@ defmodule String do
   replacement string, or is negative, an `ArgumentError` is raised.
   """
   @spec replace(t, pattern | Regex.t, t, Keyword.t) :: t
-  def replace(subject, pattern, replacement, options \\ []) when is_binary(replacement) do
+  def replace(subject, pattern, replacement, options \\ []) do
+    _replace(subject, pattern, replacement, options)
+  end
+
+  defp _replace(subject, pattern, replacement, options) when is_map(replacement) do
+    matched_results = Regex.scan(pattern, subject)
+    update(matched_results, subject, replacement, options)
+  end
+
+  defp _replace(subject, pattern, replacement, options) when is_binary(replacement) do
     if Regex.regex?(pattern) do
       Regex.replace(pattern, subject, replacement, global: options[:global])
     else
       opts = translate_replace_options(options)
       :binary.replace(subject, pattern, replacement, opts)
     end
+  end
+
+  defp update([], subject, _, _), do: subject
+  defp update([[matched] | rest], subject, replacement, options) do
+    new_value = Map.fetch!(replacement, matched)
+    updated_string = replace(subject, matched, new_value, options)
+    update(rest, updated_string, replacement, options)
   end
 
   defp translate_replace_options(options) do

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -274,6 +274,8 @@ defmodule StringTest do
 
     assert String.replace("a,b,c", ~r/,(.)/, ",\\1\\1") == "a,bb,cc"
     assert String.replace("a,b,c", ~r/,(.)/, ",\\1\\1", global: false) == "a,bb,c"
+    assert String.replace("a.b.c", ~r/\./, %{"." => "-"}) == "a-b-c"
+    assert String.replace("abba", ~r/a|b/, %{"a" => "1", "b" => "2"}) == "1221"
   end
 
   test "duplicate" do


### PR DESCRIPTION
This is based on the idea that already exists in [other languages](https://clojuredocs.org/clojure.string/replace#example-542692d7c026201cdc327100). I didn't want to deviate much from the current implementation of `String.replace` so I tried to go with a simple approach.

This allows for the following to be valid:

```
String.replace("abba", ~r/a|b/, %{"a" => "1", "b" => "2"})
=> "1221"
```

Any feedback would be greatly appreciated!