### PR TITLE
Inline hard-deprecated functions

### DIFF
--- a/lib/elixir/lib/atom.ex
+++ b/lib/elixir/lib/atom.ex
@@ -39,6 +39,7 @@ defmodule Atom do
 
   # TODO: Remove by 2.0
   # (hard-deprecated in elixir_dispatch)
+  # Inlined by the compiler
   @doc false
   @spec to_char_list(atom) :: charlist
   def to_char_list(atom), do: Atom.to_charlist(atom)

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -402,12 +402,14 @@ defmodule Integer do
 
   # TODO: Remove by 2.0
   # (hard-deprecated in elixir_dispatch)
+  # Inlined by the compiler
   @doc false
   @spec to_char_list(integer) :: charlist
   def to_char_list(integer), do: Integer.to_charlist(integer)
 
   # TODO: Remove by 2.0
   # (hard-deprecated in elixir_dispatch)
+  # Inlined by the compiler
   @doc false
   @spec to_char_list(integer, 2..36) :: charlist
   def to_char_list(integer, base), do: Integer.to_charlist(integer, base)

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -27,12 +27,15 @@
 %% Inline rules are straightforward, they keep the same
 %% number and order of arguments and show up on captures.
 
+inline(?atom, to_char_list, 1) -> {erlang, atom_to_list}; %% TODO: Remove on 2.0
 inline(?atom, to_charlist, 1) -> {erlang, atom_to_list};
 
 inline(?function, capture, 3) -> {erlang, make_fun};
 inline(?function, info, 1) -> {erlang, fun_info};
 inline(?function, info, 2) -> {erlang, fun_info};
 
+inline(?integer, to_char_list, 1) -> {erlang, integer_to_list}; %% TODO: Remove on 2.0
+inline(?integer, to_char_list, 2) -> {erlang, integer_to_list}; %% TODO: Remove on 2.0
 inline(?integer, to_charlist, 1) -> {erlang, integer_to_list};
 inline(?integer, to_charlist, 2) -> {erlang, integer_to_list};
 inline(?integer, to_string, 1) -> {erlang, integer_to_binary};


### PR DESCRIPTION
These functions were inlined in the past. I think they should still
be inlined until removed in v2.0

I see they were removed in an unrelated commit 9c0d6a66d5fc05868fa0e7cdbe180c0a478b0547

before:

    iex(1)> &Atom.to_charlist/1
    &:erlang.atom_to_list/1
    iex(2)> &Atom.to_char_list/1
    warning: Atom.to_char_list/1 is deprecated, use Atom.to_charlist/1
      iex:2

    &Atom.to_char_list/1

now:

    iex(1)> &Atom.to_charlist/1
    &:erlang.atom_to_list/1
    iex(2)> &Atom.to_char_list/1
    warning: Atom.to_char_list/1 is deprecated, use Atom.to_charlist/1
      iex:2

    &:erlang.atom_to_list/1