### PR TITLE
Fix spec of Integer.gcd/2 [ci skip]

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -404,7 +404,7 @@ defmodule Integer do
       0
 
   """
-  @spec gcd(integer, integer) :: pos_integer
+  @spec gcd(integer, integer) :: non_neg_integer
   def gcd(int1, int2) when is_integer(int1) and is_integer(int2) do
     gcd_positive(abs(int1), abs(int2))
   end


### PR DESCRIPTION
The type `pos_integer` does not include the 0, but `Integer.gcd(0, 0)` returns 0 since a0b6612c71d6e7de17087330d5fbe7ba6648bca8.

(See https://github.com/elixir-lang/elixir/blob/master/lib/elixir/pages/Typespecs.md.)