### PR TITLE
Raise an error when trying to make private macros overridable

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -830,6 +830,10 @@ defmodule Module do
         false ->
           {name, arity} = tuple
           raise "cannot make function #{name}/#{arity} overridable because it was not defined"
+        {{{:def, {name, arity}}, :defmacrop, _line, _file, _check, _location, _defaults}, _clauses} ->
+          raise ArgumentError,
+            "cannot make private macro #{name}/#{arity} overridable, overriding " <>
+            "private macros is not supported"
         clause ->
           neighbours =
             if :elixir_compiler.get_opt(:internal) do

--- a/lib/elixir/test/elixir/kernel/overridable_test.exs
+++ b/lib/elixir/test/elixir/kernel/overridable_test.exs
@@ -189,4 +189,18 @@ defmodule Kernel.OverridableTest do
   test "overridable macros" do
     assert Overridable.overridable_macro(1) == 1101
   end
+
+  test "private macros can't be overridden" do
+    message =
+      "cannot make private macro foo/0 overridable, overriding " <>
+      "private macros is not supported"
+    assert_raise ArgumentError, message, fn ->
+      Code.eval_string """
+      defmodule Foo do
+        defmacrop foo, do: 1
+        defoverridable foo: 0
+      end
+      """
+    end
+  end
 end


### PR DESCRIPTION
Part of what discussed in #4830. I'm raising a `RuntimeError` as you can see in the code but I think that a `CompileError` would be more appropriate, however the neighbour code raises a `RuntimeError` for a very similar situation; should I make both `CompileError`s? 

(I will also add a test later for the neighbour error, which apparently has no tests)