### PR TITLE
Update :test_started and :test_finished event docs

### DIFF
--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -21,11 +21,11 @@ defmodule ExUnit.Formatter do
     * `{:case_finished, test_case}` -
       a test case has finished. See `ExUnit.TestCase` for details.
 
-    * `{:test_started, test_case}` -
-      a test case has started. See `ExUnit.Test` for details.
+    * `{:test_started, test}` -
+      a test has started. See `ExUnit.Test` for details.
 
-    * `{:test_finished, test_case}` -
-      a test case has finished. See `ExUnit.Test` for details.
+    * `{:test_finished, test}` -
+      a test has finished. See `ExUnit.Test` for details.
 
   """
 


### PR DESCRIPTION
The `:test_started` and `:test_finished` events in the `moduledoc` refer to a `test_case` in the prose. In reality, those events receive an `ExUnit.Test` struct.