### PR TITLE
Fix more typos and spelling errors

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -37,7 +37,7 @@ defmodule Calendar do
 
   This is the amount of days including the fractional part that has passed of
   the last day since 0000-01-01+00:00T00:00.00000 in ISO 8601 notation (also
-  known as midnight 1 January BC 1 of the Proleptic Gregorian Calendar).
+  known as midnight 1 January BC 1 of the proleptic Gregorian calendar).
 
   The `parts_per_day` represent how many subparts the current day is subdivided in
   (for different calendars, picking a different `parts_per_day` might make sense).

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -422,7 +422,7 @@ defmodule Date do
   end
 
   @doc """
-  Converts the given `date` from it's calendar to the given `calendar`.
+  Converts the given `date` from its calendar to the given `calendar`.
 
   Returns `{:ok, date}` if the calendars are compatible,
   or `{:error, :incompatible_calendars}` if they are not.
@@ -482,7 +482,7 @@ defmodule Date do
   @doc """
   Adds the number of days to the given `date`.
 
-  The days are counted as gregorian days. The date is returned in the same
+  The days are counted as Gregorian days. The date is returned in the same
   calendar as it was given in.
 
   ## Examples
@@ -505,7 +505,7 @@ defmodule Date do
   @doc """
   Calculates the difference between two dates, in a full number of days.
 
-  It returns the number of gregorian days between the dates. Only `Date`
+  It returns the number of Gregorian days between the dates. Only `Date`
   structs that follow the same or compatible calendars can be compared
   this way. If two calendars are not compatible, it will raise.
 

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -647,7 +647,7 @@ defmodule DateTime do
     end
   end
 
-  defp to_iso_days(%{calendar: calendar,year: year, month: month, day: day,
+  defp to_iso_days(%{calendar: calendar, year: year, month: month, day: day,
                      hour: hour, minute: minute, second: second, microsecond: microsecond}) do
     calendar.naive_datetime_to_iso_days(year, month, day, hour, minute, second, microsecond)
   end

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1642,7 +1642,7 @@ defmodule Enum do
   in the `enumerable` as its only argument. Returns a tuple with the first list
   containing all the elements in `enumerable` for which applying `fun` returned
   a truthy value, and a second list with all the elements for which applying
-  `fun` returned a falsey value (`false` or `nil`).
+  `fun` returned a falsy value (`false` or `nil`).
 
   The elements in both the returned lists are in the same relative order as they
   were in the original enumerable (if such enumerable was ordered, e.g., a

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -326,7 +326,7 @@ defmodule Module do
     * the function/macro name
     * the list of quoted arguments
     * the list of quoted guards
-    * the squoted function body
+    * the quoted function body
 
   Note the hook receives the quoted arguments and it is invoked before
   the function is stored in the module. So `Module.defines?/2` will return
@@ -680,8 +680,8 @@ defmodule Module do
     {simplify_var(var, nil), acc}
   end
 
-  # If we have only the varible as argument, it also gets
-  # higher priority. However, if the variable starts with
+  # If we have only the variable as argument, it also gets
+  # higher priority. However, if the variable starts with an
   # underscore, we give it a secondary context (Elixir) with
   # lower priority.
   defp simplify_signature({var, _, atom}, acc) when is_atom(atom) do

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -811,7 +811,7 @@ defmodule Registry do
     {pid_server, pid_ets} = pid_ets || pid_ets!(registry, pid_partition)
 
     # Notice we write first to the pid ets table because it will
-    # always be able to do the clean up. If we register first to the
+    # always be able to do the cleanup. If we register first to the
     # key one and the process crashes, the key will stay there forever.
     Process.link(pid_server)
     true = :ets.insert(pid_ets, {self, key, key_ets})

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -140,7 +140,7 @@ defmodule Supervisor do
   When a supervisor shuts down, it terminates all children in the opposite
   order they are listed. The termination happens by sending a shutdown exit
   signal to the child process and then awaiting for a time interval, which
-  defaults to 5000 miliseconds, for the child process to terminate. If the
+  defaults to 5000 milliseconds, for the child process to terminate. If the
   child process does not terminate, it is abruptly terminated with reason
   `:brutal_kill`. The shutdown time can be configured in the child specification
   which is detailed in the next section.
@@ -205,7 +205,7 @@ defmodule Supervisor do
   and the `:shutdown` is `:infinity`. Still, if you need to customize
   a certain behaviour, you can do so by defining your own `child_spec/1`
   function or by passing options on `use`. For example, to specify a
-  `GenServer` with a shutdown limit of 10 seconds (10_000 miliseconds),
+  `GenServer` with a shutdown limit of 10 seconds (10_000 milliseconds),
   one might do:
 
       use GenServer, shutdown: 10_000
@@ -219,12 +219,12 @@ defmodule Supervisor do
     * `:brutal_kill` - the child process is unconditionally terminated
       using `Process.exit(child, :kill)`.
 
-    * any integer >= 0 - the amount of time in miliseconds that the
+    * any integer >= 0 - the amount of time in milliseconds that the
       supervisor will wait for children to terminate after emitting a
       `Process.exit(child, :shutdown)` signal. If the child process is
       not trapping exits, the initial `:shutdown` signal will terminate
       the child process immediately. If the child process is trapping
-      exits, it has the given amount of time in miliseconds to terminate.
+      exits, it has the given amount of time in milliseconds to terminate.
       If it doesn't terminate within the specified time, the child process
       is unconditionally terminated by the supervisor via
       `Process.exit(child, :kill)`.

--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -424,7 +424,7 @@ defmodule Task.Supervised do
         stream_monitor_loop(running_tasks, config)
 
       # The parent process is telling us to stop because the stream is being
-      # closed. In this case, we forcely kill all spawned processes and then
+      # closed. In this case, we forcibly kill all spawned processes and then
       # exit gracefully ourselves.
       {:stop, ^monitor_ref} ->
         Process.flag(:trap_exit, true)
@@ -438,7 +438,7 @@ defmodule Task.Supervised do
 
       # The parent process went down with a given reason. We kill all the
       # spawned processes (that are also linked) with the same reason, and then
-      # exit ourself with the same reason.
+      # exit ourselves with the same reason.
       {:DOWN, ^parent_ref, _, _, reason} ->
         for {_ref, %{type: :link, pid: pid}} <- running_tasks do
           Process.exit(pid, reason)

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -212,7 +212,7 @@ eval_quoted(Tree, Binding, #{line := Line} = E) ->
   eval_forms(elixir_quote:linify(Line, Tree), Binding, E).
 
 %% Handle forms evaluation. The main difference to
-%% eval_quoted is that it does not linefy the given
+%% eval_quoted is that it does not linify the given
 %% args.
 
 eval_forms(Tree, Binding, Opts) when is_list(Opts) ->

--- a/lib/elixir/src/elixir_bootstrap.erl
+++ b/lib/elixir/src/elixir_bootstrap.erl
@@ -1,5 +1,5 @@
 %% An Erlang module that behaves like an Elixir module
-%% used for bootstraping.
+%% used for bootstrapping.
 -module(elixir_bootstrap).
 -export(['MACRO-def'/2, 'MACRO-def'/3, 'MACRO-defp'/3, 'MACRO-defmodule'/3,
          'MACRO-defmacro'/2, 'MACRO-defmacro'/3, 'MACRO-defmacrop'/3,

--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -121,7 +121,7 @@ allows_fast_compilation({'__block__', _, Exprs}) ->
 allows_fast_compilation({defmodule, _, _}) -> true;
 allows_fast_compilation(_) -> false.
 
-%% Bootstraper
+%% Bootstrapper
 
 bootstrap() ->
   {ok, _} = application:ensure_all_started(elixir),

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -135,7 +135,7 @@ load_struct(Meta, Name, Args, InContext, E) ->
         %% local function will fail. In this case, we need to fallback to
         %% the regular dispatching since the module will be available if
         %% the table has not been deleted (unless compilation of that
-        %% module failed which then should cause this call to fail too).
+        %% module failed which should then cause this call to fail too).
         try
           apply(LocalFun, Args)
         catch

--- a/lib/elixir/test/elixir/base_test.exs
+++ b/lib/elixir/test/elixir/base_test.exs
@@ -474,11 +474,11 @@ defmodule BaseTest do
     end
   end
 
-  test "decode32/2 with one pad and :pading to false" do
+  test "decode32/2 with one pad and :padding to false" do
     assert {:ok, "foob"} == decode32("MZXW6YQ", padding: false)
   end
 
-  test "decode32!/2 with one pad and :pading to false" do
+  test "decode32!/2 with one pad and :padding to false" do
     assert "foob" == decode32!("MZXW6YQ", padding: false)
   end
 

--- a/lib/elixir/test/elixir/kernel/alias_test.exs
+++ b/lib/elixir/test/elixir/kernel/alias_test.exs
@@ -22,7 +22,7 @@ defmodule Kernel.AliasTest do
     assert Nested2.value == 1
   end
 
-  test "overwriten alias" do
+  test "overwritten alias" do
     assert alias(List, as: Nested) == List
     assert Nested.flatten([[13]]) == [13]
   end

--- a/lib/elixir/test/elixir/kernel/dialyzer_test.exs
+++ b/lib/elixir/test/elixir/kernel/dialyzer_test.exs
@@ -92,7 +92,7 @@ defmodule Kernel.DialyzerTest do
     assert_dialyze_no_warnings! context
   end
 
-  test "no warnings on for falsey check that always boolean", context do
+  test "no warnings on for falsy check that always boolean", context do
     copy_beam! context, Dialyzer.ForBooleanCheck
     assert_dialyze_no_warnings! context
   end

--- a/lib/elixir/test/elixir/kernel/import_test.exs
+++ b/lib/elixir/test/elixir/kernel/import_test.exs
@@ -114,7 +114,7 @@ defmodule Kernel.ImportTest do
 
   import Bitwise, only: :macros
 
-  test "conflicing imports with only and except" do
+  test "conflicting imports with only and except" do
     import Bitwise, only: :macros, except: [bnot: 1]
     import MessedBitwise, only: [bnot: 1]
     assert bnot(0) == 0

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -496,8 +496,8 @@ defmodule RegistryTest do
         kill_and_assert_down(task1)
         kill_and_assert_down(task2)
 
-        # pid might be in different parition to key so need to sync with all
-        # paritions before checking ets tables are empty.
+        # pid might be in different partition to key so need to sync with all
+        # partitions before checking ets tables are empty.
         for i <- 0..7 do
           [{_, _, {partition, _}}] = :ets.lookup(registry, i)
           GenServer.call(partition, :sync)

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -105,7 +105,7 @@ defmodule SystemTest do
 
     @echo "echo-elixir-test"
 
-    test "cmd/2 with absolute and relative paths win" do
+    test "cmd/2 with absolute and relative Windows paths" do
       echo = tmp_path(@echo)
       File.mkdir_p! Path.dirname(echo)
       File.cp! System.find_executable("cmd"), echo
@@ -136,7 +136,7 @@ defmodule SystemTest do
 
     @echo "echo-elixir-test"
 
-    test "cmd/2 with absolute and relative paths ynix" do
+    test "cmd/2 with absolute and relative Unix paths" do
       echo = tmp_path(@echo)
       File.mkdir_p! Path.dirname(echo)
       File.cp! System.find_executable("echo"), echo

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -32,7 +32,7 @@ defmodule ExUnit.Callbacks do
   linked to the test process will also exit, although asynchronously. Therefore
   it is preferred to use `start_supervised/2` to guarantee synchronous termination.
 
-  Here is a run down of the life-cycle of the test process:
+  Here is a rundown of the life-cycle of the test process:
 
     1. the test process is spawned
     2. it runs `setup/2` callbacks

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -80,7 +80,7 @@ defmodule IEx.HelpersTest do
                      fn -> break!(URI, :unknown, 2) end
       end
 
-      test "errors for non elixir modules" do
+      test "errors for non-Elixir modules" do
         assert_raise RuntimeError,
                      "could not set breakpoint, module :elixir was not written in Elixir",
                      fn -> break!(:elixir, :unknown, 2) end
@@ -672,7 +672,7 @@ defmodule IEx.HelpersTest do
         Sample.run
       end
 
-      assert l(:non_existent_module) == {:error, :nofile}
+      assert l(:nonexistent_module) == {:error, :nofile}
 
       filename = "sample.ex"
       with_file filename, test_module_code(), fn ->
@@ -695,7 +695,7 @@ defmodule IEx.HelpersTest do
 
   describe "nl" do
     test "loads a given module on the given nodes" do
-      assert nl(:non_existent_module) == {:error, :nofile}
+      assert nl(:nonexistent_module) == {:error, :nofile}
       assert nl([node()], Enum) == {:ok, [{:nonode@nohost, :loaded, Enum}]}
       assert nl([:nosuchnode@badhost], Enum) == {:ok, [{:nosuchnode@badhost, :badrpc, :nodedown}]}
       capture_log fn ->
@@ -705,9 +705,9 @@ defmodule IEx.HelpersTest do
   end
 
   describe "r" do
-    test "raises when reloading a non existent module" do
-      assert_raise ArgumentError, "could not load nor find module: :non_existent_module", fn ->
-        r :non_existent_module
+    test "raises when reloading a nonexistent module" do
+      assert_raise ArgumentError, "could not load nor find module: :nonexistent_module", fn ->
+        r :nonexistent_module
       end
     end
 

--- a/lib/iex/test/iex/pry_test.exs
+++ b/lib/iex/test/iex/pry_test.exs
@@ -88,7 +88,7 @@ defmodule IEx.PryTest do
         assert IEx.Pry.break(URI, :unknown, 2) == {:error, :unknown_function_arity}
       end
 
-      test "errors for non elixir modules" do
+      test "errors for non-Elixir modules" do
         assert IEx.Pry.break(:elixir, :unknown, 2) == {:error, :non_elixir_module}
       end
     end

--- a/lib/iex/test/iex/server_test.exs
+++ b/lib/iex/test/iex/server_test.exs
@@ -18,7 +18,7 @@ defmodule IEx.ServerTest do
   end
 
   describe "take_over" do
-    test "allows take over of the shell during boot" do
+    test "allows takeover of the shell during boot" do
       assert capture_io("Y\na+b", fn ->
         server = self()
         boot([], fn ->
@@ -28,7 +28,7 @@ defmodule IEx.ServerTest do
       end) =~ "dbg(1)> "
     end
 
-    test "continues if take over is refused" do
+    test "continues if takeover is refused" do
       assert capture_io("N\n", fn ->
         server = self()
         boot([], fn ->
@@ -49,7 +49,7 @@ defmodule IEx.ServerTest do
     end
   end
 
-  test "pry wraps around take over" do
+  test "pry wraps around takeover" do
     require IEx
     assert capture_io(fn ->
       assert IEx.pry == {:error, :no_iex}

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -682,7 +682,7 @@ defmodule Logger do
 
   The macros `debug/2`, `warn/2`, `info/2`, and `error/2` are
   preferred over this macro as they can automatically eliminate
-  the call to `Logger` alotgether at compile time if desired
+  the call to `Logger` altogether at compile time if desired
   (see the documentation for the `Logger` module).
   """
   defmacro log(level, chardata_or_fun, metadata \\ []) do

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -156,7 +156,7 @@ defmodule Mix do
       [clean: ["clean", &clean_extra/1]]
 
   Where `&clean_extra/1` would be a function in your `mix.exs`
-  with extra clean up logic.
+  with extra cleanup logic.
 
   Note aliases do not show up on `mix help`.
   Aliases defined in the current project do not affect its dependencies and aliases defined in dependencies are not accessible from the current project.

--- a/lib/mix/lib/mix/compilers/test.ex
+++ b/lib/mix/lib/mix/compilers/test.ex
@@ -215,7 +215,7 @@ defmodule Mix.Compilers.Test do
             do: module,
             into: MapSet.new()
 
-      stale_modules = find_all_dependant_on(stale_modules, elixir_manifest_entries.source, elixir_manifest_entries.module)
+      stale_modules = find_all_dependent_on(stale_modules, elixir_manifest_entries.source, elixir_manifest_entries.module)
 
       for module <- stale_modules,
           source(source: source, runtime_references: r, compile_references: c) <- test_sources,
@@ -227,27 +227,27 @@ defmodule Mix.Compilers.Test do
     end
   end
 
-  defp find_all_dependant_on(modules, sources, all_modules, resolved \\ MapSet.new()) do
+  defp find_all_dependent_on(modules, sources, all_modules, resolved \\ MapSet.new()) do
     new_modules =
       for module <- modules,
           module not in resolved,
-          dependant_module <- dependant_modules(module, all_modules, sources),
-          do: dependant_module,
+          dependent_module <- dependent_modules(module, all_modules, sources),
+          do: dependent_module,
           into: modules
 
     if MapSet.size(new_modules) == MapSet.size(modules) do
       new_modules
     else
-      find_all_dependant_on(new_modules, sources, all_modules, modules)
+      find_all_dependent_on(new_modules, sources, all_modules, modules)
     end
   end
 
-  defp dependant_modules(module, modules, sources) do
+  defp dependent_modules(module, modules, sources) do
     for CE.source(source: source, runtime_references: r, compile_references: c) <- sources,
         module in r or module in c,
-        CE.module(sources: sources, module: dependant_module) <- modules,
+        CE.module(sources: sources, module: dependent_module) <- modules,
         source in sources,
-        do: dependant_module
+        do: dependent_module
   end
 
   ## ParallelRequire callback

--- a/lib/mix/lib/mix/remote_converger.ex
+++ b/lib/mix/lib/mix/remote_converger.ex
@@ -26,7 +26,7 @@ defmodule Mix.RemoteConverger do
 
   @doc """
   Called after all convergers have run so that the remote
-  converger can perform clean up.
+  converger can perform cleanup.
   """
   @callback post_converge() :: any
 

--- a/lib/mix/test/mix/tasks/deps.path_test.exs
+++ b/lib/mix/test/mix/tasks/deps.path_test.exs
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.DepsPathTest do
   end
 
   @tag apps: [:raw_sample]
-  test "compiles ands runs even if lock does not match" do
+  test "compiles and runs even if lock does not match" do
     Mix.Project.push DepsApp
 
     in_fixture "deps_status", fn ->

--- a/lib/mix/test/mix/tasks/loadconfig_test.exs
+++ b/lib/mix/test/mix/tasks/loadconfig_test.exs
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.LoadconfigTest do
       :ok = :application.load({:application, :my_app, [vsn: '1.0.0', env: [key: :app]]})
       assert Application.fetch_env(:my_app, :key) == {:ok, :project}
 
-      # laodconfig can be called multiple times
+      # loadconfig can be called multiple times
       # Later values should have higher precedence
       Mix.Task.run "loadconfig", [fixture_path("configs/good_config.exs")]
       assert Application.fetch_env(:my_app, :key) == {:ok, :value}

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -66,7 +66,7 @@ defmodule Mix.UtilsTest do
 
   @windows? match?({:win32, _}, :os.type)
   unless @windows? do
-    test "symlink or copy erases wrong symblinks" do
+    test "symlink or copy erases wrong symlinks" do
       in_fixture "archive", fn ->
         File.mkdir_p!("_build/archive")
         Mix.Utils.symlink_or_copy(Path.expand("priv"), Path.expand("_build/archive/ebin"))


### PR DESCRIPTION
Notes:

standardize on "falsy" because there are more instances of that in the code already

"clean up" isn't a noun, "cleanup" is

"run down" isn't a noun

"take over" isn't a noun

A dependant is a person who is dependent on someone else; "dependent" is the adjective; American English uses "dependent" for both which makes things really simple when code has both "dependent on" and "dependent module"
