### PR TITLE
Make description of IEx.flush/0 even clearer

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -675,7 +675,7 @@ defmodule IEx.Helpers do
   defp pad_key(key), do: String.pad_trailing("#{key}:", 20, " ")
 
   @doc """
-  Flushes all messages sent to the shell and prints them out.
+  Clears out all messages sent to the shell's inbox and prints them out.
   """
   def flush do
     do_flush(IEx.inspect_opts())


### PR DESCRIPTION
It make not be 100% clear what "to flush the messages" mean.