### PR TITLE
Update doc for DynamicSupervisor.start_child

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -106,7 +106,7 @@ defmodule DynamicSupervisor do
         def start_child(foo, bar, baz) do
           # If MyWorker is not using the new child specs, we need to pass a map:
           # spec = %{id: MyWorker, start: {MyWorker, :start_link, [foo, bar, baz]}}
-          spec = MyWorker
+          spec = {MyWorker, foo, bar, baz}
           DynamicSupervisor.start_child(__MODULE__, spec)
         end
 

--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -106,7 +106,7 @@ defmodule DynamicSupervisor do
         def start_child(foo, bar, baz) do
           # If MyWorker is not using the new child specs, we need to pass a map:
           # spec = %{id: MyWorker, start: {MyWorker, :start_link, [foo, bar, baz]}}
-          spec = {MyWorker, foo, bar, baz}
+          spec = {MyWorker, foo: foo, bar: bar, baz: baz}
           DynamicSupervisor.start_child(__MODULE__, spec)
         end
 


### PR DESCRIPTION
The example makes it appear like the arguments to `def start_child`: `foo, bar, baz` are being ignored by the line `spec = MyWorker`. I *think* this would be the correct way to delegate the module and arguments to `DynamicSupervisor.start_child` in the implied case that MyWorker is using the new child specs. If not, I'd be curious about the preferred approach.