### PR TITLE
Improve error message when importing non-existent or private function

### DIFF
--- a/lib/elixir/src/elixir_import.erl
+++ b/lib/elixir/src/elixir_import.erl
@@ -160,7 +160,7 @@ ensure_keyword_list(Meta, File, _Other, Kind) ->
 %% ERROR HANDLING
 
 format_error({invalid_import, {Receiver, Name, Arity}}) ->
-  io_lib:format("cannot import ~ts.~ts/~B because it doesn't exist or is declared as private",
+  io_lib:format("cannot import ~ts.~ts/~B because it is undefined or private",
     [elixir_aliases:inspect(Receiver), Name, Arity]);
 
 format_error({special_form_conflict, {Receiver, Name, Arity}}) ->

--- a/lib/elixir/src/elixir_import.erl
+++ b/lib/elixir/src/elixir_import.erl
@@ -160,7 +160,7 @@ ensure_keyword_list(Meta, File, _Other, Kind) ->
 %% ERROR HANDLING
 
 format_error({invalid_import, {Receiver, Name, Arity}}) ->
-  io_lib:format("cannot import ~ts.~ts/~B because it doesn't exist",
+  io_lib:format("cannot import ~ts.~ts/~B because it doesn't exist or is declared as private",
     [elixir_aliases:inspect(Receiver), Name, Arity]);
 
 format_error({special_form_conflict, {Receiver, Name, Arity}}) ->

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -533,7 +533,7 @@ defmodule Kernel.ErrorsTest do
 
   test "import invalid macro" do
     assert_compile_fail CompileError,
-      "nofile:1: cannot import Kernel.invalid/1 because it doesn't exist",
+      "nofile:1: cannot import Kernel.invalid/1 because it is undefined or private",
       'import Kernel, only: [invalid: 1]'
   end
 


### PR DESCRIPTION
Before, when importing private function, the compiler was informing that is doesn't exist.