### PR TITLE
Consistently refer to callback functions as fun

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -182,8 +182,8 @@ defmodule List do
 
   """
   @spec foldl([elem], acc, (elem, acc -> acc)) :: acc when elem: var, acc: var
-  def foldl(list, acc, function) when is_list(list) and is_function(function) do
-    :lists.foldl(function, acc, list)
+  def foldl(list, acc, fun) when is_list(list) and is_function(fun) do
+    :lists.foldl(fun, acc, list)
   end
 
   @doc """
@@ -197,8 +197,8 @@ defmodule List do
 
   """
   @spec foldr([elem], acc, (elem, acc -> acc)) :: acc when elem: var, acc: var
-  def foldr(list, acc, function) when is_list(list) and is_function(function) do
-    :lists.foldr(function, acc, list)
+  def foldr(list, acc, fun) when is_list(list) and is_function(fun) do
+    :lists.foldr(fun, acc, list)
   end
 
   @doc """

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -516,12 +516,12 @@ defmodule Map do
   defdelegate merge(map1, map2), to: :maps
 
   @doc """
-  Merges two maps into one, resolving conflicts through the given `callback`.
+  Merges two maps into one, resolving conflicts through the given `fun`.
 
   All keys in `map2` will be added to `map1`. The given function will be invoked
   when there are duplicate keys; its arguments are `key` (the duplicate key),
   `value1` (the value of `key` in `map1`), and `value2` (the value of `key` in
-  `map2`). The value returned by `callback` is used as the value under `key` in
+  `map2`). The value returned by `fun` is used as the value under `key` in
   the resulting map.
 
   ## Examples
@@ -533,14 +533,14 @@ defmodule Map do
 
   """
   @spec merge(map, map, (key, value, value -> value)) :: map
-  def merge(map1, map2, callback) when is_function(callback, 3) do
+  def merge(map1, map2, fun) when is_function(fun, 3) do
     if map_size(map1) > map_size(map2) do
       :maps.fold fn key, val2, acc ->
-        update(acc, key, val2, fn val1 -> callback.(key, val1, val2) end)
+        update(acc, key, val2, fn val1 -> fun.(key, val1, val2) end)
       end, map1, map2
     else
       :maps.fold fn key, val2, acc ->
-        update(acc, key, val2, fn val1 -> callback.(key, val2, val1) end)
+        update(acc, key, val2, fn val1 -> fun.(key, val2, val1) end)
       end, map2, map1
     end
   end


### PR DESCRIPTION
In collections, use `fun` instead of `callback` or `function` for consistency.