### PR TITLE
Use ISO8601 for System.build_info :date

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -139,7 +139,7 @@ defmodule System do
 
   # Get the date at compilation time.
   defmacrop get_date do
-    IO.iodata_to_binary(:httpd_util.rfc1123_date())
+    DateTime.utc_now() |> DateTime.to_iso8601()
   end
 
   @doc """


### PR DESCRIPTION
The current implementation of this field uses rfc1123. This will change it to use to_iso8601 so that it can easily be parsed using built in types later.