### PR TITLE
Clarify that the :trim option defaults to false

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -416,6 +416,7 @@ defmodule Regex do
       given pattern.
 
     * `:trim` - when `true`, removes empty strings (`""`) from the result.
+      Defaults to `false`.
 
     * `:on` - specifies which captures to split the string on, and in what
       order. Defaults to `:first` which means captures inside the regex do not


### PR DESCRIPTION
Was unsure with the current wording, and the other options have the default documented too!