### PR TITLE
Fix #3634

### DIFF
--- a/lib/mix/lib/mix/dep/converger.ex
+++ b/lib/mix/lib/mix/dep/converger.ex
@@ -16,8 +16,11 @@ defmodule Mix.Dep.Converger do
       end)
 
       Enum.each(deps, fn %Mix.Dep{app: app, deps: other_deps} ->
-        Enum.each(other_deps, fn %Mix.Dep{app: other_app} ->
-          :digraph.add_edge(graph, other_app, app)
+        Enum.each(other_deps, fn
+          %Mix.Dep{app: ^app} ->
+            Mix.raise "app #{app} lists itself as a dependency"
+          %Mix.Dep{app: other_app} ->
+            :digraph.add_edge(graph, other_app, app)
         end)
       end)
 


### PR DESCRIPTION
This should fix the issue with umbrella deps, but also any future SCMs that exhibit similar issues. 

I'm not 100% on this. I first did a check against `Mix.Project.config()[:app]` in [`Mix.SCM.Path.accepts_options/2`](https://github.com/elixir-lang/elixir/blob/master/lib/mix/lib/mix/scm/path.ex#L21) and raised if it was the same as `app`, but that seemed like the wrong place to fix the issue.

btw, I tracked the infinite recursion to [`Mix.Dep.Fetcher.do_with_depending/2`](https://github.com/elixir-lang/elixir/blob/master/lib/mix/lib/mix/dep/fetcher.ex#L136).
