### PR TITLE
Fix small curly typo in tuple docs

### DIFF
--- a/lib/elixir/lib/tuple.ex
+++ b/lib/elixir/lib/tuple.ex
@@ -36,7 +36,7 @@ defmodule Tuple do
       tuple = {:ok, :example}
 
       # Avoid
-      Tuple.insert_at(tuple, 2, %{}}
+      Tuple.insert_at(tuple, 2, %{})
 
       # Prefer
       {:ok, atom} = tuple


### PR DESCRIPTION
Hello! Saw this little bugger when I was reading some tuple docs, thought I'd help out!

![image](https://user-images.githubusercontent.com/19894032/44992284-0cb37000-af54-11e8-8373-949c0fb8437f.png)
