### PR TITLE
Fix inspect for non-decimal negative integers

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -262,6 +262,10 @@ defimpl Inspect, for: Integer do
 
   defp prepend_prefix(value, :decimal), do: value
 
+  defp prepend_prefix(<<?-, value::binary>>, base) do
+    "-" <> prepend_prefix(value, base)
+  end
+
   defp prepend_prefix(value, base) do
     prefix =
       case base do

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -194,14 +194,17 @@ defmodule Inspect.NumberTest do
 
   test "hex" do
     assert inspect(100, base: :hex) == "0x64"
+    assert inspect(-100, base: :hex) == "-0x64"
   end
 
   test "octal" do
     assert inspect(100, base: :octal) == "0o144"
+    assert inspect(-100, base: :octal) == "-0o144"
   end
 
   test "binary" do
     assert inspect(86, base: :binary) == "0b1010110"
+    assert inspect(-86, base: :binary) == "-0b1010110"
   end
 
   test "float" do


### PR DESCRIPTION
Before:

iex> inspect(-1, base: :hex)
"0x-1"

After:

iex> inspect(-1, base: :hex)
"-0x1"

This change also applies to the octal and binary base options.