### PR TITLE
Test case for unused import inside conditional

### DIFF
--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -302,6 +302,23 @@ defmodule Kernel.WarningTest do
     purge Sample
   end
 
+  test "unused import in conditional" do
+    assert capture_err(fn ->
+      Code.compile_string """
+      defmodule Sample do
+        if false do
+          import :lists
+          def a, do: sort([1, 2, 3])
+        else
+          def a, do: nil
+        end
+      end
+      """
+    end) == ""
+  after
+    purge Sample
+  end
+
   test "unused import of one of the functions in :only" do
     output = capture_err(fn ->
       Code.compile_string """


### PR DESCRIPTION
This test fails, as there is an "unused import" error when the import is in fact used.

I haven't spent a huge amount of time trying to fix this, I'd appreciate it if someone could confirm that this is a bug. If so, a pointer on where to look to fix it would be appreciated.

The following is valid:

```elixir
    defmodule Sample do
      if false do
        def a do
          import :lists
          sort([1, 2, 3])
        end
      else
        def a, do: nil
      end
    end
```