### PR TITLE
New guard-safe implementation of `Integer.mod` and `Integer.floor_div`

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -59,35 +59,16 @@ defmodule Integer do
     quote do: (unquote(integer) &&& 1) == 0
   end
 
-  @doc """
-  Computes the modulo remainder of an integer division.
-
-  `Integer.mod/2` uses floored division, which means that 
-  the result will always have the sign of the `divisor`.
-
-  Raises an `ArithmeticError` exception if one of the arguments is not an
-  integer, or when the `divisor` is `0`.
-
-  ## Examples
-
-      iex> Integer.mod(5, 2)
-      1
-      iex> Integer.mod(6, -4)
-      -2
-
-  """
-  @spec mod(integer, neg_integer | pos_integer) :: integer
-  def mod(dividend, divisor) do
-    remainder = rem(dividend, divisor)
-    if remainder * divisor < 0 do
-      remainder + divisor
-    else
-      remainder
+  defp do_floor_div(a, n) do
+    quote bind_quoted: [a: a, n: n] do
+      div(a, n) + ((rem(a, n) * n) >>> abs(a * n))
     end
   end
 
   @doc """
   Performs a floored integer division.
+
+  Allowed in guard tests.
 
   Raises an `ArithmeticError` exception if one of the arguments is not an
   integer, or when the `divisor` is `0`.
@@ -109,11 +90,48 @@ defmodule Integer do
       
   """
   @spec floor_div(integer, neg_integer | pos_integer) :: integer
-  def floor_div(dividend, divisor) do
-    if (dividend * divisor < 0) and rem(dividend, divisor) != 0 do
-      div(dividend, divisor) - 1
+  defmacro floor_div(divisor, dividend) do
+      do_floor_div(divisor, dividend)
+  end
+
+  @doc """
+  Computes the modulo remainder of an integer division.
+
+  Allowed in guard tests.
+
+  `Integer.mod/2` uses floored division, which means that 
+  the result will always have the sign of the `divisor`.
+
+  Raises an `ArithmeticError` exception if one of the arguments is not an
+  integer, or when the `divisor` is `0`.
+
+
+  ## Examples
+
+      iex> Integer.mod(5, 2)
+      1
+      iex> Integer.mod(6, -4)
+      -2
+
+  """
+  @spec mod(integer, neg_integer | pos_integer) :: integer
+  defmacro mod(dividend, divisor) do
+    in_module? = (__CALLER__.context == nil)
+    if not in_module? do
+      # Guard-clause implementation
+      quote do
+        unquote(dividend) - (unquote(divisor) * unquote(do_floor_div(dividend, divisor)))
+      end
     else
-      div(dividend, divisor)
+      # Normal implementation
+      quote bind_quoted: [a: dividend, n: divisor] do
+        remainder = rem(a, n)
+        if remainder * n < 0 do
+          remainder + n
+        else
+          remainder
+        end
+      end
     end
   end
 

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -3,9 +3,9 @@ Code.require_file "test_helper.exs", __DIR__
 defmodule IntegerTest do
   use ExUnit.Case, async: true
 
-  doctest Integer
-
   require Integer
+
+  doctest Integer
 
   def test_is_odd_in_guards(number) when Integer.is_odd(number),
     do: number
@@ -58,6 +58,19 @@ defmodule IntegerTest do
     assert_raise ArithmeticError, fn -> Integer.mod(20, 1.2) end
   end
 
+  def fun_mod(x) when Integer.mod(x, 3) == 0, do: 0
+  def fun_mod(x) when Integer.mod(x, 3) == 1, do: 1
+  def fun_mod(x) when Integer.mod(x, 3) == 2, do: 2
+
+  test "mod/2 in guards" do
+    assert fun_mod(0) == 0
+    assert fun_mod(1) == 1
+    assert fun_mod(2) == 2
+    assert fun_mod(3) == 0
+    assert fun_mod(-3) == 0
+    assert fun_mod(-10) == 2
+  end
+
   test "floor_div/2" do
     assert Integer.floor_div(3, 2) == 1
     assert Integer.floor_div(0, 10) == 0
@@ -73,6 +86,20 @@ defmodule IntegerTest do
   test "floor_div/2 raises ArithmeticError when non-integers used as parameters" do
     assert_raise ArithmeticError, fn -> Integer.floor_div(3.0, 2) end
     assert_raise ArithmeticError, fn -> Integer.floor_div(20, 1.2) end
+  end
+
+  def fun_floor_div(x) when Integer.floor_div(x, 2) > 0, do: "positive"
+  def fun_floor_div(x) when Integer.floor_div(x, 2) = 0, do: "zero"
+  def fun_floor_div(x) when Integer.floor_div(x, 2) < 0, do: "negative"
+  def fun_floor_div(x = -99) when Integer.floor_div(x, 2) == -50, do: "One lower than div(-99, 2)"
+
+  test "floor_div/2 in guards" do
+    assert fun_floor_div(0) == "zero"
+    assert fun_floor_div(1) == "zero"
+    assert fun_floor_div(2) == "positive"
+    assert fun_floor_div(-99) == "One lower than div(-99, 2)"
+    assert fun_floor_div(-3) == "negative"
+    assert fun_floor_div(-10) == "negative"
   end
 
   test "digits/2" do

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -88,16 +88,16 @@ defmodule IntegerTest do
     assert_raise ArithmeticError, fn -> Integer.floor_div(20, 1.2) end
   end
 
-  def fun_floor_div(x) when Integer.floor_div(x, 2) > 0, do: "positive"
-  def fun_floor_div(x) when Integer.floor_div(x, 2) = 0, do: "zero"
-  def fun_floor_div(x) when Integer.floor_div(x, 2) < 0, do: "negative"
   def fun_floor_div(x = -99) when Integer.floor_div(x, 2) == -50, do: "One lower than div(-99, 2)"
+  def fun_floor_div(x) when Integer.floor_div(x, 2) >  0, do: "positive"
+  def fun_floor_div(x) when Integer.floor_div(x, 2) == 0, do: "zero"
+  def fun_floor_div(x) when Integer.floor_div(x, 2) <  0, do: "negative"
 
   test "floor_div/2 in guards" do
+    assert fun_floor_div(-99) == "One lower than div(-99, 2)"
+    assert fun_floor_div(2) == "positive"
     assert fun_floor_div(0) == "zero"
     assert fun_floor_div(1) == "zero"
-    assert fun_floor_div(2) == "positive"
-    assert fun_floor_div(-99) == "One lower than div(-99, 2)"
     assert fun_floor_div(-3) == "negative"
     assert fun_floor_div(-10) == "negative"
   end


### PR DESCRIPTION
See #5135 for the discussion. This is a continuation of #5112 and #5117.

It:

- Replaces the implementation of `Integer.floor_div/2` with one that also works inside guards.
- Changes the implementation of `Integer.mod/2` to use this new floor_div implementation to also work inside guards.
- Code is a whole lot more readable and short than the version in #5112.

As I'll be on vacation coming week, I do not know if I'll be able to be online and parlay about this proposal.
So if you want to make changes to this pull request and don't want to wait until I'm back, feel free to do so ;-).