### PR TITLE
Restore (deprecated) Integer.to_char_list/2

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -385,4 +385,10 @@ defmodule Integer do
   @doc false
   @spec to_char_list(integer) :: charlist
   def to_char_list(integer), do: Integer.to_charlist(integer)
+
+  # TODO: Remove by 2.0
+  # (hard-deprecated in elixir_dispatch)
+  @doc false
+  @spec to_char_list(integer, 2..36) :: charlist
+  def to_char_list(integer, base), do: Integer.to_charlist(integer, base)
 end

--- a/lib/elixir/src/elixir_dispatch.erl
+++ b/lib/elixir/src/elixir_dispatch.erl
@@ -387,6 +387,8 @@ deprecation('Elixir.Float', to_char_list, 1) ->
   "use Float.to_charlist/1";
 deprecation('Elixir.Integer', to_char_list, 1) ->
   "use Integer.to_charlist/1";
+deprecation('Elixir.Integer', to_char_list, 2) ->
+  "use Integer.to_charlist/2";
 deprecation('Elixir.String', to_char_list, 1) ->
   "use String.to_charlist/1";
 deprecation('Elixir.List.Chars', to_char_list, 1) ->

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -206,7 +206,8 @@ defmodule IntegerTest do
   end
 
   test "to_char_list/1" do
-    assert Integer.to_char_list(42) == '42'
+    integer = Integer
+    assert integer.to_char_list(42) == '42'
   end
 
   test "to_charlist/2" do
@@ -235,6 +236,7 @@ defmodule IntegerTest do
   end
 
   test "to_char_list/2" do
-    assert Integer.to_char_list(42, 2) == '101010'
+    integer = Integer
+    assert integer.to_char_list(42, 2) == '101010'
   end
 end

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -206,8 +206,8 @@ defmodule IntegerTest do
   end
 
   test "to_char_list/1" do
-    integer = Integer
-    assert integer.to_char_list(42) == '42'
+    module = Integer
+    assert module.to_char_list(42) == '42'
   end
 
   test "to_charlist/2" do
@@ -236,7 +236,7 @@ defmodule IntegerTest do
   end
 
   test "to_char_list/2" do
-    integer = Integer
-    assert integer.to_char_list(42, 2) == '101010'
+    module = Integer
+    assert module.to_char_list(42, 2) == '101010'
   end
 end

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -205,6 +205,10 @@ defmodule IntegerTest do
     end
   end
 
+  test "to_char_list/1" do
+    assert Integer.to_char_list(42) == '42'
+  end
+
   test "to_charlist/2" do
     assert Integer.to_charlist(42, 2) == '101010'
     assert Integer.to_charlist(42, 10) == '42'
@@ -228,5 +232,9 @@ defmodule IntegerTest do
         Integer.to_charlist(n, n)
       end
     end
+  end
+
+  test "to_char_list/2" do
+    assert Integer.to_char_list(42, 2) == '101010'
   end
 end


### PR DESCRIPTION
A regression was introduced in 9c0d6a that removed `Integer.to_char_list/2`, while it should have been hard-deprecated (in favour of `.to_charlist/2`) to be eventually removed in 2.0.

    ** (UndefinedFunctionError) function Integer.to_char_list/2 is undefined or private. Did you mean one of:

          * to_char_list/1

This patch adds `Integer.to_char_list/2` back, which calls `Integer.to_charlist/2` and is deprectated in dispatch, so it produces a deprecation warning (instead of an UndefinedFunctionError) when called:

    warning: Integer.to_char_list/2 is deprecated, use Integer.to_charlist/2

⚠️ I've added tests for both [`Integer.to_char_list/1`](https://github.com/jeffkreeftmeijer/elixir/blob/e37751ce1230075aae808bcb12dd2f0ac7a22eef/lib/elixir/test/elixir/integer_test.exs#L208-L210) and [`Integer.to_char_list/2`](https://github.com/jeffkreeftmeijer/elixir/blob/e37751ce1230075aae808bcb12dd2f0ac7a22eef/lib/elixir/test/elixir/integer_test.exs#L237-L239), to make sure this doesn't break again. However, these throw deprecation warnings in the test suite and I couldn't find any tests for other deprecated functions, so I'm unsure how this should be properly tested. Could you give me some guidance on that?