### PR TITLE
Support rebar3 dependency package declaration

### DIFF
--- a/lib/mix/test/mix/rebar_test.exs
+++ b/lib/mix/test/mix/rebar_test.exs
@@ -55,6 +55,10 @@ defmodule Mix.RebarTest do
     assert [{:git_rebar, "~> 1.0", hex: :rebar_fork}] ==
            Mix.Rebar.deps(:foo, config, [])
 
+    config = [deps: [{:git_rebar, {:pkg, :rebar_fork}}]]
+    assert [{:git_rebar, ">= 0.0.0", hex: :rebar_fork}] ==
+           Mix.Rebar.deps(:foo, config, [])
+
     config = [deps: [{:git_rebar, '0.1..*', {:git, '../../test/fixtures/git_rebar', :master}}]]
     assert [{:git_rebar, ~r"0.1..*", [git: "../../test/fixtures/git_rebar", ref: "master"]}] ==
            Mix.Rebar.deps(:foo, config, [])


### PR DESCRIPTION
Currently only {app, “~> 1.0.0”, {pkg, hex_package}} is supported. This
change will also support {app, {pkg, hex_package}}.