### PR TITLE
Fix invalid expansion for remote

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -740,7 +740,7 @@ expand_local(Meta, Name, Args, #{module := Module, function := Function} = E) ->
 
 %% Remote
 
-expand_remote(Receiver, DotMeta, Right, Meta, Args, #{context := Context} = E, EL) ->
+expand_remote(Receiver, DotMeta, Right, Meta, Args, #{context := Context} = E, EL) when is_atom(Receiver) or is_tuple(Receiver) ->
   assert_no_clauses(Right, Meta, Args, E),
 
   Arity = length(Args),
@@ -753,7 +753,10 @@ expand_remote(Receiver, DotMeta, Right, Meta, Args, #{context := Context} = E, E
       maybe_warn_comparison(Rewritten, Args, E),
       {Rewritten, elixir_env:mergev(EL, EA)};
     {error, Error} -> form_error(Meta, ?key(E, file), elixir_rewrite, Error)
-  end.
+  end;
+expand_remote(Receiver, DotMeta, Right, Meta, Args, E, _) ->
+  Call = {{'.', DotMeta, [Receiver, Right]}, Meta, Args},
+  form_error(Meta, ?key(E, file), ?MODULE, {invalid_call, Call}).
 
 rewrite(match, Receiver, DotMeta, Right, Meta, EArgs) ->
   elixir_rewrite:match_rewrite(Receiver, DotMeta, Right, Meta, EArgs);

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -2299,6 +2299,10 @@ defmodule Kernel.ExpansionTest do
       expand(quote(do: 1.foo))
     end
 
+    assert_raise CompileError, ~r"invalid call 0\.foo\(\)", fn ->
+      expand(quote(do: __ENV__.line.foo))
+    end
+
     assert_raise CompileError, ~r"unhandled operator ->", fn ->
       expand(quote(do: (foo -> bar)))
     end


### PR DESCRIPTION
When left side is expanded but become invalid, the expansion result in the AST leaking for the user, for example:

```
iex(1)> __ENV__.line.foo
{{:., [line: 1], [1, :foo]}, [line: 1], []}
```

This checks the expanded left to ensure that it's safe