### PR TITLE
Tweak performance of `Enumerable.member?/2` for Map

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3188,7 +3188,7 @@ defimpl Enumerable, for: Map do
   end
 
   def member?(map, {key, value}) do
-    {:ok, match?({:ok, ^value}, :maps.find(key, map))}
+    {:ok, match?(%{^key => ^value}, map)}
   end
 
   def member?(_map, _other) do


### PR DESCRIPTION
Recently someone(@dploop) told me that matching a key is much faster than use `maps:find/2` in erlang. So I did a little benchmark. See:
https://gist.github.com/Kabie/e34db1b4722211d1c27d2becbacce325

The pattern match wins in most cases. Only situations like when map is a large flat map(map size around 20~31) and the key does not exist, pattern match is slower. This is an acceptable trade off IMO.