### PR TITLE
Leave blank line before closing comment if idented

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -762,6 +762,7 @@ defmodule Access do
 
       iex> get_in(%{}, [Access.filter(fn a -> a == 10 end)])
       ** (RuntimeError) Access.filter/1 expected a list, got: %{}
+
   """
   @since "1.6.0"
   @spec filter((term -> boolean)) :: access_fun(data :: list, get_value :: list)

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -85,6 +85,7 @@ defmodule Date do
       true
       iex> Enum.reduce(range, 0, fn _date, acc -> acc - 1 end)
       -366
+
   """
 
   @since "1.5.0"

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -252,6 +252,7 @@ defmodule Time do
       ~T[23:50:07.123]
       iex> Time.from_iso8601!("2015:01:23 23-50-07")
       ** (ArgumentError) cannot parse "2015:01:23 23-50-07" as time, reason: :invalid_format
+
   """
   @spec from_iso8601!(String.t(), Calendar.calendar()) :: t
   def from_iso8601!(string, calendar \\ Calendar.ISO) do

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -654,6 +654,7 @@ defmodule File do
 
       # Rename directory "samples" to "tmp"
       File.rename "samples", "tmp"
+
   """
   @spec rename(Path.t(), Path.t()) :: :ok | {:error, posix}
   def rename(source, destination) do

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -329,6 +329,7 @@ defmodule GenServer do
     * [`:gen_server` module documentation](http://www.erlang.org/doc/man/gen_server.html)
     * [gen_server Behaviour – OTP Design Principles](http://www.erlang.org/doc/design_principles/gen_server_concepts.html)
     * [Clients and Servers – Learn You Some Erlang for Great Good!](http://learnyousomeerlang.com/clients-and-servers)
+
   """
 
   @doc """

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1773,6 +1773,7 @@ defmodule Kernel do
             reraise exception, stacktrace
           end
       end
+
   """
   defmacro reraise(message, stacktrace) do
     # Try to figure out the type at compilation time
@@ -5034,6 +5035,7 @@ defmodule Kernel do
 
       iex> ~D[2015-01-13]
       ~D[2015-01-13]
+
   """
   defmacro sigil_D(date, modifiers)
 

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -225,6 +225,7 @@ defmodule Map do
       true
       iex> Map.has_key?(%{a: 1}, :b)
       false
+
   """
   @spec has_key?(map, key) :: boolean
   def has_key?(map, key), do: :maps.is_key(key, map)
@@ -243,6 +244,7 @@ defmodule Map do
       {:ok, 1}
       iex> Map.fetch(%{a: 1}, :b)
       :error
+
   """
   @spec fetch(map, key) :: {:ok, value} | :error
   def fetch(map, key), do: :maps.find(key, map)
@@ -324,6 +326,7 @@ defmodule Map do
 
       iex> Map.replace!(%{a: 1}, :b, 2)
       ** (KeyError) key :b not found in: %{a: 1}
+
   """
   @since "1.5.0"
   @spec replace!(map, key, value) :: map
@@ -485,6 +488,7 @@ defmodule Map do
       %{a: 1, b: 2}
       iex> Map.put(%{a: 1, b: 2}, :a, 3)
       %{a: 3, b: 2}
+
   """
   @spec put(map, key, value) :: map
   def put(map, key, value) do

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -281,6 +281,7 @@ defmodule OptionParser do
       ** (OptionParser.ParseError) 2 errors found!
       --verbose : Missing argument of type integer
       --source : Expected type integer, got "lib"
+
   """
   @spec parse_head!(argv, options) :: {parsed, argv} | no_return
   def parse_head!(argv, opts \\ []) when is_list(argv) and is_list(opts) do

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -239,6 +239,7 @@ defmodule Process do
 
       iex> Process.send({:name, :node_that_does_not_exist}, :hi, [:noconnect])
       :noconnect
+
   """
   @spec send(dest, msg, [option]) :: :ok | :noconnect | :nosuspend
         when dest: pid | port | atom | {atom, node},
@@ -314,6 +315,7 @@ defmodule Process do
       described above) is sent to the caller of this function when the
       cancellation has been performed. If `:async` is `true` and `:info` is
       `false`, no message is sent. Defaults to `true`.
+
   """
   @spec cancel_timer(reference, options) :: non_neg_integer | false | :ok
         when options: [async: boolean, info: boolean]
@@ -493,6 +495,7 @@ defmodule Process do
     * `false`
     * `true`
     * `:undefined`
+
   """
   @spec register(pid | port, atom) :: true
   def register(pid_or_port, name)

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -775,6 +775,7 @@ defmodule Registry do
       ["hello", "hello"]
       iex> Registry.lookup(Registry.DuplicateUnregisterMatchTest, "hello")
       [{self(), :world_b}, {self(), :world_c}]
+
   """
   @since "1.5.0"
   def unregister_match(registry, key, pattern, guards \\ []) when is_list(guards) do
@@ -1011,6 +1012,7 @@ defmodule Registry do
       iex> {:ok, _} = Registry.register(Registry.DuplicateCountTest, "hello", :world)
       iex> Registry.count(Registry.DuplicateCountTest)
       2
+
   """
   @since "1.7.0"
   @spec count(registry) :: non_neg_integer()

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2047,6 +2047,7 @@ defmodule String do
 
       iex> String.to_charlist("æß")
       'æß'
+
   """
   @spec to_charlist(t) :: charlist
   def to_charlist(string) when is_binary(string) do

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -639,6 +639,7 @@ defmodule ExUnit.Assertions do
       assert_raise RuntimeError, ~r/^today's lucky number is 0\.\d+!$/, fn ->
         raise "today's lucky number is #{:rand.uniform()}!"
       end
+
   """
   def assert_raise(exception, message, function) when is_function(function) do
     error = assert_raise(exception, function)

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -200,6 +200,7 @@ defmodule ExUnit.Case do
   messages as well, remove the console backend globally:
 
       config :logger, backends: []
+
   """
 
   @reserved [:module, :file, :line, :test, :async, :registered, :describe, :type]
@@ -514,6 +515,7 @@ defmodule ExUnit.Case do
           assert context.registered.hello == "world"
         end
       end
+
   """
   def register_attribute(env, name, opts \\ [])
 

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -536,6 +536,7 @@ defmodule IEx do
 
       iex -S mix test --trace
       iex -S mix test path/to/file:line --trace
+
   """
   defmacro pry() do
     quote do

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -308,6 +308,7 @@ defmodule IEx.Helpers do
       iex> b(Mix.Task.run/1)
       iex> b(Mix.Task.run)
       iex> b(GenServer)
+
   """
   defmacro b(term) do
     quote do

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -220,6 +220,7 @@ defmodule Mix.Task do
 
     * `Mix.NoTaskError`      - raised if the task could not be found
     * `Mix.InvalidTaskError` - raised if the task is not a valid `Mix.Task`
+
   """
   @spec get!(task_name) :: task_module | no_return
   def get!(task) do

--- a/lib/mix/lib/mix/tasks/app.tree.ex
+++ b/lib/mix/lib/mix/tasks/app.tree.ex
@@ -28,6 +28,7 @@ defmodule Mix.Tasks.App.Tree do
       * `dot` - produces a DOT graph description of the application tree
         in `app_tree.dot` in the current directory.
         Warning: this will overwrite any previously generated file.
+
   """
 
   @default_excluded [:kernel, :stdlib, :compiler]

--- a/lib/mix/lib/mix/tasks/deps.get.ex
+++ b/lib/mix/lib/mix/tasks/deps.get.ex
@@ -11,6 +11,7 @@ defmodule Mix.Tasks.Deps.Get do
 
     * `--only` - only fetches dependencies for given environment
     * `--no-archives-check` - does not check archives before fetching deps
+
   """
 
   def run(args) do

--- a/lib/mix/lib/mix/tasks/deps.update.ex
+++ b/lib/mix/lib/mix/tasks/deps.update.ex
@@ -30,6 +30,7 @@ defmodule Mix.Tasks.Deps.Update do
     * `--all` - updates all dependencies
     * `--only` - only fetches dependencies for given environment
     * `--no-archives-check` - does not check archives before fetching deps
+
   """
 
   def run(args) do

--- a/lib/mix/lib/mix/tasks/local.public_keys.ex
+++ b/lib/mix/lib/mix/tasks/local.public_keys.ex
@@ -31,6 +31,7 @@ defmodule Mix.Tasks.Local.PublicKeys do
 
     * `--force` - forces installation without a shell prompt; primarily
       intended for automation in build systems like `make`
+
   """
 
   def run(argv) do

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -63,6 +63,7 @@ defmodule Mix.Utils do
       :error
       iex> Mix.Utils.parse_mfa("Foo.bar/2/2")
       :error
+
   """
   def parse_mfa(mfa) do
     with {:ok, quoted} <- Code.string_to_quoted(mfa),
@@ -486,6 +487,7 @@ defmodule Mix.Utils do
 
     * `:sha512` - checks against the given SHA-512 checksum. Returns
       `{:checksum, message}` in case it fails
+
   """
   @spec read_path(String.t(), keyword) ::
           {:ok, binary}


### PR DESCRIPTION
If last line in the docs is idented, leave an emptyline before closing the comment.

Mentioned by @whatyouhide in https://github.com/elixir-lang/elixir/pull/7606#discussion_r184348514

The command/regexp used to find these offending lines is:

    ag "\ {4,}[^\n]+\n\s{2}[\"']{3}"