### PR TITLE
Drop support for "rescue exception in _"

### DIFF
--- a/lib/elixir/src/elixir_exp_clauses.erl
+++ b/lib/elixir/src/elixir_exp_clauses.erl
@@ -162,9 +162,9 @@ expand_rescue(Meta, [Arg], E) ->
 expand_rescue(Meta, _, E) ->
   compile_error(Meta, ?m(E, file), "expected one arg for rescue clauses (->) in try").
 
-%% rescue var => var in _
+%% rescue var
 expand_rescue({Name, _, Atom} = Var, E) when is_atom(Name), is_atom(Atom) ->
-  expand_rescue({in, [], [Var, {'_', [], ?m(E, module)}]}, E);
+  match(fun elixir_exp:expand/2, Var, E);
 
 %% rescue var in [Exprs]
 expand_rescue({in, Meta, [Left, Right]}, E) ->

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -611,7 +611,7 @@ defmodule Kernel.ExpansionTest do
 
     test "expands rescue" do
       assert expand(quote do: (try do x rescue x -> x; Error -> x end; x)) ==
-             quote do: (try do x() rescue unquote(:in)(x, _) -> x; unquote(:in)(_, [:"Elixir.Error"]) -> x() end; x())
+             quote do: (try do x() rescue x -> x; unquote(:in)(_, [:"Elixir.Error"]) -> x() end; x())
     end
 
     test "expects more than do" do

--- a/lib/elixir/test/elixir/kernel/raise_test.exs
+++ b/lib/elixir/test/elixir/kernel/raise_test.exs
@@ -199,11 +199,11 @@ defmodule Kernel.RaiseTest do
     assert result
   end
 
-  test "rescue named with underscore" do
+  test "rescue named without aliases" do
     result = try do
       raise "an exception"
     rescue
-      x in _ -> Exception.message(x)
+      x -> Exception.message(x)
     end
 
     assert result == "an exception"


### PR DESCRIPTION
We never officially supported this, but "accidentally" supported it because of how we implemented `rescue exception` (without `in`). With this commit, we move this step from expansion to `elixir_try`.