### PR TITLE
Replace :gen_server process loop with own implementation

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -667,13 +667,13 @@ defmodule GenServer do
   defp do_start(link, module, args, options) do
     case Keyword.pop(options, :name) do
       {nil, opts} ->
-        :gen.start(:gen_server, link, module, args, opts)
+        :gen.start(GenServer.Loop, link, module, args, opts)
       {atom, opts} when is_atom(atom) ->
-        :gen.start(:gen_server, link, {:local, atom}, module, args, opts)
+        :gen.start(GenServer.Loop, link, {:local, atom}, module, args, opts)
       {{:global, _term} = tuple, opts} ->
-        :gen.start(:gen_server, link, tuple, module, args, opts)
+        :gen.start(GenServer.Loop, link, tuple, module, args, opts)
       {{:via, via_module, _term} = tuple, opts} when is_atom(via_module) ->
-        :gen.start(:gen_server, link, tuple, module, args, opts)
+        :gen.start(GenServer.Loop, link, tuple, module, args, opts)
       other ->
         raise ArgumentError, """
         expected :name option to be one of:

--- a/lib/elixir/lib/gen_server/loop.ex
+++ b/lib/elixir/lib/gen_server/loop.ex
@@ -8,10 +8,10 @@ defmodule GenServer.Loop do
 
   @spec init_it(pid(), :self | pid(), gen_name(), module(), term(), Keyword.t()) ::
     no_return()
-  def init_it(starter, parent, gen_name, mod, args, opts) do
-    parent = gen_parent(parent)
-    name = :gen.name(gen_name)
-    dbg  = :gen.debug_options(name, opts)
+  def init_it(starter, gen_parent, gen_name, mod, args, opts) do
+    parent = server_parent(gen_parent)
+    name = server_name(gen_name)
+    dbg = server_debug(name, opts)
     try do
       apply(mod, :init, [args])
     catch
@@ -20,9 +20,9 @@ defmodule GenServer.Loop do
         init_stop(starter, reason, gen_name)
     else
       {:ok, state} ->
-        init_ok(starter, parent, dbg, mod, state, :infinity)
+        init_ok(starter, parent, dbg, name, mod, state, :infinity)
       {:ok, state, await} ->
-        init_ok(starter, parent, dbg, mod, state, await)
+        init_ok(starter, parent, dbg, name, mod, state, await)
       {:stop, reason} ->
         init_stop(starter, reason, gen_name)
       :ignore ->
@@ -34,31 +34,31 @@ defmodule GenServer.Loop do
 
   ## :proc_lib callbacks
 
-  @spec continue(pid(), [:sys.dbg_opt], module(), term()) :: no_return()
-  def continue(parent, dbg, mod, state) do
+  @spec continue(pid(), [:sys.dbg_opt], term(), module(), term()) :: no_return()
+  def continue(parent, dbg, name, mod, state) do
     # must be message in queue as woke up from hibernation
     receive do
       msg ->
-        handle(msg, parent, dbg, mod, state, :hibernate)
+        handle(msg, parent, dbg, name, mod, state, :hibernate)
     end
   end
 
   ## :sys callbacks
 
-  def system_continue(parent, dbg, {mod, state, await}) do
-    loop(parent, dbg, mod, state, await)
+  def system_continue(parent, dbg, {name, mod, state, await}) do
+    loop(parent, dbg, name, mod, state, await)
   end
 
-  def system_get_state({_, state, _}) do
+  def system_get_state({_, _, state, _}) do
     {:ok, state}
   end
 
-  def system_replace_state(replace, {mod, state, await}) do
+  def system_replace_state(replace, {name, mod, state, await}) do
     state = replace.(state)
-    {:ok, state, {mod, state, await}}
+    {:ok, state, {name, mod, state, await}}
   end
 
-  def system_code_change({mod, state, await}, _, oldvsn, extra) do
+  def system_code_change({name, mod, state, await}, _, oldvsn, extra) do
     try do
       apply(mod, :code_change, [oldvsn, state, extra])
     catch
@@ -66,25 +66,76 @@ defmodule GenServer.Loop do
         :erlang.raise(:error, {:nocatch, value}, System.stacktrace())
     else
       {:ok, state} ->
-        {:ok, {mod, state, await}}
+        {:ok, {name, mod, state, await}}
     end
   end
 
   # TODO: add format_status/2 for :sys.get_status
 
-  def system_terminate(reason, _, _, {mod, state, _}) do
+  def system_terminate(reason, _, dbg, {name, mod, state, _}) do
     try do
       throw(:terminate)
     catch
       :throw, :terminate ->
-        handle_exception(:exit, reason, System.stacktrace(), nil, mod, state)
+        stack = System.stacktrace()
+        handle_exception(:exit, reason, stack, nil, dbg, name, mod, state)
     end
   end
 
   ## Helpers
 
-  defp gen_parent(:self),  do: self()
-  defp gen_parent(parent), do: parent
+  defp server_parent(:self),  do: self()
+  defp server_parent(parent), do: parent
+
+  defp server_name(name) when is_pid(name), do: name
+  defp server_name({:local, name}),         do: name
+  defp server_name({:global, name}),        do: name
+  defp server_name({:via, _, name}),        do: name
+
+  defp server_debug(name, opts) do
+    dbg_opts = Keyword.get(opts, :debug, [])
+    try do
+      :sys.debug_options(opts)
+    catch
+      _, _ ->
+        format = '** Generic server ~p started with invalid debug options: ~p~n'
+        :error_logger.format(format, [name, dbg_opts])
+        []
+    end
+  end
+
+  defp debug([], _, _, _, _), do: []
+  defp debug(dbg, event, name, mod, state) do
+    :sys.handle_debug(dbg, &debug_inspect/3, {name, mod, state}, event)
+  end
+
+  defp debug_inspect(device, event, {name, mod, state}) do
+    msg = ["** (DEBUG from ", inspect(name), ?), ?\s, inspect(mod),
+           " with state ", inspect(state) | debug_format(event)]
+    IO.puts(device, msg)
+  end
+
+  defp debug_format({:in, {:call, req}, {from, _}}) do
+    [" received call (from ", inspect(from), ?:, ?\s | inspect(req)]
+  end
+  defp debug_format({:in, {type, req}}) do
+    [" received ", Atom.to_string(type), ?:, ?\s | inspect(req)]
+  end
+  defp debug_format({:out, {:reply, resp}, {to, _}}) do
+    [" replied (to ", inspect(to), ?:, ?\s | inspect(resp)]
+  end
+  defp debug_format(:noreply) do
+    " did not reply"
+  end
+  defp debug_format(:timeout) do
+    " timed out"
+  end
+  defp debug_format(:enter_loop) do
+    " entered loop"
+  end
+  defp debug_format({:stop, reason}) do
+    [" stopped: " | Exception.format_exit(reason)]
+  end
 
   defp init_stop(starter, reason, gen_name) do
     init_stop(starter, reason, gen_name, {:error, reason})
@@ -93,147 +144,165 @@ defmodule GenServer.Loop do
   defp init_stop(starter, reason, gen_name, return) do
     # Unregister before init_ack/2 so that if supervisor restarts process the
     # name is not taken
-    :gen.unregister_name(gen_name)
+    _ = gen_unregister(gen_name)
     :proc_lib.init_ack(starter, return)
     exit(reason)
   end
+
+  defp gen_unregister(name) when is_pid(name), do: :ok
+  defp gen_unregister({:local, name}),         do: Process.unregister(name)
+  defp gen_unregister({:global, name}),        do: :gobal.unregister_name(name)
+  defp gen_unregister({:via, mod, name}),      do: mod.unregister_name(name)
 
   defp exit_reason(:exit, reason, _),      do: reason
   defp exit_reason(:error, reason, stack), do: {reason, stack}
   defp exit_reason(:throw, value, stack),  do: {{:nocatch, value}, stack}
 
-  defp init_ok(starter, parent, dbg, mod, state, await) do
+  defp init_ok(starter, parent, dbg, name, mod, state, await) do
     :proc_lib.init_ack(starter, {:ok, self()})
-    loop(parent, dbg, mod, state, await)
+    dbg = debug(dbg, :enter_loop, name, mod, state)
+    loop(parent, dbg, name, mod, state, await)
   end
 
-  defp loop(parent, dbg, mod, state, :hibernate) do
-    args = [parent, dbg, mod, state]
+  defp loop(parent, dbg, name, mod, state, :hibernate) do
+    args = [parent, dbg, name, mod, state]
     :proc_lib.hibernate(__MODULE__, :continue, args)
   end
 
-  defp loop(parent, dbg, mod, state, timeout) do
+  defp loop(parent, dbg, name, mod, state, timeout) do
     receive do
       msg ->
-        # TODO: handle events with dbg
-        handle(msg, parent, dbg, mod, state, timeout)
+        handle(msg, parent, dbg, name, mod, state, timeout)
     after
       timeout ->
-        handle(:timeout, parent, dbg, mod, state, timeout)
+        dbg = debug(dbg, :timeout, name, mod, state)
+        async(:handle_info, :timeout, parent, dbg, name, mod, state)
     end
   end
 
-  defp handle({:"$gen_call", from, req}, parent, dbg, mod, state, _) do
-    sync(req, from, parent, dbg, mod, state)
+  defp handle({:"$gen_call", from, req}, parent, dbg, name, mod, state, _) do
+    dbg = debug(dbg, {:in, {:call, req}, from}, name, mod, state)
+    sync(req, from, parent, dbg, name, mod, state)
   end
-  defp handle({:"$gen_cast", req}, parent, dbg, mod, state, _) do
-    async(:handle_cast, req, parent, dbg, mod, state)
+  defp handle({:"$gen_cast", req}, parent, dbg, name, mod, state, _) do
+    dbg = debug(dbg, {:in, {:cast, req}}, name, mod, state)
+    async(:handle_cast, req, parent, dbg, name, mod, state)
   end
-  defp handle({:system, from, req}, parent, dbg, mod, state, await) do
-    misc = {mod, state, await}
+  defp handle({:system, from, req}, parent, dbg, name, mod, state, await) do
+    misc = {name, mod, state, await}
     :sys.handle_system_msg(req, from, parent, __MODULE__, dbg, misc)
   end
-  defp handle({:EXIT, parent, reason}, parent, _, mod, state, _) do
+  defp handle({:EXIT, parent, reason}, parent, dbg, name, mod, state, _) do
     try do
       throw(:EXIT)
     catch
       :throw, :EXIT ->
-        handle_exception(:exit, reason, System.stacktrace, nil, mod, state)
+        stack = System.stacktrace()
+        handle_exception(:exit, reason, stack, nil, dbg, name, mod, state)
     end
   end
-  defp handle(msg, parent, dbg, mod, state, _) do
-    async(:handle_info, msg, parent, dbg, mod, state)
+  defp handle(msg, parent, dbg, name, mod, state, _) do
+    dbg = debug(dbg, {:in, {:info, msg}}, name, mod, state)
+    async(:handle_info, msg, parent, dbg, name, mod, state)
   end
 
-  defp sync(req, from, parent, dbg, mod, state) do
+  defp sync(req, from, parent, dbg, name, mod, state) do
     try do
       apply(mod, :handle_call, [req, from, state])
     catch
       kind, reason ->
-        handle_exception(kind, reason, System.stacktrace(), req, mod, state)
+        stack = System.stacktrace()
+        handle_exception(kind, reason, stack, req, dbg, name, mod, state)
     else
       {:reply, resp, state} ->
         :gen.reply(from, resp)
-        loop(parent, dbg, mod, state, :infinity)
+        dbg = debug(dbg, {:out, {:reply, resp}, from}, name, mod, state)
+        loop(parent, dbg, name, mod, state, :infinity)
       {:reply, resp, state, await} ->
         :gen.reply(from, resp)
-        loop(parent, dbg, mod, state, await)
+        dbg = debug(dbg, {:out, {:reply, resp}, from}, name, mod, state)
+        loop(parent, dbg, name, mod, state, await)
       {:stop, reason, resp, state} ->
         :gen.reply(from, resp)
-        handle_stop(reason, req, mod, state)
+        dbg = debug(dbg, {:out, {:reply, resp}, from}, name, mod, state)
+        handle_stop(reason, req, dbg, name, mod, state)
       other ->
-        handle_async(other, req, parent, dbg, mod, state)
+        handle_async(other, req, parent, dbg, name, mod, state)
     end
   end
 
-  defp async(fun, msg, parent, dbg, mod, state) do
+  defp async(fun, msg, parent, dbg, name, mod, state) do
     try do
       apply(mod, fun, [msg, state])
     catch
       kind, reason ->
-        handle_exception(kind, reason, System.stacktrace(), msg, mod, state)
+        stack = System.stacktrace()
+        handle_exception(kind, reason, stack, msg, dbg, name, mod, state)
     else
       return ->
-        handle_async(return, msg, parent, dbg, mod, state)
+        handle_async(return, msg, parent, dbg, name, mod, state)
     end
   end
 
-  defp handle_async({:noreply, state}, _, parent, dbg, mod, _) do
-    loop(parent, dbg, mod, state, :infinity)
+  defp handle_async({:noreply, state}, _, parent, dbg, name, mod, _) do
+    dbg = debug(dbg, :noreply, name, mod, state)
+    loop(parent, dbg, name, mod, state, :infinity)
   end
-  defp handle_async({:noreply, state, await}, _, parent, dbg, mod, _) do
-    loop(parent, dbg, mod, state, await)
+  defp handle_async({:noreply, state, await}, _, parent, dbg, name, mod, _) do
+    dbg = debug(dbg, :noreply, name, mod, state)
+    loop(parent, dbg, name, mod, state, await)
   end
-  defp handle_async({:stop, reason, state}, msg, _, _, mod, _) do
-    handle_stop(reason, msg, mod, state)
+  defp handle_async({:stop, reason, state}, msg, _, dbg, name, mod, _) do
+    handle_stop(reason, msg, dbg, name, mod, state)
   end
-  defp handle_async(other, msg, _, _, mod, state) do
+  defp handle_async(other, msg, _, dbg, name, mod, state) do
     try do
       throw(:bad_return_value)
     catch
       :bad_return_value ->
         reason = {:bad_return_value, other}
-        handle_exception(:exit, reason, System.stacktrace(), msg, mod, state)
+        stack = System.stacktrace()
+        handle_exception(:exit, reason, stack, msg, dbg, name, mod, state)
     end
   end
 
-  defp handle_exception(kind, reason, stack, msg, mod, state) do
+  defp handle_exception(kind, reason, stack, msg, dbg, name, mod, state) do
     exit_reason = exit_reason(kind, reason, stack)
     log_reason = log_reason(kind, reason, stack)
-    terminate(exit_reason, log_reason, msg, mod, state)
+    terminate(exit_reason, log_reason, msg, dbg, name, mod, state)
   end
 
-  defp handle_stop(reason, msg, mod, state) do
-    terminate(reason, reason, msg, mod, state)
+  defp handle_stop(reason, msg, dbg, name, mod, state) do
+    terminate(reason, reason, msg, dbg, name, mod, state)
   end
 
   defp log_reason(:exit, reason, stack),  do: {reason, stack}
   defp log_reason(:error, reason, stack), do: {reason, stack}
   defp log_reason(:throw, value, stack),  do: {{:nocatch, value}, stack}
 
-  defp terminate(exit_reason, log_reason, msg, mod, state) do
+  defp terminate(exit_reason, log_reason, msg, dbg, name, mod, state) do
+    dbg = debug(dbg, {:stop, exit_reason}, name, mod, state)
     try do
       apply(mod, :terminate, [exit_reason, state])
     catch
       kind, reason ->
         stack = System.stacktrace()
         exit_reason = exit_reason(kind, reason, stack)
-        log_exit(exit_reason, log_reason(kind, reason, stack), msg, state)
+        log_exit(exit_reason, log_reason(kind, reason, stack), msg, dbg, state)
     else
       _ ->
-        handle_exit(exit_reason, log_reason, msg, state)
+        handle_exit(exit_reason, log_reason, msg, dbg, state)
     end
   end
 
-  defp handle_exit(:normal, _, _, _),                   do: exit(:normal)
-  defp handle_exit(:shutdown, _, _, _),                 do: exit(:shutdown)
-  defp handle_exit(shutdown = {:shutdown, _}, _, _, _), do: exit(shutdown)
-  defp handle_exit(exit_reason, log_reason, msg, state) do
-    log_exit(exit_reason, log_reason, msg, state)
+  defp handle_exit(:normal, _, _, _, _),                   do: exit(:normal)
+  defp handle_exit(:shutdown, _, _, _, _),                 do: exit(:shutdown)
+  defp handle_exit(shutdown = {:shutdown, _}, _, _, _, _), do: exit(shutdown)
+  defp handle_exit(exit_reason, log_reason, msg, dbg, state) do
+    log_exit(exit_reason, log_reason, msg, dbg, state)
   end
 
-  defp log_exit(exit_reason, log_reason, msg, state) do
-    # TODO: log dbg events
+  defp log_exit(exit_reason, log_reason, msg, dbg, state) do
     format = '** Generic server ~p terminating~n' ++
              '** Last message in was ~p~n' ++
              '** When Server state == ~p~n' ++
@@ -241,6 +310,7 @@ defmodule GenServer.Loop do
     # TODO: log name
     # TODO: format status on state
     :error_logger.format(format, [self(), msg, state, log_reason])
+    :sys.print_log(dbg)
     exit(exit_reason)
   end
 end

--- a/lib/elixir/lib/gen_server/loop.ex
+++ b/lib/elixir/lib/gen_server/loop.ex
@@ -1,0 +1,171 @@
+defmodule GenServer.Loop do
+  @moduledoc false
+
+  @typep gen_name() ::
+    pid() | {:local, atom()} | {:global, term()} | {:via, module(), term}
+
+  ## :gen callbacks
+
+  @spec init_it(pid(), :self | pid(), gen_name(), module(), term(), Keyword.t()) ::
+    no_return()
+  def init_it(starter, parent, gen_name, mod, args, opts) do
+    parent = gen_parent(parent)
+    name = :gen.name(gen_name)
+    dbg  = :gen.debug_options(name, opts)
+    try do
+      apply(mod, :init, [args])
+    catch
+      kind, reason ->
+        reason = exit_reason(kind, reason, Systen.stacktrace())
+        init_stop(starter, reason, gen_name)
+    else
+      {:ok, state} ->
+        init_ok(starter, parent, dbg, mod, state, :infinity)
+      {:ok, state, await} ->
+        init_ok(starter, parent, dbg, mod, state, await)
+      {:stop, reason} ->
+        init_stop(starter, reason, gen_name)
+      :ignore ->
+        init_stop(starter, :normal, gen_name, :ignore)
+      other ->
+        init_stop(starter, {:bad_return_value, other}, gen_name)
+    end
+  end
+
+  ## :proc_lib callbacks
+
+  @spec continue(pid(), [:sys.dbg_opt], module(), term()) :: no_return()
+  def continue(parent, dbg, mod, state) do
+    # must be message in queue as woke up from hibernation
+    receive do
+      msg ->
+        handle(msg, parent, dbg, mod, state, :hibernate)
+    end
+  end
+
+  ## :sys callbacks
+
+  def system_continue(parent, dbg, {mod, state, await}) do
+    loop(parent, dbg, mod, state, await)
+  end
+
+  def system_terminate(reason, _, _, {mod, state, _}) do
+    handle_stop(reason, mod, state)
+  end
+
+  ## Helpers
+
+  defp gen_parent(:self),  do: self()
+  defp gen_parent(parent), do: parent
+
+  defp init_stop(starter, reason, gen_name) do
+    init_stop(starter, reason, gen_name, {:error, reason})
+  end
+
+  defp init_stop(starter, reason, gen_name, return) do
+    # Unregister before init_ack/2 so that if supervisor restarts process the
+    # name is not taken
+    :gen.unregister_name(gen_name)
+    :proc_lib.init_ack(starter, return)
+    exit(reason)
+  end
+
+  defp exit_reason(:exit, reason, _),      do: reason
+  defp exit_reason(:error, reason, stack), do: {reason, stack}
+  defp exit_reason(:throw, value, stack),  do: {{:nocatch, value}, stack}
+
+  defp init_ok(starter, parent, dbg, mod, state, await) do
+    :proc_lib.init_ack(starter, {:ok, self()})
+    loop(parent, dbg, mod, state, await)
+  end
+
+  defp loop(parent, dbg, mod, state, :hibernate) do
+    args = [parent, dbg, mod, state]
+    :proc_lib.hibernate(__MODULE__, :continue, args)
+  end
+
+  defp loop(parent, dbg, mod, state, timeout) do
+    receive do
+      msg ->
+        handle(msg, parent, dbg, mod, state, timeout)
+    after
+      timeout ->
+        handle(:timeout, parent, dbg, mod, state, timeout)
+    end
+  end
+
+  defp handle({:"$gen_call", from, req}, parent, dbg, mod, state, _) do
+    handle_sync(req, from, parent, dbg, mod, state)
+  end
+  defp handle({:"$gen_cast", req}, parent, dbg, mod, state, _) do
+    handle_async(:handle_cast, req, parent, dbg, mod, state)
+  end
+  defp handle({:system, from, req}, parent, dbg, mod, state, await) do
+    misc = {mod, state, await}
+    :sys.handle_system_msg(req, from, parent, __MODULE__, dbg, misc)
+  end
+  defp handle(msg, parent, dbg, mod, state, _) do
+    handle_async(:handle_info, msg, parent, dbg, mod, state)
+  end
+
+  defp handle_sync(req, from, parent, dbg, mod, state) do
+    try do
+      apply(mod, :handle_call, [req, from, state])
+    catch
+      kind, reason ->
+        reason = exit_reason(kind, reason, System.stacktrace())
+        handle_stop(reason, mod, state)
+    else
+      {:reply, resp, state} ->
+        :gen.reply(from, resp)
+        loop(parent, dbg, mod, state, :infinity)
+      {:reply, resp, state, await} ->
+        :gen.reply(from, resp)
+        loop(parent, dbg, mod, state, await)
+      {:stop, reason, resp, state} ->
+        :gen.reply(from, resp)
+        handle_stop(reason, mod, state)
+      other ->
+        handle_async(other, parent, dbg, mod, state)
+    end
+  end
+
+  defp handle_async(fun, msg, parent, dbg, mod, state) do
+    try do
+      apply(mod, fun, [msg, state])
+    catch
+      kind, reason ->
+        reason = exit_reason(kind, reason, System.stacktrace())
+        handle_stop(reason, mod, state)
+    else
+      return ->
+        handle_async(return, parent, dbg, mod, state)
+    end
+  end
+
+  defp handle_async({:noreply, state}, parent, dbg, mod, _) do
+    loop(parent, dbg, mod, state, :infinity)
+  end
+  defp handle_async({:noreply, state, await}, parent, dbg, mod, _) do
+    loop(parent, dbg, mod, state, await)
+  end
+  defp handle_async({:stop, reason, state}, _, _, mod, _) do
+    handle_stop(reason, mod, state)
+  end
+  defp handle_async(other, _, _, mod, state) do
+    handle_stop({:bad_return_value, other}, mod, state)
+  end
+
+  defp handle_stop(reason, mod, state) do
+    try do
+      apply(mod, :terminate, [reason, state])
+    catch
+      kind, reason ->
+        reason = exit_reason(kind, reason, System.stacktrace())
+        exit(reason)
+    else
+      _ ->
+        exit(reason)
+    end
+  end
+end

--- a/lib/elixir/lib/gen_server/loop.ex
+++ b/lib/elixir/lib/gen_server/loop.ex
@@ -50,7 +50,12 @@ defmodule GenServer.Loop do
   end
 
   def system_terminate(reason, _, _, {mod, state, _}) do
-    handle_stop(reason, mod, state)
+    try do
+      throw(:terminate)
+    catch
+      :throw, :terminate ->
+        handle_exception(:exit, reason, System.stacktrace(), nil, mod, state)
+    end
   end
 
   ## Helpers
@@ -95,26 +100,33 @@ defmodule GenServer.Loop do
   end
 
   defp handle({:"$gen_call", from, req}, parent, dbg, mod, state, _) do
-    handle_sync(req, from, parent, dbg, mod, state)
+    sync(req, from, parent, dbg, mod, state)
   end
   defp handle({:"$gen_cast", req}, parent, dbg, mod, state, _) do
-    handle_async(:handle_cast, req, parent, dbg, mod, state)
+    async(:handle_cast, req, parent, dbg, mod, state)
   end
   defp handle({:system, from, req}, parent, dbg, mod, state, await) do
     misc = {mod, state, await}
     :sys.handle_system_msg(req, from, parent, __MODULE__, dbg, misc)
   end
+  defp handle({:EXIT, parent, reason}, parent, _, mod, state, _) do
+    try do
+      throw(:EXIT)
+    catch
+      :throw, :EXIT ->
+        handle_exception(:exit, reason, System.stacktrace, nil, mod, state)
+    end
+  end
   defp handle(msg, parent, dbg, mod, state, _) do
-    handle_async(:handle_info, msg, parent, dbg, mod, state)
+    async(:handle_info, msg, parent, dbg, mod, state)
   end
 
-  defp handle_sync(req, from, parent, dbg, mod, state) do
+  defp sync(req, from, parent, dbg, mod, state) do
     try do
       apply(mod, :handle_call, [req, from, state])
     catch
       kind, reason ->
-        reason = exit_reason(kind, reason, System.stacktrace())
-        handle_stop(reason, mod, state)
+        handle_exception(kind, reason, System.stacktrace(), req, mod, state)
     else
       {:reply, resp, state} ->
         :gen.reply(from, resp)
@@ -124,48 +136,86 @@ defmodule GenServer.Loop do
         loop(parent, dbg, mod, state, await)
       {:stop, reason, resp, state} ->
         :gen.reply(from, resp)
-        handle_stop(reason, mod, state)
+        handle_stop(reason, req, mod, state)
       other ->
-        handle_async(other, parent, dbg, mod, state)
+        handle_async(other, req, parent, dbg, mod, state)
     end
   end
 
-  defp handle_async(fun, msg, parent, dbg, mod, state) do
+  defp async(fun, msg, parent, dbg, mod, state) do
     try do
       apply(mod, fun, [msg, state])
     catch
       kind, reason ->
-        reason = exit_reason(kind, reason, System.stacktrace())
-        handle_stop(reason, mod, state)
+        handle_exception(kind, reason, System.stacktrace(), msg, mod, state)
     else
       return ->
-        handle_async(return, parent, dbg, mod, state)
+        handle_async(return, msg, parent, dbg, mod, state)
     end
   end
 
-  defp handle_async({:noreply, state}, parent, dbg, mod, _) do
+  defp handle_async({:noreply, state}, _, parent, dbg, mod, _) do
     loop(parent, dbg, mod, state, :infinity)
   end
-  defp handle_async({:noreply, state, await}, parent, dbg, mod, _) do
+  defp handle_async({:noreply, state, await}, _, parent, dbg, mod, _) do
     loop(parent, dbg, mod, state, await)
   end
-  defp handle_async({:stop, reason, state}, _, _, mod, _) do
-    handle_stop(reason, mod, state)
+  defp handle_async({:stop, reason, state}, msg, _, _, mod, _) do
+    handle_stop(reason, msg, mod, state)
   end
-  defp handle_async(other, _, _, mod, state) do
-    handle_stop({:bad_return_value, other}, mod, state)
+  defp handle_async(other, msg, _, _, mod, state) do
+    try do
+      throw(:bad_return_value)
+    catch
+      :bad_return_value ->
+        reason = {:bad_return_value, other}
+        handle_exception(:exit, reason, System.stacktrace(), msg, mod, state)
+    end
   end
 
-  defp handle_stop(reason, mod, state) do
+  defp handle_exception(kind, reason, stack, msg, mod, state) do
+    exit_reason = exit_reason(kind, reason, stack)
+    log_reason = log_reason(kind, reason, stack)
+    terminate(exit_reason, log_reason, msg, mod, state)
+  end
+
+  defp handle_stop(reason, msg, mod, state) do
+    terminate(reason, reason, msg, mod, state)
+  end
+
+  defp log_reason(:exit, reason, stack),  do: {reason, stack}
+  defp log_reason(:error, reason, stack), do: {reason, stack}
+  defp log_reason(:throw, value, stack),  do: {{:nocatch, value}, stack}
+
+  defp terminate(exit_reason, log_reason, msg, mod, state) do
     try do
-      apply(mod, :terminate, [reason, state])
+      apply(mod, :terminate, [exit_reason, state])
     catch
       kind, reason ->
-        reason = exit_reason(kind, reason, System.stacktrace())
-        exit(reason)
+        stack = System.stacktrace()
+        exit_reason = exit_reason(kind, reason, stack)
+        log_exit(exit_reason, log_reason(kind, reason, stack), msg, state)
     else
       _ ->
-        exit(reason)
+        handle_exit(exit_reason, log_reason, msg, state)
     end
+  end
+
+  defp handle_exit(:normal, _, _, _),                   do: exit(:normal)
+  defp handle_exit(:shutdown, _, _, _),                 do: exit(:shutdown)
+  defp handle_exit(shutdown = {:shutdown, _}, _, _, _), do: exit(shutdown)
+  defp handle_exit(exit_reason, log_reason, msg, state) do
+    log_exit(exit_reason, log_reason, msg, state)
+  end
+
+  defp log_exit(exit_reason, log_reason, msg, state) do
+    format = '** Generic server ~p terminating~n' ++
+             '** Last message in was ~p~n' ++
+             '** When Server state == ~p~n' ++
+             '** Reason for termination == ~n** ~p~n'
+    # TODO: log name
+    # TODO: format status on state
+    :error_logger.format(format, [self(), msg, state, log_reason])
+    exit(exit_reason)
   end
 end

--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -329,7 +329,8 @@ defmodule Logger.Translator do
   end
 
   # OTP processes rewrite the :undef error to these reasons when logging
-  @gen_undef [:"module could not be loaded", :"function not exported"]
+  @gen_undef [:"module could not be loaded", :"function not exported",
+              :"callback not exported"]
 
   defp format_stop_banner(undef, [{mod, fun, args, _info} | _]  = stacktrace)
   when undef in @gen_undef and is_atom(mod) and is_atom(fun) do


### PR DESCRIPTION
Initial work on an improve handle loop for GenServer. The goals of this PR are:

- [ ] improve logging by being more explicit
- [x] improve error handling for undefined functions
- [x] improve error handling for undefined callbacks
- [x] improve error handling for bad return values
- [x] format `:sys` dbg events in elixir format
- [x] error on uncaught throw
- [ ] add dispatching to next callback using return value

Unfortunately we can't make all these changes upstream in a backwards compatible manner.