### PR TITLE
Deprecate support for making private functions overridable

### DIFF
--- a/lib/elixir/test/elixir/kernel/overridable_test.exs
+++ b/lib/elixir/test/elixir/kernel/overridable_test.exs
@@ -113,7 +113,7 @@ defmodule Kernel.OverridableTest do
       process_url(str)
     end
 
-    defp process_url(_str) do
+    def process_url(_str) do
       :first
     end
 
@@ -124,13 +124,15 @@ defmodule Kernel.OverridableTest do
     # errors. If it compiles, it works!
     defoverridable [process_url: 1, not_private: 1]
 
-    defp process_url(_str) do
+    def process_url(_str) do
       :second
     end
   end
 
   require Kernel.Overridable, as: Overridable
-  use ExUnit.Case, async: true
+  use ExUnit.Case
+
+  import ExUnit.CaptureIO
 
   test "overridable is made concrete if no other is defined" do
     assert Overridable.sample == 1

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -459,20 +459,6 @@ defmodule Kernel.WarningTest do
     purge Sample
   end
 
-  test "used with local with reattached overridable" do
-    assert capture_err(fn ->
-      Code.eval_string """
-      defmodule Sample do
-        def hello, do: world()
-        defp world, do: :ok
-        defoverridable [hello: 0, world: 0]
-      end
-      """
-    end) == ""
-  after
-    purge Sample
-  end
-
   test "undefined module attribute" do
     assert capture_err(fn ->
       Code.eval_string """


### PR DESCRIPTION
We already don't support private macros so not supporting private functions anymore seems reasonable. Less magic!