### PR TITLE
Fix handling deprecated return value for Erlang.compile callback

### DIFF
--- a/lib/mix/lib/mix/compilers/erlang.ex
+++ b/lib/mix/lib/mix/compilers/erlang.ex
@@ -238,10 +238,10 @@ defmodule Mix.Compilers.Erlang do
         {:error, [], warnings, errors}
 
       {:ok, _} ->
-        {:ok, [], []}
+        {:ok, [], [], []}
 
       :error ->
-        {:error, [], []}
+        {:error, [], [], []}
     end
   end
 


### PR DESCRIPTION
`do_compile` should always return 4-element tuple. Looks like a minor mistake in https://github.com/elixir-lang/elixir/pull/6598.

On hexpm we are using custom compiler for protobuf [1] and it broke on
Elixir master:

    $ mix compile.all --force
    Compiling 4 files (.proto)
    ** (MatchError) no match of right hand side value: {:ok, [], []}
        (mix) lib/mix/compilers/erlang.ex:249: Mix.Compilers.Erlang.combine_results/2
        (elixir) lib/enum.ex:1826: Enum."-reduce/3-lists^foldl/2-0-"/3
        (mix) lib/mix/compilers/erlang.ex:125: Mix.Compilers.Erlang.compile/5
        (mix) lib/mix/task.ex:354: Mix.Task.run_alias/3
        (mix) lib/mix/task.ex:278: Mix.Task.run/2
        (mix) lib/mix/tasks/compile.all.ex:63: Mix.Tasks.Compile.All.run_compiler/2
        (mix) lib/mix/tasks/compile.all.ex:47: Mix.Tasks.Compile.All.do_compile/4
        (mix) lib/mix/tasks/compile.all.ex:18: anonymous fn/1 in Mix.Tasks.Compile.All.run/1
        (mix) lib/mix/tasks/compile.all.ex:34: Mix.Tasks.Compile.All.with_logger_app/1
        (mix) lib/mix/task.ex:315: Mix.Task.run_task/3
        (mix) lib/mix/tasks/compile.ex:90: Mix.Tasks.Compile.run/1
        (mix) lib/mix/task.ex:315: Mix.Task.run_task/3
        (mix) lib/mix/cli.ex:80: Mix.CLI.run_task/2
        (elixir) lib/code.ex:646: Code.require_file/2

As mentioned in [2], `{:ok, _}` and `:error` returns from compile
callback are to be deprecated in Elixir v1.8.

FWIW on hexpm side, a fix is to turn `{:ok, output}` into `{:ok, output, []}` (and similar for `:error`)

[1] https://github.com/hexpm/hexpm/blob/6c4e7ab2d569eb09848f74cf0179702d5a847a90/mix.exs#L103
[2] https://github.com/elixir-lang/elixir/blob/f36a0f4a389eb819f383de935935dcae201332bb/lib/mix/lib/mix/compilers/erlang.ex#L230