### PR TITLE
Implement Access.filter/1

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -700,4 +700,158 @@ defmodule Access do
   defp get_and_update_at([], _index, _next, updates) do
     {nil, :lists.reverse(updates)}
   end
+
+  @doc ~S"""
+    Returns a function that accesses all elements of a list that match the provided predicate.
+
+    The returned function is typically passed as an accessor to `Kernel.get_in/2`,
+    `Kernel.get_and_update_in/3`, and friends.
+
+    ## Examples
+
+        iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
+        iex> get_in(list, [Access.filter(&(&1.salary >= 20)), :name])
+        ["mary", "francine"]
+        iex> get_and_update_in(list, [Access.filter(&(&1.salary <= 20)), :name], fn
+        ...>   prev -> {prev, String.upcase(prev)}
+        ...> end)
+        {["john", "mary"], [%{name: "JOHN", salary: 10}, %{name: "MARY", salary: 20}, %{name: "francine", salary: 30}]}
+
+    `filter/1` can also be used to pop elements out of a list or
+    a key inside of a list:
+
+        iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
+        iex> pop_in(list, [Access.filter(&(&1.salary >= 20))])
+        {[%{name: "mary", salary: 20}, %{name: "francine", salary: 30}], [%{name: "john", salary: 10}]}
+        iex> pop_in(list, [Access.filter(&(&1.salary >= 20)), :name])
+        {["mary", "francine"], [%{name: "john", salary: 10}, %{salary: 20}, %{salary: 30}]}
+
+    When no match is found, an empty list is returned and the update function is never called
+
+        iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
+        iex> get_in(list, [Access.filter(&(&1.salary >= 50)), :name])
+        []
+        iex> get_and_update_in(list, [Access.filter(&(&1.salary >= 50)), :name], fn
+        ...>   prev -> {prev, String.upcase(prev)}
+        ...> end)
+        {[], [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]}
+
+    An error is raised if the predicate is not a function or is of the incorrect arity:
+
+        iex> get_in([], [Access.filter(fn a, b -> a == b end)])
+        ** (FunctionClauseError) no function clause matching in Access.filter/1
+
+    An error is raised if the accessed structure is not a list:
+
+        iex> get_in(%{}, [Access.filter(fn a -> a == 10 end)])
+        ** (RuntimeError) Access.filter/1 expected a list, got: %{}
+  """
+  def filter(func) when is_function(func, 1) do
+    fn(op, data, next) -> filter(op, data, func, next) end
+  end
+
+  defp filter(:get, data, func, next) when is_list(data) do
+    data |> Enum.filter(func) |> Enum.map(next)
+  end
+
+  defp filter(:get_and_update, data, func, next) when is_list(data) do
+    get_and_update_where(data, func, next, [], [])
+  end
+
+  defp filter(_op, data, _func, _next) do
+    raise "Access.filter/1 expected a list, got: #{inspect data}"
+  end
+
+  @doc ~S"""
+    Returns a function that accesses all elements of a list that match the provided predicate.
+
+    The returned function is typically passed as an accessor to `Kernel.get_in/2`,
+    `Kernel.get_and_update_in/3`, and friends.
+
+    ## Examples
+
+        iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
+        iex> get_in(list, [Access.find(&(&1.salary >= 20)), :name])
+        "mary"
+        iex> get_and_update_in(list, [Access.find(&(&1.salary <= 20)), :name], fn
+        ...>   prev -> {prev, String.upcase(prev)}
+        ...> end)
+        {"john", [%{name: "JOHN", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]}
+
+    `find/1` can also be used to pop elements out of a list or
+    a key inside of a list:
+
+        iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
+        iex> pop_in(list, [Access.find(&(&1.salary >= 20))])
+        {%{name: "mary", salary: 20}, [%{name: "john", salary: 10}, %{name: "francine", salary: 30}]}
+        iex> pop_in(list, [Access.find(&(&1.salary >= 20)), :name])
+        {"mary", [%{name: "john", salary: 10}, %{salary: 20}, %{name: "francine", salary: 30}]}
+
+    When no match is found, an empty list is returned and the update function is never called
+
+        iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
+        iex> get_in(list, [Access.find(&(&1.salary >= 50)), :name])
+        nil
+        iex> get_and_update_in(list, [Access.find(&(&1.salary >= 50)), :name], fn
+        ...>   prev -> {prev, String.upcase(prev)}
+        ...> end)
+        {nil, [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]}
+
+    An error is raised if the predicate is not a function or is of the incorrect arity:
+
+        iex> get_in([], [Access.find(fn a, b -> a == b end)])
+        ** (FunctionClauseError) no function clause matching in Access.find/1
+
+    An error is raised if the accessed structure is not a list:
+
+        iex> get_in(%{}, [Access.find(fn a -> a == 10 end)])
+        ** (RuntimeError) Access.find/1 expected a list, got: %{}
+  """
+  def find(func) when is_function(func, 1) do
+    fn(op, data, next) -> find(op, data, func, next) end
+  end
+
+  defp find(:get, data, func, next) when is_list(data) do
+    data |> Enum.find(func) |> next.()
+  end
+
+  defp find(:get_and_update, data, func, next) when is_list(data) do
+    get_and_update_found(data, func, next, [])
+  end
+
+  defp find(_op, data, _func, _next) do
+    raise "Access.find/1 expected a list, got: #{inspect data}"
+  end
+
+  defp get_and_update_where([head | rest], func, next, updates, gets) do
+    if func.(head) do
+      case next.(head) do
+        {get, update} ->
+          get_and_update_where(rest, func, next, [update | updates], [get | gets])
+        :pop ->
+          get_and_update_where(rest, func, next, updates, [head | gets])
+      end
+    else
+      get_and_update_where(rest, func, next, [head | updates], gets)
+    end
+  end
+
+  defp get_and_update_where([], _func, _next, updates, gets) do
+    {:list.reverse(gets), :lists.reverse(updates)}
+  end
+
+  defp get_and_update_found([head | rest], func, next, updates) do
+    if func.(head) do
+      case next.(head) do
+        {get, update} -> {get, :lists.reverse([update | updates], rest)}
+        :pop -> {head, :lists.reverse(updates, rest)}
+      end
+    else
+      get_and_update_found(rest, func, next, [head | updates])
+    end
+  end
+
+  defp get_and_update_found([], _index, _next, updates) do
+    {nil, :lists.reverse(updates)}
+  end
 end

--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -702,49 +702,49 @@ defmodule Access do
   end
 
   @doc ~S"""
-    Returns a function that accesses all elements of a list that match the provided predicate.
+  Returns a function that accesses all elements of a list that match the provided predicate.
 
-    The returned function is typically passed as an accessor to `Kernel.get_in/2`,
-    `Kernel.get_and_update_in/3`, and friends.
+  The returned function is typically passed as an accessor to `Kernel.get_in/2`,
+  `Kernel.get_and_update_in/3`, and friends.
 
-    ## Examples
+  ## Examples
 
-        iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
-        iex> get_in(list, [Access.filter(&(&1.salary >= 20)), :name])
-        ["mary", "francine"]
-        iex> get_and_update_in(list, [Access.filter(&(&1.salary <= 20)), :name], fn
-        ...>   prev -> {prev, String.upcase(prev)}
-        ...> end)
-        {["john", "mary"], [%{name: "JOHN", salary: 10}, %{name: "MARY", salary: 20}, %{name: "francine", salary: 30}]}
+      iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
+      iex> get_in(list, [Access.filter(&(&1.salary >= 20)), :name])
+      ["mary", "francine"]
+      iex> get_and_update_in(list, [Access.filter(&(&1.salary <= 20)), :name], fn
+      ...>   prev -> {prev, String.upcase(prev)}
+      ...> end)
+      {["john", "mary"], [%{name: "JOHN", salary: 10}, %{name: "MARY", salary: 20}, %{name: "francine", salary: 30}]}
 
-    `filter/1` can also be used to pop elements out of a list or
-    a key inside of a list:
+  `filter/1` can also be used to pop elements out of a list or
+  a key inside of a list:
 
-        iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
-        iex> pop_in(list, [Access.filter(&(&1.salary >= 20))])
-        {[%{name: "mary", salary: 20}, %{name: "francine", salary: 30}], [%{name: "john", salary: 10}]}
-        iex> pop_in(list, [Access.filter(&(&1.salary >= 20)), :name])
-        {["mary", "francine"], [%{name: "john", salary: 10}, %{salary: 20}, %{salary: 30}]}
+      iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
+      iex> pop_in(list, [Access.filter(&(&1.salary >= 20))])
+      {[%{name: "mary", salary: 20}, %{name: "francine", salary: 30}], [%{name: "john", salary: 10}]}
+      iex> pop_in(list, [Access.filter(&(&1.salary >= 20)), :name])
+      {["mary", "francine"], [%{name: "john", salary: 10}, %{salary: 20}, %{salary: 30}]}
 
-    When no match is found, an empty list is returned and the update function is never called
+  When no match is found, an empty list is returned and the update function is never called
 
-        iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
-        iex> get_in(list, [Access.filter(&(&1.salary >= 50)), :name])
-        []
-        iex> get_and_update_in(list, [Access.filter(&(&1.salary >= 50)), :name], fn
-        ...>   prev -> {prev, String.upcase(prev)}
-        ...> end)
-        {[], [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]}
+      iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
+      iex> get_in(list, [Access.filter(&(&1.salary >= 50)), :name])
+      []
+      iex> get_and_update_in(list, [Access.filter(&(&1.salary >= 50)), :name], fn
+      ...>   prev -> {prev, String.upcase(prev)}
+      ...> end)
+      {[], [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]}
 
-    An error is raised if the predicate is not a function or is of the incorrect arity:
+  An error is raised if the predicate is not a function or is of the incorrect arity:
 
-        iex> get_in([], [Access.filter(fn a, b -> a == b end)])
-        ** (FunctionClauseError) no function clause matching in Access.filter/1
+      iex> get_in([], [Access.filter(fn a, b -> a == b end)])
+      ** (FunctionClauseError) no function clause matching in Access.filter/1
 
-    An error is raised if the accessed structure is not a list:
+  An error is raised if the accessed structure is not a list:
 
-        iex> get_in(%{}, [Access.filter(fn a -> a == 10 end)])
-        ** (RuntimeError) Access.filter/1 expected a list, got: %{}
+      iex> get_in(%{}, [Access.filter(fn a -> a == 10 end)])
+      ** (RuntimeError) Access.filter/1 expected a list, got: %{}
   """
   def filter(func) when is_function(func, 1) do
     fn(op, data, next) -> filter(op, data, func, next) end
@@ -763,49 +763,49 @@ defmodule Access do
   end
 
   @doc ~S"""
-    Returns a function that accesses all elements of a list that match the provided predicate.
+  Returns a function that accesses all elements of a list that match the provided predicate.
 
-    The returned function is typically passed as an accessor to `Kernel.get_in/2`,
-    `Kernel.get_and_update_in/3`, and friends.
+  The returned function is typically passed as an accessor to `Kernel.get_in/2`,
+  `Kernel.get_and_update_in/3`, and friends.
 
-    ## Examples
+  ## Examples
 
-        iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
-        iex> get_in(list, [Access.find(&(&1.salary >= 20)), :name])
-        "mary"
-        iex> get_and_update_in(list, [Access.find(&(&1.salary <= 20)), :name], fn
-        ...>   prev -> {prev, String.upcase(prev)}
-        ...> end)
-        {"john", [%{name: "JOHN", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]}
+      iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
+      iex> get_in(list, [Access.find(&(&1.salary >= 20)), :name])
+      "mary"
+      iex> get_and_update_in(list, [Access.find(&(&1.salary <= 20)), :name], fn
+      ...>   prev -> {prev, String.upcase(prev)}
+      ...> end)
+      {"john", [%{name: "JOHN", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]}
 
-    `find/1` can also be used to pop elements out of a list or
-    a key inside of a list:
+  `find/1` can also be used to pop elements out of a list or
+  a key inside of a list:
 
-        iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
-        iex> pop_in(list, [Access.find(&(&1.salary >= 20))])
-        {%{name: "mary", salary: 20}, [%{name: "john", salary: 10}, %{name: "francine", salary: 30}]}
-        iex> pop_in(list, [Access.find(&(&1.salary >= 20)), :name])
-        {"mary", [%{name: "john", salary: 10}, %{salary: 20}, %{name: "francine", salary: 30}]}
+      iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
+      iex> pop_in(list, [Access.find(&(&1.salary >= 20))])
+      {%{name: "mary", salary: 20}, [%{name: "john", salary: 10}, %{name: "francine", salary: 30}]}
+      iex> pop_in(list, [Access.find(&(&1.salary >= 20)), :name])
+      {"mary", [%{name: "john", salary: 10}, %{salary: 20}, %{name: "francine", salary: 30}]}
 
-    When no match is found, an empty list is returned and the update function is never called
+  When no match is found, an empty list is returned and the update function is never called
 
-        iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
-        iex> get_in(list, [Access.find(&(&1.salary >= 50)), :name])
-        nil
-        iex> get_and_update_in(list, [Access.find(&(&1.salary >= 50)), :name], fn
-        ...>   prev -> {prev, String.upcase(prev)}
-        ...> end)
-        {nil, [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]}
+      iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
+      iex> get_in(list, [Access.find(&(&1.salary >= 50)), :name])
+      nil
+      iex> get_and_update_in(list, [Access.find(&(&1.salary >= 50)), :name], fn
+      ...>   prev -> {prev, String.upcase(prev)}
+      ...> end)
+      {nil, [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]}
 
-    An error is raised if the predicate is not a function or is of the incorrect arity:
+  An error is raised if the predicate is not a function or is of the incorrect arity:
 
-        iex> get_in([], [Access.find(fn a, b -> a == b end)])
-        ** (FunctionClauseError) no function clause matching in Access.find/1
+      iex> get_in([], [Access.find(fn a, b -> a == b end)])
+      ** (FunctionClauseError) no function clause matching in Access.find/1
 
-    An error is raised if the accessed structure is not a list:
+  An error is raised if the accessed structure is not a list:
 
-        iex> get_in(%{}, [Access.find(fn a -> a == 10 end)])
-        ** (RuntimeError) Access.find/1 expected a list, got: %{}
+      iex> get_in(%{}, [Access.find(fn a -> a == 10 end)])
+      ** (RuntimeError) Access.find/1 expected a list, got: %{}
   """
   def find(func) when is_function(func, 1) do
     fn(op, data, next) -> find(op, data, func, next) end

--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -738,7 +738,7 @@ defmodule Access do
 
   An error is raised if the predicate is not a function or is of the incorrect arity:
 
-      iex> get_in([], [Access.filter(fn a, b -> a == b end)])
+      iex> get_in([], [Access.filter(5)])
       ** (FunctionClauseError) no function clause matching in Access.filter/1
 
   An error is raised if the accessed structure is not a list:
@@ -746,7 +746,7 @@ defmodule Access do
       iex> get_in(%{}, [Access.filter(fn a -> a == 10 end)])
       ** (RuntimeError) Access.filter/1 expected a list, got: %{}
   """
-  def filter(func) when is_function(func, 1) do
+  def filter(func) when is_function(func) do
     fn(op, data, next) -> filter(op, data, func, next) end
   end
 
@@ -760,67 +760,6 @@ defmodule Access do
 
   defp filter(_op, data, _func, _next) do
     raise "Access.filter/1 expected a list, got: #{inspect data}"
-  end
-
-  @doc ~S"""
-  Returns a function that accesses all elements of a list that match the provided predicate.
-
-  The returned function is typically passed as an accessor to `Kernel.get_in/2`,
-  `Kernel.get_and_update_in/3`, and friends.
-
-  ## Examples
-
-      iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
-      iex> get_in(list, [Access.find(&(&1.salary >= 20)), :name])
-      "mary"
-      iex> get_and_update_in(list, [Access.find(&(&1.salary <= 20)), :name], fn
-      ...>   prev -> {prev, String.upcase(prev)}
-      ...> end)
-      {"john", [%{name: "JOHN", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]}
-
-  `find/1` can also be used to pop elements out of a list or
-  a key inside of a list:
-
-      iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
-      iex> pop_in(list, [Access.find(&(&1.salary >= 20))])
-      {%{name: "mary", salary: 20}, [%{name: "john", salary: 10}, %{name: "francine", salary: 30}]}
-      iex> pop_in(list, [Access.find(&(&1.salary >= 20)), :name])
-      {"mary", [%{name: "john", salary: 10}, %{salary: 20}, %{name: "francine", salary: 30}]}
-
-  When no match is found, an empty list is returned and the update function is never called
-
-      iex> list = [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]
-      iex> get_in(list, [Access.find(&(&1.salary >= 50)), :name])
-      nil
-      iex> get_and_update_in(list, [Access.find(&(&1.salary >= 50)), :name], fn
-      ...>   prev -> {prev, String.upcase(prev)}
-      ...> end)
-      {nil, [%{name: "john", salary: 10}, %{name: "mary", salary: 20}, %{name: "francine", salary: 30}]}
-
-  An error is raised if the predicate is not a function or is of the incorrect arity:
-
-      iex> get_in([], [Access.find(10)])
-      ** (FunctionClauseError) no function clause matching in Access.find/1
-
-  An error is raised if the accessed structure is not a list:
-
-      iex> get_in(%{}, [Access.find(fn a -> a == 10 end)])
-      ** (RuntimeError) Access.find/1 expected a list, got: %{}
-  """
-  def find(func) when is_function(func) do
-    fn(op, data, next) -> find(op, data, func, next) end
-  end
-
-  defp find(:get, data, func, next) when is_list(data) do
-    data |> Enum.find(func) |> next.()
-  end
-
-  defp find(:get_and_update, data, func, next) when is_list(data) do
-    get_and_update_found(data, func, next, [])
-  end
-
-  defp find(_op, data, _func, _next) do
-    raise "Access.find/1 expected a list, got: #{inspect data}"
   end
 
   defp get_and_update_where([head | rest], func, next, updates, gets) do
@@ -838,20 +777,5 @@ defmodule Access do
 
   defp get_and_update_where([], _func, _next, updates, gets) do
     {:lists.reverse(gets), :lists.reverse(updates)}
-  end
-
-  defp get_and_update_found([head | rest], func, next, updates) do
-    if func.(head) do
-      case next.(head) do
-        {get, update} -> {get, :lists.reverse([update | updates], rest)}
-        :pop -> {head, :lists.reverse(updates, rest)}
-      end
-    else
-      get_and_update_found(rest, func, next, [head | updates])
-    end
-  end
-
-  defp get_and_update_found([], _index, _next, updates) do
-    {nil, :lists.reverse(updates)}
   end
 end

--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -799,7 +799,7 @@ defmodule Access do
 
   An error is raised if the predicate is not a function or is of the incorrect arity:
 
-      iex> get_in([], [Access.find(fn a, b -> a == b end)])
+      iex> get_in([], [Access.find(10)])
       ** (FunctionClauseError) no function clause matching in Access.find/1
 
   An error is raised if the accessed structure is not a list:
@@ -807,7 +807,7 @@ defmodule Access do
       iex> get_in(%{}, [Access.find(fn a -> a == 10 end)])
       ** (RuntimeError) Access.find/1 expected a list, got: %{}
   """
-  def find(func) when is_function(func, 1) do
+  def find(func) when is_function(func) do
     fn(op, data, next) -> find(op, data, func, next) end
   end
 

--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -837,7 +837,7 @@ defmodule Access do
   end
 
   defp get_and_update_where([], _func, _next, updates, gets) do
-    {:list.reverse(gets), :lists.reverse(updates)}
+    {:lists.reverse(gets), :lists.reverse(updates)}
   end
 
   defp get_and_update_found([head | rest], func, next, updates) do

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -90,22 +90,21 @@ defmodule AccessTest do
   describe "filter/1" do
     @test_list [1, 2, 3, 4, 5, 6]
 
-    test "get_in filters appropriately" do
+    test "filters in get_in" do
       assert(get_in(@test_list, [Access.filter(&(&1 > 3))]) == [4, 5, 6])
     end
 
-    test "it chains with other access functions correctly" do
-      mixed_map_and_list = %{foo: Enum.map(@test_list, &(%{value: &1}))}
-
-      assert(get_in(mixed_map_and_list, [:foo, Access.filter(&(&1 <= 3)), :value]) == [])
-    end
-
-    test "it retains order in get_and_update_in/1" do
+    test "retains order in get_and_update_in/1" do
       assert(get_and_update_in(@test_list, [Access.filter(&(&1 == 3 || &1 == 2))], &({&1 * 2, &1})) == {[4, 6], [1, 2, 3, 4, 5, 6]})
     end
 
-    test "it retains order in pop_in/1" do
+    test "retains order in pop_in/1" do
       assert(pop_in(@test_list, [Access.filter(&(&1 == 3 || &1 == 2))]) == {[2, 3], [1, 4, 5, 6]})
+    end
+
+    test "chains with other access functions" do
+      mixed_map_and_list = %{foo: Enum.map(@test_list, &(%{value: &1}))}
+      assert(get_in(mixed_map_and_list, [:foo, Access.filter(&(&1 <= 3)), :value]) == [])
     end
   end
 end

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -86,4 +86,26 @@ defmodule AccessTest do
       Access.pop(struct(Sample, []), :name)
     end
   end
+
+  describe "filter/1" do
+    @test_list [1, 2, 3, 4, 5, 6]
+
+    test "get_in filters appropriately" do
+      assert(get_in(@test_list, [Access.filter(&(&1 > 3))]) == [4, 5, 6])
+    end
+
+    test "it chains with other access functions correctly" do
+      mixed_map_and_list = %{foo: Enum.map(@test_list, &(%{value: &1}))}
+
+      assert(get_in(mixed_map_and_list, [:foo, Access.filter(&(&1 <= 3)), :value]) == [])
+    end
+
+    test "it retains order in get_and_update_in/1" do
+      assert(get_and_update_in(@test_list, [Access.filter(&(&1 == 3 || &1 == 2))], &({&1 * 2, &1})) == {[4, 6], [1, 2, 3, 4, 5, 6]})
+    end
+
+    test "it retains order in pop_in/1" do
+      assert(pop_in(@test_list, [Access.filter(&(&1 == 3 || &1 == 2))]) == {[2, 3], [1, 4, 5, 6]})
+    end
+  end
 end

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -91,20 +91,20 @@ defmodule AccessTest do
     @test_list [1, 2, 3, 4, 5, 6]
 
     test "filters in get_in" do
-      assert(get_in(@test_list, [Access.filter(&(&1 > 3))]) == [4, 5, 6])
+      assert get_in(@test_list, [Access.filter(&(&1 > 3))]) == [4, 5, 6]
     end
 
     test "retains order in get_and_update_in/1" do
-      assert(get_and_update_in(@test_list, [Access.filter(&(&1 == 3 || &1 == 2))], &({&1 * 2, &1})) == {[4, 6], [1, 2, 3, 4, 5, 6]})
+      assert get_and_update_in(@test_list, [Access.filter(&(&1 == 3 || &1 == 2))], &({&1 * 2, &1})) == {[4, 6], [1, 2, 3, 4, 5, 6]}
     end
 
     test "retains order in pop_in/1" do
-      assert(pop_in(@test_list, [Access.filter(&(&1 == 3 || &1 == 2))]) == {[2, 3], [1, 4, 5, 6]})
+      assert pop_in(@test_list, [Access.filter(&(&1 == 3 || &1 == 2))]) == {[2, 3], [1, 4, 5, 6]}
     end
 
     test "chains with other access functions" do
       mixed_map_and_list = %{foo: Enum.map(@test_list, &(%{value: &1}))}
-      assert(get_in(mixed_map_and_list, [:foo, Access.filter(&(&1 <= 3)), :value]) == [])
+      assert get_in(mixed_map_and_list, [:foo, Access.filter(&(&1.value <= 3)), :value]) == [1, 2, 3]
     end
   end
 end


### PR DESCRIPTION
Implements `Access.find/1` and `Access.filter/1`. Examples and documentation provided in the code (aligned with examples and documentation for `Access.at/1`.