### PR TITLE
Expand DocTest's RegExp to allow Unicode and Multi-line inside opaque inspect types

### DIFF
--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -599,7 +599,7 @@ defmodule ExUnit.DocTest do
         [mod, message] = :binary.split(error, ")")
         {:error, Module.concat([mod]), String.trim_leading(message)}
       _ ->
-        if string =~ ~r/\A#[A-Z][\w\.]*<(.|\n)*?\z/mu do
+        if string =~ ~r/\A#[A-Z][\w\.]*</mu do
           {:inspect, inspect(string)}
         else
           {:test, string}

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -308,7 +308,7 @@ defmodule ExUnit.DocTest do
   end
 
   defp test_case_content(expr, {:inspect, expected}, location, stack) do
-    expr_ast     = quote do: inspect(unquote(string_to_quoted(location, stack, expr)))
+    expr_ast     = quote do: inspect(unquote(string_to_quoted(location, stack, expr))) |> String.replace_suffix("\n", "")
     expected_ast = string_to_quoted(location, stack, expected)
 
     quote do
@@ -599,7 +599,7 @@ defmodule ExUnit.DocTest do
         [mod, message] = :binary.split(error, ")")
         {:error, Module.concat([mod]), String.trim_leading(message)}
       _ ->
-        if string =~ ~r/^#[A-Z][\w\.]*<.*>$/ do
+        if string =~ ~r/\A#[A-Z][\w\.]*<(.|\n)*?\z/mu do
           {:inspect, inspect(string)}
         else
           {:test, string}

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -217,6 +217,71 @@ defmodule ExUnit.DocTestTest.Numbered do
   def test_fun(), do: :ok
 end |> write_beam()
 
+defmodule ExUnit.DocTestTest.Haiku do
+  @moduledoc """
+  This module describes the ancient Japanese poem form known as Haiku.
+
+  The Inspect protocol has been overriden for `%Haiku{}` 
+  so that Haikus are shown in a pretty-printed fashion.
+  
+  This module is part of the DocTest test suite, 
+  to ensure that DocTest can handle opaque inspect types 
+  which contain unicode and possibly consist of multiple lines.
+  """
+
+  defstruct [:first_phrase, :second_phrase, :third_phrase, :author]
+  alias __MODULE__
+
+  @doc """
+  Creates a new Haiku.
+  Optionally pass in the `author` as fourth argument.
+  
+  ## Examples:
+  
+      # Simple Haiku, inspect output consists of multiple lines.
+      iex> ExUnit.DocTestTest.Haiku.new( "Haikus are easy","But sometimes they don't make sense","Refrigerator")
+      #Haiku<
+        Haikus are easy
+        But sometimes they don't make sense
+        Refrigerator
+      >
+
+
+      # Haiku with Unicode characters (Japanese Kanji, em-dash).
+      iex> ExUnit.DocTestTest.Haiku.new("古池や","蛙飛びこむ","水の音", "Matsuo Basho")
+      #Haiku<
+        古池や
+        蛙飛びこむ
+        水の音
+        ― Matsuo Basho
+      >
+
+  
+  """
+  def new(first, second, third, author \\ "") when is_binary(first) and is_binary(second) and is_binary(third) and is_binary(author) do
+    %Haiku{
+      first_phrase: first,
+      second_phrase: second,
+      third_phrase: third,
+      author: author
+    }
+  end
+
+  defimpl Inspect do
+    def inspect(haiku, _opts) do
+      author_str = if haiku.author == "", do: "", else: "\n  ― #{haiku.author}"
+      """
+      #Haiku<
+        #{haiku.first_phrase}
+        #{haiku.second_phrase}
+        #{haiku.third_phrase}#{author_str}
+      >
+      """
+    end
+  end
+end |> write_beam
+
+
 defmodule ExUnit.DocTestTest do
   use ExUnit.Case
 
@@ -229,6 +294,7 @@ defmodule ExUnit.DocTestTest do
   doctest ExUnit.DocTestTest.SomewhatGoodModuleWithExcept, except: [:moduledoc, test_fun2: 0], import: true
   doctest ExUnit.DocTestTest.NoImport
   doctest ExUnit.DocTestTest.IndentationHeredocs
+  doctest ExUnit.DocTestTest.Haiku
 
   import ExUnit.CaptureIO
 
@@ -257,7 +323,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       1) test moduledoc at ExUnit.DocTestTest.Invalid (1) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:248
+         test/ex_unit/doc_test_test.exs:314
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:127: syntax error before: '*'
          code: 1 + * 1
          stacktrace:
@@ -266,7 +332,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       2) test moduledoc at ExUnit.DocTestTest.Invalid (2) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:248
+         test/ex_unit/doc_test_test.exs:314
          Doctest failed
          code: 1 + hd(List.flatten([1])) === 3
          left: 2
@@ -276,7 +342,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       3) test moduledoc at ExUnit.DocTestTest.Invalid (3) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:248
+         test/ex_unit/doc_test_test.exs:314
          Doctest failed
          code: inspect(:oops) === "#MapSet<[]>"
          left: ":oops"
@@ -287,7 +353,7 @@ defmodule ExUnit.DocTestTest do
     # The stacktrace points to the cause of the error
     assert output =~ """
       4) test moduledoc at ExUnit.DocTestTest.Invalid (4) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:248
+         test/ex_unit/doc_test_test.exs:314
          Doctest failed: got UndefinedFunctionError with message "function Hello.world/0 is undefined (module Hello is not available)"
          code: Hello.world
          stacktrace:
@@ -297,7 +363,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       5) test moduledoc at ExUnit.DocTestTest.Invalid (5) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:248
+         test/ex_unit/doc_test_test.exs:314
          Doctest failed: expected exception WhatIsThis but got RuntimeError with message "oops"
          code: raise "oops"
          stacktrace:
@@ -306,7 +372,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       6) test moduledoc at ExUnit.DocTestTest.Invalid (6) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:248
+         test/ex_unit/doc_test_test.exs:314
          Doctest failed: wrong message for RuntimeError
          expected:
            "hello"
@@ -319,7 +385,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       7) test doc at ExUnit.DocTestTest.Invalid.a/0 (7) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:248
+         test/ex_unit/doc_test_test.exs:314
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:148: syntax error before: '*'
          code: 1 + * 1
          stacktrace:
@@ -328,7 +394,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       8) test doc at ExUnit.DocTestTest.Invalid.b/0 (8) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:248
+         test/ex_unit/doc_test_test.exs:314
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:154: syntax error before: '*'
          code: 1 + * 1
          stacktrace:


### PR DESCRIPTION
- DocTest Regex changed to:
  - Allow Unicode
  - Allow multiline statements.
    - Doctest will still match if Inspect output ends with a `\n`.
  - Instead of enforcing `#Name<...>` now enforces `#Name<...` (Trailing `>` no longer required) for opaque inspect types.

Fixes #5103. Fixes #5100.

Also contains some very poetic specs. :innocent: 