### PR TITLE
Fix small math error in error_logger config option

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -172,8 +172,8 @@ defmodule Logger do
       entries. The threshold will be checked once again after 10% of threshold
       messages are processed, to avoid messages from being constantly dropped.
       For example, if the threshold is 500 (the default) and the inbox has
-      600 messages, 250 messages will dropped, bringing the inbox down to
-      350 (0.75 * threshold) entries and 50 (0.1 * threshold) messages will
+      600 messages, 225 messages will dropped, bringing the inbox down to
+      375 (0.75 * threshold) entries and 50 (0.1 * threshold) messages will
       be processed before the threshold is checked once again.
 
   For example, to configure `Logger` to redirect all


### PR DESCRIPTION
75% of 500 should be 225 instead of 250 🙂 