### PR TITLE
Fix typespec for DynamicSupervisor.on_start_child

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -162,6 +162,9 @@ defmodule DynamicSupervisor do
   @typedoc "Supported strategies"
   @type strategy :: :one_for_one
 
+  @typedoc "Return values of `start_child` functions"
+  @type on_start_child :: Supervisor.on_start_child() | :ignore | {:error, :max_children}
+
   defstruct [
     :args,
     :extra_arguments,
@@ -291,7 +294,7 @@ defmodule DynamicSupervisor do
   """
   @since "1.6.0"
   @spec start_child(Supervisor.supervisor(), :supervisor.child_spec() | {module, term} | module) ::
-          Supervisor.on_start_child()
+          on_start_child()
   def start_child(supervisor, {_, _, _, _, _, _} = child_spec) do
     validate_and_start_child(supervisor, child_spec)
   end


### PR DESCRIPTION
`DynamicSupervisor.start_child/2` is typespec'ed to return the same type as `Supervisor.start_child/2`, but it can also return `:ignore` and `{:error, :max_children}`

This PR fixes that.