### PR TITLE
Kernel Module: put_ok/1 and put_error/1

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1659,6 +1659,39 @@ defmodule Kernel do
   end
 
   @doc """
+  Inserts `value` into a a tuple of the type, `{:ok, value}`
+
+  A simple helper function to allow piping a value into a
+  tuple intended to be used as the the final call in a pipeline.
+
+  Intended to support idiomatic pipeline completion for functions.
+
+  ## Examples
+
+      iex> [1, 2, 3] |> Enum.first!() |> put_ok()
+  """
+  @spec put_ok(term) :: tuple
+  def put_ok(value) do
+    {:ok, value}
+  end
+
+  @doc """
+  Inserts `value` into a a tuple of the type, `{:error, value}`
+
+  A simple helper function to allow piping a value into a
+  return tuple, intended to support idiomatic pipeline
+  completion.
+
+  ## Examples
+
+      iex> "Invalid argument" |> put_error()
+  """
+  @spec put_error(term) :: tuple
+  def put_error(value) do
+    {:error, value}
+  end
+
+  @doc """
   Gets a value from a nested structure.
 
   Uses the `Access` module to traverse the structures


### PR DESCRIPTION
These are a couple of small wrapper functions which I think would
be very useful to developers. They create an idiomatic pathway for
returning tuples from a pipeline.

The intended use case is in any module-level function that is
entirely a pipeline, and where you would like to return the value
that is the result of a pipeline of functions in tuple form, and
where you know the result of your pipeline will be either :ok or
:error with certainty.

For a simplistic example, suppose I have a list of ids and I
write a simple function to take the first id and return it in an
:ok tuple. Normally I would have to do something like this:

    def return_first(id_list) do
      first_id = id_list |> List.first!()
      {:ok, first_id}
    end

And that is okay, but somehow it doesn't *feel* like idiomatic
Elixir. Here you could just do this:

    def return_first(id_list), do: id_list |> List.first!() |> put_ok()

To me, that feels a lot cleaner and clearer. It allows me to
express my intention the in a way that feels closer to how Elixir
asks me to think about programming.