### PR TITLE
Enum fetch more optimizations

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -722,7 +722,11 @@ defmodule Enum do
   def fetch(enumerable, index)
 
   def fetch(enumerable, index) when is_list(enumerable) and is_integer(index) do
-    fetch_list(enumerable, index)
+    if index < 0 do
+      enumerable |> :lists.reverse |> fetch_list((-index) - 1)
+    else
+      fetch_list(enumerable, index)
+    end
   end
 
   def fetch(first..last, index) when is_integer(index) do

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -721,45 +721,37 @@ defmodule Enum do
   @spec fetch(t, index) :: {:ok, element} | :error
   def fetch(enumerable, index)
 
+  def fetch(enumerable, index) when is_list(enumerable) and is_integer(index) do
+    fetch_list(enumerable, index)
+  end
+
   def fetch(first..last, index) when is_integer(index) do
     fetch_range(first, last, index)
   end
 
   def fetch(enumerable, index) when is_integer(index) and index < 0 do
     case Enumerable.count(enumerable) do
+      {:error, _module} ->
+        enumerable |> reverse |> fetch_list((-index) - 1)
+
       {:ok, count} when (count + index) < 0 ->
         :error
 
       {:ok, count} ->
         fetch_enumerable(enumerable, count + index, Enumerable)
-
-      {:error, _} ->
-        enumerable
-        |> reverse()
-        |> fetch_list((-index) - 1)
     end
   end
 
-  def fetch(enumerable, index) when is_list(enumerable) and is_integer(index) do
-    fetch_list(enumerable, index)
-  end
-
   def fetch(enumerable, index) when is_integer(index) do
-    count_result =
-      case Enumerable.count(enumerable) do
-        {:ok, count} when (count - 1 - index) < 0 ->
-          :error
-        {:ok, _} ->
-          {:ok, Enumerable}
-        {:error, module} ->
-          {:ok, module}
-      end
-
-    case count_result do
-      :error ->
-        :error
-      {:ok, module} ->
+    case Enumerable.count(enumerable) do
+      {:error, module} ->
         fetch_enumerable(enumerable, index, module)
+
+      {:ok, count} when count <= index ->
+        :error
+
+      {:ok, _count} ->
+        fetch_enumerable(enumerable, index, Enumerable)
     end
   end
 


### PR DESCRIPTION
This PR does two optimizations,

First commit adds a clause to check for lists, when dealing with negative indexes
Second commit, revert's a change by @lexmag,
I think lists should be prioritized in Enum over ranges. In addition to this, I'm doing it based on the idea that checking for a range in a guard is more expensive than checking for a list, so it's better to leave it for as late as possible (just before the fallback guard that would deal with any other enumerable).

Benchmarks accompany this PR, between each commit.
https://gist.github.com/eksperimental/3f9c58a5b27fa9ff05abcd1df4678b1a

for the final results before this PR and after.
https://gist.github.com/eksperimental/3f9c58a5b27fa9ff05abcd1df4678b1a#file-enum_fetch_benchmarking_report_new-txt-L1172-L1360

the gain is considerable for out-of-bound and negative indexes.