### PR TITLE
Add proper location to generated code on 19

### DIFF
--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -1,6 +1,8 @@
 -define(m(M, K), maps:get(K, M)).
 -define(ann(Opts), elixir_utils:get_ann(Opts)).
 -define(line(Opts), elixir_utils:get_line(Opts)).
+-define(generated(Opts), [{generated, true}, {location, ?line(Opts)}]).
+%% TODO: remove once we drop Erlang 18 support
 -define(generated, [{generated, true}, {location, 0}]).
 
 -record(elixir_scope, {

--- a/lib/elixir/src/elixir_for.erl
+++ b/lib/elixir/src/elixir_for.erl
@@ -206,7 +206,8 @@ build_reduce(Clauses, Expr, {bin, _, _} = Into, Acc, S) ->
   build_reduce_clause(Clauses, BinExpr, Into, Acc, S).
 
 build_reduce_clause([{enum, Meta, Left, Right, Filters} | T], Expr, Arg, Acc, S) ->
-  Ann  = ?ann(Meta),
+  Generated = ?generated(Meta),
+  Ann   = ?ann(Meta),
   True  = build_reduce_clause(T, Expr, Acc, Acc, S),
   False = Acc,
 
@@ -214,7 +215,7 @@ build_reduce_clause([{enum, Meta, Left, Right, Filters} | T], Expr, Arg, Acc, S)
     case is_var(Left) of
       true  -> [];
       false ->
-        [{clause, ?generated,
+        [{clause, Generated,
           [{var, Ann, '_'}, Acc], [],
           [False]}]
     end,
@@ -229,6 +230,7 @@ build_reduce_clause([{enum, Meta, Left, Right, Filters} | T], Expr, Arg, Acc, S)
 
 build_reduce_clause([{bin, Meta, Left, Right, Filters} | T], Expr, Arg, Acc, S) ->
   Ann = ?ann(Meta),
+  Generated = ?generated(Meta),
   {Tail, ST} = build_var(Ann, S),
   {Fun, SF}  = build_var(Ann, ST),
 
@@ -249,10 +251,10 @@ build_reduce_clause([{bin, Meta, Left, Right, Filters} | T], Expr, Arg, Acc, S) 
      {clause, ?generated,
       [NoVarMatch, Acc], [],
       [{call, Ann, Fun, [Tail, False]}]},
-     {clause, ?generated,
+     {clause, Generated,
       [{bin, Ann, []}, Acc], [],
       [Acc]},
-     {clause, ?generated,
+     {clause, Generated,
       [Tail, {var, Ann, '_'}], [],
       [elixir_utils:erl_call(Ann, erlang, error, [pair(Ann, badarg, Tail)])]}],
 

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -82,6 +82,7 @@ translate_struct(Meta, Name, {'%{}', MapMeta, Args}, S) ->
   case Operation of
     update ->
       Ann = ?ann(Meta),
+      Generated = ?generated(Meta),
       {VarName, _, VS} = elixir_scope:build_var('_', US),
 
       Var = {var, Ann, VarName},
@@ -92,9 +93,9 @@ translate_struct(Meta, Name, {'%{}', MapMeta, Args}, S) ->
 
       {TMap, TS} = translate_map(MapMeta, Assocs, Var, VS),
 
-      {{'case', ?generated, TUpdate, [
+      {{'case', Generated, TUpdate, [
         {clause, Ann, [Match], [], [TMap]},
-        {clause, ?generated, [Var], [], [elixir_utils:erl_call(Ann, erlang, error, [Error])]}
+        {clause, Generated, [Var], [], [elixir_utils:erl_call(Ann, erlang, error, [Error])]}
       ]}, TS};
     match ->
       translate_map(MapMeta, Assocs ++ [{'__struct__', Name}], nil, US);

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -194,27 +194,29 @@ rewrite(?string_chars, _DotMeta, 'to_string', _Meta, [String], _Env) when is_bin
 rewrite(?string_chars, _, 'to_string', _, [{{'.', _, [?kernel, inspect]}, _, _} = Call], _Env) ->
   Call;
 rewrite(?string_chars, DotMeta, 'to_string', Meta, [Call], _Env) ->
+  Generated = ?generated(Meta),
   Var   = {'rewrite', Meta, 'Elixir'},
-  Guard = remote(erlang, ?generated, is_binary, ?generated, [Var]),
+  Guard = remote(erlang, Generated, is_binary, Generated, [Var]),
   Slow  = remote(?string_chars, DotMeta, 'to_string', Meta, [Var]),
   Fast  = Var,
 
-  {'case', ?generated, [Call, [{do,
-    [{'->', ?generated, [[{'when', Meta, [Var, Guard]}], Fast]},
-     {'->', ?generated, [[Var], Slow]}]
+  {'case', Generated, [Call, [{do,
+    [{'->', Generated, [[{'when', Meta, [Var, Guard]}], Fast]},
+     {'->', Generated, [[Var], Slow]}]
   }]]};
 
 rewrite(?enum, DotMeta, 'reverse', Meta, [List], _Env) when is_list(List) ->
   remote(lists, DotMeta, 'reverse', Meta, [List]);
 rewrite(?enum, DotMeta, 'reverse', Meta, [List], _Env) ->
+  Generated = ?generated(Meta),
   Var   = {'rewrite', Meta, 'Elixir'},
-  Guard = remote(erlang, ?generated, is_list, ?generated, [Var]),
+  Guard = remote(erlang, Generated, is_list, Generated, [Var]),
   Slow  = remote(?enum, DotMeta, 'reverse', Meta, [Var, []]),
   Fast  = remote(lists, DotMeta, 'reverse', Meta, [Var]),
 
-  {'case', ?generated, [List, [{do,
-    [{'->', ?generated, [[{'when', Meta, [Var, Guard]}], Fast]},
-     {'->', ?generated, [[Var], Slow]}]
+  {'case', Generated, [List, [{do,
+    [{'->', Generated, [[{'when', Meta, [Var, Guard]}], Fast]},
+     {'->', Generated, [[Var], Slow]}]
   }]]};
 
 rewrite(Receiver, DotMeta, Right, Meta, Args, _Env) ->

--- a/lib/elixir/src/elixir_translator.erl
+++ b/lib/elixir/src/elixir_translator.erl
@@ -242,6 +242,7 @@ translate({{'.', _, [Left, Right]}, Meta, []}, S)
   {Var, _, SV} = elixir_scope:build_var('_', SL),
 
   Ann = ?ann(Meta),
+  Generated = ?generated(Meta),
   TRight = {atom, Ann, Right},
   TVar = {var, Ann, Var},
   TError = {tuple, Ann, [{atom, Ann, badkey}, TRight, TVar]},
@@ -249,8 +250,8 @@ translate({{'.', _, [Left, Right]}, Meta, []}, S)
   %% TODO: there is a bug in Dialyzer that warns about generated matches that
   %% can never match on line 0. The is_map/1 guard is used instead of matching
   %% against an empty map to avoid the warning.
-  {{'case', ?generated, TLeft, [
-    {clause, ?generated,
+  {{'case', Generated, TLeft, [
+    {clause, Generated,
       [{map, Ann, [{map_field_exact, Ann, TRight, TVar}]}],
       [],
       [TVar]},
@@ -258,10 +259,10 @@ translate({{'.', _, [Left, Right]}, Meta, []}, S)
       [TVar],
       [[elixir_utils:erl_call(?generated, erlang, is_map, [TVar])]],
       [elixir_utils:erl_call(Ann, erlang, error, [TError])]},
-    {clause, ?generated,
+    {clause, Generated,
       [TVar],
       [],
-      [{call, ?generated, {remote, ?generated, TVar, TRight}, []}]}
+      [{call, Generated, {remote, Generated, TVar, TRight}, []}]}
   ]}, SV};
 
 translate({{'.', _, [Left, Right]}, Meta, Args}, S)

--- a/lib/elixir/src/elixir_with.erl
+++ b/lib/elixir/src/elixir_with.erl
@@ -91,11 +91,12 @@ build_case([{'<-', Meta, [{Name, _, Ctx}, _] = Args} | Rest], DoExpr, Wrapper)
   build_case([{'=', Meta, Args} | Rest], DoExpr, Wrapper);
 build_case([{'<-', Meta, [Left, Right]} | Rest], DoExpr, Wrapper) ->
   Other = {other, Meta, ?MODULE},
+  Generated = ?generated(Meta),
   Clauses = [
-    {'->', ?generated, [[Left], build_case(Rest, DoExpr, Wrapper)]},
-    {'->', ?generated, [[Other], Wrapper(Other)]}
+    {'->', Generated, [[Left], build_case(Rest, DoExpr, Wrapper)]},
+    {'->', Generated, [[Other], Wrapper(Other)]}
   ],
-  {'case', ?generated, [Right, [{do, Clauses}]]};
+  {'case', Generated, [Right, [{do, Clauses}]]};
 build_case([Expr | Rest], DoExpr, Wrapper) ->
   {'__block__', [], [Expr, build_case(Rest, DoExpr, Wrapper)]};
 build_case([], DoExpr, _Wrapper) ->
@@ -117,4 +118,4 @@ error_match_for_match(Match) ->
 
 build_raise(Meta) ->
   Other = {other, Meta, ?MODULE},
-  {match, ?generated, [{error, Other}], {{'.', Meta, [erlang, error]}, Meta, [{with_clause, Other}]}}.
+  {match, ?generated(Meta), [{error, Other}], {{'.', Meta, [erlang, error]}, Meta, [{with_clause, Other}]}}.

--- a/lib/elixir/test/elixir/fixtures/dialyzer/remote_call.ex
+++ b/lib/elixir/test/elixir/fixtures/dialyzer/remote_call.ex
@@ -4,6 +4,8 @@ defmodule Dialyzer.RemoteCall do
     ~c(3.) ++ _ ->
       @dialyzer {:no_return, [map_var: 0]}
       @dialyzer {:no_match, [map_var: 0, mod_var: 0, mod_var: 1]}
+    ~c(2.) ++ _ ->
+      @dialyzer {:no_fail_call, [map_var: 0]}
     _ ->
       :ok
   end

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -991,6 +991,19 @@ defmodule Kernel.ErrorsTest do
       """)
   end
 
+  test "failed remote call stacktrace includes file/line info" do
+    try do
+      bad_remote_call(1)
+    rescue
+      ArgumentError ->
+        stack = System.stacktrace
+        assert [{:erlang, :apply, [1, :foo, []], []},
+                {__MODULE__, :bad_remote_call, 1, [file: _, line: _]} | _] = stack
+    end
+  end
+
+  defp bad_remote_call(x), do: x.foo
+
   defmacro sample(0), do: 0
 
   defmacro before_compile(_) do


### PR DESCRIPTION
This still needs a proper test, but I'm opening it early, because I expect a lot of discussion around this anyway.

This fixes one major issue - missing file/line info in stacktraces following a dynamic remote dispatch on nullary functions. For example a code like `x.foo` (when x is not an atom or a map) will produce a stacktrace with top function missing the file/line info, since the code in dispatch is all marked with `[{generated, true}, {location, 0}]`. A runnable example can be found here: https://gist.github.com/michalmuskala/44e2af7d90df09e27cc9abba0c75154b

This changes how we add the generated annotation on erlang 19 by keeping the proper line information. This adds the missing stacktrace information.

Unfortunately this means we'll be generating different code on different erlang versions. This is already done today (to some extent) with struct typespecs. The typespec check is a compile-time one, i.e. elixir compiled on 18 will always emit code for erlang 18.
The change I propose here is a runtime one - even if elixir and stdlib are compiled against erlang 18, we'll be able to emit 19 code when user compiles code on erlang 19. 

\cc @fishcakez, @ericmj 
