### PR TITLE
Add File.read_link/1 and File.read_link!/1

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -365,7 +365,7 @@ defmodule File do
 
   If path exists and is a symlink, returns `{:ok, target}`, otherwise returns `{:error, reason}`.
 
-  For more details, see [`:file.read_link/1`](http://erlang.org/doc/man/file.html#read_link-1)
+  For more details, see [`:file.read_link/1`](http://erlang.org/doc/man/file.html#read_link-1).
 
   Typical error reasons are:
   

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -361,12 +361,14 @@ defmodule File do
   end
 
   @doc """
-  Reads the symbolic link at `path`. If path exists and is a symlink, returns `{:ok, target}`,
-  otherwise returns `{:error, reason}`.
+  Reads the symbolic link at `path`.
+
+  If path exists and is a symlink, returns `{:ok, target}`, otherwise returns `{:error, reason}`.
 
   For more details, see [`:file.read_link/1`](http://erlang.org/doc/man/file.html#read_link-1)
 
   Typical error reasons are:
+  
     * `:einval` - path is not a symbolic link
     * `:enoent` - path does not exist
     * `:enotsup` - symbolic links are not supported on the current platform

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -302,7 +302,7 @@ defmodule File do
   end
 
   @doc """
-  Same as `stat/2` but returns the `File.Stat` directly and
+  Same as `stat/2` but returns the `File.Stat` directly, or
   throws `File.Error` if an error is returned.
   """
   @spec stat!(Path.t, stat_options) :: File.Stat.t | no_return
@@ -347,7 +347,7 @@ defmodule File do
   end
 
   @doc """
-  Same as `lstat/2` but returns the `File.Stat` struct directly and
+  Same as `lstat/2` but returns the `File.Stat` struct directly, or
   throws `File.Error` if an error is returned.
   """
   @spec lstat!(Path.t, stat_options) :: File.Stat.t | no_return
@@ -376,13 +376,13 @@ defmodule File do
   @spec read_link(Path.t) :: {:ok, binary} | {:error, posix}
   def read_link(path) do
     case path |> IO.chardata_to_string |> F.read_link do
-      {:ok, target} -> {:ok, target |> IO.chardata_to_string}
+      {:ok, target} -> {:ok, IO.chardata_to_string(target)}
       error -> error
     end
   end
 
   @doc """
-  Same as `read_link/1` but returns the target directly and throws `File.Error` if an error is
+  Same as `read_link/1` but returns the target directly, or throws `File.Error` if an error is
   returned.
   """
   @spec read_link!(Path.t) :: binary | no_return

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -361,6 +361,39 @@ defmodule File do
   end
 
   @doc """
+  Reads the symbolic link at `path`. If path exists and is a symlink, returns `{:ok, target}`,
+  otherwise returns `{:error, reason}`.
+
+  For more details, see [`:file.read_link/1`](http://erlang.org/doc/man/file.html#read_link-1)
+
+  Typical error reasons are:
+    * `:einval` - path is not a symbolic link
+    * `:enoent` - path does not exist
+    * `:enotsup` - symbolic links are not supported on the current platform
+  """
+  @spec read_link(Path.t) :: {:ok, binary} | {:error, posix}
+  def read_link(path) do
+    case path |> IO.chardata_to_string |> F.read_link do
+      {:ok, target} -> {:ok, target |> IO.chardata_to_string}
+      error -> error
+    end
+  end
+
+  @doc """
+  Same as `read_link/1` but returns the target directly and throws `File.Error` if an error is
+  returned.
+  """
+  @spec read_link!(Path.t) :: binary | no_return
+  def read_link!(path) do
+    case read_link(path) do
+      {:ok, resolved} ->
+        resolved
+      {:error, reason} ->
+        raise File.Error, reason: reason, action: "read link", path: IO.chardata_to_string(path)
+    end
+  end
+
+  @doc """
   Writes the given `File.Stat` back to the filesystem at the given
   path. Returns `:ok` or `{:error, reason}`.
   """

--- a/lib/elixir/test/elixir/file_test.exs
+++ b/lib/elixir/test/elixir/file_test.exs
@@ -1264,6 +1264,49 @@ defmodule FileTest do
   end
 
 
+  test "read_link with symlink" do
+    target = tmp_path("does_not_need_to_exist")
+    dest = tmp_path("symlink")
+    File.ln_s(target, dest)
+    try do
+      assert File.read_link(dest) == {:ok, target}
+    after
+      File.rm(dest)
+    end
+  end
+
+  test "read_link with regular file" do
+    dest = tmp_path("symlink")
+    File.touch(dest)
+    try do
+      assert File.read_link(dest) == {:error, :einval}
+    after
+      File.rm(dest)
+    end
+  end
+
+  test "read_link with nonexistent file" do
+    dest = tmp_path("does_not_exist")
+    assert File.read_link(dest) == {:error, :enoent}
+  end
+
+  test "read_link! with symlink" do
+    target = tmp_path("does_not_need_to_exist")
+    dest = tmp_path("symlink")
+    File.ln_s(target, dest)
+    try do
+      assert File.read_link!(dest) == target
+    after
+      File.rm(dest)
+    end
+  end
+
+  test "read_link! with nonexistent file" do
+    dest = tmp_path("does_not_exist")
+    assert_raise File.Error, fn -> File.read_link!(dest) end
+  end
+
+
   test "IO stream UTF-8" do
     src  = File.open! fixture_path("file.txt"), [:utf8]
     dest = tmp_path("tmp_test.txt")


### PR DESCRIPTION
I have encountered multiple situations where I need to read a link rather than follow it. I think it should be available in Elixir.File rather than having to drop down to Erlang.