### PR TITLE
Unused inlined implementations

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -131,8 +131,12 @@ defmodule Kernel do
 
   """
   @spec bit_size(bitstring) :: non_neg_integer
-  def bit_size(bitstring) do
-    :erlang.bit_size(bitstring)
+  def bit_size(_bitstring) do
+    # This function is inlined, please check the clause 
+    #
+    #   inline(?kernel, bit_size, 1)
+    #
+    # in src/elixir_rewrite.erl.
   end
 
   @doc """


### PR DESCRIPTION
This pull request is mostly a request for comments (for past 1.5).

Some time ago, I believed "inlining" meant "the compiler replaces function calls with their bodies" and I thought I was looking at the implementation of inlined functions in their corresponding Elixir sources. I think that would be a pretty standard interpretation of "inlining".

But in the process of reading the source code of the compiler for my talk in Barcelona I noticed that [expansion inlines functions](https://github.com/elixir-lang/elixir/blob/531975610fce41be29f8d177baf3034fe8064c2b/lib/elixir/src/elixir_expand.erl#L631) by replacing nodes with whatever [_src/elixir_rewrite.erl_](https://github.com/elixir-lang/elixir/blob/master/lib/elixir/src/elixir_rewrite.erl) has.

The attached patch makes this pretty clear to the reader of the code, and gives a pointer in case they want to check the implementation. It is just an example of one possible way to address this (though I do not assume you agree this is worth addressing, thus sending a small sample to open the discussion).

Note that the test suite with that empty function body passes, which is the point: that code is doing nothing, so better not have it there.

If on the contrary, there is a use case where that code gets executed that I am not aware of, then this is telling us said use case lacks coverage and both implementations could theoretically diverge without the test suite noticing.

What do you think?