### PR TITLE
Prevent creation of DateTime above year 10k

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -1445,10 +1445,11 @@ defmodule DateTime do
 
   The unit can also be an integer as in `t:System.time_unit/0`:
 
-      iex> DateTime.from_unix(1432560368868569, 1024)
-      {:ok, %DateTime{calendar: Calendar.ISO, day: 23, hour: 22, microsecond: {211914, 3}, minute: 53,
-                      month: 1, second: 43, std_offset: 0, time_zone: "Etc/UTC", utc_offset: 0,
-                      year: 46302, zone_abbr: "UTC"}}
+      iex> DateTime.from_unix(143256036886856, 1024)
+      {:ok, %DateTime{calendar: Calendar.ISO, day: 17, hour: 7, microsecond: {320312, 3},
+        minute: 5, month: 3, second: 22, std_offset: 0, time_zone: "Etc/UTC",
+        utc_offset: 0, year: 6403, zone_abbr: "UTC"}}
+
 
   Negative Unix times are supported, up to -#{@unix_epoch} seconds,
   which is equivalent to "0000-01-01T00:00:00Z" or 0 gregorian seconds.

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -10,7 +10,11 @@ defmodule Calendar.ISO do
   """
 
   @behaviour Calendar
+
   @unix_epoch :calendar.datetime_to_gregorian_seconds {{1970, 1, 1}, {0, 0, 0}}
+  @unix_start 1_000_000 * -@unix_epoch
+  @unix_end 1_000_000 * (-@unix_epoch + :calendar.datetime_to_gregorian_seconds({{9999, 12, 31}, {23, 59, 59}}))
+  @unix_range_microseconds @unix_start..@unix_end
 
   @type year  :: 0..9999
   @type month :: 1..12
@@ -163,13 +167,13 @@ defmodule Calendar.ISO do
   @doc false
   def from_unix(integer, unit) when is_integer(integer) do
     total = System.convert_time_unit(integer, unit, :microsecond)
-    if total < -@unix_epoch * 1_000_000 do
-      {:error, :invalid_unix_time}
-    else
+    if total in @unix_range_microseconds do
       microsecond = rem(total, 1_000_000)
       precision = precision_for_unit(unit)
       {date, time} = :calendar.gregorian_seconds_to_datetime(@unix_epoch + div(total, 1_000_000))
       {:ok, date, time, {microsecond, precision}}
+    else
+      {:error, :invalid_unix_time}
     end
   end
 

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -115,13 +115,22 @@ defmodule DateTimeTest do
 
   test "from_unix/2" do
     # with Unix times back to 0 Gregorian Seconds
-    datetime = %DateTime{
+    min_datetime = %DateTime{
       calendar: Calendar.ISO, day: 1, hour: 0, microsecond: {0, 0},
       minute: 0, month: 1, second: 0, std_offset: 0, time_zone: "Etc/UTC",
       utc_offset: 0, year: 0, zone_abbr: "UTC"
     }
-    assert DateTime.from_unix(-62167219200) == {:ok, datetime}
+    assert DateTime.from_unix(-62167219200) == {:ok, min_datetime}
     assert DateTime.from_unix(-62167219201) == {:error, :invalid_unix_time}
+
+    max_datetime = %DateTime{
+      calendar: Calendar.ISO, day: 31, hour: 23, microsecond: {0, 0},
+      minute: 59, month: 12, second: 59, std_offset: 0, time_zone: "Etc/UTC",
+      utc_offset: 0, year: 9999, zone_abbr: "UTC"
+    }
+
+    assert DateTime.from_unix(253402300799) == {:ok, max_datetime}
+    assert DateTime.from_unix(253402300800) == {:error, :invalid_unix_time}
   end
 
   test "from_unix!/2" do


### PR DESCRIPTION
This aligns the behavior with NaiveDateTime and prevents exception when
calling DateTime.to_iso8601. It will catch the common case of
interpreting timestamps with the wrong accuracy, i.e. using
DateTime.from_unix(ts) when ts is in microsecond accuracy.