### PR TITLE
[WIP] Complete specs and guards for Kernel module and some submodules

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -604,7 +604,7 @@ defmodule Kernel do
 
   """
   @spec round(float) :: integer
-  @spec round(arg) :: arg when arg: integer
+  @spec round(value) :: value when value: integer
   def round(number) do
     :erlang.round(number)
   end
@@ -803,7 +803,7 @@ defmodule Kernel do
       5
 
   """
-  @spec trunc(arg) :: arg when arg: integer
+  @spec trunc(value) :: value when value: integer
   @spec trunc(float) :: integer
   def trunc(number) do
     :erlang.trunc(number)

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -263,7 +263,7 @@ defmodule Kernel do
       1
 
   """
-  @spec hd(maybe_improper_list) :: term
+  @spec hd(nonempty_maybe_improper_list) :: term
   def hd(list) do
     :erlang.hd(list)
   end
@@ -516,7 +516,7 @@ defmodule Kernel do
       :b
 
   """
-  @spec max(term, term) :: term
+  @spec max(first, second) :: (first | second) when first: term, second: term
   def max(first, second) do
     :erlang.max(first, second)
   end
@@ -536,7 +536,7 @@ defmodule Kernel do
       "bar"
 
   """
-  @spec min(term, term) :: term
+  @spec min(first, second) :: (first | second) when first: term, second: term
   def min(first, second) do
     :erlang.min(first, second)
   end
@@ -559,7 +559,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @spec node(pid | reference | port) :: node
+  @spec node(pid | reference | port) :: node | :nonode@nohost
   def node(arg) do
     :erlang.node(arg)
   end
@@ -603,7 +603,8 @@ defmodule Kernel do
       -10
 
   """
-  @spec round(number) :: integer
+  @spec round(float) :: integer
+  @spec round(arg) :: arg when arg: integer
   def round(number) do
     :erlang.round(number)
   end
@@ -780,8 +781,9 @@ defmodule Kernel do
 
       iex> tl([1, 2, 3, :go])
       [2, 3, :go]
+
   """
-  @spec tl(maybe_improper_list) :: maybe_improper_list
+  @spec tl(nonempty_maybe_improper_list) :: maybe_improper_list | term
   def tl(list) do
     :erlang.tl(list)
   end
@@ -795,11 +797,13 @@ defmodule Kernel do
 
       iex> trunc(5.4)
       5
+
       iex> trunc(5.99)
       5
 
   """
-  @spec trunc(number) :: integer
+  @spec trunc(arg) :: arg when arg: integer
+  @spec trunc(float) :: integer
   def trunc(number) do
     :erlang.trunc(number)
   end
@@ -833,7 +837,10 @@ defmodule Kernel do
       3
 
   """
-  @spec (number + number) :: number
+  @spec (integer + integer) :: integer
+  @spec (float + float) :: float
+  @spec (integer + float) :: float
+  @spec (float + integer) :: float
   def left + right do
     :erlang.+(left, right)
   end
@@ -849,7 +856,10 @@ defmodule Kernel do
       -1
 
   """
-  @spec (number - number) :: number
+  @spec (integer - integer) :: integer
+  @spec (float - float) :: float
+  @spec (integer - float) :: float
+  @spec (float - integer) :: float
   def left - right do
     :erlang.-(left, right)
   end
@@ -865,7 +875,7 @@ defmodule Kernel do
       1
 
   """
-  @spec (+number) :: number
+  @spec (+arg) :: arg when arg: number
   def (+value) do
     :erlang.+(value)
   end
@@ -881,7 +891,8 @@ defmodule Kernel do
       -2
 
   """
-  @spec (-number) :: number
+  @spec (-float) :: float
+  @spec (-integer) :: integer
   def (-value) do
     :erlang.-(value)
   end
@@ -897,7 +908,10 @@ defmodule Kernel do
       2
 
   """
-  @spec (number * number) :: number
+  @spec (integer * integer) :: integer
+  @spec (float * float) :: float
+  @spec (integer * float) :: float
+  @spec (float * integer) :: float
   def left * right do
     :erlang.*(left, right)
   end
@@ -957,7 +971,10 @@ defmodule Kernel do
       [1, 2 | 3]
 
   """
-  @spec (list ++ term) :: maybe_improper_list
+  @spec (nonempty_list ++ nonempty_list) :: nonempty_list
+  @spec (left ++ []) :: left when left: nonempty_list
+  @spec ([] ++ right) :: right when right: term
+  @spec (list ++ nonempty_improper_list(any, any)) :: nonempty_improper_list(any(), any())
   def left ++ right do
     :erlang.++(left, right)
   end
@@ -1000,7 +1017,8 @@ defmodule Kernel do
       true
 
   """
-  @spec not(boolean) :: boolean
+  @spec not(true) :: false
+  @spec not(false) :: true
   def not(arg) do
     :erlang.not(arg)
   end
@@ -1146,6 +1164,7 @@ defmodule Kernel do
       false
 
   """
+  @spec (arg === arg) :: true when arg: term
   @spec (term === term) :: boolean
   def left === right do
     :erlang."=:="(left, right)
@@ -1515,7 +1534,6 @@ defmodule Kernel do
       true
 
   """
-
   @spec (String.t =~ (String.t | Regex.t)) :: boolean
   def left =~ "" when is_binary(left), do: true
 
@@ -1630,7 +1648,7 @@ defmodule Kernel do
       #=> %User{name: "john"}
 
   """
-  @spec struct(module | map, Enum.t) :: map
+  @spec struct(module | struct, Enum.t) :: struct
   def struct(struct, kv \\ []) do
     struct(struct, kv, fn({key, val}, acc) ->
       case :maps.is_key(key, acc) and key != :__struct__ do
@@ -1659,7 +1677,7 @@ defmodule Kernel do
       only when building;
 
   """
-  @spec struct!(module | map, Enum.t) :: map | no_return
+  @spec struct!(module | struct, Enum.t) :: struct | no_return
   def struct!(struct, kv \\ [])
 
   def struct!(struct, kv) when is_atom(struct) do
@@ -1843,8 +1861,8 @@ defmodule Kernel do
   like the `all` anonymous function defined above. See `Access.all/0`,
   `Access.key/2` and others as examples.
   """
-  @spec get_and_update_in(Access.t, nonempty_list(term),
-                          (term -> {get, term} | :pop)) :: {get, Access.t} when get: var
+  @spec get_and_update_in(Access.t, nonempty_list(term), (term -> {get, term} | :pop)) ::
+                          {get, Access.t} when get: var
   def get_and_update_in(data, keys, fun)
 
   def get_and_update_in(data, [h], fun) when is_function(h),
@@ -2805,7 +2823,7 @@ defmodule Kernel do
       true
 
   """
-  @spec function_exported?(atom | tuple, atom, arity) :: boolean
+  @spec function_exported?(module, atom, arity) :: boolean
   def function_exported?(module, function, arity) do
     :erlang.function_exported(module, function, arity)
   end
@@ -2830,8 +2848,10 @@ defmodule Kernel do
       false
 
   """
-  @spec macro_exported?(atom, atom, integer) :: boolean
-  def macro_exported?(module, macro, arity) do
+  @spec macro_exported?(module, atom, arity) :: boolean
+  def macro_exported?(module, macro, arity)
+      when :erlang.is_atom(module) and :erlang.is_atom(macro) and
+           :erlang.is_integer(arity) and (arity >= 0 and arity <= 255) do
     function_exported?(module, :__info__, 1) and :lists.member({macro, arity}, module.__info__(:macros))
   end
 
@@ -3015,8 +3035,6 @@ defmodule Kernel do
 
   Check `Kernel.SpecialForms.quote/2` for more information.
   """
-  defmacro alias!(alias)
-
   defmacro alias!(alias) when is_atom(alias) do
     alias
   end

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -263,7 +263,7 @@ defmodule Kernel do
       1
 
   """
-  @spec hd(nonempty_maybe_improper_list) :: term
+  @spec hd(nonempty_maybe_improper_list(elem, any)) :: elem when elem: term
   def hd(list) do
     :erlang.hd(list)
   end
@@ -559,7 +559,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @spec node(pid | reference | port) :: node | :nonode@nohost
+  @spec node(pid | reference | port) :: node
   def node(arg) do
     :erlang.node(arg)
   end
@@ -783,7 +783,8 @@ defmodule Kernel do
       [2, 3, :go]
 
   """
-  @spec tl(nonempty_maybe_improper_list) :: maybe_improper_list | term
+  @spec tl(nonempty_maybe_improper_list(elem, tail)) ::
+        maybe_improper_list(elem, tail) | tail when elem: term, tail: term
   def tl(list) do
     :erlang.tl(list)
   end
@@ -875,7 +876,7 @@ defmodule Kernel do
       1
 
   """
-  @spec (+arg) :: arg when arg: number
+  @spec (+value) :: value when value: number
   def (+value) do
     :erlang.+(value)
   end
@@ -891,8 +892,10 @@ defmodule Kernel do
       -2
 
   """
+  @spec (-0) :: 0
+  @spec (-pos_integer) :: neg_integer
+  @spec (-neg_integer) :: pos_integer
   @spec (-float) :: float
-  @spec (-integer) :: integer
   def (-value) do
     :erlang.-(value)
   end
@@ -971,10 +974,7 @@ defmodule Kernel do
       [1, 2 | 3]
 
   """
-  @spec (nonempty_list ++ nonempty_list) :: nonempty_list
-  @spec (left ++ []) :: left when left: nonempty_list
-  @spec ([] ++ right) :: right when right: term
-  @spec (list ++ nonempty_improper_list(any, any)) :: nonempty_improper_list(any(), any())
+  @spec (list ++ term) :: maybe_improper_list
   def left ++ right do
     :erlang.++(left, right)
   end
@@ -1164,7 +1164,6 @@ defmodule Kernel do
       false
 
   """
-  @spec (arg === arg) :: true when arg: term
   @spec (term === term) :: boolean
   def left === right do
     :erlang."=:="(left, right)
@@ -2850,9 +2849,10 @@ defmodule Kernel do
   """
   @spec macro_exported?(module, atom, arity) :: boolean
   def macro_exported?(module, macro, arity)
-      when :erlang.is_atom(module) and :erlang.is_atom(macro) and
-           :erlang.is_integer(arity) and (arity >= 0 and arity <= 255) do
-    function_exported?(module, :__info__, 1) and :lists.member({macro, arity}, module.__info__(:macros))
+      when is_atom(module) and is_atom(macro) and is_integer(arity) and
+           (arity >= 0 and arity <= 255) do
+    function_exported?(module, :__info__, 1) and
+      :lists.member({macro, arity}, module.__info__(:macros))
   end
 
   @doc """

--- a/lib/elixir/lib/kernel/error_handler.ex
+++ b/lib/elixir/lib/kernel/error_handler.ex
@@ -3,28 +3,35 @@
 defmodule Kernel.ErrorHandler do
   @moduledoc false
 
-  def undefined_function(module, fun, args) do
+  @spec undefined_function(module, atom, list) :: term
+  def undefined_function(module, fun, args)
+      when is_atom(module) and is_atom(fun) and is_list(args) do
     ensure_loaded(module) or ensure_compiled(module, :module)
     :error_handler.undefined_function(module, fun, args)
   end
 
-  def undefined_lambda(module, fun, args) do
+  @spec undefined_function(module, fun, list) :: term
+  def undefined_lambda(module, fun, args)
+      when is_atom(module) and is_function(fun) and is_list(args) do
     ensure_loaded(module) or ensure_compiled(module, :module)
     :error_handler.undefined_lambda(module, fun, args)
   end
 
-  def ensure_loaded(module) do
+  @spec ensure_loaded(module) :: boolean
+  def ensure_loaded(module) when is_atom(module) do
     case :code.ensure_loaded(module) do
       {:module, _} -> true
       {:error, _} -> false
     end
   end
 
+  @spec ensure_compiled(module, atom) :: boolean
   # Never wait on nil because it should never be defined.
   def ensure_compiled(nil, _kind) do
     false
   end
-  def ensure_compiled(module, kind) do
+
+  def ensure_compiled(module, kind) when is_atom(module) and is_atom(kind) do
     parent = :erlang.get(:elixir_compiler_pid)
     ref    = :erlang.make_ref
     send parent, {:waiting, kind, self(), ref, module, :elixir_module.compiler_modules()}

--- a/lib/elixir/lib/kernel/error_handler.ex
+++ b/lib/elixir/lib/kernel/error_handler.ex
@@ -4,21 +4,19 @@ defmodule Kernel.ErrorHandler do
   @moduledoc false
 
   @spec undefined_function(module, atom, list) :: term
-  def undefined_function(module, fun, args)
-      when is_atom(module) and is_atom(fun) and is_list(args) do
+  def undefined_function(module, fun, args) do
     ensure_loaded(module) or ensure_compiled(module, :module)
     :error_handler.undefined_function(module, fun, args)
   end
 
-  @spec undefined_function(module, fun, list) :: term
-  def undefined_lambda(module, fun, args)
-      when is_atom(module) and is_function(fun) and is_list(args) do
+  @spec undefined_lambda(module, fun, list) :: term
+  def undefined_lambda(module, fun, args) do
     ensure_loaded(module) or ensure_compiled(module, :module)
     :error_handler.undefined_lambda(module, fun, args)
   end
 
   @spec ensure_loaded(module) :: boolean
-  def ensure_loaded(module) when is_atom(module) do
+  def ensure_loaded(module) do
     case :code.ensure_loaded(module) do
       {:module, _} -> true
       {:error, _} -> false
@@ -31,7 +29,7 @@ defmodule Kernel.ErrorHandler do
     false
   end
 
-  def ensure_compiled(module, kind) when is_atom(module) and is_atom(kind) do
+  def ensure_compiled(module, kind) do
     parent = :erlang.get(:elixir_compiler_pid)
     ref    = :erlang.make_ref
     send parent, {:waiting, kind, self(), ref, module, :elixir_module.compiler_modules()}

--- a/lib/elixir/lib/kernel/lexical_tracker.ex
+++ b/lib/elixir/lib/kernel/lexical_tracker.ex
@@ -52,32 +52,32 @@ defmodule Kernel.LexicalTracker do
   end
 
   @doc false
-  def add_import(pid, module, fas, line, warn) do
+  def add_import(pid, module, fas, line, warn) when is_atom(module) do
     :gen_server.cast(pid, {:add_import, module, fas, line, warn})
   end
 
   @doc false
-  def add_alias(pid, module, line, warn) do
+  def add_alias(pid, module, line, warn) when is_atom(module) do
     :gen_server.cast(pid, {:add_alias, module, line, warn})
   end
 
   @doc false
-  def remote_reference(pid, module, mode) do
+  def remote_reference(pid, module, mode) when is_atom(module) do
     :gen_server.cast(pid, {:remote_reference, module, mode})
   end
 
   @doc false
-  def remote_dispatch(pid, module, fa, line, mode) do
+  def remote_dispatch(pid, module, fa, line, mode) when is_atom(module) do
     :gen_server.cast(pid, {:remote_dispatch, module, fa, line, mode})
   end
 
   @doc false
-  def import_dispatch(pid, module, fa, line, mode) do
+  def import_dispatch(pid, module, fa, line, mode) when is_atom(module) do
     :gen_server.cast(pid, {:import_dispatch, module, fa, line, mode})
   end
 
   @doc false
-  def alias_dispatch(pid, module) do
+  def alias_dispatch(pid, module) when is_atom(module) do
     :gen_server.cast(pid, {:alias_dispatch, module})
   end
 
@@ -147,7 +147,7 @@ defmodule Kernel.LexicalTracker do
     {:noreply, %{state | directives: add_dispatch(state.directives, module, :alias)}}
   end
 
-  def handle_cast({:add_import, module, fas, line, warn}, state) when is_atom(module) do
+  def handle_cast({:add_import, module, fas, line, warn}, state) do
     directives =
       state.directives
       |> Enum.reject(&match?({{:import, {^module, _, _}}, _}, &1))

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -335,7 +335,6 @@ defmodule Kernel.Typespec do
   ## Macro callbacks
 
   @doc false
-  @spec defspec(atom, Macro.t, Macro.Env.t) :: Keyword.t
   def defspec(kind, expr, caller) when kind in [:callback, :macrocallback] do
     case spec_to_signature(expr) do
       {name, arity} ->

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -108,6 +108,7 @@ defmodule Kernel.Typespec do
   @doc """
   Defines a `spec` by receiving a typespec expression.
   """
+  @spec define_spec(atom, Macro.t, Macro.Env.t) :: Keyword.t
   def define_spec(kind, expr, env) do
     defspec(kind, expr, env)
   end
@@ -117,7 +118,9 @@ defmodule Kernel.Typespec do
   (private, opaque or not). This function is only available
   for modules being compiled.
   """
-  def defines_type?(module, name, arity) do
+  @spec defines_type?(module, atom, arity) :: boolean
+  def defines_type?(module, name, arity)
+      when is_atom(module) and is_atom(name) and arity in 0..255 do
     finder = fn {_kind, expr, _caller} ->
       type_to_signature(expr) == {name, arity}
     end
@@ -129,7 +132,9 @@ defmodule Kernel.Typespec do
   Returns `true` if the current module defines a given spec.
   This function is only available for modules being compiled.
   """
-  def defines_spec?(module, name, arity) do
+  @spec defines_spec?(module, atom, arity) :: boolean
+  def defines_spec?(module, name, arity)
+      when is_atom(module) and is_atom(name) and arity in 0..255 do
     finder = fn {_kind, expr, _caller} ->
       spec_to_signature(expr) == {name, arity}
     end
@@ -140,7 +145,9 @@ defmodule Kernel.Typespec do
   Returns `true` if the current module defines a callback.
   This function is only available for modules being compiled.
   """
-  def defines_callback?(module, name, arity) do
+  @spec defines_callback?(module, atom, arity) :: boolean
+  def defines_callback?(module, name, arity)
+      when is_atom(module) and is_atom(name) and arity in 0..255 do
     finder = fn {_kind, expr, _caller} ->
       spec_to_signature(expr) == {name, arity}
     end
@@ -150,8 +157,10 @@ defmodule Kernel.Typespec do
   @doc """
   Converts a spec clause back to Elixir AST.
   """
+  @spec spec_to_ast(atom, tuple) :: {atom, Keyword.t, [Macro.t]}
   def spec_to_ast(name, spec)
-  def spec_to_ast(name, {:type, line, :fun, [{:type, _, :product, args}, result]}) do
+  def spec_to_ast(name, {:type, line, :fun, [{:type, _, :product, args}, result]})
+      when is_atom(name) do
     meta = [line: line]
     body = {name, meta, Enum.map(args, &typespec_to_ast/1)}
 
@@ -169,11 +178,12 @@ defmodule Kernel.Typespec do
     end
   end
 
-  def spec_to_ast(name, {:type, line, :fun, []}) do
+  def spec_to_ast(name, {:type, line, :fun, []}) when is_atom(name) do
     {:::, [line: line], [{name, [line: line], []}, quote(do: term)]}
   end
 
-  def spec_to_ast(name, {:type, line, :bounded_fun, [{:type, _, :fun, [{:type, _, :product, args}, result]}, constraints]}) do
+  def spec_to_ast(name, {:type, line, :bounded_fun, [{:type, _, :fun, [{:type, _, :product, args}, result]}, constraints]})
+      when is_atom(name) do
     guards =
       for {:type, _, :constraint, [{:atom, _, :is_subtype}, [{:var, _, var}, type]]} <- constraints do
         {var, typespec_to_ast(type)}
@@ -206,7 +216,7 @@ defmodule Kernel.Typespec do
     quote do: unquote(record)(unquote_splicing(args)) :: unquote(type)
   end
 
-  def type_to_ast({name, type, args}) do
+  def type_to_ast({name, type, args}) when is_atom(name) do
     args = for arg <- args, do: typespec_to_ast(arg)
     quote do: unquote(name)(unquote_splicing(args)) :: unquote(typespec_to_ast(type))
   end
@@ -325,6 +335,7 @@ defmodule Kernel.Typespec do
   ## Macro callbacks
 
   @doc false
+  @spec defspec(atom, Macro.t, Macro.Env.t) :: Keyword.t
   def defspec(kind, expr, caller) when kind in [:callback, :macrocallback] do
     case spec_to_signature(expr) do
       {name, arity} ->

--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -6,8 +6,10 @@ defmodule Kernel.Utils do
   @doc """
   Callback for destructure.
   """
-  def destructure(list, count) when is_list(list), do: destructure_list(list, count)
-  def destructure(nil, count), do: destructure_nil(count)
+  def destructure(list, count) when is_list(list) and is_integer(count) and count >= 0,
+    do: destructure_list(list, count)
+  def destructure(nil, count) when is_integer(count) and count >= 0,
+    do: destructure_nil(count)
 
   defp destructure_list(_, 0), do: []
   defp destructure_list([], count), do: destructure_nil(count)
@@ -19,7 +21,7 @@ defmodule Kernel.Utils do
   @doc """
   Callback for defdelegate.
   """
-  def defdelegate(fun, opts) do
+  def defdelegate(fun, opts) when is_list(opts) do
     append_first = Keyword.get(opts, :append_first, false)
 
     {name, args} =
@@ -110,12 +112,15 @@ defmodule Kernel.Utils do
   def raise(msg) when is_binary(msg) do
     RuntimeError.exception(msg)
   end
+
   def raise(atom) when is_atom(atom) do
     atom.exception([])
   end
+
   def raise(%{__struct__: struct, __exception__: true} = exception) when is_atom(struct) do
     exception
   end
+
   def raise(other) do
     ArgumentError.exception("raise/1 expects an alias, string or exception as " <>
                             "the first argument, got: #{inspect other}")

--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -112,15 +112,12 @@ defmodule Kernel.Utils do
   def raise(msg) when is_binary(msg) do
     RuntimeError.exception(msg)
   end
-
   def raise(atom) when is_atom(atom) do
     atom.exception([])
   end
-
   def raise(%{__struct__: struct, __exception__: true} = exception) when is_atom(struct) do
     exception
   end
-
   def raise(other) do
     ArgumentError.exception("raise/1 expects an alias, string or exception as " <>
                             "the first argument, got: #{inspect other}")

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -199,7 +199,7 @@ defmodule IEx.HelpersTest do
     assert capture_io(fn -> s Enum.all?/1 end) ==
            "@spec all?(t()) :: boolean()\n"
     assert capture_io(fn -> s struct end) ==
-           "@spec struct(module() | map(), Enum.t()) :: map()\n"
+           "@spec struct(module() | struct(), Enum.t()) :: struct()\n"
   end
 
   test "v helper" do


### PR DESCRIPTION
Cover the specs and add guards to functions for the Kernel module, and for some submodules,

- lib/elixir/lib/kernel/error_handler.ex
- lib/elixir/lib/kernel/lexical_tracker.ex
- lib/elixir/lib/kernel/typespec.ex
- lib/elixir/lib/kernel/utils.ex

I think for we don't need to do anything
- kernel/special_forms.ex

some submodules have been left untouched
- kernel/parallel_compiler.ex
- kernel/parallel_require.ex


There are a few specs that the compiler cannot understand, marked as:
`# TODO: FIX: following line gives error`

Once this is merged, I will update in a new PR the documentation based on the specs.
Specially the one with `no_return`.

I'm still unsure about the specs for some macros and that needs reviewing.