### PR TITLE
 Optimizes multiple :maps put and merge operations

### DIFF
--- a/lib/elixir/src/elixir_erl_compiler.erl
+++ b/lib/elixir/src/elixir_erl_compiler.erl
@@ -52,6 +52,7 @@ handle_file_warning(_, _File, {_Line, erl_lint, {unused_function, _}}) -> ok;
 handle_file_warning(_, _File, {_Line, erl_lint, {unused_var, _}}) -> ok;
 handle_file_warning(_, _File, {_Line, erl_lint, {shadowed_var, _, _}}) -> ok;
 handle_file_warning(_, _File, {_Line, erl_lint, {exported_var, _, _}}) -> ok;
+handle_file_warning(_, _File, {_Line, v3_core, {map_key_repeated, _}}) -> ok;
 
 %% Ignore behaviour warnings as we check for these problem ourselves
 handle_file_warning(_, _File, {_Line, erl_lint, {conflicting_behaviours, _, _, _, _}}) -> ok;
@@ -101,10 +102,6 @@ format_error(sys_core_fold, {no_effect, {erlang, F, A}}) ->
 %% Rewrite nomatch_guard to be more generic it can happen inside if, unless, etc
 format_error(sys_core_fold, nomatch_guard) ->
   "this check/guard will always yield the same result";
-
-%% Properly format keys using inspect.
-format_error(v3_core, {map_key_repeated, Key}) ->
-    io_lib:format("key ~ts will be overridden in map", ['Elixir.Kernel':inspect(Key)]);
 
 %% Handle literal eval failures
 format_error(sys_core_fold, {eval_failure, Error}) ->

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -644,10 +644,20 @@ will_override(_, _, false) ->
   false;
 will_override({Atom, _, Arg}, {Atom, _, Arg}, Result) when is_atom(Atom) ->
   Result;
+will_override({map_field_assoc, _, Key1, Value1}, {map_field_assoc, _, Key2, Value2}, Result) ->
+  KeyOverride = will_override(Key1, Key2, Result),
+  will_override(Value1, Value2, KeyOverride);
+will_override({Atom, _, Args1}, {Atom, _, Args2}, Result) when is_list(Args1), is_list(Args2) ->
+  will_override(Args1, Args2, Result);
 will_override({cons, _, Head1, Tail1}, {cons, _, Head2, Tail2}, Result) ->
   HeadOverride = will_override(Head1, Head2, Result),
   will_override(Tail1, Tail2, HeadOverride);
 will_override({nil, _}, {nil, _}, Result) ->
+  Result;
+will_override([Head1 | Tail1], [Head2 | Tail2], Result) ->
+  HeadOverride = will_override(Head1, Head2, Result),
+  will_override(Tail1, Tail2, HeadOverride);
+will_override([], [], Result) ->
   Result;
 will_override(_, _, _) ->
   false.

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -87,33 +87,10 @@ validate_match_key(_, _, _) ->
   ok.
 
 validate_not_repeated(Meta, Key, Used, E) ->
-  try
-    KeyWithoutMeta = remove_key_meta(Key),
-    case Used of
-      #{KeyWithoutMeta := true} ->
-        form_warn(Meta, ?key(E, file), ?MODULE, {repeated_key, Key});
-
-      #{} ->
-        Used#{KeyWithoutMeta => true}
-    end
-  catch
-    non_literal_key -> Used
+  case Used of
+    #{Key := true} -> form_warn(Meta, ?key(E, file), ?MODULE, {repeated_key, Key});
+    #{} -> Used#{Key => true}
   end.
-
-remove_key_meta(Literal) when is_atom(Literal); is_number(Literal) ->
-  Literal;
-remove_key_meta({'%{}', _, Args}) ->
-  {'%{}', remove_key_meta(Args)};
-remove_key_meta({'{}', _, Args}) ->
-  {'{}', remove_key_meta(Args)};
-remove_key_meta({Arg1, Arg2}) ->
-  {'{}', [Arg1, Arg2]};
-remove_key_meta([Head | Tail]) ->
-  [remove_key_meta(Head) | remove_key_meta(Tail)];
-remove_key_meta([]) ->
-  [];
-remove_key_meta(_) ->
-  throw(non_literal_key).
 
 validate_kv(Meta, KV, Original, #{context := Context} = E) ->
   lists:foldl(fun

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -87,10 +87,16 @@ validate_match_key(_, _, _) ->
   ok.
 
 validate_not_repeated(Meta, Key, Used, E) ->
-  case Used of
+  case is_literal(Key) andalso Used of
     #{Key := true} -> form_warn(Meta, ?key(E, file), ?MODULE, {repeated_key, Key});
-    #{} -> Used#{Key => true}
+    #{} -> Used#{Key => true};
+    false -> Used
   end.
+
+is_literal({_, _, _}) -> false;
+is_literal({Left, Right}) -> is_literal(Left) andalso is_literal(Right);
+is_literal([_ | _] = List) -> lists:all(fun is_literal/1, List);
+is_literal(_) -> true.
 
 validate_kv(Meta, KV, Original, #{context := Context} = E) ->
   lists:foldl(fun

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -86,16 +86,46 @@ validate_match_key(Meta, List, E) when is_list(List) ->
 validate_match_key(_, _, _) ->
   ok.
 
+validate_not_repeated(Meta, Key, Used, E) ->
+  try
+    Literal = literal_key(Key),
+    case Used of
+      #{Literal := true} ->
+        form_warn(Meta, ?key(E, file), ?MODULE, {repeated_key, Key});
+
+      #{} ->
+        Used#{Literal => true}
+    end
+  catch
+    non_literal_key -> Used
+  end.
+
+literal_key(Literal) when is_atom(Literal); is_number(Literal) ->
+  Literal;
+literal_key({'%{}', _, Args}) ->
+  maps:from_list(literal_key(Args));
+literal_key({'{}', _, Args}) ->
+  erlang:list_to_tuple(literal_key(Args));
+literal_key({_, _} = Tuple) ->
+  Tuple;
+literal_key([Head | Tail]) ->
+  [literal_key(Head) | literal_key(Tail)];
+literal_key([]) ->
+  [];
+literal_key(_) ->
+  throw(non_literal_key).
+
 validate_kv(Meta, KV, Original, #{context := Context} = E) ->
   lists:foldl(fun
-    ({{'^', _, [_]}, _}, Acc) ->
-      Acc + 1;
-    ({K, _V}, Acc) ->
+    ({{'^', _, [_]}, _}, {Index, Used}) ->
+      {Index + 1, Used};
+    ({K, _V}, {Index, Used}) ->
       (Context == match) andalso validate_match_key(Meta, K, E),
-      Acc + 1;
-    (_, Acc) ->
-      form_error(Meta, ?key(E, file), ?MODULE, {not_kv_pair, lists:nth(Acc, Original)})
-  end, 1, KV).
+      NewUsed = validate_not_repeated(Meta, K, Used, E),
+      {Index + 1, NewUsed};
+    (_, {Index, _Used}) ->
+      form_error(Meta, ?key(E, file), ?MODULE, {not_kv_pair, lists:nth(Index, Original)})
+  end, {1, #{}}, KV).
 
 extract_struct_assocs(_, {'%{}', Meta, [{'|', _, [_, Assocs]}]}, _) ->
   {update, Meta, delete_struct_key(Assocs)};
@@ -189,6 +219,8 @@ format_error({invalid_variable_in_map_key_match, Name}) ->
     "(such as atoms, strings, tuples, etc) or an existing variable matched with the pin operator "
     "(such as ^some_var)",
   io_lib:format(Message, [Name]);
+format_error({repeated_key, Key}) ->
+    io_lib:format("key ~ts will be overridden in map", ['Elixir.Macro':to_string(Key)]);
 format_error({not_kv_pair, Expr}) ->
   io_lib:format("expected key-value pairs in a map, got: ~ts",
                 ['Elixir.Macro':to_string(Expr)]);

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -589,6 +589,18 @@ defmodule Kernel.WarningTest do
 
     assert output =~ "key :a will be overridden in map"
     assert output =~ "key 1 will be overridden in map"
+
+    output =
+      capture_err(fn ->
+        defmodule NoWarningDuplicateMapKeys do
+          assert Map.merge(%{a: :b}, %{a: :c}) == %{a: :c}
+          assert Map.merge(%{1 => 2}, %{1 => 3}) == %{1 => 3}
+          assert Map.merge(%{[1] => 2}, %{[1] => 3}) == %{[1] => 3}
+          assert Map.merge(%{%{a: :b} => 2}, %{%{a: :b} => 3}) == %{%{a: :b} => 3}
+        end
+      end)
+
+    assert output == ""
   end
 
   test "unused guard" do

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -584,15 +584,11 @@ defmodule Kernel.WarningTest do
         defmodule DuplicateMapKeys do
           assert %{a: :b, a: :c} == %{a: :c}
           assert %{1 => 2, 1 => 3} == %{1 => 3}
-          assert %{[1] => 2, [1] => 3} == %{[1] => 3}
-          assert %{%{a: :b} => 2, %{a: :b} => 3} == %{%{a: :b} => 3}
         end
       end)
 
     assert output =~ "key :a will be overridden in map"
     assert output =~ "key 1 will be overridden in map"
-    assert output =~ "key [1] will be overridden in map"
-    assert output =~ "key %{a: :b} will be overridden in map"
   end
 
   test "unused guard" do

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -589,6 +589,21 @@ defmodule Kernel.WarningTest do
 
     assert output =~ "key :a will be overridden in map"
     assert output =~ "key 1 will be overridden in map"
+
+    pid = start_supervised!({Agent, fn -> 1 end})
+
+    next = fn ->
+      Agent.get_and_update(pid, fn acc -> {acc, acc + 1} end)
+    end
+
+    output =
+      capture_err(fn ->
+        defmodule NonLiteralDuplicateMapKeys do
+          assert %{next.() => 1, next.() => 2} == %{1 => 1, 2 => 2}
+        end
+      end)
+
+    assert output == ""
   end
 
   test "unused guard" do

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -584,23 +584,15 @@ defmodule Kernel.WarningTest do
         defmodule DuplicateMapKeys do
           assert %{a: :b, a: :c} == %{a: :c}
           assert %{1 => 2, 1 => 3} == %{1 => 3}
+          assert %{[1] => 2, [1] => 3} == %{[1] => 3}
+          assert %{%{a: :b} => 2, %{a: :b} => 3} == %{%{a: :b} => 3}
         end
       end)
 
     assert output =~ "key :a will be overridden in map"
     assert output =~ "key 1 will be overridden in map"
-
-    output =
-      capture_err(fn ->
-        defmodule NoWarningDuplicateMapKeys do
-          assert Map.merge(%{a: :b}, %{a: :c}) == %{a: :c}
-          assert Map.merge(%{1 => 2}, %{1 => 3}) == %{1 => 3}
-          assert Map.merge(%{[1] => 2}, %{[1] => 3}) == %{[1] => 3}
-          assert Map.merge(%{%{a: :b} => 2}, %{%{a: :b} => 3}) == %{%{a: :b} => 3}
-        end
-      end)
-
-    assert output == ""
+    assert output =~ "key [1] will be overridden in map"
+    assert output =~ "key %{a: :b} will be overridden in map"
   end
 
   test "unused guard" do

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -590,20 +590,7 @@ defmodule Kernel.WarningTest do
     assert output =~ "key :a will be overridden in map"
     assert output =~ "key 1 will be overridden in map"
 
-    pid = start_supervised!({Agent, fn -> 1 end})
-
-    next = fn ->
-      Agent.get_and_update(pid, fn acc -> {acc, acc + 1} end)
-    end
-
-    output =
-      capture_err(fn ->
-        defmodule NonLiteralDuplicateMapKeys do
-          assert %{next.() => 1, next.() => 2} == %{1 => 1, 2 => 2}
-        end
-      end)
-
-    assert output == ""
+    assert map_size(%{System.unique_integer() => 1, System.unique_integer() => 2}) == 2
   end
 
   test "unused guard" do

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -149,6 +149,39 @@ defmodule MapTest do
     end
   end
 
+  test "put/3 optimized by the compiler" do
+    map = %{a: 1, b: 2}
+
+    assert Map.put(map, :a, 2) == %{a: 2, b: 2}
+    assert Map.put(map, :c, 3) == %{a: 1, b: 2, c: 3}
+
+    assert Map.put(%{map | a: 2}, :a, 3) == %{a: 3, b: 2}
+    assert Map.put(%{map | a: 2}, :b, 3) == %{a: 2, b: 3}
+
+    assert Map.put(map, :a, 2) |> Map.put(:a, 3) == %{a: 3, b: 2}
+    assert Map.put(map, :a, 2) |> Map.put(:c, 3) == %{a: 2, b: 2, c: 3}
+    assert Map.put(map, :c, 3) |> Map.put(:a, 2) == %{a: 2, b: 2, c: 3}
+    assert Map.put(map, :c, 3) |> Map.put(:c, 4) == %{a: 1, b: 2, c: 4}
+  end
+
+  test "merge/2 with map literals optimized by the compiler" do
+    map = %{a: 1, b: 2}
+
+    assert Map.merge(map, %{a: 2}) == %{a: 2, b: 2}
+    assert Map.merge(map, %{c: 3}) == %{a: 1, b: 2, c: 3}
+    assert Map.merge(%{a: 2}, map) == %{a: 1, b: 2}
+    assert Map.merge(%{c: 3}, map) == %{a: 1, b: 2, c: 3}
+
+    assert Map.merge(%{map | a: 2}, %{a: 3}) == %{a: 3, b: 2}
+    assert Map.merge(%{map | a: 2}, %{b: 3}) == %{a: 2, b: 3}
+    assert Map.merge(%{a: 2}, %{map | a: 3}) == %{a: 3, b: 2}
+    assert Map.merge(%{a: 2}, %{map | b: 3}) == %{a: 1, b: 3}
+
+    assert Map.merge(map, %{a: 2}) |> Map.merge(%{a: 3, c: 3}) == %{a: 3, b: 2, c: 3}
+    assert Map.merge(map, %{c: 3}) |> Map.merge(%{c: 4}) == %{a: 1, b: 2, c: 4}
+    assert Map.merge(map, %{a: 3, c: 3}) |> Map.merge(%{a: 2}) == %{a: 2, b: 2, c: 3}
+  end
+
   test "merge/3" do
     # When first map is bigger
     assert Map.merge(%{a: 1, b: 2, c: 3}, %{c: 4, d: 5}, fn :c, 3, 4 -> :x end) ==

--- a/lib/elixir/test/erlang/control_test.erl
+++ b/lib/elixir/test/erlang/control_test.erl
@@ -274,6 +274,24 @@ optimized_map_merge_variable_test() ->
      }]
   } = to_erl("x = %{}; Map.merge(x, %{a: 1})").
 
+optimized_map_update_and_merge_test() ->
+  {block, _,
+    [_,
+     {map, _, {var, _, _},
+       [{map_field_exact, _, {atom, _, a}, {integer, _, 2}},
+        {map_field_assoc, _, {atom, _, b}, {integer, _, 3}}]
+     }]
+  } = to_erl("x = %{a: 1}; Map.merge(%{x | a: 2}, %{b: 3})"),
+  {block, _,
+    [_,
+     {call, _, {remote, _, {atom, _, maps}, {atom, _, merge}},
+       [{map, _,
+          [{map_field_assoc, _, {atom, _, a}, {integer, _, 2}}]},
+        {map, _, {var, _, _},
+          [{map_field_exact, _, {atom, _, b}, {integer, _, 3}}]}]
+     }]
+  } = to_erl("x = %{a: 1}; Map.merge(%{a: 2}, %{x | b: 3})").
+
 optimized_nested_map_merge_variable_test() ->
   {block, _,
     [_,

--- a/lib/elixir/test/erlang/control_test.erl
+++ b/lib/elixir/test/erlang/control_test.erl
@@ -235,3 +235,50 @@ optimized_inspect_interpolation_test() ->
      [{bin_element, _,
        {call, _, {remote, _,{atom, _, 'Elixir.Kernel'}, {atom, _, inspect}}, [_]},
        default, [binary]}]} = to_erl("\"#{inspect(1)}\"").
+
+optimized_map_put_test() ->
+  {map, _,
+    [{map_field_assoc, _, {atom, _, a}, {integer, _, 1}},
+     {map_field_assoc, _, {atom, _, b}, {integer, _, 3}}]
+  } = to_erl("Map.put(%{a: 1, b: 2}, :b, 3)").
+
+optimized_map_put_variable_test() ->
+  {block, _,
+    [_,
+     {map, _, {var, _, _},
+       [{map_field_assoc, _, {atom, _, a}, {integer, _, 1}}]
+     }]
+  } = to_erl("x = %{}; Map.put(x, :a, 1)").
+
+optimized_nested_map_put_variable_test() ->
+  {block, _,
+    [_,
+     {map, _, {var, _, _},
+       [{map_field_assoc, _, {atom, _, a}, {integer, _, 1}},
+        {map_field_assoc, _, {atom, _, b}, {integer, _, 2}}]
+     }]
+  } = to_erl("x = %{}; Map.put(Map.put(x, :a, 1), :b, 2)").
+
+optimized_map_merge_test() ->
+  {map, _,
+    [{map_field_assoc, _, {atom, _, a}, {integer, _, 1}},
+     {map_field_assoc, _, {atom, _, b}, {integer, _, 3}},
+     {map_field_assoc, _, {atom, _, c}, {integer, _, 4}}]
+  } = to_erl("Map.merge(%{a: 1, b: 2}, %{b: 3, c: 4})").
+
+optimized_map_merge_variable_test() ->
+  {block, _,
+    [_,
+     {map, _, {var, _, _},
+       [{map_field_assoc, _, {atom, _, a}, {integer, _, 1}}]
+     }]
+  } = to_erl("x = %{}; Map.merge(x, %{a: 1})").
+
+optimized_nested_map_merge_variable_test() ->
+  {block, _,
+    [_,
+     {map, _, {var, _, _},
+       [{map_field_assoc, _, {atom, _, a}, {integer, _, 1}},
+        {map_field_assoc, _, {atom, _, b}, {integer, _, 2}}]
+     }]
+  } = to_erl("x = %{}; Map.merge(Map.merge(x, %{a: 1}), %{b: 2})").

--- a/lib/elixir/test/erlang/control_test.erl
+++ b/lib/elixir/test/erlang/control_test.erl
@@ -239,8 +239,8 @@ optimized_inspect_interpolation_test() ->
 optimized_map_put_test() ->
   {map, _,
     [{map_field_assoc, _, {atom, _, a}, {integer, _, 1}},
-     {map_field_assoc, _, {atom, _, b}, {integer, _, 3}}]
-  } = to_erl("Map.put(%{a: 1, b: 2}, :b, 3)").
+     {map_field_assoc, _, {atom, _, b}, {integer, _, 2}}]
+  } = to_erl("Map.put(%{a: 1}, :b, 2)").
 
 optimized_map_put_variable_test() ->
   {block, _,
@@ -262,9 +262,9 @@ optimized_nested_map_put_variable_test() ->
 optimized_map_merge_test() ->
   {map, _,
     [{map_field_assoc, _, {atom, _, a}, {integer, _, 1}},
-     {map_field_assoc, _, {atom, _, b}, {integer, _, 3}},
-     {map_field_assoc, _, {atom, _, c}, {integer, _, 4}}]
-  } = to_erl("Map.merge(%{a: 1, b: 2}, %{b: 3, c: 4})").
+     {map_field_assoc, _, {atom, _, b}, {integer, _, 2}},
+     {map_field_assoc, _, {atom, _, c}, {integer, _, 3}}]
+  } = to_erl("Map.merge(%{a: 1, b: 2}, %{c: 3})").
 
 optimized_map_merge_variable_test() ->
   {block, _,


### PR DESCRIPTION
Optimizes `:maps.put/3` to a VM operation instead of a remote call, including nested calls to it.
It does the same for `:maps.merge/2` with a simple map on the right side.

Keys that will be overridden are removed from the operation to avoid warnings.

Closes #7353