### PR TITLE
Highlight that :gen.stop/3 is synchronous

### DIFF
--- a/lib/elixir/lib/agent.ex
+++ b/lib/elixir/lib/agent.ex
@@ -295,7 +295,7 @@ defmodule Agent do
   end
 
   @doc """
-  Stops the agent with the given `reason`.
+  Stops synchronously the agent with the given `reason`.
 
   It returns `:ok` if the server terminates with the given
   reason, if it terminates with another reason, the call will

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -684,7 +684,7 @@ defmodule GenServer do
   end
 
   @doc """
-  Stops the server with the given `reason`.
+  Stops synchronously the server with the given `reason`.
 
   The `c:terminate/2` callback of the given `server` will be invoked before
   exiting. This function returns `:ok` if the server terminates with the

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -505,7 +505,7 @@ defmodule Supervisor do
   end
 
   @doc """
-  Stops the given supervisor with the given `reason`.
+  Stops synchronously the given supervisor with the given `reason`.
 
   It returns `:ok` if the supervisor terminates with the given
   reason. If it terminates with another reason, the call exits.


### PR DESCRIPTION
It's an important information, that makes the concerned functions much more
useful in contexts where synchronous termination is important, such as cleaning
up related processes in tests.