### PR TITLE
Correctly inspect functions with undef arity in Logger.Translator

### DIFF
--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -375,6 +375,8 @@ defmodule Logger.Translator do
     end
   end
 
-  defp format_mfa(mod, fun, :undefined), do: [inspect(mod), ?., to_string(fun) | "/?"]
-  defp format_mfa(mod, fun, args), do: Exception.format_mfa(mod, fun, args)
+  defp format_mfa(mod, fun, :undefined),
+    do: [inspect(mod), ?., Inspect.Function.escape_name(fun) | "/?"]
+  defp format_mfa(mod, fun, args),
+    do: Exception.format_mfa(mod, fun, args)
 end

--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -620,6 +620,27 @@ defmodule Logger.TranslatorTest do
       catch_exit(GenServer.call(pid, :error))
       [] = Supervisor.which_children(sup)
     end) =~ "Start Call: GenServer.start_link/?"
+
+    defmodule WeirdFunctionNamesGenServer do
+      use GenServer
+
+      def unquote(:"start link")(), do: GenServer.start_link(__MODULE__, [])
+
+      def handle_call(_call, _from, _state), do: raise("oops")
+    end
+
+    child_opts = [restart: :temporary, function: :"start link"]
+    children = [Supervisor.Spec.worker(WeirdFunctionNamesGenServer, [], child_opts)]
+    {:ok, sup} = Supervisor.start_link(children, strategy: :simple_one_for_one)
+
+    assert capture_log(:info, fn ->
+      {:ok, pid} = Supervisor.start_child(sup, [])
+      catch_exit(GenServer.call(pid, :error))
+      [] = Supervisor.which_children(sup)
+    end) =~ ~s(Start Call: Logger.TranslatorTest.WeirdFunctionNamesGenServer."start link"/?)
+  after
+    :code.purge(WeirdFunctionNamesGenServer)
+    :code.delete(WeirdFunctionNamesGenServer)
   end
 
   def task(parent, fun \\ (fn() -> raise "oops" end)) do

--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -614,9 +614,7 @@ defmodule Logger.TranslatorTest do
   test "handles :undefined MFA properly" do
     defmodule WeirdFunctionNamesGenServer do
       use GenServer
-
       def unquote(:"start link")(), do: GenServer.start_link(__MODULE__, [])
-
       def handle_call(_call, _from, _state), do: raise("oops")
     end
 


### PR DESCRIPTION
@josevalim I am not sure if this is the best course of action. This will work, but we keep relying on internals a lot (`Inspect.Function.escape_name/1`). Maybe this is fine. An alternative solution, which I am not a fan of though, would be to do

```elixir
defp format_mfa(mod, fun, :undefined) do
  Exception.format_mfa(mod, fun, 0) |> String.replace_suffix("/0", "/?")
end
```

Thoughts?