### PR TITLE
Make tokenizer recognize VC merge conflict marks

### DIFF
--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -132,6 +132,12 @@ tokenize([], EndLine, _Column, #elixir_tokenizer{terminators=[{Start, {StartLine
   Message = io_lib:format("missing terminator: ~ts (for \"~ts\" starting at line ~B)", [End, Start, StartLine]),
   {error, {EndLine, Message, []}, [], Tokens};
 
+% VC merge conflict
+
+tokenize(("<<<<<<<" ++ _) = Original, Line, 1, _Scope, Tokens) ->
+  FirstLine = lists:takewhile(fun(C) -> C =/= $\n andalso C =/= $\r end, Original),
+  {error, {Line, "found an unexpected version control marker, please resolve the conflicts: ", FirstLine}, Original, Tokens};
+
 % Base integers
 
 tokenize([$0, $x, H | T], Line, Column, Scope, Tokens) when ?is_hex(H) ->

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -170,3 +170,7 @@ capture_test() ->
    {identifier, {1, 2, 4}, 'or'},
    {mult_op,    {1, 4, 5}, '/'},
    {number,     {1, 5, 6}, 2}] = tokenize("&or/2").
+
+vc_merge_conflict_test() ->
+  {1, "found an unexpected version control marker, please resolve the conflicts: ", "<<<<<<< HEAD"} =
+    tokenize_error("<<<<<<< HEAD\n[1, 2, 3]").


### PR DESCRIPTION
The <<<<<<< symbol is used by all major VC systems including [git](https://help.github.com/articles/resolving-a-merge-conflict-from-the-command-line/), [subversion](https://tortoisesvn.net/docs/nightly/TortoiseSVN_en/tsvn-dug-conflicts.html) and [mercurial](https://www.mercurial-scm.org/wiki/TutorialConflict).

As proposed on the [mailing list](https://groups.google.com/forum/#!msg/elixir-lang-core/NHLXsV1e4uI/eHARgyRdBQAJ)