### PR TITLE
Fix `Kernel.defprotocol` documentation bug.

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3784,7 +3784,7 @@ defmodule Kernel do
   Now that the protocol can be implemented for every data structure
   the protocol may have a compliant implementation for:
 
-      defimpl Size, for: Binary do
+      defimpl Size, for: BitString do
         def size(binary), do: byte_size(binary)
       end
 


### PR DESCRIPTION
Defining a protocol implementation for binaries is done with `for: BitString`, not `for: Binary`.