### PR TITLE
Deprecate some functions here and there for v1.4

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2450,8 +2450,8 @@ defmodule Enum do
   end
 
   @doc false
-  # TODO: Deprecate by 1.4
   def uniq(enumerable, fun) do
+    IO.warn "Enum.uniq/2 is deprecated, use Enum.uniq_by/2 instead"
     uniq_by(enumerable, fun)
   end
 

--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -214,15 +214,15 @@ defmodule Float do
   @doc false
   def to_char_list(float), do: Float.to_charlist(float)
 
-  # TODO: Deprecate by v1.4
   @doc false
   def to_char_list(float, options) do
+    IO.warn "Float.to_char_list/2 is deprecated, use :erlang.float_to_list/2 instead"
     :erlang.float_to_list(float, expand_compact(options))
   end
 
-  # TODO: Deprecate by v1.4
   @doc false
   def to_string(float, options) do
+    IO.warn "Float.to_string/2 is deprecated, use :erlang.float_to_binary/2 instead"
     :erlang.float_to_binary(float, expand_compact(options))
   end
 

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -844,8 +844,8 @@ defmodule Stream do
   end
 
   @doc false
-  # TODO: Deprecate by 1.4
   def uniq(enum, fun) do
+    IO.warn "Stream.uniq/2 is deprecated, use Stream.uniq_by/2 instead"
     uniq_by(enum, fun)
   end
 

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -1,7 +1,7 @@
 Code.require_file "../test_helper.exs", __DIR__
 
 defmodule Kernel.TypespecTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   alias Kernel.TypespecTest.TestTypespec
 

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -866,11 +866,7 @@ defmodule StreamTest do
   end
 
   test "uniq/1 & uniq/2" do
-    assert Stream.uniq([1, 2, 3, 2, 1]) |> Enum.to_list ==
-           [1, 2, 3]
-
-    assert Stream.uniq([{1, :x}, {2, :y}, {1, :z}], fn {x, _} -> x end) |> Enum.to_list ==
-           [{1, :x}, {2, :y}]
+    assert Stream.uniq([1, 2, 3, 2, 1]) |> Enum.to_list == [1, 2, 3]
   end
 
   test "uniq_by/2" do

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -2,7 +2,6 @@ defmodule Mix.Tasks.New do
   use Mix.Task
 
   import Mix.Generator
-  import Mix.Utils, only: [camelize: 1]
 
   @shortdoc "Creates a new Elixir project"
 
@@ -55,7 +54,7 @@ defmodule Mix.Tasks.New do
       [path | _] ->
         app = opts[:app] || Path.basename(Path.expand(path))
         check_application_name!(app, !!opts[:app])
-        mod = opts[:module] || camelize(app)
+        mod = opts[:module] || Macro.camelize(app)
         check_mod_name_validity!(mod)
         check_mod_name_availability!(mod)
         File.mkdir_p!(path)

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -236,14 +236,14 @@ defmodule Mix.Utils do
   end
 
   @doc false
-  # TODO: Deprecate by 1.4
   def underscore(value) do
+    IO.warn "Mix.Utils.underscore/1 is deprecated, use Macro.underscore/1 instead"
     Macro.underscore(value)
   end
 
   @doc false
-  # TODO: Deprecate by 1.4
   def camelize(value) do
+    IO.warn "Mix.Utils.camelize/1 is deprecated, use Macro.camelize/1 instead"
     Macro.camelize(value)
   end
 
@@ -273,7 +273,7 @@ defmodule Mix.Utils do
     |> to_string()
     |> String.split(".")
     |> Enum.drop(nesting)
-    |> Enum.map_join(".", &underscore/1)
+    |> Enum.map_join(".", &Macro.underscore/1)
   end
 
   @doc """
@@ -289,7 +289,7 @@ defmodule Mix.Utils do
     command
     |> to_string()
     |> String.split(".")
-    |> Enum.map_join(".", &camelize/1)
+    |> Enum.map_join(".", &Macro.camelize/1)
   end
 
   @doc """


### PR DESCRIPTION
Follow up to #5037. I'm keeping the big ones - `HashDict`, `HashSet`, `Dict` - for later :)

Btw, question: would it make sense to **not** use `@doc false` on these deprecated functions, so that they show up in the docs, and mention they're deprecated in the docs themselves? I know they will show up in autocomplete as well and that's bad, but I'm afraid when people look at old code that uses these function and try to find them they will have a hard time 😕 This is what we do with the `Behaviour` module btw, that's why I was wondering :)