### PR TITLE
Add/correct arities (part 3)

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -26,7 +26,7 @@ defmodule Application do
   Once an application is started, OTP provides an application environment
   that can be used to configure the application.
 
-  Assuming you are inside a Mix project, you can edit the `application`
+  Assuming you are inside a Mix project, you can edit the `application/0`
   function in the `mix.exs` file to the following:
 
       def application do

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -206,7 +206,7 @@ defmodule Enum do
 
   @doc """
   Returns true if the given `fun` evaluates to true on all of the items in the enumerable.
-  
+
   It stops the iteration at the first invocation that returns `false` or `nil`.
 
   ## Examples
@@ -244,7 +244,7 @@ defmodule Enum do
 
   @doc """
   Returns true if the given `fun` evaluates to true on any of the items in the enumerable.
-  
+
   It stops the iteration at the first invocation that returns a truthy value (not `false` or `nil`).
 
   ## Examples
@@ -2128,10 +2128,10 @@ defmodule Enum do
   end
 
   @doc """
-  Sorts the mapped results of the enumerable according to the `sorter`
+  Sorts the mapped results of the enumerable according to the provided `sorter`
   function.
 
-  This function maps each element of the enumerable using the `mapper`
+  This function maps each element of the enumerable using the provided `mapper`
   function.  The enumerable is then sorted by the mapped elements
   using the `sorter` function, which defaults to `Kernel.<=/2`
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -7,7 +7,7 @@ defmodule Exception do
   `System.stacktrace/0` will return the stacktrace for the
   last throw/error/exit that occurred in the current process.
 
-  Do not rely on the particular format returned by the `format`
+  Do not rely on the particular format returned by the `format*`
   functions in this module. They may be changed in future releases
   in order to better suit Elixir's tool chain. In other words,
   by using the functions in this module it is guaranteed you will

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1210,7 +1210,7 @@ defmodule File do
   in raw mode for performance reasons. Therefore, Elixir **will** open
   streams in `:raw` mode with the `:read_ahead` option unless an encoding
   is specified. This means any data streamed into the file must be
-  converted to `iodata` type. If you pass `[:utf8]` in the modes parameter,
+  converted to `t:iodata/0` type. If you pass `[:utf8]` in the modes parameter,
   the underlying stream will use `IO.write/2` and the `String.Chars` protocol
   to convert the data. See `IO.binwrite/2` and `IO.write/2` .
 

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -27,7 +27,7 @@ defprotocol Inspect do
         end
       end
 
-  The `concat` function comes from `Inspect.Algebra` and it
+  The `concat/1` function comes from `Inspect.Algebra` and it
   concatenates algebra documents together. In the example above,
   it is concatenating the string `"MapSet<"` (all strings are
   valid algebra documents that keep their formatting when pretty

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1844,7 +1844,7 @@ defmodule Kernel do
   accordingly (be it by failing or providing a sane default).
 
   The `Access` module ships with many convenience accessor functions,
-  like the `all` function defined above. See `Access.all/0`,
+  like the `all` anonymous function defined above. See `Access.all/0`,
   `Access.key/2` and others as examples.
   """
   @spec get_and_update_in(Access.t, nonempty_list(term),

--- a/lib/elixir/lib/list/chars.ex
+++ b/lib/elixir/lib/list/chars.ex
@@ -5,7 +5,7 @@ defprotocol List.Chars do
   The only function required to be implemented is
   `to_charlist` which does the conversion.
 
-  The `to_charlist` function automatically imported
+  The `to_charlist/1` function automatically imported
   by `Kernel` invokes this protocol.
   """
 

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -503,7 +503,7 @@ defmodule Macro do
       def unescape_map(?u), do: true
       def unescape_map(e),  do: e
 
-  If the `unescape_map` function returns `false`. The char is
+  If the `unescape_map/1` function returns `false`. The char is
   not escaped and the backslash is kept in the string.
 
   Hexadecimals and Unicode codepoints will be escaped if the map
@@ -512,7 +512,7 @@ defmodule Macro do
 
   ## Examples
 
-  Using the `unescape_map` function defined above is easy:
+  Using the `unescape_map/1` function defined above is easy:
 
       Macro.unescape_string "example\\n", &unescape_map(&1)
 

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -8,7 +8,7 @@ defmodule Module do
   After a module is compiled, using many of the functions in
   this module will raise errors, since it is out of their scope
   to inspect runtime data. Most of the runtime data can be inspected
-  via the `__info__(attr)` function attached to each compiled module.
+  via the `__info__/1` function attached to each compiled module.
 
   ## Module attributes
 

--- a/lib/elixir/lib/string/chars.ex
+++ b/lib/elixir/lib/string/chars.ex
@@ -7,7 +7,7 @@ defprotocol String.Chars do
   The only function required to be implemented is
   `to_string` which does the conversion.
 
-  The `to_string` function automatically imported
+  The `to_string/1` function automatically imported
   by `Kernel` invokes this protocol. String
   interpolation also invokes `to_string` in its
   arguments. For example, `"foo#{bar}"` is the same

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -674,7 +674,7 @@ defmodule System do
   The result is rounded via the floor function.
 
   `convert_time_unit/3` accepts an additional time unit (other than the
-  ones in the `time_unit` type) called `:native`. `:native` is the time
+  ones in the `t:time_unit/0` type) called `:native`. `:native` is the time
   unit used by the Erlang runtime system. It's determined when the runtime
   starts and stays the same until the runtime is stopped. To determine what
   the `:native` unit amounts to in a system, you can call this function to

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -314,7 +314,7 @@ defmodule Task do
 
   It is not recommended to `await` a long-running task inside an OTP
   behaviour such as `GenServer`. Instead, you should match on the message
-  coming from a task inside your `handle_info` callback.
+  coming from a task inside your `GenServer.handle_info/2` callback.
 
   ## Examples
 

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -81,7 +81,7 @@ defmodule Task.Supervisor do
 
   If you create a task using `async_nolink` inside an OTP behaviour
   like `GenServer`, you should match on the message coming from the
-  task inside your `handle_info` callback.
+  task inside your `GenServer.handle_info/2` callback.
 
   The reply sent by the task will be in the format `{ref, result}`,
   where `ref` is the monitor reference held by the task struct

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -255,7 +255,7 @@ defmodule URI do
   @doc """
   Percent-escapes the given string.
 
-  This function accepts a `predicate` function as an optional argument; if
+  This function accepts a predicate function as an optional argument; if
   passed, this function will be called with each character (byte) in `str` as
   its argument and should return `true` if that character should not be escaped
   and left as is.

--- a/lib/elixir/pages/Naming Conventions.md
+++ b/lib/elixir/pages/Naming Conventions.md
@@ -105,4 +105,4 @@ When you see `length`, the operation runs in linear time ("O(n) time") because t
 
 Examples: `Kernel.length/1`, `String.length/1`
 
-In other words, `size` functions will take the same amount of time whether the data structure is tiny or huge. `length` functions will take more time as the data structure grows in size.
+In other words, functions using the word "size" in its name will take the same amount of time whether the data structure is tiny or huge. Conversely, functions having "length" in its name will take more time as the data structure grows in size.

--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -118,7 +118,7 @@ Built-in type           | Defined as
 
 ### Remote types
 
-Any module is also able to define its own types and the modules in Elixir are no exception. For example, the `Range` module defines a `t` type that represents a range: this type can be referred to as `Range.t`. In a similar fashion, a string is `String.t`, any enumerable can be `Enum.t`, and so on.
+Any module is also able to define its own types and the modules in Elixir are no exception. For example, the `Range` module defines a `t/0` type that represents a range: this type can be referred to as `t:Range.t/0`. In a similar fashion, a string is `t:String.t/0`, any enumerable can be `t:Enum.t/0`, and so on.
 
 ### Maps
 
@@ -170,6 +170,6 @@ Specifications can be overloaded just like ordinary functions.
 
 ## Notes
 
-Elixir discourages the use of type `string` as it might be confused with binaries which are referred to as "strings" in Elixir (as opposed to character lists). In order to use the type that is called `string` in Erlang, one has to use the `charlist` type which is a synonym for `string`. If you use `string`, you'll get a warning from the compiler.
+Elixir discourages the use of type `t:string/0` as it might be confused with binaries which are referred to as "strings" in Elixir (as opposed to character lists). In order to use the type that is called `t:string/0` in Erlang, one has to use the `t:charlist/0` type which is a synonym for `string`. If you use `string`, you'll get a warning from the compiler.
 
-If you want to refer to the "string" type (the one operated on by functions in the `String` module), use `String.t` type instead.
+If you want to refer to the "string" type (the one operated on by functions in the `String` module), use `t:String.t/0` type instead.

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -3,7 +3,7 @@ defmodule ExUnit.Callbacks do
   Defines ExUnit Callbacks.
 
   This module defines both `setup_all` and `setup` callbacks, as well as
-  the `on_exit` facility.
+  the `on_exit/2` facility.
 
   The setup callbacks are defined via macros and each one can optionally
   receive a map with metadata, usually referred to as `context`. The
@@ -14,17 +14,17 @@ defmodule ExUnit.Callbacks do
   test is run and all `setup` callbacks are run before each test. No callback
   runs if the test case has no tests or all tests were filtered out.
 
-  `on_exit` callbacks are registered on demand, usually to undo an action
-  performed by a setup callback. `on_exit` may also take a reference,
-  allowing callback to be overridden in the future. A registered `on_exit`
+  `on_exit/2` callbacks are registered on demand, usually to undo an action
+  performed by a setup callback. `on_exit/2` may also take a reference,
+  allowing callback to be overridden in the future. A registered `on_exit/2`
   callback always runs, while failures in `setup` and `setup_all` will stop
   all remaining setup callbacks from executing.
 
   Finally, `setup_all` callbacks run in the test case process, while all
-  `setup` callbacks run in the same process as the test itself. `on_exit`
+  `setup` callbacks run in the same process as the test itself. `on_exit/2`
   callbacks always run in a separate process than the test case or the
   test itself. Since the test process exits with reason `:shutdown`, most
-  of times `on_exit/1` can be avoided as processes are going to clean
+  of times `on_exit/2` can be avoided as processes are going to clean
   up on their own.
 
   ## Context
@@ -198,11 +198,11 @@ defmodule ExUnit.Callbacks do
   @doc """
   Defines a callback that runs on the test (or test case) exit.
 
-  An `on_exit` callback is a function that receives no arguments and
+  `callback` is a function that receives no arguments and
   runs in a separate process than the caller.
 
   `on_exit/2` is usually called from `setup` and `setup_all` callbacks,
-  often to undo the action performed during `setup`. However, `on_exit`
+  often to undo the action performed during `setup`. However, `on_exit/2`
   may also be called dynamically, where a reference can be used to
   guarantee the callback will be invoked only once.
   """
@@ -211,7 +211,7 @@ defmodule ExUnit.Callbacks do
     case ExUnit.OnExitHandler.add(self(), ref, callback) do
       :ok -> :ok
       :error ->
-        raise ArgumentError, "on_exit/1 callback can only be invoked from the test process"
+        raise ArgumentError, "on_exit/2 callback can only be invoked from the test process"
     end
   end
 

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -80,7 +80,7 @@ defmodule IEx do
       iex(foo@HOST)1>
 
   The string between the parentheses in the prompt is the name
-  of your node. We can retrieve it by calling the `node()`
+  of your node. We can retrieve it by calling the `node/0`
   function:
 
       iex(foo@HOST)1> node()

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -8,14 +8,14 @@ defmodule IEx.Helpers do
   This message was triggered by invoking the helper `h()`,
   usually referred to as `h/0` (since it expects 0 arguments).
 
-  You can use the `h` function to invoke the documentation
+  You can use the `h/1` function to invoke the documentation
   for any Elixir module or function:
 
       h Enum
       h Enum.map
       h Enum.reverse/1
 
-  You can also use the `i` function to introspect any value
+  You can also use the `i/1` function to introspect any value
   you have in the shell:
 
       i "hello"
@@ -48,7 +48,7 @@ defmodule IEx.Helpers do
     * `v/1`           - retrieves the nth value from the history
 
   Help for all of those functions can be consulted directly from
-  the command line using the `h` helper itself. Try:
+  the command line using the `h/1` helper itself. Try:
 
       h(v/0)
 

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Compile.App do
 
   In order to generate the `.app` file, Mix expects your application
   to have both `:app` and `:version` keys. Furthermore, you can
-  configure the generated application by defining an `application`
+  configure the generated application by defining an `application/0`
   function in your `mix.exs` with the following options:
 
     * `:applications` - all applications your application depends
@@ -41,7 +41,7 @@ defmodule Mix.Tasks.Compile.App do
       The application environment is one of the most common ways
       to configure applications.
 
-  Let's see an example `application` function:
+  Let's see an example `application/0` function:
 
       def application do
         [mod: {MyApp, []},

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -46,7 +46,7 @@ defmodule Mix.Tasks.Escript.Build do
 
     * `:embed_elixir` - if `true` embed elixir and its children apps
       (`ex_unit`, `mix`, etc.) mentioned in the `:applications` list inside the
-      `application` function in `mix.exs`.
+      `application/0` function in `mix.exs`.
 
       Defaults to `true` for Elixir projects, `false` for Erlang projects.
 


### PR DESCRIPTION
- Add missing arities to functions, callbacks and types
- ~~Remove backticks from wildcard function references such as in
  "`start*` functions", to use italics instead "_start*_  functions"~~

For posterity, the command used to find out these errors:
```console
$ ag "\`[^ /]+\`\s+(fun|function|callback|type|typespec|helper)"
```