### PR TITLE
Improve error message on bad return in Map.get_and_update/3

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -731,8 +731,12 @@ defmodule Map do
     case :maps.find(key, map) do
       {:ok, value} ->
         case fun.(value) do
-          {get, update} -> {get, :maps.put(key, update, map)}
-          :pop          -> {value, :maps.remove(key, map)}
+          {get, update} ->
+            {get, :maps.put(key, update, map)}
+          :pop ->
+            {value, :maps.remove(key, map)}
+          other ->
+            raise "must return a two-element tuple or :pop, got: #{inspect(other)}"
         end
       :error ->
         raise KeyError, term: map, key: key

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -696,7 +696,7 @@ defmodule Map do
       :pop ->
         {current, :maps.remove(key, map)}
       other ->
-        raise "must return a two-element tuple or :pop, got: #{inspect(other)}"
+        raise "the given function must return a two-element tuple or :pop, got: #{inspect(other)}"
     end
   end
 
@@ -736,7 +736,7 @@ defmodule Map do
           :pop ->
             {value, :maps.remove(key, map)}
           other ->
-            raise "must return a two-element tuple or :pop, got: #{inspect(other)}"
+            raise "the given function must return a two-element tuple or :pop, got: #{inspect(other)}"
         end
       :error ->
         raise KeyError, term: map, key: key

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -691,8 +691,12 @@ defmodule Map do
       end
 
     case fun.(current) do
-      {get, update} -> {get, :maps.put(key, update, map)}
-      :pop          -> {current, :maps.remove(key, map)}
+      {get, update} ->
+        {get, :maps.put(key, update, map)}
+      :pop ->
+        {current, :maps.remove(key, map)}
+      other ->
+        raise "must return a two-element tuple or :pop, got: #{inspect(other)}"
     end
   end
 

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -74,6 +74,12 @@ defmodule MapTest do
     end
   end
 
+  test "get_and_update!/3" do
+    assert_raise RuntimeError, "must return a two-element tuple or :pop, got: 1", fn ->
+      Map.get_and_update!(%{a: 1}, :a, fn value -> value end)
+    end
+  end
+
   test "maps with optional comma" do
     assert %{a: :b,} == %{a: :b}
     assert %{1 => 2,} == %{1 => 2}

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -69,13 +69,13 @@ defmodule MapTest do
   end
 
   test "get_and_update/3" do
-    assert_raise RuntimeError, "must return a two-element tuple or :pop, got: 1", fn ->
+    assert_raise RuntimeError, "the given function must return a two-element tuple or :pop, got: 1", fn ->
       Map.get_and_update(%{a: 1}, :a, fn value -> value end)
     end
   end
 
   test "get_and_update!/3" do
-    assert_raise RuntimeError, "must return a two-element tuple or :pop, got: 1", fn ->
+    assert_raise RuntimeError, "the given function must return a two-element tuple or :pop, got: 1", fn ->
       Map.get_and_update!(%{a: 1}, :a, fn value -> value end)
     end
   end

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -68,6 +68,12 @@ defmodule MapTest do
     assert_raise BadMapError, fn -> Map.split(:foo, []) end
   end
 
+  test "get_and_update/3" do
+    assert_raise RuntimeError, "must return a two-element tuple or :pop, got: 1", fn ->
+      Map.get_and_update(%{a: 1}, :a, fn value -> value end)
+    end
+  end
+
   test "maps with optional comma" do
     assert %{a: :b,} == %{a: :b}
     assert %{1 => 2,} == %{1 => 2}


### PR DESCRIPTION
Current error message is quite unhelpful for new comers

    Map.get_and_update(%{a: 1}, :a, fn value -> value end)
    ** (MatchError) no match of right hand side value: 1
        (elixir) lib/map.ex:513: Map.get_and_update/3

This change introduces an improved message:

    ** (RuntimeError) must return a two-element tuple or :pop, got: 1
        (elixir) lib/map.ex:699: Map.get_and_update/3
