### PR TITLE
Add ~w doctest to highlight the behaviour of white space inside interpolation

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4053,6 +4053,9 @@ defmodule Kernel do
       iex> ~w(foo #{:bar} baz)
       ["foo", "bar", "baz"]
 
+      iex> ~w(foo #{" bar baz "})
+      ["foo", "bar", "baz"]
+
       iex> ~w(--source test/enum_test.exs)
       ["--source", "test/enum_test.exs"]
 


### PR DESCRIPTION
Continuing the idea of #4532, I've added a doctest so we have at least one example of this behaviour in the docs.