### PR TITLE
Fix broken hash link in Registry doc

### DIFF
--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -23,8 +23,8 @@ defmodule Registry do
 
   ## Using in `:via`
 
-  Once the registry is started with a given name (using
-  `Registry.start_link/2`), it can be used to register and access named
+  Once the registry is started with a given name using
+  `Registry.start_link/2`, it can be used to register and access named
   processes using the `{:via, Registry, {registry, key}}` tuple:
 
       {:ok, _} = Registry.start_link(:unique, Registry.ViaTest)


### PR DESCRIPTION
While going through the Registry doc, I found a broken hash link which might be caused by a bug in `ex_doc`. Specifically, when a closing back tick is followed by a close parenthesis, the latter becomes part of the link. Instead of working around the problem, I decided to remove the parentheses altogether to avoid any ambiguity.