### PR TITLE
Improve label option in IO.inspect

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -288,11 +288,16 @@ defmodule IO do
   """
   @spec inspect(device, item, keyword) :: item when item: var
   def inspect(device, item, opts) when is_list(opts) do
-    label    = if (label = opts[:label]), do: [to_chardata(label), ": "], else: []
-    opts     = struct(Inspect.Opts, opts)
+    label = inspect_label(opts[:label])
+    opts = struct(Inspect.Opts, opts)
     chardata = Inspect.Algebra.format(Inspect.Algebra.to_doc(item, opts), opts.width)
     puts device, [label, chardata]
     item
+  end
+
+  defp inspect_label(nil), do: []
+  defp inspect_label(label) do
+    IO.ANSI.format([:blue, to_chardata(label), ":\t"])
   end
 
   @doc """


### PR DESCRIPTION
* make label blue to stand out more
* separate the label and data with tabs to align multiple labels

---

Here's how it looks:
<img width="658" alt="screenshot 2017-06-24 11 10 57" src="https://user-images.githubusercontent.com/477062/27507363-e510b45a-58cd-11e7-8ecf-e44ff8d324fe.png">
