### PR TITLE
Fix warning when asserting a pattern that always match

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -123,7 +123,7 @@ defmodule ExUnit.Assertions do
         end
       end)
 
-    match_case =
+    match_expr =
       no_warning(quote do
         case right do
           unquote(left) ->
@@ -140,8 +140,8 @@ defmodule ExUnit.Assertions do
 
     quote do
       right = unquote(right)
-      expr  = unquote(code)
-      unquote(vars) = unquote(match_case)
+      expr = unquote(code)
+      unquote(vars) = unquote(match_expr)
       right
     end
   end

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -123,10 +123,8 @@ defmodule ExUnit.Assertions do
         end
       end)
 
-    quote do
-      right = unquote(right)
-      expr  = unquote(code)
-      unquote(vars) =
+    match_case =
+      no_warning(quote do
         case right do
           unquote(left) ->
             unquote(return)
@@ -138,6 +136,12 @@ defmodule ExUnit.Assertions do
               message: "match (=) failed" <>
                        ExUnit.Assertions.__pins__(unquote(pins))
         end
+      end)
+
+    quote do
+      right = unquote(right)
+      expr  = unquote(code)
+      unquote(vars) = unquote(match_case)
       right
     end
   end


### PR DESCRIPTION
Assertion macro generated a case statement that can have patterns that
cannot match. For example:

```Elixir
test "warning" do
  assert a = %{a: 1}[:a]
  a #don't complain about unused var
end
```

Would generate the following output
```Bash
warning: this clause cannot match because a previous clause at line 7
always matches
```