### PR TITLE
Documents the :name option of start_link/2 [ci skip]

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -78,7 +78,7 @@ defmodule GenServer do
 
   See the `Supervisor` docs for more information.
 
-  ## Name Registration
+  ## Name registration
 
   Both `start_link/3` and `start/3` support the `GenServer` to register
   a name on start via the `:name` option. Registered names are also

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -413,8 +413,8 @@ defmodule Supervisor do
   The second argument is a keyword list of options:
 
     * `:strategy` - the restart strategy option. It can be either
-      `:one_for_one`, `:rest_for_one` or `:one_for_all`. See the
-      "Strategies" section.
+      `:one_for_one`, `:rest_for_one` or `:one_for_all`. Required.
+      See the "Strategies" section.
 
     * `:max_restarts` - the maximum number of restarts allowed in
       a time frame. Defaults to `3`.
@@ -422,8 +422,9 @@ defmodule Supervisor do
     * `:max_seconds` - the time frame in which `:max_restarts` applies.
       Defaults to `5`.
 
-  The `:strategy` option is required and by default a maximum of 3 restarts
-  is allowed within 5 seconds.
+    * `:name` - a name to register the supervisor process. Supported values are
+      explained in the "Name registration" section of the documentation of
+      `GenServer`. Optional.
 
   ### Strategies
 


### PR DESCRIPTION
Title says it all :).

Since I was on it, the patch also deletes the paragraph that repeates the default values of `:max_restarts` and `:max_seconds`, and revises the capitalization of the section title "Name registration" to match the existing convention.