### PR TITLE
Do not wait for self in parallel compiler

### DIFF
--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -206,8 +206,10 @@ defmodule Kernel.ParallelCompiler do
 
       {:waiting, kind, child, ref, on, defining} ->
         # Oops, we already got it, do not put it on waiting.
+        # OR
+        # We're waiting on ourselves, send :found so that we can crash with a better error
         waiting =
-          if :lists.any(&match?({^kind, ^on}, &1), result) do
+          if :lists.any(&match?({^kind, ^on}, &1), result) or on in defining do
             send child, {ref, :found}
             waiting
           else

--- a/lib/elixir/test/elixir/fixtures/parallel_struct/undef.ex
+++ b/lib/elixir/test/elixir/fixtures/parallel_struct/undef.ex
@@ -1,0 +1,5 @@
+defmodule Undef do
+  def undef do
+    %__MODULE__{}
+  end
+end

--- a/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
+++ b/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
@@ -28,6 +28,13 @@ defmodule Kernel.ParallelCompilerTest do
     end
   end
 
+  test "emits struct undefined error when local struct is undefined" do
+    fixtures = [fixture_path("parallel_struct/undef.ex")]
+    assert capture_io(fn ->
+      assert catch_exit(Kernel.ParallelCompiler.files(fixtures)) == {:shutdown, 1}
+    end) =~ "Undef.__struct__/1 is undefined, cannot expand struct Undef"
+  end
+
   test "does not hang on missing dependencies" do
     fixtures = [fixture_path("parallel_compiler/bat.ex")]
     assert capture_io(fn ->


### PR DESCRIPTION
Closes #5053.

If the module we are waiting `on` is in the list of modules we are currently `defining`, simply send `:found` so that the compiler process can produce whatever error it would outside of the parallel compiler.

This fixes the issue described in #5053 and should also improve any other potential future similar issues.