### PR TITLE
Improve calendar functions consistency and typespecs

### DIFF
--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -196,7 +196,8 @@ defmodule Date do
       {:error, :invalid_date}
 
   """
-  @spec new(Calendar.year(), Calendar.month(), Calendar.day()) :: {:ok, t} | {:error, atom}
+  @spec new(Calendar.year(), Calendar.month(), Calendar.day(), Calendar.calendar()) ::
+          {:ok, t} | {:error, atom}
   def new(year, month, day, calendar \\ Calendar.ISO) do
     if calendar.valid_date?(year, month, day) do
       {:ok, %Date{year: year, month: month, day: day, calendar: calendar}}
@@ -239,7 +240,7 @@ defmodule Date do
       {:error, :invalid_date}
 
   """
-  @spec from_iso8601(String.t()) :: {:ok, t} | {:error, atom}
+  @spec from_iso8601(String.t(), Calendar.calendar()) :: {:ok, t} | {:error, atom}
   def from_iso8601(string, calendar \\ Calendar.ISO)
 
   def from_iso8601(<<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes>>, calendar) do
@@ -269,7 +270,7 @@ defmodule Date do
       iex> Date.from_iso8601!("2015:01:23")
       ** (ArgumentError) cannot parse "2015:01:23" as date, reason: :invalid_format
   """
-  @spec from_iso8601!(String.t()) :: t
+  @spec from_iso8601!(String.t(), Calendar.calendar()) :: t
   def from_iso8601!(string, calendar \\ Calendar.ISO) do
     case from_iso8601(string, calendar) do
       {:ok, value} ->
@@ -346,7 +347,7 @@ defmodule Date do
       {:error, :invalid_date}
 
   """
-  @spec from_erl(:calendar.date()) :: {:ok, t} | {:error, atom}
+  @spec from_erl(:calendar.date(), Calendar.calendar()) :: {:ok, t} | {:error, atom}
   def from_erl(tuple, calendar \\ Calendar.ISO)
 
   def from_erl({year, month, day}, calendar) do

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -364,9 +364,9 @@ defmodule Date do
       ** (ArgumentError) cannot convert {2000, 13, 1} to date, reason: :invalid_date
 
   """
-  @spec from_erl!(:calendar.date()) :: t
-  def from_erl!(tuple) do
-    case from_erl(tuple) do
+  @spec from_erl!(:calendar.date(), Calendar.calendar()) :: t
+  def from_erl!(tuple, calendar \\ Calendar.ISO) do
+    case from_erl(tuple, calendar) do
       {:ok, value} ->
         value
 

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -631,8 +631,8 @@ defmodule DateTime do
   """
   @spec compare(Calendar.datetime(), Calendar.datetime()) :: :lt | :eq | :gt
   def compare(
-        %DateTime{utc_offset: utc_offset1, std_offset: std_offset1} = datetime1,
-        %DateTime{utc_offset: utc_offset2, std_offset: std_offset2} = datetime2
+        %{calendar: _, utc_offset: utc_offset1, std_offset: std_offset1} = datetime1,
+        %{calendar: _, utc_offset: utc_offset2, std_offset: std_offset2} = datetime2
       ) do
     {days1, {parts1, ppd1}} =
       datetime1

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -572,10 +572,7 @@ defmodule NaiveDateTime do
       {{2000, 2, 29}, {23, 00, 07}}
 
   """
-  @spec to_erl(t) :: :calendar.datetime()
-  def to_erl(naive_datetime)
-
-  @spec to_erl(Calendar.time()) :: :calendar.time()
+  @spec to_erl(Calendar.naive_datetime()) :: :calendar.datetime()
   def to_erl(%{calendar: _} = naive_datetime) do
     %{year: year, month: month, day: day, hour: hour, minute: minute, second: second} =
       convert!(naive_datetime, Calendar.ISO)
@@ -600,7 +597,8 @@ defmodule NaiveDateTime do
       {:error, :invalid_date}
 
   """
-  @spec from_erl(:calendar.datetime(), Calendar.microsecond()) :: {:ok, t} | {:error, atom}
+  @spec from_erl(:calendar.datetime(), Calendar.microsecond(), Calendar.calendar()) ::
+          {:ok, t} | {:error, atom}
   def from_erl(tuple, microsecond \\ {0, 0}, calendar \\ Calendar.ISO)
 
   def from_erl({{year, month, day}, {hour, minute, second}}, microsecond, calendar) do
@@ -624,7 +622,8 @@ defmodule NaiveDateTime do
       ** (ArgumentError) cannot convert {{2000, 13, 1}, {13, 30, 15}} to naive datetime, reason: :invalid_date
 
   """
-  @spec from_erl!(:calendar.datetime(), Calendar.microsecond(), Calendar.calendar()) :: t | no_return
+  @spec from_erl!(:calendar.datetime(), Calendar.microsecond(), Calendar.calendar()) ::
+          t | no_return
   def from_erl!(tuple, microsecond \\ {0, 0}, calendar \\ Calendar.ISO) do
     case from_erl(tuple, microsecond, calendar) do
       {:ok, value} ->

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -624,9 +624,9 @@ defmodule NaiveDateTime do
       ** (ArgumentError) cannot convert {{2000, 13, 1}, {13, 30, 15}} to naive datetime, reason: :invalid_date
 
   """
-  @spec from_erl!(:calendar.datetime(), Calendar.microsecond()) :: t | no_return
-  def from_erl!(tuple, microsecond \\ {0, 0}) do
-    case from_erl(tuple, microsecond) do
+  @spec from_erl!(:calendar.datetime(), Calendar.microsecond(), Calendar.calendar()) :: t | no_return
+  def from_erl!(tuple, microsecond \\ {0, 0}, calendar \\ Calendar.ISO) do
+    case from_erl(tuple, microsecond, calendar) do
       {:ok, value} ->
         value
 

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -213,7 +213,7 @@ defmodule Time do
       {:error, :invalid_time}
 
   """
-  @spec from_iso8601(String.t()) :: {:ok, t} | {:error, atom}
+  @spec from_iso8601(String.t(), Calendar.calendar()) :: {:ok, t} | {:error, atom}
   def from_iso8601(string, calendar \\ Calendar.ISO)
 
   def from_iso8601(<<?T, h, rest::binary>>, calendar) when h in ?0..?9 do

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -252,9 +252,9 @@ defmodule Time do
       iex> Time.from_iso8601!("2015:01:23 23-50-07")
       ** (ArgumentError) cannot parse "2015:01:23 23-50-07" as time, reason: :invalid_format
   """
-  @spec from_iso8601!(String.t()) :: t
-  def from_iso8601!(string) do
-    case from_iso8601(string) do
+  @spec from_iso8601!(String.t(), Calendar.calendar()) :: t
+  def from_iso8601!(string, calendar \\ Calendar.ISO) do
+    case from_iso8601(string, calendar) do
       {:ok, value} ->
         value
 


### PR DESCRIPTION
* Add `Date.from_erl!/2` to match `from_erl/2`
* Add `Time.from_iso8601!/2` to match `from_iso8601/2`
* Add `NaiveDateTime.from_erl!/3` to match `from_erl/3`
* Update `DateTime.compare/2` to actually accept `Calendar.datetime()`
* Improve typespecs

---

Ideas for further improvements:
- Loosen up functions from taking `t` to taking `Calendar.naive_datetime()` (and similar), e.g. `NaiveDateTime.to_date` [1], `NaiveDateTime.to_time`, `NaiveDateTime.add`, `DateTime.to_date` etc
- similar to above for `DateTime.from_naive/2`, `NaiveDateTime.new/2`

I don't have a use case for the things above, but seems to improve consistency with other functions.

[1] https://github.com/wojtekmach/elixir/blob/wm-calendar-improvements/lib/elixir/lib/calendar/naive_datetime.ex#L304