### PR TITLE
Optimize reversal of lists with {Enum/:lists}.reverse/1-2

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -652,7 +652,7 @@ defmodule Access do
 
   defp get_and_update_at([head | rest], 0, next, updates) do
     case next.(head) do
-      {get, update} -> {get, :lists.reverse([update | updates], rest)}
+      {get, update} -> {get, :lists.reverse(updates, [update | rest])}
       :pop -> {head, :lists.reverse(updates, rest)}
     end
   end

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -372,7 +372,7 @@ defmodule Enum do
       :lists.reverse(acc)
     else
       buffer = :lists.reverse(buffer, take(leftover, count - i))
-      :lists.reverse([buffer | acc])
+      :lists.reverse(acc, [buffer])
     end
   end
 

--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -539,12 +539,12 @@ defmodule IO.ANSI.Docs do
   end
 
   defp handle_inline(<<>>, _mark, buffer, acc, _options) do
-    IO.iodata_to_binary Enum.reverse([Enum.reverse(buffer) | acc])
+    IO.iodata_to_binary Enum.reverse(acc, [Enum.reverse(buffer)])
   end
 
   defp inline_buffer(buffer, options) do
-    [h | t] = Enum.reverse([IO.ANSI.reset | buffer])
-    [color_for(h, options) | t]
+    [head | tail] = Enum.reverse(buffer, [IO.ANSI.reset])
+    [color_for(head, options) | tail]
   end
 
   defp color_for(mark, colors) do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3364,11 +3364,11 @@ defmodule Kernel do
     end
   end
 
-  defp module_nesting([x | t1], [x | t2], acc, full),
-    do: module_nesting(t1, t2, [x | acc], full)
-  defp module_nesting([], [h | _], acc, _full),
-    do: {String.to_atom(<<"Elixir.", h::binary>>),
-          :elixir_aliases.concat(:lists.reverse([h | acc]))}
+  defp module_nesting([head | tail1], [head | tail2], acc, full),
+    do: module_nesting(tail1, tail2, [head | acc], full)
+  defp module_nesting([], [head | _], acc, _full),
+    do: {String.to_atom(<<"Elixir.", head::binary>>),
+         :elixir_aliases.concat(:lists.reverse(acc, [head]))}
   defp module_nesting(_, _, _acc, full),
     do: {nil, full}
 

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -519,7 +519,7 @@ defmodule OptionParser do
     do: Enum.reverse(acc)
 
   defp do_split(<<>>, buffer, acc, nil),
-    do: Enum.reverse([buffer | acc])
+    do: Enum.reverse(acc, [buffer])
 
   # Otherwise raise
   defp do_split(<<>>, _, _acc, marker) do

--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -368,11 +368,11 @@ defmodule StringIO do
   end
 
   defp collect_line([?\r, ?\n | rest], stack) do
-    {:lists.reverse([?\n | stack]), rest}
+    {:lists.reverse(stack, [?\n]), rest}
   end
 
   defp collect_line([?\n | rest], stack) do
-    {:lists.reverse([?\n | stack]), rest}
+    {:lists.reverse(stack, [?\n]), rest}
   end
 
   defp collect_line([h | t], stack) do

--- a/lib/elixir/unicode/graphemes_test.exs
+++ b/lib/elixir/unicode/graphemes_test.exs
@@ -54,7 +54,7 @@ defmodule GraphemesTest do
         parse_grapheme_break(right, acc_string <> grapheme, [grapheme | acc_list])
       [left] ->
         grapheme = breaks_to_grapheme(left)
-        {acc_string <> grapheme, Enum.reverse([grapheme | acc_list])}
+        {acc_string <> grapheme, Enum.reverse(acc_list, [grapheme])}
     end
   end
 

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -524,7 +524,7 @@ defmodule ExUnit.DocTest do
   # End of input and we've still got a test pending.
   defp extract_tests([], expr_acc, expected_acc, [test | rest], _, _) do
     test = add_expr(test, expr_acc, expected_acc)
-    Enum.reverse([test | rest])
+    Enum.reverse(rest, [test])
   end
 
   # We've encountered the next test on an adjacent line. Put them into one group.

--- a/lib/mix/lib/mix/tasks/do.ex
+++ b/lib/mix/lib/mix/tasks/do.ex
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Do do
     current =
       case binary_part(head, 0, byte_size(head) - 1) do
         "" -> Enum.reverse(current)
-        part -> Enum.reverse([part | current])
+        part -> Enum.reverse(current, [part])
       end
     gather_commands(rest, [], [current | acc])
   end


### PR DESCRIPTION
_Second try for https://github.com/elixir-lang/elixir/pull/6078_

It takes advantage of :lists/Enum.reverse/2,
prebuilding the second argument list.
ie. instead of doing: `{Enum,:lists}.reverse([value | acc])`
We do: `reverse(acc, [value])`

And instead of `{Enum, :lists}.reverse([value | acc], rest)`,
we do: `reverse(acc, [value | rest])`