### PR TITLE
Fix reference to "archive" in Mix.Tasks.Escript.Install

### DIFF
--- a/lib/mix/lib/mix/tasks/escript.install.ex
+++ b/lib/mix/lib/mix/tasks/escript.install.ex
@@ -28,7 +28,7 @@ defmodule Mix.Tasks.Escript.Install do
 
   ## Command line options
 
-    * `--sha512` - checks the archive matches the given sha512 checksum
+    * `--sha512` - checks the escript matches the given sha512 checksum
 
     * `--force` - forces installation without a shell prompt; primarily
       intended for automation in build systems like make


### PR DESCRIPTION
Seems like a missed find/replace from archive.install?