### PR TITLE
Optimize Enum.reverse/1

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1731,9 +1731,8 @@ defmodule Enum do
 
   """
   @spec reverse(t, t) :: list
-  def reverse(enumerable, tail)
-      when is_list(enumerable) and is_list(tail) do
-    :lists.reverse(enumerable, tail)
+  def reverse(enumerable, tail) when is_list(enumerable) do
+    :lists.reverse(enumerable, to_list(tail))
   end
 
   def reverse(enumerable, tail) do

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1714,7 +1714,7 @@ defmodule Enum do
   end
 
   def reverse(enumerable) do
-    reverse(enumerable, [])
+    do_reverse(enumerable, [])
   end
 
   @doc """
@@ -1737,7 +1737,11 @@ defmodule Enum do
   end
 
   def reverse(enumerable, tail) do
-    reduce(enumerable, to_list(tail), fn(entry, acc) ->
+    do_reverse(enumerable, to_list(tail))
+  end
+
+  defp do_reverse(enumerable, tail) do
+    reduce(enumerable, tail, fn(entry, acc) ->
       [entry | acc]
     end)
   end


### PR DESCRIPTION
Private function Enum.do_reverse/2 abstracts the code now, and we call it directly from Enum.reduce/1
Avoiding calling Enum.reduce/2 and having unnecessary is_list/1 guard checks.