### PR TITLE
Fix a typo in IEx.Evaluator.prune_stacktrace

### DIFF
--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -261,7 +261,7 @@ defmodule IEx.Evaluator do
 
   defp prune_stacktrace(stacktrace) do
     # The order in which each drop_while is listed is important.
-    # For example, the user my call Code.eval_string/2 in IEx
+    # For example, the user may call Code.eval_string/2 in IEx
     # and if there is an error we should not remove erl_eval
     # and eval_bits information from the user stacktrace.
     stacktrace


### PR DESCRIPTION
Found it while skimming over the IEx code. It's just a comment in a
private function, so you guys decide whether this pollutes git history.

✌️