### PR TITLE
Handles shell history path, with or without spaces.

### DIFF
--- a/bin/iex.bat
+++ b/bin/iex.bat
@@ -40,7 +40,13 @@ echo ** Options can be passed to the Erlang VM using ELIXIR_ERL_OPTIONS or --erl
 goto end
 
 :run
+@set ELIXIR_HISTORY_DIR=%USERPROFILE%\.elixir-history
+@set ELIXIR_HISTORY_DIR=%ELIXIR_HISTORY_DIR:\=\\%
+@for %%I in ("%ELIXIR_HISTORY_DIR%") do @set SHORT_ELIXIR_HISTORY_DIR=%%~sI
+@set SHORT_ELIXIR_HISTORY_DIR=%SHORT_ELIXIR_HISTORY_DIR:\=\\%
+
+@set ERL="-kernel shell_history_path \"%SHORT_ELIXIR_HISTORY_DIR%\" -noshell -user Elixir.IEx.CLI"
 @if defined IEX_WITH_WERL (@set __ELIXIR_IEX_FLAGS=--werl) else (set __ELIXIR_IEX_FLAGS=)
-call "%~dp0\elixir.bat" --no-halt --erl "-noshell -user Elixir.IEx.CLI" +iex %__ELIXIR_IEX_FLAGS% %*
+call "%~dp0\elixir.bat" --no-halt --erl %ERL% +iex %__ELIXIR_IEX_FLAGS% %*
 :end
 endlocal


### PR DESCRIPTION
_I use Windows 10 x64, Elixir 1.4.5 and Erlang 20 (not the RC, the official version that got out several days ago)._

Directories with spaces are handled via a workaround, namely the path is converted to the DOS name (8.3 format). When `iex` is started,  the following commands are issued:

```elixir
dir = List.to_string(Application.get_env(:kernel, :shell_history_path))
File.exists?(dir)
```
- For `C:\Users\dimi\.elixir-history`, result is:
  * `"C:\\Users\\dimi\\.elixir-history"`
  * `true` (I previously created the directory)
- For `C:\Users\dimi\_elixir history`, result is:
  * `"C:\\Users\\dimi\\_ELIXI~1"`
  * `true` (I previously created the directory)

The 8.3 filenames are supported quite back to the past so it's IMO a safe workaround. I've been using tricks like that one ever since XP first hit major adoption (circa Q1 2002). Please raise concerns if you have more info than me though, I am not all-knowing. :smile: 

NOTES:

- Don't put double quotes around the directory where `ELIXIR_HISTORY_DIR` is first set! This will result in unusable path being passed to Erlang/Elixir.
- The backslash plus double quotes (where `ERL` is set) was proposed by @josevalim and it's working fine _only_ for paths without spaces, but I wasn't able to find a better way, hence I am using the 8.3 name format. I tried many other options (double double quotes around the path, no quotes at all, backslash and double double quotes, and several others) but Erlang kept complaining. I am no Erlang expert so I cut the fight at the 8.3 name format workaround.
- When `ERL` is used (when starting `elixir.bat`) I purposefully didn't use double quotes there; note they are already put when `ERL` is set. Double double quotes break the startup process.

In short, this looks to be working perfectly right now but is very sensitive to even the smallest changes, hence the long and boring explanations.

**QUESTION**: shall we use an environment variable for the history directory path, and if the variable isn't set, only then to use a hardcoded value?