### PR TITLE
Run code Formatter on lib/elixir/lib/exception.ex 

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -234,7 +234,8 @@ defmodule Exception do
   end
 
   defp blame_mfa(module, function, arity, call_args) do
-    with path when is_list(path) <- :code.which(module),
+    with path
+         when is_list(path) <- :code.which(module),
          {:ok, {_, [debug_info: debug_info]}} <- :beam_lib.chunks(path, [:debug_info]),
          {:debug_info_v1, backend, data} <- debug_info,
          {:ok, %{definitions: defs}} <- backend.debug_info(:elixir_v1, module, data, []),


### PR DESCRIPTION
Looking at the history the code formatter was already run on this file.  However, the script still picked up this file and indented the second `when`.  I also came across this running the formatter on `lib/mix/lib/mix/tasks/xref.ex`.  Did the code formatter change?  Is this a legit change?