### PR TITLE
Add doc example for Module.eval_quoted with __ENV__ as first argument

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -396,20 +396,10 @@ defmodule Module do
 
       Foo.sum(1, 2) #=> 3
 
-  For convenience, you can pass any `Macro.Env` instance, such
-  as  `__ENV__/0`, as an argument and all options will be
-  automatically extracted from the environment:
-
-      defmodule Foo do
-        contents = quote do: (def sum(a, b), do: a + b)
-        Module.eval_quoted __MODULE__, contents, [], __ENV__
-      end
-
-      Foo.sum(1, 2) #=> 3
-
-  You can also pass a `Macro.Env` instance as the first argument,
-  which will have both the module and all options extracted from
-  the environment:
+  For convenience, you can pass any `Macro.Env` struct, such
+  as  `__ENV__/0`, as the first argument or as options. Both
+  the module and all options will be automatically extracted
+  from the environment:
 
       defmodule Foo do
         contents = quote do: (def sum(a, b), do: a + b)

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -419,7 +419,7 @@ defmodule Module do
       Foo.sum(1, 2) #=> 3
 
   """
-  def eval_quoted(module, quoted, binding \\ [], opts \\ [])
+  def eval_quoted(module_or_env, quoted, binding \\ [], opts \\ [])
 
   def eval_quoted(%Macro.Env{} = env, quoted, binding, opts) do
     eval_quoted(env.module, quoted, binding, Keyword.merge(Map.to_list(env), opts))

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -408,6 +408,10 @@ defmodule Module do
 
       Foo.sum(1, 2) #=> 3
 
+  Note that if you pass a `Macro.Env` struct as first argument
+  while also passing `opts`, they will be merged with `opts`
+  having precedence.
+
   """
   def eval_quoted(module_or_env, quoted, binding \\ [], opts \\ [])
 

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -406,6 +406,17 @@ defmodule Module do
 
       Foo.sum(1, 2) #=> 3
 
+  You can also pass `__ENV__/0` as the first argument, which will
+  use the module from the environment as the first argument, and have
+  all options extracted from the environment:
+
+      defmodule Foo do
+        contents = quote do: (def sum(a, b), do: a + b)
+        Module.eval_quoted __ENV__, contents
+      end
+
+      Foo.sum(1, 2) #=> 3
+
   """
   def eval_quoted(module, quoted, binding \\ [], opts \\ [])
 

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -396,8 +396,9 @@ defmodule Module do
 
       Foo.sum(1, 2) #=> 3
 
-  For convenience, you can pass `__ENV__/0` as an argument and
-  all options will be automatically extracted from the environment:
+  For convenience, you can pass any `Macro.Env` instance, such
+  as  `__ENV__/0`, as an argument and all options will be
+  automatically extracted from the environment:
 
       defmodule Foo do
         contents = quote do: (def sum(a, b), do: a + b)
@@ -406,9 +407,9 @@ defmodule Module do
 
       Foo.sum(1, 2) #=> 3
 
-  You can also pass `__ENV__/0` as the first argument, which will
-  use the module from the environment as the first argument, and have
-  all options extracted from the environment:
+  You can also pass a `Macro.Env` instance as the first argument,
+  which will have both the module and all options extracted from
+  the environment:
 
       defmodule Foo do
         contents = quote do: (def sum(a, b), do: a + b)


### PR DESCRIPTION
The usage with __ENV__ as the first argument to Module.eval_quoted was found in [Ecto's schema.ex](https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/schema.ex#L392) but that was not reflected in the docs.

I thought I might add an example for that. Is it ok?