### PR TITLE
Optimize reversal of lists with :lists.reverse/1-2

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -652,7 +652,7 @@ defmodule Access do
 
   defp get_and_update_at([head | rest], 0, next, updates) do
     case next.(head) do
-      {get, update} -> {get, :lists.reverse([update | updates], rest)}
+      {get, update} -> {get, :lists.reverse(updates, [update | rest])}
       :pop -> {head, :lists.reverse(updates, rest)}
     end
   end

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -372,7 +372,7 @@ defmodule Enum do
       :lists.reverse(acc)
     else
       buffer = :lists.reverse(buffer, take(leftover, count - i))
-      :lists.reverse([buffer | acc])
+      :lists.reverse(acc, [buffer])
     end
   end
 

--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -161,13 +161,13 @@ defmodule IO.ANSI.Docs do
     {stripped, next_count} = strip_spaces(line, 0, max)
     case process_list_next_kind(stripped, rest, count, next_count) do
       :next -> process_list_next(rest, count, max, [stripped | acc])
-      :done -> {Enum.reverse(acc), [line | rest], true}
-      :list -> {Enum.reverse(acc), [line | rest], false}
+      :done -> {:lists.reverse(acc), [line | rest], true}
+      :list -> {:lists.reverse(acc), [line | rest], false}
     end
   end
 
   defp process_list_next([], _count, _max, acc) do
-    {Enum.reverse(acc), [], true}
+    {:lists.reverse(acc), [], true}
   end
 
   defp process_list_next_kind(stripped, rest, count, next_count) do
@@ -190,7 +190,7 @@ defmodule IO.ANSI.Docs do
   ## Text
 
   defp write_text(text, indent, options) do
-    case Enum.reverse(text) do
+    case :lists.reverse(text) do
       [:no_wrap | rest] -> write_text(rest, indent, options, true)
       rest -> write_text(rest, indent, options, false)
     end
@@ -249,7 +249,7 @@ defmodule IO.ANSI.Docs do
   end
 
   defp write_code(code, indent, options) do
-    write(:doc_code, "#{indent}    #{Enum.join(Enum.reverse(code), "\n#{indent}    ")}", options)
+    write(:doc_code, "#{indent}    #{Enum.join(:lists.reverse(code), "\n#{indent}    ")}", options)
     newline_after_block()
   end
 
@@ -395,12 +395,12 @@ defmodule IO.ANSI.Docs do
 
       # Otherwise
       true ->
-        {Enum.reverse(acc), [word | words]}
+        {:lists.reverse(acc), [word | words]}
     end
   end
 
   defp take_words([], _available, acc) do
-    {Enum.reverse(acc), []}
+    {:lists.reverse(acc), []}
   end
 
   defp length_without_escape(<<?\e, ?[, _, _, ?m>> <> rest, count) do
@@ -471,29 +471,29 @@ defmodule IO.ANSI.Docs do
 
   defp handle_inline(<<delimiter, ?*, ?*, rest::binary>>, nil, buffer, acc, options)
       when rest != "" and delimiter in @delimiters do
-    handle_inline(rest, ?d, ["**"], [delimiter, Enum.reverse(buffer) | acc], options)
+    handle_inline(rest, ?d, ["**"], [delimiter, :lists.reverse(buffer) | acc], options)
   end
 
   defp handle_inline(<<delimiter, mark, rest::binary>>, nil, buffer, acc, options)
       when rest != "" and delimiter in @delimiters and mark in @single do
-    handle_inline(rest, mark, [<<mark>>], [delimiter, Enum.reverse(buffer) | acc], options)
+    handle_inline(rest, mark, [<<mark>>], [delimiter, :lists.reverse(buffer) | acc], options)
   end
 
   defp handle_inline(<<?`, rest::binary>>, nil, buffer, acc, options)
       when rest != "" do
-    handle_inline(rest, ?`, ["`"], [Enum.reverse(buffer) | acc], options)
+    handle_inline(rest, ?`, ["`"], [:lists.reverse(buffer) | acc], options)
   end
 
   # Clauses for handling escape
 
   defp handle_inline(<<?\\, ?\\, ?*, ?*, rest::binary>>, nil, buffer, acc, options)
       when rest != "" do
-    handle_inline(rest, ?d, ["**"], [?\\, Enum.reverse(buffer) | acc], options)
+    handle_inline(rest, ?d, ["**"], [?\\, :lists.reverse(buffer) | acc], options)
   end
 
   defp handle_inline(<<?\\, ?\\, mark, rest::binary>>, nil, buffer, acc, options)
       when rest != "" and mark in @single do
-    handle_inline(rest, mark, [<<mark>>], [?\\, Enum.reverse(buffer) | acc], options)
+    handle_inline(rest, mark, [<<mark>>], [?\\, :lists.reverse(buffer) | acc], options)
   end
 
   defp handle_inline(<<?\\, ?\\, rest::binary>>, limit, buffer, acc, options) do
@@ -539,12 +539,12 @@ defmodule IO.ANSI.Docs do
   end
 
   defp handle_inline(<<>>, _mark, buffer, acc, _options) do
-    IO.iodata_to_binary Enum.reverse([Enum.reverse(buffer) | acc])
+    IO.iodata_to_binary :lists.reverse(acc, [:lists.reverse(buffer)])
   end
 
   defp inline_buffer(buffer, options) do
-    [h | t] = Enum.reverse([IO.ANSI.reset | buffer])
-    [color_for(h, options) | t]
+    [head | tail] = :lists.reverse(buffer, [IO.ANSI.reset])
+    [color_for(head, options) | tail]
   end
 
   defp color_for(mark, colors) do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3364,11 +3364,11 @@ defmodule Kernel do
     end
   end
 
-  defp module_nesting([x | t1], [x | t2], acc, full),
-    do: module_nesting(t1, t2, [x | acc], full)
-  defp module_nesting([], [h | _], acc, _full),
-    do: {String.to_atom(<<"Elixir.", h::binary>>),
-          :elixir_aliases.concat(:lists.reverse([h | acc]))}
+  defp module_nesting([head | tail1], [head | tail2], acc, full),
+    do: module_nesting(tail1, tail2, [head | acc], full)
+  defp module_nesting([], [head | _], acc, _full),
+    do: {String.to_atom(<<"Elixir.", head::binary>>),
+          :elixir_aliases.concat(:lists.reverse(acc, [head]))}
   defp module_nesting(_, _, _acc, full),
     do: {nil, full}
 

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -290,7 +290,7 @@ defmodule OptionParser do
   end
 
   defp do_parse([], _config, opts, args, invalid, _all?) do
-    {Enum.reverse(opts), Enum.reverse(args), Enum.reverse(invalid)}
+    {:lists.reverse(opts), :lists.reverse(args), :lists.reverse(invalid)}
   end
 
   defp do_parse(argv, %{switches: switches} = config, opts, args, invalid, all?) do
@@ -310,14 +310,14 @@ defmodule OptionParser do
         do_parse(rest, config, opts, args, [{option, nil} | invalid], all?)
 
       {:error, ["--" | rest]} ->
-        {Enum.reverse(opts), Enum.reverse(args, rest), Enum.reverse(invalid)}
+        {:lists.reverse(opts), :lists.reverse(args, rest), :lists.reverse(invalid)}
 
       {:error, [arg | rest] = remaining_args} ->
         # there is no option
         if all? do
           do_parse(rest, config, opts, [arg | args], invalid, all?)
         else
-          {Enum.reverse(opts), Enum.reverse(args, remaining_args), Enum.reverse(invalid)}
+          {:lists.reverse(opts), :lists.reverse(args, remaining_args), :lists.reverse(invalid)}
         end
     end
   end
@@ -516,10 +516,10 @@ defmodule OptionParser do
 
   # Finish the string expecting a nil marker
   defp do_split(<<>>, "", acc, nil),
-    do: Enum.reverse(acc)
+    do: :lists.reverse(acc)
 
   defp do_split(<<>>, buffer, acc, nil),
-    do: Enum.reverse([buffer | acc])
+    do: :lists.reverse(acc, [buffer])
 
   # Otherwise raise
   defp do_split(<<>>, _, _acc, marker) do

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1328,9 +1328,9 @@ defmodule String do
 
   defp do_chunk(string, flag, pred_fn), do: do_chunk(string, [], <<>>, flag, pred_fn)
 
-  defp do_chunk(<<>>, acc, <<>>, _, _), do: Enum.reverse(acc)
+  defp do_chunk(<<>>, acc, <<>>, _, _), do: :lists.reverse(acc)
 
-  defp do_chunk(<<>>, acc, chunk, _, _), do: Enum.reverse(acc, [chunk])
+  defp do_chunk(<<>>, acc, chunk, _, _), do: :lists.reverse(acc, [chunk])
 
   defp do_chunk(string, acc, chunk, flag, pred_fn) do
     {cp, rest} = next_codepoint(string)
@@ -2013,7 +2013,7 @@ defmodule String do
   defp detect(_char, [], _lim, _idx, _acc),  do: nil
 
   defp detect(char, [char | rest], _lim, idx, acc),
-    do: {idx, Enum.reverse(acc, [nil | rest])}
+    do: {idx, :lists.reverse(acc, [nil | rest])}
 
   defp detect(char, [other | rest], lim, idx, acc),
     do: detect(char, rest, lim - 1, idx + 1, [other | acc])

--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -368,11 +368,11 @@ defmodule StringIO do
   end
 
   defp collect_line([?\r, ?\n | rest], stack) do
-    {:lists.reverse([?\n | stack]), rest}
+    {:lists.reverse(stack, [?\n]), rest}
   end
 
   defp collect_line([?\n | rest], stack) do
-    {:lists.reverse([?\n | stack]), rest}
+    {:lists.reverse(stack, [?\n]), rest}
   end
 
   defp collect_line([h | t], stack) do

--- a/lib/elixir/unicode/graphemes_test.exs
+++ b/lib/elixir/unicode/graphemes_test.exs
@@ -54,7 +54,7 @@ defmodule GraphemesTest do
         parse_grapheme_break(right, acc_string <> grapheme, [grapheme | acc_list])
       [left] ->
         grapheme = breaks_to_grapheme(left)
-        {acc_string <> grapheme, Enum.reverse([grapheme | acc_list])}
+        {acc_string <> grapheme, :lists.reverse(acc_list, [grapheme])}
     end
   end
 

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -439,7 +439,7 @@ defmodule ExUnit.DocTest do
   end
 
   defp adjust_indent(_kind, [], _line_no, adjusted_lines, _indent, _module) do
-    Enum.reverse adjusted_lines
+    :lists.reverse(adjusted_lines)
   end
 
   defp adjust_indent(:text, [line | rest], line_no, adjusted_lines, indent, module) do
@@ -518,13 +518,13 @@ defmodule ExUnit.DocTest do
   end
 
   defp extract_tests([], "", "", acc, _, _) do
-    Enum.reverse(acc)
+    :lists.reverse(acc)
   end
 
   # End of input and we've still got a test pending.
   defp extract_tests([], expr_acc, expected_acc, [test | rest], _, _) do
     test = add_expr(test, expr_acc, expected_acc)
-    Enum.reverse([test | rest])
+    :lists.reverse(rest, [test])
   end
 
   # We've encountered the next test on an adjacent line. Put them into one group.
@@ -613,7 +613,7 @@ defmodule ExUnit.DocTest do
   end
 
   defp normalize_test(%{exprs: exprs} = test, fa) do
-    %{test | fun_arity: fa, exprs: Enum.reverse(exprs)}
+    %{test | fun_arity: fa, exprs: :lists.reverse(exprs)}
   end
 
   defp add_expr(%{exprs: exprs} = test, expr, expected) do

--- a/lib/mix/lib/mix/local.ex
+++ b/lib/mix/lib/mix/local.ex
@@ -156,7 +156,7 @@ defmodule Mix.Local do
   defp find_latest_eligible_version(entries) do
     {:ok, current_version} = Version.parse(System.version)
     entries
-    |> Enum.reverse
+    |> :lists.reverse()
     |> Enum.find_value(entries, &find_version(&1, current_version))
   end
 

--- a/lib/mix/lib/mix/tasks/do.ex
+++ b/lib/mix/lib/mix/tasks/do.ex
@@ -33,8 +33,8 @@ defmodule Mix.Tasks.Do do
       when binary_part(head, byte_size(head), -1) == "," do
     current =
       case binary_part(head, 0, byte_size(head) - 1) do
-        "" -> Enum.reverse(current)
-        part -> Enum.reverse([part | current])
+        "" -> :lists.reverse(current)
+        part -> :lists.reverse(current, [part])
       end
     gather_commands(rest, [], [current | acc])
   end


### PR DESCRIPTION
This optimization avoids the indirection by Enum.reverse/1-2
when it is known that we are dealing with lists.
ie. instead of doing:
  - `Enum.reverse(list)` or `Enum.reverse(list, rest)`

we do:
  - `:lists.reverse(list)` and `:lists.reverse(list, rest)`

Additionally it takes advantage of :lists.reverse/2,
prebuilding the second argument list.
Ie. instead of doing: `:lists.reverse([value | acc])`
We do: `:lists.reverse(acc, [value])`

And instead of `:lists.reverse([value | acc], rest)`,
we do: `:lists.reverse(acc, [value | rest])`