### PR TITLE
Add System.get_env!/1, which raises if the env var isn't set

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -363,6 +363,22 @@ defmodule System do
   end
 
   @doc """
+  Environment variable value.
+
+  Returns the value of the environment variable
+  `varname` as a binary or raises `RuntimeError`
+  if the environment variable is undefined.
+  """
+  @spec get_env!(binary) :: binary
+  def get_env!(varname) when is_binary(varname) do
+    case get_env(varname) do
+      nil ->
+        raise RuntimeError, message: "environment variable #{varname} is undefined"
+      binary -> binary
+    end
+  end
+
+  @doc """
   Erlang VM process identifier.
 
   Returns the process identifier of the current Erlang emulator

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -64,8 +64,12 @@ defmodule SystemTest do
 
   test "*_env/*" do
     assert System.get_env(@test_var) == nil
+    assert_raise RuntimeError, "environment variable #{@test_var} is undefined", fn ->
+      System.get_env!(@test_var)
+    end
     System.put_env(@test_var, "SAMPLE")
     assert System.get_env(@test_var) == "SAMPLE"
+    assert System.get_env!(@test_var) == "SAMPLE"
     assert System.get_env()[@test_var] == "SAMPLE"
 
     System.delete_env(@test_var)


### PR DESCRIPTION
There are times when forgetting to set an environment variable could
cause an app to silently misbehave. For example, if the environment
variable contains the salt value for hashing passwords and it's silently
converted to an empty string, the passwords will be unsalted.

In such situations, it's useful to explicitly raise an error about the
missing environment variable.