### PR TITLE
Deprecate Exception.normalize/2 and Exception.format/2 

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -92,8 +92,7 @@ defmodule Exception do
   @spec normalize(:error, any, stacktrace) :: t
   @spec normalize(non_error_kind, payload, stacktrace) :: payload when payload: var
 
-  # Generating a stacktrace is expensive, default to nil
-  # to only fetch it when needed.
+  @deprecated "Use normalize/3 instead"
   def normalize(kind, payload, stacktrace \\ nil)
 
   def normalize(:error, exception, stacktrace) do
@@ -151,6 +150,8 @@ defmodule Exception do
   (as they are retrieved as messages without stacktraces).
   """
   @spec format(kind, any, stacktrace | nil) :: String.t()
+
+  @deprecated "Use format/3 instead"
   def format(kind, payload, stacktrace \\ nil)
 
   def format({:EXIT, _} = kind, any, _) do

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -349,14 +349,14 @@ defmodule ExUnit.Runner do
   defp failed(:error, %ExUnit.MultiError{errors: errors}, _stack) do
     errors =
       Enum.map(errors, fn {kind, reason, stack} ->
-        {kind, Exception.normalize(kind, reason), prune_stacktrace(stack)}
+        {kind, Exception.normalize(kind, reason, []), prune_stacktrace(stack)}
       end)
 
     {:failed, errors}
   end
 
   defp failed(kind, reason, stack) do
-    {:failed, [{kind, Exception.normalize(kind, reason), stack}]}
+    {:failed, [{kind, Exception.normalize(kind, reason, []), stack}]}
   end
 
   defp pruned_stacktrace, do: prune_stacktrace(System.stacktrace())


### PR DESCRIPTION
Changes for Issue #7626 

As a first step I only set the `@deprecated` and changed to call `Exception.normalize` in module `ExUnit.Runner` according to the documentation to `[]`

I'm not 100% that's all work to do, please give me a feedback if something is missing e.g. change the documentation or I misunderstood the issue completely.