### PR TITLE
Remove check for legacy @export_type attribute

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1887,9 +1887,9 @@ defmodule Module do
     do: {atom, :__on_definition__}
 
   defp preprocess_attribute(key, _value)
-       when key in [:type, :typep, :export_type, :opaque, :callback, :macrocallback] do
+       when key in [:type, :typep, :opaque, :callback, :macrocallback] do
     raise ArgumentError,
-          "attributes type, typep, export_type, opaque, callback, and macrocallback" <>
+          "attributes type, typep, opaque, callback, and macrocallback" <>
             "must be set directly via the @ notation"
   end
 


### PR DESCRIPTION
Erlang uses this attribute to export types, but Elixir abstracts it via `@type`, `@typep` and `@opaque`.

Besides, adding `@export_type` to a module does not have any effect; and it's not documented.