### PR TITLE
Improve IEx autocomplete to support navigating map atom keys

### DIFF
--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -24,6 +24,19 @@ defmodule IEx.Evaluator do
     end
   end
 
+  @doc """
+  Gets the binding from the evaluator, for use by autocompletion.
+  """
+  def get_binding(evaluator) do
+    send evaluator, {:peek_binding, self()}
+
+    receive do
+      {:peek_binding, binding} -> binding
+    after
+      5000 -> []
+    end
+  end
+
   defp loop(server, history, state) do
     receive do
       {:eval, ^server, code, iex_state} ->
@@ -32,6 +45,9 @@ defmodule IEx.Evaluator do
         loop(server, history, state)
       {:peek_env, receiver} ->
         send receiver, {:peek_env, state.env}
+        loop(server, history, state)
+      {:peek_binding, receiver} ->
+        send receiver, {:peek_binding, state.binding}
         loop(server, history, state)
       {:done, ^server} ->
         :ok

--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -144,7 +144,11 @@ defmodule IEx.Server do
     loop(run_state(opts), evaluator, Process.monitor(evaluator))
   end
 
-  defp start_evaluator(opts) do
+  @doc """
+  Starst an evaluator using the provided options.
+  """
+  @spec start_evaluator(Keyword.t) :: pid
+  def start_evaluator(opts) do
     self_pid = self()
     self_leader = Process.group_leader
     evaluator = opts[:evaluator] ||

--- a/lib/iex/mix.exs
+++ b/lib/iex/mix.exs
@@ -11,7 +11,6 @@ defmodule IEx.Mixfile do
     [registered: [IEx.Supervisor, IEx.Config],
      mod: {IEx.App, []},
      env: [
-      autocomplete_server: IEx.Server,
       colors: [],
       inspect: [pretty: true],
       history_size: 20,

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -7,8 +7,6 @@ defmodule IEx.AutocompleteTest do
     previous_line = context[:previous_line]
 
     if previous_line do
-      Application.put_env(:iex, :autocomplete_server, __MODULE__.MyServer)
-
       ExUnit.CaptureIO.capture_io(fn ->
         evaluator = IEx.Server.start_evaluator([])
         Process.put(:evaluator, evaluator)
@@ -21,7 +19,7 @@ defmodule IEx.AutocompleteTest do
   end
 
   def expand(expr) do
-    IEx.Autocomplete.expand(Enum.reverse expr)
+    IEx.Autocomplete.expand(Enum.reverse(expr), __MODULE__.MyServer)
   end
 
   test "Erlang module completion" do
@@ -220,16 +218,12 @@ defmodule IEx.AutocompleteTest do
   end
 
   test "complete aliases of Elixir modules" do
-    Application.put_env(:iex, :autocomplete_server, MyServer)
-
     assert expand('MyL') == {:yes, 'ist', []}
     assert expand('MyList') == {:yes, '.', []}
     assert expand('MyList.to_integer') == {:yes, [], ['to_integer/1', 'to_integer/2']}
   end
 
   test "complete aliases of Erlang modules" do
-    Application.put_env(:iex, :autocomplete_server, MyServer)
-
     assert expand('EL') == {:yes, 'ist', []}
     assert expand('EList') == {:yes, '.', []}
     assert expand('EList.map') == {:yes, [], ['map/2', 'mapfoldl/3', 'mapfoldr/3']}

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -3,8 +3,30 @@ Code.require_file "../test_helper.exs", __DIR__
 defmodule IEx.AutocompleteTest do
   use ExUnit.Case, async: true
 
+  setup context do
+    previous_line = context[:previous_line]
+
+    if previous_line do
+      ExUnit.CaptureIO.capture_io(fn ->
+        evaluator = IEx.Server.start_evaluator([])
+        send evaluator, {:eval, self(), previous_line <> "\n", %IEx.State{}}
+        assert_receive {:evaled, _, _}
+        send self(), {:evaluator, evaluator}
+      end)
+
+      evaluator = receive do: ({:evaluator, evaluator} -> evaluator)
+      %{evaluator: evaluator}
+    else
+      :ok
+    end
+  end
+
   def expand(expr) do
     IEx.Autocomplete.expand(Enum.reverse expr)
+  end
+
+  def expand(expr, context) do
+    IEx.Autocomplete.expand(Enum.reverse(expr), context.evaluator)
   end
 
   test "Erlang module completion" do
@@ -91,6 +113,55 @@ defmodule IEx.AutocompleteTest do
   test "function completion with arity" do
     assert expand('String.printable?')  == {:yes, '', ['printable?/1']}
     assert expand('String.printable?/') == {:yes, '', ['printable?/1']}
+  end
+
+  @tag previous_line: "mod = String"
+  test "function completion using a variable bound to a module", context do
+    assert expand('mod.print', context) == {:yes, 'able?', []}
+  end
+
+  @tag previous_line: "map = %{foo: 1, bar_1: 23, bar_2: 14}"
+  test "map atom key completion is supported", context do
+    assert expand('map.f', context) == {:yes, 'oo', []}
+    assert expand('map.b', context) == {:yes, 'ar_', []}
+    assert expand('map.bar_', context) == {:yes, '', ['bar_1', 'bar_2']}
+    assert expand('map.c', context) == {:no, '', []}
+    assert expand('map.', context) == {:yes, '', ['bar_1', 'bar_2', 'foo']}
+    assert expand('map.foo', context) == {:no, '', []}
+  end
+
+  @tag previous_line: "map = %{nested: %{deeply: %{foo: 1, bar_1: 23, bar_2: 14, mod: String, num: 1}}}"
+  test "nested map atom key completion is supported", context do
+    assert expand('map.nested.deeply.f', context) == {:yes, 'oo', []}
+    assert expand('map.nested.deeply.b', context) == {:yes, 'ar_', []}
+    assert expand('map.nested.deeply.bar_', context) == {:yes, '', ['bar_1', 'bar_2']}
+    assert expand('map.nested.deeply.', context) == {:yes, '', ['bar_1', 'bar_2', 'foo', 'mod', 'num']}
+    assert expand('map.nested.deeply.mod.print', context) == {:yes, 'able?', []}
+
+    assert expand('map.nested', context) == {:yes, '.', []}
+    assert expand('map.nested.deeply', context) == {:yes, '.', []}
+    assert expand('map.nested.deeply.foo', context) == {:no, '', []}
+
+    assert expand('map.nested.deeply.c', context) == {:no, '', []}
+    assert expand('map.a.b.c.f', context) == {:no, '', []}
+  end
+
+  @tag previous_line: ~s(map = %{"foo" => 1})
+  test "map string key completion is not supported", context do
+    assert expand('map.f', context) == {:no, '', []}
+  end
+
+  @tag previous_line: "num = 5; map = %{nested: %{num: 23}}"
+  test "autocompletion off a bound variable only works for modules and maps", context do
+    assert expand('num.print', context) == {:no, '', []}
+    assert expand('map.nested.num.f', context) == {:no, '', []}
+    assert expand('map.nested.num.key.f', context) == {:no, '', []}
+  end
+
+  @tag previous_line: "num = 5"
+  test "autocompletion off of unbound variables is not supported", context do
+    assert expand('other_var.f', context) == {:no, '', []}
+    assert expand('a.b.c.d', context) == {:no, '', []}
   end
 
   test "macro completion" do


### PR DESCRIPTION
Eventually we may want to take this a step further and support autocompletion of the variable names themselves but I don't have time today to look into that and that would probably be a separate PR.

I noticed that 1.4.0.rc-0 was just released...any chance this could be included in 1.4?  This is a feature I've long wanted and I'd be sad to see it pushed out months :(.