### PR TITLE
Cleanup exit messages on Task.async_stream

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -287,8 +287,10 @@ defmodule Task do
   concurrently on each item in `enumerable`.
 
   Each item will be appended to the given `args` and processed by its
-  own task. The tasks will be linked to the current process similar to
-  `async/3`.
+  own task. The tasks will be linked to an intermediate process that is
+  then linked to the current process. This means a failure in a task
+  terminates the current process and a failure in the current process
+  terminates all tasks.
 
   When streamed, each task will emit `{:ok, val}` upon successful
   completion or `{:exit, val}` if the caller is trapping exits. Results

--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -335,8 +335,8 @@ defmodule Task.Supervised do
         counters = Map.put(counters, ref, {counter, type, pid})
         stream_monitor(parent_pid, parent_ref, mfa, spawn, monitor_ref, counters)
       {:stop, ^monitor_ref} ->
+        Process.flag(:trap_exit, true)
         for {ref, {_counter, _, pid}} <- counters do
-          Process.unlink(pid)
           Process.exit(pid, :kill)
           receive do
             {:DOWN, ^ref, _, _, _} -> :ok

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -492,6 +492,7 @@ defmodule TaskTest do
         Process.flag(:trap_exit, true)
         assert 1..4 |> Task.async_stream(&exit/1, @opts) |> Enum.to_list ==
                [exit: 1, exit: 2, exit: 3, exit: 4]
+        refute_received {:EXIT, _, _}
       end
 
       test "shuts down unused tasks" do


### PR DESCRIPTION
We do so by starting the tasks directly in the monitor
process, which in this case takes care of linking and
therefore we only need to clean up the monitor process
message.

Closes #5554