### PR TITLE
is_integer guard for `n` argument in Stream.drop/2

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -323,11 +323,11 @@ defmodule Stream do
 
   """
   @spec drop(Enumerable.t(), non_neg_integer) :: Enumerable.t()
-  def drop(enum, n) when n >= 0 do
+  def drop(enum, n) when is_integer(n) and n >= 0 do
     lazy(enum, n, fn f1 -> R.drop(f1) end)
   end
 
-  def drop(enum, n) when n < 0 do
+  def drop(enum, n) when is_integer(n) and n < 0 do
     n = abs(n)
 
     lazy(enum, {0, [], []}, fn f1 ->


### PR DESCRIPTION
Before this change providing non-number produces harder to understand error "bad argument in arithmetic expression" like this:
```
[1,2,3] |> Stream.drop(nil) |> Enum.to_list
** (ArithmeticError) bad argument in arithmetic expression
    (elixir) lib/stream.ex:293: anonymous fn/3 in Stream.drop/2
    (elixir) lib/enum.ex:3161: Enumerable.List.reduce/3
    (elixir) lib/stream.ex:1433: Enumerable.Stream.do_each/4
    (elixir) lib/enum.ex:1823: Enum.reverse/1
    (elixir) lib/enum.ex:2581: Enum.to_list/1
```
And floating point numbers give results like this:
```
[1,2,3] |> Stream.drop(1.1) |> Enum.to_list
[3]
```
All other similar functions that I've checked have these guards (i.e. Enum.drop, Stream.take).