### PR TITLE
fix #5144

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -239,8 +239,8 @@ defmodule Kernel.SpecialForms do
   -------------------- | ----------------
   `signed`             | `integer`
   `unsigned` (default) | `integer`
-  `little`             | `integer`, `utf16`, `utf32`
-  `big` (default)      | `integer`, `utf16`, `utf32`
+  `little`             | `integer`, `float`, `utf16`, `utf32`
+  `big` (default)      | `integer`, `float`, `utf16`, `utf32`
   `native`             | `integer`, `utf16`, `utf32`
 
   ### Sign


### PR DESCRIPTION
Mention in <<>> macro documentation that also float
can use 'little' and 'big' modifiers.