### PR TITLE
Make Mix more friendly for newcomers

### DIFF
--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -48,7 +48,14 @@ defmodule Mix.CLI do
   end
 
   defp get_task([]) do
-    {Mix.Project.config[:default_task], []}
+    case Mix.Project.get do
+      nil ->
+        Mix.shell.error "Could not find a Mix.Project, please ensure a mix.exs file is available"
+        Mix.shell.info usage()
+        exit({:shutdown, 1})
+
+      _ -> {Mix.Project.config[:default_task], []}
+    end
   end
 
   defp run_task(name, args) do
@@ -126,4 +133,13 @@ defmodule Mix.CLI do
       ["--version", "-v"], do: :version
 
   defp check_for_shortcuts(_), do: nil
+
+  defp usage() do
+    "usage:\n" <>
+    "	 mix new [path]        # Creates a new Elixir project\n" <>
+    "\n" <>
+    "further help:\n" <>
+    "	 mix help\n" <>
+    "	 mix help [command]"
+  end
 end

--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -12,6 +12,8 @@ defmodule Mix.CLI do
     if env_variable_activated?("MIX_DEBUG"), do: Mix.debug(true)
 
     case check_for_shortcuts(args) do
+      :usage ->
+        proceed(["usage"])
       :help ->
         proceed(["help"])
       :version ->
@@ -51,7 +53,7 @@ defmodule Mix.CLI do
     case Mix.Project.get do
       nil ->
         Mix.shell.error "Could not find a Mix.Project, please ensure a mix.exs file is available"
-        Mix.shell.info usage()
+        proceed(["usage"])
         exit({:shutdown, 1})
 
       _ -> {Mix.Project.config[:default_task], []}
@@ -133,13 +135,4 @@ defmodule Mix.CLI do
       ["--version", "-v"], do: :version
 
   defp check_for_shortcuts(_), do: nil
-
-  defp usage() do
-    "usage:\n" <>
-    "	 mix new [path]        # Creates a new Elixir project\n" <>
-    "\n" <>
-    "further help:\n" <>
-    "	 mix help\n" <>
-    "	 mix help [command]"
-  end
 end

--- a/lib/mix/lib/mix/tasks/usage.ex
+++ b/lib/mix/lib/mix/tasks/usage.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Usage do
   use Mix.Task
 
-  @shortdoc "Prints usage information for mix"
+  @shortdoc "Prints usage information for Mix"
 
   @moduledoc ~S"""
   Usage: mix [task]

--- a/lib/mix/lib/mix/tasks/usage.ex
+++ b/lib/mix/lib/mix/tasks/usage.ex
@@ -1,0 +1,42 @@
+defmodule Mix.Tasks.Usage do
+  use Mix.Task
+
+  @shortdoc "Prints usage information for mix"
+
+  @moduledoc ~S"""
+  Usage: mix [task]
+    mix                       - Runs the default task (current: "mix run")
+    mix new                   - Creates a new Elixir project
+
+  For further help:
+    mix help                  - Prints help information for tasks
+    mix help                  - Prints all tasks and their shortdoc
+    mix help TASK             - Prints full docs for the given task
+    mix help --search PATTERN - Prints all tasks that contain PATTERN in the name
+    mix help --names          - Prints all task names and aliases
+    mix cmd                   - Executes the given command
+    mix compile               - Compiles source files
+    mix deps                  - Lists dependencies and their status
+    mix do                    - Executes the tasks separated by comma
+    mix escript               - Lists installed escripts
+    mix loadconfig            - Loads and persists the given configuration
+    mix local                 - Lists local tasks
+    mix local.hex             - Installs Hex locally
+    mix local.public_keys     - Manages public keys
+    mix local.rebar           - Installs Rebar locally
+    mix profile.cprof         - Profiles the given file or expression with cprof
+    mix profile.fprof         - Profiles the given file or expression with fprof
+    mix run                   - Runs the given file or expression
+    iex -S mix                - Starts IEx and runs the default task
+  """
+
+  @spec run(OptionParser.argv) :: no_return
+  def run(_) do
+    Mix.shell.info usage()
+  end
+
+  defp usage() do
+    Mix.Task.moduledoc(__MODULE__)
+    |> String.trim_trailing("\n")
+  end
+end


### PR DESCRIPTION
### Environment

* Elixir & Erlang versions (elixir --version): 1.4.2
* Operating system: all

### Current behaviour

Execute `mix` outside of an elixir project directory.

```
** (Mix) Could not find a Mix.Project, please ensure a mix.exs file is available
```

In Red letters no less, indicating a failure.

### Expected behaviour

I've often thought its out of character (for Elixir) that the Mix tool would be so blunt when a user has run the `mix` tool outside of a project. This might even be the first time they've ever run the tool. 

When you run git with no commands it provides an extensive usage. 

Perhaps a short usage description might be a better user experience?

