### PR TITLE
Fix deps.get infinite loop on depedency cycles

### DIFF
--- a/lib/mix/lib/mix/dep/converger.ex
+++ b/lib/mix/lib/mix/dep/converger.ex
@@ -84,6 +84,9 @@ defmodule Mix.Dep.Converger do
     use_remote? = !!remote and Enum.any?(deps, &remote.remote?/1)
 
     if not diverged? and use_remote? do
+      # Make sure there are no cycles before calling remote converge
+      topsort(deps)
+
       # If there is a lock, it means we are doing a get/update
       # and we need to hit the remote converger which do external
       # requests and what not. In case of deps.loadpaths, deps and so

--- a/lib/mix/test/fixtures/deps_cycle/app1/mix.exs
+++ b/lib/mix/test/fixtures/deps_cycle/app1/mix.exs
@@ -1,0 +1,13 @@
+defmodule App1 do
+  use Mix.Project
+
+  def project do
+    [
+      app: :app1,
+      version: "0.1.0",
+      deps: [
+        {:app2, "0.1.0", in_umbrella: true}
+      ]
+    ]
+  end
+end

--- a/lib/mix/test/fixtures/deps_cycle/app2/mix.exs
+++ b/lib/mix/test/fixtures/deps_cycle/app2/mix.exs
@@ -1,0 +1,13 @@
+defmodule App2 do
+  use Mix.Project
+
+  def project do
+    [
+      app: :app2,
+      version: "0.1.0",
+      deps: [
+        {:app1, "0.1.0", in_umbrella: true}
+      ]
+    ]
+  end
+end


### PR DESCRIPTION
When Hex.RemoteConverger is called with circular dependency it tries to
flatten the graph and ends up in an infinite loop. This can be prevented
by running the topological sort before calling the remote converger.

Solves issue:
https://github.com/elixir-lang/elixir/issues/5487