### PR TITLE
Add nonempty_charlist/0 built-in type

### DIFF
--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -106,6 +106,7 @@ Built-in type           | Defined as
 `byte()`                | `0..255`
 `char()`                | `0..0x10FFFF`
 `charlist()`            | `[char()]`
+`nonempty_charlist()`   | `[char(), ...]`
 `fun()`                 | `(... -> any)`
 `identifier()`          | `pid()` \| `port()` \| `reference()`
 `iodata()`              | `iolist()` \| `binary()`

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -11,9 +11,10 @@
 
 %% Top level types
 %% TODO: Remove char_list type by 2.0
--export_type([charlist/0, char_list/0, struct/0, as_boolean/1, keyword/0, keyword/1]).
+-export_type([charlist/0, char_list/0, nonempty_charlist/0, struct/0, as_boolean/1, keyword/0, keyword/1]).
 -type charlist() :: string().
 -type char_list() :: string().
+-type nonempty_charlist() :: nonempty_string().
 -type as_boolean(T) :: T.
 -type keyword() :: [{atom(), any()}].
 -type keyword(T) :: [{atom(), T}].

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -3,6 +3,8 @@ Code.require_file "../test_helper.exs", __DIR__
 defmodule Kernel.TypespecTest do
   use ExUnit.Case
 
+  import ExUnit.CaptureIO
+
   alias Kernel.TypespecTest.TestTypespec
 
   defstruct [:hello]
@@ -705,6 +707,7 @@ defmodule Kernel.TypespecTest do
       quote(do: @type builtin_byte() :: byte()),
       quote(do: @type builtin_char() :: char()),
       quote(do: @type builtin_charlist() :: charlist()),
+      quote(do: @type builtin_nonempty_charlist() :: nonempty_charlist()),
       quote(do: @type builtin_fun() :: fun()),
       quote(do: @type builtin_identifier() :: identifier()),
       quote(do: @type builtin_iodata() :: iodata()),
@@ -883,5 +886,25 @@ defmodule Kernel.TypespecTest do
         @spec my_fun(integer)
       end
     end
+  end
+
+  test "warn on discouraged types" do
+    message = capture_io(:stderr, fn ->
+      test_module do
+        @type foo :: string()
+        @type bar :: nonempty_string()
+      end
+    end)
+
+    expected_string =
+      "string() type use is discouraged. " <>
+      "For character lists, use charlist() type, for strings, String.t()\n"
+
+    expected_nonempty_string =
+      "nonempty_string() type use is discouraged. " <>
+      "For non-empty character lists, use nonempty_charlist() type, for strings, String.t()\n"
+
+    assert message =~ expected_string
+    assert message =~ expected_nonempty_string
   end
 end


### PR DESCRIPTION
I think this is the only built-in type that we've been missing.
