### PR TITLE
Fixed indentation in StringIO.open/3 examples and added missing @doc :since metadata

### DIFF
--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -15,7 +15,6 @@ defmodule StringIO do
 
   use GenServer
 
-  @doc since: "1.7.0"
   @doc ~S"""
   Creates an IO device.
 

--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -15,6 +15,7 @@ defmodule StringIO do
 
   use GenServer
 
+  @doc since: "1.7.0"
   @doc ~S"""
   Creates an IO device.
 

--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -31,19 +31,19 @@ defmodule StringIO do
 
   ## Examples
 
-    iex> StringIO.open("foo", [], fn(pid) ->
-    ...>   input = IO.gets(pid, ">")
-    ...>   IO.write(pid, "The input was #{input}")
-    ...>   StringIO.contents(pid)
-    ...> end)
-    {:ok, {"", "The input was foo"}}
+      iex> StringIO.open("foo", [], fn(pid) ->
+      ...>   input = IO.gets(pid, ">")
+      ...>   IO.write(pid, "The input was #{input}")
+      ...>   StringIO.contents(pid)
+      ...> end)
+      {:ok, {"", "The input was foo"}}
 
-    iex> StringIO.open("foo", [capture_prompt: true], fn(pid) ->
-    ...>   input = IO.gets(pid, ">")
-    ...>   IO.write(pid, "The input was #{input}")
-    ...>   StringIO.contents(pid)
-    ...> end)
-    {:ok, {"", ">The input was foo"}}
+      iex> StringIO.open("foo", [capture_prompt: true], fn(pid) ->
+      ...>   input = IO.gets(pid, ">")
+      ...>   IO.write(pid, "The input was #{input}")
+      ...>   StringIO.contents(pid)
+      ...> end)
+      {:ok, {"", ">The input was foo"}}
 
   """
   @spec open(binary, keyword, (pid -> res)) :: {:ok, res} when res: var


### PR DESCRIPTION
At the moment examples are interpreted as normal text because indentation is too small
https://hexdocs.pm/elixir/1.7.0-rc.0/StringIO.html#open/3

Also, `@doc :since` metadata was missing and I cannot find anything about `StringIO` in v1.7 CHANGELOG. Function was added in #7477
