### PR TITLE
Fix random seed generation in ExUnit for Windows systems

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -301,10 +301,9 @@ defmodule ExUnit do
     Keyword.put_new_lazy(opts, :seed, fn ->
       # We're using `rem System.system_time()` here
       # instead of directly using :os.timestamp or using the
-      # :microsecond argument because the VM on Windows has... odd...
+      # :microsecond argument because the VM on Windows has odd
       # precision. Calling with :microsecond will give us a multiple
       # of 1000. Calling without it gives actual microsecond precision.
-      # Yeah, it's weird.
       rem System.system_time(), 1_000_000
     end)
   end

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -299,7 +299,13 @@ defmodule ExUnit do
 
   defp put_seed(opts) do
     Keyword.put_new_lazy(opts, :seed, fn ->
-      rem :os.system_time, 1_000_000
+      # We're using `rem System.system_time()` here
+      # instead of directly using :os.timestamp or using the
+      # :microsecond argument because the VM on Windows has... odd...
+      # precision. Calling with :microsecond will give us a multiple
+      # of 1000. Calling without it gives actual microsecond precision.
+      # Yeah, it's weird.
+      rem System.system_time(), 1_000_000
     end)
   end
 

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -299,7 +299,7 @@ defmodule ExUnit do
 
   defp put_seed(opts) do
     Keyword.put_new_lazy(opts, :seed, fn ->
-      :os.timestamp |> elem(2)
+      rem :os.system_time, 1_000_000
     end)
   end
 


### PR DESCRIPTION
Windows does not have microsecond-level timestamps. As such, the seed
generated by :os.timestamp is only in the millisecond range, giving
multiples of 1000 for "random" seeds. This change should give the same
results in *nix systems while giving a wider seed variety on Windows.