### PR TITLE
Raise an ArgumentError when overriding an undefined function

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -829,7 +829,8 @@ defmodule Module do
       case :elixir_def.take_definition(module, tuple) do
         false ->
           {name, arity} = tuple
-          raise "cannot make function #{name}/#{arity} overridable because it was not defined"
+          raise ArgumentError,
+            "cannot make function #{name}/#{arity} overridable because it was not defined"
         {{{:def, {name, arity}}, :defmacrop, _line, _file, _check, _location, _defaults}, _clauses} ->
           raise ArgumentError,
             "cannot make private macro #{name}/#{arity} overridable, overriding " <>

--- a/lib/elixir/test/elixir/kernel/overridable_test.exs
+++ b/lib/elixir/test/elixir/kernel/overridable_test.exs
@@ -190,6 +190,17 @@ defmodule Kernel.OverridableTest do
     assert Overridable.overridable_macro(1) == 1101
   end
 
+  test "undefined functions can't be marked as overridable" do
+    message = "cannot make function foo/2 overridable because it was not defined"
+    assert_raise ArgumentError, message, fn ->
+      Code.eval_string """
+      defmodule Foo do
+        defoverridable foo: 2
+      end
+      """
+    end
+  end
+
   test "private macros can't be overridden" do
     message =
       "cannot make private macro foo/0 overridable, overriding " <>


### PR DESCRIPTION
I also added a test for this behaviour as there was none. Related to #4856.