### PR TITLE
Implement Stream.zip/1 and Enum.zip/1

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2625,7 +2625,30 @@ defmodule Enum do
   end
 
   def zip(enumerable1, enumerable2) do
-    Stream.zip(enumerable1, enumerable2).({:cont, []}, &{:cont, [&1 | &2]})
+    zip([enumerable1, enumerable2])
+  end
+
+  @doc """
+  Zips corresponding elements from a collection of enumerables
+  into one list of tuples.
+
+  The zipping finishes as soon as any enumerable completes.
+
+  ## Examples
+
+      iex> Enum.zip([[1, 2, 3], [:a, :b, :c], ["foo", "bar", "baz"]])
+      [{1, :a, "foo"}, {2, :b, "bar"}, {3, :c, "baz"}]
+
+      iex> Enum.zip([[1, 2, 3, 4, 5], [:a, :b, :c]])
+      [{1, :a}, {2, :b}, {3, :c}]
+
+  """
+  @spec zip([t]) :: t
+
+  def zip([]), do: []
+
+  def zip(enumerables) do
+    Stream.zip(enumerables).({:cont, []}, &{:cont, [&1 | &2]})
     |> elem(1)
     |> :lists.reverse
   end

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1015,9 +1015,7 @@ defmodule Stream do
   def zip(enumerables) do
     step      = &do_zip_step(&1, &2)
     enum_funs = enumerables
-    |> map(fn enum -> &Enumerable.reduce(enum, &1, step) end)
-    |> map(fn enum_fun -> {enum_fun, :cont} end)
-    |> Enum.to_list
+    |> Enum.map(fn enum -> {&Enumerable.reduce(enum, &1, step), :cont} end)
 
     &do_zip(enum_funs, &1, &2)
   end

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1014,8 +1014,9 @@ defmodule Stream do
   @spec zip([Enumerable.t]) :: Enumerable.t
   def zip(enumerables) do
     step      = &do_zip_step(&1, &2)
-    enum_funs = enumerables
-    |> Enum.map(fn enum -> {&Enumerable.reduce(enum, &1, step), :cont} end)
+    enum_funs = Enum.map(enumerables, fn enum ->
+      {&Enumerable.reduce(enum, &1, step), :cont}
+    end)
 
     &do_zip(enum_funs, &1, &2)
   end

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -766,6 +766,7 @@ defmodule EnumTest do
     assert Enum.zip([[:a, :b], [1, 2, 3, 4], ["foo", "bar", "baz", "qux"]]) == [{:a, 1, "foo"}, {:b, 2, "bar"}]
     assert Enum.zip([[:a, :b, :c, :d], [1, 2], ["foo", "bar", "baz", "qux"]]) == [{:a, 1, "foo"}, {:b, 2, "bar"}]
     assert Enum.zip([[:a, :b, :c, :d], [1, 2, 3, 4], ["foo", "bar"]]) == [{:a, 1, "foo"}, {:b, 2, "bar"}]
+    assert Enum.zip([1..10, ["foo", "bar"]]) == [{1, "foo"}, {2, "bar"}]
 
     assert Enum.zip([]) == []
     assert Enum.zip([[]]) == []

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -760,6 +760,19 @@ defmodule EnumTest do
     assert Enum.zip([1], []) == []
     assert Enum.zip([], [])  == []
   end
+
+  test "zip/1" do
+    assert Enum.zip([[:a, :b], [1, 2], ["foo", "bar"]]) == [{:a, 1, "foo"}, {:b, 2, "bar"}]
+    assert Enum.zip([[:a, :b], [1, 2, 3, 4], ["foo", "bar", "baz", "qux"]]) == [{:a, 1, "foo"}, {:b, 2, "bar"}]
+    assert Enum.zip([[:a, :b, :c, :d], [1, 2], ["foo", "bar", "baz", "qux"]]) == [{:a, 1, "foo"}, {:b, 2, "bar"}]
+    assert Enum.zip([[:a, :b, :c, :d], [1, 2, 3, 4], ["foo", "bar"]]) == [{:a, 1, "foo"}, {:b, 2, "bar"}]
+
+    assert Enum.zip([]) == []
+    assert Enum.zip([[]]) == []
+    assert Enum.zip([[1]]) == [{1}]
+
+    assert Enum.zip([[], [], [], []])  == []
+  end
 end
 
 defmodule EnumTest.Range do

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -925,6 +925,13 @@ defmodule StreamTest do
            [a: {:tea, 2}, c: {:coffee, 1}]
   end
 
+  test "zip/2" do
+    concat = Stream.concat(1..3, 4..6)
+    cycle  = Stream.cycle([:a, :b, :c])
+    assert Stream.zip(concat, cycle) |> Enum.to_list ==
+           [{1, :a}, {2, :b}, {3, :c}, {4, :a}, {5, :b}, {6, :c}]
+  end
+
   test "zip/1" do
     concat = Stream.concat(1..3, 4..6)
     cycle  = Stream.cycle([:a, :b, :c])

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -925,50 +925,49 @@ defmodule StreamTest do
            [a: {:tea, 2}, c: {:coffee, 1}]
   end
 
-  test "zip/2" do
+  test "zip/1" do
     concat = Stream.concat(1..3, 4..6)
     cycle  = Stream.cycle([:a, :b, :c])
-    assert Stream.zip(concat, cycle) |> Enum.to_list ==
+    assert Stream.zip([concat, cycle]) |> Enum.to_list ==
            [{1, :a}, {2, :b}, {3, :c}, {4, :a}, {5, :b}, {6, :c}]
   end
 
-  test "zip/2 does not leave streams suspended" do
+  test "zip/1 does not leave streams suspended" do
     stream = Stream.resource(fn -> 1 end,
                              fn acc -> {[acc], acc + 1} end,
                              fn _ -> Process.put(:stream_zip, true) end)
 
     Process.put(:stream_zip, false)
-    assert Stream.zip([:a, :b, :c], stream) |> Enum.to_list == [a: 1, b: 2, c: 3]
+    assert Stream.zip([[:a, :b, :c], stream]) |> Enum.to_list == [a: 1, b: 2, c: 3]
     assert Process.get(:stream_zip)
 
     Process.put(:stream_zip, false)
-    assert Stream.zip(stream, [:a, :b, :c]) |> Enum.to_list == [{1, :a}, {2, :b}, {3, :c}]
+    assert Stream.zip([stream, [:a, :b, :c]]) |> Enum.to_list == [{1, :a}, {2, :b}, {3, :c}]
     assert Process.get(:stream_zip)
   end
 
-  test "zip/2 does not leave streams suspended on halt" do
+  test "zip/1 does not leave streams suspended on halt" do
     stream = Stream.resource(fn -> 1 end,
                              fn acc -> {[acc], acc + 1} end,
                              fn _ -> Process.put(:stream_zip, :done) end)
 
-    assert Stream.zip([:a, :b, :c, :d, :e], stream) |> Enum.take(3) ==
+    assert Stream.zip([[:a, :b, :c, :d, :e], stream]) |> Enum.take(3) ==
            [a: 1, b: 2, c: 3]
 
     assert Process.get(:stream_zip) == :done
   end
 
-  test "zip/2 closes on inner error" do
+  test "zip/1 closes on inner error" do
     stream = Stream.into([1, 2, 3], %Pdict{})
-    stream = Stream.zip(stream, Stream.map([:a, :b, :c], fn _ -> throw(:error) end))
+    stream = Stream.zip([stream, Stream.map([:a, :b, :c], fn _ -> throw(:error) end)])
 
     Process.put(:stream_done, false)
     assert catch_throw(Enum.to_list(stream)) == :error
     assert Process.get(:stream_done)
   end
 
-  test "zip/2 closes on outer error" do
-    stream = Stream.into([1, 2, 3], %Pdict{})
-             |> Stream.zip([:a, :b, :c])
+  test "zip/1 closes on outer error" do
+    stream = Stream.zip([Stream.into([1, 2, 3], %Pdict{}), [:a, :b, :c]])
              |> Stream.map(fn _ -> throw(:error) end)
 
     Process.put(:stream_done, false)


### PR DESCRIPTION
Similar to the corresponding `zip/2` functions, except allows any number of
input enumerables.

Based on a [suggestion by José](https://groups.google.com/d/msg/phoenix-core/2EWFCMYxDBk/KLRWbYOEBQAJ) on the phoenix-core mailing list.