### PR TITLE
Make it more clear that file permissions are octal

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1361,19 +1361,21 @@ defmodule File do
 
   ## Permissions
 
-    * 0o400 - read permission: owner
-    * 0o200 - write permission: owner
-    * 0o100 - execute permission: owner
+  File permissions are specified by adding together the following octal flags:
 
-    * 0o040 - read permission: group
-    * 0o020 - write permission: group
-    * 0o010 - execute permission: group
+    * `0o400` - read permission: owner
+    * `0o200` - write permission: owner
+    * `0o100` - execute permission: owner
 
-    * 0o004 - read permission: other
-    * 0o002 - write permission: other
-    * 0o001 - execute permission: other
+    * `0o040` - read permission: group
+    * `0o020` - write permission: group
+    * `0o010` - execute permission: group
 
-  For example, setting the mode 0o755 gives it
+    * `0o004` - read permission: other
+    * `0o002` - write permission: other
+    * `0o001` - execute permission: other
+
+  For example, setting the mode `0o755` gives it
   write, read and execute permission to the owner
   and both read and execute permission to group
   and others.


### PR DESCRIPTION
The font used in the rendered docs does not differentiate `0` and `o`
very well. Put the flags in inline code blocks so that they use a
monospace font that's more unambiguous.

Also, add a short sentence stating that the flags are octal.

## Before

![image](https://cloud.githubusercontent.com/assets/60145/24854696/6538bf80-1dad-11e7-8e39-876f549474ce.png)

## After

![image](https://cloud.githubusercontent.com/assets/60145/24854669/4af31468-1dad-11e7-8758-60c44f46ec83.png)
