### PR TITLE
Run the formatter on lib/elixir/test/elixir/calendar_test.exs

### DIFF
--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -1,12 +1,12 @@
-Code.require_file "test_helper.exs", __DIR__
-Code.require_file "fixtures/calendar/holocene.exs", __DIR__
+Code.require_file("test_helper.exs", __DIR__)
+Code.require_file("fixtures/calendar/holocene.exs", __DIR__)
 
 defmodule FakeCalendar do
   def date_to_string(_, _, _), do: "boom"
   def time_to_string(_, _, _, _), do: "boom"
   def naive_datetime_to_string(_, _, _, _, _, _, _), do: "boom"
   def datetime_to_string(_, _, _, _, _, _, _, _, _, _), do: "boom"
-  def day_rollover_relative_to_midnight_utc, do: {123456, 123457}
+  def day_rollover_relative_to_midnight_utc, do: {123_456, 123_457}
 end
 
 defmodule DateTest do
@@ -57,19 +57,23 @@ defmodule DateTest do
 
   test "convert/2" do
     assert Date.convert(~D[2000-01-01], Calendar.Holocene) ==
-           {:ok, Calendar.Holocene.date(12000, 01, 01)}
-    assert ~D[2000-01-01] |> Date.convert!(Calendar.Holocene) |> Date.convert!(Calendar.ISO) ==
-           ~D[2000-01-01]
-    assert Date.convert(~D[2016-02-03], FakeCalendar) ==
-           {:error, :incompatible_calendars}
+             {:ok, Calendar.Holocene.date(12000, 01, 01)}
+
+    assert ~D[2000-01-01]
+           |> Date.convert!(Calendar.Holocene)
+           |> Date.convert!(Calendar.ISO) == ~D[2000-01-01]
+
+    assert Date.convert(~D[2016-02-03], FakeCalendar) == {:error, :incompatible_calendars}
+
     assert Date.convert(~N[2000-01-01 00:00:00], Calendar.Holocene) ==
-           {:ok, Calendar.Holocene.date(12000, 01, 01)}
+             {:ok, Calendar.Holocene.date(12000, 01, 01)}
   end
 
   test "add/2" do
     assert_raise FunctionClauseError, fn ->
-      Date.add(~D[0000-01-01], 3652425)
+      Date.add(~D[0000-01-01], 3_652_425)
     end
+
     assert_raise FunctionClauseError, fn ->
       Date.add(~D[0000-01-01], -1)
     end
@@ -126,8 +130,10 @@ defmodule NaiveDateTimeTest do
     assert inspect(~N[2000-01-01 23:00:07.005]) == "~N[2000-01-01 23:00:07.005]"
 
     ndt = %{~N[2000-01-01 23:00:07.005] | calendar: FakeCalendar}
-    assert inspect(ndt) == "%NaiveDateTime{calendar: FakeCalendar, day: 1, hour: 23, " <>
-                           "microsecond: {5000, 3}, minute: 0, month: 1, second: 7, year: 2000}"
+
+    assert inspect(ndt) ==
+             "%NaiveDateTime{calendar: FakeCalendar, day: 1, hour: 23, " <>
+               "microsecond: {5000, 3}, minute: 0, month: 1, second: 7, year: 2000}"
   end
 
   test "compare/2" do
@@ -143,12 +149,12 @@ defmodule NaiveDateTimeTest do
 
   test "to_iso8601/1" do
     ndt = ~N[2000-04-16 12:34:15.1234]
-    ndt = put_in ndt.calendar, FakeCalendar
+    ndt = put_in(ndt.calendar, FakeCalendar)
 
     message =
       "cannot convert #{inspect(ndt)} to target calendar Calendar.ISO, " <>
-      "reason: #{inspect(ndt.calendar)} and Calendar.ISO have different day rollover moments, " <>
-      "making this conversion ambiguous"
+        "reason: #{inspect(ndt.calendar)} and Calendar.ISO have different day rollover moments, " <>
+        "making this conversion ambiguous"
 
     assert_raise ArgumentError, message, fn ->
       NaiveDateTime.to_iso8601(ndt)
@@ -159,8 +165,16 @@ defmodule NaiveDateTimeTest do
     assert ~N[2000-01-01 12:34:15.123456]
            |> NaiveDateTime.convert!(Calendar.Holocene)
            |> NaiveDateTime.add(10, :second) ==
-           %NaiveDateTime{calendar: Calendar.Holocene, year: 12000, month: 1, day: 1,
-                          hour: 12, minute: 34, second: 25, microsecond: {123456, 6}}
+             %NaiveDateTime{
+               calendar: Calendar.Holocene,
+               year: 12000,
+               month: 1,
+               day: 1,
+               hour: 12,
+               minute: 34,
+               second: 25,
+               microsecond: {123_456, 6}
+             }
   end
 
   test "diff/2 with other calendars" do
@@ -172,25 +186,24 @@ defmodule NaiveDateTimeTest do
 
   test "convert/2" do
     assert NaiveDateTime.convert(~N[2000-01-01 12:34:15.123400], Calendar.Holocene) ==
-           {:ok, Calendar.Holocene.naive_datetime(12000, 1, 1, 12, 34, 15, {123400, 6})}
+             {:ok, Calendar.Holocene.naive_datetime(12000, 1, 1, 12, 34, 15, {123_400, 6})}
 
     assert ~N[2000-01-01 12:34:15]
            |> NaiveDateTime.convert!(Calendar.Holocene)
-           |> NaiveDateTime.convert!(Calendar.ISO) ==
-           ~N[2000-01-01 12:34:15]
+           |> NaiveDateTime.convert!(Calendar.ISO) == ~N[2000-01-01 12:34:15]
 
     assert ~N[2000-01-01 12:34:15.123456]
            |> NaiveDateTime.convert!(Calendar.Holocene)
-           |> NaiveDateTime.convert!(Calendar.ISO) ==
-           ~N[2000-01-01 12:34:15.123456]
+           |> NaiveDateTime.convert!(Calendar.ISO) == ~N[2000-01-01 12:34:15.123456]
 
     assert NaiveDateTime.convert(~N[2016-02-03 00:00:01], FakeCalendar) ==
-           {:error, :incompatible_calendars}
+             {:error, :incompatible_calendars}
 
     assert NaiveDateTime.convert(~N[1970-01-01 00:00:00], Calendar.Holocene) ==
-           {:ok, Calendar.Holocene.naive_datetime(11970, 1, 1, 0, 0, 0, {0, 0})}
+             {:ok, Calendar.Holocene.naive_datetime(11970, 1, 1, 0, 0, 0, {0, 0})}
+
     assert NaiveDateTime.convert(DateTime.from_unix!(0, :seconds), Calendar.Holocene) ==
-           {:ok, Calendar.Holocene.naive_datetime(11970, 1, 1, 0, 0, 0, {0, 0})}
+             {:ok, Calendar.Holocene.naive_datetime(11970, 1, 1, 0, 0, 0, {0, 0})}
   end
 end
 
@@ -200,86 +213,190 @@ defmodule DateTimeTest do
 
   test "to_string/1" do
     datetime = %DateTime{
-      year: 2000, month: 2, day: 29, zone_abbr: "BRM",
-      hour: 23, minute: 0, second: 7, microsecond: {0, 0},
-      utc_offset: -12600, std_offset: 3600, time_zone: "Brazil/Manaus"
+      year: 2000,
+      month: 2,
+      day: 29,
+      zone_abbr: "BRM",
+      hour: 23,
+      minute: 0,
+      second: 7,
+      microsecond: {0, 0},
+      utc_offset: -12600,
+      std_offset: 3600,
+      time_zone: "Brazil/Manaus"
     }
+
     assert to_string(datetime) == "2000-02-29 23:00:07-02:30 BRM Brazil/Manaus"
   end
 
   test "from_iso8601/1 handles positive and negative offsets" do
-     assert DateTime.from_iso8601("2015-01-24T09:50:07-10:00") |> elem(1) ==
-            %DateTime{microsecond: {0, 0}, month: 1, std_offset: 0, time_zone: "Etc/UTC",
-                      utc_offset: 0, year: 2015, zone_abbr: "UTC", day: 24, hour: 19,
-                      minute: 50, second: 7}
+    assert DateTime.from_iso8601("2015-01-24T09:50:07-10:00")
+           |> elem(1) ==
+             %DateTime{
+               microsecond: {0, 0},
+               month: 1,
+               std_offset: 0,
+               time_zone: "Etc/UTC",
+               utc_offset: 0,
+               year: 2015,
+               zone_abbr: "UTC",
+               day: 24,
+               hour: 19,
+               minute: 50,
+               second: 7
+             }
 
-     assert DateTime.from_iso8601("2015-01-24T09:50:07+10:00") |> elem(1) ==
-            %DateTime{microsecond: {0, 0}, month: 1, std_offset: 0, time_zone: "Etc/UTC",
-                      utc_offset: 0, year: 2015, zone_abbr: "UTC", day: 23, hour: 23,
-                      minute: 50, second: 7}
+    assert DateTime.from_iso8601("2015-01-24T09:50:07+10:00")
+           |> elem(1) ==
+             %DateTime{
+               microsecond: {0, 0},
+               month: 1,
+               std_offset: 0,
+               time_zone: "Etc/UTC",
+               utc_offset: 0,
+               year: 2015,
+               zone_abbr: "UTC",
+               day: 23,
+               hour: 23,
+               minute: 50,
+               second: 7
+             }
   end
 
   test "from_unix/2" do
     # with Unix times back to 0 Gregorian seconds
     min_datetime = %DateTime{
-      calendar: Calendar.ISO, day: 1, hour: 0, microsecond: {0, 0},
-      minute: 0, month: 1, second: 0, std_offset: 0, time_zone: "Etc/UTC",
-      utc_offset: 0, year: 0, zone_abbr: "UTC"
+      calendar: Calendar.ISO,
+      day: 1,
+      hour: 0,
+      microsecond: {0, 0},
+      minute: 0,
+      month: 1,
+      second: 0,
+      std_offset: 0,
+      time_zone: "Etc/UTC",
+      utc_offset: 0,
+      year: 0,
+      zone_abbr: "UTC"
     }
-    assert DateTime.from_unix(-62167219200) == {:ok, min_datetime}
-    assert DateTime.from_unix(-62167219201) == {:error, :invalid_unix_time}
+
+    assert DateTime.from_unix(-62_167_219_200) == {:ok, min_datetime}
+    assert DateTime.from_unix(-62_167_219_201) == {:error, :invalid_unix_time}
 
     max_datetime = %DateTime{
-      calendar: Calendar.ISO, day: 31, hour: 23, microsecond: {0, 0},
-      minute: 59, month: 12, second: 59, std_offset: 0, time_zone: "Etc/UTC",
-      utc_offset: 0, year: 9999, zone_abbr: "UTC"
+      calendar: Calendar.ISO,
+      day: 31,
+      hour: 23,
+      microsecond: {0, 0},
+      minute: 59,
+      month: 12,
+      second: 59,
+      std_offset: 0,
+      time_zone: "Etc/UTC",
+      utc_offset: 0,
+      year: 9999,
+      zone_abbr: "UTC"
     }
 
-    assert DateTime.from_unix(253402300799) == {:ok, max_datetime}
-    assert DateTime.from_unix(253402300800) == {:error, :invalid_unix_time}
+    assert DateTime.from_unix(253_402_300_799) == {:ok, max_datetime}
+    assert DateTime.from_unix(253_402_300_800) == {:error, :invalid_unix_time}
 
     minus_datetime = %DateTime{
-      calendar: Calendar.ISO, day: 31, hour: 23, microsecond: {999999, 6},
-      minute: 59, month: 12, second: 59, std_offset: 0, time_zone: "Etc/UTC",
-      utc_offset: 0, year: 1969, zone_abbr: "UTC"
+      calendar: Calendar.ISO,
+      day: 31,
+      hour: 23,
+      microsecond: {999_999, 6},
+      minute: 59,
+      month: 12,
+      second: 59,
+      std_offset: 0,
+      time_zone: "Etc/UTC",
+      utc_offset: 0,
+      year: 1969,
+      zone_abbr: "UTC"
     }
+
     assert DateTime.from_unix(-1, :microsecond) == {:ok, minus_datetime}
   end
 
   test "from_unix!/2" do
     # with Unix times back to 0 Gregorian seconds
     datetime = %DateTime{
-      calendar: Calendar.ISO, day: 1, hour: 0, microsecond: {0, 0},
-      minute: 0, month: 1, second: 0, std_offset: 0, time_zone: "Etc/UTC",
-      utc_offset: 0, year: 0, zone_abbr: "UTC"
+      calendar: Calendar.ISO,
+      day: 1,
+      hour: 0,
+      microsecond: {0, 0},
+      minute: 0,
+      month: 1,
+      second: 0,
+      std_offset: 0,
+      time_zone: "Etc/UTC",
+      utc_offset: 0,
+      year: 0,
+      zone_abbr: "UTC"
     }
-    assert DateTime.from_unix!(-62167219200) == datetime
+
+    assert DateTime.from_unix!(-62_167_219_200) == datetime
 
     assert_raise ArgumentError, fn ->
-      DateTime.from_unix!(-62167219201)
+      DateTime.from_unix!(-62_167_219_201)
     end
   end
 
   test "to_unix/2 works with Unix times back to 0 Gregorian seconds" do
     # with Unix times back to 0 Gregorian seconds
-    gregorian_0 = %DateTime{calendar: Calendar.ISO, day: 1, hour: 0, microsecond: {0, 0},
-                            minute: 0, month: 1, second: 0, std_offset: 0, time_zone: "Etc/UTC",
-                            utc_offset: 0, year: 0, zone_abbr: "UTC"}
-    assert DateTime.to_unix(gregorian_0) == -62167219200
+    gregorian_0 = %DateTime{
+      calendar: Calendar.ISO,
+      day: 1,
+      hour: 0,
+      microsecond: {0, 0},
+      minute: 0,
+      month: 1,
+      second: 0,
+      std_offset: 0,
+      time_zone: "Etc/UTC",
+      utc_offset: 0,
+      year: 0,
+      zone_abbr: "UTC"
+    }
+
+    assert DateTime.to_unix(gregorian_0) == -62_167_219_200
 
     before_gregorian_0 = %DateTime{gregorian_0 | year: -1}
+
     assert_raise FunctionClauseError, fn ->
       DateTime.to_unix(before_gregorian_0)
     end
   end
 
   test "compare/2" do
-    datetime1 = %DateTime{year: 2000, month: 2, day: 29, zone_abbr: "CET",
-                          hour: 23, minute: 0, second: 7, microsecond: {0, 0},
-                          utc_offset: 3600, std_offset: 0, time_zone: "Europe/Warsaw"}
-    datetime2 = %DateTime{year: 2000, month: 2, day: 29, zone_abbr: "AMT",
-                          hour: 23, minute: 0, second: 7, microsecond: {0, 0},
-                          utc_offset: -14400, std_offset: 0, time_zone: "America/Manaus"}
+    datetime1 = %DateTime{
+      year: 2000,
+      month: 2,
+      day: 29,
+      zone_abbr: "CET",
+      hour: 23,
+      minute: 0,
+      second: 7,
+      microsecond: {0, 0},
+      utc_offset: 3600,
+      std_offset: 0,
+      time_zone: "Europe/Warsaw"
+    }
+
+    datetime2 = %DateTime{
+      year: 2000,
+      month: 2,
+      day: 29,
+      zone_abbr: "AMT",
+      hour: 23,
+      minute: 0,
+      second: 7,
+      microsecond: {0, 0},
+      utc_offset: -14400,
+      std_offset: 0,
+      time_zone: "America/Manaus"
+    }
 
     assert DateTime.compare(datetime1, datetime1) == :eq
     assert DateTime.compare(datetime1, datetime2) == :lt
@@ -287,59 +404,143 @@ defmodule DateTimeTest do
   end
 
   test "convert/2" do
-    datetime_iso = %DateTime{year: 2000, month: 2, day: 29, zone_abbr: "CET",
-                             hour: 23, minute: 0, second: 7, microsecond: {0, 0},
-                             utc_offset: 3600, std_offset: 0, time_zone: "Europe/Warsaw"}
-    datetime_hol = %DateTime{year: 12000, month: 2, day: 29, zone_abbr: "CET",
-                             hour: 23, minute: 0, second: 7, microsecond: {0, 0},
-                             utc_offset: 3600, std_offset: 0, time_zone: "Europe/Warsaw",
-                             calendar: Calendar.Holocene}
+    datetime_iso = %DateTime{
+      year: 2000,
+      month: 2,
+      day: 29,
+      zone_abbr: "CET",
+      hour: 23,
+      minute: 0,
+      second: 7,
+      microsecond: {0, 0},
+      utc_offset: 3600,
+      std_offset: 0,
+      time_zone: "Europe/Warsaw"
+    }
+
+    datetime_hol = %DateTime{
+      year: 12000,
+      month: 2,
+      day: 29,
+      zone_abbr: "CET",
+      hour: 23,
+      minute: 0,
+      second: 7,
+      microsecond: {0, 0},
+      utc_offset: 3600,
+      std_offset: 0,
+      time_zone: "Europe/Warsaw",
+      calendar: Calendar.Holocene
+    }
 
     assert DateTime.convert(datetime_iso, Calendar.Holocene) == {:ok, datetime_hol}
 
     assert datetime_iso
            |> DateTime.convert!(Calendar.Holocene)
-           |> DateTime.convert!(Calendar.ISO) ==
-           datetime_iso
+           |> DateTime.convert!(Calendar.ISO) == datetime_iso
 
     assert %{datetime_iso | microsecond: {123, 6}}
            |> DateTime.convert!(Calendar.Holocene)
-           |> DateTime.convert!(Calendar.ISO) ==
-           %{datetime_iso | microsecond: {123, 6}}
+           |> DateTime.convert!(Calendar.ISO) == %{datetime_iso | microsecond: {123, 6}}
 
-    assert DateTime.convert(datetime_iso, FakeCalendar) ==
-           {:error, :incompatible_calendars}
+    assert DateTime.convert(datetime_iso, FakeCalendar) == {:error, :incompatible_calendars}
   end
 
   test "from_iso8601/1 with tz offsets" do
-    assert DateTime.from_iso8601("2017-06-02T14:00:00+01:00") |> elem(1) ==
-           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
-                     hour: 13, minute: 0, second: 0, microsecond: {0, 0},
-                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+    assert DateTime.from_iso8601("2017-06-02T14:00:00+01:00")
+           |> elem(1) ==
+             %DateTime{
+               year: 2017,
+               month: 6,
+               day: 2,
+               zone_abbr: "UTC",
+               hour: 13,
+               minute: 0,
+               second: 0,
+               microsecond: {0, 0},
+               utc_offset: 0,
+               std_offset: 0,
+               time_zone: "Etc/UTC"
+             }
 
-    assert DateTime.from_iso8601("2017-06-02T14:00:00-04:00") |> elem(1) ==
-           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
-                     hour: 18, minute: 0, second: 0, microsecond: {0, 0},
-                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+    assert DateTime.from_iso8601("2017-06-02T14:00:00-04:00")
+           |> elem(1) ==
+             %DateTime{
+               year: 2017,
+               month: 6,
+               day: 2,
+               zone_abbr: "UTC",
+               hour: 18,
+               minute: 0,
+               second: 0,
+               microsecond: {0, 0},
+               utc_offset: 0,
+               std_offset: 0,
+               time_zone: "Etc/UTC"
+             }
 
-    assert DateTime.from_iso8601("2017-06-02T14:00:00+0100") |> elem(1) ==
-           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
-                     hour: 13, minute: 0, second: 0, microsecond: {0, 0},
-                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+    assert DateTime.from_iso8601("2017-06-02T14:00:00+0100")
+           |> elem(1) ==
+             %DateTime{
+               year: 2017,
+               month: 6,
+               day: 2,
+               zone_abbr: "UTC",
+               hour: 13,
+               minute: 0,
+               second: 0,
+               microsecond: {0, 0},
+               utc_offset: 0,
+               std_offset: 0,
+               time_zone: "Etc/UTC"
+             }
 
-    assert DateTime.from_iso8601("2017-06-02T14:00:00-0400") |> elem(1) ==
-           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
-                     hour: 18, minute: 0, second: 0, microsecond: {0, 0},
-                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+    assert DateTime.from_iso8601("2017-06-02T14:00:00-0400")
+           |> elem(1) ==
+             %DateTime{
+               year: 2017,
+               month: 6,
+               day: 2,
+               zone_abbr: "UTC",
+               hour: 18,
+               minute: 0,
+               second: 0,
+               microsecond: {0, 0},
+               utc_offset: 0,
+               std_offset: 0,
+               time_zone: "Etc/UTC"
+             }
 
-    assert DateTime.from_iso8601("2017-06-02T14:00:00+01") |> elem(1) ==
-           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
-                     hour: 13, minute: 0, second: 0, microsecond: {0, 0},
-                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+    assert DateTime.from_iso8601("2017-06-02T14:00:00+01")
+           |> elem(1) ==
+             %DateTime{
+               year: 2017,
+               month: 6,
+               day: 2,
+               zone_abbr: "UTC",
+               hour: 13,
+               minute: 0,
+               second: 0,
+               microsecond: {0, 0},
+               utc_offset: 0,
+               std_offset: 0,
+               time_zone: "Etc/UTC"
+             }
 
-    assert DateTime.from_iso8601("2017-06-02T14:00:00-04") |> elem(1) ==
-           %DateTime{year: 2017, month: 6, day: 2, zone_abbr: "UTC",
-                     hour: 18, minute: 0, second: 0, microsecond: {0, 0},
-                     utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"}
+    assert DateTime.from_iso8601("2017-06-02T14:00:00-04")
+           |> elem(1) ==
+             %DateTime{
+               year: 2017,
+               month: 6,
+               day: 2,
+               zone_abbr: "UTC",
+               hour: 18,
+               minute: 0,
+               second: 0,
+               microsecond: {0, 0},
+               utc_offset: 0,
+               std_offset: 0,
+               time_zone: "Etc/UTC"
+             }
   end
 end


### PR DESCRIPTION
Formatter worked just dandy, but I added a new line before a few pipes then re-ran it. 

## 1) After running the formatter once:

![screenshot 2017-10-10 21 35 19](https://user-images.githubusercontent.com/3220620/31422658-22970d20-ae04-11e7-91ef-caef9cde8a62.png)

## 2) After adding a return before the pipe, then rerunning the formatter
![screenshot 2017-10-10 21 36 05](https://user-images.githubusercontent.com/3220620/31422668-2ffaaba2-ae04-11e7-8a49-f1cf0dd19cba.png)

I find #2 easier to read, personally, but if you'd prefer #1 then I'll edit and commit it. 