### PR TITLE
Add missing & in port zombie script

### DIFF
--- a/lib/elixir/lib/port.ex
+++ b/lib/elixir/lib/port.ex
@@ -132,7 +132,7 @@ defmodule Port do
   script in bash:
 
       #!/bin/sh
-      "$@"
+      "$@" &
       pid=$!
       while read line ; do
         :


### PR DESCRIPTION
This is needed to background the processing being run so that control
could move on to the read loop.