### PR TITLE
Change GenServer to use optional callbacks (#5735)

### DIFF
--- a/lib/elixir/lib/agent/server.ex
+++ b/lib/elixir/lib/agent/server.ex
@@ -23,16 +23,8 @@ defmodule Agent.Server do
     {:reply, :ok, run(fun, [state])}
   end
 
-  def handle_call(msg, from, state) do
-    super(msg, from, state)
-  end
-
   def handle_cast({:cast, fun}, state) do
     {:noreply, run(fun, [state])}
-  end
-
-  def handle_cast(msg, state) do
-    super(msg, state)
   end
 
   def code_change(_old, state, fun) do

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -380,6 +380,8 @@ defmodule GenServer do
     {:stop, reason, reply, new_state} |
     {:stop, reason, new_state} when reply: term, new_state: term, reason: term
 
+  @optional_callbacks handle_call: 3
+
   @doc """
   Invoked to handle asynchronous `cast/2` messages.
 
@@ -408,6 +410,8 @@ defmodule GenServer do
     {:noreply, new_state, timeout | :hibernate} |
     {:stop, reason :: term, new_state} when new_state: term
 
+  @optional_callbacks handle_cast: 2
+
   @doc """
   Invoked to handle all other messages.
 
@@ -423,6 +427,8 @@ defmodule GenServer do
     {:noreply, new_state} |
     {:noreply, new_state, timeout | :hibernate} |
     {:stop, reason :: term, new_state} when new_state: term
+
+  @optional_callbacks handle_info: 2
 
   @doc """
   Invoked when the server is about to exit. It should do any cleanup required.
@@ -548,49 +554,7 @@ defmodule GenServer do
 
       @doc false
       def init(args) do
-        {:ok, args}
-      end
-
-      @doc false
-      def handle_call(msg, _from, state) do
-        proc =
-          case Process.info(self(), :registered_name) do
-            {_, []}   -> self()
-            {_, name} -> name
-          end
-
-        # We do this to trick Dialyzer to not complain about non-local returns.
-        case :erlang.phash2(1, 1) do
-          0 -> raise "attempted to call GenServer #{inspect proc} but no handle_call/3 clause was provided"
-          1 -> {:stop, {:bad_call, msg}, state}
-        end
-      end
-
-      @doc false
-      def handle_info(msg, state) do
-        proc =
-          case Process.info(self(), :registered_name) do
-            {_, []}   -> self()
-            {_, name} -> name
-          end
-        :error_logger.error_msg('~p ~p received unexpected message in handle_info/2: ~p~n',
-                                [__MODULE__, proc, msg])
-        {:noreply, state}
-      end
-
-      @doc false
-      def handle_cast(msg, state) do
-        proc =
-          case Process.info(self(), :registered_name) do
-            {_, []}   -> self()
-            {_, name} -> name
-          end
-
-        # We do this to trick Dialyzer to not complain about non-local returns.
-        case :erlang.phash2(1, 1) do
-          0 -> raise "attempted to cast GenServer #{inspect proc} but no handle_cast/2 clause was provided"
-          1 -> {:stop, {:bad_cast, msg}, state}
-        end
+        raise "init/1 not implemented"
       end
 
       @doc false
@@ -603,8 +567,7 @@ defmodule GenServer do
         {:ok, state}
       end
 
-      defoverridable [init: 1, handle_call: 3, handle_info: 2,
-                      handle_cast: 2, terminate: 2, code_change: 3]
+      defoverridable [init: 1, terminate: 2, code_change: 3]
     end
   end
 

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -929,7 +929,4 @@ defmodule Registry.Partition do
     end
     {:noreply, ets}
   end
-  def handle_info(msg, state) do
-    super(msg, state)
-  end
 end

--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -109,10 +109,6 @@ defmodule StringIO do
     {:noreply, s}
   end
 
-  def handle_info(msg, s) do
-    super(msg, s)
-  end
-
   def handle_call(:contents, _from, %{input: input, output: output} = s) do
     {:reply, {input, output}, s}
   end
@@ -123,10 +119,6 @@ defmodule StringIO do
 
   def handle_call(:close, _from, %{input: input, output: output} = s) do
     {:stop, :normal, {:ok, {input, output}}, s}
-  end
-
-  def handle_call(request, from, s) do
-    super(request, from, s)
   end
 
   defp io_request(from, reply_as, req, s) do

--- a/lib/elixir/test/elixir/gen_server_test.exs
+++ b/lib/elixir/test/elixir/gen_server_test.exs
@@ -6,6 +6,10 @@ defmodule GenServerTest do
   defmodule Stack do
     use GenServer
 
+    def init(args) do
+      {:ok, args}
+    end
+
     def handle_call(:pop, _from, [h | t]) do
       {:reply, h, t}
     end
@@ -14,16 +18,8 @@ defmodule GenServerTest do
       {:noreply, h}
     end
 
-    def handle_call(request, from, state) do
-      super(request, from, state)
-    end
-
     def handle_cast({:push, item}, state) do
       {:noreply, [item | state]}
-    end
-
-    def handle_cast(request, state) do
-      super(request, state)
     end
 
     def terminate(_reason, _state) do

--- a/lib/elixir/test/elixir/supervisor_test.exs
+++ b/lib/elixir/test/elixir/supervisor_test.exs
@@ -10,6 +10,10 @@ defmodule SupervisorTest do
       GenServer.start_link(__MODULE__, state, opts)
     end
 
+    def init(args) do
+      {:ok, args}
+    end
+
     def handle_call(:pop, _from, [h | t]) do
       {:reply, h, t}
     end

--- a/lib/ex_unit/lib/ex_unit/capture_server.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_server.ex
@@ -78,10 +78,6 @@ defmodule ExUnit.CaptureServer do
     {:noreply, config}
   end
 
-  def handle_info(msg, state) do
-    super(msg, state)
-  end
-
   defp release_device(ref, %{devices: {names, refs}} = config) do
     case Map.pop(refs, ref) do
       {{name, pid}, refs} ->

--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -5,6 +5,10 @@ defmodule Logger.TranslatorTest do
   defmodule MyGenServer do
     use GenServer
 
+    def init(args) do
+      {:ok, args}
+    end
+
     def handle_call(:error, _, _) do
       raise "oops"
     end
@@ -614,6 +618,7 @@ defmodule Logger.TranslatorTest do
   test "handles :undefined MFA properly" do
     defmodule WeirdFunctionNamesGenServer do
       use GenServer
+      def init(args), do: {:ok, args}
       def unquote(:"start link")(), do: GenServer.start_link(__MODULE__, [])
       def handle_call(_call, _from, _state), do: raise("oops")
     end


### PR DESCRIPTION
Use defoverridable for `init/1`, `terminate/2` and `code_change/3`. The `init/1` will raise an error, if not implemented. All other callbacks, such as `handle_call/3` are now optional.