### PR TITLE
Add :apply option to IO.inspect/3

### DIFF
--- a/lib/elixir/test/elixir/io_test.exs
+++ b/lib/elixir/test/elixir/io_test.exs
@@ -184,5 +184,9 @@ defmodule IOTest do
     assert capture_io(fn -> IO.inspect(1) end) == "1\n"
     assert capture_io(fn -> IO.inspect(1, label: "foo") end) == "foo: 1\n"
     assert capture_io(fn -> IO.inspect(1, label: :foo) end) == "foo: 1\n"
+
+    assert capture_io(fn ->
+      assert IO.inspect([], apply: &length/1) == []
+    end) == "0\n"
   end
 end


### PR DESCRIPTION
This is an attempt to build functionality of IO.inspect/3 that was mentioned in the proposal here: https://groups.google.com/forum/#!topic/elixir-lang-core/TUkmNHI4IbI

The goal is to make something like this...

```elixir
["thing1", "thing2"]
|> generate_more_things()
|> (fn things ->
  things |> length() |> IO.inspect()
  things
end).()
|> do_something_with_things()
```

simpler to write, with something like this...

```elixir
["thing1", "thing2"]
|> generate_more_things()
|> IO.inspect(apply: &length/1)
|> do_something_with_things()
```