### PR TITLE
Introduce Kernel.divrem/2

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -177,6 +177,24 @@ defmodule Kernel do
   end
 
   @doc """
+  Performs an integer division and returns both the quotient and remainder
+  as a tuple.
+
+  Raises an `ArithmeticError` exception if one of the arguments is not an
+  integer.
+
+  ## Examples
+
+      iex> divrem(5, 2)
+      {2, 1}
+
+  """
+  @spec divrem(integer, integer) :: {integer, integer}
+  def divrem(left, right) do
+    {:erlang.div(left, right), :erlang.rem(left, right)}
+  end
+
+  @doc """
   Stops the execution of the calling process with the given reason.
 
   Since evaluating this function causes the process to terminate,

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -571,6 +571,11 @@ defmodule KernelTest do
     assert_raise ArgumentError, fn -> pop_in(nil, ["john", :age]) end
   end
 
+  test "divrem/2" do
+    assert divrem(15, 2) == {7, 1}
+    assert_raise ArithmeticError, fn -> divrem(15.0, 2) end
+  end
+
   test "paths" do
     map = empty_map()
 


### PR DESCRIPTION
When you have need for `div` or `rem`, I think it's not unusual to want both of them, with the same arguments.

I've used it (in other languages – Ruby, Python, Haskell and others have some equivalent) for time formatting, where I had some number of seconds and wanted to convert into minutes, hours etc.

I "needed" it more recently for the Roman Numerals kata.

What do you think?

Maybe this could be made to work in guards by turning it into a macro – did not explore that. Let me know if I should. I don't see a use case for using it in guards, so maybe that could wait until someone offers one.
