### PR TITLE
More helpful deprecation warning for piping into unary operator.

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -193,7 +193,7 @@ defmodule Macro do
 
   @doc false
   def pipe_warning({call, _, _}) when call in unquote(@unary_ops) do
-    "piping into a unary operator is deprecated"
+    "piping into a unary operator is deprecated. You could use e.g. Kernel.+(5) instead of +5."
   end
   def pipe_warning(_), do: nil
 


### PR DESCRIPTION
I saw this warning when compiling some code and was not sure what to do about it. This message suggests a solution.