### PR TITLE
Cleanup lib/mix/lib/mix/compilers/elixir.ex

### DIFF
--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -348,6 +348,7 @@ defmodule Mix.Compilers.Elixir do
       _ -> {[], []}
     else
       [@manifest_vsn | data] -> do_parse_manifest(data, compile_path)
+      _ -> {[], []}
     end
   end
 

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -342,23 +342,12 @@ defmodule Mix.Compilers.Elixir do
 
   # Similar to read_manifest, but supports data migration.
   defp parse_manifest(manifest, compile_path) do
-    # TODO: No longer support file consult once v1.3 is out
-    manifest =
-      try do
-        {:ok, manifest |> File.read!() |> :erlang.binary_to_term()}
-      rescue
-        _ -> :file.consult(manifest)
-      end
-
-    case manifest do
-      {:ok, [@manifest_vsn | data]} ->
-        do_parse_manifest(data, compile_path)
-      {:ok, [:v2 | data]} ->
-        for {beam, module, _, _, _, _, _, _} <- data,
-            do: remove_and_purge(beam, module)
-        {[], []}
-      _ ->
-        {[], []}
+    try do
+      manifest |> File.read!() |> :erlang.binary_to_term()
+    rescue
+      _ -> {[], []}
+    else
+      [@manifest_vsn | data] -> do_parse_manifest(data, compile_path)
     end
   end
 


### PR DESCRIPTION
Per TODO and https://github.com/elixir-lang/elixir/commit/f8e88ebe6014511a4276699c4705f6d0bb8dcc9b#commitcomment-18420581.

`:file.consult` also used in these files, but there are no TODOs there
```
lib/mix/lib/mix/dep/loader.ex
lib/mix/lib/mix/rebar.ex
lib/mix/lib/mix/tasks/compile.app.ex
lib/mix/test/mix/tasks/compile.app_test.exs
```