### PR TITLE
Use imported function in elixir_parser.yrl

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -504,9 +504,9 @@ container_expr -> no_parens_expr : error_no_parens_container_strict('$1').
 container_args_base -> container_expr : ['$1'].
 container_args_base -> container_args_base ',' container_expr : ['$3' | '$1'].
 
-container_args -> container_args_base : lists:reverse('$1').
-container_args -> container_args_base ',' : lists:reverse('$1').
-container_args -> container_args_base ',' kw : lists:reverse(['$3' | '$1']).
+container_args -> container_args_base : reverse('$1').
+container_args -> container_args_base ',' : reverse('$1').
+container_args -> container_args_base ',' kw : reverse(['$3' | '$1']).
 
 % Function calls with parentheses
 


### PR DESCRIPTION
Minor thing I spotted while reading the `elixir_parser.yrl` file. Other rules use the imported function, so I thought it would be nice to use it here as well.