### PR TITLE
Extend System.get_env/1 to support a default value

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -373,13 +373,13 @@ defmodule System do
   Returns the value of the given environment variable.
 
   The returned value of the environment variable
-  `varname` is a string, or `nil` if the environment
-  variable is undefined.
+  `varname` is a string. If the environment variable is undefined
+  then a `default` value is returned or `nil` if none is provided.
   """
-  @spec get_env(String.t()) :: String.t() | nil
-  def get_env(varname) when is_binary(varname) do
+  @spec get_env(String.t(), any()) :: String.t() | any()
+  def get_env(varname, default \\ nil) when is_binary(varname) do
     case :os.getenv(String.to_charlist(varname)) do
-      false -> nil
+      false -> default
       other -> List.to_string(other)
     end
   end


### PR DESCRIPTION
It is common to read an environment variable then to choose
whether to return a default value. For instance in config files
one can call `System.get_env("MY_VAR")` to fill some field, but
if one wants to have a way to handle defaults from within the config
one has to repeat a case block, or define a module that exports the
desired wrapped around `System.get_env/1`.