### PR TITLE
Fixes Access.key/1 when passed nil as data

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -392,8 +392,8 @@ defmodule Access do
       :get_and_update, data, next ->
         value = Map.get(to_map(data), key, default)
         case next.(value) do
-          {get, update} -> {get, Map.put(data, key, update)}
-          :pop -> {value, Map.delete(data, key)}
+          {get, update} -> {get, Map.put(to_map(data), key, update)}
+          :pop -> {value, Map.delete(to_map(data), key)}
         end
     end
   end

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -26,6 +26,9 @@ defmodule AccessTest do
     assert_raise ArgumentError, "could not put/update key :foo on a nil value", fn ->
       Access.get_and_update(nil, :foo, fn nil -> {:ok, :bar} end)
     end
+
+    assert Access.key(:key).(:get_and_update, nil, fn _ -> {nil, 1} end) == {nil, %{key: 1}}
+    assert Access.key(:key).(:get_and_update, nil, fn _ -> :pop end) == {nil, %{}}
   end
 
   test "for keywords" do


### PR DESCRIPTION
Reading _access.ex_ today I noticed that in `Access.key/1`:

```elixir
def key(key, default \\ nil) do
  fn
    :get, data, next ->
      next.(Map.get(to_map(data), key, default))
    :get_and_update, data, next ->
      value = Map.get(to_map(data), key, default)          # 1
      case next.(value) do
        {get, update} -> {get, Map.put(data, key, update)} # 2
        :pop -> {value, Map.delete(data, key)}             # 3
      end
  end
end
```

the code assumes `data` can be `nil` in (1), but it does not in (2) and (3), so there is a chance that `nil` reaches those calls, which would err.

I don't know if the correct behaviour is to not support `nil`, or to support it. I'd say that similar functions tolerate `nil`s and obviously the following code is explicitly supporting it

```elixir
defp to_map(nil), do: %{}
defp to_map(%{} = map), do: map
defp to_map(data), do: raise "Access.key/1 expected a map/struct or nil, got: #{inspect data}"
```

both in the first clause, and in the error message. So I have written this patch assuming this is the case.

I have opted to put the tests in the test file, because at first sight these are edge cases to have covered, rather than example code. But please feel free to ask me to do it the other way around if you prefer.