### PR TITLE
Add a user friendly error for merge conflicts on mix.lock.

### DIFF
--- a/lib/mix/lib/mix/dep/lock.ex
+++ b/lib/mix/lib/mix/dep/lock.ex
@@ -34,6 +34,7 @@ defmodule Mix.Dep.Lock do
   def read() do
     case File.read(lockfile) do
       {:ok, info} ->
+        assert_no_merge_conflicts_in_lockfile(lockfile, info)
         case Code.eval_string(info, [], file: lockfile) do
           {lock, _binding} when is_map(lock)  -> lock
           {_, _binding} -> %{}
@@ -61,5 +62,12 @@ defmodule Mix.Dep.Lock do
 
   defp lockfile do
     Mix.Project.config[:lockfile]
+  end
+
+  defp assert_no_merge_conflicts_in_lockfile(lockfile, info) do
+    if String.contains?(info, ~w(<<<<<<< ======= >>>>>>>)) do
+      Mix.raise "Your #{lockfile} contains merge conflicts. Please resolve the conflicts " <>
+                "and run the command again."
+    end
   end
 end

--- a/lib/mix/test/mix/dep/lock_test.exs
+++ b/lib/mix/test/mix/dep/lock_test.exs
@@ -25,4 +25,21 @@ defmodule Mix.Dep.LockTest do
       refute File.regular? "_build/dev/lib/sample/.compile.lock"
     end
   end
+
+  test "raises a proper error for merge conflicts", context do
+    in_tmp context.test, fn ->
+      File.write "mix.lock", ~S"""
+      %{"dep": {:hex, :dep, "0.1.0"},
+      <<<<<<< HEAD
+        "foo": {:hex, :foo, "0.1.0"},
+      =======
+        "bar": {:hex, :bar, "0.1.0"},
+      >>>>>>> foobar
+        "baz": {:hex, :baz, "0.1.0"}}
+      """
+      assert_raise Mix.Error, ~r/Your mix\.lock contains merge conflicts/, fn ->
+        Mix.Dep.Lock.read()
+      end
+    end
+  end
 end


### PR DESCRIPTION
As [proposed in the ML](https://groups.google.com/forum/#!topic/elixir-lang-core/ORl4QArbaxI), I added a user friendly message when `mix.lock` contains conflicts.