### PR TITLE
Be consistent with v version prefix in mix error message.

### DIFF
--- a/lib/mix/lib/mix/exceptions.ex
+++ b/lib/mix/lib/mix/exceptions.ex
@@ -55,7 +55,7 @@ defmodule Mix.ElixirVersionError do
     actual   = opts[:actual]
     expected = opts[:expected]
     message  = "You're trying to run #{inspect target} on Elixir v#{actual} but it " <>
-               "has declared in its mix.exs file it supports only Elixir #{expected}"
+               "has declared in its mix.exs file it supports only Elixir v#{expected}"
     %Mix.ElixirVersionError{target: target, expected: expected, actual: actual, message: message}
   end
 end


### PR DESCRIPTION
The "actual" version if prefix with the letter "v", this adds the same prefix to the "expected" version.