### PR TITLE
Better behavior for the default test task when no tests were found

### DIFF
--- a/lib/mix/lib/mix/compilers/test.ex
+++ b/lib/mix/lib/mix/compilers/test.ex
@@ -36,6 +36,10 @@ defmodule Mix.Compilers.Test do
         Mix.shell.info "No stale tests."
         :noop
 
+      [] when test_patterns == [] ->
+        Mix.shell.info "There are no tests to run"
+        :noop
+
       [] ->
         Mix.shell.error "Test patterns did not match any file: " <> Enum.join(test_patterns, ", ")
         :noop

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -122,8 +122,8 @@ defmodule Mix.Tasks.Test do
   ## Configuration
 
     * `:test_paths` - list of paths containing test files, defaults to
-      `["test"]`. It is expected all test paths to contain a `test_helper.exs`
-      file.
+      `["test"]` if the `test` directory exists, otherwise it defaults to `[]`.
+      It is expected all test paths to contain a `test_helper.exs` file.
 
     * `:test_pattern` - a pattern to load test files, defaults to `*_test.exs`.
 
@@ -225,7 +225,7 @@ defmodule Mix.Tasks.Test do
     ex_unit_opts = ex_unit_opts(opts)
     ExUnit.configure(ex_unit_opts)
 
-    test_paths = project[:test_paths] || ["test"]
+    test_paths = project[:test_paths] || default_test_paths()
     Enum.each(test_paths, &require_test_helper(&1))
     ExUnit.configure(merge_helper_opts(ex_unit_opts))
 
@@ -363,6 +363,14 @@ defmodule Mix.Tasks.Test do
       Code.require_file file
     else
       Mix.raise "Cannot run tests because test helper file #{inspect file} does not exist"
+    end
+  end
+
+  defp default_test_paths do
+    if File.dir?("test") do
+      ["test"]
+    else
+      []
     end
   end
 end

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -108,6 +108,14 @@ defmodule Mix.Tasks.TestTest do
     end
   end
 
+  test "logs test absence for a project with no test paths" do
+    in_fixture "test_stale", fn ->
+      File.rm_rf! "test"
+
+      assert_run_output "There are no tests to run"
+    end
+  end
+
   test "--listen-on-stdin: runs tests after input" do
     in_fixture "test_stale", fn ->
       port = mix_port(~w[test --stale --listen-on-stdin])
@@ -190,6 +198,10 @@ defmodule Mix.Tasks.TestTest do
   end
 
   defp assert_stale_run_output(opts \\ [], expected) do
-    assert mix(~w[test --stale] ++ opts) =~ expected
+    assert_run_output(["--stale" | opts], expected)
+  end
+
+  defp assert_run_output(opts \\ [], expected) do
+    assert mix(["test" | opts]) =~ expected
   end
 end


### PR DESCRIPTION
This born in a discussion on this issue #5556.

- [x] Show a warning instead of an error when the test helper is not found
- [x] Improve the message for when no test path is given
- [x] Test scenarios for each of the above