### PR TITLE
Add __protocol__(:impls) to protocols

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3971,7 +3971,7 @@ defmodule Kernel do
 
     * `__protocol__/1` - returns the protocol name when `:name` is given, a
       keyword list with the protocol functions and their arities when
-      `:functions` is given, and a list of the implementation when `:impls` is
+      `:functions` is given, and a list of the implementations when `:impls` is
       given
 
     * `impl_for/1` - receives a structure and returns the module that

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3969,9 +3969,10 @@ defmodule Kernel do
 
   Any protocol module contains three extra functions:
 
-    * `__protocol__/1` - returns the protocol name when `:name` is given, and a
+    * `__protocol__/1` - returns the protocol name when `:name` is given, a
       keyword list with the protocol functions and their arities when
-      `:functions` is given
+      `:functions` is given, and a list of the implementation when `:impls` is
+      given
 
     * `impl_for/1` - receives a structure and returns the module that
       implements the protocol for the structure, `nil` otherwise

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -348,7 +348,7 @@ defmodule Protocol do
           {:type, line, :fun,
            [{:type, line, :product, [{:atom, 0, :consolidated?}]},
             {:atom, 0, true}]}
-        {:type, line, :fun, [{:type, _, :product, [{:atom, _, :impls}]}, _]} = i ->
+        {:type, line, :fun, [{:type, _, :product, [{:atom, _, :impls}]}, _]} ->
           {:type, line, :fun,
            [{:type, line, :product, [{:atom, 0, :impls}]},
             {:type, 0, :list, [{:type, 0, :module, []}]}]}

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -226,14 +226,6 @@ defmodule Protocol do
   end
 
   @doc """
-  Returns a list of implementations, or `:error` if the protocol was not consolidated.
-  """
-  @spec impls(module) :: [module] | :error
-  def impls(protocol) do
-    protocol.__protocol__(:impls)
-  end
-
-  @doc """
   Receives a protocol and a list of implementations and
   consolidates the given protocol.
 
@@ -309,7 +301,7 @@ defmodule Protocol do
       {:clause, l, [{:atom, _, :consolidated?}], [], [{:atom, _, _}]} ->
         {:clause, l, [{:atom, 0, :consolidated?}], [], [{:atom, 0, true}]}
       {:clause, l, [{:atom, _, :impls}], [], [{:atom, _, _}]} ->
-        {:clause, l, [{:atom, 0, :impls}], [], [:erl_parse.abstract(types)]}
+        {:clause, l, [{:atom, 0, :impls}], [], [{:tuple, 0, [{:atom, 0, :consolidated}, :erl_parse.abstract(types)]}]}
       {:clause, _, _, _, _} = c ->
         c
     end, clauses)
@@ -351,7 +343,9 @@ defmodule Protocol do
         {:type, line, :fun, [{:type, _, :product, [{:atom, _, :impls}]}, _]} ->
           {:type, line, :fun,
            [{:type, line, :product, [{:atom, 0, :impls}]},
-            {:type, 0, :list, [{:type, 0, :module, []}]}]}
+            {:type, 0, :tuple,
+             [{:atom, 0, :consolidated},
+              {:type, 0, :list, [{:type, 0, :module, []}]}]}]}
         other -> other
       end
     end
@@ -530,11 +524,11 @@ defmodule Protocol do
       @spec __protocol__(:module) :: __MODULE__
       @spec __protocol__(:functions) :: unquote(Protocol.__functions_spec__(@functions))
       @spec __protocol__(:consolidated?) :: false
-      @spec __protocol__(:impls) :: :error
+      @spec __protocol__(:impls) :: :not_consolidated
       Kernel.def __protocol__(:module), do: __MODULE__
       Kernel.def __protocol__(:functions), do: unquote(:lists.sort(@functions))
       Kernel.def __protocol__(:consolidated?), do: false
-      Kernel.def __protocol__(:impls), do: :error
+      Kernel.def __protocol__(:impls), do: :not_consolidated
     end
   end
 

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -140,11 +140,13 @@ defmodule ProtocolTest do
     assert Sample.__protocol__(:module) == Sample
     assert Sample.__protocol__(:functions) == [ok: 1]
     refute Sample.__protocol__(:consolidated?)
+    assert Sample.__protocol__(:impls) == :error
     assert Sample.__info__(:attributes)[:protocol] == [fallback_to_any: false]
 
     assert WithAny.__protocol__(:module) == WithAny
     assert WithAny.__protocol__(:functions) == [ok: 1]
     refute WithAny.__protocol__(:consolidated?)
+    assert WithAny.__protocol__(:impls) == :error
     assert WithAny.__info__(:attributes)[:protocol] == [fallback_to_any: true]
   end
 
@@ -327,6 +329,11 @@ defmodule Protocol.ConsolidationTest do
     refute Protocol.consolidated?(Enumerable)
   end
 
+  test "impls/1" do
+    assert Protocol.impls(WithAny) == [Any, ImplStruct, Map]
+    assert Protocol.impls(Enumerable) == :error
+  end
+
   test "consolidation prevents new implementations" do
     assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
       defimpl WithAny, for: Integer do
@@ -387,7 +394,9 @@ defmodule Protocol.ConsolidationTest do
 
   test "consolidation updates attributes" do
     assert Sample.__protocol__(:consolidated?)
+    assert Sample.__protocol__(:impls) == [ImplStruct]
     assert WithAny.__protocol__(:consolidated?)
+    assert WithAny.__protocol__(:impls) == [Any, ImplStruct, Map]
   end
 
   test "consolidation extracts protocols" do

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -140,13 +140,13 @@ defmodule ProtocolTest do
     assert Sample.__protocol__(:module) == Sample
     assert Sample.__protocol__(:functions) == [ok: 1]
     refute Sample.__protocol__(:consolidated?)
-    assert Sample.__protocol__(:impls) == :error
+    assert Sample.__protocol__(:impls) == :not_consolidated
     assert Sample.__info__(:attributes)[:protocol] == [fallback_to_any: false]
 
     assert WithAny.__protocol__(:module) == WithAny
     assert WithAny.__protocol__(:functions) == [ok: 1]
     refute WithAny.__protocol__(:consolidated?)
-    assert WithAny.__protocol__(:impls) == :error
+    assert WithAny.__protocol__(:impls) == :not_consolidated
     assert WithAny.__info__(:attributes)[:protocol] == [fallback_to_any: true]
   end
 
@@ -329,11 +329,6 @@ defmodule Protocol.ConsolidationTest do
     refute Protocol.consolidated?(Enumerable)
   end
 
-  test "impls/1" do
-    assert Protocol.impls(WithAny) == [Any, ImplStruct, Map]
-    assert Protocol.impls(Enumerable) == :error
-  end
-
   test "consolidation prevents new implementations" do
     assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
       defimpl WithAny, for: Integer do
@@ -394,9 +389,9 @@ defmodule Protocol.ConsolidationTest do
 
   test "consolidation updates attributes" do
     assert Sample.__protocol__(:consolidated?)
-    assert Sample.__protocol__(:impls) == [ImplStruct]
+    assert Sample.__protocol__(:impls) == {:consolidated, [ImplStruct]}
     assert WithAny.__protocol__(:consolidated?)
-    assert WithAny.__protocol__(:impls) == [Any, ImplStruct, Map]
+    assert WithAny.__protocol__(:impls) == {:consolidated, [Any, ImplStruct, Map]}
   end
 
   test "consolidation extracts protocols" do


### PR DESCRIPTION
Implements #6178.

Some questions:

- Keep `Protocol.impls/1` and/or document `protocol.__protocol__(:impls)` in the `Kernel.defprotocol/2` docs?

- I used `[module]` for the spec of the return type of `protocol.__protocol__(:impls)` and `Protocol.impls/1`, is this really correct (since the returned impls aren't really necessarily modules, e.g. `Any`)? Should I be returning the generated impl module names instead of the "types"?