### PR TITLE
Fix description of max_children option

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -493,7 +493,7 @@ defmodule DynamicSupervisor do
 
     * `:max_children` - the maximum amount of children to be running
       under this supervisor at the same time. When `:max_children` is
-      exceeded, `start_child/2` returns `{:error, :dynamic}`. Defaults
+      exceeded, `start_child/2` returns `{:error, :max_children}`. Defaults
       to `:infinity`.
 
     * `:extra_arguments` - arguments that are prepended to the arguments


### PR DESCRIPTION
It returns `{:error, :max_children}` instead of `{:error, :dynamic}`.