### PR TITLE
Fix Enum.max for Date.Range by implementing it as a protocol.

### DIFF
--- a/lib/elixir/lib/calendar/date_range.ex
+++ b/lib/elixir/lib/calendar/date_range.ex
@@ -22,6 +22,14 @@ defmodule Date.Range do
   defstruct [:first, :last, :first_in_iso_days, :last_in_iso_days]
 
   defimpl Enumerable do
+    def max(%Date.Range{first: first, last: last}) do
+      if Date.compare(last, first) == :gt do
+        {:ok, last}
+      else
+        {:ok, first}
+      end
+    end
+
     def member?(
           %{
             first: %{calendar: calendar, year: first_year, month: first_month, day: first_day},

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -131,6 +131,10 @@ defprotocol Enumerable do
   @spec member?(t, term) :: {:ok, boolean} | {:error, module}
   def member?(enumerable, element)
 
+  @doc false
+  @spec max(t) :: {:ok, term} | {:error, module}
+  def max(enumerable)
+
   @doc """
   Retrieves the enumerable's size.
 
@@ -1442,7 +1446,13 @@ defmodule Enum do
   def max(enumerable, empty_fallback \\ fn -> raise Enum.EmptyError end)
 
   def max(enumerable, empty_fallback) do
-    aggregate(enumerable, & &1, &Kernel.max/2, empty_fallback)
+    case Enumerable.max(enumerable) do
+      {:ok, element} ->
+        element
+
+      {:error, _module} ->
+        aggregate(enumerable, & &1, &Kernel.max/2, empty_fallback)
+    end
   end
 
   @doc """
@@ -3249,6 +3259,8 @@ end
 defimpl Enumerable, for: List do
   def count(_list), do: {:error, __MODULE__}
 
+  def max(_list), do: {:error, __MODULE__}
+
   def member?(_list, _value), do: {:error, __MODULE__}
 
   def reduce(_, {:halt, acc}, _fun), do: {:halted, acc}
@@ -3261,6 +3273,8 @@ defimpl Enumerable, for: Map do
   def count(map) do
     {:ok, map_size(map)}
   end
+
+  def max(_map), do: {:error, __MODULE__}
 
   def member?(map, {key, value}) do
     {:ok, match?(%{^key => ^value}, map)}
@@ -3282,6 +3296,8 @@ end
 
 defimpl Enumerable, for: Function do
   def count(_function), do: {:error, __MODULE__}
+
+  def max(_function), do: {:error, __MODULE__}
 
   def member?(_function, _value), do: {:error, __MODULE__}
 

--- a/lib/elixir/lib/file/stream.ex
+++ b/lib/elixir/lib/file/stream.ex
@@ -120,6 +120,8 @@ defmodule File.Stream do
       end
     end
 
+    def max(_stream), do: {:error, __MODULE__}
+
     def member?(_stream, _term) do
       {:error, __MODULE__}
     end

--- a/lib/elixir/lib/gen_event/stream.ex
+++ b/lib/elixir/lib/gen_event/stream.ex
@@ -57,6 +57,8 @@ defimpl Enumerable, for: GenEvent.Stream do
     {:error, __MODULE__}
   end
 
+  def max(_stream), do: {:error, __MODULE__}
+
   def member?(_stream, _item) do
     {:error, __MODULE__}
   end

--- a/lib/elixir/lib/hash_dict.ex
+++ b/lib/elixir/lib/hash_dict.ex
@@ -252,6 +252,8 @@ defimpl Enumerable, for: HashDict do
     module.reduce(dict, acc, fun)
   end
 
+  def max(_dict), do: {:error, __MODULE__}
+
   def member?(dict, {key, value}) do
     # Avoid warnings about HashDict being deprecated.
     module = HashDict

--- a/lib/elixir/lib/hash_set.ex
+++ b/lib/elixir/lib/hash_set.ex
@@ -262,6 +262,8 @@ defimpl Enumerable, for: HashSet do
     module.reduce(set, acc, fun)
   end
 
+  def max(_set), do: {:error, __MODULE__}
+
   def member?(set, term) do
     # Avoid warnings about HashSet being deprecated.
     module = HashSet

--- a/lib/elixir/lib/io/stream.ex
+++ b/lib/elixir/lib/io/stream.ex
@@ -66,6 +66,8 @@ defmodule IO.Stream do
       {:error, __MODULE__}
     end
 
+    def max(_stream), do: {:error, __MODULE__}
+
     def member?(_stream, _term) do
       {:error, __MODULE__}
     end

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -367,6 +367,7 @@ defmodule MapSet do
 
   defimpl Enumerable do
     def reduce(map_set, acc, fun), do: Enumerable.List.reduce(MapSet.to_list(map_set), acc, fun)
+    def max(_map_set), do: {:error, __MODULE__}
     def member?(map_set, val), do: {:ok, MapSet.member?(map_set, val)}
     def count(map_set), do: {:ok, MapSet.size(map_set)}
   end

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -100,6 +100,14 @@ defimpl Enumerable, for: Range do
     {:done, acc}
   end
 
+  def max(first..last) do
+    if last > first do
+      {:ok, last}
+    else
+      {:ok, first}
+    end
+  end
+
   def member?(first..last, value) when is_integer(value) do
     if first <= last do
       {:ok, first <= value and value <= last}

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1494,6 +1494,8 @@ defimpl Enumerable, for: Stream do
     {:error, __MODULE__}
   end
 
+  def max(_lazy), do: {:error, __MODULE__}
+
   def member?(_lazy, _value) do
     {:error, __MODULE__}
   end

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -377,6 +377,10 @@ defmodule EnumTest do
     assert Enum.max([1]) == 1
     assert Enum.max([1, 2, 3]) == 3
     assert Enum.max([1, [], :a, {}]) == []
+    assert Enum.max(1..10) == 10
+    assert Enum.max(10..1) == 10
+    assert Enum.max(Date.range(~D[1999-12-30], ~D[2000-01-01])) == ~D[2000-01-01]
+    assert Enum.max(Date.range(~D[2000-01-01], ~D[1999-12-30])) == ~D[2000-01-01]
 
     assert_raise Enum.EmptyError, fn ->
       Enum.max([])


### PR DESCRIPTION
1. Fix `Enum.max` for `Date.Range` by implementing it as a protocol (in current implementation `~D[1999-12-31]` is bigger than `~D[2000-01-01]`)
2. Speed up `Enum.max` for `Range` from O(N) to O(1).

I would also add docs for `Enumerable.max` and implement `Enum.mix` in the same way, but I need initial approval from core team.
Any feedback is welcome.
Cheers.