### PR TITLE
Support (exported) macros with defoverridable/super

### DIFF
--- a/lib/elixir/src/elixir_translator.erl
+++ b/lib/elixir/src/elixir_translator.erl
@@ -161,8 +161,15 @@ translate({super, Meta, Args}, S) when is_list(Args) ->
                     "arguments as the current function")
   end,
 
-  Super = elixir_def_overridable:name(Module, Function),
-  {{call, ?ann(Meta), {atom, ?ann(Meta), Super}, TArgs}, TS#elixir_scope{super=true}};
+  {FinalName, FinalArgs} =
+    case elixir_def_overridable:kind_and_name(Module, Function) of
+      {Kind, Name} when Kind == def; Kind == defp ->
+        {Name, TArgs};
+      {Kind, Name} when Kind == defmacro; Kind == defmacrop ->
+        {elixir_utils:macro_name(Name), [{var, ?ann(Meta), '_@CALLER'} | TArgs]}
+    end,
+
+  {{call, ?ann(Meta), {atom, ?ann(Meta), FinalName}, FinalArgs}, TS#elixir_scope{super=true}};
 
 %% Variables
 

--- a/lib/elixir/test/elixir/kernel/overridable_test.exs
+++ b/lib/elixir/test/elixir/kernel/overridable_test.exs
@@ -93,6 +93,18 @@ defmodule Kernel.Overridable do
   def many_clauses(x) do
     super(x)
   end
+
+  ## Macros
+
+  defmacro overridable_macro(x) do
+    x + 100
+  end
+
+  defoverridable overridable_macro: 1
+
+  defmacro overridable_macro(x) do
+    super(x) + 1_000
+  end
 end
 
 defmodule Kernel.OverridableTest do
@@ -169,5 +181,9 @@ defmodule Kernel.OverridableTest do
           "nofile:4: no super defined for foo/0 in module Foo.Forwarding. " <>
           "Overridable functions available are: bar/0"
     end
+  end
+
+  test "overridable macros" do
+    assert Overridable.overridable_macro(1) == 1101
   end
 end


### PR DESCRIPTION
This is a WIP PR that I'd really like to collect feedback on; it's a possible *partial* fix for #4830 as it fixes `super()` and `defoverridable` for public macros but not private macros.

Is this a good way to approach this? :)