### PR TITLE
Add breakpoint support to IEx.pry

### DIFF
--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -44,8 +44,9 @@ defmodule Macro.Env do
 
     * `export_vars` - a list keeping all variables to be exported in a
       construct (may be `nil`)
-    * `match_vars` - a list of variables defined in a given match (is
-      `nil` when not inside a match)
+    * `match_vars` - controls how "new" variables are handled. Inside a
+      match it is a list with all variables in a match. Outside of a match
+      is either `:warn` or `:apply`
     * `prematch_vars` - a list of variables defined before a match (is
       `nil` when not inside a match)
 
@@ -66,7 +67,7 @@ defmodule Macro.Env do
   @type local :: atom | nil
 
   @opaque export_vars :: vars | nil
-  @opaque match_vars :: vars | nil
+  @opaque match_vars :: vars | :warn | :apply
   @opaque prematch_vars :: vars | nil
 
   @type t :: %{__struct__: __MODULE__,
@@ -103,7 +104,7 @@ defmodule Macro.Env do
       vars: [],
       lexical_tracker: nil,
       export_vars: nil,
-      match_vars: nil,
+      match_vars: :warn,
       prematch_vars: nil}
   end
 

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -177,8 +177,13 @@ env_for_eval(Env, Opts) ->
     false -> nil
   end,
 
+  FA = case lists:keyfind(function, 1, Opts) of
+    {function, {Function, Arity}} when is_atom(Function), is_integer(Arity) -> {Function, Arity};
+    false -> nil
+  end,
+
   Env#{
-    file := File, module := Module,
+    file := File, module := Module, function := FA,
     macros := Macros, functions := Functions,
     requires := Requires, aliases := Aliases, line := Line
   }.

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -179,6 +179,7 @@ env_for_eval(Env, Opts) ->
 
   FA = case lists:keyfind(function, 1, Opts) of
     {function, {Function, Arity}} when is_atom(Function), is_integer(Arity) -> {Function, Arity};
+    {function, nil} -> nil;
     false -> nil
   end,
 

--- a/lib/elixir/src/elixir_clauses.erl
+++ b/lib/elixir/src/elixir_clauses.erl
@@ -9,13 +9,13 @@
 
 match(Fun, Expr, #{context := match} = E) ->
   Fun(Expr, E);
-match(Fun, Expr, #{context := Context, match_vars := nil, prematch_vars := nil, vars := Vars} = E) ->
+match(Fun, Expr, #{context := Context, match_vars := Match, prematch_vars := nil, vars := Vars} = E) ->
   {EExpr, EE} = Fun(Expr, E#{context := match, match_vars := [], prematch_vars := Vars}),
-  {EExpr, EE#{context := Context, match_vars := nil, prematch_vars := nil}}.
+  {EExpr, EE#{context := Context, match_vars := Match, prematch_vars := nil}}.
 
-def({Meta, Args, Guards, Body}, E) ->
+def({Meta, Args, Guards, Body}, #{match_vars := Match} = E) ->
   {EArgs, EA}   = elixir_expand:expand(Args, E#{context := match, match_vars := []}),
-  {EGuards, EG} = guard(Guards, EA#{context := guard, match_vars := nil}),
+  {EGuards, EG} = guard(Guards, EA#{context := guard, match_vars := Match}),
   {EBody, _}    = elixir_expand:expand(Body, EG#{context := ?key(E, context)}),
   {Meta, EArgs, EGuards, EBody}.
 

--- a/lib/elixir/src/elixir_env.erl
+++ b/lib/elixir/src/elixir_env.erl
@@ -19,8 +19,8 @@ new() ->
     lexical_tracker => nil,                %% holds the lexical tracker PID
     vars => [],                            %% a set of defined variables
     export_vars => nil,                    %% a set of variables to be exported in some constructs
-    match_vars => nil,                     %% a set of variables defined in the current match
-    prematch_vars => nil}.                 %% a set of variables defined before the current match
+    prematch_vars => nil,                  %% a set of variables defined before the current match
+    match_vars => warn}.                   %% handling of new variables
 
 linify({Line, Env}) ->
   Env#{line := Line};

--- a/lib/elixir/src/elixir_erl_try.erl
+++ b/lib/elixir/src/elixir_erl_try.erl
@@ -28,14 +28,14 @@ each_clause({'catch', Meta, Raw, Expr}, S) ->
 
 each_clause({rescue, Meta, [{in, _, [Left, Right]}], Expr}, S) ->
   {TempName, _, CS} = elixir_erl_var:build('_', S),
-  TempVar = {TempName, Meta, nil},
+  TempVar = {TempName, Meta, 'Elixir'},
   {Parts, Safe, FS} = rescue_guards(Meta, TempVar, Right, CS),
   Body = rescue_clause_body(Left, Expr, Safe, TempVar, Meta),
   build_rescue(Meta, Parts, Body, FS);
 
 each_clause({rescue, Meta, [{VarName, _, Context} = Left], Expr}, S) when is_atom(VarName), is_atom(Context) ->
   {TempName, _, CS} = elixir_erl_var:build('_', S),
-  TempVar = {TempName, Meta, nil},
+  TempVar = {TempName, Meta, 'Elixir'},
   Body = rescue_clause_body(Left, Expr, false, TempVar, Meta),
   build_rescue(Meta, [{TempVar, []}], Body, CS).
 
@@ -76,7 +76,7 @@ rescue_guards(Meta, Var, Aliases, S) ->
       [] -> {[], S};
       _  ->
         {VarName, _, CS} = elixir_erl_var:build('_', S),
-        StructVar = {VarName, Meta, nil},
+        StructVar = {VarName, Meta, 'Elixir'},
         Map = {'%{}', Meta, [{'__struct__', StructVar}, {'__exception__', true}]},
         Match = {'=', Meta, [Map, Var]},
         Guards = [{erl(Meta, '=='), Meta, [StructVar, Mod]} || Mod <- Elixir],

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -357,10 +357,15 @@ expand({Name, Meta, Kind} = Var, #{vars := Vars} = E) when is_atom(Name), is_ato
         {var, true} ->
           form_error(Meta, ?key(E, file), ?MODULE, {undefined_var, Name, Kind});
         _ ->
-          Message =
-            io_lib:format("variable \"~ts\" does not exist and is being expanded to \"~ts()\","
-              " please use parentheses to remove the ambiguity or change the variable name", [Name, Name]),
-          elixir_errors:warn(?line(Meta), ?key(E, file), Message),
+          case ?key(E, match_vars) of
+            warn ->
+              Message =
+                io_lib:format("variable \"~ts\" does not exist and is being expanded to \"~ts()\","
+                  " please use parentheses to remove the ambiguity or change the variable name", [Name, Name]),
+              elixir_errors:warn(?line(Meta), ?key(E, file), Message);
+            apply ->
+              ok
+          end,
           expand({Name, Meta, []}, E)
       end
   end;

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -515,7 +515,23 @@ defmodule IEx do
   end
 
   @doc """
-  Sets up a breakpoint in the given module, function and arity.
+  Macro-based shortcut for `IEx.break!/4`.
+  """
+  defmacro break!(ast, stops \\ 1) do
+    with {:/, _, [call, arity]} when is_integer(arity) <- ast,
+         {mod, fun, []} <- Macro.decompose_call(call) do
+      quote do
+        IEx.break!(unquote(mod), unquote(fun), unquote(arity), unquote(stops))
+      end
+    else
+      _ ->
+        raise ArgumentError, "expected Mod.fun/arity, such as URI.parse/1, got: #{Macro.to_string(ast)}"
+    end
+  end
+
+  @doc """
+  Sets up a breakpoint in `module`, `function` and `arity` with
+  the given number of `stops`.
 
   This function will recompile the given module and load a new
   version in memory with breakpoints at the given function and

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -507,6 +507,15 @@ defmodule IEx do
   Setting variables or importing modules in IEx does not
   affect the caller's environment. However, sending and
   receiving messages will change the process state.
+
+  ## Pry and mix test
+
+  To use `IEx.pry/0` during tests, you need to run Mix inside
+  `iex` and pass the `--trace` to `mix test` to avoid running
+  into timeouts:
+
+      iex -S mix test --trace
+      iex -S mix test path/to/file:line --trace
   """
   defmacro pry() do
     quote do
@@ -602,6 +611,16 @@ defmodule IEx do
 
   This function returns the breakpoint ID and will raise if there
   is an error setting up the breakpoint.
+
+  ## Breaks and mix test
+
+  To use `IEx.break!/4` during tests, you need to run Mix inside
+  `iex` and pass the `--trace` to `mix test` to avoid running
+  into timeouts:
+
+      iex -S mix test --trace
+      iex -S mix test path/to/file:line --trace
+
   """
   def break!(module, function, arity, stops \\ 10) do
     case IEx.Pry.break(module, function, arity, stops) do
@@ -625,7 +644,7 @@ defmodule IEx do
             :unknown_function_arity ->
               "unknown function/macro #{Exception.format_mfa(module, function, arity)}"
           end
-        raise ArgumentError, "could not set breakpoint, " <> message
+        raise "could not set breakpoint, " <> message
     end
   end
 

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -533,9 +533,9 @@ defmodule IEx do
   Sets up a breakpoint in `module`, `function` and `arity` with
   the given number of `stops`.
 
-  This function will recompile the given module and load a new
+  This function will instrument the given module and load a new
   version in memory with breakpoints at the given function and
-  arity.
+  arity. If the module is recompiled, all breakpoints are lost.
 
   When a breakpoint is reached, IEx will ask if you want to `pry`
   the given function and arity. In other words, this works similar
@@ -556,8 +556,8 @@ defmodule IEx do
     * `IEx.Helpers.open/0` - opens editor on the current breakpoint
     * `IEx.Helpers.remove_breaks/0` - removes all breakpoints in all modules
     * `IEx.Helpers.remove_breaks/1` - removes all breakpoints in a given module
-    * `IEx.Helpers.reset_break/1` - resets all breaks for the given id or `Mod.fun/arity`
-    * `IEx.Helpers.reset_break/3` - resets all breaks for the given module, function, arity
+    * `IEx.Helpers.reset_break/1` - sets the number of stops on the given id to zero
+    * `IEx.Helpers.reset_break/3` - sets the number of stops on the given module, function, arity to zero
     * `IEx.Helpers.respawn/0` - starts a new shell (breakpoints will ask for permission once more)
     * `IEx.Helpers.whereami/1` - shows the current location
 

--- a/lib/iex/lib/iex/app.ex
+++ b/lib/iex/lib/iex/app.ex
@@ -4,18 +4,7 @@ defmodule IEx.App do
   use Application
 
   def start(_type, _args) do
-    tab = IEx.Config.new()
-
-    case Supervisor.start_link([IEx.Config], strategy: :one_for_one, name: IEx.Supervisor) do
-      {:ok, pid} ->
-        {:ok, pid, tab}
-      {:error, _} = error ->
-        IEx.Config.delete(tab)
-        error
-    end
-  end
-
-  def stop(tab) do
-    IEx.Config.delete(tab)
+    children = [IEx.Config, IEx.Pry]
+    Supervisor.start_link(children, strategy: :one_for_one, name: IEx.Supervisor)
   end
 end

--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -395,8 +395,8 @@ defmodule IEx.Autocomplete do
   ## Evaluator interface
 
   defp imports_from_env(server) do
-    with evaluator when is_pid(evaluator) <- server.evaluator(),
-         env_fields = IEx.Evaluator.fields_from_env(evaluator, [:functions, :macros]),
+    with {evaluator, server} <- server.evaluator(),
+         env_fields = IEx.Evaluator.fields_from_env(evaluator, server, [:functions, :macros]),
          %{functions: funs, macros: macros} <- env_fields do
       Enum.flat_map(funs ++ macros, &elem(&1, 1))
     else
@@ -405,8 +405,8 @@ defmodule IEx.Autocomplete do
   end
 
   defp aliases_from_env(server) do
-    with evaluator when is_pid(evaluator) <- server.evaluator,
-         %{aliases: aliases} <- IEx.Evaluator.fields_from_env(evaluator, [:aliases]) do
+    with {evaluator, server} <- server.evaluator(),
+         %{aliases: aliases} <- IEx.Evaluator.fields_from_env(evaluator, server, [:aliases]) do
       aliases
     else
       _ -> []
@@ -414,17 +414,17 @@ defmodule IEx.Autocomplete do
   end
 
   defp variables_from_binding(hint, server) do
-    with evaluator when is_pid(evaluator) <- server.evaluator() do
-      IEx.Evaluator.variables_from_binding(evaluator, hint)
+    with {evaluator, server} <- server.evaluator() do
+      IEx.Evaluator.variables_from_binding(evaluator, server, hint)
     else
       _ -> []
     end
   end
 
   defp value_from_binding(ast_node, server) do
-    with evaluator when is_pid(evaluator) <- server.evaluator(),
+    with {evaluator, server} <- server.evaluator(),
          {var, map_key_path} <- extract_from_ast(ast_node, []) do
-      IEx.Evaluator.value_from_binding(evaluator, var, map_key_path)
+      IEx.Evaluator.value_from_binding(evaluator, server, var, map_key_path)
     else
       _ -> :error
     end

--- a/lib/iex/lib/iex/config.ex
+++ b/lib/iex/lib/iex/config.ex
@@ -119,7 +119,7 @@ defmodule IEx.Config do
   # Agent API
 
   def start_link(_) do
-    Agent.start_link(__MODULE__, :handle_init, [], [name: @agent])
+    Agent.start_link(__MODULE__, :handle_init, [], name: @agent)
   end
 
   def after_spawn(fun) do

--- a/lib/iex/lib/iex/config.ex
+++ b/lib/iex/lib/iex/config.ex
@@ -119,17 +119,7 @@ defmodule IEx.Config do
   # Agent API
 
   def start_link(_) do
-    Agent.start_link(__MODULE__, :handle_init, [@table], [name: @agent])
-  end
-
-  def new() do
-    tab = :ets.new(@table, [:named_table, :public])
-    true = :ets.insert_new(tab, [after_spawn: []])
-    tab
-  end
-
-  def delete(__MODULE__) do
-    :ets.delete(__MODULE__)
+    Agent.start_link(__MODULE__, :handle_init, [], [name: @agent])
   end
 
   def after_spawn(fun) do
@@ -146,9 +136,10 @@ defmodule IEx.Config do
 
   # Agent callbacks
 
-  def handle_init(tab) do
-    :public = :ets.info(tab, :protection)
-    tab
+  def handle_init do
+    :ets.new(@table, [:named_table, :public])
+    true = :ets.insert_new(@table, [after_spawn: []])
+    @table
   end
 
   def handle_after_spawn(tab, fun) do
@@ -164,10 +155,9 @@ defmodule IEx.Config do
   end
 
   defp update_configuration(config) do
-    put = fn({key, value}) when key in @keys ->
+    Enum.each(config, fn {key, value} when key in @keys ->
       Application.put_env(:iex, key, value)
-    end
-    Enum.each(config, put)
+    end)
   end
 
   defp merge_option(:colors, old, new) when is_list(new), do: Keyword.merge(old, new)

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -196,7 +196,7 @@ defmodule IEx.Evaluator do
     line = iex_state.counter
     put_history(state)
     put_whereami(state)
-    quoted = Code.string_to_quoted(code, [line: line, file: "iex"])
+    quoted = Code.string_to_quoted(code, line: line, file: "iex")
     handle_eval(quoted, code, line, iex_state, state)
   after
     Process.delete(:iex_history)

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -200,13 +200,22 @@ defmodule IEx.Evaluator do
     code = iex_state.cache ++ latest_input
     line = iex_state.counter
     put_history(state)
+    put_whereami(state)
     handle_eval(Code.string_to_quoted(code, [line: line, file: "iex"]), code, line, iex_state, state)
   after
     Process.delete(:iex_history)
+    Process.delete(:iex_whereami)
   end
 
   defp put_history(%{history: history}) do
     Process.put(:iex_history, history)
+  end
+
+  defp put_whereami(%{env: %{file: "iex"}}) do
+    :ok
+  end
+  defp put_whereami(%{env: %{file: file, line: line}}) do
+    Process.put(:iex_whereami, {file, line})
   end
 
   defp handle_eval({:ok, forms}, code, line, iex_state, state) do

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -112,10 +112,11 @@ defmodule IEx.Evaluator do
 
   defp loop_state(server, history, opts) do
     env = opts[:env] || :elixir.env_for_eval(file: "iex")
+    env = %{env | match_vars: :apply}
     {_, _, env, scope} = :elixir.eval('import IEx.Helpers', [], env)
 
     binding = Keyword.get(opts, :binding, [])
-    state  = %{binding: binding, scope: scope, env: env, server: server, history: history}
+    state = %{binding: binding, scope: scope, env: env, server: server, history: history}
 
     case opts[:dot_iex_path] do
       ""   -> state

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -111,13 +111,7 @@ defmodule IEx.Evaluator do
   end
 
   defp loop_state(server, history, opts) do
-    env =
-      if env = opts[:env] do
-        :elixir.env_for_eval(env, [])
-      else
-        :elixir.env_for_eval(file: "iex")
-      end
-
+    env = opts[:env] || :elixir.env_for_eval(file: "iex")
     {_, _, env, scope} = :elixir.eval('import IEx.Helpers', [], env)
 
     binding = Keyword.get(opts, :binding, [])

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -707,6 +707,25 @@ defmodule IEx.Helpers do
   end
 
   @doc """
+  Macro-based shortcut for `IEx.break!/4`.
+  """
+  defmacro break!(ast, stops \\ 1) do
+    quote do
+      require IEx
+      IEx.break!(unquote(ast), unquote(stops))
+    end
+  end
+
+  @doc """
+  Sets up a breakpoint in `module`, `function` and `arity`
+  with the given number of `stops`.
+
+  See `IEx.break!/4` for a complete description of breakpoints
+  in IEx.
+  """
+  defdelegate break!(module, function, arity, stops \\ 1), to: IEx
+
+  @doc """
   Prints the current location in a pry session.
 
   It expects a `radius` which chooses how many lines before and after

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -201,10 +201,10 @@ defmodule IEx.Helpers do
   Opens the current prying location.
 
   This command only works inside a pry session started manually
-  via `IEx.pry` or a breakpoint set via `IEx.break/1`. Calling
+  via `IEx.pry/0` or a breakpoint set via `IEx.break!/4`. Calling
   this function during a regular `IEx` session will print an error.
 
-  Keep in mind the `open` location may not exist when prying
+  Keep in mind the `open/0` location may not exist when prying
   precompiled source code, such as Elixir itself.
 
   For more information and to open any module or function, see
@@ -224,11 +224,11 @@ defmodule IEx.Helpers do
   @doc """
   Opens the given module, module/function/arity or file.
 
-  This function uses the ELIXIR_EDITOR environment variable
+  This function uses the `ELIXIR_EDITOR` environment variable
   and falls back to EDITOR if the former is not available.
 
   Since this function prints the result returned by the
-  editor, ELIXIR_EDITOR can be set "echo" if you prefer
+  editor, `ELIXIR_EDITOR` can be set "echo" if you prefer
   to display the location rather than opening it.
 
   ## Examples
@@ -826,10 +826,10 @@ defmodule IEx.Helpers do
       81:       config = Mix.Project.config
 
   This command only works inside a pry session started manually
-  via `IEx.pry` or a breakpoint set via `IEx.break/1`. Calling
+  via `IEx.pry/0` or a breakpoint set via `IEx.break!/4`. Calling
   this function during a regular `IEx` session will print an error.
 
-  Keep in mind the `whereami` location may not exist when prying
+  Keep in mind the `whereami/1` location may not exist when prying
   precompiled source code, such as Elixir itself.
   """
   def whereami(radius \\ 2) do

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -35,6 +35,7 @@ defmodule IEx.Helpers do
     * `i/1`           - prints information about the given term
     * `ls/0`          - lists the contents of the current directory
     * `ls/1`          - lists the contents of the specified directory
+    * `open/1`        - opens the source for the given module or function in your editor
     * `pid/1`         - creates a PID from a string
     * `pid/3`         - creates a PID with the 3 integer arguments passed
     * `pwd/0`         - prints the current working directory
@@ -53,6 +54,9 @@ defmodule IEx.Helpers do
   exports (functions and macros) in the `IEx.Helpers` module:
 
       iex> e(IEx.Helpers)
+
+  This module also include helpers for debugging purposes, see
+  `IEx.break!/4` for more information.
 
   To learn more about IEx as a whole, type `h(IEx)`.
   """

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -676,14 +676,34 @@ defmodule IEx.Helpers do
 
   @doc """
   Respawns the current shell by starting a new shell process.
-
-  Returns `true` if it worked.
   """
   def respawn do
     if whereis = IEx.Server.whereis do
       send whereis, {:respawn, self()}
-      dont_display_result()
     end
+    dont_display_result()
+  end
+
+  @doc """
+  Continues execution of the current process.
+
+  This is usually called by sessions started with `IEx.pry/0`
+  or `IEx.break!/4`. This allows the current to execute until
+  the next breakpoint, which will automatically yield control
+  back to IEx without requesting permission to pry.
+
+  If the running process terminates, a new IEx session is
+  started.
+
+  While the process executes, the user will no longer have
+  control of the shell. If you would rather start a new shell,
+  use `respawn/0` instead.
+  """
+  def continue do
+    if whereis = IEx.Server.whereis do
+      send whereis, {:continue, self()}
+    end
+    dont_display_result()
   end
 
   @doc """

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -710,7 +710,7 @@ defmodule IEx.Helpers do
         IO.puts IEx.color(:eval_info, ["Location: ", Path.relative_to_cwd(file), ":", Integer.to_string(line)])
         case IEx.Pry.whereami(file, line, radius) do
           {:ok, lines} ->
-            IO.write [?\n, lines, ?\n, ?\n]
+            IO.write [?\n, lines, ?\n]
           :error ->
             IO.puts IEx.color(:eval_error, "Could not extract source snippet. Location is not available.")
         end

--- a/lib/iex/lib/iex/pry.ex
+++ b/lib/iex/lib/iex/pry.ex
@@ -13,7 +13,7 @@ defmodule IEx.Pry do
     meta = "#{inspect self()} at #{Path.relative_to_cwd(env.file)}:#{env.line}"
     desc =
       case whereami(env.file, env.line, 2) do
-        {:ok, lines} -> [?\n, ?\n, lines]
+        {:ok, lines} -> [?\n, ?\n, lines, ?\n]
         :error -> ""
       end
 
@@ -24,8 +24,8 @@ defmodule IEx.Pry do
       {:error, :no_iex} ->
         extra =
           case :os.type do
-            {:win32, _} -> " If you are Windows, you may need to start IEx with the --werl flag."
-            _           -> ""
+            {:win32, _} -> " If you are using Windows, you may need to start IEx with the --werl flag."
+            _ -> ""
           end
         IO.puts :stdio, "Cannot pry #{meta}. Is an IEx shell running?" <> extra
       _ ->

--- a/lib/iex/lib/iex/pry.ex
+++ b/lib/iex/lib/iex/pry.ex
@@ -243,7 +243,7 @@ defmodule IEx.Pry do
   end
 
   def handle_call(:remove_breaks, _from, _counter) do
-    # Make sure to deinstrumented before clearing
+    # Make sure to deinstrument before clearing
     # up the table to avoid race conditions.
     @table
     |> :ets.match({:_, :"$1", :_, :_})

--- a/lib/iex/lib/iex/pry.ex
+++ b/lib/iex/lib/iex/pry.ex
@@ -166,7 +166,7 @@ defmodule IEx.Pry do
 
   def init(:ok) do
     Process.flag(:trap_exit, true)
-    :ets.new(@table, [:named_table, :public])
+    :ets.new(@table, [:named_table, :public, write_concurrency: true])
     {:ok, 0}
   end
 

--- a/lib/iex/lib/iex/pry.ex
+++ b/lib/iex/lib/iex/pry.ex
@@ -1,5 +1,16 @@
 defmodule IEx.Pry do
-  @moduledoc false
+  @moduledoc """
+  The low-level API for prying sessions and setting up breakpoints.
+  """
+
+  use GenServer
+
+  @table __MODULE__
+  @server __MODULE__
+  @timeout :infinity
+
+  @type id :: integer()
+  @type break :: {id, module, {function, arity}, pending :: non_neg_integer}
 
   @doc """
   Callback for `IEx.pry/1`.
@@ -8,12 +19,12 @@ defmodule IEx.Pry do
   `IEx.pry/1` as a macro. This function expects the binding (from
   `Kernel.binding/0`) and the environment (from `__ENV__/0`).
   """
-  def pry(binding, env) do
+  def pry(binding, %Macro.Env{file: file, line: line} = env) do
     opts = [binding: binding, dot_iex_path: "", env: env, prefix: "pry"]
-    meta = "#{inspect self()} at #{Path.relative_to_cwd(env.file)}:#{env.line}"
+    meta = "#{inspect self()} at #{Path.relative_to_cwd(file)}:#{line}"
     desc =
-      case whereami(env.file, env.line, 2) do
-        {:ok, lines} -> [?\n, ?\n, lines, ?\n]
+      case whereami(file, line, 2) do
+        {:ok, lines} -> [?\n, ?\n, lines]
         :error -> ""
       end
 
@@ -35,6 +46,11 @@ defmodule IEx.Pry do
     res
   end
 
+  def pry(binding, opts) when is_list(opts) do
+    vars = for {k, _} when is_atom(k) <- binding, do: {k, nil}
+    pry(binding, %{:elixir.env_for_eval(opts) | vars: vars})
+  end
+
   @doc """
   Formats the location for `whereami/3` prying.
 
@@ -44,7 +60,8 @@ defmodule IEx.Pry do
 
   The actual line is especially formatted in bold.
   """
-  def whereami(file, line, radius) do
+  def whereami(file, line, radius)
+      when is_binary(file) and is_integer(line) and is_integer(radius) and radius > 0 do
     with true <- File.regular?(file),
          [_ | _] = lines <- whereami_lines(file, line, radius) do
       {:ok, lines}
@@ -71,5 +88,283 @@ defmodule IEx.Pry do
     else
       [gutter, ": ", line_text]
     end
+  end
+
+  @doc """
+  Sets up a breakpoint on the given module/function or
+  given module/function/arity.
+  """
+  @spec break(module, function, arity, pos_integer) ::
+        {:ok, id} |
+        {:error, :recompilation_failed | :no_beam_file | :unknown_function_arity |
+                 :otp_20_is_required | :missing_debug_info | :outdated_debug_info |
+                 :non_elixir_module}
+  def break(module, function, arity, breaks \\ 1)
+      when is_atom(module) and is_atom(function) and is_integer(arity) and arity >= 0 and
+           is_integer(breaks) and breaks > 0 do
+    GenServer.call(@server, {:break, module, {function, arity}, breaks}, @timeout)
+  end
+
+  @doc """
+  Resets the breaks on a given breakpoint id.
+  """
+  @spec reset_break(id) :: :ok | :not_found
+  def reset_break(id) when is_integer(id) do
+    GenServer.call(@server, {:reset_break, {id, :_, :_, :_}}, @timeout)
+  end
+
+  @doc """
+  Resets the breaks for the given module, function and arity.
+
+  If the module is not instrumented or if the given function
+  does not have a breakpoint, it is a no-op and it returns
+  `:not_found`. Otherwise it returns `:ok`.
+  """
+  @spec reset_break(module, function, arity) :: :ok | :not_found
+  def reset_break(module, function, arity) do
+    GenServer.call(@server, {:reset_break, {:_, module, {function, arity}, :_}}, @timeout)
+  end
+
+  @doc """
+  Removes all breakpoints on all modules.
+
+  This effectively loads the non-instrumented version of
+  currently instrumented modules into memory.
+  """
+  @spec remove_breaks :: :ok
+  def remove_breaks do
+    GenServer.call(@server, :remove_breaks, @timeout)
+  end
+
+  @doc """
+  Removes breakpoints in the given module.
+
+  This effectively loads the non-instrumented version of
+  the module into memory.
+  """
+  @spec remove_breaks(module) :: :ok | {:error, :no_beam_file}
+  def remove_breaks(module) do
+    GenServer.call(@server, {:remove_breaks, module}, @timeout)
+  end
+
+  @doc """
+  Returns all breakpoints.
+  """
+  @spec breaks :: [break]
+  def breaks do
+    @server
+    |> GenServer.call(:breaks, @timeout)
+    |> Enum.sort()
+  end
+
+  ## Callbacks
+
+  @doc false
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: @server)
+  end
+
+  def init(:ok) do
+    Process.flag(:trap_exit, true)
+    :ets.new(@table, [:named_table, :public])
+    {:ok, 0}
+  end
+
+  def handle_call({:break, module, fa, breaks}, _from, counter) do
+    # If there is a match for the given module and fa, and
+    # the module is still instrumented, we just increment
+    # the breaks counter.
+    #
+    # Otherwise we need to invoke the whole instrumentation
+    # tool chain.
+    case :ets.match_object(@table, {:_, module, fa, :_}) do
+      [{ref, module, fa, _}] ->
+        if instrumented?(module) do
+          :ets.insert(@table, {ref, module, fa, breaks})
+          {:reply, {:ok, ref}, counter}
+        else
+          :ets.delete(@table, ref)
+          instrument_and_reply(module, fa, breaks, counter)
+        end
+      [] ->
+        instrument_and_reply(module, fa, breaks, counter)
+    end
+  end
+
+  def handle_call({:reset_break, pattern}, _from, counter) do
+    reset =
+      for {ref, module, fa, _} <- :ets.match_object(@table, pattern) do
+        if instrumented?(module) do
+          :ets.insert(@table, {ref, module, fa, 0})
+          true
+        else
+          :ets.delete(@table, ref)
+          false
+        end
+      end
+
+    if Enum.any?(reset) do
+      {:reply, :ok, counter}
+    else
+      {:reply, :not_found, counter}
+    end
+  end
+
+  def handle_call(:breaks, _from, counter) do
+    entries =
+      for {id, module, function_arity, breaks} <- :ets.tab2list(@table),
+          keep_instrumented(id, module) == :ok do
+        {id, module, function_arity, max(breaks, 0)}
+      end
+    {:reply, entries, counter}
+  end
+
+  def handle_call(:remove_breaks, _from, _counter) do
+    # Make sure to deinstrumented before clearing
+    # up the table to avoid race conditions.
+    @table
+    |> :ets.match({:_, :"$1", :_, :_})
+    |> List.flatten
+    |> Enum.uniq
+    |> Enum.each(&deinstrument_if_instrumented/1)
+    true = :ets.delete_all_objects(@table)
+    {:reply, :ok, 0}
+  end
+
+  def handle_call({:remove_breaks, module}, _from, counter) do
+    # Make sure to deinstrumented before clearing
+    # up the table to avoid race conditions.
+    reply = deinstrument_if_instrumented(module)
+    true = :ets.match_delete(@table, {:_, module, :_, :_})
+    {:reply, reply, counter}
+  end
+
+  defp keep_instrumented(id, module) do
+    if instrumented?(module) do
+      :ok
+    else
+      :ets.delete(@table, id)
+      :error
+    end
+  end
+
+  defp deinstrument_if_instrumented(module) do
+    if instrumented?(module) do
+      deinstrument(module)
+    else
+      :ok
+    end
+  end
+
+  defp deinstrument(module) do
+    with beam when is_list(beam) <- :code.which(module),
+         {:ok, binary} = File.read(beam) do
+      :code.purge(module)
+      {:module, _} = :code.load_binary(module, beam, binary)
+      :ok
+    else
+      _ -> {:error, :no_beam_file}
+    end
+  end
+
+  defp instrument_and_reply(module, fa, breaks, counter) do
+    case fetch_elixir_debug_info_with_fa_check(module, fa) do
+      {:ok, beam, backend, elixir} ->
+        counter = counter + 1
+        true = :ets.insert_new(@table, {counter, module, fa, breaks})
+        entries = :ets.match_object(@table, {:_, module, :_, :_})
+        {:reply, instrument(beam, backend, elixir, counter, entries), counter}
+      {:error, _} = error ->
+        {:reply, error, counter}
+    end
+  end
+
+  defp fetch_elixir_debug_info_with_fa_check(module, fa) do
+    case :code.which(module) do
+      beam when is_list(beam) ->
+        case :beam_lib.chunks(beam, [:debug_info]) do
+          {:ok, {_, [debug_info: {:debug_info_v1, backend, {:elixir_v1, map, _} = elixir}]}} ->
+            case List.keyfind(map.definitions, fa, 0) do
+              {_, _, _, _} -> {:ok, beam, backend, elixir}
+              nil -> {:error, :unknown_function_arity}
+            end
+          {:ok, {_, [debug_info: {:debug_info_v1, _, _}]}} ->
+            {:error, :non_elixir_module}
+          {:error, :beam_lib, {:unknown_chunk, _, _}} ->
+            {:error, :otp_20_is_required} # TODO: Remove this when we require OTP 20+
+          {:error, :beam_lib, {:missing_chunk, _, _}} ->
+            {:error, :missing_debug_info}
+          _ ->
+            {:error, :outdated_debug_info}
+        end
+      _ ->
+        {:error, :no_beam_file}
+    end
+  end
+
+  defp instrument(beam, backend, {:elixir_v1, map, specs}, counter, entries) do
+    %{attributes: attributes, definitions: definitions, module: module} = map
+    map = %{map | attributes: [{:iex_pry, true} | attributes],
+                  definitions: Enum.map(definitions, &instrument_definition(&1, map, entries))}
+
+    with {:ok, forms} <- backend.debug_info(:erlang_v1, module, {:elixir_v1, map, specs}, []),
+         {:ok, _, binary, _} <- :compile.noenv_forms(forms, [:return | map.compile_opts]) do
+      :code.purge(module)
+      {:module, _} = :code.load_binary(module, beam, binary)
+      {:ok, counter}
+    else
+      _error ->
+        {:error, :recompilation_failed}
+    end
+  end
+
+  defp instrument_definition({fa, kind, meta, clauses} = definition, map, entries) do
+    case List.keyfind(entries, fa, 2) do
+      {ref, _, ^fa, _} ->
+        %{module: module, file: file} = map
+        file =
+          case meta[:location] do
+            {file, _} -> file
+            _ -> file
+          end
+        opts = [module: module, file: file, function: fa]
+        clauses = Enum.map(clauses, &instrument_clause(&1, ref, opts))
+        {fa, kind, meta, clauses}
+      nil ->
+        definition
+    end
+  end
+
+  defp instrument_clause({meta, args, guards, clause}, ref, opts) do
+    opts = [line: Keyword.get(meta, :line, 1)] ++ opts
+
+    # We store variables on a map ignoring the context.
+    # In the rare case where variables in different contexts
+    # have the same name, the last one wins.
+    {_, binding} =
+      Macro.prewalk(args, %{}, fn
+        {name, _, ctx} = var, acc when name != :_ and is_atom(name) and is_atom(ctx) ->
+          {var, Map.put(acc, name, var)}
+        expr, acc ->
+          {expr, acc}
+      end)
+
+    # Generate the take_over condition with the ets lookup.
+    # Remember this is expanded AST, so no aliases allowed,
+    # no locals (such as the unary -) and so on.
+    condition =
+      quote do
+        # :ets.update_counter(table, key, {pos, inc, threshold, reset})
+        case :ets.update_counter(unquote(@table), unquote(ref), {4, unquote(-1), unquote(-1), unquote(-1)}) do
+          unquote(-1) -> :ok
+          _ -> :"Elixir.IEx.Pry".pry(unquote(Map.to_list(binding)), unquote(opts))
+        end
+      end
+
+    {meta, args, guards, {:__block__, [], [condition, clause]}}
+  end
+
+  defp instrumented?(module) do
+    module.module_info(:attributes)[:iex_pry] == [true]
   end
 end

--- a/lib/iex/lib/iex/pry.ex
+++ b/lib/iex/lib/iex/pry.ex
@@ -36,7 +36,13 @@ defmodule IEx.Pry do
   end
 
   @doc """
-  Formats the location for whereami prying.
+  Formats the location for `whereami/3` prying.
+
+  It receives the `file`, `line` and the snippet `radius` and
+  returns `{:ok, lines}`, where lines is a list of chardata
+  containing each formatted line, or `:error`.
+
+  The actual line is especially formatted in bold.
   """
   def whereami(file, line, radius) do
     with true <- File.regular?(file),

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -11,13 +11,13 @@ defmodule IEx.AutocompleteTest do
 
   defmodule MyServer do
     def evaluator do
-      Process.get(:evaluator)
+      {Process.get(:evaluator), self()}
     end
   end
 
   defp eval(line) do
     ExUnit.CaptureIO.capture_io(fn ->
-      evaluator = MyServer.evaluator
+      {evaluator, _} = MyServer.evaluator
       Process.group_leader(evaluator, Process.group_leader)
       send evaluator, {:eval, self(), line <> "\n", %IEx.State{}}
       assert_receive {:evaled, _, _}

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -29,15 +29,43 @@ defmodule IEx.HelpersTest do
   end
 
   if :erlang.system_info(:otp_release) >= '20' do
-    describe "break!" do
-      test "sets up a breakpoint on the given module" do
-        assert break!(URI, :decode_query, 2) == 1
-        assert [_] = IEx.Pry.breaks()
+    describe "breakpoints" do
+      setup do
+        on_exit fn -> IEx.Pry.remove_breaks() end
       end
 
       test "sets up a breakpoint with macro syntax" do
         assert break!(URI.decode_query/2) == 1
-        assert [_] = IEx.Pry.breaks()
+        assert IEx.Pry.breaks() == [{1, URI, {:decode_query, 2}, 1}]
+      end
+
+      test "sets up a breakpoint on the given module" do
+        assert break!(URI, :decode_query, 2) == 1
+        assert IEx.Pry.breaks() == [{1, URI, {:decode_query, 2}, 1}]
+      end
+
+      test "resets breaks on the given id" do
+        assert break!(URI, :decode_query, 2) == 1
+        assert reset_break(1) == :ok
+        assert IEx.Pry.breaks() == [{1, URI, {:decode_query, 2}, 0}]
+      end
+
+      test "resets breaks on the given module" do
+        assert break!(URI, :decode_query, 2) == 1
+        assert reset_break(URI, :decode_query, 2) == :ok
+        assert IEx.Pry.breaks() == [{1, URI, {:decode_query, 2}, 0}]
+      end
+
+      test "removes breaks in the given module" do
+        assert break!(URI.decode_query/2) == 1
+        assert remove_breaks(URI) == :ok
+        assert IEx.Pry.breaks() == []
+      end
+
+      test "removes breaks on all modules" do
+        assert break!(URI.decode_query/2) == 1
+        assert remove_breaks() == :ok
+        assert IEx.Pry.breaks() == []
       end
 
       test "errors when setting up a break with no beam" do
@@ -56,6 +84,40 @@ defmodule IEx.HelpersTest do
         assert_raise ArgumentError,
                      "could not set breakpoint, module :elixir was not written in Elixir",
                      fn -> break!(:elixir, :unknown, 2) end
+      end
+
+      test "prints table with breaks" do
+        break!(URI, :decode_query, 2)
+        assert capture_io(fn -> breaks() end) == """
+
+         ID   Module.function/arity   Pending stops
+        ---- ----------------------- ---------------
+         1    URI.decode_query/2      1
+
+        """
+
+        assert capture_io(fn -> URI.decode_query("foo=bar", %{}) end) != ""
+        assert capture_io(fn -> breaks() end) == """
+
+         ID   Module.function/arity   Pending stops
+        ---- ----------------------- ---------------
+         1    URI.decode_query/2      0
+
+        """
+
+        assert capture_io(fn -> URI.decode_query("foo=bar", %{}) end) == ""
+        assert capture_io(fn -> breaks() end) == """
+
+         ID   Module.function/arity   Pending stops
+        ---- ----------------------- ---------------
+         1    URI.decode_query/2      0
+
+        """
+      end
+
+      test "does not print table when there are no breaks" do
+        assert capture_io(fn -> breaks() end) ==
+               "No breakpoints set\n"
       end
     end
   end

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -69,19 +69,19 @@ defmodule IEx.HelpersTest do
       end
 
       test "errors when setting up a break with no beam" do
-        assert_raise ArgumentError,
+        assert_raise RuntimeError,
                      "could not set breakpoint, could not find .beam file for IEx.HelpersTest",
                      fn -> break!(__MODULE__, :setup, 1) end
       end
 
       test "errors when setting up a break for unknown function" do
-        assert_raise ArgumentError,
+        assert_raise RuntimeError,
                      "could not set breakpoint, unknown function/macro URI.unknown/2",
                      fn -> break!(URI, :unknown, 2) end
       end
 
       test "errors for non elixir modules" do
-        assert_raise ArgumentError,
+        assert_raise RuntimeError,
                      "could not set breakpoint, module :elixir was not written in Elixir",
                      fn -> break!(:elixir, :unknown, 2) end
       end

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -5,6 +5,29 @@ defmodule IEx.HelpersTest do
 
   import IEx.Helpers
 
+  describe "whereami" do
+    test "is disabled by default" do
+      assert capture_iex("whereami()") =~
+             "Pry session is not currently enabled"
+    end
+
+    test "shows current location for custom envs" do
+      whereami = capture_iex("whereami()", [], env: %{__ENV__ | line: 3})
+      assert whereami =~ "test/iex/helpers_test.exs:3"
+      assert whereami =~ "3: defmodule IEx.HelpersTest do"
+    end
+
+    test "prints message when location is not available" do
+      whereami = capture_iex("whereami()", [], env: %{__ENV__ | line: 30000})
+      assert whereami =~ "test/iex/helpers_test.exs:30000"
+      assert whereami =~ "Could not extract source snippet. Location is not available."
+
+      whereami = capture_iex("whereami()", [], env: %{__ENV__ | file: "nofile", line: 1})
+      assert whereami =~ "nofile:1"
+      assert whereami =~ "Could not extract source snippet. Location is not available."
+    end
+  end
+
   describe "clear" do
     test "clear the screen with ansi" do
       Application.put_env(:elixir, :ansi_enabled, true)

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -656,7 +656,6 @@ defmodule IEx.HelpersTest do
   end
 
   describe "pid" do
-
     test "builds a pid from string" do
       assert inspect(pid("0.32767.3276")) == "#PID<0.32767.3276>"
       assert inspect(pid("0.5.6")) == "#PID<0.5.6>"

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -28,6 +28,38 @@ defmodule IEx.HelpersTest do
     end
   end
 
+  if :erlang.system_info(:otp_release) >= '20' do
+    describe "break!" do
+      test "sets up a breakpoint on the given module" do
+        assert break!(URI, :decode_query, 2) == 1
+        assert [_] = IEx.Pry.breaks()
+      end
+
+      test "sets up a breakpoint with macro syntax" do
+        assert break!(URI.decode_query/2) == 1
+        assert [_] = IEx.Pry.breaks()
+      end
+
+      test "errors when setting up a break with no beam" do
+        assert_raise ArgumentError,
+                     "could not set breakpoint, could not find .beam file for IEx.HelpersTest",
+                     fn -> break!(__MODULE__, :setup, 1) end
+      end
+
+      test "errors when setting up a break for unknown function" do
+        assert_raise ArgumentError,
+                     "could not set breakpoint, unknown function/macro URI.unknown/2",
+                     fn -> break!(URI, :unknown, 2) end
+      end
+
+      test "errors for non elixir modules" do
+        assert_raise ArgumentError,
+                     "could not set breakpoint, module :elixir was not written in Elixir",
+                     fn -> break!(:elixir, :unknown, 2) end
+      end
+    end
+  end
+
   describe "open" do
     @iex_helpers Path.expand("../../lib/iex/helpers.ex", __DIR__)
     @elixir_erl Path.expand("../../../elixir/src/elixir.erl", __DIR__)

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -28,6 +28,107 @@ defmodule IEx.HelpersTest do
     end
   end
 
+  describe "open" do
+    @iex_helpers Path.expand("../../lib/iex/helpers.ex", __DIR__)
+    @elixir_erl Path.expand("../../../elixir/src/elixir.erl", __DIR__)
+
+    test "opens Elixir module" do
+      assert capture_iex("open(IEx.Helpers)") |> maybe_trim_quotes() =~
+             ~r/#{@iex_helpers}:1/
+    end
+
+    test "opens function" do
+      assert capture_iex("open(h)") |> maybe_trim_quotes() =~
+             ~r/#{@iex_helpers}:\d+/
+    end
+
+    test "opens function/arity" do
+      assert capture_iex("open(b/1)") |> maybe_trim_quotes() =~
+             ~r/#{@iex_helpers}:\d+/
+      assert capture_iex("open(h/0)") |> maybe_trim_quotes() =~
+             ~r/#{@iex_helpers}:\d+/
+    end
+
+    test "opens module.function" do
+      assert capture_iex("open(IEx.Helpers.b)") |> maybe_trim_quotes() =~
+             ~r/#{@iex_helpers}:\d+/
+      assert capture_iex("open(IEx.Helpers.h)") |> maybe_trim_quotes() =~
+             ~r/#{@iex_helpers}:\d+/
+    end
+
+    test "opens module.function/arity" do
+      assert capture_iex("open(IEx.Helpers.b/1)") |> maybe_trim_quotes() =~
+             ~r/#{@iex_helpers}:\d+/
+      assert capture_iex("open(IEx.Helpers.h/0)") |> maybe_trim_quotes() =~
+             ~r/#{@iex_helpers}:\d+/
+    end
+
+    test "opens Erlang module" do
+      assert capture_iex("open(:elixir)") |> maybe_trim_quotes() =~
+             ~r/#{@elixir_erl}:\d+/
+    end
+
+    test "opens Erlang module.function" do
+      assert capture_iex("open(:elixir.start)") |> maybe_trim_quotes() =~
+             ~r/#{@elixir_erl}:\d+/
+    end
+
+    test "opens Erlang module.function/arity" do
+      assert capture_iex("open(:elixir.start/2)") |> maybe_trim_quotes() =~
+             ~r/#{@elixir_erl}:\d+/
+    end
+
+    test "errors if module is not available" do
+      assert capture_iex("open(:unknown)") ==
+             "Could not open: :unknown. Module is not available."
+    end
+
+    test "errors if module.function is not available" do
+      assert capture_iex("open(:unknown.unknown)") ==
+             "Could not open: :unknown.unknown. Module is not available."
+      assert capture_iex("open(:elixir.unknown)") ==
+             "Could not open: :elixir.unknown. Function/macro is not available."
+    end
+
+    test "errors if module.function/arity is not available" do
+      assert capture_iex("open(:unknown.start/10)") ==
+             "Could not open: :unknown.start/10. Module is not available."
+      assert capture_iex("open(:elixir.start/10)") ==
+             "Could not open: :elixir.start/10. Function/macro is not available."
+    end
+
+    test "opens the current pry location" do
+      assert capture_iex("open()", [], env: %{__ENV__ | line: 3}) |> maybe_trim_quotes() ==
+             "#{__ENV__.file}:3"
+    end
+
+    test "errors if prying is not available" do
+      assert capture_iex("open()") == "Pry session is not currently enabled"
+    end
+
+    test "opens given {file, line}" do
+      assert capture_iex("open({#{inspect __ENV__.file}, 3})") |> maybe_trim_quotes() ==
+             "#{__ENV__.file}:3"
+    end
+
+    test "errors when given {file, line} is not available" do
+      assert capture_iex("open({~s[foo], 3})") ==
+             "Could not open: \"foo\". File is not available."
+    end
+
+    test "opens given path" do
+      assert capture_iex("open(#{inspect __ENV__.file})") |> maybe_trim_quotes() ==
+             __ENV__.file
+    end
+
+    defp maybe_trim_quotes(string) do
+      case :os.type do
+        {:win32, _} -> String.trim(string, "\"")
+        _ -> string
+      end
+    end
+  end
+
   describe "clear" do
     test "clear the screen with ansi" do
       Application.put_env(:elixir, :ansi_enabled, true)

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -102,6 +102,12 @@ defmodule IEx.InteractionTest do
            ~r/erl_eval/s
   end
 
+  test "exception while invoking conflicting helpers" do
+    import File, only: [open: 1], warn: false
+    assert capture_iex("open('README.md')", [], [env: __ENV__]) =~
+           ~r"function open/1 imported from both File and IEx.Helpers"
+  end
+
   test "receive exit" do
     assert capture_iex("spawn_link(fn -> exit(:bye) end); Process.sleep(1000)") =~
            ~r"\*\* \(EXIT from #PID<\d+\.\d+\.\d+>\) :bye"

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -110,9 +110,9 @@ defmodule IEx.InteractionTest do
 
   test "receive exit" do
     assert capture_iex("spawn_link(fn -> exit(:bye) end); Process.sleep(1000)") =~
-           ~r"\*\* \(EXIT from #PID<\d+\.\d+\.\d+>\) :bye"
+           ~r"\*\* \(EXIT from #PID<\d+\.\d+\.\d+>\) evaluator process exited with reason: :bye"
     assert capture_iex("spawn_link(fn -> exit({:bye, [:world]}) end); Process.sleep(1000)") =~
-           ~r"\*\* \(EXIT from #PID<\d+\.\d+\.\d+>\) {:bye, \[:world\]}"
+           ~r"\*\* \(EXIT from #PID<\d+\.\d+\.\d+>\) evaluator process exited with reason: {:bye, \[:world\]}"
   end
 
   test "receive exit from exception" do
@@ -121,7 +121,7 @@ defmodule IEx.InteractionTest do
     content = capture_iex("spawn_link(fn -> exit({%ArgumentError{},
                            [{:not_a_real_module, :function, 0, []}]}) end);
                            Process.sleep(1000)")
-    assert content =~ ~r"\*\* \(EXIT from #PID<\d+\.\d+\.\d+>\) an exception was raised:\n"
+    assert content =~ ~r"\*\* \(EXIT from #PID<\d+\.\d+\.\d+>\) evaluator process exited with reason: an exception was raised:\n"
     assert content =~ ~r"\s{4}\*\* \(ArgumentError\) argument error\n"
     assert content =~ ~r"\s{8}:not_a_real_module\.function/0"
   end

--- a/lib/iex/test/iex/pry_test.exs
+++ b/lib/iex/test/iex/pry_test.exs
@@ -1,0 +1,201 @@
+Code.require_file "../test_helper.exs", __DIR__
+
+defmodule IEx.PryTest do
+  use ExUnit.Case
+
+  setup do
+    on_exit fn -> IEx.Pry.remove_breaks() end
+  end
+
+  describe "whereami" do
+    test "shows lines with radius" do
+      Application.put_env(:elixir, :ansi_enabled, true)
+
+      {:ok, contents} = IEx.Pry.whereami(__ENV__.file, 3, 2)
+      assert IO.iodata_to_binary(contents) == """
+          1: Code.require_file "../test_helper.exs", __DIR__
+          2:\s
+      \e[1m    3: defmodule IEx.PryTest do
+      \e[22m    4:   use ExUnit.Case
+          5:\s
+      """
+
+      {:ok, contents} = IEx.Pry.whereami(__ENV__.file, 1, 4)
+      assert IO.iodata_to_binary(contents) == """
+      \e[1m    1: Code.require_file "../test_helper.exs", __DIR__
+      \e[22m    2:\s
+          3: defmodule IEx.PryTest do
+          4:   use ExUnit.Case
+          5:\s
+      """
+    after
+      Application.delete_env(:elixir, :ansi_enabled)
+    end
+
+    test "returns error for unknown files" do
+      assert IEx.Pry.whereami("unknown", 3, 2) == :error
+    end
+
+    test "returns error for out of range lines" do
+      assert IEx.Pry.whereami(__ENV__.file, 1000, 2) == :error
+    end
+  end
+
+  if :erlang.system_info(:otp_release) >= '20' do
+    describe "break" do
+      test "sets up a breakpoint on the given module" do
+        assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
+        assert instrumented?(URI)
+        assert [_] = IEx.Pry.breaks()
+      end
+
+      test "sets up multiple breakpoints in the same module" do
+        assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
+        assert instrumented?(URI)
+        assert IEx.Pry.break(URI, :parse, 1) == {:ok, 2}
+        assert instrumented?(URI)
+        assert [_, _] = IEx.Pry.breaks()
+      end
+
+      test "reinstruments if module has been reloaded" do
+        assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
+        assert instrumented?(URI)
+        deinstrument!(URI)
+        refute instrumented?(URI)
+        assert IEx.Pry.break(URI, :parse, 1) == {:ok, 2}
+        assert instrumented?(URI)
+        assert [_, _] = IEx.Pry.breaks()
+      end
+
+      test "returns id when breakpoint is already set" do
+        assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
+        assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
+        assert [_] = IEx.Pry.breaks()
+      end
+
+      test "builds new id when breakpoint is already set on deinstrument" do
+        assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
+        deinstrument!(URI)
+        assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 2}
+        assert [_] = IEx.Pry.breaks()
+      end
+
+      test "errors when setting up a break with no beam" do
+        assert IEx.Pry.break(__MODULE__, :setup, 2) == {:error, :no_beam_file}
+      end
+
+      test "errors when setting up a break for unknown function" do
+        assert IEx.Pry.break(URI, :unknown, 2) == {:error, :unknown_function_arity}
+      end
+
+      test "errors for non elixir modules" do
+        assert IEx.Pry.break(:elixir, :unknown, 2) == {:error, :non_elixir_module}
+      end
+    end
+
+    describe "breaks" do
+      test "returns all breaks" do
+        assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
+        assert IEx.Pry.breaks() ==
+               [{1, URI, {:decode_query, 2}, 1}]
+
+        assert IEx.Pry.break(URI, :decode_query, 2, 10) == {:ok, 1}
+        assert IEx.Pry.breaks() ==
+               [{1, URI, {:decode_query, 2}, 10}]
+
+        assert IEx.Pry.break(URI, :parse, 1, 1) == {:ok, 2}
+        assert IEx.Pry.breaks() ==
+               [{1, URI, {:decode_query, 2}, 10}, {2, URI, {:parse, 1}, 1}]
+      end
+
+      test "sets negative break to 0" do
+        assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
+        :ets.insert(IEx.Pry, {1, URI, {:decode_query, 2}, -1})
+        assert IEx.Pry.breaks() == [{1, URI, {:decode_query, 2}, 0}]
+      end
+
+      test "do not return break points for deinstrumented modules" do
+        assert IEx.Pry.break(URI, :parse, 1) == {:ok, 1}
+        assert IEx.Pry.breaks() == [{1, URI, {:parse, 1}, 1}]
+        deinstrument!(URI)
+        assert IEx.Pry.breaks() == []
+      end
+    end
+
+    describe "reset_break" do
+      test "resets break for given id" do
+        assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
+        assert IEx.Pry.reset_break(1) == :ok
+        assert IEx.Pry.breaks() == [{1, URI, {:decode_query, 2}, 0}]
+      end
+
+      test "resets break for given mfa" do
+        assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
+        assert IEx.Pry.reset_break(URI, :decode_query, 2) == :ok
+        assert IEx.Pry.breaks() == [{1, URI, {:decode_query, 2}, 0}]
+      end
+
+      test "returns not_found if module is deinstrumented" do
+        assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
+        deinstrument!(URI)
+        assert IEx.Pry.reset_break(URI, :decode_query, 2) == :not_found
+        assert IEx.Pry.breaks() == []
+      end
+
+      test "returns not_found if mfa has no break" do
+        assert IEx.Pry.reset_break(URI, :decode_query, 2) == :not_found
+      end
+
+      test "returns not_found if id is deinstrumented" do
+        assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
+        deinstrument!(URI)
+        assert IEx.Pry.reset_break(1) == :not_found
+        assert IEx.Pry.breaks() == []
+      end
+
+      test "returns not_found if id has no break" do
+        assert IEx.Pry.reset_break(1) == :not_found
+      end
+    end
+
+    describe "remove_breaks" do
+      test "removes all breaks" do
+        assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
+        assert IEx.Pry.remove_breaks() == :ok
+        assert IEx.Pry.breaks() == []
+      end
+
+      test "removes all breaks even if module is deinstrumented" do
+        assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
+        deinstrument!(URI)
+        assert IEx.Pry.remove_breaks() == :ok
+        assert IEx.Pry.breaks() == []
+      end
+
+      test "remove breaks in a given module" do
+        assert IEx.Pry.remove_breaks(Date.Range) == :ok
+        assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
+        assert IEx.Pry.break(Date.Range, :__struct__, 1) == {:ok, 2}
+        assert IEx.Pry.remove_breaks(Date.Range) == :ok
+        assert IEx.Pry.breaks() == [{1, URI, {:decode_query, 2}, 1}]
+      end
+
+      test "remove breaks in a given module even if deinstrumented" do
+        assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
+        deinstrument!(URI)
+        assert IEx.Pry.breaks() == []
+      end
+    end
+  end
+
+  defp instrumented?(module) do
+    module.module_info(:attributes)[:iex_pry] == [true]
+  end
+
+  defp deinstrument!(module) do
+    beam = :code.which(module)
+    :code.purge(module)
+    {:module, _} = :code.load_binary(module, beam, File.read!(beam))
+    :ok
+  end
+end

--- a/lib/iex/test/test_helper.exs
+++ b/lib/iex/test/test_helper.exs
@@ -2,6 +2,8 @@ assert_timeout = String.to_integer(
   System.get_env("ELIXIR_ASSERT_TIMEOUT") || "500"
 )
 
+System.put_env("ELIXIR_EDITOR", "echo")
+
 :ok = Application.start(:iex)
 IEx.configure([colors: [enabled: false]])
 ExUnit.start [trace: "--trace" in System.argv, assert_receive_timeout: assert_timeout]


### PR DESCRIPTION
The following functions will be added:

  * [x] `IEx.break!(Mod.fun/arity, break_count \\ 1)` - sets a breakpoint on the given function and arity
  * [x] `IEx.break!(Mod, fun, arity, break_count \\ 1)` - functional API for setting a breaking point

The following helpers will be added:

  * [x] `break!/2` - see above
  * [x] `break!/4` - see above
  * [x] `breaks/0` - prints all breakpoints and their counts
  * [x] `whereami/0` - shows the current location and debugging info
  * [x] `continue/0` - continues until the next breakpoint in the same shell
  * [x] `respawn/0` - discards the current shell (breakpoints will ask for permission once more)
  * [x] `open/0` - opens editor on the current breakpoint
  * [x] `open/1` - opens the given module or mfa or {file,line} or binary
  * [x] `reset_break/1` - resets all breaks in the given id or mfa
  * [x] `reset_break/3` - resets all breaks in the given mfa tuple
  * [x] `remove_breaks/0` - removes all breakpoints in all modules
  * [x] `remove_breaks/1` - removes all breakpoints in a given module

Then we need to add the pry specific documentation.