### PR TITLE
Disable warnings_as_errors for rebar3 dependencies

### DIFF
--- a/lib/mix/lib/mix/rebar.ex
+++ b/lib/mix/lib/mix/rebar.ex
@@ -171,6 +171,20 @@ defmodule Mix.Rebar do
   end
 
   @doc """
+  Update Rebar configuration to be more suitable for dependencies.
+
+  Drops `warnings_as_errors` from `erl_opts`.
+  """
+  def dependency_config(config) do
+    Enum.map(config, fn
+      {:erl_opts, opts} ->
+        {:erl_opts, Enum.reject(opts, &(&1 == :warnings_as_errors))}
+      other ->
+        other
+    end)
+  end
+
+  @doc """
   Parses the dependencies in given `rebar.config` to Mix's dependency format.
   """
   def deps(app, config, overrides) do

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -163,8 +163,14 @@ defmodule Mix.Tasks.Deps.Compile do
     cmd = "#{rebar_cmd(dep)} bare compile --paths #{inspect lib_path}"
 
     File.mkdir_p!(dep_path)
-    File.write!(config_path, Mix.Rebar.serialize_config(dep.extra))
+    File.write!(config_path, rebar_config(dep))
     do_command dep, config, cmd, false, env
+  end
+
+  defp rebar_config(dep) do
+    dep.extra
+    |> Mix.Rebar.dependency_config
+    |> Mix.Rebar.serialize_config
   end
 
   defp rebar_cmd(%Mix.Dep{manager: manager} = dep) do

--- a/lib/mix/test/fixtures/rebar_dep/rebar.config.script
+++ b/lib/mix/test/fixtures/rebar_dep/rebar.config.script
@@ -1,1 +1,4 @@
-CONFIG ++ [{'SCRIPT', SCRIPT}] ++ [{deps, [{git_rebar, "0.1..*", {git, filename:absname("../../test/fixtures/git_rebar"), master}}]}].
+CONFIG ++
+  [{'SCRIPT', SCRIPT}] ++
+  [{erl_opts, [warnings_as_errors]}] ++
+  [{deps, [{git_rebar, "0.1..*", {git, filename:absname("../../test/fixtures/git_rebar"), master}}]}].

--- a/lib/mix/test/mix/rebar_test.exs
+++ b/lib/mix/test/mix/rebar_test.exs
@@ -98,6 +98,14 @@ defmodule Mix.RebarTest do
 
   end
 
+  test "convert rebar config to dependency config" do
+    config = Mix.Rebar.load_config(fixture_path("rebar_dep"))
+    dep_config = Mix.Rebar.dependency_config(config)
+
+    assert config[:erl_opts] == [:warnings_as_errors]
+    assert dep_config[:erl_opts] == []
+  end
+
   test "parse Rebar dependencies from rebar.config" do
     Mix.Project.push(RebarAsDep)
 


### PR DESCRIPTION
Closes #4913.

REBAR_CONFIG bug fixed in rebar3 https://github.com/erlang/rebar3/pull/1387. On the next rebar3 release we need to update `mix local.rebar`.