### PR TITLE
Pass a function StringIO.open to allow the device to be closed automatically

### DIFF
--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -49,16 +49,12 @@ defmodule StringIO do
   @spec open(binary, keyword, (pid -> res)) :: {:ok, res} when res: var
   def open(string, options, function)
       when is_binary(string) and is_list(options) and is_function(function, 1) do
-    case GenServer.start_link(__MODULE__, {string, options}, []) do
-      {:ok, pid} ->
-        try do
-          {:ok, function.(pid)}
-        after
-          {:ok, {_input, _output}} = close(pid)
-        end
+    {:ok, pid} = GenServer.start_link(__MODULE__, {string, options}, [])
 
-      error ->
-        error
+    try do
+      {:ok, function.(pid)}
+    after
+      {:ok, {_input, _output}} = close(pid)
     end
   end
 

--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -23,7 +23,58 @@ defmodule StringIO do
 
   If the `:capture_prompt` option is set to `true`,
   prompts (specified as arguments to `IO.get*` functions)
-  are captured.
+  are captured in the output.
+
+  The device will be created and sent to the function given.
+  When the function returns, the device will be closed. The final
+  result will be a tuple with `:ok` and the result of the function.
+
+  ## Examples
+      iex> {:ok, _contents} = StringIO.open("foo", [], fn(pid) ->
+      ...>     input = IO.gets(pid, ">")
+      ...>     IO.write(pid, "The input was \#{input}")
+      ...>     StringIO.contents(pid)
+      ...>   end)
+      {:ok, {"", "The input was foo"}}
+
+      iex> {:ok, _contents} = StringIO.open("foo", [capture_prompt: true], fn(pid) ->
+      ...>     input = IO.gets(pid, ">")
+      ...>     IO.write(pid, "The input was \#{input}")
+      ...>     StringIO.contents(pid)
+      ...>   end)
+      {:ok, {"", ">The input was foo"}}
+  """
+  @spec open(binary, keyword, (pid -> res)) :: {:ok, res} when res: var
+  def open(string, options, function)
+      when is_binary(string) and is_list(options) and is_function(function, 1) do
+    with {:ok, pid} <- GenServer.start_link(__MODULE__, {string, options}, []) do
+      try do
+        {:ok, function.(pid)}
+      after
+        {:ok, {_input, _output}} = close(pid)
+      end
+    else
+      error -> error
+    end
+  end
+
+  @doc """
+  Creates an IO device.
+
+  `string` will be the initial input of the newly created
+  device.
+
+  `options_or_function` can be a keyword list of options or
+  a function.
+
+  If options are provided, the result will be `{:ok, pid}`, returning the
+  IO device created. The option `:capture_prompt`, when set to `true`, causes
+  prompts (which are specified as arguments to `IO.get*` functions) to be
+  included in the device's output.
+
+  If a function is provided, the device will be created and sent to the
+  function. When the function returns, the device will be closed. The final
+  result will be a tuple with `:ok` and the result of the function.
 
   ## Examples
 
@@ -39,10 +90,24 @@ defmodule StringIO do
       iex> StringIO.contents(pid)
       {"", ">"}
 
+      iex> {:ok, _contents} = StringIO.open("foo", fn(pid) ->
+      ...>     input = IO.gets(pid, ">")
+      ...>     IO.write(pid, "The input was \#{input}")
+      ...>     StringIO.contents(pid)
+      ...>   end)
+      {:ok, {"", "The input was foo"}}
   """
   @spec open(binary, keyword) :: {:ok, pid}
-  def open(string, options \\ []) when is_binary(string) do
-    GenServer.start_link(__MODULE__, {string, options}, [])
+  @spec open(binary, (pid -> res)) :: {:ok, res} when res: var
+  def open(path, options_or_function \\ [])
+
+  def open(string, options_or_function) when is_binary(string) and is_list(options_or_function) do
+    GenServer.start_link(__MODULE__, {string, options_or_function}, [])
+  end
+
+  def open(string, options_or_function)
+      when is_binary(string) and is_function(options_or_function, 1) do
+    open(string, [], options_or_function)
   end
 
   @doc """

--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -15,7 +15,7 @@ defmodule StringIO do
 
   use GenServer
 
-  @doc """
+  @doc ~S"""
   Creates an IO device.
 
   `string` will be the initial input of the newly created
@@ -31,17 +31,17 @@ defmodule StringIO do
 
   ## Examples
 
-    iex> {:ok, _contents} = StringIO.open("foo", [], fn(pid) ->
-    ...>    input = IO.gets(pid, ">")
-    ...>    IO.write(pid, "The input was \#{input}")
-    ...>    StringIO.contents(pid)
+    iex> StringIO.open("foo", [], fn(pid) ->
+    ...>   input = IO.gets(pid, ">")
+    ...>   IO.write(pid, "The input was #{input}")
+    ...>   StringIO.contents(pid)
     ...> end)
     {:ok, {"", "The input was foo"}}
 
-    iex> {:ok, _contents} = StringIO.open("foo", [capture_prompt: true], fn(pid) ->
-    ...>    input = IO.gets(pid, ">")
-    ...>    IO.write(pid, "The input was \#{input}")
-    ...>    StringIO.contents(pid)
+    iex> StringIO.open("foo", [capture_prompt: true], fn(pid) ->
+    ...>   input = IO.gets(pid, ">")
+    ...>   IO.write(pid, "The input was #{input}")
+    ...>   StringIO.contents(pid)
     ...> end)
     {:ok, {"", ">The input was foo"}}
 
@@ -58,7 +58,7 @@ defmodule StringIO do
     end
   end
 
-  @doc """
+  @doc ~S"""
   Creates an IO device.
 
   `string` will be the initial input of the newly created
@@ -90,11 +90,11 @@ defmodule StringIO do
       iex> StringIO.contents(pid)
       {"", ">"}
 
-      iex> {:ok, _contents} = StringIO.open("foo", fn(pid) ->
-      ...>     input = IO.gets(pid, ">")
-      ...>     IO.write(pid, "The input was \#{input}")
-      ...>     StringIO.contents(pid)
-      ...>   end)
+      iex> StringIO.open("foo", fn(pid) ->
+      ...>   input = IO.gets(pid, ">")
+      ...>   IO.write(pid, "The input was #{input}")
+      ...>   StringIO.contents(pid)
+      ...> end)
       {:ok, {"", "The input was foo"}}
 
   """

--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -30,31 +30,35 @@ defmodule StringIO do
   result will be a tuple with `:ok` and the result of the function.
 
   ## Examples
-      iex> {:ok, _contents} = StringIO.open("foo", [], fn(pid) ->
-      ...>     input = IO.gets(pid, ">")
-      ...>     IO.write(pid, "The input was \#{input}")
-      ...>     StringIO.contents(pid)
-      ...>   end)
-      {:ok, {"", "The input was foo"}}
 
-      iex> {:ok, _contents} = StringIO.open("foo", [capture_prompt: true], fn(pid) ->
-      ...>     input = IO.gets(pid, ">")
-      ...>     IO.write(pid, "The input was \#{input}")
-      ...>     StringIO.contents(pid)
-      ...>   end)
-      {:ok, {"", ">The input was foo"}}
+    iex> {:ok, _contents} = StringIO.open("foo", [], fn(pid) ->
+    ...>    input = IO.gets(pid, ">")
+    ...>    IO.write(pid, "The input was \#{input}")
+    ...>    StringIO.contents(pid)
+    ...> end)
+    {:ok, {"", "The input was foo"}}
+
+    iex> {:ok, _contents} = StringIO.open("foo", [capture_prompt: true], fn(pid) ->
+    ...>    input = IO.gets(pid, ">")
+    ...>    IO.write(pid, "The input was \#{input}")
+    ...>    StringIO.contents(pid)
+    ...> end)
+    {:ok, {"", ">The input was foo"}}
+
   """
   @spec open(binary, keyword, (pid -> res)) :: {:ok, res} when res: var
   def open(string, options, function)
       when is_binary(string) and is_list(options) and is_function(function, 1) do
-    with {:ok, pid} <- GenServer.start_link(__MODULE__, {string, options}, []) do
-      try do
-        {:ok, function.(pid)}
-      after
-        {:ok, {_input, _output}} = close(pid)
-      end
-    else
-      error -> error
+    case GenServer.start_link(__MODULE__, {string, options}, []) do
+      {:ok, pid} ->
+        try do
+          {:ok, function.(pid)}
+        after
+          {:ok, {_input, _output}} = close(pid)
+        end
+
+      error ->
+        error
     end
   end
 
@@ -96,6 +100,7 @@ defmodule StringIO do
       ...>     StringIO.contents(pid)
       ...>   end)
       {:ok, {"", "The input was foo"}}
+
   """
   @spec open(binary, keyword) :: {:ok, pid}
   @spec open(binary, (pid -> res)) :: {:ok, res} when res: var


### PR DESCRIPTION
Similar to the way you can pass a function to `File.open` this change allows you to pass a function to `StringIO.open`.  The function will receive the `StringIO` device as a parameter and when the function completes the device will be closed automatically.  The function may be passed in lieu of options to `StringIO.open/2` and a new `StringIO.open/3` function is available should you wish to pass both options and a function.

Examples are included in doc tests.

Please offer feedback or suggestions.  Reviewers should pay particular attention to `@spec` declarations as they are an area of weakness for me.