### PR TITLE
Enhancement: negative integer support in `DateTime.from_unix`

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -986,7 +986,6 @@ defmodule DateTime do
   Unix times are always in UTC and therefore the DateTime
   will be returned in UTC.
 
-
   ## Examples
 
       iex> DateTime.from_unix(1464096368)

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -1123,7 +1123,7 @@ defmodule DateTime do
   end
 
   def to_unix(%DateTime{year: year}, _unit) do
-    raise ArgumentError, "Can only convert %DateTime{} to Unix time with a year >= 0, got: #{year}"
+    raise ArgumentError, "can only convert %DateTime{} to Unix time with a year >= 0, got: #{year}"
   end
 
   @doc """

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -1005,7 +1005,7 @@ defmodule DateTime do
                       month: 1, second: 43, std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0,
                       year: 46302, zone_abbr: "UTC"}}
   
-  Negative Unix times are supported, up to -62167219200000000 microseconds, 
+  Negative Unix times are supported, up to -#{@unix_epoch} seconds, 
   which is equivalent to "0000-01-01T00:00:00Z" or 0 gregorian seconds.
 
       iex> DateTime.from_unix(-12345678910)
@@ -1018,7 +1018,7 @@ defmodule DateTime do
   @spec from_unix(integer, :native | System.time_unit) :: {:ok, DateTime.t}
   def from_unix(integer, unit \\ :seconds) when is_integer(integer) do
     total = System.convert_time_unit(integer, unit, :microseconds)
-    if total < -62167219200000000 do
+    if total < -@unix_epoch * 1_000_000 do
       :error  
     else
       microsecond = rem(total, 1_000_000)

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -1066,7 +1066,7 @@ defmodule DateTime do
                 month: 5, second: 8, std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0,
                 year: 2015, zone_abbr: "UTC"}
 
-  Negative Unix times are supported, up to -62167219200000000 microseconds, 
+  Negative Unix times are supported, up to -#{@unix_epoch} seconds, 
   which is equivalent to "0000-01-01T00:00:00Z" or 0 gregorian seconds.
 
       iex> DateTime.from_unix(-12345678910)
@@ -1120,10 +1120,6 @@ defmodule DateTime do
       |> Kernel.-(utc_offset)
       |> Kernel.-(std_offset)
     System.convert_time_unit((seconds - @unix_epoch) * 1_000_000 + microsecond, :microseconds, unit)
-  end
-
-  def to_unix(%DateTime{year: year}, _unit) do
-    raise ArgumentError, "can only convert %DateTime{} to Unix time with a year >= 0, got: #{year}"
   end
 
   @doc """

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -1013,24 +1013,24 @@ defmodule DateTime do
       {:ok, %DateTime{calendar: Calendar.ISO, day: 13, hour: 4, microsecond: {0, 0}, minute: 44, 
                       month: 10, second: 50, std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0, 
                       year: 1578, zone_abbr: "UTC"}}
-
-
+  
+  When a Unix time before that moment is passed to `from_unix/2`, `:error` will be returned.
   """
-  @spec from_unix(non_neg_integer, :native | System.time_unit) :: {:ok, DateTime.t}
+  @spec from_unix(integer, :native | System.time_unit) :: {:ok, DateTime.t}
   def from_unix(integer, unit \\ :seconds) when is_integer(integer) do
     total = System.convert_time_unit(integer, unit, :microseconds)
     if total < -62167219200000000 do
-      raise ArgumentError, 
-        "Date.from_unix cannot handle unix times lower than -62167219200000000 microseconds, which is equivalent to \"0000-01-01T00:00:00Z\" or 0 gregorian seconds. Got: #{total}"
-    end
-    microsecond = rem(total, 1_000_000)
-    precision = precision_for_unit(unit)
-    {{year, month, day}, {hour, minute, second}} =
-      :calendar.gregorian_seconds_to_datetime(@unix_epoch + div(total, 1_000_000))
+      :error  
+    else
+      microsecond = rem(total, 1_000_000)
+      precision = precision_for_unit(unit)
+      {{year, month, day}, {hour, minute, second}} =
+        :calendar.gregorian_seconds_to_datetime(@unix_epoch + div(total, 1_000_000))
 
-    {:ok, %DateTime{year: year, month: month, day: day,
-                    hour: hour, minute: minute, second: second, microsecond: {microsecond, precision},
-                    std_offset: 0, utc_offset: 0, zone_abbr: "UTC", time_zone: "Etc/UTC"}}
+      {:ok, %DateTime{year: year, month: month, day: day,
+                      hour: hour, minute: minute, second: second, microsecond: {microsecond, precision},
+                      std_offset: 0, utc_offset: 0, zone_abbr: "UTC", time_zone: "Etc/UTC"}}
+    end
   end
 
   def precision_for_unit(unit) do
@@ -1048,6 +1048,13 @@ defmodule DateTime do
   @doc """
   Converts the given Unix time to DateTime.
 
+  The integer can be given in different unit
+  according to `System.convert_time_unit/3` and it will
+  be converted to microseconds internally.
+
+  Unix times are always in UTC and therefore the DateTime
+  will be returned in UTC.
+
   ## Examples
 
       iex> DateTime.from_unix!(1464096368)
@@ -1060,6 +1067,15 @@ defmodule DateTime do
                 month: 5, second: 8, std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0,
                 year: 2015, zone_abbr: "UTC"}
 
+  Negative Unix times are supported, up to -62167219200000000 microseconds, 
+  which is equivalent to "0000-01-01T00:00:00Z" or 0 gregorian seconds.
+
+      iex> DateTime.from_unix(-12345678910)
+      {:ok, %DateTime{calendar: Calendar.ISO, day: 13, hour: 4, microsecond: {0, 0}, minute: 44, 
+                      month: 10, second: 50, std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0, 
+                      year: 1578, zone_abbr: "UTC"}}
+
+  When a Unix time before that moment is passed to `from_unix!/2`, an ArgumentError will be raised.
   """
   @spec from_unix!(non_neg_integer, :native | System.time_unit) :: DateTime.t
   def from_unix!(integer, unit \\ :seconds) when is_atom(unit) do
@@ -1071,7 +1087,7 @@ defmodule DateTime do
   Converts the given DateTime to Unix time.
 
   The DateTime is expected to be using the ISO calendar
-  with a year greater than or equal to 1970.
+  with a year greater than or equal to 0.
 
   It will return the integer with the given unit,
   according to `System.convert_time_unit/3`.
@@ -1091,7 +1107,7 @@ defmodule DateTime do
   @spec to_unix(DateTime.t, System.time_unit) :: non_neg_integer
   def to_unix(%DateTime{calendar: Calendar.ISO, std_offset: std_offset, utc_offset: utc_offset,
                         hour: hour, minute: minute, second: second, microsecond: {microsecond, _},
-                        year: year, month: month, day: day}, unit \\ :seconds) when year >= 1970 do
+                        year: year, month: month, day: day}, unit \\ :seconds) when year >= 0 do
     seconds =
       :calendar.datetime_to_gregorian_seconds({{year, month, day}, {hour, minute, second}})
       |> Kernel.-(utc_offset)

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -1102,6 +1102,12 @@ defmodule DateTime do
       iex> DateTime.to_unix(dt)
       1416517099
 
+      iex> flamel = %DateTime{calendar: Calendar.ISO, day: 22, hour: 8, microsecond: {527771, 6},
+      ...>                minute: 2, month: 3, second: 25, std_offset: 0, time_zone: "Etc/UTC",
+      ...>                utc_offset: 0, year: 1418, zone_abbr: "UTC"}
+      iex> DateTime.to_unix(flamel)
+      -17412508655
+
   """
   @spec to_unix(DateTime.t, System.time_unit) :: non_neg_integer
   def to_unix(%DateTime{calendar: Calendar.ISO, std_offset: std_offset, utc_offset: utc_offset,

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -1110,14 +1110,20 @@ defmodule DateTime do
 
   """
   @spec to_unix(DateTime.t, System.time_unit) :: non_neg_integer
+  def to_unix(datetime, unit \\ :seconds)
+  
   def to_unix(%DateTime{calendar: Calendar.ISO, std_offset: std_offset, utc_offset: utc_offset,
                         hour: hour, minute: minute, second: second, microsecond: {microsecond, _},
-                        year: year, month: month, day: day}, unit \\ :seconds) when year >= 0 do
+                        year: year, month: month, day: day}, unit) when year >= 0 do
     seconds =
       :calendar.datetime_to_gregorian_seconds({{year, month, day}, {hour, minute, second}})
       |> Kernel.-(utc_offset)
       |> Kernel.-(std_offset)
     System.convert_time_unit((seconds - @unix_epoch) * 1_000_000 + microsecond, :microseconds, unit)
+  end
+
+  def to_unix(%DateTime{year: year}, _unit) do
+    raise ArgumentError, "Can only convert %DateTime{} to Unix time with a year >= 0, got: #{year}"
   end
 
   @doc """

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -83,7 +83,7 @@ defmodule DateTimeTest do
     before_gregorian_0 = %DateTime{gregorian_0 | year: -1}
 
     assert DateTime.to_unix(gregorian_0) == -62167219200
-    assert_raise ArgumentError, "Can only convert %DateTime{} to Unix time with a year >= 0, got: -1", fn ->
+    assert_raise ArgumentError, "can only convert %DateTime{} to Unix time with a year >= 0, got: -1", fn ->
       DateTime.to_unix(before_gregorian_0)
     end
   end

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -83,7 +83,7 @@ defmodule DateTimeTest do
     before_gregorian_0 = %DateTime{gregorian_0 | year: -1}
 
     assert DateTime.to_unix(gregorian_0) == -62167219200
-    assert_raise ArgumentError, fn ->
+    assert_raise ArgumentError, "Can only convert %DateTime{} to Unix time with a year >= 0, got: -1", fn ->
       DateTime.to_unix(before_gregorian_0)
     end
   end

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -75,4 +75,16 @@ defmodule DateTimeTest do
 
     assert DateTime.from_unix(-62167219201) == :error
   end
+
+  test "to_unix/2 works with Unix times back to 0 Gregorian Seconds" do
+    gregorian_0 = %DateTime{calendar: Calendar.ISO, day: 1, hour: 0, microsecond: {0, 0},
+                            minute: 0, month: 1, second: 0, std_offset: 0, time_zone: "Etc/UTC",
+                            utc_offset: 0, year: 0, zone_abbr: "UTC"}
+    before_gregorian_0 = %DateTime{gregorian_0 | year: -1}
+
+    assert DateTime.to_unix(gregorian_0) == -62167219200
+    assert_raise ArgumentError, fn ->
+      DateTime.to_unix(before_gregorian_0)
+    end
+  end
 end

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -83,7 +83,7 @@ defmodule DateTimeTest do
     before_gregorian_0 = %DateTime{gregorian_0 | year: -1}
 
     assert DateTime.to_unix(gregorian_0) == -62167219200
-    assert_raise ArgumentError, "can only convert %DateTime{} to Unix time with a year >= 0, got: -1", fn ->
+    assert_raise FunctionClauseError, fn ->
       DateTime.to_unix(before_gregorian_0)
     end
   end

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -66,4 +66,13 @@ defmodule DateTimeTest do
                    utc_offset: -12600, std_offset: 3600, time_zone: "Brazil/Manaus"}
     assert to_string(dt) == "2000-02-29 23:00:07-02:30 BRM Brazil/Manaus"
   end
+
+  test "from_unix/2 works with Unix times back to 0 Gregorian Seconds" do
+    assert DateTime.from_unix(-62167219200) == {:ok,
+                    %DateTime{calendar: Calendar.ISO, day: 1, hour: 0, microsecond: {0, 0},
+                              minute: 0, month: 1, second: 0, std_offset: 0, time_zone: "Etc/UTC",
+                              utc_offset: 0, year: 0, zone_abbr: "UTC"}}
+
+    assert DateTime.from_unix(-62167219201) == :error
+  end
 end


### PR DESCRIPTION
Fixes #5124:

- Unix times back to -62167219200000000 microseconds (0 Gregorian seconds) are now supported by `DateTime.from_unix/2`.
- For lower integers, `:error` will be returned instead of `{:ok, datetime}`. The bang-version of the method will raise an ArgumentError in these cases.
- Usage of negative Unix times has been documented.
- A couple of tests were added to ensure that this is indeed the behaviour that is happening.
- `DateTime.to_unix` has similarly been altered to support all DateTimes with `year >= 0`, which matches the new cutoff-point for `DateTime.from_unix`.
- When passing a DateTime with a negative year to `DateTime.from_unix`, a descriptive ArgumentError is raised.