### PR TITLE
Updated documentation for delete/2 of MapSet

### DIFF
--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -99,8 +99,8 @@ defmodule MapSet do
 
   """
   @spec delete(t, value) :: t
-  def delete(%MapSet{map: map} = set, term) do
-    %{set | map: Map.delete(map, term)}
+  def delete(%MapSet{map: map} = set, value) do
+    %{set | map: Map.delete(map, value)}
   end
 
   @doc """


### PR DESCRIPTION
The second argument of `delete/2` function of `MapSet` should be `value` instead of `term`. This doesn't affect the compiled code, but it makes the documentation for the `delete/2` function a bit confusing.