### PR TITLE
fix DynamicSupervisor error report

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -939,7 +939,7 @@ defmodule DynamicSupervisor do
 
   defp report_error(error, reason, pid, child, %{name: name}) do
     :error_logger.error_report(
-      :supervision_report,
+      :supervisor_report,
       supervisor: name,
       errorContext: error,
       reason: reason,


### PR DESCRIPTION
DynamicSupervisor doesn't trigger SASL reports on child restarts due to a typo in the report type. Here's Erlang's supervisor for comparison:
https://github.com/erlang/otp/blob/master/lib/stdlib/src/supervisor.erl#L1394

I tried to add a relevant test, but it got messy very quickly. I'll be happy to look into that once I have a bit more time. For now I tested the fix and I was able to get SASL reports for my DynamicSupervisor.