### PR TITLE
Add documentation for string keys in Keyword's colon syntax

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -20,12 +20,13 @@ defmodule Keyword do
       iex> [{:active, :once}]
       [active: :once]
 
-  The two syntaxes are completely equivalent. 
-  
-  Using the colon syntax will automatically convert string keys to atoms:
+  The two syntaxes are completely equivalent. When using the colon syntax,
+  the key is always an atom, even when wrapped in quotes:
   
       iex> ["exit_on_close": true]
       [exit_on_close: true]
+  
+  This mirrors the quoted atom syntax such as `:"exit_on_close"`.
   
   Note that when keyword lists are passed as the last argument to a function,
   if the short-hand syntax is used then the square brackets around the keyword list

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -20,10 +20,16 @@ defmodule Keyword do
       iex> [{:active, :once}]
       [active: :once]
 
-  The two syntaxes are completely equivalent. Note that when keyword
-  lists are passed as the last argument to a function, if the short-hand
-  syntax is used then the square brackets around the keyword list can
-  be omitted as well. For example, the following:
+  The two syntaxes are completely equivalent. 
+  
+  Using the colon syntax will automatically convert string keys to atoms:
+  
+      iex> ["exit_on_close": true]
+      [exit_on_close: true]
+  
+  Note that when keyword lists are passed as the last argument to a function,
+  if the short-hand syntax is used then the square brackets around the keyword list
+  can be omitted as well. For example, the following:
 
       String.split("1-0", "-", trim: true, parts: 2)
 


### PR DESCRIPTION
Following ex_doc's [#821](https://github.com/elixir-lang/ex_doc/pull/821) discussion...

This is the example provided in [`Keyword`](https://hexdocs.pm/elixir/Keyword.html) docs:

```ex
iex> [{:exit_on_close, true}]
[exit_on_close: true]
```

And because below, `elem(0)` is a string, it is not a `Keyword`. So it remains a list of tuples:

```ex
iex> [{"exit_on_close", true}]
[{"exit_on_close", true}]
```

But the code below, which is currently not documented, is actually a valid keyword syntax, and the string key automatically gets converted to an atom:

```ex
iex> ["key": "value"]
[key: "value"]
```

So I thought it would be nice to document this in the docs. :heart: