### PR TITLE
Handle -compile module attributes when specified as a list

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -140,6 +140,8 @@ defmodule Mix.Tasks.Compile.Erlang do
         end
       {:attribute, _, :behaviour, behaviour} ->
         %{erl | behaviours: [behaviour | erl.behaviours]}
+      {:attribute, _, :compile, value} when is_list(value) ->
+        %{erl | compile: value ++ erl.compile}
       {:attribute, _, :compile, value} ->
         %{erl | compile: [value | erl.compile]}
       _ ->


### PR DESCRIPTION
I was trying to build ejabberd using Mix but many of the source files contain the following Erlang module attribute.

`-compile([{parse_transform, ejabberd_sql_pt}]).`

These options were not getting matched, and so were not being added to the Erlang module dependency tree resulting in ejabberd_sql_pt not being compiled early enough. 