### PR TITLE
Update Process.info spec to reflect the possible nil return value

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -739,7 +739,7 @@ defmodule Process do
 
   See `:erlang.process_info/1` for more info.
   """
-  @spec info(pid) :: keyword
+  @spec info(pid) :: keyword | nil
   def info(pid) do
     nillify(:erlang.process_info(pid))
   end


### PR DESCRIPTION
Process.info returns nil if the process is no longer alive, however the @spec for it did not reflect that possible return value .

This causes dialyzer to throw errors if you check for the nil return value.

This pull request updates the @spec for Process.info to allow for the nil return value.

Tests passed. No doc changes necessary as it already said it could return nil.