### PR TITLE
mix xref graph

### DIFF
--- a/lib/mix/lib/mix/tasks/app.tree.ex
+++ b/lib/mix/lib/mix/tasks/app.tree.ex
@@ -56,7 +56,7 @@ defmodule Mix.Tasks.App.Tree do
 
     if opts[:format] == "dot" do
       Mix.Utils.write_dot_graph!("app_tree.dot", "application tree",
-                                 {:normal, app}, callback, opts)
+                                 [{:normal, app}], callback, opts)
       """
       Generated "app_tree.dot" in the current directory. To generate a PNG:
 
@@ -67,7 +67,7 @@ defmodule Mix.Tasks.App.Tree do
       |> String.trim_trailing
       |> Mix.shell.info
     else
-      Mix.Utils.print_tree({:normal, app}, callback, opts)
+      Mix.Utils.print_tree([{:normal, app}], callback, opts)
     end
   end
 

--- a/lib/mix/lib/mix/tasks/deps.tree.ex
+++ b/lib/mix/lib/mix/tasks/deps.tree.ex
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Deps.Tree do
 
     if opts[:format] == "dot" do
       callback = callback(&format_dot/1, deps, opts)
-      Mix.Utils.write_dot_graph!("deps_tree.dot", "dependency tree", root, callback, opts)
+      Mix.Utils.write_dot_graph!("deps_tree.dot", "dependency tree", [root], callback, opts)
       """
       Generated "deps_tree.dot" in the current directory. To generate a PNG:
 
@@ -63,7 +63,7 @@ defmodule Mix.Tasks.Deps.Tree do
       |> Mix.shell.info
     else
       callback = callback(&format_tree/1, deps, opts)
-      Mix.Utils.print_tree(root, callback, opts)
+      Mix.Utils.print_tree([root], callback, opts)
     end
   end
 

--- a/lib/mix/test/mix/tasks/app.tree_test.exs
+++ b/lib/mix/test/mix/tasks/app.tree_test.exs
@@ -87,6 +87,7 @@ defmodule Mix.Tasks.App.TreeTest do
 
       assert File.read!("app_tree.dot") == """
         digraph "application tree" {
+          "test"
           "test" -> "elixir"
           "test" -> "logger"
           "logger" -> "elixir"

--- a/lib/mix/test/mix/tasks/deps.tree_test.exs
+++ b/lib/mix/test/mix/tasks/deps.tree_test.exs
@@ -117,6 +117,7 @@ defmodule Mix.Tasks.Deps.TreeTest do
 
       assert File.read!("deps_tree.dot") == """
         digraph "dependency tree" {
+          "sample"
           "sample" -> "git_repo" [label=">= 0.1.0"]
           "sample" -> "deps_on_git_repo" [label="0.2.0"]
         }
@@ -127,6 +128,7 @@ defmodule Mix.Tasks.Deps.TreeTest do
 
       assert File.read!("deps_tree.dot") == """
         digraph "dependency tree" {
+          "sample"
           "sample" -> "git_repo" [label=">= 0.1.0"]
           "sample" -> "deps_on_git_repo" [label="0.2.0"]
           "deps_on_git_repo" -> "git_repo" [label=""]

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -467,12 +467,12 @@ defmodule Mix.Tasks.XrefTest do
     assert_graph """
     sample application
     ├── lib/a.ex
-    │   └── lib/b.ex
-    │       └── lib/a.ex
+    │   └── lib/b.ex (runtime)
+    │       └── lib/a.ex (runtime)
     ├── lib/b.ex
     ├── lib/c.ex
     └── lib/d.ex
-        └── lib/a.ex
+        └── lib/a.ex (compile)
     """
   end
 
@@ -481,7 +481,7 @@ defmodule Mix.Tasks.XrefTest do
     sample application
     ├── lib/a.ex
     └── lib/d.ex
-        └── lib/a.ex
+        └── lib/a.ex (compile)
     """
   end
 
@@ -489,8 +489,8 @@ defmodule Mix.Tasks.XrefTest do
     assert_graph ~w[--exclude lib/d.ex], """
     sample application
     ├── lib/a.ex
-    │   └── lib/b.ex
-    │       └── lib/a.ex
+    │   └── lib/b.ex (runtime)
+    │       └── lib/a.ex (runtime)
     ├── lib/b.ex
     └── lib/c.ex
     """
@@ -500,12 +500,12 @@ defmodule Mix.Tasks.XrefTest do
     assert_graph ~w[--format dot], true, """
     digraph "xref graph" {
       "sample application" -> "lib/a.ex"
-      "lib/a.ex" -> "lib/b.ex"
-      "lib/b.ex" -> "lib/a.ex"
+      "lib/a.ex" -> "lib/b.ex" [label="(runtime)"]
+      "lib/b.ex" -> "lib/a.ex" [label="(runtime)"]
       "sample application" -> "lib/b.ex"
       "sample application" -> "lib/c.ex"
       "sample application" -> "lib/d.ex"
-      "lib/d.ex" -> "lib/a.ex"
+      "lib/d.ex" -> "lib/a.ex" [label="(compile)"]
     }
     """
   end
@@ -513,8 +513,8 @@ defmodule Mix.Tasks.XrefTest do
   test "graph: source" do
     assert_graph ~w[--source lib/a.ex], """
     lib/a.ex
-    └── lib/b.ex
-        └── lib/a.ex
+    └── lib/b.ex (runtime)
+        └── lib/a.ex (runtime)
     """
   end
 
@@ -527,9 +527,9 @@ defmodule Mix.Tasks.XrefTest do
   test "graph: sink" do
     assert_graph ~w[--sink lib/b.ex], """
     lib/b.ex
-    └── lib/a.ex
-        ├── lib/d.ex
-        └── lib/b.ex
+    └── lib/a.ex (runtime)
+        ├── lib/d.ex (compile)
+        └── lib/b.ex (runtime)
     """
   end
 
@@ -552,6 +552,8 @@ defmodule Mix.Tasks.XrefTest do
         def a do
           B.a
         end
+
+        def b, do: :ok
       end
       """
 
@@ -570,9 +572,7 @@ defmodule Mix.Tasks.XrefTest do
 
       File.write! "lib/d.ex", """
       defmodule :d do
-        def a do
-          A.a
-        end
+        A.b
       end
       """
 

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -465,46 +465,43 @@ defmodule Mix.Tasks.XrefTest do
 
   test "graph: basic usage" do
     assert_graph """
-    sample application
-    ├── lib/a.ex
-    │   └── lib/b.ex (runtime)
-    │       └── lib/a.ex (runtime)
-    ├── lib/b.ex
-    ├── lib/c.ex
-    └── lib/d.ex
-        └── lib/a.ex (compile)
+    lib/a.ex
+    └── lib/b.ex
+        └── lib/a.ex
+    lib/b.ex
+    lib/c.ex
+    lib/d.ex
+    └── lib/a.ex (compile)
     """
   end
 
   test "graph: exclude" do
     assert_graph ~w[--exclude lib/c.ex --exclude lib/b.ex], """
-    sample application
-    ├── lib/a.ex
-    └── lib/d.ex
-        └── lib/a.ex (compile)
+    lib/a.ex
+    lib/d.ex
+    └── lib/a.ex (compile)
     """
   end
 
   test "graph: exclude 1" do
     assert_graph ~w[--exclude lib/d.ex], """
-    sample application
-    ├── lib/a.ex
-    │   └── lib/b.ex (runtime)
-    │       └── lib/a.ex (runtime)
-    ├── lib/b.ex
-    └── lib/c.ex
+    lib/a.ex
+    └── lib/b.ex
+        └── lib/a.ex
+    lib/b.ex
+    lib/c.ex
     """
   end
 
   test "graph: dot format" do
     assert_graph ~w[--format dot], true, """
     digraph "xref graph" {
-      "sample application" -> "lib/a.ex"
-      "lib/a.ex" -> "lib/b.ex" [label="(runtime)"]
-      "lib/b.ex" -> "lib/a.ex" [label="(runtime)"]
-      "sample application" -> "lib/b.ex"
-      "sample application" -> "lib/c.ex"
-      "sample application" -> "lib/d.ex"
+      "lib/a.ex"
+      "lib/a.ex" -> "lib/b.ex"
+      "lib/b.ex" -> "lib/a.ex"
+      "lib/b.ex"
+      "lib/c.ex"
+      "lib/d.ex"
       "lib/d.ex" -> "lib/a.ex" [label="(compile)"]
     }
     """
@@ -513,8 +510,8 @@ defmodule Mix.Tasks.XrefTest do
   test "graph: source" do
     assert_graph ~w[--source lib/a.ex], """
     lib/a.ex
-    └── lib/b.ex (runtime)
-        └── lib/a.ex (runtime)
+    └── lib/b.ex
+        └── lib/a.ex
     """
   end
 
@@ -527,9 +524,9 @@ defmodule Mix.Tasks.XrefTest do
   test "graph: sink" do
     assert_graph ~w[--sink lib/b.ex], """
     lib/b.ex
-    └── lib/a.ex (runtime)
+    └── lib/a.ex
         ├── lib/d.ex (compile)
-        └── lib/b.ex (runtime)
+        └── lib/b.ex
     """
   end
 
@@ -561,6 +558,7 @@ defmodule Mix.Tasks.XrefTest do
       defmodule B do
         def a do
           A.a
+          B.a
         end
       end
       """

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -523,10 +523,11 @@ defmodule Mix.Tasks.XrefTest do
 
   test "graph: sink" do
     assert_graph ~w[--sink lib/b.ex], """
-    lib/b.ex
-    └── lib/a.ex
-        ├── lib/d.ex (compile)
-        └── lib/b.ex
+    lib/a.ex
+    └── lib/b.ex
+        └── lib/a.ex
+    lib/d.ex
+    └── lib/a.ex (compile)
     """
   end
 


### PR DESCRIPTION
Implements #4810.

Maybe it would be nice to also emit whether it's a runtime or compile time dep as edge_info in --format dot? I'm not sure it's worth the extra effort. Thoughts?

/cc @josevalim @michalmuskala 