### PR TITLE
Add terminator info to sigil AST node metadata

### DIFF
--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -37,5 +37,6 @@
   check_terminators=true,
   existing_atoms_only=false,
   preserve_comments=false,
+  detect_sigil_terminators=false,
   identifier_tokenizer=elixir_tokenizer
 }).

--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -37,6 +37,5 @@
   check_terminators=true,
   existing_atoms_only=false,
   preserve_comments=false,
-  detect_sigil_terminators=false,
   identifier_tokenizer=elixir_tokenizer
 }).

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -86,7 +86,7 @@ parse_error(Line, File, <<"syntax error before: ">>, <<"'end'">>) ->
 
 %% Produce a human-readable message for errors before a sigil
 parse_error(Line, File, <<"syntax error before: ">>, <<"{sigil,", _Rest/binary>> = Full) ->
-  {sigil, _, Sigil, [Content | _], _} = parse_erl_term(Full),
+  {sigil, _, Sigil, [Content | _], _, _} = parse_erl_term(Full),
   Content2 = case is_binary(Content) of
     true -> Content;
     false -> <<>>

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -719,10 +719,6 @@ build_access(Expr, {List, Location}) ->
 
 %% Interpolation aware
 
-build_sigil({sigil, Location, Sigil, Parts, Modifiers}) ->
-  Meta = meta_from_location(Location),
-  {list_to_atom("sigil_" ++ [Sigil]), Meta, [{'<<>>', Meta, string_parts(Parts)}, Modifiers]};
-
 build_sigil({sigil, Location, Sigil, Parts, Modifiers, Terminator}) ->
   Meta = meta_from_location(Location),
   MetaWithTerminator = [{terminator, Terminator} | Meta],

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -721,7 +721,12 @@ build_access(Expr, {List, Location}) ->
 
 build_sigil({sigil, Location, Sigil, Parts, Modifiers}) ->
   Meta = meta_from_location(Location),
-  {list_to_atom("sigil_" ++ [Sigil]), Meta, [{'<<>>', Meta, string_parts(Parts)}, Modifiers]}.
+  {list_to_atom("sigil_" ++ [Sigil]), Meta, [{'<<>>', Meta, string_parts(Parts)}, Modifiers]};
+
+build_sigil({sigil, Location, Sigil, Parts, Modifiers, Terminator}) ->
+  Meta = meta_from_location(Location),
+  MetaWithTerminator = [{terminator, Terminator} | Meta],
+  {list_to_atom("sigil_" ++ [Sigil]), MetaWithTerminator, [{'<<>>', Meta, string_parts(Parts)}, Modifiers]}.
 
 build_bin_string({bin_string, _Location, [H]} = Token) when is_binary(H) ->
   handle_literal(H, Token);

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -137,11 +137,18 @@ tokenize(String, Line, Column, Opts) ->
     _ -> false
   end,
 
+  DetectSigilTerminators = case lists:keyfind(detect_sigil_terminators, 1, Opts) of
+    {detect_sigil_terminators, DetectSigilTerminatorsBool} when
+      is_boolean(DetectSigilTerminatorsBool) -> DetectSigilTerminatorsBool;
+    _ -> false
+  end,
+
   tokenize(String, Line, Column, #elixir_tokenizer{
     file=File,
     existing_atoms_only=ExistingAtomsOnly,
     check_terminators=CheckTerminators,
     preserve_comments=PreserveComments,
+    detect_sigil_terminators=DetectSigilTerminators,
     identifier_tokenizer=elixir_config:get(identifier_tokenizer)
   }).
 
@@ -194,7 +201,8 @@ tokenize([$~, S, H, H, H | T] = Original, Line, Column, Scope, Tokens) when ?is_
   case extract_heredoc_with_interpolation(Line, Column, Scope, ?is_downcase(S), T, H) of
     {ok, NewLine, NewColumn, Parts, Rest} ->
       {Final, Modifiers} = collect_modifiers(Rest, []),
-      tokenize(Final, NewLine, NewColumn, Scope, [{sigil, {Line, Column, NewColumn}, S, Parts, Modifiers} | Tokens]);
+      SigilToken = handle_sigil(Line, Column, NewColumn, S, Parts, Modifiers, [H, H, H], Scope),
+      tokenize(Final, NewLine, NewColumn, Scope, [SigilToken | Tokens]);
     {error, Reason} ->
       {error, Reason, Original, Tokens}
   end;
@@ -203,7 +211,8 @@ tokenize([$~, S, H | T] = Original, Line, Column, Scope, Tokens) when ?is_sigil(
   case elixir_interpolation:extract(Line, Column + 3, Scope, ?is_downcase(S), T, sigil_terminator(H)) of
     {NewLine, NewColumn, Parts, Rest} ->
       {Final, Modifiers} = collect_modifiers(Rest, []),
-      tokenize(Final, NewLine, NewColumn, Scope, [{sigil, {Line, Column, NewColumn}, S, Parts, Modifiers} | Tokens]);
+      SigilToken = handle_sigil(Line, Column, NewColumn, S, Parts, Modifiers, H, Scope),
+      tokenize(Final, NewLine, NewColumn, Scope, [SigilToken | Tokens]);
     {error, Reason} ->
       Sigil = [$~, S, H],
       interpolation_error(Reason, Original, Tokens, " (for sigil ~ts starting at line ~B)", [Sigil, Line])
@@ -595,8 +604,14 @@ handle_op(Rest, Line, Column, Kind, Length, Op, Scope, Tokens) ->
 
 handle_comments(CommentTokens, Tokens, Scope) ->
   case Scope#elixir_tokenizer.preserve_comments of
-    true  -> lists:append(CommentTokens, Tokens);
+    true -> lists:append(CommentTokens, Tokens);
     false -> Tokens
+  end.
+
+handle_sigil(Line, Column, NewColumn, S, Parts, Modifiers, Terminator, Scope) ->
+  case Scope#elixir_tokenizer.detect_sigil_terminators of
+    true -> {sigil, {Line, Column, NewColumn}, S, Parts, Modifiers, Terminator};
+    false -> {sigil, {Line, Column, NewColumn}, S, Parts, Modifiers}
   end.
 
 % ## Three Token Operators

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -203,7 +203,7 @@ tokenize([$~, S, H | T] = Original, Line, Column, Scope, Tokens) when ?is_sigil(
   case elixir_interpolation:extract(Line, Column + 3, Scope, ?is_downcase(S), T, sigil_terminator(H)) of
     {NewLine, NewColumn, Parts, Rest} ->
       {Final, Modifiers} = collect_modifiers(Rest, []),
-      tokenize(Final, NewLine, NewColumn, Scope, [{sigil, {Line, Column, NewColumn}, S, Parts, Modifiers, H} | Tokens]);
+      tokenize(Final, NewLine, NewColumn, Scope, [{sigil, {Line, Column, NewColumn}, S, Parts, Modifiers, [H]} | Tokens]);
     {error, Reason} ->
       Sigil = [$~, S, H],
       interpolation_error(Reason, Original, Tokens, " (for sigil ~ts starting at line ~B)", [Sigil, Line])

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -101,16 +101,16 @@ defmodule CodeTest do
   end
 
   test "string_to_quoted/1 for presence of sigils terminators" do
-    assert Code.string_to_quoted("~r/foo/") == {:ok, {:sigil_r, [terminator: '/', line: 1],
-                                                [{:<<>>, [line: 1], ["foo"]}, []]}}
-    assert Code.string_to_quoted("~r[foo]") == {:ok, {:sigil_r, [terminator: '[', line: 1],
-                                                [{:<<>>, [line: 1], ["foo"]}, []]}}
-    assert Code.string_to_quoted("~r\"foo\"") == {:ok, {:sigil_r, [terminator: '"', line: 1],
-                                                  [{:<<>>, [line: 1], ["foo"]}, []]}}
-    assert Code.string_to_quoted("~S\"\"\"\nsigil heredoc\n\"\"\"") == {:ok, {:sigil_S, [terminator: '"""', line: 1],
-                                                                        [{:<<>>, [line: 1], ["sigil heredoc\n"]}, []]}}
-    assert Code.string_to_quoted("~S'''\nsigil heredoc\n'''") == {:ok, {:sigil_S, [terminator: '\'\'\'', line: 1],
-                                                                  [{:<<>>, [line: 1], ["sigil heredoc\n"]}, []]}}
+    assert Code.string_to_quoted("~r/foo/") ==
+           {:ok, {:sigil_r, [terminator: '/', line: 1], [{:<<>>, [line: 1], ["foo"]}, []]}}
+    assert Code.string_to_quoted("~r[foo]") ==
+           {:ok, {:sigil_r, [terminator: '[', line: 1], [{:<<>>, [line: 1], ["foo"]}, []]}}
+    assert Code.string_to_quoted("~r\"foo\"") ==
+           {:ok, {:sigil_r, [terminator: '"', line: 1], [{:<<>>, [line: 1], ["foo"]}, []]}}
+    assert Code.string_to_quoted("~S\"\"\"\nsigil heredoc\n\"\"\"") ==
+           {:ok, {:sigil_S, [terminator: '"""', line: 1], [{:<<>>, [line: 1], ["sigil heredoc\n"]}, []]}}
+    assert Code.string_to_quoted("~S'''\nsigil heredoc\n'''") ==
+           {:ok, {:sigil_S, [terminator: '\'\'\'', line: 1], [{:<<>>, [line: 1], ["sigil heredoc\n"]}, []]}}
   end
 
   test "string_to_quoted!/1 works as string_to_quoted/1 but raises on errors" do

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -100,6 +100,19 @@ defmodule CodeTest do
     assert Code.string_to_quoted("a.1") == {:error, {1, "syntax error before: ", "1"}}
   end
 
+  test "string_to_quoted/1 for presence of sigils terminators" do
+    assert Code.string_to_quoted("~r/foo/") == {:ok, {:sigil_r, [terminator: '/', line: 1],
+                                                [{:<<>>, [line: 1], ["foo"]}, []]}}
+    assert Code.string_to_quoted("~r[foo]") == {:ok, {:sigil_r, [terminator: '[', line: 1],
+                                                [{:<<>>, [line: 1], ["foo"]}, []]}}
+    assert Code.string_to_quoted("~r\"foo\"") == {:ok, {:sigil_r, [terminator: '"', line: 1],
+                                                  [{:<<>>, [line: 1], ["foo"]}, []]}}
+    assert Code.string_to_quoted("~S\"\"\"\nsigil heredoc\n\"\"\"") == {:ok, {:sigil_S, [terminator: '"""', line: 1],
+                                                                        [{:<<>>, [line: 1], ["sigil heredoc\n"]}, []]}}
+    assert Code.string_to_quoted("~S'''\nsigil heredoc\n'''") == {:ok, {:sigil_S, [terminator: '\'\'\'', line: 1],
+                                                                  [{:<<>>, [line: 1], ["sigil heredoc\n"]}, []]}}
+  end
+
   test "string_to_quoted!/1 works as string_to_quoted/1 but raises on errors" do
     assert Code.string_to_quoted!("1 + 2") == {:+, [line: 1], [1, 2]}
 

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -195,9 +195,9 @@ vc_merge_conflict_test() ->
     tokenize_error("<<<<<<< HEAD\n[1, 2, 3]").
 
 sigil_terminator_test() ->
-  [{sigil, {1, 1, 8}, 114, [<<"foo">>], [], 47}] = tokenize("~r/foo/"),
-  [{sigil, {1, 1, 8}, 114, [<<"foo">>], [], 91}] = tokenize("~r[foo]"),
-  [{sigil, {1, 1, 8}, 114, [<<"foo">>], [], 34}] = tokenize("~r\"foo\""),
+  [{sigil, {1, 1, 8}, 114, [<<"foo">>], [], "/"}] = tokenize("~r/foo/"),
+  [{sigil, {1, 1, 8}, 114, [<<"foo">>], [], "["}] = tokenize("~r[foo]"),
+  [{sigil, {1, 1, 8}, 114, [<<"foo">>], [], "\""}] = tokenize("~r\"foo\""),
   [{sigil, {1, 1, 1}, 83, [<<"sigil heredoc\n">>], [], "\"\"\""}] = tokenize("~S\"\"\"\nsigil heredoc\n\"\"\""),
   [{sigil, {1, 1, 1}, 83, [<<"sigil heredoc\n">>], [], "'''"}] = tokenize("~S'''\nsigil heredoc\n'''").
 

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -194,6 +194,13 @@ vc_merge_conflict_test() ->
   {1, "found an unexpected version control marker, please resolve the conflicts: ", "<<<<<<< HEAD"} =
     tokenize_error("<<<<<<< HEAD\n[1, 2, 3]").
 
+sigil_terminator_test() ->
+  [{sigil, {1, 1, 8}, 114, [<<"foo">>], [], 47}] = tokenize("~r/foo/"),
+  [{sigil, {1, 1, 8}, 114, [<<"foo">>], [], 91}] = tokenize("~r[foo]"),
+  [{sigil, {1, 1, 8}, 114, [<<"foo">>], [], 34}] = tokenize("~r\"foo\""),
+  [{sigil, {1, 1, 1}, 83, [<<"sigil heredoc\n">>], [], "\"\"\""}] = tokenize("~S\"\"\"\nsigil heredoc\n\"\"\""),
+  [{sigil, {1, 1, 1}, 83, [<<"sigil heredoc\n">>], [], "'''"}] = tokenize("~S'''\nsigil heredoc\n'''").
+
 invalid_sigil_delimiter_test() ->
   {1, "invalid sigil delimiter: ", Message} = tokenize_error("~s\\"),
   true = lists:prefix("\"\\\" (column 3, codepoint U+005C)", lists:flatten(Message)).


### PR DESCRIPTION
Currently, we don't have a way to know which sigil terminators are used after the sigils are tokenized. This PR adds an option to detect such terminators by passing an extra `Terminator` element in the sigil token. The parser will detect the presence of the `Terminator` value and insert it into the sigil AST node's metadata appropriately.

Usage:
```elixir
iex(2)> Code.string_to_quoted("~r/foo\\//")
{:ok, {:sigil_r, [line: 1], [{:<<>>, [line: 1], ["foo/"]}, []]}}
iex(3)> Code.string_to_quoted("~r/foo\\//", detect_sigil_terminators: true)
{:ok, {:sigil_r, [terminator: 47, line: 1], [{:<<>>, [line: 1], ["foo/"]}, []]}}
iex(5)> Code.string_to_quoted("~S\"\"\"\nsigil heredoc\n\"\"\"\n", detect_sigil_terminators: true)
{:ok,
 {:sigil_S, [terminator: '"""', line: 1],
  [{:<<>>, [line: 1], ["sigil heredoc\n"]}, []]}}
```

@josevalim @whatyouhide please let me know what you think, would like your buy-in before I start adding tests. Thanks!