### PR TITLE
Enhance difference highlighting for lists

### DIFF
--- a/lib/ex_unit/examples/difference.exs
+++ b/lib/ex_unit/examples/difference.exs
@@ -20,7 +20,7 @@ defmodule Difference do
   end
 
   test "strings" do
-    string1 = "fox hops over the dog"
+    string1 = "fox hops over \"the dog"
     string2 = "fox jumps over the lazy cat"
     assert string1 == string2
   end

--- a/lib/ex_unit/examples/difference.exs
+++ b/lib/ex_unit/examples/difference.exs
@@ -11,59 +11,77 @@ defmodule Difference do
     defstruct [:age]
   end
 
-  test "1. integers" do
+  test "integers" do
     assert 491512235 == 490512035
   end
 
-  test "2. floats" do
+  test "floats" do
     assert 42.0 == 43.0
   end
 
-  test "3. strings" do
+  test "strings" do
     string1 = "fox hops over the dog"
     string2 = "fox jumps over the lazy cat"
     assert string1 == string2
   end
 
-  test "4. lists" do
-    list1 = [{"Content-type", "text/plain"}, {"etag", "One"}]
-    list2 = [{"content-type", "text/html"}, {"Etag", "Two"}]
+  test "lists" do
+    list1 = ["One", :ok, make_ref(), {}]
+    list2 = ["Two", :ok, self(), {true}]
     assert list1 == list2
   end
 
-  test "5. tuples" do
+  test "lists; missing entries" do
+    assert [] == [1, 2, 3]
+  end
+
+  test "lists; surplus entries" do
+    assert [1, 2, 3] == []
+  end
+
+  test "char lists" do
+    char_list1 = 'fox hops over \'the dog'
+    char_list2 = 'fox jumps over the lazy cat'
+    assert char_list1 == char_list2
+  end
+
+  test "keyword lists" do
+    assert [file: "nofile", line: 12] == [file: nil, llne: 10]
+  end
+
+  test "tuples" do
     tuple1 = {:yes, 'ject', []}
     tuple2 = {:yes, 'lter', []}
     assert tuple1 == tuple2
   end
 
-  test "6. maps; mixed diff" do
+  test "maps; mixed diff" do
     map1 = Enum.into(1..40, %{}, &{&1, &1}) |> Map.delete(33)
     map2 = Enum.reduce(5..10, map1, &Map.delete(&2, &1)) |> Map.put(33, 33) |> Map.put(23, 32)
     assert map1 == map2
   end
 
-  test "7. maps; missing pair and match" do
+  test "maps; missing pairs and match" do
     map1 = %{baz: 12}
     map2 = %{foo: 12, bar: 12, baz: 12}
     assert map1 == map2
   end
 
-  test "8. maps; surplus pair and match" do
+  test "maps; surplus pairs and match" do
     map1 = %{foo: 12, bar: 12, baz: 12}
     map2 = %{baz: 12}
     assert map1 == map2
   end
 
-  test "9. maps; missing pair" do
+  test "maps; missing pair" do
     assert %{} == %{baz: 12}
   end
 
-  test "10. maps; surplus pair" do
+  test "maps; surplus pair" do
     assert %{baz: 12} == %{}
   end
 
-  test "11. structs" do
+  test "structs" do
     assert %User{age: 16} == %User{age: 21}
   end
 end

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -251,10 +251,12 @@ defmodule ExUnit.Formatter do
     format_map_diff(left, right, inspect(name), formatter)
   end
 
-  def format_diff(%_{}, %_{}, _formatter), do: nil
-
   def format_diff(%{} = left, %{} = right, formatter) do
-    format_map_diff(left, right, "", formatter)
+    if match?(%_{}, left) or match?(%_{}, right) do
+      nil
+    else
+      format_map_diff(left, right, "", formatter)
+    end
   end
 
   def format_diff(left, right, formatter) when is_list(left) and is_list(right) do

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -194,7 +194,7 @@ defmodule ExUnit.Formatter do
   defp format_label(:note, _formatter), do: ""
 
   defp format_label(label, formatter) do
-    formatter.(:error_info, String.ljust("#{label}:", byte_size(@label_padding)))
+    formatter.(:extra_info, String.ljust("#{label}:", byte_size(@label_padding)))
   end
 
   defp format_banner(value, formatter) do

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -257,6 +257,17 @@ defmodule ExUnit.Formatter do
     format_map_diff(left, right, "", formatter)
   end
 
+  def format_diff(left, right, formatter) when is_list(left) and is_list(right) do
+    if Inspect.List.printable?(left) and Inspect.List.printable?(right) do
+      left = List.to_string(left) |> Inspect.BitString.escape(?')
+      right = List.to_string(right) |> Inspect.BitString.escape(?')
+      "'" <> format_diff(left, right, formatter) <> "'"
+    else
+      keyword? = Inspect.List.keyword?(left) and Inspect.List.keyword?(right)
+      format_list_diff(left, right, formatter, keyword?, [])
+    end
+  end
+
   def format_diff(left, right, formatter)
       when is_integer(left) and is_integer(right)
       when is_float(left) and is_float(right) do
@@ -272,12 +283,54 @@ defmodule ExUnit.Formatter do
   end
 
   def format_diff(left, right, formatter)
-      when is_tuple(left) and is_tuple(right)
-      when is_list(left) and is_list(right) do
+      when is_tuple(left) and is_tuple(right) do
     format_diff(inspect(left), inspect(right), formatter)
   end
 
   def format_diff(_left, _right, _formatter), do: nil
+
+  defp format_list_diff([], [], _formatter, _keyword?, acc) do
+    result = Enum.reverse(acc)
+    "[" <> Enum.join(result, ", ") <> "]"
+  end
+
+  defp format_list_diff([], [elem | rest], formatter, keyword?, acc) do
+    elem_diff = formatter.(:diff_insert, format_list_elem(elem, keyword?))
+    format_list_diff([], rest, formatter, keyword?, [elem_diff | acc])
+  end
+
+  defp format_list_diff([elem | rest], [], formatter, keyword?, acc) do
+    elem_diff = formatter.(:diff_delete, format_list_elem(elem, keyword?))
+    format_list_diff(rest, [], formatter, keyword?, [elem_diff | acc])
+  end
+
+  defp format_list_diff([elem | rest1], [elem | rest2], formatter, keyword?, acc) do
+    elem_diff = format_list_elem(elem, keyword?)
+    format_list_diff(rest1, rest2, formatter, keyword?, [elem_diff | acc])
+  end
+
+  defp format_list_diff([{key1, val1} | rest1], [{key2, val2} | rest2], formatter, true, acc) do
+    key_diff =
+      if key1 != key2 do
+        format_diff(Atom.to_string(key1), Atom.to_string(key2), formatter)
+      else
+        Atom.to_string(key1)
+      end
+    value_diff = format_inner_diff(val1, val2, formatter)
+    elem_diff = format_key_value(key_diff, value_diff, true)
+    format_list_diff(rest1, rest2, formatter, true, [elem_diff | acc])
+  end
+
+  defp format_list_diff([elem1 | rest1], [elem2 | rest2], formatter, false, acc) do
+    elem_diff = format_inner_diff(elem1, elem2, formatter)
+    format_list_diff(rest1, rest2, formatter, false, [elem_diff | acc])
+  end
+
+  defp format_list_elem(elem, false), do: inspect(elem)
+
+  defp format_list_elem({key, val}, true) do
+    format_key_value(Atom.to_string(key), inspect(val), true)
+  end
 
   defp format_map_diff(left, right, name, formatter) do
     {surplus, altered, missing} = map_difference(left, right)
@@ -292,16 +345,16 @@ defmodule ExUnit.Formatter do
         do: ["..."],
         else: []
     result = Enum.reduce(missing, result, fn({key, val}, acc) ->
-      map_pair = format_map_pair(inspect(key), inspect(val), keyword?)
+      map_pair = format_key_value(inspect(key), inspect(val), keyword?)
       [formatter.(:diff_insert, map_pair) | acc]
     end)
     result = Enum.reduce(surplus, result, fn({key, val}, acc) ->
-      map_pair = format_map_pair(inspect(key), inspect(val), keyword?)
+      map_pair = format_key_value(inspect(key), inspect(val), keyword?)
       [formatter.(:diff_delete, map_pair) | acc]
     end)
     result = Enum.reduce(altered, result, fn({key, {val1, val2}}, acc) ->
       value_diff = format_inner_diff(val1, val2, formatter)
-      [format_map_pair(inspect(key), value_diff, keyword?) | acc]
+      [format_key_value(inspect(key), value_diff, keyword?) | acc]
     end)
     "%" <> name <> "{" <> Enum.join(result, ", ") <> "}"
   end
@@ -324,15 +377,15 @@ defmodule ExUnit.Formatter do
     {surplus, altered, missing}
   end
 
-  defp format_map_pair(key, value, false) do
+  defp format_key_value(key, value, false) do
     key <> " => " <> value
   end
 
-  defp format_map_pair(":" <> rest, value, true) do
-    format_map_pair(rest, value, true)
+  defp format_key_value(":" <> rest, value, true) do
+    format_key_value(rest, value, true)
   end
 
-  defp format_map_pair(key, value, true) do
+  defp format_key_value(key, value, true) do
     key <> ": " <> value
   end
 

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -260,10 +260,20 @@ defmodule ExUnit.FormatterTest do
     string2 = "fox jumps over the lazy cat"
     assert format_diff(string1, string2, &formatter/2) == "fox {ho}[jum]ps over the {dog}[lazy cat]"
 
-    list1 = [{"Content-type", "text/plain"}, {"etag", "One"}]
-    list2 = [{"content-type", "text/html"}, {"Etag", "Two"}]
-    expected = ~S([{"{C}[c]ontent-type", "text/{p}[htm]l{ain}"}, {"{e}[E]tag", "{One}[Two]"}])
+    list1 = ["One", :ok, nil, {}, :ok]
+    list2 = ["Two", :ok, 0.0, {true}]
+    expected = ~S<["{One}[Two]", :ok, {nil}[0.0], {[true]}, {:ok}]>
     assert format_diff(list1, list2, &formatter/2) == expected
+
+    keyword_list1 = [file: "nofile", line: 12]
+    keyword_list2 = [file: nil, llne: 10]
+    expected = ~S<[file: {"nofile"}[nil], l{i}[l]ne: 1{2}[0] {(off by -2)}]>
+    assert format_diff(keyword_list1, keyword_list2, &formatter/2) == expected
+
+    char_list1 = 'fox hops over \'the dog'
+    char_list2 = 'fox jumps over the lazy cat'
+    expected = "'fox {ho}[jum]ps over {\\'}the {dog}[lazy cat]'"
+    assert format_diff(char_list1, char_list2, &formatter/2) == expected
 
     tuple1 = {:yes, 'ject', []}
     tuple2 = {:yes, 'lter', []}

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -294,6 +294,7 @@ defmodule ExUnit.FormatterTest do
     user1 = %User{age: 16}
     user2 = %User{age: 21}
     assert format_diff(user1, user2, &formatter/2) == "%ExUnit.FormatterTest.User{age: [2]1{6} [(off by +5)]}"
+    assert format_diff(%User{}, %{}, &formatter/2) == nil
     assert format_diff(%User{}, %ExUnit.Test{}, &formatter/2) == nil
 
     bin1 = <<147, 1, 2, 31>>

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -256,9 +256,10 @@ defmodule ExUnit.FormatterTest do
     assert format_diff(int1, int2, &formatter/2) == "49{1}[0]512{2}[0]35 {(off by -1000200)}"
     assert format_diff(42.0, 43.0, &formatter/2) == "4{2}[3].0 [(off by +1.0)]"
 
-    string1 = "fox hops over the dog"
+    string1 = "fox hops over \"the dog"
     string2 = "fox jumps over the lazy cat"
-    assert format_diff(string1, string2, &formatter/2) == "fox {ho}[jum]ps over the {dog}[lazy cat]"
+    expected = ~S<"fox {ho}[jum]ps over {\"}the {dog}[lazy cat]">
+    assert format_diff(string1, string2, &formatter/2) == expected
 
     list1 = ["One", :ok, nil, {}, :ok]
     list2 = ["Two", :ok, 0.0, {true}]


### PR DESCRIPTION
Make it recursive and element-aware, it also should be faster than difference for their `inspect`ed representation (especially when difference is big).