### PR TITLE
Use Kernel.to_string/1 for conversion

### DIFF
--- a/lib/eex/lib/eex/engine.ex
+++ b/lib/eex/lib/eex/engine.ex
@@ -128,7 +128,7 @@ defmodule EEx.Engine do
   def handle_expr(buffer, "=", expr) do
     quote do
       tmp1 = unquote(buffer)
-      tmp1 <> String.Chars.to_string(unquote(expr))
+      tmp1 <> to_string(unquote(expr))
     end
   end
 


### PR DESCRIPTION
Kernel.to_string/1 is actually a macro that expands to literally what is being changed, but it's probably a little cleaner to go ahead and use that abstraction rather than call to the protocol directly.

It seems this was originally introduced (https://github.com/iamvery/elixir/commit/071b0830f8e81b89e0d43ca9f16d288510559361) with a case statement to preserve line numbers. That appears to no longer be the case.

Anyway, this may or may not be useful, but I figured it's worth a couple minutes incase it is ❤️ 