### PR TITLE
Implement String.Chars for Regex

### DIFF
--- a/lib/elixir/lib/string/chars.ex
+++ b/lib/elixir/lib/string/chars.ex
@@ -55,3 +55,9 @@ defimpl String.Chars, for: Float do
     IO.iodata_to_binary(:io_lib_format.fwrite_g(term))
   end
 end
+
+defimpl String.Chars, for: Regex do
+  def to_string(term) do
+    Regex.source(term)
+  end
+end

--- a/lib/elixir/test/elixir/string/chars_test.exs
+++ b/lib/elixir/test/elixir/string/chars_test.exs
@@ -52,6 +52,14 @@ defmodule String.Chars.NumberTest do
   end
 end
 
+defmodule String.Chars.RegexTest do
+  use ExUnit.Case, async: true
+
+  test "regex" do
+    assert to_string(~r/@/) == "@"
+  end
+end
+
 defmodule String.Chars.ListTest do
   use ExUnit.Case, async: true
 

--- a/lib/elixir/test/elixir/string/chars_test.exs
+++ b/lib/elixir/test/elixir/string/chars_test.exs
@@ -57,6 +57,8 @@ defmodule String.Chars.RegexTest do
 
   test "regex" do
     assert to_string(~r/@/) == "@"
+    assert to_string(~r//) == ""
+    assert to_string(~r/foo/iu) == "foo"
   end
 end
 


### PR DESCRIPTION
I think it would be nice to be able to use `to_string/1` on regular expressions.