### PR TITLE
Adds Kernel.defguard/1 macro to build guard-safe macros.

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3985,11 +3985,65 @@ defmodule Kernel do
 
   As seen as in the example above, `super` can be used to call the default
   implementation.
-
   """
   defmacro defoverridable(keywords) do
     quote do
       Module.make_overridable(__MODULE__, unquote(keywords))
+    end
+  end
+
+  @doc """
+  Generates a macro suitable for use in guard expressions.
+
+  It raises at compile time if the definition uses expressions that aren't
+  allowed in guards, and otherwise creates a macro that can be used both inside
+  or outside guards, as per the requirements of `Macro.guard/3`.
+
+  ## Example
+
+      defmodule Integer.Guards do
+        defguard is_even(value) when is_integer(value) and rem(value, 2) == 0
+      end
+
+      defmodule Integer.Utils do
+        import Integer.Guards
+
+        def is_even_guard(value) when is_even(value), do: true
+        def is_even_guard(_), do: false
+
+        def is_even_func(value) do
+          if is_even(value), do: true, else: false
+        end
+
+        def is_large_even(value) when is_even(value) and value > 10, do: true
+        def is_large_even(_), do: false
+      end
+
+  """
+  defmacro defguard(guard) do
+    case :elixir_utils.extract_guards(guard) do
+      {_, []} -> raise ArgumentError, message: "defguard expects guards to be specified, such as `name(args) when implementation`"
+      {definition, implementation} -> do_defguard definition, implementation, __CALLER__
+    end
+  end
+
+  defp do_defguard(definition, implementation, env) do
+    env = Map.put(env, :context, :guard)
+    case Macro.validate_guard(implementation, env) do
+      :ok ->
+        {_ast, vars} = Macro.prewalk(elem(definition, 2), [], fn
+          {token, _, atom} = ast, acc when is_atom(atom) ->
+            {ast, [token | acc]}
+          ast, acc ->
+            {ast, acc}
+        end)
+        quote do
+          defmacro unquote(definition) do
+            unquote(Macro.guard(implementation, vars))
+          end
+        end
+      {:error, remainder} ->
+        raise ArgumentError, "not allowed in guard expression: `#{Macro.to_string(remainder)}`"
     end
   end
 

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -691,6 +691,8 @@ defmodule Macro do
   @spec validate_guard(Macro.t) :: :ok | {:error, term}
   def validate_guard(expr) do
     validate expr, fn
+      {container, [], exprs} when is_list(exprs) and container in [:{}, :%{}, :%, :<<>>] ->
+        true
       {:__block__, [], exprs} when is_list(exprs) and length(exprs) == 1 ->
         true
       {{:., _, [:erlang, call]}, _, args} when is_list(args) ->
@@ -699,7 +701,7 @@ defmodule Macro do
         true
       {_, _, atom} when is_atom(atom) ->
         true
-      term when not is_tuple(term) ->
+      term when not is_tuple(term) or is_tuple(term) and tuple_size(term) == 2 ->
         true
       _other ->
         false

--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -115,21 +115,8 @@ defmodule Record do
       true
 
   """
-  defmacro is_record(data, kind) do
-    case Macro.Env.in_guard?(__CALLER__) do
-      true ->
-        quote do
-          is_atom(unquote(kind)) and is_tuple(unquote(data)) and tuple_size(unquote(data)) > 0 and
-            elem(unquote(data), 0) == unquote(kind)
-        end
-      false ->
-        quote do
-          result = unquote(data)
-          kind = unquote(kind)
-          is_atom(kind) and is_tuple(result) and tuple_size(result) > 0 and elem(result, 0) == kind
-        end
-    end
-  end
+  defguard is_record(data, kind) when
+    is_atom(kind) and is_tuple(data) and tuple_size(data) > 0 and elem(data, 0) == kind
 
   @doc """
   Checks if the given `data` is a record.
@@ -146,20 +133,8 @@ defmodule Record do
       false
 
   """
-  defmacro is_record(data) do
-    case Macro.Env.in_guard?(__CALLER__) do
-      true ->
-        quote do
-          is_tuple(unquote(data)) and tuple_size(unquote(data)) > 0 and
-            is_atom(elem(unquote(data), 0))
-        end
-      false ->
-        quote do
-          result = unquote(data)
-          is_tuple(result) and tuple_size(result) > 0 and is_atom(elem(result, 0))
-        end
-    end
-  end
+  defguard is_record(data) when
+    is_tuple(data) and tuple_size(data) > 0 and is_atom(elem(data, 0))
 
   @doc """
   Defines a set of macros to create, access, and pattern match

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -555,234 +555,229 @@ defmodule MacroTest do
   ## validate_guard
 
   test "true is valid in guards" do
-    guard = Macro.expand (quote do: true), __ENV__
+    guard = quote do: true
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "atoms are valid in guards" do
-    guard = Macro.expand (quote do: :a), __ENV__
+    guard = quote do: :a
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "strings are valid in guards" do
-    guard = Macro.expand (quote do: "asdf"), __ENV__
+    guard = quote do: "asdf"
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "string operators are valid in guards" do
-    guard = Macro.expand (quote do: "foo" <> "bar"), __ENV__
+    guard = quote do: "foo" <> "bar"
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "binaries are valid in guards" do
-    guard = Macro.expand (quote do: <<0, 1, 2, 3>>), __ENV__
+    guard = quote do: <<0, 1, 2, 3>>
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "ranges are valid in guards" do
-    guard = Macro.expand (quote do: 1..100), __ENV__
+    guard = quote do: 1..100
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "maps are valid in guards" do
-    guard = Macro.expand (quote do: %{:foo => :bar}), __ENV__
+    guard = quote do: %{:foo => :bar}
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "variables are valid in guards" do
-    guard = Macro.expand (quote do: var), __ENV__
+    guard = quote do: var
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "__MODULE__ is valid in guards" do
-    guard = Macro.expand (quote do: __MODULE__), __ENV__
+    guard = quote do: __MODULE__
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "sigils are valid in guards" do
-    guard = Macro.expand (quote do: ~w[asdf]), __ENV__
+    guard = quote do: ~w[asdf]
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "Elixir type tests are valid in guards" do
-    guard = Macro.expand (quote do: is_integer(var)), __ENV__
+    guard = quote do: is_integer(var)
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "erlang type tests are valid in guards" do
-    guard = Macro.expand (quote do: :erlang.is_integer(var)), __ENV__
+    guard = quote do: :erlang.is_integer(var)
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "Elixir extra bifs are valid in guards" do
-    guard = Macro.expand (quote do: binary_part(self(), abs(length([])), 2)), __ENV__
+    guard = quote do: binary_part(self(), abs(length([])), 2)
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "erlang extra bifs are valid in guards" do
-    guard = Macro.expand (quote do: :erlang.binary_part(:erlang.self(), :erlang.abs(:erlang.length([])), 2)), __ENV__
+    guard = quote do: :erlang.binary_part(:erlang.self(), :erlang.abs(:erlang.length([])), 2)
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "Elixir term comparison operators are valid in guards" do
-    guard = Macro.expand (quote do: 1 == 2), __ENV__
+    guard = quote do: 1 == 2
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "erlang term comparison operators are valid in guards" do
-    guard = Macro.expand (quote do: :erlang.== 1, 2), __ENV__
+    guard = quote do: :erlang.== 1, 2
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "Elixir arithmetic operators are valid in guards" do
-    guard = Macro.expand (quote do: -1 + 2 * 3 / 0 ), __ENV__
+    guard = quote do: -1 + 2 * 3 / 0
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "erlang arithmetic operators are valid in guards" do
-    guard = Macro.expand (quote do: :erlang.+(1, :erlang.bor(1, 0) )), __ENV__
+    guard = quote do: :erlang.+(1, :erlang.bor(1, 0) )
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "Elixir boolean operators are valid in guards" do
-    guard = Macro.expand (quote do: true or not false and bool), __ENV__
+    guard = quote do: true or not false and bool
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "erlang boolean operators are valid in guards" do
-    guard = Macro.expand (quote do: :erlang.xor(true, :erlang.not(false))), __ENV__
+    guard = quote do: :erlang.xor(true, :erlang.not(false))
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "Elixir list operators are valid in guards" do
-    guard = Macro.expand (quote do: x ++ y), __ENV__
+    guard = quote do: x ++ y
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "erlang list operators are valid in guards" do
-    guard = Macro.expand (quote do: :erlang.++(x, y)), __ENV__
+    guard = quote do: :erlang.++(x, y)
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "list membership operators are valid in guards for static lists" do
-    guard = Macro.expand (quote do: x in [:foo, :bar]), __ENV__
+    guard = quote do: x in [:foo, :bar]
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "exclusionary list membership operators are valid in guards for static lists" do
-    guard = Macro.expand (quote do: x not in [:foo, :bar]), __ENV__
+    guard = quote do: x not in [:foo, :bar]
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "erlang short-circuit expressions are valid in guards" do
-    guard = Macro.expand (quote do: :erlang.andalso(true, :erlang.orelse(false, :asdf))), __ENV__
+    guard = quote do: :erlang.andalso(true, :erlang.orelse(false, :asdf))
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "other compound guards are valid in guards" do
     import Record
     env = Map.put(__ENV__, :context, :guard)
-    guard = Macro.expand (quote do: is_record(foo)), env
+    guard = quote do: is_record(foo)
     assert :ok == Macro.validate_guard(guard, env)
   end
 
   test "remote calls are not valid in guards" do
-    bad_guard = Macro.expand (quote do: Macro.ExternalTest.remote_call()), __ENV__
+    bad_guard = quote do: Macro.ExternalTest.remote_call()
     refute :ok == Macro.validate_guard(bad_guard, __ENV__)
   end
 
   test "imported remote calls are not valid in guards" do
-    bad_guard = Macro.expand (quote do: remote_call()), __ENV__
+    bad_guard = quote do: remote_call()
     refute :ok == Macro.validate_guard(bad_guard, __ENV__)
   end
 
   test "local calls are not valid in guards" do
-    bad_guard = Macro.expand (quote do: local_call()), __ENV__
+    bad_guard = quote do: local_call()
     refute :ok == Macro.validate_guard(bad_guard, __ENV__)
   end
 
-  test "maps cannot match on keys in guards" do
-    guard = Macro.expand (quote do: %{x => :bar}), __ENV__
-    refute :ok == Macro.validate_guard(guard, __ENV__)
-  end
-
   test "cases are not valid in guards" do
-    guard = Macro.expand (quote do: (case x do; x -> x; end)), __ENV__
+    guard = quote do: (case x do; x -> x; end)
     refute :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "conds are not valid in guards" do
-    guard = Macro.expand (quote do: (cond do; x -> x; end)), __ENV__
+    guard = quote do: (cond do; x -> x; end)
     refute :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "ifs are not valid in guards" do
-    guard = Macro.expand (quote do: (if x, do: x)), __ENV__
+    guard = quote do: (if x, do: x)
     refute :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "funs are not valid in guards" do
-    guard = Macro.expand (quote do: &(&1)), __ENV__
+    guard = quote do: &(&1)
     refute :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "trys are not valid in guards" do
-    guard = Macro.expand (quote do: (try do: x)), __ENV__
+    guard = quote do: (try do: x)
     refute :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "pins are not valid in guards" do
-    guard = Macro.expand (quote do: ^var), __ENV__
+    guard = quote do: ^var
     refute :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "aliases are not valid in guards" do
-    bad_guard = Macro.expand (quote do: alias Supervisor.Spec), __ENV__
+    bad_guard = quote do: alias Supervisor.Spec
     refute :ok == Macro.validate_guard(bad_guard, __ENV__)
   end
 
   test "imports are not valid in guards" do
-    bad_guard = Macro.expand (quote do: import Map), __ENV__
+    bad_guard = quote do: import Map
     refute :ok == Macro.validate_guard(bad_guard, __ENV__)
   end
 
   test "requires are not valid in guards" do
-    bad_guard = Macro.expand (quote do: require Record), __ENV__
+    bad_guard = quote do: require Record
     refute :ok == Macro.validate_guard(bad_guard, __ENV__)
   end
 
   test "assignment is not valid in guards" do
-    guard = Macro.expand (quote do: x = 9001), __ENV__
+    guard = quote do: x = 9001
     refute :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "blocks are not valid in guards" do
-    guard = Macro.expand (quote do: (a; b)), __ENV__
+    guard = quote do: (a; b)
     refute :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "list membership operators not valid in guards for static lists" do
-    guard = Macro.expand (quote do: x in [:foo, :bar]), __ENV__
+    guard = quote do: x in [:foo, :bar]
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "exclusionary list membership operators not valid in guards for static lists" do
-    guard = Macro.expand (quote do: x not in [:foo, :bar]), __ENV__
+    guard = quote do: x not in [:foo, :bar]
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "soft boolean logic is not valid in guards" do
-    guard = Macro.expand (quote do: :this || !nil && 1), __ENV__
+    guard = quote do: :this || !nil && 1
     refute :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "Elixir send operators are not valid in guards" do
-    bad_guard = Macro.expand (quote do: send(self, :data)), __ENV__
+    bad_guard = quote do: send(self, :data)
     refute :ok == Macro.validate_guard(bad_guard, __ENV__)
   end
 
   test "erlang send operators are not valid in guards" do
-    bad_guard = Macro.expand (quote do: :erlang."!"(self(), :data)), __ENV__
+    bad_guard = quote do: :erlang."!"(self(), :data)
     refute :ok == Macro.validate_guard(bad_guard, __ENV__)
   end
 

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -594,6 +594,11 @@ defmodule MacroTest do
     assert :ok == Macro.validate_guard(guard, __ENV__)
   end
 
+  test "pins are valid in guards" do
+    guard = quote do: ^a
+    assert :ok == Macro.validate_guard(guard, __ENV__)
+  end
+
   test "__MODULE__ is valid in guards" do
     guard = quote do: __MODULE__
     assert :ok == Macro.validate_guard(guard, __ENV__)
@@ -701,6 +706,11 @@ defmodule MacroTest do
     refute :ok == Macro.validate_guard(bad_guard, __ENV__)
   end
 
+  test "assignment is not valid in guards" do
+    guard = quote do: x = 9001
+    refute :ok == Macro.validate_guard(guard, __ENV__)
+  end
+
   test "cases are not valid in guards" do
     guard = quote do: (case x do; x -> x; end)
     refute :ok == Macro.validate_guard(guard, __ENV__)
@@ -726,11 +736,6 @@ defmodule MacroTest do
     refute :ok == Macro.validate_guard(guard, __ENV__)
   end
 
-  test "pins are not valid in guards" do
-    guard = quote do: ^var
-    refute :ok == Macro.validate_guard(guard, __ENV__)
-  end
-
   test "aliases are not valid in guards" do
     bad_guard = quote do: alias Supervisor.Spec
     refute :ok == Macro.validate_guard(bad_guard, __ENV__)
@@ -744,11 +749,6 @@ defmodule MacroTest do
   test "requires are not valid in guards" do
     bad_guard = quote do: require Record
     refute :ok == Macro.validate_guard(bad_guard, __ENV__)
-  end
-
-  test "assignment is not valid in guards" do
-    guard = quote do: x = 9001
-    refute :ok == Macro.validate_guard(guard, __ENV__)
   end
 
   test "blocks are not valid in guards" do


### PR DESCRIPTION
Closes #2469.

## Public API

(Checks denote that documentation has been updated where necessary to the satisfaction of involved reviewers. Uncheck if they need work.)

#### Public functions modified

- [x] `Macro.validate/1` is now implemented in terms of `Macro.validate/2`
- [x] `Macro.expand(_once)/2` is now implemented in terms of `Macro.expand(_once)/3`

#### Public functions added

- [x] `Macro.validate/2` allows you to verify an AST tree against an additional custom validator function
- [x] `Macro.expand(_once)/3` allows you to provide option `rewrite: true` to perform the expansions in [`elixir_rewrite.erl`](https://github.com/elixir-lang/elixir/blob/master/lib/elixir/src/elixir_rewrite.erl)
- [x] `Macro.validate_guard/1` allows you to check if an AST tree is guard-safe
- [x] `Macro.validate_guard/2` does so after a rewrite-expansion over the provided `Macro.Env.t`
- [x] `Macro.guard/2` prepares an AST tree to be used in a guard by handling the provided list of variable names differently inside and outside of guards

#### Public macros added

- [x] `Kernel.defguard/1` creates a guard macro that behaves correctly inside and outside of guards, provided the macro implementation is valid in guards

#### Public macros modified

- [x] `Record.is_record/{1,2}` now uses `defguard`

## How it works

The heart of this implementation is that it makes few hard-coded assumptions about what is allowed in a guard.

The criteria used to validate a guard is that:

- it can be rewritten into an expression
  - composed exclusively of calls to [sequences allowed in guards](http://erlang.org/doc/reference_manual/expressions.html#id84508)
  - or special forms
    - except for special forms known to `assert_no_guard_scope` in [`:elixir_expand`](https://github.com/elixir-lang/elixir/blob/c55f92d78b04baaa274fb2d54bea557c444165d4/lib/elixir/src/elixir_expand.erl)
- the arguments to those calls must be simple terms
- the expression must be one line long

The only hardcoded values in the algorithm are the list of special forms that `assert_no_guard_scope`. The rest uses erlang introspection and Elixir compiler helpers to inform the validation.

This is only a rough algorithm. It's still possible to create an invalid guard with`defguard` that passes this test and is syntactically correct, but semantically invalid. For example, odd pins, using variables in map keys, other funny business. The errors in those guards won't be discovered until the macro that `defguard` generates is invoked, and the AST proves to be subtly invalid.

To get any further into those woods, we would have either have access to more metaprogramming predicates like those found in `:erl_internal` and `:erl_syntax`, or start emulating the low-level compiler translations of things like binary literals that expand into forms that are only valid erlang, but not valid Elixir, AST.

This is the best algorithm I could come up with that is 

- simple (single extra expansion step, single validation function)
- accurate (no false negatives) 
- helpful (has as few as possible false positives)
- future-proof (not *too* much hardcoded into the implementation)

Here are the semi-private erlang introspection and Elixir compiler calls I make:

##### In `Kernel.defguard/1`

- `:elixir_utils.extract_guards/1` to pull out the guard definition in the macro

##### In `Macro.validate_guard/1`

- `:erl_internal.guard_bif/2` to check for guard bifs
- `:elixir_utils.guard_op/2` to more concisely make other erlang guard checks

##### In `Macro.expand(_once)/3`

- `:elixir_rewrite.inline/3` to perform simple compiler rewrites of the AST in advance to check for validity
- `:elixir_rewrite.rewrite/5` to perform more complicated ones that involve changing arities or changing AST forms

## Tests

(Please uncheck any items that need better/more/any tests, or check off unchecked things you determine are sufficiently covered.)

#### For changed functions

- [x] `Macro.validate/1` tests still all pass
- [x] `Macro.expand(_once)/2` tests still all pass

#### For added functions

- [x] `Macro.validate/2` is indirectly tested by the above and below
- [x] `Macro.expand(_once)/3` is indirectly tested by the above and below
- [x] `Macro.validate_guard/1` is indirectly tested by the below
- [x] `Macro.validate_guard/2` explores 45 forms in guards, exercising `Macro.validate/2` and `Macro.expand(_once)/3` in the process.
- [x] `Macro.guard/2` is not really tested beyond usage

#### For added macros

- [x] `Kernel.defguard/1` is not really tested beyond usage

#### For changed macros

- [x] `Record.is_record/{1,2}` tests still all pass

###### Errata: I have a rather lengthy explanation of how I reached this implementation [here](https://gist.github.com/christhekeele/76c3e37cb9082274f52f79fa94bab6fe).