### PR TITLE
Introduce a group for collections

### DIFF
--- a/lib/elixir/docs.exs
+++ b/lib/elixir/docs.exs
@@ -4,34 +4,37 @@
   groups_for_modules: [
     # [Kernel, Kernel.SpecialForms],
 
-    "Data & Behaviours": [
-      Access,
+    "Basic Types": [
       Atom,
       Base,
       Bitwise,
       Calendar,
       Calendar.ISO,
       Date,
-      Date.Range,
       DateTime,
-      Enum,
       Exception,
       Float,
       Integer,
-      Keyword,
-      List,
-      Map,
-      MapSet,
       NaiveDateTime,
-      Range,
       Record,
       Regex,
-      Stream,
       String,
       Time,
       Tuple,
       URI,
       Version,
+    ],
+
+    "Collections & Enumerables": [
+      Access,
+      Date.Range,
+      Enum,
+      Keyword,
+      List,
+      Map,
+      MapSet,
+      Range,
+      Stream,
     ],
 
     "IO & System": [


### PR DESCRIPTION
Currently the docs have a large group called "Data & Behaviour". The goal of this PR is to extract "Collections" (lists, sets, etc) and "Enumerables" (such as ranges) into their own group. Feedback is welcome!