### PR TITLE
Fix local.hex --if-missing

### DIFF
--- a/lib/mix/lib/mix/tasks/local.hex.ex
+++ b/lib/mix/lib/mix/tasks/local.hex.ex
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Local.Hex do
 
     should_install? =
       if Keyword.get(opts, :if_missing, false) do
-        Code.ensure_loaded?(Hex)
+        !Code.ensure_loaded?(Hex)
       else
         true
       end

--- a/lib/mix/lib/mix/tasks/local.hex.ex
+++ b/lib/mix/lib/mix/tasks/local.hex.ex
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Local.Hex do
 
     should_install? =
       if Keyword.get(opts, :if_missing, false) do
-        !Code.ensure_loaded?(Hex)
+        not Code.ensure_loaded?(Hex)
       else
         true
       end


### PR DESCRIPTION
When Hex is loaded then `should_install?` should be `false`.

Looks like it never worked properly :(