### PR TITLE
More helpful error message when Process.register/2 fails

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -421,6 +421,12 @@ defmodule Process do
   @spec register(pid | port, atom) :: true
   def register(pid, name) when not name in [nil, false, true] and is_atom(name) do
     :erlang.register(name, pid)
+  catch
+    :error, :badarg ->
+      message = "could not register the process #{inspect pid} with" <>
+        " name #{inspect name}. Or the process is not alive, or the" <>
+        " name is already taken, or the process has already been named"
+      :erlang.error ArgumentError.exception(message), [pid, name]
   end
 
   @doc """


### PR DESCRIPTION
Hey :wave:

This PR improves the error message displayed when call to `Process.register/2` fails for any reason.

Currently the error is:

```
iex(2)> Process.register(self(), :test)
** (ArgumentError) argument error
             :erlang.register(:test, #PID<0.170.0>)
    (elixir) lib/process.ex:414: Process.register/2
```

The new message is as follows:

```
iex(2)> Process.register(self(), :test)
** (ArgumentError) could not register the process #PID<0.81.0> with name :test. Or the process is not alive, or the name is already taken, or the process has already been named
    (elixir) lib/process.ex:429: Process.register(#PID<0.81.0>, :test)
```

Detailed conversation about the different error cases can be found in PR #5278 

Thanks,
Ville