### PR TITLE
Perform unused variable checks during Elixir expansion

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -229,7 +229,7 @@ defmodule Exception do
          {_, kind, _, clauses} <- List.keyfind(defs, {function, arity}, 0) do
       clauses =
         for {meta, ex_args, guards, _block} <- clauses do
-          scope = :elixir_erl.definition_scope(meta, "nofile")
+          scope = :elixir_erl.scope(meta)
 
           {erl_args, scope} =
             :elixir_erl_clauses.match(&:elixir_erl_pass.translate_args/2, ex_args, scope)

--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -188,7 +188,8 @@ defmodule Kernel.Utils do
   @spec defguard([Macro.t()], Macro.t(), Macro.Env.t()) :: Macro.t()
   def defguard(args, expr, env) do
     {^args, vars} = extract_refs_from_args(args)
-    {expr, _scope} = :elixir_expand.expand(expr, %{env | context: :guard, vars: vars})
+    env = :elixir_env.with_vars(%{env | context: :guard}, vars)
+    {expr, _scope} = :elixir_expand.expand(expr, env)
 
     quote do
       case Macro.Env.in_guard?(__CALLER__) do

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -44,6 +44,7 @@ defmodule Macro.Env do
 
   The following fields are private and must not be accessed or relied on:
 
+    * `unused_vars` - controls which variables have not been used yet
     * `prematch_vars` - controls how variables are handled outside of matches.
       It is either `:warn`, `:apply`, `:pin` or `:raise`. Inside a match it is
       a copy of current_vars
@@ -69,8 +70,9 @@ defmodule Macro.Env do
   @type current_vars :: %{var => var_info}
 
   @typep var_info :: {version :: non_neg_integer, type_info :: term}
-  @typep prematch_vars :: current_vars | :warn | :raise | :pin | :apply
   @typep vars :: [var]
+  @typep unused_vars :: %{{var, version :: non_neg_integer} => non_neg_integer | false}
+  @typep prematch_vars :: current_vars | :warn | :raise | :pin | :apply
 
   @type t :: %{
           __struct__: __MODULE__,
@@ -86,6 +88,7 @@ defmodule Macro.Env do
           macro_aliases: aliases,
           context_modules: context_modules,
           vars: vars,
+          unused_vars: unused_vars,
           current_vars: current_vars,
           prematch_vars: prematch_vars,
           lexical_tracker: lexical_tracker
@@ -107,6 +110,7 @@ defmodule Macro.Env do
       macro_aliases: [],
       context_modules: [],
       vars: [],
+      unused_vars: %{},
       current_vars: %{},
       prematch_vars: :warn,
       lexical_tracker: nil

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -44,11 +44,9 @@ defmodule Macro.Env do
 
   The following fields are private and must not be accessed or relied on:
 
-    * `match_vars` - controls how "new" variables are handled. Inside a
-      match it is a list with all variables in a match. Outside of a match
-      is either `:warn`, `:apply`, `:pin` or `:raise`
-    * `prematch_vars` - a copy of current_vars when inside a match (is
-      `nil` when not inside a match)
+    * `prematch_vars` - controls how variables are handled outside of matches.
+      It is either `:warn`, `:apply`, `:pin` or `:raise`. Inside a match it is
+      a copy of current_vars
 
   The following fields are deprecated and must not be accessed or relied on:
 
@@ -70,9 +68,8 @@ defmodule Macro.Env do
   @type var :: {atom, atom | non_neg_integer}
   @type current_vars :: %{var => var_info}
 
-  @typep var_info :: {version :: non_neg_integer, line_or_used :: :used | non_neg_integer}
-  @typep prematch_vars :: current_vars | nil
-  @typep match_vars :: [var] | :warn | :raise | :pin | :apply
+  @typep var_info :: {version :: non_neg_integer, type_info :: term}
+  @typep prematch_vars :: current_vars | :warn | :raise | :pin | :apply
   @typep vars :: [var]
 
   @type t :: %{
@@ -89,7 +86,6 @@ defmodule Macro.Env do
           macro_aliases: aliases,
           context_modules: context_modules,
           vars: vars,
-          match_vars: match_vars,
           current_vars: current_vars,
           prematch_vars: prematch_vars,
           lexical_tracker: lexical_tracker
@@ -111,9 +107,8 @@ defmodule Macro.Env do
       macro_aliases: [],
       context_modules: [],
       vars: [],
-      match_vars: :warn,
       current_vars: %{},
-      prematch_vars: nil,
+      prematch_vars: :warn,
       lexical_tracker: nil
     }
   end
@@ -142,7 +137,7 @@ defmodule Macro.Env do
   end
 
   def to_match(%{__struct__: Macro.Env, current_vars: vars} = env) do
-    %{env | context: :match, match_vars: [], prematch_vars: vars}
+    %{env | context: :match, prematch_vars: vars}
   end
 
   @doc """

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -42,8 +42,6 @@ defmodule Macro.Env do
 
   The following fields are private and must not be accessed or relied on:
 
-    * `export_vars` - a list keeping all variables to be exported in a
-      construct (may be `nil`)
     * `match_vars` - controls how "new" variables are handled. Inside a
       match it is a list with all variables in a match. Outside of a match
       is either `:warn` or `:apply`
@@ -66,7 +64,6 @@ defmodule Macro.Env do
   @type lexical_tracker :: pid | nil
   @type local :: atom | nil
 
-  @opaque export_vars :: vars | nil
   @opaque match_vars :: vars | :warn | :apply
   @opaque prematch_vars :: vars | nil
 
@@ -84,7 +81,6 @@ defmodule Macro.Env do
           macro_aliases: aliases,
           context_modules: context_modules,
           vars: vars,
-          export_vars: export_vars,
           match_vars: match_vars,
           prematch_vars: prematch_vars,
           lexical_tracker: lexical_tracker
@@ -106,7 +102,6 @@ defmodule Macro.Env do
       context_modules: [],
       vars: [],
       lexical_tracker: nil,
-      export_vars: nil,
       match_vars: :warn,
       prematch_vars: nil
     }

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -717,7 +717,7 @@ defmodule Protocol do
     assert_impl!(protocol, Any, extra)
 
     # Clean up variables from eval context
-    env = %{env | vars: [], export_vars: nil}
+    env = :elixir_env.reset_vars(env)
     args = [for, struct, opts]
     impl = Module.concat(protocol, Any)
 

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -295,7 +295,7 @@ quoted_to_erl(Quoted, Env) ->
 
 quoted_to_erl(Quoted, Env, Scope) ->
   {Expanded, NewEnv} = elixir_expand:expand(Quoted, Env),
-  {Erl, NewScope}    = elixir_erl_pass:translate(Expanded, Scope),
+  {Erl, NewScope} = elixir_erl_pass:translate(Expanded, Scope),
   {Erl, NewEnv, NewScope}.
 
 %% Converts a given string (charlist) into quote expression

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -252,7 +252,7 @@ eval_forms(Tree, Binding, E) ->
   eval_forms(Tree, Binding, E, elixir_env:env_to_scope(E)).
 eval_forms(Tree, Binding, Env, Scope) ->
   {ParsedBinding, ParsedVars, ParsedScope} = elixir_erl_var:load_binding(Binding, Scope),
-  ParsedEnv = Env#{vars := ParsedVars},
+  ParsedEnv = elixir_env:with_vars(Env, ParsedVars),
   {Erl, NewEnv, NewScope} = quoted_to_erl(Tree, ParsedEnv, ParsedScope),
 
   case Erl of

--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -11,8 +11,7 @@
   vars=#{},                %% a map of defined variables and their alias
   backup_vars=nil,         %% a copy of vars to be used on ^var
   extra_guards=[],         %% extra guards from args expansion
-  counter=#{},             %% a map counting the variables defined
-  file=(<<"nofile">>)      %% the current scope filename
+  counter=#{}              %% a map counting the variables defined
 }).
 
 -record(elixir_quote, {

--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -10,7 +10,6 @@
   caller=false,            %% when true, it means caller was invoked
   vars=#{},                %% a map of defined variables and their alias
   backup_vars=nil,         %% a copy of vars to be used on ^var
-  export_vars=nil,         %% a dict of all variables defined in a particular clause
   extra_guards=[],         %% extra guards from args expansion
   counter=#{},             %% a map counting the variables defined
   file=(<<"nofile">>)      %% the current scope filename

--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -23,7 +23,7 @@ expand(BitstrMeta, Fun, [{'::', Meta, [Left, Right]} | T], Acc, E, RequireSize) 
   {ER, MatchSize} =
     case E of
       {EExtracted, _} -> {EExtracted, false}; %% expand_arg,  no assigns
-      _ -> {E#{context := nil, match_vars := raise}, T /= []} %% expand, revert assigns
+      _ -> {E#{context := nil, prematch_vars := raise}, T /= []} %% expand, revert assigns
     end,
 
   ERight = expand_specs(expr_type(ELeft), Meta, Right, ER, RequireSize or MatchSize),

--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -23,7 +23,7 @@ expand(BitstrMeta, Fun, [{'::', Meta, [Left, Right]} | T], Acc, E, RequireSize) 
   {ER, MatchSize} =
     case E of
       {EExtracted, _} -> {EExtracted, false}; %% expand_arg,  no assigns
-      _ -> {E#{context := nil, match_vars := warn}, T /= []} %% expand, revert assigns
+      _ -> {E#{context := nil, match_vars := raise}, T /= []} %% expand, revert assigns
     end,
 
   ERight = expand_specs(expr_type(ELeft), Meta, Right, ER, RequireSize or MatchSize),

--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -6,8 +6,8 @@
 expand(Meta, Args, E, RequireSize) ->
   case ?key(E, context) of
     match ->
-      {EArgs, EA} = expand(Meta, fun elixir_expand:expand/2, Args, [], E, RequireSize),
-      {{'<<>>', Meta, EArgs}, EA};
+      {EArgs, EE} = expand(Meta, fun elixir_expand:expand/2, Args, [], E, RequireSize),
+      {{'<<>>', Meta, EArgs}, EE};
     _ ->
       {EArgs, {EC, EV}} = expand(Meta, fun elixir_expand:expand_arg/2, Args, [], {E, E}, RequireSize),
       {{'<<>>', Meta, EArgs}, elixir_env:mergea(EV, EC)}
@@ -20,14 +20,27 @@ expand(BitstrMeta, Fun, [{'::', Meta, [Left, Right]} | T], Acc, E, RequireSize) 
 
   %% Variables defined outside the binary can be accounted
   %% on subparts, however we can't assign new variables.
-  {ER, MatchSize} =
-    case E of
-      {EExtracted, _} -> {EExtracted, false}; %% expand_arg,  no assigns
-      _ -> {E#{context := nil, prematch_vars := raise}, T /= []} %% expand, revert assigns
+  {EM, MatchSize} =
+    case EL of
+      %% expand_arg, no assigns
+      {EC1, _} -> {EC1, false};
+
+      %% expand, revert assigns
+      _ -> {EL#{context := nil, prematch_vars := raise}, T /= []}
     end,
 
-  ERight = expand_specs(expr_type(ELeft), Meta, Right, ER, RequireSize or MatchSize),
-  expand(BitstrMeta, Fun, T, [{'::', Meta, [ELeft, ERight]} | Acc], EL, RequireSize);
+  {ERight, ES} = expand_specs(expr_type(ELeft), Meta, Right, EM, RequireSize or MatchSize),
+
+  EE =
+    case EL of
+      %% no assigns, vars are kept separately
+      {EC2, EV2} -> {EC2, elixir_env:mergev(EV2, ES)};
+
+      %% copy only vars on top
+      _ -> elixir_env:mergea(ES, EL)
+    end,
+
+  expand(BitstrMeta, Fun, T, [{'::', Meta, [ELeft, ERight]} | Acc], EE, RequireSize);
 expand(BitstrMeta, Fun, [{_, Meta, _} = H | T], Acc, E, RequireSize) ->
   {Expr, ES} = expand_expr(Meta, H, Fun, E),
   expand(BitstrMeta, Fun, T, [wrap_expr(Expr) | Acc], ES, RequireSize);
@@ -82,13 +95,13 @@ expand_specs(ExprType, Meta, Info, E, RequireSize) ->
       sign => default,
       type => default,
       endianness => default},
-  #{size := Size, unit := Unit, type := Type, endianness := Endianness, sign := Sign} =
+  {#{size := Size, unit := Unit, type := Type, endianness := Endianness, sign := Sign}, ES} =
     expand_each_spec(Meta, unpack_specs(Info, []), Default, E),
   MergedType = type(Meta, ExprType, Type, E),
-  validate_size_required(Meta, RequireSize, ExprType, MergedType, Size, E),
-  SizeAndUnit = size_and_unit(Meta, ExprType, Size, Unit, E),
-  [H | T] = build_spec(Meta, Size, Unit, MergedType, Endianness, Sign, SizeAndUnit, E),
-  lists:foldl(fun(I, Acc) -> {'-', Meta, [Acc, I]} end, H, T).
+  validate_size_required(Meta, RequireSize, ExprType, MergedType, Size, ES),
+  SizeAndUnit = size_and_unit(Meta, ExprType, Size, Unit, ES),
+  [H | T] = build_spec(Meta, Size, Unit, MergedType, Endianness, Sign, SizeAndUnit, ES),
+  {lists:foldl(fun(I, Acc) -> {'-', Meta, [Acc, I]} end, H, T), ES}.
 
 type(_, default, default, _) ->
   integer;
@@ -130,8 +143,8 @@ expand_each_spec(Meta, [{Expr, _, Args} = H | T], Map, E) when is_atom(Expr) ->
   end;
 expand_each_spec(Meta, [Expr | _], _Map, E) ->
   form_error(Meta, ?key(E, file), ?MODULE, {undefined_bittype, Expr});
-expand_each_spec(_Meta, [], Map, _E) ->
-  Map.
+expand_each_spec(_Meta, [], Map, E) ->
+  {Map, E}.
 
 unpack_specs({'-', _, [H, T]}, Acc) ->
   unpack_specs(H, unpack_specs(T, Acc));

--- a/lib/elixir/src/elixir_clauses.erl
+++ b/lib/elixir/src/elixir_clauses.erl
@@ -9,13 +9,13 @@
 
 match(Fun, Expr, #{context := match} = E) ->
   Fun(Expr, E);
-match(Fun, Expr, #{context := Context, match_vars := Match, prematch_vars := nil, current_vars := Current} = E) ->
-  {EExpr, EE} = Fun(Expr, E#{context := match, match_vars := [], prematch_vars := Current}),
-  {EExpr, EE#{context := Context, match_vars := Match, prematch_vars := nil}}.
+match(Fun, Expr, #{context := Context, prematch_vars := Prematch, current_vars := Current} = E) ->
+  {EExpr, EE} = Fun(Expr, E#{context := match, prematch_vars := Current}),
+  {EExpr, EE#{context := Context, prematch_vars := Prematch}}.
 
 def({Meta, Args, Guards, Body}, E) ->
-  {EArgs, EA}   = elixir_expand:expand(Args, E#{context := match, match_vars := [], prematch_vars := #{}}),
-  {EGuards, EG} = guard(Guards, EA#{context := guard, match_vars := warn, prematch_vars := nil}),
+  {EArgs, EA}   = elixir_expand:expand(Args, E#{context := match, prematch_vars := #{}}),
+  {EGuards, EG} = guard(Guards, EA#{context := guard, prematch_vars := warn}),
   {EBody, _}    = elixir_expand:expand(Body, EG#{context := nil}),
   {Meta, EArgs, EGuards, EBody}.
 

--- a/lib/elixir/src/elixir_clauses.erl
+++ b/lib/elixir/src/elixir_clauses.erl
@@ -9,12 +9,12 @@
 
 match(Fun, Expr, #{context := match} = E) ->
   Fun(Expr, E);
-match(Fun, Expr, #{context := Context, match_vars := Match, prematch_vars := nil, vars := Vars} = E) ->
-  {EExpr, EE} = Fun(Expr, E#{context := match, match_vars := [], prematch_vars := Vars}),
+match(Fun, Expr, #{context := Context, match_vars := Match, prematch_vars := nil, current_vars := Current} = E) ->
+  {EExpr, EE} = Fun(Expr, E#{context := match, match_vars := [], prematch_vars := Current}),
   {EExpr, EE#{context := Context, match_vars := Match, prematch_vars := nil}}.
 
 def({Meta, Args, Guards, Body}, E) ->
-  {EArgs, EA}   = elixir_expand:expand(Args, E#{context := match, match_vars := [], prematch_vars := []}),
+  {EArgs, EA}   = elixir_expand:expand(Args, E#{context := match, match_vars := [], prematch_vars := #{}}),
   {EGuards, EG} = guard(Guards, EA#{context := guard, match_vars := warn, prematch_vars := nil}),
   {EBody, _}    = elixir_expand:expand(Body, EG#{context := nil}),
   {Meta, EArgs, EGuards, EBody}.

--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -65,7 +65,7 @@ eval_forms(Forms, Vars, E) ->
   end.
 
 compile(Forms, Vars, #{line := Line, file := File} = E) ->
-  Dict = [{{Name, Kind}, {Value, 0}} || {Name, Kind, Value, _} <- Vars],
+  Dict = [{{Name, Kind}, {0, Value}} || {Name, Kind, Value, _} <- Vars],
   S = elixir_env:env_to_scope_with_vars(E, Dict),
   {Expr, EE, _S} = elixir:quoted_to_erl(Forms, E, S),
 

--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -65,7 +65,7 @@ eval_forms(Forms, Vars, E) ->
   end.
 
 compile(Forms, Vars, #{line := Line, file := File} = E) ->
-  Dict = [{{Name, Kind}, {Value, 0, true}} || {Name, Kind, Value, _} <- Vars],
+  Dict = [{{Name, Kind}, {Value, 0}} || {Name, Kind, Value, _} <- Vars],
   S = elixir_env:env_to_scope_with_vars(E, Dict),
   {Expr, EE, _S} = elixir:quoted_to_erl(Forms, E, S),
 

--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -68,6 +68,7 @@ compile(Forms, Vars, #{line := Line, file := File} = E) ->
   Dict = [{{Name, Kind}, {0, Value}} || {Name, Kind, Value, _} <- Vars],
   S = elixir_env:env_to_scope_with_vars(E, Dict),
   {Expr, EE, _S} = elixir:quoted_to_erl(Forms, E, S),
+  elixir_env:check_unused_vars(EE),
 
   {Module, I} = retrieve_compiler_module(),
   Fun  = code_fun(?key(E, module)),

--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -20,9 +20,9 @@ local_for(Module, Name, Arity, Kinds) ->
     Table = elixir_module:defs_table(Module),
     {ets:lookup(Table, {def, Tuple}), ets:lookup(Table, {clauses, Tuple})}
   of
-    {[{_, Kind, Meta, File, _, _}], Clauses} ->
+    {[{_, Kind, Meta, _, _, _}], Clauses} ->
       case (Kinds == all) orelse (lists:member(Kind, Kinds)) of
-        true -> elixir_erl:definition_to_anonymous(File, Module, Kind, Meta,
+        true -> elixir_erl:definition_to_anonymous(Module, Kind, Meta,
                                                    [Clause || {_, Clause} <- Clauses]);
         false -> false
       end;

--- a/lib/elixir/src/elixir_env.erl
+++ b/lib/elixir/src/elixir_env.erl
@@ -71,10 +71,8 @@ merge_vars(V1, V2) ->
 merge_current_vars(V, V) -> V;
 merge_current_vars(V1, V2) ->
   maps:fold(fun(K, M2, Acc) ->
-    V =
-      case Acc of
-        #{K := M1} when M1 > M2 -> M1;
-        _ -> M2
-      end,
-    maps:put(K, V, Acc)
+    case Acc of
+      #{K := M1} when M1 >= M2 -> Acc;
+      _ -> maps:put(K, M2, Acc)
+    end
   end, V1, V2).

--- a/lib/elixir/src/elixir_env.erl
+++ b/lib/elixir/src/elixir_env.erl
@@ -26,8 +26,8 @@ linify({Line, Env}) ->
 linify(#{} = Env) ->
   Env.
 
-env_to_scope(#{file := File, context := Context}) ->
-  #elixir_erl{file=File, context=Context}.
+env_to_scope(#{context := Context}) ->
+  #elixir_erl{context=Context}.
 
 env_to_scope_with_vars(Env, Vars) ->
   Map = maps:from_list(Vars),

--- a/lib/elixir/src/elixir_env.erl
+++ b/lib/elixir/src/elixir_env.erl
@@ -1,7 +1,10 @@
 -module(elixir_env).
 -include("elixir.hrl").
--export([new/0, linify/1, env_to_scope/1, env_to_scope_with_vars/2, reset_vars/1]).
--export([mergea/2, mergev/2]).
+-export([
+  new/0, linify/1, with_vars/2, reset_vars/1,
+  env_to_scope/1, env_to_scope_with_vars/2,
+  mergea/2, mergev/2
+]).
 
 new() ->
   #{'__struct__' => 'Elixir.Macro.Env',
@@ -16,15 +19,20 @@ new() ->
     macros => [],                          %% a list with macros imported from module
     macro_aliases => [],                   %% keep aliases defined inside a macro
     context_modules => [],                 %% modules defined in the current context
-    lexical_tracker => nil,                %% holds the lexical tracker PID
     vars => [],                            %% a set of defined variables
-    prematch_vars => nil,                  %% a set of variables defined before the current match
-    match_vars => warn}.                   %% handling of new variables
+    match_vars => warn,                    %% handling of new variables
+    current_vars => #{},                   %% a map with current vars
+    prematch_vars => nil,                  %% a copy of variables defined before the current match
+    lexical_tracker => nil}.               %% holds the lexical tracker PID}.
 
 linify({Line, Env}) ->
   Env#{line := Line};
 linify(#{} = Env) ->
   Env.
+
+with_vars(Env, Vars) ->
+  CurrentVars = maps:from_list([{Var, {0, used}} || Var <- Vars]),
+  Env#{vars := Vars, current_vars := CurrentVars}.
 
 env_to_scope(#{context := Context}) ->
   #elixir_erl{context=Context}.
@@ -36,16 +44,17 @@ env_to_scope_with_vars(Env, Vars) ->
   }.
 
 reset_vars(Env) ->
-  Env#{vars := []}.
+  Env#{vars := [], current_vars := #{}}.
 
 %% SCOPE MERGING
 
 %% Receives two scopes and return a new scope based on the second
 %% with their variables merged.
-mergev(E1, E2) when is_list(E1) ->
-  E2#{vars := merge_vars(E1, ?key(E2, vars))};
-mergev(E1, E2) ->
-  E2#{vars := merge_vars(?key(E1, vars), ?key(E2, vars))}.
+mergev(#{vars := V1, current_vars := CV1}, #{vars := V2, current_vars := CV2} = E2) ->
+  E2#{
+    vars := merge_vars(V1, V2),
+    current_vars := merge_current_vars(CV1, CV2)
+  }.
 
 %% Receives two scopes and return the later scope
 %% keeping the variables from the first (imports
@@ -56,3 +65,14 @@ mergea(E1, E2) ->
 
 merge_vars(V1, V2) ->
   ordsets:union(V1, V2).
+
+merge_current_vars(V, V) -> V;
+merge_current_vars(V1, V2) ->
+  maps:fold(fun(K, M2, Acc) ->
+    V =
+      case Acc of
+        #{K := M1} when M1 > M2 -> M1;
+        _ -> M2
+      end,
+    maps:put(K, V, Acc)
+  end, V1, V2).

--- a/lib/elixir/src/elixir_env.erl
+++ b/lib/elixir/src/elixir_env.erl
@@ -20,9 +20,8 @@ new() ->
     macro_aliases => [],                   %% keep aliases defined inside a macro
     context_modules => [],                 %% modules defined in the current context
     vars => [],                            %% a set of defined variables
-    match_vars => warn,                    %% handling of new variables
     current_vars => #{},                   %% a map with current vars
-    prematch_vars => nil,                  %% a copy of variables defined before the current match
+    prematch_vars => warn,                 %% behaviour outside and inside matches
     lexical_tracker => nil}.               %% holds the lexical tracker PID}.
 
 linify({Line, Env}) ->
@@ -31,7 +30,7 @@ linify(#{} = Env) ->
   Env.
 
 with_vars(Env, Vars) ->
-  CurrentVars = maps:from_list([{Var, {0, used}} || Var <- Vars]),
+  CurrentVars = maps:from_list([{Var, {0, term}} || Var <- Vars]),
   Env#{vars := Vars, current_vars := CurrentVars}.
 
 env_to_scope(#{context := Context}) ->
@@ -61,7 +60,10 @@ mergev(#{vars := V1, current_vars := CV1}, #{vars := V2, current_vars := CV2} = 
 %% and everything else are passed forward).
 
 mergea(E1, E2) ->
-  E2#{vars := ?key(E1, vars)}.
+  E2#{
+    vars := ?key(E1, vars),
+    current_vars := ?key(E1, current_vars)
+  }.
 
 merge_vars(V1, V2) ->
   ordsets:union(V1, V2).

--- a/lib/elixir/src/elixir_env.erl
+++ b/lib/elixir/src/elixir_env.erl
@@ -3,7 +3,8 @@
 -export([
   new/0, linify/1, with_vars/2, reset_vars/1,
   env_to_scope/1, env_to_scope_with_vars/2,
-  mergea/2, mergev/2
+  check_unused_vars/1, merge_and_check_unused_vars/2,
+  mergea/2, mergev/2, format_error/1
 ]).
 
 new() ->
@@ -20,7 +21,8 @@ new() ->
     macro_aliases => [],                   %% keep aliases defined inside a macro
     context_modules => [],                 %% modules defined in the current context
     vars => [],                            %% a set of defined variables
-    current_vars => #{},                   %% a map with current vars
+    unused_vars => #{},                    %% a map with unused variables
+    current_vars => #{},                   %% a map with current variables
     prematch_vars => warn,                 %% behaviour outside and inside matches
     lexical_tracker => nil}.               %% holds the lexical tracker PID}.
 
@@ -43,36 +45,117 @@ env_to_scope_with_vars(Env, Vars) ->
   }.
 
 reset_vars(Env) ->
-  Env#{vars := [], current_vars := #{}}.
+  Env#{vars := [], current_vars := #{}, unused_vars := #{}}.
 
 %% SCOPE MERGING
 
 %% Receives two scopes and return a new scope based on the second
 %% with their variables merged.
-mergev(#{vars := V1, current_vars := CV1}, #{vars := V2, current_vars := CV2} = E2) ->
+mergev(#{vars := V1, unused_vars := U1, current_vars := C1},
+       #{vars := V2, unused_vars := U2, current_vars := C2} = E2) ->
   E2#{
-    vars := merge_vars(V1, V2),
-    current_vars := merge_current_vars(CV1, CV2)
+    vars := ordsets:union(V1, V2),
+    unused_vars := merge_vars(U1, U2),
+    current_vars := merge_vars(C1, C2)
   }.
 
 %% Receives two scopes and return the later scope
 %% keeping the variables from the first (imports
 %% and everything else are passed forward).
 
-mergea(E1, E2) ->
-  E2#{
-    vars := ?key(E1, vars),
-    current_vars := ?key(E1, current_vars)
-  }.
+mergea(#{vars := V1, unused_vars := U1, current_vars := C1}, E2) ->
+  E2#{vars := V1, unused_vars := U1, current_vars := C1}.
 
+merge_vars(V, V) -> V;
 merge_vars(V1, V2) ->
-  ordsets:union(V1, V2).
-
-merge_current_vars(V, V) -> V;
-merge_current_vars(V1, V2) ->
   maps:fold(fun(K, M2, Acc) ->
     case Acc of
       #{K := M1} when M1 >= M2 -> Acc;
       _ -> maps:put(K, M2, Acc)
     end
   end, V1, V2).
+
+
+%% UNUSED VARS
+
+check_unused_vars(#{unused_vars := Unused} = E) ->
+  [begin
+     case not_underscored(Name) of
+       true ->
+         elixir_errors:form_warn([{line, Line}], ?key(E, file), ?MODULE, {unused_var, Name, false});
+       false ->
+         ok
+     end
+   end || {{{Name, nil}, _}, Line} <- maps:to_list(Unused), Line /= false].
+
+merge_and_check_unused_vars(#{unused_vars := Unused} = E, #{unused_vars := ClauseUnused}) ->
+  E#{unused_vars := merge_and_check_unused_vars(Unused, ClauseUnused, E)}.
+
+merge_and_check_unused_vars(Unused, ClauseUnused, E) ->
+  maps:fold(fun(Key, ClauseValue, Acc) ->
+    case ClauseValue of
+      %% The variable was used...
+      false ->
+        case Acc of
+          %% So we propagate if it was not yet used
+          #{Key := Value} when Value /= false ->
+            Acc#{Key := false};
+
+          %% Otherwise we don't know it or it was already used
+          _ ->
+            Acc
+        end;
+
+      %% The variable was not used...
+      _ ->
+        case Acc of
+          %% If we know it, there is nothing to propagate
+          #{Key := _} ->
+            Acc;
+
+          %% Otherwise we must warn
+          _ ->
+            {{Name, Kind} = Pair, _} = Key,
+
+            case (Kind == nil) andalso not_underscored(Name) of
+              true ->
+                IsShadowing = maps:is_key(Pair, ?key(E, current_vars)),
+                Warn = {unused_var, Name, IsShadowing},
+                elixir_errors:form_warn([{line, ClauseValue}], ?key(E, file), ?MODULE, Warn);
+
+              false ->
+                ok
+            end,
+
+            Acc
+        end
+    end
+  end, Unused, ClauseUnused).
+
+not_underscored(Name) ->
+  case atom_to_list(Name) of
+    "_" ++ _ -> false;
+    _ -> true
+  end.
+
+format_error({unused_var, Name, false}) ->
+  io_lib:format("variable \"~ts\" is unused", [Name]);
+
+format_error({unused_var, Name, true}) ->
+  io_lib:format("variable \"~ts\" is unused\n\n"
+                "Note variables defined inside case, cond, fn, if and similar do not leak. "
+                "If you want to conditionally override an existing variable \"~ts\", "
+                "you will have to explicitly return the variable. For example:\n\n"
+                "    if some_condition? do\n"
+                "      atom = :one\n"
+                "    else\n"
+                "      atom = :two\n"
+                "    end\n\n"
+                "should be written as\n\n"
+                "    atom =\n"
+                "      if some_condition? do\n"
+                "        :one\n"
+                "      else\n"
+                "        :two\n"
+                "      end\n\n"
+                "Unused variable found at:", [Name, Name]).

--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -2,7 +2,7 @@
 -module(elixir_erl).
 -export([elixir_to_erl/1, definition_to_anonymous/5, compile/1,
          get_ann/1, remote/4, add_beam_chunks/2, debug_info/4,
-         definition_scope/2, format_error/1]).
+         scope/1, format_error/1]).
 -include("elixir.hrl").
 
 %% TODO: Remove extra chunk functionality when OTP 20+.
@@ -153,17 +153,10 @@ elixir_to_erl_cons2([H | T], Acc) ->
 elixir_to_erl_cons2([], Acc) ->
   Acc.
 
-%% Returns a definition scope for translation.
+%% Returns a scope for translation.
 
-definition_scope(Meta, File) ->
-  %% TODO: We only need to do this dance because some
-  %% warnings are raised in elixir_erl_pass. Once we remove
-  %% all warnings from the Erlang pass, we can remove the
-  %% file field from #elixir_erl and clean up the code.
-  case lists:keyfind(file, 1, Meta) of
-    {file, {F, _}} -> #elixir_erl{file=F};
-    false -> #elixir_erl{file=File}
-  end.
+scope(_Meta) ->
+  #elixir_erl{}.
 
 %% Compilation hook.
 
@@ -253,7 +246,7 @@ translate_definition(Kind, Meta, File, {Name, Arity}, Clauses) ->
   end.
 
 translate_clause(Kind, {Meta, Args, Guards, Body}, File) ->
-  S = definition_scope(Meta, File),
+  S = scope(Meta),
 
   {TClause, TS} = elixir_erl_clauses:clause(Meta,
                     fun elixir_erl_pass:translate_args/2, Args, Body, Guards, S),

--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -1,6 +1,6 @@
 %% Compiler backend to Erlang.
 -module(elixir_erl).
--export([elixir_to_erl/1, definition_to_anonymous/5, compile/1,
+-export([elixir_to_erl/1, definition_to_anonymous/4, compile/1,
          get_ann/1, remote/4, add_beam_chunks/2, debug_info/4,
          scope/1, format_error/1]).
 -include("elixir.hrl").
@@ -79,8 +79,8 @@ remote(Ann, Module, Function, Args) when is_atom(Module), is_atom(Function), is_
 
 %% Converts an Elixir definition to an anonymous function.
 
-definition_to_anonymous(File, Module, Kind, Meta, Clauses) ->
-  ErlClauses = [translate_clause(Kind, Clause, File) || Clause <- Clauses],
+definition_to_anonymous(Module, Kind, Meta, Clauses) ->
+  ErlClauses = [translate_clause(Kind, Clause) || Clause <- Clauses],
   Fun = {'fun', ?ann(Meta), {clauses, ErlClauses}},
   LocalHandler = fun(LocalName, LocalArgs) -> invoke_local(Module, LocalName, LocalArgs) end,
   {value, Result, _Binding} = erl_eval:expr(Fun, [], {value, LocalHandler}),
@@ -174,7 +174,7 @@ compile(#{module := Module} = Map) ->
 dynamic_form(#{module := Module, line := Line, file := File, attributes := Attributes,
                definitions := Definitions, unreachable := Unreachable}, Deprecated) ->
   {Def, Defmacro, Macros, Exports, Functions} =
-    split_definition(Definitions, File, Unreachable, [], [], [], [], {[], []}),
+    split_definition(Definitions, Unreachable, [], [], [], [], {[], []}),
 
   Location = {elixir_utils:characters_to_list(elixir_utils:relative_to_cwd(File)), Line},
   Prefix = [{attribute, Line, file, Location},
@@ -187,40 +187,40 @@ dynamic_form(#{module := Module, line := Line, file := File, attributes := Attri
 
 % Definitions
 
-split_definition([{Tuple, Kind, Meta, Clauses} | T], File, Unreachable,
+split_definition([{Tuple, Kind, Meta, Clauses} | T], Unreachable,
                  Def, Defmacro, Macros, Exports, Functions) ->
   case lists:member(Tuple, Unreachable) of
     false ->
-      split_definition(Tuple, Kind, Meta, Clauses, T, File, Unreachable,
+      split_definition(Tuple, Kind, Meta, Clauses, T, Unreachable,
                        Def, Defmacro, Macros, Exports, Functions);
     true ->
-      split_definition(T, File, Unreachable, Def, Defmacro, Macros, Exports, Functions)
+      split_definition(T, Unreachable, Def, Defmacro, Macros, Exports, Functions)
   end;
-split_definition([], _File, _Unreachable, Def, Defmacro, Macros, Exports, {Head, Tail}) ->
+split_definition([], _Unreachable, Def, Defmacro, Macros, Exports, {Head, Tail}) ->
   {Def, Defmacro, Macros, Exports, Head ++ Tail}.
 
-split_definition(Tuple, def, Meta, Clauses, T, File, Unreachable,
+split_definition(Tuple, def, Meta, Clauses, T, Unreachable,
                  Def, Defmacro, Macros, Exports, Functions) ->
-  {_, _, N, A, _} = Entry = translate_definition(def, Meta, File, Tuple, Clauses),
-  split_definition(T, File, Unreachable, [Tuple | Def], Defmacro, Macros, [{N, A} | Exports],
+  {_, _, N, A, _} = Entry = translate_definition(def, Meta, Tuple, Clauses),
+  split_definition(T, Unreachable, [Tuple | Def], Defmacro, Macros, [{N, A} | Exports],
                    add_definition(Meta, Entry, Functions));
 
-split_definition(Tuple, defp, Meta, Clauses, T, File, Unreachable,
+split_definition(Tuple, defp, Meta, Clauses, T, Unreachable,
                  Def, Defmacro, Macros, Exports, Functions) ->
-  Entry = translate_definition(defp, Meta, File, Tuple, Clauses),
-  split_definition(T, File, Unreachable, Def, Defmacro, Macros, Exports,
+  Entry = translate_definition(defp, Meta, Tuple, Clauses),
+  split_definition(T, Unreachable, Def, Defmacro, Macros, Exports,
                    add_definition(Meta, Entry, Functions));
 
-split_definition(Tuple, defmacro, Meta, Clauses, T, File, Unreachable,
+split_definition(Tuple, defmacro, Meta, Clauses, T, Unreachable,
                  Def, Defmacro, Macros, Exports, Functions) ->
-  {_, _, N, A, _} = Entry = translate_definition(defmacro, Meta, File, Tuple, Clauses),
-  split_definition(T, File, Unreachable, Def, [Tuple | Defmacro], [Tuple | Macros], [{N, A} | Exports],
+  {_, _, N, A, _} = Entry = translate_definition(defmacro, Meta, Tuple, Clauses),
+  split_definition(T, Unreachable, Def, [Tuple | Defmacro], [Tuple | Macros], [{N, A} | Exports],
                    add_definition(Meta, Entry, Functions));
 
-split_definition(Tuple, defmacrop, Meta, Clauses, T, File, Unreachable,
+split_definition(Tuple, defmacrop, Meta, Clauses, T, Unreachable,
                  Def, Defmacro, Macros, Exports, Functions) ->
-  Entry = translate_definition(defmacro, Meta, File, Tuple, Clauses),
-  split_definition(T, File, Unreachable, Def, Defmacro, [Tuple | Macros], Exports,
+  Entry = translate_definition(defmacro, Meta, Tuple, Clauses),
+  split_definition(T, Unreachable, Def, Defmacro, [Tuple | Macros], Exports,
                    add_definition(Meta, Entry, Functions)).
 
 add_definition(Meta, Body, {Head, Tail}) ->
@@ -237,15 +237,15 @@ add_definition(Meta, Body, {Head, Tail}) ->
       {[Body | Head], Tail}
   end.
 
-translate_definition(Kind, Meta, File, {Name, Arity}, Clauses) ->
-  ErlClauses = [translate_clause(Kind, Clause, File) || Clause <- Clauses],
+translate_definition(Kind, Meta, {Name, Arity}, Clauses) ->
+  ErlClauses = [translate_clause(Kind, Clause) || Clause <- Clauses],
 
   case is_macro(Kind) of
     true -> {function, ?ann(Meta), elixir_utils:macro_name(Name), Arity + 1, ErlClauses};
     false -> {function, ?ann(Meta), Name, Arity, ErlClauses}
   end.
 
-translate_clause(Kind, {Meta, Args, Guards, Body}, File) ->
+translate_clause(Kind, {Meta, Args, Guards, Body}) ->
   S = scope(Meta),
 
   {TClause, TS} = elixir_erl_clauses:clause(Meta,

--- a/lib/elixir/src/elixir_erl_clauses.erl
+++ b/lib/elixir/src/elixir_erl_clauses.erl
@@ -1,7 +1,7 @@
 %% Handle code related to args, guard and -> matching for case,
 %% fn, receive and friends. try is handled in elixir_erl_try.
 -module(elixir_erl_clauses).
--export([match/3, clause/6, clauses/3, guards/3, get_clauses/3]).
+-export([match/3, clause/6, clauses/2, guards/3, get_clauses/3]).
 -include("elixir.hrl").
 
 %% Get clauses under the given key.
@@ -28,7 +28,7 @@ clause(Meta, Fun, Args, Expr, Guards, S) when is_list(Meta) ->
   {TArgs, SA} = match(Fun, Args, S),
   SG = SA#elixir_erl{extra_guards=[]},
   TGuards = guards(Guards, SA#elixir_erl.extra_guards, SG),
-  {TExpr, SE} = elixir_erl_pass:translate(Expr, SG#elixir_erl{export_vars=S#elixir_erl.export_vars}),
+  {TExpr, SE} = elixir_erl_pass:translate(Expr, SG),
   {{clause, ?ann(Meta), TArgs, TGuards, unblock(TExpr)}, SE}.
 
 % Translate/Extract guards from the given expression.
@@ -45,76 +45,15 @@ translate_guard(Guard, Extra, S) ->
 
 % Function for translating macros with match style like case and receive.
 
-clauses(Meta, Clauses, #elixir_erl{export_vars=CV} = S) ->
-  {TC, TS} = do_clauses(Meta, Clauses, S#elixir_erl{export_vars=#{}}),
-  {TC, TS#elixir_erl{export_vars=elixir_erl_var:merge_opt_vars(CV, TS#elixir_erl.export_vars)}}.
-
-do_clauses(_Meta, [], S) ->
+clauses([], S) ->
   {[], S};
 
-do_clauses(Meta, DecoupledClauses, S) ->
-  % Transform tree just passing the variables counter forward
-  % and storing variables defined inside each clause.
-  Transformer = fun(X, {SAcc, VAcc}) ->
+clauses(Clauses, S) ->
+  Transformer = fun(X, SAcc) ->
     {TX, TS} = each_clause(X, SAcc),
-    {TX, {elixir_erl_var:mergec(S, TS), [TS#elixir_erl.export_vars | VAcc]}}
+    {TX, elixir_erl_var:mergec(S, TS)}
   end,
-
-  {TClauses, {TS, ReverseCV}} =
-    lists:mapfoldl(Transformer, {S, []}, DecoupledClauses),
-
-  % Now get all the variables defined inside each clause
-  CV = lists:reverse(ReverseCV),
-  AllVars = lists:foldl(fun elixir_erl_var:merge_vars/2, #{}, CV),
-
-  % Create a new scope that contains a list of all variables
-  % defined inside all the clauses. It returns this new scope and
-  % a list of tuples where the first element is the variable name,
-  % the second one is the new pointer to the variable and the third
-  % is the old pointer.
-  {FinalVars, FS} = lists:mapfoldl(fun({Key, Val}, Acc) ->
-    normalize_vars(Key, Val, Acc)
-  end, TS, maps:to_list(AllVars)),
-
-  % Expand all clauses by adding a match operation at the end
-  % that defines variables missing in one clause to the others.
-  expand_clauses(?ann(Meta), TClauses, CV, FinalVars, [], FS).
-
-expand_clauses(Ann, [Clause | T], [ClauseVars | V], FinalVars, Acc, S) ->
-  case generate_match_vars(FinalVars, ClauseVars, [], []) of
-    {[], []} ->
-      expand_clauses(Ann, T, V, FinalVars, [Clause | Acc], S);
-    {Left, Right} ->
-      MatchExpr   = generate_match(Ann, Left, Right),
-      ClauseExprs = element(5, Clause),
-      [Final | RawClauseExprs] = lists:reverse(ClauseExprs),
-
-      % If the last sentence has a match clause, we need to assign its value
-      % in the variable list. If not, we insert the variable list before the
-      % final clause in order to keep it tail call optimized.
-      {FinalClauseExprs, FS} = case has_match_tuple(Final) of
-        true ->
-          case Final of
-            {match, _, {var, _, UserVarName} = UserVar, _} when UserVarName /= '_' ->
-              {[UserVar, MatchExpr, Final | RawClauseExprs], S};
-            _ ->
-              {VarName, _, SS} = elixir_erl_var:build('_', S),
-              StorageVar  = {var, Ann, VarName},
-              StorageExpr = {match, Ann, StorageVar, Final},
-              {[StorageVar, MatchExpr, StorageExpr | RawClauseExprs], SS}
-          end;
-        false ->
-          {[Final, MatchExpr | RawClauseExprs], S}
-      end,
-
-      FinalClause = setelement(5, Clause, lists:reverse(FinalClauseExprs)),
-      expand_clauses(Ann, T, V, FinalVars, [FinalClause | Acc], FS)
-  end;
-
-expand_clauses(_Ann, [], [], _FinalVars, Acc, S) ->
-  {lists:reverse(Acc), S}.
-
-% Handle each key/value clause pair and translate them accordingly.
+  lists:mapfoldl(Transformer, S, Clauses).
 
 each_clause({match, Meta, [Condition], Expr}, S) ->
   {Arg, Guards} = elixir_utils:extract_guards(Condition),
@@ -122,80 +61,8 @@ each_clause({match, Meta, [Condition], Expr}, S) ->
 
 each_clause({expr, Meta, [Condition], Expr}, S) ->
   {TCondition, SC} = elixir_erl_pass:translate(Condition, S),
-  {TExpr, SB} = elixir_erl_pass:translate(Expr, SC#elixir_erl{export_vars = S#elixir_erl.export_vars}),
+  {TExpr, SB} = elixir_erl_pass:translate(Expr, SC),
   {{clause, ?ann(Meta), [TCondition], [], unblock(TExpr)}, SB}.
-
-% Check if the given expression is a match tuple.
-% This is a small optimization to allow us to change
-% existing assignments instead of creating new ones every time.
-
-has_match_tuple({'receive', _, _, _, _}) ->
-  true;
-has_match_tuple({'receive', _, _}) ->
-  true;
-has_match_tuple({'case', _, _, _}) ->
-  true;
-has_match_tuple({match, _, _, _}) ->
-  true;
-has_match_tuple({'fun', _, {clauses, _}}) ->
-  false;
-has_match_tuple(H) when is_tuple(H) ->
-  has_match_tuple(tuple_to_list(H));
-has_match_tuple(H) when is_list(H) ->
-  lists:any(fun has_match_tuple/1, H);
-has_match_tuple(_) -> false.
-
-% Normalize the given var between clauses
-% by picking one value as reference and retrieving
-% its previous value.
-
-normalize_vars(Key, {Ref, Counter, _Safe},
-               #elixir_erl{vars=Vars, export_vars=ClauseVars} = S) ->
-  Expr =
-    case maps:find(Key, Vars) of
-      {ok, {PrevRef, _, _}} ->
-        {var, 0, PrevRef};
-      error ->
-        {atom, 0, nil}
-    end,
-
-  %% TODO: For v2.0, we will never export unsafe vars but
-  %% we need to consider if we want to raise or a emit a warning.
-  %% Such a warning should be applied consistently to the language
-  %% (for example, case/try/receive/fn/etc).
-  Value = {Ref, Counter, false},
-
-  VS = S#elixir_erl{
-    vars=maps:put(Key, Value, Vars),
-    export_vars=maps:put(Key, Value, ClauseVars)
-  },
-
-  {{Key, Value, Expr}, VS}.
-
-% Generate match vars by checking if they were updated
-% or not and assigning the previous value.
-
-generate_match_vars([{Key, {Value, _, _}, Expr} | T], ClauseVars, Left, Right) ->
-  case maps:find(Key, ClauseVars) of
-    {ok, {Value, _, _}} ->
-      generate_match_vars(T, ClauseVars, Left, Right);
-    {ok, {Clause, _, _}} ->
-      generate_match_vars(T, ClauseVars,
-        [{var, 0, Value} | Left],
-        [{var, 0, Clause} | Right]);
-    error ->
-      generate_match_vars(T, ClauseVars,
-        [{var, 0, Value} | Left], [Expr | Right])
-  end;
-
-generate_match_vars([], _ClauseVars, Left, Right) ->
-  {Left, Right}.
-
-generate_match(Ann, [Left], [Right]) ->
-  {match, Ann, Left, Right};
-
-generate_match(Ann, LeftVars, RightVars) ->
-  {match, Ann, {tuple, Ann, LeftVars}, {tuple, Ann, RightVars}}.
 
 unblock({'block', _, Exprs}) -> Exprs;
 unblock(Exprs) -> [Exprs].

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -176,7 +176,7 @@ translate({with, Meta, [_ | _] = Args}, S) ->
 
 translate({'^', Meta, [{Name, VarMeta, Kind}]}, #elixir_erl{context=match} = S) when is_atom(Name), is_atom(Kind) ->
   Tuple = {Name, var_context(VarMeta, Kind)},
-  {ok, {Value, _Counter, Safe}} = maps:find(Tuple, S#elixir_erl.backup_vars),
+  {ok, {Value, _Counter}} = maps:find(Tuple, S#elixir_erl.backup_vars),
 
   PAnn = ?ann(?generated(Meta)),
   PVar = {var, PAnn, Value},

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -176,7 +176,7 @@ translate({with, Meta, [_ | _] = Args}, S) ->
 
 translate({'^', Meta, [{Name, VarMeta, Kind}]}, #elixir_erl{context=match} = S) when is_atom(Name), is_atom(Kind) ->
   Tuple = {Name, var_context(VarMeta, Kind)},
-  {ok, {Value, _Counter}} = maps:find(Tuple, S#elixir_erl.backup_vars),
+  {ok, {_Counter, Value}} = maps:find(Tuple, S#elixir_erl.backup_vars),
 
   PAnn = ?ann(?generated(Meta)),
   PVar = {var, PAnn, Value},

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -174,10 +174,9 @@ translate({with, Meta, [_ | _] = Args}, S) ->
 
 %% Variables
 
-translate({'^', Meta, [{Name, VarMeta, Kind}]}, #elixir_erl{context=match, file=File} = S) when is_atom(Name), is_atom(Kind) ->
+translate({'^', Meta, [{Name, VarMeta, Kind}]}, #elixir_erl{context=match} = S) when is_atom(Name), is_atom(Kind) ->
   Tuple = {Name, var_context(VarMeta, Kind)},
   {ok, {Value, _Counter, Safe}} = maps:find(Tuple, S#elixir_erl.backup_vars),
-  elixir_erl_var:warn_unsafe_var(VarMeta, File, Name, Safe),
 
   PAnn = ?ann(?generated(Meta)),
   PVar = {var, PAnn, Value},

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -121,8 +121,7 @@ translate({'cond', CondMeta, [[{do, Clauses}]]}, S) ->
 %% Case
 
 translate({'case', Meta, [Expr, Opts]}, S) ->
-  ShouldExportVars = proplists:get_value(export_vars, Meta, true),
-  translate_case(ShouldExportVars, Meta, Expr, Opts, S);
+  translate_case(Meta, Expr, Opts, S);
 
 %% Try
 
@@ -142,7 +141,7 @@ translate({'try', Meta, [Opts]}, S) ->
   end,
 
   Else = elixir_erl_clauses:get_clauses(else, Opts, match),
-  {TElse, SE} = elixir_erl_clauses:clauses(Meta, Else, mergec(S, SA)),
+  {TElse, SE} = elixir_erl_clauses:clauses(Else, mergec(S, SA)),
   {{'try', ?ann(Meta), unblock(TDo), TElse, TCatch, TAfter}, mergec(S, SE)};
 
 %% Receive
@@ -152,11 +151,11 @@ translate({'receive', Meta, [Opts]}, S) ->
 
   case lists:keyfind('after', 1, Opts) of
     false ->
-      {TClauses, SC} = elixir_erl_clauses:clauses(Meta, Do, S),
+      {TClauses, SC} = elixir_erl_clauses:clauses(Do, S),
       {{'receive', ?ann(Meta), TClauses}, SC};
     _ ->
       After = elixir_erl_clauses:get_clauses('after', Opts, expr),
-      {TClauses, SC} = elixir_erl_clauses:clauses(Meta, Do ++ After, S),
+      {TClauses, SC} = elixir_erl_clauses:clauses(Do ++ After, S),
       {FClauses, TAfter} = elixir_utils:split_last(TClauses),
       {_, _, [FExpr], _, FAfter} = TAfter,
       {{'receive', ?ann(Meta), FClauses, FExpr, FAfter}, SC}
@@ -262,14 +261,11 @@ translate(Other, S) ->
 
 %% Helpers
 
-translate_case(true, Meta, Expr, Opts, S) ->
+translate_case(Meta, Expr, Opts, S) ->
   Clauses = elixir_erl_clauses:get_clauses(do, Opts, match),
   {TExpr, SE} = translate(Expr, S),
-  {TClauses, SC} = elixir_erl_clauses:clauses(Meta, Clauses, SE),
-  {{'case', ?ann(Meta), TExpr, TClauses}, SC};
-translate_case(false, Meta, Expr, Opts, S) ->
-  {Case, SC} = translate_case(true, Meta, Expr, Opts, S),
-  {Case, elixir_erl_var:mergec(S, SC)}.
+  {TClauses, SC} = elixir_erl_clauses:clauses(Clauses, SE),
+  {{'case', ?ann(Meta), TExpr, TClauses}, SC}.
 
 translate_list([{'|', _, [_, _]=Args}], Fun, Acc, List) ->
   {[TLeft, TRight], TAcc} = lists:mapfoldl(Fun, Acc, Args),
@@ -398,7 +394,7 @@ translate_with_else(Meta, [{else, Else}], S) ->
 
   GeneratedElse = [build_generated_clause(Generated, ElseClause) || ElseClause <- Else],
 
-  Case = {'case', [{export_vars, false} | Generated], [ElseVarEx, [{do, GeneratedElse ++ [RaiseClause]}]]},
+  Case = {'case', Generated, [ElseVarEx, [{do, GeneratedElse ++ [RaiseClause]}]]},
   {TranslatedCase, SC} = elixir_erl_pass:translate(Case, SV),
   {{clause, ?ann(Generated), [ElseVarErl], [], [TranslatedCase]}, SC}.
 

--- a/lib/elixir/src/elixir_erl_var.erl
+++ b/lib/elixir/src/elixir_erl_var.erl
@@ -78,12 +78,10 @@ mergec(S1, S2) ->
 merge_vars(V, V) -> V;
 merge_vars(V1, V2) ->
   maps:fold(fun(K, M2, Acc) ->
-    V =
-      case Acc of
-        #{K := M1} when M1 > M2 -> M1;
-        _ -> M2
-      end,
-    maps:put(K, V, Acc)
+    case Acc of
+      #{K := M1} when M1 >= M2 -> Acc;
+      _ -> maps:put(K, M2, Acc)
+    end
   end, V1, V2).
 
 %% BINDINGS
@@ -93,7 +91,7 @@ load_binding(Binding, Scope) ->
   {NewBinding, NewKeys, Scope#elixir_erl{
     vars=NewVars,
     counter=#{'_' => NewCounter}
- }}.
+  }}.
 
 load_binding([{Key, Value} | T], Binding, Keys, Vars, Counter) ->
   Actual = case Key of

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -202,12 +202,12 @@ expand({quote, Meta, [_, _]}, E) ->
 expand({'&', Meta, [Arg]}, E) ->
   assert_no_match_or_guard_scope(Meta, "&", E),
   case elixir_fn:capture(Meta, Arg, E) of
-    {remote, Remote, Fun, Arity} ->
+    {{remote, Remote, Fun, Arity}, EE} ->
       is_atom(Remote) andalso
         elixir_lexical:record_remote(Remote, Fun, Arity, ?key(E, function), ?line(Meta), ?key(E, lexical_tracker)),
-      {{'&', Meta, [{'/', [], [{{'.', [], [Remote, Fun]}, [], []}, Arity]}]}, E};
-    {local, Fun, Arity} ->
-      {{'&', Meta, [{'/', [], [{Fun, [], nil}, Arity]}]}, E};
+      {{'&', Meta, [{'/', [], [{{'.', [], [Remote, Fun]}, [], []}, Arity]}]}, EE};
+    {{local, Fun, Arity}, EE} ->
+      {{'&', Meta, [{'/', [], [{Fun, [], nil}, Arity]}]}, EE};
     {expand, Expr, EE} ->
       expand(Expr, EE)
   end;
@@ -256,6 +256,7 @@ expand({for, Meta, [_ | _] = Args}, E) ->
     end,
 
   validate_opts(Meta, for, [do, into, uniq], Block, E),
+
   {Expr, Opts} =
     case lists:keytake(do, 1, Block) of
       {value, {do, Do}, DoOpts} ->
@@ -272,9 +273,9 @@ expand({for, Meta, [_ | _] = Args}, E) ->
 
   {EOpts, EO} = expand(Opts, E),
   {ECases, EC} = lists:mapfoldl(fun expand_for/2, EO, Cases),
-  {EExpr, _} = expand(Expr, EC),
+  {EExpr, EE} = expand(Expr, EC),
   assert_generator_start(Meta, ECases, E),
-  {{for, Meta, ECases ++ [[{do, EExpr} | EOpts]]}, E};
+  {{for, Meta, ECases ++ [[{do, EExpr} | EOpts]]}, elixir_env:merge_and_check_unused_vars(E, EE)};
 
 %% With
 
@@ -328,37 +329,48 @@ expand({'_', Meta, Kind}, E) when is_atom(Kind) ->
   form_error(Meta, ?key(E, file), ?MODULE, unbound_underscore);
 
 expand({Name, Meta, Kind} = Var, #{context := match} = E) when is_atom(Name), is_atom(Kind) ->
-  #{vars := Vars, current_vars := Current, prematch_vars := Prematch} = E,
+  #{unused_vars := Unused, current_vars := Current, prematch_vars := Prematch} = E,
   Pair = {Name, var_context(Meta, Kind)},
   PrematchVersion = var_version(Prematch, Pair),
 
-  NewCurrent =
+  EE =
     case Current of
       %% Variable is being overridden now
       #{Pair := {PrematchVersion, _}} ->
-        Current#{Pair := {PrematchVersion + 1, term}};
+        NewUnused = var_unused(Pair, Meta, PrematchVersion + 1, Unused),
+        NewCurrent = Current#{Pair => {PrematchVersion + 1, term}},
+        E#{unused_vars := NewUnused, current_vars := NewCurrent};
 
       %% Variable was already overriden
-      #{Pair := _} ->
+      #{Pair := {CurrentVersion, _}} ->
         maybe_warn_underscored_var_repeat(Meta, Name, Kind, E),
-        Current;
+        NewUnused = Unused#{{Pair, CurrentVersion} => false},
+        E#{unused_vars := NewUnused};
 
       %% Variable defined for the first time
       _ ->
-        Current#{Pair => {0, term}}
+        NewVars = ordsets:add_element(Pair, ?key(E, vars)),
+        NewUnused = var_unused(Pair, Meta, 0, Unused),
+        NewCurrent = Current#{Pair => {0, term}},
+        E#{vars := NewVars, unused_vars := NewUnused, current_vars := NewCurrent}
     end,
 
-  %% Deprecated variable handling
-  NewVars = ordsets:add_element(Pair, Vars),
-
-  {Var, E#{vars := NewVars, current_vars := NewCurrent}};
-expand({Name, Meta, Kind} = Var, #{current_vars := Current} = E) when is_atom(Name), is_atom(Kind) ->
+  {Var, EE};
+expand({Name, Meta, Kind} = Var, E) when is_atom(Name), is_atom(Kind) ->
+  #{unused_vars := Unused, current_vars := Current} = E,
   Pair = {Name, var_context(Meta, Kind)},
 
   case Current of
-    #{Pair := _} ->
+    #{Pair := {Version, _}} ->
       maybe_warn_underscored_var_access(Meta, Name, Kind, E),
-      {Var, E};
+      UnusedKey = {Pair, Version},
+
+      case Unused of
+        #{UnusedKey := Entry} when Entry /= false ->
+          {Var, E#{unused_vars := Unused#{UnusedKey := false}}};
+        _ ->
+          {Var, E}
+      end;
 
     _ ->
       case lists:keyfind(var, 1, Meta) of
@@ -468,12 +480,12 @@ expand(Other, E) ->
 
 %% Helpers
 
-escape_env_entries(Meta, #{current_vars := CurrentVars} = Env0) ->
+escape_env_entries(Meta, #{unused_vars := Unused, current_vars := Current} = Env0) ->
   Env1 = case Env0 of
     #{function := nil} -> Env0;
     _ -> Env0#{lexical_tracker := nil}
   end,
-  Env2 = Env1#{current_vars := escape_map(CurrentVars)},
+  Env2 = Env1#{unused_vars := escape_map(Unused), current_vars := escape_map(Current)},
   Env3 = elixir_env:linify({?line(Meta), Env2}),
   Env3.
 
@@ -570,6 +582,12 @@ expand_args(Args, E) ->
   {EArgs, elixir_env:mergea(EV, EC)}.
 
 %% Match/var helpers
+
+var_unused(Pair, Meta, Version, Unused) ->
+  case should_warn(Meta) of
+    true -> Unused#{{Pair, Version} => ?line(Meta)};
+    false -> Unused
+  end.
 
 var_version(Map, Pair) ->
   case Map of

--- a/lib/elixir/src/elixir_locals.erl
+++ b/lib/elixir/src/elixir_locals.erl
@@ -60,7 +60,7 @@ if_tracker(Module, Default, Callback) ->
 
 cache_env(#{line := Line, module := Module} = E) ->
   Table = elixir_module:data_table(Module),
-  Cache = E#{line := nil, vars := []},
+  Cache = elixir_env:reset_vars(E#{line := nil}),
 
   Pos =
     case ets:lookup(Table, ?cache) of

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -50,8 +50,8 @@ compile(Module, Block, Vars, #{line := Line} = Env) when is_atom(Module) ->
   %% we get rid of the lexical tracker information as, at this
   %% point, the lexical tracker process is long gone.
   LexEnv = case ?key(Env, function) of
-    nil -> Env#{module := Module};
-    _   -> Env#{lexical_tracker := nil, function := nil, module := Module}
+    nil -> Env#{module := Module, unused_vars := #{}};
+    _   -> Env#{lexical_tracker := nil, function := nil, module := Module, unused_vars := #{}}
   end,
 
   case ?key(LexEnv, lexical_tracker) of

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -222,7 +222,7 @@ build(Line, File, Module, Lexical) ->
 eval_form(Line, Module, Data, Block, Vars, E) ->
   {Value, EE} = elixir_compiler:eval_forms(Block, Vars, E),
   Pairs1 = elixir_overridable:store_pending(Module),
-  EV = elixir_env:linify({Line, reset_env(EE)}),
+  EV = elixir_env:linify({Line, elixir_env:reset_vars(EE)}),
   EC = eval_callbacks(Line, Data, before_compile, [EV], EV),
   Pairs2 = elixir_overridable:store_pending(Module),
   OverridablePairs = Pairs1 ++ Pairs2,
@@ -231,7 +231,7 @@ eval_form(Line, Module, Data, Block, Vars, E) ->
 eval_callbacks(Line, Data, Name, Args, E) ->
   Callbacks = ets:lookup_element(Data, Name, 2),
   lists:foldr(fun({M, F}, Acc) ->
-    expand_callback(Line, M, F, Args, reset_env(Acc),
+    expand_callback(Line, M, F, Args, elixir_env:reset_vars(Acc),
                     fun(AM, AF, AA) -> apply(AM, AF, AA) end)
   end, E, Callbacks).
 
@@ -257,9 +257,6 @@ expand_callback(Line, M, F, Args, E, Fun) ->
           erlang:raise(Kind, Reason, prune_stacktrace(Info, Stacktrace))
       end
   end.
-
-reset_env(Env) ->
-  Env#{vars := [], export_vars := nil}.
 
 %% Add attributes handling to the form
 

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -235,8 +235,8 @@ defmodule Kernel.ErrorsTest do
                       ~r"nofile:3: definitions with multiple clauses and default values require a header",
                       ~C'''
                       defmodule Kernel.ErrorsTest.ClauseWithDefaults1 do
-                        def hello(arg \\ 0), do: nil
-                        def hello(arg \\ 1), do: nil
+                        def hello(_arg \\ 0), do: nil
+                        def hello(_arg \\ 1), do: nil
                       end
                       '''
 

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -986,7 +986,7 @@ defmodule Kernel.ExpansionTest do
       assert expand(before_expansion) == after_expansion
     end
 
-    test "leaks vars" do
+    test "does not leak vars" do
       before_expansion =
         quote do
           cond do
@@ -1004,7 +1004,7 @@ defmodule Kernel.ExpansionTest do
             2 -> y = 2
           end
 
-          :erlang.+(x, y)
+          :erlang.+(x(), y())
         end
 
       assert expand(before_expansion) == after_expansion
@@ -1155,7 +1155,7 @@ defmodule Kernel.ExpansionTest do
       assert expand(before_expansion) == after_expansion
     end
 
-    test "leaks vars" do
+    test "does not leak vars" do
       before_expansion =
         quote do
           case w do
@@ -1173,7 +1173,7 @@ defmodule Kernel.ExpansionTest do
             y -> y = y
           end
 
-          :erlang.+(x, y)
+          :erlang.+(x(), y())
         end
 
       assert expand(before_expansion) == after_expansion
@@ -1322,7 +1322,7 @@ defmodule Kernel.ExpansionTest do
       assert expand(before_expansion) == after_expansion
     end
 
-    test "leaks vars" do
+    test "does not leak vars" do
       before_expansion =
         quote do
           receive do
@@ -1340,13 +1340,13 @@ defmodule Kernel.ExpansionTest do
             y -> y = y
           end
 
-          :erlang.+(x, y)
+          :erlang.+(x(), y())
         end
 
       assert expand(before_expansion) == after_expansion
     end
 
-    test "leaks vars on after" do
+    test "does not leak vars on after" do
       before_expansion =
         quote do
           receive do
@@ -1370,7 +1370,7 @@ defmodule Kernel.ExpansionTest do
               w = y()
           end
 
-          :erlang.+(x, w)
+          :erlang.+(x(), w())
         end
 
       assert expand(before_expansion) == after_expansion

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -26,28 +26,27 @@ defmodule Kernel.WarningTest do
     output =
       capture_err(fn ->
         Code.eval_string("""
+        top = 1
         defmodule Sample do
           def hello(arg), do: nil
-
-          if true do
-            user = :warning
-          else
-            :nothing
-          end
         end
+        bottom = 2
+        bottom = 3
+        bottom
         """)
       end)
 
+    assert output =~ "variable \"bottom\" is unused"
+    assert output =~ "variable \"top\" is unused"
     assert output =~ "variable \"arg\" is unused"
-    assert output =~ "variable \"user\" is unused"
   after
     purge(Sample)
   end
 
-  test "unsafe variable" do
-    message = "variable \"x\" is unsafe"
+  test "nested unused variable" do
+    message = "variable \"x\" is unused"
 
-    capture_err(fn ->
+    assert capture_err(fn ->
       assert_raise CompileError, ~r/undefined function x/, fn ->
         Code.eval_string("""
         case false do
@@ -59,7 +58,7 @@ defmodule Kernel.WarningTest do
       end
     end) =~ message
 
-    capture_err(fn ->
+    assert capture_err(fn ->
       assert_raise CompileError, ~r/undefined function x/, fn ->
         Code.eval_string("""
         false and (x = 1)
@@ -68,7 +67,7 @@ defmodule Kernel.WarningTest do
       end
     end) =~ message
 
-    capture_err(fn ->
+    assert capture_err(fn ->
       assert_raise CompileError, ~r/undefined function x/, fn ->
         Code.eval_string("""
         true or (x = 1)
@@ -77,7 +76,7 @@ defmodule Kernel.WarningTest do
       end
     end) =~ message
 
-    capture_err(fn ->
+    assert capture_err(fn ->
       assert_raise CompileError, ~r/undefined function x/, fn ->
         Code.eval_string("""
         if false do
@@ -88,7 +87,7 @@ defmodule Kernel.WarningTest do
       end
     end) =~ message
 
-    capture_err(fn ->
+    assert capture_err(fn ->
       assert_raise CompileError, ~r/undefined function x/, fn ->
         Code.eval_string("""
         cond do
@@ -100,7 +99,7 @@ defmodule Kernel.WarningTest do
       end
     end) =~ message
 
-    capture_err(fn ->
+    assert capture_err(fn ->
       assert_raise CompileError, ~r/undefined function x/, fn ->
         Code.eval_string("""
         receive do
@@ -113,7 +112,7 @@ defmodule Kernel.WarningTest do
       end
     end) =~ message
 
-    capture_err(fn ->
+    assert capture_err(fn ->
       assert_raise CompileError, ~r/undefined function x/, fn ->
         Code.eval_string("""
         false && (x = 1)
@@ -122,7 +121,7 @@ defmodule Kernel.WarningTest do
       end
     end) =~ message
 
-    capture_err(fn ->
+    assert capture_err(fn ->
       assert_raise CompileError, ~r/undefined function x/, fn ->
         Code.eval_string("""
         true || (x = 1)

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -48,71 +48,87 @@ defmodule Kernel.WarningTest do
     message = "variable \"x\" is unsafe"
 
     capture_err(fn ->
-      Code.eval_string("""
-      case false do
-        true -> x = 1
-        _ -> 1
+      assert_raise CompileError, ~r/undefined function x/, fn ->
+        Code.eval_string("""
+        case false do
+          true -> x = 1
+          _ -> 1
+        end
+        x
+        """)
       end
-      x
-      """)
     end) =~ message
 
     capture_err(fn ->
-      Code.eval_string("""
-      false and (x = 1)
-      x
-      """)
-    end) =~ message
-
-    capture_err(fn ->
-      Code.eval_string("""
-      true or (x = 1)
-      x
-      """)
-    end) =~ message
-
-    capture_err(fn ->
-      Code.eval_string("""
-      if false do
-        x = 1
+      assert_raise CompileError, ~r/undefined function x/, fn ->
+        Code.eval_string("""
+        false and (x = 1)
+        x
+        """)
       end
-      x
-      """)
     end) =~ message
 
     capture_err(fn ->
-      Code.eval_string("""
-      cond do
-        false -> x = 1
-        true -> 1
+      assert_raise CompileError, ~r/undefined function x/, fn ->
+        Code.eval_string("""
+        true or (x = 1)
+        x
+        """)
       end
-      x
-      """)
     end) =~ message
 
     capture_err(fn ->
-      Code.eval_string("""
-      receive do
-        :foo -> x = 1
-      after
-        0 -> 1
+      assert_raise CompileError, ~r/undefined function x/, fn ->
+        Code.eval_string("""
+        if false do
+          x = 1
+        end
+        x
+        """)
       end
-      x
-      """)
     end) =~ message
 
     capture_err(fn ->
-      Code.eval_string("""
-      false && (x = 1)
-      x
-      """)
+      assert_raise CompileError, ~r/undefined function x/, fn ->
+        Code.eval_string("""
+        cond do
+          false -> x = 1
+          true -> 1
+        end
+        x
+        """)
+      end
     end) =~ message
 
     capture_err(fn ->
-      Code.eval_string("""
-      true || (x = 1)
-      x
-      """)
+      assert_raise CompileError, ~r/undefined function x/, fn ->
+        Code.eval_string("""
+        receive do
+          :foo -> x = 1
+        after
+          0 -> 1
+        end
+        x
+        """)
+      end
+    end) =~ message
+
+    capture_err(fn ->
+      assert_raise CompileError, ~r/undefined function x/, fn ->
+        Code.eval_string("""
+        false && (x = 1)
+        x
+        """)
+      end
+    end) =~ message
+
+    capture_err(fn ->
+      assert_raise CompileError, ~r/undefined function x/, fn ->
+        Code.eval_string("""
+        true || (x = 1)
+        x
+        """)
+      end
     end) =~ message
   end
 

--- a/lib/elixir/test/erlang/control_test.erl
+++ b/lib/elixir/test/erlang/control_test.erl
@@ -39,7 +39,7 @@ try_test() ->
 
 try_else_test() ->
   {true, _} = eval("try do\n1\nelse 2 -> false\n1 -> true\nrescue\nErlangError -> nil\nend"),
-  {true, _} = eval("try do\n1\nelse {x, y} -> false\nx -> true\nrescue\nErlangError -> nil\nend"),
+  {true, _} = eval("try do\n1\nelse {_x, _y} -> false\n_x -> true\nrescue\nErlangError -> nil\nend"),
   {true, _} = eval("try do\n{1, 2}\nelse {3, 4} -> false\n_ -> true\nrescue\nErlangError -> nil\nend").
 
 % Receive
@@ -53,7 +53,7 @@ receive_test() ->
 
 case_test() ->
   {true, []} = eval("case 1 do\n2 -> false\n1 -> true\nend"),
-  {true, []} = eval("case 1 do\n{x, y} -> false\nx -> true\nend"),
+  {true, []} = eval("case 1 do\n{_x, _y} -> false\n_x -> true\nend"),
   {true, []} = eval("case {1, 2} do; {3, 4} -> false\n_ -> true\nend").
 
 case_with_do_ambiguity_test() ->

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -128,7 +128,7 @@ defmodule IEx.Evaluator do
 
   defp loop_state(server, history, opts) do
     env = opts[:env] || :elixir.env_for_eval(file: "iex")
-    env = %{env | match_vars: :apply}
+    env = %{env | prematch_vars: :apply}
     {_, _, env, scope} = :elixir.eval('import IEx.Helpers', [], env)
     stacktrace = opts[:stacktrace]
 


### PR DESCRIPTION
This gives us better control over when and how unused variables are printed.

As a result, we are able to emit unused variable warnings in situations
we could not before. This also opens up the way for us to remove a
dependency on erl_lint and track types information, which allows us to
speed up compilation times about 5% and allow us to emit more performant
code in some situations.
