### PR TITLE
Inspect Opts Printable String Limit

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -99,8 +99,9 @@ defimpl Inspect, for: Atom do
 end
 
 defimpl Inspect, for: BitString do
-  def inspect(term, %Inspect.Opts{binaries: bins, base: base} = opts) when is_binary(term) do
-    if base == :decimal and (bins == :as_strings or (bins == :infer and String.printable?(term))) do
+  def inspect(term, %Inspect.Opts{binaries: bins, base: base, printable_limit: printable_limit} = opts) when is_binary(term) do
+    if base == :decimal and (bins == :as_strings or (bins == :infer and String.printable?(term, printable_limit))) do
+      term = String.slice(term, 0..printable_limit)
       inspected = IO.iodata_to_binary([?", escape(term, ?"), ?"])
       color(inspected, :string, opts)
     else

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -27,6 +27,9 @@ defmodule Inspect.Opts do
       bitstrings, maps, lists and any other collection of items. It does not
       apply to strings nor charlists and defaults to 50.
 
+    * `:printable_limit` - limits the number of bytes that are printed for strings
+      and char lists. Defaults to 1024.
+
     * `:pretty` - if set to `true` enables pretty printing, defaults to `false`.
 
     * `:width` - defaults to 80 characters, used when pretty is `true` or when
@@ -55,6 +58,7 @@ defmodule Inspect.Opts do
             charlists: :infer,
             char_lists: :infer,
             limit: 50,
+            printable_limit: 1024,
             width: 80,
             base: :decimal,
             pretty: false,
@@ -70,6 +74,7 @@ defmodule Inspect.Opts do
                charlists: :infer | :as_lists | :as_charlists,
                char_lists: :infer | :as_lists | :as_char_lists,
                limit: pos_integer | :infinity,
+               printable_limit: pos_integer | :infinity,
                width: pos_integer | :infinity,
                base: :decimal | :binary | :hex | :octal,
                pretty: boolean,

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -141,6 +141,15 @@ defmodule Inspect.BitStringTest do
   test "unprintable with opts" do
     assert inspect(<<193, 193, 193, 193>>, limit: 3) == "<<193, 193, 193, ...>>"
   end
+
+  test "string with limits" do
+    assert inspect("hello world", printable_limit: 4) == ~s("hello")
+    # non printable characters after the limit don't matter
+    assert inspect("hello world" <> <<0>>, printable_limit: 4) == ~s("hello")
+    # non printable strings aren't affected by printable limit
+    assert inspect(<<0,1,2,3,4>>, printable_limit: 3) == ~s(<<0, 1, 2, 3, 4>>)
+
+  end
 end
 
 defmodule Inspect.NumberTest do

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -111,8 +111,8 @@ defmodule IEx.AutocompleteTest do
   end
 
   test "function completion with arity" do
-    assert expand('String.printable?')  == {:yes, '', ['printable?/1']}
-    assert expand('String.printable?/') == {:yes, '', ['printable?/1']}
+    assert expand('String.printable?')  == {:yes, '', ['printable?/1', 'printable?/2']}
+    assert expand('String.printable?/') == {:yes, '', ['printable?/1', 'printable?/2']}
   end
 
   test "function completion using a variable bound to a module" do


### PR DESCRIPTION
provide inspect opts printable_limit to avoid performance issues found when inspecting large printable strings

Fixes https://github.com/elixir-lang/elixir/issues/5817