### PR TITLE
Select certain command-line arguments from a restricted set of values

### DIFF
--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -723,7 +723,7 @@ defmodule OptionParser do
   defp to_underscore(<<>>, acc),
     do: acc
 
-  def get_option_key(option, allow_nonexistent_atoms?) do
+  defp get_option_key(option, allow_nonexistent_atoms?) do
     if string = to_underscore(option) do
       to_existing_key(string, allow_nonexistent_atoms?)
     end

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -306,7 +306,7 @@ defmodule OptionParser do
   end
 
   defp do_parse(argv, %{switches: switches} = config, opts, args, invalid, all?) do
-    case do_next(argv, config) do
+    case next(argv, config) do
       {:ok, option, value, rest} ->
         # the option exists and it was successfully parsed
         kinds = List.wrap Keyword.get(switches, option)
@@ -359,35 +359,37 @@ defmodule OptionParser do
         {:undefined, String.t, String.t | nil, argv} |
         {:error, argv}
 
-  def next(argv, opts \\ []) when is_list(argv) and is_list(opts) do
-    do_next(argv, compile_config(opts))
+  def next(argv, opts \\ [])
+
+  def next(argv, opts) when is_list(argv) and is_list(opts) do
+    next(argv, compile_config(opts))
   end
 
-  defp do_next([], _config) do
+  def next([], _config) do
     {:error, []}
   end
 
-  defp do_next(["--" | _] = argv, _config) do
+  def next(["--" | _] = argv, _config) do
     {:error, argv}
   end
 
-  defp do_next(["-" | _] = argv, _config) do
+  def next(["-" | _] = argv, _config) do
     {:error, argv}
   end
 
-  defp do_next(["- " <> _ | _] = argv, _config) do
+  def next(["- " <> _ | _] = argv, _config) do
     {:error, argv}
   end
 
   # Handles --foo or --foo=bar
-  defp do_next(["--" <> option | rest], config) do
+  def next(["--" <> option | rest], config) do
     {option, value} = split_option(option)
     tagged = tag_option(option, config)
     next_tagged(tagged, value, "--" <> option, rest, config)
   end
 
   # Handles -a, -abc, -abc=something
-  defp do_next(["-" <> option | rest] = argv, config) do
+  def next(["-" <> option | rest] = argv, config) do
     %{aliases: aliases, allow_nonexistent_atoms?: allow_nonexistent_atoms?} = config
     {option, value} = split_option(option)
     original = "-" <> option
@@ -404,7 +406,7 @@ defmodule OptionParser do
           IO.warn "multi-letter aliases are deprecated, got: #{inspect(key)}"
           next_tagged({:default, option_key}, value, original, rest, config)
         else
-          do_next(expand_multi_letter_alias(option, value) ++ rest, config)
+          next(expand_multi_letter_alias(option, value) ++ rest, config)
         end
       true ->
         # We have a regular one-letter alias here
@@ -413,7 +415,7 @@ defmodule OptionParser do
     end
   end
 
-  defp do_next(argv, _config) do
+  def next(argv, _config) do
     {:error, argv}
   end
 

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -53,6 +53,7 @@ defmodule OptionParser do
     * `:switches` or `:strict` - see the "Switch definitions" section below
     * `:allow_nonexistent_atoms` - see the "Parsing dynamic switches" section below
     * `:aliases` - see the "Aliases" section below
+    * `:choices` - see the "Filtering command-line arguments" section bellow
 
   ## Switch definitions
 
@@ -157,6 +158,14 @@ defmodule OptionParser do
       iex> OptionParser.parse(["-d"], aliases: [d: :debug])
       {[debug: true], [], []}
 
+  ## Filtering command-line arguments
+
+  A set of restricted values can be specified for a particular command-line
+  argument in the `:choices` option:
+
+      iex> OptionParser.parse(["--move", "rock"], switches: [move: :choices], choices: [move: ["rock", "paper", "scissors", "lizard", "spock"]])
+      {[move: "rock"], [], []}
+
   ## Examples
 
   Here are some examples of working with different types and modifiers:
@@ -189,6 +198,9 @@ defmodule OptionParser do
 
       iex> OptionParser.parse(["--unlock", "path/to/file", "--unlock", "path/to/another/file"], strict: [unlock: :keep])
       {[unlock: "path/to/file", unlock: "path/to/another/file"], [], []}
+
+      iex> OptionParser.parse(["--food", "egg"], switches: [food: :choices], choices: [food: ["egg", "spam"]])
+      {[food: "egg"], [], []}
 
   """
   @spec parse(argv, options) :: {parsed, argv, errors}
@@ -294,7 +306,7 @@ defmodule OptionParser do
   end
 
   defp do_parse(argv, %{switches: switches} = config, opts, args, invalid, all?) do
-    case next(argv, config) do
+    case do_next(argv, config) do
       {:ok, option, value, rest} ->
         # the option exists and it was successfully parsed
         kinds = List.wrap Keyword.get(switches, option)

--- a/lib/elixir/test/elixir/option_parser_test.exs
+++ b/lib/elixir/test/elixir/option_parser_test.exs
@@ -49,6 +49,16 @@ defmodule OptionParserTest do
            {[source: "from_docs/"], ["other"], []}
   end
 
+  test "parses --key choice among valid choices" do
+    assert OptionParser.parse(["--food", "egg"], switches: [food: :choices], choices: [food: ["egg", "spam"]]) ==
+           {[food: "egg"], [], []}
+  end
+
+  test "does not parse --key when is not among valid choices" do
+    assert OptionParser.parse(["--food", "apple"], switches: [food: :choices], choices: [food: ["egg", "spam"]]) ==
+           {[], [], [{"--food", "apple"}]}
+  end
+
   test "does not interpret undefined options with value as boolean" do
     assert OptionParser.parse(["--no-bool"]) ==
            {[no_bool: true], [], []}
@@ -238,6 +248,13 @@ defmodule OptionParserTest do
     assert_raise OptionParser.ParseError, fn ->
       argv = ["--bad", "opt", "foo", "-o", "bad", "bar"]
       OptionParser.parse!(argv, switches: [bad: :integer])
+    end
+  end
+
+  test "parse!/2 raise an exception when the given choice is not among the valid choices" do
+    assert_raise OptionParser.ParseError, fn ->
+      argv = ["--food", "bacon"]
+      OptionParser.parse!(argv, switches: [food: :choices], choices: [food: ["egg", "spam"]])
     end
   end
 


### PR DESCRIPTION
Sometimes you want to select certain command-line arguments from a restricted set of values, assume for a moment that we want to play Rock–paper–scissors. So, there is a restricted set of values for the argument `--move`.

The current behavior from `OptionParser` does not allow to filter some values:

```elixir
iex(1)> OptionParser.parse(["--move", "rock"], switches: [move: :string])
{[move: "rock"], [], []}
iex(2)> OptionParser.parse(["--move", "scissors"], switches: [move: :string])
{[move: "scissors"], [], []}
iex(3)> OptionParser.parse(["--move", "bacon"], switches: [move: :string])
{[move: "bacon"], [], []}
```

This proposal includes the `choices` option, which allow us to select the command-line arguments based on a restricted set of values:

```elixir
iex(4)> OptionParser.parse(["--move", "rock"], switches: [move: :choices], choices: [move: ["rock", "paper", "scissors"]])
{[move: "rock"], [], []}
iex(5)> OptionParser.parse(["--move", "bacon"], switches: [move: :choices], choices: [move: ["rock", "paper", "scissors"]])
{[], [], [{"--move", "bacon"}]}
```

This also work with ranges or list of integers:

```elixir
iex(6)> OptionParser.parse(["--door", 1], switches: [move: :choices], choices: [door: 1..4])
{[door: 1], [], []}
```

If we use `OptionParser.parse!/2` we should get an exception in case of an invalid value:

```elixir
iex(7)> OptionParser.parse!(["--move", "bacon"], switches: [move: :choices], choices: [move: ["rock", "paper", "scissors"]])
** (OptionParser.ParseError) 1 error found!
--move : Invalid choice bacon, choose from: rock, paper, scissors
    (elixir) lib/option_parser.ex:244: OptionParser.parse!/2
```

This commit also includes some minor refactoring in `OptionParser` to reduce the number of parameters in some functions.