### PR TITLE
Info instead of error on unmatched umbrella tests

### DIFF
--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -666,6 +666,16 @@ defmodule Mix.Project do
     end
   end
 
+  @doc """
+  Indicates if currently recursing through the project stack
+  """
+  def recursing?() do
+    case Mix.ProjectStack.recursing() do
+      nil -> false
+      _ -> true
+    end
+  end
+
   # Loads mix.exs in the current directory or loads the project from the
   # mixfile cache and pushes the project onto the project stack.
   defp load_project(app, post_config) do

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -421,11 +421,16 @@ defmodule Mix.Tasks.Test do
   end
 
   defp raise_or_error_at_exit(message, opts) do
-    if opts[:raise] do
-      Mix.raise(message)
-    else
-      Mix.shell().error(message)
-      System.at_exit(fn _ -> exit({:shutdown, 1}) end)
+    cond do
+      Mix.Project.recursing?() ->
+        Mix.shell().info(message)
+
+      opts[:raise] ->
+        Mix.raise(message)
+
+      true ->
+        Mix.shell().error(message)
+        System.at_exit(fn _ -> exit({:shutdown, 1}) end)
     end
   end
 


### PR DESCRIPTION
When running `mix test file_in_one_child_app_but_not_another.exs` an error is logged and an exit/raise happens for every other child app stating `Paths given to 'mix test' did not match any directory/file...`. Since this is a frequent valid use case, this Pull Request changes the message to an `info()` (similar to the `There are no tests to run` message) and doesn't raise or exit when no matching files are found while recursing.