### PR TITLE
Fix typo in String doc

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -301,7 +301,7 @@ defmodule String do
   ## Options
 
     * `:parts` (positive integer or `:infinity`) - the string
-      is split into at most as many parts as this options specifies.
+      is split into at most as many parts as this option specifies.
       If `:infinity`, the string will be split into all possible
       parts. Defaults to `:infinity`.
 


### PR DESCRIPTION
Hi all,

`as this options specifies` → `as this option specifies`.

Cheers!