### PR TITLE
Add mix test --slowest reporting to ExUnit

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -211,6 +211,10 @@ defmodule ExUnit do
 
     * `:seed` - an integer seed value to randomize the test suite;
 
+    * `:slowest` - prints timing information for the N slowest tests. Running
+      ExUnit with slow test reporting automatically runs in `trace` mode. It
+      is disabled by default;
+
     * `:stacktrace_depth` - configures the stacktrace depth to be used
       on formatting and reporters, defaults to `20`;
 
@@ -233,6 +237,7 @@ defmodule ExUnit do
   def configuration do
     Application.get_all_env(:ex_unit)
     |> put_seed()
+    |> put_slowest()
     |> put_max_cases()
   end
 
@@ -275,7 +280,7 @@ defmodule ExUnit do
   # Persists default values in application
   # environment before the test suite starts.
   defp persist_defaults(config) do
-    config |> Keyword.take([:seed, :max_cases]) |> configure()
+    config |> Keyword.take([:max_cases, :seed, :trace]) |> configure()
     config
   end
 
@@ -287,6 +292,14 @@ defmodule ExUnit do
 
   defp put_max_cases(opts) do
     Keyword.put(opts, :max_cases, max_cases(opts))
+  end
+
+  defp put_slowest(opts) do
+    if opts[:slowest] > 0 do
+      Keyword.put(opts, :trace, true)
+    else
+      opts
+    end
   end
 
   defp max_cases(opts) do

--- a/lib/ex_unit/mix.exs
+++ b/lib/ex_unit/mix.exs
@@ -27,6 +27,7 @@ defmodule ExUnit.Mixfile do
         formatters: [ExUnit.CLIFormatter],
         include: [],
         refute_receive_timeout: 100,
+        slowest: 0,
         stacktrace_depth: 20,
         timeout: 60_000,
         trace: false

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -67,6 +67,8 @@ defmodule Mix.Tasks.Test do
     * `--raise` - raises if the test suite failed
     * `--seed` - seeds the random number generator used to randomize tests order;
       `--seed 0` disables randomization
+    * `--slowest` - prints timing information for the N slowest tests; automatically
+      sets `--trace`
     * `--stale` - runs only tests which reference modules that changed since the
       last `test --stale`. You can read more about this option in the "Stale" section below.
     * `--timeout` - sets the timeout for the tests
@@ -168,7 +170,8 @@ defmodule Mix.Tasks.Test do
              exclude: :keep, seed: :integer, only: :keep, compile: :boolean,
              start: :boolean, timeout: :integer, raise: :boolean,
              deps_check: :boolean, archives_check: :boolean, elixir_version_check: :boolean,
-             stale: :boolean, listen_on_stdin: :boolean, formatter: :keep]
+             stale: :boolean, listen_on_stdin: :boolean, formatter: :keep,
+             slowest: :integer]
 
   @cover [output: "cover", tool: Cover]
 
@@ -265,7 +268,7 @@ defmodule Mix.Tasks.Test do
   end
 
   @option_keys [:trace, :max_cases, :include, :exclude,
-                :seed, :timeout, :formatters, :colors]
+                :seed, :timeout, :formatters, :colors, :slowest]
 
   @doc false
   def ex_unit_opts(opts) do


### PR DESCRIPTION
This adds a `--slowest N` CLI flag to `mix test`, which will print timing information for the slowest test times. To ensure that reported times are accurate enabling slow reporting will automatically set the suite in `--trace` mode.

The `slowest` setting defaults to `0`, disabling it for normal test runs. Setting it to any positive integer will report a cumalitve slow test time and display individual timings for each of the slowest tests.

**Notes**

This has been manually tested/inspected against the ex_unit test suite itself as I was developing it. When the suite is ran with `trace: true` it hangs on a timeout test, so I just ran it with slowest enabled and trace disabled. The timings were fairly consistent, even with async testing.

Here is sample output for an async run of the ex_unit suite:

<img width="1280" alt="screen shot 2017-07-26 at 8 52 53 am" src="https://user-images.githubusercontent.com/270831/28624838-02e79342-71e0-11e7-98f5-36ec97e3f949.png">

It seemed consistent with trace mode to use `ms` for each suite run. It is debatable whether the total run time should be in `ms` or `s`.

Closes #6334