### PR TITLE
Correct blame message in FunctionClauseError for funs of arity 1

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1051,7 +1051,14 @@ defmodule FunctionClauseError do
     %{module: module, function: function, arity: arity, kind: kind, args: args, clauses: clauses} =
       exception
 
-    mfa = Exception.format_mfa(module, function, arity)
+    formatted_mfa = Exception.format_mfa(module, function, arity)
+
+    formatted_msg =
+      if arity == 1 do
+        "The following argument was given to #{formatted_mfa}:\n"
+      else
+        "The following arguments were given to #{formatted_mfa}:\n"
+      end
 
     formatted_args =
       args
@@ -1081,7 +1088,7 @@ defmodule FunctionClauseError do
         ""
       end
 
-    "\n\nThe following arguments were given to #{mfa}:\n#{formatted_args}#{formatted_clauses}"
+    "\n\n#{formatted_msg}#{formatted_args}#{formatted_clauses}"
   end
 
   defp pad(string) do

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -757,6 +757,17 @@ defmodule ExceptionTest do
              """
     end
 
+    test "FunctionClauseError with blame and arity 1" do
+      {exception, _} =
+        Exception.blame(:error, :function_clause, [{Foo, :arity_one, [1], [line: 13]}])
+
+      assert message(exception) =~ """
+             no function clause matching in Foo.arity_one/1
+
+             The following argument was given to Foo.arity_one/1:
+             """
+    end
+
     test "ErlangError" do
       assert %ErlangError{original: :sample} |> message == "Erlang error: :sample"
     end


### PR DESCRIPTION
before
iex> Time.to_string(:foo)
** (FunctionClauseError) no function clause matching in Time.to_string/1

    The following arguments were given to Time.to_string/1:

        # 1
        :foo

    (elixir) lib/calendar/time.ex:166: Time.to_string/1

Now the message reads:
The following argument was given to Time.to_string/1: