### PR TITLE
s/when/after/ in Application.stop/1 docs [ci skip]

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -186,9 +186,9 @@ defmodule Application do
               | {:error, reason :: term}
 
   @doc """
-  Called when an application is stopped.
+  Called after an application has been stopped.
 
-  This function is called when an application has stopped, i.e., when its
+  This function is called after an application has been stopped, i.e., after its
   supervision tree has been stopped. It should do the opposite of what the
   `start/2` callback did, and should perform any necessary cleanup. The return
   value of this callback is ignored.


### PR DESCRIPTION
Small tweak in the docs of `Application.stop/1`.

The word _when_ in this description seems a bit ambiguous to me, it may suggest _while_ to the reader.

By using _after_ and _has been_, the reader unambiguously understands that stopping the application is something else that somehow has already happened.

[OTP docs](http://erlang.org/doc/design_principles/applications.html) also use "after":

> `stop/1` is called **after** the application has been stopped and is to do any necessary cleaning up.