### PR TITLE
Re-format codebase

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -74,15 +74,16 @@ defmodule Calendar.ISO do
       {2000, 1, 1, 12, 0, 0, {0, 6}}
 
   """
-  @spec naive_datetime_from_iso_days(Calendar.iso_days()) :: {
-          Calendar.year(),
-          Calendar.month(),
-          Calendar.day(),
-          Calendar.hour(),
-          Calendar.minute(),
-          Calendar.second(),
-          Calendar.microsecond()
-        }
+  @spec naive_datetime_from_iso_days(Calendar.iso_days()) ::
+          {
+            Calendar.year(),
+            Calendar.month(),
+            Calendar.day(),
+            Calendar.hour(),
+            Calendar.minute(),
+            Calendar.second(),
+            Calendar.microsecond()
+          }
   @impl true
   def naive_datetime_from_iso_days({days, day_fraction}) do
     {year, month, day} = date_from_iso_days(days)

--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -440,15 +440,14 @@ defmodule DynamicSupervisor do
          :ok <- validate_seconds(max_seconds),
          :ok <- validate_dynamic(max_children),
          :ok <- validate_extra_arguments(extra_arguments) do
-      {:ok,
-       %{
-         state
-         | extra_arguments: extra_arguments,
-           max_children: max_children,
-           max_restarts: max_restarts,
-           max_seconds: max_seconds,
-           strategy: strategy
-       }}
+      {:ok, %{
+        state
+        | extra_arguments: extra_arguments,
+          max_children: max_children,
+          max_restarts: max_restarts,
+          max_seconds: max_seconds,
+          strategy: strategy
+      }}
     end
   end
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3134,9 +3134,10 @@ defmodule Kernel do
     fun = fn {x, pos}, acc ->
       case x do
         {op, _, [_]} when op == :+ or op == :- ->
-          message =
-            <<"piping into a unary operator is deprecated, please use the ",
-              "qualified name. For example, Kernel.+(5), instead of +5">>
+          message = <<
+            "piping into a unary operator is deprecated, please use the ",
+            "qualified name. For example, Kernel.+(5), instead of +5"
+          >>
 
           :elixir_errors.warn(__CALLER__.line, __CALLER__.file, message)
 

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -751,11 +751,13 @@ defmodule Kernel.Typespec do
     typespec_to_ast({:type, line, :charlist, []})
   end
 
-  defp typespec_to_ast({
-         :remote_type,
-         line,
-         [{:atom, _, :elixir}, {:atom, _, :nonempty_charlist}, []]
-       }) do
+  defp typespec_to_ast(
+         {
+           :remote_type,
+           line,
+           [{:atom, _, :elixir}, {:atom, _, :nonempty_charlist}, []]
+         }
+       ) do
     typespec_to_ast({:type, line, :nonempty_charlist, []})
   end
 

--- a/lib/elixir/test/elixir/dynamic_supervisor_test.exs
+++ b/lib/elixir/test/elixir/dynamic_supervisor_test.exs
@@ -40,14 +40,13 @@ defmodule DynamicSupervisorTest do
   describe "init/1" do
     test "set default options" do
       assert DynamicSupervisor.init(strategy: :one_for_one) ==
-               {:ok,
-                %{
-                  strategy: :one_for_one,
-                  intensity: 3,
-                  period: 5,
-                  max_children: :infinity,
-                  extra_arguments: []
-                }}
+               {:ok, %{
+                 strategy: :one_for_one,
+                 intensity: 3,
+                 period: 5,
+                 max_children: :infinity,
+                 extra_arguments: []
+               }}
     end
   end
 

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -275,10 +275,11 @@ defmodule ExceptionTest do
     {:error, reason} = __MODULE__.Sup.start_link(fn -> return end)
     assert Exception.format_exit(reason) =~ "bad child specification, invalid restart type: :foo"
 
-    return = {
-      :ok,
-      {{:one_for_one, 1, 1}, [{:child, {:m, :f, []}, :temporary, :foo, :worker, []}]}
-    }
+    return =
+      {
+        :ok,
+        {{:one_for_one, 1, 1}, [{:child, {:m, :f, []}, :temporary, :foo, :worker, []}]}
+      }
 
     {:error, reason} = __MODULE__.Sup.start_link(fn -> return end)
     assert Exception.format_exit(reason) =~ "bad child specification, invalid shutdown: :foo"
@@ -291,47 +292,51 @@ defmodule ExceptionTest do
     {:error, reason} = __MODULE__.Sup.start_link(fn -> return end)
     assert Exception.format_exit(reason) =~ "bad child specification, invalid modules: :foo"
 
-    return = {
-      :ok,
-      {{:one_for_one, 1, 1}, [{:child, {:m, :f, []}, :temporary, 1, :worker, [{:foo}]}]}
-    }
+    return =
+      {
+        :ok,
+        {{:one_for_one, 1, 1}, [{:child, {:m, :f, []}, :temporary, 1, :worker, [{:foo}]}]}
+      }
 
     {:error, reason} = __MODULE__.Sup.start_link(fn -> return end)
     assert Exception.format_exit(reason) =~ "bad child specification, invalid module: {:foo}"
 
-    return = {
-      :ok,
+    return =
       {
-        {:one_for_one, 1, 1},
-        [
-          {:child, {:m, :f, []}, :permanent, 1, :worker, []},
-          {:child, {:m, :f, []}, :permanent, 1, :worker, []}
-        ]
+        :ok,
+        {
+          {:one_for_one, 1, 1},
+          [
+            {:child, {:m, :f, []}, :permanent, 1, :worker, []},
+            {:child, {:m, :f, []}, :permanent, 1, :worker, []}
+          ]
+        }
       }
-    }
 
     {:error, reason} = __MODULE__.Sup.start_link(fn -> return end)
 
     assert Exception.format_exit(reason) =~
              "bad child specification, more than one child specification has the id: :child"
 
-    return = {
-      :ok,
-      {{:one_for_one, 1, 1}, [{:child, {Kernel, :exit, [:foo]}, :temporary, 1, :worker, []}]}
-    }
+    return =
+      {
+        :ok,
+        {{:one_for_one, 1, 1}, [{:child, {Kernel, :exit, [:foo]}, :temporary, 1, :worker, []}]}
+      }
 
     {:error, reason} = __MODULE__.Sup.start_link(fn -> return end)
 
     assert Exception.format_exit(reason) ==
              "shutdown: failed to start child: :child\n    ** (EXIT) :foo"
 
-    return = {
-      :ok,
+    return =
       {
-        {:one_for_one, 1, 1},
-        [{:child, {Kernel, :apply, [fn -> {:error, :foo} end, []]}, :temporary, 1, :worker, []}]
+        :ok,
+        {
+          {:one_for_one, 1, 1},
+          [{:child, {Kernel, :apply, [fn -> {:error, :foo} end, []]}, :temporary, 1, :worker, []}]
+        }
       }
-    }
 
     {:error, reason} = __MODULE__.Sup.start_link(fn -> return end)
 

--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -76,10 +76,15 @@ defmodule Logger.Translator do
     end
   end
 
-  def translate(_min_level, :info, :report, {
-        :std_info,
-        [application: app, exited: reason, type: _type]
-      }) do
+  def translate(
+        _min_level,
+        :info,
+        :report,
+        {
+          :std_info,
+          [application: app, exited: reason, type: _type]
+        }
+      ) do
     {:ok, "Application #{app} exited: #{Application.format_error(reason)}"}
   end
 

--- a/lib/mix/test/mix/tasks/app.start_test.exs
+++ b/lib/mix/test/mix/tasks/app.start_test.exs
@@ -66,11 +66,13 @@ defmodule Mix.Tasks.App.StartTest do
       Mix.Tasks.Compile.run([])
       Mix.Tasks.App.Start.run([])
 
-      assert_received {:mix_shell, :error,
-                       ["You have configured application :app_unknown_sample" <> _]}
+      assert_received {:mix_shell, :error, [
+                        "You have configured application :app_unknown_sample" <> _
+                      ]}
 
-      refute_received {:mix_shell, :error,
-                       ["You have configured application :app_loaded_sample" <> _]}
+      refute_received {:mix_shell, :error, [
+                        "You have configured application :app_loaded_sample" <> _
+                      ]}
     end
   end
 

--- a/lib/mix/test/mix/umbrella_test.exs
+++ b/lib/mix/test/mix/umbrella_test.exs
@@ -12,8 +12,9 @@ defmodule Mix.UmbrellaTest do
       Mix.Project.in_project(:umbrella, ".", fn _ ->
         assert Mix.Project.apps_paths() == %{bar: "apps/bar", foo: "apps/foo"}
 
-        assert_received {:mix_shell, :error,
-                         ["warning: path \"apps/dont_error_on_missing_mixfile\"" <> _]}
+        assert_received {:mix_shell, :error, [
+                          "warning: path \"apps/dont_error_on_missing_mixfile\"" <> _
+                        ]}
 
         refute_received {:mix_shell, :error, ["warning: path \"apps/dont_error_on_files\"" <> _]}
       end)
@@ -218,8 +219,9 @@ defmodule Mix.UmbrellaTest do
 
         assert_received {:mix_shell, :error, ["Dependencies have diverged:"]}
 
-        assert_received {:mix_shell, :error,
-                         ["  the dependency foo in mix.exs is overriding a child" <> _]}
+        assert_received {:mix_shell, :error, [
+                          "  the dependency foo in mix.exs is overriding a child" <> _
+                        ]}
       end)
     end
   end


### PR DESCRIPTION
I noticed yesterday while working on a different PR that when I ran
`mix format` on the Elixir codebase from the root directly, there were
changes that I didn't expect to see. I'm not sure how these snuck by
(maybe they came as a result of some recent updates to the formatter?),
but on my machine they are consistently applied by the formatter after
updating from the current master branch.

I was especially surprised to see this since the formating is checked
in CI, right? Wouldn't these changes being outstanding cause CI to
fail? Maybe there's some bug hidden in there that's giving false
positives in CI?