### PR TITLE
Fix typo in Enum.filter/2 @doc

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -869,7 +869,7 @@ defmodule Enum do
   for which `fun` returns a truthy value.
 
   See also `reject/2` which discards all elements where the
-  function a truthy value.
+  function returns a truthy value.
 
   ## Examples
 


### PR DESCRIPTION
Hi all, 

added a missing word:

`…function a truthy value.` → `…function returns a truthy value.`

Cheers!