### PR TITLE
clarify behavior of `:temporary` processes within supervisor strategies

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -212,7 +212,8 @@ defmodule Supervisor do
     * `:permanent` - the child process is always restarted.
 
     * `:temporary` - the child process is never restarted, regardless
-      of the supervision strategy.
+      of the supervision strategy: any termination (even abnormal) is
+      considered successful.
 
     * `:transient` - the child process is restarted only if it
       terminates abnormally, i.e., with an exit reason other than
@@ -446,6 +447,9 @@ defmodule Supervisor do
       the child processes, i.e., the child processes after the terminated
       one in start order, are terminated. Then the terminated child
       process and the rest of the child processes are restarted.
+      
+  In the above, process termination refers to unsuccessful termination, which
+  is determined by the `:restart` option.
 
   There is also a deprecated strategy called `:simple_one_for_one` which
   has been replaced by the `DynamicSupervisor`. The `:simple_one_for_one`


### PR DESCRIPTION
The documentation for the `:one_for_all` supervisor strategy indicates

> if a child process terminates, all other child processes are terminated

But this is not entirely true. Imagine a supervisor S with a `:one_for_all` strategy. S has 2 children: a `:permanent` process P, and a `:temporary` process T. Killing T will never cause P to get restarted event though that is what seems to be indicated by the documentation (T is a child of S, after all, so P should be terminated given it is an "other child" of the same supervisor).

Hopefully, this commit clarifies that `:temporary` processes are essentially ignored by supervisors with respect to restarting the temporary process or its siblings.