### PR TITLE
Specify that the timeout is expressed in milliseconds for increased clarity

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1841,7 +1841,7 @@ defmodule Kernel.SpecialForms do
       end
 
   An optional `after` clause can be given in case the message was not
-  received after the specified timeout period:
+  received after the given timeout period, specified in milliseconds:
 
       receive do
         {:selector, i, value} when is_integer(i) ->

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -638,7 +638,7 @@ defmodule ExUnit.Assertions do
 
   @doc """
   Asserts that a message matching `pattern` was not received (and won't be received)
-  within the `timeout` period.
+  within the `timeout` period, specified in milliseconds.
 
   The `pattern` argument must be a match pattern. Flunks with `failure_message`
   if a message matching `pattern` is received.

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -317,9 +317,10 @@ defmodule ExUnit.Assertions do
   end
 
   @doc """
-  Asserts that a message matching `pattern` was or is going to be received.
+  Asserts that a message matching `pattern` was or is going to be received
+  within the `timeout` period, specified in milliseconds.
 
-  Unlike `assert_received`, it has a default timeout
+  Unlike `assert_received`, it has a default `timeout`
   of 100 milliseconds.
 
   The `pattern` argument must be a match pattern. Flunks with `failure_message`


### PR DESCRIPTION
Noticed it was missing in the `refute_receive` docs and also looked and added it to the `receive` docs. It was already specified for `assert_receive`.

Anywhere else that I should check that might benefit from this addition? Feedback on way to introduce this/wording welcome as always :)