### PR TITLE
Use orelse instead of or when expanding in operator

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -593,7 +593,7 @@ expand_case(false, Meta, Expr, Opts, E) ->
 
 rewrite_case_clauses([{do, [
   {'->', FalseMeta, [
-    [{'when', _, [Var, {{'.', _, [erlang, 'or']}, _, [
+    [{'when', _, [Var, {{'.', _, [erlang, 'orelse']}, _, [
       {{'.', _, [erlang, '=:=']}, _, [Var, nil]},
       {{'.', _, [erlang, '=:=']}, _, [Var, false]}
     ]}]}],

--- a/lib/elixir/test/elixir/kernel/alias_test.exs
+++ b/lib/elixir/test/elixir/kernel/alias_test.exs
@@ -28,7 +28,7 @@ defmodule Kernel.AliasTest do
   end
 
   test "lexical" do
-    if true do
+    if true_fun() do
       alias OMG, as: List, warn: false
     else
       alias ABC, as: List, warn: false
@@ -36,6 +36,8 @@ defmodule Kernel.AliasTest do
 
     assert List.flatten([1, [2], 3]) == [1, 2, 3]
   end
+
+  defp true_fun(), do: true
 
   defmodule Elixir do
     def sample, do: 1

--- a/lib/elixir/test/elixir/kernel/comprehension_test.exs
+++ b/lib/elixir/test/elixir/kernel/comprehension_test.exs
@@ -173,10 +173,12 @@ defmodule Kernel.ComprehensionTest do
   end
 
   test "list for comprehension matched to '_' on last line of block" do
-    assert (if true do
+    assert (if true_fun() do
       _ = for x <- [1, 2, 3], do: x * 2
     end) == [2, 4, 6]
   end
+
+  defp true_fun(), do: true
 
   test "list for comprehensions with filters" do
     assert for(x <- [1, 2, 3], x > 1, x < 3, do: x * 2) == [4]

--- a/lib/elixir/test/erlang/control_test.erl
+++ b/lib/elixir/test/erlang/control_test.erl
@@ -206,7 +206,7 @@ optimized_andand_test() ->
   {'case', _, _,
     [{clause, _,
       [{var, _, Var}],
-      [[{op, _, 'or', _, _}]],
+      [[{op, _, 'orelse', _, _}]],
       [{var, _, Var}]},
     {clause, _, [{var, _, '_'}], [], [{atom, 0, done}]}]
   } = to_erl("is_list([]) && :done").
@@ -215,7 +215,7 @@ optimized_oror_test() ->
   {'case', _, _,
     [{clause, 1,
       [{var, 1, _}],
-      [[{op, 1, 'or', _, _}]],
+      [[{op, 1, 'orelse', _, _}]],
       [{atom, 0, done}]},
     {clause, 1, [{var, 1, Var}], [], [{var, 1, Var}]}]
   } = to_erl("is_list([]) || :done").


### PR DESCRIPTION
orelse may lead to better code in many occasions. Since we're comparing
to literals, there's no semantic difference.

This also means, the compiler is able to figure out more "will always match"
checks. For example in a situation like the following a warning will be emitted.
This pull request also fixes such warnings in the test suite.

    if true do
      IO.puts("true")
    end