### PR TITLE
max-failures implementation for ExUnit

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -181,7 +181,6 @@ defmodule ExUnit do
   @spec start(Keyword.t()) :: :ok
   def start(options \\ []) do
     {:ok, _} = Application.ensure_all_started(:ex_unit)
-
     configure(options)
 
     if Application.fetch_env!(:ex_unit, :autorun) do
@@ -243,6 +242,9 @@ defmodule ExUnit do
       different modules run in parallel. It defaults to `System.schedulers_online * 2`
       to optimize both CPU-bound and IO-bound tests;
 
+    * `:max_failures` - maximum number of tests that may fail. When the maximum is reached, the
+       execution of tests is stopped and the results are returned.
+
     * `:module_load_timeout` - the timeout to be used when loading a test module,
       defaults to `60_000` milliseconds;
 
@@ -290,6 +292,15 @@ defmodule ExUnit do
     |> put_seed()
     |> put_slowest()
     |> put_max_cases()
+    |> put_max_failures()
+  end
+
+  defp put_max_failures(opts) do
+    if opts[:max_failures] > 0 do
+      Keyword.put(opts, :max_failures, opts[:max_failures])
+    else
+      opts
+    end
   end
 
   @doc """
@@ -349,7 +360,7 @@ defmodule ExUnit do
   # Persists default values in application
   # environment before the test suite starts.
   defp persist_defaults(config) do
-    config |> Keyword.take([:max_cases, :seed, :trace]) |> configure()
+    config |> Keyword.take([:max_cases, :seed, :trace, :max_failures]) |> configure()
     config
   end
 

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -1,6 +1,21 @@
 defmodule ExUnit.Runner do
   @moduledoc false
 
+  defmodule MaxFailureCounter do
+    use Agent
+
+    def start_link do
+      Agent.start_link(fn -> 0 end)
+    end
+
+    def increase(fail_counter) do
+      Agent.get_and_update(fail_counter, fn state ->
+        state = state + 1
+        {state, state}
+      end)
+    end
+  end
+
   alias ExUnit.EventManager, as: EM
 
   @rand_algorithm :exs1024
@@ -8,7 +23,8 @@ defmodule ExUnit.Runner do
   def run(opts, load_us) do
     {:ok, manager} = EM.start_link()
     {:ok, stats} = EM.add_handler(manager, ExUnit.RunnerStats, opts)
-    {opts, config} = configure(manager, opts)
+    {:ok, fail_counter} = MaxFailureCounter.start_link()
+    {opts, config} = configure(manager, fail_counter, opts)
 
     :erlang.system_flag(:backtrace_depth, Keyword.fetch!(opts, :stacktrace_depth))
 
@@ -26,7 +42,7 @@ defmodule ExUnit.Runner do
     result
   end
 
-  defp configure(manager, opts) do
+  defp configure(manager, fail_counter, opts) do
     opts = normalize_opts(opts)
     Enum.each(opts[:formatters], &EM.add_handler(manager, &1, opts))
 
@@ -35,6 +51,7 @@ defmodule ExUnit.Runner do
       exclude: opts[:exclude],
       include: opts[:include],
       manager: manager,
+      fail_counter: fail_counter,
       max_cases: opts[:max_cases],
       max_failures: opts[:max_failures],
       only_test_ids: opts[:only_test_ids],
@@ -242,8 +259,18 @@ defmodule ExUnit.Runner do
       end
 
     EM.test_finished(config.manager, test)
+    handle_result(config, test)
     test
   end
+
+  defp handle_result(config, %{state: {:failed, _}}) do
+    failures = MaxFailureCounter.increase(config.fail_counter)
+    if(config.max_failures == failures) do
+      EM.stop(config.manager)
+    end
+  end
+
+  defp handle_result(_, _), do: :ok
 
   defp spawn_test(config, test, context) do
     parent = self()

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -36,6 +36,7 @@ defmodule ExUnit.Runner do
       include: opts[:include],
       manager: manager,
       max_cases: opts[:max_cases],
+      max_failures: opts[:max_failures],
       only_test_ids: opts[:only_test_ids],
       seed: opts[:seed],
       modules: :async,

--- a/lib/ex_unit/lib/ex_unit/runner_stats.ex
+++ b/lib/ex_unit/lib/ex_unit/runner_stats.ex
@@ -16,7 +16,6 @@ defmodule ExUnit.RunnerStats do
       failures: 0,
       skipped: 0,
       excluded: 0,
-      max_failures: opts[:max_failures],
       failures_manifest_file: opts[:failures_manifest_file],
       failures_manifest: FailuresManifest.new()
     }
@@ -35,7 +34,6 @@ defmodule ExUnit.RunnerStats do
       |> Map.update!(:failures_manifest, &FailuresManifest.put_test(&1, test))
       |> Map.update!(:total, &(&1 + 1))
       |> increment_status_counter(test.state)
-      |> handle_max_failures
 
     {:noreply, state}
   end
@@ -75,11 +73,4 @@ defmodule ExUnit.RunnerStats do
   end
 
   defp increment_status_counter(state, _), do: state
-
-  defp handle_max_failures(state) do
-    if(state.failures >= state.max_failures) do
-      IO.puts("STOP TESTING")
-    end
-    state
-  end
 end

--- a/lib/ex_unit/lib/ex_unit/runner_stats.ex
+++ b/lib/ex_unit/lib/ex_unit/runner_stats.ex
@@ -16,6 +16,7 @@ defmodule ExUnit.RunnerStats do
       failures: 0,
       skipped: 0,
       excluded: 0,
+      max_failures: opts[:max_failures],
       failures_manifest_file: opts[:failures_manifest_file],
       failures_manifest: FailuresManifest.new()
     }
@@ -34,6 +35,7 @@ defmodule ExUnit.RunnerStats do
       |> Map.update!(:failures_manifest, &FailuresManifest.put_test(&1, test))
       |> Map.update!(:total, &(&1 + 1))
       |> increment_status_counter(test.state)
+      |> handle_max_failures
 
     {:noreply, state}
   end
@@ -73,4 +75,11 @@ defmodule ExUnit.RunnerStats do
   end
 
   defp increment_status_counter(state, _), do: state
+
+  defp handle_max_failures(state) do
+    if(state.failures >= state.max_failures) do
+      IO.puts("STOP TESTING")
+    end
+    state
+  end
 end

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -156,6 +156,8 @@ defmodule Mix.Tasks.Test do
       external commands which produce output on stdout upon file system modification
     * `--max-cases` - sets the maximum number of tests running async. Only tests from
       different modules run in parallel. Defaults to twice the number of cores
+    * `--max-failures` - maximum number of tests that may fail. When the maximum is reached, the
+       execution of tests is stopped and the results are returned.
     * `--no-archives-check` - does not check archives
     * `--no-color` - disables color in the output
     * `--no-compile` - does not compile, even if files require compilation
@@ -293,6 +295,7 @@ defmodule Mix.Tasks.Test do
     seed: :integer,
     only: :keep,
     compile: :boolean,
+    max_failures: :integer,
     start: :boolean,
     timeout: :integer,
     raise: :boolean,
@@ -440,6 +443,7 @@ defmodule Mix.Tasks.Test do
   @option_keys [
     :trace,
     :max_cases,
+    :max_failures,
     :include,
     :exclude,
     :seed,


### PR DESCRIPTION
Max failures implementation for Exunit

It's still a work in progress, but I would like to ask some feedback about a proper way to stop testing. 

What is advised to get back to the `Runner` and hit the `EventManager.stop`? 
