### PR TITLE
Normalize trace config docs for Mix.Tasks.Test

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -77,7 +77,10 @@ defmodule Mix.Tasks.Test do
       last `test --stale`. You can read more about this option in the "Stale" section below.
     * `--failed` - runs only tests that failed the last time they ran
     * `--timeout` - sets the timeout for the tests
-    * `--trace` - runs tests with detailed reporting; automatically sets `--max-cases` to 1
+    * `--trace` - runs tests with detailed reporting; automatically sets `--max-cases` to 1.
+      Note that in trace mode test timeouts will be ignored.
+
+  See `ExUnit.configure/1` for more information on configuration options.
 
   ## Filters
 


### PR DESCRIPTION
I noticed this while reading though some of the source code, was surprised it wasn't documented, then  realized it was in fact documented, but not in the place I had first looked.