### PR TITLE
Optimize Enum.random/1, Enum.take_random/2 for ranges

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1542,7 +1542,7 @@ defmodule Enum do
   ## Examples
 
       # Although not necessary, let's seed the random algorithm
-      iex> :rand.seed(:exsplus, {1, 2, 3})
+      iex> :rand.seed(:exsplus, {101, 102, 103})
       iex> Enum.random([1, 2, 3])
       2
       iex> Enum.random([1, 2, 3])
@@ -1550,10 +1550,22 @@ defmodule Enum do
 
   """
   @spec random(t) :: element | no_return
+  def random(enumerable)
+
+  def random(first..last),
+    do: random_integer(first, last)
+
   def random(enumerable) do
-    case take_random(enumerable, 1) do
-      [] -> raise Enum.EmptyError
-      [e] -> e
+    case Enumerable.count(enumerable) do
+      {:ok, 0} ->
+        raise Enum.EmptyError
+      {:ok, count} ->
+        at(enumerable, random_integer(0, count - 1))
+      {:error, _} ->
+        case take_random(enumerable, 1) do
+          []     -> raise Enum.EmptyError
+          [elem] -> elem
+        end
     end
   end
 
@@ -2247,9 +2259,9 @@ defmodule Enum do
       # Although not necessary, let's seed the random algorithm
       iex> :rand.seed(:exsplus, {1, 2, 3})
       iex> Enum.take_random(1..10, 2)
-      [5, 8]
+      [5, 4]
       iex> Enum.take_random(?a..?z, 5)
-      'fhjni'
+      'ipybz'
 
   """
   @spec take_random(t, non_neg_integer) :: list
@@ -2259,14 +2271,10 @@ defmodule Enum do
     do: []
   def take_random(first..first, count) when is_integer(count) and count >= 1,
     do: [first]
-  def take_random(first..last, 1) when first > last,
-    do: take_random(last..first, 1)
-  def take_random(first..last, 1),
-    do: [random_index(last - first) + first]
 
   def take_random(enumerable, count) when is_integer(count) and count > 128 do
     reducer = fn(elem, {idx, sample}) ->
-      jdx = random_index(idx)
+      jdx = random_integer(0, idx)
       cond do
         idx < count ->
           value = Map.get(sample, jdx)
@@ -2286,7 +2294,7 @@ defmodule Enum do
     sample = Tuple.duplicate(nil, count)
 
     reducer = fn(elem, {idx, sample}) ->
-      jdx = random_index(idx)
+      jdx = random_integer(0, idx)
       cond do
         idx < count ->
           value = elem(sample, jdx)
@@ -2494,8 +2502,14 @@ defmodule Enum do
   defp enum_to_string(entry) when is_binary(entry), do: entry
   defp enum_to_string(entry), do: String.Chars.to_string(entry)
 
-  defp random_index(n) do
-    :rand.uniform(n + 1) - 1
+  defp random_integer(limit, limit) when is_integer(limit),
+    do: limit
+
+  defp random_integer(lower_limit, upper_limit) when upper_limit < lower_limit,
+    do: random_integer(upper_limit, lower_limit)
+
+  defp random_integer(lower_limit, upper_limit) do
+    lower_limit + :rand.uniform(upper_limit - lower_limit + 1) - 1
   end
 
   ## Implementations

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -346,15 +346,15 @@ defmodule EnumTest do
     seed1 = {1406, 407414, 139258}
     seed2 = {1306, 421106, 567597}
     :rand.seed(:exsplus, seed1)
-    assert Enum.random([1, 2]) == 1
+    assert Enum.random([1, 2]) == 2
     assert Enum.random([1, 2, 3]) == 1
-    assert Enum.random([1, 2, 3, 4]) == 2
-    assert Enum.random([1, 2, 3, 4, 5]) == 4
+    assert Enum.random([1, 2, 3, 4]) == 1
+    assert Enum.random([1, 2, 3, 4, 5]) == 2
     :rand.seed(:exsplus, seed2)
     assert Enum.random([1, 2]) == 2
-    assert Enum.random([1, 2, 3]) == 2
-    assert Enum.random([1, 2, 3, 4]) == 3
-    assert Enum.random([1, 2, 3, 4, 5]) == 5
+    assert Enum.random([1, 2, 3]) == 3
+    assert Enum.random([1, 2, 3, 4]) == 2
+    assert Enum.random([1, 2, 3, 4, 5]) == 3
   end
 
   test "reduce/2" do
@@ -587,15 +587,15 @@ defmodule EnumTest do
     seed1 = {1406, 407414, 139258}
     seed2 = {1406, 421106, 567597}
     :rand.seed(:exsplus, seed1)
-    assert Enum.take_random([1, 2, 3], 1) == [1]
-    assert Enum.take_random([1, 2, 3], 2) == [1, 3]
-    assert Enum.take_random([1, 2, 3], 3) == [2, 1, 3]
-    assert Enum.take_random([1, 2, 3], 4) == [3, 1, 2]
+    assert Enum.take_random([1, 2, 3], 1) == [2]
+    assert Enum.take_random([1, 2, 3], 2) == [3, 1]
+    assert Enum.take_random([1, 2, 3], 3) == [1, 3, 2]
+    assert Enum.take_random([1, 2, 3], 4) == [2, 3, 1]
     :rand.seed(:exsplus, seed2)
     assert Enum.take_random([1, 2, 3], 1) == [3]
     assert Enum.take_random([1, 2, 3], 2) == [1, 2]
     assert Enum.take_random([1, 2, 3], 3) == [1, 2, 3]
-    assert Enum.take_random([1, 2, 3], 4) == [1, 2, 3]
+    assert Enum.take_random([1, 2, 3], 4) == [2, 1, 3]
     assert Enum.take_random([1, 2, 3], 129) == [3, 2, 1]
 
     # assert that every item in the sample comes from the input list
@@ -1141,6 +1141,7 @@ defmodule EnumTest.Range do
     # corner cases, independent of the seed
     assert_raise FunctionClauseError, fn -> Enum.take_random(1..2, -1) end
     assert Enum.take_random(1..1, 0) == []
+    assert Enum.take_random(1..1, 1) == [1]
     assert Enum.take_random(1..1, 2) == [1]
     assert Enum.take_random(1..2, 0) == []
 
@@ -1149,16 +1150,23 @@ defmodule EnumTest.Range do
     seed1 = {1406, 407414, 139258}
     seed2 = {1406, 421106, 567597}
     :rand.seed(:exsplus, seed1)
-    assert Enum.take_random(1..3, 1) == [3]
+    assert Enum.take_random(1..3, 1) == [2]
     assert Enum.take_random(1..3, 2) == [3, 1]
-    assert Enum.take_random(1..3, 3) == [3, 1, 2]
-    assert Enum.take_random(1..3, 4) == [1, 3, 2]
-    assert Enum.take_random(3..1, 1) == [2]
-    :rand.seed(:exsplus, seed2)
-    assert Enum.take_random(1..3, 1) == [1]
-    assert Enum.take_random(1..3, 2) == [1, 2]
     assert Enum.take_random(1..3, 3) == [1, 3, 2]
-    assert Enum.take_random(1..3, 4) == [3, 2, 1]
+    assert Enum.take_random(1..3, 4) == [2, 3, 1]
+    assert Enum.take_random(3..1, 1) == [3]
+    :rand.seed(:exsplus, seed2)
+    assert Enum.take_random(1..3, 1) == [3]
+    assert Enum.take_random(1..3, 2) == [1, 2]
+    assert Enum.take_random(1..3, 3) == [1, 2, 3]
+    assert Enum.take_random(1..3, 4) == [2, 1, 3]
+
+    # make sure optimizations don't change fixed seeded tests
+    :rand.seed(:exsplus, {101, 102, 103})
+    one = Enum.take_random(1..100, 1)
+    :rand.seed(:exsplus, {101, 102, 103})
+    two = Enum.take_random(1..100, 2)
+    assert hd(one) == hd(two)
   end
 
   test "take_while/2" do
@@ -1223,15 +1231,15 @@ defmodule EnumTest.Map do
     seed1 = {1406, 407414, 139258}
     seed2 = {1406, 421106, 567597}
     :rand.seed(:exsplus, seed1)
-    assert Enum.take_random(map, 1) == [a: 1]
-    assert Enum.take_random(map, 2) == [a: 1, c: 3]
-    assert Enum.take_random(map, 3) == [b: 2, a: 1, c: 3]
-    assert Enum.take_random(map, 4) == [c: 3, a: 1, b: 2]
+    assert Enum.take_random(map, 1) == [b: 2]
+    assert Enum.take_random(map, 2) == [c: 3, a: 1]
+    assert Enum.take_random(map, 3) == [a: 1, c: 3, b: 2]
+    assert Enum.take_random(map, 4) == [b: 2, c: 3, a: 1]
     :rand.seed(:exsplus, seed2)
     assert Enum.take_random(map, 1) == [c: 3]
     assert Enum.take_random(map, 2) == [a: 1, b: 2]
     assert Enum.take_random(map, 3) == [a: 1, b: 2, c: 3]
-    assert Enum.take_random(map, 4) == [a: 1, b: 2, c: 3]
+    assert Enum.take_random(map, 4) == [b: 2, a: 1, c: 3]
   end
 end
 


### PR DESCRIPTION
Private function Enum.random_index/2 has been replaced with Enum.random_integer/2
and the deterministic examples had to be updated.