### PR TITLE
correctly handle maps in logger metadata

### DIFF
--- a/lib/logger/lib/logger/formatter.ex
+++ b/lib/logger/lib/logger/formatter.ex
@@ -154,5 +154,8 @@ defmodule Logger.Formatter do
       binary -> binary
     end
   end
+  defp metadata(map) when is_map(map) do
+    inspect(map)
+  end
   defp metadata(other), do: to_string(other)
 end


### PR DESCRIPTION
Sometimes (maybe with custom file loggers) metadata may contains maps, and can be useful to log also on console.
Right now the console logger crashes if a metadata contains a map, this should address it.

If can be useful, I'll look also into tests.