### PR TITLE
Calendar standards for Date conversion

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -1742,7 +1742,7 @@ defmodule DateTime do
          {min, ""} <- Integer.parse(min),
          {sec, ""} <- Integer.parse(sec),
          {microsec, rest} <- Calendar.ISO.parse_microsecond(rest),
-         {:ok, date} <- Calendar.ISO.date(year, month, day),
+         {:ok, date} <- Date.new(year, month, day),
          {:ok, time} <- Time.new(hour, min, sec, microsec),
          {:ok, offset} <- parse_offset(rest) do
       %{year: year, month: month, day: day} = date

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -113,7 +113,7 @@ defmodule Calendar do
   @doc """
   Checks if a date valid in specified calendar
   """
-  @callback is_valid_date(year, month day) :: boolean
+  @callback is_valid_date(year, month, day) :: boolean
 end
 
 defmodule Date do

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -173,6 +173,15 @@ defmodule Calendar.ISO do
     end
   end
 
+  @doc false
+  def to_unix({year, month, day}, {hour, minute, second}, {microsecond, _precision}, std_offset, utc_offset, unit) do
+    seconds =
+      :calendar.datetime_to_gregorian_seconds({{year, month, day}, {hour, minute, second}})
+      |> Kernel.-(utc_offset)
+      |> Kernel.-(std_offset)
+    System.convert_time_unit((seconds - @unix_epoch) * 1_000_000 + microsecond, :microsecond, unit)
+  end
+
   defp precision_for_unit(unit) do
     subsecond = div System.convert_time_unit(1, :second, unit), 10
     precision_for_unit(subsecond, 0)

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -151,13 +151,9 @@ defmodule Calendar.ISO do
     zero_pad(hour, 2) <> ":" <> zero_pad(minute, 2) <> ":" <> zero_pad(second, 2)
   end
 
-  @doc false
-  def date(year, month, day) when is_integer(year) and is_integer(month) and is_integer(day) do
-    if :calendar.valid_date(year, month, day) and year <= 9999 do
-      {:ok, %Date{year: year, month: month, day: day}}
-    else
-      {:error, :invalid_date}
-    end
+  @doc "Checks if an ISO date is valid or not"
+  def is_valid_date(year, month, day) do
+    :calendar.valid_date(year, month, day) and year <= 9999
   end
 
   @doc false


### PR DESCRIPTION
From a [discussion on Elixir forum](https://elixirforum.com/t/jalaali-shamsi-calendar-for-elixir-persian-calendar/2883/19), for purpose of Calendar conversions i had implemented a conversion based on UNIX epoch.

My main reasons for using UNIX as a timestamp is:

1. ``Date.today`` and ``DateTime.utc_now`` where already using it
2. it is simpler for other developers that want to integrate new calendars to find algorithms based on UNIX
3. a vary respected DateTime library, Joda-Time is using unix as base timestamp

For more information you can [read the topic](https://elixirforum.com/t/jalaali-shamsi-calendar-for-elixir-persian-calendar/2883/19) on forum.

Things i have changed and added to achieve this:

- in Calendar callbacks i've added: ``from_unix``, ``to_unix`` and ``is_valid_date``
- ``convert`` functions in Date, DateTime and NaiveDateTime (maybe requires function renaming as i couldn't think of anything else)
- remove ``Calendar.ISO.date`` function since it was not in Calendar callbacks. it was replaced with ``is_valid_date`` callback, so that every calendar can support date validation upon every date creation.