### PR TITLE
Add Add MapSet.map_set?/1 function

### DIFF
--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -350,6 +350,25 @@ defmodule MapSet do
   defp order_by_size(map1, map2) when map_size(map1) > map_size(map2), do: {map2, map1}
   defp order_by_size(map1, map2), do: {map1, map2}
 
+  @doc """
+  Returns `true` if `term` is a map set; otherwise returns `false`.
+
+  ## Examples
+
+      iex> MapSet.map_set?(MapSet.new([]))
+      true
+      iex> MapSet.map_set?(MapSet.new([:a, :b]))
+      true
+      iex> MapSet.map_set?([])
+      false
+      iex> MapSet.map_set?(%{})
+      false
+
+  """
+  @spec map_set?(term) :: boolean
+  def map_set?(%MapSet{}), do: true
+  def map_set?(_other), do: false
+
   defimpl Enumerable do
     def reduce(map_set, acc, fun), do: Enumerable.List.reduce(MapSet.to_list(map_set), acc, fun)
     def member?(map_set, val), do: {:ok, MapSet.member?(map_set, val)}

--- a/lib/elixir/test/elixir/map_set_test.exs
+++ b/lib/elixir/test/elixir/map_set_test.exs
@@ -81,6 +81,11 @@ defmodule MapSetTest do
     assert Enum.sort(list) == Enum.to_list(5..120)
   end
 
+  test "map_set?/1" do
+    assert S.map_set?(S.new()) == true
+    assert S.map_set?(:not_a_map_set) == false
+  end
+
   defp make(collection) do
     Enum.into(collection, S.new)
   end


### PR DESCRIPTION
I wanted a function to check if an object is a map set, so I added one!

    iex(1)> MapSet.new() |> MapSet.map_set?()
    true

## Should this edge case a bug?

While adding both ExUnit and DocTest tests, I did bump into an edge case.

    # it's likely no one intentionally builds a MapSet w/ non-true values
    # but I did think of it as a use case
    iex(9)> maybe_map_set = %{__struct__: MapSet, map: %{a: false}}
    #MapSet<[:a]>

    # it walks and talks like a MapSet
    iex(10)> maybe_map_set |> MapSet.map_set?
    true
    iex(11)> %MapSet{} = maybe_map_set
    #MapSet<[:a]>

    # but this just looks weird!
    iex(12)> maybe_map_set |> Map.values
    [MapSet, %{a: false}]
