### PR TITLE
Add OTP version to System.build_info/0

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -116,7 +116,7 @@ defmodule System do
 
   # Returns OTP version that Elixir was compiled with.
   defmacrop get_otp_release do
-    List.to_string(:erlang.system_info(:otp_release))
+    :erlang.list_to_binary(:erlang.system_info(:otp_release))
   end
 
   # Tries to run "git rev-parse --short HEAD". In the case of success returns
@@ -802,7 +802,7 @@ defmodule System do
   """
   @spec otp_release :: String.t
   def otp_release do
-    :erlang.list_to_binary :erlang.system_info(:otp_release)
+    :erlang.list_to_binary(:erlang.system_info(:otp_release))
   end
 
   @doc """

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -115,7 +115,7 @@ defmodule System do
   end
 
   # Returns OTP version that Elixir was compiled with.
-  defmacrop get_otp_version do
+  defmacrop get_otp_release do
     List.to_string(:erlang.system_info(:otp_release))
   end
 
@@ -175,7 +175,7 @@ defmodule System do
       date:        get_date(),
       revision:    revision(),
       version:     version(),
-      otp_version: get_otp_version()}
+      otp_release: get_otp_release()}
   end
 
   # Returns a string of the build info
@@ -183,7 +183,7 @@ defmodule System do
     {:ok, v} = Version.parse(version())
 
     revision_string = if v.pre != [] and revision() != "", do: " (#{revision()})", else: ""
-    otp_version_string = " (compiled with OTP #{get_otp_version()})"
+    otp_version_string = " (compiled with OTP #{get_otp_release()})"
 
     version() <> revision_string <> otp_version_string
   end

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -114,6 +114,11 @@ defmodule System do
     end
   end
 
+  # Returns OTP version that Elixir was compiled with.
+  defmacrop get_otp_version do
+    List.to_string(:erlang.system_info(:otp_release))
+  end
+
   # Tries to run "git rev-parse --short HEAD". In the case of success returns
   # the short revision hash. If that fails, returns an empty string.
   defmacrop get_revision do
@@ -166,10 +171,11 @@ defmodule System do
   """
   @spec build_info() :: map
   def build_info do
-    %{build:    build(),
-      date:     get_date(),
-      revision: revision(),
-      version:  version()}
+    %{build:       build(),
+      date:        get_date(),
+      revision:    revision(),
+      version:     version(),
+      otp_version: get_otp_version()}
   end
 
   # Returns a string of the build info

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -182,12 +182,10 @@ defmodule System do
   defp build do
     {:ok, v} = Version.parse(version())
 
-    cond do
-      ([] == v.pre) or ("" == revision()) ->
-        version()
-      true ->
-        "#{version()} (#{revision()})"
-    end
+    revision_string = if v.pre != [] and revision() != "", do: " (#{revision()})", else: ""
+    otp_version_string = " (compiled with OTP #{get_otp_version()})"
+
+    version() <> revision_string <> otp_version_string
   end
 
   @doc """

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -171,11 +171,13 @@ defmodule System do
   """
   @spec build_info() :: map
   def build_info do
-    %{build:       build(),
-      date:        get_date(),
-      revision:    revision(),
-      version:     version(),
-      otp_release: get_otp_release()}
+    %{
+      build: build(),
+      date: get_date(),
+      revision: revision(),
+      version: version(),
+      otp_release: get_otp_release()
+    }
   end
 
   # Returns a string of the build info

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -11,6 +11,7 @@ defmodule SystemTest do
     assert is_binary build_info[:date]
     assert is_binary build_info[:revision]
     assert is_binary build_info[:version]
+    assert is_binary build_info[:otp_version]
 
     if build_info[:revision] != "" do
       assert String.length(build_info[:revision]) >= 7

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -20,7 +20,7 @@ defmodule SystemTest do
     version_file = Path.join([__DIR__, "../../../..", "VERSION"]) |> Path.expand
     {:ok, version} = File.read(version_file)
     assert build_info[:version] == String.trim(version)
-    assert build_info[:build] != ""
+    assert build_info[:build] =~ "compiled with OTP"
   end
 
   test "cwd/0" do

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -11,7 +11,7 @@ defmodule SystemTest do
     assert is_binary build_info[:date]
     assert is_binary build_info[:revision]
     assert is_binary build_info[:version]
-    assert is_binary build_info[:otp_version]
+    assert is_binary build_info[:otp_release]
 
     if build_info[:revision] != "" do
       assert String.length(build_info[:revision]) >= 7


### PR DESCRIPTION
Example:

```
$ elixir -v
Erlang/OTP 20 [erts-9.0] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe] [kernel-poll:false]

Elixir 1.6.0-dev (9d3753ded) (compiled with OTP 20)
```