### PR TITLE
Update link to `:erlang.module_info/0`

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -409,9 +409,11 @@ defmodule Module do
     * `:module`     - module name (`Module == Module.__info__(:module)`)
 
   In addition to the above, you may also pass to `__info__/1` any atom supported
-  by [`:erlang.module_info/0`](http://erlang.org/doc/reference_manual/modules.html#id77914) which also gets defined for each compiled module.
+  by [`:erlang.module_info/0`](http://erlang.org/doc/reference_manual/modules.html#id77914)
+  which also gets defined for each compiled module.
 
-  For a list of supported attributes and more information, see [Modules – Erlang Reference Manual](http://www.erlang.org/doc/reference_manual/modules.html#id77056).
+  For a list of supported attributes and more information, see
+  [Modules – Erlang Reference Manual](http://www.erlang.org/doc/reference_manual/modules.html#id77056).
   """
   def __info__(kind)
 

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -409,7 +409,7 @@ defmodule Module do
     * `:module`     - module name (`Module == Module.__info__(:module)`)
 
   In addition to the above, you may also pass to `__info__/1` any atom supported
-  by `:erlang.module_info/0` which also gets defined for each compiled module.
+  by `:erlang.module_info/0` [should link to http://erlang.org/doc/reference_manual/modules.html#id77914 ] which also gets defined for each compiled module.
 
   For a list of supported attributes and more information, see [Modules – Erlang Reference Manual](http://www.erlang.org/doc/reference_manual/modules.html#id77056).
   """

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -409,7 +409,7 @@ defmodule Module do
     * `:module`     - module name (`Module == Module.__info__(:module)`)
 
   In addition to the above, you may also pass to `__info__/1` any atom supported
-  by `:erlang.module_info/0` [should link to http://erlang.org/doc/reference_manual/modules.html#id77914 ] which also gets defined for each compiled module.
+  by [`:erlang.module_info/0`](http://erlang.org/doc/reference_manual/modules.html#id77914) which also gets defined for each compiled module.
 
   For a list of supported attributes and more information, see [Modules – Erlang Reference Manual](http://www.erlang.org/doc/reference_manual/modules.html#id77056).
   """


### PR DESCRIPTION
It turns out the *link* is auto-generated so I'm not sure how to override the auto-generation. The link, as is, goes to a non-existent page ( try it: https://hexdocs.pm/elixir/Module.html ) so it's not helpful. I've made an obviously bad change here to start the conversation, as soon as I know how to override the auto-linking I'll do that.