### PR TITLE
Resolve circular struct dependencies in typespecs

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -533,14 +533,9 @@ defmodule Kernel.Typespec do
     module = Macro.expand(name, caller)
 
     struct =
-      if module == caller.module do
-        Module.get_attribute(module, :struct) ||
-          compile_error(caller, "struct is not defined for #{Macro.to_string(name)}")
-      else
-        module.__struct__
-      end
-
-    struct = struct |> Map.from_struct() |> Map.to_list()
+      :elixir_map.load_struct(meta, module, [], caller)
+      |> Map.from_struct()
+      |> Map.to_list()
 
     unless Keyword.keyword?(fields) do
       compile_error(caller, "expected key-value pairs in struct #{Macro.to_string(name)}")
@@ -553,7 +548,10 @@ defmodule Kernel.Typespec do
 
     Enum.each(fields, fn {field, _} ->
       unless Keyword.has_key?(struct, field) do
-        compile_error(caller, "undefined field #{field} on struct #{Macro.to_string(name)}")
+        compile_error(
+          caller,
+          "undefined field #{inspect(field)} on struct #{Macro.to_string(name)}"
+        )
       end
     end)
 

--- a/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
+++ b/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
@@ -80,6 +80,30 @@ defmodule Kernel.ParallelCompilerTest do
       purge([FooStruct, BarStruct])
     end
 
+    test "solves dependencies between structs in typespecs" do
+      fixtures =
+        write_tmp(
+          "parallel_typespec_struct",
+          bar: """
+          defmodule BarStruct do
+            defstruct name: ""
+            @type t :: %FooStruct{}
+          end
+          """,
+          foo: """
+          defmodule FooStruct do
+            defstruct name: ""
+            @type t :: %BarStruct{}
+          end
+          """
+        )
+
+      assert {:ok, modules, []} = Kernel.ParallelCompiler.compile(fixtures)
+      assert [BarStruct, FooStruct] = Enum.sort(modules)
+    after
+      purge([FooStruct, BarStruct])
+    end
+
     test "returns struct undefined error when local struct is undefined" do
       [fixture] =
         write_tmp(


### PR DESCRIPTION
Prior to this patch, if a module depends on the struct of
another module and that other module depends on the struct
of the first module inside typespecs, it would lead to a
compiler deadlock, which this deadlock would not happen
in "regular code".

This commit also adds a test to ensure @enforce_keys are
not enforced when expanding typespecs.

For now, we are using a compiler private API, but we should
provide a public version for it. This will be discussed below.