### PR TITLE
Use Macro.to_string/1 when printing bad struct keys

### DIFF
--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -207,5 +207,5 @@ build_map(Ann, TUpdate, TArgs, SA) -> {{map, Ann, TUpdate, TArgs}, SA}.
 assert_struct_keys(Meta, Name, Struct, Assocs, S) ->
   [begin
      compile_error(Meta, S#elixir_scope.file, "unknown key ~ts for struct ~ts",
-                   ['Elixir.Kernel':inspect(Key), elixir_aliases:inspect(Name)])
+                   ['Elixir.Macro':to_string(Key), elixir_aliases:inspect(Name)])
    end || {Key, _} <- Assocs, not maps:is_key(Key, Struct)].

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -356,6 +356,10 @@ defmodule Kernel.ErrorsTest do
     assert_compile_fail CompileError,
       "nofile:1: unknown key :age for struct Kernel.ErrorsTest.GoodStruct",
       '%#{GoodStruct}{age: 27} = %{}'
+
+    assert_compile_fail CompileError,
+      "nofile:1: unknown key ^field for struct Kernel.ErrorsTest.GoodStruct",
+      '%#{GoodStruct}{^field => 27} = %{}'
   end
 
   test "name for defmodule" do


### PR DESCRIPTION
In reference to https://github.com/elixir-lang/elixir/pull/5379#issuecomment-257079870 and https://github.com/elixir-lang/elixir/issues/5378