### PR TITLE
Allow use of @describetag before a describe block.

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -391,7 +391,6 @@ defmodule ExUnit.Case do
 
       @ex_unit_describe {__ENV__.line, message}
       @ex_unit_used_describes message
-      Module.delete_attribute(__ENV__.module, :describetag)
 
       try do
         unquote(block)

--- a/lib/ex_unit/test/ex_unit/describe_test.exs
+++ b/lib/ex_unit/test/ex_unit/describe_test.exs
@@ -9,8 +9,8 @@ defmodule ExUnit.DescribeTest do
     [setup_tag: :from_module]
   end
 
+  @describetag attribute_tag: :from_describe
   describe "tags" do
-    @describetag attribute_tag: :from_describe
 
     test "from describe have higher precedence", context do
       assert context.attribute_tag == :from_describe


### PR DESCRIPTION
My expectation for the use of the `@describetag` directive is to use it before the `describe` block, as demonstrated in [a recent addition to the docs](https://github.com/elixir-lang/elixir/blob/master/lib/ex_unit/lib/ex_unit/case.ex#L123).

However in practice when used this way the tag does not work, and is completely ignored unless used within the describe block (see [the test case in this repo](https://github.com/elixir-lang/elixir/blob/master/lib/ex_unit/test/ex_unit/describe_test.exs#L13)).

This PR assumes that current behaviour is a bug and fixes use of `@describetag` outside of the block, however if this is incorrect then using it outside of a block should be changed to display an error.

