### PR TITLE
build: allow downstream packagers to tweak manpage generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PREFIX ?= /usr/local
 SHARE_PREFIX ?= $(PREFIX)/share
+MAN_PREFIX ?= $(SHARE_PREFIX)/man
 CANONICAL := master/ # master/ or vMAJOR.MINOR/
 ELIXIRC := bin/elixirc --verbose --ignore-module-conflict
 ERLC := erlc -I lib/elixir/include
@@ -279,9 +280,9 @@ clean_man:
 	rm -f man/iex.1.bak
 
 install_man: build_man
-	$(Q) mkdir -p $(DESTDIR)$(SHARE_PREFIX)/man/man1
-	$(Q) $(INSTALL_DATA) man/elixir.1  $(DESTDIR)$(SHARE_PREFIX)/man/man1
-	$(Q) $(INSTALL_DATA) man/elixirc.1 $(DESTDIR)$(SHARE_PREFIX)/man/man1
-	$(Q) $(INSTALL_DATA) man/iex.1     $(DESTDIR)$(SHARE_PREFIX)/man/man1
-	$(Q) $(INSTALL_DATA) man/mix.1     $(DESTDIR)$(SHARE_PREFIX)/man/man1
+	$(Q) mkdir -p $(DESTDIR)$(MAN_PREFIX)/man1
+	$(Q) $(INSTALL_DATA) man/elixir.1  $(DESTDIR)$(MAN_PREFIX)/man1
+	$(Q) $(INSTALL_DATA) man/elixirc.1 $(DESTDIR)$(MAN_PREFIX)/man1
+	$(Q) $(INSTALL_DATA) man/iex.1     $(DESTDIR)$(MAN_PREFIX)/man1
+	$(Q) $(INSTALL_DATA) man/mix.1     $(DESTDIR)$(MAN_PREFIX)/man1
 	$(MAKE) clean_man


### PR DESCRIPTION
downstream packagers such as FreeBSD support building and shipping binary-style packages with or without manpages enabled, or in different locations, in addition to setting `PREFIX` or `SHARE_PREFIX`
directly.

This simple patch allows them to do so by setting `MAN_PREFIX` and Make will Do The Right Thing.

It should have no impact on users not using this feature, as the default config will fall through to the current value.