### PR TITLE
Add reference to Integer.parse/2 in String.to_integer/1

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2187,7 +2187,7 @@ defmodule String do
   Returns an integer whose text representation is `string`.
 
   `string` must be the string representation of an integer. In order to parse
-  a string that can contain ill-formatted integer then `Integer.parse/1`
+  a string that may contain an ill-formatted integer then `Integer.parse/1`
   should be used. Otherwise, an `ArgumentError` will be raised.
 
   Inlined by the compiler.

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2186,12 +2186,19 @@ defmodule String do
   @doc """
   Returns an integer whose text representation is `string`.
 
+  `string` must be the string representation of a integer. In order to parse
+  a string that can contain ill-formatted integer then `Integer.parse/1`
+  should be used. Otherwise, an `ArgumentError` will be raised.
+
   Inlined by the compiler.
 
   ## Examples
 
       iex> String.to_integer("123")
       123
+
+      String.to_integer("invalid data")
+      #=> ** (ArgumentError) argument error
 
   """
   @spec to_integer(String.t()) :: integer

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2186,7 +2186,7 @@ defmodule String do
   @doc """
   Returns an integer whose text representation is `string`.
 
-  `string` must be the string representation of a integer. In order to parse
+  `string` must be the string representation of an integer. In order to parse
   a string that can contain ill-formatted integer then `Integer.parse/1`
   should be used. Otherwise, an `ArgumentError` will be raised.
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2186,9 +2186,10 @@ defmodule String do
   @doc """
   Returns an integer whose text representation is `string`.
 
-  `string` must be the string representation of an integer. In order to parse
-  a string that may contain an ill-formatted integer then `Integer.parse/1`
-  should be used. Otherwise, an `ArgumentError` will be raised.
+  `string` must be the string representation of an integer.
+  Otherwise, an `ArgumentError` will be raised. If you want
+  to parse a string that may contain an ill-formatted integer,
+  use `Integer.parse/1`.
 
   Inlined by the compiler.
 
@@ -2196,6 +2197,8 @@ defmodule String do
 
       iex> String.to_integer("123")
       123
+
+  Passing a string that does not represent an integer leads to an error:
 
       String.to_integer("invalid data")
       #=> ** (ArgumentError) argument error


### PR DESCRIPTION
This should reduce confusion for newcomers about how function works and
what to use when you need to gracefully handle possible ill-formated
strings.