### PR TITLE
Add failing format test for assert with line limit

### DIFF
--- a/lib/elixir/test/elixir/code_formatter/general_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/general_test.exs
@@ -88,6 +88,21 @@ defmodule Code.Formatter.GeneralTest do
       assert_format bad, good, @short_length
     end
 
+    test "with assert on line limit" do
+      bad = ~S"""
+      assert foobar = bazqux
+      """
+
+      good = ~S"""
+      assert(
+        foobar =
+          bazqux
+      )
+      """
+
+      assert_format bad, good, @short_length
+    end
+
     test "with heredoc syntax" do
       assert_same ~S"""
       ~s'''


### PR DESCRIPTION
I honestly don't know how to distill this formatting issue to bare minimum, but in my specific case this was generated by context generator:

```elixir
    test "create_account/1 with invalid data returns error changeset" do
      assert {:error, %Ecto.Changeset{}} = Accounts.create_account(@invalid_attrs)
    end
```

And despite that `.formatter.exs` has the setting `line_length: 79`, the assert line above stays at 82 characters no matter what. If I try to manually add a line break after assert or equals, it still resets it to what you see above.

This PR adds a test that also violates `line_length`, but I can't be 100% certain it's the same issue.

The test failure is as follows:

```
  1) test sigils with assert on line limit (Code.Formatter.GeneralTest)
     lib/elixir/test/elixir/code_formatter/general_test.exs:91
     Assertion with == failed
     code:  assert IO.iodata_to_binary(Code.format_string!(bad, opts)) == result
     left:  "assert foobar =\n         bazqux"
     right: "assert(\n  foobar =\n    bazqux\n)"
     stacktrace:
       lib/elixir/test/elixir/code_formatter/general_test.exs:103: (test)
```

As you can see in the left part the `assert foobar =` would violate the 10 char limit imposed by `@short_length`.

Edit: I might've accidentally put this into a wrong describe block. If this kind of test is welcome, happy to fix.