### PR TITLE
mix profile.fprof --warmup

### DIFF
--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -33,6 +33,7 @@ defmodule Mix.Tasks.Profile.Fprof do
     * `--no-archives-check` - do not check archives
     * `--no-start`      - do not start applications after compilation
     * `--no-elixir-version-check` - do not check the Elixir version from mix.exs
+    * `--no-warmup`     - do not execute code once before profiling
 
   ## Profile output
 
@@ -106,7 +107,8 @@ defmodule Mix.Tasks.Profile.Fprof do
 
   @switches [parallel_require: :keep, require: :keep, eval: :keep, config: :keep,
              compile: :boolean, deps_check: :boolean, start: :boolean, archives_check: :boolean,
-             details: :boolean, callers: :boolean, sort: :string, elixir_version_check: :boolean]
+             details: :boolean, callers: :boolean, sort: :string, elixir_version_check: :boolean,
+             warmup: :boolean]
 
   @spec run(OptionParser.argv) :: :ok
   def run(args) do
@@ -201,6 +203,11 @@ defmodule Mix.Tasks.Profile.Fprof do
   end
 
   defp profile_and_analyse(fun, opts) do
+    if Keyword.get(opts, :warmup, true) do
+      IO.puts "Warmup..."
+      fun.()
+    end
+
     sorting = case Keyword.get(opts, :sort, "acc") do
       "acc" -> :acc
       "own" -> :own

--- a/lib/mix/test/mix/tasks/profile.fprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.fprof_test.exs
@@ -85,4 +85,16 @@ defmodule Mix.Tasks.Profile.FprofTest do
       end
     end
   end
+
+  test "warmup", context do
+    in_tmp context.test, fn ->
+      assert capture_io(fn ->
+        Fprof.run(["-e", "Enum.each(1..5, fn(_) -> MapSet.new end)"])
+      end) =~ "Warmup..."
+
+      refute capture_io(fn ->
+        Fprof.run(["-e", "Enum.each(1..5, fn(_) -> MapSet.new end)", "--no-warmup"])
+      end) =~ "Warmup..."
+    end
+  end
 end

--- a/lib/mix/test/mix/tasks/profile.fprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.fprof_test.exs
@@ -22,15 +22,17 @@ defmodule Mix.Tasks.Profile.FprofTest do
   end
 
   test "profiles the script", context do
-    git_repo = fixture_path("git_repo/lib/git_repo.ex")
-
     in_tmp context.test, fn ->
+      profile_script_name = "profile_script.ex"
+
+      File.write! profile_script_name, """
+      Enum.each(1..5, fn(_) -> MapSet.new end)
+      """
+
       assert capture_io(fn ->
-        Fprof.run([git_repo])
-      end) =~ ~r(:elixir_module\.compile/4 *\d+ *\d+\.\d{3} *\d+\.\d{3})
+        Fprof.run([profile_script_name])
+      end) =~ ~r(MapSet\.new/0 *5 *\d+\.\d{3} *\d+\.\d{3})
     end
-  after
-    purge [GitRepo]
   end
 
   test "expands callers", context do


### PR DESCRIPTION
Implements #4723.

Had to modify an existing test that was profiling a file which defined a module, because now that warmup happens by default it was causing a module redefined error during the test suite. Let me know if there is some other way that should have been solved.

/cc @josevalim 