### PR TITLE
Fix Path.join/1 for lists of one element

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -449,9 +449,9 @@ defmodule Path do
   end
 
   @doc """
-  Joins a list of strings.
+  Joins a list of paths.
 
-  This function should be used to convert a list of strings to a path.
+  This function should be used to convert a list of paths to a path.
   Note that any trailing slash is removed when joining.
 
   ## Examples
@@ -466,11 +466,11 @@ defmodule Path do
       "/foo/bar"
 
   """
-  @spec join([t]) :: binary
+  @spec join(nonempty_list(t)) :: binary
   def join([name1, name2 | rest]), do:
     join([join(name1, name2) | rest])
   def join([name]), do:
-    name
+    IO.chardata_to_string(name)
 
   @doc """
   Joins two paths.

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -213,6 +213,8 @@ defmodule PathTest do
     assert Path.join(['/foo/', "/bar/"]) == "/foo/bar"
     assert Path.join(["/", ""]) == "/"
     assert Path.join(["/", "", "bar"]) == "/bar"
+    assert Path.join(['foo', [?b, "a", ?r]]) == "foo/bar"
+    assert Path.join([[?f, 'o', "o"]]) == "foo"
   end
 
   test "join two" do


### PR DESCRIPTION
Also fix the spec for `Path.join/1` to mention that the input list of paths has to be non-empty, and fix the documentation to mention that this function takes a list of paths (`Path.t`), not strings like it said before.

Closes #5637.