### PR TITLE
Improved documentation of List.foldl/3 and List.foldr/3

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -115,6 +115,8 @@ defmodule List do
   Folds (reduces) the given list from the left with
   a function. Requires an accumulator.
 
+  `foldl/3` is [tail-recursive](https://en.wikipedia.org/wiki/Tail_call).
+
   ## Examples
 
       iex> List.foldl([5, 5], 10, fn (x, acc) -> x + acc end)
@@ -132,6 +134,8 @@ defmodule List do
   @doc """
   Folds (reduces) the given list from the right with
   a function. Requires an accumulator.
+
+  Notice that `foldr/3` is not [tail-recursive](https://en.wikipedia.org/wiki/Tail_call). Therefore, `foldl/3` is usually preferred.
 
   ## Examples
 

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -135,7 +135,8 @@ defmodule List do
   Folds (reduces) the given list from the right with
   a function. Requires an accumulator.
 
-  Notice that `foldr/3` is not [tail-recursive](https://en.wikipedia.org/wiki/Tail_call). Therefore, `foldl/3` is usually preferred.
+  Notice that `foldr/3` is not [tail-recursive](https://en.wikipedia.org/wiki/Tail_call). 
+  Therefore, `foldl/3` is usually preferred.
 
   ## Examples
 


### PR DESCRIPTION
This Pull Request adds a notice at `List.foldl/3` 's documentation to indicate that it is tail-recursive. It also adds a notice at `List.foldr/3` to indicate that it is **not** tail-recursive, and that it usually is better to use `List.foldl/3`.

This information is listed in the [Erlang docs of :lists.foldr/3](http://erlang.org/doc/man/lists.html#foldr-3), but was missing from the documentation of Elixir's wrapper around it. 