### PR TITLE
disambiguate def/2 docs regarding anonymous functions

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3852,7 +3852,7 @@ defmodule Kernel do
       end
 
   Note that `\\` can't be used with anonymous functions because they
-  can only have a single arity.
+  can only have a sole arity.
 
   ## Function and variable names
 


### PR DESCRIPTION
I was reading through the docs, and I can see how `single` here can be misconstrued to mean functions of arity 1. I think that sole makes it clearer as referring to a sole arity instead of a single arity function.