### PR TITLE
Do not re-compile a compiled pattern for String.split/3

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -413,6 +413,7 @@ defmodule String do
   end
 
   defp maybe_compile_pattern(""), do: ""
+  defp maybe_compile_pattern(pattern) when is_tuple(pattern), do: pattern
   defp maybe_compile_pattern(pattern), do: :binary.compile_pattern(pattern)
 
   @doc """

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -82,6 +82,14 @@ defmodule StringTest do
     assert String.split("a,b", ~r{\.}) == ["a,b"]
   end
 
+  test "split with compiled pattern" do
+    pattern = :binary.compile_pattern("-")
+
+    assert String.split("x-", pattern) == ["x", ""]
+    assert String.split("x-", pattern, parts: 2, trim: true) == ["x"]
+    assert String.split("x-x-", pattern, parts: 3, trim: true) == ["x", "x"]
+  end
+
   test "splitter" do
     assert String.splitter("a,b,c", ",") |> Enum.to_list == ["a", "b", "c"]
     assert String.splitter("a,b", ".") |> Enum.to_list == ["a,b"]


### PR DESCRIPTION
Fixes #5126 