### PR TITLE
Polish the error messages in OptionParser.ParseError

### DIFF
--- a/lib/elixir/test/elixir/option_parser_test.exs
+++ b/lib/elixir/test/elixir/option_parser_test.exs
@@ -222,7 +222,12 @@ defmodule OptionParserTest do
   end
 
   test "parse!/2 raise an exception for an unknown option using strict" do
-    assert_raise OptionParser.ParseError, "1 error found!\n--doc : Unknown option", fn ->
+    message = String.trim_trailing("""
+    found errors:
+    --doc : Unknown option
+    """)
+
+    assert_raise OptionParser.ParseError, message, fn ->
       argv = ["--source", "from_docs/", "--doc", "show"]
       OptionParser.parse!(argv, strict: [source: :string, docs: :string])
     end
@@ -236,7 +241,12 @@ defmodule OptionParserTest do
   end
 
   test "parse_head!/2 raise an exception when an option is of the wrong type" do
-    assert_raise OptionParser.ParseError, "1 error found!\n--number : Expected type integer, got \"lib\"", fn ->
+    message = String.trim_trailing("""
+    found errors:
+    --number : Expected a value of type integer, got: "lib"
+    """)
+
+    assert_raise OptionParser.ParseError, message, fn ->
       argv = ["--number", "lib", "test/enum_test.exs"]
       OptionParser.parse_head!(argv, strict: [number: :integer])
     end

--- a/lib/mix/test/mix/task_test.exs
+++ b/lib/mix/test/mix/task_test.exs
@@ -35,17 +35,19 @@ defmodule Mix.TaskTest do
   end
 
   test "run/2 converts OptionParser.ParseError into mix errors" do
-    assert_raise Mix.Error,
-                 "Could not invoke task \"hello\": 1 error found!\n--unknown : Unknown option", fn ->
+    exception = assert_raise Mix.Error, fn ->
       Mix.Task.run("hello", ["--parser", "--unknown"])
     end
+    message = Exception.message(exception)
+    assert message =~ ~s(Could not invoke task "hello")
+    assert message =~ ~s(--unknown : Unknown option)
 
     Mix.Task.clear
 
-    assert_raise Mix.Error,
-                 "Could not invoke task \"hello\": 1 error found!\n--int : Expected type integer, got \"foo\"", fn ->
+    exception = assert_raise Mix.Error, fn ->
       Mix.Task.run("hello", ["--parser", "--int", "foo"])
     end
+    assert Exception.message(exception) =~ ~s(--int : Expected a value of type integer, got: "foo")
   end
 
   test "run/2 outputs task debug info if Mix.debug? is true" do


### PR DESCRIPTION
A bunch of stuff that I believe could improve the readability and "feeling" of these error messages":

* no more exclamation points: I think they're distracting and don't really bring value to the error message. We're all busy business people™ trying to make money here 😛 
* no more errors count ("4 errors found"), which I don't believe to be informative (I don't really care how many errors, they will likely be just one or two, but basically never a gazillion); this also reduces the code and its complexity
* no more `--foo : Something something` formatting, but a more "standardish" `--foo - something something`, with `-` instead of `:` and no capital letters

What does everyone think? :) 💟 