### PR TITLE
Add a "erl_lint" check for behaviour_info/1 plus callback attributes

### DIFF
--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -380,12 +380,12 @@ specs_form(Map, Data, Defmacro, Unreachable, Forms) ->
   specs_form(callback, AllCallbacks, [], Optional,
              [NameArity || {_, NameArity, _, _} <- Macrocallbacks], SpecsForms).
 
-validate_behaviour_info_and_attributes(#{definitions := Defs, module := Mod} = Map, AllCallbacks) ->
+validate_behaviour_info_and_attributes(#{definitions := Defs} = Map, AllCallbacks) ->
   case {lists:keyfind({behaviour_info, 1}, 1, Defs), AllCallbacks} of
     {false, _} ->
       ok;
     {_, [{Kind, {Name, Arity}, _, _} | _]} when Kind == callback; Kind == macrocallback ->
-      form_error(Map, {behaviour_info, {Mod, Name, Arity}});
+      form_error(Map, {callbacks_but_also_behaviour_info, {Kind, Name, Arity}});
     {_, _} ->
       ok
   end.
@@ -567,6 +567,6 @@ format_error({unknown_callback, {Name, Arity}}) ->
   io_lib:format("unknown callback ~ts/~B given as optional callback", [Name, Arity]);
 format_error({duplicate_optional_callback, {Name, Arity}}) ->
   io_lib:format("~ts/~B has been specified as optional callback more than once", [Name, Arity]);
-format_error({behaviour_info, {_Mod, Fun, Arity}}) ->
-  io_lib:format("cannot define @callback/@macrocallback attribute for ~ts/~B when behaviour_info/1 is defined",
-                [Fun, Arity]).
+format_error({callbacks_but_also_behaviour_info, {Type, Fun, Arity}}) ->
+  io_lib:format("cannot define @~ts attribute for ~ts/~B when behaviour_info/1 is defined",
+                [Type, Fun, Arity]).

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -117,7 +117,7 @@ defmodule Kernel.TypespecTest do
   end
 
   test "behaviour_info/1 explicitly defined alongside @callback/@macrocallback" do
-    message = ~r"cannot define @callback/@macrocallback attribute for foo/1 when behaviour_info/1"
+    message = ~r"cannot define @callback attribute for foo/1 when behaviour_info/1"
 
     assert_raise CompileError, message, fn ->
       test_module do
@@ -125,6 +125,8 @@ defmodule Kernel.TypespecTest do
         def behaviour_info(_), do: []
       end
     end
+
+    message = ~r"cannot define @macrocallback attribute for foo/1 when behaviour_info/1"
 
     assert_raise CompileError, message, fn ->
       test_module do

--- a/lib/elixir/test/elixir/kernel/typespec_test.exs
+++ b/lib/elixir/test/elixir/kernel/typespec_test.exs
@@ -116,6 +116,24 @@ defmodule Kernel.TypespecTest do
     end
   end
 
+  test "behaviour_info/1 explicitly defined alongside @callback/@macrocallback" do
+    message = ~r"cannot define @callback/@macrocallback attribute for foo/1 when behaviour_info/1"
+
+    assert_raise CompileError, message, fn ->
+      test_module do
+        @callback foo(:ok) :: :ok
+        def behaviour_info(_), do: []
+      end
+    end
+
+    assert_raise CompileError, message, fn ->
+      test_module do
+        @macrocallback foo(:ok) :: :ok
+        def behaviour_info(_), do: []
+      end
+    end
+  end
+
   test "@type with a single type" do
     bytecode =
       test_module do


### PR DESCRIPTION
Part of https://github.com/elixir-lang/elixir/issues/5800.

@josevalim if we want to keep the shape of the `erl_lint` error (`{behaviour_info, {M, F, A}}`), then I don't think we can give more information than that and so we can't say `@callback` or `@macrocallback` with certainty, that's why I went with `@callback/@macrocallback` in the error message.