### PR TITLE
Remove throw/catch pattern for Keyword.delete/2 and friends to prevent stacktrace corruption.

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -463,19 +463,23 @@ defmodule Keyword do
   """
   @spec delete(t, key, value) :: t
   def delete(keywords, key, value) when is_list(keywords) and is_atom(key) do
-    delete_key_value(keywords, key, value, _deleted? = false)
-  catch
-    :not_deleted -> keywords
+    case :lists.keymember(key, 1, keywords) do
+      true -> delete_key_value(keywords, key, value)
+      _ -> keywords
+    end
   end
 
-  defp delete_key_value([{key, value} | rest], key, value, _deleted?),
-    do: delete_key_value(rest, key, value, true)
+  defp delete_key_value([{key, value} | tail], key, value) do
+    delete_key_value(tail, key, value)
+  end
 
-  defp delete_key_value([{_, _} = pair | rest], key, value, deleted?),
-    do: [pair | delete_key_value(rest, key, value, deleted?)]
+  defp delete_key_value([{_, _} = pair | tail], key, value) do
+    [pair | delete_key_value(tail, key, value)]
+  end
 
-  defp delete_key_value([], _key, _value, _deleted? = true), do: []
-  defp delete_key_value([], _key, _value, _deleted? = false), do: throw(:not_deleted)
+  defp delete_key_value([], _key, _value) do
+    []
+  end
 
   @doc """
   Deletes the entries in the keyword list for a specific `key`.
@@ -497,18 +501,23 @@ defmodule Keyword do
   @spec delete(t, key) :: t
   @compile {:inline, delete: 2}
   def delete(keywords, key) when is_list(keywords) and is_atom(key) do
-    delete_key(keywords, key, _deleted? = false)
-  catch
-    :not_deleted -> keywords
+    case :lists.keymember(key, 1, keywords) do
+      true -> delete_key(keywords, key)
+      _ -> keywords
+    end
   end
 
-  defp delete_key([{key, _} | rest], key, _deleted?), do: delete_key(rest, key, true)
+  defp delete_key([{key, _} | tail], key) do
+    delete_key(tail, key)
+  end
 
-  defp delete_key([{_, _} = pair | rest], key, deleted?),
-    do: [pair | delete_key(rest, key, deleted?)]
+  defp delete_key([{_, _} = pair | tail], key) do
+    [pair | delete_key(tail, key)]
+  end
 
-  defp delete_key([], _key, _deleted? = true), do: []
-  defp delete_key([], _key, _deleted? = false), do: throw(:not_deleted)
+  defp delete_key([], _key) do
+    []
+  end
 
   @doc """
   Deletes the first entry in the keyword list for a specific `key`.
@@ -525,14 +534,23 @@ defmodule Keyword do
   """
   @spec delete_first(t, key) :: t
   def delete_first(keywords, key) when is_list(keywords) and is_atom(key) do
-    delete_first_key(keywords, key)
-  catch
-    :not_deleted -> keywords
+    case :lists.keymember(key, 1, keywords) do
+      true -> delete_first_key(keywords, key)
+      _ -> keywords
+    end
   end
 
-  defp delete_first_key([{key, _} | rest], key), do: rest
-  defp delete_first_key([{_, _} = pair | rest], key), do: [pair | delete_first_key(rest, key)]
-  defp delete_first_key([], _key), do: throw(:not_deleted)
+  defp delete_first_key([{key, _} | tail], key) do
+    tail
+  end
+
+  defp delete_first_key([{_, _} = pair | tail], key) do
+    [pair | delete_first_key(tail, key)]
+  end
+
+  defp delete_first_key([], _key) do
+    []
+  end
 
   @doc """
   Puts the given `value` under `key`.


### PR DESCRIPTION
Calling [`Keyword.put/3`](https://github.com/elixir-lang/elixir/blob/e9dfa50c74488000d2c9de71e926cdd78609b3ac/lib/elixir/lib/keyword.ex#L553-L556), [`Keyword.delete/2`](https://github.com/elixir-lang/elixir/blob/e9dfa50c74488000d2c9de71e926cdd78609b3ac/lib/elixir/lib/keyword.ex#L497-L503), and other related functions changes the stacktrace returned from [`:erlang.get_stacktrace/0`](http://erlang.org/doc/man/erlang.html#get_stacktrace-0).

This is due to the throw/catch pattern used in the implementation of these functions.

This pull request helps prevent the following scenario and associated developer confusion:

```elixir
options = []
{exception, options} =
  try do
    :lists.last([])
  catch
    class, reason ->
      options = Keyword.put(options, :reason, reason)
      exception = Exception.normalize(class, reason)
      {exception, options}
  end
exception == %FunctionClauseError{
  args: nil,
  arity: 3,
  clauses: nil,
  function: :delete_key,
  kind: nil,
  module: Keyword
}
```

Notice that the `module`, `function`, and `arity` for the `FunctionClauseError` is `Keyword.delete_key/3` instead of `:lists.last/1`.

In "property test form", the problem could be represented with the following example:

```elixir
try do
  :lists.last([])
rescue _ ->
  frame1 = hd(System.stacktrace())
  _ = Keyword.delete([], :key)
  frame2 = hd(System.stacktrace())
  frame1 == frame2 # currently, this is false, but this pull request changes that
end
```

#### Why does this matter?

Good question...?  It might not.

I ran into this problem initially while using [`sentry-elixir`](https://github.com/getsentry/sentry-elixir) and was confused to see messages logged as `(FunctionClauseError) no function clause matching in Keyword.delete_key/3` instead of `(FunctionClauseError) no function clause matching in MyModule.real_function/1`.

The [fix](https://github.com/potatosalad/sentry-elixir/commit/2ee4c57d7085b5c211cdaff0911cac3720b5f02e) involved simply passing the already captured `stacktrace` to [`Exception.normalize/3`](https://github.com/elixir-lang/elixir/blob/27f046321d8fe7e320cf8e0665d41d908f97a106/lib/elixir/lib/exception.ex#L97-L109).  I still wondered, however, where the `Keyword.delete_key/3` was coming from and decided to keep digging.

The [current implementation](https://github.com/elixir-lang/elixir/blob/e9dfa50c74488000d2c9de71e926cdd78609b3ac/lib/elixir/lib/keyword.ex#L467-L468) of `Keyword.delete/2` (and some other related functions) uses the throw/catch pattern to short-circuit for cases when the given key is not present within a list.  Since [`Keyword.put/3`](https://github.com/elixir-lang/elixir/blob/e9dfa50c74488000d2c9de71e926cdd78609b3ac/lib/elixir/lib/keyword.ex#L555) calls `Keyword.delete/2`, the stacktrace will be corrupted for lists where the key being "put" is not yet present.

I was hesitant to even submit this pull request due to the changes in syntax coming in OTP 21 related to catching errors and stacktraces.  And really, as a developer if the _first thing_ you do after a `catch` doesn't involve running `:erlang.get_stacktrace()` there's really no guarantee that some other call won't have corrupted the stacktrace by the time you get around to asking for it.

However, I do think this behavior is fairly confusing and is non-obvious where the stacktrace change is actually coming from.

So...

¯\\\_(ツ)\_/¯

#### A few options...

Therefore, I set out to undo all of the hard work @michalmuskala contributed with elixir-lang/elixir#6564 and possibly find a happy solution for everyone.

*TL;DR* This pull request currently contains an implementation described below as [`delete_v2/2`](https://gist.github.com/potatosalad/f4fea8490bea09eb000a3a346a52cb6e#file-keyword_delete_bench-ex-L245-L260).  Alternatively, [`delete_v3/2`](https://gist.github.com/potatosalad/f4fea8490bea09eb000a3a346a52cb6e#file-keyword_delete_bench-ex-L262-L280) has some pros/cons that might make it the preferred implementation.

I put together a very rough module to help measure the difference in time, reductions, and garbage collected heap bytes: https://gist.github.com/potatosalad/f4fea8490bea09eb000a3a346a52cb6e

Here's part of the output:

```
## count=100000, size=10
[h] delete_v0/2:     1.60 μs (avg),   344.05 gc/μs (avg),    41.04 reds/μs (avg)
[m] delete_v0/2:     1.82 μs (avg),   311.45 gc/μs (avg),    38.56 reds/μs (avg)
[h] delete_v1/2:     2.14 μs (avg),   232.09 gc/μs (avg),    19.50 reds/μs (avg)
[m] delete_v1/2:     1.19 μs (avg),   397.58 gc/μs (avg),    16.42 reds/μs (avg)
[h] delete_v2/2:     1.12 μs (avg),   569.17 gc/μs (avg),    17.59 reds/μs (avg)
[m] delete_v2/2:     1.44 μs (avg),   467.06 gc/μs (avg),    16.72 reds/μs (avg)
[h] delete_v3/2:     1.55 μs (avg),   413.40 gc/μs (avg),    16.92 reds/μs (avg)
[m] delete_v3/2:     1.02 μs (avg),   344.93 gc/μs (avg),     5.99 reds/μs (avg)
## count=100000, size=100
[h] delete_v0/2:     7.39 μs (avg),   269.51 gc/μs (avg),    71.53 reds/μs (avg)
[m] delete_v0/2:     7.11 μs (avg),   282.24 gc/μs (avg),    72.44 reds/μs (avg)
[h] delete_v1/2:     3.95 μs (avg),   489.96 gc/μs (avg),    96.15 reds/μs (avg)
[m] delete_v1/2:     2.41 μs (avg),   195.41 gc/μs (avg),    57.20 reds/μs (avg)
[h] delete_v2/2:     3.51 μs (avg),  1003.66 gc/μs (avg),    59.73 reds/μs (avg)
[m] delete_v2/2:     3.46 μs (avg),  1025.16 gc/μs (avg),    60.34 reds/μs (avg)
[h] delete_v3/2:     3.62 μs (avg),   971.51 gc/μs (avg),    55.39 reds/μs (avg)
[m] delete_v3/2:     1.02 μs (avg),   343.82 gc/μs (avg),     5.98 reds/μs (avg)
## count=100000, size=10000
[h] delete_v0/2:   312.93 μs (avg),   512.56 gc/μs (avg),   130.60 reds/μs (avg)
[m] delete_v0/2:   321.35 μs (avg),   499.19 gc/μs (avg),   128.00 reds/μs (avg)
[h] delete_v1/2:   138.01 μs (avg),  1161.84 gc/μs (avg),   149.91 reds/μs (avg)
[m] delete_v1/2:   150.13 μs (avg),     3.17 gc/μs (avg),    68.16 reds/μs (avg)
[h] delete_v2/2:   126.68 μs (avg),  2234.20 gc/μs (avg),    94.37 reds/μs (avg)
[m] delete_v2/2:   126.99 μs (avg),  2228.79 gc/μs (avg),    93.90 reds/μs (avg)
[h] delete_v3/2:   154.80 μs (avg),  1828.32 gc/μs (avg),    75.68 reds/μs (avg)
[m] delete_v3/2:    21.35 μs (avg),    16.67 gc/μs (avg),     0.29 reds/μs (avg)
```

| Symbol | Description |
|--------|-------------|
| `[h]`  | "hit" test where the very last element of a list was deleted |
| `[m]`  | "miss" test where no elements were deleted |
| `gc/μs` | the total(-ish) heap bytes garbage collected across all iterations divided by total time |
| `reds/μs` | the total reductions counted across all iterations divided by total time |

Here's a summary of the different `delete/2` implementations:

| Function | Description | Pros | Cons |
|----------|-------------|------|------|
| [`delete_v0/2`](https://gist.github.com/potatosalad/f4fea8490bea09eb000a3a346a52cb6e#file-keyword_delete_bench-ex-L225-L228) | Uses [`lists:filter/2`](http://erlang.org/doc/man/lists.html#filter-2) to remove `key` (on `master` previously) | Memory Efficient | Slow for "hit" and "miss" |
| [`delete_v1/2`](https://gist.github.com/potatosalad/f4fea8490bea09eb000a3a346a52cb6e#file-keyword_delete_bench-ex-L230-L243) | Uses throw/catch (on `master` now) | Faster than `delete_v0/2` for "hit" and "miss", More Memory Efficient for "miss" | Corrupts stacktrace, Slower than `delete_v2/2` and `delete_v3/2` for "miss" |
| [`delete_v2/2`](https://gist.github.com/potatosalad/f4fea8490bea09eb000a3a346a52cb6e#file-keyword_delete_bench-ex-L245-L260) | Uses [`:lists.reverse/1,2`](http://erlang.org/doc/man/lists.html#reverse-1) and simple recursion (the version in this PR) | Faster than `delete_v1/2` for large lists | Less Memory Efficient |
| [`delete_v3/2`](https://gist.github.com/potatosalad/f4fea8490bea09eb000a3a346a52cb6e#file-keyword_delete_bench-ex-L262-L280) | Same as `delete_v2/2` with short-circuit BIF [`:lists.keymember/3`](http://erlang.org/doc/man/lists.html#keymember-3) | Fastest on "miss", Moderately Memory Efficient | Slightly slower than `delete_v2/2` on "hit" for large lists |

Also, for the curious, I put together a [native C implementation](https://github.com/potatosalad/erlang-nativelists) to see if I could achieve better performance, but was unsuccessful:

```
## count=100000, size=10
[h] delete_na/2:     2.97 μs (avg),   166.02 gc/μs (avg),     2.85 reds/μs (avg)
[m] delete_na/2:     2.49 μs (avg),   205.61 gc/μs (avg),     3.08 reds/μs (avg)
## count=100000, size=100
[h] delete_na/2:     5.28 μs (avg),   358.11 gc/μs (avg),     2.70 reds/μs (avg)
[m] delete_na/2:     6.37 μs (avg),   278.72 gc/μs (avg),     2.52 reds/μs (avg)
## count=100000, size=10000
[h] delete_na/2:   172.08 μs (avg),   853.65 gc/μs (avg),     3.50 reds/μs (avg)
[m] delete_na/2:   143.41 μs (avg),   862.68 gc/μs (avg),     3.84 reds/μs (avg)
```