### PR TITLE
Clarify arguments to Supervisor.start_child/2.

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -345,10 +345,11 @@ defmodule Supervisor do
   is a `:simple_one_for_one` supervisor, see below). The child process will
   be started as defined in the child specification.
 
-  In the case of `:simple_one_for_one`, the child specification defined in
-  the supervisor is used and instead of a `child_spec`, an arbitrary list
-  of terms is expected. The child process will then be started by appending
-  the given list to the existing function arguments in the child specification.
+  In the case of `:simple_one_for_one`, the child specification defined in the
+  supervisor is used and instead of a `child_spec`, an arbitrary, non-empty
+  list of terms is expected. The child process will then be started by
+  appending the given list to the existing function arguments in the child
+  specification.
 
   If a child specification with the specified id already exists, `child_spec` is
   discarded and this function returns an error with `:already_started` or


### PR DESCRIPTION
While the current doc's language - i.e., `arbitrary list of terms` -
implies that the second argument to `Supervisor.start_child/2` should
should not be an empty list, this restriction can be made clearer and
help avoid confusion.