### PR TITLE
Add Function module docs to "Basic Types" group

### DIFF
--- a/lib/elixir/docs.exs
+++ b/lib/elixir/docs.exs
@@ -14,6 +14,7 @@
       DateTime,
       Exception,
       Float,
+      Function,
       Integer,
       NaiveDateTime,
       Record,


### PR DESCRIPTION
At the moment `Function` module is in one group (without group?) with Kernel and Kernel.SpecialForms.

I'm not sure if "Basic Types" is correct group, but functions in this module are taking/returning other functions so function looks like kind of type to me.