### PR TITLE
Allow Enum.zip/1 and Stream.zip/1 to work on Streams

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2734,11 +2734,15 @@ defmodule Enum do
       [{1, :a}, {2, :b}, {3, :c}]
 
   """
-  @spec zip([t]) :: t
+  @spec zip([t] | %Stream{}) :: t
 
   def zip([]), do: []
 
-  def zip(enumerables) when is_list(enumerables) do
+  def zip(%Stream{} = enumerables), do: do_zip(enumerables)
+
+  def zip(enumerables) when is_list(enumerables), do: do_zip(enumerables)
+
+  defp do_zip(enumerables) do
     Stream.zip(enumerables).({:cont, []}, &{:cont, [&1 | &2]})
     |> elem(1)
     |> :lists.reverse()

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1106,8 +1106,12 @@ defmodule Stream do
       [{1, :a, "foo"}, {2, :b, "bar"}, {3, :c, "baz"}]
 
   """
-  @spec zip([Enumerable.t()]) :: Enumerable.t()
-  def zip(enumerables) when is_list(enumerables) do
+  @spec zip([Enumerable.t()] | %Stream{}) :: Enumerable.t()
+  def zip(%Stream{} = enumerables), do: zip_fun(enumerables)
+
+  def zip(enumerables) when is_list(enumerables), do: zip_fun(enumerables)
+
+  defp zip_fun(enumerables) do
     step = &do_zip_step(&1, &2)
 
     enum_funs =

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -1084,6 +1084,10 @@ defmodule StreamTest do
     assert Stream.zip([concat, cycle]) |> Enum.to_list() ==
              [{1, :a}, {2, :b}, {3, :c}, {4, :a}, {5, :b}, {6, :c}]
 
+    assert Stream.chunk_every([0, 1, 2, 3], 2)
+           |> Stream.zip()
+           |> Enum.to_list() == [{0, 2}, {1, 3}]
+
     assert_raise FunctionClauseError, fn ->
       enum_of_enums = Stream.cycle([[1, 2], [:a, :b]])
       Stream.zip(enum_of_enums)


### PR DESCRIPTION
Before `v1.6.0` the following code worked:

```
 iex(1)> Stream.chunk([0, 1, 2, 3], 2) |> Stream.zip() |> Enum.to_list()
[{0, 2}, {1, 3}]
```
However, we now get an error in versions >=`1.6.0`:

```
iex(1)> Stream.chunk([0, 1, 2, 3], 2) |> Stream.zip() |> Enum.to_list()

** (FunctionClauseError) no function clause matching in Stream.zip/1

    The following arguments were given to Stream.zip/1:

        # 1
        #Stream<[
          enum: [0, 1, 2, 3],
          funs: [#Function<3.91433161/1 in Stream.chunk_while/4>]
        ]>

    (elixir) lib/stream.ex:1110: Stream.zip/1
```
This happens with `Enum.zip/1` as well.

It looks like the behaviour of the `zip/1` function was changed in https://github.com/elixir-lang/elixir/pull/6322. 

If this is not the intended behaviour then this PR will allow the pre-`v1.6.0` code to work again. Otherwise, I'm happy to close this PR and update the documentation to state that `zip/1` can only work with lists of enumerables and not streams.