### PR TITLE
Fix typo in Macro docs

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1322,7 +1322,7 @@ defmodule Macro do
       iex> Macro.camelize("foo_bar")
       "FooBar"
 
-  If uppercase characters are present, they are not modified in anyway
+  If uppercase characters are present, they are not modified in any way
   as a mechanism to preserve acronyms:
 
       iex> Macro.camelize("API.V1")


### PR DESCRIPTION
Hi all,

`they are not modified in anyway` → `they are not modified in any way`

Cheers!