### PR TITLE
Remove invalid flag from Emakefile

### DIFF
--- a/lib/elixir/Emakefile
+++ b/lib/elixir/Emakefile
@@ -8,7 +8,6 @@
   warn_unused_record,
   warn_deprecated_function,
   warn_obsolete_guard,
-  strict_validation,
   warn_exported_vars,
   %% warn_missing_spec,
   %% warn_untyped_record,


### PR DESCRIPTION
[Erlang's make](http://erlang.org/doc/man/make.html) does not document it, neither the docs nor the codebase of the [Erlang's compiler](http://erlang.org/doc/man/compile.html). The options `basic_validation` and `strong_validation` exist though, but not `strict_validation`.

I cloned the [`Erlang/OTP` repo](https://github.com/erlang/otp) and search for `strict_validation` on the branches `maint-17`, `maint-18`, `maint-19`, and `master`. Nothing was found.

I've also tried looking on Internet, but I couldn't find any documentation nor any article on the matter. However, I did found other Erlang repos containing `strict_validation` 😕 

Removing the flag seems to not have any effect, the codebase compiles and all the tests pass. 