### PR TITLE
Allow generated variables in map keys. Fix #4428

### DIFF
--- a/lib/elixir/src/elixir_translator.erl
+++ b/lib/elixir/src/elixir_translator.erl
@@ -92,14 +92,14 @@ translate({'cond', CondMeta, [[{do, Pairs}]]}, S) ->
 translate({'case', Meta, [Expr, KV]}, S) ->
   Clauses = elixir_clauses:get_pairs(do, KV, match),
   {TExpr, NS} = translate(Expr, S),
-  {TClauses, TS} = elixir_clauses:clauses(Meta, Clauses, NS),
-  {{'case', ?ann(Meta), TExpr, TClauses}, TS};
+  {TClauses, TS} = elixir_clauses:clauses(Meta, Clauses, NS#elixir_scope{extra=nil}),
+  {{'case', ?ann(Meta), TExpr, TClauses}, TS#elixir_scope{extra=NS#elixir_scope.extra}};
 
 %% Try
 
 translate({'try', Meta, [Clauses]}, S) ->
   Do = proplists:get_value('do', Clauses, nil),
-  {TDo, SB} = elixir_translator:translate(Do, S),
+  {TDo, SB} = elixir_translator:translate(Do, S#elixir_scope{extra=nil}),
 
   Catch = [Tuple || {X, _} = Tuple <- Clauses, X == 'rescue' orelse X == 'catch'],
   {TCatch, SC} = elixir_try:clauses(Meta, Catch, mergec(S, SB)),

--- a/lib/elixir/src/elixir_try.erl
+++ b/lib/elixir/src/elixir_try.erl
@@ -23,8 +23,8 @@ each_clause({'catch', Meta, Raw, Expr}, S) ->
 
   Condition = [{'{}', Meta, Final}],
   {TC, TS} = elixir_clauses:clause(Meta, fun elixir_translator:translate_args/2,
-                                   Condition, Expr, Guards, S),
-  {[TC], TS};
+                                   Condition, Expr, Guards, S#elixir_scope{extra=nil}),
+  {[TC], TS#elixir_scope{extra=S#elixir_scope.extra}};
 
 each_clause({rescue, Meta, [{in, _, [Left, Right]}], Expr}, S) ->
   {VarName, _, CS} = elixir_scope:build_var('_', S),
@@ -57,10 +57,11 @@ each_clause({Key, Meta, _, _}, S) ->
 build_rescue(Meta, Parts, Body, S) ->
   Matches = [Match || {Match, _} <- Parts],
 
-  {{clause, Line, TMatches, _, TBody}, TS} =
+  {{clause, Line, TMatches, _, TBody}, TSTmp} =
     elixir_clauses:clause(Meta, fun elixir_translator:translate_args/2,
-                          Matches, Body, [], S),
+                          Matches, Body, [], S#elixir_scope{extra=nil}),
 
+  TS = TSTmp#elixir_scope{extra=S#elixir_scope.extra},
   TClauses =
     [begin
       TArgs   = [{tuple, Line, [{atom, Line, error}, TMatch, {var, Line, '_'}]}],

--- a/lib/elixir/src/elixir_with.erl
+++ b/lib/elixir/src/elixir_with.erl
@@ -72,7 +72,7 @@ translate(Meta, Args, S) ->
       [] ->
         build_cases(Parts, Expr, fun(X) -> X end)
     end,
-  {TC, TS} = elixir_translator:translate(CaseExpr, S),
+  {TC, TS} = elixir_translator:translate(CaseExpr, S#elixir_scope{extra=nil}),
   {TC, elixir_scope:mergec(S, TS)}.
 
 build_cases([{'<-', Meta, [Left, Right]} | Rest], DoExpr, Wrapper) ->

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -28,6 +28,16 @@ defmodule MapTest do
     assert a == 1
   end
 
+  test "maps with generated variables in key" do
+    assert %{"#{1}" => 1} == %{"1" => 1}
+    assert %{(for x <- 1..3, do: x) => 1} == %{[1, 2, 3] => 1}
+    assert %{(with x = 1, do: x) => 1} == %{1 => 1}
+    assert %{(with {:ok, x} <- {:ok, 1}, do: x) => 1} == %{1 => 1}
+    assert %{(try do raise "error" rescue _ -> 1 end) => 1} == %{1 => 1}
+    assert %{(try do throw 1 catch x -> x end) => 1} == %{1 => 1}
+    assert %{(try do a = 1; a rescue _ -> 2 end) => 1} == %{1 => 1}
+  end
+
   test "is_map/1" do
     assert is_map(Map.new)
     refute is_map(Enum.to_list(%{}))


### PR DESCRIPTION
Hi,

This is another try to fix #4428.
I used @josevalim instructions from #4468, and changed scope `extra` to `nil` before
translating `with`, `try`, `catch`, `rescue`, `case` and `for`.
Please let me know if I forgot something.

Also, I am not sure if we should allow

```elixir
%{(a = 1) => 1}
```

so I left it as is. It seems a bit creepy and the scope is kind of ambiguous
but I am not sure it should raise a `CompilerError` either. What do you think?