### PR TITLE
Silence compilation warnings about the deprecation of HashDict/HashSet

### DIFF
--- a/lib/elixir/lib/hash_dict.ex
+++ b/lib/elixir/lib/hash_dict.ex
@@ -221,16 +221,35 @@ defmodule HashDict do
 end
 
 defimpl Enumerable, for: HashDict do
-  def reduce(dict, acc, fun),  do: HashDict.reduce(dict, acc, fun)
-  def member?(dict, {k, v}), do: {:ok, match?({:ok, ^v}, HashDict.fetch(dict, k))}
-  def member?(_dict, _),       do: {:ok, false}
-  def count(dict),             do: {:ok, HashDict.size(dict)}
+  def reduce(dict, acc, fun) do
+    # Avoid warnings about HashDict being deprecated.
+    module = HashDict
+    module.reduce(dict, acc, fun)
+  end
+
+  def member?(dict, {key, value}) do
+    # Avoid warnings about HashDict being deprecated.
+    module = HashDict
+    {:ok, match?({:ok, ^value}, module.fetch(dict, key))}
+  end
+
+  def member?(_dict, _) do
+    {:ok, false}
+  end
+
+  def count(dict) do
+    # Avoid warnings about HashDict being deprecated.
+    module = HashDict
+    {:ok, module.size(dict)}
+  end
 end
 
 defimpl Collectable, for: HashDict do
   def into(original) do
+    # Avoid warnings about HashDict being deprecated.
+    module = HashDict
     {original, fn
-      dict, {:cont, {k, v}} -> HashDict.put(dict, k, v)
+      dict, {:cont, {key, value}} -> module.put(dict, key, value)
       dict, :done -> dict
       _, :halt -> :ok
     end}
@@ -241,6 +260,8 @@ defimpl Inspect, for: HashDict do
   import Inspect.Algebra
 
   def inspect(dict, opts) do
-    concat ["#HashDict<", Inspect.List.inspect(HashDict.to_list(dict), opts), ">"]
+    # Avoid warnings about HashDict being deprecated.
+    module = HashDict
+    concat ["#HashDict<", Inspect.List.inspect(module.to_list(dict), opts), ">"]
   end
 end

--- a/lib/elixir/lib/hash_set.ex
+++ b/lib/elixir/lib/hash_set.ex
@@ -236,15 +236,31 @@ defmodule HashSet do
 end
 
 defimpl Enumerable, for: HashSet do
-  def reduce(set, acc, fun), do: HashSet.reduce(set, acc, fun)
-  def member?(set, v),       do: {:ok, HashSet.member?(set, v)}
-  def count(set),            do: {:ok, HashSet.size(set)}
+  def reduce(set, acc, fun) do
+    # Avoid warnings about HashSet being deprecated.
+    module = HashSet
+    module.reduce(set, acc, fun)
+  end
+
+  def member?(set, term) do
+    # Avoid warnings about HashSet being deprecated.
+    module = HashSet
+    {:ok, module.member?(set, term)}
+  end
+
+  def count(set) do
+    # Avoid warnings about HashSet being deprecated.
+    module = HashSet
+    {:ok, module.size(set)}
+  end
 end
 
 defimpl Collectable, for: HashSet do
   def into(original) do
+    # Avoid warnings about HashSet being deprecated.
+    module = HashSet
     {original, fn
-      set, {:cont, x} -> HashSet.put(set, x)
+      set, {:cont, term} -> module.put(set, term)
       set, :done -> set
       _, :halt -> :ok
     end}
@@ -255,6 +271,8 @@ defimpl Inspect, for: HashSet do
   import Inspect.Algebra
 
   def inspect(set, opts) do
-    concat ["#HashSet<", Inspect.List.inspect(HashSet.to_list(set), opts), ">"]
+    # Avoid warnings about HashSet being deprecated.
+    module = HashSet
+    concat ["#HashSet<", Inspect.List.inspect(module.to_list(set), opts), ">"]
   end
 end


### PR DESCRIPTION
Similar to what was done in 73ae8ed2856f3d324a8f3b044e7d43bce130db4f for `Dict`.