### PR TITLE
Add a reference to `filter/2` to the documentation for `reject/2`.

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1610,6 +1610,8 @@ defmodule Enum do
   Returns elements of `enumerable` for which the function `fun` returns
   `false` or `nil`.
 
+  For the inverse (opposite), see `filter`.
+
   ## Examples
 
       iex> Enum.reject([1, 2, 3], fn(x) -> rem(x, 2) == 0 end)


### PR DESCRIPTION
As I was learning Elixir, i was looking for a Ruby analogy to `select`. I couldn't find it, but I found a reference to `reject`, since that's a ruby keyword that I know.  What I really wanted was the Elixir version of `select`.  If the documentation had mentioned `filter`, I wouldn't have had to continue searching.

Here we add a reference to `filter/2` for the documentation for `reject/2`.

See also this reference that will help people find `filter/2` if all they know is `select`: 

http://stackoverflow.com/questions/37404592/how-to-i-use-select-in-elixir
