### PR TITLE
Add `@impl true` to Mix tasks

### DIFF
--- a/lib/mix/lib/mix/tasks/app.start.ex
+++ b/lib/mix/lib/mix/tasks/app.start.ex
@@ -46,6 +46,7 @@ defmodule Mix.Tasks.App.Start do
     preload_modules: :boolean
   ]
 
+  @impl true
   def run(args) do
     Mix.Project.get!()
     config = Mix.Project.config()

--- a/lib/mix/lib/mix/tasks/app.tree.ex
+++ b/lib/mix/lib/mix/tasks/app.tree.ex
@@ -33,6 +33,7 @@ defmodule Mix.Tasks.App.Tree do
 
   @default_excluded [:kernel, :stdlib, :compiler]
 
+  @impl true
   def run(args) do
     Mix.Task.run("compile")
 

--- a/lib/mix/lib/mix/tasks/archive.build.ex
+++ b/lib/mix/lib/mix/tasks/archive.build.ex
@@ -53,6 +53,7 @@ defmodule Mix.Tasks.Archive.Build do
     include_dot_files: :boolean
   ]
 
+  @impl true
   def run(args) do
     {opts, _} = OptionParser.parse!(args, aliases: [o: :output, i: :input], strict: @switches)
 

--- a/lib/mix/lib/mix/tasks/archive.check.ex
+++ b/lib/mix/lib/mix/tasks/archive.check.ex
@@ -11,6 +11,8 @@ defmodule Mix.Tasks.Archive.Check do
 
   This task guarantees this option is respected.
   """
+
+  @impl true
   def run(_) do
     archives = Mix.Project.config()[:archives] || []
 

--- a/lib/mix/lib/mix/tasks/archive.ex
+++ b/lib/mix/lib/mix/tasks/archive.ex
@@ -15,6 +15,8 @@ defmodule Mix.Tasks.Archive do
   variable to different locations based on a particular
   Elixir installation.
   """
+
+  @impl true
   def run(_) do
     Mix.Local.path_for(:archive)
     |> Path.join("*")

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -67,6 +67,7 @@ defmodule Mix.Tasks.Archive.Install do
     organization: :string
   ]
 
+  @impl true
   def run(argv) do
     Mix.Local.Installer.install(__MODULE__, argv, @switches)
   end

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -72,7 +72,7 @@ defmodule Mix.Tasks.Archive.Install do
     Mix.Local.Installer.install(__MODULE__, argv, @switches)
   end
 
-  # Callbacks
+  @impl true
   def check_install_spec({local_or_url, path_or_url} = _install_spec, _opts)
       when local_or_url in [:local, :url] do
     if Path.extname(path_or_url) == ".ez" do
@@ -84,6 +84,7 @@ defmodule Mix.Tasks.Archive.Install do
 
   def check_install_spec(_, _), do: :ok
 
+  @impl true
   def find_previous_versions(src) do
     app =
       src
@@ -98,6 +99,7 @@ defmodule Mix.Tasks.Archive.Install do
     end
   end
 
+  @impl true
   def install(basename, contents, previous) do
     ez_path = Path.join(Mix.Local.path_for(:archive), basename)
     dir_dest = resolve_destination(ez_path, contents)
@@ -114,6 +116,7 @@ defmodule Mix.Tasks.Archive.Install do
     :ok
   end
 
+  @impl true
   def build(_install_spec, _opts) do
     src = Mix.Local.name_for(:archive, Mix.Project.config())
     previous = find_previous_versions(src)

--- a/lib/mix/lib/mix/tasks/archive.uninstall.ex
+++ b/lib/mix/lib/mix/tasks/archive.uninstall.ex
@@ -17,6 +17,7 @@ defmodule Mix.Tasks.Archive.Uninstall do
     force: :boolean
   ]
 
+  @impl true
   def run(argv) do
     Mix.Local.Installer.uninstall(Mix.Local.path_for(:archive), "archive", argv, @switches)
   end

--- a/lib/mix/lib/mix/tasks/clean.ex
+++ b/lib/mix/lib/mix/tasks/clean.ex
@@ -17,6 +17,7 @@ defmodule Mix.Tasks.Clean do
 
   @switches [deps: :boolean, only: :string]
 
+  @impl true
   def run(args) do
     Mix.Project.get!()
     loadpaths!()

--- a/lib/mix/lib/mix/tasks/cmd.ex
+++ b/lib/mix/lib/mix/tasks/cmd.ex
@@ -35,6 +35,7 @@ defmodule Mix.Tasks.Cmd do
   of the `Port` module documentation.
   """
 
+  @impl true
   def run(args) do
     {args, apps} = parse_apps(args, [])
 

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -113,6 +113,8 @@ defmodule Mix.Tasks.Compile.App do
       MyApp.start_phase(:finish, :normal, [])
 
   """
+
+  @impl true
   def run(args) do
     {opts, _, _} = OptionParser.parse(args, switches: [force: :boolean])
 

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -51,9 +51,7 @@ defmodule Mix.Tasks.Compile.Elixir do
     all_warnings: :boolean
   ]
 
-  @doc """
-  Runs this task.
-  """
+  @impl true
   def run(args) do
     {opts, _, _} = OptionParser.parse(args, switches: @switches)
 

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -71,15 +71,12 @@ defmodule Mix.Tasks.Compile.Elixir do
     Mix.Compilers.Elixir.compile(manifest, srcs, dest, [:ex], force, opts)
   end
 
-  @doc """
-  Returns Elixir manifests.
-  """
+  @impl true
   def manifests, do: [manifest()]
+
   defp manifest, do: Path.join(Mix.Project.manifest_path(), @manifest)
 
-  @doc """
-  Cleans up compilation artifacts.
-  """
+  @impl true
   def clean do
     dest = Mix.Project.compile_path()
     Mix.Compilers.Elixir.clean(manifest(), dest)

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -112,15 +112,12 @@ defmodule Mix.Tasks.Compile.Erlang do
     end)
   end
 
-  @doc """
-  Returns Erlang manifests.
-  """
+  @impl true
   def manifests, do: [manifest()]
+
   defp manifest, do: Path.join(Mix.Project.manifest_path(), @manifest)
 
-  @doc """
-  Cleans up compilation artifacts.
-  """
+  @impl true
   def clean do
     Mix.Compilers.Erlang.clean(manifest())
   end

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -52,9 +52,7 @@ defmodule Mix.Tasks.Compile.Erlang do
 
   """
 
-  @doc """
-  Runs this task.
-  """
+  @impl true
   def run(args) do
     {opts, _, _} = OptionParser.parse(args, switches: @switches)
     project = Mix.Project.config()

--- a/lib/mix/lib/mix/tasks/compile.ex
+++ b/lib/mix/lib/mix/tasks/compile.ex
@@ -152,9 +152,7 @@ defmodule Mix.Tasks.Compile do
     Mix.Project.config()[:compilers] || Mix.compilers()
   end
 
-  @doc """
-  Returns manifests for all compilers.
-  """
+  @impl true
   def manifests do
     Enum.flat_map(compilers(), fn compiler ->
       module = Mix.Task.get("compile.#{compiler}")

--- a/lib/mix/lib/mix/tasks/compile.ex
+++ b/lib/mix/lib/mix/tasks/compile.ex
@@ -52,6 +52,8 @@ defmodule Mix.Tasks.Compile do
     * `--erl-config` - path to an Erlang term file that will be loaded as Mix config
 
   """
+
+  @impl true
   def run(["--list"]) do
     loadpaths!()
     _ = Mix.Task.load_all()

--- a/lib/mix/lib/mix/tasks/compile.leex.ex
+++ b/lib/mix/lib/mix/tasks/compile.leex.ex
@@ -61,15 +61,12 @@ defmodule Mix.Tasks.Compile.Leex do
     end)
   end
 
-  @doc """
-  Returns Leex manifests.
-  """
+  @impl true
   def manifests, do: [manifest()]
+
   defp manifest, do: Path.join(Mix.Project.manifest_path(), @manifest)
 
-  @doc """
-  Cleans up compilation artifacts.
-  """
+  @impl true
   def clean do
     Erlang.clean(manifest())
   end

--- a/lib/mix/lib/mix/tasks/compile.leex.ex
+++ b/lib/mix/lib/mix/tasks/compile.leex.ex
@@ -38,9 +38,7 @@ defmodule Mix.Tasks.Compile.Leex do
 
   """
 
-  @doc """
-  Runs this task.
-  """
+  @impl true
   def run(args) do
     {opts, _, _} = OptionParser.parse(args, switches: @switches)
 

--- a/lib/mix/lib/mix/tasks/compile.protocols.ex
+++ b/lib/mix/lib/mix/tasks/compile.protocols.ex
@@ -70,18 +70,15 @@ defmodule Mix.Tasks.Compile.Protocols do
     end
   end
 
-  @doc """
-  Cleans up consolidated protocols.
-  """
+  @impl true
   def clean do
     File.rm(manifest())
     File.rm_rf(Mix.Project.consolidation_path())
   end
 
-  @doc """
-  Returns protocols manifests.
-  """
+  @impl true
   def manifests, do: [manifest()]
+
   defp manifest, do: Path.join(Mix.Project.manifest_path(), @manifest)
 
   @doc """

--- a/lib/mix/lib/mix/tasks/compile.protocols.ex
+++ b/lib/mix/lib/mix/tasks/compile.protocols.ex
@@ -41,9 +41,7 @@ defmodule Mix.Tasks.Compile.Protocols do
 
   """
 
-  @doc """
-  Runs this task.
-  """
+  @impl true
   def run(args) do
     config = Mix.Project.config()
     Mix.Task.run("compile")

--- a/lib/mix/lib/mix/tasks/compile.xref.ex
+++ b/lib/mix/lib/mix/tasks/compile.xref.ex
@@ -64,10 +64,9 @@ defmodule Mix.Tasks.Compile.Xref do
     end)
   end
 
-  @doc """
-  Returns xref manifests.
-  """
+  @impl true
   def manifests, do: [manifest()]
+
   defp manifest, do: Path.join(Mix.Project.manifest_path(), @manifest)
 
   defp write_manifest(warnings, timestamp) do
@@ -88,9 +87,7 @@ defmodule Mix.Tasks.Compile.Xref do
     end
   end
 
-  @doc """
-  Cleans up xref manifest.
-  """
+  @impl true
   def clean do
     File.rm(manifest())
   end

--- a/lib/mix/lib/mix/tasks/compile.xref.ex
+++ b/lib/mix/lib/mix/tasks/compile.xref.ex
@@ -26,9 +26,7 @@ defmodule Mix.Tasks.Compile.Xref do
 
   """
 
-  @doc """
-  Runs this task.
-  """
+  @impl true
   def run(args) do
     {opts, _, _} =
       OptionParser.parse(args, switches: [force: :boolean, warnings_as_errors: :boolean])

--- a/lib/mix/lib/mix/tasks/compile.yecc.ex
+++ b/lib/mix/lib/mix/tasks/compile.yecc.ex
@@ -38,9 +38,7 @@ defmodule Mix.Tasks.Compile.Yecc do
 
   """
 
-  @doc """
-  Runs this task.
-  """
+  @impl true
   def run(args) do
     {opts, _, _} = OptionParser.parse(args, switches: @switches)
 

--- a/lib/mix/lib/mix/tasks/compile.yecc.ex
+++ b/lib/mix/lib/mix/tasks/compile.yecc.ex
@@ -61,15 +61,12 @@ defmodule Mix.Tasks.Compile.Yecc do
     end)
   end
 
-  @doc """
-  Returns Yecc manifests.
-  """
+  @impl true
   def manifests, do: [manifest()]
+
   defp manifest, do: Path.join(Mix.Project.manifest_path(), @manifest)
 
-  @doc """
-  Cleans up compilation artifacts.
-  """
+  @impl true
   def clean do
     Erlang.clean(manifest())
   end

--- a/lib/mix/lib/mix/tasks/deps.clean.ex
+++ b/lib/mix/lib/mix/tasks/deps.clean.ex
@@ -24,6 +24,7 @@ defmodule Mix.Tasks.Deps.Clean do
 
   @switches [unlock: :boolean, all: :boolean, only: :string, unused: :boolean, build: :boolean]
 
+  @impl true
   def run(args) do
     Mix.Project.get!()
     {opts, apps, _} = OptionParser.parse(args, switches: @switches)

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -32,7 +32,7 @@ defmodule Mix.Tasks.Deps.Compile do
 
   @switches [include_children: :boolean, force: :boolean]
 
-  @spec run(OptionParser.argv()) :: :ok
+  @impl true
   def run(args) do
     unless "--no-archives-check" in args do
       Mix.Task.run("archive.check", args)

--- a/lib/mix/lib/mix/tasks/deps.ex
+++ b/lib/mix/lib/mix/tasks/deps.ex
@@ -143,7 +143,8 @@ defmodule Mix.Tasks.Deps do
     * `--all` - checks all dependencies, regardless of specified environment
 
   """
-  @spec run(OptionParser.argv()) :: :ok
+
+  @impl true
   def run(args) do
     Mix.Project.get!()
     {opts, _, _} = OptionParser.parse(args, switches: [all: :boolean])

--- a/lib/mix/lib/mix/tasks/deps.get.ex
+++ b/lib/mix/lib/mix/tasks/deps.get.ex
@@ -14,6 +14,7 @@ defmodule Mix.Tasks.Deps.Get do
 
   """
 
+  @impl true
   def run(args) do
     unless "--no-archives-check" in args do
       Mix.Task.run("archive.check", args)

--- a/lib/mix/lib/mix/tasks/deps.loadpaths.ex
+++ b/lib/mix/lib/mix/tasks/deps.loadpaths.ex
@@ -20,6 +20,7 @@ defmodule Mix.Tasks.Deps.Loadpaths do
 
   """
 
+  @impl true
   def run(args) do
     all = Mix.Dep.load_and_cache()
 

--- a/lib/mix/lib/mix/tasks/deps.precompile.ex
+++ b/lib/mix/lib/mix/tasks/deps.precompile.ex
@@ -15,6 +15,8 @@ defmodule Mix.Tasks.Deps.Precompile do
   loading is deliberately ad-hoc, loading as much as
   possible without validating the files.
   """
+
+  @impl true
   def run(_) do
     config = Mix.Project.config()
 

--- a/lib/mix/lib/mix/tasks/deps.tree.ex
+++ b/lib/mix/lib/mix/tasks/deps.tree.ex
@@ -32,6 +32,7 @@ defmodule Mix.Tasks.Deps.Tree do
   """
   @switches [only: :string, exclude: :keep, format: :string]
 
+  @impl true
   def run(args) do
     Mix.Project.get!()
     {opts, args, _} = OptionParser.parse(args, switches: @switches)

--- a/lib/mix/lib/mix/tasks/deps.unlock.ex
+++ b/lib/mix/lib/mix/tasks/deps.unlock.ex
@@ -18,6 +18,7 @@ defmodule Mix.Tasks.Deps.Unlock do
 
   @switches [all: :boolean, unused: :boolean, filter: :string]
 
+  @impl true
   def run(args) do
     Mix.Project.get!()
     {opts, apps, _} = OptionParser.parse(args, switches: @switches)

--- a/lib/mix/lib/mix/tasks/deps.update.ex
+++ b/lib/mix/lib/mix/tasks/deps.update.ex
@@ -33,6 +33,7 @@ defmodule Mix.Tasks.Deps.Update do
 
   """
 
+  @impl true
   def run(args) do
     unless "--no-archives-check" in args do
       Mix.Task.run("archive.check", args)

--- a/lib/mix/lib/mix/tasks/do.ex
+++ b/lib/mix/lib/mix/tasks/do.ex
@@ -19,6 +19,7 @@ defmodule Mix.Tasks.Do do
 
   """
 
+  @impl true
   def run(args) do
     Mix.Task.reenable("do")
     Enum.each(gather_commands(args), fn [task | args] -> Mix.Task.run(task, args) end)

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -116,6 +116,8 @@ defmodule Mix.Tasks.Escript.Build do
       end
 
   """
+
+  @impl true
   def run(args) do
     Mix.Project.get!()
     Mix.Task.run("loadpaths", args)

--- a/lib/mix/lib/mix/tasks/escript.ex
+++ b/lib/mix/lib/mix/tasks/escript.ex
@@ -12,6 +12,7 @@ defmodule Mix.Tasks.Escript do
 
   use Bitwise
 
+  @impl true
   def run(_) do
     escripts_path = Mix.Local.path_for(:escript)
 

--- a/lib/mix/lib/mix/tasks/escript.install.ex
+++ b/lib/mix/lib/mix/tasks/escript.install.ex
@@ -74,15 +74,16 @@ defmodule Mix.Tasks.Escript.Install do
     Mix.Local.Installer.install(__MODULE__, argv, @switches)
   end
 
-  # Callbacks
-
+  @impl true
   def check_install_spec(_, _), do: :ok
 
+  @impl true
   def find_previous_versions(basename) do
     dst = destination(basename)
     if File.exists?(dst), do: [dst], else: []
   end
 
+  @impl true
   def install(basename, binary, _previous) do
     dst = destination(basename)
 
@@ -106,6 +107,7 @@ defmodule Mix.Tasks.Escript.Install do
     end
   end
 
+  @impl true
   def build(_spec, _opts) do
     Mix.Task.run("escript.build", [])
     Mix.Local.name_for(:escript, Mix.Project.config())

--- a/lib/mix/lib/mix/tasks/escript.install.ex
+++ b/lib/mix/lib/mix/tasks/escript.install.ex
@@ -69,6 +69,7 @@ defmodule Mix.Tasks.Escript.Install do
     organization: :string
   ]
 
+  @impl true
   def run(argv) do
     Mix.Local.Installer.install(__MODULE__, argv, @switches)
   end

--- a/lib/mix/lib/mix/tasks/escript.uninstall.ex
+++ b/lib/mix/lib/mix/tasks/escript.uninstall.ex
@@ -17,6 +17,7 @@ defmodule Mix.Tasks.Escript.Uninstall do
     force: :boolean
   ]
 
+  @impl true
   def run(argv) do
     if path =
          Mix.Local.Installer.uninstall(Mix.Local.path_for(:escript), "escript", argv, @switches) do

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -135,6 +135,7 @@ defmodule Mix.Tasks.Format do
   @manifest "cached_dot_formatter"
   @manifest_vsn 1
 
+  @impl true
   def run(args) do
     {opts, args} = OptionParser.parse!(args, strict: @switches)
     {dot_formatter, formatter_opts} = eval_dot_formatter(opts)

--- a/lib/mix/lib/mix/tasks/help.ex
+++ b/lib/mix/lib/mix/tasks/help.ex
@@ -38,6 +38,7 @@ defmodule Mix.Tasks.Help do
 
   """
 
+  @impl true
   def run(argv)
 
   def run([]) do

--- a/lib/mix/lib/mix/tasks/iex.ex
+++ b/lib/mix/lib/mix/tasks/iex.ex
@@ -5,6 +5,7 @@ defmodule Mix.Tasks.Iex do
   A task that simply instructs users to run `iex -S mix`.
   """
 
+  @impl true
   def run(_) do
     Mix.raise("To use IEx with Mix, please run \"iex -S mix\"")
   end

--- a/lib/mix/lib/mix/tasks/loadconfig.ex
+++ b/lib/mix/lib/mix/tasks/loadconfig.ex
@@ -16,6 +16,7 @@ defmodule Mix.Tasks.Loadconfig do
   multiple times to load different configs.
   """
 
+  @impl true
   def run(args) do
     config = Mix.Project.config()
 

--- a/lib/mix/lib/mix/tasks/loadpaths.ex
+++ b/lib/mix/lib/mix/tasks/loadpaths.ex
@@ -17,6 +17,7 @@ defmodule Mix.Tasks.Loadpaths do
 
   """
 
+  @impl true
   def run(args) do
     config = Mix.Project.config()
 

--- a/lib/mix/lib/mix/tasks/local.ex
+++ b/lib/mix/lib/mix/tasks/local.ex
@@ -7,6 +7,7 @@ defmodule Mix.Tasks.Local do
   Lists local tasks.
   """
 
+  @impl true
   def run([]) do
     shell = Mix.shell()
     modules = Mix.Local.archives_tasks()

--- a/lib/mix/lib/mix/tasks/local.hex.ex
+++ b/lib/mix/lib/mix/tasks/local.hex.ex
@@ -29,6 +29,7 @@ defmodule Mix.Tasks.Local.Hex do
   """
   @switches [if_missing: :boolean, force: :boolean]
 
+  @impl true
   def run(argv) do
     {opts, _} = OptionParser.parse!(argv, switches: @switches)
 

--- a/lib/mix/lib/mix/tasks/local.public_keys.ex
+++ b/lib/mix/lib/mix/tasks/local.public_keys.ex
@@ -34,6 +34,7 @@ defmodule Mix.Tasks.Local.PublicKeys do
 
   """
 
+  @impl true
   def run(argv) do
     {opts, argv} = OptionParser.parse!(argv, switches: [force: :boolean, detailed: :boolean])
 

--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -42,6 +42,7 @@ defmodule Mix.Tasks.Local.Rebar do
 
   @switches [force: :boolean, sha512: :string]
 
+  @impl true
   def run(argv) do
     {opts, argv, _} = OptionParser.parse(argv, switches: @switches)
 

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -55,6 +55,7 @@ defmodule Mix.Tasks.New do
     umbrella: :boolean
   ]
 
+  @impl true
   def run(argv) do
     {opts, argv} = OptionParser.parse!(argv, strict: @switches)
 

--- a/lib/mix/lib/mix/tasks/profile.cprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.cprof.ex
@@ -112,6 +112,7 @@ defmodule Mix.Tasks.Profile.Cprof do
 
   @aliases [r: :require, p: :parallel, e: :eval, c: :config]
 
+  @impl true
   def run(args) do
     {opts, head} = OptionParser.parse_head!(args, aliases: @aliases, strict: @switches)
     Mix.Task.reenable("profile.cprof")

--- a/lib/mix/lib/mix/tasks/profile.eprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.eprof.ex
@@ -124,6 +124,7 @@ defmodule Mix.Tasks.Profile.Eprof do
     c: :config
   ]
 
+  @impl true
   def run(args) do
     {opts, head} = OptionParser.parse_head!(args, aliases: @aliases, strict: @switches)
     Mix.Task.reenable("profile.eprof")

--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -128,6 +128,7 @@ defmodule Mix.Tasks.Profile.Fprof do
 
   @aliases [r: :require, p: :parallel, e: :eval, c: :config]
 
+  @impl true
   def run(args) do
     {opts, head} = OptionParser.parse_head!(args, aliases: @aliases, strict: @switches)
     Mix.Task.reenable("profile.fprof")

--- a/lib/mix/lib/mix/tasks/run.ex
+++ b/lib/mix/lib/mix/tasks/run.ex
@@ -60,6 +60,7 @@ defmodule Mix.Tasks.Run do
 
   """
 
+  @impl true
   def run(args) do
     {opts, head} =
       OptionParser.parse_head!(

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -315,6 +315,7 @@ defmodule Mix.Tasks.Test do
 
   @cover [output: "cover", tool: Cover]
 
+  @impl true
   def run(args) do
     {opts, files} = OptionParser.parse!(args, strict: @switches)
 

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -155,6 +155,7 @@ defmodule Mix.Tasks.Xref do
     source: :string
   ]
 
+  @impl true
   def run(args) do
     {opts, args} = OptionParser.parse!(args, strict: @switches)
     Mix.Task.run("loadpaths")


### PR DESCRIPTION
The primary motivation is most Mix tasks have only 1 function `run/1` so by effectively hiding it from docs, with ExDoc when clicking it in sidebar we'll go straight to docs instead of using "Top" link. (Which to be fair should really be handled in ExDoc instead.) Regardless of ExDoc situation, I think `run` is so pervasive that it's noisy so imho can be implicit. See also 2nd commit where I effectively hide other callbacks.