### PR TITLE
Improve unused variable warnings

### DIFF
--- a/lib/elixir/src/elixir_env.erl
+++ b/lib/elixir/src/elixir_env.erl
@@ -160,13 +160,13 @@ not_underscored(Name) ->
   end.
 
 format_error({unused_var, Name, false}) ->
-  io_lib:format("variable \"~ts\" is unused", [Name]);
+  io_lib:format("variable \"~ts\" is unused (if the variable is not meant to be used, prefix it with an underscore)", [Name]);
 
 format_error({unused_var, Name, true}) ->
   io_lib:format("variable \"~ts\" is unused\n\n"
-                "Note variables defined inside case, cond, fn, if and similar do not leak. "
-                "If you want to conditionally override an existing variable \"~ts\", "
-                "you will have to explicitly return the variable. For example:\n\n"
+                "Note variables defined inside case, cond, fn, if and similar do not affect "
+                "variables defined outside of the construct. Instead you have to explicitly "
+                "return those values. For example:\n\n"
                 "    if some_condition? do\n"
                 "      atom = :one\n"
                 "    else\n"
@@ -179,4 +179,4 @@ format_error({unused_var, Name, true}) ->
                 "      else\n"
                 "        :two\n"
                 "      end\n\n"
-                "Unused variable \"~ts\" found at:", [Name, Name, Name]).
+                "Unused variable \"~ts\" found at:", [Name, Name]).

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -487,8 +487,9 @@ defmodule Mix.Tasks.Compile.ElixirTest do
         file: Path.absname("lib/a.ex"),
         severity: :warning,
         position: 2,
-        message: "variable \"unused\" is unused",
-        compiler_name: "Elixir"
+        compiler_name: "Elixir",
+        message:
+          "variable \"unused\" is unused (if the variable is not meant to be used, prefix it with an underscore)"
       }
 
       ExUnit.CaptureIO.capture_io(:standard_error, fn ->


### PR DESCRIPTION
Mention that adding a underscore can address it and remove the concept of "leaking vars".