### PR TITLE
Introduce Process.send_after/4

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -239,10 +239,20 @@ defmodule Process do
   which is not alive or when the given PID exits. Note that timers will not be
   automatically canceled when `dest` is an atom (as the atom resolution is done
   on delivery).
+
+  ## Options
+
+    * `:abs` - (boolean) when `false`, `time` is treated as relative to the
+    current monotonic time. When `true`, `time` is the absolute value of the
+    Erlang monotonic time at which `msg` should be delivered to `dest`.
+    To read more about Erlang monotonic time and other time-related concepts,
+    look at the documentation for the `System` module. Defaults to `false`.
+
   """
-  @spec send_after(pid | atom, term, non_neg_integer) :: reference
-  def send_after(dest, msg, time) do
-    :erlang.send_after(time, dest, msg)
+  @spec send_after(pid | atom, term, non_neg_integer, [option]) :: reference
+        when option: {:abs, boolean}
+  def send_after(dest, msg, time, opts \\ []) do
+    :erlang.send_after(time, dest, msg, opts)
   end
 
   @doc """

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -247,6 +247,8 @@ rewrite(?process, monitor, [Arg]) ->
   {erlang, monitor, [process, Arg]};
 rewrite(?process, send_after, [Dest, Msg, Time]) ->
   {erlang, send_after, [Time, Dest, Msg]};
+rewrite(?process, send_after, [Dest, Msg, Time, Opts]) ->
+  {erlang, send_after, [Time, Dest, Msg, Opts]};
 rewrite(?string, to_atom, [Arg]) ->
   {erlang, binary_to_atom, [Arg, utf8]};
 rewrite(?string, to_existing_atom, [Arg]) ->

--- a/lib/elixir/test/elixir/process_test.exs
+++ b/lib/elixir/test/elixir/process_test.exs
@@ -68,6 +68,12 @@ defmodule ProcessTest do
     assert_receive :hello
   end
 
+  test "send_after/4 with absolute time sends message once expired" do
+    time = System.monotonic_time(:milliseconds) + 10
+    Process.send_after(self(), :hello, time, abs: true)
+    assert_receive :hello
+  end
+
   test "send_after/3 returns a timer reference that can be read or cancelled" do
     timer = Process.send_after(self(), :hello, 100_000)
     refute_received :hello


### PR DESCRIPTION
For some reason the `/4` version was missing.