### PR TITLE
Fix documentation for `Mix.Generator.create_file/3`

### DIFF
--- a/lib/mix/lib/mix/generator.ex
+++ b/lib/mix/lib/mix/generator.ex
@@ -6,7 +6,7 @@ defmodule Mix.Generator do
   the action to be performed via `Mix.shell/0`.
   """
 
-  @doc """
+  @doc ~S"""
   Creates a file with the given contents.
   If the file already exists, asks for user confirmation.
 


### PR DESCRIPTION
![screen shot 2017-12-13 at 14 50 35](https://user-images.githubusercontent.com/274656/33923536-14bbfa9c-e015-11e7-96d1-3270a4ca0a20.png)

Disallow unnecessary escape

![screen shot 2017-12-13 at 14 53 25](https://user-images.githubusercontent.com/274656/33923664-c4b754dc-e015-11e7-916c-32432cc0bec9.png)
