### PR TITLE
Standardize messages that suggest to run a command-line command

### DIFF
--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -209,13 +209,13 @@ defmodule Mix.Dep do
     do: "the dependency does not match the requirement #{inspect req}, got #{inspect vsn}"
 
   def format_status(%Mix.Dep{status: {:lockmismatch, _}}),
-    do: "lock mismatch: the dependency is out of date (run \"mix deps.get\" to fetch locked version)"
+    do: "lock mismatch: the dependency is out of date. To fetch locked version run \"mix deps.get\""
 
   def format_status(%Mix.Dep{status: :lockoutdated}),
-    do: "lock outdated: the lock is outdated compared to the options in your mixfile (run \"mix deps.get\" to fetch locked version)"
+    do: "lock outdated: the lock is outdated compared to the options in your mixfile. To fetch locked version run \"mix deps.get\""
 
   def format_status(%Mix.Dep{status: :nolock}),
-    do: "the dependency is not locked (run \"mix deps.get\" to generate \"mix.lock\" file)"
+    do: "the dependency is not locked. To generate the \"mix.lock\" file run \"mix deps.get\""
 
   def format_status(%Mix.Dep{status: :compile}),
     do: "the dependency build is outdated, please run \"#{mix_env_var()}mix deps.compile\""

--- a/lib/mix/lib/mix/hex.ex
+++ b/lib/mix/lib/mix/hex.ex
@@ -14,7 +14,7 @@ defmodule Mix.Hex do
       shell = Mix.shell
       shell.info "Could not find Hex, which is needed to build dependency #{inspect app}"
 
-      if shell.yes?("Shall I install Hex? (if running non-interactively, use: \"mix local.hex --force\")") do
+      if shell.yes?("Shall I install Hex? (if running non-interactively, use \"mix local.hex --force\")") do
         Mix.Tasks.Local.Hex.run ["--force"]
       else
         false

--- a/lib/mix/lib/mix/local/installer.ex
+++ b/lib/mix/lib/mix/local/installer.ex
@@ -51,13 +51,13 @@ defmodule Mix.Local.Installer do
 
     install_spec =
       case parse_args(args, opts) do
-        {:error, message} -> Mix.raise message <> "\n" <> usage(name)
+        {:error, message} -> Mix.raise message <> "\n\n" <> usage(name)
         install_spec -> install_spec
       end
 
     case module.check_install_spec(install_spec, opts) do
       :ok -> :noop
-      {:error, message} -> Mix.raise message <> "\n" <> usage(name)
+      {:error, message} -> Mix.raise message <> "\n\n" <> usage(name)
     end
 
     case install_spec do
@@ -81,7 +81,7 @@ defmodule Mix.Local.Installer do
           do_install({module, name}, src, opts)
         else
           Mix.raise "Expected an #{name} to exist in the current directory " <>
-                    "or an argument to be given.\n#{usage(name)}"
+                    "or an argument to be given.\n\n#{usage(name)}"
         end
     end
   end
@@ -94,7 +94,7 @@ defmodule Mix.Local.Installer do
     URI.parse(url_or_path).scheme in ["http", "https"]
   end
 
-  defp usage(name), do: "\nRun:\n\n    mix help #{name}.install\n\nfor more information."
+  defp usage(name), do: "For more information run \"mix help #{name}.install\""
 
   defp do_install({module, name}, src, opts) do
     src_basename = Path.basename(URI.parse(src).path)

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -182,7 +182,7 @@ defmodule Mix.Tasks.Deps.Compile do
     shell.info "Could not find \"#{manager}\", which is needed to build dependency #{inspect app}"
     shell.info "I can install a local copy which is just used by Mix"
 
-    unless shell.yes?("Shall I install #{manager}? (if running non-interactively, use: \"mix local.rebar --force\")") do
+    unless shell.yes?("Shall I install #{manager}? (if running non-interactively, use \"mix local.rebar --force\")") do
       Mix.raise "Could not find \"#{manager}\" to compile " <>
         "dependency #{inspect app}, please ensure \"#{manager}\" is available"
     end

--- a/lib/mix/lib/mix/tasks/iex.ex
+++ b/lib/mix/lib/mix/tasks/iex.ex
@@ -7,6 +7,6 @@ defmodule Mix.Tasks.Iex do
 
   @spec run(OptionParser.argv) :: no_return
   def run(_) do
-    Mix.raise "To use IEx with Mix, please run: \"iex -S mix\""
+    Mix.raise "To use IEx with Mix, please run \"iex -S mix\""
   end
 end

--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -54,7 +54,7 @@ defmodule Mix.Tasks.Local.Rebar do
         install_from_s3(:rebar3, @rebar3_list_url, @rebar3_escript_url, opts)
       _ ->
         Mix.raise "Invalid arguments given to mix local.rebar. " <>
-                  "Check the proper call syntax with: mix help local.rebar"
+                  "To find out the proper call syntax run \"mix help local.rebar\""
     end
   end
 

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -122,7 +122,7 @@ defmodule Mix.Tasks.Xref do
       ["graph"] ->
         graph(opts)
       _ ->
-        Mix.raise "xref doesn't support this command, see \"mix help xref\" for more information"
+        Mix.raise "xref doesn't support this command. For more information run \"mix help xref\""
     end
   end
 

--- a/lib/mix/test/mix/tasks/deps.git_test.exs
+++ b/lib/mix/test/mix/tasks/deps.git_test.exs
@@ -352,7 +352,7 @@ defmodule Mix.Tasks.DepsGitTest do
       refresh deps: [{:git_repo, "0.1.0", git: fixture_path("git_repo"), ref: last}]
 
       Mix.Tasks.Deps.run []
-      msg = "  lock outdated: the lock is outdated compared to the options in your mixfile (run \"mix deps.get\" to fetch locked version)"
+      msg = "  lock outdated: the lock is outdated compared to the options in your mixfile. To fetch locked version run \"mix deps.get\""
       assert_received {:mix_shell, :info, [^msg]}
 
       # Check an update was triggered

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -104,20 +104,20 @@ defmodule Mix.Tasks.DepsTest do
 
       Mix.Tasks.Deps.run []
       assert_received {:mix_shell, :info, ["* ok (https://github.com/elixir-lang/ok.git) (mix)"]}
-      assert_received {:mix_shell, :info, ["  the dependency is not locked (run \"mix deps.get\" to generate \"mix.lock\" file)"]}
+      assert_received {:mix_shell, :info, ["  the dependency is not locked. To generate the \"mix.lock\" file run \"mix deps.get\""]}
 
       Mix.Dep.Lock.write %{ok: {:git, "https://github.com/elixir-lang/ok.git", "abcdefghi", []}}
       Mix.Tasks.Deps.run []
 
       assert_received {:mix_shell, :info, ["* ok (https://github.com/elixir-lang/ok.git) (mix)"]}
       assert_received {:mix_shell, :info, ["  locked at abcdefg"]}
-      assert_received {:mix_shell, :info, ["  lock mismatch: the dependency is out of date (run \"mix deps.get\" to fetch locked version)"]}
+      assert_received {:mix_shell, :info, ["  lock mismatch: the dependency is out of date. To fetch locked version run \"mix deps.get\""]}
 
       Mix.Dep.Lock.write %{ok: {:git, "git://github.com/elixir-lang/another.git", "abcdefghi", []}}
       Mix.Tasks.Deps.run []
 
       assert_received {:mix_shell, :info, ["* ok (https://github.com/elixir-lang/ok.git) (mix)"]}
-      assert_received {:mix_shell, :info, ["  lock outdated: the lock is outdated compared to the options in your mixfile (run \"mix deps.get\" to fetch locked version)"]}
+      assert_received {:mix_shell, :info, ["  lock outdated: the lock is outdated compared to the options in your mixfile. To fetch locked version run \"mix deps.get\""]}
     end
   end
 

--- a/lib/mix/test/mix/tasks/iex_test.exs
+++ b/lib/mix/test/mix/tasks/iex_test.exs
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.IexTest do
 
   test "raises error message about correct usage", context do
     in_tmp context.test, fn ->
-      msg = "To use IEx with Mix, please run: \"iex -S mix\""
+      msg = "To use IEx with Mix, please run \"iex -S mix\""
       assert_raise Mix.Error, msg, fn ->
         Mix.Tasks.Iex.run []
       end

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -451,7 +451,7 @@ defmodule Mix.Tasks.XrefTest do
 
   test "callers: no argument gives error" do
     in_fixture "no_mixfile", fn ->
-      message = "xref doesn't support this command, see \"mix help xref\" for more information"
+      message = "xref doesn't support this command. For more information run \"mix help xref\""
 
       assert_raise Mix.Error, message, fn ->
         assert Mix.Task.run("xref", ["callers"]) == :error


### PR DESCRIPTION
It tries to avoid the use of different styles such as:
- inline commands sentence with user of double-quotes (ie. Invalid arguments, please run "mix something" for more information)
- inline commands in sentence with use of semi-colon (ie. Invalid arguments, please run: mix something)

Suggested commands go in a new line, indented with 4
white-spaces.

Error messages follow the following format:

```
** (Mix) Invalid arguments given to "mix local.rebar"

Check the proper call syntax with:
    mix help local.rebar
```