### PR TITLE
Ensure args 2 and 3 to Enum,Stream.chunk/3,4 are integers

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -355,7 +355,9 @@ defmodule Enum do
 
   """
   @spec chunk(t, pos_integer, pos_integer, t | nil) :: [list]
-  def chunk(enumerable, count, step, leftover \\ nil) when count > 0 and step > 0 do
+  def chunk(enumerable, count, step, leftover \\ nil) when count > 0
+    and step > 0 and is_integer(count) and is_integer(step) do
+
     limit = :erlang.max(count, step)
 
     {acc, {buffer, i}} =

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -158,7 +158,9 @@ defmodule Stream do
   """
   @spec chunk(Enumerable.t, pos_integer, pos_integer) :: Enumerable.t
   @spec chunk(Enumerable.t, pos_integer, pos_integer, Enumerable.t | nil) :: Enumerable.t
-  def chunk(enum, n, step, leftover \\ nil) when n > 0 and step > 0 do
+  def chunk(enum, n, step, leftover \\ nil) when n > 0 and step > 0
+    and step > 0 and is_integer(n) and is_integer(step) do
+
     limit = :erlang.max(n, step)
     if is_nil(leftover) do
       lazy enum, {[], 0}, fn(f1) -> R.chunk(n, step, limit, f1) end


### PR DESCRIPTION
I confused myself the other day by accidentally doing:

```elixir
iex(1)> 1..10 |> Enum.chunk(1, [], [])
```

Instead of blowing up this actually produces
```
[[1], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]
```

This happens because `[] > 0` is valid in the guard clause.

I add `is_integer` checks to args 2 and 3 in order to make sure that they're actually numbers.
