### PR TITLE
Simplify Calendar.truncate/2 precision check

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -246,12 +246,7 @@ defmodule Calendar do
   def truncate(microsecond_tuple, :microsecond), do: microsecond_tuple
 
   def truncate({microsecond, precision}, :millisecond) do
-    output_precision =
-      case precision do
-        precision when precision >= 3 -> 3
-        _ -> precision
-      end
-
+    output_precision = min(precision, 3)
     {div(microsecond, 1000) * 1000, output_precision}
   end
 


### PR DESCRIPTION
`Calendar.truncate/2` clamps the precision to a maximum of 3, which would seem to be more clearly expressed by `min(precision, 3)` than the current case statement.  All tests pass.