### PR TITLE
Forbid using only the "else" clause in "try"

### DIFF
--- a/lib/elixir/src/elixir_clauses.erl
+++ b/lib/elixir/src/elixir_clauses.erl
@@ -187,7 +187,12 @@ expand_with_else(Meta, Opts, E, HasMatch) ->
 'try'(Meta, [{do, _}], E) ->
   form_error(Meta, ?key(E, file), elixir_expand, {missing_option, 'try', ['catch', 'rescue', 'after', 'else']});
 'try'(Meta, [{do, _}, {else, _}], E) ->
-  form_error(Meta, ?key(E, file), ?MODULE, try_with_only_else_clause);
+  Kind =
+    case lists:keyfind(origin, 1, Meta) of
+      {origin, Origin} -> Origin;
+      false -> 'try'
+    end,
+  form_error(Meta, ?key(E, file), ?MODULE, {try_with_only_else_clause, Kind});
 'try'(Meta, Opts, E) when not is_list(Opts) ->
   form_error(Meta, ?key(E, file), elixir_expand, {invalid_args, 'try'});
 'try'(Meta, Opts, E) ->
@@ -346,9 +351,9 @@ format_error(invalid_rescue_clause) ->
 format_error(catch_before_rescue) ->
   "\"catch\" should always come after \"rescue\" in try";
 
-format_error(try_with_only_else_clause) ->
-  "\"else\" can't be used as the only clause in \"try\" since it's equivalent to not "
-    "having the \"try\" in the first place";
+format_error({try_with_only_else_clause, Kind}) ->
+  io_lib:format("\"else\" can't be used as the only clause in \"~ts\" since it's equivalent to not "
+                "having the \"try\" in the first place", [Kind]);
 
 format_error(unmatchable_else_in_with) ->
   "\"else\" clauses will never match because all patterns in \"with\" will always match";

--- a/lib/elixir/src/elixir_clauses.erl
+++ b/lib/elixir/src/elixir_clauses.erl
@@ -186,6 +186,8 @@ expand_with_else(Meta, Opts, E, HasMatch) ->
   form_error(Meta, ?key(E, file), elixir_expand, {missing_option, 'try', [do]});
 'try'(Meta, [{do, _}], E) ->
   form_error(Meta, ?key(E, file), elixir_expand, {missing_option, 'try', ['catch', 'rescue', 'after', 'else']});
+'try'(Meta, [{do, _}, {else, _}], E) ->
+  form_error(Meta, ?key(E, file), ?MODULE, try_with_only_else_clause);
 'try'(Meta, Opts, E) when not is_list(Opts) ->
   form_error(Meta, ?key(E, file), elixir_expand, {invalid_args, 'try'});
 'try'(Meta, Opts, E) ->
@@ -343,6 +345,10 @@ format_error(invalid_rescue_clause) ->
 
 format_error(catch_before_rescue) ->
   "\"catch\" should always come after \"rescue\" in try";
+
+format_error(try_with_only_else_clause) ->
+  "\"else\" can't be used as the only clause in \"try\" since it's equivalent to not "
+    "having the \"try\" in the first place";
 
 format_error(unmatchable_else_in_with) ->
   "\"else\" clauses will never match because all patterns in \"with\" will always match";

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -952,6 +952,18 @@ defmodule Kernel.ErrorsTest do
     """
   end
 
+  test "def raises if there's only the else clause" do
+    assert_eval_raise CompileError, ~r"\"else\" can't be used as the only clause in \"def\"", """
+    defmodule Example do
+      def foo do
+        bar()
+      else
+        _other -> :ok
+      end
+    end
+    """
+  end
+
   defp bad_remote_call(x), do: x.foo
 
   defmacro sample(0), do: 0

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -941,11 +941,11 @@ defmodule Kernel.ErrorsTest do
   end
 
   test "def fails when rescue, else or catch don't have clauses" do
-    assert_eval_raise CompileError, ~r"expected -> clauses for :else in \"def\"", """
+    assert_eval_raise CompileError, ~r"expected -> clauses for :rescue in \"def\"", """
     defmodule Example do
       def foo do
         bar()
-      else
+      rescue
         baz()
       end
     end

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -1583,6 +1583,8 @@ defmodule Kernel.ExpansionTest do
         quote do
           try do
             x
+          catch
+            _, _ -> :ok
           else
             z -> z
           end
@@ -1594,6 +1596,8 @@ defmodule Kernel.ExpansionTest do
         quote do
           try do
             x()
+          catch
+            _, _ -> :ok
           else
             z -> z
           end
@@ -1650,6 +1654,21 @@ defmodule Kernel.ExpansionTest do
     test "raises if do is missing" do
       assert_raise CompileError, ~r"missing :do option in \"try\"", fn ->
         expand(quote(do: try([])))
+      end
+    end
+
+    test "raises if the only clause other than do is else" do
+      assert_raise CompileError, ~r"\"else\" can't be used as the only clause", fn ->
+        code =
+          quote do
+            try do
+              :ok
+            else
+              other -> other
+            end
+          end
+
+        expand(code)
       end
     end
 
@@ -1836,6 +1855,8 @@ defmodule Kernel.ExpansionTest do
           quote do
             try do
               e
+            catch
+              _ -> :ok
             else
               x
             end
@@ -1849,6 +1870,8 @@ defmodule Kernel.ExpansionTest do
           quote do
             try do
               e
+            catch
+              _ -> :ok
             else
               [:not, :clauses]
             end

--- a/lib/elixir/test/elixir/kernel/raise_test.exs
+++ b/lib/elixir/test/elixir/kernel/raise_test.exs
@@ -451,6 +451,9 @@ defmodule Kernel.RaiseTest do
         try do
           try do
             f.()
+          rescue
+            _exception ->
+              :ok
           else
             :other ->
               :ok

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -60,6 +60,8 @@ defmodule MapTest do
     assert %{
              try do
                1
+             rescue
+               _exception -> :exception
              else
                a -> a
              end => 1

--- a/lib/elixir/test/erlang/control_test.erl
+++ b/lib/elixir/test/erlang/control_test.erl
@@ -228,7 +228,7 @@ optimized_or_test() ->
   } = to_erl("is_list([]) or :done").
 
 no_after_in_try_test() ->
-  {'try', _, [_], [_], _, []} = to_erl("try do :foo.bar() else _ -> :ok end").
+  {'try', _, [_], [], [_], []} = to_erl("try do :foo.bar() catch _ -> :ok end").
 
 optimized_inspect_interpolation_test() ->
     {bin, _,


### PR DESCRIPTION
Closes #8146.

Now using `else` without a `rescue`, `catch`, or `after` in `try` expressions is not allowed anymore.

I started with not allowing `else` by itself but I wonder if it would make sense to also disallow `else` if the only other clause is `after`. `else` is there to handle what happens if nothing is caught/rescued, so it might make sense to disallow `else`/`after` as well. Let me know your thoughts!