### PR TITLE
Align multiline when in specs to the standard

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -995,9 +995,9 @@ defmodule Enum do
       {[[1], [2], [3], [4], [5]], 15}
 
   """
-  @spec flat_map_reduce(t, acc, fun) :: {[any], any} when
-        fun: (element, acc -> {t, acc} | {:halt, acc}),
-        acc: any
+  @spec flat_map_reduce(t, acc, fun) :: {[any], any}
+        when fun: (element, acc -> {t, acc} | {:halt, acc}),
+             acc: any
   def flat_map_reduce(enumerable, acc, fun) when is_function(fun, 2) do
     {_, {list, acc}} =
       Enumerable.reduce(enumerable, {:cont, {[], acc}},

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -216,10 +216,10 @@ defmodule Process do
       :noconnect
 
   """
-  @spec send(dest, msg, [option]) :: :ok | :noconnect | :nosuspend when
-        dest: pid | port | atom | {atom, node},
-        msg: any,
-        option: :noconnect | :nosuspend
+  @spec send(dest, msg, [option]) :: :ok | :noconnect | :nosuspend
+        when dest: pid | port | atom | {atom, node},
+             msg: any,
+             option: :noconnect | :nosuspend
   def send(dest, msg, options) do
     :erlang.send(dest, msg, options)
   end

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -729,9 +729,9 @@ defmodule Stream do
       [1, 2, 3]
 
   """
-  @spec transform(Enumerable.t, acc, fun) :: Enumerable.t when
-        fun: (element, acc -> {Enumerable.t, acc} | {:halt, acc}),
-        acc: any
+  @spec transform(Enumerable.t, acc, fun) :: Enumerable.t
+        when fun: (element, acc -> {Enumerable.t, acc} | {:halt, acc}),
+             acc: any
   def transform(enum, acc, reducer) when is_function(reducer, 2) do
     &do_transform(enum, fn -> acc end, reducer, &1, &2, nil)
   end
@@ -746,9 +746,9 @@ defmodule Stream do
   This function can be seen as a combination of `Stream.resource/3` with
   `Stream.transform/3`.
   """
-  @spec transform(Enumerable.t, (() -> acc), fun, (acc -> term)) :: Enumerable.t when
-        fun: (element, acc -> {Enumerable.t, acc} | {:halt, acc}),
-        acc: any
+  @spec transform(Enumerable.t, (() -> acc), fun, (acc -> term)) :: Enumerable.t
+        when fun: (element, acc -> {Enumerable.t, acc} | {:halt, acc}),
+             acc: any
   def transform(enum, start_fun, reducer, after_fun)
       when is_function(start_fun, 0) and is_function(reducer, 2) and is_function(after_fun, 1) do
     &do_transform(enum, start_fun, reducer, &1, &2, after_fun)


### PR DESCRIPTION
As discovered in https://github.com/elixir-lang/elixir/pull/5182 some `when`s where misaligned.

I'm not sure if that's the right way to indent all of them, so suggestions are welcome.

\cc @lexmag 