### PR TITLE
Small optimization on expand_args/2

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -598,8 +598,8 @@ expand_args([Arg], E) ->
 expand_args(Args, #{context := match} = E) ->
   lists:mapfoldl(fun expand/2, E, Args);
 expand_args(Args, E) ->
-  {EArgs, {EC, EV}} = lists:mapfoldl(fun expand_arg/2, {E, E}, Args),
-  {EArgs, elixir_env:mergea(EV, EC)}.
+  {EArgs, {_EC, EV}} = lists:mapfoldl(fun expand_arg/2, {E, E}, Args),
+  {EArgs, EV}.
 
 %% Match/var helpers
 


### PR DESCRIPTION
`elixir_env:mergea(EV, EC)` is always equivalent to `EV` so we can avoid the operation