### PR TITLE
Adopt EEP 48

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -309,7 +309,7 @@ defmodule Protocol do
   end
 
   defp beam_protocol(protocol) do
-    chunk_ids = [:abstract_code, :attributes, :compile_info, 'ExDc', 'ExDp']
+    chunk_ids = [:abstract_code, :attributes, :compile_info, 'Docs', 'ExDc', 'ExDp']
     opts = [:allow_missing_chunks]
 
     case :beam_lib.chunks(beam_file(protocol), chunk_ids, opts) do

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -123,8 +123,10 @@ defmodule ProtocolTest do
       end
     )
 
-    docs = Code.get_docs(SampleDocsProto, :docs)
-    assert {{:ok, 1}, _, :def, [{:term, _, nil}], "Ok"} = List.keyfind(docs, {:ok, 1}, 0)
+    {:docs_v1, _, _, _, _, _, docs} = Code.fetch_docs(SampleDocsProto)
+
+    assert {{:function, :ok, 1}, _, ["ok(term)"], %{"en" => "Ok"}, _} =
+             List.keyfind(docs, {:function, :ok, 1}, 0)
 
     deprecated = SampleDocsProto.__info__(:deprecated)
     assert [{{:ok, 1}, "Reason"}] = deprecated
@@ -378,11 +380,11 @@ defmodule Protocol.ConsolidationTest do
   end
 
   test "consolidation keeps docs" do
-    {:ok, {Sample, [{'ExDc', docs_bin}]}} = :beam_lib.chunks(@sample_binary, ['ExDc'])
-    {:elixir_docs_v1, docs} = :erlang.binary_to_term(docs_bin)
-    ok_doc = Keyword.get(docs, :docs) |> List.keyfind({:ok, 1}, 0)
+    {:ok, {Sample, [{'Docs', docs_bin}]}} = :beam_lib.chunks(@sample_binary, ['Docs'])
+    {:docs_v1, _, _, _, _, _, docs} = :erlang.binary_to_term(docs_bin)
+    ok_doc = List.keyfind(docs, {:function, :ok, 1}, 0)
 
-    assert {{:ok, 1}, _, :def, [{:term, _, nil}], "Ok"} = ok_doc
+    assert {{:function, :ok, 1}, _, ["ok(term)"], %{"en" => "Ok"}, _} = ok_doc
   end
 
   test "consolidation keeps deprecated" do

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -280,7 +280,7 @@ defmodule Mix.Tasks.Escript.Build do
 
   defp strip_beam(beam) when is_binary(beam) do
     {:ok, _, all_chunks} = :beam_lib.all_chunks(beam)
-    strip_chunks = ['Abst', 'CInf', 'Dbgi', 'ExDc']
+    strip_chunks = ['Abst', 'CInf', 'Dbgi', 'Docs', 'ExDc']
     preserved_chunks = for {name, _} = chunk <- all_chunks, name not in strip_chunks, do: chunk
     {:ok, content} = :beam_lib.build_module(preserved_chunks)
     compress(content)


### PR DESCRIPTION
Related to #7198.

As discussed in the referenced issue the following are in scope for this PR:

- [x] extend `docs_chunk/6` in `elixir_erl.erl` to also generate the new `Docs` chunk according to EEP 48
- [x] read the new chunk in `Code.fetch_docs/1`
- [x] adjust `Protocol` and the `escript.build` mix task to include the new chunk

The following are to be implemented in separate PRs:

* migrate all functionality that uses `Code.get_docs/2` to use `Code.fetch_docs/1`
* remove the old docs chunk and return `nil` from `Code.get_docs/2`
* change how we store docs to be closer to the new docs format
* dependent functionalities (e.g. `@since` and `@deprecated`)