### PR TITLE
Add `assert_member` to ExUnit assertions

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -468,6 +468,34 @@ defmodule ExUnit.Assertions do
   end
 
   @doc """
+  Asserts that an element matching `pattern` exists within `enumerable`.
+
+  ## Examples
+
+      assert_member %{second: 2}, [%{first: 1, second: 2}]
+      assert_member "my_" <> _, ["your_name", "my_name", "our_names"]
+  """
+  defmacro assert_member(pattern, enumerable, failure_message \\ nil) do
+    binary = Macro.to_string(pattern)
+
+    quote do
+      enum = unquote(enumerable)
+      any = Enum.any? enum, fn
+        unquote(pattern) -> true
+        _ -> false
+      end
+
+      if any do
+        true
+      else
+        members = Enum.reduce(enum, "", &(&2 <> "\n  #{inspect &1}"))
+        message = "No member matching #{unquote(binary)}.\nMembers:#{members}"
+        flunk(unquote(failure_message) || message)
+      end
+    end
+  end
+
+  @doc """
   Asserts that `value1` and `value2` differ by no more than `delta`.
 
 

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -483,6 +483,22 @@ defmodule ExUnit.AssertionsTest do
       "test message (difference between 10 and 11 is less than 2)" = error.message
   end
 
+  test "assert member with pattern" do
+    true = assert_member %{foo: 1}, [%{foo: 1, bar: 2}]
+    true = assert_member "my" <> _, ["your_name", "my_name", "our_names"]
+    true = assert_member 42, 1..100
+  end
+
+  test "assert member with pattern when no match" do
+    "This should never be tested" = assert_member %{foo: 1, bar: 2}, [%{foo: 1}, %{baz: 3}]
+  rescue
+    error in [ExUnit.AssertionError] ->
+      "No member matching %{foo: 1, bar: 2}." <>
+      "\nMembers:" <>
+      "\n  %{foo: 1}" <>
+      "\n  %{baz: 3}" = error.message
+  end
+
   test "catch_throw with no throw" do
     catch_throw(1)
   rescue


### PR DESCRIPTION
This macro asserts that an element **matching a pattern** exists within an enumerable.

Examples:
```elixir
assert_member %{second: 2}, [%{first: 1, second: 2}]
assert_member "my_" <> _, ["your_name", "my_name", "our_names"]
assert_member {:day, {"is_invalid", _}}, [day: {"is invalid", [type: SmashingSpecialDay]}, year: {"can't be blank", []}]
```