### PR TITLE
Split out the built-in knowledge of escript and archive locations and…

### DIFF
--- a/lib/mix/lib/mix/local/target.ex
+++ b/lib/mix/lib/mix/local/target.ex
@@ -1,0 +1,63 @@
+defmodule Mix.Local.Target do
+
+  @moduledoc ~S"""
+  A mix local target is a repository for various kinds of system-wide assets.
+  For example, the Escript target is the store for escripts that you install, and
+  the Archive target is typically used to hold archives implementing mix tasks.
+
+  Previously, these two targets were hard-wired into mix. This new interface
+  allows brave souls to add new local targets. For example, @pragdave's templating
+  system uses its own mix local assets, managed by the its own Target behviour.
+
+  ### Adding a new target
+
+  Define a module that uses the `Mix.Local.Target` behaviour. In that module,
+  write the following functions:
+
+      defmodule MyMixExtension.Target do
+        @behaviour Mix.Local.Target
+
+        @doc “““
+        Given a project configuration keyword list, return the name to be
+        used in the local storage
+        ”””
+
+        @spec name_for(Keyword.t) :: String.t
+        def name_for(project_config) do
+          version = if version = project[:version], do: "-#{version}"
+          "#{project[:app]}#{version}.ez"
+        end
+
+        @doc “““
+        Return the path where items of this target should be stored.
+        ”””
+
+        @spec path_for() :: String.t
+        def path_for() do
+          Path.join(Mix.Utils.mix_home, "templates")
+        end
+
+
+        @doc “““
+        Return the singular and plural forms of the human name for this
+        target.
+        ”””
+
+        @spec printable_name() :: { String.t, String.t }
+        def printable_name() do
+          { "template", "templates" }
+        end
+
+        @doc “““
+        Return the base part of the mix task name for this target. 
+        For example, the Escript target would return "escript", as
+        its tasks have names such as "escript.build" and "escript.install"
+        ”””
+        @spec task_name() :: String.t
+  """
+
+  @callback name_for(Keyword.t) :: String.t
+  @callback path_for()          :: String.t
+  @callback printable_name()    :: { String.t, String.t }
+  @callback task_name()         :: String.t
+end

--- a/lib/mix/lib/mix/local/target/archive.ex
+++ b/lib/mix/lib/mix/local/target/archive.ex
@@ -1,0 +1,20 @@
+defmodule Mix.Local.Target.Archive do
+  @moduledoc "See Mix.Local.Target"
+  
+  @behaviour Mix.Local.Target
+
+  def name_for(project) do
+    version = if (v = project[:version]), do: "-#{v}"
+    "#{project[:app]}#{version}.ez"
+  end
+
+  def path_for() do
+    System.get_env("MIX_ARCHIVES") || Path.join(Mix.Utils.mix_home, "archives")
+  end
+  
+  def printable_name() do
+    { "archive", "archives" }
+  end
+
+  def task_name(), do: "archive"
+end

--- a/lib/mix/lib/mix/local/target/escript.ex
+++ b/lib/mix/lib/mix/local/target/escript.ex
@@ -1,0 +1,24 @@
+defmodule Mix.Local.Target.Escript do
+  @moduledoc "See Mix.Local.Target"
+  
+  @behaviour Mix.Local.Target
+
+  def name_for(project) do
+    case get_in(project, [:escript, :name]) do
+      nil  -> project[:app]
+      name -> name
+    end
+    |> to_string()
+  end
+
+  def path_for() do
+    Path.join(Mix.Utils.mix_home, "escripts")
+  end
+  
+  def printable_name() do
+    { "escript", "escripts" }
+  end
+
+  def task_name(), do: "escript"
+  
+end

--- a/lib/mix/lib/mix/tasks/archive.build.ex
+++ b/lib/mix/lib/mix/tasks/archive.build.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Archive.Build do
-  use Mix.Task
+  use   Mix.Task
+  alias Mix.Local.Target.Archive, as: TargetArchive
 
   @shortdoc "Archives this project into a .ez file"
 
@@ -74,7 +75,7 @@ defmodule Mix.Tasks.Archive.Build do
       output = opts[:output] ->
         output
       project_config[:app] ->
-        Mix.Local.name_for(:archive, project_config)
+        Mix.Local.name_for(TargetArchive, project_config)
       true ->
         Mix.raise "Cannot create archive without output file, " <>
           "please pass -o as an option"

--- a/lib/mix/lib/mix/tasks/archive.ex
+++ b/lib/mix/lib/mix/tasks/archive.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Archive do
-  use Mix.Task
+  use   Mix.Task
+  alias Mix.Local.Target.Archive, as: TargetArchive
 
   @shortdoc "Lists installed archives"
 
@@ -18,10 +19,10 @@ defmodule Mix.Tasks.Archive do
   @spec run(OptionParser.argv) :: :ok
   def run(_) do
     archives =
-      Mix.Local.path_for(:archive)
+      Mix.Local.path_for(TargetArchive)
       |> Path.join("*")
       |> Path.wildcard()
       |> Enum.map(&Path.basename/1)
-    Mix.Local.Installer.print_list(:archive, archives)
+    Mix.Local.Installer.print_list(TargetArchive, archives)
   end
 end

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Archive.Install do
-  use Mix.Task
+  use   Mix.Task
+  alias Mix.Local.Target.Archive, as: TargetArchive
 
   @shortdoc "Installs an archive locally"
 
@@ -53,7 +54,7 @@ defmodule Mix.Tasks.Archive.Install do
   @switches [force: :boolean, sha512: :string, submodules: :boolean, app: :string]
   @spec run(OptionParser.argv) :: boolean
   def run(argv) do
-    Mix.Local.Installer.install({__MODULE__, :archive}, argv, @switches)
+    Mix.Local.Installer.install({__MODULE__, TargetArchive}, argv, @switches)
   end
 
   ### Mix.Local.Installer callbacks
@@ -118,7 +119,7 @@ defmodule Mix.Tasks.Archive.Install do
 
   defp archives(name) do
     # TODO: We can remove the .ez extension on Elixir 2.0 since we always unzip since 1.3
-    Mix.Local.path_for(:archive)
+    Mix.Local.path_for(TargetArchive)
     |> Path.join(name <> "{,*.ez}")
     |> Path.wildcard
   end

--- a/lib/mix/lib/mix/tasks/archive.uninstall.ex
+++ b/lib/mix/lib/mix/tasks/archive.uninstall.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Archive.Uninstall do
-  use Mix.Task
+  use   Mix.Task
+  alias Mix.Local.Target.Archive, as: TargetArchive
 
   @shortdoc "Uninstalls archives"
 
@@ -11,6 +12,6 @@ defmodule Mix.Tasks.Archive.Uninstall do
   """
   @spec run(OptionParser.argv) :: :ok
   def run(argv) do
-    Mix.Local.Installer.uninstall(:archive, argv)
+    Mix.Local.Installer.uninstall(TargetArchive, argv)
   end
 end

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -1,6 +1,7 @@
 defmodule Mix.Tasks.Escript.Build do
-  use Mix.Task
-  use Bitwise, only_operators: true
+  use   Mix.Task
+  use   Bitwise, only_operators: true
+  alias Mix.Local.Target.Escript, as: TargetEscript
 
   @shortdoc "Builds an escript for the project"
 
@@ -123,7 +124,7 @@ defmodule Mix.Tasks.Escript.Build do
       Mix.raise "Building escripts for umbrella projects is unsupported"
     end
 
-    script_name = Mix.Local.name_for(:escript, project)
+    script_name = Mix.Local.name_for(TargetEscript, project)
     filename = escript_opts[:path] || script_name
     main = escript_opts[:main_module]
     files = project_files()

--- a/lib/mix/lib/mix/tasks/escript.ex
+++ b/lib/mix/lib/mix/tasks/escript.ex
@@ -1,25 +1,28 @@
 defmodule Mix.Tasks.Escript do
-  use Mix.Task
-
+  use   Mix.Task
+  alias Mix.Local.Target.Escript, as: TargetEscript
+  
   @shortdoc "Lists installed escripts"
 
   @moduledoc ~S"""
   Lists all installed escripts.
 
-  Escripts are installed at `~/.mix/escripts`. Add that path to your `PATH` environment variable
-  to be able to run installed escripts from any directory.
+  Escripts are installed at `~/.mix/escripts`. Add that path to your
+  `PATH` environment variable to be able to run installed escripts
+  from any directory. 
   """
 
   use Bitwise
 
   @spec run(OptionParser.argv) :: :ok
   def run(_) do
-    escripts_path = Mix.Local.path_for(:escript)
+    escripts_path = Mix.Local.path_for(TargetEscript)
     escripts =
       escripts_path
       |> list_dir()
-      |> Enum.filter(fn filename -> executable?(Path.join(escripts_path, filename)) end)
-    Mix.Local.Installer.print_list(:escript, escripts)
+      |> Enum.filter(&executable?(Path.join(escripts_path, &1)))
+
+    Mix.Local.Installer.print_list(TargetEscript, escripts)
   end
 
   defp list_dir(path) do

--- a/lib/mix/lib/mix/tasks/escript.install.ex
+++ b/lib/mix/lib/mix/tasks/escript.install.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Escript.Install do
-  use Mix.Task
+  use   Mix.Task
+  alias Mix.Local.Target.Escript, as: TargetEscript
 
   @shortdoc "Installs an escript locally"
 
@@ -59,7 +60,7 @@ defmodule Mix.Tasks.Escript.Install do
   @switches [force: :boolean, sha512: :string, submodules: :boolean, app: :string]
   @spec run(OptionParser.argv) :: boolean
   def run(argv) do
-    Mix.Local.Installer.install({__MODULE__, :escript}, argv, @switches)
+    Mix.Local.Installer.install({__MODULE__, TargetEscript}, argv, @switches)
   end
 
   ### Mix.Local.Installer callbacks
@@ -127,8 +128,10 @@ defmodule Mix.Tasks.Escript.Install do
       # If current executable is nil or does not match the one we just installed,
       # PATH is misconfigured
       current_executable != dst ->
-        Mix.shell.error "\nwarning: you must append #{inspect Mix.Local.path_for(:escript)} " <>
-                        "to your PATH if you want to invoke escripts by name\n"
+        Mix.shell.error("""
+        warning: you must append #{inspect Mix.Local.path_for(TargetEscript)}
+                        "to your PATH if you want to invoke escripts by name
+        """)
 
       true ->
         :ok

--- a/lib/mix/lib/mix/tasks/escript.uninstall.ex
+++ b/lib/mix/lib/mix/tasks/escript.uninstall.ex
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Escript.Uninstall do
   use Mix.Task
+  alias Mix.Local.Target.Escript, as: TargetEscript
 
   @shortdoc "Uninstalls escripts"
 
@@ -11,7 +12,7 @@ defmodule Mix.Tasks.Escript.Uninstall do
   """
   @spec run(OptionParser.argv) :: :ok
   def run(argv) do
-    if path = Mix.Local.Installer.uninstall(:escript, argv) do
+    if path = Mix.Local.Installer.uninstall(TargetEscript, argv) do
       File.rm(path <> ".bat")
     end
   end


### PR DESCRIPTION
… other metadata. Defined a Mix.Local.Target behaviour that lets people extend this from the outside.

This is implemented by passing not the name of the type of local (:escript or :archive) but instead a module that knows how to generate names and paths for locals of that type.

The module implements the new Mix.Local.Target behaviour, where the API is documented.