### PR TITLE
Return failure details from ExUnit.run

### DIFF
--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -425,7 +425,13 @@ defmodule ExUnit.DocTestTest do
 
     ExUnit.configure(seed: 0, colors: [enabled: false])
     ExUnit.Server.modules_loaded()
-    output = capture_io(fn -> ExUnit.run() end)
+
+    output =
+      capture_io(fn ->
+        %{failure_details: failure_details} = ExUnit.run()
+        failure_lines = [138, 141, 144, 147, 150, 153, 159, 165, 172, 180, 188]
+        assert ^failure_lines = Enum.sort(Enum.map(failure_details, &elem(&1, 1)))
+      end)
 
     # Test order is not guaranteed, we can't match this as a string for each failing doctest
     assert output =~

--- a/lib/ex_unit/test/ex_unit/register_test.exs
+++ b/lib/ex_unit/test/ex_unit/register_test.exs
@@ -31,7 +31,7 @@ defmodule ExUnit.RegisterTest do
     ExUnit.Server.modules_loaded()
 
     assert capture_io(fn ->
-             assert ExUnit.run() == %{failures: 0, skipped: 0, total: 2}
+             assert %{failures: 0, skipped: 0, total: 2} = ExUnit.run()
            end) =~ "1 property, 1 test, 0 failures"
   end
 
@@ -71,7 +71,7 @@ defmodule ExUnit.RegisterTest do
     ExUnit.Server.modules_loaded()
 
     assert capture_io(fn ->
-             assert ExUnit.run() == %{failures: 0, skipped: 0, total: 4}
+             assert %{failures: 0, skipped: 0, total: 4} = ExUnit.run()
            end) =~ "2 properties, 2 tests, 0 failures"
   end
 end


### PR DESCRIPTION
I'm examining options for adding support for ExUnit tests in ElixirLS. Ideally, it could show diagnostics for build warnings and errors in test files and for test failures themselves.

As a first step, I've attempted to add more detailed failure information to the return values for `ExUnit.run`. `ExUnit.RunnerStats` may not be the best place to do this, and I'm open to other ideas for how to approach it.

Please review. Thanks!