### PR TITLE
Add missing calls of remove_dot_segments to URI.merge/2

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -509,11 +509,13 @@ defmodule URI do
     |> Enum.join("/")
   end
 
-  defp remove_dot_segments_from_path(nil),
-    do: nil
+  defp remove_dot_segments_from_path(nil) do
+    nil
+  end
+
   defp remove_dot_segments_from_path(path) do
     path
-    |> path_to_segments
+    |> path_to_segments()
     |> remove_dot_segments([])
     |> Enum.join("/")
   end

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -481,10 +481,10 @@ defmodule URI do
     raise ArgumentError, "you must merge onto an absolute URI"
   end
   def merge(_base, %URI{scheme: rel_scheme} = rel) when rel_scheme != nil do
-    rel
+    %{rel | path: remove_dot_segments_from_path(rel.path)}
   end
   def merge(base, %URI{authority: authority} = rel) when authority != nil do
-    %{rel | scheme: base.scheme}
+    %{rel | scheme: base.scheme, path: remove_dot_segments_from_path(rel.path)}
   end
   def merge(%URI{} = base, %URI{path: rel_path} = rel) when rel_path in ["", nil] do
     %{base | query: rel.query || base.query, fragment: rel.fragment}
@@ -500,11 +500,20 @@ defmodule URI do
   defp merge_paths(nil, rel_path),
     do: merge_paths("/", rel_path)
   defp merge_paths(_, "/" <> _ = rel_path),
-    do: rel_path
+    do: remove_dot_segments_from_path(rel_path)
   defp merge_paths(base_path, rel_path) do
     [_ | base_segments] = path_to_segments(base_path)
     path_to_segments(rel_path)
     |> Kernel.++(base_segments)
+    |> remove_dot_segments([])
+    |> Enum.join("/")
+  end
+
+  defp remove_dot_segments_from_path(nil),
+    do: nil
+  defp remove_dot_segments_from_path(path) do
+    path
+    |> path_to_segments
     |> remove_dot_segments([])
     |> Enum.join("/")
   end

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -240,9 +240,13 @@ defmodule URITest do
     end
 
     assert URI.merge("http://google.com/foo", "http://example.com/baz") |> to_string == "http://example.com/baz"
+    assert URI.merge("http://google.com/foo", "http://example.com/.././bar/../../baz") |> to_string == "http://example.com/baz"
+
     assert URI.merge("http://google.com/foo", "//example.com/baz") |> to_string == "http://example.com/baz"
+    assert URI.merge("http://google.com/foo", "//example.com/.././bar/../../../baz") |> to_string == "http://example.com/baz"
 
     assert URI.merge("http://example.com", URI.parse("/foo")) |> to_string == "http://example.com/foo"
+    assert URI.merge("http://example.com", URI.parse("/.././bar/../../../baz")) |> to_string == "http://example.com/baz"
 
     base = URI.parse("http://example.com/foo/bar")
     assert URI.merge(base, "") |> to_string == "http://example.com/foo/bar"


### PR DESCRIPTION
Some `remove_dot_segments` calls were missing in `URI.merge/2` with respect to [RFC3986](https://tools.ietf.org/html/rfc3986#section-5.2.2).