### PR TITLE
Add newline spacing around documentation example

### DIFF
--- a/lib/elixir/lib/tuple.ex
+++ b/lib/elixir/lib/tuple.ex
@@ -98,6 +98,7 @@ defmodule Tuple do
   Inlined by the compiler.
 
   ## Examples
+  
       iex> tuple = {:foo, :bar}
       iex> Tuple.append(tuple, :baz)
       {:foo, :bar, :baz}


### PR DESCRIPTION
Fixed some inconsistent spacing in the documentation example for `Tuple.append`.