### PR TITLE
Document that consolidate_protocols is enabled by default

### DIFF
--- a/lib/mix/lib/mix/tasks/app.start.ex
+++ b/lib/mix/lib/mix/tasks/app.start.ex
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.App.Start do
       applications are started in permanent mode
 
     * `:consolidate_protocols` - when `true`, loads consolidated
-      protocols before start. Enabled by default.
+      protocols before start. The default value is `true`.
 
     * `:elixir` - matches the current elixir version against the
       given requirement

--- a/lib/mix/lib/mix/tasks/app.start.ex
+++ b/lib/mix/lib/mix/tasks/app.start.ex
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.App.Start do
       applications are started in permanent mode
 
     * `:consolidate_protocols` - when `true`, loads consolidated
-      protocols before start
+      protocols before start. Enabled by default.
 
     * `:elixir` - matches the current elixir version against the
       given requirement

--- a/lib/mix/lib/mix/tasks/compile.ex
+++ b/lib/mix/lib/mix/tasks/compile.ex
@@ -14,7 +14,8 @@ defmodule Mix.Tasks.Compile do
       `[:yecc, :leex, :erlang, :elixir, :xref, :app]`
 
     * `:consolidate_protocols` - when `true`, runs protocol
-      consolidation via the `compile.protocols` task. Enabled by default.
+      consolidation via the `compile.protocols` task. The default
+      value is `true`.
 
     * `:build_embedded` - when `true`, activates protocol
       consolidation and does not generate symlinks in builds

--- a/lib/mix/lib/mix/tasks/compile.ex
+++ b/lib/mix/lib/mix/tasks/compile.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Compile do
       `[:yecc, :leex, :erlang, :elixir, :xref, :app]`
 
     * `:consolidate_protocols` - when `true`, runs protocol
-      consolidation via the `compile.protocols` task
+      consolidation via the `compile.protocols` task. Enabled by default.
 
     * `:build_embedded` - when `true`, activates protocol
       consolidation and does not generate symlinks in builds

--- a/lib/mix/lib/mix/tasks/compile.protocols.ex
+++ b/lib/mix/lib/mix/tasks/compile.protocols.ex
@@ -9,7 +9,8 @@ defmodule Mix.Tasks.Compile.Protocols do
 
   This task is automatically invoked whenever the project
   enables `:consolidate_protocols` or `:build_embedded` in
-  its configuration.
+  its configuration. As `:consolidate_protocols` is enabled
+  in the default configuration, this is the default case.
 
   ## Consolidation
 


### PR DESCRIPTION
Didn't know about this (and apparently several other people who
asked me if I had it enabled as well) so I thought it'd be good
to mention, I like defaults being mentioned in the docs
in general :)

As [by this default configuration](https://github.com/elixir-lang/elixir/blob/843783a890f00fcbd014170cada06a7c1d3aafd4/lib/mix/lib/mix/project.ex#L490-L507). I also think it'd be nice to mention the project default configuration in Mix.Project docs, but that's prone to error. I thought about making `default_config` public, and adding a doc test for it. Sure, annoying to update but that way the docs would stay up to date and people would have an easy reference for the default configuration without digging through the code. I'd be happy to add that in as well if desired :)

Also for compile/app.start might want to add the other default values in the docs.

Thanks!
Tobi