### PR TITLE
Fix DynamicSupervisor handling of extra arguments on child restart (fixes #7369)

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -942,8 +942,9 @@ defmodule DynamicSupervisor do
 
   defp restart_child(:one_for_one, current_pid, child, state) do
     {{m, f, args} = mfa, restart, shutdown, type, modules} = child
+    %{extra_arguments: extra} = state
 
-    case start_child(m, f, args) do
+    case start_child(m, f, extra ++ args) do
       {:ok, pid, _} ->
         state = delete_child(current_pid, state)
         {:ok, save_child(pid, mfa, restart, shutdown, type, modules, state)}

--- a/lib/elixir/test/elixir/dynamic_supervisor_test.exs
+++ b/lib/elixir/test/elixir/dynamic_supervisor_test.exs
@@ -356,6 +356,27 @@ defmodule DynamicSupervisorTest do
       assert {:error, :max_children} = DynamicSupervisor.start_child(pid, child)
     end
 
+    # regression test for #7369
+    test "restarting a child with extra_args does not crash the supervisor" do
+      parent = self()
+
+      fun = fn ->
+        send(parent, :from_child)
+        :timer.sleep(:infinity)
+      end
+
+      {:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one, extra_arguments: [fun])
+      child = %{id: Task, restart: :transient, start: {Task, :start_link, []}}
+
+      assert {:ok, child} = DynamicSupervisor.start_child(sup, child)
+      assert is_pid(child)
+      assert_receive :from_child
+      assert %{active: 1, workers: 1} = DynamicSupervisor.count_children(sup)
+      assert_kill(child, :oops)
+      assert_receive :from_child
+      assert %{workers: 1, active: 1} = DynamicSupervisor.count_children(sup)
+    end
+
     test "child is restarted when trying again" do
       child = current_module_worker([:try_again, self()], restart: :permanent)
       {:ok, pid} = DynamicSupervisor.start_link(strategy: :one_for_one, max_restarts: 2)

--- a/lib/elixir/test/elixir/dynamic_supervisor_test.exs
+++ b/lib/elixir/test/elixir/dynamic_supervisor_test.exs
@@ -357,7 +357,7 @@ defmodule DynamicSupervisorTest do
     end
 
     # regression test for #7369
-    test "restarting a child with extra_args does not crash the supervisor" do
+    test "restarting a child with extra_args successfully restarts child" do
       parent = self()
 
       fun = fn ->

--- a/lib/elixir/test/elixir/dynamic_supervisor_test.exs
+++ b/lib/elixir/test/elixir/dynamic_supervisor_test.exs
@@ -356,7 +356,6 @@ defmodule DynamicSupervisorTest do
       assert {:error, :max_children} = DynamicSupervisor.start_child(pid, child)
     end
 
-    # regression test for #7369
     test "restarting a child with extra_args successfully restarts child" do
       parent = self()
 


### PR DESCRIPTION
Fixes #7369 where a DynamicSupervisor using `extra_arguments` crashed when children were restarted.