### PR TITLE
Add option to generate a CLI skeleton app

### DIFF
--- a/lib/mix/test/mix/tasks/new_test.exs
+++ b/lib/mix/test/mix/tasks/new_test.exs
@@ -60,6 +60,37 @@ defmodule Mix.Tasks.NewTest do
     end
   end
 
+  test "new with --cli" do
+    in_tmp "new cli", fn ->
+      Mix.Tasks.New.run ["hello_world", "--cli"]
+
+      assert_file "hello_world/mix.exs", fn file ->
+        assert file =~ "app: :hello_world"
+        assert file =~ "version: \"0.1.0\""
+        assert file =~ "escript: [main_module: HelloWorld.CLI]"
+      end
+
+      assert_file "hello_world/README.md", ~r/# HelloWorld\n/
+      assert_file "hello_world/.gitignore"
+
+      assert_file "hello_world/lib/hello_world/cli.ex", fn file ->
+        assert file =~ "defmodule HelloWorld.CLI do"
+        assert file =~ "def main(_args) do"
+      end
+
+      assert_file "hello_world/test/test_helper.exs", ~r/ExUnit.start()/
+
+      assert_file "hello_world/test/hello_world/cli_test.exs", fn file ->
+        assert file =~ "defmodule HelloWorld.CLITest do"
+        assert file =~ "import ExUnit.CaptureIO"
+        assert file =~ "capture_io"
+      end
+
+      assert_received {:mix_shell, :info, ["* creating mix.exs"]}
+      assert_received {:mix_shell, :info, ["* creating lib/hello_world/cli.ex"]}
+    end
+  end
+
   test "new with --app" do
     in_tmp "new app", fn ->
       Mix.Tasks.New.run ["HELLO_WORLD", "--app", "hello_world"]


### PR DESCRIPTION
This PR adds a `--cli` option to `mix new` that generates a skeleton command-line application.

I gave some thought on whether to use `--escript` or `--cli`. I went for the latter because it's shorter and it's the least surprising — I assume the majority of Elixir users may not know about escript, but they may be familiar with CLI apps.

I wrote a few CLI apps in Elixir and found myself always reaching the docs because I don't remember how to turn a normal application into an executable. It's simply a matter of adding `escript: [main_module: MyApp.CLI]` into `mix.exs`, but I keep forgetting it. So I think a cli option that scaffolds that for you would be a time saver.

Another benefit of `--cli` is that it enforces the convention of having a `*.CLI` module, for a better separation of concerns. This is something Elixir itself does already (`Kernel.CLI`, `Mix.CLI`, `IEx.CLI`) so I thought it would be a good default to have.

Apart from that one convention, I haven't really made any assumptions, except maybe that users may want to use `ExUnit.CaptureIO` to test the module. But it think this is also good, it should encourage people to write some end-to-end tests that check the actual output instead of just unit tests.
