### PR TITLE
Fix broken GenServer using :via registry.

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -613,7 +613,7 @@ defmodule GenServer do
         :gen.start(:gen_server, link, {:local, atom}, module, args, opts)
       {{:global, _term} = tuple, opts} ->
         :gen.start(:gen_server, link, tuple, module, args, opts)
-      {{:via, module, _term} = tuple, opts} when is_atom(module) ->
+      {{:via, via_module, _term} = tuple, opts} when is_atom(via_module) ->
         :gen.start(:gen_server, link, tuple, module, args, opts)
       other ->
         raise ArgumentError, String.trim_trailing("""


### PR DESCRIPTION
Bug introduced in d9cdeeb2f135abcac87a30b35169efe5d3d7e94c
Variable `module` in the case clause shadows argument of the function.
Servers using `:via` simply do crash on start(_link).
In the mentioned commit similar change in supervisor.ex was correct.