### PR TITLE
DynamicSupervisor documentation fix

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -377,7 +377,7 @@ defmodule DynamicSupervisor do
   end
 
   @doc """
-  Terminates the given child identified by child id.
+  Terminates the given child identified by child pid.
 
   If successful, this function returns `:ok`. If there is no process with
   the given PID, this function returns `{:error, :not_found}`.


### PR DESCRIPTION
The documentation is refering to an `id` for terminating a child, but
DynamicSupervisor uses a `pid`.

Amos King @adkron <amos@binarynoggin.com>