### PR TITLE
Fix negative microsecond result from DateTime.from_unix/2

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -16,6 +16,7 @@ defmodule Calendar.ISO do
   @behaviour Calendar
 
   @unix_epoch 62167219200
+  @unix_epoch_microseconds 1_000_000 * @unix_epoch
   @unix_start 1_000_000 * -@unix_epoch
   @unix_end 1_000_000 * (315569519999 - @unix_epoch)
   @unix_range_microseconds @unix_start..@unix_end
@@ -343,9 +344,8 @@ defmodule Calendar.ISO do
   def from_unix(integer, unit) when is_integer(integer) do
     total = System.convert_time_unit(integer, unit, :microsecond)
     if total in @unix_range_microseconds do
-      microsecond = rem(total, 1_000_000)
       precision = precision_for_unit(unit)
-      {date, time} = iso_seconds_to_datetime(@unix_epoch + div(total, 1_000_000))
+      {date, time, microsecond} = iso_microseconds_to_datetime(@unix_epoch_microseconds + total)
       {:ok, date, time, {microsecond, precision}}
     else
       {:error, :invalid_unix_time}
@@ -556,12 +556,13 @@ defmodule Calendar.ISO do
     {12, day_of_year - (334 + extra_day)}
   end
 
-  defp iso_seconds_to_datetime(seconds) do
-    {days, rest_seconds} = div_mod(seconds, @seconds_per_day)
+  defp iso_microseconds_to_datetime(microseconds) do
+    {days, rest_microseconds} = div_mod(microseconds, @parts_per_day)
+    {seconds, rest_microseconds} = div_mod(rest_microseconds, @microseconds_per_second)
 
     date = date_from_iso_days(days)
-    time = seconds_to_time(rest_seconds)
-    {date, time}
+    time = seconds_to_time(seconds)
+    {date, time, rest_microseconds}
   end
 
   defp seconds_to_time(seconds) when seconds in 0..(@seconds_per_day - 1) do

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -237,6 +237,13 @@ defmodule DateTimeTest do
 
     assert DateTime.from_unix(253402300799) == {:ok, max_datetime}
     assert DateTime.from_unix(253402300800) == {:error, :invalid_unix_time}
+
+    minus_datetime = %DateTime{
+      calendar: Calendar.ISO, day: 31, hour: 23, microsecond: {999999, 6},
+      minute: 59, month: 12, second: 59, std_offset: 0, time_zone: "Etc/UTC",
+      utc_offset: 0, year: 1969, zone_abbr: "UTC"
+    }
+    assert DateTime.from_unix(-1, :microsecond) == {:ok, minus_datetime}
   end
 
   test "from_unix!/2" do


### PR DESCRIPTION
Fixes negative microsecond result when calling `DateTime.from_unix/2` with :microsecond unit and a value which is not a multiple of 1_000_000. 

Before changes:

```
iex(1)> DateTime.from_unix!(-1, :microsecond)
#DateTime<1970-01-01 00:00:00.0000-1Z>
```

After changes:

```
iex(1)> DateTime.from_unix!(-1, :microsecond)
#DateTime<1969-12-31 23:59:59.999999Z>
```

This resolves #6589.