### PR TITLE
Enhance difference highlighting for proper lists

### DIFF
--- a/lib/ex_unit/examples/difference.exs
+++ b/lib/ex_unit/examples/difference.exs
@@ -38,7 +38,7 @@ defmodule Difference do
   end
 
   test "lists" do
-    list1 = ["One", :ok, make_ref(), {}]
+    list1 = ["Tvo", make_ref(), :ok, {}]
     list2 = ["Two", :ok, self(), {true}]
     assert list1 == list2
   end

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -44,7 +44,7 @@ defmodule ExUnit.Diff do
       Inspect.List.printable?(left) and Inspect.List.printable?(right) ->
         script_string(List.to_string(left), List.to_string(right), ?')
       Inspect.List.keyword?(left) and Inspect.List.keyword?(right) ->
-        script_keyword(left, right)
+        script_keyword(left, right, true)
       true ->
         script_list(left, right, [])
     end
@@ -119,69 +119,72 @@ defmodule ExUnit.Diff do
     end)
   end
 
-  defp script_keyword(list1, list2) do
+  defp script_keyword(list1, list2, keywords?) do
     path = {0, 0, list1, list2, []}
     result =
-      find_script(0, length(list1) + length(list2), [path])
-      |> format_each_fragment([])
+      find_script(0, length(list1) + length(list2), [path], keywords?)
+      |> format_each_fragment([], keywords?)
     [{:eq, "["}, result, {:eq, "]"}]
   end
 
-  defp format_each_fragment([{:diff, script}], []),
+  defp format_each_fragment([{:diff, script}], [], _keywords?),
     do: script
 
-  defp format_each_fragment([{kind, elems}], []),
-    do: [format_fragment(kind, elems)]
+  defp format_each_fragment([{kind, elems}], [], keywords?),
+    do: [format_fragment(kind, elems, keywords?)]
 
-  defp format_each_fragment([_, _] = fragments, acc) do
+  defp format_each_fragment([_, _] = fragments, acc, keywords?) do
     result =
       case fragments do
         [diff: script1, diff: script2] ->
           [script1, {:eq, ", "}, script2]
 
         [{:diff, script}, {kind, elems}] ->
-          [script, {kind, ", "}, format_fragment(kind, elems)]
+          [script, {kind, ", "}, format_fragment(kind, elems, keywords?)]
 
         [{kind, elems}, {:diff, script}] ->
-          [format_fragment(kind, elems), {kind, ", "}, script]
+          [format_fragment(kind, elems, keywords?), {kind, ", "}, script]
 
         [del: elems1, ins: elems2] ->
-          [format_fragment(:del, elems1), format_fragment(:ins, elems2)]
+          [format_fragment(:del, elems1, keywords?), format_fragment(:ins, elems2, keywords?)]
 
         [{:eq, elems1}, {kind, elems2}] ->
-          [format_fragment(:eq, elems1), {kind, ", "}, format_fragment(kind, elems2)]
+          [format_fragment(:eq, elems1, keywords?), {kind, ", "}, format_fragment(kind, elems2, keywords?)]
 
         [{kind, elems1}, {:eq, elems2}] ->
-          [format_fragment(kind, elems1), {kind, ", "}, format_fragment(:eq, elems2)]
+          [format_fragment(kind, elems1, keywords?), {kind, ", "}, format_fragment(:eq, elems2, keywords?)]
       end
     Enum.reverse(acc, result)
   end
 
-  defp format_each_fragment([{:diff, script} | rest], acc) do
-    format_each_fragment(rest, [{:eq, ", "}, script | acc])
+  defp format_each_fragment([{:diff, script} | rest], acc, keywords?) do
+    format_each_fragment(rest, [{:eq, ", "}, script | acc], keywords?)
   end
 
-  defp format_each_fragment([{kind, elems} | rest], acc) do
-    new_acc = [{kind, ", "}, format_fragment(kind, elems) | acc]
-    format_each_fragment(rest, new_acc)
+  defp format_each_fragment([{kind, elems} | rest], acc, keywords?) do
+    new_acc = [{kind, ", "}, format_fragment(kind, elems, keywords?) | acc]
+    format_each_fragment(rest, new_acc, keywords?)
   end
 
-  defp format_fragment(kind, elems) do
-    formatter = fn {key, val} ->
-      format_key_value(key, val, true)
+  defp format_fragment(kind, elems, keywords?) do
+    formatter = fn
+      {key, val} when keywords? ->
+        format_key_value(key, val, true)
+      elem ->
+        inspect(elem)
     end
     {kind, Enum.map_join(elems, ", ", formatter)}
   end
 
-  defp find_script(envelope, max, _paths) when envelope > max do
+  defp find_script(envelope, max, _paths, _keywords?) when envelope > max do
     nil
   end
 
-  defp find_script(envelope, max, paths) do
-    case each_diagonal(-envelope, envelope, paths, []) do
+  defp find_script(envelope, max, paths, keywords?) do
+    case each_diagonal(-envelope, envelope, paths, [], keywords?) do
       {:done, edits} ->
         compact_reverse(edits, [])
-      {:next, paths} -> find_script(envelope + 1, max, paths)
+      {:next, paths} -> find_script(envelope + 1, max, paths, keywords?)
     end
   end
 
@@ -197,70 +200,73 @@ defmodule ExUnit.Diff do
   defp compact_reverse([{kind, char} | rest], acc),
     do: compact_reverse(rest, [{kind, [char]} | acc])
 
-  defp each_diagonal(diag, limit, _paths, next_paths) when diag > limit do
+  defp each_diagonal(diag, limit, _paths, next_paths, _keywords?) when diag > limit do
     {:next, Enum.reverse(next_paths)}
   end
 
-  defp each_diagonal(diag, limit, paths, next_paths) do
-    {path, rest} = proceed_path(diag, limit, paths)
+  defp each_diagonal(diag, limit, paths, next_paths, keywords?) do
+    {path, rest} = proceed_path(diag, limit, paths, keywords?)
     with {:cont, path} <- follow_snake(path) do
-      each_diagonal(diag + 2, limit, rest, [path | next_paths])
+      each_diagonal(diag + 2, limit, rest, [path | next_paths], keywords?)
     end
   end
 
-  defp proceed_path(0, 0, [path]), do: {path, []}
+  defp proceed_path(0, 0, [path], _keywords?), do: {path, []}
 
-  defp proceed_path(diag, limit, [path | _] = paths) when diag == -limit do
-    {move_down(path), paths}
+  defp proceed_path(diag, limit, [path | _] = paths, keywords?) when diag == -limit do
+    {move_down(path, keywords?), paths}
   end
 
-  defp proceed_path(diag, limit, [path]) when diag == limit do
-    {move_right(path), []}
+  defp proceed_path(diag, limit, [path], keywords?) when diag == limit do
+    {move_right(path, keywords?), []}
   end
 
-  defp proceed_path(_diag, _limit, [path1, path2 | rest]) do
+  defp proceed_path(_diag, _limit, [path1, path2 | rest], keywords?) do
     if elem(path1, 1) > elem(path2, 1) do
-      {move_right(path1), [path2 | rest]}
+      {move_right(path1, keywords?), [path2 | rest]}
     else
-      {move_down(path2), [path2 | rest]}
+      {move_down(path2, keywords?), [path2 | rest]}
     end
   end
 
-  defp script_keyword_inner({key, val1}, {key, val2}),
+  defp script_keyword_inner({key, val1}, {key, val2}, true),
     do: [{:eq, format_key(key, true)}, script_inner(val1, val2)]
 
-  defp script_keyword_inner(_pair1, _pair2),
+  defp script_keyword_inner(_pair1, _pair2, true),
     do: nil
 
-  defp move_right({x, x, [elem1 | rest1] = list1, [elem2 | rest2], edits}) do
-    if result = script_keyword_inner(elem1, elem2) do
+  defp script_keyword_inner(elem1, elem2, false),
+    do: script(elem1, elem2)
+
+  defp move_right({x, x, [elem1 | rest1] = list1, [elem2 | rest2], edits}, keywords?) do
+    if result = script_keyword_inner(elem1, elem2, keywords?) do
       {x + 1, x + 1, rest1, rest2, [{:diff, result} | edits]}
     else
       {x + 1, x, list1, rest2, [{:ins, elem2} | edits]}
     end
   end
 
-  defp move_right({x, y, list1, [elem | rest], edits}) do
+  defp move_right({x, y, list1, [elem | rest], edits}, _keywords?) do
     {x + 1, y, list1, rest, [{:ins, elem} | edits]}
   end
 
-  defp move_right({x, y, list1, [], edits}) do
+  defp move_right({x, y, list1, [], edits}, _keywords?) do
     {x + 1, y, list1, [], edits}
   end
 
-  defp move_down({x, x, [elem1 | rest1], [elem2 | rest2] = list2, edits}) do
-    if result = script_keyword_inner(elem1, elem2) do
+  defp move_down({x, x, [elem1 | rest1], [elem2 | rest2] = list2, edits}, keywords?) do
+    if result = script_keyword_inner(elem1, elem2, keywords?) do
       {x + 1, x + 1, rest1, rest2, [{:diff, result} | edits]}
     else
       {x, x + 1, rest1, list2, [{:del, elem1} | edits]}
     end
   end
 
-  defp move_down({x, y, [elem | rest], list2, edits}) do
+  defp move_down({x, y, [elem | rest], list2, edits}, _keywords?) do
     {x, y + 1, rest, list2, [{:del, elem} | edits]}
   end
 
-  defp move_down({x, y, [], list2, edits}) do
+  defp move_down({x, y, [], list2, edits}, _keywords?) do
     {x, y + 1, [], list2, edits}
   end
 


### PR DESCRIPTION
With this path we unify script building for keywords and proper lists, which gives better highlighting as well (see on the animation we have __less noisy diff__). Next step is to make improper lists work with this algorithm, thus we unify list handling and remove a lot of code.
 
![untitled](https://cloud.githubusercontent.com/assets/248290/16428911/64c18704-3d74-11e6-9d3e-3e09f2e85db1.gif)

