### PR TITLE
show UTF-8 BOM on inspected strings

### DIFF
--- a/lib/elixir/lib/code/identifier.ex
+++ b/lib/elixir/lib/code/identifier.ex
@@ -235,6 +235,8 @@ defmodule Code.Identifier do
 
   defp escape_char(0), do: '\\0'
 
+  defp escape_char(65279), do: '\\uFEFF'
+
   defp escape_char(char)
        when char in 0x20..0x7E
        when char in 0xA0..0xD7FF

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -175,6 +175,10 @@ defmodule Inspect.BitStringTest do
     # non printable strings aren't affected by printable limit
     assert inspect(<<0, 1, 2, 3, 4>>, printable_limit: 3) == ~s(<<0, 1, 2, 3, 4>>)
   end
+
+  test "utf-8 BOM" do
+    assert inspect("\uFEFFhello world") == "\"\\uFEFFhello world\""
+  end
 end
 
 defmodule Inspect.NumberTest do


### PR DESCRIPTION
As per #7084, this PR adds the printing of the UTF-8 BOM on inspected strings. I think this is the right behavior, but if anything needs being revisited I'm happy to talk about it.

Closes #7084 