### PR TITLE
Fix version incompatible __info__(:deprecated) call

### DIFF
--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -329,12 +329,11 @@ defmodule Mix.Tasks.Xref do
 
   defp load_exports_and_deprecated(module) do
     if :code.is_loaded(module) do
-      # If the module is loaded, we will use the faster function_exported?/3
-      # check for exports and __info__/1 for deprecated
-      if function_exported?(module, :__info__, 1) do
+      try do
         {module, module.__info__(:deprecated)}
-      else
-        {module, []}
+      rescue
+        [ArgumentError, UndefinedFunctionError] ->
+          {module, []}
       end
     else
       # Otherwise we get the information from :beam_lib to avoid loading modules


### PR DESCRIPTION
Fixes errors such as this that seems to happen with code compiled on older Elixir versions:

```
** (ArgumentError) argument error
    :erlang.get_module_info(Hex, :deprecated)
    (hex) Hex.__info__/1
    (mix) lib/mix/tasks/xref.ex:333: Mix.Tasks.Xref.load_exports_and_deprecated/1
    (mix) lib/mix/tasks/xref.ex:326: Mix.Tasks.Xref.load_exports_and_deprecated_into_acc/2
    (elixir) lib/enum.ex:1906: Enum."-reduce/3-lists^foldl/2-0-"/3
    (mix) lib/mix/tasks/xref.ex:295: anonymous fn/2 in Mix.Tasks.Xref.source_warnings/2
    (elixir) lib/enum.ex:1906: Enum."-reduce/3-lists^foldl/2-0-"/3
    (mix) lib/mix/tasks/xref.ex:291: Mix.Tasks.Xref.source_warnings/2
```