### PR TITLE
feat(String): Add append/2 and prepend/2 functions to the String module

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1802,6 +1802,44 @@ defmodule String do
   end
 
   @doc """
+  Adds a string or an atom to the end of another string.
+
+  ## Examples
+    iex> String.append("hello", " world")
+    "hello world"
+    iex> String.append("hello", :world)
+    "helloworld"
+  """
+
+  @spec append(t, t) :: t
+  def append(string, suffix) when is_binary(string) and is_binary(suffix) do
+    string <> suffix
+  end
+
+  def append(string, suffix) when is_binary(string) and is_atom(suffix) do
+    string <> Atom.to_string(suffix)
+  end
+
+  @doc """
+  Adds a string or an atom to the beginning of another string
+
+  ## Examples
+    iex> String.prepend("world", "hello ")
+    "hello world"
+    iex> String.prepend("world", :hello)
+    "helloworld"
+  """
+
+  @spec append(t, t) :: t
+  def prepend(string, prefix) when is_binary(string) and is_binary(prefix) do
+    prefix <> string
+  end
+
+  def prepend(string, prefix) when is_binary(string) and is_atom(prefix) do
+    Atom.to_string(prefix) <> string
+  end
+
+  @doc """
   Converts a string into a charlist.
 
   Specifically, this functions takes a UTF-8 encoded binary and returns a list of its integer

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -518,6 +518,16 @@ defmodule StringTest do
     end
   end
 
+  test "append/2" do
+    assert String.append("hello", " world") == "hello world"
+    assert String.append("hello", :world) == "helloworld"
+  end
+
+  test "prepend/2" do
+    assert String.prepend("world", "hello ") == "hello world"
+    assert String.prepend("world", :hello) == "helloworld"
+  end
+
   test "slice/2,3" do
     assert String.slice("elixir", 1, 3) == "lix"
     assert String.slice("あいうえお", 2, 2) == "うえ"


### PR DESCRIPTION
I've added a few convenience methods to the String module because I've run into the issue where I need to perform a concat in the middle of a series of string transformations and I would like to represent those as a series of piped functions without having to write a local function. 

Let me know what you think! 