### PR TITLE
Supports log formatter customization for metadata

### DIFF
--- a/lib/logger/test/logger/formatter_test.exs
+++ b/lib/logger/test/logger/formatter_test.exs
@@ -24,12 +24,8 @@ defmodule Logger.FormatterTest do
   end
 
   test "compile/1 with str" do
-    assert compile("$level $time $date $metadata $message $node") ==
-             Enum.intersperse([:level, :time, :date, :metadata, :message, :node], " ")
-
-    assert_raise ArgumentError, "$bad is an invalid format pattern", fn ->
-      compile("$bad $good")
-    end
+    assert compile("$level $time $date $metadata $message $node $foo") ==
+             Enum.intersperse([:level, :time, :date, :metadata, :message, :node, :foo], " ")
   end
 
   test "compile/1 with {mod, fun}" do
@@ -43,6 +39,28 @@ defmodule Logger.FormatterTest do
   test "format with format string" do
     compiled = compile("[$level] $message")
     assert format(compiled, :error, "hello", nil, []) == ["[", "error", "] ", "hello"]
+
+    compiled = compile("[$level] $message $foo")
+
+    assert format(compiled, :error, "hello", nil, []) == [
+             "[",
+             "error",
+             "] ",
+             "hello",
+             " ",
+             "$foo"
+           ]
+
+    compiled = compile("[$level] $message $foo")
+
+    assert format(compiled, :error, "hello", nil, foo: "bar") == [
+             "[",
+             "error",
+             "] ",
+             "hello",
+             " ",
+             "bar"
+           ]
 
     compiled = compile("$node")
     assert format(compiled, :error, nil, nil, []) == [Atom.to_string(node())]


### PR DESCRIPTION
All log messages except those created by `Logger.bare_log/2` include
module, function, line, and file as attributes. These are very useful in
log messages. The problem with supporting them is that the data may not
be present. This forces the developer to write a custom logger or deal
with the metadata format `module=MyModyle function=my_fun/2`.

This format is hard to read since other places that we use this data it
is usually formatted as `MyModule.my_fun/2`.

In order to keep developers from having to write custom formatters for
basic output of values I thought that any parameter `$foo` could easily
pull from the metadata if it is present. This would keep from breaking
`Logger.bare_log/2` if the format included `$module` and keep it simple
to use.

In the case where the key does not exist in metadata it will be printed
as a string. So `$module` would be printed as `$module` if it isn't
found. That means if a developer wants a `$somthing` to show up in their
log messages that would also now work.

Amos King @adkron <amos@binarynoggin.com>