### PR TITLE
IO: Several improvements

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -1,18 +1,18 @@
 defmodule IO do
   @moduledoc """
-  Functions handling IO.
+  Functions handling input/output (IO).
 
   Many functions in this module expect an IO device as an argument.
   An IO device must be a pid or an atom representing a process.
   For convenience, Elixir provides `:stdio` and `:stderr` as
   shortcuts to Erlang's `:standard_io` and `:standard_error`.
 
-  The majority of the functions expect char data, i.e. strings or
+  The majority of the functions expect chardata, i.e. strings or
   lists of characters and strings. In case another type is given,
   functions will convert to string via the `String.Chars` protocol
   (as shown in typespecs).
 
-  The functions starting with `bin*` expect iodata as an argument,
+  The functions starting with `bin` expect iodata as an argument,
   i.e. binaries or lists of bytes and binaries.
 
   ## IO devices
@@ -47,8 +47,11 @@ defmodule IO do
   end
 
   @doc """
-  Reads `count` characters from the IO device, a whole
-  `:line` or the whole device with `:all`.
+  Reads from the IO `device`.
+
+  The `device` is iterated by the given number of characters or line by line if
+  `:line` is given.
+  Alternatively, if `:all` is given, then whole `device` is returned.
 
   It returns:
 
@@ -64,7 +67,7 @@ defmodule IO do
   empty string in case the device has reached EOF.
   """
   @spec read(device, :all | :line | non_neg_integer) :: chardata | nodata
-  def read(device \\ group_leader(), chars_or_line)
+  def read(device \\ group_leader(), line_or_chars)
 
   def read(device, :all) do
     do_read_all(map_dev(device), "")
@@ -74,7 +77,7 @@ defmodule IO do
     :io.get_line(map_dev(device), '')
   end
 
-  def read(device, count) when count >= 0 do
+  def read(device, count) when is_integer(count) and count >= 0 do
     :io.get_chars(map_dev(device), '', count)
   end
 
@@ -87,8 +90,11 @@ defmodule IO do
   end
 
   @doc """
-  Reads `count` characters from the IO device, a whole
-  `:line` or the whole device with `:all`.
+  Reads from the IO `device`. The operation is Unicode unsafe.
+
+  The `device` is iterated by the given number of characters or line by line if
+  `:line` is given.
+  Alternatively, if `:all` is given, then whole `device` is returned.
 
   It returns:
 
@@ -103,11 +109,11 @@ defmodule IO do
   If `:all` is given, `:eof` is never returned, but an
   empty string in case the device has reached EOF.
 
-  Note: do not use this function on IO devices in unicode mode
+  Note: do not use this function on IO devices in Unicode mode
   as it will return the wrong result.
   """
   @spec binread(device, :all | :line | non_neg_integer) :: iodata | nodata
-  def binread(device \\ group_leader(), chars_or_line)
+  def binread(device \\ group_leader(), line_or_chars)
 
   def binread(device, :all) do
     do_binread_all(map_dev(device), "")
@@ -120,7 +126,7 @@ defmodule IO do
     end
   end
 
-  def binread(device, count) when count >= 0 do
+  def binread(device, count) when is_integer(count) and count >= 0 do
     case :file.read(map_dev(device), count) do
       {:ok, data} -> data
       other -> other
@@ -137,9 +143,9 @@ defmodule IO do
   end
 
   @doc """
-  Writes the given argument to the given device.
+  Writes `item` to the given `device`.
 
-  By default the device is the standard output.
+  By default the `device` is the standard output.
   It returns `:ok` if it succeeds.
 
   ## Examples
@@ -157,12 +163,13 @@ defmodule IO do
   end
 
   @doc """
-  Writes the given argument to the given device
-  as a binary, no unicode conversion happens.
+  Writes `item` as a binary to the given `device`.
+  No Unicode conversion happens.
+  The operation is Unicode unsafe.
 
   Check `write/2` for more information.
 
-  Note: do not use this function on IO devices in unicode mode
+  Note: do not use this function on IO devices in Unicode mode
   as it will return the wrong result.
   """
   @spec binwrite(device, iodata) :: :ok | {:error, term}
@@ -171,18 +178,17 @@ defmodule IO do
   end
 
   @doc """
-  Writes the argument to the device, similar to `write/2`,
-  but adds a newline at the end. The argument is expected
-  to be a chardata.
+  Writes `item` to the given `device`, similar to `write/2`,
+  but adds a newline at the end.
+
   """
   @spec puts(device, chardata | String.Chars.t) :: :ok
   def puts(device \\ group_leader(), item) do
-    erl_dev = map_dev(device)
-    :io.put_chars erl_dev, [to_chardata(item), ?\n]
+    :io.put_chars map_dev(device), [to_chardata(item), ?\n]
   end
 
   @doc """
-  Inspects and writes the given argument to the device.
+  Inspects and writes the given `item` to the device.
 
   It enables pretty printing by default with width of
   80 characters. The width can be changed by explicitly
@@ -201,7 +207,7 @@ defmodule IO do
   end
 
   @doc """
-  Inspects the item with options using the given device.
+  Inspects `item` according to the given options using the IO `device`.
 
   See `Inspect.Opts` for a full list of options.
   """
@@ -214,10 +220,35 @@ defmodule IO do
   end
 
   @doc """
-  Gets a number of bytes from the io device. If the
-  io device is a unicode device, `count` implies
-  the number of unicode codepoints to be retrieved.
+  Gets a number of bytes from IO device `:stdio`.
+
+  If `:stdio` is a Unicode device, `count` implies
+  the number of Unicode codepoints to be retrieved.
   Otherwise, `count` is the number of raw bytes to be retrieved.
+
+  See `IO.getn/3` for a description of return values.
+
+  """
+  @spec getn(chardata | String.Chars.t, pos_integer) :: chardata | nodata
+  @spec getn(device, chardata | String.Chars.t) :: chardata | nodata
+  def getn(prompt, count \\ 1)
+
+  def getn(prompt, count) when is_integer(count) and count > 0 do
+    getn(group_leader, prompt, count)
+  end
+
+  # This a catch-all function to call IO.getn/3
+  def getn(device, prompt) when not is_integer(prompt) do
+    getn(device, prompt, 1)
+  end
+
+  @doc """
+  Gets a number of bytes from the IO `device`.
+
+  If the IO `device` is a Unicode device, `count` implies
+  the number of Unicode codepoints to be retrieved.
+  Otherwise, `count` is the number of raw bytes to be retrieved.
+
   It returns:
 
     * `data` - the input characters
@@ -227,32 +258,15 @@ defmodule IO do
     * `{:error, reason}` - other (rare) error condition;
       for instance, `{:error, :estale}` if reading from an
       NFS volume
-  """
-  @spec getn(chardata | String.Chars.t, pos_integer) :: chardata | nodata
-  @spec getn(device, chardata | String.Chars.t) :: chardata | nodata
-  def getn(prompt, count \\ 1)
 
-  def getn(prompt, count) when is_integer(count) do
-    getn(group_leader, prompt, count)
-  end
-
-  def getn(device, prompt) do
-    getn(device, prompt, 1)
-  end
-
-  @doc """
-  Gets a number of bytes from the io device. If the
-  io device is a unicode device, `count` implies
-  the number of unicode codepoints to be retrieved.
-  Otherwise, `count` is the number of raw bytes to be retrieved.
   """
   @spec getn(device, chardata | String.Chars.t, pos_integer) :: chardata | nodata
-  def getn(device, prompt, count) do
+  def getn(device, prompt, count) when is_integer(count) and count > 0 do
     :io.get_chars(map_dev(device), to_chardata(prompt), count)
   end
 
   @doc """
-  Reads a line from the IO device.
+  Reads a line from the IO `device`.
 
   It returns:
 
@@ -269,7 +283,8 @@ defmodule IO do
 
   To display "What is your name?" as a prompt and await user input:
 
-      IO.gets "What is your name?"
+      IO.gets "What is your name?\n"
+
   """
   @spec gets(device, chardata | String.Chars.t) :: chardata | nodata
   def gets(device \\ group_leader(), prompt) do
@@ -277,16 +292,16 @@ defmodule IO do
   end
 
   @doc """
-  Converts the io device into a `IO.Stream`.
+  Converts the IO `device` into an `IO.Stream`.
 
   An `IO.Stream` implements both `Enumerable` and
   `Collectable`, allowing it to be used for both read
   and write.
 
-  The device is iterated line by line if `:line` is given or
-  by a given number of codepoints.
+  The `device` is iterated by the given number of characters or line by line if
+  `:line` is given.
 
-  This reads the IO as utf-8. Check out
+  This reads from the IO as utf-8. Check out
   `IO.binstream/2` to handle the IO as a raw binary.
 
   Note that an IO stream has side effects and every time
@@ -301,28 +316,34 @@ defmodule IO do
 
   """
   @spec stream(device, :line | pos_integer) :: Enumerable.t
-  def stream(device, line_or_codepoints) do
+  def stream(device, line_or_codepoints)
+      when line_or_codepoints == :line or
+      (is_integer(line_or_codepoints) and line_or_codepoints > 0) do
     IO.Stream.__build__(map_dev(device), false, line_or_codepoints)
   end
 
   @doc """
-  Converts the IO device into a `IO.Stream`.
+  Converts the IO `device` into an `IO.Stream`. The operation is Unicode unsafe.
 
   An `IO.Stream` implements both `Enumerable` and
   `Collectable`, allowing it to be used for both read
   and write.
 
-  The device is iterated line by line or by a number of bytes.
-  This reads the IO device as a raw binary.
+  The `device` is iterated by the given number of bytes or line by line if
+  `:line` is given.
+  This reads from the IO device as a raw binary.
 
   Note that an IO stream has side effects and every time
   you go over the stream you may get different results.
 
-  Finally, do not use this function on IO devices in unicode
+  Finally, do not use this function on IO devices in Unicode
   mode as it will return the wrong result.
+
   """
   @spec binstream(device, :line | pos_integer) :: Enumerable.t
-  def binstream(device, line_or_bytes) do
+  def binstream(device, line_or_bytes)
+      when line_or_bytes == :line or
+      (is_integer(line_or_bytes) and line_or_bytes > 0) do
     IO.Stream.__build__(map_dev(device), true, line_or_bytes)
   end
 
@@ -330,8 +351,8 @@ defmodule IO do
   Converts chardata (a list of integers representing codepoints,
   lists and strings) into a string.
 
-  In case the conversion fails, it raises a `UnicodeConversionError`.
-  If a string is given, returns the string itself.
+  In case the conversion fails, it raises an `UnicodeConversionError`.
+  If a string is given, it returns the string itself.
 
   ## Examples
 
@@ -340,6 +361,9 @@ defmodule IO do
 
       iex> IO.chardata_to_string([0x0061, "bc"])
       "abc"
+
+      iex> IO.chardata_to_string("string")
+      "string"
 
   """
   @spec chardata_to_string(chardata) :: String.t | no_return
@@ -354,6 +378,7 @@ defmodule IO do
   @doc """
   Converts iodata (a list of integers representing bytes, lists
   and binaries) into a binary.
+  The operation is Unicode unsafe.
 
   Notice that this function treats lists of integers as raw bytes
   and does not perform any kind of encoding conversion. If you want
@@ -399,8 +424,8 @@ defmodule IO do
   end
 
   @doc false
-  def each_stream(device, what) do
-    case read(device, what) do
+  def each_stream(device, line_or_codepoints) do
+    case read(device, line_or_codepoints) do
       :eof ->
         {:halt, device}
       {:error, reason} ->
@@ -411,8 +436,8 @@ defmodule IO do
   end
 
   @doc false
-  def each_binstream(device, what) do
-    case binread(device, what) do
+  def each_binstream(device, line_or_chars) do
+    case binread(device, line_or_chars) do
       :eof ->
         {:halt, device}
       {:error, reason} ->

--- a/lib/elixir/lib/io/stream.ex
+++ b/lib/elixir/lib/io/stream.ex
@@ -18,6 +18,9 @@ defmodule IO.Stream do
     * `raw`           - a boolean indicating if bin functions should be used
     * `line_or_bytes` - if reading should read lines or a given amount of bytes
 
+  It is worth noting that an IO stream has side effects and every time you go
+  over the stream you may get different results.
+
   """
 
   defstruct device: nil, raw: true, line_or_bytes: :line

--- a/lib/elixir/test/elixir/io_test.exs
+++ b/lib/elixir/test/elixir/io_test.exs
@@ -43,7 +43,9 @@ defmodule IOTest do
 
   test "getn with count" do
     {:ok, file} = File.open(Path.expand('fixtures/file.txt', __DIR__), [:char_list])
-    assert 'FOO' == IO.getn(file, "", 3)
+    assert 'F' == IO.getn(file, "λ")
+    assert 'OO' == IO.getn(file, "", 2)
+    assert '\n' == IO.getn(file, "λ", 99)
     assert File.close(file) == :ok
   end
 
@@ -135,5 +137,32 @@ defmodule IOTest do
     assert capture_io("foo\n", fn -> IO.getn('hello', 3) end) == "hello"
     assert capture_io("foo\n", fn -> IO.getn(:hello, 3) end) == "hello"
     assert capture_io("foo\n", fn -> IO.getn(13, 3) end) == "13"
+  end
+
+  test "getn with different arities" do
+    assert capture_io("hello", fn ->
+      input = IO.getn(">")
+      IO.write input
+    end) == ">h"
+
+    assert capture_io("hello", fn ->
+      input = IO.getn(">", 3)
+      IO.write input
+    end) == ">hel"
+
+    assert capture_io("hello", fn ->
+      input = IO.getn(:erlang.group_leader, ">")
+      IO.write input
+    end) == ">h"
+
+    assert capture_io([input: "hello", capture_prompt: false], fn ->
+      input = IO.getn(:erlang.group_leader, ">")
+      IO.write input
+    end) == "h"
+
+    assert capture_io([input: "hello", capture_prompt: false], fn ->
+      input = IO.getn(:erlang.group_leader, ">", 99)
+      IO.write input
+    end) == "hello"
   end
 end


### PR DESCRIPTION
IO Module:
  * Impoves wording in documentation, particularly in the use of :all, :line, count
  * Standardizes arg names to be `line_*`.
  * Adds function guards to check for integers.
  * Unicode is a proper noun, so it should be always capitalized.
  * Adds backticks to args suchs as `device`, `item`, `count`.
  * When functions are "Unicode unsafe", they are indicated in the first paragraph of docs.
  * IO.puts: code simplified removing unnecessary variable.
  * Adds \n to example in IO.gets/2
  * Adds example in IO.chardata_to_string/1 when dealing with strings
  * Renames args in IO.each_stream/2 and IO.each_binstream/2
  * Adds tests for IO.getn/2-3 calling functions with different arities

IO.Steam Module:
  * Adds a note about side effects when dealing with IO streams.