### PR TITLE
Add examples in the docs for the i/1 IEx helper

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -30,7 +30,7 @@ defmodule IEx.Helpers do
     * `flush/0`       - flushes all messages sent to the shell
     * `h/0`           - prints this help message
     * `h/1`           - prints help for the given module, function or macro
-    * `i/1`           - prints information about the data type of a given term
+    * `i/1`           - prints information about the data type of any given term
     * `import_file/1` - evaluates the given file in the shell's context
     * `l/1`           - loads the given module's BEAM code
     * `ls/0`          - lists the contents of the current directory

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -30,7 +30,7 @@ defmodule IEx.Helpers do
     * `flush/0`       - flushes all messages sent to the shell
     * `h/0`           - prints this help message
     * `h/1`           - prints help for the given module, function or macro
-    * `i/1`           - prints information about the given data type
+    * `i/1`           - prints information about the data type of a given term
     * `import_file/1` - evaluates the given file in the shell's context
     * `l/1`           - loads the given module's BEAM code
     * `ls/0`          - lists the contents of the current directory
@@ -393,12 +393,14 @@ defmodule IEx.Helpers do
   end
 
   @doc """
-  Prints information about the given data type.
+  Prints information about the data type of a given term.
   
   ## Examples
 
-      i(Int)
-      i(Atom)
+      i([1,2,3])
+      i("Elixir rocks!")
+      i(:some_atom)
+      i(fn x -> x * 2 end)
   """
   def i(term) do
     info = ["Term": inspect(term)] ++ IEx.Info.info(term)

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -393,14 +393,19 @@ defmodule IEx.Helpers do
   end
 
   @doc """
-  Prints information about the data type of the given term.
+  Prints information about the data type of any vaild Elixir term.
   
   ## Examples
 
-      i([1,2,3])
-      i("Elixir rocks!")
-      i(:some_atom)
-      i(fn x -> x * 2 end)
+      iex> i(1..5)
+      Term
+        1..5
+      Data type
+        Range
+      Description
+        This is a struct. Structs are maps with a __struct__ key.
+      Reference modules
+        Range, Map
   """
   def i(term) do
     info = ["Term": inspect(term)] ++ IEx.Info.info(term)

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -398,6 +398,9 @@ defmodule IEx.Helpers do
   ## Examples
 
       iex> i(1..5)
+      
+    Will print:
+    
       Term
         1..5
       Data type

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -393,7 +393,7 @@ defmodule IEx.Helpers do
   end
 
   @doc """
-  Prints information about the data type of any vaild Elixir term.
+  Prints information about the data type of any given term.
   
   ## Examples
 

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -393,7 +393,7 @@ defmodule IEx.Helpers do
   end
 
   @doc """
-  Prints information about the data type of a given term.
+  Prints information about the data type of the given term.
   
   ## Examples
 

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -104,7 +104,7 @@ defmodule IEx.Helpers do
   the compiled code to (defaults to the current directory). When compiling
   one file, there is no need to wrap it in a list.
 
-  It returns the name of the compiled modules.
+  It returns the names of the compiled modules.
 
   If you want to recompile an existing module, check `r/1` instead.
 
@@ -394,6 +394,11 @@ defmodule IEx.Helpers do
 
   @doc """
   Prints information about the given data type.
+  
+  ## Examples
+
+      i(Int)
+      i(Atom)
   """
   def i(term) do
     info = ["Term": inspect(term)] ++ IEx.Info.info(term)

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -399,7 +399,7 @@ defmodule IEx.Helpers do
 
       iex> i(1..5)
       
-    Will print:
+  Will print:
     
       Term
         1..5


### PR DESCRIPTION
All other helper functions/macros like `h` or `b` have examples. So I feelt like there should be examples in the same style for `i` too.

(And I also fixed a typo).