### PR TITLE
Two fixes in `record/1`

### DIFF
--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -422,7 +422,7 @@ defmodule Record do
         kv when is_list(kv) ->
           kv
         expected_fields ->
-          msg = "expected argument can be a #{inspect atom} record with #{expected_fields} fields, while got: #{inspect record}"
+          msg = "expected argument to be a #{inspect atom} record with #{expected_fields} fields, got: #{inspect record}"
           raise ArgumentError, msg
       end
     else

--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -175,7 +175,7 @@ defmodule Record do
 
     * `name/0` to create a new record with default values for all fields
     * `name/1` to create a new record with the given fields and values,
-      to get zero-based index of the given field in a record or to
+      to get the zero-based index of the given field in a record or to
       convert the given record to a keyword list
     * `name/2` to update an existing record with the given fields and values
       or to access a given field in a given record
@@ -207,8 +207,8 @@ defmodule Record do
       # To update the record
       user(record, age: 26) #=> {:user, "meg", 26}
 
-      # To get zero-based index of the field in record tuple (index 0 is
-      # occupied by the record "tag")
+      # To get the zero-based index of the field in record tuple
+      # (index 0 is occupied by the record "tag")
       user(:name) #=> 1
 
       # Convert a record to a keyword list

--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -174,7 +174,8 @@ defmodule Record do
   The following macros are generated:
 
     * `name/0` to create a new record with default values for all fields
-    * `name/1` to create a new record with the given fields and values or to
+    * `name/1` to create a new record with the given fields and values,
+      to get zero-based index of the given field in a record or to
       convert the given record to a keyword list
     * `name/2` to update an existing record with the given fields and values
       or to access a given field in a given record
@@ -205,6 +206,10 @@ defmodule Record do
 
       # To update the record
       user(record, age: 26) #=> {:user, "meg", 26}
+
+      # To get zero-based index of the field in record tuple (index 0 is
+      # occupied by the record "tag")
+      user(:name) #=> 1
 
       # Convert a record to a keyword list
       user(record) #=> [name: "meg", age: 26]

--- a/lib/elixir/test/elixir/record_test.exs
+++ b/lib/elixir/test/elixir/record_test.exs
@@ -178,15 +178,15 @@ defmodule RecordTest do
     end
 
     pretender = {RecordTest, "john"}
-    msg = "expected argument can be a RecordTest record with 2 fields, " <>
-          "while got: {RecordTest, \"john\"}"
+    msg = "expected argument to be a RecordTest record with 2 fields, " <>
+          "got: {RecordTest, \"john\"}"
     assert_raise ArgumentError, msg, fn ->
       user(pretender)
     end
 
     pretender = {RecordTest, "john", 25, []}
-    msg = "expected argument can be a RecordTest record with 2 fields, " <>
-          "while got: {RecordTest, \"john\", 25, []}"
+    msg = "expected argument to be a RecordTest record with 2 fields, " <>
+          "got: {RecordTest, \"john\", 25, []}"
     assert_raise ArgumentError, msg, fn ->
       user(pretender)
     end

--- a/lib/elixir/test/elixir/record_test.exs
+++ b/lib/elixir/test/elixir/record_test.exs
@@ -176,6 +176,20 @@ defmodule RecordTest do
     assert_raise ArgumentError, msg, fn ->
       file_info(record)
     end
+
+    pretender = {RecordTest, "john"}
+    msg = "expected argument can be a RecordTest record with 2 fields, " <>
+          "while got: {RecordTest, \"john\"}"
+    assert_raise ArgumentError, msg, fn ->
+      user(pretender)
+    end
+
+    pretender = {RecordTest, "john", 25, []}
+    msg = "expected argument can be a RecordTest record with 2 fields, " <>
+          "while got: {RecordTest, \"john\", 25, []}"
+    assert_raise ArgumentError, msg, fn ->
+      user(pretender)
+    end
   end
 
   test "records visibility" do


### PR DESCRIPTION
Each in separate commit:
* Document use of `record/1` with atom argument.
  (it was not)
* In `record/1` used with record argument, raise ArgumentError on record size mismatch.
  (when a given record matched the record tag, but not the size, FunctionClauseError was raised in private Record.join_keyword/3)