### PR TITLE
Add missing discard_threshold option to Logger configuration

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -512,7 +512,8 @@ defmodule Logger do
     :sync_threshold,
     :truncate,
     :level,
-    :utc_log
+    :utc_log,
+    :discard_threshold
   ]
   @spec configure(keyword) :: :ok
   def configure(options) do

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -363,4 +363,21 @@ defmodule LoggerTest do
     Logger.App.stop()
     Application.start(:logger)
   end
+
+  test "configure/1 sets options" do
+    Logger.configure(sync_threshold: 10)
+    Logger.configure(truncate: 4048)
+    Logger.configure(utc_log: true)
+    Logger.configure(discard_threshold: 10_000)
+    logger_data = Logger.Config.__data__()
+    assert Map.get(logger_data, :sync_threshold) == 10
+    assert Map.get(logger_data, :truncate) == 4048
+    assert Map.get(logger_data, :utc_log) == true
+    assert Map.get(logger_data, :discard_threshold) == 10_000
+  after
+    Logger.configure(sync_threshold: 20)
+    Logger.configure(sync_threshold: 8096)
+    Logger.configure(utc_log: false)
+    Logger.configure(discard_threshold: 500)
+  end
 end


### PR DESCRIPTION
Fix for #7532 

Add missing option `:discard_threshold` and unit test to test the correct implementation of `configure` for valid options