### PR TITLE
Remove double line-break in List

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -131,7 +131,6 @@ defmodule List do
       iex> List.duplicate([1, 2], 2)
       [[1, 2], [1, 2]]
 
-
   """
   @spec duplicate(elem, non_neg_integer) :: [elem] when elem: var
   def duplicate(elem, n) do


### PR DESCRIPTION
Hey all,

another PR of highly questionable usefulness.

Removed a double line-break inside a `@doc`.

Cheers!