### PR TITLE
Move parentheses in System.cmd() docs

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -564,10 +564,10 @@ defmodule System do
       iex> System.cmd("echo", ["hello"])
       {"hello\n", 0}
 
-      iex> System.cmd("echo", ["hello"]), env: [{"MIX_ENV", "test"}]
+      iex> System.cmd("echo", ["hello"], env: [{"MIX_ENV", "test"}])
       {"hello\n", 0}
 
-      iex> System.cmd("echo", ["hello"]), into: IO.stream(:stdio, :line)
+      iex> System.cmd("echo", ["hello"], into: IO.stream(:stdio, :line))
       hello
       {%IO.Stream{}, 0}
 


### PR DESCRIPTION
This is fixed upstream - but reading through the docs for 1.7.1 it caught me out.