### PR TITLE
Document the edge case Integer.gcd(0, 0)

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -384,6 +384,7 @@ defmodule Integer do
   Returns the greatest common divisor of the two given numbers.
 
   This is the largest positive integer that divides both `int1` and `int2` without leaving a remainder.
+  By convention, `Integer.gcd(0, 0)` returns 0.
 
   ## Examples
 


### PR DESCRIPTION
The description of `Integer.gcd`

> This is the largest positive integer that divides both `int1` and `int2` without leaving a remainder.

does not cover the edge case where both arguments are 0, because 0 divides no integer (and oftentimes 0 is not considered to be a positive number either, but that is a minor nuance).

The examples section does have a call that demonstrates the behaviour, but I guess users will be less surprised if the description is complete explaining the edge case, and explaining why does it return precisely 0.

This is a convention in its mathematical definition, it could return 7 for that matter, but it is convenient/practical to be defined as 0.

You can double-check this rationale in [Wolfram Alpha](https://www.wolframalpha.com/input/?i=gcd(0,0)) for example (click on "Step-by-step solution").