### PR TITLE
Ignore .fetch in project root

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -245,6 +245,9 @@ defmodule Mix.Tasks.New do
 
   # Also ignore archive artifacts (built via "mix archive.build").
   *.ez
+
+  # Ignore .fetch files in case you like to edit your project deps locally
+  /.fetch
   """
 
   embed_template :mixfile, """


### PR DESCRIPTION
This PR adds `.fetch` to the Git ignore directory in case people find themselves editing deps inside the dependency directory. If you edit something in the `deps/` directory, then commit it, future updates will cause the following error:

```
error: The following untracked working tree files would be overwritten by checkout:
        .fetch
Please move or remove them before you can switch branches.
```

This is a easy fix to help people avoid shooting themselves in the foot (like I did).