### PR TITLE
Show better error when h/1 is used on callback

### DIFF
--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -102,6 +102,16 @@ defmodule IEx.HelpersTest do
 
       assert capture_io(fn -> h Impl.first end) == "* @callback first(integer()) :: integer()\n\nDocs for MyBehaviour.first\n"
       assert capture_io(fn -> h Impl.second end) == "* def second(int)\n\nDocs for Impl.second/1\n* def second(int1, int2)\n\nDocs for Impl.second/2\n"
+
+      assert capture_io(fn -> h MyBehaviour.first end) == """
+      No documentation for function MyBehaviour.first was found, but there is a callback with the same name.
+      You can view callback documentations with the b/1 helper.\n
+      """
+      assert capture_io(fn -> h MyBehaviour.second/2 end) == """
+      No documentation for function MyBehaviour.second/2 was found, but there is a callback with the same name.
+      You can view callback documentations with the b/1 helper.\n
+      """
+      assert capture_io(fn -> h MyBehaviour.second/3 end) == "No documentation for MyBehaviour.second/3 was found\n"
     end
   after
     cleanup_modules([Impl, MyBehaviour])


### PR DESCRIPTION
closes #6204 

## Current behaviour
When calling `h/1` on a `callback`
```
iex(1)> h GenServer.init
No documentation for GenServer.init was found
```

## After this change
```
iex(1)> h GenServer.init
No documentation for function GenServer.init was found, but there is a callback
with the same name.
You can view callback documentations with the b/1 helper.
```

when requesting specific arity
```
iex(1)> h GenServer.init/1
No documentation for function GenServer.init/1 was found, but there is a callback
with the same name.
You can view callback documentations with the b/1 helper.
```

Any feedback is welcome, thanks! :)
