### PR TITLE
Mention true, false and nil literals in typespecs

### DIFF
--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -55,6 +55,7 @@ The syntax Elixir provides for type specifications is similar to [the one in Erl
 The following literals are also supported in typespecs:
 
     type :: :atom                         ## Atoms
+          | true | false | nil            # Special atom literals
 
                                           ## Bitstrings
           | <<>>                          # empty bitstring


### PR DESCRIPTION
These were missing from the docs. I'm not sure if mentioning them all in one line is the right way to do it, or should each be on a separate line.