### PR TITLE
Link style guide in "mix format" documentation

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -4,7 +4,8 @@ defmodule Mix.Tasks.Format do
   @shortdoc "Formats the given files/patterns"
 
   @moduledoc """
-  Formats the given files and patterns.
+  Formats the given files and patterns. In compliance with
+  [lexmag's Elixir Style Guide](https://github.com/lexmag/elixir-style-guide).
 
       mix format mix.exs "lib/**/*.{ex,exs}" "test/**/*.{ex,exs}"
 


### PR DESCRIPTION
I might be late to the party but thanks for introducing the formatter in 1.6. It truly helps to maintain the code style among the team much more easier.

I would like to propose a change in the documentation for `mix format`. I linked @lexmag's style guide which I assume to be the guide that is being followed by the formatter. Please kindly advise if my assumption was wrong.

I think having a link to the guide in the docs would help the users to know what to expect when running the Mix task.