### PR TITLE
Format error message in Mix.Task.Compiler

### DIFF
--- a/lib/mix/lib/mix/task.compiler.ex
+++ b/lib/mix/lib/mix/task.compiler.ex
@@ -122,7 +122,7 @@ defmodule Mix.Task.Compiler do
 
       _ ->
         Mix.shell().error(
-          "[warning] Mix compiler #{inspect(name)} was supposed to return " <>
+          "warning: Mix compiler #{inspect(name)} was supposed to return " <>
             "{:ok | :noop | :error, [diagnostic]} but it returned #{inspect(result)}"
         )
 


### PR DESCRIPTION
For what I've seen, that's the format the Elixir codebase usually use.