### PR TITLE
Mix archive.install parse file before installing

### DIFF
--- a/lib/mix/lib/mix/local/installer.ex
+++ b/lib/mix/lib/mix/local/installer.ex
@@ -104,10 +104,7 @@ defmodule Mix.Local.Installer do
     if opts[:force] || should_install?(name, src, previous_files) do
       case Mix.Utils.read_path(src, opts) do
         {:ok, binary} ->
-          case module.install(dst, binary, previous_files) do
-            :ok -> :ok
-            {:error, reason} -> Mix.raise "Installation failed: #{reason}"
-          end
+           module.install(dst, binary, previous_files)
 
         :badpath ->
           Mix.raise "Expected #{inspect src} to be a URL or a local file path"

--- a/lib/mix/lib/mix/local/installer.ex
+++ b/lib/mix/lib/mix/local/installer.ex
@@ -105,7 +105,7 @@ defmodule Mix.Local.Installer do
       case Mix.Utils.read_path(src, opts) do
         {:ok, binary} ->
           case module.install(dst, binary, previous_files) do
-            :ok -> nil
+            :ok -> :ok
             {:error, reason} -> Mix.raise "Installation failed: #{reason}"
           end
 

--- a/lib/mix/lib/mix/local/installer.ex
+++ b/lib/mix/lib/mix/local/installer.ex
@@ -104,7 +104,7 @@ defmodule Mix.Local.Installer do
     if opts[:force] || should_install?(name, src, previous_files) do
       case Mix.Utils.read_path(src, opts) do
         {:ok, binary} ->
-           module.install(dst, binary, previous_files)
+          module.install(dst, binary, previous_files)
 
         :badpath ->
           Mix.raise "Expected #{inspect src} to be a URL or a local file path"

--- a/lib/mix/lib/mix/local/installer.ex
+++ b/lib/mix/lib/mix/local/installer.ex
@@ -104,7 +104,10 @@ defmodule Mix.Local.Installer do
     if opts[:force] || should_install?(name, src, previous_files) do
       case Mix.Utils.read_path(src, opts) do
         {:ok, binary} ->
-          module.install(dst, binary, previous_files)
+          case module.install(dst, binary, previous_files) do
+            :ok -> nil
+            {:error, reason} -> Mix.raise "Installation failed: #{reason}"
+          end
 
         :badpath ->
           Mix.raise "Expected #{inspect src} to be a URL or a local file path"

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -114,7 +114,7 @@ defmodule Mix.Tasks.Archive.Install do
           |> Path.split()
           |> hd
 
-      Path.join(Path.dirname(ez_path), zip_root_dir)
+        Path.join(Path.dirname(ez_path), zip_root_dir)
       {:error, _reason} ->
         Mix.raise "Installation failed: Invalid archive file"
     end

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -109,7 +109,7 @@ defmodule Mix.Tasks.Archive.Install do
          {:zip_file, zip_first_path, _, _, _, _} = zip_first_file,
          [zip_root_dir | _] = Path.split(zip_first_path) do
 
-        Path.join(Path.dirname(ez_path), zip_root_dir)
+      Path.join(Path.dirname(ez_path), zip_root_dir)
     else
       _ ->
         Mix.raise "Installation failed: invalid archive file"

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -106,16 +106,13 @@ defmodule Mix.Tasks.Archive.Install do
   ### Private helpers
 
   defp resolve_destination(ez_path, contents) do
-    case :zip.list_dir(contents) do
-      {:ok, [_comment, zip_first_file | _]} ->
-        zip_root_dir =
-          zip_first_file
-          |> elem(1)
-          |> Path.split()
-          |> hd
+    with {:ok, [_comment, zip_first_file | _]} <- :zip.list_dir(contents),
+         {:zip_file, zip_first_path, _, _, _, _} = zip_first_file,
+         [zip_root_dir | _] = Path.split(zip_first_path) do
 
         Path.join(Path.dirname(ez_path), zip_root_dir)
-      {:error, _reason} ->
+    else
+      _ ->
         Mix.raise "Installation failed: Invalid archive file"
     end
   end

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -84,7 +84,6 @@ defmodule Mix.Tasks.Archive.Install do
   end
 
   def install(ez_path, contents, previous) do
-    # Get the directory name and extract it there
     dir_dest = resolve_destination(ez_path, contents)
 
     remove_previous_versions(previous)
@@ -113,7 +112,7 @@ defmodule Mix.Tasks.Archive.Install do
         Path.join(Path.dirname(ez_path), zip_root_dir)
     else
       _ ->
-        Mix.raise "Installation failed: Invalid archive file"
+        Mix.raise "Installation failed: invalid archive file"
     end
   end
 

--- a/lib/mix/test/mix/tasks/archive_test.exs
+++ b/lib/mix/test/mix/tasks/archive_test.exs
@@ -70,6 +70,23 @@ defmodule Mix.Tasks.ArchiveTest do
     end
   end
 
+  test "archive install invalid file" do
+    in_fixture "invalid_archive", fn ->
+      assert File.regular? 'bad-archive-0.1.0.ez'
+
+      send self(), {:mix_shell_input, :yes?, true}
+      assert_raise Mix.Error, ~r/Invalid archive file/, fn ->
+        Mix.Tasks.Archive.Install.run ["./bad-archive-0.1.0.ez"]
+      end
+    end
+  end
+
+  test "archive install missing file" do
+    assert_raise Mix.Error, ~r/Expected a local file path or a file/, fn ->
+      Mix.Tasks.Archive.Install.run ["./unlikely-to-exist-0.1.0.ez"]
+    end
+  end
+
   test "archive update" do
     in_fixture "archive", fn() ->
       # Install previous version

--- a/lib/mix/test/mix/tasks/archive_test.exs
+++ b/lib/mix/test/mix/tasks/archive_test.exs
@@ -71,12 +71,13 @@ defmodule Mix.Tasks.ArchiveTest do
   end
 
   test "archive install invalid file" do
-    in_fixture "invalid_archive", fn ->
-      assert File.regular? 'bad-archive-0.1.0.ez'
+    in_fixture "archive", fn ->
+      file_name = "invalid-archive-0.1.0.ez"
+      assert File.regular?(file_name)
 
       send self(), {:mix_shell_input, :yes?, true}
       assert_raise Mix.Error, ~r/Invalid archive file/, fn ->
-        Mix.Tasks.Archive.Install.run ["./bad-archive-0.1.0.ez"]
+        Mix.Tasks.Archive.Install.run [file_name]
       end
     end
   end

--- a/lib/mix/test/mix/tasks/archive_test.exs
+++ b/lib/mix/test/mix/tasks/archive_test.exs
@@ -76,7 +76,7 @@ defmodule Mix.Tasks.ArchiveTest do
       assert File.regular?(file_name)
 
       send self(), {:mix_shell_input, :yes?, true}
-      assert_raise Mix.Error, ~r/Invalid archive file/, fn ->
+      assert_raise Mix.Error, ~r/invalid archive file/, fn ->
         Mix.Tasks.Archive.Install.run [file_name]
       end
     end


### PR DESCRIPTION
This allows to ignore file naming convention and install correctly even if file name is changed.
Solves https://github.com/elixir-lang/elixir/issues/5882