### PR TITLE
Replace GenEvent.remove_handler/3 with :gen_event in GenEvent.Stream

### DIFF
--- a/lib/elixir/lib/gen_event/stream.ex
+++ b/lib/elixir/lib/gen_event/stream.ex
@@ -137,7 +137,7 @@ defimpl Enumerable, for: GenEvent.Stream do
   # If we reach this branch, the handler was not removed yet,
   # so we trigger a request for doing so.
   defp stop(stream, {pid, ref, _} = acc) do
-    _ = GenEvent.remove_handler(pid, {pid, ref}, :shutdown)
+    _ = :gen_event.delete_handler(pid, {pid, ref}, :shutdown)
     stop(stream, {:removed, acc})
   end
 


### PR DESCRIPTION
This suppresses the deprecation warning. Functionality should be equivalent, but please double check :)