### PR TITLE
Check if the left argument of the lists concatenation is a proper list

### DIFF
--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -559,8 +559,18 @@ defmodule Kernel.ExpansionTest do
       message = ~r"cannot invoke remote function :erlang.make_ref/0 inside match"
       assert_raise CompileError, message, fn -> expand(quote(do: make_ref() = :foo)) end
 
-      assert_raise CompileError, ~r"invalid argument for \+\+ operator", fn ->
+      message = ~r"invalid argument for \+\+ operator"
+
+      assert_raise CompileError, message, fn ->
         expand(quote(do: "a" ++ "b" = "ab"))
+      end
+
+      assert_raise CompileError, message, fn ->
+        expand(quote(do: [1 | 2] ++ [3] = [1, 2, 3]))
+      end
+
+      assert_raise CompileError, message, fn ->
+        expand(quote(do: [1] ++ 2 ++ [3] = [1, 2, 3]))
       end
     end
 


### PR DESCRIPTION
Fix illegal pattern error in Erlang:
```
iex(1)> [1 | 2] ++ [3] = [1, 2, 3]
** (ErlangError) Erlang error: {:illegal_pattern, {:op, 1, :++, {:cons, 0, {:integer, 0, 1}, {:integer, 0, 2}}, {:cons, 0, {:integer, 0, 3}, {nil, 0}}}}
iex(1)> [1] ++ 2 ++ [3] = [1,2]
** (ErlangError) Erlang error: {:illegal_pattern, {:op, 1, :++, {:cons, 0, {:integer, 0, 1}, {nil, 0}}, {:op, 1, :++, {:integer, 0, 2}, {:cons, 0, {:integer, 0, 3}, {nil, 0}}}}}
```