### PR TITLE
Fixed #6565 by adding a test for if the module exists

### DIFF
--- a/lib/elixir/test/elixir/supervisor_test.exs
+++ b/lib/elixir/test/elixir/supervisor_test.exs
@@ -78,7 +78,11 @@ defmodule SupervisorTest do
                                        restart: :permanent, shutdown: :infinity) ==
            %{id: :foo, start: {:foo, :bar, []}, restart: :permanent, shutdown: :infinity}
 
-    assert_raise ArgumentError, ~r"The module Unknown was given as a child", fn ->
+    assert_raise ArgumentError, ~r"The module String was given as a child", fn ->
+      Supervisor.child_spec(String, [])
+    end
+
+    assert_raise ArgumentError, ~r"The module Unknown does not exist", fn ->
       Supervisor.child_spec(Unknown, [])
     end
 


### PR DESCRIPTION
Fixed #6565 by adding a test for if the module exists along with adding an appropriate message.

I did not know if you wanted a CHANGELOG.md entry or not so I left it out, I can add it back is requested.

Added a new test and changed an existing test:

* **Added:**  Test for when module does not exist
* **Changed:**  Existing test tested a non-existing module, changed it to test `String` since it exists and is not a server of any form.

All tests passed:

```elixir
==> elixir (eunit)
  All 198 tests passed.

==> elixir (exunit)
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
...............................................................................................................

Finished in 35.9 seconds (17.9s on load, 18.0s on tests)
1339 doctests, 2408 tests, 0 failures

Randomized with seed 584283
==> ex_unit (exunit)
..........................................................................................................................................................................................................
..........................................

Finished in 3.7 seconds (1.8s on load, 1.8s on tests)
34 doctests, 210 tests, 0 failures

Randomized with seed 937138
==> logger (exunit)
....................................................................................................

Finished in 1.1 seconds (0.6s on load, 0.4s on tests)
1 doctest, 99 tests, 0 failures

Randomized with seed 849934
==> mix (exunit)
..........................................................................................................................................................................................................
..........................................................................................................................................................................................................
.........................

Finished in 73.2 seconds (4.9s on load, 68.2s on tests)
8 doctests, 421 tests, 0 failures

Randomized with seed 109997
==> eex (exunit)
.................................................................................

Finished in 0.4 seconds (0.4s on load, 0.04s on tests)
5 doctests, 76 tests, 0 failures

Randomized with seed 618432
==> iex (exunit)
..............................................................................................................................................................................................

Finished in 4.8 seconds (1.0s on load, 3.7s on tests)
190 tests, 0 failures

Randomized with seed 556399
```

Any other changes requested?  Maintainers can edit as well.