### PR TITLE
Make Kernel.!/1 (boolean not) guard-safe

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1470,7 +1470,7 @@ defmodule Kernel do
   Receives any argument (not just booleans) and returns `true` if the argument
   is `false` or `nil`; returns `false` otherwise.
 
-  Not allowed in guard clauses.
+  Allowed in guard tests.
 
   ## Examples
 
@@ -1484,21 +1484,35 @@ defmodule Kernel do
   defmacro !(value)
 
   defmacro !({:!, _, [value]}) do
-    optimize_boolean(quote do
-      case unquote(value) do
-        x when x in [false, nil] -> false
-        _ -> true
-      end
-    end)
+    case Macro.Env.in_guard?(__CALLER__) do
+      true ->
+        quote do
+          unquote(value) not in [false, nil]
+        end
+      _ ->
+        optimize_boolean(quote do
+          case unquote(value) do
+            x when x in [false, nil] -> false
+            _ -> true
+          end
+        end)
+    end
   end
 
   defmacro !(value) do
-    optimize_boolean(quote do
-      case unquote(value) do
-        x when x in [false, nil] -> true
-        _ -> false
-      end
-    end)
+    case Macro.Env.in_guard?(__CALLER__) do
+      true ->
+        quote do
+          unquote(value) in [false, nil]
+        end
+      _ ->
+        optimize_boolean(quote do
+          case unquote(value) do
+            x when x in [false, nil] -> true
+            _ -> false
+          end
+        end)
+    end
   end
 
   @doc """

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -238,6 +238,28 @@ defmodule KernelTest do
     assert_raise BadBooleanError, fn -> 0 or 1 end
   end
 
+  describe "!/1" do
+    def not_fun(x) when !x, do: true
+    def not_fun(_), do: false
+
+    test "! in guard" do
+      assert not_fun(false)
+      assert not_fun(nil)
+      refute not_fun(true)
+      refute not_fun(1)
+    end
+
+    def not_not_fun(x) when !!x, do: true
+    def not_not_fun(_), do: false
+
+    test "!! in guard" do
+      assert not_not_fun(true)
+      assert not_not_fun(1)
+      refute not_not_fun(false)
+      refute not_not_fun(nil)
+    end
+  end
+
   describe "in/2" do
     test "with literals on right side" do
       assert 2 in [1, 2, 3]


### PR DESCRIPTION
This change makes it possible to do `def fun(x) when !x, do: "x was falsy"` or `def fun(x) when !!x, do: "x was truthy"`.

After macro expansion, `when !x` should become `when x === false or x === nil`.

I tried to look around in the issue tracker and mailing list if there was discussion on reasons for not making it guard-safe before, but the name of the macro is defeating my search skills.

My experience in chat rooms and other forums is that people are surprised they cannot use `!value` in a guard. They are also sometimes confused by the error message `invalid expression in guard, case is not allowed in guards`, since the case is from the expansion of `!`, and they don't see it in their source.