### PR TITLE
Ignore unknown child info in Logger.Translator

### DIFF
--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -339,6 +339,10 @@ defmodule Logger.Translator do
     ["\nStart Module: ", inspect(mod) | child_debug(min_level, debug)]
   end
 
+  defp child_info(_min_level, _child) do
+    []
+  end
+
   defp child_debug(:debug, restart_type: restart, shutdown: shutdown, child_type: type) do
     ["\nRestart: ", inspect(restart), "\nShutdown: ", inspect(shutdown)] ++
       ["\nType: ", inspect(type)]


### PR DESCRIPTION
This prevents Logger application from crashing when supervisors report children progress with fields unknown to Logger.Translator. 

Closes #7889 
