### PR TITLE
updated "start_link" function arity in the example description

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -45,7 +45,7 @@ defmodule GenServer do
       GenServer.call(pid, :pop)
       #=> :world
 
-  We start our `Stack` by calling `start_link/3`, passing the module
+  We start our `Stack` by calling `start_link/2`, passing the module
   with the server implementation and its initial argument (a list
   representing the stack containing the item `:hello`). We can primarily
   interact with the server by sending two types of messages. **call**


### PR DESCRIPTION
In GenServer documentation, in the first example description the arity of the start_link does not match the one used in the example