### PR TITLE
Format @spec with map literal with multi keys

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -1286,8 +1286,8 @@ defmodule Code.Formatter do
     {name_left_doc, state} = quoted_to_algebra(name_left, :parens_arg, state)
     {name_right_doc, state} = quoted_to_algebra(name_right, :parens_arg, state)
     {args_doc, state} = quoted_to_algebra(args, :parens_arg, state)
-
     inner_args_doc = glue(name_left_doc, concat("| ", nest(name_right_doc, 2)))
+
     inner_args_doc =
       surround("(", inner_args_doc, ")") |> concat(" => ") |> concat(group(args_doc))
 

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -1281,6 +1281,20 @@ defmodule Code.Formatter do
     {surround(name_doc, args_doc, "}"), state}
   end
 
+  # @spec map
+  defp map_to_algebra(meta, name_doc, [{{:|, _, [name_left, name_right]}, args}], state) do
+    {name_left_doc, state} = quoted_to_algebra(name_left, :parens_arg, state)
+    {name_right_doc, state} = quoted_to_algebra(name_right, :parens_arg, state)
+    {args_doc, state} = quoted_to_algebra(args, :parens_arg, state)
+
+    inner_args_doc = glue(name_left_doc, concat("| ", nest(name_right_doc, 2)))
+    inner_args_doc =
+      surround("(", inner_args_doc, ")") |> concat(" => ") |> concat(group(args_doc))
+
+    name_doc = "%" |> concat(name_doc) |> concat("{")
+    {surround(name_doc, inner_args_doc, "}"), state}
+  end
+
   defp map_to_algebra(meta, name_doc, args, state) do
     {args_doc, state} =
       args_to_algebra_with_comments(args, meta, state, &quoted_to_algebra(&1, :parens_arg, &2))

--- a/lib/elixir/test/elixir/code_formatter/integration_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/integration_test.exs
@@ -143,6 +143,12 @@ defmodule Code.Formatter.IntegrationTest do
     """
   end
 
+  test "spec with multiple keys on type" do
+    assert_same """
+    @spec foo(%{(String.t() | atom) => any}) :: any
+    """
+  end
+
   test "multiple whens with new lines" do
     assert_same """
     def sleep(timeout)


### PR DESCRIPTION
This fixes #6951 

When we format the a map inside @spec and the @spec contains a map with `%{(String.t | atom) => any}` formats it properly 