### PR TITLE
Support path with spaces as argument to elixir.bat

### DIFF
--- a/bin/elixir.bat
+++ b/bin/elixir.bat
@@ -88,7 +88,7 @@ if """"=="%par:--sname=%"               (set parsErlang=%parsErlang% -sname %1 &
 if """"=="%par:--name=%"                (set parsErlang=%parsErlang% -name %1 && shift)
 if """"=="%par:--logger-otp-reports=%"  (set parsErlang=%parsErlang% -logger handle_otp_reports %1 && shift)
 if """"=="%par:--logger-sasl-reports=%" (set parsErlang=%parsErlang% -logger handle_sasl_reports %1 && shift)
-if """"=="%par:--erl=%"                 (set beforeExtra=%beforeExtra% %~1 && shift)
+if """"=="%par:--erl=%"                 (set "beforeExtra=%beforeExtra% %~1" && shift)
 goto:startloop
 
 rem ******* assume all pre-params are parsed ********************


### PR DESCRIPTION
Erlang parameters (CLI switch '--erl') are used with possible quotes around the argument removed ('%~1').
This causes an error if one arbitrary argument to elixir.bat represents a quoted path with spaces in it:
"[part of path after space] was unexpected at this time."

Enclose the complete expression with quotes to work around this (the quotes are not added to the content).

This behavior is not documented in the [Windows XP Command Line Reference for SET](https://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/set.mspx)
but there are other places which document the [SET command](https://ss64.com/nt/set.html).

Fix for #6455