### PR TITLE
Make sure System.stracktrace is first thing done in the handler

### DIFF
--- a/lib/elixir/src/elixir_dispatch.erl
+++ b/lib/elixir/src/elixir_dispatch.erl
@@ -186,10 +186,11 @@ expand_macro_fun(Meta, Fun, Receiver, Name, Args, E) ->
     apply(Fun, [EArg | Args])
   catch
     Kind:Reason ->
+      Stacktrace = erlang:get_stacktrace(),
       Arity = length(Args),
       MFA  = {Receiver, elixir_utils:macro_name(Name), Arity+1},
       Info = [{Receiver, Name, Arity, [{file, "expanding macro"}]}, caller(Line, E)],
-      erlang:raise(Kind, Reason, prune_stacktrace(erlang:get_stacktrace(), MFA, Info, EArg))
+      erlang:raise(Kind, Reason, prune_stacktrace(Stacktrace, MFA, Info, EArg))
   end.
 
 expand_macro_named(Meta, Receiver, Name, Arity, Args, E) ->
@@ -208,9 +209,10 @@ expand_quoted(Meta, Receiver, Name, Arity, Quoted, E) ->
       E)
   catch
     Kind:Reason ->
+      Stacktrace = erlang:get_stacktrace(),
       MFA  = {Receiver, elixir_utils:macro_name(Name), Arity+1},
       Info = [{Receiver, Name, Arity, [{file, "expanding macro"}]}, caller(Line, E)],
-      erlang:raise(Kind, Reason, prune_stacktrace(erlang:get_stacktrace(), MFA, Info, nil))
+      erlang:raise(Kind, Reason, prune_stacktrace(Stacktrace, MFA, Info, nil))
   end.
 
 caller(Line, E) ->

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -162,9 +162,10 @@ load_struct(Meta, Name, Args, InContext, E) ->
       end;
 
     Kind:Reason ->
+      Stacktrace = erlang:get_stacktrace(),
       Info = [{Name, '__struct__', Arity, [{file, "expanding struct"}]},
               elixir_utils:caller(?line(Meta), ?key(E, file), ?key(E, module), ?key(E, function))],
-      erlang:raise(Kind, Reason, prune_stacktrace(erlang:get_stacktrace(), Name, Arity) ++ Info)
+      erlang:raise(Kind, Reason, prune_stacktrace(Stacktrace, Name, Arity) ++ Info)
   end.
 
 prune_stacktrace([{Module, '__struct__', Arity, _} | _], Module, Arity) ->

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -259,8 +259,9 @@ expand_callback(Line, M, F, Args, E, Fun) ->
         EF
       catch
         Kind:Reason ->
+          Stacktrace = erlang:get_stacktrace(),
           Info = {M, F, length(Args), location(Line, E)},
-          erlang:raise(Kind, Reason, prune_stacktrace(Info, erlang:get_stacktrace()))
+          erlang:raise(Kind, Reason, prune_stacktrace(Info, Stacktrace))
       end
   end.
 

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -157,8 +157,9 @@ defmodule IEx.Evaluator do
       %{state | binding: binding, env: :elixir.env_for_eval(env, file: "iex", line: 1)}
     catch
       kind, error ->
+        stacktrace = System.stacktrace()
         io_result "Error while evaluating: #{path}"
-        print_error(kind, error, System.stacktrace)
+        print_error(kind, error, stacktrace)
         System.halt(1)
     end
   end


### PR DESCRIPTION
If any of the functions catches an error, we'd get a wrong trace