### PR TITLE
Support compiling from other build tools

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -168,6 +168,7 @@ defmodule Mix do
   Mix responds to the following variables:
 
     * `MIX_ARCHIVES` - specifies the directory into which the archives should be installed
+    * `MIX_BUILD_PATH` - sets the project build_path config
     * `MIX_DEBUG` - outputs debug information about each task before running it
     * `MIX_ENV` - specifies which environment should be used. See [Environments](#module-environments)
     * `MIX_EXS` - changes the full path to the `mix.exs` file

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -430,7 +430,7 @@ defmodule Mix.Project do
   """
   @spec build_path(keyword) :: Path.t()
   def build_path(config \\ config()) do
-    config[:env_path] || env_path(config)
+    System.get_env("MIX_BUILD_PATH") || config[:env_path] || env_path(config)
   end
 
   defp env_path(config) do

--- a/lib/mix/test/mix/tasks/compile_test.exs
+++ b/lib/mix/test/mix/tasks/compile_test.exs
@@ -137,4 +137,24 @@ defmodule Mix.Tasks.CompileTest do
       end)
     end
   end
+
+  test "skip protocol consolidation when --no-protocol-consolidation" do
+    in_fixture "no_mixfile", fn ->
+      File.rm("_build/dev/lib/sample/.mix/compile.protocols")
+      assert Mix.Task.run("compile", ["--no-protocol-consolidation"]) == {:ok, []}
+      assert File.regular?("_build/dev/lib/sample/ebin/Elixir.A.beam")
+      refute File.regular?("_build/dev/lib/sample/consolidated/Elixir.Enumerable.beam")
+    end
+  end
+
+  test "loads mix config with --erl-config" do
+    in_fixture "no_mixfile", fn ->
+      File.write!("mix.config", "{erl_config_app, [{value, true}]}.")
+      assert Mix.Task.run("compile", ["--erl-config", "mix.config"]) == {:ok, []}
+      assert File.regular?("_build/dev/lib/sample/ebin/Elixir.A.beam")
+      assert Application.get_env(:erl_config_app, :value)
+    end
+  after
+    Application.delete_env(:erl_config_app, :value)
+  end
 end


### PR DESCRIPTION
How it would be called from rebar3:

```
# For each dependency
cd deps/my_dep && \
MIX_BUILD_PATH=../../_build/default MIX_ENV=prod mix compile --no-deps-check --no-consolidate-protocol --erl-config mix.config

# --erl-config should point to a term file in the following format
{my_dep, [{key, value}]}.

# For protocol consolidation run the following script
# paths is a list of paths to dependency ebin directory
# output is the output directory for the compiled protocol beam files
Enum.each(Protocol.extract_protocols(paths), fn protocol ->
  Enum.each(Protocol.extract_impls(protocol, paths), fn impls ->
    :code.purge(protocol)
    :code.delete(protocol)
    {:ok, beam} = Protocol.consolidate(protocol, impls)
    File.write!(Path.join(output, "#{protocol}.beam"), beam)
  end)
end)
```