### PR TITLE
Refactor Version.parse/1 to not use regexes

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -256,9 +256,10 @@ defmodule Version do
   @spec parse(String.t) :: {:ok, t} | :error
   def parse(string) when is_binary(string) do
     case Version.Parser.parse_version(string) do
-      {:ok, {major, minor, patch, pre}} ->
+      {:ok, {major, minor, patch, pre, build_parts}} ->
+        build = if build_parts == [], do: nil, else: Enum.join(build_parts, "")
         version = %Version{major: major, minor: minor, patch: patch,
-                           pre: pre, build: get_build(string)}
+                           pre: pre, build: build}
         {:ok, version}
      :error ->
        :error
@@ -330,19 +331,10 @@ defmodule Version do
 
   defp to_matchable(string, allow_pre?) do
     case Version.Parser.parse_version(string) do
-      {:ok, {major, minor, patch, pre}} ->
+      {:ok, {major, minor, patch, pre, _build_parts}} ->
         {major, minor, patch, pre, allow_pre?}
       :error ->
         raise InvalidVersionError, string
-    end
-  end
-
-  defp get_build(string) do
-    case Regex.run(~r/\+([^\s]+)$/, string) do
-      nil ->
-        nil
-      [_, build] ->
-        build
     end
   end
 
@@ -411,8 +403,8 @@ defmodule Version do
            {:ok, patch} <- maybe_patch(patch, approximate?),
            {:ok, pre_parts} <- optional_dot_separated(pre),
            {:ok, pre_parts} <- convert_parts_to_integer(pre_parts, []),
-           {:ok, _build_parts} <- optional_dot_separated(build) do
-        {:ok, {major, minor, patch, pre_parts}}
+           {:ok, build_parts} <- optional_dot_separated(build) do
+        {:ok, {major, minor, patch, pre_parts, build_parts}}
       else
         _other -> :error
       end
@@ -597,7 +589,7 @@ defmodule Version do
 
     defp parse_condition(version, approximate? \\ false) do
       case parse_version(version, approximate?) do
-        {:ok, version} -> version
+        {:ok, {major, minor, patch, pre, _build}} -> {major, minor, patch, pre}
         :error -> throw :invalid_matchspec
       end
     end


### PR DESCRIPTION
Rebuilding the `build` part in `Version.parse/1` may not be the absolute best, but we were basically parsing out the build in `Version.Parser.parse_version/1` only to throw it out and not use it anywhere, and then parsing the build again (with a regex) in `Version.parse/1`. This way, we get rid of the regex and simplify the code a bit.