### PR TITLE
Allow to prune metadata while escaping

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2866,7 +2866,7 @@ defmodule Kernel do
           end
 
         try do
-          :elixir_quote.escape(value, false)
+          :elixir_quote.escape(value, :default, false)
         rescue
           ex in [ArgumentError] ->
             raise ArgumentError,
@@ -3789,7 +3789,7 @@ defmodule Kernel do
           quote(do: Kernel.LexicalTracker.read_cache(unquote(pid), unquote(integer)))
 
         %{} ->
-          {escaped, _} = :elixir_quote.escape(block, false)
+          {escaped, _} = :elixir_quote.escape(block, :default, false)
           escaped
       end
 
@@ -4063,8 +4063,8 @@ defmodule Kernel do
     module = assert_module_scope(env, kind, 2)
     assert_no_function_scope(env, kind, 2)
 
-    {escaped_call, unquoted_call} = :elixir_quote.escape(call, true)
-    {escaped_expr, unquoted_expr} = :elixir_quote.escape(expr, true)
+    {escaped_call, unquoted_call} = :elixir_quote.escape(call, :default, true)
+    {escaped_expr, unquoted_expr} = :elixir_quote.escape(expr, :default, true)
 
     escaped_expr =
       case unquoted_expr do

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -384,10 +384,10 @@ defmodule Macro do
       As an example, `ExUnit` stores the AST of every assertion, so when
       an assertion fails we can show code snippets to users. Without this
       option, each time the test module is compiled, we get a different
-      MD5 of the module byte code, because the AST contains metadata
-      specific, such as counters, specific the compilation environment.
-      By pruning the metadata, we ensure that the module is deterministic
-      and reduce the amount of data ExUnit needs to keep around.
+      MD5 of the module byte code, because the AST contains metadata,
+      such as counters, specific the compilation environment. By pruning
+      the metadata, we ensure that the module is deterministic and reduce
+      the amount of data `ExUnit` needs to keep around.
 
   ## Comparison to `Kernel.quote/2`
 

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -385,7 +385,7 @@ defmodule Macro do
       an assertion fails we can show code snippets to users. Without this
       option, each time the test module is compiled, we get a different
       MD5 of the module byte code, because the AST contains metadata,
-      such as counters, specific the compilation environment. By pruning
+      such as counters, specific to the compilation environment. By pruning
       the metadata, we ensure that the module is deterministic and reduce
       the amount of data `ExUnit` needs to keep around.
 

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -380,6 +380,14 @@ defmodule Macro do
       nodes. Note this option changes the semantics of escaped code and
       it should only be used when escaping ASTs, never values. Defaults
       to false.
+      
+      As an example, `ExUnit` stores the AST of every assertion, so when
+      an assertion fails we can show code snippets to users. Without this
+      option, each time the test module is compiled, we get a different
+      MD5 of the module byte code, because the AST contains metadata
+      specific, such as counters, specific the compilation environment.
+      By pruning the metadata, we ensure that the module is deterministic
+      and reduce the amount of data ExUnit needs to keep around.
 
   ## Comparison to `Kernel.quote/2`
 

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -356,12 +356,7 @@ defmodule Macro do
   def decompose_call(_), do: :error
 
   @doc """
-  Recursively escapes a value so it can be inserted
-  into a syntax tree.
-
-  One may pass `unquote: true` to `escape/2`
-  which leaves `unquote/1` statements unescaped, effectively
-  unquoting the contents on escape.
+  Recursively escapes a value so it can be inserted into a syntax tree.
 
   ## Examples
 
@@ -373,6 +368,18 @@ defmodule Macro do
 
       iex> Macro.escape({:unquote, [], [1]}, unquote: true)
       1
+
+  ## Options
+
+    * `:unquote` - when true, this function leaves `unquote/1` and
+      `unquote_splicing/1` statements unescaped, effectively unquoting
+      the contents on escape. This option is useful only when escaping
+      ASTs which may have quoted fragments in them. Defaults to false.
+
+    * `:prune_metadata` - when true, removes metadata from escaped AST
+      nodes. Note this option changes the semantics of escaped code and
+      it should only be used when escaping ASTs, never values. Defaults
+      to false.
 
   ## Comparison to `Kernel.quote/2`
 
@@ -402,7 +409,9 @@ defmodule Macro do
   """
   @spec escape(term, keyword) :: t()
   def escape(expr, opts \\ []) do
-    elem(:elixir_quote.escape(expr, Keyword.get(opts, :unquote, false)), 0)
+    unquote = Keyword.get(opts, :unquote, false)
+    kind = if Keyword.get(opts, :prune_metadata, false), do: :prune_metadata, else: :default
+    elem(:elixir_quote.escape(expr, kind, unquote), 0)
   end
 
   @doc """

--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -24,7 +24,6 @@
   imports_hygiene=true,
   unquote=true,
   unquoted=false,
-  escape=false,
   generated=false
 }).
 

--- a/lib/elixir/src/elixir_bootstrap.erl
+++ b/lib/elixir/src/elixir_bootstrap.erl
@@ -19,7 +19,7 @@
 'MACRO-defmacrop'(Caller, Call, Expr) -> define(Caller, defmacrop, Call, Expr).
 
 'MACRO-defmodule'(_Caller, Alias, [{do, Block}]) ->
-  {Escaped, _} = elixir_quote:escape(Block, false),
+  {Escaped, _} = elixir_quote:escape(Block, default, false),
   Args = [Alias, Escaped, [], env()],
   {{'.', [], [elixir_module, compile]}, [], Args}.
 
@@ -36,8 +36,8 @@
    {defp, 2}].
 
 define({Line, E}, Kind, Call, Expr) ->
-  {EscapedCall, UC} = elixir_quote:escape(Call, true),
-  {EscapedExpr, UE} = elixir_quote:escape(Expr, true),
+  {EscapedCall, UC} = elixir_quote:escape(Call, default, true),
+  {EscapedExpr, UE} = elixir_quote:escape(Expr, default, true),
   Args = [Kind, not(UC or UE), EscapedCall, EscapedExpr, elixir_locals:cache_env(E#{line := Line})],
   {{'.', [], [elixir_def, store_definition]}, [], Args}.
 

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -33,7 +33,8 @@ expand_struct(Meta, Left, {'%{}', MapMeta, MapArgs}, #{context := Context} = E) 
           Struct = load_struct(Meta, ELeft, [Assocs], InContext, EE),
           assert_struct_keys(Meta, ELeft, Struct, Assocs, EE),
           Keys = ['__struct__'] ++ [K || {K, _} <- Assocs],
-          {StructAssocs, _} = elixir_quote:escape(maps:to_list(maps:without(Keys, Struct)), false),
+          WithoutKeys = maps:to_list(maps:without(Keys, Struct)),
+          {StructAssocs, _} = elixir_quote:escape(WithoutKeys, default, false),
           {{'%', Meta, [ELeft, {'%{}', MapMeta, StructAssocs ++ Assocs}]}, EE};
 
         {_, _, Assocs} -> %% Update or match

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -317,7 +317,7 @@ defmodule ExUnit.Assertions do
   end
 
   defp escape_quoted(kind, expr) do
-    Macro.escape({kind, [], [expr]})
+    Macro.escape({kind, [], [expr]}, prune_metadata: true)
   end
 
   defp extract_args({root, meta, [_ | _] = args} = expr, env) do


### PR DESCRIPTION
We use this option in ExUnit as we are escaping
the code to eventually convert it to a string
representation and therefore the metadata is not
relevant.

Closes #7947.