### PR TITLE
Parameter rename in Protocol.each_struct_clause_for/3

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -382,9 +382,9 @@ defmodule Protocol do
           [{:var, line, :x}]}]}
   end
 
-  defp each_struct_clause_for(other, protocol, line) do
-    {:clause, line, [{:atom, line, other}], [],
-      [{:atom, line, load_impl(protocol, other)}]}
+  defp each_struct_clause_for(struct, protocol, line) do
+    {:clause, line, [{:atom, line, struct}], [],
+      [{:atom, line, load_impl(protocol, struct)}]}
   end
 
   defp fallback_clause_for(value, _protocol, line) do


### PR DESCRIPTION
Easy one.

This function is for structs, when read on itself, `struct` may communicate that better than `other`.