### PR TITLE
Implements `Integer.mod/2` and `Integer.floor_div/2`.

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -78,7 +78,7 @@ defmodule Integer do
       -2
 
   """
-  @spec mod(integer, integer) :: integer
+  @spec mod(integer, neg_integer | pos_integer) :: integer
   def mod(dividend, divisor) do
     remainder = rem(dividend, divisor)
     if remainder * divisor < 0 do
@@ -112,7 +112,7 @@ defmodule Integer do
       -50
       
   """
-  @spec floor_div(integer, integer) :: integer
+  @spec floor_div(integer, neg_integer | pos_integer) :: integer
   def floor_div(dividend, divisor) do
     if (dividend * divisor < 0) and rem(dividend, divisor) != 0 do
       div(dividend, divisor) - 1

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -60,6 +60,88 @@ defmodule Integer do
   end
 
   @doc """
+  Computes the modulo remainder of an integer division.
+
+  `Integer.mod/2` uses floored division, which means that 
+  the result will always have the sign of the `divisor`.
+
+  Raises an `ArithmeticError` exception if one of the arguments is not an
+  integer, or when the `divisor` is `0`.
+
+  Unlike `rem/2`, `Integer.mod/2` is _not_ allowed in guard tests.
+
+  ## Examples
+
+      iex> Integer.mod(5, 2)
+      1
+      iex> Integer.mod(6, -4)
+      -2
+
+  """
+  @spec mod(integer, integer) :: integer
+  def mod(dividend, divisor) do
+    remainder = rem(dividend, divisor)
+    if remainder * divisor < 0 do
+      remainder + divisor
+    else
+      remainder
+    end
+  end
+
+  @doc """
+  Performs a floored integer division.
+
+  Raises an `ArithmeticError` exception if one of the arguments is not an
+  integer, or when the `divisor` is `0`.
+
+  Unlike `Kernel.div/2`, `Integer.floor_div/2` is _not_ allowed inside guard tests.
+
+  `Integer.floor_div/2` performs _floored_ integer division. This means that
+  the result is always rounded towards negative infinity.
+
+  If you want to perform truncated integer division (rounding towards zero),
+  use `Kernel.div/2` instead.
+
+  ## Examples
+
+      iex> Integer.floor_div(5, 2)
+      2
+      iex> Integer.floor_div(6, -4)
+      -2
+      iex> Integer.floor_div(-99, 2)
+      -50
+  """
+  @spec floor_div(integer, integer) :: integer
+  def floor_div(dividend, divisor) do
+    if (dividend * divisor < 0) && rem(dividend, divisor) != 0 do
+      div(dividend, divisor) - 1
+    else
+      div(dividend, divisor)
+    end
+  end
+
+  # defmacro mod(dividend, divisor) do
+  #   in_module? = (__CALLER__.context == nil)
+  #   if not in_module? do
+  #     # Guard-clause implementation
+  #     quote do
+  #       unquote(dividend) - (unquote(divisor) * unquote(floor_div(dividend, divisor)))
+  #     end
+  #   else
+  #     # Normal implementation
+  #     quote do
+  #       bound_divisor = unquote(divisor)
+  #       remainder = rem(unquote(dividend), bound_divisor)
+  #       if remainder * bound_divisor < 0 do
+  #         remainder + bound_divisor
+  #       else
+  #         remainder
+  #       end
+  #     end
+  #   end
+  # end
+
+  @doc """
   Returns the ordered digits for the given `integer`.
 
   An optional `base` value may be provided representing the radix for the returned

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -110,36 +110,16 @@ defmodule Integer do
       -2
       iex> Integer.floor_div(-99, 2)
       -50
+      
   """
   @spec floor_div(integer, integer) :: integer
   def floor_div(dividend, divisor) do
-    if (dividend * divisor < 0) && rem(dividend, divisor) != 0 do
+    if (dividend * divisor < 0) and rem(dividend, divisor) != 0 do
       div(dividend, divisor) - 1
     else
       div(dividend, divisor)
     end
   end
-
-  # defmacro mod(dividend, divisor) do
-  #   in_module? = (__CALLER__.context == nil)
-  #   if not in_module? do
-  #     # Guard-clause implementation
-  #     quote do
-  #       unquote(dividend) - (unquote(divisor) * unquote(floor_div(dividend, divisor)))
-  #     end
-  #   else
-  #     # Normal implementation
-  #     quote do
-  #       bound_divisor = unquote(divisor)
-  #       remainder = rem(unquote(dividend), bound_divisor)
-  #       if remainder * bound_divisor < 0 do
-  #         remainder + bound_divisor
-  #       else
-  #         remainder
-  #       end
-  #     end
-  #   end
-  # end
 
   @doc """
   Returns the ordered digits for the given `integer`.

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -68,8 +68,6 @@ defmodule Integer do
   Raises an `ArithmeticError` exception if one of the arguments is not an
   integer, or when the `divisor` is `0`.
 
-  Unlike `rem/2`, `Integer.mod/2` is _not_ allowed in guard tests.
-
   ## Examples
 
       iex> Integer.mod(5, 2)
@@ -94,9 +92,7 @@ defmodule Integer do
   Raises an `ArithmeticError` exception if one of the arguments is not an
   integer, or when the `divisor` is `0`.
 
-  Unlike `Kernel.div/2`, `Integer.floor_div/2` is _not_ allowed inside guard tests.
-
-  `Integer.floor_div/2` performs _floored_ integer division. This means that
+  `Integer.floor_div/2` performs *floored* integer division. This means that
   the result is always rounded towards negative infinity.
 
   If you want to perform truncated integer division (rounding towards zero),

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -165,7 +165,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
 
-  `div/2` performs _truncated_ integer division. This means that
+  `div/2` performs *truncated* integer division. This means that
   the result is always rounded towards zero.
 
   If you want to perform floored integer division (rounding towards negative infinity),

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -573,9 +573,6 @@ defmodule Kernel do
   Raises an `ArithmeticError` exception if one of the arguments is not an
   integer, or when the `divisor` is `0`.
 
-  When the only expected input are positive numbers, use `rem/2` over `Integer.mod/2` because
-  its implementation is more efficient.
-
   Allowed in guard tests. Inlined by the compiler.
 
   ## Examples

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -181,7 +181,7 @@ defmodule Kernel do
       -49
 
   """
-  @spec div(integer, integer) :: integer
+  @spec div(integer, neg_integer | pos_integer) :: integer
   def div(dividend, divisor) do
     :erlang.div(dividend, divisor)
   end
@@ -583,7 +583,7 @@ defmodule Kernel do
       2
 
   """
-  @spec rem(integer, integer) :: integer
+  @spec rem(integer, neg_integer | pos_integer) :: integer
   def rem(dividend, divisor) do
     :erlang.rem(dividend, divisor)
   end

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -161,19 +161,29 @@ defmodule Kernel do
   Performs an integer division.
 
   Raises an `ArithmeticError` exception if one of the arguments is not an
-  integer.
+  integer, or when the `divisor` is `0`.
 
   Allowed in guard tests. Inlined by the compiler.
+
+  `div/2` performs _truncated_ integer division. This means that
+  the result is always rounded towards zero.
+
+  If you want to perform floored integer division (rounding towards negative infinity),
+  use `Integer.floor_div/2` instead.
 
   ## Examples
 
       iex> div(5, 2)
       2
+      iex> div(6, -4)
+      -1
+      iex> div(-99, 2)
+      -49
 
   """
   @spec div(integer, integer) :: integer
-  def div(left, right) do
-    :erlang.div(left, right)
+  def div(dividend, divisor) do
+    :erlang.div(dividend, divisor)
   end
 
   @doc """
@@ -557,8 +567,14 @@ defmodule Kernel do
   @doc """
   Computes the remainder of an integer division.
 
+  `rem/2` uses truncated division, which means that 
+  the result will always have the sign of the `dividend`.
+
   Raises an `ArithmeticError` exception if one of the arguments is not an
-  integer.
+  integer, or when the `divisor` is `0`.
+
+  When the only expected input are positive numbers, use `rem/2` over `Integer.mod/2` because
+  its implementation is more efficient.
 
   Allowed in guard tests. Inlined by the compiler.
 
@@ -566,11 +582,13 @@ defmodule Kernel do
 
       iex> rem(5, 2)
       1
+      iex> rem(6, -4)
+      2
 
   """
   @spec rem(integer, integer) :: integer
-  def rem(left, right) do
-    :erlang.rem(left, right)
+  def rem(dividend, divisor) do
+    :erlang.rem(dividend, divisor)
   end
 
   @doc """

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -3,9 +3,9 @@ Code.require_file "test_helper.exs", __DIR__
 defmodule IntegerTest do
   use ExUnit.Case, async: true
 
+  require Integer
   doctest Integer
 
-  require Integer
 
   def test_is_odd_in_guards(number) when Integer.is_odd(number),
     do: number
@@ -39,6 +39,40 @@ defmodule IntegerTest do
     assert Integer.is_even(-3) == false
     assert test_is_even_in_guards(10) == 10
     assert test_is_even_in_guards(11) == false
+  end
+
+  test "mod/2" do
+    assert Integer.mod(3, 2) == 1
+    assert Integer.mod(0, 10) == 0
+    assert Integer.mod(30000, 2001) == 1986
+    assert Integer.mod(-20, 11) == 2
+  end
+
+  test "mod/2 raises ArithmeticError when divisor is 0" do
+    assert_raise ArithmeticError, fn -> Integer.mod(3, 0) end
+    assert_raise ArithmeticError, fn -> Integer.mod(-50, 0) end
+  end
+
+  test "mod/2 raises ArithmeticError when non-integers used as parameters" do
+    assert_raise ArithmeticError, fn -> Integer.mod(3.0, 2) end
+    assert_raise ArithmeticError, fn -> Integer.mod(20, 1.2) end
+  end
+
+  test "floor_div/2" do
+    assert Integer.floor_div(3, 2) == 1
+    assert Integer.floor_div(0, 10) == 0
+    assert Integer.floor_div(30000, 2001) == 14
+    assert Integer.floor_div(-20, 11) == -2
+  end
+
+  test "floor_div/2 raises ArithmeticError when divisor is 0" do
+    assert_raise ArithmeticError, fn -> Integer.floor_div(3, 0) end
+    assert_raise ArithmeticError, fn -> Integer.floor_div(-50, 0) end
+  end
+
+  test "floor_div/2 raises ArithmeticError when non-integers used as parameters" do
+    assert_raise ArithmeticError, fn -> Integer.floor_div(3.0, 2) end
+    assert_raise ArithmeticError, fn -> Integer.floor_div(20, 1.2) end
   end
 
   test "digits/2" do

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -3,9 +3,9 @@ Code.require_file "test_helper.exs", __DIR__
 defmodule IntegerTest do
   use ExUnit.Case, async: true
 
-  require Integer
   doctest Integer
 
+  require Integer
 
   def test_is_odd_in_guards(number) when Integer.is_odd(number),
     do: number


### PR DESCRIPTION
Implements `Integer.mod/2` and `Integer.floor_div/2` as simple functions.

Also includes:
- documentation (+doctests)
- typespecs
- tests
- updated documentation and doctests for `Kernel.rem/2` and `Kernel.div/2`

Does not include:
- Crazy guard-safe macros. (See #5112 )
