### PR TITLE
Fix typos in literals (strings/charlists)

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -105,7 +105,7 @@ defmodule Access do
   ### Summing up
 
   The bracket-based syntax, `user[:name]`, is used by dynamic structures,
-  is extensible and returns nil on misisng keys.
+  is extensible and returns nil on missing keys.
 
   The dot-based syntax, `user.name`, is used exclusively to access atom
   keys in maps and structs, and it raises on missing keys.

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -66,7 +66,7 @@ defmodule Application do
   own environment. Please do not use the functions in this module for directly
   accessing or modifying the environment of other applications.
 
-  The application environment can be overriden via the `-config` option of
+  The application environment can be overridden via the `-config` option of
   `erl`, as well as command-line flags, as we are going to see below.
 
   ## The application callback module

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -528,7 +528,7 @@ defmodule Calendar.ISO do
   end
 
   @doc """
-  See `c:Calendar.day_rollover_relative_to_midlight_utc/0` for documentation.
+  See `c:Calendar.day_rollover_relative_to_midnight_utc/0` for documentation.
   """
   @doc since: "1.5.0"
   @impl true

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -26,7 +26,7 @@ defmodule Code do
   times. This is common in scripts.
 
   `compile_file/2` must be used when you are interested in the modules defined in a
-  file, without tracking. `eval_file/2` should be used when you are intested on
+  file, without tracking. `eval_file/2` should be used when you are interested in
   the result of evaluating the file rather than the modules it defines.
   """
 

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -809,7 +809,7 @@ defmodule Code do
   The compiler utilizes temporary modules to compile code. For example,
   `elixir_compiler_1`, `elixir_compiler_2`, etc. In case the compiled code
   stores references to anonymous functions or similar, the Elixir compiler
-  may be unable to reclaim those modules, keeping an unecessary amount of
+  may be unable to reclaim those modules, keeping an unnecessary amount of
   code in memory and eventually leading to modules such as `elixir_compiler_12345`.
 
   This function purges all modules currently kept by the compiler, allowing

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -813,7 +813,7 @@ defmodule Code do
   code in memory and eventually leading to modules such as `elixir_compiler_12345`.
 
   This function purges all modules currently kept by the compiler, allowing
-  old compiler module names to be resued. If there are any processes running
+  old compiler module names to be reused. If there are any processes running
   any code from such modules, they will be terminated too.
 
   It returns `{:ok, number_of_modules_purged}`.

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -687,7 +687,7 @@ defmodule Kernel.SpecialForms do
   defmacro __CALLER__, do: error!([])
 
   @doc """
-  Returns the stacktrace for the curently handled exception.
+  Returns the stacktrace for the currently handled exception.
 
   It is available only in the `catch` and `rescue` clauses of `try/1`
   expressions.

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -63,7 +63,7 @@ defmodule List do
       iex> list ++ [4] # slow
       [1, 2, 3, 4]
 
-  Additonally, getting a list's length and accessing it by index are
+  Additionally, getting a list's length and accessing it by index are
   linear time operations. Negative indexes are also supported but
   they imply the list will be iterated twice, once to calculate the
   proper index and another time to perform the operation.

--- a/lib/elixir/lib/tuple.ex
+++ b/lib/elixir/lib/tuple.ex
@@ -31,7 +31,7 @@ defmodule Tuple do
 
   The functions in this module that add and remove elements from tuples are
   rarely used in practice, as they typically imply tuples are being used as
-  collections. To append to a tuple, it is preferrable to use pattern matching:
+  collections. To append to a tuple, it is preferable to use pattern matching:
 
       tuple = {:ok, :example}
 

--- a/lib/elixir/test/elixir/kernel/deprecated_test.exs
+++ b/lib/elixir/test/elixir/kernel/deprecated_test.exs
@@ -26,7 +26,7 @@ defmodule Kernel.DeprecatedTest do
            ]
   end
 
-  test "add deprecated to __info__ and beam chuncks" do
+  test "add deprecated to __info__ and beam chunks" do
     write_beam(
       defmodule SampleDeprecated do
         @deprecated "Use SampleDeprecated.bar/0 instead"

--- a/lib/elixir/test/elixir/kernel/guard_test.exs
+++ b/lib/elixir/test/elixir/kernel/guard_test.exs
@@ -259,7 +259,7 @@ defmodule Kernel.GuardTest do
   end
 
   describe "defguard(p) compilation" do
-    test "refuses to compile non-sensical code" do
+    test "refuses to compile nonsensical code" do
       assert_raise CompileError, ~r"cannot find or invoke local undefined/1", fn ->
         defmodule UndefinedUsage do
           defguard foo(function) when undefined(function)

--- a/lib/elixir/test/elixir/kernel/impl_test.exs
+++ b/lib/elixir/test/elixir/kernel/impl_test.exs
@@ -415,7 +415,7 @@ defmodule Kernel.ImplTest do
            end) == ""
   end
 
-  test "does not warn for @impl with defaults when the same function is defined mutiple times" do
+  test "does not warn for @impl with defaults when the same function is defined multiple times" do
     assert capture_err(fn ->
              Code.eval_string(~S"""
              defmodule Kernel.ImplTest.ImplAttributes do

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -21,7 +21,7 @@ defmodule ExUnit.Callbacks do
   as parameter if defined by a block. Functions used to define a test
   setup must accept the context as single argument.
 
-  A test module can define mutiple `setup` and `setup_all` callbacks,
+  A test module can define multiple `setup` and `setup_all` callbacks,
   and they are invoked in order of appearance.
 
   `start_supervised/2` is used to start processes under a supervisor. The

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -342,7 +342,7 @@ defmodule Logger do
       the message being anything (and do something like the `rescue` in the example
       above)
     * the current timestamp: a term of type `t:Logger.Formatter.time/0`
-    * the medatata: a keyword list
+    * the metadata: a keyword list
 
   You can read more about formatting in `Logger.Formatter`.
 

--- a/lib/mix/lib/mix/tasks/cmd.ex
+++ b/lib/mix/lib/mix/tasks/cmd.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Cmd do
   that those child processes won't be terminated with the VM.
 
   A solution is to make sure the child processes listen to the
-  stdndard input and terminate when standard input is closed.
+  standard input and terminate when standard input is closed.
   We discuss this topic at length in the "Zombie OS processes"
   of the `Port` module documentation.
   """

--- a/lib/mix/lib/mix/tasks/profile.cprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.cprof.ex
@@ -155,7 +155,7 @@ defmodule Mix.Tasks.Profile.Cprof do
   defp parse_opt(other), do: other
 
   @doc """
-  Allows to programatically run the `cprof` profiler on expression in `fun`.
+  Allows to programmatically run the `cprof` profiler on expression in `fun`.
 
   ## Options
 

--- a/lib/mix/lib/mix/tasks/profile.eprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.eprof.ex
@@ -169,7 +169,7 @@ defmodule Mix.Tasks.Profile.Eprof do
   defp parse_opt(other), do: other
 
   @doc """
-  Allows to programatically run the `eprof` profiler on expression in `fun`.
+  Allows to programmatically run the `eprof` profiler on expression in `fun`.
 
   ## Options
 

--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -164,7 +164,7 @@ defmodule Mix.Tasks.Profile.Fprof do
   defp parse_opt(other), do: other
 
   @doc """
-  Allows to programatically run the `fprof` profiler on expression in `fun`.
+  Allows to programmatically run the `fprof` profiler on expression in `fun`.
 
   ## Options
 

--- a/lib/mix/test/mix/dep_test.exs
+++ b/lib/mix/test/mix/dep_test.exs
@@ -608,7 +608,7 @@ defmodule Mix.DepTest do
         File.mkdir_p!("custom/deps_repo/lib")
 
         File.write!("custom/deps_repo/lib/a.ex", """
-        # Check that the overriden requirement shows up in the child dependency
+        # Check that the overridden requirement shows up in the child dependency
         [%Mix.Dep{app: :git_repo, requirement: ">= 0.0.0"}] = Mix.Dep.cached()
         """)
 


### PR DESCRIPTION
Added literals spell checking support for IntelliJ Elixir, so found some more typos when compiling the dictionary against elixir-lang/elixir.

# Changelog
## Bug Fixes
* misisng -> missing
* Fix typo in callback reference
* curently -> currently
* overriden -> overridden
* intested on -> interested in
* unecessary -> unnecessary
* resued -> reused
* Additonally -> Additionally
* preferrable -> preferable
* chuncks -> chunks
* non-sensical -> nonsensical
* mutiple -> multiple