### PR TITLE
Update `IO.write/2` docs

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -144,7 +144,6 @@ defmodule IO do
   Writes `item` to the given `device`.
 
   By default the `device` is the standard output.
-  It returns `:ok` if it succeeds.
 
   ## Examples
 


### PR DESCRIPTION
When I was reading the documentation for this function a couple days
ago, the line "It returns `:ok` if it succeeds." was really confusing
to me. It made me think there was some other error possibility that I
was missing and should handle.

After looking at the Erlang docs for `:io.put_chars/2`, it looks like
there isn't some additional error case. Only then did I even notice the
typespec that says this function always returns `:ok`. So, I think this
line is misleading, and we should remove it.