### PR TITLE
Illustrate specifying function argument names in Writing Documentation docs

### DIFF
--- a/lib/elixir/pages/Writing Documentation.md
+++ b/lib/elixir/pages/Writing Documentation.md
@@ -46,7 +46,7 @@ When documenting a function, argument names are inferred by the compiler. For ex
 
 The compiler will infer this argument as `map`. Sometimes the inference will be suboptimal, especially if the function contains multiple clauses with the argument matching on different values each time. You can specify the proper names for documentation by declaring only the function head at any moment before the implementation:
 
-    def size(map)
+    def size(map_with_size)
     def size(%{size: size}) do
       size
     end


### PR DESCRIPTION
The previous example wasn't changing the name because `map` was inferred so I was confused about how this feature is supposed to work.