### PR TITLE
Use setup_all instead of "setup all" to refer to the callback

### DIFF
--- a/lib/ex_unit/test/ex_unit/case_template_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_template_test.exs
@@ -53,7 +53,7 @@ defmodule ExUnit.CaseTemplateTest do
     assert context[:setup] == 2
   end
 
-  test "runs both templates setup all", context do
+  test "runs both templates setup_all", context do
     assert context[:setup_all] == 2
   end
 

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -182,7 +182,7 @@ defmodule ExUnit.FormatterTest do
     assert failure =~ ~r"\(elixir\) lib/access\.ex:\d+: Access\.fetch/2"
   end
 
-  test "formats setup all errors" do
+  test "formats setup_all errors" do
     failure = [{:error, catch_error(raise "oops"), []}]
 
     assert format_test_all_failure(test_module(), failure, 1, 80, &formatter/2) =~ """


### PR DESCRIPTION
[ci skip]