### PR TITLE
Check for "unbound variable _" in elixir_exp

### DIFF
--- a/lib/elixir/src/elixir_exp.erl
+++ b/lib/elixir/src/elixir_exp.erl
@@ -754,7 +754,7 @@ assert_no_underscore_clause_in_cond([{do, Clauses}], E) ->
     _Other ->
       ok
   end;
-assert_no_underscore_clause_in_cond(_BadBody, _E) ->
+assert_no_underscore_clause_in_cond(_Other, _E) ->
   ok.
 
 format_error({useless_literal, Term}) ->

--- a/lib/elixir/src/elixir_translator.erl
+++ b/lib/elixir/src/elixir_translator.erl
@@ -165,9 +165,6 @@ translate({Name, Meta, Kind}, #elixir_scope{extra=map_key, context=match} = S) w
 translate({'_', Meta, Kind}, #elixir_scope{context=match} = S) when is_atom(Kind) ->
   {{var, ?ann(Meta), '_'}, S};
 
-translate({'_', Meta, Kind}, S) when is_atom(Kind) ->
-  compile_error(Meta, S#elixir_scope.file, "unbound variable _");
-
 translate({Name, Meta, Kind}, S) when is_atom(Name), is_atom(Kind) ->
   elixir_scope:translate_var(Meta, Name, var_kind(Meta, Kind), S);
 

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -166,6 +166,12 @@ defmodule Kernel.ExpansionTest do
       message = ~r"expected variable \"a\" \(context Unknown\) to expand to an existing variable or be part of a match"
       assert_raise CompileError, message, fn -> expand(quote do: var!(a, Unknown)) end
     end
+
+    test "raises for _ used outside of a match" do
+      assert_raise CompileError, ~r"unbound variable _", fn ->
+        expand(quote do: {1, 2, _})
+      end
+    end
   end
 
   describe "^" do


### PR DESCRIPTION
I also had to adjust the check for `_ -> ...` clauses in `cond` because right now, it performs such check after expanding the clauses, but with the change in this commit then the `unbound variable _` error would fire first. With this commit, we check for `_ -> ...` clauses before expanding the clauses, which may not be ideal since the clauses could expand to `_ -> ...` but it's a compromise we're willing to make (after all, this error is just a friendlier error than `unbound variable _`, not a necessary one).