### PR TITLE
Add additional documentation about `@moduletag`s

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -116,7 +116,18 @@ defmodule ExUnit.Case do
   A tag can be set for all tests in a module or describe block by
   setting `@moduletag` or `@describetag` respectively:
 
-      @moduletag :external
+      defmodule ApiTest do
+        use ExUnit.Case
+        @moduletag :external
+
+        @describetag :endpoint
+        describe "makes calls to the right endpoint" do
+          # ...
+        end
+      end
+
+  If you are setting a `@moduletag`, you must set that after your
+  call to `use ExUnit.Case` or you will see compilation errors.
 
   If the same key is set via `@tag`, the `@tag` value has higher
   precedence.


### PR DESCRIPTION
I was attempting to use a `@moduletag` tag in a test module today, and
I kept getting odd behavior, including this compilation error:

```
== Compilation error in file test/benchee/memory_measure_test.exs ==
** (Protocol.UndefinedError) protocol Enumerable not implemented for :memory_measurement. This protocol is implemented for: Date.Range, File.Stream, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, List, Map, MapSet, Range, Stream
    (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir) lib/enum.ex:141: Enumerable.reduce/3
    (elixir) lib/enum.ex:1919: Enum.reverse/1
    (ex_unit) lib/ex_unit/case.ex:534: ExUnit.Case.normalize_tags/1
    (ex_unit) lib/ex_unit/case.ex:466: ExUnit.Case.register_test/4
    test/benchee/memory_measure_test.exs:11: (module)
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
    (elixir) lib/code.ex:677: Code.require_file/2
    (elixir) lib/kernel/parallel_compiler.ex:201: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/6
```

I was trying to do this:

```elixir
defmodule Benchee.MemoryMeasureTest do
  @moduletag :memory_measurement
  # We cannot use async: true because of the tests that we're running to ensure
  # there aren't any leaked processes if functions fail while we're tracing
  # them.
  use ExUnit.Case
  alias Benchee.MemoryMeasure
  import ExUnit.CaptureIO
  # ...
end
```

After checking how those `@moduletag`s are used in the Elixir codebase,
I realized that they're all after the call to `use ExUnit.Case`, and
once I moved that `@moduletag` down to the line after `use ExUnit.Case`,
it all worked as expected. So, I figured this was helpful behavior to
document!