### PR TITLE
Avoid warnings in hd/1 and tl/1 tests

### DIFF
--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -2,8 +2,9 @@ Code.require_file "test_helper.exs", __DIR__
 
 defmodule KernelTest do
   use ExUnit.Case, async: true
-
   doctest Kernel
+
+  defp empty_list(), do: []
 
   test "=~/2" do
     assert ("abcd" =~ ~r/c(d)/) == true
@@ -863,22 +864,18 @@ defmodule KernelTest do
   test "tl/2" do
     assert tl([:one]) == []
     assert tl([1, 2, 3]) == [2, 3]
-
     assert_raise ArgumentError, "argument error", fn ->
-      tl([])
+      tl(empty_list())
     end
-
     assert tl([:a | :b]) == :b
     assert tl([:a, :b | :c]) == [:b | :c]
   end
 
   test "hd/2" do
     assert hd([1, 2, 3, 4]) == 1
-
     assert_raise ArgumentError, "argument error", fn ->
-      hd([])
+      hd(empty_list())
     end
-
     assert hd([1 | 2]) == 1
   end
 

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -861,7 +861,7 @@ defmodule KernelTest do
     end
   end
 
-  test "tl/2" do
+  test "tl/1" do
     assert tl([:one]) == []
     assert tl([1, 2, 3]) == [2, 3]
     assert_raise ArgumentError, "argument error", fn ->
@@ -871,7 +871,7 @@ defmodule KernelTest do
     assert tl([:a, :b | :c]) == [:b | :c]
   end
 
-  test "hd/2" do
+  test "hd/1" do
     assert hd([1, 2, 3, 4]) == 1
     assert_raise ArgumentError, "argument error", fn ->
       hd(empty_list())


### PR DESCRIPTION
It will warn:
> warning: this expression will fail with ArgumentError

Recently introduced in
980a73cc7ff2e5ba522c9d0ac166043f4a97c7c6
f523b485d04624e8d757ff0ae7d97fdd97be5ce9