### PR TITLE
Changes wording.

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -456,8 +456,8 @@ defmodule String do
   @doc """
   Returns an enumerable that splits a string on demand.
 
-  This is in contrast to `split/3` which splits all
-  the string upfront.
+  This is in contrast to `split/3` which splits the
+  entire string upfront.
 
   Note splitter does not support regular expressions
   (as it is often more efficient to have the regular


### PR DESCRIPTION
"the entire string" is more idiomatic than "all the string"