### PR TITLE
include crash_reason in Logger translator

### DIFF
--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -191,7 +191,9 @@ defmodule Logger.Backends.Console do
     |> color_event(level, colors, md)
   end
 
-  defp take_metadata(metadata, :all), do: metadata
+  defp take_metadata(metadata, :all) do
+    Keyword.drop(metadata, [:crash_reason])
+  end
 
   defp take_metadata(metadata, keys) do
     Enum.reduce(keys, [], fn key, acc ->

--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -87,45 +87,46 @@ defmodule Logger.Translator do
 
     case message do
       {'** Generic server ' ++ _, [name, last, state, reason | client]} ->
-        {formatted, _reason} = format_reason(reason)
+        {formatted, reason} = format_reason(reason)
 
         msg =
           ["GenServer #{inspect(name)} terminating", formatted] ++
             ["\nLast message#{format_from(client)}: #{inspect(last, opts)}"]
 
         if min_level == :debug do
-          {:ok, [msg, "\nState: #{inspect(state, opts)}" | format_client(client)]}
+          {:ok, [msg, "\nState: #{inspect(state, opts)}" | format_client(client)],
+           [crash_reason: reason]}
         else
-          {:ok, msg}
+          {:ok, msg, [crash_reason: reason]}
         end
 
       {'** gen_event handler ' ++ _, [name, manager, last, state, reason]} ->
-        {formatted, _reason} = format_reason(reason)
+        {formatted, reason} = format_reason(reason)
 
         msg =
           [":gen_event handler #{inspect(name)} installed in #{inspect(manager)} terminating"] ++
             [formatted, "\nLast message: #{inspect(last, opts)}"]
 
         if min_level == :debug do
-          {:ok, [msg | "\nState: #{inspect(state, opts)}"]}
+          {:ok, [msg | "\nState: #{inspect(state, opts)}"], [crash_reason: reason]}
         else
-          {:ok, msg}
+          {:ok, msg, [crash_reason: reason]}
         end
 
       {'** Task ' ++ _, [name, starter, function, args, reason]} ->
-        {formatted, _reason} = format_reason(reason)
+        {formatted, reason} = format_reason(reason)
 
         msg =
           ["Task #{inspect(name)} started from #{inspect(starter)} terminating"] ++
             [formatted, "\nFunction: #{inspect(function, opts)}"] ++
             ["\n    Args: #{inspect(args, opts)}"]
 
-        {:ok, msg}
+        {:ok, msg, [crash_reason: reason]}
 
       {'Error in process ' ++ _, [pid, {reason, stack}]} ->
         msg = ["Process ", inspect(pid), " raised an exception" | format(:error, reason, stack)]
 
-        {:ok, msg}
+        {:ok, msg, [crash_reason: reason]}
 
       _ ->
         :none
@@ -176,16 +177,17 @@ defmodule Logger.Translator do
       state: state
     } = report
 
-    {formatted, _reason} = format_reason(reason)
+    {formatted, reason} = format_reason(reason)
 
     msg =
       ["GenServer ", inspect(name), " terminating", formatted] ++
         ["\nLast message", format_last_message_from(client), ": ", inspect(last, inspect_opts)]
 
     if min_level == :debug do
-      {:ok, [msg, "\nState: ", inspect(state, inspect_opts) | format_client_info(client)]}
+      {:ok, [msg, "\nState: ", inspect(state, inspect_opts) | format_client_info(client)],
+       [crash_reason: reason]}
     else
-      {:ok, msg}
+      {:ok, msg, [crash_reason: reason]}
     end
   end
 
@@ -213,9 +215,9 @@ defmodule Logger.Translator do
         [formatted, "\nLast message: ", inspect(last, inspect_opts)]
 
     if min_level == :debug do
-      {:ok, [msg, "\nState: ", inspect(state, inspect_opts)]}
+      {:ok, [msg, "\nState: ", inspect(state, inspect_opts)], [], [crash_reason: reason]}
     else
-      {:ok, msg}
+      {:ok, msg, [crash_reason: reason]}
     end
   end
 
@@ -264,7 +266,7 @@ defmodule Logger.Translator do
         [?\s, sup_context(context), "\n** (exit) ", offender_reason(reason, context)] ++
         pid_info ++ child_info(min_level, offender)
 
-    {:ok, msg}
+    {:ok, msg, [crash_reason: reason]}
   end
 
   defp report_supervisor(
@@ -279,7 +281,7 @@ defmodule Logger.Translator do
         ["\n** (exit) ", offender_reason(reason, context), "\nNumber: ", Integer.to_string(n)] ++
         child_info(min_level, offender)
 
-    {:ok, msg}
+    {:ok, msg, [crash_reason: reason]}
   end
 
   defp report_supervisor(
@@ -294,7 +296,7 @@ defmodule Logger.Translator do
         ["\n** (exit) ", offender_reason(reason, context), "\nPid: ", inspect(pid)] ++
         child_info(min_level, offender)
 
-    {:ok, msg}
+    {:ok, msg, [crash_reason: reason]}
   end
 
   defp report_supervisor(_min_level, _other), do: :none
@@ -356,7 +358,7 @@ defmodule Logger.Translator do
       ["Process ", crash_name(pid, name), " terminating", format(kind, reason, stack)] ++
         [crash_info(min_level, [initial_call | crashed])] ++ crash_linked(min_level, linked)
 
-    {:ok, msg}
+    {:ok, msg, [crash_reason: reason]}
   end
 
   defp report_crash(min_level, [
@@ -373,7 +375,7 @@ defmodule Logger.Translator do
       ["Process ", crash_name(pid, name), " terminating", format(kind, reason, stack)] ++
         [crash_info(min_level, crashed), crash_linked(min_level, linked)]
 
-    {:ok, msg}
+    {:ok, msg, [crash_reason: reason]}
   end
 
   defp crash_name(pid, []), do: inspect(pid)

--- a/lib/logger/test/logger/backends/console_test.exs
+++ b/lib/logger/test/logger/backends/console_test.exs
@@ -66,6 +66,15 @@ defmodule Logger.Backends.ConsoleTest do
            end) =~ "user_id=13 hello"
   end
 
+  test "ignores crash_reason metadata when configured with metadata: :all" do
+    Logger.configure_backend(:console, format: "$metadata$message", metadata: :all)
+    Logger.metadata(crash_reason: {%RuntimeError{message: "oops"}, []})
+
+    assert capture_log(fn ->
+             Logger.debug("hello")
+           end) =~ "hello"
+  end
+
   test "configures formatter to {module, function} tuple" do
     Logger.configure_backend(:console, format: {__MODULE__, :format})
 

--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -83,6 +83,7 @@ defmodule Logger.TranslatorTest do
   end
 
   test "translates GenServer crashes" do
+    add_test_logger_backend()
     {:ok, pid} = GenServer.start(MyGenServer, :ok)
 
     assert capture_log(:info, fn ->
@@ -91,9 +92,18 @@ defmodule Logger.TranslatorTest do
            [error] GenServer #{inspect(pid)} terminating
            ** (RuntimeError) oops
            """
+
+    assert_receive {:error, _pid, {Logger, ["GenServer " <> _ | _], _ts, gen_server_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+
+    assert {%RuntimeError{message: "oops"}, [_ | _]} =
+             Keyword.get(gen_server_metadata, :crash_reason)
+
+    assert %RuntimeError{message: "oops"} == Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates GenServer crashes with custom inspect options" do
+    add_test_logger_backend()
     {:ok, pid} = GenServer.start(MyGenServer, List.duplicate(:ok, 1000))
     Application.put_env(:logger, :translator_inspect_opts, limit: 3)
 
@@ -102,6 +112,16 @@ defmodule Logger.TranslatorTest do
            end) =~ """
            [:ok, :ok, :ok, ...]
            """
+
+    assert_receive {:error, _pid,
+                    {Logger, [["GenServer " <> _ | _] | _], _ts, gen_server_metadata}}
+
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+
+    assert {%RuntimeError{message: "oops"}, [_ | _]} =
+             Keyword.get(gen_server_metadata, :crash_reason)
+
+    assert %RuntimeError{message: "oops"} == Keyword.get(process_metadata, :crash_reason)
   after
     Application.put_env(:logger, :translator_inspect_opts, [])
   end
@@ -109,6 +129,7 @@ defmodule Logger.TranslatorTest do
   # TODO: Remove this check once we depend only on 20
   if :erlang.system_info(:otp_release) >= '20' do
     test "translates GenServer crashes on debug" do
+      add_test_logger_backend()
       {:ok, pid} = GenServer.start(MyGenServer, :ok)
 
       assert capture_log(:debug, fn ->
@@ -122,9 +143,20 @@ defmodule Logger.TranslatorTest do
              Client #PID<\d+\.\d+\.\d+> is alive
              .*
              """s
+
+      assert_receive {:error, _pid,
+                      {Logger, [["GenServer " <> _ | _] | _], _ts, gen_server_metadata}}
+
+      assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+
+      assert {%RuntimeError{message: "oops"}, [_ | _]} =
+               Keyword.get(gen_server_metadata, :crash_reason)
+
+      assert %RuntimeError{message: "oops"} == Keyword.get(process_metadata, :crash_reason)
     end
 
     test "translates GenServer crashes with named client on debug" do
+      add_test_logger_backend()
       {:ok, pid} = GenServer.start(MyGenServer, :ok)
 
       assert capture_log(:debug, fn ->
@@ -139,9 +171,20 @@ defmodule Logger.TranslatorTest do
              Client :named_client is alive
              .*
              """s
+
+      assert_receive {:error, _pid,
+                      {Logger, [["GenServer " <> _ | _] | _], _ts, gen_server_metadata}}
+
+      assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+
+      assert {%RuntimeError{message: "oops"}, [_ | _]} =
+               Keyword.get(gen_server_metadata, :crash_reason)
+
+      assert %RuntimeError{message: "oops"} == Keyword.get(process_metadata, :crash_reason)
     end
 
     test "translates GenServer crashes with dead client on debug" do
+      add_test_logger_backend()
       {:ok, pid} = GenServer.start(MyGenServer, :ok)
 
       assert capture_log(:debug, fn ->
@@ -160,9 +203,20 @@ defmodule Logger.TranslatorTest do
              State: :ok
              Client #PID<\d+\.\d+\.\d+> is dead
              """s
+
+      assert_receive {:error, _pid,
+                      {Logger, [["GenServer " <> _ | _] | _], _ts, gen_server_metadata}}
+
+      assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+
+      assert {%RuntimeError{message: "oops"}, [_ | _]} =
+               Keyword.get(gen_server_metadata, :crash_reason)
+
+      assert %RuntimeError{message: "oops"} == Keyword.get(process_metadata, :crash_reason)
     end
   else
     test "translates GenServer crashes on debug" do
+      add_test_logger_backend()
       {:ok, pid} = GenServer.start(MyGenServer, :ok)
 
       assert capture_log(:debug, fn ->
@@ -174,10 +228,21 @@ defmodule Logger.TranslatorTest do
              Last message: :error
              State: :ok
              """s
+
+      assert_receive {:error, _pid,
+                      {Logger, [["GenServer " <> _ | _] | _], _ts, gen_server_metadata}}
+
+      assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+
+      assert {%RuntimeError{message: "oops"}, [_ | _]} =
+               Keyword.get(gen_server_metadata, :crash_reason)
+
+      assert %RuntimeError{message: "oops"} == Keyword.get(process_metadata, :crash_reason)
     end
   end
 
   test "translates GenServer crashes with no client" do
+    add_test_logger_backend()
     {:ok, pid} = GenServer.start(MyGenServer, :ok)
 
     assert capture_log(:debug, fn ->
@@ -191,9 +256,20 @@ defmodule Logger.TranslatorTest do
            Last message: {:"\$gen_cast", :error}
            State: :ok
            """s
+
+    assert_receive {:error, _pid,
+                    {Logger, [["GenServer " <> _ | _] | _], _ts, gen_server_metadata}}
+
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+
+    assert {%RuntimeError{message: "oops"}, [_ | _]} =
+             Keyword.get(gen_server_metadata, :crash_reason)
+
+    assert %RuntimeError{message: "oops"} == Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates GenServer crashes with no client on debug" do
+    add_test_logger_backend()
     {:ok, pid} = GenServer.start(MyGenServer, :ok)
 
     refute capture_log(:debug, fn ->
@@ -201,9 +277,20 @@ defmodule Logger.TranslatorTest do
              GenServer.cast(pid, :error)
              assert_receive {:DOWN, ^mon, _, _, _}
            end) =~ "Client"
+
+    assert_receive {:error, _pid,
+                    {Logger, [["GenServer " <> _ | _] | _], _ts, gen_server_metadata}}
+
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+
+    assert {%RuntimeError{message: "oops"}, [_ | _]} =
+             Keyword.get(gen_server_metadata, :crash_reason)
+
+    assert %RuntimeError{message: "oops"} == Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates :gen_event crashes" do
+    add_test_logger_backend()
     {:ok, pid} = :gen_event.start()
     :ok = :gen_event.add_handler(pid, MyGenEvent, :ok)
 
@@ -215,9 +302,13 @@ defmodule Logger.TranslatorTest do
            } terminating
            ** (RuntimeError) oops
            """
+
+    assert_receive {:error, _pid, {Logger, [":gen_event handler " <> _ | _], _ts, metadata}}
+    assert {%RuntimeError{message: "oops"}, [_ | _]} = Keyword.get(metadata, :crash_reason)
   end
 
   test "translates :gen_event crashes on debug" do
+    add_test_logger_backend()
     {:ok, pid} = :gen_event.start()
     :ok = :gen_event.add_handler(pid, MyGenEvent, :ok)
 
@@ -230,9 +321,13 @@ defmodule Logger.TranslatorTest do
            Last message: :error
            State: :ok
            """s
+
+    assert_receive {:error, _pid, {Logger, [[":gen_event handler " <> _ | _] | _], _ts, metadata}}
+    assert {%RuntimeError{message: "oops"}, [_ | _]} = Keyword.get(metadata, :crash_reason)
   end
 
   test "translates Task crashes" do
+    add_test_logger_backend()
     {:ok, pid} = Task.start_link(__MODULE__, :task, [self()])
 
     assert capture_log(fn ->
@@ -246,9 +341,17 @@ defmodule Logger.TranslatorTest do
            Function: &Logger.TranslatorTest.task\/1
                Args: \[#PID<\d+\.\d+\.\d+>\]
            """s
+
+    assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert {%RuntimeError{message: "oops"}, [_ | _]} = Keyword.get(task_metadata, :crash_reason)
+
+    assert {%RuntimeError{message: "oops"}, [_ | _]} =
+             Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates Task async_stream crashes with neighbour" do
+    add_test_logger_backend()
     fun = fn -> Task.async_stream([:oops], :erlang, :error, []) |> Enum.to_list() end
     {:ok, pid} = Task.start(__MODULE__, :task, [self(), fun])
 
@@ -261,9 +364,16 @@ defmodule Logger.TranslatorTest do
                #{inspect(pid)}
                    Initial Call: Logger\.TranslatorTest\.task/2
            """
+
+    assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert {:oops, [_ | _]} = Keyword.get(task_metadata, :crash_reason)
+    assert {:oops, [_ | _]} = Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates Task undef module crash" do
+    add_test_logger_backend()
+
     assert capture_log(fn ->
              {:ok, pid} = Task.start(:module_does_not_exist, :undef, [])
              ref = Process.monitor(pid)
@@ -275,9 +385,19 @@ defmodule Logger.TranslatorTest do
            Function: &:module_does_not_exist.undef/0
                Args: \[\]
            """s
+
+    assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+
+    assert {%UndefinedFunctionError{function: :undef}, [_ | _]} =
+             Keyword.get(task_metadata, :crash_reason)
+
+    assert {:undef, [_ | _]} = Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates Task undef function crash" do
+    add_test_logger_backend()
+
     assert capture_log(fn ->
              {:ok, pid} = Task.start(__MODULE__, :undef, [])
              ref = Process.monitor(pid)
@@ -289,9 +409,19 @@ defmodule Logger.TranslatorTest do
            Function: &Logger.TranslatorTest.undef/0
                Args: \[\]
            """s
+
+    assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+
+    assert {%UndefinedFunctionError{function: :undef}, [_ | _]} =
+             Keyword.get(task_metadata, :crash_reason)
+
+    assert {:undef, [_ | _]} = Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates Task raising ErlangError" do
+    add_test_logger_backend()
+
     assert capture_log(fn ->
              exception =
                try do
@@ -311,9 +441,16 @@ defmodule Logger.TranslatorTest do
            Function: &:erlang\.error/1
                Args: \[%ErlangError{.*}\]
            """s
+
+    assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert {%ErlangError{original: :foo}, [_ | _]} = Keyword.get(task_metadata, :crash_reason)
+    assert {%ErlangError{original: :foo}, [_ | _]} = Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates Task raising Erlang badarg error" do
+    add_test_logger_backend()
+
     assert capture_log(fn ->
              {:ok, pid} = Task.start(:erlang, :error, [:badarg])
              ref = Process.monitor(pid)
@@ -325,9 +462,19 @@ defmodule Logger.TranslatorTest do
            Function: &:erlang\.error/1
                Args: \[:badarg\]
            """s
+
+    assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+
+    assert {%ArgumentError{message: "argument error"}, [_ | _]} =
+             Keyword.get(task_metadata, :crash_reason)
+
+    assert {:badarg, [_ | _]} = Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates Task exiting abnormally" do
+    add_test_logger_backend()
+
     assert capture_log(fn ->
              {:ok, pid} = Task.start(:erlang, :exit, [:abnormal])
              ref = Process.monitor(pid)
@@ -339,6 +486,11 @@ defmodule Logger.TranslatorTest do
            Function: &:erlang\.exit/1
                Args: \[:abnormal\]
            """s
+
+    assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert {:abnormal, [_ | _]} = Keyword.get(task_metadata, :crash_reason)
+    assert :abnormal = Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates application start" do
@@ -360,6 +512,8 @@ defmodule Logger.TranslatorTest do
   end
 
   test "translates Process crashes" do
+    add_test_logger_backend()
+
     assert capture_log(:info, fn ->
              {_, ref} = spawn_monitor(fn -> raise "oops" end)
              receive do: ({:DOWN, ^ref, _, _, _} -> :ok)
@@ -370,9 +524,13 @@ defmodule Logger.TranslatorTest do
            \[error\] Process #PID<\d+\.\d+\.\d+>\ raised an exception
            \*\* \(RuntimeError\) oops
            """
+
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert %RuntimeError{message: "oops"} = Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates :proc_lib crashes" do
+    add_test_logger_backend()
     {:ok, pid} = Task.start_link(__MODULE__, :task, [self()])
 
     assert capture_log(:info, fn ->
@@ -388,9 +546,18 @@ defmodule Logger.TranslatorTest do
            Initial Call: Logger.TranslatorTest.task/1
            Ancestors: \[#PID<\d+\.\d+\.\d+>\]
            """s
+
+    assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert {%RuntimeError{message: "oops"}, [_ | _]} = Keyword.get(task_metadata, :crash_reason)
+
+    assert {%RuntimeError{message: "oops"}, [_ | _]} =
+             Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates :proc_lib crashes with name" do
+    add_test_logger_backend()
+
     fun = fn ->
       Process.register(self(), __MODULE__)
       raise "oops"
@@ -411,9 +578,18 @@ defmodule Logger.TranslatorTest do
            Initial Call: Logger.TranslatorTest.task/2
            Ancestors: \[#PID<\d+\.\d+\.\d+>\]
            """s
+
+    assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert {%RuntimeError{message: "oops"}, [_ | _]} = Keyword.get(task_metadata, :crash_reason)
+
+    assert {%RuntimeError{message: "oops"}, [_ | _]} =
+             Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates :proc_lib crashes without initial call" do
+    add_test_logger_backend()
+
     fun = fn ->
       Process.delete(:"$initial_call")
       raise "oops"
@@ -433,9 +609,17 @@ defmodule Logger.TranslatorTest do
            .*
            Ancestors: \[#PID<\d+\.\d+\.\d+>\]
            """s
+
+    assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert {%RuntimeError{message: "oops"}, [_ | _]} = Keyword.get(task_metadata, :crash_reason)
+
+    assert {%RuntimeError{message: "oops"}, [_ | _]} =
+             Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates :proc_lib crashes with neighbour" do
+    add_test_logger_backend()
     {:ok, pid} = Task.start_link(__MODULE__, :sub_task, [self()])
 
     assert capture_log(:info, fn ->
@@ -451,9 +635,18 @@ defmodule Logger.TranslatorTest do
                    Current Call: Logger.TranslatorTest.sleep/1
                    Ancestors: \[#PID<\d+\.\d+\.\d+>, #PID<\d+\.\d+\.\d+>\]
            """
+
+    assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert {%RuntimeError{message: "oops"}, [_ | _]} = Keyword.get(task_metadata, :crash_reason)
+
+    assert {%RuntimeError{message: "oops"}, [_ | _]} =
+             Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates :proc_lib crashes with neighbour with name" do
+    add_test_logger_backend()
+
     fun = fn pid2 ->
       Process.register(pid2, __MODULE__)
       raise "oops"
@@ -474,9 +667,17 @@ defmodule Logger.TranslatorTest do
                    Current Call: Logger.TranslatorTest.sleep/1
                    Ancestors: \[#PID<\d+\.\d+\.\d+>, #PID<\d+\.\d+\.\d+>\]
            """
+
+    assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert {%RuntimeError{message: "oops"}, [_ | _]} = Keyword.get(task_metadata, :crash_reason)
+
+    assert {%RuntimeError{message: "oops"}, [_ | _]} =
+             Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates :proc_lib crashes on debug" do
+    add_test_logger_backend()
     {:ok, pid} = Task.start_link(__MODULE__, :task, [self()])
 
     assert capture_log(:debug, fn ->
@@ -496,9 +697,17 @@ defmodule Logger.TranslatorTest do
            Stack Size: \d+
            Reductions: \d+
            """
+
+    assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert {%RuntimeError{message: "oops"}, [_ | _]} = Keyword.get(task_metadata, :crash_reason)
+
+    assert {%RuntimeError{message: "oops"}, [_ | _]} =
+             Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates :proc_lib crashes with neighbour on debug" do
+    add_test_logger_backend()
     {:ok, pid} = Task.start_link(__MODULE__, :sub_task, [self()])
 
     assert capture_log(:debug, fn ->
@@ -520,6 +729,13 @@ defmodule Logger.TranslatorTest do
                    Current Stacktrace:
                        test/logger/translator_test.exs:\d+: Logger.TranslatorTest.sleep/1(?#TODO: Require once depend on Erlang/OTP 20)|)
            """
+
+    assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert {%RuntimeError{message: "oops"}, [_ | _]} = Keyword.get(task_metadata, :crash_reason)
+
+    assert {%RuntimeError{message: "oops"}, [_ | _]} =
+             Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates Supervisor progress" do
@@ -604,6 +820,8 @@ defmodule Logger.TranslatorTest do
   end
 
   test "translates Supervisor reports start error with raise" do
+    add_test_logger_backend()
+
     assert capture_log(:info, fn ->
              trap = Process.flag(:trap_exit, true)
              children = [worker(__MODULE__, [], function: :undef)]
@@ -617,9 +835,14 @@ defmodule Logger.TranslatorTest do
                .*
            Start Call: Logger.TranslatorTest.undef\(\)
            """s
+
+    assert_receive {:error, _pid, {Logger, ["Child " | _], _ts, child_metadata}}
+    assert {:EXIT, {:undef, [_ | _]}} = Keyword.get(child_metadata, :crash_reason)
   end
 
   test "translates Supervisor reports terminated" do
+    add_test_logger_backend()
+
     assert capture_log(:info, fn ->
              trap = Process.flag(:trap_exit, true)
              children = [worker(Task, [Kernel, :exit, [:stop]])]
@@ -632,9 +855,20 @@ defmodule Logger.TranslatorTest do
            Pid: #PID<\d+\.\d+\.\d+>
            Start Call: Task.start_link\(Kernel, :exit, \[:stop\]\)
            """
+
+    assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Child " | _], _ts, child_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Child ", "Task" | _], _ts, child_task_metadata}}
+    assert {:stop, [_ | _]} = Keyword.get(task_metadata, :crash_reason)
+    assert :stop = Keyword.get(process_metadata, :crash_reason)
+    assert :stop = Keyword.get(child_metadata, :crash_reason)
+    assert :reached_max_restart_intensity = Keyword.get(child_task_metadata, :crash_reason)
   end
 
   test "translates Supervisor reports max restarts shutdown" do
+    add_test_logger_backend()
+
     assert capture_log(:info, fn ->
              trap = Process.flag(:trap_exit, true)
              children = [worker(Task, [Kernel, :exit, [:stop]])]
@@ -646,9 +880,20 @@ defmodule Logger.TranslatorTest do
            \*\* \(exit\) :reached_max_restart_intensity
            Start Call: Task.start_link\(Kernel, :exit, \[:stop\]\)
            """
+
+    assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Child " | _], _ts, child_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Child ", "Task" | _], _ts, child_task_metadata}}
+    assert {:stop, [_ | _]} = Keyword.get(task_metadata, :crash_reason)
+    assert :stop = Keyword.get(process_metadata, :crash_reason)
+    assert :stop = Keyword.get(child_metadata, :crash_reason)
+    assert :reached_max_restart_intensity = Keyword.get(child_task_metadata, :crash_reason)
   end
 
   test "translates Supervisor reports abnormal shutdown" do
+    add_test_logger_backend()
+
     assert capture_log(:info, fn ->
              children = [worker(__MODULE__, [], function: :abnormal)]
              {:ok, pid} = Supervisor.start_link(children, strategy: :one_for_one)
@@ -659,9 +904,16 @@ defmodule Logger.TranslatorTest do
            Pid: #PID<\d+\.\d+\.\d+>
            Start Call: Logger.TranslatorTest.abnormal\(\)
            """
+
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Child " | _], _ts, child_metadata}}
+    assert :stop = Keyword.get(process_metadata, :crash_reason)
+    assert :stop = Keyword.get(child_metadata, :crash_reason)
   end
 
   test "translates Supervisor reports abnormal shutdown on debug" do
+    add_test_logger_backend()
+
     assert capture_log(:debug, fn ->
              children = [
                worker(__MODULE__, [], function: :abnormal, restart: :permanent, shutdown: 5000)
@@ -677,9 +929,16 @@ defmodule Logger.TranslatorTest do
            Shutdown: 5000
            Type: :worker
            """
+
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Child " | _], _ts, child_metadata}}
+    assert :stop = Keyword.get(process_metadata, :crash_reason)
+    assert :stop = Keyword.get(child_metadata, :crash_reason)
   end
 
   test "translates Supervisor reports abnormal shutdown in simple_one_for_one" do
+    add_test_logger_backend()
+
     assert capture_log(:info, fn ->
              trap = Process.flag(:trap_exit, true)
              children = [worker(__MODULE__, [], function: :abnormal)]
@@ -694,9 +953,16 @@ defmodule Logger.TranslatorTest do
            Number: 1
            Start Call: Logger.TranslatorTest.abnormal\(\)
            """
+
+    assert_receive {:error, _pid, {Logger, ["Children " | _], _ts, children_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert :stop = Keyword.get(children_metadata, :crash_reason)
+    assert :stop = Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates DynamicSupervisor reports abnormal shutdown" do
+    add_test_logger_backend()
+
     assert capture_log(:info, fn ->
              trap = Process.flag(:trap_exit, true)
              child = %{id: __MODULE__, start: {__MODULE__, :abnormal, []}}
@@ -711,9 +977,16 @@ defmodule Logger.TranslatorTest do
            Pid: #PID<\d+\.\d+\.\d+>
            Start Call: Logger.TranslatorTest.abnormal\(\)
            """
+
+    assert_receive {:error, _pid, {Logger, ["Child " | _], _ts, child_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert :stop = Keyword.get(child_metadata, :crash_reason)
+    assert :stop = Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates DynamicSupervisor reports abnormal shutdown including extra_arguments" do
+    add_test_logger_backend()
+
     assert capture_log(:info, fn ->
              trap = Process.flag(:trap_exit, true)
 
@@ -731,9 +1004,16 @@ defmodule Logger.TranslatorTest do
            Pid: #PID<\d+\.\d+\.\d+>
            Start Call: Logger.TranslatorTest.abnormal\(:extra, :args\)
            """
+
+    assert_receive {:error, _pid, {Logger, ["Child " | _], _ts, child_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert :stop = Keyword.get(child_metadata, :crash_reason)
+    assert :stop = Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates named DynamicSupervisor reports abnormal shutdown" do
+    add_test_logger_backend()
+
     assert capture_log(:info, fn ->
              trap = Process.flag(:trap_exit, true)
              child = %{id: __MODULE__, start: {__MODULE__, :abnormal, []}}
@@ -748,6 +1028,11 @@ defmodule Logger.TranslatorTest do
            Pid: #PID<\d+\.\d+\.\d+>
            Start Call: Logger.TranslatorTest.abnormal\(\)
            """
+
+    assert_receive {:error, _pid, {Logger, ["Child " | _], _ts, child_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert :stop = Keyword.get(child_metadata, :crash_reason)
+    assert :stop = Keyword.get(process_metadata, :crash_reason)
   end
 
   test "translates :supervisor_bridge progress" do
@@ -764,6 +1049,8 @@ defmodule Logger.TranslatorTest do
   end
 
   test "translates :supervisor_bridge reports" do
+    add_test_logger_backend()
+
     assert capture_log(:info, fn ->
              trap = Process.flag(:trap_exit, true)
              {:ok, pid} = :supervisor_bridge.start_link(MyBridge, :stop)
@@ -775,9 +1062,23 @@ defmodule Logger.TranslatorTest do
            Pid: #PID<\d+\.\d+\.\d+>
            Start Module: Logger.TranslatorTest.MyBridge
            """
+
+    assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+
+    assert_receive {:error, _pid,
+                    {Logger, ["Child of Supervisor " | _], _ts, supervisor_child_metadata}}
+
+    assert_receive {:error, _pid, {Logger, ["GenServer " <> _ | _], _ts, gen_server_metadata}}
+    assert {:stop, [_ | _]} = Keyword.get(task_metadata, :crash_reason)
+    assert :stop == Keyword.get(process_metadata, :crash_reason)
+    assert :stop == Keyword.get(supervisor_child_metadata, :crash_reason)
+    assert {:stop, []} == Keyword.get(gen_server_metadata, :crash_reason)
   end
 
   test "reports :undefined MFA properly" do
+    add_test_logger_backend()
+
     defmodule WeirdFunctionNamesGenServer do
       use GenServer
 
@@ -798,6 +1099,15 @@ defmodule Logger.TranslatorTest do
       end)
 
     assert log =~ ~s(Start Call: Logger.TranslatorTest.WeirdFunctionNamesGenServer."start link"/?)
+    assert_receive {:error, _pid, {Logger, ["GenServer " <> _ | _], _ts, gen_server_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Child " | _], _ts, child_metadata}}
+
+    assert {%RuntimeError{message: "oops"}, [_ | _]} =
+             Keyword.get(gen_server_metadata, :crash_reason)
+
+    assert %RuntimeError{message: "oops"} == Keyword.get(process_metadata, :crash_reason)
+    assert {%RuntimeError{message: "oops"}, [_ | _]} = Keyword.get(child_metadata, :crash_reason)
   after
     :code.purge(WeirdFunctionNamesGenServer)
     :code.delete(WeirdFunctionNamesGenServer)

--- a/lib/logger/test/test_helper.exs
+++ b/lib/logger/test/test_helper.exs
@@ -37,6 +37,17 @@ defmodule Logger.Case do
     end
   end
 
+  def add_test_logger_backend(inspect \\ false) do
+    capture_log(:info, fn ->
+      Logger.add_backend(TestLoggerBackend)
+      Logger.configure_backend(TestLoggerBackend, callback_pid: self(), inspect: inspect)
+    end)
+
+    ExUnit.Callbacks.on_exit(fn ->
+      :ok = Logger.remove_backend(TestLoggerBackend)
+    end)
+  end
+
   def capture_log(level \\ :debug, fun) do
     Logger.configure(level: level)
 
@@ -46,5 +57,62 @@ defmodule Logger.Case do
     end)
   after
     Logger.configure(level: :debug)
+  end
+end
+
+defmodule TestLoggerBackend do
+  @moduledoc """
+  A module that implements a custom `Logger` backend for use in testing.
+  This module can be used to verify events sent with `Logger`.
+  """
+
+  @behaviour :gen_event
+
+  def init(_) do
+    {:ok, %{events: []}}
+  end
+
+  def handle_call(:get, %{events: events} = state) do
+    {:ok, events, state}
+  end
+
+  def handle_call({:configure, opts}, state) do
+    callback_pid = Keyword.get(opts, :callback_pid)
+    inspect = Keyword.get(opts, :inspect)
+
+    state =
+      Map.put(state, :callback_pid, callback_pid)
+      |> Map.put(:inspect, inspect)
+
+    {:ok, :ok, state}
+  end
+
+  def handle_event(
+        {_level, _gl, {Logger, _msg, _ts, _md}} = event,
+        %{events: events, callback_pid: pid, inspect: inspect} = state
+      ) do
+    if inspect, do: IO.inspect(event)
+    send(pid, event)
+    {:ok, %{state | events: [event | events]}}
+  end
+
+  def handle_event(:flush, state) do
+    {:ok, %{state | events: []}}
+  end
+
+  def handle_event(_, state) do
+    {:ok, state}
+  end
+
+  def handle_info(_, state) do
+    {:ok, state}
+  end
+
+  def code_change(_old, state, _extra) do
+    {:ok, state}
+  end
+
+  def terminate(_reason, _state) do
+    :ok
   end
 end

--- a/lib/logger/test/test_helper.exs
+++ b/lib/logger/test/test_helper.exs
@@ -63,7 +63,8 @@ end
 defmodule TestLoggerBackend do
   @moduledoc """
   A module that implements a custom `Logger` backend for use in testing.
-  This module can be used to verify events sent with `Logger`.
+
+  This module can be used to verify events sent to `Logger`.
   """
 
   @behaviour :gen_event
@@ -81,7 +82,8 @@ defmodule TestLoggerBackend do
     inspect = Keyword.get(opts, :inspect)
 
     state =
-      Map.put(state, :callback_pid, callback_pid)
+      state
+      |> Map.put(:callback_pid, callback_pid)
       |> Map.put(:inspect, inspect)
 
     {:ok, :ok, state}
@@ -91,7 +93,7 @@ defmodule TestLoggerBackend do
         {_level, _gl, {Logger, _msg, _ts, _md}} = event,
         %{events: events, callback_pid: pid, inspect: inspect} = state
       ) do
-    if inspect, do: IO.inspect(event)
+    inspect && IO.inspect(event)
     send(pid, event)
     {:ok, %{state | events: [event | events]}}
   end


### PR DESCRIPTION
Related to #7494

@josevalim we hadn't discussed it, but for the other metadata mentioned in #7494 (`:name`, `:initial_call`), should it be pulled from places like https://github.com/elixir-lang/elixir/blob/8a971fcb44391bd8b16456666f3033b633c6ff77/lib/logger/lib/logger/translator.ex#L348 and https://github.com/elixir-lang/elixir/blob/8a971fcb44391bd8b16456666f3033b633c6ff77/lib/logger/lib/logger/translator.ex#L346?

I also added the `:inspect` option to the test logger backend to print events to the console as it was helpful to be able to turn it on and off per test.  I wasn't sure if it should be merged in, so let me know if it should be removed/refactored.