### PR TITLE
Clarify comment in the supervisor example included in the Supervisor moduledoc

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -39,8 +39,9 @@ defmodule Supervisor do
       import Supervisor.Spec
 
       # Supervise the Stack server which will be started with
-      # a single argument [:hello] and the default registered
-      # name of MyStack.
+      # two arguments. The initial stack, [:hello], and a
+      # keyword list containing the GenServer options that
+      # set the registered name of the server to MyStack.
       children = [
         worker(Stack, [[:hello], [name: MyStack]])
       ]


### PR DESCRIPTION
Based on my confusion in #5020, I've updated the sentence above the list containing the child spec in the supervisor example. Hopefully this makes things a little easier to understand.