### PR TITLE
Add --if-missing flag to local.hex mix task

### DIFF
--- a/lib/mix/lib/mix/tasks/local.hex.ex
+++ b/lib/mix/lib/mix/tasks/local.hex.ex
@@ -16,13 +16,35 @@ defmodule Mix.Tasks.Local.Hex do
     * `--force` - forces installation without a shell prompt; primarily
       intended for automation in build systems like `make`
 
+    * `--if-missing` - performs installation only if Hex is not installed yet;
+      intended for automation as a replacement of `--force` to not reinstall
+      Hex every time scripts are run.
+      If both options are set `--force` takes precedence
+
   ## Mirrors
 
   If you want to change the [default mirror](https://repo.hex.pm)
   used for fetching Hex, set the `HEX_MIRROR` environment variable.
   """
   @spec run(OptionParser.argv) :: boolean
-  def run(args) do
+  def run(argv) do
+    {opts, _} = OptionParser.parse!(argv, switches: [if_missing: :boolean,
+                                                     force: :boolean])
+    should_install = case opts do
+      %{force: true}      -> true;
+      %{if_missing: true} -> Code.ensure_loaded?(Hex);
+      _                   -> true
+    end
+
+    if should_install do
+      do_install(argv)
+    else
+      true
+    end
+  end
+
+  @spec do_install(OptionParser.argv) :: boolean
+  def do_install(argv) do
     hex_mirror = Mix.Hex.mirror
 
     {elixir_version, hex_version, sha512} =
@@ -33,6 +55,6 @@ defmodule Mix.Tasks.Local.Hex do
       |> String.replace("[ELIXIR_VERSION]", elixir_version)
       |> String.replace("[HEX_VERSION]", hex_version)
 
-    Mix.Tasks.Archive.Install.run [url, "--sha512", sha512 | args]
+    Mix.Tasks.Archive.Install.run [url, "--sha512", sha512 | argv]
   end
 end

--- a/lib/mix/lib/mix/tasks/local.hex.ex
+++ b/lib/mix/lib/mix/tasks/local.hex.ex
@@ -17,9 +17,10 @@ defmodule Mix.Tasks.Local.Hex do
       intended for automation in build systems like `make`
 
     * `--if-missing` - performs installation only if Hex is not installed yet;
-      intended for automation as a replacement of `--force` to not reinstall
-      Hex every time scripts are run.
-      If both options are set `--force` takes precedence
+      intended for automation when sctips can be run multiple times to avoid
+      reinstalling Hex.
+
+    If both options are set `--force` takes precedence
 
   ## Mirrors
 
@@ -34,8 +35,8 @@ defmodule Mix.Tasks.Local.Hex do
     if_missing = opts[:if_missing] || false
 
     should_install = case {force, if_missing} do
-      {false, true} -> Code.ensure_loaded?(Hex);
-      _             -> true
+      {false, true} -> Code.ensure_loaded?(Hex)
+      _ -> true
     end
 
     if should_install do

--- a/lib/mix/lib/mix/tasks/local.hex.ex
+++ b/lib/mix/lib/mix/tasks/local.hex.ex
@@ -30,10 +30,12 @@ defmodule Mix.Tasks.Local.Hex do
   def run(argv) do
     {opts, _} = OptionParser.parse!(argv, switches: [if_missing: :boolean,
                                                      force: :boolean])
-    should_install = case opts do
-      %{force: true}      -> true;
-      %{if_missing: true} -> Code.ensure_loaded?(Hex);
-      _                   -> true
+    force = opts[:force] || false
+    if_missing = opts[:if_missing] || false
+
+    should_install = case {force, if_missing} do
+      {false, true} -> Code.ensure_loaded?(Hex);
+      _             -> true
     end
 
     if should_install do


### PR DESCRIPTION
In automation scripts like `make`, `--force` flag causes reinstallation of Hex
every time `mix` is run (to avoid hanging on prompt), which is unnecessary.
Locating that Hex is installed from make tasks is not a trivial task,
so adding `mix local.hex --if-missing` would be much more convenient.