### PR TITLE
Validate options in Code.compiler_options/1

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -440,9 +440,16 @@ defmodule Code do
   def compiler_options(opts) do
     available = available_compiler_options()
 
-    for {k, _} <- opts,
-        not k in available,
-        do: raise "unknown compiler options: #{k}"
+    Enum.each(opts, fn({key, value}) ->
+      cond do
+        not key in available ->
+          raise "unknown compiler option: #{inspect(key)}"
+        not is_boolean(value) ->
+          raise "compiler option #{inspect(key)} should be a boolean, got: #{inspect(value)}"
+        true ->
+          :ok
+      end
+    end)
 
     :elixir_config.update :compiler_options, &Enum.into(opts, &1)
   end

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -161,6 +161,18 @@ defmodule CodeTest do
     assert Code.ensure_compiled?(__MODULE__)
     refute Code.ensure_compiled?(Code.NoFile)
   end
+
+  test "compiler_options/1 validates options" do
+    message = "unknown compiler option: :not_a_valid_option"
+    assert_raise RuntimeError, message, fn ->
+      Code.compiler_options(not_a_valid_option: :foo)
+    end
+
+    message = "compiler option :debug_info should be a boolean, got: :not_a_boolean"
+    assert_raise RuntimeError, message, fn ->
+      Code.compiler_options(debug_info: :not_a_boolean)
+    end
+  end
 end
 
 defmodule Code.SyncTest do


### PR DESCRIPTION
\cc @josevalim, related to #5470, since `Code.compiler_options/1` is called down the road it may be worth improving the already existing validation there as well.