### PR TITLE
Remove use of underscore before ordinal numbers in functions and vars

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1891,7 +1891,7 @@ defmodule Enum do
   """
   @spec scan(t, (element, any -> any)) :: list
   def scan(enumerable, fun) when is_function(fun, 2) do
-    {res, _} = reduce(enumerable, {[], :first}, R.scan_2(fun))
+    {res, _} = reduce(enumerable, {[], :first}, R.scan2(fun))
     :lists.reverse(res)
   end
 
@@ -1908,7 +1908,7 @@ defmodule Enum do
   """
   @spec scan(t, any, (element, any -> any)) :: list
   def scan(enumerable, acc, fun) when is_function(fun, 2) do
-    {res, _} = reduce(enumerable, {[], acc}, R.scan_3(fun))
+    {res, _} = reduce(enumerable, {[], acc}, R.scan3(fun))
     :lists.reverse(res)
   end
 
@@ -2901,10 +2901,10 @@ defmodule Enum do
     sort_merge(list, [], fun, false)
 
   defp sort_merge([t1, [h2 | t2] | l], acc, fun, true), do:
-    sort_merge(l, [sort_merge_1(t1, h2, t2, [], fun, false) | acc], fun, true)
+    sort_merge(l, [sort_merge1(t1, h2, t2, [], fun, false) | acc], fun, true)
 
   defp sort_merge([[h2 | t2], t1 | l], acc, fun, false), do:
-    sort_merge(l, [sort_merge_1(t1, h2, t2, [], fun, false) | acc], fun, false)
+    sort_merge(l, [sort_merge1(t1, h2, t2, [], fun, false) | acc], fun, false)
 
   defp sort_merge([l], [], _fun, _bool), do: l
 
@@ -2915,10 +2915,10 @@ defmodule Enum do
     reverse_sort_merge(acc, [], fun, bool)
 
   defp reverse_sort_merge([[h2 | t2], t1 | l], acc, fun, true), do:
-    reverse_sort_merge(l, [sort_merge_1(t1, h2, t2, [], fun, true) | acc], fun, true)
+    reverse_sort_merge(l, [sort_merge1(t1, h2, t2, [], fun, true) | acc], fun, true)
 
   defp reverse_sort_merge([t1, [h2 | t2] | l], acc, fun, false), do:
-    reverse_sort_merge(l, [sort_merge_1(t1, h2, t2, [], fun, true) | acc], fun, false)
+    reverse_sort_merge(l, [sort_merge1(t1, h2, t2, [], fun, true) | acc], fun, false)
 
   defp reverse_sort_merge([l], acc, fun, bool), do:
     sort_merge([:lists.reverse(l, []) | acc], [], fun, bool)
@@ -2926,26 +2926,26 @@ defmodule Enum do
   defp reverse_sort_merge([], acc, fun, bool), do:
     sort_merge(acc, [], fun, bool)
 
-  defp sort_merge_1([h1 | t1], h2, t2, m, fun, bool) do
+  defp sort_merge1([h1 | t1], h2, t2, m, fun, bool) do
     if fun.(h1, h2) == bool do
-      sort_merge_2(h1, t1, t2, [h2 | m], fun, bool)
+      sort_merge2(h1, t1, t2, [h2 | m], fun, bool)
     else
-      sort_merge_1(t1, h2, t2, [h1 | m], fun, bool)
+      sort_merge1(t1, h2, t2, [h1 | m], fun, bool)
     end
   end
 
-  defp sort_merge_1([], h2, t2, m, _fun, _bool), do:
+  defp sort_merge1([], h2, t2, m, _fun, _bool), do:
     :lists.reverse(t2, [h2 | m])
 
-  defp sort_merge_2(h1, t1, [h2 | t2], m, fun, bool) do
+  defp sort_merge2(h1, t1, [h2 | t2], m, fun, bool) do
     if fun.(h1, h2) == bool do
-      sort_merge_2(h1, t1, t2, [h2 | m], fun, bool)
+      sort_merge2(h1, t1, t2, [h2 | m], fun, bool)
     else
-      sort_merge_1(t1, h2, t2, [h1 | m], fun, bool)
+      sort_merge1(t1, h2, t2, [h1 | m], fun, bool)
     end
   end
 
-  defp sort_merge_2(h1, t1, [], m, _fun, _bool), do:
+  defp sort_merge2(h1, t1, [], m, _fun, _bool), do:
     :lists.reverse(t1, [h1 | m])
 
   ## split

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -581,7 +581,7 @@ defmodule Stream do
   """
   @spec scan(Enumerable.t, (element, acc -> any)) :: Enumerable.t
   def scan(enum, fun) do
-    lazy enum, :first, fn(f1) -> R.scan_2(fun, f1) end
+    lazy enum, :first, fn(f1) -> R.scan2(fun, f1) end
   end
 
   @doc """
@@ -598,7 +598,7 @@ defmodule Stream do
   """
   @spec scan(Enumerable.t, acc, (element, acc -> any)) :: Enumerable.t
   def scan(enum, acc, fun) do
-    lazy enum, acc, fn(f1) -> R.scan_3(fun, f1) end
+    lazy enum, acc, fn(f1) -> R.scan3(fun, f1) end
   end
 
   @doc """

--- a/lib/elixir/lib/stream/reducers.ex
+++ b/lib/elixir/lib/stream/reducers.ex
@@ -142,7 +142,7 @@ defmodule Stream.Reducers do
     end
   end
 
-  defmacro scan_2(callback, fun \\ nil) do
+  defmacro scan2(callback, fun \\ nil) do
     quote do
       fn
         entry, acc(head, :first, tail) ->
@@ -154,7 +154,7 @@ defmodule Stream.Reducers do
     end
   end
 
-  defmacro scan_3(callback, fun \\ nil) do
+  defmacro scan3(callback, fun \\ nil) do
     quote do
       fn(entry, acc(head, acc, tail)) ->
         value = unquote(callback).(entry, acc)

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -343,8 +343,8 @@ defmodule URI do
     unpercent(tail, <<acc::binary, ?\s>>, spaces)
   end
 
-  defp unpercent(<<?%, hex_1, hex_2, tail::binary>>, acc, spaces) do
-    unpercent(tail, <<acc::binary, bsl(hex_to_dec(hex_1), 4) + hex_to_dec(hex_2)>>, spaces)
+  defp unpercent(<<?%, hex1, hex2, tail::binary>>, acc, spaces) do
+    unpercent(tail, <<acc::binary, bsl(hex_to_dec(hex1), 4) + hex_to_dec(hex2)>>, spaces)
   end
   defp unpercent(<<?%, _::binary>>, _acc, _spaces), do: throw(:malformed_uri)
 

--- a/lib/elixir/src/elixir_utils.erl
+++ b/lib/elixir/src/elixir_utils.erl
@@ -139,7 +139,7 @@ elixir_to_erl(<<>>) ->
   {bin, 0, []};
 
 elixir_to_erl(Tree) when is_list(Tree) ->
-  elixir_to_erl_cons_1(Tree, []);
+  elixir_to_erl_cons1(Tree, []);
 
 elixir_to_erl(Tree) when is_atom(Tree) ->
   {atom, 0, Tree};
@@ -180,12 +180,12 @@ elixir_to_erl(Pid) when is_pid(Pid) ->
 elixir_to_erl(_Other) ->
   error(badarg).
 
-elixir_to_erl_cons_1([H | T], Acc) -> elixir_to_erl_cons_1(T, [H | Acc]);
-elixir_to_erl_cons_1(Other, Acc) -> elixir_to_erl_cons_2(Acc, elixir_to_erl(Other)).
+elixir_to_erl_cons1([H | T], Acc) -> elixir_to_erl_cons1(T, [H | Acc]);
+elixir_to_erl_cons1(Other, Acc) -> elixir_to_erl_cons2(Acc, elixir_to_erl(Other)).
 
-elixir_to_erl_cons_2([H | T], Acc) ->
-  elixir_to_erl_cons_2(T, {cons, 0, elixir_to_erl(H), Acc});
-elixir_to_erl_cons_2([], Acc) ->
+elixir_to_erl_cons2([H | T], Acc) ->
+  elixir_to_erl_cons2(T, {cons, 0, elixir_to_erl(H), Acc});
+elixir_to_erl_cons2([], Acc) ->
   Acc.
 
 %% Boolean checks

--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -63,24 +63,24 @@ defmodule Mix.Tasks.Profile.Fprof do
 
   When `--callers` option is specified, you'll see expanded function entries:
 
-      Mod.caller_1/0                            3     200.000       0.017
-      Mod.caller_2/0                            2     100.000       0.017
+      Mod.caller1/0                             3     200.000       0.017
+      Mod.caller2/0                             2     100.000       0.017
         Mod.some_function/0                     5     300.000       0.017  <--
-          Mod.called_1/0                        4     250.000       0.010
-          Mod.called_2/0                        1      50.000       0.030
+          Mod.called1/0                         4     250.000       0.010
+          Mod.called2/0                         1      50.000       0.030
 
   Here, the arrow (`<--`) indicates the __marked__ function - the function
   described by this paragraph. You also see its immediate callers (above) and
   called functions (below).
 
   All the values of caller functions describe the marked function. For example,
-  the first row means that `Mod.caller_1/0` invoked `Mod.some_function/0` 3 times.
+  the first row means that `Mod.caller1/0` invoked `Mod.some_function/0` 3 times.
   200ms of the total time spent in `Mod.some_function/0` was spent processing
   calls from this particular caller.
 
   In contrast, the values for the called functions describe those functions, but
   in the context of the marked function. For example, the last row means that
-  `Mod.called_2/0` was called once by `Mod.some_function/0`, and in that case
+  `Mod.called2/0` was called once by `Mod.some_function/0`, and in that case
   the total time spent in the function was 50ms.
 
   For a detailed explanation it's worth reading the analysis in


### PR DESCRIPTION
this corrects the very few cases left for functions and vars, but doesn't include a few tests that still keep this.