### PR TITLE
Add .formatter.exs to the list of inputs to format

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -248,7 +248,7 @@ defmodule Mix.Tasks.New do
   embed_template(:formatter, """
   # Used by "mix format"
   [
-    inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+    inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
   ]
   """)
 


### PR DESCRIPTION
I saw this practice in [Plug](https://github.com/elixir-plug/plug/blob/master/.formatter.exs#L25) and I always include it in my `.formatter.exs` files.