### PR TITLE
Improve Float ceil/round/floor error messages

### DIFF
--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -114,7 +114,7 @@ defmodule Float do
   end
 
   def floor(number, precision) when is_float(number) do
-    raise ArgumentError, "precision #{inspect precision} is out of valid range of #{inspect @precision_range}"
+    raise ArgumentError, invalid_precision_message(precision)
   end
 
   @doc """
@@ -155,7 +155,7 @@ defmodule Float do
   end
 
   def ceil(number, precision) when is_float(number) do
-    raise ArgumentError, "precision #{inspect precision} is out of valid range of #{inspect @precision_range}"
+    raise ArgumentError, invalid_precision_message(precision)
   end
 
   @doc """
@@ -208,7 +208,7 @@ defmodule Float do
   end
 
   def round(number, precision) when is_float(number) do
-    raise ArgumentError, "precision #{inspect precision} is out of valid range of #{inspect @precision_range}"
+    raise ArgumentError, invalid_precision_message(precision)
   end
 
   defp round(float, precision, rounding) do
@@ -430,6 +430,10 @@ defmodule Float do
   # (hard-deprecated in elixir_dispatch)
   def to_string(float, options) do
     :erlang.float_to_binary(float, expand_compact(options))
+  end
+
+  defp invalid_precision_message(precision) do
+    "precision #{inspect precision} is out of valid range of #{inspect @precision_range}"
   end
 
   defp expand_compact([{:compact, false} | t]), do: expand_compact(t)

--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -8,6 +8,8 @@ defmodule Float do
   import Bitwise
 
   @power_of_2_to_52 4503599627370496
+  @precision_range 0..15
+  @type precision_range :: 0..15
 
   @doc """
   Parses a binary into a float.
@@ -106,9 +108,13 @@ defmodule Float do
       34.25
 
   """
-  @spec floor(float, 0..15) :: float
-  def floor(number, precision \\ 0) when is_float(number) and precision in 0..15 do
+  @spec floor(float, precision_range) :: float
+  def floor(number, precision \\ 0) when is_float(number) and precision in @precision_range do
     round(number, precision, :floor)
+  end
+
+  def floor(number, precision) when is_float(number) do
+    raise ArgumentError, "precision #{inspect precision} is out of valid range of #{inspect @precision_range}"
   end
 
   @doc """
@@ -143,9 +149,13 @@ defmodule Float do
       34.26
 
   """
-  @spec ceil(float, 0..15) :: float
-  def ceil(number, precision \\ 0) when is_float(number) and precision in 0..15 do
+  @spec ceil(float, precision_range) :: float
+  def ceil(number, precision \\ 0) when is_float(number) and precision in @precision_range do
     round(number, precision, :ceil)
+  end
+
+  def ceil(number, precision) when is_float(number) do
+    raise ArgumentError, "precision #{inspect precision} is out of valid range of #{inspect @precision_range}"
   end
 
   @doc """
@@ -188,13 +198,17 @@ defmodule Float do
       12.341444444444441
 
   """
-  @spec round(float, 0..15) :: float
+  @spec round(float, precision_range) :: float
 
   # This implementation is slow since it relies on big integers.
   # Faster implementations are available on more recent papers
   # and could be implemented in the future.
-  def round(float, precision \\ 0) when is_float(float) and precision in 0..15 do
+  def round(float, precision \\ 0) when is_float(float) and precision in @precision_range do
     round(float, precision, :half_up)
+  end
+
+  def round(number, precision) when is_float(number) do
+    raise ArgumentError, "precision #{inspect precision} is out of valid range of #{inspect @precision_range}"
   end
 
   defp round(float, precision, rounding) do

--- a/lib/elixir/test/elixir/float_test.exs
+++ b/lib/elixir/test/elixir/float_test.exs
@@ -66,6 +66,10 @@ defmodule FloatTest do
 
     assert Float.floor(12.32453e-20, 2) === 0.0
     assert Float.floor(-12.32453e-20, 2) === -0.01
+
+    assert_raise ArgumentError, "precision 16 is out of valid range of 0..15" , fn ->
+      Float.floor(1.1, 16)
+    end
   end
 
   test "ceil/1" do
@@ -97,6 +101,10 @@ defmodule FloatTest do
     assert Float.ceil(-12.32453e-20, 2) === 0.0
 
     assert Float.ceil(0.0, 2) === 0.0
+
+    assert_raise ArgumentError, "precision 16 is out of valid range of 0..15" , fn ->
+      Float.ceil(1.1, 16)
+    end
   end
 
   test "round/2" do
@@ -106,5 +114,8 @@ defmodule FloatTest do
     assert Float.round(5.5e-10, 10) === 5.0e-10
     assert Float.round(5.5e-10, 8) === 0.0
     assert Float.round(5.0, 0) === 5.0
+    assert_raise ArgumentError, "precision 16 is out of valid range of 0..15" , fn ->
+      Float.round(1.1, 16)
+    end
   end
 end


### PR DESCRIPTION
In the case where precision is out of valid range, the default message is FunctionClause error.
With this commit an ArgumentError will be raised when precision is out of valid range.

This change aligns the behavior with Integer.parse, Float.parse that return ArgumentError on invalid input.