### PR TITLE
Unexpected behavior when using @impl true on fun

### DIFF
--- a/lib/elixir/test/elixir/kernel/impl_test.exs
+++ b/lib/elixir/test/elixir/kernel/impl_test.exs
@@ -24,6 +24,10 @@ defmodule Kernel.ImplTest do
     @callback foo(any) :: any
   end
 
+  defmodule BehaviourWithThreeArguments do
+    @callback foo(any, any, any) :: any
+  end
+
   defmodule MacroBehaviour do
     @macrocallback bar :: any
   end
@@ -332,6 +336,130 @@ defmodule Kernel.ImplTest do
              end
              """)
            end) == ""
+  end
+
+  test "does not warn for @impl when there is a second function with the same name" do
+    assert capture_err(fn ->
+             Code.eval_string(~S"""
+             defmodule Kernel.ImplTest.ImplAttributes do
+               @behaviour Kernel.ImplTest.BehaviourWithArgument
+
+               @impl true
+               def foo(arg_1) do
+                 foo(arg_1, [])
+               end
+
+               def foo(arg_1, _args), do: arg_1
+             end
+             """)
+           end) == ""
+  end
+
+  test "does not warn for @impl when the function conforms to typespec but has additional trailing default args" do
+    assert capture_err(fn ->
+             Code.eval_string(~S"""
+             defmodule Kernel.ImplTest.ImplAttributes do
+               @behaviour Kernel.ImplTest.BehaviourWithArgument
+
+               @impl true
+               def foo(arg_1, _args \\ []), do: arg_1
+             end
+             """)
+           end) == ""
+  end
+
+  test "does not warn for @impl when the function conforms to typespec but has additional leading default args" do
+    assert capture_err(fn ->
+             Code.eval_string(~S"""
+             defmodule Kernel.ImplTest.ImplAttributes do
+               @behaviour Kernel.ImplTest.BehaviourWithArgument
+
+               @impl true
+               def foo(_defaulted_arg \\ [], args), do: args
+             end
+             """)
+           end) == ""
+  end
+
+  test "does not warn for @impl when the function conforms to typespec but has default value for arg" do
+    assert capture_err(fn ->
+             Code.eval_string(~S"""
+             defmodule Kernel.ImplTest.ImplAttributes do
+               @behaviour Kernel.ImplTest.BehaviourWithArgument
+
+               @impl true
+               def foo(args \\ []), do: args
+             end
+             """)
+           end) == ""
+  end
+
+  test "does not warn for @impl when the function has more args than callback, but they're all defaulted " do
+    assert capture_err(fn ->
+             Code.eval_string(~S"""
+             defmodule Kernel.ImplTest.ImplAttributes do
+               @behaviour Kernel.ImplTest.BehaviourWithArgument
+
+               @impl true
+               def foo(args \\ [], _bar \\ []), do: args
+             end
+             """)
+           end) == ""
+  end
+
+  test "does not warn for @impl with defaults when the same function is defined mutiple times" do
+    assert capture_err(fn ->
+             Code.eval_string(~S"""
+             defmodule Kernel.ImplTest.ImplAttributes do
+               @behaviour Kernel.ImplTest.BehaviourWithArgument
+               @behaviour Kernel.ImplTest.BehaviourWithThreeArguments
+
+               @impl Kernel.ImplTest.BehaviourWithArgument
+               def foo(_foo \\ [], _bar \\ []), do: :ok
+
+               @impl Kernel.ImplTest.BehaviourWithThreeArguments
+               def foo(_foo, _bar, _baz, _qux \\ []), do: :ok
+             end
+             """)
+           end) == ""
+  end
+
+  test "warns for impl when module name doesn't match impl" do
+    error =
+      capture_err(fn ->
+        Code.eval_string(~S"""
+        defmodule Kernel.ImplTest.ImplAttributes do
+          @behaviour Kernel.ImplTest.BehaviourWithArgument
+          @behaviour Kernel.ImplTest.BehaviourWithThreeArguments
+
+          @impl Kernel.ImplTest.BehaviourWithThreeArguments
+          def foo(_foo \\ [], _bar \\ []), do: :ok
+
+          @impl Kernel.ImplTest.BehaviourWithArgument
+          def foo(_foo, _bar, _baz, _qux \\ []), do: :ok
+        end
+        """)
+      end)
+
+    assert error =~
+             "got \"@impl Kernel.ImplTest.BehaviourWithThreeArguments\" for function foo/2 but this behaviour does not specify such callback"
+
+    assert error =~
+             "got \"@impl Kernel.ImplTest.BehaviourWithArgument\" for function foo/4 but this behaviour does not specify such callback"
+  end
+
+  test "warns for @impl when the callback doesn't have enough args" do
+    assert capture_err(fn ->
+             Code.eval_string(~S"""
+             defmodule Kernel.ImplTest.ImplAttributes do
+               @behaviour Kernel.ImplTest.BehaviourWithArgument
+
+               @impl true
+               def foo(), do: :ok
+             end
+             """)
+           end) =~
+             "got \"@impl true\" for function foo/0 but no behaviour specifies such callback"
   end
 
   test "does not warn for no @impl when overriding callback" do


### PR DESCRIPTION
I've been recently playing around with `@impl true` and have found it weird that I'm getting warnings on functions that technically meet the behaviour's typespec, but have additional defaulted arguments. I've included a couple of tests that should illustrate the issue. For reference, here is the behaviour module:

```elixir
defmodule BehaviourWithArgument do
  @callback foo(any) :: any
end
```

The first test passes because I'm not using any default args, but the 2nd and 3rd tests fail because they contain additional (though defaulted) arguments.

The main reason I have functions that take more arguments than the typespec is so I can inject functions or data while testing. However, when actually running the app, it uses the default data/functions.

Is raising warnings on the 2nd and 3rd tests intended behavior or a potential bug? 

