### PR TITLE
Add a --force flag to mix archive.uninstall

### DIFF
--- a/lib/mix/lib/mix/local/installer.ex
+++ b/lib/mix/lib/mix/local/installer.ex
@@ -236,9 +236,9 @@ defmodule Mix.Local.Installer do
   @doc """
   A common implementation for uninstalling archives and scripts.
   """
-  @spec uninstall(Path.t(), String.t(), OptionParser.argv()) :: Path.t() | nil
-  def uninstall(root, listing, argv) do
-    {_, argv, _} = OptionParser.parse(argv, switches: [])
+  @spec uninstall(Path.t(), String.t(), OptionParser.argv(), keyword) :: Path.t() | nil
+  def uninstall(root, listing, argv, switches) do
+    {opts, argv} = OptionParser.parse!(argv, switches: switches)
 
     if name = List.first(argv) do
       path = Path.join(root, name)
@@ -249,7 +249,7 @@ defmodule Mix.Local.Installer do
           Mix.Task.rerun(listing)
           nil
 
-        should_uninstall?(path) ->
+        should_uninstall?(path, opts) ->
           File.rm_rf!(path)
           path
 
@@ -261,8 +261,8 @@ defmodule Mix.Local.Installer do
     end
   end
 
-  defp should_uninstall?(path) do
-    Mix.shell().yes?("Are you sure you want to uninstall #{path}?")
+  defp should_uninstall?(path, opts) do
+    opts[:force] || Mix.shell().yes?("Are you sure you want to uninstall #{path}?")
   end
 
   @doc """

--- a/lib/mix/lib/mix/tasks/archive.uninstall.ex
+++ b/lib/mix/lib/mix/tasks/archive.uninstall.ex
@@ -9,16 +9,14 @@ defmodule Mix.Tasks.Archive.Uninstall do
       mix archive.uninstall archive.ez
 
   ## Command line options
-
-    * `--sha512` - checks the archive matches the given SHA-512 checksum. Only
-      applies to installations via URL or local path
-
     * `--force` - forces uninstallation without a shell prompt; primarily
       intended for automation
   """
+
   @switches [
     force: :boolean
   ]
+
   def run(argv) do
     Mix.Local.Installer.uninstall(Mix.Local.path_for(:archive), "archive", argv, @switches)
   end

--- a/lib/mix/lib/mix/tasks/archive.uninstall.ex
+++ b/lib/mix/lib/mix/tasks/archive.uninstall.ex
@@ -8,8 +8,18 @@ defmodule Mix.Tasks.Archive.Uninstall do
 
       mix archive.uninstall archive.ez
 
+  ## Command line options
+
+    * `--sha512` - checks the archive matches the given SHA-512 checksum. Only
+      applies to installations via URL or local path
+
+    * `--force` - forces uninstallation without a shell prompt; primarily
+      intended for automation
   """
+  @switches [
+    force: :boolean
+  ]
   def run(argv) do
-    Mix.Local.Installer.uninstall(Mix.Local.path_for(:archive), "archive", argv)
+    Mix.Local.Installer.uninstall(Mix.Local.path_for(:archive), "archive", argv, @switches)
   end
 end

--- a/lib/mix/lib/mix/tasks/escript.uninstall.ex
+++ b/lib/mix/lib/mix/tasks/escript.uninstall.ex
@@ -10,8 +10,11 @@ defmodule Mix.Tasks.Escript.Uninstall do
 
   """
 
+  @switches []
+
   def run(argv) do
-    if path = Mix.Local.Installer.uninstall(Mix.Local.path_for(:escript), "escript", argv) do
+    if path =
+         Mix.Local.Installer.uninstall(Mix.Local.path_for(:escript), "escript", argv, @switches) do
       File.rm(path <> ".bat")
     end
   end

--- a/lib/mix/lib/mix/tasks/escript.uninstall.ex
+++ b/lib/mix/lib/mix/tasks/escript.uninstall.ex
@@ -8,9 +8,14 @@ defmodule Mix.Tasks.Escript.Uninstall do
 
       mix escript.uninstall escript_name
 
+  ## Command line options
+    * `--force` - forces uninstallation without a shell prompt; primarily
+      intended for automation
   """
 
-  @switches []
+  @switches [
+    force: :boolean
+  ]
 
   def run(argv) do
     if path =

--- a/lib/mix/test/mix/tasks/archive_test.exs
+++ b/lib/mix/test/mix/tasks/archive_test.exs
@@ -51,6 +51,19 @@ defmodule Mix.Tasks.ArchiveTest do
     assert has_zip_file?('archive-0.1.0.ez', 'archive-0.1.0/ebin/archive.app')
   end
 
+  test "archive install --force" do
+    in_fixture("archive", fn ->
+      Mix.Tasks.Archive.Build.run(["--no-elixir-version-check"])
+      Mix.Tasks.Archive.Install.run(["--force"])
+
+      message = "Generated archive \"archive-0.1.0.ez\" with MIX_ENV=dev"
+      assert_received {:mix_shell, :info, [^message]}
+
+      Mix.Tasks.Archive.Uninstall.run(["archive-0.1.0", "--force"])
+      refute File.dir?(tmp_path("userhome/.mix/archives/archive-0.1.0/archive-0.1.0/ebin"))
+    end)
+  end
+
   test "archive install" do
     in_fixture("archive", fn ->
       # Build and install archive

--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -271,6 +271,27 @@ defmodule Mix.Tasks.EscriptTest do
     end)
   end
 
+  test "escript install and uninstall --force" do
+    File.rm_rf!(tmp_path(".mix/escripts"))
+    Mix.Project.push(Escript)
+
+    in_fixture("escript_test", fn ->
+      Mix.Tasks.Escript.Install.run(["--force"])
+
+      # check that it shows in the list
+      Mix.Tasks.Escript.run([])
+      assert_received {:mix_shell, :info, ["* escript_test"]}
+      refute_received {:mix_shell, :info, ["* escript_test.bat"]}
+
+      # uninstall the escript
+      Mix.Tasks.Escript.Uninstall.run(["escript_test", "--force"])
+
+      # check that no escripts remain
+      Mix.Tasks.Escript.run([])
+      assert_received {:mix_shell, :info, ["No escripts currently installed."]}
+    end)
+  end
+
   test "escript invalid install" do
     # Install our escript
     send(self(), {:mix_shell_input, :yes?, true})


### PR DESCRIPTION
Mix archive.install contains a `--force` flag to allow silent installation/upgrades. However, the same is not true for uninstall.

This PR copies the same pattern used in install to add a similar force flag to uninstall.