### PR TITLE
Naming inconsistencies in Enum.group_by/3

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1005,7 +1005,7 @@ defmodule Enum do
   end
 
   @doc """
-  Splits the enumerable into groups based on `fun`.
+  Splits the enumerable into groups based on `key_fun`.
 
   The result is a map where each key is given by `key_fun` and each
   value is a list of elements given by `value_fun`. Ordering is preserved.

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1020,7 +1020,7 @@ defmodule Enum do
 
   """
   @spec group_by(t, (element -> any), (element -> any)) :: map
-  def group_by(enumerable, key_fun, mapper_fun \\ fn x -> x end)
+  def group_by(enumerable, key_fun, value_fun \\ fn x -> x end)
 
   def group_by(enumerable, key_fun, value_fun)
       when is_function(key_fun, 1) and is_function(value_fun, 1) do


### PR DESCRIPTION
Renamed `mapper_fun` to `value_fun` in function head, to match doctest and other function definitions.
Renamed `fun` to `key_fun` in docs, to match function definitions.

See http://elixir-lang.org/docs/stable/elixir/Enum.html#group_by/3