### PR TITLE
Clarification of aliases' non-visibility if defined in dependency

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -149,6 +149,7 @@ defmodule Mix do
   with extra clean up logic.
 
   Note aliases do not show up on `mix help`.
+  Aliases defined in the current project do not affect its dependencies and aliases defined in dependencies are not accessible from the current project.
 
   ## Environment variables
 


### PR DESCRIPTION
See https://elixirforum.com/t/task-aliases-in-mix-ex-of-dependencies-ignored/2218