### PR TITLE
Fix typo in NaiveDateTime moduledoc.

### DIFF
--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -4,7 +4,7 @@ defmodule NaiveDateTime do
 
   The NaiveDateTime struct contains the fields year, month, day, hour,
   minute, second, microsecond and calendar. New naive datetimes can be
-  built with the `new/2` and `new/7` functions or using the
+  built with the `new/2` and `new/8` functions or using the
   [`~N`](`Kernel.sigil_N/2`) sigil:
 
       iex> ~N[2000-01-01 23:00:07]


### PR DESCRIPTION
There's a typo in NaiveDateTime moduledoc.

There's no more new/7 which is then replaced with new/8 since some previous version.
