### PR TITLE
Don't crash in macro_exported?/3 when dealing with Erlang modules

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2826,18 +2826,21 @@ defmodule Kernel do
   it is not loaded. Check `Code.ensure_loaded/1` for more
   information.
 
+  If `module` is an Erlang module (as opposed to an Elixir module), this
+  function always returns `false`.
+
   ## Examples
 
       iex> macro_exported?(Kernel, :use, 2)
       true
 
+      iex> macro_exported?(:erlang, :abs, 1)
+      false
+
   """
   @spec macro_exported?(atom, atom, integer) :: boolean
   def macro_exported?(module, macro, arity) do
-    case :code.is_loaded(module) do
-      {:file, _} -> :lists.member({macro, arity}, module.__info__(:macros))
-      _ -> false
-    end
+    function_exported?(module, :__info__, 1) and :lists.member({macro, arity}, module.__info__(:macros))
   end
 
   @doc """

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -302,6 +302,7 @@ defmodule KernelTest do
     assert macro_exported?(Kernel, :def, 2) == true
     assert macro_exported?(Kernel, :def, 3) == false
     assert macro_exported?(Kernel, :no_such_macro, 2) == false
+    assert macro_exported?(:erlang, :abs, 1) == false
   end
 
   test "apply/3 and apply/2" do


### PR DESCRIPTION
Right now, `Kernel.macro_exported?/3` blindly calls `__info__/1` on the given module, but since `__info__/1` is defined by Elixir when compiling modules, this breaks if an Erlang module is passed to `macro_exported?/3`. This commit fixes this behaviour by always returning `false` in `macro_exported?/3` when an Erlang module is given.

This is mildly related to #5156, which is gonna be a bit simpler once we merge this.

\cc @josevalim 