### PR TITLE
Update Tuple doc to express it's a composite type

### DIFF
--- a/lib/elixir/lib/tuple.ex
+++ b/lib/elixir/lib/tuple.ex
@@ -2,9 +2,9 @@ defmodule Tuple do
   @moduledoc """
   Functions for working with tuples.
 
-  Tuples are ordered collections of elements. Tuples can contain elements
-  of any type, and a tuple can contain elements of different types. Curly
-  braces can be used to create tuples:
+  Tuples are composite data types with a fixed number of elements. Tuples
+  can contain elements of any type, and a tuple can contain elements of
+  different types. Curly braces can be used to create tuples:
 
       iex> {}
       {}


### PR DESCRIPTION
Tuples were not included into the new "Collections & Enumerables" group, but the first paragraph of the `Tuple` documentation says: `Tuples are ordered collections of elements`.

This pull-request edits the documentation to reflect that tuples are composite data types. This should avoid any confusion about why tuples were not included in the "Collections & Enumerables" group.

These changes were previously suggested [here](https://github.com/elixir-lang/elixir/pull/7185#discussion_r160052646).