### PR TITLE
Correct documentation referencing System.schedulers_online/1 to System.schedulers_online/0.

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -295,7 +295,7 @@ defmodule Task do
   are emitted in the same order as the original `enumerable`.
 
   The level of concurrency can be controlled via the `:max_concurrency`
-  option and defaults to `System.schedulers_online/1`. A timeout
+  option and defaults to `System.schedulers_online/0`. A timeout
   can also be given as an option representing the maximum amount of
   time to wait without a task reply.
 
@@ -307,7 +307,7 @@ defmodule Task do
   ## Options
 
     * `:max_concurrency` - sets the maximum number of tasks to run
-      at the same time. Defaults to `System.schedulers_online/1`.
+      at the same time. Defaults to `System.schedulers_online/0`.
     * `:timeout` - the maximum amount of time to wait (in milliseconds)
       without receiving a task reply (across all running tasks).
       Defaults to `5000`.

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -122,7 +122,7 @@ defmodule Task.Supervisor do
   are emitted in the same order as the original `enumerable`.
 
   The level of concurrency can be controlled via the `:max_concurrency`
-  option and defaults to `System.schedulers_online/1`. A timeout
+  option and defaults to `System.schedulers_online/0`. A timeout
   can also be given as an option representing the maximum amount of
   time to wait without a task reply.
 
@@ -133,7 +133,7 @@ defmodule Task.Supervisor do
   ## Options
 
     * `:max_concurrency` - sets the maximum number of tasks to run
-      at the same time. Defaults to `System.schedulers_online/1`.
+      at the same time. Defaults to `System.schedulers_online/0`.
     * `:timeout` - the maximum amount of time to wait (in milliseconds)
       without receiving a task reply (across all running tasks).
       Defaults to `5000`.


### PR DESCRIPTION
Noticed some errors in the documentation of `Task.async_stream` and friends...