### PR TITLE
Docker based development environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+version: "2.0"
+
+services:
+  erl181:
+    build: docker/erl181
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/elixir
+
+  erl182:
+    build: docker/erl182
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/elixir
+
+  erl183:
+    build: docker/erl183
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/elixir
+
+  erl190:
+    build: docker/erl190
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/elixir
+
+  erl191:
+    build: docker/erl191
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/elixir
+
+  erl192:
+    build: docker/erl192
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/elixir
+
+  erl193:
+    build: docker/erl193
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/elixir

--- a/docker/erl181/Dockerfile
+++ b/docker/erl181/Dockerfile
@@ -1,0 +1,24 @@
+FROM erlang:18.1
+
+# install basic dev tools
+RUN apt-get update -qq && apt-get install -y \
+      vim \
+      make \
+      curl
+
+# Install and use UTF-8 locale
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update -qq && \
+	apt-get install -y locales -qq && \
+	locale-gen en_US.UTF-8 en_us && \
+	dpkg-reconfigure locales && \
+	dpkg-reconfigure locales && \
+	locale-gen C.UTF-8 && \
+	/usr/sbin/update-locale LANG=C.UTF-8
+
+ENV LANG C.UTF-8
+ENV LANGUAGE C.UTF-8
+ENV LC_ALL C.UTF-8
+
+WORKDIR /elixir
+ENTRYPOINT ["bash"]

--- a/docker/erl182/Dockerfile
+++ b/docker/erl182/Dockerfile
@@ -1,0 +1,24 @@
+FROM erlang:18.2
+
+# install basic dev tools
+RUN apt-get update -qq && apt-get install -y \
+      vim \
+      make \
+      curl
+
+# Install and use UTF-8 locale
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update -qq && \
+	apt-get install -y locales -qq && \
+	locale-gen en_US.UTF-8 en_us && \
+	dpkg-reconfigure locales && \
+	dpkg-reconfigure locales && \
+	locale-gen C.UTF-8 && \
+	/usr/sbin/update-locale LANG=C.UTF-8
+
+ENV LANG C.UTF-8
+ENV LANGUAGE C.UTF-8
+ENV LC_ALL C.UTF-8
+
+WORKDIR /elixir
+ENTRYPOINT ["bash"]

--- a/docker/erl183/Dockerfile
+++ b/docker/erl183/Dockerfile
@@ -1,0 +1,24 @@
+FROM erlang:18.3
+
+# install basic dev tools
+RUN apt-get update -qq && apt-get install -y \
+      vim \
+      make \
+      curl
+
+# Install and use UTF-8 locale
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update -qq && \
+	apt-get install -y locales -qq && \
+	locale-gen en_US.UTF-8 en_us && \
+	dpkg-reconfigure locales && \
+	dpkg-reconfigure locales && \
+	locale-gen C.UTF-8 && \
+	/usr/sbin/update-locale LANG=C.UTF-8
+
+ENV LANG C.UTF-8
+ENV LANGUAGE C.UTF-8
+ENV LC_ALL C.UTF-8
+
+WORKDIR /elixir
+ENTRYPOINT ["bash"]

--- a/docker/erl190/Dockerfile
+++ b/docker/erl190/Dockerfile
@@ -1,0 +1,24 @@
+FROM erlang:19.0
+
+# install basic dev tools
+RUN apt-get update -qq && apt-get install -y \
+      vim \
+      make \
+      curl
+
+# Install and use UTF-8 locale
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update -qq && \
+	apt-get install -y locales -qq && \
+	locale-gen en_US.UTF-8 en_us && \
+	dpkg-reconfigure locales && \
+	dpkg-reconfigure locales && \
+	locale-gen C.UTF-8 && \
+	/usr/sbin/update-locale LANG=C.UTF-8
+
+ENV LANG C.UTF-8
+ENV LANGUAGE C.UTF-8
+ENV LC_ALL C.UTF-8
+
+WORKDIR /elixir
+ENTRYPOINT ["bash"]

--- a/docker/erl191/Dockerfile
+++ b/docker/erl191/Dockerfile
@@ -1,0 +1,24 @@
+FROM erlang:19.1
+
+# install basic dev tools
+RUN apt-get update -qq && apt-get install -y \
+      vim \
+      make \
+      curl
+
+# Install and use UTF-8 locale
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update -qq && \
+	apt-get install -y locales -qq && \
+	locale-gen en_US.UTF-8 en_us && \
+	dpkg-reconfigure locales && \
+	dpkg-reconfigure locales && \
+	locale-gen C.UTF-8 && \
+	/usr/sbin/update-locale LANG=C.UTF-8
+
+ENV LANG C.UTF-8
+ENV LANGUAGE C.UTF-8
+ENV LC_ALL C.UTF-8
+
+WORKDIR /elixir
+ENTRYPOINT ["bash"]

--- a/docker/erl192/Dockerfile
+++ b/docker/erl192/Dockerfile
@@ -1,0 +1,24 @@
+FROM erlang:19.2
+
+# install basic dev tools
+RUN apt-get update -qq && apt-get install -y \
+      vim \
+      make \
+      curl
+
+# Install and use UTF-8 locale
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update -qq && \
+	apt-get install -y locales -qq && \
+	locale-gen en_US.UTF-8 en_us && \
+	dpkg-reconfigure locales && \
+	dpkg-reconfigure locales && \
+	locale-gen C.UTF-8 && \
+	/usr/sbin/update-locale LANG=C.UTF-8
+
+ENV LANG C.UTF-8
+ENV LANGUAGE C.UTF-8
+ENV LC_ALL C.UTF-8
+
+WORKDIR /elixir
+ENTRYPOINT ["bash"]

--- a/docker/erl193/Dockerfile
+++ b/docker/erl193/Dockerfile
@@ -1,0 +1,24 @@
+FROM erlang:19.3
+
+# install basic dev tools
+RUN apt-get update -qq && apt-get install -y \
+      vim \
+      make \
+      curl
+
+# Install and use UTF-8 locale
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update -qq && \
+	apt-get install -y locales -qq && \
+	locale-gen en_US.UTF-8 en_us && \
+	dpkg-reconfigure locales && \
+	dpkg-reconfigure locales && \
+	locale-gen C.UTF-8 && \
+	/usr/sbin/update-locale LANG=C.UTF-8
+
+ENV LANG C.UTF-8
+ENV LANGUAGE C.UTF-8
+ENV LC_ALL C.UTF-8
+
+WORKDIR /elixir
+ENTRYPOINT ["bash"]


### PR DESCRIPTION
I have played around with the idea of using docker as a development environment for developing elixir. It works very nice, and it would allow us quickly compile on more than one OTP platform without dirtying our host machines (e.g installing kerl and compiling various erlang versions).

The development flow would be the following:

1. First, you open a terminal, navigate to the root of the project, and start a development machine. For example, you would type `docker-compose run erl192` to compile/test your code based on Erlang 19.2. This starts a bash shell, and shares(mounts) the projects into the docker image.

2. You edit the code, either on your host machine with Atom for example, or from inside of the docker image with Vim and when you are happy with the changes you can type `make test` in the bash shell from the running docker image.

This _could_ be also used as the base for testing in the CI environment, but I am not sure of the performance penalty.

I got a successful (green) build for every docker image (erl_18.1, erl_18.2, erl_18.3, erl_19.0, erl_19.1, erl_19.2, erl_19.3)

Let me know if you like this idea 🙇 

* the code is a bit messy, and would require some DRYing.
* tested only on OSX