### PR TITLE
Optimize tokenizer for commas

### DIFF
--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -329,7 +329,7 @@ tokenize([T1, T2, T3 | Rest], Line, Column, Scope, Tokens) when ?arrow_op3(T1, T
 % ## Containers + punctuation tokens
 tokenize([$, | Rest], Line, Column, Scope, Tokens) ->
   Token = {',', {Line, Column, 0}},
-  handle_terminator(Rest, Line, Column + 1, Scope, Token, Tokens);
+  tokenize(Rest, Line, Column + 1, Scope, [Token | Tokens]);
 
 tokenize([$<, $< | Rest], Line, Column, Scope, Tokens) ->
   Token = {'<<', {Line, Column, nil}},


### PR DESCRIPTION
Small optimization skipping the `handle_terminator` function for commas since they don't require terminators.

I'm not sure if this makes sense, feel free to close it if doesn't.