### PR TITLE
Update docs for LexicalTracker

### DIFF
--- a/lib/elixir/lib/kernel/lexical_tracker.ex
+++ b/lib/elixir/lib/kernel/lexical_tracker.ex
@@ -1,9 +1,6 @@
 # This is an Elixir module responsible for tracking
 # the usage of aliases, imports and requires in the Elixir scope.
 #
-# The implementation simply stores dispatch information in an
-# ETS table and then consults this table once compilation is done.
-#
 # Note that since this is required for bootstrap, we can't use
 # any of the `GenServer.Behaviour` conveniences.
 defmodule Kernel.LexicalTracker do


### PR DESCRIPTION
We no longer store state in ETS so the paragraph is outdated and I simply removed it.
Alternatively, this paragraph could read e.g.:

> The implementation simply stores dispatch information in GenServer with two maps: one for directives and one for references.
This information is being used during compilation.

(as far as I know LexicalTracker is being used during compilation not sure to what part of build process "once compilation is done" was referring to (pardon my ignorance) :-))