### PR TITLE
Fix 2 bugs in ExUnit.Runner

### DIFF
--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -150,12 +150,6 @@ defmodule ExUnit.CLIFormatter do
 
     print_failure(formatted, config)
 
-    test_counter =
-      Enum.reduce(test_module.tests, config.test_counter, &update_test_counter(&2, &1))
-
-    failure_counter = config.failure_counter + tests_length
-    config = %{config | test_counter: test_counter, failure_counter: failure_counter}
-
     {:noreply, config}
   end
 

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -376,12 +376,12 @@ defmodule ExUnit.Runner do
   defp process_max_failures(%{max_failures: :infinity}, _), do: :no
 
   defp process_max_failures(config, %ExUnit.TestModule{state: {tag, _}, tests: tests})
-       when tag in [:failed, :invalid] do
+       when tag in [:failed] do
     process_max_failures(config.stats_pid, config.max_failures, length(tests))
   end
 
   defp process_max_failures(config, %ExUnit.Test{state: {tag, _}})
-       when tag in [:failed, :invalid] do
+       when tag in [:failed] do
     process_max_failures(config.stats_pid, config.max_failures, 1)
   end
 

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -378,13 +378,11 @@ defmodule ExUnit.Runner do
 
   defp process_max_failures(%{max_failures: :infinity}, _), do: :no
 
-  defp process_max_failures(config, %ExUnit.TestModule{state: {tag, _}, tests: tests})
-       when tag in [:failed] do
+  defp process_max_failures(config, %ExUnit.TestModule{state: {:failed, _}, tests: tests}) do
     process_max_failures(config.stats_pid, config.max_failures, length(tests))
   end
 
-  defp process_max_failures(config, %ExUnit.Test{state: {tag, _}})
-       when tag in [:failed] do
+  defp process_max_failures(config, %ExUnit.Test{state: {:failed, _}}) do
     process_max_failures(config.stats_pid, config.max_failures, 1)
   end
 

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -120,17 +120,17 @@ defmodule ExUnit.Runner do
 
     # Prepare tests, selecting which ones should be run or skipped
     tests = prepare_tests(config, test_module.tests)
-    {excluded_tests, to_run_tests} = Enum.split_with(tests, & &1.state)
+    {excluded_and_skipped_tests, to_run_tests} = Enum.split_with(tests, & &1.state)
 
     {test_module, invalid_tests, finished_tests} = spawn_module(config, test_module, to_run_tests)
 
     pending_tests =
       case process_max_failures(config, test_module) do
         :no ->
-          invalid_tests ++ excluded_tests
+          invalid_tests ++ excluded_and_skipped_tests
 
         {:reached, n} ->
-          Enum.take(invalid_tests, n) ++ excluded_tests
+          Enum.take(invalid_tests, n) ++ excluded_and_skipped_tests
 
         :surpassed ->
           nil

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -141,6 +141,8 @@ defmodule ExUnit.Runner do
           nil
       end
 
+    # If pending_tests is [], EM.module_finished is still called.
+    # Only if process_max_failures/2 returns :surpassed it is not.
     if pending_tests do
       for pending_test <- pending_tests do
         EM.test_started(config.manager, pending_test)

--- a/lib/ex_unit/lib/ex_unit/runner_stats.ex
+++ b/lib/ex_unit/lib/ex_unit/runner_stats.ex
@@ -2,7 +2,7 @@ defmodule ExUnit.RunnerStats do
   @moduledoc false
 
   use GenServer
-  alias ExUnit.{FailuresManifest, Test, TestModule}
+  alias ExUnit.{FailuresManifest, Test}
 
   @typep counter :: non_neg_integer
 
@@ -67,12 +67,6 @@ defmodule ExUnit.RunnerStats do
       |> increment_status_counter(test.state)
 
     {:noreply, state}
-  end
-
-  def handle_cast({:module_finished, %TestModule{state: {:failed, _}} = test_module}, state) do
-    %{failures: failures, total: total} = state
-    test_count = length(test_module.tests)
-    {:noreply, %{state | failures: failures + test_count, total: total + test_count}}
   end
 
   def handle_cast({:suite_started, _opts}, %{failures_manifest_file: file} = state)

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -505,8 +505,8 @@ defmodule ExUnitTest do
 
   If setup_all fails, the skipped and excluded tests should not be counted as invalid or failures.
   """
-  test "skipped and excluded" do
-    defmodule SkippedAndExcludedTests do
+  test "setup_all fails and module has skipped and excluded tests" do
+    defmodule SetupAllFailsModuleHasSkippedExcludedTest do
       use ExUnit.Case
 
       setup_all do
@@ -535,37 +535,6 @@ defmodule ExUnitTest do
       end)
 
     refute output =~ max_failures_reached_msg()
-    assert strip(output) =~ "6 tests, 0 failures, 1 excluded, 4 invalid, 1 skipped"
-  end
-
-  test "check for invalid and excluded tests in stdout" do
-    defmodule CheckForInvalidExcludedStdoutTest do
-      use ExUnit.Case
-
-      setup_all do
-        raise "oops"
-      end
-
-      @tag :skip
-      test "skipped", do: assert(true)
-
-      test "pass #{__ENV__.line}", do: assert(true)
-      test "pass #{__ENV__.line}", do: assert(true)
-      test "fail #{__ENV__.line}", do: assert(false)
-      test "fail #{__ENV__.line}", do: assert(false)
-
-      @tag :exclude
-      test "exclude me please", do: assert(true)
-    end
-
-    ExUnit.Server.modules_loaded()
-
-    output =
-      capture_io(fn ->
-        predictable_ex_unit_start(exclude: [:exclude])
-        assert ExUnit.run() == %{total: 6, failures: 4, skipped: 1, excluded: 1}
-      end)
-
     assert strip(output) =~ "6 tests, 0 failures, 1 excluded, 4 invalid, 1 skipped"
   end
 

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -637,11 +637,11 @@ defmodule ExUnitTest do
       output =
         capture_io(fn ->
           predictable_ex_unit_start(max_failures: 2)
-          assert ExUnit.run() == %{total: 4, failures: 2, skipped: 0, excluded: 0}
+          assert ExUnit.run() == %{total: 5, failures: 2, skipped: 1, excluded: 0}
         end)
 
       assert output =~ max_failures_reached_msg()
-      assert output =~ "4 tests, 2 failures"
+      assert strip(output) =~ "5 tests, 2 failures, 1 skipped"
     end
 
     test ":max_failures is not reached" do
@@ -689,11 +689,11 @@ defmodule ExUnitTest do
       output =
         capture_io(fn ->
           predictable_ex_unit_start(max_failures: 2)
-          assert ExUnit.run() == %{total: 3, failures: 2, excluded: 0, skipped: 0}
+          assert ExUnit.run() == %{total: 4, failures: 2, excluded: 0, skipped: 1}
         end)
 
       assert output =~ max_failures_reached_msg()
-      assert output =~ "3 tests, 2 failures"
+      assert strip(output) =~ "4 tests, 2 failures, 1 skipped"
     end
 
     @doc """

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -636,7 +636,7 @@ defmodule ExUnitTest do
         end)
 
       refute output =~ max_failures_reached_msg()
-      assert output =~ "6 tests, 2 failures"
+      assert strip(output) =~ "6 tests, 2 failures, 1 skipped"
     end
 
     test ":max_failures has been reached" do

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -535,7 +535,7 @@ defmodule ExUnitTest do
       end)
 
     refute output =~ max_failures_reached_msg()
-    assert strip(output) =~ "6 tests, 0 failures, 1 excluded, 4 invalid, 1 skipped"
+    assert output =~ "6 tests, 0 failures, 1 excluded, 4 invalid, 1 skipped"
   end
 
   describe "after_suite/1" do
@@ -610,7 +610,7 @@ defmodule ExUnitTest do
         end)
 
       assert output =~ max_failures_reached_msg()
-      assert strip(output) =~ "5 tests, 2 failures, 1 skipped"
+      assert output =~ "5 tests, 2 failures, 1 skipped"
     end
 
     test ":max_failures is not reached" do
@@ -636,7 +636,7 @@ defmodule ExUnitTest do
         end)
 
       refute output =~ max_failures_reached_msg()
-      assert strip(output) =~ "6 tests, 2 failures, 1 skipped"
+      assert output =~ "6 tests, 2 failures, 1 skipped"
     end
 
     test ":max_failures has been reached" do
@@ -662,7 +662,7 @@ defmodule ExUnitTest do
         end)
 
       assert output =~ max_failures_reached_msg()
-      assert strip(output) =~ "4 tests, 2 failures, 1 skipped"
+      assert output =~ "4 tests, 2 failures, 1 skipped"
     end
 
     @doc """
@@ -699,7 +699,7 @@ defmodule ExUnitTest do
         end)
 
       assert output =~ max_failures_reached_msg()
-      assert strip(output) =~ "4 tests, 0 failures, 1 excluded, 2 invalid, 1 skipped"
+      assert output =~ "4 tests, 0 failures, 1 excluded, 2 invalid, 1 skipped"
     end
 
     test ":max_failures flushes all async/sync cases" do
@@ -762,15 +762,10 @@ defmodule ExUnitTest do
 
   # Runs ExUnit.start/1 with common options needed for predictability
   def predictable_ex_unit_start(options) do
-    ExUnit.start(options ++ [autorun: false, seed: 0])
+    ExUnit.start(options ++ [autorun: false, seed: 0, colors: [enabled: false]])
   end
 
   defp max_failures_reached_msg() do
     "--max-failures reached, aborting test suite"
-  end
-
-  # Strips escape-sequence colors from IO.ANSI strings
-  defp strip(string) do
-    String.replace(string, ~r/\e\[(\d+;?)+m/, "")
   end
 end

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -499,11 +499,11 @@ defmodule ExUnitTest do
   end
 
   @doc """
-    Skipped and excluded tests should be included in the stats as well as printed to stdout.
-    On the other hand, invalid tests should be marked as failures in the stats,
-    but still be printed as "invalid" to stdout.
+  Skipped and excluded tests should be included in the stats as well as printed to stdout.
+  On the other hand, invalid tests should be marked as failures in the stats,
+  but still be printed as "invalid" to stdout.
 
-    If setup_all fails, the skipped and excluded tests should not be counted as invalid or failures.
+  If setup_all fails, the skipped and excluded tests should not be counted as invalid or failures.
   """
   test "skipped and excluded" do
     defmodule SkippedAndExcludedTests do


### PR DESCRIPTION
There were 2 bugs in the current implementation

1. After the introduction of max-failures, the printing of the number of invalid tests went missing.

2. Invalid and Excluded (pending) tests were counted twice if setup_all failed.
A module with 1 skipped test and 1 excluded and 6 tests in it, it would be reported with a total of 8 tests.
This happened before max-failures was introduced.

A test file is provided including the new tests:
https://gist.github.com/eksperimental/30073f1b190fd2d34c75eadb92a41551

This PR takes the following approach:

1. We determine before running any test which are the tests to be skipped and excluded,
therefore:
  A. these tests are always part of the total number of tests in the stats.
  B. these tests are not counted as failures or invalid ones if setup_all fails.

2.
 A. We call `EM.test_started/2` and `EM.test_finished/2` for every test in a module that is run.
 B. We call `EM.module_started/2` and `EM.module_finished/2` for every module that is run.

 This way it is upto the implementation of the Event Manager handler to choose what to do to.
 The approach that we take in `ExUnit.CLIFormatter` is to evaluate the calls for test_started and test_finished,
 and to ignore the ones for `module_started` and `module_finished`.