### PR TITLE
Restore and/or optimisation

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1540,14 +1540,9 @@ defmodule Kernel do
     optimize_boolean(
       quote do
         case unquote(check) do
-          true ->
-            unquote(true_clause)
-
-          false ->
-            unquote(false_clause)
-
-          other ->
-            :erlang.error(BadBooleanError.exception(operator: unquote(operator), term: other))
+          false -> unquote(false_clause)
+          true -> unquote(true_clause)
+          other -> :erlang.error({:badbool, unquote(operator), other})
         end
       end
     )

--- a/lib/elixir/test/elixir/fixtures/dialyzer/boolean_check.ex
+++ b/lib/elixir/test/elixir/fixtures/dialyzer/boolean_check.ex
@@ -3,15 +3,7 @@ defmodule Dialyzer.BooleanCheck do
     arg and arg
   end
 
-  def and_check_optimized(arg) when is_integer(arg) do
-    arg < :infinity and arg
-  end
-
   def or_check(arg) when is_boolean(arg) do
     arg or arg
-  end
-
-  def or_check_optimized(arg) when is_integer(arg) do
-    arg < :infinity or arg
   end
 end

--- a/lib/elixir/test/erlang/control_test.erl
+++ b/lib/elixir/test/erlang/control_test.erl
@@ -215,6 +215,18 @@ optimized_oror_test() ->
     {clause, 1, [{var, 1, Var}], [], [{var, 1, Var}]}]
   } = to_erl("is_list([]) || :done").
 
+optimized_and_test() ->
+  {'case',_, _,
+   [{clause, _, [{atom, 0, false}], [], [{atom, 0, false}]},
+    {clause, _, [{atom, 0, true}], [], [{atom, 0, done}]}]
+  } = to_erl("is_list([]) and :done").
+
+optimized_or_test() ->
+  {'case', _, _,
+    [{clause, _, [{atom, 0, false}], [], [{atom, 0, done}]},
+     {clause, _, [{atom, 0, true}], [], [{atom, 0, true}]}]
+  } = to_erl("is_list([]) or :done").
+
 no_after_in_try_test() ->
   {'try', _, [_], [_], _, []} = to_erl("try do :foo.bar() else _ -> :ok end").
 


### PR DESCRIPTION
The optimize_boolean option is very sensitive to the order of
clauses and the optimisation was not happening for and/2 and or/2.

Add regression tests to ensure that won't happen again.

---

This change breaks the dialyzer test for optimised booleans:
```elixir
  def and_check_optimized(arg) when is_integer(arg) do
    arg < :infinity and arg
  end
```
this now emits a warning that the pattern `false` can never match. It's weird because we have already all the clauses marked with `generated`, so I'm not sure why this is emitted. Anyway, the warning is very correct in here, since the `false` branch can never be taken, it's just pretty unreadable to the user - I'm not sure what to do about this.