### PR TITLE
Modulo division

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -581,6 +581,35 @@ defmodule Kernel do
   end
 
   @doc """
+  Computes the modulo of an integer division. Output follows the floored
+  division algorithm where the result always has the same sign as the divisor.
+
+  Raises an `ArithmeticError` exception if one of the arguments is not an
+  integer.
+
+  Allowed in guard tests. Inlined by the compiler.
+
+  ## Examples
+
+      iex> mod(5, 3)
+      2
+      iex> mod(-5, 3)
+      1
+      iex> mod(-5, -3)
+      -2
+      iex> mod(5, -3)
+      -1
+
+  """
+  @spec mod(integer, integer) :: integer
+  def mod(left, right) do
+    cond do
+      left * right >= 0 -> :erlang.rem(left, right)
+      true -> right + :erlang.rem(left, right)
+    end
+  end
+
+  @doc """
   Rounds a number to the nearest integer.
 
   Allowed in guard tests. Inlined by the compiler.

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -555,7 +555,8 @@ defmodule Kernel do
   end
 
   @doc """
-  Computes the remainder of an integer division.
+  Computes the remainder of an integer division. Output follows the truncated
+  division algorithm where the result always has the same sign as the divisor.
 
   Raises an `ArithmeticError` exception if one of the arguments is not an
   integer.
@@ -564,8 +565,14 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> rem(5, 2)
-      1
+      iex> rem(5, 3)
+      2
+      iex> rem(-5, 3)
+      -2
+      iex> rem(-5, -3)
+      -2
+      iex> rem(5, -3)
+      2
 
   """
   @spec rem(integer, integer) :: integer

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -304,6 +304,14 @@ defmodule KernelTest do
     assert rem(-5,-3) == trunc_div_alg.(-5,-3)
   end
 
+  test "mod/2" do
+    floor_div_alg = fn(a,n) -> a-n*(round Float.floor(a/n)) end
+    assert mod( 5, 3) == floor_div_alg.( 5, 3)
+    assert mod(-5, 3) == floor_div_alg.(-5, 3)
+    assert mod( 5,-3) == floor_div_alg.( 5,-3)
+    assert mod(-5,-3) == floor_div_alg.(-5,-3)
+  end
+
   defmodule User do
     assert is_map defstruct name: "john"
   end

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -296,6 +296,14 @@ defmodule KernelTest do
     assert binding() == [_x: 1]
   end
 
+  test "rem/2" do
+    trunc_div_alg = fn(a,n) -> a-n*trunc(a/n) end
+    assert rem( 5, 3) == trunc_div_alg.( 5, 3)
+    assert rem(-5, 3) == trunc_div_alg.(-5, 3)
+    assert rem( 5,-3) == trunc_div_alg.( 5,-3)
+    assert rem(-5,-3) == trunc_div_alg.(-5,-3)
+  end
+
   defmodule User do
     assert is_map defstruct name: "john"
   end


### PR DESCRIPTION
Hello!

I hope this PR finds you well. I was working with modulo (`rem` in elixir, as it were) and it was not behaving as in ruby. I checked out wikipedia and noticed that ruby differentiate between remainder and modulo, and was thinking why not have the same in elixir? 

There is also a background on [wikipedia modulo](https://en.wikipedia.org/wiki/Modulo_operation#Remainder_calculation_for_the_modulo_operation) where Donald Knuth describes the floored divisor in favor of the current which is truncated divisor.

There is a third option called euclidean division, but almost no programming language uses it. I thought it would be best option to be ruby like but still keep the old Erlang version for `rem` and instead add a new operator called `mod`.

Please let me know what you think.