### PR TITLE
Polish the documentation for a bunch of Mix.* modules

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -17,8 +17,7 @@ defmodule Mix do
         end
       end
 
-  The `project/0` function is where the project information is defined
-  and tasks are configured.
+  See the `Mix.Project` module for detailed documentation on Mix projects.
 
   Once the project is defined, a number of default Mix tasks can be run
   directly from the command line:
@@ -55,8 +54,8 @@ defmodule Mix do
 
   ## Dependencies
 
-  Another important feature in Mix is that it is able to manage your
-  dependencies and integrates nicely with the [Hex package manager](https://hex.pm).
+  Mix also manages your dependencies and integrates nicely with the [Hex package
+  manager](https://hex.pm).
 
   In order to use dependencies, you need to add a `:deps` key
   to your project configuration. We often extract the list of dependencies
@@ -81,15 +80,13 @@ defmodule Mix do
 
   ## Environments
 
-  Mix provides environments.
-
-  Environments allow developers to prepare and organize their project
-  specifically for different scenarios. By default, Mix provides three
-  environments:
+  Mix supports different environments. Environments allow developers to prepare
+  and organize their project specifically for different scenarios. By default,
+  Mix provides three environments:
 
     * `:dev` - the default environment
     * `:test` - the environment `mix test` runs on
-    * `:prod` - the environment your dependencies runs on
+    * `:prod` - the environment your dependencies run on
 
   The environment can be changed via the command line by setting
   the `MIX_ENV` environment variable, for example:
@@ -155,7 +152,7 @@ defmodule Mix do
 
   ## Environment variables
 
-  Environment variables can be used to modify Mix's behaviour.
+  Several environment variables can be used to modify Mix's behaviour.
 
   Mix responds to the following variables:
 
@@ -169,9 +166,11 @@ defmodule Mix do
     * `MIX_REBAR` - path to rebar command that overrides the one mix installs
     * `MIX_REBAR3` - path to rebar3 command that overrides the one mix installs
 
-  Variables which do not take a value should be set to either `1` or `true`, for example:
+  Environment variables that are not meant to hold a value (and act basically as
+  flags) should be set to either `1` or `true`, for example:
 
       $ MIX_DEBUG=1 mix compile
+
   """
 
   use Application

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -2,11 +2,10 @@ defmodule Mix.Project do
   @moduledoc """
   Defines and manipulates Mix projects.
 
-  To configure Mix, the project should include a module that `use`s
-  `Mix.Project` and defines a function named `project` that returns
-  a keyword list of configurations.
+  A Mix project is defined by calling `use Mix.Project` in a module, usually
+  placed in `mix.exs`:
 
-      defmodule MyApp do
+      defmodule MyApp.Mixfile do
         use Mix.Project
 
         def project do
@@ -15,25 +14,77 @@ defmodule Mix.Project do
         end
       end
 
-  Once defined, the configuration for the project can be read
-  using `Mix.Project.config/0`. Note that `config/0` won't fail if a
-  project is not defined; this allows many Mix tasks to work
-  without a project.
+  ## Configuration
+
+  In order to configure Mix, the module that `use`s `Mix.Project` should export
+  a `project/0` function that returns a keyword list representing configuration
+  for the project.
+
+  This configuration can be read using `Mix.Project.config/0`. Note that
+  `config/0` won't fail if a project is not defined; this allows many Mix tasks
+  to work without a project.
 
   If a task requires a project to be defined or needs to access a
   special function within the project, the task can call `Mix.Project.get!/0`
   which fails with `Mix.NoProjectError` in the case a project is not
   defined.
 
+  There isn't a comprehensive list of all the options that can be returned by
+  `project/0` since many Mix tasks define their own options that they read from
+  this configuration. For example, look at the "Configuration" section in the
+  documentation for the `Mix.Tasks.Compile` task.
+
+  These are a few options that are not used by just one Mix task (and will thus
+  be documented here):
+
+    * `:build_per_environment` - if `true`, builds will be *per-environment*. If
+      `false`, builds will go in `_build/shared` regardless of the Mix
+      environment. Defaults to `true`.
+
+    * `:aliases` - a list of task aliases. For more information, check out the
+      "Aliases" section in the documentation for the `Mix` module. Defaults to
+      `[]`.
+
+    * `:config_path` - a string representing the path of the main config
+      file. See `config_files/0` for more information. Defaults to
+      `"config/config.exs"`.
+
+    * `:default_task` - a string representing the default task to be run by
+      `mix` when no task is specified. Defaults to `"run"`.
+
+    * `:deps` - a list of dependencies of this project. Refer to the
+      documentation for the `Mix.Tasks.Deps` task for more information. Defaults
+      to `[]`.
+
+    * `:deps_path` - directory where dependencies are stored. Also see
+      `deps_path/1`. Defaults to `"deps"`.
+
+    * `:lockfile` - the name of the lockfile used by the `mix deps.*` family of
+      tasks. Defaults to `"mix.lock"`.
+
+    * `:preferred_cli_env` - a keyword list of `{task, env}` tuples here `task`
+      is the task name as an atom (for example, `:"deps.get"`) and `env` is the
+      preferred environment (for example, `:test`). This option overrides what
+      specified by the single tasks with the `@preferred_cli_env` attribute (see
+      `Mix.Task`). Defaults to `[]`.
+
+  For more options, keep an eye on the documentation for single Mix tasks; good
+  examples are the `Mix.Tasks.Compile` task and all the specific compiler tasks
+  (such as `Mix.Tasks.Compile.Elixir` or `Mix.Tasks.Compile.Erlang`).
+
+  Note that sometimes the same configuration option is mentioned in the
+  documentation for different tasks; this is just because it's common for many
+  tasks to read and use the same configuration option (for example,
+  `:erlc_paths` is used by `mix compile.erlang`, `mix compile.yecc`, and other
+  tasks).
+
   ## Erlang projects
 
   Mix can be used to manage Erlang projects that don't have any Elixir code. To
-  ensure Mix tasks work correctly for an Erlang project, `language: :erlang`
-  has to be added to `project`.
-
-  The setting also makes sure Elixir is not added as a dependency to the
-  generated .app file or to the escript generated with `mix escript.build`,
-  etc.
+  ensure Mix tasks work correctly for an Erlang project, `language: :erlang` has
+  to be part of the configuration returned by `project/0`. This setting also
+  makes sure Elixir is not added as a dependency to the generated `.app` file or
+  to the escript generated with `mix escript.build`, and so on.
   """
 
   @doc false
@@ -262,8 +313,8 @@ defmodule Mix.Project do
       Mix.Project.build_path
       #=> "/path/to/project/_build/shared"
 
-  If :build_per_environment is set to `true` (the default), it
-  will create a new build per environment:
+  If `:build_per_environment` is set to `true`, it will create a new build per
+  environment:
 
       Mix.env
       #=> :dev

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -27,7 +27,7 @@ defmodule Mix.Task do
       on `mix help`
     * `@recursive` - run the task recursively in umbrella projects
     * `@preferred_cli_env` - recommends environment to run task. It is used in absence of
-      mix project recommendation, or explicit MIX_ENV.
+      a Mix project recommendation, or explicit `MIX_ENV`
 
   ## Documentation
 

--- a/lib/mix/lib/mix/tasks/app.start.ex
+++ b/lib/mix/lib/mix/tasks/app.start.ex
@@ -17,7 +17,7 @@ defmodule Mix.Tasks.App.Start do
   ## Configuration
 
     * `:start_permanent` - the application and all of its children
-      applications are started in permanent mode
+      applications are started in permanent mode. Defaults to `false`.
 
     * `:consolidate_protocols` - when `true`, loads consolidated
       protocols before start. The default value is `true`.

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -36,8 +36,8 @@ defmodule Mix.Tasks.Compile.Erlang do
     * `:erlc_include_path` - directory for adding include files.
       Defaults to `"include"`.
 
-    * `:erlc_options` - compilation options that apply to Erlang's compiler.
-      `:debug_info` is enabled by default.
+    * `:erlc_options` - compilation options that apply to Erlang's
+      compiler. Defaults to `[:debug_info]`.
 
       For a complete list of options,
       see [`:compile.file/2`](http://www.erlang.org/doc/man/compile.html#file-2).

--- a/lib/mix/lib/mix/tasks/compile.ex
+++ b/lib/mix/lib/mix/tasks/compile.ex
@@ -10,15 +10,16 @@ defmodule Mix.Tasks.Compile do
 
   ## Configuration
 
-    * `:compilers` - compilers to run, defaults to:
-      `[:yecc, :leex, :erlang, :elixir, :xref, :app]`
+    * `:compilers` - compilers to run, defaults to `Mix.compilers/0`,
+      which are `[:yecc, :leex, :erlang, :elixir, :xref, :app]`.
 
     * `:consolidate_protocols` - when `true`, runs protocol
       consolidation via the `compile.protocols` task. The default
       value is `true`.
 
     * `:build_embedded` - when `true`, activates protocol
-      consolidation and does not generate symlinks in builds
+      consolidation and does not generate symlinks in builds. Defaults
+      to `false`.
 
     * `:build_path` - the directory where build artifacts
       should be written to. This option is intended only for


### PR DESCRIPTION
The most important change is listing a few options supported by `project/0` in the documentation for the `Mix.Project` module. I've wanted to do this for a while since it's hard to get a grasp of what *can* be returned in `project/0`; this is not a comprehensive list but I hope it can still be helpful and at least point people to the right direction :)