### PR TITLE
Inline Enum.into with bitstring implementation

### DIFF
--- a/lib/elixir/lib/collectable.ex
+++ b/lib/elixir/lib/collectable.ex
@@ -89,12 +89,9 @@ end
 
 defimpl Collectable, for: BitString do
   def into(original) do
-    {[original], fn
-      list, {:cont, x} -> [x | list]
-      list, :done ->
-        list
-        |> :lists.reverse()
-        |> IO.iodata_to_binary()
+    {original, fn
+      acc, {:cont, x} when is_bitstring(x) -> [acc | x]
+      acc, :done -> IO.iodata_to_binary(acc)
       _, :halt -> :ok
     end}
   end

--- a/lib/elixir/lib/collectable.ex
+++ b/lib/elixir/lib/collectable.ex
@@ -89,9 +89,12 @@ end
 
 defimpl Collectable, for: BitString do
   def into(original) do
-    {original, fn
-      acc, {:cont, x} when is_bitstring(x) -> [acc | x]
-      acc, :done -> IO.iodata_to_binary(acc)
+    {[original], fn
+      list, {:cont, x} -> [x | list]
+      list, :done ->
+        list
+        |> :lists.reverse()
+        |> IO.iodata_to_binary()
       _, :halt -> :ok
     end}
   end

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1099,6 +1099,14 @@ defmodule Enum do
     collectable ++ to_list(enumerable)
   end
 
+  def into(enumerable, collectable) when is_binary(collectable) do
+    postfix =
+      enumerable
+      |> to_list
+      |> IO.iodata_to_binary
+    collectable <> postfix
+  end
+
   def into(%_{} = enumerable, collectable) do
     do_into(enumerable, collectable)
   end

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1100,11 +1100,8 @@ defmodule Enum do
   end
 
   def into(enumerable, collectable) when is_binary(collectable) do
-    postfix =
-      enumerable
-      |> to_list
-      |> IO.iodata_to_binary
-    collectable <> postfix
+    postfix = to_list(enumerable)
+    IO.iodata_to_binary([collectable | postfix])
   end
 
   def into(%_{} = enumerable, collectable) do


### PR DESCRIPTION
Replaces recursive io list implementation with a flat list
implementation.

According to my benchmarks it improves performance by 6x-35x according
to collection length.
See the following test script and results:

```Elixir
def compare do
 thousand = Enum.map(1..1000, &to_string/1)
 Benchee.run(%{
   "before 1k" => fn ->
     Enum.into(thousand, "")
   end,
   "after 1k" => fn ->
     Enum.into(thousand, [])
     |> IO.iodata_to_binary
   end
 },time: 2)

 million = Enum.map(1..1000_000, &to_string/1)
 Benchee.run(%{
   "before 1m" => fn ->
     Enum.into(million, "")
   end,
   "after 1m" => fn ->
     Enum.into(million, [])
     |> IO.iodata_to_binary
   end
 },time: 10)

 million_x_100 = Enum.map(1..100_000_000, &to_string/1)
 Benchee.run(%{
   "before 100m" => fn ->
     Enum.into(million_x_100, "")
   end,
   "after 100m" => fn ->
     Enum.into(million_x_100, [])
     |> IO.iodata_to_binary
   end
 }, time: 30)
end
```

Results:

```Shell
Name                ips        average  deviation         median
after 1k       160.45 K        6.23 μs    ±70.31%        6.00 μs
before 1k       25.69 K       38.93 μs    ±18.08%       37.00 μs

Comparison:
after 1k       160.45 K
before 1k       25.69 K - 6.25x slower

Name                ips        average  deviation         median
after 1m         124.98        8.00 ms     ±4.01%        7.97 ms
before 1m         16.17       61.83 ms    ±28.17%       51.69 ms

Comparison:
after 1m         124.98
before 1m         16.17 - 7.73x slower

Name                  ips        average  deviation         median
after 100m           0.83         1.21 s   ±140.25%         0.85 s
before 100m        0.0241        41.55 s     ±0.00%        41.55 s

Comparison:
after 100m           0.83
before 100m        0.0241 - 34.47x slower
```