### PR TITLE
Fix typo in File doc

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -179,7 +179,7 @@ defmodule File do
   @doc """
   Returns `true` if the given path exists.
 
-  It can be a regular file, directory, socket, symbolic link, named pipe or device file.
+  It can be a regular file, directory, socket, symbolic link, named pipe, or device file.
   Returns `false` for symbolic links pointing to non-existing targets.
 
   ## Options

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -179,7 +179,7 @@ defmodule File do
   @doc """
   Returns `true` if the given path exists.
 
-  It can be regular file, directory, socket, symbolic link, named pipe or device file.
+  It can be a regular file, directory, socket, symbolic link, named pipe or device file.
   Returns `false` for symbolic links pointing to non-existing targets.
 
   ## Options


### PR DESCRIPTION
Hi all,

changed wording in `File.exists?/2` doc from 
`It can be regular file,…` to `It can be a regular file,…`

Cheers!
