### PR TITLE
Adjust a String code example

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -151,8 +151,8 @@ defmodule String do
 
   Or also via pattern matching:
 
-      iex> <<eacute::utf8>> = "á"
-      iex> eacute
+      iex> <<aacute::utf8>> = "á"
+      iex> aacute
       225
 
   As we have seen above, codepoints can be inserted into


### PR DESCRIPTION
This once was `iex> << eacute :: utf8 >> = "é"` but the variable name became out of sync.