### PR TITLE
Correct typo

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -481,7 +481,7 @@ defmodule Code do
         # code
       end)
 
-      some_funtion_without_parens %{
+      some_function_without_parens %{
         foo: :bar,
         baz: :bat
       }


### PR DESCRIPTION
`some_funtion_without_parens` ... doc needs a C in function