### PR TITLE
use positive in @doc of Enum.sort/2

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2054,7 +2054,7 @@ defmodule Enum do
   Sorts the enumerable by the given function.
 
   This function uses the merge sort algorithm. The given function should compare
-  two arguments, and return `false` if the first argument follows the second one.
+  two arguments, and return `true` if the first argument preceeds the second one.
 
   ## Examples
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2054,7 +2054,7 @@ defmodule Enum do
   Sorts the enumerable by the given function.
 
   This function uses the merge sort algorithm. The given function should compare
-  two arguments, and return `true` if the first argument preceeds the second one.
+  two arguments, and return `true` if the first argument precedes the second one.
 
   ## Examples
 


### PR DESCRIPTION
positives are slightly easier to understand than negavites.

I find it more in intuitively to describe the second argument this way, because it's easier to understand that it
> determines whether the first precedes

than it is to understand that it

> determines whether the first doesn't follow the second

`true` meaning *yes* and `false` meaning *no* in both cases. 