### PR TITLE
@typespec declarations returns nil

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1601,6 +1601,7 @@ defmodule Module do
       end
 
     :ets.insert(table, {key, typespecs, true, nil})
+    nil
   end
 
   @doc false


### PR DESCRIPTION
In the moment all typespec declarations are returning `true` to the module body, which is not bad, since its not going to harm anything. But in some cases, someone probably wants to put the specs inside a comment to extract it from the main code, also to make the real code more readable and clear, since a lot of languages are supporting it, its actually easy to do in elixir with interpolation:

```elixir
    @doc """
      says hello

      #{@spec say_hello() :: "Hello"}
    """
    def say_hello(), do: "Hello"
```

Besides the above snippet is syntactically and semantically correct, its also respected by dialyzer. But there is still a problem with it. The doc text now contains a "true" string in the place where the interpolation happened. Because the underlying typespec registration macro will reduce the spec statement to a boolean after inserting it into `:ets` 

However, the return value for spec is unnecessary, and when we change the return value to `nil` the above snippet will also be fine when compiling to docs, if somebody finds the above doc&spec pattern reasonable to use.