### PR TITLE
Return explicit error if escript main_module target is undefined

### DIFF
--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -117,9 +117,13 @@ defmodule Mix.Tasks.Escript.Build do
         Mix.raise "Could not generate escript, no name given, " <>
           "set :name escript option or :app in the project settings"
 
-      !main or !Code.ensure_loaded?(main)->
+      !main ->
         Mix.raise "Could not generate escript, please set :main_module " <>
           "in your project configuration (under :escript option) to a module that implements main/1"
+
+      !Code.ensure_loaded?(main) ->
+        Mix.raise "Could not generate escript, module #{main} defined as " <>
+          ":main_module could not be loaded"
 
       force || Mix.Utils.stale?(files, [filename]) ->
         beam_paths =

--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -49,6 +49,17 @@ defmodule Mix.Tasks.EscriptTest do
     end
   end
 
+  defmodule EscriptWithUnknownMainModule do
+    def project do
+      [ app: :escripttestwithunknownmainmodule,
+        version: "0.0.1",
+        escript: [
+          main_module: BogusEscripttest
+        ]
+      ]
+    end
+  end
+
   defmodule EscriptConsolidated do
     def project do
       [ app: :escripttestconsolidated,
@@ -174,6 +185,17 @@ defmodule Mix.Tasks.EscriptTest do
     assert_raise Mix.Error,
                  "The given path does not point to an escript, installation aborted", fn ->
       Mix.Tasks.Escript.Install.run [__ENV__.file]
+    end
+  end
+
+  test "escript invalid main module" do
+    Mix.Project.push EscriptWithUnknownMainModule
+
+    in_fixture "escripttest", fn ->
+      assert_raise Mix.Error, "Could not generate escript, module Elixir.BogusEscripttest defined as " <>
+                ":main_module could not be loaded", fn ->
+        Mix.Tasks.Escript.Build.run []
+      end
     end
   end
 end


### PR DESCRIPTION
Minor improvement / polish. Not sure this is worth merging in, yet submitting it in case!

I could go down the road and check that `main` is implemented on the target module too, yet I wanted to get my feet wet first.