### PR TITLE
Fix warning for unused var in Module

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1331,7 +1331,7 @@ defmodule Module do
     end
   end
 
-  defp compile_doc(table, line, kind, name, arity, args, body, doc, doc_meta, env, impl) do
+  defp compile_doc(table, line, kind, name, arity, args, _body, doc, doc_meta, env, impl) do
     key = {doc_key(kind), name, arity}
     signature = build_signature(args, env)
 


### PR DESCRIPTION
Fixes:

```
==> elixir (compile)
warning: variable "body" is unused
  lib/module.ex:1334
```