### PR TITLE
Add support for "--organization" in the archive.install task

### DIFF
--- a/lib/mix/lib/mix/local/installer.ex
+++ b/lib/mix/lib/mix/local/installer.ex
@@ -216,7 +216,7 @@ defmodule Mix.Local.Installer do
     dep_opts =
       opts
       |> Keyword.take([:organization])
-      |> Keyword.merge(hex: String.to_atom(package_name))
+      |> Keyword.put(:hex, String.to_atom(package_name))
 
     {:fetcher, {String.to_atom(app_name), version, dep_opts}}
   end

--- a/lib/mix/lib/mix/local/installer.ex
+++ b/lib/mix/lib/mix/local/installer.ex
@@ -213,7 +213,12 @@ defmodule Mix.Local.Installer do
         package_name
       end
 
-    {:fetcher, {String.to_atom(app_name), version, hex: String.to_atom(package_name)}}
+    dep_opts =
+      opts
+      |> Keyword.take([:organization])
+      |> Keyword.merge(hex: String.to_atom(package_name))
+
+    {:fetcher, {String.to_atom(app_name), version, dep_opts}}
   end
 
   def parse_args(["hex" | [_package_name | rest]], _opts) do

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -51,11 +51,21 @@ defmodule Mix.Tasks.Archive.Install do
     * `--app` - specifies a custom app name to be used for building the archive
       from Git, GitHub, or Hex
 
+    * `--organization` - specifies an organization to use if fetching the package
+      from a private Hex repository
+
   """
 
   @behaviour Mix.Local.Installer
 
-  @switches [force: :boolean, sha512: :string, submodules: :boolean, app: :string]
+  @switches [
+    force: :boolean,
+    sha512: :string,
+    submodules: :boolean,
+    app: :string,
+    organization: :string
+  ]
+
   def run(argv) do
     Mix.Local.Installer.install(__MODULE__, argv, @switches)
   end

--- a/lib/mix/lib/mix/tasks/escript.install.ex
+++ b/lib/mix/lib/mix/tasks/escript.install.ex
@@ -51,13 +51,23 @@ defmodule Mix.Tasks.Escript.Install do
     * `--app` - specifies a custom app name to be used for building the escript
       from Git, GitHub, or Hex
 
+    * `--organization` - specifies an organization to use if fetching the package
+      from a private Hex repository
+
   """
 
   @behaviour Mix.Local.Installer
 
   # only read and execute permissions
   @escript_file_mode 0o555
-  @switches [force: :boolean, sha512: :string, submodules: :boolean, app: :string]
+
+  @switches [
+    force: :boolean,
+    sha512: :string,
+    submodules: :boolean,
+    app: :string,
+    organization: :string
+  ]
 
   def run(argv) do
     Mix.Local.Installer.install(__MODULE__, argv, @switches)

--- a/lib/mix/test/mix/local/installer_test.exs
+++ b/lib/mix/test/mix/local/installer_test.exs
@@ -85,6 +85,6 @@ defmodule Mix.Local.InstallerTest do
 
   test "parse_args Hex with organization" do
     assert Mix.Local.Installer.parse_args(["hex", "a_package"], organization: "my_org") ==
-             {:fetcher, {:a_package, ">= 0.0.0", [organization: "my_org", hex: :a_package]}}
+             {:fetcher, {:a_package, ">= 0.0.0", [hex: :a_package, organization: "my_org"]}}
   end
 end

--- a/lib/mix/test/mix/local/installer_test.exs
+++ b/lib/mix/test/mix/local/installer_test.exs
@@ -82,4 +82,9 @@ defmodule Mix.Local.InstallerTest do
     assert Mix.Local.Installer.parse_args(["hex", "a_package", "1.0.0"], []) ==
              {:fetcher, {:a_package, "1.0.0", [hex: :a_package]}}
   end
+
+  test "parse_args Hex with organization" do
+    assert Mix.Local.Installer.parse_args(["hex", "a_package"], organization: "my_org") ==
+             {:fetcher, {:a_package, ">= 0.0.0", [organization: "my_org", hex: :a_package]}}
+  end
 end


### PR DESCRIPTION
For archives downloaded from Hex, we want to be able to pass in an organization:

    mix archive.install hex my_package --organization my_org

Do we want to support `--repo` as well?

PS: did this pairing up with @idlehands, thanks for the help Jeffrey! 💟 