### PR TITLE
Give helpful error message if a string is used to name a GenServer / Supervisor

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -546,8 +546,21 @@ defmodule GenServer do
         :gen.start(:gen_server, link, module, args, opts)
       {atom, opts} when is_atom(atom) ->
         :gen.start(:gen_server, link, {:local, atom}, module, args, opts)
-      {other, opts} when is_tuple(other) ->
-        :gen.start(:gen_server, link, other, module, args, opts)
+      {{:global, _term} = tuple, opts} ->
+        :gen.start(:gen_server, link, tuple, module, args, opts)
+      {{:via, module, _term} = tuple, opts} when is_atom(module) ->
+        :gen.start(:gen_server, link, tuple, module, args, opts)
+      other ->
+        raise ArgumentError, String.trim_trailing("""
+        expected :name option to be one of:
+
+          * nil
+          * atom
+          * {:global, term}
+          * {:via, module, term}
+
+        Got: #{inspect(other)}
+        """)
     end
   end
 

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -311,8 +311,21 @@ defmodule Supervisor do
         :supervisor.start_link(module, arg)
       atom when is_atom(atom) ->
         :supervisor.start_link({:local, atom}, module, arg)
-      other when is_tuple(other) ->
-        :supervisor.start_link(other, module, arg)
+      {:global, _term} = tuple ->
+        :supervisor.start_link(tuple, module, arg)
+      {:via, via_module, _term} = tuple when is_atom(via_module) ->
+        :supervisor.start_link(tuple, module, arg)
+      other ->
+        raise ArgumentError, String.trim_trailing("""
+        expected :name option to be one of:
+
+          * nil
+          * atom
+          * {:global, term}
+          * {:via, module, term}
+
+        Got: #{inspect(other)}
+        """)
     end
   end
 

--- a/lib/elixir/test/elixir/gen_server_test.exs
+++ b/lib/elixir/test/elixir/gen_server_test.exs
@@ -38,6 +38,20 @@ defmodule GenServerTest do
     end
   end
 
+  test "start_link/3" do
+    assert_raise ArgumentError, ~r"expected :name option to be one of:", fn ->
+      GenServer.start_link(Stack, [:hello], name: "my_gen_server_name")
+    end
+
+    assert_raise ArgumentError, ~r"expected :name option to be one of:", fn ->
+      GenServer.start_link(Stack, [:hello], name: {:invalid_tuple, "my_gen_server_name"})
+    end
+
+    assert_raise ArgumentError, ~r"expected :name option to be one of:", fn ->
+      GenServer.start_link(Stack, [:hello], name: {:via, "Via", "my_gen_server_name"})
+    end
+  end
+
   test "start_link/2, call/2 and cast/2" do
     {:ok, pid} = GenServer.start_link(Stack, [:hello])
 

--- a/lib/elixir/test/elixir/supervisor_test.exs
+++ b/lib/elixir/test/elixir/supervisor_test.exs
@@ -52,6 +52,18 @@ defmodule SupervisorTest do
     wait_until_registered(:dyn_stack)
     assert GenServer.call(:dyn_stack, :pop) == :hello
     Supervisor.stop(pid)
+
+    assert_raise ArgumentError, ~r"expected :name option to be one of:", fn ->
+      Supervisor.start_link(children, name: "my_gen_server_name", strategy: :one_for_one)
+    end
+
+    assert_raise ArgumentError, ~r"expected :name option to be one of:", fn ->
+      Supervisor.start_link(children, name: {:invalid_tuple, "my_gen_server_name"}, strategy: :one_for_one)
+    end
+
+    assert_raise ArgumentError, ~r"expected :name option to be one of:", fn ->
+      Supervisor.start_link(children, name: {:via, "Via", "my_gen_server_name"}, strategy: :one_for_one)
+    end
   end
 
   test "start_link/3" do


### PR DESCRIPTION
Hi, this is my second PR related to #3932.
It should add helpful messages for GenServer and Supervisor.
Thanks!