### PR TITLE
Clean deps when deps.compile is run with --force

### DIFF
--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -33,12 +33,16 @@ defmodule Mix.Tasks.Deps.Compile do
   import Mix.Dep, only: [loaded: 1, available?: 1, loaded_by_name: 2,
                          make?: 1, mix?: 1]
 
-  @switches [include_children: :boolean]
+  @switches [include_children: :boolean, force: :boolean]
 
   @spec run(OptionParser.argv) :: :ok
   def run(args) do
     unless "--no-archives-check" in args do
       Mix.Task.run "archive.check", args
+    end
+
+    if "--force" in args do
+      Mix.Task.run "deps.clean", ["--all"]
     end
 
     Mix.Project.get!

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -65,7 +65,7 @@ defmodule Mix.Tasks.Deps.Compile do
       Enum.map(deps, fn %Mix.Dep{app: app, status: status, opts: opts, scm: scm} = dep ->
         check_unavailable!(app, status)
 
-        clean(app,options)
+        clean(app, options)
 
         compiled? = cond do
           not is_nil(opts[:compile]) ->
@@ -95,9 +95,9 @@ defmodule Mix.Tasks.Deps.Compile do
     if true in compiled, do: Mix.Dep.Lock.touch_manifest, else: :ok
   end
 
-  defp clean(dep, opts) do
+  defp clean(app, opts) do
     if Keyword.get(opts, :force, false) do
-      Mix.Tasks.Deps.Clean.run [dep, "--build"]
+      File.rm_rf! Path.join [Mix.Project.build_path, "lib", Atom.to_string(app)]
     end
   end
 

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -193,6 +193,20 @@ defmodule Mix.Tasks.DepsTest do
 
   ## deps.unlock
 
+  test "cleans and recompiles artifacts if --force given" do
+    Mix.Project.push SuccessfulDepsApp
+
+    in_fixture "deps_status", fn ->
+      Mix.Tasks.Deps.Compile.run []
+      File.touch! "deps/ok/clean-me"
+
+      Mix.Tasks.Deps.Compile.run ["--force"]
+      refute File.exists? "deps/ok/clean-me"
+    end
+  end
+
+  ## deps.unlock
+
   test "unlocks all deps", context do
     Mix.Project.push DepsApp
     in_tmp context.test, fn ->

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -198,10 +198,10 @@ defmodule Mix.Tasks.DepsTest do
 
     in_fixture "deps_status", fn ->
       Mix.Tasks.Deps.Compile.run []
-      File.touch! "deps/ok/clean-me"
+      File.touch! "_build/dev/lib/ok/clean-me"
 
       Mix.Tasks.Deps.Compile.run ["--force"]
-      refute File.exists? "deps/ok/clean-me"
+      refute File.exists? "_build/dev/lib/ok/clean-me"
     end
   end
 


### PR DESCRIPTION
@josevalim @ericmj  this is a first stab.
~~The test does not pass, but I wanted to check if I am on track.~~

~~The condition `if "--force" in args do` gets hit, but I wonder why the file does not disappear.~~
~~I wonder if I am placing the "tracer-file" in the right place?~~

It should be working now.
To verify that the cleaning happens I add a tracer file and ensure its removed afterwards.

Any feedback/ideas/suggestions welcome ❤️ 