### PR TITLE
Renames load_impl to target_for

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -311,7 +311,7 @@ defmodule Protocol do
   end
 
   defp change_impl_for([{:function, line, :impl_for, 1, _} | tail], protocol, types, structs, protocol?, acc) do
-    fallback = if Any in types, do: load_impl(protocol, Any)
+    fallback = if Any in types, do: target_for(protocol, Any)
 
     clauses = for {guard, mod} <- __builtin__(),
                   mod in types,
@@ -325,7 +325,7 @@ defmodule Protocol do
   end
 
   defp change_impl_for([{:function, line, :struct_impl_for, 1, _} | tail], protocol, types, structs, protocol?, acc) do
-    fallback = if Any in types, do: load_impl(protocol, Any)
+    fallback = if Any in types, do: target_for(protocol, Any)
     clauses = for struct <- structs, do: each_struct_clause_for(struct, protocol, line)
     clauses = clauses ++ [fallback_clause_for(fallback, protocol, line)]
 
@@ -365,7 +365,7 @@ defmodule Protocol do
           {:remote, line, {:atom, line, :erlang}, {:atom, line, guard}},
           [{:var, line, :x}],
      }]],
-      [{:atom, line, load_impl(protocol, mod)}]}
+      [{:atom, line, target_for(protocol, mod)}]}
   end
 
   defp struct_clause_for(line) do
@@ -384,7 +384,7 @@ defmodule Protocol do
 
   defp each_struct_clause_for(struct, protocol, line) do
     {:clause, line, [{:atom, line, struct}], [],
-      [{:atom, line, load_impl(protocol, struct)}]}
+      [{:atom, line, target_for(protocol, struct)}]}
   end
 
   defp fallback_clause_for(value, _protocol, line) do
@@ -392,7 +392,7 @@ defmodule Protocol do
       [{:atom, line, value}]}
   end
 
-  defp load_impl(protocol, for) do
+  defp target_for(protocol, for) do
     Module.concat(protocol, for).__impl__(:target)
   end
 


### PR DESCRIPTION
This one is debatable, please consider the patch just as a proposal.

In the terminology of protocols, there is a word for "the module where the functions are implemented", which is _target_. Indeed, `__impl__` also holds information for `:protocol` and `:for`, in addition to `:target`.

Just thought that while reading this code, `target_for` seems to be more concise than `load_impl`. Also, the function is primarily about returning an alias via a function call, rather than loading something.

But... maybe I am lacking more context, in which case we'd just close 😄.