### PR TITLE
Remove extraneous 'is' from Supervisor moduledoc

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -260,7 +260,7 @@ defmodule Supervisor do
 
   Notice that supervisor that reached maximum restart intensity will exit with
   `:shutdown` reason. In this case the supervisor will only be restarted if its
-  child specification was defined with the `:restart` option is set to `:permanent`
+  child specification was defined with the `:restart` option set to `:permanent`
   (the default).
 
   ## Module-based supervisors


### PR DESCRIPTION
Hey all,

this one is in a longer phrase, but it removes an `is` near its end.

From

```
In this case the supervisor will only be restarted if its
child specification was defined with the `:restart` option is set to `:permanent`
(the default).
```

to 

```
In this case the supervisor will only be restarted if its
child specification was defined with the `:restart` option set to `:permanent`
(the default).
```

Cheers!