### PR TITLE
Fix typo in Kernel doc

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -932,7 +932,7 @@ defmodule Kernel do
   Instead, consider prepending via `[item | rest]` and then reversing.
 
   If the `right` operand is not a proper list, it returns an improper list.
-  If the `left` operand it not a proper list, it raises `ArgumentError`.
+  If the `left` operand is not a proper list, it raises `ArgumentError`.
 
   Inlined by the compiler.
 


### PR DESCRIPTION
Just a little typo, `it` → `is` in the phrase
`If the left operand is not a proper list,`...

Thanks for Elixir!