### PR TITLE
Remove error message from IEx test suite

### DIFF
--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1016,7 +1016,7 @@ defmodule IEx.HelpersTest do
       end
     end
 
-    test "reloads elixir modules" do
+    test "reloads Elixir modules" do
       message = ~r"function Sample.run/0 is undefined \(module Sample is not available\)"
 
       assert_raise UndefinedFunctionError, message, fn ->

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1000,14 +1000,12 @@ defmodule IEx.HelpersTest do
   end
 
   describe "nl" do
+    @tag :capture_log
     test "loads a given module on the given nodes" do
       assert nl(:nonexistent_module) == {:error, :nofile}
-      assert nl([node()], Enum) == {:ok, [{:nonode@nohost, :loaded, Enum}]}
+      assert nl([node()], :lists) == {:ok, [{:nonode@nohost, :error, :sticky_directory}]}
       assert nl([:nosuchnode@badhost], Enum) == {:ok, [{:nosuchnode@badhost, :badrpc, :nodedown}]}
-
-      capture_log(fn ->
-        assert nl([node()], :lists) == {:ok, [{:nonode@nohost, :error, :sticky_directory}]}
-      end)
+      assert nl([node()], Enum) == {:ok, [{:nonode@nohost, :loaded, Enum}]}
     end
   end
 


### PR DESCRIPTION
Due to race conditions, the capturing logic introduced by `ExUnit.CaptureLog.capture_log/2` might not be there when the error messages logged by the Erlang's code server arrived. If that happens, this error message is printed:

<img width="687" alt="screen shot 2018-08-05 at 11 18 47 pm" src="https://user-images.githubusercontent.com/651203/43690271-d0bcca54-9907-11e8-94ca-96036a6fc5b4.png">



