### PR TITLE
Add Date.range/2

### DIFF
--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -62,10 +62,7 @@ defmodule Date do
   ## Examples
 
       iex> Date.range(~D[2000-01-01], ~D[2001-01-01])
-      %Date.Range{
-        first: ~D[2000-01-01],
-        last: ~D[2001-01-01],
-      }
+      #DateRange<~D[2000-01-01], ~D[2001-01-01]>
 
   """
 

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -57,6 +57,34 @@ defmodule Date do
                    day: Calendar.day, calendar: Calendar.calendar}
 
   @doc """
+  Returns a Date.Range
+
+  ## Examples
+
+      iex> Date.range(~D[2000-01-01], ~D[2001-01-01])
+      %Date.Range{
+        first: ~D[2000-01-01],
+        last: ~D[2001-01-01],
+      }
+
+  """
+
+  @spec range(Date.t, Date.t) :: Date.Range.t
+  def range(%{calendar: calendar} = first, %{calendar: calendar} = last) do
+    %Date.Range{
+      first: first,
+      last: last,
+      first_rata_die: to_rata_die_days(first),
+      last_rata_die: to_rata_die_days(last),
+    }
+  end
+
+  def range(%Date{}, %Date{}) do
+    raise ArgumentError,
+      "both dates must have matching calendars"
+  end
+
+  @doc """
   Returns the current date in UTC.
 
   ## Examples
@@ -466,6 +494,12 @@ defmodule Date do
     calendar.naive_datetime_to_rata_die(year, month, day, 0, 0, 0, {0, 0})
   end
 
+  @doc false
+  def to_rata_die_days(date) do
+    {days, _} = to_rata_die(date)
+    days
+  end
+
   defp from_rata_die({days, _}, Calendar.ISO) do
     {year, month, day} = Calendar.ISO.date_from_rata_die_days(days)
     %Date{year: year, month: month, day: day, calendar: Calendar.ISO}
@@ -473,6 +507,11 @@ defmodule Date do
   defp from_rata_die(rata_die, target_calendar) do
     {year, month, day, _, _, _, _} = target_calendar.naive_datetime_from_rata_die(rata_die)
     %Date{year: year, month: month, day: day, calendar: target_calendar}
+  end
+
+  @doc false
+  def from_rata_die_days(rata_die, target_calendar) do
+    from_rata_die({rata_die, {0, 86400000000}}, target_calendar)
   end
 
   @doc """

--- a/lib/elixir/lib/calendar/date_range.ex
+++ b/lib/elixir/lib/calendar/date_range.ex
@@ -22,6 +22,7 @@ defmodule Date.Range do
 
   """
 
+  @opaque t :: %__MODULE__{first: Date.t, last: Date.t}
   @doc false
   defstruct [:first, :last, :first_rata_die, :last_rata_die]
 
@@ -71,6 +72,12 @@ defmodule Date.Range do
 
     defp reduce(_, _, {:cont, acc}, _fun, _up) do
       {:done, acc}
+    end
+  end
+
+  defimpl Inspect do
+    def inspect(%Date.Range{first: first, last: last}, _) do
+      "#DateRange<" <> inspect(first) <> ", " <> inspect(last) <> ">"
     end
   end
 end

--- a/lib/elixir/lib/calendar/date_range.ex
+++ b/lib/elixir/lib/calendar/date_range.ex
@@ -1,0 +1,76 @@
+defmodule Date.Range do
+  @moduledoc """
+  Defines a range of dates.
+
+  A range of dates represents a discrete number of dates where
+  the first and last values are dates with matching calendars.
+
+  Ranges of dates can be either increasing (`first <= last`) or
+  decreasing (`first > last`). They are also always inclusive.
+
+  A range of dates implements the `Enumerable` protocol, which means
+  functions in the `Enum` module can be used to work with
+  ranges:
+
+      iex> range = Date.range(~D[2001-01-01], ~D[2002-01-01])
+      iex> Enum.count(range)
+      366
+      iex> Enum.member?(range, ~D[2001-02-01])
+      true
+      iex> Enum.reduce(range, 0, fn(_date, acc) -> acc - 1 end)
+      -366
+
+  """
+
+  @doc false
+  defstruct [:first, :last, :first_rata_die, :last_rata_die]
+
+  defimpl Enumerable do
+    def member?(%Date.Range{first: %{calendar: calendar, year: first_year, month: first_month, day: first_day},
+              last: %{calendar: calendar, year: last_year, month: last_month, day: last_day},
+              first_rata_die: first_rata_die, last_rata_die: last_rata_die},
+            %Date{calendar: calendar, year: year, month: month, day: day}) do
+      first = {first_year, first_month, first_day}
+      last = {last_year, last_month, last_day}
+      date = {year, month, day}
+
+      if first_rata_die <= last_rata_die do
+        {:ok, date >= first and date <= last}
+      else
+        {:ok, date >= last and date <= first}
+      end
+    end
+
+    def member?(_, _) do
+      {:ok, false}
+    end
+
+    def count(%Date.Range{first_rata_die: first_rata_die, last_rata_die: last_rata_die}) do
+      {:ok, abs(first_rata_die - last_rata_die) + 1}
+    end
+
+    def reduce(%Date.Range{first_rata_die: first_rata_die, last_rata_die: last_rata_die, first: %{calendar: c}}, acc, fun) do
+      reduce(first_rata_die, last_rata_die, acc, &(fun.(Date.from_rata_die_days(&1, c), &2)), first_rata_die <= last_rata_die)
+    end
+
+    defp reduce(_x, _y, {:halt, acc}, _fun, _up?) do
+      {:halted, acc}
+    end
+
+    defp reduce(x, y, {:suspend, acc}, fun, up?) do
+      {:suspended, acc, &reduce(x, y, &1, fun, up?)}
+    end
+
+    defp reduce(x, y, {:cont, acc}, fun, _up? = true) when x <= y do
+      reduce(x + 1, y, fun.(x, acc), fun, _up? = true)
+    end
+
+    defp reduce(x, y, {:cont, acc}, fun, _up? = false) when x >= y do
+      reduce(x - 1, y, fun.(x, acc), fun, _up? = false)
+    end
+
+    defp reduce(_, _, {:cont, acc}, _fun, _up) do
+      {:done, acc}
+    end
+  end
+end

--- a/lib/elixir/test/elixir/calendar/date_range_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_range_test.exs
@@ -1,0 +1,54 @@
+Code.require_file "../test_helper.exs", __DIR__
+Code.require_file "../fixtures/calendar/julian.exs", __DIR__
+
+defmodule Date.RangeTest do
+  use ExUnit.Case, async: true
+  doctest Date.Range
+
+  setup do
+    {:ok, range: Date.range(~D[2000-01-01], ~D[2001-01-01])}
+  end
+
+  describe "Enum.member?/2" do
+    test "for ascending range", %{range: range} do
+      assert Enum.member?(range, ~D[2000-02-22])
+      refute Enum.member?(range, ~D[2002-01-01])
+    end
+
+    test "for descending range", %{range: range} do
+      assert Enum.member?(range, ~D[2000-02-22])
+      refute Enum.member?(range, ~D[1999-01-01])
+    end
+  end
+
+  describe "Enum.count/1" do
+    test "counts days in range", %{range: range} do
+      assert Enum.count(range) == 367
+    end
+  end
+
+  describe "Enum.reduce/3" do
+    test "acts as a normal reduce" do
+      range = Date.range(~D[2000-01-01], ~D[2000-01-03])
+      fun = fn (date, acc) -> acc ++ [date] end
+
+      assert Enum.reduce(range, [], fun) == [~D[2000-01-01], ~D[2000-01-02], ~D[2000-01-03]]
+    end
+  end
+
+  test "both dates must have matching calendars" do
+    first = ~D[2000-01-01]
+    last = Calendar.Julian.date(2001, 01, 01)
+
+    assert_raise ArgumentError, "both dates must have matching calendars", fn ->
+      Date.range(first, last)
+    end
+  end
+
+  test "accepts equal but not Calendar.ISO calendars" do
+    first = Calendar.Julian.date(2001, 01, 01)
+    last = Calendar.Julian.date(2000, 01, 01)
+
+    assert Date.range(first, last)
+  end
+end


### PR DESCRIPTION
closes #6223 

Adds `Date.Range`, implementing the `Enumerable` module so you can `count/1`, `member?/2`, etc.

Usage example:

```elixir
iex> range = Date.range(~D[2000-01-01], ~D[2001-01-1])
#DateRange<~D[2000-01-01], ~D[2001-01-1]>
iex> Enum.member?(range, ~D[2000-02-01])
true
iex> Enum.member?(range, ~D[2002-02-01])
false
```

As suggested in the issue, the `Date.Range` struct holds also `first_rata_die` and `last_rata_die`, which are later used for faster `count/1`, `member?/2` and `reduce/3` implementations.

Would love some feedback on this, thanks! 😃 