### PR TITLE
Fix faulty function call in comment

### DIFF
--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -12,7 +12,7 @@ defmodule Task.Supervisor do
         {Task.Supervisor, name: MyApp.TaskSupervisor}
       ]
 
-      Supervisor.start_link(strategy: :one_for_one)
+      Supervisor.start_link(children, strategy: :one_for_one)
 
   The options given in the child specification are documented in `start_link/1`.
 


### PR DESCRIPTION
This PR is nothing but a fix for the documentation of `Task.Supervisor`.

A comment containing an example function call to `Supervisor.start_link/2` is written without any children passed in.