### PR TITLE
Add Enum.count/2 function for given element

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -576,11 +576,28 @@ defmodule Enum do
 
   """
   @spec count(t, (element -> as_boolean(term))) :: non_neg_integer
-  def count(enumerable, fun) do
+  def count(enumerable, fun) when is_function(fun) do
     reduce(enumerable, 0, fn entry, acc ->
       if(fun.(entry), do: acc + 1, else: acc)
     end)
   end
+
+  @doc """
+  Returns the count of items in the enumerable which are equal `===/2`
+  to given `element`.
+
+  ## Examples
+
+      iex> Enum.count([1, 2, 3, 3, 4, 5], 3)
+      2
+
+      iex> Enum.count([1, 2, 3, 4, 5], 7)
+      0
+
+  """
+  @since "1.7.0"
+  @spec count(t, element) :: non_neg_integer
+  def count(enumerable, element), do: count(enumerable, fn entry -> entry === element end)
 
   @doc """
   Enumerates the `enumerable`, returning a list where all consecutive

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -138,6 +138,11 @@ defmodule EnumTest do
     assert Enum.count([1, 2, 3], fn x -> rem(x, 2) == 0 end) == 1
     assert Enum.count([], fn x -> rem(x, 2) == 0 end) == 0
     assert Enum.count([1, true, false, nil], & &1) == 2
+
+    assert Enum.count([1, 2, 3], 2) == 1
+    assert Enum.count([], 3) == 0
+    assert Enum.count([1, 2, 4, 6], 3) == 0
+    assert Enum.count([1, true, false, nil], true) == 1
   end
 
   test "dedup/1" do


### PR DESCRIPTION
What you think about such new function for simplify counting elements?

Right now I can count given element by calling count/2 by with defining function: 

```elixir
# when I just want to count 3
Enum.count([1, 3, 2, 3, 4, 3], &(&1 === 3)) 
# or
Enum.count([1, 3, 2, 3, 4, 3], fn(entry) -> entry === 3))

```
After chages code can be more understandable:

```elixir
Enum.count([1, 3, 2, 3, 4, 3], 3) # when I just want to count 3
```

Side note: Maybe better name for `count` with function as a second argument could be `count_by` some time in future?