### PR TITLE
Mix test with only option raise a error if no tests matched

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -282,11 +282,11 @@ defmodule Mix.Tasks.Test do
             System.at_exit(fn _ -> exit({:shutdown, 1}) end)
 
           excluded == total and option_only_present and opts[:raise] ->
-              Mix.raise("no test matched only option")
-          
+            Mix.raise("no test matched only option")
+
           excluded == total and option_only_present ->
-              Mix.shell().error("no test matched only option")
-              System.at_exit(fn _ -> exit({:shutdown, 1}) end)
+            Mix.shell().error("no test matched only option")
+            System.at_exit(fn _ -> exit({:shutdown, 1}) end)
 
           true ->
             :ok

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -272,7 +272,7 @@ defmodule Mix.Tasks.Test do
       {:ok, %{excluded: excluded, failures: failures, total: total}} ->
         cover && cover.()
 
-        option_only_present = Keyword.has_key?(opts, :only)
+        option_only_present? = Keyword.has_key?(opts, :only)
 
         cond do
           failures > 0 and opts[:raise] ->
@@ -281,11 +281,11 @@ defmodule Mix.Tasks.Test do
           failures > 0 ->
             System.at_exit(fn _ -> exit({:shutdown, 1}) end)
 
-          excluded == total and option_only_present and opts[:raise] ->
-            Mix.raise("no test matched only option")
+          excluded == total and option_only_present? and opts[:raise] ->
+            Mix.raise("The --only option was given to \"mix test\" but no test executed")
 
-          excluded == total and option_only_present ->
-            Mix.shell().error("no test matched only option")
+          excluded == total and option_only_present? ->
+            Mix.shell().error("The --only option was given to \"mix test\" but no test executed")
             System.at_exit(fn _ -> exit({:shutdown, 1}) end)
 
           true ->


### PR DESCRIPTION
Fix for issue #7294 

`mix test` raise a error if the only option is used and the excluded and total number of tests is equal