### PR TITLE
Add missing translator_inspect_opts option to Logger configuration

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -513,7 +513,8 @@ defmodule Logger do
     :truncate,
     :level,
     :utc_log,
-    :discard_threshold
+    :discard_threshold,
+    :translator_inspect_opts
   ]
   @spec configure(keyword) :: :ok
   def configure(options) do

--- a/lib/logger/lib/logger/config.ex
+++ b/lib/logger/lib/logger/config.ex
@@ -219,6 +219,7 @@ defmodule Logger.Config do
     utc_log = Application.get_env(:logger, :utc_log)
     truncate = Application.get_env(:logger, :truncate)
     translators = Application.get_env(:logger, :translators)
+    translator_inspect_opts = Application.get_env(:logger, :translator_inspect_opts)
 
     sync_threshold = Application.get_env(:logger, :sync_threshold)
     async_threshold = trunc(sync_threshold * 0.75)
@@ -235,7 +236,8 @@ defmodule Logger.Config do
       sync_threshold: sync_threshold,
       keep_threshold: keep_threshold,
       discard_threshold: discard_threshold,
-      translators: translators
+      translators: translators,
+      translator_inspect_opts: translator_inspect_opts
     }
 
     case compute_mode(state) do

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -369,15 +369,18 @@ defmodule LoggerTest do
     Logger.configure(truncate: 4048)
     Logger.configure(utc_log: true)
     Logger.configure(discard_threshold: 10_000)
+    Logger.configure(translator_inspect_opts: [limit: 3])
     logger_data = Logger.Config.__data__()
     assert Map.get(logger_data, :sync_threshold) == 10
     assert Map.get(logger_data, :truncate) == 4048
     assert Map.get(logger_data, :utc_log) == true
     assert Map.get(logger_data, :discard_threshold) == 10_000
+    assert Map.get(logger_data, :translator_inspect_opts) == [limit: 3]
   after
     Logger.configure(sync_threshold: 20)
     Logger.configure(sync_threshold: 8096)
     Logger.configure(utc_log: false)
     Logger.configure(discard_threshold: 500)
+    Logger.configure(translator_inspect_opts: [])
   end
 end


### PR DESCRIPTION
Addtional fix for #7532 

After my fix for the option `:discard_threshold` in PR #7533 another missing option `:translator_inspect_opts` was reported. This option is [documented](https://hexdocs.pm/logger/Logger.html#module-runtime-configuration) but not part of the `Logger.Config.__data__()` ouput and not configurable with `Logger.configure/1`.

This PR adds `:translator_inspect_opts` to the output and makes it configurable with `Logger.configure/1`.