### PR TITLE
Rename vars in Kernel

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3377,11 +3377,11 @@ defmodule Kernel do
     assert_no_function_scope(env, kind, 2)
     line = env.line
 
-    {call, uc} = :elixir_quote.escape(call, true)
-    {expr, ue} = :elixir_quote.escape(expr, true)
+    {call, unquoted_call} = :elixir_quote.escape(call, true)
+    {expr, unquoted_expr} = :elixir_quote.escape(expr, true)
 
     # Do not check clauses if any expression was unquoted
-    check_clauses = not(ue or uc)
+    check_clauses = not(unquoted_expr or unquoted_call)
     pos = :elixir_locals.cache_env(env)
 
     quote do


### PR DESCRIPTION
Hi all,

I've seen recent PRs making a few var names more declarative, and wonder what you think of these.

I was trying to understand `define/4` in `Kernel`, and came across vars `ue` and `uc` which, at least to me, weren't quickly self-evident.

So I wonder if I even interpreted them right, and also if you think this improves things at all.

If so...great.