### PR TITLE
Fix logger and stacktrace warnings on OTP 21

### DIFF
--- a/lib/elixir/src/elixir_erl_compiler.erl
+++ b/lib/elixir/src/elixir_erl_compiler.erl
@@ -63,6 +63,7 @@ handle_file_warning(_, _File, {_Line, erl_lint, {undefined_behaviour_func, _, _}
 handle_file_warning(_, _File, {_Line, erl_lint, {undefined_behaviour, _}}) -> ok;
 handle_file_warning(_, _File, {_Line, erl_lint, {ill_defined_behaviour_callbacks, _}}) -> ok;
 handle_file_warning(_, _File, {_Line, erl_lint, {ill_defined_optional_callbacks, _}}) -> ok;
+handle_file_warning(_, _File, {_Line, erl_lint, {deprecated,{erlang,get_stacktrace,0},_}}) -> ok;
 
 handle_file_warning(_, File, {Line, Module, Desc}) ->
   Message = format_error(Module, Desc),

--- a/lib/logger/lib/logger/watcher.ex
+++ b/lib/logger/lib/logger/watcher.ex
@@ -20,6 +20,13 @@ defmodule Logger.Watcher do
   def init({mod, handler, args}) do
     Process.flag(:trap_exit, true)
 
+    # This is required for OTP 21. A better fix would be to not include
+    # the error_logger handler in the first place but we will do so only
+    # in future Elixir versions.
+    unless Process.whereis(mod) do
+      _ = :logger.add_handler(mod, mod, %{level: :info, filter_default: :log})
+    end
+
     case :gen_event.delete_handler(mod, handler, :ok) do
       {:error, :module_not_found} ->
         case :gen_event.add_sup_handler(mod, handler, args) do


### PR DESCRIPTION
Those are the minimum fixes which preserve the existing behaviour.
More performant fixes in the logger cases will be applied to master
and the upcoming Elixir v1.7.