### PR TITLE
Update Module doc - split behaviour link

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -27,7 +27,9 @@ defmodule Module do
   Accepts a module or a `{module, function_or_macro_name}` tuple.
   See the "Compile callbacks" section below.
 
-  ### `@behaviour` (notice the British spelling)
+  ### `@behaviour`
+
+  Note the British spelling!
 
   Behaviours can be referenced by modules to ensure they implement
   required specific function signatures defined by `@callback`.


### PR DESCRIPTION
Firstly I commend the use of british spelling.

This commit updates the documentation to improve the href. Currently the link is:

https://hexdocs.pm/elixir/1.6.6/Module.html#module-behaviour-notice-the-british-spelling

With this update the link will be:

https://hexdocs.pm/elixir/1.6.6/Module.html#module-behaviour