### PR TITLE
Fix Dialyzer warnings on protocol calls with opaque arguments

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -451,6 +451,16 @@ defmodule Protocol do
         end
       end, builtin)
 
+      # Define a catch-all impl_for/1 clause to pacify Dialyzer (since
+      # destructuring opaque types is illegal, Dialyzer will think none of the
+      # previous clauses matches opaque types, and without this clause, will
+      # conclude that impl_for can't handle an opaque argument). This is a hack
+      # since it relies on Dialyzer not being smart enough to conclude that all
+      # opaque types will get the any_impl_for/0 implementation.
+      Kernel.def impl_for(_) do
+        any_impl_for()
+      end
+
       @doc false
       @spec impl_for!(term) :: atom | no_return
       Kernel.def impl_for!(data) do

--- a/lib/elixir/test/elixir/fixtures/dialyzer/protocol_opaque.ex
+++ b/lib/elixir/test/elixir/fixtures/dialyzer/protocol_opaque.ex
@@ -1,0 +1,21 @@
+defmodule Dialyzer.ProtocolOpaque do
+  def circus() do
+    Dialyzer.ProtocolOpaque.Entity.speak(Dialyzer.ProtocolOpaque.Duck.new)
+  end
+end
+
+defprotocol Dialyzer.ProtocolOpaque.Entity do
+  def speak(entity)
+end
+
+defmodule Dialyzer.ProtocolOpaque.Duck do
+  @opaque t :: %__MODULE__{}
+  defstruct feathers: :white_and_grey
+
+  @spec new :: t
+  def new(), do: %__MODULE__{}
+
+  defimpl Dialyzer.ProtocolOpaque.Entity do
+    def speak(%Dialyzer.ProtocolOpaque.Duck{}), do: "Quack!"
+  end
+end

--- a/lib/elixir/test/elixir/kernel/dialyzer_test.exs
+++ b/lib/elixir/test/elixir/kernel/dialyzer_test.exs
@@ -80,6 +80,13 @@ defmodule Kernel.DialyzerTest do
     assert_dialyze_no_warnings! context
   end
 
+  test "no warnings on protocol calls with opaque types", context do
+    copy_beam! context, Dialyzer.ProtocolOpaque
+    copy_beam! context, Dialyzer.ProtocolOpaque.Entity
+    copy_beam! context, Dialyzer.ProtocolOpaque.Duck
+    assert_dialyze_no_warnings! context
+  end
+
   defp copy_beam!(context, module) do
     name = "#{module}.beam"
     File.cp! Path.join(context[:base_dir], name),


### PR DESCRIPTION
Prior to this change, calling a protocol function with an opaque type would yield a warning, as Dialyzer concludes that the `impl_for/1` function can't handle opaque arguments, since all clauses would destructure their arguments in some way.

By adding a catch-all clause that does not destructure its argument, Dialyzer no longer draws this conclusion, and the warnings go away.

As noted in the protocol.ex comment, this is technically a hack as it relies on Dialyzer not being smart enough. However, I would not expect it to break soon, if ever.

Of course, there is a non-hacky way of solving this problem, which is to not declare any type that implements a protocol as opaque in the first place. However, I believe the Elixir team will agree that such a restriction is undesirable.