### PR TITLE
Change stdlib path to transparent for release/dev version

### DIFF
--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -142,8 +142,7 @@ defmodule IEx.HelpersTest do
   describe "open" do
     @iex_helpers "iex/lib/iex/helpers.ex"
     @elixir_erl "elixir/src/elixir.erl"
-    {:ok, vsn} = :application.get_key(:stdlib, :vsn)
-    @lists_erl "lib/stdlib-#{vsn}/src/lists.erl"
+    @lists_erl "#{:code.lib_dir(:stdlib, :src)}/lists.erl"
     @httpc_erl "src/http_client/httpc.erl"
     @editor System.get_env("ELIXIR_EDITOR")
 


### PR DESCRIPTION
If you build your otp version from sources you won't have stdlib path such as `"lib/stdlib-#{vsn}/src/"` but `"lib/stdlib/src/"`. In this case tests on development environment fails.

By using `{:code.lib_dir(:stdlib, :src)}` instead, you can get absolute path to the stdlib library so this solution is transparent for dev/release version.