### PR TITLE
Fix failing Kernel.DialyzerTest under Windows

### DIFF
--- a/lib/elixir/test/elixir/kernel/dialyzer_test.exs
+++ b/lib/elixir/test/elixir/kernel/dialyzer_test.exs
@@ -16,7 +16,7 @@ defmodule Kernel.DialyzerTest do
       |> Path.join("base_plt")
       |> String.to_charlist()
 
-    # some os (e.g. Windows) does not provide HOME environment variable
+    # Some os (e.g. Windows) does not provide HOME environment variable
     unless System.get_env("HOME") do
       System.put_env("HOME", System.user_home())
     end

--- a/lib/elixir/test/elixir/kernel/dialyzer_test.exs
+++ b/lib/elixir/test/elixir/kernel/dialyzer_test.exs
@@ -16,7 +16,7 @@ defmodule Kernel.DialyzerTest do
       |> Path.join("base_plt")
       |> String.to_charlist()
 
-    # Some os (e.g. Windows) does not provide HOME environment variable
+    # Some OSs (like Windows) do not provide the HOME environment variable.
     unless System.get_env("HOME") do
       System.put_env("HOME", System.user_home())
     end

--- a/lib/elixir/test/elixir/kernel/dialyzer_test.exs
+++ b/lib/elixir/test/elixir/kernel/dialyzer_test.exs
@@ -16,6 +16,7 @@ defmodule Kernel.DialyzerTest do
       |> Path.join("base_plt")
       |> String.to_charlist()
 
+    # some os (e.g. Windows) does not provide HOME environment variable
     unless System.get_env("HOME") do
       System.put_env("HOME", System.user_home())
     end

--- a/lib/elixir/test/elixir/kernel/dialyzer_test.exs
+++ b/lib/elixir/test/elixir/kernel/dialyzer_test.exs
@@ -16,6 +16,10 @@ defmodule Kernel.DialyzerTest do
       |> Path.join("base_plt")
       |> String.to_charlist()
 
+    unless System.get_env("HOME") do
+      System.put_env("HOME", System.user_home())
+    end
+
     # Add a few key elixir modules for types
     files = Enum.map([Kernel, String, Keyword, Exception], &:code.which/1)
     :dialyzer.run([analysis_type: :plt_build, output_plt: plt,


### PR DESCRIPTION
Under Windows (7 Pro, 64 bit) the Kernel.DialyzerTest fails:
```
  1) Kernel.DialyzerTest: failure on setup_all callback, tests invalidated
     ** (ErlangError) erlang error: {:dialyzer_error, 'The HOME environment variable needs to be set so that Dialyzer knows where to find the default PLT'}
     stacktrace:
       dialyzer.erl:173: :dialyzer.run/1
       lib/elixir/test/elixir/kernel/dialyzer_test.exs:21: Kernel.DialyzerTest.__ex_unit_setup_all_0/1
       lib/elixir/test/elixir/kernel/dialyzer_test.exs:3: Kernel.DialyzerTest.__ex_unit__/2
```

Actually this is an erlang error: [dialyzer expects the environment variable HOME set](https://github.com/erlang/otp/blob/e1489c448b7486cdcfec6a89fea238d88e6ce2f3/lib/dialyzer/src/dialyzer_plt.erl#L229-L232).
But Windows does not have this environment variable available.
(It has HOMEDRIVE and HOMEPATH.)

This commit makes the DialyzerTest pass by setting the HOME environment variable (when necessary).

Using System.user_home to set the HOME env var works because System.user_home uses `:elixir_config.get(:home)`.
`elixir_config` gets the value of `:home` from `init:get_argument(home)` (see file `lib\elixir\src\elixir.erl`)
And - finally - erlang honors these environment variables when computing `home`
(see https://github.com/erlang/otp/blob/maint/erts/etc/common/erlexec.c#L1548-L1549).

Erlang sometimes uses `os:getenv("HOME")` and sometimes `init:get_argument(home)` to get the home directory of the user.