### PR TITLE
Hard-deprecate Enum.partition/2

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1630,7 +1630,8 @@ defmodule Enum do
   end
 
   @doc false
-  # TODO: Deprecate by v1.5
+  # TODO: Remove by 2.0
+  # (hard-deprecated in elixir_dispatch)
   @spec partition(t, (element -> any)) :: {list, list}
   def partition(enumerable, fun) when is_function(fun, 1) do
     split_with(enumerable, fun)

--- a/lib/elixir/src/elixir_dispatch.erl
+++ b/lib/elixir/src/elixir_dispatch.erl
@@ -368,6 +368,8 @@ deprecation('Elixir.String', lstrip, 2) ->
   "use String.trim_leading/2 with a binary second argument";
 deprecation('Elixir.String', rstrip, 2) ->
   "use String.trim_trailing/2 with a binary second argument";
+deprecation('Elixir.Enum', partition, 2) ->
+  "use Enum.split_with/2";
 
 deprecation(_, _, _) ->
   false.


### PR DESCRIPTION
(PS: sorry for spamming with very small PRs but I prefer to keep them as small as it makes sense to and also I always prefer a second eye for this, that's why I'm not pushing to master :) )