### PR TITLE
Fix year in negative datetimes with offset

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -513,30 +513,28 @@ defmodule DateTime do
   @doc since: "1.4.0"
   @spec from_iso8601(String.t(), Calendar.calendar()) ::
           {:ok, t, Calendar.utc_offset()} | {:error, atom}
-
   def from_iso8601(string, calendar \\ Calendar.ISO)
 
   def from_iso8601(<<?-, rest::binary>>, calendar) do
-    with {:ok, %{year: year} = datetime, offset} <- raw_from_iso8601(rest, calendar) do
-      {:ok, %{datetime | year: -year}, offset}
-    end
+    raw_from_iso8601(rest, calendar, true)
   end
 
   def from_iso8601(<<rest::binary>>, calendar) do
-    raw_from_iso8601(rest, calendar)
+    raw_from_iso8601(rest, calendar, false)
   end
 
   @sep [?\s, ?T]
   [match_date, guard_date, read_date] = Calendar.ISO.__match_date__()
   [match_time, guard_time, read_time] = Calendar.ISO.__match_time__()
 
-  defp raw_from_iso8601(string, calendar) do
+  defp raw_from_iso8601(string, calendar, is_negative_datetime) do
     with <<unquote(match_date), sep, unquote(match_time), rest::binary>> <- string,
          true <- unquote(guard_date) and sep in @sep and unquote(guard_time),
          {microsecond, rest} <- Calendar.ISO.parse_microsecond(rest),
          {offset, ""} <- Calendar.ISO.parse_offset(rest) do
       {year, month, day} = unquote(read_date)
       {hour, minute, second} = unquote(read_time)
+      year = if is_negative_datetime, do: -year, else: year
 
       cond do
         not calendar.valid_date?(year, month, day) ->

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -322,6 +322,21 @@ defmodule DateTimeTest do
                minute: 50,
                second: 7
              }
+
+    assert DateTime.from_iso8601("0000-01-01T01:22:07+10:30") |> elem(1) ==
+             %DateTime{
+               microsecond: {0, 0},
+               month: 12,
+               std_offset: 0,
+               time_zone: "Etc/UTC",
+               utc_offset: 0,
+               year: -1,
+               zone_abbr: "UTC",
+               day: 31,
+               hour: 14,
+               minute: 52,
+               second: 7
+             }
   end
 
   test "from_iso8601/1 handles negative dates" do
@@ -352,6 +367,51 @@ defmodule DateTimeTest do
                day: 23,
                hour: 23,
                minute: 50,
+               second: 7
+             }
+
+    assert DateTime.from_iso8601("-0001-01-01T01:22:07+10:30") |> elem(1) ==
+             %DateTime{
+               microsecond: {0, 0},
+               month: 12,
+               std_offset: 0,
+               time_zone: "Etc/UTC",
+               utc_offset: 0,
+               year: -2,
+               zone_abbr: "UTC",
+               day: 31,
+               hour: 14,
+               minute: 52,
+               second: 7
+             }
+
+    assert DateTime.from_iso8601("-0001-01-01T01:22:07-10:30") |> elem(1) ==
+             %DateTime{
+               microsecond: {0, 0},
+               month: 1,
+               std_offset: 0,
+               time_zone: "Etc/UTC",
+               utc_offset: 0,
+               year: -1,
+               zone_abbr: "UTC",
+               day: 1,
+               hour: 11,
+               minute: 52,
+               second: 7
+             }
+
+    assert DateTime.from_iso8601("-0001-12-31T23:22:07-10:30") |> elem(1) ==
+             %DateTime{
+               microsecond: {0, 0},
+               month: 1,
+               std_offset: 0,
+               time_zone: "Etc/UTC",
+               utc_offset: 0,
+               year: 0,
+               zone_abbr: "UTC",
+               day: 1,
+               hour: 9,
+               minute: 52,
                second: 7
              }
   end


### PR DESCRIPTION
Follow up of https://github.com/elixir-lang/elixir/pull/8033#issuecomment-410188416

These are the expected results:

```elixir
iex(1)> DateTime.from_iso8601("0000-01-01T01:22:07+10:30")
#DateTime<-0001-12-31 14:52:07Z>

iex(2)> DateTime.from_iso8601("-0001-01-01T01:22:07+10:30")
#DateTime<-0002-12-31 14:52:07Z>

iex(3)> DateTime.from_iso8601("-0001-01-01T01:22:07-10:30")
#DateTime<-0001-01-01 11:52:07Z>

iex(4)> DateTime.from_iso8601("-0001-12-31T23:22:07-10:30")
#DateTime<0000-01-01 9:52:07Z>
```