### PR TITLE
Allow guards in setup and skip non matching definitions

### DIFF
--- a/lib/ex_unit/test/ex_unit/callbacks_test.exs
+++ b/lib/ex_unit/test/ex_unit/callbacks_test.exs
@@ -10,7 +10,16 @@ defmodule ExUnit.CallbacksTest do
       use ExUnit.Case
 
       setup_all do
-        {:ok, [context: :setup_all]}
+        {:ok, [context: :setup_all, value: 1]}
+      end
+
+      setup_all %{context: :setup_all, value: value} = context when is_integer(value) do
+        assert value == 1
+        {:ok, context}
+      end
+
+      setup_all %{value: value} when is_binary(value) do
+        flunk "value is not a binary, I should not be executed"
       end
 
       setup do
@@ -21,6 +30,15 @@ defmodule ExUnit.CallbacksTest do
         assert context[:initial_setup]
         assert context[:context] == :setup_all
         {:ok, [context: :setup]}
+      end
+
+      setup %{foo: "bar"} do
+        flunk "there is not key foo, I should not be executed"
+      end
+
+      setup %{value: value} = context when is_integer(value) do
+        assert value == 1
+        {:ok, context}
       end
 
       test "callbacks", context do


### PR DESCRIPTION
I gave a first shot at the idea described in #4451.
There are a few questions:

* First, do we add the feature or not, as the opinion was mitigated in #4451 discussion
* If we add it, I think at least `setup_all` should behave like `setup`, what do you think?
* It feels a little inconsistent to me to skip the setup when no clause matches but to raise in tests:

```elixir
setup %{foo: "bar"} do
  # I am skipped
end

test "I will fail with a FunctionClauseError", %{foo: "bar"} do
  # I don't behave like setup
end
```

but I am not sure what is the best thing to do here.
What do you think?