### PR TITLE
Declare var/0 as built-in type

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -373,6 +373,7 @@ defmodule Kernel.Typespec do
   defp builtin_type?(:nonempty_charlist, 0), do: true
   defp builtin_type?(:keyword, 0), do: true
   defp builtin_type?(:keyword, 1), do: true
+  defp builtin_type?(:var, 0), do: true
   defp builtin_type?(name, arity), do: :erl_internal.is_type(name, arity)
 
   defp ensure_no_defaults!(args) do

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -64,13 +64,13 @@ defmodule Macro.Env do
   @type macros :: [{module, [name_arity]}]
   @type context_modules :: [module]
   @type lexical_tracker :: pid | nil
-  @type var :: {atom, atom | term}
+  @type variable :: {atom, atom | term}
 
-  @typep vars :: [var]
+  @typep vars :: [variable]
   @typep var_type :: :term
   @typep var_version :: non_neg_integer
-  @typep unused_vars :: %{{var, var_version} => non_neg_integer | false}
-  @typep current_vars :: %{var => {var_version, var_type}}
+  @typep unused_vars :: %{{variable, var_version} => non_neg_integer | false}
+  @typep current_vars :: %{variable => {var_version, var_type}}
   @typep prematch_vars :: current_vars | :warn | :raise | :pin | :apply
   @typep contextual_vars :: [atom]
 
@@ -132,7 +132,7 @@ defmodule Macro.Env do
   atom or an integer.
   """
   @doc since: "1.7.0"
-  @spec vars(t) :: [var]
+  @spec vars(t) :: [variable]
   def vars(env)
 
   def vars(%{__struct__: Macro.Env, current_vars: current_vars}) do
@@ -143,7 +143,7 @@ defmodule Macro.Env do
   Checks if a variable belongs to the environment.
   """
   @doc since: "1.7.0"
-  @spec has_var?(t, var) :: boolean()
+  @spec has_var?(t, variable) :: boolean()
   def has_var?(env, var)
 
   def has_var?(%{__struct__: Macro.Env, current_vars: current_vars}, var) do


### PR DESCRIPTION
As discussed in https://github.com/elixir-lang/elixir/issues/5800#issuecomment-418888952

Redefining the pseudo-type "var" might lead to ambiguous typespecs.

Here is an example:

```elixir
    defmodule DefineVarType do
      @type my_var :: integer
      @type var :: integer

      @spec foo(x, x, var) :: boolean when x: var
      def foo(x, y, z), do: x + y == z

      @spec bar(x, x, my_var) :: boolean when x: my_var
      def bar(x, y, z), do: x + y == z
    end
```