### PR TITLE
Fix wrong word in System.cmd docs

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -526,7 +526,7 @@ defmodule System do
   Internally, this function uses a `Port` for interacting with the
   outside world. However, if you plan to run a long-running program,
   ports guarantee stdin/stdout devices will be closed but it does not
-  automatically terminate the problem. The documentation for the
+  automatically terminate the program. The documentation for the
   `Port` module describes this problem and possible solutions under
   the "Zombie processes" section.
 


### PR DESCRIPTION
Changed "problem" to "program".