### PR TITLE
Fix typo in Library Guidelines: paralleiize -> parallelize

### DIFF
--- a/lib/elixir/pages/Library Guidelines.md
+++ b/lib/elixir/pages/Library Guidelines.md
@@ -235,7 +235,7 @@ def subtract(a, b) do
 end
 ```
 
-Use processes only to model runtime properties, never for code organization. And even when you think something could be done in parallel with processes, often it is best to let the callers of your library decide how to paralleiize, rather than impose a certain execution flow in users of your code.
+Use processes only to model runtime properties, never for code organization. And even when you think something could be done in parallel with processes, often it is best to let the callers of your library decide how to parallelize, rather than impose a certain execution flow in users of your code.
 
 ### Avoid spawning unsupervised processes
 


### PR DESCRIPTION
[ci skip]