### PR TITLE
Add optional callbacks to IEx.Introspection.b/1 output

### DIFF
--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -521,8 +521,31 @@ defmodule IEx.Introspection do
               {format_callback(kind, fun, {fun, arity}, callbacks), doc}
           end)
 
+        docs =
+          case get_optional_callbacks(mod) do
+            [] ->
+              docs
+
+            nil ->
+              docs
+
+            opt_callbacks ->
+              docs ++ [{format_optional_callbacks(opt_callbacks), ""}]
+          end
+
         {:ok, docs}
     end
+  end
+
+  defp get_optional_callbacks(mod) do
+    if function_exported?(mod, :behaviour_info, 1) do
+      mod.behaviour_info(:optional_callbacks)
+    end
+  end
+
+  defp format_optional_callbacks(callbacks) do
+    format_typespec(callbacks, :optional_callbacks)
+    |> pair(?\n)
   end
 
   defp format_callback(kind, name, key, callbacks) do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -568,7 +568,32 @@ defmodule IEx.HelpersTest do
       assert capture_io(fn -> b(NoMix.run()) end) == "Could not load module NoMix, got: nofile\n"
 
       assert capture_io(fn -> b(Exception.message() / 1) end) ==
-               "@callback message(t()) :: String.t()\n\n"
+               "@callback message(t()) :: String.t()\n\n@optional_callbacks [blame: 2]\n\n\n"
+    end
+
+    test "prints optional callback" do
+      filename = "optional_callbacks.ex"
+
+      content = """
+      defmodule OptionalCallbacks do
+        @doc "callback"
+        @callback optional_1(:foo) :: integer
+        @optional_callbacks optional_1: 1
+      end
+      """
+
+      with_file(filename, content, fn ->
+        assert c(filename, ".") == [OptionalCallbacks]
+
+        assert capture_io(fn -> b(OptionalCallbacks) end) =~ """
+               @callback optional_1(:foo) :: integer()
+
+               @optional_callbacks [optional_1: 1]
+
+               """
+      end)
+    after
+      cleanup_modules([OptionalCallbacks])
     end
   end
 

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -568,7 +568,7 @@ defmodule IEx.HelpersTest do
       assert capture_io(fn -> b(NoMix.run()) end) == "Could not load module NoMix, got: nofile\n"
 
       assert capture_io(fn -> b(Exception.message() / 1) end) ==
-               "@callback message(t()) :: String.t()\n\n@optional_callbacks [blame: 2]\n\n\n"
+               "@callback message(t()) :: String.t()\n\n"
     end
 
     test "prints optional callback" do


### PR DESCRIPTION
This is an attempt of solving #7267.

Output:
```
iex(1) b GenServer
@callback code_change(old_vsn, state :: term(), extra :: term()) ::
            {:ok, new_state :: term()}
            | {:error, reason :: term()}
            | {:down, term()}
          when old_vsn: term()

@callback format_status(reason, pdict_and_state :: list()) :: term()
          when reason: :normal | :terminate

@callback handle_call(request :: term(), from(), state :: term()) ::
            {:reply, reply, new_state}
            | {:reply, reply, new_state, timeout() | :hibernate}
            | {:noreply, new_state}
            | {:noreply, new_state, timeout() | :hibernate}
            | {:stop, reason, reply, new_state}
            | {:stop, reason, new_state}
          when reply: term(), new_state: term(), reason: term()

@callback handle_cast(request :: term(), state :: term()) ::
            {:noreply, new_state}
            | {:noreply, new_state, timeout() | :hibernate}
            | {:stop, reason :: term(), new_state}
          when new_state: term()

@callback handle_info(msg :: :timeout | term(), state :: term()) ::
            {:noreply, new_state}
            | {:noreply, new_state, timeout() | :hibernate}
            | {:stop, reason :: term(), new_state}
          when new_state: term()

@callback init(args :: term()) ::
            {:ok, state}
            | {:ok, state, timeout() | :hibernate}
            | :ignore
            | {:stop, reason :: any()}
          when state: any()

@callback terminate(reason, state :: term()) :: term()
          when reason: :normal | :shutdown | {:shutdown, term()}

@optional_callbacks [format_status: 2]

iex(2)> b Application
@callback start(start_type(), start_args :: term()) ::
            {:ok, pid()} | {:ok, pid(), state()} | {:error, reason :: term()}

@callback start_phase(phase :: term(), start_type(), phase_args :: term()) ::
            :ok | {:error, reason :: term()}

@callback stop(state()) :: term()

@optional_callbacks [start_phase: 3]
```

I've taken the info on optional_callbacks from `mod.behaviour_info(:optional_callbacks)`.