### PR TITLE
Doctests for basic agent functionality

### DIFF
--- a/lib/elixir/lib/agent.ex
+++ b/lib/elixir/lib/agent.ex
@@ -150,6 +150,13 @@ defmodule Agent do
 
   If the given function callback fails with `reason`, the function returns
   `{:error, reason}`.
+
+  ## Examples
+
+      iex> {:ok, pid} = Agent.start_link fn -> 42 end
+      iex> Agent.get pid, fn(state) -> state end
+      42
+
   """
   @spec start_link((() -> term), GenServer.options) :: on_start
   def start_link(fun, options \\ []) when is_function(fun, 0) do
@@ -172,6 +179,13 @@ defmodule Agent do
   Starts an agent process without links (outside of a supervision tree).
 
   See `start_link/2` for more information.
+
+  ## Examples
+
+      iex> {:ok, pid} = Agent.start fn -> 42 end
+      iex> Agent.get pid, fn(state) -> state end
+      42
+
   """
   @spec start((() -> term), GenServer.options) :: on_start
   def start(fun, options \\ []) when is_function(fun, 0) do
@@ -197,6 +211,13 @@ defmodule Agent do
   returned.
 
   A timeout can also be specified (it has a default value of 5000).
+
+  ## Examples
+
+      iex> {:ok, pid} = Agent.start_link fn -> 42 end
+      iex> Agent.get pid, fn(state) -> state end
+      42
+
   """
   @spec get(agent, (state -> a), timeout) :: a when a: var
   def get(agent, fun, timeout \\ 5000) when is_function(fun, 1) do
@@ -224,6 +245,15 @@ defmodule Agent do
   and the second one is the new state.
 
   A timeout can also be specified (it has a default value of 5000).
+
+  ## Examples
+
+      iex> {:ok, pid} = Agent.start_link fn -> 42 end
+      iex> Agent.get_and_update pid, fn(state) -> {state, state + 1} end
+      42
+      iex> Agent.get pid, fn(state) -> state end
+      43
+
   """
   @spec get_and_update(agent, (state -> {a, state}), timeout) :: a when a: var
   def get_and_update(agent, fun, timeout \\ 5000) when is_function(fun, 1) do
@@ -250,6 +280,15 @@ defmodule Agent do
 
   A timeout can also be specified (it has a default value of 5000).
   This function always returns `:ok`.
+
+  ## Examples
+
+      iex> {:ok, pid} = Agent.start_link fn -> 42 end
+      iex> Agent.update pid, fn(state) -> state + 1 end
+      :ok
+      iex> Agent.get pid, fn(state) -> state end
+      43
+
   """
   @spec update(agent, (state -> state), timeout) :: :ok
   def update(agent, fun, timeout \\ 5000) when is_function(fun, 1) do
@@ -304,6 +343,13 @@ defmodule Agent do
   This function keeps OTP semantics regarding error reporting.
   If the reason is any other than `:normal`, `:shutdown` or
   `{:shutdown, _}`, an error report will be logged.
+
+  ## Examples
+
+      iex> {:ok, pid} = Agent.start_link fn -> 42 end
+      iex> Agent.stop pid
+      :ok
+
   """
   @spec stop(agent, reason :: term, timeout) :: :ok
   def stop(agent, reason \\ :normal, timeout \\ :infinity) do

--- a/lib/elixir/lib/agent.ex
+++ b/lib/elixir/lib/agent.ex
@@ -153,8 +153,8 @@ defmodule Agent do
 
   ## Examples
 
-      iex> {:ok, pid} = Agent.start_link fn -> 42 end
-      iex> Agent.get pid, fn(state) -> state end
+      iex> {:ok, pid} = Agent.start_link(fn -> 42 end)
+      iex> Agent.get(pid, fn(state) -> state end)
       42
 
   """
@@ -182,8 +182,8 @@ defmodule Agent do
 
   ## Examples
 
-      iex> {:ok, pid} = Agent.start fn -> 42 end
-      iex> Agent.get pid, fn(state) -> state end
+      iex> {:ok, pid} = Agent.start(fn -> 42 end)
+      iex> Agent.get(pid, fn(state) -> state end)
       42
 
   """
@@ -214,8 +214,8 @@ defmodule Agent do
 
   ## Examples
 
-      iex> {:ok, pid} = Agent.start_link fn -> 42 end
-      iex> Agent.get pid, fn(state) -> state end
+      iex> {:ok, pid} = Agent.start_link(fn -> 42 end)
+      iex> Agent.get(pid, fn(state) -> state end)
       42
 
   """
@@ -248,10 +248,10 @@ defmodule Agent do
 
   ## Examples
 
-      iex> {:ok, pid} = Agent.start_link fn -> 42 end
-      iex> Agent.get_and_update pid, fn(state) -> {state, state + 1} end
+      iex> {:ok, pid} = Agent.start_link(fn -> 42 end)
+      iex> Agent.get_and_update(pid, fn(state) -> {state, state + 1} end)
       42
-      iex> Agent.get pid, fn(state) -> state end
+      iex> Agent.get(pid, fn(state) -> state end)
       43
 
   """
@@ -283,10 +283,10 @@ defmodule Agent do
 
   ## Examples
 
-      iex> {:ok, pid} = Agent.start_link fn -> 42 end
-      iex> Agent.update pid, fn(state) -> state + 1 end
+      iex> {:ok, pid} = Agent.start_link(fn -> 42 end)
+      iex> Agent.update(pid, fn(state) -> state + 1 end)
       :ok
-      iex> Agent.get pid, fn(state) -> state end
+      iex> Agent.get(pid, fn(state) -> state end)
       43
 
   """
@@ -346,8 +346,8 @@ defmodule Agent do
 
   ## Examples
 
-      iex> {:ok, pid} = Agent.start_link fn -> 42 end
-      iex> Agent.stop pid
+      iex> {:ok, pid} = Agent.start_link(fn -> 42 end)
+      iex> Agent.stop(pid)
       :ok
 
   """

--- a/lib/elixir/test/elixir/agent_test.exs
+++ b/lib/elixir/test/elixir/agent_test.exs
@@ -2,6 +2,7 @@ Code.require_file "test_helper.exs", __DIR__
 
 defmodule AgentTest do
   use ExUnit.Case, async: true
+
   doctest Agent
 
   def identity(state) do

--- a/lib/elixir/test/elixir/agent_test.exs
+++ b/lib/elixir/test/elixir/agent_test.exs
@@ -2,6 +2,7 @@ Code.require_file "test_helper.exs", __DIR__
 
 defmodule AgentTest do
   use ExUnit.Case, async: true
+  doctest Agent
 
   def identity(state) do
     state


### PR DESCRIPTION
Read the docs and thought it'd be nice to have usage examples
right there so why not make it doc tests :)

It's a bit repetetive as you always need to start the agent and
I figured even for start/start_link it'd be nice to show that
the value now lives there but that might be discussion worthy.

I also started out always calling Agent.stop to stop the agent
(the other agent tests do that) but the GenServer tests don't
seem to shut it down every time so I thought it might be okay
here in favor of less clutter and to have more clarity :)

Happy about feedback!