### PR TITLE
Update InvalidVersionError & InvalidRequirementError messages

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -113,7 +113,7 @@ defmodule Version do
   defmodule InvalidRequirementError do
     defexception [:requirement]
 
-    def exception(requirement) do
+    def exception(requirement) when is_binary(requirement) do
       %__MODULE__{requirement: requirement}
     end
 
@@ -125,7 +125,7 @@ defmodule Version do
   defmodule InvalidVersionError do
     defexception [:version]
 
-    def exception(version) do
+    def exception(version) when is_binary(version) do
       %__MODULE__{version: version}
     end
 

--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -258,14 +258,14 @@ defmodule Version do
       #Version<2.0.1-alpha1>
 
       iex> Version.parse!("2.0-alpha1")
-      ** (Version.InvalidVersionError) expected a valid version string, got: "2.0-alpha1"
+      ** (Version.InvalidVersionError) invalid version string: "2.0-alpha1"
 
   """
   @spec parse!(String.t) :: t | no_return
   def parse!(string) when is_binary(string) do
     case parse(string) do
       {:ok, version} -> version
-      :error -> raise InvalidVersionError, message: "expected a valid version string, got: #{inspect string}"
+      :error -> raise InvalidVersionError, message: "invalid version string: #{inspect string}"
     end
   end
 

--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -115,7 +115,15 @@ defmodule Version do
   end
 
   defmodule InvalidVersionError do
-    defexception [:message]
+    defexception [:version]
+
+    def exception(version) do
+      %__MODULE__{version: version}
+    end
+
+    def message(%{version: version}) do
+      "invalid version: #{inspect version}"
+    end
   end
 
   @doc """
@@ -142,7 +150,7 @@ defmodule Version do
       false
 
       iex> Version.match?("foo", "== 1.0.0")
-      ** (Version.InvalidVersionError) foo
+      ** (Version.InvalidVersionError) invalid version: "foo"
 
       iex> Version.match?("2.0.0", "== == 1.0.0")
       ** (Version.InvalidRequirementError) == == 1.0.0
@@ -202,7 +210,7 @@ defmodule Version do
       :eq
 
       iex> Version.compare("invalid", "2.0.1")
-      ** (Version.InvalidVersionError) invalid
+      ** (Version.InvalidVersionError) invalid version: "invalid"
 
   """
   @spec compare(version, version) :: :gt | :eq | :lt
@@ -258,14 +266,14 @@ defmodule Version do
       #Version<2.0.1-alpha1>
 
       iex> Version.parse!("2.0-alpha1")
-      ** (Version.InvalidVersionError) invalid version string: "2.0-alpha1"
+      ** (Version.InvalidVersionError) invalid version: "2.0-alpha1"
 
   """
   @spec parse!(String.t) :: t | no_return
   def parse!(string) when is_binary(string) do
     case parse(string) do
       {:ok, version} -> version
-      :error -> raise InvalidVersionError, message: "invalid version string: #{inspect string}"
+      :error -> raise InvalidVersionError, string
     end
   end
 
@@ -315,7 +323,7 @@ defmodule Version do
       {:ok, {major, minor, patch, pre}} ->
         {major, minor, patch, pre, allow_pre?}
       :error ->
-        raise InvalidVersionError, message: string
+        raise InvalidVersionError, string
     end
   end
 

--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -111,7 +111,15 @@ defmodule Version do
   end
 
   defmodule InvalidRequirementError do
-    defexception [:message]
+    defexception [:requirement]
+
+    def exception(requirement) do
+      %__MODULE__{requirement: requirement}
+    end
+
+    def message(%{requirement: requirement}) do
+      "invalid requirement: #{inspect requirement}"
+    end
   end
 
   defmodule InvalidVersionError do
@@ -153,7 +161,7 @@ defmodule Version do
       ** (Version.InvalidVersionError) invalid version: "foo"
 
       iex> Version.match?("2.0.0", "== == 1.0.0")
-      ** (Version.InvalidRequirementError) == == 1.0.0
+      ** (Version.InvalidRequirementError) invalid requirement: "== == 1.0.0"
 
   """
   @spec match?(version, requirement, Keyword.t) :: boolean
@@ -164,7 +172,7 @@ defmodule Version do
       {:ok, requirement} ->
         match?(version, requirement, opts)
       :error ->
-        raise InvalidRequirementError, message: requirement
+        raise InvalidRequirementError, requirement
     end
   end
 

--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -258,14 +258,14 @@ defmodule Version do
       #Version<2.0.1-alpha1>
 
       iex> Version.parse!("2.0-alpha1")
-      ** (Version.InvalidVersionError) 2.0-alpha1
+      ** (Version.InvalidVersionError) expected a valid version string, got: "2.0-alpha1"
 
   """
   @spec parse!(String.t) :: t | no_return
   def parse!(string) when is_binary(string) do
     case parse(string) do
       {:ok, version} -> version
-      :error -> raise InvalidVersionError, message: string
+      :error -> raise InvalidVersionError, message: "expected a valid version string, got: #{inspect string}"
     end
   end
 


### PR DESCRIPTION
Before this, I got an unhelpful error message:

```
iex> "1.0.0\n1.1.0\n" |> String.split("\n") |> Enum.map(&Version.parse!/1)
** (Version.InvalidVersionError)
```

now it's:

```
** (Version.InvalidVersionError) expected a valid version string, got: ""
```