### PR TITLE
Improvements in Mix docs

### DIFF
--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -11,7 +11,7 @@ defmodule Mix.Dep do
 
     * `app` - the application name as an atom
 
-    * `requirement` - a binary or regex with the dependency's requirement
+    * `requirement` - a binary or regular expression with the dependency's requirement
 
     * `status` - the current status of the dependency, check
       `Mix.Dep.format_status/1` for more info
@@ -296,7 +296,7 @@ defmodule Mix.Dep do
   def format_status(%Mix.Dep{status: {:nosemver, vsn}, requirement: req}) do
     "the app file specified a non-Semantic Versioning format: #{inspect(vsn)}. Mix can only match the " <>
       "requirement #{inspect(req)} against semantic versions. Please fix the application version " <>
-      "or use a regex as a requirement to match against any version"
+      "or use a regular expression as a requirement to match against any version"
   end
 
   def format_status(%Mix.Dep{status: {:nomatchvsn, vsn}, requirement: req}) do

--- a/lib/mix/lib/mix/rebar.ex
+++ b/lib/mix/lib/mix/rebar.ex
@@ -180,7 +180,7 @@ defmodule Mix.Rebar do
             re
 
           {:error, reason} ->
-            Mix.raise("Unable to compile version regex: #{inspect(req)}, #{reason}")
+            Mix.raise("Unable to compile version regular expression: #{inspect(req)}, #{reason}")
         end
     end
   end

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -289,7 +289,7 @@ defmodule Mix.Tasks.Format do
         else
           Mix.raise(
             "Unavailable dependency #{inspect(dep)} given to :import_deps in the formatter configuration. " <>
-              "The dependency cannot be found in the file system, please run mix deps.get and try again"
+              "The dependency cannot be found in the file system, please run \"mix deps.get\" and try again"
           )
         end
 

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -435,7 +435,7 @@ defmodule Mix.Tasks.FormatTest do
 
       message =
         "Unavailable dependency :my_dep given to :import_deps in the formatter configuration. " <>
-          "The dependency cannot be found in the file system, please run mix deps.get and try again"
+          "The dependency cannot be found in the file system, please run \"mix deps.get\" and try again"
 
       assert_raise Mix.Error, message, fn -> Mix.Tasks.Format.run([]) end
 


### PR DESCRIPTION
- Use "regular expression" instead of the more informal term "regex"
- Use double quotes around commands