### PR TITLE
Unify formatting of some common expansion errors

### DIFF
--- a/lib/elixir/src/elixir_clauses.erl
+++ b/lib/elixir/src/elixir_clauses.erl
@@ -44,7 +44,7 @@ guard(Other, E) ->
 %% Case
 
 'case'(Meta, [], E) ->
-  form_error(Meta, ?key(E, file), elixir_expand, {missing_do, 'case'});
+  form_error(Meta, ?key(E, file), elixir_expand, {missing_options, 'case', [do]});
 'case'(Meta, Opts, E) when not is_list(Opts) ->
   form_error(Meta, ?key(E, file), elixir_expand, {invalid_args, 'case'});
 'case'(Meta, Opts, E) ->
@@ -64,7 +64,7 @@ expand_case(Meta, {Key, _}, _Acc, E) ->
 %% Cond
 
 'cond'(Meta, [], E) ->
-  form_error(Meta, ?key(E, file), elixir_expand, {missing_do, 'cond'});
+  form_error(Meta, ?key(E, file), elixir_expand, {missing_options, 'cond', [do]});
 'cond'(Meta, Opts, E) when not is_list(Opts) ->
   form_error(Meta, ?key(E, file), elixir_expand, {invalid_args, 'cond'});
 'cond'(Meta, Opts, E) ->
@@ -84,7 +84,7 @@ expand_cond(Meta, {Key, _}, _Acc, E) ->
 %% Receive
 
 'receive'(Meta, [], E) ->
-  form_error(Meta, ?key(E, file), ?MODULE, missing_do_or_after_in_receive);
+  form_error(Meta, ?key(E, file), elixir_expand, {missing_options, 'receive', [do, 'after']});
 'receive'(Meta, Opts, E) when not is_list(Opts) ->
   form_error(Meta, ?key(E, file), elixir_expand, {invalid_args, 'receive'});
 'receive'(Meta, Opts, E) ->
@@ -113,9 +113,9 @@ expand_receive(Meta, {Key, _}, _Acc, E) ->
 %% Try
 
 'try'(Meta, [], E) ->
-  form_error(Meta, ?key(E, file), elixir_expand, {missing_do, 'try'});
+  form_error(Meta, ?key(E, file), elixir_expand, {missing_options, 'try', [do]});
 'try'(Meta, [{do, _}], E) ->
-  form_error(Meta, ?key(E, file), ?MODULE, missing_keyword_in_try);
+  form_error(Meta, ?key(E, file), elixir_expand, {missing_options, 'try', ['catch', 'rescue', 'after', 'else']});
 'try'(Meta, Opts, E) when not is_list(Opts) ->
   form_error(Meta, ?key(E, file), elixir_expand, {invalid_args, 'try'});
 'try'(Meta, Opts, E) ->
@@ -247,12 +247,6 @@ format_error({wrong_number_of_args_for_clause, Expected, Kind, Key}) ->
 
 format_error(multiple_after_clauses_in_receive) ->
   "expected a single -> clause for :after in \"receive\"";
-
-format_error(missing_do_or_after_in_receive) ->
-  "missing :do or :after in \"receive\"";
-
-format_error(missing_keyword_in_try) ->
-  "missing :catch/:rescue/:after/:else in \"try\"";
 
 format_error(invalid_rescue_clause) ->
   "invalid \"rescue\" clause. The clause should match on an alias, a variable "

--- a/lib/elixir/src/elixir_clauses.erl
+++ b/lib/elixir/src/elixir_clauses.erl
@@ -44,7 +44,7 @@ guard(Other, E) ->
 %% Case
 
 'case'(Meta, [], E) ->
-  form_error(Meta, ?key(E, file), elixir_expand, {missing_options, 'case', [do]});
+  form_error(Meta, ?key(E, file), elixir_expand, {missing_option, 'case', [do]});
 'case'(Meta, Opts, E) when not is_list(Opts) ->
   form_error(Meta, ?key(E, file), elixir_expand, {invalid_args, 'case'});
 'case'(Meta, Opts, E) ->
@@ -64,7 +64,7 @@ expand_case(Meta, {Key, _}, _Acc, E) ->
 %% Cond
 
 'cond'(Meta, [], E) ->
-  form_error(Meta, ?key(E, file), elixir_expand, {missing_options, 'cond', [do]});
+  form_error(Meta, ?key(E, file), elixir_expand, {missing_option, 'cond', [do]});
 'cond'(Meta, Opts, E) when not is_list(Opts) ->
   form_error(Meta, ?key(E, file), elixir_expand, {invalid_args, 'cond'});
 'cond'(Meta, Opts, E) ->
@@ -84,7 +84,7 @@ expand_cond(Meta, {Key, _}, _Acc, E) ->
 %% Receive
 
 'receive'(Meta, [], E) ->
-  form_error(Meta, ?key(E, file), elixir_expand, {missing_options, 'receive', [do, 'after']});
+  form_error(Meta, ?key(E, file), elixir_expand, {missing_option, 'receive', [do, 'after']});
 'receive'(Meta, Opts, E) when not is_list(Opts) ->
   form_error(Meta, ?key(E, file), elixir_expand, {invalid_args, 'receive'});
 'receive'(Meta, Opts, E) ->
@@ -113,9 +113,9 @@ expand_receive(Meta, {Key, _}, _Acc, E) ->
 %% Try
 
 'try'(Meta, [], E) ->
-  form_error(Meta, ?key(E, file), elixir_expand, {missing_options, 'try', [do]});
+  form_error(Meta, ?key(E, file), elixir_expand, {missing_option, 'try', [do]});
 'try'(Meta, [{do, _}], E) ->
-  form_error(Meta, ?key(E, file), elixir_expand, {missing_options, 'try', ['catch', 'rescue', 'after', 'else']});
+  form_error(Meta, ?key(E, file), elixir_expand, {missing_option, 'try', ['catch', 'rescue', 'after', 'else']});
 'try'(Meta, Opts, E) when not is_list(Opts) ->
   form_error(Meta, ?key(E, file), elixir_expand, {invalid_args, 'try'});
 'try'(Meta, Opts, E) ->

--- a/lib/elixir/src/elixir_clauses.erl
+++ b/lib/elixir/src/elixir_clauses.erl
@@ -44,9 +44,9 @@ guard(Other, E) ->
 %% Case
 
 'case'(Meta, [], E) ->
-  form_error(Meta, ?key(E, file), ?MODULE, {missing_do, 'case'});
+  form_error(Meta, ?key(E, file), elixir_expand, {missing_do, 'case'});
 'case'(Meta, Opts, E) when not is_list(Opts) ->
-  form_error(Meta, ?key(E, file), ?MODULE, {invalid_args, 'case'});
+  form_error(Meta, ?key(E, file), elixir_expand, {invalid_args, 'case'});
 'case'(Meta, Opts, E) ->
   ok = assert_at_most_once('do', Opts, 0, fun(Key) ->
     form_error(Meta, ?key(E, file), ?MODULE, {duplicated_clauses, 'case', Key})
@@ -59,14 +59,14 @@ expand_case(Meta, {'do', _} = Do, Acc, E) ->
   Fun = expand_one(Meta, 'case', 'do', fun head/2),
   expand_with_export(Meta, 'case', Fun, Do, Acc, E);
 expand_case(Meta, {Key, _}, _Acc, E) ->
-  form_error(Meta, ?key(E, file), ?MODULE, {unexpected_keyword, 'case', Key}).
+  form_error(Meta, ?key(E, file), ?MODULE, {unexpected_option, 'case', Key}).
 
 %% Cond
 
 'cond'(Meta, [], E) ->
-  form_error(Meta, ?key(E, file), ?MODULE, {missing_do, 'cond'});
+  form_error(Meta, ?key(E, file), elixir_expand, {missing_do, 'cond'});
 'cond'(Meta, Opts, E) when not is_list(Opts) ->
-  form_error(Meta, ?key(E, file), ?MODULE, {invalid_args, 'cond'});
+  form_error(Meta, ?key(E, file), elixir_expand, {invalid_args, 'cond'});
 'cond'(Meta, Opts, E) ->
   ok = assert_at_most_once('do', Opts, 0, fun(Key) ->
     form_error(Meta, ?key(E, file), ?MODULE, {duplicated_clauses, 'cond', Key})
@@ -79,14 +79,14 @@ expand_cond(Meta, {'do', _} = Do, Acc, E) ->
   Fun = expand_one(Meta, 'cond', 'do', fun elixir_expand:expand_args/2),
   expand_with_export(Meta, 'cond', Fun, Do, Acc, E);
 expand_cond(Meta, {Key, _}, _Acc, E) ->
-  form_error(Meta, ?key(E, file), ?MODULE, {unexpected_keyword, 'cond', Key}).
+  form_error(Meta, ?key(E, file), ?MODULE, {unexpected_option, 'cond', Key}).
 
 %% Receive
 
 'receive'(Meta, [], E) ->
   form_error(Meta, ?key(E, file), ?MODULE, missing_do_or_after_in_receive);
 'receive'(Meta, Opts, E) when not is_list(Opts) ->
-  form_error(Meta, ?key(E, file), ?MODULE, {invalid_args, 'receive'});
+  form_error(Meta, ?key(E, file), elixir_expand, {invalid_args, 'receive'});
 'receive'(Meta, Opts, E) ->
   RaiseError = fun(Key) ->
     form_error(Meta, ?key(E, file), ?MODULE, {duplicated_clauses, 'receive', Key})
@@ -108,16 +108,16 @@ expand_receive(Meta, {'after', [_]} = After, Acc, E) ->
 expand_receive(Meta, {'after', _}, _Acc, E) ->
   form_error(Meta, ?key(E, file), ?MODULE, multiple_after_clauses_in_receive);
 expand_receive(Meta, {Key, _}, _Acc, E) ->
-  form_error(Meta, ?key(E, file), ?MODULE, {unexpected_keyword, 'receive', Key}).
+  form_error(Meta, ?key(E, file), ?MODULE, {unexpected_option, 'receive', Key}).
 
 %% Try
 
 'try'(Meta, [], E) ->
-  form_error(Meta, ?key(E, file), ?MODULE, {missing_do, 'try'});
+  form_error(Meta, ?key(E, file), elixir_expand, {missing_do, 'try'});
 'try'(Meta, [{do, _}], E) ->
   form_error(Meta, ?key(E, file), ?MODULE, missing_keyword_in_try);
 'try'(Meta, Opts, E) when not is_list(Opts) ->
-  form_error(Meta, ?key(E, file), ?MODULE, {invalid_args, 'try'});
+  form_error(Meta, ?key(E, file), elixir_expand, {invalid_args, 'try'});
 'try'(Meta, Opts, E) ->
   RaiseError = fun(Key) ->
     form_error(Meta, ?key(E, file), ?MODULE, {duplicated_clauses, 'try', Key})
@@ -143,7 +143,7 @@ expand_try(Meta, {'catch', _} = Catch, E) ->
 expand_try(Meta, {'rescue', _} = Rescue, E) ->
   expand_without_export(Meta, 'try', fun expand_rescue/3, Rescue, E);
 expand_try(Meta, {Key, _}, E) ->
-  form_error(Meta, ?key(E, file), ?MODULE, {unexpected_keyword, 'try', Key}).
+  form_error(Meta, ?key(E, file), ?MODULE, {unexpected_option, 'try', Key}).
 
 expand_catch(_Meta, [_] = Args, E) ->
   head(Args, E);
@@ -232,25 +232,28 @@ assert_at_most_once(Kind, [_ | Rest], Count, Fun) ->
   assert_at_most_once(Kind, Rest, Count, Fun).
 
 format_error({bad_or_missing_clauses, {Kind, Key}}) ->
-  io_lib:format("expected -> clauses for ~ts in ~ts", [Key, Kind]);
+  io_lib:format("expected -> clauses for :~ts in \"~ts\"", [Key, Kind]);
 format_error({bad_or_missing_clauses, Kind}) ->
-  io_lib:format("expected -> clauses in ~ts", [Kind]);
-format_error({missing_do, Kind}) ->
-  io_lib:format("missing do keyword in ~ts", [Kind]);
-format_error({invalid_args, Kind}) ->
-  io_lib:format("invalid arguments for ~ts", [Kind]);
+  io_lib:format("expected -> clauses in \"~ts\"", [Kind]);
+
 format_error({duplicated_clauses, Kind, Key}) ->
-  io_lib:format("duplicated ~ts clauses given for ~ts", [Key, Kind]);
-format_error({unexpected_keyword, Kind, Keyword}) ->
-  io_lib:format("unexpected keyword ~ts in ~ts", [Keyword, Kind]);
+  io_lib:format("duplicated :~ts clauses given for \"~ts\"", [Key, Kind]);
+
+format_error({unexpected_option, Kind, Option}) ->
+  io_lib:format("unexpected option ~ts in \"~ts\"", ['Elixir.Macro':to_string(Option), Kind]);
+
 format_error({wrong_number_of_args_for_clause, Expected, Kind, Key}) ->
-  io_lib:format("expected ~ts for ~ts clauses (->) in ~ts", [Expected, Key, Kind]);
+  io_lib:format("expected ~ts for :~ts clauses (->) in \"~ts\"", [Expected, Key, Kind]);
+
 format_error(multiple_after_clauses_in_receive) ->
-  "expected a single -> clause for after in receive";
+  "expected a single -> clause for :after in \"receive\"";
+
 format_error(missing_do_or_after_in_receive) ->
-  "missing do or after keyword in receive";
+  "missing :do or :after in \"receive\"";
+
 format_error(missing_keyword_in_try) ->
-  "missing catch/rescue/after/else keyword in try";
+  "missing :catch/:rescue/:after/:else in \"try\"";
+
 format_error(invalid_rescue_clause) ->
-  "invalid rescue clause. The clause should match on an alias, a variable "
+  "invalid \"rescue\" clause. The clause should match on an alias, a variable "
     "or be in the \"var in [alias]\" format".

--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -170,7 +170,7 @@ def_to_clauses(_Kind, Meta, Args, [], nil, E) ->
   check_args_for_bodyless_clause(Meta, Args, E),
   [];
 def_to_clauses(Kind, Meta, _Args, _Guards, nil, E) ->
-  elixir_errors:form_error(Meta, ?key(E, file), elixir_expand, {missing_options, Kind, [do]});
+  elixir_errors:form_error(Meta, ?key(E, file), elixir_expand, {missing_option, Kind, [do]});
 def_to_clauses(_Kind, Meta, Args, Guards, [{do, Body}], _E) ->
   [{Meta, Args, Guards, Body}];
 def_to_clauses(_Kind, Meta, Args, Guards, Body, _E) ->

--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -170,7 +170,7 @@ def_to_clauses(_Kind, Meta, Args, [], nil, E) ->
   check_args_for_bodyless_clause(Meta, Args, E),
   [];
 def_to_clauses(Kind, Meta, _Args, _Guards, nil, E) ->
-  elixir_errors:form_error(Meta, ?key(E, file), ?MODULE, {missing_do, Kind});
+  elixir_errors:form_error(Meta, ?key(E, file), elixir_expand, {missing_do, Kind});
 def_to_clauses(_Kind, Meta, Args, Guards, [{do, Body}], _E) ->
   [{Meta, Args, Guards, Body}];
 def_to_clauses(_Kind, Meta, Args, Guards, Body, _E) ->
@@ -365,7 +365,4 @@ format_error(invalid_args_for_bodyless_clause) ->
 
 format_error({is_record, Kind}) ->
   io_lib:format("cannot define function named ~ts is_record/2 due to compatibility "
-                "issues with the Erlang compiler (it is a known bug)", [Kind]);
-
-format_error({missing_do, Kind}) ->
-  io_lib:format("missing do keyword in ~ts", [Kind]).
+                "issues with the Erlang compiler (it is a known bug)", [Kind]).

--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -170,7 +170,7 @@ def_to_clauses(_Kind, Meta, Args, [], nil, E) ->
   check_args_for_bodyless_clause(Meta, Args, E),
   [];
 def_to_clauses(Kind, Meta, _Args, _Guards, nil, E) ->
-  elixir_errors:form_error(Meta, ?key(E, file), elixir_expand, {missing_do, Kind});
+  elixir_errors:form_error(Meta, ?key(E, file), elixir_expand, {missing_options, Kind, [do]});
 def_to_clauses(_Kind, Meta, Args, Guards, [{do, Body}], _E) ->
   [{Meta, Args, Guards, Body}];
 def_to_clauses(_Kind, Meta, Args, Guards, Body, _E) ->

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -134,17 +134,17 @@ expand({quote, Meta, [Opts]}, E) when is_list(Opts) ->
     {do, Do} ->
       expand({quote, Meta, [lists:keydelete(do, 1, Opts), [{do, Do}]]}, E);
     false ->
-      form_error(Meta, ?key(E, file), ?MODULE, missing_do_in_quote)
+      form_error(Meta, ?key(E, file), ?MODULE, {missing_do, 'quote'})
   end;
 
 expand({quote, Meta, [_]}, E) ->
-  form_error(Meta, ?key(E, file), ?MODULE, invalid_args_for_quote);
+  form_error(Meta, ?key(E, file), ?MODULE, {invalid_args, 'quote'});
 
 expand({quote, Meta, [Opts, Do]}, E) when is_list(Do) ->
   Exprs =
     case lists:keyfind(do, 1, Do) of
       {do, Expr} -> Expr;
-      false -> form_error(Meta, ?key(E, file), ?MODULE, missing_do_in_quote)
+      false -> form_error(Meta, ?key(E, file), ?MODULE, {missing_do, 'quote'})
     end,
 
   ValidOpts = [context, location, line, file, unquote, bind_quoted, generated],
@@ -199,7 +199,7 @@ expand({quote, Meta, [Opts, Do]}, E) when is_list(Do) ->
   expand(Quoted, ET);
 
 expand({quote, Meta, [_, _]}, E) ->
-  form_error(Meta, ?key(E, file), ?MODULE, invalid_args_for_quote);
+  form_error(Meta, ?key(E, file), ?MODULE, {invalid_args, 'quote'});
 
 %% Functions
 
@@ -807,6 +807,10 @@ format_error({useless_attr, Attr}) ->
                 [Attr]);
 
 %% Errors.
+format_error({missing_do, Construct}) ->
+  io_lib:format("missing :do option in \"~ts\"", [Construct]);
+format_error({invalid_args, Construct}) ->
+  io_lib:format("invalid arguments for \"~ts\"", [Construct]);
 format_error(for_generator_start) ->
   "for comprehensions must start with a generator";
 format_error(unhandled_arrow_op) ->
@@ -819,10 +823,6 @@ format_error({expected_compile_time_module, Kind, GivenTerm}) ->
 format_error({unquote_outside_quote, Unquote}) ->
   %% Unquote can be "unquote" or "unquote_splicing".
   io_lib:format("~p called outside quote", [Unquote]);
-format_error(missing_do_in_quote) ->
-  "missing do keyword in quote";
-format_error(invalid_args_for_quote) ->
-  "invalid arguments for quote";
 format_error({invalid_context_opt_for_quote, Context}) ->
   io_lib:format("invalid :context for quote, expected non-nil compile time atom or alias, got: ~ts",
                 ['Elixir.Macro':to_string(Context)]);

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -263,8 +263,7 @@ expand({for, Meta, [_ | _] = Args}, E) ->
       {value, {do, Do}, DoOpts} ->
         {Do, DoOpts};
       false ->
-        elixir_errors:compile_error(Meta, ?key(E, file),
-          "missing do keyword in for comprehension")
+        form_error(Meta, ?key(E, file), ?MODULE, {missing_options, for, [do]})
     end,
 
   {EOpts, EO} = expand(Opts, E),
@@ -808,9 +807,8 @@ format_error({useless_attr, Attr}) ->
 
 %% Errors.
 format_error({missing_options, Construct, Opts}) when is_list(Opts) ->
-  StringOpts = lists:map(fun 'Elixir.Macro':to_string/1, Opts),
-  FormattedOpts = iolist_to_binary(lists:join($/, StringOpts)),
-  io_lib:format("missing ~ts in \"~ts\"", [FormattedOpts, Construct]);
+  StringOpts = lists:map(fun(Opt) -> [$: | atom_to_list(Opt)] end, Opts),
+  io_lib:format("missing ~ts option in \"~ts\"", [string:join(StringOpts, "/"), Construct]);
 format_error({invalid_args, Construct}) ->
   io_lib:format("invalid arguments for \"~ts\"", [Construct]);
 format_error(for_generator_start) ->

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -134,7 +134,7 @@ expand({quote, Meta, [Opts]}, E) when is_list(Opts) ->
     {do, Do} ->
       expand({quote, Meta, [lists:keydelete(do, 1, Opts), [{do, Do}]]}, E);
     false ->
-      form_error(Meta, ?key(E, file), ?MODULE, {missing_options, 'quote', [do]})
+      form_error(Meta, ?key(E, file), ?MODULE, {missing_option, 'quote', [do]})
   end;
 
 expand({quote, Meta, [_]}, E) ->
@@ -144,7 +144,7 @@ expand({quote, Meta, [Opts, Do]}, E) when is_list(Do) ->
   Exprs =
     case lists:keyfind(do, 1, Do) of
       {do, Expr} -> Expr;
-      false -> form_error(Meta, ?key(E, file), ?MODULE, {missing_options, 'quote', [do]})
+      false -> form_error(Meta, ?key(E, file), ?MODULE, {missing_option, 'quote', [do]})
     end,
 
   ValidOpts = [context, location, line, file, unquote, bind_quoted, generated],
@@ -263,7 +263,7 @@ expand({for, Meta, [_ | _] = Args}, E) ->
       {value, {do, Do}, DoOpts} ->
         {Do, DoOpts};
       false ->
-        form_error(Meta, ?key(E, file), ?MODULE, {missing_options, for, [do]})
+        form_error(Meta, ?key(E, file), ?MODULE, {missing_option, for, [do]})
     end,
 
   {EOpts, EO} = expand(Opts, E),
@@ -806,7 +806,7 @@ format_error({useless_attr, Attr}) ->
                 [Attr]);
 
 %% Errors.
-format_error({missing_options, Construct, Opts}) when is_list(Opts) ->
+format_error({missing_option, Construct, Opts}) when is_list(Opts) ->
   StringOpts = lists:map(fun(Opt) -> [$: | atom_to_list(Opt)] end, Opts),
   io_lib:format("missing ~ts option in \"~ts\"", [string:join(StringOpts, "/"), Construct]);
 format_error({invalid_args, Construct}) ->

--- a/lib/elixir/src/elixir_with.erl
+++ b/lib/elixir/src/elixir_with.erl
@@ -16,7 +16,7 @@ expand(Meta, Args, Env) ->
       {value, {do, DoValue}, RestOpts1} ->
         {DoValue, RestOpts1};
       false ->
-        elixir_errors:form_error(Meta, ?key(Env, file), elixir_expand, {missing_options, 'with', [do]})
+        elixir_errors:form_error(Meta, ?key(Env, file), elixir_expand, {missing_option, 'with', [do]})
     end,
 
   {ElseExpr, OtherOpts2} =

--- a/lib/elixir/src/elixir_with.erl
+++ b/lib/elixir/src/elixir_with.erl
@@ -1,5 +1,5 @@
 -module(elixir_with).
--export([expand/3, format_error/1]).
+-export([expand/3]).
 -include("elixir.hrl").
 
 expand(Meta, Args, Env) ->
@@ -16,7 +16,7 @@ expand(Meta, Args, Env) ->
       {value, {do, DoValue}, RestOpts1} ->
         {DoValue, RestOpts1};
       false ->
-        elixir_errors:form_error(Meta, ?key(Env, file), ?MODULE, missing_do_in_with)
+        elixir_errors:form_error(Meta, ?key(Env, file), elixir_expand, {missing_do, 'with'})
     end,
 
   {ElseExpr, OtherOpts2} =
@@ -30,7 +30,7 @@ expand(Meta, Args, Env) ->
 
   case OtherOpts2 of
     [{Key, _} | _] ->
-      elixir_errors:form_error(Meta, ?key(Env, file), ?MODULE, {unexpected_keyword, Key});
+      elixir_errors:form_error(Meta, ?key(Env, file), elixir_clauses, {unexpected_option, with, Key});
     [] ->
       ok
   end,
@@ -62,7 +62,7 @@ assert_clauses(_Meta, [], _Env) ->
 assert_clauses(Meta, [{'->', _, [_, _]} | Rest], Env) ->
   assert_clauses(Meta, Rest, Env);
 assert_clauses(Meta, _Other, Env) ->
-  elixir_errors:form_error(Meta, ?key(Env, file), ?MODULE, expected_clauses_for_else).
+  elixir_errors:form_error(Meta, ?key(Env, file), elixir_clauses, {bad_or_missing_clauses, {with, else}}).
 
 build_main_case([{'<-', Meta, [{Name, _, Ctx}, _] = Args} | Rest], DoExpr, Wrapper, HasMatch)
     when is_atom(Name) andalso is_atom(Ctx) ->
@@ -103,10 +103,3 @@ wrap_pattern({'when', Meta, [Left, Right]}, Wrapper) ->
   {'when', Meta, [Wrapper(Left), Right]};
 wrap_pattern(Expr, Wrapper) ->
   Wrapper(Expr).
-
-format_error(missing_do_in_with) ->
-  "missing do keyword in with";
-format_error({unexpected_keyword, Key}) ->
-  io_lib:format("unexpected keyword ~ts in with", [Key]);
-format_error(expected_clauses_for_else) ->
-  "expected -> clauses for else in with".

--- a/lib/elixir/src/elixir_with.erl
+++ b/lib/elixir/src/elixir_with.erl
@@ -16,7 +16,7 @@ expand(Meta, Args, Env) ->
       {value, {do, DoValue}, RestOpts1} ->
         {DoValue, RestOpts1};
       false ->
-        elixir_errors:form_error(Meta, ?key(Env, file), elixir_expand, {missing_do, 'with'})
+        elixir_errors:form_error(Meta, ?key(Env, file), elixir_expand, {missing_options, 'with', [do]})
     end,
 
   {ElseExpr, OtherOpts2} =

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -703,7 +703,7 @@ defmodule Kernel.ErrorsTest do
 
   test "bodyless function with guard" do
     assert_compile_fail CompileError,
-      "nofile:2: missing :do option in \"def\"",
+      "nofile:2: missing :do in \"def\"",
       '''
       defmodule Kernel.ErrorsTest.BodyessFunctionWithGuard do
         def foo(n) when is_number(n)

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -703,7 +703,7 @@ defmodule Kernel.ErrorsTest do
 
   test "bodyless function with guard" do
     assert_compile_fail CompileError,
-      "nofile:2: missing :do in \"def\"",
+      "nofile:2: missing :do option in \"def\"",
       '''
       defmodule Kernel.ErrorsTest.BodyessFunctionWithGuard do
         def foo(n) when is_number(n)

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -703,7 +703,7 @@ defmodule Kernel.ErrorsTest do
 
   test "bodyless function with guard" do
     assert_compile_fail CompileError,
-      "nofile:2: missing do keyword in def",
+      "nofile:2: missing :do option in \"def\"",
       '''
       defmodule Kernel.ErrorsTest.BodyessFunctionWithGuard do
         def foo(n) when is_number(n)

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -349,13 +349,13 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "raises for missing do" do
-      assert_raise CompileError, ~r"missing do keyword in quote", fn ->
+      assert_raise CompileError, ~r"missing :do option in \"quote\"", fn ->
         expand(quote do: (quote context: Foo))
       end
     end
 
     test "raises for invalid arguments" do
-      assert_raise CompileError, ~r"invalid arguments for quote", fn ->
+      assert_raise CompileError, ~r"invalid arguments for \"quote\"", fn ->
         expand(quote do: (quote 1 + 1))
       end
     end
@@ -516,29 +516,29 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "fails if \"do\" is missing" do
-      assert_raise CompileError, ~r"missing do keyword in with", fn ->
+      assert_raise CompileError, ~r"missing :do option in \"with\"", fn ->
         expand(quote do: with(_ <- true, []))
       end
     end
 
     test "fails on invalid else option" do
-      assert_raise CompileError, ~r"expected -> clauses for else in with", fn ->
+      assert_raise CompileError, ~r"expected -> clauses for :else in \"with\"", fn ->
         expand(quote(do: with(_ <- true, do: :ok, else: [:error])))
       end
 
-      assert_raise CompileError, ~r"expected -> clauses for else in with", fn ->
+      assert_raise CompileError, ~r"expected -> clauses for :else in \"with\"", fn ->
         expand(quote(do: with(_ <- true, do: :ok, else: ())))
       end
     end
 
     test "fails for invalid options" do
       # Only the required "do" is present alongside the unexpected option.
-      assert_raise CompileError, ~r"unexpected keyword foo in with", fn ->
+      assert_raise CompileError, ~r"unexpected option :foo in \"with\"", fn ->
         expand(quote do: with(_ <- true, foo: :bar, do: :ok))
       end
 
       # More options are present alongside the unexpected option.
-      assert_raise CompileError, ~r"unexpected keyword foo in with", fn ->
+      assert_raise CompileError, ~r"unexpected option :foo in \"with\"", fn ->
         expand(quote do: with(_ <- true, do: :ok, else: (_ -> :ok), foo: :bar))
       end
     end
@@ -664,39 +664,39 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "expects exactly one do" do
-      assert_raise CompileError, ~r"missing do keyword in cond", fn ->
+      assert_raise CompileError, ~r"missing :do option in \"cond\"", fn ->
         expand(quote do: (cond []))
       end
 
-      assert_raise CompileError, ~r"duplicated do clauses given for cond", fn ->
+      assert_raise CompileError, ~r"duplicated :do clauses given for \"cond\"", fn ->
         expand(quote(do: (cond do: (x -> x), do: (y -> y))))
       end
     end
 
     test "expects clauses" do
-      assert_raise CompileError, ~r"expected -> clauses for do in cond", fn ->
+      assert_raise CompileError, ~r"expected -> clauses for :do in \"cond\"", fn ->
         expand(quote do: (cond do: :ok))
       end
 
-      assert_raise CompileError, ~r"expected -> clauses for do in cond", fn ->
+      assert_raise CompileError, ~r"expected -> clauses for :do in \"cond\"", fn ->
         expand(quote do: (cond do: [:not, :clauses]))
       end
     end
 
     test "expects one argument in clauses" do
-      assert_raise CompileError, ~r"expected one arg for do clauses \(->\) in cond", fn ->
+      assert_raise CompileError, ~r"expected one arg for :do clauses \(->\) in \"cond\"", fn ->
         expand(quote do: (cond do _, _ -> :ok end))
       end
     end
 
     test "raises for invalid arguments" do
-      assert_raise CompileError, ~r"invalid arguments for cond", fn ->
+      assert_raise CompileError, ~r"invalid arguments for \"cond\"", fn ->
         expand(quote do: (cond :foo))
       end
     end
 
     test "raises with invalid keywords" do
-      assert_raise CompileError, ~r"unexpected keyword foo in cond", fn ->
+      assert_raise CompileError, ~r"unexpected option :foo in \"cond\"", fn ->
         expand(quote do: (cond do: (1 -> 1), foo: :bar))
       end
     end
@@ -735,39 +735,39 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "expects exactly one do" do
-      assert_raise CompileError, ~r"missing do keyword in case", fn ->
+      assert_raise CompileError, ~r"missing :do option in \"case\"", fn ->
         expand(quote(do: (case e, [])))
       end
 
-      assert_raise CompileError, ~r"duplicated do clauses given for case", fn ->
+      assert_raise CompileError, ~r"duplicated :do clauses given for \"case\"", fn ->
         expand(quote(do: (case e, do: (x -> x), do: (y -> y))))
       end
     end
 
     test "expects clauses" do
-      assert_raise CompileError, ~r"expected -> clauses for do in case", fn ->
+      assert_raise CompileError, ~r"expected -> clauses for :do in \"case\"", fn ->
         expand(quote do: (case e do x end))
       end
 
-      assert_raise CompileError, ~r"expected -> clauses for do in case", fn ->
+      assert_raise CompileError, ~r"expected -> clauses for :do in \"case\"", fn ->
         expand(quote do: (case e do [:not, :clauses] end))
       end
     end
 
     test "expects exactly one argument in clauses" do
-      assert_raise CompileError, ~r"expected one arg for do clauses \(->\) in case", fn ->
+      assert_raise CompileError, ~r"expected one arg for :do clauses \(->\) in \"case\"", fn ->
         expand(quote do: (case e do _, _ -> :ok end))
       end
     end
 
     test "fails with invalid arguments" do
-      assert_raise CompileError, ~r"invalid arguments for case", fn ->
+      assert_raise CompileError, ~r"invalid arguments for \"case\"", fn ->
         expand(quote do: (case :foo, :bar))
       end
     end
 
     test "fails for invalid keywords" do
-      assert_raise CompileError, ~r"unexpected keyword foo in case", fn ->
+      assert_raise CompileError, ~r"unexpected option :foo in \"case\"", fn ->
         expand(quote do: (case e, do: (x -> x), foo: :bar))
       end
     end
@@ -805,53 +805,53 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "expects exactly one do or after" do
-      assert_raise CompileError, ~r"missing do or after keyword in receive", fn ->
+      assert_raise CompileError, ~r"missing :do or :after in \"receive\"", fn ->
         expand(quote do: (receive []))
       end
 
-      assert_raise CompileError, ~r"duplicated do clauses given for receive", fn ->
+      assert_raise CompileError, ~r"duplicated :do clauses given for \"receive\"", fn ->
         expand(quote(do: (receive do: (x -> x), do: (y -> y))))
       end
 
-      assert_raise CompileError, ~r"duplicated after clauses given for receive", fn ->
+      assert_raise CompileError, ~r"duplicated :after clauses given for \"receive\"", fn ->
         expand(quote(do: (receive do x -> x after y -> y after z -> z end)))
       end
     end
 
     test "expects clauses" do
-      assert_raise CompileError, ~r"expected -> clauses for do in receive", fn ->
+      assert_raise CompileError, ~r"expected -> clauses for :do in \"receive\"", fn ->
         expand(quote do: (receive do x end))
       end
 
-      assert_raise CompileError, ~r"expected -> clauses for do in receive", fn ->
+      assert_raise CompileError, ~r"expected -> clauses for :do in \"receive\"", fn ->
         expand(quote do: (receive do [:not, :clauses] end))
       end
     end
 
     test "expects on argument for do/after clauses" do
-      assert_raise CompileError, ~r"expected one arg for do clauses \(->\) in receive", fn ->
+      assert_raise CompileError, ~r"expected one arg for :do clauses \(->\) in \"receive\"", fn ->
         expand(quote do: (receive do _, _ -> :ok end))
       end
 
-      assert_raise CompileError, ~r"expected one arg for after clauses \(->\) in receive", fn ->
+      assert_raise CompileError, ~r"expected one arg for :after clauses \(->\) in \"receive\"", fn ->
         expand(quote do: (receive do x -> x after _, _ -> :ok end))
       end
     end
 
     test "expects a single clause for \"after\"" do
-      assert_raise CompileError, ~r"expected a single -> clause for after in receive", fn ->
+      assert_raise CompileError, ~r"expected a single -> clause for :after in \"receive\"", fn ->
         expand(quote do: (receive do x -> x after 1 -> y; 2 -> z end))
       end
     end
 
     test "raises for invalid arguments" do
-      assert_raise CompileError, ~r"invalid arguments for receive", fn ->
+      assert_raise CompileError, ~r"invalid arguments for \"receive\"", fn ->
         expand(quote do: (receive :foo))
       end
     end
 
     test "raises with invalid keywords" do
-      assert_raise CompileError, ~r"unexpected keyword foo in receive", fn ->
+      assert_raise CompileError, ~r"unexpected option :foo in \"receive\"", fn ->
         expand(quote do: (receive do: (x -> x), foo: :bar))
       end
     end
@@ -879,97 +879,91 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "expects more than do" do
-      assert_raise CompileError, ~r"missing catch/rescue/after/else keyword in try", fn ->
+      assert_raise CompileError, ~r"missing :catch/:rescue/:after/:else in \"try\"", fn ->
         expand(quote do: (try do x = y end; x))
       end
     end
 
     test "raises if do is missing" do
-      assert_raise CompileError, ~r"missing do keyword in try", fn ->
+      assert_raise CompileError, ~r"missing :do option in \"try\"", fn ->
         expand(quote do: (try []))
       end
     end
 
-    test "raises if do is not accompanied by catch/rescue/after/else" do
-      assert_raise CompileError, ~r"missing catch/rescue/after/else keyword in try", fn ->
-        expand(quote do: (try do x end))
-      end
-    end
-
     test "expects at most one clause" do
-      assert_raise CompileError, ~r"duplicated do clauses given for try", fn ->
+      assert_raise CompileError, ~r"duplicated :do clauses given for \"try\"", fn ->
         expand(quote(do: (try do: e, do: f)))
       end
 
-      assert_raise CompileError, ~r"duplicated rescue clauses given for try", fn ->
+      assert_raise CompileError, ~r"duplicated :rescue clauses given for \"try\"", fn ->
         expand(quote(do: (try do e rescue x -> x rescue y -> y end)))
       end
 
-      assert_raise CompileError, ~r"duplicated after clauses given for try", fn ->
+      assert_raise CompileError, ~r"duplicated :after clauses given for \"try\"", fn ->
         expand(quote(do: (try do e after x = y after x = y end)))
       end
 
-      assert_raise CompileError, ~r"duplicated else clauses given for try", fn ->
+      assert_raise CompileError, ~r"duplicated :else clauses given for \"try\"", fn ->
         expand(quote(do: (try do e else x -> x else y -> y end)))
       end
 
-      assert_raise CompileError, ~r"duplicated catch clauses given for try", fn ->
+      assert_raise CompileError, ~r"duplicated :catch clauses given for \"try\"", fn ->
         expand(quote(do: (try do e catch x -> x catch y -> y end)))
       end
     end
 
     test "raises with invalid arguments" do
-      assert_raise CompileError, ~r"invalid arguments for try", fn ->
+      assert_raise CompileError, ~r"invalid arguments for \"try\"", fn ->
         expand(quote do: (try :foo))
       end
     end
 
     test "raises with invalid keywords" do
-      assert_raise CompileError, ~r"unexpected keyword foo in try", fn ->
+      assert_raise CompileError, ~r"unexpected option :foo in \"try\"", fn ->
         expand(quote do: (try do: x, foo: :bar))
       end
     end
 
     test "expects exactly one argument in rescue clauses" do
-      assert_raise CompileError, ~r"expected one arg for rescue clauses \(->\) in try", fn ->
+      assert_raise CompileError, ~r"expected one arg for :rescue clauses \(->\) in \"try\"", fn ->
         expand(quote do: (try do x rescue _, _ -> :ok end))
       end
     end
 
     test "expects an alias, a variable, or \"var in [alias]\" as the argument of rescue clauses" do
-      assert_raise CompileError, ~r"invalid rescue clause\. The clause should match", fn ->
+      assert_raise CompileError, ~r"invalid \"rescue\" clause\. The clause should match", fn ->
         expand(quote do: (try do x rescue function(:call) -> :ok end))
       end
     end
 
     test "expects one or two args for catch clauses" do
-      assert_raise CompileError, ~r"expected one or two args for catch clauses \(->\) in try", fn ->
+      assert_raise CompileError, ~r"expected one or two args for :catch clauses \(->\) in \"try\"", fn ->
         expand(quote do: (try do x catch _, _, _ -> :ok end))
       end
     end
 
     test "expects clauses for rescue, else, catch" do
-      assert_raise CompileError, ~r"expected -> clauses for rescue in try", fn ->
+      assert_raise CompileError, ~r"expected -> clauses for :rescue in \"try\"", fn ->
         expand(quote do: (try do e rescue x end))
       end
 
-      assert_raise CompileError, ~r"expected -> clauses for rescue in try", fn ->
+      assert_raise CompileError, ~r"expected -> clauses for :rescue in \"try\"", fn ->
         expand(quote do: (try do e rescue [:not, :clauses] end))
       end
 
-      assert_raise CompileError, ~r"expected -> clauses for catch in try", fn ->
+      assert_raise CompileError, ~r"expected -> clauses for :catch in \"try\"", fn ->
         expand(quote do: (try do e catch x end))
       end
 
-      assert_raise CompileError, ~r"expected -> clauses for catch in try", fn ->
+      assert_raise CompileError, ~r"expected -> clauses for :catch in \"try\"", fn ->
         expand(quote do: (try do e catch [:not, :clauses] end))
       end
 
-      assert_raise CompileError, ~r"expected -> clauses for else in try", fn ->
+      assert_raise CompileError, ~r"expected -> clauses for :else in \"try\"", fn ->
         expand(quote do: (try do e else x end))
       end
 
-      assert_raise CompileError, ~r"expected -> clauses for else in try", fn ->
+      assert_raise CompileError, ~r"expected -> clauses for :else in \"try\"", fn ->
         expand(quote do: (try do e else [:not, :clauses] end))
       end
     end

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -349,7 +349,7 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "raises for missing do" do
-      assert_raise CompileError, ~r"missing :do in \"quote\"", fn ->
+      assert_raise CompileError, ~r"missing :do option in \"quote\"", fn ->
         expand(quote do: (quote context: Foo))
       end
     end
@@ -462,7 +462,7 @@ defmodule Kernel.ExpansionTest do
 
     test "require do keyword" do
       assert_raise CompileError,
-        ~r"missing do keyword in for comprehension",
+        ~r"missing :do option in \"for\"",
         fn -> expand(quote do: for x <- 1..2) end
     end
   end
@@ -516,7 +516,7 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "fails if \"do\" is missing" do
-      assert_raise CompileError, ~r"missing :do in \"with\"", fn ->
+      assert_raise CompileError, ~r"missing :do option in \"with\"", fn ->
         expand(quote do: with(_ <- true, []))
       end
     end
@@ -664,7 +664,7 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "expects exactly one do" do
-      assert_raise CompileError, ~r"missing :do in \"cond\"", fn ->
+      assert_raise CompileError, ~r"missing :do option in \"cond\"", fn ->
         expand(quote do: (cond []))
       end
 
@@ -735,7 +735,7 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "expects exactly one do" do
-      assert_raise CompileError, ~r"missing :do in \"case\"", fn ->
+      assert_raise CompileError, ~r"missing :do option in \"case\"", fn ->
         expand(quote(do: (case e, [])))
       end
 
@@ -805,7 +805,7 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "expects exactly one do or after" do
-      assert_raise CompileError, ~r"missing :do/:after in \"receive\"", fn ->
+      assert_raise CompileError, ~r"missing :do/:after option in \"receive\"", fn ->
         expand(quote do: (receive []))
       end
 
@@ -879,13 +879,13 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "expects more than do" do
-      assert_raise CompileError, ~r"missing :catch/:rescue/:after/:else in \"try\"", fn ->
+      assert_raise CompileError, ~r"missing :catch/:rescue/:after/:else option in \"try\"", fn ->
         expand(quote do: (try do x = y end; x))
       end
     end
 
     test "raises if do is missing" do
-      assert_raise CompileError, ~r"missing :do in \"try\"", fn ->
+      assert_raise CompileError, ~r"missing :do option in \"try\"", fn ->
         expand(quote do: (try []))
       end
     end

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -349,7 +349,7 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "raises for missing do" do
-      assert_raise CompileError, ~r"missing :do option in \"quote\"", fn ->
+      assert_raise CompileError, ~r"missing :do in \"quote\"", fn ->
         expand(quote do: (quote context: Foo))
       end
     end
@@ -516,7 +516,7 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "fails if \"do\" is missing" do
-      assert_raise CompileError, ~r"missing :do option in \"with\"", fn ->
+      assert_raise CompileError, ~r"missing :do in \"with\"", fn ->
         expand(quote do: with(_ <- true, []))
       end
     end
@@ -664,7 +664,7 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "expects exactly one do" do
-      assert_raise CompileError, ~r"missing :do option in \"cond\"", fn ->
+      assert_raise CompileError, ~r"missing :do in \"cond\"", fn ->
         expand(quote do: (cond []))
       end
 
@@ -702,7 +702,7 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "raises for _ in clauses" do
-      assert_raise CompileError, ~r"unbound variable _ inside cond\. If you want the last clause", fn ->
+      assert_raise CompileError, ~r"unbound variable _ inside \"cond\"\. If you want the last clause", fn ->
         expand(quote(do: (cond do x -> x; _ -> :raise end)))
       end
     end
@@ -735,7 +735,7 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "expects exactly one do" do
-      assert_raise CompileError, ~r"missing :do option in \"case\"", fn ->
+      assert_raise CompileError, ~r"missing :do in \"case\"", fn ->
         expand(quote(do: (case e, [])))
       end
 
@@ -805,7 +805,7 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "expects exactly one do or after" do
-      assert_raise CompileError, ~r"missing :do or :after in \"receive\"", fn ->
+      assert_raise CompileError, ~r"missing :do/:after in \"receive\"", fn ->
         expand(quote do: (receive []))
       end
 
@@ -885,7 +885,7 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "raises if do is missing" do
-      assert_raise CompileError, ~r"missing :do option in \"try\"", fn ->
+      assert_raise CompileError, ~r"missing :do in \"try\"", fn ->
         expand(quote do: (try []))
       end
     end


### PR DESCRIPTION
These errors can now be formatted via either `elixir_expand:format_error/1` or
`elixir_clauses:format_error/1`.