### PR TITLE
Annotates arithmetic error for better debug experience

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -713,13 +713,10 @@ defmodule ArithmeticError do
   defexception message: "bad argument in arithmetic expression"
 
   @impl true
-  def blame(
-        %{message: default_message} = exception,
-        [{:erlang, func, args, _} | _] = stacktrace
-      ) do
+  def blame(%{message: message} = exception, [{:erlang, fun, args, _} | _] = stacktrace) do
     message =
-      default_message <>
-        case {func, args} do
+      message <>
+        case {fun, args} do
           {:+, [a]} ->
             ": +(#{inspect(a)})"
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -711,6 +711,67 @@ end
 
 defmodule ArithmeticError do
   defexception message: "bad argument in arithmetic expression"
+
+  @impl true
+  def blame(
+        %{message: default_message} = exception,
+        [{:erlang, func, args, _} | _] = stacktrace
+      ) do
+    message =
+      default_message <>
+        case {func, args} do
+          {:+, [a]} ->
+            ": +(#{inspect(a)})"
+
+          {:+, [a, b]} ->
+            ": #{inspect(a)} + #{inspect(b)}"
+
+          {:-, [a]} ->
+            ": -(#{inspect(a)})"
+
+          {:-, [a, b]} ->
+            ": #{inspect(a)} - #{inspect(b)}"
+
+          {:*, [a, b]} ->
+            ": #{inspect(a)} * #{inspect(b)}"
+
+          {:/, [a, b]} ->
+            ": #{inspect(a)} / #{inspect(b)}"
+
+          {:div, [a, b]} ->
+            ": div(#{inspect(a)}, #{inspect(b)})"
+
+          {:rem, [a, b]} ->
+            ": rem(#{inspect(a)}, #{inspect(b)})"
+
+          {:band, [a, b]} ->
+            ": Bitwise.band(#{inspect(a)}, #{inspect(b)})"
+
+          {:bor, [a, b]} ->
+            ": Bitwise.bor(#{inspect(a)}, #{inspect(b)})"
+
+          {:bxor, [a, b]} ->
+            ": Bitwise.bxor(#{inspect(a)}, #{inspect(b)})"
+
+          {:bsl, [a, b]} ->
+            ": Bitwise.bsl(#{inspect(a)}, #{inspect(b)})"
+
+          {:bsr, [a, b]} ->
+            ": Bitwise.bsr(#{inspect(a)}, #{inspect(b)})"
+
+          {:bnot, [a]} ->
+            ": Bitwise.bnot(#{inspect(a)})"
+
+          _ ->
+            ""
+        end
+
+    {%{exception | message: message}, stacktrace}
+  end
+
+  def blame(exception, stacktrace) do
+    {exception, stacktrace}
+  end
 end
 
 defmodule SystemLimitError do

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -482,11 +482,92 @@ defmodule ExceptionTest do
                  "such as map.field or module.function, make sure the left side of the dot is an atom or a map"
     end
 
+    if :erlang.system_info(:otp_release) >= '21' do
+      test "annotates +/1 arithmetic errors" do
+        assert blame_message(:foo, &(+&1)) == "bad argument in arithmetic expression: +(:foo)"
+      end
+
+      test "annotates -/1 arithmetic errors" do
+        assert blame_message(:foo, &(-&1)) == "bad argument in arithmetic expression: -(:foo)"
+      end
+
+      test "annotates div arithmetic errors" do
+        assert blame_message(0, &div(10, &1)) ==
+                 "bad argument in arithmetic expression: div(10, 0)"
+      end
+
+      test "annotates rem arithmetic errors" do
+        assert blame_message(0, &rem(10, &1)) ==
+                 "bad argument in arithmetic expression: rem(10, 0)"
+      end
+
+      test "annotates band arithmetic errors" do
+        use Bitwise
+
+        assert blame_message(:foo, &band(10, &1)) ==
+                 "bad argument in arithmetic expression: Bitwise.band(10, :foo)"
+
+        assert blame_message(:foo, &(10 &&& &1)) ==
+                 "bad argument in arithmetic expression: Bitwise.band(10, :foo)"
+      end
+
+      test "annotates bor arithmetic errors" do
+        use Bitwise
+
+        assert blame_message(:foo, &bor(10, &1)) ==
+                 "bad argument in arithmetic expression: Bitwise.bor(10, :foo)"
+
+        assert blame_message(:foo, &(10 ||| &1)) ==
+                 "bad argument in arithmetic expression: Bitwise.bor(10, :foo)"
+      end
+
+      test "annotates bxor arithmetic errors" do
+        use Bitwise
+
+        assert blame_message(:foo, &bxor(10, &1)) ==
+                 "bad argument in arithmetic expression: Bitwise.bxor(10, :foo)"
+
+        assert blame_message(:foo, &(10 ^^^ &1)) ==
+                 "bad argument in arithmetic expression: Bitwise.bxor(10, :foo)"
+      end
+
+      test "annotates bsl arithmetic errors" do
+        use Bitwise
+
+        assert blame_message(:foo, &bsl(10, &1)) ==
+                 "bad argument in arithmetic expression: Bitwise.bsl(10, :foo)"
+
+        assert blame_message(:foo, &(10 <<< &1)) ==
+                 "bad argument in arithmetic expression: Bitwise.bsl(10, :foo)"
+      end
+
+      test "annotates bsr arithmetic errors" do
+        use Bitwise
+
+        assert blame_message(:foo, &bsr(10, &1)) ==
+                 "bad argument in arithmetic expression: Bitwise.bsr(10, :foo)"
+
+        assert blame_message(:foo, &(10 >>> &1)) ==
+                 "bad argument in arithmetic expression: Bitwise.bsr(10, :foo)"
+      end
+
+      test "annotates bnot arithmetic errors" do
+        use Bitwise
+
+        assert blame_message(:foo, &bnot(&1)) ==
+                 "bad argument in arithmetic expression: Bitwise.bnot(:foo)"
+
+        assert blame_message(:foo, &(~~~&1)) ==
+                 "bad argument in arithmetic expression: Bitwise.bnot(:foo)"
+      end
+    end
+
     defp blame_message(arg, fun) do
       try do
         fun.(arg)
       rescue
-        e -> Exception.blame(:error, e, __STACKTRACE__) |> elem(0) |> Exception.message()
+        e ->
+          Exception.blame(:error, e, __STACKTRACE__) |> elem(0) |> Exception.message()
       end
     end
 


### PR DESCRIPTION
Tries to solve #7789 

There are four operators that do not work correctly because the stack trace does not include the last call. The following tests were not added to avoid test fails:

```elixir
# FAIL
test "annotates +/2 arithmetic errors" do
  assert blame_message(:foo, &(&1+1)) == "bad argument in arithmetic expression: tried to sum :foo and 1"
end

# FAIL
test "annotates -/2 arithmetic errors" do
  assert blame_message(:foo, &(&1 - 1)) == "bad argument in arithmetic expression: tried to substract :foo and 1"
end

# FAIL
test "annotates */2 arithmetic errors" do
  assert blame_message(:foo, &(&1 * 1)) == "bad argument in arithmetic expression: tried to multiply :foo by 1"
end

# FAIL
test "annotates '/' operator arithmetic errors" do
  assert blame_message(0, &(10 / &1)) == "bad argument in arithmetic expression: tried to divide 10 by 0"
end
```