### PR TITLE
Add helpful error message for Keyword.delete

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -477,6 +477,14 @@ defmodule Keyword do
     [pair | delete_key_value(tail, key, value)]
   end
 
+  defp delete_key_value([not_pair | _tail], _key, _value) do
+    raise ArgumentError,
+      message:
+        "expected a keyword list as the first argument, but got list with invalid element #{
+          inspect(not_pair)
+        }"
+  end
+
   defp delete_key_value([], _key, _value) do
     []
   end
@@ -513,6 +521,14 @@ defmodule Keyword do
 
   defp delete_key([{_, _} = pair | tail], key) do
     [pair | delete_key(tail, key)]
+  end
+
+  defp delete_key([not_pair | _tail], _key) do
+    raise ArgumentError,
+      message:
+        "expected a keyword list as the first argument, but got list with invalid element #{
+          inspect(not_pair)
+        }"
   end
 
   defp delete_key([], _key) do

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -176,4 +176,25 @@ defmodule KeywordTest do
       assert_raise ArgumentError, error.message, fn -> Keyword.merge(arg1, arg2, fun) end
     end
   end
+
+  test "delete/2 and delete/3" do
+    message =
+      "expected a keyword list as the first argument, but got list with invalid element :b"
+
+    assert_raise ArgumentError, message, fn ->
+      Keyword.delete([{:a, 1}, :b], :a)
+    end
+
+    assert_raise ArgumentError, message, fn ->
+      Keyword.delete([{:a, 1}, :b, {:c, 3}], :c)
+    end
+
+    assert_raise ArgumentError, message, fn ->
+      Keyword.delete([{:a, 1}, :b, {:a, 2}], :a, 1)
+    end
+
+    assert_raise ArgumentError, message, fn ->
+      Keyword.delete([{:a, 1}, :b, {:a, 2}], :a, 2)
+    end
+  end
 end


### PR DESCRIPTION
Since we're recursively traversing a full list to delete elements, we can validate the keyword list with a pattern match at each step to throw a helpful exception, and avoid the performance penalty of validation in advance with `Keyword.keyword?/1`. This, I think, is preferable to the current behaviour of `(FunctionClauseError) no function clause matching in Keyword.delete_key/3`, since it avoids leaving the developer searching through private functions to track down the offending caller.

I thought it would be helpful enough to show only the offending element in the error messag, rather than changing the function definitions to pass the full list through the recursion for the sake of the error message, but I could certainly change that to make the message similar to `Keyword.merge/3` if anyone thinks that's important.

This is my first PR of code for this project, feel free to give me feedback on anything about the process I may have missed.