### PR TITLE
Minor update in Kernel's doc

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -140,7 +140,7 @@ defmodule Kernel do
     * [Typespecs](typespecs.html)- types and function specifications, including list of types
     * [Unicode Syntax](unicode-syntax.html) - outlines Elixir support for Unicode
     * [Writing Documentation](writing-documentation.html) - guidelines for writing
-      documentation in Elixir.
+      documentation in Elixir
 
   ## Guards
 


### PR DESCRIPTION
Looking at the documentation, final dots are not included when listing items.