### PR TITLE
Fixes a silly typo in the docs

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -268,7 +268,7 @@ defmodule GenServer do
   """
 
   @doc """
-  Invoked when the server is started. `start_link/3` (or `start/3` ) will
+  Invoked when the server is started. `start_link/3` or `start/3` will
   block until it returns.
 
   `args` is the argument term (second argument) passed to `start_link/3`.

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -268,7 +268,7 @@ defmodule GenServer do
   """
 
   @doc """
-  Invoked when the server is started. `start_link/3` (or `start/3`) will
+  Invoked when the server is started. `start_link/3` (or `start/3` ) will
   block until it returns.
 
   `args` is the argument term (second argument) passed to `start_link/3`.


### PR DESCRIPTION
The "(or `start/3`)" bit in the gen_server docs broke both the `)` from
showing up in the HTML, and the `start/3` link from working correctly.
Adding a space "(or `start/3` )" fixes both of those problems.