### PR TITLE
Add current stacktrace to whereami/0

### DIFF
--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -114,9 +114,10 @@ defmodule IEx.Evaluator do
     env = opts[:env] || :elixir.env_for_eval(file: "iex")
     env = %{env | match_vars: :apply}
     {_, _, env, scope} = :elixir.eval('import IEx.Helpers', [], env)
+    stacktrace = opts[:stacktrace]
 
     binding = Keyword.get(opts, :binding, [])
-    state = %{binding: binding, scope: scope, env: env, server: server, history: history}
+    state = %{binding: binding, scope: scope, env: env, server: server, history: history, stacktrace: stacktrace}
 
     case opts[:dot_iex_path] do
       ""   -> state
@@ -210,8 +211,8 @@ defmodule IEx.Evaluator do
   defp put_whereami(%{env: %{file: "iex"}}) do
     :ok
   end
-  defp put_whereami(%{env: %{file: file, line: line}}) do
-    Process.put(:iex_whereami, {file, line})
+  defp put_whereami(%{env: %{file: file, line: line}, stacktrace: stacktrace}) do
+    Process.put(:iex_whereami, {file, line, stacktrace})
   end
 
   defp handle_eval({:ok, forms}, code, line, iex_state, state) do


### PR DESCRIPTION
Prints the current stacktrace with `whereami/0` output. See #6390.

```
iex> whereami
Location: lib/Foo.ex:17

    15:   def bar do
    16:     require IEx
    17:     IEx.pry
    18:     :blah
    19:   end

Stacktrace:

    (Foo) lib/foo.ex:15: Foo.bar/0
    (Baz) lib/baz.ex:3: Baz.qux/0
```