### PR TITLE
Teach ExUnit.DocTest to handle fenced code block closings.

### DIFF
--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -509,6 +509,8 @@ defmodule ExUnit.DocTest do
     end
   end
 
+  @fence ["```", "~~~"]
+
   defp extract_tests([], "", "", [], _) do
     []
   end
@@ -564,6 +566,12 @@ defmodule ExUnit.DocTest do
   # Skip empty or documentation line.
   defp extract_tests([_ | lines], "", "", acc, _) do
     extract_tests(lines, "", "", acc, true)
+  end
+
+  # Encountered end of fenced code block, store pending test
+  defp extract_tests([{<<fence::bytes-size(3)>> <> _, _} | lines], expr_acc, expected_acc, [test | t], _) when fence in @fence and expr_acc != "" do
+    test = add_expr(test, expr_acc, expected_acc)
+    extract_tests(lines, "", "", [test | t], true)
   end
 
   # Encountered an empty line, store pending test

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -509,7 +509,7 @@ defmodule ExUnit.DocTest do
     end
   end
 
-  @fence ["```", "~~~"]
+  @fences ["```", "~~~"]
 
   defp extract_tests([], "", "", [], _) do
     []
@@ -569,7 +569,7 @@ defmodule ExUnit.DocTest do
   end
 
   # Encountered end of fenced code block, store pending test
-  defp extract_tests([{<<fence::bytes-size(3)>> <> _, _} | lines], expr_acc, expected_acc, [test | t], _) when fence in @fence and expr_acc != "" do
+  defp extract_tests([{<<fence::3-bytes>> <> _, _} | lines], expr_acc, expected_acc, [test | t], _) when fence in @fences and expr_acc != "" do
     test = add_expr(test, expr_acc, expected_acc)
     extract_tests(lines, "", "", [test | t], true)
   end

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -569,7 +569,8 @@ defmodule ExUnit.DocTest do
   end
 
   # Encountered end of fenced code block, store pending test
-  defp extract_tests([{<<fence::3-bytes>> <> _, _} | lines], expr_acc, expected_acc, [test | t], _) when fence in @fences and expr_acc != "" do
+  defp extract_tests([{<<fence::3-bytes>> <> _, _} | lines], expr_acc, expected_acc, [test | t], _)
+      when fence in @fences and expr_acc != "" do
     test = add_expr(test, expr_acc, expected_acc)
     extract_tests(lines, "", "", [test | t], true)
   end

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -156,6 +156,29 @@ defmodule ExUnit.DocTestTest.Invalid do
   """
   defmacro b(), do: :ok
 
+  @doc """
+    ```
+    iex> 1 + 2
+    3
+  ```
+  """
+  def indented_not_enough, do: :ok
+
+  @doc ~S'''
+  ```
+  iex> 1 + 2
+  3
+    ```
+  '''
+  def indented_too_much, do: :ok
+
+  @doc """
+      ```
+  iex> 1 + 2
+  3
+      ```
+  """
+  def dedented_past_fence, do: :ok
 end |> write_beam
 
 defmodule ExUnit.DocTestTest.IndentationHeredocs do
@@ -222,38 +245,13 @@ defmodule ExUnit.DocTestTest.FencedHeredocs do
   ```
   '''
   def heredocs, do: :ok
-end |> write_beam
 
-defmodule ExUnit.DocTestTest.FencedIndentationMismatchedPrompt do
-  @doc ~S'''
-  ```
-  iex> foo = 1
-   iex> bar = 2
-  iex> foo + bar
-  3
-  ```
-  '''
-  def mismatched, do: :ok
-end |> write_beam
-
-defmodule ExUnit.DocTestTest.FencedIndentationTooMuch do
   @doc ~S'''
   ```
   iex> 1 + 2
-    3
-  ```
-  '''
-  def too_much, do: :ok
-end |> write_beam
-
-defmodule ExUnit.DocTestTest.FencedIndentationNotEnough do
-  @doc ~S'''
-  ```
-    iex> 1 + 2
   3
-  ```
   '''
-  def test_fun, do: :ok
+  def incomplete, do: :ok
 end |> write_beam
 
 defmodule ExUnit.DocTestTest.Incomplete do
@@ -268,7 +266,7 @@ defmodule ExUnit.DocTestTest.FenceIncomplete do
   @doc ~S'''
   ```
   iex> 1 + 2
-
+  3
   '''
   def test_fun, do: :ok
 end |> write_beam
@@ -390,7 +388,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       1) test moduledoc at ExUnit.DocTestTest.Invalid (1) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:381
+         test/ex_unit/doc_test_test.exs:379
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:127: syntax error before: '*'
          code: 1 + * 1
          stacktrace:
@@ -399,7 +397,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       2) test moduledoc at ExUnit.DocTestTest.Invalid (2) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:381
+         test/ex_unit/doc_test_test.exs:379
          Doctest failed
          code: 1 + hd(List.flatten([1])) === 3
          left: 2
@@ -409,7 +407,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       3) test moduledoc at ExUnit.DocTestTest.Invalid (3) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:381
+         test/ex_unit/doc_test_test.exs:379
          Doctest failed
          code: inspect(:oops) === "#MapSet<[]>"
          left: ":oops"
@@ -420,7 +418,7 @@ defmodule ExUnit.DocTestTest do
     # The stacktrace points to the cause of the error
     assert output =~ """
       4) test moduledoc at ExUnit.DocTestTest.Invalid (4) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:381
+         test/ex_unit/doc_test_test.exs:379
          Doctest failed: got UndefinedFunctionError with message "function Hello.world/0 is undefined (module Hello is not available)"
          code: Hello.world
          stacktrace:
@@ -430,7 +428,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       5) test moduledoc at ExUnit.DocTestTest.Invalid (5) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:381
+         test/ex_unit/doc_test_test.exs:379
          Doctest failed: expected exception WhatIsThis but got RuntimeError with message "oops"
          code: raise "oops"
          stacktrace:
@@ -439,7 +437,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       6) test moduledoc at ExUnit.DocTestTest.Invalid (6) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:381
+         test/ex_unit/doc_test_test.exs:379
          Doctest failed: wrong message for RuntimeError
          expected:
            "hello"
@@ -452,7 +450,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       7) test doc at ExUnit.DocTestTest.Invalid.a/0 (7) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:381
+         test/ex_unit/doc_test_test.exs:379
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:148: syntax error before: '*'
          code: 1 + * 1
          stacktrace:
@@ -461,11 +459,41 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       8) test doc at ExUnit.DocTestTest.Invalid.b/0 (8) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:381
+         test/ex_unit/doc_test_test.exs:379
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:154: syntax error before: '*'
          code: 1 + * 1
          stacktrace:
            test/ex_unit/doc_test_test.exs:154: ExUnit.DocTestTest.Invalid (module)
+    """
+
+    assert output =~ """
+      9) test doc at ExUnit.DocTestTest.Invalid.dedented_past_fence/0 (9) (ExUnit.DocTestTest.ActuallyCompiled)
+         test/ex_unit/doc_test_test.exs:379
+         Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:178: unexpected token: "`" (column 5, codepoint U+0060)
+         code: 3
+                   ```
+         stacktrace:
+           test/ex_unit/doc_test_test.exs:177: ExUnit.DocTestTest.Invalid (module)
+    """
+
+    assert output =~ """
+     10) test doc at ExUnit.DocTestTest.Invalid.indented_not_enough/0 (10) (ExUnit.DocTestTest.ActuallyCompiled)
+         test/ex_unit/doc_test_test.exs:379
+         Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:162: unexpected token: "`" (column 1, codepoint U+0060)
+         code: 3
+               `
+         stacktrace:
+           test/ex_unit/doc_test_test.exs:161: ExUnit.DocTestTest.Invalid (module)
+    """
+
+    assert output =~ """
+     11) test doc at ExUnit.DocTestTest.Invalid.indented_too_much/0 (11) (ExUnit.DocTestTest.ActuallyCompiled)
+         test/ex_unit/doc_test_test.exs:379
+         Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:170: unexpected token: "`" (column 3, codepoint U+0060)
+         code: 3
+                 ```
+         stacktrace:
+           test/ex_unit/doc_test_test.exs:169: ExUnit.DocTestTest.Invalid (module)
     """
   end
 
@@ -547,46 +575,12 @@ defmodule ExUnit.DocTestTest do
     end
   end
 
-  test "fails in fenced indentation mismatch" do
-    assert_raise ExUnit.DocTest.Error,
-      ~r[test/ex_unit/doc_test_test\.exs:\d+: indentation level mismatch: " iex> bar = 2", should have been 0 spaces], fn ->
-      defmodule NeverCompiled do
-        import ExUnit.DocTest
-        doctest ExUnit.DocTestTest.FencedIndentationMismatchedPrompt
-      end
-    end
-
-    assert_raise ExUnit.DocTest.Error,
-      ~r[test/ex_unit/doc_test_test\.exs:\d+: indentation level mismatch: "  3", should have been 0 spaces], fn ->
-      defmodule NeverCompiled do
-        import ExUnit.DocTest
-        doctest ExUnit.DocTestTest.FencedIndentationTooMuch
-      end
-    end
-
-    assert_raise ExUnit.DocTest.Error,
-      ~r[test/ex_unit/doc_test_test\.exs:\d+: indentation level mismatch: \"3\", should have been 2 spaces], fn ->
-      defmodule NeverCompiled do
-        import ExUnit.DocTest
-        doctest ExUnit.DocTestTest.FencedIndentationNotEnough
-      end
-    end
-  end
-
   test "fails with improper termination" do
     assert_raise ExUnit.DocTest.Error,
       ~r[test/ex_unit/doc_test_test.exs:\d+: expected non-blank line to follow iex> prompt], fn ->
       defmodule NeverCompiled do
         import ExUnit.DocTest
         doctest ExUnit.DocTestTest.Incomplete
-      end
-    end
-
-    assert_raise ExUnit.DocTest.Error,
-      ~r[test/ex_unit/doc_test_test\.exs:\d+: expected non-blank line to follow iex> prompt], fn ->
-      defmodule NeverCompiled do
-        import ExUnit.DocTest
-        doctest ExUnit.DocTestTest.FenceIncomplete
       end
     end
   end

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -373,6 +373,11 @@ defmodule ExUnit.DocTestTest do
   end
 
   test "doctest failures" do
+
+    # When adding or removing lines in this file above this line,
+    # the second line number in the raw stacktrace tests (test/ex_unit/doc_test_test.exs:xxx)
+    # below this line must be adjusted to the `doctest` line number in `ActuallyCompiled`.
+
     defmodule ActuallyCompiled do
       use ExUnit.Case
       doctest ExUnit.DocTestTest.Invalid
@@ -387,7 +392,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       1) test moduledoc at ExUnit.DocTestTest.Invalid (1) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:312
+         test/ex_unit/doc_test_test.exs:383
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:127: syntax error before: '*'
          code: 1 + * 1
          stacktrace:
@@ -396,7 +401,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       2) test moduledoc at ExUnit.DocTestTest.Invalid (2) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:312
+         test/ex_unit/doc_test_test.exs:383
          Doctest failed
          code: 1 + hd(List.flatten([1])) === 3
          left: 2
@@ -406,7 +411,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       3) test moduledoc at ExUnit.DocTestTest.Invalid (3) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:312
+         test/ex_unit/doc_test_test.exs:383
          Doctest failed
          code: inspect(:oops) === "#MapSet<[]>"
          left: ":oops"
@@ -417,7 +422,7 @@ defmodule ExUnit.DocTestTest do
     # The stacktrace points to the cause of the error
     assert output =~ """
       4) test moduledoc at ExUnit.DocTestTest.Invalid (4) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:312
+         test/ex_unit/doc_test_test.exs:383
          Doctest failed: got UndefinedFunctionError with message "function Hello.world/0 is undefined (module Hello is not available)"
          code: Hello.world
          stacktrace:
@@ -427,7 +432,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       5) test moduledoc at ExUnit.DocTestTest.Invalid (5) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:312
+         test/ex_unit/doc_test_test.exs:383
          Doctest failed: expected exception WhatIsThis but got RuntimeError with message "oops"
          code: raise "oops"
          stacktrace:
@@ -436,7 +441,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       6) test moduledoc at ExUnit.DocTestTest.Invalid (6) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:312
+         test/ex_unit/doc_test_test.exs:383
          Doctest failed: wrong message for RuntimeError
          expected:
            "hello"
@@ -449,7 +454,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       7) test doc at ExUnit.DocTestTest.Invalid.a/0 (7) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:312
+         test/ex_unit/doc_test_test.exs:383
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:148: syntax error before: '*'
          code: 1 + * 1
          stacktrace:
@@ -458,7 +463,7 @@ defmodule ExUnit.DocTestTest do
 
     assert output =~ """
       8) test doc at ExUnit.DocTestTest.Invalid.b/0 (8) (ExUnit.DocTestTest.ActuallyCompiled)
-         test/ex_unit/doc_test_test.exs:312
+         test/ex_unit/doc_test_test.exs:383
          Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:154: syntax error before: '*'
          code: 1 + * 1
          stacktrace:

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -549,7 +549,7 @@ defmodule ExUnit.DocTestTest do
 
   test "fails in fenced indentation mismatch" do
     assert_raise ExUnit.DocTest.Error,
-      ~r[test/ex_unit/doc_test_test.exs:\d+: indentation level mismatch: " iex> bar = 2", should have been 0 spaces], fn ->
+      ~r[test/ex_unit/doc_test_test\.exs:\d+: indentation level mismatch: " iex> bar = 2", should have been 0 spaces], fn ->
       defmodule NeverCompiled do
         import ExUnit.DocTest
         doctest ExUnit.DocTestTest.FencedIndentationMismatchedPrompt
@@ -557,7 +557,7 @@ defmodule ExUnit.DocTestTest do
     end
 
     assert_raise ExUnit.DocTest.Error,
-      ~r[test/ex_unit/doc_test_test.exs:\d+: indentation level mismatch: "  3", should have been 0 spaces], fn ->
+      ~r[test/ex_unit/doc_test_test\.exs:\d+: indentation level mismatch: "  3", should have been 0 spaces], fn ->
       defmodule NeverCompiled do
         import ExUnit.DocTest
         doctest ExUnit.DocTestTest.FencedIndentationTooMuch
@@ -565,7 +565,7 @@ defmodule ExUnit.DocTestTest do
     end
 
     assert_raise ExUnit.DocTest.Error,
-      ~r[test/ex_unit/doc_test_test.exs:\d+: indentation level mismatch: \"3\", should have been 2 spaces], fn ->
+      ~r[test/ex_unit/doc_test_test\.exs:\d+: indentation level mismatch: \"3\", should have been 2 spaces], fn ->
       defmodule NeverCompiled do
         import ExUnit.DocTest
         doctest ExUnit.DocTestTest.FencedIndentationNotEnough
@@ -583,7 +583,7 @@ defmodule ExUnit.DocTestTest do
     end
 
     assert_raise ExUnit.DocTest.Error,
-      ~r[test/ex_unit/doc_test_test.exs:\d+: expected non-blank line to follow iex> prompt], fn ->
+      ~r[test/ex_unit/doc_test_test\.exs:\d+: expected non-blank line to follow iex> prompt], fn ->
       defmodule NeverCompiled do
         import ExUnit.DocTest
         doctest ExUnit.DocTestTest.FenceIncomplete

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -200,6 +200,71 @@ defmodule ExUnit.DocTestTest.IndentationNotEnough do
   def test_fun, do: :ok
 end |> write_beam
 
+defmodule ExUnit.DocTestTest.FencedHeredocs do
+  @doc ~S'''
+  Receives a test and formats its failure.
+
+  ## Examples
+
+  ```
+  iex> 1 + 2
+  3
+  ```
+
+      ```
+      iex> 1 + 2
+      3
+      ```
+
+  ```
+      iex> 1 + 2
+      3
+  ```
+  '''
+  def heredocs, do: :ok
+end |> write_beam
+
+defmodule ExUnit.DocTestTest.FencedMismatchedPrompt do
+  @doc ~S'''
+  ```
+  iex> foo = 1
+   iex> bar = 2
+  iex> foo + bar
+  3
+  ```
+  '''
+  def mismatched, do: :ok
+end |> write_beam
+
+defmodule ExUnit.DocTestTest.FencedIndentationTooMuch do
+  @doc ~S'''
+  ```
+  iex> 1 + 2
+    3
+  ```
+  '''
+  def too_much, do: :ok
+end |> write_beam
+
+defmodule ExUnit.DocTestTest.FencedIndentationNotEnough do
+  @doc ~S'''
+  ```
+    iex> 1 + 2
+  3
+  ```
+  '''
+  def test_fun, do: :ok
+end |> write_beam
+
+defmodule ExUnit.DocTestTest.FencedIncomplete do
+  @doc ~S'''
+  ```
+  iex> 1 + 2
+
+  '''
+  def test_fun, do: :ok
+end |> write_beam
+
 defmodule ExUnit.DocTestTest.Incomplete do
   @doc ~S'''
       iex> 1 + 2
@@ -292,6 +357,7 @@ defmodule ExUnit.DocTestTest do
   doctest ExUnit.DocTestTest.SomewhatGoodModuleWithExcept, except: [:moduledoc, test_fun2: 0], import: true
   doctest ExUnit.DocTestTest.NoImport
   doctest ExUnit.DocTestTest.IndentationHeredocs
+  doctest ExUnit.DocTestTest.FencedHeredocs
   doctest ExUnit.DocTestTest.Haiku
 
   import ExUnit.CaptureIO
@@ -458,6 +524,7 @@ defmodule ExUnit.DocTestTest do
       defmodule NeverCompiled do
         import ExUnit.DocTest
         doctest ExUnit.DocTestTest.IndentationMismatchedPrompt
+        doctest ExUnit.DocTestTest.FencedMismatchedPrompt
       end
     end
 
@@ -466,6 +533,7 @@ defmodule ExUnit.DocTestTest do
       defmodule NeverCompiled do
         import ExUnit.DocTest
         doctest ExUnit.DocTestTest.IndentationTooMuch
+        doctest ExUnit.DocTestTest.FencedIndentationTooMuch
       end
     end
 
@@ -474,6 +542,7 @@ defmodule ExUnit.DocTestTest do
       defmodule NeverCompiled do
         import ExUnit.DocTest
         doctest ExUnit.DocTestTest.IndentationNotEnough
+        doctest ExUnit.DocTestTest.FencedIndentationNotEnough
       end
     end
 
@@ -482,6 +551,7 @@ defmodule ExUnit.DocTestTest do
       defmodule NeverCompiled do
         import ExUnit.DocTest
         doctest ExUnit.DocTestTest.Incomplete
+        doctest ExUnit.DocTestTest.FencedIncomplete
       end
     end
   end


### PR DESCRIPTION
Previously it was having a hard time discerning what to do with them, and included them in the compiled code for the doctest.

[Discussed and vetted](https://groups.google.com/forum/#!msg/elixir-lang-core/EsRK3n7sifo/MtaX0CRaBwAJ) on #elixir-lang-core.
