### PR TITLE
Use passed value for raise_merge_reserved!/3

### DIFF
--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -266,7 +266,7 @@ defmodule ExUnit.Callbacks do
   defp context_merge(mod, context, data) do
     Map.merge(context, data, fn
       k, v1, v2 when k in @reserved ->
-        if v1 == v2, do: v1, else: raise_merge_reserved!(mod, k, v1)
+        if v1 == v2, do: v1, else: raise_merge_reserved!(mod, k, v2)
       _, _, v ->
         v
     end)

--- a/lib/ex_unit/test/ex_unit/callbacks_test.exs
+++ b/lib/ex_unit/test/ex_unit/callbacks_test.exs
@@ -303,6 +303,26 @@ defmodule ExUnit.CallbacksTest do
            "ExUnit.CallbacksTest.SetupErrorTest to return " <>
            ":ok | keyword | map, got {:ok, \"foo\"} instead"
   end
+
+  test "raises an error when overriding a reserved callback key in setup" do
+    defmodule SetupReservedTest do
+      use ExUnit.Case
+
+      setup do
+        {:ok, file: "foo"}
+      end
+
+      test "ok" do
+        :ok
+      end
+    end
+
+    ExUnit.Server.cases_loaded()
+    assert capture_io(fn -> ExUnit.run end) =~
+           "** (RuntimeError) ExUnit callback in " <>
+           "ExUnit.CallbacksTest.SetupReservedTest is " <>
+           "trying to set reserved field :file to \"foo\""
+  end
 end
 
 defmodule ExUnit.CallbacksNoTests do


### PR DESCRIPTION
While working on #5901, I found that the wrong value was passed to `ExUnit.Callbacks.raise_merge_reserved!/3`, which caused the current value to be used in the error message instead of the one passed in the context. With a setup block like this:

    setup do
      {:ok, file: "foo"}
    end

The error message uses the current `:file` value (the path to the test file) instead of the passed one ("foo"):

     ** (RuntimeError) ExUnit callback in MyAppTest is trying to set reserved field :file to "/path/to/test/my_app_test.exs"

This one-character patch uses the passed value instead, resulting in an error message like this:

     ** (RuntimeError) ExUnit callback in MyAppTest is trying to set reserved field :file to "foo"