### PR TITLE
User uppercase letter in Hexadecimal values

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1169,10 +1169,10 @@ defmodule String do
       iex> String.valid?("ø")
       true
 
-      iex> String.valid?(<<0xffff :: 16>>)
+      iex> String.valid?(<<0xFFFF :: 16>>)
       false
 
-      iex> String.valid?("asd" <> <<0xffff :: 16>>)
+      iex> String.valid?("asd" <> <<0xFFFF :: 16>>)
       false
 
   """
@@ -1223,11 +1223,11 @@ defmodule String do
       iex> String.chunk(<<?a, ?b, ?c, 0>>, :valid)
       ["abc\0"]
 
-      iex> String.chunk(<<?a, ?b, ?c, 0, 0x0ffff::utf8>>, :valid)
-      ["abc\0", <<0x0ffff::utf8>>]
+      iex> String.chunk(<<?a, ?b, ?c, 0, 0x0FFFF::utf8>>, :valid)
+      ["abc\0", <<0x0FFFF::utf8>>]
 
-      iex> String.chunk(<<?a, ?b, ?c, 0, 0x0ffff::utf8>>, :printable)
-      ["abc", <<0, 0x0ffff::utf8>>]
+      iex> String.chunk(<<?a, ?b, ?c, 0, 0x0FFFF::utf8>>, :printable)
+      ["abc", <<0, 0x0FFFF::utf8>>]
 
   """
   @spec chunk(t, :valid | :printable) :: [t]

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -209,7 +209,7 @@ defmodule URI do
 
   """
   @spec char_reserved?(char) :: boolean
-  def char_reserved?(char) when char in 0..0x10ffff do
+  def char_reserved?(char) when char in 0..0x10FFFF do
     char in ':/?#[]@!$&\'()*+,;='
   end
 
@@ -226,7 +226,7 @@ defmodule URI do
 
   """
   @spec char_unreserved?(char) :: boolean
-  def char_unreserved?(char) when char in 0..0x10ffff do
+  def char_unreserved?(char) when char in 0..0x10FFFF do
     char in ?0..?9 or
       char in ?a..?z or
       char in ?A..?Z or
@@ -246,7 +246,7 @@ defmodule URI do
 
   """
   @spec char_unescaped?(char) :: boolean
-  def char_unescaped?(char) when char in 0..0x10ffff do
+  def char_unescaped?(char) when char in 0..0x10FFFF do
     char_reserved?(char) or char_unreserved?(char)
   end
 

--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -87,7 +87,7 @@ Built-in type           | Defined as
 `bitstring()`           | `<<_::_ * 1>>`
 `boolean()`             | `false` \| `true`
 `byte()`                | `0..255`
-`char()`                | `0..0x10ffff`
+`char()`                | `0..0x10FFFF`
 `number()`              | `integer()` \| `float()`
 `charlist()`            | `[char()]`
 `list()`                | `[any()]`

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -542,8 +542,8 @@ defmodule StringTest do
     assert String.valid?("øsdfh")
     assert String.valid?("dskfjあska")
 
-    refute String.valid?(<<0xffff :: 16>>)
-    refute String.valid?("asd" <> <<0xffff :: 16>>)
+    refute String.valid?(<<0xFFFF :: 16>>)
+    refute String.valid?("asd" <> <<0xFFFF :: 16>>)
   end
 
   test "chunk valid" do
@@ -552,11 +552,11 @@ defmodule StringTest do
     assert String.chunk("ødskfjあ\x11ska", :valid)
            == ["ødskfjあ\x11ska"]
     assert String.chunk("abc\u{0ffff}def", :valid)
-           == ["abc", <<0x0ffff::utf8>>, "def"]
-    assert String.chunk("\u{0fffe}\u{3ffff}привет\u{0ffff}мир", :valid)
-           == [<<0x0fffe::utf8, 0x3ffff::utf8>>, "привет", <<0x0ffff::utf8>>, "мир"]
-    assert String.chunk("日本\u{0ffff}\u{fdef}ござございます\u{fdd0}", :valid)
-           == ["日本", <<0x0ffff::utf8, 0xfdef::utf8>>, "ござございます", <<0xfdd0::utf8>>]
+           == ["abc", <<0x0FFFF::utf8>>, "def"]
+    assert String.chunk("\u{0FFFE}\u{3FFFF}привет\u{0FFFF}мир", :valid)
+           == [<<0x0FFFE::utf8, 0x3FFFF::utf8>>, "привет", <<0x0FFFF::utf8>>, "мир"]
+    assert String.chunk("日本\u{0FFFF}\u{FDEF}ござございます\u{FDD0}", :valid)
+           == ["日本", <<0x0FFFF::utf8, 0xFDEF::utf8>>, "ござございます", <<0xFDD0::utf8>>]
   end
 
   test "chunk printable" do
@@ -564,8 +564,8 @@ defmodule StringTest do
 
     assert String.chunk("ødskfjあska", :printable)
            == ["ødskfjあska"]
-    assert String.chunk("abc\u{0ffff}def", :printable)
-           == ["abc", <<0x0ffff::utf8>>, "def"]
+    assert String.chunk("abc\u{0FFFF}def", :printable)
+           == ["abc", <<0x0FFFF::utf8>>, "def"]
     assert String.chunk("\x06ab\x05cdef\x03\0", :printable)
            == [<<6>>, "ab", <<5>>, "cdef", <<3, 0>>]
   end


### PR DESCRIPTION
Convert hex to use uppercase after "x", ie: 0xffff to 0xFFFF, and \u{0fffe} to \u{0FFFE}