### PR TITLE
Fix Macro.to_string keyword blocks in normal function calls

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -766,7 +766,7 @@ defmodule Macro do
   # Block keywords
   @kw_keywords [:do, :catch, :rescue, :after, :else]
 
-  defp kw_blocks?([_|_] = kw) do
+  defp kw_blocks?([{:do, _} | _] = kw) do
     Enum.all?(kw, &match?({x, _} when x in unquote(@kw_keywords), &1))
   end
   defp kw_blocks?(_), do: false

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -467,6 +467,8 @@ defmodule MacroTest do
     assert Macro.to_string(quote do: {[]}) == "{[]}"
     assert Macro.to_string(quote do: {[a: b]}) == "{[a: b]}"
     assert Macro.to_string(quote do: {x, a: b}) == "{x, [a: b]}"
+    assert Macro.to_string(quote do: foo(else: a)) == "foo(else: a)"
+    assert Macro.to_string(quote do: foo(catch: a)) == "foo(catch: a)"
   end
 
   test "to string with fun" do


### PR DESCRIPTION
This should fix the `Macro.to_string` behavior seen in #4524.