### PR TITLE
Add clarification to Enum.uniq_by

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2555,6 +2555,8 @@ defmodule Enum do
   The function `fun` maps every element to a term which is used to
   determine if two elements are duplicates.
 
+  The first occurrence of each element is kept.
+
   ## Example
 
       iex> Enum.uniq_by([{1, :x}, {2, :y}, {1, :z}], fn {x, _} -> x end)


### PR DESCRIPTION
When I was using `Enum.uniq_by` the following example in the docs helped me understand that the first occurrence of each element was preserved.

```elixir
iex> Enum.uniq_by([{1, :x}, {2, :y}, {1, :z}], fn {x, _} -> x end)
[{1, :x}, {2, :y}]
```

However, the correctness of my code depended on this behavior. So I had to double-check with the source to make sure that this was the case.

I we should explicitly say the first occurrence is kept.

Thoughts?