### PR TITLE
Range: to_charlist/1 and to_string/1 + Protocols

### DIFF
--- a/lib/elixir/lib/list/chars.ex
+++ b/lib/elixir/lib/list/chars.ex
@@ -61,3 +61,9 @@ defimpl List.Chars, for: Float do
     Float.to_charlist(thing, compact: true, decimals: @digits)
   end
 end
+
+defimpl List.Chars, for: Range do
+  def to_charlist(thing) do
+    Range.to_charlist(thing)
+  end
+end

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -73,6 +73,50 @@ defmodule Range do
   def range?(term)
   def range?(first..last) when is_integer(first) and is_integer(last), do: true
   def range?(_), do: false
+
+  @doc """
+  Returns a binary which corresponds to the text representation of the given `range`.
+
+  ## Examples
+
+      iex> Range.to_string(12..34)
+      "12..34"
+
+      iex> Range.to_string(-56..78)
+      "-56..78"
+
+  """
+  @spec to_string(t) :: String.t
+  def to_string(range)
+  def to_string(first..first) when is_integer(first) do
+    string = Integer.to_string(first)
+    string <> ".." <> string
+  end
+  def to_string(first..last) when is_integer(first) and is_integer(last) do
+    Integer.to_string(first) <> ".." <> Integer.to_string(last)
+  end
+
+  @doc """
+  Returns a charlist which corresponds to the text representation of the given `range`.
+
+  ## Examples
+
+      iex> Range.to_charlist(12..34)
+      '12..34'
+
+      iex> Range.to_charlist(-56..78)
+      '-56..78'
+
+  """
+  @spec to_charlist(t) :: charlist
+  def to_charlist(range)
+  def to_charlist(first..first) when is_integer(first) do
+    charlist = Integer.to_charlist(first)
+    charlist ++ '..' ++ charlist
+  end
+  def to_charlist(first..last) when is_integer(first) and is_integer(last) do
+    Integer.to_charlist(first) ++ '..' ++ Integer.to_charlist(last)
+  end
 end
 
 defimpl Enumerable, for: Range do

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -168,6 +168,11 @@ end
 defimpl Inspect, for: Range do
   import Inspect.Algebra
 
+  def inspect(first..first, opts) do
+    doc = to_doc(first, opts)
+    concat [doc, "..", doc]
+  end
+
   def inspect(first..last, opts) do
     concat [to_doc(first, opts), "..", to_doc(last, opts)]
   end

--- a/lib/elixir/lib/string/chars.ex
+++ b/lib/elixir/lib/string/chars.ex
@@ -55,3 +55,9 @@ defimpl String.Chars, for: Float do
     IO.iodata_to_binary(:io_lib_format.fwrite_g(thing))
   end
 end
+
+defimpl String.Chars, for: Range do
+  def to_string(thing) do
+    Range.to_string(thing)
+  end
+end

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -389,4 +389,10 @@ defmodule Inspect.OthersTest do
     "~r/\\a\\x08\\x7F\\x1B\\f\\n\\r \\t\\v\\//" = inspect(Regex.compile!("\a\b\d\e\f\n\r\s\t\v/"))
     "~r/\\a\\b\\d\\e\\f\\n\\r\\s\\t\\v\\//" = inspect(~r<\a\b\d\e\f\n\r\s\t\v/>)
   end
+
+  test "range" do
+    assert inspect(1..2) ==  "1..2"
+    assert inspect(-2..-1) ==  "-2..-1"
+    assert inspect(33..33) ==  "33..33"
+  end
 end

--- a/lib/elixir/test/elixir/list/chars_test.exs
+++ b/lib/elixir/test/elixir/list/chars_test.exs
@@ -35,3 +35,12 @@ defmodule List.Chars.ListTest do
     assert to_charlist([ 1, "b", 3 ]) == [1, "b", 3]
   end
 end
+
+defmodule List.Chars.RangeTest do
+  use ExUnit.Case, async: true
+
+  test "basic" do
+    assert to_charlist(100..200) == '100..200'
+    assert to_charlist(-100..-100) == '-100..-100'
+  end
+end

--- a/lib/elixir/test/elixir/range_test.exs
+++ b/lib/elixir/test/elixir/range_test.exs
@@ -60,6 +60,17 @@ defmodule RangeTest do
       first..last
       Enum.map(first..last, &(&1))
     end
+  end
 
+  test "to_charlist/1" do
+    assert Range.to_charlist(20..30) == '20..30'
+    assert Range.to_charlist(-20..+30) == '-20..30'
+    assert Range.to_charlist(-20..-20) == '-20..-20'
+  end
+
+  test "to_string/1" do
+    assert Range.to_string(20..30) == "20..30"
+    assert Range.to_string(-20..+30) == "-20..30"
+    assert Range.to_string(-20..-20) == "-20..-20"
   end
 end


### PR DESCRIPTION
Currently we can get the binary representation of a range via `inspect`, but not through another way.