### PR TITLE
Always use `use ExUnit.Case` when trying to run doctests

### DIFF
--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -548,7 +548,7 @@ defmodule ExUnit.DocTestTest do
   test "multiple exceptions in one test case is not supported" do
     assert_raise ExUnit.DocTest.Error, ~r"multiple exceptions in one doctest case are not supported", fn ->
       defmodule NeverCompiled do
-        import ExUnit.DocTest
+        use ExUnit.Case
         doctest ExUnit.DocTestTest.MultipleExceptions
       end
     end
@@ -557,7 +557,7 @@ defmodule ExUnit.DocTestTest do
   test "fails on invalid module" do
     assert_raise CompileError, ~r"module ExUnit\.DocTestTest\.Unknown is not loaded and could not be found", fn ->
       defmodule NeverCompiled do
-        import ExUnit.DocTest
+        use ExUnit.Case
         doctest ExUnit.DocTestTest.Unknown
       end
     end
@@ -566,7 +566,7 @@ defmodule ExUnit.DocTestTest do
   test "fails when there are no docs" do
     assert_raise ExUnit.DocTest.Error, ~r"could not retrieve the documentation for module ExUnit\.DocTestTest", fn ->
       defmodule NeverCompiled do
-        import ExUnit.DocTest
+        use ExUnit.Case
         doctest ExUnit.DocTestTest
       end
     end
@@ -576,7 +576,7 @@ defmodule ExUnit.DocTestTest do
     assert_raise ExUnit.DocTest.Error,
       ~r[test/ex_unit/doc_test_test\.exs:\d+: indentation level mismatch: "   iex> bar = 2", should have been 2 spaces], fn ->
       defmodule NeverCompiled do
-        import ExUnit.DocTest
+        use ExUnit.Case
         doctest ExUnit.DocTestTest.IndentationMismatchedPrompt
       end
     end
@@ -584,7 +584,7 @@ defmodule ExUnit.DocTestTest do
     assert_raise ExUnit.DocTest.Error,
       ~r[test/ex_unit/doc_test_test\.exs:\d+: indentation level mismatch: "    3", should have been 2 spaces], fn ->
       defmodule NeverCompiled do
-        import ExUnit.DocTest
+        use ExUnit.Case
         doctest ExUnit.DocTestTest.IndentationTooMuch
       end
     end
@@ -592,7 +592,7 @@ defmodule ExUnit.DocTestTest do
     assert_raise ExUnit.DocTest.Error,
       ~r[test/ex_unit/doc_test_test\.exs:\d+: indentation level mismatch: \"  3\", should have been 4 spaces], fn ->
       defmodule NeverCompiled do
-        import ExUnit.DocTest
+        use ExUnit.Case
         doctest ExUnit.DocTestTest.IndentationNotEnough
       end
     end
@@ -602,7 +602,7 @@ defmodule ExUnit.DocTestTest do
     assert_raise ExUnit.DocTest.Error,
       ~r[test/ex_unit/doc_test_test\.exs:\d+: expected non-blank line to follow iex> prompt], fn ->
       defmodule NeverCompiled do
-        import ExUnit.DocTest
+        use ExUnit.Case
         doctest ExUnit.DocTestTest.Incomplete
       end
     end
@@ -611,7 +611,7 @@ defmodule ExUnit.DocTestTest do
   test "fails on invalid use" do
     assert_raise RuntimeError, ~r"cannot define test", fn ->
       defmodule FunctionClashFail do
-        import ExUnit.DocTest
+        use ExUnit.Case
         doctest ExUnit.DocTestTest.Invalid
       end
     end


### PR DESCRIPTION
Fixes an error of importing doctest/2 in tests,
otherwise we will get a RuntimeError if we import ExUnit.DocTest

  ** (RuntimeError) cannot define test. Please make sure you have invoked "use ExUnit.Case" in the current module