### PR TITLE
Clarify how to configure :test_coverage

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -256,7 +256,13 @@ defmodule Mix.Tasks.Test do
   By default, a very simple wrapper around OTP's `cover` is used as a tool,
   but it can be overridden as follows:
 
-      test_coverage: [tool: CoverModule]
+      def project() do
+        [
+          ...
+          test_coverage: [tool: CoverModule]
+          ...
+        ]
+      end
 
   `CoverModule` can be any module that exports `start/2`, receiving the
   compilation path and the `test_coverage` options as arguments.


### PR DESCRIPTION
Given `ExUnit.configure` was previously mentioned in these docs, I thought that's where `:test_coverage` is to be put and was surprised that it didn't work.