### PR TITLE
Bring back Mix.Shell.cmd/2

### DIFF
--- a/lib/mix/lib/mix/shell.ex
+++ b/lib/mix/lib/mix/shell.ex
@@ -81,7 +81,7 @@ defmodule Mix.Shell do
     * `:quiet` - overrides the callback to no-op
 
   """
-  def cmd(command, options, callback) when is_function(callback, 1) do
+  def cmd(command, options \\ [], callback) when is_function(callback, 1) do
     callback =
       if Keyword.get(options, :quiet, false) do
         fn x -> x end


### PR DESCRIPTION
It was not brought back when Mix.Shell.cmd/3 was "undeprecated" in b2e5b69.

This broke couple projects including test suite of mariaex.