### PR TITLE
Add `@impl true` to StringIO & IEx.Pry

### DIFF
--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -99,11 +99,13 @@ defmodule StringIO do
 
   ## callbacks
 
+  @impl true
   def init({string, options}) do
     capture_prompt = options[:capture_prompt] || false
     {:ok, %{input: string, output: "", capture_prompt: capture_prompt}}
   end
 
+  @impl true
   def handle_info({:io_request, from, reply_as, req}, state) do
     state = io_request(from, reply_as, req, state)
     {:noreply, state}
@@ -113,6 +115,7 @@ defmodule StringIO do
     super(message, state)
   end
 
+  @impl true
   def handle_call(:contents, _from, %{input: input, output: output} = state) do
     {:reply, {input, output}, state}
   end

--- a/lib/iex/lib/iex/pry.ex
+++ b/lib/iex/lib/iex/pry.ex
@@ -264,12 +264,14 @@ defmodule IEx.Pry do
     GenServer.start_link(__MODULE__, :ok, name: @server)
   end
 
+  @impl true
   def init(:ok) do
     Process.flag(:trap_exit, true)
     :ets.new(@table, [:named_table, :public, write_concurrency: true])
     {:ok, @initial_counter}
   end
 
+  @impl true
   def handle_call({:break, module, fa, condition, breaks}, _from, counter) do
     # If there is a match for the given module and fa, we
     # use the ref, otherwise we create a new one.


### PR DESCRIPTION
This way we'll no longer see `init/1` callback in docs:
https://hexdocs.pm/elixir/1.6.0-rc.0/StringIO.html#init/1