### PR TITLE
Add Port.stream!/2

### DIFF
--- a/lib/elixir/lib/port.ex
+++ b/lib/elixir/lib/port.ex
@@ -263,6 +263,53 @@ defmodule Port do
     :erlang.ports
   end
 
+  @doc """
+  Returns a `Port.Stream`, accepting the same `name` and `settings`
+  arguments accepted by `Port.open/2`.
+
+  The stream implements both `Enumerable` and `Collectable` protocols,
+  which means it can be used both for sending and receiving messages
+  to and from the port.
+
+  Operating the stream can fail on open for the same reasons as `Port.open/2`. See
+  [`:erlang.open_port/2`](http://www.erlang.org/doc/man/erlang.html#open_port-2)
+  for error codes and failure scenarios.
+
+  In case the port is opened with the `{:line, l}` flag, the stream takes care of
+  concatenating messages into complete lines. This is not the case when a third
+  `raw` argument is passed as `true`. In this case, the stream of data from the
+  port is untouched (again, see
+  [`:erlang.open_port/2`](http://www.erlang.org/doc/man/erlang.html#open_port-2)
+  for the different types of messages).
+
+  If not already present, `Port.stream!` sets the `:exit_status` flag. This is to
+  ensure that the port lets us know when it is closing, so that we can halt the
+  stream.
+
+  ## Examples
+
+      # Open a line-based port stream.
+      Port.stream!({:spawn_executable, "/usr/bin/ls"}, [{:line, 2048}])
+      #=> %Port.Stream{name: {:spawn_executable, "/usr/bin/ls"},
+      #=> settings: [{:line, 2048}], raw: false}
+
+      # Open a raw port stream.
+      Port.stream!({:spawn, "echo hello"}, [:binary], true)
+      #=> %Port.Stream{name: {:spawn, "echo hello"},
+      #=> settings: [:binary], raw: true}
+
+      # Stream from a file into a port
+      File.stream!("code")
+      |> Stream.map(&String.replace(&1, "#", "%"))
+      |> Stream.into(Port.stream!({:spawn, "./script.sh"}, [:binary]))
+      |> Stream.run
+
+  """
+  @spec stream!(name, list, boolean()) :: Port.Stream.t
+  def stream!(name, settings, raw \\ false) do
+    Port.Stream.__build__(name, settings, raw)
+  end
+
   @compile {:inline, nillify: 1}
   defp nillify(:undefined), do: nil
   defp nillify(other),      do: other

--- a/lib/elixir/lib/port/server.ex
+++ b/lib/elixir/lib/port/server.ex
@@ -1,0 +1,102 @@
+defmodule Port.Server do
+  @moduledoc """
+  Utility GenServer to exchange data with a port.
+  It is used by `Port.Stream`.
+
+  """
+
+  use GenServer
+
+  def start_link(name, settings, raw) do
+    GenServer.start_link(__MODULE__, {name, settings, raw})
+  end
+
+  def fetch(pid) do
+    GenServer.call(pid, :fetch)
+  end
+
+  def command(pid, data, options \\ []) do
+    GenServer.call(pid, {:command, data, options})
+  end
+
+  def close(pid) do
+    GenServer.call(pid, :close)
+  end
+
+
+  def init({name, settings, raw}) do
+    {:ok, %{
+      port: Port.open(name, settings),
+      buffer: :queue.new(),
+      terminated: false,
+      raw: raw,
+      line: nil
+    }}
+  end
+
+
+  def handle_call(:fetch, _from, %{terminated: true} = state) do
+    {:reply, {:halt, self()}, state}
+  end
+
+  def handle_call(:fetch, _from, %{buffer: buffer} = state) do
+    {value, new_buffer} = case :queue.out(buffer) do
+      {{:value, value}, new_buffer} -> {[value], new_buffer}
+      {:empty, new_buffer}          -> {[], new_buffer}
+    end
+
+    {:reply, {value, self()}, %{state | buffer: new_buffer}}
+  end
+
+  def handle_call({:command, data, options}, _from, %{port: port} = state) do
+    Port.command(port, data, options)
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:close, _from, %{port: port} = state) do
+    Port.close(port)
+    {:reply, :ok, state}
+  end
+
+  def handle_info({_port, {:data, data}}, %{raw: true, buffer: buffer} = state) do
+    {:noreply, %{state | buffer: :queue.in(data, buffer)}}
+  end
+
+  def handle_info({_port, {:data, {:eol, data}}}, %{line: nil, buffer: buffer} = state) do
+    {:noreply, %{state | buffer: :queue.in(data, buffer)}}
+  end
+
+  def handle_info({_port, {:data, {:eol, data}}}, %{line: line, buffer: buffer} = state) do
+    buffer = :queue.in(concat(line, data), buffer)
+    {:noreply, %{state | line: nil, buffer: buffer}}
+  end
+
+  def handle_info({_port, {:data, {:noeol, data}}}, %{line: nil} = state) do
+    {:noreply, %{state | line: data}}
+  end
+
+  def handle_info({_port, {:data, {:noeol, data}}}, %{line: line} = state) do
+    {:noreply, %{state | line: concat(line, data)}}
+  end
+
+  def handle_info({_port, {:data, data}}, %{buffer: buffer} = state) do
+    {:noreply, %{state | buffer: :queue.in(data, buffer)}}
+  end
+
+
+  def handle_info({_port, {:exit_status, _status}}, state) do
+    {:noreply, %{state | terminated: true}}
+  end
+
+  def handle_info({_port, :eof}, state) do
+    {:noreply, %{state | terminated: true}}
+  end
+
+  def terminate(_reason, _state) do
+    :ok
+  end
+
+
+  defp concat(line, data) when is_binary(data), do: line <> data
+  defp concat(line, data), do: line ++ data
+end

--- a/lib/elixir/lib/port/stream.ex
+++ b/lib/elixir/lib/port/stream.ex
@@ -1,0 +1,67 @@
+defmodule Port.Stream do
+  @moduledoc """
+  Defines a `Port.Stream` struct returned by `Port.stream!/3`.
+
+  The following fields are public:
+
+    * `name`     - the name tuple expected by `Port.open/2`
+    * `settings` - the settings arguments expected by `Port.open/2`
+    * `raw`      - if set to `true`, the stream of data is proxied from the port, with no modifications
+
+  """
+
+  defstruct name: nil, settings: [], raw: false
+
+  @type t :: %__MODULE__{}
+
+  @doc false
+  def __build__(name, settings, raw) do
+    settings = case :exit_status in settings do
+      true  -> settings
+      false -> [:exit_status | settings]
+    end
+
+    %Port.Stream{name: name, settings: settings, raw: raw}
+  end
+
+  defimpl Collectable do
+    def into(%{name: name, settings: settings, raw: raw} = stream) do
+      {:ok, server_pid} = Port.Server.start_link(name, settings, raw)
+      into(server_pid, stream)
+    end
+
+    defp into(server_pid, stream) do
+      fn
+        :ok, {:cont, x} ->
+          :ok = Port.Server.command(server_pid, x)
+        :ok, :done ->
+          :ok = Port.Server.close(server_pid)
+          stream
+        :ok, :halt ->
+          :ok = Port.Server.close(server_pid)
+      end
+    end
+  end
+
+  defimpl Enumerable do
+    def reduce(%{name: name, settings: settings, raw: raw}, acc, fun) do
+      start_fun = fn ->
+        {:ok, server_pid} = Port.Server.start_link(name, settings, raw)
+        server_pid
+      end
+
+      next_fun = &Port.Server.fetch/1
+      stop_fun = &Process.exit(&1, :normal)
+
+      Stream.resource(start_fun, next_fun, stop_fun).(acc, fun)
+    end
+
+    def count(_stream) do
+      {:error, __MODULE__}
+    end
+
+    def member?(_stream, _term) do
+      {:error, __MODULE__}
+    end
+  end
+end

--- a/lib/elixir/test/elixir/port_test.exs
+++ b/lib/elixir/test/elixir/port_test.exs
@@ -2,6 +2,7 @@ Code.require_file "test_helper.exs", __DIR__
 
 defmodule PortTest do
   use ExUnit.Case, async: true
+  import PathHelpers
 
   test "info/1,2 with registered name" do
     {:ok, port} = :gen_udp.open(0)
@@ -17,5 +18,62 @@ defmodule PortTest do
 
     assert Port.info(port, :registered_name) == nil
     assert Port.info(port) == nil
+  end
+
+  test "stream map" do
+    stream = Port.stream!({:spawn, "echo"}, [:stream])
+
+    assert %Port.Stream{} = stream
+    assert stream.name == {:spawn, "echo"}
+    assert stream.settings == [:exit_status, :stream]
+    assert stream.raw == false
+
+    stream = Port.stream!({:spawn, "echo"}, [:stream], true)
+    assert stream.raw == true
+  end
+
+  test "stream simple" do
+    {name, settings} = case windows?() do
+      true  -> {{:spawn, "cmd /c echo hello"}, []}
+      false -> {{:spawn, "echo hello"}, []}
+    end
+
+    messages = Port.stream!(name, settings) |> Enum.into([])
+    assert messages == ['hello\n']
+  end
+
+  test "stream binary" do
+    {name, settings} = case windows?() do
+      true  -> {{:spawn, "cmd /c echo hello"}, [:binary]}
+      false -> {{:spawn, "echo hello"}, [:binary]}
+    end
+
+    stream = Port.stream!(name, settings)
+
+    transformed = Enum.map stream, fn(data) ->
+      String.replace(data, "e", "a")
+    end
+
+    assert transformed == ["hallo\n"]
+  end
+
+  test "stream line" do
+    {name, settings} = case windows?() do
+      true  -> {{:spawn, "cmd /c echo 'hello\nworld"}, [:binary, {:line, 2048}]}
+      false -> {{:spawn, "echo 'hello\nworld'"}, [:binary, {:line, 2048}]}
+    end
+
+    lines = Port.stream!(name, settings) |> Enum.into([])
+    assert lines == ["hello", "world"]
+  end
+
+  test "stream raw and line" do
+    {name, settings} = case windows?() do
+      true  -> {{:spawn, "cmd /c echo hello"}, [{:line, 2}]}
+      false -> {{:spawn, "echo hello"}, [{:line, 2}]}
+    end
+
+    messages = Port.stream!(name, settings, true) |> Enum.into([])
+    assert messages == [{:noeol, 'he'}, {:noeol, 'll'}, {:eol, 'o'}]
   end
 end


### PR DESCRIPTION
Hi there! 

This PR is to add `stream!/2` to the `Port` module, in order to create `Collectable` and `Enumerable` streams from Erlang ports. 🎉

A `Port.Server` GenServer is used internally, to have a single point of contact with the port. I initially tried opening and serving the stream from the calling process, but this made using ports' streams with `Experimental.Flow` impossible, as the consuming processes would be different from the one that initially opened the port. I couldn't come up with a better idea to avoid the additional GenServer, but obviously open to suggestions! 🙇 

As stated in the documentation, split lines are stitched together before going downstream (I found this particularly needed for things like CSV parsing), but this can be turned off by passing a third `raw` argument set to `true`, which makes the stream proxy all data messages from the port.

Hope this is something useful (and decently implemented!). 
Thank you very much in advance! 👋 