### PR TITLE
Improves GenServer.handle_info documentation with paragraph about handling all messages.

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -418,6 +418,11 @@ defmodule GenServer do
 
   If this callback is not implemented, the default implementation by
   `use GenServer` will return `{:noreply, state}`.
+
+  The default implementation catches all messages. If you override it,
+  make sure to add a catch-all as final function variant as well,
+  to ensure that a message that your GenServer does not understand
+  is still removed from its inbox.
   """
   @callback handle_info(msg :: :timeout | term, state :: term) ::
     {:noreply, new_state} |

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -420,7 +420,7 @@ defmodule GenServer do
   `use GenServer` will return `{:noreply, state}`.
 
   The default implementation catches all messages. If you override it,
-  make sure to add a catch-all as final function variant as well,
+  make sure to add a catch-all as final function clause as well,
   to ensure that a message that your GenServer does not understand
   is still removed from its inbox.
   """


### PR DESCRIPTION
Recently there was [a question on the Elixirforum](https://elixirforum.com/t/should-we-catch-stray-messages-in-a-genserver/2656/3) about the behaviour of GenServer.handle_info when it was overridden in regards to messages that the GenServer does not understand.

This small Pull Request adds a small paragraph about this, to ensure that people are aware that a catch-all clause for `handle_info` is important to prevent the GenServer's inbox from being clogged up by messages that are not handled.

