### PR TITLE
Use :io_lib.scan_format/2 on Logger.Utils.inspect/4

### DIFF
--- a/lib/logger/lib/logger/error_handler.ex
+++ b/lib/logger/lib/logger/error_handler.ex
@@ -141,10 +141,11 @@ defmodule Logger.ErrorHandler do
   end
 
   defp translate([], _min_level, _level, :format, {format, args}, truncate) do
-    {:ok,
-     format
-     |> Logger.Utils.scan_inspect(args, truncate)
-     |> :io_lib.build_text()}
+    msg =
+      format
+      |> Logger.Utils.scan_inspect(args, truncate)
+      |> :io_lib.build_text()
+    {:ok, msg}
   end
 
   defp translate([], _min_level, _level, :report, {_type, data}, _truncate) do

--- a/lib/logger/lib/logger/error_handler.ex
+++ b/lib/logger/lib/logger/error_handler.ex
@@ -141,8 +141,10 @@ defmodule Logger.ErrorHandler do
   end
 
   defp translate([], _min_level, _level, :format, {format, args}, truncate) do
-    {format, args} = Logger.Utils.inspect(format, args, truncate)
-    {:ok, :io_lib.format(format, args)}
+    {:ok,
+     format
+     |> Logger.Utils.scan_inspect(args, truncate)
+     |> :io_lib.build_text()}
   end
 
   defp translate([], _min_level, _level, :report, {_type, data}, _truncate) do

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -88,23 +88,16 @@ defmodule Logger.Utils do
   check `:io_lib.scan_format/2`
   """
   def scan_inspect(format, args, truncate, opts \\ %Inspect.Opts{})
-
   def scan_inspect(format, args, truncate, opts) when is_atom(format) do
-    do_scan_inspect(Atom.to_charlist(format), args, truncate, opts)
+    scan_inspect(Atom.to_charlist(format), args, truncate, opts)
   end
-
   def scan_inspect(format, args, truncate, opts) when is_binary(format) do
-    do_scan_inspect(:binary.bin_to_list(format), args, truncate, opts)
+    scan_inspect(:binary.bin_to_list(format), args, truncate, opts)
   end
-
-  def scan_inspect(format, args, truncate, opts) when is_list(format) do
-    do_scan_inspect(format, args, truncate, opts)
-  end
-
-  defp do_scan_inspect(format, [], _truncate, _opts) do
+  def scan_inspect(format, [], _truncate, _opts) when is_list(format) do
     :io_lib.scan_format(format, [])
   end
-  defp do_scan_inspect(format, args, truncate, opts) do
+  def scan_inspect(format, args, truncate, opts) when is_list(format) do
     # A pre-pass that removes binaries from
     # arguments according to the truncate limit.
     {args, _} = Enum.map_reduce(args, truncate, fn arg, acc ->

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -109,129 +109,63 @@ defmodule Logger.Utils do
         {arg, acc}
       end
     end)
-    do_inspect(format, args, [], [], opts)
+
+    format
+    |> :io_lib.scan_format(args)
+    |> do_inspect(opts, [])
+    |> :io_lib.unscan_format()
   end
 
-  defp do_inspect([?~ | t], args, used_format, used_args, opts) do
-    {t, args, cc_format, cc_args} = collect_cc(:width, t, args, [?~], [], opts)
-    do_inspect(t, args, cc_format ++ used_format, cc_args ++ used_args, opts)
+  defp do_inspect([], _opts, acc),
+    do: :lists.reverse(acc)
+  defp do_inspect([map | t], opts, acc) when is_map(map),
+    do: do_inspect(t, opts, [handle_format_map(map, opts) | acc])
+  defp do_inspect([h | t], opts, acc),
+    do: do_inspect(t, opts, [h | acc])
+
+  @inspected_format_map %{
+    adjust: :right,
+    args: [],
+    control_char: ?s,
+    encoding: :unicode,
+    pad_char: ?\s,
+    precision: :none,
+    strings: true,
+    width: :none
+  }
+
+  defp handle_format_map(%{control_char: char} = map, opts) when char in 'wWpP',
+    do: %{@inspected_format_map | args: [inspect_data(map, opts)]}
+  defp handle_format_map(map, _opts),
+    do: map
+
+  defp inspect_data(%{strings: false} = map, opts) do
+    map
+    |> Map.delete(:strings)
+    |> inspect_data(%{opts | charlists: :as_lists})
+  end
+  defp inspect_data(%{width: width} = map, opts) do
+    map
+    |> Map.delete(:width)
+    |> inspect_data(%{opts | width: width})
+  end
+  defp inspect_data(%{control_char: ?W, args: [data, limit]}, opts) do
+    do_inspect_data(data, %{opts | limit: limit, width: :infinity})
+  end
+  defp inspect_data(%{control_char: ?w, args: [data]}, opts) do
+    do_inspect_data(data, %{opts | width: :infinity})
+  end
+  defp inspect_data(%{control_char: ?P, args: [data, limit]}, opts) do
+    do_inspect_data(data, %{opts | limit: limit})
+  end
+  defp inspect_data(%{control_char: ?p, args: [data]}, opts) do
+    do_inspect_data(data, opts)
   end
 
-  defp do_inspect([h | t], args, used_format, used_args, opts),
-    do: do_inspect(t, args, [h | used_format], used_args, opts)
-
-  defp do_inspect([], [], used_format, used_args, _opts),
-    do: {:lists.reverse(used_format), :lists.reverse(used_args)}
-
-  ## width
-
-  defp collect_cc(:width, [?- | t], args, used_format, used_args, opts),
-    do: collect_value(:width, t, args, [?- | used_format], used_args, opts, :precision)
-
-  defp collect_cc(:width, t, args, used_format, used_args, opts),
-    do: collect_value(:width, t, args, used_format, used_args, opts, :precision)
-
-  ## precision
-
-  defp collect_cc(:precision, [?. | t], args, used_format, used_args, opts),
-    do: collect_value(:precision, t, args, [?. | used_format], used_args, opts, :pad_char)
-
-  defp collect_cc(:precision, t, args, used_format, used_args, opts),
-    do: collect_cc(:pad_char, t, args, used_format, used_args, opts)
-
-  ## pad char
-
-  defp collect_cc(:pad_char, [?., ?* | t], [arg | args], used_format, used_args, opts),
-    do: collect_cc(:encoding, t, args, [?*, ?. | used_format], [arg | used_args], opts)
-
-  defp collect_cc(:pad_char, [?., p | t], args, used_format, used_args, opts),
-    do: collect_cc(:encoding, t, args, [p, ?. | used_format], used_args, opts)
-
-  defp collect_cc(:pad_char, t, args, used_format, used_args, opts),
-    do: collect_cc(:encoding, t, args, used_format, used_args, opts)
-
-  ## encoding
-
-  defp collect_cc(:encoding, [?l | t], args, used_format, used_args, opts),
-    do: collect_cc(:done, t, args, [?l | used_format], used_args, %{opts | charlists: :as_lists})
-
-  defp collect_cc(:encoding, [?t | t], args, used_format, used_args, opts),
-    do: collect_cc(:done, t, args, [?t | used_format], used_args, opts)
-
-  defp collect_cc(:encoding, t, args, used_format, used_args, opts),
-    do: collect_cc(:done, t, args, used_format, used_args, opts)
-
-  ## done
-
-  defp collect_cc(:done, [?W | t], [data, limit | args], _used_format, _used_args, opts),
-    do: collect_inspect(t, args, data, %{opts | limit: limit, width: :infinity})
-
-  defp collect_cc(:done, [?w | t], [data | args], _used_format, _used_args, opts),
-    do: collect_inspect(t, args, data, %{opts | width: :infinity})
-
-  defp collect_cc(:done, [?P | t], [data, limit | args], _used_format, _used_args, opts),
-    do: collect_inspect(t, args, data, %{opts | limit: limit})
-
-  defp collect_cc(:done, [?p | t], [data | args], _used_format, _used_args, opts),
-    do: collect_inspect(t, args, data, opts)
-
-  defp collect_cc(:done, [h | t], args, used_format, used_args, _opts) do
-    {args, used_args} = collect_cc(h, args, used_args)
-    {t, args, [h | used_format], used_args}
-  end
-
-  defp collect_cc(?x, [a, prefix | args], used), do: {args, [prefix, a | used]}
-  defp collect_cc(?X, [a, prefix | args], used), do: {args, [prefix, a | used]}
-  defp collect_cc(?s, [a | args], used), do: {args, [a | used]}
-  defp collect_cc(?e, [a | args], used), do: {args, [a | used]}
-  defp collect_cc(?f, [a | args], used), do: {args, [a | used]}
-  defp collect_cc(?g, [a | args], used), do: {args, [a | used]}
-  defp collect_cc(?b, [a | args], used), do: {args, [a | used]}
-  defp collect_cc(?B, [a | args], used), do: {args, [a | used]}
-  defp collect_cc(?+, [a | args], used), do: {args, [a | used]}
-  defp collect_cc(?#, [a | args], used), do: {args, [a | used]}
-  defp collect_cc(?c, [a | args], used), do: {args, [a | used]}
-  defp collect_cc(?i, [a | args], used), do: {args, [a | used]}
-  defp collect_cc(?~, args, used), do: {args, used}
-  defp collect_cc(?n, args, used), do: {args, used}
-
-  defp collect_inspect(t, args, data, opts) do
-    data =
-      data
-      |> Inspect.Algebra.to_doc(opts)
-      |> Inspect.Algebra.format(opts.width)
-    {t, args, 'st~', [data]}
-  end
-
-  defp collect_value(current, [?* | t], [arg | args], used_format, used_args, opts, next)
-      when is_integer(arg) do
-    collect_cc(next, t, args, [?* | used_format], [arg | used_args],
-               put_value(opts, current, arg))
-  end
-
-  defp collect_value(current, [c | t], args, used_format, used_args, opts, next)
-      when is_integer(c) and c >= ?0 and c <= ?9 do
-    {t, c} = collect_value([c | t], [])
-    collect_cc(next, t, args, c ++ used_format, used_args,
-               put_value(opts, current, c |> :lists.reverse |> List.to_integer))
-  end
-
-  defp collect_value(_current, t, args, used_format, used_args, opts, next),
-    do: collect_cc(next, t, args, used_format, used_args, opts)
-
-  defp collect_value([c | t], buffer)
-    when is_integer(c) and c >= ?0 and c <= ?9,
-    do: collect_value(t, [c | buffer])
-
-  defp collect_value(other, buffer),
-    do: {other, buffer}
-
-  defp put_value(opts, key, value) do
-    if Map.has_key?(opts, key) do
-      Map.put(opts, key, value)
-    else
-      opts
-    end
+  defp do_inspect_data(data, opts) do
+    data
+    |> Inspect.Algebra.to_doc(opts)
+    |> Inspect.Algebra.format(opts.width)
   end
 
   @doc """

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -117,15 +117,8 @@ defmodule Logger.Utils do
 
     format
     |> :io_lib.scan_format(args)
-    |> handle_format_list(opts, [])
+    |> Enum.map(&handle_format_spec(&1, opts))
   end
-
-  defp handle_format_list([], _opts, acc),
-    do: :lists.reverse(acc)
-  defp handle_format_list([spec | t], opts, acc) when is_map(spec),
-    do: handle_format_list(t, opts, [handle_format_spec(spec, opts) | acc])
-  defp handle_format_list([h | t], opts, acc),
-    do: handle_format_list(t, opts, [h | acc])
 
   @inspected_format_spec %{
     adjust: :right,

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -138,13 +138,8 @@ defmodule Logger.Utils do
     width: :none
   }
 
-  defp handle_format_spec(%{control_char: char} = spec, opts)
-       when char in 'wWpP' do
-    %{
-      args: args,
-      width: width,
-      strings: strings?
-    } = spec
+  defp handle_format_spec(%{control_char: char} = spec, opts) when char in 'wWpP' do
+    %{args: args, width: width, strings: strings?} = spec
 
     opts = %{
       opts |

--- a/lib/logger/test/logger/utils_test.exs
+++ b/lib/logger/test/logger/utils_test.exs
@@ -4,7 +4,11 @@ defmodule Logger.UtilsTest do
   import Logger.Utils
 
   import Kernel, except: [inspect: 2]
-  defp inspect(format, args), do: Logger.Utils.inspect(format, args, 10)
+  defp inspect(format, args) do
+    format
+    |> Logger.Utils.scan_inspect(args, 10)
+    |> :io_lib.unscan_format()
+  end
 
   test "truncate/2" do
     # ASCII binaries


### PR DESCRIPTION
Mentioned on #4617.

It made the code a lot easier to read.

I did not write any tests, since `Logger.Utils.inspect` already has some

There is also room for a performance improvement here.

The way `Logger.Utils.inspect` is used now follows the flow:

- scan the format
- handle the inpects
- unscan the format
- then it is used by `Logger.ErrorHandler.translate`, which calls `io_lib:format` that consequently:
  - scan the format again
  - then finally build it

To optimize, we can call `io_lib:build_text` on the scanned and inspected format
list.

I'll do it soon in this same PR if you could wait a little bit.