### PR TITLE
Allow running a task multiple times within a "mix do" invocation

### DIFF
--- a/lib/mix/lib/mix/tasks/do.ex
+++ b/lib/mix/lib/mix/tasks/do.ex
@@ -20,7 +20,9 @@ defmodule Mix.Tasks.Do do
   @spec run(OptionParser.argv) :: :ok
   def run(args) do
     Enum.each gather_commands(args), fn
-      [task | args] -> Mix.Task.run task, args
+      [task | args] ->
+        Mix.Task.run task, args
+        Mix.Task.clear
     end
   end
 

--- a/lib/mix/test/mix/tasks/do_test.exs
+++ b/lib/mix/test/mix/tasks/do_test.exs
@@ -5,7 +5,9 @@ defmodule Mix.Tasks.DoTest do
 
   test "runs given tasks", context do
     in_tmp context.test, fn ->
-      Mix.Tasks.Do.run ["compile", "--list,", "help"]
+      Mix.Tasks.Do.run ["compile", "--list,", "help,", "help"]
+      # Allow running a task multiple times within one "do"
+      assert_received {:mix_shell, :info, ["mix help" <> _]}
       assert_received {:mix_shell, :info, ["mix help" <> _]}
       assert_received {:mix_shell, :info, ["mix compile.app" <> _]}
     end


### PR DESCRIPTION
Also fixes interference between `clean` and `compile` inside one `do`: https://github.com/elixir-lang/elixir/issues/5094