### PR TITLE
Link to functions and types

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -31,7 +31,7 @@ defprotocol Enumerable do
   while also guaranteeing the resource will be closed at the end of the
   enumeration. This protocol also allows suspension of the enumeration,
   which is useful when interleaving between many enumerables is required
-  (as in zip).
+  (as in the `zip/*` functions).
 
   This protocol requires four functions to be implemented, `reduce/3`,
   `count/1`, `member?/2`, and `slice/1`. The core of the protocol is the

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4166,10 +4166,10 @@ defmodule Kernel do
       MyProtocol.call(john) #=> works
 
   For each protocol in the `@derive` list, Elixir will assert there is an
-  implementation of that protocol for any (regardless if fallback to any
+  implementation of that protocol for any (regardless if `@fallback_to_any`
   is `true`) and check if the any implementation defines a `__deriving__/3`
   callback (via `Protocol.derive/3`). If so, the callback is invoked,
-  otherwise an implementation that simply points to the any implementation
+  otherwise an implementation that simply points to the `Any` implementation
   is automatically derived.
 
   ## Enforcing keys
@@ -4213,7 +4213,7 @@ defmodule Kernel do
   `%User{}`.
 
   The types of the struct fields that are not included in `%User{}` default to
-  `term`.
+  `t:term/0`.
 
   Structs whose internal structure is private to the local module (pattern
   matching them or directly accessing their fields should not be allowed) should
@@ -4482,7 +4482,7 @@ defmodule Kernel do
   for more information about deriving
   protocols.
 
-  ## Fallback to any
+  ## Fallback to `Any`
 
   In some cases, it may be convenient to provide a default
   implementation for all types. This can be achieved by setting
@@ -4501,8 +4501,8 @@ defmodule Kernel do
       end
 
   Although the implementation above is arguably not a reasonable
-  one. For example, it makes no sense to say a PID or an Integer
-  have a size of 0. That's one of the reasons why `@fallback_to_any`
+  one. For example, it makes no sense to say a PID or an integer
+  have a size of `0`. That's one of the reasons why `@fallback_to_any`
   is an opt-in behaviour. For the majority of protocols, raising
   an error when a protocol is not implemented is the proper behaviour.
 

--- a/lib/elixir/pages/Compatibility and Deprecations.md
+++ b/lib/elixir/pages/Compatibility and Deprecations.md
@@ -78,7 +78,7 @@ Passing a non-empty list to `:into` in `for`     | [v1.8]        | `Kernel.++/2`
 `Kernel.ParallelCompiler.files_to_path/2`        | [v1.8]        | `Kernel.ParallelCompiler.compile_to_path/2` (v1.6)
 `Kernel.ParallelRequire.files/2`                 | [v1.8]        | `Kernel.ParallelCompiler.require/2` (v1.6)
 `Code.get_docs/2`                                | [v1.7]        | `Code.fetch_docs/1` (v1.7)
-Calling `super` on GenServer callbacks           | [v1.7]        | Not calling super (v1.0)
+Calling `super/1` on GenServer callbacks           | [v1.7]        | Not calling `super/1` (v1.0)
 `Enum.chunk/2`[`/3/4`](Enum.chunk/4)             | [v1.7]        | `Enum.chunk_every/2`[`/3/4`](`Enum.chunk_every/4`) (v1.5)
 `not left in right`                              | [v1.7]        | [`left not in right`](`Kernel.SpecialForms.in/2`) (v1.5)
 `Registry.start_link/3`                          | [v1.7]        | `Registry.start_link/1` (v1.5)


### PR DESCRIPTION
Additionally, use module "`Any`", not just "any" when it suits.