### PR TITLE
Give a meaningful error when doctest has invalid prompt

### DIFF
--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -280,6 +280,15 @@ defmodule ExUnit.DocTestTest.Numbered do
   def test_fun(), do: :ok
 end |> write_beam()
 
+defmodule ExUnit.DocTestTest.Host do
+  @doc """
+      iex(foo@bar)1> 1 +
+      ...(foo@bar)1> 2
+      3
+  """
+  def test_fun(), do: :ok
+end |> write_beam()
+
 defmodule ExUnit.DocTestTest.Haiku do
   @moduledoc """
   This module describes the ancient Japanese poem form known as Haiku.
@@ -373,7 +382,7 @@ defmodule ExUnit.DocTestTest do
   test "doctest failures" do
     # When adding or removing lines above this line, the tests below will
     # fail because we are explicitly asserting some doctest lines from
-    # ActuallyCompiled in the format of test/ex_unit/doc_test_test.exs:<LINE>.
+    # ActuallyCompiled in the format of "test/ex_unit/doc_test_test.exs:<LINE>".
     defmodule ActuallyCompiled do
       use ExUnit.Case
       doctest ExUnit.DocTestTest.Invalid
@@ -388,7 +397,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       1) test moduledoc at ExUnit.DocTestTest.Invalid (1) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:379
+         test/ex_unit/doc_test_test.exs:388
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:127: syntax error before: '*'
          code: 1 + * 1
          stacktrace:
@@ -397,7 +406,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       2) test moduledoc at ExUnit.DocTestTest.Invalid (2) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:379
+         test/ex_unit/doc_test_test.exs:388
          Doctest failed
          code: 1 + hd(List.flatten([1])) === 3
          left: 2
@@ -407,7 +416,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       3) test moduledoc at ExUnit.DocTestTest.Invalid (3) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:379
+         test/ex_unit/doc_test_test.exs:388
          Doctest failed
          code: inspect(:oops) === "#MapSet<[]>"
          left: ":oops"
@@ -418,7 +427,7 @@ defmodule ExUnit.DocTestTest do
     # The stacktrace points to the cause of the error
     assert output =~ """
       4) test moduledoc at ExUnit.DocTestTest.Invalid (4) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:379
+         test/ex_unit/doc_test_test.exs:388
          Doctest failed: got UndefinedFunctionError with message "function Hello.world/0 is undefined (module Hello is not available)"
          code: Hello.world
          stacktrace:
@@ -428,7 +437,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       5) test moduledoc at ExUnit.DocTestTest.Invalid (5) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:379
+         test/ex_unit/doc_test_test.exs:388
          Doctest failed: expected exception WhatIsThis but got RuntimeError with message "oops"
          code: raise "oops"
          stacktrace:
@@ -437,7 +446,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       6) test moduledoc at ExUnit.DocTestTest.Invalid (6) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:379
+         test/ex_unit/doc_test_test.exs:388
          Doctest failed: wrong message for RuntimeError
          expected:
            "hello"
@@ -450,7 +459,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       7) test doc at ExUnit.DocTestTest.Invalid.a/0 (7) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:379
+         test/ex_unit/doc_test_test.exs:388
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:148: syntax error before: '*'
          code: 1 + * 1
          stacktrace:
@@ -459,7 +468,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       8) test doc at ExUnit.DocTestTest.Invalid.b/0 (8) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:379
+         test/ex_unit/doc_test_test.exs:388
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:154: syntax error before: '*'
          code: 1 + * 1
          stacktrace:
@@ -468,7 +477,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       9) test doc at ExUnit.DocTestTest.Invalid.dedented_past_fence/0 (9) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:379
+         test/ex_unit/doc_test_test.exs:388
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:178: unexpected token: "`" (column 5, codepoint U+0060)
          code: 3
                    ```
@@ -478,7 +487,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
      10) test doc at ExUnit.DocTestTest.Invalid.indented_not_enough/0 (10) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:379
+         test/ex_unit/doc_test_test.exs:388
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:162: unexpected token: "`" (column 1, codepoint U+0060)
          code: 3
                `
@@ -488,7 +497,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
      11) test doc at ExUnit.DocTestTest.Invalid.indented_too_much/0 (11) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:379
+         test/ex_unit/doc_test_test.exs:388
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:170: unexpected token: "`" (column 3, codepoint U+0060)
          code: 3
                  ```
@@ -497,7 +506,7 @@ defmodule ExUnit.DocTestTest do
     """
   end
 
-  test "iex prefix contains a number" do
+  test "IEx prefix contains a number" do
     defmodule NumberedUsage do
       use ExUnit.Case
       doctest ExUnit.DocTestTest.Numbered
@@ -505,6 +514,20 @@ defmodule ExUnit.DocTestTest do
 
     ExUnit.Server.cases_loaded()
     assert capture_io(fn -> ExUnit.run end) =~ "1 test, 0 failures"
+  end
+
+  test "IEx prompt contains host" do
+    message =
+      ~s[unknown IEx prompt: "iex(foo@bar)1> 1 +".\nAccepted formats are: iex>, iex(1)>, ...>, ...(1)>]
+
+    regex = ~r[test/ex_unit/doc_test_test\.exs:\d+: #{Regex.escape(message)}]
+
+    assert_raise ExUnit.DocTest.Error, regex, fn ->
+      defmodule HostUsage do
+        use ExUnit.Case
+        doctest ExUnit.DocTestTest.Host
+      end
+    end
   end
 
   test "tags tests as doctests" do
@@ -532,7 +555,7 @@ defmodule ExUnit.DocTestTest do
   end
 
   test "fails on invalid module" do
-    assert_raise CompileError, ~r"module ExUnit.DocTestTest.Unknown is not loaded and could not be found", fn ->
+    assert_raise CompileError, ~r"module ExUnit\.DocTestTest\.Unknown is not loaded and could not be found", fn ->
       defmodule NeverCompiled do
         import ExUnit.DocTest
         doctest ExUnit.DocTestTest.Unknown
@@ -541,7 +564,7 @@ defmodule ExUnit.DocTestTest do
   end
 
   test "fails when there are no docs" do
-    assert_raise ExUnit.DocTest.Error, ~r"could not retrieve the documentation for module ExUnit.DocTestTest", fn ->
+    assert_raise ExUnit.DocTest.Error, ~r"could not retrieve the documentation for module ExUnit\.DocTestTest", fn ->
       defmodule NeverCompiled do
         import ExUnit.DocTest
         doctest ExUnit.DocTestTest
@@ -551,7 +574,7 @@ defmodule ExUnit.DocTestTest do
 
   test "fails in indentation mismatch" do
     assert_raise ExUnit.DocTest.Error,
-      ~r[test/ex_unit/doc_test_test.exs:\d+: indentation level mismatch: "   iex> bar = 2", should have been 2 spaces], fn ->
+      ~r[test/ex_unit/doc_test_test\.exs:\d+: indentation level mismatch: "   iex> bar = 2", should have been 2 spaces], fn ->
       defmodule NeverCompiled do
         import ExUnit.DocTest
         doctest ExUnit.DocTestTest.IndentationMismatchedPrompt
@@ -559,7 +582,7 @@ defmodule ExUnit.DocTestTest do
     end
 
     assert_raise ExUnit.DocTest.Error,
-      ~r[test/ex_unit/doc_test_test.exs:\d+: indentation level mismatch: "    3", should have been 2 spaces], fn ->
+      ~r[test/ex_unit/doc_test_test\.exs:\d+: indentation level mismatch: "    3", should have been 2 spaces], fn ->
       defmodule NeverCompiled do
         import ExUnit.DocTest
         doctest ExUnit.DocTestTest.IndentationTooMuch
@@ -567,7 +590,7 @@ defmodule ExUnit.DocTestTest do
     end
 
     assert_raise ExUnit.DocTest.Error,
-      ~r[test/ex_unit/doc_test_test.exs:\d+: indentation level mismatch: \"  3\", should have been 4 spaces], fn ->
+      ~r[test/ex_unit/doc_test_test\.exs:\d+: indentation level mismatch: \"  3\", should have been 4 spaces], fn ->
       defmodule NeverCompiled do
         import ExUnit.DocTest
         doctest ExUnit.DocTestTest.IndentationNotEnough
@@ -577,7 +600,7 @@ defmodule ExUnit.DocTestTest do
 
   test "fails with improper termination" do
     assert_raise ExUnit.DocTest.Error,
-      ~r[test/ex_unit/doc_test_test.exs:\d+: expected non-blank line to follow iex> prompt], fn ->
+      ~r[test/ex_unit/doc_test_test\.exs:\d+: expected non-blank line to follow iex> prompt], fn ->
       defmodule NeverCompiled do
         import ExUnit.DocTest
         doctest ExUnit.DocTestTest.Incomplete


### PR DESCRIPTION
Launching iex with:

  $ iex --sname foo

The following code will break doctests

```
  iex(foo@HOST)1> :foo
  :foo
```

and will give a non descriptive error.
That's because "skip_iex_number" never found the ")>" piece, so it
consumes the line all the way to the end until it's empty.
