### PR TITLE
Configure Mix.Utils.read_path to use ipv6 with auto fallback to ipv4 

### DIFF
--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -574,6 +574,8 @@ defmodule Mix.Utils do
     # If a proxy environment variable was supplied add a proxy to httpc.
     http_options = [relaxed: true] ++ proxy_config(path)
 
+    :httpc.set_option(:ipfamily, :inet6fb4, :mix)
+
     case :httpc.request(:get, request, http_options, [body_format: :binary], :mix) do
       {:ok, {{_, status, _}, _, body}} when status in 200..299 ->
         {:ok, body}


### PR DESCRIPTION
Fix for #7522

Sets the option for `:httpc` to use `:inet6fb4` as `ipfamily` which first tries ipv6 and if that does not works falls back to ipv6.

Testing-Domain with IPv4 only: https://v4-wp123.webpack.hosteurope.de
Testing-Domain with IPv6 only: https://v6-wp123.webpack.hosteurope.de

Function: `Mix.Utils.read_path/1`

Result IPv4 before Fix: `{:remote, "httpc request failed with: {:bad_status_code, 403}"}`
Result IPv6 before Fix: `{:remote, "httpc request failed with: {:failed_connect, [{:to_address, {'v6-wp123.webpack.hosteurope.de', 80}}, {:inet, [:inet], :nxdomain}]}"}`

Result IPv4 after Fix: `{:remote, "httpc request failed with: {:bad_status_code, 403}"}`
Result IPv6 before Fix: `{:remote, "httpc request failed with: {:bad_status_code, 403}"}`
