### PR TITLE
Change `args` to `init_arg` in GenServer start_link/3 and init/1

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -170,7 +170,7 @@ defmodule DynamicSupervisor do
           | :ignore
           | {:error, {:already_started, pid} | :max_children | term}
 
-  # NOTE: `args` refers to `init_arg`.
+  # In this struct, `args` refers to the arguments passed to init/1 (the `init_arg`).
   defstruct [
     :args,
     :extra_arguments,

--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -170,8 +170,9 @@ defmodule DynamicSupervisor do
           | :ignore
           | {:error, {:already_started, pid} | :max_children | term}
 
+  # NOTE: `args` refers to `init_arg`.
   defstruct [
-    :init_arg,
+    :args,
     :extra_arguments,
     :mod,
     :name,
@@ -540,7 +541,7 @@ defmodule DynamicSupervisor do
             is_tuple(name) -> name
           end
 
-        state = %DynamicSupervisor{mod: mod, init_arg: init_arg, name: name}
+        state = %DynamicSupervisor{mod: mod, args: init_arg, name: name}
 
         case init(state, flags) do
           {:ok, state} -> {:ok, state}
@@ -745,12 +746,7 @@ defmodule DynamicSupervisor do
   end
 
   @impl true
-  def code_change(old_vsn, %{args: init_arg} = state, extra) do
-    new_state = Map.delete(state, :args) |> Map.put(:init_arg, init_arg)
-    code_change(old_vsn, new_state, extra)
-  end
-
-  def code_change(_, %{mod: mod, init_arg: init_arg} = state, _) do
+  def code_change(_, %{mod: mod, args: init_arg} = state, _) do
     case mod.init(init_arg) do
       {:ok, flags} when is_map(flags) ->
         case init(state, flags) do

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -805,7 +805,7 @@ defmodule GenServer do
   This is often used to start the `GenServer` as part of a supervision tree.
 
   Once the server is started, the `c:init/1` function of the given `module` is
-  called with `init_arg` as its arguments to initialize the server. To ensure a
+  called with `init_arg` as its argument to initialize the server. To ensure a
   synchronized start-up procedure, this function does not return until `c:init/1`
   has returned.
 

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -495,7 +495,7 @@ defmodule Supervisor do
   Developers typically invoke `Supervisor.init/2` at the end of their
   init callback to return the proper supervision flags.
   """
-  @callback init(args :: term) ::
+  @callback init(init_arg :: term) ::
               {:ok, {:supervisor.sup_flags(), [:supervisor.child_spec()]}}
               | :ignore
 

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -353,12 +353,12 @@ defmodule Supervisor do
         # Automatically defines child_spec/1
         use Supervisor
 
-        def start_link(arg) do
-          Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
+        def start_link(init_arg) do
+          Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
         end
 
         @impl true
-        def init(_arg) do
+        def init(_init_arg) do
           children = [
             {Stack, [:hello]}
           ]
@@ -475,10 +475,10 @@ defmodule Supervisor do
 
       See `Supervisor`.
       """
-      def child_spec(arg) do
+      def child_spec(init_arg) do
         default = %{
           id: __MODULE__,
-          start: {__MODULE__, :start_link, [arg]},
+          start: {__MODULE__, :start_link, [init_arg]},
           type: :supervisor
         }
 
@@ -593,7 +593,7 @@ defmodule Supervisor do
 
   ## Examples
 
-      def init(_arg) do
+      def init(_init_arg) do
         children = [
           {Stack, [:hello]}
         ]
@@ -756,10 +756,10 @@ defmodule Supervisor do
   end
 
   @doc """
-  Starts a module-based supervisor process with the given `module` and `arg`.
+  Starts a module-based supervisor process with the given `module` and `init_arg`.
 
   To start the supervisor, the `c:init/1` callback will be invoked in the given
-  `module`, with `arg` as its argument. The `c:init/1` callback must return a
+  `module`, with `init_arg` as its argument. The `c:init/1` callback must return a
   supervisor specification which can be created with the help of the `init/2`
   function.
 
@@ -778,19 +778,19 @@ defmodule Supervisor do
   # all to start_link(children, options).
   @spec start_link(module, term) :: on_start
   @spec start_link(module, term, GenServer.options()) :: on_start
-  def start_link(module, arg, options \\ []) when is_list(options) do
+  def start_link(module, init_arg, options \\ []) when is_list(options) do
     case Keyword.get(options, :name) do
       nil ->
-        :supervisor.start_link(module, arg)
+        :supervisor.start_link(module, init_arg)
 
       atom when is_atom(atom) ->
-        :supervisor.start_link({:local, atom}, module, arg)
+        :supervisor.start_link({:local, atom}, module, init_arg)
 
       {:global, _term} = tuple ->
-        :supervisor.start_link(tuple, module, arg)
+        :supervisor.start_link(tuple, module, init_arg)
 
       {:via, via_module, _term} = tuple when is_atom(via_module) ->
-        :supervisor.start_link(tuple, module, arg)
+        :supervisor.start_link(tuple, module, init_arg)
 
       other ->
         raise ArgumentError, """

--- a/lib/elixir/test/elixir/dynamic_supervisor_test.exs
+++ b/lib/elixir/test/elixir/dynamic_supervisor_test.exs
@@ -173,27 +173,9 @@ defmodule DynamicSupervisorTest do
       assert DynamicSupervisor.start_child(pid, {Task, fn -> :ok end}) == {:error, :max_children}
     end
 
-    test "with args" do
-      {:ok, pid} = DynamicSupervisor.start_link(Simple, {:ok, %{}})
-      {:ok, _} = DynamicSupervisor.start_child(pid, sleepy_worker())
-      assert %{active: 1} = DynamicSupervisor.count_children(pid)
-
-      :ok = :sys.suspend(pid)
-
-      :sys.replace_state(pid, fn %{init_arg: args} = state ->
-        Map.delete(state, :init_arg) |> Map.put(:args, args)
-      end)
-
-      res = :sys.change_code(pid, :gen_server, 123, :extra)
-      :ok = :sys.resume(pid)
-      assert res == :ok
-
-      assert %{active: 1} = DynamicSupervisor.count_children(pid)
-    end
-
     defp fake_upgrade(pid, init_arg) do
       :ok = :sys.suspend(pid)
-      :sys.replace_state(pid, fn state -> %{state | init_arg: init_arg} end)
+      :sys.replace_state(pid, fn state -> %{state | args: init_arg} end)
       res = :sys.change_code(pid, :gen_server, 123, :extra)
       :ok = :sys.resume(pid)
       res

--- a/lib/elixir/test/elixir/dynamic_supervisor_test.exs
+++ b/lib/elixir/test/elixir/dynamic_supervisor_test.exs
@@ -173,9 +173,27 @@ defmodule DynamicSupervisorTest do
       assert DynamicSupervisor.start_child(pid, {Task, fn -> :ok end}) == {:error, :max_children}
     end
 
-    defp fake_upgrade(pid, args) do
+    test "with args" do
+      {:ok, pid} = DynamicSupervisor.start_link(Simple, {:ok, %{}})
+      {:ok, _} = DynamicSupervisor.start_child(pid, sleepy_worker())
+      assert %{active: 1} = DynamicSupervisor.count_children(pid)
+
       :ok = :sys.suspend(pid)
-      :sys.replace_state(pid, fn state -> %{state | args: args} end)
+
+      :sys.replace_state(pid, fn %{init_arg: args} = state ->
+        Map.delete(state, :init_arg) |> Map.put(:args, args)
+      end)
+
+      res = :sys.change_code(pid, :gen_server, 123, :extra)
+      :ok = :sys.resume(pid)
+      assert res == :ok
+
+      assert %{active: 1} = DynamicSupervisor.count_children(pid)
+    end
+
+    defp fake_upgrade(pid, init_arg) do
+      :ok = :sys.suspend(pid)
+      :sys.replace_state(pid, fn state -> %{state | init_arg: init_arg} end)
       res = :sys.change_code(pid, :gen_server, 123, :extra)
       :ok = :sys.resume(pid)
       res


### PR DESCRIPTION
I tend to get confused when I read the GenServer docs on how the second argument of `start_link/3` gets transmitted to `init/1`. It's especially confusing in the context of the normal flow of child spec -> start_link -> init.

Here is an example:
`Supervisor.start_child(%{id: 1, start: {Foo, :start_link, [1,2,3]}})`

results in the following being called:
`Foo.start_link(1, 2, 3)`

So far so good. The `args` in `{mod, fun, args}` gets unpacked to multiple arguments in the `start_link` function.

The function header for `GenServer.start_link/3` looks like this: `start_link(module, args, options \\ [])`. Here we also see an `args`, but `args` actually represents a singular argument. This is confusing because it makes it unclear how `args` gets sent to `init/1`. With an argument like `args` I am expecting the following behaviour:

```elixir
GenServer.start_link(Foo, [1,2,3], [])
# Foo.init(1,2,3) gets called
```

What really happens: `Foo.init([1,2,3])` gets called.

Calling it `args` creates the expectation that it should be multiple arguments, like in `{mod, fun, args}`. I think we can clarify this by changing the name to be singular (`arg` for example). IMO it can be further improved by indicating its use: `init_arg`.

This is a deviaton from the Erlang docs, but I think it might be a worthwhile one.