### PR TITLE
Fix the LFE example in Mix.Compilers.Erlang

### DIFF
--- a/lib/mix/lib/mix/compilers/erlang.ex
+++ b/lib/mix/lib/mix/compilers/erlang.ex
@@ -22,7 +22,7 @@ defmodule Mix.Compilers.Erlang do
 
       compile manifest, [{"src", dest}], :lfe, :beam, opts, fn input, output ->
         :lfe_comp.file(to_erl_file(input),
-                       [{output_dir, Path.dirname(output)}, :return])
+                       [{:outdir, Path.dirname(output)}, :return, :report])
       end
 
   The command above will:


### PR DESCRIPTION
I wanted to make it easier for Elixir developers to try and play with LFE (as I like LFE), so decided to create a mix task for compiling LFE, which gave birth to [mix_lfe](https://github.com/meddle0x53/mix_lfe).

To my surprise, I found an example for exactly that in `Mix.Compilers.Erlang`, while I was looking at Mix's sources which was almost right, but not quite. I used the idea [here](https://github.com/meddle0x53/mix_lfe/blob/6021715d5af181069eb0fd09dcd1787a020ff0de/lib/mix/compilers/lfe.ex#L26) and modified it to work, so decided to fix this example too:

* The `:outdir` fixes a syntax error in the example and is a real option of the `:lfe_comp.file/2`.
* The `:report` option will make it so that compiler errors are shown when the sources are compiled.