### PR TITLE
On mix format checks formatted for stdin

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -237,8 +237,12 @@ defmodule Mix.Tasks.Format do
   end
 
   defp to_bullet_list(files) do
-    Enum.map_join(files, "\n", &["  * ", &1])
+    Enum.map_join(files, "\n", &bullet_line/1)
   end
+
+  defp bullet_line("-"), do: ["  * stdin"]
+
+  defp bullet_line(file), do: ["  * ", file]
 
   defp equivalent?(input, output) do
     Code.Formatter.equivalent(input, output) == :ok

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -91,6 +91,21 @@ defmodule Mix.Tasks.FormatTest do
     end
   end
 
+  test "checks if stdin is formatted with --check-formatted" do
+    assert_raise Mix.Error, ~r"mix format failed due to --check-formatted", fn ->
+      capture_io("foo( )", fn ->
+        Mix.Tasks.Format.run(["--check-formatted", "-"])
+      end)
+    end
+
+    output =
+      capture_io("foo()\n", fn ->
+        Mix.Tasks.Format.run(["--check-formatted", "-"])
+      end)
+
+    assert output == ""
+  end
+
   test "checks if file is equivalent with --check-equivalent", context do
     in_tmp context.test, fn ->
       File.write!("a.ex", """


### PR DESCRIPTION
Improve output message when --check-* is passed to mix format with
stdin. And add tests for --check-formated with stdin.

Before when we ran `$ echo 'foo( )' | mix format  - --check-formatted` the output was

```
** (Mix) mix format failed due to --check-formatted.
The following files were not formatted:

  * -
```

Now the output will tell on the bullet list that the formatted error came from stdin

```
** (Mix) mix format failed due to --check-formatted.
The following files were not formatted:

  * stdin
```