### PR TITLE
Remove unused ignored entries in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /doc
-/ebin
 /lib/*/ebin/
 /lib/*/_build/
 /lib/*/tmp
@@ -8,10 +7,8 @@
 /lib/elixir/test/ebin
 /man/elixir.1
 /man/iex.1
-/rel/elixir
 /Docs-v*.zip
 /Precompiled-v*.zip
 /.eunit
-/.release
 .elixir.plt
 erl_crash.dump


### PR DESCRIPTION
1) /.release
Removed long time ago in these two commits.
commit 8ced611aee30a30ed6728a9ef32c0d7094f3a262
Author: José Valim <jose.valim@plataformatec.com.br>
Date:   Thu Jan 24 08:05:01 2013 -0700
    We no longer have a .release task
commit 85fca3de2ecc36436e655db6afa0acf9bfa51f43
Author: José Valim <jose.valim@plataformatec.com.br>
Date:   Wed Jan 23 13:53:09 2013 -0700
    Properly declare .PHONY targets

2) /rel/elixir
Removed in this commit.
commit d44e8bd1f6efc54e664c28fdfc864af37e7e3129
Author: José Valim <jose.valim@plataformatec.com.br>
Date:   Tue Feb 11 10:24:27 2014 +0100
    Remove release files

3) /ebin
Previously used with rebar2