### PR TITLE
Idiomatic parentheses in Macro.to_string on some macros

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -831,6 +831,13 @@ defmodule Macro do
   defp call_to_string(other, fun),
     do: to_string(other, fun)
 
+  # Omit parenthesis for some macros for more idiomatic output
+  defp call_to_string_with_args(target, args, fun) when target in [:defmodule, :def, :defp] do
+    target = call_to_string(target, fun)
+    args = args_to_string(args, fun)
+    target <> " " <> args
+  end
+
   defp call_to_string_with_args(target, args, fun) do
     target = call_to_string(target, fun)
     args = args_to_string(args, fun)

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -366,8 +366,8 @@ defmodule MacroTest do
 
   test "nested to string" do
     assert Macro.to_string(quote do: (defmodule Foo do def foo do 1 + 1 end end)) <> "\n" == """
-    defmodule(Foo) do
-      def(foo) do
+    defmodule Foo do
+      def foo do
         1 + 1
       end
     end


### PR DESCRIPTION
I'm opening this PR for feedback. It's not complete. The problem it solves is only one of aesthetics (and perhaps of teaching non-idiomatic style). I will not be offended if you simply close it. 

Simply stated, `Macro.to_string` will put parentheses around arguments in a function call, including some places where it is non-idiomatic. Example:

```elixir
quote do
  defmodule MathyThings do
    def add(a, b) do
      a + b
    end
  end
end |> Macro.to_string |> IO.puts
```

Current output:

```elixir
defmodule(MathyThings) do
  def(add(a, b)) do
    a + b
  end
end
```

With this change applied:

```elixir
defmodule MathyThings do
  def add(a, b) do
    a + b
  end
end
```

I've only listed some macros off the top of my head in the guard clause. Obviously this list needs to be updated if we want this behaviour. I would appreciate pointers on what to include, in that case. Also, more tests should be added. I will happily add those.