### PR TITLE
Add Elixir 1.2's multi alias to the docs

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -454,6 +454,16 @@ defmodule Kernel.SpecialForms do
 
       alias Foo.Bar.Baz, as: Baz
 
+  We can also alias multiple modules in one line:
+
+      alias Foo.{Bar, Baz, Biz}
+
+  Is the same as:
+
+      alias Foo.Bar
+      alias Foo.Baz
+      alias Foo.Biz
+
   ## Lexical scope
 
   `import/2`, `require/2` and `alias/2` are called directives and all


### PR DESCRIPTION
Gives an example of aliasing multiple modles on a single line