### PR TITLE
Fix a typo in the ExDoc for File.stream!/3

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1195,7 +1195,7 @@ defmodule File do
   The stream implements both `Enumerable` and `Collectable` protocols,
   which means it can be used both for read and write.
 
-  The `line_or_byte` argument configures how the file is read when
+  The `line_or_bytes` argument configures how the file is read when
   streaming, by `:line` (default) or by a given number of bytes.
 
   Operating the stream can fail on open for the same reasons as


### PR DESCRIPTION
Fix a typo in the name of a parameter in the ExDoc comment for `File.stream!/3`
