### PR TITLE
First stab at implementation of `after_suite/1` callback

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -319,7 +319,8 @@ defmodule ExUnit do
   map containing the results of the test suite's execution.
 
   If `after_suite/1` is called multiple times, the callbacks will be called in
-  reverse order - i.e. the last callback set will be the first to be called.
+  reverse order. In other words, the last callback set will be the first to be
+  called.
   """
   @spec after_suite(
           (%{

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -313,16 +313,26 @@ defmodule ExUnit do
   end
 
   @doc """
-  Allows users to configure functions to run after the test suite has finished.
-  Functions passed in will be executed after all tests have finished running. If
-  `after_suite/1` is called multiple times, the functions will be executed in
-  reverse order (i.e. the last function given will be executed first).
+  Sets a callback to be executed after the completion of a test suite.
+
+  Callbacks set with `after_suite/1` must accept a single argument, which is a
+  map containing the results of the test suite's execution.
+
+  If `after_suite/1` is called multiple times, the callbacks will be called in
+  reverse order - i.e. the last callback set will be the first to be called.
   """
-  @spec after_suite(fun) :: :ok
-  def after_suite(function) do
+  @spec after_suite(
+          (%{
+             excluded: non_neg_integer,
+             failures: non_neg_integer,
+             skipped: non_neg_integer,
+             total: non_neg_integer
+           } ->
+             any)
+        ) :: :ok
+  def after_suite(function) when is_function(function) do
     current_callbacks = Application.fetch_env!(:ex_unit, :after_suite)
     configure(after_suite: [function | current_callbacks])
-    :ok
   end
 
   # Persists default values in application

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -312,6 +312,19 @@ defmodule ExUnit do
     ExUnit.Runner.run(config, nil)
   end
 
+  @doc """
+  Allows users to configure functions to run after the test suite has finished.
+  Functions passed in will be executed after all tests have finished running. If
+  `after_suite/1` is called multiple times, the functions will be executed in
+  reverse order (i.e. the last function given will be executed first).
+  """
+  @spec after_suite(fun) :: :ok
+  def after_suite(function) do
+    current_callbacks = Application.fetch_env!(:ex_unit, :after_suite)
+    configure(after_suite: [function | current_callbacks])
+    :ok
+  end
+
   # Persists default values in application
   # environment before the test suite starts.
   defp persist_defaults(config) do

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -21,6 +21,8 @@ defmodule ExUnit.Runner do
     EM.suite_finished(config.manager, run_us, load_us)
     result = ExUnit.RunnerStats.stats(stats)
     EM.stop(config.manager)
+    after_suite_callbacks = Application.fetch_env!(:ex_unit, :after_suite)
+    Enum.each(after_suite_callbacks, fn callback -> callback.(result) end)
     result
   end
 

--- a/lib/ex_unit/mix.exs
+++ b/lib/ex_unit/mix.exs
@@ -30,7 +30,8 @@ defmodule ExUnit.MixProject do
         slowest: 0,
         stacktrace_depth: 20,
         timeout: 60000,
-        trace: false
+        trace: false,
+        after_suite: []
       ]
     ]
   end

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -170,7 +170,7 @@ defmodule Mix.Tasks.Test do
     * `--slowest` - prints timing information for the N slowest tests.
       Automatically sets `--trace` and `--preload-modules`
     * `--stale` - runs only tests which reference modules that changed since the
-      last time tests were ran with `--stale`. You can read more about this option 
+      last time tests were ran with `--stale`. You can read more about this option
       in the "Stale" section below
     * `--timeout` - sets the timeout for the tests
     * `--trace` - runs tests with detailed reporting. Automatically sets `--max-cases` to 1.


### PR DESCRIPTION
This is a first take at the `after_suite/1` callback in ExUnit. I've
done basic testing by making this work with an app on my local machine,
but I'm going to think about automated tests tomorrow. I also still
need to document this better, but I wanted to get this up just to make
sure this implementation is along the lines of what y'all are looking
for.

Eventually resolves #8082 