### PR TITLE
Feat/table alignment

### DIFF
--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -303,6 +303,24 @@ defmodule IO.ANSI.DocsTest do
            "\e[7mcolumn 1 | and 2\e[0m\na        | b    \none      | two  \n\e[0m"
   end
 
+  test "table with heading alignment" do
+    table = """
+    column 1 | 2        | and three
+    -------: | :------: | :-----
+        a    |  even    | c\none | odd | three
+    """
+
+    expected = """
+    \e[7m\
+    column 1 |   2   | and three\e[0m
+           a | even  | c        
+         one |  odd  | three    
+    \e[0m
+    """ |> String.trim_trailing
+
+    assert format(table) == expected
+  end
+
   test "table with formatting in cells" do
     assert format("`a` | _b_\nc | d") ==
            "\e[36ma\e[0m | \e[4mb\e[0m\nc | d\n\e[0m"


### PR DESCRIPTION
I've done this as two commits as the second commit is technically a breaking change for the way the docs are rendered. You can see the result of of the same table being rendered with:

1) elixir 1.4.1 (before this feature)
2) After commit 1
3) After commit 2

![table-alignment](https://user-images.githubusercontent.com/477511/27230407-042a5c60-52a7-11e7-9475-9e425b152218.png)

Commit messages below for convenience.

---

Add table column alignment in IO.ANSI.Docs

This commit adds table alignment in markdown which allows the following
for tables:

    right aligned | center aligned | left aligned
    -: | :-: | :-
    a | b | c

This will output a table in the following format:

    right aligned | center aligned | left aligned
                a |       b        | c

---

Remove duplicate spacings for table alignment

Previously, a table in the format:

    right aligned     | center aligned | left aligned
    ----------------: | :------------: | :-----------
                    a |       b        | c

Would be displayed as:

    right aligned     | center aligned | left aligned
                    a |       b        | c

This commit changes it so it displays as:

    right aligned | center aligned  | left aligned
                a |        b        | c