### PR TITLE
NaiveDateTime.from_iso8601!() handles nil value properly

### DIFF
--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -356,6 +356,8 @@ defmodule NaiveDateTime do
       {:error, :invalid_format}
       iex> NaiveDateTime.from_iso8601("2015-01-23T23:50:07.123-24:00")
       {:error, :invalid_format}
+      iex> NaiveDateTime.from_iso8601(nil)
+      {:error, :invalid_format}
 
   """
   @spec from_iso8601(String.t, Calendar.calendar) :: {:ok, t} | {:error, atom}
@@ -379,6 +381,10 @@ defmodule NaiveDateTime do
   end
 
   def from_iso8601(<<_::binary>>, _calendar) do
+    {:error, :invalid_format}
+  end
+
+  def from_iso8601(nil, _calendar) do
     {:error, :invalid_format}
   end
 

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -204,6 +204,38 @@ defmodule DateTimeTest do
     assert DateTime.from_iso8601(nil) == {:error, :invalid_format}
   end
 
+  test "from_iso8601/1 with tz offsets" do
+    assert DateTime.from_iso8601("2017-06-02T14:00:00+01:00") |> elem(1) ==
+           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
+                     hour: 13, minute: 0, second: 0, microsecond: {0, 0},
+                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+
+    assert DateTime.from_iso8601("2017-06-02T14:00:00-04:00") |> elem(1) ==
+           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
+                     hour: 18, minute: 0, second: 0, microsecond: {0, 0},
+                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+
+    assert DateTime.from_iso8601("2017-06-02T14:00:00+0100") |> elem(1) ==
+           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
+                     hour: 13, minute: 0, second: 0, microsecond: {0, 0},
+                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+
+    assert DateTime.from_iso8601("2017-06-02T14:00:00-0400") |> elem(1) ==
+           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
+                     hour: 18, minute: 0, second: 0, microsecond: {0, 0},
+                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+
+    assert DateTime.from_iso8601("2017-06-02T14:00:00+01") |> elem(1) ==
+           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
+                     hour: 13, minute: 0, second: 0, microsecond: {0, 0},
+                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+
+    assert DateTime.from_iso8601("2017-06-02T14:00:00-04") |> elem(1) ==
+           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
+                     hour: 18, minute: 0, second: 0, microsecond: {0, 0},
+                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+  end
+
   test "from_unix/2" do
     # with Unix times back to 0 Gregorian seconds
     min_datetime = %DateTime{
@@ -262,37 +294,5 @@ defmodule DateTimeTest do
     assert DateTime.compare(datetime1, datetime1) == :eq
     assert DateTime.compare(datetime1, datetime2) == :lt
     assert DateTime.compare(datetime2, datetime1) == :gt
-  end
-
-  test "from_iso8601/1 with tz offsets" do
-    assert DateTime.from_iso8601("2017-06-02T14:00:00+01:00") |> elem(1) ==
-           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
-                     hour: 13, minute: 0, second: 0, microsecond: {0, 0},
-                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
-
-    assert DateTime.from_iso8601("2017-06-02T14:00:00-04:00") |> elem(1) ==
-           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
-                     hour: 18, minute: 0, second: 0, microsecond: {0, 0},
-                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
-
-    assert DateTime.from_iso8601("2017-06-02T14:00:00+0100") |> elem(1) ==
-           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
-                     hour: 13, minute: 0, second: 0, microsecond: {0, 0},
-                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
-
-    assert DateTime.from_iso8601("2017-06-02T14:00:00-0400") |> elem(1) ==
-           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
-                     hour: 18, minute: 0, second: 0, microsecond: {0, 0},
-                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
-
-    assert DateTime.from_iso8601("2017-06-02T14:00:00+01") |> elem(1) ==
-           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
-                     hour: 13, minute: 0, second: 0, microsecond: {0, 0},
-                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
-
-    assert DateTime.from_iso8601("2017-06-02T14:00:00-04") |> elem(1) ==
-           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
-                     hour: 18, minute: 0, second: 0, microsecond: {0, 0},
-                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
   end
 end

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -200,6 +200,10 @@ defmodule DateTimeTest do
                       minute: 50, second: 7}
   end
 
+  test "from_iso8601/1 handles nil value properly" do
+    assert DateTime.from_iso8601(nil) == {:error, :invalid_format}
+  end
+
   test "from_unix/2" do
     # with Unix times back to 0 Gregorian seconds
     min_datetime = %DateTime{


### PR DESCRIPTION
I had a problem with `NaiveDateTime.from_iso8601!()` sometimes the result which we send to this method can be `nil`, and instead of receiving proper message about wrong format we've got 
```** (FunctionClauseError) no function clause matching in NaiveDateTime.from_iso8601/1```
 
<img width="1419" alt="screenshot 2017-06-14 14 12 27" src="https://user-images.githubusercontent.com/1594996/27132256-77c327c8-510e-11e7-8314-ca43dce0f78d.png">

Now you will get the proper error message for `from_iso8601'