### PR TITLE
Fix typespecs for Stream.chunk/2

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -124,7 +124,7 @@ defmodule Stream do
   @doc """
   Shortcut to `chunk(enum, n, n)`.
   """
-  @spec chunk(Enumerable.t, non_neg_integer) :: Enumerable.t
+  @spec chunk(Enumerable.t, pos_integer) :: Enumerable.t
   def chunk(enum, n), do: chunk(enum, n, n, nil)
 
   @doc """


### PR DESCRIPTION
```
iex> [1,2,3] |> Stream.chunk(0)
** (FunctionClauseError) no function clause matching in Stream.chunk/4
    (elixir) lib/stream.ex:160: Stream.chunk([1, 2, 3], 0, 0, nil)
```

Typespecs for parameter `n` in `Stream.chunk/2` should match `n` in `Stream.chunk/4`, which is  `pos_integer`.