### PR TITLE
Correctly inspect function calls with weird atoms

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -431,7 +431,7 @@ defmodule Exception do
   def format_mfa(module, fun, arity) when is_atom(module) and is_atom(fun) do
     fun = Atom.to_string(fun)
 
-    case Inspect.Function.maybe_extract_anonymous_fun_parent(fun) do
+    case Inspect.Function.extract_anonymous_fun_parent(fun) do
       {outer_name, outer_arity} ->
         "anonymous fn#{format_arity(arity)} in " <>
           "#{inspect(module)}.#{Inspect.Function.escape_name(outer_name)}/#{outer_arity}"

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -429,22 +429,13 @@ defmodule Exception do
   "anonymous fn in func/arity"
   """
   def format_mfa(module, fun, arity) when is_atom(module) and is_atom(fun) do
-    fun_binary = Atom.to_string(fun)
-
-    case match?("-" <> _, fun_binary) and String.split(fun_binary, "-") do
-      ["", outer_fun, "fun", _count, ""] ->
-        "anonymous fn#{format_arity(arity)} in #{inspect(module)}.#{outer_fun}"
-      _other ->
-        inspected_fun =
-          case Inspect.Atom.classify(fun) do
-            type when type in [:boolean_or_nil, :callable] ->
-              fun_binary
-            type when type in [:non_callable, :alias] ->
-              "\"" <> fun_binary <> "\""
-            :atom ->
-              Inspect.Atom.escape(fun_binary)
-          end
-        "#{inspect(module)}.#{inspected_fun}#{format_arity(arity)}"
+    case Atom.to_string(fun) do
+      "-" <> _rest = outer ->
+        {outer_name, outer_arity} = Inspect.Function.extract_nested_function_name_and_arity(outer)
+        "anonymous fn#{format_arity(arity)} in " <>
+          "#{inspect(module)}.#{Inspect.Function.escape_name(outer_name)}/#{outer_arity}"
+      fun ->
+        "#{inspect(module)}.#{Inspect.Function.escape_name(fun)}#{format_arity(arity)}"
     end
   end
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -430,8 +430,8 @@ defmodule Exception do
   """
   def format_mfa(module, fun, arity) when is_atom(module) and is_atom(fun) do
     case Atom.to_string(fun) do
-      "-" <> _rest = outer ->
-        {outer_name, outer_arity} = Inspect.Function.extract_nested_function_name_and_arity(outer)
+      "-" <> _rest = root ->
+        {outer_name, outer_arity} = Inspect.Function.extract_nested_function_name_and_arity(root)
         "anonymous fn#{format_arity(arity)} in " <>
           "#{inspect(module)}.#{Inspect.Function.escape_name(outer_name)}/#{outer_arity}"
       fun ->

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -431,7 +431,7 @@ defmodule Exception do
   def format_mfa(module, fun, arity) when is_atom(module) and is_atom(fun) do
     case Atom.to_string(fun) do
       "-" <> _rest = root ->
-        {outer_name, outer_arity} = Inspect.Function.extract_nested_function_name_and_arity(root)
+        {outer_name, outer_arity} = Inspect.Function.extract_anonymous_fun_parent(root)
         "anonymous fn#{format_arity(arity)} in " <>
           "#{inspect(module)}.#{Inspect.Function.escape_name(outer_name)}/#{outer_arity}"
       fun ->

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -429,12 +429,13 @@ defmodule Exception do
   "anonymous fn in func/arity"
   """
   def format_mfa(module, fun, arity) when is_atom(module) and is_atom(fun) do
-    case Atom.to_string(fun) do
-      "-" <> _rest = root ->
-        {outer_name, outer_arity} = Inspect.Function.extract_anonymous_fun_parent(root)
+    fun = Atom.to_string(fun)
+
+    case Inspect.Function.maybe_extract_anonymous_fun_parent(fun) do
+      {outer_name, outer_arity} ->
         "anonymous fn#{format_arity(arity)} in " <>
           "#{inspect(module)}.#{Inspect.Function.escape_name(outer_name)}/#{outer_arity}"
-      fun ->
+      :error ->
         "#{inspect(module)}.#{Inspect.Function.escape_name(fun)}#{format_arity(arity)}"
     end
   end

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -431,8 +431,6 @@ defimpl Inspect, for: Regex do
 end
 
 defimpl Inspect, for: Function do
-  require Macro
-
   def inspect(function, _opts) do
     fun_info = :erlang.fun_info(function)
     mod = fun_info[:module]

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -470,7 +470,11 @@ defimpl Inspect, for: Function do
   end
 
   # Example of this format: -func/arity-fun-count-
-  def extract_nested_function_name_and_arity("-" <> rest) do
+  def extract_anonymous_fun_parent("-" <> rest) do
+    # We use :re instead of String.split/3 because we want to keep the "/"s and
+    # "-"s (this is what the "(" and ")" in the regex do). We want to keep them
+    # because we want to rebuild part of this split list (the function name)
+    # later on.
     ["-", count, "-", "fun", "-", arity, "/" | reversed_function] =
       rest
       |> :re.split("([/-])")
@@ -492,7 +496,7 @@ defimpl Inspect, for: Function do
   defp extract_name(name) do
     case Atom.to_string(name) do
       "-" <> _rest = string_name ->
-        {string_name, arity} = extract_nested_function_name_and_arity(string_name)
+        {string_name, arity} = extract_anonymous_fun_parent(string_name)
         "." <> escape_name(string_name) <> "/" <> arity
       string_name ->
         "." <> escape_name(string_name)

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -69,12 +69,14 @@ defimpl Inspect, for: Atom do
   defp color_key(nil), do: :nil
   defp color_key(_), do: :atom
 
+  def inspect(atom) when is_nil(atom) or is_boolean(atom) do
+    Atom.to_string(atom)
+  end
+
   def inspect(atom) do
     binary = Atom.to_string(atom)
 
-    case Macro.classify_atom(binary) do
-      :boolean_or_nil ->
-        binary
+    case Macro.classify_identifier(binary) do
       :alias ->
         case binary do
           binary when binary in ["Elixir", "Elixir.Elixir"] ->
@@ -84,9 +86,9 @@ defimpl Inspect, for: Atom do
           "Elixir." <> rest ->
             rest
         end
-      type when type in [:callable, :non_callable] ->
+      type when type in [:callable, :not_callable] ->
         ":" <> binary
-      :atom ->
+      :other ->
         ":" <> escape(binary)
     end
   end
@@ -457,12 +459,12 @@ defimpl Inspect, for: Function do
   end
 
   def escape_name(string_name) when is_binary(string_name) do
-    case Macro.classify_atom(string_name) do
-      type when type in [:boolean_or_nil, :callable] ->
+    case Macro.classify_identifier(string_name) do
+      :callable ->
         string_name
-      type when type in [:non_callable, :alias] ->
+      type when type in [:not_callable, :alias] ->
         "\"" <> string_name <> "\""
-      :atom ->
+      :other ->
         Inspect.Atom.escape(string_name)
     end
   end

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -485,7 +485,7 @@ defimpl Inspect, for: Function do
     end
   end
 
-  def extract_anonymous_fun_parent(_other), do: :error
+  def extract_anonymous_fun_parent(other) when is_binary(other), do: :error
 
   defp default_inspect(mod, fun_info) do
     "#Function<#{uniq(fun_info)}/#{fun_info[:arity]} in " <>

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -458,14 +458,14 @@ defimpl Inspect, for: Function do
     escape_name(Atom.to_string(name))
   end
 
-  def escape_name(string_name) when is_binary(string_name) do
-    case Macro.classify_identifier(string_name) do
+  def escape_name(name) when is_binary(name) do
+    case Macro.classify_identifier(name) do
       :callable ->
-        string_name
+        name
       type when type in [:not_callable, :alias] ->
-        "\"" <> string_name <> "\""
+        "\"" <> name <> "\""
       :other ->
-        Inspect.Atom.escape(string_name)
+        Inspect.Atom.escape(name)
     end
   end
 
@@ -495,11 +495,11 @@ defimpl Inspect, for: Function do
 
   defp extract_name(name) do
     case Atom.to_string(name) do
-      "-" <> _rest = string_name ->
-        {string_name, arity} = extract_anonymous_fun_parent(string_name)
-        "." <> escape_name(string_name) <> "/" <> arity
-      string_name ->
-        "." <> escape_name(string_name)
+      "-" <> _rest = name ->
+        {name, arity} = extract_anonymous_fun_parent(name)
+        "." <> escape_name(name) <> "/" <> arity
+      name ->
+        "." <> escape_name(name)
     end
   end
 

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -466,7 +466,7 @@ defimpl Inspect, for: Function do
   end
 
   # Example of this format: -func/arity-fun-count-
-  def maybe_extract_anonymous_fun_parent("-" <> rest) do
+  def extract_anonymous_fun_parent("-" <> rest) do
     # We use :re instead of String.split/3 because we want to keep the "/"s and
     # "-"s (this is what the "(" and ")" in the regex do). We want to keep them
     # because we want to rebuild part of this split list (the function name)
@@ -485,7 +485,7 @@ defimpl Inspect, for: Function do
     end
   end
 
-  def maybe_extract_anonymous_fun_parent(_other), do: :error
+  def extract_anonymous_fun_parent(_other), do: :error
 
   defp default_inspect(mod, fun_info) do
     "#Function<#{uniq(fun_info)}/#{fun_info[:arity]} in " <>
@@ -498,7 +498,7 @@ defimpl Inspect, for: Function do
 
   defp extract_name(name) do
     name = Atom.to_string(name)
-    case maybe_extract_anonymous_fun_parent(name) do
+    case extract_anonymous_fun_parent(name) do
       {name, arity} ->
         "." <> escape_name(name) <> "/" <> arity
       :error ->

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -475,7 +475,7 @@ defimpl Inspect, for: Function do
     # "-"s (this is what the "(" and ")" in the regex do). We want to keep them
     # because we want to rebuild part of this split list (the function name)
     # later on.
-    ["-", count, "-", "fun", "-", arity, "/" | reversed_function] =
+    ["-", _count, "-", "fun", "-", arity, "/" | reversed_function] =
       rest
       |> :re.split("([/-])")
       |> Enum.reject(&(&1 == ""))

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -845,6 +845,8 @@ defmodule Macro do
     do: "(" <> module_to_string(arg, fun) <> ")."
   defp call_to_string({:., _, [arg]}, fun),
     do: module_to_string(arg, fun) <> "."
+  defp call_to_string({:., _, [left, right]}, fun) when is_atom(right),
+    do: module_to_string(left, fun) <> "." <> call_to_string_for_atom(right)
   defp call_to_string({:., _, [left, right]}, fun),
     do: module_to_string(left, fun) <> "." <> call_to_string(right, fun)
   defp call_to_string(other, fun),
@@ -854,6 +856,19 @@ defmodule Macro do
     target = call_to_string(target, fun)
     args = args_to_string(args, fun)
     target <> "(" <> args <> ")"
+  end
+
+  defp call_to_string_for_atom(atom) do
+    binary = Atom.to_string(atom)
+
+    case Inspect.Atom.classify(atom) do
+      type when type in [:boolean_or_nil, :callable] ->
+        binary
+      type when type in [:alias, :non_callable] ->
+        "\"" <> binary <> "\""
+      :atom ->
+        Inspect.Atom.escape(binary)
+    end
   end
 
   defp args_to_string(args, fun) do

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -121,6 +121,10 @@ defmodule ExceptionTest do
   end
 
   test "format_mfa/3" do
+    # Let's create this atom so that String.to_existing_atom/1 inside
+    # format_mfa/3 doesn't raise.
+    _ = :"some function"
+
     assert Exception.format_mfa(Foo, nil, 1) == "Foo.nil/1"
     assert Exception.format_mfa(Foo, :bar, 1) == "Foo.bar/1"
     assert Exception.format_mfa(Foo, :bar, []) == "Foo.bar()"
@@ -128,6 +132,7 @@ defmodule ExceptionTest do
     assert Exception.format_mfa(:foo, :bar, [1, 2]) == ":foo.bar(1, 2)"
     assert Exception.format_mfa(Foo, :"bar baz", 1) == "Foo.\"bar baz\"/1"
     assert Exception.format_mfa(Foo, :"-func/2-fun-0-", 4) == "anonymous fn/4 in Foo.func/2"
+    assert Exception.format_mfa(Foo, :"-some function/2-fun-0-", 4) == "anonymous fn/4 in Foo.\"some function\"/2"
     assert Exception.format_mfa(Foo, :"42", 1) == "Foo.\"42\"/1"
     assert Exception.format_mfa(Foo, :Bar, [1, 2]) == "Foo.\"Bar\"(1, 2)"
     assert Exception.format_mfa(Foo, :%{}, [1, 2]) == "Foo.\"%{}\"(1, 2)"
@@ -136,7 +141,7 @@ defmodule ExceptionTest do
 
   test "format_fa/2" do
     assert Exception.format_fa(fn -> nil end, 1) =~
-           ~r"#Function<\d+\.\d+/0 in ExceptionTest\.test format_fa/2/1>/1"
+           ~r"#Function<\d+\.\d+/0 in ExceptionTest\.\"test format_fa/2\"/1>/1"
   end
 
   ## Format exits

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -128,6 +128,10 @@ defmodule ExceptionTest do
     assert Exception.format_mfa(:foo, :bar, [1, 2]) == ":foo.bar(1, 2)"
     assert Exception.format_mfa(Foo, :"bar baz", 1) == "Foo.\"bar baz\"/1"
     assert Exception.format_mfa(Foo, :"-func/2-fun-0-", 4) == "anonymous fn/4 in Foo.func/2"
+    assert Exception.format_mfa(Foo, :"42", 1) == "Foo.\"42\"/1"
+    assert Exception.format_mfa(Foo, :Bar, [1, 2]) == "Foo.\"Bar\"(1, 2)"
+    assert Exception.format_mfa(Foo, :%{}, [1, 2]) == "Foo.\"%{}\"(1, 2)"
+    assert Exception.format_mfa(Foo, :..., 1) == "Foo.\"...\"/1"
   end
 
   test "format_fa/2" do

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -30,7 +30,7 @@ defmodule Inspect.AtomTest do
     assert inspect(Elixir) == "Elixir"
     assert inspect(Elixir.Foo) == "Foo"
     assert inspect(Elixir.Elixir) == "Elixir.Elixir"
-    assert inspect(Elixir.Elixir.Foo) == "Elixir.Foo"
+    assert inspect(Elixir.Elixir.Foo) == "Elixir.Elixir.Foo"
   end
 
   test "with integers" do
@@ -453,9 +453,16 @@ defmodule Inspect.OthersTest do
     fn() -> :ok end
   end
 
+  def unquote(:"weirdly named/fun-")() do
+    fn() -> :ok end
+  end
+
   test "external Elixir funs" do
     bin = inspect(&Enum.map/2)
     assert bin == "&Enum.map/2"
+
+    assert inspect(&__MODULE__."weirdly named/fun-"/0) ==
+           ~s(&Inspect.OthersTest."weirdly named/fun-"/0)
   end
 
   test "external Erlang funs" do
@@ -494,6 +501,9 @@ defmodule Inspect.OthersTest do
     opts = [syntax_colors: [reset: :red]]
     assert "#Function<" <> rest = inspect(fun(), opts)
     assert String.ends_with?(rest, ">")
+
+    inspected = inspect(__MODULE__."weirdly named/fun-"())
+    assert inspected =~ ~r(#Function<\d+\.\d+/0 in Inspect\.OthersTest\."weirdly named/fun-"/0>)
   end
 
   test "map set" do

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -979,7 +979,7 @@ defmodule Kernel.ErrorsTest do
       'alias Elixir.{Map}, as: Dict'
 
     assert_compile_fail UndefinedFunctionError,
-      "function List.{}/1 is undefined or private",
+      "function List.\"{}\"/1 is undefined or private",
       '[List.{Chars}, "one"]'
   end
 

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -418,15 +418,15 @@ defmodule KernelTest do
 
       result = expand_to_string(quote(do: rand() in 1..2))
       assert result =~ "var = rand()"
-      assert result =~ ":erlang.andalso(:erlang.is_integer(var), :erlang.andalso(:erlang.>=(var, 1), :erlang.=<(var, 2)))"
+      assert result =~ ":erlang.andalso(:erlang.is_integer(var), :erlang.andalso(:erlang.>=(var, 1), :erlang.\"=<\"(var, 2)))"
 
       result = expand_to_string(quote(do: rand() in [1, 2]))
       assert result =~ "var = rand()"
-      assert result =~ ":erlang.or(:erlang.=:=(var, 2), :erlang.=:=(var, 1))"
+      assert result =~ ":erlang.or(:erlang.\"=:=\"(var, 2), :erlang.\"=:=\"(var, 1))"
 
       result = expand_to_string(quote(do: rand() in [1 | [2]]))
       assert result =~ "var = rand()"
-      assert result =~ ":erlang.or(:erlang.=:=(var, 1), :erlang.=:=(var, 2))"
+      assert result =~ ":erlang.or(:erlang.\"=:=\"(var, 1), :erlang.\"=:=\"(var, 2))"
     end
 
     defp expand_to_string(ast) do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -267,6 +267,14 @@ defmodule MacroTest do
     assert Macro.to_string(quote do: foo.bar.([1, 2, 3])) == "foo.bar().([1, 2, 3])"
   end
 
+  test "unusual remote atom fun call to string" do
+    assert Macro.to_string(quote do: Foo."42") == ~s/Foo."42"()/
+    assert Macro.to_string(quote do: Foo.'Bar') == ~s/Foo."Bar"()/
+    assert Macro.to_string(quote do: Foo."bar baz"."") == ~s/Foo."bar baz"().""()/
+    assert Macro.to_string(quote do: Foo."%{}") == ~s/Foo."%{}"()/
+    assert Macro.to_string(quote do: Foo."...") == ~s/Foo."..."()/
+  end
+
   test "atom fun call to string" do
     assert Macro.to_string(quote do: :foo.(1, 2, 3)) == ":foo.(1, 2, 3)"
   end


### PR DESCRIPTION
With this commit, we fix the inspection (both in `Macro.to_string/2` as well as `Exception.format_mfa/3`) of function calls with "weird" atoms like:

    Foo."Bar"() # was inspected as Foo.Bar()
    Foo."..."() # was inspecetd as Foo....()

and many others.

This is a rework of #5606, which was aimed at #5605.

@josevalim: I went with implementing `Inspect.Atom.classify/1`, but tailored the result to function calls specifically (`:callable`, `:non_callable`) as it turns out this is enough to reuse the logic in `Inspect.Atom.inspect/1` as well. 