### PR TITLE
Highlight skipped tests in yellow

### DIFF
--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -55,11 +55,7 @@ defmodule ExUnit.CLIFormatter do
   end
 
   def handle_cast({:test_finished, %ExUnit.Test{state: {:skip, _}} = test}, config) do
-    if config.trace do
-      IO.puts(trace_test_skip(test))
-    else
-      IO.write(skipped("*", config))
-    end
+    if config.trace, do: IO.puts(trace_test_skip(test))
 
     test_counter = update_test_counter(config.test_counter, test)
     config = %{config | test_counter: test_counter, skipped_counter: config.skipped_counter + 1}
@@ -242,7 +238,10 @@ defmodule ExUnit.CLIFormatter do
 
     message =
       "#{test_type_counts}#{config.failure_counter} #{failure_pl}"
-      |> if_true(config.skipped_counter > 0, &(&1 <> ", #{config.skipped_counter} skipped"))
+      |> if_true(
+        config.skipped_counter > 0,
+        &(&1 <> "," <> skipped(" #{config.skipped_counter} skipped", config))
+      )
       |> if_true(config.invalid_counter > 0, &(&1 <> ", #{config.invalid_counter} invalid"))
 
     cond do

--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -55,7 +55,11 @@ defmodule ExUnit.CLIFormatter do
   end
 
   def handle_cast({:test_finished, %ExUnit.Test{state: {:skip, _}} = test}, config) do
-    if config.trace, do: IO.puts(trace_test_skip(test))
+    if config.trace do
+      IO.puts(trace_test_skip(test))
+    else
+      IO.write(skipped("*", config))
+    end
 
     test_counter = update_test_counter(config.test_counter, test)
     config = %{config | test_counter: test_counter, skipped_counter: config.skipped_counter + 1}
@@ -297,6 +301,10 @@ defmodule ExUnit.CLIFormatter do
   end
 
   defp invalid(msg, config) do
+    colorize(:yellow, msg, config)
+  end
+
+  defp skipped(msg, config) do
     colorize(:yellow, msg, config)
   end
 

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -32,7 +32,6 @@ defmodule ExUnit.FormatterTest do
     message
   end
 
-  @tag :skip
   test "formats test case filters" do
     filters = [run: true, slow: false]
     assert format_filters(filters, :include) =~ "Including tags: [run: true, slow: false]"

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -32,6 +32,7 @@ defmodule ExUnit.FormatterTest do
     message
   end
 
+  @tag :skip
   test "formats test case filters" do
     filters = [run: true, slow: false]
     assert format_filters(filters, :include) =~ "Including tags: [run: true, slow: false]"

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -159,19 +159,27 @@ defmodule ExUnitTest do
 
     {result, output} = run_with_filter([exclude: [even: true]], [ParityTest])
     assert result == %{failures: 0, skipped: 1, total: 4}
-    assert output =~ "4 tests, 0 failures, 1 skipped"
+    assert output =~ "4 tests,"
+    assert output =~ "0 failures,"
+    assert output =~ "1 skipped"
 
     {result, output} = run_with_filter([exclude: :even], [ParityTest])
     assert result == %{failures: 0, skipped: 3, total: 4}
-    assert output =~ "4 tests, 0 failures, 3 skipped"
+    assert output =~ "4 tests,"
+    assert output =~ "0 failures,"
+    assert output =~ "3 skipped"
 
     {result, output} = run_with_filter([exclude: :even, include: [even: true]], [ParityTest])
     assert result == %{failures: 1, skipped: 2, total: 4}
-    assert output =~ "4 tests, 1 failure, 2 skipped"
+    assert output =~ "4 tests,"
+    assert output =~ "1 failure,"
+    assert output =~ "2 skipped"
 
     {result, output} = run_with_filter([exclude: :test, include: [even: true]], [ParityTest])
     assert result == %{failures: 1, skipped: 3, total: 4}
-    assert output =~ "4 tests, 1 failure, 3 skipped"
+    assert output =~ "4 tests,"
+    assert output =~ "1 failure,"
+    assert output =~ "3 skipped"
   end
 
   test "log capturing" do
@@ -326,7 +334,35 @@ defmodule ExUnitTest do
         assert ExUnit.run() == %{failures: 0, skipped: 2, total: 2}
       end)
 
-    assert output =~ "2 tests, 0 failures, 2 skipped"
+    assert output =~ "2 tests,"
+    assert output =~ "0 failures,"
+    assert output =~ "2 skipped"
+  end
+
+  test "highlights skipped tests correctly" do
+    defmodule TestSkippedColor do
+      use ExUnit.Case
+
+      setup context do
+        assert context[:not_implemented]
+        :ok
+      end
+
+      @tag :skip
+      test "this will raise", do: raise("oops")
+
+      @tag skip: "won't work"
+      test "this will also raise", do: raise("oops")
+    end
+
+    ExUnit.Server.modules_loaded()
+
+    output =
+      capture_io(fn ->
+        assert ExUnit.run() == %{failures: 0, skipped: 2, total: 2}
+      end)
+
+    assert output =~ "\e[33m 2 skipped\e[0m"
   end
 
   test "filtering cases with :module tag" do
@@ -343,7 +379,10 @@ defmodule ExUnitTest do
     # Empty because it is already loaded
     {result, output} = run_with_filter([exclude: :module], [])
     assert result == %{failures: 0, skipped: 2, total: 2}
-    assert output =~ "2 tests, 0 failures, 2 skipped"
+
+    assert output =~ "2 tests,"
+    assert output =~ "0 failures,"
+    assert output =~ "2 skipped"
 
     {result, output} =
       [exclude: :test, include: [module: "ExUnitTest.SecondTestModule"]]
@@ -351,7 +390,9 @@ defmodule ExUnitTest do
 
     assert result == %{failures: 1, skipped: 1, total: 2}
     assert output =~ "1) test false (ExUnitTest.SecondTestModule)"
-    assert output =~ "2 tests, 1 failure, 1 skipped"
+    assert output =~ "2 tests,"
+    assert output =~ "1 failure,"
+    assert output =~ "1 skipped"
   end
 
   test "raises on reserved tag :file in module" do

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -339,32 +339,6 @@ defmodule ExUnitTest do
     assert output =~ "2 skipped"
   end
 
-  test "highlights skipped tests correctly" do
-    defmodule TestSkippedColor do
-      use ExUnit.Case
-
-      setup context do
-        assert context[:not_implemented]
-        :ok
-      end
-
-      @tag :skip
-      test "this will raise", do: raise("oops")
-
-      @tag skip: "won't work"
-      test "this will also raise", do: raise("oops")
-    end
-
-    ExUnit.Server.modules_loaded()
-
-    output =
-      capture_io(fn ->
-        assert ExUnit.run() == %{failures: 0, skipped: 2, total: 2}
-      end)
-
-    assert output =~ "\e[33m 2 skipped\e[0m"
-  end
-
   test "filtering cases with :module tag" do
     defmodule FirstTestModule do
       use ExUnit.Case


### PR DESCRIPTION
This adds yellow highlighting for skipped tests in the ExUnit CLI output. This way, when folks have skipped tests that were only intended to be temporary, they will have less of a chance of accidentally thinking they're "all green" and pushing broken code (that would also pass automated CI/CD tests and break production, which I _may_ have done last week 😜 ).

Here's what the new output will look like with skipped tests.
![ex_unit_colors](https://user-images.githubusercontent.com/8422484/34906691-75a6f206-f872-11e7-8ec8-fca058810749.png)
