### PR TITLE
Reorder keyword blocks in Macro.to_string

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -745,7 +745,7 @@ defmodule Macro do
   end
 
   # Block keywords
-  kw_keywords = [:do, :catch, :rescue, :after, :else]
+  kw_keywords = [:do, :rescue, :catch, :else, :after]
 
   defp kw_blocks?([{:do, _} | _] = kw) do
     Enum.all?(kw, &match?({x, _} when x in unquote(kw_keywords), &1))

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -412,6 +412,45 @@ defmodule MacroTest do
       assert Macro.to_string(quoted) <> "\n" == expected
     end
 
+    test "try" do
+      quoted =
+        quote do
+          try do
+            foo
+          catch
+            _, _ ->
+              2
+          rescue
+            ArgumentError ->
+              1
+          after
+            4
+          else
+            _ ->
+              3
+          end
+        end
+
+      expected = """
+      try() do
+        foo
+      rescue
+        ArgumentError ->
+          1
+      catch
+        _, _ ->
+          2
+      else
+        _ ->
+          3
+      after
+        4
+      end
+      """
+
+      assert Macro.to_string(quoted) <> "\n" == expected
+    end
+
     test "fn" do
       assert Macro.to_string(quote(do: fn -> 1 + 2 end)) == "fn -> 1 + 2 end"
       assert Macro.to_string(quote(do: fn x -> x + 1 end)) == "fn x -> x + 1 end"


### PR DESCRIPTION
Currently modules created with `Macro.to_string` will warn if rescue and catch because of the ordering. As we now get warnings if `catch` is before `rescue` I have changed the order to be more idiomatic.