### PR TITLE
Enum documentation: Reformulate the returned element for min/max/max_by 

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1211,6 +1211,9 @@ defmodule Enum do
       iex> Enum.max_by(["a", "aa", "aaa"], fn(x) -> String.length(x) end)
       "aaa"
 
+      iex> Enum.max_by(["a", "aa", "aaa", "b", "bbb"], &String.length/1)
+      "aaa"
+
   """
   @spec max_by(t, (element -> any)) :: element | no_return
   def max_by([h | t], fun) do
@@ -1312,6 +1315,9 @@ defmodule Enum do
       iex> Enum.min_by(["a", "aa", "aaa"], fn(x) -> String.length(x) end)
       "a"
 
+      iex> Enum.min_by(["a", "aa", "aaa", "b", "bbb"], &String.length/1)
+      "a"
+
   """
   @spec min_by(t, (element -> any)) :: element | no_return
   def min_by([h | t], fun) do
@@ -1385,6 +1391,9 @@ defmodule Enum do
 
       iex> Enum.min_max_by(["aaa", "bb", "c"], fn(x) -> String.length(x) end)
       {"c", "aaa"}
+
+      iex> Enum.min_max_by(["aaa", "a", "bb", "c", "ccc"], &String.length/1)
+      {"a", "aaa"}
 
   """
   @spec min_max_by(t, (element -> any)) :: {element, element} | no_return

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1181,7 +1181,7 @@ defmodule Enum do
   Returns the biggest of the elements in the enumerable according
   to Erlang's term ordering.
 
-  If more than one elements compare equal, the first one that was found
+  If multiple elements are considered the biggest, the first one that was found
   is returned.
 
   Raises `Enum.EmptyError` if `enumerable` is empty.
@@ -1201,7 +1201,7 @@ defmodule Enum do
   Returns the biggest of the elements in the enumerable as calculated
   by the given function.
 
-  If more than one elements compare equal, the first one that was found
+  If multiple elements are considered the biggest, the first one that was found
   is returned.
 
   Raises `Enum.EmptyError` if `enumerable` is empty.
@@ -1282,7 +1282,7 @@ defmodule Enum do
   Returns the smallest of the elements in the enumerable according
   to Erlang's term ordering.
 
-  If more than one elements compare equal, the first one that was found
+  If multiple elements are considered the smallest, the first one that was found
   is returned.
 
   Raises `Enum.EmptyError` if `enumerable` is empty.
@@ -1302,7 +1302,7 @@ defmodule Enum do
   Returns the smallest of the elements in the enumerable as calculated
   by the given function.
 
-  If more than one elements compare equal, the first one that was found
+  If multiple elements are considered the smallest, the first one that was found
   is returned.
 
   Raises `Enum.EmptyError` if `enumerable` is empty.
@@ -1345,8 +1345,8 @@ defmodule Enum do
   Returns a tuple with the smallest and the biggest elements in the
   enumerable according to Erlang's term ordering.
 
-  If more than one elements compare equal, the first one that was found
-  is picked.
+  If multiple elements are considered the biggest or smallest, the first one
+  that was found is returned.
 
   Raises `Enum.EmptyError` if `enumerable` is empty.
 
@@ -1376,8 +1376,8 @@ defmodule Enum do
   Returns a tuple with the smallest and the biggest elements in the
   enumerable as calculated by the given function.
 
-  If more than one elements compare equal, the first one that was found
-  is picked.
+  If multiple elements are considered the biggest or smallest, the first one
+  that was found is returned.
 
   Raises `Enum.EmptyError` if `enumerable` is empty.
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1178,10 +1178,10 @@ defmodule Enum do
   end
 
   @doc """
-  Returns the biggest of the elements in the enumerable according
+  Returns the maximal element in the enumerable according
   to Erlang's term ordering.
 
-  If multiple elements are considered the biggest, the first one that was found
+  If multiple elements are considered maximal, the first one that was found
   is returned.
 
   Raises `Enum.EmptyError` if `enumerable` is empty.
@@ -1198,10 +1198,10 @@ defmodule Enum do
   end
 
   @doc """
-  Returns the biggest of the elements in the enumerable as calculated
+  Returns the maximal element in the enumerable as calculated
   by the given function.
 
-  If multiple elements are considered the biggest, the first one that was found
+  If multiple elements are considered maximal, the first one that was found
   is returned.
 
   Raises `Enum.EmptyError` if `enumerable` is empty.
@@ -1282,10 +1282,10 @@ defmodule Enum do
   end
 
   @doc """
-  Returns the smallest of the elements in the enumerable according
+  Returns the minimal element in the enumerable according
   to Erlang's term ordering.
 
-  If multiple elements are considered the smallest, the first one that was found
+  If multiple elements are considered minimal, the first one that was found
   is returned.
 
   Raises `Enum.EmptyError` if `enumerable` is empty.
@@ -1302,10 +1302,10 @@ defmodule Enum do
   end
 
   @doc """
-  Returns the smallest of the elements in the enumerable as calculated
+  Returns the minimal element in the enumerable as calculated
   by the given function.
 
-  If multiple elements are considered the smallest, the first one that was found
+  If multiple elements are considered minimal, the first one that was found
   is returned.
 
   Raises `Enum.EmptyError` if `enumerable` is empty.
@@ -1348,10 +1348,10 @@ defmodule Enum do
   end
 
   @doc """
-  Returns a tuple with the smallest and the biggest elements in the
+  Returns a tuple with the minimal and the maximal elements in the
   enumerable according to Erlang's term ordering.
 
-  If multiple elements are considered the biggest or smallest, the first one
+  If multiple elements are considered maximal or minimal, the first one
   that was found is returned.
 
   Raises `Enum.EmptyError` if `enumerable` is empty.
@@ -1379,10 +1379,10 @@ defmodule Enum do
   end
 
   @doc """
-  Returns a tuple with the smallest and the biggest elements in the
+  Returns a tuple with the minimal and the maximal elements in the
   enumerable as calculated by the given function.
 
-  If multiple elements are considered the biggest or smallest, the first one
+  If multiple elements are considered maximal or minimal, the first one
   that was found is returned.
 
   Raises `Enum.EmptyError` if `enumerable` is empty.


### PR DESCRIPTION
The sentence seemed a bit strange, wanted to make it more understandable.
Also wanted to convey that the "compared equal" part only applies/matters to the smallest/biggest element.

Still not sure, if this is really good. Might want to check with a native speaker, to me it read a bit strange so tried to improve upon it.

Also included a second commit, adding the inline doc `iex` for min/max/min_max_by to show the mentioned behavior that the first biggest/smallest element is returned.

2 commits so if wanted only one of them could be taken. Also happy to squash or let github squash it.