### PR TITLE
Improve performance of File.exists?/1

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -120,15 +120,21 @@ defmodule File do
   This function follows symbolic links, so if a symbolic link points to a
   regular file, `true` is returned.
 
+  ## Options
+
+   - The list of options currently supports a single option, the atom `:raw`,
+     which bypasses the file server and only checks for the file locally.
+
   ## Examples
 
       File.regular?(__ENV__.file)
       #=> true
 
   """
-  @spec regular?(Path.t()) :: boolean
-  def regular?(path) do
-    :elixir_utils.read_file_type(IO.chardata_to_string(path)) == {:ok, :regular}
+  @spec regular?(Path.t(), [regular_option]) :: boolean
+        when regular_option: :raw
+  def regular?(path, opts \\ []) do
+    :elixir_utils.read_file_type(IO.chardata_to_string(path), opts) == {:ok, :regular}
   end
 
   @doc """
@@ -136,6 +142,11 @@ defmodule File do
 
   This function follows symbolic links, so if a symbolic link points to a
   directory, `true` is returned.
+
+  ## Options
+
+   - The list of options currently supports a single option, the atom `:raw`,
+     which bypasses the file server and only checks for the directory locally.
 
   ## Examples
 
@@ -155,9 +166,10 @@ defmodule File do
       #=> true
 
   """
-  @spec dir?(Path.t()) :: boolean
-  def dir?(path) do
-    :elixir_utils.read_file_type(IO.chardata_to_string(path)) == {:ok, :directory}
+  @spec dir?(Path.t(), [dir_option]) :: boolean
+        when dir_option: :raw
+  def dir?(path, opts \\ []) do
+    :elixir_utils.read_file_type(IO.chardata_to_string(path), opts) == {:ok, :directory}
   end
 
   @doc """

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -122,8 +122,10 @@ defmodule File do
 
   ## Options
 
-   - The list of options currently supports a single option, the atom `:raw`,
-     which bypasses the file server and only checks for the file locally.
+  The supported options are:
+
+    * `:raw` - a single atom to bypass the file server and only check
+      for the file locally
 
   ## Examples
 
@@ -145,8 +147,10 @@ defmodule File do
 
   ## Options
 
-   - The list of options currently supports a single option, the atom `:raw`,
-     which bypasses the file server and only checks for the directory locally.
+  The supported options are:
+
+    * `:raw` - a single atom to bypass the file server and only check
+      for the file locally
 
   ## Examples
 
@@ -180,8 +184,10 @@ defmodule File do
 
   ## Options
 
-   - The list of options currently supports a single option, the atom `:raw`,
-     which bypasses the file server and only checks for the file locally.
+  The supported options are:
+
+    * `:raw` - a single atom to bypass the file server and only check
+      for the file locally
 
   ## Examples
 

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -166,6 +166,11 @@ defmodule File do
   It can be regular file, directory, socket, symbolic link, named pipe or device file.
   Returns `false` for symbolic links pointing to non-existing targets.
 
+  ## Options
+
+   - The list of options currently supports a single option, the atom `:raw`,
+     which bypasses the file server and only checks for the file locally.
+
   ## Examples
 
       File.exists?("test/")
@@ -178,9 +183,11 @@ defmodule File do
       #=> true
 
   """
-  @spec exists?(Path.t()) :: boolean
-  def exists?(path) do
-    match?({:ok, _}, :file.read_file_info(IO.chardata_to_string(path)))
+  @spec exists?(Path.t(), [exists_option]) :: boolean
+        when exists_option: :raw
+  def exists?(path, opts \\ []) do
+    opts = [{:time, :posix}] ++ opts
+    match?({:ok, _}, :file.read_file_info(IO.chardata_to_string(path), opts))
   end
 
   @doc """

--- a/lib/elixir/src/elixir_utils.erl
+++ b/lib/elixir/src/elixir_utils.erl
@@ -4,7 +4,7 @@
 -export([get_line/1, split_last/1, noop/0,
   characters_to_list/1, characters_to_binary/1, relative_to_cwd/1,
   macro_name/1, returns_boolean/1, caller/4, meta_keep/1,
-  read_file_type/1, read_link_type/1, read_posix_mtime_and_size/1,
+  read_file_type/1, read_file_type/2, read_link_type/1, read_posix_mtime_and_size/1,
   change_posix_time/2, change_universal_time/2,
   guard_op/2, match_op/2, extract_splat_guards/1, extract_guards/1,
   erlang_comparison_op_to_elixir/1]).
@@ -71,7 +71,11 @@ split_last([H], Acc)     -> {lists:reverse(Acc), H};
 split_last([H | T], Acc) -> split_last(T, [H | Acc]).
 
 read_file_type(File) ->
-  case file:read_file_info(File) of
+  read_file_type(File, []).
+
+read_file_type(File, Opts) ->
+  Opts1 = [{time, posix} | Opts],
+  case file:read_file_info(File, Opts1) of
     {ok, #file_info{type=Type}} -> {ok, Type};
     {error, _} = Error -> Error
   end.

--- a/lib/elixir/src/elixir_utils.erl
+++ b/lib/elixir/src/elixir_utils.erl
@@ -74,8 +74,7 @@ read_file_type(File) ->
   read_file_type(File, []).
 
 read_file_type(File, Opts) ->
-  Opts1 = [{time, posix} | Opts],
-  case file:read_file_info(File, Opts1) of
+  case file:read_file_info(File, [{time, posix} | Opts]) of
     {ok, #file_info{type=Type}} -> {ok, Type};
     {error, _} = Error -> Error
   end.


### PR DESCRIPTION
I've hit a situation where I need to call `File.exists?/1` in the inner loop of a bulk text processing application.

The erlang docs for [file:read_file_info/2](http://erlang.org/doc/man/file.html#read_file_info-2) suggest two optimizations that can speed up calls to this function:

> If the option raw is set, the file server is not called and only information about local files is returned. Note that this will break this module's atomicity guarantees as it can race with a concurrent call to write_file_info/1,2

> As file times are stored in POSIX time on most OS, it is faster to query file information with option posix.

I noticed a significant speedup when calling `read_file_info/2` with these options.
I'm not sure what are the implications of "only information about local files is returned", so maybe that would be a breaking change to `File.exists?/1`.