### PR TITLE
Fix default encoding for put_chars in StringIO

### DIFF
--- a/lib/elixir/test/elixir/string_io_test.exs
+++ b/lib/elixir/test/elixir/string_io_test.exs
@@ -140,7 +140,7 @@ defmodule StringIOTest do
   test "IO.binwrite with utf8" do
     pid = start("")
     assert IO.binwrite(pid, "あいう") == :ok
-    assert contents(pid) == {"", "あいう"}
+    assert contents(pid) == {"", <<195, 163, 194, 129, 194, 130, 195, 163, 194, 129, 194, 132, 195, 163, 194, 129, 194, 134>>}
   end
 
   test "IO.puts" do


### PR DESCRIPTION
StringIO is a unicode device. I wonder how many people rely on this bug? `IO.binwrite/2` says do not use this on a unicode device.