### PR TITLE
Bypass erl_lint and spawn compiler processes manually

### DIFF
--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -4,7 +4,7 @@
 -behaviour(application).
 -export([start_cli/0,
   string_to_tokens/4, tokens_to_quoted/3, 'string_to_quoted!'/4,
-  env_for_eval/1, env_for_eval/2, quoted_to_erl/2, quoted_to_erl/3,
+  env_for_eval/1, env_for_eval/2, quoted_to_erl/2,
   eval/2, eval/3, eval_forms/3, eval_forms/4, eval_quoted/3]).
 -include("elixir.hrl").
 -define(system, 'Elixir.System').

--- a/lib/elixir/src/elixir_erl_compiler.erl
+++ b/lib/elixir/src/elixir_erl_compiler.erl
@@ -1,5 +1,28 @@
 -module(elixir_erl_compiler).
--export([forms/3, noenv_forms/3]).
+-export([spawn/2, forms/3, noenv_forms/3, erl_to_core/2]).
+-include("elixir.hrl").
+
+spawn(Fun, Args) ->
+  CompilerPid = get(elixir_compiler_pid),
+
+  {_, Ref} =
+    spawn_monitor(fun() ->
+      put(elixir_compiler_pid, CompilerPid),
+
+      try apply(Fun, Args) of
+        Result -> exit({ok, Result})
+      catch
+        ?WITH_STACKTRACE(Kind, Reason, Stack)
+          exit({Kind, Reason, Stack})
+      end
+    end),
+
+  receive
+    {'DOWN', Ref, process, _, {ok, Result}} ->
+      Result;
+    {'DOWN', Ref, process, _, {Kind, Reason, Stack}} ->
+      erlang:raise(Kind, Reason, Stack)
+  end.
 
 forms(Forms, File, Opts) ->
   compile(fun compile:forms/2, Forms, File, Opts).
@@ -7,15 +30,40 @@ forms(Forms, File, Opts) ->
 noenv_forms(Forms, File, Opts) ->
   compile(fun compile:noenv_forms/2, Forms, File, Opts).
 
+erl_to_core(Forms, Opts) ->
+  %% TODO: Remove parse transform handling on Elixir v2.0
+  case [M || {parse_transform, M} <- Opts] of
+    [] ->
+      v3_core:module(Forms, Opts);
+    _ ->
+      case compile:noenv_forms(Forms, [dialyzer, to_core0, return, no_auto_import | Opts]) of
+        {ok, _Module, Core, Warnings} -> {ok, Core, Warnings};
+        {error, Errors, Warnings} -> {error, Errors, Warnings}
+      end
+  end.
+
 compile(Fun, Forms, File, Opts) when is_list(Forms), is_list(Opts), is_binary(File) ->
   Source = elixir_utils:characters_to_list(File),
-  case Fun(Forms, [return, {source, Source} | Opts]) of
-    {ok, Module, Binary, Warnings} ->
-      format_warnings(Opts, Warnings),
-      {Module, Binary};
-    {error, Errors, Warnings} ->
-      format_warnings(Opts, Warnings),
-      format_errors(Errors)
+
+  case erl_to_core(Forms, Opts) of
+    {ok, CoreForms, CoreWarnings} ->
+      format_warnings(Opts, CoreWarnings),
+
+      %% The dialyzer flag tells the Erlang compiler
+      %% to not start a new process to do this work.
+      case Fun(CoreForms, [dialyzer, from_core, no_auto_import, return, {source, Source} | Opts]) of
+        {ok, Module, Binary, Warnings} ->
+          format_warnings(Opts, Warnings),
+          {Module, Binary};
+
+        {error, Errors, Warnings} ->
+          format_warnings(Opts, Warnings),
+          format_errors(Errors)
+      end;
+
+    {error, CoreErrors, CoreWarnings} ->
+      format_warnings(Opts, CoreWarnings),
+      format_errors(CoreErrors)
   end.
 
 format_errors([]) ->
@@ -41,26 +89,12 @@ format_warnings(Opts, Warnings) ->
 handle_file_warning(true, _File, {_Line, sys_core_fold, nomatch_guard}) -> ok;
 handle_file_warning(true, _File, {_Line, sys_core_fold, {nomatch_shadow, _}}) -> ok;
 
-%% Ignore always
+%% Those we implement ourselves
+handle_file_warning(_, _File, {_Line, v3_core, {map_key_repeated, _}}) -> ok;
 handle_file_warning(_, _File, {_Line, sys_core_fold, useless_building}) -> ok;
 
-%% This is an Erlang bug, it considers {tuple, _}.call to always fail
-handle_file_warning(_, _File, {_Line, v3_kernel, bad_call}) -> ok;
-
-%% Those we handle them ourselves
-handle_file_warning(_, _File, {_Line, erl_lint, {unused_function, _}}) -> ok;
-handle_file_warning(_, _File, {_Line, erl_lint, {unused_var, _}}) -> ok;
-handle_file_warning(_, _File, {_Line, erl_lint, {shadowed_var, _, _}}) -> ok;
-handle_file_warning(_, _File, {_Line, erl_lint, {exported_var, _, _}}) -> ok;
-handle_file_warning(_, _File, {_Line, erl_lint, {underspecified_opaque, _}}) -> ok;
-handle_file_warning(_, _File, {_Line, v3_core, {map_key_repeated, _}}) -> ok;
-
-%% Ignore behaviour warnings as we check for these problem ourselves
-handle_file_warning(_, _File, {_Line, erl_lint, {conflicting_behaviours, _, _, _, _}}) -> ok;
-handle_file_warning(_, _File, {_Line, erl_lint, {undefined_behaviour_func, _, _}}) -> ok;
-handle_file_warning(_, _File, {_Line, erl_lint, {undefined_behaviour, _}}) -> ok;
-handle_file_warning(_, _File, {_Line, erl_lint, {ill_defined_behaviour_callbacks, _}}) -> ok;
-handle_file_warning(_, _File, {_Line, erl_lint, {ill_defined_optional_callbacks, _}}) -> ok;
+%% Ignore all linting errors (only come up on parse transforms)
+handle_file_warning(_, _File, {_Line, erl_lint, _}) -> ok;
 
 handle_file_warning(_, File, {Line, Module, Desc}) ->
   Message = format_error(Module, Desc),
@@ -75,10 +109,6 @@ handle_file_error(File, {Line, Module, Desc}) ->
   elixir_errors:compile_error([{line, Line}], File, Message).
 
 %% Custom formatting
-
-%% Normalize formatting of specs
-format_error(erl_lint, {spec_fun_undefined, {M, F, A}}) ->
-  io_lib:format("spec for undefined function ~ts.~ts/~B", [elixir_aliases:inspect(M), F, A]);
 
 %% Mention the capture operator in make_fun
 format_error(sys_core_fold, {no_effect, {erlang, make_fun, 3}}) ->


### PR DESCRIPTION
This speeds up the Elixir compiler from 5-10% as we no
longer do duplicate work on erl_lint and expand_records.
We also avoid the copying of messages by controlling
exactly when the compiler spawns new processes.