### PR TITLE
Run code formatter on tokenizer_text.exs

### DIFF
--- a/lib/eex/test/eex/tokenizer_test.exs
+++ b/lib/eex/test/eex/tokenizer_test.exs
@@ -40,16 +40,15 @@ defmodule EEx.TokenizerTest do
     <% foo %>
     '''
 
-    assert T.tokenize(string, 1) == {
-             :ok,
-             [
-               {:text, 'foo '},
-               {:expr, 1, '=', ' bar\n\nbaz '},
-               {:text, '\n'},
-               {:expr, 4, '', ' foo '},
-               {:text, '\n'}
-             ]
-           }
+    exprs = [
+      {:text, 'foo '},
+      {:expr, 1, '=', ' bar\n\nbaz '},
+      {:text, '\n'},
+      {:expr, 4, '', ' foo '},
+      {:text, '\n'}
+    ]
+
+    assert T.tokenize(string, 1) == {:ok, exprs}
   end
 
   test "quotation" do
@@ -57,132 +56,130 @@ defmodule EEx.TokenizerTest do
   end
 
   test "quotation with do/end" do
-    assert T.tokenize('foo <%% true do %>bar<%% end %>', 1) == {:ok, [{:text, 'foo <% true do %>bar<% end %>'}]}
+    assert T.tokenize('foo <%% true do %>bar<%% end %>', 1) == {
+             :ok,
+             [{:text, 'foo <% true do %>bar<% end %>'}]
+           }
   end
 
   test "quotation with interpolation" do
-    assert T.tokenize('a <%% b <%= c %> <%= d %> e %> f', 1) == {
-             :ok,
-             [
-               {:text, 'a <% b '},
-               {:expr, 1, '=', ' c '},
-               {:text, ' '},
-               {:expr, 1, '=', ' d '},
-               {:text, ' e %> f'}
-             ]
-           }
+    exprs = [
+      {:text, 'a <% b '},
+      {:expr, 1, '=', ' c '},
+      {:text, ' '},
+      {:expr, 1, '=', ' d '},
+      {:text, ' e %> f'}
+    ]
 
-    assert T.tokenize('<%%% a <%%= b %> c %>', 1) == {
-             :ok,
-             [
-               {:text, '<%% a <%= b %> c %>'}
-             ]
-           }
+    assert T.tokenize('a <%% b <%= c %> <%= d %> e %> f', 1) == {:ok, exprs}
+  end
+
+  test "improperly formatted quotation with interpolation" do
+    exprs = [
+      {:text, '<%% a <%= b %> c %>'}
+    ]
+
+    assert T.tokenize('<%%% a <%%= b %> c %>', 1) == {:ok, exprs}
   end
 
   test "comments" do
-    assert T.tokenize('foo <%# true %>', 1) == {
-             :ok,
-             [
-               {:text, 'foo '}
-             ]
-           }
+    exprs = [
+      {:text, 'foo '}
+    ]
+
+    assert T.tokenize('foo <%# true %>', 1) == {:ok, exprs}
   end
 
   test "comments with do/end" do
-    assert T.tokenize('foo <%# true do %>bar<%# end %>', 1) == {
-             :ok,
-             [
-               {:text, 'foo bar'}
-             ]
-           }
+    exprs = [
+      {:text, 'foo bar'}
+    ]
+
+    assert T.tokenize('foo <%# true do %>bar<%# end %>', 1) == {:ok, exprs}
   end
 
   test "strings with embedded do end" do
-    assert T.tokenize('foo <% if true do %>bar<% end %>', 1) == {
-             :ok,
-             [
-               {:text, 'foo '},
-               {:start_expr, 1, '', ' if true do '},
-               {:text, 'bar'},
-               {:end_expr, 1, '', ' end '}
-             ]
-           }
+    exprs = [
+      {:text, 'foo '},
+      {:start_expr, 1, '', ' if true do '},
+      {:text, 'bar'},
+      {:end_expr, 1, '', ' end '}
+    ]
+
+    assert T.tokenize('foo <% if true do %>bar<% end %>', 1) == {:ok, exprs}
   end
 
   test "strings with embedded -> end" do
+    exprs = [
+      {:text, 'foo '},
+      {:start_expr, 1, '', ' cond do '},
+      {:middle_expr, 1, '', ' false -> '},
+      {:text, 'bar'},
+      {:middle_expr, 1, '', ' true -> '},
+      {:text, 'baz'},
+      {:end_expr, 1, '', ' end '}
+    ]
+
     assert T.tokenize('foo <% cond do %><% false -> %>bar<% true -> %>baz<% end %>', 1) == {
              :ok,
-             [
-               {:text, 'foo '},
-               {:start_expr, 1, '', ' cond do '},
-               {:middle_expr, 1, '', ' false -> '},
-               {:text, 'bar'},
-               {:middle_expr, 1, '', ' true -> '},
-               {:text, 'baz'},
-               {:end_expr, 1, '', ' end '}
-             ]
+             exprs
            }
   end
 
   test "strings with embedded keywords blocks" do
-    assert T.tokenize('foo <% if true do %>bar<% else %>baz<% end %>', 1) == {
-             :ok,
-             [
-               {:text, 'foo '},
-               {:start_expr, 1, '', ' if true do '},
-               {:text, 'bar'},
-               {:middle_expr, 1, '', ' else '},
-               {:text, 'baz'},
-               {:end_expr, 1, '', ' end '}
-             ]
-           }
+    exprs =
+      [
+        {:text, 'foo '},
+        {:start_expr, 1, '', ' if true do '},
+        {:text, 'bar'},
+        {:middle_expr, 1, '', ' else '},
+        {:text, 'baz'},
+        {:end_expr, 1, '', ' end '}
+      ]
+
+    assert T.tokenize('foo <% if true do %>bar<% else %>baz<% end %>', 1) == {:ok, exprs}
   end
 
   test "trim mode" do
     template = '\t<%= if true do %> \n TRUE \n  <% else %>\n FALSE \n  <% end %>  '
 
-    assert T.tokenize(template, 1, trim: true) == {
-             :ok,
-             [
-               {:start_expr, 1, '=', ' if true do '},
-               {:text, ' TRUE \n'},
-               {:middle_expr, 3, '', ' else '},
-               {:text, ' FALSE \n'},
-               {:end_expr, 5, '', ' end '}
-             ]
-           }
+    exprs = [
+      {:start_expr, 1, '=', ' if true do '},
+      {:text, ' TRUE \n'},
+      {:middle_expr, 3, '', ' else '},
+      {:text, ' FALSE \n'},
+      {:end_expr, 5, '', ' end '}
+    ]
+
+    assert T.tokenize(template, 1, trim: true) == {:ok, exprs}
   end
 
   test "trim mode with comment" do
-    assert T.tokenize('  <%# comment %>  \n123', 1, trim: true) == {
-             :ok,
-             [
-               {:text, '123'}
-             ]
-           }
+    exprs = [
+      {:text, '123'}
+    ]
+
+    assert T.tokenize('  <%# comment %>  \n123', 1, trim: true) == {:ok, exprs}
   end
 
   test "trim mode with CRLF" do
-    assert T.tokenize('0\r\n  <%= 12 %>  \r\n34', 1, trim: true) == {
-             :ok,
-             [
-               {:text, '0\r\n'},
-               {:expr, 2, '=', ' 12 '},
-               {:text, '34'}
-             ]
-           }
+    exprs = [
+      {:text, '0\r\n'},
+      {:expr, 2, '=', ' 12 '},
+      {:text, '34'}
+    ]
+
+    assert T.tokenize('0\r\n  <%= 12 %>  \r\n34', 1, trim: true) == {:ok, exprs}
   end
 
   test "trim mode set to false" do
-    assert T.tokenize(' <%= 12 %> \n', 1, trim: false) == {
-             :ok,
-             [
-               {:text, ' '},
-               {:expr, 1, '=', ' 12 '},
-               {:text, ' \n'}
-             ]
-           }
+    exprs = [
+      {:text, ' '},
+      {:expr, 1, '=', ' 12 '},
+      {:text, ' \n'}
+    ]
+
+    assert T.tokenize(' <%= 12 %> \n', 1, trim: false) == {:ok, exprs}
   end
 
   test "trim mode no false positives" do

--- a/lib/eex/test/eex/tokenizer_test.exs
+++ b/lib/eex/test/eex/tokenizer_test.exs
@@ -1,4 +1,4 @@
-Code.require_file "../test_helper.exs", __DIR__
+Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule EEx.TokenizerTest do
   use ExUnit.Case, async: true
@@ -13,148 +13,176 @@ defmodule EEx.TokenizerTest do
   end
 
   test "strings with embedded code" do
-    assert T.tokenize('foo <% bar %>', 1) ==
-           {:ok, [{:text, 'foo '}, {:expr, 1, '', ' bar '}]}
+    assert T.tokenize('foo <% bar %>', 1) == {:ok, [{:text, 'foo '}, {:expr, 1, '', ' bar '}]}
   end
 
   test "strings with embedded equals code" do
-    assert T.tokenize('foo <%= bar %>', 1) ==
-           {:ok, [{:text, 'foo '}, {:expr, 1, '=', ' bar '}]}
+    assert T.tokenize('foo <%= bar %>', 1) == {:ok, [{:text, 'foo '}, {:expr, 1, '=', ' bar '}]}
   end
 
   test "strings with embedded slash code" do
-    assert T.tokenize('foo <%/ bar %>', 1) ==
-           {:ok, [{:text, 'foo '}, {:expr, 1, '/', ' bar '}]}
+    assert T.tokenize('foo <%/ bar %>', 1) == {:ok, [{:text, 'foo '}, {:expr, 1, '/', ' bar '}]}
   end
 
   test "strings with embedded pipe code" do
-    assert T.tokenize('foo <%| bar %>', 1) ==
-           {:ok, [{:text, 'foo '}, {:expr, 1, '|', ' bar '}]}
+    assert T.tokenize('foo <%| bar %>', 1) == {:ok, [{:text, 'foo '}, {:expr, 1, '|', ' bar '}]}
   end
 
   test "strings with more than one line" do
-    assert T.tokenize('foo\n<%= bar %>', 1) ==
-           {:ok, [{:text, 'foo\n'}, {:expr, 2, '=', ' bar '}]}
+    assert T.tokenize('foo\n<%= bar %>', 1) == {:ok, [{:text, 'foo\n'}, {:expr, 2, '=', ' bar '}]}
   end
 
   test "strings with more than one line and expression with more than one line" do
     string = '''
-foo <%= bar
+    foo <%= bar
 
-baz %>
-<% foo %>
-'''
+    baz %>
+    <% foo %>
+    '''
 
-    assert T.tokenize(string, 1) == {:ok, [
-      {:text, 'foo '},
-      {:expr, 1, '=', ' bar\n\nbaz '},
-      {:text, '\n'},
-      {:expr, 4, '', ' foo '},
-      {:text, '\n'}
-    ]}
+    assert T.tokenize(string, 1) == {
+             :ok,
+             [
+               {:text, 'foo '},
+               {:expr, 1, '=', ' bar\n\nbaz '},
+               {:text, '\n'},
+               {:expr, 4, '', ' foo '},
+               {:text, '\n'}
+             ]
+           }
   end
 
   test "quotation" do
-    assert T.tokenize('foo <%% true %>', 1) == {:ok, [
-      {:text, 'foo <% true %>'}
-    ]}
+    assert T.tokenize('foo <%% true %>', 1) == {:ok, [{:text, 'foo <% true %>'}]}
   end
 
   test "quotation with do/end" do
-    assert T.tokenize('foo <%% true do %>bar<%% end %>', 1) == {:ok, [
-      {:text, 'foo <% true do %>bar<% end %>'}
-    ]}
+    assert T.tokenize('foo <%% true do %>bar<%% end %>', 1) == {:ok, [{:text, 'foo <% true do %>bar<% end %>'}]}
   end
 
   test "quotation with interpolation" do
-    assert T.tokenize('a <%% b <%= c %> <%= d %> e %> f', 1) == {:ok, [
-      {:text, 'a <% b '},
-      {:expr, 1, '=', ' c '},
-      {:text, ' '},
-      {:expr, 1, '=', ' d '},
-      {:text, ' e %> f'}
-    ]}
+    assert T.tokenize('a <%% b <%= c %> <%= d %> e %> f', 1) == {
+             :ok,
+             [
+               {:text, 'a <% b '},
+               {:expr, 1, '=', ' c '},
+               {:text, ' '},
+               {:expr, 1, '=', ' d '},
+               {:text, ' e %> f'}
+             ]
+           }
 
-    assert T.tokenize('<%%% a <%%= b %> c %>', 1) == {:ok, [
-      {:text, '<%% a <%= b %> c %>'}
-    ]}
+    assert T.tokenize('<%%% a <%%= b %> c %>', 1) == {
+             :ok,
+             [
+               {:text, '<%% a <%= b %> c %>'}
+             ]
+           }
   end
 
   test "comments" do
-    assert T.tokenize('foo <%# true %>', 1) == {:ok, [
-      {:text, 'foo '}
-    ]}
+    assert T.tokenize('foo <%# true %>', 1) == {
+             :ok,
+             [
+               {:text, 'foo '}
+             ]
+           }
   end
 
   test "comments with do/end" do
-    assert T.tokenize('foo <%# true do %>bar<%# end %>', 1) == {:ok, [
-      {:text, 'foo bar'}
-    ]}
+    assert T.tokenize('foo <%# true do %>bar<%# end %>', 1) == {
+             :ok,
+             [
+               {:text, 'foo bar'}
+             ]
+           }
   end
 
   test "strings with embedded do end" do
-    assert T.tokenize('foo <% if true do %>bar<% end %>', 1) == {:ok, [
-      {:text, 'foo '},
-      {:start_expr, 1, '', ' if true do '},
-      {:text, 'bar'},
-      {:end_expr, 1, '', ' end '}
-    ]}
+    assert T.tokenize('foo <% if true do %>bar<% end %>', 1) == {
+             :ok,
+             [
+               {:text, 'foo '},
+               {:start_expr, 1, '', ' if true do '},
+               {:text, 'bar'},
+               {:end_expr, 1, '', ' end '}
+             ]
+           }
   end
 
   test "strings with embedded -> end" do
-    assert T.tokenize('foo <% cond do %><% false -> %>bar<% true -> %>baz<% end %>', 1) == {:ok, [
-      {:text, 'foo '},
-      {:start_expr, 1, '', ' cond do '},
-      {:middle_expr, 1, '', ' false -> '},
-      {:text, 'bar'},
-      {:middle_expr, 1, '', ' true -> '},
-      {:text, 'baz'},
-      {:end_expr, 1, '', ' end '}
-    ]}
+    assert T.tokenize('foo <% cond do %><% false -> %>bar<% true -> %>baz<% end %>', 1) == {
+             :ok,
+             [
+               {:text, 'foo '},
+               {:start_expr, 1, '', ' cond do '},
+               {:middle_expr, 1, '', ' false -> '},
+               {:text, 'bar'},
+               {:middle_expr, 1, '', ' true -> '},
+               {:text, 'baz'},
+               {:end_expr, 1, '', ' end '}
+             ]
+           }
   end
 
   test "strings with embedded keywords blocks" do
-    assert T.tokenize('foo <% if true do %>bar<% else %>baz<% end %>', 1) == {:ok, [
-      {:text, 'foo '},
-      {:start_expr, 1, '', ' if true do '},
-      {:text, 'bar'},
-      {:middle_expr, 1, '', ' else '},
-      {:text, 'baz'},
-      {:end_expr, 1, '', ' end '}
-    ]}
+    assert T.tokenize('foo <% if true do %>bar<% else %>baz<% end %>', 1) == {
+             :ok,
+             [
+               {:text, 'foo '},
+               {:start_expr, 1, '', ' if true do '},
+               {:text, 'bar'},
+               {:middle_expr, 1, '', ' else '},
+               {:text, 'baz'},
+               {:end_expr, 1, '', ' end '}
+             ]
+           }
   end
 
   test "trim mode" do
     template = '\t<%= if true do %> \n TRUE \n  <% else %>\n FALSE \n  <% end %>  '
-    assert T.tokenize(template, 1, trim: true) == {:ok, [
-      {:start_expr, 1, '=', ' if true do '},
-      {:text, ' TRUE \n'},
-      {:middle_expr, 3, '', ' else '},
-      {:text, ' FALSE \n'},
-      {:end_expr, 5, '', ' end '}
-    ]}
+
+    assert T.tokenize(template, 1, trim: true) == {
+             :ok,
+             [
+               {:start_expr, 1, '=', ' if true do '},
+               {:text, ' TRUE \n'},
+               {:middle_expr, 3, '', ' else '},
+               {:text, ' FALSE \n'},
+               {:end_expr, 5, '', ' end '}
+             ]
+           }
   end
 
   test "trim mode with comment" do
-    assert T.tokenize('  <%# comment %>  \n123', 1, trim: true) == {:ok, [
-      {:text, '123'}
-    ]}
+    assert T.tokenize('  <%# comment %>  \n123', 1, trim: true) == {
+             :ok,
+             [
+               {:text, '123'}
+             ]
+           }
   end
 
   test "trim mode with CRLF" do
-    assert T.tokenize('0\r\n  <%= 12 %>  \r\n34', 1, trim: true) == {:ok, [
-      {:text, '0\r\n'},
-      {:expr, 2, '=', ' 12 '},
-      {:text, '34'}
-    ]}
+    assert T.tokenize('0\r\n  <%= 12 %>  \r\n34', 1, trim: true) == {
+             :ok,
+             [
+               {:text, '0\r\n'},
+               {:expr, 2, '=', ' 12 '},
+               {:text, '34'}
+             ]
+           }
   end
 
   test "trim mode set to false" do
-    assert T.tokenize(' <%= 12 %> \n', 1, trim: false) == {:ok, [
-      {:text, ' '},
-      {:expr, 1, '=', ' 12 '},
-      {:text, ' \n'}
-    ]}
+    assert T.tokenize(' <%= 12 %> \n', 1, trim: false) == {
+             :ok,
+             [
+               {:text, ' '},
+               {:expr, 1, '=', ' 12 '},
+               {:text, ' \n'}
+             ]
+           }
   end
 
   test "trim mode no false positives" do


### PR DESCRIPTION
Formatter worked great. 

## Note
These sorts of expressions feel a bit awkward, but I can't really think of a better way and it's just a test:

![screenshot 2017-10-11 11 08 01](https://user-images.githubusercontent.com/3220620/31458278-787533a0-ae74-11e7-9cc3-44faae4eaab5.png)
