### PR TITLE
Ignore unused var in String.ex

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -275,7 +275,7 @@ defmodule String do
     recur_printable?(rest, decrement(character_limit))
   end
 
-  defp recur_printable?(string, _character_limit) do
+  defp recur_printable?(_string, _character_limit) do
     false
   end
 


### PR DESCRIPTION
Removes warning:

```
warning: variable "string" is unused
  lib/string.ex:278
```