### PR TITLE
Improve ExUnit documentation with regards to "setup" and "using"

### DIFF
--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -2,13 +2,13 @@ defmodule ExUnit.Callbacks do
   @moduledoc ~S"""
   Defines ExUnit callbacks.
 
-  This module defines both `setup_all` and `setup` callbacks, as well as
+  This module defines both `setup` and `setup_all` callbacks, as well as
   the `on_exit/2`, `start_supervised/2` and `stop_supervised/1` functions.
 
   The setup callbacks are defined via macros and each one can optionally
-  receive a map with metadata, usually referred to as `context`. The
-  callback may optionally put extra data into the `context` to be used in
-  the tests.
+  receive a map with metadata, usually referred to as `context`. The context
+  to be used in the tests can be optionally extended by the callbacks by
+  returning a properly structured value (see below).
 
   The `setup_all` callbacks are invoked only once per module, before any
   test runs. All `setup` callbacks are run before each test. No callback
@@ -43,14 +43,13 @@ defmodule ExUnit.Callbacks do
 
   ## Context
 
-  If you return a keyword list, a map, or `{:ok, keywords | map}` from
-  `setup_all`, the keyword list/map will be merged into the current context and
-  be available in all subsequent `setup_all`, `setup`, and the `test` itself.
+  If `setup_all` returns a keyword list, a map, or `{:ok, keywords | map}`,
+  the keyword list/map will be merged into the current context and will be
+  available in all subsequent `setup_all`, `setup`, and the `test` itself.
 
-  Similarly, returning a keyword list, map, or `{:ok, keywords | map}` from
-  `setup` means that the returned keyword list/map will be merged into the
-  current context and be available in all subsequent `setup` and the `test`
-  itself.
+  Similarly, if `setup` returns a keyword list, map, or `{:ok, keywords | map}`,
+  the returned keyword list/map will be merged into the current context and will
+  be available in all subsequent `setup` and the `test` itself.
 
   Returning `:ok` leaves the context unchanged (both in `setup` and `setup_all`
   callbacks).
@@ -67,7 +66,7 @@ defmodule ExUnit.Callbacks do
         setup_all do
           IO.puts "Starting AssertionTest"
 
-          # No context is returned here
+          # Context is not updated here
           :ok
         end
 
@@ -81,6 +80,11 @@ defmodule ExUnit.Callbacks do
 
           # Returns extra metadata to be merged into context
           [hello: "world"]
+
+          # Similarly, any of the following would work:
+          #   {:ok, [hello: "world"]}
+          #   %{hello: "world"}
+          #   {:ok, %{hello: "world"}}
         end
 
         # Same as above, but receives the context as argument
@@ -98,6 +102,7 @@ defmodule ExUnit.Callbacks do
 
         test "uses metadata from setup", context do
           assert context[:hello] == "world"
+          assert context[:from_named_setup] == true
         end
 
         defp invoke_local_or_imported_function(context) do

--- a/lib/ex_unit/lib/ex_unit/case_template.ex
+++ b/lib/ex_unit/lib/ex_unit/case_template.ex
@@ -65,9 +65,14 @@ defmodule ExUnit.CaseTemplate do
 
   ## Example
 
-      using do
-        quote do
-          alias MyApp.FunModule
+      defmodule MyCase do
+        use ExUnit.CaseTemplate
+
+        using do
+          quote do
+            # This code is injected into every case that calls "use MyCase"
+            alias MyApp.FunModule
+          end
         end
       end
 


### PR DESCRIPTION
Phoenix's generated `conn_case.ex` uses both `setup` and `using` extensively, so it would be nice to have a clean and more explicit documentation around these two:
- Rearranged the docs so that it's easier to visually scan for `setup` and tried to make it more clear how to update the context for tests,
- Extended the example for `using` to make it more clear what is happening there.