### PR TITLE
Fix the documentation for Dynamic Supervisor

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -20,16 +20,16 @@ defmodule DynamicSupervisor do
   Once the dynamic supervisor is running, we can start children
   with `start_child/2`, which receives a child specification:
 
-      {:ok, agent1} = DynamicSupervisor.start_link(sup, {Agent, fn -> %{} end})
+      {:ok, agent1} = DynamicSupervisor.start_child(sup, {Agent, fn -> %{} end})
       Agent.update(agent1, &Map.put(&1, :key, "value"))
       Agent.get(agent1, & &1)
       #=> %{key: "value"}
 
-      {:ok, agent2} = DynamicSupervisor.start_link(sup, {Agent, fn -> %{} end})
+      {:ok, agent2} = DynamicSupervisor.start_child(sup, {Agent, fn -> %{} end})
       Agent.get(agent2, & &1)
       #=> %{}
 
-      DynamicSupervisor.count_children(sup_pid)
+      DynamicSupervisor.count_children(sup)
       #=> %{active: 2, specs: 2, supervisors: 0, workers: 2}
 
   ## Module-based supervisors


### PR DESCRIPTION
Hi Elixir Team.
I found mistake on the document for dynamic supervisor.
I think it will be correct that uses function `DynamicSupervisor.start_child/2` instead of `DynamicSupervisor.start_link/2`.
And an argument of `count_children` should be `sup` instead of `sup_pid`.

Thanks!