### PR TITLE
Remove isolated multiple space from VersionTest

### DIFF
--- a/lib/elixir/test/elixir/version_test.exs
+++ b/lib/elixir/test/elixir/version_test.exs
@@ -1,7 +1,7 @@
 Code.require_file "test_helper.exs", __DIR__
 
 defmodule VersionTest do
-  use   ExUnit.Case, async: true
+  use ExUnit.Case, async: true
 
   doctest Version
 


### PR DESCRIPTION
Hi all, 

`use___ExUnit.Case, async: true` → `use ExUnit.Case, async: true` with no lines around justifying the multiple space.

Cheers!

