### PR TITLE
Add link to docs for guards, when an invalid guard expression is used

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -909,7 +909,10 @@ format_error(underscore_in_cond) ->
   "unbound variable _ inside \"cond\". If you want the last clause to always match, "
     "you probably meant to use: true ->";
 format_error({invalid_expr_in_guard, Kind}) ->
-  io_lib:format("invalid expression in guard, ~ts is not allowed in guards", [Kind]);
+  Message =
+    "invalid expression in guard, ~ts is not allowed in guards. To learn more about "
+    "guards, visit: https://hexdocs.pm/elixir/guards.html",
+  io_lib:format(Message, [Kind]);
 format_error({invalid_pattern_in_match, Kind}) ->
   io_lib:format("invalid pattern in match, ~ts is not allowed in matches", [Kind]);
 format_error({invalid_expr_in_scope, Scope, Kind}) ->


### PR DESCRIPTION
I believe this should resolve #6583. Linking seemed like the more appropriate solution, since there would be a lot of built-in guard functions to list and wouldn't cover macros the user defined.