### PR TITLE
Warn users that uses length to check if list is not empty on guards

### DIFF
--- a/lib/elixir/src/elixir_clauses.erl
+++ b/lib/elixir/src/elixir_clauses.erl
@@ -52,7 +52,15 @@ warn_zero_length_guard({{'.', _, [erlang, '==']}, Meta,
   Message = io_lib:format("\"length(~ts) == 0\" is discouraged since it has to "
                           "traverse the whole list to check if it is empty or not. "
                           "Prefer to pattern match on an empty list or use "
-                          "\"~ts == []\" as a guard", [ArgString, ArgString]),
+                          "\"~ts == []\" as a guard.", [ArgString, ArgString]),
+  elixir_errors:warn(?line(Meta), ?key(E, file), Message);
+warn_zero_length_guard({{'.', _, [erlang, '>']}, Meta,
+                        [{{'.', _, [erlang, length]}, _, [Arg]}, 0]}, E) ->
+  ArgString = 'Elixir.Macro':to_string(Arg),
+  Message = io_lib:format("\"length(~ts) > 0\" is discouraged since it has to "
+                          "traverse the whole list to check if it is empty or not. "
+                          "Prefer to pattern match on a non-empty list, such as [_ | _], "
+                          "or use \"~ts != []\" as a guard.", [ArgString, ArgString]),
   elixir_errors:warn(?line(Meta), ?key(E, file), Message);
 warn_zero_length_guard({Op, _, [L, R]}, E) when Op == 'or'; Op == 'and' ->
   warn_zero_length_guard(L, E),

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -551,20 +551,51 @@ defmodule Kernel.WarningTest do
   end
 
   test "length(list) == 0 in guard" do
-    assert capture_err(fn ->
-             Code.eval_string("""
-             defmodule Sample do
-               def list_case do
-                 v = []
-                 case v do
-                   _ when length(v) == 0 -> :ok
-                   _ -> :fail
-                 end
-               end
-             end
-             """)
-           end) =~
+    error_message =
+      capture_err(fn ->
+        Code.eval_string("""
+        defmodule Sample do
+          def list_case do
+            v = []
+            case v do
+              _ when length(v) == 0 -> :ok
+              _ -> :fail
+            end
+          end
+        end
+        """)
+      end)
+
+    assert error_message =~
              "\"length(v) == 0\" is discouraged since it has to traverse the whole list to check if it is empty or not"
+
+    assert error_message =~
+             "Prefer to pattern match on an empty list or use \"v == []\" as a guard"
+  after
+    purge(Sample)
+  end
+
+  test "length(list) > 0 in guard" do
+    error_message =
+      capture_err(fn ->
+        Code.eval_string("""
+        defmodule Sample do
+          def list_case do
+            v = []
+            case v do
+              _ when length(v) > 0 -> :ok
+              _ -> :fail
+            end
+          end
+        end
+        """)
+      end)
+
+    assert error_message =~
+             "\"length(v) > 0\" is discouraged since it has to traverse the whole list to check if it is empty or not"
+
+    assert error_message =~
+             "Prefer to pattern match on a non-empty list, such as [_ | _], or use \"v != []\" as a guard"
   after
     purge(Sample)
   end


### PR DESCRIPTION
Some Elixir users check if the list is not
empty by using the length function. It's not the optimal solution since it has to transverse the whole
list. Now we're warning the users and suggesting them
to use `!= []`.

Apply https://github.com/elixir-lang/elixir/issues/7513 enhancement.