### PR TITLE
Fix errors with ref/4 IEx helper

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -1210,16 +1210,26 @@ defmodule IEx.Helpers do
     :erlang.list_to_ref('#Ref<#{string}>')
   end
 
+  @doc """
+  Creates a Reference with 4 non-negative integers passed as arguments
+  to the function.
+
+  ## Examples
+
+      iex> ref(0, 21, 32, 43)
+      #Reference<0.21.32.43>
+
+  """
   @doc since: "1.6.0"
   def ref(w, x, y, z)
       when is_integer(w) and w >= 0 and is_integer(x) and x >= 0 and is_integer(y) and y >= 0 and
              is_integer(z) and z >= 0 do
     :erlang.list_to_ref(
-      '<' ++
+      '#Ref<' ++
         Integer.to_charlist(w) ++
         '.' ++
         Integer.to_charlist(x) ++
-        '.' ++ '.' ++ Integer.to_charlist(y) ++ '.' ++ '.' ++ Integer.to_charlist(z) ++ '.' ++ '>'
+        '.' ++ Integer.to_charlist(y) ++ '.' ++ Integer.to_charlist(z) ++ '>'
     )
   end
 


### PR DESCRIPTION
In addition, I've included the documentation for that function.

Before:

```
$ iex
Erlang/OTP 21 [erts-10.0.4] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe] [dtrace]

Interactive Elixir (1.7.0) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> make_ref
#Reference<0.2597424430.1465122823.223385>
iex(2)> ref("0.2597424430.1465122823.1")
#Reference<0.2597424430.1465122823.1>
iex(3)> ref(0, 2597424430, 1465122823, 1)
** (ArgumentError) argument error
    :erlang.list_to_ref('<0.2597424430..1465122823..1.>')
    (iex) lib/iex/helpers.ex:1220: IEx.Helpers.ref/4
iex(3)>
```

After:

```
$ bin/iex
Erlang/OTP 21 [erts-10.0.4] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe] [dtrace]

Interactive Elixir (1.8.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> ref("0.2597424430.1465122823.1")
#Reference<0.2597424430.1465122823.1>
iex(2)> ref(0, 2597424430, 1465122823, 1)
#Reference<0.2597424430.1465122823.1>
iex(3)>
```