### PR TITLE
Improve error when using non-arith guard BIF in match

### DIFF
--- a/lib/elixir/src/elixir_translator.erl
+++ b/lib/elixir/src/elixir_translator.erl
@@ -436,7 +436,7 @@ assert_function_scope(_Meta, _Kind, #elixir_scope{function=Function}) -> Functio
 
 assert_allowed_in_context(Meta, Left, Right, Arity, #elixir_scope{context=Context} = S)
     when (Context == match) orelse (Context == guard) ->
-  case (Left == erlang) andalso erl_internal:guard_bif(Right, Arity) of
+  case (Left == erlang) andalso is_erlang_allowed(Context, Right, Arity) of
     true  -> ok;
     false ->
       compile_error(Meta, S#elixir_scope.file, "cannot invoke remote function ~ts.~ts/~B inside ~ts",
@@ -444,3 +444,8 @@ assert_allowed_in_context(Meta, Left, Right, Arity, #elixir_scope{context=Contex
   end;
 assert_allowed_in_context(_, _, _, _, _) ->
   ok.
+
+is_erlang_allowed(match, Right, Arity) ->
+  erl_internal:arith_op(Right, Arity);
+is_erlang_allowed(guard, Right, Arity) ->
+  erl_internal:guard_bif(Right, Arity).

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -925,6 +925,22 @@ defmodule Kernel.ErrorsTest do
       'case [] do; [] when Hello.something_that_does_not_exist == [] -> :ok; end'
   end
 
+  test "invalid :erlang call on match" do
+    assert_compile_fail CompileError,
+      "nofile:1: cannot invoke remote function :erlang.make_ref/0 inside match",
+      'case [] do; :erlang.make_ref() -> :ok; end'
+
+    assert_compile_fail CompileError,
+      "nofile:1: cannot invoke remote function :erlang.self/0 inside match",
+      'case [] do; self() -> :ok; end'
+  end
+
+  test "invalid :erlang call on guard" do
+    assert_compile_fail CompileError,
+      "nofile:1: cannot invoke remote function :erlang.make_ref/0 inside match",
+      'case [] do; :erlang.make_ref() -> :ok; end'
+  end
+
   test "typespec errors" do
     assert_compile_fail CompileError,
       "nofile:2: type foo() undefined",

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -928,7 +928,7 @@ defmodule Kernel.ErrorsTest do
   test "invalid :erlang call on match" do
     assert_compile_fail CompileError,
       "nofile:1: cannot invoke remote function :erlang.make_ref/0 inside match",
-      'case [] do; :erlang.make_ref() -> :ok; end'
+      'case [] do; make_ref() -> :ok; end'
 
     assert_compile_fail CompileError,
       "nofile:1: cannot invoke remote function :erlang.self/0 inside match",
@@ -937,8 +937,8 @@ defmodule Kernel.ErrorsTest do
 
   test "invalid :erlang call on guard" do
     assert_compile_fail CompileError,
-      "nofile:1: cannot invoke remote function :erlang.make_ref/0 inside match",
-      'case [] do; :erlang.make_ref() -> :ok; end'
+      "nofile:1: cannot invoke remote function :erlang.make_ref/0 inside guard",
+      'case [] do; _ when make_ref() -> :ok; end'
   end
 
   test "typespec errors" do


### PR DESCRIPTION
Only arith BIFs are allowed in matches.

Partial fix for #5666.