### PR TITLE
Produce meaningful warning when with's else clauses have no effect

### DIFF
--- a/lib/elixir/src/elixir_with.erl
+++ b/lib/elixir/src/elixir_with.erl
@@ -70,37 +70,51 @@ translate(Meta, Args, S) ->
   {Parts, [{do, Expr} | ExprList]} = elixir_utils:split_last(Args),
   case ExprList of
     [{else, ElseExpr}] ->
-      {TCases, TS} = translate_case(Parts, {ok, Expr}, fun(X) -> {error, X} end, S),
-      translate_else(Meta, TCases, ElseExpr, TS);
+      {TCase, TS, HasMatch} = translate_case(Parts, {ok, Expr}, fun(X) -> {error, X} end, S),
+      translate_else(Meta, TCase, ElseExpr, TS, HasMatch);
     [] ->
-      translate_case(Parts, Expr, fun(X) -> X end, S)
+      {TCase, TS, _HasMatch} = translate_case(Parts, Expr, fun(X) -> X end, S),
+      {TCase, TS}
   end.
 
 translate_case(Parts, DoExpr, Wrapper, S) ->
-  Cases = build_case(Parts, DoExpr, Wrapper),
-  {TCases, TS} = elixir_translator:translate(Cases, S#elixir_scope{extra=nil}),
-  {TCases, elixir_scope:mergec(S, TS)}.
+  {Case, HasMatch} = build_case(Parts, DoExpr, Wrapper, false),
+  {TCase, TS} = elixir_translator:translate(Case, S#elixir_scope{extra=nil}),
+  {TCase, elixir_scope:mergec(S, TS), HasMatch}.
 
-translate_else(Meta, WithCases, ElseExpr, S) ->
+translate_else(Meta, WithCases, _ElseExpr, S, false) ->
+  Warning =
+    "\"else\" clauses will never match"
+    " because all patterns in \"with\" will always match",
+  elixir_errors:warn(?line(Meta), S#elixir_scope.file, Warning),
+  Ann = ?ann(Meta),
+  Call = {call, Ann,
+    {remote, Ann, {atom, Ann, erlang}, {atom, Ann, element}},
+    [{integer, Ann, 2}, WithCases]
+  },
+  {Call, S};
+translate_else(Meta, WithCases, ElseExpr, S, true) ->
   ElseClauses = build_else(Meta, ElseExpr),
   {TClauses, TS} = elixir_clauses:clauses(Meta, ElseClauses, S#elixir_scope{extra=nil}),
   {{'case', ?ann(Meta), WithCases, TClauses}, elixir_scope:mergec(S, TS)}.
 
-build_case([{'<-', Meta, [{Name, _, Ctx}, _] = Args} | Rest], DoExpr, Wrapper)
+build_case([{'<-', Meta, [{Name, _, Ctx}, _] = Args} | Rest], DoExpr, Wrapper, HasMatch)
     when is_atom(Name) andalso is_atom(Ctx) ->
-  build_case([{'=', Meta, Args} | Rest], DoExpr, Wrapper);
-build_case([{'<-', Meta, [Left, Right]} | Rest], DoExpr, Wrapper) ->
+  build_case([{'=', Meta, Args} | Rest], DoExpr, Wrapper, HasMatch);
+build_case([{'<-', Meta, [Left, Right]} | Rest], DoExpr, Wrapper, _HasMatch) ->
+  {InnerCase, true} = build_case(Rest, DoExpr, Wrapper, true),
   Other = {other, Meta, ?MODULE},
   Generated = ?generated(Meta),
   Clauses = [
-    {'->', Generated, [[Left], build_case(Rest, DoExpr, Wrapper)]},
+    {'->', Generated, [[Left], InnerCase]},
     {'->', Generated, [[Other], Wrapper(Other)]}
   ],
-  {'case', Generated, [Right, [{do, Clauses}]]};
-build_case([Expr | Rest], DoExpr, Wrapper) ->
-  {'__block__', [], [Expr, build_case(Rest, DoExpr, Wrapper)]};
-build_case([], DoExpr, _Wrapper) ->
-  DoExpr.
+  {{'case', Generated, [Right, [{do, Clauses}]]}, true};
+build_case([Expr | Rest], DoExpr, Wrapper, HasMatch) ->
+  {InnerCase, InnerHasMatch} = build_case(Rest, DoExpr, Wrapper, HasMatch),
+  {{'__block__', [], [Expr, InnerCase]}, InnerHasMatch};
+build_case([], DoExpr, _Wrapper, HasMatch) ->
+  {DoExpr, HasMatch}.
 
 build_else(Meta, ElseClauses) ->
   Result = {result, Meta, ?MODULE},


### PR DESCRIPTION
Isolated example:

```elixir
defmodule Foo do
  def foo(arg) do
    with foo = arg do
      foo
    else
      _ -> :not_ok
    end
  end
end
```

which translates to:

```elixir
defmodule Foo do
  def foo(arg) do
    case (foo = arg; {:ok, foo}) do
      {:ok, result} -> result
      {:error, _} -> :not_ok
    end
  end
end
```

I have found which part should be marked as `generated` to suppress the "this clause cannot match because of different types/sizes" warning.
However, I think we can make it even better: with this patch that code produces meaningful warning and also we simply dropping else clauses.
Thoughts?

Closes #5164.