### PR TITLE
Clarify some confusion regarding the === operator.

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1051,7 +1051,7 @@ defmodule Kernel do
   @doc """
   Returns `true` if the two items are equal.
 
-  This operator considers 1 and 1.0 to be equal. For match
+  This operator considers 1 and 1.0 to be equal. For stricter
   semantics, use `===` instead.
 
   All terms in Elixir can be compared with each other.
@@ -1097,11 +1097,12 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns `true` if the two items are match.
+  Returns `true` if the two items are exactly equal.
 
-  This operator gives the same semantics as the one existing in
-  pattern matching, i.e., `1` and `1.0` are equal, but they do
-  not match.
+  The items are only considered to be exactly equal if they
+  have the same value and are of the same type. For example,
+  `1 == 1.0` returns true, but since they are of different
+  types, `1 === 1.0` returns false.
 
   All terms in Elixir can be compared with each other.
 
@@ -1122,7 +1123,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns `true` if the two items do not match.
+  Returns `true` if the two items are not exactly equal.
 
   All terms in Elixir can be compared with each other.
 

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -15,7 +15,7 @@ defmodule Map do
 
   Maps do not impose any restriction on the key type: anything can be a key in a
   map. As a key-value structure, maps do not allow duplicated keys; keys are
-  compared using the match operator (`===`).
+  compared using the exact-equality operator (`===`).
 
   When the key in a key-value pair is an atom, the `key: value` shorthand syntax
   can be used:


### PR DESCRIPTION
- The new `Map` module doc added in #4820 called `===`
  the match operator but `=` is the match operator.
- I looked at the docs for `===` to see what it is called
  and it did not really give it a name. It did, however,
  use the confusing expression "returns true if the two
  times are match".  "Are match" is not a very clear explanation.
- The [Erlang docs](http://erlang.org/doc/reference_manual/expressions.html#id80318) describe the equivalent `=:=` operator as
  "Exactly equal to", so I think "exact equality operator" is a
  better name for this.