### PR TITLE
Revert mix do to enforce space after comma

### DIFF
--- a/lib/mix/lib/mix/tasks/do.ex
+++ b/lib/mix/lib/mix/tasks/do.ex
@@ -6,6 +6,8 @@ defmodule Mix.Tasks.Do do
   @moduledoc """
   Executes the tasks separated by comma.
 
+  The comma should be followed by a space.
+
   ## Examples
 
   The example below prints the available compilers and
@@ -24,27 +26,21 @@ defmodule Mix.Tasks.Do do
 
   @doc false
   def gather_commands(args) do
-    gather_commands(args, [], [])
+    gather_commands args, [], []
   end
 
-  defp gather_commands([], current, commands) do
-    [current | commands]
-    |> Enum.reject(&(&1 == []))
-    |> Enum.map(&Enum.reverse(&1))
-    |> Enum.reverse
+  def gather_commands([head | rest], current, acc)
+      when binary_part(head, byte_size(head), -1) == "," do
+    part    = binary_part(head, 0, byte_size(head) - 1)
+    current = Enum.reverse([part | current])
+    gather_commands rest, [], [current | acc]
   end
 
-  defp gather_commands([arg | rest], current, commands) do
-    case String.split(arg, ",", parts: 2) do
-      [arg] ->
-        gather_commands(rest, [arg | current], commands)
-      [left, right] ->
-        rest    = append_unless_empty(right, rest)
-        current = append_unless_empty(left, current)
-        gather_commands(rest, [], [current | commands])
-    end
+  def gather_commands([head | rest], current, acc) do
+    gather_commands rest, [head | current], acc
   end
 
-  defp append_unless_empty("", list), do: list
-  defp append_unless_empty(h, list),  do: [h | list]
+  def gather_commands([], current, acc) do
+    Enum.reverse [Enum.reverse(current) | acc]
+  end
 end

--- a/lib/mix/test/mix/tasks/do_test.exs
+++ b/lib/mix/test/mix/tasks/do_test.exs
@@ -11,15 +11,11 @@ defmodule Mix.Tasks.DoTest do
     end
   end
 
-  test "gather_command ignore spaces and trailing commas" do
+  test "gather_command returns a list of commands" do
     import Mix.Tasks.Do, only: [gather_commands: 1]
     assert gather_commands(["compile", "--list,", "help"]) == [["compile", "--list"], ["help"]]
-    assert gather_commands(["compile", "--list,help"]) == [["compile", "--list"], ["help"]]
-    assert gather_commands(["help", ",compile", "--list"]) == [["help"], ["compile", "--list"]]
-    assert gather_commands(["compile", "--list", ",", "help"]) == [["compile", "--list"], ["help"]]
+    assert gather_commands(["help,", "compile", "--list"]) == [["help"], ["compile", "--list"]]
     assert gather_commands(["compile,", "run", "-e", "IO.puts :hello"]) == [["compile"], ["run", "-e", "IO.puts :hello"]]
-    assert gather_commands(
-      [",", "compile,", "run", "-e", "IO.puts :hello",",foo", "--bar", "--baz", ",", "baz,qux,abc", ","]) ==
-      [["compile"], ["run", "-e", "IO.puts :hello"], ["foo", "--bar", "--baz"], ["baz"], ["qux"], ["abc"]]
+    assert gather_commands(["compile,", "run", "-e", "[1, 2]"]) == [["compile"], ["run", "-e", "[1, 2]"]]
   end
 end


### PR DESCRIPTION
I reverted the `mix do` behavior, this should fix #4861.
Sorry for messing up! :sweat: 