### PR TITLE
No longer use outdated rand algorithms

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1774,7 +1774,7 @@ defmodule Enum do
   ## Examples
 
       # Although not necessary, let's seed the random algorithm
-      iex> :rand.seed(:exsplus, {101, 102, 103})
+      iex> :rand.seed(:exsp, {101, 102, 103})
       iex> Enum.random([1, 2, 3])
       2
       iex> Enum.random([1, 2, 3])
@@ -2083,7 +2083,7 @@ defmodule Enum do
   ## Examples
 
       # Although not necessary, let's seed the random algorithm
-      iex> :rand.seed(:exsplus, {1, 2, 3})
+      iex> :rand.seed(:exsp, {1, 2, 3})
       iex> Enum.shuffle([1, 2, 3])
       [2, 1, 3]
       iex> Enum.shuffle([1, 2, 3])
@@ -2487,7 +2487,7 @@ defmodule Enum do
   ## Examples
 
       # Although not necessary, let's seed the random algorithm
-      iex> :rand.seed(:exsplus, {1, 2, 3})
+      iex> :rand.seed(:exsp, {1, 2, 3})
       iex> Enum.take_random(1..10, 2)
       [5, 4]
       iex> Enum.take_random(?a..?z, 5)

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1291,9 +1291,9 @@ defmodule Stream do
   ## Examples
 
       # Although not necessary, let's seed the random algorithm
-      iex> :rand.seed(:exsplus, {1, 2, 3})
+      iex> :rand.seed(:exsp, {1, 2, 3})
       iex> Stream.repeatedly(&:rand.uniform/0) |> Enum.take(3)
-      [0.40502929729990744, 0.45336720247823126, 0.04094511692041057]
+      [0.40502929729990744, 0.45336720247823115, 0.040945116920410474]
 
   """
   @spec repeatedly((() -> element)) :: Enumerable.t()

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -515,12 +515,12 @@ defmodule EnumTest do
     # please note the order of following assertions is important
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1306, 421_106, 567_597}
-    :rand.seed(:exsplus, seed1)
+    :rand.seed(:exsp, seed1)
     assert Enum.random([1, 2]) == 2
     assert Enum.random([1, 2, 3]) == 1
     assert Enum.random([1, 2, 3, 4]) == 1
     assert Enum.random([1, 2, 3, 4, 5]) == 2
-    :rand.seed(:exsplus, seed2)
+    :rand.seed(:exsp, seed2)
     assert Enum.random([1, 2]) == 2
     assert Enum.random([1, 2, 3]) == 3
     assert Enum.random([1, 2, 3, 4]) == 2
@@ -590,7 +590,7 @@ defmodule EnumTest do
 
   test "shuffle/1" do
     # set a fixed seed so the test can be deterministic
-    :rand.seed(:exsplus, {1374, 347_975, 449_264})
+    :rand.seed(:exsp, {1374, 347_975, 449_264})
     assert Enum.shuffle([1, 2, 3, 4, 5]) == [2, 1, 3, 5, 4]
   end
 
@@ -768,12 +768,12 @@ defmodule EnumTest do
     # please note the order of following assertions is important
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1406, 421_106, 567_597}
-    :rand.seed(:exsplus, seed1)
+    :rand.seed(:exsp, seed1)
     assert Enum.take_random([1, 2, 3], 1) == [2]
     assert Enum.take_random([1, 2, 3], 2) == [3, 1]
     assert Enum.take_random([1, 2, 3], 3) == [1, 3, 2]
     assert Enum.take_random([1, 2, 3], 4) == [2, 3, 1]
-    :rand.seed(:exsplus, seed2)
+    :rand.seed(:exsp, seed2)
     assert Enum.take_random([1, 2, 3], 1) == [3]
     assert Enum.take_random([1, 2, 3], 2) == [1, 2]
     assert Enum.take_random([1, 2, 3], 3) == [1, 2, 3]
@@ -1192,12 +1192,12 @@ defmodule EnumTest.Range do
     # please note the order of following assertions is important
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1306, 421_106, 567_597}
-    :rand.seed(:exsplus, seed1)
+    :rand.seed(:exsp, seed1)
     assert Enum.random(1..2) == 1
     assert Enum.random(1..3) == 2
     assert Enum.random(3..1) == 1
 
-    :rand.seed(:exsplus, seed2)
+    :rand.seed(:exsp, seed2)
     assert Enum.random(1..2) == 1
     assert Enum.random(1..3) == 3
   end
@@ -1256,7 +1256,7 @@ defmodule EnumTest.Range do
 
   test "shuffle/1" do
     # set a fixed seed so the test can be deterministic
-    :rand.seed(:exsplus, {1374, 347_975, 449_264})
+    :rand.seed(:exsp, {1374, 347_975, 449_264})
     assert Enum.shuffle(1..5) == [2, 1, 3, 5, 4]
   end
 
@@ -1434,22 +1434,22 @@ defmodule EnumTest.Range do
     # please note the order of following assertions is important
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1406, 421_106, 567_597}
-    :rand.seed(:exsplus, seed1)
+    :rand.seed(:exsp, seed1)
     assert Enum.take_random(1..3, 1) == [2]
     assert Enum.take_random(1..3, 2) == [3, 1]
     assert Enum.take_random(1..3, 3) == [1, 3, 2]
     assert Enum.take_random(1..3, 4) == [2, 3, 1]
     assert Enum.take_random(3..1, 1) == [3]
-    :rand.seed(:exsplus, seed2)
+    :rand.seed(:exsp, seed2)
     assert Enum.take_random(1..3, 1) == [3]
     assert Enum.take_random(1..3, 2) == [1, 2]
     assert Enum.take_random(1..3, 3) == [1, 2, 3]
     assert Enum.take_random(1..3, 4) == [2, 1, 3]
 
     # make sure optimizations don't change fixed seeded tests
-    :rand.seed(:exsplus, {101, 102, 103})
+    :rand.seed(:exsp, {101, 102, 103})
     one = Enum.take_random(1..100, 1)
-    :rand.seed(:exsplus, {101, 102, 103})
+    :rand.seed(:exsp, {101, 102, 103})
     two = Enum.take_random(1..100, 2)
     assert hd(one) == hd(two)
   end
@@ -1508,12 +1508,12 @@ defmodule EnumTest.Map do
     map = %{a: 1, b: 2, c: 3}
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1406, 421_106, 567_597}
-    :rand.seed(:exsplus, seed1)
+    :rand.seed(:exsp, seed1)
     assert Enum.random(map) == {:c, 3}
     assert Enum.random(map) == {:b, 2}
     assert Enum.random(map) == {:c, 3}
 
-    :rand.seed(:exsplus, seed2)
+    :rand.seed(:exsp, seed2)
     assert Enum.random(map) == {:a, 1}
     assert Enum.random(map) == {:a, 1}
   end
@@ -1530,12 +1530,12 @@ defmodule EnumTest.Map do
     map = %{a: 1, b: 2, c: 3}
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1406, 421_106, 567_597}
-    :rand.seed(:exsplus, seed1)
+    :rand.seed(:exsp, seed1)
     assert Enum.take_random(map, 1) == [b: 2]
     assert Enum.take_random(map, 2) == [c: 3, a: 1]
     assert Enum.take_random(map, 3) == [a: 1, c: 3, b: 2]
     assert Enum.take_random(map, 4) == [b: 2, c: 3, a: 1]
-    :rand.seed(:exsplus, seed2)
+    :rand.seed(:exsp, seed2)
     assert Enum.take_random(map, 1) == [c: 3]
     assert Enum.take_random(map, 2) == [a: 1, b: 2]
     assert Enum.take_random(map, 3) == [a: 1, b: 2, c: 3]

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -3,7 +3,7 @@ defmodule ExUnit.Runner do
 
   alias ExUnit.EventManager, as: EM
 
-  @rand_algorithm :exs1024
+  @rand_algorithm :exs1024s
 
   def run(opts, load_us) do
     {:ok, manager} = EM.start_link()


### PR DESCRIPTION
Erlang 20 added new rand algorithms and marked others as outdated.
Replacing the usages of `:exs1024` to `:exs1024s` and `:exsplus` to
`:exsp` to support current random algorithms.

This addresses one of the TODO items in #5851 