### PR TITLE
Clarify Application.get_env by illustrating a use case

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -404,9 +404,9 @@ defmodule Application do
 
   If the configuration parameter does not exist, the function returns the
   `default` value.
-  
+
   ## Examples 
-  
+
   `get_env/3` is commonly used to read the configuration of your OTP applications.
   Since Mix configurations are commonly used to configure applications, we will use
   this as a point of illustration. 

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -405,6 +405,8 @@ defmodule Application do
   If the configuration parameter does not exist, the function returns the
   `default` value.
   
+  ## Examples 
+  
   Within Elixir, get_env is commonly used to resolve configurations within an OTP application. Since Mix configurations are commonly used to generate an OTP application's environment in Elixir, we will use this as a point of illustration. 
 
   Consider a new application `my_otp_app`. `my_otp_app` contains a database engine which supports a pool of databases. The database engine needs to know the configuration for each of those databases, and that configuration is supplied by key-value pairs in environment of `my_otp_app`. 
@@ -431,6 +433,7 @@ defmodule Application do
     port: 20717
   ]
   ```
+
   """
   @spec get_env(app, key, value) :: value
   def get_env(app, key, default \\ nil) do

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -400,10 +400,26 @@ defmodule Application do
   end
 
   @doc """
-  Returns the value for `key` in `app`'s environment.
+  Returns the value for `key` in `app`'s environment. 
 
   If the configuration parameter does not exist, the function returns the
   `default` value.
+  
+  Within Elixir, get_env is commonly used to resolve configurations within an OTP application. Since Mix configurations are *commonly* used to generate an OTP application's environment in Elixir, we will use this as a point of illustration. 
+
+  Consider a new application `my_otp_app`. `my_otp_app` contains a database engine which supports a pool of databases. The database engine needs to know the configuration for each of those databases, and that configuration is supplied by key-value pairs in environment of `my_otp_app`. 
+ 
+  ```
+  config :my_otp_app, Databases.RepoOne,
+  # A database configuration. 
+   config :my_otp_app, Databases.RepoTwo,
+  # Another database configuration (for the same OTP app). 
+   config :my_otp_app, my_otp_apps_databases: [Databases.RepoOne, Databases.RepoTwo]
+  ```
+
+  Our database engine used by `my_otp_app` needs to know what databases exist, and what the database configurations are. The database engine can make a call to `get_env(:my_otp_app, :my_otp_apps_databases)` to retrieve the list of databases (specified by module names). Our database engine can then make function calls to each repository in the list i.e. with `Enum.map` in order to then call  `get_env(:my_otp_app, :Databases.RepoOne)` and `get_env(:my_otp_app, :Databases.RepoTwo)`, retrieving the configurations for each. 
+
+  So, by supplying our OTP application as the first parameter, and the keys to retrieve as the second parameter, to `Application.get_env`, and some `Enum.map` magic we can scope configuration both repositories used by the database engine for the OTP application.
   """
   @spec get_env(app, key, value) :: value
   def get_env(app, key, default \\ nil) do

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -405,21 +405,32 @@ defmodule Application do
   If the configuration parameter does not exist, the function returns the
   `default` value.
   
-  Within Elixir, get_env is commonly used to resolve configurations within an OTP application. Since Mix configurations are *commonly* used to generate an OTP application's environment in Elixir, we will use this as a point of illustration. 
+  Within Elixir, get_env is commonly used to resolve configurations within an OTP application. Since Mix configurations are commonly used to generate an OTP application's environment in Elixir, we will use this as a point of illustration. 
 
   Consider a new application `my_otp_app`. `my_otp_app` contains a database engine which supports a pool of databases. The database engine needs to know the configuration for each of those databases, and that configuration is supplied by key-value pairs in environment of `my_otp_app`. 
  
   ```
   config :my_otp_app, Databases.RepoOne,
   # A database configuration. 
+   ip: localhost 
+   port: 5433
    config :my_otp_app, Databases.RepoTwo,
-  # Another database configuration (for the same OTP app). 
+  # Another database configuration (for the same OTP app).
+   ip: localhost 
+   port: 20717
    config :my_otp_app, my_otp_apps_databases: [Databases.RepoOne, Databases.RepoTwo]
   ```
 
   Our database engine used by `my_otp_app` needs to know what databases exist, and what the database configurations are. The database engine can make a call to `get_env(:my_otp_app, :my_otp_apps_databases)` to retrieve the list of databases (specified by module names). Our database engine can then make function calls to each repository in the list i.e. with `Enum.map` in order to then call  `get_env(:my_otp_app, :Databases.RepoOne)` and `get_env(:my_otp_app, :Databases.RepoTwo)`, retrieving the configurations for each. 
 
-  So, by supplying our OTP application as the first parameter, and the keys to retrieve as the second parameter, to `Application.get_env`, and some `Enum.map` magic we can scope configuration both repositories used by the database engine for the OTP application.
+  So, by supplying our OTP application as the first parameter, and the keys to retrieve as the second parameter, to `Application.get_env`, and some `Enum.map` magic, we can scope configuration both repositories used by the database engine for the OTP application. A call `Application.get(:my_app, Databases.RepoTwo)` then returns...
+  
+  ```
+  [
+    ip:localhost,
+    port: 20717
+  ]
+  ```
   """
   @spec get_env(app, key, value) :: value
   def get_env(app, key, default \\ nil) do

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -407,7 +407,7 @@ defmodule Application do
   
   ## Examples 
   
-  Within Elixir, get_env is commonly used to resolve configurations within an OTP application. Since Mix configurations are commonly used to generate an OTP application's environment in Elixir, we will use this as a point of illustration. 
+  Within Elixir, `Application.get_env` is commonly used to resolve configurations within an OTP application. Since Mix configurations are commonly used to generate an OTP application's environment in Elixir, we will use this as a point of illustration. 
 
   Consider a new application `my_otp_app`. `my_otp_app` contains a database engine which supports a pool of databases. The database engine needs to know the configuration for each of those databases, and that configuration is supplied by key-value pairs in environment of `my_otp_app`. 
  

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -409,21 +409,21 @@ defmodule Application do
 
   `get_env/3` is commonly used to read the configuration of your OTP applications.
   Since Mix configurations are commonly used to configure applications, we will use
-  this as a point of illustration. 
+  this as a point of illustration.
 
   Consider a new application `:my_app`. `:my_app` contains a database engine which
   supports a pool of databases. The database engine needs to know the configuration for
   each of those databases, and that configuration is supplied by key-value pairs in
-  environment of `:my_app`. 
+  environment of `:my_app`.
 
       config :my_app, Databases.RepoOne,
-        # A database configuration. 
-        ip: localhost 
+        # A database configuration
+        ip: "localhost"
         port: 5433
 
       config :my_app, Databases.RepoTwo,
-        # Another database configuration (for the same OTP app).
-        ip: localhost 
+        # Another database configuration (for the same OTP app)
+        ip: "localhost"
         port: 20717
 
       config :my_app, my_app_databases: [Databases.RepoOne, Databases.RepoTwo]
@@ -433,7 +433,7 @@ defmodule Application do
   `get_env(:my_app, :my_app_databases)` to retrieve the list of databases (specified
   by module names). Our database engine can then traverse each repository in the
   list and then call `get_env(:my_app, Databases.RepoOne)` and so forth to retrieve
-  the configuration of each one. 
+  the configuration of each one.
 
   **Important:** if you are writing a library to be used by other developers,
   it is generally recommended to avoid the application environment, as the

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -400,40 +400,45 @@ defmodule Application do
   end
 
   @doc """
-  Returns the value for `key` in `app`'s environment. 
+  Returns the value for `key` in `app`'s environment.
 
   If the configuration parameter does not exist, the function returns the
   `default` value.
   
   ## Examples 
   
-  Within Elixir, `Application.get_env` is commonly used to resolve configurations within an OTP application. Since Mix configurations are commonly used to generate an OTP application's environment in Elixir, we will use this as a point of illustration. 
+  `get_env/3` is commonly used to read the configuration of your OTP applications.
+  Since Mix configurations are commonly used to configure applications, we will use
+  this as a point of illustration. 
 
-  Consider a new application `my_otp_app`. `my_otp_app` contains a database engine which supports a pool of databases. The database engine needs to know the configuration for each of those databases, and that configuration is supplied by key-value pairs in environment of `my_otp_app`. 
- 
-  ```
-  config :my_otp_app, Databases.RepoOne,
-  # A database configuration. 
-   ip: localhost 
-   port: 5433
-   config :my_otp_app, Databases.RepoTwo,
-  # Another database configuration (for the same OTP app).
-   ip: localhost 
-   port: 20717
-   config :my_otp_app, my_otp_apps_databases: [Databases.RepoOne, Databases.RepoTwo]
-  ```
+  Consider a new application `:my_app`. `:my_app` contains a database engine which
+  supports a pool of databases. The database engine needs to know the configuration for
+  each of those databases, and that configuration is supplied by key-value pairs in
+  environment of `:my_app`. 
 
-  Our database engine used by `my_otp_app` needs to know what databases exist, and what the database configurations are. The database engine can make a call to `get_env(:my_otp_app, :my_otp_apps_databases)` to retrieve the list of databases (specified by module names). Our database engine can then make function calls to each repository in the list i.e. with `Enum.map` in order to then call  `get_env(:my_otp_app, :Databases.RepoOne)` and `get_env(:my_otp_app, :Databases.RepoTwo)`, retrieving the configurations for each. 
+      config :my_app, Databases.RepoOne,
+        # A database configuration. 
+        ip: localhost 
+        port: 5433
 
-  So, by supplying our OTP application as the first parameter, and the keys to retrieve as the second parameter, to `Application.get_env`, and some `Enum.map` magic, we can scope configuration both repositories used by the database engine for the OTP application. A call `Application.get(:my_app, Databases.RepoTwo)` then returns...
-  
-  ```
-  [
-    ip:localhost,
-    port: 20717
-  ]
-  ```
+      config :my_app, Databases.RepoTwo,
+        # Another database configuration (for the same OTP app).
+        ip: localhost 
+        port: 20717
 
+      config :my_app, my_app_databases: [Databases.RepoOne, Databases.RepoTwo]
+
+  Our database engine used by `:my_app` needs to know what databases exist, and
+  what the database configurations are. The database engine can make a call to
+  `get_env(:my_app, :my_app_databases)` to retrieve the list of databases (specified
+  by module names). Our database engine can then traverse each repository in the
+  list and then call `get_env(:my_app, Databases.RepoOne)` and so forth to retrieve
+  the configuration of each one. 
+
+  **Important:** if you are writing a library to be used by other developers,
+  it is generally recommended to avoid the application environment, as the
+  application environment is effectively a global storage. For more information,
+  read our [library guidelines](/library-guidelines.html).
   """
   @spec get_env(app, key, value) :: value
   def get_env(app, key, default \\ nil) do


### PR DESCRIPTION
The documentation for Application.get_env is not newcomer friendly and can be considered one of the most important and granular functions to understand in the Elixir programming language. In particular, an inexperienced developer will find it difficult to understand from the documentation what is meant by the 'app', 'environment' and 'environment keys' without bouncing between different sources of information. It's then up to the inexperienced developer to make that (frankly quite difficult) connection. When we try to make elicit the concept of scoping in a Mix configuration file, and how that is laden on `Application.get_env`, and how `Application.get_env` is then used to acquire the various configurations for our application (which are conceptual leaps we need to make in turn), fundamental to Elixir, we can't do all of that in one place. That is, we can read our 'app' has an 'environment' and those environments have 'keys' (but which app, which environment, and which keys)? We can improve this by providing an example of Application.get_env!

Below I illustrate while this might seem obvious to experienced developers, this is not clear to inexperienced developers given the current standard of documentation. Consider the following example...

```config :my_app, App.RepoOne,
# Database configuration

config :my_app, App.RepoTwo,
# Database configuration`
```
How does our OTP application know the configuration for RepoOne without making a lookup for the module name RepoOne? To answer that question we need to understand how our Mix configuration attains its configuration. We are greeted with...

> Returns the value for key in app's environment. If the configuration parameter does not exist, the function returns the default value.

But if the `mix.exs` file for `:my_app` includes Ecto within `application`, so...

``` 
def application do
    [
      extra_applications: [:ecto],
    ]
  end
````

So our 'app' has an 'environment' and those environments have 'keys' (but in practice, which app, which environment, and which keys)? How do I know _how_ `Application.get_env` is utilized? We can know as experienced developers this is defined by Ecto, but as newcomers assuming no knowledge we are at a disjunction... Do calls to `Application.get_env` get made by the OTP app we are building, say `MyApp`, or `Ecto` itself? An experienced developer can answer calls are being made by Ecto but we are getting the configuration for `my_app` because Ecto considers the repo part of _your application_ and that's why calls are made there. 

But the non-experienced developer finds themselves in a situation where they are trying to understand how our config for `config.exs` is retrieved by calls to `Application.get_env`, but have no idea which application is being passed into the parameter (and why). This becomes utterly confusing to people trying to understand error messages raised by applications in related to configuration files, trying to figure out why they need to set the configuration as one atom `:my_app` than the other `:ecto`, as people don't have access to all of the information at face value (you have to look in multiple different sources and figure out by yourself how it comes together).

My suggestion (and contribution) is to strengthen understanding to newcomers by means of illustration, by explaining _how_ we can Application.get_env, but explain it so people can understand _how_ the flow of calls could work in a meaningful and accessible way. I feel this is a much-needed feature which will greatly clarify the usage of Application.get_env whether it's via Mix, via an implementing application, iex, or otherwise! 