### PR TITLE
Improve syntax error for "fn do ... end"

### DIFF
--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1043,6 +1043,6 @@ invalid_do_error(Prefix) ->
   "Syntax error before: ".
 
 do_with_fn_error(Prefix) ->
-  Prefix ++ ". Anonymous function literals do not accept do...end blocks. Their syntax is:\n\n"
-  "    fn -> :result end\n\n"
+  Prefix ++ ". Anonymous functions are written as:\n\n"
+  "    fn pattern -> expression end\n\n"
   "Syntax error before: ".

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -972,6 +972,8 @@ check_keyword(_Line, _Column, _Length, Atom, [{capture_op, _, _} | _]) when ?ope
 check_keyword(DoLine, DoColumn, _Length, do, [{Identifier, {Line, Column, EndColumn}, Atom} | T]) when Identifier == identifier ->
   {ok, add_token_with_nl({do, {DoLine, DoColumn, DoColumn + 2}},
        [{do_identifier, {Line, Column, EndColumn}, Atom} | T])};
+check_keyword(_Line, _Column, _Length, do, [{'fn', _} | _]) ->
+  {error, do_with_fn_error("unexpected token \"do\""), "do"};
 check_keyword(Line, Column, _Length, do, Tokens) ->
   case do_keyword_valid(Tokens) of
     true  -> {ok, add_token_with_nl({do, {Line, Column, Column + 2}}, Tokens)};
@@ -1038,4 +1040,9 @@ invalid_do_error(Prefix) ->
   "is syntactic sugar for the Elixir construct:\n\n"
   "    if(some_condition?, do: :this, else: :that)\n\n"
   "where \"some_condition?\" is the first argument and the second argument is a keyword list.\n\n"
+  "Syntax error before: ".
+
+do_with_fn_error(Prefix) ->
+  Prefix ++ ". Anonymous function literals do not accept do...end blocks. Their syntax is:\n\n"
+  "    fn -> :result end\n\n"
   "Syntax error before: ".

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -852,6 +852,14 @@ defmodule Kernel.ErrorsTest do
       ':ok ?す'
   end
 
+  test "good error message on \"fn do expr end\"" do
+    assert_compile_fail SyntaxError,
+      "nofile:1: unexpected token \"do\". Anonymous functions are written as:\n\n" <>
+        "    fn pattern -> expression end\n\n" <>
+        "Syntax error before: do",
+      'fn do :ok end'
+  end
+
   test "invalid var or function on guard" do
     assert_compile_fail CompileError,
       "nofile:4: unknown variable something_that_does_not_exist or " <>


### PR DESCRIPTION
<strike>I took a stab at #5527 but I am definitely not sure this is the way to go, would love opinions on this as I'm sure I will learn something out of it :).</strike>

Closes #5527.

Btw, it doesn't work for `fn (...) do ... end`, but it should still be a worthy improvement.