### PR TITLE
Add metadata: :all option to Logger.Backends.Console

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -210,6 +210,7 @@ defmodule Logger do
 
     * `:metadata` - the metadata to be printed by `$metadata`.
       Defaults to an empty list (no metadata).
+      Setting `:metadata` to `:all` prints all metadata.
 
     * `:colors` - a keyword list of coloring options.
 

--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -93,12 +93,15 @@ defmodule Logger.Backends.Console do
     device = Keyword.get(config, :device, :user)
     format = Logger.Formatter.compile Keyword.get(config, :format)
     colors = configure_colors(config)
-    metadata = Keyword.get(config, :metadata, [])
+    metadata = Keyword.get(config, :metadata, []) |> configure_metadata()
     max_buffer = Keyword.get(config, :max_buffer, 32)
 
-    %{state | format: format, metadata: Enum.reverse(metadata),
+    %{state | format: format, metadata: metadata,
               level: level, colors: colors, device: device, max_buffer: max_buffer}
   end
+
+  defp configure_metadata(:all), do: :all
+  defp configure_metadata(metadata), do: Enum.reverse(metadata)
 
   defp configure_merge(env, options) do
     Keyword.merge(env, options, fn
@@ -163,6 +166,7 @@ defmodule Logger.Backends.Console do
     |> color_event(level, colors, md)
   end
 
+  defp take_metadata(metadata, :all), do: metadata
   defp take_metadata(metadata, keys) do
     Enum.reduce keys, [], fn key, acc ->
       case Keyword.fetch(metadata, key) do

--- a/lib/logger/test/logger/backends/console_test.exs
+++ b/lib/logger/test/logger/backends/console_test.exs
@@ -70,6 +70,25 @@ defmodule Logger.Backends.ConsoleTest do
     "my_format: #{message}"
   end
 
+  test "can configure metadata to :all" do
+    Logger.configure_backend(:console, format: "$metadata$message", metadata: :all)
+
+    Logger.metadata(user_id: 11)
+    Logger.metadata(Keyword.new([{:"dynamic_metadata", 5}]))
+
+    %{module: mod, function: {name, arity}, file: file, line: line} = __ENV__
+
+    log_msg = capture_log(fn ->
+      Logger.debug("hello")
+    end)
+
+    assert log_msg =~ "file=#{file}"
+    assert log_msg =~ "line=#{line + 3}"
+    assert log_msg =~ "module=#{inspect(mod)}"
+    assert log_msg =~ "function=#{name}/#{arity}"
+    assert log_msg =~ "dynamic_metadata=5 user_id=11"
+  end
+
   test "metadata defaults" do
     Logger.configure_backend(:console,
       format: "$metadata", metadata: [:file, :line, :module, :function])

--- a/lib/logger/test/logger/backends/console_test.exs
+++ b/lib/logger/test/logger/backends/console_test.exs
@@ -58,6 +58,18 @@ defmodule Logger.Backends.ConsoleTest do
     end) =~ "user_id=13 hello"
   end
 
+  test "can configure formatter to {module, :func} tuple" do
+    Logger.configure_backend(:console, format: {__MODULE__, :format}, metadata: :all)
+
+    assert capture_log(fn ->
+      Logger.debug("hello")
+    end) =~ "my_format: hello"
+  end
+
+  def format(level, message, ts, metadata) do
+    "my_format: #{message}"
+  end
+
   test "metadata defaults" do
     Logger.configure_backend(:console,
       format: "$metadata", metadata: [:file, :line, :module, :function])


### PR DESCRIPTION
Hi José and friends!

As discussed on [elixir-lang-core](https://groups.google.com/d/msg/elixir-lang-core/CjVhZj0j7kk/m5bqZ3qfAwAJ) this pull-request adds a `:all` option to the `metadata` configuration option for `Logger.Backends.Console`.

In addition I added a test that verifies that you can configure the `format` option with a `{module, :func}` format.

I want to mention that I had some trouble running the tests. Unless I did a forced compile before running the tests I got random failing tests so I ended up running my tests using:
```
MIX_ENV=test mix do compile --force, test -- test/logger/backends/console_test.exs
```

Best regards

Simon Boisen
CTO, Lix Technologies