### PR TITLE
Merge integer tokens into the "int" token

### DIFF
--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -113,15 +113,6 @@ parse_error(Line, File, {ErrorPrefix, ErrorSuffix}, Token) when is_binary(ErrorP
   Message = <<ErrorPrefix/binary, Token/binary, ErrorSuffix/binary >>,
   raise(Line, File, 'Elixir.SyntaxError', Message);
 
-%% Misplaced char tokens (e.g., {char, _, 97}) are translated by Erlang into
-%% the char literal (i.e., the token in the previous example becomes $a),
-%% because {char, _, _} is a valid Erlang token for an Erlang char literal. We
-%% want to represent that token as ?a in the error, according to the Elixir
-%% syntax.
-parse_error(Line, File, <<"syntax error before: ">>, <<$$, Char/binary>>) ->
-  Message = <<"syntax error before: ?", Char/binary>>,
-  raise(Line, File, 'Elixir.SyntaxError', Message);
-
 %% Everything else is fine as is
 parse_error(Line, File, Error, Token) when is_binary(Error), is_binary(Token) ->
   Message = <<Error/binary, Token/binary >>,

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -32,7 +32,7 @@ Terminals
   identifier kw_identifier kw_identifier_safe kw_identifier_unsafe bracket_identifier
   paren_identifier do_identifier block_identifier
   fn 'end' aliases
-  char atom atom_safe atom_unsafe bin_string list_string sigil
+  atom atom_safe atom_unsafe bin_string list_string sigil
   bin_heredoc list_heredoc
   dot_call_op op_identifier
   comp_op at_op unary_op and_op or_op arrow_op match_op in_op in_match_op
@@ -261,7 +261,6 @@ access_expr -> sigil : build_sigil('$1').
 access_expr -> max_expr : '$1'.
 
 %% Augment integer literals with representation format if wrap_literals_in_blocks option is true
-number -> char : handle_literal(?exprs('$1'), '$1', [{format, char}]).
 number -> int : handle_literal(integer_value('$1'), '$1', [{original, ?exprs('$1')}]).
 number -> float : handle_literal(?exprs('$1'), '$1').
 
@@ -634,8 +633,7 @@ handle_literal(Literal, Token, ExtraMeta) ->
     false -> Literal
   end.
 
-integer_value(Token) ->
-  {_, _, Value} = element(2, Token),
+integer_value({_, {_, _, Value}, _}) ->
   Value.
 
 %% Operators

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -40,7 +40,7 @@ Terminals
   capture_op rel_op
   'true' 'false' 'nil' 'do' eol ';' ',' '.'
   '(' ')' '[' ']' '{' '}' '<<' '>>' '%{}' '%'
-  integer float
+  int float
   .
 
 Rootsymbol grammar.
@@ -237,7 +237,7 @@ no_parens_zero_expr -> dot_identifier : build_identifier('$1', nil).
 %% marks identifiers followed by brackets as bracket_identifier.
 access_expr -> bracket_at_expr : '$1'.
 access_expr -> bracket_expr : '$1'.
-access_expr -> capture_op_eol integer : build_unary_op('$1', integer_value('$2')).
+access_expr -> capture_op_eol int : build_unary_op('$1', integer_value('$2')).
 access_expr -> fn_eoe stab end_eoe : build_fn('$1', reverse('$2')).
 access_expr -> open_paren stab close_paren : build_stab(reverse('$2')).
 access_expr -> open_paren stab ';' close_paren : build_stab(reverse('$2')).
@@ -262,7 +262,7 @@ access_expr -> max_expr : '$1'.
 
 %% Augment integer literals with representation format if wrap_literals_in_blocks option is true
 number -> char : handle_literal(?exprs('$1'), '$1', [{format, char}]).
-number -> integer : handle_literal(integer_value('$1'), '$1', [{original, ?exprs('$1')}]).
+number -> int : handle_literal(integer_value('$1'), '$1', [{original, ?exprs('$1')}]).
 number -> float : handle_literal(?exprs('$1'), '$1').
 
 %% Aliases and properly formed calls. Used by map_expr.

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -40,7 +40,7 @@ Terminals
   capture_op rel_op
   'true' 'false' 'nil' 'do' eol ';' ',' '.'
   '(' ')' '[' ']' '{' '}' '<<' '>>' '%{}' '%'
-  binary octal decimal float hex
+  integer float
   .
 
 Rootsymbol grammar.
@@ -237,7 +237,7 @@ no_parens_zero_expr -> dot_identifier : build_identifier('$1', nil).
 %% marks identifiers followed by brackets as bracket_identifier.
 access_expr -> bracket_at_expr : '$1'.
 access_expr -> bracket_expr : '$1'.
-access_expr -> capture_op_eol decimal : build_unary_op('$1', ?exprs('$2')).
+access_expr -> capture_op_eol integer : build_unary_op('$1', integer_value('$2')).
 access_expr -> fn_eoe stab end_eoe : build_fn('$1', reverse('$2')).
 access_expr -> open_paren stab close_paren : build_stab(reverse('$2')).
 access_expr -> open_paren stab ';' close_paren : build_stab(reverse('$2')).
@@ -262,10 +262,7 @@ access_expr -> max_expr : '$1'.
 
 %% Augment integer literals with representation format if wrap_literals_in_blocks option is true
 number -> char : handle_literal(?exprs('$1'), '$1', [{format, char}]).
-number -> binary : handle_literal(?exprs('$1'), '$1', [{format, binary}]).
-number -> octal : handle_literal(?exprs('$1'), '$1', [{format, octal}]).
-number -> decimal : handle_literal(?exprs('$1'), '$1', [{format, decimal}]).
-number -> hex : handle_literal(?exprs('$1'), '$1', [{format, hex}]).
+number -> integer : handle_literal(integer_value('$1'), '$1', [{original, ?exprs('$1')}]).
 number -> float : handle_literal(?exprs('$1'), '$1').
 
 %% Aliases and properly formed calls. Used by map_expr.
@@ -636,6 +633,10 @@ handle_literal(Literal, Token, ExtraMeta) ->
     true -> {'__block__', ExtraMeta ++ meta_from_token(Token), [Literal]};
     false -> Literal
   end.
+
+integer_value(Token) ->
+  {_, _, Value} = element(2, Token),
+  Value.
 
 %% Operators
 

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -166,17 +166,17 @@ tokenize(("<<<<<<<" ++ _) = Original, Line, 1, _Scope, Tokens) ->
 
 tokenize([$0, $x, H | T], Line, Column, Scope, Tokens) when ?is_hex(H) ->
   {Rest, Number, OriginalRepresentation, Length} = tokenize_hex(T, [H], 1),
-  Token = {integer, {Line, {Column, Column + 2 + Length}, Number}, OriginalRepresentation},
+  Token = {int, {Line, {Column, Column + 2 + Length}, Number}, OriginalRepresentation},
   tokenize(Rest, Line, Column + 2 + Length, Scope, [Token | Tokens]);
 
 tokenize([$0, $b, H | T], Line, Column, Scope, Tokens) when ?is_bin(H) ->
   {Rest, Number, OriginalRepresentation, Length} = tokenize_bin(T, [H], 1),
-  Token = {integer, {Line, {Column, Column + 2 + Length}, Number}, OriginalRepresentation},
+  Token = {int, {Line, {Column, Column + 2 + Length}, Number}, OriginalRepresentation},
   tokenize(Rest, Line, Column + 2 + Length, Scope, [Token | Tokens]);
 
 tokenize([$0, $o, H | T], Line, Column, Scope, Tokens) when ?is_octal(H) ->
   {Rest, Number, OriginalRepresentation, Length} = tokenize_octal(T, [H], 1),
-  Token = {integer, {Line, {Column, Column + 2 + Length}, Number}, OriginalRepresentation},
+  Token = {int, {Line, {Column, Column + 2 + Length}, Number}, OriginalRepresentation},
   tokenize(Rest, Line, Column + 2 + Length, Scope, [Token | Tokens]);
 
 % Comments
@@ -433,7 +433,7 @@ tokenize([H | T], Line, Column, Scope, Tokens) when ?is_digit(H) ->
     {error, Reason, Number} ->
       {error, {Line, Reason, Number}, T, Tokens};
     {Rest, Number, Length} when is_integer(Number) ->
-      Token = {integer, {Line, {Column, Column + Length}, Number}, integer_to_list(Number)},
+      Token = {int, {Line, {Column, Column + Length}, Number}, integer_to_list(Number)},
       tokenize(Rest, Line, Column + Length, Scope, [Token | Tokens]);
     {Rest, Number, Length} ->
       Token = {float, {Line, {Column, Column + Length}, nil}, Number},

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -231,7 +231,7 @@ tokenize([$~, S, H | _] = Original, Line, Column, _Scope, Tokens) when ?is_upcas
 
 tokenize([$?, $\\, H | T], Line, Column, Scope, Tokens) ->
   Char = elixir_interpolation:unescape_map(H),
-  Token = {char, {Line, {Column, Column + 3}, nil}, Char},
+  Token = {int, {Line, {Column, Column + 3}, Char}, [$?, $\\, H]},
   tokenize(T, Line, Column + 3, Scope, [Token | Tokens]);
 
 tokenize([$?, Char | T], Line, Column, Scope, Tokens) ->
@@ -243,7 +243,7 @@ tokenize([$?, Char | T], Line, Column, Scope, Tokens) ->
     false ->
       ok
   end,
-  Token = {char, {Line, {Column, Column + 2}, nil}, Char},
+  Token = {int, {Line, {Column, Column + 2}, Char}, [$?, Char]},
   tokenize(T, Line, Column + 2, Scope, [Token | Tokens]);
 
 % Heredocs

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -164,32 +164,20 @@ tokenize(("<<<<<<<" ++ _) = Original, Line, 1, _Scope, Tokens) ->
 
 % Base integers
 
-% tokenize([$0, $x, H | T], Line, Column, Scope, Tokens) when ?is_hex(H) ->
-%   {Rest, Number, OriginalRepresentation, Length} = tokenize_hex(T, [H], 1),
-%   Token = {integer, {Line, {Column, Column + 2 + Length}, Number}, OriginalRepresentation},
-%   tokenize(Rest, Line, Column + 2 + Length, Scope, [Token | Tokens]);
-%
-% tokenize([$0, $b, H | T], Line, Column, Scope, Tokens) when ?is_bin(H) ->
-%   {Rest, Number, OriginalRepresentation, Length} = tokenize_bin(T, [H], 1),
-%   Token = {integer, {Line, {Column, Column + 2 + Length}, Number}, OriginalRepresentation},
-%   tokenize(Rest, Line, Column + 2 + Length, Scope, [Token | Tokens]);
-%
-% tokenize([$0, $o, H | T], Line, Column, Scope, Tokens) when ?is_octal(H) ->
-%   {Rest, Number, OriginalRepresentation, Length} = tokenize_octal(T, [H], 1),
-%   Token = {integer, {Line, {Column, Column + 2 + Length}, Number}, OriginalRepresentation},
-%   tokenize(Rest, Line, Column + 2 + Length, Scope, [Token | Tokens]);
-
 tokenize([$0, $x, H | T], Line, Column, Scope, Tokens) when ?is_hex(H) ->
-  {Rest, Number, Length} = tokenize_hex(T, [H], 1),
-  tokenize(Rest, Line, Column + 2 + Length, Scope, [{hex, {Line, {Column, Column + 2 + Length}, nil}, Number} | Tokens]);
+  {Rest, Number, OriginalRepresentation, Length} = tokenize_hex(T, [H], 1),
+  Token = {integer, {Line, {Column, Column + 2 + Length}, Number}, OriginalRepresentation},
+  tokenize(Rest, Line, Column + 2 + Length, Scope, [Token | Tokens]);
 
 tokenize([$0, $b, H | T], Line, Column, Scope, Tokens) when ?is_bin(H) ->
-  {Rest, Number, Length} = tokenize_bin(T, [H], 1),
-  tokenize(Rest, Line, Column + 2 + Length, Scope, [{binary, {Line, {Column, Column + 2 + Length}, nil}, Number} | Tokens]);
+  {Rest, Number, OriginalRepresentation, Length} = tokenize_bin(T, [H], 1),
+  Token = {integer, {Line, {Column, Column + 2 + Length}, Number}, OriginalRepresentation},
+  tokenize(Rest, Line, Column + 2 + Length, Scope, [Token | Tokens]);
 
 tokenize([$0, $o, H | T], Line, Column, Scope, Tokens) when ?is_octal(H) ->
-  {Rest, Number, Length} = tokenize_octal(T, [H], 1),
-  tokenize(Rest, Line, Column + 2 + Length, Scope, [{octal, {Line, {Column, Column + 2 + Length}, nil}, Number} | Tokens]);
+  {Rest, Number, OriginalRepresentation, Length} = tokenize_octal(T, [H], 1),
+  Token = {integer, {Line, {Column, Column + 2 + Length}, Number}, OriginalRepresentation},
+  tokenize(Rest, Line, Column + 2 + Length, Scope, [Token | Tokens]);
 
 % Comments
 
@@ -445,7 +433,7 @@ tokenize([H | T], Line, Column, Scope, Tokens) when ?is_digit(H) ->
     {error, Reason, Number} ->
       {error, {Line, Reason, Number}, T, Tokens};
     {Rest, Number, Length} when is_integer(Number) ->
-      Token = {decimal, {Line, {Column, Column + Length}, nil}, Number},
+      Token = {integer, {Line, {Column, Column + Length}, Number}, integer_to_list(Number)},
       tokenize(Rest, Line, Column + Length, Scope, [Token | Tokens]);
     {Rest, Number, Length} ->
       Token = {float, {Line, {Column, Column + Length}, nil}, Number},
@@ -868,21 +856,24 @@ tokenize_hex([H | T], Acc, Length) when ?is_hex(H) ->
 tokenize_hex([$_, H | T], Acc, Length) when ?is_hex(H) ->
   tokenize_hex(T, [H | Acc], Length + 2);
 tokenize_hex(Rest, Acc, Length) ->
-  {Rest, list_to_integer(lists:reverse(Acc), 16), Length}.
+  Digits = lists:reverse(Acc),
+  {Rest, list_to_integer(Digits, 16), [$0, $x | Digits], Length}.
 
 tokenize_octal([H | T], Acc, Length) when ?is_octal(H) ->
   tokenize_octal(T, [H | Acc], Length + 1);
 tokenize_octal([$_, H | T], Acc, Length) when ?is_octal(H) ->
   tokenize_octal(T, [H | Acc], Length + 2);
 tokenize_octal(Rest, Acc, Length) ->
-  {Rest, list_to_integer(lists:reverse(Acc), 8), Length}.
+  Digits = lists:reverse(Acc),
+  {Rest, list_to_integer(Digits, 8), [$0, $o | Digits], Length}.
 
 tokenize_bin([H | T], Acc, Length) when ?is_bin(H) ->
   tokenize_bin(T, [H | Acc], Length + 1);
 tokenize_bin([$_, H | T], Acc, Length) when ?is_bin(H) ->
   tokenize_bin(T, [H | Acc], Length + 2);
 tokenize_bin(Rest, Acc, Length) ->
-  {Rest, list_to_integer(lists:reverse(Acc), 2), Length}.
+  Digits = lists:reverse(Acc),
+  {Rest, list_to_integer(Digits, 2), [$0, $b | Digits], Length}.
 
 %% Comments
 

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -97,7 +97,7 @@ defmodule CodeTest do
 
   test "string_to_quoted/1" do
     assert Code.string_to_quoted("1 + 2") == {:ok, {:+, [line: 1], [1, 2]}}
-    assert Code.string_to_quoted("a.1") == {:error, {1, "syntax error before: ", "1"}}
+    assert Code.string_to_quoted("a.1") == {:error, {1, "syntax error before: ", "\"1\""}}
   end
 
   test "string_to_quoted/1 for presence of sigils terminators" do

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -133,15 +133,15 @@ defmodule CodeTest do
     assert Code.string_to_quoted("\"one\"", wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], ["one"]}}
     assert Code.string_to_quoted("\"one\"") == {:ok, "one"}
     assert Code.string_to_quoted("?é", wrap_literals_in_blocks: true) == {:ok, {:__block__, [format: :char, line: 1], [233]}}
-    assert Code.string_to_quoted("0b10", wrap_literals_in_blocks: true) == {:ok, {:__block__, [format: :binary, line: 1], [2]}}
-    assert Code.string_to_quoted("12", wrap_literals_in_blocks: true) == {:ok, {:__block__, [format: :decimal, line: 1], [12]}}
-    assert Code.string_to_quoted("0o123", wrap_literals_in_blocks: true) == {:ok, {:__block__, [format: :octal, line: 1], [83]}}
-    assert Code.string_to_quoted("0xEF", wrap_literals_in_blocks: true) == {:ok, {:__block__, [format: :hex, line: 1], [239]}}
+    assert Code.string_to_quoted("0b10", wrap_literals_in_blocks: true) == {:ok, {:__block__, [original: '0b10', line: 1], [2]}}
+    assert Code.string_to_quoted("12", wrap_literals_in_blocks: true) == {:ok, {:__block__, [original: '12', line: 1], [12]}}
+    assert Code.string_to_quoted("0o123", wrap_literals_in_blocks: true) == {:ok, {:__block__, [original: '0o123', line: 1], [83]}}
+    assert Code.string_to_quoted("0xEF", wrap_literals_in_blocks: true) == {:ok, {:__block__, [original: '0xEF', line: 1], [239]}}
     assert Code.string_to_quoted("12.3", wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [12.3]}}
     assert Code.string_to_quoted("nil", wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [nil]}}
     assert Code.string_to_quoted(":one", wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], [:one]}}
     assert Code.string_to_quoted("[1]", wrap_literals_in_blocks: true) ==
-           {:ok, {:__block__, [line: 1], [[{:__block__, [format: :decimal, line: 1], [1]}]]}}
+           {:ok, {:__block__, [line: 1], [[{:__block__, [original: '1', line: 1], [1]}]]}}
     assert Code.string_to_quoted("{:ok, :test}", wrap_literals_in_blocks: true) ==
            {:ok, {:__block__, [line: 1], [{{:__block__, [line: 1], [:ok]}, {:__block__, [line: 1], [:test]}}]}}
     assert Code.string_to_quoted("\"\"\"\nhello\n\"\"\"", wrap_literals_in_blocks: true)

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -132,7 +132,7 @@ defmodule CodeTest do
   test "string_to_quoted/2 with wrap_literals_in_blocks option" do
     assert Code.string_to_quoted("\"one\"", wrap_literals_in_blocks: true) == {:ok, {:__block__, [line: 1], ["one"]}}
     assert Code.string_to_quoted("\"one\"") == {:ok, "one"}
-    assert Code.string_to_quoted("?é", wrap_literals_in_blocks: true) == {:ok, {:__block__, [format: :char, line: 1], [233]}}
+    assert Code.string_to_quoted("?é", wrap_literals_in_blocks: true) == {:ok, {:__block__, [original: '?é', line: 1], [233]}}
     assert Code.string_to_quoted("0b10", wrap_literals_in_blocks: true) == {:ok, {:__block__, [original: '0b10', line: 1], [2]}}
     assert Code.string_to_quoted("12", wrap_literals_in_blocks: true) == {:ok, {:__block__, [original: '12', line: 1], [12]}}
     assert Code.string_to_quoted("0o123", wrap_literals_in_blocks: true) == {:ok, {:__block__, [original: '0o123', line: 1], [83]}}

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -694,17 +694,15 @@ defmodule Kernel.ErrorsTest do
       'if true do\n  foo = [],\n  baz\nend'
   end
 
-  # As reported and discussed in
-  # https://github.com/elixir-lang/elixir/issues/4419.
   test "characters literal are printed correctly in syntax errors" do
     assert_eval_raise SyntaxError,
-      "nofile:1: syntax error before: ?a",
+      "nofile:1: syntax error before: \"?a\"",
       ':ok ?a'
     assert_eval_raise SyntaxError,
-      "nofile:1: syntax error before: ?\\s",
+      "nofile:1: syntax error before: \"?\\\\s\"",
       ':ok ?\\s'
     assert_eval_raise SyntaxError,
-      "nofile:1: syntax error before: ?す"
+      "nofile:1: syntax error before: \"?す\""
       ':ok ?す'
   end
 

--- a/lib/elixir/test/erlang/string_test.erl
+++ b/lib/elixir/test/erlang/string_test.erl
@@ -41,12 +41,12 @@ extract_interpolations_with_only_two_interpolations_test() ->
 
 extract_interpolations_with_tuple_inside_interpolation_test() ->
   [<<"f">>,
-   {{1, {2, 8}, nil}, [{'{', {1, {4, 5}, nil}}, {integer, {1, {5, 6}, 1}, "1"}, {'}', {1, {6, 7}, nil}}]},
+   {{1, {2, 8}, nil}, [{'{', {1, {4, 5}, nil}}, {int, {1, {5, 6}, 1}, "1"}, {'}', {1, {6, 7}, nil}}]},
    <<"o">>] = extract_interpolations("f#{{1}}o").
 
 extract_interpolations_with_many_expressions_inside_interpolation_test() ->
   [<<"f">>,
-   {{1, {2, 3}, nil}, [{integer, {1, {4, 5}, 1}, "1"}, {eol, {1, {5, 6}, nil}}, {integer, {2, {1, 2}, 2}, "2"}]},
+   {{1, {2, 3}, nil}, [{int, {1, {4, 5}, 1}, "1"}, {eol, {1, {5, 6}, nil}}, {int, {2, {1, 2}, 2}, "2"}]},
     <<"o">>] = extract_interpolations("f#{1\n2}o").
 
 extract_interpolations_with_right_curly_inside_string_inside_interpolation_test() ->
@@ -66,7 +66,7 @@ extract_interpolations_with_escaped_quote_inside_string_inside_interpolation_tes
 
 extract_interpolations_with_less_than_operation_inside_interpolation_test() ->
   [<<"f">>,
-   {{1, {2, 8}, nil}, [{integer, {1, {4, 5}, 1}, "1"}, {rel_op, {1, {5, 6}, nil}, '<'}, {integer, {1, {6, 7}, 2}, "2"}]},
+   {{1, {2, 8}, nil}, [{int, {1, {4, 5}, 1}, "1"}, {rel_op, {1, {5, 6}, nil}, '<'}, {int, {1, {6, 7}, 2}, "2"}]},
    <<"o">>] = extract_interpolations("f#{1<2}o").
 
 extract_interpolations_with_an_escaped_character_test() ->
@@ -184,5 +184,5 @@ char_test() ->
 
 %% Binaries
 
-bitstr_with_integer_test() ->
+bitstr_with_int_test() ->
   {<<"fdo">>, _} = eval("<< \"f\", 50+50, \"o\" >>").

--- a/lib/elixir/test/erlang/string_test.erl
+++ b/lib/elixir/test/erlang/string_test.erl
@@ -71,7 +71,7 @@ extract_interpolations_with_less_than_operation_inside_interpolation_test() ->
 
 extract_interpolations_with_an_escaped_character_test() ->
   [<<"f">>,
-   {{1, {2, 17}, nil}, [{char, {1, {4, 7}, nil}, 7}, {rel_op, {1, {8, 9}, nil}, '>'}, {char, {1, {10, 13}, nil}, 7}]}
+   {{1, {2, 17}, nil}, [{int, {1, {4, 7}, 7}, "?\\a"}, {rel_op, {1, {8, 9}, nil}, '>'}, {int, {1, {10, 13}, 7}, "?\\a"}]}
    ] = extract_interpolations("f#{?\\a > ?\\a   }").
 
 extract_interpolations_with_invalid_expression_inside_interpolation_test() ->

--- a/lib/elixir/test/erlang/string_test.erl
+++ b/lib/elixir/test/erlang/string_test.erl
@@ -41,12 +41,12 @@ extract_interpolations_with_only_two_interpolations_test() ->
 
 extract_interpolations_with_tuple_inside_interpolation_test() ->
   [<<"f">>,
-   {{1, {2, 8}, nil}, [{'{', {1, {4, 5}, nil}}, {decimal, {1, {5, 6}, nil}, 1}, {'}', {1, {6, 7}, nil}}]},
+   {{1, {2, 8}, nil}, [{'{', {1, {4, 5}, nil}}, {integer, {1, {5, 6}, 1}, "1"}, {'}', {1, {6, 7}, nil}}]},
    <<"o">>] = extract_interpolations("f#{{1}}o").
 
 extract_interpolations_with_many_expressions_inside_interpolation_test() ->
   [<<"f">>,
-   {{1, {2, 3}, nil}, [{decimal, {1, {4, 5}, nil}, 1}, {eol, {1, {5, 6}, nil}}, {decimal, {2, {1, 2}, nil}, 2}]},
+   {{1, {2, 3}, nil}, [{integer, {1, {4, 5}, 1}, "1"}, {eol, {1, {5, 6}, nil}}, {integer, {2, {1, 2}, 2}, "2"}]},
     <<"o">>] = extract_interpolations("f#{1\n2}o").
 
 extract_interpolations_with_right_curly_inside_string_inside_interpolation_test() ->
@@ -66,7 +66,7 @@ extract_interpolations_with_escaped_quote_inside_string_inside_interpolation_tes
 
 extract_interpolations_with_less_than_operation_inside_interpolation_test() ->
   [<<"f">>,
-   {{1, {2, 8}, nil}, [{decimal, {1, {4, 5}, nil}, 1}, {rel_op, {1, {5, 6}, nil}, '<'}, {decimal, {1, {6, 7}, nil}, 2}]},
+   {{1, {2, 8}, nil}, [{integer, {1, {4, 5}, 1}, "1"}, {rel_op, {1, {5, 6}, nil}, '<'}, {integer, {1, {6, 7}, 2}, "2"}]},
    <<"o">>] = extract_interpolations("f#{1<2}o").
 
 extract_interpolations_with_an_escaped_character_test() ->

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -13,22 +13,22 @@ tokenize_error(String) ->
   Error.
 
 type_test() ->
-  [{decimal, {1, {1, 2}, nil}, 1},
+  [{integer, {1, {1, 2}, 1}, "1"},
    {type_op, {1, {3, 5}, nil}, '::'},
-   {decimal, {1, {6, 7}, nil}, 3}] = tokenize("1 :: 3"),
+   {integer, {1, {6, 7}, 3}, "3"}] = tokenize("1 :: 3"),
   [{identifier, {1, {1, 5}, nil}, name},
    {'.', {1, {5, 6}, nil}},
    {paren_identifier, {1, {6, 8}, nil}, '::'},
    {'(', {1, {8, 9}, nil}},
-   {decimal, {1, {9, 10}, nil}, 3},
+   {integer, {1, {9, 10}, 3}, "3"},
    {')', {1, {10, 11}, nil}}] = tokenize("name.::(3)").
 
 arithmetic_test() ->
-  [{decimal, {1, {1, 2}, nil}, 1},
+  [{integer, {1, {1, 2}, 1}, "1"},
    {dual_op, {1, {3, 4}, nil}, '+'},
-   {decimal, {1, {5, 6}, nil}, 2},
+   {integer, {1, {5, 6}, 2}, "2"},
    {dual_op, {1, {7, 8}, nil}, '+'},
-   {decimal, {1, {9, 10}, nil}, 3}] = tokenize("1 + 2 + 3").
+   {integer, {1, {9, 10}, 3}, "3"}] = tokenize("1 + 2 + 3").
 
 op_kw_test() ->
   [{atom, {1, {1, 5}, nil}, foo},
@@ -41,12 +41,12 @@ scientific_test() ->
   {1, "invalid float number ", "1.0e309"} = tokenize_error("1.0e309").
 
 hex_bin_octal_test() ->
-  [{hex, {1, {1, 5}, nil}, 255}] = tokenize("0xFF"),
-  [{hex, {1, {1, 6}, nil}, 255}] = tokenize("0xF_F"),
-  [{octal, {1, {1, 5}, nil}, 63}] = tokenize("0o77"),
-  [{octal, {1, {1, 6}, nil}, 63}] = tokenize("0o7_7"),
-  [{binary, {1, {1, 5}, nil}, 3}] = tokenize("0b11"),
-  [{binary, {1, {1, 6}, nil}, 3}] = tokenize("0b1_1").
+  [{integer, {1, {1, 5}, 255}, "0xFF"}] = tokenize("0xFF"),
+  [{integer, {1, {1, 6}, 255}, "0xFF"}] = tokenize("0xF_F"),
+  [{integer, {1, {1, 5}, 63}, "0o77"}] = tokenize("0o77"),
+  [{integer, {1, {1, 6}, 63}, "0o77"}] = tokenize("0o7_7"),
+  [{integer, {1, {1, 5}, 3}, "0b11"}] = tokenize("0b11"),
+  [{integer, {1, {1, 6}, 3}, "0b11"}] = tokenize("0b1_1").
 
 unquoted_atom_test() ->
   [{atom, {1, {1, 3}, nil}, '+'}] = tokenize(":+"),
@@ -76,10 +76,10 @@ kw_test() ->
   [{kw_identifier_unsafe, {1, {1, 10}, nil}, [<<"foo bar">>]}] = tokenize("\"foo bar\": ").
 
 integer_test() ->
-  [{decimal, {1, {1, 4}, nil}, 123}] = tokenize("123"),
-  [{decimal, {1, {1, 4}, nil}, 123}, {';', {1, {4, 5}, nil}}] = tokenize("123;"),
-  [{eol, {1, {1, 2}, nil}}, {decimal, {3, {1, 4}, nil}, 123}] = tokenize("\n\n123"),
-  [{decimal, {1, {3, 6}, nil}, 123}, {decimal, {1, {8, 11}, nil}, 234}] = tokenize("  123  234  ").
+  [{integer, {1, {1, 4}, 123}, "123"}] = tokenize("123"),
+  [{integer, {1, {1, 4}, 123}, "123"}, {';', {1, {4, 5}, nil}}] = tokenize("123;"),
+  [{eol, {1, {1, 2}, nil}}, {integer, {3, {1, 4}, 123}, "123"}] = tokenize("\n\n123"),
+  [{integer, {1, {3, 6}, 123}, "123"}, {integer, {1, {8, 11}, 234}, "234"}] = tokenize("  123  234  ").
 
 float_test() ->
   [{float, {1, {1, 5}, nil}, 12.3}] = tokenize("12.3"),
@@ -90,13 +90,13 @@ float_test() ->
   {1, "invalid float number ", OversizedFloat} = tokenize_error(OversizedFloat).
 
 comments_test() ->
-  [{decimal, {1, {1, 2}, nil}, 1},
+  [{integer, {1, {1, 2}, 1}, "1"},
    {eol, {1, {3, 4}, nil}},
-   {decimal, {2, {1, 2}, nil}, 2}] = tokenize("1 # Comment\n2"),
-  [{decimal, {1, {1, 2}, nil}, 1},
+   {integer, {2, {1, 2}, 2}, "2"}] = tokenize("1 # Comment\n2"),
+  [{integer, {1, {1, 2}, 1}, "1"},
    {comment, {1, {3, 12}, nil}, "# Comment"},
    {eol, {1, {12, 13}, nil}},
-   {decimal, {2, {1, 2}, nil}, 2}] = tokenize("1 # Comment\n2", [{preserve_comments, true}]),
+   {integer, {2, {1, 2}, 2}, "2"}] = tokenize("1 # Comment\n2", [{preserve_comments, true}]),
   [{comment, {1, {1, 10}, nil}, "# Comment"}] = tokenize("# Comment", [{preserve_comments, true}]).
 
 identifier_test() ->
@@ -130,24 +130,24 @@ newline_test() ->
   [{identifier, {1, {1, 4}, nil}, foo},
    {'.', {2, {1, 2}, nil}},
    {identifier, {2, {2, 5}, nil}, bar}]  = tokenize("foo\n.bar"),
-  [{decimal, {1, {1, 2}, nil}, 1},
+  [{integer, {1, {1, 2}, 1}, "1"},
    {two_op, {2, {1, 3}, nil}, '++'},
-   {decimal, {2, {3, 4}, nil}, 2}]  = tokenize("1\n++2").
+   {integer, {2, {3, 4}, 2}, "2"}]  = tokenize("1\n++2").
 
 dot_newline_operator_test() ->
   [{identifier, {1, {1, 4}, nil}, foo},
    {'.', {1, {4, 5}, nil}},
    {identifier, {2, {1, 2}, nil}, '+'},
-   {decimal, {2, {2, 3}, nil}, 1}] = tokenize("foo.\n+1"),
+   {integer, {2, {2, 3}, 1}, "1"}] = tokenize("foo.\n+1"),
   [{identifier, {1, {1, 4}, nil}, foo},
    {'.', {1, {4, 5}, nil}},
    {identifier, {2, {1, 2}, nil}, '+'},
-   {decimal, {2, {2, 3}, nil}, 1}] = tokenize("foo.#bar\n+1"),
+   {integer, {2, {2, 3}, 1}, "1"}] = tokenize("foo.#bar\n+1"),
   [{identifier, {1, {1, 4}, nil}, foo},
    {'.', {1, {4, 5}, nil}},
    {comment, {1, {5, 9}, nil}, "#bar"},
    {identifier, {2, {1, 2}, nil}, '+'},
-   {decimal, {2, {2, 3}, nil}, 1}] = tokenize("foo.#bar\n+1", [{preserve_comments, true}]).
+   {integer, {2, {2, 3}, 1}, "1"}] = tokenize("foo.#bar\n+1", [{preserve_comments, true}]).
 
 aliases_test() ->
   [{'aliases', {1, {1, 4}, nil}, ['Foo']}] = tokenize("Foo"),
@@ -174,10 +174,10 @@ addadd_test() ->
 space_test() ->
   [{op_identifier, {1, {1, 4}, nil}, foo},
    {dual_op, {1, {5, 6}, nil}, '-'},
-   {decimal, {1, {6, 7}, nil}, 2}] = tokenize("foo -2"),
+   {integer, {1, {6, 7}, 2}, "2"}] = tokenize("foo -2"),
   [{op_identifier, {1, {1, 4}, nil}, foo},
    {dual_op, {1, {6, 7}, nil}, '-'},
-   {decimal, {1, {7, 8}, nil}, 2}] = tokenize("foo  -2").
+   {integer, {1, {7, 8}, 2}, "2"}] = tokenize("foo  -2").
 
 chars_test() ->
   [{char, {1, {1, 3}, nil}, 97}] = tokenize("?a"),
@@ -195,17 +195,17 @@ interpolation_test() ->
 capture_test() ->
   [{capture_op, {1, {1, 2}, nil}, '&'},
    {identifier, {1, {2, 4}, nil}, '||'},
-   {mult_op,    {1, {4, 5}, nil}, '/'},
-   {decimal,     {1, {5, 6}, nil}, 2}] = tokenize("&||/2"),
+   {mult_op, {1, {4, 5}, nil}, '/'},
+   {integer, {1, {5, 6}, 2}, "2"}] = tokenize("&||/2"),
   [{capture_op, {1, {1, 2}, nil}, '&'},
    {identifier, {1, {2, 4}, nil}, 'or'},
-   {mult_op,    {1, {4, 5}, nil}, '/'},
-   {decimal,     {1, {5, 6}, nil}, 2}] = tokenize("&or/2"),
+   {mult_op, {1, {4, 5}, nil}, '/'},
+   {integer, {1, {5, 6}, 2}, "2"}] = tokenize("&or/2"),
   [{capture_op, {1, {1, 2}, nil}, '&'},
    {unary_op, {1, {2, 5}, nil}, 'not'},
-   {decimal, {1, {6, 7}, nil}, 1},
+   {integer, {1, {6, 7}, 1}, "1"},
    {',', {1, {7, 8}, nil}},
-   {decimal, {1, {9, 10}, nil}, 2}] = tokenize("&not 1, 2").
+   {integer, {1, {9, 10}, 2}, "2"}] = tokenize("&not 1, 2").
 
 vc_merge_conflict_test() ->
   {1, "found an unexpected version control marker, please resolve the conflicts: ", "<<<<<<< HEAD"} =

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -13,22 +13,22 @@ tokenize_error(String) ->
   Error.
 
 type_test() ->
-  [{integer, {1, {1, 2}, 1}, "1"},
+  [{int, {1, {1, 2}, 1}, "1"},
    {type_op, {1, {3, 5}, nil}, '::'},
-   {integer, {1, {6, 7}, 3}, "3"}] = tokenize("1 :: 3"),
+   {int, {1, {6, 7}, 3}, "3"}] = tokenize("1 :: 3"),
   [{identifier, {1, {1, 5}, nil}, name},
    {'.', {1, {5, 6}, nil}},
    {paren_identifier, {1, {6, 8}, nil}, '::'},
    {'(', {1, {8, 9}, nil}},
-   {integer, {1, {9, 10}, 3}, "3"},
+   {int, {1, {9, 10}, 3}, "3"},
    {')', {1, {10, 11}, nil}}] = tokenize("name.::(3)").
 
 arithmetic_test() ->
-  [{integer, {1, {1, 2}, 1}, "1"},
+  [{int, {1, {1, 2}, 1}, "1"},
    {dual_op, {1, {3, 4}, nil}, '+'},
-   {integer, {1, {5, 6}, 2}, "2"},
+   {int, {1, {5, 6}, 2}, "2"},
    {dual_op, {1, {7, 8}, nil}, '+'},
-   {integer, {1, {9, 10}, 3}, "3"}] = tokenize("1 + 2 + 3").
+   {int, {1, {9, 10}, 3}, "3"}] = tokenize("1 + 2 + 3").
 
 op_kw_test() ->
   [{atom, {1, {1, 5}, nil}, foo},
@@ -41,12 +41,12 @@ scientific_test() ->
   {1, "invalid float number ", "1.0e309"} = tokenize_error("1.0e309").
 
 hex_bin_octal_test() ->
-  [{integer, {1, {1, 5}, 255}, "0xFF"}] = tokenize("0xFF"),
-  [{integer, {1, {1, 6}, 255}, "0xFF"}] = tokenize("0xF_F"),
-  [{integer, {1, {1, 5}, 63}, "0o77"}] = tokenize("0o77"),
-  [{integer, {1, {1, 6}, 63}, "0o77"}] = tokenize("0o7_7"),
-  [{integer, {1, {1, 5}, 3}, "0b11"}] = tokenize("0b11"),
-  [{integer, {1, {1, 6}, 3}, "0b11"}] = tokenize("0b1_1").
+  [{int, {1, {1, 5}, 255}, "0xFF"}] = tokenize("0xFF"),
+  [{int, {1, {1, 6}, 255}, "0xFF"}] = tokenize("0xF_F"),
+  [{int, {1, {1, 5}, 63}, "0o77"}] = tokenize("0o77"),
+  [{int, {1, {1, 6}, 63}, "0o77"}] = tokenize("0o7_7"),
+  [{int, {1, {1, 5}, 3}, "0b11"}] = tokenize("0b11"),
+  [{int, {1, {1, 6}, 3}, "0b11"}] = tokenize("0b1_1").
 
 unquoted_atom_test() ->
   [{atom, {1, {1, 3}, nil}, '+'}] = tokenize(":+"),
@@ -75,11 +75,11 @@ kw_test() ->
   [{kw_identifier, {1, {1, 5}, nil}, 'a@!'}] = tokenize("a@!: "),
   [{kw_identifier_unsafe, {1, {1, 10}, nil}, [<<"foo bar">>]}] = tokenize("\"foo bar\": ").
 
-integer_test() ->
-  [{integer, {1, {1, 4}, 123}, "123"}] = tokenize("123"),
-  [{integer, {1, {1, 4}, 123}, "123"}, {';', {1, {4, 5}, nil}}] = tokenize("123;"),
-  [{eol, {1, {1, 2}, nil}}, {integer, {3, {1, 4}, 123}, "123"}] = tokenize("\n\n123"),
-  [{integer, {1, {3, 6}, 123}, "123"}, {integer, {1, {8, 11}, 234}, "234"}] = tokenize("  123  234  ").
+int_test() ->
+  [{int, {1, {1, 4}, 123}, "123"}] = tokenize("123"),
+  [{int, {1, {1, 4}, 123}, "123"}, {';', {1, {4, 5}, nil}}] = tokenize("123;"),
+  [{eol, {1, {1, 2}, nil}}, {int, {3, {1, 4}, 123}, "123"}] = tokenize("\n\n123"),
+  [{int, {1, {3, 6}, 123}, "123"}, {int, {1, {8, 11}, 234}, "234"}] = tokenize("  123  234  ").
 
 float_test() ->
   [{float, {1, {1, 5}, nil}, 12.3}] = tokenize("12.3"),
@@ -90,13 +90,13 @@ float_test() ->
   {1, "invalid float number ", OversizedFloat} = tokenize_error(OversizedFloat).
 
 comments_test() ->
-  [{integer, {1, {1, 2}, 1}, "1"},
+  [{int, {1, {1, 2}, 1}, "1"},
    {eol, {1, {3, 4}, nil}},
-   {integer, {2, {1, 2}, 2}, "2"}] = tokenize("1 # Comment\n2"),
-  [{integer, {1, {1, 2}, 1}, "1"},
+   {int, {2, {1, 2}, 2}, "2"}] = tokenize("1 # Comment\n2"),
+  [{int, {1, {1, 2}, 1}, "1"},
    {comment, {1, {3, 12}, nil}, "# Comment"},
    {eol, {1, {12, 13}, nil}},
-   {integer, {2, {1, 2}, 2}, "2"}] = tokenize("1 # Comment\n2", [{preserve_comments, true}]),
+   {int, {2, {1, 2}, 2}, "2"}] = tokenize("1 # Comment\n2", [{preserve_comments, true}]),
   [{comment, {1, {1, 10}, nil}, "# Comment"}] = tokenize("# Comment", [{preserve_comments, true}]).
 
 identifier_test() ->
@@ -130,24 +130,24 @@ newline_test() ->
   [{identifier, {1, {1, 4}, nil}, foo},
    {'.', {2, {1, 2}, nil}},
    {identifier, {2, {2, 5}, nil}, bar}]  = tokenize("foo\n.bar"),
-  [{integer, {1, {1, 2}, 1}, "1"},
+  [{int, {1, {1, 2}, 1}, "1"},
    {two_op, {2, {1, 3}, nil}, '++'},
-   {integer, {2, {3, 4}, 2}, "2"}]  = tokenize("1\n++2").
+   {int, {2, {3, 4}, 2}, "2"}]  = tokenize("1\n++2").
 
 dot_newline_operator_test() ->
   [{identifier, {1, {1, 4}, nil}, foo},
    {'.', {1, {4, 5}, nil}},
    {identifier, {2, {1, 2}, nil}, '+'},
-   {integer, {2, {2, 3}, 1}, "1"}] = tokenize("foo.\n+1"),
+   {int, {2, {2, 3}, 1}, "1"}] = tokenize("foo.\n+1"),
   [{identifier, {1, {1, 4}, nil}, foo},
    {'.', {1, {4, 5}, nil}},
    {identifier, {2, {1, 2}, nil}, '+'},
-   {integer, {2, {2, 3}, 1}, "1"}] = tokenize("foo.#bar\n+1"),
+   {int, {2, {2, 3}, 1}, "1"}] = tokenize("foo.#bar\n+1"),
   [{identifier, {1, {1, 4}, nil}, foo},
    {'.', {1, {4, 5}, nil}},
    {comment, {1, {5, 9}, nil}, "#bar"},
    {identifier, {2, {1, 2}, nil}, '+'},
-   {integer, {2, {2, 3}, 1}, "1"}] = tokenize("foo.#bar\n+1", [{preserve_comments, true}]).
+   {int, {2, {2, 3}, 1}, "1"}] = tokenize("foo.#bar\n+1", [{preserve_comments, true}]).
 
 aliases_test() ->
   [{'aliases', {1, {1, 4}, nil}, ['Foo']}] = tokenize("Foo"),
@@ -174,10 +174,10 @@ addadd_test() ->
 space_test() ->
   [{op_identifier, {1, {1, 4}, nil}, foo},
    {dual_op, {1, {5, 6}, nil}, '-'},
-   {integer, {1, {6, 7}, 2}, "2"}] = tokenize("foo -2"),
+   {int, {1, {6, 7}, 2}, "2"}] = tokenize("foo -2"),
   [{op_identifier, {1, {1, 4}, nil}, foo},
    {dual_op, {1, {6, 7}, nil}, '-'},
-   {integer, {1, {7, 8}, 2}, "2"}] = tokenize("foo  -2").
+   {int, {1, {7, 8}, 2}, "2"}] = tokenize("foo  -2").
 
 chars_test() ->
   [{char, {1, {1, 3}, nil}, 97}] = tokenize("?a"),
@@ -196,16 +196,16 @@ capture_test() ->
   [{capture_op, {1, {1, 2}, nil}, '&'},
    {identifier, {1, {2, 4}, nil}, '||'},
    {mult_op, {1, {4, 5}, nil}, '/'},
-   {integer, {1, {5, 6}, 2}, "2"}] = tokenize("&||/2"),
+   {int, {1, {5, 6}, 2}, "2"}] = tokenize("&||/2"),
   [{capture_op, {1, {1, 2}, nil}, '&'},
    {identifier, {1, {2, 4}, nil}, 'or'},
    {mult_op, {1, {4, 5}, nil}, '/'},
-   {integer, {1, {5, 6}, 2}, "2"}] = tokenize("&or/2"),
+   {int, {1, {5, 6}, 2}, "2"}] = tokenize("&or/2"),
   [{capture_op, {1, {1, 2}, nil}, '&'},
    {unary_op, {1, {2, 5}, nil}, 'not'},
-   {integer, {1, {6, 7}, 1}, "1"},
+   {int, {1, {6, 7}, 1}, "1"},
    {',', {1, {7, 8}, nil}},
-   {integer, {1, {9, 10}, 2}, "2"}] = tokenize("&not 1, 2").
+   {int, {1, {9, 10}, 2}, "2"}] = tokenize("&not 1, 2").
 
 vc_merge_conflict_test() ->
   {1, "found an unexpected version control marker, please resolve the conflicts: ", "<<<<<<< HEAD"} =

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -180,12 +180,12 @@ space_test() ->
    {int, {1, {7, 8}, 2}, "2"}] = tokenize("foo  -2").
 
 chars_test() ->
-  [{char, {1, {1, 3}, nil}, 97}] = tokenize("?a"),
-  [{char, {1, {1, 3}, nil}, 99}] = tokenize("?c"),
-  [{char, {1, {1, 4}, nil}, 0}]  = tokenize("?\\0"),
-  [{char, {1, {1, 4}, nil}, 7}]  = tokenize("?\\a"),
-  [{char, {1, {1, 4}, nil}, 10}] = tokenize("?\\n"),
-  [{char, {1, {1, 4}, nil}, 92}] = tokenize("?\\\\").
+  [{int, {1, {1, 3}, 97}, "?a"}] = tokenize("?a"),
+  [{int, {1, {1, 3}, 99}, "?c"}] = tokenize("?c"),
+  [{int, {1, {1, 4}, 0}, "?\\0"}]  = tokenize("?\\0"),
+  [{int, {1, {1, 4}, 7}, "?\\a"}]  = tokenize("?\\a"),
+  [{int, {1, {1, 4}, 10}, "?\\n"}] = tokenize("?\\n"),
+  [{int, {1, {1, 4}, 92}, "?\\\\"}] = tokenize("?\\\\").
 
 interpolation_test() ->
   [{bin_string, {1, {1, 9}, nil}, [<<"f">>, {{1, {3, 8}, nil}, [{identifier, {1, {5, 7}, nil}, oo}]}]},


### PR DESCRIPTION
This is basically the same as #6492, but reworked after #6495. Integer tokens are now `int`, not `hex`/`binary`/`octal`/`decimal`. Reasons for this change are in #6495.

Note that the `int` token looks like this

```erlang
{int, {Line, {StartColumn, EndColumn}, IntValue}, OriginalRepresentation}
```

so for `0b010` you'd have

```erlang
{int, {_, _, 2}, "0b010"}
```