### PR TITLE
Allow deprecation of structures

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4275,10 +4275,13 @@ defmodule Kernel do
         _ -> Protocol.__derive__(derive, __MODULE__, __ENV__)
       end
 
+      deprecation = Module.get_attribute(__MODULE__, :deprecated)
+
       def __struct__() do
         @struct
       end
 
+      if deprecation, do: @deprecated deprecation
       unquote(builder)
       Kernel.Utils.announce_struct(__MODULE__)
       struct

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4281,7 +4281,7 @@ defmodule Kernel do
         @struct
       end
 
-      if deprecation, do: @deprecated deprecation
+      if deprecation, do: @deprecated(deprecation)
       unquote(builder)
       Kernel.Utils.announce_struct(__MODULE__)
       struct


### PR DESCRIPTION
This adds support for deprecation of structures by keeping `@deprecated`
attribute for both defined function.  This will make `%Foo{foo: 1}` to
raise deprecation warnings when used.