### PR TITLE
Add missing comma

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -254,7 +254,7 @@ defmodule Logger do
   `config/config.exs` file:
 
       config :logger, :console,
-        format: "\n$time $metadata[$level] $levelpad$message\n"
+        format: "\n$time $metadata[$level] $levelpad$message\n",
         metadata: [:user_id]
 
   #### Custom Formatting


### PR DESCRIPTION
Just a missing comma in the documentation of `Logger`.