### PR TITLE
Deprecate -pr CLI option in favour of --parallel

### DIFF
--- a/lib/mix/test/mix/tasks/profile.fprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.fprof_test.exs
@@ -73,7 +73,7 @@ defmodule Mix.Tasks.Profile.FprofTest do
         capture_io(fn -> Fprof.run ["-r", "non-existent"] end)
       end
 
-      assert_raise Mix.Error, "No files matched pattern \"non-existent\" given to --parallel-require", fn ->
+      assert_raise Mix.Error, "No files matched pattern \"non-existent\" given to --require", fn ->
         capture_io(fn -> Fprof.run ["-pr", "non-existent"] end)
       end
 

--- a/lib/mix/test/mix/tasks/run_test.exs
+++ b/lib/mix/test/mix/tasks/run_test.exs
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.RunTest do
         Mix.Tasks.Run.run ["-r", "non-existent"]
       end
 
-      assert_raise Mix.Error, "No files matched pattern \"non-existent\" given to --parallel-require", fn ->
+      assert_raise Mix.Error, "No files matched pattern \"non-existent\" given to --require", fn ->
         Mix.Tasks.Run.run ["-pr", "non-existent"]
       end
 


### PR DESCRIPTION
This is a first step towards implementing https://github.com/elixir-lang/elixir/issues/4920. It splits the `-pr` option in `mix run` and `elixir`/`elixir.bat` into `-p` and `-r`, still having backwards compatibility. I'd love some early feedback. Couple of things to note:

* the code in `Mix.Tasks.Run` that checks if `-pr` is present in the argv and replaces it with `-p -r` is not nice but very temporary as we can drop it as soon as we'll be able to parse `-pr` as `-p -r` in `OptionParser`
* support for explicit `-pr` in `elixir` and `elixir.bat` is necessary I think, given they don't go through `OptionParser`

Wdyt?