### PR TITLE
Make fun in Stream.do_reduce less confusing

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1497,7 +1497,7 @@ defimpl Enumerable, for: Stream do
   end
 
   defp do_reduce(%Stream{enum: enum, funs: funs, accs: accs, done: done}, acc, fun) do
-    composed = :lists.foldl(fn fun, acc -> fun.(acc) end, fun, funs)
+    composed = :lists.foldl(fn f1, acc -> f1.(acc) end, fun, funs)
     reduce = &Enumerable.reduce(enum, &1, composed)
     do_each(reduce, done && {done, fun}, :lists.reverse(accs), acc)
   end

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1497,7 +1497,7 @@ defimpl Enumerable, for: Stream do
   end
 
   defp do_reduce(%Stream{enum: enum, funs: funs, accs: accs, done: done}, acc, fun) do
-    composed = :lists.foldl(fn f1, acc -> f1.(acc) end, fun, funs)
+    composed = :lists.foldl(fn entry_fun, acc -> entry_fun.(acc) end, fun, funs)
     reduce = &Enumerable.reduce(enum, &1, composed)
     do_each(reduce, done && {done, fun}, :lists.reverse(accs), acc)
   end


### PR DESCRIPTION
IMHO, it is a bit confusing to shadow the outer `fun` in the first function passed into `:lists.unfoldl`. Maybe we could change it to `f1` to be consistent to the rest of the module?