### PR TITLE
Replace options for option in ExUnit.Case

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -13,7 +13,7 @@ defmodule ExUnit.Case do
   This module must be used in other modules as a way to configure
   and prepare them for testing.
 
-  When used, it accepts the following options:
+  When used, it accepts the following option:
 
     * `:async` - configure this specific test case to run in parallel
       with other test cases. May be used for performance when this test case


### PR DESCRIPTION
There appears to be only one option when using ExUnit.Case, so replaced
`When used, it accepts the following options:`
with
`When used, it accepts the following option:`.