### PR TITLE
Add System.cmd!/3

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -637,6 +637,26 @@ defmodule System do
     end
   end
 
+  @doc """
+  Similar to `System.cmd/3` but raises an error on non-zero exit status.
+
+  ## Examples
+
+      iex> System.cmd! "echo", ["hello"]
+      "hello\n"
+
+  """
+  @spec cmd!(binary, [binary], keyword) :: Collectable.t()
+  def cmd!(command, args, opts \\ []) when is_binary(command) and is_list(args) do
+    case cmd(command, args, opts) do
+      {result, 0} ->
+        result
+
+      {result, status} ->
+        raise "command exited with status #{inspect(status)}\n\n    Result: #{inspect(result)}"
+    end
+  end
+
   defp do_cmd(port, acc, fun) do
     receive do
       {^port, {:data, data}} ->

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -652,6 +652,17 @@ defmodule System do
       {result, 0} ->
         result
 
+      {"", status} ->
+        raise "command exited with status #{inspect(status)}"
+
+      {result, status} when is_binary(result) ->
+        result =
+          result
+          |> String.split("\n")
+          |> Enum.map_join("\n", &"        " <> &1)
+
+        raise "command exited with status #{inspect(status)}\n\n    Result:\n#{result}"
+
       {result, status} ->
         raise "command exited with status #{inspect(status)}\n\n    Result: #{inspect(result)}"
     end

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -659,7 +659,7 @@ defmodule System do
         result =
           result
           |> String.split("\n")
-          |> Enum.map_join("\n", &"        " <> &1)
+          |> Enum.map_join("\n", &("        " <> &1))
 
         raise "command exited with status #{inspect(status)}\n\n    Result:\n#{result}"
 


### PR DESCRIPTION
This is just a small convenience so that e.g. in IEx we don't have to "unpack" result with `|> elem(0)` when we expect the command to always succeed.

Examples:

Success:

```
iex> System.cmd!("elixir", ["--version"])
"Erlang/OTP 20 [erts-9.1.5] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe] [kernel-poll:false]\n\nElixir 1.6.0-dev (b209e3c79) (compiled with OTP 20)\n"
```

Failure:

```
iex> System.cmd!("elixir", ["--invalid"])
--invalid : Unknown option
                          ** (RuntimeError) command exited with status 1
    (elixir) lib/system.ex:656: System.cmd!/3
```

Failure with `stderr_to_stdout: true` - much better output. Maybe this should be default for `cmd!/3`?

```
iex> System.cmd!("elixir", ["--invalid"], stderr_to_stdout: true)
** (RuntimeError) command exited with status 1

    Result:
        --invalid : Unknown option

    (elixir) lib/system.ex:664: System.cmd!/3
```

Failure with `stderr_to_stdout: true` and `into: []`:

```
iex> System.cmd!("elixir", ["--invalid"], stderr_to_stdout: true, into: [])
** (RuntimeError) command exited with status 1

    Result: ["--invalid : Unknown option\n"]
    (elixir) lib/system.ex:667: System.cmd!/3
```

Edit: updated per bea2942d3