### PR TITLE
Validate @on_load function in Elixir

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -276,8 +276,8 @@ defmodule Module do
 
   Accepts the function name (as an atom) of a function in the current module or
   `{function_name, 0}` tuple where `function_name` is the name of a function in
-  the current module. The function must have arity 0 (no arguments) and has to
-  return `:ok`, otherwise the loading of the module will be aborted. For
+  the current module. The function must have arity 0 (no arguments), public, and
+  has to return `:ok`, otherwise the loading of the module will be aborted. For
   example:
 
       defmodule MyModule do

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -276,9 +276,9 @@ defmodule Module do
 
   Accepts the function name (as an atom) of a function in the current module or
   `{function_name, 0}` tuple where `function_name` is the name of a function in
-  the current module. The function must have arity 0 (no arguments), public, and
-  has to return `:ok`, otherwise the loading of the module will be aborted. For
-  example:
+  the current module. The function must be public and have an arity of 0 (no
+  arguments). If the function does not return `:ok`, the loading of the module
+  will be aborted. For example:
 
       defmodule MyModule do
         @on_load :load_check

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -169,7 +169,6 @@ validate_on_load_attribute({on_load, Def}, Defs, File, Line) ->
   end;
 validate_on_load_attribute(false, _Defs, _File, _Line) -> ok.
 
-
 %% An undef error for a function in the module being compiled might result in an
 %% exception message suggesting the current module is not loaded. This is
 %% misleading so use a custom reason.

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -722,25 +722,28 @@ defmodule Kernel.ErrorsTest do
   test "@on_load attribute with undefined function" do
     assert_eval_raise CompileError,
                       "nofile:1: @on_load function foo/0 is undefined",
-                      'defmodule UndefinedOnLoadAttribute do @on_load :foo end'
+                      'defmodule UndefinedOnLoadFunction do @on_load :foo end'
   end
 
   test "wrong kind for @on_load attribute" do
-    # Capture warning: function foo/0 is unused
-    ExUnit.CaptureIO.capture_io(:stderr, fn ->
-      assert_eval_raise CompileError,
-                        "nofile:1: expected @on_load function foo/0 to be defined as \"def\", " <>
-                          "got \"defp\"",
-                        '''
-                        defmodule PrivateOnLoadAttribute do
-                          @on_load :foo
+    assert_eval_raise CompileError,
+                      "nofile:1: expected @on_load function foo/0 to be defined as \"def\", " <>
+                        "got \"defp\"",
+                      '''
+                      defmodule PrivateOnLoadFunction do
+                        @on_load :foo
 
-                          defp foo do
-                            :ok
-                          end
+
+                        defp foo do
+                          :ok
                         end
-                        '''
-    end)
+
+                        # To avoid warning: function foo/0 is unused
+                        def bar do
+                          foo()
+                        end
+                      end
+                      '''
   end
 
   test "interpolation error" do

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -719,6 +719,29 @@ defmodule Kernel.ErrorsTest do
     end
   end
 
+  test "@on_load attribute with undefined function" do
+    assert_eval_raise CompileError,
+                      "nofile:1: @on_load function foo/0 is undefined",
+                      'defmodule UndefinedOnLoadAttribute do @on_load :foo end'
+  end
+
+  test "@on_load attribute with private function" do
+    # Capture warning: function foo/0 is unused
+    ExUnit.CaptureIO.capture_io(:stderr, fn ->
+      assert_eval_raise CompileError,
+                        "nofile:1: @on_load function foo/0 cannot be private",
+                        '''
+                        defmodule PrivateOnLoadAttribute do
+                          @on_load :foo
+
+                          defp foo do
+                            :ok
+                          end
+                        end
+                        '''
+    end)
+  end
+
   test "interpolation error" do
     assert_eval_raise SyntaxError,
                       "nofile:1: unexpected token: ). The \"do\" at line 1 is missing terminator \"end\"",

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -725,11 +725,12 @@ defmodule Kernel.ErrorsTest do
                       'defmodule UndefinedOnLoadAttribute do @on_load :foo end'
   end
 
-  test "@on_load attribute with private function" do
+  test "wrong kind for @on_load attribute" do
     # Capture warning: function foo/0 is unused
     ExUnit.CaptureIO.capture_io(:stderr, fn ->
       assert_eval_raise CompileError,
-                        "nofile:1: @on_load function foo/0 cannot be private",
+                        "nofile:1: expected @on_load function foo/0 to be defined as \"def\", " <>
+                          "got \"defp\"",
                         '''
                         defmodule PrivateOnLoadAttribute do
                           @on_load :foo


### PR DESCRIPTION
This is an attempt to implement the check from #5800: `{undefined_on_load,{F,A}}`: function for `on_load` undefined.

These are my first steps with Erlang 🎉 , any feedback is more than appreciated :) 

During the development of this PR, I had some doubts regarding the visibility of the `@on_load` function. According to the [Erlang's documentation](http://erlang.org/doc/reference_manual/code_loading.html#on_load), "It is not necessary to export the function". (I'm currently learning the Elixir internals and what I'm about to say might not make sense, so please be bear with me 😅) I would think that public functions map to exported functions, and private functions to non-exported functions. If that's the case, this should work (as the function does not need to be public/exported):

```elixir
defmodule Example
  @on_load :foo

  defp foo do
    IO.puts("HELLO")
    :ok
  end
end
```

However, when executing the code, this error is returned:

```
warning: function foo/0 is unused
  lib/test.ex:4

** (CompileError) lib/test.ex:1: function foo/0 undefined
    (stdlib) lists.erl:1338: :lists.foreach/2
    (stdlib) erl_eval.erl:677: :erl_eval.do_apply/6
```

I wasn't sure if this was an expected behavior. I've assumed the current implementation was right, and this PR will make the compiler raise a `CompileError` is the function used in `@on_load` is private. I've also updated the documentation to reflect the visibility of the `on_load` function. 
