### PR TITLE
Remove nonexisting struct field `local` from type of `Macro.Env.t`

### DIFF
--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -41,7 +41,6 @@ defmodule Macro.Env do
       construct (may be `nil`)
     * `lexical_tracker` - PID of the lexical tracker which is responsible for
       keeping user info
-    * `local` - the module to expand local functions to
   """
 
   @type name_arity :: {atom, arity}
@@ -73,8 +72,7 @@ defmodule Macro.Env do
                context_modules: context_modules,
                vars: vars,
                export_vars: export_vars,
-               lexical_tracker: lexical_tracker,
-               local: local}
+               lexical_tracker: lexical_tracker}
 
   def __struct__ do
     %{__struct__: __MODULE__,


### PR DESCRIPTION
Migrating Erlang/OTP from 18.3 to 19.0, dialyzer (now much smarter than before!) starts to complain about the following perfectly legitimate expression:

```ex
Macro.Env.location(__ENV__)
```

The actual warning I got:
```
lib/foo.ex:3: The call 'Elixir.Macro.Env':location(#{'__struct__':='Elixir.Macro.Env', 'aliases':=[], 'context':='nil', 'context_modules':=['Elixir.Foo',...], 'export_vars':='nil', 'file':=<<_:264>>, 'function':={'f',0}, 'functions':=[{'Elixir.Kernel',[{atom(),0 | 1 | 2 | 3},...]},...], 'lexical_tracker':=_, 'line':=3, 'macro_aliases':=[], 'macros':=[{'Elixir.Kernel',[{atom(),0 | 1 | 2 | 3},...]},...], 'module':='Elixir.Foo', 'requires':=['Elixir.Kernel' | 'Elixir.Kernel.Typespec',...], 'vars':=[]}) breaks the contract (t()) -> 'Elixir.Keyword':t()
```
This is a bit cryptic but it says that the map given to `Macro.Env.location/1` does not have `local` field and thus is not a `Macro.Env.t`.

So this PR cleans up the `local` field from the type definition.
I'm not sure whether the auxiliary type `local` should also be removed since it is an exported type; it's kept as is.
(Should I also remove the `@type local` line?)

Just for reference:
- `local` field was removed by [this commit](https://github.com/elixir-lang/elixir/commit/a7dbfd1e82d2061a9e1a88e8896c3d11f3fc9a0a#diff-064a5928dd68c7eb919b932c9a2a02b5L95).
- Tried Elixir 1.3.1 and latest master.

Thanks in advance!