### PR TITLE
Add Agent.get/1 by defaulting the function to the identity function

### DIFF
--- a/lib/elixir/lib/agent.ex
+++ b/lib/elixir/lib/agent.ex
@@ -231,7 +231,7 @@ defmodule Agent do
 
   """
   @spec get(agent, (state -> a), timeout) :: a when a: var
-  def get(agent, fun, timeout \\ 5000) when is_function(fun, 1) do
+  def get(agent, fun \\ &(&1), timeout \\ 5000) when is_function(fun, 1) do
     GenServer.call(agent, {:get, fun}, timeout)
   end
 


### PR DESCRIPTION
Default the function to the identity function to allow easier access to the state. 

Most uses of this function I've seen pass in the identity function. Is there any reason not to default it?

(This is my first Elixir PR. Let me know if I haven't followed protocol 😃  Thanks! )