### PR TITLE
Inline String.duplicate to :binary.copy BIF

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1177,8 +1177,12 @@ defmodule String do
 
   defp do_reverse(nil, acc), do: IO.iodata_to_binary(acc)
 
+  @compile {:inline, duplicate: 2}
+
   @doc """
   Returns a string `subject` duplicated `n` times.
+
+  Inlined by the compiler.
 
   ## Examples
 
@@ -1193,7 +1197,7 @@ defmodule String do
 
   """
   @spec duplicate(t, non_neg_integer) :: t
-  def duplicate(subject, n) when is_integer(n) and n >= 0 do
+  def duplicate(subject, n) do
     :binary.copy(subject, n)
   end
 

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -151,6 +151,7 @@ inline(?port, list, 0) -> {erlang, ports};
 inline(?string, to_float, 1) -> {erlang, binary_to_float};
 inline(?string, to_integer, 1) -> {erlang, binary_to_integer};
 inline(?string, to_integer, 2) -> {erlang, binary_to_integer};
+inline(?string, duplicate, 2) -> {binary, copy};
 
 inline(?system, stacktrace, 0) -> {erlang, get_stacktrace};
 inline(?system, monotonic_time, 0) -> {erlang, monotonic_time};

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -372,7 +372,7 @@ defmodule StringTest do
     assert String.duplicate("abc", 1) == "abc"
     assert String.duplicate("abc", 2) == "abcabc"
     assert String.duplicate("&ã$", 2) == "&ã$&ã$"
-    assert_raise FunctionClauseError, fn ->
+    assert_raise ArgumentError, fn ->
       String.duplicate("abc", -1)
     end
   end


### PR DESCRIPTION
Furthermore, also inline duplicate/2 inside the String module, since it's
used there in couple places.