### PR TITLE
Change `Task.child_spec/1` to expect `arg` and not `[arg]`.

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -191,7 +191,7 @@ defmodule Task do
       def child_spec(arg) do
         default = %{
           id: __MODULE__,
-          start: {__MODULE__, :start_link, [arg]},
+          start: {__MODULE__, :start_link, arg},
           restart: :temporary
         }
 

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -43,7 +43,7 @@ defmodule TaskTest do
     assert MyTask.child_spec([:hello]) == %{
              id: MyTask,
              restart: :temporary,
-             start: {MyTask, :start_link, [[:hello]]}
+             start: {MyTask, :start_link, [:hello]}
            }
 
     defmodule CustomTask do


### PR DESCRIPTION
This fixes the arity where one needed `start_link/2` for a module based `Task`

```elixir
defmodule Printer do
  use Task

  def start_link([], event) do
    Task.start_link(fn ->
      IO.puts "HI"
    end
end
```