### PR TITLE
Show specific description for dont_display_result atom in i/1 helper

### DIFF
--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -23,7 +23,17 @@ defimpl IEx.Info, for: Atom do
         true ->
           info_atom(atom)
       end
-    ["Data type": "Atom"] ++ specific_info
+
+    description =
+      if atom == IEx.dont_display_result() do
+        ["Description": """
+        This atom is returned by IEx when a function that should not print its
+        return value on screen is executed.
+        """]
+      else
+        []
+      end
+    ["Data type": "Atom"] ++ description ++ specific_info
   end
 
   defp info_module(mod) do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -484,7 +484,7 @@ defmodule IEx.HelpersTest do
     end
   end
 
-  test "i helper" do
+  test "i/1 helper" do
     output = capture_io fn -> i(:ok) end
     assert output =~ String.trim_trailing("""
     Term
@@ -493,6 +493,19 @@ defmodule IEx.HelpersTest do
       Atom
     Reference modules
       Atom
+    """)
+  end
+
+  test "i/1 helper on functions that don't display result" do
+    output = capture_io fn -> i(IEx.dont_display_result()) end
+    assert output =~ String.trim_trailing("""
+    Term
+      :"do not show this result in output"
+    Data type
+      Atom
+    Description
+      This atom is returned by IEx when a function that should not print its
+      return value on screen is executed.
     """)
   end
 


### PR DESCRIPTION
:"do not show this result in output" is the returned value of functions
that print to screen and do not want to show in screen any returned value.

This commits prints the information about `nil` instead.