### PR TITLE
Document Path.wildcard/2 expects / dir separator

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -619,6 +619,8 @@ defmodule Path do
   that matching is case-sensitive: `"a"` will not match `"A"`.
   
   Directory separators must always be written as `/`, even on Windows.
+  You may call `Path.expand/1` to normalize the path before invoking
+  this function.
 
   By default, the patterns `*` and `?` do not match files starting
   with a dot `.`. See the `:match_dot` option in the "Options" section

--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -617,6 +617,8 @@ defmodule Path do
   Other characters represent themselves. Only paths that have
   exactly the same character in the same position will match. Note
   that matching is case-sensitive: `"a"` will not match `"A"`.
+  
+  Directory separators must always be written as `/`, even on Windows.
 
   By default, the patterns `*` and `?` do not match files starting
   with a dot `.`. See the `:match_dot` option in the "Options" section


### PR DESCRIPTION
Related to https://github.com/elixir-lang/elixir/pull/8147

As documented in [`filelib:wildcard/1`](http://erlang.org/doc/man/filelib.html#wildcard-1).