### PR TITLE
Reword String.to_float documentation

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1900,10 +1900,9 @@ defmodule String do
   @doc """
   Returns a float whose text representation is `string`.
 
-  `string` must be the string representation of a float.
-  If a string representation of an integer wants to be used,
-  then `Float.parse/1` should be used instead,
-  otherwise an argument error will be raised.
+  `string` must be the string representation of a float including a decimal point.
+  In order to parse a string without decimal point as a float then `Float.parse/1`
+  should be used. Otherwise, an `ArgumentError` will be raised.
 
   Inlined by the compiler.
 
@@ -1914,6 +1913,9 @@ defmodule String do
 
       iex> String.to_float("3.0")
       3.0
+
+      String.to_float("3")
+      #=> ** (ArgumentError) argument error
 
   """
   @spec to_float(String.t) :: float


### PR DESCRIPTION
Clarify the difference between ```String.to_float/1``` and
```Float.parse/1```
