### PR TITLE
Allow a list of apps to be passed to mix cmd

### DIFF
--- a/lib/mix/lib/mix/tasks/cmd.ex
+++ b/lib/mix/lib/mix/tasks/cmd.ex
@@ -12,13 +12,30 @@ defmodule Mix.Tasks.Cmd do
 
       mix cmd echo pwd
 
+  You can limit which apps the cmd runs in by passing the app names
+  before the cmd using --only:
+
+      mix cmd --only app1 --only app2 echo pwd
+
   Aborts when a command exits with a non-zero status.
   """
+
   @spec run(OptionParser.argv) :: :ok
   def run(args) do
-    case Mix.shell.cmd(Enum.join(args, " ")) do
-      0 -> :ok
-      s -> exit(s)
+    {args, apps} = parse_apps(args, [])
+    if apps == [] or Mix.Project.config[:app] in apps do
+      case Mix.shell.cmd(Enum.join(args, " ")) do
+        0 -> :ok
+        s -> exit(s)
+      end
+    end
+  end
+
+  defp parse_apps(args, apps) do
+    case args do
+      ["--only", app | tail] ->
+        parse_apps(tail, [String.to_atom(app) | apps])
+      args -> {args, apps}
     end
   end
 end

--- a/lib/mix/test/mix/tasks/cmd_test.exs
+++ b/lib/mix/test/mix/tasks/cmd_test.exs
@@ -15,4 +15,17 @@ defmodule Mix.Tasks.CmdTest do
       end)
     end
   end
+
+  test "only run the cmd for specified apps" do
+    in_fixture "umbrella_dep/deps/umbrella", fn ->
+      Mix.Project.in_project(:umbrella, ".", fn _ ->
+        Mix.Task.run "cmd", ["--only", "bar", "echo", "hello"]
+        nl = os_newline()
+        assert_received {:mix_shell, :info, ["==> bar"]}
+        assert_received {:mix_shell, :run, ["hello" <> ^nl]}
+        refute_received {:mix_shell, :info, ["==> foo"]}
+        refute_received {:mix_shell, :run, ["hello" <> ^nl]}
+      end)
+    end
+  end
 end


### PR DESCRIPTION
Allows a list of apps to be passed to mix cmd and limits the execution of the cmd to only apps in the list. Defaults to all if list is empty.

example
`mix cmd --app1 --app2 mix test`

Todo:
Update tests