### PR TITLE
[ci skip] Fix typespecs for List.keymember?/3

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -277,7 +277,7 @@ defmodule List do
       false
 
   """
-  @spec keymember?([tuple], any, non_neg_integer) :: any
+  @spec keymember?([tuple], any, non_neg_integer) :: boolean
   def keymember?(list, key, position) do
     :lists.keymember(key, position + 1, list)
   end


### PR DESCRIPTION
Fix return type for [List.keymember?/3](http://elixir-lang.org/docs/master/elixir/List.html#keymember?/3). 

Function ends with `?` should return a `boolean` type as described in the [Naming Conventions](http://elixir-lang.org/docs/stable/elixir/naming-conventions.html) page.

> Trailing question mark (foo?)
> 
> Functions that return a boolean are named with a trailing question mark.
> 
> Examples: Keyword.keyword?/1, Mix.debug?/0, String.contains?/2