### PR TITLE
Fix: ExUnit Setup_all fails with 0 exit status (#5967)

### DIFF
--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -89,10 +89,12 @@ defmodule ExUnit.CLIFormatter do
   end
 
   def handle_cast({:case_finished, %ExUnit.TestCase{state: {:failed, failures}} = test_case}, config) do
-    formatted = format_test_case_failure(test_case, failures, config.failure_counter + 1,
+    formatted = format_test_case_failure(test_case, failures, config.failure_counter + length(test_case.tests),
                                          config.width, &formatter(&1, &2, config))
+
     print_failure(formatted, config)
-    {:noreply, %{config | failure_counter: config.failure_counter + 1}}
+    test_counter = Enum.reduce(test_case.tests, config.test_counter, &update_test_counter(&2, &1))
+    {:noreply, %{config | test_counter: test_counter, failure_counter: config.failure_counter + length(test_case.tests)}}
   end
 
   ## Tracing

--- a/lib/ex_unit/lib/ex_unit/runner_stats.ex
+++ b/lib/ex_unit/lib/ex_unit/runner_stats.ex
@@ -25,6 +25,12 @@ defmodule ExUnit.RunnerStats do
     {:noreply, %{map | total: total + 1, skipped: skipped + 1}}
   end
 
+  def handle_cast({:case_finished, %ExUnit.TestCase{state: {:failed, _reason}} = test_case},
+                  %{failures: failures, total: total} = map) do
+    test_count = length(test_case.tests)
+    {:noreply, %{map | failures: failures + test_count, total: total + test_count}}
+  end
+
   def handle_cast({:test_finished, _}, %{total: total} = map) do
     {:noreply, %{map | total: total + 1}}
   end


### PR DESCRIPTION
Addresses #5967 
- Handle `setup_all` failures as the failure of all test in the case for `RunnerStats` and `CliFormatter` WRT `test_counter` and `failure_counter`