### PR TITLE
Improve warning for missing protocols in tests

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -702,7 +702,8 @@ defmodule Protocol do
     if Protocol.consolidated?(protocol) do
       message =
         "the #{inspect(protocol)} protocol has already been consolidated" <>
-          ", an implementation for #{inspect(for)} has no effect"
+          ", an implementation for #{inspect(for)} has no effect. " <>
+          "For testing define the protocol in `test/support/<file>.ex`"
 
       :elixir_errors.warn(env.line, env.file, message)
     end


### PR DESCRIPTION
@coderdan and I were trying to define a protocol in a test much like what is described in #4175.

We received the warning implemented in #4188 but we couldn't easily find any good advice about how to achieve our goal.

Since we didn't want to add the test protocol into the code in `lib` we ended up defining it in `test/support/<file>.ex`.

We've added this guidance about what do in the case of tests, but are aware that there are other situations where this advice probably doesn't apply.

This is really a draft proposal which we'd love some feedback on, and we had some other questions.

- Is this the right advice or is there a better solution?
- What other situations can this warning occur in? What should be done in that case?
- Should this really be a warning? In our case this resulted in an immediate error (`There are no implementations for this protocol`) when trying to use the protocol, so there might be an argument to make this an error?