### PR TITLE
Implement Registry.register with pid 

### DIFF
--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -21,6 +21,11 @@ defmodule RegistryTest do
         assert length(Supervisor.which_children(registry)) == partitions
       end
 
+      test "registers process with pid", %{registry: registry} do
+        {:ok, agent} = Agent.start_link fn -> [] end
+        {:ok, pid} = Registry.register(agent, registry, "hello", :value)
+      end
+
       test "has unique registrations", %{registry: registry} do
         {:ok, pid} = Registry.register(registry, "hello", :value)
         assert is_pid(pid)


### PR DESCRIPTION
I propose a little change into `Registry` module. Today is not possible to register a process to registry with a pid. The process need to known how register itself. 

I am open to all comments to improve this feature.