### PR TITLE
Make lexicals (alias, import and require) return the given module(s) instead of nil

### DIFF
--- a/lib/elixir/src/elixir_translator.erl
+++ b/lib/elixir/src/elixir_translator.erl
@@ -50,8 +50,8 @@ translate({{'.', _, [erlang, 'orelse']}, Meta, [Left, Right]}, S) ->
 
 %% Lexical
 
-translate({Lexical, _, [_, _]}, S) when Lexical == import; Lexical == alias; Lexical == require ->
-  {{atom, 0, nil}, S};
+translate({Lexical, _, [Module, _]}, S) when Lexical == import; Lexical == alias; Lexical == require ->
+  {{atom, 0, Module}, S};
 
 %% Pseudo variables
 

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -235,7 +235,7 @@ defmodule IEx.HelpersTest do
              = capture_iex("puts \"hi\"")
 
       assert capture_iex("import_file \"dot-iex\"\nvariable\nputs \"hi\"")
-             == "nil\n:hello\nhi\n:ok"
+             == "IO\n:hello\nhi\n:ok"
     end
   end
 
@@ -250,7 +250,7 @@ defmodule IEx.HelpersTest do
              = capture_iex("puts \"hi\"")
 
       assert capture_iex("import_file \"dot-iex\"\nvariable\nputs \"hi\"\nparent")
-             == "nil\n:hello\nhi\n:ok\ntrue"
+             == "IO\n:hello\nhi\n:ok\ntrue"
     end
   end
 


### PR DESCRIPTION
Implements changes suggested by @josevalim at #4596.

```elixir
iex> import String
String
```

```elixir
iex> require String
String
```

```elixir
iex> alias String
String
```

```elixir
iex> alias String, as: Foo
String
iex> alias Foo, as: Bar
String
```

```elixir
iex> alias String.{Break, Casing, Chars}
[String.Break, String.Casing, String.Chars]
```

Little updates to section 13 of the [Getting Started](https://github.com/elixir-lang/elixir-lang.github.com/blob/master/getting-started/alias-require-and-import.markdown) may be required, so I will take care of it upon merge.

This is my very first PR to this project, but I am really eager to keep contributing.

We are using Elixir extensively at [Stampery](https://github.com/stampery), so we will try to give back as much as possible to this community. :smiley_cat:  