### PR TITLE
Add light foreground and background colors to IO.ANSI

### DIFF
--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -135,8 +135,14 @@ defmodule IO.ANSI do
     @doc "Sets foreground color to #{color}."
     defsequence color, code + 30
 
+    @doc "Sets foreground color to light #{color}."
+    defsequence :"light_#{color}", code + 90
+
     @doc "Sets background color to #{color}."
     defsequence :"#{color}_background", code + 40
+
+    @doc "Sets background color to light #{color}."
+    defsequence :"light_#{color}_background", code + 100
   end
 
   @doc "Default text color."

--- a/lib/elixir/test/elixir/io/ansi_test.exs
+++ b/lib/elixir/test/elixir/io/ansi_test.exs
@@ -97,6 +97,14 @@ defmodule IO.ANSITest do
     end
   end
 
+  test "colors" do
+    assert IO.ANSI.red       == "\e[31m"
+    assert IO.ANSI.light_red == "\e[91m"
+
+    assert IO.ANSI.red_background       == "\e[41m"
+    assert IO.ANSI.light_red_background == "\e[101m"
+  end
+
   test "color/1" do
     assert IO.ANSI.color(0) == "\e[38;5;0m"
     assert IO.ANSI.color(42) == "\e[38;5;42m"


### PR DESCRIPTION
I added a very basic spec, as well. I didn't see where these values were being tested explicitly, if they are.

If this can be merged, it might be nice to convert some of the warnings (I'm looking at mix, in particular) from `[:red, :bright]`, which is essentially bold light red to `[:light_red]`, which is... light red and seems more appropriate.

I would be more than happy to help with that work, as well, should you wish for it to be done.