### PR TITLE
Update docs for `ExUnit.configure/1` and `ExUnit.Formatter`

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -273,7 +273,6 @@ defmodule ExUnit do
   Any arbitrary configuration can also be passed to `configure/1`, and these options
   can then be used in places such as custom formatters. These other options will be
   ignored by ExUnit itself.
-
   """
   @spec configure(Keyword.t()) :: :ok
   def configure(options) do

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -270,9 +270,9 @@ defmodule ExUnit do
       prints each test case and test while running. Note that in trace mode test timeouts
       will be ignored.
 
-  Any arbitrary configuration can also be passed to `configure/1`, and these options
-  can then be used in places such as custom formatters. These other options will be
-  ignored by ExUnit itself.
+  Any arbitrary configuration can also be passed to `configure/1` or `start/1`,
+  and these options can then be used in places such as custom formatters. These
+  other options will be ignored by ExUnit itself.
   """
   @spec configure(Keyword.t()) :: :ok
   def configure(options) do

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -270,6 +270,10 @@ defmodule ExUnit do
       prints each test case and test while running. Note that in trace mode test timeouts
       will be ignored.
 
+  Any arbitrary configuration can also be passed to `configure/1`, and these options
+  can then be used in places such as custom formatters. These other options will be
+  ignored by ExUnit itself.
+
   """
   @spec configure(Keyword.t()) :: :ok
   def configure(options) do

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -35,11 +35,11 @@ defmodule ExUnit.Formatter do
     * `{:case_finished, test_module}` -
       a test module has finished. See `ExUnit.TestCase` for details.
 
-  When formatters are started, they are passed the full ExUnit configuration as
-  the argument to `init/1`. If you need to do runtime configuration of a
-  formatter, you can add any configuration needed by using `ExUnit.configure/1`,
-  and this will then be included in the options passed to the GenServer's
-  `init/1` callback.
+  The full ExUnit configuration is passed as the argument to `init/1` when the
+  formatters are started. If you need to do runtime configuration of a
+  formatter, you can add any configuration needed by using `ExUnit.configure/1`
+  or `ExUnit.start/1`, and this will then be included in the options passed to
+  the GenServer's `init/1` callback.
   """
 
   @type id :: term

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -40,7 +40,6 @@ defmodule ExUnit.Formatter do
   formatter, you can add any configuration needed by using `ExUnit.configure/1`,
   and this will then be included in the options passed to the GenServer's
   `init/1` callback.
-
   """
 
   @type id :: term

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -35,6 +35,12 @@ defmodule ExUnit.Formatter do
     * `{:case_finished, test_module}` -
       a test module has finished. See `ExUnit.TestCase` for details.
 
+  When formatters are started, they are passed the full ExUnit configuration as
+  the argument to `init/1`. If you need to do runtime configuration of a
+  formatter, you can add any configuration needed by using `ExUnit.configure/1`,
+  and this will then be included in the options passed to the GenServer's
+  `init/1` callback.
+
   """
 
   @type id :: term


### PR DESCRIPTION
This includes documentation explicitly allowing the passing of arbitrary
configuration options in `ExUnit.configure/1`, and also tells how to do
runtime configuration of custom formatters by using this arbitrary
configuration.