### PR TITLE
Fix documentation formatting where ` follows \

### DIFF
--- a/lib/elixir/pages/Syntax Reference.md
+++ b/lib/elixir/pages/Syntax Reference.md
@@ -82,13 +82,13 @@ end
 
 ### Strings
 
-Strings in Elixir are written between double-quotes, such as `"foo"`. Any double-quote inside the string must be escaped with `\`. Strings support Unicode characters and are stored in UTF-8 encoding.
+Strings in Elixir are written between double-quotes, such as `"foo"`. Any double-quote inside the string must be escaped with `\ `. Strings support Unicode characters and are stored in UTF-8 encoding.
 
 Strings are always represented as themselves in the AST.
 
 ### Charlists
 
-Charlists in Elixir are written in single-quotes, such as `'foo'`. Any single-quote inside the string must be escaped with `\`. Charlists are a list of integers, each integer representing a Unicode character.
+Charlists in Elixir are written in single-quotes, such as `'foo'`. Any single-quote inside the string must be escaped with `\ `. Charlists are a list of integers, each integer representing a Unicode character.
 
 Charlists are always represented as themselves in the AST.
 

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -89,7 +89,7 @@ defmodule IEx do
 
     * via the `BREAK` menu (available via `Ctrl+C`) by typing `q`, pressing enter
     * by hitting `Ctrl+C`, `Ctrl+C`
-    * by hitting `Ctrl+\`
+    * by hitting `Ctrl+\ `
 
   If you are connected to remote shell, it remains alive after disconnection.
 


### PR DESCRIPTION
Found a formatting issue in the Syntax Reference documentation, where charlist does not get a proper section (see https://hexdocs.pm/elixir/syntax-reference.html#strings).

I found that the issue was caused by the preceeding `` `\` `` block. It can be fixed simply by adding a space, so it becomes `` `\ ` ``. I also applied this in the IEx documentation, which suffers from the same problem (see https://hexdocs.pm/iex/IEx.html#module-exiting-the-shell).

This also means warnings like `` lib/iex/lib/iex.ex:269: warning: Closing unclosed backquotes ` at end of input `` no longer appear when generating the documentation.