### PR TITLE
Detect describe block at given line filter and run all tests in it

### DIFF
--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -162,7 +162,8 @@ defmodule ExUnit.Callbacks do
     quote bind_quoted: [var: escape(var), block: escape(block)] do
       name = :"__ex_unit_setup_#{length(@ex_unit_setup)}"
       defp unquote(name)(unquote(var)), unquote(block)
-      @ex_unit_setup [{name, @ex_unit_describe} | @ex_unit_setup]
+      describe_name = @ex_unit_describe && @ex_unit_describe |> elem(1)
+      @ex_unit_setup [{name, describe_name} | @ex_unit_setup]
     end
   end
 
@@ -322,7 +323,8 @@ defmodule ExUnit.Callbacks do
                              "a list of callback names, got: #{inspect k}"
       end
 
-      {k, describe}
+      describe_name = describe && describe |> elem(1)
+      {k, describe_name}
     end |> Enum.reverse()
   end
 

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -162,8 +162,7 @@ defmodule ExUnit.Callbacks do
     quote bind_quoted: [var: escape(var), block: escape(block)] do
       name = :"__ex_unit_setup_#{length(@ex_unit_setup)}"
       defp unquote(name)(unquote(var)), unquote(block)
-      describe_name = @ex_unit_describe && @ex_unit_describe |> elem(1)
-      @ex_unit_setup [{name, describe_name} | @ex_unit_setup]
+      @ex_unit_setup [{name, @ex_unit_describe} | @ex_unit_setup]
     end
   end
 
@@ -323,8 +322,7 @@ defmodule ExUnit.Callbacks do
                              "a list of callback names, got: #{inspect k}"
       end
 
-      describe_name = describe && describe |> elem(1)
-      {k, describe_name}
+      {k, describe}
     end |> Enum.reverse()
   end
 
@@ -410,7 +408,7 @@ defmodule ExUnit.Callbacks do
     end
   end
 
-  defp compile_merge({callback, describe}) do
+  defp compile_merge({callback, {_line, describe}}) do
     quote do
       if unquote(describe) == describe do
         unquote(compile_merge({callback, nil}))

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -437,8 +437,8 @@ defmodule ExUnit.Case do
 
     {name, describe, describe_line, describetag} =
       case Module.get_attribute(mod, :ex_unit_describe) do
-        {dline, dname} ->
-          {:"#{type} #{dname} #{name}", dname, dline, Module.get_attribute(mod, :describetag)}
+        {line, describe} ->
+          {:"#{type} #{describe} #{name}", describe, line, Module.get_attribute(mod, :describetag)}
         _ ->
           {:"#{type} #{name}", nil, nil, []}
       end

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -375,16 +375,14 @@ defmodule ExUnit.Case do
           :ok
       end
 
-      @ex_unit_describe message
+      @ex_unit_describe {__ENV__.line, message}
       @ex_unit_used_describes message
-      @ex_unit_describe_line __ENV__.line
       Module.delete_attribute(__ENV__.module, :describetag)
 
       try do
         unquote(block)
       after
         @ex_unit_describe nil
-        @ex_unit_describe_line nil
         Module.delete_attribute(__ENV__.module, :describetag)
       end
     end
@@ -435,11 +433,11 @@ defmodule ExUnit.Case do
     async = Module.get_attribute(mod, :ex_unit_async)
 
     {name, describe, describe_line, describetag} =
-      if describe = Module.get_attribute(mod, :ex_unit_describe) do
-        dline = Module.get_attribute(mod, :ex_unit_describe_line)
-        {:"#{type} #{describe} #{name}", describe, dline, Module.get_attribute(mod, :describetag)}
-      else
-        {:"#{type} #{name}", nil, nil, []}
+      case Module.get_attribute(mod, :ex_unit_describe) do
+        {dline, dname} ->
+          {:"#{type} #{dname} #{name}", dname, dline, Module.get_attribute(mod, :describetag)}
+        _ ->
+          {:"#{type} #{name}", nil, nil, []}
       end
 
     if Module.defines?(mod, {name, 1}) do

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -328,7 +328,7 @@ defmodule ExUnit.Case do
 
       mix test --only describe:"String.capitalize/1"
 
-  or by passing the exact line the describe block starts:
+  or by passing the exact line the describe block starts on:
 
       mix test path/to/file:123
 

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -324,9 +324,12 @@ defmodule ExUnit.Case do
         end
       end
 
-  When using Mix, you can run all tests in a describe block (starting at line 123) as either:
+  When using Mix, you can run all tests in a describe block by name:
 
       mix test --only describe:"String.capitalize/1"
+
+  or by passing the exact line the describe block starts:
+
       mix test path/to/file:123
 
   Note describe blocks cannot be nested. Instead of relying on hierarchy

--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -105,7 +105,7 @@ defmodule ExUnit.Filters do
     cond do
       describe_line == line ->
         true
-      is_describe_block?(line, collection) ->
+      describe_block?(line, collection) ->
         false
       true ->
         tags.line <= line and
@@ -139,7 +139,7 @@ defmodule ExUnit.Filters do
   defp compare(tag, tag), do: true
   defp compare(_, _), do: false
 
-  defp is_describe_block?(line, collection) do
+  defp describe_block?(line, collection) do
     Enum.any?(collection, fn %ExUnit.Test{tags: %{describe_line: describe_line}} ->
       line == describe_line
     end)

--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -100,10 +100,17 @@ defmodule ExUnit.Filters do
     end
   end
 
-  defp has_tag({:line, line}, %{line: _} = tags, collection) do
+  defp has_tag({:line, line}, %{line: _, describe_line: describe_line} = tags, collection) do
     line = to_integer(line)
-    tags.line <= line and
-      closest_test_before_line(line, collection).tags.line == tags.line
+    cond do
+      describe_line == line ->
+        true
+      is_describe_block?(line, collection) ->
+        false
+      true ->
+        tags.line <= line and
+          closest_test_before_line(line, collection).tags.line == tags.line
+    end
   end
 
   defp has_tag({key, %Regex{} = value}, tags, _collection) when is_atom(key) do
@@ -131,6 +138,12 @@ defmodule ExUnit.Filters do
   defp compare(tag1, "Elixir." <> tag2), do: compare(tag1, tag2)
   defp compare(tag, tag), do: true
   defp compare(_, _), do: false
+
+  defp is_describe_block?(line, collection) do
+    Enum.any?(collection, fn %ExUnit.Test{tags: %{describe_line: describe_line}} ->
+      line == describe_line
+    end)
+  end
 
   defp closest_test_before_line(line, collection) do
     Enum.min_by(collection, fn %ExUnit.Test{tags: %{line: test_line}} ->

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -54,4 +54,16 @@ defmodule ExUnit.CaseTest do
     assert context.registered.foo == nil
     assert context.registered.bar == []
   end
+
+  describe "describe block" do
+    test "sets describe tag and line", context do
+      describe_line = __ENV__.line - 2
+      assert context.describe == "describe block"
+      assert context.describe_line == describe_line
+    end
+
+    test "is prepended to title", context do
+      assert context.test == :"test describe block is prepended to title"
+    end
+  end
 end

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -54,16 +54,4 @@ defmodule ExUnit.CaseTest do
     assert context.registered.foo == nil
     assert context.registered.bar == []
   end
-
-  describe "describe block" do
-    test "sets describe tag and line", context do
-      describe_line = __ENV__.line - 2
-      assert context.describe == "describe block"
-      assert context.describe_line == describe_line
-    end
-
-    test "is prepended to title", context do
-      assert context.test == :"test describe block is prepended to title"
-    end
-  end
 end

--- a/lib/ex_unit/test/ex_unit/describe_test.exs
+++ b/lib/ex_unit/test/ex_unit/describe_test.exs
@@ -102,8 +102,7 @@ defmodule ExUnit.DescribeTest do
 
   describe "describe block" do
     test "sets describe_line", context do
-      describe_line = __ENV__.line - 2
-      assert context.describe_line == describe_line
+      assert context.describe_line == __ENV__.line - 2
     end
   end
 end

--- a/lib/ex_unit/test/ex_unit/describe_test.exs
+++ b/lib/ex_unit/test/ex_unit/describe_test.exs
@@ -99,4 +99,11 @@ defmodule ExUnit.DescribeTest do
     assert context.setup_tag == :from_module
     assert context.test == :"test attributes from outside describe"
   end
+
+  describe "describe block" do
+    test "sets describe_line", context do
+      describe_line = __ENV__.line - 2
+      assert context.describe_line == describe_line
+    end
+  end
 end

--- a/lib/ex_unit/test/ex_unit/filters_test.exs
+++ b/lib/ex_unit/test/ex_unit/filters_test.exs
@@ -47,12 +47,22 @@ defmodule ExUnit.FiltersTest do
   end
 
   test "evaluating filter uses special rules for line" do
-    tests = [%ExUnit.Test{tags: %{line: 3}}, %ExUnit.Test{tags: %{line: 5}}]
+    tests = [%ExUnit.Test{tags: %{line: 3, describe_line: 2}},
+             %ExUnit.Test{tags: %{line: 5, describe_line: nil}},
+             %ExUnit.Test{tags: %{line: 8, describe_line: 7}},
+             %ExUnit.Test{tags: %{line: 10, describe_line: 7}},
+             %ExUnit.Test{tags: %{line: 13, describe_line: 12}}]
 
-    assert ExUnit.Filters.eval([line: 3], [:line], %{line: 3}, tests) == :ok
-    assert ExUnit.Filters.eval([line: 4], [:line], %{line: 3}, tests) == :ok
-    assert ExUnit.Filters.eval([line: 2], [:line], %{line: 3}, tests) == {:error, "due to line filter"}
-    assert ExUnit.Filters.eval([line: 5], [:line], %{line: 3}, tests) == {:error, "due to line filter"}
+    assert ExUnit.Filters.eval([line: "3"], [:line], %{line: 3, describe_line: 2}, tests) == :ok
+    assert ExUnit.Filters.eval([line: "4"], [:line], %{line: 3, describe_line: 2}, tests) == :ok
+    assert ExUnit.Filters.eval([line: "5"], [:line], %{line: 5, describe_line: nil}, tests) == :ok
+    assert ExUnit.Filters.eval([line: "6"], [:line], %{line: 5, describe_line: nil}, tests) == :ok
+    assert ExUnit.Filters.eval([line: "2"], [:line], %{line: 3, describe_line: 2}, tests) == :ok
+    assert ExUnit.Filters.eval([line: "7"], [:line], %{line: 8, describe_line: 7}, tests) == :ok
+    assert ExUnit.Filters.eval([line: "7"], [:line], %{line: 10, describe_line: 7}, tests) == :ok
+    assert ExUnit.Filters.eval([line: "1"], [:line], %{line: 3, describe_line: 2}, tests) == {:error, "due to line filter"}
+    assert ExUnit.Filters.eval([line: "7"], [:line], %{line: 3, describe_line: 2}, tests) == {:error, "due to line filter"}
+    assert ExUnit.Filters.eval([line: "7"], [:line], %{line: 5, describe_line: nil}, tests) == {:error, "due to line filter"}
   end
 
   test "parsing filters" do

--- a/lib/ex_unit/test/ex_unit/filters_test.exs
+++ b/lib/ex_unit/test/ex_unit/filters_test.exs
@@ -47,11 +47,13 @@ defmodule ExUnit.FiltersTest do
   end
 
   test "evaluating filter uses special rules for line" do
-    tests = [%ExUnit.Test{tags: %{line: 3, describe_line: 2}},
-             %ExUnit.Test{tags: %{line: 5, describe_line: nil}},
-             %ExUnit.Test{tags: %{line: 8, describe_line: 7}},
-             %ExUnit.Test{tags: %{line: 10, describe_line: 7}},
-             %ExUnit.Test{tags: %{line: 13, describe_line: 12}}]
+    tests = [
+      %ExUnit.Test{tags: %{line: 3, describe_line: 2}},
+      %ExUnit.Test{tags: %{line: 5, describe_line: nil}},
+      %ExUnit.Test{tags: %{line: 8, describe_line: 7}},
+      %ExUnit.Test{tags: %{line: 10, describe_line: 7}},
+      %ExUnit.Test{tags: %{line: 13, describe_line: 12}},
+    ]
 
     assert ExUnit.Filters.eval([line: "3"], [:line], %{line: 3, describe_line: 2}, tests) == :ok
     assert ExUnit.Filters.eval([line: "4"], [:line], %{line: 3, describe_line: 2}, tests) == :ok

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -117,8 +117,10 @@ defmodule Mix.Tasks.Test do
 
       mix test --only line:12 test/some/particular/file_test.exs
 
-  Note that line filter takes the closest test on or before the given line number.
-  In the case a single file contains more than one test module (test case),
+  If the given line starts a `describe` block, the line filter runs all tests in it.
+  Otherwise, it runs the closest test on or before the given line number.
+
+  Note that in the case a single file contains more than one test module (test case),
   line filter applies to every test case before the given line number, thus more
   than one test might be taken for the run.
 


### PR DESCRIPTION
Until now, ExUnit's line filter (such as `mix test path/to/file:123`) only detected a test case starting at the given line number. Running all tests in a describe block was only possible using `mix test --only describe:"String.capitalize/1"`.

This PR adds the possibility to run all tests in a describe block by addressing the line starting it. If `describe "String.capitalize/1"` is at line 123, all tests in it can now be run via `mix test path/to/file:123`.

This filter is shorter and more intuitive as it makes the line filter smarter, and is in line with the behavior of other test runners, such as rspec, as well as what IDEs such as RubyMine expect.

Implementation-wise, I added an automatic tag `@ex_unit_describe_line` that is added to each test's tags as `:describe_line` and then used for filtering.

I've also added a test for existing functionality of setting the `:describe` tag and prepending it to the name (`:test` tag).

Please let me know if this makes sense for you, and if there's anything I can improve :)