### PR TITLE
Use flush/0 in Logger instead of GenEvent.which_handlers

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -417,7 +417,7 @@ defmodule Logger do
 
   """
   def add_backend(backend, opts \\ []) do
-    _ = if opts[:flush], do: GenEvent.which_handlers(:error_logger)
+    _ = if opts[:flush], do: flush()
     case Logger.Watcher.watch(Logger, Logger.Config.translate_backend(backend), backend) do
       {:ok, _} = ok ->
         Logger.Config.add_backend(backend)
@@ -437,7 +437,7 @@ defmodule Logger do
       the backend is removed
   """
   def remove_backend(backend, opts \\ []) do
-    _ = if opts[:flush], do: GenEvent.which_handlers(:error_logger)
+    _ = if opts[:flush], do: flush()
     Logger.Config.remove_backend(backend)
     Logger.Watcher.unwatch(Logger, Logger.Config.translate_backend(backend))
   end


### PR DESCRIPTION
Use flush/0 instead of GenEvent.which_handlers(:error_logger) in Logger.add_backend/2 and Logger.remove_backend/2
See: https://groups.google.com/forum/#!topic/elixir-lang-talk/TrekCMxEZAE for more info
