### PR TITLE
Fix old initialisation for match_vars

### DIFF
--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -23,7 +23,7 @@ expand(BitstrMeta, Fun, [{'::', Meta, [Left, Right]} | T], Acc, E, RequireSize) 
   {ER, MatchSize} =
     case E of
       {EExtracted, _} -> {EExtracted, false}; %% expand_arg,  no assigns
-      _               -> {E#{context := nil, match_vars := warn}, T /= []} %% expand, revert assigns
+      _ -> {E#{context := nil, match_vars := warn}, T /= []} %% expand, revert assigns
     end,
 
   ERight = expand_specs(expr_type(ELeft), Meta, Right, ER, RequireSize or MatchSize),

--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -22,8 +22,8 @@ expand(BitstrMeta, Fun, [{'::', Meta, [Left, Right]} | T], Acc, E, RequireSize) 
   %% on subparts, however we can't assign new variables.
   {ER, MatchSize} =
     case E of
-      {EExtracted, _} -> {EExtracted, false};          %% expand_arg,  no assigns
-      _               -> {E#{context := nil}, T /= []} %% expand, revert assigns
+      {EExtracted, _} -> {EExtracted, false}; %% expand_arg,  no assigns
+      _               -> {E#{context := nil, match_vars := warn}, T /= []} %% expand, revert assigns
     end,
 
   ERight = expand_specs(expr_type(ELeft), Meta, Right, ER, RequireSize or MatchSize),

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -648,6 +648,17 @@ defmodule Kernel.ErrorsTest do
     assert_compile_fail CompileError,
       "nofile:1: cannot use ^x outside of match clauses",
       'x = 8; <<a, b::size(^x)>> = <<?a, ?b>>'
+
+    # There is a warn generated on this because the expansion from ambiguous variable to
+    # a function call that is necessary to catch the error, fixing the warn creates
+    # a false-positive result.
+    assert_compile_fail CompileError,
+      "nofile:2: size in bitstring expects an integer or a variable as argument, got: bar()",
+      '''
+      defmodule Kernel.ErrorsTest.InvalidSizeInBitstring do
+        def foo(<<_::size(bar)>>), do: :ok
+      end
+      '''
   end
 
   test "end of expression" do

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -3,8 +3,6 @@ Code.require_file "../test_helper.exs", __DIR__
 defmodule Kernel.ErrorsTest do
   use ExUnit.Case, async: true
 
-  import ExUnit.CaptureIO
-
   defmacro hello do
     quote location: :keep do
       def hello, do: :world
@@ -650,17 +648,6 @@ defmodule Kernel.ErrorsTest do
     assert_compile_fail CompileError,
       "nofile:1: cannot use ^x outside of match clauses",
       'x = 8; <<a, b::size(^x)>> = <<?a, ?b>>'
-
-    warning = capture_io(:stderr, fn ->
-      assert_compile_fail CompileError,
-        "nofile:2: size in bitstring expects an integer or a variable as argument, got: bar()",
-        '''
-        defmodule Kernel.ErrorsTest.InvalidSizeInBitstring do
-          def foo(<<_::size(bar)>>), do: :ok
-        end
-        '''
-    end)
-    assert warning =~ "variable \"bar\" does not exist and is being expanded to \"bar()\""
   end
 
   test "end of expression" do

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -1180,6 +1180,13 @@ defmodule Kernel.ExpansionTest do
     assert_raise CompileError, ~r"unhandled operator ->", fn ->
       expand(quote do: (foo -> bar))
     end
+
+    assert_raise CompileError,
+      ~r"size in bitstring expects an integer or a variable as argument, got: bar\(\)",
+      fn ->
+        assert expand(quote do: <<x::size(bar)>>) ==
+               "variable \"bar\" does not exist and is being expanded to \"bar\(\)\""
+      end
   end
 
   ## Helpers

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -1182,10 +1182,11 @@ defmodule Kernel.ExpansionTest do
     end
 
     assert_raise CompileError,
-      ~r"size in bitstring expects an integer or a variable as argument, got: bar\(\)",
+      ~r"size in bitstring expects an integer or a variable as argument, got: foo\(\)",
       fn ->
-        assert expand(quote do: <<x::size(bar)>>) ==
-               "variable \"bar\" does not exist and is being expanded to \"bar\(\)\""
+        expand(quote do
+          fn <<_::size(foo)>> -> :ok end
+        end)
       end
   end
 


### PR DESCRIPTION
The error was introduced with the changes on 35fae4790440cab90b85a99c04fad8de6b0f1d1a

Resolves #6450