### PR TITLE
Mix.Tasks.Local.Hex: Clarify --if-missing docs

### DIFF
--- a/lib/mix/lib/mix/tasks/local.hex.ex
+++ b/lib/mix/lib/mix/tasks/local.hex.ex
@@ -17,8 +17,8 @@ defmodule Mix.Tasks.Local.Hex do
       intended for automation in build systems like `make`
 
     * `--if-missing` - performs installation only if Hex is not installed yet;
-      intended for automation when sctips can be run multiple times to avoid
-      reinstalling Hex.
+      intended to avoid repeatedly reinstalling Hex in automation when a script
+      may be run multiple times
 
   If both options are set, `--force` takes precedence.
 


### PR DESCRIPTION
I noticed there was a typo in the docs for `mix local.hex --if-missing` and that the sentence was a little confusing as written, so I tried to clarify it.