### PR TITLE
Fix column in :elixir_tokenizer for double quotes in keyword identifiers

### DIFF
--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -617,8 +617,9 @@ handle_strings(T, Line, Column, H, Scope, Tokens) ->
         true  -> kw_identifier_safe;
         false -> kw_identifier_unsafe
       end,
+      NewColumn2 = NewColumn + 1,
       Token = {Key, {Line, Column - 1, nil}, Unescaped},
-      tokenize(Rest, NewLine, NewColumn, Scope, [Token | Tokens]);
+      tokenize(Rest, NewLine, NewColumn2, Scope, [Token | Tokens]);
     {NewLine, NewColumn, Parts, Rest} ->
       Token = {string_type(H), {Line, Column - 1, nil}, unescape_tokens(Parts, Scope)},
       tokenize(Rest, NewLine, NewColumn, Scope, [Token | Tokens])

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -184,8 +184,8 @@ tokenize([$~, S, H, H, H | T] = Original, Line, Column, Scope, Tokens) when ?is_
     {ok, NewLine, NewColumn, Parts, Rest} ->
       {Final, Modifiers} = collect_modifiers(Rest, []),
       Token = {sigil, {Line, Column, nil}, S, Parts, Modifiers, <<H, H, H>>},
-      NewColumn2 = NewColumn + length(Modifiers),
-      tokenize(Final, NewLine, NewColumn2, Scope, [Token | Tokens]);
+      NewColumnWithModifiers = NewColumn + length(Modifiers),
+      tokenize(Final, NewLine, NewColumnWithModifiers, Scope, [Token | Tokens]);
     {error, Reason} ->
       {error, Reason, Original, Tokens}
   end;
@@ -195,8 +195,8 @@ tokenize([$~, S, H | T] = Original, Line, Column, Scope, Tokens) when ?is_sigil(
     {NewLine, NewColumn, Parts, Rest} ->
       {Final, Modifiers} = collect_modifiers(Rest, []),
       Token = {sigil, {Line, Column, nil}, S, Parts, Modifiers, <<H>>},
-      NewColumn2 = NewColumn + length(Modifiers),
-      tokenize(Final, NewLine, NewColumn2, Scope, [Token | Tokens]);
+      NewColumnWithModifiers = NewColumn + length(Modifiers),
+      tokenize(Final, NewLine, NewColumnWithModifiers, Scope, [Token | Tokens]);
     {error, Reason} ->
       Sigil = [$~, S, H],
       interpolation_error(Reason, Original, Tokens, " (for sigil ~ts starting at line ~B)", [Sigil, Line])
@@ -617,9 +617,8 @@ handle_strings(T, Line, Column, H, Scope, Tokens) ->
         true  -> kw_identifier_safe;
         false -> kw_identifier_unsafe
       end,
-      NewColumn2 = NewColumn + 1,
       Token = {Key, {Line, Column - 1, nil}, Unescaped},
-      tokenize(Rest, NewLine, NewColumn2, Scope, [Token | Tokens]);
+      tokenize(Rest, NewLine, NewColumn + 1, Scope, [Token | Tokens]);
     {NewLine, NewColumn, Parts, Rest} ->
       Token = {string_type(H), {Line, Column - 1, nil}, unescape_tokens(Parts, Scope)},
       tokenize(Rest, NewLine, NewColumn, Scope, [Token | Tokens])

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -74,7 +74,8 @@ kw_test() ->
   [{kw_identifier, {1, 1, nil}, a@b}] = tokenize("a@b: "),
   [{kw_identifier, {1, 1, nil}, 'A@!'}] = tokenize("A@!: "),
   [{kw_identifier, {1, 1, nil}, 'a@!'}] = tokenize("a@!: "),
-  [{kw_identifier_unsafe, {1, 1, nil}, [<<"foo bar">>]}] = tokenize("\"foo bar\": ").
+  [{kw_identifier, {1, 1, nil}, foo}, {bin_string, {1, 6, nil}, [<<"bar">>]}] = tokenize("foo: \"bar\""),
+  [{kw_identifier_unsafe, {1, 1, nil}, [<<"foo">>]}, {bin_string, {1, 8, nil}, [<<"bar">>]}] = tokenize("\"foo\": \"bar\"").
 
 int_test() ->
   [{int, {1, 1, 123}, "123"}] = tokenize("123"),


### PR DESCRIPTION
This PR fixes cases where `:elixir_tokenizer` does not account for double quotes in keyword identifiers when determining the column for the next token.

### Current behavior

Given the tokens for

```elixir
foo: "bar"
```

and

```elixir
"foo": "bar"
```

the column value of the `"bar"` token is only incremented by +1 for the second example:

```elixir
iex(1)> :elixir_tokenizer.tokenize('foo: "bar"', 1, [])
{:ok,
 [{:kw_identifier, {1, 1, nil}, :foo}, {:bin_string, {1, 6, nil}, ["bar"]}]}
iex(2)> :elixir_tokenizer.tokenize('"foo": "bar"', 1, [])
{:ok,
 [
   {:kw_identifier_unsafe, {1, 1, nil}, ["foo"]},
   {:bin_string, {1, 7, nil}, ["bar"]}
 ]}
```

### Expected behavior

IMHO the column information should have changed by +2 instead of +1 after we added the two double quotes:

```elixir
iex(1)> :elixir_tokenizer.tokenize('"foo": "bar"', 1, [])
{:ok,
 [
   {:kw_identifier_unsafe, {1, 1, nil}, ["foo"]},
   {:bin_string, {1, 8, nil}, ["bar"]}
 ]}
```
