### PR TITLE
Fix failing SigilsTest for newline under Windows

### DIFF
--- a/lib/elixir/test/elixir/kernel/sigils_test.exs
+++ b/lib/elixir/test/elixir/kernel/sigils_test.exs
@@ -3,6 +3,8 @@ Code.require_file "../test_helper.exs", __DIR__
 defmodule Kernel.SigilsTest do
   use ExUnit.Case, async: true
 
+  import PathHelpers
+
   test "sigil s" do
     assert ~s(foo) == "foo"
     assert ~s(f#{:o}o) == "foo"
@@ -29,8 +31,22 @@ defmodule Kernel.SigilsTest do
     assert ~S(f\no) == "f\\no"
     assert ~S(foo\)) == "foo)"
     assert ~S[foo\]] == "foo]"
-    assert ~S(foo\
+  end
+
+  if windows?() do
+
+    test "sigil S newline windows" do
+      assert ~S(foo\
+bar) == "foo\\\r\nbar"
+    end
+
+  else
+
+    test "sigil S newline unix" do
+      assert ~S(foo\
 bar) == "foo\\\nbar"
+    end
+
   end
 
   test "sigil S with heredoc" do

--- a/lib/elixir/test/elixir/kernel/sigils_test.exs
+++ b/lib/elixir/test/elixir/kernel/sigils_test.exs
@@ -34,19 +34,15 @@ defmodule Kernel.SigilsTest do
   end
 
   if windows?() do
-
     test "sigil S newline windows" do
       assert ~S(foo\
 bar) == "foo\\\r\nbar"
     end
-
   else
-
     test "sigil S newline unix" do
       assert ~S(foo\
 bar) == "foo\\\nbar"
     end
-
   end
 
   test "sigil S with heredoc" do


### PR DESCRIPTION
SigilsTest fails for newline under Windows

```
  1) test sigil S (Kernel.SigilsTest)
     lib/elixir/test/elixir/kernel/sigils_test.exs:18
     Assertion with == failed
     code: ~S"foo\\\r\nbar" == "foo\\\nbar"
     lhs:  "foo\\\r\nbar"
     rhs:  "foo\\\nbar"
     stacktrace:
       lib/elixir/test/elixir/kernel/sigils_test.exs:32: (test)
```

[Newlines](https://en.wikipedia.org/wiki/Newline).
[Github](https://help.github.com/articles/dealing-with-line-endings/#platform-windows) recommends setting `core.autocrlf true` on Windows for cross-platform projects.
[Git documentation](https://git-scm.com/book/tr/v2/Customizing-Git-Git-Configuration#Formatting-and-Whitespace) also recommends this setting on Windows.
Using this setting let the SigilsTest fail because the sigil contains a newline which is `\r\n` under Windows and not `\n`.

Use os dependent tests for newline.