### PR TITLE
Change arg names in example in receive/1

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1981,10 +1981,10 @@ defmodule Kernel.SpecialForms do
   ## Examples
 
       receive do
-        {:selector, i, value} when is_integer(i) ->
-          value
-        value when is_atom(value) ->
-          value
+        {:selector, number, name} when is_integer(number) ->
+          name
+        name when is_atom(name) ->
+          name
         _ ->
           IO.puts :stderr, "Unexpected message received"
       end
@@ -1993,10 +1993,10 @@ defmodule Kernel.SpecialForms do
   received after the given timeout period, specified in milliseconds:
 
       receive do
-        {:selector, i, value} when is_integer(i) ->
-          value
-        value when is_atom(value) ->
-          value
+        {:selector, number, name} when is_integer(number) ->
+          name
+        name when is_atom(name) ->
+          name
         _ ->
           IO.puts :stderr, "Unexpected message received"
       after


### PR DESCRIPTION
1. avoid use of single-char variables with not descriptive names ("i")
2. "value" can be thought of a number, so to make it clearer I replace it with "name"