### PR TITLE
Add missing key to type in `ExUnit.Test`

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -106,7 +106,8 @@ defmodule ExUnit do
             module: module,
             state: ExUnit.state(),
             time: non_neg_integer,
-            tags: map
+            tags: map,
+            logs: String.t()
           }
   end
 


### PR DESCRIPTION
There was a `:logs` key that was included in the struct and in the
documentation, but wasn't included in `ExUnit.Test.t()`.