### PR TITLE
Fix comment typos

### DIFF
--- a/lib/elixir/test/elixir/code_formatter/general_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/general_test.exs
@@ -20,7 +20,7 @@ defmodule Code.Formatter.GeneralTest do
 
     test "starting with expression" do
       assert_same "__MODULE__.Foo.Bar"
-      # Syntatically valid, semantically invalid
+      # Syntactically valid, semantically invalid
       assert_same "'Foo'.Bar.Baz"
     end
 

--- a/lib/elixir/test/elixir/fixtures/calendar/holocene.exs
+++ b/lib/elixir/test/elixir/fixtures/calendar/holocene.exs
@@ -1,7 +1,7 @@
 defmodule Calendar.Holocene do
   # This calendar is used to test conversions between calendars.
   # It implements the Holocene calendar, which is based on the
-  # Propleptic Gregorian calendar with every year + 10000.
+  # Proleptic Gregorian calendar with every year + 10000.
 
   @behaviour Calendar
 

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -282,7 +282,7 @@ defmodule Mix.Tasks.Xref do
     :ok
   end
 
-  ## Warnings (unreacheable + deprecated)
+  ## Warnings (unreachable + deprecated)
 
   defp source_warnings(excludes, opts) do
     sources = sources(opts)

--- a/lib/mix/test/mix/dep_test.exs
+++ b/lib/mix/test/mix/dep_test.exs
@@ -505,7 +505,7 @@ defmodule Mix.DepTest do
   end
 
   test "nested deps with no overrides" do
-    # deps_repo brings git_repo but it is overriden
+    # deps_repo brings git_repo but it is overridden
     deps = [
       {:deps_repo, "0.1.0", path: "custom/deps_repo"}
     ]
@@ -597,7 +597,7 @@ defmodule Mix.DepTest do
   end
 
   test "nested deps with overrides" do
-    # deps_repo brings git_repo but it is overriden
+    # deps_repo brings git_repo but it is overridden
     deps = [
       {:deps_repo, "0.1.0", path: "custom/deps_repo"},
       {:git_repo, ">= 0.0.0", git: MixTest.Case.fixture_path("git_repo"), override: true}


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Fix typos in comments
  * overriden -> overridden
  * Syntatically -> Syntactically
  * Propleptic -> Proleptic
  * unreacheable -> unreachable
