### PR TITLE
Eliminate "if" warning

### DIFF
--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -345,7 +345,9 @@ defmodule OptionParser do
       String.contains?(option, ["-", "_"]) ->
         {:undefined, original_option, value, rest}
       String.length(option) > 1 ->
-        if (opt = get_option(option)) && (alias = aliases[opt]) do
+        opt = get_option(option)
+        alias = aliases[opt]
+        if opt && alias do
           IO.warn "multi-letter aliases are deprecated, got: #{inspect(opt)}"
           do_next({:default, alias}, value, original_option, rest, switches, strict?)
         else


### PR DESCRIPTION
warning: the variable "alias" is unsafe as it has been set inside a case/cond/receive/if/&&/||.
Please explicitly return the variable value instead.
...
Unsafe variable found at:
  lib/option_parser.ex:350