### PR TITLE
Document --only and --include --exclude difference

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -210,7 +210,8 @@ defmodule Mix.Tasks.Test do
 
       mix test --only external
 
-  Which is equivalent to:
+  If no tests match and the `--only` option was used the test will raise an error.
+  The following produces a similar result, except it doesn't raise an error on no matches:
 
       mix test --include external --exclude test
 

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -214,7 +214,7 @@ defmodule Mix.Tasks.Test do
 
       mix test --include external --exclude test
 
-  It differs in that the test suite will fail if no tests are executed when the --only option is used.
+  It differs in that the test suite will fail if no tests are executed when the `--only` option is used.
 
   In case a single file is being tested, it is possible to pass a specific
   line number:

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -210,10 +210,11 @@ defmodule Mix.Tasks.Test do
 
       mix test --only external
 
-  If no tests match and the `--only` option was used the test suite will fail.
-  The following produces a similar result, except it doesn't fail on no matches:
+  Which is similar to:
 
       mix test --include external --exclude test
+
+  It differs in that the test suite will fail if no tests are executed when the --only option is used.
 
   In case a single file is being tested, it is possible to pass a specific
   line number:

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -210,8 +210,8 @@ defmodule Mix.Tasks.Test do
 
       mix test --only external
 
-  If no tests match and the `--only` option was used the test will raise an error.
-  The following produces a similar result, except it doesn't raise an error on no matches:
+  If no tests match and the `--only` option was used the test suite will fail.
+  The following produces a similar result, except it doesn't fail on no matches:
 
       mix test --include external --exclude test
 


### PR DESCRIPTION
#7295 made tests raise an error if the option --only was used and it matched no tests, but it isn't mentioned in the documentation and it says `--only tag` and `--include tag --exclude test` are the same when now they are not, as `--include tag --exclude test` doesn't raise on no matches.