### PR TITLE
Small wording fix to String.split/3 documentation

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -271,7 +271,7 @@ defmodule String do
   The string is split into as many parts as possible by
   default, but can be controlled via the `parts: pos_integer` option.
   If you pass `parts: :infinity`, it will return all possible parts
-  (being this one the default behaviour).
+  (`:infinity` is the default).
 
   Empty strings are only removed from the result if the
   `trim` option is set to `true` (default is `false`).


### PR DESCRIPTION
Prior wording of this was awkward. This makes it much clearer that `:infinity` is the default `parts:` option.