### PR TITLE
Fix ExUnit.Diff when comparing maps with nil or boolean keys

### DIFF
--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -436,6 +436,10 @@ defmodule ExUnit.Diff do
     inspect(key) <> " => "
   end
 
+  defp format_key(key, true) when is_nil(key) or is_boolean(key) do
+    inspect(key) <> ": "
+  end
+
   defp format_key(key, true) do
     ":" <> result = inspect(key)
     result <> ": "

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -289,6 +289,10 @@ defmodule ExUnit.DiffTest do
 
     assert script(%{"foo-bar": 1}, %{}) == [{:eq, "%{"}, [[del: "\"foo-bar\": 1"]], {:eq, "}"}]
     assert script(%{}, %{}) == [eq: "%{}"]
+
+    assert script(%{nil: 42}, %{}) == [{:eq, "%{"}, [[del: "nil: 42"]], {:eq, "}"}]
+    assert script(%{true: 42}, %{}) == [{:eq, "%{"}, [[del: "true: 42"]], {:eq, "}"}]
+    assert script(%{false: 42}, %{}) == [{:eq, "%{"}, [[del: "false: 42"]], {:eq, "}"}]
   end
 
   test "structs" do


### PR DESCRIPTION
All of 
```elixir
assert %{nil => 42} == %{}
assert %{true => 42} == %{}
assert %{false => 42} == %{}
```
resulted in a `MatchError`, instead of proper diffs.