### PR TITLE
Revises the description of :extra_applications

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -18,10 +18,13 @@ defmodule Mix.Tasks.Compile.App do
   The most commonly used options are:
 
     * `:extra_applications` - a list of Erlang/Elixir applications
-      that you want started before your application. For example,
-      Elixir's `:logger` or Erlang's `:crypto`. Mix guarantees
-      that any application given here and all of your runtime
-      dependencies are started before your application starts.
+      your application depends on which are not included in `:deps`
+      (usually defined in `deps/0` in your `mix.exs`). For example,
+      here you can declare a dependency on applications that ship with
+      Erlang or Elixir, like `:crypto` or `:logger`, but anything in
+      the code path works. Mix guarantees that these applications and
+      the rest of your runtime dependencies are started before your
+      application starts.
 
     * `:registered` - the name of all registered processes in the
       application. If your application defines a local GenServer


### PR DESCRIPTION
The current description of `:extra_applications` says

> a list of Erlang/Elixir applications that you want started before your application

but from that information the reader is not able to understand how are they different from what you put in `deps/0`, since for example Cowboy is an Erlang application you might want started before your application, so it fits the definition, but it does not go there typically.

The patch is just a proposal (as any patch 😄), because the emphasis depends on what the core team wants to transmit. It tries to reword the description in a way that respects how it technically works today, but I don't really know if custom code paths are a use case intentionally supported, or just an accident of the implementation.

Another option could be that you want to encourage using `path` in `deps/0`, and document `:extra_applications` as something thought specifically for applications shipped with Erlang/Elixir. (Though in that case the key name wouldn't be a natural choice, `:builtin_applications` or something in that line would perhaps communicate better.)

What do you think?