### PR TITLE
Optimize Map.merge/3 by choosing merge direction

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -470,11 +470,11 @@ defmodule Map do
   def merge(map1, map2, callback) when is_function(callback, 3) do
     if map_size(map1) > map_size(map2) do
       :maps.fold fn key, val2, acc ->
-        update(acc, key, val2, fn(val1) -> callback.(key, val1, val2) end)
+        update(acc, key, val2, fn val1 -> callback.(key, val1, val2) end)
       end, map1, map2
     else
       :maps.fold fn key, val2, acc ->
-        update(acc, key, val2, fn(val1) -> callback.(key, val2, val1) end)
+        update(acc, key, val2, fn val1 -> callback.(key, val2, val1) end)
       end, map2, map1
     end
   end

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -468,9 +468,15 @@ defmodule Map do
   """
   @spec merge(map, map, (key, value, value -> value)) :: map
   def merge(map1, map2, callback) when is_function(callback, 3) do
-    :maps.fold fn k, v2, acc ->
-      update(acc, k, v2, fn(v1) -> callback.(k, v1, v2) end)
-    end, map1, map2
+    if map_size(map1) > map_size(map2) do
+      :maps.fold fn k, v2, acc ->
+        update(acc, k, v2, fn(v1) -> callback.(k, v1, v2) end)
+      end, map1, map2
+    else
+      :maps.fold fn k, v2, acc ->
+        update(acc, k, v2, fn(v1) -> callback.(k, v2, v1) end)
+      end, map2, map1
+    end
   end
 
   @doc """

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -469,12 +469,12 @@ defmodule Map do
   @spec merge(map, map, (key, value, value -> value)) :: map
   def merge(map1, map2, callback) when is_function(callback, 3) do
     if map_size(map1) > map_size(map2) do
-      :maps.fold fn k, v2, acc ->
-        update(acc, k, v2, fn(v1) -> callback.(k, v1, v2) end)
+      :maps.fold fn key, val2, acc ->
+        update(acc, key, val2, fn(val1) -> callback.(key, val1, val2) end)
       end, map1, map2
     else
-      :maps.fold fn k, v2, acc ->
-        update(acc, k, v2, fn(v1) -> callback.(k, v2, v1) end)
+      :maps.fold fn key, val2, acc ->
+        update(acc, key, val2, fn(val1) -> callback.(key, val2, val1) end)
       end, map2, map1
     end
   end

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -113,6 +113,16 @@ defmodule MapTest do
     end
   end
 
+  test "merge with function" do
+    #when source map is bigger
+    assert Map.merge(%{a: 1, b: 2, c: 3}, %{c: 4, d: 5}, fn :c, 3, 4 -> :x end) ==
+             %{a: 1, b: 2, c: :x, d: 5}
+
+    # When target map is bigger
+    assert Map.merge(%{b: 2, c: 3}, %{a: 1, c: 4, d: 5}, fn :c, 3, 4 -> :x end) ==
+             %{a: 1, b: 2, c: :x, d: 5}
+  end
+
   test "implements (almost) all functions in Keyword" do
     assert Keyword.__info__(:functions) -- Map.__info__(:functions) ==
            [delete: 3, delete_first: 2, get_values: 2, keyword?: 1, pop_first: 2, pop_first: 3]

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -113,7 +113,7 @@ defmodule MapTest do
     end
   end
 
-  test "merge with function" do
+  test "merge/3" do
     # When first map is bigger
     assert Map.merge(%{a: 1, b: 2, c: 3}, %{c: 4, d: 5}, fn :c, 3, 4 -> :x end) ==
            %{a: 1, b: 2, c: :x, d: 5}

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -114,13 +114,13 @@ defmodule MapTest do
   end
 
   test "merge with function" do
-    #when source map is bigger
+    # When first map is bigger
     assert Map.merge(%{a: 1, b: 2, c: 3}, %{c: 4, d: 5}, fn :c, 3, 4 -> :x end) ==
-             %{a: 1, b: 2, c: :x, d: 5}
+           %{a: 1, b: 2, c: :x, d: 5}
 
-    # When target map is bigger
+    # When second map is bigger
     assert Map.merge(%{b: 2, c: 3}, %{a: 1, c: 4, d: 5}, fn :c, 3, 4 -> :x end) ==
-             %{a: 1, b: 2, c: :x, d: 5}
+           %{a: 1, b: 2, c: :x, d: 5}
   end
 
   test "implements (almost) all functions in Keyword" do


### PR DESCRIPTION
This produces order of magnitude improvement on the best case, where source map is empty.

You can see benchmark [script](https://github.com/tsubery/misc_bench/pull/1) and results on [travis](https://travis-ci.org/tsubery/misc_bench/builds/212359883).