### PR TITLE
Hard-deprecate String.*strip/1,2 functions

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -602,12 +602,12 @@ defmodule String do
 
   @doc false
   # TODO: Remove by 2.0
-  # (hard-deprecated in elixir_rewrite)
+  # (hard-deprecated in elixir_dispatch)
   defdelegate rstrip(binary), to: String.Break, as: :trim_trailing
 
   @doc false
   # TODO: Remove by 2.0
-  # (hard-deprecated in elixir_rewrite)
+  # (hard-deprecated in elixir_dispatch)
   def rstrip(string, char) when is_integer(char) do
     replace_trailing(string, <<char::utf8>>, "")
   end
@@ -790,26 +790,26 @@ defmodule String do
 
   @doc false
   # TODO: Remove by 2.0
-  # (hard-deprecated in elixir_rewrite)
+  # (hard-deprecated in elixir_dispatch)
   defdelegate lstrip(binary), to: String.Break, as: :trim_leading
 
   @doc false
   # TODO: Remove by 2.0
-  # (hard-deprecated in elixir_rewrite)
+  # (hard-deprecated in elixir_dispatch)
   def lstrip(string, char) when is_integer(char) do
     replace_leading(string, <<char::utf8>>, "")
   end
 
   @doc false
   # TODO: Remove by 2.0
-  # (hard-deprecated in elixir_rewrite)
+  # (hard-deprecated in elixir_dispatch)
   def strip(string) do
     trim(string)
   end
 
   @doc false
   # TODO: Remove by 2.0
-  # (hard-deprecated in elixir_rewrite)
+  # (hard-deprecated in elixir_dispatch)
   def strip(string, char) do
     trim(string, <<char::utf8>>)
   end

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -601,11 +601,13 @@ defmodule String do
   end
 
   @doc false
-  # TODO: Deprecate by 1.5
+  # TODO: Remove by 2.0
+  # (hard-deprecated in elixir_rewrite)
   defdelegate rstrip(binary), to: String.Break, as: :trim_trailing
 
   @doc false
-  # TODO: Deprecate by 1.5
+  # TODO: Remove by 2.0
+  # (hard-deprecated in elixir_rewrite)
   def rstrip(string, char) when is_integer(char) do
     replace_trailing(string, <<char::utf8>>, "")
   end
@@ -787,23 +789,27 @@ defmodule String do
   end
 
   @doc false
-  # TODO: Deprecate by 1.5
+  # TODO: Remove by 2.0
+  # (hard-deprecated in elixir_rewrite)
   defdelegate lstrip(binary), to: String.Break, as: :trim_leading
 
   @doc false
-  # TODO: Deprecate by 1.5
+  # TODO: Remove by 2.0
+  # (hard-deprecated in elixir_rewrite)
   def lstrip(string, char) when is_integer(char) do
     replace_leading(string, <<char::utf8>>, "")
   end
 
   @doc false
-  # TODO: Deprecate by 1.5
+  # TODO: Remove by 2.0
+  # (hard-deprecated in elixir_rewrite)
   def strip(string) do
     trim(string)
   end
 
   @doc false
-  # TODO: Deprecate by 1.5
+  # TODO: Remove by 2.0
+  # (hard-deprecated in elixir_rewrite)
   def strip(string, char) do
     trim(string, <<char::utf8>>)
   end

--- a/lib/elixir/src/elixir_dispatch.erl
+++ b/lib/elixir/src/elixir_dispatch.erl
@@ -347,11 +347,27 @@ deprecation_message(Warning, Message) ->
     Message -> Warning ++ ", " ++ Message
   end.
 
+%% Modules
 deprecation('Elixir.HashDict', _, _) ->
   "use maps and the Map module instead";
 deprecation('Elixir.HashSet', _, _) ->
   "use the MapSet module instead";
 deprecation('Elixir.Dict', _, _) ->
   "use the Map module for working with maps or the Keyword module for working with keyword lists";
+
+%% Single functions
+deprecation('Elixir.String', strip, 1) ->
+  "use String.trim/1";
+deprecation('Elixir.String', lstrip, 1) ->
+  "use String.trim_leading/1";
+deprecation('Elixir.String', rstrip, 1) ->
+  "use String.trim_trailing/1";
+deprecation('Elixir.String', strip, 2) ->
+  "use String.trim/2 with a binary second argument";
+deprecation('Elixir.String', lstrip, 2) ->
+  "use String.trim_leading/2 with a binary second argument";
+deprecation('Elixir.String', rstrip, 2) ->
+  "use String.trim_trailing/2 with a binary second argument";
+
 deprecation(_, _, _) ->
   false.

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -219,38 +219,6 @@ rewrite(?enum, DotMeta, 'reverse', Meta, [List], _Env) ->
      {'->', Generated, [[Var], Slow]}]
   }]]};
 
-%% Deprecations
-
-%% String.*strip/1 functions
-rewrite(?string, DotMeta, strip, Meta, [String], Env) ->
-  Warning = "String.strip/1 is deprecated, use String.trim/1",
-  elixir_errors:warn(?line(Meta), ?m(Env, file), Warning),
-  remote(?string, DotMeta, trim, Meta, [String]);
-rewrite(?string, DotMeta, lstrip, Meta, [String], Env) ->
-  Warning = "String.lstrip/1 is deprecated, use String.trim_leading/1",
-  elixir_errors:warn(?line(Meta), ?m(Env, file), Warning),
-  remote(?string, DotMeta, trim_leading, Meta, [String]);
-rewrite(?string, DotMeta, rstrip, Meta, [String], Env) ->
-  Warning = "String.rstrip/1 is deprecated, use String.trim_trailing/1",
-  elixir_errors:warn(?line(Meta), ?m(Env, file), Warning),
-  remote(?string, DotMeta, trim_trailing, Meta, [String]);
-
-%% String.*strip/2 functions
-rewrite(?string, DotMeta, strip, Meta, [String, Char], Env) ->
-  Warning = "String.strip/2 is deprecated, use String.trim/2 with a binary replacement",
-  elixir_errors:warn(?line(Meta), ?m(Env, file), Warning),
-  remote(?string, DotMeta, trim, Meta, [String, <<Char/utf8>>]);
-rewrite(?string, DotMeta, lstrip, Meta, [String, Char], Env) when is_integer(Char) ->
-  Warning = ["String.lstrip/2 is deprecated, use String.replace_leading/3 ",
-             "with a binary patter and an empty replacement"],
-  elixir_errors:warn(?line(Meta), ?m(Env, file), Warning),
-  remote(?string, DotMeta, replace_leading, Meta, [String, <<Char/utf8>>, <<>>]);
-rewrite(?string, DotMeta, rstrip, Meta, [String, Char], Env) when is_integer(Char) ->
-  Warning = ["String.rstrip/2 is deprecated, use String.replace_trailing/3 ",
-             "with a binary patter and an empty replacement"],
-  elixir_errors:warn(?line(Meta), ?m(Env, file), Warning),
-  remote(?string, DotMeta, replace_trailing, Meta, [String, <<Char/utf8>>, <<>>]);
-
 rewrite(Receiver, DotMeta, Right, Meta, Args, _Env) ->
   {EReceiver, ERight, EArgs} = rewrite(Receiver, Right, Args),
   remote(EReceiver, DotMeta, ERight, Meta, EArgs).

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -219,6 +219,38 @@ rewrite(?enum, DotMeta, 'reverse', Meta, [List], _Env) ->
      {'->', Generated, [[Var], Slow]}]
   }]]};
 
+%% Deprecations
+
+%% String.*strip/1 functions
+rewrite(?string, DotMeta, strip, Meta, [String], Env) ->
+  Warning = "String.strip/1 is deprecated, use String.trim/1",
+  elixir_errors:warn(?line(Meta), ?m(Env, file), Warning),
+  remote(?string, DotMeta, trim, Meta, [String]);
+rewrite(?string, DotMeta, lstrip, Meta, [String], Env) ->
+  Warning = "String.lstrip/1 is deprecated, use String.trim_leading/1",
+  elixir_errors:warn(?line(Meta), ?m(Env, file), Warning),
+  remote(?string, DotMeta, trim_leading, Meta, [String]);
+rewrite(?string, DotMeta, rstrip, Meta, [String], Env) ->
+  Warning = "String.rstrip/1 is deprecated, use String.trim_trailing/1",
+  elixir_errors:warn(?line(Meta), ?m(Env, file), Warning),
+  remote(?string, DotMeta, trim_trailing, Meta, [String]);
+
+%% String.*strip/2 functions
+rewrite(?string, DotMeta, strip, Meta, [String, Char], Env) ->
+  Warning = "String.strip/2 is deprecated, use String.trim/2 with a binary replacement",
+  elixir_errors:warn(?line(Meta), ?m(Env, file), Warning),
+  remote(?string, DotMeta, trim, Meta, [String, <<Char/utf8>>]);
+rewrite(?string, DotMeta, lstrip, Meta, [String, Char], Env) when is_integer(Char) ->
+  Warning = ["String.lstrip/2 is deprecated, use String.replace_leading/3 ",
+             "with a binary patter and an empty replacement"],
+  elixir_errors:warn(?line(Meta), ?m(Env, file), Warning),
+  remote(?string, DotMeta, replace_leading, Meta, [String, <<Char/utf8>>, <<>>]);
+rewrite(?string, DotMeta, rstrip, Meta, [String, Char], Env) when is_integer(Char) ->
+  Warning = ["String.rstrip/2 is deprecated, use String.replace_trailing/3 ",
+             "with a binary patter and an empty replacement"],
+  elixir_errors:warn(?line(Meta), ?m(Env, file), Warning),
+  remote(?string, DotMeta, replace_trailing, Meta, [String, <<Char/utf8>>, <<>>]);
+
 rewrite(Receiver, DotMeta, Right, Meta, Args, _Env) ->
   {EReceiver, ERight, EArgs} = rewrite(Receiver, Right, Args),
   remote(EReceiver, DotMeta, ERight, Meta, EArgs).


### PR DESCRIPTION
First in a set of deprecations to be implemented for 1.5. I'd love to take care of all of them if no one argues against that :)

Also, I am not 100% sure we should keep the implementation in both `elixir_rewrite` as well as `String`, but it seems to be what we do for other rewrites. Suggestions?