### PR TITLE
Fix typespec for Mix.ProjectStack.project()

### DIFF
--- a/lib/mix/lib/mix/project_stack.ex
+++ b/lib/mix/lib/mix/project_stack.ex
@@ -5,7 +5,7 @@ defmodule Mix.ProjectStack do
 
   @typep file    :: binary
   @typep config  :: Keyword.t
-  @typep project :: {module, config, file}
+  @typep project :: %{name: module, config: config, file: file}
 
   @spec start_link :: {:ok, pid}
   def start_link() do


### PR DESCRIPTION
#### What does this PR do?

Fixes typespec for Mix.ProjectStack.project()

#### Where should the reviewer start?

[This type is a tuple](https://github.com/elixir-lang/elixir/blob/v1.3.3/lib/mix/lib/mix/project_stack.ex#L8):

```
@typep project :: {module, config, file}
```

[This method returns a map](https://github.com/elixir-lang/elixir/blob/v1.3.3/lib/mix/lib/mix/project_stack.ex#L65):

```
@spec peek() :: project | nil
def peek do
  get fn %{stack: stack} ->
    case stack do
      [h | _] -> take(h)
      [] -> nil
    end
  end
end
```

#### How should this be manually tested?

Easiest would be to clone this project => [ProjectStackTypespec](https://github.com/amorphid/project_stack_typespec)

```
$ git clone git@github.com:amorphid/project_stack_typespec.git
$ cd project_stack_typespec
$ mix deps.get
$ mix dialyzer.plt
$ mix dialyzer

  Starting Dialyzer...
  ...
  example.ex:8: The pattern _stack@1 = #{'config':=_config@1, 'name':=_, 'file':=_} can never match the type 'nil' | {atom(),[{atom(),_}],binary()}
  ...

```
