### PR TITLE
Remove unnecessary processing of the ExDc chunk

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -309,7 +309,7 @@ defmodule Protocol do
   end
 
   defp beam_protocol(protocol) do
-    chunk_ids = [:abstract_code, :attributes, :compile_info, 'ExDc']
+    chunk_ids = [:abstract_code, :attributes, :compile_info]
     opts = [:allow_missing_chunks]
 
     case :beam_lib.chunks(beam_file(protocol), chunk_ids, opts) do
@@ -317,13 +317,12 @@ defmodule Protocol do
         [
           {:abstract_code, {_raw, abstract_code}},
           {:attributes, attributes},
-          {:compile_info, compile_info},
-          {'ExDc', docs}
+          {:compile_info, compile_info}
         ] = entries
 
         case attributes[:protocol] do
           [fallback_to_any: any] ->
-            {:ok, {protocol, any, abstract_code}, {compile_info, docs}}
+            {:ok, {protocol, any, abstract_code}, compile_info}
 
           _ ->
             {:error, :not_a_protocol}
@@ -497,15 +496,12 @@ defmodule Protocol do
   end
 
   # Finally compile the module and emit its bytecode.
-  defp compile(protocol, code, {compile_info, docs}) do
+  defp compile(protocol, code, compile_info) do
     opts = Keyword.take(compile_info, [:source])
     opts = if Code.compiler_options()[:debug_info], do: [:debug_info | opts], else: opts
     {:ok, ^protocol, binary, _warnings} = :compile.forms(code, [:return | opts])
 
-    case docs do
-      :missing_chunk -> {:ok, binary}
-      _ -> {:ok, :elixir_erl.add_beam_chunks(binary, [{"ExDc", docs}])}
-    end
+    {:ok, binary}
   end
 
   ## Definition callbacks

--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -1,8 +1,7 @@
 %% Compiler backend to Erlang.
 -module(elixir_erl).
--export([elixir_to_erl/1, definition_to_anonymous/5, compile/1,
-         get_ann/1, remote/4, add_beam_chunks/2, debug_info/4,
-         definition_scope/2, format_error/1]).
+-export([elixir_to_erl/1, definition_to_anonymous/5, compile/1, get_ann/1,
+         remote/4, debug_info/4, definition_scope/2, format_error/1]).
 -include("elixir.hrl").
 
 %% TODO: Remove extra chunk functionality when OTP 20+.


### PR DESCRIPTION
The extra chuncks are already preserved during consolidation, no extra work is needed.
Notice this when I was working on #7113, and I think it will speed up protocol consolidation.