### PR TITLE
Docs: change wording about WithClauseError

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1435,7 +1435,7 @@ defmodule Kernel.SpecialForms do
       ...> end
       {:error, :wrong_data}
 
-  If an else block is used and there is no matching clause, a `WithClauseError`
+  If an `else` block is used and there are no matching clauses, a `WithClauseError`
   exception is raised.
   """
   defmacro with(args), do: error!([args])

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1435,7 +1435,8 @@ defmodule Kernel.SpecialForms do
       ...> end
       {:error, :wrong_data}
 
-  If there is no matching `else` condition, then a `WithClauseError` exception is raised.
+  If an else block is used and there is no matching clause, a `WithClauseError`
+  exception is raised.
   """
   defmacro with(args), do: error!([args])
 


### PR DESCRIPTION
This way I hope people will not fall into the trap that no else has different error semantics, as mentioned above in the docs.