### PR TITLE
[Typespec#spec_to_quoted] ignore_vars should be converted to elixir variables

### DIFF
--- a/lib/elixir/lib/code/typespec.ex
+++ b/lib/elixir/lib/code/typespec.ex
@@ -40,7 +40,7 @@ defmodule Code.Typespec do
       end
 
     meta = [line: line]
-    ignore_vars = Keyword.keys(guards)
+    ignore_vars = Keyword.keys(guards) |> Enum.map(&erl_to_ex_var/1)
 
     vars =
       for type_expr <- args ++ [result],

--- a/lib/elixir/lib/code/typespec.ex
+++ b/lib/elixir/lib/code/typespec.ex
@@ -36,11 +36,11 @@ defmodule Code.Typespec do
 
     guards =
       for {:type, _, :constraint, [{:atom, _, :is_subtype}, [{:var, _, var}, type]]} <- constrs do
-        {var, typespec_to_quoted(type)}
+        {erl_to_ex_var(var), typespec_to_quoted(type)}
       end
 
     meta = [line: line]
-    ignore_vars = Keyword.keys(guards) |> Enum.map(&erl_to_ex_var/1)
+    ignore_vars = Keyword.keys(guards)
 
     vars =
       for type_expr <- args ++ [result],

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -339,7 +339,7 @@ defmodule IEx.HelpersTest do
       assert capture_io(fn -> h(:timer.sleep() / 1) end) == """
              * :timer.sleep/1
 
-               @spec sleep(time) :: :ok when Time: timeout()
+               @spec sleep(time) :: :ok when time: timeout()
 
              Documentation is not available for non-Elixir modules. Showing only specs.
              """
@@ -348,17 +348,17 @@ defmodule IEx.HelpersTest do
              * :timer.send_interval/3
 
                @spec send_interval(time, pid, message) :: {:ok, tRef} | {:error, reason}
-                     when Time: time(),
-                          Pid: pid() | (regName :: atom()),
-                          Message: term(),
-                          TRef: tref(),
-                          Reason: term()
+                     when time: time(),
+                          pid: pid() | (regName :: atom()),
+                          message: term(),
+                          tRef: tref(),
+                          reason: term()
 
              Documentation is not available for non-Elixir modules. Showing only specs.
              * :timer.send_interval/2
 
                @spec send_interval(time, message) :: {:ok, tRef} | {:error, reason}
-                     when Time: time(), Message: term(), TRef: tref(), Reason: term()
+                     when time: time(), message: term(), tRef: tref(), reason: term()
 
              Documentation is not available for non-Elixir modules. Showing only specs.
              """

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -339,7 +339,7 @@ defmodule IEx.HelpersTest do
       assert capture_io(fn -> h(:timer.sleep() / 1) end) == """
              * :timer.sleep/1
 
-               @spec sleep(time) :: :ok when Time: timeout(), time: var
+               @spec sleep(time) :: :ok when Time: timeout()
 
              Documentation is not available for non-Elixir modules. Showing only specs.
              """
@@ -352,25 +352,13 @@ defmodule IEx.HelpersTest do
                           Pid: pid() | (regName :: atom()),
                           Message: term(),
                           TRef: tref(),
-                          Reason: term(),
-                          time: var,
-                          pid: var,
-                          message: var,
-                          tRef: var,
-                          reason: var
+                          Reason: term()
 
              Documentation is not available for non-Elixir modules. Showing only specs.
              * :timer.send_interval/2
 
                @spec send_interval(time, message) :: {:ok, tRef} | {:error, reason}
-                     when Time: time(),
-                          Message: term(),
-                          TRef: tref(),
-                          Reason: term(),
-                          time: var,
-                          message: var,
-                          tRef: var,
-                          reason: var
+                     when Time: time(), Message: term(), TRef: tref(), Reason: term()
 
              Documentation is not available for non-Elixir modules. Showing only specs.
              """


### PR DESCRIPTION
Refs https://github.com/elixir-lang/elixir/issues/7712

When building the `when` clause `Typespec#spec_to_quoted`, we want to ignore var:

```elixir
    ignore_vars = Keyword.keys(guards)

    vars =
      for type_expr <- args ++ [result],
          var <- collect_vars(type_expr),
          var not in ignore_vars,
          uniq: true,
          do: {var, {:var, meta, nil}}
```

But `ignore_vars` contains a list of codelists where as `collect_vars` returns an elixir variable:

```elixir
  defp collect_vars({:var, _line, var}) do
    [erl_to_ex_var(var)]
  end
```
As a result, this filter (`var not in ignore_vars,`) doesn't work as intended.

Converting ignore_vars to a list of elixir variables will fix it.
`ignore_vars = Keyword.keys(guards) |> Enum.map(&erl_to_ex_var/1)`

Before:
![image](https://user-images.githubusercontent.com/3139206/40889489-6b9587be-671c-11e8-98a7-c83482e6a2f8.png)

After:
![image](https://user-images.githubusercontent.com/3139206/40889492-7da4a822-671c-11e8-8b1e-84910480a95d.png)

====
Updates after @michalmuskala 's feedback.

Now the variable names inside the when clause are lower case for the sake of consistency.
![image](https://user-images.githubusercontent.com/3139206/40892208-87e45d2e-6748-11e8-9622-fa16734c90a3.png)
