### PR TITLE
Enum.slice/2 and Enum.slice/3 rewrite

### DIFF
--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -1312,6 +1312,62 @@ defmodule EnumTest.Map do
     assert Stream.take(map, 3) |> Enum.fetch(3) == :error
     assert Stream.take(map, 5) |> Enum.fetch(4) == {:ok, {:e, 5}}
   end
+
+  test "slice/2" do
+    map = %{a: 1, b: 2, c: 3, d: 4, e: 5}
+    assert Enum.slice(map, 0..0) == [a: 1]
+    assert Enum.slice(map, 0..1) == [a: 1, b: 2]
+    assert Enum.slice(map, 0..2) == [a: 1, b: 2, c: 3]
+  end
+
+  test "slice/3" do
+    map = %{a: 1, b: 2, c: 3, d: 4, e: 5}
+    assert Enum.slice(map, 1, 2) == [b: 2, c: 3]
+    assert Enum.slice(map, 1, 0) == []
+    assert Enum.slice(map, 2, 5) == [c: 3, d: 4, e: 5]
+    assert Enum.slice(map, 2, 6) == [c: 3, d: 4, e: 5]
+    assert Enum.slice(map, 5, 5) == []
+    assert Enum.slice(map, 6, 5) == []
+    assert Enum.slice(map, 6, 0) == []
+    assert Enum.slice(map, -6, 0) == []
+    assert Enum.slice(map, -6, 5) == []
+    assert Enum.slice(map, -2, 5) == [d: 4, e: 5]
+    assert Enum.slice(map, -3, 1) == [c: 3]
+    assert_raise FunctionClauseError, fn ->
+      Enum.slice(map, 0, -1)
+    end
+    assert_raise FunctionClauseError, fn ->
+      Enum.slice(map, 0.99, 0)
+    end
+    assert_raise FunctionClauseError, fn ->
+      Enum.slice(map, 0, 0.99)
+    end
+
+    assert Enum.slice(map, 0, 0) == []
+    assert Enum.slice(map, 0, 1) == [a: 1]
+    assert Enum.slice(map, 0, 2) == [a: 1, b: 2]
+    assert Enum.slice(map, 1, 2) == [b: 2, c: 3]
+    assert Enum.slice(map, 1, 0) == []
+    assert Enum.slice(map, 2, 5) == [c: 3, d: 4, e: 5]
+    assert Enum.slice(map, 2, 6) == [c: 3, d: 4, e: 5]
+    assert Enum.slice(map, 5, 5) == []
+    assert Enum.slice(map, 6, 5) == []
+    assert Enum.slice(map, 6, 0) == []
+    assert Enum.slice(map, -6, 0) == []
+    assert Enum.slice(map, -6, 5) == []
+    assert Enum.slice(map, -2, 5) == [d: 4, e: 5]
+    assert Enum.slice(map, -3, 1) == [c: 3]
+
+    assert_raise FunctionClauseError, fn ->
+      Enum.slice(map, 0, -1)
+    end
+    assert_raise FunctionClauseError, fn ->
+      Enum.slice(map, 0.99, 0)
+    end
+    assert_raise FunctionClauseError, fn ->
+      Enum.slice(map, 0, 0.99)
+    end
+  end
 end
 
 defmodule EnumTest.SideEffects do


### PR DESCRIPTION
slice/2,3 have been rewritten changing the approach.
Previous approach was based on count (now named "n") number of elements to be fetched,
and slice/2 would call slice/3.
This leads to the problem of having to recalculate the amount of elements in the enumerable
when dealing with negative indexes.
The new aproach uses slice/2 as the main funtion, and deal with start and finish indexes.
When a negative index is needed, we determine the number of elements, and we convert it to indexes.

Benchmarks for the new implemetation can be seen here:

Runing time: https://gist.github.com/eksperimental/e7cda7722d42e43c4c2f69825149c7df#file-enum_slice_benchmarking_report_new-txt-L773

Comparison: https://gist.github.com/eksperimental/e7cda7722d42e43c4c2f69825149c7df#file-enum_slice_benchmarking_report_new-txt-L1540