### PR TITLE
Fixed typo in Logger reset_metadata documentation

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -325,7 +325,7 @@ defmodule Logger do
   end
 
   @doc """
-  Resets the current process metadata to the the given keyword list.
+  Resets the current process metadata to the given keyword list.
   """
   def reset_metadata(keywords \\ []) do
     {enabled?, _metadata} = __metadata__()


### PR DESCRIPTION
The word "the" is repeated
