### PR TITLE
Keep naming it enumerable for documentation consistency in Enumerable module

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -881,8 +881,8 @@ defmodule Enum do
   @doc """
   Maps and reduces an enumerable, flattening the given results.
 
-  It expects an accumulator and a function that receives each stream
-  item, and must return a tuple containing a new stream (often a list)
+  It expects an accumulator and a function that receives each enumerable
+  item, and must return a tuple containing a new enumerable (often a list)
   with the new accumulator or a tuple with `:halt` as first element and
   the accumulator as second.
 


### PR DESCRIPTION
Noticed it while browsing the docs, just a small doc fix :) Seems to be the only reference of `stream` in the Enumerable module save the ones explaining the difference between `Enum` and `Stream` (or using/requiring some `Stream`) stuff.