### PR TITLE
Add tuple to Access.t

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -136,7 +136,7 @@ defmodule Access do
 
   """
 
-  @type t :: list | map | nil
+  @type t :: list | map | nil | any
   @type key :: any
   @type value :: any
 


### PR DESCRIPTION
The following clearly works:

```elixir
iex(1)> get_in({nil, %{a: :b}}, [Access.elem(1), :a])
:b
```

However code like this fails to dialyze, due to `tuple` not being an allowed alternative in `Access.t`.