### PR TITLE
Revises grammar in Mix.Config config template [ci skip]

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -352,15 +352,15 @@ defmodule Mix.Tasks.New do
   # if you want to provide default values for your application for
   # 3rd-party users, it should be done in your "mix.exs" file.
 
-  # You can configure for your application as:
+  # You can configure your application as:
   #
   #     config :<%= @app %>, key: :value
   #
-  # And access this configuration in your application as:
+  # and access this configuration in your application as:
   #
   #     Application.get_env(:<%= @app %>, :key)
   #
-  # Or configure a 3rd-party app:
+  # You can also configure a 3rd-party app:
   #
   #     config :logger, level: :info
   #


### PR DESCRIPTION
Saw the sentence

> You can configure for your application as:

Since I was on it, I believe the connection with the next line naturally flows as a single sentence, because a displayed code snippet is not a paragraph separator necessarily.

Then we can still start with uppercase the third one, reads well because it separates a "my app config" block from "3rd-party config".