### PR TITLE
Change argument 'val' to 'value' in Map.put/3

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -409,8 +409,8 @@ defmodule Map do
 
   """
   @spec put(map, key, value) :: map
-  def put(map, key, val) do
-    :maps.put(key, val, map)
+  def put(map, key, value) do
+    :maps.put(key, value, map)
   end
 
   @doc """


### PR DESCRIPTION
    Puts the given `value` under `key` in `map`.

The documentation for Map.put/3 refers to the `value` function argument, even though it is actually called `val`. We should rename it to `value` for consistency with other examples.