### PR TITLE
optimized reduce for range

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1756,7 +1756,11 @@ defmodule Enum do
   end
 
   def reduce(first..last, acc, fun) when is_function(fun, 2) do
-    reduce_range(first, last, acc, fun, last >= first)
+    if first <= last do
+      reduce_range_inc(first, last, acc, fun)
+    else
+      reduce_range_dec(first, last, acc, fun)
+    end
   end
 
   def reduce(%{__struct__: _} = enumerable, acc, fun) when is_function(fun, 2) do
@@ -1773,16 +1777,20 @@ defmodule Enum do
                       fn x, acc -> {:cont, fun.(x, acc)} end) |> elem(1)
   end
 
-  defp reduce_range(x, y, acc, fun, true) when x <= y do
-    reduce_range(x + 1, y, fun.(x, acc), fun, true)
+  defp reduce_range_inc(first, first, acc, fun) do
+    fun.(first, acc)
   end
 
-  defp reduce_range(x, y, acc, fun, false) when x >= y do
-    reduce_range(x - 1, y, fun.(x, acc), fun, false)
+  defp reduce_range_inc(first, last, acc, fun) do
+    reduce_range_inc(first + 1, last, fun.(first, acc), fun)
   end
 
-  defp reduce_range(_, _, acc, _, _) do
-    acc
+  defp reduce_range_dec(first, first, acc, fun) do
+    fun.(first, acc)
+  end
+
+  defp reduce_range_dec(first, last, acc, fun)  do
+    reduce_range_dec(first - 1, last, fun.(first, acc), fun)
   end
 
   @doc """


### PR DESCRIPTION
After @josevalim [commit](https://github.com/elixir-lang/elixir/commit/a4682f383d104c350df5c9313aec5d8c953abeb2) yesterday I was playing around with this trying to optimize it a bit more.

What I got seems to be around 30% faster testing with a "noop" reduce function like 

```
def noop(_x, acc) do
  acc
end
```

Here is also the implementation as a [gist](https://gist.github.com/gustf/84d57a8501234587bd8bf9e97268b7ca) that I used for testing.

Example result I got was
```
iex(30)> :timer.tc(ReduceTest, :reduce_new, [1..10000000, 1, &ReduceTest.noop/2]) 
{331031, 1}
iex(31)> :timer.tc(ReduceTest, :reduce_new, [10000000..1, 1, &ReduceTest.noop/2]) 
{339605, 1}
iex(32)> :timer.tc(ReduceTest, :reduce, [1..10000000, 1, &ReduceTest.noop/2])    
{474536, 1}
iex(33)> :timer.tc(ReduceTest, :reduce, [10000000..1, 1, &ReduceTest.noop/2])    
{481838, 1}
```

I am not sure about the "loop unrolling" on lines `1784-1786` and `1796-1798`, as they are a bit of an obfuscation. But they gave 10-15% of the speedup, so I kept them for now.