### PR TITLE
Fix URI.parse/1 to preserve empty fragments

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -435,28 +435,18 @@ defmodule URI do
     regex = Regex.recompile!(~r/(^(.*)@)?(\[[a-zA-Z0-9:.]*\]|[^:]*)(:(\d*))?/)
     components = Regex.run(regex, string || "")
 
-    destructure [_, _, userinfo, host, _, port], nillify(components)
-    host = if host, do: host |> String.trim_leading("[") |> String.trim_trailing("]")
-    port = if port, do: String.to_integer(port)
+    destructure [_, _, userinfo, host, _, port], components
+    userinfo = nillify(userinfo)
+    host = if nillify(host), do: host |> String.trim_leading("[") |> String.trim_trailing("]")
+    port = if nillify(port), do: String.to_integer(port)
 
     {userinfo, host, port}
   end
 
   # Regex.run returns empty strings sometimes. We want
   # to replace those with nil for consistency.
-  defp nillify(list) when is_list(list) do
-    for string <- list do
-      if byte_size(string) > 0, do: string
-    end
-  end
-
-  defp nillify("") do
-    nil
-  end
-
-  defp nillify(other) do
-    other
-  end
+  defp nillify(""), do: nil
+  defp nillify(other), do: other
 
   @doc """
   Returns the string representation of the given `URI` struct.

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -411,7 +411,7 @@ defmodule URI do
   def parse(string) when is_binary(string) do
     # From https://tools.ietf.org/html/rfc3986#appendix-B
     regex = Regex.recompile!(~r/^(([a-z][a-z0-9\+\-\.]*):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/i)
-    parts = nillify(Regex.run(regex, string))
+    parts = normalize_parts(string, Regex.run(regex, string))
 
     destructure [_, _, scheme, _, authority, path, _, query, _, fragment], parts
     {userinfo, host, port} = split_authority(authority)
@@ -424,6 +424,15 @@ defmodule URI do
       fragment: fragment, authority: authority,
       userinfo: userinfo, host: host, port: port
     }
+  end
+
+  defp normalize_parts(string, parts) do
+    if String.ends_with?(string, "#") do
+      [fragment | rest] = Enum.reverse(parts)
+      Enum.reverse([fragment | nillify(rest)])
+    else
+      nillify(parts)
+    end
   end
 
   # Split an authority into its userinfo, host and port parts.

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -200,6 +200,17 @@ defmodule URITest do
     test "downcases the scheme" do
       assert URI.parse("hTtP://google.com").scheme == "http"
     end
+
+    test "preserves empty fragments" do
+      ~w[
+          http://example.com#
+          http://example.com/#
+          http://example.com/test#
+      ]
+      |> Enum.each(fn uri -> 
+           assert URI.parse(uri).fragment == ""
+         end)
+    end
   end
 
   test "default_port/1,2" do


### PR DESCRIPTION
Problem: The current implementation removes empty fragments.

```elixir
iex> "http://example.com/test#" |> URI.parse |> to_string
"http://example.com/test"

iex> URI.parse("http://example.com/test#") == URI.parse("http://example.com/test")
true
```

[RFC 3986](https://tools.ietf.org/html/rfc3986#section-6.2.3) clearly says: _"[...] two URIs that differ only by the suffix "#" are considered different [...]_"

This is also serious problem with respect to the most common solution to the [httpRange-14 issue](https://en.wikipedia.org/wiki/HTTPRange-14#Use_of_.23). 

I've stumbled across this problem on several occasions during the development on [RDF.ex](https://github.com/marcelotto/rdf-ex).


