### PR TITLE
Fix h helper for binary operators, closes #4859

### DIFF
--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -139,6 +139,8 @@ defmodule IEx.Introspection do
     end)
   end
 
+  defp has_content?(nil),
+    do: false
   defp has_content?({_, _, _, _, false}),
     do: false
   defp has_content?({{name, _}, _, _, _, nil}),

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -34,9 +34,11 @@ defmodule IEx.HelpersTest do
   test "h helper function" do
     pwd_h = "* def pwd()\n\nPrints the current working directory.\n\n"
     c_h   = "* def c(files, path \\\\ :in_memory)\n\nCompiles the given files."
+    eq_h  = "* def ==(left, right)\n\nReturns `true` if the two items are equal.\n\n"
 
     assert capture_io(fn -> h IEx.Helpers.pwd/0 end) =~ pwd_h
     assert capture_io(fn -> h IEx.Helpers.c/2 end) =~ c_h
+    assert capture_io(fn -> h ==/2 end) =~ eq_h
 
     assert capture_io(fn -> h IEx.Helpers.c/1 end) =~ c_h
     assert capture_io(fn -> h pwd end) =~ pwd_h


### PR DESCRIPTION
As reported in #4859, the `h` helper was not working with `==/2`, or `div/2`
It seems the regression is here since 1.3.0-rc.0.