### PR TITLE
[WIP] Rename char_list to charlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ This release deprecates many APIs that have been soft-deprecated in previous Eli
 
   * [Dict] `Dict` is no longer a behaviour and its functions will be deprecated in upcoming releases
   * [Enum] Passing a non-map to `Enum.group_by/3` is deprecated
-  * [Kernel] `\x{H*}` in strings/sigils/char lists is deprecated
+  * [Kernel] `\x{H*}` in strings/sigils/charlists is deprecated
   * [Kernel] Add deprecation for `defdelegate` list arguments and `:append_first` option
   * [Kernel] Warn if a variable is assigned inside `case`/`if`/etc and used outside the block
   * [Keyword] `Keyword.size/1` is deprecated in favor of `Kernel.length/1`

--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -74,7 +74,7 @@ defmodule EEx.Compiler do
   defp wrap_expr(current, line, buffer, chars, state) do
     new_lines = List.duplicate(?\n, line - state.line)
     key = length(state.quoted)
-    placeholder = '__EEX__(' ++ Integer.to_char_list(key) ++ ');'
+    placeholder = '__EEX__(' ++ Integer.to_charlist(key) ++ ');'
     {current ++ placeholder ++ new_lines ++ chars,
      %{state | quoted: [{key, buffer} | state.quoted]}}
   end

--- a/lib/eex/lib/eex/tokenizer.ex
+++ b/lib/eex/lib/eex/tokenizer.ex
@@ -2,7 +2,7 @@ defmodule EEx.Tokenizer do
   @moduledoc false
 
   @doc """
-  Tokenizes the given char list or binary.
+  Tokenizes the given charlist or binary.
 
   It returns {:ok, list} with the following tokens:
 
@@ -17,7 +17,7 @@ defmodule EEx.Tokenizer do
   def tokenize(bin, line, opts \\ [])
 
   def tokenize(bin, line, opts) when is_binary(bin) do
-    tokenize(String.to_char_list(bin), line, opts)
+    tokenize(String.to_charlist(bin), line, opts)
   end
 
   def tokenize(list, line, opts) do

--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -370,7 +370,7 @@ foo
         {EExTest.Compiled,
           :before_compile,
           0,
-          [file: to_char_list(Path.relative_to_cwd(__ENV__.file)), line: 7]
+          [file: to_charlist(Path.relative_to_cwd(__ENV__.file)), line: 7]
        }
      }
 
@@ -379,7 +379,7 @@ foo
         {EExTest.Compiled,
           :after_compile,
           0,
-          [file: to_char_list(Path.relative_to_cwd(__ENV__.file)), line: 22]
+          [file: to_charlist(Path.relative_to_cwd(__ENV__.file)), line: 22]
        }
      }
 

--- a/lib/elixir/lib/atom.ex
+++ b/lib/elixir/lib/atom.ex
@@ -22,18 +22,18 @@ defmodule Atom do
   end
 
   @doc """
-  Converts an atom to a char list.
+  Converts an atom to a charlist.
 
   Inlined by the compiler.
 
   ## Examples
 
-      iex> Atom.to_char_list(:"An atom")
+      iex> Atom.to_charlist(:"An atom")
       'An atom'
 
   """
-  @spec to_char_list(atom) :: char_list
-  def to_char_list(atom) do
+  @spec to_charlist(atom) :: charlist
+  def to_charlist(atom) do
     :erlang.atom_to_list(atom)
   end
 end

--- a/lib/elixir/lib/atom.ex
+++ b/lib/elixir/lib/atom.ex
@@ -36,4 +36,9 @@ defmodule Atom do
   def to_charlist(atom) do
     :erlang.atom_to_list(atom)
   end
+
+  # TODO: Deprecate by v1.5
+  @doc false
+  @spec to_char_list(atom) :: charlist
+  def to_char_list(atom), do: Atom.to_charlist(atom)
 end

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -593,11 +593,10 @@ defmodule Code do
 
   ## Examples
 
-      # Get the documentation for the first function listed
-      iex> [fun | _] = Code.get_docs(Atom, :docs) |> Enum.sort()
-      iex> {{_function, _arity}, _line, _kind, _signature, text} = fun
+      # Get the module documentation
+      iex> {_line, text} = Code.get_docs(Atom, :moduledoc)
       iex> String.split(text, "\n") |> Enum.at(0)
-      "Converts an atom to a charlist."
+      "Convenience functions for working with atoms."
 
       # Module doesn't exist
       iex> Code.get_docs(ModuleNotGood, :all)

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -56,7 +56,7 @@ defmodule Code do
 
   """
   def append_path(path) do
-    :code.add_pathz(to_char_list(Path.expand path))
+    :code.add_pathz(to_charlist(Path.expand path))
   end
 
   @doc """
@@ -76,7 +76,7 @@ defmodule Code do
 
   """
   def prepend_path(path) do
-    :code.add_patha(to_char_list(Path.expand path))
+    :code.add_patha(to_charlist(Path.expand path))
   end
 
   @doc """
@@ -95,7 +95,7 @@ defmodule Code do
 
   """
   def delete_path(path) do
-    :code.del_path(to_char_list(Path.expand path))
+    :code.del_path(to_charlist(Path.expand path))
   end
 
   @doc """
@@ -159,13 +159,13 @@ defmodule Code do
   def eval_string(string, binding \\ [], opts \\ [])
 
   def eval_string(string, binding, %Macro.Env{} = env) do
-    {value, binding, _env, _scope} = :elixir.eval to_char_list(string), binding, Map.to_list(env)
+    {value, binding, _env, _scope} = :elixir.eval to_charlist(string), binding, Map.to_list(env)
     {value, binding}
   end
 
   def eval_string(string, binding, opts) when is_list(opts) do
     validate_eval_opts(opts)
-    {value, binding, _env, _scope} = :elixir.eval to_char_list(string), binding, opts
+    {value, binding, _env, _scope} = :elixir.eval to_charlist(string), binding, opts
     {value, binding}
   end
 
@@ -263,7 +263,7 @@ defmodule Code do
   def string_to_quoted(string, opts \\ []) when is_list(opts) do
     file = Keyword.get opts, :file, "nofile"
     line = Keyword.get opts, :line, 1
-    :elixir.string_to_quoted(to_char_list(string), line, file, opts)
+    :elixir.string_to_quoted(to_charlist(string), line, file, opts)
   end
 
   @doc """
@@ -279,7 +279,7 @@ defmodule Code do
   def string_to_quoted!(string, opts \\ []) when is_list(opts) do
     file = Keyword.get opts, :file, "nofile"
     line = Keyword.get opts, :line, 1
-    :elixir.string_to_quoted!(to_char_list(string), line, file, opts)
+    :elixir.string_to_quoted!(to_charlist(string), line, file, opts)
   end
 
   @doc """
@@ -445,7 +445,7 @@ defmodule Code do
   For compiling many files at once, check `Kernel.ParallelCompiler.files/2`.
   """
   def compile_string(string, file \\ "nofile") when is_binary(file) do
-    :elixir_compiler.string to_char_list(string), file
+    :elixir_compiler.string to_charlist(string), file
   end
 
   @doc """
@@ -597,7 +597,7 @@ defmodule Code do
       iex> [fun | _] = Code.get_docs(Atom, :docs) |> Enum.sort()
       iex> {{_function, _arity}, _line, _kind, _signature, text} = fun
       iex> String.split(text, "\n") |> Enum.at(0)
-      "Converts an atom to a char list."
+      "Converts an atom to a charlist."
 
       # Module doesn't exist
       iex> Code.get_docs(ModuleNotGood, :all)
@@ -616,7 +616,7 @@ defmodule Code do
   end
 
   def get_docs(binpath, kind) when is_binary(binpath) and kind in @doc_kinds do
-    do_get_docs(String.to_char_list(binpath), kind)
+    do_get_docs(String.to_charlist(binpath), kind)
   end
 
   @docs_chunk 'ExDc'

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -20,7 +20,7 @@ defmodule File do
   `IO.write/2` functions must be used as they are responsible for
   doing the proper conversions and providing the proper data guarantees.
 
-  Note that filenames when given as char lists in Elixir are
+  Note that filenames when given as charlists in Elixir are
   always treated as UTF-8. In particular, we expect that the
   shell and the operating system are configured to use UTF-8
   encoding. Binary filenames are considered raw and passed
@@ -946,8 +946,8 @@ defmodule File do
     * `:exclusive` - the file, when opened for writing, is created if it does
       not exist. If the file exists, open will return `{:error, :eexist}`.
 
-    * `:char_list` - when this term is given, read operations on the file will
-      return char lists rather than binaries.
+    * `:charlist` - when this term is given, read operations on the file will
+      return charlists rather than binaries.
 
     * `:compressed` - makes it possible to read or write gzip compressed files.
 
@@ -1318,7 +1318,7 @@ defmodule File do
 
   @read_ahead 64*1024
 
-  defp open_defaults([:char_list | t], _add_binary) do
+  defp open_defaults([:charlist | t], _add_binary) do
     open_defaults(t, false)
   end
 

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1318,7 +1318,8 @@ defmodule File do
 
   @read_ahead 64*1024
 
-  defp open_defaults([:charlist | t], _add_binary) do
+  # TODO: Deprecate :char_list mode by v1.5
+  defp open_defaults([mode | t], _add_binary) when mode in [:charlist, :char_list] do
     open_defaults(t, false)
   end
 

--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -254,4 +254,9 @@ defmodule Float do
   defp expand_compact([{:compact, true} | t]),  do: [:compact | expand_compact(t)]
   defp expand_compact([h | t]),                 do: [h | expand_compact(t)]
   defp expand_compact([]),                      do: []
+
+  # TODO: Deprecate by v1.5
+  @doc false
+  @spec to_char_list(float) :: charlist
+  def to_char_list(float), do: Float.to_charlist(float)
 end

--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -171,18 +171,18 @@ defmodule Float do
   end
 
   @doc """
-  Returns a char list which corresponds to the text representation of the given float.
+  Returns a charlist which corresponds to the text representation of the given float.
 
   Inlined by the compiler.
 
   ## Examples
 
-      iex> Float.to_char_list(7.0)
+      iex> Float.to_charlist(7.0)
       '7.00000000000000000000e+00'
 
   """
-  @spec to_char_list(float) :: char_list
-  def to_char_list(float) do
+  @spec to_charlist(float) :: charlist
+  def to_charlist(float) do
     :erlang.float_to_list(float)
   end
 
@@ -199,12 +199,12 @@ defmodule Float do
 
   ## Examples
 
-      iex> Float.to_char_list 7.1, [decimals: 2, compact: true]
+      iex> Float.to_charlist 7.1, [decimals: 2, compact: true]
       '7.1'
 
   """
-  @spec to_char_list(float, list) :: char_list
-  def to_char_list(float, options) do
+  @spec to_charlist(float, list) :: charlist
+  def to_charlist(float, options) do
     :erlang.float_to_list(float, expand_compact(options))
   end
 

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -279,7 +279,20 @@ end
 defimpl Inspect, for: List do
   def inspect([], _opts), do: "[]"
 
-  def inspect(thing, %Inspect.Opts{charlists: lists} = opts) do
+  # TODO: Deprecate :char_lists and :as_char_lists keys in v1.5
+  def inspect(thing, %Inspect.Opts{charlists: lists, char_lists: lists_deprecated} = opts) do
+    lists =
+      if lists == :infer and lists_deprecated != :infer do
+        case lists_deprecated do
+          :as_char_lists ->
+            :as_charlists
+          _ ->
+            lists_deprecated
+        end
+      else
+        lists
+      end
+
     cond do
       lists == :as_charlists or (lists == :infer and printable?(thing)) ->
         <<?', Inspect.BitString.escape(IO.chardata_to_string(thing), ?')::binary, ?'>>

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -279,9 +279,9 @@ end
 defimpl Inspect, for: List do
   def inspect([], _opts), do: "[]"
 
-  def inspect(thing, %Inspect.Opts{char_lists: lists} = opts) do
+  def inspect(thing, %Inspect.Opts{charlists: lists} = opts) do
     cond do
-      lists == :as_char_lists or (lists == :infer and printable?(thing)) ->
+      lists == :as_charlists or (lists == :infer and printable?(thing)) ->
         <<?', Inspect.BitString.escape(IO.chardata_to_string(thing), ?')::binary, ?'>>
       keyword?(thing) ->
         surround_many("[", thing, "]", opts, &keyword/2)
@@ -300,7 +300,7 @@ defimpl Inspect, for: List do
 
   @doc false
   def keyword?([{key, _value} | rest]) when is_atom(key) do
-    case Atom.to_char_list(key) do
+    case Atom.to_charlist(key) do
       'Elixir.' ++ _ -> false
       _ -> keyword?(rest)
     end
@@ -459,7 +459,7 @@ defimpl Inspect, for: Function do
     if fun_info[:type] == :external and fun_info[:env] == [] do
       "&#{Inspect.Atom.inspect(mod)}.#{fun_info[:name]}/#{fun_info[:arity]}"
     else
-      case Atom.to_char_list(mod) do
+      case Atom.to_charlist(mod) do
         'elixir_compiler_' ++ _ ->
           if function_exported?(mod, :__RELATIVE__, 0) do
             "#Function<#{uniq(fun_info)} in file:#{mod.__RELATIVE__}>"

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -44,19 +44,23 @@ defmodule Inspect.Opts do
 
   """
 
+  # TODO: Deprecate char_lists key by v1.5
   defstruct structs: true,
             binaries: :infer,
             charlists: :infer,
+            char_lists: :infer,
             limit: 50,
             width: 80,
             base: :decimal,
             pretty: false,
             safe: true
 
+  # TODO: Deprecate char_lists key and :as_char_lists value by v1.5
   @type t :: %__MODULE__{
                structs: boolean,
                binaries: :infer | :as_binaries | :as_strings,
                charlists: :infer | :as_lists | :as_charlists,
+               char_lists: :infer | :as_lists | :as_char_lists,
                limit: pos_integer | :infinity,
                width: pos_integer | :infinity,
                base: :decimal | :binary | :hex | :octal,

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -15,16 +15,16 @@ defmodule Inspect.Opts do
       When the default `:infer`, the binary will be printed as a string if it
       is printable, otherwise in bit syntax.
 
-    * `:char_lists` - when `:as_char_lists` all lists will be printed as char
+    * `:charlists` - when `:as_charlists` all lists will be printed as char
       lists, non-printable elements will be escaped.
 
       When `:as_lists` all lists will be printed as lists.
 
-      When the default `:infer`, the list will be printed as a char list if it
+      When the default `:infer`, the list will be printed as a charlist if it
       is printable, otherwise as list.
 
     * `:limit` - limits the number of items that are printed for tuples,
-      bitstrings, and lists, does not apply to strings nor char lists, defaults
+      bitstrings, and lists, does not apply to strings nor charlists, defaults
       to 50.
 
     * `:pretty` - if set to `true` enables pretty printing, defaults to `false`.
@@ -46,7 +46,7 @@ defmodule Inspect.Opts do
 
   defstruct structs: true,
             binaries: :infer,
-            char_lists: :infer,
+            charlists: :infer,
             limit: 50,
             width: 80,
             base: :decimal,
@@ -56,7 +56,7 @@ defmodule Inspect.Opts do
   @type t :: %__MODULE__{
                structs: boolean,
                binaries: :infer | :as_binaries | :as_strings,
-               char_lists: :infer | :as_lists | :as_char_lists,
+               charlists: :infer | :as_lists | :as_charlists,
                limit: pos_integer | :infinity,
                width: pos_integer | :infinity,
                base: :decimal | :binary | :hex | :octal,

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -261,4 +261,9 @@ defmodule Integer do
   def to_charlist(number, base) do
     :erlang.integer_to_list(number, base)
   end
+
+  # TODO: Deprecate by v1.5
+  @doc false
+  @spec to_char_list(integer) :: charlist
+  def to_char_list(integer), do: Integer.to_charlist(integer)
 end

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -230,35 +230,35 @@ defmodule Integer do
   end
 
   @doc """
-  Returns a char list which corresponds to the text representation of the given integer.
+  Returns a charlist which corresponds to the text representation of the given integer.
 
   Inlined by the compiler.
 
   ## Examples
 
-      iex> Integer.to_char_list(7)
+      iex> Integer.to_charlist(7)
       '7'
 
   """
-  @spec to_char_list(integer) :: char_list
-  def to_char_list(number) do
+  @spec to_charlist(integer) :: charlist
+  def to_charlist(number) do
     :erlang.integer_to_list(number)
   end
 
   @doc """
-  Returns a char list which corresponds to the text representation of the
+  Returns a charlist which corresponds to the text representation of the
   given integer in the given base.
 
   Inlined by the compiler.
 
   ## Examples
 
-      iex> Integer.to_char_list(1023, 16)
+      iex> Integer.to_charlist(1023, 16)
       '3FF'
 
   """
-  @spec to_char_list(integer, 2..36) :: char_list
-  def to_char_list(number, base) do
+  @spec to_charlist(integer, 2..36) :: charlist
+  def to_charlist(number, base) do
     :erlang.integer_to_list(number, base)
   end
 end

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -381,7 +381,7 @@ defmodule IO do
 
   Notice that this function treats lists of integers as raw bytes
   and does not perform any kind of encoding conversion. If you want
-  to convert from a char list to a string (UTF-8 encoded), please
+  to convert from a charlist to a string (UTF-8 encoded), please
   use `chardata_to_string/1` instead.
 
   If this function receives a binary, the same binary is returned.

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4161,4 +4161,10 @@ defmodule Kernel do
       false -> []
     end
   end
+
+  # TODO: Deprecate by v1.5
+  # @doc false
+  defmacro to_char_list(arg) do
+    quote do: Kernel.to_charlist(unquote(arg))
+  end
 end

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2139,16 +2139,16 @@ defmodule Kernel do
   end
 
   @doc """
-  Converts the argument to a char list according to the `List.Chars` protocol.
+  Converts the argument to a charlist according to the `List.Chars` protocol.
 
   ## Examples
 
-      iex> to_char_list(:foo)
+      iex> to_charlist(:foo)
       'foo'
 
   """
-  defmacro to_char_list(arg) do
-    quote do: List.Chars.to_char_list(unquote(arg))
+  defmacro to_charlist(arg) do
+    quote do: List.Chars.to_charlist(unquote(arg))
   end
 
   @doc """
@@ -3941,7 +3941,7 @@ defmodule Kernel do
   @doc ~S"""
   Handles the sigil `~C`.
 
-  It simply returns a char list without escaping characters and without
+  It simply returns a charlist without escaping characters and without
   interpolations.
 
   ## Examples
@@ -3955,13 +3955,13 @@ defmodule Kernel do
   """
   defmacro sigil_C(term, modifiers)
   defmacro sigil_C({:<<>>, _line, [string]}, []) when is_binary(string) do
-    String.to_char_list(string)
+    String.to_charlist(string)
   end
 
   @doc ~S"""
   Handles the sigil `~c`.
 
-  It returns a char list as if it were a single quoted string, unescaping
+  It returns a charlist as if it were a single quoted string, unescaping
   characters and replacing interpolations.
 
   ## Examples
@@ -3981,12 +3981,12 @@ defmodule Kernel do
   # We can skip the runtime conversion if we are
   # creating a binary made solely of series of chars.
   defmacro sigil_c({:<<>>, _line, [string]}, []) when is_binary(string) do
-    String.to_char_list(Macro.unescape_string(string))
+    String.to_charlist(Macro.unescape_string(string))
   end
 
   defmacro sigil_c({:<<>>, line, pieces}, []) do
     binary = {:<<>>, line, Macro.unescape_tokens(pieces)}
-    quote do: String.to_char_list(unquote(binary))
+    quote do: String.to_charlist(unquote(binary))
   end
 
   @doc """
@@ -4048,7 +4048,7 @@ defmodule Kernel do
 
     * `s`: words in the list are strings (default)
     * `a`: words in the list are atoms
-    * `c`: words in the list are char lists
+    * `c`: words in the list are charlists
 
   ## Examples
 
@@ -4085,7 +4085,7 @@ defmodule Kernel do
 
     * `s`: words in the list are strings (default)
     * `a`: words in the list are atoms
-    * `c`: words in the list are char lists
+    * `c`: words in the list are charlists
 
   ## Examples
 
@@ -4110,14 +4110,14 @@ defmodule Kernel do
         case mod do
           ?s -> parts
           ?a -> :lists.map(&String.to_atom/1, parts)
-          ?c -> :lists.map(&String.to_char_list/1, parts)
+          ?c -> :lists.map(&String.to_charlist/1, parts)
         end
       false ->
         parts = quote(do: String.split(unquote(string)))
         case mod do
           ?s -> parts
           ?a -> quote(do: :lists.map(&String.to_atom/1, unquote(parts)))
-          ?c -> quote(do: :lists.map(&String.to_char_list/1, unquote(parts)))
+          ?c -> quote(do: :lists.map(&String.to_charlist/1, unquote(parts)))
         end
     end
   end

--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -203,8 +203,8 @@ defmodule Kernel.CLI do
   defp expand_code_path(path) do
     path = Path.expand(path)
     case Path.wildcard(path) do
-      []   -> [to_char_list(path)]
-      list -> Enum.map(list, &to_char_list/1)
+      []   -> [to_charlist(path)]
+      list -> Enum.map(list, &to_charlist/1)
     end
   end
 

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -204,7 +204,7 @@ defmodule Kernel.SpecialForms do
       <<1, 2, 3>>
 
   Elixir also accepts by default the segment to be a literal
-  string or a literal char list, which are by default expanded to integers:
+  string or a literal charlist, which are by default expanded to integers:
 
       iex> <<0, "foo">>
       <<0, 102, 111, 111>>
@@ -222,7 +222,7 @@ defmodule Kernel.SpecialForms do
       "foo"
 
   The utf8, utf16, and utf32 types are for Unicode codepoints. They
-  can also be applied to literal strings and char lists:
+  can also be applied to literal strings and charlists:
 
       iex> <<"foo"::utf16>>
       <<0, 102, 0, 111, 0, 111>>

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -407,7 +407,7 @@ defmodule Kernel.Typespec do
 
   defp elixir_builtin_type?(:as_boolean, 1), do: true
   defp elixir_builtin_type?(:struct, 0), do: true
-  defp elixir_builtin_type?(:char_list, 0), do: true
+  defp elixir_builtin_type?(:charlist, 0), do: true
   defp elixir_builtin_type?(:keyword, 0), do: true
   defp elixir_builtin_type?(:keyword, 1), do: true
   defp elixir_builtin_type?(_, _), do: false
@@ -634,8 +634,8 @@ defmodule Kernel.Typespec do
   end
 
   # Special shortcut(s)
-  defp typespec_to_ast({:remote_type, line, [{:atom, _, :elixir}, {:atom, _, :char_list}, []]}) do
-    typespec_to_ast({:type, line, :char_list, []})
+  defp typespec_to_ast({:remote_type, line, [{:atom, _, :elixir}, {:atom, _, :charlist}, []]}) do
+    typespec_to_ast({:type, line, :charlist, []})
   end
 
   defp typespec_to_ast({:remote_type, line, [{:atom, _, :elixir}, {:atom, _, :struct}, []]}) do
@@ -877,13 +877,13 @@ defmodule Kernel.Typespec do
   # Handle local calls
   defp typespec({type, meta, arguments}, vars, caller) when type in [:string, :nonempty_string] do
     :elixir_errors.warn caller.line, caller.file, "#{type}() type use is discouraged. For character lists, use " <>
-      "char_list() type, for strings, String.t()\n#{Exception.format_stacktrace(Macro.Env.stacktrace(caller))}"
+      "charlist() type, for strings, String.t()\n#{Exception.format_stacktrace(Macro.Env.stacktrace(caller))}"
     arguments = for arg <- arguments, do: typespec(arg, vars, caller)
     {:type, line(meta), type, arguments}
   end
 
-  defp typespec({:char_list, _meta, []}, vars, caller) do
-    typespec((quote do: :elixir.char_list()), vars, caller)
+  defp typespec({:charlist, _meta, []}, vars, caller) do
+    typespec((quote do: :elixir.charlist()), vars, caller)
   end
 
   defp typespec({:struct, _meta, []}, vars, caller) do

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -408,6 +408,8 @@ defmodule Kernel.Typespec do
   defp elixir_builtin_type?(:as_boolean, 1), do: true
   defp elixir_builtin_type?(:struct, 0), do: true
   defp elixir_builtin_type?(:charlist, 0), do: true
+  # TODO: Deprecate char_list type by v1.5
+  defp elixir_builtin_type?(:char_list, 0), do: true
   defp elixir_builtin_type?(:keyword, 0), do: true
   defp elixir_builtin_type?(:keyword, 1), do: true
   defp elixir_builtin_type?(_, _), do: false
@@ -634,7 +636,9 @@ defmodule Kernel.Typespec do
   end
 
   # Special shortcut(s)
-  defp typespec_to_ast({:remote_type, line, [{:atom, _, :elixir}, {:atom, _, :charlist}, []]}) do
+  # TODO: Deprecate char_list type by v1.5
+  defp typespec_to_ast({:remote_type, line, [{:atom, _, :elixir}, {:atom, _, type}, []]})
+      when type in [:charlist, :char_list] do
     typespec_to_ast({:type, line, :charlist, []})
   end
 
@@ -882,7 +886,8 @@ defmodule Kernel.Typespec do
     {:type, line(meta), type, arguments}
   end
 
-  defp typespec({:charlist, _meta, []}, vars, caller) do
+  # TODO: Deprecate char_list type by v1.5
+  defp typespec({type, _meta, []}, vars, caller) when type in [:charlist, :char_list] do
     typespec((quote do: :elixir.charlist()), vars, caller)
   end
 

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -14,23 +14,23 @@ defmodule List do
   of receiving the subject (in this case, a list) as the
   first argument.
 
-  ## Char lists
+  ## Charlists
 
   If a list is made of non-negative integers, it can also
-  be called as a char list. Elixir uses single quotes to
-  define char lists:
+  be called as a charlist. Elixir uses single quotes to
+  define charlists:
 
       iex> 'héllo'
       [104, 233, 108, 108, 111]
 
-  In particular, char lists may be printed back in single
+  In particular, charlists may be printed back in single
   quotes if they contain only ASCII-printable codepoints:
 
       iex> 'abc'
       'abc'
 
   The rationale behind this behaviour is to better support
-  Erlang libraries which may return text as char lists
+  Erlang libraries which may return text as charlists
   instead of Elixir strings. One example of such functions
   is `Application.loaded_applications`:
 
@@ -492,9 +492,9 @@ defmodule List do
   end
 
   @doc """
-  Converts a char list to an atom.
+  Converts a charlist to an atom.
 
-  Currently Elixir does not support conversions from char lists
+  Currently Elixir does not support conversions from charlists
   which contains Unicode codepoints greater than 0xFF.
 
   Inlined by the compiler.
@@ -505,16 +505,16 @@ defmodule List do
       :elixir
 
   """
-  @spec to_atom(char_list) :: atom
-  def to_atom(char_list) do
-    :erlang.list_to_atom(char_list)
+  @spec to_atom(charlist) :: atom
+  def to_atom(charlist) do
+    :erlang.list_to_atom(charlist)
   end
 
   @doc """
-  Converts a char list to an existing atom. Raises an `ArgumentError`
+  Converts a charlist to an existing atom. Raises an `ArgumentError`
   if the atom does not exist.
 
-  Currently Elixir does not support conversions from char lists
+  Currently Elixir does not support conversions from charlists
   which contains Unicode codepoints greater than 0xFF.
 
   Inlined by the compiler.
@@ -529,13 +529,13 @@ defmodule List do
       ** (ArgumentError) argument error
 
   """
-  @spec to_existing_atom(char_list) :: atom
-  def to_existing_atom(char_list) do
-    :erlang.list_to_existing_atom(char_list)
+  @spec to_existing_atom(charlist) :: atom
+  def to_existing_atom(charlist) do
+    :erlang.list_to_existing_atom(charlist)
   end
 
   @doc """
-  Returns the float whose text representation is `char_list`.
+  Returns the float whose text representation is `charlist`.
 
   Inlined by the compiler.
 
@@ -545,13 +545,13 @@ defmodule List do
       2.2017764
 
   """
-  @spec to_float(char_list) :: float
-  def to_float(char_list) do
-    :erlang.list_to_float(char_list)
+  @spec to_float(charlist) :: float
+  def to_float(charlist) do
+    :erlang.list_to_float(charlist)
   end
 
   @doc """
-  Returns an integer whose text representation is `char_list`.
+  Returns an integer whose text representation is `charlist`.
 
   Inlined by the compiler.
 
@@ -561,13 +561,13 @@ defmodule List do
       123
 
   """
-  @spec to_integer(char_list) :: integer
-  def to_integer(char_list) do
-    :erlang.list_to_integer(char_list)
+  @spec to_integer(charlist) :: integer
+  def to_integer(charlist) do
+    :erlang.list_to_integer(charlist)
   end
 
   @doc """
-  Returns an integer whose text representation is `char_list` in base `base`.
+  Returns an integer whose text representation is `charlist` in base `base`.
 
   Inlined by the compiler.
 
@@ -577,9 +577,9 @@ defmodule List do
       1023
 
   """
-  @spec to_integer(char_list, 2..36) :: integer
-  def to_integer(char_list, base) do
-    :erlang.list_to_integer(char_list, base)
+  @spec to_integer(charlist, 2..36) :: integer
+  def to_integer(charlist, base) do
+    :erlang.list_to_integer(charlist, base)
   end
 
   @doc """

--- a/lib/elixir/lib/list/chars.ex
+++ b/lib/elixir/lib/list/chars.ex
@@ -3,43 +3,43 @@ defprotocol List.Chars do
   The List.Chars protocol is responsible for
   converting a structure to a list (only if applicable).
   The only function required to be implemented is
-  `to_char_list` which does the conversion.
+  `to_charlist` which does the conversion.
 
-  The `to_char_list` function automatically imported
+  The `to_charlist` function automatically imported
   by Kernel invokes this protocol.
   """
 
-  def to_char_list(thing)
+  def to_charlist(thing)
 end
 
 defimpl List.Chars, for: Atom do
-  def to_char_list(atom), do: Atom.to_char_list(atom)
+  def to_charlist(atom), do: Atom.to_charlist(atom)
 end
 
 defimpl List.Chars, for: BitString do
   @doc """
-  Returns the given binary converted to a char list.
+  Returns the given binary converted to a charlist.
   """
-  def to_char_list(thing) when is_binary(thing) do
-    String.to_char_list(thing)
+  def to_charlist(thing) when is_binary(thing) do
+    String.to_charlist(thing)
   end
 
-  def to_char_list(thing) do
+  def to_charlist(thing) do
     raise Protocol.UndefinedError,
              protocol: @protocol,
                 value: thing,
-          description: "cannot convert a bitstring to a char list"
+          description: "cannot convert a bitstring to a charlist"
   end
 end
 
 defimpl List.Chars, for: List do
   # Note that same inlining is used for the rewrite rule.
-  def to_char_list(list), do: list
+  def to_charlist(list), do: list
 end
 
 defimpl List.Chars, for: Integer do
-  def to_char_list(thing) do
-    Integer.to_char_list(thing)
+  def to_charlist(thing) do
+    Integer.to_charlist(thing)
   end
 end
 
@@ -47,11 +47,11 @@ defimpl List.Chars, for: Float do
   @digits 20
   @limit  :math.pow(10, @digits)
 
-  def to_char_list(thing) when thing > @limit do
-    Float.to_char_list(thing, scientific: @digits)
+  def to_charlist(thing) when thing > @limit do
+    Float.to_charlist(thing, scientific: @digits)
   end
 
-  def to_char_list(thing) do
-    Float.to_char_list(thing, compact: true, decimals: @digits)
+  def to_charlist(thing) do
+    Float.to_charlist(thing, compact: true, decimals: @digits)
   end
 end

--- a/lib/elixir/lib/list/chars.ex
+++ b/lib/elixir/lib/list/chars.ex
@@ -10,6 +10,12 @@ defprotocol List.Chars do
   """
 
   def to_charlist(thing)
+
+  # TODO: Deprecate by v1.5
+  @doc false
+  Kernel.def to_char_list(thing) do
+    __MODULE__.to_charlist(thing)
+  end
 end
 
 defimpl List.Chars, for: Atom do

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -8,7 +8,7 @@ defmodule Macro do
 
   To create a custom sigil, define a function with the name
   `sigil_{identifier}` that takes two arguments. The first argument will be
-  the string, the second will be a char list containing any modifiers. If the
+  the string, the second will be a charlist containing any modifiers. If the
   sigil is lower case (such as `sigil_x`) then the string argument will allow
   interpolation. If the sigil is upper case (such as `sigil_X`) then the string
   will not be interpolated.
@@ -504,7 +504,7 @@ defmodule Macro do
       def unescape_map(e),  do: e
 
   If the `unescape_map` function returns `false`. The char is
-  not escaped and `\` is kept in the char list.
+  not escaped and `\` is kept in the charlist.
 
   Hexadecimals and Unicode codepoints will be escaped if the map
   function returns `true` for `?x`. Unicode codepoints if the map
@@ -976,7 +976,7 @@ defmodule Macro do
   Consider the implementation below:
 
       defmacro defmodule_with_length(name, do: block) do
-        length = length(Atom.to_char_list(name))
+        length = length(Atom.to_charlist(name))
 
         quote do
           defmodule unquote(name) do
@@ -1016,7 +1016,7 @@ defmodule Macro do
 
       defmacro defmodule_with_length(name, do: block) do
         expanded = Macro.expand(name, __CALLER__)
-        length   = length(Atom.to_char_list(expanded))
+        length   = length(Atom.to_charlist(expanded))
 
         quote do
           defmodule unquote(name) do

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -534,7 +534,7 @@ defmodule Module do
   was already referenced.
 
   If the alias was not referenced yet, fails with `ArgumentError`.
-  It handles char lists, binaries and atoms.
+  It handles charlists, binaries and atoms.
 
   ## Examples
 
@@ -555,7 +555,7 @@ defmodule Module do
   already referenced.
 
   If the alias was not referenced yet, fails with `ArgumentError`.
-  It handles char lists, binaries and atoms.
+  It handles charlists, binaries and atoms.
 
   ## Examples
 

--- a/lib/elixir/lib/port.ex
+++ b/lib/elixir/lib/port.ex
@@ -3,9 +3,9 @@ defmodule Port do
   Functions related to Erlang ports.
   """
 
-  @type name :: {:spawn, char_list | binary} |
-                {:spawn_driver, char_list | binary} |
-                {:spawn_executable, char_list | atom} |
+  @type name :: {:spawn, charlist | binary} |
+                {:spawn_driver, charlist | binary} |
+                {:spawn_executable, charlist | atom} |
                 {:fd, non_neg_integer, non_neg_integer}
 
   @doc """

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -129,8 +129,8 @@ defmodule Protocol do
   @doc """
   Extracts all protocols from the given paths.
 
-  The paths can be either a char list or a string. Internally
-  they are worked on as char lists, so passing them as lists
+  The paths can be either a charlist or a string. Internally
+  they are worked on as charlists, so passing them as lists
   avoid extra conversion.
 
   Does not load any of the protocols.
@@ -144,7 +144,7 @@ defmodule Protocol do
       true
 
   """
-  @spec extract_protocols([char_list | String.t]) :: [atom]
+  @spec extract_protocols([charlist | String.t]) :: [atom]
   def extract_protocols(paths) do
     extract_matching_by_attribute paths, 'Elixir.',
       fn module, attributes ->
@@ -159,8 +159,8 @@ defmodule Protocol do
   Extracts all types implemented for the given protocol from
   the given paths.
 
-  The paths can be either a char list or a string. Internally
-  they are worked on as char lists, so passing them as lists
+  The paths can be either a charlist or a string. Internally
+  they are worked on as charlists, so passing them as lists
   avoid extra conversion.
 
   Does not load any of the implementations.
@@ -174,9 +174,9 @@ defmodule Protocol do
       true
 
   """
-  @spec extract_impls(module, [char_list | String.t]) :: [atom]
+  @spec extract_impls(module, [charlist | String.t]) :: [atom]
   def extract_impls(protocol, paths) when is_atom(protocol) do
-    prefix = Atom.to_char_list(protocol) ++ '.'
+    prefix = Atom.to_charlist(protocol) ++ '.'
     extract_matching_by_attribute paths, prefix, fn
       _mod, attributes ->
         case attributes[:impl] do
@@ -200,7 +200,7 @@ defmodule Protocol do
     end
   end
 
-  defp list_dir(path), do: list_dir(to_char_list(path))
+  defp list_dir(path), do: list_dir(to_charlist(path))
 
   defp extract_from_file(path, file, prefix, callback) do
     if :lists.prefix(prefix, file) and :filename.extension(file) == '.beam' do

--- a/lib/elixir/lib/record/extractor.ex
+++ b/lib/elixir/lib/record/extractor.ex
@@ -27,7 +27,7 @@ defmodule Record.Extractor do
 
   # Find file using the same lookup as the *include* attribute from Erlang modules.
   defp from_file(file) do
-    file = String.to_char_list(file)
+    file = String.to_charlist(file)
     case :code.where_is_file(file) do
       :non_existing -> file
       realfile -> realfile
@@ -36,7 +36,7 @@ defmodule Record.Extractor do
 
   # Find file using the same lookup as the *include_lib* attribute from Erlang modules.
   defp from_lib_file(file) do
-    [app | path] = :filename.split(String.to_char_list(file))
+    [app | path] = :filename.split(String.to_charlist(file))
     case :code.lib_dir(List.to_atom(app)) do
       {:error, _} ->
         raise ArgumentError, "lib file #{file} could not be found"

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1701,7 +1701,7 @@ defmodule String do
   end
 
   @doc """
-  Converts a string into a char list.
+  Converts a string into a charlist.
 
   Specifically, this functions takes a UTF-8 encoded binary and returns a list of its integer
   codepoints. It is similar to `codepoints/1` except that the latter returns a list of codepoints as
@@ -1712,11 +1712,11 @@ defmodule String do
 
   ## Examples
 
-      iex> String.to_char_list("æß")
+      iex> String.to_charlist("æß")
       'æß'
   """
-  @spec to_char_list(t) :: char_list
-  def to_char_list(string) when is_binary(string) do
+  @spec to_charlist(t) :: charlist
+  def to_charlist(string) when is_binary(string) do
     case :unicode.characters_to_list(string) do
       result when is_list(result) ->
         result

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2020,4 +2020,9 @@ defmodule String do
   defp follow_snake(path) do
     {:cont, path}
   end
+
+  # TODO: Deprecate by v1.5
+  @doc false
+  @spec to_char_list(t) :: charlist
+  def to_char_list(string), do: String.to_charlist(string)
 end

--- a/lib/elixir/lib/string/chars.ex
+++ b/lib/elixir/lib/string/chars.ex
@@ -41,7 +41,7 @@ defimpl String.Chars, for: BitString do
 end
 
 defimpl String.Chars, for: List do
-  def to_string(char_list), do: List.to_string(char_list)
+  def to_string(charlist), do: List.to_string(charlist)
 end
 
 defimpl String.Chars, for: Integer do

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -328,7 +328,7 @@ defmodule System do
   """
   @spec find_executable(binary) :: binary | nil
   def find_executable(program) when is_binary(program) do
-    case :os.find_executable(String.to_char_list(program)) do
+    case :os.find_executable(String.to_charlist(program)) do
       false -> nil
       other -> List.to_string(other)
     end
@@ -358,7 +358,7 @@ defmodule System do
   """
   @spec get_env(binary) :: binary | nil
   def get_env(varname) when is_binary(varname) do
-    case :os.getenv(String.to_char_list(varname)) do
+    case :os.getenv(String.to_charlist(varname)) do
       false -> nil
       other -> List.to_string(other)
     end
@@ -382,7 +382,7 @@ defmodule System do
   """
   @spec put_env(binary, binary) :: :ok
   def put_env(varname, value) when is_binary(varname) and is_binary(value) do
-   :os.putenv String.to_char_list(varname), String.to_char_list(value)
+   :os.putenv String.to_charlist(varname), String.to_charlist(value)
    :ok
   end
 
@@ -404,7 +404,7 @@ defmodule System do
   """
   @spec delete_env(String.t) :: :ok
   def delete_env(varname) do
-    :os.unsetenv(String.to_char_list(varname))
+    :os.unsetenv(String.to_charlist(varname))
     :ok
   end
 
@@ -457,7 +457,7 @@ defmodule System do
   end
 
   def halt(status) when is_binary(status) do
-    :erlang.halt(String.to_char_list(status))
+    :erlang.halt(String.to_charlist(status))
   end
 
   @doc ~S"""
@@ -537,7 +537,7 @@ defmodule System do
   @spec cmd(binary, [binary], Keyword.t) ::
         {Collectable.t, exit_status :: non_neg_integer}
   def cmd(command, args, opts \\ []) when is_binary(command) and is_list(args) do
-    cmd = String.to_char_list(command)
+    cmd = String.to_charlist(command)
 
     cmd =
       if Path.type(cmd) == :absolute do
@@ -599,9 +599,9 @@ defmodule System do
   defp validate_env(enum) do
     Enum.map enum, fn
       {k, nil} ->
-        {String.to_char_list(k), false}
+        {String.to_charlist(k), false}
       {k, v} ->
-        {String.to_char_list(k), String.to_char_list(v)}
+        {String.to_charlist(k), String.to_charlist(v)}
       other ->
         raise ArgumentError, "invalid environment key-value #{inspect other}"
     end

--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -83,7 +83,7 @@ Built-in type           | Defined as
 `byte()`                | `0..255`
 `char()`                | `0..0x10ffff`
 `number()`              | `integer()` \| `float()`
-`charlist()`           | `[char()]`
+`charlist()`            | `[char()]`
 `list()`                | `[any()]`
 `maybe_improper_list()` | `maybe_improper_list(any(), any())`
 `nonempty_list()`       | `nonempty_list(any())`

--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -83,7 +83,7 @@ Built-in type           | Defined as
 `byte()`                | `0..255`
 `char()`                | `0..0x10ffff`
 `number()`              | `integer()` \| `float()`
-`char_list()`           | `[char()]`
+`charlist()`           | `[char()]`
 `list()`                | `[any()]`
 `maybe_improper_list()` | `maybe_improper_list(any(), any())`
 `nonempty_list()`       | `nonempty_list(any())`
@@ -148,7 +148,7 @@ Specifications can be overloaded just like ordinary functions.
 
 ## Notes
 
-Elixir discourages the use of type `string` as it might be confused with binaries which are referred to as "strings" in Elixir (as opposed to character lists). In order to use the type that is called `string` in Erlang, one has to use the `char_list` type which is a synonym for `string`. If you use `string`, you'll get a warning from the compiler.
+Elixir discourages the use of type `string` as it might be confused with binaries which are referred to as "strings" in Elixir (as opposed to character lists). In order to use the type that is called `string` in Erlang, one has to use the `charlist` type which is a synonym for `string`. If you use `string`, you'll get a warning from the compiler.
 
 If you want to refer to the "string" type (the one operated on by functions in the `String` module), use `String.t` type instead.
 

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -10,8 +10,8 @@
 -define(system, 'Elixir.System').
 
 %% Top level types
--export_type([char_list/0, struct/0, as_boolean/1, keyword/0, keyword/1]).
--type char_list() :: string().
+-export_type([charlist/0, struct/0, as_boolean/1, keyword/0, keyword/1]).
+-type charlist() :: string().
 -type struct() :: #{'__struct__' => atom()}.
 -type as_boolean(T) :: T.
 -type keyword() :: [{atom(), any()}].
@@ -248,7 +248,7 @@ quoted_to_erl(Quoted, Env, Scope) ->
   {Erl, NewScope}    = elixir_translator:translate(Expanded, Scope),
   {Erl, NewEnv, NewScope}.
 
-%% Converts a given string (char list) into quote expression
+%% Converts a given string (charlist) into quote expression
 
 string_to_quoted(String, StartLine, File, Opts) when is_integer(StartLine), is_binary(File) ->
   case elixir_tokenizer:tokenize(String, StartLine, [{file, File} | Opts]) of

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -10,8 +10,10 @@
 -define(system, 'Elixir.System').
 
 %% Top level types
--export_type([charlist/0, struct/0, as_boolean/1, keyword/0, keyword/1]).
+%% TODO: Deprecate char_list type by v1.5
+-export_type([charlist/0, char_list/0, struct/0, as_boolean/1, keyword/0, keyword/1]).
 -type charlist() :: string().
+-type char_list() :: string().
 -type struct() :: #{'__struct__' => atom()}.
 -type as_boolean(T) :: T.
 -type keyword() :: [{atom(), any()}].

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -723,7 +723,7 @@ build_list_string({list_string, _Location, [H]}) when is_binary(H) ->
   elixir_utils:characters_to_list(H);
 build_list_string({list_string, Location, Args}) ->
   Meta = meta_from_location(Location),
-  {{'.', Meta, ['Elixir.String', to_char_list]}, Meta, [{'<<>>', Meta, string_parts(Args)}]}.
+  {{'.', Meta, ['Elixir.String', to_charlist]}, Meta, [{'<<>>', Meta, string_parts(Args)}]}.
 
 build_quoted_atom({_, _Location, [H]}, Safe) when is_binary(H) ->
   Op = binary_to_atom_op(Safe), erlang:Op(H, utf8);

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -30,14 +30,21 @@
 %% number and order of arguments and show up on captures.
 
 inline(?atom, to_charlist, 1) -> {erlang, atom_to_list};
+%% TODO: Deprecate to_char_list function by v1.5
+inline(?atom, to_char_list, 1) -> {erlang, atom_to_list};
 inline(?io, iodata_length, 1) -> {erlang, iolist_size};
 inline(?io, iodata_to_binary, 1) -> {erlang, iolist_to_binary};
 inline(?integer, to_string, 1) -> {erlang, integer_to_binary};
 inline(?integer, to_string, 2) -> {erlang, integer_to_binary};
 inline(?integer, to_charlist, 1) -> {erlang, integer_to_list};
 inline(?integer, to_charlist, 2) -> {erlang, integer_to_list};
+%% TODO: Deprecate to_char_list function by v1.5
+inline(?integer, to_char_list, 1) -> {erlang, integer_to_list};
+inline(?integer, to_char_list, 2) -> {erlang, integer_to_list};
 inline(?float, to_string, 1) -> {erlang, float_to_binary};
 inline(?float, to_charlist, 1) -> {erlang, float_to_list};
+%% TODO: Deprecate to_char_list function by v1.5
+inline(?float, to_char_list, 1) -> {erlang, float_to_list};
 inline(?list, to_atom, 1) -> {erlang, list_to_atom};
 inline(?list, to_existing_atom, 1) -> {erlang, list_to_existing_atom};
 inline(?list, to_float, 1) -> {erlang, list_to_float};
@@ -183,6 +190,9 @@ rewrite(?access, _DotMeta, 'get', Meta, [Arg, _], Env)
     "the Access syntax and calls to Access.get/2 are not available for the value: ~ts",
     ['Elixir.Macro':to_string(Arg)]);
 rewrite(?list_chars, _DotMeta, 'to_charlist', _Meta, [List], _Env) when is_list(List) ->
+  List;
+%% TODO: Deprecate to_char_list function by v1.5
+rewrite(?list_chars, _DotMeta, 'to_char_list', _Meta, [List], _Env) when is_list(List) ->
   List;
 rewrite(?string_chars, _DotMeta, 'to_string', _Meta, [String], _Env) when is_binary(String) ->
   String;

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -29,15 +29,15 @@
 %% Inline rules are straight-forward, they keep the same
 %% number and order of arguments and show up on captures.
 
-inline(?atom, to_char_list, 1) -> {erlang, atom_to_list};
+inline(?atom, to_charlist, 1) -> {erlang, atom_to_list};
 inline(?io, iodata_length, 1) -> {erlang, iolist_size};
 inline(?io, iodata_to_binary, 1) -> {erlang, iolist_to_binary};
 inline(?integer, to_string, 1) -> {erlang, integer_to_binary};
 inline(?integer, to_string, 2) -> {erlang, integer_to_binary};
-inline(?integer, to_char_list, 1) -> {erlang, integer_to_list};
-inline(?integer, to_char_list, 2) -> {erlang, integer_to_list};
+inline(?integer, to_charlist, 1) -> {erlang, integer_to_list};
+inline(?integer, to_charlist, 2) -> {erlang, integer_to_list};
 inline(?float, to_string, 1) -> {erlang, float_to_binary};
-inline(?float, to_char_list, 1) -> {erlang, float_to_list};
+inline(?float, to_charlist, 1) -> {erlang, float_to_list};
 inline(?list, to_atom, 1) -> {erlang, list_to_atom};
 inline(?list, to_existing_atom, 1) -> {erlang, list_to_existing_atom};
 inline(?list, to_float, 1) -> {erlang, list_to_float};
@@ -182,7 +182,7 @@ rewrite(?access, _DotMeta, 'get', Meta, [Arg, _], Env)
   elixir_errors:compile_error(Meta, ?m(Env, file),
     "the Access syntax and calls to Access.get/2 are not available for the value: ~ts",
     ['Elixir.Macro':to_string(Arg)]);
-rewrite(?list_chars, _DotMeta, 'to_char_list', _Meta, [List], _Env) when is_list(List) ->
+rewrite(?list_chars, _DotMeta, 'to_charlist', _Meta, [List], _Env) when is_list(List) ->
   List;
 rewrite(?string_chars, _DotMeta, 'to_string', _Meta, [String], _Env) when is_binary(String) ->
   String;

--- a/lib/elixir/src/elixir_utils.erl
+++ b/lib/elixir/src/elixir_utils.erl
@@ -75,7 +75,7 @@ characters_to_list(Data) when is_list(Data) ->
 characters_to_list(Data) ->
   case elixir_compiler:get_opt(internal) of
     true  -> unicode:characters_to_list(Data);
-    false -> 'Elixir.String':to_char_list(Data)
+    false -> 'Elixir.String':to_charlist(Data)
   end.
 
 characters_to_binary(Data) when is_binary(Data) ->

--- a/lib/elixir/test/elixir/atom_test.exs
+++ b/lib/elixir/test/elixir/atom_test.exs
@@ -9,7 +9,7 @@ defmodule AtomTest do
     assert Atom.to_string(:"héllo") == "héllo"
   end
 
-  test "to_char_list/1" do
-    assert Atom.to_char_list(:"héllo") == 'héllo'
+  test "to_charlist/1" do
+    assert Atom.to_charlist(:"héllo") == 'héllo'
   end
 end

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -123,7 +123,7 @@ defmodule CodeTest do
   end
 
   test "compile source" do
-    assert __MODULE__.__info__(:compile)[:source] == String.to_char_list(__ENV__.file)
+    assert __MODULE__.__info__(:compile)[:source] == String.to_charlist(__ENV__.file)
   end
 
   test "compile info returned with source accessible through keyword module" do
@@ -169,9 +169,9 @@ defmodule Code.SyncTest do
   test "path manipulation" do
     path = Path.join(__DIR__, "fixtures")
     Code.prepend_path path
-    assert to_char_list(path) in :code.get_path
+    assert to_charlist(path) in :code.get_path
 
     Code.delete_path path
-    refute to_char_list(path) in :code.get_path
+    refute to_charlist(path) in :code.get_path
   end
 end

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -13,7 +13,7 @@ defmodule ExceptionTest do
         [top | _] = System.stacktrace
         top
       end
-    file = __ENV__.file |> Path.relative_to_cwd |> String.to_char_list
+    file = __ENV__.file |> Path.relative_to_cwd |> String.to_charlist
     assert {__MODULE__, :"test raise preserves the stacktrace", _,
            [file: ^file, line: 11]} = stacktrace
   end

--- a/lib/elixir/test/elixir/file_test.exs
+++ b/lib/elixir/test/elixir/file_test.exs
@@ -577,8 +577,8 @@ defmodule FileTest do
     end
 
     test "cp_r with src dir and dest dir using lists" do
-      src  = fixture_path("cp_r") |> to_char_list
-      dest = tmp_path("tmp") |> to_char_list
+      src  = fixture_path("cp_r") |> to_charlist
+      dest = tmp_path("tmp") |> to_charlist
 
       File.mkdir(dest)
 
@@ -691,7 +691,7 @@ defmodule FileTest do
 
     test "regular" do
       assert File.regular?(__ENV__.file)
-      assert File.regular?(String.to_char_list(__ENV__.file))
+      assert File.regular?(String.to_charlist(__ENV__.file))
       refute File.regular?("#{__ENV__.file}.unknown")
     end
 
@@ -789,8 +789,8 @@ defmodule FileTest do
       assert File.close(file) == :ok
     end
 
-    test "open file with char list" do
-      {:ok, file} = File.open(fixture_path("file.txt"), [:char_list])
+    test "open file with charlist" do
+      {:ok, file} = File.open(fixture_path("file.txt"), [:charlist])
       assert IO.gets(file, "") == 'FOO\n'
       assert File.close(file) == :ok
     end
@@ -832,7 +832,7 @@ defmodule FileTest do
     end
 
     test "open utf8 and charlist" do
-      {:ok, file} = File.open(fixture_path("utf8.txt"), [:char_list, :utf8])
+      {:ok, file} = File.open(fixture_path("utf8.txt"), [:charlist, :utf8])
       assert IO.gets(file, "") == [1056, 1091, 1089, 1089, 1082, 1080, 1081, 10]
       assert File.close(file) == :ok
     end
@@ -880,7 +880,7 @@ defmodule FileTest do
     end
 
     test "mkdir with list" do
-      fixture = tmp_path("tmp_test") |> to_char_list
+      fixture = tmp_path("tmp_test") |> to_charlist
       try do
         refute File.exists?(fixture)
         assert File.mkdir(fixture) == :ok
@@ -944,7 +944,7 @@ defmodule FileTest do
     end
 
     test "mkdir_p with nested directory and list" do
-      base    = tmp_path("tmp_test") |> to_char_list
+      base    = tmp_path("tmp_test") |> to_charlist
       fixture = Path.join(base, "test")
       refute File.exists?(base)
 
@@ -1115,8 +1115,8 @@ defmodule FileTest do
       File.rm(tmp_path("tmp/from"))
     end
 
-    test "rm_rf with char list" do
-      fixture = tmp_path("tmp") |> to_char_list
+    test "rm_rf with charlist" do
+      fixture = tmp_path("tmp") |> to_charlist
       File.mkdir(fixture)
       File.cp_r!(fixture_path("cp_r"), fixture)
 

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -200,21 +200,21 @@ defmodule Inspect.ListTest do
   end
 
   test "opt infer" do
-    assert inspect('john' ++ [0] ++ 'doe', char_lists: :infer) == "[106, 111, 104, 110, 0, 100, 111, 101]"
-    assert inspect('john', char_lists: :infer) == "'john'"
-    assert inspect([0], char_lists: :infer) == "[0]"
+    assert inspect('john' ++ [0] ++ 'doe', charlists: :infer) == "[106, 111, 104, 110, 0, 100, 111, 101]"
+    assert inspect('john', charlists: :infer) == "'john'"
+    assert inspect([0], charlists: :infer) == "[0]"
   end
 
   test "opt as strings" do
-    assert inspect('john' ++ [0] ++ 'doe', char_lists: :as_char_lists) == "'john\\0doe'"
-    assert inspect('john', char_lists: :as_char_lists) == "'john'"
-    assert inspect([0], char_lists: :as_char_lists) == "'\\0'"
+    assert inspect('john' ++ [0] ++ 'doe', charlists: :as_charlists) == "'john\\0doe'"
+    assert inspect('john', charlists: :as_charlists) == "'john'"
+    assert inspect([0], charlists: :as_charlists) == "'\\0'"
   end
 
   test "opt as lists" do
-    assert inspect('john' ++ [0] ++ 'doe', char_lists: :as_lists) == "[106, 111, 104, 110, 0, 100, 111, 101]"
-    assert inspect('john', char_lists: :as_lists) == "[106, 111, 104, 110]"
-    assert inspect([0], char_lists: :as_lists) == "[0]"
+    assert inspect('john' ++ [0] ++ 'doe', charlists: :as_lists) == "[106, 111, 104, 110, 0, 100, 111, 101]"
+    assert inspect('john', charlists: :as_lists) == "[106, 111, 104, 110]"
+    assert inspect([0], charlists: :as_lists) == "[0]"
   end
 
   test "non printable" do

--- a/lib/elixir/test/elixir/io/ansi_test.exs
+++ b/lib/elixir/test/elixir/io/ansi_test.exs
@@ -40,7 +40,7 @@ defmodule IO.ANSITest do
            "Hello, world!"
   end
 
-  test "format char list" do
+  test "format charlist" do
     assert IO.chardata_to_string(IO.ANSI.format('Hello, world!', true)) ==
            "Hello, world!"
     assert IO.chardata_to_string(IO.ANSI.format('Hello, world!', false)) ==

--- a/lib/elixir/test/elixir/io_test.exs
+++ b/lib/elixir/test/elixir/io_test.exs
@@ -8,7 +8,7 @@ defmodule IOTest do
   import ExUnit.CaptureIO
 
   test "read with count" do
-    {:ok, file} = File.open(Path.expand('fixtures/file.txt', __DIR__), [:char_list])
+    {:ok, file} = File.open(Path.expand('fixtures/file.txt', __DIR__), [:charlist])
     assert 'FOO' == IO.read(file, 3)
     assert File.close(file) == :ok
   end
@@ -42,7 +42,7 @@ defmodule IOTest do
   end
 
   test "getn with count" do
-    {:ok, file} = File.open(Path.expand('fixtures/file.txt', __DIR__), [:char_list])
+    {:ok, file} = File.open(Path.expand('fixtures/file.txt', __DIR__), [:charlist])
     assert 'F' == IO.getn(file, "λ")
     assert 'OO' == IO.getn(file, "", 2)
     assert '\n' == IO.getn(file, "λ", 99)
@@ -56,7 +56,7 @@ defmodule IOTest do
   end
 
   test "gets" do
-    {:ok, file} = File.open(Path.expand('fixtures/file.txt', __DIR__), [:char_list])
+    {:ok, file} = File.open(Path.expand('fixtures/file.txt', __DIR__), [:charlist])
     assert 'FOO\n' == IO.gets(file, "")
     assert :eof == IO.gets(file, "")
     assert File.close(file) == :ok

--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -40,17 +40,17 @@ defmodule Kernel.CLI.OptionParsingTest do
   use ExUnit.Case, async: true
 
   test "properly parses paths" do
-    root = fixture_path("../../..") |> to_char_list
+    root = fixture_path("../../..") |> to_charlist
     list = elixir('-pa "#{root}/*" -pz "#{root}/lib/*" -e "IO.inspect(:code.get_path, limit: :infinity)"')
     {path, _} = Code.eval_string list, []
 
     # pa
-    assert to_char_list(Path.expand('ebin', root)) in path
-    assert to_char_list(Path.expand('lib', root)) in path
-    assert to_char_list(Path.expand('src', root)) in path
+    assert to_charlist(Path.expand('ebin', root)) in path
+    assert to_charlist(Path.expand('lib', root)) in path
+    assert to_charlist(Path.expand('src', root)) in path
 
     # pz
-    assert to_char_list(Path.expand('lib/list', root)) in path
+    assert to_charlist(Path.expand('lib/list', root)) in path
   end
 end
 
@@ -58,7 +58,7 @@ defmodule Kernel.CLI.AtExitTest do
   use ExUnit.Case, async: true
 
   test "invokes at_exit callbacks" do
-    assert elixir(fixture_path("at_exit.exs") |> to_char_list) ==
+    assert elixir(fixture_path("at_exit.exs") |> to_charlist) ==
            'goodbye cruel world with status 1\n'
   end
 end
@@ -123,7 +123,7 @@ defmodule Kernel.CLI.CompileTest do
     # Can only assert when read-only applies to the user
     if access != :read_write do
       output = elixirc(compilation_args)
-      expected = '(File.Error) could not write to "' ++ String.to_char_list(context[:beam_file_path]) ++ '": permission denied'
+      expected = '(File.Error) could not write to "' ++ String.to_charlist(context[:beam_file_path]) ++ '": permission denied'
       assert :string.str(output, expected) > 0, "expected compilation error message due to not having write access"
     end
   end

--- a/lib/elixir/test/elixir/kernel/dialyzer_test.exs
+++ b/lib/elixir/test/elixir/kernel/dialyzer_test.exs
@@ -14,7 +14,7 @@ defmodule Kernel.DialyzerTest do
     plt =
       dir
       |> Path.join("base_plt")
-      |> String.to_char_list()
+      |> String.to_charlist()
 
     # Add a few key elixir modules for types
     files = Enum.map([Kernel, String, Keyword, Exception], &:code.which/1)
@@ -33,13 +33,13 @@ defmodule Kernel.DialyzerTest do
     dir =
       context[:base_dir]
       |> Path.join("line#{context[:line]}")
-      |> String.to_char_list()
+      |> String.to_charlist()
     File.mkdir_p!(dir)
 
     plt =
       dir
       |> Path.join("plt")
-      |> String.to_char_list()
+      |> String.to_charlist()
     File.cp!(context[:base_plt], plt)
 
     dialyzer = [analysis_type: :succ_typings, check_plt: false,

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -997,7 +997,7 @@ defmodule Kernel.ErrorsTest do
 
   defp rescue_stacktrace(expr) do
     result = try do
-      :elixir.eval(to_char_list(expr), [])
+      :elixir.eval(to_charlist(expr), [])
       nil
     rescue
       _ -> System.stacktrace

--- a/lib/elixir/test/elixir/kernel/fn_test.exs
+++ b/lib/elixir/test/elixir/kernel/fn_test.exs
@@ -24,7 +24,7 @@ defmodule Kernel.FnTest do
 
   test "capture remote" do
     assert (&:erlang.atom_to_list/1).(:a) == 'a'
-    assert (&Atom.to_char_list/1).(:a) == 'a'
+    assert (&Atom.to_charlist/1).(:a) == 'a'
 
     assert (&List.flatten/1).([[0]]) == [0]
     assert (&(List.flatten/1)).([[0]]) == [0]

--- a/lib/elixir/test/elixir/kernel/quote_test.exs
+++ b/lib/elixir/test/elixir/kernel/quote_test.exs
@@ -219,7 +219,7 @@ defmodule Kernel.QuoteTest.ErrorsTest do
     end
 
     mod  = Kernel.QuoteTest.ErrorsTest
-    file = __ENV__.file |> Path.relative_to_cwd |> String.to_char_list
+    file = __ENV__.file |> Path.relative_to_cwd |> String.to_charlist
     assert [{^mod, :add, 2, [file: ^file, line: 200]} | _] = System.stacktrace
   end
 
@@ -229,7 +229,7 @@ defmodule Kernel.QuoteTest.ErrorsTest do
     end
 
     mod  = Kernel.QuoteTest.ErrorsTest
-    file = __ENV__.file |> Path.relative_to_cwd |> String.to_char_list
+    file = __ENV__.file |> Path.relative_to_cwd |> String.to_charlist
     assert [{^mod, _, _, [file: ^file, line: 228]} | _] = System.stacktrace
   end
 end

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -344,11 +344,11 @@ defmodule Kernel.TypespecTest do
 
   test "@type with a union" do
     module = test_module do
-      @type mytype :: integer | char_list | atom
+      @type mytype :: integer | charlist | atom
     end
 
     assert [type: {:mytype, {:type, _, :union, [{:type, _, :integer, []},
-             {:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :char_list}, []]},
+             {:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :charlist}, []]},
              {:type, _, :atom, []}]}, []}] =
            types(module)
   end
@@ -504,7 +504,7 @@ defmodule Kernel.TypespecTest do
     module = test_module do
       def myfun(x), do: x
       @spec myfun(integer)   :: integer
-      @spec myfun(char_list) :: char_list
+      @spec myfun(charlist) :: charlist
       @callback cb(integer)  :: integer
     end
 
@@ -513,8 +513,8 @@ defmodule Kernel.TypespecTest do
 
     assert [{{:myfun, 1}, [
              {:type, _, :fun, [{:type, _, :product, [
-               {:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :char_list}, []]}]},
-               {:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :char_list}, []]}]},
+               {:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :charlist}, []]}]},
+               {:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :charlist}, []]}]},
              {:type, _, :fun, [{:type, _, :product, [{:type, _, :integer, []}]}, {:type, _, :integer, []}]}]}] =
            specs(module)
   end
@@ -550,7 +550,7 @@ defmodule Kernel.TypespecTest do
       (quote do: @type binary_type3() :: <<_ :: 3>>),
       (quote do: @type tuple_type() :: {integer()}),
       (quote do: @type ftype() :: (() -> any()) | (() -> integer()) | ((integer() -> integer()))),
-      (quote do: @type cl() :: char_list()),
+      (quote do: @type cl() :: charlist()),
       (quote do: @type st() :: struct()),
       (quote do: @type ab() :: as_boolean(term())),
       (quote do: @type kw() :: keyword()),

--- a/lib/elixir/test/elixir/list/chars_test.exs
+++ b/lib/elixir/test/elixir/list/chars_test.exs
@@ -4,7 +4,7 @@ defmodule List.Chars.AtomTest do
   use ExUnit.Case, async: true
 
   test "basic" do
-    assert to_char_list(:foo) == 'foo'
+    assert to_charlist(:foo) == 'foo'
   end
 end
 
@@ -12,7 +12,7 @@ defmodule List.Chars.BitStringTest do
   use ExUnit.Case, async: true
 
   test "basic" do
-    assert to_char_list("foo") == 'foo'
+    assert to_charlist("foo") == 'foo'
   end
 end
 
@@ -20,11 +20,11 @@ defmodule List.Chars.NumberTest do
   use ExUnit.Case, async: true
 
   test "integer" do
-    assert to_char_list(1) == '1'
+    assert to_charlist(1) == '1'
   end
 
   test "float" do
-    assert to_char_list(1.0) == '1.0'
+    assert to_charlist(1.0) == '1.0'
   end
 end
 
@@ -32,6 +32,6 @@ defmodule List.Chars.ListTest do
   use ExUnit.Case, async: true
 
   test "basic" do
-    assert to_char_list([ 1, "b", 3 ]) == [1, "b", 3]
+    assert to_charlist([ 1, "b", 3 ]) == [1, "b", 3]
   end
 end

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -90,8 +90,8 @@ defmodule PathTest do
     assert Path.relative_to_cwd(__ENV__.file) ==
            Path.relative_to(__ENV__.file, System.cwd!)
 
-    assert Path.relative_to_cwd(to_char_list(__ENV__.file)) ==
-           Path.relative_to(to_char_list(__ENV__.file), to_char_list(System.cwd!))
+    assert Path.relative_to_cwd(to_charlist(__ENV__.file)) ==
+           Path.relative_to(to_charlist(__ENV__.file), to_charlist(System.cwd!))
   end
 
   test "absname" do

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -232,7 +232,7 @@ defmodule ProtocolTest do
 
   test "derived implementation keeps local file/line info" do
     assert ProtocolTest.WithAny.ProtocolTest.ImplStruct.__info__(:compile)[:source] ==
-           String.to_char_list(__ENV__.file)
+           String.to_charlist(__ENV__.file)
   end
 
   test "cannot derive without any implementation" do

--- a/lib/elixir/test/elixir/string/chars_test.exs
+++ b/lib/elixir/test/elixir/string/chars_test.exs
@@ -63,7 +63,7 @@ defmodule String.Chars.ListTest do
     assert to_string('abc') == "abc"
   end
 
-  test "char list" do
+  test "charlist" do
     assert to_string([0, 1, 2, 3, 255]) ==
            <<0, 1, 2, 3, 195, 191>>
 

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -605,18 +605,18 @@ defmodule StringTest do
     refute String.contains? "elixir of life", ["death", "mercury", "eternal life"]
   end
 
-  test "to char list" do
-    assert String.to_char_list("æß")  == [?æ, ?ß]
-    assert String.to_char_list("abc") == [?a, ?b, ?c]
+  test "to charlist" do
+    assert String.to_charlist("æß")  == [?æ, ?ß]
+    assert String.to_charlist("abc") == [?a, ?b, ?c]
 
     assert_raise UnicodeConversionError,
                  "invalid encoding starting at <<223, 255>>", fn ->
-      String.to_char_list(<< 0xDF, 0xFF >>)
+      String.to_charlist(<< 0xDF, 0xFF >>)
     end
 
     assert_raise UnicodeConversionError,
                  "incomplete encoding starting at <<195>>", fn ->
-      String.to_char_list(<< 106, 111, 115, 195 >>)
+      String.to_charlist(<< 106, 111, 115, 195 >>)
     end
   end
 

--- a/lib/elixir/test/elixir/test_helper.exs
+++ b/lib/elixir/test/elixir/test_helper.exs
@@ -94,7 +94,7 @@ defmodule CompileAssertion do
 
   defp format_rescue(expr) do
     result = try do
-      :elixir.eval(to_char_list(expr), [])
+      :elixir.eval(to_charlist(expr), [])
       nil
     rescue
       error -> {error.__struct__, Exception.message(error)}

--- a/lib/elixir/test/erlang/control_test.erl
+++ b/lib/elixir/test/erlang/control_test.erl
@@ -57,13 +57,13 @@ case_test() ->
   {true, []} = eval("case {1, 2} do; {3, 4} -> false\n_ -> true\nend").
 
 case_with_do_ambiguity_test() ->
-  {true, _} = eval("case Atom.to_char_list(true) do\n_ -> true\nend").
+  {true, _} = eval("case Atom.to_charlist(true) do\n_ -> true\nend").
 
 case_with_match_do_ambiguity_test() ->
-  {true, _} = eval("case x = Atom.to_char_list(true) do\n_ -> true\nend").
+  {true, _} = eval("case x = Atom.to_charlist(true) do\n_ -> true\nend").
 
 case_with_unary_do_ambiguity_test() ->
-  {false, _} = eval("! case Atom.to_char_list(true) do\n_ -> true\nend").
+  {false, _} = eval("! case Atom.to_charlist(true) do\n_ -> true\nend").
 
 % Comparison
 

--- a/lib/ex_unit/examples/difference.exs
+++ b/lib/ex_unit/examples/difference.exs
@@ -45,10 +45,10 @@ defmodule Difference do
     assert list1 == list2
   end
 
-  test "char lists" do
-    char_list1 = 'fox hops over \'the dog'
-    char_list2 = 'fox jumps over the lazy cat'
-    assert char_list1 == char_list2
+  test "charlists" do
+    charlist1 = 'fox hops over \'the dog'
+    charlist2 = 'fox jumps over the lazy cat'
+    assert charlist1 == charlist2
   end
 
   test "keyword lists" do

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -44,10 +44,10 @@ defmodule ExUnit.DiffTest do
     expected = ~S<[file: {"nofile"}[nil], l{i}[l]ne: 1{2}[0] {(off by -2)}]>
     assert format(keyword_list1, keyword_list2, &formatter/2) == expected
 
-    char_list1 = 'fox hops over \'the dog'
-    char_list2 = 'fox jumps over the lazy cat'
+    charlist1 = 'fox hops over \'the dog'
+    charlist2 = 'fox jumps over the lazy cat'
     expected = "'fox {ho}[jum]ps over {\\'}the {dog}[lazy cat]'"
-    assert format(char_list1, char_list2, &formatter/2) == expected
+    assert format(charlist1, charlist2, &formatter/2) == expected
   end
 
   test "improper lists" do

--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -66,7 +66,7 @@ defmodule IEx.Autocomplete do
   defp strip_ampersand(expr), do: expr
 
   defp yes(hint, entries) do
-    {:yes, String.to_char_list(hint), Enum.map(entries, &String.to_char_list/1)}
+    {:yes, String.to_charlist(hint), Enum.map(entries, &String.to_charlist/1)}
   end
 
   defp no do
@@ -292,7 +292,7 @@ defmodule IEx.Autocomplete do
     do: true
 
   defp underscored_fun?({name, _}),
-    do: hd(Atom.to_char_list(name)) == ?_
+    do: hd(Atom.to_charlist(name)) == ?_
 
   defp ensure_loaded(Elixir), do: {:error, :nofile}
   defp ensure_loaded(mod),

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -77,7 +77,7 @@ defmodule IEx.Evaluator do
 
       # Evaluate the contents in the same environment server_loop will run in
       {_result, binding, env, _scope} =
-        :elixir.eval(String.to_char_list(code), state.binding, env)
+        :elixir.eval(String.to_charlist(code), state.binding, env)
 
       %{state | binding: binding, env: :elixir.env_for_eval(env, file: "iex", line: 1)}
     catch
@@ -105,7 +105,7 @@ defmodule IEx.Evaluator do
 
   defp eval(code, iex_state, history, state) do
     try do
-      do_eval(String.to_char_list(code), iex_state, history, state)
+      do_eval(String.to_charlist(code), iex_state, history, state)
     catch
       kind, error ->
         print_error(kind, error, System.stacktrace)

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -612,7 +612,7 @@ defmodule IEx.Helpers do
 
   # Compiles and loads an Erlang source file, returns {module, binary}
   defp compile_erlang(source) do
-    source = Path.relative_to_cwd(source) |> String.to_char_list
+    source = Path.relative_to_cwd(source) |> String.to_charlist
     case :compile.file(source, [:binary, :report]) do
       {:ok, module, binary} ->
         :code.purge(module)
@@ -654,9 +654,9 @@ defmodule IEx.Helpers do
                         is_integer(y) and y >= 0 and
                         is_integer(z) and z >= 0 do
     :erlang.list_to_pid(
-      '<' ++ Integer.to_char_list(x) ++ '.' ++
-             Integer.to_char_list(y) ++ '.' ++
-             Integer.to_char_list(z) ++ '>'
+      '<' ++ Integer.to_charlist(x) ++ '.' ++
+             Integer.to_charlist(y) ++ '.' ++
+             Integer.to_charlist(z) ++ '>'
     )
   end
 

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -80,7 +80,7 @@ defimpl IEx.Info, for: List do
     specific_info =
       cond do
         list == []                    -> info_list(list)
-        Inspect.List.printable?(list) -> info_char_list(list)
+        Inspect.List.printable?(list) -> info_charlist(list)
         Keyword.keyword?(list)        -> info_kw_list(list)
         true                          -> info_list(list)
       end
@@ -88,17 +88,17 @@ defimpl IEx.Info, for: List do
     ["Data type": "List"] ++ specific_info
   end
 
-  defp info_char_list(char_list) do
+  defp info_charlist(charlist) do
     desc = """
     This is a list of integers that is printed as a sequence of characters
     delimited by single quotes because all the integers in it represent valid
     ASCII characters. Conventionally, such lists of integers are referred to as
-    "char lists" (more precisely, a char list is a list of Unicode codepoints,
+    "charlists" (more precisely, a charlist is a list of Unicode codepoints,
     and ASCII is a subset of Unicode).
     """
 
     ["Description": desc,
-     "Raw representation": inspect(char_list, char_lists: :as_lists),
+     "Raw representation": inspect(charlist, charlists: :as_lists),
      "Reference modules": "List"]
   end
 

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -142,7 +142,7 @@ defmodule IEx.Introspection do
   defp has_content?({_, _, _, _, false}),
     do: false
   defp has_content?({{name, _}, _, _, _, nil}),
-    do: hd(Atom.to_char_list(name)) != ?_
+    do: hd(Atom.to_charlist(name)) != ?_
   defp has_content?({_, _, _, _, _}),
     do: true
 

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -104,7 +104,7 @@ defmodule IEx.InteractionTest do
   end
 
   test "inspect opts" do
-    opts = [inspect: [binaries: :as_binaries, char_lists: :as_lists, structs: false, limit: 4]]
+    opts = [inspect: [binaries: :as_binaries, charlists: :as_lists, structs: false, limit: 4]]
     assert capture_iex("<<45, 46, 47>>\n[45, 46, 47]\n%IO.Stream{}", opts) ==
               "<<45, 46, 47>>\n[45, 46, 47]\n%{__struct__: IO.Stream, device: nil, line_or_bytes: :line, raw: true}"
   end

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -87,7 +87,7 @@ defmodule Logger.Utils do
   def inspect(format, args, truncate, opts \\ %Inspect.Opts{})
 
   def inspect(format, args, truncate, opts) when is_atom(format) do
-    do_inspect(Atom.to_char_list(format), args, truncate, opts)
+    do_inspect(Atom.to_charlist(format), args, truncate, opts)
   end
 
   def inspect(format, args, truncate, opts) when is_binary(format) do
@@ -153,7 +153,7 @@ defmodule Logger.Utils do
   ## encoding
 
   defp collect_cc(:encoding, [?l | t], args, used_format, used_args, opts),
-    do: collect_cc(:done, t, args, [?l | used_format], used_args, %{opts | char_lists: false})
+    do: collect_cc(:done, t, args, [?l | used_format], used_args, %{opts | charlists: false})
 
   defp collect_cc(:encoding, [?t | t], args, used_format, used_args, opts),
     do: collect_cc(:done, t, args, [?t | used_format], used_args, opts)

--- a/lib/mix/lib/mix/compilers/erlang.ex
+++ b/lib/mix/lib/mix/compilers/erlang.ex
@@ -128,7 +128,7 @@ defmodule Mix.Compilers.Erlang do
   the Erlang compilation tools.
   """
   def to_erl_file(file) do
-    to_char_list(file)
+    to_charlist(file)
   end
 
   defp extract_targets(src_dir, src_ext, dest_dir, dest_ext, force) do

--- a/lib/mix/lib/mix/local.ex
+++ b/lib/mix/lib/mix/local.ex
@@ -90,7 +90,7 @@ defmodule Mix.Local do
   and print a warning if it is not satisfied.
   """
   def check_elixir_version_in_ebin(ebin) do
-    elixir = ebin |> Path.dirname |> Path.join(".elixir") |> String.to_char_list
+    elixir = ebin |> Path.dirname |> Path.join(".elixir") |> String.to_charlist
     case :erl_prim_loader.get_file(elixir) do
       {:ok, req, _} ->
         unless Version.match?(System.version, req) do

--- a/lib/mix/lib/mix/rebar.ex
+++ b/lib/mix/lib/mix/rebar.ex
@@ -254,7 +254,7 @@ defmodule Mix.Rebar do
   end
 
   defp eval_script(script_path, config) do
-    script = Path.basename(script_path) |> String.to_char_list
+    script = Path.basename(script_path) |> String.to_charlist
 
     result = File.cd!(Path.dirname(script_path), fn ->
       :file.script(script, eval_binds(CONFIG: config, SCRIPT: script))

--- a/lib/mix/lib/mix/shell.ex
+++ b/lib/mix/lib/mix/shell.ex
@@ -111,11 +111,11 @@ defmodule Mix.Shell do
       {:unix, _} ->
         command = command
           |> String.replace("\"", "\\\"")
-          |> String.to_char_list
+          |> String.to_charlist
         'sh -c "' ++ command ++ '"'
 
       {:win32, osname} ->
-        command = '"' ++ String.to_char_list(command) ++ '"'
+        command = '"' ++ String.to_charlist(command) ++ '"'
         case {System.get_env("COMSPEC"), osname} do
           {nil, :windows} -> 'command.com /s /c ' ++ command
           {nil, _}        -> 'cmd /s /c ' ++ command
@@ -127,9 +127,9 @@ defmodule Mix.Shell do
   defp validate_env(enum) do
     Enum.map enum, fn
       {k, nil} ->
-        {String.to_char_list(k), false}
+        {String.to_charlist(k), false}
       {k, v} ->
-        {String.to_char_list(k), String.to_char_list(v)}
+        {String.to_charlist(k), String.to_charlist(v)}
       other ->
         raise ArgumentError, "invalid environment key-value #{inspect other}"
     end

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -69,7 +69,7 @@ defmodule Mix.Task do
     # entire load path so make sure we only return unique modules.
 
     for(dir <- dirs,
-        {:ok, files} = :erl_prim_loader.list_dir(to_char_list(dir)),
+        {:ok, files} = :erl_prim_loader.list_dir(to_charlist(dir)),
         file <- files,
         mod = task_from_path(file),
         do: mod)
@@ -400,7 +400,7 @@ defmodule Mix.Task do
   """
   @spec task?(task_module) :: boolean
   def task?(module) when is_atom(module) do
-    match?('Elixir.Mix.Tasks.' ++ _, Atom.to_char_list(module)) and ensure_task?(module)
+    match?('Elixir.Mix.Tasks.' ++ _, Atom.to_charlist(module)) and ensure_task?(module)
   end
 
   defp ensure_task?(module) do

--- a/lib/mix/lib/mix/tasks/archive.build.ex
+++ b/lib/mix/lib/mix/tasks/archive.build.ex
@@ -81,8 +81,8 @@ defmodule Mix.Tasks.Archive.Build do
   defp create(source, target) do
     source_path = Path.expand(source)
     target_path = Path.expand(target)
-    dir = Mix.Local.archive_name(target_path) |> String.to_char_list
-    {:ok, _} = :zip.create(String.to_char_list(target_path),
+    dir = Mix.Local.archive_name(target_path) |> String.to_charlist
+    {:ok, _} = :zip.create(String.to_charlist(target_path),
                   files_to_add(source_path, dir),
                   uncompress: ['.beam', '.app'])
     :ok
@@ -97,7 +97,7 @@ defmodule Mix.Tasks.Archive.Build do
       Enum.reduce evsn ++ ebin ++ priv, [], fn(f, acc) ->
         case File.read(f) do
           {:ok, bin} ->
-            [{Path.join(dir, f) |> String.to_char_list, bin} | acc]
+            [{Path.join(dir, f) |> String.to_charlist, bin} | acc]
           {:error, _} ->
             acc
         end

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -79,7 +79,7 @@ defmodule Mix.Tasks.Compile.App do
 
     if opts[:force] || Mix.Utils.stale?(sources, [target]) || modules_changed?(mods, target) do
       best_guess = [
-        vsn: to_char_list(version),
+        vsn: to_charlist(version),
         modules: mods,
         applications: []
       ]
@@ -149,7 +149,7 @@ defmodule Mix.Tasks.Compile.App do
 
   defp ensure_correct_properties(app, config, properties) do
     properties
-    |> Keyword.put_new(:description, to_char_list(config[:description] || app))
+    |> Keyword.put_new(:description, to_charlist(config[:description] || app))
     |> Keyword.put_new(:registered, [])
     |> validate_properties
   end

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -208,7 +208,7 @@ defmodule Mix.Tasks.Escript.Build do
   defp read_beams(items) do
     items
     |> Enum.map(fn {basename, beam_path} ->
-      {String.to_char_list(basename), File.read!(beam_path)}
+      {String.to_charlist(basename), File.read!(beam_path)}
     end)
   end
 

--- a/lib/mix/lib/mix/tasks/help.ex
+++ b/lib/mix/lib/mix/tasks/help.ex
@@ -130,7 +130,7 @@ defmodule Mix.Tasks.Help do
   end
 
   defp where_is_file(module) do
-    case :code.where_is_file(Atom.to_char_list(module) ++ '.beam') do
+    case :code.where_is_file(Atom.to_charlist(module) ++ '.beam') do
       :non_existing ->
         "not available"
       location ->

--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -215,7 +215,7 @@ defmodule Mix.Tasks.Profile.Fprof do
     else
       :ok ->
         {_in, analysis_output} = StringIO.contents(analyse_dest)
-        String.to_char_list(analysis_output)
+        String.to_charlist(analysis_output)
     after
       StringIO.close(analyse_dest)
     end
@@ -230,8 +230,8 @@ defmodule Mix.Tasks.Profile.Fprof do
     |> Enum.each(&print_analysis_result/1)
   end
 
-  defp next_term(char_list) do
-    case :erl_scan.tokens([], char_list, 1) do
+  defp next_term(charlist) do
+    case :erl_scan.tokens([], charlist, 1) do
       {:done, result, leftover} ->
         case result do
           {:ok, tokens, _} ->

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Test do
       Mix.shell.info "Cover compiling modules ... "
       _ = :cover.start
 
-      case :cover.compile_beam_directory(compile_path |> to_char_list) do
+      case :cover.compile_beam_directory(compile_path |> to_charlist) do
         results when is_list(results) ->
           :ok
         {:error, _} ->

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -240,7 +240,7 @@ defmodule Mix.Utils do
       link = case :os.type do
         {:win32, _} -> source
         _           -> make_relative_path(source, target)
-      end |> String.to_char_list
+      end |> String.to_charlist
 
       case :file.read_link(target) do
         {:ok, ^link} ->
@@ -409,7 +409,7 @@ defmodule Mix.Utils do
     uri = URI.parse(proxy || "")
 
     if uri.host && uri.port do
-      host = String.to_char_list(uri.host)
+      host = String.to_charlist(uri.host)
       :httpc.set_options([{proxy_scheme(scheme), {{host, uri.port}, []}}], :mix)
     end
 
@@ -435,8 +435,8 @@ defmodule Mix.Utils do
   defp proxy_auth(%URI{userinfo: auth}) do
     destructure [user, pass], String.split(auth, ":", parts: 2)
 
-    user = String.to_char_list(user)
-    pass = String.to_char_list(pass || "")
+    user = String.to_charlist(user)
+    pass = String.to_charlist(pass || "")
 
     [proxy_auth: {user, pass}]
   end

--- a/lib/mix/test/mix/rebar_test.exs
+++ b/lib/mix/test/mix/rebar_test.exs
@@ -43,7 +43,7 @@ defmodule Mix.RebarTest do
   test "execute rebar.config.script on dependency directory" do
     path = MixTest.Case.fixture_path("rebar_dep_script")
     config = Mix.Rebar.load_config(path)
-    assert config[:dir] == {:ok, String.to_char_list(path)}
+    assert config[:dir] == {:ok, String.to_charlist(path)}
   end
 
   test "parse rebar dependencies" do

--- a/lib/mix/test/mix/tasks/archive_test.exs
+++ b/lib/mix/test/mix/tasks/archive_test.exs
@@ -49,7 +49,7 @@ defmodule Mix.Tasks.ArchiveTest do
       assert_received {:mix_shell, :error, [^version_error]}
 
       archive = tmp_path("userhome/.mix/archives/archive-0.1.0.ez/archive-0.1.0/ebin")
-      assert to_char_list(archive) in :code.get_path
+      assert to_charlist(archive) in :code.get_path
 
       # Loading the archive should emit warning again
       Mix.Local.append_archives

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -165,7 +165,7 @@ defmodule Mix.Tasks.DepsTest do
       assert File.exists?("_build/dev/lib/ok/priv/sample")
 
       Mix.Tasks.Compile.run []
-      assert to_char_list(Path.expand("_build/dev/lib/ok/ebin/")) in :code.get_path
+      assert to_charlist(Path.expand("_build/dev/lib/ok/ebin/")) in :code.get_path
       assert File.exists?("_build/dev/lib/sample/ebin/sample.app")
 
       # Remove the deps but set build_path, deps won't be pruned, but load paths are
@@ -175,7 +175,7 @@ defmodule Mix.Tasks.DepsTest do
       Mix.Project.push SuccessfulDepsApp
 
       Mix.Tasks.Deps.Check.run []
-      refute to_char_list(Path.expand("_build/dev/lib/ok/ebin/")) in :code.get_path
+      refute to_charlist(Path.expand("_build/dev/lib/ok/ebin/")) in :code.get_path
       assert File.exists?("_build/dev/lib/ok/ebin/ok.app")
       assert File.exists?("_build/dev/lib/sample/ebin/sample.app")
 

--- a/lib/mix/test/mix/umbrella_test.exs
+++ b/lib/mix/test/mix/umbrella_test.exs
@@ -92,9 +92,9 @@ defmodule Mix.UmbrellaTest do
       File.mkdir_p!("_build/dev/lib/bar/ebin")
 
       Mix.Task.run "loadpaths", ["--no-deps-check", "--no-elixir-version-check"]
-      assert to_char_list(Path.expand("_build/dev/lib/some_dep/ebin")) in :code.get_path
-      assert to_char_list(Path.expand("_build/dev/lib/foo/ebin")) in :code.get_path
-      assert to_char_list(Path.expand("_build/dev/lib/bar/ebin")) in :code.get_path
+      assert to_charlist(Path.expand("_build/dev/lib/some_dep/ebin")) in :code.get_path
+      assert to_charlist(Path.expand("_build/dev/lib/foo/ebin")) in :code.get_path
+      assert to_charlist(Path.expand("_build/dev/lib/bar/ebin")) in :code.get_path
     end
   end
 

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -89,7 +89,7 @@ defmodule MixTest.Case do
   def in_fixture(which, tmp, function) do
     src  = fixture_path(which)
     dest = tmp_path(tmp)
-    flag = String.to_char_list(tmp_path)
+    flag = String.to_charlist(tmp_path)
 
     File.rm_rf!(dest)
     File.mkdir_p!(dest)
@@ -130,7 +130,7 @@ defmodule MixTest.Case do
   end
 
   defp delete_tmp_paths do
-    tmp = tmp_path |> String.to_char_list
+    tmp = tmp_path |> String.to_charlist
     for path <- :code.get_path,
         :string.str(path, tmp) != 0,
         do: :code.del_path(path)


### PR DESCRIPTION
This is a big change.
We need to make consistent char_list by renaming it to charlist  

### DONE
- [x] Replace every occurrence of "char_list" and "char list"
- [x] Soft-deprecate `Kernel.to_char_list/1` and in `to_char_list` in /lib/elixir/lib/list/chars.ex
__Soft-deprecate:__
- [x] `/lib/elixir/lib/inspect/algebra.ex`: Inspect.Opts: :char_lists, :as_char_lists options
- [x] `/lib/elixir/pages/Typespecs.md`: Should we leave a note saying `char_list()` type has been deprecated in favor of `charlist()`?
- [x] `/lib/elixir/src/elixir.erl`, `/lib/elixir/src/elixir_rewrite.erl`: We need to softdeprecate `char_list/0` type
- [x] Fix protocol warnings when compiling Elixir

### TODO
- ~~~Add tests for soft-deprecated:~~~
  - ~~~functions / protocols: Kernel.to_char_list/1, Lists.Chars.to_char_list/1, File.open/1-2, and Inspect.~~~
  - ~~~options in algebra function: Inspect.Opts~~~
  - ~~~data type `char_list/0`~~~
