### PR TITLE
fix DateTime.from_iso8601/2 fails when offset has no colon

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -240,6 +240,14 @@ defmodule Calendar.ISO do
     do: parse_offset(1, hour, min, rest)
   def parse_offset(<<?-, hour::2-bytes, ?:, min::2-bytes, rest::binary>>),
     do: parse_offset(-1, hour, min, rest)
+  def parse_offset(<<?+, hour::2-bytes, min::2-bytes, rest::binary>>),
+    do: parse_offset(1, hour, min, rest)
+  def parse_offset(<<?-, hour::2-bytes, min::2-bytes, rest::binary>>),
+    do: parse_offset(-1, hour, min, rest)
+  def parse_offset(<<?+, hour::2-bytes, rest::binary>>),
+    do: parse_offset(1, hour, "00", rest)
+  def parse_offset(<<?-, hour::2-bytes, rest::binary>>),
+    do: parse_offset(-1, hour, "00", rest)
   def parse_offset(_),
     do: :error
 

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -163,4 +163,46 @@ defmodule DateTimeTest do
     assert DateTime.compare(datetime1, datetime2) == :lt
     assert DateTime.compare(datetime2, datetime1) == :gt
   end
+
+  test "from_iso8601/1 accepts offset in +HH:MM format" do
+    assert DateTime.from_iso8601("2017-06-02T14:00:00+01:00") |> elem(1) ==
+      %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
+                hour: 13, minute: 0, second: 0, microsecond: {0, 0},
+                utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+  end
+
+  test "from_iso8601/1 accepts offset in -HH:MM format" do
+    assert DateTime.from_iso8601("2017-06-02T14:00:00-04:00") |> elem(1) ==
+      %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
+                hour: 18, minute: 0, second: 0, microsecond: {0, 0},
+                utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+  end
+
+  test "from_iso8601/1 accepts offset in +HHMM format" do
+    assert DateTime.from_iso8601("2017-06-02T14:00:00+0100") |> elem(1) ==
+      %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
+                hour: 13, minute: 0, second: 0, microsecond: {0, 0},
+                utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+  end
+
+  test "from_iso8601/1 accepts offset in -HHMM format" do
+    assert DateTime.from_iso8601("2017-06-02T14:00:00-0400") |> elem(1) ==
+      %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
+                hour: 18, minute: 0, second: 0, microsecond: {0, 0},
+                utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+  end
+
+  test "from_iso8601/1 accepts offset in +HH format" do
+    assert DateTime.from_iso8601("2017-06-02T14:00:00+01") |> elem(1) ==
+      %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
+                hour: 13, minute: 0, second: 0, microsecond: {0, 0},
+                utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+  end
+
+  test "from_iso8601/1 accepts offset in -HH format" do
+    assert DateTime.from_iso8601("2017-06-02T14:00:00-04") |> elem(1) ==
+      %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
+                hour: 18, minute: 0, second: 0, microsecond: {0, 0},
+                utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/elixir-lang/elixir/issues/6181

I'm not sure if it is the right way to work on `v1.4` branch. `master` seems to be bit under the construction at the time of creating this.

It would be appreciated if you can package it in next v1.4 minor :)