### PR TITLE
Update the documentation for `archive.install`

### DIFF
--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -34,6 +34,9 @@ defmodule Mix.Tasks.Archive.Install do
 
       mix some_task
 
+  Note that installing via git/github/hex fetches the source of the archive
+  and builds it, while using URL/local path fetches a pre-built archive.
+
   ## Command line options
 
     * `--sha512` - checks the archive matches the given SHA-512 checksum. Only

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -36,7 +36,8 @@ defmodule Mix.Tasks.Archive.Install do
 
   ## Command line options
 
-    * `--sha512` - checks the archive matches the given SHA-512 checksum
+    * `--sha512` - checks the archive matches the given SHA-512 checksum. Only
+      applies to installations via URL or local path.
 
     * `--force` - forces installation without a shell prompt; primarily
       intended for automation in build systems like `make`


### PR DESCRIPTION
Checksum checking cannot be performed on archives being installed
from git/github/hex. This change makes a note of that, using the
same wording from [`escript.install.ex`](https://github.com/elixir-lang/elixir/blob/master/lib/mix/lib/mix/tasks/escript.install.ex#L42)