### PR TITLE
IEx config: remove redundant code

### DIFF
--- a/lib/iex/lib/iex/config.ex
+++ b/lib/iex/lib/iex/config.ex
@@ -14,7 +14,7 @@ defmodule IEx.Config do
 
   def width() do
     columns = columns()
-    value = Application.get_env(:iex, :width) || min(columns, 80)
+    value = Application.get_env(:iex, :width) || 80
     min(value, columns)
   end
 


### PR DESCRIPTION
Because there is a `min` function in line 18, the `min` function in line 17 is redundant.