### PR TITLE
Set proper path of common options used in manpages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,13 +243,13 @@ build_man: man/iex.1 man/elixir.1
 
 man/iex.1:
 	$(Q) cp man/iex.1.in man/iex.1
-	$(Q) sed -i.bak "/{COMMON}/r common" man/iex.1
+	$(Q) sed -i.bak "/{COMMON}/r man/common" man/iex.1
 	$(Q) sed -i.bak "/{COMMON}/d" man/iex.1
 	$(Q) rm -f man/iex.1.bak
 
 man/elixir.1:
 	$(Q) cp man/elixir.1.in man/elixir.1
-	$(Q) sed -i.bak "/{COMMON}/r common" man/elixir.1
+	$(Q) sed -i.bak "/{COMMON}/r man/common" man/elixir.1
 	$(Q) sed -i.bak "/{COMMON}/d" man/elixir.1
 	$(Q) rm -f man/elixir.1.bak
 


### PR DESCRIPTION
The path for the common options shared between `elixir` and `iex` was not changed when the `man/Makefile` was merged into the top-level `Makefile`.

Here is an screenshot of the change, "before" (left) and "after" (right):

<img width="1393" alt="screen shot 2018-01-20 at 12 55 27 pm" src="https://user-images.githubusercontent.com/651203/35183203-6f483dc8-fde2-11e7-9e81-94eb2e63cf84.png">

By the way, I installed Elixir v1.6.0 via Homebrew (Mac OS X) and it does not come with the manpages, is that intended?
