### PR TITLE
Fix formatting of multiline "foo.{...}" calls

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -1877,6 +1877,10 @@ defmodule Code.Formatter do
     meta[:format] == :list_heredoc
   end
 
+  defp next_break_fits?({{:., _, [_left, :{}]}, _, _}) do
+    true
+  end
+
   defp next_break_fits?({:__block__, _meta, [{_, _}]}) do
     true
   end

--- a/lib/elixir/test/elixir/code_formatter/calls_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/calls_test.exs
@@ -154,6 +154,23 @@ defmodule Code.Formatter.CallsTest do
 
       assert_format bad, good, @short_length
     end
+
+    test "for {} calls" do
+      bad = """
+      alias Foo.{
+              Bar, Baz
+            }
+      """
+
+      good = """
+      alias Foo.{
+        Bar,
+        Baz
+      }
+      """
+
+      assert_format bad, good, @medium_length
+    end
   end
 
   describe "local calls" do


### PR DESCRIPTION
Calls such as `alias Foo.{Bar}` would be formatted when multiline as

```elixir
alias Foo.{
        Bar
      }
```

Now they're formatted as

```elixir
alias Foo.{
  Bar
}
```