### PR TITLE
Use function module

### DIFF
--- a/lib/elixir/lib/agent/server.ex
+++ b/lib/elixir/lib/agent/server.ex
@@ -45,8 +45,8 @@ defmodule Agent.Server do
   end
 
   defp get_initial_call(fun) when is_function(fun, 0) do
-    {:module, module} = :erlang.fun_info(fun, :module)
-    {:name, name} = :erlang.fun_info(fun, :name)
+    {:module, module} = Function.info(fun, :module)
+    {:name, name} = Function.info(fun, :name)
     {module, name, 0}
   end
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -812,7 +812,7 @@ defmodule BadArityError do
     fun = exception.function
     args = exception.args
     insp = Enum.map_join(args, ", ", &inspect/1)
-    {:arity, arity} = :erlang.fun_info(fun, :arity)
+    {:arity, arity} = Function.info(fun, :arity)
     "#{inspect(fun)} with arity #{arity} called with #{count(length(args), insp)}"
   end
 

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -303,7 +303,7 @@ end
 
 defimpl Inspect, for: Function do
   def inspect(function, _opts) do
-    fun_info = :erlang.fun_info(function)
+    fun_info = Function.info(function)
     mod = fun_info[:module]
     name = fun_info[:name]
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -49,6 +49,8 @@ defmodule Kernel do
 
     * `Atom` - literal constants with a name (`true`, `false`, and `nil` are atoms)
     * `Float` - numbers with floating point precision
+    * `Function` - a reference to code chunk, created with the `Kernel.SpecialForms.fn/2`
+      special form
     * `Integer` - whole numbers (not fractions)
     * `List` - collections of a variable number of elements (linked lists)
     * `Map` - collections of key-value pairs
@@ -56,13 +58,11 @@ defmodule Kernel do
     * `Port` - mechanisms to interact with the external world
     * `Tuple` - collections of a fixed number of elements
 
-  There are three data types without an accompanying module:
+  There are two data types without an accompanying module:
 
     * Bitstrings - a sequence of bits, created with `Kernel.SpecialForms.<<>>/1`.
       When the number of bits is divisible by 8, they are called binaries and can
       be manipulated with Erlang's `:binary` module
-    * Function - a reference to code chunk, created with the `Kernel.SpecialForms.fn/2`
-      special form
     * Reference - a unique value in the runtime system, created with `make_ref/0`
 
   ### Data types

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -442,8 +442,8 @@ defmodule Macro do
   defp find_invalid(bin) when is_binary(bin), do: nil
 
   defp find_invalid(fun) when is_function(fun) do
-    unless :erlang.fun_info(fun, :env) == {:env, []} and
-             :erlang.fun_info(fun, :type) == {:type, :external} do
+    unless Function.info(fun, :env) == {:env, []} and
+             Function.info(fun, :type) == {:type, :external} do
       {:error, fun}
     end
   end

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -599,7 +599,7 @@ defmodule Regex do
 
   def replace(regex, string, replacement, options)
       when is_binary(string) and is_function(replacement) and is_list(options) do
-    {:arity, arity} = :erlang.fun_info(replacement, :arity)
+    {:arity, arity} = Function.info(replacement, :arity)
     do_replace(regex, string, {replacement, arity}, options)
   end
 

--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -74,8 +74,8 @@ defmodule Task.Supervised do
   end
 
   defp get_initial_call({:erlang, :apply, [fun, []]}) when is_function(fun, 0) do
-    {:module, module} = :erlang.fun_info(fun, :module)
-    {:name, name} = :erlang.fun_info(fun, :name)
+    {:module, module} = Function.info(fun, :module)
+    {:name, name} = Function.info(fun, :name)
     {module, name, 0}
   end
 

--- a/lib/elixir/test/elixir/task/supervisor_test.exs
+++ b/lib/elixir/test/elixir/task/supervisor_test.exs
@@ -55,7 +55,7 @@ defmodule Task.SupervisorTest do
     receive do: (:ready -> :ok)
 
     # Assert the initial call
-    {:name, fun_name} = :erlang.fun_info(fun, :name)
+    {:name, fun_name} = Function.info(fun, :name)
     assert {__MODULE__, fun_name, 0} === :proc_lib.translate_initial_call(task.pid)
 
     # Run the task
@@ -109,7 +109,7 @@ defmodule Task.SupervisorTest do
     receive do: (:ready -> :ok)
 
     # Assert the initial call
-    {:name, fun_name} = :erlang.fun_info(fun, :name)
+    {:name, fun_name} = Function.info(fun, :name)
     assert {__MODULE__, fun_name, 0} === :proc_lib.translate_initial_call(task.pid)
 
     # Run the task
@@ -155,7 +155,7 @@ defmodule Task.SupervisorTest do
     refute pid in links
 
     receive do: (:ready -> :ok)
-    {:name, fun_name} = :erlang.fun_info(fun, :name)
+    {:name, fun_name} = Function.info(fun, :name)
     assert {__MODULE__, fun_name, 0} === :proc_lib.translate_initial_call(pid)
 
     send(pid, true)

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -75,7 +75,7 @@ defmodule TaskTest do
     receive do: (:ready -> :ok)
 
     # Assert the initial call
-    {:name, fun_name} = :erlang.fun_info(fun, :name)
+    {:name, fun_name} = Function.info(fun, :name)
     assert {__MODULE__, fun_name, 0} === :proc_lib.translate_initial_call(task.pid)
 
     # Run the task
@@ -114,7 +114,7 @@ defmodule TaskTest do
 
     receive do: (:ready -> :ok)
 
-    {:name, fun_name} = :erlang.fun_info(fun, :name)
+    {:name, fun_name} = Function.info(fun, :name)
     assert {__MODULE__, fun_name, 0} === :proc_lib.translate_initial_call(pid)
 
     send(pid, true)
@@ -145,7 +145,7 @@ defmodule TaskTest do
 
     receive do: (:ready -> :ok)
 
-    {:name, fun_name} = :erlang.fun_info(fun, :name)
+    {:name, fun_name} = Function.info(fun, :name)
     assert {__MODULE__, fun_name, 0} === :proc_lib.translate_initial_call(pid)
 
     send(pid, true)

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -249,7 +249,7 @@ end
 
 defimpl IEx.Info, for: Function do
   def info(fun) do
-    fun_info = :erlang.fun_info(fun)
+    fun_info = Function.info(fun)
 
     specific_info =
       if fun_info[:type] == :external and fun_info[:env] == [] do


### PR DESCRIPTION
After having `Function` module might as well make the internal code use it.

* change elixir code to use `Function.fun_info`
* point function type to this module now

Feel free to close this PR if you feel those changes are unnecessary!
Should I change the docs in kernel to reflect that the module is for normal functions too?
More forgotten stuff... :sweat_smile: