### PR TITLE
Improve Typespecs page and test every document type

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -578,7 +578,7 @@ defmodule Kernel.Typespec do
   defp typespec_to_ast({:type, line, :map, fields}) do
     fields = Enum.map fields, fn
       {:type, _, :map_field_assoc, :any} ->
-        {:..., [line: line], nil}
+        {{:optional, [], [{:any, [], []}]}, {:any, [], []}}
       {:type, _, :map_field_exact, [{:atom, _, k}, v]} ->
         {k, typespec_to_ast(v)}
       {:type, _, :map_field_exact, [k, v]} ->
@@ -750,8 +750,6 @@ defmodule Kernel.Typespec do
   defp typespec({:%{}, meta, fields} = map, vars, caller) do
     fields =
       :lists.map(fn
-        :... ->
-          {:type, line(meta), :map_field_assoc, :any}
         {k, v} when is_atom(k) ->
           {:type, line(meta), :map_field_exact, [typespec(k, vars, caller), typespec(v, vars, caller)]}
         {{:required, meta2, [k]}, v} ->

--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -47,7 +47,7 @@ The syntax Elixir provides for type specifications is similar to [the one in Erl
           | nonempty_maybe_improper_list(type1, type2)  # non-empty proper or improper list
 
           | Literals                # Described in section "Literals"
-          | BuiltIn                 # Described in section "Built-in types"
+          | Builtin                 # Described in section "Built-in types"
           | Remotes                 # Described in section "Remote types"
 
 ### Literals
@@ -59,8 +59,8 @@ The following literals are also supported in typespecs:
                                           ## Bitstrings
           | <<>>                          # empty bitstring
           | <<_::size>>                   # size is 0 or a positive integer
-          | <<_::_ * unit>>               # unit is an integer from 1 to 256
-          | <<_::size, _::_ * unit>>
+          | <<_::_*unit>>                 # unit is an integer from 1 to 256
+          | <<_::size, _::_*unit>>
 
                                           ## Functions
           | (... -> type)                 # any arity, returns type
@@ -69,27 +69,26 @@ The following literals are also supported in typespecs:
 
                                           ## Integers
           | 1                             # integer
-          | 1..10                         # integers from 1 to 10
+          | 1..10                         # integer from 1 to 10
 
                                           ## Lists
           | [type]                        # list with any number of type elements
           | []                            # empty list
           | [...]                         # shorthand for nonempty_list(any())
           | [type, ...]                   # shorthand for nonempty_list(type)
-          | [key: value_type]             # keyword list with key is atom :key and value of value_type
+          | [key: value_type]             # keyword list with key :key of value_type
 
                                                   ## Maps
           | %{}                                   # empty map
-          | %{key: value_type}                    # map with required key :key and value of value_type
-          | %{required(key_type) => value_type}   # map with required types for keys and values
-          | %{optional(key_type) => value_type}   # map with optional types for keys and values
+          | %{key: value_type}                    # map with required key :key of value_type
+          | %{required(key_type) => value_type}   # map with required pairs of key_type and value_type
+          | %{optional(key_type) => value_type}   # map with optional pairs of key_type and value_type
           | %SomeStruct{}                         # struct with all fields of any type
           | %SomeStruct{key: value_type}          # struct with required key :key and type
 
                                           ## Tuples
           | {}                            # empty tuple
           | {:ok, type}                   # two-element tuple with an atom and any type
-
 
 ### Built-in types
 
@@ -100,8 +99,8 @@ Built-in type           | Defined as
 `term()`                | `any()`
 `arity()`               | `0..255`
 `as_boolean(t)`         | `t`
-`binary()`              | `<<_::_ * 8>>`
-`bitstring()`           | `<<_::_ * 1>>`
+`binary()`              | `<<_::_*8>>`
+`bitstring()`           | `<<_::_*1>>`
 `boolean()`             | `false` \| `true`
 `byte()`                | `0..255`
 `char()`                | `0..0x10FFFF`

--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -25,23 +25,29 @@ The syntax Elixir provides for type specifications is similar to [the one in Erl
     type :: any()                   # the top type, the set of all terms
           | none()                  # the bottom type, contains no terms
           | atom()
-          | float()
-          | integer()
-          | neg_integer()           # ..., -3, -2, -1
-          | non_neg_integer()       # 0, 1, 2, 3, ...
-          | pos_integer()           # 1, 2, 3, ...
-          | list(type)
-          | nonempty_list(type)
-          | improper_list(type1, type2)
-          | maybe_improper_list(type1, type2)
           | map()                   # any map
           | pid()
           | port()
           | reference()
           | struct()                # any struct
-          | tuple()
+          | tuple()                 # tuple of any size
+
+                                    ## Numbers
+          | float()                 # float
+          | integer()               # integer
+          | neg_integer()           # ..., -3, -2, -1
+          | non_neg_integer()       # 0, 1, 2, 3, ...
+          | pos_integer()           # 1, 2, 3, ...
+
+                                                        ## Lists
+          | list(type)                                  # proper list ([]-terminated)
+          | nonempty_list(type)                         # non-empty proper list
+          | maybe_improper_list(type1, type2)           # proper or improper list
+          | nonempty_improper_list(type1, type2)        # improper list
+          | nonempty_maybe_improper_list(type1, type2)  # non-empty proper or improper list
+
           | Literals                # Described in section "Literals"
-          | Builtin                 # Described in section "Built-in types"
+          | BuiltIn                 # Described in section "Built-in types"
           | Remotes                 # Described in section "Remote types"
 
 ### Literals
@@ -49,40 +55,41 @@ The syntax Elixir provides for type specifications is similar to [the one in Erl
 The following literals are also supported in typespecs:
 
     type :: :atom                         ## Atoms
-          | 1.0                           ## Floats
-          | 1                             ## Integers
-          | 1..10                         ## Integers from 1 to 10
 
                                           ## Bitstrings
           | <<>>                          # empty bitstring
           | <<_::size>>                   # size is 0 or a positive integer
           | <<_::_ * unit>>               # unit is an integer from 1 to 256
-          | <<_::size, _::_*unit>>
+          | <<_::size, _::_ * unit>>
 
                                           ## Functions
           | (... -> type)                 # any arity, returns type
           | (() -> type)                  # 0-arity, returns type
           | (type1, type2 -> type)        # 2-arity, returns type
 
+                                          ## Integers
+          | 1                             # integer
+          | 1..10                         # integers from 1 to 10
+
                                           ## Lists
           | [type]                        # list with any number of type elements
           | []                            # empty list
           | [...]                         # shorthand for nonempty_list(any())
           | [type, ...]                   # shorthand for nonempty_list(type)
-          | [key: type]                   # keyword lists
+          | [key: value_type]             # keyword list with key is atom :key and value of value_type
 
-                                          ## Maps
-          | %{}                           # empty map
-          | %{...}                        # any map
-          | %{key: type}                  # map with required key :key with value of type
-          | %{required(type1) => type2}   # map with required keys of type1 with values of type2
-          | %{optional(type1) => type2}   # map with optional keys of type1 with values of type2
-          | %SomeStruct{}                 # struct with all fields of any type
-          | %SomeStruct{key: type}        # struct with :key field of type
+                                                  ## Maps
+          | %{}                                   # empty map
+          | %{key: value_type}                    # map with required key :key and value of value_type
+          | %{required(key_type) => value_type}   # map with required types for keys and values
+          | %{optional(key_type) => value_type}   # map with optional types for keys and values
+          | %SomeStruct{}                         # struct with all fields of any type
+          | %SomeStruct{key: value_type}          # struct with required key :key and type
 
                                           ## Tuples
           | {}                            # empty tuple
           | {:ok, type}                   # two-element tuple with an atom and any type
+
 
 ### Built-in types
 
@@ -108,6 +115,7 @@ Built-in type           | Defined as
 `list()`                | `[any()]`
 `nonempty_list()`       | `nonempty_list(any())`
 `maybe_improper_list()` | `maybe_improper_list(any(), any())`
+`nonempty_maybe_improper_list()` | `nonempty_maybe_improper_list(any(), any())`
 `mfa()`                 | `{module(), atom(), arity()}`
 `module()`              | `atom()`
 `no_return()`           | `none()`
@@ -122,11 +130,13 @@ Any module is also able to define its own types and the modules in Elixir are no
 
 ### Maps
 
-The key types in maps are allowed to overlap, and if they do, the leftmost key takes precedence. A map value does not belong to this type if it contains a key that is not in the maps allowed keys.
+The key types in maps are allowed to overlap, and if they do, the leftmost key takes precedence.
+A map value does not belong to this type if it contains a key that is not in the allowed map keys.
 
-Because it is common to end a map type with `optional(any) => any` to denote that keys that do not belong to any other key in the map type are allowed, and may map to any value, the shorthand notation `...` is allowed as the last element of a map type.
+If you want to denote that keys that were not previously defined in the map are allowed,
+it is common to end a map type with `optional(any) => any`.
 
-Notice that the syntactic representation of `map()` is `%{...}` (or `%{optional(any) => any}`), not `%{}`. The notation `%{}` specifies the singleton type for the empty map.
+Notice that the syntactic representation of `map()` is `%{optional(any) => any}`, not `%{}`. The notation `%{}` specifies the singleton type for the empty map.
 
 ## Defining a type
 

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -638,7 +638,7 @@ defmodule Kernel.TypespecTest do
   # This is a test that implements all types specified in lib/elixir/pages/Typespecs.md
   test "test documented types and their AST" do
     defmodule SomeStruct do
-      defstruct key: nil
+      defstruct [:key]
     end
 
     quoted = [
@@ -652,13 +652,13 @@ defmodule Kernel.TypespecTest do
       (quote do: @type basic_reference() :: reference()),
       (quote do: @type basic_struct() :: struct()),
       (quote do: @type basic_tuple() :: tuple()),
-      # numbers
+      # Numbers
       (quote do: @type basic_float() :: float()),
       (quote do: @type basic_integer() :: integer()),
       (quote do: @type basic_neg_integer() :: neg_integer()),
       (quote do: @type basic_non_neg_integer() :: non_neg_integer()),
       (quote do: @type basic_pos_integer() :: pos_integer()),
-      # lists
+      # Lists
       (quote do: @type basic_list_type() :: list(integer())),
       (quote do: @type basic_nonempty_list_type() :: nonempty_list(integer())),
       (quote do: @type basic_maybe_improper_list_type() :: maybe_improper_list(integer(), atom())),
@@ -670,9 +670,9 @@ defmodule Kernel.TypespecTest do
       (quote do: @type literal_integer() :: 1),
       (quote do: @type literal_integers() :: 1..10),
       (quote do: @type literal_empty_bitstring() :: <<>>),
-      (quote do: @type literal_size_0() :: (<<_::0>>)),
-      (quote do: @type literal_unit_1() :: (<<_::_ * 1>>)),
-      (quote do: @type literal_size_1_unit_8() :: (<<_::100, _::_ * 256>>)),
+      (quote do: @type literal_size_0() :: <<_::0>>),
+      (quote do: @type literal_unit_1() :: <<_::_*1>>),
+      (quote do: @type literal_size_1_unit_8() :: <<_::100, _::_*256>>),
       (quote do: @type literal_function_arity_any() :: (... -> integer())),
       (quote do: @type literal_function_arity_0() :: (() -> integer())),
       (quote do: @type literal_function_arity_2() :: (integer(), atom() -> integer())),
@@ -687,7 +687,7 @@ defmodule Kernel.TypespecTest do
       (quote do: @type literal_map_with_key() :: %{key: integer()}),
       (quote do: @type literal_map_with_required_key() :: %{required(bitstring()) => integer()}),
       (quote do: @type literal_map_with_optional_key() :: %{optional(bitstring()) => integer()}),
-      # TODO: Remove by 1.5
+      # TODO: Remove by 1.5, when the following line with give a warning
       (quote do: @type literal_map_with_arrow() :: %{any() => any()}),
       (quote do: @type literal_struct_all_fields_any_type() :: %SomeStruct{}),
       (quote do: @type literal_struct_all_fields_key_type() :: %SomeStruct{key: integer()}),
@@ -695,32 +695,32 @@ defmodule Kernel.TypespecTest do
       (quote do: @type literal_2_element_tuple() :: {1, 2}),
 
       ## Built-in types
-      (quote do: @type built_in_term() :: term()),
-      (quote do: @type built_in_arity() :: arity()),
-      (quote do: @type built_in_as_boolean() :: as_boolean(:t)),
-      (quote do: @type built_in_binary() :: binary()),
-      (quote do: @type built_in_bitstring() :: bitstring()),
-      (quote do: @type built_in_boolean() :: boolean()),
-      (quote do: @type built_in_byte() :: byte()),
-      (quote do: @type built_in_char() :: char()),
-      (quote do: @type built_in_charlist() :: charlist()),
-      (quote do: @type built_in_fun() :: fun()),
-      (quote do: @type built_in_identifier() :: identifier()),
-      (quote do: @type built_in_iodata() :: iodata()),
-      (quote do: @type built_in_iolist() :: iolist()),
-      (quote do: @type built_in_keyword() :: keyword()),
-      (quote do: @type built_in_keyword_value_type() :: keyword(:t)),
-      (quote do: @type built_in_list() :: list()),
-      (quote do: @type built_in_nonempty_list() :: nonempty_list()),
-      (quote do: @type built_in_maybe_improper_list() :: maybe_improper_list()),
-      (quote do: @type built_in_nonempty_maybe_improper_list() :: nonempty_maybe_improper_list()),
-      (quote do: @type built_in_mfa() :: mfa()),
-      (quote do: @type built_in_module() :: module()),
-      (quote do: @type built_in_no_return() :: no_return()),
-      (quote do: @type built_in_node() :: node()),
-      (quote do: @type built_in_number() :: number()),
-      (quote do: @type built_in_struct() :: struct()),
-      (quote do: @type built_in_timeout() :: timeout()),
+      (quote do: @type builtin_term() :: term()),
+      (quote do: @type builtin_arity() :: arity()),
+      (quote do: @type builtin_as_boolean() :: as_boolean(:t)),
+      (quote do: @type builtin_binary() :: binary()),
+      (quote do: @type builtin_bitstring() :: bitstring()),
+      (quote do: @type builtin_boolean() :: boolean()),
+      (quote do: @type builtin_byte() :: byte()),
+      (quote do: @type builtin_char() :: char()),
+      (quote do: @type builtin_charlist() :: charlist()),
+      (quote do: @type builtin_fun() :: fun()),
+      (quote do: @type builtin_identifier() :: identifier()),
+      (quote do: @type builtin_iodata() :: iodata()),
+      (quote do: @type builtin_iolist() :: iolist()),
+      (quote do: @type builtin_keyword() :: keyword()),
+      (quote do: @type builtin_keyword_value_type() :: keyword(:t)),
+      (quote do: @type builtin_list() :: list()),
+      (quote do: @type builtin_nonempty_list() :: nonempty_list()),
+      (quote do: @type builtin_maybe_improper_list() :: maybe_improper_list()),
+      (quote do: @type builtin_nonempty_maybe_improper_list() :: nonempty_maybe_improper_list()),
+      (quote do: @type builtin_mfa() :: mfa()),
+      (quote do: @type builtin_module() :: module()),
+      (quote do: @type builtin_no_return() :: no_return()),
+      (quote do: @type builtin_node() :: node()),
+      (quote do: @type builtin_number() :: number()),
+      (quote do: @type builtin_struct() :: struct()),
+      (quote do: @type builtin_timeout() :: timeout()),
 
       ## Remote types
       (quote do: @type remote_enum_t0() :: Enum.t()),
@@ -738,7 +738,7 @@ defmodule Kernel.TypespecTest do
       ast_string = Macro.to_string(quote do: @type unquote(ast))
 
       case type do
-        # these cases do not translate directly to the string version
+        # these cases do not translate directly to their own string version
         {:basic_list_type, _, _} ->
           assert ast_string == "@type(basic_list_type() :: [integer()])"
 
@@ -754,6 +754,10 @@ defmodule Kernel.TypespecTest do
         {:literal_keyword_list_fixed_key2, _, _} ->
           assert ast_string == "@type(literal_keyword_list_fixed_key2() :: [{:key, integer()}])"
 
+        # TODO: Remove by 1.5
+        {:literal_map_with_arrow, _, _} ->
+          assert ast_string == "@type(literal_map_with_arrow() :: %{optional(any()) => any()})"
+
         {:literal_struct_all_fields_any_type, _, _} ->
           assert ast_string ==
             "@type(literal_struct_all_fields_any_type() :: %Kernel.TypespecTest.SomeStruct{key: term()})"
@@ -762,14 +766,14 @@ defmodule Kernel.TypespecTest do
           assert ast_string ==
             "@type(literal_struct_all_fields_key_type() :: %Kernel.TypespecTest.SomeStruct{key: integer()})"
 
-        {:built_in_fun, _, _} ->
-          assert ast_string == "@type(built_in_fun() :: (... -> any()))"
+        {:builtin_fun, _, _} ->
+          assert ast_string == "@type(builtin_fun() :: (... -> any()))"
 
-        {:built_in_nonempty_list, _, _} ->
-          assert ast_string == "@type(built_in_nonempty_list() :: [...])"
+        {:builtin_nonempty_list, _, _} ->
+          assert ast_string == "@type(builtin_nonempty_list() :: [...])"
 
         _ ->
-          assert Macro.to_string(quote do: @type unquote(ast)) == Macro.to_string(definition)
+          assert ast_string == Macro.to_string(definition)
       end
     end)
   end

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -635,6 +635,143 @@ defmodule Kernel.TypespecTest do
     end)
   end
 
+  # This is a test that implements all types specified in lib/elixir/pages/Typespecs.md
+  test "test documented types and their AST" do
+    defmodule SomeStruct do
+      defstruct key: nil
+    end
+
+    quoted = [
+      ##  Basic types
+      (quote do: @type basic_any() :: any()),
+      (quote do: @type basic_none() :: none()),
+      (quote do: @type basic_atom() :: atom()),
+      (quote do: @type basic_map() :: map()),
+      (quote do: @type basic_pid() :: pid()),
+      (quote do: @type basic_port() :: port()),
+      (quote do: @type basic_reference() :: reference()),
+      (quote do: @type basic_struct() :: struct()),
+      (quote do: @type basic_tuple() :: tuple()),
+      # numbers
+      (quote do: @type basic_float() :: float()),
+      (quote do: @type basic_integer() :: integer()),
+      (quote do: @type basic_neg_integer() :: neg_integer()),
+      (quote do: @type basic_non_neg_integer() :: non_neg_integer()),
+      (quote do: @type basic_pos_integer() :: pos_integer()),
+      # lists
+      (quote do: @type basic_list_type() :: list(integer())),
+      (quote do: @type basic_nonempty_list_type() :: nonempty_list(integer())),
+      (quote do: @type basic_maybe_improper_list_type() :: maybe_improper_list(integer(), atom())),
+      (quote do: @type basic_nonempty_improper_list_type() :: nonempty_improper_list(integer(), atom())),
+      (quote do: @type basic_nonempty_maybe_improper_list_type() :: nonempty_maybe_improper_list(integer(), atom())),
+
+      ## Literals
+      (quote do: @type literal_atom() :: :atom),
+      (quote do: @type literal_integer() :: 1),
+      (quote do: @type literal_integers() :: 1..10),
+      (quote do: @type literal_empty_bitstring() :: <<>>),
+      (quote do: @type literal_size_0() :: (<<_::0>>)),
+      (quote do: @type literal_unit_1() :: (<<_::_ * 1>>)),
+      (quote do: @type literal_size_1_unit_8() :: (<<_::100, _::_ * 256>>)),
+      (quote do: @type literal_function_arity_any() :: (... -> integer())),
+      (quote do: @type literal_function_arity_0() :: (() -> integer())),
+      (quote do: @type literal_function_arity_2() :: (integer(), atom() -> integer())),
+      (quote do: @type literal_list_type() :: [integer()]),
+      (quote do: @type literal_empty_list() :: []),
+      (quote do: @type literal_list_nonempty() :: [...]),
+      (quote do: @type literal_nonempty_list_type() :: [atom(), ...]),
+      (quote do: @type literal_keyword_list_fixed_key() :: [key: integer()]),
+      (quote do: @type literal_keyword_list_fixed_key2() :: [{:key, integer()}]),
+      (quote do: @type literal_keyword_list_type_key() :: [{binary(), integer()}]),
+      (quote do: @type literal_empty_map() :: %{}),
+      (quote do: @type literal_map_with_key() :: %{key: integer()}),
+      (quote do: @type literal_map_with_required_key() :: %{required(bitstring()) => integer()}),
+      (quote do: @type literal_map_with_optional_key() :: %{optional(bitstring()) => integer()}),
+      (quote do: @type literal_struct_all_fields_any_type() :: %SomeStruct{}),
+      (quote do: @type literal_struct_all_fields_key_type() :: %SomeStruct{key: integer()}),
+      (quote do: @type literal_empty_tuple() :: {}),
+      (quote do: @type literal_2_element_tuple() :: {1, 2}),
+
+      ## Built-in types
+      (quote do: @type built_in_term() :: term()),
+      (quote do: @type built_in_arity() :: arity()),
+      (quote do: @type built_in_as_boolean() :: as_boolean(:t)),
+      (quote do: @type built_in_binary() :: binary()),
+      (quote do: @type built_in_bitstring() :: bitstring()),
+      (quote do: @type built_in_boolean() :: boolean()),
+      (quote do: @type built_in_byte() :: byte()),
+      (quote do: @type built_in_char() :: char()),
+      (quote do: @type built_in_charlist() :: charlist()),
+      (quote do: @type built_in_fun() :: fun()),
+      (quote do: @type built_in_identifier() :: identifier()),
+      (quote do: @type built_in_iodata() :: iodata()),
+      (quote do: @type built_in_iolist() :: iolist()),
+      (quote do: @type built_in_keyword() :: keyword()),
+      (quote do: @type built_in_keyword_value_type() :: keyword(:t)),
+      (quote do: @type built_in_list() :: list()),
+      (quote do: @type built_in_nonempty_list() :: nonempty_list()),
+      (quote do: @type built_in_maybe_improper_list() :: maybe_improper_list()),
+      (quote do: @type built_in_nonempty_maybe_improper_list() :: nonempty_maybe_improper_list()),
+      (quote do: @type built_in_mfa() :: mfa()),
+      (quote do: @type built_in_module() :: module()),
+      (quote do: @type built_in_no_return() :: no_return()),
+      (quote do: @type built_in_node() :: node()),
+      (quote do: @type built_in_number() :: number()),
+      (quote do: @type built_in_struct() :: struct()),
+      (quote do: @type built_in_timeout() :: timeout()),
+
+      ## Remote types
+      (quote do: @type remote_enum_t0() :: Enum.t()),
+      (quote do: @type remote_keyword_t1() :: Keyword.t(integer())),
+    ] |> Enum.sort
+
+    module = test_module do
+      Module.eval_quoted __MODULE__, quoted
+    end
+
+    types = types(module)
+
+    Enum.each(Enum.zip(types, quoted), fn {{:type, type}, definition} ->
+      ast = Kernel.Typespec.type_to_ast(type)
+      ast_string = Macro.to_string(quote do: @type unquote(ast))
+
+      case type do
+        # these cases do not translate directly to the string version
+        {:basic_list_type, _, _} ->
+          assert ast_string == "@type(basic_list_type() :: [integer()])"
+
+        {:basic_nonempty_list_type, _, _} ->
+          assert ast_string == "@type(basic_nonempty_list_type() :: [integer(), ...])"
+
+        {:literal_empty_bitstring, _, _} ->
+          assert ast_string == "@type(literal_empty_bitstring() :: <<_::0>>)"
+
+        {:literal_keyword_list_fixed_key, _, _} ->
+          assert ast_string == "@type(literal_keyword_list_fixed_key() :: [{:key, integer()}])"
+
+        {:literal_keyword_list_fixed_key2, _, _} ->
+          assert ast_string == "@type(literal_keyword_list_fixed_key2() :: [{:key, integer()}])"
+
+        {:literal_struct_all_fields_any_type, _, _} ->
+          assert ast_string ==
+            "@type(literal_struct_all_fields_any_type() :: %Kernel.TypespecTest.SomeStruct{key: term()})"
+
+        {:literal_struct_all_fields_key_type, _, _} ->
+          assert ast_string ==
+            "@type(literal_struct_all_fields_key_type() :: %Kernel.TypespecTest.SomeStruct{key: integer()})"
+
+        {:built_in_fun, _, _} ->
+          assert ast_string == "@type(built_in_fun() :: (... -> any()))"
+
+        {:built_in_nonempty_list, _, _} ->
+          assert ast_string == "@type(built_in_nonempty_list() :: [...])"
+
+        _ ->
+          assert Macro.to_string(quote do: @type unquote(ast)) == Macro.to_string(definition)
+      end
+    end)
+  end
+
   test "type_to_ast for paren_type" do
     type = {:my_type, {:paren_type, 0, [{:type, 0, :integer, []}]}, []}
     assert Kernel.Typespec.type_to_ast(type) ==

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -687,6 +687,8 @@ defmodule Kernel.TypespecTest do
       (quote do: @type literal_map_with_key() :: %{key: integer()}),
       (quote do: @type literal_map_with_required_key() :: %{required(bitstring()) => integer()}),
       (quote do: @type literal_map_with_optional_key() :: %{optional(bitstring()) => integer()}),
+      # TODO: Remove by 1.5
+      (quote do: @type literal_map_with_arrow() :: %{any() => any()}),
       (quote do: @type literal_struct_all_fields_any_type() :: %SomeStruct{}),
       (quote do: @type literal_struct_all_fields_key_type() :: %SomeStruct{key: integer()}),
       (quote do: @type literal_empty_tuple() :: {}),


### PR DESCRIPTION
Closes https://github.com/elixir-lang/elixir/issues/5351

Typespecs page:
- Remove literal float
- Replace improper_list/2 with nonempty_improper_list/2
- Add nonempty_maybe_improper_list/2 and nonempty_maybe_improper_list/0
- Reword documentation and comments
- Group and reorder types a bit
- Reword documentation and comments

Tests:
- Add tests for every single type described in Typespecs page
- Also test the AST