### PR TITLE
Include with when warning about unsafe variables

### DIFF
--- a/lib/elixir/src/elixir_scope.erl
+++ b/lib/elixir/src/elixir_scope.erl
@@ -212,8 +212,8 @@ format_error({unused_match, Name, Kind}) ->
 
 format_error({unsafe_var, Name}) ->
   io_lib:format("the variable \"~ts\" is unsafe as it has been set inside "
-                "a case/cond/receive/if/&&/||. Please explicitly return the "
-                "variable value instead. For example:\n\n"
+                "a case/cond/receive/if/with/&&/||. Please explicitly return "
+                "the variable value instead. For example:\n\n"
                 "    case int do\n"
                 "      1 -> atom = :one\n"
                 "      2 -> atom = :two\n"


### PR DESCRIPTION
The unsafe variable warning can be triggered from the following `with`:

    state = true

    with true  <-state, state = !state,
    do: state,
    else: (other -> {other, state})