### PR TITLE
Warn about comparison with calendar structs

### DIFF
--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1248,11 +1248,11 @@ defmodule Kernel.WarningTest do
         expression <- expressions do
       assert capture_err(fn ->
                Code.eval_string("x #{op} #{expression}", x: 1)
-             end) =~ "perform structural and not semantic comparison"
+             end) =~ "invalid comparison with struct literal"
 
       assert capture_err(fn ->
                Code.eval_string("#{expression} #{op} x", x: 1)
-             end) =~ "perform structural and not semantic comparison"
+             end) =~ "invalid comparison with struct literal"
     end
   end
 

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1241,10 +1241,7 @@ defmodule Kernel.WarningTest do
       "~N[2018-01-28 12:00:00]",
       "~T[12:00:00]",
       "~D[2018-01-28]",
-      "NaiveDateTime.utc_now()",
-      "DateTime.utc_now()",
-      "Time.utc_now()",
-      "Date.utc_today()"
+      "%File.Stat{}"
     ]
 
     for op <- [:<, :>, :<=, :>=],

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1236,6 +1236,29 @@ defmodule Kernel.WarningTest do
     purge(Sample)
   end
 
+  test "struct comparisons" do
+    expressions = [
+      "~N[2018-01-28 12:00:00]",
+      "~T[12:00:00]",
+      "~D[2018-01-28]",
+      "NaiveDateTime.utc_now()",
+      "DateTime.utc_now()",
+      "Time.utc_now()",
+      "Date.utc_today()"
+    ]
+
+    for op <- [:<, :>, :<=, :>=],
+        expression <- expressions do
+      assert capture_err(fn ->
+               Code.eval_string("x #{op} #{expression}", x: 1)
+             end) =~ "perform structural and not semantic comparison"
+
+      assert capture_err(fn ->
+               Code.eval_string("#{expression} #{op} x", x: 1)
+             end) =~ "perform structural and not semantic comparison"
+    end
+  end
+
   defp purge(list) when is_list(list) do
     Enum.each(list, &purge/1)
   end


### PR DESCRIPTION
People are frequently confused about results of comparison of structs. This is frequently experienced with calendar structs. This PR tries to catch common erroneous expressions in the compiler and issue warnings at compile-time.