### PR TITLE
Fix protocols diff calculation between compilations

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.protocols.ex
+++ b/lib/mix/lib/mix/tasks/compile.protocols.ex
@@ -204,7 +204,7 @@ defmodule Mix.Tasks.Compile.Protocols do
 
     protocols =
       for {_, {:impl, protocol}, _beam} <- removed_metadata,
-          !Map.has_key?(removed_protocols, protocol),
+          not Map.has_key?(removed_protocols, protocol),
           do: {protocol, true},
           into: protocols
 


### PR DESCRIPTION
This PR fixes a bug when recompiling a mix project where a protocol has been converted into a standard module.

## Steps to reproduce the error

1. Create a new mix project (`mix new bug_demo`)
2. Define a protocol and an implementation somewhere:
    ```elixir
    defprotocol Foo do
      def bar(arg)
    end
    defimpl Foo, for: Integer do
      def bar(_), do: :ok
    end
    ```
3. Compile (`mix compile`)
4. Remove the protocol (and its implementation) and define a module with the same name:
    ```elixir
    defmodule Foo do
    end
    ```
5. Compile (`mix compile`)

### Expected behaviour:

Compile without errors

### Current behaviour: 

It shows the following error:
```
Compiling 1 file (.ex)
Generated bug_demo app
** (EXIT from #PID<0.70.0>) an exception was raised:
    ** (CaseClauseError) no case clause matching: {:error, :not_a_protocol}
        (mix) lib/mix/tasks/compile.protocols.ex:125: Mix.Tasks.Compile.Protocols.consolidate/4
        (elixir) lib/task/supervised.ex:85: Task.Supervised.do_apply/2
        (elixir) lib/task/supervised.ex:36: Task.Supervised.reply/5
        (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3

14:45:56.930 [error] Task #PID<0.102.0> started from #PID<0.70.0> terminating
** (CaseClauseError) no case clause matching: {:error, :not_a_protocol}
    (mix) lib/mix/tasks/compile.protocols.ex:125: Mix.Tasks.Compile.Protocols.consolidate/4
    (elixir) lib/task/supervised.ex:85: Task.Supervised.do_apply/2
    (elixir) lib/task/supervised.ex:36: Task.Supervised.reply/5
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Function: #Function<8.127116546/0 in Mix.Tasks.Compile.Protocols.consolidate/6>
    Args: []
```

## The bug

The bug is located in `Mix.Tasks.Compile.Protocols` module.

It marks a module to be consolidated when an implementation has been removed, without checking if that module is still a protocol.

I have added a test that fails because of that bug. It creates, compiles and removes files and maybe is too expensive for such a specific case. Should it be removed?