### PR TITLE
Properly cancel timeout on compilation error in ParallelCompiler #7428

### DIFF
--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -360,6 +360,7 @@ defmodule Kernel.ParallelCompiler do
       {:file_done, child_pid, file, {kind, reason, stack}} ->
         discard_down(child_pid)
         print_error(file, kind, reason, stack)
+        cancel_waiting_timer(queued, child_pid)
         terminate(queued)
         {:error, [to_error(file, kind, reason, stack)], warnings}
 


### PR DESCRIPTION
The `:timed_out` message was not cancelled properly when compilation failed in ParallelCompiler. This meant the timeout message would be delivered even after compilation completed. This could be problematic when invoking compilation programmatically via e.g. `Mix.Task.run("compile", ["--return-errors"])` since it means that the calling process, depending on the implemenation, might crash unexpectedly or get its inbox filled with messages.

The fix simply calls the `cancel_waiting_timer` when a compilation error has ocurred in the same way it is called in other similar cases.

This fixes issue #7428 