### PR TITLE
Use 0.1.0 as default first version in `mix new` task

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -207,7 +207,7 @@ defmodule Mix.Tasks.New do
 
       ```elixir
       def deps do
-        [{:<%= @app %>, "~> 0.0.1"}]
+        [{:<%= @app %>, "~> 0.1.0"}]
       end
       ```
 
@@ -247,7 +247,7 @@ defmodule Mix.Tasks.New do
 
     def project do
       [app: :<%= @app %>,
-       version: "0.0.1",
+       version: "0.1.0",
        elixir: "~> <%= @version %>",
        build_embedded: Mix.env == :prod,
        start_permanent: Mix.env == :prod,
@@ -282,7 +282,7 @@ defmodule Mix.Tasks.New do
 
     def project do
       [app: :<%= @app %>,
-       version: "0.0.1",
+       version: "0.1.0",
        build_path: "../../_build",
        config_path: "../../config/config.exs",
        deps_path: "../../deps",

--- a/lib/mix/test/mix/tasks/new_test.exs
+++ b/lib/mix/test/mix/tasks/new_test.exs
@@ -9,7 +9,7 @@ defmodule Mix.Tasks.NewTest do
 
       assert_file "hello_world/mix.exs", fn(file) ->
         assert file =~ "app: :hello_world"
-        assert file =~ "version: \"0.0.1\""
+        assert file =~ "version: \"0.1.0\""
       end
 
       assert_file "hello_world/README.md", ~r/# HelloWorld\n/
@@ -31,7 +31,7 @@ defmodule Mix.Tasks.NewTest do
 
       assert_file "hello_world/mix.exs", fn(file) ->
         assert file =~ "app: :hello_world"
-        assert file =~ "version: \"0.0.1\""
+        assert file =~ "version: \"0.1.0\""
         assert file =~ "mod: {HelloWorld, []}"
       end
 
@@ -58,7 +58,7 @@ defmodule Mix.Tasks.NewTest do
 
       assert_file "HELLO_WORLD/mix.exs", fn(file) ->
         assert file =~ "app: :hello_world"
-        assert file =~ "version: \"0.0.1\""
+        assert file =~ "version: \"0.1.0\""
       end
 
       assert_file "HELLO_WORLD/README.md", ~r/# HelloWorld\n/


### PR DESCRIPTION
Triggered from this tweet: https://twitter.com/HugoGiraudel/status/738694810350014464

> This is your friendly reminder that semantic versioning starts at 0.1.0, not 0.0.1. You can’t start with a bug fix.

Also documented in Semantic Versioning's FAQ (http://semver.org/#how-should-i-deal-with-revisions-in-the-0yz-initial-development-phase)

> The simplest thing to do is start your initial development release at 0.1.0 and then increment the minor version for each subsequent release.