### PR TITLE
Add `min/2`, `max/2` and `min_max/2` to `Enum`.

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1359,17 +1359,6 @@ defmodule Enum do
   @spec max_by(t, (element -> any), (() -> empty_result)) :: element | empty_result | no_return when empty_result: any
   def max_by(enumerable, fun, empty_fallback \\ fn -> raise Enum.EmptyError end)
 
-  def max_by([h | t], fun, _empty_fallback) when is_function(fun, 1) do
-    reduce(t, {h, fun.(h)}, fn(entry, {_, fun_max} = old) ->
-      fun_entry = fun.(entry)
-      if(fun_entry > fun_max, do: {entry, fun_entry}, else: old)
-    end) |> elem(0)
-  end
-
-  def max_by([], _fun, empty_fallback) when is_function(empty_fallback, 0) do
-    empty_fallback.()
-  end
-
   def max_by(enumerable, fun, empty_fallback) when is_function(fun, 1) and is_function(empty_fallback, 0) do
     reduce_handling_empty(enumerable, fn entry, {_, fun_max} = old ->
       fun_entry = fun.(entry)
@@ -1466,17 +1455,6 @@ defmodule Enum do
   """
   @spec min_by(t, (element -> any), (() -> empty_result)) :: element | empty_result | no_return when empty_result: any
   def min_by(enumerable, fun, empty_fallback \\ fn -> raise Enum.EmptyError end)
-
-  def min_by([h | t], fun, _empty_fallback) when is_function(fun, 1) do
-    reduce(t, {h, fun.(h)}, fn(entry, {_, fun_min} = old) ->
-      fun_entry = fun.(entry)
-      if(fun_entry < fun_min, do: {entry, fun_entry}, else: old)
-    end) |> elem(0)
-  end
-
-  def min_by([], _fun, empty_fallback) when is_function(empty_fallback, 0) do
-    empty_fallback.()
-  end
 
   def min_by(enumerable, fun, empty_fallback) when is_function(fun, 1) and is_function(empty_fallback, 0) do
     reduce_handling_empty(enumerable, fn entry, {_, fun_min} = old ->

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1315,8 +1315,8 @@ defmodule Enum do
   If multiple elements are considered maximal, the first one that was found
   is returned.
 
-  Calls the provided `empty_fallback` and returns its value if `enumerable`
-  is empty. The default `empty_fallback` raises `Enum.EmptyError`.
+  Calls the provided `empty_fallback` function and returns its value if
+  `enumerable` is empty. The default `empty_fallback` raises `Enum.EmptyError`.
 
   ## Examples
 
@@ -1329,6 +1329,7 @@ defmodule Enum do
   """
   @spec max(t, (() -> empty_result)) :: element | empty_result | no_return when empty_result: any
   def max(enumerable, empty_fallback \\ fn -> raise Enum.EmptyError end)
+
   def max(enumerable, empty_fallback) when is_function(empty_fallback, 0) do
     reduce_handling_empty(enumerable, &Kernel.max(&1, &2), empty_fallback)
   end
@@ -1424,8 +1425,8 @@ defmodule Enum do
   If multiple elements are considered minimal, the first one that was found
   is returned.
 
-  Calls the provided `empty_fallback` and returns its value if `enumerable`
-  is empty. The default `empty_fallback` raises `Enum.EmptyError`.
+  Calls the provided `empty_fallback` function and returns its value if
+  `enumerable` is empty. The default `empty_fallback` raises `Enum.EmptyError`.
 
   ## Examples
 
@@ -1438,6 +1439,7 @@ defmodule Enum do
   """
   @spec min(t, (() -> empty_result)) :: element | empty_result | no_return when empty_result: any
   def min(enumerable, empty_fallback \\ fn -> raise Enum.EmptyError end)
+
   def min(enumerable, empty_fallback) when is_function(empty_fallback, 0) do
     reduce_handling_empty(enumerable, &Kernel.min(&1, &2), empty_fallback)
   end
@@ -1495,8 +1497,8 @@ defmodule Enum do
   If multiple elements are considered maximal or minimal, the first one
   that was found is returned.
 
-  Calls the provided `empty_fallback` and returns its value if `enumerable`
-  is empty. The default `empty_fallback` raises `Enum.EmptyError`.
+  Calls the provided `empty_fallback` function and returns its value if
+  `enumerable` is empty. The default `empty_fallback` raises `Enum.EmptyError`.
 
   ## Examples
 
@@ -1509,6 +1511,7 @@ defmodule Enum do
   """
   @spec min_max(t, (() -> empty_result)) :: {element, element} | empty_result | no_return when empty_result: any
   def min_max(enumerable, empty_fallback \\ fn -> raise Enum.EmptyError end)
+
   def min_max(enumerable, empty_fallback) when is_function(empty_fallback, 0) do
     reduce_handling_empty(enumerable, fn entry, {min_value, max_value} ->
       {Kernel.min(entry, min_value), Kernel.max(entry, max_value)}

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1328,7 +1328,8 @@ defmodule Enum do
 
   """
   @spec max(t, (() -> empty_result)) :: element | empty_result | no_return when empty_result: any
-  def max(enumerable, empty_fallback \\ fn -> raise Enum.EmptyError end) do
+  def max(enumerable, empty_fallback \\ fn -> raise Enum.EmptyError end)
+  def max(enumerable, empty_fallback) when is_function(empty_fallback, 0) do
     reduce_handling_empty(enumerable, &Kernel.max(&1, &2), empty_fallback)
   end
 
@@ -1436,7 +1437,8 @@ defmodule Enum do
 
   """
   @spec min(t, (() -> empty_result)) :: element | empty_result | no_return when empty_result: any
-  def min(enumerable, empty_fallback \\ fn -> raise Enum.EmptyError end) do
+  def min(enumerable, empty_fallback \\ fn -> raise Enum.EmptyError end)
+  def min(enumerable, empty_fallback) when is_function(empty_fallback, 0) do
     reduce_handling_empty(enumerable, &Kernel.min(&1, &2), empty_fallback)
   end
 
@@ -1506,7 +1508,8 @@ defmodule Enum do
 
   """
   @spec min_max(t, (() -> empty_result)) :: {element, element} | empty_result | no_return when empty_result: any
-  def min_max(enumerable, empty_fallback \\ fn -> raise Enum.EmptyError end) do
+  def min_max(enumerable, empty_fallback \\ fn -> raise Enum.EmptyError end)
+  def min_max(enumerable, empty_fallback) when is_function(empty_fallback, 0) do
     reduce_handling_empty(enumerable, fn entry, {min_value, max_value} ->
       {Kernel.min(entry, min_value), Kernel.max(entry, max_value)}
     end, empty_fallback, &{&1, &1})

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -291,6 +291,14 @@ defmodule EnumTest do
     end
   end
 
+  test "max/2" do
+    assert Enum.max([1], fn -> nil end) == 1
+    assert Enum.max([1, 2, 3], fn -> nil end) == 3
+    assert Enum.max([1, [], :a, {}], fn -> nil end) == []
+    assert Enum.max([], fn -> :empty_value end) == :empty_value
+    assert Enum.max(%{}, fn -> :empty_value end) == :empty_value
+  end
+
   test "max_by/2" do
     assert Enum.max_by(["a", "aa", "aaa"], fn(x) -> String.length(x) end) == "aaa"
     assert_raise Enum.EmptyError, fn ->
@@ -316,6 +324,14 @@ defmodule EnumTest do
     end
   end
 
+  test "min/2" do
+    assert Enum.min([1], fn -> nil end) == 1
+    assert Enum.min([1, 2, 3], fn -> nil end) == 1
+    assert Enum.min([[], :a, {}], fn -> nil end) == :a
+    assert Enum.min([], fn -> :empty_value end) == :empty_value
+    assert Enum.min(%{}, fn -> :empty_value end) == :empty_value
+  end
+
   test "min_by/2" do
     assert Enum.min_by(["a", "aa", "aaa"], fn(x) -> String.length(x) end) == "a"
     assert_raise Enum.EmptyError, fn ->
@@ -333,6 +349,14 @@ defmodule EnumTest do
     assert_raise Enum.EmptyError, fn ->
       Enum.min_max([])
     end
+  end
+
+  test "min_max/2" do
+    assert Enum.min_max([1], fn -> nil end) == {1, 1}
+    assert Enum.min_max([2, 3, 1], fn -> nil end) == {1, 3}
+    assert Enum.min_max([[], :a, {}], fn -> nil end) == {:a, []}
+    assert Enum.min_max([], fn -> {:empty_min, :empty_max} end) == {:empty_min, :empty_max}
+    assert Enum.min_max(%{}, fn -> {:empty_min, :empty_max} end) == {:empty_min, :empty_max}
   end
 
   test "min_max_by/2" do

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -297,6 +297,7 @@ defmodule EnumTest do
     assert Enum.max([1, [], :a, {}], fn -> nil end) == []
     assert Enum.max([], fn -> :empty_value end) == :empty_value
     assert Enum.max(%{}, fn -> :empty_value end) == :empty_value
+    assert_runs_enumeration_only_once(&Enum.max(&1, fn -> nil end))
   end
 
   test "max_by/2" do
@@ -330,6 +331,18 @@ defmodule EnumTest do
     assert Enum.min([[], :a, {}], fn -> nil end) == :a
     assert Enum.min([], fn -> :empty_value end) == :empty_value
     assert Enum.min(%{}, fn -> :empty_value end) == :empty_value
+    assert_runs_enumeration_only_once(&Enum.min(&1, fn -> nil end))
+  end
+
+  defp assert_runs_enumeration_only_once(enum_fun) do
+    enumerator = Stream.map([:element], fn element ->
+      send(self(), element)
+      element
+    end)
+
+    enum_fun.(enumerator)
+    assert_received :element
+    refute_received :element
   end
 
   test "min_by/2" do
@@ -357,6 +370,7 @@ defmodule EnumTest do
     assert Enum.min_max([[], :a, {}], fn -> nil end) == {:a, []}
     assert Enum.min_max([], fn -> {:empty_min, :empty_max} end) == {:empty_min, :empty_max}
     assert Enum.min_max(%{}, fn -> {:empty_min, :empty_max} end) == {:empty_min, :empty_max}
+    assert_runs_enumeration_only_once(&Enum.min_max(&1, fn -> nil end))
   end
 
   test "min_max_by/2" do

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -310,6 +310,14 @@ defmodule EnumTest do
     end
   end
 
+  test "max_by/3" do
+    assert Enum.max_by(["a", "aa", "aaa"], fn(x) -> String.length(x) end, fn -> nil end) == "aaa"
+    assert Enum.max_by([], fn(x) -> String.length(x) end, fn -> :empty_value end) == :empty_value
+    assert Enum.max_by(%{}, &(&1), fn -> :empty_value end) == :empty_value
+    assert Enum.max_by(%{}, &(&1), fn -> {:a, :tuple} end) == {:a, :tuple}
+    assert_runs_enumeration_only_once(&Enum.max_by(&1, fn e -> e end, fn -> nil end))
+  end
+
   test "member?/2" do
     assert Enum.member?([1, 2, 3], 2)
     refute Enum.member?([], 0)
@@ -355,6 +363,14 @@ defmodule EnumTest do
     end
   end
 
+  test "min_by/3" do
+    assert Enum.min_by(["a", "aa", "aaa"], fn(x) -> String.length(x) end, fn -> nil end) == "a"
+    assert Enum.min_by([], fn(x) -> String.length(x) end, fn -> :empty_value end) == :empty_value
+    assert Enum.min_by(%{}, &(&1), fn -> :empty_value end) == :empty_value
+    assert Enum.min_by(%{}, &(&1), fn -> {:a, :tuple} end) == {:a, :tuple}
+    assert_runs_enumeration_only_once(&Enum.min_by(&1, fn e -> e end, fn -> nil end))
+  end
+
   test "min_max/1" do
     assert Enum.min_max([1]) == {1, 1}
     assert Enum.min_max([2, 3, 1]) == {1, 3}
@@ -378,6 +394,13 @@ defmodule EnumTest do
     assert_raise Enum.EmptyError, fn ->
       Enum.min_max_by([], fn(x) -> String.length(x) end)
     end
+  end
+
+  test "min_max_by/3" do
+    assert Enum.min_max_by(["aaa", "a", "aa"], fn(x) -> String.length(x) end, fn -> nil end) == {"a", "aaa"}
+    assert Enum.min_max_by([], fn(x) -> String.length(x) end, fn -> {:no_min, :no_max} end) == {:no_min, :no_max}
+    assert Enum.min_max_by(%{}, fn(x) -> String.length(x) end, fn -> {:no_min, :no_max} end) == {:no_min, :no_max}
+    assert_runs_enumeration_only_once(&Enum.min_max_by(&1, fn x -> x end, fn -> nil end))
   end
 
   test "split_with/2" do

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -314,15 +314,15 @@ defmodule EnumTest do
     assert_raise Enum.EmptyError, fn ->
       Enum.min([])
     end
-    assert_raise Enum.EmptyError, fn ->
-      Enum.min_by(%{}, &(&1))
-    end
   end
 
   test "min_by/2" do
     assert Enum.min_by(["a", "aa", "aaa"], fn(x) -> String.length(x) end) == "a"
     assert_raise Enum.EmptyError, fn ->
       Enum.min_by([], fn(x) -> String.length(x) end)
+    end
+    assert_raise Enum.EmptyError, fn ->
+      Enum.min_by(%{}, &(&1))
     end
   end
 

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -366,7 +366,9 @@ defmodule ExceptionTest do
 
                  * map/2
                  * max/1
+                 * max/2
                  * min/1
+                 * min/2
            """
     assert %UndefinedFunctionError{module: :erlang, function: :gt_cookie, arity: 0} |> message == """
            function :erlang.gt_cookie/0 is undefined or private. Did you mean one of:


### PR DESCRIPTION
As discussed on the [mailing list](https://groups.google.com/forum/#!topic/elixir-lang-core/goQuIjs00YE).

The new 2nd argument is a function that is called when the enumerable is empty. It defaults to raising `Enum.EmptyError` to preserve existing behavior.

One thing I'm unsure of: should we add `min_by/3`, `max_by/3` and `min_max_by/3` as well?