### PR TITLE
Run travis tests against Erlang 19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: erlang
 
 otp_release:
   - 18.0
+  - 19.0
 
 sudo: false
 


### PR DESCRIPTION
With some of the incompatibilities expected from a major version
thought this might be a good idea, and the builds are fast enough
so I think travis won't mind :)

(not sure if this is wanted, I just noted that they were only running against 18, so I thought adding the new major might be a good idea :) )

Tobi