### PR TITLE
Ignore escape characters inside markdown backticks

### DIFF
--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -538,8 +538,9 @@ defmodule IO.ANSI.Docs do
   # We have four entries: **, *, _ and `.
   #
   # The first three behave the same while the last one is simpler
-  # when it comes to delimiters. But, since the first has two
-  # characters, we need to handle 3 cases:
+  # when it comes to delimiters as it ignores spaces and escape
+  # characters. But, since the first has two characters, we need to
+  # handle 3 cases:
   #
   # 1. **
   # 2. _ and *
@@ -601,8 +602,7 @@ defmodule IO.ANSI.Docs do
   end
 
   # An escape is not valid inside `
-  defp handle_inline(<<?\\, mark, rest::binary>>, limit, buffer, acc, options)
-       when not (mark == limit and mark == ?`) do
+  defp handle_inline(<<?\\, mark, rest::binary>>, limit, buffer, acc, options) when limit != ?` do
     handle_inline(rest, limit, [mark | buffer], acc, options)
   end
 

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -237,6 +237,11 @@ defmodule IO.ANSI.DocsTest do
     assert result == "\e[36munit \e[0msize\n\e[0m"
   end
 
+  test "backtick does not escape characters" do
+    result = format("`Ctrl+\\ `")
+    assert result == "\e[36mCtrl+\\ \e[0m\n\e[0m"
+  end
+
   test "star/underscore/backtick with leading escape" do
     result = format("\\_unit_")
     assert result == "_unit_\n\e[0m"


### PR DESCRIPTION
Closes #8382.