### PR TITLE
Comment that the "in" operator on ranges succeeds only on integers

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2973,7 +2973,9 @@ defmodule Kernel do
 
   translates to:
 
-      when x >= 1 and x <= 3
+      when is_integer(x) and x >= 1 and x <= 3
+
+  Note that only integers can be considered inside a range by `in`.
 
   ### AST considerations
 


### PR DESCRIPTION
Alternatively, the note could be "Note that only integers can be `in` a range", what do you think ?


Also, thank you very much for the `not in` ❤️ 