### PR TITLE
Fix dialyzer warnings for with's else argument

### DIFF
--- a/lib/elixir/test/elixir/fixtures/dialyzer/with.ex
+++ b/lib/elixir/test/elixir/fixtures/dialyzer/with.ex
@@ -1,23 +1,21 @@
 defmodule Dialyzer.With do
   def with_else do
-    with :ok <- ok_or_error(),
-         :ok <- ok_or_other_error() do
+    with :ok <- ok_or_error_with_atom(),
+         :ok <- ok_or_error_with_string() do
       :ok
     else
-      :error ->
-        :error
-      :other_error ->
-        :other_error
+      {:error, msg} when is_atom(msg) -> :error
+      {:error, _msg} -> :error
     end
   end
 
-  @spec ok_or_error() :: :ok | :error
-  defp ok_or_error do
-    Enum.random([:ok, :error])
+  @spec ok_or_error_with_atom() :: :ok | {:error, atom()}
+  defp ok_or_error_with_atom do
+    Enum.random([:ok, {:error, :err}])
   end
 
-  @spec ok_or_other_error() :: :ok | :other_error
-  defp ok_or_other_error do
-    Enum.random([:ok, :other_error])
+  @spec ok_or_error_with_string() :: :ok | {:error, String.t}
+  defp ok_or_error_with_string do
+    Enum.random([:ok, {:error, "err"}])
   end
 end


### PR DESCRIPTION
This changes the way that the `else` argument of a `with` clause is translated to Erlang.
For example, given the following `with` clause:

```elixir
with :ok <- ok_or_error_with_atom(),
     :ok <- ok_or_error_with_string() do
  :ok
else
  {:error, msg} when is_atom(msg) -> :error
  {:error, _msg} -> :error
end

@spec ok_or_error_with_atom() :: :ok | {:error, atom()}
defp ok_or_error_with_atom do
  Enum.random([:ok, {:error, :err}])
end

@spec ok_or_error_with_string() :: :ok | {:error, String.t}
defp ok_or_error_with_string do
  Enum.random([:ok, {:error, "err"}])
end
```

The translation to Erlang used to be something like:

```erlang
case ok_or_error_with_atom() of
  ok ->
    case ok_or_error_with_string() of
      ok -> ok;
      {error, Msg} when is_atom(Msg) -> error;
      {error, _Msg} -> error
    end;
  {error, Msg} when is_atom(Msg) -> error;
  {error, _Msg} -> error
end.
```

Since `ok_or_error_with_string()` can't return a tuple with an atom on the second element, the guard clause `is_atom` would trigger a warning on dialyzer.
The new translation creates a function for `else` part fixing this warning, and it would be equivalent to:

```erlang
Else = fun
  ({error, Msg}) when is_atom(Msg) -> error;
  ({error, _Msg}) -> error
end,
case ok_or_error_with_atom() of
  ok ->
    case ok_or_error_with_string() of
      ok -> ok;
      other -> Else(other)
    end;
  other -> Else(other)
end.
```

Resolves #6426