### PR TITLE
Add suport for Polish version of if/else clause (kiedy/inaczej)

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2642,6 +2642,8 @@ defmodule Kernel do
   In order to compare more than two clauses, the `cond/1` macro has to be used.
   """
   defmacro if(condition, clauses) do
+    :elixir_errors.warn(__CALLER__.line, __CALLER__.file, "the if/else clauses are deprecated, use kiedy/inaczej instead")
+
     build_if(condition, clauses)
   end
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2544,6 +2544,66 @@ defmodule Kernel do
   end
 
   @doc """
+  Provides an `kiedy/2` macro.
+
+  This macro expects the first argument to be a condition and the second
+  argument to be a keyword list.
+
+  ## One-liner examples
+
+      kiedy(foo, do: bar)
+
+  In the example above, `bar` will be returned if `foo` evaluates to
+  `true` (i.e., it is neither `false` nor `nil`). Otherwise, `nil` will be
+  returned.
+
+  An `inaczej` option can be given to specify the opposite:
+
+      kiedy(foo, do: bar, inaczej: baz)
+
+  ## Blocks examples
+
+  It's also possible to pass a block to the `kiedy/2` macro. The first
+  example above would be translated to:
+
+      kiedy foo to
+        bar
+      end
+
+  Note that `do/end` become delimiters. The second example would
+  translate to:
+
+      kiedy foo do
+        bar
+      inaczej
+        baz
+      end
+
+  In order to compare more than two clauses, the `cond/1` macro has to be used.
+  """
+  defmacro kiedy(condition, clauses) do
+    build_kiedy(condition, clauses)
+  end
+
+  defp build_kiedy(condition, do: do_clause) do
+    build_kiedy(condition, do: do_clause, inaczej: nil)
+  end
+
+  defp build_kiedy(condition, do: do_clause, inaczej: else_clause) do
+    optimize_boolean(quote do
+      case unquote(condition) do
+        x when x in [false, nil] -> unquote(else_clause)
+        _ -> unquote(do_clause)
+      end
+    end)
+  end
+
+  defp build_kiedy(_condition, _arguments) do
+    raise(ArgumentError, "invalid or duplicate keys for kiedy, only \"do\" " <>
+      "and an optional \"inaczej\" are permitted")
+  end
+
+  @doc """
   Provides an `if/2` macro.
 
   This macro expects the first argument to be a condition and the second

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1058,6 +1058,7 @@ keyword('in')     -> in_op;
 % Block keywords
 keyword('after')  -> block;
 keyword('else')   -> block;
+keyword('inaczej')   -> block;
 keyword('rescue') -> block;
 keyword('catch')  -> block;
 


### PR DESCRIPTION
This work is heavily inspired by amazing bold move by Skala community (formerly Scala): http://scala-lang.org/blog/2017/04/01/announcing-skala.html

They move all their keywords to German versions (since Britain leaves EU, it makes total sense, really).

We should not be total copy cats, however, so we defo should use Polish. This would also significantly help @josevalim pick up a few local words.

Let's start with if/else. This PR also soft deprecates English language version of the macro.

I think the next step would be to replace "do" with "wykonaj", "end" with "koniec". Thankfully we can keep "def", "defmodule" and just rename "defmacro" to "defmakro" since it's all the same in Polish.

And, of course, I think it makes sense to switch all internal discussions about the language to Polish. Look at Ruby. They did that with Japanese and Ruby is crazy popular. Now they switched to English and people start migrating away. Polish is defo the language to go.