### PR TITLE
Move the docs for the Task struct to the Task moduledoc

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -132,21 +132,21 @@ defmodule Task do
   the same module version to exist on all involved nodes. Check the `Agent` module
   documentation for more information on distributed processes as the limitations
   described there apply to the whole ecosystem.
-  """
 
-  @doc """
-  The Task struct.
+  ## The `Task` struct
 
-  It contains these fields:
+  When tasks are spawned (for example with `async/1`), a `Task` struct is
+  returned. Such structs contain the following fields:
 
-    * `:pid` - the PID of the task process; `nil` if the task does
-      not use a task process
+    * `:pid` - the PID of the task process; `nil` if the task does not use a
+      task process
 
     * `:ref` - the task monitor reference
 
     * `:owner` - the PID of the process that started the task
 
   """
+
   defstruct pid: nil, ref: nil, owner: nil
 
   @type t :: %__MODULE__{}


### PR DESCRIPTION
By documenting `defstruct`, we were exposing `__struct__/0`. I'm not sure this is bad but we only do this for `Task` in Elixir (I know also `Phoenix.HTML.Form` does it FWIW), and I think this is not an ideal format since `__struct__/0` doesn't really have to do with the struct, but more with how we deal with structs internally. Maybe we should have a generically better way to document structs though. Thoughts?