### PR TITLE
Support module attributes in remote types

### DIFF
--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -455,6 +455,27 @@ defmodule Kernel.TypespecTest do
            types(module)
   end
 
+  test "@type with module attributes" do
+    module = test_module do
+      @keyword Keyword
+      @type kw :: @keyword.t
+      @type kw(value) :: @keyword.t(value)
+    end
+
+    assert [type: {:kw, {:remote_type, _, [{:atom, _, Keyword}, {:atom, _, :t}, []]}, _},
+            type: {:kw, {:remote_type, _, [{:atom, _, Keyword}, {:atom, _, :t}, [{:var, _, :value}]]}, [{:var, _, :value}]}] =
+      types(module)
+  end
+
+  test "invalid remote @type with module attribute that does not evaluate to a module" do
+    assert_raise CompileError, ~r/(@foo is "bar")/, fn ->
+      test_module do
+        @foo "bar"
+        @type t :: @foo.t
+      end
+    end
+  end
+
   test "defines_type?" do
     test_module do
       @type mytype :: tuple


### PR DESCRIPTION
For example, `@for.t` in protocols or similar use cases. This PR closes #4874.

I'm open to feedback on the error message we should give if the module attribute doesn't expand to a module :)

For the record, this was broken in https://github.com/elixir-lang/elixir/commit/a3c429f9b9a476f995b23328430a1dcca55d1799, when we stopped expanding module attributes in `Macro.expand_once/2`.