### PR TITLE
Removes .gitignore pattern for generated lexer [ci skip]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /ebin
 /lib/*/ebin/*
 /lib/*/tmp
-/lib/elixir/src/*_lexer.erl
 /lib/elixir/src/*_parser.erl
 /lib/elixir/src/elixir.app.src
 /lib/elixir/test/ebin


### PR DESCRIPTION
In the beginning of times Elixir used [`leex`](http://erlang.org/doc/man/leex.html), a tokenizer generator that took as input the .xrl file removed in 2f1f1393c9b6055114eee438e5444e010241a37e.

The Erlang scanner was introduced in 2b48933b9320b8a566c2d8aeaea41174d2b1569d.