### PR TITLE
Add symmetric closure

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -172,6 +172,7 @@ defmodule Integer do
   defp do_undigits([], _base, 0), do: 0
   defp do_undigits([digit], base, 0) when is_integer(digit) and digit < base, do: digit
   defp do_undigits([1, 0], base, 0), do: base
+  defp do_undigits([-1, 0], base, 0), do: -base
   defp do_undigits([0 | tail], base, 0), do: do_undigits(tail, base, 0)
   defp do_undigits([], _base, acc), do: acc
 

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -101,6 +101,8 @@ defmodule IntegerTest do
     assert Integer.undigits([]) == 0
     assert Integer.undigits([0]) == 0
     assert Integer.undigits([1]) == 1
+    assert Integer.undigits([1, 0]) == 10
+    assert Integer.undigits([-1, 0]) == -10
     assert Integer.undigits([1, 0, 1]) == 101
     assert Integer.undigits([1, 4], 16) == 0x14
     assert Integer.undigits([1, 4], 8) == 0o14


### PR DESCRIPTION
In `do_digits()` there are two symmetric closures in recursion, so probably for `do_undigits()` there can be two too. 