### PR TITLE
Warn when a :__struct__ key is used when building/updating structs

### DIFF
--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -1,6 +1,6 @@
 -module(elixir_map).
 -export([expand_map/3, expand_struct/4, format_error/1]).
--import(elixir_errors, [form_error/4]).
+-import(elixir_errors, [form_error/4, form_warn/4]).
 -include("elixir.hrl").
 
 expand_map(Meta, [{'|', UpdateMeta, [Left, Right]}], #{context := nil} = E) ->
@@ -28,7 +28,7 @@ expand_map(Meta, Args, E) ->
   {{'%{}', Meta, EArgs}, EE}.
 
 expand_struct(Meta, Left, {'%{}', MapMeta, MapArgs}, #{context := Context} = E) ->
-  CleanMapArgs = clean_struct_key_from_map_args(Meta, E, MapArgs),
+  CleanMapArgs = clean_struct_key_from_map_args(Meta, MapArgs, E),
   {[ELeft, ERight], EE} = elixir_expand:expand_args([Left, {'%{}', MapMeta, CleanMapArgs}], E),
 
   case validate_struct(ELeft, Context) of
@@ -69,15 +69,15 @@ expand_struct(Meta, Left, {'%{}', MapMeta, MapArgs}, #{context := Context} = E) 
 expand_struct(Meta, _Left, Right, E) ->
   form_error(Meta, ?key(E, file), ?MODULE, {non_map_after_struct, Right}).
 
-clean_struct_key_from_map_args(Meta, E, [{'|', PipeMeta, [Left, MapAssocs]}]) ->
-  [{'|', PipeMeta, [Left, clean_struct_key_from_map_assocs(Meta, E, MapAssocs)]}];
-clean_struct_key_from_map_args(Meta, E, MapAssocs) ->
-  clean_struct_key_from_map_assocs(Meta, E, MapAssocs).
+clean_struct_key_from_map_args(Meta, [{'|', PipeMeta, [Left, MapAssocs]}], E) ->
+  [{'|', PipeMeta, [Left, clean_struct_key_from_map_assocs(Meta, MapAssocs, E)]}];
+clean_struct_key_from_map_args(Meta, MapAssocs, E) ->
+  clean_struct_key_from_map_assocs(Meta, MapAssocs, E).
 
-clean_struct_key_from_map_assocs(Meta, E, Assocs) ->
+clean_struct_key_from_map_assocs(Meta, Assocs, E) ->
   case lists:keytake('__struct__', 1, Assocs) of
     {value, _, CleanAssocs} ->
-      elixir_errors:warn(?line(Meta), ?key(E, file), "key :__struct__ is ignored when using structs"),
+      form_warn(Meta, ?key(E, file), ?MODULE, ignored_struct_key_in_struct),
       CleanAssocs;
     false ->
       Assocs
@@ -222,4 +222,6 @@ format_error({undefined_struct, Module, Arity}) ->
                 [StringName, Arity, StringName]);
 format_error({unknown_key_for_struct, Module, Key}) ->
   io_lib:format("unknown key ~ts for struct ~ts",
-                ['Elixir.Macro':to_string(Key), 'Elixir.Macro':to_string(Module)]).
+                ['Elixir.Macro':to_string(Key), 'Elixir.Macro':to_string(Module)]);
+format_error(ignored_struct_key_in_struct) ->
+  "key :__struct__ is ignored when using structs".

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -69,21 +69,18 @@ expand_struct(Meta, Left, {'%{}', MapMeta, MapArgs}, #{context := Context} = E) 
 expand_struct(Meta, _Left, Right, E) ->
   form_error(Meta, ?key(E, file), ?MODULE, {non_map_after_struct, Right}).
 
-clean_struct_key_from_map_args(Meta, E, [{'|', PipeMeta, [Left, MapAssocs]}] = MapArgs) ->
-  case lists:keytake('__struct__', 1, MapAssocs) of
-    {value, _, CleanAssocs} ->
-      elixir_errors:warn(?line(Meta), ?key(E, file), "key :__struct__ is ignored when updating structs"),
-      [{'|', PipeMeta, [Left, CleanAssocs]}];
-    false ->
-      MapArgs
-  end;
+clean_struct_key_from_map_args(Meta, E, [{'|', PipeMeta, [Left, MapAssocs]}]) ->
+  [{'|', PipeMeta, [Left, clean_struct_key_from_map_assocs(Meta, E, MapAssocs)]}];
 clean_struct_key_from_map_args(Meta, E, MapAssocs) ->
-  case lists:keytake('__struct__', 1, MapAssocs) of
+  clean_struct_key_from_map_assocs(Meta, E, MapAssocs).
+
+clean_struct_key_from_map_assocs(Meta, E, Assocs) ->
+  case lists:keytake('__struct__', 1, Assocs) of
     {value, _, CleanAssocs} ->
-      elixir_errors:warn(?line(Meta), ?key(E, file), "key :__struct__ is ignored when building structs"),
+      elixir_errors:warn(?line(Meta), ?key(E, file), "key :__struct__ is ignored when using structs"),
       CleanAssocs;
     false ->
-      MapAssocs
+      Assocs
   end.
 
 validate_match_key(_Meta, {'^', _, [_]}, _E) ->

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -790,7 +790,7 @@ defmodule Kernel.WarningTest do
       Code.eval_string """
       assert %Kernel.WarningTest.User{__struct__: Ignored, name: "joe"} ==
              %Kernel.WarningTest.User{name: "joe"}
-      """, _bindings = [], __ENV__
+      """, [], __ENV__
     end) =~ "key :__struct__ is ignored when using structs"
 
     assert capture_err(fn ->
@@ -798,7 +798,7 @@ defmodule Kernel.WarningTest do
       user = %Kernel.WarningTest.User{name: "meg"}
       assert %Kernel.WarningTest.User{user | __struct__: Ignored, name: "joe"} ==
              %Kernel.WarningTest.User{__struct__: Kernel.WarningTest.User, name: "joe"}
-      """, _bindings = [], __ENV__
+      """, [], __ENV__
     end) =~ "key :__struct__ is ignored when using structs"
   end
 

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -785,23 +785,21 @@ defmodule Kernel.WarningTest do
     defstruct [:name]
   end
 
-  test ":__struct__ is ignored when building structs" do
+  test ":__struct__ is ignored when using structs" do
     assert capture_err(fn ->
       Code.eval_string """
       assert %Kernel.WarningTest.User{__struct__: Ignored, name: "joe"} ==
              %Kernel.WarningTest.User{name: "joe"}
       """, _bindings = [], __ENV__
-    end) =~ "key :__struct__ is ignored when building structs"
-  end
+    end) =~ "key :__struct__ is ignored when using structs"
 
-  test ":__struct__ is ignored when updating structs" do
     assert capture_err(fn ->
       Code.eval_string """
       user = %Kernel.WarningTest.User{name: "meg"}
       assert %Kernel.WarningTest.User{user | __struct__: Ignored, name: "joe"} ==
              %Kernel.WarningTest.User{__struct__: Kernel.WarningTest.User, name: "joe"}
       """, _bindings = [], __ENV__
-    end) =~ "key :__struct__ is ignored when updating structs"
+    end) =~ "key :__struct__ is ignored when using structs"
   end
 
   defp purge(list) when is_list(list) do

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -781,6 +781,29 @@ defmodule Kernel.WarningTest do
     purge Sample
   end
 
+  defmodule User do
+    defstruct [:name]
+  end
+
+  test ":__struct__ is ignored when building structs" do
+    assert capture_err(fn ->
+      Code.eval_string """
+      assert %Kernel.WarningTest.User{__struct__: Ignored, name: "joe"} ==
+             %Kernel.WarningTest.User{name: "joe"}
+      """, _bindings = [], __ENV__
+    end) =~ "key :__struct__ is ignored when building structs"
+  end
+
+  test ":__struct__ is ignored when updating structs" do
+    assert capture_err(fn ->
+      Code.eval_string """
+      user = %Kernel.WarningTest.User{name: "meg"}
+      assert %Kernel.WarningTest.User{user | __struct__: Ignored, name: "joe"} ==
+             %Kernel.WarningTest.User{__struct__: Kernel.WarningTest.User, name: "joe"}
+      """, _bindings = [], __ENV__
+    end) =~ "key :__struct__ is ignored when updating structs"
+  end
+
   defp purge(list) when is_list(list) do
     Enum.each list, &purge/1
   end

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -149,9 +149,6 @@ defmodule MapTest do
     assert %ExternalUser{name: "meg"} ==
            %{__struct__: ExternalUser, name: "meg", age: 27}
 
-    assert %ExternalUser{__struct__: ThisWillBeIgnored} ==
-           %{__struct__: ExternalUser, name: "john", age: 27}
-
     user = %ExternalUser{}
     assert %ExternalUser{user | name: "meg"} ==
            %{__struct__: ExternalUser, name: "meg", age: 27}


### PR DESCRIPTION
Until now, `%x{__struct__: y}` would ignore the `:__struct__` part and only use/match on `x`, without warnings. With this commit, a warning is emitted in this case and in the respective case when updating (`%SomeStruct{x | __struct__: y}`).