### PR TITLE
Let `File.write` and `File.write!` take advantage of `writev`

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1365,10 +1365,7 @@ defmodule File do
   # and raw mode is also requested.
   # http://erlang.org/doc/man/file.html#open-2
   defp set_raw_unless_encoding_specified(modes) do
-    case Keyword.has_key?(modes, :encoding) do
-      true  -> modes
-      false -> [:raw | modes]
-    end
+    if Keyword.has_key?(modes, :encoding), do: modes, else: [:raw | modes]
   end
 
   defp maybe_to_string(path) when is_pid(path),

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -704,9 +704,12 @@ defmodule File do
     content = convert_to_binary_unless_raw_mode(content, modes)
     case F.open(IO.chardata_to_string(path), modes) do
       {:ok, file} ->
-        result = F.write(file, content)
-        F.close(file)
-        result
+        case F.write(file, content) do
+          :ok -> F.close(file)
+          error ->
+            F.close(file)
+            error
+        end
       error -> error
     end
   end
@@ -721,9 +724,7 @@ defmodule File do
     case F.open(IO.chardata_to_string(path), modes) do
       {:ok, file} ->
         case F.write(file, content) do
-          :ok ->
-            F.close(file)
-            :ok
+          :ok -> F.close(file)
           {:error, reason} ->
             F.close(file)
             raise File.Error, reason: reason, action: "write to file",

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1365,16 +1365,10 @@ defmodule File do
   # and raw mode is also requested.
   # http://erlang.org/doc/man/file.html#open-2
   defp set_raw_unless_encoding_specified(modes) do
-    case specifies_encoding?(modes) do
+    case Keyword.has_key?(modes, :encoding) do
       true  -> modes
-      false -> modes ++ [:raw]
+      false -> [:raw | modes]
     end
-  end
-
-  defp specifies_encoding?(modes) do
-    Enum.any?(modes, fn (mode) ->
-      is_tuple(mode) && elem(mode, 0) == :encoding
-    end)
   end
 
   defp maybe_to_string(path) when is_pid(path),

--- a/lib/elixir/test/elixir/file_test.exs
+++ b/lib/elixir/test/elixir/file_test.exs
@@ -771,6 +771,17 @@ defmodule FileTest do
       end
     end
 
+    test "write utf8 from a charlist" do
+      fixture = tmp_path("tmp_test.txt")
+      try do
+        refute File.exists?(fixture)
+        assert File.write(fixture, [74, 111, 115, 233, 10], [:utf8]) == :ok
+        assert {:ok, "José\n"} == File.read(fixture)
+      after
+        File.rm(fixture)
+      end
+    end
+
     test "write with options" do
       fixture = tmp_path("tmp_test.txt")
       try do


### PR DESCRIPTION
Closes https://github.com/elixir-lang/elixir/issues/5150

As a performance optimization, have these functions use `:file.write/3`,
usually with `:raw` mode, instead of `:file.write_file/3`. This will
cause the BEAM to use the `writev` system call instead of `write`.

The advantage of this is that, when writing an iolist, the BEAM need not
concatenate the items and produce a single binary for writing. Instead,
it can let the operating system read each item from memory individually;
the final output is produced only in the target file. Skipping the
binary concatenation saves work, saves memory, and creates less garbage
for later collection.

Note that `:raw` mode cannot be used when a character encoding is given.
In `:raw` mode, the BEAM does not create a separate process to handle
the file, and (I think) it would normally be this process which performs
the character encoding. So if an encoding like `:utf8` is given, we do
not use `:raw` mode and therefore do not use `writev`.