### PR TITLE
Implement :env_vars option for %Mix.Dep{}

### DIFF
--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -31,6 +31,9 @@ defmodule Mix.Dep do
       the information on this field is private to the manager and should not be
       relied on
 
+    * `system_env` - an enumerable of key-value tuples of binaries to be set as environment variables
+      when loading or compiling the dependency
+
   A dependency is in two specific states: loaded and unloaded.
 
   When a dependency is unloaded, it means Mix only parsed its specification
@@ -56,7 +59,8 @@ defmodule Mix.Dep do
             top_level: false,
             extra: [],
             manager: nil,
-            from: nil
+            from: nil,
+            system_env: []
 
   @type t :: %__MODULE__{
           scm: module,
@@ -67,7 +71,8 @@ defmodule Mix.Dep do
           top_level: boolean,
           manager: :rebar | :rebar3 | :mix | :make | nil,
           from: String.t(),
-          extra: term
+          extra: term,
+          system_env: keyword
         }
 
   @doc """

--- a/lib/mix/lib/mix/dep/converger.ex
+++ b/lib/mix/lib/mix/dep/converger.ex
@@ -184,10 +184,12 @@ defmodule Mix.Dep.Converger do
             {:unloaded, dep, children} ->
               {dep, rest, lock} = callback.(put_lock(dep, lock), rest, lock)
 
-              # After we invoke the callback (which may actually check out the
-              # dependency), we load the dependency including its latest info
-              # and children information.
-              {Mix.Dep.Loader.load(dep, children), rest, lock}
+              Mix.Dep.Loader.with_system_env(dep, fn ->
+                # After we invoke the callback (which may actually check out the
+                # dependency), we load the dependency including its latest info
+                # and children information.
+                {Mix.Dep.Loader.load(dep, children), rest, lock}
+              end)
           end
 
         {acc, rest, lock} =

--- a/lib/mix/lib/mix/dep/loader.ex
+++ b/lib/mix/lib/mix/dep/loader.ex
@@ -36,6 +36,19 @@ defmodule Mix.Dep.Loader do
     only != nil and env not in List.wrap(only)
   end
 
+  def with_system_env(%Mix.Dep{system_env: []}, callback), do: callback.()
+
+  def with_system_env(%Mix.Dep{system_env: system_env}, callback) do
+    env = System.get_env()
+
+    try do
+      System.put_env(system_env)
+      callback.()
+    after
+      System.put_env(env)
+    end
+  end
+
   @doc """
   Loads the given dependency information, including its
   latest status and children.
@@ -161,7 +174,8 @@ defmodule Mix.Dep.Loader do
       app: app,
       requirement: req,
       status: scm_status(scm, opts),
-      opts: Keyword.put_new(opts, :env, :prod)
+      opts: Keyword.put_new(opts, :env, :prod),
+      system_env: Keyword.get(opts, :system_env, [])
     }
   end
 

--- a/lib/mix/lib/mix/dep/loader.ex
+++ b/lib/mix/lib/mix/dep/loader.ex
@@ -153,6 +153,7 @@ defmodule Mix.Dep.Loader do
       |> Keyword.put(:dest, dest)
       |> Keyword.put(:build, build)
 
+    {system_env, opts} = opts |> Keyword.pop(:system_env, [])
     {scm, opts} = get_scm(app, opts)
 
     {scm, opts} =
@@ -175,7 +176,7 @@ defmodule Mix.Dep.Loader do
       requirement: req,
       status: scm_status(scm, opts),
       opts: Keyword.put_new(opts, :env, :prod),
-      system_env: Keyword.get(opts, :system_env, [])
+      system_env: system_env
     }
   end
 

--- a/lib/mix/lib/mix/dep/loader.ex
+++ b/lib/mix/lib/mix/dep/loader.ex
@@ -153,7 +153,7 @@ defmodule Mix.Dep.Loader do
       |> Keyword.put(:dest, dest)
       |> Keyword.put(:build, build)
 
-    {system_env, opts} = opts |> Keyword.pop(:system_env, [])
+    {system_env, opts} = Keyword.pop(opts, :system_env, [])
     {scm, opts} = get_scm(app, opts)
 
     {scm, opts} =

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -261,9 +261,11 @@ defmodule Mix.Tasks.Deps.Compile do
     end
   end
 
-  defp do_command(%Mix.Dep{app: app, opts: opts}, config, command, print_app?, env \\ []) do
+  defp do_command(dep, config, command, print_app?, env \\ []) do
+    %Mix.Dep{app: app, system_env: system_env, opts: opts} = dep
+
     File.cd!(opts[:dest], fn ->
-      env = [{"ERL_LIBS", Path.join(config[:env_path], "lib")}] ++ env
+      env = [{"ERL_LIBS", Path.join(config[:env_path], "lib")} | system_env] ++ env
 
       if Mix.shell().cmd(command, env: env, print_app: print_app?) != 0 do
         Mix.raise(

--- a/lib/mix/test/fixtures/rebar_dep/rebar.config.script
+++ b/lib/mix/test/fixtures/rebar_dep/rebar.config.script
@@ -1,4 +1,10 @@
-CONFIG ++
-  [{'SCRIPT', SCRIPT}] ++
-  [{erl_opts, [warnings_as_errors]}] ++
-  [{deps, [{git_rebar, "0.1..*", {git, filename:absname("../../test/fixtures/git_rebar"), master}}]}].
+CFG1 = CONFIG ++
+[{'SCRIPT', SCRIPT}] ++
+[{erl_opts, [warnings_as_errors]}] ++
+[{deps, [{git_rebar, "0.1..*", {git, filename:absname("../../test/fixtures/git_rebar"), master}}]}].
+
+case {os:getenv("FILE_FROM_ENV"), os:getenv("CONTENTS_FROM_ENV")} of
+  {false, _} -> ok;
+  {File, Contents} -> file:write_file(File, [Contents])
+end,
+CFG1.

--- a/lib/mix/test/mix/dep_test.exs
+++ b/lib/mix/test/mix/dep_test.exs
@@ -269,15 +269,8 @@ defmodule Mix.DepTest do
   test "deps with system_env set" do
     dep_path = MixTest.Case.tmp_path("rebar_dep")
 
-    deps = [
-      {
-        :rebar_dep,
-        path: dep_path,
-        app: false,
-        manager: :rebar,
-        system_env: [{"FILE_FROM_ENV", "dep-test"}, {"CONTENTS_FROM_ENV", "contents dep test"}]
-      }
-    ]
+    system_env = [{"FILE_FROM_ENV", "dep-test"}, {"CONTENTS_FROM_ENV", "contents dep test"}]
+    deps = [{:rebar_dep, path: dep_path, app: false, manager: :rebar, system_env: system_env}]
 
     with_deps(deps, fn ->
       in_tmp "load dependency with env vars", fn ->

--- a/lib/mix/test/mix/dep_test.exs
+++ b/lib/mix/test/mix/dep_test.exs
@@ -266,6 +266,30 @@ defmodule Mix.DepTest do
     end)
   end
 
+  test "deps with system_env set" do
+    dep_path = MixTest.Case.tmp_path("rebar_dep")
+
+    deps = [
+      {
+        :rebar_dep,
+        path: dep_path,
+        app: false,
+        manager: :rebar,
+        system_env: [{"FILE_FROM_ENV", "dep-test"}, {"CONTENTS_FROM_ENV", "contents dep test"}]
+      }
+    ]
+
+    with_deps(deps, fn ->
+      in_tmp "load dependency with env vars", fn ->
+        expected_file = Path.join(dep_path, "dep-test")
+        File.rm(expected_file)
+        Mix.Dep.loaded([])
+
+        assert {:ok, "contents dep test"} = File.read(expected_file)
+      end
+    end)
+  end
+
   ## Remove converger
 
   defmodule IdentityRemoteConverger do


### PR DESCRIPTION
This PR is the implementation of [this proposal](https://groups.google.com/forum/#!topic/elixir-lang-core/Lk08Vt0eRR0), which allows defining per dependency env variables to be used when loading or compiling it.

Example:

```elixir
def deps do
  {:exometer, "~> 1.2.1", env_vars: [{"EXOMETER_PACKAGES", "(amqp)"}]}
end
```

Will set the `EXOMETER_PACKAGES` env variable to "(amqp)" which will include the amqp dependencies in the `mix.lock` (see: [exometer-dependency-management](https://github.com/Feuerlabs/exometer#dependency-management)). This is a Rebar specific example, but the PR sets the env vars to all types of supported packages.

All the files have been formatted using the new `mix format` task.
I'll be really happy to get feedback to improve this PR and make all the required changes to have it merged.