### PR TITLE
Remove unused import in kernel/overridable_test.exs

### DIFF
--- a/lib/elixir/test/elixir/kernel/overridable_test.exs
+++ b/lib/elixir/test/elixir/kernel/overridable_test.exs
@@ -132,8 +132,6 @@ defmodule Kernel.OverridableTest do
   require Kernel.Overridable, as: Overridable
   use ExUnit.Case
 
-  import ExUnit.CaptureIO
-
   test "overridable is made concrete if no other is defined" do
     assert Overridable.sample == 1
   end


### PR DESCRIPTION
It seems like the `import ExUnit.CaptureIO` is not needed in this test file.
This pull request just removes that line.