### PR TITLE
Do not truncate Logger timestamps

### DIFF
--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -251,7 +251,7 @@ defmodule Logger.Utils do
   Formats time as chardata.
   """
   def format_time({hh, mi, ss, ms}) do
-    [pad2(hh), ?:, pad2(mi), ?:, pad2(ss), ?., pad3(ms)]
+    [pad2(hh), ?:, pad2(mi), ?:, pad2(ss), ?., ms]
   end
 
   @doc """
@@ -260,10 +260,6 @@ defmodule Logger.Utils do
   def format_date({yy, mm, dd}) do
     [Integer.to_string(yy), ?-, pad2(mm), ?-, pad2(dd)]
   end
-
-  defp pad3(int) when int < 10,  do: [?0, ?0, Integer.to_string(int)]
-  defp pad3(int) when int < 100, do: [?0, Integer.to_string(int)]
-  defp pad3(int), do: Integer.to_string(int)
 
   defp pad2(int) when int < 10, do: [?0, Integer.to_string(int)]
   defp pad2(int), do: Integer.to_string(int)

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -251,7 +251,7 @@ defmodule Logger.Utils do
   Formats time as chardata.
   """
   def format_time({hh, mi, ss, ms}) do
-    [pad2(hh), ?:, pad2(mi), ?:, pad2(ss), ?., pad6(ms)]
+    [pad2(hh), ?:, pad2(mi), ?:, pad2(ss), ?., ms |> div(1000) |> pad3()]
   end
 
   @doc """
@@ -261,12 +261,9 @@ defmodule Logger.Utils do
     [Integer.to_string(yy), ?-, pad2(mm), ?-, pad2(dd)]
   end
 
-  defp pad6(int) when int < 10,  do: [?0, ?0, ?0, ?0, ?0, Integer.to_string(int)]
-  defp pad6(int) when int < 100, do: [?0, ?0, ?0, ?0, Integer.to_string(int)]
-  defp pad6(int) when int < 1_000, do: [?0, ?0, ?0, Integer.to_string(int)]
-  defp pad6(int) when int < 10_000, do: [?0, ?0, Integer.to_string(int)]
-  defp pad6(int) when int < 100_000, do: [?0, Integer.to_string(int)]
-  defp pad6(int), do: Integer.to_string(int)
+  defp pad3(int) when int < 10,  do: [?0, ?0, Integer.to_string(int)]
+  defp pad3(int) when int < 100, do: [?0, Integer.to_string(int)]
+  defp pad3(int), do: Integer.to_string(int)
 
   defp pad2(int) when int < 10, do: [?0, Integer.to_string(int)]
   defp pad2(int), do: Integer.to_string(int)

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -244,7 +244,7 @@ defmodule Logger.Utils do
         true  -> :calendar.now_to_universal_time(now)
         false -> :calendar.now_to_local_time(now)
       end
-    {date, {hours, minutes, seconds, div(micro, 1000)}}
+    {date, {hours, minutes, seconds, micro}}
   end
 
   @doc """

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -251,7 +251,7 @@ defmodule Logger.Utils do
   Formats time as chardata.
   """
   def format_time({hh, mi, ss, ms}) do
-    [pad2(hh), ?:, pad2(mi), ?:, pad2(ss), ?., ms]
+    [pad2(hh), ?:, pad2(mi), ?:, pad2(ss), ?., pad6(ms)]
   end
 
   @doc """
@@ -260,6 +260,13 @@ defmodule Logger.Utils do
   def format_date({yy, mm, dd}) do
     [Integer.to_string(yy), ?-, pad2(mm), ?-, pad2(dd)]
   end
+
+  defp pad6(int) when int < 10,  do: [?0, ?0, ?0, ?0, ?0, Integer.to_string(int)]
+  defp pad6(int) when int < 100, do: [?0, ?0, ?0, ?0, Integer.to_string(int)]
+  defp pad6(int) when int < 1_000, do: [?0, ?0, ?0, Integer.to_string(int)]
+  defp pad6(int) when int < 10_000, do: [?0, ?0, Integer.to_string(int)]
+  defp pad6(int) when int < 100_000, do: [?0, Integer.to_string(int)]
+  defp pad6(int), do: Integer.to_string(int)
 
   defp pad2(int) when int < 10, do: [?0, Integer.to_string(int)]
   defp pad2(int), do: Integer.to_string(int)


### PR DESCRIPTION
Is there any reason why the precision on `Logger` timestamps is being truncated? If so, can this be commented / documented somewhere?

A few reasons we should _not_ do this:

1. We're seeing log messages share the same timestamp, thus presenting them out of order in external logging systems.
2. The syslog specification allows up to a microsecond precision: https://tools.ietf.org/html/rfc5424
3. The backend should be solely responsible for removing precision.

Thanks for taking a look!