### PR TITLE
Use @impl to avoid warnings when implementing GenServer

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -550,12 +550,12 @@ defmodule GenServer do
     quote location: :keep do
       @behaviour GenServer
 
-      @doc false
+      @impl GenServer
       def init(args) do
         {:ok, args}
       end
 
-      @doc false
+      @impl GenServer
       def handle_call(msg, _from, state) do
         proc =
           case Process.info(self(), :registered_name) do
@@ -570,7 +570,7 @@ defmodule GenServer do
         end
       end
 
-      @doc false
+      @impl GenServer
       def handle_info(msg, state) do
         proc =
           case Process.info(self(), :registered_name) do
@@ -582,7 +582,7 @@ defmodule GenServer do
         {:noreply, state}
       end
 
-      @doc false
+      @impl GenServer
       def handle_cast(msg, state) do
         proc =
           case Process.info(self(), :registered_name) do
@@ -597,18 +597,17 @@ defmodule GenServer do
         end
       end
 
-      @doc false
+      @impl GenServer
       def terminate(_reason, _state) do
         :ok
       end
 
-      @doc false
+      @impl GenServer
       def code_change(_old, state, _extra) do
         {:ok, state}
       end
 
-      defoverridable [init: 1, handle_call: 3, handle_info: 2,
-                      handle_cast: 2, terminate: 2, code_change: 3]
+      defoverridable GenServer
     end
   end
 


### PR DESCRIPTION
- With the new @impl directive we must define @impl in the `__using__`
  block otherwise we see "module attribute not set" warnings for all the
  callbacks we don't override.