### PR TITLE
Fix map elements order in the example for Map.put_new/3

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -263,7 +263,7 @@ defmodule Map do
   ## Examples
 
       iex> Map.put_new(%{a: 1}, :b, 2)
-      %{b: 2, a: 1}
+      %{a: 1, b: 2}
       iex> Map.put_new(%{a: 1, b: 2}, :a, 3)
       %{a: 1, b: 2}
 


### PR DESCRIPTION
Even the example for Map.put_new/3 asserts as true in the tests, the correct output is a map with sorted keys.