### PR TITLE
Add warning for an invalid path on deps.clean task

### DIFF
--- a/lib/mix/lib/mix/tasks/deps.clean.ex
+++ b/lib/mix/lib/mix/tasks/deps.clean.ex
@@ -10,11 +10,11 @@ defmodule Mix.Tasks.Deps.Clean do
   Since this is a destructive action, cleaning of dependencies
   can only happen by passing arguments/options:
 
-    * `dep1, dep2` - the name of dependencies to be deleted
-    * `--unlock`   - also unlocks the deleted dependencies
-    * `--build`    - deletes only compiled files (keeps source files)
-    * `--all`      - deletes all dependencies
-    * `--unused`   - deletes only unused dependencies
+    * `dep1 dep2` - the name of dependencies to be deleted separated by a space
+    * `--unlock` - also unlocks the deleted dependencies
+    * `--build` - deletes only compiled files (keeps source files)
+    * `--all` - deletes all dependencies
+    * `--unused` - deletes only unused dependencies
       (i.e. dependencies no longer mentioned in `mix.exs` are removed)
 
   By default this task works across all environments,
@@ -73,6 +73,14 @@ defmodule Mix.Tasks.Deps.Clean do
     apps -- Enum.map(deps, &Atom.to_string(&1.app))
   end
 
+  defp maybe_warn_for_invalid_path(path, dependency) do
+    unless File.dir?(path) do
+      Mix.shell.error "warning: the dependency #{dependency} is not present in the build directory"
+    end
+
+    path
+  end
+
   defp do_clean(apps, deps, build_path, deps_path, build_only?) do
     shell = Mix.shell
 
@@ -87,6 +95,7 @@ defmodule Mix.Tasks.Deps.Clean do
       # Remove everything from the build directory of dependencies
       build_path
       |> Path.join(to_string(app))
+      |> maybe_warn_for_invalid_path(app)
       |> Path.wildcard
       |> Enum.each(&File.rm_rf!/1)
 

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -692,6 +692,21 @@ defmodule Mix.Tasks.DepsTest do
     end
   end
 
+  test "warns on invalid path on clean dependencies" do
+    Mix.Project.push CleanDepsApp
+
+    in_fixture "deps_status", fn ->
+      File.mkdir_p!("deps/raw_sample")
+      File.mkdir_p!("_build/dev/lib/raw_sample")
+
+      Mix.Tasks.Deps.Clean.run ["raw_sample_with_a_typo"]
+      assert File.exists?("deps/raw_sample")
+
+      msg = "warning: the dependency raw_sample_with_a_typo is not present in the build directory"
+      assert_received {:mix_shell, :error, [^msg]}
+    end
+  end
+
   test "does not remove dependency source when using :path" do
     Mix.Project.push CleanDepsApp
 


### PR DESCRIPTION
I think it could be useful to warn when the user makes a typo like `mix deps.clean pheonix` instead of just printing `* Cleaning pheonix` even if the `File.rm_rf!` did nothing.

I’v decided to just check if the path is a directory instead of checking in the app’s dependencies because a user could want to clean an old dependency not present in the app.

The message could be something else, english is not my first language 😄