### PR TITLE
Propose new styling for generated applications

### DIFF
--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -498,26 +498,10 @@ defmodule Mix.Project do
 
   @doc """
   Compiles the given project.
-
-  It will run the compile task unless the project
-  is in build embedded mode, which may fail as an
-  explicit execution of `mix compile` is required.
   """
   @spec compile([term], Keyword.t) :: term
-  def compile(args, config \\ config()) do
-    if config[:build_embedded] do
-      path = if umbrella?(config), do: build_path(config), else: compile_path(config)
-
-      unless File.exists?(path) do
-        Mix.raise "Cannot execute task because the project was not yet compiled. " <>
-                  "When build_embedded is set to true, \"MIX_ENV=#{Mix.env} mix compile\" " <>
-                  "must be explicitly executed"
-      end
-
-      Mix.Task.run "loadpaths", args
-    else
-      Mix.Task.run "compile", args
-    end
+  def compile(args, _config \\ []) do
+    Mix.Task.run "compile", args
   end
 
   @doc """

--- a/lib/mix/lib/mix/tasks/compile.ex
+++ b/lib/mix/lib/mix/tasks/compile.ex
@@ -17,10 +17,8 @@ defmodule Mix.Tasks.Compile do
       consolidation via the `compile.protocols` task. The default
       value is `true`.
 
-    * `:build_embedded` - when `true`, prepares the `_build` directory
-      for production by not using symlinks and optimizing paths. Once
-      enabled, implicit compilation is disabled and explicit calls
-      to `mix compile` is required. Defaults to `false`.
+    * `:build_embedded` - when `true`, embeds all code and priv
+      content in the `_build` directory instead of using symlinks.
 
     * `:build_path` - the directory where build artifacts
       should be written to. This option is intended only for

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -260,7 +260,6 @@ defmodule Mix.Tasks.New do
         app: :<%= @app %>,
         version: "0.1.0",
         elixir: "~> <%= @version %>",
-        build_embedded: Mix.env == :prod,
         start_permanent: Mix.env == :prod,
         deps: deps()
       ]
@@ -296,7 +295,6 @@ defmodule Mix.Tasks.New do
         deps_path: "../../deps",
         lockfile: "../../mix.lock",
         elixir: "~> <%= @version %>",
-        build_embedded: Mix.env == :prod,
         start_permanent: Mix.env == :prod,
         deps: deps()
       ]
@@ -327,7 +325,6 @@ defmodule Mix.Tasks.New do
     def project do
       [
         apps_path: "apps",
-        build_embedded: Mix.env == :prod,
         start_permanent: Mix.env == :prod,
         deps: deps()
       ]

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -42,7 +42,12 @@ defmodule Mix.Tasks.New do
 
   """
 
-  @switches [sup: :boolean, umbrella: :boolean, app: :string, module: :string]
+  @switches [
+    app: :string,
+    module: :string,
+    sup: :boolean,
+    umbrella: :boolean
+  ]
 
   @spec run(OptionParser.argv) :: :ok
   def run(argv) do
@@ -73,7 +78,7 @@ defmodule Mix.Tasks.New do
   end
 
   defp generate(app, mod, path, opts) do
-    assigns = [app: app, mod: mod, otp_app: otp_app(mod, !!opts[:sup]),
+    assigns = [app: app, mod: mod, sup_app: sup_app(mod, !!opts[:sup]),
                version: get_version(System.version)]
 
     create_file "README.md",  readme_template(assigns)
@@ -112,21 +117,11 @@ defmodule Mix.Tasks.New do
     |> Mix.shell.info
   end
 
-  defp otp_app(_mod, false) do
-    "    [extra_applications: [:logger]]"
-  end
+  defp sup_app(_mod, false), do: ""
+  defp sup_app(mod, true), do: ",\n      mod: {#{mod}.Application, []}"
 
-  defp otp_app(mod, true) do
-    "    [extra_applications: [:logger],\n     mod: {#{mod}.Application, []}]"
-  end
-
-  defp cd_path(".") do
-    ""
-  end
-
-  defp cd_path(path) do
-    "cd #{path}\n    "
-  end
+  defp cd_path("."), do: ""
+  defp cd_path(path), do: "cd #{path}\n    "
 
   defp generate_umbrella(_app, mod, path, _opts) do
     assigns = [app: nil, mod: mod]
@@ -261,33 +256,29 @@ defmodule Mix.Tasks.New do
     use Mix.Project
 
     def project do
-      [app: :<%= @app %>,
-       version: "0.1.0",
-       elixir: "~> <%= @version %>",
-       build_embedded: Mix.env == :prod,
-       start_permanent: Mix.env == :prod,
-       deps: deps()]
+      [
+        app: :<%= @app %>,
+        version: "0.1.0",
+        elixir: "~> <%= @version %>",
+        build_embedded: Mix.env == :prod,
+        start_permanent: Mix.env == :prod,
+        deps: deps()
+      ]
     end
 
-    # Configuration for the OTP application
-    #
-    # Type "mix help compile.app" for more information
+    # Run "mix help compile.app" to learn about applications.
     def application do
-      # Specify extra applications you'll use from Erlang/Elixir
-  <%= @otp_app %>
+      [
+        extra_applications: [:logger]<%= @sup_app %>
+      ]
     end
 
-    # Dependencies can be Hex packages:
-    #
-    #   {:my_dep, "~> 0.3.0"}
-    #
-    # Or git/path repositories:
-    #
-    #   {:my_dep, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
-    #
-    # Type "mix help deps" for more examples and options
+    # Run "mix help deps" to learn about dependencies.
     defp deps do
-      []
+      [
+        # {:dep_example, "~> 0.3.0"},
+        # {:dep_example, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+      ]
     end
   end
   """
@@ -297,41 +288,34 @@ defmodule Mix.Tasks.New do
     use Mix.Project
 
     def project do
-      [app: :<%= @app %>,
-       version: "0.1.0",
-       build_path: "../../_build",
-       config_path: "../../config/config.exs",
-       deps_path: "../../deps",
-       lockfile: "../../mix.lock",
-       elixir: "~> <%= @version %>",
-       build_embedded: Mix.env == :prod,
-       start_permanent: Mix.env == :prod,
-       deps: deps()]
+      [
+        app: :<%= @app %>,
+        version: "0.1.0",
+        build_path: "../../_build",
+        config_path: "../../config/config.exs",
+        deps_path: "../../deps",
+        lockfile: "../../mix.lock",
+        elixir: "~> <%= @version %>",
+        build_embedded: Mix.env == :prod,
+        start_permanent: Mix.env == :prod,
+        deps: deps()
+      ]
     end
 
-    # Configuration for the OTP application
-    #
-    # Type "mix help compile.app" for more information
+    # Run "mix help compile.app" to learn about applications.
     def application do
-      # Specify extra applications you'll use from Erlang/Elixir
-  <%= @otp_app %>
+      [
+        extra_applications: [:logger]<%= @sup_app %>
+      ]
     end
 
-    # Dependencies can be Hex packages:
-    #
-    #   {:my_dep, "~> 0.3.0"}
-    #
-    # Or git/path repositories:
-    #
-    #   {:my_dep, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
-    #
-    # To depend on another app inside the umbrella:
-    #
-    #   {:my_app, in_umbrella: true}
-    #
-    # Type "mix help deps" for more examples and options
+    # Run "mix help deps" to learn about dependencies.
     defp deps do
-      []
+      [
+        # {:dep_example, "~> 0.3.0"},
+        # {:dep_example, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+        # {:sibling_app_in_umbrella, in_umbrella: true},
+      ]
     end
   end
   """
@@ -341,24 +325,19 @@ defmodule Mix.Tasks.New do
     use Mix.Project
 
     def project do
-      [apps_path: "apps",
-       build_embedded: Mix.env == :prod,
-       start_permanent: Mix.env == :prod,
-       deps: deps()]
+      [
+        apps_path: "apps",
+        build_embedded: Mix.env == :prod,
+        start_permanent: Mix.env == :prod,
+        deps: deps()
+      ]
     end
 
-    # Dependencies can be Hex packages:
+    # Dependencies listed here are available only for this
+    # project and cannot be accessed from applications inside
+    # the apps folder.
     #
-    #   {:my_dep, "~> 0.3.0"}
-    #
-    # Or git/path repositories:
-    #
-    #   {:my_dep, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
-    #
-    # Type "mix help deps" for more examples and options.
-    #
-    # Dependencies listed here are available only for this project
-    # and cannot be accessed from applications inside the apps folder
+    # Run "mix help deps" for examples and options.
     defp deps do
       []
     end

--- a/lib/mix/test/mix/task_test.exs
+++ b/lib/mix/test/mix/task_test.exs
@@ -101,17 +101,6 @@ defmodule Mix.TaskTest do
     end
   end
 
-  test "run/2 does not try to compile if task is missing in build embedded", context do
-    in_tmp context.test, fn ->
-      Mix.ProjectStack.post_config(build_embedded: true)
-      Mix.Project.push(SampleProject, "sample")
-
-      assert_raise Mix.Error, ~r/Cannot execute task because the project was not yet compiled/, fn ->
-        Mix.Task.run("unknown")
-      end
-    end
-  end
-
   test "clear/0" do
     assert Mix.Task.run("hello") == "Hello, World!"
     Mix.Task.clear

--- a/lib/mix/test/mix/tasks/app.start_test.exs
+++ b/lib/mix/test/mix/tasks/app.start_test.exs
@@ -13,12 +13,6 @@ defmodule Mix.Tasks.App.StartTest do
     end
   end
 
-  defmodule AppEmbeddedSample do
-    def project do
-      [app: :app_embedded_sample, version: "0.1.0", build_embedded: true]
-    end
-  end
-
   defmodule WrongElixirProject do
     def project do
       [app: :error, version: "0.1.0", elixir: "~> 0.8.1"]
@@ -50,18 +44,6 @@ defmodule Mix.Tasks.App.StartTest do
     end
   end
 
-  @tag apps: [:app_embedded_sample]
-  test "compiles and starts a project with build_embedded", context do
-    Mix.Project.push AppEmbeddedSample
-
-    in_tmp context.test, fn ->
-      assert_raise  Mix.Error, ~r"Cannot execute task because the project was not yet compiled", fn ->
-        Mix.Tasks.App.Start.run []
-      end
-      Mix.Tasks.Compile.run([])
-      Mix.Tasks.App.Start.run([])
-    end
-  end
 
   @tag apps: [:app_start_sample, :app_loaded_sample]
   test "start checks for invalid configuration", context do
@@ -74,7 +56,6 @@ defmodule Mix.Tasks.App.StartTest do
       Mix.Tasks.Compile.run([])
       Mix.Tasks.App.Start.run([])
 
-      refute_received {:mix_shell, :error, ["You have configured application :app_embedded_sample" <> _]}
       assert_received {:mix_shell, :error, ["You have configured application :app_unknown_sample" <> _]}
       refute_received {:mix_shell, :error, ["You have configured application :app_loaded_sample" <> _]}
     end

--- a/lib/mix/test/mix/umbrella_test.exs
+++ b/lib/mix/test/mix/umbrella_test.exs
@@ -57,15 +57,10 @@ defmodule Mix.UmbrellaTest do
     end
   end
 
-  test "compiles umbrella with protocol consolidation (via build embedded)" do
+  test "compiles umbrella with protocol consolidation" do
     in_fixture "umbrella_dep/deps/umbrella", fn ->
-      Mix.Project.in_project(:umbrella, ".", [build_embedded: true], fn _ ->
-        assert_raise Mix.Error, ~r"Cannot execute task because the project was not yet compiled", fn ->
-          Mix.Tasks.App.Start.run []
-        end
-
+      Mix.Project.in_project(:umbrella, ".", fn _ ->
         Mix.Task.run "compile", ["--verbose"]
-
         assert_received {:mix_shell, :info, ["Generated bar app"]}
         assert_received {:mix_shell, :info, ["Generated foo app"]}
         assert File.regular? "_build/dev/consolidated/Elixir.Enumerable.beam"
@@ -77,9 +72,9 @@ defmodule Mix.UmbrellaTest do
     end
   end
 
-  test "recursive compiles umbrella with protocol consolidation" do
+  test "recursively compiles umbrella with protocol consolidation" do
     in_fixture "umbrella_dep/deps/umbrella", fn ->
-      Mix.Project.in_project(:umbrella, ".", [build_embedded: true], fn _ ->
+      Mix.Project.in_project(:umbrella, ".", fn _ ->
         defmodule Elixir.Mix.Tasks.Umbrella.Recur do
           use Mix.Task
           @recursive true


### PR DESCRIPTION
Instead of:

```elixir
defmodule HelloWorld.Mixfile do
  use Mix.Project

  def project do
    [app: :hello_world,
     version: "0.1.0",
     elixir: "~> 1.5-dev",
     build_embedded: Mix.env == :prod,
     start_permanent: Mix.env == :prod,
     deps: deps()]
  end

  # Configuration for the OTP application
  #
  # Type "mix help compile.app" for more information
  def application do
    # Specify extra applications you'll use from Erlang/Elixir
    [extra_applications: [:logger]]
  end

  # Dependencies can be Hex packages:
  #
  #   {:my_dep, "~> 0.3.0"}
  #
  # Or git/path repositories:
  #
  #   {:my_dep, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
  #
  # Type "mix help deps" for more examples and options
  defp deps do
    []
  end
end
```

we propose:

```elixir
defmodule HelloWorld.Mixfile do
  use Mix.Project

  def project do
    [
      app: :hello_world,
      version: "0.1.0",
      elixir: "~> 1.5-dev",
      start_permanent: Mix.env == :prod,
      deps: deps()
    ]
  end

  # Run "mix help compile.app" to learn about applications.
  def application do
    [
      extra_applications: [:logger]
    ]
  end

  # Run "mix help deps" to learn about dependencies.
  defp deps do
    [
      # {:dep_example, "~> 0.3.0"},
      # {:dep_example, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
    ]
  end
end
```

The changes are:

  * Use new line after `[` and `]` for multi-line constructs for easier manipulation. If accepted, this will be a new rule throughout the Elixir codebase (but please do no send pull request for changing the style, those won't be merged)

  * Rely less on comments and more on the available documentation
