### PR TITLE
Rename Mix.Dep.Converger.topsort/1 to topological_sort/1

### DIFF
--- a/lib/mix/lib/mix/dep/converger.ex
+++ b/lib/mix/lib/mix/dep/converger.ex
@@ -5,9 +5,9 @@ defmodule Mix.Dep.Converger do
   @moduledoc false
 
   @doc """
-  Topsorts the given dependencies.
+  Topologically sorts the given dependencies.
   """
-  def topsort(deps) do
+  def topological_sort(deps) do
     graph = :digraph.new
 
     try do
@@ -49,7 +49,7 @@ defmodule Mix.Dep.Converger do
   def converge(acc, lock, opts, callback) do
     {deps, acc, lock} = all(acc, lock, opts, callback)
     if remote = Mix.RemoteConverger.get, do: remote.post_converge()
-    {topsort(deps), acc, lock}
+    {topological_sort(deps), acc, lock}
   end
 
   defp all(acc, lock, opts, callback) do
@@ -85,7 +85,7 @@ defmodule Mix.Dep.Converger do
 
     if not diverged? and use_remote? do
       # Make sure there are no cycles before calling remote converge
-      topsort(deps)
+      topological_sort(deps)
 
       # If there is a lock, it means we are doing a get/update
       # and we need to hit the remote converger which do external

--- a/lib/mix/lib/mix/dep/umbrella.ex
+++ b/lib/mix/lib/mix/dep/umbrella.ex
@@ -48,6 +48,6 @@ defmodule Mix.Dep.Umbrella do
         Mix.Dep.available?(dep) and dep.app in apps
       end)
       %{umbrella_dep | deps: deps}
-    end) |> Mix.Dep.Converger.topsort
+    end) |> Mix.Dep.Converger.topological_sort
   end
 end


### PR DESCRIPTION
`topsort` should be renamed `top_sort` but I took the liberty to renamed it `topological_sort` for clarity