### PR TITLE
Use callback module to handle compiler errors/warnings.

### DIFF
--- a/lib/elixir/src/elixir_errors_default.erl
+++ b/lib/elixir/src/elixir_errors_default.erl
@@ -1,0 +1,46 @@
+%% Compiler errors default handler
+%%
+-module(elixir_errors_default).
+
+-behaviour(elixir_errors).
+
+%% elixir_errors_handler callbacks
+-export([handle_warn/4,
+         handle_error/4]).
+
+-include("elixir.hrl").
+
+handle_warn(File, Line, _Type, Msg) ->
+  CompilerPid = get(elixir_compiler_pid),
+  if
+    CompilerPid =/= undefined -> elixir_code_server:cast({register_warning, CompilerPid});
+    true -> ok
+  end,
+  FmtMsg = [Msg, "\n ", file_format(Line, File), $\n],
+  io:put_chars(standard_error, [warning_prefix(), FmtMsg, $\n]).
+
+
+handle_error(File, Line, Type, Msg) ->
+  try
+    throw(ok)
+  catch
+    ok -> ok
+  end,
+  StackTrace = erlang:get_stacktrace(),
+  Exception = Type:exception([{description, Msg}, {file, File}, {line, Line}]),
+  erlang:raise(error, Exception, tl(StackTrace)).
+
+%%
+%% Helpers
+%%
+warning_prefix() ->
+  case application:get_env(elixir, ansi_enabled) of
+    {ok, true} -> <<"\e[33mwarning: \e[0m">>;
+    _ -> <<"warning: ">>
+  end.
+
+file_format(0, File) ->
+  io_lib:format("~ts", [elixir_utils:relative_to_cwd(File)]);
+
+file_format(Line, File) ->
+  io_lib:format("~ts:~w", [elixir_utils:relative_to_cwd(File), Line]).


### PR DESCRIPTION
Handlers implements behaviour 'elixir_errors'.
Handlers are defined through compiler process dictionary 'elixir_compiler_handlers'.

Default to 'elixir_errors_default' module, implementing default error handling.

Example:
```
$ iex
Erlang/OTP 19 [erts-8.2.1] [source] [64-bit] [smp:4:4] [async-threads:10] [kernel-poll:false]

Interactive Elixir (1.5.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> Code.eval_string("defmodule MyMod do\n\tdef f(i), do: :ok\ne")
** (TokenMissingError) nofile:3: missing terminator: end (for "do" starting at line 1)
    (stdlib) lists.erl:1338: :lists.foreach/2
    (elixir) lib/code.ex:170: Code.eval_string/3
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
       (iex) lib/iex/evaluator.ex:210: IEx.Evaluator.handle_eval/6
iex(1)> defmodule CustomErrHandler do
...(1)>   def handle_warn(file, line, _type, msg) do
...(1)>     IO.puts "W:#{file}:#{line}:#{msg}"
...(1)>   end
...(1)>
...(1)>   def handle_error(file, line, _type, msg) do
...(1)>     IO.puts "E:#{file}:#{line}:#{msg}"
...(1)>   end
...(1)> end
{:module, CustomErrHandler,
 <<70, 79, 82, 49, 0, 0, 8, 236, 66, 69, 65, 77, 69, 120, 68, 99, 0, 0, 1, 56,
   131, 104, 2, 100, 0, 14, 101, 108, 105, 120, 105, 114, 95, 100, 111, 99, 115,
   95, 118, 49, 108, 0, 0, 0, 4, 104, 2, ...>>, {:handle_error, 4}}
iex(2)> :erlang.put(:elixir_compiler_handlers, [CustomErrHandler])
:undefined
iex(3)> Code.eval_string("defmodule MyMod do\n\tdef f(i), do: :ok\ne")
E:nofile:3:missing terminator: end (for "do" starting at line 1)
{:ok, []}
iex(4)>
```