### PR TITLE
Add preserve_comments option to tokenizer

### DIFF
--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -36,5 +36,6 @@
   terminators=[],
   check_terminators=true,
   existing_atoms_only=false,
+  preserve_comments=false,
   identifier_tokenizer=elixir_tokenizer
 }).

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -119,9 +119,9 @@ tokenize(String, Line, Column, Opts) ->
     false -> <<"nofile">>
   end,
 
-  ExistingAtoms = case lists:keyfind(existing_atoms_only, 1, Opts) of
-    {existing_atoms_only, ExistingAtomsBool} when
-      is_boolean(ExistingAtomsBool) -> ExistingAtomsBool;
+  ExistingAtomsOnly = case lists:keyfind(existing_atoms_only, 1, Opts) of
+    {existing_atoms_only, ExistingAtomsOnlyBool} when
+      is_boolean(ExistingAtomsOnlyBool) -> ExistingAtomsOnlyBool;
     _ -> false
   end,
 
@@ -139,7 +139,7 @@ tokenize(String, Line, Column, Opts) ->
 
   tokenize(String, Line, Column, #elixir_tokenizer{
     file=File,
-    existing_atoms_only=ExistingAtoms,
+    existing_atoms_only=ExistingAtomsOnly,
     check_terminators=CheckTerminators,
     preserve_comments=PreserveComments,
     identifier_tokenizer=elixir_config:get(identifier_tokenizer)
@@ -519,9 +519,12 @@ strip_dot_space(T, Counter, Column, StartLine, Tokens) ->
       {Rest, Comment, Length} = tokenize_comment(R, [$#], 1),
       CommentToken = {comment, {StartLine + Counter, Column, Column + Length}, Comment},
       strip_dot_space(Rest, Counter, 1, StartLine, [CommentToken | Tokens]);
-    {"\r\n" ++ Rest, _} -> strip_dot_space(Rest, Counter + 1, 1, StartLine, Tokens);
-    {"\n" ++ Rest, _}   -> strip_dot_space(Rest, Counter + 1, 1, StartLine, Tokens);
-    {Rest, Length}      -> {Rest, Counter, Column + Length, Tokens}
+    {"\r\n" ++ Rest, _} ->
+      strip_dot_space(Rest, Counter + 1, 1, StartLine, Tokens);
+    {"\n" ++ Rest, _} ->
+      strip_dot_space(Rest, Counter + 1, 1, StartLine, Tokens);
+    {Rest, Length} ->
+      {Rest, Counter, Column + Length, Tokens}
   end.
 
 handle_char(7)   -> {"\\a", "alert"};

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -119,24 +119,27 @@ tokenize(String, Line, Column, Opts) ->
     false -> <<"nofile">>
   end,
 
-  ExistingAtomsOnly = case lists:keyfind(existing_atoms_only, 1, Opts) of
-    {existing_atoms_only, true} -> true;
+  ExistingAtoms = case lists:keyfind(existing_atoms_only, 1, Opts) of
+    {existing_atoms_only, ExistingAtomsBool} when
+      is_boolean(ExistingAtomsBool) -> ExistingAtomsBool;
     _ -> false
   end,
 
   CheckTerminators = case lists:keyfind(check_terminators, 1, Opts) of
-    {check_terminators, false} -> false;
+    {check_terminators, CheckTerminatorsBool} when
+      is_boolean(CheckTerminatorsBool) -> CheckTerminatorsBool;
     _ -> true
   end,
 
   PreserveComments = case lists:keyfind(preserve_comments, 1, Opts) of
-    {preserve_comments, true} -> true;
+    {preserve_comments, PreserveCommentsBool} when
+      is_boolean(PreserveCommentsBool) -> PreserveCommentsBool;
     _ -> false
   end,
 
   tokenize(String, Line, Column, #elixir_tokenizer{
     file=File,
-    existing_atoms_only=ExistingAtomsOnly,
+    existing_atoms_only=ExistingAtoms,
     check_terminators=CheckTerminators,
     preserve_comments=PreserveComments,
     identifier_tokenizer=elixir_config:get(identifier_tokenizer)

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -5,6 +5,10 @@ tokenize(String) ->
   {ok, _Line, _Column, Result} = elixir_tokenizer:tokenize(String, 1, []),
   Result.
 
+tokenize(String, Opts) ->
+  {ok, _Line, _Column, Result} = elixir_tokenizer:tokenize(String, 1, Opts),
+  Result.
+
 tokenize_error(String) ->
   {error, Error, _, _} = elixir_tokenizer:tokenize(String, 1, []),
   Error.
@@ -79,7 +83,9 @@ float_test() ->
   {1, "invalid float number ", OversizedFloat} = tokenize_error(OversizedFloat).
 
 comments_test() ->
-  [{number, {1, 1, 2}, 1}, {eol, {1, 3, 4}}, {number, {2, 1, 2}, 2}] = tokenize("1 # Comment\n2").
+  [{number, {1, 1, 2}, 1}, {eol, {1, 3, 4}}, {number, {2, 1, 2}, 2}] = tokenize("1 # Comment\n2"),
+  [{number, {1, 1, 2}, 1}, {comment, {1, 3, 12}, "# Comment"},
+   {eol, {1, 12, 13}}, {number, {2, 1, 2}, 2}] = tokenize("1 # Comment\n2", [{preserve_comments, true}]).
 
 identifier_test() ->
   [{identifier, {1, 1, 4}, abc}] = tokenize("abc "),
@@ -124,7 +130,12 @@ dot_newline_operator_test() ->
   [{identifier, {1, 1, 4}, foo},
    {'.', {1, 4, 5}},
    {identifier, {2, 1, 2}, '+'},
-   {number, {2, 2, 3}, 1}] = tokenize("foo.#bar\n+1").
+   {number, {2, 2, 3}, 1}] = tokenize("foo.#bar\n+1"),
+  [{identifier, {1, 1, 4}, foo},
+   {'.', {1, 4, 5}},
+   {comment, {1, 5, 9}, "#bar"},
+   {identifier, {2, 1, 2}, '+'},
+   {number, {2, 2, 3}, 1}] = tokenize("foo.#bar\n+1", [{preserve_comments, true}]).
 
 aliases_test() ->
   [{'aliases', {1, 1, 4}, ['Foo']}] = tokenize("Foo"),

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -2,8 +2,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 tokenize(String) ->
-  {ok, _Line, _Column, Result} = elixir_tokenizer:tokenize(String, 1, []),
-  Result.
+  tokenize(String, []).
 
 tokenize(String, Opts) ->
   {ok, _Line, _Column, Result} = elixir_tokenizer:tokenize(String, 1, Opts),

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -118,11 +118,11 @@ newline_test() ->
 
 dot_newline_operator_test() ->
   [{identifier, {1, 1, 4}, foo},
-   {'.', {2, 4, 5}},
+   {'.', {1, 4, 5}},
    {identifier, {2, 1, 2}, '+'},
    {number, {2, 2, 3}, 1}] = tokenize("foo.\n+1"),
   [{identifier, {1, 1, 4}, foo},
-   {'.', {2, 4, 5}},
+   {'.', {1, 4, 5}},
    {identifier, {2, 1, 2}, '+'},
    {number, {2, 2, 3}, 1}] = tokenize("foo.#bar\n+1").
 


### PR DESCRIPTION
Adds a `preserve_comments` option to preserve comment tokens. This will be useful for code formatting purposes.

Sample code:

```ruby
def test3() do
  if true do
    # comment 1
  else
    # comment 2
  end
  # comment 3
end
```

Usage:

```
iex(4)> :elixir_tokenizer.tokenize(code, 0, 0, [])
{:ok, 7, 4,
 [{:identifier, {0, 0, 3}, :def}, {:paren_identifier, {0, 4, 9}, :test3},
  {:"(", {0, 9, 10}}, {:")", {0, 10, 11}}, {:do, {0, 12, 14}},
  {:eol, {0, 14, 15}}, {:identifier, {1, 3, 5}, :if}, {true, {1, 6, 10}},
  {:do, {1, 11, 13}}, {:eol, {1, 13, 14}},
  {:block_identifier, {3, 3, 7}, :else}, {:eol, {3, 7, 8}}, {:end, {5, 3, 6}},
  {:eol, {5, 6, 7}}, {:end, {7, 1, 4}}]}
iex(5)> :elixir_tokenizer.tokenize(code, 0, 0, [{:preserve_comments, true}])
{:ok, 7, 4,
 [{:identifier, {0, 0, 3}, :def}, {:paren_identifier, {0, 4, 9}, :test3},
  {:"(", {0, 9, 10}}, {:")", {0, 10, 11}}, {:do, {0, 12, 14}},
  {:eol, {0, 14, 15}}, {:identifier, {1, 3, 5}, :if}, {true, {1, 6, 10}},
  {:do, {1, 11, 13}}, {:eol, {1, 13, 14}},
  {:comment, {2, 5, 16}, '# comment 1'}, {:eol, {2, 16, 17}},
  {:block_identifier, {3, 3, 7}, :else}, {:eol, {3, 7, 8}},
  {:comment, {4, 5, 16}, '# comment 2'}, {:eol, {4, 16, 17}}, {:end, {5, 3, 6}},
  {:eol, {5, 6, 7}}, {:comment, {6, 3, 14}, '# comment 3'}, {:eol, {6, 14, 15}},
  {:end, {7, 1, 4}}]}
```

Comments after dot operator:
```
iex(8)> :elixir_tokenizer.tokenize('foo.#bar\n #last\n+1', 1, 1, [])
{:ok, 3, 3,
 [{:identifier, {1, 1, 4}, :foo}, {:., {1, 4, 5}}, {:identifier, {3, 1, 2}, :+},
  {:number, {3, 2, 3}, 1}]}
iex(9)> :elixir_tokenizer.tokenize('foo.#bar\n #last\n+1', 1, 1, [{:preserve_comments, :true}])
{:ok, 3, 3,
 [{:identifier, {1, 1, 4}, :foo}, {:., {1, 4, 5}},
  {:comment, {1, 5, 9}, '#bar'}, {:comment, {2, 1, 6}, '#last'},
  {:identifier, {3, 1, 2}, :+}, {:number, {3, 2, 3}, 1}]}
iex(10)>
```