### PR TITLE
Elixir version related fixes and improvements

### DIFF
--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -149,6 +149,7 @@ defmodule Kernel.CLI do
     if function_exported?(IEx, :started?, 0) and IEx.started? do
       IO.puts "IEx " <> System.build_info[:build]
     else
+      IO.puts :erlang.system_info(:system_version)
       IO.puts "Elixir " <> System.build_info[:build]
     end
 

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -164,7 +164,7 @@ defmodule IEx do
       13
 
   It is possible to load another file by supplying the `--dot-iex`
-  option to iex. See `iex --help`.
+  option to iex. See `iex -h`.
 
   ## Configuring the shell
 

--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -118,7 +118,7 @@ defmodule Mix.CLI do
     IO.puts "Mix " <> System.build_info[:build]
   end
 
-  # Check for --help or --version in the args
+  # Check for -h or -v in the args
   defp check_for_shortcuts([first_arg|_]) when first_arg in
       ["--help", "-h"], do: :help
 

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -92,7 +92,7 @@ defmodule Mix.CLITest do
   test "--version smoke test", context do
     in_tmp context.test, fn ->
       output = mix ~w[--version]
-      assert output =~ ~r/Mix [0-9\.a-z]+/
+      assert output =~ ~r{Erlang/OTP \d+ .+\n\nMix [0-9\.a-z]+}
     end
   end
 

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -81,17 +81,17 @@ defmodule Mix.CLITest do
     end
   end
 
-  test "--help smoke test", context do
+  test "-h smoke test", context do
     in_tmp context.test, fn ->
-      output = mix ~w[--help]
+      output = mix ~w[-h]
       assert output =~ ~r/mix compile\s+# Compiles source files/
       refute output =~ "mix invalid"
     end
   end
 
-  test "--version smoke test", context do
+  test "-v smoke test", context do
     in_tmp context.test, fn ->
-      output = mix ~w[--version]
+      output = mix ~w[-v]
       assert output =~ ~r{Erlang/OTP \d+ .+\n\nMix [0-9\.a-z]+}
     end
   end


### PR DESCRIPTION
1) `elixir -v`: Erlang system version was not getting printed due to a bug I introduced myself.
2) test improved fro `mix -v`
3) remove long argument version, in favour of short ones for binaries.

I would like to add tests for `iex -v` and `elixir -v` but I couldn't find an easy way to add them.