### PR TITLE
Change the documentation for defdelegate from :lists to Enum

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4964,8 +4964,8 @@ defmodule Kernel do
   ## Examples
 
       defmodule MyList do
-        defdelegate reverse(list), to: :lists
-        defdelegate other_reverse(list), to: :lists, as: :reverse
+        defdelegate reverse(list), to: Enum
+        defdelegate other_reverse(list), to: Enum, as: :reverse
       end
 
       MyList.reverse([1, 2, 3])


### PR DESCRIPTION
The current docs for `defdelegate` use  the erlang `:lists` module as an example. At least for a sample size of myself, this proved to be extremely confusing. I assumed that there was an __elixir__ module named `Lists`, and was then surprised to see that `Lists.reverse/1` (or the Lists module in general) does not exist.

This PR simplifies the docs to use `Enum.reverse/1` as the defdelegate target