### PR TITLE
Registry: Associate value to process using via tuple

### DIFF
--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -36,6 +36,22 @@ defmodule Registry do
       Agent.get(name, & &1)
       #=> 1
 
+  In the previous example, we were not interested in associating a value to the
+  process:
+
+      Registry.lookup(Registry.ViaTest, "agent")
+      #=> [{self(), nil}]
+
+  However, in some cases it may be desired to associate a value to the process
+  using the alternate `{:via, Registry, {registry, key, value}}` tuple:
+
+      {:ok, _} = Registry.start_link(keys: :unique, name: Registry.ViaTest)
+      name = {:via, Registry, {Registry.ViaTest, "agent", :hello}}
+      {:ok, _} = Agent.start_link(fn -> 0 end, name: name)
+      Registry.lookup(Registry.ViaTest, "agent")
+      #=> [{self(), :hello}]
+
+  To this point, we have been starting `Registry` using `start_link/1`.
   Typically the registry is started as part of a supervision tree though:
 
       {Registry, keys: :unique, name: Registry.ViaTest}
@@ -210,9 +226,21 @@ defmodule Registry do
   end
 
   @doc false
+  @doc since: "1.x.x"
+  def whereis_name({registry, key, _value}) do
+    whereis_name({registry, key})
+  end
+
+  @doc false
   @doc since: "1.4.0"
-  def register_name({registry, key}, pid) when pid == self() do
-    case register(registry, key, nil) do
+  def register_name({registry, key}, pid) do
+    register_name({registry, key, nil}, pid)
+  end
+
+  @doc false
+  @doc since: "1.x.x"
+  def register_name({registry, key, value}, pid) when pid == self() do
+    case register(registry, key, value) do
       {:ok, _} -> :yes
       {:error, _} -> :no
     end

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -207,7 +207,10 @@ defmodule Registry do
 
   @doc false
   @doc since: "1.4.0"
-  def whereis_name({registry, key}) do
+  def whereis_name({registry, key}), do: whereis_name(registry, key)
+  def whereis_name({registry, key, _value}), do: whereis_name(registry, key)
+
+  defp whereis_name(registry, key) do
     case key_info!(registry) do
       {:unique, partitions, key_ets} ->
         key_ets = key_ets || key_ets!(registry, key, partitions)
@@ -226,20 +229,11 @@ defmodule Registry do
   end
 
   @doc false
-  @doc since: "1.x.x"
-  def whereis_name({registry, key, _value}) do
-    whereis_name({registry, key})
-  end
-
-  @doc false
   @doc since: "1.4.0"
-  def register_name({registry, key}, pid) do
-    register_name({registry, key, nil}, pid)
-  end
+  def register_name({registry, key}, pid), do: register_name(registry, key, nil, pid)
+  def register_name({registry, key, value}, pid), do: register_name(registry, key, value, pid)
 
-  @doc false
-  @doc since: "1.x.x"
-  def register_name({registry, key, value}, pid) when pid == self() do
+  defp register_name(registry, key, value, pid) when pid == self() do
     case register(registry, key, value) do
       {:ok, _} -> :yes
       {:error, _} -> :no

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -255,6 +255,12 @@ defmodule RegistryTest do
         # errors
         assert {:error, {:already_started, ^pid}} = Agent.start(fn -> 0 end, name: name)
       end
+
+      test "uses value provided in via", %{registry: registry} do
+        name = {:via, Registry, {registry, "hello", :value}}
+        {:ok, pid} = Agent.start_link(fn -> 0 end, name: name)
+        assert Registry.lookup(registry, "hello") == [{pid, :value}]
+      end
     end
   end
 


### PR DESCRIPTION
When using Registry with `:via` tuples, in some cases it may be desired to associate a value to the process at the same time.  Currently this is not possible, resulting in a value of `nil` unless you call `Registry.update_value` as an additional step after the process has started.

This PR introduces an additional `:via` tuple element for the value to be associated with the process (while retaining the existing behavior, of course):

      {:ok, _} = Registry.start_link(keys: :unique, name: Registry.ViaTest)
      name = {:via, Registry, {Registry.ViaTest, "agent", :hello}}
      {:ok, _} = Agent.start_link(fn -> 0 end, name: name)
      Registry.lookup(Registry.ViaTest, "agent")
      #=> [{self(), :hello}]

Thoughts?