### PR TITLE
Add calendar callback months_in_year/1

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -118,6 +118,11 @@ defmodule Calendar do
   @callback days_in_month(year, month) :: day
 
   @doc """
+  Returns how many months there are in the given year.
+  """
+  @callback months_in_year(year) :: month
+
+  @doc """
   Returns true if the given year is a leap year.
 
   A leap year is a year of a longer length than normal. The exact meaning

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -177,6 +177,23 @@ defmodule Date do
   end
 
   @doc """
+  Returns the number of days in the given `date` month.
+
+  ## Example
+
+      iex> Date.months_in_year(~D[1900-01-13])
+      12
+
+  """
+  @since "1.7.0"
+  @spec months_in_year(Calendar.date()) :: Calendar.month()
+  def months_in_year(date)
+
+  def months_in_year(%{calendar: calendar, year: year}) do
+    calendar.months_in_year(year)
+  end
+
+  @doc """
   Builds a new ISO date.
 
   Expects all values to be integers. Returns `{:ok, date}` if each

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -34,6 +34,8 @@ defmodule Calendar.ISO do
   @days_per_nonleap_year 365
   @days_per_leap_year 366
 
+  @months_in_year 12
+
   @doc """
   Returns the `t:Calendar.iso_days/0` format of the specified date.
 
@@ -231,6 +233,22 @@ defmodule Calendar.ISO do
 
   def days_in_month(_, month) when month in [4, 6, 9, 11], do: 30
   def days_in_month(_, month) when month in 1..12, do: 31
+
+  @doc """
+  Returns how many months there are in the given year.
+
+  ## Example
+
+      iex> Calendar.ISO.months_in_year(2004)
+      12
+
+  """
+  @impl true
+  @since "1.7.0"
+  @spec months_in_year(year) :: 12
+  def months_in_year(_year) do
+    @months_in_year
+  end
 
   @doc """
   Returns if the given year is a leap year.

--- a/lib/elixir/test/elixir/fixtures/calendar/holocene.exs
+++ b/lib/elixir/test/elixir/fixtures/calendar/holocene.exs
@@ -91,6 +91,9 @@ defmodule Calendar.Holocene do
   defdelegate days_in_month(year, month), to: Calendar.ISO
 
   @impl true
+  defdelegate months_in_year(year), to: Calendar.ISO
+
+  @impl true
   defdelegate day_of_week(year, month, day), to: Calendar.ISO
 
   @impl true


### PR DESCRIPTION
Not all calendars have a constant 12 months in
a year.  This function returns the number of
months for a given year. Calendar.ISO will return
12 for all years.