### PR TITLE
Fix port message format

### DIFF
--- a/lib/elixir/lib/port.ex
+++ b/lib/elixir/lib/port.ex
@@ -63,7 +63,7 @@ defmodule Port do
 
   On its turn, the port will send the connected process the following messages:
 
-    * `{port, {:port, data}}` - data sent by the port
+    * `{port, {:data, data}}` - data sent by the port
     * `{port, :closed}` - reply to the `{pid, :close}` message
     * `{port, :connected}` - reply to the `{pid, {:connect, new_pid}}` message
     * `{:EXIT, port, reason}` - exit signals in case the port crashes and the


### PR DESCRIPTION
In the documentation it states that the port data format is

    {port, {:port, data}}

but the examples show it is

    {port, {:data, data}}

Fixed this in the documentation.