### PR TITLE
Faster version for List.last/1

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -240,8 +240,7 @@ defmodule List do
   """
   @spec last([elem]) :: nil | elem when elem: var
   def last([]), do: nil
-  def last([head]), do: head
-  def last([_ | tail]), do: last(tail)
+  def last(list), do: :erlang.hd(:lists.reverse(list))
 
   @doc """
   Receives a list of tuples and returns the first tuple


### PR DESCRIPTION
For Erlang it's about two times faster to reverse the list and take the last element than traversing all it's elements, however, I'm not sure does it make sense to optimize such operations. 

On my laptop results are:
```
Settings:
  duration:      1.0 s

## ListBench
[19:27:38] 1/6: Elixir 10
[19:27:46] 2/6: Elixir 10000
[19:27:52] 3/6: Elixir 1000000
[19:27:58] 4/6: Reverse 10
[19:28:04] 5/6: Reverse 10000
[19:28:07] 6/6: Reverse 1000000

Finished in 32.89 seconds

## ListBench
benchmark name   iterations   average time 
Reverse 10        100000000   0.06 µs/op
Elixir 10         100000000   0.08 µs/op
Reverse 10000      10000000   0.28 µs/op
Reverse 1000000    10000000   0.29 µs/op
Elixir 10000       10000000   0.52 µs/op
Elixir 1000000     10000000   0.52 µs/op
```
