### PR TITLE
Move `Code.string_to_quoted` error logic up

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -661,8 +661,12 @@ defmodule Code do
     file = Keyword.get(opts, :file, "nofile")
     line = Keyword.get(opts, :line, 1)
 
-    with {:ok, tokens} <- :elixir.string_to_tokens(to_charlist(string), line, file, opts) do
-      :elixir.tokens_to_quoted(tokens, file, opts)
+    case :elixir.string_to_tokens(to_charlist(string), line, file, opts) do
+      {:ok, tokens} ->
+        :elixir.tokens_to_quoted(tokens, file, opts)
+
+      {:error, _error_msg} = error ->
+        error
     end
   end
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4943,7 +4943,7 @@ defmodule Kernel do
   end
 
   defmacro sigil_s({:<<>>, line, pieces}, []) do
-    {:<<>>, line, :elixir_interpolation.unescape_tokens(pieces)}
+    {:<<>>, line, unescape_tokens(pieces)}
   end
 
   @doc ~S"""
@@ -4994,7 +4994,7 @@ defmodule Kernel do
   end
 
   defmacro sigil_c({:<<>>, meta, pieces}, []) do
-    binary = {:<<>>, meta, :elixir_interpolation.unescape_tokens(pieces)}
+    binary = {:<<>>, meta, unescape_tokens(pieces)}
     quote(do: String.to_charlist(unquote(binary)))
   end
 
@@ -5024,7 +5024,7 @@ defmodule Kernel do
   end
 
   defmacro sigil_r({:<<>>, meta, pieces}, options) do
-    binary = {:<<>>, meta, :elixir_interpolation.unescape_tokens(pieces, &Regex.unescape_map/1)}
+    binary = {:<<>>, meta, unescape_tokens(pieces, &Regex.unescape_map/1)}
     quote(do: Regex.compile!(unquote(binary), unquote(:binary.list_to_bin(options))))
   end
 
@@ -5141,7 +5141,7 @@ defmodule Kernel do
   end
 
   defmacro sigil_w({:<<>>, meta, pieces}, modifiers) do
-    binary = {:<<>>, meta, :elixir_interpolation.unescape_tokens(pieces)}
+    binary = {:<<>>, meta, unescape_tokens(pieces)}
     split_words(binary, modifiers)
   end
 
@@ -5225,6 +5225,21 @@ defmodule Kernel do
 
       _ ->
         :ok
+    end
+  end
+
+  # Helper to handle the :ok | :error tuple returned from :elixir_interpolation.unescape_tokens
+  defp unescape_tokens(tokens) do
+    case :elixir_interpolation.unescape_tokens(tokens) do
+      {:ok, unescaped_tokens} -> unescaped_tokens
+      {:error, reason} -> raise(ArgumentError, to_string(reason))
+    end
+  end
+
+  defp unescape_tokens(tokens, unescape_map) do
+    case :elixir_interpolation.unescape_tokens(tokens, unescape_map) do
+      {:ok, unescaped_tokens} -> unescaped_tokens
+      {:error, reason} -> raise(ArgumentError, to_string(reason))
     end
   end
 

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -532,13 +532,19 @@ defmodule Macro do
   @doc false
   @deprecated "Traverse over the arguments using Enum.map/2 instead"
   def unescape_tokens(tokens) do
-    :elixir_interpolation.unescape_tokens(tokens)
+    case :elixir_interpolation.unescape_tokens(tokens) do
+      {:ok, unescaped_tokens} -> unescaped_tokens
+      {:error, reason} -> raise(ArgumentError, to_string(reason))
+    end
   end
 
   @doc false
   @deprecated "Traverse over the arguments using Enum.map/2 instead"
   def unescape_tokens(tokens, map) do
-    :elixir_interpolation.unescape_tokens(tokens, map)
+    case :elixir_interpolation.unescape_tokens(tokens, map) do
+      {:ok, unescaped_tokens} -> unescaped_tokens
+      {:error, reason} -> raise(ArgumentError, to_string(reason))
+    end
   end
 
   @doc """

--- a/lib/elixir/src/elixir_interpolation.erl
+++ b/lib/elixir/src/elixir_interpolation.erl
@@ -78,7 +78,13 @@ unescape_tokens(Tokens) ->
   unescape_tokens(Tokens, fun unescape_map/1).
 
 unescape_tokens(Tokens, Map) ->
-  [unescape_token(Token, Map) || Token <- Tokens].
+  try [unescape_token(Token, Map) || Token <- Tokens] of
+    Unescaped ->
+      {ok, Unescaped}
+  catch
+    {error, _Reason} = Error ->
+      Error
+  end.
 
 unescape_token(Token, Map) when is_binary(Token) -> unescape_chars(Token, Map);
 unescape_token(Other, _Map) -> Other.
@@ -151,8 +157,7 @@ unescape_hex(<<${, A, B, C, D, E, F, $}, Rest/binary>>, Map, Acc) when ?is_hex(A
   append_codepoint(Rest, Map, [A, B, C, D, E, F], Acc, 16);
 
 unescape_hex(<<_/binary>>, _Map, _Acc) ->
-  Msg = <<"missing hex sequence after \\x, expected \\xHH">>,
-  error('Elixir.ArgumentError':exception([{message, Msg}])).
+  throw({error, "missing hex sequence after \\x, expected \\xHH"}).
 
 %% Finish deprecated sequences
 

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -118,6 +118,11 @@ defmodule CodeTest do
       assert string_to_quoted.("foo + bar") == {:ok, {:+, [line: 1, column: 5], [foo, bar]}}
     end
 
+    test "returns an error tuple on hex errors" do
+      assert Code.string_to_quoted("\"\\x\"") ==
+               {:error, {1, "missing hex sequence after \\x, expected \\xHH", "\""}}
+    end
+
     test "raises on errors when string_to_quoted!/2 is used" do
       assert Code.string_to_quoted!("1 + 2") == {:+, [line: 1], [1, 2]}
 


### PR DESCRIPTION
As discussed in #7270, it would help if we moved up the error logic out of Erlang. So, instead of raising an exception, we'll return an error tuple.
Currently, this will only fix the Hex error use case, so does not completely resolve this issue. But, if this is the route we want to take, I can work on the other usecases.