### PR TITLE
Handle final sigma unicode exception

### DIFF
--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -159,6 +159,11 @@ defmodule StringTest do
     assert String.downcase("áüÈß") == "áüèß"
   end
 
+  test "downcase/1 with greek final sigma" do
+    assert String.downcase("ΣΣ") == "σς"
+    assert String.downcase("ΣΣ ΣΣ") == "σς σς"
+  end
+
   test "capitalize/1" do
     assert String.capitalize("") == ""
     assert String.capitalize("abc") == "Abc"


### PR DESCRIPTION
This is a first pass at resolving #6437. I'm not sure whether it's the right way to approach it, as it adds a decent amount of time to the compilation step for unicode (on my machine, `make unicode` runs in 31s vs 13s).

I got the approach from [this blog post](http://knight666.com/blog/the-curious-case-of-the-greek-final-sigma/) that uses the final sigma unless the next code point is in the [Letter general category](https://en.wikipedia.org/wiki/Unicode_character_property#General_Category)