### PR TITLE
Updated Guards.md to for clairty on boolean ops

### DIFF
--- a/lib/elixir/pages/Guards.md
+++ b/lib/elixir/pages/Guards.md
@@ -7,7 +7,9 @@ Guards are a way to augment pattern matching with more complex checks; they are 
 For reference, the following is a comprehensive list of all expressions allowed in guards:
 
   * comparison operators (`==`, `!=`, `===`, `!==`, `>`, `>=`, `<`, `<=`)
-  * strictly boolean operators (`and`, `or`, `not`) (the `&&`, `||`, and `!` sibling operators are not allowed as they're not *strictly* boolean - meaning they don't require both sides to be booleans)
+  * strictly boolean operators (`and`, `or`, `not`) 
+    - __NOTE__: `&&`, `||`, and `!` sibling operators are not allowed as they're not 
+    *strictly* boolean - meaning they don't require both sides to be booleans
   * arithmetic binary operators (`+`, `-`, `*`, `/`)
   * arithmetic unary operators (`+`, `-`)
   * binary concatenation operator (`<>`)


### PR DESCRIPTION
Updated Guards.md to be more clear in regard to allowed ops in guard clauses.

I found myself doing a double take on the docs today. The sentence about what boolean ops are not allowed can ran together with the allowed ops.