### PR TITLE
Extend Macro.escape/2 docs to illustrate difference from quote/2

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -370,6 +370,31 @@ defmodule Macro do
       iex> Macro.escape({:unquote, [], [1]}, unquote: true)
       1
 
+  ## Comparison to `Kernel.quote/2`
+
+  The `escape/2` function is sometimes confused with `Kernel.SpecialForms.quote/2`,
+  because the above examples behave the same with both. The key difference is
+  best illustrated when the value to escape is stored in a variable.
+
+      iex> Macro.escape({:a, :b, :c})
+      {:{}, [], [:a, :b, :c]}
+      iex> quote do: {:a, :b, :c}
+      {:{}, [], [:a, :b, :c]}
+
+      iex> value = {:a, :b, :c}
+      iex> Macro.escape(value)
+      {:{}, [], [:a, :b, :c]}
+
+      iex> quote do: value
+      {:value, [], __MODULE__}
+
+      iex> value = {:a, :b, :c}
+      iex> quote do: unquote(value)
+      {:a, :b, :c}
+
+  `escape/2` is used to escape _values_ (either directly passed or variable
+  bound), while `Kernel.SpecialForms.quote/2` produces syntax trees for
+  expressions.
   """
   @spec escape(term, keyword) :: Macro.t()
   def escape(expr, opts \\ []) do

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -392,7 +392,7 @@ defmodule Macro do
       iex> quote do: unquote(value)
       {:a, :b, :c}
 
-  `escape/2` is used to escape _values_ (either directly passed or variable
+  `escape/2` is used to escape *values* (either directly passed or variable
   bound), while `Kernel.SpecialForms.quote/2` produces syntax trees for
   expressions.
   """


### PR DESCRIPTION
# Problem

Today I realized I couldn't remember the difference in Macro.escape/2 and Kernel.quote/2. The documented examples weren't quite enough to illustrate the difference as the results are the same from both.

# Solution

Extend documentation for Macro.escape/2 to illustrate the key difference in it from Kernel.quote/2. Namely: when working on a variable, Macro.escape/2 operates on the _value_.