### PR TITLE
Move `doctest Macro` to Macro module test file

### DIFF
--- a/lib/elixir/test/elixir/kernel/macros_test.exs
+++ b/lib/elixir/test/elixir/kernel/macros_test.exs
@@ -11,8 +11,6 @@ end
 defmodule Kernel.MacrosTest do
   use ExUnit.Case, async: true
 
-  doctest Macro
-
   Kernel.MacrosTest.Nested = require Kernel.MacrosTest.Nested, as: Nested
 
   @spec my_macro :: Macro.t()

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -17,6 +17,7 @@ end
 
 defmodule MacroTest do
   use ExUnit.Case, async: true
+  doctest Macro
 
   # Changing the lines above will make compilation
   # fail since we are asserting on the caller lines


### PR DESCRIPTION
This isn't a really big deal, but it was a little surprising to me that the doctest specification for the Macro module wasn't in the test file for the Macro module. Unless the decision to put it where it is, it might lower friction slightly to move it to the Macro module test file.

Thoughts?