### PR TITLE
Standardize use of reverse name in functions

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2132,7 +2132,7 @@ defmodule Enum do
   end
 
   def split(enumerable, count) when count < 0 do
-    do_split_reverse(reverse(enumerable), abs(count), [])
+    do_reverse_split(reverse(enumerable), abs(count), [])
   end
 
   @doc """
@@ -2884,15 +2884,15 @@ defmodule Enum do
     {:lists.reverse(acc), []}
   end
 
-  defp do_split_reverse([h | t], counter, acc) when counter > 0 do
-    do_split_reverse(t, counter - 1, [h | acc])
+  defp do_reverse_split([h | t], counter, acc) when counter > 0 do
+    do_reverse_split(t, counter - 1, [h | acc])
   end
 
-  defp do_split_reverse(list, 0, acc) do
+  defp do_reverse_split(list, 0, acc) do
     {:lists.reverse(list), acc}
   end
 
-  defp do_split_reverse([], _, acc) do
+  defp do_reverse_split([], _, acc) do
     {[], acc}
   end
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1986,19 +1986,19 @@ defmodule String do
 
   defp find_script(envelope, max, paths) do
     case each_diagonal(-envelope, envelope, paths, []) do
-      {:done, edits} -> compact_reverse(edits, [])
+      {:done, edits} -> reverse_compact(edits, [])
       {:next, paths} -> find_script(envelope + 1, max, paths)
     end
   end
 
-  defp compact_reverse([], acc), do: acc
+  defp reverse_compact([], acc), do: acc
 
-  defp compact_reverse([{kind, char} | rest], [{kind, chars} | acc]) do
-    compact_reverse(rest, [{kind, char <> chars} | acc])
+  defp reverse_compact([{kind, char} | rest], [{kind, chars} | acc]) do
+    reverse_compact(rest, [{kind, char <> chars} | acc])
   end
 
-  defp compact_reverse([elem | rest], acc) do
-    compact_reverse(rest, [elem | acc])
+  defp reverse_compact([elem | rest], acc) do
+    reverse_compact(rest, [elem | acc])
   end
 
   defp each_diagonal(diag, limit, _paths, next_paths) when diag > limit do

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -197,22 +197,22 @@ defmodule ExUnit.Diff do
   defp find_script(envelope, max, paths, keywords?) do
     case each_diagonal(-envelope, envelope, paths, [], keywords?) do
       {:done, edits} ->
-        compact_reverse(edits, [])
+        reverse_compact(edits, [])
       {:next, paths} -> find_script(envelope + 1, max, paths, keywords?)
     end
   end
 
-  defp compact_reverse([], acc),
+  defp reverse_compact([], acc),
     do: acc
 
-  defp compact_reverse([{:diff, _} = fragment | rest], acc),
-    do: compact_reverse(rest, [fragment | acc])
+  defp reverse_compact([{:diff, _} = fragment | rest], acc),
+    do: reverse_compact(rest, [fragment | acc])
 
-  defp compact_reverse([{kind, char} | rest], [{kind, chars} | acc]),
-    do: compact_reverse(rest, [{kind, [char | chars]} | acc])
+  defp reverse_compact([{kind, char} | rest], [{kind, chars} | acc]),
+    do: reverse_compact(rest, [{kind, [char | chars]} | acc])
 
-  defp compact_reverse([{kind, char} | rest], acc),
-    do: compact_reverse(rest, [{kind, [char]} | acc])
+  defp reverse_compact([{kind, char} | rest], acc),
+    do: reverse_compact(rest, [{kind, [char]} | acc])
 
   defp each_diagonal(diag, limit, _paths, next_paths, _keywords?) when diag > limit do
     {:next, Enum.reverse(next_paths)}


### PR DESCRIPTION
** While working on `split/2` in the `Enum` module, I wasn't able to find `do_reverse_split`... this is what lead to this PR **

We use "reverse_" at the beginning of functions names, as in the public function "reverse_slice"

this PR renames private functions `do_split_reverse` to `do_reverse_split`,
and `compact_reverse` to `reverse_compact`

this is where `reverse_` is used across the code base.

```sh
$ ag "def\w*\s+reverse_"
lib/elixir/lib/path.ex
118:  defp reverse_maybe_remove_dirsep([?/, ?:, letter], :win32), do:
...

lib/elixir/lib/enum.ex
1798:  def reverse_slice(enumerable, start, count)
2718:  defp reverse_slice(rest, idx, idx, count, acc) do
...
2839:  defp reverse_sort_merge([[h2 | t2], t1 | l], acc, fun, true), do:
...

lib/elixir/lib/uri.ex
517:  defp reverse_and_discard_empty([], acc),
...
```