### PR TITLE
Add Function module for introspecting functions.

### DIFF
--- a/lib/elixir/lib/function.ex
+++ b/lib/elixir/lib/function.ex
@@ -26,17 +26,11 @@ defmodule Function do
 
   ## Examples
 
-    iex> Function.capture(String, :length, 1)
-    &String.length/1
-
-  Useful when you want to capture a function when having variables.
-
-    iex> {module, function_name, arity} = {String, :length, 1}
-    iex> Function.capture(module, function_name, arity)
-    &String.length/1
+      iex> Function.capture(String, :length, 1)
+      &String.length/1
 
   """
-  @spec capture(module, atom, integer) :: (... -> any)
+  @spec capture(module, atom, integer) :: fun
   def capture(module, function_name, arity)
       when is_atom(module) and is_atom(function_name) and is_integer(arity) and arity in 0..255 do
     :erlang.make_fun(module, function_name, arity)
@@ -46,37 +40,42 @@ defmodule Function do
   Returns a keyword list with information about a function.
 
   The `{key, value}`s will include the following:
-  - `:type` - `:local` (for anonymous functions) or `:external` (for
+  
+    * `:type` - `:local` (for anonymous functions) or `:external` (for
   named functions)
-    - `:module` - an atom - the module where the function is defined when
+    * `:module` - an atom - the module where the function is defined when
     anonymous or the module which the function refers to when it's a named one.
-    - `:arity` - the number of arguments the function is to be called with
-    - `:name` - the name of the functions
-    - `:env` - a list of the environment or free variables. For named
-    functions, the returned list is always empty.
+    * `:arity` - the number of arguments the function is to be called with
+    * `:name` - the name of the functions
+    * `:env` - a list of the environment or free variables. For named
+      functions, the returned list is always empty.
 
   When it is an anonymous function it will also return info about:
-  - `:pid` - process identifier of the process that originally created
+  
+    * `:pid` - process identifier of the process that originally created
   the funciton
-    - `:index` - an integer - is an index into the module function table.
-    - `:new_index` - an integer - is an index into the module function table.
-    - `:new_uniq` - a binary-  it's a unique value for this function. It is
+    * `:index` - an integer - is an index into the module function table.
+    * `:new_index` - an integer - is an index into the module function table.
+    * `:new_uniq` - a binary-  it's a unique value for this function. It is
     calculated from the compiled code for the entire module.
-    - `:uniq` - an integer, a unique value for this function. As from Erlang/OTP
+    * `:uniq` - an integer, a unique value for this function. As from Erlang/OTP
     R15, this integer is calculated from the compiled code for the entire
     module. Before Erlang/OTP R15, this integer was based on only the body
     of the function.
 
+  **Note**: this function must be used only for debugging purposes.
 
   ## Examples
-    iex> fun = fn x -> x end
-    iex> info = Function.info(fun)
-    iex> info |> Keyword.get(:arity)
-    1
-    iex> info |> Keyword.get(:type)
-    :local
+
+      iex> fun = fn x -> x end
+      iex> info = Function.info(fun)
+      iex> Keyword.get(info, :arity)
+      1
+      iex> Keyword.get(info, :type)
+      :local
+
   """
-  @spec info((... -> any)) :: [{information, value}]
+  @spec info(fun) :: [{information, value}]
   def info(fun) when is_function(fun), do: :erlang.fun_info(fun)
 
   @doc """
@@ -91,19 +90,19 @@ defmodule Function do
   For a named function, the value of any of these items is always the
   atom `:undefined`.
 
-  For more information on each of the value returned - check the docs for
+  For more information on each of the value returned. Check the docs for
   `Function.info/1`.
 
   ## Examples
 
-    iex> f = fn x -> x end
-    iex> Function.info(f, :arity)
-    {:arity, 1}
-    iex> Function.info(f, :type)
-    {:type, :local}
+      iex> f = fn x -> x end
+      iex> Function.info(f, :arity)
+      {:arity, 1}
+      iex> Function.info(f, :type)
+      {:type, :local}
 
   """
-  @spec info((... -> any)) :: {information, value}
+  @spec info(fun) :: {information, value}
   def info(fun, item) when is_function(fun) and is_atom(item) do
     :erlang.fun_info(fun, item)
   end

--- a/lib/elixir/lib/function.ex
+++ b/lib/elixir/lib/function.ex
@@ -33,6 +33,7 @@ defmodule Function do
       &String.length/1
 
   """
+  @since "1.7.0"
   @spec capture(module, atom, integer) :: fun
   def capture(module, function_name, arity) do
     :erlang.make_fun(module, function_name, arity)
@@ -76,6 +77,7 @@ defmodule Function do
       :local
 
   """
+  @since "1.7.0"
   @spec info(fun) :: [{information, value}]
   def info(fun), do: :erlang.fun_info(fun)
 
@@ -105,6 +107,7 @@ defmodule Function do
       {:type, :local}
 
   """
+  @since "1.7.0"
   @spec info(fun) :: {information, value}
   def info(fun, item), do: :erlang.fun_info(fun, item)
 end

--- a/lib/elixir/lib/function.ex
+++ b/lib/elixir/lib/function.ex
@@ -1,0 +1,90 @@
+defmodule Function do
+  @moduledoc """
+  A set of funtions for working with functions.
+
+  We can have two types of captures functions - external and local -
+  external functions are our normal functions residing in modules while
+  local are the anonymous functions defined with `fn` or the capture
+  operator `&`.
+  """
+
+  @doc """
+  Captures a function by a given module, function name and arity.
+
+  Useful when you want to capture a function when having variables.
+
+  ## Examples
+
+    iex> Function.capture(String, :length, 1)
+    &String.length/1
+  """
+  @type information ::
+          :type
+          | :module
+          | :arity
+          | :name
+          | :env
+          | :pid
+          | :index
+          | :new_index
+          | :new_uniq
+          | :uniq
+  @type value :: any
+
+  @spec capture(atom, atom, integer) :: (... -> any)
+  def capture(mod, fun, arity) when is_atom(mod) and is_atom(fun) and is_integer(arity) do
+    :erlang.make_fun(mod, fun, arity)
+  end
+
+  @doc """
+  Returns a keyword list with information about a function.
+
+  The {key,value}s will include the following:
+    - :type - :local(for anonymous functions) or :external(for named functions)
+    - :module - an atom - the module where the function is defined when anonymous
+    or the module which the function refers to when it's a named one.
+    - :arity - the number of arguments the function is to be called with
+    - :name - the name of the functions
+    - :env - a list of the environment or free variables. For named functions, the returned list is always empty.
+
+  When it is an anonymous function it will also return info about:
+    - :pid - process identifier of the process that originally created the fun
+    - :index - an integer - is an index into the module fun table.
+    - :new_index - an integer - is an index into the module fun table.
+    - :new_uniq - a binary-  it's a unique value for this fun. It is calculated from the compiled code for the entire module.
+    - :uniq - an integer, a unique value for this fun. As from Erlang/OTP R15, this integer is calculated from the compiled code for the entire module. Before Erlang/OTP R15, this integer was based on only the body of the fun.
+
+
+  ## Examples
+    iex> fun = fn x -> x end
+    iex> info = Function.info(fun)
+    iex> info |> Keyword.get(:arity)
+    1
+    iex> info |> Keyword.get(:type)
+    :local
+  """
+  @spec info((... -> any)) :: [{information, value}]
+  def info(fun) when is_function(fun), do: :erlang.fun_info(fun)
+
+  @doc """
+  Returns a tuple of information about the function in the form {:info, information}.
+
+  For any function, the information asked for can be any of the atoms :module, :name, :arity, :env, or :type.
+
+  For anonymous functions fun, there is also information about any of the atoms :index, :new_index, :new_uniq, :uniq, and :pid.
+  For a named function, the value of any of these items is always the atom :undefined.
+
+  For more information on each of the value returned - check the docs for Function.info/1.
+
+  ## Examples
+
+    iex> f = fn x -> x end
+    iex> Function.info(f, :arity)
+    {:arity, 1}
+
+  """
+  @spec info((... -> any)) :: {information, value}
+  def info(fun, item) when is_function(fun) and is_atom(item) do
+    :erlang.fun_info(fun, item)
+  end
+end

--- a/lib/elixir/lib/function.ex
+++ b/lib/elixir/lib/function.ex
@@ -4,55 +4,68 @@ defmodule Function do
 
   We can have two types of captures functions - external and local -
   external functions are our normal functions residing in modules while
-  local are the anonymous functions defined with `fn` or the capture
-  operator `&`.
+  local are the anonymous functions defined with `fn/1` or the capture
+  operator `&/1`.
   """
 
-  @doc """
-  Captures a function by a given module, function name and arity.
+  @type information ::
+          :arity
+          | :env
+          | :index
+          | :module
+          | :name
+          | :new_index
+          | :new_uniq
+          | :pid
+          | :type
+          | :uniq
+  @type value :: any
 
-  Useful when you want to capture a function when having variables.
+  @doc """
+  Captures a function by a given `module`, `function_name` and `arity`.
 
   ## Examples
 
     iex> Function.capture(String, :length, 1)
     &String.length/1
-  """
-  @type information ::
-          :type
-          | :module
-          | :arity
-          | :name
-          | :env
-          | :pid
-          | :index
-          | :new_index
-          | :new_uniq
-          | :uniq
-  @type value :: any
 
-  @spec capture(atom, atom, integer) :: (... -> any)
-  def capture(mod, fun, arity) when is_atom(mod) and is_atom(fun) and is_integer(arity) do
-    :erlang.make_fun(mod, fun, arity)
+  Useful when you want to capture a function when having variables.
+
+    iex> {module, function_name, arity} = {String, :length, 1}
+    iex> Function.capture(module, function_name, arity)
+    &String.length/1
+
+  """
+  @spec capture(module, atom, integer) :: (... -> any)
+  def capture(module, function_name, arity)
+      when is_atom(module) and is_atom(function_name) and is_integer(arity) and arity in 0..255 do
+    :erlang.make_fun(module, function_name, arity)
   end
 
   @doc """
   Returns a keyword list with information about a function.
 
-  The {key,value}s will include the following:
-    - :type - :local(for anonymous functions) or :external(for named functions)
-    - :module - an atom - the module where the function is defined when anonymous
-    or the module which the function refers to when it's a named one.
-    - :arity - the number of arguments the function is to be called with
-    - :name - the name of the functions
-    - :env - a list of the environment or free variables. For named functions, the returned list is always empty.
+  The `{key, value}`s will include the following:
+  - `:type` - `:local` (for anonymous functions) or `:external` (for
+  named functions)
+    - `:module` - an atom - the module where the function is defined when
+    anonymous or the module which the function refers to when it's a named one.
+    - `:arity` - the number of arguments the function is to be called with
+    - `:name` - the name of the functions
+    - `:env` - a list of the environment or free variables. For named
+    functions, the returned list is always empty.
 
   When it is an anonymous function it will also return info about:
-    - :pid - process identifier of the process that originally created the fun
-    - :index - an integer - is an index into the module fun table.
-    - :new_index - an integer - is an index into the module fun table.
-    - :new_uniq - a binary-  it's a unique value for this fun. It is calculated from the compiled code for the entire module.
-    - :uniq - an integer, a unique value for this fun. As from Erlang/OTP R15, this integer is calculated from the compiled code for the entire module. Before Erlang/OTP R15, this integer was based on only the body of the fun.
+  - `:pid` - process identifier of the process that originally created
+  the funciton
+    - `:index` - an integer - is an index into the module function table.
+    - `:new_index` - an integer - is an index into the module function table.
+    - `:new_uniq` - a binary-  it's a unique value for this function. It is
+    calculated from the compiled code for the entire module.
+    - `:uniq` - an integer, a unique value for this function. As from Erlang/OTP
+    R15, this integer is calculated from the compiled code for the entire
+    module. Before Erlang/OTP R15, this integer was based on only the body
+    of the function.
 
 
   ## Examples
@@ -67,20 +80,27 @@ defmodule Function do
   def info(fun) when is_function(fun), do: :erlang.fun_info(fun)
 
   @doc """
-  Returns a tuple of information about the function in the form {:info, information}.
+  Returns a tuple of information about the function in the form
+  `{:info, information}`.
 
-  For any function, the information asked for can be any of the atoms :module, :name, :arity, :env, or :type.
+  For any function, the information asked for can be any of the atoms
+  `:module`, `:name`, `:arity`, `:env`, or `:type`.
 
-  For anonymous functions fun, there is also information about any of the atoms :index, :new_index, :new_uniq, :uniq, and :pid.
-  For a named function, the value of any of these items is always the atom :undefined.
+  For anonymous functions, there is also information about any of the
+  atoms `:index`, `:new_index`, `:new_uniq`, `:uniq`, and `:pid`.
+  For a named function, the value of any of these items is always the
+  atom `:undefined`.
 
-  For more information on each of the value returned - check the docs for Function.info/1.
+  For more information on each of the value returned - check the docs for
+  `Function.info/1`.
 
   ## Examples
 
     iex> f = fn x -> x end
     iex> Function.info(f, :arity)
     {:arity, 1}
+    iex> Function.info(f, :type)
+    {:type, :local}
 
   """
   @spec info((... -> any)) :: {information, value}

--- a/lib/elixir/lib/function.ex
+++ b/lib/elixir/lib/function.ex
@@ -25,6 +25,8 @@ defmodule Function do
   @doc """
   Captures a function by a given `module`, `function_name` and `arity`.
 
+  Inlined by the compiler.
+
   ## Examples
 
       iex> Function.capture(String, :length, 1)
@@ -32,8 +34,7 @@ defmodule Function do
 
   """
   @spec capture(module, atom, integer) :: fun
-  def capture(module, function_name, arity)
-      when is_atom(module) and is_atom(function_name) and is_integer(arity) and arity in 0..255 do
+  def capture(module, function_name, arity) do
     :erlang.make_fun(module, function_name, arity)
   end
 
@@ -41,7 +42,7 @@ defmodule Function do
   Returns a keyword list with information about a function.
 
   The `{key, value}`s will include the following:
-  
+
     * `:type` - `:local` (for anonymous functions) or `:external` (for
   named functions)
     * `:module` - an atom - the module where the function is defined when
@@ -52,7 +53,6 @@ defmodule Function do
       functions, the returned list is always empty.
 
   When it is an anonymous function it will also return info about:
-  
     * `:pid` - process identifier of the process that originally created
   the funciton
     * `:index` - an integer - is an index into the module function table.
@@ -63,6 +63,8 @@ defmodule Function do
       calculated from the compiled code for the entire module.
 
   **Note**: this function must be used only for debugging purposes.
+
+  Inlined by the compiler.
 
   ## Examples
 
@@ -75,7 +77,7 @@ defmodule Function do
 
   """
   @spec info(fun) :: [{information, value}]
-  def info(fun) when is_function(fun), do: :erlang.fun_info(fun)
+  def info(fun), do: :erlang.fun_info(fun)
 
   @doc """
   Returns a tuple of information about the function in the form
@@ -92,6 +94,8 @@ defmodule Function do
   For more information on each of the value returned. Check the docs for
   `Function.info/1`.
 
+  Inlined by the compiler.
+
   ## Examples
 
       iex> f = fn x -> x end
@@ -102,7 +106,5 @@ defmodule Function do
 
   """
   @spec info(fun) :: {information, value}
-  def info(fun, item) when is_function(fun) and is_atom(item) do
-    :erlang.fun_info(fun, item)
-  end
+  def info(fun, item), do: :erlang.fun_info(fun, item)
 end

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -169,7 +169,7 @@ compile_undef(Module, Fun, Arity, Stack) ->
 %% Handle reserved modules and duplicates.
 
 check_module_availability(Line, File, Module) ->
-  Reserved = ['Elixir.Any', 'Elixir.BitString', 'Elixir.Function', 'Elixir.PID',
+  Reserved = ['Elixir.Any', 'Elixir.BitString', 'Elixir.PID',
               'Elixir.Reference', 'Elixir.Elixir', 'Elixir'],
 
   case lists:member(Module, Reserved) of

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -20,6 +20,7 @@
 -define(string_chars, 'Elixir.String.Chars').
 -define(system, 'Elixir.System').
 -define(tuple, 'Elixir.Tuple').
+-define(function, 'Elixir.Function').
 
 %% Inline
 
@@ -165,6 +166,10 @@ inline(?system, unique_integer, 1) -> {erlang, unique_integer};
 
 inline(?tuple, to_list, 1) -> {erlang, tuple_to_list};
 inline(?tuple, append, 2) -> {erlang, append_element};
+
+inline(?function, capture, 3) -> {erlang, make_fun};
+inline(?function, info, 1) -> {erlang, fun_info};
+inline(?function, info, 2) -> {erlang, fun_info};
 
 inline(_, _, _) -> false.
 

--- a/lib/elixir/test/elixir/function_test.exs
+++ b/lib/elixir/test/elixir/function_test.exs
@@ -1,0 +1,80 @@
+Code.require_file("test_helper.exs", __DIR__)
+
+defmodule DummyFunction do
+  def function_with_arity_0 do
+    true
+  end
+
+  def zero?(0), do: true
+  def zero?(_), do: false
+end
+
+defmodule FunctionTest do
+  use ExUnit.Case, async: true
+
+  doctest Function
+  import Function
+
+  @information_keys_for_named [:type, :module, :arity, :name, :env]
+  @information_keys_for_anonymous @information_keys_for_named ++
+                                    [:pid, :index, :new_index, :new_uniq, :uniq]
+
+  describe "capture/3" do
+    test "that it can capture module functions with arity 0" do
+      f = capture(DummyFunction, :function_with_arity_0, 0)
+
+      assert is_function(f)
+    end
+
+    test "that it can capture module functions with any arity" do
+      f = capture(DummyFunction, :zero?, 1)
+
+      assert is_function(f)
+      assert f.(0)
+    end
+  end
+
+  describe "info/1" do
+    test "it returns info for named captured functions" do
+      f = &DummyFunction.zero?/1
+      expected = [module: DummyFunction, name: :zero?, arity: 1, env: [], type: :external]
+
+      result = info(f)
+
+      assert expected == result
+    end
+
+    test "it returns info for anonymous functions" do
+      f = fn x -> x end
+
+      result = info(f)
+
+      result
+      |> Enum.each(fn {key, _value} ->
+        assert key in @information_keys_for_anonymous
+      end)
+    end
+  end
+
+  describe "info/2" do
+    test "it returns info for every possible information key for named functions" do
+      f = &DummyFunction.zero?/1
+
+      @information_keys_for_named
+      |> Enum.each(fn x ->
+        assert {^x, _} = info(f, x)
+      end)
+    end
+
+    test "it returns info for every possible information key for anonymous functions" do
+      f = &DummyFunction.zero?/1
+
+      @information_keys_for_anonymous
+      |> Enum.each(fn x ->
+        assert {^x, _} = info(f, x)
+      end)
+
+      assert {:arity, 1} = info(f, :arity)
+    end
+  end
+end

--- a/lib/elixir/test/elixir/function_test.exs
+++ b/lib/elixir/test/elixir/function_test.exs
@@ -49,7 +49,7 @@ defmodule FunctionTest do
 
       result = info(f)
 
-      for {key, _value} <- result  do
+      for {key, _value} <- result do
         assert key in @information_keys_for_anonymous
       end
     end

--- a/lib/elixir/test/elixir/function_test.exs
+++ b/lib/elixir/test/elixir/function_test.exs
@@ -20,13 +20,13 @@ defmodule FunctionTest do
                                     [:pid, :index, :new_index, :new_uniq, :uniq]
 
   describe "capture/3" do
-    test "that it can capture module functions with arity 0" do
+    test "captures module functions with arity 0" do
       f = capture(DummyFunction, :function_with_arity_0, 0)
 
       assert is_function(f)
     end
 
-    test "that it can capture module functions with any arity" do
+    test "captures module functions with any arity" do
       f = capture(DummyFunction, :zero?, 1)
 
       assert is_function(f)
@@ -35,7 +35,7 @@ defmodule FunctionTest do
   end
 
   describe "info/1" do
-    test "it returns info for named captured functions" do
+    test "returns info for named captured functions" do
       f = &DummyFunction.zero?/1
       expected = [module: DummyFunction, name: :zero?, arity: 1, env: [], type: :external]
 
@@ -44,35 +44,32 @@ defmodule FunctionTest do
       assert expected == result
     end
 
-    test "it returns info for anonymous functions" do
+    test "returns info for anonymous functions" do
       f = fn x -> x end
 
       result = info(f)
 
-      result
-      |> Enum.each(fn {key, _value} ->
+      for {key, _value} <- result  do
         assert key in @information_keys_for_anonymous
-      end)
+      end
     end
   end
 
   describe "info/2" do
-    test "it returns info for every possible information key for named functions" do
+    test "returns info for every possible information key for named functions" do
       f = &DummyFunction.zero?/1
 
-      @information_keys_for_named
-      |> Enum.each(fn x ->
+      for x <- @information_keys_for_named do
         assert {^x, _} = info(f, x)
-      end)
+      end
     end
 
-    test "it returns info for every possible information key for anonymous functions" do
+    test "returns info for every possible information key for anonymous functions" do
       f = &DummyFunction.zero?/1
 
-      @information_keys_for_anonymous
-      |> Enum.each(fn x ->
+      for x <- @information_keys_for_anonymous do
         assert {^x, _} = info(f, x)
-      end)
+      end
 
       assert {:arity, 1} = info(f, :arity)
     end

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -172,8 +172,8 @@ defmodule Logger do
       entries. The threshold will be checked once again after 10% of threshold
       messages are processed, to avoid messages from being constantly dropped.
       For example, if the threshold is 500 (the default) and the inbox has
-      600 messages, 250 messages will dropped, bringing the inbox down to
-      350 (0.75 * threshold) entries and 50 (0.1 * threshold) messages will
+      600 messages, 225 messages will dropped, bringing the inbox down to
+      375 (0.75 * threshold) entries and 50 (0.1 * threshold) messages will
       be processed before the threshold is checked once again.
 
   For example, to configure `Logger` to redirect all


### PR DESCRIPTION
Reason to add it is capturing functions(#7500) when passing in module name,
function name and arity using variables, because the capture operator
can't handle them.

Done by delegating to `:erlang.make_fun(mod, f, arity)`, also exposed
some erlang functions for getting information for a function and removing
:"Elixir.Function" from the reserved modules.

Added docs for capture/3, info1/ and info/2.
Also added some tests.