### PR TITLE
Simplify Kernel.match?/2

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2282,18 +2282,10 @@ defmodule Kernel do
       []
 
   """
-  defmacro match?(pattern, expr)
-
-  # Special case where underscore, which always matches, is passed as the first
-  # argument.
-  defmacro match?({:_, _, atom}, _right) when is_atom(atom) do
-    true
-  end
-
-  defmacro match?(left, right) do
+  defmacro match?(pattern, expr) do
     quote do
-      case unquote(right) do
-        unquote(left) ->
+      case unquote(expr) do
+        unquote(pattern) ->
           true
         _ ->
           false

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -199,7 +199,7 @@ defmodule EnumTest do
     assert Enum.filter([1, 2, false, 3, nil], & &1) == [1, 2, 3]
     assert Enum.filter([1, 2, 3], &match?(1, &1)) == [1]
     assert Enum.filter([1, 2, 3], &match?(x when x < 3, &1)) == [1, 2]
-    assert Enum.filter([1, 2, 3], &match?(_, &1)) == [1, 2, 3]
+    assert Enum.filter([1, 2, 3], fn _ -> true end) == [1, 2, 3]
   end
 
   test "filter_map/3" do
@@ -962,7 +962,7 @@ defmodule EnumTest.Range do
 
     assert Enum.filter(1..3, &match?(1, &1)) == [1]
     assert Enum.filter(1..3, &match?(x when x < 3, &1)) == [1, 2]
-    assert Enum.filter(1..3, &match?(_, &1)) == [1, 2, 3]
+    assert Enum.filter(1..3, fn _ -> true end) == [1, 2, 3]
   end
 
   test "filter_map/3" do

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -74,9 +74,6 @@ defmodule KernelTest do
   end
 
   test "match?/2" do
-    assert match?(_, List.first(1)) == true
-    assert binding() == []
-
     a = List.first([0])
     assert match?(b when b > a, 1) == true
     assert binding() == [a: 0]


### PR DESCRIPTION
There's no need for a special handling of the underscore as the pattern,
the case expression is able of optimizing such cases too.

Additionally the right was never evaluated with underscore as the
pattern, which could lead to subtle bugs.

Currently match?(_, foo) will emit a pattern warning since both branches
of the case are exactly the same. This means such expressions had to be
removed from the test suite. They were replaced with the equivalent:

    fn _ -> true end