### PR TITLE
Document multi clause anonymous functions

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1407,6 +1407,14 @@ defmodule Kernel.SpecialForms do
       iex> add.(1, 2)
       3
 
+  Anonymous functions can also have multiple clauses
+
+      iex> negate = fn
+      ...>   true -> false
+      ...>   false -> true
+      ...> end
+      iex> negate.(false)
+      true
   """
   defmacro unquote(:fn)(clauses), do: error!([clauses])
 

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1394,7 +1394,6 @@ defmodule Kernel.SpecialForms do
       {:error, :wrong_data}
 
   If there is no matching `else` condition, then a `WithClauseError` exception is raised.
-
   """
   defmacro with(args), do: error!([args])
 
@@ -1407,7 +1406,8 @@ defmodule Kernel.SpecialForms do
       iex> add.(1, 2)
       3
 
-  Anonymous functions can also have multiple clauses
+  Anonymous functions can also have multiple clauses. All clauses
+  should expect the same number of arguments:
 
       iex> negate = fn
       ...>   true -> false
@@ -1415,6 +1415,7 @@ defmodule Kernel.SpecialForms do
       ...> end
       iex> negate.(false)
       true
+
   """
   defmacro unquote(:fn)(clauses), do: error!([clauses])
 


### PR DESCRIPTION
I was looking for the multi-clause anonymous function syntax, but couldn't find it when i searched for `fn`. I recall that it is documented somewhere else, but this seems like it would help as well.

Happy to change the example, I had a hard time thinking of a simple multi-clause function that wasn't self-referential. Not trying to write a y-combinator as an example :)

🍍🍍🍍🍍🍍🍍 