### PR TITLE
Improving the function header def args compilation error

### DIFF
--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -419,7 +419,11 @@ format_error({invalid_def, Kind, NameAndArgs}) ->
   io_lib:format("invalid syntax in ~ts ~ts", [Kind, 'Elixir.Macro':to_string(NameAndArgs)]);
 
 format_error(invalid_args_for_bodyless_clause) ->
-  "can use only variables and \\\\ as arguments in definition header";
+  "only variables and \\\\ are allowed as arguments in definition header.\n"
+  "\n"
+  "If you did not intend to define a header, make sure your function "
+  "definition has the proper syntax by wrapping the arguments in parentheses "
+  "and ensuring there is no space between the function name and arguments.";
 
 format_error({is_record, Kind}) ->
   io_lib:format("cannot define function named ~ts is_record/2 due to compatibility "

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -891,7 +891,7 @@ defmodule Kernel.ErrorsTest do
 
   test "invalid args for bodyless clause" do
     assert_compile_fail CompileError,
-      "nofile:2: can use only variables and \\\\ as arguments in definition header",
+      "nofile:2: only variables and \\\\ are allowed as arguments in definition header.",
       '''
       defmodule Kernel.ErrorsTest.InvalidArgsForBodylessClause do
         def foo(nil)


### PR DESCRIPTION
The code:

    def f (x), do: x

was printing the function header definition error because it is parsed
to this:

    def f((x), do: x)

So we made an additional description to the compilation error.

This commit fixes #5761