### PR TITLE
Tolerate missing git repo "info/" when setting sparse configuration (#5525)

### DIFF
--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -139,6 +139,7 @@ defmodule Mix.SCM.Git do
       sparse = opts[:sparse] ->
         sparse_check(git_version())
         git!("--git-dir=.git config core.sparsecheckout true")
+        File.mkdir_p!(".git/info")
         File.write!(".git/info/sparse-checkout", sparse)
       File.exists?(".git/info/sparse-checkout") ->
         File.write!(".git/info/sparse-checkout", "*")

--- a/lib/mix/test/mix/tasks/deps.git_test.exs
+++ b/lib/mix/test/mix/tasks/deps.git_test.exs
@@ -282,6 +282,16 @@ defmodule Mix.Tasks.DepsGitTest do
 
   @tag :git_sparse
   test "updates the repo when sparse is turned off" do
+    old_template_dir = System.get_env("GIT_TEMPLATE_DIR")
+    if old_template_dir do
+      on_exit(fn -> System.put_env("GIT_TEMPLATE_DIR", old_template_dir) end)
+    else
+      on_exit(fn -> System.delete_env("GIT_TEMPLATE_DIR") end)
+    end
+    template_without_info = fixture_path("git_template_without_info")
+    File.mkdir_p!(template_without_info)
+    System.put_env("GIT_TEMPLATE_DIR", template_without_info)
+
     Process.put(:git_repo_opts, sparse: "sparse_dir")
     Mix.Project.push GitApp
 

--- a/lib/mix/test/mix/tasks/deps.git_test.exs
+++ b/lib/mix/test/mix/tasks/deps.git_test.exs
@@ -282,16 +282,6 @@ defmodule Mix.Tasks.DepsGitTest do
 
   @tag :git_sparse
   test "updates the repo when sparse is turned off" do
-    old_template_dir = System.get_env("GIT_TEMPLATE_DIR")
-    if old_template_dir do
-      on_exit(fn -> System.put_env("GIT_TEMPLATE_DIR", old_template_dir) end)
-    else
-      on_exit(fn -> System.delete_env("GIT_TEMPLATE_DIR") end)
-    end
-    template_without_info = fixture_path("git_template_without_info")
-    File.mkdir_p!(template_without_info)
-    System.put_env("GIT_TEMPLATE_DIR", template_without_info)
-
     Process.put(:git_repo_opts, sparse: "sparse_dir")
     Mix.Project.push GitApp
 


### PR DESCRIPTION
I traced the cause of #5525 (for me, anyway) to my global git template, which didn't have an `info/` subdirectory; this caused `Mix.SCM.Git.sparse_toggle/1`'s write to a file in `info/` to fail, causing the same three test failures reported in that issue.

The fix just adds a `File.mkdir_p!/` to make sure the directory exists before writing.

I also modified an existing sparse-checkout test (temporarily adding a git template without `info/`) to show the failure when the fix isn't present; I'm happy to rework this test if you don't think it's the right approach (or remove it entirely).