### PR TITLE
Clarify args in docs for `apply`

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -58,7 +58,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Invokes the given `fun` with the array of arguments `args`.
+  Invokes the given `fun` with the list of arguments `args`.
 
   Inlined by the compiler.
 
@@ -74,7 +74,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Invokes the given `fun` from `module` with the array of arguments `args`.
+  Invokes the given `fun` from `module` with the list of arguments `args`.
 
   Inlined by the compiler.
 


### PR DESCRIPTION
I think we should avoid calling lists arrays. I looked up the docs for `Kernel.apply` to see if it would accept a tuple, and was surprised to see the word "array" in there.

I did a quick search through the source, and the only other mention of "array" is in the docs for `Logger.Formatter.compile/1`, but it can return either List or Tuple, so I'm less inclined to change it to "a list".