### PR TITLE
Improve error message when application description contains non-ASCII codepoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
   * [Mix] Improve task not found message when Mix would include the not found task as a suggestion due to different casing
   * [Mix] Ignore lock revision when the lock is out of date when updating Mix dependencies
   * [Mix] Only recompile empty Elixir files if they changed instead of recompiling them on every run
+  * [Mix] Improve error message when application description contains non-ASCII codepoints
 
 ### 3. Soft deprecations (no warnings emitted)
 

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -160,6 +160,10 @@ defmodule Mix.Tasks.Compile.App do
         unless is_list(value) do
           Mix.raise "Application description (:description) is not a character list, got: #{inspect value}"
         end
+
+        unless Enum.all?(value, fn char -> char in 0..127 end) do
+          Mix.raise "Application description (:description) may contain only ASCII codepoints, got: #{inspect value}"
+        end
       {:id, value} ->
         unless is_list(value) do
           Mix.raise "Application id (:id) is not a character list, got: #{inspect value}"

--- a/lib/mix/test/mix/tasks/compile.app_test.exs
+++ b/lib/mix/test/mix/tasks/compile.app_test.exs
@@ -39,6 +39,14 @@ defmodule Mix.Tasks.Compile.AppTest do
     end
   end
 
+  defmodule NonASCIIDescriptionProject do
+    def project do
+      [app: :non_ascii_description_project,
+       version: "0.3.0",
+       description: "São Paulo"]
+    end
+  end
+
   test "generates .app file when changes happen" do
     Mix.Project.push MixTest.Case.Sample
 
@@ -105,6 +113,17 @@ defmodule Mix.Tasks.Compile.AppTest do
 
     in_fixture "no_mixfile", fn ->
       message = "Expected :version to be a SemVer version, got: \"0.3\""
+      assert_raise Mix.Error, message, fn ->
+        Mix.Tasks.Compile.App.run([])
+      end
+    end
+  end
+
+  test "raise on non-ASCII description" do
+    Mix.Project.push NonASCIIDescriptionProject
+
+    in_fixture "no_mixfile", fn ->
+      message = "Application description (:description) may contain only ASCII codepoints, got: [83, 227, 111, 32, 80, 97, 117, 108, 111]"
       assert_raise Mix.Error, message, fn ->
         Mix.Tasks.Compile.App.run([])
       end


### PR DESCRIPTION
Improves the situation described in #4578.

@josevalim, you mentioned you wanted to investigate, so not sure if there were more similar issues you wanted to address, but this addresses the one mentioned in the issue, at least.