### PR TITLE
Explicitly specify limit 'infinity' as an option as part of the options one can take wrt IO.inspect

### DIFF
--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -26,18 +26,18 @@ defmodule Inspect.Opts do
     * `:limit` - limits the number of items that are printed for tuples,
       bitstrings, maps, lists and any other collection of items. It does not
       apply to strings nor charlists and defaults to 50. If you don't want to limit
-      the number of items to a particular number you could set the limit as `:infinity`.
+      the number of items to a particular number, use `:infinity`.
 
     * `:printable_limit` - limits the number of bytes that are printed for strings
       and char lists. Defaults to 4096. If you don't want to limit the number of items
-      to a particular number you could set the limit as `:infinity`.
+      to a particular number, use `:infinity`.
 
     * `:pretty` - if set to `true` enables pretty printing, defaults to `false`.
 
     * `:width` - defaults to 80 characters, used when pretty is `true` or when
       printing to IO devices. Set to 0 to force each item to be printed on its
       own line. If you don't want to limit the number of items to a particular
-      number you could set the limit as `:infinity`.
+      number, use `:infinity`.
 
     * `:base` - prints integers as `:binary`, `:octal`, `:decimal`, or `:hex`,
       defaults to `:decimal`. When inspecting binaries any `:base` other than

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -25,16 +25,19 @@ defmodule Inspect.Opts do
 
     * `:limit` - limits the number of items that are printed for tuples,
       bitstrings, maps, lists and any other collection of items. It does not
-      apply to strings nor charlists and defaults to 50.
+      apply to strings nor charlists and defaults to 50. If you don't want to limit
+      the number of items to a particular number you could set the limit as `:infinity`.
 
     * `:printable_limit` - limits the number of bytes that are printed for strings
-      and char lists. Defaults to 4096.
+      and char lists. Defaults to 4096. If you don't want to limit the number of items
+      to a particular number you could set the limit as `:infinity`.
 
     * `:pretty` - if set to `true` enables pretty printing, defaults to `false`.
 
     * `:width` - defaults to 80 characters, used when pretty is `true` or when
       printing to IO devices. Set to 0 to force each item to be printed on its
-      own line.
+      own line. If you don't want to limit the number of items to a particular
+      number you could set the limit as `:infinity`.
 
     * `:base` - prints integers as `:binary`, `:octal`, `:decimal`, or `:hex`,
       defaults to `:decimal`. When inspecting binaries any `:base` other than


### PR DESCRIPTION
**Background**: As I was researching more on the different use cases around which one can use `IO.inspect`, I stumbled across this [SO post](https://stackoverflow.com/questions/29566248/elixir-io-inspect-to-not-trim-a-long-list) where they mentioned that in case one uses some of the options provide as part of `Inspect.opts` in the context `IO.inspect`, there was a missing information in the documentation. 

**The use case that had missing documentation**: If we want  `IO.inspect` to not trim a particular list, there wasn't an explicit way mentioned of how to do so in the documentation but the [code here](https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/inspect/algebra.ex#L77-L79) seemed to provide the `:infinity` option for `limit`, `printable_limit` and `width` option used in the context of `IO.inspect`. This PR is an attempt to make the documentation more explicit so that users are aware they can use the `:infinity` option wrt `IO.inspect` whenever needed.

Please feel free to let me know if I'm missing something.

Thank you.
