### PR TITLE
 Mention in the docs every function inlined by the compiler

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -299,13 +299,13 @@ defmodule Kernel do
   Raises an `ArithmeticError` exception if one of the arguments is not an
   integer, or when the `divisor` is `0`.
 
-  Allowed in guard tests. Inlined by the compiler.
-
   `div/2` performs *truncated* integer division. This means that
   the result is always rounded towards zero.
 
   If you want to perform floored integer division (rounding towards negative infinity),
   use `Integer.floor_div/2` instead.
+
+  Allowed in guard tests. Inlined by the compiler.
 
   ## Examples
 

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -104,6 +104,8 @@ defmodule Map do
   @doc """
   Returns all keys from `map`.
 
+  Inlined by the compiler.
+
   ## Examples
 
       iex> Map.keys(%{a: 1, b: 2})
@@ -115,6 +117,8 @@ defmodule Map do
 
   @doc """
   Returns all values from `map`.
+
+  Inlined by the compiler.
 
   ## Examples
 
@@ -130,6 +134,8 @@ defmodule Map do
 
   Each key-value pair in the map is converted to a two-element tuple `{key,
   value}` in the resulting list.
+
+  Inlined by the compiler.
 
   ## Examples
 
@@ -211,14 +217,14 @@ defmodule Map do
   @doc """
   Returns whether the given `key` exists in the given `map`.
 
+  Inlined by the compiler.
+
   ## Examples
 
       iex> Map.has_key?(%{a: 1}, :a)
       true
       iex> Map.has_key?(%{a: 1}, :b)
       false
-
-  Inlined by the compiler.
   """
   @spec has_key?(map, key) :: boolean
   def has_key?(map, key), do: :maps.is_key(key, map)
@@ -229,14 +235,14 @@ defmodule Map do
   If `map` contains the given `key` with value `value`, then `{:ok, value}` is
   returned. If `map` doesn't contain `key`, `:error` is returned.
 
+  Inlined by the compiler.
+
   ## Examples
 
       iex> Map.fetch(%{a: 1}, :a)
       {:ok, 1}
       iex> Map.fetch(%{a: 1}, :b)
       :error
-
-  Inlined by the compiler.
   """
   @spec fetch(map, key) :: {:ok, value} | :error
   def fetch(map, key), do: :maps.find(key, map)
@@ -247,6 +253,8 @@ defmodule Map do
 
   If `map` contains the given `key`, the corresponding value is returned. If
   `map` doesn't contain `key`, a `KeyError` exception is raised.
+
+  Inlined by the compiler.
 
   ## Examples
 
@@ -307,6 +315,8 @@ defmodule Map do
 
   If `key` is not present in `map`, a `KeyError` exception is raised.
 
+  Inlined by the compiler.
+
   ## Examples
 
       iex> Map.replace!(%{a: 1, b: 2}, :a, 3)
@@ -314,8 +324,6 @@ defmodule Map do
 
       iex> Map.replace!(%{a: 1}, :b, 2)
       ** (KeyError) key :b not found in: %{a: 1}
-
-  Inlined by the compiler.
   """
   @since "1.5.0"
   @spec replace!(map, key, value) :: map
@@ -469,14 +477,14 @@ defmodule Map do
   @doc """
   Puts the given `value` under `key` in `map`.
 
+  Inlined by the compiler.
+
   ## Examples
 
       iex> Map.put(%{a: 1}, :b, 2)
       %{a: 1, b: 2}
       iex> Map.put(%{a: 1, b: 2}, :a, 3)
       %{a: 3, b: 2}
-
-  Inlined by the compiler.
   """
   @spec put(map, key, value) :: map
   def put(map, key, value) do
@@ -487,6 +495,8 @@ defmodule Map do
   Deletes the entry in `map` for a specific `key`.
 
   If the `key` does not exist, returns `map` unchanged.
+
+  Inlined by the compiler.
 
   ## Examples
 
@@ -510,6 +520,8 @@ defmodule Map do
   struct, do not use this function, as it would merge all keys on the right
   side into the struct, even if the key is not part of the struct. Instead,
   use `Kernel.struct/2`.
+
+  Inlined by the compiler.
 
   ## Examples
 
@@ -881,6 +893,7 @@ defmodule Map do
 
   @doc false
   # TODO: Remove on 2.0
+  # Inlined by the compiler.
   # (hard-deprecated in elixir_dispatch)
   def size(map) do
     map_size(map)

--- a/lib/elixir/lib/node.ex
+++ b/lib/elixir/lib/node.ex
@@ -59,6 +59,8 @@ defmodule Node do
   the local node.
 
   Same as `list(:visible)`.
+
+  Inlined by the compiler.
   """
   @spec list :: [t]
   def list do
@@ -72,6 +74,8 @@ defmodule Node do
   satisfying the disjunction(s) of the list elements.
 
   For more information, see `:erlang.nodes/1`.
+
+  Inlined by the compiler.
   """
   @type state :: :visible | :hidden | :connected | :this | :known
   @spec list(state | [state]) :: [t]

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -222,6 +222,8 @@ defmodule Process do
   @doc """
   Sends a message to the given process.
 
+  Inlined by the compiler.
+
   ## Options
 
     * `:noconnect` - when used, if sending the message would require an
@@ -237,8 +239,6 @@ defmodule Process do
 
       iex> Process.send({:name, :node_that_does_not_exist}, :hi, [:noconnect])
       :noconnect
-
-  Inlined by the compiler.
   """
   @spec send(dest, msg, [option]) :: :ok | :noconnect | :nosuspend
         when dest: pid | port | atom | {atom, node},
@@ -296,6 +296,8 @@ defmodule Process do
   Even if the timer had expired and the message was sent, this function does not
   tell you if the timeout message has arrived at its destination yet.
 
+  Inlined by the compiler.
+
   ## Options
 
     * `:async` - (boolean) when `false`, the request for cancellation is
@@ -312,8 +314,6 @@ defmodule Process do
       described above) is sent to the caller of this function when the
       cancellation has been performed. If `:async` is `true` and `:info` is
       `false`, no message is sent. Defaults to `true`.
-
-  Inlined by the compiler.
   """
   @spec cancel_timer(reference, options) :: non_neg_integer | false | :ok
         when options: [async: boolean, info: boolean]
@@ -493,7 +493,6 @@ defmodule Process do
     * `false`
     * `true`
     * `:undefined`
-
   """
   @spec register(pid | port, atom) :: true
   def register(pid_or_port, name)

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -451,7 +451,7 @@ defmodule System do
   return the current stacktrace but rather the stacktrace of the
   latest exception.
 
-  Inlined by the compiler into `:erlang.get_stacktrace/0`.
+  Inlined by the compiler.
   """
   def stacktrace do
     :erlang.get_stacktrace()
@@ -694,7 +694,7 @@ defmodule System do
   This time is monotonically increasing and starts in an unspecified
   point in time.
 
-  Inlined by the compiler into `:erlang.monotonic_time/0`.
+  Inlined by the compiler.
   """
   @spec monotonic_time() :: integer
   def monotonic_time do
@@ -719,7 +719,7 @@ defmodule System do
   case of time warps although the VM works towards aligning
   them. This time is not monotonic.
 
-  Inlined by the compiler into `:erlang.system_time/0`.
+  Inlined by the compiler.
   """
   @spec system_time() :: integer
   def system_time do
@@ -764,7 +764,7 @@ defmodule System do
 
   See `time_offset/1` for more information.
 
-  Inlined by the compiler into `:erlang.time_offset/0`.
+  Inlined by the compiler.
   """
   @spec time_offset() :: integer
   def time_offset do
@@ -793,7 +793,7 @@ defmodule System do
   This time may be adjusted forwards or backwards in time
   with no limitation and is not monotonic.
 
-  Inlined by the compiler into `:os.system_time/0`.
+  Inlined by the compiler.
   """
   @spec os_time() :: integer
   def os_time do
@@ -856,7 +856,7 @@ defmodule System do
   All modifiers listed above can be combined; repeated modifiers in `modifiers`
   will be ignored.
 
-  Inlined by the compiler into `:erlang.unique_integer/1`.
+  Inlined by the compiler.
   """
   @spec unique_integer([:positive | :monotonic]) :: integer
   def unique_integer(modifiers \\ []) do

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -114,7 +114,7 @@ inline(?list, to_tuple, 1) -> {erlang, list_to_tuple};
 
 inline(?map, keys, 1) -> {maps, keys};
 inline(?map, merge, 2) -> {maps, merge};
-inline(?map, size, 1) -> {maps, size};
+inline(?map, size, 1) -> {maps, size}; %% TODO: Remove on 2.0
 inline(?map, to_list, 1) -> {maps, to_list};
 inline(?map, values, 1) -> {maps, values};
 

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -4,11 +4,12 @@
 
 %% Convenience variables
 
--define(atom, 'Elixir.Atom').
 -define(access, 'Elixir.Access').
+-define(atom, 'Elixir.Atom').
 -define(enum, 'Elixir.Enum').
--define(io, 'Elixir.IO').
+-define(function, 'Elixir.Function').
 -define(integer, 'Elixir.Integer').
+-define(io, 'Elixir.IO').
 -define(kernel, 'Elixir.Kernel').
 -define(list, 'Elixir.List').
 -define(list_chars, 'Elixir.List.Chars').
@@ -20,7 +21,6 @@
 -define(string_chars, 'Elixir.String.Chars').
 -define(system, 'Elixir.System').
 -define(tuple, 'Elixir.Tuple').
--define(function, 'Elixir.Function').
 
 %% Inline
 
@@ -28,36 +28,35 @@
 %% number and order of arguments and show up on captures.
 
 inline(?atom, to_charlist, 1) -> {erlang, atom_to_list};
-inline(?io, iodata_length, 1) -> {erlang, iolist_size};
-inline(?io, iodata_to_binary, 1) -> {erlang, iolist_to_binary};
-inline(?integer, to_string, 1) -> {erlang, integer_to_binary};
-inline(?integer, to_string, 2) -> {erlang, integer_to_binary};
+
+inline(?function, capture, 3) -> {erlang, make_fun};
+inline(?function, info, 1) -> {erlang, fun_info};
+inline(?function, info, 2) -> {erlang, fun_info};
+
 inline(?integer, to_charlist, 1) -> {erlang, integer_to_list};
 inline(?integer, to_charlist, 2) -> {erlang, integer_to_list};
-inline(?list, to_atom, 1) -> {erlang, list_to_atom};
-inline(?list, to_existing_atom, 1) -> {erlang, list_to_existing_atom};
-inline(?list, to_float, 1) -> {erlang, list_to_float};
-inline(?list, to_integer, 1) -> {erlang, list_to_integer};
-inline(?list, to_integer, 2) -> {erlang, list_to_integer};
-inline(?list, to_tuple, 1) -> {erlang, list_to_tuple};
+inline(?integer, to_string, 1) -> {erlang, integer_to_binary};
+inline(?integer, to_string, 2) -> {erlang, integer_to_binary};
 
-inline(?kernel, '+', 2) -> {erlang, '+'};
-inline(?kernel, '-', 2) -> {erlang, '-'};
-inline(?kernel, '+', 1) -> {erlang, '+'};
-inline(?kernel, '-', 1) -> {erlang, '-'};
-inline(?kernel, '*', 2) -> {erlang, '*'};
-inline(?kernel, '/', 2) -> {erlang, '/'};
-inline(?kernel, '++', 2) -> {erlang, '++'};
-inline(?kernel, '--', 2) -> {erlang, '--'};
-inline(?kernel, 'not', 1) -> {erlang, 'not'};
-inline(?kernel, '<', 2) -> {erlang, '<'};
-inline(?kernel, '>', 2) -> {erlang, '>'};
-inline(?kernel, '<=', 2) -> {erlang, '=<'};
-inline(?kernel, '>=', 2) -> {erlang, '>='};
-inline(?kernel, '==', 2) -> {erlang, '=='};
+inline(?io, iodata_length, 1) -> {erlang, iolist_size};
+inline(?io, iodata_to_binary, 1) -> {erlang, iolist_to_binary};
+
 inline(?kernel, '!=', 2) -> {erlang, '/='};
-inline(?kernel, '===', 2) -> {erlang, '=:='};
 inline(?kernel, '!==', 2) -> {erlang, '=/='};
+inline(?kernel, '*', 2) -> {erlang, '*'};
+inline(?kernel, '+', 1) -> {erlang, '+'};
+inline(?kernel, '+', 2) -> {erlang, '+'};
+inline(?kernel, '++', 2) -> {erlang, '++'};
+inline(?kernel, '-', 1) -> {erlang, '-'};
+inline(?kernel, '-', 2) -> {erlang, '-'};
+inline(?kernel, '--', 2) -> {erlang, '--'};
+inline(?kernel, '/', 2) -> {erlang, '/'};
+inline(?kernel, '<', 2) -> {erlang, '<'};
+inline(?kernel, '<=', 2) -> {erlang, '=<'};
+inline(?kernel, '==', 2) -> {erlang, '=='};
+inline(?kernel, '===', 2) -> {erlang, '=:='};
+inline(?kernel, '>', 2) -> {erlang, '>'};
+inline(?kernel, '>=', 2) -> {erlang, '>='};
 inline(?kernel, abs, 1) -> {erlang, abs};
 inline(?kernel, apply, 2) -> {erlang, apply};
 inline(?kernel, apply, 3) -> {erlang, apply};
@@ -90,6 +89,7 @@ inline(?kernel, max, 2) -> {erlang, max};
 inline(?kernel, min, 2) -> {erlang, min};
 inline(?kernel, node, 0) -> {erlang, node};
 inline(?kernel, node, 1) -> {erlang, node};
+inline(?kernel, 'not', 1) -> {erlang, 'not'};
 inline(?kernel, 'rem', 2) -> {erlang, 'rem'};
 inline(?kernel, round, 1) -> {erlang, round};
 inline(?kernel, self, 0) -> {erlang, self};
@@ -105,11 +105,18 @@ inline(?kernel, tl, 1) -> {erlang, tl};
 inline(?kernel, trunc, 1) -> {erlang, trunc};
 inline(?kernel, tuple_size, 1) -> {erlang, tuple_size};
 
+inline(?list, to_atom, 1) -> {erlang, list_to_atom};
+inline(?list, to_existing_atom, 1) -> {erlang, list_to_existing_atom};
+inline(?list, to_float, 1) -> {erlang, list_to_float};
+inline(?list, to_integer, 1) -> {erlang, list_to_integer};
+inline(?list, to_integer, 2) -> {erlang, list_to_integer};
+inline(?list, to_tuple, 1) -> {erlang, list_to_tuple};
+
 inline(?map, keys, 1) -> {maps, keys};
 inline(?map, merge, 2) -> {maps, merge};
 inline(?map, size, 1) -> {maps, size};
-inline(?map, values, 1) -> {maps, values};
 inline(?map, to_list, 1) -> {maps, to_list};
+inline(?map, values, 1) -> {maps, values};
 
 inline(?node, list, 0) -> {erlang, nodes};
 inline(?node, list, 1) -> {erlang, nodes};
@@ -120,19 +127,28 @@ inline(?node, spawn, 5) -> {erlang, spawn_opt};
 inline(?node, spawn_link, 2) -> {erlang, spawn_link};
 inline(?node, spawn_link, 4) -> {erlang, spawn_link};
 
+inline(?port, close, 1) -> {erlang, port_close};
+inline(?port, command, 2) -> {erlang, port_command};
+inline(?port, command, 3) -> {erlang, port_command};
+inline(?port, connect, 2) -> {erlang, port_connect};
+inline(?port, demonitor, 1) -> {erlang, demonitor};
+inline(?port, demonitor, 2) -> {erlang, demonitor};
+inline(?port, list, 0) -> {erlang, ports};
+inline(?port, open, 2) -> {erlang, open_port};
+
 inline(?process, 'alive?', 1) -> {erlang, is_process_alive};
 inline(?process, cancel_timer, 1) -> {erlang, cancel_timer};
 inline(?process, cancel_timer, 2) -> {erlang, cancel_timer};
+inline(?process, demonitor, 1) -> {erlang, demonitor};
+inline(?process, demonitor, 2) -> {erlang, demonitor};
 inline(?process, exit, 2) -> {erlang, exit};
+inline(?process, flag, 2) -> {erlang, process_flag};
+inline(?process, flag, 3) -> {erlang, process_flag};
 inline(?process, get, 0) -> {erlang, get};
 inline(?process, get_keys, 0) -> {erlang, get_keys};
 inline(?process, get_keys, 1) -> {erlang, get_keys};
 inline(?process, group_leader, 0) -> {erlang, group_leader};
 inline(?process, hibernate, 3) -> {erlang, hibernate};
-inline(?process, demonitor, 1) -> {erlang, demonitor};
-inline(?process, demonitor, 2) -> {erlang, demonitor};
-inline(?process, flag, 2) -> {erlang, process_flag};
-inline(?process, flag, 3) -> {erlang, process_flag};
 inline(?process, link, 1) -> {erlang, link};
 inline(?process, list, 0) -> {erlang, processes};
 inline(?process, read_timer, 1) -> {erlang, read_timer};
@@ -143,34 +159,21 @@ inline(?process, spawn, 4) -> {erlang, spawn_opt};
 inline(?process, unlink, 1) -> {erlang, unlink};
 inline(?process, unregister, 1) -> {erlang, unregister};
 
-inline(?port, open, 2) -> {erlang, open_port};
-inline(?port, close, 1) -> {erlang, port_close};
-inline(?port, command, 2) -> {erlang, port_command};
-inline(?port, command, 3) -> {erlang, port_command};
-inline(?port, connect, 2) -> {erlang, port_connect};
-inline(?port, demonitor, 1) -> {erlang, demonitor};
-inline(?port, demonitor, 2) -> {erlang, demonitor};
-inline(?port, list, 0) -> {erlang, ports};
-
+inline(?string, duplicate, 2) -> {binary, copy};
 inline(?string, to_float, 1) -> {erlang, binary_to_float};
 inline(?string, to_integer, 1) -> {erlang, binary_to_integer};
 inline(?string, to_integer, 2) -> {erlang, binary_to_integer};
-inline(?string, duplicate, 2) -> {binary, copy};
 
-inline(?system, stacktrace, 0) -> {erlang, get_stacktrace};
 inline(?system, monotonic_time, 0) -> {erlang, monotonic_time};
 inline(?system, os_time, 0) -> {os, system_time};
+inline(?system, stacktrace, 0) -> {erlang, get_stacktrace};
 inline(?system, system_time, 0) -> {erlang, system_time};
 inline(?system, time_offset, 0) -> {erlang, time_offset};
 inline(?system, unique_integer, 0) -> {erlang, unique_integer};
 inline(?system, unique_integer, 1) -> {erlang, unique_integer};
 
-inline(?tuple, to_list, 1) -> {erlang, tuple_to_list};
 inline(?tuple, append, 2) -> {erlang, append_element};
-
-inline(?function, capture, 3) -> {erlang, make_fun};
-inline(?function, info, 1) -> {erlang, fun_info};
-inline(?function, info, 2) -> {erlang, fun_info};
+inline(?tuple, to_list, 1) -> {erlang, tuple_to_list};
 
 inline(_, _, _) -> false.
 
@@ -211,26 +214,26 @@ rewrite(?map, put, [Map, Key, Value]) ->
   {maps, put, [Key, Value, Map]};
 rewrite(?map, 'replace!', [Map, Key, Value]) ->
   {maps, update, [Key, Value, Map]};
-rewrite(?process, monitor, [Arg]) ->
-  {erlang, monitor, [process, Arg]};
+rewrite(?port, monitor, [Arg]) ->
+  {erlang, monitor, [port, Arg]};
 rewrite(?process, group_leader, [Pid, Leader]) ->
   {erlang, group_leader, [Leader, Pid]};
+rewrite(?process, monitor, [Arg]) ->
+  {erlang, monitor, [process, Arg]};
 rewrite(?process, send_after, [Dest, Msg, Time]) ->
   {erlang, send_after, [Time, Dest, Msg]};
 rewrite(?process, send_after, [Dest, Msg, Time, Opts]) ->
   {erlang, send_after, [Time, Dest, Msg, Opts]};
-rewrite(?port, monitor, [Arg]) ->
-  {erlang, monitor, [port, Arg]};
 rewrite(?string, to_atom, [Arg]) ->
   {erlang, binary_to_atom, [Arg, utf8]};
 rewrite(?string, to_existing_atom, [Arg]) ->
   {erlang, binary_to_existing_atom, [Arg, utf8]};
-rewrite(?tuple, insert_at, [Tuple, Index, Term]) ->
-  {erlang, insert_element, [increment(Index), Tuple, Term]};
 rewrite(?tuple, delete_at, [Tuple, Index]) ->
   {erlang, delete_element, [increment(Index), Tuple]};
 rewrite(?tuple, duplicate, [Data, Size]) ->
   {erlang, make_tuple, [Size, Data]};
+rewrite(?tuple, insert_at, [Tuple, Index, Term]) ->
+  {erlang, insert_element, [increment(Index), Tuple, Term]};
 rewrite(Receiver, Fun, Args) ->
   {Receiver, Fun, Args}.
 


### PR DESCRIPTION
* Sort alphabetically elixir_rewrite.erl
* Mention in the docs every function inlined by the compiler
  elixir_rewrite.erl has been audited, function by function:
  - All missing "Inlined by the compiler." lines have been added.
  - Standardize sentence avoid mentioning the function its inline to (System module).
  - "Inline by the compiler." goes always before ##Options or ##Examples

Note: Please do not squash the commits into a single one.