### PR TITLE
Add cursor movement to IO.ANSI

### DIFF
--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -174,26 +174,35 @@ defmodule IO.ANSI do
   Sends cursor to the absolute position specified by `lines`, `columns`, 
   with 0,0 being the top left corner.
   """
+  @spec cursor(integer, integer) :: String.t()
   def cursor(line, column) when line >= 0 and column >= 0, do: "\e[#{line};#{column}H"
 
   @doc "Sends cursor `lines` up (defaults to 1)."
-  @spec cursor_up(integer) :: String.t()
+  @spec cursor_up :: String.t()
   def cursor_up(), do: "\e[A"
+
+  @spec cursor_up(integer) :: String.t()
   def cursor_up(lines) when lines > 0, do: "\e[#{lines}A"
 
   @doc "Sends cursor `lines` down (defaults to 1)."
-  @spec cursor_down(integer) :: String.t()
+  @spec cursor_down :: String.t()
   def cursor_down(), do: "\e[B"
+
+  @spec cursor_down(integer) :: String.t()
   def cursor_down(lines) when lines > 0, do: "\e[#{lines}B"
 
   @doc "Sends cursor `columns` to the left (defaults to 1)."
-  @spec cursor_left(integer) :: String.t()
+  @spec cursor_left :: String.t()
   def cursor_left(), do: "\e[C"
+
+  @spec cursor_left(integer) :: String.t()
   def cursor_left(columns) when columns > 0, do: "\e[#{columns}C"
 
   @doc "Sends cursor `columns` to the right (defaults to 1)."
-  @spec cursor_right(integer) :: String.t()
+  @spec cursor_right :: String.t()
   def cursor_right(), do: "\e[D"
+
+  @spec cursor_right(integer) :: String.t()
   def cursor_right(columns) when columns > 0, do: "\e[#{columns}D"
 
   @doc "Clears screen."

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -171,27 +171,30 @@ defmodule IO.ANSI do
   defsequence(:home, "", "H")
 
   @doc """
-  Sends cursor to the absolute position specified by `lines`, `columns`, 
-  with 0,0 being the top left corner.
+  Sends cursor to the absolute position specified by `line` and `column`.
+
+  Line `0` and column `0` would mean the top left corner.
   """
   @spec cursor(integer, integer) :: String.t()
-  def cursor(line, column) when line >= 0 and column >= 0, do: "\e[#{line};#{column}H"
+  def cursor(line, column)
+      when is_integer(line) and line >= 0 and is_integer(column) and column >= 0,
+      do: "\e[#{line};#{column}H"
 
-  @doc "Sends cursor `lines` up. Defaults to 1"
+  @doc "Sends cursor `lines` up."
   @spec cursor_up(integer) :: String.t()
-  def cursor_up(lines \\ 1) when lines > 0, do: "\e[#{lines}A"
+  def cursor_up(lines \\ 1) when is_integer(lines) and lines > 0, do: "\e[#{lines}A"
 
-  @doc "Sends cursor `lines` down. Defaults to 1"
+  @doc "Sends cursor `lines` down."
   @spec cursor_down(integer) :: String.t()
-  def cursor_down(lines \\ 1) when lines > 0, do: "\e[#{lines}B"
+  def cursor_down(lines \\ 1) when is_integer(lines) and lines > 0, do: "\e[#{lines}B"
 
-  @doc "Sends cursor `columns` to the left. Defaults to 1."
+  @doc "Sends cursor `columns` to the left."
   @spec cursor_left(integer) :: String.t()
-  def cursor_left(columns \\ 1) when columns > 0, do: "\e[#{columns}C"
+  def cursor_left(columns \\ 1) when is_integer(columns) and columns > 0, do: "\e[#{columns}C"
 
-  @doc "Sends cursor `columns` to the right. Defaults to 1."
+  @doc "Sends cursor `columns` to the right."
   @spec cursor_right(integer) :: String.t()
-  def cursor_right(columns \\ 1) when columns > 0, do: "\e[#{columns}D"
+  def cursor_right(columns \\ 1) when is_integer(columns) and columns > 0, do: "\e[#{columns}D"
 
   @doc "Clears screen."
   defsequence(:clear, "2", "J")

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -177,8 +177,9 @@ defmodule IO.ANSI do
   """
   @spec cursor(integer, integer) :: String.t()
   def cursor(line, column)
-      when is_integer(line) and line >= 0 and is_integer(column) and column >= 0,
-      do: "\e[#{line};#{column}H"
+      when is_integer(line) and line >= 0 and is_integer(column) and column >= 0 do
+    "\e[#{line};#{column}H"
+  end
 
   @doc "Sends cursor `lines` up."
   @spec cursor_up(integer) :: String.t()

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -175,27 +175,27 @@ defmodule IO.ANSI do
 
   Line `0` and column `0` would mean the top left corner.
   """
-  @spec cursor(integer, integer) :: String.t()
+  @spec cursor(non_neg_integer, non_neg_integer) :: String.t()
   def cursor(line, column)
       when is_integer(line) and line >= 0 and is_integer(column) and column >= 0 do
     "\e[#{line};#{column}H"
   end
 
   @doc "Sends cursor `lines` up."
-  @spec cursor_up(integer) :: String.t()
-  def cursor_up(lines \\ 1) when is_integer(lines) and lines > 0, do: "\e[#{lines}A"
+  @spec cursor_up(pos_integer) :: String.t()
+  def cursor_up(lines \\ 1) when is_integer(lines) and lines >= 1, do: "\e[#{lines}A"
 
   @doc "Sends cursor `lines` down."
-  @spec cursor_down(integer) :: String.t()
-  def cursor_down(lines \\ 1) when is_integer(lines) and lines > 0, do: "\e[#{lines}B"
+  @spec cursor_down(pos_integer) :: String.t()
+  def cursor_down(lines \\ 1) when is_integer(lines) and lines >= 1, do: "\e[#{lines}B"
 
   @doc "Sends cursor `columns` to the left."
-  @spec cursor_left(integer) :: String.t()
-  def cursor_left(columns \\ 1) when is_integer(columns) and columns > 0, do: "\e[#{columns}C"
+  @spec cursor_left(pos_integer) :: String.t()
+  def cursor_left(columns \\ 1) when is_integer(columns) and columns >= 1, do: "\e[#{columns}C"
 
   @doc "Sends cursor `columns` to the right."
-  @spec cursor_right(integer) :: String.t()
-  def cursor_right(columns \\ 1) when is_integer(columns) and columns > 0, do: "\e[#{columns}D"
+  @spec cursor_right(pos_integer) :: String.t()
+  def cursor_right(columns \\ 1) when is_integer(columns) and columns >= 1, do: "\e[#{columns}D"
 
   @doc "Clears screen."
   defsequence(:clear, "2", "J")

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -170,6 +170,26 @@ defmodule IO.ANSI do
   @doc "Sends cursor home."
   defsequence(:home, "", "H")
 
+  @doc "Sends cursor to specified position"
+  @spec cursor(integer, integer) :: String.t()
+  def cursor(line, col), do: "\e[#{line};#{col}H"
+
+  @doc "Sends cursor up"
+  @spec cursor_up(integer) :: String.t()
+  def cursor_up(lines), do: "\e[#{lines}A"
+
+  @doc "Sends cursor down"
+  @spec cursor_down(integer) :: String.t()
+  def cursor_down(lines), do: "\e[#{lines}B"
+
+  @doc "Sends cursor back"
+  @spec cursor_back(integer) :: String.t()
+  def cursor_back(cols), do: "\e[#{cols}C"
+
+  @doc "Sends cursor forward"
+  @spec cursor_forward(integer) :: String.t()
+  def cursor_forward(cols), do: "\e[#{cols}D"
+
   @doc "Clears screen."
   defsequence(:clear, "2", "J")
 

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -170,8 +170,10 @@ defmodule IO.ANSI do
   @doc "Sends cursor home."
   defsequence(:home, "", "H")
 
-  @doc "Sends cursor to the absolute position specified by `lines`, `columns`, with 0,0 being the top left corner."
-  @spec cursor(integer, integer) :: String.t()
+  @doc """
+  Sends cursor to the absolute position specified by `lines`, `columns`, 
+  with 0,0 being the top left corner.
+  """
   def cursor(line, column) when line >= 0 and column >= 0, do: "\e[#{line};#{column}H"
 
   @doc "Sends cursor `lines` up (defaults to 1)."

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -170,25 +170,29 @@ defmodule IO.ANSI do
   @doc "Sends cursor home."
   defsequence(:home, "", "H")
 
-  @doc "Sends cursor to specified position."
+  @doc "Sends cursor to the absolute position specified by `lines`, `columns`, with 0,0 being the top left corner."
   @spec cursor(integer, integer) :: String.t()
-  def cursor(line, col), do: "\e[#{line};#{col}H"
+  def cursor(line, column) when line >= 0 and column >= 0, do: "\e[#{line};#{column}H"
 
-  @doc "Sends cursor up."
+  @doc "Sends cursor `lines` up (defaults to 1)."
   @spec cursor_up(integer) :: String.t()
-  def cursor_up(lines), do: "\e[#{lines}A"
+  def cursor_up(), do: "\e[A"
+  def cursor_up(lines) when lines > 0, do: "\e[#{lines}A"
 
-  @doc "Sends cursor down."
+  @doc "Sends cursor `lines` down (defaults to 1)."
   @spec cursor_down(integer) :: String.t()
-  def cursor_down(lines), do: "\e[#{lines}B"
+  def cursor_down(), do: "\e[B"
+  def cursor_down(lines) when lines > 0, do: "\e[#{lines}B"
 
-  @doc "Sends cursor left."
+  @doc "Sends cursor `columns` to the left (defaults to 1)."
   @spec cursor_left(integer) :: String.t()
-  def cursor_left(cols), do: "\e[#{cols}C"
+  def cursor_left(), do: "\e[C"
+  def cursor_left(columns) when columns > 0, do: "\e[#{columns}C"
 
-  @doc "Sends cursor right."
+  @doc "Sends cursor `columns` to the right (defaults to 1)."
   @spec cursor_right(integer) :: String.t()
-  def cursor_right(cols), do: "\e[#{cols}D"
+  def cursor_right(), do: "\e[D"
+  def cursor_right(columns) when columns > 0, do: "\e[#{columns}D"
 
   @doc "Clears screen."
   defsequence(:clear, "2", "J")

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -182,13 +182,13 @@ defmodule IO.ANSI do
   @spec cursor_down(integer) :: String.t()
   def cursor_down(lines), do: "\e[#{lines}B"
 
-  @doc "Sends cursor back."
-  @spec cursor_back(integer) :: String.t()
-  def cursor_back(cols), do: "\e[#{cols}C"
+  @doc "Sends cursor left."
+  @spec cursor_left(integer) :: String.t()
+  def cursor_left(cols), do: "\e[#{cols}C"
 
-  @doc "Sends cursor forward."
-  @spec cursor_forward(integer) :: String.t()
-  def cursor_forward(cols), do: "\e[#{cols}D"
+  @doc "Sends cursor right."
+  @spec cursor_right(integer) :: String.t()
+  def cursor_right(cols), do: "\e[#{cols}D"
 
   @doc "Clears screen."
   defsequence(:clear, "2", "J")

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -177,37 +177,21 @@ defmodule IO.ANSI do
   @spec cursor(integer, integer) :: String.t()
   def cursor(line, column) when line >= 0 and column >= 0, do: "\e[#{line};#{column}H"
 
-  @doc "Sends cursor one line up."
-  @spec cursor_up :: String.t()
-  def cursor_up(), do: "\e[A"
-
-  @doc "Sends cursor `lines` up."
+  @doc "Sends cursor `lines` up. Defaults to 1"
   @spec cursor_up(integer) :: String.t()
-  def cursor_up(lines) when lines > 0, do: "\e[#{lines}A"
+  def cursor_up(lines \\ 1) when lines > 0, do: "\e[#{lines}A"
 
-  @doc "Sends cursor one line down."
-  @spec cursor_down :: String.t()
-  def cursor_down(), do: "\e[B"
-
-  @doc "Sends cursor `lines` down."
+  @doc "Sends cursor `lines` down. Defaults to 1"
   @spec cursor_down(integer) :: String.t()
-  def cursor_down(lines) when lines > 0, do: "\e[#{lines}B"
+  def cursor_down(lines \\ 1) when lines > 0, do: "\e[#{lines}B"
 
-  @doc "Sends cursor one line to the left"
-  @spec cursor_left :: String.t()
-  def cursor_left(), do: "\e[C"
-
-  @doc "Sends cursor `columns` to the left."
+  @doc "Sends cursor `columns` to the left. Defaults to 1."
   @spec cursor_left(integer) :: String.t()
-  def cursor_left(columns) when columns > 0, do: "\e[#{columns}C"
+  def cursor_left(columns \\ 1) when columns > 0, do: "\e[#{columns}C"
 
-  @doc "Sends cursor one column to the right."
-  @spec cursor_right :: String.t()
-  def cursor_right(), do: "\e[D"
-
-  @doc "Sends cursor `columns` to the right."
+  @doc "Sends cursor `columns` to the right. Defaults to 1."
   @spec cursor_right(integer) :: String.t()
-  def cursor_right(columns) when columns > 0, do: "\e[#{columns}D"
+  def cursor_right(columns \\ 1) when columns > 0, do: "\e[#{columns}D"
 
   @doc "Clears screen."
   defsequence(:clear, "2", "J")

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -170,23 +170,23 @@ defmodule IO.ANSI do
   @doc "Sends cursor home."
   defsequence(:home, "", "H")
 
-  @doc "Sends cursor to specified position"
+  @doc "Sends cursor to specified position."
   @spec cursor(integer, integer) :: String.t()
   def cursor(line, col), do: "\e[#{line};#{col}H"
 
-  @doc "Sends cursor up"
+  @doc "Sends cursor up."
   @spec cursor_up(integer) :: String.t()
   def cursor_up(lines), do: "\e[#{lines}A"
 
-  @doc "Sends cursor down"
+  @doc "Sends cursor down."
   @spec cursor_down(integer) :: String.t()
   def cursor_down(lines), do: "\e[#{lines}B"
 
-  @doc "Sends cursor back"
+  @doc "Sends cursor back."
   @spec cursor_back(integer) :: String.t()
   def cursor_back(cols), do: "\e[#{cols}C"
 
-  @doc "Sends cursor forward"
+  @doc "Sends cursor forward."
   @spec cursor_forward(integer) :: String.t()
   def cursor_forward(cols), do: "\e[#{cols}D"
 

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -177,31 +177,35 @@ defmodule IO.ANSI do
   @spec cursor(integer, integer) :: String.t()
   def cursor(line, column) when line >= 0 and column >= 0, do: "\e[#{line};#{column}H"
 
-  @doc "Sends cursor `lines` up (defaults to 1)."
+  @doc "Sends cursor one line up."
   @spec cursor_up :: String.t()
   def cursor_up(), do: "\e[A"
 
+  @doc "Sends cursor `lines` up."
   @spec cursor_up(integer) :: String.t()
   def cursor_up(lines) when lines > 0, do: "\e[#{lines}A"
 
-  @doc "Sends cursor `lines` down (defaults to 1)."
+  @doc "Sends cursor one line down."
   @spec cursor_down :: String.t()
   def cursor_down(), do: "\e[B"
 
+  @doc "Sends cursor `lines` down."
   @spec cursor_down(integer) :: String.t()
   def cursor_down(lines) when lines > 0, do: "\e[#{lines}B"
 
-  @doc "Sends cursor `columns` to the left (defaults to 1)."
+  @doc "Sends cursor one line to the left"
   @spec cursor_left :: String.t()
   def cursor_left(), do: "\e[C"
 
+  @doc "Sends cursor `columns` to the left."
   @spec cursor_left(integer) :: String.t()
   def cursor_left(columns) when columns > 0, do: "\e[#{columns}C"
 
-  @doc "Sends cursor `columns` to the right (defaults to 1)."
+  @doc "Sends cursor one column to the right."
   @spec cursor_right :: String.t()
   def cursor_right(), do: "\e[D"
 
+  @doc "Sends cursor `columns` to the right."
   @spec cursor_right(integer) :: String.t()
   def cursor_right(columns) when columns > 0, do: "\e[#{columns}D"
 

--- a/lib/elixir/test/elixir/io/ansi_test.exs
+++ b/lib/elixir/test/elixir/io/ansi_test.exs
@@ -174,6 +174,10 @@ defmodule IO.ANSITest do
     assert IO.ANSI.cursor_up(12) == "\e[12A"
 
     assert_raise FunctionClauseError, fn ->
+      IO.ANSI.cursor_up(0)
+    end
+
+    assert_raise FunctionClauseError, fn ->
       IO.ANSI.cursor_up(-1)
     end
   end
@@ -181,6 +185,10 @@ defmodule IO.ANSITest do
   test "cursor_down/1" do
     assert IO.ANSI.cursor_down() == "\e[1B"
     assert IO.ANSI.cursor_down(2) == "\e[2B"
+
+    assert_raise FunctionClauseError, fn ->
+      IO.ANSI.cursor_right(0)
+    end
 
     assert_raise FunctionClauseError, fn ->
       IO.ANSI.cursor_down(-1)
@@ -192,6 +200,10 @@ defmodule IO.ANSITest do
     assert IO.ANSI.cursor_left(3) == "\e[3C"
 
     assert_raise FunctionClauseError, fn ->
+      IO.ANSI.cursor_left(0)
+    end
+
+    assert_raise FunctionClauseError, fn ->
       IO.ANSI.cursor_left(-1)
     end
   end
@@ -199,6 +211,10 @@ defmodule IO.ANSITest do
   test "cursor_right/0" do
     assert IO.ANSI.cursor_right() == "\e[1D"
     assert IO.ANSI.cursor_right(4) == "\e[4D"
+
+    assert_raise FunctionClauseError, fn ->
+      IO.ANSI.cursor_right(0)
+    end
 
     assert_raise FunctionClauseError, fn ->
       IO.ANSI.cursor_right(-1)

--- a/lib/elixir/test/elixir/io/ansi_test.exs
+++ b/lib/elixir/test/elixir/io/ansi_test.exs
@@ -208,7 +208,7 @@ defmodule IO.ANSITest do
     end
   end
 
-  test "cursor_right/0" do
+  test "cursor_right/1" do
     assert IO.ANSI.cursor_right() == "\e[1D"
     assert IO.ANSI.cursor_right(4) == "\e[4D"
 

--- a/lib/elixir/test/elixir/io/ansi_test.exs
+++ b/lib/elixir/test/elixir/io/ansi_test.exs
@@ -168,11 +168,11 @@ defmodule IO.ANSITest do
     assert IO.ANSI.cursor_down(2) == "\e[2B"
   end
 
-  test "cursor_back/1" do
-    assert IO.ANSI.cursor_back(3) == "\e[3C"
+  test "cursor_left/1" do
+    assert IO.ANSI.cursor_left(3) == "\e[3C"
   end
 
-  test "cursor_forward/1" do
-    assert IO.ANSI.cursor_forward(4) == "\e[4D"
+  test "cursor_right/1" do
+    assert IO.ANSI.cursor_right(4) == "\e[4D"
   end
 end

--- a/lib/elixir/test/elixir/io/ansi_test.exs
+++ b/lib/elixir/test/elixir/io/ansi_test.exs
@@ -157,22 +157,51 @@ defmodule IO.ANSITest do
   end
 
   test "cursor/2" do
+    assert IO.ANSI.cursor(0, 0) == "\e[0;0H"
     assert IO.ANSI.cursor(11, 12) == "\e[11;12H"
+
+    assert_raise FunctionClauseError, fn ->
+      IO.ANSI.cursor(-1, 5)
+    end
+
+     assert_raise FunctionClauseError, fn ->
+      IO.ANSI.cursor(5, -1)
+    end
   end
 
   test "cursor_up/1" do
+    assert IO.ANSI.cursor_up() == "\e[A"
     assert IO.ANSI.cursor_up(1) == "\e[1A"
+
+    assert_raise FunctionClauseError, fn ->
+      IO.ANSI.cursor_up(-1)
+    end
   end
 
   test "cursor_down/1" do
+    assert IO.ANSI.cursor_down() == "\e[B"
     assert IO.ANSI.cursor_down(2) == "\e[2B"
+
+    assert_raise FunctionClauseError, fn ->
+      IO.ANSI.cursor_down(-1)
+    end
   end
 
   test "cursor_left/1" do
+    assert IO.ANSI.cursor_left() == "\e[C"
     assert IO.ANSI.cursor_left(3) == "\e[3C"
+
+    assert_raise FunctionClauseError, fn ->
+      IO.ANSI.cursor_left(-1)
+    end
   end
 
   test "cursor_right/1" do
+    assert IO.ANSI.cursor_right() == "\e[D"
     assert IO.ANSI.cursor_right(4) == "\e[4D"
+
+    assert_raise FunctionClauseError, fn ->
+      IO.ANSI.cursor_right(-1)
+    end
   end
 end

--- a/lib/elixir/test/elixir/io/ansi_test.exs
+++ b/lib/elixir/test/elixir/io/ansi_test.exs
@@ -169,23 +169,17 @@ defmodule IO.ANSITest do
     end
   end
 
-  test "cursor_up/0" do
-    assert IO.ANSI.cursor_up() == "\e[A"
-  end
-
   test "cursor_up/1" do
-    assert IO.ANSI.cursor_up(1) == "\e[1A"
+    assert IO.ANSI.cursor_up() == "\e[1A"
+    assert IO.ANSI.cursor_up(12) == "\e[12A"
 
     assert_raise FunctionClauseError, fn ->
       IO.ANSI.cursor_up(-1)
     end
   end
 
-  test "cursor_down/0" do
-    assert IO.ANSI.cursor_down() == "\e[B"
-  end
-
   test "cursor_down/1" do
+    assert IO.ANSI.cursor_down() == "\e[1B"
     assert IO.ANSI.cursor_down(2) == "\e[2B"
 
     assert_raise FunctionClauseError, fn ->
@@ -193,11 +187,8 @@ defmodule IO.ANSITest do
     end
   end
 
-  test "cursor_left/0" do
-    assert IO.ANSI.cursor_left() == "\e[C"
-  end
-
   test "cursor_left/1" do
+    assert IO.ANSI.cursor_left() == "\e[1C"
     assert IO.ANSI.cursor_left(3) == "\e[3C"
 
     assert_raise FunctionClauseError, fn ->
@@ -206,10 +197,7 @@ defmodule IO.ANSITest do
   end
 
   test "cursor_right/0" do
-    assert IO.ANSI.cursor_right() == "\e[D"
-  end
-
-  test "cursor_right/1" do
+    assert IO.ANSI.cursor_right() == "\e[1D"
     assert IO.ANSI.cursor_right(4) == "\e[4D"
 
     assert_raise FunctionClauseError, fn ->

--- a/lib/elixir/test/elixir/io/ansi_test.exs
+++ b/lib/elixir/test/elixir/io/ansi_test.exs
@@ -155,4 +155,24 @@ defmodule IO.ANSITest do
       IO.ANSI.color_background(5, -1, 1)
     end
   end
+
+  test "cursor/2" do
+    assert IO.ANSI.cursor(11,12) == "\e[11;12H"
+  end
+
+  test "cursor_up/1" do
+    assert IO.ANSI.cursor_up(1) == "\e[1A"
+  end
+
+  test "cursor_down/1" do
+    assert IO.ANSI.cursor_down(2) == "\e[2B"
+  end
+
+  test "cursor_back/1" do
+    assert IO.ANSI.cursor_back(3) == "\e[3C"
+  end
+
+  test "cursor_forward/1" do
+    assert IO.ANSI.cursor_forward(4) == "\e[4D"
+  end
 end

--- a/lib/elixir/test/elixir/io/ansi_test.exs
+++ b/lib/elixir/test/elixir/io/ansi_test.exs
@@ -157,7 +157,7 @@ defmodule IO.ANSITest do
   end
 
   test "cursor/2" do
-    assert IO.ANSI.cursor(11,12) == "\e[11;12H"
+    assert IO.ANSI.cursor(11, 12) == "\e[11;12H"
   end
 
   test "cursor_up/1" do

--- a/lib/elixir/test/elixir/io/ansi_test.exs
+++ b/lib/elixir/test/elixir/io/ansi_test.exs
@@ -169,8 +169,11 @@ defmodule IO.ANSITest do
     end
   end
 
-  test "cursor_up/1" do
+  test "cursor_up/0" do
     assert IO.ANSI.cursor_up() == "\e[A"
+  end
+
+  test "cursor_up/1" do
     assert IO.ANSI.cursor_up(1) == "\e[1A"
 
     assert_raise FunctionClauseError, fn ->
@@ -178,8 +181,11 @@ defmodule IO.ANSITest do
     end
   end
 
-  test "cursor_down/1" do
+  test "cursor_down/0" do
     assert IO.ANSI.cursor_down() == "\e[B"
+  end
+
+  test "cursor_down/1" do
     assert IO.ANSI.cursor_down(2) == "\e[2B"
 
     assert_raise FunctionClauseError, fn ->
@@ -187,8 +193,11 @@ defmodule IO.ANSITest do
     end
   end
 
-  test "cursor_left/1" do
+  test "cursor_left/0" do
     assert IO.ANSI.cursor_left() == "\e[C"
+  end
+
+  test "cursor_left/1" do
     assert IO.ANSI.cursor_left(3) == "\e[3C"
 
     assert_raise FunctionClauseError, fn ->
@@ -196,8 +205,11 @@ defmodule IO.ANSITest do
     end
   end
 
-  test "cursor_right/1" do
+  test "cursor_right/0" do
     assert IO.ANSI.cursor_right() == "\e[D"
+  end
+
+  test "cursor_right/1" do
     assert IO.ANSI.cursor_right(4) == "\e[4D"
 
     assert_raise FunctionClauseError, fn ->

--- a/lib/elixir/test/elixir/io/ansi_test.exs
+++ b/lib/elixir/test/elixir/io/ansi_test.exs
@@ -164,7 +164,7 @@ defmodule IO.ANSITest do
       IO.ANSI.cursor(-1, 5)
     end
 
-     assert_raise FunctionClauseError, fn ->
+    assert_raise FunctionClauseError, fn ->
       IO.ANSI.cursor(5, -1)
     end
   end


### PR DESCRIPTION
I added the cursor movement escape codes (from https://www.tldp.org/HOWTO/Bash-Prompt-HOWTO/x361.html) to `IO.ANSI`