### PR TITLE
Enum: clarify uniq_by function parameter

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2584,8 +2584,9 @@ defmodule Enum do
   Enumerates the `enumerable`, by removing the elements for which
   function `fun` returned duplicate items.
 
-  The function `fun` maps every element to a term which is used to
-  determine if two elements are duplicates.
+  The function `fun` maps every element to a term and then compares the
+  terms for each element in the `enumerable`. Matching terms indicate a
+  duplicate.
 
   The first occurrence of each element is kept.
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2584,9 +2584,9 @@ defmodule Enum do
   Enumerates the `enumerable`, by removing the elements for which
   function `fun` returned duplicate items.
 
-  The function `fun` maps every element to a term and then compares the
-  terms for each element in the `enumerable`. Matching terms indicate a
-  duplicate.
+  The function `fun` maps every element to a term. Two elements are
+  considered duplicates if the return value of `fun` is equal for
+  both of them.
 
   The first occurrence of each element is kept.
 


### PR DESCRIPTION
I had difficulty understanding what sort of function should actually be passed to the second parameter of `Enum.uniq_by/2`. I believe that this helps to clarify it.