### PR TITLE
More informative message for DOT tree generation

### DIFF
--- a/lib/mix/lib/mix/tasks/app.tree.ex
+++ b/lib/mix/lib/mix/tasks/app.tree.ex
@@ -63,7 +63,7 @@ defmodule Mix.Tasks.App.Tree do
            dot -Tpng app_tree.dot -o app_tree.png
 
         For more options see http://www.graphviz.org/.
-        """
+        """ |> String.strip
     else
       Mix.Utils.print_tree({:normal, app}, callback, opts)
     end

--- a/lib/mix/lib/mix/tasks/app.tree.ex
+++ b/lib/mix/lib/mix/tasks/app.tree.ex
@@ -55,8 +55,15 @@ defmodule Mix.Tasks.App.Tree do
     end
 
     if opts[:format] == "dot" do
-      Mix.Utils.write_dot_graph!("app_tree", "application tree",
+      Mix.Utils.write_dot_graph!("app_tree.dot", "application tree",
                                  {:normal, app}, callback, opts)
+      Mix.shell.info """
+        Generated "app_tree.dot" in the current directory. To generate a PNG:
+
+           dot -Tpng app_tree.dot -o app_tree.png
+
+        For more options see http://www.graphviz.org/.
+        """
     else
       Mix.Utils.print_tree({:normal, app}, callback, opts)
     end

--- a/lib/mix/lib/mix/tasks/app.tree.ex
+++ b/lib/mix/lib/mix/tasks/app.tree.ex
@@ -57,8 +57,6 @@ defmodule Mix.Tasks.App.Tree do
     if opts[:format] == "dot" do
       Mix.Utils.write_dot_graph!("app_tree.dot", "application tree",
                                  {:normal, app}, callback, opts)
-      Mix.shell.info "Generated \"app_tree.dot\" in current directory.\n" <>
-                     "You can use http://www.graphviz.org/ to open it."
     else
       Mix.Utils.print_tree({:normal, app}, callback, opts)
     end

--- a/lib/mix/lib/mix/tasks/app.tree.ex
+++ b/lib/mix/lib/mix/tasks/app.tree.ex
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.App.Tree do
     end
 
     if opts[:format] == "dot" do
-      Mix.Utils.write_dot_graph!("app_tree.dot", "application tree",
+      Mix.Utils.write_dot_graph!("app_tree", "application tree",
                                  {:normal, app}, callback, opts)
     else
       Mix.Utils.print_tree({:normal, app}, callback, opts)

--- a/lib/mix/lib/mix/tasks/deps.tree.ex
+++ b/lib/mix/lib/mix/tasks/deps.tree.ex
@@ -58,7 +58,7 @@ defmodule Mix.Tasks.Deps.Tree do
             dot -Tpng deps_tree.dot -o deps_tree.png
 
         For more options see http://www.graphviz.org/.
-        """
+        """ |> String.strip
     else
       callback = callback(&format_tree/1, deps, opts)
       Mix.Utils.print_tree(root, callback, opts)

--- a/lib/mix/lib/mix/tasks/deps.tree.ex
+++ b/lib/mix/lib/mix/tasks/deps.tree.ex
@@ -51,7 +51,14 @@ defmodule Mix.Tasks.Deps.Tree do
 
     if opts[:format] == "dot" do
       callback = callback(&format_dot/1, deps, opts)
-      Mix.Utils.write_dot_graph!("deps_tree", "dependency tree", root, callback, opts)
+      Mix.Utils.write_dot_graph!("deps_tree.dot", "dependency tree", root, callback, opts)
+      Mix.shell.info """
+        Generated "deps_tree.dot" in the current directory. To generate a PNG:
+
+            dot -Tpng deps_tree.dot -o deps_tree.png
+
+        For more options see http://www.graphviz.org/.
+        """
     else
       callback = callback(&format_tree/1, deps, opts)
       Mix.Utils.print_tree(root, callback, opts)

--- a/lib/mix/lib/mix/tasks/deps.tree.ex
+++ b/lib/mix/lib/mix/tasks/deps.tree.ex
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Deps.Tree do
 
     if opts[:format] == "dot" do
       callback = callback(&format_dot/1, deps, opts)
-      Mix.Utils.write_dot_graph!("deps_tree.dot", "dependency tree", root, callback, opts)
+      Mix.Utils.write_dot_graph!("deps_tree", "dependency tree", root, callback, opts)
     else
       callback = callback(&format_tree/1, deps, opts)
       Mix.Utils.print_tree(root, callback, opts)

--- a/lib/mix/lib/mix/tasks/deps.tree.ex
+++ b/lib/mix/lib/mix/tasks/deps.tree.ex
@@ -52,8 +52,6 @@ defmodule Mix.Tasks.Deps.Tree do
     if opts[:format] == "dot" do
       callback = callback(&format_dot/1, deps, opts)
       Mix.Utils.write_dot_graph!("deps_tree.dot", "dependency tree", root, callback, opts)
-      Mix.shell.info "Generated \"deps_tree.dot\" in current directory.\n" <>
-                     "You can use http://www.graphviz.org/ to open it."
     else
       callback = callback(&format_tree/1, deps, opts)
       Mix.Utils.print_tree(root, callback, opts)

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -192,15 +192,10 @@ defmodule Mix.Utils do
   `false` if the given node must not be printed.
   """
   @spec write_dot_graph!(Path.t, String.t, term, (term -> {String.t, [term]}), Keyword.t) :: :ok
-  def write_dot_graph!(basepath, title, root, callback, _opts \\ []) do
+  def write_dot_graph!(path, title, root, callback, _opts \\ []) do
     {{parent, _}, children} = callback.(root)
     {dot, _} = build_dot_graph(parent, children, %{}, callback)
-    path = basepath <> ".dot"
     File.write! path, "digraph \"#{title}\" {\n#{dot}}\n"
-    Mix.shell.info "Generated \"#{path}\" in the current directory. " <>
-                   "To generate an SVG:\n\n" <>
-                   "    dot -Tsvg #{path} -o #{basepath <> ".svg"}\n\n" <>
-                   "For more options see http://www.graphviz.org/."
   end
 
   defp build_dot_graph(_parent, [], seen, _callback), do: {"", seen}
@@ -219,7 +214,7 @@ defmodule Mix.Utils do
         {"", seen}
       %{} when is_nil(edge_info) ->
         {~s(  "#{parent}" -> "#{name}"\n),
-         Map.put(seen, key, true),}
+         Map.put(seen, key, true)}
       %{} ->
         {~s(  "#{parent}" -> "#{name}" [label=\"#{edge_info}\"]\n),
          Map.put(seen, key, true)}

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -192,12 +192,15 @@ defmodule Mix.Utils do
   `false` if the given node must not be printed.
   """
   @spec write_dot_graph!(Path.t, String.t, term, (term -> {String.t, [term]}), Keyword.t) :: :ok
-  def write_dot_graph!(path, title, root, callback, _opts \\ []) do
+  def write_dot_graph!(basepath, title, root, callback, _opts \\ []) do
     {{parent, _}, children} = callback.(root)
     {dot, _} = build_dot_graph(parent, children, %{}, callback)
+    path = basepath <> ".dot"
     File.write! path, "digraph \"#{title}\" {\n#{dot}}\n"
-    Mix.shell.info "Generated \"#{path}\" in the current directory.\n" <>
-                   "You can use http://www.graphviz.org/ to open it."
+    Mix.shell.info "Generated \"#{path}\" in the current directory. " <>
+                   "To generate an SVG:\n\n" <>
+                   "    dot -Tsvg #{path} -o #{basepath <> ".svg"}\n\n" <>
+                   "For more options see http://www.graphviz.org/."
   end
 
   defp build_dot_graph(_parent, [], seen, _callback), do: {"", seen}

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -196,6 +196,8 @@ defmodule Mix.Utils do
     {{parent, _}, children} = callback.(root)
     {dot, _} = build_dot_graph(parent, children, %{}, callback)
     File.write! path, "digraph \"#{title}\" {\n#{dot}}\n"
+    Mix.shell.info "Generated \"#{path}\" in the current directory.\n" <>
+                   "You can use http://www.graphviz.org/ to open it."
   end
 
   defp build_dot_graph(_parent, [], seen, _callback), do: {"", seen}


### PR DESCRIPTION
Added an SVG example for converting the generated `.dot` file.

The intention of this is that users don't have to instantly go and hunt
for the docs if they already have graphviz installed.

This should work as is on Windows too, once installed and in the path.