### PR TITLE
Add MapSet.intersect?/2

### DIFF
--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -203,6 +203,22 @@ defmodule MapSet do
   end
 
   @doc """
+  Checks if `map_set1` and `map_set2` have any members in common.
+
+  ## Examples
+
+      iex> MapSet.intersect?(MapSet.new([1, 2]), MapSet.new([3, 4]))
+      false
+      iex> MapSet.intersect?(MapSet.new([1, 2]), MapSet.new([2, 3]))
+      true
+
+  """
+  @spec intersect?(t, t) :: boolean
+  def intersect?(set1, set2) do
+    not disjoint?(set1, set2)
+  end
+
+  @doc """
   Checks if two sets are equal.
 
   The comparison between elements must be done using `===`.

--- a/lib/elixir/test/elixir/map_set_test.exs
+++ b/lib/elixir/test/elixir/map_set_test.exs
@@ -66,6 +66,14 @@ defmodule MapSetTest do
     refute MapSet.disjoint?(MapSet.new(1..120), MapSet.new(1..6))
   end
 
+  test "intersect?/2" do
+    assert MapSet.intersect?(MapSet.new(1..6), MapSet.new(1..2))
+    assert MapSet.intersect?(MapSet.new(1..2), MapSet.new(1..6))
+    assert MapSet.intersect?(MapSet.new(1..2), MapSet.new(2..3))
+    refute MapSet.intersect?(MapSet.new(1..2), MapSet.new(3..4))
+    refute MapSet.intersect?(MapSet.new(), MapSet.new())
+  end
+
   test "subset?/2" do
     assert MapSet.subset?(MapSet.new, MapSet.new)
     assert MapSet.subset?(MapSet.new(1..6), MapSet.new(1..10))


### PR DESCRIPTION
Before there wasn't an obvious way to check whether two sets have overlapping members. The accurate, though non-obvious, way was to use `not MapSet.disjoint?/2`, which is slightly slower in the worst case.

Benchmarking the changes shows a marginal (though consistent) difference in performance:

```elixir
set_a = MapSet.new(1..200)
set_b = MapSet.new(100..102)
```

```
Name               ips        average  deviation         median
intersect     631.85 K        1.58 μs  ±2453.50%        1.00 μs
disjoint      621.88 K        1.61 μs  ±2407.12%        1.00 μs

Comparison:
intersect     631.85 K
disjoint      621.88 K - 1.02x slower
```