### PR TITLE
Add links to Erlang modules

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -419,7 +419,7 @@ defmodule Application do
       #=> "bar-123"
 
   For more information on code paths, check the `Code` module in
-  Elixir and also Erlang's `:code` module.
+  Elixir and also Erlang's [`:code` module](http://www.erlang.org/doc/man/code.html).
   """
   @spec app_dir(app) :: String.t
   def app_dir(app) when is_atom(app) do

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1641,7 +1641,7 @@ defmodule Enum do
 
   Raises `Enum.EmptyError` if `enumerable` is empty.
 
-  This function uses Erlang's `:rand` module to calculate
+  This function uses Erlang's [`:rand` module](http://www.erlang.org/doc/man/rand.html) to calculate
   the random value. Check its documentation for setting a
   different random algorithm or a different seed.
 
@@ -1939,7 +1939,7 @@ defmodule Enum do
   @doc """
   Returns a list with the elements of `enumerable` shuffled.
 
-  This function uses Erlang's `:rand` module to calculate
+  This function uses Erlang's [`:rand` module](http://www.erlang.org/doc/man/rand.html) to calculate
   the random value. Check its documentation for setting a
   different random algorithm or a different seed.
 

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -73,12 +73,12 @@ defmodule GenServer do
       using `Process.register/2`.
 
     * `{:global, term}`- the GenServer is registered globally with the given
-      term using the functions in the `:global` module.
+      term using the functions in the [`:global` module](http://www.erlang.org/doc/man/global.html).
 
     * `{:via, module, term}` - the GenServer is registered with the given
       mechanism and name. The `:via` option expects a module that exports
       `register_name/2`, `unregister_name/1`, `whereis_name/1` and `send/2`.
-      One such example is the `:global` module which uses these functions
+      One such example is the [`:global` module](http://www.erlang.org/doc/man/global.html) which uses these functions
       for keeping the list of names of processes and their associated PIDs
       that are available globally for a network of Elixir nodes. Elixir also
       ships with a local, decentralized and scalable registry called `Registry`
@@ -200,12 +200,12 @@ defmodule GenServer do
   ## Debugging with the :sys module
 
   GenServers, as [special processes](http://erlang.org/doc/design_principles/spec_proc.html),
-  can be debugged using the `:sys` module. Through various hooks, this module
+  can be debugged using the [`:sys` module](http://www.erlang.org/doc/man/sys.html). Through various hooks, this module
   allows developers to introspect the state of the process and trace
   system events that happen during its execution, such as received messages,
   sent replies and state changes.
 
-  Let's explore the basic functions from the `:sys` module used for debugging:
+  Let's explore the basic functions from the [`:sys` module](http://www.erlang.org/doc/man/sys.html) used for debugging:
 
     * [`:sys.get_state/2`](http://erlang.org/doc/man/sys.html#get_state-2) -
       allows retrieval of the state of the process. In the case of
@@ -627,8 +627,7 @@ defmodule GenServer do
       milliseconds initializing or it will be terminated and the start function
       will return `{:error, :timeout}`
 
-    * `:debug` - if present, the corresponding function in the [`:sys`
-      module](http://www.erlang.org/doc/man/sys.html) is invoked
+    * `:debug` - if present, the corresponding function in the [`:sys` module](http://www.erlang.org/doc/man/sys.html) is invoked
 
     * `:spawn_opt` - if present, its value is passed as options to the
       underlying process as in `Process.spawn/4`

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -20,8 +20,9 @@ defmodule Kernel do
   cannot be skipped. These are described in `Kernel.SpecialForms`.
 
   Some of the functions described in this module are inlined by
-  the Elixir compiler into their Erlang counterparts in the `:erlang`
-  module. Those functions are called BIFs (built-in internal functions)
+  the Elixir compiler into their Erlang counterparts in the
+  [`:erlang` module](http://www.erlang.org/doc/man/erlang.html).
+  Those functions are called BIFs (built-in internal functions)
   in Erlang-land and they exhibit interesting properties, as some of
   them are allowed in guards and others are used for compiler
   optimizations.

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -348,7 +348,7 @@ defmodule Module do
       it is dispatched to
 
   You can see a handful more options used by the Erlang compiler in
-  the documentation for the `:compile` module.
+  the documentation for the [`:compile` module](http://www.erlang.org/doc/man/compile.html).
   '''
 
   @doc """

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -3,7 +3,7 @@ defmodule Regex do
   Provides regular expressions for Elixir. Built on top of Erlang's `:re`
   module.
 
-  As the `:re` module, Regex is based on PCRE
+  As the [`:re` module](http://www.erlang.org/doc/man/re.html), Regex is based on PCRE
   (Perl Compatible Regular Expressions). More information can be
   found in the [`:re` module documentation](http://www.erlang.org/doc/man/re.html).
 

--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -89,8 +89,9 @@ defmodule Mix.Tasks.Profile.Fprof do
   ## Caveats
 
   You should be aware that the code being profiled is running in an anonymous
-  function which is invoked by `:fprof` module. Thus, you'll see some additional
-  entries in your profile output, such as `:fprof` calls, an anonymous
+  function which is invoked by [`:fprof` module](http://wwww.erlang.org/doc/man/fprof.html).
+  Thus, you'll see some additional entries in your profile output,
+  such as `:fprof` calls, an anonymous
   function with high ACC time, or an `:undefined` function which represents
   the outer caller (non-profiled code which started the profiler).
 


### PR DESCRIPTION
command used to find these cases:

    $ ag '(?<!\[)`\:[^`]+`\s+module'