### PR TITLE
Raise Protocol.UndefinedError on bad functions in Enumerable implementation

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3192,6 +3192,13 @@ defimpl Enumerable, for: Function do
   def member?(_function, _value),
     do: {:error, __MODULE__}
 
-  def reduce(function, acc, fun),
+  def reduce(function, acc, fun) when is_function(function, 2),
     do: function.(acc, fun)
+
+  def reduce(function, _acc, _fun) do
+    raise Protocol.UndefinedError,
+      protocol: @protocol,
+      value: function,
+      description: "only anonymous functions of arity 2 are enumerable"
+  end
 end

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -1566,3 +1566,13 @@ defmodule EnumTest.SideEffects do
     assert Enum.take(iterator, 0) == []
   end
 end
+
+defmodule EnumTest.Function do
+  use ExUnit.Case, async: true
+
+  test "raises Protocol.UndefinedError for funs of wrong arity" do
+    assert_raise Protocol.UndefinedError, fn ->
+      Enum.to_list(fn -> nil end)
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/elixir-lang/elixir/issues/6291

---

One thing to note is that even with that impelmentation, you might get an arbitrary binary function (for example `&+/2`) that still won't work - there's just no way to know other than trying to execute. And the execution can throw arbitrary errors since the function can be completely arbitrary.