### PR TITLE
Change wording in error giving options

### DIFF
--- a/lib/elixir/lib/gen_event.ex
+++ b/lib/elixir/lib/gen_event.ex
@@ -182,7 +182,7 @@ defmodule GenEvent do
 
       other ->
         raise ArgumentError, """
-        expected :name option to be one of:
+        expected :name option to be one of the following:
 
           * nil
           * atom

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -558,7 +558,7 @@ defmodule GenServer do
   exits. For such reasons, we usually recommend important clean-up rules to
   happen in separated processes either by use of monitoring or by links
   themselves. There is no cleanup needed when the `GenServer` controls a `port` (e.g.
-  `:gen_tcp.socket`) or `t:File.io_device/0`, because these will be closed on 
+  `:gen_tcp.socket`) or `t:File.io_device/0`, because these will be closed on
   receiving a `GenServer`'s exit signal and do not need to be closed manually
   in `c:terminate/2`.
 
@@ -843,7 +843,7 @@ defmodule GenServer do
 
       {other, _} ->
         raise ArgumentError, """
-        expected :name option to be one of:
+        expected :name option to be one of the following:
 
           * nil
           * atom

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -16,7 +16,7 @@ defmodule Kernel do
       data type handling, etc
     * macros for control-flow and defining new functionality (modules, functions, and so on)
     * [guard](guards.html) checks for augmenting pattern matching
-    
+
   You can use `Kernel` functions/macros without the `Kernel` prefix anywhere in
   Elixir code as all its functions and macros are automatically imported. For
   example, in IEx:
@@ -24,11 +24,11 @@ defmodule Kernel do
       iex> is_number(13)
       true
 
-  If you don't want to import a function or macro from `Kernel`, use the `:except` 
+  If you don't want to import a function or macro from `Kernel`, use the `:except`
   option and then list the function/macro by arity:
 
         import Kernel, except: [if: 2, unless: 2]
-        
+
   See `Kernel.SpecialForms.import/2` for more information on importing.
 
   Elixir also has special forms that are always imported and

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -275,7 +275,7 @@ defmodule Supervisor do
   with other developers and they can add it directly to their supervision tree
   without worrying about the low-level details of the worker.
 
-  Overall, the child specification can be one of:
+  Overall, the child specification can be one of the following:
 
     * a map representing the child specification itself - as outlined in the
       "Child specification" section
@@ -655,7 +655,7 @@ defmodule Supervisor do
 
   defp init_child(other) do
     raise ArgumentError, """
-    supervisors expect each child to be one of:
+    supervisors expect each child to be one of the following:
 
       * a module
       * a {module, arg} tuple
@@ -789,7 +789,7 @@ defmodule Supervisor do
 
       other ->
         raise ArgumentError, """
-        expected :name option to be one of:
+        expected :name option to be one of the following:
 
           * nil
           * atom

--- a/lib/elixir/test/elixir/gen_server_test.exs
+++ b/lib/elixir/test/elixir/gen_server_test.exs
@@ -63,15 +63,15 @@ defmodule GenServerTest do
   end
 
   test "start_link/3" do
-    assert_raise ArgumentError, ~r"expected :name option to be one of:", fn ->
+    assert_raise ArgumentError, ~r"expected :name option to be one of the following:", fn ->
       GenServer.start_link(Stack, [:hello], name: "my_gen_server_name")
     end
 
-    assert_raise ArgumentError, ~r"expected :name option to be one of:", fn ->
+    assert_raise ArgumentError, ~r"expected :name option to be one of the following:", fn ->
       GenServer.start_link(Stack, [:hello], name: {:invalid_tuple, "my_gen_server_name"})
     end
 
-    assert_raise ArgumentError, ~r"expected :name option to be one of:", fn ->
+    assert_raise ArgumentError, ~r"expected :name option to be one of the following:", fn ->
       GenServer.start_link(Stack, [:hello], name: {:via, "Via", "my_gen_server_name"})
     end
 

--- a/lib/elixir/test/elixir/supervisor_test.exs
+++ b/lib/elixir/test/elixir/supervisor_test.exs
@@ -166,17 +166,17 @@ defmodule SupervisorTest do
     assert GenServer.call(:dyn_stack, :pop) == :hello
     Supervisor.stop(pid)
 
-    assert_raise ArgumentError, ~r"expected :name option to be one of:", fn ->
+    assert_raise ArgumentError, ~r"expected :name option to be one of the following:", fn ->
       name = "my_gen_server_name"
       Supervisor.start_link(children, name: name, strategy: :one_for_one)
     end
 
-    assert_raise ArgumentError, ~r"expected :name option to be one of:", fn ->
+    assert_raise ArgumentError, ~r"expected :name option to be one of the following:", fn ->
       name = {:invalid_tuple, "my_gen_server_name"}
       Supervisor.start_link(children, name: name, strategy: :one_for_one)
     end
 
-    assert_raise ArgumentError, ~r"expected :name option to be one of:", fn ->
+    assert_raise ArgumentError, ~r"expected :name option to be one of the following:", fn ->
       name = {:via, "Via", "my_gen_server_name"}
       Supervisor.start_link(children, name: name, strategy: :one_for_one)
     end


### PR DESCRIPTION
Message read weird (didn't read natural):

    supervisors expect each child to be one of:
      * a module
      * a {module, arg} tuple
      * a child specification as a map with at least the :id and :start fields
      * or a tuple with 6 elements generated by Supervisor.Spec (deprecated)

changed to
    supervisors expect each child to be one of the following:
      * a module
      ....