### PR TITLE
Fix typespec for DynamicSupervisor.init/1

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -494,7 +494,7 @@ defmodule DynamicSupervisor do
 
   """
   @since "1.6.0"
-  @spec init([init_option]) :: {:ok, map()}
+  @spec init([init_option]) :: {:ok, sup_flags()}
   def init(options) when is_list(options) do
     unless strategy = options[:strategy] do
       raise ArgumentError, "expected :strategy option to be given"

--- a/lib/elixir/test/elixir/dynamic_supervisor_test.exs
+++ b/lib/elixir/test/elixir/dynamic_supervisor_test.exs
@@ -6,7 +6,6 @@ defmodule DynamicSupervisorTest do
   defmodule Simple do
     use DynamicSupervisor
 
-    @spec init([atom]) :: {:ok, DynamicSupervisor.sup_flags()} | :ignore
     def init(args), do: args
   end
 

--- a/lib/elixir/test/elixir/dynamic_supervisor_test.exs
+++ b/lib/elixir/test/elixir/dynamic_supervisor_test.exs
@@ -6,6 +6,7 @@ defmodule DynamicSupervisorTest do
   defmodule Simple do
     use DynamicSupervisor
 
+    @spec init([atom]) :: {:ok, DynamicSupervisor.sup_flags()} | :ignore
     def init(args), do: args
   end
 


### PR DESCRIPTION
  DynamicSupervisor.init/1 should have %{:ok, sup_flags()} per the @opaque type

Example code:
```elixir
  @spec init(atom()) :: {:ok, sup_flags()} | :ignore
  def init(arg) do
    DynamicSupervisor.init(
      strategy: :one_for_one,
      extra_arguments: [arg]
    )
```

 Previous behavior:

```elixir
Starting Dialyzer
dialyzer args: [
  check_plt: false,
  init_plt: '/Users/starbelly/devel/elixir/soda/_build/dev/dialyxir_erlang-20.3.1_elixir-1.6.4_deps-dev.plt',
  files_rec: ['/Users/starbelly/devel/elixir/soda/_build/dev/lib/soda/ebin'],
  warnings: [:unknown]
]
done in 0m1.23s
lib/soda_dyn.ex:24: The specification for 'Elixir.Soda.Supervisor':init/1 has an opaque subtype 'Elixir.DynamicSupervisor':sup_flags() which is violated by the success typing (_) -> {'ok',#{'extra_arguments':=_, 'max_children':=_, 'strategy':=_, _=>_}}
done (warnings were emitted)
```

Behavior after patch:
```elixir
Starting Dialyzer
dialyzer args: [
  check_plt: false,
  init_plt: '/Users/starbelly/devel/elixir/soda/_build/dev/dialyxir_erlang-20.3.1_elixir-1.7.0-dev_deps-dev.plt',
  files_rec: ['/Users/starbelly/devel/elixir/soda/_build/dev/lib/soda/ebin'],
  warnings: [:unknown]
]
done in 0m1.0s
done (passed successfully)
```

