### PR TITLE
Make `mix format -` more suitable for use in Vim by preserving surrounding whitespace

### DIFF
--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -90,6 +90,29 @@ defmodule Mix.Tasks.FormatTest do
     end)
   end
 
+  test "preserves surrounding whitespace when working with stdio", context do
+    in_tmp(context.test, fn ->
+      input = """
+
+          foo bar
+
+
+      """
+
+      output =
+        capture_io(input, fn ->
+          Mix.Tasks.Format.run(["-"])
+        end)
+
+      assert output == """
+
+                 foo(bar)
+
+
+             """
+    end)
+  end
+
   test "reads file from stdin and prints to stdout with formatter", context do
     in_tmp(context.test, fn ->
       File.write!(".formatter.exs", """


### PR DESCRIPTION
I like formatting snippets of code in my editor by selecting them and running a command to format just that snippet. There are a few benefits to avoiding formatting an entire file:

- It can be faster
- It can minimise commit diffs / PRs when somebody else has committed unformatted code

But when I do this with `mix format -` (e.g. in Vim, highlight code and type `:!mix format -<CR>`), the selected code becomes unindented (it moves to column 0) and also loses any whitespace such as newlines at the start and the end of the code.

This PR measures and restores the leading/trailing whitespace and the indentation on the Elixir code only when run on stdio via the `mix format -`, making it suitable to run within Vim (or Spacemacs) via the `!` operator.