### PR TITLE
Fix operation passed to assert_no_null_byte

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -954,7 +954,7 @@ defmodule File do
   def rm_rf(path) do
     path
     |> IO.chardata_to_string()
-    |> assert_no_null_byte!("File.cp_r/3")
+    |> assert_no_null_byte!("File.rm_rf/1")
     |> do_rm_rf({:ok, []})
   end
 


### PR DESCRIPTION
"File.cp_r/3" currently shows up in the File.rm_rf null byte error.