### PR TITLE
Add function to Mix.Tasks.Format that returns options to be used for a given file

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -142,6 +142,19 @@ defmodule Mix.Tasks.Format do
     |> check!()
   end
 
+  @doc """
+  Returns formatter options to be used for the given file.
+  """
+  def formatter_opts_for_file(path, opts \\ []) do
+    {dot_formatter, formatter_opts} = eval_dot_formatter(opts)
+
+    {formatter_opts_and_subs, _sources} =
+      eval_deps_and_subdirectories(dot_formatter, [], formatter_opts, [dot_formatter])
+
+    [{^path, formatter_opts}] = expand_args([path], dot_formatter, formatter_opts_and_subs)
+    formatter_opts
+  end
+
   defp eval_dot_formatter(opts) do
     cond do
       dot_formatter = opts[:dot_formatter] ->

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -145,14 +145,14 @@ defmodule Mix.Tasks.Format do
   @doc """
   Returns formatter options to be used for the given file.
   """
-  def formatter_opts_for_file(path, opts \\ []) do
+  def formatter_opts_for_file(file, opts \\ []) do
     {dot_formatter, formatter_opts} = eval_dot_formatter(opts)
 
     {formatter_opts_and_subs, _sources} =
       eval_deps_and_subdirectories(dot_formatter, [], formatter_opts, [dot_formatter])
 
-    [{^path, formatter_opts}] = expand_args([path], dot_formatter, formatter_opts_and_subs)
-    formatter_opts
+    split = file |> Path.relative_to_cwd() |> Path.split()
+    find_formatter_opts_for_file(split, formatter_opts_and_subs)
   end
 
   defp eval_dot_formatter(opts) do

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -357,6 +357,9 @@ defmodule Mix.Tasks.FormatTest do
       File.touch!("lib/extra/.formatter.exs", {{2030, 1, 1}, {0, 0, 0}})
       Mix.Tasks.Format.run([])
 
+      assert [inputs: "a.ex", locals_without_parens: [other_fun: 1]] =
+               Mix.Tasks.Format.formatter_opts_for_file("lib/extra/a.ex")
+
       assert File.read!("lib/extra/a.ex") == """
              my_fun(:foo, :bar)
              other_fun :baz

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -213,6 +213,9 @@ defmodule Mix.Tasks.FormatTest do
       [inputs: "a.ex", locals_without_parens: [my_fun: 2]]
       """)
 
+      formatter_opts = Mix.Tasks.Format.formatter_opts_for_file("lib/extra/a.ex")
+      assert [my_fun: 2] = Keyword.get(formatter_opts, :locals_without_parens)
+
       File.write!("lib/a.ex", """
       my_fun :foo, :bar
       other_fun :baz
@@ -279,6 +282,9 @@ defmodule Mix.Tasks.FormatTest do
 
       # Let's check that the manifest gets updated if it's stale.
       File.touch!(manifest_path, {{1970, 1, 1}, {0, 0, 0}})
+
+      formatter_opts = Mix.Tasks.Format.formatter_opts_for_file("a.ex")
+      assert [my_fun: 2] = Keyword.get(formatter_opts, :locals_without_parens)
 
       Mix.Tasks.Format.run(["a.ex"])
       assert File.stat!(manifest_path).mtime > {{1970, 1, 1}, {0, 0, 0}}
@@ -357,8 +363,8 @@ defmodule Mix.Tasks.FormatTest do
       File.touch!("lib/extra/.formatter.exs", {{2030, 1, 1}, {0, 0, 0}})
       Mix.Tasks.Format.run([])
 
-      assert [inputs: "a.ex", locals_without_parens: [other_fun: 1]] =
-               Mix.Tasks.Format.formatter_opts_for_file("lib/extra/a.ex")
+      formatter_opts = Mix.Tasks.Format.formatter_opts_for_file("lib/extra/a.ex")
+      assert [other_fun: 1] = Keyword.get(formatter_opts, :locals_without_parens)
 
       assert File.read!("lib/extra/a.ex") == """
              my_fun(:foo, :bar)


### PR DESCRIPTION
Someone recently filed an issue on ElixirLS pointing out that it hasn't kept up with the available options in `.formatter.exs`: https://github.com/JakeBecker/elixir-ls/issues/67 .  I had been loading them from `.formatter.exs` manually, but now that it supports having different config files in subdirectories and importing from dependencies, adding that functionality would increase code duplication more than I would like. I'd also like to have a more future-proof way to do it. The Language Server Protocol has the server respond to the format request with the changed file contents rather than changing the file on-disk, so simply running `mix format` on the file isn't ideal.

I took a quick stab at adding a function that exports the options to be used for a particular file. It doesn't change any of the existing code in `Mix.Tasks.Format`, and I tacked an assertion onto an existing test. It's a bit of a bolt-on, but at least not much code.

I'm open to other ideas for how to handle this, so let me know if there's another approach you'd recommend or prefer.