### PR TITLE
Perform some checks on the value of @moduledoc, @typedoc, and @doc

### DIFF
--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -660,12 +660,21 @@ defmodule Kernel.ErrorsTest do
   end
 
   test "doc attributes format" do
-    message = "expected moduledoc attribute given in the {line, doc} format, got: \"Other\""
+    message =
+      "expected the moduledoc attribute to be {line, doc} (where \"doc\" is " <>
+      "a binary, a boolean, or nil), got: \"Other\""
     assert_raise ArgumentError, message, fn ->
       defmodule DocAttributesFormat do
         @moduledoc "ModuleTest"
-        {666, "ModuleTest"} = Module.get_attribute(__MODULE__, :moduledoc)
+        {668, "ModuleTest"} = Module.get_attribute(__MODULE__, :moduledoc)
         Module.put_attribute(__MODULE__, :moduledoc, "Other")
+      end
+    end
+
+    message = "expected the moduledoc attribute to contain a binary, a boolean, or nil, got: :not_a_binary"
+    assert_raise ArgumentError, message, fn ->
+      defmodule AtSyntaxDocAttributesFormat do
+        @moduledoc :not_a_binary
       end
     end
   end


### PR DESCRIPTION
Aimed towards #5049.

`@doc` was being checked by `Module.add_doc/6` but `@moduledoc` and `@typedoc` weren't.

I think it makes sense to perform all these checks as soon as possible (i.e., when setting the proper attribute with `@`) and raise a helpful error message when we can.

Wdyt?