### PR TITLE
Stop using keyword lists in IEx.Info

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -465,9 +465,8 @@ defmodule IEx.Helpers do
 
   """
   def i(term \\ v(-1)) do
-    info =
-      [Term: inspect(term)] ++
-        IEx.Info.info(term) ++ ["Implemented protocols": all_implemented_protocols_for_term(term)]
+    implemented_protocols = [{"Implemented protocols", all_implemented_protocols_for_term(term)}]
+    info = [{"Term", inspect(term)}] ++ IEx.Info.info(term) ++ implemented_protocols
 
     for {subject, info} <- info do
       info = info |> to_string() |> String.trim() |> String.replace("\n", "\n  ")

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -1,15 +1,15 @@
 defprotocol IEx.Info do
   @fallback_to_any true
 
-  @spec info(term) :: [{atom, String.t()}]
+  @spec info(term()) :: [{info_name :: String.t(), info :: String.t()}]
   def info(term)
 end
 
 defimpl IEx.Info, for: Tuple do
   def info(_tuple) do
     [
-      "Data type": "Tuple",
-      "Reference modules": "Tuple"
+      {"Data type", "Tuple"},
+      {"Reference modules", "Tuple"}
     ]
   end
 end
@@ -35,12 +35,12 @@ defimpl IEx.Info, for: Atom do
         return value on screen is executed.
         """
 
-        [Description: description]
+        [{"Description", description}]
       else
         []
       end
 
-    ["Data type": "Atom"] ++ description ++ specific_info
+    [{"Data type", "Atom"}] ++ description ++ specific_info
   end
 
   defp info_module(mod) do
@@ -54,42 +54,43 @@ defimpl IEx.Info, for: Atom do
     mod_info = mod.module_info()
 
     generic_info = [
-      "Module bytecode": module_object_file(mod),
-      Source: module_source_file(mod_info),
-      Version: module_version(mod_info),
-      "Compile options": module_compile_options(mod_info),
-      Description: "#{extra}Call #{inspect(mod)}.module_info() to access metadata."
+      {"Module bytecode", module_object_file(mod)},
+      {"Source", module_source_file(mod_info)},
+      {"Version", module_version(mod_info)},
+      {"Compile options", module_compile_options(mod_info)},
+      {"Description", "#{extra}Call #{inspect(mod)}.module_info() to access metadata."}
     ]
-
-    specific_info =
-      if function_exported?(mod, :__protocol__, 1) do
-        impls =
-          mod
-          |> Protocol.extract_impls(:code.get_path())
-          |> Enum.map_join(", ", &inspect/1)
-
-        [Protocol: "This module is a protocol. These data structures implement it:\n  #{impls}"]
-      else
-        []
-      end
 
     final_info = [
-      "Raw representation": ":" <> inspect(Atom.to_string(mod)),
-      "Reference modules": "Module, Atom"
+      {"Raw representation", ":" <> inspect(Atom.to_string(mod))},
+      {"Reference modules", "Module, Atom"}
     ]
 
-    generic_info ++ specific_info ++ final_info
+    generic_info ++ protocol_info(mod) ++ final_info
+  end
+
+  defp protocol_info(mod) do
+    if function_exported?(mod, :__protocol__, 1) do
+      impls =
+        mod
+        |> Protocol.extract_impls(:code.get_path())
+        |> Enum.map_join(", ", &inspect/1)
+
+      [{"Protocol", "This module is a protocol. These data structures implement it:\n  #{impls}"}]
+    else
+      []
+    end
   end
 
   defp info_module_like_atom(atom) do
     [
-      "Raw representation": ":" <> inspect(Atom.to_string(atom)),
-      "Reference modules": "Atom"
+      {"Raw representation", ":" <> inspect(Atom.to_string(atom))},
+      {"Reference modules", "Atom"}
     ]
   end
 
   defp info_atom(_atom) do
-    ["Reference modules": "Atom"]
+    [{"Reference modules", "Atom"}]
   end
 
   defp module_object_file(mod) do
@@ -125,11 +126,11 @@ defimpl IEx.Info, for: List do
         true -> info_list(list)
       end
 
-    ["Data type": "List"] ++ specific_info
+    [{"Data type", "List"}] ++ specific_info
   end
 
   defp info_charlist(charlist) do
-    desc = """
+    description = """
     This is a list of integers that is printed as a sequence of characters
     delimited by single quotes because all the integers in it represent valid
     ASCII characters. Conventionally, such lists of integers are referred to
@@ -138,23 +139,23 @@ defimpl IEx.Info, for: List do
     """
 
     [
-      Description: desc,
-      "Raw representation": inspect(charlist, charlists: :as_lists),
-      "Reference modules": "List"
+      {"Description", description},
+      {"Raw representation", inspect(charlist, charlists: :as_lists)},
+      {"Reference modules", "List"}
     ]
   end
 
   defp info_kw_list(_kw_list) do
-    desc = """
+    description = """
     This is what is referred to as a "keyword list". A keyword list is a list
     of two-element tuples where the first element of each tuple is an atom.
     """
 
-    [Description: desc, "Reference modules": "Keyword, List"]
+    [{"Description", description}, {"Reference modules", "Keyword, List"}]
   end
 
   defp info_list(_list) do
-    ["Reference modules": "List"]
+    [{"Reference modules", "List"}]
   end
 end
 
@@ -168,28 +169,25 @@ defimpl IEx.Info, for: BitString do
         is_bitstring(bitstring) -> info_bitstring(bitstring)
       end
 
-    ["Data type": "BitString"] ++ specific_info
+    [{"Data type", "BitString"}] ++ specific_info
   end
 
   defp info_string(bitstring) do
-    desc = """
+    description = """
     This is a string: a UTF-8 encoded binary. It's printed surrounded by
     "double quotes" because all UTF-8 encoded codepoints in it are printable.
     """
 
     [
-      "Byte size": byte_size(bitstring),
-      Description: desc,
-      "Raw representation": inspect(bitstring, binaries: :as_binaries),
-      "Reference modules": "String, :binary"
+      {"Byte size", byte_size(bitstring)},
+      {"Description", description},
+      {"Raw representation", inspect(bitstring, binaries: :as_binaries)},
+      {"Reference modules", "String, :binary"}
     ]
   end
 
   defp info_non_printable_string(bitstring) do
-    first_non_printable =
-      bitstring
-      |> String.codepoints()
-      |> Enum.find(fn cp -> not String.printable?(cp) end)
+    first_non_printable = find_first_codepoint(bitstring, &(not String.printable?(&1)))
 
     desc = """
     This is a string: a UTF-8 encoded binary. It's printed with the `<<>>`
@@ -199,50 +197,53 @@ defimpl IEx.Info, for: BitString do
     """
 
     [
-      "Byte size": byte_size(bitstring),
-      Description: desc,
-      "Reference modules": "String, :binary"
+      {"Byte size", byte_size(bitstring)},
+      {"Description", desc},
+      {"Reference modules", "String, :binary"}
     ]
   end
 
   defp info_binary(bitstring) do
-    first_non_valid =
-      bitstring
-      |> String.codepoints()
-      |> Enum.find(fn cp -> not String.valid?(cp) end)
+    first_non_valid = find_first_codepoint(bitstring, &(not String.valid?(&1)))
 
-    desc = """
+    description = """
     This is a binary: a collection of bytes. It's printed with the `<<>>`
     syntax (as opposed to double quotes) because it is not a UTF-8 encoded
     binary (the first invalid byte being `#{inspect(first_non_valid)}`)
     """
 
     [
-      "Byte size": byte_size(bitstring),
-      Description: desc,
-      "Reference modules": ":binary"
+      {"Byte size", byte_size(bitstring)},
+      {"Description", description},
+      {"Reference modules", ":binary"}
     ]
   end
 
   defp info_bitstring(bitstring) do
-    desc = """
+    description = """
     This is a bitstring. It's a chunk of bits that are not divisible by 8
     (the number of bytes isn't whole).
     """
 
-    ["Bits size": bit_size(bitstring), Description: desc]
+    [{"Bits size", bit_size(bitstring)}, {"Description", description}]
+  end
+
+  defp find_first_codepoint(binary, fun) do
+    binary
+    |> String.codepoints()
+    |> Enum.find(fun)
   end
 end
 
 defimpl IEx.Info, for: Integer do
-  def info(_) do
-    ["Data type": "Integer", "Reference modules": "Integer"]
+  def info(_integer) do
+    [{"Data type", "Integer"}, {"Reference modules", "Integer"}]
   end
 end
 
 defimpl IEx.Info, for: Float do
-  def info(_) do
-    ["Data type": "Float", "Reference modules": "Float"]
+  def info(_float) do
+    [{"Data type", "Float"}, {"Reference modules", "Float"}]
   end
 end
 
@@ -257,19 +258,22 @@ defimpl IEx.Info, for: Function do
         info_anon_fun(fun_info)
       end
 
-    ["Data type": "Function"] ++ specific_info
+    [{"Data type", "Function"}] ++ specific_info
   end
 
   defp info_anon_fun(fun_info) do
     [
-      Type: to_string(fun_info[:type]),
-      Arity: fun_info[:arity],
-      Description: "This is an anonymous function."
+      {"Type", to_string(fun_info[:type])},
+      {"Arity", fun_info[:arity]},
+      {"Description", "This is an anonymous function."}
     ]
   end
 
   defp info_named_fun(fun_info) do
-    [Type: to_string(fun_info[:type]), Arity: fun_info[:arity]]
+    [
+      {"Type", to_string(fun_info[:type])},
+      {"Arity", fun_info[:arity]}
+    ]
   end
 end
 
@@ -277,27 +281,27 @@ defimpl IEx.Info, for: PID do
   @keys [:registered_name, :links, :message_queue_len]
 
   def info(pid) do
-    extra =
+    extra_info =
       case :rpc.pinfo(pid, @keys) do
         [_ | _] = info ->
           [
-            Alive: true,
-            Name: process_name(info[:registered_name]),
-            Links: links(info[:links]),
-            "Message queue length": info[:message_queue_len]
+            {"Alive", true},
+            {"Name", process_name(info[:registered_name])},
+            {"Links", links(info[:links])},
+            {"Message queue length", info[:message_queue_len]}
           ]
 
         _ ->
-          [Alive: false]
+          [{"Alive", false}]
       end
 
     final_info =
       [
-        Description: "Use Process.info/1 to get more info about this process",
-        "Reference modules": "Process, Node"
+        {"Description", "Use Process.info/1 to get more info about this process"},
+        {"Reference modules", "Process, Node"}
       ]
 
-    ["Data type": "PID"] ++ extra ++ final_info
+    [{"Data type", "PID"}] ++ extra_info ++ final_info
   end
 
   defp process_name([]), do: "not registered"
@@ -308,8 +312,8 @@ defimpl IEx.Info, for: PID do
 end
 
 defimpl IEx.Info, for: Map do
-  def info(_) do
-    ["Data type": "Map", "Reference modules": "Map"]
+  def info(_map) do
+    [{"Data type", "Map"}, {"Reference modules", "Map"}]
   end
 end
 
@@ -318,16 +322,16 @@ defimpl IEx.Info, for: Port do
     connected = :rpc.call(node(port), :erlang, :port_info, [port, :connected])
 
     [
-      "Data type": "Port",
-      Open: match?({:connected, _}, connected),
-      "Reference modules": "Port"
+      {"Data type", "Port"},
+      {"Open", match?({:connected, _}, connected)},
+      {"Reference modules", "Port"}
     ]
   end
 end
 
 defimpl IEx.Info, for: Reference do
-  def info(_) do
-    ["Data type": "Reference"]
+  def info(_ref) do
+    [{"Data type", "Reference"}]
   end
 end
 
@@ -340,17 +344,17 @@ defimpl IEx.Info, for: [Date, Time, NaiveDateTime] do
     end
 
   def info(value) do
-    desc = """
+    description = """
     This is a struct representing a #{unquote(repr)}. It is commonly
     represented using the `~#{unquote(sigil)}` sigil syntax, that is
     defined in the `Kernel.sigil_#{unquote(sigil)}/2` macro.
     """
 
     [
-      "Data type": inspect(@for),
-      Description: desc,
-      "Raw representation": raw_inspect(value),
-      "Reference modules": inspect(@for) <> ", Calendar, Map"
+      {"Data type", inspect(@for)},
+      {"Description", description},
+      {"Raw representation", raw_inspect(value)},
+      {"Reference modules", inspect(@for) <> ", Calendar, Map"}
     ]
   end
 
@@ -365,9 +369,9 @@ end
 defimpl IEx.Info, for: Any do
   def info(%module{}) do
     [
-      "Data type": inspect(module),
-      Description: "This is a struct. Structs are maps with a __struct__ key.",
-      "Reference modules": inspect(module) <> ", Map"
+      {"Data type", inspect(module)},
+      {"Description", "This is a struct. Structs are maps with a __struct__ key."},
+      {"Reference modules", inspect(module) <> ", Map"}
     ]
   end
 end

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -1,7 +1,7 @@
 defprotocol IEx.Info do
   @fallback_to_any true
 
-  @spec info(term()) :: [{info_name :: String.t(), info :: String.t()}]
+  @spec info(term()) :: [{info_name :: String.Chars.t(), info :: String.t()}]
   def info(term)
 end
 

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -924,6 +924,29 @@ defmodule IEx.HelpersTest do
                return value on screen is executed.\
              """
     end
+
+    defmodule MyIExInfoModule do
+      defstruct []
+
+      defimpl IEx.Info do
+        def info(_), do: [{"A", "it's A"}, {:b, "it's :b"}, {'c', "it's 'c'"}]
+      end
+    end
+
+    test "uses the IEx.Info protocol" do
+      assert capture_io(fn -> i(%MyIExInfoModule{}) end) =~ """
+             Term
+               %IEx.HelpersTest.MyIExInfoModule{}
+             A
+               it's A
+             b
+               it's :b
+             c
+               it's 'c'
+             """
+    after
+      cleanup_modules([MyIExInfoModule])
+    end
   end
 
   defp test_module_code do

--- a/lib/iex/test/iex/info_test.exs
+++ b/lib/iex/test/iex/info_test.exs
@@ -10,181 +10,199 @@ defmodule IEx.InfoTest do
   end
 
   test "tuples" do
-    assert Info.info({:ok, "good!"}) == ["Data type": "Tuple", "Reference modules": "Tuple"]
+    assert Info.info({:ok, "good!"}) == [{"Data type", "Tuple"}, {"Reference modules", "Tuple"}]
   end
 
-  test "atoms: loaded module (without docs)" do
-    info = Info.info(Foo)
-    assert info[:"Data type"] == "Atom"
-    assert info[:Source] == Path.relative_to_cwd(__ENV__.file)
-    assert info[:Description] == "Call IEx.InfoTest.Foo.module_info() to access metadata."
-    assert info[:"Raw representation"] == ~s(:"Elixir.IEx.InfoTest.Foo")
+  describe "atoms" do
+    test "loaded module (without docs)" do
+      info = Info.info(Foo)
+      assert get_key(info, "Data type") == "Atom"
+      assert get_key(info, "Source") == Path.relative_to_cwd(__ENV__.file)
+      assert get_key(info, "Description") == "Call IEx.InfoTest.Foo.module_info() to access metadata."
+      assert get_key(info, "Raw representation") == ~s(:"Elixir.IEx.InfoTest.Foo")
+    end
+
+    test "loaded module (with docs)" do
+      info = Info.info(List)
+
+      description = """
+      Use h(List) to access its documentation.
+      Call List.module_info() to access metadata.\
+      """
+
+      assert get_key(info, "Description") == description
+    end
+
+    test "module that is also a protocol" do
+      info = Info.info(String.Chars)
+      protocol_info = get_key(info, "Protocol")
+      assert protocol_info =~ "This module is a protocol"
+      assert protocol_info =~ "Atom"
+      assert protocol_info =~ "BitString"
+    end
+
+    test "module-like atom (Foo)" do
+      info = Info.info(NonexistentModuleAtom)
+      assert get_key(info, "Raw representation") == ~s(:"Elixir.NonexistentModuleAtom")
+    end
+
+    test "regular atom" do
+      assert Info.info(:foo) == [{"Data type", "Atom"}, {"Reference modules", "Atom"}]
+    end
   end
 
-  test "atoms: loaded module (with docs)" do
-    info = Info.info(List)
+  describe "lists" do
+    test "charlists" do
+      info = Info.info('foo')
+      assert get_key(info, "Description") =~ "This is a list of integers that is printed"
+      assert get_key(info, "Raw representation") == "[102, 111, 111]"
+    end
 
-    description =
-      "Use h(List) to access its documentation.\n" <>
-        "Call List.module_info() to access metadata."
+    test "keyword lists" do
+      info = Info.info(a: 1, b: 2)
+      assert get_key(info, "Description") =~ "This is what is referred to as a \"keyword list\""
+    end
 
-    assert info[:Description] == description
+    test "regular lists" do
+      assert get_key(Info.info([:foo, :bar, :baz]), "Reference modules") == "List"
+    end
   end
 
-  test "atoms: module that is also a protocol" do
-    info = Info.info(String.Chars)
-    description = info[:Protocol]
-    assert description =~ "This module is a protocol"
-    assert description =~ "Atom"
-    assert description =~ "BitString"
-  end
+  describe "bitstring" do
+    test "strings" do
+      info = Info.info("føø")
+      assert get_key(info, "Byte size") == 5
+      assert get_key(info, "Description") =~ "This is a string: a UTF-8 encoded binary"
+      assert get_key(info, "Raw representation") == "<<102, 195, 184, 195, 184>>"
+    end
 
-  test "atoms: module-like atom (Foo)" do
-    info = Info.info(NonexistentModuleAtom)
-    assert info[:"Raw representation"] == ~s(:"Elixir.NonexistentModuleAtom")
-  end
+    test "non-printable string" do
+      info = Info.info(<<"foo", 0, "bar">>)
+      description = get_key(info, "Description")
 
-  test "atoms: regular atom" do
-    assert Info.info(:foo) == ["Data type": "Atom", "Reference modules": "Atom"]
-  end
+      assert get_key(info, "Byte size") == 7
+      assert description =~ "This is a string"
+      assert description =~ "It's printed with the `<<>>`"
+      assert description =~ "the first non-printable codepoint being\n`<<0>>`"
+    end
 
-  test "lists: charlists" do
-    info = Info.info('foo')
-    assert info[:Description] =~ "This is a list of integers that is printed"
-    assert info[:"Raw representation"] == "[102, 111, 111]"
-  end
+    test "binary" do
+      info = Info.info(<<255, 255>>)
+      assert get_key(info, "Description") =~ "This is a binary: a collection of bytes"
+    end
 
-  test "lists: keyword lists" do
-    info = Info.info(a: 1, b: 2)
-    assert info[:Description] =~ "This is what is referred to as a \"keyword list\""
-  end
-
-  test "lists: regular lists" do
-    assert Info.info([:foo, :bar, :baz])[:"Reference modules"] == "List"
-  end
-
-  test "bitstring: strings" do
-    info = Info.info("føø")
-    assert info[:"Byte size"] == 5
-    assert info[:Description] =~ "This is a string: a UTF-8 encoded binary"
-    assert info[:"Raw representation"] == "<<102, 195, 184, 195, 184>>"
-  end
-
-  test "bitstring: non-printable string" do
-    info = Info.info(<<"foo", 0, "bar">>)
-    assert info[:"Byte size"] == 7
-    assert info[:Description] =~ "This is a string"
-    assert info[:Description] =~ "It's printed with the `<<>>`"
-    assert info[:Description] =~ "the first non-printable codepoint being\n`<<0>>`"
-  end
-
-  test "bitstring: binary" do
-    info = Info.info(<<255, 255>>)
-    assert info[:Description] =~ "This is a binary: a collection of bytes"
-  end
-
-  test "bitstring: bitstring" do
-    info = Info.info(<<1::1>>)
-    assert info[:"Bits size"] == 1
-    assert info[:Description] =~ "This is a bitstring"
+    test "bitstring" do
+      info = Info.info(<<1::1>>)
+      assert get_key(info, "Bits size") == 1
+      assert get_key(info, "Description") =~ "This is a bitstring"
+    end
   end
 
   test "integers" do
-    assert Info.info(99) == ["Data type": "Integer", "Reference modules": "Integer"]
+    assert Info.info(99) == [{"Data type", "Integer"}, {"Reference modules", "Integer"}]
   end
 
   test "float" do
-    assert Info.info(3.14) == ["Data type": "Float", "Reference modules": "Float"]
+    assert Info.info(3.14) == [{"Data type", "Float"}, {"Reference modules", "Float"}]
   end
 
-  test "functions: named function" do
-    info = Info.info(&String.length/1)
-    assert info[:Type] == "external"
-    assert info[:Arity] == 1
-  end
+  describe "functions" do
+    test "named function" do
+      info = Info.info(&String.length/1)
+      assert get_key(info, "Type") == "external"
+      assert get_key(info, "Arity") == 1
+    end
 
-  test "functions: anonymous function" do
-    info = Info.info(fn -> :ok end)
-    assert info[:Type] == "local"
-    assert info[:Arity] == 0
-    assert info[:Description] == "This is an anonymous function."
+    test "anonymous function" do
+      info = Info.info(fn -> :ok end)
+      assert get_key(info, "Type") == "local"
+      assert get_key(info, "Arity") == 0
+      assert get_key(info, "Description") == "This is an anonymous function."
+    end
   end
 
   test "PIDs" do
     pid = spawn_link(fn -> Process.sleep(1000) end)
 
     info = Info.info(pid)
-    assert info[:Alive] == true
-    assert info[:Name] == "not registered"
-    assert info[:Links] == inspect(self())
-    assert info[:"Message queue length"] == 0
+    assert get_key(info, "Alive") == true
+    assert get_key(info, "Name") == "not registered"
+    assert get_key(info, "Links") == inspect(self())
+    assert get_key(info, "Message queue length") == 0
 
     Process.register(pid, :iex_info_registered_pid)
     Process.unlink(pid)
     send(pid, :oops)
     info = Info.info(pid)
-    assert info[:Name] == ":iex_info_registered_pid"
-    assert info[:Links] == "none"
-    assert info[:"Message queue length"] == 1
+    assert get_key(info, "Name") == ":iex_info_registered_pid"
+    assert get_key(info, "Links") == "none"
+    assert get_key(info, "Message queue length") == 1
 
     Process.exit(pid, :kill)
-    assert Info.info(pid)[:Alive] == false
+    assert get_key(Info.info(pid), "Alive") == false
   end
 
   test "ports" do
     {:ok, port} = :gen_udp.open(0)
-    assert Info.info(port)[:Open] == true
+    assert get_key(Info.info(port), "Open") == true
     :ok = :gen_udp.close(port)
-    assert Info.info(port)[:Open] == false
+    assert get_key(Info.info(port), "Open") == false
   end
 
   test "references" do
-    assert Info.info(make_ref()) == ["Data type": "Reference"]
+    assert Info.info(make_ref()) == [{"Data type", "Reference"}]
   end
 
-  test "date" do
-    {:ok, date} = Date.new(2017, 1, 1)
-    info = Info.info(date)
-    assert info[:"Data type"] == "Date"
+  describe "calendar types" do
+    test "date" do
+      {:ok, date} = Date.new(2017, 1, 1)
+      info = Info.info(date)
+      assert get_key(info, "Data type") == "Date"
 
-    assert info[:"Raw representation"] ==
-             "%Date{calendar: Calendar.ISO, day: 1, month: 1, year: 2017}"
+      assert get_key(info, "Raw representation") ==
+               "%Date{calendar: Calendar.ISO, day: 1, month: 1, year: 2017}"
 
-    assert info[:"Reference modules"] == "Date, Calendar, Map"
-    assert info[:Description] =~ "a date"
-    assert info[:Description] =~ "`~D`"
-  end
+      assert get_key(info, "Reference modules") == "Date, Calendar, Map"
+      assert get_key(info, "Description") =~ "a date"
+      assert get_key(info, "Description") =~ "`~D`"
+    end
 
-  test "time" do
-    {:ok, time} = Time.new(23, 59, 59)
-    info = Info.info(time)
-    assert info[:"Data type"] == "Time"
+    test "time" do
+      {:ok, time} = Time.new(23, 59, 59)
+      info = Info.info(time)
+      assert get_key(info, "Data type") == "Time"
 
-    assert info[:"Raw representation"] ==
-             "%Time{calendar: Calendar.ISO, hour: 23, microsecond: {0, 0}, minute: 59, second: 59}"
+      assert get_key(info, "Raw representation") ==
+               "%Time{calendar: Calendar.ISO, hour: 23, microsecond: {0, 0}, minute: 59, second: 59}"
 
-    assert info[:"Reference modules"] == "Time, Calendar, Map"
-    assert info[:Description] =~ "a time"
-    assert info[:Description] =~ "`~T`"
-  end
+      assert get_key(info, "Reference modules") == "Time, Calendar, Map"
+      assert get_key(info, "Description") =~ "a time"
+      assert get_key(info, "Description") =~ "`~T`"
+    end
 
-  test "naive datetime" do
-    {:ok, time} = NaiveDateTime.new(2017, 1, 1, 23, 59, 59)
-    info = Info.info(time)
-    assert info[:"Data type"] == "NaiveDateTime"
+    test "naive datetime" do
+      {:ok, time} = NaiveDateTime.new(2017, 1, 1, 23, 59, 59)
+      info = Info.info(time)
+      assert get_key(info, "Data type") == "NaiveDateTime"
 
-    assert info[:"Raw representation"] ==
-             "%NaiveDateTime{calendar: Calendar.ISO, day: 1, hour: 23, microsecond: {0, 0}, minute: 59, month: 1, second: 59, year: 2017}"
+      assert get_key(info, "Raw representation") ==
+               "%NaiveDateTime{calendar: Calendar.ISO, day: 1, hour: 23, microsecond: {0, 0}, minute: 59, month: 1, second: 59, year: 2017}"
 
-    assert info[:"Reference modules"] == "NaiveDateTime, Calendar, Map"
-    assert info[:Description] =~ ~S{a "naive" datetime (that is, a datetime without a timezone)}
-    assert info[:Description] =~ "`~N`"
+      assert get_key(info, "Reference modules") == "NaiveDateTime, Calendar, Map"
+      assert get_key(info, "Description") =~ ~S{a "naive" datetime (that is, a datetime without a timezone)}
+      assert get_key(info, "Description") =~ "`~N`"
+    end
   end
 
   test "structs" do
     info = Info.info(%Foo{})
-    assert info[:"Data type"] == "IEx.InfoTest.Foo"
-    assert info[:Description] == "This is a struct. Structs are maps with a __struct__ key."
-    assert info[:"Reference modules"] == "IEx.InfoTest.Foo, Map"
+    assert get_key(info, "Data type") == "IEx.InfoTest.Foo"
+    assert get_key(info, "Description") == "This is a struct. Structs are maps with a __struct__ key."
+    assert get_key(info, "Reference modules") == "IEx.InfoTest.Foo, Map"
+  end
+
+  defp get_key(info, key) do
+    {^key, value} = List.keyfind(info, key, 0)
+    value
   end
 end

--- a/lib/iex/test/iex/info_test.exs
+++ b/lib/iex/test/iex/info_test.exs
@@ -18,7 +18,10 @@ defmodule IEx.InfoTest do
       info = Info.info(Foo)
       assert get_key(info, "Data type") == "Atom"
       assert get_key(info, "Source") == Path.relative_to_cwd(__ENV__.file)
-      assert get_key(info, "Description") == "Call IEx.InfoTest.Foo.module_info() to access metadata."
+
+      assert get_key(info, "Description") ==
+               "Call IEx.InfoTest.Foo.module_info() to access metadata."
+
       assert get_key(info, "Raw representation") == ~s(:"Elixir.IEx.InfoTest.Foo")
     end
 
@@ -189,7 +192,10 @@ defmodule IEx.InfoTest do
                "%NaiveDateTime{calendar: Calendar.ISO, day: 1, hour: 23, microsecond: {0, 0}, minute: 59, month: 1, second: 59, year: 2017}"
 
       assert get_key(info, "Reference modules") == "NaiveDateTime, Calendar, Map"
-      assert get_key(info, "Description") =~ ~S{a "naive" datetime (that is, a datetime without a timezone)}
+
+      assert get_key(info, "Description") =~
+               ~S{a "naive" datetime (that is, a datetime without a timezone)}
+
       assert get_key(info, "Description") =~ "`~N`"
     end
   end
@@ -197,7 +203,10 @@ defmodule IEx.InfoTest do
   test "structs" do
     info = Info.info(%Foo{})
     assert get_key(info, "Data type") == "IEx.InfoTest.Foo"
-    assert get_key(info, "Description") == "This is a struct. Structs are maps with a __struct__ key."
+
+    assert get_key(info, "Description") ==
+             "This is a struct. Structs are maps with a __struct__ key."
+
     assert get_key(info, "Reference modules") == "IEx.InfoTest.Foo, Map"
   end
 


### PR DESCRIPTION
We were returning info from the protocol as lists of `{atom, string}` pairs with atoms being "titles" of info (such as "Reference modules"). This is a bit weird and it definitely becomes annoying with the new code formatter because it formats things like `["Description": ...]` as `[Description: ...]` which looks weird.

This PR turns all atom keys into strings so that now info is a list of `{string, string}` tuples.

I'm sure @fishcakez will be much relieved by this PR :).