### PR TITLE
insert_tail: shortcut common inputs to List.insert_at/3 for performance

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -543,11 +543,20 @@ defmodule List do
 
   """
   @spec insert_at(list, integer, any) :: list
-  def insert_at(list, index, value) when is_integer(index) do
-    if index < 0 do
-      do_insert_at(list, length(list) + index + 1, value)
-    else
-      do_insert_at(list, index, value)
+  def insert_at(list, index, value)
+      when is_integer(index) and is_list(list) do
+    cond do
+      index == -1 ->
+        list ++ [value]
+
+      index == 0 ->
+        [value | list]
+
+      index > 0 ->
+        do_insert_at(list, index, value)
+
+      index < 0 ->
+        do_insert_at(list, length(list) + index + 1, value)
     end
   end
 


### PR DESCRIPTION
The main idea is to skip length(list) computation when adding to the tail.
Two possible incompatibilities however:
* Added `is_list/1` guard so some inputs will now `FunctionClauseError`
* Not computing `length(list)` on index `-1` implies that this call
  no longer ensures input list is a proper list

Micro benchmark code & results can be seen at:
* code: https://github.com/fenollp/benchees/blob/a84b7db544f21a2359c3892e56d8cc36800e56b2/lib/insert_tail.exs
* results: https://circleci.com/gh/fenollp/benchees/3
Comparison:
append            65.75
insert_at         16.72 - 3.93x slower