### PR TITLE
Improve Task.Supervisor docs

### DIFF
--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -5,7 +5,8 @@ defmodule Task.Supervisor do
   This module defines a supervisor which can be used to dynamically
   supervise tasks. Behind the scenes, this module is implemented as a
   `:simple_one_for_one` supervisor where the workers are temporary
-  (i.e. they are not restarted after they die).
+  (i.e. they are not restarted if they exit with reason `:normal`,
+  `:shutdown` or `{:shutdown, term}`).
 
   See the `Task` module for more information.
 


### PR DESCRIPTION
The phrase *they are not restarted after they die* can led someone that do not have the `simple_one_for_one` restart rules already in his head to think that Task.Supervisor **never** restarts its children (a confusion that just happened to me; I had to look at Supervisor module and check the `simple_one_for_one` restart rules).

So I think making this explicit may be helpful to others in the future.