### PR TITLE
Remove space around * in bit syntax in Macro.to_string/2

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -763,11 +763,11 @@ defmodule Macro do
     to_string(ast, fun)
   end
 
-  defp bitmods_to_string({:-, _, [left, right]} = ast, fun, _, _) do
+  defp bitmods_to_string({atom, _, [left, right]} = ast, fun, _, _) when atom in [:*, :-] do
     result =
-      bitmods_to_string(left, fun, :-, :left) <>
-      "-" <>
-      bitmods_to_string(right, fun, :-, :right)
+      bitmods_to_string(left, fun, atom, :left) <>
+      Atom.to_string(atom) <>
+      bitmods_to_string(right, fun, atom, :right)
     fun.(ast, result)
   end
 

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -463,13 +463,22 @@ defmodule MacroTest do
   end
 
   test "bit syntax to string" do
+    ast = quote(do: <<1::8*4>>)
+    assert Macro.to_string(ast) == "<<1::8*4>>"
+
+    ast = quote(do: @type foo :: <<_::8, _::_*4>>)
+    assert Macro.to_string(ast) == "@type(foo :: <<_::8, _::_*4>>)"
+
     ast = quote(do: <<69 - 4::bits-size(8 - 4)-unit(1), 65>>)
     assert Macro.to_string(ast) == "<<69 - 4::bits-size(8 - 4)-unit(1), 65>>"
+
     ast = quote(do: << <<65>>, 65>>)
     assert Macro.to_string(ast) == "<<(<<65>>), 65>>"
+
     ast = quote(do: <<65, <<65>> >>)
     assert Macro.to_string(ast) == "<<65, (<<65>>)>>"
-    ast = quote do: for <<a::4 <- <<1, 2>> >>, do: a
+
+    ast = quote(do: (for <<a::4 <- <<1, 2>> >>, do: a))
     assert Macro.to_string(ast) == "for(<<(a :: 4 <- <<1, 2>>)>>) do\n  a\nend"
   end
 


### PR DESCRIPTION
As discussed in https://github.com/elixir-lang/elixir/pull/5362#discussion_r85313529