### PR TITLE
Defines the prep_stop/1 optional callback for applications

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -79,10 +79,20 @@ defmodule Application do
     * [`:application` module](http://www.erlang.org/doc/man/application.html)
     * [Applications – OTP Design Principles](http://www.erlang.org/doc/design_principles/applications.html)
 
-  A developer may also implement the `stop/1` callback (automatically defined
-  by `use Application`) which does any application cleanup. It receives the
-  application state and can return any value. Note that shutting down the
-  supervisor is automatically handled by the VM.
+  When an application is shutting down, its `c:stop/1` callback is called after
+  the supervision tree has been stopped by `kernel`. This callback allows the
+  application to do any final cleanup. The argument is the state returned by
+  `c:start/2`, if it did, or `[]` otherwise. The return value of `c:stop/1` is
+  ignored.
+
+  By using `Application`, modules get a default implementation of `c:stop/1`
+  that ignores its argument and returns `:ok`, but it can ben overridden.
+
+  Application callback modules may also implement the optional callback
+  `c:prep_stop/1`. If present, `c:prep_stop/1` is invoked by `kernel` before
+  the supervision tree is terminated. Its argument is the state returned by
+  `c:start/2`, if it did, or `[]` otherwise, and its return value is passed to
+  `c:stop/1`.
 
   An application without a supervision tree doesn't define an application
   module callback in the application definition in `mix.exs` file. Even though
@@ -186,15 +196,25 @@ defmodule Application do
               | {:error, reason :: term}
 
   @doc """
+  Called before stopping the application.
+
+  This function is called before the top-level supervisor is terminated. It
+  receives the state returned by `c:start/2`, if it did, or `[]` otherwise.
+  The return value is later passed to `c:stop/1`.
+  """
+  @callback prep_stop(state) :: state
+
+  @doc """
   Called after an application has been stopped.
 
   This function is called after an application has been stopped, i.e., after its
   supervision tree has been stopped. It should do the opposite of what the
-  `start/2` callback did, and should perform any necessary cleanup. The return
+  `c:start/2` callback did, and should perform any necessary cleanup. The return
   value of this callback is ignored.
 
-  `state` is the return value of the `start/2` callback or the return value of
-  the `prep_stop/1` function if the application module defines such a function.
+  `state` is the state returned by `c:start/2`, if it did, or `[]` otherwise.
+  If the optional callback `c:prep_stop/1` is present, `state` is its return
+  value instead.
 
   `use Application` defines a default implementation of this function which does
   nothing and just returns `:ok`.
@@ -212,7 +232,7 @@ defmodule Application do
   @callback start_phase(phase :: term, start_type, phase_args :: term) ::
               :ok | {:error, reason :: term}
 
-  @optional_callbacks start_phase: 3
+  @optional_callbacks start_phase: 3, prep_stop: 1
 
   @doc false
   defmacro __using__(_) do

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -80,19 +80,18 @@ defmodule Application do
     * [Applications – OTP Design Principles](http://www.erlang.org/doc/design_principles/applications.html)
 
   When an application is shutting down, its `c:stop/1` callback is called after
-  the supervision tree has been stopped by `kernel`. This callback allows the
+  the supervision tree has been stopped by the runtime. This callback allows the
   application to do any final cleanup. The argument is the state returned by
   `c:start/2`, if it did, or `[]` otherwise. The return value of `c:stop/1` is
   ignored.
 
   By using `Application`, modules get a default implementation of `c:stop/1`
-  that ignores its argument and returns `:ok`, but it can ben overridden.
+  that ignores its argument and returns `:ok`, but it can be overridden.
 
   Application callback modules may also implement the optional callback
-  `c:prep_stop/1`. If present, `c:prep_stop/1` is invoked by `kernel` before
-  the supervision tree is terminated. Its argument is the state returned by
-  `c:start/2`, if it did, or `[]` otherwise, and its return value is passed to
-  `c:stop/1`.
+  `c:prep_stop/1`. If present, `c:prep_stop/1` is invoked before the supervision
+  tree is terminated. Its argument is the state returned by `c:start/2`, if it did,
+  or `[]` otherwise, and its return value is passed to `c:stop/1`.
 
   An application without a supervision tree doesn't define an application
   module callback in the application definition in `mix.exs` file. Even though


### PR DESCRIPTION
This PR defines the `prep_stop/1` optional callback for application callback modules. See the [original Erlang/OTP documentation](http://erlang.org/doc/apps/kernel/application.html#Module:prep_stop-1). As of this writing, the application master invokes that callback [here](https://github.com/erlang/otp/blob/1fe1c9a57d365c8203cb1380e4bdfe8f7f6ab8ce/lib/kernel/src/application_master.erl#L377).

In some places, the wording is deliberately a bit vague in identifying applications with application callback modules, to be coherent with the existing style (an application is a broader concept and may not have a callback module associated, you know).

The patch also complements the description of the argument of `stop/1` when `start/2` does not return a state.

The description mentions `kernel` in passing. I believe that way help build a mental model that is good enough. If you say nothing, the reader may be wondering who is doing that. There was a spot that said "the VM", maybe too generic. Some Erlang docs say "the application master", which is more specific and probably the best option, but this documentation does not introduce this concept by now, so you cannot use it. `kernel` seemed like a sweet spot to me in the current docs.