### PR TITLE
Match files starting with dot in "mix format"

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -358,7 +358,7 @@ defmodule Mix.Tasks.Format do
 
     map =
       for input <- List.wrap(formatter_opts[:inputs]),
-          file <- Path.wildcard(Path.join(prefix ++ [input])),
+          file <- Path.wildcard(Path.join(prefix ++ [input]), match_dot: true),
           do: {file, formatter_opts},
           into: %{}
 
@@ -381,7 +381,7 @@ defmodule Mix.Tasks.Format do
   end
 
   defp stdin_or_wildcard("-"), do: [:stdin]
-  defp stdin_or_wildcard(path), do: Path.wildcard(path)
+  defp stdin_or_wildcard(path), do: Path.wildcard(path, match_dot: true)
 
   defp read_file(:stdin) do
     {IO.stream(:stdio, :line) |> Enum.to_list() |> IO.iodata_to_binary(), file: "stdin"}

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -180,6 +180,34 @@ defmodule Mix.Tasks.FormatTest do
     end)
   end
 
+  test "expands patterns in inputs from .formatter.exs", context do
+    in_tmp(context.test, fn ->
+      File.write!(".formatter.exs", """
+      [
+        inputs: ["{a,.b}.ex"]
+      ]
+      """)
+
+      File.write!("a.ex", """
+      foo bar
+      """)
+
+      File.write!(".b.ex", """
+      foo bar
+      """)
+
+      Mix.Tasks.Format.run([])
+
+      assert File.read!("a.ex") == """
+             foo(bar)
+             """
+
+      assert File.read!(".b.ex") == """
+             foo(bar)
+             """
+    end)
+  end
+
   test "uses inputs and configuration from --dot-formatter", context do
     in_tmp(context.test, fn ->
       File.write!("custom_formatter.exs", """


### PR DESCRIPTION
Here is the example `.formatter.exs` file given in the documentation of `mix format`:

    [
      inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
    ]

With the previous implementation, the `.formatter.exs` file would not be formatted because internally `Path.wildcard/2` was used without expanding files starting with dot ".":

    iex> Path.wildcard("{mix,.formatter}.exs")
    ["mix.exs"]

    iex> Path.wildcard("{mix,.formatter}.exs", match_dot: true)
    [".formatter.exs", "mix.exs"]