### PR TITLE
Add informations about `Code.compile_string/2` insecurities

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -801,10 +801,10 @@ defmodule Code do
   given as second argument which will be used for reporting warnings
   and errors.
 
-  **Warning**: `string` can be any Elixir code and some code can be executed
-  with the same privileges as the Elixir compiler: this means that such code
+  **Warning**: `string` can be any Elixir code and code can be executed with
+  the same privileges as the Elixir compiler: this means that such code
   could compromise the machine (for example by executing system commands).
-  Don't use `oompile_string/2` with untrusted input (such as strings coming
+  Don't use `compile_string/2` with untrusted input (such as strings coming
   from the network).
   """
   @spec compile_string(List.Chars.t(), binary) :: [{module, binary}]

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -800,6 +800,12 @@ defmodule Code do
   and the second one is its bytecode (as a binary). A `file` can be
   given as second argument which will be used for reporting warnings
   and errors.
+
+  **Warning**: `string` can be any Elixir code and some code can be executed
+  with the same privileges as the Elixir compiler: this means that such code
+  could compromise the machine (for example by executing system commands).
+  Don't use `oompile_string/2` with untrusted input (such as strings coming
+  from the network).
   """
   @spec compile_string(List.Chars.t(), binary) :: [{module, binary}]
   def compile_string(string, file \\ "nofile") when is_binary(file) do

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -802,8 +802,8 @@ defmodule Code do
   and errors.
 
   **Warning**: `string` can be any Elixir code and code can be executed with
-  the same privileges as the Elixir compiler: this means that such code
-  could compromise the machine (for example by executing system commands).
+  the same privileges as the Erlang VM: this means that such code could
+  compromise the machine (for example by executing system commands).
   Don't use `compile_string/2` with untrusted input (such as strings coming
   from the network).
   """


### PR DESCRIPTION
Elixir can execute any valid code during compilation.  This can
compromise user machine.  Example of such code:

    defmodule Foo do
      @foo File.rm_rf(System.get_env("HOME"))
    end

Such code would remove whole `$HOME` of current user.

This PR introduces warning similar to the one used in
`Code.eval_string/3` that there is possibility for attacker to run code
via compilation (without evaluation).