### PR TITLE
Friendly error message for duplicate ExUnit test names

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -1,3 +1,7 @@
+defmodule ExUnit.DuplicateTestError do
+  defexception [:message]
+end
+
 defmodule ExUnit.Case do
   @moduledoc """
   Sets up an ExUnit test case.
@@ -253,6 +257,11 @@ defmodule ExUnit.Case do
 
     quote bind_quoted: binding do
       test = :"test #{message}"
+
+      if Module.defines?(__MODULE__, {test, 1}) do
+        raise ExUnit.DuplicateTestError, ~s(a test named "#{message}" is already defined in #{inspect __MODULE__})
+      end
+
       ExUnit.Case.__on_definition__(__ENV__, test, [])
       def unquote(test)(unquote(var)), do: unquote(contents)
     end

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -192,24 +192,22 @@ defmodule ExUnitTest do
     end
   end
 
-  test "registers only the first test with any given name" do
-    capture_io :stderr, fn ->
+  test "raises friendly error for duplicate test names" do
+    message = ~s(a test named "duplicate" is already defined in ExUnitTest.TestWithSameNames)
+
+    assert_raise ExUnit.DuplicateTestError, message, fn ->
       defmodule TestWithSameNames do
         use ExUnit.Case
 
-        test "same name, different outcome" do
-          assert 1 == 1
+        test "duplicate" do
+          assert true
         end
 
-        test "same name, different outcome" do
-          assert 1 == 2
+        test "duplicate" do
+          assert true
         end
       end
     end
-
-    assert capture_io(fn ->
-      assert ExUnit.run == %{failures: 0, skipped: 0, total: 1}
-    end) =~ "1 test, 0 failure"
   end
 
   test "produces error on not implemented tests" do


### PR DESCRIPTION
First, it should be noted that the below-described "problem" **is expected** (and tested) by ExUnit.
This pull-request suggests that behavior be changed.

# Problem

Given a test having duplicate names defined as the following:

```elixir
ExUnit.start

defmodule TestWithSameNames do
  use ExUnit.Case

  test "foo" do
    assert true == true
  end

  test "foo" do
    assert true == true
  end
end
```

The second test is not run and the warning that is output is not very helpful to the untrained eye.

```
$ elixir example.exs
example.exs:10: warning: this clause cannot match because a previous clause at line 6 always matches
.
1 test, 0 failures
```

In order to understand the warning, the user must know that ExUnit defines functions based on the test names.
This is an implementation detail that the user shouldn't have to know about.

# Solution

Since the second test definition is useless, make the definition of it fail immediately without running the tests and explicitly tell the user why.

```
$ mix test
** (ExUnit.DuplicateTestError) A test named "foo" is already defined in Elixir.DupTest.
    test/dup_test.exs:6: (module)
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
```

As always, I'm happy to change the implementation/output/etc. if you have any suggestions!
Thank you for the amazing tools :) :heart:

h/t @nathanl for pairing! A great partner! 💫 