### PR TITLE
Range: Enforce integers values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   * [Kernel] Track `{module, function, arity}` imports and warn on unused ones when such are specified in `:only`
   * [Kernel] Add `keyword/0` and `keyword/1` built-in types to typespecs
   * [Process] Add `Process.sleep/1`
+  * [Range] `Range.range?/1` now checks the validity of a range.
   * [Regex] Support `:include_captures` in `Regex.split/3`
   * [String] Add `String.myers_difference/2` for calculating the difference between two strings
   * [System] Add `System.os_time/0` and `System.os_time/1`

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -57,9 +57,7 @@ defmodule Range do
   end
 
   @doc """
-  Returns `true` if the given `term` is a range.
-
-  It does not check if the range is valid.
+  Returns `true` if the given `term` is a valid range.
 
   ## Examples
 
@@ -72,7 +70,7 @@ defmodule Range do
   """
   @spec range?(term) :: boolean
   def range?(term)
-  def range?(%Range{}), do: true
+  def range?(first..last) when is_integer(first) and is_integer(last), do: true
   def range?(_), do: false
 end
 

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -39,8 +39,9 @@ defmodule Range do
 
   defstruct first: nil, last: nil
 
-  @type t :: %Range{}
+  @type t :: %Range{first: integer, last: integer}
   @type t(first, last) :: %Range{first: first, last: last}
+
 
   @doc """
   Creates a new range.

--- a/lib/elixir/test/elixir/range_test.exs
+++ b/lib/elixir/test/elixir/range_test.exs
@@ -18,6 +18,10 @@ defmodule RangeTest do
   test "range?" do
     assert Range.range?(1..3)
     refute Range.range?(0)
+    assert %Range{first: -10, last: 10} |> Range.range?
+    refute %Range{first: nil, last: 10} |> Range.range?
+    refute %Range{first: -10, last: nil} |> Range.range?
+    refute %Range{} |> Range.range?
   end
 
   test "enum" do


### PR DESCRIPTION
- Range.range?/1: Checks for valid ranges
- Range.t typespec: args are integers

Can anybody please confirm that this is the correct definition:
`@type t(first :: integer, last :: integer) :: %Range{first: integer, last: integer}`
