### PR TITLE
Strip debug information from escripts by default and add option :strip_beam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
 #### Mix
 
   * [Mix.Hex] Add `--if-missing` flag to `local.hex` mix task
-  * [Mix.Tasks.Escript] Debug information is now stripped unless escript option `:strip_beam` is set to `false`
 
 ### 2. Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 #### Mix
 
   * [Mix.Hex] Add `--if-missing` flag to `local.hex` mix task
+  * [Mix.Tasks.Escript] Debug information is now stripped unless escript option `:strip_beam` is set to `false`
 
 ### 2. Bug fixes
 

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -252,7 +252,7 @@ defmodule Mix.Tasks.Escript.Build do
     for {basename, maybe_beam} <- tuples do
       case Path.extname(basename) do
         ".beam" -> {basename, strip_beam(maybe_beam)}
-        _       -> {basename, maybe_beam}
+        _ -> {basename, maybe_beam}
       end
     end
   end

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -249,8 +249,11 @@ defmodule Mix.Tasks.Escript.Build do
   end
 
   defp strip_beams(tuples) do
-    for {basename, beam} <- tuples, Path.extname(basename) == ".beam" do
-      {basename, strip_beam(beam)}
+    for {basename, maybe_beam} <- tuples do
+      case Path.extname(basename) do
+        ".beam" -> {basename, strip_beam(maybe_beam)}
+        _       -> {basename, maybe_beam}
+      end
     end
   end
 

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -44,6 +44,9 @@ defmodule Mix.Tasks.Escript.Build do
       Defaults to app name. Set it to `nil` if no application should
       be started.
 
+    * `:strip_beam` - if `true` strip BEAM code in the escript to remove
+      debug information (chunk `abstract_code`). Defaults to `true`.
+
     * `:embed_elixir` - if `true` embed Elixir and its children apps
       (`ex_unit`, `mix`, etc.) mentioned in the `:applications` list inside the
       `application/0` function in `mix.exs`.
@@ -123,6 +126,7 @@ defmodule Mix.Tasks.Escript.Build do
     filename     = escript_opts[:path] || script_name
     main         = escript_opts[:main_module]
     app          = Keyword.get(escript_opts, :app, project[:app])
+    strip_beam   = Keyword.get(escript_opts, :strip_beam, true)
     files        = project_files()
 
     escript_mod = String.to_atom(Atom.to_string(app) <> "_escript")
@@ -149,6 +153,7 @@ defmodule Mix.Tasks.Escript.Build do
 
         tuples = gen_main(project, escript_mod, main, app, language) ++
                  read_beams(beam_paths)
+        tuples = if strip_beam, do: strip_beams(tuples), else: tuples
 
         case :zip.create 'mem', tuples, [:memory] do
           {:ok, {'mem', zip}} ->
@@ -240,6 +245,19 @@ defmodule Mix.Tasks.Escript.Build do
     |> Enum.map(fn {basename, beam_path} ->
       {String.to_charlist(basename), File.read!(beam_path)}
     end)
+  end
+
+  defp strip_beams(tuples) do
+    for {basename, maybe_beam} <- tuples do
+      {basename, strip_beam(maybe_beam)}
+    end
+  end
+
+  defp strip_beam(maybe_beam) do
+    case :beam_lib.strip(maybe_beam) do
+      {:ok, {_, stripped_beam}} -> stripped_beam
+      {:error, :beam_lib, {:not_a_beam_file, _}} -> maybe_beam
+    end
   end
 
   defp consolidated_paths(config) do

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -248,16 +248,14 @@ defmodule Mix.Tasks.Escript.Build do
   end
 
   defp strip_beams(tuples) do
-    for {basename, maybe_beam} <- tuples do
-      {basename, strip_beam(maybe_beam)}
+    for {basename, beam} <- tuples, Path.extname(basename) == ".beam" do
+      {basename, strip_beam(beam)}
     end
   end
 
-  defp strip_beam(maybe_beam) do
-    case :beam_lib.strip(maybe_beam) do
-      {:ok, {_, stripped_beam}} -> stripped_beam
-      {:error, :beam_lib, {:not_a_beam_file, _}} -> maybe_beam
-    end
+  defp strip_beam(beam) do
+    {:ok, {_, stripped_beam}} = :beam_lib.strip(beam)
+    stripped_beam
   end
 
   defp consolidated_paths(config) do

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -126,7 +126,7 @@ defmodule Mix.Tasks.Escript.Build do
     filename     = escript_opts[:path] || script_name
     main         = escript_opts[:main_module]
     app          = Keyword.get(escript_opts, :app, project[:app])
-    strip_beam   = Keyword.get(escript_opts, :strip_beam, true)
+    strip_beam?  = Keyword.get(escript_opts, :strip_beam, true)
     files        = project_files()
 
     escript_mod = String.to_atom(Atom.to_string(app) <> "_escript")
@@ -153,7 +153,7 @@ defmodule Mix.Tasks.Escript.Build do
 
         tuples = gen_main(project, escript_mod, main, app, language) ++
                  read_beams(beam_paths)
-        tuples = if strip_beam, do: strip_beams(tuples), else: tuples
+        tuples = if strip_beam?, do: strip_beams(tuples), else: tuples
 
         case :zip.create 'mem', tuples, [:memory] do
           {:ok, {'mem', zip}} ->

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -44,8 +44,9 @@ defmodule Mix.Tasks.Escript.Build do
       Defaults to app name. Set it to `nil` if no application should
       be started.
 
-    * `:strip_beam` - if `true` strip BEAM code in the escript to remove
-      debug information (chunk `abstract_code`). Defaults to `true`.
+    * `:strip_beam` - if `true` strip BEAM code in the escript to remove chunks
+      unnecessary at runtime, such as debug information and documentation.
+      Defaults to `true`.
 
     * `:embed_elixir` - if `true` embed Elixir and its children apps
       (`ex_unit`, `mix`, etc.) mentioned in the `:applications` list inside the

--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -15,6 +15,17 @@ defmodule Mix.Tasks.EscriptTest do
     end
   end
 
+  defmodule EscriptWithDebugInfo do
+    def project do
+      [app: :escripttestwithdebuginfo,
+       version: "0.0.1",
+       escript: [
+         main_module: Escripttest,
+         strip_beam: false
+       ]]
+    end
+  end
+
   defmodule EscriptWithPath do
     def project do
       [app: :escripttestwithpath,
@@ -94,6 +105,19 @@ defmodule Mix.Tasks.EscriptTest do
       Mix.Tasks.Escript.Build.run []
       assert_received {:mix_shell, :info, ["Generated escript escriptest with MIX_ENV=dev"]}
       assert System.cmd("escript", ["escriptest"]) == {"FROM CONFIG\n", 0}
+    end
+  end
+
+  test "generate escript with debug information" do
+    Mix.Project.push EscriptWithDebugInfo
+
+    in_fixture "escripttest", fn ->
+      Mix.Tasks.Escript.Build.run []
+      assert_received {:mix_shell, :info, ["Generated escript escriptest with MIX_ENV=dev"]}
+      assert System.cmd("escript", ["escripttestwithdebuginfo"]) == {"TEST\n", 0}
+
+      Mix.Tasks.Escript.Build.run []
+      refute_received {:mix_shell, :info, ["Generated escript escriptest with MIX_ENV=dev"]}
     end
   end
 

--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -142,7 +142,7 @@ defmodule Mix.Tasks.EscriptTest do
   end
 
   defp remove_escript_header(escript_data) do
-    {offset, length} = :binary.match(escript_data, "\nPK")
+    {offset, _length} = :binary.match(escript_data, "\nPK")
     zip_start = offset + 1
     binary_part(escript_data, zip_start, byte_size(escript_data) - zip_start)
   end

--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -125,9 +125,9 @@ defmodule Mix.Tasks.EscriptTest do
   end
 
   defp count_abstract_code(escript_filename) do
-    for {_filename, beam} <- get_beams(escript_filename) do
-      get_abstract_code(beam)
-    end
+    escript_filename
+    |> get_beams()
+    |> Enum.map(fn {_, beam} -> get_abstract_code(beam) end)
     |> Enum.reject(&is_nil/1)
     |> Enum.count
   end

--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -148,7 +148,7 @@ defmodule Mix.Tasks.EscriptTest do
   defp get_abstract_code(beam) do
     case :beam_lib.chunks(beam, [:abstract_code]) do
       {:ok, {_, [{:abstract_code, {_, abstract_code}}]}} -> abstract_code
-      _                                                  -> nil
+      _ -> nil
     end
   end
 

--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -113,11 +113,11 @@ defmodule Mix.Tasks.EscriptTest do
 
     in_fixture "escripttest", fn ->
       Mix.Tasks.Escript.Build.run []
-      assert_received {:mix_shell, :info, ["Generated escript escriptest with MIX_ENV=dev"]}
+      assert_received {:mix_shell, :info, ["Generated escript escripttestwithdebuginfo with MIX_ENV=dev"]}
       assert System.cmd("escript", ["escripttestwithdebuginfo"]) == {"TEST\n", 0}
 
       Mix.Tasks.Escript.Build.run []
-      refute_received {:mix_shell, :info, ["Generated escript escriptest with MIX_ENV=dev"]}
+      refute_received {:mix_shell, :info, ["Generated escript escripttestwithdebuginfo with MIX_ENV=dev"]}
     end
   end
 

--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -127,9 +127,7 @@ defmodule Mix.Tasks.EscriptTest do
   defp count_abstract_code(escript_filename) do
     escript_filename
     |> get_beams()
-    |> Enum.map(fn {_, beam} -> get_abstract_code(beam) end)
-    |> Enum.reject(&is_nil/1)
-    |> Enum.count
+    |> Enum.count(fn {_, beam} -> get_abstract_code(beam) end)
   end
 
   defp get_beams(escript_filename) do


### PR DESCRIPTION
This is a PR for #5688.  I went with `:strip_beam` because BEAM can work as a plural/collective noun, but I will change it to `:strip_beams` if you want.