### PR TITLE
Show invalid option in error message when invalid options are expanded

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -659,8 +659,8 @@ validate_opts(Meta, Kind, Allowed, Opts, E) when is_list(Opts) ->
     form_error(Meta, ?key(E, file), ?MODULE, {unsupported_option, Kind, Key})
   end || {Key, _} <- Opts, not lists:member(Key, Allowed)];
 
-validate_opts(Meta, Kind, _Allowed, _Opts, E) ->
-  form_error(Meta, ?key(E, file), ?MODULE, {options_are_not_keyword, Kind}).
+validate_opts(Meta, Kind, _Allowed, Opts, E) ->
+  form_error(Meta, ?key(E, file), ?MODULE, {options_are_not_keyword, Kind, Opts}).
 
 no_alias_opts(Opts) when is_list(Opts) ->
   case lists:keyfind(as, 1, Opts) of
@@ -909,7 +909,8 @@ format_error({invalid_pid_or_ref_in_function, PidOrRef, {Name, Arity}}) ->
 format_error({unsupported_option, Kind, Key}) ->
   io_lib:format("unsupported option ~ts given to ~s",
                 ['Elixir.Macro':to_string(Key), Kind]);
-format_error({options_are_not_keyword, Kind}) ->
-  io_lib:format("invalid options for ~s, expected a keyword list", [Kind]);
+format_error({options_are_not_keyword, Kind, Opts}) ->
+  io_lib:format("invalid options for ~s, expected a keyword list, got: ~ts",
+                [Kind, 'Elixir.Macro':to_string(Opts)]);
 format_error({undefined_function, Name, Args}) ->
   io_lib:format("undefined function ~ts/~B", [Name, length(Args)]).

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -103,6 +103,10 @@ defmodule Kernel.ExpansionTest do
       assert_raise CompileError,
         ~r"invalid :except option for import, expected a keyword list with integer values",
         fn -> expand(quote do: (import Kernel, except: [invalid: nil])) end
+
+      assert_raise CompileError,
+        ~r/invalid options for import, expected a keyword list, got: "invalid_options"/,
+        fn -> expand(quote do: (import Kernel, "invalid_options")) end
     end
 
     test "raises on conflicting options" do


### PR DESCRIPTION
I was working with import/2 in a macro, and it was not easy to see what was wrong. I hope this helps