### PR TITLE
Add float overflow error message to Tokenizer

### DIFF
--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -794,7 +794,8 @@ tokenize_number([H | T], Acc, Length, Bool) when ?is_digit(H) ->
 
 %% Cast to float...
 tokenize_number(Rest, Acc, Length, true) ->
-  try {Rest, list_to_float(lists:reverse(Acc)), Length}
+  try
+    {Rest, list_to_float(lists:reverse(Acc)), Length}
   catch
     error:badarg -> {error, "float number out of range ", lists:reverse(Acc)}
   end;

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -797,7 +797,7 @@ tokenize_number(Rest, Acc, Length, true) ->
   try
     {Rest, list_to_float(lists:reverse(Acc)), Length}
   catch
-    error:badarg -> {error, "float number out of range ", lists:reverse(Acc)}
+    error:badarg -> {error, "invalid float number ", lists:reverse(Acc)}
   end;
 
 %% Or integer.

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -448,8 +448,12 @@ tokenize([$. | T], Line, Column, Scope, Tokens) ->
 % Integers and floats
 
 tokenize([H | T], Line, Column, Scope, Tokens) when ?is_digit(H) ->
-  {Rest, Number, Length} = tokenize_number(T, [H], 1, false),
-  tokenize(Rest, Line, Column + Length, Scope, [{number, {Line, Column, Column + Length}, Number} | Tokens]);
+  case tokenize_number(T, [H], 1, false) of
+    {error, Reason, Number} ->
+      {error, {Line, Reason, Number}, T, Tokens};
+    {Rest, Number, Length} ->
+      tokenize(Rest, Line, Column + Length, Scope, [{number, {Line, Column, Column + Length}, Number} | Tokens])
+  end;
 
 % Identifiers (including aliases)
 
@@ -790,7 +794,10 @@ tokenize_number([H | T], Acc, Length, Bool) when ?is_digit(H) ->
 
 %% Cast to float...
 tokenize_number(Rest, Acc, Length, true) ->
-  {Rest, list_to_float(lists:reverse(Acc)), Length};
+  try {Rest, list_to_float(lists:reverse(Acc)), Length}
+  catch
+    error:badarg -> {error, "float number out of range ", lists:reverse(Acc)}
+  end;
 
 %% Or integer.
 tokenize_number(Rest, Acc, Length, false) ->

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -27,7 +27,7 @@ op_kw_test() ->
 scientific_test() ->
   [{number, {1, 1, 7}, 0.1}] = tokenize("1.0e-1"),
   [{number, {1, 1, 16}, 1.2345678e-7}] = tokenize("1_234.567_8e-10"),
-  {1, "float number out of range ", "1.0e309"} = tokenize_error("1.0e309").
+  {1, "invalid float number ", "1.0e309"} = tokenize_error("1.0e309").
 
 hex_bin_octal_test() ->
   [{number, {1, 1, 5}, 255}] = tokenize("0xFF"),
@@ -76,7 +76,7 @@ float_test() ->
   [{eol, {1, 1, 2}}, {number, {3, 1, 5}, 12.3}] = tokenize("\n\n12.3"),
   [{number, {1, 3, 7}, 12.3}, {number, {1, 9, 13}, 23.4}] = tokenize("  12.3  23.4  "),
   OversizedFloat = string:copies("9", 310) ++ ".0",
-  {1, "float number out of range ", OversizedFloat} = tokenize_error(OversizedFloat).
+  {1, "invalid float number ", OversizedFloat} = tokenize_error(OversizedFloat).
 
 comments_test() ->
   [{number, {1, 1, 2}, 1}, {eol, {1, 3, 4}}, {number, {2, 1, 2}, 2}] = tokenize("1 # Comment\n2").

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -26,7 +26,8 @@ op_kw_test() ->
 
 scientific_test() ->
   [{number, {1, 1, 7}, 0.1}] = tokenize("1.0e-1"),
-  [{number, {1, 1, 16}, 1.2345678e-7}] = tokenize("1_234.567_8e-10").
+  [{number, {1, 1, 16}, 1.2345678e-7}] = tokenize("1_234.567_8e-10"),
+  {1, "float number out of range ", "1.0e309"} = tokenize_error("1.0e309").
 
 hex_bin_octal_test() ->
   [{number, {1, 1, 5}, 255}] = tokenize("0xFF"),
@@ -73,7 +74,9 @@ float_test() ->
   [{number, {1, 1, 5}, 12.3}] = tokenize("12.3"),
   [{number, {1, 1, 5}, 12.3}, {';', {1, 5, 6}}] = tokenize("12.3;"),
   [{eol, {1, 1, 2}}, {number, {3, 1, 5}, 12.3}] = tokenize("\n\n12.3"),
-  [{number, {1, 3, 7}, 12.3}, {number, {1, 9, 13}, 23.4}] = tokenize("  12.3  23.4  ").
+  [{number, {1, 3, 7}, 12.3}, {number, {1, 9, 13}, 23.4}] = tokenize("  12.3  23.4  "),
+  OversizedFloat = string:copies("9", 310) ++ ".0",
+  {1, "float number out of range ", OversizedFloat} = tokenize_error(OversizedFloat).
 
 comments_test() ->
   [{number, {1, 1, 2}, 1}, {eol, {1, 3, 4}}, {number, {2, 1, 2}, 2}] = tokenize("1 # Comment\n2").


### PR DESCRIPTION
Changes the error message to be

```Elixir
Interactive Elixir (1.5.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> 1.0e310
** (SyntaxError) iex:1: float number out of range 1.0e310
```
Instead of 
```Elixir
Interactive Elixir (1.4.2) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> 1.0e310           
** (ArgumentError) argument error
             :erlang.list_to_float('1.0e310')
    (elixir) src/elixir_tokenizer.erl:765: :elixir_tokenizer.tokenize_number/4
    (elixir) src/elixir_tokenizer.erl:423: :elixir_tokenizer.tokenize/5
```


