### PR TITLE
Streamline typespec of EEx.Engine.fetch_assign! and Access.fetch

### DIFF
--- a/lib/eex/lib/eex/engine.ex
+++ b/lib/eex/lib/eex/engine.ex
@@ -83,7 +83,7 @@ defmodule EEx.Engine do
 
   @doc false
   # TODO: Raise on 2.0
-  @spec fetch_assign!(map, Map.key) :: term | nil
+  @spec fetch_assign!(Access.t, Access.key) :: term | nil
   def fetch_assign!(assigns, key) do
     case Access.fetch(assigns, key) do
       {:ok, val} ->


### PR DESCRIPTION
Whenever EEx templates are used to pass variables via `assigns` whatever
this data structure is will be passed into `EEx.Engine.fetch_assign` and
then into `Access.fetch`.

So it makes sense to use the same typespec for the both. Otherwise
dialyzer will complain about every instance where keyword lists are
passed into functions like `eval_string`, `function_from_file` and
`function_from_string`.