### PR TITLE
Basic type optimisations in Elixir compiler

### DIFF
--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -15,7 +15,7 @@
   export_vars=nil,         %% a dict of all variables defined in a particular clause
   extra_guards=nil,        %% extra guards from args expansion
   counter=#{},             %% a map counting the variables defined
-  var_types=#{},           %% a map of variables and their types
+  ssa_types=#{},           %% a map of SSA variables and their types
   file=(<<"nofile">>)      %% the current scope filename
 }).
 

--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -15,6 +15,7 @@
   export_vars=nil,         %% a dict of all variables defined in a particular clause
   extra_guards=nil,        %% extra guards from args expansion
   counter=#{},             %% a map counting the variables defined
+  var_types=#{},           %% a map of variables and their types
   file=(<<"nofile">>)      %% the current scope filename
 }).
 

--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -476,37 +476,34 @@ put_type({var, _, Name}, Type, #elixir_erl{ssa_types=Types} = S) ->
 put_type(_Expr, _Type, S) ->
   S.
 
--define(OP(Name, Left, Right),
-        {op, _, (Name), (Left), (Right)}).
-
 %% When extracting type information from guards, we can't use anything
 %% containing an alternative: 'or', 'orelse', or ';'
 
 type_guards([], S) ->
-    S;
+  S;
 type_guards([Exprs], S) ->
-    lists:foldl(fun type_guard/2, S, Exprs);
+  lists:foldl(fun type_guard/2, S, Exprs);
 type_guards(_Alternative, S) ->
-    S.
+  S.
 
 type_guard({call, _, {remote, _, {atom, _, erlang}, {atom, _, Fun}}, [Var|_]}, S) ->
-    type_check(Var, Fun, S);
+  type_check(Var, Fun, S);
 type_guard({op, _, 'andalso', Left, Right}, S) ->
-    SL = type_guard(Left, S),
-    type_guard(Right, SL);
+  SL = type_guard(Left, S),
+  type_guard(Right, SL);
 type_guard({op, _, 'and', Left, Right}, S) ->
-    SL = type_guard(Left, S),
-    type_guard(Right, SL);
+  SL = type_guard(Left, S),
+  type_guard(Right, SL);
 type_guard(_Other, S) ->
-    S.
+  S.
 
 type_check(Var, is_map, S) ->
-    put_type(Var, map, S);
+  put_type(Var, map, S);
 type_check(Var, is_atom, S) ->
-    put_type(Var, atom, S);
+  put_type(Var, atom, S);
 type_check(Var, is_tuple, S) ->
-    put_type(Var, tuple, S);
+  put_type(Var, tuple, S);
 type_check(Var, is_binary, S) ->
-    put_type(Var, binary, S);
+  put_type(Var, binary, S);
 type_check(_Var, _Check, S) ->
-    S.
+  S.

--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -2,7 +2,7 @@
 -module(elixir_erl).
 -export([elixir_to_erl/1, definition_to_anonymous/6, compile/7,
          get_ann/1, remote/4, add_beam_chunk/3, format_error/1,
-         get_type/2, put_type/3]).
+         get_type/2, put_type/3, type_guards/2]).
 -include("elixir.hrl").
 
 %% Adds custom chunk to a .beam binary
@@ -475,3 +475,38 @@ put_type({var, _, Name}, Type, #elixir_erl{ssa_types=Types} = S) ->
   S#elixir_erl{ssa_types=maps:put(Name, Type, Types)};
 put_type(_Expr, _Type, S) ->
   S.
+
+-define(OP(Name, Left, Right),
+        {op, _, (Name), (Left), (Right)}).
+
+%% When extracting type information from guards, we can't use anything
+%% containing an alternative: 'or', 'orelse', or ';'
+
+type_guards([], S) ->
+    S;
+type_guards([Exprs], S) ->
+    lists:foldl(fun type_guard/2, S, Exprs);
+type_guards(_Alternative, S) ->
+    S.
+
+type_guard({call, _, {remote, _, {atom, _, erlang}, {atom, _, Fun}}, [Var|_]}, S) ->
+    type_check(Var, Fun, S);
+type_guard({op, _, 'andalso', Left, Right}, S) ->
+    SL = type_guard(Left, S),
+    type_guard(Right, SL);
+type_guard({op, _, 'and', Left, Right}, S) ->
+    SL = type_guard(Left, S),
+    type_guard(Right, SL);
+type_guard(_Other, S) ->
+    S.
+
+type_check(Var, is_map, S) ->
+    put_type(Var, map, S);
+type_check(Var, is_atom, S) ->
+    put_type(Var, atom, S);
+type_check(Var, is_tuple, S) ->
+    put_type(Var, tuple, S);
+type_check(Var, is_binary, S) ->
+    put_type(Var, binary, S);
+type_check(_Var, _Check, S) ->
+    S.

--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -1,7 +1,8 @@
 %% Compiler backend to Erlang.
 -module(elixir_erl).
 -export([elixir_to_erl/1, definition_to_anonymous/6, compile/7,
-         get_ann/1, remote/4, add_beam_chunk/3, format_error/1]).
+         get_ann/1, remote/4, add_beam_chunk/3, format_error/1,
+         get_type/2, put_type/3]).
 -include("elixir.hrl").
 
 %% Adds custom chunk to a .beam binary
@@ -434,3 +435,13 @@ get_type_docs(Data) ->
 
 format_error({internal_function_overridden, {Name, Arity}}) ->
   io_lib:format("function ~ts/~B is internal and should not be overridden", [Name, Arity]).
+
+%% Types
+
+get_type({var, _, Var}, #elixir_erl{var_types = Types}) ->
+  maps:get(Var, Types, term);
+get_type(_Other, _S) ->
+  term.
+
+put_type(Var, Type, #elixir_erl{var_types = Types} = S) ->
+  S#elixir_erl{var_types = maps:put(Var, Type, Types)}.

--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -449,14 +449,14 @@ get_expr_type({map, _, Keys}) ->
   struct_or_map(Keys);
 get_expr_type({atom, _, _}) ->
   atom;
+%% We'd need to check if it's a binary or a bitstring, we only want binaries
+%% we can't perform any optimisations with bitstrings
 %% get_expr_type({bin, _, Elems}) ->
 %%   binary;
-%% get_expr_type({lc, _, _, _}) ->
-%%   list;
 %% get_expr_type({bc, _, _, _}) ->
 %%   binary;
-get_expr_type({tuple, _, Keys}) ->
-  {tuple, length(Keys)};
+get_expr_type({tuple, _, _}) ->
+  tuple;
 get_expr_type(_Other) ->
   term.
 

--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -443,5 +443,9 @@ get_type({var, _, Var}, #elixir_erl{var_types = Types}) ->
 get_type(_Other, _S) ->
   term.
 
-put_type(Var, Type, #elixir_erl{var_types = Types} = S) ->
-  S#elixir_erl{var_types = maps:put(Var, Type, Types)}.
+put_type(_Expr, term, S) ->
+  S;
+put_type({var, _, Name}, Type, #elixir_erl{var_types = Types} = S) ->
+  S#elixir_erl{var_types = maps:put(Name, Type, Types)};
+put_type(_Expr, _Type, S) ->
+  S.

--- a/lib/elixir/src/elixir_erl_clauses.erl
+++ b/lib/elixir/src/elixir_erl_clauses.erl
@@ -32,11 +32,10 @@ match(Fun, Args, S) -> Fun(Args, S).
 
 clause(Meta, Fun, Args, Expr, Guards, S) when is_list(Meta) ->
   {TArgs, SA} = match(Fun, Args, S#elixir_erl{extra_guards=[]}),
-  {TExpr, SE} = elixir_erl_pass:translate(Expr,
-                  SA#elixir_erl{extra_guards=nil, export_vars=S#elixir_erl.export_vars}),
-
   Extra = SA#elixir_erl.extra_guards,
-  TGuards = guards(Guards, Extra, SA),
+  {TGuards, SG} = guards(Guards, Extra, SA),
+  {TExpr, SE} = elixir_erl_pass:translate(Expr,
+                  SG#elixir_erl{extra_guards=nil, export_vars=S#elixir_erl.export_vars}),
   {{clause, ?ann(Meta), TArgs, TGuards, unblock(TExpr)}, SE}.
 
 % Translate/Extract guards from the given expression.
@@ -45,12 +44,19 @@ guards(Guards, Extra, S) ->
   SG = S#elixir_erl{context=guard, extra_guards=nil},
 
   case Guards of
-    [] -> case Extra of [] -> []; _ -> [Extra] end;
-    _  -> [translate_guard(Guard, Extra, SG) || Guard <- Guards]
+    [] ->
+      case Extra of [] -> {[], S}; _ -> {[Extra], S} end;
+    _ ->
+      {TGuards, ST} = translate_guards(Guards, Extra, SG),
+      {TGuards, ST#elixir_erl{context=S#elixir_erl.context, extra_guards=S#elixir_erl.extra_guards}}
   end.
 
-translate_guard(Guard, Extra, S) ->
-  [element(1, elixir_erl_pass:translate(Guard, S)) | Extra].
+translate_guards(Guards, Extra, S) ->
+  Fun = fun(Guard, SG) ->
+    {TGuard, ST} = elixir_erl_pass:translate(Guard, SG#elixir_erl{extra_guards=nil}),
+    {[TGuard | Extra], ST}
+  end,
+  lists:mapfoldl(Fun, S, Guards).
 
 % Function for translating macros with match style like case and receive.
 

--- a/lib/elixir/src/elixir_erl_clauses.erl
+++ b/lib/elixir/src/elixir_erl_clauses.erl
@@ -52,7 +52,7 @@ guards(Guards, Extra, S) ->
   {TGuards, ST}.
 
 translate_guard(Guard, Extra, S) ->
-    [element(1, elixir_erl_pass:translate(Guard, S)) | Extra].
+  [element(1, elixir_erl_pass:translate(Guard, S)) | Extra].
 
 % Function for translating macros with match style like case and receive.
 

--- a/lib/elixir/src/elixir_erl_clauses.erl
+++ b/lib/elixir/src/elixir_erl_clauses.erl
@@ -32,10 +32,10 @@ match(Fun, Args, S) -> Fun(Args, S).
 
 clause(Meta, Fun, Args, Expr, Guards, S) when is_list(Meta) ->
   {TArgs, SA} = match(Fun, Args, S#elixir_erl{extra_guards=[]}),
-  {TExpr, SE} = elixir_erl_pass:translate(Expr,
-                  SA#elixir_erl{extra_guards=nil, export_vars=S#elixir_erl.export_vars}),
   Extra = SA#elixir_erl.extra_guards,
-  TGuards = guards(Guards, Extra, SA),
+  {TGuards, SG} = guards(Guards, Extra, SA),
+  {TExpr, SE} = elixir_erl_pass:translate(Expr,
+                  SG#elixir_erl{extra_guards=nil, export_vars=S#elixir_erl.export_vars}),
   {{clause, ?ann(Meta), TArgs, TGuards, unblock(TExpr)}, SE}.
 
 % Translate/Extract guards from the given expression.
@@ -43,10 +43,13 @@ clause(Meta, Fun, Args, Expr, Guards, S) when is_list(Meta) ->
 guards(Guards, Extra, S) ->
   SG = S#elixir_erl{context=guard, extra_guards=nil},
 
-  case Guards of
-    [] -> case Extra of [] -> []; _ -> [Extra] end;
-    _  -> [translate_guard(Guard, Extra, SG) || Guard <- Guards]
-  end.
+  TGuards =
+    case Guards of
+      [] -> case Extra of [] -> []; _ -> [Extra] end;
+      _  -> [translate_guard(Guard, Extra, SG) || Guard <- Guards]
+    end,
+  ST = elixir_erl:type_guards(TGuards, S),
+  {TGuards, ST}.
 
 translate_guard(Guard, Extra, S) ->
     [element(1, elixir_erl_pass:translate(Guard, S)) | Extra].

--- a/lib/elixir/src/elixir_erl_for.erl
+++ b/lib/elixir/src/elixir_erl_for.erl
@@ -52,9 +52,9 @@ translate_gen(_Meta, Left, Right, T, S) ->
   {TLeft, SL} = elixir_erl_clauses:match(fun elixir_erl_pass:translate/2, LeftArgs,
                                      SR#elixir_erl{extra=pin_guard, extra_guards=[]}),
 
-  {TLeftGuards, SG} = elixir_erl_clauses:guards(LeftGuards, [], SL),
-  ExtraGuards = [{nil, X} || X <- SG#elixir_erl.extra_guards],
-  SF = SG#elixir_erl{extra=S#elixir_erl.extra, extra_guards=nil},
+  TLeftGuards = elixir_erl_clauses:guards(LeftGuards, [], SL),
+  ExtraGuards = [{nil, X} || X <- SL#elixir_erl.extra_guards],
+  SF = SL#elixir_erl{extra=S#elixir_erl.extra, extra_guards=nil},
 
   {TT, {TFilters, TS}} = translate_filters(T, SF),
 

--- a/lib/elixir/src/elixir_erl_for.erl
+++ b/lib/elixir/src/elixir_erl_for.erl
@@ -52,9 +52,9 @@ translate_gen(_Meta, Left, Right, T, S) ->
   {TLeft, SL} = elixir_erl_clauses:match(fun elixir_erl_pass:translate/2, LeftArgs,
                                      SR#elixir_erl{extra=pin_guard, extra_guards=[]}),
 
-  TLeftGuards = elixir_erl_clauses:guards(LeftGuards, [], SL),
-  ExtraGuards = [{nil, X} || X <- SL#elixir_erl.extra_guards],
-  SF = SL#elixir_erl{extra=S#elixir_erl.extra, extra_guards=nil},
+  {TLeftGuards, SG} = elixir_erl_clauses:guards(LeftGuards, [], SL),
+  ExtraGuards = [{nil, X} || X <- SG#elixir_erl.extra_guards],
+  SF = SG#elixir_erl{extra=S#elixir_erl.extra, extra_guards=nil},
 
   {TT, {TFilters, TS}} = translate_filters(T, SF),
 

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -200,7 +200,7 @@ translate({{'.', _, [Left, Right]}, Meta, []}, S)
         TExtractClause,
         {clause, Generated, [TVar], [], [TErrorCall]}
       ]}, SL};
-    Module when Module =:= atom; element(1, Module) =:= tuple ->
+    Module when Module =:= atom; Module =:= tuple ->
       {TRemoteCall, SL};
     _Other ->
       {{'case', Generated, TLeft, [

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -13,7 +13,7 @@ translate({'=', Meta, [{'_', _, Atom}, Right]}, S) when is_atom(Atom) ->
 translate({'=', Meta, [Left, Right]}, S) ->
   {TRight, SR} = translate(Right, S),
   {TLeft, SL} = elixir_erl_clauses:match(fun translate/2, Left, SR),
-  ST = assign_type(TLeft, TRight, SL),
+  ST = assign_type(TRight, TLeft, SL),
   {{match, ?ann(Meta), TLeft, TRight}, ST};
 
 %% Containers
@@ -532,17 +532,17 @@ translate_remote(Left, Right, Meta, Args, S) ->
 
 %% Types
 
-assign_type(TLeft, TRight, #elixir_erl{context = match} = S) ->
+assign_type(TRight, TLeft, #elixir_erl{context = match} = S) ->
   case is_var(TLeft) of
     true -> assign_type_1(TRight, TLeft, S);
     false -> assign_type_1(TLeft, TRight, S)
   end;
-assign_type(TLeft, TRight, S) ->
-  assign_type_1(TLeft, TRight, S).
+assign_type(TRight, TLeft, S) ->
+  assign_type_1(TRight, TLeft, S).
 
 assign_type_1(Expr, MaybeVar, S) ->
-    Type = elixir_erl:get_type(Expr, S),
-    elixir_erl:put_type(MaybeVar, Type, S).
+  Type = elixir_erl:get_type(Expr, S),
+  elixir_erl:put_type(MaybeVar, Type, S).
 
 is_var({var, _, _}) -> true;
 is_var(_) -> false.

--- a/lib/elixir/src/elixir_erl_try.erl
+++ b/lib/elixir/src/elixir_erl_try.erl
@@ -55,13 +55,13 @@ build_rescue(Meta, Parts, Body, S) ->
   {{clause, Line, TMatches, _, TBody}, TS} =
     elixir_erl_clauses:clause(Meta, fun elixir_erl_pass:translate_args/2,
                           Matches, Body, [], S),
-
-  Fun = fun({TMatch, {_, Guards}}, SG) ->
-    TArgs   = [{tuple, Line, [{atom, Line, error}, TMatch, {var, Line, '_'}]}],
-    {TGuards, ST} = elixir_erl_clauses:guards(Guards, [], SG),
-    {{clause, Line, TArgs, TGuards, TBody}, ST}
-  end,
-  lists:mapfoldl(Fun, TS, lists:zip(TMatches, Parts)).
+  TClauses =
+    [begin
+      TArgs   = [{tuple, Line, [{atom, Line, error}, TMatch, {var, Line, '_'}]}],
+      TGuards = elixir_erl_clauses:guards(Guards, [], TS),
+      {clause, Line, TArgs, TGuards, TBody}
+     end || {TMatch, {_, Guards}} <- lists:zip(TMatches, Parts)],
+  {TClauses, TS}.
 
 %% Convert rescue clauses ("var in [alias1, alias2]") into guards.
 rescue_guards(Meta, Var, Aliases, S) ->

--- a/lib/elixir/src/elixir_erl_try.erl
+++ b/lib/elixir/src/elixir_erl_try.erl
@@ -55,12 +55,14 @@ build_rescue(Meta, Parts, Body, S) ->
   {{clause, Line, TMatches, _, TBody}, TS} =
     elixir_erl_clauses:clause(Meta, fun elixir_erl_pass:translate_args/2,
                           Matches, Body, [], S),
+
   TClauses =
     [begin
       TArgs = [{tuple, Line, [{atom, Line, error}, TMatch, {var, Line, '_'}]}],
       {TGuards, _} = elixir_erl_clauses:guards(Guards, [], TS),
       {clause, Line, TArgs, TGuards, TBody}
      end || {TMatch, {_, Guards}} <- lists:zip(TMatches, Parts)],
+
   {TClauses, TS}.
 
 %% Convert rescue clauses ("var in [alias1, alias2]") into guards.

--- a/lib/elixir/src/elixir_erl_try.erl
+++ b/lib/elixir/src/elixir_erl_try.erl
@@ -56,14 +56,12 @@ build_rescue(Meta, Parts, Body, S) ->
     elixir_erl_clauses:clause(Meta, fun elixir_erl_pass:translate_args/2,
                           Matches, Body, [], S),
 
-  TClauses =
-    [begin
-      TArgs   = [{tuple, Line, [{atom, Line, error}, TMatch, {var, Line, '_'}]}],
-      TGuards = elixir_erl_clauses:guards(Guards, [], TS),
-      {clause, Line, TArgs, TGuards, TBody}
-     end || {TMatch, {_, Guards}} <- lists:zip(TMatches, Parts)],
-
-  {TClauses, TS}.
+  Fun = fun({TMatch, {_, Guards}}, SG) ->
+    TArgs   = [{tuple, Line, [{atom, Line, error}, TMatch, {var, Line, '_'}]}],
+    {TGuards, ST} = elixir_erl_clauses:guards(Guards, [], SG),
+    {{clause, Line, TArgs, TGuards, TBody}, ST}
+  end,
+  lists:mapfoldl(Fun, TS, lists:zip(TMatches, Parts)).
 
 %% Convert rescue clauses ("var in [alias1, alias2]") into guards.
 rescue_guards(Meta, Var, Aliases, S) ->

--- a/lib/elixir/src/elixir_erl_try.erl
+++ b/lib/elixir/src/elixir_erl_try.erl
@@ -57,8 +57,8 @@ build_rescue(Meta, Parts, Body, S) ->
                           Matches, Body, [], S),
   TClauses =
     [begin
-      TArgs   = [{tuple, Line, [{atom, Line, error}, TMatch, {var, Line, '_'}]}],
-      TGuards = elixir_erl_clauses:guards(Guards, [], TS),
+      TArgs = [{tuple, Line, [{atom, Line, error}, TMatch, {var, Line, '_'}]}],
+      {TGuards, _} = elixir_erl_clauses:guards(Guards, [], TS),
       {clause, Line, TArgs, TGuards, TBody}
      end || {TMatch, {_, Guards}} <- lists:zip(TMatches, Parts)],
   {TClauses, TS}.

--- a/lib/elixir/src/elixir_erl_var.erl
+++ b/lib/elixir/src/elixir_erl_var.erl
@@ -114,7 +114,8 @@ should_warn(Meta) ->
 mergev(S1, S2) ->
   S2#elixir_erl{
     vars=merge_vars(S1#elixir_erl.vars, S2#elixir_erl.vars),
-    export_vars=merge_opt_vars(S1#elixir_erl.export_vars, S2#elixir_erl.export_vars)
+    export_vars=merge_opt_vars(S1#elixir_erl.export_vars, S2#elixir_erl.export_vars),
+    ssa_types=maps:merge(S1#elixir_erl.ssa_types, S2#elixir_erl.ssa_types)
  }.
 
 %% Receives two scopes and return the first scope with


### PR DESCRIPTION
This is a PoC that optimises struct updates when we already know the struct is correct. We could add additional optimisations in more places that we expand to case expressions.

To see the effect of the optimisations let's examine the resulting assembly of the `Test.test/1` function:
```elixir
defmodule Test do
  defstruct [:foo]
  def test(%Test{} = test) do
    %Test{test | foo: 1}
  end
end
```

Before changes:
```S
{function, test, 1, 17}.
  {label,16}.
    {line,[{location,"test.ex",3}]}.
    {func_info,{atom,'Elixir.Test'},{atom,test},1}.
  {label,17}.
    {test,is_map,{f,16},[{x,0}]}.
    {get_map_elements,{f,16},{x,0},{list,[{atom,'__struct__'},{x,1}]}}.
    {test,is_eq_exact,{f,16},[{x,1},{atom,'Elixir.Test'}]}.
    {test,is_map,{f,19},[{x,0}]}.
    {get_map_elements,{f,19},{x,0},{list,[{atom,'__struct__'},{x,1}]}}.
    {test,is_eq_exact,{f,19},[{x,1},{atom,'Elixir.Test'}]}.
    {test,is_map,{f,18},[{x,0}]}.
    {line,[{location,"test.ex",4}]}.
    {put_map_exact,{f,0},{x,0},{x,0},1,{list,[{atom,foo},{integer,1}]}}.
    return.
  {label,18}.
    {test_heap,3,1}.
    {put_tuple,2,{x,1}}.
    {put,{atom,badmap}}.
    {put,{x,0}}.
    {move,{x,1},{x,0}}.
    {line,[{location,"test.ex",4}]}.
    {call_ext,1,{extfunc,erlang,error,1}}.
  {label,19}.
    {test_heap,4,1}.
    {put_tuple,3,{x,1}}.
    {put,{atom,badstruct}}.
    {put,{atom,'Elixir.Test'}}.
    {put,{x,0}}.
    {move,{x,1},{x,0}}.
    {line,[{location,"test.ex",4}]}.
    {call_ext,1,{extfunc,erlang,error,1}}.
```

After those changes (and on OTP 20 after additional optimisations from beam_type https://github.com/erlang/otp/commit/0377592dc2238f561291be854d2ce859dd9a5fb1):
```S
{function, test, 1, 17}.
  {label,16}.
    {line,[{location,"test.ex",3}]}.
    {func_info,{atom,'Elixir.Test'},{atom,test},1}.
  {label,17}.
    {test,is_map,{f,16},[{x,0}]}.
    {get_map_elements,{f,16},{x,0},{list,[{atom,'__struct__'},{x,1}]}}.
    {test,is_eq_exact,{f,16},[{x,1},{atom,'Elixir.Test'}]}.
    {line,[{location,"test.ex",4}]}.
    {put_map_exact,{f,0},{x,0},{x,0},1,{list,[{atom,foo},{integer,1}]}}.
    return.
```