### PR TITLE
Add a subsection for function types in typespecs docs

### DIFF
--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -24,7 +24,8 @@ The notation to represent the union of types is the pipe `|`. For example, the t
 
 ### Basic types
 
-    type :: any()                   # the top type, the set of all terms
+    type ::
+          any()                     # the top type, the set of all terms
           | none()                  # the bottom type, contains no terms
           | atom()
           | map()                   # any map
@@ -53,23 +54,12 @@ The notation to represent the union of types is the pipe `|`. For example, the t
           | Remotes                 # Described in section "Remote types"
           | UserDefined             # Described in section "User-defined types"
 
-### Function types
-
-Types of (anonymous) functions can be defined using the following syntax:
-
-    type ::                               ## Functions
-          | (... -> type)                 # any arity, returns type
-          | (() -> type)                  # 0-arity, returns type
-          | (type1, type2 -> type)        # 2-arity, returns type
-
-
-
 ### Literals
 
 The following literals are also supported in typespecs:
 
     type ::                               ## Atoms
-            :atom                         # atoms: :foo, :bar, ...
+          :atom                           # atoms: :foo, :bar, ...
           | true | false | nil            # special atom literals
 
                                           ## Bitstrings
@@ -81,6 +71,11 @@ The following literals are also supported in typespecs:
                                           ## Integers
           | 1                             # integer
           | 1..10                         # integer from 1 to 10
+
+                                          ## Anonymous functions
+          | (-> type)                     # 0-arity, returns type
+          | (type1, type2 -> type)        # 2-arity, returns type
+          | (... -> type)                 # any arity, returns type
 
                                           ## Lists
           | [type]                        # list with any number of type elements

--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -53,6 +53,17 @@ The notation to represent the union of types is the pipe `|`. For example, the t
           | Remotes                 # Described in section "Remote types"
           | UserDefined             # Described in section "User-defined types"
 
+### Function types
+
+Types of (anonymous) functions can be defined using the following syntax:
+
+    type ::                               ## Functions
+          | (... -> type)                 # any arity, returns type
+          | (() -> type)                  # 0-arity, returns type
+          | (type1, type2 -> type)        # 2-arity, returns type
+
+
+
 ### Literals
 
 The following literals are also supported in typespecs:
@@ -66,11 +77,6 @@ The following literals are also supported in typespecs:
           | <<_::size>>                   # size is 0 or a positive integer
           | <<_::_*unit>>                 # unit is an integer from 1 to 256
           | <<_::size, _::_*unit>>
-
-                                          ## Functions
-          | (... -> type)                 # any arity, returns type
-          | (() -> type)                  # 0-arity, returns type
-          | (type1, type2 -> type)        # 2-arity, returns type
 
                                           ## Integers
           | 1                             # integer


### PR DESCRIPTION
Makes it easier to find the syntax used for typing anonymous functions which is not mentioned explicitly in the Getting Started guide and is impossible to find by searching for "function types".

I would update the guide as well by adding a paragraph mentioning function types and providing an example.