### PR TITLE
Stringify truncated function data in Logger

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -587,7 +587,7 @@ defmodule Logger do
   end
 
   defp truncate(data, n) when is_function(data, 0),
-    do: Logger.Utils.truncate(data.(), n)
+    do: truncate(data.(), n)
   defp truncate(data, n) when is_list(data) or is_binary(data),
     do: Logger.Utils.truncate(data, n)
   defp truncate(data, n),


### PR DESCRIPTION
#### What does this PR do?

Converts return value of functions passed into Logger into a string.

#### Where should the reviewer start?

Notice how this line doesn't convert `data.()` to a string:
[https://github.com/elixir-lang/elixir/blob/master/lib/logger/lib/logger.ex#L590](https://github.com/elixir-lang/elixir/blob/master/lib/logger/lib/logger.ex#L590)

And this line converts `data` to a string:
[https://github.com/elixir-lang/elixir/blob/master/lib/logger/lib/logger.ex#L594](https://github.com/elixir-lang/elixir/blob/master/lib/logger/lib/logger.ex#L594)

I believe the intent is for data to be converted into a string value.

#### How should this be manually tested?

To replicate the bug:

* checkout branch 23dd2723bd43d3eef0991d3d35eb50a7362796b3
* launch iex
* use the following code block

```
defmodule Handler do
  use GenEvent

  def handle_event({_,_,{_,message,_,_}}, state) do
    IO.puts "the message #{message} is a string? => #{is_bitstring(message)}"
    {:ok, state}
  end
end

require Logger
Logger.remove_backend(:console)
Logger.add_backend(Handler)
Logger.debug(123)             # the message "123" is a string? => true
Logger.debug(fn -> 123 end)   # the message 123 is a string? => false
Logger.debug(:atom)           # the message "atom" is a string? => true
Logger.debug(fn -> :atom end) # ** (FunctionClauseError) no function clause...
```

To replicate the fix:

* checkout branch 23dd2723bd43d3eef0991d3d35eb50a7362796b3
* launch iex
* run the same code again

```
defmodule Handler do
  use GenEvent

  def handle_event({_,_,{_,message,_,_}}, state) do
    IO.puts "the message #{message} is a string? => #{is_bitstring(message)}"
    {:ok, state}
  end
end

require Logger
Logger.remove_backend(:console)
Logger.add_backend(Handler)
Logger.debug(123)             # the message 123 is a string? => true
Logger.debug(fn -> 123 end)   # the message 123 is a string? => true
Logger.debug(:atom)           # the message atom is a string? => true
Logger.debug(fn -> :atom end) # the message atom is a string? => true
```

#### Questions:
- Does this PR depend on any others?

No.

- Did I run this locally?

Yes.

- Did I run the whole test suite?

Yes.

- Did I add tests to cover the change?

No.  It's a private function.
