### PR TITLE
Allow passing empty string as match argument to String.replace/4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   * [Inspect] Add `:strict` and `:flex` breaks to `Inspect.Algebra`
   * [Stream] Add `Stream.intersperse/2`
   * [String] Update to Unicode 10
+  * [String] Allow passing empty string `match` to `String.replace`
 
 #### Mix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   * [Inspect] Add `:strict` and `:flex` breaks to `Inspect.Algebra`
   * [Stream] Add `Stream.intersperse/2`
   * [String] Update to Unicode 10
-  * [String] Allow passing empty string `match` to `String.replace`
+  * [String] Allow passing empty string `match` to `String.replace/4`
 
 #### Mix
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -341,9 +341,6 @@ defmodule String do
 
   Splitting on empty patterns returns graphemes:
 
-      iex> String.split("abc", ~r{})
-      ["a", "b", "c", ""]
-
       iex> String.split("abc", "")
       ["a", "b", "c", ""]
 
@@ -1122,7 +1119,7 @@ defmodule String do
       "a[,,]b[,,]c"
 
   When an empty string is provided as a `pattern`, the function will treat it as
-  an implicit empty string between each character and the string will be
+  an implicit empty string between each grapheme and the string will be
   interspersed. If an empty string is provided as `replacement` the `subject`
   will be returned:
 
@@ -1131,6 +1128,7 @@ defmodule String do
 
       iex> String.replace("ELIXIR", "", "")
       "ELIXIR"
+
   """
   @spec replace(t, pattern | Regex.t, t, keyword) :: t
   def replace(subject, pattern, replacement, options \\ [])

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1123,7 +1123,12 @@ defmodule String do
 
   """
   @spec replace(t, pattern | Regex.t, t, keyword) :: t
-  def replace(subject, pattern, replacement, options \\ []) when is_binary(replacement) do
+  def replace(subject, pattern, replacement, options \\ [])
+  def replace(subject, "", "", _), do: subject
+  def replace(subject, "", replacement, options) do
+    replace(subject, ~r//, replacement, options)
+  end
+  def replace(subject, pattern, replacement, options) when is_binary(replacement) do
     if Regex.regex?(pattern) do
       Regex.replace(pattern, subject, replacement, global: options[:global])
     else

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1126,7 +1126,11 @@ defmodule String do
   def replace(subject, pattern, replacement, options \\ [])
   def replace(subject, "", "", _), do: subject
   def replace(subject, "", replacement, options) do
-    replace(subject, ~r//, replacement, options)
+    if Keyword.get(options, :global, true) do
+      IO.iodata_to_binary [replacement | intersperse(subject, replacement)]
+    else
+      replacement <> subject
+    end
   end
   def replace(subject, pattern, replacement, options) when is_binary(replacement) do
     if Regex.regex?(pattern) do
@@ -1134,6 +1138,13 @@ defmodule String do
     else
       opts = translate_replace_options(options)
       :binary.replace(subject, pattern, replacement, opts)
+    end
+  end
+
+  defp intersperse(subject, replacement) do
+    case next_grapheme(subject) do
+      {current, rest} -> [current, replacement | intersperse(rest, replacement)]
+      nil -> []
     end
   end
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1121,6 +1121,16 @@ defmodule String do
       iex> String.replace("a,b,c", ",", "[]", insert_replaced: [1, 1])
       "a[,,]b[,,]c"
 
+  When an empty string is provided as a `pattern`, the function will treat it as
+  an implicit empty string between each character and the string will be
+  interspersed. If an empty string is provided as `replacement` the `subject`
+  will be returned:
+
+      iex> String.replace("ELIXIR", "", ".")
+      ".E.L.I.X.I.R."
+
+      iex> String.replace("ELIXIR", "", "")
+      "ELIXIR"
   """
   @spec replace(t, pattern | Regex.t, t, keyword) :: t
   def replace(subject, pattern, replacement, options \\ [])

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -365,6 +365,11 @@ defmodule StringTest do
 
     assert String.replace("a,b,c", ~r/,(.)/, ",\\1\\1") == "a,bb,cc"
     assert String.replace("a,b,c", ~r/,(.)/, ",\\1\\1", global: false) == "a,bb,c"
+
+    assert String.replace("elixir", "", "") == "elixir"
+    assert String.replace("ELIXIR", "", ".") == ".E.L.I.X.I.R."
+    assert String.replace("ELIXIR", "", ".", global: true) == ".E.L.I.X.I.R."
+    assert String.replace("ELIXIR", "", ".", global: false) == ".ELIXIR"
   end
 
   test "duplicate/2" do


### PR DESCRIPTION
## Summary

This patch allows calling `String.replace` with an empty string as the match argument.

## Reason for patch

When I found out that passing an empty string as a match argument to `replace` throws an `ArgumentError` I was surprised by this unexpected behavior. 

Many languages support this feature which allows supplying match arguments coming from dynamic sources.

For example assume we are processing file names and trying to remove the
extension (*assuming `Path.basename/2` function did not exist*):

**Before** patch:

```elixir
inputs = ["README.md", "package.json", "LICENSE"]

inputs
|> Enum.map(&(String.replace(&1, Path.extname(&1), "")))
# ** (ArgumentError) argument error
#    (stdlib) binary.erl:275: :binary.replace/4
#    (elixir) lib/enum.ex:1255: Enum."-map/2-lists^map/1-0-"/2
#    (elixir) lib/enum.ex:1255: Enum."-map/2-lists^map/1-0-"/2
```

To fix it we would have to transform the code to something like this:
 
```elixir
inputs = ["README.md", "package.json", "LICENSE"]
inputs
|> Enum.map(fn (file) ->
  ext = Path.extname(file)
  if ext == "" do
    file
  else
    String.replace(file, ext, ""))
  end
end)

# => ["README", "package", "LICENSE"]
```

**After** patch:

```elixir
inputs = ["README.md", "package.json", "LICENSE"]

inputs
|> Enum.map(&(String.replace(&1, Path.extname(&1), "")))

# => ["README", "package", "LICENSE"]
```

## Examples from other languages

#### Ruby

```ruby
'LICENSE'.gsub('','')
# => 'LICENSE'
```

#### JavaScript

```javascript
'LICENSE'.replace('','')
// => 'LICENSE'
```

#### Go

```golang
fmt.Println(strings.Replace("LICENSE", "", "", -1))
// => "LICENSE"
```

#### Rust

```rust
fn main() {
    let result = str::replace("LICENSE", "", "");
    println!("{}", result); // => "LICENSE"
}
```

#### Java

```java
System.out.println("LICENSE".replace("",""));
// => "LICENSE"
```

#### Lua

```lua
str = "LICENSE"
res = str:gsub("", "")

io.write(res, "\n")
-- "LICENSE"
```

#### SQL

```sql
select replace('LICENSE', '', '');
-- LICENSE
```

#### Swift

```swift
"LICENSE".replacingOccurrences(of: "", with: "") // "LICENSE"
```

#### Objective C

```objc
NSString *str = [@"LICENSE" stringByReplacingOccurrencesOfString:@"" withString:@""];
NSLog (str);
```

## Using empty string match for interspersing

This patch also adds support for interspersing every character using the empty string as match - as in many other languages (Ruby, Rust, Java, Python, Lua...):

#### Ruby

```ruby
'LICENSE'.gsub('','x')
# => 'xLxIxCxExNxSxEx'
```


After this patch:

```elixir
String.replace("LICENSE","","x") 
# => "xLxIxCxExNxSxEx"
```


Thank you for your consideration and time.

---

Edit: added more languages as examples