### PR TITLE
Add comment in typespecs page next to port type

### DIFF
--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -48,7 +48,7 @@ The notation to represent the union of types is the pipe `|`. For example, the t
           | atom()
           | map()                   # any map
           | pid()                   # process identifier
-          | port()
+          | port()                  # port identifier
           | reference()
           | struct()                # any struct
           | tuple()                 # tuple of any size


### PR DESCRIPTION
Mention that `port()` is a "port identifier", in the same vein as
`pid()` is commented as being a "proccess identifier"

[ci skip]