### PR TITLE
Remove redundant preposition from Access doc

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -82,7 +82,7 @@ defmodule Access do
       #=> "John"
 
   The same `user.name` syntax can also be used by `Kernel.put_in/2`
-  to for updating structs fields:
+  for updating structs fields:
 
       put_in user.name, "Mary"
       #=> %User{name: "Mary"}


### PR DESCRIPTION
Hi all,

`can also be used … to for updating`  → `can also be used …
  for updating`

Cheers!

