### PR TITLE
Fix ExUnit case when dealing with timeout 0

### DIFF
--- a/lib/ex_unit/lib/ex_unit/on_exit_handler.ex
+++ b/lib/ex_unit/lib/ex_unit/on_exit_handler.ex
@@ -25,7 +25,7 @@ defmodule ExUnit.OnExitHandler do
 
   @spec run(pid, non_neg_integer | :infinity) :: :ok | {Exception.kind, term, Exception.stacktrace}
   def run(pid, timeout) do
-    callbacks = Agent.get_and_update(@name, &Map.pop(&1, pid))
+    callbacks = Agent.get_and_update(@name, &Map.pop(&1, pid, []))
     exec_on_exit_callbacks(Enum.reverse(callbacks), timeout)
   end
 


### PR DESCRIPTION
Agent is returning `nil` when it should be `[]`.


Before the fix
```console
$ mix test --timeout 0

  1) TestTest: failure on setup_all callback, tests invalidated
     ** (EXIT from #PID<0.122.0>) an exception was raised:
         ** (Protocol.UndefinedError) protocol Enumerable not implemented for nil
             (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
             (elixir) lib/enum.ex:116: Enumerable.reduce/3
             (elixir) lib/enum.ex:1768: Enum.reverse/2
             (ex_unit) lib/ex_unit/on_exit_handler.ex:29: ExUnit.OnExitHandler.run/2
             (ex_unit) lib/ex_unit/runner.ex:307: ExUnit.Runner.exec_on_exit/3
             (ex_unit) lib/ex_unit/runner.ex:231: ExUnit.Runner.run_test/3
             (elixir) lib/enum.ex:645: Enum."-each/2-lists^foreach/1-0-"/2
             (elixir) lib/enum.ex:645: Enum.each/2
             (ex_unit) lib/ex_unit/runner.ex:162: anonymous fn/4 in ExUnit.Runner.spawn_case/3



Finished in 0.04 seconds
1 failure

Randomized with seed 146783

07:52:46.207 [error] Process #PID<0.122.0> raised an exception
** (Protocol.UndefinedError) protocol Enumerable not implemented for nil
    (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir) lib/enum.ex:116: Enumerable.reduce/3
    (elixir) lib/enum.ex:1768: Enum.reverse/2
    (ex_unit) lib/ex_unit/on_exit_handler.ex:29: ExUnit.OnExitHandler.run/2
    (ex_unit) lib/ex_unit/runner.ex:307: ExUnit.Runner.exec_on_exit/3
    (ex_unit) lib/ex_unit/runner.ex:231: ExUnit.Runner.run_test/3
    (elixir) lib/enum.ex:645: Enum."-each/2-lists^foreach/1-0-"/2
    (elixir) lib/enum.ex:645: Enum.each/2
    (ex_unit) lib/ex_unit/runner.ex:162: anonymous fn/4 in ExUnit.Runner.spawn_case/3
```


After the fix

```console
$ mix test --timeout 0

  1) test the truth (TestTest)
     test/test_test.exs:6
     ** (ExUnit.TimeoutError) test timed out after 0ms. You can change the timeout:
     
       1. per test by setting "@tag timeout: x"
       2. per case by setting "@moduletag timeout: x"
       3. globally via "ExUnit.start(timeout: x)" configuration
       4. or set it to infinity per run by calling "mix test --trace"
          (useful when using IEx.pry)
     
     Timeouts are given as integers in milliseconds.
     
     stacktrace:
       (stdlib) gen.erl:168: :gen.do_call/4
       (elixir) lib/gen_server.ex:717: GenServer.call/3
       (ex_unit) lib/ex_unit/runner.ex:244: anonymous fn/3 in ExUnit.Runner.spawn_test/3



Finished in 0.04 seconds
1 test, 1 failure

Randomized with seed 793170
```