### PR TITLE
Handle external files for xref callers and warnings

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.xref.ex
+++ b/lib/mix/lib/mix/tasks/compile.xref.ex
@@ -95,9 +95,8 @@ defmodule Mix.Tasks.Compile.Xref do
   end
 
   defp to_diagnostics(warnings, severity) do
-    for {file, entries} <- warnings,
-        {lines, message} <- entries,
-        line <- lines do
+    for {message, locations} <- warnings,
+        {file, line} <- locations do
       %Mix.Task.Compiler.Diagnostic{
         compiler_name: "Xref",
         file: Path.absname(file),

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -170,11 +170,11 @@ defmodule Mix.Tasks.XrefTest do
     """
 
     warning = """
-    warning: function :not_a_module.no_module/0 is undefined (module :not_a_module is not available)
-      lib/a.ex:2
-
     warning: function :lists.no_func/0 is undefined or private
       lib/a.ex:3
+
+    warning: function :not_a_module.no_module/0 is undefined (module :not_a_module is not available)
+      lib/a.ex:2
 
     """
 
@@ -195,11 +195,11 @@ defmodule Mix.Tasks.XrefTest do
     """
 
     warning = """
-    warning: function A2.no_func/0 is undefined or private
-      lib/a.ex:2
-
     warning: function A1.no_func/0 is undefined or private
       lib/a.ex:7
+
+    warning: function A2.no_func/0 is undefined or private
+      lib/a.ex:2
 
     """
 
@@ -248,7 +248,7 @@ defmodule Mix.Tasks.XrefTest do
     warning: function A.no_func/0 is undefined or private
     Found at 2 locations:
       lib/a.ex:2
-      lib/a.ex:6
+      lib/a.ex:7
 
     warning: function A2.no_func/0 is undefined (module A2 is not available)
     Found at 2 locations:
@@ -367,7 +367,7 @@ defmodule Mix.Tasks.XrefTest do
 
       output =
         capture_io(:stderr, fn ->
-          assert Mix.Task.run("xref", ["warnings"]) == {:ok, []}
+          assert Mix.Task.run("xref", ["warnings"]) == {:ok, %{}}
         end)
 
       assert output == ""

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.XrefTest do
       lib/a.ex:2
 
     warning: function A.no_func/1 is undefined or private
-      lib/a.ex:6
+      lib/external_source.ex:6
 
     """
 
@@ -67,7 +67,7 @@ defmodule Mix.Tasks.XrefTest do
 
           * b/0
 
-      lib/a.ex:6
+      lib/external_source.ex:6
 
     """
 
@@ -89,7 +89,7 @@ defmodule Mix.Tasks.XrefTest do
       lib/a.ex:2
 
     warning: function E.no_module/0 is undefined (module E is not available)
-      lib/a.ex:5
+      lib/external_source.ex:5
 
     """
 
@@ -111,7 +111,7 @@ defmodule Mix.Tasks.XrefTest do
       lib/a.ex:2
 
     warning: function A.no_func/1 is undefined or private
-      lib/a.ex:5
+      lib/external_source.ex:5
 
     """
 
@@ -235,26 +235,25 @@ defmodule Mix.Tasks.XrefTest do
     code = """
     defmodule A do
       def a, do: A.no_func
-      def b, do: A2.no_func
-      def c, do: A.no_func
-      def d, do: A2.no_func
 
       @file "lib/external_source.ex"
-      def e, do: A.no_func
+      def b, do: A2.no_func
+
+      def c, do: A.no_func
+      def d, do: A2.no_func
     end
     """
 
     warning = """
     warning: function A.no_func/0 is undefined or private
-    Found at 3 locations:
+    Found at 2 locations:
       lib/a.ex:2
-      lib/a.ex:4
-      lib/a.ex:8
+      lib/a.ex:6
 
     warning: function A2.no_func/0 is undefined (module A2 is not available)
     Found at 2 locations:
-      lib/a.ex:3
-      lib/a.ex:5
+      lib/a.ex:8
+      lib/external_source.ex:5
 
     """
 
@@ -332,7 +331,7 @@ defmodule Mix.Tasks.XrefTest do
     Found at 3 locations:
       lib/a.ex:4
       lib/a.ex:5
-      lib/a.ex:10
+      lib/external_source.ex:10
 
     """
 
@@ -390,7 +389,7 @@ defmodule Mix.Tasks.XrefTest do
 
     warning = """
     lib/a.ex:2: A.no_func/0
-    lib/a.ex:6: A.no_func/0
+    lib/external_source.ex:6: A.no_func/0
     """
 
     assert_unreachable(code, warning)

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -367,7 +367,7 @@ defmodule Mix.Tasks.XrefTest do
 
       output =
         capture_io(:stderr, fn ->
-          assert Mix.Task.run("xref", ["warnings"]) == {:ok, %{}}
+          assert Mix.Task.run("xref", ["warnings"]) == {:ok, []}
         end)
 
       assert output == ""
@@ -375,6 +375,10 @@ defmodule Mix.Tasks.XrefTest do
   end
 
   ## Unreachable
+
+  test "unreachable: reports nothing with no references" do
+    assert_reachable("defmodule A do end")
+  end
 
   test "unreachable: reports missing functions" do
     code = """
@@ -395,13 +399,17 @@ defmodule Mix.Tasks.XrefTest do
     assert_unreachable(code, warning)
   end
 
-  defp assert_unreachable(contents, expected) do
+  defp assert_reachable(contents) do
+    assert_unreachable(contents, "", :ok)
+  end
+
+  defp assert_unreachable(contents, expected, result \\ :error) do
     in_fixture "no_mixfile", fn ->
       File.write!("lib/a.ex", contents)
 
       output =
         capture_io(fn ->
-          assert Mix.Task.run("xref", ["unreachable"]) == :error
+          assert Mix.Task.run("xref", ["unreachable"]) == result
         end)
 
       assert output == expected


### PR DESCRIPTION
Use the file location available in the manifest to display external sources.

Closes #6629