### PR TITLE
Validate options for comprehension

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -263,6 +263,7 @@ expand({for, Meta, [_ | _] = Args}, E) ->
         {Args, []}
     end,
 
+  validate_opts(Meta, for, [do, into], Block, E),
   {Expr, Opts} =
     case lists:keytake(do, 1, Block) of
       {value, {do, Do}, DoOpts} ->

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -476,6 +476,16 @@ defmodule Kernel.ExpansionTest do
         ~r"missing :do option in \"for\"",
         fn -> expand(quote do: for x <- 1..2) end
     end
+
+    test "raise error for unknown keywords" do
+      assert_raise CompileError,
+        ~r"unsupported option :else given to for",
+        fn -> expand(quote do: for x <- 1..2, do: a, else: 1) end
+
+      assert_raise CompileError,
+        ~r"unsupported option :intoo given to for",
+        fn -> expand(quote do: for x <- 1..2, do: a, intoo: 1) end
+    end
   end
 
   describe "with" do


### PR DESCRIPTION
This change raises error when invalid keys are give to "for" loops and
prevents silent errors.