### PR TITLE
Better handling of non existing atoms

### DIFF
--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -685,12 +685,20 @@ unsafe_to_atom(Part, Line, #elixir_tokenizer{}) when
     is_binary(Part) andalso size(Part) > 255;
     is_list(Part) andalso length(Part) > 255 ->
   {error, {Line, "atom length must be less than system limit: ", [$: | Part]}};
-unsafe_to_atom(Binary, _Line, #elixir_tokenizer{existing_atoms_only=true}) when is_binary(Binary) ->
-  {ok, binary_to_existing_atom(Binary, utf8)};
+unsafe_to_atom(Binary, Line, #elixir_tokenizer{existing_atoms_only=true}) when is_binary(Binary) ->
+  try
+    {ok, binary_to_existing_atom(Binary, utf8)}
+  catch
+    error:badarg -> {error, {Line, "unsafe atom does not exist: ", binary}}
+  end;
 unsafe_to_atom(Binary, _Line, #elixir_tokenizer{}) when is_binary(Binary) ->
   {ok, binary_to_atom(Binary, utf8)};
-unsafe_to_atom(List, _Line, #elixir_tokenizer{existing_atoms_only=true}) when is_list(List) ->
-  {ok, list_to_existing_atom(List)};
+unsafe_to_atom(List, Line, #elixir_tokenizer{existing_atoms_only=true}) when is_list(List) ->
+  try
+    {ok, list_to_existing_atom(List)}
+  catch
+    error:badarg -> {error, {Line, "unsafe atom does not exist: ", List}}
+  end;
 unsafe_to_atom(List, _Line, #elixir_tokenizer{}) when is_list(List) ->
   {ok, list_to_atom(List)}.
 

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -689,7 +689,7 @@ unsafe_to_atom(Binary, Line, #elixir_tokenizer{existing_atoms_only=true}) when i
   try
     {ok, binary_to_existing_atom(Binary, utf8)}
   catch
-    error:badarg -> {error, {Line, "unsafe atom does not exist: ", binary}}
+    error:badarg -> {error, {Line, "unsafe atom does not exist: ", Binary}}
   end;
 unsafe_to_atom(Binary, _Line, #elixir_tokenizer{}) when is_binary(Binary) ->
   {ok, binary_to_atom(Binary, utf8)};

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -126,9 +126,9 @@ defmodule CodeTest do
 
     test "raises when string_to_quoted!/2 is used and no atom is found with :existing_atoms_only" do
       unknown_atom = ":there_is_no_such_atom"
-
-      assert catch_error(Code.string_to_quoted!(unknown_atom, existing_atoms_only: true)) ==
-               :badarg
+      assert_raise SyntaxError, fn ->
+        Code.string_to_quoted!(unknown_atom, existing_atoms_only: true)
+      end
     end
   end
 

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -126,7 +126,9 @@ defmodule CodeTest do
 
     test "raises when string_to_quoted!/2 is used and no atom is found with :existing_atoms_only" do
       unknown_atom = ":there_is_no_such_atom"
-      assert_raise SyntaxError, fn ->
+      message = "nofile:1: unsafe atom does not exist: there_is_no_such_atom"
+
+      assert_raise SyntaxError, message, fn ->
         Code.string_to_quoted!(unknown_atom, existing_atoms_only: true)
       end
     end


### PR DESCRIPTION
Addresses #6974 by always catching the `error:badarg` when `Code.string_to_quoted/2` is called with `existing_atoms_only: true`, returning an error tuple in `Code.string_to_quoted/2` and raising a `SyntaxError` in `Code.string_to_quoted!/2`.