### PR TITLE
Fix example of "Catching values of any kind"

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1776,19 +1776,19 @@ defmodule Kernel.SpecialForms do
   allows matching on both the *kind* of the caught value as well as the value
   itself:
 
-    try do
-      exit(:shutdown)
-    catch
-      :exit, value
-        IO.puts "Exited with value #{inspect(value)}"
-    end
+      try do
+        exit(:shutdown)
+      catch
+        :exit, value
+          IO.puts "Exited with value #{inspect(value)}"
+      end
 
-    try do
-      exit(:shutdown)
-    catch
-      kind, value when kind in [:exit, :throw] ->
-        IO.puts "Caught exit or throw with value #{inspect(value)}"
-    end
+      try do
+        exit(:shutdown)
+      catch
+        kind, value when kind in [:exit, :throw] ->
+          IO.puts "Caught exit or throw with value #{inspect(value)}"
+      end
 
   The `catch` clause also supports `:error` alongside `:exit` and `:throw` as
   in Erlang, although this is commonly avoided in favor of `raise`/`rescue` control


### PR DESCRIPTION
The code snippet in the section "Catching values of any kind" of the documentation of `try` had wrong indentation, because of that the snippet was wrongly formatted.

Before:
![image](https://user-images.githubusercontent.com/821260/35193170-58f18710-fe9f-11e7-8c60-d66793bc30ef.png)

After:
![image](https://user-images.githubusercontent.com/821260/35193178-64cbc654-fe9f-11e7-87fa-39d9e78331fd.png)
