### PR TITLE
Changelog: explain `mix test --failed` more accurately.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@ ExUnit has also seen its own share of improvements. Assertions such as `assert s
 
 Furthermore, failures in doctests are now colored and diffed.
 
-On the `mix test` side of things, there is a new `--failed` flag that runs all tests that failed in the previous run. Finally, coverage reports generated with `mix test --cover` include a summary out of the box:
+On the `mix test` side of things, there is a new `--failed` flag that runs all tests that failed the last time they ran. Finally, coverage reports generated with `mix test --cover` include a summary out of the box:
 
 ```
 Generating cover results ...


### PR DESCRIPTION
`mix test --failed` runs all tests that failed the last time they ran,
even if they were not included in the last run of the test suite. This
is important, because it means that you can run individual failed tests
to focus on fixing them without worrying about mix losing track of the
other failed tests.