### PR TITLE
Add new line after make test_* are executed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ lib/$(1)/ebin/Elixir.$(2).beam: $(wildcard lib/$(1)/lib/*.ex) $(wildcard lib/$(1
 test_$(1): compile $(1)
 	@ echo "==> $(1) (ex_unit)"
 	$(Q) cd lib/$(1) && ../../bin/elixir -r "test/test_helper.exs" -pr "test/**/*_test.exs";
+	@ echo ""
 endef
 
 #==> Compilation tasks
@@ -238,6 +239,7 @@ test_stdlib: compile
 	else \
 		cd lib/elixir && ../../bin/elixir -r "test/elixir/test_helper.exs" -pr "test/elixir/**/*_test.exs"; \
 	fi
+	@ echo ""
 
 #==> Dialyzer tasks
 


### PR DESCRIPTION
It is confusing as the seed seems to belong to the following test

BEFORE:
```
..........................................................

Finished in 40.4 seconds (20.4s on load, 19.9s on tests)
1424 doctests, 3034 tests, 0 failures, 7 excluded

Randomized with seed 789593
==> ex_unit (ex_unit)
...................................................................................................................................................................................................................................................................................................................

Finished in 4.8 seconds (2.1s on load, 2.7s on tests)
38 doctests, 269 tests, 0 failures

Randomized with seed 383349
==> logger (ex_unit)
Excluding tags: [:error_logger]

.......................................................................................................................

Finished in 1.8 seconds (1.3s on load, 0.4s on tests)
3 doctests, 125 tests, 0 failures, 9 excluded

Randomized with seed 947893
==> mix (ex_unit)
..............................
```


AFTER:
```
..........................................................

Finished in 40.4 seconds (20.4s on load, 19.9s on tests)
1424 doctests, 3034 tests, 0 failures, 7 excluded

Randomized with seed 789593

==> ex_unit (ex_unit)
...................................................................................................................................................................................................................................................................................................................

Finished in 4.8 seconds (2.1s on load, 2.7s on tests)
38 doctests, 269 tests, 0 failures

Randomized with seed 383349

==> logger (ex_unit)
Excluding tags: [:error_logger]

.......................................................................................................................

Finished in 1.8 seconds (1.3s on load, 0.4s on tests)
3 doctests, 125 tests, 0 failures, 9 excluded

Randomized with seed 947893

==> mix (ex_unit)
..............................
```