### PR TITLE
ExUnit includes tests when configured with [include: :skip]

### DIFF
--- a/lib/ex_unit/test/ex_unit/filters_test.exs
+++ b/lib/ex_unit/test/ex_unit/filters_test.exs
@@ -24,6 +24,8 @@ defmodule ExUnit.FiltersTest do
     assert ExUnit.Filters.eval([], [], %{skip: true}, []) == {:error, "due to skip tag"}
     assert ExUnit.Filters.eval([], [], %{skip: "skipped"}, []) == {:error, "skipped"}
     assert ExUnit.Filters.eval([], [:os], %{skip: "skipped"}, []) == {:error, "skipped"}
+    assert ExUnit.Filters.eval([:skip], [], %{skip: true}, []) == :ok
+    assert ExUnit.Filters.eval([:skip], [], %{skip: "skipped"}, []) == :ok
   end
 
   test "evaluating filters matches integers" do


### PR DESCRIPTION
Currently any tests tagged with `@tag :skip` will be skipped even if ExUnit is configured with `[include: :skip]`.

For instance:

```
ExUnit.configure include: :skip

@tag :skip
test "never run" do
  raise "oops"
end
```

Produces:

```bash
Including tags: [:skip]

Finished in 0.05 seconds
1 test, 0 failures, 1 skipped
```

This seems confusing. I have changed the behavior in this PR to allow skipped tests to be included. However, if that is not the desired behavior then I would suggest at least emitting a warning instead of erroneously emitting `Including tags: [:skip]`. I'd be happy to make that change. Let me know. Thanks.

P.S. I do have a valid use case for this behavior which lead me to discover the issue. I'd be happy to elaborate if you need more information.


