### PR TITLE
URI.merge/2

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -431,7 +431,19 @@ defmodule URI do
     remove_dot_segments(tail, [head | acc], repeat)
   end
 
-  defp path_to_segments(path), do: String.split(path, ~r[/+]) |> Enum.reverse
+  def path_to_segments(path) do
+    [h | t] = String.split(path, "/")
+    reverse_and_discard_empty(t, [h])
+  end
+
+  defp reverse_and_discard_empty([], acc),
+    do: acc
+  defp reverse_and_discard_empty([h], acc),
+    do: [h | acc]
+  defp reverse_and_discard_empty(["" | t], acc),
+    do: reverse_and_discard_empty(t, acc)
+  defp reverse_and_discard_empty([h | t], acc),
+    do: reverse_and_discard_empty(t, [h | acc])
 end
 
 defimpl String.Chars, for: URI do

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -421,8 +421,6 @@ defmodule URI do
     do: remove_dot_segments(tail, [head | acc])
   defp remove_dot_segments(segments, [_, ".." | acc]),
     do: remove_dot_segments(segments, acc)
-  defp remove_dot_segments(["" | tail], acc),
-    do: remove_dot_segments(tail, ["" | acc])
   defp remove_dot_segments([head | tail], acc),
     do: remove_dot_segments(tail, [head | acc])
 

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -407,11 +407,10 @@ defmodule URI do
     [_ | base_segments] = path_to_segments(base_path)
     rel_segments = path_to_segments(rel_path)
     rel_segments ++ base_segments
-    |> remove_dot_segments
+    |> remove_dot_segments([])
     |> Enum.join("/")
   end
 
-  defp remove_dot_segments(list, acc \\ [])
   defp remove_dot_segments([], [head, ".." | acc]),
     do: remove_dot_segments([], [head | acc])
   defp remove_dot_segments([], acc), do: acc

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -385,24 +385,24 @@ defmodule URI do
       iex> URI.merge("http://example.com", "http://google.com")|> to_string
       "http://google.com"
   """
-  def merge(%URI{authority: nil}, %URI{}), do: raise ArgumentError, "you must merge onto an absolute URI"
-  def merge(%URI{}, %URI{scheme: scheme}=rel) when not is_nil(scheme) do
+  def merge(%URI{authority: nil}, _rel), do: raise ArgumentError, "you must merge onto an absolute URI"
+  def merge(%URI{}, %URI{scheme: scheme} = rel) when scheme != nil do
     rel
   end
-  def merge(%URI{}=base, %URI{path: "", query: query, fragment: fragment}=rel) do
+  def merge(%URI{} = base, %URI{path: "", query: query, fragment: fragment} = rel) do
     merge(base, %{rel | path: nil, query: query, fragment: fragment})
   end
-  def merge(%URI{}=base, %URI{path: nil, query: query, fragment: fragment}) do
+  def merge(%URI{} = base, %URI{path: nil, query: query, fragment: fragment}) do
     %{base | path: base.path, query: query || base.query, fragment: fragment}
   end
-  def merge(%URI{path: base_path}=base, %URI{path: path, query: query, fragment: fragment}) do
-    %{base | path: merge_paths(base_path, path), query: query, fragment: fragment}
+  def merge(%URI{path: base_path} = base, %URI{path: rel_path, query: query, fragment: fragment}) do
+    %{base | path: merge_paths(base_path, rel_path), query: query, fragment: fragment}
   end
   # Convert binary to URI
-  def merge(base, rel), do: merge(URI.parse(base), URI.parse(rel))
+  def merge(base, rel), do: merge(parse(base), parse(rel))
 
   defp merge_paths(nil, rel_path), do: merge_paths("/", rel_path)
-  defp merge_paths(_, "/" <> _=rel_path), do: rel_path
+  defp merge_paths(_, "/" <> _ = rel_path), do: rel_path
   defp merge_paths(base_path, rel_path) do
     [_ | base_segments] = path_to_segments(base_path)
     rel_segments = path_to_segments(rel_path)

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -385,7 +385,7 @@ defmodule URI do
       iex> URI.merge("http://example.com", "http://google.com")|> to_string
       "http://google.com"
   """
-  def merge(%URI{authority: nil}, %URI{}), do: raise ArgumentError, "You must merge onto an absolute URI"
+  def merge(%URI{authority: nil}, %URI{}), do: raise ArgumentError, "you must merge onto an absolute URI"
   def merge(%URI{}, %URI{scheme: scheme}=rel) when not is_nil(scheme) do
     rel
   end
@@ -402,7 +402,7 @@ defmodule URI do
   def merge(base, rel), do: merge(URI.parse(base), URI.parse(rel))
 
   defp merge_paths(nil, rel_path), do: merge_paths("/", rel_path)
-  defp merge_paths(_, << "/" <> _ >>=rel_path), do: rel_path
+  defp merge_paths(_, "/" <> _=rel_path), do: rel_path
   defp merge_paths(base_path, rel_path) do
     [_ | base_segments] = path_to_segments(base_path)
     rel_segments = path_to_segments(rel_path)
@@ -421,10 +421,10 @@ defmodule URI do
   defp remove_dot_segments([".." | [".." | _]=tail], acc, _repeat) do
     remove_dot_segments(tail, [".." | acc], true)
   end
-  defp remove_dot_segments([".." | []], acc, _repeat) do
+  defp remove_dot_segments([".."], acc, _repeat) do
     remove_dot_segments([], acc, true)
   end
-  defp remove_dot_segments([".." | [_ | tail]], acc, repeat) do
+  defp remove_dot_segments(["..", _ | tail], acc, repeat) do
     remove_dot_segments(tail, acc, repeat)
   end
   defp remove_dot_segments([head | tail], acc, repeat) do

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -411,25 +411,20 @@ defmodule URI do
     |> Enum.join("/")
   end
 
-  defp remove_dot_segments(list, acc \\ [], repeat \\ false)
-  defp remove_dot_segments([], acc, true), do: remove_dot_segments(Enum.reverse(acc))
-  defp remove_dot_segments([], ["" | _]=acc, false), do: acc
-  defp remove_dot_segments([], acc, false), do: ["" | acc]
-  defp remove_dot_segments(["." | tail], acc, repeat) do
-    remove_dot_segments(tail, acc, repeat)
-  end
-  defp remove_dot_segments([".." | [".." | _]=tail], acc, _repeat) do
-    remove_dot_segments(tail, [".." | acc], true)
-  end
-  defp remove_dot_segments([".."], acc, _repeat) do
-    remove_dot_segments([], acc, true)
-  end
-  defp remove_dot_segments(["..", _ | tail], acc, repeat) do
-    remove_dot_segments(tail, acc, repeat)
-  end
-  defp remove_dot_segments([head | tail], acc, repeat) do
-    remove_dot_segments(tail, [head | acc], repeat)
-  end
+  defp remove_dot_segments(list, acc \\ [])
+  defp remove_dot_segments([], [head, ".." | acc]),
+    do: remove_dot_segments([], [head | acc])
+  defp remove_dot_segments([], acc), do: acc
+  defp remove_dot_segments(["." | tail], acc),
+    do: remove_dot_segments(tail, acc)
+  defp remove_dot_segments([head | tail], ["..", ".." | _] = acc),
+    do: remove_dot_segments(tail, [head | acc])
+  defp remove_dot_segments(segments, [_, ".." | acc]),
+    do: remove_dot_segments(segments, acc)
+  defp remove_dot_segments(["" | tail], acc),
+    do: remove_dot_segments(tail, ["" | acc])
+  defp remove_dot_segments([head | tail], acc),
+    do: remove_dot_segments(tail, [head | acc])
 
   def path_to_segments(path) do
     [h | t] = String.split(path, "/")

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -225,4 +225,44 @@ defmodule URITest do
     assert URI.to_string(URI.parse("http://google.com")) == "http://google.com"
     assert URI.to_string(URI.parse("//user:password@google.com/")) == "//user:password@google.com/"
   end
+
+  test "merge/2" do
+    assert_raise ArgumentError, fn ->
+      URI.merge("/relative", "")
+    end
+
+    assert URI.merge("http://google.com/foo", "http://example.com/baz") |> to_string == "http://example.com/baz"
+
+    assert URI.merge("http://example.com", URI.parse("/foo")) |> to_string == "http://example.com/foo"
+
+    base = URI.parse("http://example.com/foo/bar")
+    assert URI.merge(base, "") |> to_string == "http://example.com/foo/bar"
+    assert URI.merge(base, "#fragment") |> to_string == "http://example.com/foo/bar#fragment"
+    assert URI.merge(base, "?query") |> to_string == "http://example.com/foo/bar?query"
+    assert URI.merge(base, %URI{path: ""}) |> to_string == "http://example.com/foo/bar"
+    assert URI.merge(base, %URI{path: "", fragment: "fragment"}) |> to_string == "http://example.com/foo/bar#fragment"
+
+    base = URI.parse("http://example.com")
+    assert URI.merge(base, "/foo") |> to_string == "http://example.com/foo"
+    assert URI.merge(base, "foo") |> to_string == "http://example.com/foo"
+
+    base = URI.parse("http://example.com/foo/bar")
+    assert URI.merge(base, "/baz") |> to_string == "http://example.com/baz"
+    assert URI.merge(base, "baz") |> to_string == "http://example.com/foo/baz"
+    assert URI.merge(base, "../baz") |> to_string == "http://example.com/baz"
+    assert URI.merge(base, "./baz") |> to_string == "http://example.com/foo/baz"
+    assert URI.merge(base, "bar/./baz") |> to_string == "http://example.com/foo/bar/baz"
+
+    base = URI.parse("http://example.com/foo/../bar")
+    assert URI.merge(base, "baz") |> to_string == "http://example.com/baz"
+
+    base = URI.parse("http://example.com/foo/./bar")
+    assert URI.merge(base, "baz") |> to_string == "http://example.com/foo/baz"
+
+    base = URI.parse("http://example.com/foo?query1")
+    assert URI.merge(base, "?query2") |> to_string == "http://example.com/foo?query2"
+
+    base = URI.parse("http://example.com/foo#fragment1")
+    assert URI.merge(base, "#fragment2") |> to_string == "http://example.com/foo#fragment2"
+  end
 end

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -254,6 +254,14 @@ defmodule URITest do
     assert URI.merge(base, "./baz") |> to_string == "http://example.com/foo/baz"
     assert URI.merge(base, "bar/./baz") |> to_string == "http://example.com/foo/bar/baz"
 
+    base = URI.parse("http://example.com/foo/bar/")
+    assert URI.merge(base, "/baz") |> to_string == "http://example.com/baz"
+    assert URI.merge(base, "baz") |> to_string == "http://example.com/foo/bar/baz"
+    assert URI.merge(base, "../baz") |> to_string == "http://example.com/foo/baz"
+    assert URI.merge(base, ".././baz") |> to_string == "http://example.com/foo/baz"
+    assert URI.merge(base, "./baz") |> to_string == "http://example.com/foo/bar/baz"
+    assert URI.merge(base, "bar/./baz") |> to_string == "http://example.com/foo/bar/bar/baz"
+
     base = URI.parse("http://example.com/foo/bar/baz")
     assert URI.merge(base, "../../foobar") |> to_string == "http://example.com/foobar"
     assert URI.merge(base, "../../../foobar") |> to_string == "http://example.com/foobar"

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -250,8 +250,14 @@ defmodule URITest do
     assert URI.merge(base, "/baz") |> to_string == "http://example.com/baz"
     assert URI.merge(base, "baz") |> to_string == "http://example.com/foo/baz"
     assert URI.merge(base, "../baz") |> to_string == "http://example.com/baz"
+    assert URI.merge(base, ".././baz") |> to_string == "http://example.com/baz"
     assert URI.merge(base, "./baz") |> to_string == "http://example.com/foo/baz"
     assert URI.merge(base, "bar/./baz") |> to_string == "http://example.com/foo/bar/baz"
+
+    base = URI.parse("http://example.com/foo/bar/baz")
+    assert URI.merge(base, "../../foobar") |> to_string == "http://example.com/foobar"
+    assert URI.merge(base, "../../../foobar") |> to_string == "http://example.com/foobar"
+    assert URI.merge(base, "../../../../../../foobar") |> to_string == "http://example.com/foobar"
 
     base = URI.parse("http://example.com/foo/../bar")
     assert URI.merge(base, "baz") |> to_string == "http://example.com/baz"
@@ -261,8 +267,10 @@ defmodule URITest do
 
     base = URI.parse("http://example.com/foo?query1")
     assert URI.merge(base, "?query2") |> to_string == "http://example.com/foo?query2"
+    assert URI.merge(base, "") |> to_string == "http://example.com/foo?query1"
 
     base = URI.parse("http://example.com/foo#fragment1")
     assert URI.merge(base, "#fragment2") |> to_string == "http://example.com/foo#fragment2"
+    assert URI.merge(base, "") |> to_string == "http://example.com/foo"
   end
 end


### PR DESCRIPTION
Merge a relative path/URI to a base URI as per RFC3986 §5.2

Examples:

    iex> URI.merge("http://example.com/foo", "/bar") |> to_string
    "http://example.com/bar"

    iex> URI.parse("http://example.com/foo") |> URI.merge("bar") |> to_string
    "http://example.com/bar"

…and more
