### PR TITLE
[WIP] Expand multi-letter aliases in OptionParser

### DIFF
--- a/lib/elixir/test/elixir/option_parser_test.exs
+++ b/lib/elixir/test/elixir/option_parser_test.exs
@@ -58,9 +58,17 @@ defmodule OptionParserTest do
            == {[s: "from_docs/"], [], []}
   end
 
-  test "does not parse - as a switch" do
-    assert OptionParser.parse(["-source=from_docs/"], aliases: [s: :source])
-           == {[], [], [{"-source", "from_docs/"}]}
+  test "parses -ab as -a -b" do
+    aliases = [a: :first, b: :second]
+
+    assert OptionParser.parse(["-ab"], aliases: aliases)
+           == {[first: true, second: true], [], []}
+
+    assert OptionParser.parse(["-ab=1"], aliases: aliases, switches: [second: :integer])
+           == {[first: true, second: 1], [], []}
+
+    assert OptionParser.parse(["-ab", "1"], aliases: aliases, switches: [second: :integer])
+           == {[first: true, second: 1], [], []}
   end
 
   test "parses configured booleans" do


### PR DESCRIPTION
This is work towards closing #4920.

Before this PR, `-abc` is processed by `OptionParser` as an alias. With this PR, we deprecate this behaviour: if `-abc` still matches an alias, we warn, otherwise, we split it into `-a -b -c`.

This is a WIP because I don't like this implementation but I can't seem to come up with something better and am a bit stuck :)

The current implementation just rewrites the `argv` by expanding the alias (which I believed was a good and clean way to do things so that we don't have to go too deep), but it duplicates some work such as splitting the option (`split_option/1`) or converting to underscored/atom.

What are your feelings? Sorry I opened this in not quite a good state, but at least we can get the discussion started 😕 