### PR TITLE
Use `@t :: %__MODULE__{}` convention in `Range`.

### DIFF
--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -40,8 +40,8 @@ defmodule Range do
 
   defstruct first: nil, last: nil
 
-  @type t :: %Range{first: integer, last: integer}
-  @type t(first, last) :: %Range{first: first, last: last}
+  @type t :: %__MODULE__{first: integer, last: integer}
+  @type t(first, last) :: %__MODULE__{first: first, last: last}
 
   @doc """
   Creates a new range.


### PR DESCRIPTION
Use `@t :: %__MODULE__{}` convention.