### PR TITLE
Syntax highlighting of IEx results

### DIFF
--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -600,7 +600,7 @@ defmodule Inspect.Algebra do
   end
 
   defp ansi(color) do
-    color |> IO.ANSI.format_fragment(true)
+    IO.ANSI.format_fragment(color, true)
   end
 
   defp indent(0), do: @newline

--- a/lib/elixir/test/elixir/inspect/algebra_test.exs
+++ b/lib/elixir/test/elixir/inspect/algebra_test.exs
@@ -26,10 +26,10 @@ defmodule Inspect.AlgebraTest do
   end
 
   test "empty doc" do
-    # Consistence with definitions
+    # Consistent with definitions
     assert empty() == :doc_nil
 
-    # Consistence of corresponding sdoc
+    # Consistent of corresponding sdoc
     assert sdoc(empty()) == []
 
     # Consistent formatting
@@ -37,14 +37,14 @@ defmodule Inspect.AlgebraTest do
   end
 
   test "break doc" do
-    # Consistence with definitions
+    # Consistent with definitions
     assert break("break") == {:doc_break, "break"}
     assert break("") == {:doc_break, ""}
 
     # Wrong argument type
     assert_raise FunctionClauseError, fn -> break(42) end
 
-    # Consistence of corresponding sdoc
+    # Consistent with corresponding sdoc
     assert sdoc(break("_")) == ["_"]
 
     # Consistent formatting
@@ -52,7 +52,7 @@ defmodule Inspect.AlgebraTest do
   end
 
   test "glue doc" do
-    # Consistence with definitions
+    # Consistent with definitions
     assert glue("a", "->", "b") == {:doc_cons,
       "a", {:doc_cons, {:doc_break, "->"}, "b"}
    }
@@ -63,7 +63,7 @@ defmodule Inspect.AlgebraTest do
   end
 
   test "text doc" do
-    # Consistence of corresponding sdoc
+    # Consistent with corresponding sdoc
     assert sdoc("_") == ["_"]
 
     # Consistent formatting
@@ -71,21 +71,21 @@ defmodule Inspect.AlgebraTest do
   end
 
   test "space doc" do
-    # Consistency with definitions
+    # Consistent with definitions
     assert space("a", "b") == {:doc_cons,
       "a", {:doc_cons, " ", "b"}
    }
   end
 
   test "nest doc" do
-    # Consistence with definitions
+    # Consistent with definitions
     assert nest(empty(), 1) == {:doc_nest, empty(), 1}
     assert nest(empty(), 0) == :doc_nil
 
     # Wrong argument type
     assert_raise FunctionClauseError, fn -> nest("foo", empty()) end
 
-    # Consistence of corresponding sdoc
+    # Consistent with corresponding sdoc
     assert sdoc(nest("a", 1))  == ["a"]
 
     # Consistent formatting
@@ -93,12 +93,42 @@ defmodule Inspect.AlgebraTest do
     assert render(nest(glue("a", "b"), 1), 2) == "a\n b"
   end
 
+  test "color doc" do
+    # Consistent with definitions
+    opts = %Inspect.Opts{}
+    assert color(empty(), :atom, opts) == empty()
+
+    opts = %Inspect.Opts{syntax_colors: [regex: :red]}
+    assert color(empty(), :atom, opts) == empty()
+
+    opts = %Inspect.Opts{syntax_colors: [atom: :red]}
+    assert color("Hi", :atom, opts) == concat(
+      {:doc_color, "Hi", [:red]},
+      {:doc_color, empty(), [:reset]}
+    )
+
+    opts = %Inspect.Opts{syntax_colors: [reset: :red]}
+    assert color(empty(), :atom, opts) == empty()
+
+    opts = %Inspect.Opts{syntax_colors: [number: :cyan, reset: :red]}
+    assert color("123", :number, opts) == concat(
+      {:doc_color, "123", [:cyan]},
+      {:doc_color, empty(), [:red]}
+    )
+
+    # Consistent formatting
+    opts = %Inspect.Opts{syntax_colors: [atom: :cyan]}
+    assert render(glue(color("AA", :atom, opts), "BB"), 5) == "\e[36mAA\e[0m BB"
+    assert render(glue(color("AA", :atom, opts), "BB"), 3) == "\e[36mAA\e[0m\nBB"
+    assert render(glue("AA", color("BB", :atom, opts)), 6) == "AA \e[36mBB\e[0m"
+  end
+
   test "line doc" do
-    # Consistency with definitions
+    # Consistent with definitions
     assert line("a", "b") ==
       {:doc_cons, "a", {:doc_cons, :doc_line, "b"}}
 
-    # Consistence of corresponding sdoc
+    # Consistent with corresponding sdoc
     assert sdoc(line("a", "b")) == ["a", "\n", "b"]
 
     # Consistent formatting
@@ -107,12 +137,12 @@ defmodule Inspect.AlgebraTest do
   end
 
   test "group doc" do
-    # Consistency with definitions
+    # Consistent with definitions
     assert group(glue("a", "b")) ==
       {:doc_group, {:doc_cons, "a", concat(break(), "b")}}
     assert group(empty()) == {:doc_group, empty()}
 
-    # Consistence of corresponding sdoc
+    # Consistent with corresponding sdoc
     assert sdoc(glue("a", "b")) == ["a", " ", "b"]
 
     # Consistent formatting

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -42,7 +42,7 @@ defmodule Inspect.AtomTest do
   end
 
   test "op" do
-    assert inspect(:+)   == ":+"
+    assert inspect(:+) == ":+"
     assert inspect(:<~) == ":<~"
     assert inspect(:~>) == ":~>"
     assert inspect(:&&&) == ":&&&"
@@ -69,6 +69,13 @@ defmodule Inspect.AtomTest do
     assert inspect(:{})   == ":{}"
     assert inspect(:%{})  == ":%{}"
     assert inspect(:%)    == ":%"
+  end
+
+  test "colors" do
+    opts = [syntax_colors: [atom: :red]]
+    assert inspect(:hello, opts) == "\e[31m:hello\e[0m"
+    opts = [syntax_colors: [reset: :cyan]]
+    assert inspect(:hello, opts) == ":hello"
   end
 end
 
@@ -158,6 +165,20 @@ defmodule Inspect.NumberTest do
     assert inspect(1.0e10) == "1.0e10"
     assert inspect(1.0e-10) == "1.0e-10"
   end
+
+  test "integer colors" do
+    opts = [syntax_colors: [number: :red]]
+    assert inspect(123, opts) == "\e[31m123\e[0m"
+    opts = [syntax_colors: [reset: :cyan]]
+    assert inspect(123, opts) == "123"
+  end
+
+  test "float colors" do
+    opts = [syntax_colors: [number: :red]]
+    assert inspect(1.3, opts) == "\e[31m1.3\e[0m"
+    opts = [syntax_colors: [reset: :cyan]]
+    assert inspect(1.3, opts) == "1.3"
+  end
 end
 
 defmodule Inspect.TupleTest do
@@ -174,6 +195,29 @@ defmodule Inspect.TupleTest do
 
   test "with limit" do
     assert inspect({1, 2, 3, 4}, limit: 3) == "{1, 2, 3, ...}"
+  end
+
+  test "colors" do
+    opts = [syntax_colors: []]
+    assert inspect({}, opts) == "{}"
+
+    opts = [syntax_colors: [reset: :cyan]]
+    assert inspect({}, opts) == "{}"
+    assert inspect({:X, :Y}, opts) == "{:X, :Y}"
+
+    opts = [syntax_colors: [reset: :cyan, atom: :red]]
+    assert inspect({}, opts) == "{}"
+    assert inspect({:X, :Y}, opts) ==
+      "{\e[31m:X\e[36m, \e[31m:Y\e[36m}"
+
+    opts = [syntax_colors: [tuple: :green, reset: :cyan, atom: :red]]
+    assert inspect({}, opts) == "\e[32m{\e[36m\e[32m}\e[36m"
+    assert inspect({:X, :Y}, opts) ==
+      "\e[32m{\e[36m" <>
+      "\e[31m:X\e[36m" <>
+      "\e[32m,\e[36m " <>
+      "\e[31m:Y\e[36m" <>
+      "\e[32m}\e[36m"
   end
 end
 
@@ -244,6 +288,59 @@ defmodule Inspect.ListTest do
 
   test "with limit" do
     assert inspect([ 1, 2, 3, 4 ], limit: 3) == "[1, 2, 3, ...]"
+  end
+
+  test "colors" do
+    opts = [syntax_colors: []]
+    assert inspect([], opts) == "[]"
+
+    opts = [syntax_colors: [reset: :cyan]]
+    assert inspect([], opts) == "[]"
+    assert inspect([:X, :Y], opts) ==
+      "[:X, :Y]"
+
+    opts = [syntax_colors: [reset: :cyan, atom: :red]]
+    assert inspect([], opts) == "[]"
+    assert inspect([:X, :Y], opts) ==
+      "[\e[31m:X\e[36m, \e[31m:Y\e[36m]"
+
+    opts = [syntax_colors: [reset: :cyan, atom: :red, list: :green]]
+    assert inspect([], opts) == "\e[32m[]\e[36m"
+    assert inspect([:X, :Y], opts) ==
+      "\e[32m[\e[36m" <>
+      "\e[31m:X\e[36m" <>
+      "\e[32m,\e[36m " <>
+      "\e[31m:Y\e[36m" <>
+      "\e[32m]\e[36m"
+  end
+
+  test "keyword with colors" do
+    opts = [syntax_colors: [reset: :cyan, list: :green, number: :blue]]
+    assert inspect([], opts) == "\e[32m[]\e[36m"
+    assert inspect([a: 9999], opts) ==
+      "\e[32m[\e[36m" <>
+      "a: " <>
+      "\e[34m9999\e[36m" <>
+      "\e[32m]\e[36m"
+
+    opts = [syntax_colors: [reset: :cyan, atom: :red, list: :green, number: :blue]]
+    assert inspect([], opts) == "\e[32m[]\e[36m"
+    assert inspect([a: 9999], opts) ==
+      "\e[32m[\e[36m" <>
+      "\e[31ma: \e[36m" <>
+      "\e[34m9999\e[36m" <>
+      "\e[32m]\e[36m"
+  end
+
+  test "limit with colors" do
+    opts = [limit: 1, syntax_colors: [reset: :cyan, list: :green, atom: :red]]
+    assert inspect([], opts) == "\e[32m[]\e[36m"
+    assert inspect([:X, :Y], opts) ==
+      "\e[32m[\e[36m" <>
+      "\e[31m:X\e[36m" <>
+      "\e[32m,\e[36m " <>
+      "..." <>
+      "\e[32m]\e[36m"
   end
 end
 
@@ -321,6 +418,25 @@ defmodule Inspect.MapTest do
     assert inspect(%RuntimeError{message: "runtime error"}) ==
            "%RuntimeError{message: \"runtime error\"}"
   end
+
+  test "colors" do
+    opts = [syntax_colors: [reset: :cyan, atom: :red, number: :magenta]]
+    assert inspect(%{1 => 2}, opts) ==
+      "%{\e[35m1\e[36m => \e[35m2\e[36m}"
+
+    assert inspect(%{a: 1}, opts) ==
+      "%{\e[31ma: \e[36m\e[35m1\e[36m}"
+
+    assert inspect(%Public{key: 1}, opts) ==
+      "%Inspect.MapTest.Public{\e[31mkey: \e[36m\e[35m1\e[36m}"
+
+    opts = [syntax_colors: [reset: :cyan, atom: :red, map: :green, number: :blue]]
+    assert inspect(%{a: 9999}, opts) ==
+      "\e[32m%{\e[36m" <>
+      "\e[31ma: \e[36m" <>
+      "\e[34m9999\e[36m" <>
+      "\e[32m}\e[36m"
+  end
 end
 
 defmodule Inspect.OthersTest do
@@ -366,6 +482,11 @@ defmodule Inspect.OthersTest do
   test "other funs" do
     assert "#Function<" <> _ = inspect(fn(x) -> x + 1 end)
     assert "#Function<" <> _ = inspect(fun())
+    opts = [syntax_colors: []]
+    assert "#Function<" <> _ = inspect(fun(), opts)
+    opts = [syntax_colors: [reset: :red]]
+    assert "#Function<" <> _ = inspect(fun(), opts)
+    assert String.ends_with?(inspect(fun(), opts), ">")
   end
 
   test "map set" do
@@ -374,6 +495,11 @@ defmodule Inspect.OthersTest do
 
   test "PIDs" do
     assert "#PID<" <> _ = inspect(self())
+    opts = [syntax_colors: []]
+    assert "#PID<" <> _ = inspect(self(), opts)
+    opts = [syntax_colors: [reset: :cyan]]
+    assert "#PID" <> _ = inspect(self(), opts)
+    assert String.ends_with?(inspect(self(), opts), ">")
   end
 
   test "references" do
@@ -381,8 +507,13 @@ defmodule Inspect.OthersTest do
   end
 
   test "regex" do
-    "~r/foo/m" = inspect(~r(foo)m)
-    "~r/\\a\\x08\\x7F\\x1B\\f\\n\\r \\t\\v\\//" = inspect(Regex.compile!("\a\b\d\e\f\n\r\s\t\v/"))
-    "~r/\\a\\b\\d\\e\\f\\n\\r\\s\\t\\v\\//" = inspect(~r<\a\b\d\e\f\n\r\s\t\v/>)
+    assert inspect(~r(foo)m) == "~r/foo/m"
+    assert inspect(Regex.compile!("\a\b\d\e\f\n\r\s\t\v/")) ==
+      "~r/\\a\\x08\\x7F\\x1B\\f\\n\\r \\t\\v\\//"
+    assert inspect(~r<\a\b\d\e\f\n\r\s\t\v/>) ==
+      "~r/\\a\\b\\d\\e\\f\\n\\r\\s\\t\\v\\//"
+    opts = [syntax_colors: [regex: :red]]
+    assert inspect(~r/hi/, opts) ==
+      "\e[31m~r/hi/\e[0m"
   end
 end

--- a/lib/iex/lib/iex/config.ex
+++ b/lib/iex/lib/iex/config.ex
@@ -6,6 +6,9 @@ defmodule IEx.Config do
   @keys [:colors, :inspect, :history_size, :default_prompt, :alive_prompt, :width]
   @colors [:eval_interrupt, :eval_result, :eval_error, :eval_info, :stack_app,
     :stack_info, :ls_directory, :ls_device]
+  @syntax_colors [number: [:bright, :blue], atom: [:bright, :green],
+                  regex: [:bright, :magenta], string: :cyan]
+
 
   def new() do
     tab = :ets.new(@table, [:named_table, :public])
@@ -131,7 +134,9 @@ defmodule IEx.Config do
       Keyword.has_key?(inspect_options, :width) ->
         inspect_options
       colors_enabled?() ->
-        [width: width()] ++ inspect_options
+        eval_color = List.flatten([:normal, color(:eval_result)])
+        syntax_colors = [{:reset, eval_color} | @syntax_colors]
+        [width: width(), syntax_colors: syntax_colors] ++ inspect_options
       true ->
         inspect_options
     end

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -95,15 +95,15 @@ defmodule IEx.InteractionTest do
   end
 
   unless match?({:win32, _}, :os.type) do
-    # test "color" do
-    #   opts = [colors: [enabled: true, eval_result: [:red]]]
-    #   assert capture_iex("1 + 2", opts) ==
-    #     "\e[31m\e[1m\e[34m3\e[0m\e[0m"
-    #   assert capture_iex("IO.ANSI.blue", opts) ==
-    #     "\e[31m\"\\e[34m\"\e[0m"
-    #   assert capture_iex("{:ok}", opts) ==
-    #     "\e[31m{\e[1m\e[32m:ok\e[0m}\e[0m"
-    # end
+    test "color" do
+      opts = [colors: [enabled: true, eval_result: [:red]]]
+      assert capture_iex("1 + 2", opts) ==
+        "\e[31m\e[1m\e[34m3\e[22m\e[31m\e[0m"
+      assert capture_iex("IO.ANSI.blue", opts) ==
+        "\e[31m\e[36m\"\\e[34m\"\e[22m\e[31m\e[0m"
+      assert capture_iex("{:ok}", opts) ==
+        "\e[31m{\e[1m\e[32m:ok\e[22m\e[31m}\e[0m"
+    end
   end
   test "inspect opts" do
     opts = [inspect: [binaries: :as_binaries, charlists: :as_lists, structs: false, limit: 4]]

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -95,14 +95,16 @@ defmodule IEx.InteractionTest do
   end
 
   unless match?({:win32, _}, :os.type) do
-    test "color" do
-      opts = [colors: [enabled: true, eval_result: [:red]]]
-      assert capture_iex("1 + 2", opts) == "\e[31m3\e[0m"
-      assert capture_iex("IO.ANSI.blue", opts)
-             == "\e[31m\"\\e[34m\"\e[0m"
-    end
+    # test "color" do
+    #   opts = [colors: [enabled: true, eval_result: [:red]]]
+    #   assert capture_iex("1 + 2", opts) ==
+    #     "\e[31m\e[1m\e[34m3\e[0m\e[0m"
+    #   assert capture_iex("IO.ANSI.blue", opts) ==
+    #     "\e[31m\"\\e[34m\"\e[0m"
+    #   assert capture_iex("{:ok}", opts) ==
+    #     "\e[31m{\e[1m\e[32m:ok\e[0m}\e[0m"
+    # end
   end
-
   test "inspect opts" do
     opts = [inspect: [binaries: :as_binaries, charlists: :as_lists, structs: false, limit: 4]]
     assert capture_iex("<<45, 46, 47>>\n[45, 46, 47]\n%IO.Stream{}", opts) ==


### PR DESCRIPTION
Hello!

This weekend I took a stab at adding syntax highling to the repl, inspired by a thread on the mailing list a while back. Here's what I have so far- is this along the right lines?

Additionally there are a few problems.
- After these changes the Inspect protocol seems to wrap far too early. I don't understand how `Inspect.Algebra` works, so I wasn't sure how to resolve this.

![wrap](https://cloud.githubusercontent.com/assets/6134406/19656283/3eb5f478-9a17-11e6-957f-a74386f136ad.png)
- There is additional color configuration for IEx. I'm unsure how this should be changed to fit with syntax highlighting.
