### PR TITLE
Enum.find_and_update/3

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -931,6 +931,35 @@ defmodule Enum do
   end
 
   @doc """
+  Finds the first element in the enumerable that return true
+  for the finder function and updates it with the updater function.
+
+  ## Examples
+
+      iex> Enum.find_and_update([1, 2, 3, 4], fn(x) -> rem(x, 2) == 0 end, &(&1 * 2))
+      [1, 4, 3, 4]
+
+  """
+  @spec find_and_update(t, (element -> as_boolean(term)),
+    (element -> element)) :: list
+  def find_and_update(enumerable, finder, updater)
+
+  def find_and_update(enumerable, finder, updater)
+      when is_list(enumerable) and is_function(finder, 1) and is_function(updater, 1) do
+    case find_index(enumerable, finder) do
+      nil -> enumerable
+      index -> List.replace_at(enumerable, index, updater.(at(enumerable, index)))
+    end
+  end
+
+  def find_and_update(enumerable, finder, updater)
+      when is_function(finder, 1) and is_function(updater, 1) do
+    enumerable
+    |> to_list
+    |> find_and_update(finder, updater)
+  end
+
+  @doc """
   Returns a new enumerable appending the result of invoking `fun` on
   each corresponding item of `enumerable`.
 

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -226,6 +226,13 @@ defmodule EnumTest do
     assert Enum.find_value([2, 3, 4], fn(x) -> rem(x, 2) == 1 end)
   end
 
+  test "find_and_update/3" do
+    assert Enum.find_and_update([1, 2, 3, 4], fn(x) -> rem(x, 2) == 0 end, &(&1 * 2)) == [1, 4, 3, 4]
+    assert Enum.find_and_update(1..4, fn(x) -> rem(x, 2) == 0 end, &(&1 * 2)) == [1, 4, 3, 4]
+    assert Enum.find_and_update([1, 2, 3, 4], fn(x) -> x > 5 end, &(&1 * 2)) == [1, 2, 3, 4]
+    assert Enum.find_and_update(["Hi", "There"], fn(x) -> String.length(x) > 3 end,  &(String.downcase(&1))) == ["Hi", "there"]
+  end
+
   test "flat_map/2" do
     assert Enum.flat_map([], fn(x) -> [x, x] end) == []
     assert Enum.flat_map([1, 2, 3], fn(x) -> [x, x] end) == [1, 1, 2, 2, 3, 3]


### PR DESCRIPTION
Hello!

This PR would add Enum.find_and_update/3, which finds the first element in an enum that returns true for a finder function, and replaces it in the enum with the return value of the updater function.

Similar to Map.get_and_update, but for enum.