### PR TITLE
Make the example a valid mix project

### DIFF
--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -77,7 +77,7 @@ defmodule Mix.Tasks.Escript.Build do
         def project do
           [app: :my_app,
            version: "0.0.1",
-           escript: escript]
+           escript: escript()]
         end
 
         def escript do

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -74,6 +74,8 @@ defmodule Mix.Tasks.Escript.Build do
   ## Example
 
       defmodule MyApp.Mixfile do
+        use Mix.Project
+
         def project do
           [app: :my_app,
            version: "0.0.1",


### PR DESCRIPTION
I couldn't build the example code without using `use Mix.Project`.
I could build it with using `use Mix.Project`.

```
/Users/niku/sandbox% cat mix.exs
defmodule MyApp.Mixfile do
  def project do
    [app: :my_app,
     version: "0.0.1",
     escript: escript()]
  end

  def escript do
    [main_module: MyApp.CLI]
  end
end

defmodule MyApp.CLI do
  def main(_args) do
    IO.puts("Hello from MyApp!")
  end
end
/Users/niku/sandbox% mix escript.build
** (Mix) Could not find a Mix.Project, please ensure a mix.exs file is available
```

```
/Users/niku/sandbox% cat mix.exs
defmodule MyApp.Mixfile do
  use Mix.Project

  def project do
    [app: :my_app,
     version: "0.0.1",
     escript: escript()]
  end

  def escript do
    [main_module: MyApp.CLI]
  end
end

defmodule MyApp.CLI do
  def main(_args) do
    IO.puts("Hello from MyApp!")
  end
end
/Users/niku/sandbox% mix escript.build
Generated my_app app
Generated escript my_app with MIX_ENV=dev
```
