### PR TITLE
Store the last_run_status of each test in a manifest

### DIFF
--- a/lib/ex_unit/lib/ex_unit/manifest.ex
+++ b/lib/ex_unit/lib/ex_unit/manifest.ex
@@ -1,0 +1,109 @@
+defmodule ExUnit.Manifest do
+  @moduledoc false
+
+  import Record
+
+  defrecord :entry, [:last_run_status, :file]
+  @type status :: :passed | :failed
+  @type entry :: record(:entry, last_run_status: status, file: Path.t())
+  @type test_id :: {module, name :: atom}
+  @type t :: %{test_id => entry}
+
+  @manifest_vsn 1
+
+  @spec add_test(t, ExUnit.Test.t()) :: t
+  def add_test(%{} = manifest, %ExUnit.Test{state: {ignored_state, _}})
+      when ignored_state in [:skipped, :excluded],
+      do: manifest
+
+  def add_test(%{} = manifest, %ExUnit.Test{} = test) do
+    status =
+      case test.state do
+        nil -> :passed
+        {:failed, _} -> :failed
+        {:invalid, _} -> :failed
+      end
+
+    entry = entry(last_run_status: status, file: test.tags.file)
+    Map.put(manifest, {test.module, test.name}, entry)
+  end
+
+  @spec write!(t, Path.t()) :: :ok
+  def write!(%{} = manifest, file) when is_binary(file) do
+    binary = :erlang.term_to_binary({@manifest_vsn, manifest})
+    Path.dirname(file) |> File.mkdir_p!()
+    File.write!(file, binary)
+  end
+
+  @spec load_from(Path.t()) :: t
+  def load_from(file) when is_binary(file) do
+    with {:ok, binary} <- File.read(file),
+         {:ok, {@manifest_vsn, manifest}} <- safe_binary_to_term(binary) do
+      manifest
+    else
+      _ -> %{}
+    end
+  end
+
+  defp safe_binary_to_term(binary) do
+    {:ok, :erlang.binary_to_term(binary)}
+  rescue
+    ArgumentError ->
+      :error
+  end
+
+  # Responsible for smartly merging an old and new manifest, using the following rules:
+  #
+  #   1. Entries in the new manifest are accepted as-is.
+  #   2. Entries in the old manifest that are not in the new manifest are kept
+  #      if the identified test either *definitely* exists or *might* exist.
+  #
+  # More specifically, old manifest entries that satisfy either of these
+  # criteria are deleted:
+  #
+  #   1. The file the test came from no longer exists.
+  #   2. The test no longer exists, as indicated by the module no longer
+  #      exporting the test function. Note that we can only check this for
+  #      test modules that have been loaded.
+  @spec merge(t, t) :: t
+  def merge(%{} = old_manifest, %{} = new_manifest) do
+    old_manifest
+    |> Enum.to_list()
+    |> prune_deleted_tests(%{}, [])
+    |> Map.new()
+    |> Map.merge(new_manifest)
+  end
+
+  defp prune_deleted_tests([], _, acc), do: acc
+
+  defp prune_deleted_tests([{{mod, name}, entry} | rest], file_existence, acc) do
+    file_exists = Map.fetch(file_existence, entry(entry, :file))
+
+    cond do
+      file_exists == :error ->
+        # This is the first time we've looked up the existence of the file.
+        # Cache the result and try again.
+        file_existence =
+          Map.put(file_existence, entry(entry, :file), File.regular?(entry(entry, :file)))
+
+        prune_deleted_tests([{{mod, name}, entry} | rest], file_existence, acc)
+
+      file_exists == {:ok, false} ->
+        # The file does not exist, so we should prune the test.
+        prune_deleted_tests(rest, file_existence, acc)
+
+      function_exported?(mod, name, 1) ->
+        # The test still exists, at the same file, so keep it.
+        prune_deleted_tests(rest, file_existence, [{{mod, name}, entry} | acc])
+
+      Code.ensure_loaded?(mod) ->
+        # The test module has been loaded, but the test no longer exists, so prune it.
+        prune_deleted_tests(rest, file_existence, acc)
+
+      true ->
+        # The file exists, but the test module was not loaded. We do not know
+        # if the test still exists, so we err on the side of keeping it.
+        prune_deleted_tests(rest, file_existence, [{{mod, name}, entry} | acc])
+    end
+  end
+end

--- a/lib/ex_unit/lib/ex_unit/runner_stats.ex
+++ b/lib/ex_unit/lib/ex_unit/runner_stats.ex
@@ -2,47 +2,83 @@ defmodule ExUnit.RunnerStats do
   @moduledoc false
 
   use GenServer
-  alias ExUnit.{Test, TestModule}
+  alias ExUnit.{Manifest, Test, TestModule}
 
-  def init(_opts) do
-    {:ok, %{total: 0, failures: 0, skipped: 0, excluded: 0}}
+  @manifest ".ex_unit_results.elixir"
+
+  def init(opts) do
+    manifest_file =
+      case Keyword.fetch(opts, :manifest_path) do
+        :error -> nil
+        {:ok, manifest_path} -> Path.join(manifest_path, @manifest)
+      end
+
+    state = %{
+      total: 0,
+      failures: 0,
+      skipped: 0,
+      excluded: 0,
+      manifest_file: manifest_file,
+      old_manifest: %{},
+      new_manifest: %{}
+    }
+
+    {:ok, state}
   end
 
   def stats(pid) do
     GenServer.call(pid, :stats, :infinity)
   end
 
-  def handle_call(:stats, _from, map) do
-    {:reply, map, map}
+  def handle_call(:stats, _from, state) do
+    stats = Map.take(state, [:total, :failures, :skipped, :excluded])
+    {:reply, stats, state}
   end
 
-  def handle_cast({:test_finished, %Test{state: {tag, _}}}, map)
-      when tag in [:failed, :invalid] do
-    %{total: total, failures: failures} = map
-    {:noreply, %{map | total: total + 1, failures: failures + 1}}
+  def handle_cast({:suite_started, _opts}, %{manifest_file: file} = state) when is_binary(file) do
+    state = %{state | old_manifest: Manifest.load_from(file)}
+    {:noreply, state}
   end
 
-  def handle_cast({:test_finished, %Test{state: {:excluded, _}}}, map) do
-    %{total: total, excluded: excluded} = map
-    {:noreply, %{map | total: total + 1, excluded: excluded + 1}}
+  def handle_cast({:test_finished, %Test{} = test}, state) do
+    state =
+      state
+      |> Map.update!(:new_manifest, &Manifest.add_test(&1, test))
+      |> Map.update!(:total, &(&1 + 1))
+      |> increment_status_counter(test.state)
+
+    {:noreply, state}
   end
 
-  def handle_cast({:test_finished, %Test{state: {:skipped, _}}}, map) do
-    %{total: total, skipped: skipped} = map
-    {:noreply, %{map | total: total + 1, skipped: skipped + 1}}
-  end
-
-  def handle_cast({:test_finished, _}, %{total: total} = map) do
-    {:noreply, %{map | total: total + 1}}
-  end
-
-  def handle_cast({:module_finished, %TestModule{state: {:failed, _}} = test_module}, map) do
-    %{failures: failures, total: total} = map
+  def handle_cast({:module_finished, %TestModule{state: {:failed, _}} = test_module}, state) do
+    %{failures: failures, total: total} = state
     test_count = length(test_module.tests)
-    {:noreply, %{map | failures: failures + test_count, total: total + test_count}}
+    {:noreply, %{state | failures: failures + test_count, total: total + test_count}}
   end
 
-  def handle_cast(_, map) do
-    {:noreply, map}
+  def handle_cast({:suite_finished, _, _}, %{manifest_file: file} = state) when is_binary(file) do
+    state.old_manifest
+    |> Manifest.merge(state.new_manifest)
+    |> Manifest.write!(file)
+
+    {:noreply, state}
   end
+
+  def handle_cast(_, state) do
+    {:noreply, state}
+  end
+
+  defp increment_status_counter(state, {:skipped, _}) do
+    Map.update!(state, :skipped, &(&1 + 1))
+  end
+
+  defp increment_status_counter(state, {:excluded, _}) do
+    Map.update!(state, :excluded, &(&1 + 1))
+  end
+
+  defp increment_status_counter(state, {tag, _}) when tag in [:failed, :invalid] do
+    Map.update!(state, :failures, &(&1 + 1))
+  end
+
+  defp increment_status_counter(state, _), do: state
 end

--- a/lib/ex_unit/test/ex_unit/manifest_test.exs
+++ b/lib/ex_unit/test/ex_unit/manifest_test.exs
@@ -1,0 +1,246 @@
+Code.require_file("../test_helper.exs", __DIR__)
+
+defmodule ExUnit.ManifestTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.Manifest
+  import ExUnit.TestHelpers, only: [tmp_path: 0, in_tmp: 2]
+
+  describe "add_test/2" do
+    test "ignores skipped tests since we know nothing about their pass/fail status" do
+      test = %ExUnit.Test{state: {:skipped, "reason"}}
+
+      assert add_test(%{}, test) == %{}
+    end
+
+    test "ignores excluded tests since we know nothing about their pass/fail status" do
+      test = %ExUnit.Test{state: {:excluded, "reason"}}
+
+      assert add_test(%{}, test) == %{}
+    end
+
+    test "stores passed tests, keyed by module and name" do
+      test = %ExUnit.Test{
+        state: nil,
+        module: SomeMod,
+        name: :t1,
+        tags: %{file: "file"}
+      }
+
+      assert add_test(%{}, test) == %{
+               {SomeMod, :t1} =>
+                 entry(
+                   last_run_status: :passed,
+                   file: "file"
+                 )
+             }
+    end
+
+    test "stores failed tests, keyed by module and name" do
+      test = %ExUnit.Test{
+        state: {:failed, []},
+        module: SomeMod,
+        name: :t1,
+        tags: %{file: "file"}
+      }
+
+      assert add_test(%{}, test) == %{
+               {SomeMod, :t1} =>
+                 entry(
+                   last_run_status: :failed,
+                   file: "file"
+                 )
+             }
+    end
+
+    test "stores invalid tests as failed, keyed by module and name" do
+      test = %ExUnit.Test{
+        state: {:invalid, SomeMod},
+        module: SomeMod,
+        name: :t1,
+        tags: %{file: "file"}
+      }
+
+      assert add_test(%{}, test) == %{
+               {SomeMod, :t1} =>
+                 entry(
+                   last_run_status: :failed,
+                   file: "file"
+                 )
+             }
+    end
+  end
+
+  @manifest_path "example.manifest"
+
+  describe "write!/2 and load_from/1" do
+    test "can roundtrip a manifest", context do
+      manifest = non_blank_manifest()
+
+      in_tmp context.test, fn ->
+        assert write!(manifest, @manifest_path) == :ok
+        assert load_from(@manifest_path) == manifest
+      end
+    end
+
+    test "returns a blank manifest when loading a file that does not exit" do
+      path = tmp_path() <> "missing.manifest"
+      refute File.exists?(path)
+      assert load_from(path) == %{}
+    end
+
+    test "returns a blank manifest when the file cannot be read", context do
+      manifest = non_blank_manifest()
+
+      in_tmp context.test, fn ->
+        assert write!(manifest, @manifest_path) == :ok
+
+        stat = File.stat!(@manifest_path)
+        stat = %{stat | mode: 0}
+        File.write_stat!(@manifest_path, stat)
+
+        assert load_from(@manifest_path) == %{}
+      end
+    end
+
+    test "returns a blank manifest when the file is corrupted", context do
+      manifest = non_blank_manifest()
+
+      in_tmp context.test, fn ->
+        assert write!(manifest, @manifest_path) == :ok
+        corrupted = "corrupted" <> File.read!(@manifest_path)
+        File.write!(@manifest_path, corrupted)
+
+        assert load_from(@manifest_path) == %{}
+      end
+    end
+
+    test "returns a blank manifest when the file was saved at a prior version", context do
+      manifest = non_blank_manifest()
+
+      in_tmp context.test, fn ->
+        assert write!(manifest, @manifest_path) == :ok
+        assert {vsn, ^manifest} = @manifest_path |> File.read!() |> :erlang.binary_to_term()
+        File.write!(@manifest_path, :erlang.term_to_binary({vsn + 1, manifest}))
+
+        assert load_from(@manifest_path) == %{}
+      end
+    end
+  end
+
+  defp non_blank_manifest do
+    test = %ExUnit.Test{
+      state: nil,
+      module: SomeMod,
+      name: :t1,
+      tags: %{file: "file"}
+    }
+
+    add_test(%{}, test)
+  end
+
+  describe "merge/2" do
+    @existing_file_1 __ENV__.file
+    @existing_file_2 Path.join(__DIR__, "../test_helper.exs")
+    @missing_file "missing_file_test.exs"
+
+    defmodule TestMod1 do
+      def test_1(_), do: :ok
+      def test_2(_), do: :ok
+    end
+
+    defmodule TestMod2 do
+      def test_1(_), do: :ok
+      def test_2(_), do: :ok
+    end
+
+    test "returns the new manifest when the old manifest is blank" do
+      new_manifest = %{{TestMod1, :test_1} => entry()}
+
+      assert ExUnit.Manifest.merge(%{}, new_manifest) == new_manifest
+    end
+
+    test "replaces old entries with their updated status" do
+      old_manifest = %{
+        {TestMod1, :test_1} => entry(last_run_status: :failed, file: @existing_file_1),
+        {TestMod1, :test_2} => entry(last_run_status: :passed, file: @existing_file_1)
+      }
+
+      new_manifest = %{
+        {TestMod1, :test_1} => entry(last_run_status: :passed, file: @existing_file_1),
+        {TestMod1, :test_2} => entry(last_run_status: :failed, file: @existing_file_1)
+      }
+
+      assert ExUnit.Manifest.merge(old_manifest, new_manifest) == new_manifest
+    end
+
+    test "keeps old entries for test modules in existing files that were not part of this run" do
+      old_manifest = %{
+        {UnknownMod1, :test_1} => entry(last_run_status: :failed, file: @existing_file_1),
+        {UnknownMod1, :test_2} => entry(last_run_status: :passed, file: @existing_file_1)
+      }
+
+      new_manifest = %{
+        {TestMod2, :test_1} => entry(last_run_status: :passed, file: @existing_file_2),
+        {TestMod2, :test_2} => entry(last_run_status: :failed, file: @existing_file_2)
+      }
+
+      assert ExUnit.Manifest.merge(old_manifest, new_manifest) == %{
+               {UnknownMod1, :test_1} => entry(last_run_status: :failed, file: @existing_file_1),
+               {UnknownMod1, :test_2} => entry(last_run_status: :passed, file: @existing_file_1),
+               {TestMod2, :test_1} => entry(last_run_status: :passed, file: @existing_file_2),
+               {TestMod2, :test_2} => entry(last_run_status: :failed, file: @existing_file_2)
+             }
+    end
+
+    test "keeps old entries for tests that were loaded but skipped as part of this run" do
+      old_manifest = %{
+        {TestMod1, :test_1} => entry(last_run_status: :failed, file: @existing_file_1),
+        {TestMod1, :test_2} => entry(last_run_status: :passed, file: @existing_file_1)
+      }
+
+      new_manifest = %{
+        {TestMod1, :test_1} => entry(last_run_status: :passed, file: @existing_file_1)
+      }
+
+      assert ExUnit.Manifest.merge(old_manifest, new_manifest) == %{
+               {TestMod1, :test_1} => entry(last_run_status: :passed, file: @existing_file_1),
+               {TestMod1, :test_2} => entry(last_run_status: :passed, file: @existing_file_1)
+             }
+    end
+
+    test "drops old entries from test files that no longer exist" do
+      old_manifest = %{
+        {TestMod2, :test_1} => entry(last_run_status: :failed, file: @missing_file),
+        {TestMod2, :test_2} => entry(last_run_status: :passed, file: @missing_file)
+      }
+
+      new_manifest = %{
+        {TestMod1, :test_1} => entry(last_run_status: :passed, file: @existing_file_1),
+        {TestMod1, :test_2} => entry(last_run_status: :failed, file: @existing_file_1)
+      }
+
+      assert ExUnit.Manifest.merge(old_manifest, new_manifest) == %{
+               {TestMod1, :test_1} => entry(last_run_status: :passed, file: @existing_file_1),
+               {TestMod1, :test_2} => entry(last_run_status: :failed, file: @existing_file_1)
+             }
+    end
+
+    test "drops old entries for deleted tests from loaded modules" do
+      old_manifest = %{
+        {TestMod2, :missing_1} => entry(last_run_status: :failed, file: @existing_file_1),
+        {TestMod2, :missing_2} => entry(last_run_status: :passed, file: @existing_file_2)
+      }
+
+      new_manifest = %{
+        {TestMod1, :test_1} => entry(last_run_status: :passed, file: @existing_file_1),
+        {TestMod1, :test_2} => entry(last_run_status: :failed, file: @existing_file_1)
+      }
+
+      assert ExUnit.Manifest.merge(old_manifest, new_manifest) == %{
+               {TestMod1, :test_1} => entry(last_run_status: :passed, file: @existing_file_1),
+               {TestMod1, :test_2} => entry(last_run_status: :failed, file: @existing_file_1)
+             }
+    end
+  end
+end

--- a/lib/ex_unit/test/ex_unit/runner_stats_test.exs
+++ b/lib/ex_unit/test/ex_unit/runner_stats_test.exs
@@ -1,0 +1,106 @@
+Code.require_file("../test_helper.exs", __DIR__)
+
+defmodule ExUnit.RunnerStatsTest do
+  use ExUnit.Case, async: false
+
+  alias ExUnit.{Manifest, RunnerStats}
+  import Manifest, only: [entry: 1]
+  import ExUnit.TestHelpers, only: [in_tmp: 2]
+
+  @manifest_path "manifests"
+  @manifest_file "#{@manifest_path}/.ex_unit_results.elixir"
+
+  describe "stats tracking" do
+    test "counts total, failures, skipped, and excluded tests" do
+      stats =
+        simulate_suite([], fn formatter ->
+          simulate_test(formatter, :test_1, :passed)
+          simulate_test(formatter, :test_2, :skipped)
+          simulate_test(formatter, :test_3, :failed)
+          simulate_test(formatter, :test_4, :invalid)
+          simulate_test(formatter, :test_5, :passed)
+          simulate_test(formatter, :test_6, :passed)
+          simulate_test(formatter, :test_7, :excluded)
+          simulate_test(formatter, :test_8, :excluded)
+          simulate_test(formatter, :test_9, :excluded)
+          simulate_test(formatter, :test_10, :excluded)
+        end)
+
+      assert stats == %{total: 10, failures: 2, skipped: 1, excluded: 4}
+    end
+  end
+
+  describe "when no manifest path option is provided" do
+    test "does not write a manifest", context do
+      in_tmp(context.test, fn ->
+        simulate_suite([], fn formatter ->
+          simulate_test(formatter, :test_1, :passed)
+          simulate_test(formatter, :test_2, :failed)
+        end)
+
+        assert File.ls(".") == {:ok, []}
+      end)
+    end
+  end
+
+  describe "when a manifest path option is provided" do
+    test "records the test results in the manifest file", context do
+      in_tmp(context.test, fn ->
+        simulate_suite(fn formatter ->
+          simulate_test(formatter, :test_1, :passed)
+          simulate_test(formatter, :test_2, :failed)
+        end)
+
+        assert load_manifest() == %{
+                 {TestModule, :test_1} => entry(file: __ENV__.file, last_run_status: :passed),
+                 {TestModule, :test_2} => entry(file: __ENV__.file, last_run_status: :failed)
+               }
+      end)
+    end
+
+    test "merges the results with the results from the prior run", context do
+      in_tmp(context.test, fn ->
+        simulate_suite(&simulate_test(&1, :test_1, :passed))
+        simulate_suite(&simulate_test(&1, :test_2, :failed))
+
+        assert load_manifest() == %{
+                 {TestModule, :test_1} => entry(file: __ENV__.file, last_run_status: :passed),
+                 {TestModule, :test_2} => entry(file: __ENV__.file, last_run_status: :failed)
+               }
+      end)
+    end
+  end
+
+  defp simulate_suite(opts \\ [manifest_path: @manifest_path], fun) do
+    {:ok, pid} = GenServer.start_link(RunnerStats, opts)
+    GenServer.cast(pid, {:suite_started, opts})
+
+    fun.(pid)
+
+    GenServer.cast(pid, {:suite_finished, 0, 0})
+    RunnerStats.stats(pid)
+  end
+
+  defp simulate_test(formatter, test_name, status) do
+    GenServer.cast(
+      formatter,
+      {:test_finished,
+       %ExUnit.Test{
+         module: TestModule,
+         name: test_name,
+         tags: %{file: __ENV__.file},
+         state: state_for(status)
+       }}
+    )
+  end
+
+  defp state_for(:passed), do: nil
+  defp state_for(:failed), do: {:failed, []}
+  defp state_for(:invalid), do: {:invalid, TestModule}
+  defp state_for(:skipped), do: {:skipped, "reason"}
+  defp state_for(:excluded), do: {:excluded, "reason"}
+
+  defp load_manifest do
+    Manifest.load_from(@manifest_file)
+  end
+end

--- a/lib/ex_unit/test/test_helper.exs
+++ b/lib/ex_unit/test/test_helper.exs
@@ -13,4 +13,19 @@ defmodule ExUnit.TestHelpers do
     File.write!(beam_path, bin)
     res
   end
+
+  def in_tmp(which, function) do
+    path = tmp_path(which)
+    File.rm_rf!(path)
+    File.mkdir_p!(path)
+    File.cd!(path, function)
+  end
+
+  def tmp_path do
+    Path.expand("../tmp", __DIR__)
+  end
+
+  def tmp_path(extension) do
+    Path.join(tmp_path(), to_string(extension))
+  end
 end

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -312,7 +312,8 @@ defmodule Mix.Tasks.Test do
     :timeout,
     :formatters,
     :colors,
-    :slowest
+    :slowest,
+    :manifest_path
   ]
 
   @doc false
@@ -322,6 +323,7 @@ defmodule Mix.Tasks.Test do
     |> filter_opts(:exclude)
     |> filter_opts(:only)
     |> formatter_opts()
+    |> manifest_opts()
     |> color_opts()
     |> Keyword.take(@option_keys)
     |> default_opts()
@@ -388,6 +390,10 @@ defmodule Mix.Tasks.Test do
     else
       opts
     end
+  end
+
+  defp manifest_opts(opts) do
+    Keyword.put(opts, :manifest_path, Mix.Project.manifest_path())
   end
 
   defp color_opts(opts) do

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -6,31 +6,41 @@ defmodule Mix.Tasks.TestTest do
   import Mix.Tasks.Test, only: [ex_unit_opts: 1]
 
   test "ex_unit_opts/1 returns ex unit options" do
-    assert ex_unit_opts(unknown: "ok", seed: 13) == [autorun: false, seed: 13]
+    assert ex_unit_opts_from_given(unknown: "ok", seed: 13) == [seed: 13]
   end
 
   test "ex_unit_opts/1 returns includes and excludes" do
-    included = [autorun: false, include: [:focus, key: "val"]]
-    assert ex_unit_opts(include: "focus", include: "key:val") == included
+    included = [include: [:focus, key: "val"]]
+    assert ex_unit_opts_from_given(include: "focus", include: "key:val") == included
 
-    excluded = [autorun: false, exclude: [:focus, key: "val"]]
-    assert ex_unit_opts(exclude: "focus", exclude: "key:val") == excluded
+    excluded = [exclude: [:focus, key: "val"]]
+    assert ex_unit_opts_from_given(exclude: "focus", exclude: "key:val") == excluded
   end
 
   test "ex_unit_opts/1 translates :only into includes and excludes" do
-    assert ex_unit_opts(only: "focus") == [autorun: false, include: [:focus], exclude: [:test]]
+    assert ex_unit_opts_from_given(only: "focus") == [include: [:focus], exclude: [:test]]
 
-    only = [autorun: false, include: [:focus, :special], exclude: [:test]]
-    assert ex_unit_opts(only: "focus", include: "special") == only
+    only = [include: [:focus, :special], exclude: [:test]]
+    assert ex_unit_opts_from_given(only: "focus", include: "special") == only
   end
 
   test "ex_unit_opts/1 translates :color into list containing an enabled key/value pair" do
-    assert ex_unit_opts(color: false) == [autorun: false, colors: [enabled: false]]
-    assert ex_unit_opts(color: true) == [autorun: false, colors: [enabled: true]]
+    assert ex_unit_opts_from_given(color: false) == [colors: [enabled: false]]
+    assert ex_unit_opts_from_given(color: true) == [colors: [enabled: true]]
   end
 
   test "ex_unit_opts/1 translates :formatter into list of modules" do
-    assert ex_unit_opts(formatter: "A.B") == [autorun: false, formatters: [A.B]]
+    assert ex_unit_opts_from_given(formatter: "A.B") == [formatters: [A.B]]
+  end
+
+  test "ex_unit_opts/1 includes some default options" do
+    assert ex_unit_opts([]) == [autorun: false, manifest_path: Mix.Project.manifest_path()]
+  end
+
+  defp ex_unit_opts_from_given(passed) do
+    passed
+    |> Mix.Tasks.Test.ex_unit_opts()
+    |> Keyword.drop([:manifest_path, :autorun])
   end
 
   test "--stale: runs all tests for first run, then none on second" do


### PR DESCRIPTION
This will support filtering tests to just ones that failed the last time they ran.

Background to this is in the [elixir-lang-core discussion](https://groups.google.com/forum/#!topic/elixir-lang-core/_jbuzf4UvA4).