### PR TITLE
Store lock from SCM on Dep

### DIFF
--- a/lib/mix/lib/mix/dep/fetcher.ex
+++ b/lib/mix/lib/mix/dep/fetcher.ex
@@ -65,6 +65,7 @@ defmodule Mix.Dep.Fetcher do
           end
 
         if new do
+          dep = put_in(dep.opts[:lock], new)
           {dep, [app | acc], Map.put(lock, app, new)}
         else
           {dep, acc, lock}


### PR DESCRIPTION
Hex's SCM.checkout returns package build tools in the lock, store this
information on the Dep struct so that the loader can pass this
information to SCM.managers/1.

Fixes hexpm/hex#468.