### PR TITLE
Fix bug in URI.merge

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -473,6 +473,9 @@ defmodule URI do
   def merge(_base, %URI{scheme: rel_scheme} = rel) when rel_scheme != nil do
     rel
   end
+  def merge(base, %URI{authority: authority} = rel) when authority != nil do
+    %{rel | scheme: base.scheme}
+  end
   def merge(%URI{} = base, %URI{path: rel_path} = rel) when rel_path in ["", nil] do
     %{base | query: rel.query || base.query, fragment: rel.fragment}
   end

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -240,6 +240,7 @@ defmodule URITest do
     end
 
     assert URI.merge("http://google.com/foo", "http://example.com/baz") |> to_string == "http://example.com/baz"
+    assert URI.merge("http://google.com/foo", "//example.com/baz") |> to_string == "http://example.com/baz"
 
     assert URI.merge("http://example.com", URI.parse("/foo")) |> to_string == "http://example.com/foo"
 


### PR DESCRIPTION
It seems like current implementation miss the case when ref does not have `scheme`, but has `authority`

This PR is for fixing it