### PR TITLE
Improve error messages for invalid expression in match

### DIFF
--- a/lib/elixir/src/elixir_exp.erl
+++ b/lib/elixir/src/elixir_exp.erl
@@ -684,7 +684,8 @@ assert_no_match_or_guard_scope(Meta, Kind, E) ->
   assert_no_match_scope(Meta, Kind, E),
   assert_no_guard_scope(Meta, Kind, E).
 assert_no_match_scope(Meta, _Kind, #{context := match, file := File}) ->
-  compile_error(Meta, File, "invalid pattern in match");
+  compile_error(Meta, File, "invalid pattern in match: Patterns may not be functions. "
+                "If you want complex conditions evaluate them outside of the case");
 assert_no_match_scope(_Meta, _Kind, _E) -> [].
 assert_no_guard_scope(Meta, _Kind, #{context := guard, file := File}) ->
   compile_error(Meta, File, "invalid expression in guard");

--- a/lib/elixir/src/elixir_exp.erl
+++ b/lib/elixir/src/elixir_exp.erl
@@ -684,7 +684,7 @@ assert_no_match_or_guard_scope(Meta, Kind, E) ->
   assert_no_match_scope(Meta, Kind, E),
   assert_no_guard_scope(Meta, Kind, E).
 assert_no_match_scope(Meta, _Kind, #{context := match, file := File}) ->
-  compile_error(Meta, File, "invalid expression in match");
+  compile_error(Meta, File, "invalid pattern in match");
 assert_no_match_scope(_Meta, _Kind, _E) -> [].
 assert_no_guard_scope(Meta, _Kind, #{context := guard, file := File}) ->
   compile_error(Meta, File, "invalid expression in guard");

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -223,7 +223,7 @@ defmodule Kernel.ErrorsTest do
 
   test "invalid match pattern" do
     assert_compile_fail CompileError,
-    "nofile:2: invalid expression in match",
+    "nofile:2: invalid pattern in match",
     '''
     case true do
       true && true -> true

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -223,7 +223,8 @@ defmodule Kernel.ErrorsTest do
 
   test "invalid match pattern" do
     assert_compile_fail CompileError,
-    "nofile:2: invalid pattern in match",
+    "nofile:2: invalid pattern in match: Patterns may not be functions. " <>
+      "If you want complex conditions evaluate them outside of the case",
     '''
     case true do
       true && true -> true


### PR DESCRIPTION
It was pointed out that `invalid expression in match` was unclear
because the "expression" that is referred to should is not actually an
expression. Since `case` can only match against a pattern it is clearer
to say `invalid pattern in match`.

Addresses Issue #5649

Amos King @adkron <amos@binarynoggin.com>