### PR TITLE
Make MapSet.new doc more descriptive

### DIFF
--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -63,6 +63,8 @@ defmodule MapSet do
 
   """
   @spec new(Enum.t) :: t
+  def new(enumerable)
+
   def new(%__MODULE__{} = mapset), do: mapset
   def new(enumerable) do
     map =


### PR DESCRIPTION
It changes the documentation of [MapSet.new](https://hexdocs.pm/elixir/MapSet.html#new/1) function to show it takes any enumerable and not just a mapset.
It also makes it consistent with Map.new