### PR TITLE
Ensures NaiveDateTime.to_iso8601/1 raises for non-Calendar.ISO structs.

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -1220,7 +1220,7 @@ defmodule NaiveDateTime do
 
   def to_iso8601(%{year: _, month: _, day: _,
                    hour: _, minute: _, second: _, microsecond: _, calendar: _} = naive_datetime) do
-    raise ArgumentError, "Cannot convert #{inspect naive_datetime} to the ISO 8601 format, because it does not use Calendar.ISO"
+    raise ArgumentError, "cannot convert #{inspect naive_datetime} to the ISO 8601 format, because it does not use Calendar.ISO"
   end
 
   @doc """

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -1214,8 +1214,13 @@ defmodule NaiveDateTime do
   def to_iso8601(naive_datetime)
 
   def to_iso8601(%{year: year, month: month, day: day,
-                   hour: hour, minute: minute, second: second, microsecond: microsecond}) do
+                   hour: hour, minute: minute, second: second, microsecond: microsecond, calendar: Calendar.ISO}) do
     Calendar.ISO.naive_datetime_to_iso8601(year, month, day, hour, minute, second, microsecond)
+  end
+
+  def to_iso8601(%{year: _, month: _, day: _,
+                   hour: _, minute: _, second: _, microsecond: _, calendar: _} = naive_datetime) do
+    raise ArgumentError, "cannot convert #{inspect naive_datetime} to the ISO8601 format, because it does not use Calendar.ISO."
   end
 
   @doc """

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -1220,7 +1220,7 @@ defmodule NaiveDateTime do
 
   def to_iso8601(%{year: _, month: _, day: _,
                    hour: _, minute: _, second: _, microsecond: _, calendar: _} = naive_datetime) do
-    raise ArgumentError, "cannot convert #{inspect naive_datetime} to the ISO8601 format, because it does not use Calendar.ISO."
+    raise ArgumentError, "Cannot convert #{inspect naive_datetime} to the ISO 8601 format, because it does not use Calendar.ISO"
   end
 
   @doc """

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -98,6 +98,14 @@ defmodule NaiveDateTimeTest do
     assert NaiveDateTime.compare(ndt3, ndt1) == :gt
     assert NaiveDateTime.compare(ndt3, ndt2) == :gt
   end
+
+  test "to_iso8601/1" do
+    ndt1 = ~N[2000-04-16 12:34:15.1234]
+    ndt1 = put_in ndt1.calendar, Fake.NonISOCalendar
+    assert_raise ArgumentError, fn ->
+      NaiveDateTime.to_iso8601(ndt1)
+    end
+  end
 end
 
 defmodule DateTimeTest do

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -101,8 +101,11 @@ defmodule NaiveDateTimeTest do
 
   test "to_iso8601/1" do
     ndt1 = ~N[2000-04-16 12:34:15.1234]
-    ndt1 = put_in ndt1.calendar, Fake.NonISOCalendar
-    assert_raise ArgumentError, fn ->
+    ndt1 = put_in ndt1.calendar, FakeCalendar
+    assert_raise ArgumentError, """
+    Cannot convert %NaiveDateTime{calendar: FakeCalendar, day: 16, hour: 12, microsecond: {123400, 4}, minute: 34, month: 4, second: 15, year: 2000} to the ISO 8601 format, because it does not use Calendar.ISO
+    """,
+    fn ->
       NaiveDateTime.to_iso8601(ndt1)
     end
   end

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -100,13 +100,11 @@ defmodule NaiveDateTimeTest do
   end
 
   test "to_iso8601/1" do
-    ndt1 = ~N[2000-04-16 12:34:15.1234]
-    ndt1 = put_in ndt1.calendar, FakeCalendar
-    assert_raise ArgumentError, """
-    Cannot convert %NaiveDateTime{calendar: FakeCalendar, day: 16, hour: 12, microsecond: {123400, 4}, minute: 34, month: 4, second: 15, year: 2000} to the ISO 8601 format, because it does not use Calendar.ISO
-    """,
+    ndt = ~N[2000-04-16 12:34:15.1234]
+    ndt = put_in ndt.calendar, FakeCalendar
+    assert_raise ArgumentError, "cannot convert #{inspect(ndt)} to the ISO 8601 format, because it does not use Calendar.ISO",
     fn ->
-      NaiveDateTime.to_iso8601(ndt1)
+      NaiveDateTime.to_iso8601(ndt)
     end
   end
 end


### PR DESCRIPTION
fixes #5864:

-  `NaiveDateTime.to_iso8601/1`  will raise a descriptive ArgumentError when a NaiveDateTimes that follow a non-Calendar.ISO calendar is passed to it.
- A test to ensure that this indeed works as intended.
- (Tests for the happy path where a NDT that has Calendar.ISO are not added, as the doctests of `NaiveDateTime.to_iso8601/1` already cover this).