### PR TITLE
Don't add compile-time dependency on struct with no keys

### DIFF
--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -33,9 +33,13 @@ expand_struct(Meta, Left, {'%{}', MapMeta, MapArgs}, #{context := Context} = E) 
 
   case validate_struct(ELeft, Context) of
     true when is_atom(ELeft) ->
-      %% We always record structs when they are expanded
-      %% as they expect the reference at compile time.
-      elixir_lexical:record_remote(ELeft, '__struct__', 1, nil, ?line(Meta), ?key(E, lexical_tracker)),
+      case MapArgs of
+        [] ->
+          noop;
+        _ ->
+          %% Record compile-time dependency on struct if struct keys are present
+          elixir_lexical:record_remote(ELeft, '__struct__', 1, nil, ?line(Meta), ?key(E, lexical_tracker))
+      end,
 
       %% We also include the current module because it won't be present
       %% in context module in case the module name is defined dynamically.

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -33,13 +33,8 @@ expand_struct(Meta, Left, {'%{}', MapMeta, MapArgs}, #{context := Context} = E) 
 
   case validate_struct(ELeft, Context) of
     true when is_atom(ELeft) ->
-      case MapArgs of
-        [] ->
-          noop;
-        _ ->
-          %% Record compile-time dependency on struct if struct keys are present
-          elixir_lexical:record_remote(ELeft, '__struct__', 1, nil, ?line(Meta), ?key(E, lexical_tracker))
-      end,
+      %% Record compile-time dependency on struct if struct keys are present
+      MapArgs == [] orelse elixir_lexical:record_remote(ELeft, '__struct__', 1, nil, ?line(Meta), ?key(E, lexical_tracker)),
 
       %% We also include the current module because it won't be present
       %% in context module in case the module name is defined dynamically.

--- a/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
+++ b/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
@@ -172,6 +172,7 @@ defmodule Kernel.LexicalTrackerTest do
           &R.func/0
           &Remote.func/0
           &Integer.is_even/1
+          %Macro.Env{line: 0}
           %Macro.Env{}
         end
 
@@ -183,6 +184,7 @@ defmodule Kernel.LexicalTrackerTest do
 
         &is_record/1; def b(a), do: is_record(a)
 
+        %Macro.Env{line: 0}
         %Macro.Env{}
 
         Kernel.LexicalTracker.remote_dispatches(__ENV__.module)
@@ -196,15 +198,15 @@ defmodule Kernel.LexicalTrackerTest do
     assert {15, Record, :is_record, 1} in compile_remote_calls
     assert {18, Integer, :is_even, 1} in compile_remote_calls
     assert {19, Macro.Env, :__struct__, 1} in compile_remote_calls
-    assert {22, Record, :extract, 2} in compile_remote_calls
-    assert {23, Record, :is_record, 1} in compile_remote_calls
-    assert {24, Remote, :func, 0} in compile_remote_calls
+    assert {23, Record, :extract, 2} in compile_remote_calls
+    assert {24, Record, :is_record, 1} in compile_remote_calls
     assert {25, Remote, :func, 0} in compile_remote_calls
-    assert {26, Integer, :is_even, 1} in compile_remote_calls
-    assert {28, Kernel, :def, 2} in compile_remote_calls
-    assert {28, Record, :is_record, 1} in compile_remote_calls
-    assert {30, Macro.Env, :__struct__, 1} in compile_remote_calls
-    assert {32, Kernel.LexicalTracker, :remote_dispatches, 1} in compile_remote_calls
+    assert {26, Remote, :func, 0} in compile_remote_calls
+    assert {27, Integer, :is_even, 1} in compile_remote_calls
+    assert {29, Kernel, :def, 2} in compile_remote_calls
+    assert {29, Record, :is_record, 1} in compile_remote_calls
+    assert {31, Macro.Env, :__struct__, 1} in compile_remote_calls
+    assert {34, Kernel.LexicalTracker, :remote_dispatches, 1} in compile_remote_calls
 
     runtime_remote_calls = unroll_dispatches(runtime_remote_calls)
     assert {7, Record, :extract, 2} in runtime_remote_calls
@@ -216,7 +218,7 @@ defmodule Kernel.LexicalTrackerTest do
     assert {16, Remote, :func, 0} in runtime_remote_calls
     assert {17, Remote, :func, 0} in runtime_remote_calls
     assert {18, :erlang, :==, 2} in runtime_remote_calls
-    assert {28, :erlang, :is_tuple, 1} in runtime_remote_calls
+    assert {29, :erlang, :is_tuple, 1} in runtime_remote_calls
   end
 
   defp unroll_dispatches(dispatches) do


### PR DESCRIPTION
Given these files:

```elixir
# lib/foo.ex
defmodule Foo do
  defstruct [:name]
end

# lib/bar.ex
defmodule Bar do
  def bar(%Foo{} = foo), do: foo
end

# lib/baz.ex
defmodule Baz do
  def baz(%Foo{name: _} = foo), do: foo
end
```

Before this patch we have:

```
~/foo% mix xref graph
lib/bar.ex
└── lib/foo.ex (compile)
lib/baz.ex
└── lib/foo.ex (compile)
```

After:

```
~/foo% mix xref graph
lib/bar.ex
└── lib/foo.ex
lib/baz.ex
└── lib/foo.ex (compile)
lib/foo.ex
```

---

FWIW I didn't observe a difference in recompilations on our big project, but I thought I'll submit this anyway if this is a step in the right direction.