### PR TITLE
Use "number" instead of "amount" for count nouns

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -35,7 +35,7 @@ defmodule Calendar do
   @typedoc """
   The internal date format that is used when converting between calendars.
 
-  This is the amount of days including the fractional part that has passed of
+  This is the number of days including the fractional part that has passed of
   the last day since 0000-01-01+00:00T00:00.00000 in ISO 8601 notation (also
   known as midnight 1 January BC 1 of the Proleptic Gregorian Calendar).
 

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -36,8 +36,8 @@ defmodule Date do
   ## Using epochs
 
   The `add/2` and `diff/2` functions can be used for computing dates
-  or retrieving the amount of days betweens instants. For example, if there
-  is an interest in computing the amount of days from the Unix epoch
+  or retrieving the number of days between instants. For example, if there
+  is an interest in computing the number of days from the Unix epoch
   (1970-01-01):
 
       iex> Date.diff(~D[2010-04-17], ~D[1970-01-01])

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -45,8 +45,8 @@ defmodule NaiveDateTime do
   ## Using epochs
 
   The `add/3` and `diff/3` functions can be used for computing with
-  date times or retrieving the amount of seconds betweens instants.
-  For example, if there is an interest in computing the amount of
+  date times or retrieving the number of seconds between instants.
+  For example, if there is an interest in computing the number of
   seconds from the Unix epoch (1970-01-01 00:00:00):
 
       iex> NaiveDateTime.diff(~N[2010-04-17 14:00:00], ~N[1970-01-01 00:00:00])

--- a/lib/elixir/lib/file/stream.ex
+++ b/lib/elixir/lib/file/stream.ex
@@ -7,7 +7,7 @@ defmodule File.Stream do
     * `path`          - the file path
     * `modes`         - the file modes
     * `raw`           - a boolean indicating if bin functions should be used
-    * `line_or_bytes` - if reading should read lines or a given amount of bytes
+    * `line_or_bytes` - if reading should read lines or a given number of bytes
 
   """
 

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -657,7 +657,7 @@ defmodule GenServer do
     * `:name` - used for name registration as described in the "Name
       registration" section of the module documentation
 
-    * `:timeout` - if present, the server is allowed to spend the given amount of
+    * `:timeout` - if present, the server is allowed to spend the given number of
       milliseconds initializing or it will be terminated and the start function
       will return `{:error, :timeout}`
 

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -510,7 +510,7 @@ defmodule Inspect.Algebra do
   documented is processed.
 
   This function is used by `surround/4` and friends
-  to the maximum amount of entries on the same line.
+  to the maximum number of entries on the same line.
   """
   @spec flex_break(binary) :: doc_break
   def flex_break(string \\ " ") when is_binary(string) do
@@ -522,7 +522,7 @@ defmodule Inspect.Algebra do
   `flex_break/1` given by `break_string` between them.
 
   This function is used by `surround/4` and friends
-  to the maximum amount of entries on the same line.
+  to the maximum number of entries on the same line.
   """
   @spec flex_glue(t, binary, t) :: t
   def flex_glue(doc1, break_string \\ " ", doc2) when is_binary(break_string) do

--- a/lib/elixir/lib/io/stream.ex
+++ b/lib/elixir/lib/io/stream.ex
@@ -16,7 +16,7 @@ defmodule IO.Stream do
 
     * `device`        - the IO device
     * `raw`           - a boolean indicating if bin functions should be used
-    * `line_or_bytes` - if reading should read lines or a given amount of bytes
+    * `line_or_bytes` - if reading should read lines or a given number of bytes
 
   It is worth noting that an IO stream has side effects and every time you go
   over the stream you may get different results.

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -48,11 +48,11 @@ defmodule Kernel do
     * `Atom` - literal constants with a name (`true`, `false`, and `nil` are atoms)
     * `Float` - numbers with floating point precision
     * `Integer` - whole numbers (not fractions)
-    * `List` - collections of a variable amount of elements (linked lists)
+    * `List` - collections of a variable number of elements (linked lists)
     * `Map` - collections of key-value pairs
     * `Process` - light-weight threads of execution
     * `Port` - mechanisms to interact with the external world
-    * `Tuple` - collections of fixed amount of elements
+    * `Tuple` - collections of a fixed number of elements
 
   There are three data-types without an accompanying module:
 

--- a/lib/elixir/lib/module/locals_tracker.ex
+++ b/lib/elixir/lib/module/locals_tracker.ex
@@ -156,7 +156,7 @@ defmodule Module.LocalsTracker do
   end
 
   # Collect all unused definitions based on the private
-  # given also accounting the expected amount of default
+  # given, also accounting the expected number of default
   # clauses a private function have.
   @doc false
   def collect_unused_locals(ref, private) do

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -369,7 +369,7 @@ defmodule Supervisor do
       `:one_for_one`, `:rest_for_one`, `:one_for_all`, or
       `:simple_one_for_one`. See the "Strategies" section.
 
-    * `:max_restarts` - the maximum amount of restarts allowed in
+    * `:max_restarts` - the maximum number of restarts allowed in
       a time frame. Defaults to `3`.
 
     * `:max_seconds` - the time frame in which `:max_restarts` applies.
@@ -589,7 +589,7 @@ defmodule Supervisor do
       `:simple_one_for_one`. You can learn more about strategies
       in the `Supervisor` module docs.
 
-    * `:max_restarts` - the maximum amount of restarts allowed in
+    * `:max_restarts` - the maximum number of restarts allowed in
       a time frame. Defaults to `3`.
 
     * `:max_seconds` - the time frame in which `:max_restarts` applies.

--- a/lib/elixir/lib/supervisor/spec.ex
+++ b/lib/elixir/lib/supervisor/spec.ex
@@ -152,7 +152,7 @@ defmodule Supervisor.Spec do
       `:simple_one_for_one`. You can learn more about strategies
       in the `Supervisor` module docs.
 
-    * `:max_restarts` - the maximum amount of restarts allowed in
+    * `:max_restarts` - the maximum number of restarts allowed in
       a time frame. Defaults to `3`.
 
     * `:max_seconds` - the time frame in which `:max_restarts` applies.

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -625,7 +625,7 @@ defmodule Task do
       end
 
   In the example above, we create tasks that sleep from 1
-  up to 10 seconds and return the amount of seconds they slept.
+  up to 10 seconds and return the number of seconds they slept.
   If you execute the code all at once, you should see 1 up to 5
   printed, as those were the tasks that have replied in the
   given time. All other tasks will have been shut down using

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -17,7 +17,7 @@ defmodule RegistryTest do
     describe "unique #{describe}" do
       @describetag keys: :unique, partitions: partitions
 
-      test "starts configured amount of partitions", %{registry: registry, partitions: partitions} do
+      test "starts configured number of partitions", %{registry: registry, partitions: partitions} do
         assert length(Supervisor.which_children(registry)) == partitions
       end
 
@@ -241,7 +241,7 @@ defmodule RegistryTest do
     describe "duplicate #{describe}" do
       @describetag keys: :duplicate, partitions: partitions
 
-      test "starts configured amount of partitions", %{registry: registry, partitions: partitions} do
+      test "starts configured number of partitions", %{registry: registry, partitions: partitions} do
         assert length(Supervisor.which_children(registry)) == partitions
       end
 

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -57,7 +57,7 @@ defmodule Mix.Tasks.Test do
       result in the tests being run again. Very useful when combined with `--stale` and
       external commands which produce output on stdout upon file system modification.
     * `--max-cases` - sets the maximum number of tests running async. Only tests from
-      different modules run in parallel. Defaults to twice the amount of cores.
+      different modules run in parallel. Defaults to twice the number of cores.
     * `--no-archives-check` - does not check archives
     * `--no-color` - disables color in the output
     * `--no-compile` - does not compile, even if files require compilation


### PR DESCRIPTION
"amount" is [not grammatical](https://english.stackexchange.com/questions/337989/the-amount-of-vs-the-number-of-etc/337998#337998) when used with count nouns (e.g. days, seconds, bytes, entries, restarts, partitions, cores).