### PR TITLE
Fix Logger spec for functions working with backends

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -582,7 +582,7 @@ defmodule Logger do
       to `Logger` are processed before the backend is added
 
   """
-  @spec add_backend(atom, keyword) :: Supervisor.on_start_child()
+  @spec add_backend(backend, keyword) :: Supervisor.on_start_child()
   def add_backend(backend, opts \\ []) do
     _ = if opts[:flush], do: flush()
 
@@ -608,7 +608,7 @@ defmodule Logger do
       to `Logger` are processed before the backend is removed
 
   """
-  @spec remove_backend(atom, keyword) :: :ok | {:error, term}
+  @spec remove_backend(backend, keyword) :: :ok | {:error, term}
   def remove_backend(backend, opts \\ []) do
     _ = if opts[:flush], do: flush()
     Logger.Config.remove_backend(backend)


### PR DESCRIPTION
`Logger.add_backend/1,2` and `Logger.remove_backend/1,2` are specced to only allow atoms as backends, while `Logger.configure_backend/2` allows backend to be of the more general `backend` type. But both `add_backend` and `remove_backend` work fine with the more generic `backend` type, so the specs should be extended to cover that type.

The specs were introduced with c24a13ebf8, while the spec for `configure_backends` was introduced in aeefd59b15 (with a small fix in b98421fe51).