### PR TITLE
Adds a test suite for Integer.gcd/2

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -387,18 +387,18 @@ defmodule Integer do
 
   ## Examples
 
-      iex> Integer.gcd(2, 4)
-      2
       iex> Integer.gcd(2, 3)
       1
-      iex> Integer.gcd(12, 8)
+
+      iex> Integer.gcd(8, 12)
       4
-      iex> Integer.gcd(54, 24)
-      6
-      iex> Integer.gcd(-54, 24)
-      6
+
+      iex> Integer.gcd(8, -12)
+      4
+
       iex> Integer.gcd(10, 0)
       10
+
       iex> Integer.gcd(0, 0)
       0
 

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -239,4 +239,19 @@ defmodule IntegerTest do
     module = Integer
     assert module.to_char_list(42, 2) == '101010'
   end
+
+  test "gcd/2" do
+    assert Integer.gcd(1, 5) == 1
+    assert Integer.gcd(2, 3) == 1
+    assert Integer.gcd(8, 12) == 4
+    assert Integer.gcd(-8, 12) == 4
+    assert Integer.gcd(8, -12) == 4
+    assert Integer.gcd(-8, -12) == 4
+    assert Integer.gcd(27, 27) == 27
+    assert Integer.gcd(0, 3) == 3
+    assert Integer.gcd(0, -3) == 3
+    assert Integer.gcd(3, 0) == 3
+    assert Integer.gcd(-3, 0) == 3
+    assert Integer.gcd(0, 0) == 0
+  end
 end


### PR DESCRIPTION
The current examples for `Integer.gcd/2` have some redundancy, and the function itself has no test suite.

This patch selects some examples just for illustration purposes:

* There is one with coprime numbers.
* There is one where GCD is not 1.
* There is one with negative numbers.
* A couple involving 0s.

Then, the test suite has more stuff.