### PR TITLE
Optimize Enum.fetch/2 for negative and out of bound indexes

### DIFF
--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -150,11 +150,20 @@ defmodule EnumTest do
   end
 
   test "fetch/2" do
+    assert Enum.fetch([66], 0) == {:ok, 66}
+    assert Enum.fetch([66], -1) == {:ok, 66}
+    assert Enum.fetch([66], 1) == :error
+    assert Enum.fetch([66], -2) == :error
+
     assert Enum.fetch([2, 4, 6], 0) == {:ok, 2}
+    assert Enum.fetch([2, 4, 6], -1) == {:ok, 6}
     assert Enum.fetch([2, 4, 6], 2) == {:ok, 6}
     assert Enum.fetch([2, 4, 6], 4) == :error
     assert Enum.fetch([2, 4, 6], -2) == {:ok, 4}
     assert Enum.fetch([2, 4, 6], -4) == :error
+
+    assert Enum.fetch([], 0) == :error
+    assert Enum.fetch([], 1) == :error
   end
 
   test "fetch!/2" do
@@ -1290,6 +1299,15 @@ defmodule EnumTest.Map do
     assert Enum.reverse([], %{}) == []
     assert Enum.reverse(%{a: 1}, []) == [a: 1]
     assert Enum.reverse(MapSet.new, %{}) == []
+  end
+
+  test "fetch/2" do
+    map = %{a: 1, b: 2, c: 3, d: 4, e: 5}
+    assert Enum.fetch(map, 0) == {:ok, {:a, 1}}
+    assert Enum.fetch(map, -2) == {:ok, {:d, 4}}
+    assert Enum.fetch(map, -6) == :error
+    assert Enum.fetch(map, 5) == :error
+    assert Enum.fetch(%{}, 0) == :error
   end
 end
 


### PR DESCRIPTION
This function has been highly-optimized, through thorough benchmarking.

There were serious issues when dealing with big lists and maps when an out of
bound or a negative index was given. Eg. fetching an out-of-bound index in a
1,000-element map, was reduced to 0.18% of the original item. Or same case
with a 1,000-element list time was reduced to a 10,5%.

Enumerables are no longer reversed when dealing with negative indexes.
The much cheaper `Enum.count/1` function is used now.

Benchmark .exs file are published here:
https://gist.github.com/eksperimental/dd5d4fec5988ba51f2191e5a754ed710

They have been done with lists and maps of the following configurations: 0, 1,
100, 1K, 100K, 1M elements, and indexes being 0 or positive and negative,
retrieving first, middle, last elements and and out-of-bound indexes.

There is one remark to mention about the benchmarks. In list and maps with 1K,
100K, and 1M elements, it shouldn't take into acount the porcentages in the
table when dealing with fist (negative index) and last (negative index). The
worst case scenario for negative indexes in the previous implementation was when
it was given the negative represenation of the first element in the enumerable.
Since the list was reversed, it was the last element in the reversed this. But
since the new implementation avoids using reverse, the worst case scenario from
the previous implementation (the first element with negative index) should be
compared to the worst case scenario (the last element with negative index), and
the best case scenarios should be compared as well (the last element with
negative index of previous implementation, with the first element with negative
index of the current implementation).

To faciliate this a table is provided, that shows that in every single case the
current implementation outperforms the previous one.

```
Elixir v1.3.1                                    | Elixir v1.4.0-dev

:"Enum.fetch/2: list, 1000 elements"
benchmark name      iterations   average time    | benchmark name      iterations   average time
last (neg index)       1000000   4.16 µs/op      | first (neg index)      5000000   1.59 µs/op
first (neg index)       500000   15.51 µs/op     | last (neg index)        500000   12.53 µs/op

:"Enum.fetch/2: list_big, 100000 elements"
last (neg index)         10000   349.24 µs/op    | first (neg index)        50000   146.11 µs/op
first (neg index)         5000   1428.20 µs/op   | last (neg index)          5000   1249.18 µs/op

:"Enum.fetch/2: list_huge, 1000000 elements"
last (neg index)           500   9655.58 µs/op   | first (neg index)         5000   1601.54 µs/op
first (neg index)          500   20617.46 µs/op  | last (neg index)           500   12761.61 µs/op

:"Enum.fetch/2: map, 1000 elements"
last (neg index)         50000   123.35 µs/op    | first (neg index)       200000   26.71 µs/op
first (neg index)        50000   123.22 µs/op    | last (neg index)         50000   94.47 µs/op

:"Enum.fetch/2: map_big, 100000 elements"
last (neg index)           500   12032.04 µs/op  | first (neg index)         1000   3228.43 µs/op
first (neg index)          500   12622.49 µs/op  | last (neg index)           500   10026.25 µs/op

:"Enum.fetch/2: map_huge, 1000000 elements"
last (neg index)            50   126813.58 µs/op | first (neg index)          100   32006.77 µs/op
first (neg index)           50   132636.08 µs/op | last (neg index)            50   107091.40 µs/op
```

**Decrease in performace.**
There are very few cases where performance was decreased.

__:"Enum.fetch/2: list, 1000 elements"__
```
 middle                      +3.91%
 first                       +4.00%
```

__:"Enum.fetch/2: list_big, 100000 elements"__
```
 last                        +1.25%   (1077.57 vs. 1091.07 µs/op)
 middle                      +1.37%   (543.61 vs. 551.08 µs/op)
 first                       +43.48%  (0.05 vs. 0.08 µs/op)
```
__:"Enum.fetch/2: list_empty, 0 elements"__
```
 middle                      +1.55%
```

__:"Enum.fetch/2: list_huge, 1000000 elements"__
```
 last                        +0.08%  (11518.49 vs. 11527.60 µs/op)
 first                       +30.74% (0.05 vs. 0.07 µs/op)
```

__:"Enum.fetch/2: list_single, 1 elements"__
```
 last                        +7.12%  (0.06 vs. 0.06 µs/op)
```

__:"Enum.fetch/2: map, 1000 elements"__
```
 first                       +2.47%
 middle                      +3.15%
```

When the decrease is > 5%, the absolute difference is maximum 0.03 µs/op.
