### PR TITLE
ExUnit: Replace truthy and falsy functions in assertion tests

### DIFF
--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -2,8 +2,8 @@ Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule ExUnit.AssertionsTest.Value do
   def tuple, do: {2, 1}
-  def falsy, do: false
-  def truthy, do: true
+  def falsy, do: nil
+  def truthy, do: :truthy
 end
 
 defmodule ExUnit.AssertionsTest.BrokenError do
@@ -38,26 +38,26 @@ defmodule ExUnit.AssertionsTest do
     assert_ok(42)
   end
 
-  test "assert with true value" do
-    true = assert Value.truthy()
+  test "assert with truthy value" do
+    :truthy = assert Value.truthy()
   end
 
-  test "assert with message when value is false" do
+  test "assert with message when value is falsy" do
     try do
-      "This should never be tested" = assert false, "This should be true"
+      "This should never be tested" = assert Value.falsy(), "This should be truthy"
     rescue
       error in [ExUnit.AssertionError] ->
-        "This should be true" = error.message
+        "This should be truthy" = error.message
     end
   end
 
-  test "assert when value evaluates to false" do
+  test "assert when value evaluates to falsy" do
     try do
       "This should never be tested" = assert Value.falsy()
     rescue
       error in [ExUnit.AssertionError] ->
         "assert(Value.falsy())" = error.expr |> Macro.to_string()
-        "Expected truthy, got false" = error.message
+        "Expected truthy, got nil" = error.message
     end
   end
 
@@ -76,7 +76,7 @@ defmodule ExUnit.AssertionsTest do
 
   test "assert arguments are not kept for operators" do
     try do
-      "This should never be tested" = assert not Value.truthy()
+      "This should never be tested" = assert !Value.truthy()
     rescue
       error in [ExUnit.AssertionError] ->
         false = is_list(error.args)
@@ -119,18 +119,19 @@ defmodule ExUnit.AssertionsTest do
     assert argless_macro == 1
   end
 
-  test "refute when value is false" do
+  test "refute when value is falsy" do
     false = refute false
+    nil = refute Value.falsy()
   end
 
-  test "refute when value evaluates to true" do
+  test "refute when value evaluates to truthy" do
     try do
       refute Value.truthy()
       raise "refute was supposed to fail"
     rescue
       error in [ExUnit.AssertionError] ->
         "refute(Value.truthy())" = Macro.to_string(error.expr)
-        "Expected false or nil, got true" = error.message
+        "Expected false or nil, got :truthy" = error.message
     end
   end
 


### PR DESCRIPTION
It is misleading, as they are meant to be used as true or false.