### PR TITLE
Update docs `Enum.reduce/2`

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1750,7 +1750,7 @@ defmodule Enum do
   the specified function for enumerables that are one-element long.
 
   If you wish to use another value for the accumulator, use
-  `Enumerable.reduce/3`.
+  `Enum.reduce/3`.
 
   ## Examples
 


### PR DESCRIPTION
The documentation for `Enum.reduce/2` references `Enumerable.reduce/3` for use of a different accumulator. However, the `Enum` module has a `reduce/3` function that does exactly this, so it makes more sense to reference that one instead of the more complicated `Enumerable.reduce/3` function.