### PR TITLE
Add additional documentation for `assert_in_delta` and `refute_in_delta`

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -668,13 +668,15 @@ defmodule ExUnit.Assertions do
   end
 
   @doc """
-  Asserts that `value1` and `value2` differ by no more than `delta`.
+  Asserts that `value1` and `value2` differ by no more than `delta`. This difference is
+  inclusive, so the test will pass if the difference and the `delta` are equal.
 
 
   ## Examples
 
       assert_in_delta 1.1, 1.5, 0.2
-      assert_in_delta 10, 15, 4
+      assert_in_delta 10, 15, 2
+      assert_in_delta 10, 15, 5
 
   """
   def assert_in_delta(value1, value2, delta, message \\ nil)
@@ -838,7 +840,8 @@ defmodule ExUnit.Assertions do
   end
 
   @doc """
-  Asserts `value1` and `value2` are not within `delta`.
+  Asserts `value1` and `value2` are not within `delta`. This difference is exclusive,
+  so the test will fail if the difference and the delta are equal.
 
   If you supply `message`, information about the values will
   automatically be appended to it.

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -668,9 +668,10 @@ defmodule ExUnit.Assertions do
   end
 
   @doc """
-  Asserts that `value1` and `value2` differ by no more than `delta`. This difference is
-  inclusive, so the test will pass if the difference and the `delta` are equal.
-
+  Asserts that `value1` and `value2` differ by no more than `delta`.
+  
+  This difference is inclusive, so the test will pass if the difference
+  and the `delta` are equal.
 
   ## Examples
 
@@ -840,8 +841,10 @@ defmodule ExUnit.Assertions do
   end
 
   @doc """
-  Asserts `value1` and `value2` are not within `delta`. This difference is exclusive,
-  so the test will fail if the difference and the delta are equal.
+  Asserts `value1` and `value2` are not within `delta`.
+  
+  This difference is exclusive, so the test will fail if the difference
+  and the delta are equal.
 
   If you supply `message`, information about the values will
   automatically be appended to it.

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -669,7 +669,7 @@ defmodule ExUnit.Assertions do
 
   @doc """
   Asserts that `value1` and `value2` differ by no more than `delta`.
-  
+
   This difference is inclusive, so the test will pass if the difference
   and the `delta` are equal.
 
@@ -842,7 +842,7 @@ defmodule ExUnit.Assertions do
 
   @doc """
   Asserts `value1` and `value2` are not within `delta`.
-  
+
   This difference is exclusive, so the test will fail if the difference
   and the delta are equal.
 


### PR DESCRIPTION
In a previous commit I changed the behavior of `assert_in_delta`, but I
forgot to document that change so it's clear to users in the future. I
also made it clear that `refute_in_delta` is exclusive, so folks
shouldn't have questions about that anymore.