### PR TITLE
Include a compiled test/support in new apps

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -108,6 +108,7 @@ defmodule Mix.Tasks.New do
 
     create_directory("test")
     create_file("test/test_helper.exs", test_helper_template(assigns))
+    create_file("test/support/.gitkeep", "")
     create_file("test/#{app}_test.exs", test_template(assigns))
 
     """
@@ -295,6 +296,7 @@ defmodule Mix.Tasks.New do
         app: :<%= @app %>,
         version: "0.1.0",
         elixir: "~> <%= @version %>",
+        elixirc_paths: elixirc_paths(Mix.env()),
         start_permanent: Mix.env() == :prod,
         deps: deps()
       ]
@@ -306,6 +308,10 @@ defmodule Mix.Tasks.New do
         extra_applications: [:logger]<%= @sup_app %>
       ]
     end
+
+    # Compile `.ex` files in `test/support` for testing protocols, etc
+    defp elixirc_paths(:test), do: ["lib", "test/support"]
+    defp elixirc_paths(_), do: ["lib"]
 
     # Run "mix help deps" to learn about dependencies.
     defp deps do

--- a/lib/mix/test/mix/tasks/new_test.exs
+++ b/lib/mix/test/mix/tasks/new_test.exs
@@ -10,6 +10,9 @@ defmodule Mix.Tasks.NewTest do
       assert_file("hello_world/mix.exs", fn file ->
         assert file =~ "app: :hello_world"
         assert file =~ "version: \"0.1.0\""
+        assert file =~ "elixirc_paths: elixirc_paths(Mix.env()),"
+        assert file =~ "defp elixirc_paths(:test), do: [\"lib\", \"test/support\"]"
+        assert file =~ "defp elixirc_paths(_), do: [\"lib\"]"
       end)
 
       assert_file("hello_world/README.md", ~r/# HelloWorld\n/)
@@ -18,6 +21,7 @@ defmodule Mix.Tasks.NewTest do
       assert_file("hello_world/lib/hello_world.ex", ~r/defmodule HelloWorld do/)
 
       assert_file("hello_world/test/test_helper.exs", ~r/ExUnit.start()/)
+      assert_file("hello_world/test/support/.gitkeep")
 
       assert_file("hello_world/test/hello_world_test.exs", fn file ->
         assert file =~ ~r/defmodule HelloWorldTest do/


### PR DESCRIPTION
Phoenix includes a compiled `test/support` directory which seems like a reasonably common Elixir convention.

One of the reasons this is needed is described in #7039 whereby protocols required for tests need to be consolidated and also don't make sense to put in `/lib` since they are test specific.

In the app that inspired the issue raised in #7039 this happened to have already been done, and felt very natural. However it was a surprise to learn that this wasn't there by default in `mix new`.

One counter argument is that this complicates the very first `mix.exs` unnecessarily, however the cost of adding this versus the cost of having to figure it out later seems worthwhile.

I'm not a big fan of the empty `test/support` directory but couldn't think of anything immediately useful to include in there. As precedent Phoenix includes the `conn_case.ex` etc.

Paired with @freshtonic