### PR TITLE
Document how to show all the entries in IEx

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -288,6 +288,10 @@ defmodule IEx do
   when printing results of expression evaluation. Default to
   pretty formatting with a limit of 50 entries.
 
+  To show all entries, configure the limit to `:infinity`:
+
+      IEx.configure [inspect: [limit: :infinity]]
+
   See `Inspect.Opts` for the full list of options.
 
   ## Width


### PR DESCRIPTION
It wasn't clear to me from documentation how to print all of the entries in IEx. As it's useful option while debugging, might be useful to have it in IEx documentation as example. 