### PR TITLE
Add more tests for sigil `~w` interpolation behaviour

### DIFF
--- a/lib/elixir/test/elixir/kernel/sigils_test.exs
+++ b/lib/elixir/test/elixir/kernel/sigils_test.exs
@@ -66,6 +66,10 @@ bar) == "foo\\\nbar"
     assert ~w(foo bar baz) == ["foo", "bar", "baz"]
     assert ~w(foo #{:bar} baz) == ["foo", "bar", "baz"]
 
+    assert ~w(#{""}) == []
+    assert ~w(foo #{""}) == ["foo"]
+    assert ~w(#{" foo bar "}) == ["foo", "bar"]
+
     assert ~w(foo\ #{:bar}) == ["foo", "bar"]
     assert ~w(foo\ bar) == ["foo", "bar"]
 


### PR DESCRIPTION
As discussed here: 
https://groups.google.com/forum/#!topic/elixir-lang-core/89yO3X-oGsM