### PR TITLE
Add typespec for Float.ratio/1

### DIFF
--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -380,6 +380,7 @@ defmodule Float do
 
   """
   @since "1.4.0"
+  @spec ratio(float) :: {pos_integer, pos_integer} | {neg_integer, pos_integer}
   def ratio(float) when is_float(float) do
     <<sign::1, exp::11, significant::52-bitstring>> = <<float::float>>
     {num, _, den} = decompose(significant)

--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -380,7 +380,7 @@ defmodule Float do
 
   """
   @since "1.4.0"
-  @spec ratio(float) :: {pos_integer, pos_integer} | {neg_integer, pos_integer}
+  @spec ratio(float) :: {pos_integer | neg_integer, pos_integer}
   def ratio(float) when is_float(float) do
     <<sign::1, exp::11, significant::52-bitstring>> = <<float::float>>
     {num, _, den} = decompose(significant)


### PR DESCRIPTION
While going through and adding the `@since` attributes, I notice that
this function was missing a typespec, so I figured I'd add it.

I went with `{pos_integer, pos_integer} | {neg_integer, pos_integer}`
as the return type instead of `{integer, pos_integer}` to make it clear
that we would never have a numerator of 0.