### PR TITLE
Remove redundancy from Version doc

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -66,7 +66,7 @@ defmodule Version do
 
   When `allow_pre: false` is set the requirement will not match a
   pre-release version unless the operand is a pre-release version.
-  The default is to allow always allow pre-releases but note that in
+  The default is to always allow pre-releases but note that in
   Hex `:allow_pre` is set to `false.` See the table below for examples.
 
   Requirement    | Version     | `:allow_pre` | Matches


### PR DESCRIPTION
Hi all,

`…the default is to allow always allow…` → `…the default is to always allow…`

Happy new year!