### PR TITLE
Add ANSI escape sequence 27 for turning off reverse video

### DIFF
--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -123,6 +123,12 @@ defmodule IO.ANSI do
   @doc "Blink: off"
   defsequence :blink_off, 25
 
+  @doc "Image: Positive. Normal foreground and background"
+  defsequence :inverse_off, 27
+
+  @doc "Image: Positive. Normal foreground and background"
+  defsequence :reverse_off, 27
+
   colors = [:black, :red, :green, :yellow, :blue, :magenta, :cyan, :white]
 
   for {color, code} <- Enum.with_index(colors) do


### PR DESCRIPTION
[_IO.ANSI.inverse_](http://elixir-lang.org/docs/stable/elixir/IO.ANSI.html#inverse/0) (and its synonym, [_IO.ANSI.reverse_](http://elixir-lang.org/docs/stable/elixir/IO.ANSI.html#reverse/0)) for ANSI escape sequence `7` were already implemented, but not the escape sequence that disables their effect (`27`).