### PR TITLE
Fix typespec in Version

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -94,7 +94,9 @@ defmodule Version do
   @type patch :: non_neg_integer | nil
   @type pre :: [String.t() | non_neg_integer]
   @type build :: String.t() | nil
-  @type matchable :: {major :: major, minor :: minor, patch :: patch, pre :: pre}
+  @type matchable ::
+          {major :: major, minor :: minor, patch :: patch, pre :: pre,
+           build_parts :: [String.t()]}
   @type t :: %__MODULE__{major: major, minor: minor, patch: patch, pre: pre, build: build}
 
   defmodule Requirement do


### PR DESCRIPTION
Adds a fix for #8205 to 1.7 branch. 

Note that in the master branch the fix is different (typespec has been removed), which means that this commit might cause a conflict between 1.7 branch and the master.