### PR TITLE
Use GenServer.stop/3 instead of :gen.stop/3 in Agent.stop/3

### DIFF
--- a/lib/elixir/lib/agent.ex
+++ b/lib/elixir/lib/agent.ex
@@ -373,6 +373,6 @@ defmodule Agent do
   """
   @spec stop(agent, reason :: term, timeout) :: :ok
   def stop(agent, reason \\ :normal, timeout \\ :infinity) do
-    :gen.stop(agent, reason, timeout)
+    GenServer.stop(agent, reason, timeout)
   end
 end


### PR DESCRIPTION
`GenServer.stop/3` is available and it calls `:gen.stop/3` anyways, but at least this way we consistently call out to the `GenServer` module :)