### PR TITLE
Enable URI.encode_query/1 to encode list values

### DIFF
--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -22,10 +22,9 @@ defmodule URITest do
     assert URI.encode_query([{:foo, :bar}, {:baz, :quux}]) == "foo=bar&baz=quux"
     assert URI.encode_query([{"foo", "bar"}, {"baz", "quux"}]) == "foo=bar&baz=quux"
     assert URI.encode_query([{"foo z", :bar}]) == "foo+z=bar"
-
-    assert_raise ArgumentError, fn ->
-      URI.encode_query([{"foo", 'bar'}])
-    end
+    assert URI.encode_query([{:foo, [:bar, :baz]}]) == "foo%5B%5D=bar&foo%5B%5D=baz"
+    assert URI.encode_query([{:foo, [{:bar, :a}, {:baz, :b}]}]) == "foo%5Bbar%5D=a&foo%5Bbaz%5D=b"
+    assert URI.encode_query([{"foo", 'bar'}]) == "foo%5B%5D=98&foo%5B%5D=97&foo%5B%5D=114"
 
     assert_raise ArgumentError, fn ->
       URI.encode_query([{'foo', "bar"}])


### PR DESCRIPTION
This enables the URI.encode_query/1 function, to encode lists into url parameters. Since it's currently throwing argument errors, it's not possible to create URLs like this:

```
filter[id_in][]=1&filter[id_in][]=2&filter[id_in][]=3
```

This PR adds the following two possible cases:

```
iex> URI.encode_query(%{key: [:a, :list]})
"key%5B%5D=a&key%5B%5D=list"

iex> URI.encode_query(%{key: [{:foo, :a}, {:bar, :list}]})
"key%5Bfoo%5D=a&key%5Bbar%5D=list"
```