### PR TITLE
Whitelist keys included in resource files by compile.app

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -3,6 +3,23 @@ defmodule Mix.Tasks.Compile.App do
 
   @recursive true
 
+  # See http://erlang.org/doc/man/app.html.
+  @keys_whitelist [
+    :description,
+    :id,
+    :vsn,
+    :modules,
+    :maxP,
+    :maxT,
+    :registered,
+    :included_applications,
+    :applications,
+    :env,
+    :mod,
+    :start_phases,
+    :runtime_dependencies
+  ]
+
   @moduledoc """
   Writes an .app file.
 
@@ -214,6 +231,7 @@ defmodule Mix.Tasks.Compile.App do
     |> validate_properties!
     |> Keyword.put_new_lazy(:applications, fn -> apps_from_prod_non_optional_deps(properties) end)
     |> Keyword.update!(:applications, fn apps -> normalize_apps(apps, properties, config) end)
+    |> Keyword.take(@keys_whitelist)
   end
 
   defp validate_properties!(properties) do


### PR DESCRIPTION
Hey! Here's the followup.

I noticed `compile.app` includes `extra_applications` in resource files.

There is a trade-off here to consider. On one hand, `compile.app` currently generates what could be considered to be an invalid resource file technically (although it is loaded). Not clean (?). On the other hand, though, if Erlang/OTP adds a key in the future, you need a new Elixir release to support it.

I lean on being strict in what you emit, but if you lean more on the other side of the trade-off we can just forget about this patch 😄.

(I have included `maxP` in the whitelist to match the documented keys, so users can actually generate the key if they will. They can technically include it, so be transparent to that.)