### PR TITLE
Add example with captured function to doc for `Enum.map/2`

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1220,6 +1220,9 @@ defmodule Enum do
       iex> Enum.map([a: 1, b: 2], fn({k, v}) -> {k, -v} end)
       [a: -1, b: -2]
 
+      iex> Enum.map(["1", "2", "3"], &String.to_integer/1)
+      [1, 2, 3]
+
   """
   @spec map(t, (element -> any)) :: list
   def map(enumerable, fun)


### PR DESCRIPTION
A programmer consulting the docs for `Enum.map/2` might not know the function capture syntax, and might benefit from an example demonstrating it in addition to the examples with anonymous functions.