### PR TITLE
Implement Mix.shell.warn

### DIFF
--- a/lib/mix/lib/mix/shell/io.ex
+++ b/lib/mix/lib/mix/shell/io.ex
@@ -38,6 +38,14 @@ defmodule Mix.Shell.IO do
   end
 
   @doc """
+  Writes a warn message to the shell followed by new line.
+  """
+  def warn(message) do
+    print_app
+    IO.puts IO.ANSI.format(yellow(message))
+  end
+
+  @doc """
   Writes an error message to the shell followed by new line.
   """
   def error(message) do
@@ -73,5 +81,9 @@ defmodule Mix.Shell.IO do
 
   defp red(message) do
     [:red, :bright, message]
+  end
+
+  defp yellow(message) do
+    [:yellow, :bright, message]
   end
 end

--- a/lib/mix/lib/mix/shell/process.ex
+++ b/lib/mix/lib/mix/shell/process.ex
@@ -88,6 +88,14 @@ defmodule Mix.Shell.Process do
   @doc """
   Forwards the message to the current process.
   """
+  def warn(message) do
+    print_app
+    send self, {:mix_shell, :warn, [format(message)]}
+  end
+
+  @doc """
+  Forwards the message to the current process.
+  """
   def error(message) do
     print_app
     send self, {:mix_shell, :error, [format(message)]}

--- a/lib/mix/test/mix/shell_test.exs
+++ b/lib/mix/test/mix/shell_test.exs
@@ -20,8 +20,10 @@ defmodule Mix.ShellTest do
 
   test "shell process" do
     Mix.shell.info "abc"
+    Mix.shell.warn "warn"
     Mix.shell.error "def"
     assert_received {:mix_shell, :info, ["abc"]}
+    assert_received {:mix_shell, :warn, ["warn"]}
     assert_received {:mix_shell, :error, ["def"]}
 
     send self, {:mix_shell_input, :prompt, "world"}
@@ -47,9 +49,15 @@ defmodule Mix.ShellTest do
     if IO.ANSI.enabled? do
       assert capture_io(:stderr, fn -> Mix.shell.error "def" end) ==
              "#{IO.ANSI.red}#{IO.ANSI.bright}def#{IO.ANSI.reset}\n"
+
+      assert capture_io(fn -> Mix.shell.warn "warn" end) ==
+             "#{IO.ANSI.yellow}#{IO.ANSI.bright}warn#{IO.ANSI.reset}\n"
     else
       assert capture_io(:stderr, fn -> Mix.shell.error "def" end) ==
              "def\n"
+
+      assert capture_io(fn -> Mix.shell.warn "warn" end) ==
+             "warn\n"
     end
 
     assert capture_io("world", fn -> assert Mix.shell.prompt("hello?") == "world" end) ==


### PR DESCRIPTION
Mix.shell.error will put massage in stderr, it will make some check fail, like travis,
i think we need a warn function just for warning