### PR TITLE
Standardize links

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -44,7 +44,7 @@ defmodule System do
       time may not match in case of time warps although the VM works towards
       aligning them. This time is not monotonic (i.e., it may decrease)
       as its behaviour is configured [by the VM time warp
-      mode](http://erlang.org/doc/apps/erts/time_correction.html#Time_Warp_Modes);
+      mode](http://www.erlang.org/doc/apps/erts/time_correction.html#Time_Warp_Modes);
 
     * `monotonic_time/0` - a monotonically increasing time provided
       by the Erlang VM.


### PR DESCRIPTION
- Fix erlang.org to always be www.erlang.org
- Convert to link plain URL
