### PR TITLE
Make assert_raise fail with broken message/1 implementation

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -628,6 +628,7 @@ defmodule ExUnit.Assertions do
 
         cond do
           name == exception ->
+            check_error_message(name, error)
             error
           name == ExUnit.AssertionError ->
             reraise(error, stacktrace)
@@ -637,6 +638,15 @@ defmodule ExUnit.Assertions do
     else
       _ -> flunk "Expected exception #{inspect exception} but nothing was raised"
     end
+  end
+
+  defp check_error_message(module, error) do
+    module.message(error)
+  catch
+    kind, reason ->
+      stacktrace = System.stacktrace()
+
+      flunk "Got exception #{inspect module} but it failed to produce a message with:\n\n" <> Exception.format(kind, reason, stacktrace)
   end
 
   @doc """

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -30,9 +30,9 @@ defmodule ExUnit.MultiError do
 
   defexception [errors: []]
 
-  def message(exception) do
+  def message(%{errors: errors}) do
     "got the following errors:\n\n" <>
-      Enum.map_join(exception, "\n\n", fn {kind, error, stack} ->
+      Enum.map_join(errors, "\n\n", fn {kind, error, stack} ->
         Exception.format_banner(kind, error, stack)
       end)
   end

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -6,7 +6,15 @@ defmodule ExUnit.AssertionsTest.Value do
   def truthy, do: true
 end
 
-alias ExUnit.AssertionsTest.Value
+defmodule ExUnit.AssertionsTest.BrokenError do
+  defexception [:message]
+
+  def message(_) do
+    raise "error"
+  end
+end
+
+alias ExUnit.AssertionsTest.{BrokenError, Value}
 
 defmodule ExUnit.AssertionsTest do
   use ExUnit.Case, async: true
@@ -546,6 +554,16 @@ defmodule ExUnit.AssertionsTest do
       "\n  ~r/ba[zk]/" <>
       "\nactual:" <>
       "\n  \"bar\"" = error.message
+  end
+
+  test "assert raise with an exception with bad message/1 implementation" do
+    assert_raise BrokenError, fn ->
+      raise BrokenError
+    end
+  rescue
+    error in [ExUnit.AssertionError] ->
+      "Got exception ExUnit.AssertionsTest.BrokenError but it failed to produce a message with:" <>
+      "\n\n** (RuntimeError) error\n" <> _ = error.message
   end
 
   test "assert greater than operator" do


### PR DESCRIPTION
As discussed on the mailing list. I'm open to changing how the error is reported, I wasn't sure of the best way.

Interestingly, this revealed a bug in `ExUnit.MultiError.message/1` implementation. It's fixed in a separate commit.