### PR TITLE
Add info about protocols in the i/1 IEx Helpers

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -429,7 +429,10 @@ defmodule IEx.Helpers do
 
   """
   def i(term) do
-    info = ["Term": inspect(term)] ++ IEx.Info.info(term)
+    info =
+      ["Term": inspect(term)] ++
+      IEx.Info.info(term) ++
+      ["Implemented protocols": all_implemented_protocols_for_term(term)]
 
     for {subject, info} <- info do
       info = info |> to_string() |> String.trim() |> String.replace("\n", "\n  ")
@@ -438,6 +441,17 @@ defmodule IEx.Helpers do
     end
 
     dont_display_result()
+  end
+
+  # Given any "term", this function returns all the protocols in
+  # :code.get_path() implemented by the data structure of such term, in the form
+  # of a binary like "Protocol1, Protocol2, Protocol3".
+  defp all_implemented_protocols_for_term(term) do
+    :code.get_path()
+    |> Protocol.extract_protocols()
+    |> Enum.uniq()
+    |> Enum.reject(fn(protocol) -> is_nil(protocol.impl_for(term)) end)
+    |> Enum.map_join(", ", &inspect/1)
   end
 
   @doc """

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -35,13 +35,27 @@ defimpl IEx.Info, for: Atom do
       end
 
     mod_info = mod.module_info()
-    ["Module bytecode": module_object_file(mod),
-     "Source": module_source_file(mod_info),
-     "Version": module_version(mod_info),
-     "Compile options": module_compile_options(mod_info),
-     "Description": "#{extra}Call #{inspect mod}.module_info() to access metadata.",
-     "Raw representation": ":" <> inspect(Atom.to_string(mod)),
-     "Reference modules": "Module, Atom"]
+    generic_info =
+      ["Module bytecode": module_object_file(mod),
+       "Source": module_source_file(mod_info),
+       "Version": module_version(mod_info),
+       "Compile options": module_compile_options(mod_info),
+       "Description": "#{extra}Call #{inspect mod}.module_info() to access metadata."]
+
+    specific_info =
+      if function_exported?(mod, :__protocol__, 1) do
+        impls =
+          mod
+          |> Protocol.extract_impls(:code.get_path())
+          |> Enum.map_join(", ", &inspect/1)
+        ["Protocol": "This module is a protocol. These data structures implement it:\n  #{impls}"]
+      else
+        []
+      end
+
+    generic_info ++ specific_info ++
+      ["Raw representation": ":" <> inspect(Atom.to_string(mod)),
+       "Reference modules": "Module, Atom"]
   end
 
   defp info_module_like_atom(atom) do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -493,7 +493,7 @@ defmodule IEx.HelpersTest do
 
   test "i helper" do
     output = capture_iex ~s[i(:ok)]
-    assert output == String.trim_trailing("""
+    assert output =~ String.trim_trailing("""
     Term
       :ok
     Data type

--- a/lib/iex/test/iex/info_test.exs
+++ b/lib/iex/test/iex/info_test.exs
@@ -29,6 +29,14 @@ defmodule IEx.InfoTest do
     assert info[:"Description"] == description
   end
 
+  test "atoms: module that is also a protocol" do
+    info = Info.info(String.Chars)
+    description = info[:"Protocol"]
+    assert description =~ "This module is a protocol"
+    assert description =~ "Atom"
+    assert description =~ "BitString"
+  end
+
   test "atoms: module-like atom (Foo)" do
     info = Info.info(NonexistentModuleAtom)
     assert info[:"Raw representation"] == ~s(:"Elixir.NonexistentModuleAtom")


### PR DESCRIPTION
With this PR, we show info about the protocols that a given data structure implements and in case that data structure is a module that is also a protocol, we show all the data structures that implement that protocols as well.

Opening this really early to get feedback on the feel of it and especially on how we find the protocols that a given data structure implements. I noticed that, as far as I can tell, using `Protocol.extract_protocols/1` + `Protocol.extract_impls/2` doesn't pick up protocols defined on the fly in the shell, but I may be getting something wrong or we may not care about this :)

Wdyt roughly? Style and implementation details will be refined before merging btw :)