### PR TITLE
Correct use of truthy and not true

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -276,9 +276,10 @@ defmodule Enum do
   end
 
   @doc """
-  Returns `true` if the given `fun` evaluates to true on all of the items in the `enumerable`.
+  Returns `true` if the given `fun` evaluates to a truthy value (neither `false` nor `nil`)
+  on all of the items in the `enumerable`.
 
-  It stops the iteration at the first invocation that returns `false` or `nil`.
+  It stops the iteration at the first invocation that returns either `false` or `nil`.
 
   ## Examples
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -852,7 +852,7 @@ defmodule CondClauseError do
 
   @impl true
   def message(_exception) do
-    "no cond clause evaluated to a true value"
+    "no cond clause evaluated to a truthy value"
   end
 end
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2966,7 +2966,7 @@ defmodule Kernel do
       if(foo, do: bar)
 
   In the example above, `bar` will be returned if `foo` evaluates to
-  `true` (i.e., it is neither `false` nor `nil`). Otherwise, `nil` will be
+  a thruthy value (neither `false` nor `nil`). Otherwise, `nil` will be
   returned.
 
   An `else` option can be given to specify the opposite:
@@ -3021,8 +3021,8 @@ defmodule Kernel do
   Provides an `unless` macro.
 
   This macro evaluates and returns the `do` block passed in as the second
-  argument unless `clause` evaluates to `true`. Otherwise, it returns the value
-  of the `else` block if present or `nil` if not.
+  argument unless `clause` evaluates to a truthy value (neither `false` nor `nil`).
+  Otherwise, it returns the value of the `else` block if present or `nil` if not.
 
   See also `if/2`.
 
@@ -3157,8 +3157,8 @@ defmodule Kernel do
 
   @doc """
   Provides a short-circuit operator that evaluates and returns
-  the second expression only if the first one evaluates to `true`
-  (i.e., it is neither `nil` nor `false`). Returns the first expression
+  the second expression only if the first one evaluates to to a truthy value
+  (neither `false` nor `nil`). Returns the first expression
   otherwise.
 
   Not allowed in guard clauses.
@@ -3196,7 +3196,7 @@ defmodule Kernel do
 
   @doc """
   Provides a short-circuit operator that evaluates and returns the second
-  expression only if the first one does not evaluate to `true` (i.e., it
+  expression only if the first one does not evaluate to a truthy value (i.e., it
   is either `nil` or `false`). Returns the first expression otherwise.
 
   Not allowed in guard clauses.

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2966,7 +2966,7 @@ defmodule Kernel do
       if(foo, do: bar)
 
   In the example above, `bar` will be returned if `foo` evaluates to
-  a thruthy value (neither `false` nor `nil`). Otherwise, `nil` will be
+  a truthy value (neither `false` nor `nil`). Otherwise, `nil` will be
   returned.
 
   An `else` option can be given to specify the opposite:

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3196,8 +3196,8 @@ defmodule Kernel do
 
   @doc """
   Provides a short-circuit operator that evaluates and returns the second
-  expression only if the first one does not evaluate to a truthy value (i.e., it
-  is either `nil` or `false`). Returns the first expression otherwise.
+  expression only if the first one does not evaluate to a truthy value (that is,
+  it is either `nil` or `false`). Returns the first expression otherwise.
 
   Not allowed in guard clauses.
 

--- a/lib/elixir/test/elixir/kernel/raise_test.exs
+++ b/lib/elixir/test/elixir/kernel/raise_test.exs
@@ -441,7 +441,7 @@ defmodule Kernel.RaiseTest do
           x in [CondClauseError] -> Exception.message(x)
         end
 
-      assert result == "no cond clause evaluated to a true value"
+      assert result == "no cond clause evaluated to a truthy value"
     end
 
     test "try clause error" do


### PR DESCRIPTION
Additionally, it corrects the CondClauseError message to:
"no cond clause evaluated to a truthy value"