### PR TITLE
Fix optimisation from #6240

### DIFF
--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -513,7 +513,7 @@ translate_remote(Left, Right, Meta, Args, S) ->
       {{call, Ann, {remote, Ann, TLeft, TRight}, TArgs}, SC}
   end.
 
-is_always_string({{'.', _, [Module, Function]}, Args}) ->
+is_always_string({{'.', _, [Module, Function]}, _, Args}) ->
   is_always_string(Module, Function, length(Args));
 %% Binary literals were already excluded in earlier passes.
 is_always_string(_Ast) ->

--- a/lib/elixir/test/erlang/control_test.erl
+++ b/lib/elixir/test/erlang/control_test.erl
@@ -227,4 +227,4 @@ optimized_inspect_interpolation_test() ->
     {bin, _,
      [{bin_element, _,
        {call, _, {remote, _,{atom, _, 'Elixir.Kernel'}, {atom, _, inspect}}, [_]},
-       default, [binary]}]} = to_erl("\"#{inspect 1}\"").
+       default, [binary]}]} = to_erl("\"#{inspect(1)}\"").

--- a/lib/elixir/test/erlang/control_test.erl
+++ b/lib/elixir/test/erlang/control_test.erl
@@ -222,3 +222,9 @@ optimized_oror_test() ->
 
 no_after_in_try_test() ->
   {'try', _, [_], [_], _, []} = to_erl("try do :foo.bar() else _ -> :ok end").
+
+optimized_inspect_interpolation_test() ->
+    {bin, _,
+     [{bin_element, _,
+       {call, _, {remote, _,{atom, _, 'Elixir.Kernel'}, {atom, _, inspect}}, [_]},
+       default, [binary]}]} = to_erl("\"#{inspect 1}\"").


### PR DESCRIPTION
It wasn't actually working, because of the wrong pattern match the function
never returned true.

---

This hints, it would be nice to have some tests in place, but I have no idea how to actually test it. It doesn't seem like we test other compiler optimisations either.