### PR TITLE
Raise exception when passing negative delta to assert_in_delta/4

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -611,7 +611,7 @@ defmodule ExUnit.Assertions do
   """
   def assert_in_delta(value1, value2, delta, message \\ nil)
   def assert_in_delta(_, _, delta, _) when delta < 0 do
-    raise ArgumentError, "all deltas must be positive. Did you mean #{-delta}?"
+    raise ArgumentError, "delta must always be a positive number, got: #{inspect(delta)}"
   end
   def assert_in_delta(value1, value2, delta, message) do
     diff = abs(value1 - value2)

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -600,9 +600,7 @@ defmodule ExUnit.Assertions do
   end
 
   @doc """
-  Asserts that `value1` and `value2` differ by no more than `delta`. All `delta`s
-  must be positive, and will raise an `ArgumentError` if a negative `delta` is
-  passed as the third argument to this assertion.
+  Asserts that `value1` and `value2` differ by no more than `delta`.
 
 
   ## Examples
@@ -613,7 +611,7 @@ defmodule ExUnit.Assertions do
   """
   def assert_in_delta(value1, value2, delta, message \\ nil)
   def assert_in_delta(_, _, delta, _) when delta < 0 do
-    raise ArgumentError, "All deltas must be positive. Did you mean #{abs(delta)}?"
+    raise ArgumentError, "all deltas must be positive. Did you mean #{abs(delta)}?"
   end
   def assert_in_delta(value1, value2, delta, message) do
     diff = abs(value1 - value2)

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -600,7 +600,9 @@ defmodule ExUnit.Assertions do
   end
 
   @doc """
-  Asserts that `value1` and `value2` differ by no more than `delta`.
+  Asserts that `value1` and `value2` differ by no more than `delta`. All `delta`s
+  must be positive, and will raise an `ArgumentError` if a negative `delta` is
+  passed as the third argument to this assertion.
 
 
   ## Examples
@@ -609,7 +611,11 @@ defmodule ExUnit.Assertions do
       assert_in_delta 10, 15, 4
 
   """
-  def assert_in_delta(value1, value2, delta, message \\ nil) do
+  def assert_in_delta(value1, value2, delta, message \\ nil)
+  def assert_in_delta(_, _, delta, _) when delta < 0 do
+    raise ArgumentError, "All deltas must be positive. Did you mean #{abs(delta)}?"
+  end
+  def assert_in_delta(value1, value2, delta, message) do
     diff = abs(value1 - value2)
     message = message ||
       "Expected the difference between #{inspect value1} and " <>

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -611,7 +611,7 @@ defmodule ExUnit.Assertions do
   """
   def assert_in_delta(value1, value2, delta, message \\ nil)
   def assert_in_delta(_, _, delta, _) when delta < 0 do
-    raise ArgumentError, "all deltas must be positive. Did you mean #{abs(delta)}?"
+    raise ArgumentError, "all deltas must be positive. Did you mean #{-delta}?"
   end
   def assert_in_delta(value1, value2, delta, message) do
     diff = abs(value1 - value2)

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -599,6 +599,12 @@ defmodule ExUnit.AssertionsTest do
     true = assert_in_delta(1.1, 1.2, 0.2)
   end
 
+  test "assert in delta raises when passing a negative delta" do
+    assert_raise ArgumentError, fn ->
+      assert_in_delta(1.1, 1.2, -0.2)
+    end
+  end
+
   test "assert in delta error" do
     "This should never be tested" = assert_in_delta(10, 12, 1)
   rescue


### PR DESCRIPTION
I agreed with @josevalim's idea of raising an exception here rather
than coercing the negative delta, so I implemented that. As a user, I
would find that coercion to be unexpected behavior, and I personally
felt the value of being explicit here outweighed the convenience of the
coercion. I did, however, put in the exception message a helpful hint
in the case that the user did want the absolute value of that negative
delta instead.

Fixes #6439