### PR TITLE
Path docs improvement

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -30,9 +30,10 @@ defmodule Path do
 
   ### Windows
 
-      Path.absname("foo").
+      Path.absname("foo")
       #=> "D:/usr/local/foo"
-      Path.absname("../x").
+
+      Path.absname("../x")
       #=> "D:/usr/local/../x"
 
   """
@@ -171,9 +172,10 @@ defmodule Path do
       #=> "/quux/baz/foo/bar"
 
       Path.expand("foo/bar/../bar", "/baz")
-      "/baz/foo/bar"
+      #=> "/baz/foo/bar"
+
       Path.expand("/foo/bar/../bar", "/baz")
-      "/foo/bar"
+      #=> "/foo/bar"
 
   """
   @spec expand(t, t) :: binary


### PR DESCRIPTION
* fixed two example lines that ended with a dot
* made `expand/2` examples more consistent