### PR TITLE
Run the code formatter on ExUnit.Server

### DIFF
--- a/lib/ex_unit/lib/ex_unit/server.ex
+++ b/lib/ex_unit/lib/ex_unit/server.ex
@@ -33,12 +33,14 @@ defmodule ExUnit.Server do
   ## Callbacks
 
   def init(:ok) do
-    {:ok, %{
-      loaded: System.monotonic_time,
+    state = %{
+      loaded: System.monotonic_time(),
       waiting: nil,
       async_modules: [],
-      sync_modules: [],
-    }}
+      sync_modules: []
+    }
+
+    {:ok, state}
   end
 
   # Called on demand until we are signaled all modules are loaded.
@@ -47,13 +49,13 @@ defmodule ExUnit.Server do
   end
 
   # Called once after all async modules have been sent and reverts the state.
-  def handle_call(:take_sync_modules, _from, %{waiting: nil, loaded: :done, async_modules: []} = state) do
-    {:reply, state.sync_modules,
-     %{state | sync_modules: [], loaded: System.monotonic_time}}
+  def handle_call(:take_sync_modules, from, state) do
+    %{waiting: nil, loaded: :done, async_modules: []} = state
+    {:reply, state.sync_modules, %{state | sync_modules: [], loaded: System.monotonic_time()}}
   end
 
   def handle_call(:modules_loaded, _from, %{loaded: loaded} = state) when is_integer(loaded) do
-    diff = System.convert_time_unit(System.monotonic_time - loaded, :native, :microsecond)
+    diff = System.convert_time_unit(System.monotonic_time() - loaded, :native, :microsecond)
     {:reply, diff, take_modules(%{state | loaded: :done})}
   end
 


### PR DESCRIPTION
This PR is an example of what suggested in #6643. The steps I ran were:

1. Chose a file at random with:

   ```bash
   $ bin/elixir scripts/random_file.exs
   Checking lib/ex_unit/lib/ex_unit/server.ex... jackpot!

   The file above needs formatting.
   Please format it with the command below:

      bin/elixir bin/mix format lib/ex_unit/lib/ex_unit/server.ex

   Once formatted, check for any faults and submit a pull request.
   For more information see: https://github.com/elixir-lang/elixir/issues/6643

   Have fun!
   ```

1. Formatted it with `$ bin/elixir bin/mix format lib/ex_unit/lib/ex_unit/server.ex`

1. Adjusted the result manually to make it look good, exactly like described in #6643.
