### PR TITLE
Better logger for console with direct access

### DIFF
--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -77,10 +77,10 @@ defmodule Logger.Backends.Console do
       format_event(level, msg, ts, md, state)
       |> color_event(level, colors)
     try do
-      IO.write(device, output)
+      send(device, {:io_request, self(), self(), {:put_chars, :unicode, output}})
     rescue
       ArgumentError ->
-        IO.write(device, Logger.Formatter.prune(output))
+        send(device, {:io_request, self(), self(), {:put_chars, :unicode, Logger.Formatter.prune(output)}})
     end
   end
 


### PR DESCRIPTION
Hi I've been doing some experiments that you can try out and veryify the result:
https://github.com/olafura/test_io

With sending messages directly to user_drv we are able to have less blocking, significantly less cpu time and less memory usage over all.

I'm making these changes to Logger and not IO directly since IO does a lot more than just print things to the console.

It's not faster per se at putting thing on the terminal but that is something that is going to be difficult to make faster according to my tests.

We might want to handle these reply cases:
https://github.com/erlang/otp/blob/maint/lib/stdlib/src/io.erl#L573
I'm currently pushing everything back to self so it won't be blocking