### PR TITLE
Improve the i/1 IEx helper for module-like atoms

### DIFF
--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -14,7 +14,15 @@ end
 
 defimpl IEx.Info, for: Atom do
   def info(atom) do
-    specific_info = if Code.ensure_loaded?(atom), do: info_module(atom), else: info_atom(atom)
+    specific_info =
+      cond do
+        Code.ensure_loaded?(atom) ->
+          info_module(atom)
+        match?("Elixir." <> _, Atom.to_string(atom)) ->
+          info_module_like_atom(atom)
+        true ->
+          info_atom(atom)
+      end
     ["Data type": "Atom"] ++ specific_info
   end
 
@@ -34,6 +42,11 @@ defimpl IEx.Info, for: Atom do
      "Description": "#{extra}Call #{inspect mod}.module_info() to access metadata.",
      "Raw representation": ":" <> inspect(Atom.to_string(mod)),
      "Reference modules": "Module, Atom"]
+  end
+
+  defp info_module_like_atom(atom) do
+    ["Raw representation": ":" <> inspect(Atom.to_string(atom)),
+     "Reference modules": "Atom"]
   end
 
   defp info_atom(_atom) do

--- a/lib/iex/test/iex/info_test.exs
+++ b/lib/iex/test/iex/info_test.exs
@@ -29,6 +29,11 @@ defmodule IEx.InfoTest do
     assert info[:"Description"] == description
   end
 
+  test "atoms: module-like atom (Foo)" do
+    info = Info.info(NonexistentModuleAtom)
+    assert info[:"Raw representation"] == ~s(:"Elixir.NonexistentModuleAtom")
+  end
+
   test "atoms: regular atom" do
     assert Info.info(:foo) == ["Data type": "Atom",
                                "Reference modules": "Atom"]


### PR DESCRIPTION
For atoms such as `LooksLikeAModule`, we don't show the raw representation (`:"Elixir.LooksLikeAModule"`). With this commit, we do. What does everyone think about this change? :)