### PR TITLE
Change the precedence in ExUnit.Filters.eval/4

### DIFF
--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -125,7 +125,7 @@ defmodule ExUnit.Filters do
   is returned.
 
   The only exception to this rule is that `:skip` is found in the `include` filter,
-  `:ok` is returned regardless of wether the test was excluded or not.
+  `:ok` is returned regardless of whether the test was excluded or not.
 
   ## Examples
 
@@ -143,20 +143,15 @@ defmodule ExUnit.Filters do
     excluded? = not (!excluded)
     included? = Enum.any?(include, &has_tag(&1, tags, collection))
 
-    skip_tag =
-      case Map.fetch(tags, :skip) do
-        {:ok, value} -> %{skip: value}
-        :error -> %{skip: true}
-      end
-
-    skip_included_explicitely? = Enum.any?(include, &has_tag(&1, skip_tag, collection))
-
     if included? or not excluded? do
+      skip_tag = %{skip: Map.get(tags, :skip, true)}
+      skip_included_explicitly? = Enum.any?(include, &has_tag(&1, skip_tag, collection))
+
       case Map.fetch(tags, :skip) do
-        {:ok, msg} when is_binary(msg) and not skip_included_explicitely? ->
+        {:ok, msg} when is_binary(msg) and not skip_included_explicitly? ->
           {:skipped, msg}
 
-        {:ok, true} when not skip_included_explicitely? ->
+        {:ok, true} when not skip_included_explicitly? ->
           {:skipped, "due to skip tag"}
 
         _ ->

--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -140,7 +140,7 @@ defmodule ExUnit.Filters do
           :ok | {:excluded, String.t()} | {:skipped, String.t()}
   def eval(include, exclude, tags, collection) when is_map(tags) do
     excluded = Enum.find_value(exclude, &has_tag(&1, tags, collection))
-    excluded? = not (!excluded)
+    excluded? = excluded != nil
     included? = Enum.any?(include, &has_tag(&1, tags, collection))
 
     if included? or not excluded? do

--- a/lib/ex_unit/test/ex_unit/filters_test.exs
+++ b/lib/ex_unit/test/ex_unit/filters_test.exs
@@ -33,7 +33,10 @@ defmodule ExUnit.FiltersTest do
       assert ExUnit.Filters.eval([], [:two], tags.one, []) == :ok
       assert ExUnit.Filters.eval([], [:test], tags.one, []) == {:excluded, "due to test filter"}
       assert ExUnit.Filters.eval([], [:test], tags.two, []) == {:excluded, "due to test filter"}
-      assert ExUnit.Filters.eval([], [:numeric], tags.one, []) == {:excluded, "due to numeric filter"}
+
+      assert ExUnit.Filters.eval([], [:numeric], tags.one, []) ==
+               {:excluded, "due to numeric filter"}
+
       assert ExUnit.Filters.eval([], [:unknown], tags.one, []) == :ok
       assert ExUnit.Filters.eval([], [:unknown], tags.two, []) == {:skipped, "due to skip tag"}
     end
@@ -53,10 +56,13 @@ defmodule ExUnit.FiltersTest do
 
       # --only
       assert ExUnit.Filters.eval([:one], [:test], tags.one, []) == :ok
+
       assert ExUnit.Filters.eval([:two], [:test], tags.one, []) ==
                {:excluded, "due to test filter"}
+
       assert ExUnit.Filters.eval([:unknown], [:test], tags.one, []) ==
                {:excluded, "due to test filter"}
+
       assert ExUnit.Filters.eval([:unknown], [:test], tags.two, []) ==
                {:excluded, "due to test filter"}
     end
@@ -122,7 +128,9 @@ defmodule ExUnit.FiltersTest do
       assert ExUnit.Filters.eval([:skip], [:test], %{skip: true}, []) == :ok
       assert ExUnit.Filters.eval([:skip], [:test], %{skip: "skipped"}, []) == :ok
       assert ExUnit.Filters.eval([skip: true], [:test], %{skip: true}, []) == :ok
-      assert ExUnit.Filters.eval([skip: ~r/skip me/], [:test], %{skip: "skip me please"}, []) == :ok
+
+      assert ExUnit.Filters.eval([skip: ~r/skip me/], [:test], %{skip: "skip me please"}, []) ==
+               :ok
 
       assert ExUnit.Filters.eval([skip: ~r/skip me/], [:test], %{skip: "don't skip!"}, []) ==
                {:skipped, "don't skip!"}

--- a/lib/ex_unit/test/ex_unit/filters_test.exs
+++ b/lib/ex_unit/test/ex_unit/filters_test.exs
@@ -41,7 +41,7 @@ defmodule ExUnit.FiltersTest do
       assert ExUnit.Filters.eval([], [:unknown], tags.two, []) == {:skipped, "due to skip tag"}
     end
 
-    test "explicitly exclude a test with the `:skip` tag", tags do
+    test "explicitly exclude a test with the :skip tag", tags do
       # --exclude two
       assert ExUnit.Filters.eval([], [:two], tags.two, []) == {:excluded, "due to two filter"}
 
@@ -67,7 +67,7 @@ defmodule ExUnit.FiltersTest do
                {:excluded, "due to test filter"}
     end
 
-    test "explicitly include a test with the `:skip` tag", tags do
+    test "explicitly include a test with the :skip tag", tags do
       # --include two, exclude is missing
       assert ExUnit.Filters.eval([:two], [], tags.two, []) == {:skipped, "due to skip tag"}
 
@@ -75,7 +75,7 @@ defmodule ExUnit.FiltersTest do
       assert ExUnit.Filters.eval([:two], [:test], tags.two, []) == {:skipped, "due to skip tag"}
     end
 
-    test "exception to the rule: include tests with the `:skip` tag", tags do
+    test "exception to the rule: include tests with the :skip tag", tags do
       # --include skip, exclude is missing
       assert ExUnit.Filters.eval([:skip], [], tags.two, []) == :ok
       assert ExUnit.Filters.eval([:skip], [], %{tags.two | skip: "skip me please"}, []) == :ok
@@ -122,7 +122,7 @@ defmodule ExUnit.FiltersTest do
       assert ExUnit.Filters.eval([], [:os], %{skip: "skipped"}, []) == {:skipped, "skipped"}
     end
 
-    test "exception to the rule: explicitly including tests with the `:skip` tag" do
+    test "exception to the rule: explicitly including tests with the :skip tag" do
       assert ExUnit.Filters.eval([:skip], [], %{skip: true}, []) == :ok
       assert ExUnit.Filters.eval([:skip], [], %{skip: "skipped"}, []) == :ok
       assert ExUnit.Filters.eval([:skip], [:test], %{skip: true}, []) == :ok

--- a/lib/ex_unit/test/ex_unit/filters_test.exs
+++ b/lib/ex_unit/test/ex_unit/filters_test.exs
@@ -5,38 +5,25 @@ defmodule ExUnit.FiltersTest do
 
   doctest ExUnit.Filters
 
-  setup do
-    [
-      one: %{
-        one: true,
-        numeric: true,
-        test: :"test one",
-        test_type: :test
-      },
-      two: %{
-        skip: true,
-        numeric: true,
-        test: :"test two",
-        test_type: :test,
-        two: true
-      }
-    ]
-  end
-
-  @doc """
-  Evaluates thew filter precedence.
-  Tests are excluded, then included, and if they have
-  The following setting is given:
-
-      @tag :one
-      test "one", do assert(true)
-
-      @tag :skip
-      @tag :two
-      test "two", do assert(true)
-
-  """
   describe "filter precedence" do
+    setup do
+      [
+        one: %{
+          one: true,
+          numeric: true,
+          test: :"test one",
+          test_type: :test
+        },
+        two: %{
+          skip: true,
+          numeric: true,
+          test: :"test two",
+          test_type: :test,
+          two: true
+        }
+      ]
+    end
+
     test "no filters", tags do
       assert ExUnit.Filters.eval([], [], tags.one, []) == :ok
       assert ExUnit.Filters.eval([], [], tags.two, []) == {:skipped, "due to skip tag"}
@@ -51,7 +38,7 @@ defmodule ExUnit.FiltersTest do
       assert ExUnit.Filters.eval([], [:unknown], tags.two, []) == {:skipped, "due to skip tag"}
     end
 
-    test "explicitely exclude a test with the `:skip` tag", tags do
+    test "explicitly exclude a test with the `:skip` tag", tags do
       # --exclude two
       assert ExUnit.Filters.eval([], [:two], tags.two, []) == {:excluded, "due to two filter"}
 
@@ -74,7 +61,7 @@ defmodule ExUnit.FiltersTest do
                {:excluded, "due to test filter"}
     end
 
-    test "explicitely include a test with the `:skip` tag", tags do
+    test "explicitly include a test with the `:skip` tag", tags do
       # --include two, exclude is missing
       assert ExUnit.Filters.eval([:two], [], tags.two, []) == {:skipped, "due to skip tag"}
 
@@ -129,7 +116,7 @@ defmodule ExUnit.FiltersTest do
       assert ExUnit.Filters.eval([], [:os], %{skip: "skipped"}, []) == {:skipped, "skipped"}
     end
 
-    test "exception to the rule: explicitely including tests with the `:skip` tag" do
+    test "exception to the rule: explicitly including tests with the `:skip` tag" do
       assert ExUnit.Filters.eval([:skip], [], %{skip: true}, []) == :ok
       assert ExUnit.Filters.eval([:skip], [], %{skip: "skipped"}, []) == :ok
       assert ExUnit.Filters.eval([:skip], [:test], %{skip: true}, []) == :ok


### PR DESCRIPTION
Fixes issues mentioned in #8335, particularly in this discussion:
https://github.com/elixir-lang/elixir/pull/8335#pullrequestreview-168148010

Tests should be first excluded, then included, and then skipped (if any left).
The only exception to the rule is when we explicitely include tests with :skip filter,
to which the :ok value is returned.

Fixes return value of `@spec`