### PR TITLE
Clean up usage of get_stracktrace in elixir_errors.erl

### DIFF
--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -146,11 +146,6 @@ raise(none, File, Kind, Message) ->
 raise({Line, _, _}, File, Kind, Message) when is_integer(Line) ->
   raise(Line, File, Kind, Message);
 raise(Line, File, Kind, Message) when is_integer(Line), is_binary(File), is_binary(Message) ->
-  try
-    throw(ok)
-  catch
-    ok -> ok
-  end,
-  Stacktrace = erlang:get_stacktrace(),
+  Stacktrace = try throw(ok) catch ok -> erlang:get_stacktrace() end,
   Exception = Kind:exception([{description, Message}, {file, File}, {line, Line}]),
   erlang:raise(error, Exception, tl(Stacktrace)).


### PR DESCRIPTION
It's possible get_stacktrace won't work outside of catch clauses in the future.

Reference: https://github.com/erlang/otp/pull/1449