### PR TITLE
Add String.from_codepoint/1

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1220,6 +1220,28 @@ defmodule String do
   end
 
   @doc ~S"""
+  Converts a numeric codepoint to a string containing the corresponding character.
+
+  ## Examples
+
+      iex> String.from_codepoint(97)
+      "a"
+
+      iex> String.from_codepoint(128_518)
+      "😆"
+
+      iex> String.from_codepoint("1F916")
+      "🤖"
+  """
+  def from_codepoint(cp) when is_integer(cp) when cp >= 0 and cp <= 2_097_151 do
+    <<cp :: utf8>>
+  end
+
+  def from_codepoint(cp) when is_binary(cp) do
+    :erlang.binary_to_integer(cp, 16) |> from_codepoint
+  end
+
+  @doc ~S"""
   Splits the string into chunks of characters that share a common trait.
 
   The trait can be one of two options:


### PR DESCRIPTION
Converts a numeric codepoint to a string containing the corresponding
character.

I've personally wanted this while playing around with Elixir's unicode support.

I'm not sure whether this would ever be useful in production code, but it seems nice to me to have something symmetrical to `?a`.

The question has at least [been poised before](http://stackoverflow.com/questions/17775978/how-do-i-turn-a-unicode-code-point-into-a-unicode-string).

Is this useful?