### PR TITLE
Clarify Enum.group_by/3 deprecation message

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -999,7 +999,8 @@ defmodule Enum do
 
   # TODO: Remove on 2.0
   def group_by(enumerable, dict, fun) when is_function(fun, 1) do
-    IO.warn "Enum.group_by/3 with a map/dictionary as second element is deprecated, please use a map instead"
+    IO.warn "Enum.group_by/3 with a map/dictionary as second element is deprecated. " <>
+      "A map is used by default and it is no longer required to pass one to this function"
     reduce(reverse(enumerable), dict, fn(entry, categories) ->
       Dict.update(categories, fun.(entry), [entry], &[entry | &1])
     end)


### PR DESCRIPTION
When upgrading one of my projects to Elixir v1.3, I found the `Enum.group_by/3` deprecation message to be a bit confusing. It says to `please use a map instead`, but a map is used by default with the new form of `Enum.group_by/3`. The user only needs to remove the map as an argument to the function.

I think this makes it a little more clear what do to. I'm open to any suggestions here.