### PR TITLE
Delete counter for vars in nested quotes

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3518,7 +3518,7 @@ defmodule Kernel do
   end
 
   defp ensure_evaled_var(elem, {index, ast}) do
-    var = {String.to_atom("var" <> Integer.to_string(index)), [], __MODULE__}
+    var = {String.to_atom("arg" <> Integer.to_string(index)), [], __MODULE__}
     {var, {index + 1, [{var, elem} | ast]}}
   end
 

--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -196,8 +196,8 @@ defmodule Kernel.Utils do
 
     quote do
       case Macro.Env.in_guard?(__CALLER__) do
-        true -> unquote(literal_quote(unquote_every_ref(expr, vars)))
-        false -> unquote(literal_quote(unquote_refs_once(expr, vars)))
+        true -> unquote(Macro.escape(unquote_every_ref(expr, vars), unquote: true))
+        false -> unquote(Macro.escape(unquote_refs_once(expr, vars), unquote: true))
       end
     end
   end
@@ -249,10 +249,6 @@ defmodule Kernel.Utils do
       {unquote_splicing(vars)} = {unquote_splicing(exprs)}
       unquote(guard)
     end
-  end
-
-  defp literal_quote(ast) do
-    {:quote, [], [[do: ast]]}
   end
 
   defp literal_unquote(ast) do

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -198,7 +198,7 @@ defmodule Macro do
   ## Examples
 
       iex> Macro.generate_arguments(2, __MODULE__)
-      [{:var1, [], __MODULE__}, {:var2, [], __MODULE__}]
+      [{:arg1, [], __MODULE__}, {:arg2, [], __MODULE__}]
 
   """
   @doc since: "1.5.0"
@@ -206,7 +206,7 @@ defmodule Macro do
 
   def generate_arguments(amount, context)
       when is_integer(amount) and amount > 0 and is_atom(context) do
-    for id <- 1..amount, do: var(String.to_atom("var" <> Integer.to_string(id)), context)
+    for id <- 1..amount, do: var(String.to_atom("arg" <> Integer.to_string(id)), context)
   end
 
   @doc """

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -22,7 +22,7 @@ defmodule Protocol do
     type_args = :lists.map(fn _ -> quote(do: term) end, :lists.seq(2, arity))
     type_args = [quote(do: t) | type_args]
 
-    varify = fn pos -> Macro.var(String.to_atom("var" <> Integer.to_string(pos)), __MODULE__) end
+    varify = fn pos -> Macro.var(String.to_atom("arg" <> Integer.to_string(pos)), __MODULE__) end
 
     call_args = :lists.map(varify, :lists.seq(2, arity))
     call_args = [quote(do: term) | call_args]

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -207,6 +207,10 @@ rewrite(?map, fetch, [Map, Key]) ->
   {maps, find, [Key, Map]};
 rewrite(?map, 'fetch!', [Map, Key]) ->
   {maps, get, [Key, Map]};
+rewrite(?map, 'get', [Map, Key]) ->
+  {maps, get, [Key, Map, nil]};
+rewrite(?map, 'get', [Map, Key, Default]) ->
+  {maps, get, [Key, Map, Default]};
 rewrite(?map, 'has_key?', [Map, Key]) ->
   {maps, is_key, [Key, Map]};
 rewrite(?map, put, [Map, Key, Value]) ->

--- a/lib/elixir/test/elixir/kernel/guard_test.exs
+++ b/lib/elixir/test/elixir/kernel/guard_test.exs
@@ -389,15 +389,15 @@ defmodule Kernel.GuardTest do
       args = quote(do: [1 + 1, 2 + 2, 3 + 3])
 
       assert expand_defguard_to_string(:with_unused_vars, args, :guard) == """
-      :erlang.+(1 + 1, 2 + 2)
-      """
+             :erlang.+(1 + 1, 2 + 2)
+             """
 
       assert expand_defguard_to_string(:with_unused_vars, args, nil) == """
-      (
-        {foo, bar} = {1 + 1, 2 + 2}
-        :erlang.+(foo, bar)
-      )
-      """
+             (
+               {foo, bar} = {1 + 1, 2 + 2}
+               :erlang.+(foo, bar)
+             )
+             """
     end
 
     defguard with_reused_vars(foo, bar, baz) when foo + foo + bar + baz
@@ -406,15 +406,15 @@ defmodule Kernel.GuardTest do
       args = quote(do: [1 + 1, 2 + 2, 3 + 3])
 
       assert expand_defguard_to_string(:with_reused_vars, args, :guard) == """
-      :erlang.+(:erlang.+(:erlang.+(1 + 1, 1 + 1), 2 + 2), 3 + 3)
-      """
+             :erlang.+(:erlang.+(:erlang.+(1 + 1, 1 + 1), 2 + 2), 3 + 3)
+             """
 
       assert expand_defguard_to_string(:with_reused_vars, args, nil) == """
-      (
-        {foo, bar, baz} = {1 + 1, 2 + 2, 3 + 3}
-        :erlang.+(:erlang.+(:erlang.+(foo, foo), bar), baz)
-      )
-      """
+             (
+               {foo, bar, baz} = {1 + 1, 2 + 2, 3 + 3}
+               :erlang.+(:erlang.+(:erlang.+(foo, foo), bar), baz)
+             )
+             """
     end
 
     defp expand_defguard_to_string(fun, args, context) do

--- a/lib/elixir/test/elixir/kernel/guard_test.exs
+++ b/lib/elixir/test/elixir/kernel/guard_test.exs
@@ -394,8 +394,8 @@ defmodule Kernel.GuardTest do
 
       assert expand_defguard_to_string(:with_unused_vars, args, nil) == """
              (
-               {foo, bar} = {1 + 1, 2 + 2}
-               :erlang.+(foo, bar)
+               {arg0, arg1} = {1 + 1, 2 + 2}
+               :erlang.+(arg0, arg1)
              )
              """
     end
@@ -411,8 +411,8 @@ defmodule Kernel.GuardTest do
 
       assert expand_defguard_to_string(:with_reused_vars, args, nil) == """
              (
-               {foo, bar, baz} = {1 + 1, 2 + 2, 3 + 3}
-               :erlang.+(:erlang.+(:erlang.+(foo, foo), bar), baz)
+               {arg0, arg1, arg2} = {1 + 1, 2 + 2, 3 + 3}
+               :erlang.+(:erlang.+(:erlang.+(arg0, arg0), arg1), arg2)
              )
              """
     end

--- a/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
+++ b/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
@@ -226,7 +226,6 @@ defmodule Kernel.LexicalTrackerTest do
           _ = extract(1, 2)
           _ = is_record(1)
           _ = Integer.is_even(2)
-
           NotAModule
           Remote.func()
           R.func()
@@ -243,9 +242,7 @@ defmodule Kernel.LexicalTrackerTest do
         _ = &R.func/0
         _ = &Remote.func/0
         _ = &Integer.is_even/1
-
-        _ = &is_record/1; def b(a), do: is_record(a)
-
+        _ = &is_record/1; def b(a), do: is_record(a) # both runtime and compile
         %Macro.Env{}
 
         Kernel.LexicalTracker.remote_dispatches(__ENV__.module)
@@ -256,30 +253,30 @@ defmodule Kernel.LexicalTrackerTest do
     assert {6, Kernel, :def, 2} in compile_remote_calls
     assert {8, Record, :is_record, 1} in compile_remote_calls
     assert {9, Integer, :is_even, 1} in compile_remote_calls
-    assert {15, Record, :is_record, 1} in compile_remote_calls
-    assert {18, Integer, :is_even, 1} in compile_remote_calls
-    assert {19, Macro.Env, :__struct__, 1} in compile_remote_calls
-    assert {22, Record, :extract, 2} in compile_remote_calls
-    assert {23, Record, :is_record, 1} in compile_remote_calls
+    assert {14, Record, :is_record, 1} in compile_remote_calls
+    assert {17, Integer, :is_even, 1} in compile_remote_calls
+    assert {18, Macro.Env, :__struct__, 1} in compile_remote_calls
+    assert {21, Record, :extract, 2} in compile_remote_calls
+    assert {22, Record, :is_record, 1} in compile_remote_calls
+    assert {23, Remote, :func, 0} in compile_remote_calls
     assert {24, Remote, :func, 0} in compile_remote_calls
-    assert {25, Remote, :func, 0} in compile_remote_calls
-    assert {26, Integer, :is_even, 1} in compile_remote_calls
-    assert {28, Kernel, :def, 2} in compile_remote_calls
-    assert {28, Record, :is_record, 1} in compile_remote_calls
-    assert {30, Macro.Env, :__struct__, 1} in compile_remote_calls
-    assert {32, Kernel.LexicalTracker, :remote_dispatches, 1} in compile_remote_calls
+    assert {25, Integer, :is_even, 1} in compile_remote_calls
+    assert {26, Kernel, :def, 2} in compile_remote_calls
+    assert {26, Record, :is_record, 1} in compile_remote_calls
+    assert {27, Macro.Env, :__struct__, 1} in compile_remote_calls
+    assert {29, Kernel.LexicalTracker, :remote_dispatches, 1} in compile_remote_calls
 
     runtime_remote_calls = unroll_dispatches(runtime_remote_calls)
     assert {7, Record, :extract, 2} in runtime_remote_calls
     assert {8, :erlang, :is_tuple, 1} in runtime_remote_calls
+    assert {11, Remote, :func, 0} in runtime_remote_calls
     assert {12, Remote, :func, 0} in runtime_remote_calls
-    assert {13, Remote, :func, 0} in runtime_remote_calls
-    assert {14, Record, :extract, 2} in runtime_remote_calls
-    assert {15, :erlang, :is_tuple, 1} in runtime_remote_calls
+    assert {13, Record, :extract, 2} in runtime_remote_calls
+    assert {14, :erlang, :is_tuple, 1} in runtime_remote_calls
+    assert {15, Remote, :func, 0} in runtime_remote_calls
     assert {16, Remote, :func, 0} in runtime_remote_calls
-    assert {17, Remote, :func, 0} in runtime_remote_calls
-    assert {18, :erlang, :==, 2} in runtime_remote_calls
-    assert {28, :erlang, :is_tuple, 1} in runtime_remote_calls
+    assert {17, :erlang, :==, 2} in runtime_remote_calls
+    assert {26, :erlang, :is_tuple, 1} in runtime_remote_calls
   end
 
   test "remote dispatches with external source" do

--- a/lib/elixir/test/elixir/kernel/quote_test.exs
+++ b/lib/elixir/test/elixir/kernel/quote_test.exs
@@ -374,7 +374,11 @@ defmodule Kernel.QuoteTest.VarHygieneTest do
     read_interference()
   end
 
-  test "nested" do
+  test "hat" do
+    assert hat() == 1
+  end
+
+  test "nested macro" do
     assert (nested 1 do
               nested 2 do
                 _ = :ok
@@ -382,8 +386,28 @@ defmodule Kernel.QuoteTest.VarHygieneTest do
             end) == 1
   end
 
-  test "hat" do
-    assert hat() == 1
+  test "nested quote" do
+    defmodule NestedQuote do
+      defmacrop macro(arg) do
+        quote bind_quoted: [arg: arg] do
+          quote bind_quoted: [arg: arg], do: String.duplicate(arg, 2)
+        end
+      end
+
+      defmacro __using__(_) do
+        quote do
+          def test do
+            unquote(macro("foo"))
+          end
+        end
+      end
+    end
+
+    defmodule UseNestedQuote do
+      use NestedQuote
+    end
+
+    assert UseNestedQuote.test() == "foofoo"
   end
 end
 

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -459,8 +459,8 @@ defmodule KernelTest do
 
       result = expand_to_string(quote(do: rand() in [1 | some_call()]))
       assert result =~ "var = rand()"
-      assert result =~ "{var0} = {some_call()}"
-      assert result =~ ":erlang.orelse(:erlang.\"=:=\"(var, 1), :lists.member(var, var0))"
+      assert result =~ "{arg0} = {some_call()}"
+      assert result =~ ":erlang.orelse(:erlang.\"=:=\"(var, 1), :lists.member(var, arg0))"
     end
 
     defp expand_to_string(ast) do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -901,7 +901,7 @@ defmodule MacroTest do
 
   test "generate_arguments/2" do
     assert Macro.generate_arguments(0, __MODULE__) == []
-    assert Macro.generate_arguments(1, __MODULE__) == [{:var1, [], __MODULE__}]
+    assert Macro.generate_arguments(1, __MODULE__) == [{:arg1, [], __MODULE__}]
     assert Macro.generate_arguments(4, __MODULE__) |> length == 4
   end
 


### PR DESCRIPTION
Consider the following example:

    defmodule NestedQuote do
      defmacrop macro(arg) do
        quote bind_quoted: [arg: arg] do
          quote bind_quoted: [arg: arg], do: String.duplicate(arg, 2)
        end
      end

      defmacro __using__(_) do
        quote do
          def test do
            unquote(macro("foo"))
          end
        end
      end
    end

    defmodule UseNestedQuote do
      use NestedQuote
    end

It has two macro expansions, one inside __using__/1 when it invokes
macro/1, and another when used. The issue, however, is that the
`arg` of `String.duplicate(arg, 2)` gets tagged with the context
of `macro/1` but it should be tagged with the context of `__using__`
since it is a quote inside a quote. This patch addresses this.

Closes #7709 