### PR TITLE
Consider unicode non-characters as valid (#6108)

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1254,22 +1254,15 @@ defmodule String do
       iex> String.valid?(<<0xFFFF :: 16>>)
       false
 
+      iex> String.valid?(<<0xEF, 0xB7, 0x90>>)
+      true
+
       iex> String.valid?("asd" <> <<0xFFFF :: 16>>)
       false
 
   """
   @spec valid?(t) :: boolean
   def valid?(string)
-
-  noncharacters = Enum.to_list(0xFDD0..0xFDEF) ++
-    [0x0FFFE, 0x0FFFF, 0x1FFFE, 0x1FFFF, 0x2FFFE, 0x2FFFF,
-     0x3FFFE, 0x3FFFF, 0x4FFFE, 0x4FFFF, 0x5FFFE, 0x5FFFF,
-     0x6FFFE, 0x6FFFF, 0x7FFFE, 0x7FFFF, 0x8FFFE, 0x8FFFF,
-     0x9FFFE, 0x9FFFF, 0x10FFFE, 0x10FFFF]
-
-  for noncharacter <- noncharacters do
-    def valid?(<<unquote(noncharacter)::utf8, _::binary>>), do: false
-  end
 
   def valid?(<<_::utf8, t::binary>>), do: valid?(t)
   def valid?(<<>>), do: true
@@ -1307,7 +1300,7 @@ defmodule String do
       ["abc\0"]
 
       iex> String.chunk(<<?a, ?b, ?c, 0, 0x0FFFF::utf8>>, :valid)
-      ["abc\0", <<0x0FFFF::utf8>>]
+      ["abc\0" <> <<0x0FFFF::utf8>>]
 
       iex> String.chunk(<<?a, ?b, ?c, 0, 0x0FFFF::utf8>>, :printable)
       ["abc", <<0, 0x0FFFF::utf8>>]

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1299,8 +1299,8 @@ defmodule String do
       iex> String.chunk(<<?a, ?b, ?c, 0>>, :valid)
       ["abc\0"]
 
-      iex> String.chunk(<<?a, ?b, ?c, 0, 0x0FFFF::utf8>>, :valid)
-      ["abc\0" <> <<0x0FFFF::utf8>>]
+      iex> String.chunk(<<?a, ?b, ?c, 0, 0xFFFF::utf16>>, :valid)
+      ["abc\0", <<0xFFFF::utf16>>]
 
       iex> String.chunk(<<?a, ?b, ?c, 0, 0x0FFFF::utf8>>, :printable)
       ["abc", <<0, 0x0FFFF::utf8>>]

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -569,6 +569,7 @@ defmodule StringTest do
     assert String.valid?("afds")
     assert String.valid?("øsdfh")
     assert String.valid?("dskfjあska")
+    assert String.valid?(<<0xEF, 0xB7, 0x90>>)
 
     refute String.valid?(<<0xFFFF::16>>)
     refute String.valid?("asd" <> <<0xFFFF::16>>)
@@ -580,11 +581,11 @@ defmodule StringTest do
     assert String.chunk("ødskfjあ\x11ska", :valid)
            == ["ødskfjあ\x11ska"]
     assert String.chunk("abc\u{0ffff}def", :valid)
-           == ["abc", <<0x0FFFF::utf8>>, "def"]
+           == ["abc" <> <<0x0FFFF::utf8>> <> "def"]
     assert String.chunk("\u{0FFFE}\u{3FFFF}привет\u{0FFFF}мир", :valid)
-           == [<<0x0FFFE::utf8, 0x3FFFF::utf8>>, "привет", <<0x0FFFF::utf8>>, "мир"]
+           == [<<0x0FFFE::utf8, 0x3FFFF::utf8>> <> "привет" <> <<0x0FFFF::utf8>> <> "мир"]
     assert String.chunk("日本\u{0FFFF}\u{FDEF}ござございます\u{FDD0}", :valid)
-           == ["日本", <<0x0FFFF::utf8, 0xFDEF::utf8>>, "ござございます", <<0xFDD0::utf8>>]
+           == ["日本" <> <<0x0FFFF::utf8, 0xFDEF::utf8>> <> "ござございます" <> <<0xFDD0::utf8>>]
   end
 
   test "chunk/2 with :printable trait" do

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -580,12 +580,6 @@ defmodule StringTest do
 
     assert String.chunk("ødskfjあ\x11ska", :valid)
            == ["ødskfjあ\x11ska"]
-    assert String.chunk("abc\u{0ffff}def", :valid)
-           == ["abc" <> <<0x0FFFF::utf8>> <> "def"]
-    assert String.chunk("\u{0FFFE}\u{3FFFF}привет\u{0FFFF}мир", :valid)
-           == [<<0x0FFFE::utf8, 0x3FFFF::utf8>> <> "привет" <> <<0x0FFFF::utf8>> <> "мир"]
-    assert String.chunk("日本\u{0FFFF}\u{FDEF}ござございます\u{FDD0}", :valid)
-           == ["日本" <> <<0x0FFFF::utf8, 0xFDEF::utf8>> <> "ござございます" <> <<0xFDD0::utf8>>]
   end
 
   test "chunk/2 with :printable trait" do


### PR DESCRIPTION
Hi Maintainers,

New to this community, I'm hoping to improve my understanding of Elixir by working on some issues.

This PR should address the issue raised in #6108, but also breaks the usecase for users that rely on `String.valid?` to check for non-characters...
