### PR TITLE
pass through __CALLER__ context into IEx.Introspection.decompose

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -264,7 +264,7 @@ defmodule IEx.Helpers do
   """
   defmacro open(term) do
     quote do
-      IEx.Introspection.open(unquote(IEx.Introspection.decompose(term)))
+      IEx.Introspection.open(unquote(IEx.Introspection.decompose(term, __CALLER__)))
     end
   end
 
@@ -293,7 +293,7 @@ defmodule IEx.Helpers do
   """
   defmacro h(term) do
     quote do
-      IEx.Introspection.h(unquote(IEx.Introspection.decompose(term)))
+      IEx.Introspection.h(unquote(IEx.Introspection.decompose(term, __CALLER__)))
     end
   end
 
@@ -311,7 +311,7 @@ defmodule IEx.Helpers do
   """
   defmacro b(term) do
     quote do
-      IEx.Introspection.b(unquote(IEx.Introspection.decompose(term)))
+      IEx.Introspection.b(unquote(IEx.Introspection.decompose(term, __CALLER__)))
     end
   end
 
@@ -336,7 +336,7 @@ defmodule IEx.Helpers do
   """
   defmacro t(term) do
     quote do
-      IEx.Introspection.t(unquote(IEx.Introspection.decompose(term)))
+      IEx.Introspection.t(unquote(IEx.Introspection.decompose(term, __CALLER__)))
     end
   end
 


### PR DESCRIPTION
As noted in #7381, helper methods currently don't take into account required functions. Since you're able to call the functions directly if the module has been required, ideally you should also able to invoke helpers on functions of required modules. This PR addresses this issue.

The following should now work:
```elixir
Erlang/OTP 20 [erts-9.2] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Interactive Elixir (1.7.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> h take
No documentation for Kernel.take was found
iex(2)> import Enum
Enum
iex(3)> h take

                          def take(enumerable, amount)

    @spec take(t(), integer()) :: list()

Takes the first amount items from the enumerable.

If a negative amount is given, the amount of last values will be taken. The
enumerable will be enumerated once to retrieve the proper index and the
remaining calculation is performed from the end.

## Examples

    iex> Enum.take([1, 2, 3], 2)
    [1, 2]

    iex> Enum.take([1, 2, 3], 10)
    [1, 2, 3]

    iex> Enum.take([1, 2, 3], 0)
    []

    iex> Enum.take([1, 2, 3], -1)
    [3]
```

I'm not sure on what the best way to write tests for this is. Any guidance would be great!

Solves #7381