### PR TITLE
genserver example :pop works on empty list

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -23,6 +23,10 @@ defmodule GenServer do
 
         # Callbacks
 
+        def handle_call(:pop, _from, []) do
+          {:reply, [], []}
+        end
+
         def handle_call(:pop, _from, [h | t]) do
           {:reply, h, t}
         end

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -132,6 +132,10 @@ defmodule GenServer do
         end
 
         # Server (callbacks)
+        
+        def handle_call(:pop, _from, []) do
+          {:reply, [], []}
+        end
 
         def handle_call(:pop, _from, [h | t]) do
           {:reply, h, t}


### PR DESCRIPTION
I found quite useful, as peoples implementing this code example to learn genserver might try to pop before doing a push, thus this avoid to have some errors.