### PR TITLE
Make test created by `mix new` actually test your code

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -445,7 +445,7 @@ defmodule Mix.Tasks.New do
     use ExUnit.Case
     doctest <%= @mod %>
 
-    test "salutates the world" do
+    test "greets the world" do
       assert <%= @mod %>.hello() == :world
     end
   end

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -445,8 +445,8 @@ defmodule Mix.Tasks.New do
     use ExUnit.Case
     doctest <%= @mod %>
 
-    test "the truth" do
-      assert 1 + 1 == 2
+    test "salutates the world" do
+      assert <%= @mod %>.hello == :world
     end
   end
   """

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -446,7 +446,7 @@ defmodule Mix.Tasks.New do
     doctest <%= @mod %>
 
     test "salutates the world" do
-      assert <%= @mod %>.hello == :world
+      assert <%= @mod %>.hello() == :world
     end
   end
   """

--- a/lib/mix/test/mix/tasks/new_test.exs
+++ b/lib/mix/test/mix/tasks/new_test.exs
@@ -18,8 +18,10 @@ defmodule Mix.Tasks.NewTest do
       assert_file "hello_world/lib/hello_world.ex",  ~r/defmodule HelloWorld do/
 
       assert_file "hello_world/test/test_helper.exs", ~r/ExUnit.start()/
-      assert_file "hello_world/test/hello_world_test.exs", ~r/defmodule HelloWorldTest do/
-      assert_file "hello_world/test/hello_world_test.exs", ~r/assert HelloWorld.hello == :world/
+      assert_file "hello_world/test/hello_world_test.exs", fn(file) ->
+        assert file =~ ~r/defmodule HelloWorldTest do/
+        assert file =~ "assert HelloWorld.hello() == :world"
+      end
 
       assert_received {:mix_shell, :info, ["* creating mix.exs"]}
       assert_received {:mix_shell, :info, ["* creating lib/hello_world.ex"]}

--- a/lib/mix/test/mix/tasks/new_test.exs
+++ b/lib/mix/test/mix/tasks/new_test.exs
@@ -19,6 +19,7 @@ defmodule Mix.Tasks.NewTest do
 
       assert_file "hello_world/test/test_helper.exs", ~r/ExUnit.start()/
       assert_file "hello_world/test/hello_world_test.exs", ~r/defmodule HelloWorldTest do/
+      assert_file "hello_world/test/hello_world_test.exs", ~r/assert HelloWorld.hello == :world/
 
       assert_received {:mix_shell, :info, ["* creating mix.exs"]}
       assert_received {:mix_shell, :info, ["* creating lib/hello_world.ex"]}


### PR DESCRIPTION
The motivation for this change is that we would want the developers to be either consciously testing or not the code.

This change would push you towards this goal by giving you a red build whenever you changed the code for the first time, leading you to explicitly make the decision of fixing your tests to align with the changes you introduced to the code, or consciously decide to remove them.