### PR TITLE
Format mix.lock with one dep only per line

### DIFF
--- a/lib/mix/lib/mix/dep/lock.ex
+++ b/lib/mix/lib/mix/dep/lock.ex
@@ -52,9 +52,9 @@ defmodule Mix.Dep.Lock do
     unless map == read() do
       lines =
         for {app, rev} <- Enum.sort(map), rev != nil do
-          ~s("#{app}": #{inspect rev, limit: :infinity})
+          ~s(  "#{app}": #{inspect rev, limit: :infinity},\n)
         end
-      File.write! lockfile(), "%{" <> Enum.join(lines, ",\n  ") <> "}\n"
+      File.write! lockfile(), "%{\n#{lines}}\n"
       touch_manifest()
     end
     :ok

--- a/lib/mix/lib/mix/dep/lock.ex
+++ b/lib/mix/lib/mix/dep/lock.ex
@@ -54,7 +54,7 @@ defmodule Mix.Dep.Lock do
         for {app, rev} <- Enum.sort(map), rev != nil do
           ~s(  "#{app}": #{inspect rev, limit: :infinity},\n)
         end
-      File.write! lockfile(), "%{\n#{lines}}\n"
+      File.write! lockfile(), ["%{\n", lines, "}\n"]
       touch_manifest()
     end
     :ok

--- a/lib/mix/test/mix/dep/lock_test.exs
+++ b/lib/mix/test/mix/dep/lock_test.exs
@@ -16,7 +16,7 @@ defmodule Mix.Dep.LockTest do
     end
   end
 
-  test "each dep in the lockfile is on it's own line and in same format", context do
+  test "formats each dep on its own line for better conflict handling", context do
     in_tmp context.test, fn ->
       Mix.Dep.Lock.write %{
         foo: {:hex, :foo, "0.1.0"},

--- a/lib/mix/test/mix/dep/lock_test.exs
+++ b/lib/mix/test/mix/dep/lock_test.exs
@@ -16,6 +16,21 @@ defmodule Mix.Dep.LockTest do
     end
   end
 
+  test "each dep in the lockfile is on it's own line and in same format", context do
+    in_tmp context.test, fn ->
+      Mix.Dep.Lock.write %{
+        foo: {:hex, :foo, "0.1.0"},
+        bar: {:hex, :bar, "0.1.0"}
+      }
+      assert File.read!("mix.lock") == ~S"""
+      %{
+        "bar": {:hex, :bar, "0.1.0"},
+        "foo": {:hex, :foo, "0.1.0"},
+      }
+      """
+    end
+  end
+
   test "does not touch manifest file there is no change", context do
     in_tmp context.test, fn ->
       Mix.Dep.Lock.write %{foo: :bar, bar: :bat}
@@ -29,13 +44,15 @@ defmodule Mix.Dep.LockTest do
   test "raises a proper error for merge conflicts", context do
     in_tmp context.test, fn ->
       File.write "mix.lock", ~S"""
-      %{"dep": {:hex, :dep, "0.1.0"},
+      %{
+        "dep": {:hex, :dep, "0.1.0"},
       <<<<<<< HEAD
         "foo": {:hex, :foo, "0.1.0"},
       =======
         "bar": {:hex, :bar, "0.1.0"},
       >>>>>>> foobar
-        "baz": {:hex, :baz, "0.1.0"}}
+        "baz": {:hex, :baz, "0.1.0"},
+      }
       """
       assert_raise Mix.Error, ~r/Your mix\.lock contains merge conflicts/, fn ->
         Mix.Dep.Lock.read()


### PR DESCRIPTION
As suggested by @josevalim in #6574 I've standardised the format  of `mix.lock` so that each line containing a dependency is in the same format.

So instead of this:

```elixir
%{"foo": ...,
    "bar": ...}
```

we now use this format:

```elixir
%{
  "foo": ...,
  "bar": ...,
}
```

This should improve readability, consistency and also make resolving version control conflicts much easier to deal with (manual or automated).

This change should also make possible implementations of #6554 (which may try to directly resolve conflicts in `mix.lock`) easier to implement since each line containing a dependency is in the same format.

Haven't yet found any other code that needs modification in this PR, but would appreciate any insights on what might break as a result of this change.