### PR TITLE
Provide better warnings when grouping multi clause functions

### DIFF
--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -301,8 +301,12 @@ check_valid_kind(Meta, File, Name, Arity, Kind, StoredKind) ->
 
 check_valid_clause(Meta, File, Name, Arity, Kind, Set, StoredMeta, StoredFile) ->
   case ets:lookup_element(Set, ?last_def, 2) of
-    {Name, Arity} -> ok;
     none -> ok;
+    {Name, Arity} -> ok;
+    {Name, OtherArity} ->
+      Relative = elixir_utils:relative_to_cwd(StoredFile),
+      elixir_errors:form_warn(Meta, File, ?MODULE,
+        {grouped_clause, {Kind, Name, OtherArity, ?line(StoredMeta), Relative}});
     _ ->
       Relative = elixir_utils:relative_to_cwd(StoredFile),
       elixir_errors:form_warn(Meta, File, ?MODULE,

--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -303,14 +303,14 @@ check_valid_clause(Meta, File, Name, Arity, Kind, Set, StoredMeta, StoredFile) -
   case ets:lookup_element(Set, ?last_def, 2) of
     none -> ok;
     {Name, Arity} -> ok;
-    {Name, OtherArity} ->
+    {Name, _} ->
       Relative = elixir_utils:relative_to_cwd(StoredFile),
       elixir_errors:form_warn(Meta, File, ?MODULE,
-        {grouped_clause, {Kind, Name, OtherArity, ?line(StoredMeta), Relative}});
+        {ungrouped_name, {Kind, Name, Arity, ?line(StoredMeta), Relative}});
     _ ->
       Relative = elixir_utils:relative_to_cwd(StoredFile),
       elixir_errors:form_warn(Meta, File, ?MODULE,
-        {ungrouped_clause, {Kind, Name, Arity, ?line(StoredMeta), Relative}})
+        {ungrouped_arity, {Kind, Name, Arity, ?line(StoredMeta), Relative}})
   end.
 
 % Clause with defaults after clause with defaults
@@ -400,13 +400,13 @@ format_error({clauses_with_defaults, {Kind, Name, Arity}}) ->
     "\n"
    "~ts ~ts/~B has multiple clauses and defines defaults in one or more clauses", [Kind, Name, Arity]);
 
-format_error({grouped_clause, {Kind, Name, _OtherArity, OrigLine, OrigFile}}) ->
-   io_lib:format("clauses with the same name should be grouped together, ~ts ~ts was previously defined (~ts:~B)",
-     [Kind, Name, OrigFile, OrigLine]);
+format_error({ungrouped_name, {Kind, Name, Arity, OrigLine, OrigFile}}) ->
+   io_lib:format("clauses with the same name should be grouped together, \"~ts ~ts/~B\" was previously defined (~ts:~B)",
+     [Kind, Name, Arity, OrigFile, OrigLine]);
 
-format_error({ungrouped_clause, {Kind, Name, Arity, OrigLine, OrigFile}}) ->
-  io_lib:format("clauses for the same ~ts should be grouped together, ~ts ~ts/~B was previously defined (~ts:~B)",
-    [Kind, Kind, Name, Arity, OrigFile, OrigLine]);
+format_error({ungrouped_arity, {Kind, Name, Arity, OrigLine, OrigFile}}) ->
+  io_lib:format("clauses with the same name and arity (number of arguments) should be grouped together, \"~ts ~ts/~B\" was previously defined (~ts:~B)",
+    [Kind, Name, Arity, OrigFile, OrigLine]);
 
 format_error({changed_kind, {Name, Arity, Previous, Current}}) ->
   io_lib:format("~ts ~ts/~B already defined as ~ts", [Current, Name, Arity, Previous]);

--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -400,6 +400,10 @@ format_error({clauses_with_defaults, {Kind, Name, Arity}}) ->
     "\n"
    "~ts ~ts/~B has multiple clauses and defines defaults in one or more clauses", [Kind, Name, Arity]);
 
+format_error({grouped_clause, {Kind, Name, _OtherArity, OrigLine, OrigFile}}) ->
+   io_lib:format("clauses with the same name should be grouped together, ~ts ~ts was previously defined (~ts:~B)",
+     [Kind, Name, OrigFile, OrigLine]);
+
 format_error({ungrouped_clause, {Kind, Name, Arity, OrigLine, OrigFile}}) ->
   io_lib:format("clauses for the same ~ts should be grouped together, ~ts ~ts/~B was previously defined (~ts:~B)",
     [Kind, Kind, Name, Arity, OrigFile, OrigLine]);

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -960,7 +960,22 @@ defmodule Kernel.WarningTest do
     purge([Sample1, Sample1.Atom])
   end
 
-  test "overridden def" do
+  test "overridden def just name" do
+    assert capture_err(fn ->
+             Code.eval_string("""
+             defmodule Sample do
+               def foo(x, 1), do: x + 1
+               def foo(), do: nil
+               def foo(x, 2), do: x * 2
+             end
+             """)
+           end) =~
+             "clauses with the same name should be grouped together, def foo was previously defined (nofile:2)"
+  after
+    purge(Sample)
+  end
+
+  test "overridden def name and arity" do
     assert capture_err(fn ->
              Code.eval_string("""
              defmodule Sample do

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -970,7 +970,7 @@ defmodule Kernel.WarningTest do
              end
              """)
            end) =~
-             "clauses with the same name should be grouped together, def foo was previously defined (nofile:2)"
+             "clauses with the same name should be grouped together, \"def foo/2\" was previously defined (nofile:2)"
   after
     purge(Sample)
   end
@@ -985,7 +985,7 @@ defmodule Kernel.WarningTest do
              end
              """)
            end) =~
-             "clauses for the same def should be grouped together, def foo/2 was previously defined (nofile:2)"
+             "clauses with the same name and arity (number of arguments) should be grouped together, \"def foo/2\" was previously defined (nofile:2)"
   after
     purge(Sample)
   end

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -960,7 +960,7 @@ defmodule Kernel.WarningTest do
     purge([Sample1, Sample1.Atom])
   end
 
-  test "overridden def just name" do
+  test "overridden def name" do
     assert capture_err(fn ->
              Code.eval_string("""
              defmodule Sample do


### PR DESCRIPTION
##  Chore 
Relates #7512 
Providing a separate warning for cases where just the function name matches rather than the default warning. 

##  Test Plan 
Added a new unit test to cover the new  case

## Notes
I left the new arity of the function in the arguments in case we need to use it in the warning to the user


