### PR TITLE
Add Keyword.fetch/3

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -367,6 +367,30 @@ defmodule Keyword do
   end
 
   @doc """
+  Fetches the value for a specific `key` and returns it in a tuple.
+
+  If the `key` does not exist, returns `{:error, error_message}` where error_message
+  is any value provided to fetch/3. Keyword.fetch/3 can be used as an alternative to
+  Keyword.fetch/2 in more involved pipelined operations where a specific error message
+  should be propogated up.
+
+  ## Examples
+
+      iex> Keyword.fetch([a: 1], :a, "this will not be returned")
+      {:ok, 1}
+      iex> Keyword.fetch([a: 1], :b, ":b is not available")
+      {:error, ":b is not available"}
+
+  """
+  @spec fetch(t, key, any) :: {:ok, value} | {:error, any}
+  def fetch(keywords, key, error_message) when is_list(keywords) and is_atom(key) do
+    case :lists.keyfind(key, 1, keywords) do
+      {^key, value} -> {:ok, value}
+      false -> {:error, error_message}
+    end
+  end
+
+  @doc """
   Fetches the value for specific `key`.
 
   If `key` does not exist, a `KeyError` is raised.

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -161,7 +161,15 @@ defmodule MapTest do
 
   test "implements (almost) all functions in Keyword" do
     assert Keyword.__info__(:functions) -- Map.__info__(:functions) ==
-             [delete: 3, delete_first: 2, get_values: 2, keyword?: 1, pop_first: 2, pop_first: 3]
+             [
+               delete: 3,
+               delete_first: 2,
+               fetch: 3,
+               get_values: 2,
+               keyword?: 1,
+               pop_first: 2,
+               pop_first: 3
+             ]
   end
 
   test "variable keys" do


### PR DESCRIPTION
In more involved pipelined operations, matches or with
statements, it is useful to have Keyword.fetch have an
option to return a specific value as part of the error
tuple like `{:error, values}` instead of just `:error`.