### PR TITLE
Add bad digit clause to Base.decode32!/1,2 for case: :mixed

### DIFF
--- a/lib/elixir/lib/base.ex
+++ b/lib/elixir/lib/base.ex
@@ -184,16 +184,19 @@ defmodule Base do
   end
 
   defp decode_char_clauses(alphabet, :mixed) when length(alphabet) == 32 do
-    alphabet
-    |> Stream.with_index()
-    |> Enum.flat_map(fn {encoding, value} = pair ->
-      if encoding in ?A..?Z do
-        [pair, {encoding - ?A + ?a, value}]
-      else
-        [pair]
-      end
-    end)
-    |> decode_clauses()
+    clauses =
+      alphabet
+      |> Stream.with_index()
+      |> Enum.flat_map(fn {encoding, value} = pair ->
+        if encoding in ?A..?Z do
+          [pair, {encoding - ?A + ?a, value}]
+        else
+          [pair]
+        end
+      end)
+      |> decode_clauses()
+
+    clauses ++ bad_digit_clause()
   end
 
   defp decode_mixed_clauses(first, second) do

--- a/lib/elixir/test/elixir/base_test.exs
+++ b/lib/elixir/test/elixir/base_test.exs
@@ -487,10 +487,6 @@ defmodule BaseTest do
     end
 
     assert_raise ArgumentError, "non-alphabet digit found: \"0\" (byte 48)", fn ->
-      decode32!("0ZXW6YTB0I======", case: :lower)
-    end
-
-    assert_raise ArgumentError, "non-alphabet digit found: \"0\" (byte 48)", fn ->
       decode32!("0ZXW6YTB0I======", case: :mixed)
     end
   end

--- a/lib/elixir/test/elixir/base_test.exs
+++ b/lib/elixir/test/elixir/base_test.exs
@@ -473,7 +473,7 @@ defmodule BaseTest do
     assert :error == decode32("66FF", case: :lower)
   end
 
-  test "decode32!/1,2 error on non-alphabet digit" do
+  test "decode32!/1,2 argument error on non-alphabet digit" do
     assert_raise ArgumentError, "non-alphabet digit found: \")\" (byte 41)", fn ->
       decode32!("MZX)6YTB")
     end
@@ -484,6 +484,14 @@ defmodule BaseTest do
 
     assert_raise ArgumentError, "non-alphabet digit found: \"M\" (byte 77)", fn ->
       decode32!("MZXW6YTBOI======", case: :lower)
+    end
+
+    assert_raise ArgumentError, "non-alphabet digit found: \"0\" (byte 48)", fn ->
+      decode32!("0ZXW6YTB0I======", case: :lower)
+    end
+
+    assert_raise ArgumentError, "non-alphabet digit found: \"0\" (byte 48)", fn ->
+      decode32!("0ZXW6YTB0I======", case: :mixed)
     end
   end
 


### PR DESCRIPTION
This adds the bad digit clause for Base.decode32!/1,2 when using case: :mixed. This should fix the CaseClauseError for unrecognized characters and instead produce an Argument Error (which is caught for Base.decode32/1,2).

Quoted from #7703:
> Environment
> 
> Elixir & Erlang/OTP versions (elixir --version): Elixir 1.6.5 (compiled with OTP 20)
> Operating system: Mac OS X 10.12.6
> Current behavior
> 
> iex(28)> Base.decode32("1YPPOPPP", case: :mixed)
> ** (CaseClauseError) no case clause matching: 49
>     (elixir) lib/base.ex:1174: Base.dec32_mixed/1
>     (elixir) lib/base.ex:1235: Base.do_decode32/3
>     (elixir) lib/base.ex:596: Base.decode32/2
> iex(28)> Base.decode32("1YPPOPPP")
> :error
> Expected behavior
> 
> iex(28)> Base.decode32("1YPPOPPP", case: :mixed)
> :error
> iex(28)> Base.decode32("1YPPOPPP")
> :error

Closes #7703 