### PR TITLE
Consider :runtime and :app from mix.exs

### DIFF
--- a/lib/mix/lib/mix/tasks/deps.ex
+++ b/lib/mix/lib/mix/tasks/deps.ex
@@ -96,9 +96,6 @@ defmodule Mix.Tasks.Deps do
       If the `:applications` key is not provided in `def application` in your
       mix.exs file, Mix will automatically included all dependencies as a runtime
       application, except if `runtime: false` is given. Defaults to true.
-      Note this option is not preserved if you are publishing a package to Hex.
-      In such cases, you should remove the `:runtime` option in the dependency
-      and list all runtime applications under `:applications` explicitly.
 
     * `:system_env` - an enumerable of key-value tuples of binaries to be set
       as environment variables when loading or compiling the dependency

--- a/lib/mix/test/mix/dep_test.exs
+++ b/lib/mix/test/mix/dep_test.exs
@@ -550,7 +550,7 @@ defmodule Mix.DepTest do
     end)
   end
 
-  test "nested deps with runtime override on parent" do
+  test "nested deps considers runtime from current app" do
     Process.put(:custom_deps_git_repo_opts, runtime: false)
 
     deps = [
@@ -560,38 +560,12 @@ defmodule Mix.DepTest do
 
     with_deps(deps, fn ->
       in_fixture("deps_status", fn ->
-        File.mkdir_p!("custom/deps_repo/lib")
-
-        File.write!("custom/deps_repo/lib/a.ex", """
-        # Check that the child dependency is top_level and optional
-        [%Mix.Dep{app: :git_repo, top_level: true, opts: opts}] = Mix.Dep.cached()
-        false = Keyword.fetch!(opts, :runtime)
-        """)
-
-        Mix.Tasks.Deps.Get.run([])
         Mix.Tasks.Deps.Compile.run([])
-      end)
-    end)
-  end
 
-  test "nested deps with runtime override on child" do
-    deps = [
-      {:deps_repo, "0.1.0", path: "custom/deps_repo"},
-      {:git_repo, "0.1.0", git: MixTest.Case.fixture_path("git_repo"), runtime: false}
-    ]
+        {:ok, [{:application, :deps_repo, opts}]} =
+          :file.consult("_build/dev/lib/deps_repo/ebin/deps_repo.app")
 
-    with_deps(deps, fn ->
-      in_fixture("deps_status", fn ->
-        File.mkdir_p!("custom/deps_repo/lib")
-
-        File.write!("custom/deps_repo/lib/a.ex", """
-        # Check that the child dependency is top_level and optional
-        [%Mix.Dep{app: :git_repo, top_level: true, opts: opts}] = Mix.Dep.cached()
-        false = Keyword.has_key?(opts, :runtime)
-        """)
-
-        Mix.Tasks.Deps.Get.run([])
-        Mix.Tasks.Deps.Compile.run([])
+        assert :git_repo not in Keyword.get(opts, :applications)
       end)
     end)
   end


### PR DESCRIPTION
Since those values are not stored on Hex, we should not
expect them to be available on Mix.Dep.cached. Instead
we traverse the deps in `mix.exs` to lift this information.