### PR TITLE
Adding export helper. Solves #5633

### DIFF
--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -23,6 +23,15 @@ defmodule IEx.Autocomplete do
         no()
     end
   end
+  
+  @doc false
+  def exports(mod) do
+    if function_exported?(mod, :__info__, 1) do
+      mod.__info__(:macros) ++ (mod.__info__(:functions) -- [__info__: 1])
+    else
+      mod.module_info(:exports)
+    end
+  end
 
   defp identifier?(h) do
     (h in ?a..?z) or (h in ?A..?Z) or (h in ?0..?9) or h in [?_, ??, ?!]
@@ -290,17 +299,9 @@ defmodule IEx.Autocomplete do
       not ensure_loaded?(mod) ->
         []
       docs = Code.get_docs(mod, :docs) ->
-        module_info_funs(mod) |> Enum.reject(&hidden_fun?(&1, docs))
+        exports(mod) |> Enum.reject(&hidden_fun?(&1, docs))
       true ->
-        module_info_funs(mod)
-    end
-  end
-
-  defp module_info_funs(mod) do
-    if function_exported?(mod, :__info__, 1) do
-      mod.__info__(:macros) ++ (mod.__info__(:functions) -- [__info__: 1])
-    else
-      mod.module_info(:exports)
+        exports(mod)
     end
   end
 

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -534,12 +534,12 @@ defmodule IEx.Helpers do
   end
 
   @doc """
-  Produces a simple list of  all exports in a module
+  Produces a simple list of all exports in a module.
   """
   def e(module \\ Kernel) do
     IEx.Autocomplete.exports(module) |> print_exports()
   end
-  
+
   defp print_exports(functions) do
     list = Enum.map(functions, fn({name, arity}) -> Atom.to_string(name) <> "/" <> Integer.to_string(arity) end)
     print_table(list)
@@ -555,8 +555,8 @@ defmodule IEx.Helpers do
     case File.ls(path) do
       {:ok, items} ->
         sorted_items = Enum.sort(items)
-        printer = fn(item, width) -> 
-          format_item(Path.join(path, item), String.pad_trailing(item, width)) 
+        printer = fn(item, width) ->
+          format_item(Path.join(path, item), String.pad_trailing(item, width))
         end
         print_table(sorted_items, printer)
 

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -534,6 +534,18 @@ defmodule IEx.Helpers do
   end
 
   @doc """
+  Produces a simple list of  all exports in a module
+  """
+  def e(module \\ Kernel) do
+    IEx.Autocomplete.exports(module) |> print_exports()
+  end
+  
+  defp print_exports(functions) do
+    list = Enum.map(functions, fn({name, arity}) -> Atom.to_string(name) <> "/" <> Integer.to_string(arity) end)
+    print_table(list)
+  end
+
+  @doc """
   Produces a simple list of a directory's contents.
 
   If `path` points to a file, prints its full path.
@@ -543,7 +555,10 @@ defmodule IEx.Helpers do
     case File.ls(path) do
       {:ok, items} ->
         sorted_items = Enum.sort(items)
-        ls_print(path, sorted_items)
+        printer = fn(item, width) -> 
+          format_item(Path.join(path, item), String.pad_trailing(item, width)) 
+        end
+        print_table(sorted_items, printer)
 
       {:error, :enoent} ->
         IO.puts IEx.color(:eval_error, "No such file or directory #{path}")
@@ -560,19 +575,20 @@ defmodule IEx.Helpers do
 
   defp expand_home(other), do: other
 
-  defp ls_print(_, []) do
+  defp print_table(list, printer \\ &String.pad_trailing/2)
+  defp print_table([], _printer) do
     :ok
   end
 
-  defp ls_print(path, list) do
+  defp print_table(list, printer) do
     # print items in multiple columns (2 columns in the worst case)
     lengths = Enum.map(list, &String.length(&1))
     maxlen = maxlength(lengths)
-    width = min(maxlen, 30) + 5
-    ls_print(path, list, width)
+    offset = min(maxlen, 30) + 5
+    print_table(list, printer, offset)
   end
 
-  defp ls_print(path, list, width) do
+  defp print_table(list, printer, offset) do
     Enum.reduce(list, 0, fn(item, len) ->
       len =
         if len >= 80 do
@@ -581,8 +597,8 @@ defmodule IEx.Helpers do
         else
           len
         end
-      IO.write format_item(Path.join(path, item), String.pad_trailing(item, width))
-      len + width
+      IO.write printer.(item, offset)
+      len + offset
     end)
 
     IO.puts ""

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -234,6 +234,11 @@ defmodule IEx.HelpersTest do
     end
   end
 
+  test "e helper" do
+    exports = capture_io(fn -> e(IEx.Autocomplete) end)
+    assert exports == "expand/1      expand/2      exports/1     \n"
+  end
+
   test "import_file helper" do
     with_file "dot-iex", "variable = :hello\nimport IO", fn ->
       capture_io(:stderr, fn ->


### PR DESCRIPTION
- [x]  `e/1` function that list functions and macros in the same way the autocomplete.
- [x]  make `module_info_funs/1` public
- [x]  rename `module_info_funs/1` to `exports/1`
- [x]  tests
