### PR TITLE
Support interrupting IEx evaluation

### DIFF
--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -107,6 +107,7 @@ defmodule IEx.Server do
   """
   @spec start(list, {module, atom, [any]}) :: :ok
   def start(opts, {m, f, a}) do
+    Process.flag(:trap_exit, true)
     {pid, ref} = spawn_monitor(m, f, a)
     start_loop(opts, pid, ref)
   end
@@ -139,13 +140,17 @@ defmodule IEx.Server do
 
   defp run(opts) when is_list(opts) do
     IO.puts "Interactive Elixir (#{System.version}) - press Ctrl+C to exit (type h() ENTER for help)"
+    evaluator = start_evaluator(opts)
+    loop(run_state(opts), evaluator, Process.monitor(evaluator))
+  end
 
+  defp start_evaluator(opts) do
     self_pid = self()
     self_leader = Process.group_leader
     evaluator = opts[:evaluator] ||
                 :proc_lib.start(IEx.Evaluator, :init, [:ack, self_pid, self_leader, opts])
     Process.put(:evaluator, evaluator)
-    loop(run_state(opts), evaluator, Process.monitor(evaluator))
+    evaluator
   end
 
   defp reset_loop(opts, evaluator, evaluator_ref) do
@@ -179,7 +184,7 @@ defmodule IEx.Server do
     receive do
       {:input, ^input, code} when is_binary(code) ->
         send evaluator, {:eval, self(), code, state}
-        wait_eval(evaluator, evaluator_ref)
+        wait_eval(state, evaluator, evaluator_ref)
       {:input, ^input, {:error, :interrupted}} ->
         io_error "** (EXIT) interrupted"
         loop(%{state | cache: ''}, evaluator, evaluator_ref)
@@ -197,13 +202,21 @@ defmodule IEx.Server do
     end
   end
 
-  defp wait_eval(evaluator, evaluator_ref) do
+  defp wait_eval(state, evaluator, evaluator_ref) do
     receive do
-      {:evaled, ^evaluator, state} ->
-        loop(state, evaluator, evaluator_ref)
+      {:evaled, ^evaluator, new_state} ->
+        loop(new_state, evaluator, evaluator_ref)
+      {:EXIT, _pid, :interrupt} ->
+        # User did ^G while the evaluator was busy or stuck
+        io_error "** (EXIT) interrupted"
+        Process.delete(:evaluator)
+        Process.exit(evaluator, :kill)
+        Process.demonitor(evaluator_ref, [:flush])
+        evaluator = start_evaluator([])
+        loop(%{state | cache: ''}, evaluator, Process.monitor(evaluator))
       msg ->
         handle_take_over(msg, evaluator, evaluator_ref, nil,
-                         fn -> wait_eval(evaluator, evaluator_ref) end)
+                         fn -> wait_eval(state, evaluator, evaluator_ref) end)
     end
   end
 


### PR DESCRIPTION
Doing an interrupt (Ctrl-G then "i") while IEx is busy evaluating something currently makes it crash. This PR makes IEx.Server trap the `interrupt` signal and kill the evaluation (same behavior as the Erlang shell). Fixes: https://github.com/elixir-lang/elixir/issues/4991

I tested:

* Interrupt while waiting for input

```elixir
iex(local@Ando)1>
User switch command
 --> i
 --> c
** (EXIT) interrupted
iex(local@Ando)1>
```

* Interrupt while evaluating

```elixir
iex(local@Ando)1> Process.sleep(10000000)

User switch command
 --> i
 --> c
** (EXIT) interrupted
iex(local@Ando)1>
```

* Interrupt in etop (original issue)

```elixir
iex(local@Ando)2> :etop.start

========================================================================================
 local@Ando                                                                14:51:52
 Load:  cpu         0               Memory:  total       16566    binary         42
        procs      50                        processes    4626    code         5823
        runq        0                        atom          258    ets           425

Pid            Name or Initial Func    Time    Reds  Memory    MsgQ Current Function
----------------------------------------------------------------------------------------
<0.4.0>        erl_prim_loader          '-'  340915  426488       0 erl_prim_loader:loop
<0.36.0>       code_server              '-'  124864  284592       0 code_server:loop/1
<0.31.0>       application_controll     '-'   50106  426696       0 gen_server:loop/6
<0.54.0>       user_drv                 '-'    3950   18728       0 user_drv:server_loop
<0.35.0>       kernel_sup               '-'    1988    6296       0 gen_server:loop/6
<0.89.0>       etop_server              '-'    1780   24752       0 etop:data_handler/2
<0.0.0>        init                     '-'    1584   34448       0 init:loop/1
<0.56.0>       group:server/3           '-'    1387   21848       0 group:server_loop/3
<0.50.0>       file_server_2            '-'    1243   13800       0 gen_server:loop/6
<0.45.0>       auth                     '-'     873   10744       0 gen_server:loop/6
========================================================================================


User switch command
 --> i
 --> c
** (EXIT) interrupted
iex(local@Ando)2>
```

* Pry

```elixir
iex(local@Ando)3> require IEx
IEx
iex(local@Ando)4> f = fn -> IEx.pry() end
#Function<20.52032458/0 in :erl_eval.expr/5>
iex(local@Ando)5> f.()
Request to pry #PID<0.95.0> at iex:4
Allow? [Yn] Y

Interactive Elixir (1.4.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
pry(local@Ando)1> respawn
warning: variable "respawn" does not exist and is being expanded to "respawn()", please use parentheses to remove the ambiguity or change the variable name
  iex:1


Interactive Elixir (1.4.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
:ok
iex(local@Ando)1>
```

* Remote shell
```elixir
iex(local@Ando)2>
User switch command
 --> r 'remote@Ando' 'Elixir.IEx'
 --> c
Interactive Elixir (1.4.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(remote@Ando)1> Process.sleep(1000000)

User switch command
 --> i
 --> j
   1  {erlang,apply,[#Fun<Elixir.IEx.CLI.1.103769006>,[]]}
   2* {remote@Ando,'Elixir.IEx',start,[]}
 --> c
** (EXIT) interrupted
iex(remote@Ando)1>
```