### PR TITLE
Fix documentation for Date.new

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -124,8 +124,8 @@ defmodule Date do
   @doc """
   Builds a new ISO date.
 
-  Expects all values to be integers. Returns `{:ok, time}` if each
-  entry fits its appropriate range, returns `:error` otherwise.
+  Expects all values to be integers. Returns `{:ok, date}` if each
+  entry fits its appropriate range, returns `{:error, reason}` otherwise.
 
   ## Examples
 


### PR DESCRIPTION
Adapting docs of `Date.new`, according to https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/calendar.ex#L343 and https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/calendar.ex#L615