### PR TITLE
Fix - Allow to use a dot_formatter config file in a different folder which imports dependencies

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -138,8 +138,11 @@ defmodule Mix.Tasks.Format do
 
   defp eval_dot_formatter(opts) do
     case dot_formatter(opts) do
-      {:ok, dot_formatter} -> {Path.dirname(dot_formatter), eval_file_with_keyword_list(dot_formatter)}
-      :error -> {nil, []}
+      {:ok, dot_formatter} ->
+        {Path.dirname(dot_formatter), eval_file_with_keyword_list(dot_formatter)}
+
+      :error ->
+        {nil, []}
     end
   end
 

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -219,7 +219,8 @@ defmodule Mix.Tasks.FormatTest do
     end
   end
 
-  test "can read exported configuration from dependencies with .formatter.exs in a different folder", context do
+  test "can read exported configuration from dependencies with .formatter.exs in a different folder",
+       context do
     Mix.Project.push(__MODULE__.FormatWithDepsApp)
 
     in_tmp context.test, fn ->


### PR DESCRIPTION
This PR changes the `format.ex` mix task and updates the corresponding test.

`eval_dot_formatter/1` now returns a two value tuple with the first value being the directory of the evaluated `dot_formatter` file. The second value are the actual `dot_formatter` options.

It then passes this `formatter_dir` to `fetch_deps_opts` which now has an arity two implementation. This implementation receives the `formatter_opts` and the `formatter_dir` as second argument. Take a look at the header.

```elixir
defp fetch_deps_opts(formatter_opts, in_directory: nil)
```

If the directory is non nil, it wraps the call to `fetch_deps_opts/1` in a `File.cd!/2` call. This ensures that the dependencies are actually loaded from the same directory in which the `dot_formatter` resides.

Fixes #7327 