### PR TITLE
Add tests for "mix test {--only, --include, --exclude}" + Fix bug

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -383,7 +383,7 @@ defmodule Mix.Tasks.Test do
     display_warn_test_pattern(test_files, test_pattern, matched_test_files, warn_test_pattern)
 
     case CT.require_and_run(matched_test_files, test_paths, opts) do
-      {:ok, %{excluded: excluded, failures: failures, total: total}} ->
+      {:ok, %{excluded: excluded, failures: failures, skipped: skipped, total: total}} ->
         cover && cover.()
 
         option_only_present? = Keyword.has_key?(opts, :only)
@@ -395,7 +395,7 @@ defmodule Mix.Tasks.Test do
           failures > 0 ->
             System.at_exit(fn _ -> exit({:shutdown, 1}) end)
 
-          excluded == total and option_only_present? ->
+          total == excluded + skipped and option_only_present? ->
             message = "The --only option was given to \"mix test\" but no test was executed"
             raise_or_error_at_exit(message, opts)
 

--- a/lib/mix/test/fixtures/test_passed/mix.exs
+++ b/lib/mix/test/fixtures/test_passed/mix.exs
@@ -1,0 +1,11 @@
+defmodule TestPassed.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :test_passed,
+      version: "0.1.0",
+      test_pattern: "*_test_passed.exs"
+    ]
+  end
+end

--- a/lib/mix/test/fixtures/test_passed/test/test_helper.exs
+++ b/lib/mix/test/fixtures/test_passed/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -297,6 +297,12 @@ defmodule Mix.Tasks.TestTest do
       # --only doesn't match any test; it fails
       output = mix(["test", "--only", "one_hundred", "test/test_passing_test_passed_.exs"])
       assert output =~ only_error_message
+
+      # --only doesn't match any test, but the test_module contains skipped and excluded tests;
+      # it fails
+      output = mix(["test", "--only", "one_hundred"])
+      assert output =~ "5 tests, 0 failures, 4 excluded, 1 skipped"
+      assert output =~ only_error_message
     end)
   end
 


### PR DESCRIPTION
Add tests for "mix test {--only, --include, --exclude}"
Fix bug when test module contains skipped tests when running mix test --only
    
There was a bug that when `mix test --only` didn't return any match,
it would not fail, and it would work exactly as with "--include, --exclude options"

Reviewing #8330 made me realize this feature was not tested, and there was a bug laying behind a corner case.

It's separated in two commits. Please keep them as such to maintain the history