### PR TITLE
Fix nested use of Mix.Config.eval!/2

### DIFF
--- a/lib/mix/test/fixtures/configs/nested_import.exs
+++ b/lib/mix/test/fixtures/configs/nested_import.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+Mix.Config.eval!(Path.join([__DIR__, "good_config.exs"]))
+:done

--- a/lib/mix/test/mix/config_test.exs
+++ b/lib/mix/test/mix/config_test.exs
@@ -107,6 +107,9 @@ defmodule Mix.ConfigTest do
              {[my_app: [key: :value]],
               [fixture_path("configs/good_config.exs"), fixture_path("configs/good_import.exs")]}
 
+    assert Mix.Config.eval!(fixture_path("configs/nested_import.exs")) ==
+             {[], [fixture_path("configs/nested_import.exs")]}
+
     assert_raise ArgumentError,
                  ~r"expected runtime config for app :sample to return keyword list",
                  fn -> Mix.Config.eval!(fixture_path("configs/bad_app.exs")) end


### PR DESCRIPTION
Previously, if a config file uses Mix.Config.eval!/2 then it would fail with the
following error:

 > ** (RuntimeError) could not set configuration via Mix.Config. This usually
 >  means you are trying to execute a configuration file directly instead of
 > using the proper command, such as mix loadconfig
 > code: assert Mix.Config.eval!(fixture_path("configs/nested_import.exs")) ==
 > stacktrace:
 >   (mix) lib/mix/config.ex:71: Mix.Config.raise_improper_use!/0
 >   (mix) lib/mix/config.ex:222: Mix.Config.eval!/2
 >   lib/mix/test/mix/config_test.exs:110: (test)