### PR TITLE
Fix direct `Logger.log` call in case of compile_time_purge_matching logger option

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -789,7 +789,7 @@ defmodule Logger do
         metadata = Keyword.merge(caller, metadata)
         {metadata, metadata}
       else
-        {metadata,
+        {[],
          quote do
            Keyword.merge(unquote(caller), unquote(metadata))
          end}

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -252,11 +252,13 @@ defmodule LoggerTest do
 
   test "remove unused calls at compile time based on matching metadata" do
     Logger.configure(
+      compile_time_application: :sample_app,
       compile_time_purge_matching: [
         [module: LoggerTest.PurgeMatching, function: "two_filters/0"],
         [function: "one_filter/0"],
         [custom: true],
-        [function: "level_filter/0", level_lower_than: :info]
+        [function: "level_filter/0", level_lower_than: :warn],
+        [application: :sample_app, level_lower_than: :info]
       ]
     )
 
@@ -274,12 +276,16 @@ defmodule LoggerTest do
       end
 
       def level_filter do
-        Logger.debug("debug_filter")
         Logger.info("info_filter")
+        Logger.warn("warn_filter")
       end
 
       def works do
-        Logger.debug("works")
+        Logger.info("works")
+      end
+
+      def log(level, metadata \\ []) do
+        Logger.log(level, "ok", metadata)
       end
     end
 
@@ -287,9 +293,13 @@ defmodule LoggerTest do
     assert capture_log(fn -> assert PurgeMatching.one_filter() == :ok end) == ""
     assert capture_log(fn -> assert PurgeMatching.two_filters() == :ok end) == ""
     assert capture_log(fn -> assert PurgeMatching.custom_filters() == :ok end) == ""
-    assert capture_log(fn -> assert PurgeMatching.level_filter() == :ok end) =~ "info_filter"
-    refute capture_log(fn -> assert PurgeMatching.level_filter() == :ok end) =~ "debug_filter"
+    assert capture_log(fn -> assert PurgeMatching.level_filter() == :ok end) =~ "warn_filter"
+    refute capture_log(fn -> assert PurgeMatching.level_filter() == :ok end) =~ "info_filter"
+
+    capture_log(fn -> assert PurgeMatching.log(:info) == :ok end)
+    capture_log(fn -> assert PurgeMatching.log(:debug) == :ok end)
   after
+    Logger.configure(compile_time_application: nil)
     Logger.configure(compile_time_purge_matching: [])
   end
 


### PR DESCRIPTION
Closes #8389 

Update test to reproduce the issue.
Do not check compile time purge matching in case of direct `Logger.log` call. 