### PR TITLE
Add original values to context merging in ExUnit

### DIFF
--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -235,31 +235,31 @@ defmodule ExUnit.Callbacks do
 
   @doc false
   def __merge__(mod, context, value) do
-    __merge__(mod, context, value, value)
+    merge(mod, context, value, value)
   end
 
   @doc false
-  defp __merge__(_mod, context, :ok, _original_value) do
+  defp merge(_mod, context, :ok, _original_value) do
     context
   end
 
-  defp __merge__(mod, context, {:ok, value}, original_value) do
-    __merge__(mod, context, value, original_value)
+  defp merge(mod, context, {:ok, value}, original_value) do
+    merge(mod, context, value, original_value)
   end
 
-  defp __merge__(mod, _context, %{__struct__: _}, original_value) do
+  defp merge(mod, _context, %{__struct__: _}, original_value) do
     raise_merge_failed!(mod, original_value)
   end
 
-  defp __merge__(mod, context, data, original_value) when is_list(data) do
-    __merge__(mod, context, Map.new(data), original_value)
+  defp merge(mod, context, data, original_value) when is_list(data) do
+    merge(mod, context, Map.new(data), original_value)
   end
 
-  defp __merge__(mod, context, data, _original_value) when is_map(data) do
+  defp merge(mod, context, data, _original_value) when is_map(data) do
     context_merge(mod, context, data)
   end
 
-  defp __merge__(mod, _, _return_value, original_value) do
+  defp merge(mod, _, _return_value, original_value) do
     raise_merge_failed!(mod, original_value)
   end
 

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -234,28 +234,33 @@ defmodule ExUnit.Callbacks do
   end
 
   @doc false
-  def __merge__(_mod, context, :ok) do
+  def __merge__(mod, context, value) do
+    __merge__(mod, context, value, value)
+  end
+
+  @doc false
+  defp __merge__(_mod, context, :ok, _original_value) do
     context
   end
 
-  def __merge__(mod, context, {:ok, value}) do
-    __merge__(mod, context, value)
+  defp __merge__(mod, context, {:ok, value}, original_value) do
+    __merge__(mod, context, value, original_value)
   end
 
-  def __merge__(mod, _context, %{__struct__: _} = return_value) do
-    raise_merge_failed!(mod, return_value)
+  defp __merge__(mod, _context, %{__struct__: _}, original_value) do
+    raise_merge_failed!(mod, original_value)
   end
 
-  def __merge__(mod, context, data) when is_list(data) do
-    __merge__(mod, context, Map.new(data))
+  defp __merge__(mod, context, data, original_value) when is_list(data) do
+    __merge__(mod, context, Map.new(data), original_value)
   end
 
-  def __merge__(mod, context, data) when is_map(data) do
+  defp __merge__(mod, context, data, _original_value) when is_map(data) do
     context_merge(mod, context, data)
   end
 
-  def __merge__(mod, _, return_value) do
-    raise_merge_failed!(mod, return_value)
+  defp __merge__(mod, _, _return_value, original_value) do
+    raise_merge_failed!(mod, original_value)
   end
 
   defp context_merge(mod, context, data) do

--- a/lib/ex_unit/test/ex_unit/callbacks_test.exs
+++ b/lib/ex_unit/test/ex_unit/callbacks_test.exs
@@ -283,6 +283,26 @@ defmodule ExUnit.CallbacksTest do
     on_exit setup_all run
     """
   end
+
+  test "raises an error when setting an invalid callback in setup" do
+    defmodule SetupErrorTest do
+      use ExUnit.Case
+
+      setup do
+        {:ok, "foo"}
+      end
+
+      test "ok" do
+        :ok
+      end
+    end
+
+    ExUnit.Server.cases_loaded()
+    assert capture_io(fn -> ExUnit.run end) =~
+           "** (RuntimeError) expected ExUnit callback in " <>
+           "ExUnit.CallbacksTest.SetupErrorTest to return " <>
+           ":ok | keyword | map, got {:ok, \"foo\"} instead"
+  end
 end
 
 defmodule ExUnit.CallbacksNoTests do


### PR DESCRIPTION
Closes #5898.

Since 58377cd, `ExUnit.Callbacks.__merge/3` is a recursive function which drops the `:ok` atom from the passed value if the value is an ok-tuple. This caused potential errors raised by `raise_merge_failed!/2` to show only part of the passed value in the error message.

Returning `{:ok, "foo"}` from a setup block produced an error like this:

    ** (RuntimeError) expected [...] got \"foo\" instead

This patch adds `ExUnit.Callbacks.__merge/4`, which is called by `__merge__/3` with adds the original value as the fourth argument, to be able to display the full value:

    ** (RuntimeError) expected [...] got {:ok, \"foo\"} instead