### PR TITLE
Add instructions for fixing deadlock errors

### DIFF
--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -441,7 +441,10 @@ defmodule Kernel.ParallelCompiler do
       IO.puts(["  ", String.pad_leading(file, max), " => " | inspect(mod)])
     end
 
-    IO.puts("")
+    IO.puts(
+      "\nEnsure there are no compile-time dependencies between those files " <>
+        "and that the modules they reference exist and are correctly named.\n"
+    )
 
     for {file, _, description} <- deadlock, do: {Path.absname(file), nil, description}
   end


### PR DESCRIPTION
Example:

```
Compilation failed because of a deadlock between files.
The following files depended on the following modules:

          lib/hexpm/web/controllers/api/repository_controller.ex => Organization
                                lib/hexpm/repository/sitemaps.ex => Hexpm.Accounts.AuditLog
                                      lib/hexpm/accounts/user.ex => Hexpm.Accounts.AuditLog
                                     lib/hexpm/accounts/users.ex => Hexpm.Accounts.AuditLog
                                lib/hexpm/repository/releases.ex => Hexpm.Accounts.AuditLog
                    lib/hexpm/web/controllers/user_controller.ex => Organization
                                 lib/hexpm/accounts/audit_log.ex => Organization
                                  lib/hexpm/repository/owners.ex => Hexpm.Accounts.AuditLog
                             lib/hexpm/accounts/organizations.ex => Hexpm.Accounts.AuditLog
                                lib/hexpm/repository/packages.ex => Hexpm.Accounts.AuditLog
  lib/hexpm/web/controllers/dashboard/organization_controller.ex => Organization
                              lib/hexpm/accounts/organization.ex => Hexpm.Accounts.AuditLog
                                lib/hexpm/repository/installs.ex => Hexpm.Accounts.AuditLog
                                      lib/hexpm/accounts/keys.ex => Hexpm.Accounts.AuditLog

Ensure there are no compile-time dependencies between those files and that the modules they reference exist and are correctly named.
```