### PR TITLE
Add argument guard for Task.Supervisor.start_child/3

### DIFF
--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -238,7 +238,7 @@ defmodule Task.Supervisor do
   by the given `module`, `fun` and `args`.
   """
   @spec start_child(Supervisor.supervisor, module, atom, [term]) :: {:ok, pid}
-  def start_child(supervisor, module, fun, args) do
+  def start_child(supervisor, module, fun, args) when is_atom(fun) and is_list(args) do
     Supervisor.start_child(supervisor, [get_info(self()), {module, fun, args}])
   end
 

--- a/lib/elixir/test/elixir/task/supervisor_test.exs
+++ b/lib/elixir/test/elixir/task/supervisor_test.exs
@@ -137,6 +137,14 @@ defmodule Task.SupervisorTest do
 
     send pid, true
     assert_receive :done
+
+    assert_raise FunctionClauseError, fn ->
+      Task.Supervisor.start_child(config[:supervisor], __MODULE__, :wait_and_send, :illegal_arg)
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Task.Supervisor.start_child(config[:supervisor], __MODULE__, "wait_and_send", [self(), :done])
+    end
   end
 
   test "terminate_child/2", config do


### PR DESCRIPTION
Fixing issue #5801 by adding argument guard for `Task.Supervisor.start_child/3`.
