### PR TITLE
Clarify documentation in GenServer

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -742,7 +742,7 @@ defmodule GenServer do
   ## Options
 
     * `:name` - used for name registration as described in the "Name
-      registration" section of the module documentation
+      registration" section in the documentation for `GenServer`
 
     * `:timeout` - if present, the server is allowed to spend the given number of
       milliseconds initializing or it will be terminated and the start function

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -428,7 +428,7 @@ defmodule Supervisor do
       Defaults to `5`.
 
     * `:name` - a name to register the supervisor process. Supported values are
-      explained in the "Name registration" section of the documentation of
+      explained in the "Name registration" section in the documentation for
       `GenServer`. Optional.
 
   ### Strategies


### PR DESCRIPTION
Since the documented function uses a "module" arg., it was not
clear whether "module" referrer to the argument or to GenServer

[ci skip]