### PR TITLE
Fix Module.split/1 to deal with atoms, and raise with strings

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -971,11 +971,12 @@ defmodule Module do
 
   """
   def split(module) when is_atom(module) do
-    split(String.Chars.to_string(module))
-  end
-
-  def split("Elixir." <> name) do
-    String.split(name, ".")
+    case Atom.to_string(module) do
+      "Elixir." <> name ->
+        String.split(name, ".")
+      name ->
+        [name]
+    end
   end
 
   @doc false

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -170,17 +170,32 @@ defmodule ModuleTest do
     end
   end
 
-  test "split" do
-    module = Very.Long.Module.Name.And.Even.Longer
-    assert Module.split(module) == ["Very", "Long", "Module", "Name", "And", "Even", "Longer"]
-    assert Module.split("Elixir.Very.Long") == ["Very", "Long"]
-    assert_raise FunctionClauseError, fn ->
-      Module.split(:just_an_atom)
+  describe "split/1" do
+    test "regular modules" do
+      module = Very.Long.Module.Name.And.Even.Longer
+      assert Module.split(module) == ["Very", "Long", "Module", "Name", "And", "Even", "Longer"]
+      assert Module.split(:"Elixir.Very.Long") == ["Very", "Long"]
+      assert Module.split(:just_an_atom) == ["just_an_atom"]
+      assert Module.concat(Module.split(module)) == module
     end
-    assert_raise FunctionClauseError, fn ->
-      Module.split("Foo")
+
+    test "edge cases" do
+      assert Module.split(:nil) == ["nil"]
+      assert Module.split(:"Elixir.nil") == ["nil"]
+
+      assert Module.split(:"") == [""]
+      assert Module.split(:"Elixir.") == [""]
     end
-    assert Module.concat(Module.split(module)) == module
+
+    test "raise" do
+      assert_raise FunctionClauseError, fn ->
+        Module.split("Foo")
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        Module.split("Elixir.Foo")
+      end
+    end
   end
 
   test "__MODULE__" do


### PR DESCRIPTION
Previously, Module.split(:module) would have raised, but
:module is a valid module name.

On the other hand, it would work with strings starting with "Elixir."

iex(1)> Module.split "Foo"
** (FunctionClauseError) no function clause matching in Module.split/1
    (elixir) lib/module.ex:971: Module.split("Foo")

iex(1)> Module.split "Elixir.Foo"
["Foo"]

So the fix raises a FunctionClause error on any string,
and it will convert any :atom to a string.

It also deals with the edge cases of: :nil and :""