### PR TITLE
Fix formatting in docs for access.ex

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -118,9 +118,9 @@ defmodule Access do
 
   For example, to update a map inside another map:
 
-     iex> users = %{"john" => %{age: 27}, "meg" => %{age: 23}}
-     iex> put_in(users["john"].age, 28)
-     %{"john" => %{age: 28}, "meg" => %{age: 23}}
+      iex> users = %{"john" => %{age: 27}, "meg" => %{age: 23}}
+      iex> put_in(users["john"].age, 28)
+      %{"john" => %{age: 28}, "meg" => %{age: 23}}
 
   This module provides convenience functions for traversing other
   structures, like tuples and lists. These functions can be used


### PR DESCRIPTION
The code block was rendering as regular text because it needs one more
space to be considered code.