### PR TITLE
Parameterize EEx tokenizer

### DIFF
--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -3,6 +3,7 @@ defmodule EEx.Compiler do
 
   # When changing this setting, don't forget to update the docs for EEx
   @default_engine EEx.SmartEngine
+  @default_tokenizer EEx.Tokenizer
 
   @doc """
   This is the compilation entry point. It glues the tokenizer
@@ -13,7 +14,8 @@ defmodule EEx.Compiler do
     file   = opts[:file] || "nofile"
     line   = opts[:line] || 1
     trim   = opts[:trim] || false
-    case EEx.Tokenizer.tokenize(source, line, trim: trim) do
+    tokenizer = opts[:tokenizer] || @default_tokenizer
+    case tokenizer.tokenize(source, line, trim: trim) do
       {:ok, tokens} ->
         state = %{engine: opts[:engine] || @default_engine,
                   file: file, line: line, quoted: [], start_line: nil}


### PR DESCRIPTION
Hi!

I'm currently working on a little templating language, and I wish to avoid re-implementing as much of EEx as possible. The `EEx.Compiler` implements much that I need, but due to the tokenizer being fixed I would have to maintain a near identical copy.

One solution that would be easier for me would be to parameterize the tokenizer module so that I could pass in my own tokenizer that outputs the same tokens for a different given syntax.

What do you think of this? If this seems sensible I could also create a behaviour for tokenizer modules.