### PR TITLE
Small optimization in `Stream.Reducers.chunk_every/5`

### DIFF
--- a/lib/elixir/lib/stream/reducers.ex
+++ b/lib/elixir/lib/stream/reducers.ex
@@ -25,7 +25,7 @@ defmodule Stream.Reducers do
     end
 
     after_fun = fn {acc_buffer, acc_count} ->
-      if leftover == :discard or acc_count == 0 or (step > count and acc_count >= count) do
+      if leftover == :discard or acc_count == 0 or acc_count >= count do
         {:cont, []}
       else
         {:cont, :lists.reverse(acc_buffer, Enum.take(leftover, count - acc_count)), []}


### PR DESCRIPTION
Due to the check `acc_count >= limit` inside `chunk_fun`, `acc_count` can only be greater than `count` if `step` is bigger than `count`, there is no need for this check.