### PR TITLE
Better `mix format` error message when it crashes during formatting file

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -177,6 +177,10 @@ defmodule Mix.Tasks.Format do
     end
 
     {not_equivalent, not_formatted}
+  rescue
+    e ->
+      Mix.shell().error("mix format failed when parsing file: #{file}")
+      reraise e, System.stacktrace()
   end
 
   defp check!({[], []}) do

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -145,4 +145,16 @@ defmodule Mix.Tasks.FormatTest do
       Mix.Tasks.Format.run([])
     end
   end
+
+  test "raises SyntaxError when parsing invalid source file", context do
+    in_tmp context.test, fn ->
+      File.write!("a.ex", """
+      defmodule <%= module %>.Bar do end
+      """)
+
+      assert_raise SyntaxError, ~r"nofile:1: syntax error before: '='", fn ->
+        Mix.Tasks.Format.run(["a.ex"])
+      end
+    end
+  end
 end


### PR DESCRIPTION
I messed up `.formatter.exs` configuration, and mistakenly included my HTML template files in the formatting path. The `mix format` task died suddenly on me without a nice error message, giving me:

```
$ mix format lib/ui/templates/layout/no_user.html.slim
** (SyntaxError) nofile:5: syntax error before: http
    (elixir) lib/code.ex:329: Code.format_string!/2
    (mix) lib/mix/tasks/format.ex:148: Mix.Tasks.Format.format_file/4
    (elixir) lib/enum.ex:1899: Enum."-reduce/3-lists^foldl/2-0-"/3
    (mix) lib/mix/tasks/format.ex:78: Mix.Tasks.Format.run/1
    (mix) lib/mix/task.ex:317: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:68: Mix.CLI.run_task/2
```

this change updates the above error message with important information, like the file path that the error happened on. I also kept the original syntax error message and line number as it might come in handy. The message format I cam up with is:

```
$ mix format lib/ui/templates/layout/no_user.html.slim
** (Mix) mix format failed when attempting
to parse the file:

lib/ui/templates/layout/no_user.html.slim

Error at line 5:
  syntax error before: http
```

but I am open to suggestion to improve it.
