### PR TITLE
Move rewrite match to kernel

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1187,9 +1187,34 @@ defmodule Kernel do
 
   """
   @doc guard: true
-  @spec +value :: value when value: number
-  def +value do
-    :erlang.+(value)
+  @spec +0 :: 0
+  @spec +pos_integer :: neg_integer
+  @spec +neg_integer :: pos_integer
+  @spec +float :: float
+  defmacro +value do
+    case __CALLER__.context do
+      :match ->
+        match_unary_plus(value)
+
+      _other ->
+        quote do
+          :erlang.+(unquote(value))
+        end
+    end
+  end
+
+  defp match_unary_plus(value) when is_number(value) do
+    quote do
+      unquote(value)
+    end
+  end
+
+  defp match_unary_plus(value) do
+    :erlang.error(
+      ArgumentError.exception(
+        "cannot invoke #{Macro.to_string(value)} inside a match"
+      )
+    )
   end
 
   @doc """
@@ -1208,8 +1233,30 @@ defmodule Kernel do
   @spec -pos_integer :: neg_integer
   @spec -neg_integer :: pos_integer
   @spec -float :: float
-  def -value do
-    :erlang.-(value)
+  defmacro -value do
+    case __CALLER__.context do
+      :match ->
+        match_unary_minus(value)
+
+      _other ->
+        quote do
+          :erlang.-(unquote(value))
+        end
+    end
+  end
+
+  defp match_unary_minus(value) when is_number(value) do
+    quote do
+      unquote(-value)
+    end
+  end
+
+  defp match_unary_minus(value) do
+    :erlang.error(
+      ArgumentError.exception(
+        "cannot invoke #{Macro.to_string(value)} inside a match"
+      )
+    )
   end
 
   @doc """

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1357,17 +1357,14 @@ defmodule Kernel do
   end
 
   defp match_list_concat(left, right, caller) do
-    expand =
+    expanded_left =
       case bootstrapped?(Macro) do
-        true -> &Macro.expand(&1, caller)
-        false -> & &1
+        true -> Macro.expand(left, caller)
+        false -> left
       end
 
-    expanded_left = expand.(left)
-    expanded_right = expand.(right)
-
     try do
-      static_append(expanded_left, expanded_right)
+      static_append(expanded_left, right)
     catch
       :impossible ->
         :erlang.error(

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1178,7 +1178,7 @@ defmodule Kernel do
   @doc """
   Arithmetic unary plus.
 
-  Allowed in guard tests. Inlined by the compiler.
+  Allowed in guard tests.
 
   ## Examples
 
@@ -1212,7 +1212,8 @@ defmodule Kernel do
   defp match_unary_plus(value) do
     :erlang.error(
       ArgumentError.exception(
-        "cannot invoke #{Macro.to_string(value)} inside a match"
+        <<"invalid argument for + unary operator inside a match, expected a ",
+          "literal number, got: #{Macro.to_string(value)}">>
       )
     )
   end
@@ -1220,7 +1221,7 @@ defmodule Kernel do
   @doc """
   Arithmetic unary minus.
 
-  Allowed in guard tests. Inlined by the compiler.
+  Allowed in guard tests.
 
   ## Examples
 
@@ -1254,7 +1255,8 @@ defmodule Kernel do
   defp match_unary_minus(value) do
     :erlang.error(
       ArgumentError.exception(
-        "cannot invoke #{Macro.to_string(value)} inside a match"
+        <<"invalid argument for - unary operator inside a match, expected a ",
+          "literal number, got: #{Macro.to_string(value)}">>
       )
     )
   end
@@ -1320,8 +1322,6 @@ defmodule Kernel do
   If the `right` operand is not a proper list, it returns an improper list.
   If the `left` operand is not a proper list, it raises `ArgumentError`.
 
-  Inlined by the compiler.
-
   ## Examples
 
       iex> [1] ++ [2, 3]
@@ -1372,8 +1372,8 @@ defmodule Kernel do
       :impossible ->
         :erlang.error(
           ArgumentError.exception(
-            "invalid argument for ++ operator inside a match, expected a " <>
-              "literal proper list, got: #{Macro.to_string(left)}"
+            <<"invalid argument for ++ operator inside a match, expected a ",
+              "literal proper list, got: #{Macro.to_string(left)}">>
           )
         )
     end

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -758,8 +758,8 @@ expand_remote(Receiver, DotMeta, Right, Meta, Args, E, _) ->
   Call = {{'.', DotMeta, [Receiver, Right]}, Meta, Args},
   form_error(Meta, ?key(E, file), ?MODULE, {invalid_call, Call}).
 
-rewrite(match, Receiver, DotMeta, Right, Meta, EArgs) ->
-  elixir_rewrite:match_rewrite(Receiver, DotMeta, Right, Meta, EArgs);
+rewrite(match, Receiver, _DotMeta, Right, _Meta, EArgs) ->
+  {error, {invalid_match, Receiver, Right, length(EArgs)}};
 rewrite(guard, Receiver, DotMeta, Right, Meta, EArgs) ->
   elixir_rewrite:guard_rewrite(Receiver, DotMeta, Right, Meta, EArgs);
 rewrite(_, Receiver, DotMeta, Right, Meta, EArgs) ->

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -1,5 +1,5 @@
 -module(elixir_rewrite).
--export([rewrite/5, match_rewrite/5, guard_rewrite/5, inline/3, format_error/1]).
+-export([rewrite/5, guard_rewrite/5, inline/3, format_error/1]).
 -include("elixir.hrl").
 
 %% Convenience variables
@@ -42,10 +42,7 @@ inline(?io, iodata_to_binary, 1) -> {erlang, iolist_to_binary};
 inline(?kernel, '!=', 2) -> {erlang, '/='};
 inline(?kernel, '!==', 2) -> {erlang, '=/='};
 inline(?kernel, '*', 2) -> {erlang, '*'};
-inline(?kernel, '+', 1) -> {erlang, '+'};
 inline(?kernel, '+', 2) -> {erlang, '+'};
-inline(?kernel, '++', 2) -> {erlang, '++'};
-inline(?kernel, '-', 1) -> {erlang, '-'};
 inline(?kernel, '-', 2) -> {erlang, '-'};
 inline(?kernel, '--', 2) -> {erlang, '--'};
 inline(?kernel, '/', 2) -> {erlang, '/'};
@@ -240,16 +237,6 @@ increment(Number) when is_number(Number) ->
   Number + 1;
 increment(Other) ->
   {{'.', [], [erlang, '+']}, [], [Other, 1]}.
-
-%% Match rewrite
-%%
-%% Match rewrite is similar to regular rewrite, except
-%% it also verifies the rewrite rule applies in a match context.
-%% The allowed operations are very limited.
-%% The Kernel operators are already inlined by now, we only need to
-%% care about Erlang ones.
-match_rewrite(Receiver, _, Right, _, Args) ->
-  {error, {invalid_match, Receiver, Right, length(Args)}}.
 
 %% Guard rewrite
 %%

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -250,20 +250,8 @@ increment(Other) ->
 %% care about Erlang ones.
 match_rewrite(erlang, _, '+', _, [Arg]) when is_number(Arg) -> {ok, Arg};
 match_rewrite(erlang, _, '-', _, [Arg]) when is_number(Arg) -> {ok, -Arg};
-match_rewrite(erlang, _, '++', Meta, [Left, Right]) ->
-  try {ok, static_append(Left, Right, Meta)}
-  catch impossible -> {error, {invalid_match_append, Left}}
-  end;
 match_rewrite(Receiver, _, Right, _, Args) ->
   {error, {invalid_match, Receiver, Right, length(Args)}}.
-
-static_append([], Right, _Meta) -> Right;
-static_append([{'|', InnerMeta, [Head, Tail]}], Right, Meta) when is_list(Tail) ->
-  [{'|', InnerMeta, [Head, static_append(Tail, Right, Meta)]}];
-static_append([{'|', _, [_, _]}], _, _) -> throw(impossible);
-static_append([Last], Right, Meta) -> [{'|', Meta, [Last, Right]}];
-static_append([Head | Tail], Right, Meta) -> [Head | static_append(Tail, Right, Meta)];
-static_append(_, _, _) -> throw(impossible).
 
 %% Guard rewrite
 %%
@@ -288,7 +276,4 @@ format_error({invalid_guard, Receiver, Right, Arity}) ->
                 ['Elixir.Macro':to_string(Receiver), Right, Arity]);
 format_error({invalid_match, Receiver, Right, Arity}) ->
   io_lib:format("cannot invoke remote function ~ts.~ts/~B inside a match",
-                ['Elixir.Macro':to_string(Receiver), Right, Arity]);
-format_error({invalid_match_append, Arg}) ->
-  io_lib:format("invalid argument for ++ operator inside a match, expected a literal proper list, got: ~ts",
-                ['Elixir.Macro':to_string(Arg)]).
+                ['Elixir.Macro':to_string(Receiver), Right, Arity]).

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -248,8 +248,6 @@ increment(Other) ->
 %% The allowed operations are very limited.
 %% The Kernel operators are already inlined by now, we only need to
 %% care about Erlang ones.
-match_rewrite(erlang, _, '+', _, [Arg]) when is_number(Arg) -> {ok, Arg};
-match_rewrite(erlang, _, '-', _, [Arg]) when is_number(Arg) -> {ok, -Arg};
 match_rewrite(Receiver, _, Right, _, Args) ->
   {error, {invalid_match, Receiver, Right, length(Args)}}.
 

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -560,6 +560,10 @@ defmodule Kernel.ExpansionTest do
       message = ~r"cannot invoke remote function :erlang.make_ref/0 inside a match"
       assert_raise CompileError, message, fn -> expand(quote(do: make_ref() = :foo)) end
 
+      message = ~r"cannot invoke one\(\) inside a match"
+      assert_raise ArgumentError, message, fn -> expand(quote(do: -one() = -1)) end
+      assert_raise ArgumentError, message, fn -> expand(quote(do: +one() = 1)) end
+
       message = ~r"invalid argument for \+\+ operator inside a match"
 
       assert_raise ArgumentError, message, fn ->

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -560,8 +560,10 @@ defmodule Kernel.ExpansionTest do
       message = ~r"cannot invoke remote function :erlang.make_ref/0 inside a match"
       assert_raise CompileError, message, fn -> expand(quote(do: make_ref() = :foo)) end
 
-      message = ~r"cannot invoke one\(\) inside a match"
+      message = ~r"invalid argument for - unary operator inside a match"
       assert_raise ArgumentError, message, fn -> expand(quote(do: -one() = -1)) end
+
+      message = ~r"invalid argument for \+ unary operator inside a match"
       assert_raise ArgumentError, message, fn -> expand(quote(do: +one() = 1)) end
 
       message = ~r"invalid argument for \+\+ operator inside a match"

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -562,15 +562,15 @@ defmodule Kernel.ExpansionTest do
 
       message = ~r"invalid argument for \+\+ operator inside a match"
 
-      assert_raise CompileError, message, fn ->
+      assert_raise ArgumentError, message, fn ->
         expand(quote(do: "a" ++ "b" = "ab"))
       end
 
-      assert_raise CompileError, message, fn ->
+      assert_raise ArgumentError, message, fn ->
         expand(quote(do: [1 | 2] ++ [3] = [1, 2, 3]))
       end
 
-      assert_raise CompileError, message, fn ->
+      assert_raise ArgumentError, message, fn ->
         expand(quote(do: [1] ++ 2 ++ [3] = [1, 2, 3]))
       end
 


### PR DESCRIPTION
I saw a possibility to move the rewrites made in `:elixir_rewrite.rewrite_match/5` close to their source in `Kernel` simplifying the logic, so I gave it a try. If it does not make sense, feel free to close it.

After this, it's not possible to call directly `:erlang.++/2`, `:erlang.+/1` and `:erlang.-/1`, but this behavior is similar to Erlang.