### PR TITLE
Separate tracking structs from compile-time dependencies

### DIFF
--- a/lib/elixir/src/elixir_lexical.erl
+++ b/lib/elixir/src/elixir_lexical.erl
@@ -4,6 +4,7 @@
   record_alias/4, record_alias/2,
   record_import/6, record_import/5,
   record_remote/3, record_remote/6,
+  record_struct/3,
   format_error/1
 ]).
 -include("elixir.hrl").
@@ -49,6 +50,9 @@ record_remote(Module, EnvFunction, Ref) ->
 
 record_remote(Module, Function, Arity, EnvFunction, Line, Ref) ->
   if_tracker(Ref, fun(Pid) -> ?tracker:remote_dispatch(Pid, Module, {Function, Arity}, Line, mode(EnvFunction)), ok end).
+
+record_struct(Module, Line, Ref) ->
+  if_tracker(Ref, fun(Pid) -> ?tracker:remote_struct(Pid, Module, Line), ok end).
 
 %% HELPERS
 

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -35,7 +35,7 @@ expand_struct(Meta, Left, {'%{}', MapMeta, MapArgs}, #{context := Context} = E) 
     true when is_atom(ELeft) ->
       %% We always record structs when they are expanded
       %% as they expect the reference at compile time.
-      elixir_lexical:record_remote(ELeft, '__struct__', 1, nil, ?line(Meta), ?key(E, lexical_tracker)),
+      elixir_lexical:record_struct(ELeft, ?line(Meta), ?key(E, lexical_tracker)),
 
       %% We also include the current module because it won't be present
       %% in context module in case the module name is defined dynamically.


### PR DESCRIPTION
This is a first step to limiting recompilations in case a struct is used in a
module, the "parent module" of the struct changes, but struct definition itself
does not change.

Things left to do outside this PR:
* provide `module.__info__(:struct_md5)`
* take advantage of the new information in `Mix.Compilers.Elixir`
* update `mix xref` task.