### PR TITLE
{Enum, Stream}.{take_every, drop_every}/2 little improvements

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -601,7 +601,7 @@ defmodule Enum do
       []
 
   """
-  @spec drop_every(t, non_neg_integer) :: list | no_return
+  @spec drop_every(t, non_neg_integer) :: list
   def drop_every(enumerable, nth)
 
   def drop_every(_enumerable, 1), do: []
@@ -2306,7 +2306,7 @@ defmodule Enum do
       [1, 2, 3]
 
   """
-  @spec take_every(t, non_neg_integer) :: list | no_return
+  @spec take_every(t, non_neg_integer) :: list
   def take_every(enumerable, nth)
 
   def take_every(enumerable, 1), do: to_list(enumerable)

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -310,6 +310,7 @@ defmodule Stream do
 
   """
   @spec drop_every(Enumerable.t, non_neg_integer) :: Enumerable.t
+  def drop_every(enum, nth)
   def drop_every(enum, 0), do: %Stream{enum: enum}
   def drop_every([], _nth), do: %Stream{enum: []}
 
@@ -625,6 +626,7 @@ defmodule Stream do
 
   """
   @spec take_every(Enumerable.t, non_neg_integer) :: Enumerable.t
+  def take_every(enum, nth)
   def take_every(_enum, 0), do: %Stream{enum: []}
   def take_every([], _nth), do: %Stream{enum: []}
 


### PR DESCRIPTION
- __Correct typespec return value in Enum.take_every/2, Enum.drop_every/2__
  All functions where one arg. is not any() will raise FunctionClauseError, and we don't specify it as :: `no_return`
- __Add bodyless function to Stream.take_every/2, Stream.drop_every/2__
