### PR TITLE
Pretty print numbers with underscore as digit separator

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -277,7 +277,7 @@ defmodule Date do
       iex> Date.from_erl!({2000, 1, 1})
       ~D[2000-01-01]
       iex> Date.from_erl!({2000, 13, 1})
-      ** (ArgumentError) cannot convert {2000, 13, 1} to date, reason: :invalid_date
+      ** (ArgumentError) cannot convert {2_000, 13, 1} to date, reason: :invalid_date
   """
   @spec from_erl!(:calendar.date()) :: Date.t | no_return
   def from_erl!(tuple) do
@@ -892,7 +892,7 @@ defmodule NaiveDateTime do
       iex> NaiveDateTime.from_erl!({{2000, 1, 1}, {13, 30, 15}}, {5000, 3})
       ~N[2000-01-01 13:30:15.005]
       iex> NaiveDateTime.from_erl!({{2000, 13, 1}, {13, 30, 15}})
-      ** (ArgumentError) cannot convert {{2000, 13, 1}, {13, 30, 15}} to naive date time, reason: :invalid_date
+      ** (ArgumentError) cannot convert {{2_000, 13, 1}, {13, 30, 15}} to naive date time, reason: :invalid_date
   """
   @spec from_erl!(:calendar.datetime(), Calendar.microsecond) :: NaiveDateTime.t | no_return
   def from_erl!(tuple, microsecond \\ {0, 0}) do

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -389,7 +389,11 @@ defimpl Inspect, for: Integer do
     |> prepend_prefix(base)
   end
 
-  def pretty_decimal(n, separator) when n >= 1_000 do
+  def pretty_decimal(n, separator) when n < 0 do
+    "-" <> pretty_decimal(abs(n), separator)
+  end
+
+  def pretty_decimal(n, separator) when n >= 1000 do
     left = div(n, 1_000)
     right = rem(n, 1_000)
     right_str = :io_lib.format("~3..0B", [right]) |> IO.iodata_to_binary

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -380,8 +380,8 @@ defimpl Inspect, for: Map do
 end
 
 defimpl Inspect, for: Integer do
-  def inspect(term, %Inspect.Opts{base: :decimal}) do
-    pretty_decimal(term)
+  def inspect(term, %Inspect.Opts{base: :decimal, digit_separator: separator}) do
+    pretty_decimal(term, separator)
   end
 
   def inspect(term, %Inspect.Opts{base: base}) do
@@ -389,14 +389,14 @@ defimpl Inspect, for: Integer do
     |> prepend_prefix(base)
   end
 
-  def pretty_decimal(n) when n >= 1_000 do
+  def pretty_decimal(n, separator) when n >= 1_000 do
     left = div(n, 1_000)
     right = rem(n, 1_000)
     right_str = :io_lib.format("~3..0B", [right]) |> IO.iodata_to_binary
-    pretty_decimal(left) <> "_" <> right_str
+    pretty_decimal(left, separator) <> separator <> right_str
   end
 
-  def pretty_decimal(n) do
+  def pretty_decimal(n, _) do
     Integer.to_string(n)
   end
 
@@ -419,11 +419,11 @@ defimpl Inspect, for: Integer do
 end
 
 defimpl Inspect, for: Float do
-  def inspect(term, opts) do
+  def inspect(term, %Inspect.Opts{digit_separator: separator}) do
     string = IO.iodata_to_binary(:io_lib_format.fwrite_g(term))
     [left, right] = String.split(string, ".")
     left = String.to_integer(left)
-    Inspect.Integer.pretty_decimal(left) <> "." <> right
+    Inspect.Integer.pretty_decimal(left, separator) <> "." <> right
   end
 end
 

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -37,6 +37,9 @@ defmodule Inspect.Opts do
       to :decimal. When inspecting binaries any `:base` other than `:decimal`
       implies `binaries: :as_binaries`.
 
+    * `digit_separator` - separates groups of digits in integers and floats,
+      defaults to `"_"`.
+
     * `:safe` - when `false`, failures while inspecting structs will be raised
       as errors instead of being wrapped in the `Inspect.Error` exception. This
       is useful when debugging failures and crashes for custom inspect
@@ -52,6 +55,7 @@ defmodule Inspect.Opts do
             limit: 50,
             width: 80,
             base: :decimal,
+            digit_separator: "_",
             pretty: false,
             safe: true
 
@@ -64,6 +68,7 @@ defmodule Inspect.Opts do
                limit: pos_integer | :infinity,
                width: pos_integer | :infinity,
                base: :decimal | :binary | :hex | :octal,
+               digit_separator: binary,
                pretty: boolean,
                safe: boolean}
 end

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1561,6 +1561,9 @@ defmodule Kernel do
       iex> inspect(100, base: :hex)
       "0x64"
 
+      iex> inspect(65534, digit_separator: ",")
+      "65,534"
+
   Note that the `Inspect` protocol does not necessarily return a valid
   representation of an Elixir term. In such cases, the inspected result
   must start with `#`. For example, inspecting a function will return:

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -19,7 +19,7 @@ defmodule DateTest do
     assert inspect(~D[2000-01-01]) == "~D[2000-01-01]"
 
     date = Map.put(~D[2000-01-01], :calendar, FakeCalendar)
-    assert inspect(date) == "%Date{calendar: FakeCalendar, day: 1, month: 1, year: 2000}"
+    assert inspect(date) == "%Date{calendar: FakeCalendar, day: 1, month: 1, year: 2_000}"
   end
 end
 
@@ -52,7 +52,7 @@ defmodule NaiveDateTimeTest do
 
     date = Map.put(~N[2000-01-01 23:00:07.005], :calendar, FakeCalendar)
     assert inspect(date) == "%NaiveDateTime{calendar: FakeCalendar, day: 1, hour: 23, " <>
-                            "microsecond: {5000, 3}, minute: 0, month: 1, second: 7, year: 2000}"
+                            "microsecond: {5_000, 3}, minute: 0, month: 1, second: 7, year: 2_000}"
   end
 end
 

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -139,6 +139,8 @@ defmodule Inspect.NumberTest do
   test "decimal" do
     assert inspect(100, base: :decimal) == "100"
     assert inspect(1_222_333, base: :decimal) == "1_222_333"
+    assert inspect(-100, base: :decimal) == "-100"
+    assert inspect(-1_222_333, base: :decimal) == "-1_222_333"
   end
 
   test "hex" do

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -138,6 +138,7 @@ defmodule Inspect.NumberTest do
 
   test "decimal" do
     assert inspect(100, base: :decimal) == "100"
+    assert inspect(1_222_333, base: :decimal) == "1_222_333"
   end
 
   test "hex" do
@@ -154,6 +155,7 @@ defmodule Inspect.NumberTest do
 
   test "float" do
     assert inspect(1.0) == "1.0"
+    assert inspect(1234.001) == "1_234.001"
     assert inspect(1.0E10) == "1.0e10"
     assert inspect(1.0e10) == "1.0e10"
     assert inspect(1.0e-10) == "1.0e-10"

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -138,9 +138,13 @@ defmodule Inspect.NumberTest do
 
   test "decimal" do
     assert inspect(100, base: :decimal) == "100"
+    assert inspect(1_000, base: :decimal) == "1_000"
+    assert inspect(100_000, base: :decimal) == "100_000"
     assert inspect(1_222_333, base: :decimal) == "1_222_333"
     assert inspect(-100, base: :decimal) == "-100"
     assert inspect(-1_222_333, base: :decimal) == "-1_222_333"
+
+    assert inspect(1_222_333, base: :decimal, digit_separator: ",") == "1,222,333"
   end
 
   test "hex" do
@@ -157,7 +161,7 @@ defmodule Inspect.NumberTest do
 
   test "float" do
     assert inspect(1.0) == "1.0"
-    assert inspect(1234.001) == "1_234.001"
+    assert inspect(1234.0001) == "1_234.0001"
     assert inspect(1.0E10) == "1.0e10"
     assert inspect(1.0e10) == "1.0e10"
     assert inspect(1.0e-10) == "1.0e-10"

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -12,7 +12,7 @@ defmodule ExUnit.DiffTest do
   test "numbers" do
     int1 = 491512235
     int2 = 490512035
-    expected = [eq: "49", del: "1", ins: "0", eq: "512", del: "2", ins: "0", eq: "35"]
+    expected = [eq: "49", del: "1", ins: "0", eq: "_512_", del: "2", ins: "0", eq: "35"]
     assert script(int1, int2) == expected
     assert script(42.0, 43.0) == [eq: "4", del: "2", ins: "3", eq: ".0"]
     assert script(int1, 43.0) == nil
@@ -175,7 +175,7 @@ defmodule ExUnit.DiffTest do
     keyword2 = [max_connections: 1000, port: 4000]
     expected = [
       {:eq, "["},
-      [del: "port: 4000", del: ", ", eq: "max_connections: 1000", ins: ", ", ins: "port: 4000"],
+      [del: "port: 4_000", del: ", ", eq: "max_connections: 1_000", ins: ", ", ins: "port: 4_000"],
       {:eq, "]"}
     ]
     assert script(keyword1, keyword2) == expected

--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -439,7 +439,7 @@ defmodule Logger.TranslatorTest do
     end) =~ ~r"""
     Start Call: Task.start_link\(Logger.TranslatorTest, :sleep, \[#PID<\d+\.\d+\.\d+>\]\)
     Restart: :permanent
-    Shutdown: 5000
+    Shutdown: 5_000
     Type: :worker
     """
   end
@@ -527,7 +527,7 @@ defmodule Logger.TranslatorTest do
     Pid: #PID<\d+\.\d+\.\d+>
     Start Call: Logger.TranslatorTest.abnormal\(\)
     Restart: :permanent
-    Shutdown: 5000
+    Shutdown: 5_000
     Type: :worker
     """
   end


### PR DESCRIPTION
Discussed on https://groups.google.com/forum/#!topic/elixir-lang-core/trxIuhky0a8


As discussed on ML, all integers are now "pretty printed" by default. I also added the same behavior for floats for consistency. Thus:

    iex(1)> 1000
    1_000

    iex(2)> 1_000.001
    1_000.001

    iex(3)> i 1000
    Term
      1_000
    Data type
      Integer
    Reference modules
      Integer

    # tests

    test "the truth" do
      assert 10000 == 10001
    end

    1) test the truth (BarTest)
       test/bar_test.exs:5
       Assertion with == failed
       code: 10_000 == 10_001
       lhs:  10_000
       rhs:  10_001
       stacktrace:
         test/bar_test.exs:6: (test)

Open questions:
- how should we call the option to disable this behavior? Perhaps `%Inspect.Opts{pretty_numbers true/false}` or `digit_separator: true/false`?