### PR TITLE
Give context to invalid pattern error

### DIFF
--- a/lib/elixir/src/elixir_exp.erl
+++ b/lib/elixir/src/elixir_exp.erl
@@ -684,7 +684,7 @@ assert_no_match_or_guard_scope(Meta, Kind, E) ->
   assert_no_match_scope(Meta, Kind, E),
   assert_no_guard_scope(Meta, Kind, E).
 assert_no_match_scope(Meta, _Kind, #{context := match, file := File}) ->
-  compile_error(Meta, File, "invalid pattern matching: Patterns cannot contain evaluations");
+  compile_error(Meta, File, "invalid pattern matching: Patterns cannot contain expressions");
 assert_no_match_scope(_Meta, _Kind, _E) -> [].
 assert_no_guard_scope(Meta, _Kind, #{context := guard, file := File}) ->
   compile_error(Meta, File, "invalid expression in guard");

--- a/lib/elixir/src/elixir_exp.erl
+++ b/lib/elixir/src/elixir_exp.erl
@@ -684,7 +684,7 @@ assert_no_match_or_guard_scope(Meta, Kind, E) ->
   assert_no_match_scope(Meta, Kind, E),
   assert_no_guard_scope(Meta, Kind, E).
 assert_no_match_scope(Meta, _Kind, #{context := match, file := File}) ->
-  compile_error(Meta, File, "invalid pattern in match");
+  compile_error(Meta, File, "invalid pattern matching: Patterns cannot contain evaluations");
 assert_no_match_scope(_Meta, _Kind, _E) -> [].
 assert_no_guard_scope(Meta, _Kind, #{context := guard, file := File}) ->
   compile_error(Meta, File, "invalid expression in guard");

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -223,7 +223,7 @@ defmodule Kernel.ErrorsTest do
 
   test "invalid match pattern" do
     assert_compile_fail CompileError,
-    "nofile:2: invalid pattern in match",
+    "nofile:2: invalid pattern matching: Patterns cannot contain evaluations",
     '''
     case true do
       true && true -> true

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -223,7 +223,7 @@ defmodule Kernel.ErrorsTest do
 
   test "invalid match pattern" do
     assert_compile_fail CompileError,
-    "nofile:2: invalid pattern matching: Patterns cannot contain evaluations",
+    "nofile:2: invalid pattern matching: Patterns cannot contain expressions",
     '''
     case true do
       true && true -> true


### PR DESCRIPTION
Talking with @fishcakez we thought that the error message needed a
little more context to help developers find the problem and fix it. This
also addresses the fact that this can happen outside of a `case` match.

~~~elixir
  def fun(true && true), do: :ok
  def fun(other_fun()), do: :ok
~~~

Thanks to @fishcakez for the help and the examples.

Amos King @adkron <amos@binarynoggin.com>