### PR TITLE
Translate OTP apps sources

### DIFF
--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -137,12 +137,6 @@ defmodule IEx.Introspection do
 
   defp open_abstract_code_reduce(entry, {file, module_pair, fa_pair}, fun, arity) do
     case entry do
-      {:attribute, _, :file, {ann_file, _}} ->
-        if Path.type(ann_file) == :absolute do
-          {List.to_string(ann_file), module_pair, fa_pair}
-        else
-          {file, module_pair, fa_pair}
-        end
       {:attribute, ann, :module, _} ->
         {file, {file, :erl_anno.line(ann)}, fa_pair}
       {:function, ann, ann_fun, ann_arity, _} ->
@@ -160,28 +154,32 @@ defmodule IEx.Introspection do
   end
 
   @elixir_apps ~w(eex elixir ex_unit iex logger mix)a
-  @otp_apps ~w(
-    asn1 common_test compiler cosEvent cosEventDomain cosFileTransfer
-    cosNotification cosProperty cosTime cosTransactions crypto debugger dialyzer
-    diameter edoc eldap erl_docgen erl_interface erts et eunit hipe ic inets
-    kernel megaco mnesia observer orber os_mon otp_mibs parsetools public_key
-    reltool runtime_tools sasl snmp ssh ssl stdlib syntax_tools tools wx xmerl
-  )a
+  @otp_apps ~w(kernel stdlib)a
   @apps @elixir_apps ++ @otp_apps
 
   defp rewrite_source(module, source) do
     case :application.get_application(module) do
       {:ok, app} when app in @apps ->
-        {in_app, [lib_or_src | _]} =
-          source
-          |> Path.split()
-          |> Enum.reverse()
-          |> Enum.split_while(& &1 not in ["lib", "src"])
-
-        Application.app_dir(app, Path.join([lib_or_src | Enum.reverse(in_app)]))
+        Application.app_dir(app, rewrite_source(source))
       _ ->
-        List.to_string(source)
+        beam_path = :code.which(module)
+        if List.starts_with?(beam_path, :code.root_dir()) do
+          app_vsn = beam_path |> Path.dirname() |> Path.dirname() |> Path.basename()
+
+          Path.join([:code.root_dir(), "lib", app_vsn, rewrite_source(source)])
+        else
+          List.to_string(source)
+        end
     end
+  end
+
+  defp rewrite_source(source) do
+    {in_app, [lib_or_src | _]} =
+      source
+      |> Path.split()
+      |> Enum.reverse()
+      |> Enum.split_while(& &1 not in ["lib", "src"])
+    Path.join([lib_or_src | Enum.reverse(in_app)])
   end
 
   @doc """

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -120,8 +120,12 @@ defmodule IEx.Introspection do
     else
       :preloaded ->
         beam_path = :code.where_is_file(Atom.to_charlist(module) ++ :code.objfile_extension())
-        {:ok, source_path} = :filelib.find_source(beam_path)
-        open_abstract_code(module, fun, arity, List.to_string(source_path), beam_path)
+        case :filelib.find_source(beam_path) do
+          {:ok, source_path} ->
+            open_abstract_code(module, fun, arity, List.to_string(source_path), beam_path)
+          _ ->
+            :error
+        end
       :in_memory ->
         source_path = module.module_info(:compile)[:source]
         open_abstract_code(module, fun, arity, source_path, nil)

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -163,7 +163,7 @@ defmodule IEx.Introspection do
         Application.app_dir(app, rewrite_source(source))
       _ ->
         beam_path = :code.which(module)
-        if List.starts_with?(beam_path, :code.root_dir()) do
+        if is_list(beam_path) and List.starts_with?(beam_path, :code.root_dir()) do
           app_vsn = beam_path |> Path.dirname() |> Path.dirname() |> Path.basename()
 
           Path.join([:code.root_dir(), "lib", app_vsn, rewrite_source(source)])

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -114,7 +114,7 @@ defmodule IEx.Introspection do
   defp open_mfa(module, fun, arity) do
     with {:module, _} <- Code.ensure_loaded(module),
          source when is_list(source) <- module.module_info(:compile)[:source] do
-      source = rewrite_elixir_source(module, source)
+      source = rewrite_source(module, source)
       open_abstract_code(module, fun, arity, source)
     else
       _ -> :error
@@ -159,9 +159,19 @@ defmodule IEx.Introspection do
     end
   end
 
-  defp rewrite_elixir_source(module, source) do
+  @elixir_apps ~w(eex elixir ex_unit iex logger mix)a
+  @otp_apps ~w(
+    asn1 common_test compiler cosEvent cosEventDomain cosFileTransfer
+    cosNotification cosProperty cosTime cosTransactions crypto debugger dialyzer
+    diameter edoc eldap erl_docgen erl_interface erts et eunit hipe ic inets
+    kernel megaco mnesia observer orber os_mon otp_mibs parsetools public_key
+    reltool runtime_tools sasl snmp ssh ssl stdlib syntax_tools tools wx xmerl
+  )a
+  @apps @elixir_apps ++ @otp_apps
+
+  defp rewrite_source(module, source) do
     case :application.get_application(module) do
-      {:ok, app} when app in [:eex, :elixir, :ex_unit, :iex, :logger, :mix] ->
+      {:ok, app} when app in @apps ->
         {in_app, [lib_or_src | _]} =
           source
           |> Path.split()

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -128,6 +128,7 @@ defmodule IEx.HelpersTest do
     {:ok, vsn} = :application.get_key(:stdlib, :vsn)
     @lists_erl "lib/stdlib-#{vsn}/src/lists.erl"
     @httpc_erl "src/http_client/httpc.erl"
+    @init_erl "src/init.erl"
     @editor System.get_env("ELIXIR_EDITOR")
 
     test "opens __FILE__ and __LINE__" do
@@ -214,9 +215,19 @@ defmodule IEx.HelpersTest do
              ~r/#{@httpc_erl}:\d+$/
     end
 
-    test "errors OTP preloaded module" do
-      assert capture_iex("open(:init)") ==
-             "Could not open: :init. Module is not available."
+    test "opens OTP preloaded module" do
+      assert capture_iex("open(:init)") |> maybe_trim_quotes() =~
+             ~r/#{@init_erl}:\d+$/
+    end
+
+    test "opens OTP preloaded module.function" do
+      assert capture_iex("open(:init.get_status)") |> maybe_trim_quotes() =~
+             ~r/#{@init_erl}:\d+$/
+    end
+
+    test "opens OTP preloaded module.function/arity" do
+      assert capture_iex("open(:init.get_status/0)") |> maybe_trim_quotes() =~
+             ~r/#{@init_erl}:\d+$/
     end
 
     test "errors if module is not available" do
@@ -233,6 +244,8 @@ defmodule IEx.HelpersTest do
              "Could not open: :lists.unknown. Function/macro is not available."
       assert capture_iex("open(:httpc.unknown)") ==
              "Could not open: :httpc.unknown. Function/macro is not available."
+      assert capture_iex("open(:init.unknown)") ==
+             "Could not open: :init.unknown. Function/macro is not available."
     end
 
     test "errors if module.function/arity is not available" do
@@ -244,6 +257,8 @@ defmodule IEx.HelpersTest do
              "Could not open: :lists.reverse/10. Function/macro is not available."
       assert capture_iex("open(:httpc.request/10)") ==
              "Could not open: :httpc.request/10. Function/macro is not available."
+      assert capture_iex("open(:init.get_status/10)") ==
+             "Could not open: :init.get_status/10. Function/macro is not available."
     end
 
     test "errors if module is in-memory" do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -125,7 +125,8 @@ defmodule IEx.HelpersTest do
   describe "open" do
     @iex_helpers "iex/lib/iex/helpers.ex"
     @elixir_erl "elixir/src/elixir.erl"
-    @otp_erl "src/math.erl"
+    {:ok, vsn} = :application.get_key(:stdlib, :vsn)
+    @otp_erl "lib/stdlib-#{vsn}/src/math.erl"
     @editor System.get_env("ELIXIR_EDITOR")
 
     test "opens __FILE__ and __LINE__" do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -214,6 +214,11 @@ defmodule IEx.HelpersTest do
              ~r/#{@httpc_erl}:\d+$/
     end
 
+    test "errors OTP preloaded module" do
+      assert capture_iex("open(:init)") ==
+             "Could not open: :init. Module is not available."
+    end
+
     test "errors if module is not available" do
       assert capture_iex("open(:unknown)") ==
              "Could not open: :unknown. Module is not available."

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -126,7 +126,8 @@ defmodule IEx.HelpersTest do
     @iex_helpers "iex/lib/iex/helpers.ex"
     @elixir_erl "elixir/src/elixir.erl"
     {:ok, vsn} = :application.get_key(:stdlib, :vsn)
-    @otp_erl "lib/stdlib-#{vsn}/src/math.erl"
+    @lists_erl "lib/stdlib-#{vsn}/src/lists.erl"
+    @httpc_erl "src/http_client/httpc.erl"
     @editor System.get_env("ELIXIR_EDITOR")
 
     test "opens __FILE__ and __LINE__" do
@@ -183,19 +184,34 @@ defmodule IEx.HelpersTest do
              ~r/#{@elixir_erl}:\d+$/
     end
 
-    test "opens OTP module" do
-      assert capture_iex("open(:math)") |> maybe_trim_quotes() =~
-             ~r/#{@otp_erl}:\d+$/
+    test "opens OTP lists module" do
+      assert capture_iex("open(:lists)") |> maybe_trim_quotes() =~
+             ~r/#{@lists_erl}:\d+$/
     end
 
-    test "opens OTP module.function" do
-      assert capture_iex("open(:math.pow)") |> maybe_trim_quotes() =~
-             ~r/#{@otp_erl}:\d+$/
+    test "opens OTP lists module.function" do
+      assert capture_iex("open(:lists.reverse)") |> maybe_trim_quotes() =~
+             ~r/#{@lists_erl}:\d+$/
     end
 
-    test "opens OTP module.function/arity" do
-      assert capture_iex("open(:math.pow/2)") |> maybe_trim_quotes() =~
-             ~r/#{@otp_erl}:\d+$/
+    test "opens OTP lists module.function/arity" do
+      assert capture_iex("open(:lists.reverse/1)") |> maybe_trim_quotes() =~
+             ~r/#{@lists_erl}:\d+$/
+    end
+
+    test "opens OTP httpc module" do
+      assert capture_iex("open(:httpc)") |> maybe_trim_quotes() =~
+             ~r/#{@httpc_erl}:\d+$/
+    end
+
+    test "opens OTP httpc module.function" do
+      assert capture_iex("open(:httpc.request)") |> maybe_trim_quotes() =~
+             ~r/#{@httpc_erl}:\d+$/
+    end
+
+    test "opens OTP httpc module.function/arity" do
+      assert capture_iex("open(:httpc.request/1)") |> maybe_trim_quotes() =~
+             ~r/#{@httpc_erl}:\d+$/
     end
 
     test "errors if module is not available" do
@@ -208,8 +224,10 @@ defmodule IEx.HelpersTest do
              "Could not open: :unknown.unknown. Module is not available."
       assert capture_iex("open(:elixir.unknown)") ==
              "Could not open: :elixir.unknown. Function/macro is not available."
-      assert capture_iex("open(:math.unknown)") ==
-             "Could not open: :math.unknown. Function/macro is not available."
+      assert capture_iex("open(:lists.unknown)") ==
+             "Could not open: :lists.unknown. Function/macro is not available."
+      assert capture_iex("open(:httpc.unknown)") ==
+             "Could not open: :httpc.unknown. Function/macro is not available."
     end
 
     test "errors if module.function/arity is not available" do
@@ -217,8 +235,10 @@ defmodule IEx.HelpersTest do
              "Could not open: :unknown.start/10. Module is not available."
       assert capture_iex("open(:elixir.start/10)") ==
              "Could not open: :elixir.start/10. Function/macro is not available."
-      assert capture_iex("open(:math.pow/10)") ==
-             "Could not open: :math.pow/10. Function/macro is not available."
+      assert capture_iex("open(:lists.reverse/10)") ==
+             "Could not open: :lists.reverse/10. Function/macro is not available."
+      assert capture_iex("open(:httpc.request/10)") ==
+             "Could not open: :httpc.request/10. Function/macro is not available."
     end
 
     test "opens the current pry location" do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -125,7 +125,7 @@ defmodule IEx.HelpersTest do
   describe "open" do
     @iex_helpers "iex/lib/iex/helpers.ex"
     @elixir_erl "elixir/src/elixir.erl"
-    @otp_erl "lib/erlang/lib/stdlib-3.4/src/math.erl"
+    @otp_erl "src/math.erl"
     @editor System.get_env("ELIXIR_EDITOR")
 
     test "opens __FILE__ and __LINE__" do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -125,6 +125,7 @@ defmodule IEx.HelpersTest do
   describe "open" do
     @iex_helpers "iex/lib/iex/helpers.ex"
     @elixir_erl "elixir/src/elixir.erl"
+    @otp_erl "lib/erlang/lib/stdlib-3.4/src/math.erl"
     @editor System.get_env("ELIXIR_EDITOR")
 
     test "opens __FILE__ and __LINE__" do
@@ -181,6 +182,21 @@ defmodule IEx.HelpersTest do
              ~r/#{@elixir_erl}:\d+$/
     end
 
+    test "opens OTP module" do
+      assert capture_iex("open(:math)") |> maybe_trim_quotes() =~
+             ~r/#{@otp_erl}:\d+$/
+    end
+
+    test "opens OTP module.function" do
+      assert capture_iex("open(:math.pow)") |> maybe_trim_quotes() =~
+             ~r/#{@otp_erl}:\d+$/
+    end
+
+    test "opens OTP module.function/arity" do
+      assert capture_iex("open(:math.pow/2)") |> maybe_trim_quotes() =~
+             ~r/#{@otp_erl}:\d+$/
+    end
+
     test "errors if module is not available" do
       assert capture_iex("open(:unknown)") ==
              "Could not open: :unknown. Module is not available."
@@ -191,6 +207,8 @@ defmodule IEx.HelpersTest do
              "Could not open: :unknown.unknown. Module is not available."
       assert capture_iex("open(:elixir.unknown)") ==
              "Could not open: :elixir.unknown. Function/macro is not available."
+      assert capture_iex("open(:math.unknown)") ==
+             "Could not open: :math.unknown. Function/macro is not available."
     end
 
     test "errors if module.function/arity is not available" do
@@ -198,6 +216,8 @@ defmodule IEx.HelpersTest do
              "Could not open: :unknown.start/10. Module is not available."
       assert capture_iex("open(:elixir.start/10)") ==
              "Could not open: :elixir.start/10. Function/macro is not available."
+      assert capture_iex("open(:math.pow/10)") ==
+             "Could not open: :math.pow/10. Function/macro is not available."
     end
 
     test "opens the current pry location" do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -241,6 +241,13 @@ defmodule IEx.HelpersTest do
              "Could not open: :httpc.request/10. Function/macro is not available."
     end
 
+    test "errors if module is in-memory" do
+      assert capture_iex("defmodule Foo, do: nil ; open(Foo)") =~
+             ~r"Invalid arguments for open helper:"
+    after
+      cleanup_modules([Foo])
+    end
+
     test "opens the current pry location" do
       assert capture_iex("open()", [], env: %{__ENV__ | line: 3}) |> maybe_trim_quotes() ==
              "#{__ENV__.file}:3"


### PR DESCRIPTION
Similar to https://github.com/elixir-lang/elixir/commit/d90c7bbb79a38d06c07a21477d20cee4e7db9006

This allows to do:

```
iex> open :gen_server
```

---

1. I haven't done a comprehensive search yet but this works on `asdf` which compiles Erlang from source. Also ESL ubuntu package (https://www.erlang-solutions.com/resources/download.html) ships with source files so it should work there too. If there's interest in this feature and more investigation is needed, I'm happy to do it.

2. (done) ~it doesn't handle `iex> open :erlang.phash2` yet, looking into it.~

3. (done) ~it doesn't handle `iex> open :httpc` either~