### PR TITLE
Add types autocompletion in IEx

### DIFF
--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -59,6 +59,12 @@ defmodule IEx.AutocompleteTest do
     assert expand('Enumera') == {:yes, 'ble', []}
   end
 
+  test "Elixir type completion" do
+    assert expand('t String') == {:yes, '', ['String', 'StringIO']}
+    assert expand('t String.') == {:yes, '', ['codepoint/0', 'grapheme/0', 'pattern/0', 't/0']}
+    assert expand('t String.grap') == {:yes, 'heme', []}
+  end
+
   test "Elixir completion with self" do
     assert expand('Enumerable') == {:yes, '.', []}
   end


### PR DESCRIPTION
Related issue : #6999 

# Purpose
Add type autocompletion in IEx when users tries to get the type information from the `t` helper.

# Goal
- [x] Autocomplete types only for a specific case (`t` helper only)
Added a clause to match an expression starting with `'t '` in the REPL and send it to type expansion logic.
- [x] Autocomplete all types for a module
`t String.<tab>` will show `codepoint/0    grapheme/0     pattern/0      t/0`.
- [x] Autocomplete types with a hint for a module
`t String.gra<tab>` will autocomplete to `t String.grapheme`.
- [x] Autocomplete modules like usual
`t Str<tab>` will show `Stream      String      StringIO`.

# Mentions
- `t(String.<tab>)` and all its parenthesized alternatives are not supported.  Is this a use case we want to support ?
