### PR TITLE
Improve the docs for the :async option in ExUnit.Case

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -11,9 +11,12 @@ defmodule ExUnit.Case do
 
   When used, it accepts the following options:
 
-    * :async - configure this specific test case to able to run in parallel
+    * `:async` - configure this specific test case to able to run in parallel
       with other test cases. May be used for performance when this test case
-      does not change any global state. Defaults to `false`.
+      does not change any global state. Defaults to `false`. It's usually a good
+      idea to avoid making a test case async if tests in it capture the IO or
+      the logs (via `ExUnit.CaptureIO` or `ExUnit.CaptureLog`) since that could
+      cause unwanted IO/logs to be captured and race conditions to happen.
 
   This module automatically includes all callbacks defined in
   `ExUnit.Callbacks`. See that module's documentation for more


### PR DESCRIPTION
We could likely mention this also/only in `ExUnit.CaptureIO` and `ExUnit.CaptureLog`, not sure which would be better. ¯\\\_(ツ)\_/¯ What do other people think? :)