### PR TITLE
Talk about the new announcement mailing list

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -3,6 +3,7 @@
 * Do not use the issues tracker for help or support (try Elixir Forum, Stack Overflow, IRC, etc.)
 * For proposing a new feature, please start a discussion on the Elixir Core mailing list
 * For bugs, do a quick search and make sure the bug has not yet been reported
+* Please disclose security vulnerabilities privately at elixir-security@googlegroups.com
 * Finally, be nice and have fun!
 
 ### Environment
@@ -16,3 +17,4 @@ Include code samples, errors and stacktraces if appropriate.
 
 ### Expected behavior
 
+A short description on how you expect the code to behave.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,15 @@
 [![Travis build](https://secure.travis-ci.org/elixir-lang/elixir.svg?branch=master
 "Build Status")](https://travis-ci.org/elixir-lang/elixir)
 
-Elixir is a dynamic, functional language designed for building scalable and maintainable applications.
+Elixir is a dynamic, functional language designed for building scalable
+and maintainable applications.
 
 For more about Elixir, installation and documentation,
 [check Elixir's website](http://elixir-lang.org/).
+
+## Announcements
+
+New releases are announced in the [announcements mailing list](https://groups.google.com/group/elixir-lang-ann). All security releases [will be tagged with `[security]`](https://groups.google.com/forum/#!searchin/elixir-lang-ann/%5Bsecurity%5D%7Csort:date).
 
 ## Compiling from source
 
@@ -41,8 +46,8 @@ you may want to open up a bug report, as explained next.
 ## Bug reports
 
 For reporting bugs, [visit our issues tracker][2] and follow the steps
-for reporting a new issue. Please disclose security vulnerabilities
-privately at elixir-security@googlegroups.com.
+for reporting a new issue. **Please disclose security vulnerabilities
+privately at elixir-security@googlegroups.com**.
 
 ## Proposing new features
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,7 +22,7 @@
 
 10. Add the release to `elixir.csv` and `_data/elixir-versions.yml` files in `elixir-lang/elixir-lang.github.com`
 
-11. Send an e-mail to elixir-lang-ann@googlegroups.com with title "Elixir vVERSION released" with a link to the GitHub Releases page. If it is a security release, include `[security]` in the title
+11. Send an e-mail to elixir-lang-ann@googlegroups.com with title "Elixir vVERSION released". The body should be a link to the Release page on GitHub. If it is a security release, prefix the title with the `[security]` tag
 
 ## Creating a new vMAJOR.MINOR branch
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,6 +22,8 @@
 
 10. Add the release to `elixir.csv` and `_data/elixir-versions.yml` files in `elixir-lang/elixir-lang.github.com`
 
+11. Send an e-mail to elixir-lang-ann@googlegroups.com with title "Elixir vVERSION released" with a link to the GitHub Releases page. If it is a security release, include `[security]` in the title
+
 ## Creating a new vMAJOR.MINOR branch
 
 ### In the new branch

--- a/lib/elixir/pages/Compatibility and Deprecations.md
+++ b/lib/elixir/pages/Compatibility and Deprecations.md
@@ -14,7 +14,9 @@ Elixir version | Support
 1.4            | Security patches only
 1.3            | Security patches only
 
-Major Elixir releases may contain breaking changes and those will be explicitly outlined in the CHANGELOG. There are currently no plans for a major v2 release.
+New releases are announced in the read-only [announcements mailing list](https://groups.google.com/group/elixir-lang-ann). All security releases [will be tagged with `[security]`](https://groups.google.com/forum/#!searchin/elixir-lang-ann/%5Bsecurity%5D%7Csort:date).
+
+There are currently no plans for a major v2 release.
 
 ## Compatibility between non-major Elixir versions
 


### PR DESCRIPTION
Promote the new announcements mailing list and how to retrieve
all security releases. Also promote the security disclosure link
more openly.