### PR TITLE
Add missing word in URI module doc

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -3,7 +3,7 @@ defmodule URI do
   Utilities for working with URIs.
 
   This module provides functions for working with URIs (for example, parsing
-  URIs or encoding query strings). The functions in this are implemented
+  URIs or encoding query strings). The functions in this module are implemented
   acrroding to [RFC 3986](https://tools.ietf.org/html/rfc3986).
   """
 


### PR DESCRIPTION
Fixes missing words removed in https://github.com/elixir-lang/elixir/commit/b191f6bf1f767f93c752370a851f45549a8d6b45