### PR TITLE
Add `mix xref --callers M.f/a`

### DIFF
--- a/lib/elixir/lib/kernel/lexical_tracker.ex
+++ b/lib/elixir/lib/kernel/lexical_tracker.ex
@@ -71,10 +71,6 @@ defmodule Kernel.LexicalTracker do
   end
 
   @doc false
-  def import_dispatch(pid, {module, function, arity}) do
-    :gen_server.cast(pid, {:import_dispatch, {module, function, arity}})
-  end
-
   def import_dispatch(pid, module, fa, line, mode) do
     :gen_server.cast(pid, {:import_dispatch, module, fa, line, mode})
   end
@@ -135,10 +131,6 @@ defmodule Kernel.LexicalTracker do
     references = add_reference(state.references, module, mode)
     state = add_remote_dispatch(state, module, fa, line, mode)
     {:noreply, %{state | references: references}}
-  end
-
-  def handle_cast({:import_dispatch, {module, function, arity}}, state) do
-    {:noreply, add_import_dispatch(state, module, function, arity)}
   end
 
   def handle_cast({:import_dispatch, module, {function, arity} = fa, line, mode}, state) do

--- a/lib/elixir/src/elixir_dispatch.erl
+++ b/lib/elixir/src/elixir_dispatch.erl
@@ -139,11 +139,13 @@ do_expand_import(Meta, {Name, Arity} = Tuple, Args, Module, E, Result) ->
     {function, Receiver} ->
       elixir_lexical:record_import({Receiver, Name, Arity}, ?m(E, lexical_tracker)),
       elixir_locals:record_import(Tuple, Receiver, Module, ?m(E, function)),
+      elixir_lexical:record_remote(Receiver, Name, Arity, nil, ?line(Meta), ?m(E, lexical_tracker)),
       {ok, Receiver, Name, Args};
     {macro, Receiver} ->
       check_deprecation(Meta, Receiver, Name, Arity, E),
       elixir_lexical:record_import({Receiver, Name, Arity}, ?m(E, lexical_tracker)),
       elixir_locals:record_import(Tuple, Receiver, Module, ?m(E, function)),
+      elixir_lexical:record_remote(Receiver, Name, Arity, nil, ?line(Meta), ?m(E, lexical_tracker)),
       {ok, Receiver, expand_macro_named(Meta, Receiver, Name, Arity, Args, E)};
     {import, Receiver} ->
       case expand_require([{require, false} | Meta], Receiver, Tuple, Args, E) of

--- a/lib/elixir/src/elixir_dispatch.erl
+++ b/lib/elixir/src/elixir_dispatch.erl
@@ -142,9 +142,8 @@ do_expand_import(Meta, {Name, Arity} = Tuple, Args, Module, E, Result) ->
       {ok, Receiver, Name, Args};
     {macro, Receiver} ->
       check_deprecation(Meta, Receiver, Name, Arity, E),
-      elixir_lexical:record_import({Receiver, Name, Arity}, ?m(E, lexical_tracker)),
+      elixir_lexical:record_import(Receiver, Name, Arity, nil, ?line(Meta), ?m(E, lexical_tracker)),
       elixir_locals:record_import(Tuple, Receiver, Module, ?m(E, function)),
-      elixir_lexical:record_remote(Receiver, Name, Arity, nil, ?line(Meta), ?m(E, lexical_tracker)),
       {ok, Receiver, expand_macro_named(Meta, Receiver, Name, Arity, Args, E)};
     {import, Receiver} ->
       case expand_require([{require, false} | Meta], Receiver, Tuple, Args, E) of

--- a/lib/elixir/src/elixir_dispatch.erl
+++ b/lib/elixir/src/elixir_dispatch.erl
@@ -139,7 +139,6 @@ do_expand_import(Meta, {Name, Arity} = Tuple, Args, Module, E, Result) ->
     {function, Receiver} ->
       elixir_lexical:record_import({Receiver, Name, Arity}, ?m(E, lexical_tracker)),
       elixir_locals:record_import(Tuple, Receiver, Module, ?m(E, function)),
-      elixir_lexical:record_remote(Receiver, Name, Arity, nil, ?line(Meta), ?m(E, lexical_tracker)),
       {ok, Receiver, Name, Args};
     {macro, Receiver} ->
       check_deprecation(Meta, Receiver, Name, Arity, E),

--- a/lib/elixir/src/elixir_dispatch.erl
+++ b/lib/elixir/src/elixir_dispatch.erl
@@ -26,11 +26,11 @@ find_import(Meta, Name, Arity, E) ->
 
   case find_dispatch(Meta, Tuple, [], E) of
     {function, Receiver} ->
-      elixir_lexical:record_import({Receiver, Name, Arity}, ?m(E, lexical_tracker)),
+      elixir_lexical:record_import(Receiver, Name, Arity, ?m(E, function), ?line(Meta), ?m(E, lexical_tracker)),
       %% elixir_locals:record_import(Tuple, Receiver, ?m(E, module), ?m(E, function)),
       Receiver;
     {macro, Receiver} ->
-      elixir_lexical:record_import({Receiver, Name, Arity}, ?m(E, lexical_tracker)),
+      elixir_lexical:record_import(Receiver, Name, Arity, nil, ?line(Meta), ?m(E, lexical_tracker)),
       %% elixir_locals:record_import(Tuple, Receiver, ?m(E, module), ?m(E, function)),
       Receiver;
     _ ->
@@ -43,7 +43,7 @@ import_function(Meta, Name, Arity, E) ->
   Tuple = {Name, Arity},
   case find_dispatch(Meta, Tuple, [], E) of
     {function, Receiver} ->
-      elixir_lexical:record_import({Receiver, Name, Arity}, ?m(E, lexical_tracker)),
+      elixir_lexical:record_import(Receiver, Name, Arity, ?m(E, function), ?line(Meta), ?m(E, lexical_tracker)),
       elixir_locals:record_import(Tuple, Receiver, ?m(E, module), ?m(E, function)),
       remote_function(Meta, Receiver, Name, Arity, E);
     {macro, _Receiver} ->
@@ -137,7 +137,7 @@ expand_import(Meta, {Name, Arity} = Tuple, Args, E, Extra, External) ->
 do_expand_import(Meta, {Name, Arity} = Tuple, Args, Module, E, Result) ->
   case Result of
     {function, Receiver} ->
-      elixir_lexical:record_import({Receiver, Name, Arity}, ?m(E, lexical_tracker)),
+      elixir_lexical:record_import(Receiver, Name, Arity, ?m(E, function), ?line(Meta), ?m(E, lexical_tracker)),
       elixir_locals:record_import(Tuple, Receiver, Module, ?m(E, function)),
       {ok, Receiver, Name, Args};
     {macro, Receiver} ->

--- a/lib/elixir/src/elixir_fn.erl
+++ b/lib/elixir/src/elixir_fn.erl
@@ -99,6 +99,12 @@ capture_require(Meta, {{'.', _, [Left, Right]}, RequireMeta, Args} = Expr, E, Se
 handle_capture({local, Fun, Arity}, _Meta, _Expr, _E, _Sequential) ->
   {local, Fun, Arity};
 handle_capture({remote, Receiver, Fun, Arity}, Meta, _Expr, E, _Sequential) ->
+  if
+    is_atom(Receiver) ->
+      elixir_lexical:record_remote(Receiver, Fun, Arity, ?m(E, function), ?line(Meta), ?m(E, lexical_tracker));
+    true ->
+      ok
+  end,
   Tree = {{'.', [], [erlang, make_fun]}, Meta, [Receiver, Fun, Arity]},
   {expanded, Tree, E};
 handle_capture(false, Meta, Expr, E, Sequential) ->

--- a/lib/elixir/src/elixir_lexical.erl
+++ b/lib/elixir/src/elixir_lexical.erl
@@ -3,8 +3,8 @@
 -export([run/3, dest/1,
   record_alias/4, record_alias/2,
   record_import/6, record_import/5,
-  record_import/2, record_remote/3,
-  record_remote/6, format_error/1
+  record_remote/3, record_remote/6,
+  format_error/1
 ]).
 -include("elixir.hrl").
 
@@ -40,9 +40,6 @@ record_import(Module, FAs, Line, Warn, Ref) ->
 
 record_alias(Module, Ref) ->
   if_tracker(Ref, fun(Pid) -> ?tracker:alias_dispatch(Pid, Module), ok end).
-
-record_import({Module, Function, Arity}, Ref) ->
-  if_tracker(Ref, fun(Pid) -> ?tracker:import_dispatch(Pid, {Module, Function, Arity}), ok end).
 
 record_import(Module, Function, Arity, EnvFunction, Line, Ref) ->
   if_tracker(Ref, fun(Pid) -> ?tracker:import_dispatch(Pid, Module, {Function, Arity}, Line, mode(EnvFunction)), ok end).

--- a/lib/elixir/src/elixir_lexical.erl
+++ b/lib/elixir/src/elixir_lexical.erl
@@ -2,9 +2,9 @@
 -module(elixir_lexical).
 -export([run/3, dest/1,
   record_alias/4, record_alias/2,
-  record_import/5, record_import/2,
-  record_remote/3, record_remote/6,
-  format_error/1
+  record_import/6, record_import/5,
+  record_import/2, record_remote/3,
+  record_remote/6, format_error/1
 ]).
 -include("elixir.hrl").
 
@@ -43,6 +43,9 @@ record_alias(Module, Ref) ->
 
 record_import({Module, Function, Arity}, Ref) ->
   if_tracker(Ref, fun(Pid) -> ?tracker:import_dispatch(Pid, {Module, Function, Arity}), ok end).
+
+record_import(Module, Function, Arity, EnvFunction, Line, Ref) ->
+  if_tracker(Ref, fun(Pid) -> ?tracker:import_dispatch(Pid, Module, {Function, Arity}, Line, mode(EnvFunction)), ok end).
 
 record_remote(Module, EnvFunction, Ref) ->
   if_tracker(Ref, fun(Pid) -> ?tracker:remote_reference(Pid, Module, mode(EnvFunction)), ok end).

--- a/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
+++ b/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
@@ -48,13 +48,20 @@ defmodule Kernel.LexicalTrackerTest do
 
   test "can add module imports", config do
     D.add_import(config[:pid], String, [], 1, true)
-    D.import_dispatch(config[:pid], {String, :upcase, 1})
+    D.import_dispatch(config[:pid], String, {:upcase, 1}, 1, :compile)
     assert D.remote_references(config[:pid]) == {[String], []}
+    assert D.remote_dispatches(config[:pid]) ==
+      {%{String => %{{:upcase, 1} => [1]}}, %{}}
+
+    D.import_dispatch(config[:pid], String, {:upcase, 1}, 1, :runtime)
+    assert D.remote_references(config[:pid]) == {[String], []}
+    assert D.remote_dispatches(config[:pid]) ==
+      {%{String => %{{:upcase, 1} => [1]}}, %{String => %{{:upcase, 1} => [1]}}}
   end
 
   test "can add module with {function, arity} imports", config do
     D.add_import(config[:pid], String, [upcase: 1], 1, true)
-    D.import_dispatch(config[:pid], {String, :upcase, 1})
+    D.import_dispatch(config[:pid], String, {:upcase, 1}, 1, :compile)
     assert D.remote_references(config[:pid]) == {[String], []}
   end
 
@@ -71,7 +78,7 @@ defmodule Kernel.LexicalTrackerTest do
 
   test "used module imports are not unused", config do
     D.add_import(config[:pid], String, [], 1, true)
-    D.import_dispatch(config[:pid], {String, :upcase, 1})
+    D.import_dispatch(config[:pid], String, {:upcase, 1}, 1, :compile)
     assert D.collect_unused_imports(config[:pid]) == []
   end
 
@@ -83,14 +90,14 @@ defmodule Kernel.LexicalTrackerTest do
   test "used {module, function, arity} imports are not unused", config do
     D.add_import(config[:pid], String, [upcase: 1], 1, true)
     D.add_import(config[:pid], String, [downcase: 1], 1, true)
-    D.import_dispatch(config[:pid], {String, :upcase, 1})
+    D.import_dispatch(config[:pid], String, {:upcase, 1}, 1, :compile)
     assert D.collect_unused_imports(config[:pid]) == [{{String, :downcase, 1}, 1}]
   end
 
   test "overwriting {module, function, arity} import with module import", config do
     D.add_import(config[:pid], String, [upcase: 1], 1, true)
     D.add_import(config[:pid], String, [], 1, true)
-    D.import_dispatch(config[:pid], {String, :downcase, 1})
+    D.import_dispatch(config[:pid], String, {:downcase, 1}, 1, :compile)
     assert D.collect_unused_imports(config[:pid]) == []
   end
 

--- a/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
+++ b/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
@@ -158,8 +158,12 @@ defmodule Kernel.LexicalTrackerTest do
     assert compile_remote_calls == %{
       Bitwise => %{{:&&&, 2} => [9]},
       Integer => %{{:is_even, 1} => [9]},
-      Kernel => %{{:and, 2} => [8]},
+      Kernel => %{
+        {:and, 2} => [8],
+        {:def, 2} => [6]
+      },
       Kernel.LexicalTracker => %{{:remote_dispatches, 1} => [16]},
+      Record => %{{:is_record, 1} => [8]},
       :elixir_def => %{{:store_definition, 6} => [6]}
     }
 

--- a/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
+++ b/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
@@ -162,69 +162,38 @@ defmodule Kernel.LexicalTrackerTest do
         &Remote.func/0
         &Integer.is_even/1
 
+        &is_record/1; def b(a), do: is_record(a)
+
         Kernel.LexicalTracker.remote_dispatches(__ENV__.module)
       end |> elem(3)
       """)
 
-    assert unroll_dispatches(compile_remote_calls) == [
-      {6, Kernel, :def, 2},
-      {6, :elixir_def, :store_definition, 6},
-      {8, Kernel, :and, 2},
-      {8, Record, :is_record, 1},
-      {9, Bitwise, :&&&, 2},
-      {9, Integer, :is_even, 1},
-      {15, Kernel, :and, 2},
-      {15, Record, :is_record, 1},
-      {18, Bitwise, :&&&, 2},
-      {18, Integer, :is_even, 1},
-      {21, Record, :extract, 2},
-      {21, :erlang, :make_fun, 3},
-      {22, Kernel, :and, 2},
-      {22, Record, :is_record, 1},
-      {22, :erlang, :>, 2},
-      {22, :erlang, :andalso, 2},
-      {22, :erlang, :element, 2},
-      {22, :erlang, :is_atom, 1},
-      {22, :erlang, :is_tuple, 1},
-      {22, :erlang, :tuple_size, 1},
-      {23, Remote, :func, 0},
-      {23, :erlang, :make_fun, 3},
-      {24, Remote, :func, 0},
-      {24, :erlang, :make_fun, 3},
-      {25, Bitwise, :&&&, 2},
-      {25, Integer, :is_even, 1},
-      {25, :erlang, :==, 2},
-      {25, :erlang, :band, 2},
-      {27, Kernel.LexicalTracker, :remote_dispatches, 1}
-    ]
+    compile_remote_calls = unroll_dispatches(compile_remote_calls)
+    assert {6, Kernel, :def, 2} in compile_remote_calls
+    assert {8, Record, :is_record, 1} in compile_remote_calls
+    assert {9, Integer, :is_even, 1} in compile_remote_calls
+    assert {15, Record, :is_record, 1} in compile_remote_calls
+    assert {18, Integer, :is_even, 1} in compile_remote_calls
+    assert {21, Record, :extract, 2} in compile_remote_calls
+    assert {22, Record, :is_record, 1} in compile_remote_calls
+    assert {23, Remote, :func, 0} in compile_remote_calls
+    assert {24, Remote, :func, 0} in compile_remote_calls
+    assert {25, Integer, :is_even, 1} in compile_remote_calls
+    assert {27, Kernel, :def, 2} in compile_remote_calls
+    assert {27, Record, :is_record, 1} in compile_remote_calls
+    assert {29, Kernel.LexicalTracker, :remote_dispatches, 1} in compile_remote_calls
 
-    assert unroll_dispatches(runtime_remote_calls) == [
-      {7, Record, :extract, 2},
-      {8, :erlang, :>, 2},
-      {8, :erlang, :andalso, 2},
-      {8, :erlang, :element, 2},
-      {8, :erlang, :is_atom, 1},
-      {8, :erlang, :is_tuple, 1},
-      {8, :erlang, :tuple_size, 1},
-      {9, :erlang, :==, 2},
-      {9, :erlang, :band, 2},
-      {12, Remote, :func, 0},
-      {13, Remote, :func, 0},
-      {14, Record, :extract, 2},
-      {14, :erlang, :make_fun, 3},
-      {15, :erlang, :>, 2},
-      {15, :erlang, :andalso, 2},
-      {15, :erlang, :element, 2},
-      {15, :erlang, :is_atom, 1},
-      {15, :erlang, :is_tuple, 1},
-      {15, :erlang, :tuple_size, 1},
-      {16, Remote, :func, 0},
-      {16, :erlang, :make_fun, 3},
-      {17, Remote, :func, 0},
-      {17, :erlang, :make_fun, 3},
-      {18, :erlang, :==, 2},
-      {18, :erlang, :band, 2}
-    ]
+    runtime_remote_calls = unroll_dispatches(runtime_remote_calls)
+    assert {7, Record, :extract, 2} in runtime_remote_calls
+    assert {8, :erlang, :is_tuple, 1} in runtime_remote_calls
+    assert {12, Remote, :func, 0} in runtime_remote_calls
+    assert {13, Remote, :func, 0} in runtime_remote_calls
+    assert {14, Record, :extract, 2} in runtime_remote_calls
+    assert {15, :erlang, :is_tuple, 1} in runtime_remote_calls
+    assert {16, Remote, :func, 0} in runtime_remote_calls
+    assert {17, Remote, :func, 0} in runtime_remote_calls
+    assert {18, :erlang, :==, 2} in runtime_remote_calls
+    assert {27, :erlang, :is_tuple, 1} in runtime_remote_calls
   end
 
   defp unroll_dispatches(dispatches) do

--- a/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
+++ b/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
@@ -204,10 +204,9 @@ defmodule Kernel.LexicalTrackerTest do
   end
 
   defp unroll_dispatches(dispatches) do
-    for({module, fals} <- dispatches,
+    for {module, fals} <- dispatches,
         {{func, arity}, lines} <- fals,
         line <- lines,
-        do: {line, module, func, arity})
-    |> Enum.sort()
+        do: {line, module, func, arity}
   end
 end

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -168,7 +168,7 @@ defmodule Mix.Tasks.Xref do
     ["  ", file, ?:, Integer.to_string(line), ?\n]
   end
 
-  ## Unreachable helpers
+  ## "Unreachable" helpers
 
   @protocol_builtins for {_, type} <- Protocol.__builtin__(), do: type
 
@@ -231,7 +231,7 @@ defmodule Mix.Tasks.Xref do
       do: [file, ":", to_string(line), ": ", Exception.format_mfa(module, func, arity), ?\n]
   end
 
-  ## Callers helpers
+  ## "Callers" helpers
 
   defp filter_for_callee(callee) do
     mfa_list =

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -86,6 +86,8 @@ defmodule Mix.Tasks.Xref do
     callee
     |> filter_for_callee()
     |> do_callers()
+
+    :ok
   end
 
   ## Unreachable
@@ -224,8 +226,6 @@ defmodule Mix.Tasks.Xref do
     calls
     |> Enum.sort()
     |> Enum.each(&IO.write(["  ", format_call(&1), ?\n]))
-
-    {file, calls}
   end
 
   defp format_call({module, func, arity, lines}) do

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -42,7 +42,7 @@ defmodule Mix.Tasks.Xref do
   @doc """
   Runs this task.
   """
-  @spec run(OptionParser.argv) :: :ok | :error | [{Path.t, [{atom, atom, non_neg_integer, [pos_integer]}]}]
+  @spec run(OptionParser.argv) :: :ok | :error
   def run(args) do
     {opts, _} =
       OptionParser.parse!(args, strict: @switches)

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -221,21 +221,14 @@ defmodule Mix.Tasks.Xref do
   ## Print callers
 
   defp print_calls(file, calls) do
-    IO.puts(["file: ", file])
-
     calls
     |> Enum.sort()
-    |> Enum.each(&IO.puts(["  ", format_call(&1)]))
+    |> Enum.each(&IO.write(format_call(file, &1)))
   end
 
-  defp format_call({module, func, arity, lines}) do
-    lines =
-      lines
-      |> Enum.reverse()
-      |> Enum.map(&to_string/1)
-      |> Enum.intersperse(",")
-
-    [Exception.format_mfa(module, func, arity), ":", lines]
+  defp format_call(file, {module, func, arity, lines}) do
+    for line <- Enum.sort(lines),
+      do: [file, ":", to_string(line), ": ", Exception.format_mfa(module, func, arity), ?\n]
   end
 
   ## Callers helpers

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -141,7 +141,7 @@ defmodule Mix.Tasks.Xref do
   defp print_warnings(file, entries) do
     prefix = IO.ANSI.format([:yellow, "warning: "])
     entries
-    |> Enum.sort
+    |> Enum.sort()
     |> Enum.each(&IO.write(:stderr, [prefix, format_warning(file, &1), ?\n]))
   end
 

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -221,11 +221,11 @@ defmodule Mix.Tasks.Xref do
   ## Print callers
 
   defp print_calls(file, calls) do
-    IO.write(["file: ", file, ?\n])
+    IO.puts(["file: ", file])
 
     calls
     |> Enum.sort()
-    |> Enum.each(&IO.write(["  ", format_call(&1), ?\n]))
+    |> Enum.each(&IO.puts(["  ", format_call(&1)]))
   end
 
   defp format_call({module, func, arity, lines}) do

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -321,10 +321,9 @@ defmodule Mix.Tasks.XrefTest do
     end
     """,
     """
-    file: lib/a.ex
-      A.a/0:2
-      A.a/1:3
-      A.b/0:4
+    lib/a.ex:2: A.a/0
+    lib/a.ex:3: A.a/1
+    lib/a.ex:4: A.b/0
     """
   end
 
@@ -338,9 +337,8 @@ defmodule Mix.Tasks.XrefTest do
     end
     """,
     """
-    file: lib/a.ex
-      A.a/0:2
-      A.a/1:3
+    lib/a.ex:2: A.a/0
+    lib/a.ex:3: A.a/1
     """
   end
 
@@ -354,8 +352,7 @@ defmodule Mix.Tasks.XrefTest do
     end
     """,
     """
-    file: lib/a.ex
-      A.a/0:2
+    lib/a.ex:2: A.a/0
     """
   end
 
@@ -374,9 +371,8 @@ defmodule Mix.Tasks.XrefTest do
     end
     """,
     """
-    file: lib/b.ex
-      A.a/0:5
-      A.a_macro/0:4
+    lib/b.ex:5: A.a/0
+    lib/b.ex:4: A.a_macro/0
     """
   end
 
@@ -390,9 +386,9 @@ defmodule Mix.Tasks.XrefTest do
       def a(a, b), do: E.map(a, b)
     end
     """, """
-    file: lib/a.ex
-      Enum.flatten/1:4
-      Enum.map/2:4,6
+    lib/a.ex:4: Enum.flatten/1
+    lib/a.ex:4: Enum.map/2
+    lib/a.ex:6: Enum.map/2
     """
   end
 
@@ -411,22 +407,12 @@ defmodule Mix.Tasks.XrefTest do
       def b(a), do: parse(a)
     end
     """, """
-    file: lib/a.ex
-      Integer.is_even/1:4,7,10
-      Integer.parse/1:5,8,11
-    """
-  end
-
-  test "callers: groups multiple calls" do
-    assert_callers "A", """
-    defmodule A do
-      def a, do: A.a()
-      def b, do: A.a()
-    end
-    """,
-    """
-    file: lib/a.ex
-      A.a/0:2,3
+    lib/a.ex:4: Integer.is_even/1
+    lib/a.ex:7: Integer.is_even/1
+    lib/a.ex:10: Integer.is_even/1
+    lib/a.ex:5: Integer.parse/1
+    lib/a.ex:8: Integer.parse/1
+    lib/a.ex:11: Integer.parse/1
     """
   end
 

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -325,8 +325,7 @@ defmodule Mix.Tasks.XrefTest do
       A.a/0:2
       A.a/1:3
       A.b/0:4
-    """,
-    [{"lib/a.ex", [{A, :a, 0, [2]}, {A, :a, 1, [3]}, {A, :b, 0, [4]}]}]
+    """
   end
 
   test "callers: prints callers of specified Module.func" do
@@ -342,8 +341,7 @@ defmodule Mix.Tasks.XrefTest do
     file: lib/a.ex
       A.a/0:2
       A.a/1:3
-    """,
-    [{"lib/a.ex", [{A, :a, 0, [2]}, {A, :a, 1, [3]}]}]
+    """
   end
 
   test "callers: prints callers of specified Module.func/arity" do
@@ -358,8 +356,7 @@ defmodule Mix.Tasks.XrefTest do
     """
     file: lib/a.ex
       A.a/0:2
-    """,
-    [{"lib/a.ex", [{A, :a, 0, [2]}]}]
+    """
   end
 
   test "callers: lists compile calls and macros" do
@@ -380,8 +377,7 @@ defmodule Mix.Tasks.XrefTest do
     file: lib/b.ex
       A.a/0:5
       A.a_macro/0:4
-    """,
-    [{"lib/b.ex", [{A, :a, 0, [5]}, {A, :a_macro, 0, [4]}]}]
+    """
   end
 
   test "callers: handles aliases" do
@@ -397,7 +393,7 @@ defmodule Mix.Tasks.XrefTest do
     file: lib/a.ex
       Enum.flatten/1:4
       Enum.map/2:4,6
-    """, [{"lib/a.ex", [{Enum, :flatten, 1, [4]}, {Enum, :map, 2, [6, 4]}]}]
+    """
   end
 
   test "callers: handles imports" do
@@ -418,8 +414,7 @@ defmodule Mix.Tasks.XrefTest do
     file: lib/a.ex
       Integer.is_even/1:4,7,10
       Integer.parse/1:5,8,11
-    """,
-    [{"lib/a.ex", [{Integer, :is_even, 1, [10, 7, 4]}, {Integer, :parse, 1, [11, 8, 5]}]}]
+    """
   end
 
   test "callers: groups multiple calls" do
@@ -432,8 +427,7 @@ defmodule Mix.Tasks.XrefTest do
     """
     file: lib/a.ex
       A.a/0:2,3
-    """,
-    [{"lib/a.ex", [{A, :a, 0, [3, 2]}]}]
+    """
   end
 
   test "callers: no argument gives error" do
@@ -470,14 +464,14 @@ defmodule Mix.Tasks.XrefTest do
     end
   end
 
-  defp assert_callers(callee, contents_a, contents_b \\ "", expected_print, expected_result) do
+  defp assert_callers(callee, contents_a, contents_b \\ "", expected) do
     in_fixture "no_mixfile", fn ->
       File.write!("lib/a.ex", contents_a)
       File.write!("lib/b.ex", contents_b)
 
       assert capture_io(fn ->
-        assert Mix.Task.run("xref", ["--callers", callee]) == expected_result
-      end) == expected_print
+        assert Mix.Task.run("xref", ["--callers", callee]) == :ok
+      end) == expected
     end
   end
 end

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -393,23 +393,25 @@ defmodule Mix.Tasks.XrefTest do
   end
 
   test "callers: handles imports" do
-    assert_callers "Integer", """
+    assert_callers "Integer", ~S"""
     defmodule A do
       import Integer
 
       &is_even/1
       &parse/1
 
-      _ = is_even(Enum.random([1, 2, 3]))
+      _ = is_even(Enum.random([1]))
       _ = parse("2")
 
       def a(a), do: is_even(a)
       def b(a), do: parse(a)
+      _ = is_even(Enum.random([1])); def c(a), do: is_even(a)
     end
     """, """
     lib/a.ex:4: Integer.is_even/1
     lib/a.ex:7: Integer.is_even/1
     lib/a.ex:10: Integer.is_even/1
+    lib/a.ex:12: Integer.is_even/1
     lib/a.ex:5: Integer.parse/1
     lib/a.ex:8: Integer.parse/1
     lib/a.ex:11: Integer.parse/1


### PR DESCRIPTION
Related: #4656.

`mix xref --callers` accepts a `Module`, `Module.function`, or `Module.function/arity`.

Output looks like:

```
file: lib/a.ex
  A.a/0:2,3
```

I chose this format because:
  * it looks good if you are simply manually using the task
  * file paths can have all kinds of weird characters in them (like `:` and `"` and `,`) and this should hopefully simplify parsing for libraries that will rely on the output of this task without having to define any kind of escaping

The task also returns data like:
```elixir
[{"lib/a.ex", [{A, :a, 0, [3, 2]}]}]
```
from `run`, so if you use it from within Elixir itself you don't have to parse anything.

Do we need any additional switches, like maybe `--silent` (for use from Elixir apps that will simply use the return value of `run`)?

I also added some missing `record_remote`s to get all of our compile dispatches in, and also fixed a bug where xref was not checking captured remotes.

/cc @josevalim 