### PR TITLE
Use pipeline is System time functions

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -646,7 +646,9 @@ defmodule System do
   """
   @spec monotonic_time(time_unit) :: integer
   def monotonic_time(unit) do
-    :erlang.monotonic_time(normalize_time_unit(unit))
+    unit
+    |> normalize_time_unit
+    |> :erlang.monotonic_time
   end
 
   @doc """
@@ -672,7 +674,9 @@ defmodule System do
   """
   @spec system_time(time_unit) :: integer
   def system_time(unit) do
-    :erlang.system_time(normalize_time_unit(unit))
+    unit
+    |> normalize_time_unit
+    |> :erlang.system_time
   end
 
   @doc """


### PR DESCRIPTION
Hi all,

studying `system.ex` here, and wondering if pipelining a couple of functions would make them more readable and idiomatic.

Both are very similar. One of them originally was:
```
:erlang.monotonic_time(normalize_time_unit(unit))
```

So I applied pipes.

Cheers!

