### PR TITLE
Replace Mixfile with MixProject in docs

### DIFF
--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -330,9 +330,9 @@ defmodule Mix.Project do
   ## Examples
 
       Mix.Project.in_project(:my_app, "/path/to/my_app", fn module ->
-        "MixProject is: #{inspect module}"
+        "Mix project is: #{inspect module}"
       end)
-      #=> "MixProject is: MyApp.MixProject"
+      #=> "Mix project is: MyApp.MixProject"
 
   """
   @spec in_project(atom, Path.t(), keyword, (module -> result)) :: result when result: term

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -330,9 +330,9 @@ defmodule Mix.Project do
   ## Examples
 
       Mix.Project.in_project(:my_app, "/path/to/my_app", fn module ->
-        "Mixfile is: #{inspect module}"
+        "MixProject is: #{inspect module}"
       end)
-      #=> "Mixfile is: MyApp.MixProject"
+      #=> "MixProject is: MyApp.MixProject"
 
   """
   @spec in_project(atom, Path.t(), keyword, (module -> result)) :: result when result: term


### PR DESCRIPTION
`Mixfile` was replaced with `MixProject` in https://github.com/elixir-lang/elixir/commit/c6a0edcd32359eca284ff0166d19a6dc979ee954.