### PR TITLE
Add parenthesis on Keyword doc example to match rest of the code

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -835,13 +835,13 @@ defmodule Keyword do
 
   ## Examples
 
-      iex> Keyword.pop_first [a: 1], :a
+      iex> Keyword.pop_first([a: 1], :a)
       {1, []}
-      iex> Keyword.pop_first [a: 1], :b
+      iex> Keyword.pop_first([a: 1], :b)
       {nil, [a: 1]}
-      iex> Keyword.pop_first [a: 1], :b, 3
+      iex> Keyword.pop_first([a: 1], :b, 3)
       {3, [a: 1]}
-      iex> Keyword.pop_first [a: 1, a: 2], :a
+      iex> Keyword.pop_first([a: 1, a: 2], :a)
       {1, [a: 2]}
 
   """


### PR DESCRIPTION
Same fix on `Keyword.pop_first/3` as @josevalim did in this [commit](https://github.com/elixir-lang/elixir/commit/0c2f3a4e5c2398954601f96d2d72f89a854e7038#diff-726c8befd520c8fdcebc6de0c11aac4bL658) for `Keyword.pop/3`.