### PR TITLE
Fix ceil function with zero as input

### DIFF
--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -203,7 +203,8 @@ defmodule Float do
     count = count - exp + 1023
 
     cond do
-      count <= 0 -> # There is no decimal precision
+      count <= 0 or  # There is no decimal precision
+      (0 == exp and <<0::52>> == significant) -> #zero or minus zero
         float
 
       count >= 104 -> # Precision beyond 15 digits

--- a/lib/elixir/test/elixir/float_test.exs
+++ b/lib/elixir/test/elixir/float_test.exs
@@ -80,6 +80,7 @@ defmodule FloatTest do
     assert Float.ceil(0.32453e-10) === 1.0
     assert Float.ceil(-0.32453e-10) === 0.0
     assert Float.ceil(1.32453e-10) === 1.0
+    assert Float.ceil(0.0) === 0.0
   end
 
   test "ceil/2 with precision" do
@@ -94,6 +95,8 @@ defmodule FloatTest do
 
     assert Float.ceil(12.32453e-20, 2) === 0.01
     assert Float.ceil(-12.32453e-20, 2) === 0.0
+
+    assert Float.ceil(0.0, 2) === 0.0
   end
 
   test "round/2" do


### PR DESCRIPTION
Fix for [issue](https://github.com/elixir-lang/elixir/issues/5593).
Zero has sepcial encoding as IEEE754 floating point number with a 0 value for exponent. This encoding requires special handling in current Float.round implementation.