### PR TITLE
Updated docs für GenServer.terminate

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -557,9 +557,10 @@ defmodule GenServer do
   Therefore it is not guaranteed that `c:terminate/2` is called when a `GenServer`
   exits. For such reasons, we usually recommend important clean-up rules to
   happen in separated processes either by use of monitoring or by links
-  themselves. For example if the `GenServer` controls a `port` (e.g.
-  `:gen_tcp.socket`) or `t:File.io_device/0`, they will be closed on receiving a
-  `GenServer`'s exit signal and do not need to be closed in `c:terminate/2`.
+  themselves. There is no cleanup needed when the `GenServer` controls a `port` (e.g.
+  `:gen_tcp.socket`) or `t:File.io_device/0`, because these will be closed on 
+  receiving a `GenServer`'s exit signal and do not need to be closed manually
+  in `c:terminate/2`.
 
   If `reason` is not `:normal`, `:shutdown`, nor `{:shutdown, term}` an error is
   logged.


### PR DESCRIPTION
Tried to make the docs more clear that manual cleanup is not needed for opened sockets and files.