### PR TITLE
Fix typo in Task.Supervisor

### DIFF
--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -22,7 +22,7 @@ defmodule Task.Supervisor do
   @doc false
   def child_spec(arg) do
     %{
-      id: Task.Supervivsor,
+      id: Task.Supervisor,
       start: {Task.Supervisor, :start_link, [arg]},
       type: :supervisor
     }


### PR DESCRIPTION
Just noticed this one while attending the OTP workshop @ ElixirConf 2017 🔨 