### PR TITLE
Generate error for no pid given to Genserver.reply

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -746,7 +746,7 @@ defmodule GenServer do
   @spec reply(from, term) :: :ok
   def reply(client, reply)
 
-  def reply({to, tag}, reply) do
+  def reply({to, tag}, reply) when is_pid(to) do
     try do
       send(to, {tag, reply})
       :ok


### PR DESCRIPTION
Prior to this change it is possible to send any two-pair tuple to
`GenServer.reply/2` and it will happily reply with `:ok`.  This
leads to some hard to track-down bugs if you pass it the wrong
data.  With this small check developers may be able to get a bit
more of a heads up to what is going wrong sooner.

For more information on how I came accross this:
https://github.com/benfalk/data_pool/commit/dcf81d1a87a363952715deeed3caa18ec0efccd9