### PR TITLE
Clarify that flat_map only flattens one level deep

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -870,6 +870,9 @@ defmodule Enum do
       iex> Enum.flat_map([{1, 3}, {4, 6}], fn({x, y}) -> x..y end)
       [1, 2, 3, 4, 5, 6]
 
+      iex> Enum.flat_map([:a, :b, :c], fn(x) -> [[x]] end)
+      [[:a], [:b], [:c]]
+
   """
   @spec flat_map(t, (element -> t)) :: list
   def flat_map(enumerable, fun) do

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -882,7 +882,7 @@ defmodule Enum do
   end
 
   @doc """
-  Maps and reduces an enumerable, flattening the given results.
+  Maps and reduces an enumerable, flattening the given results (only one level deep).
 
   It expects an accumulator and a function that receives each stream
   item, and must return a tuple containing a new stream (often a list)
@@ -897,6 +897,9 @@ defmodule Enum do
       ...>   if acc < n, do: {[i], acc + 1}, else: {:halt, acc}
       ...> end)
       {[1, 2, 3], 3}
+
+      iex> Enum.flat_map_reduce(1..5, 0, fn(i, acc) -> {[[i]], acc + i} end)
+      {[[1], [2], [3], [4], [5]], 15}
 
   """
   @spec flat_map_reduce(t, acc, fun) :: {[any], any} when

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -332,13 +332,17 @@ defmodule Stream do
 
   @doc """
   Creates a stream that will apply the given function on enumeration and
-  flatten the result.
+  flatten the result, but only one level deep.
 
   ## Examples
 
       iex> stream = Stream.flat_map([1, 2, 3], fn(x) -> [x, x * 2] end)
       iex> Enum.to_list(stream)
       [1, 2, 2, 4, 3, 6]
+
+      iex> stream = Stream.flat_map([1, 2, 3], fn(x) -> [[x]] end)
+      iex> Enum.to_list(stream)
+      [[1], [2], [3]]
 
   """
   @spec flat_map(Enumerable.t, (element -> Enumerable.t)) :: Enumerable.t


### PR DESCRIPTION
* got me by surprise today as I always thought it'd do the
  equivalent of List.flatten/1 so seemed nice to get some
  examples

Not quite sure yet about the added doc to Stream.flat_map - as it is described quite differently in Enum.flat_map but that's also probably due to their different nature.

Enum doc:

```
  Returns a new enumerable appending the result of invoking `fun` on
  each corresponding item of `enumerable`.

  The given function must return an enumerable.
```