### PR TITLE
Do not run doctests with empty :only option

### DIFF
--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -232,12 +232,20 @@ defmodule ExUnit.DocTest do
   end
 
   defp filter_by_opts(tests, opts) do
-    only = opts[:only] || []
-    except = opts[:except] || []
+    except = Keyword.get(opts, :except, [])
 
-    tests
-    |> Stream.reject(&(&1.fun_arity in except))
-    |> Stream.filter(&(Enum.empty?(only) or &1.fun_arity in only))
+    case Keyword.get(opts, :only) do
+      [] ->
+        []
+
+      nil ->
+        Stream.reject(tests, &(&1.fun_arity in except))
+
+      only ->
+        tests
+        |> Stream.reject(&(&1.fun_arity in except))
+        |> Stream.filter(&(&1.fun_arity in only))
+    end
   end
 
   ## Compilation of extracted tests

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -234,17 +234,17 @@ defmodule ExUnit.DocTest do
   defp filter_by_opts(tests, opts) do
     except = Keyword.get(opts, :except, [])
 
-    case Keyword.get(opts, :only) do
-      [] ->
+    case Keyword.fetch(opts, :only) do
+      {:ok, []} ->
         []
 
-      nil ->
-        Stream.reject(tests, &(&1.fun_arity in except))
-
-      only ->
+      {:ok, only} ->
         tests
         |> Stream.reject(&(&1.fun_arity in except))
         |> Stream.filter(&(&1.fun_arity in only))
+
+      :error ->
+        Stream.reject(tests, &(&1.fun_arity in except))
     end
   end
 

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -427,7 +427,7 @@ defmodule ExUnit.DocTestTest do
     ExUnit.Server.modules_loaded()
     output = capture_io(fn -> ExUnit.run() end)
 
-    assert output =~ "0 failure"
+    assert output =~ "0 failures"
     refute output =~ "doctest"
   end
 

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -418,6 +418,19 @@ defmodule ExUnit.DocTestTest do
     assert capture_io(fn -> ExUnit.run() end) =~ "2 doctests, 1 failure"
   end
 
+  test "empty :only" do
+    defmodule EmptyOnly do
+      use ExUnit.Case
+      doctest ExUnit.DocTestTest.SomewhatGoodModuleWithOnly, only: [], import: true
+    end
+
+    ExUnit.Server.modules_loaded()
+    output = capture_io(fn -> ExUnit.run() end)
+
+    assert output =~ "0 failure"
+    refute output =~ "doctest"
+  end
+
   test "doctest failures" do
     # When adding or removing lines above this line, the tests below will
     # fail because we are explicitly asserting some doctest lines from
@@ -427,7 +440,7 @@ defmodule ExUnit.DocTestTest do
       doctest ExUnit.DocTestTest.Invalid
     end
 
-    doctest_line = 427
+    doctest_line = 440
 
     ExUnit.configure(seed: 0, colors: [enabled: false])
     ExUnit.Server.modules_loaded()


### PR DESCRIPTION
It's a weird case, but I guess that's how it should behave according to the semantics of `:only`.

Raising an `ArgumentError` could be an alternative :)