### PR TITLE
StringIO.get_until bug fix, performance, and tests

### DIFF
--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -283,7 +283,7 @@ defmodule StringIO do
            _ -> list_to_binary(input, encoding)
          end
 
-        {list_to_binary(result, encoding), state_after_read(s, input, prompt, count)}
+        {get_until_result(result, encoding), state_after_read(s, input, prompt, count)}
 
       :error ->
         {:error, s}
@@ -326,6 +326,11 @@ defmodule StringIO do
   defp list_to_binary(b, _)        when is_binary(b), do: b
   defp list_to_binary(l, :unicode) when is_list(l),   do: to_string(l)
   defp list_to_binary(l, :latin1)  when is_list(l),   do: :binary.list_to_bin(l)
+
+  # From http://erlang.org/doc/apps/stdlib/io_protocol.html: Result can be any
+  # Erlang term, but if it is a list(), the I/O server can convert it to a binary().
+  defp get_until_result(l, encoding) when is_list(l), do: list_to_binary(l, encoding)
+  defp get_until_result(other, _), do: other
 
   ## io_requests
 

--- a/lib/elixir/test/elixir/string_io_test.exs
+++ b/lib/elixir/test/elixir/string_io_test.exs
@@ -248,4 +248,103 @@ defmodule StringIOTest do
     assert IO.stream(pid, 2) |> Enum.to_list == ["ab", "c"]
     assert contents(pid) == {"", ""}
   end
+
+  defp get_until(pid, encoding, prompt, module, function, extra_args \\ []) do
+    :io.request(pid, {:get_until, encoding, prompt, module, function, extra_args})
+  end
+
+  defmodule GetUntilCallbacks do
+    def until_eof(continuation, :eof) do
+      {:done, continuation, :eof}
+    end
+
+    def until_eof(continuation, content) do
+      {:more, continuation ++ content}
+    end
+
+    def until_eof_then_try_more('magic-stop-prefix' ++ continuation, :eof) do
+      {:done, continuation, :eof}
+    end
+
+    def until_eof_then_try_more(continuation, :eof) do
+      {:more, 'magic-stop-prefix' ++ continuation}
+    end
+
+    def until_eof_then_try_more(continuation, content) do
+      {:more, continuation ++ content}
+    end
+
+    def up_to_3_bytes(continuation, :eof) do
+      {:done, continuation, :eof}
+    end
+
+    def up_to_3_bytes(continuation, content) do
+      case continuation ++ content do
+        [a, b, c | tail] -> {:done, [a, b, c], tail}
+        str -> {:more, str}
+      end
+    end
+
+    def up_to_3_bytes_discard_rest(continuation, :eof) do
+      {:done, continuation, :eof}
+    end
+
+    def up_to_3_bytes_discard_rest(continuation, content) do
+      case continuation ++ content do
+        [a, b, c | _tail] -> {:done, [a, b, c], :eof}
+        str -> {:more, str}
+      end
+    end
+  end
+
+  test "get_until with up_to_3_bytes" do
+    pid = start("abcdefg")
+    result = get_until(pid, :unicode, "", GetUntilCallbacks, :up_to_3_bytes)
+    assert result == "abc"
+    assert IO.read(pid, :all) == "defg"
+  end
+
+  test "get_until with up_to_3_bytes_discard_rest" do
+    pid = start("abcdefg")
+    result = get_until(pid, :unicode, "", GetUntilCallbacks, :up_to_3_bytes_discard_rest)
+    assert result == "abc"
+    assert IO.read(pid, :all) == ""
+  end
+
+  test "get_until with until_eof" do
+    pid = start("abc\nd")
+    result = get_until(pid, :unicode, "", GetUntilCallbacks, :until_eof)
+    assert result == "abc\nd"
+  end
+
+  test "get_until with until_eof and \\r\\n" do
+    pid = start("abc\r\nd")
+    result = get_until(pid, :unicode, "", GetUntilCallbacks, :until_eof)
+    assert result == "abc\r\nd"
+  end
+
+  test "get_until with until_eof capturing prompt" do
+    pid = start("abc\nd", capture_prompt: true)
+    result = get_until(pid, :unicode, ">", GetUntilCallbacks, :until_eof)
+    assert result == "abc\nd"
+    assert StringIO.contents(pid) == {"", ">>>"}
+  end
+
+  test "get_until with until_eof_then_try_more" do
+    pid = start("abc\nd")
+    result = get_until(pid, :unicode, "", GetUntilCallbacks, :until_eof_then_try_more)
+    assert result == "abc\nd"
+  end
+
+  test "get_until with invalid UTF-8" do
+    pid = start(<<130, 227, 129, 132, 227, 129, 134>>)
+    result = get_until(pid, :unicode, "", GetUntilCallbacks, :until_eof)
+    assert result == :error
+  end
+
+  test "get_until with raw bytes (latin1)" do
+    pid = start(<<181, 255, 194, ?\n>>)
+    result = get_until(pid, :latin1, "", GetUntilCallbacks, :until_eof)
+    assert result == <<181, 255, 194, ?\n>>
+  end
 end

--- a/lib/elixir/test/elixir/string_io_test.exs
+++ b/lib/elixir/test/elixir/string_io_test.exs
@@ -347,4 +347,18 @@ defmodule StringIOTest do
     result = get_until(pid, :latin1, "", GetUntilCallbacks, :until_eof)
     assert result == <<181, 255, 194, ?\n>>
   end
+
+  test ":io.erl_scan_form/2" do
+    pid = start("1.")
+    result = :io.scan_erl_form(pid, 'p>')
+    assert result == {:ok, [{:integer, 1, 1}, {:dot, 1}], 1}
+    assert StringIO.contents(pid) == {"", ""}
+  end
+
+  test ":io.erl_scan_form/2 with capture_prompt" do
+    pid = start("1.", capture_prompt: true)
+    result = :io.scan_erl_form(pid, 'p>')
+    assert result == {:ok, [{:integer, 1, 1}, {:dot, 1}], 1}
+    assert StringIO.contents(pid) == {"", "p>p>"}
+  end
 end


### PR DESCRIPTION
This pull-request addresses the following:

1. Adds tests for `StringIO.get_until`. Previously there were no tests for this function.
2. Fixes the same performance/scalability issue that was fixed for `StringIO.read_line` in #6056.
3. Fixes 2 bugs, described below.

## Strategy

Due to the lack of tests and shortage of examples I tried to change the logic of `do_get_until` as little as possible.

I added test coverage to all of the `case` clauses in `do_get_until`. With the exception of the 2 tests listed below, all tests passed before any changes were made to the implementation.

I found `get_until` to be awkward to test. If anyone has feedback on how to improve these tests then please let me know.

## Bug 1: `\r` characters were removed from output

This bug is reproduced by the test titled `"get_until with until_eof and \\r\\n"`.

## Bug 2: `:latin1` encoding should be interpreted as "pure bytes", not Latin1

This bug is reproduced by the test titled `"get_until with raw bytes (latin1)"`.

This is documented in http://erlang.org/doc/apps/stdlib/io_protocol.html.

Also see https://github.com/elixir-lang/elixir/issues/6037#issuecomment-298233279, and https://github.com/elixir-lang/elixir/pull/6056#issuecomment-298357306.


