### PR TITLE
Add missing backquote in Module docs

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -369,7 +369,7 @@ defmodule Module do
     * `@compile :debug_info` - includes `:debug_info` regardless of the
       setting in `Code.compiler_options`
 
-    * `@compile {:debug_info, false} - disables `:debug_info` regardless
+    * `@compile {:debug_info, false}` - disables `:debug_info` regardless
       of the setting in `Code.compiler_options`
 
     * `@compile {:inline, some_fun: 2, other_fun: 3}` - inlines the given


### PR DESCRIPTION
I guess this could be backported to 1.3.x cuz the docs will look off