### PR TITLE
Raise an error in Task.Supervisor.async when reaching max_children

### DIFF
--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -101,6 +101,9 @@ defmodule Task.Supervisor do
   The task will still be linked to the caller, see `Task.async/3` for
   more information and `async_nolink/2` for a non-linked variant.
 
+  Raises an error if `supervisor` has reached the maximum number of
+  children.
+
   ## Options
 
     * `:shutdown` - `:brutal_kill` if the tasks must be killed directly on shutdown
@@ -119,6 +122,9 @@ defmodule Task.Supervisor do
   The task will still be linked to the caller, see `Task.async/3` for
   more information and `async_nolink/2` for a non-linked variant.
 
+  Raises an error if `supervisor` has reached the maximum number of
+  children.
+
   ## Options
 
     * `:shutdown` - `:brutal_kill` if the tasks must be killed directly on shutdown
@@ -136,6 +142,9 @@ defmodule Task.Supervisor do
   The `supervisor` must be a reference as defined in `Task.Supervisor`.
   The task won't be linked to the caller, see `Task.async/3` for
   more information.
+
+  Raises an error if `supervisor` has reached the maximum number of
+  children.
 
   ## Options
 
@@ -215,6 +224,9 @@ defmodule Task.Supervisor do
   The `supervisor` must be a reference as defined in `Task.Supervisor`.
   The task won't be linked to the caller, see `Task.async/3` for
   more information.
+
+  Raises an error if `supervisor` has reached the maximum number of
+  children.
 
   Note this function requires the task supervisor to have `:temporary`
   as the `:restart` option (the default), as `async_nolink/4` keeps a

--- a/lib/elixir/test/elixir/task/supervisor_test.exs
+++ b/lib/elixir/test/elixir/task/supervisor_test.exs
@@ -61,34 +61,57 @@ defmodule Task.SupervisorTest do
              %{active: 0, specs: 0, supervisors: 0, workers: 0}
   end
 
-  test "async/1", config do
-    parent = self()
-    fun = fn -> wait_and_send(parent, :done) end
-    task = Task.Supervisor.async(config[:supervisor], fun)
-    assert Task.Supervisor.children(config[:supervisor]) == [task.pid]
+  describe "async/1" do
+    test "spawns tasks under the supervisor", config do
+      parent = self()
+      fun = fn -> wait_and_send(parent, :done) end
+      task = Task.Supervisor.async(config[:supervisor], fun)
+      assert Task.Supervisor.children(config[:supervisor]) == [task.pid]
 
-    # Assert the struct
-    assert task.__struct__ == Task
-    assert is_pid(task.pid)
-    assert is_reference(task.ref)
+      # Assert the struct
+      assert task.__struct__ == Task
+      assert is_pid(task.pid)
+      assert is_reference(task.ref)
 
-    # Assert the link
-    {:links, links} = Process.info(self(), :links)
-    assert task.pid in links
+      # Assert the link
+      {:links, links} = Process.info(self(), :links)
+      assert task.pid in links
 
-    receive do: (:ready -> :ok)
+      receive do: (:ready -> :ok)
 
-    # Assert the initial call
-    {:name, fun_name} = Function.info(fun, :name)
-    assert {__MODULE__, fun_name, 0} === :proc_lib.translate_initial_call(task.pid)
+      # Assert the initial call
+      {:name, fun_name} = Function.info(fun, :name)
+      assert {__MODULE__, fun_name, 0} === :proc_lib.translate_initial_call(task.pid)
 
-    # Run the task
-    send(task.pid, true)
+      # Run the task
+      send(task.pid, true)
 
-    # Assert response and monitoring messages
-    ref = task.ref
-    assert_receive {^ref, :done}
-    assert_receive {:DOWN, ^ref, _, _, :normal}
+      # Assert response and monitoring messages
+      ref = task.ref
+      assert_receive {^ref, :done}
+      assert_receive {:DOWN, ^ref, _, _, :normal}
+    end
+
+    test "with custom shutdown", config do
+      Process.flag(:trap_exit, true)
+      parent = self()
+
+      fun = fn -> wait_and_send(parent, :done) end
+      %{pid: pid} = Task.Supervisor.async(config[:supervisor], fun, shutdown: :brutal_kill)
+
+      Process.exit(config[:supervisor], :shutdown)
+      assert_receive {:DOWN, _, _, ^pid, :killed}
+    end
+
+    test "raises when :max_children is reached" do
+      {:ok, sup} = Task.Supervisor.start_link(max_children: 1)
+
+      Task.Supervisor.async(sup, fn -> Process.sleep(:infinity) end)
+
+      assert_raise RuntimeError, ~r/reached the maximum number of tasks/, fn ->
+        Task.Supervisor.async(sup, fn -> :ok end)
+      end
+    end
   end
 
   test "async/3", config do
@@ -104,45 +127,57 @@ defmodule Task.SupervisorTest do
     assert Task.await(task) == :done
   end
 
-  test "async/1 with custom shutdown", config do
-    Process.flag(:trap_exit, true)
-    parent = self()
+  describe "async_nolink/1" do
+    test "spawns a task under the supervisor without linking to the caller", config do
+      parent = self()
+      fun = fn -> wait_and_send(parent, :done) end
+      task = Task.Supervisor.async_nolink(config[:supervisor], fun)
+      assert Task.Supervisor.children(config[:supervisor]) == [task.pid]
 
-    fun = fn -> wait_and_send(parent, :done) end
-    %{pid: pid} = Task.Supervisor.async(config[:supervisor], fun, shutdown: :brutal_kill)
+      # Assert the struct
+      assert task.__struct__ == Task
+      assert is_pid(task.pid)
+      assert is_reference(task.ref)
 
-    Process.exit(config[:supervisor], :shutdown)
-    assert_receive {:DOWN, _, _, ^pid, :killed}
-  end
+      # Refute the link
+      {:links, links} = Process.info(self(), :links)
+      refute task.pid in links
 
-  test "async_nolink/1", config do
-    parent = self()
-    fun = fn -> wait_and_send(parent, :done) end
-    task = Task.Supervisor.async_nolink(config[:supervisor], fun)
-    assert Task.Supervisor.children(config[:supervisor]) == [task.pid]
+      receive do: (:ready -> :ok)
 
-    # Assert the struct
-    assert task.__struct__ == Task
-    assert is_pid(task.pid)
-    assert is_reference(task.ref)
+      # Assert the initial call
+      {:name, fun_name} = Function.info(fun, :name)
+      assert {__MODULE__, fun_name, 0} === :proc_lib.translate_initial_call(task.pid)
 
-    # Refute the link
-    {:links, links} = Process.info(self(), :links)
-    refute task.pid in links
+      # Run the task
+      send(task.pid, true)
 
-    receive do: (:ready -> :ok)
+      # Assert response and monitoring messages
+      ref = task.ref
+      assert_receive {^ref, :done}
+      assert_receive {:DOWN, ^ref, _, _, :normal}
+    end
 
-    # Assert the initial call
-    {:name, fun_name} = Function.info(fun, :name)
-    assert {__MODULE__, fun_name, 0} === :proc_lib.translate_initial_call(task.pid)
+    test "with custom shutdown", config do
+      Process.flag(:trap_exit, true)
+      parent = self()
 
-    # Run the task
-    send(task.pid, true)
+      fun = fn -> wait_and_send(parent, :done) end
+      %{pid: pid} = Task.Supervisor.async_nolink(config[:supervisor], fun, shutdown: :brutal_kill)
 
-    # Assert response and monitoring messages
-    ref = task.ref
-    assert_receive {^ref, :done}
-    assert_receive {:DOWN, ^ref, _, _, :normal}
+      Process.exit(config[:supervisor], :shutdown)
+      assert_receive {:DOWN, _, _, ^pid, :killed}
+    end
+
+    test "raises when :max_children is reached" do
+      {:ok, sup} = Task.Supervisor.start_link(max_children: 1)
+
+      Task.Supervisor.async_nolink(sup, fn -> Process.sleep(:infinity) end)
+
+      assert_raise RuntimeError, ~r/reached the maximum number of tasks/, fn ->
+        Task.Supervisor.async_nolink(sup, fn -> :ok end)
+      end
+    end
   end
 
   test "async_nolink/3", config do
@@ -156,17 +191,6 @@ defmodule Task.SupervisorTest do
     send(task.pid, true)
     assert task.__struct__ == Task
     assert Task.await(task) == :done
-  end
-
-  test "async_nolink/1 with custom shutdown", config do
-    Process.flag(:trap_exit, true)
-    parent = self()
-
-    fun = fn -> wait_and_send(parent, :done) end
-    %{pid: pid} = Task.Supervisor.async_nolink(config[:supervisor], fun, shutdown: :brutal_kill)
-
-    Process.exit(config[:supervisor], :shutdown)
-    assert_receive {:DOWN, _, _, ^pid, :killed}
   end
 
   test "start_child/1", config do


### PR DESCRIPTION
Related to #7786.

This PR raises when the max number of children for a `Task.Supervisor` is reached when starting a task with `Task.Supervisor.async/2,4` or `Task.Supervisor.async_nolink/2,4`. I am not handling anything related to `async_stream` but this should be a start.

The big diff in tests is related to moving things around in order to be able to use `describe` blocks. I just added one test for `async/2` and one for `async_nolink/2`.