### PR TITLE
Don’t add parens to on_exit/1

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -111,6 +111,7 @@ defmodule Code.Formatter do
     check: 2,
     doctest: 1,
     doctest: 2,
+    on_exit: 1,
     property: 1,
     property: 2,
     refute: 1,


### PR DESCRIPTION
The `on_exit/1` function currently get parentheses when formatting the code. This pull request aims to add it to the locals without parens list.

As this is a function and not a macro, I’m not sure wether it’s intended, so I propose it here in a different pull request.