### PR TITLE
[Proposal] Implement Map.deep_merge/2 and Map.deep_merge/3

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -474,6 +474,77 @@ defmodule Map do
   end
 
   @doc """
+  Merges two maps similar to `Map.merge/2`, but with the important difference
+  that if keys exist in both maps and their value is also a map it will
+  recursively also merge these maps. If a value for a duplicated key is not a
+  map it will prefer the value present in `override`.
+
+  For maps without maps as possible values it behaves exactly like `Map.merge/2`
+
+  ## Example
+
+      iex> Map.deep_merge(%{a: 1, b: %{x: 10, y: 9}}, %{b: %{y: 20, z: 30}, c: 4})
+      %{a: 1, b: %{x: 10, y: 20, z: 30}, c: 4}
+
+      iex> Map.deep_merge(%{a: 1, b: 2}, %{b: 3, c: 4})
+      %{a: 1, b: 3, c: 4}
+
+      iex> Map.deep_merge(%{a: 1, b: %{x: 10, y: 9}}, %{b: 5, c: 4})
+      %{a: 1, b: 5, c: 4}
+
+      iex> Map.deep_merge(%{a: 1, b: 5}, %{b: %{x: 10, y: 9}, c: 4})
+      %{a: 1, b: %{x: 10, y: 9}, c: 4}
+
+      iex> Map.deep_merge(%{a: %{b: %{c: %{d: "foo", e: 2}}}}, %{a: %{b: %{c: %{d: "bar"}}}})
+      %{a: %{b: %{c: %{d: "bar", e: 2}}}}
+
+  """
+  @spec deep_merge(map, map) :: map
+  def deep_merge(base_map, override) do
+    deep_merge(base_map, override, fn(_key, _base, override) -> override end)
+  end
+
+  @doc """
+  And adjustable version of `Map.deep_merge/2` where one can specify the
+  resolver function akin to `Map.merge/3` which gets called if a key exists in
+  both maps and is not a map.
+
+  This can also be practical if you want to merge further values like lists.
+
+  ## Examples
+
+      iex> Map.deep_merge(%{a: %{y: "bar", z: "bar"}, b: 2}, %{a: %{y: "foo"}, b: 3, c: 4}, fn(_, _, _) -> :conflict end)
+      %{a: %{y: :conflict, z: "bar"}, b: :conflict, c: 4}
+
+      iex> simple_resolver = fn(_key, base, _override) -> base end
+      iex> Map.deep_merge(%{a: 1, b: %{x: 10, y: 9}}, %{b: 5, c: 4}, simple_resolver)
+      %{a: 1, b: %{x: 10, y: 9}, c: 4}
+
+      iex> list_merger = fn
+      ...> _, list1, list2 when is_list(list1) and is_list(list2) ->
+      ...>   list1 ++ list2
+      ...> _, _, override ->
+      ...>   override
+      ...> end
+      iex> Map.deep_merge(%{a: %{b: [1]}, c: 2}, %{a: %{b: [2]}, c: 100}, list_merger)
+      %{a: %{b: [1, 2]}, c: 100}
+
+  """
+  @spec deep_merge(map, map, (key, value, value -> value)) :: map
+  def deep_merge(base_map, override_map, fun) do
+    Map.merge base_map, override_map, build_deep_merge_resolver(fun)
+  end
+
+  defp build_deep_merge_resolver(fun) do
+    fn
+      _key, base_map, override_map when is_map(base_map) and is_map(override_map) ->
+        deep_merge(base_map, override_map, fun)
+      key, base, override ->
+        fun.(key, base, override)
+    end
+  end
+
+  @doc """
   Updates the `key` in `map` with the given function.
 
   If `key` is present in `map` with value `value`, `fun` is invoked with

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -24,7 +24,7 @@ defmodule KeywordTest do
 
   test "implements (almost) all functions in Map" do
     assert Map.__info__(:functions) -- Keyword.__info__(:functions) ==
-           [from_struct: 1]
+           [deep_merge: 2, deep_merge: 3, from_struct: 1]
   end
 
   test "get_and_update/3 raises on bad return value from the argument function" do

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -236,4 +236,31 @@ defmodule MapTest do
     assert LocalUser.new == %LocalUser{name: "john", nested: %LocalUser.NestedUser{}}
     assert LocalUser.Context.new == %LocalUser{name: "john", nested: %LocalUser.NestedUser{}}
   end
+
+  test "deep_merge/3 with a simple custom resolver" do
+    res =
+      Map.deep_merge %{a: %{b: [1]}}, %{a: %{b: [2]}},
+        fn(_key, val1, val2) ->
+          val1 ++ val2
+        end
+
+    assert res == %{a: %{b: [1, 2]}}
+  end
+
+  test "deep_merge/3 with keyword lists arrays and numbers" do
+    resolver = fn
+      _, list1, list2 when is_list(list1) and is_list(list2) ->
+        Keyword.merge(list1, list2)
+      _, num1, num2 when is_number(num1) and is_number(num2) ->
+        num1 + num2
+      _, val1, _val2 ->
+        val1
+    end
+
+    res = Map.deep_merge %{a: 1, b: [a: 1, c: 3], d: "foo"},
+                         %{a: 2, b: [c: 10, d: 4], d: "bar"},
+                         resolver
+
+    assert res == %{a: 3, b: [a: 1, c: 10, d: 4], d: "foo"}
+  end
 end


### PR DESCRIPTION
This was first proposed in https://groups.google.com/forum/#!topic/elixir-lang-core/ak3kVqJ4-8g

People seemed generally in favor of it but the need for some adjustable behavior was made clear quickly as people had differing requirements (what about lists etc.?), hence there was also a need for `Map.deep_merge/3`.

To my knowledge (not knowing all the core members by heart) there was no green light by elixir-core members for this feature but some rather popular devs agreed. The discussions got a lot into the implementation/API details so I figured drafting up an implementation was the best course of action to see if this was truly a good idea (due to some delays it took me until now to finish up a half done implementation).

Please don't feel compelled to just accept it cause someone made the work. I'm perfectly aware this might be rejected and in that case will create a deep_merge hex package. I'm also aware, that for this to be fully fledged there should be a Keyword list version but only wanted to implement that once the Map version/general idea is green lit :)

### Implementation Details + Performance

I decided to implement `deep_merge/2` in terms of `deep_merge/3` - had a specific implementation for it (called `deep_merge_specific` in the benchmark) that was only slightly faster (you can look it up [here](https://github.com/PragTob/elixir_playground/blob/master/lib/deep_merge.ex)) so I decided for the easier to maintain version.

Benchmark code (from my [elixir_playground repo](https://github.com/PragTob/elixir_playground/blob/master/bench/deep_merge.exs) - basically a map with 50 keys + some deeply nested structures:

<details>

```elixir
base_map = (0..50)
           |> Enum.zip(300..350)
           |> Enum.into(%{})

# In the end those are 2 maps with 51 flat keys plus these
orig = Map.merge base_map, %{150 => %{1 => 1, 2 => 2}, 155 => %{y: :x}, 170 => %{"foo" => "bar"}, z: %{ x: 4, y: %{a: 1, b: %{c: 2}, d: %{"hey" => "ho"}}}, a: %{b: %{c: %{a: 99, d: "foo", e: 2}}, m: [33], i: 99, y: "bar"}, b: %{y: [23, 87]}, z: %{xy: %{y: :x}}}
new = Map.merge base_map, %{150 => %{3 => 3}, 160 => %{a: "b"}, z: %{ xui: [44], y: %{b: %{c: 77, d: 55}, d: %{"ho" => "hey", "du" => "nu", "hey" => "ha"}}}, a: %{b: %{c: %{a: 1, b: 2, d: "bar"}}, m: 12, i: 102}, b: %{ x: 65, y: [23]}, z: %{ xy: %{x: :y}}}

simple = fn(_key, _base, override) -> override end

Benchee.run %{
  formatters: [&Benchee.Formatters.Console.output/1,
               &Benchee.Formatters.PlotlyJS.output/1],
  plotly_js: %{file: "deep_merge_bench.html"}
},
%{
  "Map.merge/2"           => fn -> Map.merge orig, new end,
  "Map.merge/3"           => fn -> Map.merge orig, new, simple end,
  "deep_merge/2"          => fn -> DeepMerge.deep_merge orig, new end,
  "deep_merge_specific/2" => fn -> DeepMerge.deep_merge_specific orig, new end
}
```

</details>

Results:

```
tobi@happy ~/github/elixir_playground $ mix run bench/deep_merge.exs 
Erlang/OTP 19 [erts-8.1] [source-4cc2ce3] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false]
Elixir 1.3.4
Benchmark suite executing with the following configuration:
warmup: 2.0s
time: 5.0s
parallel: 1
Estimated total run time: 28.0s

Benchmarking Map.merge/2...
Warning: The function you are trying to benchmark is super fast, making measures more unreliable! See: https://github.com/PragTob/benchee/wiki/Benchee-Warnings#fast-execution-warning

Benchmarking Map.merge/3...
Benchmarking deep_merge/2...
Benchmarking deep_merge_specific/2...

Name                            ips        average  deviation         median
Map.merge/2               2098.47 K        0.48 μs    ±13.25%        0.47 μs
Map.merge/3                 81.08 K       12.33 μs    ±31.98%       12.00 μs
deep_merge_specific/2       68.29 K       14.64 μs    ±37.77%       13.00 μs
deep_merge/2                68.14 K       14.68 μs    ±31.47%       14.00 μs

Comparison: 
Map.merge/2               2098.47 K
Map.merge/3                 81.08 K - 25.88x slower
deep_merge_specific/2       68.29 K - 30.73x slower
deep_merge/2                68.14 K - 30.80x slower
```

![ips benchmark comparison](https://cloud.githubusercontent.com/assets/606517/19519339/d8e389b2-960b-11e6-9023-955329cc280b.png)

As one can see, `deep_merge` is a lot slower than `merge/2` but that is largely due to the fact that `merge/3` is a lot slower than `merge/2` (that's why it's included in the benchmark but with the same behaviour as `merge/2`) - `merge/2` just delegates to Erlang while `merge/3` is a custom implementation that we can probably improve upon (in some other PR).

Ideas + feedback welcome :)