### PR TITLE
Test against Erlang 19.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ otp_release:
   - 18.2
   - 18.3
   - 19.0
+  - 19.1
 
 sudo: false
 


### PR DESCRIPTION
Browsing the repo just noticed that the latest Erlang minor release was missing and thought it'd be a good idea to add it :)