### PR TITLE
support :infinity timeout on Task streams

### DIFF
--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -512,6 +512,10 @@ defmodule TaskTest do
              [ok: 1, ok: 1, exit: :timeout, exit: :timeout]
       refute_received _
     end
+
+    test "streams an enumerable with infinite timeout" do
+      [ok: :ok] = Task.async_stream([1], fn _ -> :ok end, timeout: :infinity) |> Enum.to_list
+    end
   end
 
   for {desc, concurrency} <- ["==": 4, "<": 2, ">": 8] do


### PR DESCRIPTION
Fixes a regression introduced in 1.5. Relevant [thread on Elixir Forum](https://elixirforum.com/t/task-async-stream-timeout-infinity-and-1-5-0/7205) where it was reported.