### PR TITLE
Document defimpl for multiple types

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4166,9 +4166,9 @@ defmodule Kernel do
   is an opt-in behaviour. For the majority of protocols, raising
   an error when a protocol is not implemented is the proper behaviour.
 
-  ## Multiple `for`
+  ## Multiple implementations
 
-  Protocol can be implemented for multiple types at once
+  Protocols can also be implemented for multiple types at once:
 
       defprotocol Reversible do
         def reverse(term)

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4166,6 +4166,18 @@ defmodule Kernel do
   is an opt-in behaviour. For the majority of protocols, raising
   an error when a protocol is not implemented is the proper behaviour.
 
+  ## Multiple `for`
+
+  Protocol can be implemented for multiple types at once
+
+      defprotocol Reversible do
+        def reverse(term)
+      end
+
+      defimpl Reversible, for: [Map, List] do
+        def reverse(term), do: Enum.reverse(term)
+      end
+
   ## Types
 
   Defining a protocol automatically defines a type named `t`, which


### PR DESCRIPTION
I started to implement `defimplm` for multiple types, then I found that `defimpl` already can do this, but the functionality is not documented.