### PR TITLE
Add missing translator_inspect_opts option to Logger configuration

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -513,7 +513,8 @@ defmodule Logger do
     :truncate,
     :level,
     :utc_log,
-    :discard_threshold
+    :discard_threshold,
+    :translator_inspect_opts
   ]
   @spec configure(keyword) :: :ok
   def configure(options) do

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -369,11 +369,13 @@ defmodule LoggerTest do
     Logger.configure(truncate: 4048)
     Logger.configure(utc_log: true)
     Logger.configure(discard_threshold: 10_000)
+    Logger.configure(translator_inspect_opts: [limit: 3])
 
     assert Application.get_env(:logger, :sync_threshold) == 10
     assert Application.get_env(:logger, :utc_log) == true
     assert Application.get_env(:logger, :truncate) == 4048
     assert Application.get_env(:logger, :discard_threshold) == 10_000
+    assert Application.get_env(:logger, :translator_inspect_opts) == [limit: 3]
 
     logger_data = Logger.Config.__data__()
     assert logger_data.truncate == 4048
@@ -383,5 +385,6 @@ defmodule LoggerTest do
     Logger.configure(truncate: 8096)
     Logger.configure(utc_log: false)
     Logger.configure(discard_threshold: 500)
+    Logger.configure(translator_inspect_opts: [])
   end
 end


### PR DESCRIPTION
Addtional fix for #7532. Discussed in #7536. 

After my fix for the option :discard_threshold in PR #7533 another missing option `:translator_inspect_opts` was reported. This option is documented but not configurable with `Logger.configure/1`.

This PR adds makes it configurable with `Logger.configure/1`.