### PR TITLE
Prevent operators with many of same char to have same char after them

### DIFF
--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1226,6 +1226,7 @@ invalid_do_with_fn_error(Prefix) ->
   "    fn pattern -> expression end\n\n"
   "Syntax error before: ".
 
+% TODO: Turn into an error on Elixir 2.0.
 maybe_warn_too_many_of_same_char([T | _] = Token, [T | _] = _Rest, Line, Scope) ->
   Warning =
     case T of

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -1233,7 +1233,6 @@ maybe_warn_too_many_of_same_char([T | _] = Token, [T | _] = _Rest, Line, Scope) 
       $. -> "please use parens around \"...\" instead";
       _ -> io_lib:format("please use a space between \"~ts\" and the next \"~ts\"", [Token, [T]])
     end,
-  Message =
   Message = io_lib:format("found \"~ts\" followed by \"~ts\", ~ts", [Token, [T], Warning]),
   elixir_errors:warn(Line, Scope#elixir_tokenizer.file, Message);
 maybe_warn_too_many_of_same_char(_Token, _Rest, _Line, _Scope) ->

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -36,9 +36,11 @@
 -define(unary_op3(T1, T2, T3),
   T1 == $~, T2 == $~, T3 == $~).
 
--define(two_op(T1, T2),
+-define(list_op(T1, T2),
   T1 == $+, T2 == $+;
-  T1 == $-, T2 == $-;
+  T1 == $-, T2 == $-).
+
+-define(two_op(T1, T2),
   T1 == $<, T2 == $>;
   T1 == $., T2 == $.).
 
@@ -279,8 +281,8 @@ tokenize([$:, T1, T2, T3 | Rest], Line, Column, Scope, Tokens) when
 % ## Two Token Operators
 tokenize([$:, T1, T2 | Rest], Line, Column, Scope, Tokens) when
     ?comp_op2(T1, T2); ?rel_op2(T1, T2); ?and_op(T1, T2); ?or_op(T1, T2);
-    ?arrow_op(T1, T2); ?in_match_op(T1, T2); ?two_op(T1, T2); ?stab_op(T1, T2);
-    ?type_op(T1, T2) ->
+    ?arrow_op(T1, T2); ?in_match_op(T1, T2); ?two_op(T1, T2); ?list_op(T1, T2);
+    ?stab_op(T1, T2); ?type_op(T1, T2) ->
   Token = {atom, {Line, Column, nil}, list_to_atom([T1, T2])},
   tokenize(Rest, Line, Column + 3, Scope, [Token | Tokens]);
 
@@ -347,6 +349,9 @@ tokenize([T | Rest], Line, Column, Scope, Tokens) when T == $); T == $}; T == $]
 
 % ## Two Token Operators
 tokenize([T1, T2 | Rest], Line, Column, Scope, Tokens) when ?two_op(T1, T2) ->
+  handle_op(Rest, Line, Column, two_op, 2, list_to_atom([T1, T2]), Scope, Tokens);
+
+tokenize([T1, T2 | Rest], Line, Column, Scope, Tokens) when ?list_op(T1, T2) ->
   maybe_warn_too_many_of_same_char([T1, T2], Rest, Line, Scope),
   handle_op(Rest, Line, Column, two_op, 2, list_to_atom([T1, T2]), Scope, Tokens);
 
@@ -627,7 +632,7 @@ handle_dot([$., T1, T2, T3 | Rest], Line, Column, DotInfo, Scope, Tokens) when
 % ## Two Token Operators
 handle_dot([$., T1, T2 | Rest], Line, Column, DotInfo, Scope, Tokens) when
     ?comp_op2(T1, T2); ?rel_op2(T1, T2); ?and_op(T1, T2); ?or_op(T1, T2);
-    ?arrow_op(T1, T2); ?in_match_op(T1, T2); ?two_op(T1, T2); ?type_op(T1, T2) ->
+    ?arrow_op(T1, T2); ?in_match_op(T1, T2); ?two_op(T1, T2); ?list_op(T1, T2); ?type_op(T1, T2) ->
   handle_call_identifier(Rest, Line, Column, DotInfo, 2, list_to_atom([T1, T2]), Scope, Tokens);
 
 % ## Single Token Operators

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -22,6 +22,15 @@ defmodule Kernel.WarningTest do
     assert output =~ "nofile:2"
   end
 
+  test "operators formed by many of the same character followed by that character" do
+    output =
+      capture_err(fn ->
+        Code.eval_string("quote do: ....()")
+      end)
+
+    assert output =~ "found \"...\" followed by \".\", please use parens around \"...\" instead"
+  end
+
   test "unused variable" do
     output =
       capture_err(fn ->

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -210,3 +210,7 @@ sigil_terminator_test() ->
 invalid_sigil_delimiter_test() ->
   {1, "invalid sigil delimiter: ", Message} = tokenize_error("~s\\"),
   true = lists:prefix("\"\\\" (column 3, codepoint U+005C)", lists:flatten(Message)).
+
+too_many_of_same_character_error_test() ->
+  {1, Message, "...."} = tokenize_error("...."),
+  "\"...\" cannot be followed by \".\", use parens around \"...\". Syntax error before: " = lists:flatten(Message).

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -210,7 +210,3 @@ sigil_terminator_test() ->
 invalid_sigil_delimiter_test() ->
   {1, "invalid sigil delimiter: ", Message} = tokenize_error("~s\\"),
   true = lists:prefix("\"\\\" (column 3, codepoint U+005C)", lists:flatten(Message)).
-
-too_many_of_same_character_error_test() ->
-  {1, Message, "...."} = tokenize_error("...."),
-  "\"...\" cannot be followed by \".\", use parens around \"...\". Syntax error before: " = lists:flatten(Message).


### PR DESCRIPTION
First approach at closing #7342. I am not sure the error message is the best. Let me know what you think :)