### PR TITLE
Fix whitespace inconsistencies outside Elixir lib

### DIFF
--- a/lib/ex_unit/lib/ex_unit/on_exit_handler.ex
+++ b/lib/ex_unit/lib/ex_unit/on_exit_handler.ex
@@ -11,7 +11,7 @@ defmodule ExUnit.OnExitHandler do
     Agent.update(@name, &Map.put(&1, pid, []))
   end
 
-  @spec add(pid, term, (()-> term)) :: :ok | :error
+  @spec add(pid, term, (() -> term)) :: :ok | :error
   def add(pid, name_or_ref, callback) when is_pid(pid) and is_function(callback, 0) do
     Agent.get_and_update(@name, fn map ->
       if entries = Map.get(map, pid) do

--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -102,7 +102,7 @@ defmodule IEx.Autocomplete do
     if prefix in [0, length] do
       yes("", Enum.flat_map(entries, &to_entries/1))
     else
-      yes(:binary.part(first.name, prefix, length-prefix), [])
+      yes(:binary.part(first.name, prefix, length - prefix), [])
     end
   end
 
@@ -218,7 +218,7 @@ defmodule IEx.Autocomplete do
     for mod <- match_modules(base, module === Elixir),
         parts = String.split(mod, "."),
         depth <= length(parts) do
-      %{kind: :module, type: :elixir, name: Enum.at(parts, depth-1)}
+      %{kind: :module, type: :elixir, name: Enum.at(parts, depth - 1)}
     end
     |> Enum.uniq
   end

--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -307,7 +307,7 @@ defmodule Logger.Translator do
       crash_info(min_level, info, [?\n, indent | indent])]
   end
 
-  defp format_stop({maybe_exception, [_ | _ ] = maybe_stacktrace} = reason) do
+  defp format_stop({maybe_exception, [_ | _] = maybe_stacktrace} = reason) do
     try do
       format_stacktrace(maybe_stacktrace)
     catch
@@ -331,7 +331,7 @@ defmodule Logger.Translator do
   # OTP processes rewrite the :undef error to these reasons when logging
   @gen_undef [:"module could not be loaded", :"function not exported"]
 
-  defp format_stop_banner(undef, [{mod, fun, args, _info} | _ ]  = stacktrace)
+  defp format_stop_banner(undef, [{mod, fun, args, _info} | _]  = stacktrace)
   when undef in @gen_undef and is_atom(mod) and is_atom(fun) do
     cond do
       is_list(args) ->

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -32,10 +32,10 @@ defmodule Logger.Utils do
     end
   end
 
-  defp truncate_n(int, n) when int in 0..127,                      do: {int, n-1}
-  defp truncate_n(int, n) when int in 127..0x07FF,                 do: {int, n-2}
-  defp truncate_n(int, n) when int in 0x800..0xFFFF,               do: {int, n-3}
-  defp truncate_n(int, n) when int >= 0x10000 and is_integer(int), do: {int, n-4}
+  defp truncate_n(int, n) when int in 0..127,                      do: {int, n - 1}
+  defp truncate_n(int, n) when int in 127..0x07FF,                 do: {int, n - 2}
+  defp truncate_n(int, n) when int in 0x800..0xFFFF,               do: {int, n - 3}
+  defp truncate_n(int, n) when int >= 0x10000 and is_integer(int), do: {int, n - 4}
 
   defp truncate_n(list, n) when is_list(list) do
     truncate_n_list(list, n, [])

--- a/lib/mix/lib/mix/generator.ex
+++ b/lib/mix/lib/mix/generator.ex
@@ -78,7 +78,7 @@ defmodule Mix.Generator do
             @file file
             File.read!(file)
           c when is_binary(c) ->
-            @file {__ENV__.file, __ENV__.line+1}
+            @file {__ENV__.file, __ENV__.line + 1}
             c
           _ ->
             raise ArgumentError, "expected string or from_file: file"

--- a/lib/mix/lib/mix/local/installer.ex
+++ b/lib/mix/lib/mix/local/installer.ex
@@ -255,7 +255,7 @@ defmodule Mix.Local.Installer do
       path = Path.join(root, name)
       cond do
         not File.exists?(path) ->
-          Mix.shell.error "Could not find a local #{item_name} named #{inspect name}. "<>
+          Mix.shell.error "Could not find a local #{item_name} named #{inspect name}. " <>
                           "Existing #{item_plural} are:"
           Mix.Task.run item_name
           nil

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -119,11 +119,11 @@ defmodule Mix.Tasks.New do
   defp otp_app(mod, true) do
     "    [extra_applications: [:logger],\n     mod: {#{mod}.Application, []}]"
   end
-  
+
   defp cd_path(".") do
     ""
   end
-  
+
   defp cd_path(path) do
     "cd #{path}\n    "
   end


### PR DESCRIPTION
Fixing white-space inconsistencies around operators, parentheses and trailing white-space on all projects outside elixir.