### PR TITLE
Make Enum.sort/2 example use a stable sort function, to avoid confusion

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2008,7 +2008,7 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.sort([1, 2, 3], &(&1 > &2))
+      iex> Enum.sort([1, 2, 3], &(&1 >= &2))
       [3, 2, 1]
 
   The sorting algorithm will be stable as long as the given function


### PR DESCRIPTION
It all started when an old version of the Enum.sort/2 docs confused me in the way they described the semantics of the sort function in Enum.sort/2.  The new docs are much better, and I think they're clear enough, but fishcakez pointed out that the example uses a non-stable sort function.  We can make it stable with no loss in clarity, so we should do so.