### PR TITLE
Fix Macro.to_string/2 for tuple calls

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -802,6 +802,11 @@ defmodule Macro do
     fun.(ast, to_string(left, fun) <> to_string([right], fun))
   end
 
+  # foo.{bar, baz}
+  def to_string({{:., _, [left, :{}]}, _, args} = ast, fun) do
+    fun.(ast, to_string(left, fun) <> ".{" <> args_to_string(args, fun) <> "}")
+  end
+
   # All other calls
   def to_string({target, _, args} = ast, fun) when is_list(args) do
     if sigil = sigil_call(ast, fun) do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -297,6 +297,11 @@ defmodule MacroTest do
       assert Macro.to_string(quote do: ~R"\n123") == ~s/~R"\\\\n123"/
     end
 
+    test "tuple call" do
+      assert Macro.to_string(quote do: alias Foo.{Bar, Baz, Bong}) == "alias(Foo.{Bar, Baz, Bong})"
+      assert Macro.to_string(quote do: foo Foo.{}) == "foo(Foo.{})"
+    end
+
     test "arrow" do
       assert Macro.to_string(quote do: foo(1, (2 -> 3))) == "foo(1, (2 -> 3))"
     end


### PR DESCRIPTION
Calls such as `Foo.{Bar, Baz}` (used in `alias Foo.{Bar, Baz}` for example) were badly formatted by `Macro.to_string/2`. That's fixed in this PR.