### PR TITLE
Mention that HiPE-compiled modules won't call `@on_load` callback

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -220,7 +220,7 @@ defmodule Module do
         end
       end
 
-  Modules compiled with HiPE can not use this module attribute.
+  Modules compiled with HiPE would not call this hook.
 
   ### `@vsn`
 

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -220,6 +220,8 @@ defmodule Module do
         end
       end
 
+  Modules compiled with HiPE can not use this module attribute.
+
   ### `@vsn`
 
   Specify the module version. Accepts any valid Elixir value, for example:


### PR DESCRIPTION
Erlang is updating their docs regarding HiPE limitations and I think we need to mention that they also apply on Elixir.

Related changes: https://github.com/erlang/otp/pull/1618/files#diff-a0bf0e1ae6adf3eee9a66899aef70923R77