### PR TITLE
Fix dialyzer underspec warning with __protocol__/1

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -333,6 +333,19 @@ defmodule Protocol do
                     [{:function, line, :struct_impl_for, 1, clauses} | acc])
   end
 
+  defp change_impl_for([{:attribute, line, :spec, {{:__protocol__, 1}, funspecs}} | t], protocol, types, structs, is_protocol, acc) do
+    newspecs = for spec <- funspecs do
+      case spec do
+        {:type, line, :fun, [{:type, _, :product, [{:atom, _, :consolidated?}]}, _]} ->
+          {:type, line, :fun,
+           [{:type, line, :product, [{:atom, 0, :consolidated?}]},
+            {:atom, 0, true}]}
+        other -> other
+      end
+    end
+    change_impl_for(t, protocol, types, structs, is_protocol, [{:attribute, line, :spec, {{:__protocol__, 1}, newspecs}}|acc])
+  end
+
   defp change_impl_for([h | t], protocol, info, types, is_protocol, acc) do
     change_impl_for(t, protocol, info, types, is_protocol, [h | acc])
   end
@@ -504,7 +517,7 @@ defmodule Protocol do
       @doc false
       @spec __protocol__(:module) :: __MODULE__
       @spec __protocol__(:functions) :: unquote(Protocol.__functions_spec__(@functions))
-      @spec __protocol__(:consolidated?) :: boolean
+      @spec __protocol__(:consolidated?) :: false
       Kernel.def __protocol__(:module), do: __MODULE__
       Kernel.def __protocol__(:functions), do: unquote(:lists.sort(@functions))
       Kernel.def __protocol__(:consolidated?), do: false


### PR DESCRIPTION
## Context

When running dialyzer with `-Wunderspecs` against code that contains protocol definitions, one will receive warnings about the generated `__protocol__/1` function like below:

```
lib/collectable.ex:1: The specification for 'Elixir.Collectable':'__protocol__'/1 states that the function might also return 'true' but the inferred return is 'Elixir.Collectable' | 'false' | [{'into',1},...]
```

The stated spec generated in the macro, which is technically correct, contains:

```elixir
 @spec __protocol__(:consolidated?) :: boolean
```

The macro-generated function returns only `false` before consolidation, and only `true` after consolidation. The [typical solution](http://stackoverflow.com/questions/37668522/how-to-avoid-dialyzer-errors-for-protocols) to avoid this dialyzer warning is to add an attribute to the protocol:

```elixir
@dialyzer {:no_warn_function, __protocol__: 1}
```

However, should the Elixir implementation of this generated function introduce a new type warning, codebases containing that workaround would not detect the warning.

## Solution

The solution I propose is to narrow the return type: At the protocol definition phase (in the macro), the return type for that particular clause of `__protocol__/1` is `false`. During consolidation, the spec attribute is updated to reflect the new return type of `true`.