### PR TITLE
Link `Erlang's term ordering` references to the Erlang documentation

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1338,7 +1338,7 @@ defmodule Enum do
 
   @doc """
   Returns the maximal element in the enumerable according
-  to Erlang's term ordering.
+  to [Erlang's term ordering](http://erlang.org/doc/reference_manual/expressions.html#id81064).
 
   If multiple elements are considered maximal, the first one that was found
   is returned.
@@ -1434,7 +1434,7 @@ defmodule Enum do
 
   @doc """
   Returns the minimal element in the enumerable according
-  to Erlang's term ordering.
+  to [Erlang's term ordering](http://erlang.org/doc/reference_manual/expressions.html#id81064).
 
   If multiple elements are considered minimal, the first one that was found
   is returned.
@@ -1492,7 +1492,7 @@ defmodule Enum do
 
   @doc """
   Returns a tuple with the minimal and the maximal elements in the
-  enumerable according to Erlang's term ordering.
+  enumerable according to [Erlang's term ordering](http://erlang.org/doc/reference_manual/expressions.html#id81064).
 
   If multiple elements are considered maximal or minimal, the first one
   that was found is returned.
@@ -2069,7 +2069,7 @@ defmodule Enum do
   end
 
   @doc """
-  Sorts the enumerable according to Erlang's term ordering.
+  Sorts the enumerable according to [Erlang's term ordering](http://erlang.org/doc/reference_manual/expressions.html#id81064).
 
   Uses the merge sort algorithm.
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -503,7 +503,7 @@ defmodule Kernel do
 
   @doc """
   Returns the biggest of the two given terms according to
-  Erlang's term ordering. If the terms compare equal, the
+  [Erlang's term ordering](http://erlang.org/doc/reference_manual/expressions.html#id81064). If the terms compare equal, the
   first one is returned.
 
   Inlined by the compiler.
@@ -523,7 +523,7 @@ defmodule Kernel do
 
   @doc """
   Returns the smallest of the two given terms according to
-  Erlang's term ordering. If the terms compare equal, the
+  [Erlang's term ordering](http://erlang.org/doc/reference_manual/expressions.html#id81064). If the terms compare equal, the
   first one is returned.
 
   Inlined by the compiler.


### PR DESCRIPTION
Yesterday I was looking for more information about the behavior of `Enum.sort` when it comes to `Map` constructs but the Elixir documentation only refers to _Erlang's term ordering_. 

Short story, asked on Slack channel and someone pointed me to the following section in the Erlang documentation: [http://erlang.org/doc/reference_manual/expressions.html#id81064](http://erlang.org/doc/reference_manual/expressions.html#id81064).

In order to help future newbies like me, I thought I would help by contributing this small improvements to the documentation of `Enum` and `Kernel`. (The only two modules that I found that refers to this concept.)

Let me know!