### PR TITLE
Add support for supervisor fun to Task.Supervisor.async_stream

### DIFF
--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -319,23 +319,17 @@ defmodule Task.Supervisor do
   end
 
   defp supervisor_fun(supervisor, {_module, _fun, _args})
-      when is_function(supervisor, 1) do
-    fn {_module, _fun, [entry | _rest_args]} ->
-      supervisor.(entry)
-    end
+       when is_function(supervisor, 1) do
+    fn {_module, _fun, [entry | _rest_args]} -> supervisor.(entry) end
   end
 
   defp supervisor_fun(supervisor, fun)
-      when is_function(supervisor, 1) and is_function(fun, 1) do
-    fn {_erlang, _apply, [_fun, [entry]]} ->
-      supervisor.(entry)
-    end
+       when is_function(supervisor, 1) and is_function(fun, 1) do
+    fn {_erlang, _apply, [_fun, [entry]]} -> supervisor.(entry) end
   end
 
   defp supervisor_fun(supervisor, _fun) do
-    fn _mfa ->
-      supervisor
-    end
+    fn _mfa -> supervisor end
   end
 
   defp build_stream(supervisor, link_type, enumerable, fun, options) do

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -157,12 +157,13 @@ defmodule Task.Supervisor do
   linked to the current process, similarly to `async/4`.
 
   You may also provide a function as the `supervisor`. Before each task is
-  started, the function will be invoked with the stream entry that the
-  to-be-spawned task will process as its argument. The function should
-  return a supervisor pid or name, which will be used to spawn the task. This
-  can be used to dynamically assign stream entries to supervisors. One
-  use case for this functionality is the distribution of tasks over multiple
-  nodes in a distributed environment.
+  started, the function will be invoked (in a new process which is linked to
+  the current process) with the stream entry that the to-be-spawned task will
+  process as its argument. The function should return a supervisor pid or name,
+  which will be used to spawn the task. This allows one to dynamically start
+  tasks in different locations in the supervision tree(s) on the local (or
+  another) node. Notably, this enables the distribution of concurrent stream
+  tasks over multiple nodes.
 
   When streamed, each task will emit `{:ok, value}` upon successful
   completion or `{:exit, reason}` if the caller is trapping exits.

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -160,7 +160,9 @@ defmodule Task.Supervisor do
   started, the function will be invoked with the stream entry that the
   to-be-spawned task will process as its argument. The function should
   return a supervisor pid or name, which will be used to spawn the task. This
-  can be used to dynamically assign stream entries to supervisors.
+  can be used to dynamically assign stream entries to supervisors. One
+  use case for this functionality is the distribution of tasks over multiple
+  nodes in a distributed environment.
 
   When streamed, each task will emit `{:ok, value}` upon successful
   completion or `{:exit, reason}` if the caller is trapping exits.

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -19,6 +19,10 @@ defmodule Task.Supervisor do
                   {:restart, :supervisor.restart} |
                   {:shutdown, :supervisor.shutdown}
 
+  @typedoc "Supervisor spec used by `async_stream`"
+  @type async_stream_supervisor :: Supervisor.supervisor |
+                                   (term -> Supervisor.supervisor)
+
   @doc false
   def child_spec(arg) do
     %{
@@ -152,6 +156,12 @@ defmodule Task.Supervisor do
   own task. The tasks will be spawned under the given `supervisor` and
   linked to the current process, similarly to `async/4`.
 
+  You may also provide a function as the `supervisor`. Before each task is
+  started, the function will be invoked with the stream entry that the
+  to-be-spawned task will process as its argument. The function should
+  return a supervisor pid or name, which will be used to spawn the task. This
+  can be used to dynamically assign stream entries to supervisors.
+
   When streamed, each task will emit `{:ok, value}` upon successful
   completion or `{:exit, reason}` if the caller is trapping exits.
   Results are emitted in the same order as the original `enumerable`.
@@ -194,7 +204,7 @@ defmodule Task.Supervisor do
       Enum.to_list(stream)
 
   """
-  @spec async_stream(Supervisor.supervisor, Enumerable.t, module, atom, [term], keyword) ::
+  @spec async_stream(async_stream_supervisor, Enumerable.t, module, atom, [term], keyword) ::
         Enumerable.t
   def async_stream(supervisor, enumerable, module, function, args, options \\ [])
       when is_atom(module) and is_atom(function) and is_list(args) do
@@ -211,7 +221,7 @@ defmodule Task.Supervisor do
 
   See `async_stream/6` for discussion, options, and examples.
   """
-  @spec async_stream(Supervisor.supervisor, Enumerable.t, (term -> term), keyword) ::
+  @spec async_stream(async_stream_supervisor, Enumerable.t, (term -> term), keyword) ::
         Enumerable.t
   def async_stream(supervisor, enumerable, fun, options \\ []) when is_function(fun, 1) do
     build_stream(supervisor, :link, enumerable, fun, options)
@@ -227,7 +237,7 @@ defmodule Task.Supervisor do
 
   See `async_stream/6` for discussion, options, and examples.
   """
-  @spec async_stream_nolink(Supervisor.supervisor, Enumerable.t, module, atom, [term], keyword) ::
+  @spec async_stream_nolink(async_stream_supervisor, Enumerable.t, module, atom, [term], keyword) ::
         Enumerable.t
   def async_stream_nolink(supervisor, enumerable, module, function, args, options \\ [])
       when is_atom(module) and is_atom(function) and is_list(args) do
@@ -244,7 +254,7 @@ defmodule Task.Supervisor do
 
   See `async_stream/6` for discussion and examples.
   """
-  @spec async_stream_nolink(Supervisor.supervisor, Enumerable.t, (term -> term), keyword) ::
+  @spec async_stream_nolink(async_stream_supervisor, Enumerable.t, (term -> term), keyword) ::
         Enumerable.t
   def async_stream_nolink(supervisor, enumerable, fun, options \\ []) when is_function(fun, 1) do
     build_stream(supervisor, :nolink, enumerable, fun, options)
@@ -308,10 +318,31 @@ defmodule Task.Supervisor do
     %Task{pid: pid, ref: ref, owner: owner}
   end
 
+  defp supervisor_fun(supervisor, {_module, _fun, _args})
+      when is_function(supervisor, 1) do
+    fn {_module, _fun, [entry | _rest_args]} ->
+      supervisor.(entry)
+    end
+  end
+
+  defp supervisor_fun(supervisor, fun)
+      when is_function(supervisor, 1) and is_function(fun, 1) do
+    fn {_erlang, _apply, [_fun, [entry]]} ->
+      supervisor.(entry)
+    end
+  end
+
+  defp supervisor_fun(supervisor, _fun) do
+    fn _mfa ->
+      supervisor
+    end
+  end
+
   defp build_stream(supervisor, link_type, enumerable, fun, options) do
+    supervisor_fun = supervisor_fun(supervisor, fun)
     &Task.Supervised.stream(enumerable, &1, &2, fun, options, fn owner, mfa ->
       args = [owner, :monitor, get_info(owner), mfa]
-      {:ok, pid} = Supervisor.start_child(supervisor, args)
+      {:ok, pid} = Supervisor.start_child(supervisor_fun.(mfa), args)
       if link_type == :link, do: Process.link(pid)
       {link_type, pid}
     end)

--- a/lib/elixir/test/elixir/task/supervisor_test.exs
+++ b/lib/elixir/test/elixir/task/supervisor_test.exs
@@ -28,7 +28,6 @@ defmodule Task.SupervisorTest do
 
   def sleep_and_return_ancestor(number) do
     Process.sleep(number)
-
     {:dictionary, dictionary} = Process.info(self(), :dictionary)
 
     dictionary

--- a/lib/elixir/test/elixir/task/supervisor_test.exs
+++ b/lib/elixir/test/elixir/task/supervisor_test.exs
@@ -22,14 +22,18 @@ defmodule Task.SupervisorTest do
     number
   end
 
-  def sleep_and_return_ancestor(number, _another_arg \\ nil) do
-      Process.sleep(number)
+  def sleep_and_return_ancestor(number, :another_arg) do
+    sleep_and_return_ancestor(number)
+  end
 
-      {:dictionary, dictionary} = Process.info(self(), :dictionary)
+  def sleep_and_return_ancestor(number) do
+    Process.sleep(number)
 
-      dictionary
-      |> Keyword.get(:"$ancestors")
-      |> List.first()
+    {:dictionary, dictionary} = Process.info(self(), :dictionary)
+
+    dictionary
+    |> Keyword.get(:"$ancestors")
+    |> List.first()
   end
 
   test "can be supervised directly", config do


### PR DESCRIPTION
This PR allows you to pass a 1-arity fun as the `supervisor` argument for the `async_stream` functions, which receives the stream entry and should return a supervisor pid/name, which will then be used as the target supervisor for the task which will process the stream entry.

cc: @josevalim @ericmj 