### PR TITLE
Fix column in :elixir_tokenizer for sigils with modifiers

### DIFF
--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -184,7 +184,8 @@ tokenize([$~, S, H, H, H | T] = Original, Line, Column, Scope, Tokens) when ?is_
     {ok, NewLine, NewColumn, Parts, Rest} ->
       {Final, Modifiers} = collect_modifiers(Rest, []),
       Token = {sigil, {Line, Column, nil}, S, Parts, Modifiers, <<H, H, H>>},
-      tokenize(Final, NewLine, NewColumn, Scope, [Token | Tokens]);
+      NewColumn2 = NewColumn + length(Modifiers),
+      tokenize(Final, NewLine, NewColumn2, Scope, [Token | Tokens]);
     {error, Reason} ->
       {error, Reason, Original, Tokens}
   end;
@@ -194,7 +195,8 @@ tokenize([$~, S, H | T] = Original, Line, Column, Scope, Tokens) when ?is_sigil(
     {NewLine, NewColumn, Parts, Rest} ->
       {Final, Modifiers} = collect_modifiers(Rest, []),
       Token = {sigil, {Line, Column, nil}, S, Parts, Modifiers, <<H>>},
-      tokenize(Final, NewLine, NewColumn, Scope, [Token | Tokens]);
+      NewColumn2 = NewColumn + length(Modifiers),
+      tokenize(Final, NewLine, NewColumn2, Scope, [Token | Tokens]);
     {error, Reason} ->
       Sigil = [$~, S, H],
       interpolation_error(Reason, Original, Tokens, " (for sigil ~ts starting at line ~B)", [Sigil, Line])

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -208,6 +208,12 @@ sigil_terminator_test() ->
   [{sigil, {1, 1, nil}, 114, [<<"foo">>], [], <<"/">>}] = tokenize("~r/foo/"),
   [{sigil, {1, 1, nil}, 114, [<<"foo">>], [], <<"[">>}] = tokenize("~r[foo]"),
   [{sigil, {1, 1, nil}, 114, [<<"foo">>], [], <<"\"">>}] = tokenize("~r\"foo\""),
+  [{sigil, {1, 1, nil}, 114, [<<"foo">>], [], <<"/">>},
+   {comp_op, {1, 9, nil}, '=='},
+   {identifier, {1, 12, nil}, bar}] = tokenize("~r/foo/ == bar"),
+  [{sigil, {1, 1, nil}, 114, [<<"foo">>], "iu", <<"/">>},
+   {comp_op, {1, 11, nil}, '=='},
+   {identifier, {1, 14, nil}, bar}] = tokenize("~r/foo/iu == bar"),
   [{sigil, {1, 1, nil}, 83, [<<"sigil heredoc\n">>], [], <<"\"\"\"">>}] = tokenize("~S\"\"\"\nsigil heredoc\n\"\"\""),
   [{sigil, {1, 1, nil}, 83, [<<"sigil heredoc\n">>], [], <<"'''">>}] = tokenize("~S'''\nsigil heredoc\n'''").
 


### PR DESCRIPTION
This PR fixes cases where `:elixir_tokenizer` does not account for sigil modifiers when determining the column for the next token.

### Current behavior

The tokens for

```elixir
~r/foo/ == bar
```

and

```elixir
~r/foo/iu == bar
```

are identical:

```elixir
iex(1)> :elixir_tokenizer.tokenize('~r/foo/ == bar', 1, [])
{:ok,
 [
   {:sigil, {1, 1, nil}, 114, ["foo"], [], "/"},
   {:comp_op, {1, 9, nil}, :==},
   {:identifier, {1, 12, nil}, :bar}
 ]}
iex(2)> :elixir_tokenizer.tokenize('~r/foo/iu == bar', 1, [])
{:ok,
 [
   {:sigil, {1, 1, nil}, 114, ["foo"], 'iu', "/"},
   {:comp_op, {1, 9, nil}, :==},
   {:identifier, {1, 12, nil}, :bar}
 ]}
```

### Expected behavior

IMHO the column information should have changed after we added the two modifiers:

```elixir
iex(1)> :elixir_tokenizer.tokenize('~r/foo/iu == bar', 1, [])
{:ok,
 [
   {:sigil, {1, 1, nil}, 114, ["foo"], 'iu', "/"},
   {:comp_op, {1, 11, nil}, :==},
   #              ^^  +2 since the sigil token is 2 chars "longer"
   {:identifier, {1, 14, nil}, :bar}
   #                 ^^  same here
 ]}
```
