### PR TITLE
Registry.unregister_match/2

### DIFF
--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -696,7 +696,6 @@ defmodule Registry do
       iex> Registry.keys(Registry.UniqueUnregisterMatchTest, self())
       []
 
-
   For duplicate registries:
 
       iex> Registry.start_link(:duplicate, Registry.DuplicateUnregisterMatchTest)
@@ -726,12 +725,12 @@ defmodule Registry do
 
     # Here we want to count all entries for this pid under this key, regardless
     # of pattern.
-    guards = [{:"=:=", {:element, 1, :"$_"}, {:const, key}} | guards]
-    total_spec = [{{:_, {self, :_}}, guards, [{:const, true}]}]
+    total_spec = [{{key, {self, :_}}, [], [true]}]
     total = :ets.select_count(key_ets, total_spec)
 
     # We only want to delete things that match the pattern
-    delete_spec = [{{:_, {self, pattern}}, guards ,[{:const, true}]}]
+    guards = [{:"=:=", {:element, 1, :"$_"}, {:const, key}} | guards]
+    delete_spec = [{{:_, {self, pattern}}, guards ,[true]}]
     case :ets.select_delete(key_ets, delete_spec) do
       # We deleted everything, we can just delete the object
       ^total ->

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -725,12 +725,12 @@ defmodule Registry do
 
     # Here we want to count all entries for this pid under this key, regardless
     # of pattern.
-    total_spec = [{{key, {self, :_}}, [], [true]}]
+    underscore_guard = {:"=:=", {:element, 1, :"$_"}, {:const, key}}
+    total_spec = [{{:_, {self, :_}}, [underscore_guard], [true]}]
     total = :ets.select_count(key_ets, total_spec)
 
     # We only want to delete things that match the pattern
-    guards = [{:"=:=", {:element, 1, :"$_"}, {:const, key}} | guards]
-    delete_spec = [{{:_, {self, pattern}}, guards ,[true]}]
+    delete_spec = [{{:_, {self, pattern}}, [underscore_guard | guards] ,[true]}]
     case :ets.select_delete(key_ets, delete_spec) do
       # We deleted everything, we can just delete the object
       ^total ->

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -403,7 +403,7 @@ defmodule RegistryTest do
                [{self(), value1}, {self(), value2}]
         Registry.unregister_match(registry, "hello", {:_, :atom, :_})
         assert Registry.lookup(registry, "hello") ==
-              []
+               []
       end
 
       test "unregister_match supports guards", %{registry: registry} do

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -351,6 +351,50 @@ defmodule RegistryTest do
                [{self(), value1}, {self(), value2}]
       end
 
+      test "unregister_match supports patterns", %{registry: registry} do
+        value1 = {1, :atom, 1}
+        {:ok, _} = Registry.register(registry, "hello", value1)
+        value2 = {2, :atom, 2}
+        {:ok, _} = Registry.register(registry, "hello", value2)
+
+        Registry.unregister_match(registry, "hello", {2, :_, :_})
+        assert Registry.lookup(registry, "hello") ==
+               [{self(), value1}]
+
+        {:ok, _} = Registry.register(registry, "hello", value2)
+        Registry.unregister_match(registry, "hello", {2.0, :_, :_})
+        assert Registry.lookup(registry, "hello") ==
+               [{self(), value1}, {self(), value2}]
+        Registry.unregister_match(registry, "hello", {:_, :atom, :_})
+        assert Registry.lookup(registry, "hello") ==
+              []
+      end
+
+      test "unregister_match supports guards", %{registry: registry} do
+        value1 = {1, :atom, 1}
+        {:ok, _} = Registry.register(registry, "hello", value1)
+        value2 = {2, :atom, 2}
+        {:ok, _} = Registry.register(registry, "hello", value2)
+
+        Registry.unregister_match(registry, "hello", {:"$1", :_, :_}, [{:<, :"$1", 2}])
+        assert Registry.lookup(registry, "hello") ==
+               [{self(), value2}]
+      end
+
+      test "unregister_match supports tricky keys", %{registry: registry} do
+        {:ok, _} = Registry.register(registry, :_, :foo)
+        {:ok, _} = Registry.register(registry, :_, :bar)
+        {:ok, _} = Registry.register(registry, "hello", "a")
+        {:ok, _} = Registry.register(registry, "hello", "b")
+
+        Registry.unregister_match(registry, :_, :foo)
+        assert Registry.lookup(registry, :_) ==
+               [{self(), :bar}]
+
+        assert Registry.keys(registry, self()) |> Enum.sort ==
+               [:_, "hello", "hello"]
+      end
+
       @tag listener: :"duplicate_listener_#{partitions}"
       test "allows listeners", %{registry: registry, listener: listener} do
         Process.register(self(), listener)


### PR DESCRIPTION
Right now in a duplicate registry using unregister on a key unregisters all key / value pairs. The idea with this function is that it would only unregister particular values that match a given spec.

The primary issue at the moment is that the `true = :ets.delete_object(pid_ets, {self, key, key_ets})` deletes all instances of the key under self, but instead we want N instances of the key where N is the number of key value pairs remaining in the key_ets table.