### PR TITLE
Standardize use of Erlang, OTP and Erlang/OTP names

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -7,7 +7,7 @@
 
 ### Environment
 
-* Elixir & Erlang versions (elixir --version): 
+* Elixir & Erlang/OTP versions (elixir --version): 
 * Operating system: 
 
 ### Current behavior

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ GIT_TAG = $(strip $(shell head="$(call GIT_REVISION)"; git tag --points-at $$hea
 define CHECK_ERLANG_RELEASE
 	erl -noshell -eval '{V,_} = string:to_integer(erlang:system_info(otp_release)), io:fwrite("~s", [is_integer(V) and (V >= 19)])' -s erlang halt | grep -q '^true'; \
 		if [ $$? != 0 ]; then \
-		  echo "At least Erlang 19.0 is required to build Elixir"; \
+		  echo "At least Erlang/OTP 19.0 is required to build Elixir"; \
 		  exit 1; \
 		fi
 endef

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ If Elixir fails to build (specifically when pulling in a new version via
 If tests pass, you are ready to move on to the [Getting Started guide][1]
 or to try Interactive Elixir by running `bin/iex` in your terminal.
 
-However, if tests fail, it is likely you have an outdated Erlang version
-(Elixir requires Erlang 19.0 or later). You can check your Erlang version
+However, if tests fail, it is likely you have an outdated Erlang/OTP version
+(Elixir requires Erlang/OTP 19.0 or later). You can check your Erlang/OTP version
 by calling `erl` in the command line. You will see some information as follows:
 
     Erlang/OTP 19 [erts-8.0] [smp:2:2] [async-threads:10] [kernel-poll:false]

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -74,7 +74,7 @@ defmodule Application do
   The `type` argument passed to `start/2` is usually `:normal` unless in a
   distributed setup where application takeovers and failovers are configured.
   Distributed applications is beyond the scope of this documentation. For those
-  interested on the topic, please access the OTP documentation:
+  interested on the topic, please access the Erlang/OTP documentation:
 
     * [`:application` module](http://www.erlang.org/doc/man/application.html)
     * [Applications – OTP Design Principles](http://www.erlang.org/doc/design_principles/applications.html)

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -382,11 +382,11 @@ defmodule Kernel do
       exit({:shutdown, integer})
 
   This will cause the OS process to exit with the status given by
-  `integer` while signaling all linked OTP processes to politely
+  `integer` while signaling all linked Erlang processes to politely
   shutdown.
 
   Any other exit reason will cause the OS process to exit with
-  status `1` and linked OTP processes to crash.
+  status `1` and linked Erlang processes to crash.
   """
   @spec exit(term) :: no_return
   def exit(reason) do

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -41,7 +41,7 @@ defmodule Regex do
   expression engine at any time.
 
   For such reasons, we always recommend precompiling Elixir projects using
-  the OTP version meant to run in production. In case cross-compilation is
+  the Erlang/OTP version meant to run in production. In case cross-compilation is
   really necessary, you can manually invoke `Regex.recompile/1` or
   `Regex.recompile!/1` to perform a runtime version check and recompile the
   regex if necessary.

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2074,7 +2074,7 @@ defmodule String do
   By default, the maximum number of atoms is `1_048_576`. This limit
   can be raised or lowered using the VM option `+t`.
 
-  The maximum atom size is of 255 characters. Prior to OTP 20,
+  The maximum atom size is of 255 characters. Prior to Erlang/OTP 20,
   only latin1 characters are allowed.
 
   Inlined by the compiler.
@@ -2093,7 +2093,7 @@ defmodule String do
   @doc """
   Converts a string to an existing atom.
 
-  The maximum atom size is of 255 characters. Prior to OTP 20,
+  The maximum atom size is of 255 characters. Prior to Erlang/OTP 20,
   only latin1 characters are allowed.
 
   Inlined by the compiler.

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -190,7 +190,7 @@ defmodule System do
     {:ok, v} = Version.parse(version())
 
     revision_string = if v.pre != [] and revision() != "", do: " (#{revision()})", else: ""
-    otp_version_string = " (compiled with OTP #{get_otp_release()})"
+    otp_version_string = " (compiled with Erlang/OTP #{get_otp_release()})"
 
     version() <> revision_string <> otp_version_string
   end
@@ -812,7 +812,7 @@ defmodule System do
   end
 
   @doc """
-  Returns the OTP release number.
+  Returns the Erlang/OTP release number.
   """
   @spec otp_release :: String.t()
   def otp_release do

--- a/lib/elixir/pages/Compatibility and Deprecations.md
+++ b/lib/elixir/pages/Compatibility and Deprecations.md
@@ -40,15 +40,15 @@ Erlang/OTP versioning is independent from the versioning of Elixir. Each version
 
 Elixir version | Supported Erlang/OTP versions
 :------------- | :-------------------------------
-1.0            | 17 - 17 (and OTP 18 from v1.0.5)
+1.0            | 17 - 17 (and Erlang/OTP 18 from v1.0.5)
 1.1            | 17 - 18
-1.2            | 18 - 18 (and OTP 19 from v1.2.6)
+1.2            | 18 - 18 (and Erlang/OTP 19 from v1.2.6)
 1.3            | 18 - 19
-1.4            | 18 - 19 (and OTP 20 from v1.4.5)
+1.4            | 18 - 19 (and Erlang/OTP 20 from v1.4.5)
 1.5            | 18 - 20
 1.6            | 19 - 20
 
-While Elixir often adds compatibility to new Erlang versions on released branches, such as support for OTP 20 in v1.4.5, those releases usually contain the minimum changes for Elixir to run without errors. Only the next minor release, in this case v1.5.0, does effectively leverage the new features provided by the latest Erlang release.
+While Elixir often adds compatibility to new Erlang/OTP versions on released branches, such as support for Erlang/OTP 20 in v1.4.5, those releases usually contain the minimum changes for Elixir to run without errors. Only the next minor release, in this case v1.5.0, does effectively leverage the new features provided by the latest Erlang/OTP release.
 
 ## Deprecations
 
@@ -79,7 +79,7 @@ Deprecated feature                               | Hard-deprecated in | Replaced
 `Atom.to_char_list/1`                            | [v1.5]        | `Atom.to_charlist/1` (v1.3)
 `Enum.filter_map/3`                              | [v1.5]        | `Enum.filter/2` + `Enum.map/2` or [`for`](`Kernel.SpecialForms.for/1`) comprehensions (v1.0)
 `Float.to_char_list/1`                           | [v1.5]        | `Float.to_charlist/1` (v1.3)
-`GenEvent` module                                | [v1.5]        | `Supervisor` and `GenServer` (v1.0);<br/>[`GenStage`](https://hex.pm/packages/gen_stage) (v1.3);<br/>[`:gen_event`](http://www.erlang.org/doc/man/gen_event.html) (OTP 17)
+`GenEvent` module                                | [v1.5]        | `Supervisor` and `GenServer` (v1.0);<br/>[`GenStage`](https://hex.pm/packages/gen_stage) (v1.3);<br/>[`:gen_event`](http://www.erlang.org/doc/man/gen_event.html) (Erlang/OTP 17)
 `Integer.to_char_list/1` and `Integer.to_char_list/2` | [v1.5]   | `Integer.to_charlist/1` and `Integer.to_charlist/2` (v1.3)
 `Kernel.to_char_list/1`                          | [v1.5]        | `Kernel.to_charlist/1` (v1.3)
 `List.Chars.to_char_list/1`                      | [v1.5]        | `List.Chars.to_charlist/1` (v1.3)
@@ -98,8 +98,8 @@ EEx: `<%=` in middle and end expressions         | [v1.5]        | Use `<%` (`<%
 `Access.key/1`                                   | [v1.4]        | `Access.key/2` (v1.3)
 `Behaviour` module                               | [v1.4]        | `@callback` module attribute (v1.0)
 `Enum.uniq/2`                                    | [v1.4]        | `Enum.uniq_by/2` (v1.2)
-`Float.to_char_list/2`                           | [v1.4]        | `:erlang.float_to_list/2` (OTP 17)
-`Float.to_string/2`                              | [v1.4]        | `:erlang.float_to_binary/2` (OTP 17)
+`Float.to_char_list/2`                           | [v1.4]        | `:erlang.float_to_list/2` (Erlang/OTP 17)
+`Float.to_string/2`                              | [v1.4]        | `:erlang.float_to_binary/2` (Erlang/OTP 17)
 `HashDict` module                                | [v1.4]        | `Map` (v1.2)
 `HashSet` module                                 | [v1.4]        | `MapSet` (v1.1)
  Multi-letter aliases in `OptionParser`          | [v1.4]        | Use single-letter aliases (v1.0)

--- a/lib/elixir/pages/Syntax Reference.md
+++ b/lib/elixir/pages/Syntax Reference.md
@@ -21,7 +21,7 @@ Integers (`1234`) and floats (`123.4`) in Elixir are represented as a sequence o
 
 ### Atoms
 
-Atoms in Elixir start with a colon (`:`) which must be followed by non-combining Unicode characters and underscore. The atom may continue using a sequence of Unicode characters, including numbers, underscore and `@`. Atoms may end in `!` or `?`. See [Unicode Syntax](unicode-syntax.html) for a formal specification. Unicode characters require OTP 20.
+Atoms in Elixir start with a colon (`:`) which must be followed by non-combining Unicode characters and underscore. The atom may continue using a sequence of Unicode characters, including numbers, underscore and `@`. Atoms may end in `!` or `?`. See [Unicode Syntax](unicode-syntax.html) for a formal specification. Unicode characters require Erlang/OTP 20.
 
 All operators in Elixir are also valid atoms. Valid examples are `:foo`, `:FOO`, `:foo_42`, `:foo@bar` and `:++`. Invalid examples are `:@foo` (`@` is not allowed at start), `:123` (numbers are not allowed at start) and `:(*)` (not a valid operator).
 
@@ -80,13 +80,13 @@ Structs built on the map syntax by passing the struct name between `%` and `{`. 
 
 ### Variables
 
-Variables in Elixir must start with underscore or a non-combining Unicode character that is not in uppercase or titlecase. The variable may continue using a sequence of Unicode characters, including numbers and underscore. Variables may end in `?` or `!`. See [Unicode Syntax](unicode-syntax.html) for a formal specification. Unicode characters require OTP 20.
+Variables in Elixir must start with underscore or a non-combining Unicode character that is not in uppercase or titlecase. The variable may continue using a sequence of Unicode characters, including numbers and underscore. Variables may end in `?` or `!`. See [Unicode Syntax](unicode-syntax.html) for a formal specification. Unicode characters require Erlang/OTP 20.
 
 [Elixir's naming conventions](naming-conventions.html) recommend variables to be in `snake_case` format.
 
 ### Non-qualified calls (local calls)
 
-Non-qualified calls, such as `add(1, 2)`, must start with underscore or a non-combining Unicode character that is not in uppercase or titlecase. The call may continue using a sequence of Unicode characters, including numbers and underscore. Calls may end in `?` or `!`. See [Unicode Syntax](unicode-syntax.html) for a formal specification. Unicode characters require OTP 20.
+Non-qualified calls, such as `add(1, 2)`, must start with underscore or a non-combining Unicode character that is not in uppercase or titlecase. The call may continue using a sequence of Unicode characters, including numbers and underscore. Calls may end in `?` or `!`. See [Unicode Syntax](unicode-syntax.html) for a formal specification. Unicode characters require Erlang/OTP 20.
 
 Parentheses for non-qualified calls are optional, except for zero-arity calls, which would then be ambiguous with variables. If parentheses are used, they must immediately follow the function name *without spaces*. For example, `add (1, 2)` is a syntax error, since `(1, 2)` is treated as an invalid block which is attempted to be given as a single argument to `add`.
 
@@ -98,7 +98,7 @@ As many programming languages, Elixir also support operators as non-qualified ca
 
 ### Qualified calls (remote calls)
 
-Qualified calls, such as `Math.add(1, 2)`, must start with underscore or a non-combining Unicode character that is not in uppercase or titlecase. The call may continue using a sequence of Unicode characters, including numbers and underscore. Calls may end in `?` or `!`. See [Unicode Syntax](unicode-syntax.html) for a formal specification. Unicode characters require OTP 20.
+Qualified calls, such as `Math.add(1, 2)`, must start with underscore or a non-combining Unicode character that is not in uppercase or titlecase. The call may continue using a sequence of Unicode characters, including numbers and underscore. Calls may end in `?` or `!`. See [Unicode Syntax](unicode-syntax.html) for a formal specification. Unicode characters require Erlang/OTP 20.
 
 [Elixir's naming conventions](naming-conventions.html) recommend calls to be in `snake_case` format.
 

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -117,7 +117,7 @@ parse_otp_release() ->
     {Num, _} when Num >= 19 ->
       Num;
     _ ->
-      io:format(standard_error, "unsupported Erlang version, expected Erlang 19+~n", []),
+      io:format(standard_error, "unsupported Erlang/OTP version, expected Erlang/OTP 19+~n", []),
       erlang:halt(1)
   end.
 

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -20,7 +20,7 @@ defmodule SystemTest do
     version_file = Path.join([__DIR__, "../../../..", "VERSION"]) |> Path.expand()
     {:ok, version} = File.read(version_file)
     assert build_info[:version] == String.trim(version)
-    assert build_info[:build] =~ "compiled with OTP"
+    assert build_info[:build] =~ "compiled with Erlang/OTP"
   end
 
   test "cwd/0" do

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -112,7 +112,7 @@ defmodule IEx do
 
   Alternatively, you can use `IEx.break!/4` to setup a breakpoint
   on a given module, function and arity you have no control of.
-  While `IEx.break!/4` is more flexible, it requires OTP 20+ and
+  While `IEx.break!/4` is more flexible, it requires Erlang/OTP 20+ and
   it does not contain information about imports and aliases from
   the source code.
 
@@ -464,7 +464,7 @@ defmodule IEx do
 
   Alternatively, you can use `IEx.break!/4` to setup a breakpoint
   on a given module, function and arity you have no control of.
-  While `IEx.break!/4` is more flexible, it requires OTP 20+ and
+  While `IEx.break!/4` is more flexible, it requires Erlang/OTP 20+ and
   it does not contain information about imports and aliases from
   the source code.
 
@@ -658,7 +658,7 @@ defmodule IEx do
   the process terminates, or invoke `respawn()`, which starts a new IEx
   shell, freeing up the pried one.
 
-  This functionality only works on Elixir code and requires OTP 20+.
+  This functionality only works on Elixir code and requires Erlang/OTP 20+.
 
   ## Examples
 

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -519,7 +519,7 @@ defmodule IEx.Helpers do
     print_pane("System and architecture")
 
     print_entry("Elixir version", System.version())
-    print_entry("OTP version", :erlang.system_info(:otp_release))
+    print_entry("Erlang/OTP version", :erlang.system_info(:otp_release))
     print_entry("ERTS version", :erlang.system_info(:version))
     print_entry("Compiled for", :erlang.system_info(:system_architecture))
     print_entry("Schedulers", :erlang.system_info(:schedulers))

--- a/lib/iex/lib/iex/pry.ex
+++ b/lib/iex/lib/iex/pry.ex
@@ -189,7 +189,7 @@ defmodule IEx.Pry do
               "module #{inspect(module)} was not written in Elixir"
 
             :otp_20_is_required ->
-              "you are running on an earlier OTP version than OTP 20"
+              "you are running on an earlier version than Erlang/OTP 20"
 
             :outdated_debug_info ->
               "module #{inspect(module)} was not compiled with the latest debug_info"

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -16,7 +16,7 @@ defmodule Logger do
       performant when required but also apply backpressure
       when under stress.
 
-    * Wraps OTP's [`:error_logger`](http://erlang.org/doc/man/error_logger.html)
+    * Wraps Erlang's [`:error_logger`](http://erlang.org/doc/man/error_logger.html)
       to prevent it from overflowing.
 
   Logging is useful for tracking when an event of interest happens in your
@@ -63,7 +63,7 @@ defmodule Logger do
       application is started, but may be changed during runtime
 
     * Error logger configuration - configuration for the
-      wrapper around OTP's [`:error_logger`](http://erlang.org/doc/man/error_logger.html)
+      wrapper around Erlangs's [`:error_logger`](http://erlang.org/doc/man/error_logger.html)
 
   ### Application configuration
 
@@ -152,11 +152,11 @@ defmodule Logger do
   ### Error logger configuration
 
   The following configuration applies to `Logger`'s wrapper around
-  OTP's [`:error_logger`](http://erlang.org/doc/man/error_logger.html).
+  Erlang's [`:error_logger`](http://erlang.org/doc/man/error_logger.html).
   All the configurations below must be set before the `:logger` application starts.
 
     * `:handle_otp_reports` - redirects OTP reports to `Logger` so
-      they are formatted in Elixir terms. This uninstalls OTP's
+      they are formatted in Elixir terms. This uninstalls Erlang's
       logger that prints terms to terminal. Defaults to `true`.
 
     * `:handle_sasl_reports` - redirects supervisor, crash and
@@ -184,7 +184,7 @@ defmodule Logger do
         handle_otp_reports: true,
         handle_sasl_reports: true
 
-  Furthermore, `Logger` allows messages sent by OTP's `:error_logger`
+  Furthermore, `Logger` allows messages sent by Erlang's `:error_logger`
   to be translated into an Elixir format via translators. Translators
   can be dynamically added at any time with the `add_translator/1`
   and `remove_translator/1` APIs. Check `Logger.Translator` for more
@@ -540,7 +540,7 @@ defmodule Logger do
   ## Options
 
     * `:flush` - when `true`, guarantees all messages currently sent
-      to both Logger and OTP's [`:error_logger`](http://erlang.org/doc/man/error_logger.html)
+      to both `Logger` and Erlangs's [`:error_logger`](http://erlang.org/doc/man/error_logger.html)
       are processed before the backend is added
 
   """
@@ -567,7 +567,7 @@ defmodule Logger do
   ## Options
 
     * `:flush` - when `true`, guarantees all messages currently sent
-      to both Logger and OTP's [`:error_logger`](http://erlang.org/doc/man/error_logger.html)
+      to both `Logger` and Erlangs's [`:error_logger`](http://erlang.org/doc/man/error_logger.html)
       are processed before the backend is removed
 
   """

--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -3,7 +3,7 @@ defmodule Logger.Translator do
   Default translation for Erlang log messages.
 
   Logger allows developers to rewrite log messages provided by
-  Erlang applications into a format more compatible with Elixir
+  OTP applications into a format more compatible with Elixir
   log messages by providing a translator.
 
   A translator is simply a tuple containing a module and a function
@@ -28,7 +28,7 @@ defmodule Logger.Translator do
   and the default messages translated by Logger.
   """
 
-  # The name_or_id checks are required to support old OTP projects.
+  # The name_or_id checks are required to support old Erlang projects.
 
   def translate(min_level, level, kind, message)
 
@@ -372,7 +372,7 @@ defmodule Logger.Translator do
     ["\n** (stop) " | Exception.format_exit(reason)]
   end
 
-  # OTP processes rewrite the :undef error to these reasons when logging
+  # Erlang processes rewrite the :undef error to these reasons when logging
   @gen_undef [:"module could not be loaded", :"function not exported"]
 
   defp format_stop_banner(undef, [{mod, fun, args, _info} | _] = stacktrace)

--- a/lib/mix/lib/mix/compilers/erlang.ex
+++ b/lib/mix/lib/mix/compilers/erlang.ex
@@ -141,7 +141,7 @@ defmodule Mix.Compilers.Erlang do
   end
 
   @doc """
-  Ensures the native Erlang application is available.
+  Ensures the native OTP application is available.
   """
   def ensure_application!(app, input) do
     case Application.ensure_all_started(app) do

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -17,11 +17,11 @@ defmodule Mix.Tasks.Compile.App do
 
   The most commonly used options are:
 
-    * `:extra_applications` - a list of Erlang/Elixir applications
+    * `:extra_applications` - a list of OTP applications
       your application depends on which are not included in `:deps`
       (usually defined in `deps/0` in your `mix.exs`). For example,
       here you can declare a dependency on applications that ship with
-      Erlang or Elixir, like `:crypto` or `:logger`, but anything in
+      Erlang/OTP or Elixir, like `:crypto` or `:logger`, but anything in
       the code path works. Mix guarantees that these applications and
       the rest of your runtime dependencies are started before your
       application starts.

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -9,7 +9,7 @@ defmodule Mix.Tasks.Escript.Build do
 
   An escript is an executable that can be invoked from the
   command line. An escript can run on any machine that has
-  Erlang installed and by default does not require Elixir to
+  Erlang/OTP installed and by default does not require Elixir to
   be installed, as Elixir is embedded as part of the escript.
 
   This task guarantees the project and its dependencies are

--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -84,7 +84,7 @@ defmodule Mix.Tasks.Profile.Fprof do
   the total time spent in the function was 50ms.
 
   For a detailed explanation it's worth reading the analysis in
-  [Erlang documentation for fprof](http://www.erlang.org/doc/man/fprof.html#analysis).
+  [Erlang/OTP documentation for fprof](http://www.erlang.org/doc/man/fprof.html#analysis).
 
   ## Caveats
 

--- a/man/mix.1
+++ b/man/mix.1
@@ -50,9 +50,9 @@ task, you can get both the full list of local/built-in tasks and the information
 .Pp
 An
 .Em archive ,
-in terms of Erlang, is the ZIP file with the
+in terms of Erlang/OTP, is the ZIP file with the
 .Em .ez
-extension which contains a precompiled Erlang application with all its dependencies[1].
+extension which contains a precompiled OTP application with all its dependencies[1].
 .Pp
 An
 .Em application


### PR DESCRIPTION
This touches only messages directed to the end user,
So comments are (mostly) ignored.

This is important, specially for new commers, who may be confused
by the interchangeably use of Erlang and OTP.

The expressions used consistenly across the documentation are:
- Erlang/OTP version
- Erlang/OTP 20+
- Erlang/OTP release,
- Erlang/OTP documentation
- Erlang process
- Erlang project
- Erlang's error logger
- Erlang log message
- OTP application
- OTP behaviour