### PR TITLE
Add an :each_waiting option to Kernel.ParallelCompiler

### DIFF
--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -107,6 +107,8 @@ defmodule Mix.Compilers.Elixir do
       _ = Kernel.ParallelCompiler.files :lists.usort(stale),
         each_module: &each_module(pid, dest, cwd, &1, &2, &3),
         each_file: &each_file(&1),
+        each_waiting: &each_waiting(&1),
+        waiting_timeout: 5_000,
         dest: dest
       Agent.cast pid, fn {entries, sources} ->
         write_manifest(manifest, entries, sources)
@@ -171,6 +173,10 @@ defmodule Mix.Compilers.Elixir do
 
   defp each_file(source) do
     Mix.shell.info "Compiled #{source}"
+  end
+
+  defp each_waiting(source) do
+    Mix.shell.info "Compiling #{source} (it's taking more than 5s)"
   end
 
   ## Resolution


### PR DESCRIPTION
I added the `:each_waiting` and `:waiting_timeout` options to `Kernel.ParallelCompiler.files/2`. These option control what to do when a file it's taking longer than `:waiting_timeout` to compile: in such cases, the `:each_waiting` function is called with that file as its argument.

I also updated the Elixir compiler so that it now prints 

> Compiling lib/foo.ex (it's taking longer than 5 seconds)

during compilation. This is a step towards fixing #4585. I still haven't suppressed the "Compiled lib/foo.ex" messages as I think it's better to do one thing at a time (there are also a lot of tests to update if we suppress that).

The diff is pretty big because `Kernel.ParallelCompiler.spawn_compilers/8` has a lot of clauses and I had to update all of them (and I managed to raise the record of highest arity ever to 9! /cc @eksperimental); I think I'd like to refactor this function a bit so that it looks cleaner, but that's a story for another PR.