### PR TITLE
Mix.SCM.Git: Accept GitHub username as shorthand

### DIFF
--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -24,7 +24,7 @@ defmodule Mix.SCM.Git do
     end
   end
 
-  def accepts_options(_app, opts) do
+  def accepts_options(app, opts) do
     opts =
       opts
       |> Keyword.put(:checkout, opts[:dest])
@@ -34,7 +34,7 @@ defmodule Mix.SCM.Git do
       gh = opts[:github] ->
         opts
         |> Keyword.delete(:github)
-        |> Keyword.put(:git, "https://github.com/#{gh}.git")
+        |> Keyword.put(:git, "https://github.com/#{github_shorthand(app, gh)}.git")
         |> validate_git_options
       opts[:git] ->
         opts
@@ -131,6 +131,14 @@ defmodule Mix.SCM.Git do
       Keyword.put(opts, :dest, dest)
     else
       opts
+    end
+  end
+
+  defp github_shorthand(app, shorthand) do
+    if String.contains?(shorthand, "/") do
+      shorthand
+    else
+      "#{shorthand}/#{app}"
     end
   end
 

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -8,6 +8,7 @@ defmodule Mix.Tasks.DepsTest do
       [app: :deps, version: "0.1.0",
        deps: [
          {:ok, "0.1.0",         github: "elixir-lang/ok"},
+         {:ok_2, "0.1.0",       github: "elixir-lang"},
          {:invalidvsn, "0.2.0", path: "deps/invalidvsn"},
          {:invalidapp, "0.1.0", path: "deps/invalidapp"},
          {:noappfile, "0.1.0",  path: "deps/noappfile"},
@@ -45,6 +46,8 @@ defmodule Mix.Tasks.DepsTest do
       Mix.Tasks.Deps.run []
 
       assert_received {:mix_shell, :info, ["* ok (https://github.com/elixir-lang/ok.git) (mix)"]}
+      assert_received {:mix_shell, :info, ["  the dependency is not available, run \"mix deps.get\""]}
+      assert_received {:mix_shell, :info, ["* ok_2 (https://github.com/elixir-lang/ok_2.git) (mix)"]}
       assert_received {:mix_shell, :info, ["  the dependency is not available, run \"mix deps.get\""]}
       assert_received {:mix_shell, :info, ["* invalidvsn (deps/invalidvsn)"]}
       assert_received {:mix_shell, :info, ["  the app file contains an invalid version: :ok"]}


### PR DESCRIPTION
Typically repos on GitHub have the same name as the Mix project they contain. This means that the dependency name must be repeated when using the `github: "username/foo"` shorthand to specify a git dependency in a Mixfile.

This change updates `Mix.SCM.Git` to expand
```elixir
{:dependency, "~> 0.1", github: "username"}
```
to
```elixir
{:dependency, "~> 0.1", git: "https://github.com/username/dependency.git"}
```

If this is an acceptable change, is there somewhere I should update documentation?