### PR TITLE
return right side expression value on struct matching

### DIFF
--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -25,7 +25,7 @@ translate({'=', Meta, [Left, Right]}, S) ->
       Reason = {tuple, Generated, [{atom, Generated, badmatch}, ResultVar]},
       RaiseExpr = elixir_erl:remote(Generated, erlang, error, [Reason]),
       GuardsExp = {'if', Generated, [
-        {clause, Generated, [], [ExtraGuards], [True]},
+        {clause, Generated, [], [ExtraGuards], [ResultVar]},
         {clause, Generated, [], [[True]], [RaiseExpr]}
       ]},
       {{block, Generated, [ResultMatch, GuardsExp]}, SL2};

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -200,6 +200,9 @@ defmodule MapTest do
     assert_raise BadStructError, "expected a struct named MapTest.ExternalUser, got: %{}", fn ->
       %ExternalUser{map | name: "meg"}
     end
+
+    assert Code.eval_string("%struct{} = %ExternalUser{}", [], __ENV__) ==
+             {%ExternalUser{}, [struct: ExternalUser]}
   end
 
   test "structs with variable name" do


### PR DESCRIPTION
There was a regression introduced in #6347 where `true` was returned as the value of an expression match instead of the right side of the expression. See #7156 for more info.

Fixes #7156 
