### PR TITLE
Improve documentation for `File.dir?`

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -96,7 +96,21 @@ defmodule File do
   end
 
   @doc """
-  Returns `true` if the path is a directory.
+  Returns `true` if the path points to a directory.
+  It works with absolute and relative paths. Shell expansions like `~` are not
+  allowed.
+
+  ## Examples:
+
+      File.dir?("../")
+      #=> true
+
+      File.dir?("/")
+      #=> true
+
+      File.dir?("~")
+      #=> false
+
   """
   @spec dir?(Path.t) :: boolean
   def dir?(path) do


### PR DESCRIPTION
According to #5565 the documentation for `File.dir?` was missing some
information. This commit explain that it works for both absolute and
relative paths but do not expand shell expansions like `~`.