### PR TITLE
Fix mix compile error when there is a wrong project path.

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.ex
+++ b/lib/mix/lib/mix/tasks/compile.ex
@@ -91,10 +91,16 @@ defmodule Mix.Tasks.Compile do
     load_erl_config(opts)
 
     {res, diagnostics} =
-      Mix.Task.run("compile.all", args)
-      |> List.wrap()
-      |> Enum.map(&Mix.Task.Compiler.normalize(&1, :all))
-      |> Enum.reduce(&merge_diagnostics/2)
+      case Mix.Task.run("compile.all", args) do
+        [] ->
+          {:error, "path_not_found"}
+
+        projects ->
+          projects
+          |> List.wrap()
+          |> Enum.map(&Mix.Task.Compiler.normalize(&1, :all))
+          |> Enum.reduce(&merge_diagnostics/2)
+      end
 
     if res == :error and "--return-errors" not in args do
       exit({:shutdown, 1})

--- a/lib/mix/lib/mix/tasks/compile.ex
+++ b/lib/mix/lib/mix/tasks/compile.ex
@@ -90,19 +90,11 @@ defmodule Mix.Tasks.Compile do
 
     load_erl_config(opts)
 
-    diagnostics =
+    {res, diagnostics} =
       Mix.Task.run("compile.all", args)
       |> List.wrap()
       |> Enum.map(&Mix.Task.Compiler.normalize(&1, :all))
-
-    {res, diagnostics} =
-      case diagnostics do
-        [] ->
-          Enum.reduce(diagnostics, {:ok, []}, &merge_diagnostics/2)
-
-        _ ->
-          Enum.reduce(diagnostics, &merge_diagnostics/2)
-      end
+      |> Enum.reduce({:noop, []}, &merge_diagnostics/2)
 
     if res == :error and "--return-errors" not in args do
       exit({:shutdown, 1})

--- a/lib/mix/test/mix/tasks/compile_test.exs
+++ b/lib/mix/test/mix/tasks/compile_test.exs
@@ -153,7 +153,6 @@ defmodule Mix.Tasks.CompileTest do
   test "skip protocol consolidation when --no-protocol-consolidation" do
     in_fixture "no_mixfile", fn ->
       File.rm("_build/dev/lib/sample/.mix/compile.protocols")
-
       assert Mix.Task.run("compile", ["--no-protocol-consolidation"]) == {:ok, []}
       assert File.regular?("_build/dev/lib/sample/ebin/Elixir.A.beam")
       refute File.regular?("_build/dev/lib/sample/consolidated/Elixir.Enumerable.beam")

--- a/lib/mix/test/mix/tasks/compile_test.exs
+++ b/lib/mix/test/mix/tasks/compile_test.exs
@@ -174,7 +174,7 @@ defmodule Mix.Tasks.CompileTest do
     Mix.Project.push(WrongPath)
 
     ExUnit.CaptureIO.capture_io(fn ->
-      assert {:noop, []} = Mix.Task.run("compile", ["--force", "--return-errors"])
+      assert Mix.Task.run("compile", ["--no-protocol-consolidation"]) == {:noop, []}
     end)
   end
 
@@ -182,7 +182,7 @@ defmodule Mix.Tasks.CompileTest do
     Mix.Project.push(EmptyPath)
 
     ExUnit.CaptureIO.capture_io(fn ->
-      assert {:noop, []} = Mix.Task.run("compile", ["--force", "--return-errors"])
+      assert Mix.Task.run("compile", ["--no-protocol-consolidation"]) == {:noop, []}
     end)
   end
 end

--- a/lib/mix/test/mix/tasks/compile_test.exs
+++ b/lib/mix/test/mix/tasks/compile_test.exs
@@ -15,12 +15,6 @@ defmodule Mix.Tasks.CompileTest do
     end
   end
 
-  defmodule EmptyPath do
-    def project do
-      [app: :apps_path_bug, apps_path: ""]
-    end
-  end
-
   setup do
     Mix.Project.push(MixTest.Case.Sample)
     :ok
@@ -172,14 +166,6 @@ defmodule Mix.Tasks.CompileTest do
 
   test "compiles a project with wrong path" do
     Mix.Project.push(WrongPath)
-
-    ExUnit.CaptureIO.capture_io(fn ->
-      assert Mix.Task.run("compile", ["--no-protocol-consolidation"]) == {:noop, []}
-    end)
-  end
-
-  test "compiles a project with empty path" do
-    Mix.Project.push(EmptyPath)
 
     ExUnit.CaptureIO.capture_io(fn ->
       assert Mix.Task.run("compile", ["--no-protocol-consolidation"]) == {:noop, []}

--- a/lib/mix/test/mix/tasks/compile_test.exs
+++ b/lib/mix/test/mix/tasks/compile_test.exs
@@ -26,7 +26,7 @@ defmodule Mix.Tasks.CompileTest do
     :ok
   end
 
-  test "compile --list with mixfile" do
+  test "compiles --list with mixfile" do
     Mix.Task.run("compile", ["--list"])
 
     msg = "\nEnabled compilers: yecc, leex, erlang, elixir, xref, app, protocols"
@@ -35,18 +35,18 @@ defmodule Mix.Tasks.CompileTest do
     assert_received {:mix_shell, :info, ["mix compile.elixir    # " <> _]}
   end
 
-  test "compile --list with custom mixfile" do
+  test "compiles --list with custom mixfile" do
     Mix.Project.push(CustomCompilers)
     Mix.Task.run("compile", ["--list"])
     assert_received {:mix_shell, :info, ["\nEnabled compilers: elixir, app, custom, protocols"]}
   end
 
-  test "compile does not require all compilers available on manifest" do
+  test "compiles does not require all compilers available on manifest" do
     Mix.Project.push(CustomCompilers)
     assert Mix.Tasks.Compile.manifests() |> Enum.map(&Path.basename/1) == ["compile.elixir"]
   end
 
-  test "compile a project with mixfile" do
+  test "compiles a project with mixfile" do
     in_fixture "no_mixfile", fn ->
       assert Mix.Task.run("compile", ["--verbose"]) == {:ok, []}
       assert File.regular?("_build/dev/lib/sample/ebin/Elixir.A.beam")
@@ -74,7 +74,7 @@ defmodule Mix.Tasks.CompileTest do
     end
   end
 
-  test "compile a project with multiple compilers and a syntax error in an Erlang file" do
+  test "compiles a project with multiple compilers and a syntax error in an Erlang file" do
     in_fixture "no_mixfile", fn ->
       import ExUnit.CaptureIO
 
@@ -170,7 +170,7 @@ defmodule Mix.Tasks.CompileTest do
     Application.delete_env(:erl_config_app, :value)
   end
 
-  test "compile a project with wrong path" do
+  test "compiles a project with wrong path" do
     Mix.Project.push(WrongPath)
 
     ExUnit.CaptureIO.capture_io(fn ->
@@ -178,7 +178,7 @@ defmodule Mix.Tasks.CompileTest do
     end)
   end
 
-  test "compile a project with empty path" do
+  test "compiles a project with empty path" do
     Mix.Project.push(EmptyPath)
 
     ExUnit.CaptureIO.capture_io(fn ->

--- a/lib/mix/test/mix/tasks/compile_test.exs
+++ b/lib/mix/test/mix/tasks/compile_test.exs
@@ -11,7 +11,13 @@ defmodule Mix.Tasks.CompileTest do
 
   defmodule WrongPath do
     def project do
-      [app: :apps_path_bug, apps_path: "this_path_does_not_exist_or_is_empty"]
+      [app: :apps_path_bug, apps_path: "this_path_does_not_exist"]
+    end
+  end
+
+  defmodule EmptyPath do
+    def project do
+      [app: :apps_path_bug, apps_path: ""]
     end
   end
 
@@ -147,6 +153,7 @@ defmodule Mix.Tasks.CompileTest do
   test "skip protocol consolidation when --no-protocol-consolidation" do
     in_fixture "no_mixfile", fn ->
       File.rm("_build/dev/lib/sample/.mix/compile.protocols")
+
       assert Mix.Task.run("compile", ["--no-protocol-consolidation"]) == {:ok, []}
       assert File.regular?("_build/dev/lib/sample/ebin/Elixir.A.beam")
       refute File.regular?("_build/dev/lib/sample/consolidated/Elixir.Enumerable.beam")
@@ -168,7 +175,15 @@ defmodule Mix.Tasks.CompileTest do
     Mix.Project.push(WrongPath)
 
     ExUnit.CaptureIO.capture_io(fn ->
-      assert {:ok, []} = Mix.Task.run("compile", ["--force", "--return-errors"])
+      assert {:noop, []} = Mix.Task.run("compile", ["--force", "--return-errors"])
+    end)
+  end
+
+  test "compile a project with empty path" do
+    Mix.Project.push(EmptyPath)
+
+    ExUnit.CaptureIO.capture_io(fn ->
+      assert {:noop, []} = Mix.Task.run("compile", ["--force", "--return-errors"])
     end)
   end
 end

--- a/lib/mix/test/mix/tasks/compile_test.exs
+++ b/lib/mix/test/mix/tasks/compile_test.exs
@@ -168,7 +168,7 @@ defmodule Mix.Tasks.CompileTest do
     Mix.Project.push(WrongPath)
 
     ExUnit.CaptureIO.capture_io(fn ->
-      assert {:error, "path_not_found"} = Mix.Task.run("compile", ["--force", "--return-errors"])
+      assert {:ok, []} = Mix.Task.run("compile", ["--force", "--return-errors"])
     end)
   end
 end

--- a/lib/mix/test/mix/tasks/compile_test.exs
+++ b/lib/mix/test/mix/tasks/compile_test.exs
@@ -9,6 +9,12 @@ defmodule Mix.Tasks.CompileTest do
     end
   end
 
+  defmodule WrongPath do
+    def project do
+      [app: :apps_path_bug, apps_path: "this_path_does_not_exist_or_is_empty"]
+    end
+  end
+
   setup do
     Mix.Project.push(MixTest.Case.Sample)
     :ok
@@ -156,5 +162,13 @@ defmodule Mix.Tasks.CompileTest do
     end
   after
     Application.delete_env(:erl_config_app, :value)
+  end
+
+  test "compile a project with wrong path" do
+    Mix.Project.push(WrongPath)
+
+    ExUnit.CaptureIO.capture_io(fn ->
+      assert {:error, "path_not_found"} = Mix.Task.run("compile", ["--force", "--return-errors"])
+    end)
   end
 end


### PR DESCRIPTION
This PR aims to solve the issue #7531, the problem is Mix.Task.run("compile.all", args) returns a empty list when project path is wrong. 

```
def project do
    [
      app: :apps_path_bug,
      apps_path: "this_path_does_not_exist_or_is_empty"
    ]
 end
```