### PR TITLE
Rename :each_timeout and :timeout compiler options

### DIFF
--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -392,7 +392,7 @@ defmodule Kernel.CLI do
           Code.compiler_options(config.compiler_options)
           opts =
             if config.verbose_compile do
-              [each_timeout: &IO.puts("Compiling #{&1} (it's taking more than 5s)")]
+              [each_long_compilation: &IO.puts("Compiling #{&1} (it's taking more than 5s)")]
             else
               []
             end

--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -20,12 +20,12 @@ defmodule Kernel.ParallelCompiler do
     * `:each_file` - for each file compiled, invokes the callback passing the
       file
 
-    * `:each_timeout` - for each file that takes more than a given timeout (see
-      the `:timeout` option) to compile, invoke this callback passing
-      the file as its argument
+    * `:each_long_compilation` - for each file that takes more than a given
+      timeout (see the `:long_compilation_threshold` option) to compile, invoke
+      this callback passing the file as its argument
 
-    * `:timeout` - the timeout (in milliseconds) after the
-      `:each_timeout` callback is invoked; defaults to `5000`
+    * `:long_compilation_threshold` - the timeout (in milliseconds) after the
+      `:each_long_compilation` callback is invoked; defaults to `5000`
 
     * `:each_module` - for each module compiled, invokes the callback passing
       the file, module and the module bytecode
@@ -114,7 +114,7 @@ defmodule Kernel.ParallelCompiler do
         end)
       end
 
-    timeout = Keyword.get(options, :timeout, 5_000)
+    timeout = Keyword.get(options, :long_compilation_threshold, 5_000)
     timer_ref = Process.send_after(self(), {:timed_out, pid}, timeout)
 
     new_queued = [{pid, ref, h, timer_ref} | queued]
@@ -191,7 +191,7 @@ defmodule Kernel.ParallelCompiler do
         spawn_compilers(entries, original, output, options, waiting, queued, schedulers, result)
 
       {:timed_out, child} ->
-        if callback = Keyword.get(options, :each_timeout) do
+        if callback = Keyword.get(options, :each_long_compilation) do
           {^child, _, file, _} = List.keyfind(queued, child, 0)
           callback.(file)
         end

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -114,7 +114,7 @@ defmodule Mix.Compilers.Elixir do
     try do
       _ = Kernel.ParallelCompiler.files :lists.usort(stale),
             [each_module: &each_module(pid, dest, cwd, &1, &2, &3),
-             each_timeout: &each_timeout(&1),
+             each_long_compilation: &each_long_compilation(&1),
              timeout: 5_000,
              dest: dest] ++ extra
       Agent.cast pid, fn {entries, sources} ->
@@ -188,7 +188,7 @@ defmodule Mix.Compilers.Elixir do
     Mix.shell.info "Compiled #{source}"
   end
 
-  defp each_timeout(source) do
+  defp each_long_compilation(source) do
     Mix.shell.info "Compiling #{source} (it's taking more than 5s)"
   end
 


### PR DESCRIPTION
I renamed those to `:each_long_compilation` and `:long_compilation_threshold`.

Tests are failing because we didn't update them when disabling the "Compiled lib/foo.ex" messages. A PR is coming for that :)