### PR TITLE
Fix ZWJ handling in Unicode grapheme clusters

### DIFF
--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -562,6 +562,7 @@ defmodule StringTest do
     assert String.length("סם ייםח") == 7
     assert String.length("がガちゃ") == 4
     assert String.length("Ā̀stute") == 6
+    assert String.length("👨‍👩‍👧‍👦") == 1
     assert String.length("") == 0
   end
 

--- a/lib/elixir/unicode/unicode.ex
+++ b/lib/elixir/unicode/unicode.ex
@@ -200,7 +200,7 @@ defmodule String.Unicode do
 
   for codepoint <- cluster["Extended_Pictographic"] do
     defp next_extend_size(<<unquote(codepoint), rest::binary>>, size, :zwj) do
-      next_extend_size(rest, size + unquote(byte_size(codepoint)), :other)
+      next_extend_size(rest, size + unquote(byte_size(codepoint)), :emoji)
     end
   end
 


### PR DESCRIPTION
### Problem

In Elixir, `String.length("👨‍👩‍👧‍👦")` returns 2.

"👨‍👩‍👧‍👦" consists of 4 emojis joined with 3 ZWJs (ZERO WIDTH JOINER, U+200D). It should be regarded as a single Unicode grapheme cluster, so its length should be 1.

### Solution

In the module `String.Unicode`, `next_extend_size` handles some combing characters in order to properly separate grapheme clusters. However, it doesn't take account of the cases where more than 2 emojis are joined with ZWJ. This commit will fix that.