### PR TITLE
Add internal links to sections

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -464,7 +464,7 @@ defmodule DynamicSupervisor do
   Receives a set of options that initializes a dynamic supervisor.
 
   This is typically invoked at the end of the `c:init/1` callback of
-  module-based supervisors. See the sections "Module-based supervisors"
+  module-based supervisors. See the section ["Module-based supervisors"](#module-module-based-supervisors)
   in the module documentation for more information.
 
   The options received by this function are also supported by `start_link/2`.

--- a/lib/elixir/lib/gen_event.ex
+++ b/lib/elixir/lib/gen_event.ex
@@ -7,7 +7,7 @@ defmodule GenEvent do
   WARNING: this module is deprecated.
 
   If you are interested in implementing an event manager, please read the
-  "Alternatives" section below. If you have to implement an event handler to
+  ["Alternatives" section](#module-alternatives) below. If you have to implement an event handler to
   integrate with an existing system, such as Elixir's Logger, please use
   `:gen_event` instead.
 

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -741,8 +741,8 @@ defmodule GenServer do
 
   ## Options
 
-    * `:name` - used for name registration as described in the "Name
-      registration" section of the module documentation
+    * `:name` - used for name registration as described in the ["Name
+      registration" section](#module-name-registration) of the module documentation
 
     * `:timeout` - if present, the server is allowed to spend the given number of
       milliseconds initializing or it will be terminated and the start function

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2375,7 +2375,7 @@ defmodule Kernel do
       get_and_update_in(opts, [:foo, :bar], &{&1, &1 + 1})
 
   Note that in order for this macro to work, the complete path must always
-  be visible by this macro. See the Paths section below.
+  be visible by this macro. See the ["Paths" section](#module-paths) below.
 
   ## Examples
 
@@ -4310,7 +4310,7 @@ defmodule Kernel do
 
   It is possible to implement protocols for all Elixir types:
 
-    * Structs (see below)
+    * Structs ([see below](#defprotocol/2-protocols-and-structs))
     * `Tuple`
     * `Atom`
     * `List`
@@ -4322,7 +4322,7 @@ defmodule Kernel do
     * `Map`
     * `Port`
     * `Reference`
-    * `Any` (see below)
+    * `Any` ([see below](#defprotocol/2-fallback-to-any))
 
   ## Protocols and Structs
 

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -772,7 +772,7 @@ defmodule Kernel.SpecialForms do
       inside another quote and want to control what quote is able to unquote.
 
     * `:location` - when set to `:keep`, keeps the current line and file from
-      quote. Read the Stacktrace information section below for more
+      quote. Read the ["Stacktrace information" section](#module-stacktrace-information) below for more
       information.
 
     * `:line` - sets the quoted expressions to have the given line.

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -18,14 +18,14 @@ defmodule Module do
   ### `@after_compile`
 
   A hook that will be invoked right after the current module is compiled.
-  Accepts a module or a `{module, function_name}`. See the "Compile callbacks"
-  section below.
+  Accepts a module or a `{module, function_name}`. See the ["Compile callbacks"
+  section](#module-compile-callbacks) below.
 
   ### `@before_compile`
 
   A hook that will be invoked before the module is compiled.
   Accepts a module or a `{module, function_or_macro_name}` tuple.
-  See the "Compile callbacks" section below.
+  See the ["Compile callbacks" section](#module-compile-callbacks) below.
 
   ### `@behaviour` (notice the British spelling)
 
@@ -107,7 +107,7 @@ defmodule Module do
       end
 
   Multiple uses of `@compile` will accumulate instead of overriding
-  previous ones. See the "Compile options" section below.
+  previous ones. See the ["Compile options" section](#module-compile-options) below.
 
   ### `@deprecated`
 
@@ -222,7 +222,7 @@ defmodule Module do
   module is defined. Useful when annotating functions.
 
   Accepts a module or a `{module, function_name}` tuple. See the
-  "Compile callbacks" section below.
+  ["Compile callbacks" section](#module-compile-callbacks) below.
 
   ### `@on_load`
 

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -20,7 +20,7 @@ defmodule OptionParser do
     * `parsed` is a keyword list of parsed switches with `{switch_name, value}`
       tuples in it; `switch_name` is the atom representing the switch name while
       `value` is the value for that switch parsed according to `opts` (see the
-      "Examples" section for more information)
+      ["Examples" section](#parse/2-examples) for more information)
     * `args` is a list of the remaining arguments in `argv` as strings
     * `invalid` is a list of invalid options as `{option_name, value}` where
       `option_name` is the raw option and `value` is `nil` if the option wasn't
@@ -50,9 +50,9 @@ defmodule OptionParser do
 
   The following options are supported:
 
-    * `:switches` or `:strict` - see the "Switch definitions" section below
-    * `:allow_nonexistent_atoms` - see the "Parsing unknown switches" section below
-    * `:aliases` - see the "Aliases" section below
+    * `:switches` or `:strict` - see the ["Switch definitions" section](#module-switch-definitions) below
+    * `:allow_nonexistent_atoms` - see the ["Parsing unknown switches" section](#module-parsing-unknown-switches) below
+    * `:aliases` - see the ["Aliases" section](#module-aliases) below
 
   ## Switch definitions
 
@@ -65,7 +65,7 @@ defmodule OptionParser do
 
   Both these options accept a keyword list of `{name, type}` tuples where `name`
   is an atom defining the name of the switch and `type` is an atom that
-  specifies the type for the value of this switch (see the "Types" section below
+  specifies the type for the value of this switch (see the ["Types" section](#module-types) below
   for the possible types and more information about type casting).
 
   Note that you should only supply the `:switches` or the`:strict` option.
@@ -78,7 +78,7 @@ defmodule OptionParser do
   The following switches types take no arguments:
 
     * `:boolean` - sets the value to `true` when given (see also the
-      "Negation switches" section below)
+      ["Negation switches" section](#module-negation_switches) below)
     * `:count` - counts the number of times the switch is given
 
   The following switches take one argument:

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -17,7 +17,7 @@ defmodule Regex do
 
   Regular expressions created via sigils are pre-compiled and stored
   in the `.beam` file. Notice this may be a problem if you are precompiling
-  Elixir, see the "Precompilation" section for more information.
+  Elixir, see the ["Precompilation" section](#module-precompilation) for more information.
 
   A Regex is represented internally as the `Regex` struct. Therefore,
   `%Regex{}` can be used whenever there is a need to match on them.

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -407,7 +407,7 @@ defmodule Registry do
   given as an option, the dispatching happens in parallel. In both cases,
   the callback is only invoked if there are entries for that partition.
 
-  See the module documentation for examples of using the `dispatch/3`
+  See the [module documentation](Registry) for examples of using the `dispatch/3`
   function for building custom dispatching or a pubsub system.
   """
   @since "1.4.0"

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1246,7 +1246,7 @@ defmodule String do
   The `pattern` may be a string or a regular expression.
 
   By default it replaces all occurrences but this behaviour can be controlled
-  through the `:global` option; see the "Options" section below.
+  through the `:global` option; see the options below.
 
   ## Options
 

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -159,11 +159,11 @@ defmodule Supervisor do
       to start the child process. This key is required.
 
     * `:restart` - an atom that defines when a terminated child process
-       should be restarted (see the "Restart values" section below).
+       should be restarted (see the ["Restart values" section](#module-restart-values) below).
        This key is optional and defaults to `:permanent`.
 
     * `:shutdown` - an atom that defines how a child process should be
-      terminated (see the "Shutdown values" section below). This key
+      terminated (see the ["Shutdown values" section](#module-shutdown-values) below). This key
       is optional and defaults to `5000` if the type is `:worker` or
       `:infinity` if the type is `:supervisor`.
 
@@ -220,7 +220,7 @@ defmodule Supervisor do
       `:normal`, `:shutdown`, or `{:shutdown, term}`.
 
   For a more complete understanding of the exit reasons and their
-  impact, see the "Exit reasons and restarts" section.
+  impact, see the ["Exit reasons and restarts" section](#module-exit-reasons-and-restarts).
 
   ## child_spec/1
 
@@ -408,7 +408,7 @@ defmodule Supervisor do
   be either:
 
     * a map representing the child specification itself - as outlined in the
-      "Child specification" section
+      ["Child specification" section](#module-child-specification)
     * a tuple with a module as first element and the start argument as second -
       such as `{Stack, [:hello]}`. In this case, `Stack.child_spec([:hello])`
       is called to retrieve the child specification
@@ -419,7 +419,7 @@ defmodule Supervisor do
 
     * `:strategy` - the restart strategy option. It can be either
       `:one_for_one`, `:rest_for_one` or `:one_for_all`. Required.
-      See the "Strategies" section.
+      See the ["Strategies" section](#module-strategies).
 
     * `:max_restarts` - the maximum number of restarts allowed in
       a time frame. Defaults to `3`.
@@ -447,7 +447,7 @@ defmodule Supervisor do
       the child processes, i.e., the child processes after the terminated
       one in start order, are terminated. Then the terminated child
       process and the rest of the child processes are restarted.
-      
+
   In the above, process termination refers to unsuccessful termination, which
   is determined by the `:restart` option.
 
@@ -584,8 +584,8 @@ defmodule Supervisor do
   Receives a list of children to initialize and a set of options.
 
   This is typically invoked at the end of the `c:init/1` callback of
-  module-based supervisors. See the sections "Module-based supervisors"
-  and "start_link/2, init/2 and strategies" in the module
+  module-based supervisors. See the sections ["Module-based supervisors"](#module-module-based-supervisors)
+  and ["start_link/2, init/2 and strategies"](#module-start_link-2-init-2-and-strategies) in the module
   documentation for more information.
 
   This function returns a tuple containing the supervisor
@@ -720,7 +720,7 @@ defmodule Supervisor do
   are directly applied on the child spec. If `config` has keys that
   do not map to any child specification field, an error is raised.
 
-  See the "Child specification" section in the module documentation
+  See the ["Child specification" section](#module-child-specification) in the module documentation
   for all of the available keys for overriding.
 
   ## Examples

--- a/lib/elixir/lib/supervisor/spec.ex
+++ b/lib/elixir/lib/supervisor/spec.ex
@@ -59,10 +59,10 @@ defmodule Supervisor.Spec do
     * `:function` - the function to invoke on the child to start it
 
     * `:restart` - an atom that defines when a terminated child process should
-      be restarted (see the "Restart values" section below)
+      be restarted (see the ["Restart values" section](#module-restart-values) below)
 
     * `:shutdown` - an atom that defines how a child process should be
-      terminated (see the "Shutdown values" section below)
+      terminated (see the ["Shutdown values" section](#module-shutdown-values) below)
 
     * `:modules` - it should be a list with one element `[module]`,
       where module is the name of the callback module only if the
@@ -186,7 +186,8 @@ defmodule Supervisor.Spec do
     raise ArgumentError,
           "invalid tuple specification given to supervise/2. If you are trying to use " <>
             "the map child specification that is part of the Elixir v1.5, use Supervisor.init/2 " <>
-            "instead of Supervisor.Spec.supervise/2. See the Supervisor module for more information. " <>
+            "instead of Supervisor.Spec.supervise/2. See the documentation for the Supervisor " <>
+            "module for more information. " <>
             "Got: #{inspect(other)}"
   end
 

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -552,7 +552,7 @@ defmodule System do
   ports guarantee stdin/stdout devices will be closed but it does not
   automatically terminate the program. The documentation for the
   `Port` module describes this problem and possible solutions under
-  the "Zombie processes" section.
+  the ["Zombie processes" section](#module-zombie-processes).
 
   ## Examples
 

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -376,7 +376,7 @@ defmodule URI do
   Parses a well-formed URI reference into its components.
 
   Note this function expects a well-formed URI and does not perform
-  any validation. See the "Examples" section below for examples of how
+  any validation. See the ["Examples" section](#parse/1-examples) below for examples of how
   `URI.parse/1` can be used to parse a wide range of URIs.
 
   This function uses the parsing regular expression as defined

--- a/lib/elixir/pages/Guards.md
+++ b/lib/elixir/pages/Guards.md
@@ -60,7 +60,7 @@ For reference, the following is a comprehensive list of all expressions allowed 
     * [`bsr/2`](`Bitwise.bsr/2`) or the [`>>>`](`Bitwise.>>>/2`) operator
     * [`bxor/2`](`Bitwise.bxor/2`) or the [`^^^`](`Bitwise.^^^/2`) operator
 
-Macros constructed out of any combination of the above guards are also valid guards - for example, `Integer.is_even/1`. See the section "Defining custom guard expressions" below.
+Macros constructed out of any combination of the above guards are also valid guards - for example, `Integer.is_even/1`. See the ["Defining custom guard expressions" section](#defining-custom-guard-expressions) below.
 
 ## Why guards
 

--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -14,7 +14,7 @@ Type specifications (sometimes referred to as *typespecs*) are defined in differ
   * `@callback`
   * `@macrocallback`
 
-See the "User-defined types" and "Defining a specification" sub-sections below for more information on defining types and typespecs.
+See the ["User-defined types"](#user-defined-types) and ["Defining a specification"](#defining-a-specification) sub-sections below for more information on defining types and typespecs.
 
 ## A simple example
 

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -21,7 +21,7 @@ defmodule ExUnit.Case do
       Defaults to `false`.
 
   This module automatically includes all callbacks defined in
-  `ExUnit.Callbacks`. See that module for more information on `setup`,
+  `ExUnit.Callbacks`. See [that module](`ExUnit.Callbacks`) for more information on `setup`,
   `start_supervised`, `on_exit` and the test process lifecycle.
 
   For grouping tests together, see `describe/2` in this module.
@@ -150,7 +150,7 @@ defmodule ExUnit.Case do
 
   The following tags customize how tests behave:
 
-    * `:capture_log` - see the "Log Capture" section below
+    * `:capture_log` - see the ["Log Capture" section](#module-log-capture) below
     * `:skip` - skips the test with the given reason
     * `:timeout` - customizes the test timeout in milliseconds (defaults to 60000)
 

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -71,7 +71,7 @@ defmodule Logger do
   `config/config.exs`) before the `:logger` application is started.
 
     * `:backends` - the backends to be used. Defaults to `[:console]`.
-      See the "Backends" section for more information.
+      See the ["Backends" section](#module-backends) for more information.
 
     * `:compile_time_purge_level` - purges *at compilation time* all calls that
       have log level lower than the value of this option. This means that
@@ -503,7 +503,7 @@ defmodule Logger do
   @doc """
   Configures the logger.
 
-  See the "Runtime Configuration" section in the `Logger` module
+  See the ["Runtime Configuration" section](#module-runtime-configuration) in the `Logger` module
   documentation for the available options.
   """
   @valid_options [

--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -24,7 +24,7 @@ defmodule Logger.Translator do
     * `:skip` - if the message is not meant to be translated nor logged
     * `:none` - if there is no translation, which triggers the next translator
 
-  See the function `translate/4` in this module for an example implementation
+  See `translate/4` in this module for an example implementation
   and the default messages translated by Logger.
   """
 

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -60,8 +60,8 @@ defmodule Mix.Tasks.Compile.App do
       module.
 
     * `:start_phases` - specifies a list of phases and their arguments
-      to be called after the application is started. See the "Phases"
-      section below.
+      to be called after the application is started. See the ["Phases"
+      section](#module-phases) below.
 
     * `:included_applications` - specifies a list of applications
       that will be included in the application. It is the responsibility of

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -41,11 +41,12 @@ defmodule Mix.Tasks.Format do
     * `:import_deps` (a list of dependencies as atoms) - specifies a list
        of dependencies whose formatter configuration will be imported.
        When specified, the formatter should run in the same directory as
-       the `mix.exs` file that defines those dependencies. See the "Importing
-       dependencies configuration" section below for more information.
+       the `mix.exs` file that defines those dependencies. See the ["Importing
+       dependencies configuration" section](#module-importing-dependencies-configuration) below for more information.
 
     * `:export` (a keyword list) - specifies formatter configuration to be exported.
-      See the "Importing dependencies configuration" section below.
+      See the ["Importing
+       dependencies configuration" section](#module-importing-dependencies-configuration) below for more information.
 
   ## Task-specific options
 

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -74,7 +74,7 @@ defmodule Mix.Tasks.Test do
     * `--slowest` - prints timing information for the N slowest tests
       Automatically sets `--trace` and `--preload-modules`
     * `--stale` - runs only tests which reference modules that changed since the
-      last `test --stale`. You can read more about this option in the "Stale" section below.
+      last `test --stale`. You can read more about this option in the ["Stale" section](#module-stale) below.
     * `--failed` - runs only tests that failed the last time they ran
     * `--timeout` - sets the timeout for the tests
     * `--trace` - runs tests with detailed reporting; automatically sets `--max-cases` to 1


### PR DESCRIPTION
This makes more fluid the navigation of the Elixir docs, but it will look weird in IEx

the following code:

    Note that in order for this macro to work, the complete path must always be
    visible by this macro. See the ["Paths" section](#module-paths) below.

will render in IEx:

    Note that in order for this macro to work, the complete path must always be
    visible by this macro. See the "Paths" section (#module-paths) below.

I think we should do something in IEx to deal with this kind of links when not being able to link