### PR TITLE
Doc improvement to Regex functions with option return: :index

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -261,7 +261,8 @@ defmodule Regex do
 
   ## Options
 
-    * `:return`  - sets to `:index` to return indexes. Defaults to `:binary`.
+    * `:return`  - set to `:index` to return byte index and match length.
+      Defaults to `:binary`.
     * `:capture` - what to capture in the result. Check the moduledoc for `Regex`
       to see the possible capture values.
 
@@ -292,9 +293,12 @@ defmodule Regex do
   end
 
   @doc """
-  Returns the given captures as a map or `nil` if no captures are
-  found. The option `:return` can be set to `:index` to get indexes
-  back.
+  Returns the given captures as a map or `nil` if no captures are found.
+
+  ## Options
+
+  * `:return`  - set to `:index` to return byte index and match length.
+    Defaults to `:binary`.
 
   ## Examples
 
@@ -376,7 +380,8 @@ defmodule Regex do
 
   ## Options
 
-    * `:return`  - sets to `:index` to return indexes. Defaults to `:binary`.
+    * `:return`  - set to `:index` to return byte index and match length.
+      Defaults to `:binary`.
     * `:capture` - what to capture in the result. Check the moduledoc for `Regex`
       to see the possible capture values.
 
@@ -393,6 +398,9 @@ defmodule Regex do
 
       iex> Regex.scan(~r/\p{Sc}/u, "$, £, and €")
       [["$"], ["£"], ["€"]]
+
+      iex> Regex.scan(~r/=+/, "=ü†ƒ8===", return: :index)
+      [[{0, 1}], [{9, 3}]]
 
   """
   @spec scan(t, String.t(), [term]) :: [[String.t()]]


### PR DESCRIPTION
The docs for using `Regex.scan/3` with `return: :index` are terse. They don't reveal that the index is the byte index, not unicode codepoint index. There is also no example of its use in this function. There is an example in `Regex.run`, but it doesn't show the behaviour for multibyte characters.

I added an example to `Regex.scan/3` that would have some multibyte characters. It's not very elegant. If five examples are one too many, I'd argue for dropping one of the others. I don't think every option needs to be exemplified, but this one changes the return type, so I think it pulls its weight.