### PR TITLE
Clarify Path.join/2 behavior when dealing with lists

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -487,9 +487,8 @@ defmodule Path do
       iex> Path.join("/foo", "/bar/")
       "/foo/bar"
 
-  The functions in this module support chardata, so giving a list will treat it as a single entity:
-
-  ## Examples
+  The functions in this module support chardata, so giving a list will
+  treat it as a single entity:
 
       iex> Path.join("foo", ["bar", "fiz"])
       "foo/barfiz"

--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -484,14 +484,18 @@ defmodule Path do
       iex> Path.join("foo", "bar")
       "foo/bar"
 
+      iex> Path.join("/foo", "/bar/")
+      "/foo/bar"
+
+  The functions in this module support chardata, so giving a list will treat it as a single entity:
+
+  ## Examples
+
       iex> Path.join("foo", ["bar", "fiz"])
       "foo/barfiz"
 
       iex> Path.join(["foo", "bar"], "fiz")
       "foobar/fiz"
-
-      iex> Path.join("/foo", "/bar/")
-      "/foo/bar"
 
   """
   @spec join(t, t) :: binary

--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -484,6 +484,12 @@ defmodule Path do
       iex> Path.join("foo", "bar")
       "foo/bar"
 
+      iex> Path.join("foo", ["bar", "fiz"])
+      "foo/barfiz"
+
+      iex> Path.join(["foo", "bar"], "fiz")
+      "foobar/fiz"
+
       iex> Path.join("/foo", "/bar/")
       "/foo/bar"
 

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -242,6 +242,7 @@ defmodule PathTest do
     assert Path.join("/foo", "./bar") == "/foo/./bar"
 
     assert Path.join([?/, "foo"], "./bar") == "/foo/./bar"
+    assert Path.join(["/foo", "bar"], ["fiz", "buz"]) == "/foobar/fizbuz"
   end
 
   test "split/1" do


### PR DESCRIPTION
This thing caught me and @michalmuskala:
```
iex(1)> Path.join("a/b/c", ["d", "e"])
"a/b/c/de"
iex(2)> Path.join(["a/b/c", "d", "e"]) 
"a/b/c/d/e"
```

I've expected that right or left part would be joined with path separator between elements.

I think we need either join `left` and `right` parts of the path by calling `join/1` recursively (that looks like a breaking change), or clarify behavior in the docs (as I did for now).