### PR TITLE
Talk a bit about keyword syntax in the Keyword module

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -42,7 +42,7 @@ defmodule Keyword do
   duplicated entries for a given key are removed when invoked.
   Note that operations that require keys to be found in the keyword
   list (like `Keyword.get/3`) need to traverse the list in order
-  to find keys, so these operations may result slower than their map
+  to find keys, so these operations may be slower than their map
   counterparts.
 
   A handful of functions exist to handle duplicated keys, in

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -6,6 +6,31 @@ defmodule Keyword do
   element of the tuple is an atom and the second element
   can be any value.
 
+  For example, the following is a keyword list:
+
+      [{:exit_on_close, true}, {:active, :once}, {:packet_size, 1024}]
+
+  Elixir provides a special and more concise syntax for keyword lists
+  that looks like this:
+
+      [exit_on_close: true, active: :once, packet_size: 1024]
+
+  This is also the syntax that Elixir uses to inspect keyword lists:
+
+      iex> [{:active, :once}]
+      [active: :once]
+
+  The two syntaxes are completely equivalent. Note that when keyword
+  lists are passed as the last argument to a function, if the short-hand
+  syntax is used then the square brackets around the keyword list can
+  be omitted as well. For example, the following:
+
+      String.split("1-0", "-", trim: true, parts: 2)
+
+  is equivalent to:
+
+      String.split("1-0", "-", [trim: true, parts: 2])
+
   A keyword may have duplicated keys so it is not strictly
   a key-value store. However most of the functions in this module
   behave exactly as a dictionary so they work similarly to
@@ -15,6 +40,10 @@ defmodule Keyword do
   the given key, regardless if duplicated entries exist.
   Similarly, `Keyword.put/3` and `Keyword.delete/3` ensure all
   duplicated entries for a given key are removed when invoked.
+  Note that operations that require keys to be found in the keyword
+  list (like `Keyword.get/3`) need to traverse the list in order
+  to find keys, so these operations may result slower than their map
+  counterparts.
 
   A handful of functions exist to handle duplicated keys, in
   particular, `Enum.into/2` allows creating new keywords without
@@ -22,7 +51,7 @@ defmodule Keyword do
   a given key and `delete_first/2` deletes just one of the existing
   entries.
 
-  The functions in Keyword do not guarantee any property when
+  The functions in `Keyword` do not guarantee any property when
   it comes to ordering. However, since a keyword list is simply a
   list, all the operations defined in `Enum` and `List` can be
   applied too, especially when ordering is required.


### PR DESCRIPTION
We do this for maps for example, maybe it's worth doing for keywords as well. Not sure this is the best place since `{:ok, foo: :bar}` is allowed as well, but I think it's a good start anyways :)