### PR TITLE
Fix Enum.zip(%{}) infinity loop

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1106,6 +1106,10 @@ defmodule Stream do
     end
   end
 
+  defp do_zip_next_tuple([] = _zips, acc, _callback, [], _buffer) do
+    {:done, acc}
+  end
+
   defp do_zip_next_tuple([] = _zips, acc, callback, yielded_elems, buffer) do
     # "yielded_elems" is a reversed list of results for the current iteration of
     # zipping: it needs to be reversed and converted to a tuple to have the next

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -812,7 +812,9 @@ defmodule EnumTest do
     assert Enum.zip([[]]) == []
     assert Enum.zip([[1]]) == [{1}]
 
-    assert Enum.zip([[], [], [], []])  == []
+    assert Enum.zip([[], [], [], []]) == []
+
+    assert Enum.zip(%{}) == []
   end
 end
 


### PR DESCRIPTION
### Environment

* Elixir & Erlang versions (elixir --version): `Elixir 1.6.0-dev (a5aab0769)`
* Operating system: Mac OS X

### Current behavior
```
Enum.zip(%{})
```
Invoking an infinity loop

### Expected behavior
```
Enum.zip(%{})
[]
```

This PR solves this