### PR TITLE
Update defdelegate/2 docs to reflect deprecated features

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4016,28 +4016,17 @@ defmodule Kernel do
 
   ## Options
 
-    * `:to` - the expression to delegate to. Any expression
-      is allowed and its results will be evaluated at runtime. Usually
-      evaluates to the name of a module.
+    * `:to` - the module to dispatch to.
 
     * `:as` - the function to call on the target given in `:to`.
       This parameter is optional and defaults to the name being
       delegated (`funs`).
-
-    * `:append_first` - if `true`, when delegated, the first argument
-      passed to the delegated function will be relocated to the end of the
-      arguments when dispatched to the target.
-
-      The motivation behind this is because Elixir normalizes
-      the "handle" as the first argument while some Erlang modules
-      expect it as the last argument.
 
   ## Examples
 
       defmodule MyList do
         defdelegate reverse(list), to: :lists
         defdelegate other_reverse(list), to: :lists, as: :reverse
-        defdelegate [reverse(list), map(list, callback)], to: :lists, append_first: true
       end
 
       MyList.reverse([1, 2, 3])
@@ -4045,9 +4034,6 @@ defmodule Kernel do
 
       MyList.other_reverse([1, 2, 3])
       #=> [3, 2, 1]
-
-      MyList.map([1, 2, 3], &(&1 * 2))
-      #=> [2, 4, 6]
 
   """
   defmacro defdelegate(funs, opts) do

--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -22,6 +22,7 @@ defmodule Kernel.Utils do
   Callback for defdelegate.
   """
   def defdelegate(fun, opts) when is_list(opts) do
+    # TODO: Remove by 2.0
     append_first = Keyword.get(opts, :append_first, false)
 
     {name, args} =


### PR DESCRIPTION
I removed the examples that used deprecated features,
as well as mention which options have been deprecated.