### PR TITLE
Run Travis against every supported minor Erlang version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: erlang
 
 otp_release:
   - 18.0
+  - 18.1
+  - 18.2.1
+  - 18.3
   - 19.0
 
 sudo: false


### PR DESCRIPTION
After my add Erlang 19 PR (#4972) there was discussion about
adding more erlang versions to the test matrix. I'm in favor,
but didn't want too many on my first go. As other people
seem to agree and [as suggested](https://github.com/elixir-lang/elixir/pull/4972#issuecomment-231571052) by @eksperimental this now
tests all supported minor versions (latest patch level)

> I propose to add support for
> 18.0, 18.1, 18.2.1, 18.3, 19.0