### PR TITLE
Fix example for ex_unit assertion

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -79,12 +79,12 @@ defmodule ExUnit.Assertions do
   Similarly, if a match expression is given, it will report
   any failure in terms of that match. Given
 
-      assert [one] = [two]
+      assert [1] = [2]
 
   you'll see:
 
       match (=) failed
-      code:  [one] = [two]
+      code:  [1] = [2]
       right: [2]
 
   Keep in mind that `assert` does not change its semantics


### PR DESCRIPTION
This code example used variables `one` and `two` that weren't previously initialized, and don't match the assertion result message.