### PR TITLE
Make sure converged dependencies are fetched on child projects

### DIFF
--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -78,28 +78,42 @@ defmodule Mix.Dep do
   @doc """
   Returns loaded dependencies from the cache for the current environment.
 
+  If dependencies have not been cached yet, they are loaded
+  and then cached.
+
   Because the dependencies are cached during deps.loadpaths,
   their status may be outdated (for example, `:compile` did not
   yet become `:ok`). Therefore it is recommended to not rely
   on their status, also given they haven't been checked
   against the lock.
-
-  If MIX_NO_DEPS is set, we return an empty list of dependencies
-  without loading them.
   """
   def cached() do
-    cond do
-      System.get_env("MIX_NO_DEPS") in ~w(1 true) ->
-        []
+    if project = Mix.Project.get() do
+      key = {:cached_deps, Mix.env(), project}
+      Mix.ProjectStack.read_cache(key) || load_and_cache()
+    else
+      load_and_cache()
+    end
+  end
 
-      project = Mix.Project.get() ->
-        key = {:cached_deps, Mix.env(), project}
+  @doc """
+  Returns loaded dependencies recursively and caches it.
 
-        Mix.ProjectStack.read_cache(key) ||
-          Mix.ProjectStack.write_cache(key, loaded(env: Mix.env()))
+  The result is cached for future `cached/0` calls.
 
-      true ->
-        loaded(env: Mix.env())
+  ## Exceptions
+
+  This function raises an exception if any of the dependencies
+  provided in the project are in the wrong format.
+  """
+  def load_and_cache() do
+    env = Mix.env()
+    project = Mix.Project.get()
+
+    if env && project do
+      Mix.ProjectStack.write_cache({:cached_deps, env, project}, converge(env: env))
+    else
+      converge(env: env)
     end
   end
 
@@ -113,30 +127,38 @@ defmodule Mix.Dep do
     end
   end
 
+  # TODO: Remove this on v1.8
+  @doc false
+  @deprecated "Mix.Dep.loaded/1 was private API and you should not use it"
+  def loaded([]) do
+    load_on_environment([])
+  end
+
   @doc """
-  Returns loaded dependencies recursively as a `Mix.Dep` struct.
+  Returns loaded dependencies recursively on the given environment.
+
+  If no environment is passed, dependencies are loaded across all
+  environments. The result is not cached.
 
   ## Exceptions
 
   This function raises an exception if any of the dependencies
   provided in the project are in the wrong format.
   """
-  def loaded(opts) do
+  def load_on_environment(opts) do
+    converge(opts)
+  end
+
+  defp converge(opts) do
     Mix.Dep.Converger.converge(nil, nil, opts, &{&1, &2, &3}) |> elem(0)
   end
 
   @doc """
-  Receives a list of dependency names and returns loaded `Mix.Dep`s.
-  Logs a message if the dependency could not be found.
+  Filters the given dependencies by name.
 
-  ## Exceptions
-
-  This function raises an exception if any of the dependencies
-  provided in the project are in the wrong format.
+  Raises if any of the names are missing.
   """
-  def loaded_by_name(given, all_deps \\ nil, opts) do
-    all_deps = all_deps || loaded(opts)
-
+  def filter_by_name(given, all_deps, opts \\ []) do
     # Ensure all apps are atoms
     apps = to_app_names(given)
 

--- a/lib/mix/lib/mix/dep/fetcher.ex
+++ b/lib/mix/lib/mix/dep/fetcher.ex
@@ -27,7 +27,7 @@ defmodule Mix.Dep.Fetcher do
     {apps, deps} = do_finalize(result, old_lock, opts)
 
     # Check if all given dependencies are loaded or fail
-    _ = Mix.Dep.loaded_by_name(names, deps, opts)
+    _ = Mix.Dep.filter_by_name(names, deps, opts)
     apps
   end
 
@@ -85,7 +85,7 @@ defmodule Mix.Dep.Fetcher do
 
   defp do_finalize({all_deps, apps, new_lock}, old_lock, opts) do
     # Let's get the loaded versions of deps
-    deps = Mix.Dep.loaded_by_name(apps, all_deps, opts)
+    deps = Mix.Dep.filter_by_name(apps, all_deps, opts)
 
     # Note we only retrieve the parent dependencies of the updated
     # deps if all dependencies are available. This is because if a

--- a/lib/mix/lib/mix/local/installer.ex
+++ b/lib/mix/lib/mix/local/installer.ex
@@ -282,30 +282,34 @@ defmodule Mix.Local.Installer do
       File.mkdir_p!(tmp_path)
 
       File.write!(Path.join(tmp_path, "mix.exs"), """
-      defmodule Mix.Local.Installer.Fetcher.MixProject do
+      defmodule Mix.Local.Installer.MixProject do
         use Mix.Project
 
         def project do
-          [app: Mix.Local.Installer.Fetcher,
-           version: "1.0.0",
-           deps: [#{inspect(dep_spec)}]]
+          [
+            app: :mix_local_installer,
+            version: "1.0.0",
+            deps: [#{inspect(dep_spec)}]
+          ]
         end
       end
       """)
 
       with_mix_env_prod(fn ->
-        Mix.Project.in_project(Mix.Local.Installer.Fetcher, tmp_path, in_fetcher)
+        Mix.ProjectStack.on_clean_slate(fn ->
+          Mix.Project.in_project(:mix_local_installer, tmp_path, in_fetcher)
 
-        package_name = elem(dep_spec, 0)
-        package_name_string = Atom.to_string(package_name)
-        package_path = Path.join([tmp_path, "deps", package_name_string])
+          package_name = elem(dep_spec, 0)
+          package_name_string = Atom.to_string(package_name)
+          package_path = Path.join([tmp_path, "deps", package_name_string])
 
-        post_config = [
-          deps_path: Path.join(tmp_path, "deps"),
-          lockfile: Path.join(tmp_path, "mix.lock")
-        ]
+          post_config = [
+            deps_path: Path.join(tmp_path, "deps"),
+            lockfile: Path.join(tmp_path, "mix.lock")
+          ]
 
-        Mix.Project.in_project(package_name, package_path, post_config, in_package)
+          Mix.Project.in_project(package_name, package_path, post_config, in_package)
+        end)
       end)
     end)
   after

--- a/lib/mix/lib/mix/project_stack.ex
+++ b/lib/mix/lib/mix/project_stack.ex
@@ -150,6 +150,16 @@ defmodule Mix.ProjectStack do
     end)
   end
 
+  @spec top_and_bottom() :: {project, project} | nil
+  def top_and_bottom do
+    get(fn %{stack: stack} ->
+      case stack do
+        [h | _] -> {take(h), take(List.last(stack))}
+        [] -> nil
+      end
+    end)
+  end
+
   @spec post_config(config) :: :ok
   def post_config(config) do
     cast(fn state ->

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -307,7 +307,7 @@ defmodule Mix.Task do
         end)
 
       not recursive && Mix.ProjectStack.recursing() ->
-        Mix.ProjectStack.root(fn -> run(task, args) end)
+        Mix.ProjectStack.on_recursing_root(fn -> run(task, args) end)
 
       true ->
         Mix.TasksServer.put({:task, task, proj})

--- a/lib/mix/lib/mix/tasks/deps.clean.ex
+++ b/lib/mix/lib/mix/tasks/deps.clean.ex
@@ -36,7 +36,7 @@ defmodule Mix.Tasks.Deps.Clean do
     deps_path = Mix.Project.deps_path()
 
     loaded_opts = if only = opts[:only], do: [env: :"#{only}"], else: []
-    loaded_deps = Mix.Dep.loaded(loaded_opts)
+    loaded_deps = Mix.Dep.load_on_environment(loaded_opts)
 
     apps_to_clean =
       cond do

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -39,16 +39,17 @@ defmodule Mix.Tasks.Deps.Compile do
     end
 
     Mix.Project.get!()
+    deps = Mix.Dep.load_and_cache()
 
     case OptionParser.parse(args, switches: @switches) do
       {opts, [], _} ->
         # Because this command may be invoked explicitly with
         # deps.compile, we simply try to compile any available
         # dependency.
-        compile(Enum.filter(Mix.Dep.loaded(env: Mix.env()), &Mix.Dep.available?/1), opts)
+        compile(Enum.filter(deps, &Mix.Dep.available?/1), opts)
 
       {opts, tail, _} ->
-        compile(Mix.Dep.loaded_by_name(tail, [env: Mix.env()] ++ opts), opts)
+        compile(Mix.Dep.filter_by_name(tail, deps, opts), opts)
     end
   end
 

--- a/lib/mix/lib/mix/tasks/deps.ex
+++ b/lib/mix/lib/mix/tasks/deps.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Deps do
   use Mix.Task
 
-  import Mix.Dep, only: [loaded: 1, format_dep: 1, format_status: 1, check_lock: 1]
+  import Mix.Dep, only: [load_on_environment: 1, format_dep: 1, format_status: 1, check_lock: 1]
 
   @shortdoc "Lists dependencies and their status"
 
@@ -147,7 +147,7 @@ defmodule Mix.Tasks.Deps do
 
     shell = Mix.shell()
 
-    Enum.each(loaded(loaded_opts), fn dep ->
+    Enum.each(load_on_environment(loaded_opts), fn dep ->
       %Mix.Dep{scm: scm, manager: manager} = dep
       dep = check_lock(dep)
       extra = if manager, do: " (#{manager})", else: ""

--- a/lib/mix/lib/mix/tasks/deps.loadpaths.ex
+++ b/lib/mix/lib/mix/tasks/deps.loadpaths.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Deps.Loadpaths do
   use Mix.Task
 
-  import Mix.Dep, only: [loaded_by_name: 2, format_dep: 1, format_status: 1, check_lock: 1]
+  import Mix.Dep, only: [format_dep: 1, format_status: 1, check_lock: 1]
 
   @moduledoc """
   Checks and loads all dependencies along the way.
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.Deps.Loadpaths do
   """
 
   def run(args) do
-    all = Mix.Dep.cached()
+    all = Mix.Dep.load_and_cache()
 
     unless "--no-deps-check" in args do
       deps_check(all, "--no-compile" in args)
@@ -33,11 +33,7 @@ defmodule Mix.Tasks.Deps.Loadpaths do
         path
       end
 
-    # Since MIX_NO_DEPS returns no dependencies, it would
-    # cause all paths to be pruned, so we never enter here.
-    unless System.get_env("MIX_NO_DEPS") in ~w(1 true) do
-      prune_deps(load_paths, "--no-deps-check" in args)
-    end
+    prune_deps(load_paths, "--no-deps-check" in args)
   end
 
   # If the build is per environment, we should be able to look
@@ -90,7 +86,7 @@ defmodule Mix.Tasks.Deps.Loadpaths do
 
         compile
         |> Enum.map(& &1.app)
-        |> loaded_by_name(env: Mix.env())
+        |> Mix.Dep.filter_by_name(Mix.Dep.load_and_cache())
         |> Enum.filter(&(not Mix.Dep.ok?(&1)))
         |> show_not_ok!
     end

--- a/lib/mix/lib/mix/tasks/deps.tree.ex
+++ b/lib/mix/lib/mix/tasks/deps.tree.ex
@@ -37,7 +37,7 @@ defmodule Mix.Tasks.Deps.Tree do
     {opts, args, _} = OptionParser.parse(args, switches: @switches)
 
     deps_opts = if only = opts[:only], do: [env: :"#{only}"], else: []
-    deps = Mix.Dep.loaded(deps_opts)
+    deps = Mix.Dep.load_on_environment(deps_opts)
 
     root =
       case args do

--- a/lib/mix/lib/mix/tasks/deps.unlock.ex
+++ b/lib/mix/lib/mix/tasks/deps.unlock.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Deps.Unlock do
         Mix.Dep.Lock.write(%{})
 
       opts[:unused] ->
-        apps = Mix.Dep.loaded([]) |> Enum.map(& &1.app)
+        apps = Mix.Dep.load_on_environment([]) |> Enum.map(& &1.app)
         Mix.Dep.Lock.read() |> Map.take(apps) |> Mix.Dep.Lock.write()
 
       filter = opts[:filter] ->

--- a/lib/mix/test/mix/rebar_test.exs
+++ b/lib/mix/test/mix/rebar_test.exs
@@ -186,14 +186,14 @@ defmodule Mix.RebarTest do
   describe "integration with Mix" do
     test "inherits Rebar manager" do
       Mix.Project.push(Rebar3AsDep)
-      deps = Mix.Dep.loaded([])
+      deps = Mix.Dep.load_on_environment([])
       assert Enum.all?(deps, &(&1.manager == :rebar3))
     end
 
     test "parses Rebar dependencies from rebar.config" do
       Mix.Project.push(RebarAsDep)
 
-      deps = Mix.Dep.loaded([])
+      deps = Mix.Dep.load_on_environment([])
       assert Enum.find(deps, &(&1.app == :rebar_dep))
 
       assert Enum.find(deps, fn %Mix.Dep{app: app, opts: opts} ->
@@ -211,7 +211,7 @@ defmodule Mix.RebarTest do
       in_tmp("Rebar overrides", fn ->
         Mix.Tasks.Deps.Get.run([])
 
-        assert Mix.Dep.loaded([]) |> Enum.map(& &1.app) ==
+        assert Mix.Dep.load_on_environment([]) |> Enum.map(& &1.app) ==
                  [:git_repo, :git_rebar, :rebar_override]
       end)
     after
@@ -232,7 +232,7 @@ defmodule Mix.RebarTest do
         assert :rebar_dep.any_function() == :ok
 
         load_paths =
-          Mix.Dep.loaded([])
+          Mix.Dep.load_on_environment([])
           |> Enum.map(&Mix.Dep.load_paths(&1))
           |> Enum.concat()
 
@@ -280,7 +280,7 @@ defmodule Mix.RebarTest do
         assert :rebar_dep.any_function() == :ok
 
         load_paths =
-          Mix.Dep.loaded([])
+          Mix.Dep.load_on_environment([])
           |> Enum.map(&Mix.Dep.load_paths(&1))
           |> Enum.concat()
 

--- a/lib/mix/test/mix/tasks/compile_test.exs
+++ b/lib/mix/test/mix/tasks/compile_test.exs
@@ -36,20 +36,23 @@ defmodule Mix.Tasks.CompileTest do
   end
 
   test "compiles --list with custom mixfile" do
+    Mix.Project.pop()
     Mix.Project.push(CustomCompilers)
     Mix.Task.run("compile", ["--list"])
     assert_received {:mix_shell, :info, ["\nEnabled compilers: elixir, app, custom, protocols"]}
   end
 
   test "compiles does not require all compilers available on manifest" do
+    Mix.Project.pop()
     Mix.Project.push(CustomCompilers)
     assert Mix.Tasks.Compile.manifests() |> Enum.map(&Path.basename/1) == ["compile.elixir"]
   end
 
   test "compiles a project with cached deps information" do
-    in_fixture("deps_status", fn ->
-      Mix.Project.push(DepsApp)
+    Mix.Project.pop()
+    Mix.Project.push(DepsApp)
 
+    in_fixture("deps_status", fn ->
       File.mkdir_p!("lib")
 
       File.write!("lib/a.ex", """
@@ -192,6 +195,7 @@ defmodule Mix.Tasks.CompileTest do
   end
 
   test "compiles a project with wrong path" do
+    Mix.Project.pop()
     Mix.Project.push(WrongPath)
 
     ExUnit.CaptureIO.capture_io(fn ->

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -689,6 +689,7 @@ defmodule Mix.Tasks.XrefTest do
       end
     end
 
+    Mix.Project.pop()
     Mix.Project.push(ExcludeSample)
 
     files = %{
@@ -1215,6 +1216,8 @@ defmodule Mix.Tasks.XrefTest do
 
   describe "inside umbrellas" do
     test "generates reports considering siblings" do
+      Mix.Project.pop()
+
       in_fixture("umbrella_dep/deps/umbrella", fn ->
         Mix.Project.in_project(:bar, "apps/bar", fn _ ->
           File.write!("lib/bar.ex", """

--- a/lib/mix/test/mix/umbrella_test.exs
+++ b/lib/mix/test/mix/umbrella_test.exs
@@ -261,7 +261,7 @@ defmodule Mix.UmbrellaTest do
     Mix.Project.push(CycleDeps)
 
     in_fixture("umbrella_dep", fn ->
-      assert Enum.map(Mix.Dep.loaded([]), & &1.app) == [:foo, :bar, :umbrella]
+      assert Enum.map(Mix.Dep.load_on_environment([]), & &1.app) == [:foo, :bar, :umbrella]
     end)
   end
 
@@ -299,7 +299,7 @@ defmodule Mix.UmbrellaTest do
         end
         """)
 
-        assert Enum.map(Mix.Dep.loaded([]), & &1.app) == [:a, :b, :bar, :foo]
+        assert Enum.map(Mix.Dep.load_on_environment([]), & &1.app) == [:a, :b, :bar, :foo]
       end)
     end)
   end


### PR DESCRIPTION
This should also provide performance benefits as we
avoid performing resolution for each child project.

Closes #7561