### PR TITLE
Allow @type, @opaque, @typep, @spec, @callback, and @macrocallback to be used as module attributes

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -99,8 +99,9 @@ defmodule Kernel.Typespec do
   Invoked by `Kernel.@/1` expansion.
   """
   def deftypespec(:spec, expr, _line, _file, module, pos) do
-    {_set, bag} = :elixir_module.data_tables(module)
+    {set, bag} = :elixir_module.data_tables(module)
     store_typespec(bag, :spec, {expr, pos})
+    store_module_attribute(set, :spec, {expr, pos})
   end
 
   def deftypespec(kind, expr, line, _file, module, pos)
@@ -150,6 +151,11 @@ defmodule Kernel.Typespec do
     :ets.lookup_element(bag, key, 2)
   catch
     :error, :badarg -> []
+  end
+
+  defp store_module_attribute(set, key, value) do
+    :ets.insert(set, {key, value, nil})
+    :ok
   end
 
   defp store_typespec(bag, key, value) do

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -99,9 +99,8 @@ defmodule Kernel.Typespec do
   Invoked by `Kernel.@/1` expansion.
   """
   def deftypespec(:spec, expr, _line, _file, module, pos) do
-    {set, bag} = :elixir_module.data_tables(module)
+    {_set, bag} = :elixir_module.data_tables(module)
     store_typespec(bag, :spec, {expr, pos})
-    store_module_attribute(set, :spec, {expr, pos})
   end
 
   def deftypespec(kind, expr, line, _file, module, pos)
@@ -151,11 +150,6 @@ defmodule Kernel.Typespec do
     :ets.lookup_element(bag, key, 2)
   catch
     :error, :badarg -> []
-  end
-
-  defp store_module_attribute(set, key, value) do
-    :ets.insert(set, {key, value, nil})
-    :ok
   end
 
   defp store_typespec(bag, key, value) do

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1726,16 +1726,7 @@ defmodule Module do
   def get_attribute(module, key, line) when is_atom(key) do
     assert_not_compiled!(:get_attribute, module)
     {set, bag} = data_tables_for(module)
-    get_attribute(module, key, line, set, bag)
-  end
 
-  defp get_attribute(_module, :spec, _line, _set, bag) do
-    specs = bag_lookup_element(bag, :spec, 2)
-    formatted_specs = :lists.map(fn {expr, pos} -> {:spec, expr, pos} end, specs)
-    :lists.reverse(formatted_specs)
-  end
-
-  defp get_attribute(module, key, line, set, bag) do
     case :ets.lookup(set, key) do
       [{_, _, :accumulate}] ->
         :lists.reverse(bag_lookup_element(bag, {:accumulate, key}, 2))

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1726,7 +1726,16 @@ defmodule Module do
   def get_attribute(module, key, line) when is_atom(key) do
     assert_not_compiled!(:get_attribute, module)
     {set, bag} = data_tables_for(module)
+    get_attribute(module, key, line, set, bag)
+  end
 
+  defp get_attribute(_module, :spec, _line, _set, bag) do
+    specs = bag_lookup_element(bag, :spec, 2)
+    formatted_specs = :lists.map(fn {expr, pos} -> {:spec, expr, pos} end, specs)
+    :lists.reverse(formatted_specs)
+  end
+
+  defp get_attribute(module, key, line, set, bag) do
     case :ets.lookup(set, key) do
       [{_, _, :accumulate}] ->
         :lists.reverse(bag_lookup_element(bag, {:accumulate, key}, 2))
@@ -1897,9 +1906,9 @@ defmodule Module do
     do: {atom, :__on_definition__}
 
   defp preprocess_attribute(key, _value)
-       when key in [:type, :typep, :opaque, :callback, :macrocallback] do
+       when key in [:type, :typep, :opaque, :spec, :callback, :macrocallback] do
     raise ArgumentError,
-          "attributes type, typep, opaque, callback, and macrocallback" <>
+          "attributes type, typep, opaque, spec, callback, and macrocallback" <>
             "must be set directly via the @ notation"
   end
 

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -235,10 +235,7 @@ build(Line, File, Module, Lexical) ->
 
   %% In the bag table we store:
   %%
-  %% * {{accumulate, Attribute}, ...}
-  %% * {{accumulate, type}, ...}, {{accumulate, opaque}, ...}, {{accumulate, typep}, ...}
-  %% * {{accumulate, spec}, ...}, {{accumulate, callback}, ...},
-  %%   {{accumulate, macrocallback}, ...}
+  %% * {{accumulate, Attribute}, ...} (includes typespecs)
   %% * {attributes, ...}
   %% * {impls, ...}
   %% * {deprecated, ...}

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -236,6 +236,9 @@ build(Line, File, Module, Lexical) ->
   %% In the bag table we store:
   %%
   %% * {{accumulate, Attribute}, ...}
+  %% * {{accumulate, type}, ...}, {{accumulate, opaque}, ...}, {{accumulate, typep}, ...}
+  %% * {{accumulate, spec}, ...}, {{accumulate, callback}, ...},
+  %%   {{accumulate, macrocallback}, ...}
   %% * {attributes, ...}
   %% * {impls, ...}
   %% * {deprecated, ...}
@@ -245,7 +248,6 @@ build(Line, File, Module, Lexical) ->
   %% * {{clauses, Tuple}, ...} (from elixir_def)
   %% * {reattach, ...} (from elixir_local)
   %% * {{local, Tuple}, ...} (from elixir_local)
-  %% * {spec, ...}, {type, ...}, {callback, ...}, {macrocallback, ...}
   %%
   DataBag = ets:new(Module, [duplicate_bag, public]),
 
@@ -262,6 +264,12 @@ build(Line, File, Module, Lexical) ->
     {dialyzer, [], accumulate},
     {external_resource, [], accumulate},
     {on_definition, [], accumulate},
+    {type, [], accumulate},
+    {opaque, [], accumulate},
+    {typep, [], accumulate},
+    {spec, [], accumulate},
+    {callback, [], accumulate},
+    {macrocallback, [], accumulate},
     {optional_callbacks, [], accumulate},
 
     % Others

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -519,6 +519,22 @@ defmodule Kernel.ErrorsTest do
     end
   end
 
+  test "typespec attributes set via Module.put_attribute/4" do
+    message =
+      "attributes type, typep, opaque, spec, callback, and macrocallback" <>
+        "must be set directly via the @ notation"
+
+    for kind <- [:type, :typep, :opaque, :spec, :callback, :macrocallback] do
+      assert_eval_raise ArgumentError,
+                        message,
+                        """
+                        defmodule PutTypespecAttribute do
+                          Module.put_attribute(__MODULE__, #{inspect(kind)}, {})
+                        end
+                        """
+    end
+  end
+
   test "invalid struct field value" do
     msg = ~r"invalid value for struct field baz, cannot escape "
 

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -801,7 +801,7 @@ defmodule TypespecTest do
       assert [{:atom, _, :is_subtype}, [{:var, _, :y}, {:var, _, :x}]] = constraint_type
     end
 
-    test "@type, @opaque, and typep as module attributes" do
+    test "@type, @opaque, and @typep as module attributes" do
       defmodule TypeModuleAttributes do
         @type type1 :: boolean
         @opaque opaque1 :: boolean
@@ -821,7 +821,8 @@ defmodule TypespecTest do
         def opaque2, do: @opaque
         def typep2, do: @typep
 
-        @spec foo(typep1) :: typep2 # Avoid unused warnings
+        # Avoid unused warnings
+        @spec foo(typep1) :: typep2
         def foo(_x), do: :ok
       end
 

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -801,6 +801,27 @@ defmodule TypespecTest do
       assert [{:atom, _, :is_subtype}, [{:var, _, :y}, {:var, _, :x}]] = constraint_type
     end
 
+    test "@spec as module attribute" do
+      defmodule SpecModuleAttribute do
+        @spec my_fun1 :: boolean
+        def my_fun1, do: @spec
+
+        @spec my_fun2 :: atom
+        def my_fun2, do: @spec
+
+        @spec my_fun3 :: pid
+        def my_fun3, do: :ok
+        def my_fun4, do: @spec
+      end
+
+      assert {{:::, _, [{:my_fun1, _, _}, {:boolean, _, _}]}, _} = SpecModuleAttribute.my_fun1()
+      assert {{:::, _, [{:my_fun2, _, _}, {:atom, _, _}]}, _} = SpecModuleAttribute.my_fun2()
+      assert {{:::, _, [{:my_fun3, _, _}, {:pid, _, _}]}, _} = SpecModuleAttribute.my_fun4()
+    after
+      :code.delete(SpecModuleAttribute)
+      :code.purge(SpecModuleAttribute)
+    end
+
     test "@callback(callback)" do
       bytecode =
         test_module do

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -803,20 +803,37 @@ defmodule TypespecTest do
 
     test "@spec as module attribute" do
       defmodule SpecModuleAttribute do
-        @spec my_fun1 :: boolean
-        def my_fun1, do: @spec
+        @spec fun1 :: boolean
+        def fun1, do: @spec
 
-        @spec my_fun2 :: atom
-        def my_fun2, do: @spec
+        @spec fun2 :: atom
+        def fun2, do: @spec
 
-        @spec my_fun3 :: pid
-        def my_fun3, do: :ok
-        def my_fun4, do: @spec
+        @spec fun3 :: pid
+        def fun3, do: :ok
+        def fun4, do: @spec
       end
 
-      assert {{:::, _, [{:my_fun1, _, _}, {:boolean, _, _}]}, _} = SpecModuleAttribute.my_fun1()
-      assert {{:::, _, [{:my_fun2, _, _}, {:atom, _, _}]}, _} = SpecModuleAttribute.my_fun2()
-      assert {{:::, _, [{:my_fun3, _, _}, {:pid, _, _}]}, _} = SpecModuleAttribute.my_fun4()
+      assert [
+               {:spec, {:::, _, [{:fun1, _, _}, {:boolean, _, _}]},
+                {TypespecTest.SpecModuleAttribute, _}}
+             ] = SpecModuleAttribute.fun1()
+
+      assert [
+               {:spec, {:::, _, [{:fun2, _, _}, {:atom, _, _}]},
+                {TypespecTest.SpecModuleAttribute, _}},
+               {:spec, {:::, _, [{:fun1, _, _}, {:boolean, _, _}]},
+                {TypespecTest.SpecModuleAttribute, _}}
+             ] = SpecModuleAttribute.fun2()
+
+      assert [
+               {:spec, {:::, _, [{:fun3, _, _}, {:pid, _, _}]},
+                {TypespecTest.SpecModuleAttribute, _}},
+               {:spec, {:::, _, [{:fun2, _, _}, {:atom, _, _}]},
+                {TypespecTest.SpecModuleAttribute, _}},
+               {:spec, {:::, _, [{:fun1, _, _}, {:boolean, _, _}]},
+                {TypespecTest.SpecModuleAttribute, _}}
+             ] = SpecModuleAttribute.fun4()
     after
       :code.delete(SpecModuleAttribute)
       :code.purge(SpecModuleAttribute)

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -801,42 +801,133 @@ defmodule TypespecTest do
       assert [{:atom, _, :is_subtype}, [{:var, _, :y}, {:var, _, :x}]] = constraint_type
     end
 
-    test "@spec as module attribute" do
-      defmodule SpecModuleAttribute do
-        @spec fun1 :: boolean
-        def fun1, do: @spec
+    test "@type, @opaque, and typep as module attributes" do
+      defmodule TypeModuleAttributes do
+        @type type1 :: boolean
+        @opaque opaque1 :: boolean
+        @typep typep1 :: boolean
 
-        @spec fun2 :: atom
-        def fun2, do: @spec
+        def type1, do: @type
+        def opaque1, do: @opaque
+        def typep1, do: @typep
 
-        @spec fun3 :: pid
-        def fun3, do: :ok
-        def fun4, do: @spec
+        @type type2 :: atom
+        @type type3 :: pid
+        @opaque opaque2 :: atom
+        @opaque opaque3 :: pid
+        @typep typep2 :: atom
+
+        def type2, do: @type
+        def opaque2, do: @opaque
+        def typep2, do: @typep
+
+        @spec foo(typep1) :: typep2 # Avoid unused warnings
+        def foo(_x), do: :ok
       end
 
       assert [
-               {:spec, {:::, _, [{:fun1, _, _}, {:boolean, _, _}]},
-                {TypespecTest.SpecModuleAttribute, _}}
-             ] = SpecModuleAttribute.fun1()
+               {:type, {:::, _, [{:type1, _, _}, {:boolean, _, _}]},
+                {TypespecTest.TypeModuleAttributes, _}}
+             ] = TypeModuleAttributes.type1()
 
       assert [
-               {:spec, {:::, _, [{:fun2, _, _}, {:atom, _, _}]},
-                {TypespecTest.SpecModuleAttribute, _}},
-               {:spec, {:::, _, [{:fun1, _, _}, {:boolean, _, _}]},
-                {TypespecTest.SpecModuleAttribute, _}}
-             ] = SpecModuleAttribute.fun2()
+               {:type, {:::, _, [{:type3, _, _}, {:pid, _, _}]},
+                {TypespecTest.TypeModuleAttributes, _}},
+               {:type, {:::, _, [{:type2, _, _}, {:atom, _, _}]},
+                {TypespecTest.TypeModuleAttributes, _}},
+               {:type, {:::, _, [{:type1, _, _}, {:boolean, _, _}]},
+                {TypespecTest.TypeModuleAttributes, _}}
+             ] = TypeModuleAttributes.type2()
 
       assert [
-               {:spec, {:::, _, [{:fun3, _, _}, {:pid, _, _}]},
-                {TypespecTest.SpecModuleAttribute, _}},
-               {:spec, {:::, _, [{:fun2, _, _}, {:atom, _, _}]},
-                {TypespecTest.SpecModuleAttribute, _}},
-               {:spec, {:::, _, [{:fun1, _, _}, {:boolean, _, _}]},
-                {TypespecTest.SpecModuleAttribute, _}}
-             ] = SpecModuleAttribute.fun4()
+               {:opaque, {:::, _, [{:opaque1, _, _}, {:boolean, _, _}]},
+                {TypespecTest.TypeModuleAttributes, _}}
+             ] = TypeModuleAttributes.opaque1()
+
+      assert [
+               {:opaque, {:::, _, [{:opaque3, _, _}, {:pid, _, _}]},
+                {TypespecTest.TypeModuleAttributes, _}},
+               {:opaque, {:::, _, [{:opaque2, _, _}, {:atom, _, _}]},
+                {TypespecTest.TypeModuleAttributes, _}},
+               {:opaque, {:::, _, [{:opaque1, _, _}, {:boolean, _, _}]},
+                {TypespecTest.TypeModuleAttributes, _}}
+             ] = TypeModuleAttributes.opaque2()
+
+      assert [
+               {:typep, {:::, _, [{:typep1, _, _}, {:boolean, _, _}]},
+                {TypespecTest.TypeModuleAttributes, _}}
+             ] = TypeModuleAttributes.typep1()
+
+      assert [
+               {:typep, {:::, _, [{:typep2, _, _}, {:atom, _, _}]},
+                {TypespecTest.TypeModuleAttributes, _}},
+               {:typep, {:::, _, [{:typep1, _, _}, {:boolean, _, _}]},
+                {TypespecTest.TypeModuleAttributes, _}}
+             ] = TypeModuleAttributes.typep2()
     after
-      :code.delete(SpecModuleAttribute)
-      :code.purge(SpecModuleAttribute)
+      :code.delete(TypeModuleAttributes)
+      :code.purge(TypeModuleAttributes)
+    end
+
+    test "@spec, @callback, and @macrocallback as module attributes" do
+      defmodule SpecModuleAttributes do
+        @callback callback1 :: integer
+        @macrocallback macrocallback1 :: integer
+
+        @spec spec1 :: boolean
+        def spec1, do: @spec
+
+        @callback callback2 :: boolean
+        @macrocallback macrocallback2 :: boolean
+
+        @spec spec2 :: atom
+        def spec2, do: @spec
+
+        @spec spec3 :: pid
+        def spec3, do: :ok
+        def spec4, do: @spec
+
+        def callback, do: @callback
+        def macrocallback, do: @macrocallback
+      end
+
+      assert [
+               {:spec, {:::, _, [{:spec1, _, _}, {:boolean, _, _}]},
+                {TypespecTest.SpecModuleAttributes, _}}
+             ] = SpecModuleAttributes.spec1()
+
+      assert [
+               {:spec, {:::, _, [{:spec2, _, _}, {:atom, _, _}]},
+                {TypespecTest.SpecModuleAttributes, _}},
+               {:spec, {:::, _, [{:spec1, _, _}, {:boolean, _, _}]},
+                {TypespecTest.SpecModuleAttributes, _}}
+             ] = SpecModuleAttributes.spec2()
+
+      assert [
+               {:spec, {:::, _, [{:spec3, _, _}, {:pid, _, _}]},
+                {TypespecTest.SpecModuleAttributes, _}},
+               {:spec, {:::, _, [{:spec2, _, _}, {:atom, _, _}]},
+                {TypespecTest.SpecModuleAttributes, _}},
+               {:spec, {:::, _, [{:spec1, _, _}, {:boolean, _, _}]},
+                {TypespecTest.SpecModuleAttributes, _}}
+             ] = SpecModuleAttributes.spec4()
+
+      assert [
+               {:callback, {:::, _, [{:callback2, _, _}, {:boolean, _, _}]},
+                {TypespecTest.SpecModuleAttributes, _}},
+               {:callback, {:::, _, [{:callback1, _, _}, {:integer, _, _}]},
+                {TypespecTest.SpecModuleAttributes, _}}
+             ] = SpecModuleAttributes.callback()
+
+      assert [
+               {:macrocallback, {:::, _, [{:macrocallback2, _, _}, {:boolean, _, _}]},
+                {TypespecTest.SpecModuleAttributes, _}},
+               {:macrocallback, {:::, _, [{:macrocallback1, _, _}, {:integer, _, _}]},
+                {TypespecTest.SpecModuleAttributes, _}}
+             ] = SpecModuleAttributes.macrocallback()
+    after
+      :code.delete(SpecModuleAttributes)
+      :code.purge(SpecModuleAttributes)
     end
 
     test "@callback(callback)" do


### PR DESCRIPTION
Closes #8085