### PR TITLE
Fix a typo in Map

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -585,7 +585,7 @@ defmodule Map do
   end
 
   @doc """
-  Takes all entries corresponding to the given `keys` in `maps` and extracts
+  Takes all entries corresponding to the given `keys` in `map` and extracts
   them into a separate map.
 
   Returns a tuple with the new map and the old map with removed keys.


### PR DESCRIPTION
Fix a typo in the docs for `Map.split`.