### PR TITLE
Default value for System.get_env

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -90,6 +90,8 @@ defmodule System do
           | :microseconds
           | :nanoseconds
 
+  @type value :: term
+
   @base_dir :filename.join(__DIR__, "../../..")
   @version_file :filename.join(@base_dir, "VERSION")
 
@@ -378,13 +380,13 @@ defmodule System do
   Returns the value of the given environment variable.
 
   The returned value of the environment variable
-  `varname` is a string, or `nil` if the environment
+  `varname` is a string, or `default` if the environment
   variable is undefined.
   """
-  @spec get_env(String.t()) :: String.t() | nil
-  def get_env(varname) when is_binary(varname) do
+  @spec get_env(String.t(), value) :: value | nil
+  def get_env(varname, default \\ nil) when is_binary(varname) do
     case :os.getenv(String.to_charlist(varname)) do
-      false -> nil
+      false -> default
       other -> List.to_string(other)
     end
   end

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -90,8 +90,6 @@ defmodule System do
           | :microseconds
           | :nanoseconds
 
-  @type value :: term
-
   @base_dir :filename.join(__DIR__, "../../..")
   @version_file :filename.join(@base_dir, "VERSION")
 
@@ -383,8 +381,9 @@ defmodule System do
   `varname` is a string, or `default` if the environment
   variable is undefined.
   """
-  @spec get_env(String.t(), value) :: value | nil
-  def get_env(varname, default \\ nil) when is_binary(varname) do
+  @spec get_env(String.t(), String.t()) :: String.t() | nil
+  def get_env(varname, default \\ nil)
+    when is_binary(varname) and (is_binary(default) or is_nil(default)) do
     case :os.getenv(String.to_charlist(varname)) do
       false -> default
       other -> List.to_string(other)

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -76,7 +76,7 @@ defmodule SystemTest do
     assert System.get_env(@test_var) == "OTHER_SAMPLE"
 
     System.delete_env(@test_var)
-    assert System.get_env(@test_var, :default) == :default
+    assert System.get_env(@test_var, "DEFAULT_VALUE") == "DEFAULT_VALUE"
 
     assert_raise ArgumentError, ~r[cannot execute System.put_env/2 for key with \"=\"], fn ->
       System.put_env("FOO=BAR", "BAZ")

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -75,6 +75,9 @@ defmodule SystemTest do
     System.put_env(%{@test_var => "OTHER_SAMPLE"})
     assert System.get_env(@test_var) == "OTHER_SAMPLE"
 
+    System.delete_env(@test_var)
+    assert System.get_env(@test_var, :default) == :default
+
     assert_raise ArgumentError, ~r[cannot execute System.put_env/2 for key with \"=\"], fn ->
       System.put_env("FOO=BAR", "BAZ")
     end


### PR DESCRIPTION
## Issue
https://github.com/elixir-lang/elixir/issues/7171

## Problem
There is no default option for `System.get_env`

## Solution
Make it possible to supply a default value, like in `Application.get_env`

