### PR TITLE
Do not indent right-side of pipelines in the formatter

### DIFF
--- a/lib/elixir/lib/base.ex
+++ b/lib/elixir/lib/base.ex
@@ -187,12 +187,12 @@ defmodule Base do
     alphabet
     |> Stream.with_index()
     |> Enum.flat_map(fn {encoding, value} = pair ->
-         if encoding in ?A..?Z do
-           [pair, {encoding - ?A + ?a, value}]
-         else
-           [pair]
-         end
-       end)
+      if encoding in ?A..?Z do
+        [pair, {encoding - ?A + ?a, value}]
+      else
+        [pair]
+      end
+    end)
     |> decode_clauses()
   end
 

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -699,10 +699,7 @@ defmodule Code.Formatter do
           # we cannot group the left side yet.
           left = if op_info == parent_info, do: left, else: group(left)
 
-          # The right side is never the same operator, so we can group and nest
-          right = group(nest_by_length(right, op_string))
-
-          doc = glue(left, concat(op_string, right))
+          doc = glue(left, concat(op_string, group(right)))
           if Keyword.get(meta, :eol, false), do: force_unfit(doc), else: doc
 
         op in @right_new_line_before_binary_operators ->

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2763,13 +2763,13 @@ defmodule Enum do
 
     enumerable
     |> reduce(ref, fn
-         element, ^ref -> element
-         element, acc -> fun.(element, acc)
-       end)
+      element, ^ref -> element
+      element, acc -> fun.(element, acc)
+    end)
     |> case do
-         ^ref -> empty.()
-         result -> result
-       end
+      ^ref -> empty.()
+      result -> result
+    end
   end
 
   defp reduce_by([head | tail], first, fun) do

--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -251,13 +251,13 @@ defmodule Kernel.ParallelCompiler do
     |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
     |> Enum.sort_by(&length(elem(&1, 1)))
     |> case do
-         [{_on, refs} | _] ->
-           spawn_workers(refs, waiting, queued, result, warnings, state)
+      [{_on, refs} | _] ->
+        spawn_workers(refs, waiting, queued, result, warnings, state)
 
-         [] ->
-           errors = handle_deadlock(waiting, queued)
-           {:error, errors, warnings}
-       end
+      [] ->
+        errors = handle_deadlock(waiting, queued)
+        {:error, errors, warnings}
+    end
   end
 
   # No more files, but queue and waiting are not full or do not match

--- a/lib/elixir/test/elixir/code_formatter/operators_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/operators_test.exs
@@ -152,9 +152,9 @@ defmodule Code.Formatter.OperatorsTest do
       good = """
       123
       |> foo(
-           bar,
-           baz
-         )
+        bar,
+        baz
+      )
       """
 
       assert_format bad, good, @short_length
@@ -164,11 +164,11 @@ defmodule Code.Formatter.OperatorsTest do
       good = """
       123
       |> foo(
-           bar
-         )
+        bar
+      )
       |> bar(
-           bat
-         )
+        bat
+      )
       """
 
       assert_format bad, good, @short_length
@@ -180,8 +180,8 @@ defmodule Code.Formatter.OperatorsTest do
         bar,
         123
         |> bar(
-             baz
-           )
+          baz
+        )
       )
       """
 
@@ -217,9 +217,9 @@ defmodule Code.Formatter.OperatorsTest do
       good = """
       123
       |> foo(
-           bar,
-           baz
-         )
+        bar,
+        baz
+      )
       |> 456
       """
 

--- a/lib/elixir/test/elixir/kernel/quote_test.exs
+++ b/lib/elixir/test/elixir/kernel/quote_test.exs
@@ -226,7 +226,7 @@ defmodule Kernel.QuoteTest do
              (quote do
                 foo
                 |> bar do
-                   end
+                end
                 |> baz
               end)
 
@@ -235,7 +235,7 @@ defmodule Kernel.QuoteTest do
                 foo
                 |> bar
                 |> baz do
-                   end
+                end
               end)
 
     assert {:|>, _, [{:|>, _, [{:foo, _, _}, {:bar, _, _}]}, {:baz, _, _}]} =
@@ -244,7 +244,7 @@ defmodule Kernel.QuoteTest do
                 end
                 |> bar
                 |> baz do
-                   end
+                end
               end)
 
     assert {:|>, _, [{:|>, _, [{:foo, _, _}, {:bar, _, _}]}, {:baz, _, _}]} =
@@ -252,9 +252,9 @@ defmodule Kernel.QuoteTest do
                 foo do
                 end
                 |> bar do
-                   end
+                end
                 |> baz do
-                   end
+                end
               end)
   end
 end

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -385,8 +385,8 @@ defmodule StreamTest do
     # flat_map returns a lazy enumeration that does halts wrapped in an enumerable
     assert [1, 2, 3, -1, -2]
            |> Stream.flat_map(fn x ->
-                Stream.concat([x], Stream.take_while([x + 1, x + 2], &(&1 <= x + 1)))
-              end)
+             Stream.concat([x], Stream.take_while([x + 1, x + 2], &(&1 <= x + 1)))
+           end)
            |> Stream.take_while(fn x -> x >= 0 end)
            |> Enum.to_list() == [1, 2, 2, 3, 3, 4]
   end

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -661,8 +661,8 @@ defmodule TaskTest do
           1..4
           |> Task.async_stream(&sleep/1, @opts)
           |> Stream.transform(fn -> :ok end, fn x, acc -> {[x], acc} end, fn _ ->
-               Process.put(:stream_transform, true)
-             end)
+            Process.put(:stream_transform, true)
+          end)
 
         Process.put(:stream_transform, false)
         assert Enum.to_list(stream) == [ok: 1, ok: 2, ok: 3, ok: 4]
@@ -673,8 +673,8 @@ defmodule TaskTest do
         stream =
           1..4
           |> Stream.transform(fn -> :ok end, fn x, acc -> {[x], acc} end, fn _ ->
-               Process.put(:stream_transform, true)
-             end)
+            Process.put(:stream_transform, true)
+          end)
           |> Task.async_stream(&sleep/1, @opts)
 
         Process.put(:stream_transform, false)

--- a/lib/elixir/unicode/graphemes_test.exs
+++ b/lib/elixir/unicode/graphemes_test.exs
@@ -11,35 +11,35 @@ defmodule GraphemesTest do
     |> Stream.filter(&match?("÷" <> _, &1))
     |> Stream.reject(&(&1 =~ "D800"))
     |> Enum.reduce(0, fn line, acc ->
-         [string | _] = String.split(line, "#", parts: 2)
-         {string, graphemes} = parse_grapheme_break(string)
+      [string | _] = String.split(line, "#", parts: 2)
+      {string, graphemes} = parse_grapheme_break(string)
 
-         if String.graphemes(string) == graphemes do
-           acc
-         else
-           acc = acc + 1
+      if String.graphemes(string) == graphemes do
+        acc
+      else
+        acc = acc + 1
 
-           IO.puts("""
-           ============== Failure ##{acc} ==============
+        IO.puts("""
+        ============== Failure ##{acc} ==============
 
-               String.graphemes(#{inspect(string)})
+            String.graphemes(#{inspect(string)})
 
-           must be:
+        must be:
 
-               #{inspect(graphemes)}
+            #{inspect(graphemes)}
 
-           got:
+        got:
 
-               #{inspect(String.graphemes(string))}
+            #{inspect(String.graphemes(string))}
 
-           On line:
+        On line:
 
-               #{line}
-           """)
+            #{line}
+        """)
 
-           acc
-         end
-       end)
+        acc
+      end
+    end)
   end
 
   defp parse_grapheme_break(string) do

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -466,14 +466,14 @@ defmodule ExUnit.Case do
       |> normalize_tags
       |> validate_tags
       |> Map.merge(%{
-           line: line,
-           file: file,
-           registered: registered,
-           async: async,
-           describe: describe,
-           describe_line: describe_line,
-           type: type
-         })
+        line: line,
+        file: file,
+        registered: registered,
+        async: async,
+        describe: describe,
+        describe_line: describe_line,
+        type: type
+      })
 
     test = %ExUnit.Test{name: name, case: mod, tags: tags, module: mod}
     Module.put_attribute(mod, :ex_unit_tests, test)

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -225,8 +225,8 @@ defmodule ExUnit.DocTest do
     |> filter_by_opts(opts)
     |> Stream.with_index()
     |> Enum.map(fn {test, acc} ->
-         compile_test(test, module, do_import, acc + 1)
-       end)
+      compile_test(test, module, do_import, acc + 1)
+    end)
   end
 
   defp filter_by_opts(tests, opts) do

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -501,13 +501,13 @@ defmodule IEx.Introspection do
           docs
           |> Enum.filter(filter)
           |> Enum.map(fn
-               {{fun, arity}, _, :macrocallback, doc} ->
-                 macro = {:"MACRO-#{fun}", arity + 1}
-                 {format_callback(:macrocallback, fun, macro, callbacks), doc}
+            {{fun, arity}, _, :macrocallback, doc} ->
+              macro = {:"MACRO-#{fun}", arity + 1}
+              {format_callback(:macrocallback, fun, macro, callbacks), doc}
 
-               {{fun, arity}, _, kind, doc} ->
-                 {format_callback(kind, fun, {fun, arity}, callbacks), doc}
-             end)
+            {{fun, arity}, _, kind, doc} ->
+              {format_callback(kind, fun, {fun, arity}, callbacks), doc}
+          end)
 
         {:ok, docs}
     end

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -645,10 +645,10 @@ defmodule Mix.Tasks.Xref do
     incoming =
       references
       |> Enum.reduce(%{}, fn {_, deps}, acc ->
-           Enum.reduce(deps, acc, fn {file, _}, acc ->
-             Map.update(acc, file, 1, &(&1 + 1))
-           end)
-         end)
+        Enum.reduce(deps, acc, fn {file, _}, acc ->
+          Map.update(acc, file, 1, &(&1 + 1))
+        end)
+      end)
       |> Enum.map(fn {file, count} -> {count, file} end)
       |> Enum.sort()
       |> Enum.take(-10)


### PR DESCRIPTION
Closes #7102

Please use the :+1: and :-1: reaction accordingly.