### PR TITLE
Use `negate` instead of `neg` for coherence

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -409,8 +409,8 @@ defmodule Kernel.SpecialForms do
   special form has only one argument, reflecting the fact that the operator is
   unary:
 
-      iex> quote do: neg.(0)
-      {{:., [], [{:neg, [], __MODULE__}]}, [], [0]}
+      iex> quote do: negate.(0)
+      {{:., [], [{:negate, [], __MODULE__}]}, [], [0]}
 
   When the right side is an alias (i.e. starts with uppercase), we get instead:
 


### PR DESCRIPTION
@whatyouhide I realized there was a second example using `neg`, I believe it makes sense to use `negate` again, for coherence with the previous definition (though technically they are different examples).

What do you think?