### PR TITLE
Optimize Enumerable.count/1 implementation for File.Stream

### DIFF
--- a/lib/elixir/test/elixir/file_test.exs
+++ b/lib/elixir/test/elixir/file_test.exs
@@ -1310,6 +1310,18 @@ defmodule FileTest do
     assert stream.line_or_bytes == 10
   end
 
+  test "stream count" do
+    src = fixture_path("file.txt")
+    stream = File.stream!(src)
+    assert Enum.count(stream) == 1
+
+    stream = File.stream!(src, [:utf8])
+    assert Enum.count(stream) == 1
+
+    stream = File.stream!(src, [], 2)
+    assert Enum.count(stream) == 2
+  end
+
   test "stream line UTF-8" do
     src  = fixture_path("file.txt")
     dest = tmp_path("tmp_test.txt")


### PR DESCRIPTION
Results of initial benchmarks using https://github.com/michalmuskala/file_count_optim
```
-##### With input Huge (1000000 lines) #####
Name                  ips        average  deviation         median
proposed             4.02      248.64 ms     ±3.62%      248.58 ms
recur_count          3.40      294.41 ms     ±4.37%      290.18 ms
read_line            1.22      817.86 ms     ±3.91%      806.50 ms
current              1.08      925.23 ms     ±5.24%      911.27 ms

Comparison:
proposed             4.02
recur_count          3.40 - 1.18x slower
read_line            1.22 - 3.29x slower
current              1.08 - 3.72x slower

-##### With input Medium (10000 lines) #####
Name                  ips        average  deviation         median
proposed           452.59        2.21 ms    ±11.83%        2.15 ms
recur_count        313.31        3.19 ms     ±6.88%        3.15 ms
read_line          109.97        9.09 ms     ±6.11%        8.94 ms
current            101.86        9.82 ms    ±14.58%        9.45 ms

Comparison:
proposed           452.59
recur_count        313.31 - 1.44x slower
read_line          109.97 - 4.12x slower
current            101.86 - 4.44x slower

-##### With input Small (100 lines) #####
Name                  ips        average  deviation         median
proposed          13.59 K       73.61 μs    ±29.75%       68.00 μs
recur_count       11.99 K       83.41 μs    ±27.13%       77.00 μs
read_line          6.49 K      154.07 μs    ±22.86%      142.00 μs
current            5.83 K      171.60 μs    ±41.22%      157.00 μs

Comparison:
proposed          13.59 K
recur_count       11.99 K - 1.13x slower
read_line          6.49 K - 2.09x slower
current            5.83 K - 2.33x slower
```