### PR TITLE
Annotate @doc metadata when something is a guard

### DIFF
--- a/lib/elixir/lib/bitwise.ex
+++ b/lib/elixir/lib/bitwise.ex
@@ -66,6 +66,7 @@ defmodule Bitwise do
       1
 
   """
+  @doc guard: true
   defmacro bnot(expr) do
     quote(do: :erlang.bnot(unquote(expr)))
   end
@@ -79,6 +80,7 @@ defmodule Bitwise do
       1
 
   """
+  @doc guard: true
   defmacro ~~~expr do
     quote(do: :erlang.bnot(unquote(expr)))
   end
@@ -90,6 +92,7 @@ defmodule Bitwise do
       1
 
   """
+  @doc guard: true
   defmacro band(left, right) do
     quote(do: :erlang.band(unquote(left), unquote(right)))
   end
@@ -101,6 +104,7 @@ defmodule Bitwise do
       1
 
   """
+  @doc guard: true
   defmacro left &&& right do
     quote(do: :erlang.band(unquote(left), unquote(right)))
   end
@@ -112,6 +116,7 @@ defmodule Bitwise do
       11
 
   """
+  @doc guard: true
   defmacro bor(left, right) do
     quote(do: :erlang.bor(unquote(left), unquote(right)))
   end
@@ -123,6 +128,7 @@ defmodule Bitwise do
       11
 
   """
+  @doc guard: true
   defmacro left ||| right do
     quote(do: :erlang.bor(unquote(left), unquote(right)))
   end
@@ -134,6 +140,7 @@ defmodule Bitwise do
       10
 
   """
+  @doc guard: true
   defmacro bxor(left, right) do
     quote(do: :erlang.bxor(unquote(left), unquote(right)))
   end
@@ -145,6 +152,7 @@ defmodule Bitwise do
       10
 
   """
+  @doc guard: true
   defmacro left ^^^ right do
     quote(do: :erlang.bxor(unquote(left), unquote(right)))
   end
@@ -162,6 +170,7 @@ defmodule Bitwise do
       -1
 
   """
+  @doc guard: true
   defmacro bsl(left, right) do
     quote(do: :erlang.bsl(unquote(left), unquote(right)))
   end
@@ -179,6 +188,7 @@ defmodule Bitwise do
       -1
 
   """
+  @doc guard: true
   defmacro left <<< right do
     quote(do: :erlang.bsl(unquote(left), unquote(right)))
   end
@@ -196,6 +206,7 @@ defmodule Bitwise do
       -4
 
   """
+  @doc guard: true
   defmacro bsr(left, right) do
     quote(do: :erlang.bsr(unquote(left), unquote(right)))
   end
@@ -213,6 +224,7 @@ defmodule Bitwise do
       -4
 
   """
+  @doc guard: true
   defmacro left >>> right do
     quote(do: :erlang.bsr(unquote(left), unquote(right)))
   end

--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -66,7 +66,7 @@ defmodule IO.ANSI.Docs do
     print_each_metadata(metadata, options) && IO.write("\n")
   end
 
-  @metadata_filter [:deprecated, :since]
+  @metadata_filter [:deprecated, :guard, :since]
 
   defp print_each_metadata(metadata, options) do
     Enum.reduce(metadata, false, fn
@@ -74,6 +74,9 @@ defmodule IO.ANSI.Docs do
         label = metadata_label(key, options)
         indent = String.duplicate(" ", length_without_escape(label, 0) + 1)
         write_with_wrap([label | String.split(value, @spaces)], options[:width], indent, true)
+
+      {key, value}, _printed when is_boolean(value) and key in @metadata_filter ->
+        IO.puts([metadata_label(key, options), ' ', to_string(value)])
 
       _metadata, printed ->
         printed

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -191,6 +191,7 @@ defmodule Kernel do
       3
 
   """
+  @doc guard: true
   @spec abs(number) :: number
   def abs(number) do
     :erlang.abs(number)
@@ -255,6 +256,7 @@ defmodule Kernel do
       "llo"
 
   """
+  @doc guard: true
   @spec binary_part(binary, non_neg_integer, integer) :: binary
   def binary_part(binary, start, length) do
     :erlang.binary_part(binary, start, length)
@@ -274,6 +276,7 @@ defmodule Kernel do
       24
 
   """
+  @doc guard: true
   @spec bit_size(bitstring) :: non_neg_integer
   def bit_size(bitstring) do
     :erlang.bit_size(bitstring)
@@ -297,6 +300,7 @@ defmodule Kernel do
       3
 
   """
+  @doc guard: true
   @spec byte_size(bitstring) :: non_neg_integer
   def byte_size(bitstring) do
     :erlang.byte_size(bitstring)
@@ -331,6 +335,7 @@ defmodule Kernel do
       #=> ** (ArithmeticError) bad argument in arithmetic expression
 
   """
+  @doc guard: true
   @spec div(integer, neg_integer | pos_integer) :: integer
   def div(dividend, divisor) do
     :erlang.div(dividend, divisor)
@@ -421,6 +426,7 @@ defmodule Kernel do
       #=> 1
 
   """
+  @doc guard: true
   @spec hd(nonempty_maybe_improper_list(elem, any)) :: elem when elem: term
   def hd(list) do
     :erlang.hd(list)
@@ -431,6 +437,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
+  @doc guard: true
   @spec is_atom(term) :: boolean
   def is_atom(term) do
     :erlang.is_atom(term)
@@ -451,6 +458,7 @@ defmodule Kernel do
       false
 
   """
+  @doc guard: true
   @spec is_binary(term) :: boolean
   def is_binary(term) do
     :erlang.is_binary(term)
@@ -469,6 +477,7 @@ defmodule Kernel do
       true
 
   """
+  @doc guard: true
   @spec is_bitstring(term) :: boolean
   def is_bitstring(term) do
     :erlang.is_bitstring(term)
@@ -480,6 +489,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
+  @doc guard: true
   @spec is_boolean(term) :: boolean
   def is_boolean(term) do
     :erlang.is_boolean(term)
@@ -490,6 +500,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
+  @doc guard: true
   @spec is_float(term) :: boolean
   def is_float(term) do
     :erlang.is_float(term)
@@ -500,6 +511,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
+  @doc guard: true
   @spec is_function(term) :: boolean
   def is_function(term) do
     :erlang.is_function(term)
@@ -519,6 +531,7 @@ defmodule Kernel do
       false
 
   """
+  @doc guard: true
   @spec is_function(term, non_neg_integer) :: boolean
   def is_function(term, arity) do
     :erlang.is_function(term, arity)
@@ -529,6 +542,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
+  @doc guard: true
   @spec is_integer(term) :: boolean
   def is_integer(term) do
     :erlang.is_integer(term)
@@ -539,6 +553,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
+  @doc guard: true
   @spec is_list(term) :: boolean
   def is_list(term) do
     :erlang.is_list(term)
@@ -550,6 +565,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
+  @doc guard: true
   @spec is_number(term) :: boolean
   def is_number(term) do
     :erlang.is_number(term)
@@ -560,6 +576,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
+  @doc guard: true
   @spec is_pid(term) :: boolean
   def is_pid(term) do
     :erlang.is_pid(term)
@@ -570,6 +587,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
+  @doc guard: true
   @spec is_port(term) :: boolean
   def is_port(term) do
     :erlang.is_port(term)
@@ -580,6 +598,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
+  @doc guard: true
   @spec is_reference(term) :: boolean
   def is_reference(term) do
     :erlang.is_reference(term)
@@ -590,6 +609,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
+  @doc guard: true
   @spec is_tuple(term) :: boolean
   def is_tuple(term) do
     :erlang.is_tuple(term)
@@ -600,6 +620,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
+  @doc guard: true
   @spec is_map(term) :: boolean
   def is_map(term) do
     :erlang.is_map(term)
@@ -616,6 +637,7 @@ defmodule Kernel do
       9
 
   """
+  @doc guard: true
   @spec length(list) :: non_neg_integer
   def length(list) do
     :erlang.length(list)
@@ -654,6 +676,7 @@ defmodule Kernel do
       2
 
   """
+  @doc guard: true
   @spec map_size(map) :: non_neg_integer
   def map_size(map) do
     :erlang.map_size(map)
@@ -727,6 +750,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
+  @doc guard: true
   @spec node() :: node
   def node do
     :erlang.node()
@@ -739,6 +763,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
+  @doc guard: true
   @spec node(pid | reference | port) :: node
   def node(arg) do
     :erlang.node(arg)
@@ -763,6 +788,7 @@ defmodule Kernel do
       2
 
   """
+  @doc guard: true
   @spec rem(integer, neg_integer | pos_integer) :: integer
   def rem(dividend, divisor) do
     :erlang.rem(dividend, divisor)
@@ -788,6 +814,7 @@ defmodule Kernel do
       -9
 
   """
+  @doc guard: true
   @spec round(float) :: integer
   @spec round(value) :: value when value: integer
   def round(number) do
@@ -819,6 +846,7 @@ defmodule Kernel do
 
   Allowed in guard clauses. Inlined by the compiler.
   """
+  @doc guard: true
   @spec self() :: pid
   def self() do
     :erlang.self()
@@ -1016,6 +1044,7 @@ defmodule Kernel do
       #=> %{b: 1}
 
   """
+  @doc guard: true
   @spec tl(nonempty_maybe_improper_list(elem, tail)) :: maybe_improper_list(elem, tail) | tail
         when elem: term, tail: term
   def tl(list) do
@@ -1039,6 +1068,7 @@ defmodule Kernel do
       -5
 
   """
+  @doc guard: true
   @spec trunc(value) :: value when value: integer
   @spec trunc(float) :: integer
   def trunc(number) do
@@ -1058,6 +1088,7 @@ defmodule Kernel do
       3
 
   """
+  @doc guard: true
   @spec tuple_size(tuple) :: non_neg_integer
   def tuple_size(tuple) do
     :erlang.tuple_size(tuple)
@@ -1074,6 +1105,7 @@ defmodule Kernel do
       3
 
   """
+  @doc guard: true
   @spec integer + integer :: integer
   @spec float + float :: float
   @spec integer + float :: float
@@ -1093,6 +1125,7 @@ defmodule Kernel do
       -1
 
   """
+  @doc guard: true
   @spec integer - integer :: integer
   @spec float - float :: float
   @spec integer - float :: float
@@ -1112,6 +1145,7 @@ defmodule Kernel do
       1
 
   """
+  @doc guard: true
   @spec +value :: value when value: number
   def +value do
     :erlang.+(value)
@@ -1128,6 +1162,7 @@ defmodule Kernel do
       -2
 
   """
+  @doc guard: true
   @spec -0 :: 0
   @spec -pos_integer :: neg_integer
   @spec -neg_integer :: pos_integer
@@ -1147,6 +1182,7 @@ defmodule Kernel do
       2
 
   """
+  @doc guard: true
   @spec integer * integer :: integer
   @spec float * float :: float
   @spec integer * float :: float
@@ -1180,6 +1216,7 @@ defmodule Kernel do
       #=> ** (ArithmeticError) bad argument in arithmetic expression
 
   """
+  @doc guard: true
   @spec number / number :: float
   def left / right do
     :erlang./(left, right)
@@ -1261,6 +1298,7 @@ defmodule Kernel do
       true
 
   """
+  @doc guard: true
   @spec not true :: false
   @spec not false :: true
   def not value do
@@ -1280,6 +1318,7 @@ defmodule Kernel do
       true
 
   """
+  @doc guard: true
   @spec term < term :: boolean
   def left < right do
     :erlang.<(left, right)
@@ -1298,6 +1337,7 @@ defmodule Kernel do
       false
 
   """
+  @doc guard: true
   @spec term > term :: boolean
   def left > right do
     :erlang.>(left, right)
@@ -1316,6 +1356,7 @@ defmodule Kernel do
       true
 
   """
+  @doc guard: true
   @spec term <= term :: boolean
   def left <= right do
     :erlang."=<"(left, right)
@@ -1334,6 +1375,7 @@ defmodule Kernel do
       false
 
   """
+  @doc guard: true
   @spec term >= term :: boolean
   def left >= right do
     :erlang.>=(left, right)
@@ -1358,6 +1400,7 @@ defmodule Kernel do
       true
 
   """
+  @doc guard: true
   @spec term == term :: boolean
   def left == right do
     :erlang.==(left, right)
@@ -1382,6 +1425,7 @@ defmodule Kernel do
       false
 
   """
+  @doc guard: true
   @spec term != term :: boolean
   def left != right do
     :erlang."/="(left, right)
@@ -1408,6 +1452,7 @@ defmodule Kernel do
       false
 
   """
+  @doc guard: true
   @spec term === term :: boolean
   def left === right do
     :erlang."=:="(left, right)
@@ -1429,6 +1474,7 @@ defmodule Kernel do
       true
 
   """
+  @doc guard: true
   @spec term !== term :: boolean
   def left !== right do
     :erlang."=/="(left, right)
@@ -1454,6 +1500,7 @@ defmodule Kernel do
       #=> ** (ArgumentError) argument error
 
   """
+  @doc guard: true
   @spec elem(tuple, non_neg_integer) :: term
   def elem(tuple, index) do
     :erlang.element(index + 1, tuple)

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1548,6 +1548,7 @@ defmodule Kernel do
       42
 
   """
+  @doc guard: true
   defmacro left or right do
     case __CALLER__.context do
       nil -> build_boolean_check(:or, left, true, right)
@@ -1574,6 +1575,7 @@ defmodule Kernel do
       "yay!"
 
   """
+  @doc guard: true
   defmacro left and right do
     case __CALLER__.context do
       nil -> build_boolean_check(:and, left, right, false)
@@ -2635,6 +2637,7 @@ defmodule Kernel do
       true
 
   """
+  @doc guard: true
   defmacro is_nil(term) do
     quote(do: unquote(term) == nil)
   end
@@ -3376,6 +3379,7 @@ defmodule Kernel do
   Additionally, `Macro.to_string/2` will translate all occurrences of
   this AST to `left not in right`.
   """
+  @doc guard: true
   defmacro left in right do
     in_module? = __CALLER__.context == nil
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4664,18 +4664,24 @@ defmodule Kernel do
           {_name, args} ->
             validate_variable_only_args!(call, args)
 
-            case impls do
-              [] ->
-                define(kind, call, nil, env)
+            macro_definition =
+              case impls do
+                [] ->
+                  define(kind, call, nil, env)
 
-              [guard] ->
-                quoted =
-                  quote do
-                    require Kernel.Utils
-                    Kernel.Utils.defguard(unquote(args), unquote(guard))
-                  end
+                [guard] ->
+                  quoted =
+                    quote do
+                      require Kernel.Utils
+                      Kernel.Utils.defguard(unquote(args), unquote(guard))
+                    end
 
-                define(kind, call, [do: quoted], env)
+                  define(kind, call, [do: quoted], env)
+              end
+
+            quote do
+              @doc guard: true
+              unquote(macro_definition)
             end
 
           _invalid_definition ->

--- a/lib/elixir/test/elixir/kernel/docs_test.exs
+++ b/lib/elixir/test/elixir/kernel/docs_test.exs
@@ -190,6 +190,9 @@ defmodule Kernel.DocsTest do
           @doc false
           def qux(true), do: false
 
+          @doc "A guard"
+          defguard is_zero(v) when v == 0
+
           # We do this to avoid the deprecation warning.
           module = Module
           module.add_doc(__MODULE__, __ENV__.line, :def, {:nullary, 0}, [], "add_doc")
@@ -215,6 +218,7 @@ defmodule Kernel.DocsTest do
         function_foo,
         function_nullary,
         function_qux,
+        guard_is_zero,
         macrocallback_qux,
         type_bar,
         type_foo
@@ -251,6 +255,9 @@ defmodule Kernel.DocsTest do
                function_nullary
 
       assert {{:function, :qux, 1}, _, ["qux(bool)"], :hidden, %{}} = function_qux
+
+      assert {{:macro, :is_zero, 1}, _, ["is_zero(v)"], %{"en" => "A guard"}, %{guard: true}} =
+               guard_is_zero
 
       assert {{:macrocallback, :qux, 1}, _, [], %{"en" => "Macrocallback doc"}, %{}} =
                macrocallback_qux

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -458,12 +458,14 @@ defmodule IEx.Introspection do
         _ -> nil
       end
     else
-      print_doc("#{kind_to_def(kind)} #{Enum.join(signature, " ")}", spec, doc, metadata)
+      guard? = metadata[:guard]
+      print_doc("#{kind_to_def(kind, guard?)} #{Enum.join(signature, " ")}", spec, doc, metadata)
     end
   end
 
-  defp kind_to_def(:function), do: :def
-  defp kind_to_def(:macro), do: :defmacro
+  defp kind_to_def(:function, _), do: :def
+  defp kind_to_def(:macro, true), do: :defguard
+  defp kind_to_def(:macro, _), do: :defmacro
 
   defp callback_module(mod, fun, arity) do
     predicate = &match?({{^fun, ^arity}, _}, &1)

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -458,14 +458,12 @@ defmodule IEx.Introspection do
         _ -> nil
       end
     else
-      guard? = metadata[:guard]
-      print_doc("#{kind_to_def(kind, guard?)} #{Enum.join(signature, " ")}", spec, doc, metadata)
+      print_doc("#{kind_to_def(kind)} #{Enum.join(signature, " ")}", spec, doc, metadata)
     end
   end
 
-  defp kind_to_def(:function, _), do: :def
-  defp kind_to_def(:macro, true), do: :defguard
-  defp kind_to_def(:macro, _), do: :defmacro
+  defp kind_to_def(:function), do: :def
+  defp kind_to_def(:macro), do: :defmacro
 
   defp callback_module(mod, fun, arity) do
     predicate = &match?({{^fun, ^arity}, _}, &1)

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -377,7 +377,7 @@ defmodule IEx.HelpersTest do
       c_h = "* def c(files, path \\\\ :in_memory)\n\nCompiles the given files."
 
       eq_h =
-        "* def left == right\n\n  @spec term() == term() :: boolean()\n\nReturns `true` if the two items are equal.\n\n"
+        "* def left == right\n\n  @spec term() == term() :: boolean()\n\nguard: true\n\nReturns `true` if the two items are equal.\n\n"
 
       def_h =
         "* defmacro def(call, expr \\\\ nil)\n\nDefines a function with the given name and body."


### PR DESCRIPTION
Related to #7845.

This is a draft implementation after doing some experimentation with various ways of doing this. The current approach introduces the least amount of changes to make it work.

Other approaches:

1. use `:defguard`/`:defguardp` as kind and move the `@doc guard: true` call to `define/4`. `store_definition` would be called with `:defmacro`/`:defmacrop`.

This would have the added benefit of having more precise error messages in the `assert_*` functions.

2. use `:defguard`/`:defguardp`

This would be the most invasive change as there are a lot of places where we do something for `:defmacro`/`:defmacrop` that would have to be extended for guards. However, this would allow us to add `guard: true` to the metadata in `Module.compile_definition_attributes/6` which could in turn allow making `guard` a reserved metadata key. This last benefit is lost however if we need to add `@doc guard: true` to builtin guards like `is_binary` which are defined as plain functions.

Another thing to consider is whether to make the `guard` metadata key reserved. If we don't that might result in confusing behaviour if someone starts using it for other purposes (however unlikely). If we do, that will require a workaround for builtin guards.