### PR TITLE
Fix docs for \N and \g{N} in String.replace/4 and Regex.replace/4

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -456,8 +456,10 @@ defmodule Regex do
 
   The replacement can be either a string or a function. The string
   is used as a replacement for every match and it allows specific
-  captures to be accessed via `\\N` or `\g{N}`, where `N` is the
-  capture. In case `\\0` is used, the whole match is inserted.
+  captures to be accessed via `\N` or `\g{N}`, where `N` is the
+  capture. In case `\0` is used, the whole match is inserted. Note
+  that in regexes the backslash needs to be escaped, hence in practice
+  you'll need to use `\\N` and `\\g{N}`.
 
   When the replacement is a function, the function may have arity
   N where each argument maps to a capture, with the first argument

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1019,8 +1019,10 @@ defmodule String do
       iex> String.replace("a,b,c", ~r/,(.)/, ",\\1\\g{1}")
       "a,bb,cc"
 
-  Notice we had to escape the escape the backslash escape character. By giving
-  `\0`, one can inject the whole matched pattern in the replacement string.
+  Notice we had to escape the backslash escape character (i.e., we used `\\N`
+  instead of just `\N` to escape the backslash; same thing for `\\g{N}`). By
+  giving `\0`, one can inject the whole matched pattern in the replacement
+  string.
 
   When the pattern is a string, a developer can use the replaced part inside
   the `replacement` by using the `:insert_replace` option and specifying the


### PR DESCRIPTION
We were being a bit inconsistent with the use of backslashes to escape the backslash in `\N` and `\g{N}`. This commit should fix that. Should close #4975.