### PR TITLE
Fix Macro.to_string/2 for "unusual" atom remote calls

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -840,8 +840,10 @@ defmodule Macro do
     do: "(" <> module_to_string(arg, fun) <> ")."
   defp call_to_string({:., _, [arg]}, fun),
     do: module_to_string(arg, fun) <> "."
+  defp call_to_string({:., _, [left, right]}, fun) when is_atom(right),
+    do: module_to_string(left, fun) <> "." <> call_to_string_for_atom(right)
   defp call_to_string({:., _, [left, right]}, fun),
-    do: module_to_string(left, fun) <> "." <> if(is_atom(right), do: call_to_string_for_atom(right), else: call_to_string(right, fun))
+    do: module_to_string(left, fun) <> "." <> call_to_string(right, fun)
   defp call_to_string(other, fun),
     do: to_string(other, fun)
 

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -418,15 +418,15 @@ defmodule KernelTest do
 
       result = expand_to_string(quote(do: rand() in 1..2))
       assert result =~ "var = rand()"
-      assert result =~ ":erlang.andalso(:erlang.is_integer(var), :erlang.andalso(:erlang.>=(var, 1), :erlang.=<(var, 2)))"
+      assert result =~ ":erlang.andalso(:erlang.is_integer(var), :erlang.andalso(:erlang.>=(var, 1), :erlang.\"=<\"(var, 2)))"
 
       result = expand_to_string(quote(do: rand() in [1, 2]))
       assert result =~ "var = rand()"
-      assert result =~ ":erlang.or(:erlang.=:=(var, 2), :erlang.=:=(var, 1))"
+      assert result =~ ":erlang.or(:erlang.\"=:=\"(var, 2), :erlang.\"=:=\"(var, 1))"
 
       result = expand_to_string(quote(do: rand() in [1 | [2]]))
       assert result =~ "var = rand()"
-      assert result =~ ":erlang.or(:erlang.=:=(var, 1), :erlang.=:=(var, 2))"
+      assert result =~ ":erlang.or(:erlang.\"=:=\"(var, 1), :erlang.\"=:=\"(var, 2))"
     end
 
     defp expand_to_string(ast) do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -271,6 +271,12 @@ defmodule MacroTest do
     assert Macro.to_string(quote do: :foo.(1, 2, 3)) == ":foo.(1, 2, 3)"
   end
 
+  test "unusual remote atom fun call to string" do
+    assert Macro.to_string(quote do: Foo."42") == ~s/Foo."42"()/
+    assert Macro.to_string(quote do: Foo.'Bar') == ~s/Foo."Bar"()/
+    assert Macro.to_string(quote do: Foo."bar baz"."") == ~s/Foo."bar baz"().""()/
+  end
+
   test "aliases call to string" do
     assert Macro.to_string(quote do: Foo.Bar.baz(1, 2, 3)) == "Foo.Bar.baz(1, 2, 3)"
     assert Macro.to_string(quote do: Foo.Bar.baz([1, 2, 3])) == "Foo.Bar.baz([1, 2, 3])"


### PR DESCRIPTION
Aimed at fixing #5605. The reasoning is explained in the big comment in the code :)