### PR TITLE
Add heredoc type to heredoc list/binary literals

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -751,7 +751,7 @@ build_bin_string(Token) ->
 build_bin_string({bin_string, _Location, [H]} = Token, ExtraMeta) when is_binary(H) ->
   handle_literal(H, Token, ExtraMeta);
 build_bin_string({bin_string, Location, Args}, ExtraMeta) ->
-  Meta = meta_from_location(Location) ++ ExtraMeta,
+  Meta = ExtraMeta ++ meta_from_location(Location),
   {'<<>>', Meta, string_parts(Args)}.
 
 build_list_string(Token) ->
@@ -761,7 +761,7 @@ build_list_string({list_string, _Location, [H]} = Token, ExtraMeta) when is_bina
   handle_literal(elixir_utils:characters_to_list(H), Token, ExtraMeta);
 build_list_string({list_string, Location, Args}, ExtraMeta) ->
   Meta = meta_from_location(Location),
-  {{'.', Meta, ['Elixir.String', to_charlist]}, Meta, [{'<<>>', Meta ++ ExtraMeta, string_parts(Args)}]}.
+  {{'.', Meta, ['Elixir.String', to_charlist]}, Meta, [{'<<>>', ExtraMeta ++ Meta, string_parts(Args)}]}.
 
 build_quoted_atom({_, _Location, [H]} = Token, Safe) when is_binary(H) ->
   Op = binary_to_atom_op(Safe),

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -546,7 +546,7 @@ handle_char(_)  -> false.
 handle_heredocs(T, Line, Column, H, Scope, Tokens) ->
   case extract_heredoc_with_interpolation(Line, Column, Scope, true, T, H) of
     {ok, NewLine, NewColumn, Parts, Rest} ->
-      Token = {string_type(H), {Line, Column, NewColumn}, unescape_tokens(Parts)},
+      Token = {heredoc_type(H), {Line, Column, NewColumn}, unescape_tokens(Parts)},
       tokenize(Rest, NewLine, NewColumn, Scope, [Token | Tokens]);
     {error, Reason} ->
       {error, Reason, [H, H, H] ++ T, Tokens}
@@ -1028,6 +1028,9 @@ check_terminator(_, Terminators) ->
 
 string_type($") -> bin_string;
 string_type($') -> list_string.
+
+heredoc_type($") -> bin_heredoc;
+heredoc_type($') -> list_heredoc.
 
 sigil_terminator($() -> $);
 sigil_terminator($[) -> $];

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -144,6 +144,10 @@ defmodule CodeTest do
            {:ok, {:__block__, [line: 1], [[{:__block__, [format: :decimal, line: 1], [1]}]]}}
     assert Code.string_to_quoted("{:ok, :test}", wrap_literals_in_blocks: true) ==
            {:ok, {:__block__, [line: 1], [{{:__block__, [line: 1], [:ok]}, {:__block__, [line: 1], [:test]}}]}}
+    assert Code.string_to_quoted("\"\"\"\nhello\n\"\"\"", wrap_literals_in_blocks: true)
+           {:ok, {:__block__, [format: :bin_heredoc, line: 1], ["hello\n"]}}
+    assert Code.string_to_quoted("'''\nhello\n'''", wrap_literals_in_blocks: true)
+           {:ok, {:__block__, [format: :list_heredoc, line: 1], ['hello\n']}}
   end
 
   test "compile source" do


### PR DESCRIPTION
Sample code:
```
"""
this is a binary
"""

'''
this is a charlist
'''
```

Output from `Code.string_to_quoted/2` with `wrap_literals_in_blocks: true`:
```
{:ok,
 {:__block__, [],
  [{:__block__, [format: :bin_heredoc, line: 1], ["this is a binary\n"]},
   {:__block__, [format: :list_heredoc, line: 5], ['this is a charlist\n']}]}}
```

@josevalim @whatyouhide still a WIP. Would like your buy-in before adding tests. Thanks!