### PR TITLE
Annotate @doc metadata when a function is inlined

### DIFF
--- a/lib/elixir/lib/atom.ex
+++ b/lib/elixir/lib/atom.ex
@@ -16,6 +16,7 @@ defmodule Atom do
       "foo"
 
   """
+  @doc inlined: true
   @spec to_string(atom) :: String.t()
   def to_string(atom) do
     :erlang.atom_to_binary(atom, :utf8)
@@ -32,6 +33,7 @@ defmodule Atom do
       'An atom'
 
   """
+  @doc inlined: true
   @spec to_charlist(atom) :: charlist
   def to_charlist(atom) do
     :erlang.atom_to_list(atom)

--- a/lib/elixir/lib/function.ex
+++ b/lib/elixir/lib/function.ex
@@ -32,7 +32,7 @@ defmodule Function do
       &String.length/1
 
   """
-  @doc since: "1.7.0"
+  @doc since: "1.7.0", inlined: true
   @spec capture(module, atom, arity) :: fun
   def capture(module, function_name, arity) do
     :erlang.make_fun(module, function_name, arity)
@@ -93,7 +93,7 @@ defmodule Function do
       :length
 
   """
-  @doc since: "1.7.0"
+  @doc since: "1.7.0", inlined: true
   @spec info(fun) :: [{information, term}]
   def info(fun), do: :erlang.fun_info(fun)
 
@@ -131,7 +131,7 @@ defmodule Function do
       {:pid, :undefined}
 
   """
-  @doc since: "1.7.0"
+  @doc since: "1.7.0", inlined: true
   @spec info(fun, item) :: {item, term} when item: information
   def info(fun, item), do: :erlang.fun_info(fun, item)
 end

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -290,6 +290,7 @@ defmodule Integer do
       "123"
 
   """
+  @doc inlined: true
   @spec to_string(integer) :: String.t()
   def to_string(integer) do
     :erlang.integer_to_binary(integer)
@@ -315,6 +316,7 @@ defmodule Integer do
       "ELIXIR"
 
   """
+  @doc inlined: true
   @spec to_string(integer, 2..36) :: String.t()
   def to_string(integer, base) do
     :erlang.integer_to_binary(integer, base)
@@ -340,6 +342,7 @@ defmodule Integer do
       '123'
 
   """
+  @doc inlined: true
   @spec to_charlist(integer) :: charlist
   def to_charlist(integer) do
     :erlang.integer_to_list(integer)
@@ -364,6 +367,7 @@ defmodule Integer do
       'ELIXIR'
 
   """
+  @doc inlined: true
   @spec to_charlist(integer, 2..36) :: charlist
   def to_charlist(integer, base) do
     :erlang.integer_to_list(integer, base)

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -493,6 +493,7 @@ defmodule IO do
       <<1, 2, 3>>
 
   """
+  @doc inlined: true
   @spec iodata_to_binary(iodata) :: binary
   def iodata_to_binary(item) do
     :erlang.iolist_to_binary(item)
@@ -509,6 +510,7 @@ defmodule IO do
       4
 
   """
+  @doc inlined: true
   @spec iodata_length(iodata) :: non_neg_integer
   def iodata_length(item) do
     :erlang.iolist_size(item)

--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -66,7 +66,7 @@ defmodule IO.ANSI.Docs do
     print_each_metadata(metadata, options) && IO.write("\n")
   end
 
-  @metadata_filter [:deprecated, :guard, :since]
+  @metadata_filter [:deprecated, :guard, :inlined, :since]
 
   defp print_each_metadata(metadata, options) do
     Enum.reduce(metadata, false, fn

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -203,7 +203,7 @@ defmodule Kernel do
       3
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec abs(number) :: number
   def abs(number) do
     :erlang.abs(number)
@@ -221,6 +221,7 @@ defmodule Kernel do
       4
 
   """
+  @doc inlined: true
   @spec apply(fun, [any]) :: any
   def apply(fun, args) do
     :erlang.apply(fun, args)
@@ -242,6 +243,7 @@ defmodule Kernel do
       [3, 2, 1]
 
   """
+  @doc inlined: true
   @spec apply(module, function_name :: atom, [any]) :: any
   def apply(module, function_name, args) do
     :erlang.apply(module, function_name, args)
@@ -268,7 +270,7 @@ defmodule Kernel do
       "llo"
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec binary_part(binary, non_neg_integer, integer) :: binary
   def binary_part(binary, start, length) do
     :erlang.binary_part(binary, start, length)
@@ -288,7 +290,7 @@ defmodule Kernel do
       24
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec bit_size(bitstring) :: non_neg_integer
   def bit_size(bitstring) do
     :erlang.bit_size(bitstring)
@@ -312,7 +314,7 @@ defmodule Kernel do
       3
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec byte_size(bitstring) :: non_neg_integer
   def byte_size(bitstring) do
     :erlang.byte_size(bitstring)
@@ -326,7 +328,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @doc since: "1.8.0", guard: true
+  @doc since: "1.8.0", guard: true, inlined: true
   @spec ceil(number) :: integer
   def ceil(number) do
     :erlang.ceil(number)
@@ -361,7 +363,7 @@ defmodule Kernel do
       #=> ** (ArithmeticError) bad argument in arithmetic expression
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec div(integer, neg_integer | pos_integer) :: integer
   def div(dividend, divisor) do
     :erlang.div(dividend, divisor)
@@ -428,6 +430,7 @@ defmodule Kernel do
   Any other exit reason will cause the OS process to exit with
   status `1` and linked Erlang processes to crash.
   """
+  @doc inlined: true
   @spec exit(term) :: no_return
   def exit(reason) do
     :erlang.exit(reason)
@@ -441,7 +444,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @doc since: "1.8.0", guard: true
+  @doc since: "1.8.0", guard: true, inlined: true
   @spec floor(number) :: integer
   def floor(number) do
     :erlang.floor(number)
@@ -466,7 +469,7 @@ defmodule Kernel do
       #=> 1
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec hd(nonempty_maybe_improper_list(elem, any)) :: elem when elem: term
   def hd(list) do
     :erlang.hd(list)
@@ -477,7 +480,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec is_atom(term) :: boolean
   def is_atom(term) do
     :erlang.is_atom(term)
@@ -498,7 +501,7 @@ defmodule Kernel do
       false
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec is_binary(term) :: boolean
   def is_binary(term) do
     :erlang.is_binary(term)
@@ -517,7 +520,7 @@ defmodule Kernel do
       true
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec is_bitstring(term) :: boolean
   def is_bitstring(term) do
     :erlang.is_bitstring(term)
@@ -529,7 +532,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec is_boolean(term) :: boolean
   def is_boolean(term) do
     :erlang.is_boolean(term)
@@ -540,7 +543,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec is_float(term) :: boolean
   def is_float(term) do
     :erlang.is_float(term)
@@ -551,7 +554,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec is_function(term) :: boolean
   def is_function(term) do
     :erlang.is_function(term)
@@ -571,7 +574,7 @@ defmodule Kernel do
       false
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec is_function(term, non_neg_integer) :: boolean
   def is_function(term, arity) do
     :erlang.is_function(term, arity)
@@ -582,7 +585,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec is_integer(term) :: boolean
   def is_integer(term) do
     :erlang.is_integer(term)
@@ -593,7 +596,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec is_list(term) :: boolean
   def is_list(term) do
     :erlang.is_list(term)
@@ -605,7 +608,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec is_number(term) :: boolean
   def is_number(term) do
     :erlang.is_number(term)
@@ -616,7 +619,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec is_pid(term) :: boolean
   def is_pid(term) do
     :erlang.is_pid(term)
@@ -627,7 +630,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec is_port(term) :: boolean
   def is_port(term) do
     :erlang.is_port(term)
@@ -638,7 +641,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec is_reference(term) :: boolean
   def is_reference(term) do
     :erlang.is_reference(term)
@@ -649,7 +652,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec is_tuple(term) :: boolean
   def is_tuple(term) do
     :erlang.is_tuple(term)
@@ -660,7 +663,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec is_map(term) :: boolean
   def is_map(term) do
     :erlang.is_map(term)
@@ -677,7 +680,7 @@ defmodule Kernel do
       9
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec length(list) :: non_neg_integer
   def length(list) do
     :erlang.length(list)
@@ -696,6 +699,7 @@ defmodule Kernel do
       make_ref() #=> #Reference<0.0.0.135>
 
   """
+  @doc inlined: true
   @spec make_ref() :: reference
   def make_ref() do
     :erlang.make_ref()
@@ -716,7 +720,7 @@ defmodule Kernel do
       2
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec map_size(map) :: non_neg_integer
   def map_size(map) do
     :erlang.map_size(map)
@@ -748,6 +752,7 @@ defmodule Kernel do
   such cases it is common for modules to provide functions such as
   `Date.compare/1` that perform semantic comparison.
   """
+  @doc inlined: true
   @spec max(first, second) :: first | second when first: term, second: term
   def max(first, second) do
     :erlang.max(first, second)
@@ -779,6 +784,7 @@ defmodule Kernel do
   such cases it is common for modules to provide functions such as
   `Date.compare/1` that perform semantic comparison.
   """
+  @doc inlined: true
   @spec min(first, second) :: first | second when first: term, second: term
   def min(first, second) do
     :erlang.min(first, second)
@@ -790,7 +796,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec node() :: node
   def node do
     :erlang.node()
@@ -803,7 +809,7 @@ defmodule Kernel do
 
   Allowed in guard tests. Inlined by the compiler.
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec node(pid | reference | port) :: node
   def node(arg) do
     :erlang.node(arg)
@@ -828,7 +834,7 @@ defmodule Kernel do
       2
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec rem(integer, neg_integer | pos_integer) :: integer
   def rem(dividend, divisor) do
     :erlang.rem(dividend, divisor)
@@ -854,7 +860,7 @@ defmodule Kernel do
       -9
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec round(float) :: integer
   @spec round(value) :: value when value: integer
   def round(number) do
@@ -876,6 +882,7 @@ defmodule Kernel do
       :hello
 
   """
+  @doc inlined: true
   @spec send(dest :: Process.dest(), message) :: message when message: any
   def send(dest, message) do
     :erlang.send(dest, message)
@@ -886,7 +893,7 @@ defmodule Kernel do
 
   Allowed in guard clauses. Inlined by the compiler.
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec self() :: pid
   def self() do
     :erlang.self()
@@ -916,6 +923,7 @@ defmodule Kernel do
       end
 
   """
+  @doc inlined: true
   @spec spawn((() -> any)) :: pid
   def spawn(fun) do
     :erlang.spawn(fun)
@@ -939,6 +947,7 @@ defmodule Kernel do
       spawn(SomeModule, :function, [1, 2, 3])
 
   """
+  @doc inlined: true
   @spec spawn(module, atom, list) :: pid
   def spawn(module, fun, args) do
     :erlang.spawn(module, fun, args)
@@ -969,6 +978,7 @@ defmodule Kernel do
       end
 
   """
+  @doc inlined: true
   @spec spawn_link((() -> any)) :: pid
   def spawn_link(fun) do
     :erlang.spawn_link(fun)
@@ -993,6 +1003,7 @@ defmodule Kernel do
       spawn_link(SomeModule, :function, [1, 2, 3])
 
   """
+  @doc inlined: true
   @spec spawn_link(module, atom, list) :: pid
   def spawn_link(module, fun, args) do
     :erlang.spawn_link(module, fun, args)
@@ -1019,6 +1030,7 @@ defmodule Kernel do
       spawn_monitor(fn -> send current, {self(), 1 + 2} end)
 
   """
+  @doc inlined: true
   @spec spawn_monitor((() -> any)) :: {pid, reference}
   def spawn_monitor(fun) do
     :erlang.spawn_monitor(fun)
@@ -1042,6 +1054,7 @@ defmodule Kernel do
       spawn_monitor(SomeModule, :function, [1, 2, 3])
 
   """
+  @doc inlined: true
   @spec spawn_monitor(module, atom, list) :: {pid, reference}
   def spawn_monitor(module, fun, args) do
     :erlang.spawn_monitor(module, fun, args)
@@ -1054,6 +1067,7 @@ defmodule Kernel do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec throw(term) :: no_return
   def throw(term) do
     :erlang.throw(term)
@@ -1084,7 +1098,7 @@ defmodule Kernel do
       #=> %{b: 1}
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec tl(nonempty_maybe_improper_list(elem, tail)) :: maybe_improper_list(elem, tail) | tail
         when elem: term, tail: term
   def tl(list) do
@@ -1108,7 +1122,7 @@ defmodule Kernel do
       -5
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec trunc(value) :: value when value: integer
   @spec trunc(float) :: integer
   def trunc(number) do
@@ -1128,7 +1142,7 @@ defmodule Kernel do
       3
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec tuple_size(tuple) :: non_neg_integer
   def tuple_size(tuple) do
     :erlang.tuple_size(tuple)
@@ -1145,7 +1159,7 @@ defmodule Kernel do
       3
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec integer + integer :: integer
   @spec float + float :: float
   @spec integer + float :: float
@@ -1165,7 +1179,7 @@ defmodule Kernel do
       -1
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec integer - integer :: integer
   @spec float - float :: float
   @spec integer - float :: float
@@ -1185,7 +1199,7 @@ defmodule Kernel do
       1
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec +value :: value when value: number
   def +value do
     :erlang.+(value)
@@ -1202,7 +1216,7 @@ defmodule Kernel do
       -2
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec -0 :: 0
   @spec -pos_integer :: neg_integer
   @spec -neg_integer :: pos_integer
@@ -1222,7 +1236,7 @@ defmodule Kernel do
       2
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec integer * integer :: integer
   @spec float * float :: float
   @spec integer * float :: float
@@ -1256,7 +1270,7 @@ defmodule Kernel do
       #=> ** (ArithmeticError) bad argument in arithmetic expression
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec number / number :: float
   def left / right do
     :erlang./(left, right)
@@ -1295,6 +1309,7 @@ defmodule Kernel do
       [1, 2 | 3]
 
   """
+  @doc inlined: true
   @spec list ++ term :: maybe_improper_list
   def left ++ right do
     :erlang.++(left, right)
@@ -1320,6 +1335,7 @@ defmodule Kernel do
       [3, 1]
 
   """
+  @doc inlined: true
   @spec list -- list :: list
   def left -- right do
     :erlang.--(left, right)
@@ -1338,7 +1354,7 @@ defmodule Kernel do
       true
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec not true :: false
   @spec not false :: true
   def not value do
@@ -1358,7 +1374,7 @@ defmodule Kernel do
       true
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec term < term :: boolean
   def left < right do
     :erlang.<(left, right)
@@ -1377,7 +1393,7 @@ defmodule Kernel do
       false
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec term > term :: boolean
   def left > right do
     :erlang.>(left, right)
@@ -1396,7 +1412,7 @@ defmodule Kernel do
       true
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec term <= term :: boolean
   def left <= right do
     :erlang."=<"(left, right)
@@ -1415,7 +1431,7 @@ defmodule Kernel do
       false
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec term >= term :: boolean
   def left >= right do
     :erlang.>=(left, right)
@@ -1440,7 +1456,7 @@ defmodule Kernel do
       true
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec term == term :: boolean
   def left == right do
     :erlang.==(left, right)
@@ -1465,7 +1481,7 @@ defmodule Kernel do
       false
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec term != term :: boolean
   def left != right do
     :erlang."/="(left, right)
@@ -1492,7 +1508,7 @@ defmodule Kernel do
       false
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec term === term :: boolean
   def left === right do
     :erlang."=:="(left, right)
@@ -1514,7 +1530,7 @@ defmodule Kernel do
       true
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec term !== term :: boolean
   def left !== right do
     :erlang."=/="(left, right)
@@ -1540,7 +1556,7 @@ defmodule Kernel do
       #=> ** (ArgumentError) argument error
 
   """
-  @doc guard: true
+  @doc guard: true, inlined: true
   @spec elem(tuple, non_neg_integer) :: term
   def elem(tuple, index) do
     :erlang.element(index + 1, tuple)
@@ -1558,6 +1574,7 @@ defmodule Kernel do
       {:baz, :bar, 3}
 
   """
+  @doc inlined: true
   @spec put_elem(tuple, non_neg_integer, term) :: tuple
   def put_elem(tuple, index, value) do
     :erlang.setelement(index + 1, tuple, value)
@@ -3331,6 +3348,7 @@ defmodule Kernel do
       true
 
   """
+  @doc inlined: true
   @spec function_exported?(module, atom, arity) :: boolean
   def function_exported?(module, function, arity) do
     :erlang.function_exported(module, function, arity)

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -704,6 +704,7 @@ defmodule List do
       :elixir
 
   """
+  @doc inlined: true
   @spec to_atom(charlist) :: atom
   def to_atom(charlist) do
     :erlang.list_to_atom(charlist)
@@ -728,6 +729,7 @@ defmodule List do
       ** (ArgumentError) argument error
 
   """
+  @doc inlined: true
   @spec to_existing_atom(charlist) :: atom
   def to_existing_atom(charlist) do
     :erlang.list_to_existing_atom(charlist)
@@ -744,6 +746,7 @@ defmodule List do
       2.2017764
 
   """
+  @doc inlined: true
   @spec to_float(charlist) :: float
   def to_float(charlist) do
     :erlang.list_to_float(charlist)
@@ -760,6 +763,7 @@ defmodule List do
       123
 
   """
+  @doc inlined: true
   @spec to_integer(charlist) :: integer
   def to_integer(charlist) do
     :erlang.list_to_integer(charlist)
@@ -776,6 +780,7 @@ defmodule List do
       1023
 
   """
+  @doc inlined: true
   @spec to_integer(charlist, 2..36) :: integer
   def to_integer(charlist, base) do
     :erlang.list_to_integer(charlist, base)
@@ -792,6 +797,7 @@ defmodule List do
       {:share, [:elixir, 163]}
 
   """
+  @doc inlined: true
   @spec to_tuple(list) :: tuple
   def to_tuple(list) do
     :erlang.list_to_tuple(list)

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -108,6 +108,7 @@ defmodule Map do
       [:a, :b]
 
   """
+  @doc inlined: true
   @spec keys(map) :: [key]
   defdelegate keys(map), to: :maps
 
@@ -122,6 +123,7 @@ defmodule Map do
       [1, 2]
 
   """
+  @doc inlined: true
   @spec values(map) :: [value]
   defdelegate values(map), to: :maps
 
@@ -141,6 +143,7 @@ defmodule Map do
       [{1, 2}]
 
   """
+  @doc inlined: true
   @spec to_list(map) :: [{term, term}]
   defdelegate to_list(map), to: :maps
 
@@ -223,6 +226,7 @@ defmodule Map do
       false
 
   """
+  @doc inlined: true
   @spec has_key?(map, key) :: boolean
   def has_key?(map, key), do: :maps.is_key(key, map)
 
@@ -242,6 +246,7 @@ defmodule Map do
       :error
 
   """
+  @doc inlined: true
   @spec fetch(map, key) :: {:ok, value} | :error
   def fetch(map, key), do: :maps.find(key, map)
 
@@ -262,6 +267,7 @@ defmodule Map do
       ** (KeyError) key :b not found in: %{a: 1}
 
   """
+  @doc inlined: true
   @spec fetch!(map, key) :: value | no_return
   def fetch!(map, key) do
     :maps.get(key, map)
@@ -325,7 +331,7 @@ defmodule Map do
       ** (KeyError) key :b not found in: %{a: 1}
 
   """
-  @doc since: "1.5.0"
+  @doc since: "1.5.0", inlined: true
   @spec replace!(map, key, value) :: map
   def replace!(map, key, value) do
     :maps.update(key, value, map)
@@ -487,6 +493,7 @@ defmodule Map do
       %{a: 3, b: 2}
 
   """
+  @doc inlined: true
   @spec put(map, key, value) :: map
   def put(map, key, value) do
     :maps.put(key, value, map)
@@ -506,8 +513,8 @@ defmodule Map do
       iex> Map.delete(%{b: 2}, :a)
       %{b: 2}
 
-  Inlined by the compiler.
   """
+  @doc inlined: true
   @spec delete(map, key) :: map
   def delete(map, key), do: :maps.remove(key, map)
 
@@ -530,6 +537,7 @@ defmodule Map do
       %{a: 3, b: 2, d: 4}
 
   """
+  @doc inlined: true
   @spec merge(map, map) :: map
   defdelegate merge(map1, map2), to: :maps
 

--- a/lib/elixir/lib/node.ex
+++ b/lib/elixir/lib/node.ex
@@ -62,6 +62,7 @@ defmodule Node do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec list :: [t]
   def list do
     :erlang.nodes()
@@ -77,6 +78,7 @@ defmodule Node do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @type state :: :visible | :hidden | :connected | :this | :known
   @spec list(state | [state]) :: [t]
   def list(args) do
@@ -163,6 +165,7 @@ defmodule Node do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec spawn(t, (() -> any)) :: pid
   def spawn(node, fun) do
     :erlang.spawn(node, fun)
@@ -178,6 +181,7 @@ defmodule Node do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec spawn(t, (() -> any), Process.spawn_opts()) :: pid | {pid, reference}
   def spawn(node, fun, opts) do
     :erlang.spawn_opt(node, fun, opts)
@@ -193,6 +197,7 @@ defmodule Node do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec spawn(t, module, atom, [any]) :: pid
   def spawn(node, module, fun, args) do
     :erlang.spawn(node, module, fun, args)
@@ -208,6 +213,7 @@ defmodule Node do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec spawn(t, module, atom, [any], Process.spawn_opts()) :: pid | {pid, reference}
   def spawn(node, module, fun, args, opts) do
     :erlang.spawn_opt(node, module, fun, args, opts)
@@ -222,6 +228,7 @@ defmodule Node do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec spawn_link(t, (() -> any)) :: pid
   def spawn_link(node, fun) do
     :erlang.spawn_link(node, fun)
@@ -237,6 +244,7 @@ defmodule Node do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec spawn_link(t, module, atom, [any]) :: pid
   def spawn_link(node, module, fun, args) do
     :erlang.spawn_link(node, module, fun, args)

--- a/lib/elixir/lib/port.ex
+++ b/lib/elixir/lib/port.ex
@@ -176,6 +176,7 @@ defmodule Port do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec open(name, list) :: port
   def open(name, options) do
     :erlang.open_port(name, options)
@@ -188,6 +189,7 @@ defmodule Port do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec close(port) :: true
   def close(port) do
     :erlang.port_close(port)
@@ -200,6 +202,7 @@ defmodule Port do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec command(port, iodata, [:force | :nosuspend]) :: boolean
   def command(port, data, options \\ []) do
     :erlang.port_command(port, data, options)
@@ -212,6 +215,7 @@ defmodule Port do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec connect(port, pid) :: true
   def connect(port, pid) do
     :erlang.port_connect(port, pid)
@@ -265,7 +269,7 @@ defmodule Port do
 
   Inlined by the compiler.
   """
-  @doc since: "1.6.0"
+  @doc since: "1.6.0", inlined: true
   @spec monitor(port | {name :: atom, node :: atom} | name :: atom) :: reference
   def monitor(port) do
     :erlang.monitor(:port, port)
@@ -282,7 +286,7 @@ defmodule Port do
 
   Inlined by the compiler.
   """
-  @doc since: "1.6.0"
+  @doc since: "1.6.0", inlined: true
   @spec demonitor(reference, options :: [:flush | :info]) :: boolean
   defdelegate demonitor(monitor_ref, options \\ []), to: :erlang
 
@@ -291,6 +295,7 @@ defmodule Port do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec list :: [port]
   def list do
     :erlang.ports()

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -30,6 +30,7 @@ defmodule Process do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
 
   @typedoc """
   A process destination.
@@ -47,6 +48,7 @@ defmodule Process do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec get() :: [{term, term}]
   defdelegate get(), to: :erlang
 
@@ -89,6 +91,7 @@ defmodule Process do
       true
 
   """
+  @doc inlined: true
   @spec get_keys() :: [term]
   defdelegate get_keys(), to: :erlang
 
@@ -97,6 +100,7 @@ defmodule Process do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec get_keys(term) :: [term]
   defdelegate get_keys(value), to: :erlang
 
@@ -170,6 +174,7 @@ defmodule Process do
       #=> true
 
   """
+  @doc inlined: true
   @spec exit(pid, term) :: true
   defdelegate exit(pid, reason), to: :erlang
 
@@ -276,6 +281,7 @@ defmodule Process do
       :noconnect
 
   """
+  @doc inlined: true
   @spec send(dest, msg, [option]) :: :ok | :noconnect | :nosuspend
         when dest: dest(),
              msg: any,
@@ -313,6 +319,7 @@ defmodule Process do
       timer_ref = Process.send_after(pid, :hi, 1000)
 
   """
+  @doc inlined: true
   @spec send_after(pid | atom, term, non_neg_integer, [option]) :: reference
         when option: {:abs, boolean}
   def send_after(dest, msg, time, opts \\ []) do
@@ -352,6 +359,7 @@ defmodule Process do
       `false`, no message is sent. Defaults to `true`.
 
   """
+  @doc inlined: true
   @spec cancel_timer(reference, options) :: non_neg_integer | false | :ok
         when options: [async: boolean, info: boolean]
   defdelegate cancel_timer(timer_ref, options \\ []), to: :erlang
@@ -371,6 +379,7 @@ defmodule Process do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec read_timer(reference) :: non_neg_integer | false
   defdelegate read_timer(timer_ref), to: :erlang
 
@@ -404,6 +413,7 @@ defmodule Process do
       #=> #PID<0.95.0>
 
   """
+  @doc inlined: true
   @spec spawn((() -> any), spawn_opts) :: pid | {pid, reference}
   defdelegate spawn(fun, opts), to: :erlang, as: :spawn_opt
 
@@ -421,6 +431,7 @@ defmodule Process do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec spawn(module, atom, list, spawn_opts) :: pid | {pid, reference}
   defdelegate spawn(mod, fun, args, opts), to: :erlang, as: :spawn_opt
 
@@ -461,6 +472,7 @@ defmodule Process do
       #=> {:DOWN, #Reference<0.906660723.3006791681.40191>, :process, #PID<0.118.0>, :noproc}
 
   """
+  @doc inlined: true
   @spec monitor(pid | {name :: atom, node :: atom} | name :: atom) :: reference
   def monitor(item) do
     :erlang.monitor(:process, item)
@@ -485,6 +497,7 @@ defmodule Process do
       #=> true
 
   """
+  @doc inlined: true
   @spec demonitor(reference, options :: [:flush | :info]) :: boolean
   defdelegate demonitor(monitor_ref, options \\ []), to: :erlang
 
@@ -506,6 +519,7 @@ defmodule Process do
       #=> [#PID<0.0.0>, #PID<0.1.0>, #PID<0.2.0>, #PID<0.3.0>, ...]
 
   """
+  @doc inlined: true
   @spec list() :: [pid]
   defdelegate list(), to: :erlang, as: :processes
 
@@ -531,6 +545,7 @@ defmodule Process do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec link(pid | port) :: true
   defdelegate link(pid_or_port), to: :erlang
 
@@ -547,6 +562,7 @@ defmodule Process do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec unlink(pid | port) :: true
   defdelegate unlink(pid_or_port), to: :erlang
 
@@ -617,6 +633,7 @@ defmodule Process do
       #=> ** (ArgumentError) argument error
 
   """
+  @doc inlined: true
   @spec unregister(atom) :: true
   defdelegate unregister(name), to: :erlang
 
@@ -651,6 +668,7 @@ defmodule Process do
       #=> #PID<0.53.0>
 
   """
+  @doc inlined: true
   @spec group_leader() :: pid
   defdelegate group_leader(), to: :erlang
 
@@ -662,6 +680,7 @@ defmodule Process do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec group_leader(pid, leader :: pid) :: true
   def group_leader(pid, leader) do
     :erlang.group_leader(leader, pid)
@@ -679,6 +698,7 @@ defmodule Process do
       #=> [:test, :elixir_config, :inet_db, ...]
 
   """
+  @doc inlined: true
   @spec registered() :: [atom]
   defdelegate registered(), to: :erlang
 
@@ -697,6 +717,7 @@ defmodule Process do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec flag(:error_handler, module) :: module
   @spec flag(:max_heap_size, heap_size) :: heap_size
   @spec flag(:message_queue_data, :erlang.message_queue_data()) :: :erlang.message_queue_data()
@@ -724,6 +745,7 @@ defmodule Process do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec flag(pid, :save_calls, 0..10000) :: 0..10000
   defdelegate flag(pid, flag, value), to: :erlang, as: :process_flag
 
@@ -773,6 +795,7 @@ defmodule Process do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec hibernate(module, atom, list) :: no_return
   defdelegate hibernate(mod, fun_name, args), to: :erlang
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1456,6 +1456,7 @@ defmodule String do
       "abcabc"
 
   """
+  @doc inlined: true
   @spec duplicate(t, non_neg_integer) :: t
   def duplicate(subject, n) do
     :binary.copy(subject, n)
@@ -2156,6 +2157,7 @@ defmodule String do
       :my_atom
 
   """
+  @doc inlined: true
   @spec to_atom(String.t()) :: atom
   def to_atom(string) do
     :erlang.binary_to_atom(string, :utf8)
@@ -2178,6 +2180,7 @@ defmodule String do
       ** (ArgumentError) argument error
 
   """
+  @doc inlined: true
   @spec to_existing_atom(String.t()) :: atom
   def to_existing_atom(string) do
     :erlang.binary_to_existing_atom(string, :utf8)
@@ -2194,6 +2197,7 @@ defmodule String do
       123
 
   """
+  @doc inlined: true
   @spec to_integer(String.t()) :: integer
   def to_integer(string) do
     :erlang.binary_to_integer(string)
@@ -2210,6 +2214,7 @@ defmodule String do
       1023
 
   """
+  @doc inlined: true
   @spec to_integer(String.t(), 2..36) :: integer
   def to_integer(string, base) do
     :erlang.binary_to_integer(string, base)
@@ -2236,6 +2241,7 @@ defmodule String do
       #=> ** (ArgumentError) argument error
 
   """
+  @doc inlined: true
   @spec to_float(String.t()) :: float
   def to_float(string) do
     :erlang.binary_to_float(string)

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -692,6 +692,7 @@ defmodule System do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec monotonic_time() :: integer
   def monotonic_time do
     :erlang.monotonic_time()
@@ -717,6 +718,7 @@ defmodule System do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec system_time() :: integer
   def system_time do
     :erlang.system_time()
@@ -762,6 +764,7 @@ defmodule System do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec time_offset() :: integer
   def time_offset do
     :erlang.time_offset()
@@ -791,6 +794,7 @@ defmodule System do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec os_time() :: integer
   def os_time do
     :os.system_time()
@@ -854,6 +858,7 @@ defmodule System do
 
   Inlined by the compiler.
   """
+  @doc inlined: true
   @spec unique_integer([:positive | :monotonic]) :: integer
   def unique_integer(modifiers \\ []) do
     :erlang.unique_integer(modifiers)

--- a/lib/elixir/lib/tuple.ex
+++ b/lib/elixir/lib/tuple.ex
@@ -7,7 +7,7 @@ defmodule Tuple do
     * `elem/2` - access a tuple by index
     * `put_elem/3` - insert a value into a tuple by index
     * `tuple_size/3` - get the number of elements in a tuple
-    
+
   Tuples are intended as fixed-size containers for multiple elements.
   To manipulate a collection of elements, use a list instead. `Enum`
   functions do not work on tuples.
@@ -20,13 +20,13 @@ defmodule Tuple do
       {1, :two, "three"}
 
   A tuple may contain elements of different types, which are stored
-  contiguously in memory. Accessing any element takes constant time, 
-  but modifying a tuple, which produces a shallow copy, takes linear time. 
+  contiguously in memory. Accessing any element takes constant time,
+  but modifying a tuple, which produces a shallow copy, takes linear time.
   Tuples are good for reading data while lists are better for traversals.
 
   Tuples are typically used either when a function has multiple return values
-  or for error handling. `File.read/1` returns `{:ok, contents}` if reading 
-  the given file is successful, or else `{:error, reason}` such as when 
+  or for error handling. `File.read/1` returns `{:ok, contents}` if reading
+  the given file is successful, or else `{:error, reason}` such as when
   the file does not exist.
 
   The functions in this module that add and remove elements from tuples are
@@ -58,6 +58,7 @@ defmodule Tuple do
       {:hello, :hello, :hello}
 
   """
+  @doc inlined: true
   @spec duplicate(term, non_neg_integer) :: tuple
   def duplicate(data, size) do
     :erlang.make_tuple(size, data)
@@ -81,6 +82,7 @@ defmodule Tuple do
       {:bar, :baz, :bong}
 
   """
+  @doc inlined: true
   @spec insert_at(tuple, non_neg_integer, term) :: tuple
   def insert_at(tuple, index, value) do
     :erlang.insert_element(index + 1, tuple, value)
@@ -101,6 +103,7 @@ defmodule Tuple do
       {:foo, :bar, :baz}
 
   """
+  @doc inlined: true
   @spec append(tuple, term) :: tuple
   def append(tuple, value) do
     :erlang.append_element(tuple, value)
@@ -122,6 +125,7 @@ defmodule Tuple do
       {:bar, :baz}
 
   """
+  @doc inlined: true
   @spec delete_at(tuple, non_neg_integer) :: tuple
   def delete_at(tuple, index) do
     :erlang.delete_element(index + 1, tuple)
@@ -141,6 +145,7 @@ defmodule Tuple do
       [:foo, :bar, :baz]
 
   """
+  @doc inlined: true
   @spec to_list(tuple) :: list
   def to_list(tuple) do
     :erlang.tuple_to_list(tuple)

--- a/lib/elixir/test/elixir/kernel/docs_test.exs
+++ b/lib/elixir/test/elixir/kernel/docs_test.exs
@@ -168,7 +168,7 @@ defmodule Kernel.DocsTest do
           @macrocallback qux(any) :: any
 
           @doc "Function doc"
-          @doc since: "1.2.3", color: :red
+          @doc since: "1.2.3", color: :red, inlined: true
           @doc color: :blue, stable: true
           @deprecated "use baz/2 instead"
           def foo(arg \\ 0), do: arg + 1
@@ -248,6 +248,7 @@ defmodule Kernel.DocsTest do
                 deprecated: "use baz/2 instead",
                 color: :blue,
                 stable: true,
+                inlined: true,
                 defaults: 1
               }} = function_foo
 

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -377,7 +377,7 @@ defmodule IEx.HelpersTest do
       c_h = "* def c(files, path \\\\ :in_memory)\n\nCompiles the given files."
 
       eq_h =
-        "* def left == right\n\n  @spec term() == term() :: boolean()\n\nguard: true\n\nReturns `true` if the two items are equal.\n\n"
+        "* def left == right\n\n  @spec term() == term() :: boolean()\n\nguard: true\ninlined: true\n\nReturns `true` if the two items are equal.\n\n"
 
       def_h =
         "* defmacro def(call, expr \\\\ nil)\n\nDefines a function with the given name and body."


### PR DESCRIPTION
I've seen the documentation of some functions contains "Inlined by the compiler" and I thought it would be a nice addition to include that information in the `@doc` metadata.

I was going to ask first in the mailing list, but the changes were quite straightforward and I decided to give it a go :)