### PR TITLE
Failing test for :simple_one_for_one start_child

### DIFF
--- a/lib/elixir/test/elixir/supervisor_test.exs
+++ b/lib/elixir/test/elixir/supervisor_test.exs
@@ -38,6 +38,14 @@ defmodule SupervisorTest do
     end
   end
 
+  defmodule Stack.SimpleSup do
+    use Supervisor
+
+    def init(_arg) do
+      Supervisor.init([Stack], strategy: :simple_one_for_one)
+    end
+  end
+
   test "generates child_spec/1" do
     assert Stack.Sup.child_spec([:hello]) == %{
       id: Stack.Sup,
@@ -207,6 +215,12 @@ defmodule SupervisorTest do
     assert Supervisor.terminate_child(pid, Stack) == :ok
     assert Supervisor.delete_child(pid, Stack) == :ok
     Supervisor.stop(pid)
+  end
+
+  test "start_child with simple_one_for_one" do
+    {:ok, pid} = Supervisor.start_link(Stack.SimpleSup, :ok)
+    {:ok, stack} = Supervisor.start_child(pid, [{[:hello], []}])
+    assert GenServer.call(stack, :pop) == :hello
   end
 
   defp wait_until_registered(name) do


### PR DESCRIPTION
I am having trouble updating my simple_one_for_one supervisors to the new supervisor format [introduced in Elixir 1.5](https://elixir-lang.org/blog/2017/07/25/elixir-v1-5-0-released/#streamlined-child-specs).

Specifically, whenever I call `start_child`, I get something like this:

```
     ** (MatchError) no match of right hand side value: {:error, {:EXIT, {:undef, [{IM.Salesforce.Connection.Server, :start_link, [[], "865baf73-0836-4e6b-9bef-a88cd51be3c9"], []}, {:supervisor, :do_start_child_i, 3, [file: 'supervisor.erl', line: 381]}, {:supervisor, :handle_call, 3, [file: 'supervisor.erl', line: 406]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 636]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 665]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 247]}]}}}
         (im) lib/im/salesforce/connection/registry.ex:37: IM.Salesforce.Connection.Registry.handle_call/3
         (stdlib) gen_server.erl:636: :gen_server.try_handle_call/4
         (stdlib) gen_server.erl:665: :gen_server.handle_msg/6
         (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```

I have included a failing test in this pull request to demonstrate my usage.