### PR TITLE
Fix value inspect for name option

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -677,7 +677,7 @@ defmodule GenServer do
         :gen.start(:gen_server, link, tuple, module, args, opts)
       {{:via, via_module, _term} = tuple, opts} when is_atom(via_module) ->
         :gen.start(:gen_server, link, tuple, module, args, opts)
-      other ->
+      {other, _} ->
         raise ArgumentError, """
         expected :name option to be one of:
 

--- a/lib/elixir/test/elixir/gen_server_test.exs
+++ b/lib/elixir/test/elixir/gen_server_test.exs
@@ -50,6 +50,10 @@ defmodule GenServerTest do
     assert_raise ArgumentError, ~r"expected :name option to be one of:", fn ->
       GenServer.start_link(Stack, [:hello], name: {:via, "Via", "my_gen_server_name"})
     end
+
+    assert_raise ArgumentError, ~r/Got: "my_gen_server_name"/, fn ->
+      GenServer.start_link(Stack, [:hello], name: "my_gen_server_name")
+    end
   end
 
   test "start_link/3 with via" do


### PR DESCRIPTION
I think this would improve the message seen when you pass invalid value for name option. I got confused for a moment with this so I thought this would improve readability.

With something like:
```elixir
defmodule A do
  use GenServer
end
```

Current behavior:
```elixir
GenServer.start(A, [], name: "hello")
** (ArgumentError) expected :name option to be one of:

  * nil
  * atom
  * {:global, term}
  * {:via, module, term}

Got: {"hello", []}

    (elixir) lib/gen_server.ex:674: GenServer.do_start/4
```

Behavior with this PR:
```elixir
GenServer.start(A, [], name: "hello")
** (ArgumentError) expected :name option to be one of:

  * nil
  * atom
  * {:global, term}
  * {:via, module, term}

Got: "hello"

    (elixir) lib/gen_server.ex:681: GenServer.do_start/4
```