### PR TITLE
Run the code formatter on Protocol

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -19,23 +19,23 @@ defmodule Protocol do
   defmacro def({name, _, args}) when is_atom(name) and is_list(args) do
     arity = length(args)
 
-    type_args = :lists.map(fn _ -> quote(do: term) end,
-                           :lists.seq(2, arity))
+    type_args = :lists.map(fn _ -> quote(do: term) end, :lists.seq(2, arity))
     type_args = [quote(do: t) | type_args]
 
-    call_args = :lists.map(fn pos -> Macro.var(String.to_atom("var" <> Integer.to_string(pos)), __MODULE__) end,
-                           :lists.seq(2, arity))
+    varify = fn pos -> Macro.var(String.to_atom("var" <> Integer.to_string(pos)), __MODULE__) end
+    call_args = :lists.map(varify, :lists.seq(2, arity))
+
     call_args = [quote(do: term) | call_args]
 
     quote do
-      name  = unquote(name)
+      name = unquote(name)
       arity = unquote(arity)
 
       @functions [{name, arity} | @functions]
 
       # Generate a fake definition with the user
       # signature that will be used by docs
-      Kernel.def unquote(name)(unquote_splicing(args))
+      Kernel.def(unquote(name)(unquote_splicing(args)))
 
       # Generate the actual implementation
       Kernel.def unquote(name)(unquote_splicing(call_args)) do
@@ -66,14 +66,14 @@ defmodule Protocol do
   defp assert_protocol!(module, extra) do
     case Code.ensure_compiled(module) do
       {:module, ^module} -> :ok
-      _ -> raise ArgumentError, "#{inspect module} is not available" <> extra
+      _ -> raise ArgumentError, "#{inspect(module)} is not available" <> extra
     end
 
     try do
       module.__protocol__(:module)
     rescue
       UndefinedFunctionError ->
-        raise ArgumentError, "#{inspect module} is not a protocol" <> extra
+        raise ArgumentError, "#{inspect(module)} is not a protocol" <> extra
     end
 
     :ok
@@ -95,22 +95,22 @@ defmodule Protocol do
 
     case Code.ensure_compiled(impl) do
       {:module, ^impl} -> :ok
-      _ -> raise ArgumentError,
-             "#{inspect impl} is not available" <> extra
+      _ -> raise ArgumentError, "#{inspect(impl)} is not available" <> extra
     end
 
     try do
       impl.__impl__(:protocol)
     rescue
       UndefinedFunctionError ->
-        raise ArgumentError,
-          "#{inspect impl} is not an implementation of a protocol" <> extra
+        raise ArgumentError, "#{inspect(impl)} is not an implementation of a protocol" <> extra
     else
       ^protocol ->
         :ok
+
       other ->
         raise ArgumentError,
-          "expected #{inspect impl} to be an implementation of #{inspect protocol}, got: #{inspect other}" <> extra
+              "expected #{inspect(impl)} to be an implementation of #{inspect(protocol)}" <>
+                ", got: #{inspect(other)}" <> extra
     end
   end
 
@@ -144,15 +144,14 @@ defmodule Protocol do
       true
 
   """
-  @spec extract_protocols([charlist | String.t]) :: [atom]
+  @spec extract_protocols([charlist | String.t()]) :: [atom]
   def extract_protocols(paths) do
-    extract_matching_by_attribute paths, 'Elixir.',
-      fn module, attributes ->
-        case attributes[:protocol] do
-          [fallback_to_any: _] -> module
-          _ -> nil
-        end
+    extract_matching_by_attribute(paths, 'Elixir.', fn module, attributes ->
+      case attributes[:protocol] do
+        [fallback_to_any: _] -> module
+        _ -> nil
       end
+    end)
   end
 
   @doc """
@@ -174,23 +173,23 @@ defmodule Protocol do
       true
 
   """
-  @spec extract_impls(module, [charlist | String.t]) :: [atom]
+  @spec extract_impls(module, [charlist | String.t()]) :: [atom]
   def extract_impls(protocol, paths) when is_atom(protocol) do
     prefix = Atom.to_charlist(protocol) ++ '.'
-    extract_matching_by_attribute paths, prefix, fn
-      _mod, attributes ->
-        case attributes[:protocol_impl] do
-          [protocol: ^protocol, for: for] -> for
-          _ -> nil
-        end
-    end
+
+    extract_matching_by_attribute(paths, prefix, fn _mod, attributes ->
+      case attributes[:protocol_impl] do
+        [protocol: ^protocol, for: for] -> for
+        _ -> nil
+      end
+    end)
   end
 
   defp extract_matching_by_attribute(paths, prefix, callback) do
     for path <- paths,
-       file <- list_dir(path),
-       mod = extract_from_file(path, file, prefix, callback),
-       do: mod
+        file <- list_dir(path),
+        mod = extract_from_file(path, file, prefix, callback),
+        do: mod
   end
 
   defp list_dir(path) when is_list(path) do
@@ -212,8 +211,9 @@ defmodule Protocol do
     case :beam_lib.chunks(file, [:attributes]) do
       {:ok, {module, [attributes: attributes]}} ->
         callback.(module, attributes)
-       _ ->
-         nil
+
+      _ ->
+        nil
     end
   end
 
@@ -250,9 +250,9 @@ defmodule Protocol do
   it will be loaded.
   """
   @spec consolidate(module, [module]) ::
-    {:ok, binary} |
-    {:error, :not_a_protocol} |
-    {:error, :no_beam_info}
+          {:ok, binary}
+          | {:error, :not_a_protocol}
+          | {:error, :no_beam_info}
   def consolidate(protocol, types) when is_atom(protocol) do
     with {:ok, ast_info, chunks_info} <- beam_protocol(protocol),
          {:ok, code} <- change_debug_info(ast_info, types),
@@ -262,17 +262,28 @@ defmodule Protocol do
   defp beam_protocol(protocol) do
     chunk_ids = [:abstract_code, :attributes, :compile_info, 'ExDc']
     opts = [:allow_missing_chunks]
+
     case :beam_lib.chunks(beam_file(protocol), chunk_ids, opts) do
-      {:ok, {^protocol, [{:abstract_code, {_raw, abstract_code}},
-                         {:attributes, attributes},
-                         {:compile_info, compile_info},
-                         {'ExDc', docs}]}} ->
+      {
+        :ok,
+        {
+          ^protocol,
+          [
+            {:abstract_code, {_raw, abstract_code}},
+            {:attributes, attributes},
+            {:compile_info, compile_info},
+            {'ExDc', docs}
+          ]
+        }
+      } ->
         case attributes[:protocol] do
           [fallback_to_any: any] ->
             {:ok, {protocol, any, abstract_code}, {compile_info, docs}}
+
           _ ->
             {:error, :not_a_protocol}
         end
+
       _ ->
         {:error, :no_beam_info}
     end
@@ -288,72 +299,137 @@ defmodule Protocol do
   # Change the debug information to the optimized
   # impl_for/1 dispatch version.
   defp change_debug_info({protocol, any, code}, types) do
-    types   = if any, do: types, else: List.delete(types, Any)
-    all     = [Any] ++ for {_guard, mod} <- __builtin__(), do: mod
+    types = if any, do: types, else: List.delete(types, Any)
+    all = [Any] ++ for {_guard, mod} <- __builtin__(), do: mod
     structs = types -- all
+
     case change_impl_for(code, protocol, types, structs, false, []) do
       {:ok, ret} -> {:ok, ret}
-      other      -> other
+      other -> other
     end
   end
 
-  defp change_impl_for([{:function, line, :__protocol__, 1, clauses} | tail], protocol, types, structs, _, acc) do
+  defp change_impl_for(
+         [{:function, line, :__protocol__, 1, clauses} | tail],
+         protocol,
+         types,
+         structs,
+         _,
+         acc
+       ) do
     abstract_types = :erl_parse.abstract(:lists.usort(types))
 
-    clauses = :lists.map(fn
-      {:clause, l, [{:atom, _, :consolidated?}], [], [{:atom, _, _}]} ->
-        {:clause, l, [{:atom, 0, :consolidated?}], [], [{:atom, 0, true}]}
-      {:clause, l, [{:atom, _, :impls}], [], [{:atom, _, _}]} ->
-        {:clause, l, [{:atom, 0, :impls}], [], [{:tuple, 0, [{:atom, 0, :consolidated}, abstract_types]}]}
-      {:clause, _, _, _, _} = c ->
-        c
-    end, clauses)
+    clauses =
+      :lists.map(
+        fn
+          {:clause, l, [{:atom, _, :consolidated?}], [], [{:atom, _, _}]} ->
+            {:clause, l, [{:atom, 0, :consolidated?}], [], [{:atom, 0, true}]}
 
-    change_impl_for(tail, protocol, types, structs, true,
-                    [{:function, line, :__protocol__, 1, clauses} | acc])
+          {:clause, l, [{:atom, _, :impls}], [], [{:atom, _, _}]} ->
+            {
+              :clause,
+              l,
+              [{:atom, 0, :impls}],
+              [],
+              [{:tuple, 0, [{:atom, 0, :consolidated}, abstract_types]}]
+            }
+
+          {:clause, _, _, _, _} = c ->
+            c
+        end,
+        clauses
+      )
+
+    change_impl_for(tail, protocol, types, structs, true, [
+      {:function, line, :__protocol__, 1, clauses} | acc
+    ])
   end
 
-  defp change_impl_for([{:function, line, :impl_for, 1, _} | tail], protocol, types, structs, protocol?, acc) do
+  defp change_impl_for(
+         [{:function, line, :impl_for, 1, _} | tail],
+         protocol,
+         types,
+         structs,
+         protocol?,
+         acc
+       ) do
     fallback = if Any in types, do: load_impl(protocol, Any)
 
-    clauses = for {guard, mod} <- __builtin__(),
-                  mod in types,
-                  do: builtin_clause_for(mod, guard, protocol, line)
+    clauses =
+      for {guard, mod} <- __builtin__(),
+          mod in types,
+          do: builtin_clause_for(mod, guard, protocol, line)
 
-    clauses = [struct_clause_for(line) | clauses] ++
-              [fallback_clause_for(fallback, protocol, line)]
+    clauses =
+      [struct_clause_for(line) | clauses] ++ [fallback_clause_for(fallback, protocol, line)]
 
-    change_impl_for(tail, protocol, types, structs, protocol?,
-                    [{:function, line, :impl_for, 1, clauses} | acc])
+    change_impl_for(tail, protocol, types, structs, protocol?, [
+      {:function, line, :impl_for, 1, clauses} | acc
+    ])
   end
 
-  defp change_impl_for([{:function, line, :struct_impl_for, 1, _} | tail], protocol, types, structs, protocol?, acc) do
+  defp change_impl_for(
+         [{:function, line, :struct_impl_for, 1, _} | tail],
+         protocol,
+         types,
+         structs,
+         protocol?,
+         acc
+       ) do
     fallback = if Any in types, do: load_impl(protocol, Any)
     clauses = for struct <- structs, do: each_struct_clause_for(struct, protocol, line)
     clauses = clauses ++ [fallback_clause_for(fallback, protocol, line)]
 
-    change_impl_for(tail, protocol, types, structs, protocol?,
-                    [{:function, line, :struct_impl_for, 1, clauses} | acc])
+    change_impl_for(tail, protocol, types, structs, protocol?, [
+      {:function, line, :struct_impl_for, 1, clauses} | acc
+    ])
   end
 
-  defp change_impl_for([{:attribute, line, :spec, {{:__protocol__, 1}, funspecs}} | tail], protocol, types, structs, protocol?, acc) do
-    new_specs = for spec <- funspecs do
-      case spec do
-        {:type, line, :fun, [{:type, _, :product, [{:atom, _, :consolidated?}]}, _]} ->
-          {:type, line, :fun,
-           [{:type, line, :product, [{:atom, 0, :consolidated?}]},
-            {:atom, 0, true}]}
-        {:type, line, :fun, [{:type, _, :product, [{:atom, _, :impls}]}, _]} ->
-          impls = for mod <- types, do: {:atom, 0, mod}
-          {:type, line, :fun,
-           [{:type, line, :product, [{:atom, 0, :impls}]},
-            {:type, 0, :tuple,
-             [{:atom, 0, :consolidated},
-              {:type, 0, :list, [{:type, 0, :union, impls}]}]}]}
-        other -> other
+  defp change_impl_for(
+         [{:attribute, line, :spec, {{:__protocol__, 1}, funspecs}} | tail],
+         protocol,
+         types,
+         structs,
+         protocol?,
+         acc
+       ) do
+    new_specs =
+      for spec <- funspecs do
+        case spec do
+          {:type, line, :fun, [{:type, _, :product, [{:atom, _, :consolidated?}]}, _]} ->
+            {
+              :type,
+              line,
+              :fun,
+              [{:type, line, :product, [{:atom, 0, :consolidated?}]}, {:atom, 0, true}]
+            }
+
+          {:type, line, :fun, [{:type, _, :product, [{:atom, _, :impls}]}, _]} ->
+            impls = for mod <- types, do: {:atom, 0, mod}
+
+            {
+              :type,
+              line,
+              :fun,
+              [
+                {:type, line, :product, [{:atom, 0, :impls}]},
+                {
+                  :type,
+                  0,
+                  :tuple,
+                  [{:atom, 0, :consolidated}, {:type, 0, :list, [{:type, 0, :union, impls}]}]
+                }
+              ]
+            }
+
+          other ->
+            other
+        end
       end
-    end
-    change_impl_for(tail, protocol, types, structs, protocol?, [{:attribute, line, :spec, {{:__protocol__, 1}, new_specs}} | acc])
+
+    change_impl_for(tail, protocol, types, structs, protocol?, [
+      {:attribute, line, :spec, {{:__protocol__, 1}, new_specs}} | acc
+    ])
   end
 
   defp change_impl_for([head | tail], protocol, info, types, protocol?, acc) do
@@ -369,37 +445,57 @@ defmodule Protocol do
   end
 
   defp builtin_clause_for(mod, guard, protocol, line) do
-    {:clause, line,
+    {
+      :clause,
+      line,
       [{:var, line, :x}],
-      [[{:call, line,
-          {:remote, line, {:atom, line, :erlang}, {:atom, line, guard}},
-          [{:var, line, :x}],
-     }]],
-      [{:atom, line, load_impl(protocol, mod)}]}
+      [
+        [
+          {
+            :call,
+            line,
+            {:remote, line, {:atom, line, :erlang}, {:atom, line, guard}},
+            [{:var, line, :x}]
+          }
+        ]
+      ],
+      [{:atom, line, load_impl(protocol, mod)}]
+    }
   end
 
   defp struct_clause_for(line) do
-    {:clause, line,
-      [{:map, line, [
-        {:map_field_exact, line, {:atom, line, :__struct__}, {:var, line, :x}}
-      ]}],
-      [[{:call, line,
-          {:remote, line, {:atom, line, :erlang}, {:atom, line, :is_atom}},
-          [{:var, line, :x}],
-     }]],
-      [{:call, line,
-          {:atom, line, :struct_impl_for},
-          [{:var, line, :x}]}]}
+    {
+      :clause,
+      line,
+      [
+        {
+          :map,
+          line,
+          [
+            {:map_field_exact, line, {:atom, line, :__struct__}, {:var, line, :x}}
+          ]
+        }
+      ],
+      [
+        [
+          {
+            :call,
+            line,
+            {:remote, line, {:atom, line, :erlang}, {:atom, line, :is_atom}},
+            [{:var, line, :x}]
+          }
+        ]
+      ],
+      [{:call, line, {:atom, line, :struct_impl_for}, [{:var, line, :x}]}]
+    }
   end
 
   defp each_struct_clause_for(struct, protocol, line) do
-    {:clause, line, [{:atom, line, struct}], [],
-      [{:atom, line, load_impl(protocol, struct)}]}
+    {:clause, line, [{:atom, line, struct}], [], [{:atom, line, load_impl(protocol, struct)}]}
   end
 
   defp fallback_clause_for(value, _protocol, line) do
-    {:clause, line, [{:var, line, :_}], [],
-      [{:atom, line, value}]}
+    {:clause, line, [{:var, line, :_}], [], [{:atom, line, value}]}
   end
 
   defp load_impl(protocol, for) do
@@ -409,26 +505,36 @@ defmodule Protocol do
   # Finally compile the module and emit its bytecode.
   defp compile(protocol, code, {compile_info, docs}) do
     opts = Keyword.take(compile_info, [:source])
-    opts = if Code.compiler_options[:debug_info], do: [:debug_info | opts], else: opts
+    opts = if Code.compiler_options()[:debug_info], do: [:debug_info | opts], else: opts
     {:ok, ^protocol, binary, _warnings} = :compile.forms(code, [:return | opts])
-    {:ok,
+
+    {
+      :ok,
       case docs do
         :missing_chunk -> binary
         _ -> :elixir_erl.add_beam_chunks(binary, [{"ExDc", docs}])
-      end}
+      end
+    }
   end
 
   ## Definition callbacks
 
   @doc false
-  def __protocol__(name, [do: block]) do
+  def __protocol__(name, do: block) do
     quote do
       defmodule unquote(name) do
         # We don't allow function definition inside protocols
-        import Kernel, except: [
-          defmacrop: 1, defmacrop: 2, defmacro: 1, defmacro: 2,
-          defp: 1, defp: 2, def: 1, def: 2
-        ]
+        import Kernel,
+          except: [
+            defmacrop: 1,
+            defmacrop: 2,
+            defmacro: 1,
+            defmacro: 2,
+            defp: 1,
+            defp: 2,
+            def: 1,
+            def: 2
+          ]
 
         # Import the new dsl that holds the new def
         import Protocol, only: [def: 1]
@@ -453,7 +559,7 @@ defmodule Protocol do
     quote bind_quoted: [builtin: __builtin__()] do
       @doc false
       @spec impl_for(term) :: atom | nil
-      Kernel.def impl_for(data)
+      Kernel.def(impl_for(data))
 
       # Define the implementation for structs.
       #
@@ -464,16 +570,19 @@ defmodule Protocol do
       end
 
       # Define the implementation for built-ins
-      :lists.foreach(fn {guard, mod} ->
-        target = Module.concat(__MODULE__, mod)
+      :lists.foreach(
+        fn {guard, mod} ->
+          target = Module.concat(__MODULE__, mod)
 
-        Kernel.def impl_for(data) when :erlang.unquote(guard)(data) do
-          case impl_for?(unquote(target)) do
-            true  -> unquote(target).__impl__(:target)
-            false -> any_impl_for()
+          Kernel.def impl_for(data) when :erlang.unquote(guard)(data) do
+            case impl_for?(unquote(target)) do
+              true -> unquote(target).__impl__(:target)
+              false -> any_impl_for()
+            end
           end
-        end
-      end, builtin)
+        end,
+        builtin
+      )
 
       # Define a catch-all impl_for/1 clause to pacify Dialyzer (since
       # destructuring opaque types is illegal, Dialyzer will think none of the
@@ -493,24 +602,24 @@ defmodule Protocol do
 
       # Internal handler for Any
       if @fallback_to_any do
-        Kernel.defp any_impl_for(), do: __MODULE__.Any.__impl__(:target)
+        Kernel.defp(any_impl_for(), do: __MODULE__.Any.__impl__(:target))
       else
-        Kernel.defp any_impl_for(), do: nil
+        Kernel.defp(any_impl_for(), do: nil)
       end
 
       # Internal handler for Structs
       Kernel.defp struct_impl_for(struct) do
         target = Module.concat(__MODULE__, struct)
+
         case impl_for?(target) do
-          true  -> target.__impl__(:target)
+          true -> target.__impl__(:target)
           false -> any_impl_for()
         end
       end
 
       # Check if compilation is available internally
       Kernel.defp impl_for?(target) do
-        Code.ensure_compiled?(target) and
-          function_exported?(target, :__impl__, 1)
+        Code.ensure_compiled?(target) and function_exported?(target, :__impl__, 1)
       end
 
       # Inline any and struct implementations
@@ -530,16 +639,16 @@ defmodule Protocol do
       @spec __protocol__(:functions) :: unquote(Protocol.__functions_spec__(@functions))
       @spec __protocol__(:consolidated?) :: false
       @spec __protocol__(:impls) :: :not_consolidated
-      Kernel.def __protocol__(:module), do: __MODULE__
-      Kernel.def __protocol__(:functions), do: unquote(:lists.sort(@functions))
-      Kernel.def __protocol__(:consolidated?), do: false
-      Kernel.def __protocol__(:impls), do: :not_consolidated
+      Kernel.def(__protocol__(:module), do: __MODULE__)
+      Kernel.def(__protocol__(:functions), do: unquote(:lists.sort(@functions)))
+      Kernel.def(__protocol__(:consolidated?), do: false)
+      Kernel.def(__protocol__(:impls), do: :not_consolidated)
     end
   end
 
   @doc false
-  def __functions_spec__([]),
-    do: []
+  def __functions_spec__([]), do: []
+
   def __functions_spec__([head | tail]),
     do: [:lists.foldl(&{:|, [], [&1, &2]}, head, tail), quote(do: ...)]
 
@@ -548,11 +657,11 @@ defmodule Protocol do
     do_defimpl(protocol, :lists.keysort(1, opts))
   end
 
-  defp do_defimpl(protocol, [do: block, for: for]) when is_list(for) do
-    for f <- for, do: do_defimpl(protocol, [do: block, for: f])
+  defp do_defimpl(protocol, do: block, for: for) when is_list(for) do
+    for f <- for, do: do_defimpl(protocol, do: block, for: f)
   end
 
-  defp do_defimpl(protocol, [do: block, for: for]) do
+  defp do_defimpl(protocol, do: block, for: for) do
     # Unquote the implementation just later
     # when all variables will already be injected
     # into the module body.
@@ -562,23 +671,23 @@ defmodule Protocol do
         @spec __impl__(:for) :: unquote(for)
         @spec __impl__(:target) :: __MODULE__
         @spec __impl__(:protocol) :: unquote(protocol)
-        def __impl__(:for),      do: unquote(for)
-        def __impl__(:target),   do: __MODULE__
+        def __impl__(:for), do: unquote(for)
+        def __impl__(:target), do: __MODULE__
         def __impl__(:protocol), do: unquote(protocol)
       end
 
     quote do
       protocol = unquote(protocol)
-      for      = unquote(for)
-      name     = Module.concat(protocol, for)
+      for = unquote(for)
+      name = Module.concat(protocol, for)
 
       Protocol.assert_protocol!(protocol)
       Protocol.__ensure_defimpl__(protocol, for, __ENV__)
 
       defmodule name do
         @behaviour protocol
-        @protocol  protocol
-        @for       for
+        @protocol protocol
+        @for for
 
         unquote(block)
 
@@ -594,39 +703,43 @@ defmodule Protocol do
   def __derive__(derives, for, %Macro.Env{} = env) when is_atom(for) do
     struct =
       if for == env.module do
-        Module.get_attribute(for, :struct) ||
-          raise "struct is not defined for #{inspect for}"
+        Module.get_attribute(for, :struct) || raise "struct is not defined for #{inspect(for)}"
       else
         for.__struct__
       end
 
-    :lists.foreach(fn
-      proto when is_atom(proto) ->
-        derive(proto, for, struct, [], env)
-      {proto, opts} when is_atom(proto) ->
-        derive(proto, for, struct, opts, env)
-    end, :lists.flatten(derives))
+    :lists.foreach(
+      fn
+        proto when is_atom(proto) ->
+          derive(proto, for, struct, [], env)
+
+        {proto, opts} when is_atom(proto) ->
+          derive(proto, for, struct, opts, env)
+      end,
+      :lists.flatten(derives)
+    )
 
     :ok
   end
 
   defp derive(protocol, for, struct, opts, env) do
-    extra = ", cannot derive #{inspect protocol} for #{inspect for}"
+    extra = ", cannot derive #{inspect(protocol)} for #{inspect(for)}"
     assert_protocol!(protocol, extra)
     __ensure_defimpl__(protocol, for, env)
     assert_impl!(protocol, Any, extra)
 
     # Clean up variables from eval context
-    env  = %{env | vars: [], export_vars: nil}
+    env = %{env | vars: [], export_vars: nil}
     args = [for, struct, opts]
     impl = Module.concat(protocol, Any)
 
-    :elixir_module.expand_callback(env.line, impl, :__deriving__, args, env, fn
-      mod, fun, args ->
-        if function_exported?(mod, fun, length(args)) do
-          apply(mod, fun, args)
-        else
-          Module.create(Module.concat(protocol, for), quote do
+    :elixir_module.expand_callback(env.line, impl, :__deriving__, args, env, fn mod, fun, args ->
+      if function_exported?(mod, fun, length(args)) do
+        apply(mod, fun, args)
+      else
+        Module.create(
+          Module.concat(protocol, for),
+          quote do
             Module.register_attribute(__MODULE__, :protocol_impl, persist: true)
             @protocol_impl [protocol: unquote(protocol), for: unquote(for)]
 
@@ -634,11 +747,13 @@ defmodule Protocol do
             @spec __impl__(:target) :: unquote(impl)
             @spec __impl__(:protocol) :: unquote(protocol)
             @spec __impl__(:for) :: unquote(for)
-            def __impl__(:target),   do: unquote(impl)
+            def __impl__(:target), do: unquote(impl)
             def __impl__(:protocol), do: unquote(protocol)
-            def __impl__(:for),      do: unquote(for)
-          end, Macro.Env.location(env))
-        end
+            def __impl__(:for), do: unquote(for)
+          end,
+          Macro.Env.location(env)
+        )
+      end
     end)
   end
 
@@ -646,10 +761,12 @@ defmodule Protocol do
   def __ensure_defimpl__(protocol, for, env) do
     if Protocol.consolidated?(protocol) do
       message =
-        "the #{inspect protocol} protocol has already been consolidated" <>
-        ", an implementation for #{inspect for} has no effect"
+        "the #{inspect(protocol)} protocol has already been consolidated" <>
+          ", an implementation for #{inspect(for)} has no effect"
+
       :elixir_errors.warn(env.line, env.file, message)
     end
+
     :ok
   end
 
@@ -658,31 +775,37 @@ defmodule Protocol do
     signature = {name, arity}
 
     specs = Module.get_attribute(module, :spec)
-    found =
-      :lists.map(fn {:spec, expr, pos} ->
-        if Kernel.Typespec.spec_to_signature(expr) == signature do
-          Module.store_typespec(module, :callback, {:callback, expr, pos})
-          true
-        end
-      end, specs)
 
-    :lists.any(& &1 == true, found)
+    found =
+      :lists.map(
+        fn {:spec, expr, pos} ->
+          if Kernel.Typespec.spec_to_signature(expr) == signature do
+            Module.store_typespec(module, :callback, {:callback, expr, pos})
+            true
+          end
+        end,
+        specs
+      )
+
+    :lists.any(&(&1 == true), found)
   end
 
   ## Helpers
 
   @doc false
   def __builtin__ do
-    [is_tuple: Tuple,
-     is_atom: Atom,
-     is_list: List,
-     is_map: Map,
-     is_bitstring: BitString,
-     is_integer: Integer,
-     is_float: Float,
-     is_function: Function,
-     is_pid: PID,
-     is_port: Port,
-     is_reference: Reference]
+    [
+      is_tuple: Tuple,
+      is_atom: Atom,
+      is_list: List,
+      is_map: Map,
+      is_bitstring: BitString,
+      is_integer: Integer,
+      is_float: Float,
+      is_function: Function,
+      is_pid: PID,
+      is_port: Port,
+      is_reference: Reference
+    ]
   end
 end


### PR DESCRIPTION
Some of the changes in this file are quite extreme. In a few places, the formatter has added a lot of extra newlines which has made the code quite different. In my opinion, it is more readable like this but I can see why somebody might disagree.

Any thoughts?