### PR TITLE
Add a security warning to Code.eval_string

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -104,9 +104,11 @@ defmodule Code do
   The `binding` argument is a keyword list of variable bindings.
   The `opts` argument is a keyword list of environment options.
 
-  **Warning**: `string` is assumed to be fully trusted.  If you receive strings
-  (for example, over the network), passing them into this function can execute
-  arbitrary code and compromise your machine.
+  **Warning**: `string` can be any Elixir code and will be executed with
+  the same privileges as the Erlang VM: this means that such code could
+  compromise the machine (for example by executing system commands).
+  Don't use `eval_string/3` with untrusted input (such as strings coming
+  from the network).
 
   ## Options
 

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -104,6 +104,10 @@ defmodule Code do
   The `binding` argument is a keyword list of variable bindings.
   The `opts` argument is a keyword list of environment options.
 
+  **Warning**: `string` is assumed to be fully trusted.  If you receive strings
+  (for example, over the network), passing them into this function can execute
+  arbitrary code and compromise your machine.
+
   ## Options
 
   Options can be:


### PR DESCRIPTION
This PR adds a warning to the `Code.eval_string` docs about the security consequences of evaling untrusted strings.

You might think that this is obvious or unnecessary, but I've been finding serious security bugs caused by running `eval_string` on untrusted input: https://github.com/tonini/alchemist-server/issues/14; https://github.com/msaraiva/atom-elixir/issues/67