### PR TITLE
Add --all-warnings option to Elixir compiler

### DIFF
--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -30,6 +30,9 @@ defmodule Kernel.ParallelCompiler do
     * `:each_module` - for each module compiled, invokes the callback passing
       the file, module and the module bytecode
 
+    * `:each_warning` - for each warning, invokes the callback passing
+      the file, line number, and warning message
+
     * `:dest` - the destination directory for the BEAM files. When using `files/2`,
       this information is only used to properly annotate the BEAM files before
       they are loaded into memory. If you want a file to actually be written to

--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -226,6 +226,12 @@ defmodule Kernel.ParallelCompiler do
         end
         spawn_compilers(state)
 
+      {:warning, file, line, message} ->
+        if callback = Keyword.get(options, :each_warning) do
+          callback.(file, line, message)
+        end
+        wait_for_messages(state)
+
       {:DOWN, _down_ref, :process, down_pid, {:shutdown, file}} ->
         if callback = Keyword.get(options, :each_file) do
           callback.(file)

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -12,6 +12,12 @@
 warn(none, File, Warning) ->
   warn(0, File, Warning);
 warn(Line, File, Warning) when is_integer(Line), is_binary(File) ->
+  CompilerPid = get(elixir_compiler_pid),
+  if
+    CompilerPid =/= undefined ->
+      CompilerPid ! {warning, File, Line, list_to_binary(Warning)};
+    true -> ok
+  end,
   warn([Warning, "\n  ", file_format(Line, File), $\n]).
 
 -spec warn(unicode:chardata()) -> ok.

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -15,7 +15,7 @@ warn(Line, File, Warning) when is_integer(Line), is_binary(File) ->
   CompilerPid = get(elixir_compiler_pid),
   if
     CompilerPid =/= undefined ->
-      CompilerPid ! {warning, File, Line, list_to_binary(Warning)};
+      CompilerPid ! {warning, File, Line, Warning};
     true -> ok
   end,
   warn([Warning, "\n  ", file_format(Line, File), $\n]).

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -79,6 +79,8 @@ defmodule Mix.Compilers.Elixir do
     stale   = changed -- removed
     sources = update_stale_sources(all_sources, removed, changed)
 
+    if opts[:all_warnings], do: show_warnings(sources)
+
     cond do
       stale != [] ->
         compile_manifest(manifest, exts, modules, sources, stale, dest, timestamp, opts)
@@ -367,6 +369,15 @@ defmodule Mix.Compilers.Elixir do
     _ = File.rm(beam)
     _ = :code.purge(module)
     _ = :code.delete(module)
+  end
+
+  defp show_warnings(sources) do
+    for source(source: source, warnings: warnings) <- sources do
+      file = Path.join(File.cwd!, source)
+      for {line, message} <- warnings do
+        :elixir_errors.warn(line, file, to_charlist(message))
+      end
+    end
   end
 
   ## Manifest handling

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -391,7 +391,7 @@ defmodule Mix.Compilers.Elixir do
     else
       [@manifest_vsn | data] ->
         split_manifest(data, compile_path)
-      [v | data] when v in [:v4, :v5] ->
+      [v | data] when v in [:v4, :v5, :v6] ->
         for module(beam: beam) <- data, do: File.rm(Path.join(compile_path, beam))
         {[], []}
       _ ->

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -368,7 +368,7 @@ defmodule Mix.Compilers.Elixir do
     for source(source: source, warnings: warnings) <- sources do
       file = Path.join(File.cwd!, source)
       for {line, message} <- warnings do
-        :elixir_errors.warn(line, file, to_charlist(message))
+        :elixir_errors.warn(line, file, message)
       end
     end
   end

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -25,6 +25,7 @@ defmodule Mix.Tasks.Compile.Elixir do
       return a non-zero exit code
     * `--long-compilation-threshold N` - sets the "long compilation" threshold
       (in seconds) to `N` (see the docs for `Kernel.ParallelCompiler.files/2`)
+    * `--all-warnings` - prints warnings even from files that do not need to be recompiled
 
   ## Configuration
 
@@ -41,7 +42,8 @@ defmodule Mix.Tasks.Compile.Elixir do
 
   @switches [force: :boolean, docs: :boolean, warnings_as_errors: :boolean,
              ignore_module_conflict: :boolean, debug_info: :boolean,
-             verbose: :boolean, long_compilation_threshold: :integer]
+             verbose: :boolean, long_compilation_threshold: :integer,
+             all_warnings: :boolean]
 
   @doc """
   Runs this task.

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -342,9 +342,9 @@ defmodule Mix.Tasks.Compile.ElixirTest do
 
       # First compilation should print unused variable warning
       import ExUnit.CaptureIO
-      output = capture_io :standard_error, fn ->
+      output = capture_io(:standard_error, fn ->
         Mix.Tasks.Compile.Elixir.run([]) == :ok
-      end
+      end)
 
       # Should also print warning
       assert capture_io(:standard_error, fn ->


### PR DESCRIPTION
While implementing the (hacky and buggy) automatic builds and error/warning reporting in ElixirLS, one issue that made it difficult was that warnings are lost after a successful build.  If a file compiles with warnings, the next time you compile, those warnings are not shown unless you’ve changed the source or something it depends on.

This change stores warnings in the build manifest and adds an `--all-warnings` option on the CLI. When set, it will print out old warnings from non-stale files.