### PR TITLE
Fix e/1 IEx helper to not return :ok

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -534,10 +534,11 @@ defmodule IEx.Helpers do
   end
 
   @doc """
-  Returns a list of all the functions and macros exported by the given module.
+  Prints a list of all the functions and macros exported by the given module.
   """
   def e(module \\ Kernel) do
     IEx.Autocomplete.exports(module) |> print_exports()
+    dont_display_result()
   end
 
   defp print_exports(functions) do


### PR DESCRIPTION
This PR makes the new `e/1` IEX helper not return `:ok`.

Before:

```
iex(1)> e Elixir.Tuple
append/2        delete_at/2     duplicate/2     insert_at/3     to_list/1       
:ok
```

After:

```
iex(1)> e Elixir.Tuple
append/2        delete_at/2     duplicate/2     insert_at/3     to_list/1       
```