### PR TITLE
Update use of numbers as adjectives

### DIFF
--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -45,7 +45,7 @@ defmodule Kernel.ParallelCompiler do
 
   It returns `{:ok, modules, warnings}` or `{:error, errors, warnings}`.
 
-  Both errors and warnings are a list of three element tuples containing
+  Both errors and warnings are a list of three-element tuples containing
   the file, line and the formatted error/warning.
 
   ## Options
@@ -90,7 +90,7 @@ defmodule Kernel.ParallelCompiler do
 
   It returns `{:ok, modules, warnings}` or `{:error, errors, warnings}`.
 
-  Both errors and warnings are a list of three element tuples containing
+  Both errors and warnings are a list of three-element tuples containing
   the file, line and the formatted error/warning.
 
   ## Options

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -554,7 +554,7 @@ defmodule Supervisor do
   @doc """
   Starts a supervisor with the given children.
 
-  The children is a list of modules, 2-element tuples with module and
+  The children is a list of modules, two-element tuples with module and
   arguments or a map with the child specification. A strategy is required
   to be provided through the `:strategy` option. See
   "start_link/2, init/2, and strategies" for examples and other options.

--- a/lib/elixir/src/elixir_erl_try.erl
+++ b/lib/elixir/src/elixir_erl_try.erl
@@ -87,7 +87,7 @@ erl_rescue_stacktrace_for(_Meta, _Var, 'Elixir.ErlangError') ->
   %% ErlangError is a "meta" exception, we should never expand it here.
   error(badarg);
 erl_rescue_stacktrace_for(Meta, Var, 'Elixir.KeyError') ->
-  %% Only the two element tuple requires stacktrace.
+  %% Only the two-element tuple requires stacktrace.
   erl_and(Meta, erl_tuple_size(Meta, Var, 2), erl_record_compare(Meta, Var, badkey));
 erl_rescue_stacktrace_for(Meta, Var, Module) ->
   erl_rescue_guard_for(Meta, Var, Module).

--- a/lib/elixir/src/elixir_quote.erl
+++ b/lib/elixir/src/elixir_quote.erl
@@ -248,7 +248,7 @@ do_quote({'&', Meta, [{'/', _, [{F, _, C}, A]}] = Args},
 do_quote({Name, Meta, ArgsOrAtom}, #elixir_quote{imports_hygiene=true} = Q, E) when is_atom(Name) ->
   do_quote_import(Name, Meta, ArgsOrAtom, Q, E);
 
-%% Two element tuples
+%% Two-element tuples
 
 do_quote({Left, Right}, #elixir_quote{unquote=true} = Q, E) when
     is_tuple(Left)  andalso (element(1, Left) == unquote_splicing);

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -1909,7 +1909,7 @@ defmodule Kernel.ExpansionTest do
 
       assert expand(quote(do: {:foo, <<foo>>} = {<<baz>>, :baz} = bar()))
 
-      # 2-element tuples are special cased
+      # two-element tuples are special cased
       assert_raise CompileError, message, fn ->
         expand(quote(do: {:foo, <<foo>>} = {:foo, <<baz>>} = bar()))
       end

--- a/lib/mix/lib/mix/task.compiler.ex
+++ b/lib/mix/lib/mix/task.compiler.ex
@@ -64,7 +64,7 @@ defmodule Mix.Task.Compiler do
     a range specified as `{start_line, start_col, end_line, end_col}`,
     or `nil` if unknown.
 
-    Line numbers are 1-based, and column numbers in a range are 0-based and refer
+    Line numbers are one-based, and column numbers in a range are zero-based and refer
     to the cursor position at the start of the character at that index. For example,
     to indicate that a diagnostic applies to the first `n` characters of the
     first line, the range would be `{1, 0, 1, n}`.


### PR DESCRIPTION
- Replace "two element tuples" with "two-element tuples" for every number in 1..10
- Replace "2-element tuples" with "two-element tuples" for every number
- "1-based" with "one-based"
- "0-based" with "zero-based"