### PR TITLE
Update docs for DateTime.compare/2

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -610,11 +610,11 @@ defmodule DateTime do
   @doc """
   Compares two datetime structs.
 
-  Returns `:gt` if first datetime is later than the second
+  Returns `:gt` if the first datetime is later than the second
   and `:lt` for vice versa. If the two datetimes are equal
   `:eq` is returned.
 
-  Note that both utc and stc offsets will be taken into
+  Note that both UTC and Standard offsets will be taken into
   account when comparison is done.
 
   ## Examples


### PR DESCRIPTION
Add missing `the` and make the references to UTC and Standard offsets consistent with the other docs.