### PR TITLE
Function for comparing terms by order

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -977,6 +977,32 @@ defmodule Kernel do
   end
 
   @doc """
+  Compares two terms. Returns :gt if first term is greater than the second
+  and :lt for vice versa. If the two terms are equal :eq is returned
+
+  ## Examples
+
+      iex> compare_order(10, 4)
+      :gt
+
+      iex> compare_order({}, "a string")
+      :lt
+
+      iex> compare_order([], [])
+      :eq
+  """
+  @spec compare_order(term, term) :: :eq | :gt | :lt
+  def compare_order(x, x) do
+    :eq
+  end
+  def compare_order(x, y) when x > y do
+    :gt
+  end
+  def compare_order(x, y) do
+    :lt
+  end
+
+  @doc """
   Returns `true` if left is less than right.
 
   All terms in Elixir can be compared with each other.


### PR DESCRIPTION
Hello!

After some chatter in the slack channel I thought it would be useful to have a compare function for general terns as well as for versions and logger levels.

I wasn't sure where a function such as this would live. My first two thoughts were:

- `Kernel.compare/2`
- `Order.compare/2`

The former doesn't work so well as it would conflict with any functions people have defined called `compare` in their own modules.

I wasn't sure about creating a new module just for this. This option seemed popular with those I spoke to in the channel.

What do you think of this function? And where ought I place it if it's something that would be wanted in Elixir?

Cheers,
Louis