### PR TITLE
Mark struct update syntax as generated

### DIFF
--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -92,9 +92,9 @@ translate_struct(Meta, Name, {'%{}', MapMeta, Args}, S) ->
 
       {TMap, TS} = translate_map(MapMeta, Assocs, Var, VS),
 
-      {{'case', Ann, TUpdate, [
+      {{'case', ?generated, TUpdate, [
         {clause, Ann, [Match], [], [TMap]},
-        {clause, Ann, [Var], [], [elixir_utils:erl_call(Ann, erlang, error, [Error])]}
+        {clause, ?generated, [Var], [], [elixir_utils:erl_call(Ann, erlang, error, [Error])]}
       ]}, TS};
     match ->
       translate_map(MapMeta, Assocs ++ [{'__struct__', Name}], nil, US);

--- a/lib/elixir/test/elixir/fixtures/dialyzer/struct_update.ex
+++ b/lib/elixir/test/elixir/fixtures/dialyzer/struct_update.ex
@@ -1,0 +1,7 @@
+defmodule Dialyzer.StructUpdate do
+  defstruct [:foo]
+
+  def update(%__MODULE__{} = struct) do
+    %__MODULE__{struct | foo: :bar}
+  end
+end

--- a/lib/elixir/test/elixir/kernel/dialyzer_test.exs
+++ b/lib/elixir/test/elixir/kernel/dialyzer_test.exs
@@ -76,6 +76,11 @@ defmodule Kernel.DialyzerTest do
     assert_dialyze_no_warnings! context
   end
 
+  test "no warnings on struct update", context do
+    copy_beam! context, Dialyzer.StructUpdate
+    assert_dialyze_no_warnings! context
+  end
+
   defp copy_beam!(context, module) do
     name = "#{module}.beam"
     File.cp! Path.join(context[:base_dir], name),


### PR DESCRIPTION
With changes to OTP 19, dialyzer started emitting warnings for
the struct update syntax where variable could only be that struct.
For example:

    def foo(%Foo{} = struct), do: %Foo{struct | bar: :baz}

I'm not 100% sure this is the correct fix. I'm not sure how to test this properly. Do we have some way of testing for dialyzer warnings?