### PR TITLE
Clarify starting value in scan/2 documentation

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1930,7 +1930,8 @@ defmodule Enum do
   @doc """
   Applies the given function to each element in the enumerable,
   storing the result in a list and passing it as the accumulator
-  for the next computation.
+  for the next computation. Uses the first element in the enumerable
+  as the starting value.
 
   ## Examples
 

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -576,7 +576,8 @@ defmodule Stream do
   @doc """
   Creates a stream that applies the given function to each
   element, emits the result and uses the same result as the accumulator
-  for the next computation.
+  for the next computation. Uses the first element in the enumerable
+  as the starting value.
 
   ## Examples
 


### PR DESCRIPTION
Because scan/2 and scan/3 examples had similar input and output, readers could mistake
the default value to be 0. The new code clarifies that.

p.s. Why don't we implement scan/2 by taking first the value and calling scan/3?