### PR TITLE
Augment integer literals with representation info

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -242,7 +242,7 @@ access_expr -> open_paren ';' stab ';' close_paren : build_stab(reverse('$3')).
 access_expr -> open_paren ';' stab close_paren : build_stab(reverse('$3')).
 access_expr -> open_paren ';' close_paren : build_stab([]).
 access_expr -> empty_paren : warn_empty_paren('$1'), nil.
-access_expr -> number : handle_literal(?exprs('$1'), '$1').
+access_expr -> number : handle_number_literal(?exprs('$1'), '$1').
 access_expr -> char : handle_literal(?exprs('$1'), '$1').
 access_expr -> list : element(1, '$1').
 access_expr -> map : '$1'.
@@ -615,6 +615,13 @@ meta_from_location({Line, Column, EndColumn})
   when is_integer(Line), is_integer(Column), is_integer(EndColumn) -> [{line, Line}].
 
 %% Handle metadata in literals
+
+handle_number_literal(Literal, Token) ->
+  MetaWithBase = [{base, element(4, Token)} | meta_from_token(Token)],
+  case get(wrap_literals_in_blocks) of
+    true -> {'__block__', MetaWithBase, [Literal]};
+    false -> Literal
+  end.
 
 handle_literal(Literal, Token) ->
   case get(wrap_literals_in_blocks) of

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -39,7 +39,7 @@ Terminals
   capture_op rel_op
   'true' 'false' 'nil' 'do' eol ';' ',' '.'
   '(' ')' '[' ']' '{' '}' '<<' '>>' '%{}' '%'
-  binary octal decimal float hex
+  binary octal decimal float hexadecimal
   .
 
 Rootsymbol grammar.
@@ -262,7 +262,7 @@ number -> char : handle_literal(?exprs('$1'), '$1', [{format, char}]).
 number -> binary : handle_literal(?exprs('$1'), '$1', [{format, binary}]).
 number -> octal : handle_literal(?exprs('$1'), '$1', [{format, octal}]).
 number -> decimal : handle_literal(?exprs('$1'), '$1', [{format, decimal}]).
-number -> hex : handle_literal(?exprs('$1'), '$1', [{format, hexadecimal}]).
+number -> hexadecimal : handle_literal(?exprs('$1'), '$1', [{format, hexadecimal}]).
 number -> float : handle_literal(?exprs('$1'), '$1').
 
 %% Aliases and properly formed calls. Used by map_expr.

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -242,7 +242,7 @@ access_expr -> open_paren ';' stab ';' close_paren : build_stab(reverse('$3')).
 access_expr -> open_paren ';' stab close_paren : build_stab(reverse('$3')).
 access_expr -> open_paren ';' close_paren : build_stab([]).
 access_expr -> empty_paren : warn_empty_paren('$1'), nil.
-access_expr -> number : handle_number_literal(?exprs('$1'), '$1').
+access_expr -> number : handle_literal(?exprs('$1'), '$1').
 access_expr -> char : handle_literal(?exprs('$1'), '$1').
 access_expr -> list : element(1, '$1').
 access_expr -> map : '$1'.
@@ -616,16 +616,13 @@ meta_from_location({Line, Column, EndColumn})
 
 %% Handle metadata in literals
 
-handle_number_literal(Literal, Token) ->
-  MetaWithBase = [{base, element(4, Token)} | meta_from_token(Token)],
-  case get(wrap_literals_in_blocks) of
-    true -> {'__block__', MetaWithBase, [Literal]};
-    false -> Literal
-  end.
-
 handle_literal(Literal, Token) ->
+  Meta = case Token of
+    {number, _, _, Base} -> [{base, Base} | meta_from_token(Token)];
+    _ -> meta_from_token(Token)
+  end,
   case get(wrap_literals_in_blocks) of
-    true -> {'__block__', meta_from_token(Token), [Literal]};
+    true -> {'__block__', Meta, [Literal]};
     false -> Literal
   end.
 

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -166,15 +166,15 @@ tokenize(("<<<<<<<" ++ _) = Original, Line, 1, _Scope, Tokens) ->
 
 tokenize([$0, $x, H | T], Line, Column, Scope, Tokens) when ?is_hex(H) ->
   {Rest, Number, Length} = tokenize_hex(T, [H], 1),
-  tokenize(Rest, Line, Column + 2 + Length, Scope, [{number, {Line, Column, Column + 2 + Length}, Number} | Tokens]);
+  tokenize(Rest, Line, Column + 2 + Length, Scope, [{number, {Line, Column, Column + 2 + Length}, Number, 16} | Tokens]);
 
 tokenize([$0, $b, H | T], Line, Column, Scope, Tokens) when ?is_bin(H) ->
   {Rest, Number, Length} = tokenize_bin(T, [H], 1),
-  tokenize(Rest, Line, Column + 2 + Length, Scope, [{number, {Line, Column, Column + 2 + Length}, Number} | Tokens]);
+  tokenize(Rest, Line, Column + 2 + Length, Scope, [{number, {Line, Column, Column + 2 + Length}, Number, 2} | Tokens]);
 
 tokenize([$0, $o, H | T], Line, Column, Scope, Tokens) when ?is_octal(H) ->
   {Rest, Number, Length} = tokenize_octal(T, [H], 1),
-  tokenize(Rest, Line, Column + 2 + Length, Scope, [{number, {Line, Column, Column + 2 + Length}, Number} | Tokens]);
+  tokenize(Rest, Line, Column + 2 + Length, Scope, [{number, {Line, Column, Column + 2 + Length}, Number, 8} | Tokens]);
 
 % Comments
 
@@ -421,7 +421,7 @@ tokenize([H | T], Line, Column, Scope, Tokens) when ?is_digit(H) ->
     {error, Reason, Number} ->
       {error, {Line, Reason, Number}, T, Tokens};
     {Rest, Number, Length} ->
-      tokenize(Rest, Line, Column + Length, Scope, [{number, {Line, Column, Column + Length}, Number} | Tokens])
+      tokenize(Rest, Line, Column + Length, Scope, [{number, {Line, Column, Column + Length}, Number, 10} | Tokens])
   end;
 
 % Spaces
@@ -858,7 +858,7 @@ tokenize_comment("\r\n" ++ _ = Rest, Acc, Length) ->
   {Rest, lists:reverse(Acc), Length};
 tokenize_comment("\n" ++ _ = Rest, Acc, Length) ->
   {Rest, lists:reverse(Acc), Length};
-tokenize_comment([H | Rest], Acc, Length) -> 
+tokenize_comment([H | Rest], Acc, Length) ->
   tokenize_comment(Rest, [H | Acc], Length + 1);
 tokenize_comment([], Acc, Length) ->
   {[], lists:reverse(Acc), Length}.

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -166,7 +166,7 @@ tokenize(("<<<<<<<" ++ _) = Original, Line, 1, _Scope, Tokens) ->
 
 tokenize([$0, $x, H | T], Line, Column, Scope, Tokens) when ?is_hex(H) ->
   {Rest, Number, Length} = tokenize_hex(T, [H], 1),
-  tokenize(Rest, Line, Column + 2 + Length, Scope, [{hex, {Line, Column, Column + 2 + Length}, Number} | Tokens]);
+  tokenize(Rest, Line, Column + 2 + Length, Scope, [{hexadecimal, {Line, Column, Column + 2 + Length}, Number} | Tokens]);
 
 tokenize([$0, $b, H | T], Line, Column, Scope, Tokens) when ?is_bin(H) ->
   {Rest, Number, Length} = tokenize_bin(T, [H], 1),

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -166,15 +166,15 @@ tokenize(("<<<<<<<" ++ _) = Original, Line, 1, _Scope, Tokens) ->
 
 tokenize([$0, $x, H | T], Line, Column, Scope, Tokens) when ?is_hex(H) ->
   {Rest, Number, Length} = tokenize_hex(T, [H], 1),
-  tokenize(Rest, Line, Column + 2 + Length, Scope, [{number, {Line, Column, Column + 2 + Length}, Number, 16} | Tokens]);
+  tokenize(Rest, Line, Column + 2 + Length, Scope, [{hex, {Line, Column, Column + 2 + Length}, Number} | Tokens]);
 
 tokenize([$0, $b, H | T], Line, Column, Scope, Tokens) when ?is_bin(H) ->
   {Rest, Number, Length} = tokenize_bin(T, [H], 1),
-  tokenize(Rest, Line, Column + 2 + Length, Scope, [{number, {Line, Column, Column + 2 + Length}, Number, 2} | Tokens]);
+  tokenize(Rest, Line, Column + 2 + Length, Scope, [{binary, {Line, Column, Column + 2 + Length}, Number} | Tokens]);
 
 tokenize([$0, $o, H | T], Line, Column, Scope, Tokens) when ?is_octal(H) ->
   {Rest, Number, Length} = tokenize_octal(T, [H], 1),
-  tokenize(Rest, Line, Column + 2 + Length, Scope, [{number, {Line, Column, Column + 2 + Length}, Number, 8} | Tokens]);
+  tokenize(Rest, Line, Column + 2 + Length, Scope, [{octal, {Line, Column, Column + 2 + Length}, Number} | Tokens]);
 
 % Comments
 
@@ -420,8 +420,10 @@ tokenize([H | T], Line, Column, Scope, Tokens) when ?is_digit(H) ->
   case tokenize_number(T, [H], 1, false) of
     {error, Reason, Number} ->
       {error, {Line, Reason, Number}, T, Tokens};
+    {Rest, Number, Length} when is_integer(Number) ->
+      tokenize(Rest, Line, Column + Length, Scope, [{decimal, {Line, Column, Column + Length}, Number} | Tokens]);
     {Rest, Number, Length} ->
-      tokenize(Rest, Line, Column + Length, Scope, [{number, {Line, Column, Column + Length}, Number, 10} | Tokens])
+      tokenize(Rest, Line, Column + Length, Scope, [{float, {Line, Column, Column + Length}, Number} | Tokens])
   end;
 
 % Spaces

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -132,11 +132,16 @@ defmodule CodeTest do
   test "string_to_quoted/2 with wrap_literals_in_blocks option" do
     assert Code.string_to_quoted("\"one\"", wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], ["one"]}}
     assert Code.string_to_quoted("\"one\"") == {:ok, "one"}
-    assert Code.string_to_quoted("1", wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [1]}}
+    assert Code.string_to_quoted("?é", wrap_literals_in_blocks: true) == {:ok, {:__block__, [format: :char, line: 1], [233]}}
+    assert Code.string_to_quoted("0b10", wrap_literals_in_blocks: true) == {:ok, {:__block__, [format: :binary, line: 1], [2]}}
+    assert Code.string_to_quoted("12", wrap_literals_in_blocks: true) == {:ok, {:__block__, [format: :decimal, line: 1], [12]}}
+    assert Code.string_to_quoted("0o123", wrap_literals_in_blocks: true) == {:ok, {:__block__, [format: :octal, line: 1], [83]}}
+    assert Code.string_to_quoted("0xEF", wrap_literals_in_blocks: true) == {:ok, {:__block__, [format: :hexadecimal, line: 1], [239]}}
+    assert Code.string_to_quoted("12.3", wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [12.3]}}
     assert Code.string_to_quoted("nil", wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [nil]}}
     assert Code.string_to_quoted(":one", wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [:one]}}
     assert Code.string_to_quoted("[1]", wrap_literals_in_blocks: true) ==
-           {:ok, {:__block__, [line: 1], [[{:__block__, [line: 1], [1]}]]}}
+           {:ok, {:__block__, [line: 1], [[{:__block__, [format: :decimal, line: 1], [1]}]]}}
     assert Code.string_to_quoted("{:ok, :test}", wrap_literals_in_blocks: true) ==
            {:ok, {:__block__, [line: 1], [{{:__block__, [line: 1], [:ok]}, {:__block__, [line: 1], [:test]}}]}}
   end

--- a/lib/elixir/test/erlang/string_test.erl
+++ b/lib/elixir/test/erlang/string_test.erl
@@ -41,12 +41,12 @@ extract_interpolations_with_only_two_interpolations_test() ->
 
 extract_interpolations_with_tuple_inside_interpolation_test() ->
   [<<"f">>,
-   {{1, 2, 8}, [{'{', {1, 4, 5}}, {number, {1, 5, 6}, 1}, {'}', {1, 6, 7}}]},
+   {{1, 2, 8}, [{'{', {1, 4, 5}}, {decimal, {1, 5, 6}, 1}, {'}', {1, 6, 7}}]},
    <<"o">>] = extract_interpolations("f#{{1}}o").
 
 extract_interpolations_with_many_expressions_inside_interpolation_test() ->
   [<<"f">>,
-   {{1, 2, 3}, [{number, {1, 4, 5}, 1}, {eol, {1, 5, 6}}, {number, {2, 1, 2}, 2}]},
+   {{1, 2, 3}, [{decimal, {1, 4, 5}, 1}, {eol, {1, 5, 6}}, {decimal, {2, 1, 2}, 2}]},
     <<"o">>] = extract_interpolations("f#{1\n2}o").
 
 extract_interpolations_with_right_curly_inside_string_inside_interpolation_test() ->
@@ -66,7 +66,7 @@ extract_interpolations_with_escaped_quote_inside_string_inside_interpolation_tes
 
 extract_interpolations_with_less_than_operation_inside_interpolation_test() ->
   [<<"f">>,
-   {{1, 2, 8}, [{number, {1, 4, 5}, 1}, {rel_op, {1, 5, 6}, '<'}, {number, {1, 6, 7}, 2}]},
+   {{1, 2, 8}, [{decimal, {1, 4, 5}, 1}, {rel_op, {1, 5, 6}, '<'}, {decimal, {1, 6, 7}, 2}]},
    <<"o">>] = extract_interpolations("f#{1<2}o").
 
 extract_interpolations_with_an_escaped_character_test() ->

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -33,8 +33,8 @@ scientific_test() ->
   {1, "invalid float number ", "1.0e309"} = tokenize_error("1.0e309").
 
 hex_bin_octal_test() ->
-  [{hex, {1, 1, 5}, 255}] = tokenize("0xFF"),
-  [{hex, {1, 1, 6}, 255}] = tokenize("0xF_F"),
+  [{hexadecimal, {1, 1, 5}, 255}] = tokenize("0xFF"),
+  [{hexadecimal, {1, 1, 6}, 255}] = tokenize("0xF_F"),
   [{octal, {1, 1, 5}, 63}] = tokenize("0o77"),
   [{octal, {1, 1, 6}, 63}] = tokenize("0o7_7"),
   [{binary, {1, 1, 5}, 3}] = tokenize("0b11"),

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -13,32 +13,32 @@ tokenize_error(String) ->
   Error.
 
 type_test() ->
-  [{number, {1, 1, 2}, 1}, {type_op, {1, 3, 5}, '::'}, {number, {1, 6, 7}, 3}] = tokenize("1 :: 3"),
+  [{decimal, {1, 1, 2}, 1}, {type_op, {1, 3, 5}, '::'}, {decimal, {1, 6, 7}, 3}] = tokenize("1 :: 3"),
   [{identifier, {1, 1, 5}, name},
    {'.', {1, 5, 6}},
    {paren_identifier, {1, 6, 8}, '::'},
    {'(', {1, 8, 9}},
-   {number, {1, 9, 10}, 3},
+   {decimal, {1, 9, 10}, 3},
    {')', {1, 10, 11}}] = tokenize("name.::(3)").
 
 arithmetic_test() ->
-  [{number, {1, 1, 2}, 1}, {dual_op, {1, 3, 4}, '+'}, {number, {1, 5, 6}, 2}, {dual_op, {1, 7, 8}, '+'}, {number, {1, 9, 10}, 3}] = tokenize("1 + 2 + 3").
+  [{decimal, {1, 1, 2}, 1}, {dual_op, {1, 3, 4}, '+'}, {decimal, {1, 5, 6}, 2}, {dual_op, {1, 7, 8}, '+'}, {decimal, {1, 9, 10}, 3}] = tokenize("1 + 2 + 3").
 
 op_kw_test() ->
   [{atom, {1, 1, 5}, foo}, {dual_op, {1, 5, 6}, '+'}, {atom, {1, 6, 10}, bar}] = tokenize(":foo+:bar").
 
 scientific_test() ->
-  [{number, {1, 1, 7}, 0.1}] = tokenize("1.0e-1"),
-  [{number, {1, 1, 16}, 1.2345678e-7}] = tokenize("1_234.567_8e-10"),
+  [{float, {1, 1, 7}, 0.1}] = tokenize("1.0e-1"),
+  [{float, {1, 1, 16}, 1.2345678e-7}] = tokenize("1_234.567_8e-10"),
   {1, "invalid float number ", "1.0e309"} = tokenize_error("1.0e309").
 
 hex_bin_octal_test() ->
-  [{number, {1, 1, 5}, 255}] = tokenize("0xFF"),
-  [{number, {1, 1, 6}, 255}] = tokenize("0xF_F"),
-  [{number, {1, 1, 5}, 63}] = tokenize("0o77"),
-  [{number, {1, 1, 6}, 63}] = tokenize("0o7_7"),
-  [{number, {1, 1, 5}, 3}] = tokenize("0b11"),
-  [{number, {1, 1, 6}, 3}] = tokenize("0b1_1").
+  [{hex, {1, 1, 5}, 255}] = tokenize("0xFF"),
+  [{hex, {1, 1, 6}, 255}] = tokenize("0xF_F"),
+  [{octal, {1, 1, 5}, 63}] = tokenize("0o77"),
+  [{octal, {1, 1, 6}, 63}] = tokenize("0o7_7"),
+  [{binary, {1, 1, 5}, 3}] = tokenize("0b11"),
+  [{binary, {1, 1, 6}, 3}] = tokenize("0b1_1").
 
 unquoted_atom_test() ->
   [{atom, {1, 1, 3}, '+'}] = tokenize(":+"),
@@ -68,23 +68,23 @@ kw_test() ->
   [{kw_identifier_unsafe, {1, 1, 10}, [<<"foo bar">>]}] = tokenize("\"foo bar\": ").
 
 integer_test() ->
-  [{number, {1, 1, 4}, 123}] = tokenize("123"),
-  [{number, {1, 1, 4}, 123}, {';', {1, 4, 5}}] = tokenize("123;"),
-  [{eol, {1, 1, 2}}, {number, {3, 1, 4}, 123}] = tokenize("\n\n123"),
-  [{number, {1, 3, 6}, 123}, {number, {1, 8, 11}, 234}] = tokenize("  123  234  ").
+  [{decimal, {1, 1, 4}, 123}] = tokenize("123"),
+  [{decimal, {1, 1, 4}, 123}, {';', {1, 4, 5}}] = tokenize("123;"),
+  [{eol, {1, 1, 2}}, {decimal, {3, 1, 4}, 123}] = tokenize("\n\n123"),
+  [{decimal, {1, 3, 6}, 123}, {decimal, {1, 8, 11}, 234}] = tokenize("  123  234  ").
 
 float_test() ->
-  [{number, {1, 1, 5}, 12.3}] = tokenize("12.3"),
-  [{number, {1, 1, 5}, 12.3}, {';', {1, 5, 6}}] = tokenize("12.3;"),
-  [{eol, {1, 1, 2}}, {number, {3, 1, 5}, 12.3}] = tokenize("\n\n12.3"),
-  [{number, {1, 3, 7}, 12.3}, {number, {1, 9, 13}, 23.4}] = tokenize("  12.3  23.4  "),
+  [{float, {1, 1, 5}, 12.3}] = tokenize("12.3"),
+  [{float, {1, 1, 5}, 12.3}, {';', {1, 5, 6}}] = tokenize("12.3;"),
+  [{eol, {1, 1, 2}}, {float, {3, 1, 5}, 12.3}] = tokenize("\n\n12.3"),
+  [{float, {1, 3, 7}, 12.3}, {float, {1, 9, 13}, 23.4}] = tokenize("  12.3  23.4  "),
   OversizedFloat = string:copies("9", 310) ++ ".0",
   {1, "invalid float number ", OversizedFloat} = tokenize_error(OversizedFloat).
 
 comments_test() ->
-  [{number, {1, 1, 2}, 1}, {eol, {1, 3, 4}}, {number, {2, 1, 2}, 2}] = tokenize("1 # Comment\n2"),
-  [{number, {1, 1, 2}, 1}, {comment, {1, 3, 12}, "# Comment"},
-   {eol, {1, 12, 13}}, {number, {2, 1, 2}, 2}] = tokenize("1 # Comment\n2", [{preserve_comments, true}]),
+  [{decimal, {1, 1, 2}, 1}, {eol, {1, 3, 4}}, {decimal, {2, 1, 2}, 2}] = tokenize("1 # Comment\n2"),
+  [{decimal, {1, 1, 2}, 1}, {comment, {1, 3, 12}, "# Comment"},
+   {eol, {1, 12, 13}}, {decimal, {2, 1, 2}, 2}] = tokenize("1 # Comment\n2", [{preserve_comments, true}]),
   [{comment, {1, 1, 10}, "# Comment"}] = tokenize("# Comment", [{preserve_comments, true}]).
 
 identifier_test() ->
@@ -118,24 +118,24 @@ newline_test() ->
   [{identifier, {1, 1, 4}, foo},
    {'.', {2, 1, 2}},
    {identifier, {2, 2, 5}, bar}]  = tokenize("foo\n.bar"),
-  [{number, {1, 1, 2}, 1},
+  [{decimal, {1, 1, 2}, 1},
    {two_op, {2, 1, 3}, '++'},
-   {number, {2, 3, 4}, 2}]  = tokenize("1\n++2").
+   {decimal, {2, 3, 4}, 2}]  = tokenize("1\n++2").
 
 dot_newline_operator_test() ->
   [{identifier, {1, 1, 4}, foo},
    {'.', {1, 4, 5}},
    {identifier, {2, 1, 2}, '+'},
-   {number, {2, 2, 3}, 1}] = tokenize("foo.\n+1"),
+   {decimal, {2, 2, 3}, 1}] = tokenize("foo.\n+1"),
   [{identifier, {1, 1, 4}, foo},
    {'.', {1, 4, 5}},
    {identifier, {2, 1, 2}, '+'},
-   {number, {2, 2, 3}, 1}] = tokenize("foo.#bar\n+1"),
+   {decimal, {2, 2, 3}, 1}] = tokenize("foo.#bar\n+1"),
   [{identifier, {1, 1, 4}, foo},
    {'.', {1, 4, 5}},
    {comment, {1, 5, 9}, "#bar"},
    {identifier, {2, 1, 2}, '+'},
-   {number, {2, 2, 3}, 1}] = tokenize("foo.#bar\n+1", [{preserve_comments, true}]).
+   {decimal, {2, 2, 3}, 1}] = tokenize("foo.#bar\n+1", [{preserve_comments, true}]).
 
 aliases_test() ->
   [{'aliases', {1, 1, 4}, ['Foo']}] = tokenize("Foo"),
@@ -158,8 +158,8 @@ addadd_test() ->
   [{identifier, {1, 1, 2}, x}, {two_op, {1, 3, 5}, '++'}, {identifier, {1, 6, 7}, y}] = tokenize("x ++ y").
 
 space_test() ->
-  [{op_identifier, {1, 1, 4}, foo}, {dual_op, {1, 5, 6}, '-'}, {number, {1, 6, 7}, 2}] = tokenize("foo -2"),
-  [{op_identifier, {1, 1, 4}, foo}, {dual_op, {1, 6, 7}, '-'}, {number, {1, 7, 8}, 2}] = tokenize("foo  -2").
+  [{op_identifier, {1, 1, 4}, foo}, {dual_op, {1, 5, 6}, '-'}, {decimal, {1, 6, 7}, 2}] = tokenize("foo -2"),
+  [{op_identifier, {1, 1, 4}, foo}, {dual_op, {1, 6, 7}, '-'}, {decimal, {1, 7, 8}, 2}] = tokenize("foo  -2").
 
 chars_test() ->
   [{char, {1, 1, 3}, 97}] = tokenize("?a"),
@@ -179,16 +179,16 @@ capture_test() ->
   [{capture_op, {1, 1, 2}, '&'},
    {identifier, {1, 2, 4}, '||'},
    {mult_op,    {1, 4, 5}, '/'},
-   {number,     {1, 5, 6}, 2}] = tokenize("&||/2"),
+   {decimal,     {1, 5, 6}, 2}] = tokenize("&||/2"),
   [{capture_op, {1, 1, 2}, '&'},
    {identifier, {1, 2, 4}, 'or'},
    {mult_op,    {1, 4, 5}, '/'},
-   {number,     {1, 5, 6}, 2}] = tokenize("&or/2"),
+   {decimal,     {1, 5, 6}, 2}] = tokenize("&or/2"),
   [{capture_op,{1,1,2},'&'},
    {unary_op,{1,2,5},'not'},
-   {number,{1,6,7},1},
+   {decimal,{1,6,7},1},
    {',',{1,7,8}},
-   {number,{1,9,10},2}] = tokenize("&not 1, 2").
+   {decimal,{1,9,10},2}] = tokenize("&not 1, 2").
 
 vc_merge_conflict_test() ->
   {1, "found an unexpected version control marker, please resolve the conflicts: ", "<<<<<<< HEAD"} =


### PR DESCRIPTION
@josevalim @whatyouhide still a WIP. Would like your feedback. Tried emitting different tokens `binary`, `octal` and `hex` but it makes the code more complicated and resulted in obscure compilation errors.

With this implementation, there are 14 test cases failing, but they should be quite easy to fix since we just need to insert the 4th `base` element in the `number` token tuple used in the test cases. The only downside is that the 4th element may be obscure to the uninformed reader.

```elixir
iex(1)> Code.string_to_quoted("0xEF", wrap_literals_in_blocks: true)
{:ok, {:__block__, [base: 16, line: 1], [239]}}
iex(3)> Code.string_to_quoted("1234", wrap_literals_in_blocks: true)
{:ok, {:__block__, [base: 10, line: 1], [1234]}}
iex(4)> Code.string_to_quoted("0b10", wrap_literals_in_blocks: true)
{:ok, {:__block__, [base: 2, line: 1], [2]}}
iex(5)> Code.string_to_quoted("0o27", wrap_literals_in_blocks: true)
{:ok, {:__block__, [base: 8, line: 1], [23]}}
```