### PR TITLE
Make the error for local calls in matches/guards uniform

### DIFF
--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -246,7 +246,7 @@ defmodule Kernel.ExpansionTest do
       assert expand(quote(do: fn pid when :erlang.==(pid, self) -> pid end)) |> clean_meta([:import, :context]) ==
              quote(do: fn pid when :erlang.==(pid, :erlang.self()) -> pid end)
 
-      assert_raise CompileError, ~r"cannot invoke local foo/1 inside guard", fn ->
+      assert_raise CompileError, ~r"cannot invoke local foo/1 inside guard, called as: foo\(arg\)", fn ->
         expand(quote do: fn arg when foo(arg) -> arg end)
       end
     end


### PR DESCRIPTION
The error for local calls in matches was showing the call, but the one for local calls in guards wasn't.