### PR TITLE
Fix Kernel.binary_part/3 spec

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -111,7 +111,7 @@ defmodule Kernel do
       "llo"
 
   """
-  @spec binary_part(binary, pos_integer, integer) :: binary
+  @spec binary_part(binary, non_neg_integer, integer) :: binary
   def binary_part(binary, start, length) do
     :erlang.binary_part(binary, start, length)
   end


### PR DESCRIPTION
The `start` argument for `Kernel.binary_part/3` can be `0`, therefore I think `non_neg_integer` is a more accurate type spec for it than `pos_integer`.