### PR TITLE
Force defmodule to not be tail-call optimized

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3087,6 +3087,16 @@ defmodule Kernel do
           {expanded, nil}
       end
 
+    # We do this so that the block is not tail-call optimized and stacktraces
+    # are not messed up. Basically, we just insert something between the return
+    # value of the block and what is returned by defmodule. Using just ":ok" or
+    # similar doesn't work because it's likely optimized away by the compiler.
+    block = quote do
+      result = unquote(block)
+      :elixir_utils.noop()
+      result
+    end
+
     {escaped, _} = :elixir_quote.escape(block, false)
     module_vars  = module_vars(env.vars, 0)
 

--- a/lib/elixir/src/elixir_utils.erl
+++ b/lib/elixir/src/elixir_utils.erl
@@ -5,7 +5,8 @@
   characters_to_list/1, characters_to_binary/1, macro_name/1,
   convert_to_boolean/4, returns_boolean/1, atom_concat/1,
   read_file_type/1, read_link_type/1, relative_to_cwd/1, caller/4,
-  read_mtime/1, change_universal_time/2, erl_call/4, meta_location/1]).
+  read_mtime/1, change_universal_time/2, erl_call/4, meta_location/1,
+  noop/0]).
 -include("elixir.hrl").
 -include_lib("kernel/include/file.hrl").
 
@@ -14,6 +15,11 @@ macro_name(Macro) ->
 
 atom_concat(Atoms) ->
   list_to_atom(lists:concat(Atoms)).
+
+%% No-op function that can be used for stuff like preventing tail-call
+%% optimization to kick in.
+noop() ->
+  ok.
 
 erl_call(Ann, Module, Function, Args) ->
   {call, Ann,


### PR DESCRIPTION
Implements what (I think? 😄) was discussed in https://github.com/elixir-lang/elixir/pull/4941. Let me know what you think!