### PR TITLE
Remove parens in "fn" calls in the Agent docs

### DIFF
--- a/lib/elixir/lib/agent.ex
+++ b/lib/elixir/lib/agent.ex
@@ -236,7 +236,7 @@ defmodule Agent do
   ## Examples
 
       iex> {:ok, pid} = Agent.start(fn -> 42 end)
-      iex> Agent.get(pid, fn(state) -> state end)
+      iex> Agent.get(pid, fn state -> state end)
       42
 
   """


### PR DESCRIPTION
Recent editions to Agent have updated examples to notate `fn state` without parens.

Found and updated a loose one that had the previously used notation.