### PR TITLE
Added examples of practical usage to inspect

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -50,7 +50,7 @@ defprotocol Inspect do
       "23"
       iex> Kernel.inspect(1.1)
       "1.1"
-      iex> Kernel.inspect %{hello: "world", name: "steve", count: 2}
+      iex> Kernel.inspect(%{hello: "world", name: "steve", count: 2})
       "%{count: 2, hello: \"world\", name: \"steve\"}"
       iex> Kernel.inspect [1, 2, "three", 'four']
       "[1, 2, \"three\", 'four']"

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -45,25 +45,23 @@ defprotocol Inspect do
   an implementation of inspect may simply return a string,
   although that will devoid it of any pretty-printing.
   
-  ```iex
-  iex> Kernel.inspect(23)
-  "23"
-  iex> Kernel.inspect(1.1)
-  "1.1"
-  iex> Kernel.inspect %{hello: "world", name: "steve", count: 2}
-  "%{count: 2, hello: \"world\", name: \"steve\"}"
-  iex> Kernel.inspect [1, 2, "three", 'four']
-  "[1, 2, \"three\", 'four']"
-  ```
+
+      iex> Kernel.inspect(23)
+      "23"
+      iex> Kernel.inspect(1.1)
+      "1.1"
+      iex> Kernel.inspect %{hello: "world", name: "steve", count: 2}
+      "%{count: 2, hello: \"world\", name: \"steve\"}"
+      iex> Kernel.inspect [1, 2, "three", 'four']
+      "[1, 2, \"three\", 'four']"
+
   
   Options can be passed in `inspect`, see them all in `Inspect.Opts`
   
-  ```iex
-  iex> Kernel.inspect([1,2,3,4,5,6,7,8,9], limit: 2) 
-  "[1, 2, ...]"
-  iex> Kernel.inspect([1,2,3,4,5,6,7,8,9])          
-  "[1, 2, 3, 4, 5, 6, 7, 8, 9]"
-  ```
+      iex> Kernel.inspect([1,2,3,4,5,6,7,8,9], limit: 2) 
+      "[1, 2, ...]"
+      iex> Kernel.inspect([1,2,3,4,5,6,7,8,9])          
+      "[1, 2, 3, 4, 5, 6, 7, 8, 9]"
   
   If you want to automatically print this string to STDOUT see
   `IO.inspect`

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -64,7 +64,7 @@ defprotocol Inspect do
       "[1, 2, 3, 4, 5, 6, 7, 8, 9]"
 
   If you want to automatically print this string to STDOUT see
-  `IO.inspect`
+  `IO.inspect/2`.
 
   ## Error handling
 

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -9,6 +9,11 @@ defprotocol Inspect do
   data structure into an algebra document. This document is then
   formatted, either in pretty printing format or a regular one.
 
+  `Inspect` protocol basically returns a string for the data
+  structure it's given. The string returned by the `Inspect` 
+  protocol, generated using both the options from `Inspect.Opts`
+  and the internal algebra representation of the datastructure. 
+
   The `inspect/2` function receives the entity to be inspected
   followed by the inspecting options, represented by the struct
   `Inspect.Opts`.
@@ -39,6 +44,29 @@ defprotocol Inspect do
   Since regular strings are valid entities in an algebra document,
   an implementation of inspect may simply return a string,
   although that will devoid it of any pretty-printing.
+  
+  ```iex
+  iex> Kernel.inspect(23)
+  "23"
+  iex> Kernel.inspect(1.1)
+  "1.1"
+  iex> Kernel.inspect %{hello: "world", name: "steve", count: 2}
+  "%{count: 2, hello: \"world\", name: \"steve\"}"
+  iex> Kernel.inspect [1, 2, "three", 'four']
+  "[1, 2, \"three\", 'four']"
+  ```
+  
+  Options can be passed in `inspect`, see them all in `Inspect.Opts`
+  
+  ```iex
+  iex> Kernel.inspect([1,2,3,4,5,6,7,8,9], limit: 2) 
+  "[1, 2, ...]"
+  iex> Kernel.inspect([1,2,3,4,5,6,7,8,9])          
+  "[1, 2, 3, 4, 5, 6, 7, 8, 9]"
+  ```
+  
+  If you want to automatically print this string to STDOUT see
+  `IO.inspect`
 
   ## Error handling
 

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -44,7 +44,7 @@ defprotocol Inspect do
   Since regular strings are valid entities in an algebra document,
   an implementation of inspect may simply return a string,
   although that will devoid it of any pretty-printing.
-  
+
 
       iex> Kernel.inspect(23)
       "23"
@@ -55,14 +55,14 @@ defprotocol Inspect do
       iex> Kernel.inspect [1, 2, "three", 'four']
       "[1, 2, \"three\", 'four']"
 
-  
+
   Options can be passed in `inspect`, see them all in `Inspect.Opts`
-  
+
       iex> Kernel.inspect([1,2,3,4,5,6,7,8,9], limit: 2) 
       "[1, 2, ...]"
       iex> Kernel.inspect([1,2,3,4,5,6,7,8,9])          
       "[1, 2, 3, 4, 5, 6, 7, 8, 9]"
-  
+
   If you want to automatically print this string to STDOUT see
   `IO.inspect`
 

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -5,19 +5,17 @@ alias Code.Identifier
 
 defprotocol Inspect do
   @moduledoc """
-  The `Inspect` protocol is responsible for converting any Elixir
-  data structure into an algebra document. This document is then
-  formatted, either in pretty printing format or a regular one.
+  The `Inspect` protocol converts an Elixir data structure into an
+  algebra document.
 
-  This documentation refers to implementing inspecting the `Inspect`
-  protocol for your own data structures. To learn more about using 
-  inspect, see `Kernel.inspect/2` and `IO.inspect/2`.
+  This documentation refers to implementing the `Inspect` protocol
+  for your own data structures. To learn more about using inspect,
+  see `Kernel.inspect/2` and `IO.inspect/2`.
 
   The `inspect/2` function receives the entity to be inspected
   followed by the inspecting options, represented by the struct
-  `Inspect.Opts`.
-
-  Inspection is done using the functions available in `Inspect.Algebra`.
+  `Inspect.Opts`. Building of the algebra document is done with
+  `Inspect.Algebra`.
 
   ## Examples
 

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -9,10 +9,10 @@ defprotocol Inspect do
   data structure into an algebra document. This document is then
   formatted, either in pretty printing format or a regular one.
 
-  `Inspect` protocol basically returns a string for the data
+  The `Inspect` protocol basically returns a string for the data
   structure it's given. The string returned by the `Inspect` 
-  protocol, generated using both the options from `Inspect.Opts`
-  and the internal algebra representation of the datastructure. 
+  protocol is generated using both the options from `Inspect.Opts`
+  and the internal algebra representation of the data structure. 
 
   The `inspect/2` function receives the entity to be inspected
   followed by the inspecting options, represented by the struct
@@ -56,7 +56,7 @@ defprotocol Inspect do
       "[1, 2, \"three\", 'four']"
 
 
-  Options can be passed in `inspect`, see them all in `Inspect.Opts`
+  Options can be passed in `inspect/2`, see them all in `Inspect.Opts`.
 
       iex> Kernel.inspect([1,2,3,4,5,6,7,8,9], limit: 2) 
       "[1, 2, ...]"

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -9,10 +9,9 @@ defprotocol Inspect do
   data structure into an algebra document. This document is then
   formatted, either in pretty printing format or a regular one.
 
-  The `Inspect` protocol basically returns a string for the data
-  structure it's given. The string returned by the `Inspect` 
-  protocol is generated using both the options from `Inspect.Opts`
-  and the internal algebra representation of the data structure. 
+  This documentation refers to implementing inspecting the `Inspect`
+  protocol for your own data structures. To learn more about using 
+  inspect, see `Kernel.inspect/2` and `IO.inspect/2`.
 
   The `inspect/2` function receives the entity to be inspected
   followed by the inspecting options, represented by the struct
@@ -44,27 +43,6 @@ defprotocol Inspect do
   Since regular strings are valid entities in an algebra document,
   an implementation of inspect may simply return a string,
   although that will devoid it of any pretty-printing.
-
-
-      iex> Kernel.inspect(23)
-      "23"
-      iex> Kernel.inspect(1.1)
-      "1.1"
-      iex> Kernel.inspect(%{hello: "world", name: "steve", count: 2})
-      "%{count: 2, hello: \"world\", name: \"steve\"}"
-      iex> Kernel.inspect [1, 2, "three", 'four']
-      "[1, 2, \"three\", 'four']"
-
-
-  Options can be passed in `inspect/2`, see them all in `Inspect.Opts`.
-
-      iex> Kernel.inspect([1,2,3,4,5,6,7,8,9], limit: 2) 
-      "[1, 2, ...]"
-      iex> Kernel.inspect([1,2,3,4,5,6,7,8,9])          
-      "[1, 2, 3, 4, 5, 6, 7, 8, 9]"
-
-  If you want to automatically print this string to STDOUT see
-  `IO.inspect/2`.
 
   ## Error handling
 


### PR DESCRIPTION
Added examples of practical usage to inspect, so that people review the documentation can understand what the inspect protocol is used for.