### PR TITLE
Add public types for some Supervisor functions

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -943,7 +943,7 @@ defmodule Supervisor do
     * `modules` - as specified by the child specification
 
   """
-  @spec which_children(supervisor) :: [ child_tuple ]
+  @spec which_children(supervisor) :: [child_tuple]
   def which_children(supervisor) do
     call(supervisor, :which_children)
   end

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -539,6 +539,22 @@ defmodule Supervisor do
           optional(:modules) => [module()] | :dynamic
         }
 
+  @typedoc "Return values used by the `which_children/1` function"
+  @type child_tuple :: {
+          term() | :undefined,
+          child | :restarting,
+          :worker | :supervisor,
+          :supervisor.modules()
+        }
+
+  @typedoc "Return values of the `count_children/1` function"
+  @type child_count :: %{
+          specs: non_neg_integer,
+          active: non_neg_integer,
+          supervisors: non_neg_integer,
+          workers: non_neg_integer
+        }
+
   @doc """
   Starts a supervisor with the given children.
 
@@ -927,9 +943,7 @@ defmodule Supervisor do
     * `modules` - as specified by the child specification
 
   """
-  @spec which_children(supervisor) :: [
-          {term() | :undefined, child | :restarting, :worker | :supervisor, :supervisor.modules()}
-        ]
+  @spec which_children(supervisor) :: [ child_tuple ]
   def which_children(supervisor) do
     call(supervisor, :which_children)
   end
@@ -951,12 +965,7 @@ defmodule Supervisor do
       are still alive
 
   """
-  @spec count_children(supervisor) :: %{
-          specs: non_neg_integer,
-          active: non_neg_integer,
-          supervisors: non_neg_integer,
-          workers: non_neg_integer
-        }
+  @spec count_children(supervisor) :: child_count
   def count_children(supervisor) do
     call(supervisor, :count_children) |> :maps.from_list()
   end


### PR DESCRIPTION
Hi there! I'm not sure on the guidelines for submitting PRs, so please let me know of any standards I may need to adhere to in future!

The aim of this PR is to simply expose the return types of `Supervisor.which_children/1` and `Supervisor.count_children/1`. In the case you have a function which relays either of these in your own code, you need to copy the specification (and they're kinda noisy) - I find that it's more convenient to expose the types in the Supervisor module.

That's it really, let me know any thoughts :)