### PR TITLE
[WIP] Fixing :count support in OptionParser.to_argv

### DIFF
--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -396,13 +396,12 @@ defmodule OptionParser do
   """
   @spec to_argv(Enumerable.t, options) :: argv
   def to_argv(enum, opts \\ []) do
+    switches = Keyword.get(opts, :switches, [])
     Enum.flat_map(enum, fn
       {_key, nil}  -> []
       {key, true}  -> [to_switch(key)]
       {key, false} -> [to_switch(key, "--no-")]
-      {key, value} -> 
-        switches = Keyword.get(opts, :switches, [])
-        to_argv(key, value, switches)
+      {key, value} -> to_argv(key, value, switches)
     end)
   end
 

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -414,7 +414,6 @@ defmodule OptionParser do
     end
   end
 
-
   defp to_switch(key, prefix \\ "--") when is_atom(key) do
     prefix <> String.replace(Atom.to_string(key), "_", "-")
   end

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -400,21 +400,18 @@ defmodule OptionParser do
       {_key, nil}  -> []
       {key, true}  -> [to_switch(key)]
       {key, false} -> [to_switch(key, "--no-")]
-      {key, value} -> to_argv(key, value, opts)
+      {key, value} -> 
+        switches = Keyword.get(opts, :switches, [])
+        to_argv(key, value, switches)
     end)
   end
 
-  # If no options were provided consider the argv a simple pair
-  defp to_argv(key, value, []) do
-    [to_switch(key), to_string(value)]
-  end
-
-  defp to_argv(key, value, opts) do
-    {_, switches, _} = compile_config(opts)
-    if switches[:"#{key}"] == :count do
+  defp to_argv(key, value, switches) do
+    if switches[key] == :count do
       List.duplicate(to_switch(key), value)
     else
-      to_argv(key, value, [])
+      # If no options were provided consider the argv a simple pair
+      [to_switch(key), to_string(value)]
     end
   end
 

--- a/lib/elixir/test/elixir/option_parser_test.exs
+++ b/lib/elixir/test/elixir/option_parser_test.exs
@@ -396,4 +396,10 @@ defmodule OptionParserTest do
     assert OptionParser.to_argv([bool: true, bool: false, discarded: nil]) ==
            ["--bool", "--no-bool"]
   end
+
+  test ":count opts can be translated back" do
+    original = ["--counter", "--counter"]
+    {opts, [], []} = OptionParser.parse(original,  [switches: [counter: :count] ])
+    assert original == OptionParser.to_argv(opts, [switches: [counter: :count]])
+  end
 end


### PR DESCRIPTION
## First Draft for Issue: #5327 

Added an opts argument to OptionParser.to_argv. This way a user can point out args of `:count` type.
If guys agree with the approach I could add the appropriate documentation.