### PR TITLE
Avoid calling truncate_n/2 if truncate is :infinity

### DIFF
--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -145,7 +145,7 @@ defmodule Logger.Utils do
     # arguments according to the truncate limit.
     {args, _} =
       Enum.map_reduce(args, truncate, fn arg, acc ->
-        if is_binary(arg) and is_integer(acc) do
+        if is_binary(arg) and acc != :infinity do
           truncate_n(arg, acc)
         else
           {arg, acc}

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -145,7 +145,7 @@ defmodule Logger.Utils do
     # arguments according to the truncate limit.
     {args, _} =
       Enum.map_reduce(args, truncate, fn arg, acc ->
-        if is_binary(arg) do
+        if is_binary(arg) and is_integer(acc) do
           truncate_n(arg, acc)
         else
           {arg, acc}

--- a/lib/logger/test/logger/utils_test.exs
+++ b/lib/logger/test/logger/utils_test.exs
@@ -90,13 +90,13 @@ defmodule Logger.UtilsTest do
     assert truncate(long_string, :infinity) == long_string
   end
 
-  test "inspect/3 formats" do
+  test "scan_inspect/3 formats" do
     assert inspect('~p', [1]) == {'~ts', [["1"]]}
     assert inspect("~p", [1]) == {'~ts', [["1"]]}
     assert inspect(:"~p", [1]) == {'~ts', [["1"]]}
   end
 
-  test "inspect/3 sigils" do
+  test "scan_inspect/3 sigils" do
     assert inspect('~10.10tp', [1]) == {'~ts', [["1"]]}
     assert inspect('~-10.10tp', [1]) == {'~ts', [["1"]]}
 
@@ -104,24 +104,24 @@ defmodule Logger.UtilsTest do
     assert inspect('~10.10x~p~n', [1, 2, 3]) == {'~10.10x~ts~n', [1, 2, ["3"]]}
   end
 
-  test "inspect/3 with modifier t has no effect (as it is the default)" do
+  test "scan_inspect/3 with modifier t has no effect (as it is the default)" do
     assert inspect('~tp', [1]) == {'~ts', [["1"]]}
     assert inspect('~tw', [1]) == {'~ts', [["1"]]}
   end
 
-  test "inspect/3 with modifier l always prints lists" do
+  test "scan_inspect/3 with modifier l always prints lists" do
     assert inspect('~lp', ['abc']) == {'~ts', [["[", "97", ",", " ", "98", ",", " ", "99", "]"]]}
     assert inspect('~lw', ['abc']) == {'~ts', [["[", "97", ",", " ", "98", ",", " ", "99", "]"]]}
   end
 
-  test "inspect/3 with modifier for width" do
+  test "scan_inspect/3 with modifier for width" do
     assert inspect('~5lp', ['abc']) ==
              {'~ts', [["[", "97", ",", "\n ", "98", ",", "\n ", "99", "]"]]}
 
     assert inspect('~5lw', ['abc']) == {'~ts', [["[", "97", ",", " ", "98", ",", " ", "99", "]"]]}
   end
 
-  test "inspect/3 with modifier for limit" do
+  test "scan_inspect/3 with modifier for limit" do
     assert inspect('~5lP', ['abc', 2]) ==
              {'~ts', [["[", "97", ",", "\n ", "98", ",", "\n ", "...", "]"]]}
 
@@ -129,14 +129,14 @@ defmodule Logger.UtilsTest do
              {'~ts', [["[", "97", ",", " ", "98", ",", " ", "...", "]"]]}
   end
 
-  test "inspect/3 truncates binaries" do
+  test "scan_inspect/3 truncates binaries" do
     assert inspect('~ts', ["abcdeabcdeabcdeabcde"]) == {'~ts', ["abcdeabcde"]}
 
     assert inspect('~ts~ts~ts', ["abcdeabcde", "abcde", "abcde"]) ==
              {'~ts~ts~ts', ["abcdeabcde", "", ""]}
   end
 
-  test "inspect/3 with :infinity truncate" do
+  test "scan_inspect/3 with :infinity truncate" do
     long_string = String.duplicate("foo", 10000)
     assert inspect('~ts', [long_string], :infinity) == {'~ts', [long_string]}
   end

--- a/lib/logger/test/logger/utils_test.exs
+++ b/lib/logger/test/logger/utils_test.exs
@@ -5,9 +5,9 @@ defmodule Logger.UtilsTest do
 
   import Kernel, except: [inspect: 2]
 
-  defp inspect(format, args) do
+  defp inspect(format, args, truncate \\ 10) do
     format
-    |> Logger.Utils.scan_inspect(args, 10)
+    |> Logger.Utils.scan_inspect(args, truncate)
     |> :io_lib.unscan_format()
   end
 
@@ -90,13 +90,13 @@ defmodule Logger.UtilsTest do
     assert truncate(long_string, :infinity) == long_string
   end
 
-  test "inspect/2 formats" do
+  test "inspect/3 formats" do
     assert inspect('~p', [1]) == {'~ts', [["1"]]}
     assert inspect("~p", [1]) == {'~ts', [["1"]]}
     assert inspect(:"~p", [1]) == {'~ts', [["1"]]}
   end
 
-  test "inspect/2 sigils" do
+  test "inspect/3 sigils" do
     assert inspect('~10.10tp', [1]) == {'~ts', [["1"]]}
     assert inspect('~-10.10tp', [1]) == {'~ts', [["1"]]}
 
@@ -104,24 +104,24 @@ defmodule Logger.UtilsTest do
     assert inspect('~10.10x~p~n', [1, 2, 3]) == {'~10.10x~ts~n', [1, 2, ["3"]]}
   end
 
-  test "inspect/2 with modifier t has no effect (as it is the default)" do
+  test "inspect/3 with modifier t has no effect (as it is the default)" do
     assert inspect('~tp', [1]) == {'~ts', [["1"]]}
     assert inspect('~tw', [1]) == {'~ts', [["1"]]}
   end
 
-  test "inspect/2 with modifier l always prints lists" do
+  test "inspect/3 with modifier l always prints lists" do
     assert inspect('~lp', ['abc']) == {'~ts', [["[", "97", ",", " ", "98", ",", " ", "99", "]"]]}
     assert inspect('~lw', ['abc']) == {'~ts', [["[", "97", ",", " ", "98", ",", " ", "99", "]"]]}
   end
 
-  test "inspect/2 with modifier for width" do
+  test "inspect/3 with modifier for width" do
     assert inspect('~5lp', ['abc']) ==
              {'~ts', [["[", "97", ",", "\n ", "98", ",", "\n ", "99", "]"]]}
 
     assert inspect('~5lw', ['abc']) == {'~ts', [["[", "97", ",", " ", "98", ",", " ", "99", "]"]]}
   end
 
-  test "inspect/2 with modifier for limit" do
+  test "inspect/3 with modifier for limit" do
     assert inspect('~5lP', ['abc', 2]) ==
              {'~ts', [["[", "97", ",", "\n ", "98", ",", "\n ", "...", "]"]]}
 
@@ -129,11 +129,16 @@ defmodule Logger.UtilsTest do
              {'~ts', [["[", "97", ",", " ", "98", ",", " ", "...", "]"]]}
   end
 
-  test "inspect/2 truncates binaries" do
+  test "inspect/3 truncates binaries" do
     assert inspect('~ts', ["abcdeabcdeabcdeabcde"]) == {'~ts', ["abcdeabcde"]}
 
     assert inspect('~ts~ts~ts', ["abcdeabcde", "abcde", "abcde"]) ==
              {'~ts~ts~ts', ["abcdeabcde", "", ""]}
+  end
+
+  test "inspect/3 with :infinity truncate" do
+    long_string = String.duplicate("foo", 10000)
+    assert inspect('~ts', [long_string], :infinity) == {'~ts', [long_string]}
   end
 
   test "timestamp/1" do


### PR DESCRIPTION
I encountered the following while investigating an issue that occurred in dev environment but not in testing (was apparently parsing some really broken data with Sweet_xml)

```elixir
13:29:32.638 module=Logger.Watcher [error] :gen_event handler Logger.ErrorHandler installed at :error_logger
** (exit) an exception was raised:                    
    ** (ArithmeticError) bad argument in arithmetic expression    
        (logger) lib/logger/utils.ex:57: Logger.Utils.truncate_n/2    
        (elixir) lib/enum.ex:1397: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
        (elixir) lib/enum.ex:1397: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
        (logger) lib/logger/utils.ex:141: Logger.Utils.scan_inspect/4
        (logger) lib/logger/error_handler.ex:170: Logger.ErrorHandler.translate/6
        (logger) lib/logger/error_handler.ex:92: Logger.ErrorHandler.log_event/6
        (logger) lib/logger/error_handler.ex:31: Logger.ErrorHandler.handle_event/2
        (stdlib) gen_event.erl:574: :gen_event.server_update/4  
```

After some prodding I noticed that `logger, truncate` was set to `:infinity` only in dev and if I added the same to test we got the same crash there.
