### PR TITLE
[ci skip] Fix typespecs not showing up for Stream.into/3

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -442,7 +442,7 @@ defmodule Stream do
   This function is often used with `run/1` since any evaluation
   is delayed until the stream is executed. See `run/1` for an example.
   """
-  @spec into(Enumerable.t, Collectable.t) :: Enumerable.t
+  @spec into(Enumerable.t, Collectable.t, (term -> term)) :: Enumerable.t
   def into(enum, collectable, transform \\ fn x -> x end) do
     &do_into(enum, collectable, transform, &1, &2)
   end


### PR DESCRIPTION
The typespecs for [Stream.into/3](http://elixir-lang.org/docs/master/elixir/Stream.html#into/3) is not showing up due to missing typespecs for the last argument. 