### PR TITLE
Fix typo/reference in Supervisor @moduledoc (v1.5)

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -82,7 +82,7 @@ defmodule Supervisor do
   supervisor will automatically start a new one, with the initial stack
   of `[:hello]`:
 
-      GenServer.call(MyStack, :pop)
+      GenServer.call(Stack, :pop)
       #=> :hello
 
   Supervisors support different strategies; in the example above, we


### PR DESCRIPTION
All examples leading up to this snippet have used the module name
`Stack`, this updates the snippet to use the same.