### PR TITLE
Clarify the use of `async: true`

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -11,9 +11,9 @@ defmodule ExUnit.Case do
 
   When used, it accepts the following options:
 
-    * :async - configure Elixir to run that specific test case in parallel with
-      others. Must be used for performance when your test cases do not change
-      any global state. It defaults to `false`.
+    * :async - configure this specific test case to able to run in parallel
+      with other test cases. May be used for performance when this test case
+      does not change any global state. Defaults to `false`.
 
   This module automatically includes all callbacks defined in
   `ExUnit.Callbacks`. See that module's documentation for more


### PR DESCRIPTION
The documentation here a bit confusingly worded to make it sound like with `async: true` each `test` declaration in the case would run asynchronously. I've tried to reword it and make it clear that the flag is set for the test case itself.

Example of confusion: #3580. I found that thread when trying to find the same answer for why six tests with `:timer.sleep(1000)` were running in serial within a single test case.