### PR TITLE
Add documentation: `Enum.random` accepting ranges

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1653,6 +1653,10 @@ defmodule Enum do
   It assumes that the sample being returned can fit into memory;
   the input `enumerable` doesn't have to, as it is traversed just once.
 
+  If a range is passed into the function, this function will pick a
+  random value between the range limits, without traversing the whole
+  range (thus executing in constant time and constant memory).
+
   ## Examples
 
       # Although not necessary, let's seed the random algorithm
@@ -1661,6 +1665,8 @@ defmodule Enum do
       2
       iex> Enum.random([1, 2, 3])
       1
+      iex> Enum.random(1..1_000)
+      776
 
   """
   @spec random(t) :: element | no_return


### PR DESCRIPTION
Based on
https://hashrocket.com/blog/posts/the-adventures-of-generating-random-numbers-in-erlang-and-elixir

There was no documentation about `Enum.random` accepting ranges and that it will not expand the range so it is safe to pass something like `Enum.random(1..100_000)`. This PR adds this documentation as well as a doctest.