### PR TITLE
Changes focus in require explanation

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -507,13 +507,12 @@ defmodule Kernel.SpecialForms do
   defmacro alias(module, opts), do: error!([module, opts])
 
   @doc """
-  Requires a given module to be compiled and loaded.
+  Requires a module in order to use its macros.
 
   ## Examples
 
-  Notice that usually modules should not be required before usage,
-  the only exception is if you want to use the macros from a module.
-  In such cases, you need to explicitly require them.
+  Public functions in modules are globally available, but in order to use
+  macros, you need to opt-in by requiring the module they are defined in.
 
   Let's suppose you created your own `if/2` implementation in the module
   `MyMacros`. If you want to invoke it, you need to first explicitly


### PR DESCRIPTION
I think from a programmer's perspective, the fact that in order to expand macros the compiler needs to ensure the module is compiled and loaded is not relevant.

The compiler needs the module loaded in memory to have their functions available (a macro is a function prefixed with "MACRO-"), because it may need to call the function early in the expand phase. Note that the module may be loaded in memory when expansion happens:

```elixir
Integer.digits(1) # function
defmodule M do
  Integer.is_odd(1) # macro
end
```

by the time `is_odd` has to be expanded, `Elixir.Integer` is already loaded in the VM, and thus the macro available for dispatch. But Elixir errs, because the code does not opt-in. Since Elixir knows the macro exists, it gives you a better error message ("you need to require in order to use a macro", or "there is a macro with the same name"), than the one it can give if the module is not even loaded ("unknown function").

From my perspective, that is not really the concern of the programmer. The programmer does not care about what the compiler needs to do. For example, the parallel compiler may need to compile a module if needed as well, and the programmer does not need to say so.

What the programmer cares in my view is that _they have to opt-in_. [This is the spot](https://github.com/elixir-lang/elixir/blob/b3957a6b5b9806d877783ddb1b18eeb2712b3b01/lib/elixir/src/elixir_expand.erl#L681) in the source code where opting-in is stored. And that is a design decision that I suppose has as a goal to prevent macros from leaking everywhere. You need to consciously opt-in.

In order to make the macro _available_ in the scope, Elixir may need to compile and load and therefore `require` also ensures the module is loaded and compiled, but that is implementation (again, as I see it).