### PR TITLE
Fix typo in operators docs

### DIFF
--- a/lib/elixir/pages/Operators.md
+++ b/lib/elixir/pages/Operators.md
@@ -151,4 +151,4 @@ iex> 1 + 2
 
 ### Final note
 
-While it's possible to defined unused operators (such as `<~>`) and to "override" predefined operators (such as `+`), the Elixir community generally discourages this. Custom-defined operators can be really hard to read and even more to understand, as they don't have a descriptive name like functions do. That said, some specific cases or custom domain specific languages (DSLs) may justify these practices.
+While it's possible to define unused operators (such as `<~>`) and to "override" predefined operators (such as `+`), the Elixir community generally discourages this. Custom-defined operators can be really hard to read and even more to understand, as they don't have a descriptive name like functions do. That said, some specific cases or custom domain specific languages (DSLs) may justify these practices.


### PR DESCRIPTION
Changed "While it's possible to **defined**" to "While it's possible to **define**".