### PR TITLE
Unify *.to_iso8601 functions for calendar types

### DIFF
--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -306,9 +306,17 @@ defmodule Date do
 
   """
   @spec to_iso8601(Calendar.date(), :extended | :basic) :: String.t()
-  def to_iso8601(date, format \\ :extended) when format in [:basic, :extended] do
-    %{year: year, month: month, day: day} = convert!(date, Calendar.ISO)
+  def to_iso8601(date, format \\ :extended)
+
+  def to_iso8601(%{calendar: Calendar.ISO} = date, format) when format in [:basic, :extended] do
+    %{year: year, month: month, day: day} = date
     Calendar.ISO.date_to_iso8601(year, month, day, format)
+  end
+
+  def to_iso8601(%{calendar: _} = date, format) when format in [:basic, :extended] do
+    date
+    |> convert!(Calendar.ISO)
+    |> to_iso8601()
   end
 
   @doc """

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -416,12 +416,8 @@ defmodule DateTime do
   @spec to_iso8601(Calendar.datetime(), :extended | :basic) :: String.t()
   def to_iso8601(datetime, format \\ :extended)
 
-  def to_iso8601(_, format) when format not in [:extended, :basic] do
-    raise ArgumentError,
-          "DateTime.to_iso8601/2 expects format to be :extended or :basic, got: #{inspect(format)}"
-  end
-
-  def to_iso8601(%{calendar: Calendar.ISO} = datetime, format) do
+  def to_iso8601(%{calendar: Calendar.ISO} = datetime, format)
+      when format in [:extended, :basic] do
     %{
       year: year,
       month: month,
@@ -452,7 +448,7 @@ defmodule DateTime do
     )
   end
 
-  def to_iso8601(%{calendar: _} = datetime, format) do
+  def to_iso8601(%{calendar: _} = datetime, format) when format in [:extended, :basic] do
     datetime
     |> convert!(Calendar.ISO)
     |> to_iso8601(format)

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -568,12 +568,6 @@ defmodule NaiveDateTime do
     |> to_iso8601(format)
   end
 
-  def to_iso8601(_date, format) do
-    raise ArgumentError,
-          "NaiveDateTime.to_iso8601/2 expects format to be :extended or :basic, " <>
-            "got: #{inspect(format)}"
-  end
-
   @doc """
   Converts a `NaiveDateTime` struct to an Erlang datetime tuple.
 

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -288,15 +288,23 @@ defmodule Time do
 
   """
   @spec to_iso8601(Calendar.time(), :extended | :basic) :: String.t()
-  def to_iso8601(time, format \\ :extended) when format in [:extended, :basic] do
+  def to_iso8601(time, format \\ :extended)
+
+  def to_iso8601(%{calendar: Calendar.ISO} = time, format) when format in [:extended, :basic] do
     %{
       hour: hour,
       minute: minute,
       second: second,
       microsecond: microsecond
-    } = convert!(time, Calendar.ISO)
+    } = time
 
     Calendar.ISO.time_to_iso8601(hour, minute, second, microsecond, format)
+  end
+
+  def to_iso8601(%{calendar: _} = time, format) when format in [:extended, :basic] do
+    time
+    |> convert!(Calendar.ISO)
+    |> to_iso8601(format)
   end
 
   @doc """


### PR DESCRIPTION
* Fastlane structs already in the ISO calendar
* crash with `FunctionClauseError` on bad format. This should actually improve the error message in dev and test given exception blaming. Previously the "bad format" argument error would be also raised when the function was given not a calendar struct (but, for example an erlang style tuple) - very confusing!