### PR TITLE
keys and values of decoded query are always binary

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -128,7 +128,7 @@ defmodule URI do
       %{"percent" => "oh yes!", "starting" => "map"}
 
   """
-  @spec decode_query(binary, map) :: map
+  @spec decode_query(binary, %{binary => binary}) :: %{binary => binary}
   def decode_query(query, map \\ %{})
 
   # TODO: Remove on 2.0


### PR DESCRIPTION
I have warnings that dialyzer could have picked up because when taking values for the map it assumes they can be of any term.