### PR TITLE
Fix link to Kernel.elem/2 in docs

### DIFF
--- a/lib/elixir/lib/tuple.ex
+++ b/lib/elixir/lib/tuple.ex
@@ -14,7 +14,7 @@ defmodule Tuple do
   Tuples store elements contiguously in memory. This means accessing a
   tuple element by index doesn't depend on the number of elements in the
   tuple. We say the operation is done in constant-time, via the
-  `Kernel.elem/1` function:
+  `Kernel.elem/2` function:
 
       iex> tuple = {1, :two, "three"}
       iex> elem(tuple, 0)


### PR DESCRIPTION
This fixes the link to the `Kernel.elem/2` function in the Tuple docs.