### PR TITLE
Add --format option to `mix test` command

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -70,6 +70,7 @@ defmodule Mix.Tasks.Test do
     * `--listen-on-stdin` - run tests, and then listen on stdin. Receiving a newline will
       result in the tests being run again. Very useful when combined with `--stale` and
       external commands which produce output on stdout upon file system modification.
+    * `--formatter`  - formatter module
 
   ## Filters
 
@@ -167,7 +168,7 @@ defmodule Mix.Tasks.Test do
              exclude: :keep, seed: :integer, only: :keep, compile: :boolean,
              start: :boolean, timeout: :integer, raise: :boolean,
              deps_check: :boolean, archives_check: :boolean, elixir_version_check: :boolean,
-             stale: :boolean, listen_on_stdin: :boolean]
+             stale: :boolean, listen_on_stdin: :boolean, formatter: :keep]
 
   @cover [output: "cover", tool: Cover]
 
@@ -270,9 +271,10 @@ defmodule Mix.Tasks.Test do
       |> filter_opts(:include)
       |> filter_opts(:exclude)
       |> filter_only_opts()
+      |> formatter_opts()
 
     default_opts(opts) ++
-      Keyword.take(opts, [:trace, :max_cases, :include, :exclude, :seed, :timeout])
+      Keyword.take(opts, [:trace, :max_cases, :include, :exclude, :seed, :timeout, :formatters])
   end
 
   defp merge_helper_opts(opts) do
@@ -314,6 +316,19 @@ defmodule Mix.Tasks.Test do
   defp filter_opts(opts, key) do
     if filters = parse_filters(opts, key) do
       Keyword.put(opts, key, filters)
+    else
+      opts
+    end
+  end
+
+  def formatter_opts(opts) do
+    if Keyword.has_key?(opts, :formatter) do
+      formatters =
+        opts
+        |> Keyword.get_values(:formatter)
+        |> Enum.map(&(Module.concat(String.split(&1, "."))))
+
+      Keyword.put(opts, :formatters, formatters)
     else
       opts
     end

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -31,6 +31,10 @@ defmodule Mix.Tasks.TestTest do
     assert ex_unit_opts([color: true]) == [autorun: false, colors: [enabled: true]]
   end
 
+  test "ex_unit_opts translates :format options into list of modules" do
+    assert ex_unit_opts([formatter: "A.B"]) == [autorun: false, formatters: [A.B]]
+  end
+
   test "--stale: runs all tests for first run, then none on second" do
     in_fixture "test_stale", fn ->
       assert_stale_run_output "2 tests, 0 failures"


### PR DESCRIPTION
I'm attempting to add ExUnit test integration to the IntelliJ Elixir plugin (https://github.com/KronicDeth/intellij-elixir) and it requires a custom formatter. I was unable to figure out an easy way to run the ExUnit tests from the IDE using a custom formatter without requiring the user to make changes to the project itself, which is not ideal for an IDE plugin.

It seems useful to have the formatter be a CLI option for `mix test`, as it is for Rspec: https://www.relishapp.com/rspec/rspec-core/v/2-4/docs/command-line/format-option .

I added the option `--format`, which can be passed more than once in case the user wants to use multiple formatters (though I'm not sure why one would want to).

I'm still an Elixir amateur, and feedback is very welcome.