### PR TITLE
Optimize Enum.count/2

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -486,9 +486,9 @@ defmodule Enum do
   """
   @spec count(t, (element -> as_boolean(term))) :: non_neg_integer
   def count(enumerable, fun) when is_function(fun, 1) do
-    Enumerable.reduce(enumerable, {:cont, 0}, fn(entry, acc) ->
-      {:cont, if(fun.(entry), do: acc + 1, else: acc)}
-    end) |> elem(1)
+    reduce(enumerable, 0, fn(entry, acc) ->
+      if(fun.(entry), do: acc + 1, else: acc)
+    end)
   end
 
   @doc """


### PR DESCRIPTION
reduce/3 has clauses specialized for various enumerable types, so should be
much faster than the general Enumerable.reduce/3 case, especially that we don't
need additional facilities like terminating the reduction early.

Comparing 3 implementations:

  * map based

        elements |> Enum.map(&(if check(&1), do: 1, else: 0)) |> Enum.sum

  * count/2 based

        elements |> Enum.count(&check/1)

  * filter based

        elements |> Enum.filter(&check/1) |> Enum.count

We get following results before and after the change:

len   | map       | count before | count after | filter
------|-----------|--------------|-------------|------------
10    | 2.1706 μs | 7.0754 μs    | 1.6304 μs   | 1.9765 μs
100   | 19.921 μs | 27.579 μs    | 13.057 μs   | 14.591 μs
1000  | 168.93 μs | 178.93 μs    | 130.76 μs   | 163.43 μs
10000 | 2128.9 μs | 1822.1 μs    | 1298.2 μs   | 1664.6 μs

The most idiomatic code is now also the fastest.