### PR TITLE
add slack to 'Important links'

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ the `doc` directory. If you are planning to contribute documentation,
   * [Issues tracker][2]
   * [Code of Conduct][7]
   * **[#elixir-lang][4]** on [Freenode][5] IRC
+  * [Elixir-lang][8] on [Slack][9]
 
   [1]: http://elixir-lang.org
   [2]: https://github.com/elixir-lang/elixir/issues
@@ -122,6 +123,8 @@ the `doc` directory. If you are planning to contribute documentation,
   [5]: http://www.freenode.net
   [6]: http://elixir-lang.org/docs.html
   [7]: CODE_OF_CONDUCT.md
+  [8]: https://elixir-slackin.herokuapp.com/
+  [9]: https://slack.com/
 
 ## License
 


### PR DESCRIPTION
I noticed that the Slack community was missing from README. With currently 6635 members, I think it has enough members to be considered a *main* channel to get help or talk with fellow Elixir folks. 

Phoenix as the biggest Elixir project is currently linking it [here](http://www.phoenixframework.org/docs/community) which makes this even more confusing for new people. Adding it to the main README will acknowledge the slacks existence and make it a lot easier for existing slack people that maybe didn't start with the phoenix route.

I also saw https://github.com/elixir-lang/elixir/pull/4480. Is there a big distinction between slack and irc? Is one considered *official* and the other one not? 