### PR TITLE
Introduce @deprecated

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -108,11 +108,11 @@ defmodule Module do
 
   Provides the deprecation reason for a function. For example:
 
-      defmodule MyModule do
-        @deprecated "Use MyModule.hello_world/0 instead"
-        def hello, do: "world"
-
-        def hello_world, do: "Hello world!"
+      defmodule Keyword do
+        @deprecated "Use Kernel.length/1 instead"
+        def size(keyword) do
+          length(keyword)
+        end
       end
 
   ### `@doc` (and `@since`)

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -309,7 +309,7 @@ defmodule Protocol do
   end
 
   defp beam_protocol(protocol) do
-    chunk_ids = [:abstract_code, :attributes, :compile_info, 'ExDc', 'ExDp']
+    chunk_ids = [:abstract_code, :attributes, :compile_info, 'ExDc']
     opts = [:allow_missing_chunks]
 
     case :beam_lib.chunks(beam_file(protocol), chunk_ids, opts) do
@@ -318,13 +318,12 @@ defmodule Protocol do
           {:abstract_code, {_raw, abstract_code}},
           {:attributes, attributes},
           {:compile_info, compile_info},
-          {'ExDc', docs},
-          {'ExDp', deprecated}
+          {'ExDc', docs}
         ] = entries
 
         case attributes[:protocol] do
           [fallback_to_any: any] ->
-            {:ok, {protocol, any, abstract_code}, {compile_info, docs, deprecated}}
+            {:ok, {protocol, any, abstract_code}, {compile_info, docs}}
 
           _ ->
             {:error, :not_a_protocol}
@@ -498,14 +497,14 @@ defmodule Protocol do
   end
 
   # Finally compile the module and emit its bytecode.
-  defp compile(protocol, code, {compile_info, docs, deprecated}) do
+  defp compile(protocol, code, {compile_info, docs}) do
     opts = Keyword.take(compile_info, [:source])
     opts = if Code.compiler_options()[:debug_info], do: [:debug_info | opts], else: opts
     {:ok, ^protocol, binary, _warnings} = :compile.forms(code, [:return | opts])
 
     case docs do
       :missing_chunk -> {:ok, binary}
-      _ -> {:ok, :elixir_erl.add_beam_chunks(binary, [{"ExDc", docs}, {"ExDp", deprecated}])}
+      _ -> {:ok, :elixir_erl.add_beam_chunks(binary, [{"ExDc", docs}])}
     end
   end
 

--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -21,11 +21,13 @@ debug_info(elixir_v1, _Module, none, _Opts) ->
   {error, missing};
 debug_info(elixir_v1, _Module, {elixir_v1, Map, _Specs}, _Opts) ->
   {ok, Map};
-debug_info(erlang_v1, _Module, {elixir_v1, Map, Specs}, _Opts) ->
-  {Prefix, Forms, _, _} = dynamic_form(Map),
+debug_info(erlang_v1, Module, {elixir_v1, Map, Specs}, _Opts) ->
+  Data = elixir_module:data_table(Module),
+  {Prefix, Forms, _, _} = dynamic_form(Map, Data),
   {ok, Prefix ++ Specs ++ Forms};
-debug_info(core_v1, _Module, {elixir_v1, Map, Specs}, Opts) ->
-  {Prefix, Forms, _, _} = dynamic_form(Map),
+debug_info(core_v1, Module, {elixir_v1, Map, Specs}, Opts) ->
+  Data = elixir_module:data_table(Module),
+  {Prefix, Forms, _, _} = dynamic_form(Map, Data),
   #{compile_opts := CompileOpts} = Map,
 
   %% Do not rely on elixir_erl_compiler because we don't
@@ -149,7 +151,7 @@ definition_scope(Meta, File) ->
 
 compile(#{module := Module} = Map) ->
   Data = elixir_module:data_table(Module),
-  {Prefix, Forms, Defmacro, Unreachable} = dynamic_form(Map),
+  {Prefix, Forms, Defmacro, Unreachable} = dynamic_form(Map, Data),
   Specs =
     case elixir_config:get(bootstrap) of
       true -> [];
@@ -158,7 +160,7 @@ compile(#{module := Module} = Map) ->
   load_form(Map, Data, Prefix, Forms, Specs).
 
 dynamic_form(#{module := Module, line := Line, file := File, attributes := Attributes,
-               definitions := Definitions, unreachable := Unreachable}) ->
+               definitions := Definitions, unreachable := Unreachable}, Data) ->
   {Def, Defmacro, Macros, Exports, Functions} =
     split_definition(Definitions, File, Unreachable, [], [], [], [], {[], []}),
 
@@ -167,7 +169,7 @@ dynamic_form(#{module := Module, line := Line, file := File, attributes := Attri
             {attribute, Line, module, Module},
             {attribute, Line, compile, no_auto_import}],
 
-  Forms0 = functions_form(Line, Module, Def, Defmacro, Exports, Functions),
+  Forms0 = functions_form(Data, Line, Module, Def, Defmacro, Exports, Functions),
   Forms1 = attributes_form(Line, Attributes, Forms0),
   {Prefix, Forms1, Macros, Unreachable}.
 
@@ -263,11 +265,11 @@ is_macro(_)         -> false.
 
 % Functions
 
-functions_form(Line, Module, Def, Defmacro, Exports, Body) ->
-  {Spec, Info} = add_info_function(Line, Module, Def, Defmacro),
+functions_form(Data, Line, Module, Def, Defmacro, Exports, Body) ->
+  {Spec, Info} = add_info_function(Data, Line, Module, Def, Defmacro),
   [{attribute, Line, export, lists:sort([{'__info__', 1} | Exports])}, Spec, Info | Body].
 
-add_info_function(Line, Module, Def, Defmacro) ->
+add_info_function(Data, Line, Module, Def, Defmacro) ->
   AllowedAttrs = [attributes, compile, functions, macros, md5, module],
   AllowedArgs = lists:map(fun(Atom) -> {atom, Line, Atom} end, AllowedAttrs),
 
@@ -303,7 +305,8 @@ add_info_function(Line, Module, Def, Defmacro) ->
       macros_info(Defmacro),
       get_module_info(Module, attributes),
       get_module_info(Module, compile),
-      get_module_info(Module, md5)
+      get_module_info(Module, md5),
+      deprecated_info(Data)
     ]},
 
   {Spec, Info}.
@@ -320,6 +323,10 @@ macros_info(Defmacro) ->
 get_module_info(Module, Key) ->
   Call = remote(0, erlang, get_module_info, [{atom, 0, Module}, {atom, 0, Key}]),
   {clause, 0, [{atom, 0, Key}], [], [Call]}.
+
+deprecated_info(Data) ->
+  Deprecated = get_deprecated(Data),
+  {clause, 0, [{atom, 0, deprecated}], [], [elixir_erl:elixir_to_erl(Deprecated)]}.
 
 % Types
 
@@ -471,10 +478,15 @@ supports_debug_tuple() ->
 
 extra_chunks(Data, Line, Opts) ->
   Supported = supports_extra_chunks_option(),
-  case docs_chunk(Data, Line, elixir_compiler:get_opt(docs)) of
+  Chunks0 = lists:flatten([
+    docs_chunk(Data, Line, elixir_compiler:get_opt(docs)),
+    deprecated_chunk(Data)
+  ]),
+
+  case Chunks0 of
     [] -> {[], Opts};
-    Chunks when Supported -> {[], [{extra_chunks, Chunks} | Opts]};
-    Chunks -> {Chunks, Opts}
+    Chunks1 when Supported -> {[], [{extra_chunks, Chunks1} | Opts]};
+    Chunks1 -> {Chunks1, Opts}
   end.
 
 supports_extra_chunks_option() ->
@@ -495,6 +507,10 @@ docs_chunk(Data, Line, true) ->
 docs_chunk(_, _, _) ->
   [].
 
+deprecated_chunk(Data) ->
+  ChunkData = term_to_binary({elixir_deprecated_v1, get_deprecated(Data)}, [compressed]),
+  [{<<"ExDp">>, ChunkData}].
+
 get_moduledoc(Line, Data) ->
   case ets:lookup_element(Data, moduledoc, 2) of
     nil -> {Line, nil};
@@ -512,6 +528,9 @@ get_callback_docs(Data) ->
 get_type_docs(Data) ->
   lists:usort(ets:select(Data, [{{{typedoc, '$1'}, '$2', '$3', '$4'},
                                  [], [{{'$1', '$2', '$3', '$4'}}]}])).
+
+get_deprecated(Data) ->
+  lists:usort(ets:select(Data, [{{{deprecated, '$1'}, '$2'}, [], [{{'$1', '$2'}}]}])).
 
 %% Errors
 

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -1,6 +1,6 @@
 -module(elixir_module).
 -export([data_table/1, defs_table/1, is_open/1, delete_doc/6,
-         compile/4, expand_callback/6, format_error/1,
+         delete_deprecated/6, compile/4, expand_callback/6, format_error/1,
          compiler_modules/0, delete_impl/6,
          write_cache/3, read_cache/2]).
 -include("elixir.hrl").
@@ -34,6 +34,10 @@ is_open(Module) ->
 
 delete_doc(#{module := Module}, _, _, _, _, _) ->
   ets:delete(data_table(Module), doc),
+  ok.
+
+delete_deprecated(#{module := Module}, _, _, _, _, _) ->
+  ets:delete(data_table(Module), deprecated),
   ok.
 
 delete_impl(#{module := Module}, _, _, _, _, _) ->
@@ -176,20 +180,15 @@ build(Line, File, Module, Lexical) ->
   Ref  = elixir_code_server:call({defmodule, self(),
                                  {Module, Data, Defs, Line, File}}),
 
-  DocsOnDefinition =
-      case elixir_compiler:get_opt(docs) of
-        true -> [{'Elixir.Module', compile_doc}];
-        _    -> [{elixir_module, delete_doc}]
-      end,
-
-  ImplOnDefinition =
-      case elixir_config:get(bootstrap) of
-        true -> [{elixir_module, delete_impl}];
-        _    -> [{'Elixir.Module', compile_impl}]
-      end,
+  Bootstrap = elixir_config:get(bootstrap),
+  CompileDocs = elixir_compiler:get_opt(docs),
 
   %% Docs must come first as they read the impl callback.
-  OnDefinition = DocsOnDefinition ++ ImplOnDefinition,
+  OnDefinition = [
+    deprecated_on_definition(not Bootstrap),
+    docs_on_definition(CompileDocs),
+    impl_on_definition(not Bootstrap)
+  ],
 
   ets:insert(Data, [
     % {Key, Value, Accumulate?, UnreadLine}
@@ -228,6 +227,21 @@ build(Line, File, Module, Lexical) ->
   elixir_overridable:setup(Module),
 
   {Data, Defs, Ref}.
+
+deprecated_on_definition(true) ->
+  {'Elixir.Module', compile_deprecated};
+deprecated_on_definition(_) ->
+  {elixir_module, delete_deprecated}.
+
+docs_on_definition(true) ->
+  {'Elixir.Module', compile_doc};
+docs_on_definition(_) ->
+  {elixir_module, delete_doc}.
+
+impl_on_definition(true) ->
+  {'Elixir.Module', compile_impl};
+impl_on_definition(_) ->
+  {elixir_module, delete_impl}.
 
 %% Handles module and callback evaluations.
 

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -37,9 +37,6 @@ delete_doc(Data) ->
 delete_deprecated(Data) ->
   ets:delete(Data, deprecated).
 
-get_deprecated(Data) ->
-  lists:usort(ets:select(Data, [{{{deprecated, '$1'}, '$2'}, [], [{{'$1', '$2'}}]}])).
-
 delete_impl(Data) ->
   ets:delete(Data, impl).
 
@@ -85,7 +82,6 @@ compile(Line, Module, Block, Vars, E) ->
     PersistedAttributes = ets:lookup_element(Data, ?persisted_attr, 2),
     Attributes = attributes(Line, File, Data, PersistedAttributes),
     {AllDefinitions, Unreachable} = elixir_def:fetch_definitions(File, Module),
-    Deprecated = get_deprecated(Data),
 
     (not elixir_config:get(bootstrap)) andalso
      'Elixir.Module':check_behaviours_and_impls(E, Data, AllDefinitions, OverridablePairs),
@@ -99,7 +95,6 @@ compile(Line, Module, Block, Vars, E) ->
       attributes => Attributes,
       definitions => AllDefinitions,
       unreachable => Unreachable,
-      deprecated => Deprecated,
       compile_opts => CompileOpts
     },
 

--- a/lib/elixir/test/elixir/kernel/deprecated_test.exs
+++ b/lib/elixir/test/elixir/kernel/deprecated_test.exs
@@ -1,0 +1,38 @@
+Code.require_file("../test_helper.exs", __DIR__)
+
+defmodule Kernel.DeprecatedTest do
+  use ExUnit.Case
+
+  import PathHelpers
+
+  test "raises on invalid @deprecated" do
+    assert_raise ArgumentError, ~r"@deprecated expects a string with the reason", fn ->
+      defmodule InvalidDeprecated do
+        @deprecated 1.2
+        def foo, do: :bar
+      end
+    end
+  end
+
+  test "add deprecated to __info__ and beam chuncks" do
+    write_beam(
+      defmodule SampleDeprecated do
+        @deprecated "Use SampleDeprecated.bar/0 instead"
+        def foo, do: true
+
+        def bar, do: false
+      end
+    )
+
+    deprecated = [
+      {{:foo, 0}, "Use SampleDeprecated.bar/0 instead"}
+    ]
+
+    assert SampleDeprecated.__info__(:deprecated) == deprecated
+
+    {SampleDeprecated, bin, _beam_path} = :code.get_object_code(SampleDeprecated)
+    {:ok, {SampleDeprecated, [{'ExDp', deprecated_bin}]}} = :beam_lib.chunks(bin, ['ExDp'])
+
+    assert :erlang.binary_to_term(deprecated_bin) == {:elixir_deprecated_v1, deprecated}
+  end
+end

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -285,7 +285,7 @@ defmodule ModuleTest do
       end
 
     atoms = :beam_lib.chunks(binary, [:atoms])
-    assert :erlang.phash2(atoms) == 91_248_368
+    assert :erlang.phash2(atoms) == 98_328_115
   end
 
   test "create with generated true does not emit warnings" do

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -382,7 +382,13 @@ defmodule Protocol.ConsolidationTest do
   end
 
   test "consolidation keeps deprecated" do
-    assert [{{:ok, 1}, "Reason"}] = Sample.__info__(:deprecated)
+    deprecated = [{{:ok, 1}, "Reason"}]
+
+    assert deprecated == Sample.__info__(:deprecated)
+
+    {:ok, {Sample, [{'ExDp', deprecated_bin}]}} = :beam_lib.chunks(@sample_binary, ['ExDp'])
+
+    assert {:elixir_deprecated_v1, deprecated} == :erlang.binary_to_term(deprecated_bin)
   end
 
   test "consolidation keeps source" do

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -9,6 +9,7 @@ defmodule ProtocolTest do
     defprotocol Sample do
       @type t :: any
       @doc "Ok"
+      @deprecated "Reason"
       @spec ok(t) :: boolean
       def ok(term)
     end
@@ -108,13 +109,14 @@ defmodule ProtocolTest do
     end
   end
 
-  test "protocol documentation" do
+  test "protocol documentation and deprecated" do
     import PathHelpers
 
     write_beam(
       defprotocol SampleDocsProto do
         @type t :: any
         @doc "Ok"
+        @deprecated "Reason"
         @spec ok(t) :: boolean
         def ok(term)
       end
@@ -122,6 +124,9 @@ defmodule ProtocolTest do
 
     docs = Code.get_docs(SampleDocsProto, :docs)
     assert {{:ok, 1}, _, :def, [{:term, _, nil}], "Ok"} = List.keyfind(docs, {:ok, 1}, 0)
+
+    deprecated = Sample.__info__(:deprecated)
+    assert [{{:ok, 1}, "Reason"}] = deprecated
   end
 
   test "protocol keeps underlying UndefinedFunctionError" do
@@ -131,11 +136,11 @@ defmodule ProtocolTest do
   end
 
   test "protocol defines callbacks" do
-    assert [{:type, 12, :fun, args}] = get_callbacks(@sample_binary, :ok, 1)
-    assert args == [{:type, 12, :product, [{:user_type, 12, :t, []}]}, {:type, 12, :boolean, []}]
+    assert [{:type, 13, :fun, args}] = get_callbacks(@sample_binary, :ok, 1)
+    assert args == [{:type, 13, :product, [{:user_type, 13, :t, []}]}, {:type, 13, :boolean, []}]
 
-    assert [{:type, 22, :fun, args}] = get_callbacks(@with_any_binary, :ok, 1)
-    assert args == [{:type, 22, :product, [{:user_type, 22, :t, []}]}, {:type, 22, :term, []}]
+    assert [{:type, 23, :fun, args}] = get_callbacks(@with_any_binary, :ok, 1)
+    assert args == [{:type, 23, :product, [{:user_type, 23, :t, []}]}, {:type, 23, :term, []}]
   end
 
   test "protocol defines functions and attributes" do
@@ -266,6 +271,7 @@ defmodule Protocol.ConsolidationTest do
     defprotocol Sample do
       @type t :: any
       @doc "Ok"
+      @deprecated "Reason"
       @spec ok(t) :: boolean
       def ok(term)
     end
@@ -373,6 +379,10 @@ defmodule Protocol.ConsolidationTest do
   test "consolidation keeps docs" do
     docs = Code.get_docs(Sample, :docs)
     assert {{:ok, 1}, _, :def, [{:term, _, nil}], "Ok"} = List.keyfind(docs, {:ok, 1}, 0)
+  end
+
+  test "consolidation keeps deprecated" do
+    assert [{{:ok, 1}, "Reason"}] = Sample.__info__(:deprecated)
   end
 
   test "consolidation keeps source" do


### PR DESCRIPTION
Add deprecated to `ExDp` beam chunk and to `Module.__info__(:deprecated)` as discussed on #7104