### PR TITLE
References in man files for Elixir forum https://elixirforum.com/

### DIFF
--- a/man/elixir.1.in
+++ b/man/elixir.1.in
@@ -48,4 +48,5 @@ This manual page contributed by Evgeny Golyshev.
 .Bl -tag -width Ds
 .It Main website: http://elixir-lang.org
 .It Documentation: http://elixir-lang.org/docs.html
+.It Official Forums: https://elixirforum.com/
 .El

--- a/man/elixirc.1
+++ b/man/elixirc.1
@@ -49,4 +49,5 @@ This manual page contributed by Evgeny Golyshev.
 .Bl -tag -width Ds
 .It Main website: http://elixir-lang.org
 .It Documentation: http://elixir-lang.org/docs.html
+.It Official Forums: https://elixirforum.com/
 .El

--- a/man/iex.1.in
+++ b/man/iex.1.in
@@ -58,4 +58,5 @@ This manual page contributed by Evgeny Golyshev.
 .Bl -tag -width Ds
 .It Main website: http://elixir-lang.org
 .It Documentation: http://elixir-lang.org/docs.html
+.It Official Forums: https://elixirforum.com/
 .El

--- a/man/mix.1
+++ b/man/mix.1
@@ -144,4 +144,5 @@ This manual page contributed by Evgeny Golyshev.
 .Bl -tag -width Ds
 .It Main website: http://elixir-lang.org
 .It Documentation: http://elixir-lang.org/docs.html
+.It Official Forums: https://elixirforum.com/
 .El


### PR DESCRIPTION
I saw that the mailing list got deprecated and removed in https://github.com/elixir-lang/elixir/commit/e1df071b38ff8a602ce791918e83304e23880100 but did not see the forums referenced anywhere. So I made this PR, is it relevant?