### PR TITLE
Omit redundant information if both sides in assertion are exactly equal

### DIFF
--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -510,6 +510,44 @@ defmodule ExUnit.AssertionsTest do
       "assertion" = error.message
   end
 
+  test "assert lack of equality" do
+    try do
+      "This should never be tested" = assert "one" != "one"
+    rescue
+      error in [ExUnit.AssertionError] ->
+        "Assertion with != failed, both sides are exactly equal" = error.message
+        "one" = error.left
+    end
+
+    try do
+      "This should never be tested" = assert 2 != 2.0
+    rescue
+      error in [ExUnit.AssertionError] ->
+        "Assertion with != failed" = error.message
+        2 = error.left
+        2.0 = error.right
+    end
+  end
+
+  test "refute equality" do
+    try do
+      "This should never be tested" = refute "one" == "one"
+    rescue
+      error in [ExUnit.AssertionError] ->
+        "Refute with == failed, both sides are exactly equal" = error.message
+        "one" = error.left
+    end
+
+    try do
+      "This should never be tested" = refute 2 == 2.0
+    rescue
+      error in [ExUnit.AssertionError] ->
+        "Refute with == failed" = error.message
+        2 = error.left
+        2.0 = error.right
+    end
+  end
+
   test "assert in delta" do
     true = assert_in_delta(1.1, 1.2, 0.2)
   end


### PR DESCRIPTION
<img width="602" alt="screen shot 2016-08-09 at 00 52 54" src="https://cloud.githubusercontent.com/assets/248290/17499116/c349d70a-5dcb-11e6-80ca-098d15a0398d.png">

Closes #5084.

CC @fishcakez 