### PR TITLE
Show raw struct representation in IEx.Info protocol

### DIFF
--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -291,9 +291,34 @@ defimpl IEx.Info, for: Reference do
 end
 
 defimpl IEx.Info, for: Any do
-  def info(%{__struct__: mod}) do
+  def info(%{__struct__: mod} = data) do
+    representation(data, Inspect.impl_for(data)) ++ raw_struct(mod)
+  end
+
+  def raw_struct(mod) do
     ["Data type": inspect(mod),
      "Description": "This is a struct. Structs are maps with a __struct__ key.",
      "Reference modules": inspect(mod) <> ", Map"]
+  end
+
+  defp representation(_data, Inspect.Any) do
+    []
+  end
+  defp representation(data, _impl) do
+    raw =
+      data
+      |> Inspect.Any.inspect(%Inspect.Opts{})
+      |> Inspect.Algebra.format(:infinity)
+      |> IO.iodata_to_binary
+    ["Raw representation": raw]
+  end
+end
+
+# Override implementation for opaque types from stdlib, not to show
+# raw representation
+
+defimpl IEx.Info, for: [MapSet, HashSet, HashDict] do
+  def info(_map_set) do
+    IEx.Info.Any.raw_struct(@for)
   end
 end

--- a/lib/iex/test/iex/info_test.exs
+++ b/lib/iex/test/iex/info_test.exs
@@ -9,6 +9,16 @@ defmodule IEx.InfoTest do
     defstruct [:foo]
   end
 
+  defmodule Bar do
+    defstruct [:bar]
+  end
+
+  defimpl Inspect, for: Bar do
+    def inspect(%{bar: bar}, _opts) do
+      "#Bar<#{bar}>"
+    end
+  end
+
   test "tuples" do
     assert Info.info({:ok, "good!"}) == ["Data type": "Tuple",
                                          "Reference modules": "Tuple"]
@@ -148,5 +158,24 @@ defmodule IEx.InfoTest do
     assert info[:"Data type"] == "IEx.InfoTest.Foo"
     assert info[:"Description"] == "This is a struct. Structs are maps with a __struct__ key."
     assert info[:"Reference modules"] == "IEx.InfoTest.Foo, Map"
+  end
+
+  test "structs overriding Inspect protocol" do
+    info = Info.info(%Bar{})
+    assert info[:"Data type"] == "IEx.InfoTest.Bar"
+    assert info[:"Description"] == "This is a struct. Structs are maps with a __struct__ key."
+    assert info[:"Reference modules"] == "IEx.InfoTest.Bar, Map"
+    assert info[:"Raw representation"] == "%IEx.InfoTest.Bar{bar: nil}"
+  end
+
+  test "opaque structs in standard library" do
+    info = Info.info(%MapSet{})
+    refute info[:"Raw representation"]
+
+    info = Info.info(%HashSet{})
+    refute info[:"Raw representation"]
+
+    info = Info.info(%HashDict{})
+    refute info[:"Raw representation"]
   end
 end


### PR DESCRIPTION
When a struct overrides the Inspect protocol, it shows how it would look like,
with the default implementation. Additionally, for opaque types that implement
the inspect protocol, and are present in the standard library, an implementation
of the IEx.Info protocol is provided, that excludes the raw representation
information.

Closes #5743