### PR TITLE
Run code formatter on lib/elixir/lib/kernel.ex

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1,8 +1,9 @@
 # Use elixir_bootstrap module to be able to bootstrap Kernel.
 # The bootstrap module provides simpler implementations of the
 # functions removed, simple enough to bootstrap.
-import Kernel, except: [@: 1, defmodule: 2, def: 1, def: 2, defp: 2,
-                        defmacro: 1, defmacro: 2, defmacrop: 2]
+import Kernel,
+  except: [@: 1, defmodule: 2, def: 1, def: 2, defp: 2, defmacro: 1, defmacro: 2, defmacrop: 2]
+
 import :elixir_bootstrap
 
 defmodule Kernel do
@@ -654,7 +655,7 @@ defmodule Kernel do
       :b
 
   """
-  @spec max(first, second) :: (first | second) when first: term, second: term
+  @spec max(first, second) :: first | second when first: term, second: term
   def max(first, second) do
     :erlang.max(first, second)
   end
@@ -675,7 +676,7 @@ defmodule Kernel do
       "bar"
 
   """
-  @spec min(first, second) :: (first | second) when first: term, second: term
+  @spec min(first, second) :: first | second when first: term, second: term
   def min(first, second) do
     :erlang.min(first, second)
   end
@@ -688,7 +689,7 @@ defmodule Kernel do
   """
   @spec node() :: node
   def node do
-    :erlang.node
+    :erlang.node()
   end
 
   @doc """
@@ -975,8 +976,9 @@ defmodule Kernel do
       #=> %{b: 1}
 
   """
-  @spec tl(nonempty_maybe_improper_list(elem, tail)) ::
-        maybe_improper_list(elem, tail) | tail when elem: term, tail: term
+  @spec tl(nonempty_maybe_improper_list(elem, tail)) :: maybe_improper_list(elem, tail) | tail
+        when elem: term,
+             tail: term
   def tl(list) do
     :erlang.tl(list)
   end
@@ -1033,10 +1035,10 @@ defmodule Kernel do
       3
 
   """
-  @spec (integer + integer) :: integer
-  @spec (float + float) :: float
-  @spec (integer + float) :: float
-  @spec (float + integer) :: float
+  @spec integer + integer :: integer
+  @spec float + float :: float
+  @spec integer + float :: float
+  @spec float + integer :: float
   def left + right do
     :erlang.+(left, right)
   end
@@ -1052,10 +1054,10 @@ defmodule Kernel do
       -1
 
   """
-  @spec (integer - integer) :: integer
-  @spec (float - float) :: float
-  @spec (integer - float) :: float
-  @spec (float - integer) :: float
+  @spec integer - integer :: integer
+  @spec float - float :: float
+  @spec integer - float :: float
+  @spec float - integer :: float
   def left - right do
     :erlang.-(left, right)
   end
@@ -1071,7 +1073,7 @@ defmodule Kernel do
       1
 
   """
-  @spec (+value) :: value when value: number
+  @spec +value :: value when value: number
   def +value do
     :erlang.+(value)
   end
@@ -1087,10 +1089,10 @@ defmodule Kernel do
       -2
 
   """
-  @spec (-0) :: 0
-  @spec (-pos_integer) :: neg_integer
-  @spec (-neg_integer) :: pos_integer
-  @spec (-float) :: float
+  @spec -0 :: 0
+  @spec -pos_integer :: neg_integer
+  @spec -neg_integer :: pos_integer
+  @spec -float :: float
   def -value do
     :erlang.-(value)
   end
@@ -1106,10 +1108,10 @@ defmodule Kernel do
       2
 
   """
-  @spec (integer * integer) :: integer
-  @spec (float * float) :: float
-  @spec (integer * float) :: float
-  @spec (float * integer) :: float
+  @spec integer * integer :: integer
+  @spec float * float :: float
+  @spec integer * float :: float
+  @spec float * integer :: float
   def left * right do
     :erlang.*(left, right)
   end
@@ -1139,7 +1141,7 @@ defmodule Kernel do
       #=> ** (ArithmeticError) bad argument in arithmetic expression
 
   """
-  @spec (number / number) :: float
+  @spec number / number :: float
   def left / right do
     :erlang./(left, right)
   end
@@ -1177,7 +1179,7 @@ defmodule Kernel do
       [1, 2 | 3]
 
   """
-  @spec (list ++ term) :: maybe_improper_list
+  @spec list ++ term :: maybe_improper_list
   def left ++ right do
     :erlang.++(left, right)
   end
@@ -1202,7 +1204,7 @@ defmodule Kernel do
       [3, 1]
 
   """
-  @spec (list -- list) :: list
+  @spec list -- list :: list
   def left -- right do
     :erlang.--(left, right)
   end
@@ -1220,8 +1222,8 @@ defmodule Kernel do
       true
 
   """
-  @spec not(true) :: false
-  @spec not(false) :: true
+  @spec not true :: false
+  @spec not false :: true
   def not value do
     :erlang.not(value)
   end
@@ -1239,7 +1241,7 @@ defmodule Kernel do
       true
 
   """
-  @spec (term < term) :: boolean
+  @spec term < term :: boolean
   def left < right do
     :erlang.<(left, right)
   end
@@ -1257,7 +1259,7 @@ defmodule Kernel do
       false
 
   """
-  @spec (term > term) :: boolean
+  @spec term > term :: boolean
   def left > right do
     :erlang.>(left, right)
   end
@@ -1275,7 +1277,7 @@ defmodule Kernel do
       true
 
   """
-  @spec (term <= term) :: boolean
+  @spec term <= term :: boolean
   def left <= right do
     :erlang."=<"(left, right)
   end
@@ -1293,7 +1295,7 @@ defmodule Kernel do
       false
 
   """
-  @spec (term >= term) :: boolean
+  @spec term >= term :: boolean
   def left >= right do
     :erlang.>=(left, right)
   end
@@ -1317,7 +1319,7 @@ defmodule Kernel do
       true
 
   """
-  @spec (term == term) :: boolean
+  @spec term == term :: boolean
   def left == right do
     :erlang.==(left, right)
   end
@@ -1341,7 +1343,7 @@ defmodule Kernel do
       false
 
   """
-  @spec (term != term) :: boolean
+  @spec term != term :: boolean
   def left != right do
     :erlang."/="(left, right)
   end
@@ -1367,7 +1369,7 @@ defmodule Kernel do
       false
 
   """
-  @spec (term === term) :: boolean
+  @spec term === term :: boolean
   def left === right do
     :erlang."=:="(left, right)
   end
@@ -1388,7 +1390,7 @@ defmodule Kernel do
       true
 
   """
-  @spec (term !== term) :: boolean
+  @spec term !== term :: boolean
   def left !== right do
     :erlang."=/="(left, right)
   end
@@ -1458,7 +1460,7 @@ defmodule Kernel do
 
   """
   defmacro left or right do
-    quote do: :erlang.orelse(unquote(left), unquote(right))
+    quote(do: :erlang.orelse(unquote(left), unquote(right)))
   end
 
   @doc """
@@ -1481,7 +1483,7 @@ defmodule Kernel do
 
   """
   defmacro left and right do
-    quote do: :erlang.andalso(unquote(left), unquote(right))
+    quote(do: :erlang.andalso(unquote(left), unquote(right)))
   end
 
   @doc """
@@ -1501,24 +1503,28 @@ defmodule Kernel do
       true
 
   """
-  defmacro !(value)
+  defmacro !value
 
-  defmacro !({:!, _, [value]}) do
-    optimize_boolean(quote do
-      case unquote(value) do
-        x when x in [false, nil] -> false
-        _ -> true
+  defmacro !{:!, _, [value]} do
+    optimize_boolean(
+      quote do
+        case unquote(value) do
+          x when x in [false, nil] -> false
+          _ -> true
+        end
       end
-    end)
+    )
   end
 
-  defmacro !(value) do
-    optimize_boolean(quote do
-      case unquote(value) do
-        x when x in [false, nil] -> true
-        _ -> false
+  defmacro !value do
+    optimize_boolean(
+      quote do
+        case unquote(value) do
+          x when x in [false, nil] -> true
+          _ -> false
+        end
       end
-    end)
+    )
   end
 
   @doc """
@@ -1541,7 +1547,7 @@ defmodule Kernel do
   """
   defmacro left <> right do
     concats = extract_concatenations({:<>, [], [left, right]})
-    quote do: <<unquote_splicing(concats)>>
+    quote(do: <<unquote_splicing(concats)>>)
   end
 
   # Extracts concatenations in order to optimize many
@@ -1593,27 +1599,31 @@ defmodule Kernel do
   defmacro raise(message) do
     # Try to figure out the type at compilation time
     # to avoid dead code and make Dialyzer happy.
-    message = case not is_binary(message) and bootstrapped?(Macro) do
-      true  -> Macro.expand(message, __CALLER__)
-      false -> message
-    end
+    message =
+      case not is_binary(message) and bootstrapped?(Macro) do
+        true -> Macro.expand(message, __CALLER__)
+        false -> message
+      end
 
     case message do
       message when is_binary(message) ->
         quote do
-          :erlang.error RuntimeError.exception(unquote(message))
+          :erlang.error(RuntimeError.exception(unquote(message)))
         end
+
       {:<<>>, _, _} = message ->
         quote do
-          :erlang.error RuntimeError.exception(unquote(message))
+          :erlang.error(RuntimeError.exception(unquote(message)))
         end
+
       alias when is_atom(alias) ->
         quote do
-          :erlang.error unquote(alias).exception([])
+          :erlang.error(unquote(alias).exception([]))
         end
+
       _ ->
         quote do
-          :erlang.error Kernel.Utils.raise(unquote(message))
+          :erlang.error(Kernel.Utils.raise(unquote(message)))
         end
     end
   end
@@ -1637,7 +1647,7 @@ defmodule Kernel do
   """
   defmacro raise(exception, attributes) do
     quote do
-      :erlang.error unquote(exception).exception(unquote(attributes))
+      :erlang.error(unquote(exception).exception(unquote(attributes)))
     end
   end
 
@@ -1672,29 +1682,40 @@ defmodule Kernel do
     case Macro.expand(message, __CALLER__) do
       message when is_binary(message) ->
         quote do
-          :erlang.raise :error, RuntimeError.exception(unquote(message)), unquote(stacktrace)
+          :erlang.raise(:error, RuntimeError.exception(unquote(message)), unquote(stacktrace))
         end
+
       {:<<>>, _, _} = message ->
         quote do
-          :erlang.raise :error, RuntimeError.exception(unquote(message)), unquote(stacktrace)
+          :erlang.raise(:error, RuntimeError.exception(unquote(message)), unquote(stacktrace))
         end
+
       alias when is_atom(alias) ->
         quote do
-          :erlang.raise :error, unquote(alias).exception([]), unquote(stacktrace)
+          :erlang.raise(:error, unquote(alias).exception([]), unquote(stacktrace))
         end
+
       message ->
         quote do
           stacktrace = unquote(stacktrace)
+
           case unquote(message) do
             message when is_binary(message) ->
-              :erlang.raise :error, RuntimeError.exception(message), stacktrace
+              :erlang.raise(:error, RuntimeError.exception(message), stacktrace)
+
             atom when is_atom(atom) ->
-              :erlang.raise :error, atom.exception([]), stacktrace
+              :erlang.raise(:error, atom.exception([]), stacktrace)
+
             %_{__exception__: true} = other ->
-              :erlang.raise :error, other, stacktrace
+              :erlang.raise(:error, other, stacktrace)
+
             other ->
-              message = "reraise/2 expects a module name, string or exception as the first argument, got: #{inspect other}"
-              :erlang.error ArgumentError.exception(message)
+              message =
+                "reraise/2 expects a module name, string or exception as the first argument, got: #{
+                  inspect(other)
+                }"
+
+              :erlang.error(ArgumentError.exception(message))
           end
         end
     end
@@ -1719,7 +1740,11 @@ defmodule Kernel do
   """
   defmacro reraise(exception, attributes, stacktrace) do
     quote do
-      :erlang.raise :error, unquote(exception).exception(unquote(attributes)), unquote(stacktrace)
+      :erlang.raise(
+        :error,
+        unquote(exception).exception(unquote(attributes)),
+        unquote(stacktrace)
+      )
     end
   end
 
@@ -1748,7 +1773,7 @@ defmodule Kernel do
       true
 
   """
-  @spec (String.t =~ (String.t | Regex.t)) :: boolean
+  @spec String.t() =~ (String.t() | Regex.t()) :: boolean
   def left =~ "" when is_binary(left), do: true
 
   def left =~ right when is_binary(left) and is_binary(right) do
@@ -1810,12 +1835,13 @@ defmodule Kernel do
       #=> #Function<...>
 
   """
-  @spec inspect(Inspect.t, keyword) :: String.t
+  @spec inspect(Inspect.t(), keyword) :: String.t()
   def inspect(term, opts \\ []) when is_list(opts) do
     opts = struct(Inspect.Opts, opts)
+
     limit =
       case opts.pretty do
-        true  -> opts.width
+        true -> opts.width
         false -> :infinity
       end
 
@@ -1863,11 +1889,12 @@ defmodule Kernel do
       #=> %User{name: "john"}
 
   """
-  @spec struct(module | struct, Enum.t) :: struct
+  @spec struct(module | struct, Enum.t()) :: struct
   def struct(struct, fields \\ []) do
     struct(struct, fields, fn
       {:__struct__, _val}, acc ->
         acc
+
       {key, val}, acc ->
         case acc do
           %{^key => _} -> %{acc | key => val}
@@ -1895,7 +1922,7 @@ defmodule Kernel do
       only when building;
 
   """
-  @spec struct!(module | struct, Enum.t) :: struct | no_return
+  @spec struct!(module | struct, Enum.t()) :: struct | no_return
   def struct!(struct, fields \\ [])
 
   def struct!(struct, fields) when is_atom(struct) do
@@ -1904,7 +1931,9 @@ defmodule Kernel do
 
   def struct!(struct, fields) when is_map(struct) do
     struct(struct, fields, fn
-      {:__struct__, _}, acc -> acc
+      {:__struct__, _}, acc ->
+        acc
+
       {key, val}, acc ->
         Map.replace!(acc, key, val)
     end)
@@ -1967,23 +1996,17 @@ defmodule Kernel do
   the function *will* receive `nil` as a value and must handle it
   accordingly.
   """
-  @spec get_in(Access.t, nonempty_list(term)) :: term
+  @spec get_in(Access.t(), nonempty_list(term)) :: term
   def get_in(data, keys)
 
-  def get_in(data, [h]) when is_function(h),
-    do: h.(:get, data, &(&1))
-  def get_in(data, [h | t]) when is_function(h),
-    do: h.(:get, data, &get_in(&1, t))
+  def get_in(data, [h]) when is_function(h), do: h.(:get, data, & &1)
+  def get_in(data, [h | t]) when is_function(h), do: h.(:get, data, &get_in(&1, t))
 
-  def get_in(nil, [_]),
-    do: nil
-  def get_in(nil, [_ | t]),
-    do: get_in(nil, t)
+  def get_in(nil, [_]), do: nil
+  def get_in(nil, [_ | t]), do: get_in(nil, t)
 
-  def get_in(data, [h]),
-    do: Access.get(data, h)
-  def get_in(data, [h | t]),
-    do: get_in(Access.get(data, h), t)
+  def get_in(data, [h]), do: Access.get(data, h)
+  def get_in(data, [h | t]), do: get_in(Access.get(data, h), t)
 
   @doc """
   Puts a value in a nested structure.
@@ -2002,7 +2025,7 @@ defmodule Kernel do
   In case any of entries in the middle returns `nil`,
   an error will be raised when trying to access it next.
   """
-  @spec put_in(Access.t, nonempty_list(term), term) :: Access.t
+  @spec put_in(Access.t(), nonempty_list(term), term) :: Access.t()
   def put_in(data, keys, value) do
     elem(get_and_update_in(data, keys, fn _ -> {nil, value} end), 1)
   end
@@ -2024,7 +2047,7 @@ defmodule Kernel do
   In case any of entries in the middle returns `nil`,
   an error will be raised when trying to access it next.
   """
-  @spec update_in(Access.t, nonempty_list(term), (term -> term)) :: Access.t
+  @spec update_in(Access.t(), nonempty_list(term), (term -> term)) :: Access.t()
   def update_in(data, keys, fun) when is_function(fun, 1) do
     elem(get_and_update_in(data, keys, fn x -> {nil, fun.(x)} end), 1)
   end
@@ -2084,8 +2107,14 @@ defmodule Kernel do
   like the `all` anonymous function defined above. See `Access.all/0`,
   `Access.key/2` and others as examples.
   """
-  @spec get_and_update_in(structure :: Access.t, keys, (term -> {get_value, update_value} | :pop)) ::
-        {get_value, structure :: Access.t} when keys: nonempty_list(any), get_value: var, update_value: term
+  @spec get_and_update_in(
+          structure :: Access.t(),
+          keys,
+          (term -> {get_value, update_value} | :pop)
+        ) :: {get_value, structure :: Access.t()}
+        when keys: nonempty_list(any),
+             get_value: var,
+             update_value: term
   def get_and_update_in(data, keys, fun)
 
   def get_and_update_in(data, [head], fun) when is_function(head, 3),
@@ -2117,26 +2146,28 @@ defmodule Kernel do
   In case any entry returns `nil`, its key will be removed
   and the deletion will be considered a success.
   """
-  @spec pop_in(data, nonempty_list(Access.get_and_update_fun(term, data) | term)) ::
-        {term, data} when data: Access.container
+  @spec pop_in(data, nonempty_list(Access.get_and_update_fun(term, data) | term)) :: {term, data}
+        when data: Access.container()
   def pop_in(data, keys)
 
   def pop_in(nil, [key | _]) do
-    raise ArgumentError, "could not pop key #{inspect key} on a nil value"
+    raise ArgumentError, "could not pop key #{inspect(key)} on a nil value"
   end
 
   def pop_in(data, keys) when is_list(keys) do
     pop_in_data(data, keys)
   end
 
-  defp pop_in_data(nil, [_ | _]),
-    do: :pop
+  defp pop_in_data(nil, [_ | _]), do: :pop
+
   defp pop_in_data(data, [fun]) when is_function(fun),
     do: fun.(:get_and_update, data, fn _ -> :pop end)
+
   defp pop_in_data(data, [fun | tail]) when is_function(fun),
     do: fun.(:get_and_update, data, &pop_in_data(&1, tail))
-  defp pop_in_data(data, [key]),
-    do: Access.pop(data, key)
+
+  defp pop_in_data(data, [key]), do: Access.pop(data, key)
+
   defp pop_in_data(data, [key | tail]),
     do: Access.get_and_update(data, key, &pop_in_data(&1, tail))
 
@@ -2171,9 +2202,10 @@ defmodule Kernel do
     case unnest(path, [], true, "put_in/2") do
       {[h | t], true} ->
         nest_update_in(h, t, quote(do: fn _ -> unquote(value) end))
+
       {[h | t], false} ->
         expr = nest_get_and_update_in(h, t, quote(do: fn _ -> {nil, unquote(value)} end))
-        quote do: :erlang.element(2, unquote(expr))
+        quote(do: :erlang.element(2, unquote(expr)))
     end
   end
 
@@ -2242,9 +2274,10 @@ defmodule Kernel do
     case unnest(path, [], true, "update_in/2") do
       {[h | t], true} ->
         nest_update_in(h, t, fun)
+
       {[h | t], false} ->
         expr = nest_get_and_update_in(h, t, quote(do: fn x -> {nil, unquote(fun).(x)} end))
-        quote do: :erlang.element(2, unquote(expr))
+        quote(do: :erlang.element(2, unquote(expr)))
     end
   end
 
@@ -2301,33 +2334,34 @@ defmodule Kernel do
     nest_get_and_update_in(h, t, fun)
   end
 
-  defp nest_update_in([], fun),  do: fun
+  defp nest_update_in([], fun), do: fun
+
   defp nest_update_in(list, fun) do
     quote do
       fn x -> unquote(nest_update_in(quote(do: x), list, fun)) end
     end
   end
+
   defp nest_update_in(h, [{:map, key} | t], fun) do
     quote do
       Map.update!(unquote(h), unquote(key), unquote(nest_update_in(t, fun)))
     end
   end
 
-  defp nest_get_and_update_in([], fun),  do: fun
+  defp nest_get_and_update_in([], fun), do: fun
+
   defp nest_get_and_update_in(list, fun) do
     quote do
       fn x -> unquote(nest_get_and_update_in(quote(do: x), list, fun)) end
     end
   end
+
   defp nest_get_and_update_in(h, [{:access, key} | t], fun) do
     quote do
-      Access.get_and_update(
-        unquote(h),
-        unquote(key),
-        unquote(nest_get_and_update_in(t, fun))
-      )
+      Access.get_and_update(unquote(h), unquote(key), unquote(nest_get_and_update_in(t, fun)))
     end
   end
+
   defp nest_get_and_update_in(h, [{:map, key} | t], fun) do
     quote do
       Map.get_and_update!(unquote(h), unquote(key), unquote(nest_get_and_update_in(t, fun)))
@@ -2344,15 +2378,17 @@ defmodule Kernel do
     quote do
       case unquote(h) do
         nil -> {nil, nil}
-        h   -> Access.pop(h, unquote(key))
+        h -> Access.pop(h, unquote(key))
       end
     end
   end
 
   defp nest_pop_in(_, _, [{:map, key}]) do
-    raise ArgumentError, "cannot use pop_in when the last segment is a map/struct field. " <>
-                         "This would effectively remove the field #{inspect key} from the map/struct"
+    raise ArgumentError,
+          "cannot use pop_in when the last segment is a map/struct field. " <>
+            "This would effectively remove the field #{inspect(key)} from the map/struct"
   end
+
   defp nest_pop_in(_, h, [{:map, key} | t]) do
     quote do
       Map.get_and_update!(unquote(h), unquote(key), unquote(nest_pop_in(:map, t)))
@@ -2363,10 +2399,11 @@ defmodule Kernel do
     quote do
       case unquote(h) do
         nil -> :pop
-        h   -> Access.pop(h, unquote(key))
+        h -> Access.pop(h, unquote(key))
       end
     end
   end
+
   defp nest_pop_in(_, h, [{:access, key} | t]) do
     quote do
       Access.get_and_update(unquote(h), unquote(key), unquote(nest_pop_in(:access, t)))
@@ -2378,37 +2415,41 @@ defmodule Kernel do
   end
 
   defp unnest({{:., _, [expr, key]}, _, []}, acc, all_map?, kind)
-      when is_tuple(expr) and
-           :erlang.element(1, expr) != :__aliases__ and
-           :erlang.element(1, expr) != :__MODULE__ do
+       when is_tuple(expr) and :erlang.element(1, expr) != :__aliases__ and
+              :erlang.element(1, expr) != :__MODULE__ do
     unnest(expr, [{:map, key} | acc], all_map?, kind)
   end
 
   defp unnest(other, [], _all_map?, kind) do
     raise ArgumentError,
-      "expected expression given to #{kind} to access at least one element, got: #{Macro.to_string other}"
+          "expected expression given to #{kind} to access at least one element, got: #{
+            Macro.to_string(other)
+          }"
   end
 
   defp unnest(other, acc, all_map?, kind) do
     case proper_start?(other) do
-      true -> {[other | acc], all_map?}
+      true ->
+        {[other | acc], all_map?}
+
       false ->
         raise ArgumentError,
-          "expression given to #{kind} must start with a variable, local or remote call " <>
-          "and be followed by an element access, got: #{Macro.to_string other}"
+              "expression given to #{kind} must start with a variable, local or remote call " <>
+                "and be followed by an element access, got: #{Macro.to_string(other)}"
     end
   end
 
   defp proper_start?({{:., _, [expr, _]}, _, _args})
-    when is_atom(expr)
-    when :erlang.element(1, expr) == :__aliases__
-    when :erlang.element(1, expr) == :__MODULE__, do: true
+       when is_atom(expr)
+       when :erlang.element(1, expr) == :__aliases__
+       when :erlang.element(1, expr) == :__MODULE__,
+       do: true
 
   defp proper_start?({atom, _, _args})
-    when is_atom(atom), do: true
+       when is_atom(atom),
+       do: true
 
-  defp proper_start?(other),
-    do: not is_tuple(other)
+  defp proper_start?(other), do: not is_tuple(other)
 
   @doc """
   Converts the argument to a string according to the
@@ -2423,7 +2464,7 @@ defmodule Kernel do
 
   """
   defmacro to_string(term) do
-    quote do: String.Chars.to_string(unquote(term))
+    quote(do: String.Chars.to_string(unquote(term)))
   end
 
   @doc """
@@ -2436,7 +2477,7 @@ defmodule Kernel do
 
   """
   defmacro to_charlist(term) do
-    quote do: List.Chars.to_charlist(unquote(term))
+    quote(do: List.Chars.to_charlist(unquote(term)))
   end
 
   @doc """
@@ -2454,7 +2495,7 @@ defmodule Kernel do
 
   """
   defmacro is_nil(term) do
-    quote do: unquote(term) == nil
+    quote(do: unquote(term) == nil)
   end
 
   @doc """
@@ -2507,6 +2548,7 @@ defmodule Kernel do
       case unquote(expr) do
         unquote(pattern) ->
           true
+
         _ ->
           false
       end
@@ -2554,9 +2596,9 @@ defmodule Kernel do
   time and not at runtime. Check the `Module` module for other functions
   to manipulate module attributes.
   """
-  defmacro @(expr)
+  defmacro @expr
 
-  defmacro @({name, meta, args}) do
+  defmacro @{name, meta, args} do
     assert_module_scope(__CALLER__, :@, 1)
     function? = __CALLER__.function != nil
 
@@ -2566,13 +2608,14 @@ defmodule Kernel do
         nil
 
       not function? and __CALLER__.context == :match ->
-        raise ArgumentError, "invalid write attribute syntax, you probably meant to use: @#{name} expression"
+        raise ArgumentError,
+              "invalid write attribute syntax, you probably meant to use: @#{name} expression"
 
       # Typespecs attributes are currently special cased by the compiler
       macro = is_list(args) and length(args) == 1 and typespec(name) ->
         case bootstrapped?(Kernel.Typespec) do
           false -> nil
-          true  -> quote do: Kernel.Typespec.unquote(macro)(unquote(hd(args)))
+          true -> quote(do: Kernel.Typespec.unquote(macro)(unquote(hd(args))))
         end
 
       true ->
@@ -2593,25 +2636,42 @@ defmodule Kernel do
         raise ArgumentError, "cannot set attribute @#{name} inside function/macro"
 
       name == :behavior ->
-        :elixir_errors.warn env.line, env.file,
-                            "@behavior attribute is not supported, please use @behaviour instead"
+        warn_message = "@behavior attribute is not supported, please use @behaviour instead"
+        :elixir_errors.warn(env.line, env.file, warn_message)
 
       # TODO: Remove :compile check once on 2.0 as we no longer
       # need to warn on parse transforms in Module.put_attribute.
       name == :compile ->
         {stack, _} = :elixir_quote.escape(env_stacktrace(env), false)
-        quote do: Module.put_attribute(__MODULE__, unquote(name), unquote(arg),
-                                       unquote(stack), unquote(line))
+
+        quote(
+          do: Module.put_attribute(
+            __MODULE__,
+            unquote(name),
+            unquote(arg),
+            unquote(stack),
+            unquote(line)
+          )
+        )
 
       :lists.member(name, [:moduledoc, :typedoc, :doc]) ->
         {stack, _} = :elixir_quote.escape(env_stacktrace(env), false)
         arg = {env.line, arg}
-        quote do: Module.put_attribute(__MODULE__, unquote(name), unquote(arg),
-                                       unquote(stack), unquote(line))
+
+        quote(
+          do: Module.put_attribute(
+            __MODULE__,
+            unquote(name),
+            unquote(arg),
+            unquote(stack),
+            unquote(line)
+          )
+        )
 
       true ->
-        quote do: Module.put_attribute(__MODULE__, unquote(name), unquote(arg),
-                                       nil, unquote(line))
+        quote(
+          do: Module.put_attribute(__MODULE__, unquote(name), unquote(arg), nil, unquote(line))
+        )
     end
   end
 
@@ -2623,22 +2683,25 @@ defmodule Kernel do
     case function? do
       true ->
         value =
-          with {_, doc} when doc_attr? <-
-                 Module.get_attribute(env.module, name, stack),
-               do: doc
+          with {_, doc} when doc_attr? <- Module.get_attribute(env.module, name, stack), do: doc
+
         try do
           :elixir_quote.escape(value, false)
         rescue
           ex in [ArgumentError] ->
-            raise ArgumentError, "cannot inject attribute @#{name} into function/macro because " <> Exception.message(ex)
+            raise ArgumentError,
+                  "cannot inject attribute @#{name} into function/macro because " <>
+                    Exception.message(ex)
         else
           {val, _} -> val
         end
 
       false ->
         {escaped, _} = :elixir_quote.escape(stack, false)
+
         quote do
-          with {_, doc} when unquote(doc_attr?) <-
+          with {_, doc}
+               when unquote(doc_attr?) <-
                  Module.get_attribute(__MODULE__, unquote(name), unquote(escaped)),
                do: doc
         end
@@ -2650,13 +2713,13 @@ defmodule Kernel do
     raise ArgumentError, "expected 0 or 1 argument for @#{name}, got: #{length(args)}"
   end
 
-  defp typespec(:type),          do: :deftype
-  defp typespec(:typep),         do: :deftypep
-  defp typespec(:opaque),        do: :defopaque
-  defp typespec(:spec),          do: :defspec
-  defp typespec(:callback),      do: :defcallback
+  defp typespec(:type), do: :deftype
+  defp typespec(:typep), do: :deftypep
+  defp typespec(:opaque), do: :defopaque
+  defp typespec(:spec), do: :defspec
+  defp typespec(:callback), do: :defcallback
   defp typespec(:macrocallback), do: :defmacrocallback
-  defp typespec(_),              do: false
+  defp typespec(_), do: false
 
   @doc """
   Returns the binding for the given context as a keyword list.
@@ -2686,13 +2749,14 @@ defmodule Kernel do
   """
   defmacro binding(context \\ nil) do
     in_match? = Macro.Env.in_match?(__CALLER__)
+
     for {v, c} <- __CALLER__.vars, c == context do
       {v, wrap_binding(in_match?, {v, [generated: true], c})}
     end
   end
 
   defp wrap_binding(true, var) do
-    quote do: ^(unquote(var))
+    quote(do: ^unquote(var))
   end
 
   defp wrap_binding(_, var) do
@@ -2746,17 +2810,21 @@ defmodule Kernel do
   end
 
   defp build_if(condition, do: do_clause, else: else_clause) do
-    optimize_boolean(quote do
-      case unquote(condition) do
-        x when x in [false, nil] -> unquote(else_clause)
-        _ -> unquote(do_clause)
+    optimize_boolean(
+      quote do
+        case unquote(condition) do
+          x when x in [false, nil] -> unquote(else_clause)
+          _ -> unquote(do_clause)
+        end
       end
-    end)
+    )
   end
 
   defp build_if(_condition, _arguments) do
-    raise(ArgumentError, "invalid or duplicate keys for if, only \"do\" " <>
-      "and an optional \"else\" are permitted")
+    raise(
+      ArgumentError,
+      "invalid or duplicate keys for if, only \"do\" " <> "and an optional \"else\" are permitted"
+    )
   end
 
   @doc """
@@ -2799,8 +2867,11 @@ defmodule Kernel do
   end
 
   defp build_unless(_condition, _arguments) do
-    raise(ArgumentError, "invalid or duplicate keys for unless, only \"do\" " <>
-      "and an optional \"else\" are permitted")
+    raise(
+      ArgumentError,
+      "invalid or duplicate keys for unless, only \"do\" " <>
+        "and an optional \"else\" are permitted"
+    )
   end
 
   @doc """
@@ -2837,8 +2908,7 @@ defmodule Kernel do
   """
   defmacro destructure(left, right) when is_list(left) do
     quote do
-      unquote(left) =
-        Kernel.Utils.destructure(unquote(right), unquote(length(left)))
+      unquote(left) = Kernel.Utils.destructure(unquote(right), unquote(length(left)))
     end
   end
 
@@ -2870,24 +2940,22 @@ defmodule Kernel do
   end
 
   defmacro first..last
-    when is_float(first) or is_float(last) or
-         is_atom(first) or is_atom(last) or
-         is_binary(first) or is_binary(last) or
-         is_list(first) or is_list(last) do
+           when is_float(first) or is_float(last) or is_atom(first) or is_atom(last) or
+                  is_binary(first) or is_binary(last) or is_list(first) or is_list(last) do
     raise ArgumentError,
-      "ranges (first..last) expect both sides to be integers, " <>
-      "got: #{Macro.to_string({:.., [], [first, last]})}"
+          "ranges (first..last) expect both sides to be integers, " <>
+            "got: #{Macro.to_string({:.., [], [first, last]})}"
   end
 
   defmacro first..last do
     case __CALLER__.context do
       nil ->
-        quote do: Elixir.Range.new(unquote(first), unquote(last))
+        quote(do: Elixir.Range.new(unquote(first), unquote(last)))
+
       _ ->
         {:%{}, [], [__struct__: Elixir.Range, first: first, last: last]}
     end
   end
-
 
   @doc """
   Provides a short-circuit operator that evaluates and returns
@@ -2919,6 +2987,7 @@ defmodule Kernel do
       case unquote(left) do
         x when x in [false, nil] ->
           x
+
         _ ->
           unquote(right)
       end
@@ -2954,6 +3023,7 @@ defmodule Kernel do
       case unquote(left) do
         x when x in [false, nil] ->
           unquote(right)
+
         x ->
           x
       end
@@ -3039,18 +3109,25 @@ defmodule Kernel do
   """
   defmacro left |> right do
     [{h, _} | t] = Macro.unpipe({:|>, [], [left, right]})
-    :lists.foldl fn {x, pos}, acc ->
-      case x do
-        {op, _, [_]} when op == :+ or op == :- ->
-          :elixir_errors.warn(__CALLER__.line, __CALLER__.file,
-                              <<"piping into a unary operator is deprecated, please use the ",
-                                "qualified name. For example, Kernel.+(5), instead of +5">>)
-        _ ->
-          :ok
-      end
 
-      Macro.pipe(acc, x, pos)
-    end, h, t
+    :lists.foldl(
+      fn {x, pos}, acc ->
+        case x do
+          {op, _, [_]} when op == :+ or op == :- ->
+            :elixir_errors.warn(__CALLER__.line, __CALLER__.file, <<
+              "piping into a unary operator is deprecated, please use the ",
+              "qualified name. For example, Kernel.+(5), instead of +5"
+            >>)
+
+          _ ->
+            :ok
+        end
+
+        Macro.pipe(acc, x, pos)
+      end,
+      h,
+      t
+    )
   end
 
   @doc """
@@ -3095,7 +3172,7 @@ defmodule Kernel do
   @spec macro_exported?(module, atom, arity) :: boolean
   def macro_exported?(module, macro, arity)
       when is_atom(module) and is_atom(macro) and is_integer(arity) and
-           (arity >= 0 and arity <= 255) do
+             (arity >= 0 and arity <= 255) do
     function_exported?(module, :__info__, 1) and
       :lists.member({macro, arity}, module.__info__(:macros))
   end
@@ -3156,12 +3233,13 @@ defmodule Kernel do
   this AST to `left not in right`.
   """
   defmacro left in right do
-    in_module? = (__CALLER__.context == nil)
+    in_module? = __CALLER__.context == nil
 
-    expand = case bootstrapped?(Macro) do
-      true -> &Macro.expand(&1, __CALLER__)
-      false -> &(&1)
-    end
+    expand =
+      case bootstrapped?(Macro) do
+        true -> &Macro.expand(&1, __CALLER__)
+        false -> & &1
+      end
 
     case expand.(right) do
       [] when not in_module? ->
@@ -3174,36 +3252,44 @@ defmodule Kernel do
         case ensure_evaled(list, {0, []}, expand) do
           {[head | tail], {_, []}} ->
             in_var(in_module?, left, &in_list(&1, head, tail, expand, list, in_module?))
+
           {[head | tail], {_, vars_values}} ->
             {vars, values} = :lists.unzip(:lists.reverse(vars_values))
+
             quote do
               {unquote_splicing(vars)} = {unquote_splicing(values)}
-              unquote(in_var(in_module?, left, &in_list(&1, head, tail, expand, list, in_module?)))
+
+              unquote(
+                in_var(in_module?, left, &in_list(&1, head, tail, expand, list, in_module?))
+              )
             end
         end
 
       {:%{}, _meta, [__struct__: Elixir.Range, first: first, last: last]} ->
         first = Macro.expand(first, __CALLER__)
-        last  = Macro.expand(last, __CALLER__)
+        last = Macro.expand(last, __CALLER__)
         in_var(in_module?, left, &in_range(&1, first, last))
 
       right when in_module? ->
-        quote do: Elixir.Enum.member?(unquote(right), unquote(left))
+        quote(do: Elixir.Enum.member?(unquote(right), unquote(left)))
 
       %{__struct__: Elixir.Range, first: _, last: _} ->
         raise ArgumentError, "non-literal range in guard should be escaped with Macro.escape/2"
 
       right ->
-        raise ArgumentError, <<"invalid args for operator \"in\", it expects a compile-time proper list ",
-                               "or compile-time range on the right side when used in guard expressions, got: ",
-                               Macro.to_string(right)::binary>>
+        raise ArgumentError, <<
+          "invalid args for operator \"in\", it expects a compile-time proper list ",
+          "or compile-time range on the right side when used in guard expressions, got: ",
+          Macro.to_string(right)::binary
+        >>
     end
   end
 
-  defp in_var(false, ast, fun),
-    do: fun.(ast)
+  defp in_var(false, ast, fun), do: fun.(ast)
+
   defp in_var(true, {atom, _, context} = var, fun) when is_atom(atom) and is_atom(context),
     do: fun.(var)
+
   defp in_var(true, ast, fun) do
     quote do
       var = unquote(ast)
@@ -3213,19 +3299,25 @@ defmodule Kernel do
 
   # Called as ensure_evaled(list, {0, []}). Note acc is reversed.
   defp ensure_evaled(list, acc, expand) do
-    :lists.mapfoldl(fn
-      {:|, meta, [head, tail]}, acc ->
-        {head, acc} = ensure_evaled_element(head, acc)
-        {tail, acc} = ensure_evaled_tail(expand.(tail), acc, expand)
-        {{:|, meta, [head, tail]}, acc}
-      elem, acc ->
-        ensure_evaled_element(elem, acc)
-    end, acc, list)
+    :lists.mapfoldl(
+      fn
+        {:|, meta, [head, tail]}, acc ->
+          {head, acc} = ensure_evaled_element(head, acc)
+          {tail, acc} = ensure_evaled_tail(expand.(tail), acc, expand)
+          {{:|, meta, [head, tail]}, acc}
+
+        elem, acc ->
+          ensure_evaled_element(elem, acc)
+      end,
+      acc,
+      list
+    )
   end
 
   defp ensure_evaled_element(elem, acc) when is_number(elem) or is_atom(elem) or is_binary(elem) do
     {elem, acc}
   end
+
   defp ensure_evaled_element(elem, acc) do
     ensure_evaled_var(elem, acc)
   end
@@ -3233,6 +3325,7 @@ defmodule Kernel do
   defp ensure_evaled_tail(elem, acc, expand) when is_list(elem) do
     ensure_evaled(elem, acc, expand)
   end
+
   defp ensure_evaled_tail(elem, acc, _expand) do
     ensure_evaled_var(elem, acc)
   end
@@ -3244,17 +3337,17 @@ defmodule Kernel do
 
   defp in_range(left, first, last) do
     case is_integer(first) and is_integer(last) do
-      true  ->
+      true ->
         in_range_literal(left, first, last)
+
       false ->
         quote do
-          (:erlang.is_integer(unquote(left)) and
-           :erlang.is_integer(unquote(first)) and
-           :erlang.is_integer(unquote(last))) and
+          :erlang.is_integer(unquote(left)) and :erlang.is_integer(unquote(first)) and
+            :erlang.is_integer(unquote(last)) and
             ((:erlang."=<"(unquote(first), unquote(last)) and
-              unquote(increasing_compare(left, first, last))) or
-               (:erlang."<"(unquote(last), unquote(first)) and
-                unquote(decreasing_compare(left, first, last))))
+                unquote(increasing_compare(left, first, last))) or
+               (:erlang.<(unquote(last), unquote(first)) and
+                  unquote(decreasing_compare(left, first, last))))
         end
     end
   end
@@ -3267,42 +3360,61 @@ defmodule Kernel do
 
   defp in_range_literal(left, first, last) when first < last do
     quote do
-      :erlang.andalso(:erlang.is_integer(unquote(left)),
-                      unquote(increasing_compare(left, first, last)))
+      :erlang.andalso(
+        :erlang.is_integer(unquote(left)),
+        unquote(increasing_compare(left, first, last))
+      )
     end
   end
 
   defp in_range_literal(left, first, last) do
     quote do
-      :erlang.andalso(:erlang.is_integer(unquote(left)),
-                      unquote(decreasing_compare(left, first, last)))
+      :erlang.andalso(
+        :erlang.is_integer(unquote(left)),
+        unquote(decreasing_compare(left, first, last))
+      )
     end
   end
 
   defp in_list(left, head, tail, expand, right, in_module?) do
-    :lists.foldr(fn elem, acc ->
-      quote do: :erlang.orelse(unquote(comp(left, elem, expand, right, in_module?)), unquote(acc))
-    end, comp(left, head, expand, right, in_module?), tail)
+    :lists.foldr(
+      fn elem, acc ->
+        quote(
+          do: :erlang.orelse(unquote(comp(left, elem, expand, right, in_module?)), unquote(acc))
+        )
+      end,
+      comp(left, head, expand, right, in_module?),
+      tail
+    )
   end
 
   defp comp(left, {:|, _, [head, tail]}, expand, right, in_module?) do
     case expand.(tail) do
       [] ->
         quote(do: :erlang."=:="(unquote(left), unquote(head)))
+
       [tail_head | tail] ->
         quote do
-          :erlang.orelse(:erlang."=:="(unquote(left), unquote(head)),
-                         unquote(in_list(left, tail_head, tail, expand, right, in_module?)))
+          :erlang.orelse(
+            :erlang."=:="(unquote(left), unquote(head)),
+            unquote(in_list(left, tail_head, tail, expand, right, in_module?))
+          )
         end
+
       tail when in_module? ->
         quote do
-          :erlang.orelse(:erlang."=:="(unquote(left), unquote(head)),
-                         :lists.member(unquote(left), unquote(tail)))
+          :erlang.orelse(
+            :erlang."=:="(unquote(left), unquote(head)),
+            :lists.member(unquote(left), unquote(tail))
+          )
         end
+
       _ ->
-        raise ArgumentError, <<"invalid args for operator \"in\", it expects a compile-time proper list ",
-                               "or compile-time range on the right side when used in guard expressions, got: ",
-                               Macro.to_string(right)::binary>>
+        raise ArgumentError, <<
+          "invalid args for operator \"in\", it expects a compile-time proper list ",
+          "or compile-time range on the right side when used in guard expressions, got: ",
+          Macro.to_string(right)::binary
+        >>
     end
   end
 
@@ -3312,15 +3424,19 @@ defmodule Kernel do
 
   defp increasing_compare(var, first, last) do
     quote do
-      :erlang.andalso(:erlang.">="(unquote(var), unquote(first)),
-                      :erlang."=<"(unquote(var), unquote(last)))
+      :erlang.andalso(
+        :erlang.>=(unquote(var), unquote(first)),
+        :erlang."=<"(unquote(var), unquote(last))
+      )
     end
   end
 
   defp decreasing_compare(var, first, last) do
     quote do
-      :erlang.andalso(:erlang."=<"(unquote(var), unquote(first)),
-                      :erlang.">="(unquote(var), unquote(last)))
+      :erlang.andalso(
+        :erlang."=<"(unquote(var), unquote(first)),
+        :erlang.>=(unquote(var), unquote(last))
+      )
     end
   end
 
@@ -3343,8 +3459,10 @@ defmodule Kernel do
     case Macro.expand(context, __CALLER__) do
       context when is_atom(context) ->
         {name, meta, context}
+
       other ->
-        raise ArgumentError, "expected var! context to expand to an atom, got: #{Macro.to_string(other)}"
+        raise ArgumentError,
+              "expected var! context to expand to an atom, got: #{Macro.to_string(other)}"
     end
   end
 
@@ -3445,12 +3563,12 @@ defmodule Kernel do
   defmacro defmodule(alias, do_block)
 
   defmacro defmodule(alias, do: block) do
-    env   = __CALLER__
+    env = __CALLER__
     boot? = bootstrapped?(Macro)
 
     expanded =
       case boot? do
-        true  -> Macro.expand(alias, env)
+        true -> Macro.expand(alias, env)
         false -> alias
       end
 
@@ -3465,6 +3583,7 @@ defmodule Kernel do
           meta = [defined: full, context: env.module] ++ alias_meta(alias)
 
           {full, {:alias, meta, [old, [as: new, warn: false]]}}
+
         false ->
           {expanded, nil}
       end
@@ -3473,17 +3592,19 @@ defmodule Kernel do
     # are not messed up. Basically, we just insert something between the return
     # value of the block and what is returned by defmodule. Using just ":ok" or
     # similar doesn't work because it's likely optimized away by the compiler.
-    block = quote do
-      result = unquote(block)
-      :elixir_utils.noop()
-      result
-    end
+    block =
+      quote do
+        result = unquote(block)
+        :elixir_utils.noop()
+        result
+      end
 
     escaped =
       case env do
         %{function: nil, lexical_tracker: pid} when is_pid(pid) ->
           integer = Kernel.LexicalTracker.write_cache(pid, block)
-          quote do: Kernel.LexicalTracker.read_cache(unquote(pid), unquote(integer))
+          quote(do: Kernel.LexicalTracker.read_cache(unquote(pid), unquote(integer)))
+
         %{} ->
           {escaped, _} = :elixir_quote.escape(block, false)
           escaped
@@ -3493,8 +3614,7 @@ defmodule Kernel do
 
     quote do
       unquote(with_alias)
-      :elixir_module.compile(unquote(expanded), unquote(escaped),
-                             unquote(module_vars), __ENV__)
+      :elixir_module.compile(unquote(expanded), unquote(escaped), unquote(module_vars), __ENV__)
     end
   end
 
@@ -3502,35 +3622,31 @@ defmodule Kernel do
   defp alias_meta(_), do: []
 
   # defmodule :foo
-  defp expand_module(raw, _module, _env) when is_atom(raw),
-    do: raw
+  defp expand_module(raw, _module, _env) when is_atom(raw), do: raw
 
   # defmodule Elixir.Alias
-  defp expand_module({:__aliases__, _, [:Elixir | t]}, module, _env) when t != [],
-    do: module
+  defp expand_module({:__aliases__, _, [:"Elixir" | t]}, module, _env) when t != [], do: module
 
   # defmodule Alias in root
-  defp expand_module({:__aliases__, _, _}, module, %{module: nil}),
-    do: module
+  defp expand_module({:__aliases__, _, _}, module, %{module: nil}), do: module
 
   # defmodule Alias nested
   defp expand_module({:__aliases__, _, t}, _module, env),
     do: :elixir_aliases.concat([env.module | t])
 
   # defmodule _
-  defp expand_module(_raw, module, env),
-    do: :elixir_aliases.concat([env.module, module])
+  defp expand_module(_raw, module, env), do: :elixir_aliases.concat([env.module, module])
 
   # quote vars to be injected into the module definition
   defp module_vars([{key, kind} | vars], counter) do
     var =
       case is_atom(kind) do
-        true  -> {key, [generated: true], kind}
+        true -> {key, [generated: true], kind}
         false -> {key, [counter: kind, generated: true], nil}
       end
 
     under = String.to_atom(<<"_@", :erlang.integer_to_binary(counter)::binary>>)
-    args  = [key, kind, under, var]
+    args = [key, kind, under, var]
     [{:{}, [], args} | module_vars(vars, counter + 1)]
   end
 
@@ -3553,8 +3669,7 @@ defmodule Kernel do
   #     module_nesting(nil, :"Elixir.Foo.Bar.Baz.Bat")
   #     {nil, :"Elixir.Foo.Bar.Baz.Bat"}
   #
-  defp module_nesting(nil, full),
-    do: {nil, full}
+  defp module_nesting(nil, full), do: {nil, full}
 
   defp module_nesting(prefix, full) do
     case split_module(prefix) do
@@ -3563,13 +3678,15 @@ defmodule Kernel do
     end
   end
 
-  defp module_nesting([x | t1], [x | t2], acc, full),
-    do: module_nesting(t1, t2, [x | acc], full)
+  defp module_nesting([x | t1], [x | t2], acc, full), do: module_nesting(t1, t2, [x | acc], full)
+
   defp module_nesting([], [h | _], acc, _full),
-    do: {String.to_atom(<<"Elixir.", h::binary>>),
-          :elixir_aliases.concat(:lists.reverse([h | acc]))}
-  defp module_nesting(_, _, _acc, full),
-    do: {nil, full}
+    do: {
+      String.to_atom(<<"Elixir.", h::binary>>),
+      :elixir_aliases.concat(:lists.reverse([h | acc]))
+    }
+
+  defp module_nesting(_, _, _acc, full), do: {nil, full}
 
   defp split_module(atom) do
     case :binary.split(Atom.to_string(atom), ".", [:global]) do
@@ -3763,10 +3880,11 @@ defmodule Kernel do
       case unquoted_expr do
         true ->
           escaped_expr
+
         false ->
           key = :erlang.unique_integer()
           :elixir_module.write_cache(module, key, expr)
-          quote do: :elixir_module.read_cache(unquote(module), unquote(key))
+          quote(do: :elixir_module.read_cache(unquote(module), unquote(key)))
       end
 
     # Do not check clauses if any expression was unquoted
@@ -3774,8 +3892,13 @@ defmodule Kernel do
     pos = :elixir_locals.cache_env(env)
 
     quote do
-      :elixir_def.store_definition(unquote(kind), unquote(check_clauses),
-                                   unquote(escaped_call), unquote(escaped_expr), unquote(pos))
+      :elixir_def.store_definition(
+        unquote(kind),
+        unquote(check_clauses),
+        unquote(escaped_call),
+        unquote(escaped_expr),
+        unquote(pos)
+      )
     end
   end
 
@@ -3904,35 +4027,48 @@ defmodule Kernel do
                     Map.replace!(map, key, val)
                   end)
                 end
+
               _ ->
                 def __struct__(kv) do
                   {map, keys} =
                     Enum.reduce(kv, {@struct, @enforce_keys}, fn {key, val}, {map, keys} ->
                       {Map.replace!(map, key, val), List.delete(keys, key)}
                     end)
+
                   case keys do
-                    [] -> map
-                    _  -> raise ArgumentError, "the following keys must also be given when building " <>
-                        "struct #{inspect __MODULE__}: #{inspect keys}"
+                    [] ->
+                      map
+
+                    _ ->
+                      raise ArgumentError,
+                            "the following keys must also be given when building " <>
+                              "struct #{inspect(__MODULE__)}: #{inspect(keys)}"
                   end
                 end
             end
           end
+
         false ->
           quote do
             _ = @enforce_keys
+
             def __struct__(kv) do
-              :lists.foldl(fn {key, val}, acc ->
-                Map.replace!(acc, key, val)
-              end, @struct, kv)
+              :lists.foldl(
+                fn {key, val}, acc ->
+                  Map.replace!(acc, key, val)
+                end,
+                @struct,
+                kv
+              )
             end
           end
       end
 
     quote do
       if Module.get_attribute(__MODULE__, :struct) do
-        raise ArgumentError, "defstruct has already been called for " <>
-          "#{Kernel.inspect(__MODULE__)}, defstruct can only be called once per module"
+        raise ArgumentError,
+              "defstruct has already been called for " <>
+                "#{Kernel.inspect(__MODULE__)}, defstruct can only be called once per module"
       end
 
       {struct, keys, derive} = Kernel.Utils.defstruct(__MODULE__, unquote(fields))
@@ -3941,7 +4077,7 @@ defmodule Kernel do
 
       case derive do
         [] -> :ok
-        _  -> Protocol.__derive__(derive, __MODULE__, __ENV__)
+        _ -> Protocol.__derive__(derive, __MODULE__, __ENV__)
       end
 
       def __struct__() do
@@ -4011,20 +4147,20 @@ defmodule Kernel do
       struct = defstruct([__exception__: true] ++ fields)
 
       if Map.has_key?(struct, :message) do
-        @spec message(Exception.t) :: String.t
+        @spec message(Exception.t()) :: String.t()
         def message(exception) do
           exception.message
         end
 
         defoverridable message: 1
 
-        @spec exception(String.t) :: Exception.t
+        @spec exception(String.t()) :: Exception.t()
         def exception(msg) when is_binary(msg) do
           exception(message: msg)
         end
       end
 
-      @spec exception(keyword) :: Exception.t
+      @spec exception(keyword) :: Exception.t()
       # TODO: Only call Kernel.struct! by 2.0
       def exception(args) when is_list(args) do
         struct = __struct__()
@@ -4033,13 +4169,16 @@ defmodule Kernel do
         case invalid do
           [] ->
             :ok
-          _  ->
-            IO.warn "the following fields are unknown when raising " <>
-                    "#{inspect __MODULE__}: #{inspect invalid}. " <>
-                    "Please make sure to only give known fields when raising " <>
-                    "or redefine #{inspect __MODULE__}.exception/1 to " <>
-                    "discard unknown fields. Future Elixir versions will raise on " <>
-                    "unknown fields given to raise/2"
+
+          _ ->
+            IO.warn(
+              "the following fields are unknown when raising " <>
+                "#{inspect(__MODULE__)}: #{inspect(invalid)}. " <>
+                "Please make sure to only give known fields when raising " <>
+                "or redefine #{inspect(__MODULE__)}.exception/1 to " <>
+                "discard unknown fields. Future Elixir versions will raise on " <>
+                "unknown fields given to raise/2"
+            )
         end
 
         Kernel.struct!(struct, valid)
@@ -4423,26 +4562,36 @@ defmodule Kernel do
   into the caller when used.
   """
   defmacro use(module, opts \\ []) do
-    calls = Enum.map(expand_aliases(module, __CALLER__), fn
-      expanded when is_atom(expanded) ->
-        quote do
-          require unquote(expanded)
-          unquote(expanded).__using__(unquote(opts))
-        end
-      _otherwise ->
-        raise ArgumentError, "invalid arguments for use, expected a compile time atom or alias, got: #{Macro.to_string(module)}"
-    end)
-    quote(do: (unquote_splicing calls))
+    calls =
+      Enum.map(expand_aliases(module, __CALLER__), fn
+        expanded when is_atom(expanded) ->
+          quote do
+            require unquote(expanded)
+            unquote(expanded).__using__(unquote(opts))
+          end
+
+        _otherwise ->
+          raise ArgumentError,
+                "invalid arguments for use, expected a compile time atom or alias, got: #{
+                  Macro.to_string(module)
+                }"
+      end)
+
+    quote(do: (unquote_splicing(calls)))
   end
 
   defp expand_aliases({{:., _, [base, :{}]}, _, refs}, env) do
     base = Macro.expand(base, env)
+
     Enum.map(refs, fn
       {:__aliases__, _, ref} ->
         Module.concat([base | ref])
+
       ref when is_atom(ref) ->
         Module.concat(base, ref)
-      other -> other
+
+      other ->
+        other
     end)
   end
 
@@ -4486,29 +4635,33 @@ defmodule Kernel do
   """
   defmacro defdelegate(funs, opts) do
     funs = Macro.escape(funs, unquote: true)
+
     quote bind_quoted: [funs: funs, opts: opts] do
-      target = Keyword.get(opts, :to) ||
-        raise ArgumentError, "expected to: to be given as argument"
+      target =
+        Keyword.get(opts, :to) || raise ArgumentError, "expected to: to be given as argument"
 
       # TODO: Raise on 2.0
       %{file: file, line: line} = __ENV__
+
       if is_list(funs) do
-        :elixir_errors.warn(line, file,
+        :elixir_errors.warn(
+          line,
+          file,
           "passing a list to Kernel.defdelegate/2 is deprecated, " <>
-          "please define each delegate separately")
+            "please define each delegate separately"
+        )
       end
 
       # TODO: Remove on 2.0
       if Keyword.has_key?(opts, :append_first) do
-        :elixir_errors.warn(line, file,
-          "Kernel.defdelegate/2 :append_first option is deprecated")
+        :elixir_errors.warn(line, file, "Kernel.defdelegate/2 :append_first option is deprecated")
       end
 
       for fun <- List.wrap(funs) do
         {name, args, as, as_args} = Kernel.Utils.defdelegate(fun, opts)
 
         unless Module.get_attribute(__MODULE__, :doc) do
-          @doc "See `#{inspect target}.#{as}/#{:erlang.length args}`."
+          @doc "See `#{inspect(target)}.#{as}/#{:erlang.length(args)}`."
         end
 
         def unquote(name)(unquote_splicing(args)) do
@@ -4557,9 +4710,11 @@ defmodule Kernel do
 
   """
   defmacro sigil_s(term, modifiers)
+
   defmacro sigil_s({:<<>>, _, [piece]}, []) when is_binary(piece) do
     :elixir_interpolation.unescape_chars(piece)
   end
+
   defmacro sigil_s({:<<>>, line, pieces}, []) do
     {:<<>>, line, :elixir_interpolation.unescape_tokens(pieces)}
   end
@@ -4580,6 +4735,7 @@ defmodule Kernel do
 
   """
   defmacro sigil_C(term, modifiers)
+
   defmacro sigil_C({:<<>>, _meta, [string]}, []) when is_binary(string) do
     String.to_charlist(string)
   end
@@ -4612,7 +4768,7 @@ defmodule Kernel do
 
   defmacro sigil_c({:<<>>, meta, pieces}, []) do
     binary = {:<<>>, meta, :elixir_interpolation.unescape_tokens(pieces)}
-    quote do: String.to_charlist(unquote(binary))
+    quote(do: String.to_charlist(unquote(binary)))
   end
 
   @doc """
@@ -4633,15 +4789,16 @@ defmodule Kernel do
 
   """
   defmacro sigil_r(term, modifiers)
+
   defmacro sigil_r({:<<>>, _meta, [string]}, options) when is_binary(string) do
     binary = :elixir_interpolation.unescape_chars(string, &Regex.unescape_map/1)
-    regex  = Regex.compile!(binary, :binary.list_to_bin(options))
+    regex = Regex.compile!(binary, :binary.list_to_bin(options))
     Macro.escape(regex)
   end
 
   defmacro sigil_r({:<<>>, meta, pieces}, options) do
     binary = {:<<>>, meta, :elixir_interpolation.unescape_tokens(pieces, &Regex.unescape_map/1)}
-    quote do: Regex.compile!(unquote(binary), unquote(:binary.list_to_bin(options)))
+    quote(do: Regex.compile!(unquote(binary), unquote(:binary.list_to_bin(options))))
   end
 
   @doc ~S"""
@@ -4659,6 +4816,7 @@ defmodule Kernel do
 
   """
   defmacro sigil_R(term, modifiers)
+
   defmacro sigil_R({:<<>>, _meta, [string]}, options) when is_binary(string) do
     regex = Regex.compile!(string, :binary.list_to_bin(options))
     Macro.escape(regex)
@@ -4676,6 +4834,7 @@ defmodule Kernel do
       ~D[2015-01-13]
   """
   defmacro sigil_D(date, modifiers)
+
   defmacro sigil_D({:<<>>, _, [string]}, []) do
     Macro.escape(Date.from_iso8601!(string))
   end
@@ -4695,6 +4854,7 @@ defmodule Kernel do
 
   """
   defmacro sigil_T(date, modifiers)
+
   defmacro sigil_T({:<<>>, _, [string]}, []) do
     Macro.escape(Time.from_iso8601!(string))
   end
@@ -4714,6 +4874,7 @@ defmodule Kernel do
 
   """
   defmacro sigil_N(date, modifiers)
+
   defmacro sigil_N({:<<>>, _, [string]}, []) do
     Macro.escape(NaiveDateTime.from_iso8601!(string))
   end
@@ -4746,6 +4907,7 @@ defmodule Kernel do
 
   """
   defmacro sigil_w(term, modifiers)
+
   defmacro sigil_w({:<<>>, _meta, [string]}, modifiers) when is_binary(string) do
     split_words(:elixir_interpolation.unescape_chars(string), modifiers)
   end
@@ -4774,6 +4936,7 @@ defmodule Kernel do
 
   """
   defmacro sigil_W(term, modifiers)
+
   defmacro sigil_W({:<<>>, _meta, [string]}, modifiers) when is_binary(string) do
     split_words(string, modifiers)
   end
@@ -4783,17 +4946,20 @@ defmodule Kernel do
   end
 
   defp split_words(string, [mod])
-  when mod == ?s or mod == ?a or mod == ?c do
+       when mod == ?s or mod == ?a or mod == ?c do
     case is_binary(string) do
       true ->
         parts = String.split(string)
+
         case mod do
           ?s -> parts
           ?a -> :lists.map(&String.to_atom/1, parts)
           ?c -> :lists.map(&String.to_charlist/1, parts)
         end
+
       false ->
         parts = quote(do: String.split(unquote(string)))
+
         case mod do
           ?s -> parts
           ?a -> quote(do: :lists.map(&String.to_atom/1, unquote(parts)))
@@ -4818,6 +4984,7 @@ defmodule Kernel do
   case :code.ensure_loaded(Kernel) do
     {:module, _} ->
       defp bootstrapped?(_), do: true
+
     {:error, _} ->
       defp bootstrapped?(module), do: :code.ensure_loaded(module) == {:module, module}
   end
@@ -4832,13 +4999,13 @@ defmodule Kernel do
   defp assert_no_function_scope(env, fun, arity) do
     case env.function do
       nil -> :ok
-      _   -> raise ArgumentError, "cannot invoke #{fun}/#{arity} inside function/macro"
+      _ -> raise ArgumentError, "cannot invoke #{fun}/#{arity} inside function/macro"
     end
   end
 
   defp env_stacktrace(env) do
     case bootstrapped?(Path) do
-      true  -> Macro.Env.stacktrace(env)
+      true -> Macro.Env.stacktrace(env)
       false -> []
     end
   end
@@ -4847,6 +5014,6 @@ defmodule Kernel do
   # TODO: Remove by 2.0
   # (hard-deprecated in elixir_dispatch)
   defmacro to_char_list(arg) do
-    quote do: Kernel.to_charlist(unquote(arg))
+    quote(do: Kernel.to_charlist(unquote(arg)))
   end
 end


### PR DESCRIPTION
Ok, I got the Kernel 😰 If this is totally wrong, please let me know.

One thing that I recognized is that the Kernel contains a lot of very long strings with interpolations, used for warnings, error messages, etc.

It seems that three different kind of ways are used to construct this strings:

* [String concatenation](https://github.com/elixir-lang/elixir/compare/master...fabrik42:exfmt-kernel?expand=1#diff-e06d5ebc2907d951188e88476f85af51R4174)
* [Using binary type](https://github.com/elixir-lang/elixir/compare/master...fabrik42:exfmt-kernel?expand=1#diff-e06d5ebc2907d951188e88476f85af51R3413)
* [New lines in interpolation](https://github.com/elixir-lang/elixir/compare/master...fabrik42:exfmt-kernel?expand=1#diff-e06d5ebc2907d951188e88476f85af51R1714)

Would it make sense to try to streamline this as much as possible?