### PR TITLE
Macro.underscore("Foo_Bar") == "foo__bar" when likely "foo_bar" expected

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1308,8 +1308,8 @@ defmodule Macro do
   end
 
 
-  defp do_underscore(<<h, t, rest::binary>>, _)
-      when (h >= ?A and h <= ?Z) and not (t >= ?A and t <= ?Z) and t != ?. and t != ?_ do
+  defp do_underscore(<<h, t, rest::binary>>, prev)
+      when (h >= ?A and h <= ?Z) and not (t >= ?A and t <= ?Z) and t != ?. and t != ?_ and prev != ?_ do
     <<?_, to_lower_char(h), t>> <> do_underscore(rest, t)
   end
   defp do_underscore(<<h, t::binary>>, prev)

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -685,6 +685,7 @@ defmodule MacroTest do
     assert Macro.underscore("foo_bar") == "foo_bar"
     assert Macro.underscore("Foo") == "foo"
     assert Macro.underscore("FooBar") == "foo_bar"
+    assert Macro.underscore("Foo_Bar") == "foo_bar"
     assert Macro.underscore("FOOBar") == "foo_bar"
     assert Macro.underscore("FooBAR") == "foo_bar"
     assert Macro.underscore("FOO_BAR") == "foo_bar"


### PR DESCRIPTION
This commit updates Macro.underscore/1 to produce the expected output
of formatting names which already contains ?_ before a capitalized
letter.  Additional test is added.