### PR TITLE
Add Application.start_phase/3 callback and associated docs

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -146,11 +146,12 @@ defmodule Application do
   @callback stop(state) :: term
 
   @doc """
-  Called after an application starts.
+  Start an application in synchronous phases.
 
-  This function is called after an application starts and before any included
-  applications are started. It will be called once for every start phase defined
-  in the application's specification, in the order they are listed in.
+  This function is called after `start/2` finishes but before
+  `Application.start/2` returns. It will be called once for every start phase
+  defined in the application's (and any included applications') specification,
+  in the order they are listed in.
   """
   @callback start_phase(phase :: term, start_type, phase_args :: term) ::
     :ok |

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -149,7 +149,7 @@ defmodule Application do
   Called after an application starts.
 
   This function is called after an application starts and before any included
-  applications are started.  It will be called once for every start phase defined
+  applications are started. It will be called once for every start phase defined
   in the application's specification, in the order they are listed in.
   """
   @callback start_phase(phase :: term, start_type, phase_args :: term) ::

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -145,6 +145,19 @@ defmodule Application do
   """
   @callback stop(state) :: term
 
+  @doc """
+  Called after an application starts.
+
+  This function is called after an application starts and before any included
+  applications are started.  It will be called once for every start phase defined
+  in the application's specification, in the order they are listed in.
+  """
+  @callback start_phase(phase :: term, start_type, phase_args :: term) ::
+    :ok |
+    {:error, reason :: term}
+
+  @optional_callbacks start_phase: 3
+
   @doc false
   defmacro __using__(_) do
     quote location: :keep do

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -59,7 +59,7 @@ defmodule Mix.Tasks.Compile.App do
 
       def application do
         [mod: {MyApp, []},
-         start_phases: [init: [], go: []],
+         start_phases: [init: [], go: [], finish: []],
          env: [default: :value],
          applications: [:crypto],
          included_applications: [MyIncludedApp]]
@@ -79,6 +79,7 @@ defmodule Mix.Tasks.Compile.App do
       MyApp.start_phase(:init, :normal, [])
       MyApp.start_phase(:go, :normal, [])
       MyIncludedApp.start_phase(:go, :normal, [])
+      MyApp.start_phase(:finish, [])
 
   Besides the options above, `.app` files also expect other
   options like `:modules` and `:vsn`, but these are automatically

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -49,8 +49,10 @@ defmodule Mix.Tasks.Compile.App do
       included applications are started.
 
     * `:included_applications` - specifies a list of applications
-      that will be included in the application. A process in an
-      included application considers itself belonging to the
+      that will be included in the application. It is the responsability of
+      the primary application to start the supervision tree of any included
+      applications, as only the primary application will be started. A process
+      in an included application considers itself belonging to the
       primary application.
 
   Let's see an example `MyApp.application/0` function:

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -49,7 +49,7 @@ defmodule Mix.Tasks.Compile.App do
       included applications are started.
 
     * `:included_applications` - specifies a list of applications
-      that will be included in the application.  A process in an
+      that will be included in the application. A process in an
       included application considers itself belonging to the
       primary application.
 
@@ -72,7 +72,7 @@ defmodule Mix.Tasks.Compile.App do
 
   In this example, the order that the application callbacks are called in is:
 
-      iex> Application.start(MyApp)
+      Application.start(MyApp)
       MyApp.start(:normal, [])
       MyApp.start_phase(:init, :normal, [])
       MyApp.start_phase(:go, :normal, [])

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -44,18 +44,39 @@ defmodule Mix.Tasks.Compile.App do
       The application environment is one of the most common ways
       to configure applications.
 
-    * `:start_phases` - specifies a list of phases and their arguments to be
-      called after the application is started and before any included
-      applications are started.
+    * `:start_phases` - specifies a list of phases and their arguments
+      to be called after the application is started and before any
+      included applications are started.
 
-  Let's see an example `application/0` function:
+    * `:included_applications` - specifies a list of applications
+      that will be included in the application.  A process in an
+      included application considers itself belonging to the
+      primary application.
+
+  Let's see an example `MyApp.application/0` function:
 
       def application do
         [mod: {MyApp, []},
          start_phases: [init: [], go: []],
          env: [default: :value],
-         applications: [:crypto]]
+         applications: [:crypto],
+         included_applications: [MyIncludedApp]]
       end
+
+  And an example `MyIncludedApp.application/0` function:
+
+      def application do
+        [mod: {MyIncludedApp, []},
+         start_phases: [go: []]]
+      end
+
+  In this example, the order that the application callbacks are called in is:
+
+      iex> Application.start(MyApp)
+      MyApp.start(:normal, [])
+      MyApp.start_phase(:init, :normal, [])
+      MyApp.start_phase(:go, :normal, [])
+      MyIncludedApp.start_phase(:go, :normal, [])
 
   Besides the options above, `.app` files also expect other
   options like `:modules` and `:vsn`, but these are automatically

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -44,10 +44,15 @@ defmodule Mix.Tasks.Compile.App do
       The application environment is one of the most common ways
       to configure applications.
 
+    * `:start_phases` - specifies a list of phases and their arguments to be
+      called after the application is started and before any included
+      applications are started.
+
   Let's see an example `application/0` function:
 
       def application do
         [mod: {MyApp, []},
+         start_phases: [init: [], go: []],
          env: [default: :value],
          applications: [:crypto]]
       end

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -45,8 +45,9 @@ defmodule Mix.Tasks.Compile.App do
       to configure applications.
 
     * `:start_phases` - specifies a list of phases and their arguments
-      to be called after the application is started and before any
-      included applications are started.
+      to be called after the application is started. Phases will be called, in
+      order, for the application and all included applications. If a phase is
+      not defined for an included application, that application is skipped.
 
     * `:included_applications` - specifies a list of applications
       that will be included in the application. It is the responsability of

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -80,7 +80,7 @@ defmodule Mix.Tasks.Compile.App do
       MyApp.start_phase(:init, :normal, [])
       MyApp.start_phase(:go, :normal, [])
       MyIncludedApp.start_phase(:go, :normal, [])
-      MyApp.start_phase(:finish, [])
+      MyApp.start_phase(:finish, :normal, [])
 
   Besides the options above, `.app` files also expect other
   options like `:modules` and `:vsn`, but these are automatically


### PR DESCRIPTION
This callback from the `:application` module wasn't originally included in `Application`.  In addition, the mix docs did not include information on how to define start phases or included applications, even though it was possible to define and use them.

I think these additions would be useful as the underlying functionality is already there and works, just without documentation (in Elixir).