### PR TITLE
Make batch style more consistent

### DIFF
--- a/bin/elixir.bat
+++ b/bin/elixir.bat
@@ -1,10 +1,10 @@
-@if defined ELIXIR_CLI_ECHO (@echo on) else  (@echo off)
+@if defined ELIXIR_CLI_ECHO (@echo on) else (@echo off)
 setlocal
-if    ""%1""==""""       goto :documentation
-if /I ""%1""==""--help"" goto :documentation
-if /I ""%1""==""-h""     goto :documentation
-if /I ""%1""==""/h""     goto :documentation
-if    ""%1""==""/?""     goto :documentation
+if    ""%1""==""""       goto documentation
+if /I ""%1""==""--help"" goto documentation
+if /I ""%1""==""-h""     goto documentation
+if /I ""%1""==""/h""     goto documentation
+if    ""%1""==""/?""     goto documentation
 goto parseopts
 
 :documentation
@@ -61,48 +61,48 @@ set par="%1"
 shift
 if "%par%"=="" (
   rem if no parameters defined
-  goto :expand_erl_libs
+  goto expand_erl_libs
 )
 if "%par%"=="""" (
   rem if no parameters defined - special case for parameter that is already quoted
-  goto :expand_erl_libs
+  goto expand_erl_libs
 )
 rem ******* EXECUTION OPTIONS **********************
-IF "%par%"==""--werl"" (Set useWerl=1)
-IF "%par%"==""+iex"" (Set runMode="iex")
+if "%par%"==""--werl"" (set useWerl=1)
+if "%par%"==""+iex"" (set runMode="iex")
 rem ******* ELIXIR PARAMETERS **********************
 rem Note: we don't have to do anything with options that don't take an argument
-IF """"=="%par:-e=%"      (shift)
-IF """"=="%par:-r=%"      (shift)
-IF """"=="%par:-pr=%"     (shift)
-IF """"=="%par:-pa=%"     (shift)
-IF """"=="%par:-pz=%"     (shift)
-IF """"=="%par:--app=%"   (shift)
-IF """"=="%par:--remsh=%" (shift)
+if """"=="%par:-e=%"      (shift)
+if """"=="%par:-r=%"      (shift)
+if """"=="%par:-pr=%"     (shift)
+if """"=="%par:-pa=%"     (shift)
+if """"=="%par:-pz=%"     (shift)
+if """"=="%par:--app=%"   (shift)
+if """"=="%par:--remsh=%" (shift)
 rem ******* ERLANG PARAMETERS **********************
-IF """"=="%par:--detached=%"            (Set parsErlang=%parsErlang% -detached)
-IF """"=="%par:--hidden=%"              (Set parsErlang=%parsErlang% -hidden)
-IF """"=="%par:--cookie=%"              (Set parsErlang=%parsErlang% -setcookie %1 && shift)
-IF """"=="%par:--sname=%"               (Set parsErlang=%parsErlang% -sname %1 && shift)
-IF """"=="%par:--name=%"                (Set parsErlang=%parsErlang% -name %1 && shift)
-IF """"=="%par:--logger-otp-reports=%"  (Set parsErlang=%parsErlang% -logger handle_otp_reports %1 && shift)
-IF """"=="%par:--logger-sasl-reports=%" (Set parsErlang=%parsErlang% -logger handle_sasl_reports %1 && shift)
-IF """"=="%par:--erl=%"                 (Set beforeExtra=%beforeExtra% %~1 && shift)
+if """"=="%par:--detached=%"            (set parsErlang=%parsErlang% -detached)
+if """"=="%par:--hidden=%"              (set parsErlang=%parsErlang% -hidden)
+if """"=="%par:--cookie=%"              (set parsErlang=%parsErlang% -setcookie %1 && shift)
+if """"=="%par:--sname=%"               (set parsErlang=%parsErlang% -sname %1 && shift)
+if """"=="%par:--name=%"                (set parsErlang=%parsErlang% -name %1 && shift)
+if """"=="%par:--logger-otp-reports=%"  (set parsErlang=%parsErlang% -logger handle_otp_reports %1 && shift)
+if """"=="%par:--logger-sasl-reports=%" (set parsErlang=%parsErlang% -logger handle_sasl_reports %1 && shift)
+if """"=="%par:--erl=%"                 (set beforeExtra=%beforeExtra% %~1 && shift)
 goto:startloop
 
 rem ******* assume all pre-params are parsed ********************
 :expand_erl_libs
 rem ******* expand all ebin paths as Windows does not support the ..\*\ebin wildcard ********************
-SETLOCAL enabledelayedexpansion
+setlocal enabledelayedexpansion
 set ext_libs=
 for  /d %%d in ("%originPath%..\lib\*.") do (
   set ext_libs=!ext_libs! -pa "%%~fd\ebin"
 )
-SETLOCAL disabledelayedexpansion
+setlocal disabledelayedexpansion
 
 rem ******* detect ANSI terminal support ********************
-timeout 0 2>nul >nul || goto :run
-where /Q powershell || goto :run
+timeout 0 2>nul >nul || goto run
+where /Q powershell || goto run
 
 set ASSERT_ANSI= ^
   $err = 1; ^
@@ -118,16 +118,16 @@ set ASSERT_ANSI= ^
   if ($ConsoleMode -band 0x4) { $err = 0 } ^
   exit $err
 
-powershell -NoProfile -NonInteractive -Command %ASSERT_ANSI% || goto :run
+powershell -NoProfile -NonInteractive -Command %ASSERT_ANSI% || goto run
 set parsErlang=%parsErlang% -elixir ansi_enabled true
 
 :run
-IF NOT %runMode% == "iex" (
+if not %runMode% == "iex" (
   set beforeExtra=-noshell -s elixir start_cli %beforeExtra%
 )
-IF %useWerl% EQU 1 (
+if %useWerl% equ 1 (
   start werl.exe %ext_libs% %ELIXIR_ERL_OPTIONS% %parsErlang% %beforeExtra% -extra %*
-) ELSE (
+) else (
   erl.exe %ext_libs% %ELIXIR_ERL_OPTIONS% %parsErlang% %beforeExtra% -extra %*
 )
 :end

--- a/bin/elixirc.bat
+++ b/bin/elixirc.bat
@@ -1,12 +1,12 @@
-@if defined ELIXIR_CLI_ECHO (@echo on) else  (@echo off)
+@if defined ELIXIR_CLI_ECHO (@echo on) else (@echo off)
 setlocal
 set argc=0
 for %%A in (%*) do (
-    if /I "%%A"=="--help" goto documentation
-    if /I "%%A"=="-h"     goto documentation
-    if /I "%%A"=="/h"     goto documentation
-    if    "%%A"=="/?"     goto documentation
-    set /A argc+=1
+  if /I "%%A"=="--help" goto documentation
+  if /I "%%A"=="-h"     goto documentation
+  if /I "%%A"=="/h"     goto documentation
+  if    "%%A"=="/?"     goto documentation
+  set /A argc+=1
 )
 if %argc%==0 goto documentation
 goto run

--- a/bin/iex.bat
+++ b/bin/iex.bat
@@ -1,5 +1,5 @@
 @if defined ELIXIR_CLI_ECHO (@echo on) else  (@echo off)
-SETLOCAL
+setlocal
 if /I ""%1""==""--help"" goto documentation
 if /I ""%1""==""-h""     goto documentation
 if /I ""%1""==""/h""     goto documentation
@@ -42,4 +42,4 @@ goto end
 @if defined IEX_WITH_WERL (@set __ELIXIR_IEX_FLAGS=--werl) else (set __ELIXIR_IEX_FLAGS=)
 call "%~dp0\elixir.bat" +iex --erl "-user Elixir.IEx.CLI" --no-halt %__ELIXIR_IEX_FLAGS% %*
 :end
-ENDLOCAL
+endlocal

--- a/bin/mix.bat
+++ b/bin/mix.bat
@@ -1,2 +1,2 @@
-@if defined ELIXIR_CLI_ECHO (@echo on) else  (@echo off)
+@if defined ELIXIR_CLI_ECHO (@echo on) else (@echo off)
 call "%~dp0\elixir.bat" "%~dp0\mix" %*


### PR DESCRIPTION
- use lowercase for batch keywords (e.g., `set`, `if`, `not`, `setlocal`, `endlocal`, etc.)
- use two-space indents
- remove extra spaces except where used for alignment
- remove trailing whitespace
- add newline at end of file
- don't use colon after `goto` before label name (e.g., `goto end`, not `goto :end`)