### PR TITLE
Add a is_map/1 guard to Map.take/2, Map.drop/2, and Map.split/2

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -224,10 +224,16 @@ defmodule Map do
 
   """
   @spec take(map, Enumerable.t) :: map
-  def take(map, keys) do
+  def take(map, keys)
+
+  def take(map, keys) when is_map(map) do
     keys
     |> Enum.to_list
     |> do_take(map, [])
+  end
+
+  def take(non_map, _keys) do
+    :erlang.error({:badmap, non_map})
   end
 
   defp do_take([], _map, acc), do: :maps.from_list(acc)
@@ -448,10 +454,16 @@ defmodule Map do
 
   """
   @spec drop(map, Enumerable.t) :: map
-  def drop(map, keys) do
+  def drop(map, keys)
+
+  def drop(map, keys) when is_map(map) do
     keys
     |> Enum.to_list
     |> drop_list(map)
+  end
+
+  def drop(non_map, _keys) do
+    :erlang.error({:badmap, non_map})
   end
 
   defp drop_list([], acc), do: acc
@@ -474,10 +486,16 @@ defmodule Map do
 
   """
   @spec split(map, Enumerable.t) :: {map, map}
-  def split(map, keys) do
+  def split(map, keys)
+
+  def split(map, keys) when is_map(map) do
     keys
     |> Enum.to_list
     |> do_split([], map)
+  end
+
+  def split(non_map, _keys) do
+    :erlang.error({:badmap, non_map})
   end
 
   defp do_split([], inc, exc) do

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -52,16 +52,20 @@ defmodule MapTest do
   test "take/2" do
     assert Map.take(%{a: 1, b: 2, c: 3}, [:b, :c]) == %{b: 2, c: 3}
     assert Map.take(%{a: 1, b: 2, c: 3}, MapSet.new([:b, :c])) == %{b: 2, c: 3}
+    assert Map.take(%{a: 1, b: 2, c: 3}, []) == %{}
+    assert_raise BadMapError, fn -> Map.take(:foo, []) end
   end
 
   test "drop/2" do
     assert Map.drop(%{a: 1, b: 2, c: 3}, [:b, :c]) == %{a: 1}
     assert Map.drop(%{a: 1, b: 2, c: 3}, MapSet.new([:b, :c])) == %{a: 1}
+    assert_raise BadMapError, fn -> Map.drop(:foo, []) end
   end
 
   test "split/2" do
     assert Map.split(%{a: 1, b: 2, c: 3}, [:b, :c]) == {%{b: 2, c: 3}, %{a: 1}}
     assert Map.split(%{a: 1, b: 2, c: 3}, MapSet.new([:b, :c])) == {%{b: 2, c: 3}, %{a: 1}}
+    assert_raise BadMapError, fn -> Map.split(:foo, []) end
   end
 
   test "maps with optional comma" do


### PR DESCRIPTION
Without this, it was fine to not pass a map as the first argument to `Map.take/2`, `Map.drop/2`, and `Map.split/2` if the second argument was an empty enumerable of keys:

```elixir
iex> Map.take(:foo, [])
%{}
iex> Map.take(:foo, [:bar])
** (BadMapError) expected a map, got: :foo
```

With this commit, we always check for the first argument to be a map:

```elixir
iex> Map.take(:foo, [])
** (BadMapError) expected a map, got: :foo
```