### PR TITLE
Validate the value of the @on_load attribute

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1190,8 +1190,12 @@ defmodule Module do
     end
   end
 
-  defp preprocess_attribute(:on_load, atom) when is_atom(atom) do
-    {atom, 0}
+  defp preprocess_attribute(:on_load, value) do
+    if is_atom(value) do
+      {value, 0}
+    else
+      raise ArgumentError, "expected the @on_load attribute to be an atom, got: #{inspect(value)}"
+    end
   end
 
   defp preprocess_attribute(:behaviour, atom) when is_atom(atom) do

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -164,9 +164,11 @@ defmodule Module do
 
   A hook that will be invoked whenever the module is loaded.
 
-  Accepts the function name (as an atom) of a function in the current module.
-  The function must have arity 0 (no arguments) and has to return `:ok`, otherwise
-  the loading of the module will be aborted. For example:
+  Accepts the function name (as an atom) of a function in the current module or
+  `{function_name, 0}` tuple where `function_name` is the name of a function in
+  the current module. The function must have arity 0 (no arguments) and has to
+  return `:ok`, otherwise the loading of the module will be aborted. For
+  example:
 
       defmodule MyModule do
         @on_load :load_check
@@ -1191,10 +1193,14 @@ defmodule Module do
   end
 
   defp preprocess_attribute(:on_load, value) do
-    if is_atom(value) do
-      {value, 0}
-    else
-      raise ArgumentError, "expected the @on_load attribute to be an atom, got: #{inspect(value)}"
+    case value do
+      atom when is_atom(atom) ->
+        {atom, 0}
+      {atom, 0} = tuple when is_atom(atom) ->
+        tuple
+      other ->
+        raise ArgumentError, "expected the @on_load attribute to be an atom or a " <>
+                             "{atom, 0} tuple, got: #{inspect(value)}"
     end
   end
 

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -572,6 +572,15 @@ defmodule Kernel.ErrorsTest do
     end
   end
 
+  test "@on_load attribute format" do
+    message = "expected the @on_load attribute to be an atom, got: \"not an atom\""
+    assert_raise ArgumentError, message, fn ->
+      defmodule BadOnLoadAttribute do
+        Module.put_attribute(__MODULE__, :on_load, "not an atom")
+      end
+    end
+  end
+
   test "interpolation error" do
     assert_compile_fail SyntaxError,
       "nofile:1: \"do\" is missing terminator \"end\". unexpected token: \")\" at line 1",

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -573,7 +573,7 @@ defmodule Kernel.ErrorsTest do
   end
 
   test "@on_load attribute format" do
-    message = "expected the @on_load attribute to be an atom, got: \"not an atom\""
+    message = "expected the @on_load attribute to be an atom or a {atom, 0} tuple, got: \"not an atom\""
     assert_raise ArgumentError, message, fn ->
       defmodule BadOnLoadAttribute do
         Module.put_attribute(__MODULE__, :on_load, "not an atom")


### PR DESCRIPTION
I think this could be a way to implement this check:

> `{bad_on_load,Term}`: badly formed `on_load` attribute

from https://github.com/elixir-lang/elixir/issues/5800. Thoughts?