### PR TITLE
Added performant impl for string upcase/downcase `:ascii` mode.

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -677,13 +677,10 @@ defmodule String do
     upcase_ascii(string)
   end
 
-  defp upcase_ascii(string), do: upcase_ascii(string, [])
-
-  defp upcase_ascii(<<c, rest::bits>>, acc) when c >= ?a and c <= ?z,
-    do: upcase_ascii(rest, [c - 32 | acc])
-
-  defp upcase_ascii(<<c, rest::bits>>, acc), do: upcase_ascii(rest, [c | acc])
-  defp upcase_ascii(<<>>, acc), do: IO.iodata_to_binary(:lists.reverse(acc))
+  defp upcase_ascii(string), do: IO.iodata_to_binary(upcase_ascii(string))
+  defp upcase_ascii(<<c, rest::bits>>) when c >= ?a and c <= ?z, do: [c - 32 | upcase_ascii(rest)]
+  defp upcase_ascii(<<c, rest::bits>>), do: [c | upcase_ascii(rest)]
+  defp upcase_ascii(<<>>), do: []
 
   def upcase(string, mode) when mode in @conditional_mappings do
     String.Casing.upcase(string, [], mode)
@@ -739,13 +736,13 @@ defmodule String do
     downcase_ascii(string)
   end
 
-  defp downcase_ascii(string), do: downcase_ascii(string, [])
+  defp downcase_ascii(string), do: IO.iodata_to_binary(downcase_ascii(string))
 
-  defp downcase_ascii(<<c, rest::bits>>, acc) when c >= ?A and c <= ?Z,
-    do: downcase_ascii(rest, [c + 32 | acc])
+  defp downcase_ascii(<<c, rest::bits>>) when c >= ?A and c <= ?Z,
+    do: [c + 32 | downcase_ascii(rest)]
 
-  defp downcase_ascii(<<c, rest::bits>>, acc), do: downcase_ascii(rest, [c | acc])
-  defp downcase_ascii(<<>>, acc), do: IO.iodata_to_binary(:lists.reverse(acc))
+  defp downcase_ascii(<<c, rest::bits>>), do: [c | downcase_ascii(rest)]
+  defp downcase_ascii(<<>>), do: []
 
   def downcase(string, mode) when mode in @conditional_mappings do
     String.Casing.downcase(string, [], mode)

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -674,10 +674,9 @@ defmodule String do
   end
 
   def upcase(string, :ascii) when is_binary(string) do
-    upcase_ascii(string)
+    IO.iodata_to_binary(upcase_ascii(string))
   end
 
-  defp upcase_ascii(string), do: IO.iodata_to_binary(upcase_ascii(string))
   defp upcase_ascii(<<c, rest::bits>>) when c >= ?a and c <= ?z, do: [c - 32 | upcase_ascii(rest)]
   defp upcase_ascii(<<c, rest::bits>>), do: [c | upcase_ascii(rest)]
   defp upcase_ascii(<<>>), do: []
@@ -733,10 +732,8 @@ defmodule String do
   end
 
   def downcase(string, :ascii) when is_binary(string) do
-    downcase_ascii(string)
+    IO.iodata_to_binary(downcase_ascii(string))
   end
-
-  defp downcase_ascii(string), do: IO.iodata_to_binary(downcase_ascii(string))
 
   defp downcase_ascii(<<c, rest::bits>>) when c >= ?A and c <= ?Z,
     do: [c + 32 | downcase_ascii(rest)]

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -677,13 +677,13 @@ defmodule String do
     IO.iodata_to_binary(upcase_ascii(string))
   end
 
-  defp upcase_ascii(<<c, rest::bits>>) when c >= ?a and c <= ?z, do: [c - 32 | upcase_ascii(rest)]
-  defp upcase_ascii(<<c, rest::bits>>), do: [c | upcase_ascii(rest)]
-  defp upcase_ascii(<<>>), do: []
-
   def upcase(string, mode) when mode in @conditional_mappings do
     String.Casing.upcase(string, [], mode)
   end
+
+  defp upcase_ascii(<<c, rest::bits>>) when c >= ?a and c <= ?z, do: [c - 32 | upcase_ascii(rest)]
+  defp upcase_ascii(<<c, rest::bits>>), do: [c | upcase_ascii(rest)]
+  defp upcase_ascii(<<>>), do: []
 
   @doc """
   Converts all characters in the given string to lowercase according to `mode`.
@@ -735,15 +735,15 @@ defmodule String do
     IO.iodata_to_binary(downcase_ascii(string))
   end
 
+  def downcase(string, mode) when mode in @conditional_mappings do
+    String.Casing.downcase(string, [], mode)
+  end
+
   defp downcase_ascii(<<c, rest::bits>>) when c >= ?A and c <= ?Z,
     do: [c + 32 | downcase_ascii(rest)]
 
   defp downcase_ascii(<<c, rest::bits>>), do: [c | downcase_ascii(rest)]
   defp downcase_ascii(<<>>), do: []
-
-  def downcase(string, mode) when mode in @conditional_mappings do
-    String.Casing.downcase(string, [], mode)
-  end
 
   @doc """
   Converts the first character in the given string to

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -681,8 +681,10 @@ defmodule String do
     String.Casing.upcase(string, [], mode)
   end
 
-  defp upcase_ascii(<<c, rest::bits>>) when c >= ?a and c <= ?z, do: [c - 32 | upcase_ascii(rest)]
-  defp upcase_ascii(<<c, rest::bits>>), do: [c | upcase_ascii(rest)]
+  defp upcase_ascii(<<char, rest::bits>>) when char >= ?a and char <= ?z,
+    do: [char - 32 | upcase_ascii(rest)]
+
+  defp upcase_ascii(<<char, rest::bits>>), do: [char | upcase_ascii(rest)]
   defp upcase_ascii(<<>>), do: []
 
   @doc """
@@ -739,10 +741,10 @@ defmodule String do
     String.Casing.downcase(string, [], mode)
   end
 
-  defp downcase_ascii(<<c, rest::bits>>) when c >= ?A and c <= ?Z,
-    do: [c + 32 | downcase_ascii(rest)]
+  defp downcase_ascii(<<char, rest::bits>>) when char >= ?A and char <= ?Z,
+    do: [char + 32 | downcase_ascii(rest)]
 
-  defp downcase_ascii(<<c, rest::bits>>), do: [c | downcase_ascii(rest)]
+  defp downcase_ascii(<<char, rest::bits>>), do: [char | downcase_ascii(rest)]
   defp downcase_ascii(<<>>), do: []
 
   @doc """

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -674,10 +674,16 @@ defmodule String do
   end
 
   def upcase(string, :ascii) when is_binary(string) do
-    for <<x <- string>>,
-      do: if(x >= ?a and x <= ?z, do: <<x - 32>>, else: <<x>>),
-      into: ""
+    upcase_ascii(string)
   end
+
+  defp upcase_ascii(string), do: upcase_ascii(string, [])
+
+  defp upcase_ascii(<<c, rest::bits>>, acc) when c >= ?a and c <= ?z,
+    do: upcase_ascii(rest, [c - 32 | acc])
+
+  defp upcase_ascii(<<c, rest::bits>>, acc), do: upcase_ascii(rest, [c | acc])
+  defp upcase_ascii(<<>>, acc), do: IO.iodata_to_binary(:lists.reverse(acc))
 
   def upcase(string, mode) when mode in @conditional_mappings do
     String.Casing.upcase(string, [], mode)
@@ -730,10 +736,16 @@ defmodule String do
   end
 
   def downcase(string, :ascii) when is_binary(string) do
-    for <<x <- string>>,
-      do: if(x >= ?A and x <= ?Z, do: <<x + 32>>, else: <<x>>),
-      into: ""
+    downcase_ascii(string)
   end
+
+  defp downcase_ascii(string), do: downcase_ascii(string, [])
+
+  defp downcase_ascii(<<c, rest::bits>>, acc) when c >= ?A and c <= ?Z,
+    do: downcase_ascii(rest, [c + 32 | acc])
+
+  defp downcase_ascii(<<c, rest::bits>>, acc), do: downcase_ascii(rest, [c | acc])
+  defp downcase_ascii(<<>>, acc), do: IO.iodata_to_binary(:lists.reverse(acc))
 
   def downcase(string, mode) when mode in @conditional_mappings do
     String.Casing.downcase(string, [], mode)


### PR DESCRIPTION
the existing implementation with binary comprehensions turned out to be
_far_ slower than the other modes.

The current implementation is >= 2.5X faster than the earlier implementation

---
this PR is a consequence of the discussions in #7673

PS: this is my first PR in elixir 