### PR TITLE
Allways call ExUnit.EventManager.module_finished/2

### DIFF
--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -141,11 +141,14 @@ defmodule ExUnit.Runner do
           nil
       end
 
-    if pending_tests do
-      test_module = %{test_module | tests: Enum.reverse(finished_tests, pending_tests)}
-      EM.module_finished(config.manager, test_module)
-    end
+    test_module =
+      if pending_tests do
+        %{test_module | tests: Enum.reverse(finished_tests, pending_tests)}
+      else
+        test_module
+      end
 
+    EM.module_finished(config.manager, test_module)
     send(config.runner_pid, {self(), :module_finished})
   end
 


### PR DESCRIPTION
While ExUnit.RunnerStats doesn't do anything,
it may be needed by other handlers.