### PR TITLE
Give helpful error message if a string is used to name a GenServer

### DIFF
--- a/lib/elixir/lib/gen_event.ex
+++ b/lib/elixir/lib/gen_event.ex
@@ -380,8 +380,21 @@ defmodule GenEvent do
         :gen.start(GenEvent, mode, @no_callback, [], [])
       atom when is_atom(atom) ->
         :gen.start(GenEvent, mode, {:local, atom}, @no_callback, [], [])
-      other when is_tuple(other) ->
-        :gen.start(GenEvent, mode, other, @no_callback, [], [])
+      {:global, _term} = tuple ->
+        :gen.start(GenEvent, mode, tuple, @no_callback, [], [])
+      {:via, module, _term} = tuple when is_atom(module) ->
+        :gen.start(GenEvent, mode, tuple, @no_callback, [], [])
+      other ->
+        raise ArgumentError, String.trim_trailing("""
+        expected :name option to be one of:
+
+          * nil
+          * atom
+          * {:global, term}
+          * {:via, module, term}
+
+        Got: #{inspect(other)}
+        """)
     end
   end
 

--- a/lib/elixir/test/elixir/gen_event_test.exs
+++ b/lib/elixir/test/elixir/gen_event_test.exs
@@ -148,8 +148,19 @@ defmodule GenEventTest do
     assert {:ok, pid} = GenEvent.start_link(name: :my_gen_event_name)
     assert GenEvent.start_link(name: :my_gen_event_name) ==
            {:error, {:already_started, pid}}
-
     assert GenEvent.stop(pid) == :ok
+
+    assert_raise ArgumentError, ~r"expected :name option to be one of:", fn ->
+      GenEvent.start_link(name: "my_gen_event_name")
+    end
+
+    assert_raise ArgumentError, ~r"expected :name option to be one of:", fn ->
+      GenEvent.start_link(name: {:invalid_tuple, "my_gen_event_name"})
+    end
+
+    assert_raise ArgumentError, ~r"expected :name option to be one of:", fn ->
+      GenEvent.start_link(name: {:via, "Via", "my_gen_event_name"})
+    end
   end
 
   test "handles exit signals" do


### PR DESCRIPTION
I'm new to Elixir, but I wanted to see if I can help with any issues, so here is my PR for this.
I can change supervisor.ex and gen_server.ex as well if you think the implementation is ok.
Thanks!

Mentioned in #3932 