### PR TITLE
IEx.Helper documention improvement

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -33,6 +33,7 @@ defmodule IEx.Helpers do
     * `i/0`           - prints information about the last value
     * `i/1`           - prints information about the data type of any given term
     * `import_file/1` - evaluates the given file in the shell's context
+    * `import_file_if_available/1` - evaluates the given file in the shell's context if it is available.
     * `l/1`           - loads the given module's BEAM code
     * `ls/0`          - lists the contents of the current directory
     * `ls/1`          - lists the contents of the specified directory

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -678,6 +678,7 @@ defmodule IEx.Helpers do
     raise ArgumentError, "import_file/1 expects a literal binary as its argument"
   end
 
+  @doc false
   defmacro import_file(path, opts) when is_binary(path) and is_list(opts) do
     IO.warn "import_file/2 is deprecated, please use import_file_if_available/1 instead"
     import_file_if_available(path, Keyword.get(opts, :optional, false))


### PR DESCRIPTION
Affect from v1.4 to master.

Changed:

- Let IEx.Helper.import_file/2 not to generate doc
- Add description of import_file_if_available/1 to `moduledoc`

I'm really sorry not to align `import_file_if_available/1`,
however, I think it's too hard to read to developer who update this. ;)

Thanks to read and Happy new year, all XD