### PR TITLE
Adjust bind_quoted docs for language.

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -872,7 +872,7 @@ defmodule Kernel.SpecialForms do
 
   `:bind_quoted` will translate to the same code as the example above.
   `:bind_quoted` can be used in many cases and is seen as good practice,
-  not only because it prevents us from running into common mistakes, but also
+  not only because it helps prevent us from running into common mistakes, but also
   because it allows us to leverage other tools exposed by macros, such as
   unquote fragments discussed in some sections below.
 

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -872,7 +872,7 @@ defmodule Kernel.SpecialForms do
 
   `:bind_quoted` will translate to the same code as the example above.
   `:bind_quoted` can be used in many cases and is seen as good practice,
-  not only because it helps us from running into common mistakes but also
+  not only because it prevents us from running into common mistakes but also
   because it allows us to leverage other tools exposed by macros, such as
   unquote fragments discussed in some sections below.
 

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -872,7 +872,7 @@ defmodule Kernel.SpecialForms do
 
   `:bind_quoted` will translate to the same code as the example above.
   `:bind_quoted` can be used in many cases and is seen as good practice,
-  not only because it prevents us from running into common mistakes but also
+  not only because it prevents us from running into common mistakes, but also
   because it allows us to leverage other tools exposed by macros, such as
   unquote fragments discussed in some sections below.
 


### PR DESCRIPTION
Uncommon:
https://www.google.com/search?q="helps+us+from+running+into"

Uncommon:
https://www.google.com/search?q="helps+prevent+us+from+running+into"

Common and sounds natural:
https://www.google.com/search?q="prevents+us+from+running+into"