### PR TITLE
Give a proper syntax error when invalid sigil delimiters are used

### DIFF
--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -200,6 +200,10 @@ tokenize([$~, S, H | T] = Original, Line, Column, Scope, Tokens) when ?is_sigil(
       interpolation_error(Reason, Original, Tokens, " (for sigil ~ts starting at line ~B)", [Sigil, Line])
   end;
 
+tokenize([$~, S, H | _] = Original, Line, Column, _Scope, Tokens) when ?is_upcase(S) orelse ?is_downcase(S) ->
+  Message = io_lib:format("\"~ts\" (column ~p, codepoint U+~4.16.0B)", [[H], Column + 2, H]),
+  {error, {Line, "invalid sigil delimiter: ", Message}, Original, Tokens};
+
 % Char tokens
 
 % We tokenize char literals (?a) as {char, _, CharInt} instead of {number, _,

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -201,7 +201,10 @@ tokenize([$~, S, H | T] = Original, Line, Column, Scope, Tokens) when ?is_sigil(
   end;
 
 tokenize([$~, S, H | _] = Original, Line, Column, _Scope, Tokens) when ?is_upcase(S) orelse ?is_downcase(S) ->
-  Message = io_lib:format("\"~ts\" (column ~p, codepoint U+~4.16.0B)", [[H], Column + 2, H]),
+  MessageString =
+    "\"~ts\" (column ~p, codepoint U+~4.16.0B). The available delimiters are: "
+    "//, ||, \"\", '', (), [], {}, <>",
+  Message = io_lib:format(MessageString, [[H], Column + 2, H]),
   {error, {Line, "invalid sigil delimiter: ", Message}, Original, Tokens};
 
 % Char tokens

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -185,4 +185,4 @@ vc_merge_conflict_test() ->
 
 invalid_sigil_delimiter_test() ->
   {1, "invalid sigil delimiter: ", Message} = tokenize_error("~s\\"),
-  "\"\\\" (column 3, codepoint U+005C)" = lists:flatten(Message).
+  true = lists:prefix("\"\\\" (column 3, codepoint U+005C)", lists:flatten(Message)).

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -182,3 +182,7 @@ capture_test() ->
 vc_merge_conflict_test() ->
   {1, "found an unexpected version control marker, please resolve the conflicts: ", "<<<<<<< HEAD"} =
     tokenize_error("<<<<<<< HEAD\n[1, 2, 3]").
+
+invalid_sigil_delimiter_test() ->
+  {1, "invalid sigil delimiter: ", Message} = tokenize_error("~s\\"),
+  "\"\\\" (column 3, codepoint U+005C)" = lists:flatten(Message).


### PR DESCRIPTION
Before this PR, we would have:

```elixir
iex> ~s\
** (SyntaxError) iex:1: unexpected token: "~" (column 1, codepoint U+007E)
```

After this commit, we have:

```elixir
iex> ~s\
** (SyntaxError) iex:1: invalid sigil delimiter: "\" (column 3, codepoint U+005C)
```

I'm not sure if we should point to some kind of documentation, or if we should list the possible delimiters, input is welcome.

Closes #6132.