### PR TITLE
Indent an example all the way

### DIFF
--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -798,12 +798,13 @@ defmodule Inspect.Algebra do
 
   ## Examples
 
-      iex> doc = Inspect.Algebra.concat(
+      iex> doc =
       ...>   Inspect.Algebra.concat(
-      ...>     "Hughes",
-      ...>     Inspect.Algebra.line()
-      ...>   ), "Wadler"
-      ...> )
+      ...>     Inspect.Algebra.concat(
+      ...>       "Hughes",
+      ...>       Inspect.Algebra.line()
+      ...>     ), "Wadler"
+      ...>   )
       iex> Inspect.Algebra.format(doc, 80)
       ["Hughes", "\n", "Wadler"]
 

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -798,14 +798,14 @@ defmodule Inspect.Algebra do
 
   ## Examples
 
-    iex> doc = Inspect.Algebra.concat(
-    ...>   Inspect.Algebra.concat(
-    ...>     "Hughes",
-    ...>     Inspect.Algebra.line()
-    ...>   ), "Wadler"
-    ...> )
-    iex> Inspect.Algebra.format(doc, 80)
-    ["Hughes", "\n", "Wadler"]
+      iex> doc = Inspect.Algebra.concat(
+      ...>   Inspect.Algebra.concat(
+      ...>     "Hughes",
+      ...>     Inspect.Algebra.line()
+      ...>   ), "Wadler"
+      ...> )
+      iex> Inspect.Algebra.format(doc, 80)
+      ["Hughes", "\n", "Wadler"]
 
   """
   @since "1.6.0"


### PR DESCRIPTION
The example for `Inspect.Algebra.line/0` isn't indented enough to be recognized as a docstring.

![screenshot from 2018-06-03 10-49-21](https://user-images.githubusercontent.com/1505603/40888374-eda571e8-671b-11e8-9cd7-be4c628998a6.png)
