### PR TITLE
Issue warning instead of error for unhandled messages

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -568,8 +568,8 @@ defmodule GenServer do
             {_, []}   -> self()
             {_, name} -> name
           end
-        :error_logger.error_msg('~p ~p received unexpected message in handle_info/2: ~p~n',
-                                [__MODULE__, proc, msg])
+        :error_logger.warning_msg('~p ~p received unexpected message in handle_info/2: ~p~n',
+                                  [__MODULE__, proc, msg])
         {:noreply, state}
       end
 

--- a/lib/elixir/test/elixir/gen_server_test.exs
+++ b/lib/elixir/test/elixir/gen_server_test.exs
@@ -3,6 +3,8 @@ Code.require_file "test_helper.exs", __DIR__
 defmodule GenServerTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   defmodule Stack do
     use GenServer
 
@@ -160,5 +162,14 @@ defmodule GenServerTest do
 
     {:ok, _} = GenServer.start(Stack, [], name: :stack_for_stop)
     assert GenServer.stop(:stack_for_stop, :normal) == :ok
+  end
+
+  test "handle_info/2 warning" do
+    {:ok, pid} = GenServer.start(Stack, [])
+    log = capture_log(fn ->
+      send(pid, :foo)
+      GenServer.stop(pid)
+    end)
+    assert log =~ "[warn]  GenServerTest.Stack #{inspect pid} received unexpected message in handle_info/2: :foo"
   end
 end


### PR DESCRIPTION
While the change to start logging unhandled messages from handle_info/2 is a
good one, the choice to issue "error" level events was a poor one. Code that
worked perfectly fine on previous versions suddenly started issuing errors,
which is unexpected. A "warn" level log seems to be a better choice, at least
initially. The log level can be revisited in the future.