### PR TITLE
Improve doctest failure messages for exception assertions

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -476,17 +476,19 @@ defmodule ExUnit.Assertions do
   def assert_raise(exception, message, function) when is_function(function) do
     error = assert_raise(exception, function)
 
-    is_match = cond do
+    match? = cond do
       is_binary(message) -> Exception.message(error) == message
       Regex.regex?(message) -> Exception.message(error) =~ message
     end
 
-    msg = "Wrong message for #{inspect exception}\n" <>
-          "Expected:\n" <>
-          "  #{inspect message}\n" <>
-          "Got:\n" <>
-          "  #{inspect Exception.message(error)}"
-    assert is_match, message: msg
+    message =
+      "Wrong message for #{inspect exception}\n" <>
+      "expected:\n" <>
+      "  #{inspect message}\n" <>
+      "actual:\n" <>
+      "  #{inspect Exception.message(error)}"
+
+    assert match?, message: message
 
     error
   end

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -453,9 +453,9 @@ defmodule ExUnit.AssertionsTest do
   rescue
     error in [ExUnit.AssertionError] ->
       "Wrong message for RuntimeError" <>
-      "\nExpected:" <>
+      "\nexpected:" <>
       "\n  \"foo\"" <>
-      "\nGot:" <>
+      "\nactual:" <>
       "\n  \"bar\"" = error.message
   end
 
@@ -466,9 +466,9 @@ defmodule ExUnit.AssertionsTest do
   rescue
     error in [ExUnit.AssertionError] ->
       "Wrong message for RuntimeError" <>
-      "\nExpected:" <>
+      "\nexpected:" <>
       "\n  ~r/ba[zk]/" <>
-      "\nGot:" <>
+      "\nactual:" <>
       "\n  \"bar\"" = error.message
   end
 

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -298,7 +298,7 @@ defmodule ExUnit.DocTestTest do
     assert output =~ """
       5) test moduledoc at ExUnit.DocTestTest.Invalid (5) (ExUnit.DocTestTest.ActuallyCompiled)
          test/ex_unit/doc_test_test.exs:248
-         Doctest failed: expected exception WhatIsThis with message "oops" but got RuntimeError with message "oops"
+         Doctest failed: expected exception WhatIsThis but got RuntimeError with message "oops"
          code: raise "oops"
          stacktrace:
            test/ex_unit/doc_test_test.exs:139: ExUnit.DocTestTest.Invalid (module)
@@ -307,7 +307,11 @@ defmodule ExUnit.DocTestTest do
     assert output =~ """
       6) test moduledoc at ExUnit.DocTestTest.Invalid (6) (ExUnit.DocTestTest.ActuallyCompiled)
          test/ex_unit/doc_test_test.exs:248
-         Doctest failed: expected exception RuntimeError with message "hello" but got RuntimeError with message "oops"
+         Doctest failed: wrong message for RuntimeError
+         expected:
+           "hello"
+         actual:
+           "oops"
          code: raise "oops"
          stacktrace:
            test/ex_unit/doc_test_test.exs:142: ExUnit.DocTestTest.Invalid (module)


### PR DESCRIPTION
__Before:__
```
Doctest failed: expected exception Mix.Error with message "mix deps.clean expects dependencies as arguments or a flag indicating which dependencies to clean. The --all option will clean all dependencies while the --unused option cleans unused dependencies" but got Mix.Error with message "`mix deps.clean` expects dependencies as arguments or a flag indicating which dependencies to clean. The '--all' option will clean all dependencies while the '--unused' option cleans unused dependencies"
```
__After:__
```
Doctest failed: wrong message for Mix.Error
expected:
  "mix deps.clean expects dependencies as arguments or a flag indicating which dependencies to clean. The --all option will clean all dependencies while the --unused option cleans unused dependencies"
actual:
  "`mix deps.clean` expects dependencies as arguments or a flag indicating which dependencies to clean. The '--all' option will clean all dependencies while the '--unused' option cleans unused dependencies"
```