### PR TITLE
Add support for "rescue var not in [Exprs]"

### DIFF
--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -1850,6 +1850,21 @@ defmodule Kernel.ExpansionTest do
         expand(code)
       end
     end
+
+    test "doesn't allow \"var not in _\"" do
+      assert_raise CompileError, ~r"invalid \"rescue\" clause. \"_\" is not allowed", fn ->
+        code =
+          quote do
+            try do
+              e
+            rescue
+              x not in _ -> :ok
+            end
+          end
+
+        expand(code)
+      end
+    end
   end
 
   describe "bitstrings" do

--- a/lib/elixir/test/elixir/kernel/raise_test.exs
+++ b/lib/elixir/test/elixir/kernel/raise_test.exs
@@ -263,6 +263,50 @@ defmodule Kernel.RaiseTest do
 
       assert result == "an exception"
     end
+
+    test "\"not in\" with named runtime error" do
+      result =
+        try do
+          raise "an exception"
+        rescue
+          x not in [ArgumentError] -> Exception.message(x)
+        catch
+          :error, _ -> false
+        end
+
+      assert result == "an exception"
+
+      result =
+        try do
+          raise "an exception"
+        rescue
+          _x not in [ArgumentError] -> true
+        catch
+          :error, _ -> false
+        end
+
+      assert result
+
+      result =
+        try do
+          raise "an exception"
+        rescue
+          _x not in [RuntimeError] -> false
+          x -> Exception.message(x)
+        end
+
+      assert result == "an exception"
+
+      result =
+        try do
+          raise "an exception"
+        rescue
+          _x not in [ArgumentError, RuntimeError] -> false
+          x -> Exception.message(x)
+        end
+
+      assert result == "an exception"
+    end
   end
 
   describe "normalize" do


### PR DESCRIPTION
Addresses #7627.

This is a first stab. The idea is that instead of compiling `in` to a list of guards (that in Erlang AST are equivalent to `Guard1; Guard2; ...`), we build a big chain of `orelse`s as in `Guard1 orelse Guard2`. This way we can implement `not in [Exprs]` by just negating the chain of `orelse`s.

I'm also raising an error for `var not in _` as I don't think it makes sense, but let me know what you think.

Thoughts appreciated!