### PR TITLE
Missing comma in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ We outline our process below to clarify the roles of everyone involved.
 
 All pull requests must be approved by two committers before being merged into
 the repository. If any changes are necessary, the team will leave appropriate
-comments requesting changes to the code. Unfortunately we cannot guarantee a
+comments requesting changes to the code. Unfortunately, we cannot guarantee a
 pull request will be merged, even when modifications are requested, as the Elixir
 team will re-evaluate the contribution as it changes.
 


### PR DESCRIPTION
Hi All,

Just wanted to make my first contribution to elixir and immediately found a place in `README.md` where I could do it.

A very-very minor contribution. I know :-)

Nick