### PR TITLE
Fix bug that allows upper case letters in app name

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -158,7 +158,7 @@ defmodule Mix.Tasks.New do
   end
 
   defp check_application_name!(name, inferred?) do
-    unless name =~ ~r/^[a-z][\w_]*$/ do
+    unless name =~ ~r/^[a-z][a-z0-9_]*$/ do
       Mix.raise "Application name must start with a letter and have only lowercase " <>
                 "letters, numbers and underscore, got: #{inspect name}" <>
                 (if inferred? do

--- a/lib/mix/test/mix/tasks/new_test.exs
+++ b/lib/mix/test/mix/tasks/new_test.exs
@@ -119,6 +119,10 @@ defmodule Mix.Tasks.NewTest do
       assert_raise Mix.Error, ~r"Application name must start with a letter and ", fn ->
         Mix.Tasks.New.run ["007invalid"]
       end
+
+      assert_raise Mix.Error, ~r"only lowercase letters, numbers and underscore", fn ->
+        Mix.Tasks.New.run ["invAlid"]
+      end
     end
 
     in_tmp "new with an invalid application name from the app option", fn ->


### PR DESCRIPTION
The following command should fail.

    $ mix new invAlid

According to [this function](https://github.com/elixir-lang/elixir/blob/c1acfe9827f12ef58f7f301baad7497472cb4bc9/lib/mix/lib/mix/tasks/new.ex#L160), app names should only include lowercase letters, numbers, and underscore.

This pull request updates the function to enforce "only include lowercase letters, numbers, and underscore".

## Step 1 -- Add a test

    assert_raise Mix.Error, ~r"only lowercase letters, numbers and underscore", fn ->
      Mix.Tasks.New.run ["invAlid"]
    end

## Step 2 -- The test should fail

    $ bin/elixir lib/mix/test/mix/tasks/new_test.exs
    .......

      1) test new with invalid args (Mix.Tasks.NewTest)
         lib/mix/test/mix/tasks/new_test.exs:117
         Expected exception Mix.Error but nothing was raised
         stacktrace:
           (elixir) lib/file.ex:1186: File.cd!/2
           lib/mix/test/mix/tasks/new_test.exs:118: (test)



    Finished in 0.7 seconds (0.3s on load, 0.3s on tests)
    8 tests, 1 failure

## Step 3 -- Fix the bug

Change regex from this `~r/^[a-z][\w_]*$/` to this `~r/^[a-z][a-z0-9_]*$/`

Example:

    # no error :(
    iex(1)> unless "invAlid" =~ ~r/^[a-z][\w_]*$/, do: raise "only lowercase letters, numbers and underscore"
    nil

    # error :)
    iex(2)> unless "invAlid" =~ ~r/^[a-z][a-z0-9_]*$/, do: raise "only lowercase letters, numbers and underscore"
    ** (RuntimeError) only lowercase letters, numbers and underscore

## Step 4 -- Test passes

    $ bin/elixirc lib/mix/lib/mix/tasks/new.ex -o lib/mix/ebin
    warning: redefining module Mix.Tasks.New (current version loaded from bin/../lib/mix/ebin/Elixir.Mix.Tasks.New.beam)
      lib/mix/lib/mix/tasks/new.ex:1

    $ bin/elixir lib/mix/test/mix/tasks/new_test.exs
    ........

    Finished in 0.7 seconds (0.3s on load, 0.3s on tests)
    8 tests, 0 failures
