### PR TITLE
Change module attribute name that stores internal protocol metadata

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -179,7 +179,7 @@ defmodule Protocol do
     prefix = Atom.to_charlist(protocol) ++ '.'
     extract_matching_by_attribute paths, prefix, fn
       _mod, attributes ->
-        case attributes[:impl] do
+        case attributes[:protocol_metadata] do
           [protocol: ^protocol, for: for] -> for
           _ -> nil
         end
@@ -569,8 +569,8 @@ defmodule Protocol do
 
         unquote(block)
 
-        Module.register_attribute(__MODULE__, :impl, persist: true)
-        @impl [protocol: @protocol, for: @for]
+        Module.register_attribute(__MODULE__, :protocol_metadata, persist: true)
+        @protocol_metadata [protocol: @protocol, for: @for]
 
         unquote(impl)
       end
@@ -614,8 +614,8 @@ defmodule Protocol do
           apply(mod, fun, args)
         else
           Module.create(Module.concat(protocol, for), quote do
-            Module.register_attribute(__MODULE__, :impl, persist: true)
-            @impl [protocol: unquote(protocol), for: unquote(for)]
+            Module.register_attribute(__MODULE__, :protocol_metadata, persist: true)
+            @protocol_metadata [protocol: unquote(protocol), for: unquote(for)]
 
             @doc false
             @spec __impl__(:target) :: unquote(impl)

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -153,7 +153,7 @@ defmodule ProtocolTest do
     assert module.__impl__(:for) == ImplStruct
     assert module.__impl__(:target) == module
     assert module.__impl__(:protocol) == Sample
-    assert module.__info__(:attributes)[:impl] ==
+    assert module.__info__(:attributes)[:protocol_metadata] ==
            [protocol: Sample, for: ImplStruct]
   end
 
@@ -162,7 +162,7 @@ defmodule ProtocolTest do
     assert module.__impl__(:for) == ImplStruct
     assert module.__impl__(:target) == WithAny.Any
     assert module.__impl__(:protocol) == WithAny
-    assert module.__info__(:attributes)[:impl] ==
+    assert module.__info__(:attributes)[:protocol_metadata] ==
            [protocol: WithAny, for: ImplStruct]
   end
 
@@ -171,7 +171,7 @@ defmodule ProtocolTest do
     assert module.__impl__(:for) == ImplStruct
     assert module.__impl__(:target) == module
     assert module.__impl__(:protocol) == Derivable
-    assert module.__info__(:attributes)[:impl] ==
+    assert module.__info__(:attributes)[:protocol_metadata] ==
            [protocol: Derivable, for: ImplStruct]
   end
 

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -231,7 +231,7 @@ defmodule Mix.Compilers.Elixir do
   end
 
   defp detect_kind(module) do
-    impl = Module.get_attribute(module, :impl)
+    impl = Module.get_attribute(module, :protocol_metadata)
 
     cond do
       is_list(impl) and impl[:protocol] ->

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -231,11 +231,11 @@ defmodule Mix.Compilers.Elixir do
   end
 
   defp detect_kind(module) do
-    impl = Module.get_attribute(module, :protocol_metadata)
+    protocol_metadata = Module.get_attribute(module, :protocol_metadata)
 
     cond do
-      is_list(impl) and impl[:protocol] ->
-        {:impl, impl[:protocol]}
+      is_list(protocol_metadata) and protocol_metadata[:protocol] ->
+        {:impl, protocol_metadata[:protocol]}
       is_list(Module.get_attribute(module, :protocol)) ->
         :protocol
       true ->


### PR DESCRIPTION
- Changed from @impl to @__implements_protocols_for
- Required because we want to repurpose @impl - see #5734