### PR TITLE
Fix small grammar error in Integer.parse docs

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -187,7 +187,7 @@ defmodule Integer do
 
   Raises an error if `base` is less than 2 or more than 36.
 
-  If you want to convert a string-formatted integer directly to a integer,
+  If you want to convert a string-formatted integer directly to an integer,
   `String.to_integer/1` or `String.to_integer/2` can be used instead.
 
   ## Examples


### PR DESCRIPTION
... a integer -> an integer