### PR TITLE
Fix @impl warnings with default arguments

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -978,7 +978,7 @@ defmodule Module do
     impls = :ets.lookup_element(table, {:elixir, :impls}, 2)
 
     {overridable_impls, impls} =
-      :lists.splitwith(fn {pair, _, _, _, _} -> pair in tuples end, impls)
+      :lists.splitwith(fn {pair, _, _, _, _, _} -> pair in tuples end, impls)
 
     if overridable_impls != [] do
       :ets.insert(table, {{:elixir, :impls}, impls})
@@ -1264,12 +1264,9 @@ defmodule Module do
         impls = :ets.lookup_element(table, {:elixir, :impls}, 2)
         {total, defaults} = args_count(args, 0, 0)
 
-        impl =
-          for arity <- total..(total - defaults), into: impls do
-            {{name, arity}, kind, line, file, value}
-          end
+        impl = {{name, total}, defaults, kind, line, file, value}
 
-        :ets.insert(table, {{:elixir, :impls}, impl})
+        :ets.insert(table, {{:elixir, :impls}, [impl | impls]})
 
       [] ->
         :ok
@@ -1412,54 +1409,113 @@ defmodule Module do
   end
 
   defp check_impls(behaviours, callbacks, impls) do
-    Enum.reduce(impls, callbacks, fn {pair, kind, line, file, value}, acc ->
-      if message = impl_warning(pair, kind, value, behaviours, callbacks) do
-        :elixir_errors.warn(line, file, message)
-      end
+    Enum.reduce(impls, callbacks, fn {fa, defaults, kind, line, file, value}, acc ->
+      case impl_behaviours(fa, defaults, kind, value, behaviours, callbacks) do
+        {:ok, impl_behaviours} ->
+          Enum.reduce(impl_behaviours, acc, fn {fa, _}, acc -> Map.delete(acc, fa) end)
 
-      Map.delete(acc, pair)
+        {:error, message} ->
+          :elixir_errors.warn(line, file, format_message(fa, kind, message))
+          acc
+      end
     end)
   end
 
-  defp impl_warning(pair, kind, _, _, _) when kind in [:defp, :defmacrop] do
-    "#{format_definition(kind, pair)} is private, @impl attribute is always discarded for private functions/macros"
+  defp impl_behaviours({function, arity}, defaults, kind, value, behaviours, callbacks) do
+    impls = for n <- arity..(arity - defaults), do: {function, n}
+    impl_behaviours(impls, kind, value, behaviours, callbacks)
   end
 
-  defp impl_warning(pair, kind, value, [], _callbacks) do
-    "got \"@impl #{inspect(value)}\" for #{format_definition(kind, pair)} but no behaviour was declared"
+  defp impl_behaviours(_, kind, _, _, _) when kind in [:defp, :defmacrop] do
+    {:error, :private_function}
   end
 
-  defp impl_warning(pair, kind, false, _behaviours, callbacks) do
-    case Map.fetch(callbacks, pair) do
-      {:ok, {_, behaviour, _}} ->
-        "got \"@impl false\" for #{format_definition(kind, pair)} " <>
-          "but it is a callback specified in #{inspect(behaviour)}"
+  defp impl_behaviours(_, _, value, [], _) do
+    {:error, {:no_behaviours, value}}
+  end
 
-      :error ->
-        nil
+  defp impl_behaviours(impls, _, false, _, callbacks) do
+    case impl_callbacks(impls, callbacks) do
+      [] -> {:ok, []}
+      [impl | _] -> {:error, {:impl_not_defined, impl}}
     end
   end
 
-  defp impl_warning(pair, kind, true, _, callbacks) do
-    if not Map.has_key?(callbacks, pair) do
-      "got \"@impl true\" for #{format_definition(kind, pair)} " <>
-        "but no behaviour specifies such callback#{known_callbacks(callbacks)}"
+  defp impl_behaviours(impls, _, true, _, callbacks) do
+    case impl_callbacks(impls, callbacks) do
+      [] -> {:error, {:impl_defined, callbacks}}
+      impls -> {:ok, impls}
     end
   end
 
-  defp impl_warning(pair, kind, behaviour, behaviours, callbacks) do
+  defp impl_behaviours(impls, _, behaviour, behaviours, callbacks) do
+    filtered = impl_behaviours(impls, behaviour, callbacks)
+
     cond do
-      match?({:ok, {_, ^behaviour, _}}, Map.fetch(callbacks, pair)) ->
-        nil
+      filtered != [] ->
+        {:ok, filtered}
 
       behaviour not in behaviours ->
-        "got \"@impl #{inspect(behaviour)}\" for #{format_definition(kind, pair)} " <>
-          "but this behaviour was not declared with @behaviour"
+        {:error, {:behaviour_not_declared, behaviour}}
 
       true ->
-        "got \"@impl #{inspect(behaviour)}\" for #{format_definition(kind, pair)} " <>
-          "but this behaviour does not specify such callback#{known_callbacks(callbacks)}"
+        {:error, {:behaviour_not_defined, behaviour, callbacks}}
     end
+  end
+
+  defp impl_behaviours(impls, behaviour, callbacks) do
+    impl_behaviours(impl_callbacks(impls, callbacks), behaviour)
+  end
+
+  defp impl_behaviours([], _) do
+    []
+  end
+
+  defp impl_behaviours([{_, behaviour} = impl | tail], behaviour) do
+    [impl | impl_behaviours(tail, behaviour)]
+  end
+
+  defp impl_behaviours([_ | tail], behaviour) do
+    impl_behaviours(tail, behaviour)
+  end
+
+  defp impl_callbacks([], _) do
+    []
+  end
+
+  defp impl_callbacks([fa | tail], callbacks) do
+    case callbacks[fa] do
+      nil -> impl_callbacks(tail, callbacks)
+      {_, behaviour, _} -> [{fa, behaviour} | impl_callbacks(tail, callbacks)]
+    end
+  end
+
+  def format_message(fa, kind, :private_function) do
+    "#{format_definition(kind, fa)} is private, @impl attribute is always discarded for private functions/macros"
+  end
+
+  def format_message(fa, kind, {:no_behaviours, value}) do
+    "got \"@impl #{inspect(value)}\" for #{format_definition(kind, fa)} but no behaviour was declared"
+  end
+
+  def format_message(_, kind, {:impl_not_defined, {fa, behaviour}}) do
+    "got \"@impl false\" for #{format_definition(kind, fa)} " <>
+      "but it is a callback specified in #{inspect(behaviour)}"
+  end
+
+  def format_message(fa, kind, {:impl_defined, callbacks}) do
+    "got \"@impl true\" for #{format_definition(kind, fa)} " <>
+      "but no behaviour specifies such callback#{known_callbacks(callbacks)}"
+  end
+
+  def format_message(fa, kind, {:behaviour_not_declared, behaviour}) do
+    "got \"@impl #{inspect(behaviour)}\" for #{format_definition(kind, fa)} " <>
+      "but this behaviour was not declared with @behaviour"
+  end
+
+  def format_message(fa, kind, {:behaviour_not_defined, behaviour, callbacks}) do
+    "got \"@impl #{inspect(behaviour)}\" for #{format_definition(kind, fa)} " <>
+      "but this behaviour does not specify such callback#{known_callbacks(callbacks)}"
   end
 
   defp warn_missing_impls(_env, callbacks, _defs, _) when map_size(callbacks) == 0 do

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1415,7 +1415,7 @@ defmodule Module do
           Enum.reduce(impl_behaviours, acc, fn {fa, _}, acc -> Map.delete(acc, fa) end)
 
         {:error, message} ->
-          :elixir_errors.warn(line, file, format_message(fa, kind, message))
+          :elixir_errors.warn(line, file, format_impl_warning(fa, kind, message))
           acc
       end
     end)
@@ -1490,30 +1490,30 @@ defmodule Module do
     end
   end
 
-  def format_message(fa, kind, :private_function) do
+  defp format_impl_warning(fa, kind, :private_function) do
     "#{format_definition(kind, fa)} is private, @impl attribute is always discarded for private functions/macros"
   end
 
-  def format_message(fa, kind, {:no_behaviours, value}) do
+  defp format_impl_warning(fa, kind, {:no_behaviours, value}) do
     "got \"@impl #{inspect(value)}\" for #{format_definition(kind, fa)} but no behaviour was declared"
   end
 
-  def format_message(_, kind, {:impl_not_defined, {fa, behaviour}}) do
+  defp format_impl_warning(_, kind, {:impl_not_defined, {fa, behaviour}}) do
     "got \"@impl false\" for #{format_definition(kind, fa)} " <>
       "but it is a callback specified in #{inspect(behaviour)}"
   end
 
-  def format_message(fa, kind, {:impl_defined, callbacks}) do
+  defp format_impl_warning(fa, kind, {:impl_defined, callbacks}) do
     "got \"@impl true\" for #{format_definition(kind, fa)} " <>
       "but no behaviour specifies such callback#{known_callbacks(callbacks)}"
   end
 
-  def format_message(fa, kind, {:behaviour_not_declared, behaviour}) do
+  defp format_impl_warning(fa, kind, {:behaviour_not_declared, behaviour}) do
     "got \"@impl #{inspect(behaviour)}\" for #{format_definition(kind, fa)} " <>
       "but this behaviour was not declared with @behaviour"
   end
 
-  def format_message(fa, kind, {:behaviour_not_defined, behaviour, callbacks}) do
+  defp format_impl_warning(fa, kind, {:behaviour_not_defined, behaviour, callbacks}) do
     "got \"@impl #{inspect(behaviour)}\" for #{format_definition(kind, fa)} " <>
       "but this behaviour does not specify such callback#{known_callbacks(callbacks)}"
   end

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -992,7 +992,7 @@ defmodule Module do
             do: {callback, {kind, behaviour, true}},
             into: %{}
 
-      check_impls(behaviours, callbacks, overridable_impls, module)
+      check_impls(behaviours, callbacks, overridable_impls)
     end
   end
 
@@ -1262,8 +1262,14 @@ defmodule Module do
     case :ets.take(table, :impl) do
       [{:impl, value, _, _}] ->
         impls = :ets.lookup_element(table, {:elixir, :impls}, 2)
-        impl = {{name, length(args)}, kind, line, file, value}
-        :ets.insert(table, {{:elixir, :impls}, [impl | impls]})
+        {total, defaults} = args_count(args, 0, 0)
+
+        impl =
+          for arity <- total..(total - defaults), into: impls do
+            {{name, arity}, kind, line, file, value}
+          end
+
+        :ets.insert(table, {{:elixir, :impls}, impl})
 
       [] ->
         :ok
@@ -1271,6 +1277,16 @@ defmodule Module do
 
     :ok
   end
+
+  defp args_count([{:\\, _, _} | tail], total, defaults) do
+    args_count(tail, total + 1, defaults + 1)
+  end
+
+  defp args_count([_head | tail], total, defaults) do
+    args_count(tail, total + 1, defaults)
+  end
+
+  defp args_count([], total, defaults), do: {total, defaults}
 
   @doc false
   def check_behaviours_and_impls(env, table, all_definitions, overridable_pairs) do
@@ -1280,7 +1296,7 @@ defmodule Module do
 
     pending_callbacks =
       if impls != [] do
-        non_implemented_callbacks = check_impls(behaviours, callbacks, impls, env.module)
+        non_implemented_callbacks = check_impls(behaviours, callbacks, impls)
         warn_missing_impls(env, non_implemented_callbacks, all_definitions, overridable_pairs)
         non_implemented_callbacks
       else
@@ -1395,55 +1411,28 @@ defmodule Module do
       module.__protocol__(:module) == module
   end
 
-  defp check_impls(behaviours, callbacks, impls, module) do
-    table = defs_table_for(module)
-    functions_with_defaults = :ets.match(table, {{:default, :"$1"}, :"$2", :"$3"})
+  defp check_impls(behaviours, callbacks, impls) do
+    Enum.reduce(impls, callbacks, fn {pair, kind, line, file, value}, acc ->
+      if message = impl_warning(pair, kind, value, behaviours, callbacks) do
+        :elixir_errors.warn(line, file, message)
+      end
 
-    Enum.reduce(impls, callbacks, fn {pair_with_impl, kind, line, file, value}, acc ->
-      pairs_to_check = get_impl_pairs_to_check(pair_with_impl, callbacks, functions_with_defaults)
-
-      Enum.each(pairs_to_check, fn pair_to_check ->
-        if message =
-             impl_warning(pair_with_impl, pair_to_check, kind, value, behaviours, callbacks) do
-          :elixir_errors.warn(line, file, message)
-        end
-      end)
-
-      Map.drop(acc, pairs_to_check)
+      Map.delete(acc, pair)
     end)
   end
 
-  defp get_impl_pairs_to_check(pair_with_impl, callbacks, functions_with_defaults) do
-    pairs_from_defaults = unpack_pairs_from_defaults(pair_with_impl, functions_with_defaults)
-
-    case Enum.filter(pairs_from_defaults, &Map.has_key?(callbacks, &1)) do
-      [] -> [pair_with_impl]
-      pairs_matching_callbacks -> pairs_matching_callbacks
-    end
+  defp impl_warning(pair, kind, _, _, _) when kind in [:defp, :defmacrop] do
+    "#{format_definition(kind, pair)} is private, @impl attribute is always discarded for private functions/macros"
   end
 
-  defp unpack_pairs_from_defaults({fun, arity} = pair, functions_with_defaults) do
-    case Enum.find(functions_with_defaults, &match?([^fun, ^arity, _], &1)) do
-      [_, _, default_arg_count] ->
-        for n <- arity..(arity - default_arg_count), do: {fun, n}
-
-      nil ->
-        [pair]
-    end
+  defp impl_warning(pair, kind, value, [], _callbacks) do
+    "got \"@impl #{inspect(value)}\" for #{format_definition(kind, pair)} but no behaviour was declared"
   end
 
-  defp impl_warning(pair_with_impl, _, kind, _, _, _) when kind in [:defp, :defmacrop] do
-    "#{format_definition(kind, pair_with_impl)} is private, @impl attribute is always discarded for private functions/macros"
-  end
-
-  defp impl_warning(pair_with_impl, _, kind, value, [], _callbacks) do
-    "got \"@impl #{inspect(value)}\" for #{format_definition(kind, pair_with_impl)} but no behaviour was declared"
-  end
-
-  defp impl_warning(pair_with_impl, pair_to_check, kind, false, _behaviours, callbacks) do
-    case Map.fetch(callbacks, pair_to_check) do
+  defp impl_warning(pair, kind, false, _behaviours, callbacks) do
+    case Map.fetch(callbacks, pair) do
       {:ok, {_, behaviour, _}} ->
-        "got \"@impl false\" for #{format_definition(kind, pair_with_impl)} " <>
+        "got \"@impl false\" for #{format_definition(kind, pair)} " <>
           "but it is a callback specified in #{inspect(behaviour)}"
 
       :error ->
@@ -1451,24 +1440,24 @@ defmodule Module do
     end
   end
 
-  defp impl_warning(pair_with_impl, pair_to_check, kind, true, _, callbacks) do
-    if not Map.has_key?(callbacks, pair_to_check) do
-      "got \"@impl true\" for #{format_definition(kind, pair_with_impl)} " <>
+  defp impl_warning(pair, kind, true, _, callbacks) do
+    if not Map.has_key?(callbacks, pair) do
+      "got \"@impl true\" for #{format_definition(kind, pair)} " <>
         "but no behaviour specifies such callback#{known_callbacks(callbacks)}"
     end
   end
 
-  defp impl_warning(pair_with_impl, pair_to_check, kind, behaviour, behaviours, callbacks) do
+  defp impl_warning(pair, kind, behaviour, behaviours, callbacks) do
     cond do
-      match?({:ok, {_, ^behaviour, _}}, Map.fetch(callbacks, pair_to_check)) ->
+      match?({:ok, {_, ^behaviour, _}}, Map.fetch(callbacks, pair)) ->
         nil
 
       behaviour not in behaviours ->
-        "got \"@impl #{inspect(behaviour)}\" for #{format_definition(kind, pair_with_impl)} " <>
+        "got \"@impl #{inspect(behaviour)}\" for #{format_definition(kind, pair)} " <>
           "but this behaviour was not declared with @behaviour"
 
       true ->
-        "got \"@impl #{inspect(behaviour)}\" for #{format_definition(kind, pair_with_impl)} " <>
+        "got \"@impl #{inspect(behaviour)}\" for #{format_definition(kind, pair)} " <>
           "but this behaviour does not specify such callback#{known_callbacks(callbacks)}"
     end
   end

--- a/lib/elixir/test/elixir/kernel/impl_test.exs
+++ b/lib/elixir/test/elixir/kernel/impl_test.exs
@@ -324,7 +324,7 @@ defmodule Kernel.ImplTest do
              "got \"@impl Kernel.ImplTest.MacroBehaviour\" for function bar/0 but this behaviour was not declared with @behaviour"
   end
 
-  test "does not warn for @impl when using default arguments" do
+  test "does not warn for @impl when the function with default conforms with several typespecs" do
     assert capture_err(fn ->
              Code.eval_string(~S"""
              defmodule Kernel.ImplTest.ImplAttributes do
@@ -338,18 +338,14 @@ defmodule Kernel.ImplTest do
            end) == ""
   end
 
-  test "does not warn for @impl when there is a second function with the same name" do
+  test "does not warn for @impl when the function conforms to typespec but has default value for arg" do
     assert capture_err(fn ->
              Code.eval_string(~S"""
              defmodule Kernel.ImplTest.ImplAttributes do
                @behaviour Kernel.ImplTest.BehaviourWithArgument
 
                @impl true
-               def foo(arg_1) do
-                 foo(arg_1, [])
-               end
-
-               def foo(arg_1, _args), do: arg_1
+               def foo(args \\ []), do: args
              end
              """)
            end) == ""
@@ -381,20 +377,7 @@ defmodule Kernel.ImplTest do
            end) == ""
   end
 
-  test "does not warn for @impl when the function conforms to typespec but has default value for arg" do
-    assert capture_err(fn ->
-             Code.eval_string(~S"""
-             defmodule Kernel.ImplTest.ImplAttributes do
-               @behaviour Kernel.ImplTest.BehaviourWithArgument
-
-               @impl true
-               def foo(args \\ []), do: args
-             end
-             """)
-           end) == ""
-  end
-
-  test "does not warn for @impl when the function has more args than callback, but they're all defaulted " do
+  test "does not warn for @impl when the function has more args than callback, but they're all defaulted" do
     assert capture_err(fn ->
              Code.eval_string(~S"""
              defmodule Kernel.ImplTest.ImplAttributes do
@@ -422,44 +405,6 @@ defmodule Kernel.ImplTest do
              end
              """)
            end) == ""
-  end
-
-  test "warns for impl when module name doesn't match impl" do
-    error =
-      capture_err(fn ->
-        Code.eval_string(~S"""
-        defmodule Kernel.ImplTest.ImplAttributes do
-          @behaviour Kernel.ImplTest.BehaviourWithArgument
-          @behaviour Kernel.ImplTest.BehaviourWithThreeArguments
-
-          @impl Kernel.ImplTest.BehaviourWithThreeArguments
-          def foo(_foo \\ [], _bar \\ []), do: :ok
-
-          @impl Kernel.ImplTest.BehaviourWithArgument
-          def foo(_foo, _bar, _baz, _qux \\ []), do: :ok
-        end
-        """)
-      end)
-
-    assert error =~
-             "got \"@impl Kernel.ImplTest.BehaviourWithThreeArguments\" for function foo/2 but this behaviour does not specify such callback"
-
-    assert error =~
-             "got \"@impl Kernel.ImplTest.BehaviourWithArgument\" for function foo/4 but this behaviour does not specify such callback"
-  end
-
-  test "warns for @impl when the callback doesn't have enough args" do
-    assert capture_err(fn ->
-             Code.eval_string(~S"""
-             defmodule Kernel.ImplTest.ImplAttributes do
-               @behaviour Kernel.ImplTest.BehaviourWithArgument
-
-               @impl true
-               def foo(), do: :ok
-             end
-             """)
-           end) =~
-             "got \"@impl true\" for function foo/0 but no behaviour specifies such callback"
   end
 
   test "does not warn for no @impl when overriding callback" do

--- a/lib/elixir/test/elixir/kernel/impl_test.exs
+++ b/lib/elixir/test/elixir/kernel/impl_test.exs
@@ -24,6 +24,10 @@ defmodule Kernel.ImplTest do
     @callback foo(any) :: any
   end
 
+  defmodule BehaviourWithThreeArguments do
+    @callback foo(any, any, any) :: any
+  end
+
   defmodule MacroBehaviour do
     @macrocallback bar :: any
   end
@@ -332,6 +336,130 @@ defmodule Kernel.ImplTest do
              end
              """)
            end) == ""
+  end
+
+  test "does not warn for @impl when there is a second function with the same name" do
+    assert capture_err(fn ->
+             Code.eval_string(~S"""
+             defmodule Kernel.ImplTest.ImplAttributes do
+               @behaviour Kernel.ImplTest.BehaviourWithArgument
+
+               @impl true
+               def foo(arg_1) do
+                 foo(arg_1, [])
+               end
+
+               def foo(arg_1, _args), do: arg_1
+             end
+             """)
+           end) == ""
+  end
+
+  test "does not warn for @impl when the function conforms to typespec but has additional trailing default args" do
+    assert capture_err(fn ->
+             Code.eval_string(~S"""
+             defmodule Kernel.ImplTest.ImplAttributes do
+               @behaviour Kernel.ImplTest.BehaviourWithArgument
+
+               @impl true
+               def foo(arg_1, _args \\ []), do: arg_1
+             end
+             """)
+           end) == ""
+  end
+
+  test "does not warn for @impl when the function conforms to typespec but has additional leading default args" do
+    assert capture_err(fn ->
+             Code.eval_string(~S"""
+             defmodule Kernel.ImplTest.ImplAttributes do
+               @behaviour Kernel.ImplTest.BehaviourWithArgument
+
+               @impl true
+               def foo(_defaulted_arg \\ [], args), do: args
+             end
+             """)
+           end) == ""
+  end
+
+  test "does not warn for @impl when the function conforms to typespec but has default value for arg" do
+    assert capture_err(fn ->
+             Code.eval_string(~S"""
+             defmodule Kernel.ImplTest.ImplAttributes do
+               @behaviour Kernel.ImplTest.BehaviourWithArgument
+
+               @impl true
+               def foo(args \\ []), do: args
+             end
+             """)
+           end) == ""
+  end
+
+  test "does not warn for @impl when the function has more args than callback, but they're all defaulted " do
+    assert capture_err(fn ->
+             Code.eval_string(~S"""
+             defmodule Kernel.ImplTest.ImplAttributes do
+               @behaviour Kernel.ImplTest.BehaviourWithArgument
+
+               @impl true
+               def foo(args \\ [], _bar \\ []), do: args
+             end
+             """)
+           end) == ""
+  end
+
+  test "does not warn for @impl with defaults when the same function is defined mutiple times" do
+    assert capture_err(fn ->
+             Code.eval_string(~S"""
+             defmodule Kernel.ImplTest.ImplAttributes do
+               @behaviour Kernel.ImplTest.BehaviourWithArgument
+               @behaviour Kernel.ImplTest.BehaviourWithThreeArguments
+
+               @impl Kernel.ImplTest.BehaviourWithArgument
+               def foo(_foo \\ [], _bar \\ []), do: :ok
+
+               @impl Kernel.ImplTest.BehaviourWithThreeArguments
+               def foo(_foo, _bar, _baz, _qux \\ []), do: :ok
+             end
+             """)
+           end) == ""
+  end
+
+  test "warns for impl when module name doesn't match impl" do
+    error =
+      capture_err(fn ->
+        Code.eval_string(~S"""
+        defmodule Kernel.ImplTest.ImplAttributes do
+          @behaviour Kernel.ImplTest.BehaviourWithArgument
+          @behaviour Kernel.ImplTest.BehaviourWithThreeArguments
+
+          @impl Kernel.ImplTest.BehaviourWithThreeArguments
+          def foo(_foo \\ [], _bar \\ []), do: :ok
+
+          @impl Kernel.ImplTest.BehaviourWithArgument
+          def foo(_foo, _bar, _baz, _qux \\ []), do: :ok
+        end
+        """)
+      end)
+
+    assert error =~
+             "got \"@impl Kernel.ImplTest.BehaviourWithThreeArguments\" for function foo/2 but this behaviour does not specify such callback"
+
+    assert error =~
+             "got \"@impl Kernel.ImplTest.BehaviourWithArgument\" for function foo/4 but this behaviour does not specify such callback"
+  end
+
+  test "warns for @impl when the callback doesn't have enough args" do
+    assert capture_err(fn ->
+             Code.eval_string(~S"""
+             defmodule Kernel.ImplTest.ImplAttributes do
+               @behaviour Kernel.ImplTest.BehaviourWithArgument
+
+               @impl true
+               def foo(), do: :ok
+             end
+             """)
+           end) =~
+             "got \"@impl true\" for function foo/0 but no behaviour specifies such callback"
   end
 
   test "does not warn for no @impl when overriding callback" do


### PR DESCRIPTION
Remove warnings when some of the clauses of a function with defaults don't implement callbacks reported on #6975