### PR TITLE
Standardize `mix escript` task's shortdoc

### DIFF
--- a/lib/mix/lib/mix/tasks/escript.ex
+++ b/lib/mix/lib/mix/tasks/escript.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Escript do
   use Mix.Task
 
-  @shortdoc "List installed escripts."
+  @shortdoc "Lists installed escripts"
 
   @moduledoc ~S"""
   Lists all installed escripts.


### PR DESCRIPTION
Correct verb tense, and remove trailing period.