### PR TITLE
Fix the name of the ExUnit.DescribeTest module

### DIFF
--- a/lib/ex_unit/test/ex_unit/describe_test.exs
+++ b/lib/ex_unit/test/ex_unit/describe_test.exs
@@ -1,6 +1,6 @@
 Code.require_file "../test_helper.exs", __DIR__
 
-defmodule ExUnit.BundleTest do
+defmodule ExUnit.DescribeTest do
   use ExUnit.Case, async: true
 
   @moduletag [attribute_tag: :from_module]


### PR DESCRIPTION
It was ExUnit.BundleTest, in memory of ancient times when "describe" was called "bundle". 😛 