### PR TITLE
Documents :maxT in compile.app

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -67,6 +67,12 @@ defmodule Mix.Tasks.Compile.App do
       in an included application considers itself belonging to the
       primary application.
 
+    * `:maxT` - specifies the maximum time the application is allowed to run, in
+      milliseconds. Applications are stopped if `:maxT` is reached, and their
+      top-level supervisor terminated with reason `:normal`. This threshold is
+      technically valid in any resource file, but it is only effective for
+      applications with a callback module. Defaults to `:infinity`.
+
   Besides the options above, `.app` files also expect other options like
   `:modules` and `:vsn`, but these are automatically added by Mix.
 


### PR DESCRIPTION
Title says it all!

I have added a few more details than in the [Erlang docs](http://erlang.org/doc/man/app.html). In particular, the termination reason is documented, and the description addresses library applications explictly.

I have seen, by the way, that for library applications `:application.which_applications()` reports them as being started regardless of `:maxT`. That is, library applications with `:maxT` are not actually stopped.