### PR TITLE
Made clear Process.alive? is for local node only

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -20,13 +20,13 @@ defmodule Process do
   """
 
   @doc """
-  Tells whether the given process is alive.
+  Tells whether the given process is alive on the local node.
 
   If the process identified by `pid` is alive (that is, it's not exiting and has
   not exited yet) than this function returns `true`. Otherwise, it returns
   `false`.
 
-  `pid` must refer to a process running on the local node.
+  `pid` must refer to a process running on the local node or a `ArgumentError` is raised.
 
   Inlined by the compiler.
   """


### PR DESCRIPTION
At first i did not read the full documentation about this function and my app crashed when a second node was added. It was not clear for me that a `ArgumentError` could be raised with a remote pid as argument by just looking at spec and documentation. Thats why i updated this to help others.

A short example to what happens with a remote pid:

```elixir
iex(node1@julius-T470s)1> pid = Node.spawn(:"node2@julius-T470s", fn() -> Process.sleep(:infinity) end, [])
#PID<20668.415.0>
iex(node1@julius-T470s)2> Process.alive?(pid)
** (ArgumentError) argument error
    :erlang.is_process_alive(#PID<20668.415.0>)
iex(node1@julius-T470s)3> Process.alive?(self())
true
```