### PR TITLE
Add `-` to Regex.escape/1

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -629,7 +629,7 @@ defmodule Regex do
     [get_index(string, h) | get_indexes(string, t, arity - 1)]
   end
 
-  {:ok, pattern} = :re.compile(~S"[.^$*+?()\[\]{}\\\|\s#]", [:unicode])
+  {:ok, pattern} = :re.compile(~S"[.^$*+?()\[\]{}\\\|\s#-]", [:unicode])
   @escape_pattern pattern
 
   @doc ~S"""

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -247,6 +247,7 @@ defmodule RegexTest do
     assert matches_escaped?("# lol")
 
     assert matches_escaped?("\\A.^$*+?()[{\\| \t\n\x20\\z #hello\u202F\u205F")
+    assert Regex.match? Regex.compile!("[" <> Regex.escape("!-#") <> "]"), "-"
 
     assert Regex.escape("{}") == "\\{\\}"
     assert Regex.escape("[]") == "\\[\\]"


### PR DESCRIPTION
We were not escaping the `-` character, commonly found in character
classes, in cases where it is being used on its own. I've added a test
for this new escape behavior, and also implemented the change.

Resolves #5624