### PR TITLE
Explain bare expression behavior in with docs

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1375,11 +1375,10 @@ defmodule Kernel.SpecialForms do
       nil
 
   Note that if a "bare expression" fails to match, it will raise a `MatchError`
-  instead of returning the non-matched value. For example, the following will raise:
+  instead of returning the non-matched value:
 
-      with :foo = :bar, do: :ok
+      iex> with :foo = :bar, do: :ok
       ** (MatchError) no match of right hand side value: :bar
-
 
   An `else` option can be given to modify what is being returned from
   `with` in the case of a failed match:

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1375,7 +1375,11 @@ defmodule Kernel.SpecialForms do
       nil
 
   Note that if a "bare expression" fails to match, it will raise a `MatchError`
-  instead of returning the non-matched value.
+  instead of returning the non-matched value. For example, the following will raise:
+
+      with :foo = :bar, do: :ok
+      ** (MatchError) no match of right hand side value: :bar
+
 
   An `else` option can be given to modify what is being returned from
   `with` in the case of a failed match:

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1374,6 +1374,9 @@ defmodule Kernel.SpecialForms do
       iex> width
       nil
 
+  Note that if a "bare expression" fails to match, it will raise a `MatchError`
+  instead of returning the non-matched value.
+
   An `else` option can be given to modify what is being returned from
   `with` in the case of a failed match:
 

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1377,8 +1377,8 @@ defmodule Kernel.SpecialForms do
   Note that if a "bare expression" fails to match, it will raise a `MatchError`
   instead of returning the non-matched value:
 
-      iex> with :foo = :bar, do: :ok
-      ** (MatchError) no match of right hand side value: :bar
+      with :foo = :bar, do: :ok
+      #=> ** (MatchError) no match of right hand side value: :bar
 
   An `else` option can be given to modify what is being returned from
   `with` in the case of a failed match:


### PR DESCRIPTION
I wasn't sure about the difference btween `<-` and `=` in `with` statements. Writing this example helped me understand the behaviour.
```elixir
one =
  with :foo <- :bar do
    :success
  end

IO.inspect one, label: "one"

two =
  with :foo = :bar do
    :success
  end

IO.inspect two, label: "two"
```

one will output `:bar` because the match fails, while two is never reached because it throws a `MatchError`.

This PR updates the with docs to make this a bit clearer