### PR TITLE
Open up `Registry.whereis_name/1` by adding doc and typespecs.

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -526,8 +526,20 @@ defmodule Process do
   See `:erlang.whereis/1` for more info.
   """
   @spec whereis(atom) :: pid | port | nil
-  def whereis(name) do
+  def whereis(name) when is_atom(name) do
     nillify :erlang.whereis(name)
+  end
+
+  @doc """
+  Returns the PID or port identifier registered inside a `Registry` under `name` or `nil` if the
+  `name` is not registered.
+
+  See `Registry.whereis_name/1` for more info.
+  """
+  @spec whereis({:via, Registry, {atom, any}}) :: pid | port | nil
+  def whereis({:via, Registry, {registry, _key} = name}) when is_atom(registry) do
+    result = Registry.whereis_name name
+    if result == :undefined, do: nil, else: result
   end
 
   @doc """

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -173,7 +173,13 @@ defmodule Registry do
 
   ## Via callbacks
 
-  @doc false
+  @doc """
+  Returns the PID or port identifier registered under `key` or `:undefined` if the
+  `key` is not registered.
+
+  See `Process.whereis/1` for more info.
+  """
+  @spec whereis_name({atom, any}) :: pid | port | :undefined
   def whereis_name({registry, key}) do
     case key_info!(registry) do
       {:unique, partitions, key_ets} ->

--- a/lib/elixir/test/elixir/process_test.exs
+++ b/lib/elixir/test/elixir/process_test.exs
@@ -28,6 +28,22 @@ defmodule ProcessTest do
     assert Process.sleep(0) == :ok
   end
 
+  test "whereis/1" do
+    {:ok, pid} = Agent.start_link((fn -> 1 end), name: :zap)
+    assert Process.whereis(:zap) == pid
+  end
+
+  test "whereis/1 with Registry" do
+    Registry.start_link(keys: :unique, name: Registry.ViaTest)
+    name = {:via, Registry, {Registry.ViaTest, "agent"}}
+    {:ok, pid } = Agent.start(fn -> 0 end, name: name)
+
+    assert Process.whereis(name) == pid
+    assert Process.whereis({:via, Registry, {Registry.ViaTest, :none}}) == nil
+
+  end
+
+
   test "info/2" do
     pid = spawn fn -> Process.sleep(1000) end
     assert Process.info(pid, :priority) == {:priority, :normal}


### PR DESCRIPTION
* Add support for `Process.whereis/1` to look under `Registry` if possible.
* Added tests for both `Process.whereis/1`. 
* Open up `Registry.whereis_name/1` by adding doc and typespecs.

Could use another pair of eyes on the documentation as well as the typespecs themselves.

Noticed that `Process.whereis/1` returns `nil` if it doesn't find while `Registry.whereis_name/1` returns `:undefined` so for `Process.whereis/1` where the argument is to look `:via` it makes sure to make it into a nil to match regular `Process.whereis/1`

Very uncertain of the whole thing, but I've been looking for a way to get access to named processes  under `Registry` and it wasn't documented (for good reasons I suppose(?)). 