### PR TITLE
Piping assertions

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -757,6 +757,12 @@ defmodule ExUnit.Assertions do
     refute diff < delta, message
   end
 
+  defmacro assert_equal(value1, value2) do
+    quote do
+      assert(unquote(value1) == unquote(value2))
+    end
+  end
+
   @doc """
   Fails with a message.
 

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -763,6 +763,12 @@ defmodule ExUnit.Assertions do
     end
   end
 
+  defmacro assert_match(value1, value2) do
+    quote do
+      assert(unquote(value2) = unquote(value1)) 
+    end
+  end
+
   @doc """
   Fails with a message.
 

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -679,6 +679,20 @@ defmodule ExUnit.AssertionsTest do
     assert_equal(1,1)
   end
 
+  test "assert_match" do
+    try do
+      assert_match(%{foo: 1, bar: 2},%{foo: 2})
+    rescue
+      error in [ExUnit.AssertionError] ->
+        "%{foo: 2} = %{foo: 1, bar: 2}" = error.expr |> Macro.to_string
+        "match (=) failed" = error.message
+    end
+  end
+
+  test "assert_match with match" do
+     assert_match(%{foo: 1, bar: 2},%{foo: 1})
+  end
+
 
   defp ok(val), do: {:ok, val}
   defp error(val), do: {:error, val}

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -665,6 +665,21 @@ defmodule ExUnit.AssertionsTest do
       """ = Exception.message(error)
   end
 
+  test "assert_equal with non-equality" do
+    try do
+      assert_equal(1,2)
+    rescue
+      error in [ExUnit.AssertionError] ->
+        "1 == 2" = error.expr |> Macro.to_string
+        "Assertion with == failed" = error.message
+    end
+  end
+
+  test "assert_equal with equality" do
+    assert_equal(1,1)
+  end
+
+
   defp ok(val), do: {:ok, val}
   defp error(val), do: {:error, val}
 end


### PR DESCRIPTION
Hello all,

I know we can do great assertions with native operators. However often I'm using the pipe operator to chain functions together to come to certain result. Then usually I save the result, and test it.

I think in this use case a better developer experience is to be able to pipe that result directly to an assertion.

That's why in the following pull request I created two new macros:

`assert_equal` you can pipe the result directly into this function and assert if the it is the expected value.

`assert_match` you can pipe the result into this and see if it matches a pattern.

Hope this makes my case, when more explanation is needed I'm happy to respond!