### PR TITLE
Add the `:trailing_comma` option to the formatter

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -261,6 +261,11 @@ defmodule Code do
       expects a valid `Version` which is usually the minimum Elixir
       version supported by the project.
 
+    * `:trailing_comma` - if set `true`, multi-line list, map, and
+      struct literals will include a trailing comma after the last item
+      or pair in the data structure. Does not affect argument lists,
+      tuples, or lists/maps/structs rendered on a single line.
+
   ## Design principles
 
   The formatter was designed under three principles.

--- a/lib/elixir/test/elixir/code_formatter/containers_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/containers_test.exs
@@ -7,6 +7,7 @@ defmodule Code.Formatter.ContainersTest do
 
   @short_length [line_length: 10]
   @medium_length [line_length: 20]
+  @trailing_comma [trailing_comma: true]
 
   describe "tuples" do
     test "without arguments" do
@@ -234,6 +235,38 @@ defmodule Code.Formatter.ContainersTest do
         :bar
       ]
       """
+    end
+
+    test "ignores `trailing_comma: true` for single-line lists" do
+      one_line = "[1, 2, 3]"
+
+      assert_same one_line, @trailing_comma
+
+      one_line_with_cons = "[1, 2, 3 | 4]"
+
+      assert_same one_line_with_cons, @trailing_comma
+    end
+
+    test "respects `trailing_comma: true` for multi-line lists" do
+      multi_line = """
+      [
+        1,
+        2,
+        3,
+      ]
+      """
+
+      assert_same multi_line, @trailing_comma
+
+      multi_line_with_cons = """
+      [
+        1,
+        2,
+        3 | 4
+      ]
+      """
+
+      assert_same multi_line_with_cons, @trailing_comma
     end
   end
 
@@ -464,6 +497,58 @@ defmodule Code.Formatter.ContainersTest do
 
       assert_same good, @medium_length
     end
+
+    test "ignores `trailing_comma: true` on single-line maps" do
+      good_keyword = "%{a: 1, b: 2}"
+
+      assert_same good_keyword, @trailing_comma
+
+      good_assoc = "%{a => 1, b => 2}"
+
+      assert_same good_assoc, @trailing_comma
+    end
+
+    test "respects `trailing_comma: true` on multi-line maps" do
+      good_keyword = """
+      %{
+        first: 1,
+        second: 2,
+      }
+      """
+
+      assert_same good_keyword, @trailing_comma
+
+      good_assoc = """
+      %{
+        key1 => value1,
+        key2 => value2,
+      }
+      """
+
+      assert_same good_assoc, @trailing_comma
+
+      good_keyword_with_newlines = """
+      %{
+        first:
+          expression1(),
+        second:
+          expression2(),
+      }
+      """
+
+      assert_same good_keyword_with_newlines, @trailing_comma ++ @medium_length
+
+      good_assoc_with_newlines = """
+      %{
+        key1 =>
+          expression1(),
+        key2 =>
+          expression2(),
+      }
+      """
+
+      assert_same good_assoc_with_newlines, @trailing_comma ++ @medium_length
+    end
   end
 
   describe "maps with update" do
@@ -518,6 +603,64 @@ defmodule Code.Formatter.ContainersTest do
       assert_format "%{foo && bar | baz: :bat}", "%{(foo && bar) | baz: :bat}"
       assert_same "%{@foo | baz: :bat}"
     end
+
+    test "ignores `trailing_comma: true` on single-line maps" do
+      good_keyword = "%{foo | a: 1, b: 2}"
+
+      assert_same good_keyword, @trailing_comma
+
+      good_assoc = "%{foo | a => 1, b => 2}"
+
+      assert_same good_assoc, @trailing_comma
+    end
+
+    test "respects `trailing_comma: true` on multi-line maps" do
+      good_keyword = """
+      %{
+        foo
+        | first: 1,
+          second: 2,
+          third: 3,
+          fourth: 4,
+      }
+      """
+
+      assert_same good_keyword, @trailing_comma ++ @medium_length
+
+      good_assoc = """
+      %{
+        foo
+        | key1 => value1,
+          key2 => value2,
+      }
+      """
+
+      assert_same good_assoc, @trailing_comma ++ @medium_length
+
+      good_keyword_with_newlines = """
+      %{
+        foo
+        | first:
+            expression1(),
+          second:
+            expression2(),
+      }
+      """
+
+      assert_same good_keyword_with_newlines, @trailing_comma ++ @medium_length
+
+      good_assoc_with_newlines = """
+      %{
+        foo
+        | key1 =>
+            expression1(),
+          key2 =>
+            expression2(),
+      }
+      """
+
+      assert_same good_assoc_with_newlines, @trailing_comma ++ @medium_length
+    end
   end
 
   describe "structs" do
@@ -567,6 +710,60 @@ defmodule Code.Formatter.ContainersTest do
         :bar => 3
       }
       """
+    end
+
+    test "ignores `trailing_comma: true` on single-line structs" do
+      good_keyword = "%Foo{a: 1, b: 2}"
+
+      assert_same good_keyword, @trailing_comma
+
+      good_assoc = "%Foo{:a => 1, :b => 2}"
+
+      assert_same good_assoc, @trailing_comma
+    end
+
+    test "respects `trailing_comma: true` on multi-line structs" do
+      good_keyword = """
+      %Foo{
+        first: 1,
+        second: 2,
+        third: 3,
+        fourth: 4,
+      }
+      """
+
+      assert_same good_keyword, @trailing_comma ++ @medium_length
+
+      good_assoc = """
+      %Foo{
+        :key1 => value1,
+        :key2 => value2,
+      }
+      """
+
+      assert_same good_assoc, @trailing_comma ++ @medium_length
+
+      good_keyword_with_newlines = """
+      %Foo{
+        first:
+          expression1(),
+        second:
+          expression2(),
+      }
+      """
+
+      assert_same good_keyword_with_newlines, @trailing_comma ++ @medium_length
+
+      good_assoc_with_newlines = """
+      %Foo{
+        :key1 =>
+          expression1(),
+        :key2 =>
+          expression2(),
+      }
+      """
+
+      assert_same good_assoc_with_newlines, @trailing_comma ++ @medium_length
     end
   end
 
@@ -630,6 +827,64 @@ defmodule Code.Formatter.ContainersTest do
       """
 
       assert_format bad, good, line_length: 30
+    end
+
+    test "ignores `trailing_comma: true` on single-line structs" do
+      good_keyword = "%Foo{foo | a: 1, b: 2}"
+
+      assert_same good_keyword, @trailing_comma
+
+      good_assoc = "%Foo{foo | :a => 1, :b => 2}"
+
+      assert_same good_assoc, @trailing_comma
+    end
+
+    test "respects `trailing_comma: true` on multi-line structs" do
+      good_keyword = """
+      %Foo{
+        foo
+        | first: 1,
+          second: 2,
+          third: 3,
+          fourth: 4,
+      }
+      """
+
+      assert_same good_keyword, @trailing_comma ++ @medium_length
+
+      good_assoc = """
+      %Foo{
+        foo
+        | :key1 => value1,
+          :key2 => value2,
+      }
+      """
+
+      assert_same good_assoc, @trailing_comma ++ @medium_length
+
+      good_keyword_with_newlines = """
+      %Foo{
+        foo
+        | first:
+            expression1(),
+          second:
+            expression2(),
+      }
+      """
+
+      assert_same good_keyword_with_newlines, @trailing_comma ++ @medium_length
+
+      good_assoc_with_newlines = """
+      %Foo{
+        foo
+        | :key1 =>
+            expression1(),
+          :key2 =>
+            expression2(),
+      }
+      """
+
+      assert_same good_assoc_with_newlines, @trailing_comma ++ @medium_length
     end
   end
 end


### PR DESCRIPTION
This commit adds support for the `:trailing_comma` option in `Code.format_string!/2` et al, including in `.formatter.exs`.

When set `true`, multi-line list, map, and struct literals will include a trailing comma after the last item or pair in the data structure.

Does not affect other data structures, or lists/maps/structs rendered on a single line.

--

The topic of trailing commas has been raised previously by @pragdave in #6646.  No resolution was reached; instead, it was considered appropriate to wait for the formatter to have more time in common use before making decisions on which syntax variants to allow.  It's now been a little over six months since the last discussion, and in conversations with Elixir developers, the lack of trailing commas continues to be a common source of friction.

Some possible reasons to prefer trailing commas in multi-line data structures are ease of refactoring, minimal diffs when adding or removing elements, and visual symmetry.  These reasons are not worth discussing directly in this PR.  It should suffice to note that there are advantages and disadvantages to either approach, and that many developers and teams feel strongly about their preference.

This PR's goal is not to dictate the style of the Elixir project or community at large.  In a similar way to the existing `:line_length` option, the `:trailing_comma` option provides an opt-in mechanism by which projects and organizations can benefit from standardized code formatting while retaining a style they find to be more efficient and productive.