### PR TITLE
Add better ExUnit formatting when missing head of list

### DIFF
--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -185,8 +185,8 @@ defmodule ExUnit.Diff do
     end
   end
 
-  defp take_common_path([h | tail1], [h | tail2], acc) do
-    take_common_path(tail1, tail2, [h | acc])
+  defp take_common_path([head | tail1], [head | tail2], acc) do
+    take_common_path(tail1, tail2, [head | acc])
   end
 
   defp take_common_path(list1, list2, acc), do: {list1, list2, acc}

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -103,17 +103,6 @@ defmodule ExUnit.DiffTest do
 
     assert script(list1, list2) == expected
 
-    list1 = [1, 2]
-    list2 = [1, 1, 2]
-
-    expected = [
-      {:eq, "["},
-      [{:eq, "1"}, {:eq, ", "}, [del: "2", ins: "1"], {:ins, ", "}, {:ins, "2"}],
-      {:eq, "]"}
-    ]
-
-    assert script(list1, list2) == expected
-
     list1 = []
     list2 = [1, 2]
     expected = [{:eq, "["}, [ins: "1, 2"], {:eq, "]"}]
@@ -125,6 +114,30 @@ defmodule ExUnit.DiffTest do
     assert script(list1, list2) == expected
 
     assert script([], []) == [eq: "[]"]
+  end
+
+  test "lists containing subsets or supersets" do
+    list1 = [1, 2]
+    list2 = [1, 1, 2]
+
+    expected = [
+      {:eq, "["},
+      [{:eq, "1"}, {:eq, ", "}, {:ins, "1"}, {:ins, ", "}, {:eq, "2"}],
+      {:eq, "]"}
+    ]
+
+    assert script(list1, list2) == expected
+
+    list1 = [1, 2, 3]
+    list2 = [2, 3]
+
+    expected = [
+      {:eq, "["},
+      [del: "1", del: ", ", eq: "2, 3"],
+      {:eq, "]"}
+    ]
+
+    assert script(list1, list2) == expected
   end
 
   test "charlists" do

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -116,7 +116,7 @@ defmodule ExUnit.DiffTest do
     assert script([], []) == [eq: "[]"]
   end
 
-  test "lists containing subsets or supersets" do
+  test "lists containing non-empty subsets or supersets" do
     list1 = [1, 2]
     list2 = [1, 1, 2]
 
@@ -265,17 +265,6 @@ defmodule ExUnit.DiffTest do
 
     assert script(keyword1, keyword2) == expected
 
-    keyword1 = [file: nil, line: 1]
-    keyword2 = [line: 1]
-
-    expected = [
-      {:eq, "["},
-      [{:del, "file: nil"}, {:del, ", "}, {:eq, "line: 1"}],
-      {:eq, "]"}
-    ]
-
-    assert script(keyword1, keyword2) == expected
-
     keyword1 = [file: nil]
     keyword2 = []
     expected = [{:eq, "["}, [{:del, "file: nil"}], {:eq, "]"}]
@@ -298,6 +287,26 @@ defmodule ExUnit.DiffTest do
     assert script(keyword1, keyword2) == expected
 
     assert script(["foo-bar": 1], []) == [{:eq, "["}, [{:del, "\"foo-bar\": 1"}], {:eq, "]"}]
+  end
+
+  test "keyword lists containing non-empty subsets or supersets" do
+    keyword1 = [file: nil, line: 1]
+    keyword2 = [line: 1]
+
+    expected = [
+      {:eq, "["},
+      [{:del, "file: nil"}, {:del, ", "}, {:eq, "line: 1"}],
+      {:eq, "]"}
+    ]
+
+    assert script(keyword1, keyword2) == expected
+
+    keyword1 = [line: 1]
+    keyword2 = [file: nil, line: 1]
+
+    expected = [{:eq, "["}, [ins: "file: nil", ins: ", ", eq: "line: 1"], {:eq, "]"}]
+
+    assert script(keyword1, keyword2) == expected
   end
 
   test "improper lists" do
@@ -363,6 +372,22 @@ defmodule ExUnit.DiffTest do
     assert script(tuple1, {}) == [{:eq, "{"}, [{:del, ":hex, '1.1'"}], {:eq, "}"}]
     assert script({}, tuple1) == [{:eq, "{"}, [{:ins, ":hex, '1.1'"}], {:eq, "}"}]
     assert script({}, {}) == [eq: "{}"]
+  end
+
+  test "tuples containing non-empty subsets or supersets" do
+    tuple1 = {:ok}
+    tuple2 = {:ok, [1,2,3]}
+
+    expected = [{:eq, "{"}, [eq: ":ok", ins: ", ", ins: "[1, 2, 3]"], {:eq, "}"}]
+
+    assert script(tuple1, tuple2) == expected
+
+    tuple1 = {:ok, [1,2,3]}
+    tuple2 = {[1,2,3]}
+
+    expected = [{:eq, "{"}, [del: ":ok", del: ", ", eq: "[1, 2, 3]"], {:eq, "}"}]
+
+    assert script(tuple1, tuple2) == expected
   end
 
   test "maps" do

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -376,14 +376,14 @@ defmodule ExUnit.DiffTest do
 
   test "tuples containing non-empty subsets or supersets" do
     tuple1 = {:ok}
-    tuple2 = {:ok, [1,2,3]}
+    tuple2 = {:ok, [1, 2, 3]}
 
     expected = [{:eq, "{"}, [eq: ":ok", ins: ", ", ins: "[1, 2, 3]"], {:eq, "}"}]
 
     assert script(tuple1, tuple2) == expected
 
-    tuple1 = {:ok, [1,2,3]}
-    tuple2 = {[1,2,3]}
+    tuple1 = {:ok, [1, 2, 3]}
+    tuple2 = {[1, 2, 3]}
 
     expected = [{:eq, "{"}, [del: ":ok", del: ", ", eq: "[1, 2, 3]"], {:eq, "}"}]
 


### PR DESCRIPTION
The current implementation of the Myers algorithm for diffing didn't
give very helpful diff information when comparing lists in the ExUnit
formatter. This is a very naieve implementation, and at the moment it
is only for lists, but I can see that we might conceivably want to have
this "missing head" diff show up for strings as well.

For making just this work, I sort of skipped the whole Myers algorithm
and just hand built the diff script since it follows a pretty simple
pattern. If we want to expand this further, though, we might need to
implement the reverse of the Myers algorithm.

Resolves #6768