### PR TITLE
Guard against invalid input for `keys`

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -361,13 +361,13 @@ defmodule Map do
   @spec take(map, Enumerable.t) :: map
   def take(map, keys)
 
-  def take(map, keys) when is_map(map) do
+  def take(map, keys) when is_map(map) and is_list(keys) do
     keys
     |> Enum.to_list
     |> do_take(map, [])
   end
 
-  def take(non_map, _keys) do
+  def take(non_map, keys) when is_list(keys) do
     :erlang.error({:badmap, non_map})
   end
 
@@ -617,13 +617,13 @@ defmodule Map do
   @spec drop(map, Enumerable.t) :: map
   def drop(map, keys)
 
-  def drop(map, keys) when is_map(map) do
+  def drop(map, keys) when is_map(map) and is_list(keys) do
     keys
     |> Enum.to_list
     |> drop_list(map)
   end
 
-  def drop(non_map, _keys) do
+  def drop(non_map, keys) when is_list(keys) do
     :erlang.error({:badmap, non_map})
   end
 


### PR DESCRIPTION
I think it'd be nice for `Map.drop/2` and `Map.take/2` to guard against invalid inputs for the `keys` argument. I recognize that this isn't necessary, since internally the call to `Enum.to_list/1` raises for invalid inputs in these scenarios: users currently receive a `Protocol.UndefinedError` that reads `protocol Enumerable not implemented for...`.

This makes sense given the erroneous call to `Enum.to_list/1` on a non-enumerable. However this produces an error that reveals more about the implementation details of the `take/2` and `drop/2` functions than it reveals about the more immediately erroneous unsupported function call. I believe that a `FunctionClauseError` or an `ArgumentError` is perhaps more useful and instructive.