### PR TITLE
Define typespec for compiler diagnostics and return them from Mix.Com…

### DIFF
--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -31,9 +31,6 @@ defmodule Kernel.ParallelCompiler do
     * `:each_module` - for each module compiled, invokes the callback passing
       the file, module and the module bytecode
 
-    * `:each_warning` - for each warning, invokes the callback passing
-      the file, line number, and warning message
-
     * `:dest` - the destination directory for the BEAM files. When using `files/2`,
       this information is only used to properly annotate the BEAM files before
       they are loaded into memory. If you want a file to actually be written to
@@ -66,9 +63,6 @@ defmodule Kernel.ParallelCompiler do
 
     * `:each_module` - for each module compiled, invokes the callback passing
       the file, module and the module bytecode
-
-    * `:each_warning` - for each warning, invokes the callback passing
-      the file, line number, and warning message
 
   """
   def require(files, options \\ []) when is_list(options) do
@@ -301,11 +295,6 @@ defmodule Kernel.ParallelCompiler do
       {:warning, file, line, message} ->
         file = if file, do: Path.absname(file), else: nil
         message = :unicode.characters_to_binary(message)
-
-        if callback = Keyword.get(options, :each_warning) do
-          callback.(file, line, message)
-        end
-
         warning = {file, line, message}
         wait_for_messages(%{state | warnings: [warning | state.warnings]})
 

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Compilers.Elixir do
   @moduledoc false
 
-  @manifest_vsn :v7
+  @manifest_vsn :v8
 
   import Record
 
@@ -361,7 +361,7 @@ defmodule Mix.Compilers.Elixir do
 
   defp show_warnings(sources) do
     for source(source: source, warnings: warnings) <- sources do
-      file = Path.join(File.cwd!, source)
+      file = Path.absname(source)
       for {line, message} <- warnings do
         :elixir_errors.warn(line, file, message)
       end
@@ -404,7 +404,7 @@ defmodule Mix.Compilers.Elixir do
     else
       [@manifest_vsn | data] ->
         split_manifest(data, compile_path)
-      [v | data] when v in [:v4, :v5, :v6] ->
+      [v | data] when v in [:v4, :v5, :v6, :v7] ->
         for module(beam: beam) <- data, do: File.rm(Path.join(compile_path, beam))
         {[], []}
       _ ->

--- a/lib/mix/lib/mix/task.compiler.ex
+++ b/lib/mix/lib/mix/task.compiler.ex
@@ -44,10 +44,11 @@ defmodule Mix.Task.Compiler do
 
     @typedoc """
     Severity of a diagnostic:
-    * `:error`: An issue that caused compilation to fail
-    * `:warning`: An issue that did not cause failure but suggests the programmer may have made a mistake
-    * `:hint`: A suggestion for style or good practices that is not as severe as a warning
-    * `:information`: Any other information relevant to compilation that does not fit into the above categories
+
+      * `:error`: An issue that caused compilation to fail
+      * `:warning`: An issue that did not cause failure but suggests the programmer may have made a mistake
+      * `:hint`: A suggestion for style or good practices that is not as severe as a warning
+      * `:information`: Any other information relevant to compilation that does not fit into the above categories
     """
     @type severity :: :error | :warning | :information | :hint
 

--- a/lib/mix/lib/mix/task.compiler.ex
+++ b/lib/mix/lib/mix/task.compiler.ex
@@ -14,6 +14,12 @@ defmodule Mix.Task.Compiler do
         end
       end
 
+  The `run/1` function returns an atom indicating the status of the
+  compilation, and optionally can also return a list of "diagnostics"
+  such as warnings or compilation errors. Doing this enables code
+  editors to display issues inline without having to analyze the
+  command-line output.
+
   If the compiler uses manifest files to track stale sources, it should
   define `manifests/0`, and if it writes any output to disk it should
   also define `clean/0`.
@@ -22,11 +28,56 @@ defmodule Mix.Task.Compiler do
   documentation as a regular Mix task. See `Mix.Task` for more information.
   """
 
+  defmodule Diagnostic do
+    @moduledoc """
+    Diagnostic information such as a warning or compilation error.
+    """
+
+    @type t :: %__MODULE__{
+      file: Path.t,
+      severity: severity,
+      message: String.t,
+      position: position,
+      compiler_name: String.t,
+      details: any
+    }
+
+    @typedoc """
+    Severity of a diagnostic:
+    * `:error`: An issue that caused compilation to fail
+    * `:warning`: An issue that did not cause failure but suggests the programmer may have made a mistake
+    * `:hint`: A suggestion for style or good practices that is not as severe as a warning
+    * `:information`: Any other information relevant to compilation that does not fit into the above categories
+    """
+    @type severity :: :error | :warning | :information | :hint
+
+    @typedoc """
+    Where in a file the diagnostic applies. Can be either a line number,
+    a range specified as `{start_line, start_col, end_line, end_col}`,
+    or `nil` if unknown.
+
+    Line numbers are 1-based, and column numbers in a range are 0-based and refer
+    to the cursor position at the start of the character at that index. For example,
+    to indicate that a diagnostic applies to the first `n` characters of the
+    first line, the range would be `{1, 0, 1, n}`.
+    """
+    @type position ::
+      nil |
+      pos_integer |
+      {pos_integer, non_neg_integer, pos_integer, non_neg_integer}
+
+    @enforce_keys [:file, :severity, :message, :position, :compiler_name]
+    defstruct [:file, :severity, :message, :position, :compiler_name, :details]
+
+  end
+
   @doc """
-  Receives command-line arguments and performs compilation. Returns `:noop`
-  if nothing is stale and no compilation is needed, `:ok` if successful.
+  Receives command-line arguments and performs compilation. If it
+  produces errors, warnings, or any other diagnostic information,
+  it should return a tuple with the status and a list of diagnostics.
   """
   @callback run([binary]) :: :ok | :noop
+                           | {:ok | :noop | :error, [Diagnostic.t]}
 
   @doc """
   Lists manifest files for the compiler.

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -66,8 +66,8 @@ defmodule Mix.Tasks.Compile.Elixir do
 
     opts = Keyword.merge(project[:elixirc_options] || [], opts)
     case Mix.Compilers.Elixir.compile(manifest, srcs, dest, [:ex], force, opts) do
-      {[], []} -> :noop
-      {_, _} -> :ok
+      {:error, _} -> exit({:shutdown, 1})
+      {status, _} -> status
     end
   end
 


### PR DESCRIPTION
…pilers.Elixir

This commit only changes internals, but it's a starting point for returning diagnostics from all Mix compilers.