### PR TITLE
Use square brackets for IPv6 in URI.to_string/1

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -326,13 +326,6 @@ defmodule URI do
     destructure [_, _, scheme, _, authority, path, _, query, _, fragment], parts
     {userinfo, host, port} = split_authority(authority)
 
-    authority = authority &&
-      IO.iodata_to_binary([
-        if(userinfo, do: userinfo <> "@", else: ""),
-        host || "",
-        if(port, do: ":" <> Integer.to_string(port), else: "")
-      ])
-
     scheme = normalize_scheme(scheme)
     port   = port || (scheme && default_port(scheme))
 
@@ -349,8 +342,8 @@ defmodule URI do
     components = Regex.run ~r/(^(.*)@)?(\[[a-zA-Z0-9:.]*\]|[^:]*)(:(\d*))?/, s
 
     destructure [_, _, userinfo, host, _, port], nillify(components)
+    host = if host, do: host |> String.trim_leading("[") |> String.trim_trailing("]")
     port = if port, do: String.to_integer(port)
-    host = if host, do: host |> String.lstrip(?[) |> String.rstrip(?])
 
     {userinfo, host, port}
   end

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -468,7 +468,12 @@ defimpl String.Chars, for: URI do
     authority
   end
   defp extract_authority(%{host: host, userinfo: userinfo, port: port}) do
-    if(userinfo, do: userinfo <> "@" <> host, else: host) <>
+    # According to the grammar at
+    # https://tools.ietf.org/html/rfc3986#appendix-A, a "host" can have a colon
+    # in it only if it's an IPv6 or "IPvFuture" address), so if there's a colon
+    # in the host we can safely surround it with [].
+    if(userinfo, do: userinfo <> "@", else: "") <>
+    if(String.contains?(host, ":"), do: "[" <> host <> "]", else: host) <>
     if(port, do: ":" <> Integer.to_string(port), else: "")
   end
 end

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -221,6 +221,8 @@ defmodule URITest do
     assert to_string(URI.parse("//google.com/elixir")) == "//google.com/elixir"
     assert to_string(URI.parse("//google.com:8080/elixir")) == "//google.com:8080/elixir"
     assert to_string(URI.parse("//user:password@google.com/")) == "//user:password@google.com/"
+    assert to_string(URI.parse("http://[2001:db8::]:8080")) == "http://[2001:db8::]:8080"
+    assert to_string(URI.parse("http://[2001:db8::]")) == "http://[2001:db8::]"
 
     assert URI.to_string(URI.parse("http://google.com")) == "http://google.com"
     assert URI.to_string(URI.parse("//user:password@google.com/")) == "//user:password@google.com/"

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -189,17 +189,21 @@ defmodule URITest do
 
     Enum.each addrs, fn(addr) ->
       simple_uri = URI.parse("http://[#{addr}]/")
+      assert simple_uri.authority == "[#{addr}]"
       assert simple_uri.host == addr
 
       userinfo_uri = URI.parse("http://user:pass@[#{addr}]/")
+      assert userinfo_uri.authority == "user:pass@[#{addr}]"
       assert userinfo_uri.host == addr
       assert userinfo_uri.userinfo == "user:pass"
 
       port_uri = URI.parse("http://[#{addr}]:2222/")
+      assert port_uri.authority == "[#{addr}]:2222"
       assert port_uri.host == addr
       assert port_uri.port == 2222
 
       userinfo_port_uri = URI.parse("http://user:pass@[#{addr}]:2222/")
+      assert userinfo_port_uri.authority == "user:pass@[#{addr}]:2222"
       assert userinfo_port_uri.host == addr
       assert userinfo_port_uri.userinfo == "user:pass"
       assert userinfo_port_uri.port == 2222


### PR DESCRIPTION
(related to #4685)

According to the grammar at https://tools.ietf.org/html/rfc3986#appendix-A, a host can have colons in it only if it's a "IPv6" or a "IPvFuture"; in both cases, it's expected to be surrounded by square brackets. This means that when converting a URI to a string in `URI.to_string/1`, we can simply surround a host with square brackets if it contains one or more colons.

Actually, I'm not sure why we're stripping brackets *from the authority* when parsing IPv6 addresses. If given `"http://[2001:db8::]:8080"`, shouldn't the authority be `"[2001:db8::]:8080"`? And actually, shouldn't the host be `"[2001:db8::]"` as well? Give the following productions of the grammar:

```
host          = IP-literal / IPv4address / reg-name
[...]
IP-literal    = "[" ( IPv6address / IPvFuture  ) "]"
```

In this case, we wouldn't have to do anything special in `URI.to_string/1` as we'd get this for free from just dumping what we parsed in `URI.parse/1`.