### PR TITLE
Improve warning output

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -386,7 +386,7 @@ defmodule Exception do
 
     case trace do
       [] -> "\n"
-      s  -> "    " <> Enum.map_join(s, "\n    ", &format_stacktrace_entry(&1)) <> "\n"
+      _ -> "    " <> Enum.map_join(trace, "\n    ", &format_stacktrace_entry(&1)) <> "\n"
     end
   end
 

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -207,7 +207,8 @@ defmodule IO do
     :elixir_errors.warn([to_chardata(message), ?\n])
   end
   def warn(message, stacktrace) when is_list(stacktrace) do
-    :elixir_errors.warn([to_chardata(message), ?\n, Exception.format_stacktrace(stacktrace)])
+    formatted = Enum.map_join(stacktrace, "\n  ", &Exception.format_stacktrace_entry(&1))
+    :elixir_errors.warn([to_chardata(message), ?\n, "  ", formatted, ?\n])
   end
 
   @doc """

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -13,7 +13,7 @@
 warn(none, File, Warning) ->
   warn(0, File, Warning);
 warn(Line, File, Warning) when is_integer(Line), is_binary(File) ->
-  warn([Warning, "\n    ", file_format(Line, File), $\n]).
+  warn([Warning, "\n  ", file_format(Line, File), $\n]).
 
 -spec warn(unicode:chardata()) -> ok.
 warn(Message) ->
@@ -21,15 +21,15 @@ warn(Message) ->
   if
     CompilerPid =/= undefined ->
       elixir_code_server:cast({register_warning, CompilerPid});
-    true -> false
+    true -> ok
   end,
-  io:put_chars(standard_error, [warning(), Message, $\n]),
+  io:put_chars(standard_error, [warning_prefix(), Message, $\n]),
   ok.
 
-warning() ->
+warning_prefix() ->
   case application:get_env(elixir, ansi_enabled) of
-    {ok, true} -> <<"\e[33mwarning! \e[0m">>;
-    _ -> <<"warning! ">>
+    {ok, true} -> <<"\e[33mwarning: \e[0m">>;
+    _ -> <<"warning: ">>
   end.
 
 %% General forms handling.

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -849,9 +849,9 @@ warn_pipe({arrow_op, {Line, _Begin, _End}, Op}, {_, [_ | _], [_ | _]}) ->
   elixir_errors:warn(Line, ?file(),
     io_lib:format(
       "parentheses are required when piping into a function call. For example:\n\n"
-      "  foo 1 ~ts bar 2 ~ts baz 3\n\n"
+      "    foo 1 ~ts bar 2 ~ts baz 3\n\n"
       "is ambiguous and should be written as\n\n"
-      "  foo(1) ~ts bar(2) ~ts baz(3)\n\n"
+      "    foo(1) ~ts bar(2) ~ts baz(3)\n\n"
       "Ambiguous pipe found at:",
       [Op, Op, Op, Op]
     )

--- a/lib/elixir/test/elixir/io_test.exs
+++ b/lib/elixir/test/elixir/io_test.exs
@@ -119,15 +119,15 @@ defmodule IOTest do
   end
 
   test "warn with chardata" do
-    assert capture_io(:stderr, fn -> IO.warn("hello") end) =~ "hello\n    (ex_unit) lib/ex_unit"
-    assert capture_io(:stderr, fn -> IO.warn('hello') end) =~ "hello\n    (ex_unit) lib/ex_unit"
-    assert capture_io(:stderr, fn -> IO.warn(:hello) end) =~ "hello\n    (ex_unit) lib/ex_unit"
-    assert capture_io(:stderr, fn -> IO.warn(13) end) =~ "13\n    (ex_unit) lib/ex_unit"
+    assert capture_io(:stderr, fn -> IO.warn("hello") end) =~ "hello\n  (ex_unit) lib/ex_unit"
+    assert capture_io(:stderr, fn -> IO.warn('hello') end) =~ "hello\n  (ex_unit) lib/ex_unit"
+    assert capture_io(:stderr, fn -> IO.warn(:hello) end) =~ "hello\n  (ex_unit) lib/ex_unit"
+    assert capture_io(:stderr, fn -> IO.warn(13) end) =~ "13\n  (ex_unit) lib/ex_unit"
     assert capture_io(:stderr, fn -> IO.warn("hello", []) end) =~ "hello\n"
     stacktrace = [{IEx.Evaluator, :eval, 4, [file: 'lib/iex/evaluator.ex', line: 108]}]
     assert capture_io(:stderr, fn -> IO.warn("hello", stacktrace) end) =~ """
     hello
-        lib/iex/evaluator.ex:108: IEx.Evaluator.eval/4
+      lib/iex/evaluator.ex:108: IEx.Evaluator.eval/4
     """
   end
 


### PR DESCRIPTION
What if we use colon as warning prefix separator and 1 indentation level for stacktrace (we don't have exception banner anyway) as it looks too wide right now?

__Before__:
<img width="647" alt="screen shot 2016-05-15 at 21 39 07" src="https://cloud.githubusercontent.com/assets/248290/15276359/47484434-1ae6-11e6-87e4-2e7113f407fd.png">

__After__:
<img width="660" alt="screen shot 2016-05-15 at 21 41 06" src="https://cloud.githubusercontent.com/assets/248290/15276358/42092eac-1ae6-11e6-9449-6aad2b47845b.png">
