### PR TITLE
Allow 0 as URI scheme default port

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -40,7 +40,7 @@ defmodule URI do
       nil
 
   """
-  @spec default_port(binary) :: nil | pos_integer
+  @spec default_port(binary) :: nil | non_neg_integer
   def default_port(scheme) when is_binary(scheme) do
     :elixir_config.get({:uri, scheme})
   end
@@ -57,8 +57,8 @@ defmodule URI do
   application's start callback in case you want to register
   new URIs.
   """
-  @spec default_port(binary, pos_integer) :: :ok
-  def default_port(scheme, port) when is_binary(scheme) and is_integer(port) and port > 0 do
+  @spec default_port(binary, non_neg_integer) :: :ok
+  def default_port(scheme, port) when is_binary(scheme) and is_integer(port) and port >= 0 do
     :elixir_config.put({:uri, scheme}, port)
   end
 


### PR DESCRIPTION
I'm patching up Hackney/HTTPoison to support HTTP over Unix Domain Sockets, using the (informal) 'http+unix' URI scheme.

In order to comply with Erlang 19's spec for opening an `inet:local_address()` socket using `gen_tcp` (http://erlang.org/doc/man/inet.html#type-local_address) I want to make sure the port number is set to 0 by default by calling `URI.default_port("http+unix", 0)`. Unfortunately the `URI.default` functions did not foresee this use-case :)