### PR TITLE
Flatten binary literals when optimizing concatenation

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1599,19 +1599,23 @@ defmodule Kernel do
   # Extracts concatenations in order to optimize many
   # concatenations into one single clause.
   defp extract_concatenations({:<>, _, [left, right]}) do
-    [wrap_concatenation(left) | extract_concatenations(right)]
+    wrap_concatenation(left) ++ extract_concatenations(right)
   end
 
   defp extract_concatenations(other) do
-    [wrap_concatenation(other)]
+    wrap_concatenation(other)
   end
 
   defp wrap_concatenation(binary) when is_binary(binary) do
-    binary
+    [binary]
+  end
+
+  defp wrap_concatenation({:<<>>, _, segments}) do
+    segments
   end
 
   defp wrap_concatenation(other) do
-    {:::, [], [other, {:binary, [], nil}]}
+    [{:::, [], [other, {:binary, [], nil}]}]
   end
 
   @doc """


### PR DESCRIPTION
Before, code like following:

    "foo" <> "bar #{x} baz"

Would create two strings and then concatenate them, after the change
this creates just one final string. The previous optimization did not
account for binary constructors, just for binary literals.