### PR TITLE
Run the code formatter on Mix.Tasks.CleanTest

### DIFF
--- a/lib/mix/test/mix/tasks/clean_test.exs
+++ b/lib/mix/test/mix/tasks/clean_test.exs
@@ -1,4 +1,4 @@
-Code.require_file "../../test_helper.exs", __DIR__
+Code.require_file("../../test_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.CleanTest do
   use MixTest.Case
@@ -17,18 +17,18 @@ defmodule Mix.Tasks.CleanTest do
   end
 
   setup do
-    Mix.Project.push Sample
+    Mix.Project.push(Sample)
     :ok
   end
 
   test "cleans the application build" do
     in_fixture "deps_status", fn ->
-      File.mkdir_p! "_build/dev/lib/sample/consolidated"
-      File.mkdir_p! "_build/dev/lib/sample"
-      File.mkdir_p! "_build/test/lib/sample"
-      File.mkdir_p! "_build/dev/lib/ok"
+      File.mkdir_p!("_build/dev/lib/sample/consolidated")
+      File.mkdir_p!("_build/dev/lib/sample")
+      File.mkdir_p!("_build/test/lib/sample")
+      File.mkdir_p!("_build/dev/lib/ok")
 
-      Mix.Tasks.Clean.run []
+      Mix.Tasks.Clean.run([])
       refute File.exists?("_build/dev/lib/sample/consolidated")
       refute File.exists?("_build/dev/lib/sample")
       refute File.exists?("_build/test/lib/sample")
@@ -38,14 +38,14 @@ defmodule Mix.Tasks.CleanTest do
 
   test "cleans dependencies build" do
     in_fixture "deps_status", fn ->
-      File.mkdir_p! "_build/dev/lib/ok"
-      File.mkdir_p! "_build/test/lib/ok"
+      File.mkdir_p!("_build/dev/lib/ok")
+      File.mkdir_p!("_build/test/lib/ok")
 
-      Mix.Tasks.Clean.run ["--deps", "--only", "dev"]
+      Mix.Tasks.Clean.run(["--deps", "--only", "dev"])
       refute File.exists?("_build/dev")
       assert File.exists?("_build/test")
 
-      Mix.Tasks.Clean.run ["--deps"]
+      Mix.Tasks.Clean.run(["--deps"])
       refute File.exists?("_build/test")
     end
   end


### PR DESCRIPTION
This PR follows #6643. The randomizing script chose _lib/mix/test/mix/tasks/clean_test.exs_
 
It's a tad bit small, but it does the trick.

BTW, as an extra:

``
$ ./bin/elixir -v
Erlang/OTP 20 [erts-9.0] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe] [kernel-poll:false]

Elixir 1.6.0-dev (48beb79) (compiled with OTP 20)

$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 16.04.3 LTS
Release:        16.04
Codename:       xenial

$ cat /proc/version
**Linux version 4.4.0-43-Microsoft (Microsoft@Microsoft.com) (gcc version 5.4.0 (GCC) ) #1-Microsoft Wed Dec 31 14:42:53 PST 2014**
``

Elixir runs pretty well(except for file access speed) on Ubuntu 16.10 for Windows 10, aka Windows Subsystem for Linux.