### PR TITLE
Remove impossible clause on DateTime.from_naive!/2

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -218,7 +218,7 @@ defmodule DateTime do
   @doc """
   Converts the given `NaiveDateTime` to `DateTime`.
 
-  It expects a time zone to put the NaiveDateTime in.
+  It expects a time zone to put the `NaiveDateTime` in.
   Currently it only supports "Etc/UTC" as time zone.
 
   ## Examples
@@ -230,14 +230,8 @@ defmodule DateTime do
   @doc since: "1.4.0"
   @spec from_naive!(NaiveDateTime.t(), Calendar.time_zone()) :: t
   def from_naive!(naive_datetime, time_zone) do
-    case from_naive(naive_datetime, time_zone) do
-      {:ok, datetime} ->
-        datetime
-
-      {:error, reason} ->
-        raise ArgumentError,
-              "cannot parse #{inspect(naive_datetime)} to datetime, reason: #{inspect(reason)}"
-    end
+    {:ok, datetime} = from_naive(naive_datetime, time_zone)
+    datetime
   end
 
   @doc """


### PR DESCRIPTION
Currently `DateTime.from_naive/2` always returns `{:ok, datetime}`.

Other option is to update `DateTime.from_naive/2` to include a fallback clause that returns errors. For example, `{:error, :unsupported_time_zone}` when the `time_zone` attribute is not "Etc/UTC".