### PR TITLE
Add DynamicSupervisor

### DIFF
--- a/lib/elixir/docs.exs
+++ b/lib/elixir/docs.exs
@@ -59,6 +59,7 @@
     "Processes & Applications": [
       Agent,
       Application,
+      DynamicSupervisor,
       GenServer,
       Node,
       Process,

--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -1,0 +1,888 @@
+defmodule DynamicSupervisor do
+  @moduledoc ~S"""
+  A supervisor that starts children dynamically.
+
+  The `Supervisor` module was designed to handle mostly static children
+  that are started in the given order when the supervisor starts. A
+  `DynamicSupervisor` starts with no children. Instead, children are
+  started on demand via `start_child/2`. When a dynamic supervisor
+  terminates, all children are shutdown at the same time, with no guarantee
+  of ordering.
+
+  ## Examples
+
+  A dynamic supervisor is started with no children, only with the
+  supervision strategy (the only strategy currently supported is
+  `:one_for_one`):
+
+      {:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+  Once the dynamic supervisor is running, we can start children
+  with `start_child/2`, which receives a child specification:
+
+      {:ok, agent1} = DynamicSupervisor.start_link(sup, {Agent, fn -> %{} end})
+      Agent.update(agent1, &Map.put(&1, :key, "value"))
+      Agent.get(agent1, & &1)
+      #=> %{key: "value"}
+
+      {:ok, agent2} = DynamicSupervisor.start_link(sup, {Agent, fn -> %{} end})
+      Agent.get(agent2, & &1)
+      #=> %{}
+
+      DynamicSupervisor.count_children(sup_pid)
+      #=> %{active: 2, specs: 2, supervisors: 0, workers: 2}
+
+  ## Module-based supervisors
+
+  Similar to `Supervisor`, dynamic supervisors also support module-based
+  supervisors.
+
+      defmodule MyApp.DynamicSupervisor do
+        # Automatically defines child_spec/1
+        use DynamicSupervisor
+
+        def start_link(arg) do
+          DynamicSupervisor.start_link(__MODULE__, arg, name: __MODULE__)
+        end
+
+        def init(_arg) do
+          DynamicSupervisor.init(strategy: :one_for_one)
+        end
+      end
+
+  See the `Supervisor` docs for a discussion of when you may want to use
+  module-based supervisors.
+
+  ## Name registration
+
+  A supervisor is bound to the same name registration rules as a `GenServer`.
+  Read more about these rules in the documentation for `GenServer`.
+  """
+
+  @behaviour GenServer
+
+  @doc """
+  Callback invoked to start the supervisor and during hot code upgrades.
+
+  Developers typically invoke `DynamicSupervisor.init/1` at the end of
+  their init callback to return the proper supervision flags.
+  """
+  @callback init(args :: term) :: {:ok, sup_flags()} | :ignore
+
+  @opaque sup_flags() :: %{
+            strategy: strategy(),
+            intensity: non_neg_integer(),
+            period: pos_integer(),
+            max_children: non_neg_integer() | :infinity,
+            extra_arguments: [term()]
+          }
+
+  @typedoc "Option values used by the `start*` functions"
+  @type option :: {:name, Supervisor.name()} | init_option()
+
+  @typedoc "Options used by the `start*` functions"
+  @type options :: [option, ...]
+
+  @typedoc "Options given to `start_link/2` and `init/1`"
+  @type init_option ::
+          {:strategy, strategy()}
+          | {:max_restarts, non_neg_integer()}
+          | {:max_seconds, pos_integer()}
+          | {:max_children, non_neg_integer() | :infinity}
+          | {:extra_arguments, [term()]}
+
+  @typedoc "Supported strategies"
+  @type strategy :: :one_for_one
+
+  defstruct [
+    :args,
+    :extra_arguments,
+    :mod,
+    :name,
+    :strategy,
+    :max_children,
+    :max_restarts,
+    :max_seconds,
+    children: %{},
+    dynamic: 0,
+    restarts: []
+  ]
+
+  @doc false
+  defmacro __using__(opts) do
+    quote location: :keep do
+      @behaviour DynamicSupervisor
+      @opts unquote(opts)
+
+      @doc false
+      def child_spec(arg) do
+        default = %{
+          id: __MODULE__,
+          start: {__MODULE__, :start_link, [arg]},
+          type: :supervisor
+        }
+
+        Supervisor.child_spec(default, @opts)
+      end
+
+      defoverridable child_spec: 1
+
+      @doc false
+      def init(arg)
+    end
+  end
+
+  @doc """
+  Starts a supervisor with the given options.
+
+  The `:strategy` is a required option and the currently supported
+  value is `:one_for_one`. The remaining options can be found in the
+  `init/1` docs.
+
+  The `:name` option can also be used to register a supervisor name.
+  The supported values are described under the "Name registration"
+  section in the `GenServer` module docs.
+
+  If the supervisor is successfully spawned, this function returns
+  `{:ok, pid}`, where `pid` is the PID of the supervisor. If the supervisor
+  is given a name and a process with the specified name already exists,
+  the function returns `{:error, {:already_started, pid}}`, where `pid`
+  is the PID of that process.
+
+  Note that a supervisor started with this function is linked to the parent
+  process and exits not only on crashes but also if the parent process exits
+  with `:normal` reason.
+  """
+  @spec start_link(options) :: Supervisor.on_start()
+  def start_link(options) when is_list(options) do
+    keys = [:extra_arguments, :max_children, :max_seconds, :max_restarts, :strategy]
+    {sup_opts, start_opts} = Keyword.split(options, keys)
+    start_link(Supervisor.Default, init(sup_opts), start_opts)
+  end
+
+  @doc """
+  Starts a module-based supervisor process with the given `module` and `arg`.
+
+  To start the supervisor, the `c:init/1` callback will be invoked in the given
+  `module`, with `arg` as its argument. The `c:init/1` callback must return a
+  supervisor specification which can be created with the help of the `init/1`
+  function.
+
+  If the `c:init/1` callback returns `:ignore`, this function returns
+  `:ignore` as well and the supervisor terminates with reason `:normal`.
+  If it fails or returns an incorrect value, this function returns
+  `{:error, term}` where `term` is a term with information about the
+  error, and the supervisor terminates with reason `term`.
+
+  The `:name` option can also be given in order to register a supervisor
+  name, the supported values are described in the "Name registration"
+  section in the `GenServer` module docs.
+  """
+  @spec start_link(module, term, GenServer.options()) :: Supervisor.on_start()
+  def start_link(mod, args, opts \\ []) do
+    GenServer.start_link(__MODULE__, {mod, args, opts[:name]}, opts)
+  end
+
+  @doc """
+  Dynamically adds a child specification to `supervisor` and starts that child.
+
+  `child_spec` should be a valid child specification. The child process will
+  be started as defined in the child specification.
+
+  If the child process start function returns `{:ok, child}` or `{:ok, child,
+  info}`, then child specification and PID are added to the supervisor and
+  this function returns the same value.
+
+  If the child process start function returns `:ignore`, then no child is added
+  to the supervision tree and this function returns `:ignore` too.
+
+  If the child process start function returns an error tuple or an erroneous
+  value, or if it fails, the child specification is discarded and this function
+  returns `{:error, error}` where `error` is a term containing information about
+  the error and child specification.
+
+  If the supervisor already has N children in a way that N exceeds the amount
+  of `:max_children` set on the supervisor initialization (see `init/1`), then
+  this function returns `{:error, :max_children}`.
+  """
+  @spec start_child(Supervisor.supervisor(), :supervisor.child_spec() | {module, term} | module) ::
+          Supervisor.on_start_child()
+  def start_child(supervisor, {_, _, _, _, _, _} = child_spec) do
+    validate_and_start_child(supervisor, child_spec)
+  end
+
+  def start_child(supervisor, child_spec) do
+    validate_and_start_child(supervisor, Supervisor.child_spec(child_spec, []))
+  end
+
+  defp validate_and_start_child(supervisor, child_spec) do
+    case validate_child(child_spec) do
+      {:ok, child} -> call(supervisor, {:start_child, child})
+      error -> {:error, error}
+    end
+  end
+
+  defp validate_child(%{id: _, start: {mod, _, _} = start} = child) do
+    restart = Map.get(child, :restart, :permanent)
+    type = Map.get(child, :type, :worker)
+    modules = Map.get(child, :modules, [mod])
+
+    shutdown =
+      case type do
+        :worker -> Map.get(child, :shutdown, 5_000)
+        :supervisor -> Map.get(child, :shutdown, :infinity)
+      end
+
+    validate_child(start, restart, shutdown, type, modules)
+  end
+
+  defp validate_child({_, start, restart, shutdown, type, modules}) do
+    validate_child(start, restart, shutdown, type, modules)
+  end
+
+  defp validate_child(other) do
+    {:invalid_child_spec, other}
+  end
+
+  defp validate_child(start, restart, shutdown, type, modules) do
+    with :ok <- validate_start(start),
+         :ok <- validate_restart(restart),
+         :ok <- validate_shutdown(shutdown),
+         :ok <- validate_type(type),
+         :ok <- validate_modules(modules) do
+      {:ok, {start, restart, shutdown, type, modules}}
+    end
+  end
+
+  defp validate_start({m, f, args}) when is_atom(m) and is_atom(f) and is_list(args), do: :ok
+  defp validate_start(mfa), do: {:invalid_mfa, mfa}
+
+  defp validate_type(type) when type in [:supervisor, :worker], do: :ok
+  defp validate_type(type), do: {:invalid_child_type, type}
+
+  defp validate_restart(restart) when restart in [:permanent, :temporary, :transient], do: :ok
+  defp validate_restart(restart), do: {:invalid_restart_type, restart}
+
+  defp validate_shutdown(shutdown) when is_integer(shutdown) and shutdown > 0, do: :ok
+  defp validate_shutdown(shutdown) when shutdown in [:infinity, :brutal_kill], do: :ok
+  defp validate_shutdown(shutdown), do: {:invalid_shutdown, shutdown}
+
+  defp validate_modules(:dynamic), do: :ok
+
+  defp validate_modules(mods) do
+    if is_list(mods) and Enum.all?(mods, &is_atom/1) do
+      :ok
+    else
+      {:invalid_modules, mods}
+    end
+  end
+
+  @doc """
+  Terminates the given child identified by child id.
+
+  If successful, this function returns `:ok`. If there is no process with
+  the given PID, this function returns `{:error, :not_found}`.
+  """
+  @spec terminate_child(Supervisor.supervisor(), pid) :: :ok | {:error, :not_found}
+  def terminate_child(supervisor, pid) when is_pid(pid) do
+    call(supervisor, {:terminate_child, pid})
+  end
+
+  @doc """
+  Returns a list with information about all children.
+
+  Note that calling this function when supervising a large number
+  of children under low memory conditions can cause an out of memory
+  exception.
+
+  This function returns a list of tuples containing:
+
+    * `id` - it is always `:undefined` for dynamic supervisors
+
+    * `child` - the pid of the corresponding child process or the
+      atom `:restarting` if the process is about to be restarted
+
+    * `type` - `:worker` or `:supervisor` as defined in the child
+      specification
+
+    * `modules` - as defined in the child specification
+
+  """
+  @spec which_children(Supervisor.supervisor()) :: [
+          {:undefined, pid | :restarting, :worker | :supervisor, :supervisor.modules()}
+        ]
+  def which_children(supervisor) do
+    call(supervisor, :which_children)
+  end
+
+  @doc """
+  Returns a map containing count values for the supervisor.
+
+  The map contains the following keys:
+
+    * `:specs` - always 1 as dynamic supervisors have a single specification
+
+    * `:active` - the count of all actively running child processes managed by
+      this supervisor
+
+    * `:supervisors` - the count of all supervisors whether or not the child
+      process is still alive
+
+    * `:workers` - the count of all workers, whether or not the child process
+      is still alive
+
+  """
+  @spec count_children(Supervisor.supervisor()) :: %{
+          specs: non_neg_integer,
+          active: non_neg_integer,
+          supervisors: non_neg_integer,
+          workers: non_neg_integer
+        }
+  def count_children(supervisor) do
+    call(supervisor, :count_children)
+  end
+
+  @doc """
+  Receives a set of options that initializes a dynamic supervisor.
+
+  This is typically invoked at the end of the `c:init/1` callback of
+  module-based supervisors. See the sections "Module-based supervisors"
+  in the module documentation for more information.
+
+  The options received by this function are also supported by `start_link/2`.
+
+  This function returns a tuple containing the supervisor options.
+
+  ## Examples
+
+      def init(_arg) do
+        DynamicSupervisor.init(max_children: 1000, strategy: :one_for_one)
+      end
+
+  ## Options
+
+    * `:strategy` - the restart strategy option. The only supported
+      value is `:one_for_one` which means that no other child is
+      terminate if a child process terminates. You can learn more
+      about strategies in the `Supervisor` module docs.
+
+    * `:max_restarts` - the maximum number of restarts allowed in
+      a time frame. Defaults to `3`.
+
+    * `:max_seconds` - the time frame in which `:max_restarts` applies.
+      Defaults to `5`.
+
+    * `:max_children` - the maximum amount of children to be running
+      under this supervisor at the same time. When `:max_children` is
+      exceeded, `start_child/2` returns `{:error, :dynamic}`. Defaults
+      to `:infinity`.
+
+    * `:extra_arguments` - arguments that are prepended to the arguments
+      specified in the child spec given to `start_child/2`. Defaults to
+      an empty list.
+
+  """
+  @spec init([init_option]) :: {:ok, map()}
+  def init(options) when is_list(options) do
+    unless strategy = options[:strategy] do
+      raise ArgumentError, "expected :strategy option to be given"
+    end
+
+    intensity = Keyword.get(options, :max_restarts, 3)
+    period = Keyword.get(options, :max_seconds, 5)
+    max_children = Keyword.get(options, :max_children, :infinity)
+    extra_arguments = Keyword.get(options, :extra_arguments, [])
+
+    flags = %{
+      strategy: strategy,
+      intensity: intensity,
+      period: period,
+      max_children: max_children,
+      extra_arguments: extra_arguments
+    }
+
+    {:ok, flags}
+  end
+
+  ## Callbacks
+
+  @impl true
+  def init({mod, args, name}) do
+    Process.put(:"$initial_call", {:supervisor, mod, 1})
+    Process.flag(:trap_exit, true)
+
+    case mod.init(args) do
+      {:ok, flags} when is_map(flags) ->
+        state = %DynamicSupervisor{mod: mod, args: args, name: name || {self(), mod}}
+
+        case init(state, flags) do
+          {:ok, state} -> {:ok, state}
+          {:error, reason} -> {:stop, {:supervisor_data, reason}}
+        end
+
+      :ignore ->
+        :ignore
+
+      other ->
+        {:stop, {:bad_return, {mod, :init, other}}}
+    end
+  end
+
+  defp init(state, flags) do
+    extra_arguments = Map.get(flags, :extra_arguments, [])
+    max_children = Map.get(flags, :max_children, :infinity)
+    max_restarts = Map.get(flags, :intensity, 1)
+    max_seconds = Map.get(flags, :period, 5)
+    strategy = Map.get(flags, :strategy, :one_for_one)
+
+    with :ok <- validate_strategy(strategy),
+         :ok <- validate_restarts(max_restarts),
+         :ok <- validate_seconds(max_seconds),
+         :ok <- validate_dynamic(max_children),
+         :ok <- validate_extra_arguments(extra_arguments) do
+      {:ok, %{
+        state
+        | extra_arguments: extra_arguments,
+          max_children: max_children,
+          max_restarts: max_restarts,
+          max_seconds: max_seconds,
+          strategy: strategy
+      }}
+    end
+  end
+
+  defp validate_strategy(strategy) when strategy in [:one_for_one], do: :ok
+  defp validate_strategy(strategy), do: {:error, {:invalid_strategy, strategy}}
+
+  defp validate_restarts(restart) when is_integer(restart) and restart >= 0, do: :ok
+  defp validate_restarts(restart), do: {:error, {:invalid_intensity, restart}}
+
+  defp validate_seconds(seconds) when is_integer(seconds) and seconds > 0, do: :ok
+  defp validate_seconds(seconds), do: {:error, {:invalid_period, seconds}}
+
+  defp validate_dynamic(:infinity), do: :ok
+  defp validate_dynamic(dynamic) when is_integer(dynamic) and dynamic >= 0, do: :ok
+  defp validate_dynamic(dynamic), do: {:error, {:invalid_max_children, dynamic}}
+
+  defp validate_extra_arguments(list) when is_list(list), do: :ok
+  defp validate_extra_arguments(extra), do: {:error, {:invalid_extra_arguments, extra}}
+
+  @impl true
+  def handle_call(:which_children, _from, state) do
+    %{children: children} = state
+
+    reply =
+      for {pid, args} <- children do
+        case args do
+          {:restarting, {_, _, _, type, modules}} ->
+            {:undefined, :restarting, type, modules}
+
+          {_, _, _, type, modules} ->
+            {:undefined, pid, type, modules}
+        end
+      end
+
+    {:reply, reply, state}
+  end
+
+  def handle_call(:count_children, _from, state) do
+    %{children: children} = state
+    specs = map_size(children)
+
+    {active, workers, supervisors} =
+      Enum.reduce(children, {0, 0, 0}, fn
+        {_pid, {:restarting, {_, _, _, :worker, _}}}, {active, worker, supervisor} ->
+          {active, worker + 1, supervisor}
+
+        {_pid, {:restarting, {_, _, _, :supervisor, _}}}, {active, worker, supervisor} ->
+          {active, worker, supervisor + 1}
+
+        {_pid, {_, _, _, :worker, _}}, {active, worker, supervisor} ->
+          {active + 1, worker + 1, supervisor}
+
+        {_pid, {_, _, _, :supervisor, _}}, {active, worker, supervisor} ->
+          {active + 1, worker, supervisor + 1}
+      end)
+
+    reply = %{specs: specs, active: active, workers: workers, supervisors: supervisors}
+    {:reply, reply, state}
+  end
+
+  def handle_call({:terminate_child, pid}, _from, %{children: children} = state) do
+    case children do
+      %{^pid => info} ->
+        :ok = terminate_children(%{pid => info}, state)
+        {:reply, :ok, delete_child(pid, state)}
+
+      %{} ->
+        {:reply, {:error, :not_found}, state}
+    end
+  end
+
+  def handle_call({:start_child, child}, _from, state) do
+    %{dynamic: dynamic, max_children: max_children} = state
+
+    if dynamic < max_children do
+      handle_start_child(child, %{state | dynamic: dynamic + 1})
+    else
+      {:reply, {:error, :max_children}, state}
+    end
+  end
+
+  defp handle_start_child({{m, f, args} = mfa, restart, shutdown, type, modules}, state) do
+    %{extra_arguments: extra} = state
+
+    case reply = start_child(m, f, extra ++ args) do
+      {:ok, pid, _} ->
+        {:reply, reply, save_child(pid, mfa, restart, shutdown, type, modules, state)}
+
+      {:ok, pid} ->
+        {:reply, reply, save_child(pid, mfa, restart, shutdown, type, modules, state)}
+
+      _ ->
+        {:reply, reply, update_in(state.dynamic, &(&1 - 1))}
+    end
+  end
+
+  defp start_child(m, f, a) do
+    try do
+      apply(m, f, a)
+    catch
+      kind, reason ->
+        {:error, exit_reason(kind, reason, System.stacktrace())}
+    else
+      {:ok, pid, extra} when is_pid(pid) -> {:ok, pid, extra}
+      {:ok, pid} when is_pid(pid) -> {:ok, pid}
+      :ignore -> :ignore
+      {:error, _} = error -> error
+      other -> {:error, other}
+    end
+  end
+
+  defp save_child(pid, {m, f, _}, :temporary, shutdown, type, modules, state) do
+    put_in(state.children[pid], {{m, f, :undefined}, :temporary, shutdown, type, modules})
+  end
+
+  defp save_child(pid, mfa, restart, shutdown, type, modules, state) do
+    put_in(state.children[pid], {mfa, restart, shutdown, type, modules})
+  end
+
+  defp exit_reason(:exit, reason, _), do: reason
+  defp exit_reason(:error, reason, stack), do: {reason, stack}
+  defp exit_reason(:throw, value, stack), do: {{:nocatch, value}, stack}
+
+  @impl true
+  def handle_cast(_msg, state) do
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:EXIT, pid, reason}, state) do
+    case maybe_restart_child(pid, reason, state) do
+      {:ok, state} -> {:noreply, state}
+      {:shutdown, state} -> {:stop, :shutdown, state}
+    end
+  end
+
+  def handle_info({:"$gen_restart", pid}, state) do
+    %{children: children} = state
+
+    case children do
+      %{^pid => restarting_args} ->
+        {:restarting, child} = restarting_args
+
+        case restart_child(pid, child, state) do
+          {:ok, state} -> {:noreply, state}
+          {:shutdown, state} -> {:stop, :shutdown, state}
+        end
+
+      # We may hit clause if we send $gen_restart and then
+      # someone calls terminate_child, removing the child.
+      %{} ->
+        {:noreply, state}
+    end
+  end
+
+  def handle_info(msg, state) do
+    :error_logger.error_msg('DynamicSupervisor received unexpected message: ~p~n', [msg])
+    {:noreply, state}
+  end
+
+  @impl true
+  def code_change(_, %{mod: mod, args: args} = state, _) do
+    case mod.init(args) do
+      {:ok, flags} when is_map(flags) ->
+        case init(state, flags) do
+          {:ok, state} -> {:ok, state}
+          {:error, reason} -> {:error, {:supervisor_data, reason}}
+        end
+
+      :ignore ->
+        {:ok, state}
+
+      error ->
+        error
+    end
+  end
+
+  @impl true
+  def terminate(_, %{children: children} = state) do
+    :ok = terminate_children(children, state)
+  end
+
+  defp terminate_children(children, state) do
+    {pids, times, stacks} = monitor_children(children)
+    size = map_size(pids)
+
+    timers =
+      Enum.reduce(times, %{}, fn {time, pids}, acc ->
+        Map.put(acc, :erlang.start_timer(time, self(), :kill), pids)
+      end)
+
+    stacks = wait_children(pids, size, timers, stacks)
+
+    for {pid, {child, reason}} <- stacks do
+      report_error(:shutdown_error, reason, pid, child, state)
+    end
+
+    :ok
+  end
+
+  defp monitor_children(children) do
+    Enum.reduce(children, {%{}, %{}, %{}}, fn
+      {_, {:restarting, _}}, acc ->
+        acc
+
+      {pid, {_, restart, _, _, _} = child}, {pids, times, stacks} ->
+        case monitor_child(pid) do
+          :ok ->
+            times = exit_child(pid, child, times)
+            {Map.put(pids, pid, child), times, stacks}
+
+          {:error, :normal} when restart != :permanent ->
+            {pids, times, stacks}
+
+          {:error, reason} ->
+            {pids, times, Map.put(stacks, pid, {child, reason})}
+        end
+    end)
+  end
+
+  defp monitor_child(pid) do
+    ref = Process.monitor(pid)
+    Process.unlink(pid)
+
+    receive do
+      {:EXIT, ^pid, reason} ->
+        receive do
+          {:DOWN, ^ref, :process, ^pid, _} -> {:error, reason}
+        end
+    after
+      0 -> :ok
+    end
+  end
+
+  defp exit_child(pid, {_, _, shutdown, _, _}, times) do
+    case shutdown do
+      :brutal_kill ->
+        Process.exit(pid, :kill)
+        times
+
+      :infinity ->
+        Process.exit(pid, :shutdown)
+        times
+
+      time ->
+        Process.exit(pid, :shutdown)
+        Map.update(times, time, [pid], &[pid | &1])
+    end
+  end
+
+  defp wait_children(_pids, 0, timers, stacks) do
+    for {timer, _} <- timers do
+      _ = :erlang.cancel_timer(timer)
+
+      receive do
+        {:timeout, ^timer, :kill} -> :ok
+      after
+        0 -> :ok
+      end
+    end
+
+    stacks
+  end
+
+  defp wait_children(pids, size, timers, stacks) do
+    receive do
+      {:DOWN, _ref, :process, pid, reason} ->
+        case pids do
+          %{^pid => child} ->
+            stacks = wait_child(pid, child, reason, stacks)
+            wait_children(pids, size - 1, timers, stacks)
+
+          %{} ->
+            wait_children(pids, size, timers, stacks)
+        end
+
+      {:timeout, timer, :kill} ->
+        for pid <- Map.fetch!(timers, timer), do: Process.exit(pid, :kill)
+        wait_children(pids, size, Map.delete(timers, timer), stacks)
+    end
+  end
+
+  defp wait_child(pid, {_, _, :brutal_kill, _, _} = child, reason, stacks) do
+    case reason do
+      :killed -> stacks
+      _ -> Map.put(stacks, pid, {child, reason})
+    end
+  end
+
+  defp wait_child(pid, {_, restart, _, _, _} = child, reason, stacks) do
+    case reason do
+      {:shutdown, _} -> stacks
+      :shutdown -> stacks
+      :normal when restart != :permanent -> stacks
+      reason -> Map.put(stacks, pid, {child, reason})
+    end
+  end
+
+  defp maybe_restart_child(pid, reason, %{children: children} = state) do
+    case children do
+      %{^pid => {_, restart, _, _, _} = child} ->
+        maybe_restart_child(restart, reason, pid, child, state)
+
+      %{} ->
+        {:ok, state}
+    end
+  end
+
+  defp maybe_restart_child(:permanent, reason, pid, child, state) do
+    report_error(:child_terminated, reason, pid, child, state)
+    restart_child(pid, child, state)
+  end
+
+  defp maybe_restart_child(_, :normal, pid, _child, state) do
+    {:ok, delete_child(pid, state)}
+  end
+
+  defp maybe_restart_child(_, :shutdown, pid, _child, state) do
+    {:ok, delete_child(pid, state)}
+  end
+
+  defp maybe_restart_child(_, {:shutdown, _}, pid, _child, state) do
+    {:ok, delete_child(pid, state)}
+  end
+
+  defp maybe_restart_child(:transient, reason, pid, child, state) do
+    report_error(:child_terminated, reason, pid, child, state)
+    restart_child(pid, child, state)
+  end
+
+  defp maybe_restart_child(:temporary, reason, pid, child, state) do
+    report_error(:child_terminated, reason, pid, child, state)
+    {:ok, delete_child(pid, state)}
+  end
+
+  defp delete_child(pid, state) do
+    %{children: children, dynamic: dynamic} = state
+    %{state | children: Map.delete(children, pid), dynamic: dynamic - 1}
+  end
+
+  defp restart_child(pid, child, state) do
+    case add_restart(state) do
+      {:ok, %{strategy: strategy} = state} ->
+        case restart_child(strategy, pid, child, state) do
+          {:ok, state} ->
+            {:ok, state}
+
+          {:try_again, state} ->
+            send(self(), {:"$gen_restart", pid})
+            {:ok, state}
+        end
+
+      {:shutdown, state} ->
+        report_error(:shutdown, :reached_max_restart_intensity, pid, child, state)
+        {:shutdown, delete_child(pid, state)}
+    end
+  end
+
+  defp add_restart(state) do
+    %{max_seconds: max_seconds, max_restarts: max_restarts, restarts: restarts} = state
+
+    # The below is equivalent to 1 second. We avoid
+    # :second because of incompatibilties with OTP < 20
+    now = :erlang.monotonic_time(1)
+    restarts = add_restart([now | restarts], now, max_seconds)
+    state = %{state | restarts: restarts}
+
+    if length(restarts) <= max_restarts do
+      {:ok, state}
+    else
+      {:shutdown, state}
+    end
+  end
+
+  defp add_restart(restarts, now, period) do
+    for then <- restarts, now <= then + period, do: then
+  end
+
+  defp restart_child(:one_for_one, current_pid, child, state) do
+    {{m, f, args} = mfa, restart, shutdown, type, modules} = child
+
+    case start_child(m, f, args) do
+      {:ok, pid, _} ->
+        state = delete_child(current_pid, state)
+        {:ok, save_child(pid, mfa, restart, shutdown, type, modules, state)}
+
+      {:ok, pid} ->
+        state = delete_child(current_pid, state)
+        {:ok, save_child(pid, mfa, restart, shutdown, type, modules, state)}
+
+      :ignore ->
+        {:ok, delete_child(current_pid, state)}
+
+      {:error, reason} ->
+        report_error(:start_error, reason, {:restarting, current_pid}, child, state)
+        state = put_in(state.children[current_pid], {:restarting, child})
+        {:try_again, state}
+    end
+  end
+
+  defp report_error(error, reason, pid, child, %{name: name}) do
+    :error_logger.error_report(
+      :supervision_report,
+      supervisor: name,
+      errorContext: error,
+      reason: reason,
+      offender: extract_child(pid, child)
+    )
+  end
+
+  defp extract_child(pid, {mfa, restart, shutdown, type, _modules}) do
+    [
+      pid: pid,
+      id: :undefined,
+      mfargs: mfa,
+      restart_type: restart,
+      shutdown: shutdown,
+      child_type: type
+    ]
+  end
+
+  @impl true
+  def format_status(:terminate, [_pdict, state]) do
+    state
+  end
+
+  def format_status(_, [_pdict, %{mod: mod} = state]) do
+    [data: [{~c"State", state}], supervisor: [{~c"Callback", mod}]]
+  end
+
+  ## Helpers
+
+  @compile {:inline, call: 2}
+
+  defp call(supervisor, req) do
+    GenServer.call(supervisor, req, :infinity)
+  end
+end

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -481,6 +481,14 @@ defmodule Exception do
     "invalid max_seconds (period): " <> inspect(period)
   end
 
+  defp format_sup_data({:invalid_max_children, max_children}) do
+    "invalid max_children: " <> inspect(max_children)
+  end
+
+  defp format_sup_data({:invalid_extra_arguments, extra}) do
+    "invalid extra_arguments: " <> inspect(extra)
+  end
+
   defp format_sup_data(other), do: "got: #{inspect(other)}"
 
   defp format_sup_spec({:duplicate_child_name, id}) do

--- a/lib/elixir/lib/supervisor/default.ex
+++ b/lib/elixir/lib/supervisor/default.ex
@@ -1,7 +1,7 @@
 defmodule Supervisor.Default do
   @moduledoc false
 
-  def init({children, opts}) do
-    Supervisor.init(children, opts)
+  def init(args) do
+    args
   end
 end

--- a/lib/elixir/test/elixir/dynamic_supervisor_test.exs
+++ b/lib/elixir/test/elixir/dynamic_supervisor_test.exs
@@ -1,0 +1,639 @@
+Code.require_file("test_helper.exs", __DIR__)
+
+defmodule DynamicSupervisorTest do
+  use ExUnit.Case, async: true
+
+  defmodule Simple do
+    use DynamicSupervisor
+
+    def init(args), do: args
+  end
+
+  describe "use/2" do
+    test "generates child_spec/1" do
+      assert Simple.child_spec([:hello]) == %{
+               id: Simple,
+               start: {Simple, :start_link, [[:hello]]},
+               type: :supervisor
+             }
+
+      defmodule Custom do
+        use DynamicSupervisor,
+          id: :id,
+          restart: :temporary,
+          shutdown: :infinity,
+          start: {:foo, :bar, []}
+
+        def init(arg), do: {:producer, arg}
+      end
+
+      assert Custom.child_spec([:hello]) == %{
+               id: :id,
+               restart: :temporary,
+               shutdown: :infinity,
+               start: {:foo, :bar, []},
+               type: :supervisor
+             }
+    end
+  end
+
+  describe "init/1" do
+    test "set default options" do
+      assert DynamicSupervisor.init(strategy: :one_for_one) ==
+               {:ok, %{
+                 strategy: :one_for_one,
+                 intensity: 3,
+                 period: 5,
+                 max_children: :infinity,
+                 extra_arguments: []
+               }}
+    end
+  end
+
+  describe "start_link/3" do
+    test "with non-ok init" do
+      Process.flag(:trap_exit, true)
+
+      assert DynamicSupervisor.start_link(Simple, {:ok, %{strategy: :unknown}}) ==
+               {:error, {:supervisor_data, {:invalid_strategy, :unknown}}}
+
+      assert DynamicSupervisor.start_link(Simple, {:ok, %{intensity: -1}}) ==
+               {:error, {:supervisor_data, {:invalid_intensity, -1}}}
+
+      assert DynamicSupervisor.start_link(Simple, {:ok, %{period: 0}}) ==
+               {:error, {:supervisor_data, {:invalid_period, 0}}}
+
+      assert DynamicSupervisor.start_link(Simple, {:ok, %{max_children: -1}}) ==
+               {:error, {:supervisor_data, {:invalid_max_children, -1}}}
+
+      assert DynamicSupervisor.start_link(Simple, {:ok, %{extra_arguments: -1}}) ==
+               {:error, {:supervisor_data, {:invalid_extra_arguments, -1}}}
+
+      assert DynamicSupervisor.start_link(Simple, :unknown) ==
+               {:error, {:bad_return, {Simple, :init, :unknown}}}
+
+      assert DynamicSupervisor.start_link(Simple, :ignore) == :ignore
+    end
+
+    test "with registered process" do
+      {:ok, pid} = DynamicSupervisor.start_link(Simple, {:ok, %{}}, name: __MODULE__)
+
+      # Sets up a link
+      {:links, links} = Process.info(self(), :links)
+      assert pid in links
+
+      # A name
+      assert Process.whereis(__MODULE__) == pid
+
+      # And the initial call
+      assert {:supervisor, DynamicSupervisorTest.Simple, 1} =
+               :proc_lib.translate_initial_call(pid)
+    end
+
+    test "sets initial call to the same as a regular supervisor" do
+      {:ok, pid} = Supervisor.start_link([], strategy: :one_for_one)
+      assert :proc_lib.initial_call(pid) == {:supervisor, Supervisor.Default, [:Argument__1]}
+
+      {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one)
+      assert :proc_lib.initial_call(pid) == {:supervisor, Supervisor.Default, [:Argument__1]}
+    end
+
+    test "returns the callback module" do
+      {:ok, pid} = Supervisor.start_link([], strategy: :one_for_one)
+      assert :supervisor.get_callback_module(pid) == Supervisor.Default
+
+      {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one)
+      assert :supervisor.get_callback_module(pid) == Supervisor.Default
+    end
+  end
+
+  ## Code change
+
+  describe "code_change/3" do
+    test "with non-ok init" do
+      {:ok, pid} = DynamicSupervisor.start_link(Simple, {:ok, %{}})
+
+      assert fake_upgrade(pid, {:ok, %{strategy: :unknown}}) ==
+               {:error, {:error, {:supervisor_data, {:invalid_strategy, :unknown}}}}
+
+      assert fake_upgrade(pid, {:ok, %{intensity: -1}}) ==
+               {:error, {:error, {:supervisor_data, {:invalid_intensity, -1}}}}
+
+      assert fake_upgrade(pid, {:ok, %{period: 0}}) ==
+               {:error, {:error, {:supervisor_data, {:invalid_period, 0}}}}
+
+      assert fake_upgrade(pid, {:ok, %{max_children: -1}}) ==
+               {:error, {:error, {:supervisor_data, {:invalid_max_children, -1}}}}
+
+      assert fake_upgrade(pid, :unknown) == {:error, :unknown}
+      assert fake_upgrade(pid, :ignore) == :ok
+    end
+
+    test "with ok init" do
+      {:ok, pid} = DynamicSupervisor.start_link(Simple, {:ok, %{}})
+      {:ok, _} = DynamicSupervisor.start_child(pid, sleepy_worker())
+      assert %{active: 1} = DynamicSupervisor.count_children(pid)
+
+      assert fake_upgrade(pid, {:ok, %{max_children: 1}}) == :ok
+      assert %{active: 1} = DynamicSupervisor.count_children(pid)
+      assert DynamicSupervisor.start_child(pid, {Task, fn -> :ok end}) == {:error, :max_children}
+    end
+
+    defp fake_upgrade(pid, args) do
+      :ok = :sys.suspend(pid)
+      :sys.replace_state(pid, fn state -> %{state | args: args} end)
+      res = :sys.change_code(pid, :gen_server, 123, :extra)
+      :ok = :sys.resume(pid)
+      res
+    end
+  end
+
+  describe "start_child/2" do
+    test "supports old child spec" do
+      {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one)
+      child = {Task, {Task, :start_link, [fn -> :ok end]}, :temporary, 5000, :worker, [Task]}
+      assert {:ok, pid} = DynamicSupervisor.start_child(pid, child)
+      assert is_pid(pid)
+    end
+
+    test "supports new child spec as tuple" do
+      {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one)
+      child = %{id: Task, restart: :temporary, start: {Task, :start_link, [fn -> :ok end]}}
+      assert {:ok, pid} = DynamicSupervisor.start_child(pid, child)
+      assert is_pid(pid)
+    end
+
+    test "supports new child spec" do
+      {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one)
+      child = {Task, fn -> :timer.sleep(:infinity) end}
+      assert {:ok, pid} = DynamicSupervisor.start_child(pid, child)
+      assert is_pid(pid)
+    end
+
+    test "supports extra arguments" do
+      parent = self()
+      fun = fn -> send(parent, :from_child) end
+
+      {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one, extra_arguments: [fun])
+      child = %{id: Task, restart: :temporary, start: {Task, :start_link, []}}
+      assert {:ok, pid} = DynamicSupervisor.start_child(pid, child)
+      assert is_pid(pid)
+      assert_receive :from_child
+    end
+
+    test "with invalid child spec" do
+      assert DynamicSupervisor.start_child(:not_used, %{}) == {:error, {:invalid_child_spec, %{}}}
+
+      assert DynamicSupervisor.start_child(:not_used, {1, 2, 3, 4, 5, 6}) ==
+               {:error, {:invalid_mfa, 2}}
+
+      assert DynamicSupervisor.start_child(:not_used, %{id: 1, start: {Task, :foo, :bar}}) ==
+               {:error, {:invalid_mfa, {Task, :foo, :bar}}}
+    end
+
+    test "with different returns" do
+      {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+      assert {:ok, _, :extra} = DynamicSupervisor.start_child(pid, current_module_worker([:ok3]))
+      assert {:ok, _} = DynamicSupervisor.start_child(pid, current_module_worker([:ok2]))
+      assert :ignore = DynamicSupervisor.start_child(pid, current_module_worker([:ignore]))
+
+      assert {:error, :found} =
+               DynamicSupervisor.start_child(pid, current_module_worker([:error]))
+
+      assert {:error, :unknown} =
+               DynamicSupervisor.start_child(pid, current_module_worker([:unknown]))
+    end
+
+    test "with throw/error/exit" do
+      {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+      assert {:error, {{:nocatch, :oops}, [_ | _]}} =
+               DynamicSupervisor.start_child(pid, current_module_worker([:non_local, :throw]))
+
+      assert {:error, {%RuntimeError{}, [_ | _]}} =
+               DynamicSupervisor.start_child(pid, current_module_worker([:non_local, :error]))
+
+      assert {:error, :oops} =
+               DynamicSupervisor.start_child(pid, current_module_worker([:non_local, :exit]))
+    end
+
+    test "with max_children" do
+      {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one, max_children: 0)
+
+      assert {:error, :max_children} =
+               DynamicSupervisor.start_child(pid, current_module_worker([:ok2]))
+    end
+
+    test "temporary child is not restarted regardless of reason" do
+      child = current_module_worker([:ok2], restart: :temporary)
+      {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+      assert {:ok, child_pid} = DynamicSupervisor.start_child(pid, child)
+      assert_kill(child_pid, :shutdown)
+      assert %{workers: 0, active: 0} = DynamicSupervisor.count_children(pid)
+
+      assert {:ok, child_pid} = DynamicSupervisor.start_child(pid, child)
+      assert_kill(child_pid, :whatever)
+      assert %{workers: 0, active: 0} = DynamicSupervisor.count_children(pid)
+    end
+
+    test "transient child is restarted unless normal/shutdown/{shutdown, _}" do
+      child = current_module_worker([:ok2], restart: :transient)
+      {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+      assert {:ok, child_pid} = DynamicSupervisor.start_child(pid, child)
+      assert_kill(child_pid, :shutdown)
+      assert %{workers: 0, active: 0} = DynamicSupervisor.count_children(pid)
+
+      assert {:ok, child_pid} = DynamicSupervisor.start_child(pid, child)
+      assert_kill(child_pid, {:shutdown, :signal})
+      assert %{workers: 0, active: 0} = DynamicSupervisor.count_children(pid)
+
+      assert {:ok, child_pid} = DynamicSupervisor.start_child(pid, child)
+      assert_kill(child_pid, :whatever)
+      assert %{workers: 1, active: 1} = DynamicSupervisor.count_children(pid)
+    end
+
+    test "permanent child is restarted regardless of reason" do
+      child = current_module_worker([:ok2], restart: :permanent)
+      {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one, max_restarts: 100_000)
+
+      assert {:ok, child_pid} = DynamicSupervisor.start_child(pid, child)
+      assert_kill(child_pid, :shutdown)
+      assert %{workers: 1, active: 1} = DynamicSupervisor.count_children(pid)
+
+      assert {:ok, child_pid} = DynamicSupervisor.start_child(pid, child)
+      assert_kill(child_pid, {:shutdown, :signal})
+      assert %{workers: 2, active: 2} = DynamicSupervisor.count_children(pid)
+
+      assert {:ok, child_pid} = DynamicSupervisor.start_child(pid, child)
+      assert_kill(child_pid, :whatever)
+      assert %{workers: 3, active: 3} = DynamicSupervisor.count_children(pid)
+    end
+
+    test "child is restarted with different values" do
+      {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one, max_restarts: 100_000)
+
+      assert {:ok, child1} =
+               DynamicSupervisor.start_child(pid, current_module_worker([:restart, :ok2]))
+
+      assert [{:undefined, ^child1, :worker, [DynamicSupervisorTest]}] =
+               DynamicSupervisor.which_children(pid)
+
+      assert_kill(child1, :shutdown)
+      assert %{workers: 1, active: 1} = DynamicSupervisor.count_children(pid)
+
+      assert {:ok, child2} =
+               DynamicSupervisor.start_child(pid, current_module_worker([:restart, :ok3]))
+
+      assert [
+               {:undefined, _, :worker, [DynamicSupervisorTest]},
+               {:undefined, ^child2, :worker, [DynamicSupervisorTest]}
+             ] = DynamicSupervisor.which_children(pid)
+
+      assert_kill(child2, :shutdown)
+      assert %{workers: 2, active: 2} = DynamicSupervisor.count_children(pid)
+
+      assert {:ok, child3} =
+               DynamicSupervisor.start_child(pid, current_module_worker([:restart, :ignore]))
+
+      assert [
+               {:undefined, _, :worker, [DynamicSupervisorTest]},
+               {:undefined, _, :worker, [DynamicSupervisorTest]},
+               {:undefined, _, :worker, [DynamicSupervisorTest]}
+             ] = DynamicSupervisor.which_children(pid)
+
+      assert_kill(child3, :shutdown)
+      assert %{workers: 2, active: 2} = DynamicSupervisor.count_children(pid)
+
+      assert {:ok, child4} =
+               DynamicSupervisor.start_child(pid, current_module_worker([:restart, :error]))
+
+      assert [
+               {:undefined, _, :worker, [DynamicSupervisorTest]},
+               {:undefined, _, :worker, [DynamicSupervisorTest]},
+               {:undefined, _, :worker, [DynamicSupervisorTest]}
+             ] = DynamicSupervisor.which_children(pid)
+
+      assert_kill(child4, :shutdown)
+      assert %{workers: 3, active: 2} = DynamicSupervisor.count_children(pid)
+
+      assert {:ok, child5} =
+               DynamicSupervisor.start_child(pid, current_module_worker([:restart, :unknown]))
+
+      assert [
+               {:undefined, _, :worker, [DynamicSupervisorTest]},
+               {:undefined, _, :worker, [DynamicSupervisorTest]},
+               {:undefined, :restarting, :worker, [DynamicSupervisorTest]},
+               {:undefined, _, :worker, [DynamicSupervisorTest]}
+             ] = DynamicSupervisor.which_children(pid)
+
+      assert_kill(child5, :shutdown)
+      assert %{workers: 4, active: 2} = DynamicSupervisor.count_children(pid)
+    end
+
+    test "restarting children counted in max_children" do
+      child = current_module_worker([:restart, :error], restart: :permanent)
+      opts = [strategy: :one_for_one, max_children: 1, max_restarts: 100_000]
+      {:ok, pid} = DynamicSupervisor.start_link(opts)
+
+      assert {:ok, child_pid} = DynamicSupervisor.start_child(pid, child)
+      assert_kill(child_pid, :shutdown)
+      assert %{workers: 1, active: 0} = DynamicSupervisor.count_children(pid)
+
+      child = current_module_worker([:restart, :ok2], restart: :permanent)
+      assert {:error, :max_children} = DynamicSupervisor.start_child(pid, child)
+    end
+
+    test "child is restarted when trying again" do
+      child = current_module_worker([:try_again, self()], restart: :permanent)
+      {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one, max_restarts: 2)
+
+      assert {:ok, child_pid} = DynamicSupervisor.start_child(pid, child)
+      assert_received {:try_again, true}
+      assert_kill(child_pid, :shutdown)
+      assert_receive {:try_again, false}
+      assert_receive {:try_again, true}
+      assert %{workers: 1, active: 1} = DynamicSupervisor.count_children(pid)
+    end
+
+    test "child triggers maximum restarts" do
+      Process.flag(:trap_exit, true)
+      child = current_module_worker([:restart, :error], restart: :permanent)
+      {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one, max_restarts: 1)
+
+      assert {:ok, child_pid} = DynamicSupervisor.start_child(pid, child)
+      assert_kill(child_pid, :shutdown)
+      assert_receive {:EXIT, ^pid, :shutdown}
+    end
+
+    test "child triggers maximum intensity when trying again" do
+      Process.flag(:trap_exit, true)
+      child = current_module_worker([:restart, :error], restart: :permanent)
+      {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one, max_restarts: 10)
+
+      assert {:ok, child_pid} = DynamicSupervisor.start_child(pid, child)
+      assert_kill(child_pid, :shutdown)
+      assert_receive {:EXIT, ^pid, :shutdown}
+    end
+
+    def start_link(:ok3), do: {:ok, spawn_link(fn -> :timer.sleep(:infinity) end), :extra}
+    def start_link(:ok2), do: {:ok, spawn_link(fn -> :timer.sleep(:infinity) end)}
+    def start_link(:error), do: {:error, :found}
+    def start_link(:ignore), do: :ignore
+    def start_link(:unknown), do: :unknown
+
+    def start_link(:non_local, :throw), do: throw(:oops)
+    def start_link(:non_local, :error), do: raise("oops")
+    def start_link(:non_local, :exit), do: exit(:oops)
+
+    def start_link(:try_again, notify) do
+      if Process.get(:try_again) do
+        Process.put(:try_again, false)
+        send(notify, {:try_again, false})
+        {:error, :try_again}
+      else
+        Process.put(:try_again, true)
+        send(notify, {:try_again, true})
+        start_link(:ok2)
+      end
+    end
+
+    def start_link(:restart, value) do
+      if Process.get({:restart, value}) do
+        start_link(value)
+      else
+        Process.put({:restart, value}, true)
+        start_link(:ok2)
+      end
+    end
+  end
+
+  describe "terminate/2" do
+    test "terminates children with brutal kill" do
+      Process.flag(:trap_exit, true)
+      {:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+      child = sleepy_worker(shutdown: :brutal_kill)
+      assert {:ok, child1} = DynamicSupervisor.start_child(sup, child)
+      assert {:ok, child2} = DynamicSupervisor.start_child(sup, child)
+      assert {:ok, child3} = DynamicSupervisor.start_child(sup, child)
+
+      Process.monitor(child1)
+      Process.monitor(child2)
+      Process.monitor(child3)
+      assert_kill(sup, :shutdown)
+      assert_receive {:DOWN, _, :process, ^child1, :killed}
+      assert_receive {:DOWN, _, :process, ^child2, :killed}
+      assert_receive {:DOWN, _, :process, ^child3, :killed}
+    end
+
+    test "terminates children with infinity shutdown" do
+      Process.flag(:trap_exit, true)
+      {:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+      child = sleepy_worker(shutdown: :infinity)
+      assert {:ok, child1} = DynamicSupervisor.start_child(sup, child)
+      assert {:ok, child2} = DynamicSupervisor.start_child(sup, child)
+      assert {:ok, child3} = DynamicSupervisor.start_child(sup, child)
+
+      Process.monitor(child1)
+      Process.monitor(child2)
+      Process.monitor(child3)
+      assert_kill(sup, :shutdown)
+      assert_receive {:DOWN, _, :process, ^child1, :shutdown}
+      assert_receive {:DOWN, _, :process, ^child2, :shutdown}
+      assert_receive {:DOWN, _, :process, ^child3, :shutdown}
+    end
+
+    test "terminates children with infinity shutdown and abnormal reason" do
+      Process.flag(:trap_exit, true)
+      {:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+      fun = fn ->
+        Process.flag(:trap_exit, true)
+        receive(do: (_ -> exit({:shutdown, :oops})))
+      end
+
+      child = Supervisor.child_spec({Task, fun}, shutdown: :infinity)
+      assert {:ok, child1} = DynamicSupervisor.start_child(sup, child)
+      assert {:ok, child2} = DynamicSupervisor.start_child(sup, child)
+      assert {:ok, child3} = DynamicSupervisor.start_child(sup, child)
+
+      Process.monitor(child1)
+      Process.monitor(child2)
+      Process.monitor(child3)
+      assert_kill(sup, :shutdown)
+      assert_receive {:DOWN, _, :process, ^child1, {:shutdown, :oops}}
+      assert_receive {:DOWN, _, :process, ^child2, {:shutdown, :oops}}
+      assert_receive {:DOWN, _, :process, ^child3, {:shutdown, :oops}}
+    end
+
+    test "terminates children with integer shutdown" do
+      Process.flag(:trap_exit, true)
+      {:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+      child = sleepy_worker(shutdown: 1000)
+      assert {:ok, child1} = DynamicSupervisor.start_child(sup, child)
+      assert {:ok, child2} = DynamicSupervisor.start_child(sup, child)
+      assert {:ok, child3} = DynamicSupervisor.start_child(sup, child)
+
+      Process.monitor(child1)
+      Process.monitor(child2)
+      Process.monitor(child3)
+      assert_kill(sup, :shutdown)
+      assert_receive {:DOWN, _, :process, ^child1, :shutdown}
+      assert_receive {:DOWN, _, :process, ^child2, :shutdown}
+      assert_receive {:DOWN, _, :process, ^child3, :shutdown}
+    end
+
+    test "terminates children with integer shutdown and abnormal reason" do
+      Process.flag(:trap_exit, true)
+      {:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+      fun = fn ->
+        Process.flag(:trap_exit, true)
+        receive(do: (_ -> exit({:shutdown, :oops})))
+      end
+
+      child = Supervisor.child_spec({Task, fun}, shutdown: 1000)
+      assert {:ok, child1} = DynamicSupervisor.start_child(sup, child)
+      assert {:ok, child2} = DynamicSupervisor.start_child(sup, child)
+      assert {:ok, child3} = DynamicSupervisor.start_child(sup, child)
+
+      Process.monitor(child1)
+      Process.monitor(child2)
+      Process.monitor(child3)
+      assert_kill(sup, :shutdown)
+      assert_receive {:DOWN, _, :process, ^child1, {:shutdown, :oops}}
+      assert_receive {:DOWN, _, :process, ^child2, {:shutdown, :oops}}
+      assert_receive {:DOWN, _, :process, ^child3, {:shutdown, :oops}}
+    end
+
+    test "terminates children with expired integer shutdown" do
+      Process.flag(:trap_exit, true)
+      {:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+      fun = fn ->
+        :timer.sleep(:infinity)
+      end
+
+      tmt = fn ->
+        Process.flag(:trap_exit, true)
+        :timer.sleep(:infinity)
+      end
+
+      child_fun = Supervisor.child_spec({Task, fun}, shutdown: 1)
+      child_tmt = Supervisor.child_spec({Task, tmt}, shutdown: 1)
+      assert {:ok, child1} = DynamicSupervisor.start_child(sup, child_fun)
+      assert {:ok, child2} = DynamicSupervisor.start_child(sup, child_tmt)
+      assert {:ok, child3} = DynamicSupervisor.start_child(sup, child_fun)
+
+      Process.monitor(child1)
+      Process.monitor(child2)
+      Process.monitor(child3)
+      assert_kill(sup, :shutdown)
+      assert_receive {:DOWN, _, :process, ^child1, :shutdown}
+      assert_receive {:DOWN, _, :process, ^child2, :killed}
+      assert_receive {:DOWN, _, :process, ^child3, :shutdown}
+    end
+
+    test "terminates children with permanent restart and normal reason" do
+      Process.flag(:trap_exit, true)
+      {:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+      fun = fn ->
+        Process.flag(:trap_exit, true)
+        receive(do: (_ -> exit(:normal)))
+      end
+
+      child = Supervisor.child_spec({Task, fun}, shutdown: :infinity, restart: :permanent)
+      assert {:ok, child1} = DynamicSupervisor.start_child(sup, child)
+      assert {:ok, child2} = DynamicSupervisor.start_child(sup, child)
+      assert {:ok, child3} = DynamicSupervisor.start_child(sup, child)
+
+      Process.monitor(child1)
+      Process.monitor(child2)
+      Process.monitor(child3)
+      assert_kill(sup, :shutdown)
+      assert_receive {:DOWN, _, :process, ^child1, :normal}
+      assert_receive {:DOWN, _, :process, ^child2, :normal}
+      assert_receive {:DOWN, _, :process, ^child3, :normal}
+    end
+
+    test "terminates with mixed children" do
+      Process.flag(:trap_exit, true)
+      {:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+      assert {:ok, child1} =
+               DynamicSupervisor.start_child(sup, sleepy_worker(shutdown: :infinity))
+
+      assert {:ok, child2} =
+               DynamicSupervisor.start_child(sup, sleepy_worker(shutdown: :brutal_kill))
+
+      Process.monitor(child1)
+      Process.monitor(child2)
+      assert_kill(sup, :shutdown)
+      assert_receive {:DOWN, _, :process, ^child1, :shutdown}
+      assert_receive {:DOWN, _, :process, ^child2, :killed}
+    end
+  end
+
+  describe "terminate_child/2" do
+    test "terminates child with brutal kill" do
+      {:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+      child = sleepy_worker(shutdown: :brutal_kill)
+      assert {:ok, child_pid} = DynamicSupervisor.start_child(sup, child)
+
+      Process.monitor(child_pid)
+      assert :ok = DynamicSupervisor.terminate_child(sup, child_pid)
+      assert_receive {:DOWN, _, :process, ^child_pid, :killed}
+
+      assert {:error, :not_found} = DynamicSupervisor.terminate_child(sup, child_pid)
+      assert %{workers: 0, active: 0} = DynamicSupervisor.count_children(sup)
+    end
+
+    test "terminates child with integer shutdown" do
+      {:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one)
+
+      child = sleepy_worker(shutdown: 1000)
+      assert {:ok, child_pid} = DynamicSupervisor.start_child(sup, child)
+
+      Process.monitor(child_pid)
+      assert :ok = DynamicSupervisor.terminate_child(sup, child_pid)
+      assert_receive {:DOWN, _, :process, ^child_pid, :shutdown}
+
+      assert {:error, :not_found} = DynamicSupervisor.terminate_child(sup, child_pid)
+      assert %{workers: 0, active: 0} = DynamicSupervisor.count_children(sup)
+    end
+
+    test "terminates restarting child" do
+      {:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one, max_restarts: 100_000)
+
+      child = current_module_worker([:restart, :error], restart: :permanent)
+      assert {:ok, child_pid} = DynamicSupervisor.start_child(sup, child)
+      assert_kill(child_pid, :shutdown)
+      assert :ok = DynamicSupervisor.terminate_child(sup, child_pid)
+
+      assert {:error, :not_found} = DynamicSupervisor.terminate_child(sup, child_pid)
+      assert %{workers: 0, active: 0} = DynamicSupervisor.count_children(sup)
+    end
+  end
+
+  defp sleepy_worker(opts \\ []) do
+    mfa = {Task, :start_link, [:timer, :sleep, [:infinity]]}
+    Supervisor.child_spec(%{id: Task, start: mfa}, opts)
+  end
+
+  defp current_module_worker(args, opts \\ []) do
+    Supervisor.child_spec(%{id: __MODULE__, start: {__MODULE__, :start_link, args}}, opts)
+  end
+
+  defp assert_kill(pid, reason) do
+    ref = Process.monitor(pid)
+    Process.exit(pid, reason)
+    assert_receive {:DOWN, ^ref, _, _, _}
+  end
+end


### PR DESCRIPTION
As outlined in #5267.

  * [x] Write docs
  * [x] Remove simple_one_for_one references in Supervisor
  * [x] Decide the start_child API
  * [x] Support extra arguments

As @myronmarston mentioned, we need to figure out how we are going to handle the `start_child/2` arguments. He proposed an API that passes a function but that's very likely a no-go because we don't want to allow the user to run custom code inside the supervisor. Instead, I have been thinking about different start_child functions:

  * `start_child(supervisor, arg :: term)` - starts a child with a single argument given to start_link. The argument in the child_spec is ignored.

  * `start_child_with_arguments(supervisor, args :: [term])` - starts a child the given arguments in `start_link`. The arguments in the child_spec are retained.

  * `start_child_with_keywords(supervisor, keyword())` - starts a child by merging the given keywords with the single keyword argument given in the child_spec.

I am confident we need the first 2, we will likely for 3 until there is an use case.