### PR TITLE
Expand message for mix deps.unlock

### DIFF
--- a/lib/mix/lib/mix/tasks/deps.unlock.ex
+++ b/lib/mix/lib/mix/tasks/deps.unlock.ex
@@ -64,7 +64,9 @@ defmodule Mix.Tasks.Deps.Unlock do
 
       true ->
         Mix.raise "\"mix deps.unlock\" expects dependencies as arguments or " <>
-                  "the --all option to unlock all dependencies"
+                  "a flag indicating which dependencies to unlock. " <>
+                  "The --all option will unlock all dependencies while " <>
+                  "the --unused option unlocks unused dependencies"
     end
   end
 end

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -251,6 +251,13 @@ defmodule Mix.Tasks.DepsTest do
     end
   end
 
+  test "fails with message on missing dependencies" do
+    Mix.Project.push DepsApp
+    assert_raise Mix.Error, ~r/"mix deps\.unlock" expects dependencies as arguments/, fn ->
+      Mix.Tasks.Deps.Unlock.run []
+    end
+  end
+
   ## Deps environment
 
   defmodule DepsEnvApp do


### PR DESCRIPTION
I just accidentially realized that it's possible to pass `--unused` to `mix deps.unlock`. This PR aligns the error message with `mix deps.clean`.