### PR TITLE
Fix some `exported from case` from erlang source

### DIFF
--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -21,9 +21,9 @@ expand_bitstr(Fun, [{'::', Meta, [Left, Right]} | T], Acc, E) ->
 
   %% Variables defined outside the binary can be accounted
   %% on subparts, however we can't assign new variables.
-  case E of
-    {ER, _} -> ok;               %% expand_arg,  no assigns
-    _ -> ER = E#{context := nil} %% expand_each, revert assigns
+  ER = case E of
+    {EExtracted, _} -> EExtracted;        %% expand_arg,  no assigns
+    _               -> E#{context := nil} %% expand_each, revert assigns
   end,
 
   ERight = expand_bit_info(Meta, Right, ER),

--- a/lib/elixir/src/elixir_interpolation.erl
+++ b/lib/elixir/src/elixir_interpolation.erl
@@ -196,9 +196,9 @@ unescape_map(E)  -> E.
 % Extract Helpers
 
 finish_extraction(Line, Column, Buffer, Output, Remaining) ->
-  case build_string(Line, Buffer, Output) of
-    []    -> Final = [<<>>];
-    Final -> []
+  Final = case build_string(Line, Buffer, Output) of
+    [] -> [<<>>];
+    F  -> F
   end,
 
   {Line, Column, lists:reverse(Final), Remaining}.

--- a/lib/elixir/src/elixir_translator.erl
+++ b/lib/elixir/src/elixir_translator.erl
@@ -105,12 +105,12 @@ translate({'try', Meta, [Clauses]}, S) ->
   Catch = [Tuple || {X, _} = Tuple <- Clauses, X == 'rescue' orelse X == 'catch'],
   {TCatch, SC} = elixir_try:clauses(Meta, Catch, mergec(SN, SB)),
 
-  case lists:keyfind('after', 1, Clauses) of
+  {TAfter, SA} = case lists:keyfind('after', 1, Clauses) of
     {'after', After} ->
-      {TBlock, SA} = translate(After, mergec(SN, SC)),
-      TAfter = unblock(TBlock);
+      {TBlock, SAExtracted} = translate(After, mergec(SN, SC)),
+      {unblock(TBlock), SAExtracted};
     false ->
-      {TAfter, SA} = {[], mergec(SN, SC)}
+      {[], mergec(SN, SC)}
   end,
 
   Else = elixir_clauses:get_pairs(else, Clauses, match),


### PR DESCRIPTION
Some erlang code were emiting a warning message when some
variables were defined inside the case statement.