### PR TITLE
Fix Port.open/2 signature

### DIFF
--- a/lib/elixir/lib/port.ex
+++ b/lib/elixir/lib/port.ex
@@ -177,8 +177,8 @@ defmodule Port do
   Inlined by the compiler.
   """
   @spec open(name, list) :: port
-  def open(name, settings) do
-    :erlang.open_port(name, settings)
+  def open(name, options) do
+    :erlang.open_port(name, options)
   end
 
   @doc """


### PR DESCRIPTION
The `Port.open/2` signature does not match its description in the docs. It also doesn't adhere to Elixir naming conventions.