### PR TITLE
Raise on incorrect digits

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -128,7 +128,7 @@ defmodule Integer do
 
   defp do_undigits([], _base, acc),
     do: acc
-  defp do_undigits([digit | _], base, _) when is_integer(digit) when digit >= base,
+  defp do_undigits([digit | _], base, _) when is_integer(digit) and digit >= base,
     do: raise ArgumentError, "invalid digit #{digit} in base #{base}"
   defp do_undigits([digit | tail], base, acc) when is_integer(digit),
     do: do_undigits(tail, base, acc * base + digit)

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -128,8 +128,13 @@ defmodule Integer do
 
   defp do_undigits([], _base, acc),
     do: acc
-  defp do_undigits([digit | tail], base, acc) when is_integer(digit),
-    do: do_undigits(tail, base, acc * base + digit)
+  defp do_undigits([digit | tail], base, acc) when is_integer(digit) do
+    if digit >= base do
+      raise ArgumentError, "invalid digit '#{digit}' in base #{base}"
+    else
+      do_undigits(tail, base, acc * base + digit)
+    end
+  end
 
   @doc """
   Parses a text representation of an integer.

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -130,7 +130,7 @@ defmodule Integer do
     do: acc
   defp do_undigits([digit | tail], base, acc) when is_integer(digit) do
     if digit >= base do
-      raise ArgumentError, "invalid digit '#{digit}' in base #{base}"
+      raise ArgumentError, "invalid digit \"#{digit}\" in base \"#{base}\""
     else
       do_undigits(tail, base, acc * base + digit)
     end

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -128,13 +128,10 @@ defmodule Integer do
 
   defp do_undigits([], _base, acc),
     do: acc
-  defp do_undigits([digit | tail], base, acc) when is_integer(digit) do
-    if digit >= base do
-      raise ArgumentError, "invalid digit #{digit} in base #{base}"
-    else
-      do_undigits(tail, base, acc * base + digit)
-    end
-  end
+  defp do_undigits([digit | _], base, _) when is_integer(digit) when digit >= base,
+    do: raise ArgumentError, "invalid digit #{digit} in base #{base}"
+  defp do_undigits([digit | tail], base, acc) when is_integer(digit),
+    do: do_undigits(tail, base, acc * base + digit)
 
   @doc """
   Parses a text representation of an integer.

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -130,7 +130,7 @@ defmodule Integer do
     do: acc
   defp do_undigits([digit | tail], base, acc) when is_integer(digit) do
     if digit >= base do
-      raise ArgumentError, "invalid digit \"#{digit}\" in base \"#{base}\""
+      raise ArgumentError, "invalid digit #{digit} in base #{base}"
     else
       do_undigits(tail, base, acc * base + digit)
     end

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -81,6 +81,10 @@ defmodule IntegerTest do
         Integer.undigits([1, 0, 1], n)
       end
     end
+
+    assert_raise ArgumentError, "invalid digit '17' in base 16", fn ->
+      Integer.undigits([1, 2, 17], 16)
+    end
   end
 
   test "parse/2" do

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -82,7 +82,7 @@ defmodule IntegerTest do
       end
     end
 
-    assert_raise ArgumentError, "invalid digit \"17\" in base \"16\"", fn ->
+    assert_raise ArgumentError, "invalid digit 17 in base 16", fn ->
       Integer.undigits([1, 2, 17], 16)
     end
   end

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -82,7 +82,7 @@ defmodule IntegerTest do
       end
     end
 
-    assert_raise ArgumentError, "invalid digit '17' in base 16", fn ->
+    assert_raise ArgumentError, "invalid digit \"17\" in base \"16\"", fn ->
       Integer.undigits([1, 2, 17], 16)
     end
   end


### PR DESCRIPTION
Right now `Integer.undigits/2` may yield results that are hard to reason about:

```
iex(1)> Integer.undigits([10,10]) 
110
iex(2)> Integer.undigits([1,10]) 
20
```