### PR TITLE
Mix.Utils.stale?: Add support for empty target list

### DIFF
--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -138,6 +138,10 @@ defmodule Mix.Utils do
     stale_stream(sources, targets) |> Enum.to_list()
   end
 
+  defp stale_stream(sources, []) do
+    sources
+  end
+
   defp stale_stream(sources, targets) do
     modified_target = targets |> Enum.map(&last_modified/1) |> Enum.min()
 

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -50,8 +50,6 @@ defmodule Mix.UtilsTest do
   end
 
   test "handles missing target files" do
-    # Don't crash if target is empty
-    # This can easily happen using Path.wildcard()
     assert Mix.Utils.stale?([__ENV__.file], []) == true
   end
 

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -49,6 +49,12 @@ defmodule Mix.UtilsTest do
     assert Mix.Utils.extract_stale([__ENV__.file], [__ENV__.file]) == []
   end
 
+  test "handles missing target files" do
+    # Don't crash if target is empty
+    # This can easily happen using Path.wildcard()
+    assert Mix.Utils.stale?([__ENV__.file], []) == true
+  end
+
   test "symlink or copy" do
     in_fixture("archive", fn ->
       File.mkdir_p!("_build/archive")


### PR DESCRIPTION
Mix.Utils.stale? will crash if the target list is empty.  This can
easily happen if Path.wildcard() is used to generate it.