### PR TITLE
Improved error msg for process registration

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -505,7 +505,7 @@ defmodule Process do
     :error, :badarg ->
       message =
         "could not register #{inspect pid_or_port} with " <>
-        "name #{inspect name}. Or it is not alive, or the name is already " <>
+        "name #{inspect name} because it is not alive, the name is already " <>
         "taken, or it has already been given another name"
       :erlang.error ArgumentError.exception(message), [pid_or_port, name]
   end


### PR DESCRIPTION
(I hope this doesn't come across as pretentious or pedantic: that's certainly not my intention. I also realize this comes close to bikeshedding territory, but still hope it can be considered an improvement, however minuscule :p )

Improved the error message: the "or" conjuction isn't used that way in English (as it would be in French, for example).

Didn't find a way to keep the list of possibilities as a separate sentence: couldn't lead with "Either" as it is typically used to differentiate between only 2 options.

Finally, leaving the "Oxford comma" properly indicates that the issues is "one of" the presented possibilities.