### PR TITLE
Add missing 'require Logger' in ExUnit.CaptureLog doc example

### DIFF
--- a/lib/ex_unit/lib/ex_unit/capture_log.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_log.ex
@@ -8,6 +8,7 @@ defmodule ExUnit.CaptureLog do
         use ExUnit.Case
 
         import ExUnit.CaptureLog
+        require Logger
 
         test "example" do
           assert capture_log(fn ->


### PR DESCRIPTION
Without `require Logger`, the following won't compile...

```
defmodule AssertionTest do
  use ExUnit.Case

  import ExUnit.CaptureLog
  # require Logger

  test "example" do
    assert capture_log(fn ->
      Logger.error "log msg"
    end) =~ "log msg"
  end

  test "check multiple captures concurrently" do
    fun = fn ->
      for msg <- ["hello", "hi"] do
        assert capture_log(fn -> Logger.error msg end) =~ msg
      end
      Logger.debug "testing"
    end
    assert capture_log(fun) =~ "hello"
    assert capture_log(fun) =~ "testing"
  end
end
```
```
$ mix test
Compiling 1 file (.ex)

== Compilation error on file lib/lsidjflsjdf.ex ==
** (RuntimeError) cannot use ExUnit.Case without starting the ExUnit application, please call ExUnit.start() or explicitly start the :ex_unit app
    expanding macro: ExUnit.Case.__using__/1
    lib/lsidjflsjdf.ex:2: AssertionTest (module)
    (elixir) expanding macro: Kernel.use/1
    lib/lsidjflsjdf.ex:2: AssertionTest (module)
```
With `require Logger`, the compiles & tests run
```
defmodule AssertionTest do
  use ExUnit.Case

  import ExUnit.CaptureLog
  require Logger

  test "example" do
    assert capture_log(fn ->
      Logger.error "log msg"
    end) =~ "log msg"
  end

  test "check multiple captures concurrently" do
    fun = fn ->
      for msg <- ["hello", "hi"] do
        assert capture_log(fn -> Logger.error msg end) =~ msg
      end
      Logger.debug "testing"
    end
    assert capture_log(fun) =~ "hello"
    assert capture_log(fun) =~ "testing"
  end
end
```
```
$ mix test
Compiling 1 file (.ex)
..

Finished in 0.04 seconds
2 tests, 0 failures
```
