### PR TITLE
Standardize unicode and friends

### DIFF
--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -316,7 +316,7 @@ foo
     assert_eval "\ndone\n", string, packages: nil, all: nil
   end
 
-  test "unicode" do
+  test "Unicode" do
     template = """
       • <%= "•" %> •
       <%= "Jößé Vâlìm" %> Jößé Vâlìm

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -100,7 +100,7 @@ defmodule DateTime do
   @moduledoc """
   A datetime implementation with a time zone.
 
-  This datetime can be seen as a ephemeral snapshot
+  This datetime can be seen as an ephemeral snapshot
   of a datetime at a given timezone. For such purposes,
   it also includes both UTC and Standard offsets, as
   well as the zone abbreviation field used exclusively

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -221,7 +221,7 @@ defmodule Kernel.SpecialForms do
       iex> <<102, rest::binary>>
       "foo"
 
-  The utf8, utf16, and utf32 types are for unicode codepoints. They
+  The utf8, utf16, and utf32 types are for Unicode codepoints. They
   can also be applied to literal strings and char lists:
 
       iex> <<"foo"::utf16>>

--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -3,7 +3,7 @@ defmodule Path do
   This module provides conveniences for manipulating or
   retrieving file system paths.
 
-  The functions in this module may receive a char data as
+  The functions in this module may receive a chardata as
   argument (i.e. a string or a list of characters / string)
   and will always return a string (encoded in UTF-8).
 

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -13,7 +13,7 @@ defmodule Regex do
       # A simple regular expressions that matches foo anywhere in the string
       ~r/foo/
 
-      # A regular expression with case insensitive and unicode options
+      # A regular expression with case insensitive and Unicode options
       ~r/foo/iu
 
   A Regex is represented internally as the `Regex` struct. Therefore,
@@ -23,9 +23,9 @@ defmodule Regex do
 
   The modifiers available when creating a Regex are:
 
-    * `unicode` (u) - enables unicode specific patterns like `\p` and change
-      modifiers like `\w`, `\W`, `\s` and friends to also match on unicode.
-      It expects valid unicode strings to be given on match
+    * `unicode` (u) - enables Unicode specific patterns like `\p` and change
+      modifiers like `\w`, `\W`, `\s` and friends to also match on Unicode.
+      It expects valid Unicode strings to be given on match
 
     * `caseless` (i) - add case insensitivity
 

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -738,7 +738,7 @@ defmodule System do
   will never return the same integer more than once on the current runtime
   instance.
 
-  If `modifiers` is `[]`, then an unique integer (that can be positive or negative) is returned.
+  If `modifiers` is `[]`, then a unique integer (that can be positive or negative) is returned.
   Other modifiers can be passed to change the properties of the returned integer:
 
     * `:positive` - the returned integer is guaranteed to be positive.

--- a/lib/elixir/src/elixir_interpolation.erl
+++ b/lib/elixir/src/elixir_interpolation.erl
@@ -163,7 +163,7 @@ unescape_unicode(<<${, A, B, C, D, E, F, $}, Rest/binary>>, Map, Acc) when ?is_h
   append_codepoint(Rest, Map, [A, B, C, D, E, F], Acc, 16);
 
 unescape_unicode(<<_/binary>>, _Map, _Acc) ->
-  Msg = <<"invalid unicode sequence after \\u, expected \\uHHHH or \\u{H*}">>,
+  Msg = <<"invalid Unicode sequence after \\u, expected \\uHHHH or \\u{H*}">>,
   error('Elixir.ArgumentError':exception([{message, Msg}])).
 
 append_codepoint(Rest, Map, List, Acc, Base) ->
@@ -172,7 +172,7 @@ append_codepoint(Rest, Map, List, Acc, Base) ->
     Binary -> unescape_chars(Rest, Map, Binary)
   catch
     error:badarg ->
-      Msg = <<"invalid or reserved unicode codepoint ", (integer_to_binary(Codepoint))/binary>>,
+      Msg = <<"invalid or reserved Unicode codepoint ", (integer_to_binary(Codepoint))/binary>>,
       error('Elixir.ArgumentError':exception([{message, Msg}]))
   end.
 

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -79,11 +79,11 @@ defmodule RegexTest do
     assert Regex.opts(Regex.compile!("foo", "i")) == "i"
   end
 
-  test "unicode" do
+  test "Unicode" do
     assert "olá" =~ ~r"\p{Latin}$"u
     refute "£" =~ ~r/\p{Lu}/u
 
-    # Non breaking space matches [[:space:]] with unicode
+    # Non breaking space matches [[:space:]] with Unicode
     assert <<0xA0::utf8>> =~ ~r/[[:space:]]/u
     assert <<0xA0::utf8>> =~ ~r/\s/u
 
@@ -243,7 +243,7 @@ defmodule RegexTest do
 
     assert matches_escaped?("\\A  \\z")
     assert matches_escaped?("  x  ")
-    assert matches_escaped?("  x    x ") # unicode spaces here
+    assert matches_escaped?("  x    x ") # Unicode spaces here
     assert matches_escaped?("# lol")
 
     assert matches_escaped?("\\A.^$*+?()[{\\| \t\n\x20\\z #hello\u202F\u205F")

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -12,7 +12,7 @@ defmodule StringTest do
   end
 
   # test cases described in http://mortoray.com/2013/11/27/the-string-type-is-broken/
-  test "unicode" do
+  test "Unicode" do
     assert String.reverse("noël") == "lëon"
     assert String.slice("noël", 0..2) == "noë"
     assert String.length("noël") == 4

--- a/lib/elixir/unicode/unicode.ex
+++ b/lib/elixir/unicode/unicode.ex
@@ -24,7 +24,7 @@ defmodule String.Unicode do
 
   # There is no codepoint marked as Prepend by Unicode 6.3.0
   if cluster["Prepend"] do
-    raise "it seems this new unicode version has added Prepend items. " <>
+    raise "it seems this new Unicode version has added Prepend items. " <>
           "Please remove this error and uncomment the code below"
   end
 

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -2,7 +2,7 @@ defmodule Logger.Utils do
   @moduledoc false
 
   @doc """
-  Truncates a char data into n bytes.
+  Truncates a `chardata` into `n` bytes.
 
   There is a chance we truncate in the middle of a grapheme
   cluster but we never truncate in the middle of a binary


### PR DESCRIPTION
- Unicode is a proper noun, so it should be capitalized
- Replace 'charlist' with 'char list' or 'char_list'
- Replace 'char data' with 'chardata'
- Correct use of a/an articles