### PR TITLE
Use "file system" instead of "filesystem"

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -150,7 +150,7 @@ defmodule Exception do
   Attaches information to exceptions for extra debugging.
 
   This operation is potentially expensive, as it reads data
-  from the filesystem, parses beam files, evaluates code and
+  from the file system, parses beam files, evaluates code and
   so on.
 
   If the exception module implements the optional `c:blame/2`

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -464,7 +464,7 @@ defmodule File do
   end
 
   @doc """
-  Writes the given `File.Stat` back to the filesystem at the given
+  Writes the given `File.Stat` back to the file system at the given
   path. Returns `:ok` or `{:error, reason}`.
   """
   @spec write_stat(Path.t(), File.Stat.t(), stat_options) :: :ok | {:error, posix}

--- a/lib/elixir/pages/Library Guidelines.md
+++ b/lib/elixir/pages/Library Guidelines.md
@@ -70,7 +70,7 @@ iex> File.read(1)
 ** (FunctionClauseError) no function clause matching in IO.chardata_to_string/1
 ```
 
-The usage of `:ok`/`:error` tuples is about the domain that the function works on, in this case, filesystem access. Bad arguments, logical errors, invalid options should raise regardless of the function name. If in doubt, prefer to return tuples instead of raising, as users of your library can always match on the results and raise if necessary.
+The usage of `:ok`/`:error` tuples is about the domain that the function works on, in this case, file system access. Bad arguments, logical errors, invalid options should raise regardless of the function name. If in doubt, prefer to return tuples instead of raising, as users of your library can always match on the results and raise if necessary.
 
 ### Avoid working with invalid data
 

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -434,7 +434,7 @@ defmodule IEx.Helpers do
   old version was properly purged before).
 
   This function is useful when you know the bytecode for module
-  has been updated in the filesystem and you want to tell the VM
+  has been updated in the file system and you want to tell the VM
   to load it.
   """
   def l(module) when is_atom(module) do

--- a/lib/mix/lib/mix/public_key.ex
+++ b/lib/mix/lib/mix/public_key.ex
@@ -14,7 +14,7 @@ defmodule Mix.PublicKey do
   """
 
   @doc """
-  Returns the filesystem path for public keys.
+  Returns the file system path for public keys.
   """
   def public_keys_path, do: Path.join(Mix.Utils.mix_home(), "public_keys")
 

--- a/lib/mix/lib/mix/scm.ex
+++ b/lib/mix/lib/mix/scm.ex
@@ -9,7 +9,7 @@ defmodule Mix.SCM do
   @doc """
   Returns a boolean if the dependency can be fetched
   or it is meant to be previously available in the
-  filesystem.
+  file system.
 
   Local dependencies (i.e. non-fetchable ones) are automatically
   recompiled every time the parent project is compiled.

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -289,7 +289,7 @@ defmodule Mix.Tasks.Format do
         else
           Mix.raise(
             "Unavailable dependency #{inspect(dep)} given to :import_deps in the formatter configuration. " <>
-              "The dependency cannot be found in the filesystem, please run mix deps.get and try again"
+              "The dependency cannot be found in the file system, please run mix deps.get and try again"
           )
         end
 

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -477,7 +477,7 @@ defmodule Mix.Utils do
   end
 
   @doc """
-  Opens and reads content from either a URL or a local filesystem path.
+  Opens and reads content from either a URL or a local file system path.
 
   Returns the contents as a `{:ok, binary}`, `:badpath` for invalid
   paths or `{:local, message}` for local errors and `{:remote, message}`

--- a/lib/mix/test/mix/dep_test.exs
+++ b/lib/mix/test/mix/dep_test.exs
@@ -111,7 +111,7 @@ defmodule Mix.DepTest do
 
   test "does not set the manager before the dependency was loaded" do
     # It is important to not eagerly set the manager because the dependency
-    # needs to be loaded (i.e. available in the filesystem) in order to get
+    # needs to be loaded (i.e. available in the file system) in order to get
     # the proper manager.
     Mix.Project.push(DepsApp)
 

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -435,7 +435,7 @@ defmodule Mix.Tasks.FormatTest do
 
       message =
         "Unavailable dependency :my_dep given to :import_deps in the formatter configuration. " <>
-          "The dependency cannot be found in the filesystem, please run mix deps.get and try again"
+          "The dependency cannot be found in the file system, please run mix deps.get and try again"
 
       assert_raise Mix.Error, message, fn -> Mix.Tasks.Format.run([]) end
 


### PR DESCRIPTION
Standardize use of this expression.
While both accepted, Google Books Ngram Viewer shows that "file system"
is the prefered one.