### PR TITLE
Show whitespace in ExUnit diffs

### DIFF
--- a/lib/ex_unit/examples/difference.exs
+++ b/lib/ex_unit/examples/difference.exs
@@ -25,6 +25,12 @@ defmodule Difference do
     assert string1 == string2
   end
 
+  test "whitespace" do
+    string1 = "spac e"
+    string2 = "spacee  "
+    assert string1 == string2
+  end
+
   test "large strings" do
     string1 = "oops"
     string2 = "really long string that should not emit diff"

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -295,11 +295,11 @@ defmodule ExUnit.Diff do
 
   defp format_fragment({:eq, content}, _), do: content
 
-  defp format_fragment({:del, content}, formatter) do
-    formatter.(:diff_delete, content)
+  defp format_fragment({type, content}, formatter) do
+    content = String.replace(content, " ", "·")
+    formatter.(translate_type(type), content)
   end
 
-  defp format_fragment({:ins, content}, formatter) do
-    formatter.(:diff_insert, content)
-  end
+  def translate_type(:ins), do: :diff_insert
+  def translate_type(:del), do: :diff_delete
 end

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -28,7 +28,7 @@ defmodule ExUnit.DiffTest do
   test "strings" do
     string1 = "fox hops over \"the dog"
     string2 = "fox jumps over the lazy cat"
-    expected = ~S<"fox {ho}[jum]ps over {\"}the {dog}[lazy cat]">
+    expected = ~S<"fox {ho}[jum]ps over {\"}the {dog}[lazy·cat]">
     assert format(string1, string2, &formatter/2) == expected
     assert format(string1, <<193, 31>>, &formatter/2) == nil
 
@@ -50,7 +50,7 @@ defmodule ExUnit.DiffTest do
 
     charlist1 = 'fox hops over \'the dog'
     charlist2 = 'fox jumps over the lazy cat'
-    expected = "'fox {ho}[jum]ps over {\\'}the {dog}[lazy cat]'"
+    expected = "'fox {ho}[jum]ps over {\\'}the {dog}[lazy·cat]'"
     assert format(charlist1, charlist2, &formatter/2) == expected
   end
 


### PR DESCRIPTION
Hello! I had a go at showing whitespace in diffs.

This now replaces diff fragments entirely made of spaces with a sequence of the open box character (␣), for legibility.

An alternative to this character could be changing the background colour.

I was unsure how to test this. There doesn't seem to be any for the CliFormatter? I have added an ExUnit example.

Related to #4682 