### PR TITLE
Rename Enum.partition/2 to Enum.split_with/2

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1537,18 +1537,26 @@ defmodule Enum do
   end
 
   @doc """
-  Partitions `enumerable` into two lists, where the first one
-  contains elements for which `fun` returns a truthy value, and the
-  second one – for which `fun` returns `false` or `nil`.
+  Splits the `enumerable` in two lists according to the given function `fun`.
+
+  Splits the given `enumerable` in two lists by calling `fun` with each element
+  in the `enumerable` as its only argument. Returns a tuple with the first list
+  containing all the elements in `enumerable` for which applying `fun` returned
+  a truthy value, and a second list with all the elements for which applying
+  `fun` returned a falsey value (`false` or `nil`).
+
+  The elements in both the returned lists are in the same relative order as they
+  were in the original enumerable (if such enumerable was ordered, e.g., a
+  list); see the examples below.
 
   ## Examples
 
-      iex> Enum.partition([1, 2, 3], fn(x) -> rem(x, 2) == 0 end)
+      iex> Enum.split_with([1, 2, 3], fn(x) -> rem(x, 2) == 0 end)
       {[2], [1, 3]}
 
   """
-  @spec partition(t, (element -> any)) :: {list, list}
-  def partition(enumerable, fun) when is_function(fun, 1) do
+  @spec split_with(t, (element -> any)) :: {list, list}
+  def split_with(enumerable, fun) when is_function(fun, 1) do
     {acc1, acc2} =
       reduce(enumerable, {[], []}, fn(entry, {acc1, acc2}) ->
         if fun.(entry) do
@@ -1559,6 +1567,13 @@ defmodule Enum do
       end)
 
     {:lists.reverse(acc1), :lists.reverse(acc2)}
+  end
+
+  @doc false
+  # TODO: Deprecate by v1.5
+  @spec partition(t, (element -> any)) :: {list, list}
+  def partition(enumerable, fun) when is_function(fun, 1) do
+    split_with(enumerable, fun)
   end
 
   @doc """

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3563,7 +3563,7 @@ defmodule Kernel do
       # TODO: Only call Kernel.struct! by Elixir v1.5
       def exception(args) when is_list(args) do
         struct = __struct__()
-        {valid, invalid} = Enum.partition(args, fn {k, _} -> Map.has_key?(struct, k) end)
+        {valid, invalid} = Enum.split_with(args, fn {k, _} -> Map.has_key?(struct, k) end)
 
         case invalid do
           [] ->

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -340,9 +340,9 @@ defmodule EnumTest do
     end
   end
 
-  test "partition/2" do
-    assert Enum.partition([1, 2, 3], fn(x) -> rem(x, 2) == 0 end) == {[2], [1, 3]}
-    assert Enum.partition([2, 4, 6], fn(x) -> rem(x, 2) == 0 end) == {[2, 4, 6], []}
+  test "split_with/2" do
+    assert Enum.split_with([1, 2, 3], fn(x) -> rem(x, 2) == 0 end) == {[2], [1, 3]}
+    assert Enum.split_with([2, 4, 6], fn(x) -> rem(x, 2) == 0 end) == {[2, 4, 6], []}
   end
 
   test "random/1" do
@@ -972,8 +972,8 @@ defmodule EnumTest.Range do
     assert Enum.min_max_by(1..3, fn(x) -> x end) == {1, 3}
   end
 
-  test "partition/2" do
-    assert Enum.partition(1..3, fn(x) -> rem(x, 2) == 0 end) == {[2], [1, 3]}
+  test "split_with/2" do
+    assert Enum.split_with(1..3, fn(x) -> rem(x, 2) == 0 end) == {[2], [1, 3]}
   end
 
   test "random/1" do

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -124,13 +124,13 @@ defmodule IEx.Helpers do
       raise ArgumentError, "expected a binary or a list of binaries as argument"
     end
 
-    {found, not_found} = Enum.partition(files, &File.exists?/1)
+    {found, not_found} = Enum.split_with(files, &File.exists?/1)
 
     unless Enum.empty?(not_found) do
       raise ArgumentError, "could not find files #{Enum.join(not_found, ", ")}"
     end
 
-    {erls, exs} = Enum.partition(found, &String.ends_with?(&1, ".erl"))
+    {erls, exs} = Enum.split_with(found, &String.ends_with?(&1, ".erl"))
 
     modules = Enum.map(erls, fn(source) ->
       {module, binary} = compile_erlang(source)

--- a/lib/mix/lib/mix/dep/loader.ex
+++ b/lib/mix/lib/mix/dep/loader.ex
@@ -22,7 +22,7 @@ defmodule Mix.Dep.Loader do
   Partitions loaded dependencies by environment.
   """
   def partition_by_env(deps, nil), do: {deps, []}
-  def partition_by_env(deps, env), do: Enum.partition(deps, &not skip?(&1, env))
+  def partition_by_env(deps, env), do: Enum.split_with(deps, &not skip?(&1, env))
 
   @doc """
   Checks if a dependency must be skipped according to the environment.


### PR DESCRIPTION
This PR closes #4996. `Enum.partition/2` has been soft-deprecated and will be deprecated by v1.5.

Before merging this I think it would be worth asking, is `split_with/2` the best name? I can't think of any clearly better alternatives, just want to raise the question before getting this in. Maybe `split_in_two/2` to be superclear? Not sure. 😕 