### PR TITLE
Default System.cmd to File.cwd to fix running on slave nodes

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -634,6 +634,12 @@ defmodule System do
         :os.find_executable(cmd) || :erlang.error(:enoent, [command, args, opts])
       end
 
+    opts =
+      case File.cwd() do
+        {:ok, cwd} -> Keyword.put_new(opts, :cd, cwd)
+        _ -> opts
+      end
+
     {into, opts} = cmd_opts(opts, [:use_stdio, :exit_status, :binary, :hide, args: args], "")
     {initial, fun} = Collectable.into(into)
 


### PR DESCRIPTION
Running `System.cmd` in a slave node without passing `cd: File.cwd!` will use the current working directory of the master node and not the slave node.

For example:

If you start a slave node and use `File.cd "/somewhere"` and then `System.cmd("pwd", [])` the returned result will be that of the master node and not `/somewhere`. This is problematic especially because of the use of `File.cd!/2` where calls in the function expect this to work.