### PR TITLE
Fix Macro.camelize/1 for screaming snake case

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1260,27 +1260,24 @@ defmodule Macro do
     do: camelize(t)
 
   def camelize(<<h, t::binary>>),
-    do: <<to_upper_char(h)>> <> do_camelize(t)
+    do: <<to_upper_char(h)>> <> do_camelize(t, h)
 
-  defp do_camelize(<<?_, ?_, t::binary>>),
-    do: do_camelize(<<?_, t::binary >>)
+  defp do_camelize(<<?_, t::binary>>, _),
+    do: do_camelize(t, ?_)
 
-  defp do_camelize(<<?_, h, t::binary>>) when h >= ?a and h <= ?z,
-    do: <<to_upper_char(h)>> <> do_camelize(t)
+  defp do_camelize(<<h, t::binary>>, prev) when prev >= ?a and prev <= ?z and h >= ?A and h <= ?Z,
+    do: <<h>> <> do_camelize(t, h)
 
-  defp do_camelize(<<?_, h, t::binary>>) when h >= ?0 and h <= ?9,
-    do: <<h>> <> do_camelize(t)
+  defp do_camelize(<<h, t::binary>>, prev) when prev == ?_ or prev == ?.,
+    do: <<to_upper_char(h)>> <> do_camelize(t, h)
 
-  defp do_camelize(<<?_>>),
-    do: <<>>
+  defp do_camelize(<<?/, t::binary>>, _),
+    do: <<?.>> <> do_camelize(t, ?.)
 
-  defp do_camelize(<<?/, t::binary>>),
-    do: <<?.>> <> camelize(t)
+  defp do_camelize(<<h, t::binary>>, _),
+    do: <<to_lower_char(h)>> <> do_camelize(t, h)
 
-  defp do_camelize(<<h, t::binary>>),
-    do: <<h>> <> do_camelize(t)
-
-  defp do_camelize(<<>>),
+  defp do_camelize(<<>>, _),
     do: <<>>
 
   defp to_upper_char(char) when char >= ?a and char <= ?z, do: char - 32

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1263,16 +1263,13 @@ defmodule Macro do
     do: <<to_upper_char(h)>> <> do_camelize(t, h)
 
   defp do_camelize(<<?_, t::binary>>, _),
-    do: do_camelize(t, ?_)
+    do: camelize(t)
+
+  defp do_camelize(<<?/, t::binary>>, _),
+    do: <<?.>> <> camelize(t)
 
   defp do_camelize(<<h, t::binary>>, prev) when prev >= ?a and prev <= ?z and h >= ?A and h <= ?Z,
     do: <<h>> <> do_camelize(t, h)
-
-  defp do_camelize(<<h, t::binary>>, prev) when prev == ?_ or prev == ?.,
-    do: <<to_upper_char(h)>> <> do_camelize(t, h)
-
-  defp do_camelize(<<?/, t::binary>>, _),
-    do: <<?.>> <> do_camelize(t, ?.)
 
   defp do_camelize(<<h, t::binary>>, _),
     do: <<to_lower_char(h)>> <> do_camelize(t, h)

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -693,6 +693,7 @@ defmodule MacroTest do
     assert Macro.camelize("FooBar") == "FooBar"
     assert Macro.camelize("foo") == "Foo"
     assert Macro.camelize("foo_bar") == "FooBar"
+    assert Macro.camelize("FOO_BAR") == "FooBar"
     assert Macro.camelize("foo_") == "Foo"
     assert Macro.camelize("_foo") == "Foo"
     assert Macro.camelize("foo10") == "Foo10"


### PR DESCRIPTION
The screaming snake case was keeping its original format after being
camelized. As mentioned in issue #5627. This change allows it to behave
like the all lower snake case when camelized.

Amos King @adkron <amos@binarynoggin.com>