### PR TITLE
Fix breaking of documentation introduced in #8373

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -132,7 +132,7 @@ defmodule IEx do
 
     * via the `BREAK` menu (available via `Ctrl+C`) by typing `q`, pressing enter
     * by hitting `Ctrl+C`, `Ctrl+C`
-    * by hitting `Ctrl+\`
+    * by hitting `Ctrl+\ `
 
   If you are connected to remote shell, it remains alive after disconnection.
 


### PR DESCRIPTION
This was introduced accidentally in 7f771a4f3d55da1e3d2ac77a3543e220dd31444b
Making the backslash escape the closing backtick,
and ruining the documentation generated by ExDoc.

/cc @gusaiani