### PR TITLE
Fix Mix.Shell.IO.yes? documenation

### DIFF
--- a/lib/mix/lib/mix/shell/io.ex
+++ b/lib/mix/lib/mix/shell/io.ex
@@ -57,7 +57,7 @@ defmodule Mix.Shell.IO do
   @doc """
   Prints a message and asks the user if they want to proceed.
   The user must press Enter or type anything that matches the "yes"
-  regex `~r/^Y(es)?$/i`.
+  regex `~r/^(Y(es)?)?$/i`.
   """
   def yes?(message) do
     print_app()

--- a/lib/mix/lib/mix/shell/quiet.ex
+++ b/lib/mix/lib/mix/shell/quiet.ex
@@ -40,7 +40,7 @@ defmodule Mix.Shell.Quiet do
   @doc """
   Receives a message and asks the user if they want to proceed.
   The user must press enter or type anything that matches the "yes"
-  regex `~r/^Y(es)?$/i`.
+  regex `~r/^(Y(es)?)?$/i`.
   """
   defdelegate yes?(message), to: Mix.Shell.IO
 end


### PR DESCRIPTION
This is the actual regex:
https://github.com/elixir-lang/elixir/blob/master/lib/mix/lib/mix/shell/io.ex#L68

IMHO, this behaviour to return true on emply line seems surprising. I can imagine someone writing
 ```IO.yes?("launch_nukes?")```