### PR TITLE
[trivial][docs] The default implementation of `Enumerable.count/1` does not use `===`

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -136,8 +136,7 @@ defprotocol Enumerable do
   It should return `{:ok, size}`.
 
   If `{:error, __MODULE__}` is returned a default algorithm using
-  `reduce` and the match (`===`) operator is used. This algorithm runs
-  in linear time.
+  `reduce` is used. This algorithm runs in linear time.
 
   _Please force use of the default algorithm unless you can implement an
   algorithm that is significantly faster._


### PR DESCRIPTION
The documentation of `Enumerable.count/1` mentioned that its default implementation makes use of `===`, which is not the case and a bit confusing. The documentation was probably copied and adapted from `Enumerable.member?/2`, whose default implementation _does_ use `===`.