### PR TITLE
Fix translation of maps used as map keys

### DIFF
--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -190,6 +190,11 @@ extract_assoc_update([{'|', _Meta, [Update, Args]}], S) ->
   {Args, TArg, SA};
 extract_assoc_update(Args, SA) -> {Args, nil, SA}.
 
+extract_key_val_op(_TUpdate, #elixir_scope{extra=map_key}) ->
+  {map_field_assoc,
+    fun(X, Acc) -> elixir_translator:translate(X, Acc#elixir_scope{extra=map_key}) end,
+    fun elixir_translator:translate/2};
+
 extract_key_val_op(_TUpdate, #elixir_scope{context=match}) ->
   {map_field_exact,
     fun(X, Acc) -> elixir_translator:translate(X, Acc#elixir_scope{extra=map_key}) end,

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -39,6 +39,11 @@ defmodule MapTest do
     assert %{(try do 1 else a -> a end) => 1} == %{1 => 1}
   end
 
+  test "matching with map as a key" do
+    assert %{%{1 => 2} => x} = %{%{1 => 2} => 3}
+    assert x == 3
+  end
+
   test "is_map/1" do
     assert is_map(Map.new)
     refute is_map(Enum.to_list(%{}))


### PR DESCRIPTION
Fixes [issue 5602](#5602).
Erlang does not accept map_field_exact tag for map used as map keys
since it does not perform any matching on map keys.

For example this fails:
```
$ erl
Erlang/OTP 19 [erts-8.2] [source-a2c5a92] [64-bit] [smp:8:8]
[async-threads:10] [hipe] [kernel-poll:false]

Eshell V8.2  (abort with ^G)
1> #{ #{1 => X} := 3 } = #{ #{1 => 2} => 3 }.
* 1: illegal map key in pattern
```