### PR TITLE
Integer.parse/2 simpler and faster

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -252,8 +252,8 @@ defmodule Integer do
     end
   end
 
-  defp parse_digits(_, _, "-"), do: :error
-  defp parse_digits(_, _, ""), do: :error
+  defp parse_digits(<<_::binary>>, _, "-"), do: :error
+  defp parse_digits(<<_::binary>>, _, ""), do: :error
 
   defp parse_digits(<<rest::binary>>, base, acc) do
     {String.to_integer(acc, base), rest}

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -239,29 +239,25 @@ defmodule Integer do
     raise ArgumentError, "invalid base #{inspect base}"
   end
 
-  def parse(<<?-, rest::binary>>, base), do: parse_digits(-1, rest, base)
-  def parse(<<?+, rest::binary>>, base), do: parse_digits(1, rest, base)
-  def parse(<<rest::binary>>, base), do: parse_digits(1, rest, base)
-
-  defp parse_digits(sign, binary, base) do
-    binary
-    |> split_digits(base, "")
-    |> case do
-      {"", _} -> :error
-      {digits, rest} -> {sign * String.to_integer(digits, base), rest}
-    end
-  end
+  def parse(<<?-, rest::binary>>, base), do: parse_digits(rest, base, "-")
+  def parse(<<?+, rest::binary>>, base), do: parse_digits(rest, base, "")
+  def parse(<<rest::binary>>, base), do: parse_digits(rest, base, "")
 
   digits = [{?0..?9, -?0}, {?A..?Z, 10 - ?A}, {?a..?z, 10 - ?a}]
 
   for {chars, diff} <- digits, char <- chars do
-    defp split_digits(<<unquote(char), rest::binary>>, base, acc)
+    defp parse_digits(<<unquote(char), rest::binary>>, base, acc)
          when base > unquote(char + diff) do
-      split_digits(rest, base, <<acc::binary, unquote(char)>>)
+      parse_digits(rest, base, <<acc::binary, unquote(char)>>)
     end
   end
 
-  defp split_digits(<<rest::binary>>, _base, acc), do: {acc, rest}
+  defp parse_digits(_, _, "-"), do: :error
+  defp parse_digits(_, _, ""), do: :error
+
+  defp parse_digits(<<rest::binary>>, base, acc) do
+    {String.to_integer(acc, base), rest}
+  end
 
   @doc """
   Returns a binary which corresponds to the text representation

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -245,23 +245,23 @@ defmodule Integer do
 
   defp parse_digits(sign, binary, base) do
     binary
-    |> Kernel.to_charlist
-    |> Enum.split_while(&(digit_for_base?(&1, base)))
+    |> split_digits(base, "")
     |> case do
-      {'', _} -> :error
-      {digits, rest} ->
-        {sign * String.to_integer(Kernel.to_string(digits), base), Kernel.to_string(rest)}
+      {"", _} -> :error
+      {digits, rest} -> {sign * String.to_integer(digits, base), rest}
     end
   end
 
-  defp digit_for_base?(digit, base) do
-    cond do
-      digit >= ?0 and digit <= ?9 -> base > digit - ?0
-      digit >= ?a and digit <= ?z -> base > digit - ?a + 10
-      digit >= ?A and digit <= ?Z -> base > digit - ?A + 10
-      true -> false
+  digits = [{?0..?9, -?0}, {?A..?Z, 10 - ?A}, {?a..?z, 10 - ?a}]
+
+  for {chars, diff} <- digits, char <- chars do
+    defp split_digits(<<unquote(char), rest::binary>>, base, acc)
+         when base > unquote(char + diff) do
+      split_digits(rest, base, <<acc::binary, unquote(char)>>)
     end
   end
+
+  defp split_digits(<<rest::binary>>, _base, acc), do: {acc, rest}
 
   @doc """
   Returns a binary which corresponds to the text representation

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -239,24 +239,24 @@ defmodule Integer do
     raise ArgumentError, "invalid base #{inspect base}"
   end
 
-  def parse(<<?-, rest::binary>>, base), do: parse_digits(rest, base, "-")
-  def parse(<<?+, rest::binary>>, base), do: parse_digits(rest, base, "")
-  def parse(<<rest::binary>>, base), do: parse_digits(rest, base, "")
+  def parse(<<?-, rest::binary>>, base), do: parse_digits(rest, base, '-')
+  def parse(<<?+, rest::binary>>, base), do: parse_digits(rest, base, '')
+  def parse(<<rest::binary>>, base), do: parse_digits(rest, base, '')
 
   digits = [{?0..?9, -?0}, {?A..?Z, 10 - ?A}, {?a..?z, 10 - ?a}]
 
   for {chars, diff} <- digits, char <- chars do
     defp parse_digits(<<unquote(char), rest::binary>>, base, acc)
          when base > unquote(char + diff) do
-      parse_digits(rest, base, <<acc::binary, unquote(char)>>)
+      parse_digits(rest, base, [unquote(char) | acc])
     end
   end
 
-  defp parse_digits(<<_::binary>>, _, "-"), do: :error
-  defp parse_digits(<<_::binary>>, _, ""), do: :error
+  defp parse_digits(<<_::binary>>, _, '-'), do: :error
+  defp parse_digits(<<_::binary>>, _, ''), do: :error
 
   defp parse_digits(<<rest::binary>>, base, acc) do
-    {String.to_integer(acc, base), rest}
+    {acc |> :lists.reverse |> :erlang.list_to_integer(base), rest}
   end
 
   @doc """


### PR DESCRIPTION
Improves readability by being more concise ~~and avoiding meta-programming~~. It also improves performance beyond the already fast implementation from #5859.

Some numbers from executing [the benchmark](https://github.com/elixir-lang/elixir/pull/5859#issuecomment-285681896) from #5859 on my Macbook Pro (Mac OS 10.12.4, Erlang 19.3):

```
elixir 1.4.2: 8197µs
current master (3e56f6d32): 410µs
this pull-request: 149µs
```

/cc @fishcakez