### PR TITLE
Implement check for @spec attributes for undefined functions

### DIFF
--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -416,7 +416,7 @@ specs_form(Kind, Entries, Unreachable, Optional, Macros, Forms, Map) ->
   M =
     lists:foldl(fun({_, NameArity, Line, Spec}, Acc) ->
       case Kind of
-        spec -> validate_spec_for_existing_function(Map, NameArity);
+        spec -> validate_spec_for_existing_function(Map, NameArity, Line);
         _ -> ok
       end,
 
@@ -466,9 +466,9 @@ take_type_spec(Data, Key) ->
     [] -> []
   end.
 
-validate_spec_for_existing_function(#{definitions := Defs} = Map, NameAndArity) ->
+validate_spec_for_existing_function(#{definitions := Defs} = Map, NameAndArity, Line) ->
   case lists:keymember(NameAndArity, 1, Defs) of
-    false -> form_error(Map, {spec_for_undefined_function, NameAndArity});
+    false -> form_error(Map#{line := Line}, {spec_for_undefined_function, NameAndArity});
     true -> ok
   end.
 


### PR DESCRIPTION
This is part of https://github.com/elixir-lang/elixir/issues/5800. I implemented the check that checks that a `@spec` attribute is for a function/macro that is actually defined.

@josevalim this implementation might be very naive but it works for simple cases and for the tests that I did. I don't know how this is related to https://github.com/elixir-lang/elixir/blob/7bc0df82fa1c79063ce36d29a2bed90bfb71a7eb/lib/elixir/src/elixir_erl_compiler.erl#L82-L83, I can't see where `{spec_fun_undefined, {M, F, A}}` (with a module, not just `{F, A}`) is used or raised. Let me know how this looks 💟 