### PR TITLE
Rewrite match operators in elixir

### DIFF
--- a/lib/elixir/src/elixir_utils.erl
+++ b/lib/elixir/src/elixir_utils.erl
@@ -6,7 +6,7 @@
   macro_name/1, returns_boolean/1, caller/4, meta_keep/1,
   read_file_type/1, read_file_type/2, read_link_type/1, read_posix_mtime_and_size/1,
   change_posix_time/2, change_universal_time/2,
-  guard_op/2, match_op/2, extract_splat_guards/1, extract_guards/1,
+  guard_op/2, extract_splat_guards/1, extract_guards/1,
   erlang_comparison_op_to_elixir/1]).
 -include("elixir.hrl").
 -include_lib("kernel/include/file.hrl").
@@ -15,13 +15,6 @@
 
 macro_name(Macro) ->
   list_to_atom("MACRO-" ++ atom_to_list(Macro)).
-
-% Operators
-
-match_op('++', 2) -> true;
-match_op('+', 1) -> true;
-match_op('-', 1) -> true;
-match_op(_, _) -> false.
 
 guard_op('andalso', 2) ->
   true;

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -552,13 +552,13 @@ defmodule Kernel.ExpansionTest do
 
     test "in matches" do
       message =
-        ~r"cannot invoke remote function Hello.something_that_does_not_exist/0 inside match"
+        ~r"cannot invoke remote function Hello.something_that_does_not_exist/0 inside pattern"
 
       assert_raise CompileError, message, fn ->
         expand(quote(do: Hello.something_that_does_not_exist() = :foo))
       end
 
-      message = ~r"cannot invoke remote function :erlang.make_ref/0 inside match"
+      message = ~r"cannot invoke remote function :erlang.make_ref/0 inside pattern"
       assert_raise CompileError, message, fn -> expand(quote(do: make_ref() = :foo)) end
 
       message = ~r"invalid argument for \+\+ operator"
@@ -574,6 +574,12 @@ defmodule Kernel.ExpansionTest do
       assert_raise CompileError, message, fn ->
         expand(quote(do: [1] ++ 2 ++ [3] = [1, 2, 3]))
       end
+
+      assert {:=, _, [-1, {{:., [], [:erlang, :-]}, _, [1]}]} = expand(quote(do: -1 = -1))
+      assert {:=, _, [1, {{:., [], [:erlang, :+]}, _, [1]}]} = expand(quote(do: +1 = +1))
+
+      assert {:=, _, [[{:|, _, [1, [{:|, _, [2, 3]}]]}], [1, 2, 3]]} =
+               expand(quote(do: [1] ++ [2] ++ 3 = [1, 2, 3]))
     end
 
     test "in guards" do


### PR DESCRIPTION
Until now, we left rewriting operators in matches to Erlang. This forced
us to inherit Erlang semantics, especially for the ++ operator, that
only allows lists of integers on the left side inside matches. The new
implementation just rewrites this operator regular improper list matching.
Additionally we rewrite matching on -/1 and +/1 operators to number
literals - matching with those operators and variables was never
supported.

Additionally do a bit of housekeeping and refactor code around rewriting
and validating remote calls.