### PR TITLE
Use Mix.shell.info over IO.write in Mix xref

### DIFF
--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -237,7 +237,7 @@ defmodule Mix.Tasks.Xref do
   ## Print unreachable
 
   defp print_unreachable(entries) do
-    Enum.each(entries, &IO.write(format_unreachable(&1)))
+    Enum.each(entries, &Mix.shell().info(format_unreachable(&1)))
     entries
   end
 
@@ -343,7 +343,7 @@ defmodule Mix.Tasks.Xref do
   ## Print callers
 
   defp print_calls(calls) do
-    Enum.map(calls, &IO.write(format_call(&1)))
+    Enum.map(calls, &Mix.shell().info(format_call(&1)))
     calls
   end
 

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -238,7 +238,6 @@ defmodule Mix.Tasks.Xref do
 
   defp print_unreachables(entries) do
     Enum.each(entries, &print_unreachable/1)
-
     entries
   end
 
@@ -346,7 +345,6 @@ defmodule Mix.Tasks.Xref do
 
   defp print_calls(calls) do
     Enum.each(calls, &print_call/1)
-
     calls
   end
 

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -343,7 +343,11 @@ defmodule Mix.Tasks.Xref do
   ## Print callers
 
   defp print_calls(calls) do
-    Enum.map(calls, &Mix.shell().info(format_call(&1)))
+    calls
+    |> Enum.flat_map(&format_call/1)
+    |> Enum.join("")
+    |> Mix.shell().info
+
     calls
   end
 

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -141,7 +141,7 @@ defmodule Mix.Tasks.Xref do
   end
 
   defp unreachable() do
-    case warnings(&print_unreachable/1) do
+    case warnings(&print_unreachables/1) do
       {:ok, []} -> :ok
       _ -> :error
     end
@@ -236,21 +236,20 @@ defmodule Mix.Tasks.Xref do
 
   ## Print unreachable
 
-  defp print_unreachable(entries) do
-    entries
-    |> Enum.flat_map(&format_unreachable/1)
-    |> Enum.join("\n")
-    |> Mix.shell().info
+  defp print_unreachables(entries) do
+    Enum.each(entries, &print_unreachable/1)
 
     entries
   end
 
-  defp format_unreachable({{_, module, function, arity, _}, locations}) do
+  defp print_unreachable({{_, module, function, arity, _}, locations}) do
+    shell = Mix.shell()
+
     for {file, line} <- locations do
-      [
+      shell.info([
         Exception.format_file_line(file, line, " "),
         Exception.format_mfa(module, function, arity)
-      ]
+      ])
     end
   end
 
@@ -346,20 +345,19 @@ defmodule Mix.Tasks.Xref do
   ## Print callers
 
   defp print_calls(calls) do
-    calls
-    |> Enum.flat_map(&format_call/1)
-    |> Enum.join("\n")
-    |> Mix.shell().info
+    Enum.each(calls, &print_call/1)
 
     calls
   end
 
-  defp format_call({{module, func, arity}, locations}) do
+  defp print_call({{module, func, arity}, locations}) do
+    shell = Mix.shell()
+
     for {file, line} <- locations do
-      [
+      shell.info([
         Exception.format_file_line(file, line, " "),
         Exception.format_mfa(module, func, arity)
-      ]
+      ])
     end
   end
 

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -237,7 +237,11 @@ defmodule Mix.Tasks.Xref do
   ## Print unreachable
 
   defp print_unreachable(entries) do
-    Enum.each(entries, &Mix.shell().info(format_unreachable(&1)))
+    entries
+    |> Enum.flat_map(&format_unreachable/1)
+    |> Enum.join("\n")
+    |> Mix.shell().info
+
     entries
   end
 
@@ -245,8 +249,7 @@ defmodule Mix.Tasks.Xref do
     for {file, line} <- locations do
       [
         Exception.format_file_line(file, line, " "),
-        Exception.format_mfa(module, function, arity),
-        ?\n
+        Exception.format_mfa(module, function, arity)
       ]
     end
   end
@@ -345,7 +348,7 @@ defmodule Mix.Tasks.Xref do
   defp print_calls(calls) do
     calls
     |> Enum.flat_map(&format_call/1)
-    |> Enum.join("")
+    |> Enum.join("\n")
     |> Mix.shell().info
 
     calls
@@ -355,8 +358,7 @@ defmodule Mix.Tasks.Xref do
     for {file, line} <- locations do
       [
         Exception.format_file_line(file, line, " "),
-        Exception.format_mfa(module, func, arity),
-        ?\n
+        Exception.format_mfa(module, func, arity)
       ]
     end
   end

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -396,6 +396,8 @@ defmodule Mix.Tasks.XrefTest do
     """
 
     warning = """
+    Compiling 2 files (.ex)
+    Generated sample app
     lib/a.ex:2: A.no_func/0
     lib/external_source.ex:6: A.no_func/0
     """
@@ -409,7 +411,7 @@ defmodule Mix.Tasks.XrefTest do
 
       assert Mix.Task.run("xref", ["unreachable"]) == result
 
-      assert_received {:mix_shell, :info, [^expected]}
+      assert ^expected = receive_until_no_messages([])
     end
   end
 
@@ -467,6 +469,8 @@ defmodule Mix.Tasks.XrefTest do
     }
 
     output = """
+    Compiling 2 files (.ex)
+    Generated sample app
     lib/a.ex:2: A.a/0
     lib/external_source.ex:8: A.a/0
     lib/a.ex:3: A.a/1
@@ -492,6 +496,8 @@ defmodule Mix.Tasks.XrefTest do
     }
 
     output = """
+    Compiling 2 files (.ex)
+    Generated sample app
     lib/a.ex:2: A.a/0
     lib/external_source.ex:8: A.a/0
     lib/a.ex:3: A.a/1
@@ -516,6 +522,8 @@ defmodule Mix.Tasks.XrefTest do
     }
 
     output = """
+    Compiling 2 files (.ex)
+    Generated sample app
     lib/a.ex:2: A.a/0
     lib/external_source.ex:8: A.a/0
     """
@@ -548,6 +556,8 @@ defmodule Mix.Tasks.XrefTest do
     }
 
     output = """
+    Compiling 2 files (.ex)
+    Generated sample app
     lib/b.ex:5: A.a/0
     lib/external_source.ex:10: A.a/0
     lib/b.ex:4: A.a_macro/0
@@ -577,6 +587,8 @@ defmodule Mix.Tasks.XrefTest do
     }
 
     output = """
+    Compiling 2 files (.ex)
+    Generated sample app
     lib/a.ex:4: Enum.flatten/1
     lib/external_source.ex:11: Enum.flatten/1
     lib/a.ex:4: Enum.map/2
@@ -619,6 +631,8 @@ defmodule Mix.Tasks.XrefTest do
     }
 
     output = """
+    Compiling 2 files (.ex)
+    Generated sample app
     lib/a.ex:4: Integer.is_even/1
     lib/a.ex:7: Integer.is_even/1
     lib/a.ex:10: Integer.is_even/1
@@ -674,7 +688,7 @@ defmodule Mix.Tasks.XrefTest do
 
       assert Mix.Task.run("xref", ["callers", callee]) == :ok
 
-      assert_received {:mix_shell, :info, [^expected]}
+      assert ^expected = receive_until_no_messages([])
     end
   end
 

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -377,7 +377,11 @@ defmodule Mix.Tasks.XrefTest do
   ## Unreachable
 
   test "unreachable: reports nothing with no references" do
-    assert_reachable("defmodule A do end")
+    in_fixture "no_mixfile", fn ->
+      File.write!("lib/a.ex", "defmodule A do end")
+
+      assert Mix.Task.run("xref", ["unreachable"]) == :ok
+    end
   end
 
   test "unreachable: reports missing functions" do
@@ -399,20 +403,13 @@ defmodule Mix.Tasks.XrefTest do
     assert_unreachable(code, warning)
   end
 
-  defp assert_reachable(contents) do
-    assert_unreachable(contents, "", :ok)
-  end
-
   defp assert_unreachable(contents, expected, result \\ :error) do
     in_fixture "no_mixfile", fn ->
       File.write!("lib/a.ex", contents)
 
-      output =
-        capture_io(fn ->
-          assert Mix.Task.run("xref", ["unreachable"]) == result
-        end)
+      assert Mix.Task.run("xref", ["unreachable"]) == result
 
-      assert output == expected
+      assert_received {:mix_shell, :info, [^expected]}
     end
   end
 
@@ -675,12 +672,9 @@ defmodule Mix.Tasks.XrefTest do
         File.write!(file, contents)
       end
 
-      output =
-        capture_io(fn ->
-          assert Mix.Task.run("xref", ["callers", callee]) == :ok
-        end)
+      assert Mix.Task.run("xref", ["callers", callee]) == :ok
 
-      assert output == expected
+      assert_received {:mix_shell, :info, [^expected]}
     end
   end
 


### PR DESCRIPTION
As discussed in #6963, `mix xref` did not incorporate umbrella sub-app names in its output due to `IO.write` being used instead of `Mix.shell.info`. This PR fixes that, and also the tests that were using `capture_io`, which does not work with `Mix.Shell.Process`