### PR TITLE
Clarify how to use test_stdlib instead of test_elixir

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ code is divided in applications inside the `lib` folder:
 
 You can run all tests in the root directory with `make test` and you can
 also run tests for a specific framework `make test_#{NAME}`, for example,
-`make test_ex_unit`.
+`make test_ex_unit`. If you just changed something in the elixir standard
+library you can run only that portion through `make test_stdlib`, as
+`test_elixir` also runs tests for the other projects (eex, exunit etc.).
 
 In case you are changing a single file, you can compile and run tests only
 for that particular file for fast development cycles. For example, if you


### PR DESCRIPTION
I always thought test_elixir was broken as from the directory
structure I'd have expected it to only run the tests in elixir
e.g. the standard library which is what I mostly touch around
here :) However, it always ran almost everything.

A look at the Makefile reveals that this seems intentional but
that there's also test_stdlib, which seems for to point out in
the README imo.

as always, thanks for elixir :green_heart: 