### PR TITLE
General Fixes for v1.3.rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -368,7 +368,7 @@ By restricting hierarchies in favor of named setups, it is straight-forward for 
 #### Mix
 
   * [Mix] Improve task not found message when Mix would include the not found task as a suggestion due to different casing
-  * [Mix] Ignore lock revision when the lock is out of date when updating Mix dependencies. Before this fix, git tags and branches in the lock file would erroneously take higher precedence than the one in `mix.exs`
+  * [Mix] Ignore lock revision when the lock is out of date when updating Mix dependencies. Before this fix, Git tags and branches in the lock file would erroneously take higher precedence than the one in `mix.exs`
   * [Mix] Only recompile empty Elixir files if they change instead of recompiling them on every run
   * [Mix] Ensure .app file is written in UTF-8 (this allows app descriptions to contain UTF-8 characters)
   * [Mix.Dep] Always specify the `:env` option internally for dependencies to avoid false positives in the dependency resolution

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -22,7 +22,7 @@ These are the values Elixir developers should aspire to:
     * In particular, respect differences of opinion. It is important that we resolve disagreements and differing views constructively.
   * Avoid destructive behavior
     * Derailing: stay on topic; if you want to talk about something else, start a new conversation.
-    * Unconstructive criticism: don't merely decry the current state of affairs; offer—or at least solicit—suggestions as to how things may be improved.
+    * Unconstructive criticism: don't merely decry the current state of affairs; offer (or at least solicit) suggestions as to how things may be improved.
     * Snarking (pithy, unproductive, sniping comments).
 
 The following actions are explicitly forbidden:

--- a/bin/elixir.bat
+++ b/bin/elixir.bat
@@ -21,7 +21,7 @@ echo.
 echo   --app APP                   Starts the given app and its dependencies (*)
 echo   --cookie COOKIE             Sets a cookie for this distributed node
 echo   --detached                  Starts the Erlang VM detached from console
-echo   --erl SWITCHES              Switches to be passed down to erlang (*)
+echo   --erl SWITCHES              Switches to be passed down to Erlang (*)
 echo   --hidden                    Makes a hidden node
 echo   --logger-otp-reports BOOL   Enables or disables OTP reporting
 echo   --logger-sasl-reports BOOL  Enables or disables SASL reporting
@@ -32,7 +32,7 @@ echo   --werl                      Uses Erlang's Windows shell GUI
 echo.
 echo ** Options marked with (*) can be given more than once
 echo ** Options given after the .exs file or -- are passed down to the executed code
-echo ** Options can be passed to the erlang runtime using ELIXIR_ERL_OPTIONS or --erl
+echo ** Options can be passed to the Erlang runtime using ELIXIR_ERL_OPTIONS or --erl
 goto end
 
 :parseopts
@@ -70,24 +70,24 @@ if "%par%"=="""" (
 rem ******* EXECUTION OPTIONS **********************
 IF "%par%"==""--werl"" (Set useWerl=1)
 IF "%par%"==""+iex"" (Set runMode="iex")
-rem ******* elixir parameters **********************
+rem ******* ELIXIR PARAMETERS **********************
 rem Note: we don't have to do anything with options that don't take an argument
-IF """"=="%par:-e=%"      (shift) 
-IF """"=="%par:-r=%"      (shift) 
-IF """"=="%par:-pr=%"     (shift) 
-IF """"=="%par:-pa=%"     (shift) 
-IF """"=="%par:-pz=%"     (shift) 
-IF """"=="%par:--app=%"   (shift) 
-IF """"=="%par:--remsh=%" (shift) 
+IF """"=="%par:-e=%"      (shift)
+IF """"=="%par:-r=%"      (shift)
+IF """"=="%par:-pr=%"     (shift)
+IF """"=="%par:-pa=%"     (shift)
+IF """"=="%par:-pz=%"     (shift)
+IF """"=="%par:--app=%"   (shift)
+IF """"=="%par:--remsh=%" (shift)
 rem ******* ERLANG PARAMETERS **********************
-IF """"=="%par:--detached=%"            (Set parsErlang=%parsErlang% -detached) 
+IF """"=="%par:--detached=%"            (Set parsErlang=%parsErlang% -detached)
 IF """"=="%par:--hidden=%"              (Set parsErlang=%parsErlang% -hidden)
 IF """"=="%par:--cookie=%"              (Set parsErlang=%parsErlang% -setcookie %1 && shift)
-IF """"=="%par:--sname=%"               (Set parsErlang=%parsErlang% -sname %1 && shift) 
-IF """"=="%par:--name=%"                (Set parsErlang=%parsErlang% -name %1 && shift) 
-IF """"=="%par:--logger-otp-reports=%"  (Set parsErlang=%parsErlang% -logger handle_otp_reports %1 && shift) 
-IF """"=="%par:--logger-sasl-reports=%" (Set parsErlang=%parsErlang% -logger handle_sasl_reports %1 && shift) 
-IF """"=="%par:--erl=%"                 (Set beforeExtra=%beforeExtra% %~1 && shift) 
+IF """"=="%par:--sname=%"               (Set parsErlang=%parsErlang% -sname %1 && shift)
+IF """"=="%par:--name=%"                (Set parsErlang=%parsErlang% -name %1 && shift)
+IF """"=="%par:--logger-otp-reports=%"  (Set parsErlang=%parsErlang% -logger handle_otp_reports %1 && shift)
+IF """"=="%par:--logger-sasl-reports=%" (Set parsErlang=%parsErlang% -logger handle_sasl_reports %1 && shift)
+IF """"=="%par:--erl=%"                 (Set beforeExtra=%beforeExtra% %~1 && shift)
 goto:startloop
 
 rem ******* assume all pre-params are parsed ********************

--- a/bin/elixirc
+++ b/bin/elixirc
@@ -10,8 +10,8 @@ if [ $# -eq 0 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
   --ignore-module-conflict
 
 ** Options given after -- are passed down to the executed code
-** Options can be passed to the erlang runtime using ELIXIR_ERL_OPTIONS
-** Options can be passed to the erlang compiler using ERL_COMPILER_OPTIONS" >&2
+** Options can be passed to the Erlang runtime using ELIXIR_ERL_OPTIONS
+** Options can be passed to the Erlang compiler using ERL_COMPILER_OPTIONS" >&2
   exit 1
 fi
 

--- a/lib/eex/lib/eex/engine.ex
+++ b/lib/eex/lib/eex/engine.ex
@@ -88,7 +88,7 @@ defmodule EEx.Engine do
         val
       :error ->
         keys = Enum.map(assigns, &elem(&1, 0))
-        IO.warn "assign @#{key} not available in eex template. " <>
+        IO.warn "assign @#{key} not available in EEx template. " <>
                 "Please ensure all assigns are given as options. " <>
                 "Available assigns: #{inspect keys}"
         nil

--- a/lib/eex/test/eex/smart_engine_test.exs
+++ b/lib/eex/test/eex/smart_engine_test.exs
@@ -21,7 +21,7 @@ defmodule EEx.SmartEngineTest do
     stderr = capture_io(:stderr, fn ->
       assert_eval "", "<%= @foo %>", assigns: %{}
     end)
-    assert stderr =~ "assign @foo not available in eex template"
+    assert stderr =~ "assign @foo not available in EEx template"
   end
 
   test "evaluates with loops" do

--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -242,7 +242,7 @@ defmodule Access do
   Accesses the given key in a map/struct.
 
   Uses the default value if the key does not exist
-  or if the value being accessed is nil.
+  or if the value being accessed is `nil`.
 
   ## Examples
 

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -202,7 +202,7 @@ defmodule Application do
   end
 
   @doc """
-  Get the application for the given module.
+  Gets the application for the given module.
 
   The application is located by analyzing the spec
   of all loaded applications. Returns `nil` if

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -980,7 +980,7 @@ defmodule DateTime do
   end
 
   @doc """
-  Converts the given unix time to DateTime.
+  Converts the given Unix time to DateTime.
 
   The integer can be given in different unit
   according to `System.convert_time_unit/3` and it will
@@ -1035,19 +1035,19 @@ defmodule DateTime do
     do: precision_for_unit(div(number, 10), precision + 1)
 
   @doc """
-  Converts the given unix time to DateTime.
+  Converts the given Unix time to DateTime.
 
   ## Examples
 
-    iex> DateTime.from_unix!(1464096368)
-    %DateTime{calendar: Calendar.ISO, day: 24, hour: 13, microsecond: {0, 0}, minute: 26,
-              month: 5, second: 8, std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0,
-              year: 2016, zone_abbr: "UTC"}
+      iex> DateTime.from_unix!(1464096368)
+      %DateTime{calendar: Calendar.ISO, day: 24, hour: 13, microsecond: {0, 0}, minute: 26,
+                month: 5, second: 8, std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0,
+                year: 2016, zone_abbr: "UTC"}
 
-    iex> DateTime.from_unix!(1432560368868569, :microseconds)
-    %DateTime{calendar: Calendar.ISO, day: 25, hour: 13, microsecond: {868569, 6}, minute: 26,
-              month: 5, second: 8, std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0,
-              year: 2015, zone_abbr: "UTC"}
+      iex> DateTime.from_unix!(1432560368868569, :microseconds)
+      %DateTime{calendar: Calendar.ISO, day: 25, hour: 13, microsecond: {868569, 6}, minute: 26,
+                month: 5, second: 8, std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0,
+                year: 2015, zone_abbr: "UTC"}
 
   """
   @spec from_unix!(non_neg_integer, :native | System.time_unit) :: DateTime.t
@@ -1057,7 +1057,7 @@ defmodule DateTime do
   end
 
   @doc """
-  Converts the given DateTime to unix time.
+  Converts the given DateTime to Unix time.
 
   The DateTime is expected to be UTC using the ISO calendar
   with a year greater than or equal to 1970.

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -411,7 +411,7 @@ defmodule File do
   @doc """
   Copies the contents of `source` to `destination`.
 
-  Both parameters can be a filename or an io device opened
+  Both parameters can be a filename or an IO device opened
   with `open/2`. `bytes_count` specifies the number of
   bytes to copy, the default being `:infinity`.
 
@@ -485,7 +485,7 @@ defmodule File do
   The function returns `:ok` in case of success, returns
   `{:error, reason}` otherwise.
 
-  If you want to copy contents from an io device to another device
+  If you want to copy contents from an IO device to another device
   or do a straight copy from a source to a destination without
   preserving modes, check `copy/3` instead.
 
@@ -878,7 +878,7 @@ defmodule File do
     end
   end
 
-  # On windows, symlinks are treated as directory and must be removed
+  # On Windows, symlinks are treated as directory and must be removed
   # with rmdir/1. But on Unix, we remove them via rm/1. So we first try
   # to remove it as a directory and, if we get :enotdir, we fallback to
   # a file removal.

--- a/lib/elixir/lib/file/stat.ex
+++ b/lib/elixir/lib/file/stat.ex
@@ -32,7 +32,7 @@ defmodule File.Stat do
       systems which have no concept of links.
 
     * `major_device` - identifies the file system where the file is located.
-      In windows, the number indicates a drive as follows: 0 means A:, 1 means
+      In Windows, the number indicates a drive as follows: 0 means A:, 1 means
       B:, and so on.
 
     * `minor_device` - only valid for character devices on Unix. In all other

--- a/lib/elixir/lib/gen_event.ex
+++ b/lib/elixir/lib/gen_event.ex
@@ -312,7 +312,7 @@ defmodule GenEvent do
 
       @doc false
       def handle_call(msg, state) do
-        # We do this to trick dialyzer to not complain about non-local returns.
+        # We do this to trick Dialyzer to not complain about non-local returns.
         reason = {:bad_call, msg}
         case :erlang.phash2(1, 1) do
           0 -> exit(reason)

--- a/lib/elixir/lib/gen_event/stream.ex
+++ b/lib/elixir/lib/gen_event/stream.ex
@@ -22,7 +22,7 @@ defmodule GenEvent.Stream do
 
   @doc false
   def handle_event(event, _state) do
-    # We do this to trick dialyzer to not complain about non-local returns.
+    # We do this to trick Dialyzer to not complain about non-local returns.
     case :erlang.phash2(1, 1) do
       0 -> exit({:bad_event, event})
       1 -> :remove_handler
@@ -31,7 +31,7 @@ defmodule GenEvent.Stream do
 
   @doc false
   def handle_call(msg, _state) do
-    # We do this to trick dialyzer to not complain about non-local returns.
+    # We do this to trick Dialyzer to not complain about non-local returns.
     reason = {:bad_call, msg}
     case :erlang.phash2(1, 1) do
       0 -> exit(reason)

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -491,7 +491,7 @@ defmodule IO do
 
   @compile {:inline, map_dev: 1, to_chardata: 1}
 
-  # Map the Elixir names for standard io and error to Erlang names
+  # Map the Elixir names for standard IO and error to Erlang names
   defp map_dev(:stdio),  do: :standard_io
   defp map_dev(:stderr), do: :standard_error
   defp map_dev(other) when is_atom(other) or is_pid(other) or is_tuple(other), do: other

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2769,7 +2769,7 @@ defmodule Kernel do
   defmacro left |> right do
     [{h, _} | t] = Macro.unpipe({:|>, [], [left, right]})
     :lists.foldl fn {x, pos}, acc ->
-      # TODO: raise an error in `Macro.pipe` by 1.4
+      # TODO: raise an error in "Macro.pipe/3" by 1.4
       case Macro.pipe_warning(x) do
         nil -> :ok
         message ->

--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -287,7 +287,7 @@ defmodule Kernel.CLI do
     {%{config | commands: [{:compile, config.compile} | config.commands]}, []}
   end
 
-  # Parse iex options
+  # Parse IEx options
 
   defp parse_iex(["--" | t], config) do
     {config, t}

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1828,7 +1828,7 @@ defmodule Kernel.SpecialForms do
   This means the VM no longer needs to keep the stacktrace once inside
   an else clause and so tail recursion is possible when using a `try`
   with a tail call as the final call inside an else clause. The same
-  is true for `rescue` and `catch` clauses.
+  is `true` for `rescue` and `catch` clauses.
 
   ## Variable handling
 

--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -40,8 +40,7 @@ defmodule Kernel.Utils do
   end
 
   defp normalize_args(raw_args) do
-    :lists.foldr(fn
-      ({:\\, _, [arg, default_arg]}, [as_args | _] = as_args_list) ->
+    :lists.foldr(fn({:\\, _, [arg, default_arg]}, [as_args | _] = as_args_list) ->
         new_as_args = [default_arg | as_args]
         [new_as_args | add_arg(as_args_list, arg)]
       (arg, as_args_list) ->

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -104,7 +104,7 @@ defmodule Keyword do
 
   ## Examples
 
-      iex> Keyword.new([:a, :b], fn (x) -> {x, x} end)
+      iex> Keyword.new([:a, :b], fn(x) -> {x, x} end)
       [a: :a, b: :b]
 
   """

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -117,10 +117,10 @@ defmodule List do
 
   ## Examples
 
-      iex> List.foldl([5, 5], 10, fn (x, acc) -> x + acc end)
+      iex> List.foldl([5, 5], 10, fn(x, acc) -> x + acc end)
       20
 
-      iex> List.foldl([1, 2, 3, 4], 0, fn (x, acc) -> x - acc end)
+      iex> List.foldl([1, 2, 3, 4], 0, fn(x, acc) -> x - acc end)
       2
 
   """
@@ -135,7 +135,7 @@ defmodule List do
 
   ## Examples
 
-      iex> List.foldr([1, 2, 3, 4], 0, fn (x, acc) -> x - acc end)
+      iex> List.foldr([1, 2, 3, 4], 0, fn(x, acc) -> x - acc end)
       -2
 
   """

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -153,7 +153,7 @@ defmodule Macro do
     raise ArgumentError, bad_pipe(expr, call_args)
   end
 
-  # Without this, `Macro |> Env == Macro.Env`.
+  # Without this: "Macro |> Env == Macro.Env"
   def pipe(expr, {:__aliases__, _, _} = call_args, _integer) do
     raise ArgumentError, bad_pipe(expr, call_args)
   end
@@ -165,7 +165,7 @@ defmodule Macro do
   end
 
   # {:fn, _, _} is what we get when we pipe into an anonymous function without
-  # calling it, e.g., `:foo |> (fn x -> x end)`.
+  # calling it, e.g., ":foo |> (fn x -> x end)"
   def pipe(expr, {:fn, _, _}, _integer) do
     expr_str = to_string(expr)
     raise ArgumentError,

--- a/lib/elixir/lib/module/locals_tracker.ex
+++ b/lib/elixir/lib/module/locals_tracker.ex
@@ -121,7 +121,7 @@ defmodule Module.LocalsTracker do
     :gen_server.cast(pid, {:add_local, from, to})
   end
 
-  # Adds a import dispatch to the given target.
+  # Adds an import dispatch to the given target.
   @doc false
   def add_import(pid, function, module, target) when is_atom(module) and is_tuple(target) do
     :gen_server.cast(pid, {:add_import, function, module, target})

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -430,7 +430,7 @@ defmodule Stream do
   """
   @spec interval(non_neg_integer) :: Enumerable.t
   def interval(n) do
-    unfold 0, fn (count) ->
+    unfold 0, fn(count) ->
       :timer.sleep(n)
       {count, count + 1}
     end

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1169,10 +1169,10 @@ defmodule String do
       iex> String.valid?("ø")
       true
 
-      iex> String.valid?(<<0xffff :: 16>>)
+      iex> String.valid?(<<0xFFFF :: 16>>)
       false
 
-      iex> String.valid?("asd" <> <<0xffff :: 16>>)
+      iex> String.valid?("asd" <> <<0xFFFF :: 16>>)
       false
 
   """
@@ -1223,11 +1223,11 @@ defmodule String do
       iex> String.chunk(<<?a, ?b, ?c, 0>>, :valid)
       ["abc\0"]
 
-      iex> String.chunk(<<?a, ?b, ?c, 0, 0x0ffff::utf8>>, :valid)
-      ["abc\0", <<0x0ffff::utf8>>]
+      iex> String.chunk(<<?a, ?b, ?c, 0, 0x0FFFF::utf8>>, :valid)
+      ["abc\0", <<0x0FFFF::utf8>>]
 
-      iex> String.chunk(<<?a, ?b, ?c, 0, 0x0ffff::utf8>>, :printable)
-      ["abc", <<0, 0x0ffff::utf8>>]
+      iex> String.chunk(<<?a, ?b, ?c, 0, 0x0FFFF::utf8>>, :printable)
+      ["abc", <<0, 0x0FFFF::utf8>>]
 
   """
   @spec chunk(t, :valid | :printable) :: [t]

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -44,7 +44,7 @@ defmodule System do
       time may not match in case of time warps although the VM works towards
       aligning them. This time is not monotonic (i.e., it may decrease)
       as its behaviour is configured [by the VM time warp
-      mode](http://erlang.org/doc/apps/erts/time_correction.html#Time_Warp_Modes);
+      mode](http://www.erlang.org/doc/apps/erts/time_correction.html#Time_Warp_Modes);
 
     * `monotonic_time/0` - a monotonically increasing time provided
       by the Erlang VM.
@@ -150,7 +150,7 @@ defmodule System do
   @doc """
   Elixir build information.
 
-  Returns a keyword list with Elixir version, git short revision hash and compilation date.
+  Returns a keyword list with Elixir version, Git short revision hash and compilation date.
   """
   @spec build_info() :: map
   def build_info do

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -452,7 +452,7 @@ defmodule Task do
       end)
 
       # Here we are matching only on {:ok, value} and
-      # ignoring {:exit, _} (crashed tasks) and `nil` (no replies)
+      # ignoring {:exit, _} (crashed tasks) and :nil (no replies)
       for {:ok, value} <- results do
         IO.inspect value
       end

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -209,7 +209,7 @@ defmodule URI do
 
   """
   @spec char_reserved?(char) :: boolean
-  def char_reserved?(char) when char in 0..0x10ffff do
+  def char_reserved?(char) when char in 0..0x10FFFF do
     char in ':/?#[]@!$&\'()*+,;='
   end
 
@@ -226,7 +226,7 @@ defmodule URI do
 
   """
   @spec char_unreserved?(char) :: boolean
-  def char_unreserved?(char) when char in 0..0x10ffff do
+  def char_unreserved?(char) when char in 0..0x10FFFF do
     char in ?0..?9 or
       char in ?a..?z or
       char in ?A..?Z or
@@ -246,7 +246,7 @@ defmodule URI do
 
   """
   @spec char_unescaped?(char) :: boolean
-  def char_unescaped?(char) when char in 0..0x10ffff do
+  def char_unescaped?(char) when char in 0..0x10FFFF do
     char_reserved?(char) or char_unreserved?(char)
   end
 

--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -87,7 +87,7 @@ Built-in type           | Defined as
 `bitstring()`           | `<<_::_ * 1>>`
 `boolean()`             | `false` \| `true`
 `byte()`                | `0..255`
-`char()`                | `0..0x10ffff`
+`char()`                | `0..0x10FFFF`
 `number()`              | `integer()` \| `float()`
 `charlist()`            | `[char()]`
 `list()`                | `[any()]`

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -240,7 +240,7 @@ get_stacktrace(CurrentStack, CurrentStack) ->
 get_stacktrace([StackItem | Stacktrace], CurrentStack) ->
   [StackItem | get_stacktrace(Stacktrace, CurrentStack)].
 
-%% Converts a quoted expression to erlang abstract format
+%% Converts a quoted expression to Erlang abstract format
 
 quoted_to_erl(Quoted, Env) ->
   quoted_to_erl(Quoted, Env, elixir_env:env_to_scope(Env)).

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -306,8 +306,8 @@ stab -> stab eoe stab_expr : ['$3' | '$1'].
 stab_eoe -> stab : '$1'.
 stab_eoe -> stab eoe : '$1'.
 
-%% Here, `element(1, Token)` is the stab operator,
-%% while `element(2, Token)` is the expression.
+%% Here, "element(1, Token)" is the stab operator,
+%% while "element(2, Token)" is the expression.
 stab_expr -> expr :
                '$1'.
 stab_expr -> stab_op_eol_and_expr :

--- a/lib/elixir/src/elixir_translator.erl
+++ b/lib/elixir/src/elixir_translator.erl
@@ -239,7 +239,7 @@ translate({{'.', _, [Left, Right]}, Meta, []}, S)
   TVar = {var, Ann, Var},
   TError = {tuple, Ann, [{atom, Ann, badkey}, TRight, TVar]},
 
-  %% TODO: there is a bug in dialyzer that warns about generated matches that
+  %% TODO: there is a bug in Dialyzer that warns about generated matches that
   %% can never match on line 0. The is_map/1 guard is used instead of matching
   %% against an empty map to avoid the warning.
   {{'case', ?generated, TLeft, [
@@ -267,7 +267,7 @@ translate({{'.', _, [Left, Right]}, Meta, Args}, S)
   TRight = {atom, Ann, Right},
   SC = mergev(SL, SA),
 
-  %% Rewrite erlang function calls as operators so they
+  %% Rewrite Erlang function calls as operators so they
   %% work on guards, matches and so on.
   case (Left == erlang) andalso guard_op(Right, Arity) of
     true ->

--- a/lib/elixir/src/elixir_try.erl
+++ b/lib/elixir/src/elixir_try.erl
@@ -109,7 +109,7 @@ rescue_each_ref(Meta, Var, [H | T], Elixir, Erlang, S) when is_atom(H) ->
 rescue_each_ref(_, _, [], Elixir, Erlang, _) ->
   {Elixir, Erlang}.
 
-%% Handle erlang rescue matches.
+%% Handle Erlang rescue matches.
 
 erl_rescue_guard_for(Meta, Var, 'Elixir.UndefinedFunctionError') ->
   {erl(Meta, '=='), Meta, [Var, undef]};

--- a/lib/elixir/src/elixir_utils.erl
+++ b/lib/elixir/src/elixir_utils.erl
@@ -232,7 +232,7 @@ convert_to_boolean(Line, Expr, Bool, S) when is_integer(Line) ->
 
 %% Notice we use a temporary var and include nil
 %% and false checks in the same clause since
-%% it makes dialyzer happy.
+%% it makes Dialyzer happy.
 do_convert_to_boolean(Line, Expr, Bool, S) ->
   {Name, _, TS} = elixir_scope:build_var('_', S),
   Var = {var, Line, Name},

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -249,7 +249,7 @@ defmodule EnumTest do
     assert Enum.join(["", "", 1, 2, "", 3, "", "\n"], ";") == ";;1;2;;3;;\n"
     assert Enum.join([""]) == ""
 
-    assert Enum.join(fn (acc, _) -> acc end, ".") == ""
+    assert Enum.join(fn(acc, _) -> acc end, ".") == ""
   end
 
   test "map/2" do
@@ -263,7 +263,7 @@ defmodule EnumTest do
     assert Enum.map_join([1, 2, 3], &(&1 * 2)) == "246"
     assert Enum.map_join(["", "", 1, 2, "", 3, "", "\n"], ";", &(&1)) == ";;1;2;;3;;\n"
     assert Enum.map_join([""], "", &(&1)) == ""
-    assert Enum.map_join(fn (acc, _) -> acc end, ".", &(&1 + 0)) == ""
+    assert Enum.map_join(fn(acc, _) -> acc end, ".", &(&1 + 0)) == ""
   end
 
   test "map_reduce/3" do

--- a/lib/elixir/test/elixir/file_test.exs
+++ b/lib/elixir/test/elixir/file_test.exs
@@ -1245,7 +1245,7 @@ defmodule FileTest do
   end
 
 
-  test "io stream utf8" do
+  test "IO stream utf8" do
     src  = File.open! fixture_path("file.txt"), [:utf8]
     dest = tmp_path("tmp_test.txt")
 
@@ -1260,7 +1260,7 @@ defmodule FileTest do
     end
   end
 
-  test "io stream" do
+  test "IO stream" do
     src  = File.open! fixture_path("file.txt")
     dest = tmp_path("tmp_test.txt")
 

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -335,7 +335,7 @@ defmodule Inspect.OthersTest do
     assert bin == "&Enum.map/2"
   end
 
-  test "external erlang funs" do
+  test "external Erlang funs" do
     bin = inspect(&:lists.map/2)
     assert bin == "&:lists.map/2"
   end

--- a/lib/elixir/test/elixir/kernel/alias_test.exs
+++ b/lib/elixir/test/elixir/kernel/alias_test.exs
@@ -9,7 +9,7 @@ end
 defmodule Kernel.AliasTest do
   use ExUnit.Case, async: true
 
-  test "alias erlang" do
+  test "alias Erlang" do
     alias :lists, as: MyList
     assert MyList.flatten([1, [2], 3]) == [1, 2, 3]
     assert Elixir.MyList.Bar == :"Elixir.MyList.Bar"

--- a/lib/elixir/test/elixir/kernel/dialyzer_test.exs
+++ b/lib/elixir/test/elixir/kernel/dialyzer_test.exs
@@ -21,7 +21,7 @@ defmodule Kernel.DialyzerTest do
     :dialyzer.run([analysis_type: :plt_build, output_plt: plt,
                    apps: [:erts], files: files])
 
-    # Compile dialyzer fixtures
+    # Compile Dialyzer fixtures
     assert '' = elixirc("#{fixture_path("dialyzer")} -o #{dir}")
 
     {:ok, [base_dir: dir, base_plt: plt]}

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -219,7 +219,7 @@ defmodule Kernel.ExpansionTest do
 
   ## Remote calls
 
-  test "remote calls: expands to erlang" do
+  test "remote calls: expands to Erlang" do
     assert expand(quote do: Kernel.is_atom(a)) == quote do: :erlang.is_atom(a())
   end
 

--- a/lib/elixir/test/elixir/kernel/raise_test.exs
+++ b/lib/elixir/test/elixir/kernel/raise_test.exs
@@ -209,7 +209,7 @@ defmodule Kernel.RaiseTest do
     assert result == "an exception"
   end
 
-  test "wrap custom erlang error" do
+  test "wrap custom Erlang error" do
     result = try do
       :erlang.error(:sample)
     rescue
@@ -373,7 +373,7 @@ defmodule Kernel.RaiseTest do
     assert result == "no try clause matching: :example"
   end
 
-  test "undefined function error as erlang error" do
+  test "undefined function error as Erlang error" do
     result = try do
       DoNotExist.for_sure()
     rescue

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -249,7 +249,7 @@ defmodule Kernel.TypespecTest do
     end
   end
 
-  test "@type when overriding elixir builtin" do
+  test "@type when overriding Elixir builtin" do
     assert_raise CompileError, ~r"type struct\(\) is a builtin type; it cannot be redefined", fn ->
       test_module do
         @type struct :: :oops
@@ -257,7 +257,7 @@ defmodule Kernel.TypespecTest do
     end
   end
 
-  test "@type when overriding erlang builtin" do
+  test "@type when overriding Erlang builtin" do
     assert_raise CompileError, ~r"type list\(\) is a builtin type; it cannot be redefined", fn ->
       test_module do
         @type list :: :oops

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -154,7 +154,7 @@ defmodule MacroTest do
     end)
   end
 
-  test "expand once with erlang" do
+  test "expand once with Erlang" do
     assert Macro.expand_once(quote(do: :foo), __ENV__) == :foo
   end
 

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -66,14 +66,14 @@ defmodule PathTest do
       assert Path.split("C:/foo/bar") == ["c:/", "foo", "bar"]
     end
   else
-    test "relative unix" do
+    test "relative Unix" do
       assert Path.relative("/usr/local/bin")   == "usr/local/bin"
       assert Path.relative("usr/local/bin")    == "usr/local/bin"
       assert Path.relative("../usr/local/bin") == "../usr/local/bin"
       assert Path.relative(['/usr', ?/, "local/bin"]) == "usr/local/bin"
     end
 
-    test "type unix" do
+    test "type Unix" do
       assert Path.type("/usr/local/bin")   == :absolute
       assert Path.type("usr/local/bin")    == :relative
       assert Path.type("../usr/local/bin") == :relative

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -542,8 +542,8 @@ defmodule StringTest do
     assert String.valid?("øsdfh")
     assert String.valid?("dskfjあska")
 
-    refute String.valid?(<<0xffff :: 16>>)
-    refute String.valid?("asd" <> <<0xffff :: 16>>)
+    refute String.valid?(<<0xFFFF :: 16>>)
+    refute String.valid?("asd" <> <<0xFFFF :: 16>>)
   end
 
   test "chunk valid" do
@@ -552,11 +552,11 @@ defmodule StringTest do
     assert String.chunk("ødskfjあ\x11ska", :valid)
            == ["ødskfjあ\x11ska"]
     assert String.chunk("abc\u{0ffff}def", :valid)
-           == ["abc", <<0x0ffff::utf8>>, "def"]
-    assert String.chunk("\u{0fffe}\u{3ffff}привет\u{0ffff}мир", :valid)
-           == [<<0x0fffe::utf8, 0x3ffff::utf8>>, "привет", <<0x0ffff::utf8>>, "мир"]
-    assert String.chunk("日本\u{0ffff}\u{fdef}ござございます\u{fdd0}", :valid)
-           == ["日本", <<0x0ffff::utf8, 0xfdef::utf8>>, "ござございます", <<0xfdd0::utf8>>]
+           == ["abc", <<0x0FFFF::utf8>>, "def"]
+    assert String.chunk("\u{0FFFE}\u{3FFFF}привет\u{0FFFF}мир", :valid)
+           == [<<0x0FFFE::utf8, 0x3FFFF::utf8>>, "привет", <<0x0FFFF::utf8>>, "мир"]
+    assert String.chunk("日本\u{0FFFF}\u{FDEF}ござございます\u{FDD0}", :valid)
+           == ["日本", <<0x0FFFF::utf8, 0xFDEF::utf8>>, "ござございます", <<0xFDD0::utf8>>]
   end
 
   test "chunk printable" do
@@ -564,8 +564,8 @@ defmodule StringTest do
 
     assert String.chunk("ødskfjあska", :printable)
            == ["ødskfjあska"]
-    assert String.chunk("abc\u{0ffff}def", :printable)
-           == ["abc", <<0x0ffff::utf8>>, "def"]
+    assert String.chunk("abc\u{0FFFF}def", :printable)
+           == ["abc", <<0x0FFFF::utf8>>, "def"]
     assert String.chunk("\x06ab\x05cdef\x03\0", :printable)
            == [<<6>>, "ab", <<5>>, "cdef", <<3, 0>>]
   end

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -11,7 +11,7 @@ defmodule URITest do
            "%0D%0A%26%3C%25%3E%22%20%E3%82%86"
   end
 
-  test "encode www form" do
+  test "encode WWW form" do
     assert URI.encode_www_form("4test ~1.x") == "4test+~1.x"
     assert URI.encode_www_form("poll:146%") == "poll%3A146%25"
     assert URI.encode_www_form("/\n+/ゆ") == "%2F%0A%2B%2F%E3%82%86"
@@ -70,7 +70,7 @@ defmodule URITest do
     end
   end
 
-  test "decode www form" do
+  test "decode WWW form" do
     assert URI.decode_www_form("%3Eval+ue%2B") == ">val ue+"
     assert URI.decode_www_form("%E3%82%86+") == "ゆ "
 
@@ -79,18 +79,18 @@ defmodule URITest do
     end
   end
 
-  test "parse uri" do
+  test "parse URI" do
     assert URI.parse(uri = %URI{scheme: "http", host: "foo.com"}) == uri
   end
 
-  test "parse http" do
+  test "parse HTTP" do
     assert %URI{scheme: "http", host: "foo.com", path: "/path/to/something",
                 query: "foo=bar&bar=foo", fragment: "fragment", port: 80,
                 authority: "foo.com", userinfo: nil} ==
            URI.parse("http://foo.com/path/to/something?foo=bar&bar=foo#fragment")
   end
 
-  test "parse https" do
+  test "parse HTTPS" do
     assert %URI{scheme: "https", host: "foo.com", authority: "foo.com",
                 query: nil, fragment: nil, port: 443, path: nil, userinfo: nil} ==
            URI.parse("https://foo.com")
@@ -102,7 +102,7 @@ defmodule URITest do
            URI.parse("file:///foo/bar/baz")
   end
 
-  test "parse ftp" do
+  test "parse FTP" do
     assert %URI{scheme: "ftp", host: "private.ftp-servers.example.com",
                 userinfo: "user001:secretpassword", authority: "user001:secretpassword@private.ftp-servers.example.com",
                 path: "/mydirectory/myfile.txt", query: nil, fragment: nil,
@@ -110,14 +110,14 @@ defmodule URITest do
            URI.parse("ftp://user001:secretpassword@private.ftp-servers.example.com/mydirectory/myfile.txt")
   end
 
-  test "parse sftp" do
+  test "parse SFTP" do
     assert %URI{scheme: "sftp", host: "private.ftp-servers.example.com",
                 userinfo: "user001:secretpassword", authority: "user001:secretpassword@private.ftp-servers.example.com",
                 path: "/mydirectory/myfile.txt", query: nil, fragment: nil, port: 22} ==
            URI.parse("sftp://user001:secretpassword@private.ftp-servers.example.com/mydirectory/myfile.txt")
   end
 
-  test "parse tftp" do
+  test "parse TFTP" do
     assert %URI{scheme: "tftp", host: "private.ftp-servers.example.com",
                 userinfo: "user001:secretpassword", authority: "user001:secretpassword@private.ftp-servers.example.com",
                 path: "/mydirectory/myfile.txt", query: nil, fragment: nil, port: 69} ==
@@ -125,7 +125,7 @@ defmodule URITest do
   end
 
 
-  test "parse ldap" do
+  test "parse LDAP" do
     assert %URI{scheme: "ldap", host: nil, authority: nil, userinfo: nil,
                 path: "/dc=example,dc=com", query: "?sub?(givenName=John)",
                 fragment: nil, port: 389} ==
@@ -166,7 +166,7 @@ defmodule URITest do
     assert URI.default_port("unknown") == 13
   end
 
-  test "parse bad uris" do
+  test "parse bad URIs" do
     assert URI.parse("")
     assert URI.parse("https:??@?F?@#>F//23/")
 
@@ -175,7 +175,7 @@ defmodule URITest do
     assert URI.parse("ht\0tps://foo.com").path == "ht\0tps://foo.com"
   end
 
-  test "ipv6 addresses" do
+  test "IPv6 addresses" do
     addrs = [
       "::",                                      # undefined
       "::1",                                     # loopback

--- a/lib/elixir/test/erlang/function_test.erl
+++ b/lib/elixir/test/erlang/function_test.erl
@@ -49,9 +49,9 @@ function_parens_test() ->
   {1, _} = eval("(fn(1) -> 1 end).(1)"),
   {3, _} = eval("(fn(1, 2) -> 3 end).(1, 2)"),
 
-  {0, _} = eval("(fn () -> 0 end).()"),
-  {1, _} = eval("(fn (1) -> 1 end).(1)"),
-  {3, _} = eval("(fn (1, 2) -> 3 end).(1, 2)").
+  {0, _} = eval("(fn() -> 0 end).()"),
+  {1, _} = eval("(fn(1) -> 1 end).(1)"),
+  {3, _} = eval("(fn(1, 2) -> 3 end).(1, 2)").
 
 %% Function calls
 

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -462,8 +462,8 @@ defmodule ExUnit.Assertions do
         1 + "test"
       end
 
-      assert_raise RuntimeError, ~r/^Today's lucky number is 0\.\d+!$/, fn ->
-        raise "Today's lucky number is #{:rand.uniform}!"
+      assert_raise RuntimeError, ~r/^today's lucky number is 0\.\d+!$/, fn ->
+        raise "today's lucky number is #{:rand.uniform}!"
       end
   """
   def assert_raise(exception, message, function) when is_function(function) do

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -430,7 +430,7 @@ defmodule ExUnit.AssertionsTest do
       [{Not.Defined, :function, [1, 2, 3], _} | _] = stacktrace
   end
 
-  test "assert raise with erlang error" do
+  test "assert raise with Erlang error" do
     assert_raise SyntaxError, fn ->
       List.flatten(1)
     end

--- a/lib/ex_unit/test/ex_unit/capture_io_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_io_test.exs
@@ -285,7 +285,7 @@ defmodule ExUnit.CaptureIOTest do
     end)
   end
 
-  test "with multiple io requests" do
+  test "with multiple IO requests" do
     assert capture_io(fn ->
       send_and_receive_io({:requests, [{:put_chars, :unicode, "a"},
                                         {:put_chars, :unicode, "b"}]})
@@ -297,7 +297,7 @@ defmodule ExUnit.CaptureIOTest do
     end)
   end
 
-  test "with unknown io request" do
+  test "with unknown IO request" do
     assert capture_io(fn ->
       send_and_receive_io(:unknown)
     end) == ""

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -244,7 +244,7 @@ defmodule IEx do
     * `:ls_directory` - ... for directory entries (ls helper)
     * `:ls_device`    - ... device entries (ls helper)
 
-  When printing documentation, IEx will convert the markdown
+  When printing documentation, IEx will convert the Markdown
   documentation to ANSI as well. Those can be configured via:
 
     * `:doc_code`        - the attributes for code blocks (cyan, bright)
@@ -504,7 +504,7 @@ defmodule IEx do
       end
 
     # expand_fun is not supported by a shell variant
-    # on Windows, so we do two io calls, not caring
+    # on Windows, so we do two IO calls, not caring
     # about the result of the expand_fun one.
     _ = :io.setopts(gl, expand_fun: expand_fun)
     :io.setopts(gl, binary: true, encoding: :unicode)

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -80,7 +80,7 @@ defmodule IEx.Helpers do
       reenable_tasks(config)
       Mix.Task.run("compile")
     else
-      IO.puts IEx.color(:eval_error, "Mix is not running. Please start IEx with: iex -S mix")
+      IO.puts IEx.color(:eval_error, "Mix is not running. Please start IEx with: \"iex -S mix\"")
       :error
     end
   end

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -7,49 +7,49 @@ defmodule IEx.AutocompleteTest do
     IEx.Autocomplete.expand(Enum.reverse expr)
   end
 
-  test "erlang module completion" do
+  test "Erlang module completion" do
     assert expand(':zl') == {:yes, 'ib.', []}
   end
 
-  test "erlang module no completion" do
+  test "Erlang module no completion" do
     assert expand(':unknown') == {:no, '', []}
     assert expand('Enum:') == {:no, '', []}
   end
 
-  test "erlang module multiple values completion" do
+  test "Erlang module multiple values completion" do
     {:yes, '', list} = expand(':user')
     assert 'user' in list
     assert 'user_drv' in list
   end
 
-  test "erlang root completion" do
+  test "Erlang root completion" do
     {:yes, '', list} = expand(':')
     assert is_list(list)
     assert 'lists' in list
   end
 
-  test "elixir proxy" do
+  test "Elixir proxy" do
     {:yes, '', list} = expand('E')
     assert 'Elixir' in list
   end
 
-  test "elixir completion" do
+  test "Elixir completion" do
     assert expand('En') == {:yes, 'um', []}
     assert expand('Enumera') == {:yes, 'ble.', []}
   end
 
-  test "elixir completion with self" do
+  test "Elixir completion with self" do
     assert expand('Enumerable') == {:yes, '.', []}
   end
 
-  test "elixir completion on modules from load path" do
+  test "Elixir completion on modules from load path" do
     assert expand('Str') == {:yes, [], ['Stream', 'String', 'StringIO']}
     assert expand('Ma') == {:yes, '', ['Macro', 'Map', 'MapSet', 'MatchError']}
     assert expand('Dic') == {:yes, 't.', []}
     assert expand('Ex')  == {:yes, [], ['ExUnit', 'Exception']}
   end
 
-  test "elixir no completion for underscored functions with no doc" do
+  test "Elixir no completion for underscored functions with no doc" do
     {:module, _, bytecode, _} =
       defmodule Elixir.Sample do
         def __foo__(), do: 0
@@ -65,21 +65,21 @@ defmodule IEx.AutocompleteTest do
     :code.delete(Sample)
   end
 
-  test "elixir no completion" do
+  test "Elixir no completion" do
     assert expand('.')   == {:no, '', []}
     assert expand('Xyz') == {:no, '', []}
     assert expand('x.Foo') == {:no, '', []}
   end
 
-  test "elixir root submodule completion" do
+  test "Elixir root submodule completion" do
     assert expand('Elixir.Acce') == {:yes, 'ss.', []}
   end
 
-  test "elixir submodule completion" do
+  test "Elixir submodule completion" do
     assert expand('String.Cha') == {:yes, 'rs.', []}
   end
 
-  test "elixir submodule no completion" do
+  test "Elixir submodule no completion" do
     assert expand('IEx.Xyz') == {:no, '', []}
   end
 
@@ -132,7 +132,7 @@ defmodule IEx.AutocompleteTest do
   defmodule SublevelTest.LevelA.LevelB do
   end
 
-  test "elixir completion sublevel" do
+  test "Elixir completion sublevel" do
     assert expand('IEx.AutocompleteTest.SublevelTest.') == {:yes, 'LevelA.', []}
   end
 
@@ -142,7 +142,7 @@ defmodule IEx.AutocompleteTest do
     end
   end
 
-  test "complete aliases of elixir modules" do
+  test "complete aliases of Elixir modules" do
     Application.put_env(:iex, :autocomplete_server, MyServer)
 
     assert expand('MyL') == {:yes, 'ist.', []}
@@ -150,7 +150,7 @@ defmodule IEx.AutocompleteTest do
     assert expand('MyList.to_integer') == {:yes, [], ['to_integer/1', 'to_integer/2']}
   end
 
-  test "complete aliases of erlang modules" do
+  test "complete aliases of Erlang modules" do
     Application.put_env(:iex, :autocomplete_server, MyServer)
 
     assert expand('EL') == {:yes, 'ist.', []}

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -316,7 +316,7 @@ defmodule IEx.HelpersTest do
     cleanup_modules([Sample, Sample2])
   end
 
-  test "c helper erlang" do
+  test "c helper Erlang" do
     assert_raise UndefinedFunctionError, ~r"function :sample.hello/0 is undefined", fn ->
       :sample.hello
     end
@@ -387,7 +387,7 @@ defmodule IEx.HelpersTest do
     end
   end
 
-  test "r helper elixir" do
+  test "r helper Elixir" do
     assert_raise UndefinedFunctionError, ~r"function Sample.run/0 is undefined \(module Sample is not available\)", fn ->
       Sample.run
     end
@@ -410,7 +410,7 @@ defmodule IEx.HelpersTest do
     cleanup_modules([Sample])
   end
 
-  test "r helper erlang" do
+  test "r helper Erlang" do
     assert_raise UndefinedFunctionError, ~r"function :sample.hello/0 is undefined", fn ->
       :sample.hello
     end

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -624,9 +624,9 @@ defmodule Logger do
   defp notify(:async, msg), do: GenEvent.notify(Logger, msg)
 
   defp handle_unused_variable_warnings(data, caller) do
-    # We collect all the names of variables (leaving `data` unchanged) with a
-    # scope of `nil` (as we don't warn for variables with a different scope
-    # anyways). We only want the variables that figure in `caller.vars`, as the
+    # We collect all the names of variables (leaving "data" unchanged) with a
+    # scope of "nil" (as we don't warn for variables with a different scope
+    # anyways). We only want the variables that figure in "caller.vars", as the
     # AST for calls to local 0-arity functions without parens is the same as the
     # AST for variables.
     {^data, logged_vars} = Macro.postwalk(data, [], fn

--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -178,7 +178,7 @@ defmodule Logger.TranslatorTest do
     """s
   end
 
-  test "translates Task raising erlang badarg error" do
+  test "translates Task raising Erlang badarg error" do
     assert capture_log(fn ->
       {:ok, pid} = Task.start(:erlang, :error, [:badarg])
       ref = Process.monitor(pid)

--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -381,14 +381,14 @@ defmodule Mix.Dep do
   end
 
   @doc """
-  Returns `true` if dependency is a rebar project.
+  Returns `true` if dependency is a Rebar project.
   """
   def rebar?(%Mix.Dep{manager: manager}) do
     manager in [:rebar, :rebar3]
   end
 
   @doc """
-  Returns `true` if dependency is a make project.
+  Returns `true` if dependency is a Make project.
   """
   def make?(%Mix.Dep{manager: manager}) do
     manager == :make

--- a/lib/mix/lib/mix/dep/converger.ex
+++ b/lib/mix/lib/mix/dep/converger.ex
@@ -18,7 +18,7 @@ defmodule Mix.Dep.Converger do
       Enum.each(deps, fn %Mix.Dep{app: app, deps: other_deps} ->
         Enum.each(other_deps, fn
           %Mix.Dep{app: ^app} ->
-            Mix.raise "app #{app} lists itself as a dependency"
+            Mix.raise "App #{app} lists itself as a dependency"
           %Mix.Dep{app: other_app} ->
             :digraph.add_edge(graph, other_app, app)
         end)

--- a/lib/mix/lib/mix/dep/loader.ex
+++ b/lib/mix/lib/mix/dep/loader.ex
@@ -54,8 +54,8 @@ defmodule Mix.Dep.Loader do
         mix?(dep) ->
           mix_dep(dep, children)
 
-        # If not an explicit rebar or Mix dependency
-        # but came from rebar, assume to be a rebar dep.
+        # If not an explicit Rebar or Mix dependency
+        # but came from Rebar, assume to be a Rebar dep.
         rebar?(dep) ->
           rebar_dep(dep, children, manager)
 
@@ -165,7 +165,7 @@ defmodule Mix.Dep.Loader do
     end
   end
 
-  # Notice we ignore make dependencies because the
+  # Notice we ignore Make dependencies because the
   # file based heuristic will always figure it out.
   @scm_managers ~w(mix rebar rebar3)a
 
@@ -271,8 +271,8 @@ defmodule Mix.Dep.Loader do
       deps =
         if children do
           from = Path.absname("rebar.config")
-          # Pass the manager because deps of a rebar project need
-          # to default to rebar if we cannot chose a manager from
+          # Pass the manager because deps of a Rebar project need
+          # to default to Rebar if we cannot chose a manager from
           # files in the dependency
           Enum.map(children, &to_dep(&1, from, manager))
         else

--- a/lib/mix/lib/mix/hex.ex
+++ b/lib/mix/lib/mix/hex.ex
@@ -61,7 +61,7 @@ defmodule Mix.Hex do
   end
 
   @doc """
-  Returns the url to the Hex mirror.
+  Returns the URL to the `Hex` mirror.
   """
   def mirror do
     System.get_env("HEX_MIRROR") || cdn() || @hex_mirror

--- a/lib/mix/lib/mix/local.ex
+++ b/lib/mix/lib/mix/local.ex
@@ -6,7 +6,7 @@ defmodule Mix.Local do
   @type item :: :archive | :escript
 
   @doc """
-  Returns the name for an archive or an escript, based on on the project config.
+  Returns the name for an archive or an escript, based on the project config.
 
   ## Examples
 

--- a/lib/mix/lib/mix/local/installer.ex
+++ b/lib/mix/lib/mix/local/installer.ex
@@ -120,7 +120,7 @@ defmodule Mix.Local.Installer do
   end
 
   @doc """
-  Print a list of items in a uniform way. Used for printing the list of installed archives and
+  Prints a list of items in a uniform way. Used for printing the list of installed archives and
   escripts.
   """
   @spec print_list(atom, [String.t]) :: :ok

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -329,7 +329,7 @@ defmodule Mix.Project do
       app = config[:app] ->
         Path.join([build_path(config), "lib", Atom.to_string(app)])
       config[:apps_path] ->
-        raise "Trying to access Mix.Project.app_path for an umbrella project but umbrellas have no app"
+        raise "trying to access Mix.Project.app_path for an umbrella project but umbrellas have no app"
       true ->
         Mix.raise "Cannot access build without an application name, " <>
           "please ensure you are in a directory with a mix.exs file and it defines " <>
@@ -357,7 +357,7 @@ defmodule Mix.Project do
   Compiles the given project.
 
   It will run the compile task unless the project
-  is in build embedded mode, which may fail as a
+  is in build embedded mode, which may fail as an
   explicit command to `mix compile` is required.
   """
   @spec compile([term], Keyword.t) :: term

--- a/lib/mix/lib/mix/rebar.ex
+++ b/lib/mix/lib/mix/rebar.ex
@@ -2,7 +2,7 @@ defmodule Mix.Rebar do
   @moduledoc false
 
   @doc """
-  Returns the path supposed to host the local copy of rebar.
+  Returns the path supposed to host the local copy of `rebar`.
   """
   def local_rebar_path(manager) do
     Path.join(Mix.Utils.mix_home, Atom.to_string(manager))
@@ -162,7 +162,7 @@ defmodule Mix.Rebar do
   end
 
   @doc """
-  Serializes a rebar config to a term file.
+  Serializes a Rebar config to a term file.
   """
   def serialize_config(config) do
     Enum.map(config, &[:io_lib.print(&1) | ".\n"])
@@ -184,7 +184,7 @@ defmodule Mix.Rebar do
 
   @doc """
   Runs `fun` for the given config and for each `sub_dirs` in the
-  given rebar config.
+  given Rebar config.
   """
   def recur(config, fun) when is_binary(config) do
     recur(load_config(config), fun)
@@ -269,7 +269,7 @@ defmodule Mix.Rebar do
         config
       {:error, error} ->
         reason = :file.format_error(error)
-        Mix.shell.error("Error evaluating rebar config script #{script_path}:#{reason}")
+        Mix.shell.error("Error evaluating Rebar config script #{script_path}:#{reason}")
         Mix.shell.error("Any dependencies defined in the script won't be available " <>
                         "unless you add them to your Mix project")
         config
@@ -277,7 +277,7 @@ defmodule Mix.Rebar do
   end
 
   defp eval_binds(binds) do
-    Enum.reduce(binds, :erl_eval.new_bindings, fn ({k, v}, binds) ->
+    Enum.reduce(binds, :erl_eval.new_bindings, fn({k, v}, binds) ->
       :erl_eval.add_binding(k, v, binds)
     end)
   end

--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -40,7 +40,7 @@ defmodule Mix.SCM.Git do
   end
 
   def checked_out?(opts) do
-    # Are we inside a git repository?
+    # Are we inside a Git repository?
     File.regular?(Path.join(opts[:dest], ".git/HEAD"))
   end
 
@@ -115,8 +115,8 @@ defmodule Mix.SCM.Git do
       []  -> opts
       [_] -> opts
       _   ->
-        Mix.raise "you should specify only one of branch, ref or tag, and only once. " <>
-                  "Error on git dependency: #{opts[:git]}"
+        Mix.raise "You should specify only one of branch, ref or tag, and only once. " <>
+                  "Error on Git dependency: #{opts[:git]}"
     end
   end
 

--- a/lib/mix/lib/mix/shell/io.ex
+++ b/lib/mix/lib/mix/shell/io.ex
@@ -68,7 +68,7 @@ defmodule Mix.Shell.IO do
     answer =~ ~r/^(Y(es)?)?$/i
   end
 
-  # The io server may return :eof or :error
+  # The IO server may return :eof or :error
   defp got_yes?(_), do: false
 
   defp red(message) do

--- a/lib/mix/lib/mix/shell/quiet.ex
+++ b/lib/mix/lib/mix/shell/quiet.ex
@@ -3,7 +3,7 @@ defmodule Mix.Shell.Quiet do
   This is Mix's default shell when the `MIX_QUIET` environment
   variable is set.
 
-  It's just like `Mix.Shell.IO' but print far less.
+  It's just like `Mix.Shell.IO` but print far less.
   """
 
   @behaviour Mix.Shell

--- a/lib/mix/lib/mix/tasks/app.tree.ex
+++ b/lib/mix/lib/mix/tasks/app.tree.ex
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.App.Tree do
       `kernel`, `stdlib` and `compiler` are always excluded from the tree.
 
     * `--pretty` - use Unicode codepoints for formatting the tree.
-      Defaults to true except on Windows.
+      Defaults to `true` except on Windows.
 
   """
 

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Archive.Install do
 
   The argument can be an archive located at some URL:
 
-      mix archive.install http://example.com/foo.ez
+      mix archive.install https://example.com/foo.ez
 
   After installation, the tasks in the archive are available locally:
 

--- a/lib/mix/lib/mix/tasks/compile.protocols.ex
+++ b/lib/mix/lib/mix/tasks/compile.protocols.ex
@@ -68,7 +68,7 @@ defmodule Mix.Tasks.Compile.Protocols do
   end
 
   @doc """
-  Clean up consolidated protocols.
+  Cleans up consolidated protocols.
   """
   def clean do
     File.rm_rf(default_path)

--- a/lib/mix/lib/mix/tasks/deps.ex
+++ b/lib/mix/lib/mix/tasks/deps.ex
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Deps do
   Hex (if it wasn't previously installed and download a package
   suitable to your project).
 
-  Mix also supports git and path dependencies:
+  Mix also supports Git and path dependencies:
 
       {:foobar, git: "https://github.com/elixir-lang/foobar.git", tag: "0.1"}
       {:foobar, path: "path/to/foobar"}
@@ -67,18 +67,18 @@ defmodule Mix.Tasks.Deps do
     * `:override` - if set to `true` the dependency will override any other
       definitions of itself by other dependencies
 
-    * `:manager` - Mix can also compile rebar, rebar3 and makefile projects
-      and can fetch sub dependencies of rebar and rebar3 projects. Mix will
+    * `:manager` - Mix can also compile Rebar, Rebar3 and Makefile projects
+      and can fetch sub dependencies of `rebar` and `rebar3` projects. Mix will
       try to infer the type of project but it can be overridden with this
       option by setting it to `:mix`, `:rebar`, `:rebar3` or `:make`
 
   ## Git options (`:git`)
 
-    * `:git`        - the git repository URI
-    * `:github`     - a shortcut for specifying git repos from github, uses `git:`
+    * `:git`        - the Git repository URI
+    * `:github`     - a shortcut for specifying Git repos from github, uses `git:`
     * `:ref`        - the reference to checkout (may be a branch, a commit sha or a tag)
-    * `:branch`     - the git branch to checkout
-    * `:tag`        - the git tag to checkout
+    * `:branch`     - the Git branch to checkout
+    * `:tag`        - the Git tag to checkout
     * `:submodules` - when ` true`, initialize submodules for the repo
 
   ## Path options (`:path`)

--- a/lib/mix/lib/mix/tasks/deps.tree.ex
+++ b/lib/mix/lib/mix/tasks/deps.tree.ex
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.Deps.Tree do
     * `--exclude` - exclude dependencies which you do not want to see printed.
 
     * `--pretty` - use Unicode codepoints for formatting the tree.
-      Defaults to true except on Windows.
+      Defaults to `true` except on Windows.
 
   """
   @switches [only: :string, exclude: :keep, pretty: :boolean]

--- a/lib/mix/lib/mix/tasks/escript.install.ex
+++ b/lib/mix/lib/mix/tasks/escript.install.ex
@@ -1,10 +1,10 @@
 defmodule Mix.Tasks.Escript.Install do
   use Mix.Task
 
-  @shortdoc "Install an escript locally"
+  @shortdoc "Installs an escript locally"
 
   @moduledoc """
-  Install an escript locally.
+  Installs an escript locally.
 
   If no argument is supplied but there is an escript in the project's root directory
   (created with `mix escript.build`), then the escript will be installed
@@ -23,8 +23,8 @@ defmodule Mix.Tasks.Escript.Install do
       ~/.mix/escripts/foo
 
   For convenience, consider adding `~/.mix/escripts` directory to your
-  `PATH` environment variable. For more information, check the wikipedia
-  article on PATH: https://en.wikipedia.org/wiki/PATH_(variable)
+  `PATH` environment variable. For more information, check the [Wikipedia
+  article on PATH](https://en.wikipedia.org/wiki/PATH_(variable))
 
   ## Command line options
 

--- a/lib/mix/lib/mix/tasks/escript.uninstall.ex
+++ b/lib/mix/lib/mix/tasks/escript.uninstall.ex
@@ -1,10 +1,10 @@
 defmodule Mix.Tasks.Escript.Uninstall do
   use Mix.Task
 
-  @shortdoc "Uninstall escripts"
+  @shortdoc "Uninstalls escripts"
 
   @moduledoc """
-  Uninstall local escripts:
+  Uninstalls local escripts:
 
       mix escript.uninstall escript_name
 

--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -6,14 +6,14 @@ defmodule Mix.Tasks.Local.Rebar do
   @rebar3_list_url     "/installs/rebar3-1.x.csv"
   @rebar3_escript_url  "/installs/[ELIXIR_VERSION]/rebar3-[REBAR_VERSION]"
 
-  @shortdoc  "Installs rebar locally"
+  @shortdoc  "Installs Rebar locally"
 
   @moduledoc """
   Fetches a copy of `rebar` or `rebar3` from the given path or url.
 
-  It defaults to safely download a rebar copy from  Hex's CDN.
+  It defaults to safely download a Rebar copy from  Hex's CDN.
   However, a URL can be given as argument, usually from an existing
-  local copy of rebar:
+  local copy of Rebar:
 
       mix local.rebar rebar path/to/rebar
       mix local.rebar rebar3 path/to/rebar
@@ -21,7 +21,7 @@ defmodule Mix.Tasks.Local.Rebar do
   If not specified both `rebar` and `rebar3` will be fetched.
 
   The local copy is stored in your `MIX_HOME` (defaults to `~/.mix`).
-  This version of rebar will be used as required by `mix deps.compile`.
+  This version of Rebar will be used as required by `mix deps.compile`.
 
   ## Command line options
 

--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -9,7 +9,7 @@ defmodule Mix.Tasks.Local.Rebar do
   @shortdoc  "Installs Rebar locally"
 
   @moduledoc """
-  Fetches a copy of `rebar` or `rebar3` from the given path or url.
+  Fetches a copy of `rebar` or `rebar3` from the given path or URL.
 
   It defaults to safely download a Rebar copy from  Hex's CDN.
   However, a URL can be given as argument, usually from an existing
@@ -25,9 +25,9 @@ defmodule Mix.Tasks.Local.Rebar do
 
   ## Command line options
 
-    * `rebar PATH` - specify a path or url for `rebar`
+    * `rebar PATH` - specify a path or URL for `rebar`
 
-    * `rebar3 PATH` - specify a path or url for `rebar3`
+    * `rebar3 PATH` - specify a path or URL for `rebar3`
 
     * `--sha512` - checks the archive matches the given sha512 checksum
 
@@ -69,7 +69,7 @@ defmodule Mix.Tasks.Local.Rebar do
           File.chmod!(local, 0o755)
           Mix.shell.info [:green, "* creating ", :reset, Path.relative_to_cwd(local)]
         :badpath ->
-          Mix.raise "Expected #{inspect path} to be a url or a local file path"
+          Mix.raise "Expected #{inspect path} to be a URL or a local file path"
         {:local, message} ->
           Mix.raise message
         {kind, message} when kind in [:remote, :checksum] ->

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -279,7 +279,7 @@ defmodule Mix.Tasks.Xref do
 
   defp raise_invalid_callee(callee) do
     message =
-      "xref --callers expects `Module`, `Module.function`, or `Module.function/arity`, got: " <>
+      "xref --callers expects \"Module\", \"Module.function\", or \"Module.function/arity\", got: " <>
       callee
 
     Mix.raise message

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -363,8 +363,8 @@ defmodule Mix.Utils do
     {:ok, _} = Application.ensure_all_started(:ssl)
     {:ok, _} = Application.ensure_all_started(:inets)
 
-    # Starting an http client profile allows us to scope
-    # the effects of using an http proxy to this function
+    # Starting an HTTP client profile allows us to scope
+    # the effects of using an HTTP proxy to this function
     {:ok, _pid} = :inets.start(:httpc, [{:profile, :mix}])
 
     headers = [{'user-agent', 'Mix/#{System.version}'}]

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -22,7 +22,7 @@ defmodule Mix.Utils do
   Gets all paths defined in the MIX_PATH env variable.
 
   `MIX_PATH` may contain multiple paths. If on Windows, those
-  paths should be separated by `;`, if on unix systems, use `:`.
+  paths should be separated by `;`, if on Unix systems, use `:`.
   """
   def mix_paths do
     if path = System.get_env("MIX_PATH") do
@@ -87,7 +87,7 @@ defmodule Mix.Utils do
   @doc """
   Returns the date the given path was last modified.
 
-  If the path does not exist, it returns the unix epoch
+  If the path does not exist, it returns the Unix epoch
   (1970-01-01 00:00:00).
   """
   def last_modified(path)
@@ -242,7 +242,7 @@ defmodule Mix.Utils do
   """
   def symlink_or_copy(source, target) do
     if File.exists?(source) do
-      # Relative symbolic links on windows are broken
+      # Relative symbolic links on Windows are broken
       link = case :os.type do
         {:win32, _} -> source
         _           -> make_relative_path(source, target)

--- a/lib/mix/test/mix/rebar_test.exs
+++ b/lib/mix/test/mix/rebar_test.exs
@@ -33,20 +33,20 @@ defmodule Mix.RebarTest do
     end
   end
 
-  test "load rebar config" do
+  test "load Rebar config" do
     path = MixTest.Case.fixture_path("rebar_dep")
     config = Mix.Rebar.load_config(path)
     assert config[:sub_dirs] == ['apps/*']
     assert config[:SCRIPT] == 'rebar.config.script'
   end
 
-  test "execute rebar.config.script on dependency directory" do
+  test "execute Rebar.config.script on dependency directory" do
     path = MixTest.Case.fixture_path("rebar_dep_script")
     config = Mix.Rebar.load_config(path)
     assert config[:dir] == {:ok, String.to_charlist(path)}
   end
 
-  test "parse rebar dependencies" do
+  test "parse Rebar dependencies" do
     config = [deps: [{:git_rebar, '~> 1.0'}]]
     assert [{:git_rebar, "~> 1.0"}] ==
            Mix.Rebar.deps(:foo, config, [])
@@ -98,7 +98,7 @@ defmodule Mix.RebarTest do
 
   end
 
-  test "parse rebar dependencies from rebar.config" do
+  test "parse Rebar dependencies from rebar.config" do
     Mix.Project.push(RebarAsDep)
 
     deps = Mix.Dep.loaded([])
@@ -113,17 +113,17 @@ defmodule Mix.RebarTest do
     end)
   end
 
-  test "inherit rebar manager" do
+  test "inherit Rebar manager" do
     Mix.Project.push(Rebar3AsDep)
 
     deps = Mix.Dep.loaded([])
     assert Enum.all?(deps, &(&1.manager == :rebar3))
   end
 
-  test "rebar overrides" do
+  test "Rebar overrides" do
     Mix.Project.push(RebarOverrideAsDep)
 
-    in_tmp "rebar overrides", fn ->
+    in_tmp "Rebar overrides", fn ->
       Mix.Tasks.Deps.Get.run []
       assert Mix.Dep.loaded([]) |> Enum.map(& &1.app) ==
              [:git_repo, :git_rebar, :rebar_override]
@@ -150,10 +150,10 @@ defmodule Mix.RebarTest do
     end
   end
 
-  test "get and compile dependencies for rebar" do
+  test "get and compile dependencies for Rebar" do
     Mix.Project.push(RebarAsDep)
 
-    in_tmp "get and compile dependencies for rebar", fn ->
+    in_tmp "get and compile dependencies for Rebar", fn ->
       Mix.Tasks.Deps.Get.run []
       assert_received {:mix_shell, :info, ["* Getting git_rebar (../../test/fixtures/git_rebar)"]}
 
@@ -210,10 +210,10 @@ defmodule Mix.RebarTest do
     end
   end
 
-  test "get and compile dependencies for rebar with Mix" do
+  test "get and compile dependencies for Rebar with Mix" do
     Mix.Project.push(RebarAsDep)
 
-    in_tmp "get and compile dependencies for rebar with Mix", fn ->
+    in_tmp "get and compile dependencies for Rebar with Mix", fn ->
       File.write! MixTest.Case.tmp_path("rebar_dep/mix.exs"), """
       defmodule RebarDep.Mixfile do
         use Mix.Project

--- a/lib/mix/test/mix/scm/git_test.exs
+++ b/lib/mix/test/mix/scm/git_test.exs
@@ -10,7 +10,7 @@ defmodule Mix.SCM.GitTest do
     assert Mix.SCM.Git.format_lock(lock(ref: "abcdef0"))   == "abcdef0 (ref)"
   end
 
-  test "considers two dep equals if the have the same git and the same opts" do
+  test "considers two dep equals if the have the same Git and the same opts" do
     assert Mix.SCM.Git.equal?([git: "foo"], [git: "foo"])
     refute Mix.SCM.Git.equal?([git: "foo"], [git: "bar"])
 
@@ -22,12 +22,12 @@ defmodule Mix.SCM.GitTest do
     assert Mix.SCM.Git.equal?([git: "foo", lock: 1], [git: "foo", lock: 2])
   end
 
-  test "raises about conflicting git checkout options" do
-    assert_raise Mix.Error, ~r/you should specify only one of branch, ref or tag/, fn ->
+  test "raises about conflicting Git checkout options" do
+    assert_raise Mix.Error, ~r/You should specify only one of branch, ref or tag/, fn ->
       Mix.SCM.Git.accepts_options(nil, [git: "/repo", branch: "master", tag: "0.1.0"])
     end
 
-    assert_raise Mix.Error, ~r/you should specify only one of branch, ref or tag/, fn ->
+    assert_raise Mix.Error, ~r/You should specify only one of branch, ref or tag/, fn ->
       Mix.SCM.Git.accepts_options(nil, [git: "/repo", branch: "master", branch: "develop"])
     end
   end

--- a/lib/mix/test/mix/tasks/compile_test.exs
+++ b/lib/mix/test/mix/tasks/compile_test.exs
@@ -50,7 +50,7 @@ defmodule Mix.Tasks.CompileTest do
     end
   end
 
-  test "compile a project with multiple compilers and a syntax error in an erlang file" do
+  test "compile a project with multiple compilers and a syntax error in an Erlang file" do
     in_fixture "no_mixfile", fn ->
       import ExUnit.CaptureIO
 

--- a/lib/mix/test/mix/tasks/deps.git_test.exs
+++ b/lib/mix/test/mix/tasks/deps.git_test.exs
@@ -42,7 +42,7 @@ defmodule Mix.Tasks.DepsGitTest do
     end
   end
 
-  test "gets and updates git repos with compilation" do
+  test "gets and updates Git repos with compilation" do
     Mix.Project.push GitApp
 
     in_fixture "no_mixfile", fn ->
@@ -58,7 +58,7 @@ defmodule Mix.Tasks.DepsGitTest do
     end
   end
 
-  test "gets and updates git repos with submodules" do
+  test "gets and updates Git repos with submodules" do
     Mix.Project.push GitSubmodulesApp
 
     in_fixture "no_mixfile", fn ->
@@ -120,12 +120,12 @@ defmodule Mix.Tasks.DepsGitTest do
       assert File.exists?("deps/deps_on_git_repo/.fetch")
       assert File.exists?("deps/git_repo/.fetch")
 
-      # Compile git repo but unload it so...
+      # Compile Git repo but unload it so...
       Mix.Tasks.Deps.Compile.run ["git_repo"]
       assert File.exists?("_build/dev/lib/git_repo/ebin")
       Code.delete_path("_build/dev/lib/git_repo/ebin")
 
-      # Deps on git repo loads it automatically on compile
+      # Deps on Git repo loads it automatically on compile
       Mix.Task.reenable "deps.check"
       Mix.Tasks.Deps.Compile.run ["deps_on_git_repo"]
       assert File.exists?("_build/dev/lib/deps_on_git_repo/ebin")
@@ -324,7 +324,7 @@ defmodule Mix.Tasks.DepsGitTest do
     purge [GitRepo, GitRepo.Mixfile]
   end
 
-  test "updates on git opts change" do
+  test "updates on Git opts change" do
     Mix.Project.push GitApp
 
     in_fixture "no_mixfile", fn ->

--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -115,7 +115,7 @@ defmodule Mix.Tasks.EscriptTest do
     purge [Ok.Mixfile]
   end
 
-  test "generate escript with erlang and deps" do
+  test "generate escript with Erlang and deps" do
     Mix.Project.push EscriptErlangWithDeps
 
     in_fixture "escripttest", fn ->

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -102,7 +102,7 @@ defmodule Mix.Tasks.XrefTest do
     """
   end
 
-  test "warnings: handles erlang ops" do
+  test "warnings: handles Erlang ops" do
     assert_no_warnings """
     defmodule A do
       def a(a, b), do: a and b
@@ -111,7 +111,7 @@ defmodule Mix.Tasks.XrefTest do
     """
   end
 
-  test "warnings: handles erlang modules" do
+  test "warnings: handles Erlang modules" do
     assert_warnings """
     defmodule A do
       def a, do: :not_a_module.no_module
@@ -433,7 +433,7 @@ defmodule Mix.Tasks.XrefTest do
   test "callers: gives nice error for quotable but invalid callers spec" do
     in_fixture "no_mixfile", fn ->
       message =
-        "xref --callers expects `Module`, `Module.function`, or `Module.function/arity`, got: Module.func(arg)"
+        "xref --callers expects \"Module\", \"Module.function\", or \"Module.function/arity\", got: Module.func(arg)"
 
       assert_raise Mix.Error, message, fn ->
         Mix.Task.run("xref", ["--callers", "Module.func(arg)"])
@@ -444,7 +444,7 @@ defmodule Mix.Tasks.XrefTest do
   test "callers: gives nice error for unquotable callers spec" do
     in_fixture "no_mixfile", fn ->
       message =
-        "xref --callers expects `Module`, `Module.function`, or `Module.function/arity`, got: %"
+        "xref --callers expects \"Module\", \"Module.function\", or \"Module.function/arity\", got: %"
 
       assert_raise Mix.Error, message, fn ->
         Mix.Task.run("xref", ["--callers", "%"])

--- a/lib/mix/test/mix/umbrella_test.exs
+++ b/lib/mix/test/mix/umbrella_test.exs
@@ -374,7 +374,7 @@ defmodule Mix.UmbrellaTest do
         end
         """
 
-        assert_raise Mix.Error, "app bar lists itself as a dependency", fn ->
+        assert_raise Mix.Error, "App bar lists itself as a dependency", fn ->
           Mix.Task.run("deps.get", ["--verbose"]) == [:ok, :ok]
         end
       end

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -152,7 +152,7 @@ defmodule MixTest.Case do
   end
 end
 
-## Set up Mix home with rebar
+## Set up Mix home with Rebar
 
 home = MixTest.Case.tmp_path(".mix")
 File.mkdir_p!(home)
@@ -261,7 +261,7 @@ unless File.dir?(target) do
   end
 end
 
-# Git rebar
+# Git Rebar
 target = Path.expand("fixtures/git_rebar", __DIR__)
 
 unless File.dir?(target) do

--- a/rebar.config
+++ b/rebar.config
@@ -1,12 +1,12 @@
-%% Using Elixir as a rebar dependency
+%% Using Elixir as a Rebar dependency
 
 %% This configuration file only exists so Elixir can be used
-%% as a rebar dependency, the same happens for the file
+%% as a Rebar dependency, the same happens for the file
 %% src/elixir.app.src.
 
 %% In practice, Elixir is structured as OTP where many applications
 %% are placed in the lib directory. Since this structure is not
-%% supported by default by rebar, after adding Elixir as a dependency
+%% supported by default by Rebar, after adding Elixir as a dependency
 %% you need to explicitly add it to lib_dirs:
 %%
 %%   {lib_dirs, [


### PR DESCRIPTION
- Remove double words (on on)
- Use capital letter for proper nouns such as: Elixir, Erlang, Mix, EEx, IEx, Dialyzer, Rebar, Make, Git, Markdown, Unix, Windows, etc.
- User proper casing for accronysm, such as: IO
- Remove use of em-dash(`—`) in favour of parenthesis
- Replace use of backticks from messages and comments, with double quotes
- Fix indentation in code examples
- Add missing arity in function mentions
- Add backticks where needed: typical uses case `true`, `false`, `nil`
- Remove space(s) between "fn" and "("
- Correct use of indefinite article a/an
- Convert hex to use uppercase after "x", ie: 0xffff to 0xFFFF, and \u{0fffe} to \u{0FFFE}
- Fix erlang.org to always be www.erlang.org
- Fix Mix error messages to start with capital letter,
- Fix all other raise message should startwith
- Fix module, function and task tasks to use tense proper tense.
- Fix wrongly closed backtick
- Always use https:// when available
- Use Markdown links instead of just displaying the plain URL.

UPDATE:
- Use proper case in Acronysms such as IPv6, WWW, HTTP, FTP, etc