### PR TITLE
Refactor __info__ so it generates smaller assembly

### DIFF
--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -329,8 +329,8 @@ macros_info(Defmacro) ->
   {clause, 0, [{atom, 0, macros}], [], [elixir_erl:elixir_to_erl(lists:sort(Defmacro))]}.
 
 get_module_info(Module, Key) ->
-  Call = remote(0, erlang, get_module_info, [{atom, 0, Module}, {atom, 0, Key}]),
-  {clause, 0, [{atom, 0, Key}], [], [Call]}.
+  Call = remote(0, erlang, get_module_info, [{atom, 0, Module}, {var, 0, 'Key'}]),
+  {clause, 0, [{match, 0, {var, 0, 'Key'}, {atom, 0, Key}}], [], [Call]}.
 
 deprecated_info(Deprecated) ->
   {clause, 0, [{atom, 0, deprecated}], [], [elixir_erl:elixir_to_erl(Deprecated)]}.

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -294,7 +294,7 @@ defmodule ModuleTest do
       end
 
     atoms = :beam_lib.chunks(binary, [:atoms])
-    assert :erlang.phash2(atoms) == 98_328_115
+    assert :erlang.phash2(atoms) == 61_635_213
   end
 
   test "create with generated true does not emit warnings" do


### PR DESCRIPTION
The phash value changes because clauses for the `__info__` function
are now ordered differently