### PR TITLE
Fix precision note in "Operators" doc

### DIFF
--- a/lib/elixir/pages/Operators.md
+++ b/lib/elixir/pages/Operators.md
@@ -67,7 +67,7 @@ The reason we can compare different data types is pragmatism. Sorting algorithms
 number < atom < reference < function < port < pid < tuple < map < list < bitstring
 ```
 
-When comparing two numbers of different types (a number is either an integer or a float), a conversion to the type with lesser precision will always occur, unless the comparison operator used is either `===` or `!==`. A float will be considered more precise than an integer, unless the float is greater/less than +/-9007199254740992.0, at which point all the significant figures of the float are to the left of the decimal point. This behavior exists so that the comparison of large numbers remains transitive.
+When comparing two numbers of different types (a number is either an integer or a float), a conversion to the type with greater precision will always occur, unless the comparison operator used is either `===` or `!==`. A float will be considered more precise than an integer, unless the float is greater/less than +/-9007199254740992.0, at which point all the significant figures of the float are to the left of the decimal point. This behavior exists so that the comparison of large numbers remains transitive.
 
 The collection types are compared using the following rules:
 


### PR DESCRIPTION
The current wording implies that e.g. `3.3` will be converted to `3`, which isn't the case.