### PR TITLE
fix(IEx.pry/1): remove unreachable code

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -440,8 +440,6 @@ defmodule IEx do
 
     # We cannot use colors because IEx may be off.
     case res do
-      {:error, :self} ->
-        IO.puts :stdio, "IEx cannot pry the shell itself."
       {:error, :no_iex} ->
         extra =
           case :os.type do


### PR DESCRIPTION
It seems like the "IEx cannot pry the shell itself" limitation was
removed 3 years ago in 0b624ff but this code wasn't removed.

Found this thanks to Dialyzer and https://github.com/fishcakez/dialyze.

The error printed by Dialyzer was:

> lib/iex.ex:443: The pattern {'error', 'self'} can never match the type 'ok' | {'error','no_iex' | 'refused'}