### PR TITLE
Files with only comments are no longer always stale

### DIFF
--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -334,7 +334,11 @@ defmodule Mix.Compilers.Elixir do
 
   defp update_stale_sources(sources, changed) do
     # Store empty sources for the changed ones as the compiler appends data
-    Enum.reduce(changed, sources, &List.keystore(&2, &1, source(:source), source(source: &1)))
+    Enum.reduce(
+      changed,
+      sources,
+      &List.keystore(&2, &1, source(:source), source(source: &1, size: :filelib.file_size(&1)))
+    )
   end
 
   # This function receives the manifest entries and some source

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -400,15 +400,21 @@ defmodule Mix.Tasks.Compile.ElixirTest do
     end
   end
 
-  test "does not recompile empty files" do
+  test "does not recompile files that are empty or has no code" do
     in_fixture "no_mixfile", fn ->
       File.write!("lib/a.ex", "")
+      File.write!("lib/b.ex", "# Just a comment")
+      File.write!("lib/c.ex", "\n\n")
 
       assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+      assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+      assert_received {:mix_shell, :info, ["Compiled lib/c.ex"]}
 
       assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:noop, []}
       refute_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+      refute_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+      refute_received {:mix_shell, :info, ["Compiled lib/c.ex"]}
     end
   end
 

--- a/lib/mix/test/mix/tasks/compile_test.exs
+++ b/lib/mix/test/mix/tasks/compile_test.exs
@@ -34,6 +34,25 @@ defmodule Mix.Tasks.CompileTest do
     assert Mix.Tasks.Compile.manifests() |> Enum.map(&Path.basename/1) == [".compile.elixir"]
   end
 
+  test "compile a project with files containing only comments or newlines" do
+    in_fixture "no_mixfile", fn ->
+      import ExUnit.CaptureIO
+      import ExUnit.CaptureLog
+
+      File.write!("lib/a.ex", """
+      # defmodule CommentsOnly do
+      #   def foo(), do: 1
+      # end
+      """)
+
+      File.write!("lib/b.ex", "\n\n")
+
+      assert Mix.Task.run("compile", ["--verbose"]) == {:ok, []}
+      Mix.Task.clear()
+      assert Mix.Task.run("compile", ["--verbose"]) == {:noop, []}
+    end
+  end
+
   test "compile a project with mixfile" do
     in_fixture "no_mixfile", fn ->
       assert Mix.Tasks.Compile.run(["--verbose"]) == {:ok, []}

--- a/lib/mix/test/mix/tasks/compile_test.exs
+++ b/lib/mix/test/mix/tasks/compile_test.exs
@@ -34,25 +34,6 @@ defmodule Mix.Tasks.CompileTest do
     assert Mix.Tasks.Compile.manifests() |> Enum.map(&Path.basename/1) == [".compile.elixir"]
   end
 
-  test "compile a project with files containing only comments or newlines" do
-    in_fixture "no_mixfile", fn ->
-      import ExUnit.CaptureIO
-      import ExUnit.CaptureLog
-
-      File.write!("lib/a.ex", """
-      # defmodule CommentsOnly do
-      #   def foo(), do: 1
-      # end
-      """)
-
-      File.write!("lib/b.ex", "\n\n")
-
-      assert Mix.Task.run("compile", ["--verbose"]) == {:ok, []}
-      Mix.Task.clear()
-      assert Mix.Task.run("compile", ["--verbose"]) == {:noop, []}
-    end
-  end
-
   test "compile a project with mixfile" do
     in_fixture "no_mixfile", fn ->
       assert Mix.Tasks.Compile.run(["--verbose"]) == {:ok, []}


### PR DESCRIPTION
At the beginning of compilation, initial `:source` records of the files that
needs to be compiled are added to an Agent process. These records are then
updated when the files are compiled and then written to the compile manifest.

The `:size` field in the initial record has a default of 0, and since files
without any code (they only have comments or newlines) are not compiled, this
is never updated with the actual size of the file before the compile manifest
is written to disk.

These files are always seen as stale because their size on disk does not match
the compile manifest.

This is fixed by adding the actual size of the file to the initial record.

Closes #7066