### PR TITLE
Replace no-break space in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,7 +320,7 @@ This version includes changes that make Elixir fully compatible with Erlang OTP 
 
 #### Elixir
 
-  * [Access] `Access.key/1` is deprecated due to erratic behaviour for missing keys, please use `Access.key/2` instead with proper default values
+  * [Access] `Access.key/1` is deprecated due to erratic behaviour for missing keys, please use `Access.key/2` instead with proper default values
   * [Behaviour] The `Behaviour` module is deprecated. Callbacks may now be defined directly via the `@callback` attribute
   * [Enum] Deprecate `Enum.uniq/2` in favor of `Enum.uniq_by/2`
   * [Float] `Float.to_char_list/2` and `Float.to_string/2` are deprecated (use the `:erlang.float_to_list/2` and `:erlang.float_to_binary/2` functions if such conversions are desired)


### PR DESCRIPTION
This was introduced in
https://github.com/elixir-lang/elixir/pull/5804
due to creating a patch via web interface

Fixes same issue as: https://github.com/elixir-lang/elixir/pull/6032