### PR TITLE
raise if piping into bitstring operator <<>>

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -127,6 +127,10 @@ defmodule Macro do
     raise ArgumentError, bad_pipe(expr, call_args)
   end
 
+  def pipe(expr, {:<<>>, _, _} = call_args, _integer) do
+    raise ArgumentError, bad_pipe(expr, call_args)
+  end
+
   # {:fn, _, _} is what we get when we pipe into an anonymous function without
   # calling it, e.g., `:foo |> (fn x -> x end)`.
   def pipe(expr, {:fn, _, _}, _integer) do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -770,6 +770,10 @@ defmodule MacroTest do
       Macro.pipe(1, quote(do: 1 + 1), 0) == quote(do: foo(1))
     end
 
+    assert_raise ArgumentError, ~r"cannot pipe 1 into <<1>>", fn ->
+      Macro.pipe(1, quote(do: <<1>>), 0)
+    end
+
     # TODO: restore this test when we drop unary operator support in pipes
     # assert_raise ArgumentError, ~r"cannot pipe 1 into \+1", fn ->
     #   Macro.pipe(1, quote(do: + 1), 0)


### PR DESCRIPTION
Fixes #7721: 

`1 |> <<1,2,3>>` was valid syntax as it was compiled to
<<1, 1, 2, 3>>. `<<>>` is an operator, the pipe operator (`|>`) prepended an
extra argument. Same goes for situations with interpolation since that leads to
creation of a new string, using `<<>>` and `::`.