### PR TITLE
Erase elixir_parser_columns from the process dictionary after use

### DIFF
--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -322,6 +322,7 @@ tokens_to_quoted(Tokens, File, Opts) ->
     {error, {Line, _, [Error, Token]}} -> {error, {Line, to_binary(Error), to_binary(Token)}}
   after
     erase(elixir_parser_file),
+    erase(elixir_parser_columns),
     erase(elixir_formatter_metadata)
   end.
 


### PR DESCRIPTION
Notice this while reading the parser