### PR TITLE
Replace Code.load_file/2 by Code.compile_file/2

### DIFF
--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -25,59 +25,13 @@
 -export([start/2, stop/1, config_change/3]).
 
 start(_Type, _Args) ->
-  %% In case there is a shell, we can't really change its
-  %% encoding, so we just set binary to true. Otherwise
-  %% we must set the encoding as the user with no shell
-  %% has encoding set to latin1.
-  Opts =
-    case init:get_argument(noshell) of
-      {ok, _} -> [binary, {encoding, utf8}];
-      error   -> [binary]
-    end,
-
-  %% Whenever we change this check, we should also change escript.build.
-  OTPRelease =
-    case string:to_integer(erlang:system_info(otp_release)) of
-      {Num, _} when Num >= 19 ->
-        Num;
-      _ ->
-        io:format(standard_error, "unsupported Erlang version, expected Erlang 19+~n", []),
-        erlang:halt(1)
-    end,
-
-  %% We need to make sure the re module is preloaded
-  %% to make function_exported checks on it fast.
-  %% TODO: Remove this once we support OTP 20+.
-  _ = code:ensure_loaded(re),
-
-  case code:ensure_loaded(?system) of
-    {module, ?system} ->
-      Endianness = ?system:endianness(),
-      case ?system:compiled_endianness() of
-        Endianness -> ok;
-        _ ->
-          io:format(standard_error,
-            "warning: Elixir is running in a system with a different endianness than the one its "
-            "source code was compiled in. Please make sure Elixir and all source files were compiled "
-            "in a machine with the same endianness as the current one: ~ts~n", [Endianness])
-      end;
-    {error, _} ->
-      ok
-  end,
-
-  ok = io:setopts(standard_io, Opts),
-  ok = io:setopts(standard_error, [{encoding, utf8}]),
-
+  OTPRelease = parse_otp_release(),
   Encoding = file:native_name_encoding(),
-  case Encoding of
-    latin1 ->
-      io:format(standard_error,
-        "warning: the VM is running with native name encoding of latin1 which may cause "
-        "Elixir to malfunction as it expects utf8. Please ensure your locale is set to UTF-8 "
-        "(which can be verified by running \"locale\" in your shell)~n", []);
-    _ ->
-      ok
-  end,
+
+  preload_common_modules(),
+  set_stdio_and_stderr_to_binary_and_maybe_utf8(),
+  check_file_encoding(Encoding),
+  check_endianness(),
 
   %% TODO: Remove OTPRelease check once we support OTP 20+.
   Tokenizer = case code:ensure_loaded('Elixir.String.Tokenizer') of
@@ -85,23 +39,35 @@ start(_Type, _Args) ->
     _ -> elixir_tokenizer
   end,
 
-  URIConfig = [{{uri, <<"ftp">>}, 21},
-               {{uri, <<"sftp">>}, 22},
-               {{uri, <<"tftp">>}, 69},
-               {{uri, <<"http">>}, 80},
-               {{uri, <<"https">>}, 443},
-               {{uri, <<"ldap">>}, 389}],
-  CompilerOpts = #{docs => true, ignore_module_conflict => false,
-                   debug_info => true, warnings_as_errors => false,
-                   relative_paths => true},
+  URIConfig = [
+    {{uri, <<"ftp">>}, 21},
+    {{uri, <<"sftp">>}, 22},
+    {{uri, <<"tftp">>}, 69},
+    {{uri, <<"http">>}, 80},
+    {{uri, <<"https">>}, 443},
+    {{uri, <<"ldap">>}, 389}
+  ],
+
+  CompilerOpts = #{
+    docs => true,
+    ignore_module_conflict => false,
+    debug_info => true,
+    warnings_as_errors => false,
+    relative_paths => true
+  },
+
   {ok, [[Home] | _]} = init:get_argument(home),
-  Config = [{at_exit, []},
-            {argv, []},
-            {bootstrap, false},
-            {compiler_options, CompilerOpts},
-            {home, unicode:characters_to_binary(Home, Encoding, Encoding)},
-            {identifier_tokenizer, Tokenizer}
-            | URIConfig],
+
+  Config = [
+    {at_exit, []},
+    {argv, []},
+    {bootstrap, false},
+    {compiler_options, CompilerOpts},
+    {home, unicode:characters_to_binary(Home, Encoding, Encoding)},
+    {identifier_tokenizer, Tokenizer}
+    | URIConfig
+  ],
+
   Tab = elixir_config:new(Config),
   case elixir_sup:start_link() of
     {ok, Sup} ->
@@ -116,6 +82,71 @@ stop(Tab) ->
 
 config_change(_Changed, _New, _Remove) ->
   ok.
+
+set_stdio_and_stderr_to_binary_and_maybe_utf8() ->
+  %% In case there is a shell, we can't really change its
+  %% encoding, so we just set binary to true. Otherwise
+  %% we must set the encoding as the user with no shell
+  %% has encoding set to latin1.
+  Opts =
+    case init:get_argument(noshell) of
+      {ok, _} -> [binary, {encoding, utf8}];
+      error   -> [binary]
+    end,
+
+  ok = io:setopts(standard_io, Opts),
+  ok = io:setopts(standard_error, [{encoding, utf8}]),
+  ok.
+
+preload_common_modules() ->
+  %% We attempt to load those modules here so throughout
+  %% the codebase we can avoid code:ensure_loaded/1 checks.
+  _ = code:ensure_loaded('Elixir.Macro.Env'),
+
+  %% We need to make sure the re module is preloaded to make
+  %% function_exported checks inside Regex.version is fast.
+  %% TODO: Remove this once we support OTP 20+.
+  _ = code:ensure_loaded(re),
+
+  ok.
+
+parse_otp_release() ->
+  %% Whenever we change this check, we should also change escript.build and Makefile.
+  case string:to_integer(erlang:system_info(otp_release)) of
+    {Num, _} when Num >= 19 ->
+      Num;
+    _ ->
+      io:format(standard_error, "unsupported Erlang version, expected Erlang 19+~n", []),
+      erlang:halt(1)
+  end.
+
+check_endianness() ->
+  case code:ensure_loaded(?system) of
+    {module, ?system} ->
+      Endianness = ?system:endianness(),
+      case ?system:compiled_endianness() of
+        Endianness ->
+          ok;
+        _ ->
+          io:format(standard_error,
+            "warning: Elixir is running in a system with a different endianness than the one its "
+            "source code was compiled in. Please make sure Elixir and all source files were compiled "
+            "in a machine with the same endianness as the current one: ~ts~n", [Endianness])
+      end;
+    {error, _} ->
+      ok
+  end.
+
+check_file_encoding(Encoding) ->
+  case Encoding of
+    latin1 ->
+      io:format(standard_error,
+        "warning: the VM is running with native name encoding of latin1 which may cause "
+        "Elixir to malfunction as it expects utf8. Please ensure your locale is set to UTF-8 "
+        "(which can be verified by running \"locale\" in your shell)~n", []);
+    _ ->
+      ok
+  end.
 
 %% Boot and process given options. Invoked by Elixir's script.
 

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -141,7 +141,7 @@ env_for_eval(Opts) ->
     requires := elixir_dispatch:default_requires(),
     functions := elixir_dispatch:default_functions(),
     macros := elixir_dispatch:default_macros()
- }, Opts).
+  }, Opts).
 
 env_for_eval(Env, Opts) ->
   Line = case lists:keyfind(line, 1, Opts) of

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -101,6 +101,7 @@ set_stdio_and_stderr_to_binary_and_maybe_utf8() ->
 preload_common_modules() ->
   %% We attempt to load those modules here so throughout
   %% the codebase we can avoid code:ensure_loaded/1 checks.
+  _ = code:ensure_loaded('Elixir.Kernel'),
   _ = code:ensure_loaded('Elixir.Macro.Env'),
 
   %% We need to make sure the re module is preloaded to make

--- a/lib/elixir/src/elixir_code_server.erl
+++ b/lib/elixir/src/elixir_code_server.erl
@@ -105,7 +105,7 @@ handle_cast({loaded, Path}, Config) ->
       {noreply, Config#elixir_code_server{loaded=Done}}
   end;
 
-handle_cast({unload_files, Files}, Config) ->
+handle_cast({unrequire_files, Files}, Config) ->
   Current  = Config#elixir_code_server.loaded,
   Unloaded = maps:without(Files, Current),
   {noreply, Config#elixir_code_server{loaded=Unloaded}};

--- a/lib/elixir/src/elixir_code_server.erl
+++ b/lib/elixir/src/elixir_code_server.erl
@@ -6,7 +6,7 @@
 
 -define(timeout, 30000).
 -record(elixir_code_server, {
-  loaded=#{},
+  required=#{},
   mod_pool={[], 0},
   mod_ets=#{},
   compilation_status=#{}
@@ -24,13 +24,8 @@ start_link() ->
   gen_server:start_link({local, ?MODULE}, ?MODULE, ok, []).
 
 init(ok) ->
-  %% We attempt to load those modules here so throughout
-  %% the codebase we can avoid code:is_loaded/1 checks.
-  _ = code:ensure_loaded('Elixir.Macro.Env'),
-
   %% The table where we store module definitions
   _ = ets:new(elixir_modules, [set, protected, named_table, {read_concurrency, true}]),
-
   {ok, #elixir_code_server{}}.
 
 handle_call({defmodule, Pid, Tuple}, _From, Config) ->
@@ -44,20 +39,20 @@ handle_call({undefmodule, Ref}, _From, Config) ->
   {reply, ok, undefmodule(Ref, Config)};
 
 handle_call({acquire, Path}, From, Config) ->
-  Current = Config#elixir_code_server.loaded,
+  Current = Config#elixir_code_server.required,
   case maps:find(Path, Current) of
     {ok, true} ->
-      {reply, loaded, Config};
+      {reply, required, Config};
     {ok, {Ref, List}} when is_list(List), is_reference(Ref) ->
       Queued = maps:put(Path, {Ref, [From | List]}, Current),
-      {reply, {queued, Ref}, Config#elixir_code_server{loaded=Queued}};
+      {reply, {queued, Ref}, Config#elixir_code_server{required=Queued}};
     error ->
       Queued = maps:put(Path, {make_ref(), []}, Current),
-      {reply, proceed, Config#elixir_code_server{loaded=Queued}}
+      {reply, proceed, Config#elixir_code_server{required=Queued}}
   end;
 
-handle_call(loaded, _From, Config) ->
-  {reply, [F || {F, true} <- maps:to_list(Config#elixir_code_server.loaded)], Config};
+handle_call(required, _From, Config) ->
+  {reply, [F || {F, true} <- maps:to_list(Config#elixir_code_server.required)], Config};
 
 handle_call({compilation_status, CompilerPid}, _From, Config) ->
   CompilationStatusList = Config#elixir_code_server.compilation_status,
@@ -91,24 +86,24 @@ handle_cast({reset_warnings, CompilerPid}, Config) ->
   CompilationStatusNew = maps:put(CompilerPid, ok, CompilationStatusCurrent),
   {noreply, Config#elixir_code_server{compilation_status=CompilationStatusNew}};
 
-handle_cast({loaded, Path}, Config) ->
-  Current = Config#elixir_code_server.loaded,
+handle_cast({required, Path}, Config) ->
+  Current = Config#elixir_code_server.required,
   case maps:find(Path, Current) of
     {ok, true} ->
       {noreply, Config};
     {ok, {Ref, List}} when is_list(List), is_reference(Ref) ->
-      _ = [Pid ! {elixir_code_server, Ref, loaded} || {Pid, _Tag} <- lists:reverse(List)],
+      _ = [Pid ! {elixir_code_server, Ref, required} || {Pid, _Tag} <- lists:reverse(List)],
       Done = maps:put(Path, true, Current),
-      {noreply, Config#elixir_code_server{loaded=Done}};
+      {noreply, Config#elixir_code_server{required=Done}};
     error ->
       Done = maps:put(Path, true, Current),
-      {noreply, Config#elixir_code_server{loaded=Done}}
+      {noreply, Config#elixir_code_server{required=Done}}
   end;
 
 handle_cast({unrequire_files, Files}, Config) ->
-  Current  = Config#elixir_code_server.loaded,
-  Unloaded = maps:without(Files, Current),
-  {noreply, Config#elixir_code_server{loaded=Unloaded}};
+  Current  = Config#elixir_code_server.required,
+  Unrequired = maps:without(Files, Current),
+  {noreply, Config#elixir_code_server{required=Unrequired}};
 
 handle_cast({return_compiler_module, H}, #elixir_code_server{mod_pool={T, Counter}} = Config) ->
   {noreply, Config#elixir_code_server{mod_pool={[H | T], Counter}}};

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -87,14 +87,21 @@ defmodule CodeTest do
     end
   end
 
+  test "compile_file/1" do
+    assert Code.compile_file(fixture_path("code_sample.exs")) == []
+    refute fixture_path("code_sample.exs") in Code.required_files()
+  end
+
   test "require_file/1" do
-    Code.require_file(fixture_path("code_sample.exs"))
-    assert fixture_path("code_sample.exs") in Code.loaded_files()
+    assert Code.require_file(fixture_path("code_sample.exs")) == []
+    assert fixture_path("code_sample.exs") in Code.required_files()
     assert Code.require_file(fixture_path("code_sample.exs")) == nil
 
-    Code.unload_files([fixture_path("code_sample.exs")])
-    refute fixture_path("code_sample.exs") in Code.loaded_files()
+    Code.unrequire_files([fixture_path("code_sample.exs")])
+    refute fixture_path("code_sample.exs") in Code.required_files()
     assert Code.require_file(fixture_path("code_sample.exs")) != nil
+  after
+    Code.unrequire_files([fixture_path("code_sample.exs")])
   end
 
   describe "string_to_quoted/2" do

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -409,7 +409,7 @@ defmodule IEx.Helpers do
         [compile_erlang(source) |> elem(0)]
 
       true ->
-        Enum.map(Code.load_file(source), fn {name, _} -> name end)
+        Enum.map(Code.compile_file(source), fn {name, _} -> name end)
     end
   end
 

--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -36,10 +36,9 @@ defmodule Mix.CLI do
   defp load_mix_exs() do
     file = System.get_env("MIX_EXS") || "mix.exs"
 
-    _ =
-      if File.regular?(file) do
-        Code.load_file(file)
-      end
+    if File.regular?(file) do
+      Code.compile_file(file)
+    end
   end
 
   defp get_task(["-" <> _ | _]) do

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -632,7 +632,7 @@ defmodule Mix.Project do
         if File.regular?(file) do
           try do
             Code.compiler_options(relative_paths: false)
-            _ = Code.load_file(file)
+            _ = Code.compile_file(file)
             get()
           else
             ^old_proj -> Mix.raise("Could not find a Mix project at #{file}")

--- a/lib/mix/test/mix/tasks/run_test.exs
+++ b/lib/mix/test/mix/tasks/run_test.exs
@@ -85,7 +85,7 @@ defmodule Mix.Tasks.RunTest do
       File.write!(file, expr)
 
       unload_file = fn ->
-        Code.unload_files([Path.expand(file)])
+        Code.unrequire_files([Path.expand(file)])
       end
 
       Mix.Tasks.Run.run([file])


### PR DESCRIPTION
Currently there is no way to compile a file without leaving
footprints on the system. Plus, the term load_file/2 is very
confusing as loaded is the notation used by modules.

This commit focuses the whole loaded aspect of files exclusively
on require_file/2 (and renames two functions accordingly) and
introduces compile_file/2 which is semantically simpler than
load_file/2.