### PR TITLE
Time zone behaviour and functionality (RFC/WIP)

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -544,8 +544,8 @@ defmodule DateTime do
           period.zone_abbr
         )
 
-      {:error, :time_zone_not_found} ->
-        {:error, :time_zone_not_found}
+      {:error, _} = error ->
+        error
     end
   end
 
@@ -587,6 +587,8 @@ defmodule DateTime do
       iex> {:ok, datetime} = DateTime.now("Europe/Copenhagen", FakeTimeZoneDatabase)
       iex> datetime.time_zone
       "Europe/Copenhagen"
+      iex> DateTime.now("not a real time zone name", FakeTimeZoneDatabase)
+      {:error, :time_zone_not_found}
 
   """
   @spec now(Calendar.time_zone(), TimeZoneDatabaseClient.tz_db_or_config()) ::

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -880,14 +880,14 @@ defmodule DateTime do
   [match_date, guard_date, read_date] = Calendar.ISO.__match_date__()
   [match_time, guard_time, read_time] = Calendar.ISO.__match_time__()
 
-  defp raw_from_iso8601(string, calendar, tz_db_or_config, is_negative_datetime) do
+  defp raw_from_iso8601(string, calendar, tz_db_or_config, is_year_negative) do
     with <<unquote(match_date), sep, unquote(match_time), rest::binary>> <- string,
          true <- unquote(guard_date) and sep in @sep and unquote(guard_time),
          {microsecond, rest} <- Calendar.ISO.parse_microsecond(rest),
          {offset, ""} <- Calendar.ISO.parse_offset(rest) do
       {year, month, day} = unquote(read_date)
       {hour, minute, second} = unquote(read_time)
-      year = if is_negative_datetime, do: -year, else: year
+      year = if is_year_negative, do: -year, else: year
 
       do_from_iso8601(
         year,

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -261,12 +261,10 @@ defmodule DateTime do
         # we get the last microsecond just before.
         before_naive =
           first_period.until_wall
-          |> NaiveDateTime.from_erl!({999_999, 6})
+          |> Map.put(:microsecond, {999_999, 6})
           |> NaiveDateTime.add(-1)
 
-        after_naive =
-          second_period.from_wall
-          |> NaiveDateTime.from_erl!()
+        after_naive = second_period.from_wall
 
         {:ok, latest_datetime_before} =
           do_from_naive(
@@ -1141,19 +1139,11 @@ defmodule DateTime do
              TimeZoneDatabase.light_time_zone_period()}
           | {:gap, TimeZoneDatabase.time_zone_period(), TimeZoneDatabase.time_zone_period()}
           | {:error, :time_zone_not_found}
-  defp by_wall(time_zone_database, time_zone, %{
-         calendar: Calendar.ISO,
-         year: year,
-         month: month,
-         day: day,
-         hour: hour,
-         minute: minute,
-         second: second
-       }) do
+  defp by_wall(time_zone_database, time_zone, %{calendar: Calendar.ISO} = naive_datetime) do
     time_zone_data_module = time_zone_data_module_from_parameter(time_zone_database)
 
     try do
-      time_zone_data_module.by_wall(time_zone, {{year, month, day}, {hour, minute, second}})
+      time_zone_data_module.by_wall(time_zone, naive_datetime)
     rescue
       UndefinedFunctionError ->
         raise @no_valid_time_zone_database_error
@@ -1165,19 +1155,11 @@ defmodule DateTime do
           Calendar.time_zone(),
           Calendar.naive_datetime()
         ) :: {:ok, TimeZoneDatabase.time_zone_period()} | {:error, :time_zone_not_found}
-  defp by_utc(time_zone_database, time_zone, %{
-         calendar: Calendar.ISO,
-         year: year,
-         month: month,
-         day: day,
-         hour: hour,
-         minute: minute,
-         second: second
-       }) do
+  defp by_utc(time_zone_database, time_zone, %{calendar: Calendar.ISO} = naive_datetime) do
     time_zone_data_module = time_zone_data_module_from_parameter(time_zone_database)
 
     try do
-      time_zone_data_module.by_utc(time_zone, {{year, month, day}, {hour, minute, second}})
+      time_zone_data_module.by_utc(time_zone, naive_datetime)
     rescue
       UndefinedFunctionError ->
         raise @no_valid_time_zone_database_error

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -282,16 +282,16 @@ defmodule DateTime do
 
         {:ambiguous, first_datetime, second_datetime}
 
-      {:gap, first_period, second_period} ->
+      {:gap, {first_period, first_period_until_wall}, {second_period, second_period_from_wall}} ->
         # `until_wall` is not valid, but any time just before is.
         # So by subtracting a second and adding .999999 seconds
         # we get the last microsecond just before.
         before_naive =
-          first_period.until_wall
+          first_period_until_wall
           |> Map.put(:microsecond, {999_999, 6})
           |> NaiveDateTime.add(-1)
 
-        after_naive = second_period.from_wall
+        after_naive = second_period_from_wall
 
         {:ok, latest_datetime_before} =
           do_from_naive(

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -220,7 +220,7 @@ defmodule DateTime do
           | {:gap, t, t}
           | {:error, :time_zone_not_found}
           | {:error, :incompatible_calendars}
-          | {:error, :invalid_time_zone_database}
+          | {:error, :no_time_zone_database}
 
   def from_naive(naive_datetime, time_zone, tz_db_or_config \\ :from_config)
 
@@ -824,11 +824,13 @@ defmodule DateTime do
       #DateTime<2015-06-30 23:59:60Z>
       iex> DateTime.from_iso8601("2018-07-01 01:59:60+02:00", Calendar.ISO, FakeTimeZoneDatabase)
       {:error, :invalid_leap_second}
+      iex> DateTime.from_iso8601("2090-07-01 01:59:60+02:00", Calendar.ISO, FakeTimeZoneDatabase)
+      {:error, :outside_leap_second_data_validity_range}
 
       # If a TimeZoneDatabase has not been set with TimeZoneDatabaseClient.set_database
       # and the second of the parsed datetime is 60
       iex> DateTime.from_iso8601("2018-07-01 01:59:60+02:00")
-      {:error, :invalid_time_zone_database}
+      {:error, :no_time_zone_database}
 
   """
   @doc since: "1.4.0"

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -23,6 +23,7 @@ defmodule Calendar.ISO do
   @type year :: -9999..9999
   @type month :: 1..12
   @type day :: 1..31
+  @type iso_seconds :: non_neg_integer()
 
   @seconds_per_minute 60
   @seconds_per_hour 60 * 60
@@ -830,12 +831,21 @@ defmodule Calendar.ISO do
     {12, day_of_year - (334 + extra_day)}
   end
 
-  defp iso_seconds_to_datetime(seconds) do
+  @doc false
+  @spec iso_seconds_to_datetime(iso_seconds) :: :calendar.datetime()
+  def iso_seconds_to_datetime(seconds) do
     {days, rest_seconds} = div_mod(seconds, @seconds_per_day)
 
     date = date_from_iso_days(days)
     time = seconds_to_time(rest_seconds)
     {date, time}
+  end
+
+  @doc false
+  @spec datetime_to_iso_seconds(:calendar.datetime()) :: iso_seconds
+  def datetime_to_iso_seconds({{year, month, day}, {hour, minute, second}}) do
+    date_to_iso_days(year, month, day) * @seconds_per_day + hour * @seconds_per_hour +
+      minute * @seconds_per_minute + second
   end
 
   defp seconds_to_time(seconds) when seconds in 0..(@seconds_per_day - 1) do

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -830,7 +830,7 @@ defmodule Calendar.ISO do
     {12, day_of_year - (334 + extra_day)}
   end
 
-  @spec iso_seconds_to_datetime(non_neg_integer) :: :calendar.datetime()
+  @spec iso_seconds_to_datetime(integer) :: :calendar.datetime()
   defp iso_seconds_to_datetime(seconds) do
     {days, rest_seconds} = div_mod(seconds, @seconds_per_day)
 

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -23,7 +23,6 @@ defmodule Calendar.ISO do
   @type year :: -9999..9999
   @type month :: 1..12
   @type day :: 1..31
-  @type iso_seconds :: non_neg_integer()
 
   @seconds_per_minute 60
   @seconds_per_hour 60 * 60
@@ -831,21 +830,13 @@ defmodule Calendar.ISO do
     {12, day_of_year - (334 + extra_day)}
   end
 
-  @doc false
-  @spec iso_seconds_to_datetime(iso_seconds) :: :calendar.datetime()
-  def iso_seconds_to_datetime(seconds) do
+  @spec iso_seconds_to_datetime(non_neg_integer) :: :calendar.datetime()
+  defp iso_seconds_to_datetime(seconds) do
     {days, rest_seconds} = div_mod(seconds, @seconds_per_day)
 
     date = date_from_iso_days(days)
     time = seconds_to_time(rest_seconds)
     {date, time}
-  end
-
-  @doc false
-  @spec datetime_to_iso_seconds(:calendar.datetime()) :: iso_seconds
-  def datetime_to_iso_seconds({{year, month, day}, {hour, minute, second}}) do
-    date_to_iso_days(year, month, day) * @seconds_per_day + hour * @seconds_per_hour +
-      minute * @seconds_per_minute + second
   end
 
   defp seconds_to_time(seconds) when seconds in 0..(@seconds_per_day - 1) do

--- a/lib/elixir/lib/calendar/time_zone_database.ex
+++ b/lib/elixir/lib/calendar/time_zone_database.ex
@@ -61,8 +61,8 @@ defmodule TimeZoneDatabase do
   """
   @callback by_wall(Calendar.time_zone(), Calendar.ISO.iso_seconds()) ::
               {:single, light_time_zone_period}
-              | {:ambiguous, [light_time_zone_period]}
-              | {:gap, [time_zone_period]}
+              | {:ambiguous, light_time_zone_period, light_time_zone_period}
+              | {:gap, time_zone_period, time_zone_period}
               | {:error, :time_zone_not_found}
 
   @doc """

--- a/lib/elixir/lib/calendar/time_zone_database.ex
+++ b/lib/elixir/lib/calendar/time_zone_database.ex
@@ -13,7 +13,7 @@ defmodule TimeZoneDatabase do
 
   `:min` basically means "since the beginning of time" and `:max` "until forever".
   """
-  @type time_zone_period_limit :: :calendar.datetime() | :min | :max
+  @type time_zone_period_limit :: Calendar.datetime() | :min | :max
 
   @typedoc """
   A period where a certain combination of UTC offset, standard offset and zone
@@ -46,7 +46,7 @@ defmodule TimeZoneDatabase do
   Takes a time zone name and a point in time for UTC and returns a
   `time_zone_period` for that point in time.
   """
-  @callback by_utc(Calendar.time_zone(), :calendar.datetime()) ::
+  @callback by_utc(Calendar.time_zone(), Calendar.naive_datetime()) ::
               {:ok, light_time_zone_period} | {:error, :time_zone_not_found}
 
   @doc """
@@ -60,7 +60,7 @@ defmodule TimeZoneDatabase do
   If there is only a single possible period for the provided `datetime`, the a tuple with `:single`
   and the `time_zone_period` is returned.
   """
-  @callback by_wall(Calendar.time_zone(), :calendar.datetime()) ::
+  @callback by_wall(Calendar.time_zone(), Calendar.naive_datetime()) ::
               {:single, light_time_zone_period}
               | {:ambiguous, light_time_zone_period, light_time_zone_period}
               | {:gap, time_zone_period, time_zone_period}
@@ -71,7 +71,7 @@ defmodule TimeZoneDatabase do
   with the first element being the UTC datetime for the leap second and the
   second element being the difference between TAI and UTC in seconds. (TAI-UTC)
   """
-  @callback leap_seconds() :: [{:calendar.datetime(), integer()}]
+  @callback leap_seconds() :: [{Calendar.naive_datetime(), integer()}]
 
   @doc """
   Returns a datetime tuple with the UTC datetime for when the leap second
@@ -81,5 +81,5 @@ defmodule TimeZoneDatabase do
   periodically announces if there will be any leap seconds for the next
   ~6 months.
   """
-  @callback leap_second_data_valid_until() :: :calendar.datetime()
+  @callback leap_second_data_valid_until() :: Calendar.naive_datetime()
 end

--- a/lib/elixir/lib/calendar/time_zone_database.ex
+++ b/lib/elixir/lib/calendar/time_zone_database.ex
@@ -68,6 +68,21 @@ defmodule TimeZoneDatabase do
 
   @callback is_leap_second(Calander.naive_datetime()) ::
               {:ok, boolean} | {:error, :outside_leap_second_data_range}
+
+  @doc """
+  Takes two `Calendar.naive_datetime`s. They should represent UTC datetimes.
+
+  Returns the leap difference in seconds between them. For instance when passed
+  ~N[2018-01-01 00:00:00] and ~N[2014-01-01 00:00:00] it should return {:ok, 2}
+  representing two leap seconds.
+
+  The leap second system was not introduced until 1972. When passed a datetime
+  from before 1972 {:error, :pre_1972_leap_seconds_not_supported} should be returned.
+  """
+  @callback leap_second_diff(Calendar.naive_datetime(), Calendar.naive_datetime()) ::
+              {:ok, integer}
+              | {:error, :pre_1972_leap_seconds_not_supported}
+              | {:error, :outside_leap_second_data_range}
 end
 
 defmodule TimeZoneDatabaseClient do
@@ -126,6 +141,17 @@ defmodule TimeZoneDatabaseClient do
   def is_leap_second(naive_datetime, tz_db_or_config) do
     with {:ok, time_zone_database} <- time_zone_database_from_parameter(tz_db_or_config) do
       time_zone_database.is_leap_second(naive_datetime)
+    end
+  end
+
+  @spec leap_second_diff(Calendar.naive_datetime(), Calendar.naive_datetime(), tz_db_or_config) ::
+          {:ok, boolean}
+          | {:error, :no_time_zone_database}
+          | {:error, :pre_1972_leap_seconds_not_supported}
+          | {:error, :outside_leap_second_data_range}
+  def leap_second_diff(datetime1, datetime2, tz_db_or_config) do
+    with {:ok, time_zone_database} <- time_zone_database_from_parameter(tz_db_or_config) do
+      time_zone_database.leap_second_diff(datetime1, datetime2)
     end
   end
 

--- a/lib/elixir/lib/calendar/time_zone_database.ex
+++ b/lib/elixir/lib/calendar/time_zone_database.ex
@@ -7,17 +7,12 @@ defmodule TimeZoneDatabase do
   """
 
   @typedoc """
-  Limit for when a certain time zone period begins and ends.
-
-  It can either be a `Calendar.naive_datetime` or `:min` or `:max`.
-
-  `:min` basically means "since the beginning of time" and `:max` "until forever".
-  """
-  @type time_zone_period_limit :: Calendar.naive_datetime() | :min | :max
-
-  @typedoc """
   A period where a certain combination of UTC offset, standard offset and zone
   abbreviation is in effect.
+
+  For instance one period could be the summer of 2018 in "Europe/London" where summer time /
+  daylight saving time is in effect and lasts from spring to autumn. At autumn the `std_offset`
+  changes along with the `zone_abbr` so a different period is needed during winter.
   """
   @type time_zone_period :: %{
           optional(any) => any,
@@ -27,22 +22,19 @@ defmodule TimeZoneDatabase do
         }
 
   @typedoc """
-  Like `time_zone_period`, but with two added fields indicating when the period
-  begins and ends. In wall time. The fields are `from_wall` and `until_wall`.
+  Limit for when a certain time zone period begins or ends.
 
-  `from_wall` is inclusive. `until_wall` is exclusive. Eg. if a period is from
+  A beginning is inclusive. An ending is exclusive. Eg. if a period is from
   2015-03-29 01:00:00 and until 2015-10-25 01:00:00, the period includes and
   begins from the begining of 2015-03-29 01:00:00 and lasts until just before
   2015-10-25 01:00:00.
+
+  A beginning or end for certain periods are infinite. For instance the latest
+  period for time zones without DST or plans to change. However for the purpose
+  of this behaviour they are only used for gaps in wall time where the needed
+  period limits are at a certain time.
   """
-  @type time_zone_period_with_wall_limits :: %{
-          optional(any) => any,
-          utc_offset: Calendar.utc_offset(),
-          std_offset: Calendar.std_offset(),
-          zone_abbr: Calendar.zone_abbr(),
-          from_wall: time_zone_period_limit(),
-          until_wall: time_zone_period_limit()
-        }
+  @type time_zone_period_limit :: Calendar.naive_datetime()
 
   @doc """
   Takes a time zone name and a point in time for UTC and returns a
@@ -52,12 +44,16 @@ defmodule TimeZoneDatabase do
               {:ok, time_zone_period} | {:error, :time_zone_not_found}
 
   @doc """
-  When the provided `datetime` is ambiguous a tuple with `:ambiguous` and a list of two possible
+  Possible time zone periods for a certain time zone and wall clock date and time.
+
+  When the provided `datetime` is ambiguous a tuple with `:ambiguous` and two possible
   periods. The periods in the list are sorted with the first element being the one that begins first.
 
   When the provided `datetime` is in a gap - for instance during the "spring forward" when going
-  from winter time to summer time, a tuple with `:gap` and a list of two time zone periods are returned. The first
-  period in the list is the period before the gap and the second period is the period just after the gap.
+  from winter time to summer time, a tuple with `:gap` and two periods with limits are returned
+  in a nested tuple. The first nested two-tuple is the period before the gap and a naive datetime
+  with a limit for when the period ends (wall time). The second nested two-tuple is the period
+  just after the gap and a datetime (wall time) for when the period begins just after the gap.
 
   If there is only a single possible period for the provided `datetime`, the a tuple with `:single`
   and the `time_zone_period` is returned.
@@ -65,7 +61,8 @@ defmodule TimeZoneDatabase do
   @callback time_zone_periods_from_wall_datetime(Calendar.naive_datetime(), Calendar.time_zone()) ::
               {:single, time_zone_period}
               | {:ambiguous, time_zone_period, time_zone_period}
-              | {:gap, time_zone_period_with_wall_limits, time_zone_period_with_wall_limits}
+              | {:gap, {time_zone_period, time_zone_period_limit},
+                 {time_zone_period, time_zone_period_limit}}
               | {:error, :time_zone_not_found}
 
   @doc """
@@ -124,8 +121,9 @@ defmodule TimeZoneDatabaseClient do
         ) ::
           {:single, TimeZoneDatabase.time_zone_period()}
           | {:ambiguous, TimeZoneDatabase.time_zone_period(), TimeZoneDatabase.time_zone_period()}
-          | {:gap, TimeZoneDatabase.time_zone_period_with_wall_limits(),
-             TimeZoneDatabase.time_zone_period_with_wall_limits()}
+          | {:gap,
+             {TimeZoneDatabase.time_zone_period(), TimeZoneDatabase.time_zone_period_limit()},
+             {TimeZoneDatabase.time_zone_period(), TimeZoneDatabase.time_zone_period_limit()}}
           | {:error, :time_zone_not_found}
           | {:error, :no_time_zone_database}
   def time_zone_periods_from_wall_datetime(

--- a/lib/elixir/lib/calendar/time_zone_database.ex
+++ b/lib/elixir/lib/calendar/time_zone_database.ex
@@ -46,7 +46,7 @@ defmodule TimeZoneDatabase do
   Takes a time zone name and a point in time for UTC and returns a
   `time_zone_period` for that point in time.
   """
-  @callback by_utc(Calendar.naive_datetime(), Calendar.time_zone()) ::
+  @callback time_zone_period_from_utc_iso_days(Calendar.iso_days(), Calendar.time_zone()) ::
               {:ok, time_zone_period} | {:error, :time_zone_not_found}
 
   @doc """
@@ -60,7 +60,7 @@ defmodule TimeZoneDatabase do
   If there is only a single possible period for the provided `datetime`, the a tuple with `:single`
   and the `time_zone_period` is returned.
   """
-  @callback by_wall(Calendar.naive_datetime(), Calendar.time_zone()) ::
+  @callback time_zone_periods_from_wall_datetime(Calendar.naive_datetime(), Calendar.time_zone()) ::
               {:single, time_zone_period}
               | {:ambiguous, time_zone_period, time_zone_period}
               | {:gap, time_zone_period_with_wall_limits, time_zone_period_with_wall_limits}
@@ -115,7 +115,7 @@ defmodule TimeZoneDatabaseClient do
   end
 
   @doc false
-  @spec by_wall(
+  @spec time_zone_periods_from_wall_datetime(
           Calendar.naive_datetime(),
           Calendar.time_zone(),
           tz_db_or_config
@@ -126,24 +126,32 @@ defmodule TimeZoneDatabaseClient do
              TimeZoneDatabase.time_zone_period_with_wall_limits()}
           | {:error, :time_zone_not_found}
           | {:error, :no_time_zone_database}
-  def by_wall(%{calendar: Calendar.ISO} = naive_datetime, time_zone, tz_db_or_config) do
+  def time_zone_periods_from_wall_datetime(
+        %{calendar: Calendar.ISO} = naive_datetime,
+        time_zone,
+        tz_db_or_config
+      ) do
     with {:ok, time_zone_database} <- time_zone_database_from_tz_db_or_config(tz_db_or_config) do
-      time_zone_database.by_wall(naive_datetime, time_zone)
+      time_zone_database.time_zone_periods_from_wall_datetime(naive_datetime, time_zone)
     end
   end
 
   @doc false
-  @spec by_utc(
-          Calendar.naive_datetime(),
+  @spec time_zone_period_from_utc_iso_days(
+          Calendar.iso_days(),
           Calendar.time_zone(),
           tz_db_or_config
         ) ::
           {:ok, TimeZoneDatabase.time_zone_period()}
           | {:error, :time_zone_not_found}
           | {:error, :no_time_zone_database}
-  def by_utc(%{calendar: Calendar.ISO} = naive_datetime, time_zone, tz_db_or_config) do
+  def time_zone_period_from_utc_iso_days(
+        iso_days,
+        time_zone,
+        tz_db_or_config
+      ) do
     with {:ok, time_zone_database} <- time_zone_database_from_tz_db_or_config(tz_db_or_config) do
-      time_zone_database.by_utc(naive_datetime, time_zone)
+      time_zone_database.time_zone_period_from_utc_iso_days(iso_days, time_zone)
     end
   end
 

--- a/lib/elixir/lib/calendar/time_zone_database.ex
+++ b/lib/elixir/lib/calendar/time_zone_database.ex
@@ -9,27 +9,28 @@ defmodule TimeZoneDatabase do
   @typedoc """
   Limit for when a certain time zone period begins and ends.
 
-  It can either be an integer representing ISO seconds or `:min` or `:max`.
+  It can either be an Erlang-style datetime tuple or `:min` or `:max`.
 
   `:min` basically means "since the beginning of time" and `:max` "until forever".
   """
-  @type time_zone_period_limit :: Calendar.ISO.iso_seconds() | :min | :max
+  @type time_zone_period_limit :: :calendar.datetime() | :min | :max
 
   @typedoc """
   A period where a certain combination of UTC offset, standard offset and zone
   abbreviation is in effect.
 
   `from_utc` and `from_wall` is inclusive while `until_utc` and `until_wall` is
-  exclusive. Eg. if a period from 63594810000 and until 63612954000, the period
-  includes and begins from the begining of second 63594810000 and lasts until
-  just before second 63612954000.
+  exclusive. Eg. if a period from {{2015, 3, 29}, {1, 0, 0}} and until
+  {{2015, 10, 25}, {1, 0, 0}}, the period includes and begins from the begining
+  of {{2015, 3, 29}, {1, 0, 0}} and lasts until just before
+  {{2015, 10, 25}, {1, 0, 0}}.
   """
   @type time_zone_period :: %{
           utc_offset: Calendar.utc_offset(),
           std_offset: Calendar.std_offset(),
           zone_abbr: Calendar.zone_abbr(),
-          from_wall: time_zone_period_limit,
-          until_wall: time_zone_period_limit
+          from_wall: time_zone_period_limit(),
+          until_wall: time_zone_period_limit()
         }
 
   @typedoc """
@@ -45,21 +46,21 @@ defmodule TimeZoneDatabase do
   Takes a time zone name and a point in time for UTC and returns a
   `time_zone_period` for that point in time.
   """
-  @callback by_utc(Calendar.time_zone(), Calendar.ISO.iso_seconds()) ::
+  @callback by_utc(Calendar.time_zone(), :calendar.datetime()) ::
               {:ok, light_time_zone_period} | {:error, :time_zone_not_found}
 
   @doc """
-  When the provided `iso_seconds` is ambiguous for the datetime a tuple with `:ambiguous` and a list of two possible
+  When the provided `datetime` is ambiguous a tuple with `:ambiguous` and a list of two possible
   periods. The periods in the list are sorted with the first element being the one that begins first.
 
-  When the provided `iso_seconds` datetime is in a gap - for instance during the "spring forward" when going
+  When the provided `datetime` is in a gap - for instance during the "spring forward" when going
   from winter time to summer time, a tuple with `:gap` and a list of two time zone periods are returned. The first
   period in the list is the period before the gap and the second period is the period just after the gap.
 
-  If there is only a single possible period for the provided `iso_seconds`, the a tuple with `:single`
+  If there is only a single possible period for the provided `datetime`, the a tuple with `:single`
   and the `time_zone_period` is returned.
   """
-  @callback by_wall(Calendar.time_zone(), Calendar.ISO.iso_seconds()) ::
+  @callback by_wall(Calendar.time_zone(), :calendar.datetime()) ::
               {:single, light_time_zone_period}
               | {:ambiguous, light_time_zone_period, light_time_zone_period}
               | {:gap, time_zone_period, time_zone_period}

--- a/lib/elixir/lib/calendar/time_zone_database.ex
+++ b/lib/elixir/lib/calendar/time_zone_database.ex
@@ -86,13 +86,9 @@ defmodule TimeZoneDatabase do
   Returns the difference in leap seconds between them. For instance when passed
   `~N[2018-01-01 00:00:00]` and `~N[2014-01-01 00:00:00]` it should return `{:ok, 2}`
   representing two leap seconds.
-
-  The leap second system was not introduced until 1972. When passed a datetime
-  from before 1972 `{:error, :pre_1972_leap_seconds_not_supported}` should be returned.
   """
   @callback leap_second_diff(Calendar.naive_datetime(), Calendar.naive_datetime()) ::
               {:ok, integer}
-              | {:error, :pre_1972_leap_seconds_not_supported}
               | {:error, :outside_leap_second_data_range}
 end
 
@@ -166,7 +162,6 @@ defmodule TimeZoneDatabaseClient do
   @spec leap_second_diff(Calendar.naive_datetime(), Calendar.naive_datetime(), tz_db_or_config) ::
           {:ok, boolean}
           | {:error, :no_time_zone_database}
-          | {:error, :pre_1972_leap_seconds_not_supported}
           | {:error, :outside_leap_second_data_range}
   def leap_second_diff(datetime1, datetime2, tz_db_or_config) do
     with {:ok, time_zone_database} <- time_zone_database_from_tz_db_or_config(tz_db_or_config) do

--- a/lib/elixir/lib/calendar/time_zone_database.ex
+++ b/lib/elixir/lib/calendar/time_zone_database.ex
@@ -20,6 +20,7 @@ defmodule TimeZoneDatabase do
   abbreviation is in effect.
   """
   @type time_zone_period :: %{
+          optional(any) => any,
           utc_offset: Calendar.utc_offset(),
           std_offset: Calendar.std_offset(),
           zone_abbr: Calendar.zone_abbr()
@@ -35,6 +36,7 @@ defmodule TimeZoneDatabase do
   2015-10-25 01:00:00.
   """
   @type time_zone_period_with_wall_limits :: %{
+          optional(any) => any,
           utc_offset: Calendar.utc_offset(),
           std_offset: Calendar.std_offset(),
           zone_abbr: Calendar.zone_abbr(),

--- a/lib/elixir/lib/calendar/time_zone_database.ex
+++ b/lib/elixir/lib/calendar/time_zone_database.ex
@@ -37,6 +37,8 @@ defmodule TimeZoneDatabase do
   @type time_zone_period_limit :: Calendar.naive_datetime()
 
   @doc """
+  Time zone period for a point in time in UTC for a specific time zone.
+
   Takes a time zone name and a point in time for UTC and returns a
   `time_zone_period` for that point in time.
   """
@@ -66,6 +68,8 @@ defmodule TimeZoneDatabase do
               | {:error, :time_zone_not_found}
 
   @doc """
+  Determine if a datetime is a leap second or not.
+
   Takes a `Calendar.naive_datetime` and returns {:ok, true} if it is a
   leap second. {:ok, false} if it is not.
 
@@ -80,6 +84,8 @@ defmodule TimeZoneDatabase do
               {:ok, boolean} | {:error, :outside_leap_second_data_range}
 
   @doc """
+  The difference in seconds between two datetimes.
+
   Takes two `Calendar.naive_datetime`s. They should represent UTC datetimes.
 
   Returns the difference in leap seconds between them. For instance when passed
@@ -97,7 +103,7 @@ defmodule TimeZoneDatabaseClient do
   """
 
   @typedoc """
-  Either a `TimeZoneDatabase.t()` or a `:from_config` atom.
+  Returns either a `TimeZoneDatabase.t()` or a `:from_config` atom.
 
   This can be passed to functions in e.g. the `DateTime` module. If `:from_config`
   is passed, a `TimeZoneDatabase` set via the `set_database/1` function is used.

--- a/lib/elixir/lib/calendar/time_zone_database.ex
+++ b/lib/elixir/lib/calendar/time_zone_database.ex
@@ -1,0 +1,92 @@
+defmodule TimeZoneDatabase do
+  @moduledoc """
+  This module defines a behaviour for providing time zone data.
+
+  IANA provides time zone data that includes data about different UTC offsets,
+  standard offsets for timezones as well as leap second data.
+  """
+
+  @typedoc """
+  Gregorian seconds is the number of second from January 1st year 0 until the
+  specified date and time. Leap seconds are not included. Same as in the Erlang
+  calendar module. Unlike a unix timestamp, it is not limited to UTC.
+
+  The Erlang calendar module has functions for converting between gregorian
+  seconds and datetime tuples:
+
+      iex> :calendar.datetime_to_gregorian_seconds({{2017, 8, 13}, {23, 2, 58}})
+      63669884578
+      iex> :calendar.gregorian_seconds_to_datetime(63669884578)
+      {{2017, 8, 13}, {23, 2, 58}}
+  """
+  @type gregorian_seconds :: non_neg_integer()
+
+  @typedoc """
+  Limit for when a certain time zone period begins and ends.
+
+  It can either be an integer representing gregorian seconds or `:min` or `:max`.
+
+  `:min` basically means "since the beginning of time" and `:max` "until forever".
+  """
+  @type time_zone_period_limit :: gregorian_seconds() | :min | :max
+
+  @typedoc """
+  A period where a certain combination of UTC offset, standard offset and zone
+  abbreviation is in effect.
+
+  `from_utc` and `from_wall` is inclusive while `until_utc` and `until_wall` is
+  exclusive. Eg. if a period from 63594810000 and until 63612954000, the period
+  includes and begins from the begining of second 63594810000 and lasts until
+  just before second 63612954000.
+  """
+  @type time_zone_period :: %{
+          utc_offset: Calendar.utc_offset(),
+          std_offset: Calendar.std_offset(),
+          zone_abbr: Calendar.zone_abbr(),
+          from_utc: time_zone_period_limit,
+          from_wall: time_zone_period_limit,
+          until_utc: time_zone_period_limit,
+          until_wall: time_zone_period_limit
+        }
+
+  @doc """
+  Takes a time zone name and a point in time for UTC and returns a
+  `time_zone_period` for that point in time.
+  """
+  @callback by_utc(Calendar.time_zone(), gregorian_seconds) ::
+              {:ok, time_zone_period} | {:error, :time_zone_not_found}
+
+  @doc """
+  When the provided `gregorian_seconds` is ambiguous for the datetime a tuple with `:ambiguous` and a list of two possible
+  periods. The periods in the list are sorted with the first element being the one that begins first.
+
+  When the provided `gregorian_seconds` datetime is in a gap - for instance during the "spring forward" when going
+  from winter time to summer time, a tuple with `:gap` and a list of two time zone periods are returned. The first
+  period in the list is the period before the gap and the second period is the period just after the gap.
+
+  If there is only a single possible period for the provided `gregorian_seconds`, the a tuple with `:single`
+  and the `time_zone_period` is returned.
+  """
+  @callback by_wall(Calendar.time_zone(), gregorian_seconds) ::
+              {:single, time_zone_period}
+              | {:ambiguous, [time_zone_period]}
+              | {:gap, [time_zone_period]}
+              | {:error, :time_zone_not_found}
+
+  @doc """
+  Returns a list of all known leap seconds. Each element in the list is a tuple
+  with the first element being the UTC datetime for the leap second and the
+  second element being the difference between TAI and UTC in seconds. (TAI-UTC)
+  """
+  @callback leap_seconds() :: [{:calendar.datetime(), integer()}]
+
+  @doc """
+  Returns a datetime tuple with the UTC datetime for when the leap second
+  data returned by `leap_seconds/0` is valid until.
+
+  International Earth Rotation and Reference Systems Service (IERS)
+  periodically announces if there will be any leap seconds for the next
+  ~6 months.
+  """
+  @callback leap_second_data_valid_until() :: :calendar.datetime()
+end

--- a/lib/elixir/lib/calendar/time_zone_database.ex
+++ b/lib/elixir/lib/calendar/time_zone_database.ex
@@ -67,7 +67,7 @@ defmodule TimeZoneDatabase do
               | {:error, :time_zone_not_found}
 
   @callback is_leap_second(Calander.naive_datetime()) ::
-              {:ok, boolean} | {:error, :outside_leap_second_data_validity_range}
+              {:ok, boolean} | {:error, :outside_leap_second_data_range}
 end
 
 defmodule TimeZoneDatabaseClient do
@@ -121,7 +121,7 @@ defmodule TimeZoneDatabaseClient do
 
   @spec is_leap_second(Calendar.naive_datetime(), tz_db_or_config) ::
           {:ok, boolean}
-          | {:error, :outside_leap_second_data_validity_range}
+          | {:error, :outside_leap_second_data_range}
           | {:error, :no_time_zone_database}
   def is_leap_second(naive_datetime, tz_db_or_config) do
     with {:ok, time_zone_database} <- time_zone_database_from_parameter(tz_db_or_config) do

--- a/lib/elixir/lib/calendar/time_zone_database.ex
+++ b/lib/elixir/lib/calendar/time_zone_database.ex
@@ -46,7 +46,7 @@ defmodule TimeZoneDatabase do
   Takes a time zone name and a point in time for UTC and returns a
   `time_zone_period` for that point in time.
   """
-  @callback by_utc(Calendar.time_zone(), Calendar.naive_datetime()) ::
+  @callback by_utc(Calendar.naive_datetime(), Calendar.time_zone()) ::
               {:ok, light_time_zone_period} | {:error, :time_zone_not_found}
 
   @doc """
@@ -60,7 +60,7 @@ defmodule TimeZoneDatabase do
   If there is only a single possible period for the provided `datetime`, the a tuple with `:single`
   and the `time_zone_period` is returned.
   """
-  @callback by_wall(Calendar.time_zone(), Calendar.naive_datetime()) ::
+  @callback by_wall(Calendar.naive_datetime(), Calendar.time_zone()) ::
               {:single, light_time_zone_period}
               | {:ambiguous, light_time_zone_period, light_time_zone_period}
               | {:gap, time_zone_period, time_zone_period}
@@ -110,7 +110,7 @@ defmodule TimeZoneDatabaseClient do
     time_zone_data_module = time_zone_data_module_from_parameter(time_zone_database)
 
     try do
-      time_zone_data_module.by_wall(time_zone, naive_datetime)
+      time_zone_data_module.by_wall(naive_datetime, time_zone)
     rescue
       UndefinedFunctionError ->
         raise @no_valid_time_zone_database_error
@@ -127,7 +127,7 @@ defmodule TimeZoneDatabaseClient do
     time_zone_data_module = time_zone_data_module_from_parameter(time_zone_database)
 
     try do
-      time_zone_data_module.by_utc(time_zone, naive_datetime)
+      time_zone_data_module.by_utc(naive_datetime, time_zone)
     rescue
       UndefinedFunctionError ->
         raise @no_valid_time_zone_database_error

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -1,5 +1,6 @@
 Code.require_file("test_helper.exs", __DIR__)
 Code.require_file("fixtures/calendar/holocene.exs", __DIR__)
+Code.require_file("fixtures/calendar/fake_time_zone_database.exs", __DIR__)
 
 defmodule FakeCalendar do
   def date_to_string(_, _, _), do: "boom"
@@ -7,128 +8,6 @@ defmodule FakeCalendar do
   def naive_datetime_to_string(_, _, _, _, _, _, _), do: "boom"
   def datetime_to_string(_, _, _, _, _, _, _, _, _, _), do: "boom"
   def day_rollover_relative_to_midnight_utc, do: {123_456, 123_457}
-end
-
-defmodule FakeTimeZoneDatabase do
-  @behaviour TimeZoneDatabase
-
-  @time_zone_period_cph_summer_2018 %{
-    from_wall: 63_689_166_000,
-    std_offset: 3600,
-    until_wall: 63_707_914_800,
-    utc_offset: 3600,
-    zone_abbr: "CEST"
-  }
-
-  @time_zone_period_cph_winter_2018_2019 %{
-    from_wall: 63_707_911_200,
-    std_offset: 0,
-    until_wall: 63_721_216_800,
-    utc_offset: 3600,
-    zone_abbr: "CET"
-  }
-
-  @time_zone_period_cph_summer_2019 %{
-    from_wall: 63_721_220_400,
-    std_offset: 3600,
-    until_wall: 63_739_364_400,
-    utc_offset: 3600,
-    zone_abbr: "CEST"
-  }
-
-  def by_utc("Europe/Copenhagen", gregorian_seconds)
-      when gregorian_seconds >= 63_689_158_800 and gregorian_seconds < 63_707_914_800 do
-    {:ok, @time_zone_period_cph_summer_2018 |> full_period_to_light}
-  end
-
-  def by_utc("Europe/Copenhagen", gregorian_seconds)
-      when gregorian_seconds >= 63_689_158_800 and gregorian_seconds < 63_707_907_600 do
-    {:ok, @time_zone_period_cph_winter_2018_2019 |> full_period_to_light}
-  end
-
-  def by_utc("America/Los_Angeles", gregorian_seconds)
-      when gregorian_seconds >= 63_687_981_600 and gregorian_seconds < 63_708_541_200 do
-    {:ok,
-     %{
-       std_offset: 3600,
-       utc_offset: -28800,
-       zone_abbr: "PDT"
-     }}
-  end
-
-  def by_wall("Europe/Copenhagen", gregorian_seconds)
-      when gregorian_seconds >= 63_721_216_800 and gregorian_seconds < 63_721_220_400 do
-    {:gap, [@time_zone_period_cph_winter_2018_2019, @time_zone_period_cph_summer_2019]}
-  end
-
-  def by_wall("Europe/Copenhagen", gregorian_seconds)
-      when gregorian_seconds < 63_707_914_800 and gregorian_seconds >= 63_707_911_200 do
-    {:ambiguous,
-     [
-       @time_zone_period_cph_summer_2018 |> full_period_to_light,
-       @time_zone_period_cph_winter_2018_2019 |> full_period_to_light
-     ]}
-  end
-
-  def by_wall("Europe/Copenhagen", gregorian_seconds)
-      when gregorian_seconds >= 63_689_166_000 and gregorian_seconds < 63_707_914_800 do
-    {:single, @time_zone_period_cph_summer_2018 |> full_period_to_light}
-  end
-
-  def by_wall("Europe/Copenhagen", gregorian_seconds)
-      when gregorian_seconds >= 63_707_911_200 and gregorian_seconds < 63_721_216_800 do
-    {:single, @time_zone_period_cph_winter_2018_2019 |> full_period_to_light}
-  end
-
-  def by_wall("Europe/Copenhagen", gregorian_seconds)
-      when gregorian_seconds >= 63_721_220_400 and gregorian_seconds < 63_739_364_400 do
-    {:single, @time_zone_period_cph_summer_2019 |> full_period_to_light}
-  end
-
-  def by_wall(time_zone, _) when time_zone != "Europe/Copenhagen" do
-    {:error, :time_zone_not_found}
-  end
-
-  def leap_seconds do
-    [
-      {{{1971, 12, 31}, {23, 59, 60}}, 10},
-      {{{1972, 6, 30}, {23, 59, 60}}, 11},
-      {{{1972, 12, 31}, {23, 59, 60}}, 12},
-      {{{1973, 12, 31}, {23, 59, 60}}, 13},
-      {{{1974, 12, 31}, {23, 59, 60}}, 14},
-      {{{1975, 12, 31}, {23, 59, 60}}, 15},
-      {{{1976, 12, 31}, {23, 59, 60}}, 16},
-      {{{1977, 12, 31}, {23, 59, 60}}, 17},
-      {{{1978, 12, 31}, {23, 59, 60}}, 18},
-      {{{1979, 12, 31}, {23, 59, 60}}, 19},
-      {{{1981, 6, 30}, {23, 59, 60}}, 20},
-      {{{1982, 6, 30}, {23, 59, 60}}, 21},
-      {{{1983, 6, 30}, {23, 59, 60}}, 22},
-      {{{1985, 6, 30}, {23, 59, 60}}, 23},
-      {{{1987, 12, 31}, {23, 59, 60}}, 24},
-      {{{1989, 12, 31}, {23, 59, 60}}, 25},
-      {{{1990, 12, 31}, {23, 59, 60}}, 26},
-      {{{1992, 6, 30}, {23, 59, 60}}, 27},
-      {{{1993, 6, 30}, {23, 59, 60}}, 28},
-      {{{1994, 6, 30}, {23, 59, 60}}, 29},
-      {{{1995, 12, 31}, {23, 59, 60}}, 30},
-      {{{1997, 6, 30}, {23, 59, 60}}, 31},
-      {{{1998, 12, 31}, {23, 59, 60}}, 32},
-      {{{2005, 12, 31}, {23, 59, 60}}, 33},
-      {{{2008, 12, 31}, {23, 59, 60}}, 34},
-      {{{2012, 6, 30}, {23, 59, 60}}, 35},
-      {{{2015, 6, 30}, {23, 59, 60}}, 36},
-      {{{2016, 12, 31}, {23, 59, 60}}, 37}
-    ]
-  end
-
-  def leap_second_data_valid_until do
-    {{2018, 12, 28}, {0, 0, 0}}
-  end
-
-  defp full_period_to_light(full_period) do
-    Map.drop(full_period, [:from_wall, :until_wall])
-  end
 end
 
 defmodule DateTest do

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -13,30 +13,24 @@ defmodule FakeTimeZoneDatabase do
   @behaviour TimeZoneDatabase
 
   @time_zone_period_cph_summer_2018 %{
-    from_utc: 63_689_158_800,
     from_wall: 63_689_166_000,
     std_offset: 3600,
-    until_utc: 63_707_907_600,
     until_wall: 63_707_914_800,
     utc_offset: 3600,
     zone_abbr: "CEST"
   }
 
   @time_zone_period_cph_winter_2018_2019 %{
-    from_utc: 63_707_907_600,
     from_wall: 63_707_911_200,
     std_offset: 0,
-    until_utc: 63_721_213_200,
     until_wall: 63_721_216_800,
     utc_offset: 3600,
     zone_abbr: "CET"
   }
 
   @time_zone_period_cph_summer_2019 %{
-    from_utc: 63_721_213_200,
     from_wall: 63_721_220_400,
     std_offset: 3600,
-    until_utc: 63_739_357_200,
     until_wall: 63_739_364_400,
     utc_offset: 3600,
     zone_abbr: "CEST"
@@ -44,23 +38,19 @@ defmodule FakeTimeZoneDatabase do
 
   def by_utc("Europe/Copenhagen", gregorian_seconds)
       when gregorian_seconds >= 63_689_158_800 and gregorian_seconds < 63_707_914_800 do
-    {:ok, @time_zone_period_cph_summer_2018}
+    {:ok, @time_zone_period_cph_summer_2018 |> full_period_to_light}
   end
 
   def by_utc("Europe/Copenhagen", gregorian_seconds)
       when gregorian_seconds >= 63_689_158_800 and gregorian_seconds < 63_707_907_600 do
-    {:ok, @time_zone_period_cph_winter_2018_2019}
+    {:ok, @time_zone_period_cph_winter_2018_2019 |> full_period_to_light}
   end
 
   def by_utc("America/Los_Angeles", gregorian_seconds)
       when gregorian_seconds >= 63_687_981_600 and gregorian_seconds < 63_708_541_200 do
     {:ok,
      %{
-       from_utc: 63_687_981_600,
-       from_wall: 63_687_956_400,
        std_offset: 3600,
-       until_utc: 63_708_541_200,
-       until_wall: 63_708_516_000,
        utc_offset: -28800,
        zone_abbr: "PDT"
      }}
@@ -75,24 +65,24 @@ defmodule FakeTimeZoneDatabase do
       when gregorian_seconds < 63_707_914_800 and gregorian_seconds >= 63_707_911_200 do
     {:ambiguous,
      [
-       @time_zone_period_cph_summer_2018,
-       @time_zone_period_cph_winter_2018_2019
+       @time_zone_period_cph_summer_2018 |> full_period_to_light,
+       @time_zone_period_cph_winter_2018_2019 |> full_period_to_light
      ]}
   end
 
   def by_wall("Europe/Copenhagen", gregorian_seconds)
       when gregorian_seconds >= 63_689_166_000 and gregorian_seconds < 63_707_914_800 do
-    {:single, @time_zone_period_cph_summer_2018}
+    {:single, @time_zone_period_cph_summer_2018 |> full_period_to_light}
   end
 
   def by_wall("Europe/Copenhagen", gregorian_seconds)
       when gregorian_seconds >= 63_707_911_200 and gregorian_seconds < 63_721_216_800 do
-    {:single, @time_zone_period_cph_winter_2018_2019}
+    {:single, @time_zone_period_cph_winter_2018_2019 |> full_period_to_light}
   end
 
   def by_wall("Europe/Copenhagen", gregorian_seconds)
       when gregorian_seconds >= 63_721_220_400 and gregorian_seconds < 63_739_364_400 do
-    {:single, @time_zone_period_cph_summer_2019}
+    {:single, @time_zone_period_cph_summer_2019 |> full_period_to_light}
   end
 
   def by_wall(time_zone, _) when time_zone != "Europe/Copenhagen" do
@@ -134,6 +124,10 @@ defmodule FakeTimeZoneDatabase do
 
   def leap_second_data_valid_until do
     {{2018, 12, 28}, {0, 0, 0}}
+  end
+
+  defp full_period_to_light(full_period) do
+    Map.drop(full_period, [:from_wall, :until_wall])
   end
 end
 

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -959,8 +959,23 @@ defmodule DateTimeTest do
   test "from_naive with possible but unknown future positive leap second UTC" do
     ndt = ~N[2090-06-30 23:59:60]
 
-    assert DateTime.from_naive(ndt, "Etc/UTC", FakeTimeZoneDatabase) ==
-             {:error, :outside_leap_second_data_validity_range}
+    {:outside_leap_second_data_range, datetime} =
+      DateTime.from_naive(ndt, "Etc/UTC", FakeTimeZoneDatabase)
+
+    assert datetime == %DateTime{
+             calendar: Calendar.ISO,
+             day: 30,
+             hour: 23,
+             microsecond: {0, 0},
+             minute: 59,
+             month: 6,
+             second: 60,
+             std_offset: 0,
+             time_zone: "Etc/UTC",
+             utc_offset: 0,
+             year: 2090,
+             zone_abbr: "UTC"
+           }
   end
 
   test "from_naive with invalid leap second UTC" do
@@ -985,8 +1000,23 @@ defmodule DateTimeTest do
   end
 
   test "from_naive with possible but unknown future positive leap second non-UTC" do
-    assert DateTime.from_naive(~N[2090-06-30 01:59:60], "Europe/Copenhagen", FakeTimeZoneDatabase) ==
-             {:error, :outside_leap_second_data_validity_range}
+    {:outside_leap_second_data_range, datetime} =
+      DateTime.from_naive(~N[2090-06-30 01:59:60], "Europe/Copenhagen", FakeTimeZoneDatabase)
+
+    assert datetime == %DateTime{
+             calendar: Calendar.ISO,
+             day: 30,
+             hour: 1,
+             microsecond: {0, 0},
+             minute: 59,
+             month: 6,
+             second: 60,
+             std_offset: 3600,
+             time_zone: "Europe/Copenhagen",
+             utc_offset: 3600,
+             year: 2090,
+             zone_abbr: "CEST"
+           }
   end
 
   test "shift_zone for DateTime with a calendar not compatible with ISO" do
@@ -1065,6 +1095,6 @@ defmodule TimeZoneDatabaseClientTest do
              {:ok, true}
 
     assert TimeZoneDatabaseClient.is_leap_second(~N[2090-06-30 23:59:60], FakeTimeZoneDatabase) ==
-             {:error, :outside_leap_second_data_validity_range}
+             {:error, :outside_leap_second_data_range}
   end
 end

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -510,6 +510,37 @@ defmodule DateTimeTest do
              }
   end
 
+  test "from_iso8601 handles invalid date, time, formats correctly" do
+    assert DateTime.from_iso8601("2015-01-23T23:50:07") == {:error, :missing_offset}
+    assert DateTime.from_iso8601("2015-01-23 23:50:61") == {:error, :invalid_time}
+    assert DateTime.from_iso8601("2015-01-32 23:50:07") == {:error, :invalid_date}
+    assert DateTime.from_iso8601("2015-01-23 23:50:07A") == {:error, :invalid_format}
+    assert DateTime.from_iso8601("2015-01-23T23:50:07.123-00:60") == {:error, :invalid_format}
+  end
+
+  test "from_iso8601 handles leap seconds correctly" do
+    assert DateTime.from_iso8601("2018-06-30 23:59:60Z", Calendar.ISO, FakeTimeZoneDatabase) ==
+             {:error, :invalid_leap_second}
+
+    {:ok, datetime, 0} =
+      DateTime.from_iso8601("2015-06-30 23:59:60Z", Calendar.ISO, FakeTimeZoneDatabase)
+
+    assert datetime == %DateTime{
+             calendar: Calendar.ISO,
+             day: 30,
+             hour: 23,
+             microsecond: {0, 0},
+             minute: 59,
+             month: 6,
+             second: 60,
+             std_offset: 0,
+             time_zone: "Etc/UTC",
+             utc_offset: 0,
+             year: 2015,
+             zone_abbr: "UTC"
+           }
+  end
+
   test "from_unix/2" do
     min_datetime = %DateTime{
       calendar: Calendar.ISO,

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -1088,6 +1088,9 @@ defmodule TimeZoneDatabaseClientTest do
   doctest TimeZoneDatabaseClient
 
   test "is leap second TimeZoneData test" do
+    assert TimeZoneDatabaseClient.is_leap_second(~N[1971-12-31 23:59:60], FakeTimeZoneDatabase) ==
+             {:ok, false}
+
     assert TimeZoneDatabaseClient.is_leap_second(~N[2018-01-01 00:00:00], FakeTimeZoneDatabase) ==
              {:ok, false}
 
@@ -1112,10 +1115,28 @@ defmodule TimeZoneDatabaseClientTest do
            ) == {:error, :outside_leap_second_data_range}
 
     assert TimeZoneDatabaseClient.leap_second_diff(
+             ~N[1972-01-01 00:00:00],
              ~N[1960-06-30 12:00:00],
-             ~N[2008-06-30 12:00:00],
              FakeTimeZoneDatabase
-           ) == {:error, :pre_1972_leap_seconds_not_supported}
+           ) == {:ok, 0}
+
+    assert TimeZoneDatabaseClient.leap_second_diff(
+             ~N[1972-07-01 00:00:00],
+             ~N[1960-06-30 12:00:00],
+             FakeTimeZoneDatabase
+           ) == {:ok, 1}
+
+    assert TimeZoneDatabaseClient.leap_second_diff(
+             ~N[1972-12-31 23:59:60],
+             ~N[1972-12-30 12:00:00],
+             FakeTimeZoneDatabase
+           ) == {:ok, 1}
+
+    assert TimeZoneDatabaseClient.leap_second_diff(
+             ~N[1972-06-30 23:59:60],
+             ~N[1960-06-30 12:00:00],
+             FakeTimeZoneDatabase
+           ) == {:ok, 1}
 
     assert TimeZoneDatabaseClient.leap_second_diff(
              ~N[2015-07-01 00:00:01],

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -1097,4 +1097,60 @@ defmodule TimeZoneDatabaseClientTest do
     assert TimeZoneDatabaseClient.is_leap_second(~N[2090-06-30 23:59:60], FakeTimeZoneDatabase) ==
              {:error, :outside_leap_second_data_range}
   end
+
+  test "leap seconds diff" do
+    assert TimeZoneDatabaseClient.leap_second_diff(
+             ~N[2090-06-30 23:59:60],
+             ~N[2007-06-30 12:00:00],
+             FakeTimeZoneDatabase
+           ) == {:error, :outside_leap_second_data_range}
+
+    assert TimeZoneDatabaseClient.leap_second_diff(
+             ~N[2007-06-30 12:00:00],
+             ~N[2090-06-30 23:59:60],
+             FakeTimeZoneDatabase
+           ) == {:error, :outside_leap_second_data_range}
+
+    assert TimeZoneDatabaseClient.leap_second_diff(
+             ~N[1960-06-30 12:00:00],
+             ~N[2008-06-30 12:00:00],
+             FakeTimeZoneDatabase
+           ) == {:error, :pre_1972_leap_seconds_not_supported}
+
+    assert TimeZoneDatabaseClient.leap_second_diff(
+             ~N[2015-07-01 00:00:01],
+             ~N[2015-06-30 23:59:59],
+             FakeTimeZoneDatabase
+           ) == {:ok, 1}
+
+    assert TimeZoneDatabaseClient.leap_second_diff(
+             ~N[2015-06-30 23:59:60],
+             ~N[2015-06-30 23:59:59],
+             FakeTimeZoneDatabase
+           ) == {:ok, 1}
+
+    assert TimeZoneDatabaseClient.leap_second_diff(
+             ~N[2015-06-30 23:59:60],
+             ~N[2015-06-30 23:59:60],
+             FakeTimeZoneDatabase
+           ) == {:ok, 0}
+
+    assert TimeZoneDatabaseClient.leap_second_diff(
+             ~N[2016-12-31 23:59:60],
+             ~N[2015-06-30 23:59:60],
+             FakeTimeZoneDatabase
+           ) == {:ok, 1}
+
+    assert TimeZoneDatabaseClient.leap_second_diff(
+             ~N[2016-12-31 23:59:60],
+             ~N[2015-06-30 23:59:58],
+             FakeTimeZoneDatabase
+           ) == {:ok, 2}
+
+    assert TimeZoneDatabaseClient.leap_second_diff(
+             ~N[2017-01-01 00:59:59],
+             ~N[2015-06-30 23:59:58],
+             FakeTimeZoneDatabase
+           ) == {:ok, 2}
+  end
 end

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -9,6 +9,134 @@ defmodule FakeCalendar do
   def day_rollover_relative_to_midnight_utc, do: {123_456, 123_457}
 end
 
+defmodule FakeTimeZoneDatabase do
+  @behaviour TimeZoneDatabase
+
+  @time_zone_period_cph_summer_2018 %{
+    from_utc: 63_689_158_800,
+    from_wall: 63_689_166_000,
+    std_offset: 3600,
+    until_utc: 63_707_907_600,
+    until_wall: 63_707_914_800,
+    utc_offset: 3600,
+    zone_abbr: "CEST"
+  }
+
+  @time_zone_period_cph_winter_2018_2019 %{
+    from_utc: 63_707_907_600,
+    from_wall: 63_707_911_200,
+    std_offset: 0,
+    until_utc: 63_721_213_200,
+    until_wall: 63_721_216_800,
+    utc_offset: 3600,
+    zone_abbr: "CET"
+  }
+
+  @time_zone_period_cph_summer_2019 %{
+    from_utc: 63_721_213_200,
+    from_wall: 63_721_220_400,
+    std_offset: 3600,
+    until_utc: 63_739_357_200,
+    until_wall: 63_739_364_400,
+    utc_offset: 3600,
+    zone_abbr: "CEST"
+  }
+
+  def by_utc("Europe/Copenhagen", gregorian_seconds)
+      when gregorian_seconds >= 63_689_158_800 and gregorian_seconds < 63_707_914_800 do
+    {:ok, @time_zone_period_cph_summer_2018}
+  end
+
+  def by_utc("Europe/Copenhagen", gregorian_seconds)
+      when gregorian_seconds >= 63_689_158_800 and gregorian_seconds < 63_707_907_600 do
+    {:ok, @time_zone_period_cph_winter_2018_2019}
+  end
+
+  def by_utc("America/Los_Angeles", gregorian_seconds)
+      when gregorian_seconds >= 63_687_981_600 and gregorian_seconds < 63_708_541_200 do
+    {:ok,
+     %{
+       from_utc: 63_687_981_600,
+       from_wall: 63_687_956_400,
+       std_offset: 3600,
+       until_utc: 63_708_541_200,
+       until_wall: 63_708_516_000,
+       utc_offset: -28800,
+       zone_abbr: "PDT"
+     }}
+  end
+
+  def by_wall("Europe/Copenhagen", gregorian_seconds)
+      when gregorian_seconds >= 63_721_216_800 and gregorian_seconds < 63_721_220_400 do
+    {:gap, [@time_zone_period_cph_winter_2018_2019, @time_zone_period_cph_summer_2019]}
+  end
+
+  def by_wall("Europe/Copenhagen", gregorian_seconds)
+      when gregorian_seconds < 63_707_914_800 and gregorian_seconds >= 63_707_911_200 do
+    {:ambiguous,
+     [
+       @time_zone_period_cph_summer_2018,
+       @time_zone_period_cph_winter_2018_2019
+     ]}
+  end
+
+  def by_wall("Europe/Copenhagen", gregorian_seconds)
+      when gregorian_seconds >= 63_689_166_000 and gregorian_seconds < 63_707_914_800 do
+    {:single, @time_zone_period_cph_summer_2018}
+  end
+
+  def by_wall("Europe/Copenhagen", gregorian_seconds)
+      when gregorian_seconds >= 63_707_911_200 and gregorian_seconds < 63_721_216_800 do
+    {:single, @time_zone_period_cph_winter_2018_2019}
+  end
+
+  def by_wall("Europe/Copenhagen", gregorian_seconds)
+      when gregorian_seconds >= 63_721_220_400 and gregorian_seconds < 63_739_364_400 do
+    {:single, @time_zone_period_cph_summer_2019}
+  end
+
+  def by_wall(time_zone, _) when time_zone != "Europe/Copenhagen" do
+    {:error, :time_zone_not_found}
+  end
+
+  def leap_seconds do
+    [
+      {{{1971, 12, 31}, {23, 59, 60}}, 10},
+      {{{1972, 6, 30}, {23, 59, 60}}, 11},
+      {{{1972, 12, 31}, {23, 59, 60}}, 12},
+      {{{1973, 12, 31}, {23, 59, 60}}, 13},
+      {{{1974, 12, 31}, {23, 59, 60}}, 14},
+      {{{1975, 12, 31}, {23, 59, 60}}, 15},
+      {{{1976, 12, 31}, {23, 59, 60}}, 16},
+      {{{1977, 12, 31}, {23, 59, 60}}, 17},
+      {{{1978, 12, 31}, {23, 59, 60}}, 18},
+      {{{1979, 12, 31}, {23, 59, 60}}, 19},
+      {{{1981, 6, 30}, {23, 59, 60}}, 20},
+      {{{1982, 6, 30}, {23, 59, 60}}, 21},
+      {{{1983, 6, 30}, {23, 59, 60}}, 22},
+      {{{1985, 6, 30}, {23, 59, 60}}, 23},
+      {{{1987, 12, 31}, {23, 59, 60}}, 24},
+      {{{1989, 12, 31}, {23, 59, 60}}, 25},
+      {{{1990, 12, 31}, {23, 59, 60}}, 26},
+      {{{1992, 6, 30}, {23, 59, 60}}, 27},
+      {{{1993, 6, 30}, {23, 59, 60}}, 28},
+      {{{1994, 6, 30}, {23, 59, 60}}, 29},
+      {{{1995, 12, 31}, {23, 59, 60}}, 30},
+      {{{1997, 6, 30}, {23, 59, 60}}, 31},
+      {{{1998, 12, 31}, {23, 59, 60}}, 32},
+      {{{2005, 12, 31}, {23, 59, 60}}, 33},
+      {{{2008, 12, 31}, {23, 59, 60}}, 34},
+      {{{2012, 6, 30}, {23, 59, 60}}, 35},
+      {{{2015, 6, 30}, {23, 59, 60}}, 36},
+      {{{2016, 12, 31}, {23, 59, 60}}, 37}
+    ]
+  end
+
+  def leap_second_data_valid_until do
+    {{2018, 12, 28}, {0, 0, 0}}
+  end
+end
+
 defmodule DateTest do
   use ExUnit.Case, async: true
   doctest Date

--- a/lib/elixir/test/elixir/fixtures/calendar/fake_time_zone_database.exs
+++ b/lib/elixir/test/elixir/fixtures/calendar/fake_time_zone_database.exs
@@ -140,7 +140,7 @@ defmodule FakeTimeZoneDatabase do
 
       false ->
         if erl_datetime > leap_second_data_valid_until() do
-          {:error, :outside_leap_second_data_validity_range}
+          {:error, :outside_leap_second_data_range}
         else
           {:ok, false}
         end

--- a/lib/elixir/test/elixir/fixtures/calendar/fake_time_zone_database.exs
+++ b/lib/elixir/test/elixir/fixtures/calendar/fake_time_zone_database.exs
@@ -80,6 +80,10 @@ defmodule FakeTimeZoneDatabase do
      }}
   end
 
+  defp time_zone_periods_from_utc(time_zone, _) when time_zone != "Europe/Copenhagen" do
+    {:error, :time_zone_not_found}
+  end
+
   defp time_zone_periods_from_wall("Europe/Copenhagen", erl_datetime)
        when erl_datetime >= {{2019, 3, 31}, {2, 0, 0}} and
               erl_datetime < {{2019, 3, 31}, {3, 0, 0}} do

--- a/lib/elixir/test/elixir/fixtures/calendar/fake_time_zone_database.exs
+++ b/lib/elixir/test/elixir/fixtures/calendar/fake_time_zone_database.exs
@@ -1,0 +1,118 @@
+defmodule FakeTimeZoneDatabase do
+  @behaviour TimeZoneDatabase
+
+  @time_zone_period_cph_summer_2018 %{
+    from_wall: 63_689_166_000,
+    std_offset: 3600,
+    until_wall: 63_707_914_800,
+    utc_offset: 3600,
+    zone_abbr: "CEST"
+  }
+
+  @time_zone_period_cph_winter_2018_2019 %{
+    from_wall: 63_707_911_200,
+    std_offset: 0,
+    until_wall: 63_721_216_800,
+    utc_offset: 3600,
+    zone_abbr: "CET"
+  }
+
+  @time_zone_period_cph_summer_2019 %{
+    from_wall: 63_721_220_400,
+    std_offset: 3600,
+    until_wall: 63_739_364_400,
+    utc_offset: 3600,
+    zone_abbr: "CEST"
+  }
+
+  def by_utc("Europe/Copenhagen", gregorian_seconds)
+      when gregorian_seconds >= 63_689_158_800 and gregorian_seconds < 63_707_914_800 do
+    {:ok, @time_zone_period_cph_summer_2018 |> full_period_to_light}
+  end
+
+  def by_utc("Europe/Copenhagen", gregorian_seconds)
+      when gregorian_seconds >= 63_689_158_800 and gregorian_seconds < 63_707_907_600 do
+    {:ok, @time_zone_period_cph_winter_2018_2019 |> full_period_to_light}
+  end
+
+  def by_utc("America/Los_Angeles", gregorian_seconds)
+      when gregorian_seconds >= 63_687_981_600 and gregorian_seconds < 63_708_541_200 do
+    {:ok,
+     %{
+       std_offset: 3600,
+       utc_offset: -28800,
+       zone_abbr: "PDT"
+     }}
+  end
+
+  def by_wall("Europe/Copenhagen", gregorian_seconds)
+      when gregorian_seconds >= 63_721_216_800 and gregorian_seconds < 63_721_220_400 do
+    {:gap, @time_zone_period_cph_winter_2018_2019, @time_zone_period_cph_summer_2019}
+  end
+
+  def by_wall("Europe/Copenhagen", gregorian_seconds)
+      when gregorian_seconds < 63_707_914_800 and gregorian_seconds >= 63_707_911_200 do
+    {:ambiguous, @time_zone_period_cph_summer_2018 |> full_period_to_light,
+     @time_zone_period_cph_winter_2018_2019 |> full_period_to_light}
+  end
+
+  def by_wall("Europe/Copenhagen", gregorian_seconds)
+      when gregorian_seconds >= 63_689_166_000 and gregorian_seconds < 63_707_914_800 do
+    {:single, @time_zone_period_cph_summer_2018 |> full_period_to_light}
+  end
+
+  def by_wall("Europe/Copenhagen", gregorian_seconds)
+      when gregorian_seconds >= 63_707_911_200 and gregorian_seconds < 63_721_216_800 do
+    {:single, @time_zone_period_cph_winter_2018_2019 |> full_period_to_light}
+  end
+
+  def by_wall("Europe/Copenhagen", gregorian_seconds)
+      when gregorian_seconds >= 63_721_220_400 and gregorian_seconds < 63_739_364_400 do
+    {:single, @time_zone_period_cph_summer_2019 |> full_period_to_light}
+  end
+
+  def by_wall(time_zone, _) when time_zone != "Europe/Copenhagen" do
+    {:error, :time_zone_not_found}
+  end
+
+  def leap_seconds do
+    [
+      {{{1971, 12, 31}, {23, 59, 60}}, 10},
+      {{{1972, 6, 30}, {23, 59, 60}}, 11},
+      {{{1972, 12, 31}, {23, 59, 60}}, 12},
+      {{{1973, 12, 31}, {23, 59, 60}}, 13},
+      {{{1974, 12, 31}, {23, 59, 60}}, 14},
+      {{{1975, 12, 31}, {23, 59, 60}}, 15},
+      {{{1976, 12, 31}, {23, 59, 60}}, 16},
+      {{{1977, 12, 31}, {23, 59, 60}}, 17},
+      {{{1978, 12, 31}, {23, 59, 60}}, 18},
+      {{{1979, 12, 31}, {23, 59, 60}}, 19},
+      {{{1981, 6, 30}, {23, 59, 60}}, 20},
+      {{{1982, 6, 30}, {23, 59, 60}}, 21},
+      {{{1983, 6, 30}, {23, 59, 60}}, 22},
+      {{{1985, 6, 30}, {23, 59, 60}}, 23},
+      {{{1987, 12, 31}, {23, 59, 60}}, 24},
+      {{{1989, 12, 31}, {23, 59, 60}}, 25},
+      {{{1990, 12, 31}, {23, 59, 60}}, 26},
+      {{{1992, 6, 30}, {23, 59, 60}}, 27},
+      {{{1993, 6, 30}, {23, 59, 60}}, 28},
+      {{{1994, 6, 30}, {23, 59, 60}}, 29},
+      {{{1995, 12, 31}, {23, 59, 60}}, 30},
+      {{{1997, 6, 30}, {23, 59, 60}}, 31},
+      {{{1998, 12, 31}, {23, 59, 60}}, 32},
+      {{{2005, 12, 31}, {23, 59, 60}}, 33},
+      {{{2008, 12, 31}, {23, 59, 60}}, 34},
+      {{{2012, 6, 30}, {23, 59, 60}}, 35},
+      {{{2015, 6, 30}, {23, 59, 60}}, 36},
+      {{{2016, 12, 31}, {23, 59, 60}}, 37}
+    ]
+  end
+
+  def leap_second_data_valid_until do
+    {{2018, 12, 28}, {0, 0, 0}}
+  end
+
+  defp full_period_to_light(full_period) do
+    Map.drop(full_period, [:from_wall, :until_wall])
+  end
+end

--- a/lib/elixir/test/elixir/fixtures/calendar/fake_time_zone_database.exs
+++ b/lib/elixir/test/elixir/fixtures/calendar/fake_time_zone_database.exs
@@ -25,13 +25,13 @@ defmodule FakeTimeZoneDatabase do
     zone_abbr: "CEST"
   }
 
-  def by_utc(time_zone, naive_datetime) do
+  def by_utc(naive_datetime, time_zone) do
     erl_datetime = naive_datetime |> NaiveDateTime.to_erl()
 
     do_by_utc(time_zone, erl_datetime)
   end
 
-  def by_wall(time_zone, naive_datetime) do
+  def by_wall(naive_datetime, time_zone) do
     erl_datetime = naive_datetime |> NaiveDateTime.to_erl()
 
     do_by_wall(time_zone, erl_datetime)

--- a/lib/elixir/test/elixir/fixtures/calendar/fake_time_zone_database.exs
+++ b/lib/elixir/test/elixir/fixtures/calendar/fake_time_zone_database.exs
@@ -26,37 +26,38 @@ defmodule FakeTimeZoneDatabase do
     zone_abbr: "CEST"
   }
 
-  @spec by_utc(Calendar.naive_datetime(), Calendar.time_zone()) ::
+  @spec time_zone_period_from_utc_iso_days(Calendar.iso_days(), Calendar.time_zone()) ::
           {:ok, TimeZoneDatabase.time_zone_period()} | {:error, :time_zone_not_found}
   @impl true
-  def by_utc(naive_datetime, time_zone) do
-    do_by_utc(time_zone, NaiveDateTime.to_erl(naive_datetime))
+  def time_zone_period_from_utc_iso_days(iso_days, time_zone) do
+    {:ok, ndt} = naive_datetime_from_iso_days(iso_days)
+    time_zone_periods_from_utc(time_zone, NaiveDateTime.to_erl(ndt))
   end
 
-  @spec by_wall(Calendar.naive_datetime(), Calendar.time_zone()) ::
+  @spec time_zone_periods_from_wall_datetime(Calendar.naive_datetime(), Calendar.time_zone()) ::
           {:single, TimeZoneDatabase.time_zone_period()}
           | {:ambiguous, TimeZoneDatabase.time_zone_period(), TimeZoneDatabase.time_zone_period()}
           | {:gap, TimeZoneDatabase.time_zone_period_with_wall_limits(),
              TimeZoneDatabase.time_zone_period_with_wall_limits()}
           | {:error, :time_zone_not_found}
   @impl true
-  def by_wall(naive_datetime, time_zone) do
-    do_by_wall(time_zone, NaiveDateTime.to_erl(naive_datetime))
+  def time_zone_periods_from_wall_datetime(naive_datetime, time_zone) do
+    time_zone_periods_from_wall(time_zone, NaiveDateTime.to_erl(naive_datetime))
   end
 
-  defp do_by_utc("Europe/Copenhagen", erl_datetime)
+  defp time_zone_periods_from_utc("Europe/Copenhagen", erl_datetime)
        when erl_datetime >= {{2018, 3, 25}, {1, 0, 0}} and
               erl_datetime < {{2018, 10, 28}, {3, 0, 0}} do
     {:ok, @time_zone_period_cph_summer_2018 |> remove_wall_limits_from_period}
   end
 
-  defp do_by_utc("Europe/Copenhagen", erl_datetime)
+  defp time_zone_periods_from_utc("Europe/Copenhagen", erl_datetime)
        when erl_datetime >= {{2018, 10, 28}, {2, 0, 0}} and
               erl_datetime < {{2019, 3, 31}, {2, 0, 0}} do
     {:ok, @time_zone_period_cph_winter_2018_2019 |> remove_wall_limits_from_period}
   end
 
-  defp do_by_utc("Europe/Copenhagen", erl_datetime)
+  defp time_zone_periods_from_utc("Europe/Copenhagen", erl_datetime)
        when erl_datetime >= {{2015, 3, 29}, {1, 0, 0}} and
               erl_datetime < {{2015, 10, 25}, {1, 0, 0}} do
     {:ok,
@@ -67,7 +68,7 @@ defmodule FakeTimeZoneDatabase do
      }}
   end
 
-  defp do_by_utc("America/Los_Angeles", erl_datetime)
+  defp time_zone_periods_from_utc("America/Los_Angeles", erl_datetime)
        when erl_datetime >= {{2018, 3, 11}, {10, 0, 0}} and
               erl_datetime < {{2018, 11, 4}, {9, 0, 0}} do
     {:ok,
@@ -78,38 +79,38 @@ defmodule FakeTimeZoneDatabase do
      }}
   end
 
-  defp do_by_wall("Europe/Copenhagen", erl_datetime)
+  defp time_zone_periods_from_wall("Europe/Copenhagen", erl_datetime)
        when erl_datetime >= {{2019, 3, 31}, {2, 0, 0}} and
               erl_datetime < {{2019, 3, 31}, {3, 0, 0}} do
     {:gap, @time_zone_period_cph_winter_2018_2019, @time_zone_period_cph_summer_2019}
   end
 
-  defp do_by_wall("Europe/Copenhagen", erl_datetime)
+  defp time_zone_periods_from_wall("Europe/Copenhagen", erl_datetime)
        when erl_datetime < {{2018, 10, 28}, {3, 0, 0}} and
               erl_datetime >= {{2018, 10, 28}, {2, 0, 0}} do
     {:ambiguous, @time_zone_period_cph_summer_2018 |> remove_wall_limits_from_period,
      @time_zone_period_cph_winter_2018_2019 |> remove_wall_limits_from_period}
   end
 
-  defp do_by_wall("Europe/Copenhagen", erl_datetime)
+  defp time_zone_periods_from_wall("Europe/Copenhagen", erl_datetime)
        when erl_datetime >= {{2018, 3, 25}, {3, 0, 0}} and
               erl_datetime < {{2018, 10, 28}, {3, 0, 0}} do
     {:single, @time_zone_period_cph_summer_2018 |> remove_wall_limits_from_period}
   end
 
-  defp do_by_wall("Europe/Copenhagen", erl_datetime)
+  defp time_zone_periods_from_wall("Europe/Copenhagen", erl_datetime)
        when erl_datetime >= {{2018, 10, 28}, {2, 0, 0}} and
               erl_datetime < {{2019, 3, 31}, {2, 0, 0}} do
     {:single, @time_zone_period_cph_winter_2018_2019 |> remove_wall_limits_from_period}
   end
 
-  defp do_by_wall("Europe/Copenhagen", erl_datetime)
+  defp time_zone_periods_from_wall("Europe/Copenhagen", erl_datetime)
        when erl_datetime >= {{2019, 3, 31}, {3, 0, 0}} and
               erl_datetime < {{2019, 10, 27}, {3, 0, 0}} do
     {:single, @time_zone_period_cph_summer_2019 |> remove_wall_limits_from_period}
   end
 
-  defp do_by_wall("Europe/Copenhagen", erl_datetime)
+  defp time_zone_periods_from_wall("Europe/Copenhagen", erl_datetime)
        when erl_datetime >= {{2015, 3, 29}, {3, 0, 0}} and
               erl_datetime < {{2015, 10, 25}, {3, 0, 0}} do
     {:single,
@@ -120,7 +121,7 @@ defmodule FakeTimeZoneDatabase do
      }}
   end
 
-  defp do_by_wall("Europe/Copenhagen", erl_datetime)
+  defp time_zone_periods_from_wall("Europe/Copenhagen", erl_datetime)
        when erl_datetime >= {{2090, 3, 26}, {3, 0, 0}} and
               erl_datetime < {{2090, 10, 29}, {3, 0, 0}} do
     {:single,
@@ -131,7 +132,7 @@ defmodule FakeTimeZoneDatabase do
      }}
   end
 
-  defp do_by_wall(time_zone, _) when time_zone != "Europe/Copenhagen" do
+  defp time_zone_periods_from_wall(time_zone, _) when time_zone != "Europe/Copenhagen" do
     {:error, :time_zone_not_found}
   end
 
@@ -246,5 +247,12 @@ defmodule FakeTimeZoneDatabase do
           TimeZoneDatabase.time_zone_period()
   defp remove_wall_limits_from_period(full_period) do
     Map.drop(full_period, [:from_wall, :until_wall])
+  end
+
+  defp naive_datetime_from_iso_days(iso_days) do
+    {year, month, day, hour, minute, second, microsecond} =
+      Calendar.ISO.naive_datetime_from_iso_days(iso_days)
+
+    NaiveDateTime.new(year, month, day, hour, minute, second, microsecond)
   end
 end

--- a/lib/elixir/test/elixir/fixtures/calendar/fake_time_zone_database.exs
+++ b/lib/elixir/test/elixir/fixtures/calendar/fake_time_zone_database.exs
@@ -2,51 +2,56 @@ defmodule FakeTimeZoneDatabase do
   @behaviour TimeZoneDatabase
 
   @time_zone_period_cph_summer_2018 %{
-    from_wall: 63_689_166_000,
+    from_wall: {{2018, 3, 25}, {3, 0, 0}},
     std_offset: 3600,
-    until_wall: 63_707_914_800,
+    until_wall: {{2018, 10, 28}, {3, 0, 0}},
     utc_offset: 3600,
     zone_abbr: "CEST"
   }
 
   @time_zone_period_cph_winter_2018_2019 %{
-    from_wall: 63_707_911_200,
+    from_wall: {{2018, 10, 28}, {2, 0, 0}},
     std_offset: 0,
-    until_wall: 63_721_216_800,
+    until_wall: {{2019, 3, 31}, {2, 0, 0}},
     utc_offset: 3600,
     zone_abbr: "CET"
   }
 
   @time_zone_period_cph_summer_2019 %{
-    from_wall: 63_721_220_400,
+    from_wall: {{2019, 3, 31}, {3, 0, 0}},
     std_offset: 3600,
-    until_wall: 63_739_364_400,
+    until_wall: {{2019, 10, 27}, {3, 0, 0}},
     utc_offset: 3600,
     zone_abbr: "CEST"
   }
 
-  def by_utc(time_zone, erl_datetime) do
-    gregorian_seconds = :calendar.datetime_to_gregorian_seconds(erl_datetime)
-    do_by_utc(time_zone, gregorian_seconds)
+  def by_utc(time_zone, naive_datetime) do
+    erl_datetime = naive_datetime |> NaiveDateTime.to_erl()
+
+    do_by_utc(time_zone, erl_datetime)
   end
 
-  def by_wall(time_zone, erl_datetime) do
-    gregorian_seconds = :calendar.datetime_to_gregorian_seconds(erl_datetime)
-    do_by_wall(time_zone, gregorian_seconds)
+  def by_wall(time_zone, naive_datetime) do
+    erl_datetime = naive_datetime |> NaiveDateTime.to_erl()
+
+    do_by_wall(time_zone, erl_datetime)
   end
 
-  defp do_by_utc("Europe/Copenhagen", gregorian_seconds)
-       when gregorian_seconds >= 63_689_158_800 and gregorian_seconds < 63_707_914_800 do
+  defp do_by_utc("Europe/Copenhagen", erl_datetime)
+       when erl_datetime >= {{2018, 3, 25}, {1, 0, 0}} and
+              erl_datetime < {{2018, 10, 28}, {3, 0, 0}} do
     {:ok, @time_zone_period_cph_summer_2018 |> to_light_period}
   end
 
-  defp do_by_utc("Europe/Copenhagen", gregorian_seconds)
-       when gregorian_seconds >= 63_689_158_800 and gregorian_seconds < 63_707_907_600 do
+  defp do_by_utc("Europe/Copenhagen", erl_datetime)
+       when erl_datetime >= {{2018, 3, 25}, {1, 0, 0}} and
+              erl_datetime < {{2018, 10, 28}, {1, 0, 0}} do
     {:ok, @time_zone_period_cph_winter_2018_2019 |> to_light_period}
   end
 
-  defp do_by_utc("America/Los_Angeles", gregorian_seconds)
-       when gregorian_seconds >= 63_687_981_600 and gregorian_seconds < 63_708_541_200 do
+  defp do_by_utc("America/Los_Angeles", erl_datetime)
+       when erl_datetime >= {{2018, 3, 11}, {10, 0, 0}} and
+              erl_datetime < {{2018, 11, 4}, {9, 0, 0}} do
     {:ok,
      %{
        std_offset: 3600,
@@ -55,30 +60,35 @@ defmodule FakeTimeZoneDatabase do
      }}
   end
 
-  defp do_by_wall("Europe/Copenhagen", gregorian_seconds)
-       when gregorian_seconds >= 63_721_216_800 and gregorian_seconds < 63_721_220_400 do
+  defp do_by_wall("Europe/Copenhagen", erl_datetime)
+       when erl_datetime >= {{2019, 3, 31}, {2, 0, 0}} and
+              erl_datetime < {{2019, 3, 31}, {3, 0, 0}} do
     {:gap, @time_zone_period_cph_winter_2018_2019 |> to_full_period_datetime_tuple,
      @time_zone_period_cph_summer_2019 |> to_full_period_datetime_tuple}
   end
 
-  defp do_by_wall("Europe/Copenhagen", gregorian_seconds)
-       when gregorian_seconds < 63_707_914_800 and gregorian_seconds >= 63_707_911_200 do
+  defp do_by_wall("Europe/Copenhagen", erl_datetime)
+       when erl_datetime < {{2018, 10, 28}, {3, 0, 0}} and
+              erl_datetime >= {{2018, 10, 28}, {2, 0, 0}} do
     {:ambiguous, @time_zone_period_cph_summer_2018 |> to_light_period,
      @time_zone_period_cph_winter_2018_2019 |> to_light_period}
   end
 
-  defp do_by_wall("Europe/Copenhagen", gregorian_seconds)
-       when gregorian_seconds >= 63_689_166_000 and gregorian_seconds < 63_707_914_800 do
+  defp do_by_wall("Europe/Copenhagen", erl_datetime)
+       when erl_datetime >= {{2018, 3, 25}, {3, 0, 0}} and
+              erl_datetime < {{2018, 10, 28}, {3, 0, 0}} do
     {:single, @time_zone_period_cph_summer_2018 |> to_light_period}
   end
 
-  defp do_by_wall("Europe/Copenhagen", gregorian_seconds)
-       when gregorian_seconds >= 63_707_911_200 and gregorian_seconds < 63_721_216_800 do
+  defp do_by_wall("Europe/Copenhagen", erl_datetime)
+       when erl_datetime >= {{2018, 10, 28}, {2, 0, 0}} and
+              erl_datetime < {{2019, 3, 31}, {2, 0, 0}} do
     {:single, @time_zone_period_cph_winter_2018_2019 |> to_light_period}
   end
 
-  defp do_by_wall("Europe/Copenhagen", gregorian_seconds)
-       when gregorian_seconds >= 63_721_220_400 and gregorian_seconds < 63_739_364_400 do
+  defp do_by_wall("Europe/Copenhagen", erl_datetime)
+       when erl_datetime >= {{2019, 3, 31}, {3, 0, 0}} and
+              erl_datetime < {{2019, 10, 27}, {3, 0, 0}} do
     {:single, @time_zone_period_cph_summer_2019 |> to_light_period}
   end
 
@@ -128,10 +138,13 @@ defmodule FakeTimeZoneDatabase do
   end
 
   defp to_full_period_datetime_tuple(full_period_iso_seconds) do
-    from_wall_erl = full_period_iso_seconds.from_wall |> :calendar.gregorian_seconds_to_datetime()
+    from_wall_erl =
+      full_period_iso_seconds.from_wall
+      |> NaiveDateTime.from_erl!()
 
     until_wall_erl =
-      full_period_iso_seconds.until_wall |> :calendar.gregorian_seconds_to_datetime()
+      full_period_iso_seconds.until_wall
+      |> NaiveDateTime.from_erl!()
 
     %{full_period_iso_seconds | from_wall: from_wall_erl, until_wall: until_wall_erl}
   end


### PR DESCRIPTION
This provides a behaviour for providing time zone data to Elixir (`lib/elixir/lib/calendar/time_zone_database.ex`). It allows anyone to implement a library that provides time zone data and use that with Elixir.

In addition to the behaviour there is code changes that enables Elixir to get a `DateTime` for the time right now in any timezone, to change between timezones and to create a new `DateTime` in any timezone. All using the behaviour defined by `TimeZoneDatabase`.

The behaviour includes functions for getting timezone information for a certain period for a certain time zone. Either by the time in UTC or the "wall time". Wall time being the time you would see on a clock on the wall, that is taking into account UTC offset as well as DST.

There are also functions for getting leap second information. This information is provided by IANA in the time zone data tar file. It is useful for validating UTC datetimes and for calculating differences where leap seconds are taken into account. It could also be used for calculating TAI and GPS time. In this PR there is currently not any functions that use the leap second data, but I might update the PR with that later.

Additionally there is functionality that uses the time zone data in `date_time.ex`.

The functions take an optional module name with a module that implement the behaviour:

```elixir
iex> DateTime.from_naive(~N[2018-10-28 02:30:00], "Europe/Copenhagen", Tzdata.TimeZoneDatabase)
{:ambiguous,
 [#DateTime<2018-10-28 02:30:00+02:00 CEST Europe/Copenhagen>,
  #DateTime<2018-10-28 02:30:00+01:00 CET Europe/Copenhagen>]}
```

Instead of providing the module as a argument, Elixir can be configured to use a specific module.

`:elixir_config.put(:time_zone_module, Tzdata.TimeZoneDatabase)`

Then the argument is not needed for the functions and the configured module will be used instead:

```elixir
iex> DateTime.from_naive(~N[2018-10-28 02:30:00], "Europe/Copenhagen")
{:ambiguous,
 [#DateTime<2018-10-28 02:30:00+02:00 CEST Europe/Copenhagen>,
  #DateTime<2018-10-28 02:30:00+01:00 CET Europe/Copenhagen>]}
```

gaps and overlaps (ambiguity) for instance during "spring forward" and autumn are handled.

```
DateTime.from_naive(~N[2018-10-28 05:30:00], "Europe/Copenhagen", Tzdata.TimeZoneDatabase)
{:ok, #DateTime<2018-10-28 05:30:00+01:00 CET Europe/Copenhagen>}
```

You can get the time right now in any timezone:

```elixir
{:ok, datetime} = DateTime.now("Europe/London")
{:ok, #DateTime<2018-07-16 18:03:15.070876+01:00 BST Europe/London>}
```

Get the same time for a datetime in another timezone:

```elixir
iex(6)> DateTime.shift_zone(datetime, "America/New_York")
{:ok, #DateTime<2018-07-16 13:03:15.070876-04:00 EDT America/New_York>}
```

This is not considered finished. Some of the details could be optimised. The main thing I focused on is the TimeZoneData behaviour. The `iex>` examples above were made with a working implementation of the behaviour not included here.