### PR TITLE
Allows path-based dependencies to share current env

### DIFF
--- a/lib/mix/lib/mix/scm/path.ex
+++ b/lib/mix/lib/mix/scm/path.ex
@@ -17,7 +17,14 @@ defmodule Mix.SCM.Path do
   def accepts_options(app, opts) do
     cond do
       raw = opts[:path] ->
-        Keyword.put(opts, :dest, Path.expand(raw))
+        case opts[:use_mix_env] do
+          true ->
+            Keyword.put(opts, :dest, Path.expand(raw))
+            |> Keyword.put_new(:env, Mix.env())
+
+          _ ->
+            Keyword.put(opts, :dest, Path.expand(raw))
+        end
 
       opts[:in_umbrella] ->
         path = "../#{app}"

--- a/lib/mix/lib/mix/tasks/deps.ex
+++ b/lib/mix/lib/mix/tasks/deps.ex
@@ -48,6 +48,10 @@ defmodule Mix.Tasks.Deps do
   the parent project whenever they change. While fetchable dependencies,
   like the ones using `:git`, are recompiled only when fetched/updated.
 
+  Umbrella dependencies always automatically recompile sharing the
+  current environment. By default path dependencies use `:prod` environment.
+  This can be overriden to share the current environment by setting `use_mix_env: true`
+
   The dependencies' versions are expected to be formatted according to
   Semantic Versioning and the requirements must be specified as defined
   in the `Version` module.
@@ -121,6 +125,8 @@ defmodule Mix.Tasks.Deps do
     * `:path`        - the path for the dependency
     * `:in_umbrella` - when `true`, sets a path dependency pointing to
       "../#{app}", sharing the same environment as the current application
+    * `:use_mix_env` - when `true`, shares the same environment as the
+      current application
 
   ### Hex options (`:hex`)
 


### PR DESCRIPTION
All dependencies compile using `:prod` environment with the exception of umbrella dependencies, which share the current environment. The `in_umbrella` option is simply setting a default path of `../` and setting `env` to the current environment. 

As noted in #4119, a default of anything but `:prod` for dependencies would be unexpected. However, in the case of umbrella applications, the opposite is true, and the current environment is passed to the dependency. It would be helpful to allow the same functionality to path dependencies that `in_umbrella: true` provides without forcing the user to have that dependency as a sibling folder. This PR exposes an option to pass the mix env to the dependency to provide parity with the functionality `in_umbrella` provides.

This could be changed to use an `if` but I wasn't sure about the feelings in core on reassigning like this.

```
cond do
  raw = opts[:path] ->
    Keyword.put(opts, :dest, Path.expand(raw))
        
    if opts[:use_mix_env], do:  Keyword.put_new(opts, :env, Mix.env())

  opts[:in_umbrella] ->
    path = "../#{app}"

    opts
    |> Keyword.put(:dest, Path.expand(path))
    |> Keyword.put_new(:path, path)
    |> Keyword.put_new(:env, Mix.env())

  true ->
    nil
end
```

Or extracting for both `in_umbrella` and `use_mix_env` to a private function and adding it in there. I'm open to whatever works best.

```
def accepts_options(app, opts) do
  cond do
    raw = opts[:path] ->
      Keyword.put(opts, :dest, Path.expand(raw))
      |> add_env()

    opts[:in_umbrella] ->
      path = "../#{app}"

      opts
      |> Keyword.put(:dest, Path.expand(path))
      |> Keyword.put_new(:path, path)
      |> add_env()

    true ->
      nil
  end
end

defp add_env(opts) do
  Keyword.put_new(opts, :env, Mix.env())
end
```
