### PR TITLE
Document Process.monitor/1 behavior for already dead processes

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -396,7 +396,8 @@ defmodule Process do
       a PID) or `{name, node}` (if monitoring a remote or local name);
     * `reason` is the exit reason.
     
-  If the process is already dead when calling `Process.monitor/1`, a `:DOWN` message is delivered immediately.
+  If the process is already dead when calling `Process.monitor/1`, a
+  `:DOWN` message is delivered immediately.
 
   See [the need for monitoring](http://elixir-lang.org/getting-started/mix-otp/genserver.html#the-need-for-monitoring)
   for an example. See `:erlang.monitor/2` for more info.

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -395,6 +395,8 @@ defmodule Process do
     * `object` is either a `pid` of the monitored process (if monitoring
       a PID) or `{name, node}` (if monitoring a remote or local name);
     * `reason` is the exit reason.
+    
+  If the process is already dead when calling `Process.monitor/1`, a `:DOWN` message is delivered immediately.
 
   See [the need for monitoring](http://elixir-lang.org/getting-started/mix-otp/genserver.html#the-need-for-monitoring)
   for an example. See `:erlang.monitor/2` for more info.


### PR DESCRIPTION
This information is provided in the Registry documentation (see https://hexdocs.pm/elixir/Registry.html#module-registrations), but was missing here.