### PR TITLE
Add check for correct types on System.cmd/3

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -595,6 +595,9 @@ defmodule System do
         {Collectable.t, exit_status :: non_neg_integer}
   def cmd(command, args, opts \\ []) when is_binary(command) and is_list(args) do
     assert_no_null_byte!(command, "System.cmd/3")
+    unless Enum.all?(args, &is_binary/1) do
+      raise ArgumentError, "all arguments for System.cmd/3 must be binaries"
+    end
     cmd = String.to_charlist(command)
 
     cmd =

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -85,6 +85,12 @@ defmodule SystemTest do
     end
   end
 
+  test "cmd/3 raises with non-binary arguments" do
+    assert_raise ArgumentError, ~r"all arguments for System.cmd/3 must be binaries", fn ->
+      System.cmd("ls", ['/usr'])
+    end
+  end
+
   if windows?() do
     test "cmd/2 win" do
       assert {"hello\r\n", 0} = System.cmd "cmd", ~w[/c echo hello]


### PR DESCRIPTION
Currently it's possible to pass a charlist instead of a binary as an
argument, and this shouldn't be possible.

Resolves #6367 