### PR TITLE
Add c/1 documentation

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -23,6 +23,7 @@ defmodule IEx.Helpers do
   There are many other helpers available:
 
     * `b/1`           - prints callbacks info and docs for a given module
+    * `c/1`           - compiles a file at the current directory
     * `c/2`           - compiles a file at the given path
     * `cd/1`          - changes the current directory
     * `clear/0`       - clears the screen


### PR DESCRIPTION
I always tend to get a bit surprised when I see `c/2` only in the helpers documentation so I thought this would be useful to have. It's also consistent with other helpers which follow a similar pattern like `v/0` & `v/1`.