### PR TITLE
Fix for converting from negative iso days on New Year in a leap year

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -206,20 +206,11 @@ defmodule Calendar.ISO do
 
   # Converts count of days since 0000-01-01 to {year, month, day} tuple.
   @doc false
-  def date_from_iso_days(days) when days in 0..3_652_424 do
+  def date_from_iso_days(days) when days in -3_652_059..3_652_424 do
     {year, day_of_year} = days_to_year(days)
     extra_day = if leap_year?(year), do: 1, else: 0
     {month, day_in_month} = year_day_to_year_date(extra_day, day_of_year)
     {year, month, day_in_month + 1}
-  end
-
-  def date_from_iso_days(days) when days in -3_652_059..-1 do
-    {year, day_of_year} = days_to_year(-days)
-    previous_extra_day = if leap_year?(year), do: 1, else: 0
-    extra_day = if leap_year?(year + 1), do: 1, else: 0
-    day_of_year = @days_per_nonleap_year + extra_day - day_of_year
-    {month, day_in_month} = year_day_to_year_date(extra_day, day_of_year)
-    {-year - 1, month, day_in_month + previous_extra_day}
   end
 
   defp div_mod(int1, int2) do
@@ -757,18 +748,39 @@ defmodule Calendar.ISO do
     if leap_year?(year), do: 1, else: 0
   end
 
+  defp days_to_year(days) when days < 0 do
+    year_estimate = -div(-days, @days_per_nonleap_year) - 1
+
+    {year, days_before_year} =
+      days_to_year(year_estimate, days, days_to_end_of_epoch(year_estimate))
+
+    leap_year_pad = if leap_year?(year), do: 1, else: 0
+    {year, leap_year_pad + 365 + days - days_before_year}
+  end
+
   defp days_to_year(days) do
-    year = Integer.floor_div(days, @days_per_nonleap_year)
+    year = div(days, @days_per_nonleap_year)
     {year, days_before_year} = days_to_year(year, days, days_in_previous_years(year))
     {year, days - days_before_year}
   end
 
-  defp days_to_year(year, days1, days2) when days1 < days2 do
+  defp days_to_year(year, days1, days2) when year < 0 and days1 >= days2 do
+    days_to_year(year + 1, days1, days_to_end_of_epoch(year + 1))
+  end
+
+  defp days_to_year(year, days1, days2) when year >= 0 and days1 < days2 do
     days_to_year(year - 1, days1, days_in_previous_years(year - 1))
   end
 
   defp days_to_year(year, _days1, days2) do
     {year, days2}
+  end
+
+  defp days_to_end_of_epoch(year) when year < 0 do
+    previous_year = year + 1
+
+    div(previous_year, 4) - div(previous_year, 100) + div(previous_year, 400) +
+      previous_year * @days_per_nonleap_year
   end
 
   defp days_in_previous_years(0), do: 0

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -755,12 +755,15 @@ defmodule Calendar.ISO do
       days_to_year(year_estimate, days, days_to_end_of_epoch(year_estimate))
 
     leap_year_pad = if leap_year?(year), do: 1, else: 0
-    {year, leap_year_pad + 365 + days - days_before_year}
+    {year, leap_year_pad + @days_per_nonleap_year + days - days_before_year}
   end
 
   defp days_to_year(days) do
-    year = div(days, @days_per_nonleap_year)
-    {year, days_before_year} = days_to_year(year, days, days_in_previous_years(year))
+    year_estimate = div(days, @days_per_nonleap_year)
+
+    {year, days_before_year} =
+      days_to_year(year_estimate, days, days_in_previous_years(year_estimate))
+
     {year, days - days_before_year}
   end
 

--- a/lib/elixir/test/elixir/calendar/iso_test.exs
+++ b/lib/elixir/test/elixir/calendar/iso_test.exs
@@ -5,7 +5,7 @@ defmodule Calendar.ISOTest do
   doctest Calendar.ISO
 
   describe "date_from_iso_days" do
-    test "positive dates" do
+    test "with positive dates" do
       assert {0, 1, 1} == iso_day_roundtrip(0, 1, 1)
       assert {0, 12, 31} == iso_day_roundtrip(0, 12, 31)
       assert {1, 12, 31} == iso_day_roundtrip(1, 12, 31)
@@ -17,7 +17,7 @@ defmodule Calendar.ISOTest do
       assert {9996, 1, 1} == iso_day_roundtrip(9996, 1, 1)
     end
 
-    test "negative dates" do
+    test "with negative dates" do
       assert {-1, 1, 1} == iso_day_roundtrip(-1, 1, 1)
       assert {-1, 12, 31} == iso_day_roundtrip(-1, 12, 31)
       assert {-1, 12, 31} == iso_day_roundtrip(-1, 12, 31)
@@ -32,18 +32,6 @@ defmodule Calendar.ISOTest do
 
       assert {-9996, 12, 31} == iso_day_roundtrip(-9996, 12, 31)
       assert {-9996, 1, 1} == iso_day_roundtrip(-9996, 1, 1)
-    end
-  end
-
-  describe "date_from_iso_days symptoms" do
-    test "date add" do
-      assert ~D[-0004-01-01] == Date.add(~D[-0004-01-01], 0)
-    end
-
-    test "naive_datetime_from_iso_days" do
-      {iso_days, parts} = Calendar.ISO.naive_datetime_to_iso_days(-4, 1, 1, 0, 0, 0, {0, 6})
-      naive_dt = Calendar.ISO.naive_datetime_from_iso_days({iso_days, parts})
-      assert {-4, 1, 1, 0, 0, 0, {0, 6}} == naive_dt
     end
   end
 

--- a/lib/elixir/test/elixir/calendar/iso_test.exs
+++ b/lib/elixir/test/elixir/calendar/iso_test.exs
@@ -3,4 +3,52 @@ Code.require_file("../test_helper.exs", __DIR__)
 defmodule Calendar.ISOTest do
   use ExUnit.Case, async: true
   doctest Calendar.ISO
+
+  describe "date_from_iso_days" do
+    test "positive dates" do
+      assert {0, 1, 1} == iso_day_roundtrip(0, 1, 1)
+      assert {0, 12, 31} == iso_day_roundtrip(0, 12, 31)
+      assert {1, 12, 31} == iso_day_roundtrip(1, 12, 31)
+      assert {4, 1, 1} == iso_day_roundtrip(4, 1, 1)
+      assert {4, 12, 31} == iso_day_roundtrip(4, 12, 31)
+      assert {9999, 12, 31} == iso_day_roundtrip(9999, 12, 31)
+      assert {9999, 1, 1} == iso_day_roundtrip(9999, 1, 1)
+      assert {9996, 12, 31} == iso_day_roundtrip(9996, 12, 31)
+      assert {9996, 1, 1} == iso_day_roundtrip(9996, 1, 1)
+    end
+
+    test "negative dates" do
+      assert {-1, 1, 1} == iso_day_roundtrip(-1, 1, 1)
+      assert {-1, 12, 31} == iso_day_roundtrip(-1, 12, 31)
+      assert {-1, 12, 31} == iso_day_roundtrip(-1, 12, 31)
+      assert {-2, 1, 1} == iso_day_roundtrip(-2, 1, 1)
+      assert {-5, 12, 31} == iso_day_roundtrip(-5, 12, 31)
+
+      assert {-4, 1, 1} == iso_day_roundtrip(-4, 1, 1)
+      assert {-4, 12, 31} == iso_day_roundtrip(-4, 12, 31)
+
+      assert {-9999, 12, 31} == iso_day_roundtrip(-9999, 12, 31)
+      assert {-9996, 12, 31} == iso_day_roundtrip(-9996, 12, 31)
+
+      assert {-9996, 12, 31} == iso_day_roundtrip(-9996, 12, 31)
+      assert {-9996, 1, 1} == iso_day_roundtrip(-9996, 1, 1)
+    end
+  end
+
+  describe "date_from_iso_days symptoms" do
+    test "date add" do
+      assert ~D[-0004-01-01] == Date.add(~D[-0004-01-01], 0)
+    end
+
+    test "naive_datetime_from_iso_days" do
+      {iso_days, parts} = Calendar.ISO.naive_datetime_to_iso_days(-4, 1, 1, 0, 0, 0, {0, 6})
+      naive_dt = Calendar.ISO.naive_datetime_from_iso_days({iso_days, parts})
+      assert {-4, 1, 1, 0, 0, 0, {0, 6}} == naive_dt
+    end
+  end
+
+  defp iso_day_roundtrip(year, month, day) do
+    iso_days = Calendar.ISO.date_to_iso_days(year, month, day)
+    Calendar.ISO.date_from_iso_days(iso_days)
+  end
 end


### PR DESCRIPTION
👋 

This is a fix for https://github.com/elixir-lang/elixir/issues/8128

tldr; it was a bug with the 1st of January, on negative leap years - converting back from `iso_days` gave us the 32nd of December on the previous year.

