### PR TITLE
Add IO.tee

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -310,6 +310,29 @@ defmodule IO do
     puts(device, [label, chardata])
     item
   end
+  
+  @doc """
+  Inspects `item` according to the given options using `stdio` and returns it.
+  This is useful for inspecting values in a chain of pipes.
+
+  See `inspect/2` for a full list of options.
+  """
+  @spec tee(item, keyword) :: item when item: var
+  def tee(item, opts \\ []) do
+    tee(:stdio, item, opts)
+  end
+
+  @doc """
+  Inspects `item` according to the given options using the IO `device` and returns it.
+  This is useful for inspecting values in a chain of pipes. 
+
+  See `inspect/2` for a full list of options.
+  """
+  @spec tee(device, item, keyword) :: item when item: var
+  def tee(device, item, opts) when is_list(opts) do
+    inspect(device, item, opts)
+    item
+  end
 
   @doc """
   Gets a number of bytes from IO device `:stdio`.

--- a/lib/elixir/test/elixir/io_test.exs
+++ b/lib/elixir/test/elixir/io_test.exs
@@ -185,4 +185,13 @@ defmodule IOTest do
     assert capture_io(fn -> IO.inspect(1, label: "foo") end) == "foo: 1\n"
     assert capture_io(fn -> IO.inspect(1, label: :foo) end) == "foo: 1\n"
   end
+  
+  test "tee" do
+    assert capture_io(fn -> IO.tee(1) end) == "1\n"
+    assert capture_io(fn -> IO.tee(1, label: "foo") end) == "foo: 1\n"
+    assert capture_io(fn -> IO.tee(1, label: :foo) end) == "foo: 1\n"
+    assert IO.tee(1) == 1
+    assert IO.tee(1, label: "foo") == "1"
+    assert IO.tee("foo") == "foo"
+  end
 end


### PR DESCRIPTION
`IO.tee` inspects an item identically to `IO.inspect`, but it also returns the item. This is useful for inspecting in the middle of a chain of pipes.