### PR TITLE
Add @since attributes for behavior introduced in 1.5

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -229,6 +229,7 @@ defmodule Calendar do
   between them. If they are compatible, this means that we can also convert
   dates as well as naive datetimes between them.
   """
+  @since "1.5.0"
   @spec compatible_calendars?(Calendar.calendar(), Calendar.calendar()) :: boolean
   def compatible_calendars?(calendar, calendar), do: true
 

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -87,6 +87,7 @@ defmodule Date do
       -366
   """
 
+  @since "1.5.0"
   @spec range(Date.t(), Date.t()) :: Date.Range.t()
   def range(%Date{calendar: calendar} = first, %Date{calendar: calendar} = last) do
     {first_days, _} = to_iso_days(first)
@@ -444,6 +445,7 @@ defmodule Date do
       {:ok, %Date{calendar: Calendar.Holocene, year: 12000, month: 1, day: 1}}
 
   """
+  @since "1.5.0"
   @spec convert(Calendar.date(), Calendar.calendar()) ::
           {:ok, t} | {:error, :incompatible_calendars}
   def convert(%{calendar: calendar, year: year, month: month, day: day}, calendar) do
@@ -477,6 +479,7 @@ defmodule Date do
       %Date{calendar: Calendar.Holocene, year: 12000, month: 1, day: 1}
 
   """
+  @since "1.5.0"
   @spec convert!(Calendar.date(), Calendar.calendar()) :: t
   def convert!(date, calendar) do
     case convert(date, calendar) do
@@ -507,6 +510,7 @@ defmodule Date do
       ~D[2000-01-03]
 
   """
+  @since "1.5.0"
   @spec add(Calendar.date(), integer()) :: t
   def add(%{calendar: calendar} = date, days) do
     {iso_days, fraction} = to_iso_days(date)
@@ -531,6 +535,7 @@ defmodule Date do
       -2
 
   """
+  @since "1.5.0"
   @spec diff(Calendar.date(), Calendar.date()) :: integer
   def diff(%{calendar: Calendar.ISO} = date1, %{calendar: Calendar.ISO} = date2) do
     %{year: year1, month: month1, day: day1} = date1

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -677,6 +677,7 @@ defmodule DateTime do
       -18000
 
   """
+  @since "1.5.0"
   @spec diff(Calendar.datetime(), Calendar.datetime()) :: integer()
   def diff(
         %{utc_offset: utc_offset1, std_offset: std_offset1} = datetime1,
@@ -744,6 +745,7 @@ defmodule DateTime do
                       zone_abbr: "AMT"}}
 
   """
+  @since "1.5.0"
   @spec convert(Calendar.datetime(), Calendar.calendar()) ::
           {:ok, t} | {:error, :incompatible_calendars}
 
@@ -818,6 +820,7 @@ defmodule DateTime do
                 zone_abbr: "AMT"}
 
   """
+  @since "1.5.0"
   @spec convert!(Calendar.datetime(), Calendar.calendar()) :: t | no_return
   def convert!(datetime, calendar) do
     case convert(datetime, calendar) do

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -48,6 +48,7 @@ defmodule Calendar.ISO do
 
   """
   @impl true
+  @since "1.5.0"
   @spec naive_datetime_to_iso_days(
           Calendar.year(),
           Calendar.month(),
@@ -84,6 +85,7 @@ defmodule Calendar.ISO do
           Calendar.microsecond()
         }
   @impl true
+  @since "1.5.0"
   def naive_datetime_from_iso_days({days, day_fraction}) do
     {year, month, day} = date_from_iso_days(days)
     {hour, minute, second, microsecond} = time_from_day_fraction(day_fraction)
@@ -102,6 +104,7 @@ defmodule Calendar.ISO do
 
   """
   @impl true
+  @since "1.5.0"
   @spec time_to_day_fraction(
           Calendar.hour(),
           Calendar.minute(),
@@ -129,6 +132,7 @@ defmodule Calendar.ISO do
 
   """
   @impl true
+  @since "1.5.0"
   @spec time_from_day_fraction(Calendar.day_fraction()) ::
           {Calendar.hour(), Calendar.minute(), Calendar.second(), Calendar.microsecond()}
   def time_from_day_fraction({parts_in_day, parts_per_day}) do
@@ -146,6 +150,7 @@ defmodule Calendar.ISO do
 
   # Converts year, month, day to count of days since 0000-01-01.
   @doc false
+  @since "1.5.0"
   def date_to_iso_days(0, 1, 1) do
     0
   end
@@ -163,6 +168,7 @@ defmodule Calendar.ISO do
 
   # Converts count of days since 0000-01-01 to {year, month, day} tuple.
   @doc false
+  @since "1.5.0"
   def date_from_iso_days(days) when days in 0..3_652_424 do
     {year, day_of_year} = days_to_year(days)
     extra_day = if leap_year?(year), do: 1, else: 0
@@ -330,17 +336,20 @@ defmodule Calendar.ISO do
   end
 
   @impl true
+  @since "1.5.0"
   def valid_date?(year, month, day) do
     month in 1..12 and year in 0..9999 and day in 1..days_in_month(year, month)
   end
 
   @impl true
+  @since "1.5.0"
   def valid_time?(hour, minute, second, {microsecond, precision}) do
     hour in 0..23 and minute in 0..59 and second in 0..60 and microsecond in 0..999_999 and
       precision in 0..6
   end
 
   @impl true
+  @since "1.5.0"
   def day_rollover_relative_to_midnight_utc() do
     {0, 1}
   end
@@ -404,6 +413,7 @@ defmodule Calendar.ISO do
     do: precision_for_unit(div(number, 10), precision + 1)
 
   @doc false
+  @since "1.5.0"
   def date_to_iso8601(year, month, day, format \\ :extended) do
     date_to_string(year, month, day, format)
   end
@@ -508,6 +518,7 @@ defmodule Calendar.ISO do
   end
 
   @doc false
+  @since "1.5.0"
   def iso_days_to_unit({days, {parts, ppd}}, unit) do
     day_microseconds = days * @parts_per_day
     microseconds = div(parts * @parts_per_day, ppd)
@@ -515,6 +526,7 @@ defmodule Calendar.ISO do
   end
 
   @doc false
+  @since "1.5.0"
   def add_day_fraction_to_iso_days({days, {parts, ppd}}, add, ppd) do
     normalize_iso_days(days, parts + add, ppd)
   end

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -721,6 +721,7 @@ defmodule NaiveDateTime do
                            hour: 13, minute: 30, second: 15, microsecond: {0, 0}}}
 
   """
+  @since "1.5.0"
   @spec convert(Calendar.naive_datetime(), Calendar.calendar()) ::
           {:ok, t} | {:error, :incompatible_calendars}
 
@@ -782,6 +783,7 @@ defmodule NaiveDateTime do
                      hour: 13, minute: 30, second: 15, microsecond: {0, 0}}
 
   """
+  @since "1.5.0"
   @spec convert!(Calendar.naive_datetime(), Calendar.calendar()) :: t
   def convert!(naive_datetime, calendar) do
     case convert(naive_datetime, calendar) do

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -472,6 +472,7 @@ defmodule Time do
       {:ok, %Time{calendar: Calendar.Holocene, hour: 13, minute: 30, second: 15, microsecond: {0, 0}}}
 
   """
+  @since "1.5.0"
   @spec convert(Calendar.time(), Calendar.calendar()) :: {:ok, t} | {:error, atom}
 
   # Keep it multiline for proper function clause errors.
@@ -527,6 +528,7 @@ defmodule Time do
       %Time{calendar: Calendar.Holocene, hour: 13, minute: 30, second: 15, microsecond: {0, 0}}
 
   """
+  @since "1.5.0"
   @spec convert!(Calendar.time(), Calendar.calendar()) :: t
   def convert!(time, calendar) do
     case convert(time, calendar) do
@@ -577,6 +579,7 @@ defmodule Time do
       -2_000_000
 
   """
+  @since "1.5.0"
   @spec diff(Calendar.time(), Calendar.time(), System.time_unit()) :: integer
   def diff(time1, time2, unit \\ :second) do
     fraction1 = to_day_fraction(time1)

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -379,6 +379,7 @@ defmodule Enum do
   @doc """
   Shortcut to `chunk_every(enumerable, count, count)`.
   """
+  @since "1.5.0"
   @spec chunk_every(t, pos_integer) :: [list]
   def chunk_every(enumerable, count), do: chunk_every(enumerable, count, count, [])
 
@@ -418,6 +419,7 @@ defmodule Enum do
       [[1, 2], [4, 5]]
 
   """
+  @since "1.5.0"
   @spec chunk_every(t, pos_integer, pos_integer, t | :discard) :: [list]
   def chunk_every(enumerable, count, step, leftover \\ [])
       when is_integer(count) and count > 0 and is_integer(step) and step > 0 do
@@ -454,6 +456,7 @@ defmodule Enum do
       [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]
 
   """
+  @since "1.5.0"
   @spec chunk_while(
           t,
           acc,

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -177,6 +177,7 @@ defmodule Exception do
   If the exception module implements the optional `c:blame/2`
   callbak, it will be invoked to perform the computation.
   """
+  @since "1.5.0"
   @spec blame(:error, any, stacktrace) :: {t, stacktrace}
   @spec blame(non_error_kind, payload, stacktrace) :: {payload, stacktrace} when payload: var
   def blame(kind, error, stacktrace)
@@ -209,6 +210,7 @@ defmodule Exception do
   Note this functionality requires Erlang/OTP 20, otherwise `:error`
   is always returned.
   """
+  @since "1.5.0"
   @spec blame_mfa(module, function, args :: [term]) ::
           {:ok, :def | :defp | :defmacro | :defmacrop, [{args :: [term], guards :: [term]}]}
           | :error

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -428,6 +428,7 @@ defmodule File do
     * `:enotsup` - symbolic links are not supported on the current platform
 
   """
+  @since "1.5.0"
   @spec read_link(Path.t()) :: {:ok, binary} | {:error, posix}
   def read_link(path) do
     case path |> IO.chardata_to_string() |> :file.read_link() do
@@ -440,6 +441,7 @@ defmodule File do
   Same as `read_link/1` but returns the target directly or throws `File.Error` if an error is
   returned.
   """
+  @since "1.5.0"
   @spec read_link!(Path.t()) :: binary | no_return
   def read_link!(path) do
     case read_link(path) do
@@ -525,6 +527,7 @@ defmodule File do
   If the operating system does not support hard links, returns
   `{:error, :enotsup}`.
   """
+  @since "1.5.0"
   def ln(existing, new) do
     :file.make_link(IO.chardata_to_string(existing), IO.chardata_to_string(new))
   end
@@ -534,6 +537,7 @@ defmodule File do
 
   Returns `:ok` otherwise
   """
+  @since "1.5.0"
   def ln!(existing, new) do
     case ln(existing, new) do
       :ok ->
@@ -555,6 +559,7 @@ defmodule File do
   If the operating system does not support symlinks, returns
   `{:error, :enotsup}`.
   """
+  @since "1.5.0"
   def ln_s(existing, new) do
     :file.make_symlink(IO.chardata_to_string(existing), IO.chardata_to_string(new))
   end

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -387,6 +387,7 @@ defmodule Integer do
       0
 
   """
+  @since "1.5.0"
   @spec gcd(0, 0) :: 0
   @spec gcd(integer, integer) :: pos_integer
   def gcd(integer1, integer2) when is_integer(integer1) and is_integer(integer2) do

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -627,6 +627,7 @@ defmodule Keyword do
       ** (KeyError) key :b not found in: [a: 1]
 
   """
+  @since "1.5.0"
   @spec replace!(t, key, value) :: t
   def replace!(keywords, key, value) when is_list(keywords) and is_atom(key) do
     case :lists.keyfind(key, 1, keywords) do

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -676,6 +676,7 @@ defmodule List do
       false
 
   """
+  @since "1.5.0"
   @spec starts_with?(list, list) :: boolean
   @spec starts_with?(list, []) :: true
   @spec starts_with?([], nonempty_list) :: false

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -197,6 +197,7 @@ defmodule Macro do
       [{:var1, [], __MODULE__}, {:var2, [], __MODULE__}]
 
   """
+  @since "1.5.0"
   def generate_arguments(0, _), do: []
 
   def generate_arguments(amount, context)

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -312,6 +312,7 @@ defmodule Map do
 
   Inlined by the compiler.
   """
+  @since "1.5.0"
   @spec replace!(map, key, value) :: map
   def replace!(map, key, value) do
     :maps.update(key, value, map)

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -754,6 +754,7 @@ defmodule Registry do
       iex> Registry.lookup(Registry.DuplicateUnregisterMatchTest, "hello")
       [{self(), :world_b}, {self(), :world_c}]
   """
+  @since "1.5.0"
   def unregister_match(registry, key, pattern, guards \\ []) when is_list(guards) do
     self = self()
 

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -137,6 +137,7 @@ defmodule Stream do
   @doc """
   Shortcut to `chunk_every(enum, count, count)`.
   """
+  @since "1.5.0"
   @spec chunk_every(Enumerable.t(), pos_integer) :: Enumerable.t()
   def chunk_every(enum, count), do: chunk_every(enum, count, count, [])
 
@@ -170,6 +171,7 @@ defmodule Stream do
       [[1, 2, 3], [4, 5, 6]]
 
   """
+  @since "1.5.0"
   @spec chunk_every(Enumerable.t(), pos_integer, pos_integer, Enumerable.t() | :discard) ::
           Enumerable.t()
   def chunk_every(enum, count, step, leftover \\ [])
@@ -223,6 +225,7 @@ defmodule Stream do
       [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]
 
   """
+  @since "1.5.0"
   @spec chunk_while(
           Enumerable.t(),
           acc,

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -607,6 +607,7 @@ defmodule Supervisor do
   description of the available strategies.
   """
   # TODO: Warn if simple_one_for_one strategy is used on Elixir v1.8.
+  @since "1.5.0"
   @spec init([:supervisor.child_spec() | {module, term} | module], [init_option]) :: {:ok, tuple}
   def init(children, options) when is_list(children) and is_list(options) do
     unless strategy = options[:strategy] do

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -514,6 +514,7 @@ defmodule System do
       System.stop(1)
 
   """
+  @since "1.5.0"
   @spec stop(non_neg_integer | binary) :: no_return
   def stop(status \\ 0)
 

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -274,6 +274,7 @@ defmodule ExUnit.Callbacks do
   This function returns `{:ok, pid}` in case of success, otherwise it
   returns `{:error, reason}`.
   """
+  @since "1.5.0"
   @spec start_supervised(Supervisor.child_spec() | module | {module, term}, keyword) ::
           Supervisor.on_start_child()
   def start_supervised(child_spec_or_module, opts \\ []) do
@@ -329,6 +330,7 @@ defmodule ExUnit.Callbacks do
   It returns `:ok` if there is a supervised process with such
   `id`, `{:error, :not_found}` otherwise.
   """
+  @since "1.5.0"
   @spec stop_supervised(id :: term()) :: :ok | {:error, :not_found}
   def stop_supervised(id) do
     case ExUnit.OnExitHandler.get_supervisor(self()) do

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -546,6 +546,7 @@ defmodule IEx do
   @doc """
   Macro-based shortcut for `IEx.break!/4`.
   """
+  @since "1.5.0"
   defmacro break!(ast, stops \\ 1) do
     quote do
       IEx.__break__!(unquote(Macro.escape(ast)), unquote(Macro.escape(stops)), __ENV__)
@@ -724,6 +725,7 @@ defmodule IEx do
       iex -S mix test path/to/file:line --trace
 
   """
+  @since "1.5.0"
   def break!(module, function, arity, stops \\ 1) when is_integer(arity) do
     IEx.Pry.break!(module, function, arity, quote(do: _), stops)
   end

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -477,6 +477,7 @@ defmodule IEx.Helpers do
   Prints vm/runtime information such as versions, memory usage and statistics.
   Additional topics are available via `runtime_info/1`.
   """
+  @since "1.5.0"
   def runtime_info(), do: runtime_info([:system, :memory, :limits])
 
   @doc """
@@ -655,6 +656,7 @@ defmodule IEx.Helpers do
   @doc """
   Prints a list of all the functions and macros exported by the given module.
   """
+  @since "1.5.0"
   def exports(module \\ Kernel) do
     exports = IEx.Autocomplete.exports(module)
 
@@ -775,6 +777,7 @@ defmodule IEx.Helpers do
   control of the shell. If you would rather start a new shell,
   use `respawn/0` instead.
   """
+  @since "1.5.0"
   def continue do
     if whereis = IEx.Server.whereis() do
       send(whereis, {:continue, self()})
@@ -786,6 +789,7 @@ defmodule IEx.Helpers do
   @doc """
   Macro-based shortcut for `IEx.break!/4`.
   """
+  @since "1.5.0"
   defmacro break!(ast, stops \\ 1) do
     quote do
       require IEx
@@ -800,11 +804,13 @@ defmodule IEx.Helpers do
   See `IEx.break!/4` for a complete description of breakpoints
   in IEx.
   """
+  @since "1.5.0"
   defdelegate break!(module, function, arity, stops \\ 1), to: IEx
 
   @doc """
   Prints all breakpoints to the terminal.
   """
+  @since "1.5.0"
   def breaks do
     breaks(IEx.Pry.breaks())
   end
@@ -876,6 +882,7 @@ defmodule IEx.Helpers do
   like to effectively remove all breakpoints and instrumentation
   code from a module, use `remove_breaks/1` instead.
   """
+  @since "1.5.0"
   defdelegate reset_break(id), to: IEx.Pry
 
   @doc """
@@ -890,16 +897,19 @@ defmodule IEx.Helpers do
   like to effectively remove all breakpoints and instrumentation
   code from a module, use `remove_breaks/1` instead.
   """
+  @since "1.5.0"
   defdelegate reset_break(module, function, arity), to: IEx.Pry
 
   @doc """
   Removes all breakpoints and instrumentation from `module`.
   """
+  @since "1.5.0"
   defdelegate remove_breaks(module), to: IEx.Pry
 
   @doc """
   Removes all breakpoints and instrumentation from all modules.
   """
+  @since "1.5.0"
   defdelegate remove_breaks(), to: IEx.Pry
 
   @doc """
@@ -926,6 +936,7 @@ defmodule IEx.Helpers do
   Keep in mind the `whereami/1` location may not exist when prying
   precompiled source code, such as Elixir itself.
   """
+  @since "1.5.0"
   def whereami(radius \\ 2) do
     case Process.get(:iex_whereami) do
       {file, line, stacktrace} ->


### PR DESCRIPTION
I saw [here](https://github.com/elixir-lang/elixir/blob/b9591267dc87f79178a9eba435d4765ed745f55b/lib/elixir/lib/code.ex#L43) that `@since` attributes are being added for new behavior in 1.7, and I
thought it might be helpful to go through the recent changelogs and add
those attributes for some newly introduced functions and macros. My
initial thought was to go back and add them through 1.4, but if it's
helpful to go further back then I'd be happy to do that as well.

Or, if you only want to have these attributes starting with 1.7 that's
cool too!