### PR TITLE
Include override true in rebar dependencies

### DIFF
--- a/lib/mix/lib/mix/rebar.ex
+++ b/lib/mix/lib/mix/rebar.ex
@@ -122,11 +122,11 @@ defmodule Mix.Rebar do
   # Translate a rebar dependency declaration to a mix declaration
   # From http://www.rebar3.org/docs/dependencies#section-declaring-dependencies
   defp parse_dep(app) when is_atom(app) do
-    {app, ">= 0.0.0"}
+    {app, ">= 0.0.0", override: true}
   end
 
   defp parse_dep({app, req}) when is_list(req) do
-    {app, List.to_string(req)}
+    {app, List.to_string(req), override: true}
   end
 
   defp parse_dep({app, source}) when is_tuple(source) do
@@ -139,10 +139,8 @@ defmodule Mix.Rebar do
 
   defp parse_dep({app, req, source, opts}) do
     source = parse_source(source)
-
     compile = if :proplists.get_value(:raw, opts, false), do: [compile: false], else: []
-
-    {app, compile_req(req), source ++ compile}
+    {app, compile_req(req), [override: true] ++ source ++ compile}
   end
 
   defp parse_source({:pkg, pkg}) do

--- a/lib/mix/test/mix/rebar_test.exs
+++ b/lib/mix/test/mix/rebar_test.exs
@@ -85,35 +85,30 @@ defmodule Mix.RebarTest do
   @git_rebar_string "../../test/fixtures/git_rebar"
 
   describe "deps/1" do
+    defp parse_dep(dep) do
+      [deps: [dep]] |> Mix.Rebar.deps() |> hd()
+    end
+
     test "parses Rebar dependencies" do
-      config = [deps: [{:git_rebar, '~> 1.0'}]]
-      assert Mix.Rebar.deps(config) == [{:git_rebar, "~> 1.0"}]
+      assert parse_dep({:git_rebar, '~> 1.0'}) == {:git_rebar, "~> 1.0", override: true}
 
-      config = [deps: [{:git_rebar, '~> 1.0', {:pkg, :rebar_fork}}]]
-      assert Mix.Rebar.deps(config) == [{:git_rebar, "~> 1.0", hex: :rebar_fork}]
+      assert parse_dep({:git_rebar, '~> 1.0', {:pkg, :rebar_fork}}) ==
+               {:git_rebar, "~> 1.0", override: true, hex: :rebar_fork}
 
-      config = [deps: [{:git_rebar, {:pkg, :rebar_fork}}]]
-      assert Mix.Rebar.deps(config) == [{:git_rebar, ">= 0.0.0", hex: :rebar_fork}]
+      assert parse_dep({:git_rebar, {:pkg, :rebar_fork}}) ==
+               {:git_rebar, ">= 0.0.0", override: true, hex: :rebar_fork}
 
-      config = [deps: [{:git_rebar, '0.1..*', {:git, @git_rebar_charlist, :master}}]]
+      assert parse_dep({:git_rebar, '0.1..*', {:git, @git_rebar_charlist, :master}}) ==
+               {:git_rebar, ~r"0.1..*", override: true, git: @git_rebar_string, ref: "master"}
 
-      assert Mix.Rebar.deps(config) ==
-               [{:git_rebar, ~r"0.1..*", [git: @git_rebar_string, ref: "master"]}]
+      assert parse_dep({:git_rebar, {:git, @git_rebar_charlist, :master}}) ==
+               {:git_rebar, ">= 0.0.0", override: true, git: @git_rebar_string, ref: "master"}
 
-      config = [deps: [{:git_rebar, {:git, @git_rebar_charlist, :master}}]]
+      assert parse_dep({:git_rebar, '0.1..*', {:git, @git_rebar_charlist}, [:raw]}) ==
+               {:git_rebar, ~r"0.1..*", override: true, git: @git_rebar_string, compile: false}
 
-      assert Mix.Rebar.deps(config) ==
-               [{:git_rebar, ">= 0.0.0", [git: @git_rebar_string, ref: "master"]}]
-
-      config = [deps: [{:git_rebar, '0.1..*', {:git, @git_rebar_charlist}, [:raw]}]]
-
-      assert Mix.Rebar.deps(config) ==
-               [{:git_rebar, ~r"0.1..*", [git: @git_rebar_string, compile: false]}]
-
-      config = [deps: [{:git_rebar, '', {:git, @git_rebar_charlist, {:ref, '64691eb'}}}]]
-
-      assert Mix.Rebar.deps(config) ==
-               [{:git_rebar, ~r"", [git: @git_rebar_string, ref: "64691eb"]}]
+      assert parse_dep({:git_rebar, '', {:git, @git_rebar_charlist, {:ref, '64691eb'}}}) ==
+               {:git_rebar, ~r"", override: true, git: @git_rebar_string, ref: "64691eb"}
     end
   end
 


### PR DESCRIPTION
In Rebar 3, simply listing a dependency in the parent overrides
any child dependency, so we mimic this behaviour in Mix.

Closes #7346