### PR TITLE
Add support for NO_PROXY to Mix.Utils.read_path

### DIFF
--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -464,10 +464,14 @@ defmodule Mix.Utils do
   defp proxy_env do
     http_proxy  = System.get_env("HTTP_PROXY")  || System.get_env("http_proxy")
     https_proxy = System.get_env("HTTPS_PROXY") || System.get_env("https_proxy")
-    no_proxy    = System.get_env("NO_PROXY")    || System.get_env("no_proxy")
-                |> no_proxy_list()
+    no_proxy    = no_proxy_env()
+                  |> no_proxy_list()
 
     {proxy_setup(:http, http_proxy, no_proxy), proxy_setup(:https, https_proxy, no_proxy)}
+  end
+
+  defp no_proxy_env() do
+    System.get_env("NO_PROXY") || System.get_env("no_proxy")
   end
 
   defp no_proxy_list(nil) do
@@ -475,7 +479,6 @@ defmodule Mix.Utils do
   end
 
   defp no_proxy_list(no_proxy_str) do
-    
     no_proxy_list = String.split(no_proxy_str, ",")
     for item <- no_proxy_list do
       to_charlist(item)

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -479,10 +479,9 @@ defmodule Mix.Utils do
   end
 
   defp no_proxy_list(no_proxy_str) do
-    no_proxy_list = String.split(no_proxy_str, ",")
-    for item <- no_proxy_list do
-      to_charlist(item)
-    end
+    no_proxy_str
+    |> String.split(",")
+    |> Enum.map(&to_charlist/1)
   end
 
   defp proxy_setup(scheme, proxy, no_proxy) do


### PR DESCRIPTION
This fixes the corner-case where mix needs to access files that are unreachable from the proxy server.

An example is if you have a git repo on the local network, but still need to use the proxy server to fetch the rest of your dependencies. 