### PR TITLE
Specify group_by values are ordered but map is not

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1078,9 +1078,9 @@ defmodule Enum do
   @doc """
   Splits the enumerable into groups based on `key_fun`.
 
-  The result is a map where each key is given by `key_fun` and each
-  value is a list of elements given by `value_fun`. Ordering is preserved.
-
+  The result is a map where each key is given by `key_fun` and each value is a
+  list of elements given by `value_fun`. The order of each value is preserved
+  from the enumerable. However, maps themselves are unordered.
   ## Examples
 
       iex> Enum.group_by(~w{ant buffalo cat dingo}, &String.length/1)

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1081,6 +1081,7 @@ defmodule Enum do
   The result is a map where each key is given by `key_fun` and each value is a
   list of elements given by `value_fun`. The order of each value is preserved
   from the enumerable. However, maps themselves are unordered.
+
   ## Examples
 
       iex> Enum.group_by(~w{ant buffalo cat dingo}, &String.length/1)


### PR DESCRIPTION
There was some confusion in #6759 over exactly what was ordered by group_by

Hopefully this is useful. Let me know if you'd like any wording changes.