### PR TITLE
Mention that File.regular? and File.dir? follow symbolic links

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -89,6 +89,9 @@ defmodule File do
   @doc """
   Returns `true` if the path is a regular file.
 
+  This function follows symbolic links, so if the symbolic link points to a
+  regular file, this also returns `true`.
+
   ## Examples
 
       File.regular? __ENV__.file #=> true
@@ -101,6 +104,9 @@ defmodule File do
 
   @doc """
   Returns `true` if the given path is a directory.
+
+  This function follows symbolic links, so if the symbolic link points to a
+  directory, this also returns `true`.
 
   ## Examples
 

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -89,8 +89,8 @@ defmodule File do
   @doc """
   Returns `true` if the path is a regular file.
 
-  This function follows symbolic links, so if the symbolic link points to a
-  regular file, this also returns `true`.
+  This function follows symbolic links, so if a symbolic link points to a
+  regular file, `true` is returned.
 
   ## Examples
 
@@ -105,8 +105,8 @@ defmodule File do
   @doc """
   Returns `true` if the given path is a directory.
 
-  This function follows symbolic links, so if the symbolic link points to a
-  directory, this also returns `true`.
+  This function follows symbolic links, so if a symbolic link points to a
+  directory, `true` is returned.
 
   ## Examples
 


### PR DESCRIPTION
I unintentionally deleted some symlinks because I assumed `File.regular?` would return `false` for them, but it does not.

This PR mentions documents the behavior with symlinks.