### PR TITLE
Add String.empty/0

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2052,6 +2052,17 @@ defmodule String do
     end)
   end
 
+  @doc """
+  Returns an empty string.
+
+  ## Example
+
+      iex> String.empty
+      ""
+  """
+  @spec empty() :: String.t
+  def empty, do: ""
+
   # TODO: Remove by 2.0
   # (hard-deprecated in elixir_dispatch)
   @doc false


### PR DESCRIPTION
Hi everyone.

In some situations i needed an empty string. I only found two ways of achieving this in elixir

1. using `""` (two double quotes)
2. using `<<>>` (an empty binary)

The first one is not too safe. Someone can put a special utf-8 char in it by accident and debugging it is hard.

The second way is a bit ugly and scary

So i thought it's maybe a good idea to have an `empty/0` function in String module which returns an empty string. It's simply safe i think.

Thanks