### PR TITLE
Return valid MapSet when union-ing a legacy MapSet

### DIFF
--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -351,7 +351,8 @@ defmodule MapSet do
     %{map_set | map: Map.merge(map1, map2)}
   end
   def union(%MapSet{map: map1}, %MapSet{map: map2}) do
-    new_from_list(Map.keys(map1) ++ Map.keys(map2), [])
+    map = new_from_list(Map.keys(map1) ++ Map.keys(map2), [])
+    %MapSet{map: map}
   end
 
   @compile {:inline, [order_by_size: 2]}

--- a/lib/elixir/test/elixir/map_set_test.exs
+++ b/lib/elixir/test/elixir/map_set_test.exs
@@ -109,37 +109,37 @@ defmodule MapSetTest do
     assert Enum.sort(list) == Enum.to_list(5..120)
   end
 
-  test "pre-1.5 MapSet compatibility" do
-    result = v1_mapset(1..5) |> MapSet.new()
+  test "MapSet v1 compatibility" do
+    result = 1..5 |> map_set_v1() |> MapSet.new()
     assert MapSet.equal?(result, MapSet.new(1..5))
 
-    result = MapSet.put(v1_mapset(1..5), 6)
+    result = MapSet.put(map_set_v1(1..5), 6)
     assert MapSet.equal?(result, MapSet.new(1..6))
 
-    result = MapSet.union(v1_mapset(1..5), MapSet.new(6..10))
+    result = MapSet.union(map_set_v1(1..5), MapSet.new(6..10))
     assert MapSet.equal?(result, MapSet.new(1..10))
 
-    result = MapSet.intersection(v1_mapset(1..10), MapSet.new(6..15))
+    result = MapSet.intersection(map_set_v1(1..10), MapSet.new(6..15))
     assert MapSet.equal?(result, MapSet.new(6..10))
 
-    result = MapSet.difference(v1_mapset(1..10), MapSet.new(6..50))
+    result = MapSet.difference(map_set_v1(1..10), MapSet.new(6..50))
     assert MapSet.equal?(result, MapSet.new(1..5))
 
-    result = MapSet.delete(v1_mapset(1..10), 1)
+    result = MapSet.delete(map_set_v1(1..10), 1)
     assert MapSet.equal?(result, MapSet.new(2..10))
 
-    assert MapSet.size(v1_mapset(1..5)) == 5
-    assert MapSet.to_list(v1_mapset(1..5)) == Enum.to_list(1..5)
+    assert MapSet.size(map_set_v1(1..5)) == 5
+    assert MapSet.to_list(map_set_v1(1..5)) == Enum.to_list(1..5)
 
-    assert MapSet.disjoint?(v1_mapset(1..5), MapSet.new(10..15))
-    refute MapSet.disjoint?(v1_mapset(1..5), MapSet.new(5..10))
+    assert MapSet.disjoint?(map_set_v1(1..5), MapSet.new(10..15))
+    refute MapSet.disjoint?(map_set_v1(1..5), MapSet.new(5..10))
 
-    assert MapSet.subset?(v1_mapset(3..7), MapSet.new(1..10))
-    refute MapSet.subset?(v1_mapset(7..12), MapSet.new(1..10))
+    assert MapSet.subset?(map_set_v1(3..7), MapSet.new(1..10))
+    refute MapSet.subset?(map_set_v1(7..12), MapSet.new(1..10))
   end
 
-  defp v1_mapset(enumerable) do
-    map = Enum.reduce(enumerable, %{}, &Map.put(&2, &1, true))
+  defp map_set_v1(enumerable) do
+    map = Map.new(1..5, &{&1, true})
     %{__struct__: MapSet, map: map}
   end
 end

--- a/lib/elixir/test/elixir/map_set_test.exs
+++ b/lib/elixir/test/elixir/map_set_test.exs
@@ -108,4 +108,38 @@ defmodule MapSetTest do
     list = MapSet.to_list(MapSet.new(5..120))
     assert Enum.sort(list) == Enum.to_list(5..120)
   end
+
+  test "pre-1.5 MapSet compatibility" do
+    result = v1_mapset(1..5) |> MapSet.new()
+    assert MapSet.equal?(result, MapSet.new(1..5))
+
+    result = MapSet.put(v1_mapset(1..5), 6)
+    assert MapSet.equal?(result, MapSet.new(1..6))
+
+    result = MapSet.union(v1_mapset(1..5), MapSet.new(6..10))
+    assert MapSet.equal?(result, MapSet.new(1..10))
+
+    result = MapSet.intersection(v1_mapset(1..10), MapSet.new(6..15))
+    assert MapSet.equal?(result, MapSet.new(6..10))
+
+    result = MapSet.difference(v1_mapset(1..10), MapSet.new(6..50))
+    assert MapSet.equal?(result, MapSet.new(1..5))
+
+    result = MapSet.delete(v1_mapset(1..10), 1)
+    assert MapSet.equal?(result, MapSet.new(2..10))
+
+    assert MapSet.size(v1_mapset(1..5)) == 5
+    assert MapSet.to_list(v1_mapset(1..5)) == Enum.to_list(1..5)
+
+    assert MapSet.disjoint?(v1_mapset(1..5), MapSet.new(10..15))
+    refute MapSet.disjoint?(v1_mapset(1..5), MapSet.new(5..10))
+
+    assert MapSet.subset?(v1_mapset(3..7), MapSet.new(1..10))
+    refute MapSet.subset?(v1_mapset(7..12), MapSet.new(1..10))
+  end
+
+  defp v1_mapset(enumerable) do
+    map = Enum.reduce(enumerable, %{}, &Map.put(&2, &1, true))
+    %{__struct__: MapSet, map: map}
+  end
 end


### PR DESCRIPTION
Right now, the `union` function returns a bare map instead of a `MapSet` struct when operating on `MapSet`s with differing versions. This fix wraps the map appropriately.

Although this fixes behaviour at the `MapSet` API level, I'm not sure what level of support there is intended to be for legacy `MapSet`. Some of the functions have potentially unwanted behaviour that results in a hybrid `MapSet` (legacy `MapSet` with `[]` values, or v2 `MapSet` with `true` values) that would fail pattern matching even if both are at the same version.

```
Erlang/OTP 20 [erts-9.0] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:10] [hipe] [kernel-poll:false]

Interactive Elixir (1.5.1) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> old = %{__struct__: MapSet, map: %{a: true, b: true, c: true, d: true, e: true, f: true}}
#MapSet<[:a, :b, :c, :d, :e, :f]>
iex(2)> new = MapSet.new([:e, :f, :g])
#MapSet<[:e, :f, :g]>
iex(3)> inspect old, structs: false
"%{__struct__: MapSet, map: %{a: true, b: true, c: true, d: true, e: true, f: true}}"
iex(4)> inspect new, structs: false
"%{__struct__: MapSet, map: %{e: [], f: [], g: []}, version: 2}"
iex(5)> old_plus_h = MapSet.put(old, :h)
#MapSet<[:a, :b, :c, :d, :e, :f, :h]>
iex(6)> inspect old_plus_h, structs: false
"%{__struct__: MapSet, map: %{a: true, b: true, c: true, d: true, e: true, f: true, h: []}}"
iex(7)> intersection = MapSet.intersection(new, old)
#MapSet<[:e, :f]>
iex(8)> inspect intersection, structs: false
"%{__struct__: MapSet, map: %{e: true, f: true}, version: 2}"
```