### PR TITLE
Change example for drop_while

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -619,8 +619,8 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.drop_while([1, 2, 3, 4, 5], fn(x) -> x < 3 end)
-      [3, 4, 5]
+      iex> Enum.drop_while([1, 2, 3, 2, 1], fn(x) -> x < 3 end)
+      [3, 2, 1]
 
   """
   @spec drop_while(t, (element -> as_boolean(term))) :: list


### PR DESCRIPTION
While yielding the right result, the current example for `drop_while` is misleading and can cause confusion between `drop_while` and `reject`.