### PR TITLE
Simplify code to remove warning: unsafe in 'case'

### DIFF
--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -318,20 +318,16 @@ store_each(Check, Kind, File, Location, Module, Defaults, {function, Ann, Name, 
   Tuple   = {Name, Arity},
   HasBody = Clauses =/= [],
 
-  case ets:take(Defs, {def, Tuple}) of
+  {FinalAnn, FinalLocation, FinalDefaults} = case ets:take(Defs, {def, Tuple}) of
     [{_, StoredKind, StoredAnn, StoredFile, StoredCheck,
         StoredLocation, {StoredDefaults, LastHasBody, LastDefaults}}] ->
-      FinalAnn = StoredAnn,
-      FinalLocation = StoredLocation,
-      FinalDefaults = {max(Defaults, StoredDefaults), HasBody, Defaults},
       check_valid_kind(Ann, File, Name, Arity, Kind, StoredKind),
       (Check and StoredCheck) andalso
         check_valid_clause(Ann, File, Name, Arity, Kind, Data, StoredAnn, StoredFile),
-      check_valid_defaults(Ann, File, Name, Arity, Kind, Defaults, StoredDefaults, LastDefaults, LastHasBody);
+      check_valid_defaults(Ann, File, Name, Arity, Kind, Defaults, StoredDefaults, LastDefaults, LastHasBody),
+      {StoredAnn, StoredLocation, {max(Defaults, StoredDefaults), HasBody, Defaults}};
     [] ->
-      FinalAnn = Ann,
-      FinalLocation = Location,
-      FinalDefaults = {Defaults, HasBody, Defaults}
+      {Ann, Location, {Defaults, HasBody, Defaults}}
   end,
 
   Check andalso ets:insert(Data, {?last_def, {Name, Arity}}),


### PR DESCRIPTION
When reading the code I noticed 3 warnings from erlang:

1. variable `FinalAnn` unsafe in `case`
2. variable `FinalLocation` unsafe in `case`
3. variable `FinalDefaults` unsafe in `case`

Which can be eliminated with pattern matching at the return of the case statement. 