### PR TITLE
Implement `Mix.env?/1`

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -205,6 +205,21 @@ defmodule Mix do
   end
 
   @doc """
+  Checks if the given `environment` is the current one.
+
+  ## Examples
+
+     iex> Mix.env?(:dev)
+     true
+     iex> Mix.env?(:prod)
+     false
+
+  """
+  def env?(environment) when is_atom(environment) do
+    env == environment
+  end
+
+  @doc """
   Changes the current Mix environment to `env`.
 
   Be careful when invoking this function as any project

--- a/lib/mix/test/mix_test.exs
+++ b/lib/mix/test/mix_test.exs
@@ -13,6 +13,15 @@ defmodule MixTest do
     assert Mix.env == :prod
   end
 
+  test "env?" do
+    assert Mix.env?(:dev)
+    refute Mix.env?(:prod)
+
+    Mix.env(:prod)
+    assert Mix.env?(:prod)
+    refute Mix.env?(:dev)
+  end
+
   test "debug" do
     refute Mix.debug?
     Mix.debug(true)


### PR DESCRIPTION
Hi and thank you all for Elixir!

This is a minor proposal to introduce `Mix.env?/1` as an alternative solution to check the current environment.

As a personal note. I find the current way to check the env a bit inelegant. The check happens "inline", rather than being wrapped inside a public API query.

Here's a practical demo of the idea. 😄 

Before:

```elixir
    iex> Mix.env
    :dev
    iex> Mix.env == :dev
    true
    iex> Mix.env == :prod
    false
```

After:

```elixir
    iex> Mix.env
    :dev
    iex> Mix.env?(:dev)
    true
    iex> Mix.env?(:prod)
    false
```

💚 