### PR TITLE
Option for `mix app.tree` and `mix deps.tree` to be output as DOT file

### DIFF
--- a/lib/mix/lib/mix/tasks/app.tree.ex
+++ b/lib/mix/lib/mix/tasks/app.tree.ex
@@ -43,12 +43,11 @@ defmodule Mix.Tasks.App.Tree do
     excluded = @default_excluded ++ excluded
 
     if opts[:dot] do
-      Mix.Utils.build_dot_graph("application tree", [{:normal, app}], fn {type, app} ->
+      app_tree = Mix.Utils.build_dot_graph("application tree", [{:normal, app}], fn {type, app} ->
         load(app)
         {"#{app}#{type(type)}", children_for(app, excluded)}
       end, opts)
-      |> String.split("\n")
-      |> Enum.map(&Mix.shell.info/1)
+      File.write!("app_tree.dot", app_tree <> "\n")
     else
       Mix.Utils.print_tree([{:normal, app}], fn {type, app} ->
         load(app)

--- a/lib/mix/lib/mix/tasks/app.tree.ex
+++ b/lib/mix/lib/mix/tasks/app.tree.ex
@@ -43,10 +43,12 @@ defmodule Mix.Tasks.App.Tree do
     excluded = @default_excluded ++ excluded
 
     if opts[:dot] do
-      Mix.Utils.print_dot_graph("application tree", [{:normal, app}], fn {type, app} ->
+      Mix.Utils.build_dot_graph("application tree", [{:normal, app}], fn {type, app} ->
         load(app)
         {"#{app}#{type(type)}", children_for(app, excluded)}
       end, opts)
+      |> String.split("\n")
+      |> Enum.map(&Mix.shell.info/1)
     else
       Mix.Utils.print_tree([{:normal, app}], fn {type, app} ->
         load(app)

--- a/lib/mix/lib/mix/tasks/deps.tree.ex
+++ b/lib/mix/lib/mix/tasks/deps.tree.ex
@@ -46,7 +46,7 @@ defmodule Mix.Tasks.Deps.Tree do
       %Mix.Dep{app: app} = dep ->
         deps =
           # Do not show dependencies if they were
-          # already show at the top level
+          # already shown at the top level
           if not dep.top_level && find_dep(top_level, app) do
             []
           else

--- a/lib/mix/lib/mix/tasks/deps.tree.ex
+++ b/lib/mix/lib/mix/tasks/deps.tree.ex
@@ -61,9 +61,8 @@ defmodule Mix.Tasks.Deps.Tree do
       end
 
     if opts[:dot] do
-      Mix.Utils.build_dot_graph("dependency tree", [root], deps_tree_callback, opts)
-      |> String.split("\n")
-      |> Enum.map(&Mix.shell.info/1)
+      dep_tree = Mix.Utils.build_dot_graph("dependency tree", [root], deps_tree_callback, opts)
+      File.write!("dep_tree.dot", dep_tree <> "\n")
     else
       Mix.Utils.print_tree([root], deps_tree_callback, opts)
     end

--- a/lib/mix/lib/mix/tasks/deps.tree.ex
+++ b/lib/mix/lib/mix/tasks/deps.tree.ex
@@ -80,13 +80,11 @@ defmodule Mix.Tasks.Deps.Tree do
       else
         ""
       end
-    extra_info =
-      if opts[:dot] do
-        ""
-      else
-        "#{requirement(requirement)} (#{scm.format(deps_opts)})"
-      end
-    "#{app}#{extra_info}#{override}"
+    if opts[:dot] do
+      {app, "#{requirement(requirement)}#{override}"}
+    else
+      "#{app}#{requirement(requirement)} (#{scm.format(deps_opts)})#{override}"
+    end
   end
 
   defp requirement(nil), do: ""

--- a/lib/mix/lib/mix/tasks/deps.tree.ex
+++ b/lib/mix/lib/mix/tasks/deps.tree.ex
@@ -61,7 +61,9 @@ defmodule Mix.Tasks.Deps.Tree do
       end
 
     if opts[:dot] do
-      Mix.Utils.print_dot_graph("dependency tree", [root], deps_tree_callback, opts)
+      Mix.Utils.build_dot_graph("dependency tree", [root], deps_tree_callback, opts)
+      |> String.split("\n")
+      |> Enum.map(&Mix.shell.info/1)
     else
       Mix.Utils.print_tree([root], deps_tree_callback, opts)
     end

--- a/lib/mix/lib/mix/tasks/deps.tree.ex
+++ b/lib/mix/lib/mix/tasks/deps.tree.ex
@@ -80,13 +80,13 @@ defmodule Mix.Tasks.Deps.Tree do
       else
         ""
       end
-    scm_info =
+    extra_info =
       if opts[:dot] do
         ""
       else
-        " (#{scm.format(deps_opts)})"
+        "#{requirement(requirement)} (#{scm.format(deps_opts)})"
       end
-    "#{app}#{requirement(requirement)}#{scm_info}#{override}"
+    "#{app}#{extra_info}#{override}"
   end
 
   defp requirement(nil), do: ""

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -196,7 +196,9 @@ defmodule Mix.Utils do
   defp do_print_dot_graph(_parent, [], _callback), do: :ok
   defp do_print_dot_graph(parent, [node | nodes], callback) do
     {name, children} = callback.(node)
-    Mix.shell.info "  #{parent} -> #{name}"
+    if parent != name do
+      Mix.shell.info ~s(  "#{parent}" -> "#{name}")
+    end
     do_print_dot_graph(name, children, callback)
     do_print_dot_graph(parent, nodes, callback)
   end

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -185,22 +185,24 @@ defmodule Mix.Utils do
   must either return `{printed, children}` tuple or
   `false` if the given node must not be printed.
   """
-  @spec print_dot_graph(String.t, [term], (term -> {String.t, [term]}), Keyword.t) :: :ok
-  def print_dot_graph(title, nodes, callback, _opts \\ []) do
-    Mix.shell.info "digraph \"#{title}\" {"
+  @spec build_dot_graph(String.t, [term], (term -> {String.t, [term]}), Keyword.t) :: :ok
+  def build_dot_graph(title, nodes, callback, _opts \\ []) do
     {parent_name, _} = callback.(hd(nodes))
-    do_print_dot_graph(parent_name, nodes, callback)
-    Mix.shell.info "}"
+    "digraph \"#{title}\" {\n" <>
+    do_build_dot_graph(parent_name, nodes, callback) <>
+    "}"
   end
 
-  defp do_print_dot_graph(_parent, [], _callback), do: :ok
-  defp do_print_dot_graph(parent, [node | nodes], callback) do
+  defp do_build_dot_graph(_parent, [], _callback), do: ""
+  defp do_build_dot_graph(parent, [node | nodes], callback) do
     {name, children} = callback.(node)
     if parent != name do
-      Mix.shell.info ~s(  "#{parent}" -> "#{name}")
-    end
-    do_print_dot_graph(name, children, callback)
-    do_print_dot_graph(parent, nodes, callback)
+      ~s(  "#{parent}" -> "#{name}"\n)
+    else
+      ""
+    end <>
+    do_build_dot_graph(name, children, callback) <>
+    do_build_dot_graph(parent, nodes, callback)
   end
 
   @doc false

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -196,8 +196,19 @@ defmodule Mix.Utils do
   defp do_build_dot_graph(_parent, [], _callback), do: ""
   defp do_build_dot_graph(parent, [node | nodes], callback) do
     {name, children} = callback.(node)
+
+    parent_name = case parent do
+      {parent_name, _} -> parent_name
+      parent_name -> parent_name
+    end
+
     if parent != name do
-      ~s(  "#{parent}" -> "#{name}"\n)
+      case name do
+        {node_name, edge_info} ->
+          ~s(  "#{parent_name}" -> "#{node_name}" [label=\"#{edge_info}\"]\n)
+        node_name ->
+          ~s(  "#{parent_name}" -> "#{node_name}"\n)
+      end
     else
       ""
     end <>

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -151,7 +151,12 @@ defmodule Mix.Utils do
   """
   @spec print_tree([term], (term -> {String.t, [term]}), Keyword.t) :: :ok
   def print_tree(nodes, callback, opts \\ []) do
-    pretty = Keyword.get(opts, :pretty, elem(:os.type, 0) != :win32)
+    pretty =
+      case Keyword.get(opts, :format) do
+        "pretty" -> true
+        "plain" -> false
+        _ -> elem(:os.type, 0) != :win32
+      end
     print_tree(nodes, [], pretty, callback)
   end
 

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -178,6 +178,29 @@ defmodule Mix.Utils do
   defp prefix(true, _, []),  do: "└── "
   defp prefix(true, _, _),   do: "├── "
 
+  @doc """
+  Outputs the given tree according to the callback as a DOT graph.
+
+  The callback will be invoked for each node and it
+  must either return `{printed, children}` tuple or
+  `false` if the given node must not be printed.
+  """
+  @spec print_dot_graph(String.t, [term], (term -> {String.t, [term]}), Keyword.t) :: :ok
+  def print_dot_graph(title, nodes, callback, _opts \\ []) do
+    Mix.shell.info "digraph \"#{title}\" {"
+    {parent_name, _} = callback.(hd(nodes))
+    do_print_dot_graph(parent_name, nodes, callback)
+    Mix.shell.info "}"
+  end
+
+  defp do_print_dot_graph(_parent, [], _callback), do: :ok
+  defp do_print_dot_graph(parent, [node | nodes], callback) do
+    {name, children} = callback.(node)
+    Mix.shell.info "  #{parent} -> #{name}"
+    do_print_dot_graph(name, children, callback)
+    do_print_dot_graph(parent, nodes, callback)
+  end
+
   @doc false
   # TODO: Deprecate by 1.4
   def underscore(value) do

--- a/lib/mix/test/mix/tasks/app.tree_test.exs
+++ b/lib/mix/test/mix/tasks/app.tree_test.exs
@@ -19,7 +19,7 @@ defmodule Mix.Tasks.App.TreeTest do
 
     in_tmp context.test, fn ->
       load_apps()
-      Mix.Tasks.App.Tree.run(["--pretty"])
+      Mix.Tasks.App.Tree.run(["--format", "pretty"])
 
       assert_received {:mix_shell, :info, ["test"]}
       assert_received {:mix_shell, :info, ["└── app_deps_sample"]}
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.App.TreeTest do
   test "show the application tree for umbrella apps" do
     in_fixture "umbrella_dep/deps/umbrella", fn ->
       Mix.Project.in_project(:umbrella, ".", fn _ ->
-        Mix.Task.run "app.tree", ["--pretty"]
+        Mix.Task.run "app.tree", ["--format", "pretty"]
         assert_received {:mix_shell, :info, ["foo"]}
         assert_received {:mix_shell, :info, ["└── elixir"]}
         assert_received {:mix_shell, :info, ["bar"]}
@@ -48,11 +48,11 @@ defmodule Mix.Tasks.App.TreeTest do
 
     in_tmp context.test, fn ->
       assert_raise Mix.Error, "could not find application app_deps_sample", fn ->
-        Mix.Tasks.App.Tree.run(["--pretty", "app_deps_sample"])
+        Mix.Tasks.App.Tree.run(["--format", "pretty", "app_deps_sample"])
       end
 
       load_apps()
-      Mix.Tasks.App.Tree.run(["--pretty", "app_deps_sample"])
+      Mix.Tasks.App.Tree.run(["--format", "pretty", "app_deps_sample"])
 
       assert_received {:mix_shell, :info, ["app_deps_sample"]}
       assert_received {:mix_shell, :info, ["├── app_deps2_sample"]}
@@ -67,7 +67,7 @@ defmodule Mix.Tasks.App.TreeTest do
 
     in_tmp context.test, fn ->
       load_apps()
-      Mix.Tasks.App.Tree.run(["--pretty", "--exclude", "app_deps4_sample", "--exclude", "app_deps3_sample"])
+      Mix.Tasks.App.Tree.run(["--format", "pretty", "--exclude", "app_deps4_sample", "--exclude", "app_deps3_sample"])
 
       assert_received {:mix_shell, :info, ["test"]}
       assert_received {:mix_shell, :info, ["└── app_deps_sample"]}
@@ -83,7 +83,7 @@ defmodule Mix.Tasks.App.TreeTest do
 
     in_tmp context.test, fn ->
       load_apps()
-      Mix.Tasks.App.Tree.run(["--dot"])
+      Mix.Tasks.App.Tree.run(["--format", "dot"])
 
       assert File.read!("app_tree.dot") == """
         digraph "application tree" {

--- a/lib/mix/test/mix/tasks/app.tree_test.exs
+++ b/lib/mix/test/mix/tasks/app.tree_test.exs
@@ -85,9 +85,6 @@ defmodule Mix.Tasks.App.TreeTest do
       load_apps()
       Mix.Tasks.App.Tree.run(["--dot"])
 
-      # Why is this generated when it doesn't appear in other tests?
-      assert_received {:mix_shell, :info, ["Generated test app"]}
-
       assert_received {:mix_shell, :info, ["digraph \"application tree\" {"]}
       assert_received {:mix_shell, :info, ["  \"test\" -> \"app_deps_sample\""]}
       assert_received {:mix_shell, :info, ["  \"app_deps_sample\" -> \"app_deps2_sample\""]}

--- a/lib/mix/test/mix/tasks/app.tree_test.exs
+++ b/lib/mix/test/mix/tasks/app.tree_test.exs
@@ -77,6 +77,26 @@ defmodule Mix.Tasks.App.TreeTest do
     end
   end
 
+  @tag apps: [:test, :app_deps_sample, :app_deps2_sample, :app_deps3_sample, :app_deps4_sample]
+  test "shows the application tree in dot form", context do
+    Mix.Project.push AppDepsSample
+
+    in_tmp context.test, fn ->
+      load_apps()
+      Mix.Tasks.App.Tree.run(["--dot"])
+
+      # Why is this generated when it doesn't appear in other tests?
+      assert_received {:mix_shell, :info, ["Generated test app"]}
+
+      assert_received {:mix_shell, :info, ["digraph \"application tree\" {"]}
+      assert_received {:mix_shell, :info, ["  \"test\" -> \"app_deps_sample\""]}
+      assert_received {:mix_shell, :info, ["  \"app_deps_sample\" -> \"app_deps2_sample\""]}
+      assert_received {:mix_shell, :info, ["  \"app_deps2_sample\" -> \"app_deps4_sample (included)\""]}
+      assert_received {:mix_shell, :info, ["  \"app_deps_sample\" -> \"app_deps3_sample\""]}
+      assert_received {:mix_shell, :info, ["}"]}
+    end
+  end
+
   def load_apps() do
     :ok = :application.load({:application, :app_deps4_sample, [vsn: '1.0.0', env: []]})
     :ok = :application.load({:application, :app_deps3_sample, [vsn: '1.0.0', env: []]})

--- a/lib/mix/test/mix/tasks/app.tree_test.exs
+++ b/lib/mix/test/mix/tasks/app.tree_test.exs
@@ -85,12 +85,17 @@ defmodule Mix.Tasks.App.TreeTest do
       load_apps()
       Mix.Tasks.App.Tree.run(["--dot"])
 
-      assert_received {:mix_shell, :info, ["digraph \"application tree\" {"]}
-      assert_received {:mix_shell, :info, ["  \"test\" -> \"app_deps_sample\""]}
-      assert_received {:mix_shell, :info, ["  \"app_deps_sample\" -> \"app_deps2_sample\""]}
-      assert_received {:mix_shell, :info, ["  \"app_deps2_sample\" -> \"app_deps4_sample (included)\""]}
-      assert_received {:mix_shell, :info, ["  \"app_deps_sample\" -> \"app_deps3_sample\""]}
-      assert_received {:mix_shell, :info, ["}"]}
+      assert File.read!("app_tree.dot") == """
+        digraph "application tree" {
+          "test" -> "elixir"
+          "test" -> "logger"
+          "logger" -> "elixir"
+          "test" -> "app_deps_sample"
+          "app_deps_sample" -> "app_deps2_sample"
+          "app_deps2_sample" -> "app_deps4_sample (included)"
+          "app_deps_sample" -> "app_deps3_sample"
+        }
+        """
     end
   end
 

--- a/lib/mix/test/mix/tasks/deps.tree_test.exs
+++ b/lib/mix/test/mix/tasks/deps.tree_test.exs
@@ -115,17 +115,17 @@ defmodule Mix.Tasks.Deps.TreeTest do
     in_tmp context.test, fn ->
       Mix.Tasks.Deps.Tree.run(["--dot"])
       assert_received {:mix_shell, :info, ["digraph \"dependency tree\" {"]}
-      assert_received {:mix_shell, :info, ["  \"sample\" -> \"git_repo\""]}
-      assert_received {:mix_shell, :info, ["  \"sample\" -> \"deps_on_git_repo\""]}
-      refute_received {:mix_shell, :info, ["  \"deps_on_git_repo\" -> \"git_repo\""]}
+      assert_received {:mix_shell, :info, ["  \"sample\" -> \"git_repo\" [label=\" >= 0.1.0\"]"]}
+      assert_received {:mix_shell, :info, ["  \"sample\" -> \"deps_on_git_repo\" [label=\" 0.2.0\"]"]}
+      refute_received {:mix_shell, :info, ["  \"deps_on_git_repo\" -> \"git_repo\" [label=\"\"]"]}
       assert_received {:mix_shell, :info, ["}"]}
 
       Mix.Tasks.Deps.Get.run([])
       Mix.Tasks.Deps.Tree.run(["--dot"])
       assert_received {:mix_shell, :info, ["digraph \"dependency tree\" {"]}
-      assert_received {:mix_shell, :info, ["  \"sample\" -> \"git_repo\""]}
-      assert_received {:mix_shell, :info, ["  \"sample\" -> \"deps_on_git_repo\""]}
-      assert_received {:mix_shell, :info, ["  \"deps_on_git_repo\" -> \"git_repo\""]}
+      assert_received {:mix_shell, :info, ["  \"sample\" -> \"git_repo\" [label=\" >= 0.1.0\"]"]}
+      assert_received {:mix_shell, :info, ["  \"sample\" -> \"deps_on_git_repo\" [label=\" 0.2.0\"]"]}
+      assert_received {:mix_shell, :info, ["  \"deps_on_git_repo\" -> \"git_repo\" [label=\"\"]"]}
       assert_received {:mix_shell, :info, ["}"]}
     end
   after

--- a/lib/mix/test/mix/tasks/deps.tree_test.exs
+++ b/lib/mix/test/mix/tasks/deps.tree_test.exs
@@ -115,17 +115,17 @@ defmodule Mix.Tasks.Deps.TreeTest do
     in_tmp context.test, fn ->
       Mix.Tasks.Deps.Tree.run(["--dot"])
       assert_received {:mix_shell, :info, ["digraph \"dependency tree\" {"]}
-      assert_received {:mix_shell, :info, ["  \"sample\" -> \"git_repo >= 0.1.0\""]}
-      assert_received {:mix_shell, :info, ["  \"sample\" -> \"deps_on_git_repo 0.2.0\""]}
-      refute_received {:mix_shell, :info, ["  \"deps_on_git_repo 0.2.0\" -> \"git_repo\""]}
+      assert_received {:mix_shell, :info, ["  \"sample\" -> \"git_repo\""]}
+      assert_received {:mix_shell, :info, ["  \"sample\" -> \"deps_on_git_repo\""]}
+      refute_received {:mix_shell, :info, ["  \"deps_on_git_repo\" -> \"git_repo\""]}
       assert_received {:mix_shell, :info, ["}"]}
 
       Mix.Tasks.Deps.Get.run([])
       Mix.Tasks.Deps.Tree.run(["--dot"])
       assert_received {:mix_shell, :info, ["digraph \"dependency tree\" {"]}
-      assert_received {:mix_shell, :info, ["  \"sample\" -> \"git_repo >= 0.1.0\""]}
-      assert_received {:mix_shell, :info, ["  \"sample\" -> \"deps_on_git_repo 0.2.0\""]}
-      assert_received {:mix_shell, :info, ["  \"deps_on_git_repo 0.2.0\" -> \"git_repo\""]}
+      assert_received {:mix_shell, :info, ["  \"sample\" -> \"git_repo\""]}
+      assert_received {:mix_shell, :info, ["  \"sample\" -> \"deps_on_git_repo\""]}
+      assert_received {:mix_shell, :info, ["  \"deps_on_git_repo\" -> \"git_repo\""]}
       assert_received {:mix_shell, :info, ["}"]}
     end
   after

--- a/lib/mix/test/mix/tasks/deps.tree_test.exs
+++ b/lib/mix/test/mix/tasks/deps.tree_test.exs
@@ -108,4 +108,27 @@ defmodule Mix.Tasks.Deps.TreeTest do
       refute_received {:mix_shell, :info, ["└── deps_on_git_repo ~r/0.2.0/ (" <> _]}
     end
   end
+
+  test "shows the dependency tree in DOT graph format", context do
+    Mix.Project.push ConvergedDepsApp
+
+    in_tmp context.test, fn ->
+      Mix.Tasks.Deps.Tree.run(["--dot"])
+      assert_received {:mix_shell, :info, ["digraph \"dependency tree\" {"]}
+      assert_received {:mix_shell, :info, ["  \"sample\" -> \"git_repo >= 0.1.0\""]}
+      assert_received {:mix_shell, :info, ["  \"sample\" -> \"deps_on_git_repo 0.2.0\""]}
+      refute_received {:mix_shell, :info, ["  \"deps_on_git_repo 0.2.0\" -> \"git_repo\""]}
+      assert_received {:mix_shell, :info, ["}"]}
+
+      Mix.Tasks.Deps.Get.run([])
+      Mix.Tasks.Deps.Tree.run(["--dot"])
+      assert_received {:mix_shell, :info, ["digraph \"dependency tree\" {"]}
+      assert_received {:mix_shell, :info, ["  \"sample\" -> \"git_repo >= 0.1.0\""]}
+      assert_received {:mix_shell, :info, ["  \"sample\" -> \"deps_on_git_repo 0.2.0\""]}
+      assert_received {:mix_shell, :info, ["  \"deps_on_git_repo 0.2.0\" -> \"git_repo\""]}
+      assert_received {:mix_shell, :info, ["}"]}
+    end
+  after
+    purge [DepsOnGitRepo.Mixfile, GitRepo.Mixfile]
+  end
 end

--- a/lib/mix/test/mix/tasks/deps.tree_test.exs
+++ b/lib/mix/test/mix/tasks/deps.tree_test.exs
@@ -33,14 +33,14 @@ defmodule Mix.Tasks.Deps.TreeTest do
     Mix.Project.push ConvergedDepsApp
 
     in_tmp context.test, fn ->
-      Mix.Tasks.Deps.Tree.run(["--pretty"])
+      Mix.Tasks.Deps.Tree.run(["--format", "pretty"])
       assert_received {:mix_shell, :info, ["sample"]}
       assert_received {:mix_shell, :info, ["├── git_repo >= 0.1.0 (" <> _]}
       assert_received {:mix_shell, :info, ["└── deps_on_git_repo 0.2.0 (" <> _]}
       refute_received {:mix_shell, :info, ["    └── git_repo (" <> _]}
 
       Mix.Tasks.Deps.Get.run([])
-      Mix.Tasks.Deps.Tree.run(["--pretty"])
+      Mix.Tasks.Deps.Tree.run(["--format", "pretty"])
       assert_received {:mix_shell, :info, ["sample"]}
       assert_received {:mix_shell, :info, ["├── git_repo >= 0.1.0 (" <> _]}
       assert_received {:mix_shell, :info, ["└── deps_on_git_repo 0.2.0 (" <> _]}
@@ -53,7 +53,7 @@ defmodule Mix.Tasks.Deps.TreeTest do
   test "show the dependency tree for umbrella apps" do
     in_fixture "umbrella_dep/deps/umbrella", fn ->
       Mix.Project.in_project(:umbrella, ".", fn _ ->
-        Mix.Task.run "deps.tree", ["--pretty"]
+        Mix.Task.run "deps.tree", ["--format", "pretty"]
         assert_received {:mix_shell, :info, ["foo"]}
         assert_received {:mix_shell, :info, ["bar"]}
         assert_received {:mix_shell, :info, ["└── foo (../foo)"]}
@@ -66,10 +66,10 @@ defmodule Mix.Tasks.Deps.TreeTest do
 
     in_tmp context.test, fn ->
       assert_raise Mix.Error, "could not find dependency unknown", fn ->
-        Mix.Tasks.Deps.Tree.run(["--pretty", "unknown"])
+        Mix.Tasks.Deps.Tree.run(["--format", "pretty", "unknown"])
       end
 
-      Mix.Tasks.Deps.Tree.run(["--pretty", "deps_on_git_repo"])
+      Mix.Tasks.Deps.Tree.run(["--format", "pretty", "deps_on_git_repo"])
       assert_received {:mix_shell, :info, ["deps_on_git_repo 0.2.0 (" <> _]}
       refute_received {:mix_shell, :info, ["└── git_repo (" <> _]}
     end
@@ -79,7 +79,7 @@ defmodule Mix.Tasks.Deps.TreeTest do
     Mix.Project.push OverriddenDepsApp
 
     in_tmp context.test, fn ->
-      Mix.Tasks.Deps.Tree.run(["--pretty"])
+      Mix.Tasks.Deps.Tree.run(["--format", "pretty"])
       assert_received {:mix_shell, :info, ["sample"]}
       assert_received {:mix_shell, :info, ["├── git_repo (" <> msg]}
       assert_received {:mix_shell, :info, ["└── deps_on_git_repo ~r/0.2.0/ (" <> _]}
@@ -91,7 +91,7 @@ defmodule Mix.Tasks.Deps.TreeTest do
     Mix.Project.push OverriddenDepsApp
 
     in_tmp context.test, fn ->
-      Mix.Tasks.Deps.Tree.run(["--pretty", "--exclude", "deps_on_git_repo"])
+      Mix.Tasks.Deps.Tree.run(["--format", "pretty", "--exclude", "deps_on_git_repo"])
       assert_received {:mix_shell, :info, ["sample"]}
       assert_received {:mix_shell, :info, ["└── git_repo (" <> _]}
       refute_received {:mix_shell, :info, ["└── deps_on_git_repo ~r/0.2.0/ (" <> _]}
@@ -102,7 +102,7 @@ defmodule Mix.Tasks.Deps.TreeTest do
     Mix.Project.push OverriddenDepsApp
 
     in_tmp context.test, fn ->
-      Mix.Tasks.Deps.Tree.run(["--pretty", "--only", "prod"])
+      Mix.Tasks.Deps.Tree.run(["--format", "pretty", "--only", "prod"])
       assert_received {:mix_shell, :info, ["sample"]}
       assert_received {:mix_shell, :info, ["└── git_repo (" <> _]}
       refute_received {:mix_shell, :info, ["└── deps_on_git_repo ~r/0.2.0/ (" <> _]}
@@ -113,9 +113,9 @@ defmodule Mix.Tasks.Deps.TreeTest do
     Mix.Project.push ConvergedDepsApp
 
     in_tmp context.test, fn ->
-      Mix.Tasks.Deps.Tree.run(["--dot"])
+      Mix.Tasks.Deps.Tree.run(["--format", "dot"])
 
-      assert File.read!("dep_tree.dot") == """
+      assert File.read!("deps_tree.dot") == """
         digraph "dependency tree" {
           "sample" -> "git_repo" [label=" >= 0.1.0"]
           "sample" -> "deps_on_git_repo" [label=" 0.2.0"]
@@ -123,9 +123,9 @@ defmodule Mix.Tasks.Deps.TreeTest do
         """
 
       Mix.Tasks.Deps.Get.run([])
-      Mix.Tasks.Deps.Tree.run(["--dot"])
+      Mix.Tasks.Deps.Tree.run(["--format", "dot"])
 
-      assert File.read!("dep_tree.dot") == """
+      assert File.read!("deps_tree.dot") == """
         digraph "dependency tree" {
           "sample" -> "git_repo" [label=" >= 0.1.0"]
           "sample" -> "deps_on_git_repo" [label=" 0.2.0"]

--- a/lib/mix/test/mix/tasks/deps.tree_test.exs
+++ b/lib/mix/test/mix/tasks/deps.tree_test.exs
@@ -114,19 +114,24 @@ defmodule Mix.Tasks.Deps.TreeTest do
 
     in_tmp context.test, fn ->
       Mix.Tasks.Deps.Tree.run(["--dot"])
-      assert_received {:mix_shell, :info, ["digraph \"dependency tree\" {"]}
-      assert_received {:mix_shell, :info, ["  \"sample\" -> \"git_repo\" [label=\" >= 0.1.0\"]"]}
-      assert_received {:mix_shell, :info, ["  \"sample\" -> \"deps_on_git_repo\" [label=\" 0.2.0\"]"]}
-      refute_received {:mix_shell, :info, ["  \"deps_on_git_repo\" -> \"git_repo\" [label=\"\"]"]}
-      assert_received {:mix_shell, :info, ["}"]}
+
+      assert File.read!("dep_tree.dot") == """
+        digraph "dependency tree" {
+          "sample" -> "git_repo" [label=" >= 0.1.0"]
+          "sample" -> "deps_on_git_repo" [label=" 0.2.0"]
+        }
+        """
 
       Mix.Tasks.Deps.Get.run([])
       Mix.Tasks.Deps.Tree.run(["--dot"])
-      assert_received {:mix_shell, :info, ["digraph \"dependency tree\" {"]}
-      assert_received {:mix_shell, :info, ["  \"sample\" -> \"git_repo\" [label=\" >= 0.1.0\"]"]}
-      assert_received {:mix_shell, :info, ["  \"sample\" -> \"deps_on_git_repo\" [label=\" 0.2.0\"]"]}
-      assert_received {:mix_shell, :info, ["  \"deps_on_git_repo\" -> \"git_repo\" [label=\"\"]"]}
-      assert_received {:mix_shell, :info, ["}"]}
+
+      assert File.read!("dep_tree.dot") == """
+        digraph "dependency tree" {
+          "sample" -> "git_repo" [label=" >= 0.1.0"]
+          "sample" -> "deps_on_git_repo" [label=" 0.2.0"]
+          "deps_on_git_repo" -> "git_repo" [label=""]
+        }
+        """
     end
   after
     purge [DepsOnGitRepo.Mixfile, GitRepo.Mixfile]


### PR DESCRIPTION
Inspired by @josevalim's ElixirConf.EU keynote.

This is currently a work in progress, but feedback is more than welcome.

- [x] return a string from the utils function so that the caller can write the result to a file
- [x] if a file is written where should it go? `/tmp/app_tree.dot` or `/tmp/deps_tree.dot`?
- [x] if a `dot` executable exists should we also make an `.svg`?

/cc @mootpointer