### PR TITLE
Implement own version of List.starts_with?/2

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -577,22 +577,34 @@ defmodule List do
   end
 
   @doc """
-  Returns `true` if `list` starts with the given `prefix` list.
+  Returns `true` if `list` starts with the given `prefix` list; otherwise returns `false`.
+
+  If `prefix` is an empty list, it returns `true`.
 
   ### Examples
 
       iex> List.starts_with?([1, 2, 3], [1, 2])
       true
+
+      iex> List.starts_with?([1, 2], [1, 2, 3])
+      false
+
       iex> List.starts_with?([:alpha], [])
       true
+
       iex> List.starts_with?([], [:alpha])
       false
 
   """
   @spec starts_with?(list, list) :: boolean
-  def starts_with?(list, prefix) do
-    :lists.prefix(prefix, list)
-  end
+  @spec starts_with?(list, []) :: true
+  @spec starts_with?([], nonempty_list) :: false
+  def starts_with?([head | tail], [head | prefix_tail]),
+    do: starts_with?(tail, prefix_tail);
+  def starts_with?(list, []) when is_list(list),
+    do: true
+  def starts_with?(list, [_ | _]) when is_list(list),
+    do: false
 
   @doc """
   Converts a charlist to an atom.

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -159,6 +159,41 @@ defmodule ListTest do
     assert List.pop_at([1, 2, 3], -4) == {nil, [1, 2, 3]}
   end
 
+  describe "starts_with?/2" do
+    test "list and prefix are equal" do
+      assert List.starts_with?([], [])
+      assert List.starts_with?([1], [1])
+      assert List.starts_with?([1, 2, 3], [1, 2, 3])
+    end
+
+    test "proper lists" do
+      refute List.starts_with?([1], [1, 2])
+      assert List.starts_with?([1, 2, 3], [1, 2])
+      refute List.starts_with?([1, 2, 3], [1, 2, 3, 4])
+    end
+
+    test "list is empty" do
+      refute List.starts_with?([], [1])
+      refute List.starts_with?([], [1, 2])
+    end
+
+    test "prefix is empty" do
+      assert List.starts_with?([1], [])
+      assert List.starts_with?([1, 2], [])
+      assert List.starts_with?([1, 2, 3], [])
+    end
+
+    test "only accept lists" do
+      assert_raise FunctionClauseError, "no function clause matching in List.starts_with?/2", fn ->
+        List.starts_with?([1 | 2], [1 | 2])
+      end
+
+      assert_raise FunctionClauseError, "no function clause matching in List.starts_with?/2", fn ->
+        List.starts_with?([1, 2], 1)
+      end
+    end
+  end
+
   test "to_string/1" do
     assert List.to_string([?æ, ?ß]) == "æß"
     assert List.to_string([?a, ?b, ?c]) == "abc"


### PR DESCRIPTION
As discussed in the mailing list.
The function raises if `prefix` is an improper list.

Please let me know if that's the best way to detect an improper list.
I think it fits well, because we make use of the `length` results to avoid traversing and comparing elements unnecessarily.