### PR TITLE
Fix typo in mix deps.compile moduledoc

### DIFF
--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.Deps.Compile do
   Compiles dependencies.
 
   By default, compile all dependencies. A list of dependencies
-  can be given compile multiple dependencies in order.
+  can be given to compile multiple dependencies in order.
 
   This task attempts to detect if the project contains one of
   the following files and act accordingly:


### PR DESCRIPTION
Missing "to" in deps.compile task description.