### PR TITLE
State argument on Node should be documented.

### DIFF
--- a/lib/elixir/lib/node.ex
+++ b/lib/elixir/lib/node.ex
@@ -73,7 +73,7 @@ defmodule Node do
 
   For more information, see `:erlang.nodes/1`.
   """
-  @typep state :: :visible | :hidden | :connected | :this | :known
+  @type state :: :visible | :hidden | :connected | :this | :known
   @spec list(state | [state]) :: [t]
   def list(args) do
     :erlang.nodes(args)


### PR DESCRIPTION
My guess is they are private because they rely on Erlang code/docs?