### PR TITLE
Add info about 'from' parameter

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -860,7 +860,8 @@ defmodule GenServer do
 
   `client` must be the `from` argument (the second argument) accepted by
   `c:handle_call/3` callbacks. `reply` is an arbitrary term which will be given
-  back to the client as the return value of the call.
+  back to the client as the return value of the call. The `from` argument is a tuple 
+  consisting of a caller's PID and a reference, eg. `{#PID<0.72.0>, #Reference<0.0.4.992>}`.
 
   Note that `reply/2` can be called from any process, not just the GenServer
   that originally received the call (as long as that GenServer communicated the


### PR DESCRIPTION
Currently, there is not information about the contents of the `from` parameter. It is, however, an information that is sometimes useful and I think it's nice to be able to find that information in the documentation. 

The thing I'm not sure is whether this was not described on purpose (maybe it is a value that could change easily and should not be relied upon?). In this case, maybe I should add some doctests to make sure the documentation is stable? 