### PR TITLE
Stop appending a trailing dot when autocompleting modules in IEx.

### DIFF
--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -319,8 +319,12 @@ defmodule IEx.Autocomplete do
     to_entries(fun)
   end
 
+  defp to_hint(%{kind: :module, name: name}, hint) when name == hint do
+    format_hint(name, name) <> "."
+  end
+
   defp to_hint(%{kind: :module, name: name}, hint) do
-    format_hint(name, hint) <> "."
+    format_hint(name, hint)
   end
 
   defp to_hint(%{kind: :function, name: name}, hint) do

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -8,7 +8,7 @@ defmodule IEx.AutocompleteTest do
   end
 
   test "Erlang module completion" do
-    assert expand(':zl') == {:yes, 'ib.', []}
+    assert expand(':zl') == {:yes, 'ib', []}
   end
 
   test "Erlang module no completion" do
@@ -35,7 +35,7 @@ defmodule IEx.AutocompleteTest do
 
   test "Elixir completion" do
     assert expand('En') == {:yes, 'um', []}
-    assert expand('Enumera') == {:yes, 'ble.', []}
+    assert expand('Enumera') == {:yes, 'ble', []}
   end
 
   test "Elixir completion with self" do
@@ -45,7 +45,7 @@ defmodule IEx.AutocompleteTest do
   test "Elixir completion on modules from load path" do
     assert expand('Str') == {:yes, [], ['Stream', 'String', 'StringIO']}
     assert expand('Ma') == {:yes, '', ['Macro', 'Map', 'MapSet', 'MatchError']}
-    assert expand('Dic') == {:yes, 't.', []}
+    assert expand('Dic') == {:yes, 't', []}
     assert expand('Ex')  == {:yes, [], ['ExUnit', 'Exception']}
   end
 
@@ -72,11 +72,11 @@ defmodule IEx.AutocompleteTest do
   end
 
   test "Elixir root submodule completion" do
-    assert expand('Elixir.Acce') == {:yes, 'ss.', []}
+    assert expand('Elixir.Acce') == {:yes, 'ss', []}
   end
 
   test "Elixir submodule completion" do
-    assert expand('String.Cha') == {:yes, 'rs.', []}
+    assert expand('String.Cha') == {:yes, 'rs', []}
   end
 
   test "Elixir submodule no completion" do
@@ -118,9 +118,9 @@ defmodule IEx.AutocompleteTest do
   test "completion inside expression" do
     assert expand('1 En') == {:yes, 'um', []}
     assert expand('Test(En') == {:yes, 'um', []}
-    assert expand('Test :zl') == {:yes, 'ib.', []}
-    assert expand('[:zl') == {:yes, 'ib.', []}
-    assert expand('{:zl') == {:yes, 'ib.', []}
+    assert expand('Test :zl') == {:yes, 'ib', []}
+    assert expand('[:zl') == {:yes, 'ib', []}
+    assert expand('{:zl') == {:yes, 'ib', []}
   end
 
   test "ampersand completion" do
@@ -133,7 +133,7 @@ defmodule IEx.AutocompleteTest do
   end
 
   test "Elixir completion sublevel" do
-    assert expand('IEx.AutocompleteTest.SublevelTest.') == {:yes, 'LevelA.', []}
+    assert expand('IEx.AutocompleteTest.SublevelTest.') == {:yes, 'LevelA', []}
   end
 
   defmodule MyServer do
@@ -145,7 +145,7 @@ defmodule IEx.AutocompleteTest do
   test "complete aliases of Elixir modules" do
     Application.put_env(:iex, :autocomplete_server, MyServer)
 
-    assert expand('MyL') == {:yes, 'ist.', []}
+    assert expand('MyL') == {:yes, 'ist', []}
     assert expand('MyList') == {:yes, '.', []}
     assert expand('MyList.to_integer') == {:yes, [], ['to_integer/1', 'to_integer/2']}
   end
@@ -153,7 +153,7 @@ defmodule IEx.AutocompleteTest do
   test "complete aliases of Erlang modules" do
     Application.put_env(:iex, :autocomplete_server, MyServer)
 
-    assert expand('EL') == {:yes, 'ist.', []}
+    assert expand('EL') == {:yes, 'ist', []}
     assert expand('EList') == {:yes, '.', []}
     assert expand('EList.map') == {:yes, [], ['map/2', 'mapfoldl/3', 'mapfoldr/3']}
   end


### PR DESCRIPTION
I find this behavior to be surprising and annoying. I regularly type `h [first few chars of mod name]<tab><enter>` in IEx to read the read the moduledoc of a particular module, and the trailing period gets in the way every time.

Here's a demonstration showing what happens to me regularly when I try to read the `@moduledoc` for a module:

![iex_autocomplete_original](https://cloud.githubusercontent.com/assets/49391/16309353/43595d2c-391d-11e6-9ac9-8ecfc25af232.gif)

With this change, it avoids this problem:

![iex_autocomplete_improved](https://cloud.githubusercontent.com/assets/49391/16309338/391c69bc-391d-11e6-910e-213a789389ab.gif)

Now, I know the existing behavior must be intentional (after all, it's been there a long time and was specified by tests) so I'm fully expecting that this may not be merged.  If the elixir-core team feels the existing behavior is best, that's fine.  Figured I'd open the PR and see if @josevalim and the team are open to changing, it, though, since I've found it so consistently annoying.

