### PR TITLE
Add helpful error message for improperly formatted type definitions

### DIFF
--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -907,13 +907,22 @@ defmodule TypespecTest do
       end)
     end
 
-    test "badarg error" do
-      assert_raise ArgumentError, ~r/hello/, fn ->
+    test "fails with a helpful error when non-variables are given as arguments" do
+      assert_raise ArgumentError, ~r/one_bad_variable/, fn ->
         test_module do
-          @type hello(String.t()) :: String.t()
-          def hello(world) do
-            world
-          end
+          @type one_bad_variable(String.t()) :: String.t()
+        end
+      end
+
+      assert_raise ArgumentError, ~r/two_bad_variables/, fn ->
+        test_module do
+          @type two_bad_variables(:ok, Enum.t()) :: {:ok, []}
+        end
+      end
+
+      assert_raise ArgumentError, ~r/one_bad_one_good/, fn ->
+        test_module do
+          @type one_bad_one_good(input1, "") :: {:ok, input1}
         end
       end
     end

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -907,20 +907,26 @@ defmodule TypespecTest do
       end)
     end
 
-    test "fails with a helpful error when non-variables are given as arguments" do
-      assert_raise ArgumentError, ~r/one_bad_variable/, fn ->
+    test "non-variables are given as arguments" do
+      msg = ~r/The type one_bad_variable\/1 has an invalid argument\(s\): String.t\(\)/
+
+      assert_raise CompileError, msg, fn ->
         test_module do
           @type one_bad_variable(String.t()) :: String.t()
         end
       end
 
-      assert_raise ArgumentError, ~r/two_bad_variables/, fn ->
+      msg = ~r/The type two_bad_variables\/2 has an invalid argument\(s\): :ok, Enum.t\(\)/
+
+      assert_raise CompileError, msg, fn ->
         test_module do
           @type two_bad_variables(:ok, Enum.t()) :: {:ok, []}
         end
       end
 
-      assert_raise ArgumentError, ~r/one_bad_one_good/, fn ->
+      msg = ~r/The type one_bad_one_good\/2 has an invalid argument\(s\): \"\"/
+
+      assert_raise CompileError, msg, fn ->
         test_module do
           @type one_bad_one_good(input1, "") :: {:ok, input1}
         end

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -907,6 +907,17 @@ defmodule TypespecTest do
       end)
     end
 
+    test "badarg error" do
+      assert_raise ArgumentError, ~r/hello/, fn ->
+        test_module do
+          @type hello(String.t()) :: String.t()
+          def hello(world) do
+            world
+          end
+        end
+      end
+    end
+
     test "retrieval invalid data" do
       assert Code.Typespec.fetch_types(Unknown) == :error
       assert Code.Typespec.fetch_specs(Unknown) == :error


### PR DESCRIPTION
The original issue (#7647) was posted in a very specific context, but I
figured that this implementation would both address that issue as well
as provide helpful feedback if someone were to attempt to write types
with variables incorrectly in general, since that was what was being
raised here.

Resolves #7647