### PR TITLE
Typespec.md: spell it "two-element tuple"

### DIFF
--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -82,7 +82,7 @@ The following literals are also supported in typespecs:
 
                                           ## Tuples
           | {}                            # empty tuple
-          | {:ok, type}                   # two element tuple with an atom and any type
+          | {:ok, type}                   # two-element tuple with an atom and any type
 
 ### Built-in types
 


### PR DESCRIPTION
That's the way we do it across the project.