### PR TITLE
Wrap fn calls in parens in Macro.to_string/1,2

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -824,6 +824,8 @@ defmodule Macro do
     do: Atom.to_string(atom)
   defp call_to_string({:., _, [{:&, _, [val]} = arg]}, fun) when not is_integer(val),
     do: "(" <> module_to_string(arg, fun) <> ")."
+  defp call_to_string({:., _, [{:fn, _, _} = arg]}, fun),
+    do: "(" <> module_to_string(arg, fun) <> ")."
   defp call_to_string({:., _, [arg]}, fun),
     do: module_to_string(arg, fun) <> "."
   defp call_to_string({:., _, [left, right]}, fun),

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -352,6 +352,17 @@ defmodule MacroTest do
         z
     end
     """
+
+    assert Macro.to_string(quote do: (fn(x) -> x end).(1)) == "(fn x -> x end).(1)"
+
+    assert Macro.to_string(quote do: (fn %{} -> :map; _ -> :other end).(1)) <> "\n" == """
+    (fn
+      %{} ->
+        :map
+      _ ->
+        :other
+    end).(1)
+    """
   end
 
   test "range to string" do


### PR DESCRIPTION
Right now, application of anonymous function literals in `Macro.to_string/2` is represented like this:

```elixir
Macro.to_string(quote do: (fn x -> x end).(1))
#=> "fn x -> x end.(1)"
```

While this is valid, I think it's far more common (and personally, much less confusing) to have such calls with the literal `fn` wrapped in parens:

```elixir
(fn x -> x end).(1)
```

This PR makes `Macro.to_string/2` behave like this. Sorry I jumped the mailing list for discussing this, but the feature was quite small to implement and I wanted to try it out first anyways, so I thought a PR would be ok :)