### PR TITLE
ApplicationTest fails under Windows

### DIFF
--- a/lib/elixir/test/elixir/application_test.exs
+++ b/lib/elixir/test/elixir/application_test.exs
@@ -3,6 +3,8 @@ Code.require_file "test_helper.exs", __DIR__
 defmodule ApplicationTest do
   use ExUnit.Case, async: true
 
+  import PathHelpers
+
   test "application environment" do
     assert Application.get_env(:elixir, :unknown) == nil
     assert Application.get_env(:elixir, :unknown, :default) == :default
@@ -52,15 +54,26 @@ defmodule ApplicationTest do
 
   test "application directory" do
     root = Path.expand("../../../..", __DIR__)
-    assert String.downcase(Application.app_dir(:elixir)) ==
-           String.downcase(Path.join(root, "bin/../lib/elixir"))
-    assert String.downcase(Application.app_dir(:elixir, "priv")) ==
-           String.downcase(Path.join(root, "bin/../lib/elixir/priv"))
-    assert String.downcase(Application.app_dir(:elixir, ["priv", "foo"])) ==
-           String.downcase(Path.join(root, "bin/../lib/elixir/priv/foo"))
+    assert normalize_app_dir(Application.app_dir(:elixir)) ==
+           normalize_app_dir(Path.join(root, "bin/../lib/elixir"))
+    assert normalize_app_dir(Application.app_dir(:elixir, "priv")) ==
+           normalize_app_dir(Path.join(root, "bin/../lib/elixir/priv"))
+    assert normalize_app_dir(Application.app_dir(:elixir, ["priv", "foo"])) ==
+           normalize_app_dir(Path.join(root, "bin/../lib/elixir/priv/foo"))
 
     assert_raise ArgumentError, fn ->
       Application.app_dir(:unknown)
     end
   end
+
+  if windows? do
+    defp normalize_app_dir(path) do
+      path |> String.downcase |> Path.expand
+    end
+  else
+    defp normalize_app_dir(path) do
+      path |> String.downcase
+    end
+  end
+
 end


### PR DESCRIPTION
```
  2) test application directory (ApplicationTest)
     test/elixir/application_test.exs:53
     Assertion with == failed
     code: String.downcase(Application.app_dir(:elixir)) == String.downcase(Path.join(root, "bin/../lib/elixir"))
     lhs:  "d:/home/docs/dev/git_repos/robi-wan-elixir/lib/elixir"
     rhs:  "d:/home/docs/dev/git_repos/robi-wan-elixir/bin/../lib/elixir"
     stacktrace:
       test/elixir/application_test.exs:55: (test)
```

`Application.app_dir(:elixir)` delivers under Windows (7 Pro 64bit) an absolute path:

```
iex(1)> Application.app_dir(:elixir)
"d:/home/docs/dev/git_repos/robi-wan-elixir/lib/elixir"
```

Under Linux (Ubuntu 16.04 64bit) it delivers a relative path:

```
iex(1)> Application.app_dir(:elixir)
"/home/robi-wan/development/work/robi-wan-elixir/bin/../lib/elixir"
```

`Application.app_dir/1` uses `:code.lib_dir` to retrieve the code path.
So maybe the different types of paths (relative vs absolute) are caused by Erlang.

Suggestion to fix the tests under Windows: Use `Path.expand/1` to convert
the path (on the right hand side of the assertion) to an absolute path.