### PR TITLE
Use inspect in assertion diff for structs if possible

### DIFF
--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -24,9 +24,13 @@ defmodule ExUnit.Diff do
 
   # Structs
   def script(%name{} = left, %name{} = right) do
-    left = Map.from_struct(left)
-    right = Map.from_struct(right)
-    script_map(left, right, inspect(name))
+    if Inspect.impl_for(left) != Inspect.Any and inspect(left) != inspect(right) do
+      script_string(inspect(left), inspect(right))
+    else
+      left = Map.from_struct(left)
+      right = Map.from_struct(right)
+      script_map(left, right, inspect(name))
+    end
   end
 
   # Maps

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -24,12 +24,17 @@ defmodule ExUnit.Diff do
 
   # Structs
   def script(%name{} = left, %name{} = right) do
-    if Inspect.impl_for(left) != Inspect.Any and inspect(left) != inspect(right) do
-      script_string(inspect(left), inspect(right))
+    if Inspect.impl_for(left) != Inspect.Any do
+      inspect_left = inspect(left)
+      inspect_right = inspect(right)
+
+      if inspect_left != inspect_right do
+        script_string(inspect_left, inspect_right)
+      else
+        script_struct(left, right)
+      end
     else
-      left = Map.from_struct(left)
-      right = Map.from_struct(right)
-      script_map(left, right, inspect(name))
+      script_struct(left, right)
     end
   end
 
@@ -437,6 +442,12 @@ defmodule ExUnit.Diff do
 
     [[_ | elem_diff] | rest] = result
     [{:eq, "%" <> name <> "{"}, [elem_diff | rest], {:eq, "}"}]
+  end
+
+  defp script_struct(%name{} = left, %name{} = right) do
+    left = Map.from_struct(left)
+    right = Map.from_struct(right)
+    script_map(left, right, inspect(name))
   end
 
   defp map_difference(map1, map2) do

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -446,10 +446,10 @@ defmodule ExUnit.DiffTest do
     opaque2 = %Opaque{x: 2}
 
     assert script(opaque1, opaque2) == [
-      {:eq, "%ExUnit.DiffTest.Opaque{"},
-      [[{:eq, "x: "}, [del: "1", ins: "2"]]],
-      {:eq, "}"}
-    ]
+             {:eq, "%ExUnit.DiffTest.Opaque{"},
+             [[{:eq, "x: "}, [del: "1", ins: "2"]]],
+             {:eq, "}"}
+           ]
   end
 
   test "not supported" do

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -9,6 +9,16 @@ defmodule ExUnit.DiffTest do
     defstruct [:age]
   end
 
+  defmodule Opaque do
+    defstruct [:x]
+
+    defimpl Inspect do
+      def inspect(_, _) do
+        "#Opaque<???>"
+      end
+    end
+  end
+
   test "numbers" do
     int1 = 491_512_235
     int2 = 490_512_035
@@ -422,6 +432,24 @@ defmodule ExUnit.DiffTest do
     assert script(user1, user2) == expected
     assert script(%User{}, %{}) == nil
     assert script(%User{}, %ExUnit.Test{}) == nil
+  end
+
+  test "structs with inspect" do
+    date1 = ~D[2017-10-01]
+    date2 = ~D[2017-10-02]
+
+    assert script(date1, date2) == [eq: "~D[2017-10-0", del: "1", ins: "2", eq: "]"]
+  end
+
+  test "structs with no inspect difference" do
+    opaque1 = %Opaque{x: 1}
+    opaque2 = %Opaque{x: 2}
+
+    assert script(opaque1, opaque2) == [
+      {:eq, "%ExUnit.DiffTest.Opaque{"},
+      [[{:eq, "x: "}, [del: "1", ins: "2"]]],
+      {:eq, "}"}
+    ]
   end
 
   test "not supported" do


### PR DESCRIPTION
Closes #6930

For this:

```elixir
  test "1" do
    assert ~N[2017-10-01 09:00:00] == ~N[2017-11-02 09:00:00.0]
  end

  test "2" do
    assert MapSet.new([1]) == MapSet.new([1, 2])
  end

  test "3" do
    assert 1..1 == 1..2
  end

  test "4" do
    assert Stream.filter([1, 2, 3], &(&1)) == Stream.take([1, 2, 3], 2)
  end
```

Before:

![screen shot 2017-11-17 at 23 19 58](https://user-images.githubusercontent.com/76071/32971633-5bdaaeae-cbee-11e7-9664-fda250cc2a39.png)

After:

![screen shot 2017-11-17 at 23 20 26](https://user-images.githubusercontent.com/76071/32971635-5e942224-cbee-11e7-9dd1-d17337eb0d28.png)
