### PR TITLE
Add hist iex helper

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -367,6 +367,22 @@ defmodule IEx.Helpers do
     IEx.History.nth(history(), n) |> elem(2)
   end
 
+  def hist do
+    %IEx.History{queue: {history_list, first_item }} = history()
+    write_hist_item(first_item)
+
+    history_list
+    |> Enum.reverse()
+    |>Enum.map(&write_hist_item/1)
+  end
+
+  defp write_hist_item([{ 1, item, _ }]) do
+    IO.write "iex(1)> #{item}"
+  end
+  defp write_hist_item(hist_item) do
+    IO.write "iex(#{elem(hist_item, 0)})> #{elem(hist_item, 1)}"
+  end
+
   @doc """
   Recompiles and reloads the given `module`.
 

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -31,6 +31,7 @@ defmodule IEx.Helpers do
     * `flush/0`        - flushes all messages sent to the shell
     * `h/0`            - prints this help message
     * `h/1`            - prints help for the given module, function or macro
+    * `hist/0`         - prints iex session history, up to configured history size
     * `i/0`            - prints information about the last value
     * `i/1`            - prints information about the given term
     * `ls/0`           - lists the contents of the current directory

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -374,6 +374,8 @@ defmodule IEx.Helpers do
     history_list
     |> Enum.reverse()
     |>Enum.map(&write_hist_item/1)
+    
+    nil
   end
 
   defp write_hist_item([{ 1, item, _ }]) do

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -368,22 +368,23 @@ defmodule IEx.Helpers do
   end
 
   def hist do
-    %IEx.History{queue: {recent_history_list, start_history_list }} = history()
-    
+    %IEx.History{queue: {recent_history_list, start_history_list}} = history()
+
     start_history_list |> Enum.map(&write_hist_item/1)
 
     recent_history_list
     |> Enum.reverse()
     |> Enum.map(&write_hist_item/1)
-    
+
     nil
   end
 
-  defp write_hist_item({ prompt_count, item, _ }) do
-    IO.write "(#{prompt_count})> #{item}"
+  defp write_hist_item({prompt_count, item, _}) do
+    IO.write("(#{prompt_count})> #{item}")
   end
+
   defp write_hist_item(hist_item) do
-    IO.write "(#{elem(hist_item, 0)})> #{elem(hist_item, 1)}"
+    IO.write("(#{elem(hist_item, 0)})> #{elem(hist_item, 1)}")
   end
 
   @doc """

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -377,10 +377,10 @@ defmodule IEx.Helpers do
   end
 
   defp write_hist_item([{ 1, item, _ }]) do
-    IO.write "iex(1)> #{item}"
+    IO.write "(1)> #{item}"
   end
   defp write_hist_item(hist_item) do
-    IO.write "iex(#{elem(hist_item, 0)})> #{elem(hist_item, 1)}"
+    IO.write "(#{elem(hist_item, 0)})> #{elem(hist_item, 1)}"
   end
 
   @doc """

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -368,18 +368,19 @@ defmodule IEx.Helpers do
   end
 
   def hist do
-    %IEx.History{queue: {history_list, first_item }} = history()
-    write_hist_item(first_item)
+    %IEx.History{queue: {recent_history_list, start_history_list }} = history()
+    
+    start_history_list |> Enum.map(&write_hist_item/1)
 
-    history_list
+    recent_history_list
     |> Enum.reverse()
-    |>Enum.map(&write_hist_item/1)
+    |> Enum.map(&write_hist_item/1)
     
     nil
   end
 
-  defp write_hist_item([{ 1, item, _ }]) do
-    IO.write "(1)> #{item}"
+  defp write_hist_item({ prompt_count, item, _ }) do
+    IO.write "(#{prompt_count})> #{item}"
   end
   defp write_hist_item(hist_item) do
     IO.write "(#{elem(hist_item, 0)})> #{elem(hist_item, 1)}"

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -368,6 +368,39 @@ defmodule IEx.Helpers do
     IEx.History.nth(history(), n) |> elem(2)
   end
 
+  @doc """
+  Prints iex session history, up to configured history size.
+
+  It returns nil, after printing history.
+
+  If you want to modify the history size, 
+  run `IEx.configure history_size: \#{DESIRED_HISTORY_SIZE}` first.
+   
+  For example `IEx.configure history_size: 100`
+
+  Adding configuration line (e.g. `IEx.configure history_size: 500`) 
+  to local `.iex.exs` file (located in the current
+  working directory), or to global one (located at `~/.iex.exs`)
+  is recommended.
+   
+
+  ## Examples
+
+      iex(1)> IEx.configure history_size: 3
+      :ok
+      iex(2)> 1 + 1
+      2
+      iex(3)> "i" <> "i" <> "i"
+      "iii"
+      iex(4)> %{:d => 4}
+      %{d: 4}
+      iex(5)> hist
+      (2)> 1 + 1
+      (3)> "i" <> "i" <> "i"
+      (4)> %{:d => 4}
+      nil
+
+  """
   def hist do
     %IEx.History{queue: {recent_history_list, start_history_list}} = history()
 

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -394,7 +394,7 @@ defmodule IEx.Helpers do
       "iii"
       iex(4)> %{:d => 4}
       %{d: 4}
-      iex(5)> hist
+      iex(5)> hist()
       (2)> 1 + 1
       (3)> "i" <> "i" <> "i"
       (4)> %{:d => 4}

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -782,6 +782,39 @@ defmodule IEx.HelpersTest do
                (30)> 30
                """ <> "nil"
     end
+
+    test "long session only returns most recent iex session history if default history_size of 20" do
+      assert capture_iex("""
+             1\n2\n3\n4\n5\n6\n7\n8\n9\n10
+             11\n12\n13\n14\n15\n16\n17\n18\n19\n20
+             21\n22\n23\n24\n25\nhist
+             """) ==
+               """
+               1\n2\n3\n4\n5\n6\n7\n8\n9\n10
+               11\n12\n13\n14\n15\n16\n17\n18\n19\n20
+               21\n22\n23\n24\n25
+               (6)> 6
+               (7)> 7
+               (8)> 8
+               (9)> 9
+               (10)> 10
+               (11)> 11
+               (12)> 12
+               (13)> 13
+               (14)> 14
+               (15)> 15
+               (16)> 16
+               (17)> 17
+               (18)> 18
+               (19)> 19
+               (20)> 20
+               (21)> 21
+               (22)> 22
+               (23)> 23
+               (24)> 24
+               (25)> 25
+               """ <> "nil"
+    end
   end
 
   describe "flush" do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -704,6 +704,36 @@ defmodule IEx.HelpersTest do
       assert capture_iex("'a'\n'b'\n'c'\nhist") == 
                 "'a'\n'b'\n'c'\n(1)> 'a'\n(2)> 'b'\n(3)> 'c'\nnil"
     end
+
+    test "returns all recent iex session history if non-default history_size of 10 not 20" do
+      assert capture_iex("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\nhist", [history_size: 10]) == """
+              1\n2\n3\n4\n5\n6\n7\n8\n9\n10
+              (1)> 1
+              (2)> 2
+              (3)> 3
+              (4)> 4
+              (5)> 5
+              (6)> 6
+              (7)> 7
+              (8)> 8
+              (9)> 9
+              (10)> 10
+              """ <> "nil"
+    end
+    
+    test "returns all recent iex session history if non-default history_size of 8 not 20" do
+      assert capture_iex("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\nhist", [history_size: 8]) == """
+              1\n2\n3\n4\n5\n6\n7\n8\n9\n10
+              (3)> 3
+              (4)> 4
+              (5)> 5
+              (6)> 6
+              (7)> 7
+              (8)> 8
+              (9)> 9
+              (10)> 10
+              """ <> "nil"
+    end
   end
 
   describe "flush" do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -695,6 +695,17 @@ defmodule IEx.HelpersTest do
     end
   end
 
+  describe "hist" do
+    test "returns recent iex session history" do
+      assert capture_iex("1\n2\nhist") == "1\n2\niex(1)> 1\niex(2)> 2\n[:ok]"
+    end
+    
+    test "returns more recent iex session history" do
+      assert capture_iex("'a'\n'b'\n'c'\nhist") == 
+                "'a'\n'b'\n'c'\niex(1)> 'a'\niex(2)> 'b'\niex(3)> 'c'\n[:ok, :ok]"
+    end
+  end
+
   describe "flush" do
     test "flushes messages" do
       assert capture_io(fn ->

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -701,38 +701,40 @@ defmodule IEx.HelpersTest do
     end
 
     test "returns more recent iex session history" do
-      assert capture_iex("'a'\n'b'\n'c'\nhist") == 
-                "'a'\n'b'\n'c'\n(1)> 'a'\n(2)> 'b'\n(3)> 'c'\nnil"
+      assert capture_iex("'a'\n'b'\n'c'\nhist") ==
+               "'a'\n'b'\n'c'\n(1)> 'a'\n(2)> 'b'\n(3)> 'c'\nnil"
     end
 
     test "returns all recent iex session history if non-default history_size of 10 not 20" do
-      assert capture_iex("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\nhist", [history_size: 10]) == """
-              1\n2\n3\n4\n5\n6\n7\n8\n9\n10
-              (1)> 1
-              (2)> 2
-              (3)> 3
-              (4)> 4
-              (5)> 5
-              (6)> 6
-              (7)> 7
-              (8)> 8
-              (9)> 9
-              (10)> 10
-              """ <> "nil"
+      assert capture_iex("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\nhist", history_size: 10) ==
+               """
+               1\n2\n3\n4\n5\n6\n7\n8\n9\n10
+               (1)> 1
+               (2)> 2
+               (3)> 3
+               (4)> 4
+               (5)> 5
+               (6)> 6
+               (7)> 7
+               (8)> 8
+               (9)> 9
+               (10)> 10
+               """ <> "nil"
     end
-    
+
     test "returns all recent iex session history if non-default history_size of 8 not 20" do
-      assert capture_iex("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\nhist", [history_size: 8]) == """
-              1\n2\n3\n4\n5\n6\n7\n8\n9\n10
-              (3)> 3
-              (4)> 4
-              (5)> 5
-              (6)> 6
-              (7)> 7
-              (8)> 8
-              (9)> 9
-              (10)> 10
-              """ <> "nil"
+      assert capture_iex("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\nhist", history_size: 8) ==
+               """
+               1\n2\n3\n4\n5\n6\n7\n8\n9\n10
+               (3)> 3
+               (4)> 4
+               (5)> 5
+               (6)> 6
+               (7)> 7
+               (8)> 8
+               (9)> 9
+               (10)> 10
+               """ <> "nil"
     end
   end
 

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -736,6 +736,52 @@ defmodule IEx.HelpersTest do
                (10)> 10
                """ <> "nil"
     end
+
+    test "returns all recent iex session history if non-default history_size of 30 not 20" do
+      assert capture_iex(
+               """
+               1\n2\n3\n4\n5\n6\n7\n8\n9\n10
+               11\n12\n13\n14\n15\n16\n17\n18\n19\n20
+               21\n22\n23\n24\n25\n26\n27\n28\n29\n30\nhist
+               """,
+               history_size: 30
+             ) ==
+               """
+               1\n2\n3\n4\n5\n6\n7\n8\n9\n10
+               11\n12\n13\n14\n15\n16\n17\n18\n19\n20
+               21\n22\n23\n24\n25\n26\n27\n28\n29\n30
+               (1)> 1
+               (2)> 2
+               (3)> 3
+               (4)> 4
+               (5)> 5
+               (6)> 6
+               (7)> 7
+               (8)> 8
+               (9)> 9
+               (10)> 10
+               (11)> 11
+               (12)> 12
+               (13)> 13
+               (14)> 14
+               (15)> 15
+               (16)> 16
+               (17)> 17
+               (18)> 18
+               (19)> 19
+               (20)> 20
+               (21)> 21
+               (22)> 22
+               (23)> 23
+               (24)> 24
+               (25)> 25
+               (26)> 26
+               (27)> 27
+               (28)> 28
+               (29)> 29
+               (30)> 30
+               """ <> "nil"
+    end
   end
 
   describe "flush" do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -697,12 +697,12 @@ defmodule IEx.HelpersTest do
 
   describe "hist" do
     test "returns recent iex session history" do
-      assert capture_iex("1\n2\nhist") == "1\n2\niex(1)> 1\niex(2)> 2\n[:ok]"
+      assert capture_iex("1\n2\nhist") == "1\n2\n(1)> 1\n(2)> 2\n[:ok]"
     end
-    
+
     test "returns more recent iex session history" do
       assert capture_iex("'a'\n'b'\n'c'\nhist") == 
-                "'a'\n'b'\n'c'\niex(1)> 'a'\niex(2)> 'b'\niex(3)> 'c'\n[:ok, :ok]"
+                "'a'\n'b'\n'c'\n(1)> 'a'\n(2)> 'b'\n(3)> 'c'\n[:ok, :ok]"
     end
   end
 

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -697,12 +697,12 @@ defmodule IEx.HelpersTest do
 
   describe "hist" do
     test "returns recent iex session history" do
-      assert capture_iex("1\n2\nhist") == "1\n2\n(1)> 1\n(2)> 2\n[:ok]"
+      assert capture_iex("1\n2\nhist") == "1\n2\n(1)> 1\n(2)> 2\nnil"
     end
 
     test "returns more recent iex session history" do
       assert capture_iex("'a'\n'b'\n'c'\nhist") == 
-                "'a'\n'b'\n'c'\n(1)> 'a'\n(2)> 'b'\n(3)> 'c'\n[:ok, :ok]"
+                "'a'\n'b'\n'c'\n(1)> 'a'\n(2)> 'b'\n(3)> 'c'\nnil"
     end
   end
 


### PR DESCRIPTION
Add `hist/0` iex helper
 
Prints iex session history, up to configured history size
 
as a convenience for outputting the commands all at once (akin to `history` or `fc` in `bash` and `zsh`, respectively)

![](https://dl.dropbox.com/s/oul2tctgg4gr1gz/Screenshot%202018-03-18%2011.51.53.png)
 
`iex> h`:
 
![](https://dl.dropbox.com/s/t8ifqzq3jowh4gp/Screenshot%202018-03-18%2011.53.59.png)
 
`iex> h hist`:
 
![](https://dl.dropbox.com/s/rw17kek517mrzte/Screenshot%202018-03-18%2011.52.58.png)


