### PR TITLE
Fix bug introduced to ExUnit in #8257

### DIFF
--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -63,7 +63,7 @@ defmodule ExUnit.Runner do
 
       # Slots are available, start with async modules
       modules = ExUnit.Server.take_async_modules(available) ->
-        spawn_modules(config, modules, [], taken)
+        spawn_modules(config, modules, :async, taken)
 
       true ->
         modules = ExUnit.Server.take_sync_modules()


### PR DESCRIPTION
Bug was introduced in ca8ce9201aa59b59ea209086c2ead2c8cec47615

Causes almost all tests being log when `mix test` was run, and still tests passing