### PR TITLE
Optimization for Float.round/2 when precision is 0

### DIFF
--- a/lib/elixir/lib/float.ex
+++ b/lib/elixir/lib/float.ex
@@ -256,11 +256,15 @@ defmodule Float do
   # and could be implemented in the future.
   def round(float, precision \\ 0)
 
+  def round(float, 0) when is_float(float) do
+    float |> :erlang.round() |> :erlang.float()
+  end
+
   def round(float, precision) when is_float(float) and precision in @precision_range do
     round(float, precision, :half_up)
   end
 
-  def round(number, precision) when is_float(number) do
+  def round(float, precision) when is_float(float) do
     raise ArgumentError, invalid_precision_message(precision)
   end
 


### PR DESCRIPTION
I did not notice one more optimization opportunity in previous PR. 

Benchmarks (1000 floats per run)

Before
```
Name                          ips        average  deviation         median         99th %
round/1                    382.08     2617.25 μs     ±3.97%        2590 μs     3031.20 μs
round/2 precision 0        377.92     2646.05 μs     ±4.09%        2621 μs     3064.80 μs
round/2 precision 1        351.24     2847.02 μs     ±6.13%        2804 μs     3648.76 μs
```

After
```
Name                          ips        average  deviation         median         99th %
round/1                  20596.03       48.55 μs    ±18.17%          47 μs          91 μs
round/2 precision 0      20096.23       49.76 μs    ±17.50%          48 μs          91 μs
round/2 precision 1        354.77     2818.69 μs     ±4.28%        2795 μs     3292.34 μs
```