### PR TITLE
Add note to `Task.yield_many` about output ordering

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -643,6 +643,9 @@ defmodule Task do
 
   Check `yield/2` for more information.
 
+  The tasks in the returned list will be in the same order as the
+  tasks supplied in the `tasks` input argument.
+
   ## Example
 
   `Task.yield_many/2` allows developers to spawn multiple tasks

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -632,7 +632,9 @@ defmodule Task do
   This function receives a list of tasks and waits for their
   replies in the given time interval. It returns a list
   of tuples of two elements, with the task as the first element
-  and the yielded result as the second.
+  and the yielded result as the second. The tasks in the returned
+  list will be in the same order as the tasks supplied in the `tasks`
+  input argument.
 
   Similarly to `yield/2`, each task's result will be
 
@@ -642,9 +644,6 @@ defmodule Task do
     * `nil` if the task keeps running past the timeout
 
   Check `yield/2` for more information.
-
-  The tasks in the returned list will be in the same order as the
-  tasks supplied in the `tasks` input argument.
 
   ## Example
 


### PR DESCRIPTION
This isn't stated explicitly, but it is true as far as I can tell and there is already [a test that requires ordered output](https://github.com/elixir-lang/elixir/blob/v1.7.3/lib/elixir/test/elixir/task_test.exs#L315-L325).