### PR TITLE
Add a reference to String.to_integer in the doc

### DIFF
--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -15,7 +15,7 @@ defmodule Float do
   If the size of float exceeds the maximum size of `1.7976931348623157e+308`,
   the `ArgumentError` exception is raised.
 
-  If a float formatted string wants to be directly converted to a float,
+  If you want to convert a string-formatted float directly to a float,
   `String.to_float/1` can be used instead.
 
   ## Examples

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -131,7 +131,7 @@ defmodule Integer do
 
   Raises an error if `base` is less than 2 or more than 36.
 
-  If an integer formatted string wants to be directly converted to a integer,
+  If you want to convert a string-formatted integer directly to a integer,
   `String.to_integer/1` or `String.to_integer/2` can be used instead.
 
   ## Examples

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -131,6 +131,9 @@ defmodule Integer do
 
   Raises an error if `base` is less than 2 or more than 36.
 
+  If an integer formatted string wants to be directly converted to a integer,
+  `String.to_integer/1` or `String.to_integer/2` can be used instead.
+
   ## Examples
 
       iex> Integer.parse("34")


### PR DESCRIPTION
The documentation for `Float.parse` has a mention of `String.to_float`, this patch adds a similar reference for `Integer.parse` in the function documentation.