### PR TITLE
Add the ability to count the number of keys in a Registry

### DIFF
--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -1017,9 +1017,7 @@ defmodule Registry do
     case key_info!(registry) do
       {_kind, partitions, nil} ->
         Enum.reduce(0..(partitions - 1), 0, fn partition_index, acc ->
-          [{^partition_index, partition_ets, _}] = :ets.lookup(registry, partition_index)
-          size = safe_size(partition_ets)
-          acc + size
+          acc + safe_size(key_ets!(registry, partition_index))
         end)
 
       {_kind, 1, key_ets} ->

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -977,11 +977,11 @@ defmodule Registry do
   end
 
   @doc """
-  Returns the size of the Registry (ie The number of registered keys).
+  Returns the size of the registry, that is, the number of registered keys.
 
   ## Examples
   In the example below we register the current process and ask for the
-  size of the Registry:
+  size of the registry:
 
       iex> Registry.start_link(keys: :unique, name: Registry.UniqueCountTest)
       iex> Registry.size(Registry.UniqueCountTest)

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -171,6 +171,15 @@ defmodule Registry do
   @typedoc "The type of registry metadata values"
   @type meta_value :: term
 
+  @typedoc "A pattern to match on objects in a registry"
+  @type match_pattern :: atom | term
+
+  @typedoc "A guard to be evaluated when matching on objects in a registry"
+  @type guard :: {atom | term}
+
+  @typedoc "A list of guards to be evaluated when matching on objects in a registry"
+  @type guards :: [guard] | []
+
   ## Via callbacks
 
   @doc false
@@ -544,14 +553,14 @@ defmodule Registry do
 
   Pattern must be an atom or a tuple that will match the structure of the
   value stored in the registry. The atom `:_` can be used to ignore a given
-  value or tuple element, while :"$1" can be used to temporarily assign part
+  value or tuple element, while the atom `:"$1"` can be used to temporarily assign part
   of pattern to a variable for a subsequent comparison.
 
-  It is possible to pass list of guard conditions for more precise matching.
-  Each guard is a tuple, which describes check that should be passed by assigned part of pattern.
-  For example :"$1" > 1 guard condition would be expressed as {:>, :"$1", 1} tuple.
-  Please note that guard conditions will work only for assigned variables like :"$1", :"$2", etc.
-  Avoid usage of special match variables :"$_" and :"$$", because it might not work as expected.
+  Optionally, it is possible to pass a list of guard conditions for more precise matching.
+  Each guard is a tuple, which describes checks that should be passed by assigned part of pattern.
+  For example the `$1 > 1` guard condition would be expressed as the `{:>, :"$1", 1}` tuple.
+  Please note that guard conditions will work only for assigned variables like `:"$1"`, `:"$2"`, etc.
+  Avoid usage of special match variables `:"$_"` and `:"$$"`, because it might not work as expected.
 
   An empty list will be returned if there is no match.
 
@@ -581,7 +590,7 @@ defmodule Registry do
 
   """
   @since "1.4.0"
-  @spec match(registry, key, match_pattern :: term, guards :: list()) :: [{pid, term}]
+  @spec match(registry, key, match_pattern, guards) :: [{pid, term}]
   def match(registry, key, pattern, guards \\ []) when is_atom(registry) and is_list(guards) do
     guards = [{:"=:=", {:element, 1, :"$_"}, {:const, key}} | guards]
     spec = [{{:_, {:_, pattern}}, guards, [{:element, 2, :"$_"}]}]
@@ -1032,14 +1041,14 @@ defmodule Registry do
 
   Pattern must be an atom or a tuple that will match the structure of the
   value stored in the registry. The atom `:_` can be used to ignore a given
-  value or tuple element, while :"$1" can be used to temporarily assign part
+  value or tuple element, while the atom `:"$1"` can be used to temporarily assign part
   of pattern to a variable for a subsequent comparison.
 
-  It is possible to pass list of guard conditions for more precise matching.
-  Each guard is a tuple, which describes check that should be passed by assigned part of pattern.
-  For example :"$1" > 1 guard condition would be expressed as {:>, :"$1", 1} tuple.
-  Please note that guard conditions will work only for assigned variables like :"$1", :"$2", etc.
-  Avoid usage of special match variables :"$_" and :"$$", because it might not work as expected.
+  Optionally, it is possible to pass a list of guard conditions for more precise matching.
+  Each guard is a tuple, which describes checks that should be passed by assigned part of pattern.
+  For example the `$1 > 1` guard condition would be expressed as the `{:>, :"$1", 1}` tuple.
+  Please note that guard conditions will work only for assigned variables like `:"$1"`, `:"$2"`, etc.
+  Avoid usage of special match variables `:"$_"` and `:"$$"`, because it might not work as expected.
 
   Zero will be returned if there is no match.
 
@@ -1069,7 +1078,7 @@ defmodule Registry do
 
   """
   @since "1.7.0"
-  @spec count_match(registry, key, match_pattern :: term, guards :: list()) :: non_neg_integer()
+  @spec count_match(registry, key, match_pattern, guards) :: non_neg_integer()
   def count_match(registry, key, pattern, guards \\ [])
       when is_atom(registry) and is_list(guards) do
     guards = [{:"=:=", {:element, 1, :"$_"}, {:const, key}} | guards]

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -977,47 +977,47 @@ defmodule Registry do
   end
 
   @doc """
-  Counts registered keys.
+  Returns the size of the Registry (ie The number of registered keys).
 
   ## Examples
-  In the example below we register the current process and count the number
-  of registered keys:
+  In the example below we register the current process and ask for the
+  size of the Registry:
 
       iex> Registry.start_link(keys: :unique, name: Registry.UniqueCountTest)
-      iex> Registry.count(Registry.UniqueCountTest)
+      iex> Registry.size(Registry.UniqueCountTest)
       0
       iex> {:ok, _} = Registry.register(Registry.UniqueCountTest, "hello", :world)
       iex> {:ok, _} = Registry.register(Registry.UniqueCountTest, "world", :world)
-      iex> Registry.count(Registry.UniqueCountTest)
+      iex> Registry.size(Registry.UniqueCountTest)
       2
 
   The same applies to duplicate registries:
 
       iex> Registry.start_link(keys: :duplicate, name: Registry.DuplicateCountTest)
-      iex> Registry.count(Registry.DuplicateCountTest)
+      iex> Registry.size(Registry.DuplicateCountTest)
       0
       iex> {:ok, _} = Registry.register(Registry.DuplicateCountTest, "hello", :world)
       iex> {:ok, _} = Registry.register(Registry.DuplicateCountTest, "hello", :world)
-      iex> Registry.count(Registry.DuplicateCountTest)
+      iex> Registry.size(Registry.DuplicateCountTest)
       2
   """
   @since "1.7.0"
-  @spec count(registry) :: non_neg_integer()
-  def count(registry) when is_atom(registry) do
+  @spec size(registry) :: non_neg_integer()
+  def size(registry) when is_atom(registry) do
     case key_info!(registry) do
       {_kind, partitions, nil} ->
         Enum.reduce(0..(partitions - 1), 0, fn partition_index, acc ->
           [{^partition_index, partition_ets, _}] = :ets.lookup(registry, partition_index)
-          size = safe_count(partition_ets)
+          size = safe_size(partition_ets)
           acc + size
         end)
 
       {_kind, 1, key_ets} ->
-        safe_count(key_ets)
+        safe_size(key_ets)
     end
   end
 
-  defp safe_count(ets) do
+  defp safe_size(ets) do
     try do
       :ets.info(ets, :size)
     catch

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -1001,7 +1001,7 @@ defmodule Registry do
       iex> Registry.count(Registry.DuplicateCountTest)
       2
   """
-  @spec count(registry) :: integer()
+  @spec count(registry) :: non_neg_integer()
   def count(registry) when is_atom(registry) do
     case key_info!(registry) do
       {_kind, partitions, nil} ->

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -977,33 +977,34 @@ defmodule Registry do
   end
 
   @doc """
-  Returns the size of the registry, that is, the number of registered keys.
+  Returns the number of registered keys in a registry.
+  It runs in constant time.
 
   ## Examples
   In the example below we register the current process and ask for the
-  size of the registry:
+  number of keys in the registry:
 
       iex> Registry.start_link(keys: :unique, name: Registry.UniqueCountTest)
-      iex> Registry.size(Registry.UniqueCountTest)
+      iex> Registry.count(Registry.UniqueCountTest)
       0
       iex> {:ok, _} = Registry.register(Registry.UniqueCountTest, "hello", :world)
       iex> {:ok, _} = Registry.register(Registry.UniqueCountTest, "world", :world)
-      iex> Registry.size(Registry.UniqueCountTest)
+      iex> Registry.count(Registry.UniqueCountTest)
       2
 
   The same applies to duplicate registries:
 
       iex> Registry.start_link(keys: :duplicate, name: Registry.DuplicateCountTest)
-      iex> Registry.size(Registry.DuplicateCountTest)
+      iex> Registry.count(Registry.DuplicateCountTest)
       0
       iex> {:ok, _} = Registry.register(Registry.DuplicateCountTest, "hello", :world)
       iex> {:ok, _} = Registry.register(Registry.DuplicateCountTest, "hello", :world)
-      iex> Registry.size(Registry.DuplicateCountTest)
+      iex> Registry.count(Registry.DuplicateCountTest)
       2
   """
   @since "1.7.0"
-  @spec size(registry) :: non_neg_integer()
-  def size(registry) when is_atom(registry) do
+  @spec count(registry) :: non_neg_integer()
+  def count(registry) when is_atom(registry) do
     case key_info!(registry) do
       {_kind, partitions, nil} ->
         Enum.reduce(0..(partitions - 1), 0, fn partition_index, acc ->

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -1001,6 +1001,7 @@ defmodule Registry do
       iex> Registry.count(Registry.DuplicateCountTest)
       2
   """
+  @since "1.7.0"
   @spec count(registry) :: non_neg_integer()
   def count(registry) when is_atom(registry) do
     case key_info!(registry) do

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -21,6 +21,17 @@ defmodule RegistryTest do
         assert length(Supervisor.which_children(registry)) == partitions
       end
 
+      test "counts 0 elements in an empty Registry", %{registry: registry} do
+        assert 0 == Registry.count(registry)
+      end
+
+      test "counts the number of keys", %{registry: registry} do
+        {:ok, _} = Registry.register(registry, "hello", :value)
+        {:ok, _} = Registry.register(registry, "world", :value)
+
+        assert 2 == Registry.count(registry)
+      end
+
       test "has unique registrations", %{registry: registry} do
         {:ok, pid} = Registry.register(registry, "hello", :value)
         assert is_pid(pid)
@@ -229,6 +240,17 @@ defmodule RegistryTest do
 
       test "starts configured number of partitions", %{registry: registry, partitions: partitions} do
         assert length(Supervisor.which_children(registry)) == partitions
+      end
+
+      test "counts 0 elements in an empty Registry", %{registry: registry} do
+        assert 0 == Registry.count(registry)
+      end
+
+      test "counts the number of keys", %{registry: registry} do
+        {:ok, _} = Registry.register(registry, "hello", :value)
+        {:ok, _} = Registry.register(registry, "hello", :value)
+
+        assert 2 == Registry.count(registry)
       end
 
       test "has duplicate registrations", %{registry: registry} do

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -21,15 +21,15 @@ defmodule RegistryTest do
         assert length(Supervisor.which_children(registry)) == partitions
       end
 
-      test "counts 0 elements in an empty Registry", %{registry: registry} do
-        assert 0 == Registry.count(registry)
+      test "returns 0 as the size of an empty Registry", %{registry: registry} do
+        assert 0 == Registry.size(registry)
       end
 
-      test "counts the number of keys", %{registry: registry} do
+      test "returns the size of the Registry", %{registry: registry} do
         {:ok, _} = Registry.register(registry, "hello", :value)
         {:ok, _} = Registry.register(registry, "world", :value)
 
-        assert 2 == Registry.count(registry)
+        assert 2 == Registry.size(registry)
       end
 
       test "has unique registrations", %{registry: registry} do
@@ -242,15 +242,15 @@ defmodule RegistryTest do
         assert length(Supervisor.which_children(registry)) == partitions
       end
 
-      test "counts 0 elements in an empty Registry", %{registry: registry} do
-        assert 0 == Registry.count(registry)
+      test "returns 0 as the size of an empty Registry", %{registry: registry} do
+        assert 0 == Registry.size(registry)
       end
 
-      test "counts the number of keys", %{registry: registry} do
+      test "returns the size of the Registry", %{registry: registry} do
         {:ok, _} = Registry.register(registry, "hello", :value)
         {:ok, _} = Registry.register(registry, "hello", :value)
 
-        assert 2 == Registry.count(registry)
+        assert 2 == Registry.size(registry)
       end
 
       test "has duplicate registrations", %{registry: registry} do

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -21,11 +21,11 @@ defmodule RegistryTest do
         assert length(Supervisor.which_children(registry)) == partitions
       end
 
-      test "returns 0 as the size of an empty Registry", %{registry: registry} do
+      test "returns 0 as the size of an empty registry", %{registry: registry} do
         assert 0 == Registry.size(registry)
       end
 
-      test "returns the size of the Registry", %{registry: registry} do
+      test "returns the size of the registry", %{registry: registry} do
         {:ok, _} = Registry.register(registry, "hello", :value)
         {:ok, _} = Registry.register(registry, "world", :value)
 
@@ -242,11 +242,11 @@ defmodule RegistryTest do
         assert length(Supervisor.which_children(registry)) == partitions
       end
 
-      test "returns 0 as the size of an empty Registry", %{registry: registry} do
+      test "returns 0 as the size of an empty registry", %{registry: registry} do
         assert 0 == Registry.size(registry)
       end
 
-      test "returns the size of the Registry", %{registry: registry} do
+      test "returns the size of the registry", %{registry: registry} do
         {:ok, _} = Registry.register(registry, "hello", :value)
         {:ok, _} = Registry.register(registry, "hello", :value)
 

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -98,6 +98,30 @@ defmodule RegistryTest do
                  [{self(), value}]
       end
 
+      test "count_match supports match patterns", %{registry: registry} do
+        value = {1, :atom, 1}
+        {:ok, _} = Registry.register(registry, "hello", value)
+        assert 1 == Registry.count_match(registry, "hello", {1, :_, :_})
+        assert 0 == Registry.count_match(registry, "hello", {1.0, :_, :_})
+        assert 1 == Registry.count_match(registry, "hello", {:_, :atom, :_})
+        assert 1 == Registry.count_match(registry, "hello", {:"$1", :_, :"$1"})
+        assert 1 == Registry.count_match(registry, "hello", :_)
+        assert 0 == Registry.count_match(registry, :_, :_)
+
+        value2 = %{a: "a", b: "b"}
+        {:ok, _} = Registry.register(registry, "world", value2)
+        assert 1 == Registry.count_match(registry, "world", %{b: "b"})
+      end
+
+      test "count_match supports guard conditions", %{registry: registry} do
+        value = {1, :atom, 2}
+        {:ok, _} = Registry.register(registry, "hello", value)
+
+        assert 1 == Registry.count_match(registry, "hello", {:_, :_, :"$1"}, [{:>, :"$1", 1}])
+        assert 0 == Registry.count_match(registry, "hello", {:_, :_, :"$1"}, [{:>, :"$1", 2}])
+        assert 1 == Registry.count_match(registry, "hello", {:_, :"$1", :_}, [{:is_atom, :"$1"}])
+      end
+
       test "unregister_match supports patterns", %{registry: registry} do
         value = {1, :atom, 1}
         {:ok, _} = Registry.register(registry, "hello", value)
@@ -410,6 +434,30 @@ defmodule RegistryTest do
 
         assert Registry.match(registry, "hello", {:_, :"$1", :_}, [{:is_atom, :"$1"}])
                |> Enum.sort() == [{self(), value1}, {self(), value2}]
+      end
+
+      test "count_match supports match patterns", %{registry: registry} do
+        value = {1, :atom, 1}
+        {:ok, _} = Registry.register(registry, "hello", value)
+        assert 1 == Registry.count_match(registry, "hello", {1, :_, :_})
+        assert 0 == Registry.count_match(registry, "hello", {1.0, :_, :_})
+        assert 1 == Registry.count_match(registry, "hello", {:_, :atom, :_})
+        assert 1 == Registry.count_match(registry, "hello", {:"$1", :_, :"$1"})
+        assert 1 == Registry.count_match(registry, "hello", :_)
+        assert 0 == Registry.count_match(registry, :_, :_)
+
+        value2 = %{a: "a", b: "b"}
+        {:ok, _} = Registry.register(registry, "world", value2)
+        assert 1 == Registry.count_match(registry, "world", %{b: "b"})
+      end
+
+      test "count_match supports guard conditions", %{registry: registry} do
+        value = {1, :atom, 2}
+        {:ok, _} = Registry.register(registry, "hello", value)
+
+        assert 1 == Registry.count_match(registry, "hello", {:_, :_, :"$1"}, [{:>, :"$1", 1}])
+        assert 0 == Registry.count_match(registry, "hello", {:_, :_, :"$1"}, [{:>, :"$1", 2}])
+        assert 1 == Registry.count_match(registry, "hello", {:_, :"$1", :_}, [{:is_atom, :"$1"}])
       end
 
       test "unregister_match supports patterns", %{registry: registry} do

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -21,15 +21,15 @@ defmodule RegistryTest do
         assert length(Supervisor.which_children(registry)) == partitions
       end
 
-      test "returns 0 as the size of an empty registry", %{registry: registry} do
-        assert 0 == Registry.size(registry)
+      test "counts 0 keys in an empty registry", %{registry: registry} do
+        assert 0 == Registry.count(registry)
       end
 
-      test "returns the size of the registry", %{registry: registry} do
+      test "counts the number of keys in a registry", %{registry: registry} do
         {:ok, _} = Registry.register(registry, "hello", :value)
         {:ok, _} = Registry.register(registry, "world", :value)
 
-        assert 2 == Registry.size(registry)
+        assert 2 == Registry.count(registry)
       end
 
       test "has unique registrations", %{registry: registry} do
@@ -266,15 +266,15 @@ defmodule RegistryTest do
         assert length(Supervisor.which_children(registry)) == partitions
       end
 
-      test "returns 0 as the size of an empty registry", %{registry: registry} do
-        assert 0 == Registry.size(registry)
+      test "counts 0 keys in an empty registry", %{registry: registry} do
+        assert 0 == Registry.count(registry)
       end
 
-      test "returns the size of the registry", %{registry: registry} do
+      test "counts the number of keys in a registry", %{registry: registry} do
         {:ok, _} = Registry.register(registry, "hello", :value)
         {:ok, _} = Registry.register(registry, "hello", :value)
 
-        assert 2 == Registry.size(registry)
+        assert 2 == Registry.count(registry)
       end
 
       test "has duplicate registrations", %{registry: registry} do


### PR DESCRIPTION
Hello everyone,

I'd like to propose a new feature for the `Registry` module. Namely the `count/1` function that returns the number of registered keys in a `Registry`.

It works for both `:unique` and `:duplicate` registries (and the code is the same for both :) )

Do I need to propose this feature in the Mailing List or is if fine to provide it as a PR?

Thanks for making Elixir such a great and approachable language ❤️ 

