### PR TITLE
Fix IO.warn/2 crash

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -222,7 +222,7 @@ defmodule IO do
     message = [to_chardata(message), ?\n, "  ", formatted_trace, ?\n]
     line = opts[:line]
     file = opts[:file]
-    :elixir_errors.bare_warn(line, file && List.to_string(file), message)
+    :elixir_errors.bare_warn(line, file && chardata_to_string(file), message)
   end
 
   @doc """


### PR DESCRIPTION
Before:

```
elixir[master]% cat a.exs
defmodule A do
  @compile {:parse_transform, :ms_transform}
end
```

```
elixir[master]% make compile && elixir a.exs
==> elixir (compile)
** (FunctionClauseError) no function clause matching in List.to_string/1

    The following arguments were given to List.to_string/1:

        # 1
        "a.exs"

    Attempted function clauses (showing 1 out of 1):

        def to_string(list) when is_list(list)

    (elixir) lib/list.ex:816: List.to_string/1
    (elixir) lib/io.ex:225: IO.warn/2
    (elixir) lib/module.ex:1572: Module.put_attribute/5
    a.exs:2: (module)
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
```