### PR TITLE
Fix return type of Mix.Task.alias?/1

### DIFF
--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -193,7 +193,7 @@ defmodule Mix.Task do
   end
 
   def alias?(task) when is_atom(task) do
-    !!Mix.Project.config[:aliases][task]
+    Keyword.has_key?(Mix.Project.config()[:aliases], task)
   end
 
   @doc """

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -193,7 +193,10 @@ defmodule Mix.Task do
   end
 
   def alias?(task) when is_atom(task) do
-    Mix.Project.config[:aliases][task]
+    case Mix.Project.config[:aliases][task] do
+      nil -> false
+      _ -> true
+    end
   end
 
   @doc """

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -193,10 +193,7 @@ defmodule Mix.Task do
   end
 
   def alias?(task) when is_atom(task) do
-    case Mix.Project.config[:aliases][task] do
-      nil -> false
-      _ -> true
-    end
+    !!Mix.Project.config[:aliases][task]
   end
 
   @doc """

--- a/lib/mix/test/mix/task_test.exs
+++ b/lib/mix/test/mix/task_test.exs
@@ -163,13 +163,13 @@ defmodule Mix.TaskTest do
   end
 
   test "alias?/1" do
-    refute Mix.Task.alias?(:sample)
-    refute Mix.Task.alias?("sample")
+    assert Mix.Task.alias?(:sample) == false
+    assert Mix.Task.alias?("sample") == false
 
     Mix.Project.push MixTest.Case.Sample
-    assert Mix.Task.alias?(:sample)
-    assert Mix.Task.alias?("sample")
-    refute Mix.Task.alias?("another")
+    assert Mix.Task.alias?(:sample) == true
+    assert Mix.Task.alias?("sample") == true
+    assert Mix.Task.alias?("another") == false
   after
     Mix.Project.pop
   end


### PR DESCRIPTION
This function is currently returning either `nil` or the alias itself from the
mix file, so it doesn't match with the `boolean` return type indicated by the
documentation.

Thanks!