### PR TITLE
StringIO read_line performance and binread bug fix

### DIFF
--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -342,16 +342,12 @@ defmodule StringIO do
     %{s | output: <<output::binary, IO.chardata_to_string(prompt)::binary>>}
   end
 
-  defp binary_collect(<<input::binary>>, :unicode, acc) do
-    binary_collect(input, :utf8, acc)
-  end
-
   defp binary_collect("", _, acc), do: {acc, ""}
   defp binary_collect(<<"\r\n"::binary, tail::binary>>, _, acc), do: {<<acc::binary, "\n">>, tail}
   defp binary_collect(<<"\n"::binary, tail::binary>>, _, acc), do: {<<acc::binary, "\n">>, tail}
 
-  defp binary_collect(<<head::utf8, tail::binary>>, :utf8, acc) do
-    binary_collect(tail, :utf8, <<acc::binary, head::utf8 >>)
+  defp binary_collect(<<head::utf8, tail::binary>>, :unicode, acc) do
+    binary_collect(tail, :unicode, <<acc::binary, head::utf8 >>)
   end
 
   defp binary_collect(<<head, tail::binary>>, :latin1, acc) do

--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -256,15 +256,16 @@ defmodule StringIO do
   ## get_line
 
   defp get_line(encoding, prompt, %{input: input} = s) do
-    with {:ok, count} <- bytes_until_eol(input, encoding, 0) do
-      {result, remainder} = case count do
-        0 -> {:eof, ""}
-        count -> split_at_eol(input, count)
-      end
+    case bytes_until_eol(input, encoding, 0) do
+      {:ok, count} ->
+        {result, remainder} = case count do
+          0 -> {:eof, ""}
+          count -> split_at_eol(input, count)
+        end
 
-      {result, state_after_read(s, remainder, prompt)}
-    else
-      _ -> {{:error, :collect_line}, s}
+        {result, state_after_read(s, remainder, prompt)}
+      :error
+        -> {{:error, :collect_line}, s}
     end
   end
 

--- a/lib/elixir/test/elixir/string_io_test.exs
+++ b/lib/elixir/test/elixir/string_io_test.exs
@@ -110,9 +110,9 @@ defmodule StringIOTest do
     assert contents(pid) == {"", ""}
   end
 
-  test "IO.binread :line with Latin1" do
-    pid = start(<<181,?\n>>)
-    assert IO.binread(pid, :line) == "µ\n"
+  test "IO.binread :line with raw bytes" do
+    pid = start(<<181, 255, 194, ?\n>>)
+    assert IO.binread(pid, :line) == <<181, 255, 194, ?\n>>
     assert IO.binread(pid, :line) == :eof
     assert contents(pid) == {"", ""}
   end

--- a/lib/elixir/test/elixir/string_io_test.exs
+++ b/lib/elixir/test/elixir/string_io_test.exs
@@ -54,6 +54,13 @@ defmodule StringIOTest do
     assert contents(pid) == {"", ""}
   end
 
+  test "IO.read :line with UTF-8" do
+    pid = start("⼊\n")
+    assert IO.read(pid, :line) == "⼊\n"
+    assert IO.read(pid, :line) == :eof
+    assert contents(pid) == {"", ""}
+  end
+
   test "IO.read :line with invalid UTF-8" do
     pid = start(<<130, 227, 129, 132, 227, 129, 134>>)
     assert IO.read(pid, :line) == {:error, :collect_line}
@@ -99,6 +106,13 @@ defmodule StringIOTest do
   test "IO.binread :line without line break" do
     pid = start("abc")
     assert IO.binread(pid, :line) == "abc"
+    assert IO.binread(pid, :line) == :eof
+    assert contents(pid) == {"", ""}
+  end
+
+  test "IO.binread :line with Latin1" do
+    pid = start(<<181,?\n>>)
+    assert IO.binread(pid, :line) == "µ\n"
     assert IO.binread(pid, :line) == :eof
     assert contents(pid) == {"", ""}
   end


### PR DESCRIPTION
This pull request currently consists of 3 separate commits:

1. bf28be6243392a5c40367d329fa7ed233e257a2b Adds test coverage to the existing implementation.
2. 2a475a6a8d1e80b1c8790915b0d08a3eb4357429 Fixes #6037, the performance/scalability problem.
3. c7e821394841c3eda7743f37933a60d501675125 Fixes a bug. `IO.binread` should return raw bytes instead of decoding the input as if it were Latin1. See [this comment](https://github.com/elixir-lang/elixir/issues/6037#issuecomment-298233279).

I can split the last item into a separate pull-request if desired.

Using [this benchmark](https://gist.github.com/balexand/629e37f97865ce404f002199c3b406cd), each `IO.read(pid, :line)` call takes:

```
Before: 2557µs when N=5,000 O(N)
After: 14µs O(1)
```

`StringIO.get_until` suffers from the same performance problem but I've avoided touching it (and `collect_line`) because it has almost no test coverage. When I delete the entire function the only test that fails is:

```
1) test with get until (ExUnit.CaptureIOTest)
   test/ex_unit/capture_io_test.exs:196
   Assertion with == failed
   code:  capture_io(fn -> :io.scan_erl_form('>') end) == ">"
   left:  ""
   right: ">"
   stacktrace:
     test/ex_unit/capture_io_test.exs:197: (test)
```

I'd be happy to work on `get_until` in a separate pull-request. But first, does `StringIO` even need to support `get_until` or can we delete it? Also, is there any documentation about `get_until` other than http://erlang.org/doc/apps/stdlib/io_protocol.html?