### PR TITLE
Remove some rescue-related errors from elixir_translator

### DIFF
--- a/lib/elixir/src/elixir_try.erl
+++ b/lib/elixir/src/elixir_try.erl
@@ -35,13 +35,7 @@ each_clause({rescue, Meta, [{in, _, [Left, Right]}], Expr}, S) ->
 
 each_clause({rescue, Meta, [{VarName, _, Atom} = Var], Expr}, S) when is_atom(VarName), is_atom(Atom) ->
   Body = rescue_clause_body(Var, Expr, false, Var, Meta),
-  build_rescue(Meta, _Parts = [{Var, []}], Body, S);
-
-each_clause({rescue, Meta, _, _}, S) ->
-  elixir_errors:compile_error(Meta, S#elixir_scope.file, "invalid arguments for rescue in try");
-
-each_clause({Key, Meta, _, _}, S) ->
-  elixir_errors:compile_error(Meta, S#elixir_scope.file, "invalid key ~ts in try", [Key]).
+  build_rescue(Meta, _Parts = [{Var, []}], Body, S).
 
 rescue_clause_body({'_', _, Atom}, Expr, _Safe, _Var, _Meta) when is_atom(Atom) ->
   Expr;

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -704,12 +704,6 @@ defmodule Kernel.ErrorsTest do
       '<<1::unit(:x)>>'
   end
 
-  test "invalid rescue clause" do
-    assert_compile_fail CompileError,
-      "nofile:4: invalid rescue clause. The clause should match on an alias, a variable or be in the \"var in [alias]\" format",
-      'try do\n1\nrescue\n%UndefinedFunctionError{arity: 1} -> false\nend'
-  end
-
   test "invalid for bit generator" do
     assert_compile_fail CompileError,
       "nofile:1: bitstring fields without size are not allowed in bitstring generators",

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -667,6 +667,24 @@ defmodule Kernel.ExpansionTest do
         expand(quote(do: (try do e catch x -> x catch y -> y end)))
       end
     end
+
+    test "expects exactly one argument in rescue clauses" do
+      assert_raise CompileError, ~r"expected one arg for rescue clauses \(->\) in try", fn ->
+        expand(quote do: (try do x rescue _, _ -> :ok end))
+      end
+    end
+
+    test "expects an alias, a variable, or \"var in [alias]\" as the argument of rescue clauses" do
+      assert_raise CompileError, ~r"invalid rescue clause\. The clause should match", fn ->
+        expand(quote do: (try do x rescue function(:call) -> :ok end))
+      end
+    end
+
+    test "expects one or two args for catch clauses" do
+      assert_raise CompileError, ~r"expected one or two args for catch clauses \(->\) in try", fn ->
+        expand(quote do: (try do x catch _, _, _ -> :ok end))
+      end
+    end
   end
 
   describe "bitstrings" do


### PR DESCRIPTION
I also added tests for such errors in `Kernel.ExpansionTest`.