### PR TITLE
Allow Hex version to be configured by Mix.Project

### DIFF
--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -96,7 +96,7 @@ defmodule Mix.CLI do
   defp ensure_hex("local.hex"),
     do: :ok
   defp ensure_hex(_task),
-    do: Mix.Hex.ensure_updated?()
+    do: Mix.Hex.ensure_updated?(Mix.Project.config[:hex])
 
   defp ensure_no_slashes(task) do
     if String.contains?(task, "/") do

--- a/lib/mix/lib/mix/hex.ex
+++ b/lib/mix/lib/mix/hex.ex
@@ -1,7 +1,6 @@
 defmodule Mix.Hex do
   @moduledoc false
-  @hex_requirement  ">= 0.14.0"
-  @hex_mirror       "https://repo.hex.pm"
+  @hex_mirror "https://repo.hex.pm"
 
   @doc """
   Returns `true` if `Hex` is loaded or installed. Otherwise returns `false`.
@@ -26,13 +25,14 @@ defmodule Mix.Hex do
   Returns `true` if it has the required `Hex`. If an update is performed, it then exits.
   Otherwise returns `false` without updating anything.
   """
-  @spec ensure_updated?() :: boolean
-  def ensure_updated?() do
+  @spec ensure_updated?(nil | String.t) :: boolean
+  def ensure_updated?(nil), do: ensure_updated?(">= 0.14.0")
+  def ensure_updated?(hex_requirement) do
     cond do
       not Code.ensure_loaded?(Hex) ->
         false
-      not Version.match?(Hex.version, @hex_requirement) ->
-        Mix.shell.info "Mix requires Hex #{@hex_requirement} but you have #{Hex.version}"
+      not Version.match?(Hex.version, hex_requirement) ->
+        Mix.shell.info "Mix requires Hex #{hex_requirement} but you have #{Hex.version}"
 
         if Mix.shell.yes?("Shall I abort the current command and update Hex?") do
           Mix.Tasks.Local.Hex.run ["--force"]


### PR DESCRIPTION
Since different Hex versions can result in different `mix.lock` output, I think it would be helpful to allow a project's desired Hex version to be configured via `Mix.Project`. This would help everyone working on the project to avoid git conflicts/churn in the lockfile.

I didn't see any existing tests around `Mix.CLI` or `Mix.Hex` but if this change is desirable I can look into adding some. (Any guidance around the best way to test this functionality would be greatly appreciated 😄  )

Also, is [this section in Mix.Project](https://github.com/elixir-lang/elixir/blob/867da6f876c48279823a41a33030c95ef37379b2/lib/mix/lib/mix/project.ex#L17)  the best place to add documentation?