### PR TITLE
Run code formatter on lib/iex/lib/iex/pry.ex

### DIFF
--- a/lib/iex/lib/iex/pry.ex
+++ b/lib/iex/lib/iex/pry.ex
@@ -36,6 +36,7 @@ defmodule IEx.Pry do
       case function_arity do
         {function, arity} ->
           "#{Exception.format_mfa(module, function, arity)} (#{Path.relative_to_cwd(file)}:#{line})"
+
         _ ->
           "#{Path.relative_to_cwd(file)}:#{line}"
       end
@@ -52,25 +53,31 @@ defmodule IEx.Pry do
     # succeed.
     request =
       if Process.get(:iex_evaluator) do
-        IO.puts IEx.color :eval_interrupt, "Break reached: #{location}#{whereami}"
-        "Prying #{inspect self} at #{location}"
+        IO.puts(IEx.color(:eval_interrupt, "Break reached: #{location}#{whereami}"))
+        "Prying #{inspect(self)} at #{location}"
       else
-        "Request to pry #{inspect self} at #{location}#{whereami}"
+        "Request to pry #{inspect(self)} at #{location}#{whereami}"
       end
 
     # We cannot use colors because IEx may be off
     case IEx.Server.take_over(request, opts) do
       :ok ->
         :ok
+
       {:error, :no_iex} ->
         extra =
-          if match?({:win32, _}, :os.type) do
+          if match?({:win32, _}, :os.type()) do
             " If you are using Windows, you may need to start IEx with the --werl flag."
           else
             ""
           end
-        IO.puts :stdio, "Cannot pry #{inspect self} at #{location}. Is an IEx shell running?" <> extra
+
+        message = "Cannot pry #{inspect(self)} at #{location}. Is an IEx shell running?" <> extra
+
+        IO.puts(:stdio, message)
+
         {:error, :no_iex}
+
       {:error, _} = error ->
         error
     end
@@ -123,7 +130,7 @@ defmodule IEx.Pry do
     max = line + radius - 1
 
     file
-    |> File.stream!
+    |> File.stream!()
     |> Enum.slice(min..max)
     |> Enum.with_index(min + 1)
     |> Enum.map(&whereami_format_line(&1, line))
@@ -131,6 +138,7 @@ defmodule IEx.Pry do
 
   defp whereami_format_line({line_text, line_number}, line) do
     gutter = String.pad_leading(Integer.to_string(line_number), 5, " ")
+
     if line_number == line do
       IO.ANSI.format_fragment([:bright, gutter, ": ", line_text, :normal])
     else
@@ -143,13 +151,20 @@ defmodule IEx.Pry do
   given module/function/arity.
   """
   @spec break(module, function, arity, pos_integer) ::
-        {:ok, id} |
-        {:error, :recompilation_failed | :no_beam_file | :unknown_function_arity |
-                 :otp_20_is_required | :missing_debug_info | :outdated_debug_info |
-                 :non_elixir_module}
+          {:ok, id}
+          | {
+              :error,
+              :recompilation_failed
+              | :no_beam_file
+              | :unknown_function_arity
+              | :otp_20_is_required
+              | :missing_debug_info
+              | :outdated_debug_info
+              | :non_elixir_module
+            }
   def break(module, function, arity, breaks \\ 1)
       when is_atom(module) and is_atom(function) and is_integer(arity) and arity >= 0 and
-           is_integer(breaks) and breaks > 0 do
+             is_integer(breaks) and breaks > 0 do
     GenServer.call(@server, {:break, module, {function, arity}, breaks}, @timeout)
   end
 
@@ -234,6 +249,7 @@ defmodule IEx.Pry do
           :ets.delete(@table, ref)
           instrument_and_reply(module, fa, breaks, counter)
         end
+
       [] ->
         instrument_and_reply(module, fa, breaks, counter)
     end
@@ -264,6 +280,7 @@ defmodule IEx.Pry do
           keep_instrumented(id, module) == :ok do
         {id, module, function_arity, max(breaks, 0)}
       end
+
     {:reply, entries, counter}
   end
 
@@ -272,9 +289,10 @@ defmodule IEx.Pry do
     # up the table to avoid race conditions.
     @table
     |> :ets.match({:_, :"$1", :_, :_})
-    |> List.flatten
-    |> Enum.uniq
+    |> List.flatten()
+    |> Enum.uniq()
     |> Enum.each(&deinstrument_if_instrumented/1)
+
     true = :ets.delete_all_objects(@table)
     {:reply, :ok, 0}
   end
@@ -305,8 +323,7 @@ defmodule IEx.Pry do
   end
 
   defp deinstrument(module) do
-    with beam when is_list(beam) <- :code.which(module),
-         {:ok, binary} = File.read(beam) do
+    with beam when is_list(beam) <- :code.which(module), {:ok, binary} = File.read(beam) do
       :code.purge(module)
       {:module, _} = :code.load_binary(module, beam, binary)
       :ok
@@ -322,6 +339,7 @@ defmodule IEx.Pry do
         true = :ets.insert_new(@table, {counter, module, fa, breaks})
         entries = :ets.match_object(@table, {:_, module, :_, :_})
         {:reply, instrument(beam, backend, elixir, counter, entries), counter}
+
       {:error, _} = error ->
         {:reply, error, counter}
     end
@@ -336,15 +354,21 @@ defmodule IEx.Pry do
               {_, _, _, _} -> {:ok, beam, backend, elixir}
               nil -> {:error, :unknown_function_arity}
             end
+
           {:ok, {_, [debug_info: {:debug_info_v1, _, _}]}} ->
             {:error, :non_elixir_module}
+
           {:error, :beam_lib, {:unknown_chunk, _, _}} ->
-            {:error, :otp_20_is_required} # TODO: Remove this when we require OTP 20+
+            # TODO: Remove this when we require OTP 20+
+            {:error, :otp_20_is_required}
+
           {:error, :beam_lib, {:missing_chunk, _, _}} ->
             {:error, :missing_debug_info}
+
           _ ->
             {:error, :outdated_debug_info}
         end
+
       _ ->
         {:error, :no_beam_file}
     end
@@ -352,8 +376,10 @@ defmodule IEx.Pry do
 
   defp instrument(beam, backend, {:elixir_v1, map, specs}, counter, entries) do
     %{attributes: attributes, definitions: definitions, module: module} = map
-    map = %{map | attributes: [{:iex_pry, true} | attributes],
-                  definitions: Enum.map(definitions, &instrument_definition(&1, map, entries))}
+    attributes = [{:iex_pry, true} | attributes]
+    definitions = Enum.map(definitions, &instrument_definition(&1, map, entries))
+
+    map = %{map | attributes: attributes, definitions: definitions}
 
     with {:ok, forms} <- backend.debug_info(:erlang_v1, module, {:elixir_v1, map, specs}, []),
          {:ok, _, binary, _} <- :compile.noenv_forms(forms, [:return | map.compile_opts]) do
@@ -370,14 +396,17 @@ defmodule IEx.Pry do
     case List.keyfind(entries, fa, 2) do
       {ref, _, ^fa, _} ->
         %{module: module, file: file} = map
+
         file =
           case meta[:location] do
             {file, _} -> file
             _ -> file
           end
+
         opts = [module: module, file: file, function: fa]
         clauses = Enum.map(clauses, &instrument_clause(&1, ref, opts))
         {fa, kind, meta, clauses}
+
       nil ->
         definition
     end
@@ -393,6 +422,7 @@ defmodule IEx.Pry do
       Macro.prewalk(args, %{}, fn
         {name, _, ctx} = var, acc when name != :_ and is_atom(name) and is_atom(ctx) ->
           {var, Map.put(acc, name, var)}
+
         expr, acc ->
           {expr, acc}
       end)
@@ -402,8 +432,15 @@ defmodule IEx.Pry do
     # no locals (such as the unary -) and so on.
     condition =
       quote do
+        update_op = {
+          4,
+          unquote(-1),
+          unquote(-1),
+          unquote(-1)
+        }
+
         # :ets.update_counter(table, key, {pos, inc, threshold, reset})
-        case :ets.update_counter(unquote(@table), unquote(ref), {4, unquote(-1), unquote(-1), unquote(-1)}) do
+        case :ets.update_counter(unquote(@table), unquote(ref), update_op) do
           unquote(-1) -> :ok
           _ -> :"Elixir.IEx.Pry".pry(unquote(Map.to_list(binding)), unquote(opts))
         end


### PR DESCRIPTION
Ran the formatter.

I was not sure about two decisions:
* The formatting of [this typespec](https://github.com/elixir-lang/elixir/compare/master...fabrik42:exfmt-pry?expand=1#diff-06592ac682e15e56da15969a44f5358eR154)
* I [extracted this tuple](https://github.com/elixir-lang/elixir/compare/master...fabrik42:exfmt-pry?expand=1#diff-06592ac682e15e56da15969a44f5358eR435) to make the function call a single line, but the tuple is within a macro and basically a constant. Does this still make sense? I named the variable according to the param name of the Erlang function.