### PR TITLE
Improve wording in String doc

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1145,7 +1145,7 @@ defmodule String do
   When `count` is less than or equal to the length of `string`,
   given `string` is returned.
 
-  Raises `ArgumentError` if the given `padding` contains non-string element.
+  Raises `ArgumentError` if the given `padding` contains a non-string element.
 
   ## Examples
 
@@ -1187,7 +1187,7 @@ defmodule String do
   When `count` is less than or equal to the length of `string`,
   given `string` is returned.
 
-  Raises `ArgumentError` if the given `padding` contains non-string element.
+  Raises `ArgumentError` if the given `padding` contains a non-string element.
 
   ## Examples
 


### PR DESCRIPTION
Hey all,

this adds an article to `String.pad_leading/3` and `String.pad_trailing/3` `@doc`s:

`…contains non-string element` → `…contains a non-string element`.

Thanks for v1.7, keep rocking, cheers!