### PR TITLE
Made IO.ANSI.ansicode and IO.ANSI.ansilist public types.

### DIFF
--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -25,9 +25,9 @@ defmodule IO.ANSI do
 
   import IO.ANSI.Sequence
 
-  @typep ansicode :: atom
-  @typep ansilist :: maybe_improper_list(char | ansicode | binary | ansilist, binary | ansicode | [])
-  @type  ansidata :: ansilist | ansicode | binary
+  @type ansicode :: atom
+  @type ansilist :: maybe_improper_list(char | ansicode | binary | ansilist, binary | ansicode | [])
+  @type ansidata :: ansilist | ansicode | binary
 
   @doc """
   Checks if ANSI coloring is supported and enabled on this machine.


### PR DESCRIPTION
The public `@type` for `IO.ANSI.ansidata` references `IO.ANSI.ansilist` and `IO.ANSI.ansicode`, so dialyzer complains about missing type for them when referencing `IO.ANSI.ansidata`:

```
Unknown types:
  'Elixir.IO.ANSI':ansicode/0
```

From https://hexdocs.pm/elixir/IO.ANSI.html#t:ansidata/0 it seems as though the intention was for them to be public, so I made them public. This is not the forum for this, necessarily, but I do not think public types should be able to reference private types. An `@spec` should also not be able to reference a `@typep` for a public function. I believe something should have warned or errored from this usage. 