### PR TITLE
Documentation: add :pid to list of Logger metadata builtins

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -237,6 +237,8 @@ defmodule Logger do
 
     * `:line` - the current line
 
+    * `:pid` - the current process ID
+
   The supported keys in the `:colors` keyword list are:
 
     * `:enabled` - boolean value that allows for switching the


### PR DESCRIPTION
I added `:pid` to the list of Logger metadata, and was surprised to find that it worked even without doing `Logger.metadata [pid: self(), ...]`, though it isn't mentioned in the docs list of builtins. This adds it to the docs in case it was omitted by mistake.