### PR TITLE
Remove warning: variable "calendar" is unused

### DIFF
--- a/lib/elixir/lib/calendar/date_range.ex
+++ b/lib/elixir/lib/calendar/date_range.ex
@@ -22,7 +22,7 @@ defmodule Date.Range do
   defstruct [:first, :last, :first_in_iso_days, :last_in_iso_days]
 
   defimpl Enumerable do
-    def member?(range, %Date{calendar: calendar} = date) do
+    def member?(range, %Date{calendar: _calendar} = date) do
       %{
         first: first,
         last: last,


### PR DESCRIPTION
# Summary
Removes warning reported on compilation.

```
warning: variable "calendar" is unused
  lib/calendar/date_range.ex:25
```