### PR TITLE
Complete typespecs and guards for Module module

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -733,7 +733,10 @@ defmodule Module do
       end
 
   """
-  def defines?(module, tuple) when is_atom(module) and is_tuple(tuple) and tuple_size(tuple) == 2 do
+  @spec defines?(module, {function_macro_name :: atom, arity}) :: boolean
+  def defines?(module, {function_macro_name, arity} = tuple)
+      when is_atom(module) and is_atom(function_macro_name)
+      and is_integer(arity) and arity >= 0 and arity <= 255 do
     assert_not_compiled!(:defines?, module)
     table = defs_table_for(module)
     :ets.lookup(table, {:def, tuple}) != []
@@ -757,9 +760,11 @@ defmodule Module do
       end
 
   """
-  @spec defines?(module, {function_name :: atom, arity}, :def | :defp | :defmacro | :defmacrop) :: boolean
-  def defines?(module, tuple, kind)
-      when is_atom(module) and is_tuple(tuple) and tuple_size(tuple) == 2 and kind in [:def, :defp, :defmacro, :defmacrop] do
+  @spec defines?(module, {function_macro_name :: atom, arity}, :def | :defp | :defmacro | :defmacrop) :: boolean
+  def defines?(module, {function_macro_name, arity} = tuple, kind)
+      when is_atom(module) and is_atom(function_macro_name)
+      and is_integer(arity) and arity >= 0 and arity <= 255
+      and kind in [:def, :defp, :defmacro, :defmacrop] do
     assert_not_compiled!(:defines?, module)
     table = defs_table_for(module)
     case :ets.lookup(table, {:def, tuple}) do
@@ -817,7 +822,8 @@ defmodule Module do
   def make_overridable(module, tuples) when is_atom(module) and is_list(tuples) do
     assert_not_compiled!(:make_overridable, module)
 
-    :lists.foreach(fn {function_name, arity} = tuple when is_atom(function_name) and is_integer(arity) and arity >= 0 and arity <= 255 ->
+    :lists.foreach(fn {function_name, arity} = tuple
+        when is_atom(function_name) and is_integer(arity) and arity >= 0 and arity <= 255 ->
       case :elixir_def.take_definition(module, tuple) do
         false ->
           raise ArgumentError,

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -739,8 +739,8 @@ defmodule Module do
 
   """
   @spec defines?(module, definition) :: boolean
-  def defines?(module, {function_macro_name, arity} = tuple)
-      when is_atom(module) and is_atom(function_macro_name) and
+  def defines?(module, {function_or_macro_name, arity} = tuple)
+      when is_atom(module) and is_atom(function_or_macro_name) and
            is_integer(arity) and arity >= 0 and arity <= 255 do
     assert_not_compiled!(:defines?, module)
     table = defs_table_for(module)

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -351,6 +351,8 @@ defmodule Module do
   the documentation for the [`:compile` module](http://www.erlang.org/doc/man/compile.html).
   '''
 
+  @type function_arity :: {atom, arity}
+
   @doc """
   Provides runtime information about functions and macros defined by the
   module, enables docstring extraction, etc.
@@ -576,7 +578,7 @@ defmodule Module do
   """
   @spec add_doc(module, non_neg_integer,
                 :def | :defp | :defmacro | :defmacrop | :type | :typep | :opaque,
-                {function_name :: atom, arity}, list, String.t | boolean | nil)
+                function_arity, list, String.t | boolean | nil)
       :: :ok | {:error, :private_doc}
   def add_doc(module, line, kind, function_tuple, signature \\ [], doc)
 
@@ -733,7 +735,7 @@ defmodule Module do
       end
 
   """
-  @spec defines?(module, {function_macro_name :: atom, arity}) :: boolean
+  @spec defines?(module, function_arity) :: boolean
   def defines?(module, {function_macro_name, arity} = tuple)
       when is_atom(module) and is_atom(function_macro_name)
       and is_integer(arity) and arity >= 0 and arity <= 255 do
@@ -760,7 +762,7 @@ defmodule Module do
       end
 
   """
-  @spec defines?(module, {function_macro_name :: atom, arity}, :def | :defp | :defmacro | :defmacrop) :: boolean
+  @spec defines?(module, function_arity, :def | :defp | :defmacro | :defmacrop) :: boolean
   def defines?(module, {function_macro_name, arity} = tuple, kind)
       when is_atom(module) and is_atom(function_macro_name)
       and is_integer(arity) and arity >= 0 and arity <= 255
@@ -784,7 +786,7 @@ defmodule Module do
       end
 
   """
-  @spec definitions_in(module) :: [{function_name :: atom, arity}]
+  @spec definitions_in(module) :: [function_arity]
   def definitions_in(module) when is_atom(module) do
     assert_not_compiled!(:definitions_in, module)
     table = defs_table_for(module)
@@ -804,7 +806,7 @@ defmodule Module do
       end
 
   """
-  @spec definitions_in(module, atom) :: [{function_name :: atom, arity}]
+  @spec definitions_in(module, atom) :: [function_arity]
   def definitions_in(module, kind) when is_atom(module) and is_atom(kind) do
     assert_not_compiled!(:definitions_in, module)
     table = defs_table_for(module)
@@ -818,7 +820,7 @@ defmodule Module do
   developer to customize it. See `Kernel.defoverridable/1` for
   more information and documentation.
   """
-  @spec make_overridable(module, [{function_name :: atom, arity}]) :: :ok | no_return
+  @spec make_overridable(module, [function_arity]) :: :ok | no_return
   def make_overridable(module, tuples) when is_atom(module) and is_list(tuples) do
     assert_not_compiled!(:make_overridable, module)
 
@@ -850,7 +852,7 @@ defmodule Module do
   @doc """
   Returns `true` if `tuple` in `module` is marked as overridable.
   """
-  @spec overridable?(module, {function_name :: atom, arity}) :: boolean
+  @spec overridable?(module, function_arity) :: boolean
   def overridable?(module, {function_name, arity} = tuple) when is_atom(function_name) and is_integer(arity) and arity >= 0 and arity <= 255 do
     :maps.is_key(tuple, :elixir_overridable.overridable(module))
   end

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -351,9 +351,9 @@ defmodule Module do
   the documentation for the [`:compile` module](http://www.erlang.org/doc/man/compile.html).
   '''
 
-  @type function_arity :: {atom, arity}
-  @type def_kind :: :def | :defp | :defmacro | :defmacrop
-  @type type_kind :: :type | :typep | :opaque
+  @typep function_arity :: {atom, arity}
+  @typep def_kind :: :def | :defp | :defmacro | :defmacrop
+  @typep type_kind :: :type | :typep | :opaque
 
   @doc """
   Provides runtime information about functions and macros defined by the
@@ -590,8 +590,8 @@ defmodule Module do
   end
 
   def add_doc(module, line, kind, function_tuple, signature, doc)
-      when kind in [:def, :defmacro, :type, :opaque]
-      and (is_binary(doc) or is_boolean(doc) or doc == nil) do
+      when kind in [:def, :defmacro, :type, :opaque] and
+           (is_binary(doc) or is_boolean(doc) or doc == nil) do
     assert_not_compiled!(:add_doc, module)
     table = data_table_for(module)
 
@@ -853,7 +853,7 @@ defmodule Module do
 
       other ->
         raise ArgumentError,
-              "each element in tuple list has to be a {function_name :: atom, arity :: 1..255} tuple, got: #{inspect(other)}"
+              "each element in tuple list has to be a {function_name :: atom, arity :: 0..255} tuple, got: #{inspect(other)}"
     end, tuples)
   end
 
@@ -910,7 +910,7 @@ defmodule Module do
       end
 
   """
-  @spec get_attribute(module, atom) :: (term)
+  @spec get_attribute(module, atom) :: term
   def get_attribute(module, key) when is_atom(module) and is_atom(key) do
     get_attribute(module, key, nil)
   end
@@ -928,7 +928,7 @@ defmodule Module do
       end
 
   """
-  @spec delete_attribute(module, atom) :: (term)
+  @spec delete_attribute(module, atom) :: term
   def delete_attribute(module, key) when is_atom(module) and is_atom(key) do
     assert_not_compiled!(:delete_attribute, module)
     table = data_table_for(module)
@@ -976,7 +976,7 @@ defmodule Module do
 
   """
   @spec register_attribute(module, attribute :: atom, opts :: [{:accumulate, boolean}, {:persist, boolean}])
-      :: :ok | no_return
+      :: :ok
   def register_attribute(module, attribute, opts) when is_atom(module) and is_atom(attribute) do
     assert_not_compiled!(:register_attribute, module)
     table = data_table_for(module)

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -310,4 +310,29 @@ defmodule ModuleTest do
       assert Module.definitions_in(__MODULE__, :defp) == []
     end
   end
+
+  describe "make_overridable/2" do
+    test "succeed" do
+      contents =
+        quote do
+          def foo(), do: :ok
+          Module.make_overridable(__MODULE__, [{:foo, 0}])
+        end
+
+      assert {:module, Foo, _binary, :ok} = Module.create(Foo, contents, __ENV__)
+    end
+
+    test "raise" do
+      contents =
+        quote do
+          Module.make_overridable(__MODULE__, [{:foo, 256}])
+        end
+
+      assert_raise ArgumentError,
+        "each element in tuple list has to be a {function_name :: atom, arity :: 1..255} tuple, got: {:foo, 256}",
+        fn ->
+        Module.create(Foo, contents, __ENV__)
+      end
+    end
+  end
 end

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -50,11 +50,17 @@ defmodule ModuleTest do
   end
   Module.eval_quoted __MODULE__, contents, [], file: "sample.ex", line: 13
 
+  defp purge(modules) do
+    Enum.each modules, fn(m) ->
+      :code.purge(m)
+      :code.delete(m)
+    end
+  end
+
   defmacrop in_module(block) do
     quote do
       defmodule Temp, unquote(block)
-      :code.purge(Temp)
-      :code.delete(Temp)
+      purge [Temp]
     end
   end
 
@@ -311,7 +317,7 @@ defmodule ModuleTest do
     end
   end
 
-  describe "make_overridable/2" do
+  describe "make_overridable/2 arguments" do
     test "succeed" do
       contents =
         quote do
@@ -320,6 +326,8 @@ defmodule ModuleTest do
         end
 
       assert {:module, Foo, _binary, :ok} = Module.create(Foo, contents, __ENV__)
+    after
+      purge [Foo]
     end
 
     test "raise" do
@@ -333,6 +341,8 @@ defmodule ModuleTest do
         fn ->
         Module.create(Foo, contents, __ENV__)
       end
+    after
+      purge [Foo]
     end
   end
 end

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -317,32 +317,18 @@ defmodule ModuleTest do
     end
   end
 
-  describe "make_overridable/2 arguments" do
-    test "succeed" do
-      contents =
-        quote do
-          def foo(), do: :ok
-          Module.make_overridable(__MODULE__, [{:foo, 0}])
-        end
-
-      assert {:module, Foo, _binary, :ok} = Module.create(Foo, contents, __ENV__)
-    after
-      purge [Foo]
-    end
-
-    test "raise" do
-      contents =
-        quote do
-          Module.make_overridable(__MODULE__, [{:foo, 256}])
-        end
-
-      assert_raise ArgumentError,
-        "each element in tuple list has to be a {function_name :: atom, arity :: 1..255} tuple, got: {:foo, 256}",
-        fn ->
-        Module.create(Foo, contents, __ENV__)
+  test "make_overridable/2 with bad arguments" do
+    contents =
+      quote do
+        Module.make_overridable(__MODULE__, [{:foo, 256}])
       end
-    after
-      purge [Foo]
+
+    assert_raise ArgumentError,
+      "each element in tuple list has to be a {function_name :: atom, arity :: 0..255} tuple, got: {:foo, 256}",
+      fn ->
+      Module.create(Foo, contents, __ENV__)
     end
+  after
+    purge [Foo]
   end
 end

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -50,17 +50,15 @@ defmodule ModuleTest do
   end
   Module.eval_quoted __MODULE__, contents, [], file: "sample.ex", line: 13
 
-  defp purge(modules) do
-    Enum.each modules, fn(m) ->
-      :code.purge(m)
-      :code.delete(m)
-    end
+  defp purge(module) do
+    :code.purge(module)
+    :code.delete(module)
   end
 
   defmacrop in_module(block) do
     quote do
       defmodule Temp, unquote(block)
-      purge [Temp]
+      purge Temp
     end
   end
 
@@ -317,7 +315,7 @@ defmodule ModuleTest do
     end
   end
 
-  test "make_overridable/2 with bad arguments" do
+  test "make_overridable/2 with invalid arguments" do
     contents =
       quote do
         Module.make_overridable(__MODULE__, [{:foo, 256}])
@@ -329,6 +327,6 @@ defmodule ModuleTest do
       Module.create(Foo, contents, __ENV__)
     end
   after
-    purge [Foo]
+    purge Foo
   end
 end


### PR DESCRIPTION
There are plenty of changes, that's why the [WIP], but it all guards and typespecs are complete for this module.

There is a common argument which is the `{<function/macro atom>, <arity>}` tuple,
and it make me think whether we need to create a new `type` for this. 