### PR TITLE
Improve error on module case mismatch

### DIFF
--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -387,6 +387,13 @@ defmodule ExceptionTest do
                  * get_cookie/0
                  * set_cookie/2
            """
+    assert %UndefinedFunctionError{module: Genserver, function: :start_link, arity: 3} |> message == """
+           function Genserver.start_link/3 is undefined (module Genserver is not available). Did you mean:
+
+                 * GenServer.start_link/3
+           """
+    assert %UndefinedFunctionError{module: Genserver, function: :start_link, arity: 1} |> message ==
+           "function Genserver.start_link/1 is undefined (module Genserver is not available). Did you mean GenServer?"
   end
 
   test "UndefinedFunctionError when the mfa is a macro but require wasn't called" do

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -240,8 +240,12 @@ defmodule Mix.Tasks.Xref do
   end
 
   defp format_warning(file, {lines, :unknown_module, module, function, arity, _}) do
-    ["function ", Exception.format_mfa(module, function, arity),
-     " is undefined (module #{inspect module} is not available)\n" | format_file_lines(file, lines)]
+    message =
+      [module: module, function: function, arity: arity, reason: :"module could not be loaded"]
+      |> UndefinedFunctionError.exception()
+      |> Exception.message()
+
+    [message, "\n" | format_file_lines(file, lines)]
   end
 
   defp format_file_lines(file, [line]) do

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -63,6 +63,21 @@ defmodule Mix.Tasks.XrefTest do
     """
   end
 
+  test "warnings: reports module case mismatch" do
+    assert_warnings """
+    defmodule A do
+      def a, do: Genserver.start_link(A, [], [])
+    end
+    """, """
+    warning: function Genserver.start_link/3 is undefined (module Genserver is not available). Did you mean:
+
+          * GenServer.start_link/3
+
+      lib/a.ex:2
+
+    """
+  end
+
   test "warnings: reports missing captures" do
     assert_warnings """
     defmodule A do


### PR DESCRIPTION
On a case-insensitive filesystem, a module case mismatch typo results in error messages that can be confusing:

```elixir
iex(1)> Genserver.start_link(MyApp.Worker, [], name: MyApp.Worker)

09:57:03.286 [error] Loading of /lib/elixir/ebin/Elixir.Genserver.beam failed: :badfile

09:57:03.287 [error] beam/beam_load.c(1376): Error loading module 'Elixir.Genserver':
  module name in object code is Elixir.GenServer

** (UndefinedFunctionError) function Genserver.start_link/3 is undefined (module Genserver is not available)
    Genserver.start_link(MyApp.Worker, [], [name: MyApp.Worker])
```

The `:code_server` log messages do show the root cause, but it's easy to miss, and in a way they obscure the problem by suggesting the problem is in the .beam file.

This PR provides a more helpful message (the `:code_server` log messages still appear):

```elixir
iex(1)> Genserver.start_link(MyApp.Worker, [], name: MyApp.Worker)
** (UndefinedFunctionError) function Genserver.start_link/3 is undefined (module Genserver is not available). Did you mean:

      * GenServer.start_link/3

    Genserver.start_link(MyApp.Worker, [], [name: MyApp.Worker])

```

Question: would it be possible/desirable to suppress the `:code_server` log messages?

The `xref` Mix task has been updated to provide the same message as well.

/cc @benwilson512