### PR TITLE
Change `assert_in_delta` better handle a delta of 0

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -689,9 +689,9 @@ defmodule ExUnit.Assertions do
     message =
       message ||
         "Expected the difference between #{inspect(value1)} and " <>
-          "#{inspect(value2)} (#{inspect(diff)}) to be less than #{inspect(delta)}"
+          "#{inspect(value2)} (#{inspect(diff)}) to be less than or equal to #{inspect(delta)}"
 
-    assert diff < delta, message
+    assert diff <= delta, message
   end
 
   @doc """

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -667,11 +667,16 @@ defmodule ExUnit.AssertionsTest do
     end
   end
 
+  test "assert in delta works with equal values and a delta of zero" do
+    assert_in_delta(10, 10, 0)
+  end
+
   test "assert in delta error" do
     "This should never be tested" = assert_in_delta(10, 12, 1)
   rescue
     error in [ExUnit.AssertionError] ->
-      "Expected the difference between 10 and 12 (2) to be less than 1" = error.message
+      "Expected the difference between 10 and 12 (2) to be less than or equal to 1" =
+        error.message
   end
 
   test "assert in delta with message" do


### PR DESCRIPTION
Previously if the two values that we were checking were within a given
delta were equal, they would fail if the expected delta was `0`.