### PR TITLE
Fix what I believe to be some errors in the `IEx.break!` documentation/definition

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -594,10 +594,10 @@ defmodule IEx do
 
       IEx.break!(URI, :decode_query, 2)
 
-  The following call will setup a breakpoint that stops once.
+  This call will setup a breakpoint that stops once.
   To set a breakpoint that will stop 10 times:
 
-      IEx.break!(URI, :decode_query, 10)
+      IEx.break!(URI, :decode_query, 2, 10)
 
   `IEx.break!/2` is a convenience macro that allows breakpoints
   to be given in the `Mod.fun/arity` format:
@@ -622,7 +622,7 @@ defmodule IEx do
       iex -S mix test path/to/file:line --trace
 
   """
-  def break!(module, function, arity, stops \\ 10) do
+  def break!(module, function, arity, stops \\ 1) do
     case IEx.Pry.break(module, function, arity, stops) do
       {:ok, id} ->
         id


### PR DESCRIPTION
• "The following call" seems to referring to the preceding call.
• Second example is missing function arity
• Documentation states default `stops` value to be 1, but it’s currently 10.