### PR TITLE
Teach Mix erlang compiler alternative spelling for -behavior declaration

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -165,6 +165,9 @@ defmodule Mix.Tasks.Compile.Erlang do
       {:attribute, _, :behaviour, behaviour} ->
         %{erl | behaviours: [behaviour | erl.behaviours]}
 
+      {:attribute, _, :behavior, behaviour} ->
+        %{erl | behaviours: [behaviour | erl.behaviours]}
+
       {:attribute, _, :compile, value} when is_list(value) ->
         %{erl | compile: value ++ erl.compile}
 


### PR DESCRIPTION
Erlang recognizes both -behaviour and -behavior, but mix was only able to
process one, which made erlang compiler complain about missing behaviour
when source file was using the other one