### PR TITLE
Integer.(un)digits/2 improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### 1. Enhancements
 
+#### Elixir
+
+  * [Integer] `digits/2` now accepts negative integers
+
 #### IEx
 
   * [IEx.Helpers] `c/1` now compiles in memory by default to avoid common issue where `.beam` files remain at projects root directory

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -45,13 +45,20 @@ defmodule IntegerTest do
     assert Integer.digits(0) == [0]
     assert Integer.digits(0, 2) == [0]
     assert Integer.digits(1) == [1]
+    assert Integer.digits(-1) == [-1]
     assert Integer.digits(123, 123) == [1, 0]
+    assert Integer.digits(-123, 123) == [-1, 0]
+    assert Integer.digits(456, 1000) == [456]
+    assert Integer.digits(-456, 1000) == [-456]
     assert Integer.digits(123) == [1, 2, 3]
+    assert Integer.digits(-123) == [-1, -2, -3]
     assert Integer.digits(58127, 2) == [1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1]
+    assert Integer.digits(-58127, 2) == [-1, -1, -1, 0, 0, 0, -1, -1, 0, 0, 0, 0, -1, -1, -1, -1]
 
     for n <- Enum.to_list(-1..1) do
       assert_raise FunctionClauseError, fn ->
         Integer.digits(10, n)
+        Integer.digits(-10, n)
       end
     end
   end
@@ -67,6 +74,7 @@ defmodule IntegerTest do
     assert Integer.undigits([1, 2, 3, 4, 5]) == 12345
     assert Integer.undigits([1, 0, -5]) == 95
     assert Integer.undigits([-1, -1, -5]) == -115
+    assert Integer.undigits([0, 0, 0, -1, -1, -5]) == -115
 
     for n <- Enum.to_list(-1..1) do
       assert_raise FunctionClauseError, fn ->


### PR DESCRIPTION
This PR fixes
- fixes a bug in `Integer.undigits/2`
- corrects docs for `Integer.digits/2`, `Integer.undigits/2`
- optimizers `Integer.digits/2`, `Integer.undigits/2`
- improves `Integer.digits/2` by allowing negative digits

This is a backward non-compatible proposal, but I think it is worth mentioning it.
I think it is a bit weird the behaviour of allowing negative digits other than the first one in `Integer.undigits/2`
such as in this example: `Integer.undigits([1, -4, -5])`
what's the use of that?
It's weird that negative integers were allowed in Integer.undigits/2, and  a negative integer was not allowed in `Integer.digits/2`.

If we agree only on allowing the first element in the list to be a negative integer, then we could optimize this function when dealing with HUGE lists and when base is 10, as shown in the commented code.
https://github.com/elixir-lang/elixir/blob/569fd8ad0eb5ea38749c8fe432f8c1880bcfd34e/lib/elixir/lib/integer.ex#L121-L130
