### PR TITLE
Fix loading of DynamicSupervisor.init/1 docs

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1210,17 +1210,8 @@ defmodule Module do
     if kind in [:defp, :defmacrop, :typep] do
       if doc, do: {:error, :private_doc}, else: :ok
     else
-      compile_doc(
-        data_table_for(module),
-        line,
-        kind,
-        function_tuple,
-        signature,
-        doc,
-        __ENV__,
-        false
-      )
-
+      table = data_table_for(module)
+      compile_doc(table, line, kind, function_tuple, signature, doc, __ENV__, false)
       :ok
     end
   end

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1230,12 +1230,14 @@ defmodule Module do
 
     # TODO: Store @since and @deprecated alongside the docs
     {line, doc} = get_doc_info(table, env, impl)
-    compile_doc(table, line, kind, pair, args, doc, env)
+    compile_doc(table, line, kind, pair, args, doc, env, impl)
 
     :ok
   end
 
-  defp compile_doc(_table, line, kind, {name, arity}, _args, doc, env)
+  defp compile_doc(table, line, kind, pair, args, doc, env, impl \\ false)
+
+  defp compile_doc(_table, line, kind, {name, arity}, _args, doc, env, _impl)
        when kind in [:defp, :defmacrop] do
     if doc do
       error_message =
@@ -1246,7 +1248,7 @@ defmodule Module do
     end
   end
 
-  defp compile_doc(table, line, kind, pair, args, doc, env) do
+  defp compile_doc(table, line, kind, pair, args, doc, env, impl) do
     signature = build_signature(args, env)
 
     case :ets.lookup(table, {:doc, pair}) do
@@ -1255,7 +1257,7 @@ defmodule Module do
 
       [{doc_tuple, line, _current_kind, current_sign, current_doc}] ->
         signature = merge_signatures(current_sign, signature, 1)
-        doc = if is_nil(doc), do: current_doc, else: doc
+        doc = if is_nil(doc) || impl, do: current_doc, else: doc
         :ets.insert(table, {doc_tuple, line, kind, signature, doc})
     end
   end

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1210,7 +1210,17 @@ defmodule Module do
     if kind in [:defp, :defmacrop, :typep] do
       if doc, do: {:error, :private_doc}, else: :ok
     else
-      compile_doc(data_table_for(module), line, kind, function_tuple, signature, doc, __ENV__, false)
+      compile_doc(
+        data_table_for(module),
+        line,
+        kind,
+        function_tuple,
+        signature,
+        doc,
+        __ENV__,
+        false
+      )
+
       :ok
     end
   end

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1229,7 +1229,7 @@ defmodule Module do
     _since = compile_since(table)
 
     # TODO: Store @since and @deprecated alongside the docs
-    {line, doc} = get_doc_info(table, env, impl)
+    {line, doc} = get_doc_info(table, env)
     compile_doc(table, line, kind, pair, args, doc, env, impl)
 
     :ok
@@ -1251,6 +1251,7 @@ defmodule Module do
 
     case :ets.lookup(table, {:doc, pair}) do
       [] ->
+        doc = if impl, do: false, else: doc
         :ets.insert(table, {{:doc, pair}, line, kind, signature, doc})
 
       [{doc_tuple, line, _current_kind, current_sign, current_doc}] ->
@@ -1771,16 +1772,13 @@ defmodule Module do
     value
   end
 
-  defp get_doc_info(table, env, impl) do
+  defp get_doc_info(table, env) do
     case :ets.take(table, :doc) do
       [{:doc, {_, _} = pair, _, _}] ->
         pair
 
-      [] when impl == false ->
-        {env.line, nil}
-
       [] ->
-        {env.line, false}
+        {env.line, nil}
     end
   end
 

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1261,12 +1261,13 @@ defmodule Module do
 
     case :ets.lookup(table, {:doc, pair}) do
       [] ->
-        doc = if impl, do: false, else: doc
+        doc = if is_nil(doc) && impl, do: false, else: doc
         :ets.insert(table, {{:doc, pair}, line, kind, signature, doc})
 
       [{doc_tuple, line, _current_kind, current_sign, current_doc}] ->
         signature = merge_signatures(current_sign, signature, 1)
-        doc = if is_nil(doc) || impl, do: current_doc, else: doc
+        doc = if is_nil(doc), do: current_doc, else: doc
+        doc = if is_nil(doc) && impl, do: false, else: doc
         :ets.insert(table, {doc_tuple, line, kind, signature, doc})
     end
   end

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1210,7 +1210,7 @@ defmodule Module do
     if kind in [:defp, :defmacrop, :typep] do
       if doc, do: {:error, :private_doc}, else: :ok
     else
-      compile_doc(data_table_for(module), line, kind, function_tuple, signature, doc, __ENV__)
+      compile_doc(data_table_for(module), line, kind, function_tuple, signature, doc, __ENV__, false)
       :ok
     end
   end
@@ -1234,8 +1234,6 @@ defmodule Module do
 
     :ok
   end
-
-  defp compile_doc(table, line, kind, pair, args, doc, env, impl \\ false)
 
   defp compile_doc(_table, line, kind, {name, arity}, _args, doc, env, _impl)
        when kind in [:defp, :defmacrop] do

--- a/lib/elixir/test/elixir/kernel/docs_test.exs
+++ b/lib/elixir/test/elixir/kernel/docs_test.exs
@@ -227,4 +227,36 @@ defmodule Kernel.DocsTest do
              ] = docs[:callback_docs]
     end
   end
+
+  test "@impl true doesn't set @doc false if previous implementation has docs" do
+    write_beam(
+      defmodule Docs do
+        defmodule SampleBehaviour do
+          @callback foo(any()) :: any()
+          @callback bar() :: any()
+        end
+
+        @behaviour SampleBehaviour
+
+        @doc "Foo docs"
+        def foo(nil), do: nil
+
+        @impl true
+        def foo(_), do: false
+
+        @impl true
+        def bar(), do: true
+
+        def fuz(), do: true
+      end
+    )
+
+    docs = Code.get_docs(Docs, :all)
+    assert Code_
+    assert [
+      {{:bar, 0}, _, :def, [], false},
+      {{:foo, 1}, _, :def, [{:arg1, [], _}], "Foo docs"},
+      {{:fuz, 0}, _, :def, [], nil},
+    ] = docs[:docs]
+  end
 end

--- a/lib/elixir/test/elixir/kernel/docs_test.exs
+++ b/lib/elixir/test/elixir/kernel/docs_test.exs
@@ -252,11 +252,11 @@ defmodule Kernel.DocsTest do
     )
 
     docs = Code.get_docs(Docs, :all)
-    assert Code_
+
     assert [
-      {{:bar, 0}, _, :def, [], false},
-      {{:foo, 1}, _, :def, [{:arg1, [], _}], "Foo docs"},
-      {{:fuz, 0}, _, :def, [], nil},
-    ] = docs[:docs]
+             {{:bar, 0}, _, :def, [], false},
+             {{:foo, 1}, _, :def, [{:arg1, [], _}], "Foo docs"},
+             {{:fuz, 0}, _, :def, [], nil}
+           ] = docs[:docs]
   end
 end

--- a/lib/elixir/test/elixir/kernel/docs_test.exs
+++ b/lib/elixir/test/elixir/kernel/docs_test.exs
@@ -234,6 +234,7 @@ defmodule Kernel.DocsTest do
         defmodule SampleBehaviour do
           @callback foo(any()) :: any()
           @callback bar() :: any()
+          @callback baz() :: any()
         end
 
         @behaviour SampleBehaviour
@@ -247,6 +248,10 @@ defmodule Kernel.DocsTest do
         @impl true
         def bar(), do: true
 
+        @doc "Baz docs"
+        @impl true
+        def baz(), do: true
+
         def fuz(), do: true
       end
     )
@@ -255,6 +260,7 @@ defmodule Kernel.DocsTest do
 
     assert [
              {{:bar, 0}, _, :def, [], false},
+             {{:baz, 0}, _, :def, [], "Baz docs"},
              {{:foo, 1}, _, :def, [{:arg1, [], _}], "Foo docs"},
              {{:fuz, 0}, _, :def, [], nil}
            ] = docs[:docs]


### PR DESCRIPTION
Moving the `init/1` callback before the actual `init/1` function seems to fix the issue at #7382 for this specific case, but we think there's a bigger issue going on here.

We tried to track this down, and we got to the following:

- with the current code on master:
    ```elixir
      Code.get_docs(DynamicSupervisor, :docs) #=> [
        ...
        {{:init, 1}, 449, :def, [{:options, [], nil}], false},
        ...
      ]
    ```

- after changing the order of the functions:
    ```elixir
      Code.get_docs(DynamicSupervisor, :docs) #=> [
        ...
        {{:init, 1}, 452, :def, [{:options, [], nil}], "Receives a set of options that initializes a dynamic supervisor.\n\nThis is typically invoked at the end of the `c:init/1` callback of\nmodule-based supervisors. See the sections \"Module-based supervisors\"\nin the module documentation for more information.\n\nThe options received by this function are also supported by `start_link/2`.\n\nThis function returns a tuple containing the supervisor options.\n\n## Examples\n\n    def init(_arg) do\n      DynamicSupervisor.init(max_children: 1000, strategy: :one_for_one)\n    end\n\n## Options\n\n  * `:strategy` - the restart strategy option. The only supported\n    value is `:one_for_one` which means that no other child is\n    terminate if a child process terminates. You can learn more\n    about strategies in the `Supervisor` module docs.\n\n  * `:max_restarts` - the maximum number of restarts allowed in\n    a time frame. Defaults to `3`.\n\n  * `:max_seconds` - the time frame in which `:max_restarts` applies.\n    Defaults to `5`.\n\n  * `:max_children` - the maximum amount of children to be running\n    under this supervisor at the same time. When `:max_children` is\n    exceeded, `start_child/2` returns `{:error, :dynamic}`. Defaults\n    to `:infinity`.\n\n  * `:extra_arguments` - arguments that are prepended to the arguments\n    specified in the child spec given to `start_child/2`. Defaults to\n    an empty list.\n\n"},
        ...
      ]
    ```
    The weird part here is that in [dynamic_supervisor.ex#L452](https://github.com/uesteibar/elixir/blob/7382-docs-for-dynamic-supervisor/lib/elixir/lib/dynamic_supervisor.ex#L452) we find the *callback*, not the function that the documentation belongs to.

We also tracked down this to [module.ex#L1665](https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/module.ex#L1665) and we checked it was being added to the correct *ets* table in both cases.

We got lost at this point, does this clarify anything about the issue? If someone could point us in the right direction here we'd love to tackle it :)

Thanks!