### PR TITLE
List applications in runtime_info

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -492,7 +492,7 @@ defmodule IEx.Helpers do
   def runtime_info(), do: runtime_info([:system, :memory, :limits])
 
   @doc """
-  Just like runtime_info/0, except accepts topic or a list of topics.
+  Just like `runtime_info/0`, except accepts topic or a list of topics.
   E.g. topic `:applications` will list the applications loaded.
   """
   def runtime_info(topic) when is_atom(topic) and topic in @runtime_info_topics do

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -515,6 +515,9 @@ defmodule IEx.Helpers do
     print_percentage("Ports", :port_count, :port_limit)
     print_percentage("Processes", :process_count, :process_limit)
 
+    print_pane("OTP Applications")
+    print_applications()
+
     IO.puts ""
     dont_display_result()
   end
@@ -529,6 +532,15 @@ defmodule IEx.Helpers do
   defp print_uptime() do
     IO.write pad_key("Uptime")
     :c.uptime()
+  end
+
+  defp print_applications() do
+    Application.started_applications()
+    |> Enum.sort_by(& elem(&1, 0))
+    |> Enum.each(fn {app, _, version} ->
+      IO.write pad_key(app)
+      IO.puts version
+    end)
   end
 
   defp print_percentage(key, min, max) do

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -507,7 +507,7 @@ defmodule IEx.Helpers do
   end
 
   defp print_runtime_info(topics) do
-    Enum.each(topics, & print_runtime_info_topic(&1))
+    Enum.each(topics, &print_runtime_info_topic/1)
     IO.puts ""
     print_topic_info(topics)
     IO.puts ""
@@ -559,7 +559,7 @@ defmodule IEx.Helpers do
     started = Application.started_applications()
 
     Application.loaded_applications()
-    |> Enum.sort_by(& elem(&1, 0))
+    |> Enum.sort_by(&elem(&1, 0))
     |> Enum.each(fn {app, _, version} = loaded ->
       IO.write pad_key(app)
       IO.write String.pad_trailing("#{version}", 20)


### PR DESCRIPTION
IMHO this could be very useful in a number of use-cases, especially when the dev environment differs from the deployment target.

<img width="259" alt="image" src="https://user-images.githubusercontent.com/173738/28645248-1f941bd2-725d-11e7-91f2-aadf16697c3a.png">
