### PR TITLE
Create behavior for Mix compiler tasks

### DIFF
--- a/lib/mix/lib/mix/task.compiler.ex
+++ b/lib/mix/lib/mix/task.compiler.ex
@@ -43,18 +43,14 @@ defmodule Mix.Task.Compiler do
   """
   @callback clean() :: term
 
+  @optional_callbacks clean: 0, manifests: 0
+
   @doc false
   defmacro __using__(_opts) do
     quote do
       Enum.each [:shortdoc, :recursive],
         &Module.register_attribute(__MODULE__, &1, persist: true)
       @behaviour Mix.Task.Compiler
-
-      def clean, do: :noop
-
-      def manifests, do: []
-
-      defoverridable(clean: 0, manifests: 0)
     end
   end
 end

--- a/lib/mix/lib/mix/task.compiler.ex
+++ b/lib/mix/lib/mix/task.compiler.ex
@@ -36,7 +36,7 @@ defmodule Mix.Task.Compiler do
   @doc """
   Removes build artifacts and manifests.
   """
-  @callback clean() :: term
+  @callback clean() :: any
 
   @optional_callbacks clean: 0, manifests: 0
 

--- a/lib/mix/lib/mix/task.compiler.ex
+++ b/lib/mix/lib/mix/task.compiler.ex
@@ -3,7 +3,7 @@ defmodule Mix.Task.Compiler do
   This module defines the behaviour for a Mix task that does compilation.
 
   A Mix compiler task can be defined by simply using `Mix.Task.Compiler`
-  in a module starting with `Mix.Tasks.Compile.` and defining
+  in a module whose name starts with `Mix.Tasks.Compile.` and defining
   the `run/1` function:
 
       defmodule Mix.Tasks.Compile.MyLanguage do
@@ -22,8 +22,9 @@ defmodule Mix.Task.Compiler do
 
   The following attributes are used the same way as in other Mix tasks:
 
-  * `@shortdoc`  - makes the task public with a short description that appears on `mix help`
-  * `@recursive` - runs the task recursively in umbrella projects
+    * `@shortdoc`  - makes the task public with a short description that appears on `mix help`
+    * `@recursive` - runs the task recursively in umbrella projects
+
   """
 
   @doc """

--- a/lib/mix/lib/mix/task.compiler.ex
+++ b/lib/mix/lib/mix/task.compiler.ex
@@ -24,6 +24,10 @@ defmodule Mix.Task.Compiler do
 
     * `@shortdoc`  - makes the task public with a short description that appears on `mix help`
     * `@recursive` - runs the task recursively in umbrella projects
+    * `@preferred_cli_env` - recommends environment to run task. It is used in absence of
+      a Mix project recommendation, or explicit `MIX_ENV`, and it only works for tasks
+      in the current project. `@preferred_cli_env` is not loaded from dependencies as
+      we need to know the environment before dependencies are loaded.
 
   """
 
@@ -48,7 +52,7 @@ defmodule Mix.Task.Compiler do
   @doc false
   defmacro __using__(_opts) do
     quote do
-      Enum.each [:shortdoc, :recursive],
+      Enum.each [:shortdoc, :recursive, :preferred_cli_env],
         &Module.register_attribute(__MODULE__, &1, persist: true)
       @behaviour Mix.Task.Compiler
     end

--- a/lib/mix/lib/mix/task.compiler.ex
+++ b/lib/mix/lib/mix/task.compiler.ex
@@ -36,7 +36,7 @@ defmodule Mix.Task.Compiler do
   @doc """
   Lists manifest files for the compiler.
   """
-  @callback manifests() :: [binary]
+  @callback manifests() :: [Path.t]
 
   @doc """
   Removes build artifacts and manifests.

--- a/lib/mix/lib/mix/task.compiler.ex
+++ b/lib/mix/lib/mix/task.compiler.ex
@@ -43,8 +43,8 @@ defmodule Mix.Task.Compiler do
   @doc false
   defmacro __using__(_opts) do
     quote do
-      Enum.each Mix.Task.supported_attributes,
-        &Module.register_attribute(__MODULE__, &1, persist: true)
+      Enum.each(Mix.Task.supported_attributes(),
+        &Module.register_attribute(__MODULE__, &1, persist: true))
       @behaviour Mix.Task.Compiler
     end
   end

--- a/lib/mix/lib/mix/task.compiler.ex
+++ b/lib/mix/lib/mix/task.compiler.ex
@@ -1,0 +1,59 @@
+defmodule Mix.Task.Compiler do
+  @moduledoc """
+  This module defines the behaviour for a Mix task that does compilation.
+
+  A Mix compiler task can be defined by simply using `Mix.Task.Compiler`
+  in a module starting with `Mix.Tasks.Compile.` and defining
+  the `run/1` function:
+
+      defmodule Mix.Tasks.Compile.MyLanguage do
+        use Mix.Task.Compiler
+
+        def run(_args) do
+          :ok
+        end
+      end
+
+  If the compiler uses manifest files to track stale sources, it should
+  define `manifests/0`, and if it writes any output to disk it should
+  also define `clean/0`.
+
+  ## Attributes
+
+  The following attributes are used the same way as in other Mix tasks:
+
+  * `@shortdoc`  - makes the task public with a short description that appears on `mix help`
+  * `@recursive` - runs the task recursively in umbrella projects
+  """
+
+  @doc """
+  Receives command-line arguments and performs compilation. Returns `:noop`
+  if nothing is stale and no compilation is needed, `:ok` if successful.
+  """
+  @callback run([binary]) :: :ok | :noop
+
+  @doc """
+  Lists manifest files for the compiler.
+  """
+  @callback manifests() :: [binary]
+
+  @doc """
+  Removes build artifacts and manifests.
+  """
+  @callback clean() :: term
+
+  @doc false
+  defmacro __using__(_opts) do
+    quote do
+      Enum.each [:shortdoc, :recursive],
+        &Module.register_attribute(__MODULE__, &1, persist: true)
+      @behaviour Mix.Task.Compiler
+
+      def clean, do: :noop
+
+      def manifests, do: []
+
+      defoverridable(clean: 0, manifests: 0)
+    end
+  end
+end

--- a/lib/mix/lib/mix/task.compiler.ex
+++ b/lib/mix/lib/mix/task.compiler.ex
@@ -19,7 +19,7 @@ defmodule Mix.Task.Compiler do
   also define `clean/0`.
 
   A compiler supports the same attributes for configuration and
-  documentation as a regular Mix task.
+  documentation as a regular Mix task. See `Mix.Task` for more information.
   """
 
   @doc """

--- a/lib/mix/lib/mix/task.compiler.ex
+++ b/lib/mix/lib/mix/task.compiler.ex
@@ -18,17 +18,8 @@ defmodule Mix.Task.Compiler do
   define `manifests/0`, and if it writes any output to disk it should
   also define `clean/0`.
 
-  ## Attributes
-
-  The following attributes are used the same way as in other Mix tasks:
-
-    * `@shortdoc`  - makes the task public with a short description that appears on `mix help`
-    * `@recursive` - runs the task recursively in umbrella projects
-    * `@preferred_cli_env` - recommends environment to run task. It is used in absence of
-      a Mix project recommendation, or explicit `MIX_ENV`, and it only works for tasks
-      in the current project. `@preferred_cli_env` is not loaded from dependencies as
-      we need to know the environment before dependencies are loaded.
-
+  A compiler supports the same attributes for configuration and
+  documentation as a regular Mix task.
   """
 
   @doc """
@@ -52,7 +43,7 @@ defmodule Mix.Task.Compiler do
   @doc false
   defmacro __using__(_opts) do
     quote do
-      Enum.each [:shortdoc, :recursive, :preferred_cli_env],
+      Enum.each Mix.Task.supported_attributes,
         &Module.register_attribute(__MODULE__, &1, persist: true)
       @behaviour Mix.Task.Compiler
     end

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -48,7 +48,7 @@ defmodule Mix.Task do
   @doc false
   defmacro __using__(_opts) do
     quote do
-      Enum.each Mix.Task.supported_attributes,
+      Enum.each Mix.Task.supported_attributes(),
         &Module.register_attribute(__MODULE__, &1, persist: true)
       @behaviour Mix.Task
     end

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -48,10 +48,17 @@ defmodule Mix.Task do
   @doc false
   defmacro __using__(_opts) do
     quote do
-      Enum.each [:shortdoc, :recursive, :preferred_cli_env],
+      Enum.each Mix.Task.supported_attributes,
         &Module.register_attribute(__MODULE__, &1, persist: true)
       @behaviour Mix.Task
     end
+  end
+
+  @doc """
+  A list of attributes that can be set for configuration and documentation
+  """
+  def supported_attributes do
+    [:shortdoc, :recursive, :preferred_cli_env]
   end
 
   @doc """

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -54,9 +54,7 @@ defmodule Mix.Task do
     end
   end
 
-  @doc """
-  A list of attributes that can be set for configuration and documentation
-  """
+  @doc false
   def supported_attributes do
     [:shortdoc, :recursive, :preferred_cli_env]
   end

--- a/lib/mix/lib/mix/tasks/compile.all.ex
+++ b/lib/mix/lib/mix/tasks/compile.all.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Tasks.Compile.All do
-  use Mix.Task
+  use Mix.Task.Compiler
 
   @moduledoc false
   @recursive true

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Tasks.Compile.App do
-  use Mix.Task
+  use Mix.Task.Compiler
 
   @recursive true
 

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Tasks.Compile.Elixir do
-  use Mix.Task
+  use Mix.Task.Compiler
 
   @recursive true
   @manifest ".compile.elixir"

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Tasks.Compile.Erlang do
-  use Mix.Task
+  use Mix.Task.Compiler
   import Mix.Compilers.Erlang
 
   @recursive true

--- a/lib/mix/lib/mix/tasks/compile.leex.ex
+++ b/lib/mix/lib/mix/tasks/compile.leex.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Tasks.Compile.Leex do
-  use Mix.Task
+  use Mix.Task.Compiler
   alias Mix.Compilers.Erlang
 
   @recursive true

--- a/lib/mix/lib/mix/tasks/compile.protocols.ex
+++ b/lib/mix/lib/mix/tasks/compile.protocols.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Tasks.Compile.Protocols do
-  use Mix.Task
+  use Mix.Task.Compiler
 
   @manifest ".compile.protocols"
   @manifest_vsn :v2

--- a/lib/mix/lib/mix/tasks/compile.xref.ex
+++ b/lib/mix/lib/mix/tasks/compile.xref.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Tasks.Compile.Xref do
-  use Mix.Task
+  use Mix.Task.Compiler
   alias Mix.Tasks.Compile.Elixir, as: E
 
   @recursive true

--- a/lib/mix/lib/mix/tasks/compile.yecc.ex
+++ b/lib/mix/lib/mix/tasks/compile.yecc.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Tasks.Compile.Yecc do
-  use Mix.Task
+  use Mix.Task.Compiler
   alias Mix.Compilers.Erlang
 
   @recursive true


### PR DESCRIPTION
Though there isn't much immediate benefit to codifying the current behavior, the Mix.Task.Compiler behavior is good to have as documentation for how to implement a compiler. The ultimate goal is to have a callback specification for `run/1` that returns diagnostic information for errors and warnings.

Open questions:

- Should `use Mix.Task.Compiler` include default implementations for `clean/0` and `manifests/0`?
- Should `Mix.Tasks.Compile.All` have implementations for `manifests/0` and `clean/0` that call them for each compiler, or should these be noops?