### PR TITLE
Add type union explanation to typespecs

### DIFF
--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -20,6 +20,8 @@ See the "Defining a type" and "Defining a specification" sub-sections below for 
 
 The syntax Elixir provides for type specifications is similar to [the one in Erlang](http://www.erlang.org/doc/reference_manual/typespec.html). Most of the built-in types provided in Erlang (for example, `pid()`) are expressed in the same way: `pid()` (or simply `pid`). Parametrized types (such as `list(integer)`) are supported as well and so are remote types (such as `Enum.t`). Integers and atom literals are allowed as types (e.g., `1`, `:atom`, or `false`). All other types are built out of unions of predefined types. Some shorthands are allowed, such as `[...]`, `<<>>`, and `{...}`.
 
+The notation to represent the union of types is the pipe `|`. For example, the typespec `type :: atom() | pid() | tuple()` creates a type `type` that can be either an `atom`, a `pid`, or a `tuple`. This is usually called a [sum type](https://en.wikipedia.org/wiki/Tagged_union) in other languages
+
 ### Basic types
 
     type :: any()                   # the top type, the set of all terms


### PR DESCRIPTION
A [question on StackOverflow](https://stackoverflow.com/questions/48196624/what-is-the-meaning-of-an-elixir-typespec-with-types-in-parenthesis-separated-by/48196807) brought to light that type unions are not called out anywhere in the docs, so here's a small edit to hopefully shed a little more light on them for newcomers :)