### PR TITLE
typespec declarations should return :ok like other attributes

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1601,6 +1601,7 @@ defmodule Module do
       end
 
     :ets.insert(table, {key, typespecs, true, nil})
+    :ok
   end
 
   @doc false

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -1069,4 +1069,17 @@ defmodule Kernel.TypespecTest do
     assert message =~ string_discouraged
     assert message =~ nonempty_string_discouraged
   end
+
+  test "typespec declarations return :ok" do
+    test_module do
+      def foo(), do: nil
+
+      assert @type(foo :: any()) == :ok
+      assert @typep(foop :: any()) == :ok
+      assert @spec(foo() :: nil) == :ok
+      assert @opaque(my_type :: atom) == :ok
+      assert @callback(foo(foop) :: integer) == :ok
+      assert @macrocallback(foo(integer) :: integer) == :ok
+    end
+  end
 end


### PR DESCRIPTION
@josevalim as discussed in #7363 will close it in favour of this one.