### PR TITLE
Add is_binary guard to String.length

### DIFF
--- a/lib/elixir/unicode/unicode.ex
+++ b/lib/elixir/unicode/unicode.ex
@@ -265,7 +265,7 @@ defmodule String.Unicode do
 
   # Length
 
-  def length(string) do
+  def length(string) when is_binary(string) do
     do_length(next_grapheme_size(string), 0)
   end
 


### PR DESCRIPTION
This produces a bit more readable message if not a string is passed into `String.length`, then failing in the `next_grapheme_size` function.