### PR TITLE
Copy doc and spec when using defdelegate

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4803,6 +4803,20 @@ defmodule Kernel do
       for fun <- List.wrap(funs) do
         {name, args, as, as_args} = Kernel.Utils.defdelegate(fun, opts)
 
+        unless Module.get_attribute(__MODULE__, :doc) do
+          Code.ensure_loaded(target)
+          docs = Code.get_docs(target, :docs) || []
+
+          case List.keyfind(docs, {name, arity}, 0) do
+            {_, _, _, _, doc} ->
+              @doc doc
+
+            nil ->
+              doc = "See `#{target}.#{name}/#{arity}`."
+              @doc doc
+          end
+        end
+
         def unquote(name)(unquote_splicing(args)) do
           unquote(target).unquote(as)(unquote_splicing(as_args))
         end

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4780,8 +4780,9 @@ defmodule Kernel do
   """
   defmacro defdelegate(funs, opts) do
     funs = Macro.escape(funs, unquote: true)
+    pos = :elixir_locals.cache_env(__CALLER__)
 
-    quote bind_quoted: [funs: funs, opts: opts] do
+    quote bind_quoted: [funs: funs, opts: opts, pos: pos] do
       target =
         Keyword.get(opts, :to) || raise ArgumentError, "expected to: to be given as argument"
 
@@ -4802,6 +4803,14 @@ defmodule Kernel do
 
       for fun <- List.wrap(funs) do
         {name, args, as, as_args} = Kernel.Utils.defdelegate(fun, opts)
+        arity = Enum.count(args)
+        all_specs = Kernel.Typespec.beam_specs(target) || []
+
+        with {_, specs} <- List.keyfind(all_specs, {name, arity}, 0) do
+          specs
+          |> Enum.map(&Kernel.Typespec.spec_to_ast(name, &1))
+          |> Enum.map(&Kernel.Typespec.defspec(:spec, &1, line, file, __MODULE__, pos))
+        end
 
         unless Module.get_attribute(__MODULE__, :doc) do
           Code.ensure_loaded(target)


### PR DESCRIPTION
Copies documentation and specs when using `defdelegate`.
This should make it easier and cleaner to use _context_ modules that delegate to _hidden_ (`@moduledoc false`) modules to provide specific functionality.

In the current setup documentation needs to be at the `defdelegate` location.
Leaving the target function without documentation.
Or creating the need to duplicate documentation.

The same goes for the spec.
Either duplication or omission.

**Documentation**

Checks whether documentation is already set.
If not it will look for documentation for the target function.
Copies the documentation if it is found.
Adds "_See `Module.function/aroty`._" as documentation if none is found.

**Spec**

Copies spec from target function.

**Issues**

Named arguments in specs.
I'm just creating the PR to get feedback on whether it is something that would be appreciated.
Annotated types needs to be renamed and in general lines need to updated.