### PR TITLE
Use "etc." and not "etc"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
   * [Kernel.ParallelCompiler] `files/2` is deprecated in favor of `compile/2`
   * [Kernel.ParallelCompiler] `files_to_path/2` is deprecated in favor of `compile_to_path/2`
   * [Kernel.ParallelRequire] `files/2` is deprecated in favor of `Kernel.ParallelCompiler.require/2`
-  * [System] `:seconds`, `:milliseconds`, etc as time units is deprecated in favor of `:second`, `:millisecond`, etc
+  * [System] `:seconds`, `:milliseconds`, etc. as time units is deprecated in favor of `:second`, `:millisecond`, etc.
   * [System] `System.cwd/0` and `System.cwd!/0` are deprecated in favor of `File.cwd/0` and `File.cwd!/0`
 
 #### Mix

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -416,7 +416,7 @@ defmodule Code do
   rules in the future. The goal of documenting them is to provide better
   understanding on what to expect from the formatter.
 
-  ### Multi-line lists, maps, tuples, etc
+  ### Multi-line lists, maps, tuples, etc.
 
   You can force lists, tuples, bitstrings, maps, structs and function
   calls to have one entry per line by adding a newline after the opening

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -13,7 +13,7 @@ defmodule Kernel do
   It mainly consists of:
 
     * basic language primitives, such as arithmetic operators, spawning of processes,
-      data type handling, etc
+      data type handling, etc.
     * macros for control-flow and defining new functionality (modules, functions, and so on)
     * guard checks for augmenting pattern matching
 

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -4,7 +4,7 @@ defmodule Kernel.SpecialForms do
   cannot be overridden by the developer.
 
   We define them in this module. Some of these forms are lexical (like
-  `alias/2`, `case/2`, etc). The macros `{}/1` and `<<>>/1` are also special
+  `alias/2`, `case/2`, etc.). The macros `{}/1` and `<<>>/1` are also special
   forms used to define tuple and binary data structures respectively.
 
   This module also documents macros that return information about Elixir's
@@ -809,7 +809,7 @@ defmodule Kernel.SpecialForms do
       "strings"    #=> Strings
       {key, value} #=> Tuples with two elements
 
-  Any other value, such as a map or a four-element tuple, must be escaped 
+  Any other value, such as a map or a four-element tuple, must be escaped
   (`Macro.escape/1`) before being introduced into an AST.
 
   ## Options

--- a/lib/elixir/pages/Compatibility and Deprecations.md
+++ b/lib/elixir/pages/Compatibility and Deprecations.md
@@ -71,7 +71,7 @@ Deprecated feature                               | Hard-deprecated in | Replaced
 :----------------------------------------------- | :----------------- | :----------------------------
 Passing a non-empty list to `Enum.into/2`        | [v1.8]        | `Kernel.++/2` or `Keyword.merge/2` (v1.0)
 Passing a non-empty list to `:into` in `for`     | [v1.8]        | `Kernel.++/2` or `Keyword.merge/2` (v1.0)
-`:seconds`, `:milliseconds`, etc as time units   | [v1.8]        | `:second`, `:millisecond`, etc (v1.4)
+`:seconds`, `:milliseconds`, etc. as time units  | [v1.8]        | `:second`, `:millisecond`, etc. (v1.4)
 `Inspect.Algebra.surround/3`                     | [v1.8]        | `Inspect.Algebra.concat/2` and `Inspect.Algebra.nest/2` (v1.0)
 `Inspect.Algebra.surround_many/6`                | [v1.8]        | `Inspect.Algebra.container_doc/6` (v1.6)
 `Kernel.ParallelCompiler.files/2`                | [v1.8]        | `Kernel.ParallelCompiler.compile/2` (v1.6)

--- a/lib/elixir/pages/Guards.md
+++ b/lib/elixir/pages/Guards.md
@@ -13,8 +13,8 @@ You can find the built-in list of guards [in the `Kernel` module](Kernel.html#gu
   * strictly boolean operators ([`and`](`Kernel.and/2`), [`or`](`Kernel.or/2`), [`not`](`Kernel.not/1`)). Note [`&&`](`Kernel.&&/2`), [`||`](`Kernel.||/2`), and [`!`](`Kernel.!/1`) sibling operators are **not allowed** as they're not *strictly* boolean - meaning they don't require arguments to be booleans
   * arithmetic unary and binary operators ([`+`](`Kernel.+/1`), [`-`](`Kernel.-/1`), [`+`](`Kernel.+/2`), [`-`](`Kernel.-/2`), [`*`](`Kernel.*/2`), [`/`](`Kernel.//2`))
   * [`in`](`Kernel.in/2`) and [`not in`](`Kernel.in/2`) operators (as long as the right-hand side is a list or a range)
-  * "type-check" functions ([`is_list/1`](`Kernel.is_list/1`), [`is_number/1`](`Kernel.is_number/1`), etc)
-  * functions that work on built-in datatypes ([`abs/1`](`Kernel.abs/1`), [`map_size/1`](`Kernel.map_size/1`), etc)
+  * "type-check" functions ([`is_list/1`](`Kernel.is_list/1`), [`is_number/1`](`Kernel.is_number/1`), etc.)
+  * functions that work on built-in datatypes ([`abs/1`](`Kernel.abs/1`), [`map_size/1`](`Kernel.map_size/1`), etc.)
 
 The module `Bitwise` also includes a handful of [Erlang bitwise operations as guards](Bitwise.html#guards).
 

--- a/lib/elixir/pages/Library Guidelines.md
+++ b/lib/elixir/pages/Library Guidelines.md
@@ -202,7 +202,7 @@ When you absolutely have to use a macro, make sure that a macro is not the only 
 
 A developer must never use a process for code organization purposes. A process must be used to model runtime properties such as:
 
-  * Mutable state and access to shared resources (such as ETS, files, etc)
+  * Mutable state and access to shared resources (such as ETS, files, etc.)
   * Concurrency and distribution
   * Initialization, shutdown and restart logic (as seen in supervisors)
   * System messages such as timer messages and monitoring events

--- a/lib/elixir/pages/Naming Conventions.md
+++ b/lib/elixir/pages/Naming Conventions.md
@@ -4,7 +4,7 @@ This document covers some naming conventions in Elixir code, from casing to punc
 
 ## Casing
 
-Elixir developers must use `snake_case` when defining variables, function names, module attributes, etc:
+Elixir developers must use `snake_case` when defining variables, function names, module attributes, etc.:
 
     some_map = %{this_is_a_key: "and a value"}
     is_map(some_map)

--- a/lib/elixir/src/elixir_erl_compiler.erl
+++ b/lib/elixir/src/elixir_erl_compiler.erl
@@ -124,7 +124,7 @@ format_error(sys_core_fold, {no_effect, {erlang, F, A}}) ->
   end,
   io_lib:format(Fmt, Args);
 
-%% Rewrite nomatch_guard to be more generic it can happen inside if, unless, etc
+%% Rewrite nomatch_guard to be more generic it can happen inside if, unless, etc.
 format_error(sys_core_fold, nomatch_guard) ->
   "this check/guard will always yield the same result";
 

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -205,7 +205,7 @@ format_error({invalid_pin_in_map_key_match, Name}) ->
 format_error({invalid_variable_in_map_key_match, Name}) ->
   Message =
     "cannot use variable ~ts as map key inside a pattern. Map keys in patterns can only be literals "
-    "(such as atoms, strings, tuples, etc) or an existing variable matched with the pin operator "
+    "(such as atoms, strings, tuples, etc.) or an existing variable matched with the pin operator "
     "(such as ^some_var)",
   io_lib:format(Message, [Name]);
 format_error({repeated_key, Key}) ->

--- a/lib/mix/lib/mix/dep/converger.ex
+++ b/lib/mix/lib/mix/dep/converger.ex
@@ -132,7 +132,7 @@ defmodule Mix.Dep.Converger do
   # fashion. The reason for this is that we converge
   # dependencies, but allow the parent to override any
   # dependency in the child. Consider this tree with
-  # dependencies "a", "b", etc and the order they are
+  # dependencies "a", "b", etc. and the order they are
   # converged:
   #
   #     * project


### PR DESCRIPTION
Command used to detect these typos:
$ ag -s "\betc[^.]"