### PR TITLE
Make test suite for assert_no_guard more robust

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4877,7 +4877,8 @@ defmodule Kernel do
 
       if is_list(funs) do
         message =
-          "passing a list to Kernel.defdelegate/2 is deprecated, please define each delegate separately"
+          "passing a list to Kernel.defdelegate/2 is deprecated, " <>
+            "please define each delegate separately"
 
         :elixir_errors.warn(line, file, message)
       end
@@ -5219,7 +5220,8 @@ defmodule Kernel do
     case context do
       :guard ->
         raise ArgumentError,
-              "invalid expression in guard, #{exp} is not allowed in guards. To learn more about guards, visit: https://hexdocs.pm/elixir/guards.html"
+              "invalid expression in guard, #{exp} is not allowed in guards. " <>
+                "To learn more about guards, visit: https://hexdocs.pm/elixir/guards.html"
 
       _ ->
         :ok

--- a/lib/elixir/test/elixir/kernel/guard_test.exs
+++ b/lib/elixir/test/elixir/kernel/guard_test.exs
@@ -290,19 +290,19 @@ defmodule Kernel.GuardTest do
 
       # Consistent errors
 
-      assert_raise ArgumentError, ~r"invalid expression in guard", fn ->
+      assert_raise ArgumentError, ~r"invalid expression in guard, ! is not allowed", fn ->
         defmodule SoftNegationLogicUsage do
           defguard foo(logic) when !logic
         end
       end
 
-      assert_raise ArgumentError, ~r"invalid expression in guard", fn ->
+      assert_raise ArgumentError, ~r"invalid expression in guard, && is not allowed", fn ->
         defmodule SoftAndLogicUsage do
           defguard foo(soft, logic) when soft && logic
         end
       end
 
-      assert_raise ArgumentError, ~r"invalid expression in guard", fn ->
+      assert_raise ArgumentError, ~r"invalid expression in guard, || is not allowed", fn ->
         defmodule SoftOrLogicUsage do
           defguard foo(soft, logic) when soft || logic
         end


### PR DESCRIPTION
If I got it right, one of the reasons for that change was to get the message:

> invalid expression in guard, **!** is not allowed in guards. To learn more about guards, visit: https://hexdocs.pm/elixir/guards.html  

instead of:

> invalid expression in guard, **case** is not allowed in guards. To learn more about guards, visit: https://hexdocs.pm/elixir/guards.html

This change should make the test suite more robust for future changes or refactors :)

In addition, I've split a couple of strings that were exceeding the maximum line length (98). By the way, should the formatter warn when it cannot keep the code under the desired line length? maybe with a `--strict` flag?