### PR TITLE
Remove backticks from error messages and test desc

### DIFF
--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -465,7 +465,7 @@ defmodule Date do
       cannot compare #{inspect(date1)} with #{inspect(date2)}.
 
       This comparison would be ambiguous as their calendars have incompatible day rollover moments.
-      Specify an exact time of day (using `DateTime`s) to resolve this ambiguity
+      Specify an exact time of day (using DateTime) to resolve this ambiguity
       """
     end
   end

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -1120,7 +1120,7 @@ format_error({invalid_quoted_expr, Expr}) ->
     "invalid quoted expression: ~ts\n\n"
     "Please make sure your quoted expressions are made of valid AST nodes."
     "If you would like to introduce a value into the AST, such as a four-element"
-    "tuple or a map, make sure to call `Macro.escape/1` before",
+    "tuple or a map, make sure to call Macro.escape/1 before",
   io_lib:format(Message, ['Elixir.Kernel':inspect(Expr, [])]);
 format_error({invalid_local_invocation, Context, {Name, _, Args} = Call}) ->
   Message =

--- a/lib/ex_unit/test/ex_unit/failures_manifest_test.exs
+++ b/lib/ex_unit/test/ex_unit/failures_manifest_test.exs
@@ -97,7 +97,7 @@ defmodule ExUnit.FailuresManifestTest do
   @manifest_path "example.manifest"
 
   describe "write!/2" do
-    test "stores a manifest that can later be read with `read/1`", context do
+    test "stores a manifest that can later be read with read/1", context do
       manifest = non_blank_manifest(context)
 
       in_tmp(context.test, fn ->

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -138,7 +138,7 @@ defmodule ExUnitTest do
     assert config[:max_cases] == 1
   end
 
-  test "filters to the given test IDs when the `only_test_ids` option is provided" do
+  test "filters to the given test IDs when the :only_test_ids option is provided" do
     defmodule TestIdTestModule do
       use ExUnit.Case
 

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -549,7 +549,7 @@ defmodule Mix.Tasks.Test do
   defp failed_opts(opts) do
     if opts[:failed] do
       if opts[:stale] do
-        Mix.raise("Combining `--failed` and `--stale` is not supported.")
+        Mix.raise("Combining --failed and --stale is not supported.")
       end
 
       {allowed_files, failed_ids} = ExUnit.Filters.failure_info(opts[:failures_manifest_file])

--- a/lib/mix/test/mix/task_test.exs
+++ b/lib/mix/test/mix/task_test.exs
@@ -197,11 +197,11 @@ defmodule Mix.TaskTest do
     assert Mix.Task.preferred_cli_env(:no_task) == nil
   end
 
-  test "preferred_cli_env/1 returns nil when task does not have `preferred_cli_env` attribute" do
+  test "preferred_cli_env/1 returns nil when task does not have :preferred_cli_env attribute" do
     assert Mix.Task.preferred_cli_env(:deps) == nil
   end
 
-  test "preferred_cli_env/1 returns specified `preferred_cli_env` attribute" do
+  test "preferred_cli_env/1 returns specified :preferred_cli_env attribute" do
     assert Mix.Task.preferred_cli_env(:test) == :test
   end
 

--- a/lib/mix/test/mix/task_test.exs
+++ b/lib/mix/test/mix/task_test.exs
@@ -197,11 +197,11 @@ defmodule Mix.TaskTest do
     assert Mix.Task.preferred_cli_env(:no_task) == nil
   end
 
-  test "preferred_cli_env/1 returns nil when task does not have :preferred_cli_env attribute" do
+  test "preferred_cli_env/1 returns nil when task does not have @preferred_cli_env attribute" do
     assert Mix.Task.preferred_cli_env(:deps) == nil
   end
 
-  test "preferred_cli_env/1 returns specified :preferred_cli_env attribute" do
+  test "preferred_cli_env/1 returns specified @preferred_cli_env attribute" do
     assert Mix.Task.preferred_cli_env(:test) == :test
   end
 

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -178,7 +178,7 @@ defmodule Mix.Tasks.TestTest do
 
       # `--failed` and `--stale` cannot be combined
       output = mix(["test", "--failed", "--stale"])
-      assert output =~ "Combining `--failed` and `--stale` is not supported"
+      assert output =~ "Combining --failed and --stale is not supported"
     end)
   after
     System.delete_env("PASS_FAILING_TESTS")


### PR DESCRIPTION
To keep consistency in the codebase.