### PR TITLE
Collect sigil variables as part of assert matches

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -398,7 +398,7 @@ defmodule ExUnit.Assertions do
     binary = Macro.to_string(pattern)
 
     # Expand before extracting metadata
-    pattern = Macro.expand(pattern, caller)
+    pattern = Macro.prewalk(pattern, &Macro.expand(&1, caller))
     vars = collect_vars_from_pattern(pattern)
     pins = collect_pins_from_pattern(pattern, caller.vars)
 

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -98,7 +98,7 @@ defmodule ExUnit.Assertions do
   defmacro assert({:=, _, [left, right]} = assertion) do
     code = escape_quoted(:assert, assertion)
 
-    left = Macro.expand(left, __CALLER__)
+    left = Macro.prewalk(left, &Macro.expand(&1, __CALLER__))
     vars = collect_vars_from_pattern(left)
     pins = collect_pins_from_pattern(left, __CALLER__.vars)
 
@@ -553,18 +553,6 @@ defmodule ExUnit.Assertions do
 
       {name, meta, context}, acc when is_atom(name) and is_atom(context) ->
         {:ok, [{name, [generated: true] ++ meta, context} | acc]}
-
-      node = {:<<>>, meta, context}, acc when is_list(context) ->
-        if Enum.all?(context, &is_binary/1) do
-          vars =
-            Enum.map(context, fn var ->
-              {String.to_atom(var), [generated: true] ++ meta, nil}
-            end)
-
-          {:ok, vars ++ acc}
-        else
-          {node, acc}
-        end
 
       node, acc ->
         {node, acc}

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -554,11 +554,13 @@ defmodule ExUnit.Assertions do
       {name, meta, context}, acc when is_atom(name) and is_atom(context) ->
         {:ok, [{name, [generated: true] ++ meta, context} | acc]}
 
-      node = {:"<<>>", meta, context}, acc when is_list(context) ->
+      node = {:<<>>, meta, context}, acc when is_list(context) ->
         if Enum.all?(context, &is_binary/1) do
-          vars = Enum.map(context, fn(var) ->
-            {String.to_atom(var), [generated: true] ++ meta, nil}
-          end)
+          vars =
+            Enum.map(context, fn var ->
+              {String.to_atom(var), [generated: true] ++ meta, nil}
+            end)
+
           {:ok, vars ++ acc}
         else
           {node, acc}

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -554,6 +554,16 @@ defmodule ExUnit.Assertions do
       {name, meta, context}, acc when is_atom(name) and is_atom(context) ->
         {:ok, [{name, [generated: true] ++ meta, context} | acc]}
 
+      node = {:"<<>>", meta, context}, acc when is_list(context) ->
+        if Enum.all?(context, &is_binary/1) do
+          vars = Enum.map(context, fn(var) ->
+            {String.to_atom(var), [generated: true] ++ meta, nil}
+          end)
+          {:ok, vars ++ acc}
+        else
+          {node, acc}
+        end
+
       node, acc ->
         {node, acc}
     end)

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -16,12 +16,10 @@ end
 
 alias ExUnit.AssertionsTest.{BrokenError, Value}
 
-defmodule MinimalMacro do
-  defmacro sigil_l({:<<>>, _, [string]}, _), do: Code.string_to_quoted!(string, [])
-end
-
 defmodule ExUnit.AssertionsTest do
   use ExUnit.Case, async: true
+
+  defmacro sigil_l({:<<>>, _, [string]}, _), do: Code.string_to_quoted!(string, [])
 
   defmacrop assert_ok(arg) do
     quote do
@@ -79,8 +77,6 @@ defmodule ExUnit.AssertionsTest do
   end
 
   test "assert exposes sigil variables in matches" do
-    import MinimalMacro
-
     assert ~l(a) = 1
     assert a == 1
 

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -217,6 +217,13 @@ defmodule ExUnit.AssertionsTest do
     end
   end
 
+  test "assert_receive exposes sigil variables" do
+    send(self(), {:hello})
+    assert_receive {~l(a)}, 0, "failure message"
+
+    assert a == :hello
+  end
+
   test "assert received does not wait" do
     send(self(), :hello)
     :hello = assert_received :hello

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -16,6 +16,10 @@ end
 
 alias ExUnit.AssertionsTest.{BrokenError, Value}
 
+defmodule MinimalMacro do
+  defmacro sigil_l({:<<>>, _, [string]}, _), do: Code.string_to_quoted!(string, [])
+end
+
 defmodule ExUnit.AssertionsTest do
   use ExUnit.Case, async: true
 
@@ -72,6 +76,17 @@ defmodule ExUnit.AssertionsTest do
         2 = error.right
         "assert(1 == 1 + 1)" = error.expr |> Macro.to_string()
     end
+  end
+
+  test "assert exposes sigil variables in matches" do
+    import MinimalMacro
+
+    assert ~l(a) = 1
+    assert a == 1
+
+    assert {~l(b), ~l(c)} = {2, 3}
+    assert b == 2
+    assert c == 3
   end
 
   test "refute when value is false" do

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -76,7 +76,7 @@ defmodule ExUnit.AssertionsTest do
     end
   end
 
-  test "assert exposes sigil variables in matches" do
+  test "assert exposes nested macro variables in matches" do
     assert ~l(a) = 1
     assert a == 1
 
@@ -217,7 +217,7 @@ defmodule ExUnit.AssertionsTest do
     end
   end
 
-  test "assert_receive exposes sigil variables" do
+  test "assert_receive exposes nested macro variables" do
     send(self(), {:hello})
     assert_receive {~l(a)}, 0, "failure message"
 


### PR DESCRIPTION
This fixes https://github.com/elixir-lang/elixir/issues/6925

When sigils are expanded via `Macro.expand/2` they aren't expanded into
their non-sigil equivalent.

eg:

```
defmodule MinimalMacro do
  defmacro sigil_l({:<<>>, _, [string]}, _), do: Code.string_to_quoted!(string, [])
end

iex> Macro.expand((quote do: {a} = 1), nil)
{:=, [], [{:{}, [], [{:a, [], Elixir}]}, 1]}

iex> Macro.expand((quote do: {~l(a)} = 1), nil)
{:=, [], [{:{}, [], [{:sigil_l, [], [{:<<>>, [], ["a"]}, []]}]}, 1]}
```

The `assert` macro uses `Macro.prewalk` to walk the AST of a given
expression using pattern matching to find variables that should be
used as the left side of the match. Because sigils aren't expanded into
their non-sigil equivalent and `assert` doesn't look for the sigil
pattern they aren't collected as variables to use in the match.

This matches against the sigil AST pattern and follows the same approach
https://github.com/elixir-lang/gettext/commit/2f183e33ce8ac7ff317b255eb27c809526eb9535
uses to ensure we're matching only against sigils.