### PR TITLE
Remove unnecessary private function Time.to_tuple/1

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -622,10 +622,6 @@ defmodule Time do
 
   ## Helpers
 
-  defp to_tuple(%Time{hour: hour, minute: minute, second: second, microsecond: {microsecond, _precision}}) do
-    {hour, minute, second, microsecond}
-  end
-
   defimpl String.Chars do
     def to_string(time) do
       Calendar.ISO.to_string(time)


### PR DESCRIPTION
f071a7c made obsolete the use of to_tuple/1
giving a warning

    warning: function to_tuple/1 is unused
      lib/calendar.ex:625

/cc @lexmag 