### PR TITLE
Add wrap_literals_in_blocks option to parser

### DIFF
--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -270,8 +270,7 @@ quoted_to_erl(Quoted, Env, Scope) ->
 string_to_quoted(String, StartLine, File, Opts) when is_integer(StartLine), is_binary(File) ->
   case elixir_tokenizer:tokenize(String, StartLine, [{file, File} | Opts]) of
     {ok, _Line, _Column, Tokens} ->
-      put(elixir_parser_file, File),
-      handle_parsing_opts(Opts),
+      handle_parsing_opts(File, Opts),
       try elixir_parser:parse(Tokens) of
         {ok, Forms} -> {ok, Forms};
         {error, {{Line, _, _}, _, [Error, Token]}} -> {error, {Line, to_binary(Error), to_binary(Token)}};
@@ -299,10 +298,10 @@ string_to_quoted(String, StartLine, File, Opts) when is_integer(StartLine), is_b
 to_binary(List) when is_list(List) -> elixir_utils:characters_to_binary(List);
 to_binary(Atom) when is_atom(Atom) -> atom_to_binary(Atom, utf8).
 
-handle_parsing_opts(Opts) ->
-  case lists:keyfind(metadata_in_literals, 1, Opts) of
-    {metadata_in_literals, MetadataInLiteralsBool} when
-        is_boolean(MetadataInLiteralsBool) ->
-      put(metadata_in_literals, MetadataInLiteralsBool);
-    _ -> put(metadata_in_literals, false)
+handle_parsing_opts(File, Opts) ->
+  put(elixir_parser_file, File),
+  case lists:keyfind(wrap_literals_in_blocks, 1, Opts) of {wrap_literals_in_blocks, WrapLiteralsBool} when is_boolean(WrapLiteralsBool) ->
+      put(wrap_literals_in_blocks, WrapLiteralsBool);
+    _ ->
+      put(wrap_literals_in_blocks, false)
   end.

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -271,6 +271,7 @@ string_to_quoted(String, StartLine, File, Opts) when is_integer(StartLine), is_b
   case elixir_tokenizer:tokenize(String, StartLine, [{file, File} | Opts]) of
     {ok, _Line, _Column, Tokens} ->
       put(elixir_parser_file, File),
+      handle_parsing_opts(Opts),
       try elixir_parser:parse(Tokens) of
         {ok, Forms} -> {ok, Forms};
         {error, {{Line, _, _}, _, [Error, Token]}} -> {error, {Line, to_binary(Error), to_binary(Token)}};
@@ -297,3 +298,11 @@ string_to_quoted(String, StartLine, File, Opts) when is_integer(StartLine), is_b
 
 to_binary(List) when is_list(List) -> elixir_utils:characters_to_binary(List);
 to_binary(Atom) when is_atom(Atom) -> atom_to_binary(Atom, utf8).
+
+handle_parsing_opts(Opts) ->
+  case lists:keyfind(metadata_in_literals, 1, Opts) of
+    {metadata_in_literals, MetadataInLiteralsBool} when
+        is_boolean(MetadataInLiteralsBool) ->
+      put(metadata_in_literals, MetadataInLiteralsBool);
+    _ -> put(metadata_in_literals, false)
+  end.

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -279,7 +279,8 @@ string_to_quoted(String, StartLine, File, Opts) when is_integer(StartLine), is_b
         {error, {{Line, _, _}, _, [Error, Token]}} -> {error, {Line, to_binary(Error), to_binary(Token)}};
         {error, {Line, _, [Error, Token]}} -> {error, {Line, to_binary(Error), to_binary(Token)}}
       after
-        erase(elixir_parser_file)
+        erase(elixir_parser_file),
+        erase(wrap_literals_in_blocks)
       end;
     {error, {Line, {ErrorPrefix, ErrorSuffix}, Token}, _Rest, _SoFar} ->
       {error, {Line, {to_binary(ErrorPrefix), to_binary(ErrorSuffix)}, to_binary(Token)}};
@@ -299,9 +300,11 @@ to_binary(List) when is_list(List) -> elixir_utils:characters_to_binary(List);
 to_binary(Atom) when is_atom(Atom) -> atom_to_binary(Atom, utf8).
 
 handle_parsing_opts(File, Opts) ->
+  WrapLiteralsInBlocks =
+    case lists:keyfind(wrap_literals_in_blocks, 1, Opts) of
+      {wrap_literals_in_blocks, true} -> true;
+      _ -> false
+    end,
+
   put(elixir_parser_file, File),
-  case lists:keyfind(wrap_literals_in_blocks, 1, Opts) of {wrap_literals_in_blocks, WrapLiteralsBool} when is_boolean(WrapLiteralsBool) ->
-      put(wrap_literals_in_blocks, WrapLiteralsBool);
-    _ ->
-      put(wrap_literals_in_blocks, false)
-  end.
+  put(wrap_literals_in_blocks, WrapLiteralsInBlocks).

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -617,8 +617,8 @@ meta_from_location({Line, Column, EndColumn})
 %% Handle metadata in literals
 
 handle_literal(Literal, Token) ->
-  case get(metadata_in_literals) of
-    true  -> {'__block__', meta_from_token(Token), [Literal]};
+  case get(wrap_literals_in_blocks) of
+    true -> {'__block__', meta_from_token(Token), [Literal]};
     false -> Literal
   end.
 

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -77,7 +77,7 @@ Nonassoc 330 dot_identifier.
 
 %%% MAIN FLOW OF EXPRESSIONS
 
-grammar -> eoe : nil.
+grammar -> eoe : handle_literal(nil, '$1').
 grammar -> expr_list : to_block('$1').
 grammar -> eoe expr_list : to_block('$2').
 grammar -> expr_list eoe : to_block('$1').

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -117,11 +117,11 @@ defmodule CodeTest do
   end
 
   test "string_to_quoted/2 with wrap_literals_in_blocks option" do
-    assert Code.string_to_quoted('"one"', wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], ["one"]}}
-    assert Code.string_to_quoted('"one"') == {:ok, "one"}
-    assert Code.string_to_quoted('1', wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [1]}}
-    assert Code.string_to_quoted('nil', wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [nil]}}
-    assert Code.string_to_quoted(':one', wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [:one]}}
+    assert Code.string_to_quoted("\"one\"", wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], ["one"]}}
+    assert Code.string_to_quoted("\"one\"") == {:ok, "one"}
+    assert Code.string_to_quoted("1", wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [1]}}
+    assert Code.string_to_quoted("nil", wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [nil]}}
+    assert Code.string_to_quoted(":one", wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [:one]}}
   end
 
   test "compile source" do

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -116,6 +116,14 @@ defmodule CodeTest do
     assert catch_error(Code.string_to_quoted!(":there_is_no_such_atom", existing_atoms_only: true)) == :badarg
   end
 
+  test "string_to_quoted/2 with wrap_literals_in_blocks option" do
+    assert Code.string_to_quoted('"one"', wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], ["one"]}}
+    assert Code.string_to_quoted('"one"') == {:ok, "one"}
+    assert Code.string_to_quoted('1', wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [1]}}
+    assert Code.string_to_quoted('nil', wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [nil]}}
+    assert Code.string_to_quoted(':one', wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [:one]}}
+  end
+
   test "compile source" do
     assert __MODULE__.__info__(:compile)[:source] == String.to_charlist(__ENV__.file)
   end


### PR DESCRIPTION
This PR adds a `metadata_in_literals` option to the parser, which wraps literals like `123`, `:one`, `"one"` or `nil` in a `__block__` tuple along with their metadata. This will be very useful for code formatting purposes since it is now possible to attach comments to a literal based on its line number. The option is invoked from `Code.string_to_quoted/2`. 

@josevalim @whatyouhide currently, this is still a WIP. Would like your feedback on my implementation before moving forward. Also, please let me know if there are any literals that I missed.

Sample code:

```elixir
def test3() do
  if true do
    # comment 1
  else
    # comment 2
  end
  # comment 3
  1
  # comment 4
  "one"
  # comment 5
  :one
end
```

Usage:
```elixir
iex(8)> Code.string_to_quoted(code)
{:ok,
 {:def, [line: 1],
  [{:test3, [line: 1], []},
   [do: {:__block__, [],
     [{:if, [line: 2], [true, [do: nil, else: nil]]}, 1, "one", :one]}]]}}
iex(9)> Code.string_to_quoted(code, [metadata_in_literals: true])
{:ok,
 {:def, [line: 1],
  [{:test3, [line: 1], []},
   [do: {:__block__, [],
     [{:if, [line: 2],
       [{:__block__, [line: 2], [true]},
        [do: {:__block__, [line: 2], [nil]},
         else: {:__block__, [line: 4], [nil]}]]}, {:__block__, [line: 8], [1]},
      {:__block__, [line: 10], ["one"]}, {:__block__, [line: 12], [:one]}]}]]}}
```

@lpil please let me know if the format works for you:

```elixir
defp deps do
  [# Web server
   {:cowboy, "~> 1.0"},
   # Web framework
   {:phoenix, "~> 1.3.0-rc"},
   # XML parser helper
   {:sweet_xml, "~> 0.6"},
   # Statsd metrics sink client
   {:statix, "~> 1.0"}]
end
```

```elixir
iex(11)> Code.string_to_quoted(code)     
{:ok,
 {:defp, [line: 1],
  [{:deps, [line: 1], nil},
   [do: [cowboy: "~> 1.0", phoenix: "~> 1.3.0-rc", sweet_xml: "~> 0.6",
     statix: "~> 1.0"]]]}}
iex(12)> Code.string_to_quoted(code, [metadata_in_literals: true])
{:ok,
 {:defp, [line: 1],
  [{:deps, [line: 1], nil},
   [do: [{{:__block__, [line: 3], [:cowboy]},
      {:__block__, [line: 3], ["~> 1.0"]}},
     {{:__block__, [line: 5], [:phoenix]},
      {:__block__, [line: 5], ["~> 1.3.0-rc"]}},
     {{:__block__, [line: 7], [:sweet_xml]},
      {:__block__, [line: 7], ["~> 0.6"]}},
     {{:__block__, [line: 9], [:statix]},
      {:__block__, [line: 9], ["~> 1.0"]}}]]]}}
```