### PR TITLE
Fix links in documentation guideline on v1.4

### DIFF
--- a/lib/elixir/pages/Writing Documentation.md
+++ b/lib/elixir/pages/Writing Documentation.md
@@ -6,8 +6,8 @@ Elixir treats documentation as a first-class citizen. This means documentation s
 
 Elixir documentation is written using Markdown. There are plenty of guides on Markdown online, we recommend the ones available on GitHub as a getting started point:
 
-  * [https://help.github.com/articles/markdown-basics/](https://help.github.com/articles/markdown-basics/)
-  * [https://help.github.com/articles/markdown-basics/](https://help.github.com/articles/github-flavored-markdown/)
+  * [Basic writing and formatting syntax](https://help.github.com/articles/basic-writing-and-formatting-syntax/)
+  * [Mastering Markdown](https://guides.github.com/features/mastering-markdown/)
 
 ## Module Attributes
 


### PR DESCRIPTION
![zrzut ekranu 2017-07-01 o 20 46 47](https://user-images.githubusercontent.com/76071/27764650-6a3bae84-5e9e-11e7-9ace-25e219f5136a.png)

this is only a problem on v1.4, master is fine.