### PR TITLE
Fix ExUnit stacktrace formatting when its entry has no location

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -464,11 +464,7 @@ defmodule Exception do
       ""
 
   """
-  def format_file_line(file, line) do
-    format_file_line(file, line, "")
-  end
-
-  defp format_file_line(file, line, suffix) do
+  def format_file_line(file, line, suffix \\ "") do
     if file do
       if line && line != 0 do
         "#{file}:#{line}:#{suffix}"

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -35,7 +35,7 @@ defmodule ExUnit.Formatter do
   @type run_us :: pos_integer
   @type load_us :: pos_integer | nil
 
-  import Exception, only: [format_stacktrace_entry: 1]
+  import Exception, only: [format_stacktrace_entry: 1, format_file_line: 3]
 
   @label_padding   "      "
   @counter_padding "     "
@@ -236,16 +236,17 @@ defmodule ExUnit.Formatter do
 
   defp format_stacktrace(stacktrace, test_case, test, color) do
     extra_info("stacktrace:", color) <>
-      Enum.map_join(stacktrace,
-        fn(s) -> stacktrace_info format_stacktrace_entry(s, test_case, test), color end)
+      Enum.map_join(stacktrace, fn entry ->
+        stacktrace_info format_stacktrace_entry(entry, test_case, test), color
+      end)
   end
 
   defp format_stacktrace_entry({test_case, test, _, location}, test_case, test) do
-    "#{location[:file]}:#{location[:line]}"
+    format_file_line(location[:file], location[:line], " (test)")
   end
 
-  defp format_stacktrace_entry(s, _test_case, _test) do
-    format_stacktrace_entry(s)
+  defp format_stacktrace_entry(entry, _test_case, _test) do
+    format_stacktrace_entry(entry)
   end
 
   defp with_location(tags) do
@@ -277,6 +278,7 @@ defmodule ExUnit.Formatter do
   defp extra_info(msg, nil),       do: "     " <> msg <> "\n"
   defp extra_info(msg, formatter), do: extra_info(formatter.(:extra_info, msg), nil)
 
+  defp stacktrace_info("", _formatter), do: ""
   defp stacktrace_info(msg, nil),       do: "       " <> msg <> "\n"
   defp stacktrace_info(msg, formatter), do: stacktrace_info(formatter.(:stacktrace_info, msg), nil)
 end

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -283,7 +283,7 @@ defmodule ExUnit.DocTestTest do
          code:  Hello.world
          stacktrace:
            Hello.world()
-           (for doctest at) test/ex_unit/doc_test_test.exs:129
+           (for doctest at) test/ex_unit/doc_test_test.exs:129: (test)
     """
 
     assert output =~ """


### PR DESCRIPTION
Closes #4570.