### PR TITLE
Add a check for previously defined records

### DIFF
--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -255,7 +255,15 @@ defmodule Record do
   """
   defmacro defrecord(name, tag \\ nil, kv) do
     quote bind_quoted: [name: name, tag: tag, kv: kv] do
+      if Module.defines?(__MODULE__, {name, 0}, :defmacro) do
+        raise CompileError,
+          file: __ENV__.file,
+          line: __ENV__.line,
+          description: "record #{inspect(name)} was previously defined"
+      end
+
       tag = tag || name
+
       fields = Record.__fields__(:defrecord, kv)
 
       defmacro unquote(name)(args \\ []) do
@@ -273,7 +281,15 @@ defmodule Record do
   """
   defmacro defrecordp(name, tag \\ nil, kv) do
     quote bind_quoted: [name: name, tag: tag, kv: kv] do
+      if Module.defines?(__MODULE__, {name, 0}, :defmacrop) do
+        raise CompileError,
+          file: __ENV__.file,
+          line: __ENV__.line,
+          description: "record #{inspect(name)} was previously defined"
+      end
+
       tag = tag || name
+
       fields = Record.__fields__(:defrecordp, kv)
 
       defmacrop unquote(name)(args \\ []) do

--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -255,9 +255,14 @@ defmodule Record do
   """
   defmacro defrecord(name, tag \\ nil, kv) do
     quote bind_quoted: [name: name, tag: tag, kv: kv] do
-      if Module.defines?(__MODULE__, {name, 0}) do
+      defined_arity =
+        Enum.find(0..2, fn arity ->
+          Module.defines?(__MODULE__, {name, arity})
+        end)
+
+      if defined_arity do
         raise ArgumentError,
-              "cannot define record #{inspect(name)} because a definition #{name}/0 already exists"
+              "cannot define record #{inspect(name)} because a definition #{name}/#{defined_arity} already exists"
       end
 
       tag = tag || name
@@ -279,9 +284,14 @@ defmodule Record do
   """
   defmacro defrecordp(name, tag \\ nil, kv) do
     quote bind_quoted: [name: name, tag: tag, kv: kv] do
-      if Module.defines?(__MODULE__, {name, 0}) do
+      defined_arity =
+        Enum.find(0..2, fn arity ->
+          Module.defines?(__MODULE__, {name, arity})
+        end)
+
+      if defined_arity do
         raise ArgumentError,
-              "cannot define record #{inspect(name)} because a definition #{name}/0 already exists"
+              "cannot define record #{inspect(name)} because a definition #{name}/#{defined_arity} already exists"
       end
 
       tag = tag || name

--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -255,11 +255,9 @@ defmodule Record do
   """
   defmacro defrecord(name, tag \\ nil, kv) do
     quote bind_quoted: [name: name, tag: tag, kv: kv] do
-      if Module.defines?(__MODULE__, {name, 0}, :defmacro) do
-        raise CompileError,
-          file: __ENV__.file,
-          line: __ENV__.line,
-          description: "record #{inspect(name)} was previously defined"
+      if Module.defines?(__MODULE__, {name, 0}) do
+        raise ArgumentError,
+              "cannot define record #{inspect(name)} because a definition #{name}/0 already exists"
       end
 
       tag = tag || name
@@ -281,11 +279,9 @@ defmodule Record do
   """
   defmacro defrecordp(name, tag \\ nil, kv) do
     quote bind_quoted: [name: name, tag: tag, kv: kv] do
-      if Module.defines?(__MODULE__, {name, 0}, :defmacrop) do
-        raise CompileError,
-          file: __ENV__.file,
-          line: __ENV__.line,
-          description: "record #{inspect(name)} was previously defined"
+      if Module.defines?(__MODULE__, {name, 0}) do
+        raise ArgumentError,
+              "cannot define record #{inspect(name)} because a definition #{name}/0 already exists"
       end
 
       tag = tag || name

--- a/lib/elixir/test/elixir/record_test.exs
+++ b/lib/elixir/test/elixir/record_test.exs
@@ -268,4 +268,30 @@ defmodule RecordTest do
       end
     end
   end
+
+  test "macro and record with the same name defined" do
+    msg = "cannot define record :a because a definition a/1 already exists"
+
+    assert_raise ArgumentError, msg, fn ->
+      defmodule M do
+        defmacro a(_) do
+        end
+
+        require Record
+        Record.defrecord(:a, [:a])
+      end
+    end
+
+    msg = "cannot define record :a because a definition a/2 already exists"
+
+    assert_raise ArgumentError, msg, fn ->
+      defmodule M do
+        defmacro a(_, _) do
+        end
+
+        require Record
+        Record.defrecord(:a, [:a])
+      end
+    end
+  end
 end

--- a/lib/elixir/test/elixir/record_test.exs
+++ b/lib/elixir/test/elixir/record_test.exs
@@ -258,9 +258,9 @@ defmodule RecordTest do
   end
 
   test "records defined multiple times" do
-    msg_regex = ~r/record :r was previously defined/
+    msg = "cannot define record :r because a definition r/0 already exists"
 
-    assert_raise CompileError, msg_regex, fn ->
+    assert_raise ArgumentError, msg, fn ->
       defmodule M do
         import Record
         defrecord :r, [:a]

--- a/lib/elixir/test/elixir/record_test.exs
+++ b/lib/elixir/test/elixir/record_test.exs
@@ -256,4 +256,16 @@ defmodule RecordTest do
     assert timestamp(record, :date) == :foo
     assert timestamp(record, :time) == :bar
   end
+
+  test "records defined multiple times" do
+    msg_regex = ~r/record :r was previously defined/
+
+    assert_raise CompileError, msg_regex, fn ->
+      defmodule M do
+        import Record
+        defrecord :r, [:a]
+        defrecord :r, [:a]
+      end
+    end
+  end
 end


### PR DESCRIPTION
An implementation for #8210 , about a better error message for previously defined Records.

The previous error message can be seen in the linked issue.

The new error message is:
```
== Compilation error in file m.ex ==
** (CompileError) m.ex:5: record :r was previously defined
    m.ex:5: (module)
    (stdlib) erl_eval.erl:677: :erl_eval.do_apply/6
```

Any feedback is appreciated, especially around potentially pulling the `defines?` check and error message into its own function. The check and CompileError logic feels a little long in the `defrecord`/`defrecordp` functions, however, I couldn't figure out how to extract them since its inside macro definitions.
