### PR TITLE
ExUnit raise error for @moduletag and @tag when set before 'use ExUnit.Case'

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -213,6 +213,13 @@ defmodule ExUnit.Case do
       async = !!unquote(opts)[:async]
 
       unless Module.get_attribute(__MODULE__, :ex_unit_tests) do
+        moduletag_check = Module.get_attribute(__MODULE__, :moduletag)
+        tag_check = Module.get_attribute(__MODULE__, :tag)
+
+        if moduletag_check != nil or tag_check != nil do
+          raise "you must set @tag and @moduletag after the call to \"use ExUnit.Case\""
+        end
+
         attributes = [
           :ex_unit_tests,
           :tag,
@@ -524,14 +531,8 @@ defmodule ExUnit.Case do
 
   defp normalize_tags(tags) do
     Enum.reduce(Enum.reverse(tags), %{}, fn
-      tag, acc when is_atom(tag) ->
-        Map.put(acc, tag, true)
-
-      tag, acc when is_list(tag) ->
-        tag |> Enum.into(acc)
-
-      tag, _acc when is_tuple(tag) ->
-        raise "you must set @tag and @moduletag after the call to \"use ExUnit.Case\""
+      tag, acc when is_atom(tag) -> Map.put(acc, tag, true)
+      tag, acc when is_list(tag) -> tag |> Enum.into(acc)
     end)
   end
 end

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -216,7 +216,7 @@ defmodule ExUnit.Case do
         moduletag_check = Module.get_attribute(__MODULE__, :moduletag)
         tag_check = Module.get_attribute(__MODULE__, :tag)
 
-        if moduletag_check != nil or tag_check != nil do
+        if moduletag_check || tag_check do
           raise "you must set @tag and @moduletag after the call to \"use ExUnit.Case\""
         end
 

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -524,8 +524,14 @@ defmodule ExUnit.Case do
 
   defp normalize_tags(tags) do
     Enum.reduce(Enum.reverse(tags), %{}, fn
-      tag, acc when is_atom(tag) -> Map.put(acc, tag, true)
-      tag, acc when is_list(tag) -> tag |> Enum.into(acc)
+      tag, acc when is_atom(tag) ->
+        Map.put(acc, tag, true)
+
+      tag, acc when is_list(tag) ->
+        tag |> Enum.into(acc)
+
+      tag, _acc when is_tuple(tag) ->
+        raise "you must set @tag and @moduletag after the call to \"use ExUnit.Case\""
     end)
   end
 end


### PR DESCRIPTION
Addresses #7423 

The original issue mentions only `@moduletag` but I found it happens with `@tag` as well.