### PR TITLE
Do not force spaces between arguments in mix do

### DIFF
--- a/lib/mix/lib/mix/tasks/do.ex
+++ b/lib/mix/lib/mix/tasks/do.ex
@@ -19,25 +19,40 @@ defmodule Mix.Tasks.Do do
   def run(args) do
     Enum.each gather_commands(args), fn
       [task | args] -> Mix.Task.run task, args
-      [] -> Mix.raise "No expression between commas"
     end
   end
 
-  defp gather_commands(args) do
-    gather_commands args, [], []
+  @doc false
+  def gather_commands(args) do
+    gather_commands(args, [], [])
   end
 
-  defp gather_commands([h | t], current, acc) when binary_part(h, byte_size(h), -1) == "," do
-    part    = binary_part(h, 0, byte_size(h) - 1)
-    current = Enum.reverse([part | current])
-    gather_commands t, [], [current | acc]
+  defp gather_commands([], current, commands) do
+    [current | commands]
+    |> Enum.reject(&(&1 == []))
+    |> Enum.map(&Enum.reverse(&1))
+    |> Enum.reverse
+  end
+  defp gather_commands([arg | rest], current, commands) do
+    {current, commands} =
+      case String.split(arg, ",") do
+        [arg] -> {[arg | current], commands}
+        # special care if the argument contains a comma
+        args  -> update_commands(args, current, commands)
+      end
+    gather_commands(rest, current, commands)
   end
 
-  defp gather_commands([h | t], current, acc) do
-    gather_commands t, [h | current], acc
+  defp update_commands([], current, commands) do
+    {current, commands}
   end
-
-  defp gather_commands([], current, acc) do
-    Enum.reverse [Enum.reverse(current) | acc]
+  defp update_commands([arg], current, commands) when arg != "" do
+    {[arg], [current | commands]}
+  end
+  defp update_commands([arg | args], current, commands) do
+    # if the argument is empty, we had a leading or trailing comma
+    # so we simply terminate the current command
+    command = if arg == "", do: current, else: [arg | current]
+    update_commands(args, [], [command | commands])
   end
 end

--- a/lib/mix/test/mix/tasks/do_test.exs
+++ b/lib/mix/test/mix/tasks/do_test.exs
@@ -10,4 +10,16 @@ defmodule Mix.Tasks.DoTest do
       assert_received {:mix_shell, :info, ["mix compile.app" <> _]}
     end
   end
+
+  test "gather_command ignore spaces and trailing commas" do
+    import Mix.Tasks.Do, only: [gather_commands: 1]
+    assert gather_commands(["compile", "--list,", "help"]) == [["compile", "--list"], ["help"]]
+    assert gather_commands(["compile", "--list,help"]) == [["compile", "--list"], ["help"]]
+    assert gather_commands(["help", ",compile", "--list"]) == [["help"], ["compile", "--list"]]
+    assert gather_commands(["compile", "--list", ",", "help"]) == [["compile", "--list"], ["help"]]
+    assert gather_commands(["compile,", "run", "-e", "IO.puts :hello"]) == [["compile"], ["run", "-e", "IO.puts :hello"]]
+    assert gather_commands(
+      [",", "compile,", "run", "-e", "IO.puts :hello",",foo", "--bar", "--baz", ",", "baz,qux,abc", ","]) ==
+      [["compile"], ["run", "-e", "IO.puts :hello"], ["foo", "--bar", "--baz"], ["baz"], ["qux"], ["abc"]]
+  end
 end


### PR DESCRIPTION
I often forget the space after the comma when using `mix do`,
so I changed the task a little to allow separating tasks only with a comma,
so we can for example write.

```
mix do deps.get,compile, release
```