### PR TITLE
Fix Macro.camelize/1 for screaming snake case

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1260,27 +1260,30 @@ defmodule Macro do
     do: camelize(t)
 
   def camelize(<<h, t::binary>>),
-    do: <<to_upper_char(h)>> <> do_camelize(t)
+    do: <<to_upper_char(h)>> <> do_camelize(t, h)
 
-  defp do_camelize(<<?_, ?_, t::binary>>),
-    do: do_camelize(<<?_, t::binary >>)
+  defp do_camelize(<<?_, ?_, t::binary>>, prev),
+    do: do_camelize(<<?_, t::binary >>, prev)
 
-  defp do_camelize(<<?_, h, t::binary>>) when h >= ?a and h <= ?z,
-    do: <<to_upper_char(h)>> <> do_camelize(t)
+  defp do_camelize(<<?_, h, t::binary>>, _) when h >= ?a and h <= ?z,
+    do: <<to_upper_char(h)>> <> do_camelize(t, h)
 
-  defp do_camelize(<<?_, h, t::binary>>) when h >= ?0 and h <= ?9,
-    do: <<h>> <> do_camelize(t)
+  defp do_camelize(<<?_, h, t::binary>>, _) when (h >= ?0 and h <= ?9) or (h >= ?A and h <= ?Z),
+    do: <<h>> <> do_camelize(t, h)
 
-  defp do_camelize(<<?_>>),
+  defp do_camelize(<<?_>>, _),
     do: <<>>
 
-  defp do_camelize(<<?/, t::binary>>),
+  defp do_camelize(<<?/, t::binary>>, _),
     do: <<?.>> <> camelize(t)
 
-  defp do_camelize(<<h, t::binary>>),
-    do: <<h>> <> do_camelize(t)
+  defp do_camelize(<<h, t::binary>>, prev) when (prev >= ?a and prev <= ?z) and not (h >= ?a and h <= ?z),
+    do: <<to_upper_char(h)>> <> do_camelize(t, h)
 
-  defp do_camelize(<<>>),
+  defp do_camelize(<<h, t::binary>>, _),
+    do: <<to_lower_char(h)>> <> do_camelize(t, h)
+
+  defp do_camelize(<<>>, _),
     do: <<>>
 
   defp to_upper_char(char) when char >= ?a and char <= ?z, do: char - 32

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -693,6 +693,7 @@ defmodule MacroTest do
     assert Macro.camelize("FooBar") == "FooBar"
     assert Macro.camelize("foo") == "Foo"
     assert Macro.camelize("foo_bar") == "FooBar"
+    assert Macro.camelize("FOO_BAR") == "FooBar"
     assert Macro.camelize("foo_") == "Foo"
     assert Macro.camelize("_foo") == "Foo"
     assert Macro.camelize("foo10") == "Foo10"


### PR DESCRIPTION
It was pointed out that `Macro.underscore/1` had some issues dealing
with screaming snake case, and in the comments for that issue
@eksperimental also noted that `Macro.camelize/1` was buggy with
screaming snake case as well. I've dealt with the `Macro.underscore/1`
bug in a separate commit, but this commit handles the secondary bug.