### PR TITLE
Change order in which filter meesage are printed in  ExUnit.CLIFormatter

### DIFF
--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -282,8 +282,8 @@ defmodule ExUnit.CLIFormatter do
   end
 
   defp print_filters(include: include, exclude: exclude) do
-    if include != [], do: IO.puts(format_filters(include, :include))
     if exclude != [], do: IO.puts(format_filters(exclude, :exclude))
+    if include != [], do: IO.puts(format_filters(include, :include))
     IO.puts("")
     :ok
   end

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -109,8 +109,8 @@ defmodule ExUnit.Formatter do
   @spec format_filters(keyword, atom) :: String.t()
   def format_filters(filters, type) do
     case type do
-      :include -> "Including tags: #{inspect(filters)}"
       :exclude -> "Excluding tags: #{inspect(filters)}"
+      :include -> "Including tags: #{inspect(filters)}"
     end
   end
 

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -34,8 +34,8 @@ defmodule ExUnit.FormatterTest do
 
   test "formats test case filters" do
     filters = [run: true, slow: false]
-    assert format_filters(filters, :include) =~ "Including tags: [run: true, slow: false]"
     assert format_filters(filters, :exclude) =~ "Excluding tags: [run: true, slow: false]"
+    assert format_filters(filters, :include) =~ "Including tags: [run: true, slow: false]"
   end
 
   test "formats test errors" do


### PR DESCRIPTION
It was printing this when running: mix test --only foo

```
Including tags: [:foo]
Excluding tags: [:test]
```

which is deceiving beucase the order end up rendering useless the include filter.

Swaps the order then.

Additionally swaps the order in ExUnit.Formatter.format_filters/2 and tests,
while not necessary, maintaining the order is a good thing when it's something related
to precedence.