### PR TITLE
Check for recursive imports in config files.

### DIFF
--- a/lib/mix/test/fixtures/configs/imports_recursive.exs
+++ b/lib/mix/test/fixtures/configs/imports_recursive.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+import_config "recursive.exs"

--- a/lib/mix/test/fixtures/configs/recursive.exs
+++ b/lib/mix/test/fixtures/configs/recursive.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+import_config "imports_recursive.exs"

--- a/lib/mix/test/mix/config_test.exs
+++ b/lib/mix/test/mix/config_test.exs
@@ -62,6 +62,20 @@ defmodule Mix.ConfigTest do
     assert config() == [my_app: [key: :value]]
   end
 
+  test "import_config/1 raises for recursive import" do
+    use Mix.Config
+
+    exception =
+      assert_raise Mix.Config.LoadError, fn ->
+        import_config fixture_path("configs/imports_recursive.exs")
+      end
+
+    message = Exception.message(exception)
+
+    assert message =~ ~r/could not load config .*\/imports_recursive\.exs\n/
+    assert message =~ ~r/\(ArgumentError\) recursive load of.*\/imports_recursive.exs detected/
+  end
+
   test "import_config/1 with wildcards" do
     use Mix.Config
     import_config fixture_path("configs/good_*.exs")


### PR DESCRIPTION
- Closes [#4757](https://github.com/elixir-lang/elixir/issues/4757)
- Note that signature of `Code.eval_file/1` has been modified to allow
  pass-through of options to `Code.eval_string/3`.