### PR TITLE
Document change in behavior of `Enum.group_by` ordering.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,6 +283,7 @@ By restricting hierarchies in favor of named setups, it is straight-forward for 
   * [CLI] Add `--logger-otp-reports BOOL` and `--logger-sasl-reports BOOL` switches
   * [Compiler] Emit a summary of compilation errors when modules are missing
   * [Enum] Add `Enum.group_by/3` that allows developers to map on the value being grouped
+  * [Enum] Make list values in maps returned by `Enum.group_by/2` and `Enum.group_by/3` preserve the order of the input enumerable instead of reversing it.
   * [Enum] Add `Enum.drop_every/2` that drops every `nth`, including the first one
   * [Exception] Suggest possible functions on `UndefinedFunctionError` for existing modules
   * [Exception] Warn if unknown fields are given to `raise/2`


### PR DESCRIPTION
I noticed this difference in behavior while upgrading my application, but did not see it called out in the changelog anywhere so thought I'd add it.

On 1.2, here's how `group_by` behaved:

    iex(1)> 1..10 |> Enum.group_by(fn i -> i < 5 end)
    %{false: [10, 9, 8, 7, 6, 5], true: [4, 3, 2, 1]}

On 1.3, here's how it behaves:

    iex(1)> 1..10 |> Enum.group_by(fn i -> i < 5 end)
    %{false: [5, 6, 7, 8, 9, 10], true: [1, 2, 3, 4]}