### PR TITLE
Fix and improve Enum.sum/1 for ranges

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1416,12 +1416,14 @@ defmodule Enum do
   @spec sum(t) :: number
   def sum(enumerable)
 
-  def sum(first..last) when last > first do
-    ((last * (last + 1)) / 2) - ((first * (first - 1)) / 2)
-  end
+  def sum(first..first),
+    do: first
 
-  def sum(first..last) do
-    ((first * (first + 1)) / 2) - ((last * (last - 1)) / 2)
+  def sum(first..last) when last < first,
+    do: sum(last..first)
+
+  def sum(first..last) when last > first do
+    div(((last * (last + 1)) - (first * (first - 1))), 2)
   end
 
   def sum(enumerable) do

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -428,6 +428,11 @@ defmodule EnumTest do
     assert Enum.sum([1]) == 1
     assert Enum.sum([1, 2, 3]) == 6
     assert Enum.sum([1.1, 2.2, 3.3]) == 6.6
+    assert Enum.sum([-3, -2, -1, 0, 1, 2, 3]) == 0
+    assert Enum.sum(42..42) == 42
+    assert Enum.sum(11..17) == 98
+    assert Enum.sum(17..11) == 98
+    assert Enum.sum(11..-17) == Enum.sum(-17..11)
     assert_raise ArithmeticError, fn ->
       Enum.sum([{}])
     end


### PR DESCRIPTION
Lastest changes introduced in Enum.sum in #4414 changed the type of the return value
(from integer to float) when argument was a range. This commit fixes this.

Adds a spec when dealing with Range.t

It simplifies the function by making it more recursive,
and also deals with ranges where first and last are equal

Tests added

/cc @Qqwy 