### PR TITLE
Remove `b(Dict)` example

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -234,7 +234,6 @@ defmodule IEx.Helpers do
 
       b(Mix.Task.run/1)
       b(Mix.Task.run)
-      b(Dict)
 
   """
   defmacro b(term)

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -234,7 +234,7 @@ defmodule IEx.Helpers do
 
       b(Mix.Task.run/1)
       b(Mix.Task.run)
-
+      b(GenServer)
   """
   defmacro b(term)
   defmacro b({:/, _, [{{:., _, [mod, fun]}, _, []}, arity]}) do


### PR DESCRIPTION
Because:

```
iex(2)> b(Dict)
No callbacks for Dict were found
```