### PR TITLE
Fix unused variable warning

### DIFF
--- a/lib/elixir/src/elixir_aliases.erl
+++ b/lib/elixir/src/elixir_aliases.erl
@@ -33,7 +33,7 @@ remove_alias(Atom, Aliases) ->
 
 remove_macro_alias(Meta, Atom, Aliases) ->
   case lists:keyfind(counter, 1, Meta) of
-    {counter, Counter} ->
+    {counter, _Counter} ->
       lists:keydelete(Atom, 1, Aliases);
     false ->
       Aliases


### PR DESCRIPTION
Removes this warning:

```
Recompile: src/elixir_aliases
src/elixir_aliases.erl:36: Warning: variable 'Counter' is unused
```