### PR TITLE
Fix Stream.chunk_every/4 odd results when step > count

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -412,6 +412,9 @@ defmodule Enum do
       iex> Enum.chunk_every([1, 2, 3, 4], 10)
       [[1, 2, 3, 4]]
 
+      iex> Enum.chunk_every([1, 2, 3, 4, 5], 2, 3, [])
+      [[1, 2], [4, 5]]
+
   """
   @spec chunk_every(t, pos_integer, pos_integer, t | :discard) :: [list]
   def chunk_every(enumerable, count, step, leftover \\ [])

--- a/lib/elixir/lib/stream/reducers.ex
+++ b/lib/elixir/lib/stream/reducers.ex
@@ -25,7 +25,7 @@ defmodule Stream.Reducers do
     end
 
     after_fun = fn {acc_buffer, acc_count} ->
-      if leftover == :discard or acc_count == 0 do
+      if leftover == :discard or acc_count == 0 or (step > count and count == acc_count) do
         {:cont, []}
       else
         {:cont, :lists.reverse(acc_buffer, Enum.take(leftover, count - acc_count)), []}

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -71,6 +71,10 @@ defmodule EnumTest do
     assert Enum.chunk_every([1, 2, 3, 4, 5, 6], 3, 2, []) == [[1, 2, 3], [3, 4, 5], [5, 6]]
     assert Enum.chunk_every([1, 2, 3, 4, 5, 6], 3, 3, []) == [[1, 2, 3], [4, 5, 6]]
     assert Enum.chunk_every([1, 2, 3, 4, 5], 4, 4, 6..10) == [[1, 2, 3, 4], [5, 6, 7, 8]]
+    assert Enum.chunk_every([1, 2, 3, 4, 5], 2, 3, []) == [[1, 2], [4, 5]]
+    assert Enum.chunk_every([1, 2, 3, 4, 5, 6], 2, 3, []) == [[1, 2], [4, 5]]
+    assert Enum.chunk_every([1, 2, 3, 4, 5, 6, 7], 2, 3, []) == [[1, 2], [4, 5], [7]]
+    assert Enum.chunk_every([1, 2, 3, 4, 5, 6, 7], 2, 3, [8]) == [[1, 2], [4, 5], [7, 8]]
   end
 
   test "chunk_by/2" do


### PR DESCRIPTION
# Summary
`Stream.chunk_every/4` was giving odd results when step was greater than
count and the last element of the enumerable was the same as last
chunk's last element.

This patch fixes this issue and adds tests for different scenarios when
`step > count`. It also adds a `doctest` example to reflect this in the
documentation and test it simultaneously.

Fixes #7096