### PR TITLE
Remove underspecification warning for consolidated protocols

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -344,11 +344,12 @@ defmodule Protocol do
            [{:type, line, :product, [{:atom, 0, :consolidated?}]},
             {:atom, 0, true}]}
         {:type, line, :fun, [{:type, _, :product, [{:atom, _, :impls}]}, _]} ->
+          impls = for mod <- types, do: {:atom, 0, mod}
           {:type, line, :fun,
            [{:type, line, :product, [{:atom, 0, :impls}]},
             {:type, 0, :tuple,
              [{:atom, 0, :consolidated},
-              {:type, 0, :list, [{:type, 0, :module, []}]}]}]}
+              {:type, 0, :list, [{:type, 0, :union, impls}]}]}]}
         other -> other
       end
     end

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -422,22 +422,23 @@ defmodule Protocol.ConsolidationTest do
   test "consolidation updates __protocol__/1 spec" do
     {:ok, {Sample, [{:abstract_code, {:raw_abstract_v1, forms}}]}} =
       :beam_lib.chunks(@sample_binary, [:abstract_code])
+
     for {:attribute, _line, :spec, {{:__protocol__, 1}, funspecs}} <- forms,
-      {:type, _line, :fun, [{:type, _, :product, [{:atom, _, clause}]}, return_type]} <- funspecs do
-        # Only check that :consolidated? and :impls types changed
-        # after consolidation. This prevents underspec warnings in
-        # dialyzer on consolidated protocols.
-        case clause do
-          :consolidated? ->
-            assert {:atom, _, true} = return_type
-          :impls ->
-            assert {:type, _, :tuple, [
-                       {:atom, _, :consolidated},
-                       {:type, _, :list, [{:type, _, :union, [{:atom, _, ImplStruct}]}]}
-                     ]} = return_type
-          _ ->
-            :ok
-        end
+        {:type, _line, :fun, [{:type, _, :product, [{:atom, _, clause}]}, return_type]} <- funspecs do
+      # Only check that :consolidated? and :impls types changed after consolidation.
+      # This prevents underspec warnings in dialyzer on consolidated protocols.
+      case clause do
+        :consolidated? ->
+          assert {:atom, _, true} = return_type
+        :impls ->
+          {:type, _, :tuple, tuple_args} = return_type
+          assert [
+                   {:atom, _, :consolidated},
+                   {:type, _, :list, [{:type, _, :union, [{:atom, _, ImplStruct}]}]}
+                 ] = tuple_args
+        _ ->
+          :ok
+      end
     end
   end
 end

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -418,4 +418,26 @@ defmodule Protocol.ConsolidationTest do
       Sample.ok(:foo)
     end
   end
+
+  test "consolidation updates __protocol__/1 spec" do
+    {:ok, {Sample, [{:abstract_code, {:raw_abstract_v1, forms}}]}} =
+      :beam_lib.chunks(@sample_binary, [:abstract_code])
+    for {:attribute, _line, :spec, {{:__protocol__, 1}, funspecs}} <- forms,
+      {:type, _line, :fun, [{:type, _, :product, [{:atom, _, clause}]}, return_type]} <- funspecs do
+        # Only check that :consolidated? and :impls types changed
+        # after consolidation. This prevents underspec warnings in
+        # dialyzer on consolidated protocols.
+        case clause do
+          :consolidated? ->
+            assert {:atom, _, true} = return_type
+          :impls ->
+            assert {:type, _, :tuple, [
+                       {:atom, _, :consolidated},
+                       {:type, _, :list, [{:type, _, :union, [{:atom, _, ImplStruct}]}]}
+                     ]} = return_type
+          _ ->
+            :ok
+        end
+    end
+  end
 end


### PR DESCRIPTION
Example warning:

    'Elixir.Collectable':'__protocol__'('impls') -> {'consolidated',[module()]}
        ; ('consolidated?') -> 'true'
        ; ('functions') -> [{'into',1},...]
        ; ('module') -> 'Elixir.Collectable' is a supertype of the success typing: 'Elixir.Collectable':'__protocol__'('consolidated?' | 'functions' | 'impls' | 'module') -> 'Elixir.Collectable' | 'true' | [{'into',1},...] | {'consolidated',['Elixir.BitString' | 'Elixir.File.Stream' | 'Elixir.HashDict' | 'Elixir.HashSet' | 'Elixir.IO.Stream' | 'Elixir.List' | 'Elixir.Map' | 'Elixir.MapSet',...]}

Note that the mismatch is that `module()` is wider than the actual list of consolidated implementations. Since we have this information when consolidating, we can adjust the type spec to prevent this particular warning.

This pull-request also adds a test for changes to the consolidated function specifications.