### PR TITLE
Remove double space from Supervisor doc

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -524,7 +524,7 @@ defmodule Supervisor do
   `{:ok, child, info}`, or `:ignore`) this function returns
   `{:ok, pid}`, where `pid` is the PID of the supervisor. If the supervisor
   is given a name and a process with the specified name already exists,
-  the function returns `{:error,  {:already_started, pid}}`, where `pid`
+  the function returns `{:error, {:already_started, pid}}`, where `pid`
   is the PID of that process.
 
   If the start function of any of the child processes fails or returns an error


### PR DESCRIPTION
Little double space I found while studying the source code for Supervisor.

I did take note of Valim's request to aggregate these tiny commits into one PR whenever possible. I only happened to find one this time around.
