### PR TITLE
Use contextual vars for __CALLER__

### DIFF
--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -140,7 +140,7 @@ store_definition(Kind, CheckClauses, Call, Body, Pos) ->
 store_definition(Meta, Kind, CheckClauses, Name, Arity, DefaultsArgs, Guards, Body, File, ER) ->
   Module = ?key(ER, module),
   Tuple = {Name, Arity},
-  E = ER#{function := Tuple},
+  E = env_for_expansion(Kind, Tuple, ER),
 
   {Args, Defaults} = unpack_defaults(Kind, Meta, Name, DefaultsArgs, E),
   Clauses = [elixir_clauses:def(Clause, E) ||
@@ -156,6 +156,12 @@ store_definition(Meta, Kind, CheckClauses, Name, Arity, DefaultsArgs, Guards, Bo
   [store_definition(false, Kind, Meta, Name, length(DefaultArgs), File,
                     Module, 0, [Default]) || {_, DefaultArgs, _, _} = Default <- Defaults],
   Tuple.
+
+env_for_expansion(Kind, Tuple, #{contextual_vars := ContextualVars} = E)
+    when Kind =:= defmacro; Kind =:= defmacrop ->
+  E#{function := Tuple, contextual_vars := ['__CALLER__' | ContextualVars]};
+env_for_expansion(_Kind, Tuple, E) ->
+  E#{function := Tuple}.
 
 retrieve_location(Location, Module) ->
   case ets:take(elixir_module:data_table(Module), file) of

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -42,7 +42,7 @@ defmodule Kernel.ErrorsTest do
 
   test "invalid __CALLER__" do
     assert_eval_raise CompileError,
-                      "nofile:1: variable '__CALLER__' is unbound",
+                      "nofile:1: __CALLER__ is available only inside defmacro and defmacrop",
                       'defmodule Sample do def hello do __CALLER__ end end'
   end
 


### PR DESCRIPTION
I tried using the `contextual_vars` introduced along with `__STACKTRACE__` to give better error messages for `__CALLER__`. I think, I have the consumption part ready, but I can't really understand where I would set it, that the variable is available.

Any tips welcome.