### PR TITLE
Include caller information on struct expansion errors, closes #7752

### DIFF
--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -149,10 +149,9 @@ load_struct(Meta, Name, Args, InContext, E) ->
       end;
 
     Kind:Reason ->
-      Stacktrace = erlang:get_stacktrace(),
       Info = [{Name, '__struct__', Arity, [{file, "expanding struct"}]},
               elixir_utils:caller(?line(Meta), ?key(E, file), ?key(E, module), ?key(E, function))],
-      erlang:raise(Kind, Reason, prune_stacktrace(Stacktrace, Name, Arity) ++ Info)
+      erlang:raise(Kind, Reason, Info)
   end.
 
 prune_stacktrace([{Module, '__struct__', Arity, _} | _], Module, Arity) ->

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -440,7 +440,7 @@ defmodule Kernel.ErrorsTest do
     end
 
     assert_eval_raise KeyError,
-                      "key :age not found in: %Kernel.ErrorsTest.GoodStruct{name: \"john\"}",
+                      "key :age not found",
                       '%#{GoodStruct}{age: 27}'
 
     assert_eval_raise CompileError,


### PR DESCRIPTION
Partial credit: @tuxified helped me figure this puzzle out.