### PR TITLE
Add example difference between :one_for_one and :simple_one_for_one

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -48,6 +48,10 @@ defmodule Supervisor do
 
       # Start the supervisor with our child
       {:ok, pid} = Supervisor.start_link(children, strategy: :one_for_one)
+      
+      # There is one child worker started
+      Supervisor.count_children(pid)
+      #=> %{active: 1, specs: 1, supervisors: 0, workers: 1}
 
   Notice that when starting the GenServer, we are registering it
   with name `MyStack`, which allows us to call it directly and
@@ -158,8 +162,12 @@ defmodule Supervisor do
         worker(Stack, [], restart: :transient)
       ]
 
-      # Start the supervisor with our one child
+      # Start the supervisor with our one child as a template
       {:ok, sup_pid} = Supervisor.start_link(children, strategy: :simple_one_for_one)
+      
+      # No child worker is active yet until start_child is called
+      Supervisor.count_children(sup_pid)
+      #=> %{active: 0, specs: 1, supervisors: 0, workers: 0}
 
   There are a couple differences here:
 


### PR DESCRIPTION
I thought this extra iex example might be useful in understanding the difference between :one_for_one, where the child is created when the supervisor is created, vs. :simple_one_for_one where the child acts as a template and creating the supervisor in that case does not create any active child processes until start_child is called.