### PR TITLE
Fix type spec for Task.Supervisor.start_child/4

### DIFF
--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -317,7 +317,7 @@ defmodule Task.Supervisor do
       or an integer indicating the timeout value, defaults to 5000 milliseconds.
 
   """
-  @spec start_child(Supervisor.supervisor(), (() -> any)) :: {:ok, pid}
+  @spec start_child(Supervisor.supervisor(), (() -> any)) :: DynamicSupervisor.on_start_child()
   def start_child(supervisor, fun, options \\ []) do
     restart = options[:restart]
     shutdown = options[:shutdown]
@@ -331,7 +331,8 @@ defmodule Task.Supervisor do
   Similar to `start_child/2` except the task is specified
   by the given `module`, `fun` and `args`.
   """
-  @spec start_child(Supervisor.supervisor(), module, atom, [term]) :: {:ok, pid}
+  @spec start_child(Supervisor.supervisor(), module, atom, [term]) ::
+          DynamicSupervisor.on_start_child()
   def start_child(supervisor, module, fun, args, options \\ [])
       when is_atom(fun) and is_list(args) do
     restart = options[:restart]


### PR DESCRIPTION
This is v1.6 branch version of this PR https://github.com/elixir-lang/elixir/pull/7744

Behind the scenes, this function uses DynamicSupervisor.start_child/4, which can return multiple errors. This gives Task.Supervisor.start_child/4 that return type. This allows dialyzer to not complain when you pass :max_children to the Task.Supervisor and call start_child, which may return {:error, :max_children}.