### PR TITLE
Run the code formatter on Mix.UtilsTest

### DIFF
--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -1,38 +1,37 @@
-Code.require_file "../test_helper.exs", __DIR__
+Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.Cheers do
 end
 
 defmodule Mix.UtilsTest do
   use MixTest.Case
-  doctest Mix.Utils
+  doctest(Mix.Utils)
 
   test "command to module" do
-    assert Mix.Utils.command_to_module("cheers", Mix.Tasks)   == {:module, Mix.Tasks.Cheers}
+    assert Mix.Utils.command_to_module("cheers", Mix.Tasks) == {:module, Mix.Tasks.Cheers}
     assert Mix.Utils.command_to_module("unknown", Mix.Tasks) == {:error, :nofile}
   end
 
   test "module name to command" do
-    assert Mix.Utils.module_name_to_command(Mix.Tasks.Foo, 2)       == "foo"
-    assert Mix.Utils.module_name_to_command("Mix.Tasks.Foo", 2)     == "foo"
+    assert Mix.Utils.module_name_to_command(Mix.Tasks.Foo, 2) == "foo"
+    assert Mix.Utils.module_name_to_command("Mix.Tasks.Foo", 2) == "foo"
     assert Mix.Utils.module_name_to_command("Mix.Tasks.Foo.Bar", 2) == "foo.bar"
     assert Mix.Utils.module_name_to_command("Mix.Tasks.FooBar.Bing", 2) == "foo_bar.bing"
     assert Mix.Utils.module_name_to_command("Mix.Tasks.FooBar.BingBang", 2) == "foo_bar.bing_bang"
   end
 
   test "command to module name" do
-    assert Mix.Utils.command_to_module_name("foo")     == "Foo"
+    assert Mix.Utils.command_to_module_name("foo") == "Foo"
     assert Mix.Utils.command_to_module_name("foo.bar") == "Foo.Bar"
     assert Mix.Utils.command_to_module_name("foo_bar.baz") == "FooBar.Baz"
     assert Mix.Utils.command_to_module_name("foo_bar.baz_bing") == "FooBar.BazBing"
   end
 
   test "extract files" do
-    files = Mix.Utils.extract_files [Path.join(fixture_path(), "archive")], "*.ex"
+    files = Mix.Utils.extract_files([Path.join(fixture_path(), "archive")], "*.ex")
     assert length(files) == 1
     assert Path.basename(hd(files)) == "local.sample.ex"
   end
-
 
   test "extract files with empty string returns empty list" do
     assert Mix.Utils.extract_files([""], ".ex") == []
@@ -49,30 +48,39 @@ defmodule Mix.UtilsTest do
   end
 
   test "symlink or copy" do
-    in_fixture "archive", fn ->
+    fun = fn ->
       File.mkdir_p!("_build/archive")
       result = Mix.Utils.symlink_or_copy(Path.expand("ebin"), Path.expand("_build/archive/ebin"))
       assert_ebin_symlinked_or_copied(result)
     end
+
+    in_fixture("archive", fun)
   end
 
   test "symlink or copy removes previous directories" do
-    in_fixture "archive", fn ->
+    fun(fn ->
       File.mkdir_p!("_build/archive/ebin")
       result = Mix.Utils.symlink_or_copy(Path.expand("ebin"), Path.expand("_build/archive/ebin"))
       assert_ebin_symlinked_or_copied(result)
-    end
+    end)
+
+    in_fixture("archive", fun)
   end
 
-  @windows? match?({:win32, _}, :os.type)
+  @windows? match?({:win32, _}, :os.type())
   unless @windows? do
     test "symlink or copy erases wrong symlinks" do
-      in_fixture "archive", fn ->
+      fun = fn ->
         File.mkdir_p!("_build/archive")
         Mix.Utils.symlink_or_copy(Path.expand("priv"), Path.expand("_build/archive/ebin"))
-        result = Mix.Utils.symlink_or_copy(Path.expand("ebin"), Path.expand("_build/archive/ebin"))
+
+        result =
+          Mix.Utils.symlink_or_copy(Path.expand("ebin"), Path.expand("_build/archive/ebin"))
+
         assert_ebin_symlinked_or_copied(result)
       end
+
+      in_fixture("archive", fun)
     end
   end
 
@@ -94,17 +102,28 @@ defmodule Mix.UtilsTest do
 
   defp assert_ebin_symlinked_or_copied(result) do
     case result do
-      {:ok, paths} -> assert Path.expand("_build/archive/ebin") in paths
+      {:ok, paths} ->
+        assert Path.expand("_build/archive/ebin") in paths
+
       :ok ->
         expected_link =
-          case :os.type do
+          case :os.type() do
             # relative symlink on Windows are broken, see symlink_or_copy/2
-            {:win32, _} -> "ebin" |> Path.expand() |> String.to_charlist()
-            _ -> '../../ebin'
+            {:win32, _} ->
+              "ebin" |> Path.expand() |> String.to_charlist()
+
+            _ ->
+              '../../ebin'
           end
+
         {:ok, actual_link} = :file.read_link("_build/archive/ebin")
         assert actual_link == expected_link
-      _ -> flunk "expected symlink_or_copy to return :ok or {:ok, list_of_paths}, got: #{inspect result}"
+
+      _ ->
+        message =
+          "expected symlink_or_copy to return :ok or {:ok, list_of_paths}, got: #{inspect(result)}"
+
+        flunk(message)
     end
   end
 end

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -5,7 +5,7 @@ end
 
 defmodule Mix.UtilsTest do
   use MixTest.Case
-  doctest(Mix.Utils)
+  doctest Mix.Utils
 
   test "command to module" do
     assert Mix.Utils.command_to_module("cheers", Mix.Tasks) == {:module, Mix.Tasks.Cheers}
@@ -48,29 +48,25 @@ defmodule Mix.UtilsTest do
   end
 
   test "symlink or copy" do
-    fun = fn ->
+    in_fixture "archive", fn ->
       File.mkdir_p!("_build/archive")
       result = Mix.Utils.symlink_or_copy(Path.expand("ebin"), Path.expand("_build/archive/ebin"))
       assert_ebin_symlinked_or_copied(result)
     end
-
-    in_fixture("archive", fun)
   end
 
   test "symlink or copy removes previous directories" do
-    fun(fn ->
+    in_fixture "archive", fn ->
       File.mkdir_p!("_build/archive/ebin")
       result = Mix.Utils.symlink_or_copy(Path.expand("ebin"), Path.expand("_build/archive/ebin"))
       assert_ebin_symlinked_or_copied(result)
-    end)
-
-    in_fixture("archive", fun)
+    end
   end
 
   @windows? match?({:win32, _}, :os.type())
   unless @windows? do
     test "symlink or copy erases wrong symlinks" do
-      fun = fn ->
+      in_fixture "archive", fn ->
         File.mkdir_p!("_build/archive")
         Mix.Utils.symlink_or_copy(Path.expand("priv"), Path.expand("_build/archive/ebin"))
 
@@ -79,8 +75,6 @@ defmodule Mix.UtilsTest do
 
         assert_ebin_symlinked_or_copied(result)
       end
-
-      in_fixture("archive", fun)
     end
   end
 
@@ -120,10 +114,10 @@ defmodule Mix.UtilsTest do
         assert actual_link == expected_link
 
       _ ->
-        message =
+        msg =
           "expected symlink_or_copy to return :ok or {:ok, list_of_paths}, got: #{inspect(result)}"
 
-        flunk(message)
+        flunk(msg)
     end
   end
 end


### PR DESCRIPTION
I moved the anonymous functions out of `in_fixture()` calls and a long string message out of `flunk()`