### PR TITLE
Allow DateTime structs to be passed to DateTime.from_naive in typespecs

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -214,10 +214,11 @@ defmodule DateTime do
       iex> datetime
       #DateTime<2018-07-28 12:30:00+02:00 CEST Europe/Copenhagen>
 
-  Instead of passing a `NaiveDateTime` struct you can pass any map that contains the fields needed to
-  be a `Calendar.naive_datetime`. The most common example of that is a `DateTime`. In this case the
-  information about the time zone of that `DateTime` will be completely ignored. This is the same
-  principle as in for instance passing a `DateTime` to `Date.to_iso8601/2`.
+  This function accepts any map or struct that contains at least the same fields as a `NaiveDateTime`
+  struct. The most common example of that is a `DateTime`. In this case the information about the tim
+  zone of that `DateTime` is completely ignored. This is the same principle as passing a `DateTime` to
+  `Date.to_iso8601/2`. `Date.to_iso8601/2` extracts only the date-specific fields (i.e. calendar, year,
+  month and day) of the given structure and ignores all others.
 
   This way if you have a DateTime in one time zone, you can get the same wall time in another time zone.
   For instance if you have 2018-08-24 10:00:00 in Copenhagen and want a DateTime for 2018-08-24 10:00:00

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -214,10 +214,27 @@ defmodule DateTime do
       iex> datetime
       #DateTime<2018-07-28 12:30:00+02:00 CEST Europe/Copenhagen>
 
+  Instead of passing a `NaiveDateTime` struct you can pass any map that contains the fields needed to
+  be a `Calendar.naive_datetime`. The most common example of that is a `DateTime`. In this case the
+  information about the time zone of that `DateTime` will be completely ignored. This is the same
+  principle as in for instance passing a `DateTime` to `Date.to_iso8601/2`.
+
+  This way if you have a DateTime in one time zone, you can get the same wall time in another time zone.
+  For instance if you have 2018-08-24 10:00:00 in Copenhagen and want a DateTime for 2018-08-24 10:00:00
+  in UTC you can do:
+
+      iex> cph_datetime = DateTime.from_naive!(~N[2018-08-24 10:00:00], "Europe/Copenhagen", FakeTimeZoneDatabase)
+      iex> {:ok, utc_datetime} = DateTime.from_naive(cph_datetime, "Etc/UTC", FakeTimeZoneDatabase)
+      iex> utc_datetime
+      #DateTime<2018-08-24 10:00:00Z>
+
+  If instead you want a `DateTime` for the same point time in a different time zone see the
+  `DateTime.shift_zone/3` function which would convert 2018-08-24 10:00:00 in Copenhagen
+  to 2018-08-24 08:00:00 in UTC.
   """
   @doc since: "1.4.0"
   @spec from_naive(
-          NaiveDateTime.t(),
+          Calendar.naive_datetime(),
           Calendar.time_zone(),
           Calendar.get_time_zone_database()
         ) ::

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -215,13 +215,13 @@ defmodule DateTime do
       #DateTime<2018-07-28 12:30:00+02:00 CEST Europe/Copenhagen>
 
   This function accepts any map or struct that contains at least the same fields as a `NaiveDateTime`
-  struct. The most common example of that is a `DateTime`. In this case the information about the tim
+  struct. The most common example of that is a `DateTime`. In this case the information about the time
   zone of that `DateTime` is completely ignored. This is the same principle as passing a `DateTime` to
-  `Date.to_iso8601/2`. `Date.to_iso8601/2` extracts only the date-specific fields (i.e. calendar, year,
+  `Date.to_iso8601/2`. `Date.to_iso8601/2` extracts only the date-specific fields (calendar, year,
   month and day) of the given structure and ignores all others.
 
-  This way if you have a DateTime in one time zone, you can get the same wall time in another time zone.
-  For instance if you have 2018-08-24 10:00:00 in Copenhagen and want a DateTime for 2018-08-24 10:00:00
+  This way if you have a `DateTime` in one time zone, you can get the same wall time in another time zone.
+  For instance if you have 2018-08-24 10:00:00 in Copenhagen and want a `DateTime` for 2018-08-24 10:00:00
   in UTC you can do:
 
       iex> cph_datetime = DateTime.from_naive!(~N[2018-08-24 10:00:00], "Europe/Copenhagen", FakeTimeZoneDatabase)


### PR DESCRIPTION
Add example in docs for how to use it.

@michalmuskala the example shows how one can pass a `DateTime` and get the same wall time but in a different time zone as you mentioned in another PR.