### PR TITLE
{Map, Keyword}.replace/3 and replace!/3

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -757,6 +757,20 @@ defmodule KeyError do
   end
 end
 
+defmodule KeyExistsError do
+  defexception [:key, :term]
+
+  def message(exception) do
+    msg = "key #{inspect exception.key} already exists"
+    if exception.term != nil do
+      msg <> " in: #{inspect exception.term}"
+    else
+      msg
+    end
+  end
+end
+
+
 defmodule UnicodeConversionError do
   defexception [:encoded, :message]
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -757,19 +757,6 @@ defmodule KeyError do
   end
 end
 
-defmodule KeyExistsError do
-  defexception [:key, :term]
-
-  def message(exception) do
-    msg = "key #{inspect exception.key} already exists"
-    if exception.term != nil do
-      msg <> " in: #{inspect exception.term}"
-    else
-      msg
-    end
-  end
-end
-
 defmodule UnicodeConversionError do
   defexception [:encoded, :message]
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -770,7 +770,6 @@ defmodule KeyExistsError do
   end
 end
 
-
 defmodule UnicodeConversionError do
   defexception [:encoded, :message]
 

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -559,7 +559,7 @@ defmodule Keyword do
   def put_new(keywords, key, value) when is_list(keywords) and is_atom(key) do
     case :lists.keyfind(key, 1, keywords) do
       {^key, _} -> keywords
-      false     -> [{key, value} | keywords]
+      false -> [{key, value} | keywords]
     end
   end
 
@@ -579,7 +579,7 @@ defmodule Keyword do
   def put_new!(keywords, key, value) when is_list(keywords) and is_atom(key) do
     case :lists.keyfind(key, 1, keywords) do
       {^key, _} -> raise KeyExistsError, key: key, term: keywords
-      false     -> [{key, value} | keywords]
+      false -> [{key, value} | keywords]
     end
   end
 
@@ -602,7 +602,7 @@ defmodule Keyword do
   def put_existing(keywords, key, value) when is_list(keywords) and is_atom(key) do
     case :lists.keyfind(key, 1, keywords) do
       {^key, _} -> [{key, value} | keywords]
-      false     -> keywords
+      false -> keywords
     end
   end
 
@@ -622,7 +622,7 @@ defmodule Keyword do
   def put_existing!(keywords, key, value) when is_list(keywords) and is_atom(key) do
     case :lists.keyfind(key, 1, keywords) do
       {^key, _} -> [{key, value} | keywords]
-      false     -> raise KeyError, key: key, term: keywords
+      false -> raise KeyError, key: key, term: keywords
     end
   end
 

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -572,10 +572,10 @@ defmodule Keyword do
 
   ## Examples
 
-  iex> Keyword.replace([a: 1], :b, 2)
-  [a: 1]
-  iex> Keyword.replace([a: 1, b: 2, a: 4], :a, 3)
-  [a: 3, b: 2]
+      iex> Keyword.replace([a: 1], :b, 2)
+      [a: 1]
+      iex> Keyword.replace([a: 1, b: 2, a: 4], :a, 3)
+      [a: 3, b: 2]
 
   """
   @spec replace(t, key, value) :: t

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -559,7 +559,70 @@ defmodule Keyword do
   def put_new(keywords, key, value) when is_list(keywords) and is_atom(key) do
     case :lists.keyfind(key, 1, keywords) do
       {^key, _} -> keywords
-      false -> [{key, value} | keywords]
+      false     -> [{key, value} | keywords]
+    end
+  end
+
+  @doc """
+  Similar to `put_new/3`, but will raise a `KeyExistsError`
+  if the entry `key` already exists.
+
+  ## Examples
+
+      iex> Keyword.put_new!([a: 1], :b, 2)
+      [b: 2, a: 1]
+      iex> Keyword.put_new!([a: 1, b: 2], :a, 3)
+      ** (KeyExistsError) key :a already exists in: [a: 1, b: 2]
+
+  """
+  @spec put_new!(t, key, value) :: t
+  def put_new!(keywords, key, value) when is_list(keywords) and is_atom(key) do
+    case :lists.keyfind(key, 1, keywords) do
+      {^key, _} -> raise KeyExistsError, key: key, term: keywords
+      false     -> [{key, value} | keywords]
+    end
+  end
+
+  @doc """
+  Puts the given `value` under `key`, but only if the entry `key`
+  already exists.
+
+  Note that the previously existing value is _not_ deleted from the keyword list,
+  and is still accessable using `Keyword.get_values/2`
+
+  ## Examples
+
+  iex> Keyword.put_existing([a: 1], :b, 2)
+  [a: 1]
+  iex> Keyword.put_existing([a: 1, b: 2], :a, 3)
+  [a: 3, a: 1, b: 2]
+
+  """
+  @spec put_existing(t, key, value) :: t
+  def put_existing(keywords, key, value) when is_list(keywords) and is_atom(key) do
+    case :lists.keyfind(key, 1, keywords) do
+      {^key, _} -> [{key, value} | keywords]
+      false     -> keywords
+    end
+  end
+
+  @doc """
+  Similar to `put_existing/3`, but will raise a `KeyError`
+  if the entry `key` does not exist.
+
+  ## Examples
+
+      iex> Keyword.put_existing!([a: 1, b: 2], :a, 3)
+      [a: 3, a: 1, b: 2]
+      iex> Keyword.put_existing!([a: 1], :b, 2)
+      ** (KeyError) key :b not found in: [a: 1]
+
+  """
+  @spec put_existing!(t, key, value) :: t
+  def put_existing!(keywords, key, value) when is_list(keywords) and is_atom(key) do
+    case :lists.keyfind(key, 1, keywords) do
+      {^key, _} -> [{key, value} | keywords]
+      false     -> raise KeyError, key: key, term: keywords
     end
   end
 

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -564,64 +564,44 @@ defmodule Keyword do
   end
 
   @doc """
-  Similar to `put_new/3`, but will raise a `KeyExistsError`
-  if the entry `key` already exists.
+  Alters the value stored under `key` to `value`, but only
+  if the entry `key` already exists in the keyword list.
+
+  In the case a value is stored multiple times in the keyword list,
+  later occurrences are removed.
 
   ## Examples
 
-      iex> Keyword.put_new!([a: 1], :b, 2)
-      [b: 2, a: 1]
-      iex> Keyword.put_new!([a: 1, b: 2], :a, 3)
-      ** (KeyExistsError) key :a already exists in: [a: 1, b: 2]
-
-  """
-  @spec put_new!(t, key, value) :: t
-  def put_new!(keywords, key, value) when is_list(keywords) and is_atom(key) do
-    case :lists.keyfind(key, 1, keywords) do
-      {^key, _} -> raise KeyExistsError, key: key, term: keywords
-      false -> [{key, value} | keywords]
-    end
-  end
-
-  @doc """
-  Puts the given `value` under `key`, but only if the entry `key`
-  already exists.
-
-  Note that the previously existing value is _not_ deleted from the keyword list,
-  and is still accessable using `Keyword.get_values/2`
-
-  ## Examples
-
-  iex> Keyword.put_existing([a: 1], :b, 2)
+  iex> Keyword.replace([a: 1], :b, 2)
   [a: 1]
-  iex> Keyword.put_existing([a: 1, b: 2], :a, 3)
-  [a: 3, a: 1, b: 2]
+  iex> Keyword.replace([a: 1, b: 2, a: 4], :a, 3)
+  [a: 3, b: 2]
 
   """
-  @spec put_existing(t, key, value) :: t
-  def put_existing(keywords, key, value) when is_list(keywords) and is_atom(key) do
+  @spec replace(t, key, value) :: t
+  def replace(keywords, key, value) when is_list(keywords) and is_atom(key) do
     case :lists.keyfind(key, 1, keywords) do
-      {^key, _} -> [{key, value} | keywords]
+      {^key, _} -> [{key, value} | delete(keywords, key)]
       false -> keywords
     end
   end
 
   @doc """
-  Similar to `put_existing/3`, but will raise a `KeyError`
+  Similar to `replace/3`, but will raise a `KeyError`
   if the entry `key` does not exist.
 
   ## Examples
 
-      iex> Keyword.put_existing!([a: 1, b: 2], :a, 3)
-      [a: 3, a: 1, b: 2]
-      iex> Keyword.put_existing!([a: 1], :b, 2)
+      iex> Keyword.replace!([a: 1, b: 2, a: 4], :a, 3)
+      [a: 3, b: 2]
+      iex> Keyword.replace!([a: 1], :b, 2)
       ** (KeyError) key :b not found in: [a: 1]
 
   """
-  @spec put_existing!(t, key, value) :: t
-  def put_existing!(keywords, key, value) when is_list(keywords) and is_atom(key) do
+  @spec replace!(t, key, value) :: t
+  def replace!(keywords, key, value) when is_list(keywords) and is_atom(key) do
     case :lists.keyfind(key, 1, keywords) do
-      {^key, _} -> [{key, value} | keywords]
+      {^key, _} -> [{key, value} | delete(keywords, key)]
       false -> raise KeyError, key: key, term: keywords
     end
   end

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -271,7 +271,7 @@ defmodule Map do
   @spec put_new(map, key, value) :: map
   def put_new(map, key, value) do
     case has_key?(map, key) do
-      true  -> map
+      true -> map
       false -> put(map, key, value)
     end
   end
@@ -291,7 +291,7 @@ defmodule Map do
   @spec put_new!(map, key, value) :: map
   def put_new!(map, key, value) do
     case has_key?(map, key) do
-      true  -> raise KeyExistsError, key: key, term: map
+      true -> raise KeyExistsError, key: key, term: map
       false -> put(map, key, value)
     end
   end
@@ -312,7 +312,7 @@ defmodule Map do
   @spec put_existing(map, key, value) :: map
   def put_existing(map, key, value) do
     case has_key?(map, key) do
-      true  -> put(map, key, value)
+      true -> put(map, key, value)
       false -> map
     end
   end
@@ -332,7 +332,7 @@ defmodule Map do
   @spec put_existing!(map, key, value) :: map
   def put_existing!(map, key, value) do
     case has_key?(map, key) do
-      true  -> put(map, key, value)
+      true -> put(map, key, value)
       false -> raise KeyError, key: key, term: map
     end
   end
@@ -361,7 +361,7 @@ defmodule Map do
   @spec put_new_lazy(map, key, (() -> value)) :: map
   def put_new_lazy(map, key, fun) when is_function(fun, 0) do
     case has_key?(map, key) do
-      true  -> map
+      true -> map
       false -> put(map, key, fun.())
     end
   end

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -94,7 +94,7 @@ defmodule Map do
 
   @type key :: any
   @type value :: any
-  @compile {:inline, fetch: 2, put: 3, delete: 2, has_key?: 2}
+  @compile {:inline, fetch: 2, put: 3, delete: 2, has_key?: 2, replace: 3}
 
   @doc """
   Returns all keys from `map`.
@@ -277,64 +277,40 @@ defmodule Map do
   end
 
   @doc """
-  Similar to `put_new/3`, but will raise a `KeyExistsError`
-  if the key already exists in the map.
+  Alters the value stored under `key` to `value`, but only
+  if the entry `key` already exists in `map`.
 
   ## Examples
 
-      iex> Map.put_new!(%{a: 1}, :b, 2)
-      %{a: 1, b: 2}
-      iex> Map.put_new!(%{a: 1, b: 2}, :a, 3)
-      ** (KeyExistsError) key :a already exists in: %{a: 1, b: 2}
-
-  """
-  @spec put_new!(map, key, value) :: map
-  def put_new!(map, key, value) do
-    case has_key?(map, key) do
-      true -> raise KeyExistsError, key: key, term: map
-      false -> put(map, key, value)
-    end
-  end
-
-
-  @doc """
-  Puts the given `value` under `key`, but only if the entry `key`
-  already exists in `map`.
-
-  ## Examples
-
-  iex> Map.put_existing(%{a: 1}, :b, 2)
+  iex> Map.replace(%{a: 1}, :b, 2)
   %{a: 1}
-  iex> Map.put_existing(%{a: 1, b: 2}, :a, 3)
+  iex> Map.replace(%{a: 1, b: 2}, :a, 3)
   %{a: 3, b: 2}
 
   """
-  @spec put_existing(map, key, value) :: map
-  def put_existing(map, key, value) do
+  @spec replace(map, key, value) :: map
+  def replace(map, key, value) do
     case has_key?(map, key) do
-      true -> put(map, key, value)
+      true -> :maps.update(key, value, map)
       false -> map
     end
   end
 
   @doc """
-  Similar to `put_existing/3`, but will raise a `KeyError`
+  Similar to `replace/3`, but will raise a `KeyError`
   if the key does not exist in the map.
 
   ## Examples
 
-      iex> Map.put_existing!(%{a: 1, b: 2}, :a, 3)
+      iex> Map.replace!(%{a: 1, b: 2}, :a, 3)
       %{a: 3, b: 2}
-      iex> Map.put_existing!(%{a: 1}, :b, 2)
+      iex> Map.replace!(%{a: 1}, :b, 2)
       ** (KeyError) key :b not found in: %{a: 1}
 
   """
-  @spec put_existing!(map, key, value) :: map
-  def put_existing!(map, key, value) do
-    case has_key?(map, key) do
-      true -> put(map, key, value)
-      false -> raise KeyError, key: key, term: map
-    end
+  @spec replace!(map, key, value) :: map
+  def replace!(map, key, value) do
+    :maps.update(key, value, map)
   end
 
   @doc """

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -282,10 +282,10 @@ defmodule Map do
 
   ## Examples
 
-  iex> Map.replace(%{a: 1}, :b, 2)
-  %{a: 1}
-  iex> Map.replace(%{a: 1, b: 2}, :a, 3)
-  %{a: 3, b: 2}
+      iex> Map.replace(%{a: 1}, :b, 2)
+      %{a: 1}
+      iex> Map.replace(%{a: 1, b: 2}, :a, 3)
+      %{a: 3, b: 2}
 
   """
   @spec replace(map, key, value) :: map

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -285,7 +285,7 @@ defmodule Map do
       iex> Map.put_new!(%{a: 1}, :b, 2)
       %{a: 1, b: 2}
       iex> Map.put_new!(%{a: 1, b: 2}, :a, 3)
-      ** (KeyExistsError) key :a already exists in %{a: 1, b: 2}
+      ** (KeyExistsError) key :a already exists in: %{a: 1, b: 2}
 
   """
   @spec put_new!(map, key, value) :: map
@@ -323,9 +323,9 @@ defmodule Map do
 
   ## Examples
 
-      iex> Map.put_existing(%{a: 1, b: 2}, :a, 3)
+      iex> Map.put_existing!(%{a: 1, b: 2}, :a, 3)
       %{a: 3, b: 2}
-      iex> Map.put_existing(%{a: 1}, :b, 2)
+      iex> Map.put_existing!(%{a: 1}, :b, 2)
       ** (KeyError) key :b not found in: %{a: 1}
 
   """

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -277,6 +277,67 @@ defmodule Map do
   end
 
   @doc """
+  Similar to `put_new/3`, but will raise a `KeyExistsError`
+  if the key already exists in the map.
+
+  ## Examples
+
+      iex> Map.put_new!(%{a: 1}, :b, 2)
+      %{a: 1, b: 2}
+      iex> Map.put_new!(%{a: 1, b: 2}, :a, 3)
+      ** (KeyExistsError) key :a already exists in %{a: 1, b: 2}
+
+  """
+  @spec put_new!(map, key, value) :: map
+  def put_new!(map, key, value) do
+    case has_key?(map, key) do
+      true  -> raise KeyExistsError, key: key, term: map
+      false -> put(map, key, value)
+    end
+  end
+
+
+  @doc """
+  Puts the given `value` under `key`, but only if the entry `key`
+  already exists in `map`.
+
+  ## Examples
+
+  iex> Map.put_existing(%{a: 1}, :b, 2)
+  %{a: 1}
+  iex> Map.put_existing(%{a: 1, b: 2}, :a, 3)
+  %{a: 3, b: 2}
+
+  """
+  @spec put_existing(map, key, value) :: map
+  def put_existing(map, key, value) do
+    case has_key?(map, key) do
+      true  -> put(map, key, value)
+      false -> map
+    end
+  end
+
+  @doc """
+  Similar to `put_existing/3`, but will raise a `KeyError`
+  if the key does not exist in the map.
+
+  ## Examples
+
+      iex> Map.put_existing(%{a: 1, b: 2}, :a, 3)
+      %{a: 3, b: 2}
+      iex> Map.put_existing(%{a: 1}, :b, 2)
+      ** (KeyError) key :b not found in: %{a: 1}
+
+  """
+  @spec put_existing!(map, key, value) :: map
+  def put_existing!(map, key, value) do
+    case has_key?(map, key) do
+      true  -> put(map, key, value)
+      false -> raise KeyError, key: key, term: map
+    end
+  end
+
+  @doc """
   Evaluates `fun` and puts the result under `key`
   in `map` unless `key` is already present.
 


### PR DESCRIPTION
Culmination of [this discussion on the Elixir Forum](https://elixirforum.com/t/updating-structs-map-put-vs-foo-oldfoo-new-value-vs-put-in/4246?u=qqwy).

~~This Pull Request adds the following:~~

- `Map.put_new!/3` which raises a `KeyExistsError` if the key that should be inserted already exists.
- `Map.put_existing/3` which only puts a value in the given map if the key already existed.
- `Map.put_existing!/3` which only puts a value in the given map if the key already existed, and raises a `KeyError` if it did not.
- `Keyword.put_new!/3` which raises a `KeyExistsError` if the key that should be inserted already exists.
- `Keyword.put_existing/3` which only puts a value in the given keyword list if the key already existed.
- `Keyword.put_existing!/3` which only puts a value in the given keyword list if the key already existed, and raises a `KeyError` if it did not.
- The afore-mentioned `KeyExistsError` exception module.
- Documentation + Doctests for the above.

Note that `Keyword.put_existing` and `Keyword.put_existing!` add a new value to the front of the keyword list without removing the original one. I expect that this is the behaviour we want, but I wanted to draw attention to it to make sure.

----

After discussion below, this is changed to:

- `Map.replace/3` which only puts a value in the given map if the key already existed.
- `Map.replace!/3` which only puts a value in the given map if the key already existed, and raises a `KeyError` if it did not.
- `Keyword.replace/3` which only puts a value in the given keyword list if the key already existed. All earlier values with the same key are deleted from the keyword list.
- `Keyword.replace!/3` which only puts a value in the given keyword list if the key already existed, and raises a `KeyError` if it did not. All earlier values with the same key are deleted from the keyword list.



