### PR TITLE
Disable overriding the async tag

### DIFF
--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -146,7 +146,7 @@ defmodule ExUnit.Callbacks do
 
   ## Helpers
 
-  @reserved ~w(case test line file registered)a
+  @reserved [:case, :file, :line, :test, :async, :registered]
 
   @doc false
   def __merge__(_mod, context, :ok) do

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -119,9 +119,9 @@ defmodule ExUnit.Case do
   therefore reserved:
 
     * `:case`       - the test case module
-    * `:test`       - the test name
-    * `:line`       - the line on which the test was defined
     * `:file`       - the file on which the test was defined
+    * `:line`       - the line on which the test was defined
+    * `:test`       - the test name
     * `:async`      - if the test case is in async mode
     * `:registered` - used for `ExUnit.Case.register_attribute/3` values
 
@@ -191,7 +191,7 @@ defmodule ExUnit.Case do
       config :logger, backends: []
   """
 
-  @reserved [:case, :test, :file, :line, :registered]
+  @reserved [:case, :file, :line, :test, :async, :registered]
 
   @doc false
   defmacro __using__(opts) do
@@ -207,7 +207,6 @@ defmodule ExUnit.Case do
         Enum.each [:ex_unit_tests, :tag, :moduletag, :ex_unit_registered],
           &Module.register_attribute(__MODULE__, &1, accumulate: true)
 
-        @moduletag async: async
         @before_compile ExUnit.Case
         @after_compile ExUnit.Case
         @ex_unit_async async
@@ -326,12 +325,15 @@ defmodule ExUnit.Case do
     registered_attributes = Module.get_attribute(mod, :ex_unit_registered)
     registered = Map.new(registered_attributes, &{&1, Module.get_attribute(mod, &1)})
 
+    tag = Module.get_attribute(mod, :tag)
+    async = Module.get_attribute(mod, :ex_unit_async)
+
     tags =
-      (tags ++ Module.get_attribute(mod, :tag) ++ moduletag)
+      (tags ++ tag ++ moduletag)
       |> normalize_tags
       |> validate_tags
       |> Map.put_new(:type, :test)
-      |> Map.merge(%{line: line, file: file, registered: registered})
+      |> Map.merge(%{line: line, file: file, registered: registered, async: async})
 
     test = %ExUnit.Test{name: name, case: mod, tags: tags}
     Module.put_attribute(mod, :ex_unit_tests, test)

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -288,14 +288,10 @@ defmodule ExUnitTest do
     assert output =~ "2 tests, 1 failure, 1 skipped"
   end
 
-  test "raises on reserved tag in module" do
+  test "raises on reserved tag :file in module" do
     assert_raise RuntimeError, "cannot set tag :file because it is reserved by ExUnit", fn ->
-      defmodule ReservedTag do
+      defmodule ReservedTagFile do
         use ExUnit.Case
-
-        setup do
-          {:ok, file: :foo}
-        end
 
         @tag file: "oops"
         test "sample", do: :ok
@@ -303,8 +299,19 @@ defmodule ExUnitTest do
     end
   end
 
-  test "raises on reserved tag in setup" do
-    defmodule ReservedSetupTag do
+  test "raises on reserved tag :async in module" do
+    assert_raise RuntimeError, "cannot set tag :async because it is reserved by ExUnit", fn ->
+      defmodule ReservedTagAsync do
+        use ExUnit.Case
+
+        @tag async: true
+        test "sample", do: :ok
+      end
+    end
+  end
+
+  test "raises on reserved tag :file in setup" do
+    defmodule ReservedSetupTagFile do
       use ExUnit.Case
 
       setup do
@@ -321,6 +328,26 @@ defmodule ExUnitTest do
     end)
 
     assert output =~ "trying to set reserved field :file"
+  end
+
+  test "raises on reserved tag :async in setup" do
+    defmodule ReservedSetupTagAsync do
+      use ExUnit.Case
+
+      setup do
+        {:ok, async: true}
+      end
+
+      test "sample", do: :ok
+    end
+
+    ExUnit.Server.cases_loaded()
+
+    output = capture_io(fn ->
+      assert ExUnit.run == %{failures: 1, skipped: 0, total: 1}
+    end)
+
+    assert output =~ "trying to set reserved field :async"
   end
 
   test "does not raise on reserved tag in setup_all (lower priority)" do


### PR DESCRIPTION
The `async` config is meant to be set only by the time `ExUnit.Case` is used. With these changes we make sure a proper error will be raised if we eventually try to override it, either at the setup step, for the whole case as a `moduletag`, or as a regular test tag.