### PR TITLE
String.replace_trailing/leading match empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   * [Inspect] Add `:strict` and `:flex` breaks to `Inspect.Algebra`
   * [Stream] Add `Stream.intersperse/2`
   * [String] Update to Unicode 10
+  * [String] Allow using empty string as `match` argument to `String.replace_leading` and `String.replace_tailing`
 
 #### Mix
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -632,12 +632,8 @@ defmodule String do
   @doc """
   Replaces all leading occurrences of `match` by `replacement` of `match` in `string`.
 
-  Returns the string untouched if there are no occurrences.
-
-  If `match` is `""`, this function raises an `ArgumentError` exception: this
-  happens because this function replaces **all** the occurrences of `match` at
-  the beginning of `string`, and it's impossible to replace "multiple"
-  occurrences of `""`.
+  Returns the string untouched if there is no match. If `match` is an empty
+  string (`""`), `replacement` is just prepended to `string`.
 
   ## Examples
 
@@ -646,6 +642,9 @@ defmodule String do
       iex> String.replace_leading("hello hello world", "hello ", "")
       "world"
 
+      iex> String.replace_leading("world", "", "hello ")
+      "hello world"
+
       iex> String.replace_leading("hello world", "hello ", "ola ")
       "ola world"
       iex> String.replace_leading("hello hello world", "hello ", "ola ")
@@ -653,12 +652,9 @@ defmodule String do
 
   """
   @spec replace_leading(t, t, t) :: t | no_return
+  def replace_leading(string, "", replacement), do: replacement <> string
   def replace_leading(string, match, replacement)
       when is_binary(string) and is_binary(match) and is_binary(replacement) do
-    if match == "" do
-      raise ArgumentError, "cannot use an empty string as the match to replace"
-    end
-
     prefix_size = byte_size(match)
     suffix_size = byte_size(string) - prefix_size
     replace_leading(string, match, replacement, prefix_size, suffix_size, 0)
@@ -680,12 +676,8 @@ defmodule String do
   @doc """
   Replaces all trailing occurrences of `match` by `replacement` in `string`.
 
-  Returns the string untouched if there are no occurrences.
-
-  If `match` is `""`, this function raises an `ArgumentError` exception: this
-  happens because this function replaces **all** the occurrences of `match` at
-  the end of `string`, and it's impossible to replace "multiple" occurrences of
-  `""`.
+  Returns the string untouched if there is no match. If `match` is an empty
+  string (`""`), `replacement` is just appended to `string`.
 
   ## Examples
 
@@ -694,6 +686,9 @@ defmodule String do
       iex> String.replace_trailing("hello world world", " world", "")
       "hello"
 
+      iex> String.replace_trailing("hello", "", " world")
+      "hello world"
+
       iex> String.replace_trailing("hello world", " world", " mundo")
       "hello mundo"
       iex> String.replace_trailing("hello world world", " world", " mundo")
@@ -701,12 +696,9 @@ defmodule String do
 
   """
   @spec replace_trailing(t, t, t) :: t | no_return
+  def replace_trailing(string, "", replacement), do: string <> replacement
   def replace_trailing(string, match, replacement)
       when is_binary(string) and is_binary(match) and is_binary(replacement) do
-    if match == "" do
-      raise ArgumentError, "cannot use an empty string as the match to replace"
-    end
-
     suffix_size = byte_size(match)
     prefix_size = byte_size(string) - suffix_size
     replace_trailing(string, match, replacement, prefix_size, suffix_size, 0)

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -188,14 +188,7 @@ defmodule StringTest do
     assert String.replace_leading("test", "t", "T") == "Test"
     assert String.replace_leading("t", "t", "T") == "T"
     assert String.replace_leading("aaa", "b", "c") == "aaa"
-
-    message = ~r/cannot use an empty string/
-    assert_raise ArgumentError, message, fn ->
-      String.replace_leading("foo", "", "bar")
-    end
-    assert_raise ArgumentError, message, fn ->
-      String.replace_leading("", "", "bar")
-    end
+    assert String.replace_leading("aaa", "", "c") == "caaa"
   end
 
   test "replace_trailing/3" do
@@ -211,14 +204,7 @@ defmodule StringTest do
     assert String.replace_trailing("test", "t", "T") == "tesT"
     assert String.replace_trailing("t", "t", "T") == "T"
     assert String.replace_trailing("aaa", "b", "c") == "aaa"
-
-    message = ~r/cannot use an empty string/
-    assert_raise ArgumentError, message, fn ->
-      String.replace_trailing("foo", "", "bar")
-    end
-    assert_raise ArgumentError, message, fn ->
-      String.replace_trailing("", "", "bar")
-    end
+    assert String.replace_trailing("aaa", "", "c") == "aaac"
   end
 
   test "trim/1,2" do


### PR DESCRIPTION
This is a follow up to #6559.

This PR was forked from #6559 to allow easier iterations and discussion around this functionality based on @josevalim's recommendation.

Add support for using empty string as a match to `String.replace_leading` and `String.replace_trailing` while matching behavior to `String.replace_prefix` and `String.replace_suffix`.