### PR TITLE
Fix the behaviour of defdelegate/2 with default arguments

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4169,14 +4169,16 @@ defmodule Kernel do
           "Kernel.defdelegate/2 :append_first option is deprecated")
       end
 
-      for fun <- List.wrap(funs),
-        {name, args, as, as_args} <- Kernel.Utils.defdelegate(fun, opts) do
-          unless Module.get_attribute(__MODULE__, :doc) do
-            @doc "See `#{inspect target}.#{as}/#{:erlang.length args}`."
-          end
-          def unquote(name)(unquote_splicing(args)) do
-            unquote(target).unquote(as)(unquote_splicing(as_args))
-          end
+      for fun <- List.wrap(funs) do
+        {name, args, as, as_args} = Kernel.Utils.defdelegate(fun, opts)
+
+        unless Module.get_attribute(__MODULE__, :doc) do
+          @doc "See `#{inspect target}.#{as}/#{:erlang.length args}`."
+        end
+
+        def unquote(name)(unquote_splicing(args)) do
+          unquote(target).unquote(as)(unquote_splicing(as_args))
+        end
       end
     end
   end


### PR DESCRIPTION
When default arguements (`\\`) are used with `defdelegate/2`, a function is generated for each default argument and each generated function calls the delegate target function with the same arity. For example:

```elixir
defdelegate demonitor(monitor_ref, options \\ []), to: :erlang
```

will be expanded to

```elixir
def demonitor(monitor_ref), do: :erlang.demonitor(monitor_ref)
def demonitor(monitor_ref, options), do: :erlang.demonitor(monitor_ref, options)
```

However, this seems to "break" the expectation that optional arguments set: when a function has optional arguments, all the additional functions with lower arity that are generated by the default arguments only call the function with maximum arity with the default values provided for the optional arguments.

This means that if `:erlang.demonitor/1` had a different behaviour than `:erlang.demonitor/2`, then it would be hard to guess why because the expectation is that `demonitor(monitor_ref)` only calls `demonitor(monitor_ref, [])`, ending up always to `:erlang.demonitor/2`.

This PR fixes this by leaving the signature of the functions to delegate untouched (with optional arguments if present).

With this PR, `defdelegate demonitor(monitor_ref, options \\ []), to :erlang` will become

```elixir
def demonitor(monitor_ref, options \\ []) do
  :erlang.demonitor(monitor_ref, options)
end
```