### PR TITLE
Fix @impl attribute for default arguments

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1194,7 +1194,7 @@ defmodule Module do
     case :ets.take(table, :impl) do
       [{:impl, value, _, _}] ->
         impls = :ets.lookup_element(table, {:elixir, :impls}, 2)
-        {total, defaults} = args_count(args)
+        {total, defaults} = args_count(args, 0, 0)
 
         impl = for arity <- total..(total - defaults), into: impls do
           {{name, arity}, kind, line, file, value}
@@ -1208,15 +1208,13 @@ defmodule Module do
     :ok
   end
 
-  defp args_count(args), do: args_count(args, {0, 0})
-
-  defp args_count([], counts), do: counts
-  defp args_count([{:\\, _, _} | tail], {total, defaults}) do
-    args_count(tail, {total + 1, defaults + 1})
+  defp args_count([{:\\, _, _} | tail], total, defaults) do
+    args_count(tail, total + 1, defaults + 1)
   end
-  defp args_count([_head | tail], {total, defaults}) do
-    args_count(tail, {total + 1, defaults})
+  defp args_count([_head | tail], total, defaults) do
+    args_count(tail, total + 1, defaults)
   end
+  defp args_count([], total, defaults), do: {total, defaults}
 
   @doc false
   def check_behaviours_and_impls(env, table, all_definitions, overridable_pairs) do

--- a/lib/elixir/test/elixir/kernel/impl_test.exs
+++ b/lib/elixir/test/elixir/kernel/impl_test.exs
@@ -17,7 +17,11 @@ defmodule Kernel.ImplTest do
   end
 
   defmodule Behaviour do
-    @callback foo :: any
+    @callback foo() :: any
+  end
+
+  defmodule BehaviourWithArgument do
+    @callback foo(any) :: any
   end
 
   defmodule MacroBehaviour do
@@ -283,6 +287,20 @@ defmodule Kernel.ImplTest do
       end
       """
     end) =~ "got \"@impl Kernel.ImplTest.MacroBehaviour\" for function bar/0 but this behaviour was not declared with @behaviour"
+  end
+
+  test "does not warn for @impl when using default arguments" do
+    assert capture_err(fn ->
+      Code.eval_string ~S"""
+      defmodule Kernel.ImplTest.ImplAttributes do
+        @behaviour Kernel.ImplTest.Behaviour
+        @behaviour Kernel.ImplTest.BehaviourWithArgument
+
+        @impl true
+        def foo(args \\ []), do: args
+      end
+      """
+    end) == ""
   end
 
   test "does not warn for no @impl when overriding callback" do


### PR DESCRIPTION
`Module.compile_impl/6` was ignoring the default attributes when compiling the impl, now it checks the count of default attributes and adds an impl for each one.

I tried to follow the same idea of [`Module.add_doc/6`](https://github.com/elixir-lang/elixir/blob/144df88caedfae891e12fcd3595c61b64783fd12/lib/elixir/lib/module.ex#L641), that resolves the signature of the function by itself. The count of default attributes follows the same logic as [`:elixir_def.expand_defaults/2`](https://github.com/elixir-lang/elixir/blob/144df88caedfae891e12fcd3595c61b64783fd12/lib/elixir/src/elixir_def.erl#L230)

Fixes #6550