### PR TITLE
Optimize ISO-8601 Parsing

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -525,6 +525,24 @@ defmodule DateTime do
         not calendar.valid_time?(hour, minute, second, microsecond) ->
           {:error, :invalid_time}
 
+        offset == 0 ->
+          datetime = %DateTime{
+            calendar: calendar,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute,
+            second: second,
+            microsecond: microsecond,
+            std_offset: 0,
+            utc_offset: 0,
+            zone_abbr: "UTC",
+            time_zone: "Etc/UTC"
+          }
+
+          {:ok, datetime, 0}
+
         is_nil(offset) ->
           {:error, :missing_offset}
 

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -171,10 +171,35 @@ defmodule NaiveDateTime do
           Calendar.microsecond(),
           Calendar.calendar()
         ) :: {:ok, t} | {:error, atom}
-  def new(year, month, day, hour, minute, second, microsecond \\ {0, 0}, calendar \\ Calendar.ISO) do
-    with {:ok, date} <- Date.new(year, month, day, calendar),
-         {:ok, time} <- Time.new(hour, minute, second, microsecond, calendar),
-         do: new(date, time)
+  def new(year, month, day, hour, minute, second, microsecond \\ {0, 0}, calendar \\ Calendar.ISO)
+
+  def new(year, month, day, hour, minute, second, microsecond, calendar)
+      when is_integer(microsecond) do
+    new(year, month, day, hour, minute, second, {microsecond, 6}, calendar)
+  end
+
+  def new(year, month, day, hour, minute, second, microsecond, calendar) do
+    cond do
+      not calendar.valid_date?(year, month, day) ->
+        {:error, :invalid_date}
+
+      not calendar.valid_time?(hour, minute, second, microsecond) ->
+        {:error, :invalid_time}
+
+      true ->
+        naive_datetime = %NaiveDateTime{
+          calendar: calendar,
+          year: year,
+          month: month,
+          day: day,
+          hour: hour,
+          minute: minute,
+          second: second,
+          microsecond: microsecond
+        }
+
+        {:ok, naive_datetime}
+    end
   end
 
   @doc """


### PR DESCRIPTION
This PR builds on the optimizations recently committed to the v1.7 branch: https://github.com/elixir-lang/elixir/commit/04c45b031a8e766969b865015b7ba5c1b4ba04d7. I found it to be cheaper to apply the TZ offset directly to the calendar date than to go through the conversions to and from ISO days. Since TZ offsets are no more than 24 hours, we avoid a lot of the complication of counting leap days over a range of years that's handled by doing calendar math in ISO days. At most, we have to carry over +/- 1 day. I added tests for carrying over month and year boundaries and to and from leap days to verify that the date carrying logic is correct.

Note that `calendar.valid_date?` and `calendar.valid_time?` are handled inside the `Date.new/4` and `Time.new/5` constructors and produce the same error messages.

The results look like this (measured on an AMD TR 1950X):

![iso8601-speedup](https://user-images.githubusercontent.com/138065/43206324-ae7d389e-8fe2-11e8-8936-146fa0c77734.png)

* Dark green = Elixir 1.6.6
* Medium green = Elixir v1.7 HEAD
* Light green = This PR

The scale on the left is microseconds.