### PR TITLE
Undefined local structs report undef, not deadlock

### DIFF
--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -121,9 +121,16 @@ load_struct(Meta, Name, Args, S) ->
   try
     case Local of
       true ->
+        % The module is not loaded but it was defined (and possibly compiled) on the same file as
+        % the one trying to expand its struct
+        % OR
+        % The module is not loaded but it is being defined in another file (and the __struct__/0
+        % function was defined - but not yet compiled)
         try
           apply(elixir_locals:local_for(Name, '__struct__', Arity, def), Args)
         catch
+          % if it is not in the context and the function is not available, we have to try again
+          % because it may have been defined in the meantime
           error:undef when not Context -> apply(Name, '__struct__', Args);
           error:badarg -> apply(Name, '__struct__', Args)
         end;

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -124,6 +124,7 @@ load_struct(Meta, Name, Args, S) ->
         try
           apply(elixir_locals:local_for(Name, '__struct__', Arity, def), Args)
         catch
+          error:undef when not Context -> apply(Name, '__struct__', Args);
           error:badarg -> apply(Name, '__struct__', Args)
         end;
       false ->

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -124,7 +124,6 @@ load_struct(Meta, Name, Args, S) ->
         try
           apply(elixir_locals:local_for(Name, '__struct__', Arity, def), Args)
         catch
-          error:undef  -> apply(Name, '__struct__', Args);
           error:badarg -> apply(Name, '__struct__', Args)
         end;
       false ->

--- a/lib/elixir/test/elixir/fixtures/parallel_struct/undef.ex
+++ b/lib/elixir/test/elixir/fixtures/parallel_struct/undef.ex
@@ -1,0 +1,5 @@
+defmodule Undef do
+  def undef do
+    %__MODULE__{}
+  end
+end

--- a/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
+++ b/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
@@ -28,6 +28,13 @@ defmodule Kernel.ParallelCompilerTest do
     end
   end
 
+  test "emits struct undefined error when local struct is undefined" do
+    fixtures = [fixture_path("parallel_struct/undef.ex")]
+    assert capture_io(fn ->
+      assert catch_exit(Kernel.ParallelCompiler.files(fixtures)) == {:shutdown, 1}
+    end) =~ "Undef.__struct__/1 is undefined, cannot expand struct Undef"
+  end
+
   test "does not hang on missing dependencies" do
     fixtures = [fixture_path("parallel_compiler/bat.ex")]
     assert capture_io(fn ->


### PR DESCRIPTION
Closes #5053.

Looks like this is the appropriate solution, but not sure. The apply which was previously there resulted in a `:module` parallel compiler wait rather than a `:struct` wait, which was incorrect, but I don't think any wait should be emitted in any event, since if a local struct is undefined the first time a reference to it is seen, it is not possible to continue compiling the module (AFAIK).