### PR TITLE
Reconsolidate protocols if stale local deps change

### DIFF
--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -136,7 +136,6 @@ defmodule Mix.Tasks.Compile.ElixirTest do
         "warning: mtime (modified time) for \"lib/b.ex\" was set to the future, resetting to now"
 
       refute_received {:mix_shell, :error, [^message]}
-
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
       refute_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
 


### PR DESCRIPTION
Prior to this commit, a protocol change in a path
dependency would only be reconcolidated if there at
least a runtime change associated to it. This commit
makes it so changes in local deps always triggers
a potential reconsolidation.

Closes #5987