### PR TITLE
Move to __STACKTRACE__ and lazily compute stacktrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,6 @@
   * [Code] Deprecate `Code.load_file/2` in favor of `Code.compile_file/2`
   * [Code] Deprecate `Code.loaded_files/0` in favor of `Code.required_files/0`
   * [Code] Deprecate `Code.unload_files/1` in favor of `Code.unrequire_files/1`
-  * [Exception] Deprecate `Exception.normalize/2` and `Exception.format/2` as a stacktrace is now explicitly required
 
 ### 4. Hard-deprecations
 

--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -4,8 +4,7 @@ require EEx
 
 defmodule EExTest.Compiled do
   def before_compile do
-    fill_in_stacktrace()
-    {__ENV__.line, hd(tl(System.stacktrace()))}
+    {__ENV__.line, hd(tl(get_stacktrace()))}
   end
 
   EEx.function_from_string(:def, :string_sample, "<%= a + b %>", [:a, :b])
@@ -19,21 +18,19 @@ defmodule EExTest.Compiled do
   def file_sample(arg), do: private_file_sample(arg)
 
   def after_compile do
-    fill_in_stacktrace()
-    {__ENV__.line, hd(tl(System.stacktrace()))}
+    {__ENV__.line, hd(tl(get_stacktrace()))}
   end
 
   @file "unknown"
   def unknown do
-    fill_in_stacktrace()
-    {__ENV__.line, hd(tl(System.stacktrace()))}
+    {__ENV__.line, hd(tl(get_stacktrace()))}
   end
 
-  defp fill_in_stacktrace do
+  defp get_stacktrace do
     try do
       :erlang.error("failed")
-    catch
-      :error, _ -> System.stacktrace()
+    rescue
+      _ -> __STACKTRACE__
     end
   end
 end
@@ -447,13 +444,13 @@ defmodule EExTest do
       file = to_charlist(Path.relative_to_cwd(__ENV__.file))
 
       assert EExTest.Compiled.before_compile() ==
-               {8, {EExTest.Compiled, :before_compile, 0, [file: file, line: 7]}}
+               {7, {EExTest.Compiled, :before_compile, 0, [file: file, line: 7]}}
 
       assert EExTest.Compiled.after_compile() ==
-               {23, {EExTest.Compiled, :after_compile, 0, [file: file, line: 22]}}
+               {21, {EExTest.Compiled, :after_compile, 0, [file: file, line: 21]}}
 
       assert EExTest.Compiled.unknown() ==
-               {29, {EExTest.Compiled, :unknown, 0, [file: 'unknown', line: 28]}}
+               {26, {EExTest.Compiled, :unknown, 0, [file: 'unknown', line: 26]}}
     end
   end
 

--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -238,10 +238,8 @@ defmodule Access do
 
   defmacrop raise_undefined_behaviour(exception, module, top) do
     quote do
-      stacktrace = System.stacktrace()
-
       exception =
-        case stacktrace do
+        case __STACKTRACE__ do
           [unquote(top) | _] ->
             reason = "#{inspect(unquote(module))} does not implement the Access behaviour"
             %{unquote(exception) | reason: reason}
@@ -250,7 +248,7 @@ defmodule Access do
             unquote(exception)
         end
 
-      reraise exception, stacktrace
+      reraise exception, __STACKTRACE__
     end
   end
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1759,12 +1759,8 @@ defmodule Kernel do
 
   Works like `raise/1` but does not generate a new stacktrace.
 
-  Notice that `System.stacktrace/0` returns the stacktrace
-  of the last exception. That said, it is common to assign
-  the stacktrace as the first expression inside a `rescue`
-  clause as any other exception potentially raised (and
-  rescued) between the rescue clause and the raise call
-  may change the `System.stacktrace/0` value.
+  Notice that `__STACKTRACE__` can be used inside catch/rescue
+  to retrieve the current stacktrace.
 
   ## Examples
 
@@ -1772,10 +1768,7 @@ defmodule Kernel do
         raise "oops"
       rescue
         exception ->
-          stacktrace = System.stacktrace
-          if Exception.message(exception) == "oops" do
-            reraise exception, stacktrace
-          end
+          reraise exception, __STACKTRACE__
       end
 
   """
@@ -1818,8 +1811,7 @@ defmodule Kernel do
         raise "oops"
       rescue
         exception ->
-          stacktrace = System.stacktrace
-          reraise WrapperError, [exception: exception], stacktrace
+          reraise WrapperError, [exception: exception], __STACKTRACE__
       end
 
   """

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1709,7 +1709,9 @@ defmodule Kernel.SpecialForms do
   pattern matching (similar to the `case` special form).
 
   Note that calls inside `try/1` are not tail recursive since the VM
-  needs to keep the stacktrace in case an exception happens.
+  needs to keep the stacktrace in case an exception happens. To
+  retrieve the stacktrace, access `__STACKTRACE__/0` inside the `rescue`
+  or `catch` clause.
 
   ## `rescue` clauses
 

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -445,14 +445,19 @@ defmodule System do
   end
 
   @doc """
-  Last exception stacktrace.
+  Deprecated mechanism to retrieve the last exception stacktrace.
+
+  Accessing the stacktrace outside of a rescue/catch is deprecated.
+  If you want to support only Elixir v1.7+, you must access
+  `__STACKTRACE__/0` inside a rescue/catch. If you want to support
+  earlier Elixir versions, move `System.stacktrace/0` inside a rescue/catch.
 
   Note that the Erlang VM (and therefore this function) does not
   return the current stacktrace but rather the stacktrace of the
   latest exception.
-
-  Inlined by the compiler.
   """
+  # TODO: Fully deprecate it on Elixir v1.9.
+  # It is currently partially deprecated in elixir_dispatch.erl
   def stacktrace do
     :erlang.get_stacktrace()
   end

--- a/lib/elixir/src/elixir_erl_for.erl
+++ b/lib/elixir/src/elixir_erl_for.erl
@@ -177,15 +177,30 @@ build_into(Ann, Clauses, Expr, Into, Uniq, S) ->
         [Done],
         [],
         [{call, Ann, Fun, [Done, {atom, Ann, done}]}]}],
-      [{clause, Ann,
+      [stacktrace_clause(Ann, Fun, Acc, Kind, Reason, Stack)],
+      []},
+
+  {{block, Ann, [MatchExpr, TryExpr]}, SD}.
+
+stacktrace_clause(Ann, Fun, Acc, Kind, Reason, Stack) ->
+  Release = erlang:system_info(otp_release),
+
+  if
+    Release == "19"; Release == "20" ->
+      {clause, Ann,
         [{tuple, Ann, [Kind, Reason, {var, Ann, '_'}]}],
         [],
         [{match, Ann, Stack, elixir_erl:remote(Ann, erlang, get_stacktrace, [])},
          {call, Ann, Fun, [Acc, {atom, Ann, halt}]},
-         elixir_erl:remote(Ann, erlang, raise, [Kind, Reason, Stack])]}],
-      []},
+         elixir_erl:remote(Ann, erlang, raise, [Kind, Reason, Stack])]};
 
-  {{block, Ann, [MatchExpr, TryExpr]}, SD}.
+    true ->
+      {clause, Ann,
+        [{tuple, Ann, [Kind, Reason, Stack]}],
+        [],
+        [{call, Ann, Fun, [Acc, {atom, Ann, halt}]},
+         elixir_erl:remote(Ann, erlang, raise, [Kind, Reason, Stack])]}
+  end.
 
 %% Helpers
 

--- a/lib/elixir/src/elixir_erl_try.erl
+++ b/lib/elixir/src/elixir_erl_try.erl
@@ -19,102 +19,145 @@ reduce_clauses([], Acc, OldStack, SAcc, _S) ->
 each_clause({'catch', Meta, Raw, Expr}, S) ->
   {Args, Guards} = elixir_utils:extract_splat_guards(Raw),
 
-  Final = case Args of
-    [X]   -> [throw, X, {'_', Meta, nil}];
-    [X, Y] -> [X, Y, {'_', Meta, nil}]
-  end,
+  Match =
+    case Args of
+      [X] -> [throw, X];
+      [X, Y] -> [X, Y]
+    end,
 
-  Condition = [{'{}', Meta, Final}],
-  {TC, TS} = elixir_erl_clauses:clause(Meta, fun elixir_erl_pass:translate_args/2,
-                                       Condition, Expr, Guards, S),
-  {[maybe_add_stracktrace(TC, TS)], TS};
+  {{clause, Line, [TKind, TMatches], TGuards, TBody}, TS} =
+    elixir_erl_clauses:clause(Meta, fun elixir_erl_pass:translate_args/2, Match, Expr, Guards, S),
+
+  {[maybe_add_stacktrace(Line, TKind, TMatches, TGuards, TBody, TS)], TS};
 
 each_clause({rescue, Meta, [{in, _, [Left, Right]}], Expr}, S) ->
   {TempName, _, CS} = elixir_erl_var:build('_', S),
   TempVar = {TempName, Meta, ?var_context},
-  {Parts, Safe, FS} = rescue_guards(Meta, TempVar, Right, CS),
-  Body = rescue_clause_body(Left, Expr, Safe, TempVar, Meta),
+  {Parts, ErlangAliases, FS} = rescue_guards(Meta, TempVar, Right, CS),
+  Body = normalize_rescue(Meta, TempVar, Left, Expr, ErlangAliases),
   build_rescue(Meta, Parts, Body, FS);
 
 each_clause({rescue, Meta, [{VarName, _, Context} = Left], Expr}, S) when is_atom(VarName), is_atom(Context) ->
   {TempName, _, CS} = elixir_erl_var:build('_', S),
   TempVar = {TempName, Meta, ?var_context},
-  Body = rescue_clause_body(Left, Expr, false, TempVar, Meta),
+  Body = normalize_rescue(Meta, TempVar, Left, Expr, catch_all),
   build_rescue(Meta, [{TempVar, []}], Body, CS).
 
-rescue_clause_body({'_', _, Atom}, Expr, _Safe, _Var, _Meta) when is_atom(Atom) ->
+normalize_rescue(_Meta, _Var, {'_', _, Atom}, Expr, _) when is_atom(Atom) ->
   Expr;
-rescue_clause_body(Pattern, Expr, Safe, Var, Meta) ->
-  Normalized =
-    case Safe of
-      true -> Var;
-      false -> {{'.', Meta, ['Elixir.Exception', normalize]}, Meta, [error, Var]}
+normalize_rescue(Meta, Var, Pattern, Expr, []) ->
+  prepend_to_block(Meta, {'=', Meta, [Pattern, Var]}, Expr);
+normalize_rescue(Meta, Var, Pattern, Expr, CatchAllOrErlangAliases) ->
+  Stacktrace =
+    case CatchAllOrErlangAliases of
+      catch_all ->
+        dynamic_normalize(Meta, Var, normalize_with_stacktrace());
+
+      ErlangAliases ->
+        case lists:splitwith(fun is_normalized_with_stacktrace/1, ErlangAliases) of
+          {[], _} -> [];
+          {_, []} -> {'__STACKTRACE__', Meta, nil};
+          {Some, _} -> dynamic_normalize(Meta, Var, Some)
+        end
     end,
+
+  Normalized = {{'.', Meta, ['Elixir.Exception', normalize]}, Meta, [error, Var, Stacktrace]},
   prepend_to_block(Meta, {'=', Meta, [Pattern, Normalized]}, Expr).
+
+dynamic_normalize(Meta, Var, [H | T]) ->
+  Guards =
+    lists:foldl(fun(Alias, Acc) ->
+      {'when', Meta, [erl_rescue_guard_for(Meta, Var, Alias), Acc]}
+    end, erl_rescue_guard_for(Meta, Var, H), T),
+
+  {'case', Meta, [
+    Var,
+    [{do, [
+      {'->', Meta, [[{'when', Meta, [Var, Guards]}], {'__STACKTRACE__', Meta, nil}]},
+      {'->', Meta, [[{'_', Meta, nil}], []]}
+    ]}]
+  ]}.
+
+normalize_with_stacktrace() ->
+  ['Elixir.FunctionClauseError', 'Elixir.UndefinedFunctionError', 'Elixir.KeyError', 'Elixir.ErlangError'].
+
+is_normalized_with_stacktrace(Module) ->
+  lists:member(Module, normalize_with_stacktrace()).
 
 %% Helpers
 
 build_rescue(Meta, Parts, Body, S) ->
   Matches = [Match || {Match, _} <- Parts],
 
-  {TC, TS} =
-    elixir_erl_clauses:clause(Meta, fun elixir_erl_pass:translate_args/2,
-                              Matches, Body, [], S),
-
-  {clause, Line, TMatches, _, TBody} = maybe_add_stracktrace(TC, TS),
+  {{clause, Line, TMatches, _, TBody}, TS} =
+    elixir_erl_clauses:clause(Meta, fun elixir_erl_pass:translate_args/2, Matches, Body, [], S),
 
   TClauses =
     [begin
-      TArgs   = [{tuple, Line, [{atom, Line, error}, TMatch, {var, Line, '_'}]}],
-      TGuards = elixir_erl_clauses:guards(Guards, [], TS),
-      {clause, Line, TArgs, TGuards, TBody}
+       TGuards = elixir_erl_clauses:guards(Guards, [], TS),
+       maybe_add_stacktrace(Line, {atom, Line, error}, TMatch, TGuards, TBody, TS)
      end || {TMatch, {_, Guards}} <- lists:zip(TMatches, Parts)],
 
   {TClauses, TS}.
 
 %% Convert rescue clauses ("var in [alias1, alias2]") into guards.
+rescue_guards(_Meta, _Var, [], S) ->
+  {[], [], S};
 rescue_guards(Meta, Var, Aliases, S) ->
-  {Elixir, Erlang} = rescue_each_ref(Meta, Var, Aliases, [], [], S),
+  %% TODO: We emit two clauses here because we cannot access map fields
+  %% before Erlang/OTP 21. So in the future we can compile this code in a
+  %% way to emit a single clause for both Erlang and Elixir and also
+  %% simplify build_rescue.
+  {ErlangGuards, ErlangAliases} = rescue_each_ref(Meta, Var, Aliases, [], [], S),
 
-  {ElixirParts, ES} =
-    case Elixir of
-      [] -> {[], S};
-      _  ->
-        {VarName, _, CS} = elixir_erl_var:build('_', S),
-        StructVar = {VarName, Meta, 'Elixir'},
-        Map = {'%{}', Meta, [{'__struct__', StructVar}, {'__exception__', true}]},
-        Match = {'=', Meta, [Map, Var]},
-        Guards = [{erl(Meta, '=='), Meta, [StructVar, Mod]} || Mod <- Elixir],
-        {[{Match, Guards}], CS}
-    end,
-
+  %% Compute the optional Erlang check
   ErlangParts =
-    case Erlang of
+    case ErlangGuards of
       [] -> [];
-      _  -> [{Var, Erlang}]
+      _  -> [{Var, ErlangGuards}]
     end,
 
-  {ElixirParts ++ ErlangParts, ErlangParts == [], ES}.
+  %% Compute the always present Elixir check
+  {VarName, _, CS} = elixir_erl_var:build('_', S),
+  StructVar = {VarName, Meta, 'Elixir'},
+  Map = {'%{}', Meta, [{'__struct__', StructVar}, {'__exception__', true}]},
+  Match = {'=', Meta, [Map, Var]},
+  ElixirGuards = [{erl(Meta, '=='), Meta, [StructVar, Alias]} || Alias <- Aliases],
+  {[{Match, ElixirGuards} | ErlangParts], ErlangAliases, CS}.
 
-maybe_add_stracktrace({clause, Line, Args, Guards, Body}, #elixir_erl{stacktrace = {Var,true}}) ->
-  GetStacktrace = elixir_erl:remote(Line, erlang, get_stacktrace, []),
-  Stack = {match, Line, {var, Line, Var}, GetStacktrace},
-  {clause, Line, Args, Guards, [Stack|Body]};
-maybe_add_stracktrace(Clause, _) ->
-  Clause.
+maybe_add_stacktrace(Line, Kind, Expr, Guards, Body, #elixir_erl{stacktrace = {Var, true}}) ->
+  case supports_stacktrace() of
+    true ->
+      Match = {tuple, Line, [Kind, Expr, {var, Line, Var}]},
+      {clause, Line, [Match], Guards, Body};
+    false ->
+      Match = {tuple, Line, [Kind, Expr, {var, Line, '_'}]},
+      Stack = {match, Line, {var, Line, Var}, elixir_erl:remote(Line, erlang, get_stacktrace, [])},
+      {clause, Line, [Match], Guards, [Stack | Body]}
+  end;
+maybe_add_stacktrace(Line, Kind, Expr, Guards, Body, _) ->
+  Match = {tuple, Line, [Kind, Expr, {var, Line, '_'}]},
+  {clause, Line, [Match], Guards, Body}.
+
+%% TODO: Remove this check once we support Erlang/OTP 21+ exclusively.
+supports_stacktrace() ->
+  case erlang:system_info(otp_release) of
+    "19" -> false;
+    "20" -> false;
+    _ -> true
+  end.
 
 %% Rescue each atom name considering their Erlang or Elixir matches.
 %% Matching of variables is done with Erlang exceptions is done in
 %% function for optimization.
 
-rescue_each_ref(Meta, Var, [H | T], Elixir, Erlang, S) when is_atom(H) ->
+rescue_each_ref(Meta, Var, [H | T], Guards, Aliases, S) when is_atom(H) ->
   case erl_rescue_guard_for(Meta, Var, H) of
-    false -> rescue_each_ref(Meta, Var, T, [H | Elixir], Erlang, S);
-    Expr  -> rescue_each_ref(Meta, Var, T, [H | Elixir], [Expr | Erlang], S)
+    false -> rescue_each_ref(Meta, Var, T, Guards, Aliases, S);
+    Expr  -> rescue_each_ref(Meta, Var, T, [Expr | Guards], [H | Aliases], S)
   end;
-
-rescue_each_ref(_, _, [], Elixir, Erlang, _) ->
-  {Elixir, Erlang}.
+rescue_each_ref(_, _, [], Guards, Aliases, _) ->
+  {Guards, Aliases}.
 
 %% Handle Erlang rescue matches.
 
@@ -193,11 +236,9 @@ erl_rescue_guard_for(Meta, Var, 'Elixir.ArgumentError') ->
                  erl_record_compare(Meta, Var, badarg)));
 
 erl_rescue_guard_for(Meta, Var, 'Elixir.ErlangError') ->
-  IsNotTuple  = {erl(Meta, 'not'), Meta, [{erl(Meta, is_tuple), Meta, [Var]}]},
-  IsException = {erl(Meta, '/='), Meta, [
-    {erl(Meta, element), Meta, [2, Var]}, '__exception__'
-  ]},
-  erl_or(Meta, IsNotTuple, IsException);
+  %% TODO: When we require Erlang OTP/21+, we can explicitly check for the
+  %% __exception__ field besides the is_map check.
+  {erl(Meta, 'not'), Meta, [{erl(Meta, is_map), Meta, [Var]}]};
 
 erl_rescue_guard_for(_, _, _) ->
   false.
@@ -219,6 +260,6 @@ prepend_to_block(_Meta, Expr, {'__block__', Meta, Args}) ->
 prepend_to_block(Meta, Expr, Args) ->
   {'__block__', Meta, [Expr, Args]}.
 
-erl(Meta, Op)      -> {'.', Meta, [erlang, Op]}.
+erl(Meta, Op) -> {'.', Meta, [erlang, Op]}.
 erl_or(Meta, Left, Right) -> {{'.', Meta, [erlang, 'orelse']}, Meta, [Left, Right]}.
 erl_and(Meta, Left, Right) -> {{'.', Meta, [erlang, 'andalso']}, Meta, [Left, Right]}.

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -164,7 +164,6 @@ inline(?string, to_integer, 2) -> {erlang, binary_to_integer};
 
 inline(?system, monotonic_time, 0) -> {erlang, monotonic_time};
 inline(?system, os_time, 0) -> {os, system_time};
-inline(?system, stacktrace, 0) -> {erlang, get_stacktrace};
 inline(?system, system_time, 0) -> {erlang, system_time};
 inline(?system, time_offset, 0) -> {erlang, time_offset};
 inline(?system, unique_integer, 0) -> {erlang, unique_integer};

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -62,7 +62,7 @@ defmodule CodeTest do
         Code.eval_string("<<a::size(b)>>", a: :a, b: :b)
       rescue
         _ ->
-          assert System.stacktrace() |> Enum.any?(&(elem(&1, 0) == __MODULE__))
+          assert Enum.any?(__STACKTRACE__, &(elem(&1, 0) == __MODULE__))
       end
     end
   end

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -10,9 +10,7 @@ defmodule ExceptionTest do
       try do
         raise "a"
       rescue
-        _ ->
-          [top | _] = System.stacktrace()
-          top
+        _ -> hd(__STACKTRACE__)
       end
 
     file = __ENV__.file |> Path.relative_to_cwd() |> String.to_charlist()
@@ -58,7 +56,7 @@ defmodule ExceptionTest do
       try do
         throw(:stack)
       catch
-        :stack -> System.stacktrace()
+        :stack -> __STACKTRACE__
       end
 
     assert Exception.format(:error, :badarg, stacktrace) ==
@@ -84,23 +82,29 @@ defmodule ExceptionTest do
   end
 
   test "format_stacktrace/1 from file" do
-    assert_raise ArgumentError, fn ->
+    try do
       Code.eval_string("def foo do end", [], file: "my_file")
+    rescue
+      ArgumentError ->
+        assert Exception.format_stacktrace(__STACKTRACE__) =~ "my_file:1: (file)"
+    else
+      _ -> flunk("expected failure")
     end
-
-    assert Exception.format_stacktrace(System.stacktrace()) =~ "my_file:1: (file)"
   end
 
   test "format_stacktrace/1 from module" do
-    assert_raise ArgumentError, fn ->
+    try do
       Code.eval_string(
         "defmodule FmtStack do raise ArgumentError, ~s(oops) end",
         [],
         file: "my_file"
       )
+    rescue
+      ArgumentError ->
+        assert Exception.format_stacktrace(__STACKTRACE__) =~ "my_file:1: (module)"
+    else
+      _ -> flunk("expected failure")
     end
-
-    assert Exception.format_stacktrace(System.stacktrace()) =~ "my_file:1: (module)"
   end
 
   test "format_stacktrace_entry/1 with no file or line" do

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -441,11 +441,15 @@ defmodule Inspect.MapTest do
         "%{__struct__: Inspect.MapTest.Failing, key: 0}\" while " <>
         "inspecting %{__struct__: Inspect.MapTest.Failing, key: 0}"
 
-    assert_raise Inspect.Error, msg, fn ->
+    try do
       inspect(%Failing{}, safe: false)
+    rescue
+      e in Inspect.Error ->
+        assert Exception.message(e) =~ msg
+        assert [{Inspect.Inspect.MapTest.Failing, :inspect, 2, _} | _] = __STACKTRACE__
+    else
+      _ -> flunk("expected failure")
     end
-
-    assert [{Inspect.Inspect.MapTest.Failing, :inspect, 2, _} | _] = System.stacktrace()
   end
 
   test "bad implementation safe" do

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -808,12 +808,10 @@ defmodule Kernel.ErrorsTest do
       bad_remote_call(1)
     rescue
       ArgumentError ->
-        stack = System.stacktrace()
-
         assert [
                  {:erlang, :apply, [1, :foo, []], []},
                  {__MODULE__, :bad_remote_call, 1, [file: _, line: _]} | _
-               ] = stack
+               ] = __STACKTRACE__
     end
   end
 
@@ -846,14 +844,13 @@ defmodule Kernel.ErrorsTest do
   end
 
   defp rescue_stacktrace(string) do
-    stacktrace =
-      try do
-        Code.eval_string(string)
-        nil
-      rescue
-        _ -> System.stacktrace()
-      end
-
-    stacktrace || flunk("Expected expression to fail")
+    try do
+      Code.eval_string(string)
+      nil
+    rescue
+      _ -> __STACKTRACE__
+    else
+      _ -> flunk("Expected expression to fail")
+    end
   end
 end

--- a/lib/elixir/test/elixir/kernel/quote_test.exs
+++ b/lib/elixir/test/elixir/kernel/quote_test.exs
@@ -280,23 +280,29 @@ defmodule Kernel.QuoteTest.ErrorsTest do
   defraise()
 
   test "inside function error" do
-    assert_raise RuntimeError, fn ->
+    try do
       will_raise(:a, :b)
+    rescue
+      RuntimeError ->
+        mod = Kernel.QuoteTest.ErrorsTest
+        file = __ENV__.file |> Path.relative_to_cwd() |> String.to_charlist()
+        assert [{^mod, :will_raise, 2, [file: ^file, line: 266]} | _] = __STACKTRACE__
+    else
+      _ -> flunk("expected failure")
     end
-
-    mod = Kernel.QuoteTest.ErrorsTest
-    file = __ENV__.file |> Path.relative_to_cwd() |> String.to_charlist()
-    assert [{^mod, :will_raise, 2, [file: ^file, line: 266]} | _] = System.stacktrace()
   end
 
   test "outside function error" do
-    assert_raise RuntimeError, fn ->
+    try do
       will_raise()
+    rescue
+      RuntimeError ->
+        mod = Kernel.QuoteTest.ErrorsTest
+        file = __ENV__.file |> Path.relative_to_cwd() |> String.to_charlist()
+        assert [{^mod, _, _, [file: ^file, line: 297]} | _] = __STACKTRACE__
+    else
+      _ -> flunk("expected failure")
     end
-
-    mod = Kernel.QuoteTest.ErrorsTest
-    file = __ENV__.file |> Path.relative_to_cwd() |> String.to_charlist()
-    assert [{^mod, _, _, [file: ^file, line: 294]} | _] = System.stacktrace()
   end
 end
 

--- a/lib/elixir/test/elixir/kernel/raise_test.exs
+++ b/lib/elixir/test/elixir/kernel/raise_test.exs
@@ -62,7 +62,7 @@ defmodule Kernel.RaiseTest do
       flunk("should not reach")
     rescue
       RuntimeError ->
-        assert @trace == :erlang.get_stacktrace()
+        assert @trace == __STACKTRACE__
     end
 
     try do
@@ -71,7 +71,7 @@ defmodule Kernel.RaiseTest do
       flunk("should not reach")
     rescue
       RuntimeError ->
-        assert @trace == :erlang.get_stacktrace()
+        assert @trace == __STACKTRACE__
     end
   end
 
@@ -81,7 +81,7 @@ defmodule Kernel.RaiseTest do
       flunk("should not reach")
     rescue
       RuntimeError ->
-        assert @trace == :erlang.get_stacktrace()
+        assert @trace == __STACKTRACE__
     end
 
     try do
@@ -90,7 +90,7 @@ defmodule Kernel.RaiseTest do
       flunk("should not reach")
     rescue
       RuntimeError ->
-        assert @trace == :erlang.get_stacktrace()
+        assert @trace == __STACKTRACE__
     end
   end
 
@@ -100,7 +100,7 @@ defmodule Kernel.RaiseTest do
       flunk("should not reach")
     rescue
       RuntimeError ->
-        assert @trace == :erlang.get_stacktrace()
+        assert @trace == __STACKTRACE__
     end
 
     try do
@@ -110,7 +110,7 @@ defmodule Kernel.RaiseTest do
       flunk("should not reach")
     rescue
       RuntimeError ->
-        assert @trace == :erlang.get_stacktrace()
+        assert @trace == __STACKTRACE__
     end
   end
 
@@ -120,7 +120,7 @@ defmodule Kernel.RaiseTest do
       flunk("should not reach")
     rescue
       RuntimeError ->
-        assert @trace == :erlang.get_stacktrace()
+        assert @trace == __STACKTRACE__
     end
 
     try do
@@ -129,7 +129,7 @@ defmodule Kernel.RaiseTest do
       flunk("should not reach")
     rescue
       RuntimeError ->
-        assert @trace == :erlang.get_stacktrace()
+        assert @trace == __STACKTRACE__
     end
   end
 
@@ -472,43 +472,6 @@ defmodule Kernel.RaiseTest do
 
       assert result ==
                "function DoNotExist.for_sure/0 is undefined (module DoNotExist is not available)"
-    end
-  end
-
-  describe "__STACKTRACE__" do
-    test "returns the stacktrace in catch" do
-      try do
-        throw(:foo)
-      catch
-        :foo ->
-          assert __STACKTRACE__ == :erlang.get_stacktrace()
-      end
-    end
-
-    test "returns the stracktrace in rescue" do
-      try do
-        raise "foo"
-      rescue
-        _ ->
-          assert __STACKTRACE__ == :erlang.get_stacktrace()
-      end
-    end
-
-    test "returns the right stacktrace in nested tries" do
-      try do
-        throw(:foo)
-      catch
-        :foo ->
-          bar_trace =
-            try do
-              throw(:bar)
-            catch
-              :bar -> __STACKTRACE__
-            end
-
-          foo_trace = __STACKTRACE__
-          assert bar_trace != foo_trace
-      end
     end
   end
 

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1265,6 +1265,26 @@ defmodule Kernel.WarningTest do
     assert output =~ ~s("catch" should always come after "rescue" in try)
   end
 
+  test "System.stacktrace is deprecated outside catch/rescue" do
+    output = capture_err(fn -> Code.eval_string("System.stacktrace()") end)
+    assert output =~ "System.stacktrace/0 outside of rescue/catch clauses is deprecated"
+
+    output =
+      capture_err(fn ->
+        Code.eval_string("""
+        try do
+          :trying
+        rescue
+          _ -> System.stacktrace()
+        catch
+          _ -> System.stacktrace()
+        end
+        """)
+      end)
+
+    assert output == ""
+  end
+
   test "unused variable in defguard" do
     assert capture_err(fn ->
              Code.eval_string("""

--- a/lib/ex_unit/lib/ex_unit/capture_log.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_log.ex
@@ -85,9 +85,8 @@ defmodule ExUnit.CaptureLog do
       :ok
     catch
       kind, reason ->
-        stack = System.stacktrace()
         _ = StringIO.close(string_io)
-        :erlang.raise(kind, reason, stack)
+        :erlang.raise(kind, reason, __STACKTRACE__)
     else
       :ok ->
         {:ok, content} = StringIO.close(string_io)

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -295,7 +295,7 @@ defmodule ExUnit.DocTest do
         # Put all tests into one context
         (unquote_splicing(tests))
       rescue
-        e in [ExUnit.AssertionError] ->
+        e in ExUnit.AssertionError ->
           reraise e, stack
 
         error ->
@@ -304,7 +304,7 @@ defmodule ExUnit.DocTest do
               inspect(Exception.message(error))
 
           error = [message: message, expr: unquote(String.trim(whole_expr))]
-          reraise ExUnit.AssertionError, error, System.stacktrace()
+          reraise ExUnit.AssertionError, error, __STACKTRACE__
       end
     end
   end

--- a/lib/ex_unit/lib/ex_unit/on_exit_handler.ex
+++ b/lib/ex_unit/lib/ex_unit/on_exit_handler.ex
@@ -141,6 +141,6 @@ defmodule ExUnit.OnExitHandler do
     nil
   catch
     kind, error ->
-      {kind, error, System.stacktrace()}
+      {kind, error, __STACKTRACE__}
   end
 end

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -190,7 +190,7 @@ defmodule ExUnit.Runner do
     {:ok, test_module, module.__ex_unit__(:setup_all, %{module: module, case: module})}
   catch
     kind, error ->
-      failed = failed(kind, error, pruned_stacktrace())
+      failed = failed(kind, error, prune_stacktrace(__STACKTRACE__))
       {:error, %{test_module | state: failed}}
   end
 
@@ -305,7 +305,7 @@ defmodule ExUnit.Runner do
     {:ok, %{test | tags: module.__ex_unit__(:setup, context)}}
   catch
     kind, error ->
-      {:error, %{test | state: failed(kind, error, pruned_stacktrace())}}
+      {:error, %{test | state: failed(kind, error, prune_stacktrace(__STACKTRACE__))}}
   end
 
   defp exec_test(%ExUnit.Test{module: module, name: name, tags: context} = test) do
@@ -313,7 +313,7 @@ defmodule ExUnit.Runner do
     test
   catch
     kind, error ->
-      %{test | state: failed(kind, error, pruned_stacktrace())}
+      %{test | state: failed(kind, error, prune_stacktrace(__STACKTRACE__))}
   end
 
   defp exec_on_exit(test_or_case, pid, timeout) do
@@ -358,8 +358,6 @@ defmodule ExUnit.Runner do
   defp failed(kind, reason, stack) do
     {:failed, [{kind, Exception.normalize(kind, reason, stack), stack}]}
   end
-
-  defp pruned_stacktrace, do: prune_stacktrace(System.stacktrace())
 
   # Assertions can pop-up in the middle of the stack
   defp prune_stacktrace([{ExUnit.Assertions, _, _, _} | t]), do: prune_stacktrace(t)

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -557,8 +557,7 @@ defmodule ExUnit.AssertionsTest do
       assert_raise ArgumentError, fn -> Not.Defined.function(1, 2, 3) end
   rescue
     ExUnit.AssertionError ->
-      stacktrace = System.stacktrace()
-      [{Not.Defined, :function, [1, 2, 3], _} | _] = stacktrace
+      [{Not.Defined, :function, [1, 2, 3], _} | _] = __STACKTRACE__
   end
 
   test "assert raise with Erlang error" do

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -158,7 +158,7 @@ defmodule ExUnit.FormatterTest do
         try do
           Access.fetch(:foo, :bar)
         rescue
-          exception -> {exception, System.stacktrace()}
+          exception -> {exception, __STACKTRACE__}
         end
 
       failure = format_test_failure(test(), [{:error, error, [hd(stack)]}], 1, 80, &formatter/2)

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -248,7 +248,7 @@ defmodule ExUnitTest do
               assert 1 = 2
             rescue
               e in ExUnit.AssertionError ->
-                {:error, e, System.stacktrace()}
+                {:error, e, __STACKTRACE__}
             end
 
           error2 =
@@ -256,7 +256,7 @@ defmodule ExUnitTest do
               assert 3 > 4
             rescue
               e in ExUnit.AssertionError ->
-                {:error, e, System.stacktrace()}
+                {:error, e, __STACKTRACE__}
             end
 
           raise ExUnit.MultiError, errors: [error1, error2]
@@ -277,7 +277,14 @@ defmodule ExUnitTest do
     assert output =~ "Failure #2"
 
     assert_raise ExUnit.MultiError, ~r/oops/, fn ->
-      error = {:error, RuntimeError.exception("oops"), System.stacktrace()}
+      stack =
+        try do
+          raise("oops")
+        rescue
+          _ -> __STACKTRACE__
+        end
+
+      error = {:error, RuntimeError.exception("oops"), stack}
       raise ExUnit.MultiError, errors: [error]
     end
   end


### PR DESCRIPTION
Erlang/OTP 20 warns if the stacktrace is read outside of a
catch/rescue. This commit mirrors this behaviour by consistently
warning on `System.stacktrace/0` being used outside of a
catch/rescue.

Erlang/OTP 21 warns whenever System.stacktrace/:erlang.get_stacktrace
are used. Therefore we need to promote the usage of `__STACKTRACE__`
and make sure to conditionally compile it according to the OTP version.
This requires changes to the Exception normalization mechanism
so we compute `__STACKTRACE__` only when strictly required.

In future Elixir releases, `System.stacktrace/0` will warn when
used even inside catch/rescue.