### PR TITLE
Allow excluding input patterns in .formatter.exs

### DIFF
--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -208,6 +208,34 @@ defmodule Mix.Tasks.FormatTest do
     end)
   end
 
+  test "ignores !patterns in inputs from .formatter.exs", context do
+    in_tmp(context.test, fn ->
+      File.write!(".formatter.exs", """
+      [
+        inputs: ["{a,.b}.ex", "!.*.{ex,exs}"]
+      ]
+      """)
+
+      File.write!("a.ex", """
+      foo bar
+      """)
+
+      File.write!(".b.ex", """
+      foo bar
+      """)
+
+      Mix.Tasks.Format.run([])
+
+      assert File.read!("a.ex") == """
+             foo(bar)
+             """
+
+      assert File.read!(".b.ex") == """
+             foo bar
+             """
+    end)
+  end
+
   test "uses inputs and configuration from --dot-formatter", context do
     in_tmp(context.test, fn ->
       File.write!("custom_formatter.exs", """


### PR DESCRIPTION
With wildcard support, the formatter configuration makes it very
easy to include whole directories full of files for formatting.
However, excluding a single file is not as trivial. While this is
not a regular use-case, there are definitely situations where it
is very useful.

This adds support for negating include patterns in the config
analog to how `.gitignore` works. The paths are resolved the same
way normal include paths are resolved and dropped from the file
list before passing it to the code formatter.

This allows for configurations like the following:
```
inputs: ["lib/**/*.{ex,exs}", "!lib/static.{ex,exs}"]
```