### PR TITLE
Stream.Reducers.chunk_every/4 Include leftover when acc_count = 0

### DIFF
--- a/lib/elixir/lib/stream/reducers.ex
+++ b/lib/elixir/lib/stream/reducers.ex
@@ -25,7 +25,8 @@ defmodule Stream.Reducers do
     end
 
     after_fun = fn {acc_buffer, acc_count} ->
-      if leftover == :discard or acc_count == 0 or (step > count and acc_count >= count) do
+      if leftover == :discard or (acc_count == 0 and leftover == []) or
+           (step > count and acc_count >= count) do
         {:cont, []}
       else
         {:cont, :lists.reverse(acc_buffer, Enum.take(leftover, count - acc_count)), []}

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -76,6 +76,8 @@ defmodule EnumTest do
     assert Enum.chunk_every([1, 2, 3, 4, 5, 6, 7], 2, 3, []) == [[1, 2], [4, 5], [7]]
     assert Enum.chunk_every([1, 2, 3, 4, 5, 6, 7], 2, 3, [8]) == [[1, 2], [4, 5], [7, 8]]
     assert Enum.chunk_every([1, 2, 3, 4, 5, 6, 7], 2, 4, []) == [[1, 2], [5, 6]]
+    assert Enum.chunk_every([1, 2, 3, 4, 5, 6, 7, 8], 2, 4, []) == [[1, 2], [5, 6]]
+    assert Enum.chunk_every([1, 2, 3, 4, 5, 6, 7, 8], 2, 4, [9]) == [[1, 2], [5, 6], [9]]
   end
 
   test "chunk_by/2" do


### PR DESCRIPTION
# Summary
In case acc_count = 0, if there is a leftover, it should be added to the result.

## Additional information
Continues #7114 (already merged)