### PR TITLE
Exclude deprecated functions in hints

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1007,7 +1007,7 @@ defmodule UndefinedFunctionError do
 
   defp deprecated_functions_for(module) do
     if function_exported?(module, :__info__, 1) do
-      for {{name, arity} = key, _message} <- module.__info__(:deprecated), do: key
+      for {name_arity, _message} <- module.__info__(:deprecated), do: name_arity
     else
       []
     end

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1007,9 +1007,7 @@ defmodule UndefinedFunctionError do
 
   defp deprecated_functions_for(module) do
     if function_exported?(module, :__info__, 1) do
-      for {{name, arity}, _message} <- module.__info__(:deprecated) do
-        {name, arity}
-      end
+      for {{name, arity} = key, _message} <- module.__info__(:deprecated), do: key
     else
       []
     end

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -491,6 +491,32 @@ defmodule Mix.Tasks.XrefTest do
     assert_warnings(files, warning)
   end
 
+  test "warnings: hints exclude deprecated functions" do
+    files = %{
+      "lib/a.ex" => """
+      defmodule A do
+        def to_charlist(a), do: a
+
+        @deprecated "Use String.to_charlist/1 instead"
+        def to_char_list(a), do: a
+
+        def c(a), do: A.to_list(a)
+      end
+      """
+    }
+
+    warning = """
+    warning: function A.to_list/1 is undefined or private. Did you mean one of:
+
+          * to_charlist/1
+
+      lib/a.ex:7
+
+    """
+
+    assert_warnings(files, warning)
+  end
+
   test "warnings: imports" do
     files = %{
       "lib/a.ex" => """


### PR DESCRIPTION
I'd like to propose excluding deprecated functions in "did you mean" message.

If a function is deprecated, it's useless to suggest it in the hints, since the compiler would eventually show some warnings if the users go with the deprecated suggestion.