### PR TITLE
Don't process -pr in a special way in mix run and mix profile.fprof

### DIFF
--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -112,15 +112,6 @@ defmodule Mix.Tasks.Profile.Fprof do
 
   @spec run(OptionParser.argv) :: :ok
   def run(args) do
-    # We do this right now because we still support -pr as an alias for
-    # --parallel-require, we need to implement the translation from -abc to -a
-    # -b -c so that -pr becomes --parallel --require and we have free backwards
-    # compatibility.
-    args = Enum.flat_map(args, fn
-      "-pr" -> ["-p", "-r"]
-      other -> [other]
-    end)
-
     {opts, head} = OptionParser.parse_head!(args,
       aliases: [r: :require, p: :parallel, e: :eval, c: :config],
       strict: @switches)

--- a/lib/mix/lib/mix/tasks/run.ex
+++ b/lib/mix/lib/mix/tasks/run.ex
@@ -45,15 +45,6 @@ defmodule Mix.Tasks.Run do
 
   @spec run(OptionParser.argv) :: :ok
   def run(args) do
-    # We do this right now because we still support -pr as an alias for
-    # --parallel-require, we need to implement the translation from -abc to -a
-    # -b -c so that -pr becomes --parallel --require and we have free backwards
-    # compatibility.
-    args = Enum.flat_map(args, fn
-      "-pr" -> ["-p", "-r"]
-      other -> [other]
-    end)
-
     {opts, head} = OptionParser.parse_head!(args,
       aliases: [r: :require, p: :parallel, e: :eval, c: :config],
       strict: [parallel: :boolean, require: :keep, eval: :keep, config: :keep,


### PR DESCRIPTION
Follow up to #5025. We don't need this anymore now (80aec928) that we support splitting of `-abc` into `-a -b -c`.