### PR TITLE
Fix table column alignment with ANSI escapes

### DIFF
--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -389,17 +389,22 @@ defmodule IO.ANSI.Docs do
   end
 
   defp generate_table_cell({{{col, length}, width}, :center}) do
+    ansi_diff = byte_size(col) - length
+    width = width + ansi_diff
+
     col
     |> String.pad_leading(div(width, 2) - div(length, 2) + length)
     |> String.pad_trailing(width + 1 - rem(width, 2))
   end
 
-  defp generate_table_cell({{{col, _length}, width}, :right}) do
-    String.pad_leading(col, width)
+  defp generate_table_cell({{{col, length}, width}, :right}) do
+    ansi_diff = byte_size(col) - length
+    String.pad_leading(col, width + ansi_diff)
   end
 
-  defp generate_table_cell({{{col, _length}, width}, :left}) do
-    String.pad_trailing(col, width)
+  defp generate_table_cell({{{col, length}, width}, :left}) do
+    ansi_diff = byte_size(col) - length
+    String.pad_trailing(col, width + ansi_diff)
   end
 
   defp table_line?(line) do

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -324,6 +324,7 @@ defmodule IO.ANSI.DocsTest do
 
   test "table with formatting in cells" do
     assert format("`a` | _b_\nc | d") == "\e[36ma\e[0m | \e[4mb\e[0m\nc | d\n\e[0m"
+    assert format("`abc` | d \n`e` | f") == "\e[36mabc\e[0m | d\n\e[36me\e[0m   | f\n\e[0m"
   end
 
   test "table with variable number of columns" do


### PR DESCRIPTION
Before:
```
~>  | Translation
~> 2.0.0 | >= 2.0.0 and < 2.1.0
~> 2.1.2 | >= 2.1.2 and < 2.2.0
~> 2.1.3-dev | >= 2.1.3-dev and < 2.2.0
~> 2.0 | >= 2.0.0 and < 3.0.0
~> 2.1 | >= 2.1.0 and < 3.0.0
```
After:
```
~>           | Translation
~> 2.0.0     | >= 2.0.0 and < 2.1.0
~> 2.1.2     | >= 2.1.2 and < 2.2.0
~> 2.1.3-dev | >= 2.1.3-dev and < 2.2.0
~> 2.0       | >= 2.0.0 and < 3.0.0
~> 2.1       | >= 2.1.0 and < 3.0.0
```