### PR TITLE
Improve {(Naive)DateTime, Date, Time}.diff/2

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -1044,7 +1044,7 @@ defmodule Time do
 
     {0, {diff_parts, diff_ppd}}
     |> Calendar.ISO.rata_die_to_microseconds
-    |> System.convert_time_unit(unit, :microseconds)
+    |> System.convert_time_unit(:microseconds, unit)
   end
 
   ## Helpers
@@ -1310,7 +1310,7 @@ defmodule NaiveDateTime do
     {diff_days, {diff_parts, diff_ppd}}
     |> normalize_rata_die
     |> Calendar.ISO.rata_die_to_microseconds
-    |> System.convert_time_unit(unit, :microseconds)
+    |> System.convert_time_unit(:microseconds, unit)
   end
 
   @doc """
@@ -2278,7 +2278,7 @@ defmodule DateTime do
       ...>                 hour: 23, minute: 0, second: 7, microsecond: {0, 0},
       ...>                 utc_offset: 3600, std_offset: 0, time_zone: "Europe/Warsaw"}
       iex> DateTime.diff(dt1, dt2)
-      18000000000000000
+      18000
   """
   @spec diff(DateTime.t, DateTime.t) :: Calendar.rata_die
   def diff(%DateTime{utc_offset: utc_offset1, std_offset: std_offset1} = datetime1,
@@ -2304,7 +2304,7 @@ defmodule DateTime do
     {diff_days, {diff_parts, diff_ppd}}
     |> normalize_rata_die
     |> Calendar.ISO.rata_die_to_microseconds
-    |> System.convert_time_unit(unit, :microseconds)
+    |> System.convert_time_unit(:microseconds, unit)
   end
 
   @doc """

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -1042,9 +1042,7 @@ defmodule Time do
     diff_parts = div(diff_parts, gcd)
     diff_ppd = div(diff_ppd, gcd)
 
-    {0, {diff_parts, diff_ppd}}
-    |> Calendar.ISO.rata_die_to_microseconds
-    |> System.convert_time_unit(:microseconds, unit)
+    Calendar.ISO.rata_die_to_unit({0, {diff_parts, diff_ppd}}, unit)
   end
 
   ## Helpers
@@ -1304,8 +1302,7 @@ defmodule NaiveDateTime do
 
     {diff_days, {diff_parts, diff_ppd}}
     |> normalize_rata_die
-    |> Calendar.ISO.rata_die_to_microseconds
-    |> System.convert_time_unit(:microseconds, unit)
+    |> Calendar.ISO.rata_die_to_unit(unit)
   end
 
   @doc """
@@ -2293,8 +2290,7 @@ defmodule DateTime do
 
     {diff_days, {diff_parts, diff_ppd}}
     |> normalize_rata_die
-    |> Calendar.ISO.rata_die_to_microseconds
-    |> System.convert_time_unit(:microseconds, unit)
+    |> Calendar.ISO.rata_die_to_unit(unit)
   end
 
   @doc """

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -1057,11 +1057,6 @@ defmodule Time do
     calendar.time_to_day_fraction(hour, minute, second, {microsecond, 0})
   end
 
-  defp to_microsecond({hour, minute, second, {microsecond, _}}) do
-    seconds = hour * 3600 + minute * 60 + second
-    seconds * 1_000_000 + microsecond
-  end
-
   defp gcd(a, 0), do: abs(a)
   defp gcd(0, b), do: abs(b)
   defp gcd(a, b) when a < 0 or b < 0, do: gcd(abs(a), abs(b))
@@ -1300,8 +1295,8 @@ defmodule NaiveDateTime do
       raise ArgumentError, "cannot calculate the difference between #{inspect naive_datetime1} and #{inspect naive_datetime2} because their calendars are not compatible and thus the result would be ambiguous"
     end
 
-    {days1, {parts1, ppd1}} = to_rata_die(datetime1)
-    {days2, {parts2, ppd2}} = to_rata_die(datetime2)
+    {days1, {parts1, ppd1}} = to_rata_die(naive_datetime1)
+    {days2, {parts2, ppd2}} = to_rata_die(naive_datetime2)
 
     diff_days = days1 - days2
     diff_ppd = ppd1 * ppd2
@@ -1708,6 +1703,11 @@ defmodule NaiveDateTime do
   defp normalize_rata_die({diff_days, {diff_parts, diff_ppd}}) do
     {diff_days, {diff_parts, diff_ppd}}
   end
+
+  defp gcd(a, 0), do: abs(a)
+  defp gcd(0, b), do: abs(b)
+  defp gcd(a, b) when a < 0 or b < 0, do: gcd(abs(a), abs(b))
+  defp gcd(a, b), do: gcd(b, rem(a,b))
 
   defimpl String.Chars do
     def to_string(%{calendar: calendar, year: year, month: month, day: day,

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -1038,7 +1038,7 @@ defmodule Time do
     diff_parts = parts1 * ppd2 - parts2 * ppd1
 
     # Keep integers in day fraction low.
-    gcd = gcd(diff_parts, diff_ppd)
+    gcd = Integer.gcd(diff_parts, diff_ppd)
     diff_parts = div(diff_parts, gcd)
     diff_ppd = div(diff_ppd, gcd)
 
@@ -1056,11 +1056,6 @@ defmodule Time do
   defp to_day_fraction(%{hour: hour, minute: minute, second: second, microsecond: microsecond, calendar: calendar}) do
     calendar.time_to_day_fraction(hour, minute, second, {microsecond, 0})
   end
-
-  defp gcd(a, 0), do: abs(a)
-  defp gcd(0, b), do: abs(b)
-  defp gcd(a, b) when a < 0 or b < 0, do: gcd(abs(a), abs(b))
-  defp gcd(a, b), do: gcd(b, rem(a,b))
 
   defimpl String.Chars do
     def to_string(%{hour: hour, minute: minute, second: second, microsecond: microsecond, calendar: calendar}) do
@@ -1303,7 +1298,7 @@ defmodule NaiveDateTime do
     diff_parts = parts1 * ppd2 - parts2 * ppd1
 
     # Keep integers in day fraction low.
-    gcd = gcd(diff_parts, diff_ppd)
+    gcd = Integer.gcd(diff_parts, diff_ppd)
     diff_parts = div(diff_parts, gcd)
     diff_ppd = div(diff_ppd, gcd)
 
@@ -1703,11 +1698,6 @@ defmodule NaiveDateTime do
   defp normalize_rata_die({diff_days, {diff_parts, diff_ppd}}) do
     {diff_days, {diff_parts, diff_ppd}}
   end
-
-  defp gcd(a, 0), do: abs(a)
-  defp gcd(0, b), do: abs(b)
-  defp gcd(a, b) when a < 0 or b < 0, do: gcd(abs(a), abs(b))
-  defp gcd(a, b), do: gcd(b, rem(a,b))
 
   defimpl String.Chars do
     def to_string(%{calendar: calendar, year: year, month: month, day: day,
@@ -2297,7 +2287,7 @@ defmodule DateTime do
     diff_parts = parts1 * ppd2 - parts2 * ppd1
 
     # Keep integers in day fraction low.
-    gcd = gcd(diff_parts, diff_ppd)
+    gcd = Integer.gcd(diff_parts, diff_ppd)
     diff_parts = div(diff_parts, gcd)
     diff_ppd = div(diff_ppd, gcd)
 
@@ -2363,7 +2353,7 @@ defmodule DateTime do
 
     parts = parts * offset_ppd
     offset = offset * ppd
-    gcd = gcd(ppd, offset_ppd)
+    gcd = Integer.gcd(ppd, offset_ppd)
     result_parts = div(parts - offset, gcd)
     result_ppd = div(ppd * offset_ppd, gcd)
     days_offset = div(result_parts, result_ppd)
@@ -2377,9 +2367,4 @@ defmodule DateTime do
   defp normalize_rata_die({diff_days, {diff_parts, diff_ppd}}) do
     {diff_days, {diff_parts, diff_ppd}}
   end
-
-  defp gcd(a, 0), do: abs(a)
-  defp gcd(0, b), do: abs(b)
-  defp gcd(a, b) when a < 0 or b < 0, do: gcd(abs(a), abs(b))
-  defp gcd(a, b), do: gcd(b, rem(a,b))
 end

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -242,6 +242,18 @@ defmodule Calendar.ISO do
       zone_to_string(utc_offset, std_offset, zone_abbr, time_zone)
   end
 
+  def valid_date?(year, month, day) do
+    :calendar.valid_date(year, month, day) and year <= 9999
+  end
+
+  def valid_time?(hour, minute, second, {microsecond, _}) do
+    hour in 0..23 and minute in 0..59 and second in 0..60 and microsecond in 0..999_999
+  end
+
+  def day_rollover_relative_to_midnight_utc do
+    {0, 1}
+  end
+
   defp offset_to_string(0, 0, "Etc/UTC"), do: "Z"
   defp offset_to_string(utc, std, _zone) do
     total  = utc + std
@@ -380,15 +392,10 @@ defmodule Calendar.ISO do
     end
   end
 
-  def valid_date?(year, month, day) do
-    :calendar.valid_date(year, month, day) and year <= 9999
-  end
-
-  def valid_time?(hour, minute, second, {microsecond, _}) do
-    hour in 0..23 and minute in 0..59 and second in 0..60 and microsecond in 0..999_999
-  end
-
-  def day_rollover_relative_to_midnight_utc do
-    {0, 1}
+  @doc false
+  def rata_die_to_microseconds(days, {parts, ppd}) do
+    day_seconds = days * 86400
+    seconds = div(parts * 86400, ppd)
+    microseconds = 1_000_000 * (day_seconds + seconds)
   end
 end

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -25,8 +25,6 @@ defmodule Calendar.ISO do
   @seconds_per_day 24 * 60 * 60 # Note that this does _not_ handle Leap Seconds.
   @microseconds_per_second 1_000_000
 
-  import Integer, only: [floor_div: 2]
-
   @doc """
   Returns the normalized Rata Die representation of the specified date.
 
@@ -393,9 +391,9 @@ defmodule Calendar.ISO do
   end
 
   @doc false
-  def rata_die_to_microseconds(days, {parts, ppd}) do
+  def rata_die_to_microseconds({days, {parts, ppd}}) do
     day_seconds = days * 86400
     seconds = div(parts * 86400, ppd)
-    microseconds = 1_000_000 * (day_seconds + seconds)
+    1_000_000 * (day_seconds + seconds)
   end
 end

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -391,9 +391,9 @@ defmodule Calendar.ISO do
   end
 
   @doc false
-  def rata_die_to_microseconds({days, {parts, ppd}}) do
+  def rata_die_to_unit({days, {parts, ppd}}, unit) do
     day_microseconds = days * @seconds_per_day * @microseconds_per_second
     microseconds = div(parts * @seconds_per_day * @microseconds_per_second, ppd)
-    day_microseconds + microseconds
+    System.convert_time_unit(day_microseconds + microseconds, :microseconds, unit)
   end
 end

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -392,8 +392,8 @@ defmodule Calendar.ISO do
 
   @doc false
   def rata_die_to_microseconds({days, {parts, ppd}}) do
-    day_seconds = days * 86400
-    seconds = div(parts * 86400, ppd)
-    1_000_000 * (day_seconds + seconds)
+    day_microseconds = days * @seconds_per_day * @microseconds_per_second
+    microseconds = div(parts * @seconds_per_day * @microseconds_per_second, ppd)
+    day_microseconds + microseconds
   end
 end

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -403,7 +403,8 @@ defmodule Integer do
       ** (ArithmeticError) bad argument in arithmetic expression
 
   """
-  @spec gcd(integer, integer) :: integer
+  @spec gcd(integer, integer) :: pos_integer
+  @spec gcd(0, 0) :: no_return
   def gcd(a, b)
   def gcd(0, 0), do: raise ArithmeticError
   def gcd(a, 0), do: abs(a)

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -383,7 +383,6 @@ defmodule Integer do
   @doc """
   Returns the greatest common divisor of the two given numbers.
 
-
   This is the largest positive integer that divides both `a` and `b` without leaving a remainder.
 
   ## Examples

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -380,6 +380,38 @@ defmodule Integer do
     :erlang.integer_to_list(integer, base)
   end
 
+  @doc """
+  Returns the greatest common divisor of the two given numbers.
+
+
+  This is the largest positive integer that divides both `a` and `b` without leaving a remainder.
+
+  ## Examples
+
+      iex> Integer.gcd(2, 4)
+      2
+      iex> Integer.gcd(2, 3)
+      1
+      iex> Integer.gcd(12, 8)
+      4
+      iex> Integer.gcd(54, 24)
+      6
+      iex> Integer.gcd(-54, 24)
+      6
+      iex> Integer.gcd(10, 0)
+      10
+      iex> Integer.gcd(0, 0)
+      ** (ArithmeticError) bad argument in arithmetic expression
+
+  """
+  @spec gcd(integer, integer) :: integer
+  def gcd(a, b)
+  def gcd(0, 0), do: raise ArithmeticError
+  def gcd(a, 0), do: abs(a)
+  def gcd(0, b), do: abs(b)
+  def gcd(a, b) when a < 0 or b < 0, do: gcd(abs(a), abs(b))
+  def gcd(a, b), do: gcd(b, rem(a,b))
+
   # TODO: Remove by 2.0
   # (hard-deprecated in elixir_dispatch)
   @doc false

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -405,12 +405,14 @@ defmodule Integer do
   """
   @spec gcd(integer, integer) :: pos_integer
   @spec gcd(0, 0) :: no_return
-  def gcd(a, b)
-  def gcd(0, 0), do: raise ArithmeticError
-  def gcd(a, 0), do: abs(a)
-  def gcd(0, b), do: abs(b)
-  def gcd(a, b) when a < 0 or b < 0, do: gcd(abs(a), abs(b))
-  def gcd(a, b), do: gcd(b, rem(a,b))
+  def gcd(int1, int2) when is_integer(int1) and is_integer(int2) do
+    int_gcd(int1, int2)
+  end
+  defp int_gcd(0, 0), do: raise ArithmeticError
+  defp int_gcd(a, 0), do: abs(a)
+  defp int_gcd(0, b), do: abs(b)
+  defp int_gcd(a, b) when a < 0 or b < 0, do: gcd(abs(a), abs(b))
+  defp int_gcd(a, b), do: gcd(b, rem(a,b))
 
   # TODO: Remove by 2.0
   # (hard-deprecated in elixir_dispatch)


### PR DESCRIPTION
- Uses a coherent and more efficient implementation for the difference functions that only converts to `System.time_unit` after the difference has been calculated using rata die / day fractions.
- Fixes a bug in the current implementation of `DateTime.diff`.

Fixes #5920.