### PR TITLE
Improvements to the Version module documentation

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -69,7 +69,7 @@ defmodule Version do
   `~> 2.0`       | `>= 2.0.0 and < 3.0.0`
   `~> 2.1`       | `>= 2.1.0 and < 3.0.0`
 
-  The requirement operand after the `~>` is allows to omit the PATCH part of the version,
+  The requirement operand after the `~>` is allowed to omit the PATCH part of the version,
   allowing us to express `~> 2.1` or `~> 2.1-dev`, something that wouldn't be allowed
   when using the common comparison operators.
 

--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -35,9 +35,9 @@ defmodule Version do
   ## Requirements
 
   Requirements allow you to specify which versions of a given
-  dependency you are willing to work against. Requirements support common
-  operators like `>=`, `<=`, `>`, `==`, and friends that
-  work as one would expect:
+  dependency you are willing to work against. Requirements support the common
+  operators such as `>`, `>=`, `<`, `<=`, `==`, `!=` that work as one would expect,
+  and additionally the special operator `~>` described in detail further bellow.
 
       # Only version 2.0.0
       "== 2.0.0"
@@ -55,10 +55,12 @@ defmodule Version do
 
       "~> 2.0.0"
 
-  `~>` will never include pre-release versions of its upper bound.
+  `~>` will never include pre-release versions of its upper bound,
+  regardless of the usage of the `allow_pre:` option, or whether the operand
+  is a pre-release version.
   It can also be used to set an upper bound on only the major
   version part. See the table below for `~>` requirements and
-  their corresponding translation.
+  their corresponding translations.
 
   `~>`           | Translation
   :------------- | :---------------------
@@ -68,23 +70,28 @@ defmodule Version do
   `~> 2.0`       | `>= 2.0.0 and < 3.0.0`
   `~> 2.1`       | `>= 2.1.0 and < 3.0.0`
 
-  When `allow_pre: false` is set, the requirement will not match a
-  pre-release version unless the operand is a pre-release version.
+  The requirement operand after the `~>` is allows to omit the PATCH part of the version,
+  allowing us to express `~> 2.1` or `~> 2.1-dev`, something that wouldn't be allowed
+  when using the common operators.
+
+  When the option `allow_pre: false` is set in `Version.match?/3`, the requirement
+  will not match a pre-release version unless the operand is a pre-release version.
   The default is to always allow pre-releases but note that in
   Hex `:allow_pre` is set to `false`. See the table below for examples.
 
-  Requirement    | Version     | `:allow_pre` | Matches
-  :------------- | :---------- | :----------- | :------
-  `~> 2.0`       | `2.1.0`     | -            | `true`
-  `~> 2.0`       | `3.0.0`     | -            | `false`
-  `~> 2.0.0`     | `2.0.1`     | -            | `true`
-  `~> 2.0.0`     | `2.1.0`     | -            | `false`
-  `~> 2.1.2`     | `2.1.3-dev` | `true`       | `true`
-  `~> 2.1.2`     | `2.1.3-dev` | `false`      | `false`
-  `~> 2.1-dev`   | `2.2.0-dev` | `false`      | `true`
-  `~> 2.1.2-dev` | `2.1.3-dev` | `false`      | `true`
-  `>= 2.1.0`     | `2.2.0-dev` | `false`      | `false`
-  `>= 2.1.0-dev` | `2.2.3-dev` | `true`       | `true`
+  Requirement    | Version     | `:allow_pre`      | Matches
+  :------------- | :---------- | :---------------- | :------
+  `~> 2.0`       | `2.1.0`     | `true` or `false` | `true`
+  `~> 2.0`       | `3.0.0`     | `true` or `false` | `false`
+  `~> 2.0.0`     | `2.0.5`     | `true` or `false` | `true`
+  `~> 2.0.0`     | `2.1.0`     | `true` or `false` | `false`
+  `~> 2.1.2`     | `2.1.6-dev` | `true`            | `true`
+  `~> 2.1.2`     | `2.1.6-dev` | `false`           | `false`
+  `~> 2.1-dev`   | `2.2.0-dev` | `true` or `false` | `true`
+  `~> 2.1.2-dev` | `2.1.6-dev` | `true` or `false` | `true`
+  `>= 2.1.0`     | `2.2.0-dev` | `true`            | `true`
+  `>= 2.1.0`     | `2.2.0-dev` | `false`           | `false`
+  `>= 2.1.0-dev` | `2.2.6-dev` | `true` or `false` | `true`
 
   """
 
@@ -146,8 +153,8 @@ defmodule Version do
   ## Options
 
     * `:allow_pre` (boolean) - when `false`, pre-release versions will not match
-      unless the operand is a pre-release version. See the table above
-      for examples. Defaults to `true`.
+      unless the operand is a pre-release version. Defaults to `true`.
+      For examples, please refer to the table above under the "Requirements" section.
 
   ## Examples
 
@@ -155,6 +162,12 @@ defmodule Version do
       true
 
       iex> Version.match?("2.0.0", "== 1.0.0")
+      false
+
+      iex> Version.match?("2.1.6-dev", "~> 2.1.2")
+      true
+
+      iex> Version.match?("2.1.6-dev", "~> 2.1.2", allow_pre: false)
       false
 
       iex> Version.match?("foo", "== 1.0.0")

--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -69,7 +69,7 @@ defmodule Version do
   `~> 2.0`       | `>= 2.0.0 and < 3.0.0`
   `~> 2.1`       | `>= 2.1.0 and < 3.0.0`
 
-  The requirement operand after the `~>` is allowed to omit the PATCH part of the version,
+  The requirement operand after the `~>` is allowed to omit the patch version,
   allowing us to express `~> 2.1` or `~> 2.1-dev`, something that wouldn't be allowed
   when using the common comparison operators.
 

--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -36,8 +36,8 @@ defmodule Version do
 
   Requirements allow you to specify which versions of a given
   dependency you are willing to work against. Requirements support the common
-  operators such as `>`, `>=`, `<`, `<=`, `==`, `!=` that work as one would expect,
-  and additionally the special operator `~>` described in detail further bellow.
+  comparison operators such as `>`, `>=`, `<`, `<=`, `==`, `!=` that work as one would expect,
+  and additionally the special operator `~>` described in detail further below.
 
       # Only version 2.0.0
       "== 2.0.0"
@@ -56,9 +56,8 @@ defmodule Version do
       "~> 2.0.0"
 
   `~>` will never include pre-release versions of its upper bound,
-  regardless of the usage of the `allow_pre:` option, or whether the operand
-  is a pre-release version.
-  It can also be used to set an upper bound on only the major
+  regardless of the usage of the `:allow_pre` option, or whether the operand
+  is a pre-release version. It can also be used to set an upper bound on only the major
   version part. See the table below for `~>` requirements and
   their corresponding translations.
 
@@ -72,9 +71,9 @@ defmodule Version do
 
   The requirement operand after the `~>` is allows to omit the PATCH part of the version,
   allowing us to express `~> 2.1` or `~> 2.1-dev`, something that wouldn't be allowed
-  when using the common operators.
+  when using the common comparison operators.
 
-  When the option `allow_pre: false` is set in `Version.match?/3`, the requirement
+  When the `:allow_pre` option is set `false` in `Version.match?/3`, the requirement
   will not match a pre-release version unless the operand is a pre-release version.
   The default is to always allow pre-releases but note that in
   Hex `:allow_pre` is set to `false`. See the table below for examples.

--- a/lib/elixir/test/elixir/version_test.exs
+++ b/lib/elixir/test/elixir/version_test.exs
@@ -180,34 +180,43 @@ defmodule VersionTest do
     assert Version.match?("2.3.0", "<= 2.3.0")
   end
 
-  test "~>" do
-    assert Version.match?("3.0.0", "~> 3.0")
-    assert Version.match?("3.2.0", "~> 3.0")
-    refute Version.match?("4.0.0", "~> 3.0")
-    refute Version.match?("4.4.0", "~> 3.0")
+  describe "~>" do
+    test "regular cases" do
+      assert Version.match?("3.0.0", "~> 3.0")
+      assert Version.match?("3.2.0", "~> 3.0")
+      refute Version.match?("4.0.0", "~> 3.0")
+      refute Version.match?("4.4.0", "~> 3.0")
 
-    assert Version.match?("3.0.2", "~> 3.0.0")
-    assert Version.match?("3.0.0", "~> 3.0.0")
-    refute Version.match?("3.1.0", "~> 3.0.0")
-    refute Version.match?("3.4.0", "~> 3.0.0")
+      assert Version.match?("3.0.2", "~> 3.0.0")
+      assert Version.match?("3.0.0", "~> 3.0.0")
+      refute Version.match?("3.1.0", "~> 3.0.0")
+      refute Version.match?("3.4.0", "~> 3.0.0")
 
-    assert Version.match?("3.6.0", "~> 3.5")
-    assert Version.match?("3.5.0", "~> 3.5")
-    refute Version.match?("4.0.0", "~> 3.5")
-    refute Version.match?("5.0.0", "~> 3.5")
+      assert Version.match?("3.6.0", "~> 3.5")
+      assert Version.match?("3.5.0", "~> 3.5")
+      refute Version.match?("4.0.0", "~> 3.5")
+      refute Version.match?("5.0.0", "~> 3.5")
 
-    assert Version.match?("3.5.2", "~> 3.5.0")
-    assert Version.match?("3.5.4", "~> 3.5.0")
-    refute Version.match?("3.6.0", "~> 3.5.0")
-    refute Version.match?("3.6.3", "~> 3.5.0")
+      assert Version.match?("3.5.2", "~> 3.5.0")
+      assert Version.match?("3.5.4", "~> 3.5.0")
+      refute Version.match?("3.6.0", "~> 3.5.0")
+      refute Version.match?("3.6.3", "~> 3.5.0")
 
-    assert Version.match?("0.9.3", "~> 0.9.3-dev")
-    refute Version.match?("0.10.0", "~> 0.9.3-dev")
+      assert Version.match?("0.9.3", "~> 0.9.3-dev")
+      refute Version.match?("0.10.0", "~> 0.9.3-dev")
 
-    refute Version.match?("0.3.0-dev", "~> 0.2.0")
+      refute Version.match?("0.3.0-dev", "~> 0.2.0")
 
-    assert_raise Version.InvalidRequirementError, fn ->
-      Version.match?("3.0.0", "~> 3")
+      assert_raise Version.InvalidRequirementError, fn ->
+        Version.match?("3.0.0", "~> 3")
+      end
+    end
+
+    test "~> will never include pre-release versions of its upper bound" do
+      refute Version.match?("2.2.0-dev", "~> 2.1.0")
+      refute Version.match?("2.2.0-dev", "~> 2.1.0", allow_pre: false)
+      refute Version.match?("2.2.0-dev", "~> 2.1.0-dev")
+      refute Version.match?("2.2.0-dev", "~> 2.1.0-dev", allow_pre: false)
     end
   end
 


### PR DESCRIPTION
- General improvements to docs
- Minor grammar corrections
- Add doc test examples to Version.match?/3 using :allow_pre option
- List all the operators allowed in requirements.
- Mention that the PATH part of the version can be used as operand with ~>
- Make a clarification that "`~>` will never include pre-release versions of its upper bound,
  regardless of the usage of the `allow_pre:` option", and add tests to verify this
- The requirement table has been update:
  - It doesn't use the consecutive PATCH number in the example, so `~> 2.1.2` will not use
    `2.1.3-dev` but `2.1.6-dev` to make it that the upper bound is within the MINOR part
    not the PATCH one
  - Remove "-" and replace with "`true` or `false`" as it is not clear what "-" means in that example,
   and it could be understood that the option is not allowed in that example.
  - Updated to "`true` or `false`" the cases whether both options return the same value.
  - Added an additional example: `>= 2.1.0` | `2.2.0-dev` | `true` | `true`