### PR TITLE
Improve compile_doc warning

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1347,7 +1347,8 @@ defmodule Module do
           message =
             "redefining @doc attribute previously set at line #{current_line}. " <>
               "If you want to redefine a previously specified doc, " <>
-              "use a definition without a body after the original documentation"
+              "use a definition without a body after the original documentation\n" <>
+              "Example for definition without a body: def foo(a, b)\n"
 
           :elixir_errors.warn(line, env.file, message)
         end


### PR DESCRIPTION
`definition without a body` in the warning confused me when I upgraded 1.7.0 for my pheonix project.

I found in other documents, it is called `function head` or `header`.

For example:

1. https://github.com/elixir-lang/elixir/blob/691460a6e661f174476c69153776cba2f8a47341/lib/elixir/src/elixir_def.erl#L412-L426

2. https://github.com/elixir-lang/elixir/blob/caa90b563ade4818a4e49b3e20149a44ff0c00c8/lib/elixir/pages/Writing%20Documentation.md#function-arguments

Or else, is it better to add an example in the warning? Like `def foo(a, b)`