### PR TITLE
Do not start oldshell alongside IEx, closes #5730 (on Windows)

### DIFF
--- a/bin/iex.bat
+++ b/bin/iex.bat
@@ -41,6 +41,6 @@ goto end
 
 :run
 @if defined IEX_WITH_WERL (@set __ELIXIR_IEX_FLAGS=--werl) else (set __ELIXIR_IEX_FLAGS=)
-call "%~dp0\elixir.bat" +iex --erl "-user Elixir.IEx.CLI" --no-halt %__ELIXIR_IEX_FLAGS% %*
+call "%~dp0\elixir.bat" +iex --erl "-noshell -user Elixir.IEx.CLI" --no-halt %__ELIXIR_IEX_FLAGS% %*
 :end
 endlocal

--- a/bin/iex.bat
+++ b/bin/iex.bat
@@ -41,6 +41,6 @@ goto end
 
 :run
 @if defined IEX_WITH_WERL (@set __ELIXIR_IEX_FLAGS=--werl) else (set __ELIXIR_IEX_FLAGS=)
-call "%~dp0\elixir.bat" +iex --erl "-noshell -user Elixir.IEx.CLI" --no-halt %__ELIXIR_IEX_FLAGS% %*
+call "%~dp0\elixir.bat" --no-halt --erl "-noshell -user Elixir.IEx.CLI" +iex %__ELIXIR_IEX_FLAGS% %*
 :end
 endlocal


### PR DESCRIPTION
Incorporate commit 82b655a from bin/iex into bin/iex.bat

Original comment:
"Do not start oldshell alongside IEx, closes #5730
Prior to this patch, both oldshell and IEx would start,
which would make them compete for the standard io. This
could be deterministically triggered by pasting input
with multiple lines on the terminal.

This commit guarantees the oldshell is no longer started."

Reorder flags to elixir script in iex.bat to match the order of flags in iex.