### PR TITLE
Adding "/" special case in unix's Path.relative

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -238,6 +238,8 @@ defmodule Path do
     {:absolute, "."}
   defp unix_pathtype(<<?/, relative::binary>>), do:
     {:absolute, relative}
+  defp unix_pathtype([?/]), do:
+    {:absolute, '.'}
   defp unix_pathtype([?/ | relative]), do:
     {:absolute, relative}
   defp unix_pathtype([list | rest]) when is_list(list), do:

--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -234,6 +234,8 @@ defmodule Path do
     end
   end
 
+  defp unix_pathtype(<<?/>>), do:
+    {:absolute, "."}
   defp unix_pathtype(<<?/, relative::binary>>), do:
     {:absolute, relative}
   defp unix_pathtype([?/ | relative]), do:

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -71,6 +71,7 @@ defmodule PathTest do
       assert Path.relative("usr/local/bin")    == "usr/local/bin"
       assert Path.relative("../usr/local/bin") == "../usr/local/bin"
       assert Path.relative("/") == "."
+      assert Path.relative('/') == "."
       assert Path.relative(['/usr', ?/, "local/bin"]) == "usr/local/bin"
     end
 

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -70,6 +70,7 @@ defmodule PathTest do
       assert Path.relative("/usr/local/bin")   == "usr/local/bin"
       assert Path.relative("usr/local/bin")    == "usr/local/bin"
       assert Path.relative("../usr/local/bin") == "../usr/local/bin"
+      assert Path.relative("/") == "."
       assert Path.relative(['/usr', ?/, "local/bin"]) == "usr/local/bin"
     end
 


### PR DESCRIPTION
Now, `Path.relative("/")` returns `"."` instead of the empty string for unix systems.

I'm afraid that even if it's a simple change, that could a breaking change.