### PR TITLE
Rearrange assertions to (try to) capture error messages

### DIFF
--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1002,8 +1002,8 @@ defmodule IEx.HelpersTest do
   describe "nl" do
     @tag :capture_log
     test "loads a given module on the given nodes" do
-      assert nl(:nonexistent_module) == {:error, :nofile}
       assert nl([node()], :lists) == {:ok, [{:nonode@nohost, :error, :sticky_directory}]}
+      assert nl(:nonexistent_module) == {:error, :nofile}
       assert nl([:nosuchnode@badhost], Enum) == {:ok, [{:nosuchnode@badhost, :badrpc, :nodedown}]}
       assert nl([node()], Enum) == {:ok, [{:nonode@nohost, :loaded, Enum}]}
     end


### PR DESCRIPTION
Reduces the chances of #8183. Related to https://github.com/elixir-lang/elixir/pull/8055.

I've investigated a bit more about this issue. If I understood well the code, the Erlang's code server sends the error message (`[error] Can't load module ':lists' that resides in sticky dir`) to the Erlang's `:logger`; the Elixir's `Logger` is added as a handler of the Erlang's `:logger`; and the `ExUnit.CaptureLog` proxy is added as a handler of Elixir's `Logger` when `capture_log/2` is used (and the `:console` backend is removed). 

Thanks to `Logger.flush/0`, we can be sure that all the messages sent to Elixir's `Logger` during the execution of the function are consumed by all the Elixir's `Logger` handlers. However, that function does not have any effect on Erlang's `:logger`, nor `:logger` provides a similar functionality (or at least I haven't found one).

Here is my reaffirmed hypothesis: due to race conditions, the error is printed instead of being captured.

Moving the assertion one line above will give more time to process the messages sent to Erlang's `:logger`.

cc @josevalim @eksperimental 