### PR TITLE
fix minor grammar for docs of Module.register_attribute

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1226,7 +1226,7 @@ defmodule Module do
   When registering an attribute, two options can be given:
 
     * `:accumulate` - several calls to the same attribute will
-      accumulate instead of override the previous one. New attributes
+      accumulate instead of overriding the previous one. New attributes
       are always added to the top of the accumulated list.
 
     * `:persist` - the attribute will be persisted in the Erlang


### PR DESCRIPTION
Not a grammar/english expert but it does sound little incorrect to me. Hopefully, I made the correction here.