### PR TITLE
comment to Enum.flat_map/2 about flattening

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -931,11 +931,11 @@ defmodule Enum do
   end
 
   @doc """
-  Returns a new enumerable appending the result of invoking `fun` on
-  each corresponding item of `enumerable` and flattening
-  the given results (only one level deep).
+  Maps the given `fun` over `enumerable` and flattens the result.
 
-  The given function must return an enumerable.
+  This function returns a new enumerable built by appending the result of invoking `fun`
+  on each element of `enumerable` together; conceptually, this is similar to a
+  combination of `map/3` and `concat/1`.
 
   ## Examples
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -933,7 +933,7 @@ defmodule Enum do
   @doc """
   Returns a new enumerable appending the result of invoking `fun` on
   each corresponding item of `enumerable` and flattening
-  the given results (only one level deep)..
+  the given results (only one level deep).
 
   The given function must return an enumerable.
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -935,7 +935,7 @@ defmodule Enum do
 
   This function returns a new enumerable built by appending the result of invoking `fun`
   on each element of `enumerable` together; conceptually, this is similar to a
-  combination of `map/3` and `concat/1`.
+  combination of `map/2` and `concat/1`.
 
   ## Examples
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -932,7 +932,8 @@ defmodule Enum do
 
   @doc """
   Returns a new enumerable appending the result of invoking `fun` on
-  each corresponding item of `enumerable`.
+  each corresponding item of `enumerable` and flattening
+  the given results (only one level deep)..
 
   The given function must return an enumerable.
 

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -362,8 +362,11 @@ defmodule Stream do
   end
 
   @doc """
-  Creates a stream that will apply the given function on enumeration and
-  flatten the result, but only one level deep.
+  Maps the given `fun` over `enumerable` and flattens the result.
+
+  This function returns a new stream built by appending the result of invoking `fun`
+  on each element of `enumerable` together; conceptually, this is similar to a
+  combination of `map/3` and `Enum.concat/1`.
 
   ## Examples
 

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -365,8 +365,7 @@ defmodule Stream do
   Maps the given `fun` over `enumerable` and flattens the result.
 
   This function returns a new stream built by appending the result of invoking `fun`
-  on each element of `enumerable` together; conceptually, this is similar to a
-  combination of `map/3` and `Enum.concat/1`.
+  on each element of `enumerable` together.
 
   ## Examples
 


### PR DESCRIPTION
Flat_map/2 doesn't contain info about flattening, but flat_map_reduce/2 does. It was not consistent.