### PR TITLE
Reduce MapSet's space usage in Erlang term format

### DIFF
--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -34,10 +34,10 @@ defmodule MapSet do
 
   @type value :: term
 
-  @opaque t(value) :: %__MODULE__{map: %{optional(value) => []}}
+  @opaque t(value) :: %__MODULE__{data: %{optional(value) => []}}
   @type t :: t(term)
 
-  defstruct map: %{}
+  defstruct data: %{}
 
   @doc """
   Returns a new set.
@@ -72,7 +72,7 @@ defmodule MapSet do
       |> Enum.to_list
       |> new_from_list([])
 
-    %MapSet{map: map}
+    %MapSet{data: map}
   end
 
   @doc """
@@ -91,7 +91,7 @@ defmodule MapSet do
       |> Enum.to_list
       |> new_from_list_transform(transform, [])
 
-    %MapSet{map: map}
+    %MapSet{data: map}
   end
 
   defp new_from_list([], acc) do
@@ -123,8 +123,8 @@ defmodule MapSet do
 
   """
   @spec delete(t(val1), val2) :: t(val1) when val1: value, val2: value
-  def delete(%MapSet{map: map} = map_set, value) do
-    %{map_set | map: Map.delete(map, value)}
+  def delete(%MapSet{data: map} = map_set, value) do
+    %{map_set | data: Map.delete(map, value)}
   end
 
   @doc """
@@ -142,20 +142,20 @@ defmodule MapSet do
   # If the first set is less than twice the size of the second map,
   # it is fastest to re-accumulate items in the first set that are not
   # present in the second set.
-  def difference(%MapSet{map: map1}, %MapSet{map: map2})
+  def difference(%MapSet{data: map1}, %MapSet{data: map2})
       when map_size(map1) < map_size(map2) * 2 do
     map = map1
     |> Map.keys
     |> filter_not_in(map2)
 
-    %MapSet{map: map}
+    %MapSet{data: map}
   end
 
   # If the second set is less than half the size of the first set, it's fastest
   # to simply iterate through each item in the second set, deleting them from
   # the first set.
-  def difference(%MapSet{map: map1}, %MapSet{map: map2}) do
-    %MapSet{map: Map.drop(map1, Map.keys(map2))}
+  def difference(%MapSet{data: map1}, %MapSet{data: map2}) do
+    %MapSet{data: Map.drop(map1, Map.keys(map2))}
   end
 
   defp filter_not_in(keys, map2, acc \\ [])
@@ -181,7 +181,7 @@ defmodule MapSet do
 
   """
   @spec disjoint?(t, t) :: boolean
-  def disjoint?(%MapSet{map: map1}, %MapSet{map: map2}) do
+  def disjoint?(%MapSet{data: map1}, %MapSet{data: map2}) do
     {map1, map2} = order_by_size(map1, map2)
 
     map1
@@ -213,7 +213,7 @@ defmodule MapSet do
 
   """
   @spec equal?(t, t) :: boolean
-  def equal?(%MapSet{map: map1}, %MapSet{map: map2}) do
+  def equal?(%MapSet{data: map1}, %MapSet{data: map2}) do
     Map.equal?(map1, map2)
   end
 
@@ -230,10 +230,10 @@ defmodule MapSet do
 
   """
   @spec intersection(t(val), t(val)) :: t(val) when val: value
-  def intersection(%MapSet{map: map1}, %MapSet{map: map2}) do
+  def intersection(%MapSet{data: map1}, %MapSet{data: map2}) do
     {map1, map2} = order_by_size(map1, map2)
 
-    %MapSet{map: Map.take(map2, Map.keys(map1))}
+    %MapSet{data: Map.take(map2, Map.keys(map1))}
   end
 
   @doc """
@@ -248,7 +248,7 @@ defmodule MapSet do
 
   """
   @spec member?(t, value) :: boolean
-  def member?(%MapSet{map: map}, value) do
+  def member?(%MapSet{data: map}, value) do
     Map.has_key?(map, value)
   end
 
@@ -264,8 +264,8 @@ defmodule MapSet do
 
   """
   @spec put(t(val), new_val) :: t(val | new_val) when val: value, new_val: value
-  def put(%MapSet{map: map} = map_set, value) do
-    %{map_set | map: Map.put(map, value, [])}
+  def put(%MapSet{data: map} = map_set, value) do
+    %{map_set | data: Map.put(map, value, [])}
   end
 
   @doc """
@@ -278,7 +278,7 @@ defmodule MapSet do
 
   """
   @spec size(t) :: non_neg_integer
-  def size(%MapSet{map: map}) do
+  def size(%MapSet{data: map}) do
     map_size(map)
   end
 
@@ -296,7 +296,7 @@ defmodule MapSet do
 
   """
   @spec subset?(t, t) :: boolean
-  def subset?(%MapSet{map: map1}, %MapSet{map: map2}) do
+  def subset?(%MapSet{data: map1}, %MapSet{data: map2}) do
     if map_size(map1) <= map_size(map2) do
       map1
       |> Map.keys
@@ -325,7 +325,7 @@ defmodule MapSet do
 
   """
   @spec to_list(t(val)) :: [val] when val: value
-  def to_list(%MapSet{map: map}) do
+  def to_list(%MapSet{data: map}) do
     Map.keys(map)
   end
 
@@ -339,8 +339,8 @@ defmodule MapSet do
 
   """
   @spec union(t(val1), t(val2)) :: t(val1 | val2) when val1: value, val2: value
-  def union(%MapSet{map: map1}, %MapSet{map: map2}) do
-    %MapSet{map: Map.merge(map1, map2)}
+  def union(%MapSet{data: map1}, %MapSet{data: map2}) do
+    %MapSet{data: Map.merge(map1, map2)}
   end
 
   defp order_by_size(map1, map2) when map_size(map1) > map_size(map2), do: {map2, map1}

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -34,7 +34,7 @@ defmodule MapSet do
 
   @type value :: term
 
-  @opaque t(value) :: %__MODULE__{map: %{optional(value) => true}}
+  @opaque t(value) :: %__MODULE__{map: %{optional(value) => []}}
   @type t :: t(term)
 
   defstruct map: %{}
@@ -100,7 +100,7 @@ defmodule MapSet do
     |> :maps.from_list
   end
   defp do_new([item | rest], acc) do
-    do_new(rest, [{item, true} | acc])
+    do_new(rest, [{item, []} | acc])
   end
 
   defp do_new_transform([], _fun, acc) do
@@ -109,7 +109,7 @@ defmodule MapSet do
     |> :maps.from_list
   end
   defp do_new_transform([item | rest], fun, acc) do
-    do_new_transform(rest, fun, [{fun.(item), true} | acc])
+    do_new_transform(rest, fun, [{fun.(item), []} | acc])
   end
 
   @doc """
@@ -168,7 +168,7 @@ defmodule MapSet do
     acc = if Map.has_key?(map2, key) do
       acc
     else
-      [{key, true} | acc]
+      [{key, []} | acc]
     end
     filter_not_in(rest, map2, acc)
   end
@@ -269,7 +269,7 @@ defmodule MapSet do
   """
   @spec put(t(val), new_val) :: t(val | new_val) when val: value, new_val: value
   def put(%MapSet{map: map} = map_set, value) do
-    %{map_set | map: Map.put(map, value, true)}
+    %{map_set | map: Map.put(map, value, [])}
   end
 
   @doc """


### PR DESCRIPTION
MapSet is internally represented as a map with keys as set's elements and stub values of `true`, like: `%{ :key => true }`.  When MapSet, in it's current format, is written to a DETS file, or serialized using `:erlang.term_to_binary/2`, it's **two times** as big as the smallest possible case! If the stub value is replaced with an empty list, to a format `%{ :key => [] }`, there is a significant space reduction, see: 

```Elixir
iex(1)> ml = for i<- 1..1_000_000, do: {i,[]}, into: %{}; :ok
:ok
iex(2)> mt = for i<- 1..1_000_000, do: {i,true}, into: %{}; :ok
:ok
iex(3)> {:ok, table_ml} = :dets.open_file(:disk_storage_ml, [type: :duplicate_bag]) 
{:ok, :disk_storage_ml}
iex(4)> {:ok, table_mt} = :dets.open_file(:disk_storage_mt, [type: :duplicate_bag])
{:ok, :disk_storage_mt}
iex(5)> size_ml = File.lstat!("disk_storage_ml").size
5432
iex(6)> size_mt = File.lstat!("disk_storage_mt").size
5432
iex(7)> :dets.insert_new(:disk_storage_ml, {1, ml})
true
iex(8)> :dets.insert_new(:disk_storage_mt, {1, mt})
true
iex(9)> size_ml_dets = File.lstat!("disk_storage_ml").size        
6004693
iex(10)> size_mt_dets = File.lstat!("disk_storage_mt").size        
12004693
iex(11)> size_ml_etf = ml |> :erlang.term_to_binary |> byte_size
5999241
iex(12)> size_mt_etf = mt |> :erlang.term_to_binary |> byte_size
11999241
iex(13)> size_ml_dets/size_mt_dets
0.5001954652234755
iex(14)> size_ml_etf/size_mt_etf
0.49996837299959224
```

Since only keys from the map are of any importance, changing from `true` to `[]`,  doesn't change any of the functionality. MapSet is an opaque type, so nobody should be using it's internal format either.

This changes only how much space MapSet uses when it's serialized to ETF format, no RAM usage changes were observed.