### PR TITLE
Add example .formatter.exs for lazy folks

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -17,6 +17,14 @@ defmodule Mix.Tasks.Format do
   formatter configuration. Evaluating this file should return a keyword list
   with any of the options supported by `Code.format_string!/2`.
 
+  ### Example `.formatter.exs`
+
+  ```
+  [
+    inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  ]
+  ```
+
   The `.formatter.exs` also supports other options:
 
     * `:inputs` (a list of paths and patterns) - specifies the default inputs

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -14,18 +14,16 @@ defmodule Mix.Tasks.Format do
   ## Formatting options
 
   The formatter will read a `.formatter.exs` in the current directory for
-  formatter configuration. Evaluating this file should return a keyword list
-  with any of the options supported by `Code.format_string!/2`.
+  formatter configuration. Evaluating this file should return a keyword list.
 
-  ### Example `.formatter.exs`
+  Here is an example `.formatter.exs` that works as a starting point:
 
-  ```
-  [
-    inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
-  ]
-  ```
+      [
+        inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+      ]
 
-  The `.formatter.exs` also supports other options:
+  Besides the options listed in `Code.format_string!/2`, the `.formatter.exs`
+  supports the following options:
 
     * `:inputs` (a list of paths and patterns) - specifies the default inputs
       to be used by this task. For example, `["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]`.


### PR DESCRIPTION
It wasn't immediately obvious to me how the `.formatter.exs` file would look. I probably shouldn't have read the documentation more closely, but I really wanted/expected to see an example. The example I added is from https://hashrocket.com/blog/posts/format-your-elixir-code-now, which seems like a reasonable default.

What do you think?