### PR TITLE
Don't escape record literals on keyword conversion

### DIFF
--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -311,9 +311,9 @@ defmodule Record do
         case Macro.expand(args, caller) do
           {:{}, _, [^atom | list]} when length(list) == length(fields) ->
             record = List.to_tuple([atom | list])
-            Macro.escape(Record.__keyword__(atom, fields, record))
+            Record.__keyword__(atom, fields, record)
           {^atom, arg} when length(fields) == 1 ->
-            Macro.escape(Record.__keyword__(atom, fields, {atom, arg}))
+            Record.__keyword__(atom, fields, {atom, arg})
           _ ->
             quote do: Record.__keyword__(unquote(atom), unquote(fields), unquote(args))
         end

--- a/lib/elixir/test/elixir/record_test.exs
+++ b/lib/elixir/test/elixir/record_test.exs
@@ -123,6 +123,45 @@ defmodule RecordTest do
     assert user(record, :age) == :_
   end
 
+  Record.defrecord :defaults,
+    struct: ~D[2016-01-01],
+    map: %{},
+    tuple_zero: {},
+    tuple_one: {1},
+    tuple_two: {1, 2},
+    tuple_three: {1, 2, 3},
+    list: [1, 2, 3],
+    call: MapSet.new,
+    string: "abc",
+    binary: <<1, 2, 3>>,
+    charlist: 'abc'
+
+  test "records with literal defaults" do
+    assert defaults(defaults()) ==
+      [struct: ~D[2016-01-01],
+       map: %{},
+       tuple_zero: {},
+       tuple_one: {1},
+       tuple_two: {1, 2},
+       tuple_three: {1, 2, 3},
+       list: [1, 2, 3],
+       call: MapSet.new,
+       string: "abc",
+       binary: <<1, 2, 3>>,
+       charlist: 'abc']
+    assert defaults(defaults(), :struct) == ~D[2016-01-01]
+    assert defaults(defaults(), :map) == %{}
+    assert defaults(defaults(), :tuple_zero) == {}
+    assert defaults(defaults(), :tuple_one) == {1}
+    assert defaults(defaults(), :tuple_two) == {1, 2}
+    assert defaults(defaults(), :tuple_three) == {1, 2, 3}
+    assert defaults(defaults(), :list) == [1, 2, 3]
+    assert defaults(defaults(), :call) == MapSet.new
+    assert defaults(defaults(), :string) == "abc"
+    assert defaults(defaults(), :binary) == <<1, 2, 3>>
+    assert defaults(defaults(), :charlist) == 'abc'
+  end
+
   test "records with dynamic arguments" do
     record = file_info()
     assert file_info(record, :size) == :undefined


### PR DESCRIPTION
Literal values in records should not be escaped.
This lead to structs (and other non-literals in AST) being returned
as AST, which was unexpected and incorrect.

Before:

```elixir
defmodule Struct do
  defstruct foo: nil
end
defmodule Test do
  import Record
  defrecord :bar, data: %Struct{}
end

iex> require Test
iex> Test.bar(Test.bar())
[data: {:%{}, [], [__struct__: Struct, foo: nil]}]
```

After:

```elixir
iex> require Test
iex> Test.bar(Test.bar())
[data: %Struct{foo: nil}]
```