### PR TITLE
Conform the spec for String.slice/3 to its guard clauses

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1736,7 +1736,7 @@ defmodule String do
       ""
 
   """
-  @spec slice(t, integer, integer) :: grapheme
+  @spec slice(t, integer, non_neg_integer) :: grapheme
 
   def slice(_, _, 0) do
     ""


### PR DESCRIPTION
The guard clauses of [_String.slice/3_](https://github.com/elixir-lang/elixir/blob/e9dfa50c74488000d2c9de71e926cdd78609b3ac/lib/elixir/lib/string.ex#L1739) exclude negative numbers for the _length_ argument. The function’s spec does not agree, specifying it as `integer` rather than `non_neg_integer`.