### PR TITLE
Expand the capability of the :runtime option in Mix

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -263,7 +263,7 @@ defmodule Mix.Tasks.Compile.App do
 
     for %{app: app, opts: opts, top_level: true} <- Mix.Dep.cached,
         Keyword.get(opts, :app, true),
-        Keyword.get(opts, :runtime, true),
+        Keyword.get(opts, :runtime, :start) in [true, :start],
         not Keyword.get(opts, :optional, false),
         app not in included_applications,
         do: app

--- a/lib/mix/lib/mix/tasks/deps.ex
+++ b/lib/mix/lib/mix/tasks/deps.ex
@@ -92,9 +92,13 @@ defmodule Mix.Tasks.Deps do
       be automatically picked. You can find the manager by running `mix deps`
       and override it by setting the `:override` option in a top-level project.
 
-    * `:runtime` - whether the dependency is part of runtime applications.
-      Defaults to `true` which automatically adds the application to the list
-      of apps that are started automatically and included in releases
+    * `:runtime` - specifies whether the dependency is part of runtime applications,
+      and if so, what the start type is (either `:start` or `:none`).
+      Defaults to `:start` which automatically adds the application to the list
+      of apps that are started automatically and included in releases. If set to
+      `:none`, the application is not loaded or started, but included in releases, 
+      and if set to `false`, the application is excluded from releases, and neither 
+      loaded or started when running your application via Mix.
 
   ### Git options (`:git`)
 

--- a/lib/mix/test/mix/tasks/compile.app_test.exs
+++ b/lib/mix/test/mix/tasks/compile.app_test.exs
@@ -26,15 +26,16 @@ defmodule Mix.Tasks.Compile.AppTest do
     end
 
     def deps do
-      [{:ok1, path: "../ok"},
-       {:ok2, path: "../ok", only: :prod},
-       {:ok3, path: "../ok", only: :dev},
-       {:ok4, path: "../ok", runtime: true},
-       {:ok5, path: "../ok", runtime: false},
-       {:ok6, path: "../ok", optional: true},
-       {:ok7, path: "../ok", optional: false},
-       {:ok8, path: "../ok", app: false},
-       {:ok9, path: "../ok"}]
+      [{:ok1,  path: "../ok"},
+       {:ok2,  path: "../ok", only: :prod},
+       {:ok3,  path: "../ok", only: :dev},
+       {:ok4,  path: "../ok", runtime: :start},
+       {:ok5,  path: "../ok", runtime: false},
+       {:ok5b, path: "../ok", runtime: :none},
+       {:ok6,  path: "../ok", optional: true},
+       {:ok7,  path: "../ok", optional: false},
+       {:ok8,  path: "../ok", app: false},
+       {:ok9,  path: "../ok"}]
     end
   end
 


### PR DESCRIPTION
Per my conversation with @josevalim earlier today in IRC, this fix is intended to address a discrepancy between how projects run under Mix versus releases.

Previously, the purpose of `runtime: true | false` was to specify whether a given application should be included in the runtime applications list. However, this presents problems when running projects under Mix versus under releases. When run via Mix, setting `runtime: false` would result in the application not being started (because it's not in the runtime applications list), but would allow you to still load/start it at runtime (because Mix allows you to dynamically load applications which are on the code path). When in a release, the application is not even available to load as it was excluded from the release due to setting `runtime: false`. In other words, `true | false` is not granular enough to express the intermediate state, where you want the dependency included at runtime, but not started.

This change adds two additional `:runtime` option values, `:load` and `:start`. `false` behaves like it did before, and `true` is supported for backwards compatibility here (it has the same meaning as `:start`), `:start` takes it's place as the new default value. We also introduce `:load` which is effectively the same as `false` when running a project under Mix, but allows release tools (such as Distillery) to specify the start type of the application to use when compiling the release.