### PR TITLE
Use dialyzer attributes instead of ExUnit exclude tag

### DIFF
--- a/lib/elixir/test/elixir/fixtures/dialyzer/remote_call.ex
+++ b/lib/elixir/test/elixir/fixtures/dialyzer/remote_call.ex
@@ -1,4 +1,13 @@
 defmodule Dialyzer.RemoteCall do
+  _ = Application.load(:dialyzer)
+  case Application.spec(:dialyzer, :vsn) do
+    ~c(3.) ++ _ ->
+      @dialyzer {:no_return, [map_var: 0]}
+      @dialyzer {:no_match, [map_var: 0, mod_var: 0, mod_var: 1]}
+    _ ->
+      :ok
+  end
+
   def map_var() do
     map = %{a: 1}
     map.key

--- a/lib/elixir/test/elixir/kernel/dialyzer_test.exs
+++ b/lib/elixir/test/elixir/kernel/dialyzer_test.exs
@@ -54,7 +54,6 @@ defmodule Kernel.DialyzerTest do
     {:ok, [outdir: dir, dialyzer: dialyzer]}
   end
 
-  @tag otp19: false
   test "no warnings on valid remote calls", context do
     copy_beam! context, Dialyzer.RemoteCall
     assert_dialyze_no_warnings! context

--- a/lib/elixir/test/elixir/test_helper.exs
+++ b/lib/elixir/test/elixir/test_helper.exs
@@ -1,10 +1,4 @@
-exclude =
-  case :erlang.system_info(:otp_release) do
-    '19' -> [otp19: false]
-    _    -> []
-  end
-
-ExUnit.start [exclude: exclude, trace: "--trace" in System.argv]
+ExUnit.start [trace: "--trace" in System.argv]
 
 # Beam files compiled on demand
 path = Path.expand("../../tmp/beams", __DIR__)


### PR DESCRIPTION
I prefer this approach because:

* Supports custom OTP builds where a non-standard version of dialyzer/erts is used
* Easier to handle once bug is fixed
* Only ignores warnings for the bug and doesn't hide other issues that can crop up, e.g. helpful for #5116 (skipping the test hides bugs introduced in that PR at the moment)
* Shows how to hide the warnings if someone wants to