### PR TITLE
Fix misleading doc string

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -170,7 +170,7 @@ defmodule Calendar do
   @callback time_to_string(hour, minute, second, microsecond) :: String.t()
 
   @doc """
-  Converts the given datetime (with time zone) into the `t:iso_days/0` format.
+  Converts the given datetime (without time zone) into the `t:iso_days/0` format.
   """
   @callback naive_datetime_to_iso_days(year, month, day, hour, minute, second, microsecond) ::
               iso_days


### PR DESCRIPTION
The function signature for Calendar.naive_datetime_to_iso_days does not include the time zone, but the doc string implies it should. The doc string is wrong.