### PR TITLE
Automatically inflect the list of applications, closes #5249

### DIFF
--- a/lib/mix/lib/mix/tasks/deps.ex
+++ b/lib/mix/lib/mix/tasks/deps.ex
@@ -81,6 +81,10 @@ defmodule Mix.Tasks.Deps do
       try to infer the type of project but it can be overridden with this
       option by setting it to `:mix`, `:rebar`, `:rebar3` or `:make`
 
+    * `:runtime` - whether the dependency is part of runtime applications.
+      Defaults to `true` which automatically adds the application to the list
+      of apps that are started automatically and included in releases
+
   ### Git options (`:git`)
 
     * `:git`        - the Git repository URI

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -113,11 +113,11 @@ defmodule Mix.Tasks.New do
   end
 
   defp otp_app(_mod, false) do
-    "    [applications: [:logger]]"
+    "    [extra_applications: [:logger]]"
   end
 
   defp otp_app(mod, true) do
-    "    [applications: [:logger],\n     mod: {#{mod}.Application, []}]"
+    "    [extra_applications: [:logger],\n     mod: {#{mod}.Application, []}]"
   end
   
   defp cd_path(".") do
@@ -218,23 +218,14 @@ defmodule Mix.Tasks.New do
   <%= if @app do %>
   ## Installation
 
-  If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
+  If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+  by adding `<%= @app %>` to your list of dependencies in `mix.exs`:
 
-    1. Add `<%= @app %>` to your list of dependencies in `mix.exs`:
-
-      ```elixir
-      def deps do
-        [{:<%= @app %>, "~> 0.1.0"}]
-      end
-      ```
-
-    2. Ensure `<%= @app %>` is started before your application:
-
-      ```elixir
-      def application do
-        [applications: [:<%= @app %>]]
-      end
-      ```
+  ```elixir
+  def deps do
+    [{:<%= @app %>, "~> 0.1.0"}]
+  end
+  ```
 
   Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
   and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
@@ -255,14 +246,14 @@ defmodule Mix.Tasks.New do
   # Where 3rd-party dependencies like ExDoc output generated docs.
   /doc
 
+  # Ignore .fetch files in case you like to edit your project deps locally.
+  /.fetch
+
   # If the VM crashes, it generates a dump, let's ignore it too.
   erl_crash.dump
 
   # Also ignore archive artifacts (built via "mix archive.build").
   *.ez
-
-  # Ignore .fetch files in case you like to edit your project deps locally.
-  /.fetch
   """
 
   embed_template :mixfile, """
@@ -282,6 +273,7 @@ defmodule Mix.Tasks.New do
     #
     # Type "mix help compile.app" for more information
     def application do
+      # Specify extra applications you'll use from Erlang/Elixir
   <%= @otp_app %>
     end
 
@@ -321,6 +313,7 @@ defmodule Mix.Tasks.New do
     #
     # Type "mix help compile.app" for more information
     def application do
+      # Specify extra applications you'll use from Erlang/Elixir
   <%= @otp_app %>
     end
 

--- a/lib/mix/test/mix/tasks/app.tree_test.exs
+++ b/lib/mix/test/mix/tasks/app.tree_test.exs
@@ -34,10 +34,9 @@ defmodule Mix.Tasks.App.TreeTest do
     in_fixture "umbrella_dep/deps/umbrella", fn ->
       Mix.Project.in_project(:umbrella, ".", fn _ ->
         Mix.Task.run "app.tree", ["--format", "pretty"]
+        assert_received {:mix_shell, :info, ["├── elixir"]}
         assert_received {:mix_shell, :info, ["foo"]}
-        assert_received {:mix_shell, :info, ["└── elixir"]}
-        assert_received {:mix_shell, :info, ["bar"]}
-        assert_received {:mix_shell, :info, ["└── elixir"]}
+        assert_received {:mix_shell, :info, ["    └── elixir"]}
       end)
     end
   end

--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -45,6 +45,10 @@ defmodule Mix.Tasks.EscriptTest do
        escript: [main_module: :escripttest],
        deps: [{:ok, path: fixture_path("deps_status/deps/ok")}]]
     end
+
+    def application do
+      [applications: []]
+    end
   end
 
   defmodule EscriptWithUnknownMainModule do


### PR DESCRIPTION
Before merging this, we need to validate two design decisions:

  1. The list of applications is built per environment. This means test only dependencies, such as `{:meck, "> 0.0.0", only: :test}`, will be added to the list of applications when compiled for test (**and only for test**). This means `:meck` no longer needs to be started manually.

  2. To disable a dependency from being added to the list of applications, we can pass the `runtime: false` to the dependency. Such as `{:mech, "> 0.0.0", only: :test, runtime: false}`. This will disable it from being added to any environment, specially test in this case. Is `:runtime` the best name here?

The reason I decided to go with `1.` is because inflecting the list of dependencies becomes hard otherwise. For example, if we decide to only include the list of production dependencies, what would happen if a dependency is runs **only** in production? Then the application would never boot for dev and test. Then you could say: well, maybe we should add only production dependencies that also belong to the current environment. Which means we would have per-environment behaviour anyway so I decided to go all the way by including all deps in the current environment because it is simpler (simpler to explain, understand and code).

Thoughts?