### PR TITLE
Fix escript and its test on windows

### DIFF
--- a/lib/mix/lib/mix/tasks/escript.ex
+++ b/lib/mix/lib/mix/tasks/escript.ex
@@ -35,8 +35,14 @@ defmodule Mix.Tasks.Escript do
     other_exec_bit = 0o00001
     stat = File.stat!(path)
 
-    executable_bit =
-      stat.mode &&& (owner_exec_bit ||| group_exec_bit ||| other_exec_bit)
-    executable_bit != 0 and stat.type == :regular and Path.extname(path) != ".bat"
+    case :os.type() do
+      {:win32, _} -> 
+        # on win32, the script itself is not executable, but the bat is
+        File.exists?(path <> ".bat") and stat.type == :regular
+      _ -> 
+        executable_bit =
+          stat.mode &&& (owner_exec_bit ||| group_exec_bit ||| other_exec_bit)
+        executable_bit != 0 and stat.type == :regular and Path.extname(path) != ".bat"
+    end
   end
 end


### PR DESCRIPTION
This took more time than I thought :joy: It wasn't obvious whether the test needs to be fixed or escript itself.. Anyways, this should make test 100% pass on windows. https://ci.appveyor.com/project/xiamx/elixir/build/1-escript_test_windows+28

But https://github.com/elixir-lang/elixir/issues/6149 still prevents the tests from finishing.. which means we won't see the badge becoming green until that issue is fixed