### PR TITLE
:transient supervisor restart clarification

### DIFF
--- a/lib/elixir/lib/supervisor/spec.ex
+++ b/lib/elixir/lib/supervisor/spec.ex
@@ -76,7 +76,7 @@ defmodule Supervisor.Spec do
       terminates abnormally, i.e., with an exit reason other than
       `:normal`, `:shutdown` or `{:shutdown, term}`
   
-  Notice that supervisor that reached `max_restart_intensity` will exit with `:shutdown` reason. 
+  Notice that supervisor that reached max restart intensity will exit with `:shutdown` reason. 
   In this case children that have `:transient` restart value in their child spec will not be restarted, 
   because this reason it is not considered to be abnormal.
 

--- a/lib/elixir/lib/supervisor/spec.ex
+++ b/lib/elixir/lib/supervisor/spec.ex
@@ -75,6 +75,10 @@ defmodule Supervisor.Spec do
     * `:transient` - the child process is restarted only if it
       terminates abnormally, i.e., with an exit reason other than
       `:normal`, `:shutdown` or `{:shutdown, term}`
+  
+  Notice that whenever supervisor with `:transient` restart value reaches `max_restart_intensity`,
+  it would not be restarted, since exit reason in this case is `:shutdown` and it is not considered 
+  to be abnormal.
 
   ### Shutdown values (:shutdown)
 

--- a/lib/elixir/lib/supervisor/spec.ex
+++ b/lib/elixir/lib/supervisor/spec.ex
@@ -77,8 +77,8 @@ defmodule Supervisor.Spec do
       `:normal`, `:shutdown` or `{:shutdown, term}`
   
   Notice that supervisor that reached max restart intensity will exit with `:shutdown` reason. 
-  In this case children that have `:transient` restart value in their child spec will not be restarted, 
-  because this reason it is not considered to be abnormal.
+  In this case the supervisor will only be restarted if its child specification was defined with 
+  a `:restart` of `:permanent` (the default).
 
   ### Shutdown values (:shutdown)
 

--- a/lib/elixir/lib/supervisor/spec.ex
+++ b/lib/elixir/lib/supervisor/spec.ex
@@ -76,9 +76,9 @@ defmodule Supervisor.Spec do
       terminates abnormally, i.e., with an exit reason other than
       `:normal`, `:shutdown` or `{:shutdown, term}`
   
-  Notice that whenever supervisor with `:transient` restart value reaches `max_restart_intensity`,
-  it would not be restarted, since exit reason in this case is `:shutdown` and it is not considered 
-  to be abnormal.
+  Notice that supervisor that reached `max_restart_intensity` will exit with `:shutdown` reason. 
+  In this cases childs that have `:transient` restart value in their child spec will not be restarted, 
+  because this reason it is not considered to be abnormal.
 
   ### Shutdown values (:shutdown)
 

--- a/lib/elixir/lib/supervisor/spec.ex
+++ b/lib/elixir/lib/supervisor/spec.ex
@@ -78,7 +78,7 @@ defmodule Supervisor.Spec do
   
   Notice that supervisor that reached maximum restart intensity will exit with `:shutdown` reason. 
   In this case the supervisor will only be restarted if its child specification was defined with 
-  a `:restart` of `:permanent` (the default).
+  the `:restart` option set to `:permanent` (the default).
 
   ### Shutdown values (:shutdown)
 

--- a/lib/elixir/lib/supervisor/spec.ex
+++ b/lib/elixir/lib/supervisor/spec.ex
@@ -77,7 +77,7 @@ defmodule Supervisor.Spec do
       `:normal`, `:shutdown` or `{:shutdown, term}`
   
   Notice that supervisor that reached `max_restart_intensity` will exit with `:shutdown` reason. 
-  In this case childrens that have `:transient` restart value in their child spec will not be restarted, 
+  In this case children that have `:transient` restart value in their child spec will not be restarted, 
   because this reason it is not considered to be abnormal.
 
   ### Shutdown values (:shutdown)

--- a/lib/elixir/lib/supervisor/spec.ex
+++ b/lib/elixir/lib/supervisor/spec.ex
@@ -77,7 +77,7 @@ defmodule Supervisor.Spec do
       `:normal`, `:shutdown` or `{:shutdown, term}`
   
   Notice that supervisor that reached `max_restart_intensity` will exit with `:shutdown` reason. 
-  In this cases childs that have `:transient` restart value in their child spec will not be restarted, 
+  In this case childrens that have `:transient` restart value in their child spec will not be restarted, 
   because this reason it is not considered to be abnormal.
 
   ### Shutdown values (:shutdown)

--- a/lib/elixir/lib/supervisor/spec.ex
+++ b/lib/elixir/lib/supervisor/spec.ex
@@ -78,7 +78,7 @@ defmodule Supervisor.Spec do
   
   Notice that supervisor that reached maximum restart intensity will exit with `:shutdown` reason. 
   In this case the supervisor will only be restarted if its child specification was defined with 
-  the `:restart` option set to `:permanent` (the default).
+  the `:restart` option is set to `:permanent` (the default).
 
   ### Shutdown values (:shutdown)
 

--- a/lib/elixir/lib/supervisor/spec.ex
+++ b/lib/elixir/lib/supervisor/spec.ex
@@ -76,7 +76,7 @@ defmodule Supervisor.Spec do
       terminates abnormally, i.e., with an exit reason other than
       `:normal`, `:shutdown` or `{:shutdown, term}`
   
-  Notice that supervisor that reached max restart intensity will exit with `:shutdown` reason. 
+  Notice that supervisor that reached maximum restart intensity will exit with `:shutdown` reason. 
   In this case the supervisor will only be restarted if its child specification was defined with 
   a `:restart` of `:permanent` (the default).
 


### PR DESCRIPTION
Clarify that `:transient` supervisor will not be restarted when reaches `max_restart_intensity` because of `:shutdown` exit reason.

It would be nice to have someone who will proofread changes :).