### PR TITLE
Add doctest for Macro.decompose_call with variables

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -349,6 +349,9 @@ defmodule Macro do
       iex> Macro.decompose_call(quote(do: foo(1, 2, 3)))
       {:foo, [1, 2, 3]}
 
+      iex> Macro.decompose_call(quote(do: foo(a, b, c)))
+      {:foo, [{:a, [], __MODULE__}, {:b, [], __MODULE__}, {:c, [], __MODULE__}]}
+
       iex> Macro.decompose_call(quote(do: Elixir.M.foo(1, 2, 3)))
       {{:__aliases__, [], [:Elixir, :M]}, :foo, [1, 2, 3]}
 


### PR DESCRIPTION
Not 100% sure if it's worth keeping, but having this in the docs would have been helpful for me when reading about decompose_call for the 1st time.