### PR TITLE
Inline do in def sequence for KernelTest

### DIFF
--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -99,9 +99,9 @@ defmodule KernelTest do
   @at_list1  [4, 5]
   @at_range 6..8
   @at_list2 [13, 14]
-  def fun_in(x) when x in [0],       do: :list
-  def fun_in(x) when x in 1..3,      do: :range
-  def fun_in(x) when x in @at_list1,  do: :at_list
+  def fun_in(x) when x in [0], do: :list
+  def fun_in(x) when x in 1..3, do: :range
+  def fun_in(x) when x in @at_list1, do: :at_list
   def fun_in(x) when x in @at_range, do: :at_range
   def fun_in(x) when x in [9 | [10, 11]], do: :list_cons
   def fun_in(x) when x in [12 | @at_list2], do: :list_cons_at


### PR DESCRIPTION
Hi all,

came across this sequence of defs which was neither aligned nor inlined, so to speak.

This PR removes the spaces.

If you prefer to align all do's, I'll be happy to change it to that.

Cheers!