### PR TITLE
Raise on EEx with invalid middle expression

### DIFF
--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -150,6 +150,12 @@ defmodule EExTest do
       end
     end
 
+    test "when middle expression is found without a start expression" do
+      assert_raise EEx.SyntaxError, "nofile:1: unexpected middle of expression <% else %>", fn ->
+        EEx.compile_string "<% if true %> foo<% else %>bar<% end %>"
+      end
+    end
+
     test "when end expression is found without a start expression" do
       assert_raise EEx.SyntaxError, "nofile:1: unexpected end of expression <% end %>",  fn ->
         EEx.compile_string "foo <% end %>"


### PR DESCRIPTION
In EEx if we evaluate a string with a middle expression without a start block we Elixir enters in an infinite loop consuming 100% CPU.

Example:

```elixir
EEx.eval_string ~S{
  <% if true %>
    foo
  <% else %>
    bar
  <% end %>
}
```

This PR Raises an `EEx.SyntaxError` exception in case there is start expression.

it covers issue #6607 .