### PR TITLE
[WIP] Add diff to doctest

### DIFF
--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -322,7 +322,7 @@ defmodule ExUnit.DocTest do
 
         actual ->
           expr = "#{unquote(String.trim(expr))} === #{unquote(String.trim(expected))}"
-          error = [message: "Doctest failed", expr: expr, left: actual]
+          error = [message: "Doctest failed", expr: expr, left: actual, right: expected]
           reraise ExUnit.AssertionError, error, unquote(stack)
       end
     end
@@ -345,7 +345,7 @@ defmodule ExUnit.DocTest do
 
         actual ->
           expr = "inspect(#{unquote(String.trim(expr))}) === #{unquote(String.trim(expected))}"
-          error = [message: "Doctest failed", expr: expr, left: actual]
+          error = [message: "Doctest failed", expr: expr, left: actual, right: expected]
           reraise ExUnit.AssertionError, error, unquote(stack)
       end
     end

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -446,8 +446,9 @@ defmodule ExUnit.DocTestTest do
              2) doctest module ExUnit.DocTestTest.Invalid (2) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 Doctest failed
-                code: 1 + hd(List.flatten([1])) === 3
-                left: 2
+                code:  1 + hd(List.flatten([1])) === 3
+                left:  2
+                right: 3
                 stacktrace:
                   test/ex_unit/doc_test_test.exs:141: ExUnit.DocTestTest.Invalid (module)
            """
@@ -456,8 +457,9 @@ defmodule ExUnit.DocTestTest do
              3) doctest module ExUnit.DocTestTest.Invalid (3) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 Doctest failed
-                code: inspect(:oops) === "#MapSet<[]>"
-                left: ":oops"
+                code:  inspect(:oops) === "#MapSet<[]>"
+                left:  ":oops"
+                right: "#MapSet<[]>"
                 stacktrace:
                   test/ex_unit/doc_test_test.exs:144: ExUnit.DocTestTest.Invalid (module)
            """


### PR DESCRIPTION
This adds diff output to doctests, as [discussed on elixir-core](https://groups.google.com/forum/#!topic/elixir-lang-core/qGMW6lCYo5w). 

I haven't figured out a good way to add more tests for these changes. I have tested the changes manually, and they produce good output on complex data structures like Maps. Output is diffed just like normal in ExUnit tests. Are the existing (updated) tests sufficient, do you think?

I thought of adding a test to `lib/ex_unit/examples/difference.exs`, which exercises highlighting, but since doctests require creating a BEAM file, I wasn't sure this was the best approach. The current file is simple and understandable, and I didn't want to lose that quality.

I also thought to add a case to the doctests suite, but this would only test that left and right values are included, and the other tests already do that. I don't think we can test the actual highlighting here.

Thoughts?