### PR TITLE
Run code formatter on Access and Kernel

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -217,7 +217,8 @@ defmodule Access do
   for more examples.
   """
   @callback get_and_update(data, key, (value -> {get_value, value} | :pop)) :: {get_value, data}
-            when get_value: var, data: container | any_container
+            when get_value: var,
+                 data: container | any_container
 
   @doc """
   Invoked to "pop" the value under `key` out of the given data structure.
@@ -353,7 +354,8 @@ defmodule Access do
   `fun` and a new container with the updated value under `key`.
   """
   @spec get_and_update(data, key, (value -> {get_value, value} | :pop)) :: {get_value, data}
-        when get_value: var, data: container
+        when get_value: var,
+             data: container
   def get_and_update(container, key, fun)
 
   def get_and_update(%module{} = container, key, fun) do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -977,7 +977,8 @@ defmodule Kernel do
 
   """
   @spec tl(nonempty_maybe_improper_list(elem, tail)) :: maybe_improper_list(elem, tail) | tail
-        when elem: term, tail: term
+        when elem: term,
+             tail: term
   def tl(list) do
     :erlang.tl(list)
   end
@@ -1839,7 +1840,7 @@ defmodule Kernel do
     opts = struct(Inspect.Opts, opts)
 
     limit =
-      case opts.pretty do
+      case opts.pretty() do
         true -> opts.width
         false -> :infinity
       end
@@ -2698,7 +2699,8 @@ defmodule Kernel do
         {escaped, _} = :elixir_quote.escape(stack, false)
 
         quote do
-          with {_, doc} when unquote(doc_attr?) <-
+          with {_, doc}
+               when unquote(doc_attr?) <-
                  Module.get_attribute(__MODULE__, unquote(name), unquote(escaped)),
                do: doc
         end
@@ -2941,7 +2943,7 @@ defmodule Kernel do
   end
 
   defmacro first..last do
-    case __CALLER__.context do
+    case __CALLER__.context() do
       nil ->
         quote(do: Elixir.Range.new(unquote(first), unquote(last)))
 
@@ -4972,14 +4974,14 @@ defmodule Kernel do
   end
 
   defp assert_module_scope(env, fun, arity) do
-    case env.module do
+    case env.module() do
       nil -> raise ArgumentError, "cannot invoke #{fun}/#{arity} outside module"
       mod -> mod
     end
   end
 
   defp assert_no_function_scope(env, fun, arity) do
-    case env.function do
+    case env.function() do
       nil -> :ok
       _ -> raise ArgumentError, "cannot invoke #{fun}/#{arity} inside function/macro"
     end


### PR DESCRIPTION
Wondering whether the `when` formatting over multiple lines in these cases is actually an improvement?