### PR TITLE
Use relative paths for logger file when application is available

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -718,7 +718,8 @@ defmodule Logger do
     %{module: module, function: fun, file: file, line: line} = caller
 
     caller =
-      compile_time_application(file) ++ [module: module, function: form_fa(fun), line: line]
+      compile_time_application_and_file(file) ++
+        [module: module, function: form_fa(fun), line: line]
 
     metadata =
       if Keyword.keyword?(metadata) do
@@ -734,7 +735,7 @@ defmodule Logger do
     end
   end
 
-  defp compile_time_application(file) do
+  defp compile_time_application_and_file(file) do
     if app = Application.get_env(:logger, :compile_time_application) do
       [application: app, file: Path.relative_to_cwd(file)]
     else

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -718,8 +718,8 @@ defmodule Logger do
     %{module: module, function: fun, file: file, line: line} = caller
 
     caller =
-      compile_time_application() ++
-        [module: module, function: form_fa(fun), file: file, line: line]
+      compile_time_application(file) ++
+        [module: module, function: form_fa(fun), line: line]
 
     metadata =
       if Keyword.keyword?(metadata) do
@@ -735,11 +735,11 @@ defmodule Logger do
     end
   end
 
-  defp compile_time_application do
+  defp compile_time_application(file) do
     if app = Application.get_env(:logger, :compile_time_application) do
-      [application: app]
+      [application: app, file: Path.relative_to_cwd(file)]
     else
-      []
+      [file: file]
     end
   end
 

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -718,8 +718,7 @@ defmodule Logger do
     %{module: module, function: fun, file: file, line: line} = caller
 
     caller =
-      compile_time_application(file) ++
-        [module: module, function: form_fa(fun), line: line]
+      compile_time_application(file) ++ [module: module, function: form_fa(fun), line: line]
 
     metadata =
       if Keyword.keyword?(metadata) do


### PR DESCRIPTION
Today the Logger includes the full path to the source file in the `:file` metadata. With this PR, we use the relative path if the application is available, as that is enough to uniquely identify the path and it helps normalize and reduce the size of the metadata.

For example, before this patch, it would report:

     application=interpret_logger_call file=/Users/jose/OSS/interpret_logger_call/lib/interpret_logger_call.ex

and now it reports:

    application=interpret_logger_call file=lib/interpret_logger_call.ex

