### PR TITLE
Warn on underspecified opaque types

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -283,6 +283,11 @@ defmodule Kernel.Typespec do
       compile_error(caller, message)
     end
 
+    if kind == :opaque and arity == 0 and underspecified?(spec) do
+      message = "opaque type #{name}/0 is underspecified and therefore meaningless"
+      :elixir_errors.warn(caller.line, caller.file, message)
+    end
+
     {{kind, {name, arity}, caller.line, type, export}, state}
   end
 
@@ -291,6 +296,9 @@ defmodule Kernel.Typespec do
        do: true
 
   defp valid_variable_ast?(_), do: false
+
+  defp underspecified?({:type, _, type, []}) when type in [:any, :term], do: true
+  defp underspecified?(_spec), do: false
 
   defp translate_spec({kind, {{:when, _meta, [spec, guard]}, pos}}, state) do
     caller = :elixir_locals.get_cached_env(pos)

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -283,8 +283,8 @@ defmodule Kernel.Typespec do
       compile_error(caller, message)
     end
 
-    if kind == :opaque and arity == 0 and underspecified?(spec) do
-      message = "opaque type #{name}/0 is underspecified and therefore meaningless"
+    if underspecified?(kind, arity, spec) do
+      message = "@#{kind} type #{name}/#{arity} is underspecified and therefore meaningless"
       :elixir_errors.warn(caller.line, caller.file, message)
     end
 
@@ -297,8 +297,8 @@ defmodule Kernel.Typespec do
 
   defp valid_variable_ast?(_), do: false
 
-  defp underspecified?({:type, _, type, []}) when type in [:any, :term], do: true
-  defp underspecified?(_spec), do: false
+  defp underspecified?(:opaque, 0, {:type, _, type, []}) when type in [:any, :term], do: true
+  defp underspecified?(_kind, _arity, _spec), do: false
 
   defp translate_spec({kind, {{:when, _meta, [spec, guard]}, pos}}, state) do
     caller = :elixir_locals.get_cached_env(pos)

--- a/lib/elixir/src/elixir_erl_compiler.erl
+++ b/lib/elixir/src/elixir_erl_compiler.erl
@@ -52,6 +52,7 @@ handle_file_warning(_, _File, {_Line, erl_lint, {unused_function, _}}) -> ok;
 handle_file_warning(_, _File, {_Line, erl_lint, {unused_var, _}}) -> ok;
 handle_file_warning(_, _File, {_Line, erl_lint, {shadowed_var, _, _}}) -> ok;
 handle_file_warning(_, _File, {_Line, erl_lint, {exported_var, _, _}}) -> ok;
+handle_file_warning(_, _File, {_Line, erl_lint, {underspecified_opaque, _}}) -> ok;
 
 %% Ignore behaviour warnings as we check for these problem ourselves
 handle_file_warning(_, _File, {_Line, erl_lint, {conflicting_behaviours, _, _, _, _}}) -> ok;

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1201,6 +1201,28 @@ defmodule Kernel.WarningTest do
       purge(Sample)
     end
 
+    test "underspecified opaque types" do
+      output =
+        capture_err(fn ->
+          Code.eval_string("""
+          defmodule Sample do
+            @opaque op1 :: term
+            @opaque op2 :: any
+            @opaque op3 :: atom
+          end
+          """)
+        end)
+
+      assert output =~ "nofile:2"
+      assert output =~ "opaque type op1/0 is underspecified and therefore meaningless"
+      assert output =~ "nofile:3"
+      assert output =~ "opaque type op2/0 is underspecified and therefore meaningless"
+      refute output =~ "nofile:4"
+      refute output =~ "op3"
+    after
+      purge(Sample)
+    end
+
     test "typedoc on typep" do
       assert capture_err(fn ->
                Code.eval_string("""

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1214,9 +1214,9 @@ defmodule Kernel.WarningTest do
         end)
 
       assert output =~ "nofile:2"
-      assert output =~ "opaque type op1/0 is underspecified and therefore meaningless"
+      assert output =~ "@opaque type op1/0 is underspecified and therefore meaningless"
       assert output =~ "nofile:3"
-      assert output =~ "opaque type op2/0 is underspecified and therefore meaningless"
+      assert output =~ "@opaque type op2/0 is underspecified and therefore meaningless"
       refute output =~ "nofile:4"
       refute output =~ "op3"
     after


### PR DESCRIPTION
Refers to #5800 

Performs the `erl_lint` check `{underspecified_opaque, {TypeName, Arity}}` in Elixir.

After reading the Erlang/OTP codebase, it seems an "underspecified opaque" is an opaque type of arity 0 with a spec of `term` or `any`. [Here is the implementation in the Erlang/OTP codebase](https://github.com/erlang/otp/blob/master/lib/stdlib/src/erl_lint.erl#L2796-L2798) and [the test suite](https://github.com/erlang/otp/blob/master/lib/stdlib/test/erl_lint_SUITE.erl#L2606-L2613).