### PR TITLE
Add Stream.intersperse/2

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1403,14 +1403,10 @@ defmodule Stream do
   """
   @spec intersperse(Enumerable.t, any) :: Enumerable.t
   def intersperse(enumerable, intersperse_element) do
-    Stream.transform(
-      enumerable,
-      false,
-      fn
-        element, true -> {[intersperse_element, element], true}
-        element, false -> {[element], true}
-      end
-    )
+    Stream.transform(enumerable, false, fn
+      element, true -> {[intersperse_element, element], true}
+      element, false -> {[element], true}
+    end)
   end
 
   ## Helpers

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1413,20 +1413,6 @@ defmodule Stream do
     )
   end
 
-  defp emit_entries_from_lazy(fun, [entry], head, state, tail) do
-    next_with_acc(fun, entry, head, state, tail)
-  end
-  defp emit_entries_from_lazy(fun, [entry | rest], head, state, tail) do
-    case next_with_acc(fun, entry, head, state, tail) do
-      {:cont, acc(head, state, tail)} ->
-        emit_entries_from_lazy(fun, rest, head, state, tail)
-      {:halt, _} = halt ->
-        halt
-      {:suspend, acc(head, state, tail)} ->
-        {:suspend, acc(head, {:suspended_with_pending_entries, rest, state}, tail)}
-    end
-  end
-
   ## Helpers
 
   @compile {:inline, lazy: 2, lazy: 3, lazy: 4}

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -1087,7 +1087,7 @@ test "transform/4 closes on nested errors" do
 
   test "intersperse/2 is zippable" do
     stream = Stream.intersperse(1..10, 0)
-    list   = Enum.to_list(stream)
+    list = Enum.to_list(stream)
     assert Enum.zip(list, list) == Enum.zip(stream, stream)
   end
 

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -1069,6 +1069,28 @@ test "transform/4 closes on nested errors" do
     assert Stream.with_index(nats) |> Enum.take(3) == [{1, 0}, {2, 1}, {3, 2}]
   end
 
+  test "intersperse/2 is lazy" do
+    assert lazy?(Stream.intersperse([], 0))
+  end
+
+  test "intersperse/2 on an empty list" do
+    assert Enum.to_list(Stream.intersperse([], 0)) == []
+  end
+
+  test "intersperse/2 on a single element list" do
+    assert Enum.to_list(Stream.intersperse([1], 0)) == [1]
+  end
+
+  test "intersperse/2 on a multiple elements list" do
+    assert Enum.to_list(Stream.intersperse(1..3, 0)) == [1, 0, 2, 0, 3]
+  end
+
+  test "intersperse/2 is zippable" do
+    stream = Stream.intersperse(1..10, 0)
+    list   = Enum.to_list(stream)
+    assert Enum.zip(list, list) == Enum.zip(stream, stream)
+  end
+
   defp lazy?(stream) do
     match?(%Stream{}, stream) or is_function(stream, 2)
   end


### PR DESCRIPTION
This PR adds `Stream.intersperse/2`. See [here](https://groups.google.com/forum/#!topic/elixir-lang-core/AsBKS2jgP4w) for the original proposal. 

I tried implementing it as José suggested, which is based on `%Stream{}` struct. Unfortunately, that won't work well for this case. Basically, `%Stream{}` is suitable to power stream which generates zero or one element for each input element. In this case, we need to generate two elements, and if this is powered by `%Stream{}`, in some cases (in particular when zipping the stream), we might end up loading most of the input enumerable into memory before it is needed. As a result, in this case `%Stream{}` based intersperse converges into an eager version.

Therefore, I opted for this version, which is slightly different from the one I proposed. This version uses `Stream.transform/3` to keep track of whether we're emitting the first element, or any other element. The benefit of this version (compared to the one I originally proposed) is that the accumulator never grows (it's either true or false).