### PR TITLE
Fix a bug in String.replace_leading/3 and String.replace_trailing/3

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -602,6 +602,11 @@ defmodule String do
 
   Returns the string untouched if there are no occurrences.
 
+  If `match` is `""`, this function raises an `ArgumentError` exception: this
+  happens because this function replaces **all** the occurrences of `match` at
+  the beginning of `string`, and it's impossible to replace "multiple"
+  occurrences of `""`.
+
   ## Examples
 
       iex> String.replace_leading("hello world", "hello ", "")
@@ -615,9 +620,13 @@ defmodule String do
       "ola ola world"
 
   """
-  @spec replace_leading(t, t, t) :: t
+  @spec replace_leading(t, t, t) :: t | no_return
   def replace_leading(string, match, replacement)
       when is_binary(string) and is_binary(match) and is_binary(replacement) do
+    if match == "" do
+      raise ArgumentError, "cannot use an empty string as the match to replace"
+    end
+
     prefix_size = byte_size(match)
     suffix_size = byte_size(string) - prefix_size
     replace_leading(string, match, replacement, prefix_size, suffix_size, 0)
@@ -641,6 +650,11 @@ defmodule String do
 
   Returns the string untouched if there are no occurrences.
 
+  If `match` is `""`, this function raises an `ArgumentError` exception: this
+  happens because this function replaces **all** the occurrences of `match` at
+  the end of `string`, and it's impossible to replace "multiple" occurrences of
+  `""`.
+
   ## Examples
 
       iex> String.replace_trailing("hello world", " world", "")
@@ -654,9 +668,13 @@ defmodule String do
       "hello mundo mundo"
 
   """
-  @spec replace_trailing(t, t, t) :: t
+  @spec replace_trailing(t, t, t) :: t | no_return
   def replace_trailing(string, match, replacement)
       when is_binary(string) and is_binary(match) and is_binary(replacement) do
+    if match == "" do
+      raise ArgumentError, "cannot use an empty string as the match to replace"
+    end
+
     suffix_size = byte_size(match)
     prefix_size = byte_size(string) - suffix_size
     replace_trailing(string, match, replacement, prefix_size, suffix_size, 0)

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -177,6 +177,14 @@ defmodule StringTest do
     assert String.replace_leading("test", "t", "T") == "Test"
     assert String.replace_leading("t", "t", "T") == "T"
     assert String.replace_leading("aaa", "b", "c") == "aaa"
+
+    message = ~r/cannot use an empty string/
+    assert_raise ArgumentError, message, fn ->
+      String.replace_leading("foo", "", "bar")
+    end
+    assert_raise ArgumentError, message, fn ->
+      String.replace_leading("", "", "bar")
+    end
   end
 
   test "replace_trailing" do
@@ -192,6 +200,14 @@ defmodule StringTest do
     assert String.replace_trailing("test", "t", "T") == "tesT"
     assert String.replace_trailing("t", "t", "T") == "T"
     assert String.replace_trailing("aaa", "b", "c") == "aaa"
+
+    message = ~r/cannot use an empty string/
+    assert_raise ArgumentError, message, fn ->
+      String.replace_trailing("foo", "", "bar")
+    end
+    assert_raise ArgumentError, message, fn ->
+      String.replace_trailing("", "", "bar")
+    end
   end
 
   test "trim" do


### PR DESCRIPTION
Closes #5019.

These function would end up in infinite recursion if the "match" argument to replace was an empty string. With this commit, we explicitly check for that empty string and possibly raise an `ArgumentError` exception.