### PR TITLE
Fix syntax error in the supervisor.ex moduledoc example

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -42,7 +42,7 @@ defmodule Supervisor do
       # a single argument [:hello] and the default registered
       # name of MyStack.
       children = [
-        worker(Stack, [[:hello], [name: MyStack]])
+        worker(Stack, [[:hello]], [name: MyStack])
       ]
 
       # Start the supervisor with our child


### PR DESCRIPTION
The first example in the supervisor.ex moduledoc (the `Stack` module and associated supervisor) has a call to `worker/2` with a list of two sublists. It should be a call to `worker/3` with the module name and two separate lists.