### PR TITLE
Move boolean checks optimizations to Kernel

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1458,6 +1458,10 @@ defmodule Kernel do
 
   ## Implemented in Elixir
 
+  defp optimize_boolean({:case, meta, args}) do
+    {:case, [{:optimize_boolean, true} | meta], args}
+  end
+
   @doc """
   Boolean or.
 
@@ -1479,7 +1483,10 @@ defmodule Kernel do
 
   """
   defmacro left or right do
-    quote(do: :erlang.orelse(unquote(left), unquote(right)))
+    case __CALLER__.context do
+      nil -> build_boolean_check(:or, left, true, right)
+      _ -> quote(do: :erlang.orelse(unquote(left), unquote(right)))
+    end
   end
 
   @doc """
@@ -1502,7 +1509,22 @@ defmodule Kernel do
 
   """
   defmacro left and right do
-    quote(do: :erlang.andalso(unquote(left), unquote(right)))
+    case __CALLER__.context do
+      nil -> build_boolean_check(:and, left, right, false)
+      _ -> quote(do: :erlang.andalso(unquote(left), unquote(right)))
+    end
+  end
+
+  defp build_boolean_check(op, check, true_clause, false_clause) do
+    optimize_boolean(
+      quote generated: true do
+        case unquote(check) do
+          false -> unquote(false_clause)
+          true -> unquote(true_clause)
+          other -> raise BadBooleanError, operator: unquote(op), term: other
+        end
+      end
+    )
   end
 
   @doc """
@@ -5069,10 +5091,6 @@ defmodule Kernel do
   end
 
   ## Shared functions
-
-  defp optimize_boolean({:case, meta, args}) do
-    {:case, [{:optimize_boolean, true} | meta], args}
-  end
 
   # We need this check only for bootstrap purposes.
   # Once Kernel is loaded and we recompile, it is a no-op.

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1517,7 +1517,7 @@ defmodule Kernel do
 
   defp build_boolean_check(op, check, true_clause, false_clause) do
     optimize_boolean(
-      quote generated: true do
+      quote do
         case unquote(check) do
           false -> unquote(false_clause)
           true -> unquote(true_clause)

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1515,13 +1515,18 @@ defmodule Kernel do
     end
   end
 
-  defp build_boolean_check(op, check, true_clause, false_clause) do
+  defp build_boolean_check(operator, check, true_clause, false_clause) do
     optimize_boolean(
       quote do
         case unquote(check) do
-          false -> unquote(false_clause)
-          true -> unquote(true_clause)
-          other -> raise BadBooleanError, operator: unquote(op), term: other
+          true ->
+            unquote(true_clause)
+
+          false ->
+            unquote(false_clause)
+
+          other ->
+            :erlang.error(BadBooleanError.exception(operator: unquote(operator), term: other))
         end
       end
     )

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -388,6 +388,12 @@ expand({Atom, Meta, Args}, E) when is_atom(Atom), is_list(Meta), is_list(Args) -
 
 %% Remote calls
 
+expand({{'.', _, [erlang, 'andalso']}, _, [_, _]} = Expr, #{context := nil} = E) ->
+  expand_boolean_check(Expr, E);
+
+expand({{'.', _, [erlang, 'orelse']}, _, [_, _]} = Expr, #{context := nil} = E) ->
+  expand_boolean_check(Expr, E);
+
 expand({{'.', DotMeta, [Left, Right]}, Meta, Args}, E)
     when (is_tuple(Left) orelse is_atom(Left)), is_atom(Right), is_list(Meta), is_list(Args) ->
   {ELeft, EL} = expand(Left, E),
@@ -644,6 +650,13 @@ allowed_in_context(_, _Arity, guard) ->
   false;
 allowed_in_context(_, _, _) ->
   true.
+
+%% Boolean checks (`orelse`, `andalso`)
+
+expand_boolean_check({DotExpr, Meta, [Left, Right]}, E) ->
+  {ELeft, EL} = expand(Left, E),
+  {ERight, ER} = expand(Right, EL),
+  {{DotExpr, Meta, [ELeft, ERight]}, elixir_env:mergea(ER, EL)}.
 
 %% Lexical helpers
 

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -388,12 +388,6 @@ expand({Atom, Meta, Args}, E) when is_atom(Atom), is_list(Meta), is_list(Args) -
 
 %% Remote calls
 
-expand({{'.', _, [erlang, 'andalso']}, _, [_, _]} = Expr, #{context := nil} = E) ->
-  expand_boolean_check(Expr, E);
-
-expand({{'.', _, [erlang, 'orelse']}, _, [_, _]} = Expr, #{context := nil} = E) ->
-  expand_boolean_check(Expr, E);
-
 expand({{'.', DotMeta, [Left, Right]}, Meta, Args}, E)
     when (is_tuple(Left) orelse is_atom(Left)), is_atom(Right), is_list(Meta), is_list(Args) ->
   {ELeft, EL} = expand(Left, E),
@@ -595,6 +589,14 @@ rewrite_case_clauses([{do, [
     {'->', FalseMeta, [[false], FalseExpr]},
     {'->', TrueMeta, [[true], TrueExpr]}
   ]}];
+rewrite_case_clauses([{do, [
+  {'->', FalseMeta, [[false], FalseExpr]},
+  {'->', TrueMeta, [[true], TrueExpr]} | _
+]}]) ->
+  [{do, [
+    {'->', FalseMeta, [[false], FalseExpr]},
+    {'->', TrueMeta, [[true], TrueExpr]}
+  ]}];
 rewrite_case_clauses(Other) ->
   Other.
 
@@ -650,13 +652,6 @@ allowed_in_context(_, _Arity, guard) ->
   false;
 allowed_in_context(_, _, _) ->
   true.
-
-%% Boolean checks (`orelse`, `andalso`)
-
-expand_boolean_check({DotExpr, Meta, [Left, Right]}, E) ->
-  {ELeft, EL} = expand(Left, E),
-  {ERight, ER} = expand(Right, EL),
-  {{DotExpr, Meta, [ELeft, ERight]}, elixir_env:mergea(ER, EL)}.
 
 %% Lexical helpers
 

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -561,12 +561,19 @@ var_context(Meta, Kind) ->
 expand_case(true, Meta, Expr, Opts, E) ->
   {EExpr, EE} = expand(Expr, E),
   {EOpts, EO} = elixir_clauses:'case'(Meta, Opts, EE),
+
   ROpts =
-    case proplists:get_value(optimize_boolean, Meta, false) andalso
-         elixir_utils:returns_boolean(EExpr) of
-      true -> rewrite_case_clauses(EOpts);
-      false -> generated_case_clauses(EOpts)
+    case proplists:get_value(optimize_boolean, Meta, false) of
+      true ->
+        case elixir_utils:returns_boolean(EExpr) of
+          true -> rewrite_case_clauses(EOpts);
+          false -> generated_case_clauses(EOpts)
+        end;
+
+      false ->
+        EOpts
     end,
+
   {{'case', Meta, [EExpr, ROpts]}, EO};
 expand_case(false, Meta, Expr, Opts, E) ->
   {Case, _} = expand_case(true, Meta, Expr, Opts, E),

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -227,6 +227,7 @@ defmodule KernelTest do
     assert (false and true) == false
     assert (false and 0) == false
     assert (false and raise("oops")) == false
+    assert ((x = true) and not x) == false
     assert_raise BadBooleanError, fn -> 0 and 1 end
   end
 
@@ -238,6 +239,7 @@ defmodule KernelTest do
     assert (false or false) == false
     assert (false or true) == true
     assert (false or 0) == 0
+    assert ((x = false) or not x) == true
     assert_raise BadBooleanError, fn -> 0 or 1 end
   end
 


### PR DESCRIPTION
Fixes the issue raised on https://github.com/elixir-lang/elixir/pull/7069#issuecomment-347490983
returning environment from the left side to the next expressions on boolean checks (`and`, `or`)