### PR TITLE
Make folder path example more obvious

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -152,7 +152,7 @@ defmodule IEx.Helpers do
 
   ## Examples
 
-      iex> c(["foo.ex", "bar.ex"], "ebin")
+      iex> c(["foo.ex", "bar.ex"], "src")
       [Foo, Bar]
 
       iex> c("baz.ex")


### PR DESCRIPTION
"ebin" is not a common path, but a path with "src" is well known.