### PR TITLE
Add more clarity on how reduce works through each iteration

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1689,7 +1689,7 @@ defmodule Enum do
   @doc """
   Invokes `fun` for each element in the `enumerable`, passing that
   element and the accumulator as arguments. `fun`'s return value
-  is stored in the accumulator.
+  is stored in the accumulator and that gets used when iterating over the next item.
 
   The first element of the enumerable is used as the initial value of
   the accumulator.
@@ -1739,7 +1739,7 @@ defmodule Enum do
   @doc """
   Invokes `fun` for each element in the `enumerable`, passing that
   element and the accumulator `acc` as arguments. `fun`'s return value
-  is stored in `acc`.
+  is stored in `acc` and that gets used when iterating over the next item.
 
   Returns the accumulator.
 


### PR DESCRIPTION
`Enum.reduce` will emit the result of the previous function as the accumulator for the next item. This point didn't seem very evident to me when I was looking up the `Enum.reduce` related documentation [here](https://hexdocs.pm/elixir/Enum.html#reduce/2). This PR is an attempt to make this more clearer for anyone who wants to better understand how `Enum.reduce` works through each iteration.

Thanks to @josevalim for the wonderful explanation wrt the usage of `Enum.reduce` as part of [this stackoverflow question](http://stackoverflow.com/questions/29924170/elixir-looping-through-and-adding-to-map). It helped me better understand how `Enum.reduce` actually works.