### PR TITLE
Wrap lists and tuples of size 2 in blocks

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -636,10 +636,7 @@ build_unary_op({_Kind, Location, Op}, Expr) ->
   {Op, meta_from_location(Location), [Expr]}.
 
 build_list(Marker, Args) ->
-  case get(wrap_literals_in_blocks) of
-    true -> {{'__block__', meta_from_token(Marker), [Args]}, ?location(Marker)};
-    false -> {Args, ?location(Marker)}
-  end.
+  {handle_literal(Args, Marker), ?location(Marker)}.
 
 build_tuple(Marker, [Left, Right]) ->
   handle_literal({Left, Right}, Marker);

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -636,10 +636,13 @@ build_unary_op({_Kind, Location, Op}, Expr) ->
   {Op, meta_from_location(Location), [Expr]}.
 
 build_list(Marker, Args) ->
-  {Args, ?location(Marker)}.
+  case get(wrap_literals_in_blocks) of
+    true -> {{'__block__', meta_from_token(Marker), [Args]}, ?location(Marker)};
+    false -> {Args, ?location(Marker)}
+  end.
 
-build_tuple(_Marker, [Left, Right]) ->
-  {Left, Right};
+build_tuple(Marker, [Left, Right]) ->
+  handle_literal({Left, Right}, Marker);
 build_tuple(Marker, Args) ->
   {'{}', meta_from_token(Marker), Args}.
 

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -135,6 +135,10 @@ defmodule CodeTest do
     assert Code.string_to_quoted("1", wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [1]}}
     assert Code.string_to_quoted("nil", wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [nil]}}
     assert Code.string_to_quoted(":one", wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [:one]}}
+    assert Code.string_to_quoted("[1]", wrap_literals_in_blocks: true) ==
+           {:ok, {:__block__, [line: 1], [[{:__block__, [line: 1], [1]}]]}}
+    assert Code.string_to_quoted("{:ok, :test}", wrap_literals_in_blocks: true) ==
+           {:ok, {:__block__, [line: 1], [{{:__block__, [line: 1], [:ok]}, {:__block__, [line: 1], [:test]}}]}}
   end
 
   test "compile source" do


### PR DESCRIPTION
Currently, lists and tuples of size 2 do not have metadata on their own, hence, it is hard to format code where comments/newlines precede the lists/tuples of size 2. This PR wraps them in a block using an option.

```elixir
# list literals have no metadata
# so this comment is not preserved
[1,2,3]

# same here
[
  # however, this comment is preserved
  1,
  # because each integer literal has its own block
  2,
  3,
]

# tuples of size > 2 has their own metadata, so this comment is preserved
{:one, :two, :three}

# yet this is not the case for tuples of size 2
{:ok, :some_value}
```