### PR TITLE
Print information for `nil` when run `i/0` when no history is available

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -449,11 +449,27 @@ defmodule IEx.Helpers do
     :code.load_file(module)
   end
 
+
+  @doc """
+  Prints information about the data type of the previous expression used.
+
+  See `i/1` for more information.
+  """
+  def i() do
+    i(v(-1))
+  rescue
+    exception ->
+      stacktrace = System.stacktrace
+      case exception do
+        %RuntimeError{message: "v(-1) is out of bounds"} ->
+          i(nil)
+        _ ->
+          reraise(exception, stacktrace)
+      end
+  end
+
   @doc """
   Prints information about the data type of any given term.
-
-  If no argument is given, the value of the previous expression
-  is used.
 
   ## Examples
 
@@ -471,7 +487,7 @@ defmodule IEx.Helpers do
         Range, Map
 
   """
-  def i(term \\ v(-1)) do
+  def i(term) do
     info =
       ["Term": inspect(term)] ++
       IEx.Info.info(term) ++

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -496,6 +496,17 @@ defmodule IEx.HelpersTest do
     """)
   end
 
+  test "i/0 helper when no history is available" do
+    assert capture_iex("i()") =~ String.trim_trailing("""
+    Term
+      nil
+    Data type
+      Atom
+    Reference modules
+      Atom
+    """)
+  end
+
   defp test_module_code do
     """
     defmodule Sample do


### PR DESCRIPTION
Avoid cryptic RuntimeError message and print information for nil when
i/0 is called in the first line.

Interactive Elixir (1.4.2) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> i()
** (RuntimeError) v(-1) is out of bounds
    (iex) lib/iex/history.ex:119: IEx.History.nth/2
    (iex) lib/iex/helpers.ex:383: IEx.Helpers.v/1

To achive this I had to split i/1 into two different functions: `i/0` and `i/1`