### PR TITLE
Fix tiny bug in documentation

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -307,7 +307,7 @@ defmodule IO do
     :io.get_chars(map_dev(device), to_chardata(prompt), count)
   end
 
-  @doc """
+  @doc ~S"""
   Reads a line from the IO `device`.
 
   It returns:


### PR DESCRIPTION
Now documentation looks like this:
![image](https://cloud.githubusercontent.com/assets/883341/16708884/b686e6c2-4609-11e6-9eba-b40d4201f787.png)


After fix will look like this:
![image](https://cloud.githubusercontent.com/assets/883341/16708877/9af7df24-4609-11e6-82c0-c85cbcce4a32.png)
