### PR TITLE
Turn EEx.SyntaxError into a warning to keep backwards compatibility

### DIFF
--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -69,10 +69,13 @@ defmodule EEx.Compiler do
     {buffer, rest}
   end
 
-  defp generate_buffer([{:end_expr, line, modifier, chars} | _], _buffer, [_ | _], state) do
+  defp generate_buffer([{:end_expr, line, modifier, chars} | t], buffer, [_ | _] = scope, state) do
     message = "unexpected beginning of EEx tag \"<%#{modifier}\" on end of expression \"<%#{modifier}#{chars}%>\", " <>
               "please remove \"#{modifier}\" accordingly"
-    raise EEx.SyntaxError, message: message, file: state.file, line: line
+    :elixir_errors.warn line, state.file, message
+    generate_buffer([{:end_expr, line, '', chars} | t], buffer, scope, state)
+    # TODO: Make this an error on Elixir v2.0 since it accidentally worked previously.
+    # raise EEx.SyntaxError, message: message, file: state.file, line: line
   end
 
   defp generate_buffer([{:end_expr, line, _, chars} | _], _buffer, [], state) do

--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -177,7 +177,7 @@ defmodule EExTest do
     test "when end expression has a modifier" do
       assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
         EEx.compile_string "foo <%= if true do %>true<% else %>false<%= end %>"
-      end) =~ ~s[beginning of EEx tag \"<%=\" on end of expression \"<%= end %>\"]
+      end) =~ ~s[unexpected beginning of EEx tag \"<%=\" on end of expression \"<%= end %>\"]
     end
   end
 

--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -175,7 +175,7 @@ defmodule EExTest do
     end
 
     test "when end expression has a modifier" do
-      assert_raise EEx.SyntaxError, ~s[nofile:1: unexpected beginning of EEx tag "<%=" on end of expression "<%= end %>", please remove "=" accordingly], fn ->
+      assert ExUnit.CaptureIO.capture_io :stderr, fn ->
         EEx.compile_string "foo <%= if true do %>true<% else %>false<%= end %>"
       end
     end

--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -169,15 +169,15 @@ defmodule EExTest do
     end
 
     test "when middle expression has a modifier" do
-      ExUnit.CaptureIO.capture_io :stderr, fn ->
+      assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
         EEx.compile_string "foo <%= if true do %>true<%= else %>false<% end %>"
-      end
+      end) =~ ~s[unexpected beginning of EEx tag \"<%=\" on \"<%= else %>\"]
     end
 
     test "when end expression has a modifier" do
-      assert ExUnit.CaptureIO.capture_io :stderr, fn ->
+      assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
         EEx.compile_string "foo <%= if true do %>true<% else %>false<%= end %>"
-      end
+      end) =~ ~s[beginning of EEx tag \"<%=\" on end of expression \"<%= end %>\"]
     end
   end
 


### PR DESCRIPTION
Closes #6216