### PR TITLE
Add typespecs for Keyword.{split/2, take/2, drop/2, to_list/1}

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -719,6 +719,7 @@ defmodule Keyword do
       {[a: 1, c: 3, a: 4], [b: 2]}
 
   """
+  @spec split(t, [key]) :: {t, t}
   def split(keywords, keys) when is_list(keywords) do
     fun = fn {k, v}, {take, drop} ->
       case k in keys do
@@ -746,6 +747,7 @@ defmodule Keyword do
       [a: 1, c: 3, a: 5]
 
   """
+  @spec take(t, [key]) :: t
   def take(keywords, keys) when is_list(keywords) do
     :lists.filter(fn {k, _} -> k in keys end, keywords)
   end
@@ -763,6 +765,7 @@ defmodule Keyword do
       [a: 1, c: 3, a: 5]
 
   """
+  @spec drop(t, [key]) :: t
   def drop(keywords, keys) when is_list(keywords) do
     :lists.filter(fn {k, _} -> not k in keys end, keywords)
   end
@@ -862,6 +865,7 @@ defmodule Keyword do
       [a: 1]
 
   """
+  @spec to_list(t) :: t
   def to_list(keyword) when is_list(keyword) do
     keyword
   end


### PR DESCRIPTION
As typespces for

    Keyword.split/2
    Keyword.take/2
    Keyword.drop/2
    Keyword.to_list/1

are missing in the latest [doc](http://elixir-lang.org/docs/master/elixir/Keyword.html#split/2) of module `Keyword`.