### PR TITLE
Update docs & typespecs for calendar modules

### DIFF
--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -434,6 +434,14 @@ defmodule Date do
   or `{:error, :incompatible_calendars}` if they are not.
 
   See also `Calendar.compatible_calendars?/2`.
+
+  ## Examples
+
+  Imagine someone implements `Calendar.Julian`:
+
+      iex> Date.convert(~D[2000-01-01], Calendar.Julian)
+      {:ok, %Date{calendar: Calendar.Julian, year: 1999, month: 12, day: 19}}
+
   """
   @spec convert(Calendar.date, Calendar.calendar) :: {:ok, t} | {:error, :incompatible_calendars}
   def convert(%Date{calendar: calendar} = date, calendar), do: {:ok, date}
@@ -452,6 +460,14 @@ defmodule Date do
   @doc """
   Similar to `Date.convert/2`, but raises an `ArgumentError`
   if the conversion between the two calendars is not possible.
+
+  ## Examples
+
+  Imagine someone implements `Calendar.Julian`:
+
+      iex> Date.convert!(~D[2000-01-01], Calendar.Julian)
+      %Date{calendar: Calendar.Julian, year: 1999, month: 12, day: 19}
+
   """
   @spec convert!(Calendar.date, Calendar.calendar) :: t | no_return
   def convert!(date, calendar) do

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -67,8 +67,11 @@ defmodule Date do
 
   ## Examples
 
-      iex> Date.range(~D[2000-01-01], ~D[2001-01-01])
-      #DateRange<~D[2000-01-01], ~D[2001-01-01]>
+      iex> Date.range(~D[1999-01-01], ~D[2000-01-01])
+      #DateRange<~D[1999-01-01], ~D[2000-01-01]>
+
+      iex> Date.range(~N[2000-01-01 09:00:00], ~D[1999-01-01])
+      #DateRange<~N[2000-01-01 09:00:00], ~D[1999-01-01]>
 
   A range of dates implements the `Enumerable` protocol, which means
   functions in the `Enum` module can be used to work with
@@ -83,7 +86,7 @@ defmodule Date do
       -366
   """
 
-  @spec range(Date.t, Date.t) :: Date.Range.t
+  @spec range(Calendar.date, Calendar.date) :: Date.Range.t
   def range(%{calendar: calendar} = first, %{calendar: calendar} = last) do
     {first_days, _} = to_rata_die(first)
     {last_days, _} = to_rata_die(last)
@@ -96,7 +99,8 @@ defmodule Date do
     }
   end
 
-  def range(%Date{}, %Date{}) do
+  def range(%{calendar: _, year: _, month: _, day: _},
+            %{calendar: _, year: _, month: _, day: _}) do
     raise ArgumentError, "both dates must have matching calendars"
   end
 
@@ -125,7 +129,7 @@ defmodule Date do
   end
 
   @doc """
-  Returns true if the year in `date` is a leap year.
+  Returns true if the year in the given `date` is a leap year.
 
   ## Examples
 
@@ -149,7 +153,7 @@ defmodule Date do
   end
 
   @doc """
-  Returns the number of days in the given date month.
+  Returns the number of days in the given `date` month.
 
   ## Examples
 
@@ -269,7 +273,7 @@ defmodule Date do
       iex> Date.from_iso8601!("2015:01:23")
       ** (ArgumentError) cannot parse "2015:01:23" as date, reason: :invalid_format
   """
-  @spec from_iso8601!(String.t) :: t
+  @spec from_iso8601!(String.t) :: t | no_return
   def from_iso8601!(string, calendar \\ Calendar.ISO) do
     case from_iso8601(string, calendar) do
       {:ok, value} ->
@@ -309,7 +313,7 @@ defmodule Date do
   end
 
   @doc """
-  Converts a `Date` struct to an Erlang date tuple.
+  Converts the given `date` to an Erlang date tuple.
 
   Only supports converting dates which are in the ISO calendar,
   or other calendars in which the days also start at midnight.
@@ -364,7 +368,7 @@ defmodule Date do
       ** (ArgumentError) cannot convert {2000, 13, 1} to date, reason: :invalid_date
 
   """
-  @spec from_erl!(:calendar.date) :: t
+  @spec from_erl!(:calendar.date) :: t | no_return
   def from_erl!(tuple) do
     case from_erl(tuple) do
       {:ok, value} ->
@@ -375,7 +379,7 @@ defmodule Date do
   end
 
   @doc """
-  Compares two `Date` structs.
+  Compares two date structs.
 
   Returns `:gt` if first date is later than the second
   and `:lt` for vice versa. If the two dates are equal
@@ -397,7 +401,7 @@ defmodule Date do
       :eq
 
   """
-  @spec compare(Calendar.date, Calendar.date) :: :lt | :eq | :gt
+  @spec compare(Calendar.date, Calendar.date) :: :lt | :eq | :gt | no_return
   def compare(%{calendar: calendar, year: year1, month: month1, day: day1},
               %{calendar: calendar, year: year2, month: month2, day: day2}) do
     case {{year1, month1, day1}, {year2, month2, day2}} do
@@ -424,14 +428,14 @@ defmodule Date do
   end
 
   @doc """
-  Converts a date from one calendar to another.
+  Converts the given `date` from it's calendar to the given `calendar`.
 
   Returns `{:ok, date}` if the calendars are compatible,
   or `{:error, :incompatible_calendars}` if they are not.
 
   See also `Calendar.compatible_calendars?/2`.
   """
-  @spec convert(Calendar.date(), Calendar.calendar) :: {:ok, Date.t} | {:error, :incompatible_calendars}
+  @spec convert(Calendar.date, Calendar.calendar) :: {:ok, t} | {:error, :incompatible_calendars}
   def convert(%Date{calendar: calendar} = date, calendar), do: {:ok, date}
   def convert(%{calendar: calendar} = date, target_calendar) do
     if Calendar.compatible_calendars?(calendar, target_calendar) do
@@ -449,7 +453,7 @@ defmodule Date do
   Similar to `Date.convert/2`, but raises an `ArgumentError`
   if the conversion between the two calendars is not possible.
   """
-  @spec convert!(Date.t, Calendar.calendar) :: Date.t
+  @spec convert!(Calendar.date, Calendar.calendar) :: t | no_return
   def convert!(date, calendar) do
     case convert(date, calendar) do
       {:ok, value} ->
@@ -460,7 +464,7 @@ defmodule Date do
   end
 
   @doc """
-  Adds the number of days to the given date.
+  Adds the number of days to the given `date`.
 
   The days are counted as gregorian days. The date is returned in the same
   calendar as it was given in.
@@ -472,9 +476,12 @@ defmodule Date do
       iex> Date.add(~D[2000-01-01], 2)
       ~D[2000-01-03]
 
+      iex> Date.add(~N[2000-01-01 09:00:00], 2)
+      ~D[2000-01-03]
+
   """
-  @spec add(Date.t, integer()) :: Date.t
-  def add(%Date{calendar: calendar} = date, days) do
+  @spec add(Calendar.date, integer()) :: t
+  def add(%{calendar: calendar} = date, days) do
     {rata_days, fraction} = to_rata_die(date)
     from_rata_die({rata_days + days, fraction}, calendar)
   end
@@ -493,16 +500,19 @@ defmodule Date do
       iex> Date.diff(~D[2000-01-01], ~D[2000-01-03])
       -2
 
+      iex> Date.diff(~D[2000-01-01], ~N[2000-01-03 09:00:00])
+      -2
+
   """
-  @spec diff(Date.t, Date.t) :: integer
-  def diff(%Date{calendar: Calendar.ISO, year: year1, month: month1, day: day1},
-           %Date{calendar: Calendar.ISO, year: year2, month: month2, day: day2}) do
+  @spec diff(Calendar.date, Calendar.date) :: integer | no_return
+  def diff(%{calendar: Calendar.ISO, year: year1, month: month1, day: day1},
+           %{calendar: Calendar.ISO, year: year2, month: month2, day: day2}) do
     Calendar.ISO.date_to_rata_die_days(year1, month1, day1) -
       Calendar.ISO.date_to_rata_die_days(year2, month2, day2)
   end
 
-  def diff(%Date{} = date1, %Date{} = date2) do
-    if Calendar.compatible_calendars?(date1.calendar, date2.calendar) do
+  def diff(%{calendar: calendar1} = date1, %{calendar: calendar2} = date2) do
+    if Calendar.compatible_calendars?(calendar1, calendar2) do
       {days1, _} = to_rata_die(date1)
       {days2, _} = to_rata_die(date2)
       days1 - days2
@@ -528,7 +538,7 @@ defmodule Date do
   end
 
   @doc """
-  Calculates the day of the week of a given `Date` struct.
+  Calculates the day of the week of a given `date`.
 
   Returns the day of the week as an integer. For the ISO 8601
   calendar (the default), it is an integer from 1 to 7, where

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -273,7 +273,7 @@ defmodule Date do
       iex> Date.from_iso8601!("2015:01:23")
       ** (ArgumentError) cannot parse "2015:01:23" as date, reason: :invalid_format
   """
-  @spec from_iso8601!(String.t) :: t | no_return
+  @spec from_iso8601!(String.t) :: t
   def from_iso8601!(string, calendar \\ Calendar.ISO) do
     case from_iso8601(string, calendar) do
       {:ok, value} ->
@@ -368,7 +368,7 @@ defmodule Date do
       ** (ArgumentError) cannot convert {2000, 13, 1} to date, reason: :invalid_date
 
   """
-  @spec from_erl!(:calendar.date) :: t | no_return
+  @spec from_erl!(:calendar.date) :: t
   def from_erl!(tuple) do
     case from_erl(tuple) do
       {:ok, value} ->
@@ -401,7 +401,7 @@ defmodule Date do
       :eq
 
   """
-  @spec compare(Calendar.date, Calendar.date) :: :lt | :eq | :gt | no_return
+  @spec compare(Calendar.date, Calendar.date) :: :lt | :eq | :gt
   def compare(%{calendar: calendar, year: year1, month: month1, day: day1},
               %{calendar: calendar, year: year2, month: month2, day: day2}) do
     case {{year1, month1, day1}, {year2, month2, day2}} do
@@ -469,7 +469,7 @@ defmodule Date do
       %Date{calendar: Calendar.Julian, year: 1999, month: 12, day: 19}
 
   """
-  @spec convert!(Calendar.date, Calendar.calendar) :: t | no_return
+  @spec convert!(Calendar.date, Calendar.calendar) :: t
   def convert!(date, calendar) do
     case convert(date, calendar) do
       {:ok, value} ->
@@ -520,7 +520,7 @@ defmodule Date do
       -2
 
   """
-  @spec diff(Calendar.date, Calendar.date) :: integer | no_return
+  @spec diff(Calendar.date, Calendar.date) :: integer
   def diff(%{calendar: Calendar.ISO, year: year1, month: month1, day: day1},
            %{calendar: Calendar.ISO, year: year2, month: month2, day: day2}) do
     Calendar.ISO.date_to_rata_die_days(year1, month1, day1) -

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -444,7 +444,9 @@ defmodule Date do
 
   """
   @spec convert(Calendar.date, Calendar.calendar) :: {:ok, t} | {:error, :incompatible_calendars}
-  def convert(%Date{calendar: calendar} = date, calendar), do: {:ok, date}
+  def convert(%{calendar: calendar, year: year, month: month, day: day}, calendar) do
+    {:ok, %Date{calendar: calendar, year: year, month: month, day: day}}
+  end
   def convert(%{calendar: calendar} = date, target_calendar) do
     if Calendar.compatible_calendars?(calendar, target_calendar) do
       result_date =

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -593,8 +593,12 @@ defmodule DateTime do
 
   """
   @spec convert(Calendar.datetime, Calendar.calendar) :: {:ok, t} | {:error, :incompatible_calendars}
-  def convert(%DateTime{calendar: calendar} = datetime, calendar) do
-    {:ok, datetime}
+  def convert(%{calendar: calendar, year: year, month: month, day: day,
+                hour: hour, minute: minute, second: second, microsecond: microsecond,
+                time_zone: time_zone, zone_abbr: zone_abbr, utc_offset: utc_offset, std_offset: std_offset}, calendar) do
+    {:ok, %DateTime{calendar: calendar, year: year, month: month, day: day,
+                    hour: hour, minute: minute, second: second, microsecond: microsecond,
+                    time_zone: time_zone, zone_abbr: zone_abbr, utc_offset: utc_offset, std_offset: std_offset}}
   end
 
   def convert(%{calendar: dt_calendar, microsecond: {_, precision}} = datetime, calendar) do

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -127,7 +127,7 @@ defmodule DateTime do
       #DateTime<2015-05-25 13:26:08.868569Z>
 
   """
-  @spec from_unix!(integer, :native | System.time_unit, Calendar.calendar) :: t | no_return
+  @spec from_unix!(integer, :native | System.time_unit, Calendar.calendar) :: t
   def from_unix!(integer, unit \\ :second, calendar \\ Calendar.ISO) when is_atom(unit) do
     case from_unix(integer, unit, calendar) do
       {:ok, datetime} ->
@@ -173,7 +173,7 @@ defmodule DateTime do
       #DateTime<2016-05-24 13:26:08.003Z>
 
   """
-  @spec from_naive!(NaiveDateTime.t, Calendar.time_zone) :: t | no_return
+  @spec from_naive!(NaiveDateTime.t, Calendar.time_zone) :: t
   def from_naive!(naive_datetime, time_zone) do
     case from_naive(naive_datetime, time_zone) do
       {:ok, datetime} ->

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -27,6 +27,11 @@ defmodule NaiveDateTime do
   `NaiveDateTime` is not validated against a time zone, such errors
   would go unnoticed.
 
+  The functions on this module work with the `NaiveDateTime` struct as well
+  as any struct that contains the same fields as the `NaiveDateTime` struct,
+  such as `DateTime`. Such functions expect
+  `t:Calendar.naive_datetime/0` in their typespecs (instead of `t:t/0`).
+
   Developers should avoid creating the NaiveDateTime structs directly
   and instead rely on the functions provided by this module as well
   as the ones in 3rd party calendar libraries.
@@ -149,7 +154,7 @@ defmodule NaiveDateTime do
   def new(date, time)
 
   def new(%Date{calendar: calendar, year: year, month: month, day: day},
-          %Time{hour: hour, minute: minute, second: second, microsecond: microsecond, calendar: calendar}) do
+          %Time{calendar: calendar, hour: hour, minute: minute, second: second, microsecond: microsecond}) do
     {:ok, %NaiveDateTime{calendar: calendar, year: year, month: month, day: day,
                          hour: hour, minute: minute, second: second, microsecond: microsecond}}
   end
@@ -509,6 +514,7 @@ defmodule NaiveDateTime do
       {:error, :invalid_date}
       iex> NaiveDateTime.from_erl({{2000, 13, 1},{13, 30, 15}})
       {:error, :invalid_date}
+
   """
   @spec from_erl(:calendar.datetime, Calendar.microsecond) :: {:ok, t} | {:error, atom}
   def from_erl(tuple, microsecond \\ {0, 0}, calendar \\ Calendar.ISO)
@@ -532,6 +538,7 @@ defmodule NaiveDateTime do
       ~N[2000-01-01 13:30:15.005]
       iex> NaiveDateTime.from_erl!({{2000, 13, 1}, {13, 30, 15}})
       ** (ArgumentError) cannot convert {{2000, 13, 1}, {13, 30, 15}} to naive datetime, reason: :invalid_date
+
   """
   @spec from_erl!(:calendar.datetime, Calendar.microsecond) :: t | no_return
   def from_erl!(tuple, microsecond \\ {0, 0}) do
@@ -590,13 +597,13 @@ defmodule NaiveDateTime do
   end
 
   @doc """
-  Converts a `NaiveDateTime` struct from one calendar to another.
+  Converts the given `naive_datetime` from one calendar to another.
 
   If it is not possible to convert unambiguously between the calendars
   (see `Calendar.compatible_calendars?/2`), an `{:error, :incompatible_calendars}` tuple
   is returned.
   """
-  @spec convert(Calendar.naive_datetime, Calendar.calendar) :: {:ok, NaiveDateTime.t} | {:error, :incompatible_calendars}
+  @spec convert(Calendar.naive_datetime, Calendar.calendar) :: {:ok, t} | {:error, :incompatible_calendars}
   def convert(%NaiveDateTime{calendar: calendar} = naive_datetime, calendar) do
     {:ok, naive_datetime}
   end
@@ -614,12 +621,12 @@ defmodule NaiveDateTime do
   end
 
   @doc """
-  Converts a NaiveDateTime from one calendar to another.
+  Converts the given `naive_datetime` from one calendar to another.
 
   If it is not possible to convert unambiguously between the calendars
   (see `Calendar.compatible_calendars?/2`), an ArgumentError is raised.
   """
-  @spec convert!(NaiveDateTime.t, Calendar.calendar) :: NaiveDateTime.t
+  @spec convert!(Calendar.naive_datetime, Calendar.calendar) :: t
   def convert!(naive_datetime, calendar) do
     case convert(naive_datetime, calendar) do
       {:ok, value} ->
@@ -639,13 +646,13 @@ defmodule NaiveDateTime do
   defp from_rata_die(rata_die, calendar, precision) do
     {year, month, day, hour, minute, second, {microsecond, _}} =
       calendar.naive_datetime_from_rata_die(rata_die)
-    %NaiveDateTime{year: year, month: month, day: day, hour: hour, minute: minute, second: second,
-                   microsecond: {microsecond, precision}, calendar: calendar}
+    %NaiveDateTime{calendar: calendar, year: year, month: month, day: day,
+                   hour: hour, minute: minute, second: second, microsecond: {microsecond, precision}}
   end
 
   defimpl String.Chars do
     def to_string(%{calendar: calendar, year: year, month: month, day: day,
-                     hour: hour, minute: minute, second: second, microsecond: microsecond}) do
+                    hour: hour, minute: minute, second: second, microsecond: microsecond}) do
       calendar.naive_datetime_to_string(year, month, day, hour, minute, second, microsecond)
     end
   end

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -602,6 +602,15 @@ defmodule NaiveDateTime do
   If it is not possible to convert unambiguously between the calendars
   (see `Calendar.compatible_calendars?/2`), an `{:error, :incompatible_calendars}` tuple
   is returned.
+
+  ## Examples
+
+  Imagine someone implements `Calendar.Julian`:
+
+      iex> NaiveDateTime.convert(~N[2000-01-01 13:30:15], Calendar.Julian)
+      {:ok, %NaiveDateTime{calendar: Calendar.Julian, year: 1999, month: 12, day: 19,
+                           hour: 13, minute: 30, month: 12, second: 15, microsecond: {0, 0}}}
+
   """
   @spec convert(Calendar.naive_datetime, Calendar.calendar) :: {:ok, t} | {:error, :incompatible_calendars}
   def convert(%NaiveDateTime{calendar: calendar} = naive_datetime, calendar) do
@@ -625,6 +634,15 @@ defmodule NaiveDateTime do
 
   If it is not possible to convert unambiguously between the calendars
   (see `Calendar.compatible_calendars?/2`), an ArgumentError is raised.
+
+  ## Examples
+
+  Imagine someone implements `Calendar.Julian`:
+
+      iex> NaiveDateTime.convert!(~N[2000-01-01 13:30:15], Calendar.Julian)
+      %NaiveDateTime{calendar: Calendar.Julian, year: 1999, month: 12, day: 19,
+                     hour: 13, minute: 30, month: 12, second: 15, microsecond: {0, 0}}
+
   """
   @spec convert!(Calendar.naive_datetime, Calendar.calendar) :: t
   def convert!(naive_datetime, calendar) do

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -613,8 +613,10 @@ defmodule NaiveDateTime do
 
   """
   @spec convert(Calendar.naive_datetime, Calendar.calendar) :: {:ok, t} | {:error, :incompatible_calendars}
-  def convert(%NaiveDateTime{calendar: calendar} = naive_datetime, calendar) do
-    {:ok, naive_datetime}
+  def convert(%{calendar: calendar, year: year, month: month, day: day,
+                hour: hour, minute: minute, second: second, microsecond: microsecond}, calendar) do
+    {:ok, %NaiveDateTime{calendar: calendar, year: year, month: month, day: day,
+                         hour: hour, minute: minute, second: second, microsecond: microsecond}}
   end
 
   def convert(%{calendar: ndt_calendar, microsecond: {_, precision}} = naive_datetime, calendar) do

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -95,7 +95,7 @@ defmodule Time do
 
   """
   @spec new(Calendar.hour, Calendar.minute, Calendar.second, Calendar.microsecond, Calendar.calendar) ::
-        {:ok, Time.t} | {:error, atom}
+        {:ok, t} | {:error, atom}
   def new(hour, minute, second, microsecond \\ {0, 0}, calendar \\ Calendar.ISO)
 
   def new(hour, minute, second, microsecond, calendar) when is_integer(microsecond) do
@@ -114,7 +114,7 @@ defmodule Time do
   end
 
   @doc """
-  Converts the given time to a string.
+  Converts the given `time` to a string.
 
   ### Examples
 
@@ -218,7 +218,7 @@ defmodule Time do
       iex> Time.from_iso8601!("2015:01:23 23-50-07")
       ** (ArgumentError) cannot parse "2015:01:23 23-50-07" as time, reason: :invalid_format
   """
-  @spec from_iso8601!(String.t) :: t
+  @spec from_iso8601!(String.t) :: t | no_return
   def from_iso8601!(string) do
     case from_iso8601(string) do
       {:ok, value} ->
@@ -258,7 +258,7 @@ defmodule Time do
   end
 
   @doc """
-  Converts a `Time` struct to an Erlang time tuple.
+  Converts given `time` to an Erlang time tuple.
 
   WARNING: Loss of precision may occur, as Erlang time tuples
   only contain hours/minutes/seconds.
@@ -321,7 +321,7 @@ defmodule Time do
   end
 
   @doc """
-  Compares two `Time` structs.
+  Compares two time structs.
 
   Returns `:gt` if first time is later than the second
   and `:lt` for vice versa. If the two times are equal
@@ -365,12 +365,12 @@ defmodule Time do
   end
 
   @doc """
-  Converts the `Time` struct to a different calendar.
+  Converts given `time` to a different calendar.
 
   Returns `{:ok, time}` if the conversion was successful,
   or `{:error, reason}` if it was not, for some reason.
   """
-  @spec convert(Calendar.time, Calendar.calendar) :: {:ok, Time.t} | {:error, atom}
+  @spec convert(Calendar.time, Calendar.calendar) :: {:ok, t} | {:error, atom}
   def convert(%Time{calendar: calendar} = time, calendar) do
     {:ok, time}
   end
@@ -388,7 +388,7 @@ defmodule Time do
   Similar to `Time.convert/2`, but raises an `ArgumentError`
   if the conversion between the two calendars is not possible.
   """
-  @spec convert!(Calendar.time, Calendar.calendar) :: Time.t
+  @spec convert!(Calendar.time, Calendar.calendar) :: t | no_return
   def convert!(time, calendar) do
     case convert(time, calendar) do
       {:ok, value} ->
@@ -418,7 +418,7 @@ defmodule Time do
       -2_000_000
 
   """
-  @spec diff(Time.t, Time.t, System.time_unit) :: integer
+  @spec diff(t, t, System.time_unit) :: integer
   def diff(%Time{} = time1, %Time{} = time2, unit \\ :second) do
     fraction1 = to_day_fraction(time1)
     fraction2 = to_day_fraction(time2)

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -379,8 +379,8 @@ defmodule Time do
 
   """
   @spec convert(Calendar.time, Calendar.calendar) :: {:ok, t} | {:error, atom}
-  def convert(%Time{calendar: calendar} = time, calendar) do
-    {:ok, time}
+  def convert(%{calendar: calendar, hour: hour, minute: minute, second: second, microsecond: microsecond}, calendar) do
+    {:ok, %Time{calendar: calendar, hour: hour, minute: minute, second: second, microsecond: microsecond}}
   end
 
   def convert(%{microsecond: {_, precision}} = time, calendar) do

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -218,7 +218,7 @@ defmodule Time do
       iex> Time.from_iso8601!("2015:01:23 23-50-07")
       ** (ArgumentError) cannot parse "2015:01:23 23-50-07" as time, reason: :invalid_format
   """
-  @spec from_iso8601!(String.t) :: t | no_return
+  @spec from_iso8601!(String.t) :: t
   def from_iso8601!(string) do
     case from_iso8601(string) do
       {:ok, value} ->
@@ -404,7 +404,7 @@ defmodule Time do
       %Time{calendar: Calendar.Julian, hour: 13, minute: 30, second: 15, microsecond: {0, 0}}
 
   """
-  @spec convert!(Calendar.time, Calendar.calendar) :: t | no_return
+  @spec convert!(Calendar.time, Calendar.calendar) :: t
   def convert!(time, calendar) do
     case convert(time, calendar) do
       {:ok, value} ->

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -369,6 +369,14 @@ defmodule Time do
 
   Returns `{:ok, time}` if the conversion was successful,
   or `{:error, reason}` if it was not, for some reason.
+
+  ## Examples
+
+  Imagine someone implements `Calendar.Julian`:
+
+      iex> Time.convert(~T[13:30:15], Calendar.Julian)
+      {:ok, %Time{calendar: Calendar.Julian, hour: 13, minute: 30, second: 15, microsecond: {0, 0}}}
+
   """
   @spec convert(Calendar.time, Calendar.calendar) :: {:ok, t} | {:error, atom}
   def convert(%Time{calendar: calendar} = time, calendar) do
@@ -387,6 +395,14 @@ defmodule Time do
   @doc """
   Similar to `Time.convert/2`, but raises an `ArgumentError`
   if the conversion between the two calendars is not possible.
+
+  ## Examples
+
+  Imagine someone implements `Calendar.Julian`:
+
+      iex> Time.convert!(~T[13:30:15], Calendar.Julian)
+      %Time{calendar: Calendar.Julian, hour: 13, minute: 30, second: 15, microsecond: {0, 0}}
+
   """
   @spec convert!(Calendar.time, Calendar.calendar) :: t | no_return
   def convert!(time, calendar) do


### PR DESCRIPTION
- change `Date.t` to `Calendar.date` (same for other types)
- add `no_return` to function that raise error
- add doctests to `convert/2`