### PR TITLE
Allow markers "/" and "|" to be used in a custom EEx engine

### DIFF
--- a/lib/eex/lib/eex/engine.ex
+++ b/lib/eex/lib/eex/engine.ex
@@ -29,6 +29,10 @@ defmodule EEx.Engine do
       and are not implemented by default. Using them without the
       implementation raises `EEx.SyntaxError`.
 
+      If your engine does not implement all markers, please ensure that
+      `handle_expr/3` falls back to `EEx.Engine.handle_expr/3` 
+      to raise the proper error message.
+
       Read `handle_expr/3` below for more information about the markers
       implemented by default by this engine.
 

--- a/lib/eex/lib/eex/engine.ex
+++ b/lib/eex/lib/eex/engine.ex
@@ -18,7 +18,12 @@ defmodule EEx.Engine do
 
       The marker is what follows exactly after `<%`. For example,
       `<% foo %>` has an empty marker, but `<%= foo %>` has `"="`
-      as marker. The allowed markers so far are: `""` and `"="`.
+      as marker. The allowed markers so far are: `""`, `"="`, `"/"`
+      and `"|"`.
+
+      Markers `"/"` and `"|"` are only for use in a custom EEx Engines 
+      and are not implemented by default. Use of them without the
+      implementation raises `EEx.SyntaxError`.
 
       Read `handle_expr/3` below for more information about the markers
       implemented by default by this engine.
@@ -121,8 +126,10 @@ defmodule EEx.Engine do
   @doc """
   Implements expressions according to the markers.
 
-      <% Elixir expression - inline with output %>
+      <% Elixir expression  - inline with output %>
       <%= Elixir expression - replace with result %>
+      <%/ Elixir expression - raise EEx.SyntaxError, to be implemented in a custom Engine %>
+      <%| Elixir expression - raise EEx.SyntaxError, to be implemented in a custom Engine %>
 
   All other markers are not implemented by this engine.
   """
@@ -133,11 +140,23 @@ defmodule EEx.Engine do
     end
   end
 
+  def handle_expr(_buffer, "/", _expr) do
+    not_implemented!("/")
+  end
+
+  def handle_expr(_buffer, "|", _expr) do
+    not_implemented!("|")
+  end
+
   def handle_expr(buffer, "", expr) do
     quote do
       tmp2 = unquote(buffer)
       unquote(expr)
       tmp2
     end
+  end
+
+  defp not_implemented!(marker) do
+    raise EEx.SyntaxError, message: "handle_expr/3 not implemented for <%#{marker} %>"
   end
 end

--- a/lib/eex/lib/eex/engine.ex
+++ b/lib/eex/lib/eex/engine.ex
@@ -144,12 +144,8 @@ defmodule EEx.Engine do
     end
   end
 
-  def handle_expr(_buffer, "/", _expr) do
-    raise_marker_not_implemented("/")
-  end
-
-  def handle_expr(_buffer, "|", _expr) do
-    raise_marker_not_implemented("|")
+  def handle_expr(_buffer, marker, _expr) when marker in ["/", "|"] do
+    raise_marker_not_implemented(marker)
   end
 
   def handle_expr(buffer, "", expr) do

--- a/lib/eex/lib/eex/engine.ex
+++ b/lib/eex/lib/eex/engine.ex
@@ -21,7 +21,7 @@ defmodule EEx.Engine do
       as marker. The allowed markers so far are: `""`, `"="`, `"/"`
       and `"|"`.
 
-      Markers `"/"` and `"|"` are only for use in a custom EEx Engines 
+      Markers `"/"` and `"|"` are only for use in a custom EEx engines 
       and are not implemented by default. Use of them without the
       implementation raises `EEx.SyntaxError`.
 
@@ -128,8 +128,8 @@ defmodule EEx.Engine do
 
       <% Elixir expression  - inline with output %>
       <%= Elixir expression - replace with result %>
-      <%/ Elixir expression - raise EEx.SyntaxError, to be implemented in a custom Engine %>
-      <%| Elixir expression - raise EEx.SyntaxError, to be implemented in a custom Engine %>
+      <%/ Elixir expression - raise EEx.SyntaxError, to be implemented by custom engines %>
+      <%| Elixir expression - raise EEx.SyntaxError, to be implemented by custom engines %>
 
   All other markers are not implemented by this engine.
   """

--- a/lib/eex/lib/eex/engine.ex
+++ b/lib/eex/lib/eex/engine.ex
@@ -157,6 +157,7 @@ defmodule EEx.Engine do
   end
 
   defp raise_marker_not_implemented(marker) do
-    raise EEx.SyntaxError, message: "handle_expr/3 not implemented for <%#{marker} %>"
+    raise EEx.SyntaxError, 
+      "unsupported EEx syntax <%#{marker} %> (the syntax is valid but not supported by the current EEx engine)"
   end
 end

--- a/lib/eex/lib/eex/engine.ex
+++ b/lib/eex/lib/eex/engine.ex
@@ -18,11 +18,15 @@ defmodule EEx.Engine do
 
       The marker is what follows exactly after `<%`. For example,
       `<% foo %>` has an empty marker, but `<%= foo %>` has `"="`
-      as marker. The allowed markers so far are: `""`, `"="`, `"/"`
-      and `"|"`.
+      as marker. The allowed markers so far are: 
 
-      Markers `"/"` and `"|"` are only for use in a custom EEx engines 
-      and are not implemented by default. Use of them without the
+        * `""`
+        * `"="`
+        * `"/"`
+        * `"|"`
+
+      Markers `"/"` and `"|"` are only for use in custom EEx engines
+      and are not implemented by default. Using them without the
       implementation raises `EEx.SyntaxError`.
 
       Read `handle_expr/3` below for more information about the markers
@@ -126,7 +130,7 @@ defmodule EEx.Engine do
   @doc """
   Implements expressions according to the markers.
 
-      <% Elixir expression  - inline with output %>
+      <% Elixir expression - inline with output %>
       <%= Elixir expression - replace with result %>
       <%/ Elixir expression - raise EEx.SyntaxError, to be implemented by custom engines %>
       <%| Elixir expression - raise EEx.SyntaxError, to be implemented by custom engines %>
@@ -141,11 +145,11 @@ defmodule EEx.Engine do
   end
 
   def handle_expr(_buffer, "/", _expr) do
-    not_implemented!("/")
+    raise_marker_not_implemented("/")
   end
 
   def handle_expr(_buffer, "|", _expr) do
-    not_implemented!("|")
+    raise_marker_not_implemented("|")
   end
 
   def handle_expr(buffer, "", expr) do
@@ -156,7 +160,7 @@ defmodule EEx.Engine do
     end
   end
 
-  defp not_implemented!(marker) do
+  defp raise_marker_not_implemented(marker) do
     raise EEx.SyntaxError, message: "handle_expr/3 not implemented for <%#{marker} %>"
   end
 end

--- a/lib/eex/lib/eex/tokenizer.ex
+++ b/lib/eex/lib/eex/tokenizer.ex
@@ -74,11 +74,13 @@ defmodule EEx.Tokenizer do
 
   # Retrieve marker for <%
 
-  defp retrieve_marker([marker | t]) when marker in [?=, ?/, ?|],
-    do: {[marker], t}
+  defp retrieve_marker([marker | t]) when marker in [?=, ?/, ?|] do
+    {[marker], t}
+  end
 
-  defp retrieve_marker(t),
-    do: {'', t}
+  defp retrieve_marker(t) do
+    {'', t}
+  end
 
   # Tokenize an expression until we find %>
 

--- a/lib/eex/lib/eex/tokenizer.ex
+++ b/lib/eex/lib/eex/tokenizer.ex
@@ -74,21 +74,11 @@ defmodule EEx.Tokenizer do
 
   # Retrieve marker for <%
 
-  defp retrieve_marker('=' ++ t) do
-    {'=', t}
-  end
+  defp retrieve_marker([marker | t]) when marker in [?=, ?/, ?|],
+    do: {[marker], t}
 
-  defp retrieve_marker('/' ++ t) do
-    {'/', t}
-  end
-
-  defp retrieve_marker('|' ++ t) do
-    {'|', t}
-  end
-
-  defp retrieve_marker(t) do
-    {'', t}
-  end
+  defp retrieve_marker(t),
+    do: {'', t}
 
   # Tokenize an expression until we find %>
 

--- a/lib/eex/lib/eex/tokenizer.ex
+++ b/lib/eex/lib/eex/tokenizer.ex
@@ -3,8 +3,9 @@ defmodule EEx.Tokenizer do
 
   @type content :: IO.chardata
   @type line :: non_neg_integer
+  @type marker :: '=' | '/' | '|' | ''
   @type token :: {:text, content} |
-                 {:expr | :start_expr | :middle_expr | :end_expr, line, '=' | '', content}
+                 {:expr | :start_expr | :middle_expr | :end_expr, line, marker, content}
 
   @doc """
   Tokenizes the given charlist or binary.
@@ -75,6 +76,14 @@ defmodule EEx.Tokenizer do
 
   defp retrieve_marker('=' ++ t) do
     {'=', t}
+  end
+
+  defp retrieve_marker('/' ++ t) do
+    {'/', t}
+  end
+
+  defp retrieve_marker('|' ++ t) do
+    {'|', t}
   end
 
   defp retrieve_marker(t) do

--- a/lib/eex/test/eex/tokenizer_test.exs
+++ b/lib/eex/test/eex/tokenizer_test.exs
@@ -22,6 +22,16 @@ defmodule EEx.TokenizerTest do
            {:ok, [{:text, 'foo '}, {:expr, 1, '=', ' bar '}]}
   end
 
+  test "strings with embedded slash code" do
+    assert T.tokenize('foo <%/ bar %>', 1) ==
+           {:ok, [{:text, 'foo '}, {:expr, 1, '/', ' bar '}]}
+  end
+
+  test "strings with embedded pipe code" do
+    assert T.tokenize('foo <%| bar %>', 1) ==
+           {:ok, [{:text, 'foo '}, {:expr, 1, '|', ' bar '}]}
+  end
+
   test "strings with more than one line" do
     assert T.tokenize('foo\n<%= bar %>', 1) ==
            {:ok, [{:text, 'foo\n'}, {:expr, 2, '=', ' bar '}]}

--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -181,14 +181,16 @@ defmodule EExTest do
     end
 
     test "when trying to use marker '/' without implementation" do
-      assert_raise EEx.SyntaxError, ~r/handle_expr\/3 not implemented for <%\/ %>/, fn ->
-        EEx.compile_string "<%/ true %>"
+      assert_raise EEx.SyntaxError,
+        ~r/unsupported EEx syntax <%\/ %> \(the syntax is valid but not supported by the current EEx engine\)/, fn ->
+          EEx.compile_string "<%/ true %>"
       end
     end
 
     test "when trying to use marker '|' without implementation" do
-      assert_raise EEx.SyntaxError, ~r/handle_expr\/3 not implemented for <%| %>/, fn ->
-        EEx.compile_string "<%| true %>"
+      assert_raise EEx.SyntaxError, 
+        ~r/unsupported EEx syntax <%| %> \(the syntax is valid but not supported by the current EEx engine\)/, fn ->
+          EEx.compile_string "<%| true %>"
       end
     end
   end
@@ -484,8 +486,9 @@ defmodule EExTest do
     end
 
     test "not implemented custom marker" do
-      assert_raise EEx.SyntaxError, ~r/handle_expr\/3 not implemented for <%| %>/, fn ->
-        assert_eval {:wrapped, "foo baz"}, "foo <%| :bar %>", [], engine: TestEngine
+      assert_raise EEx.SyntaxError,
+        ~r/unsupported EEx syntax <%| %> \(the syntax is valid but not supported by the current EEx engine\)/, fn ->
+          assert_eval {:wrapped, "foo baz"}, "foo <%| :bar %>", [], engine: TestEngine
       end
     end
   end


### PR DESCRIPTION
Supports markers `"|"` and `"/"` in `EEx.Engine`.

To be used only within custom Engines. By default raise `EEx.SyntaxError` when not implemented.

`"|"` and `"/"` were chosen because thet should confuse the "" marker, as they should not appear at the beginning of any Elixr expression.

