### PR TITLE
Wrap httpc read in a task to timeout

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -214,10 +214,28 @@ defmodule DateTime do
       iex> datetime
       #DateTime<2018-07-28 12:30:00+02:00 CEST Europe/Copenhagen>
 
+  This function accepts any map or struct that contains at least the same fields as a `NaiveDateTime`
+  struct. The most common example of that is a `DateTime`. In this case the information about the time
+  zone of that `DateTime` is completely ignored. This is the same principle as passing a `DateTime` to
+  `Date.to_iso8601/2`. `Date.to_iso8601/2` extracts only the date-specific fields (calendar, year,
+  month and day) of the given structure and ignores all others.
+
+  This way if you have a `DateTime` in one time zone, you can get the same wall time in another time zone.
+  For instance if you have 2018-08-24 10:00:00 in Copenhagen and want a `DateTime` for 2018-08-24 10:00:00
+  in UTC you can do:
+
+      iex> cph_datetime = DateTime.from_naive!(~N[2018-08-24 10:00:00], "Europe/Copenhagen", FakeTimeZoneDatabase)
+      iex> {:ok, utc_datetime} = DateTime.from_naive(cph_datetime, "Etc/UTC", FakeTimeZoneDatabase)
+      iex> utc_datetime
+      #DateTime<2018-08-24 10:00:00Z>
+
+  If instead you want a `DateTime` for the same point time in a different time zone see the
+  `DateTime.shift_zone/3` function which would convert 2018-08-24 10:00:00 in Copenhagen
+  to 2018-08-24 08:00:00 in UTC.
   """
   @doc since: "1.4.0"
   @spec from_naive(
-          NaiveDateTime.t(),
+          Calendar.naive_datetime(),
           Calendar.time_zone(),
           Calendar.get_time_zone_database()
         ) ::

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -56,7 +56,7 @@ defmodule Mix.Tasks.Archive.Install do
       from a private Hex repository
 
     * `--timeout` - sets a request timeout in milliseconds for fetching
-      the archives. Default is 60 seconds
+      archives from URLs. Default is 60 seconds
 
   """
 

--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -55,6 +55,9 @@ defmodule Mix.Tasks.Archive.Install do
     * `--organization` - specifies an organization to use if fetching the package
       from a private Hex repository
 
+    * `--timeout` - sets a request timeout in milliseconds for fetching
+      the archives. Default is 60 seconds
+
   """
 
   @behaviour Mix.Local.Installer
@@ -64,7 +67,8 @@ defmodule Mix.Tasks.Archive.Install do
     sha512: :string,
     submodules: :boolean,
     app: :string,
-    organization: :string
+    organization: :string,
+    timeout: :integer
   ]
 
   @impl true

--- a/lib/mix/lib/mix/tasks/escript.install.ex
+++ b/lib/mix/lib/mix/tasks/escript.install.ex
@@ -54,6 +54,9 @@ defmodule Mix.Tasks.Escript.Install do
     * `--organization` - specifies an organization to use if fetching the package
       from a private Hex repository
 
+    * `--timeout` - sets a request timeout in milliseconds for fetching
+      archives from URLs. Default is 60 seconds
+
   """
 
   @behaviour Mix.Local.Installer
@@ -66,7 +69,8 @@ defmodule Mix.Tasks.Escript.Install do
     sha512: :string,
     submodules: :boolean,
     app: :string,
-    organization: :string
+    organization: :string,
+    timeout: :integer
   ]
 
   @impl true

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -489,7 +489,8 @@ defmodule Mix.Utils do
       `{:checksum, message}` in case it fails
 
     * `:timeout` - times out the request after the given milliseconds.
-      Returns `{:remote, timeout_message}` if it fails. Defaults to 60 seconds.
+      Returns `{:remote, timeout_message}` if it fails. Defaults to 60
+      seconds
 
   """
   @spec read_path(String.t(), keyword) ::
@@ -504,11 +505,9 @@ defmodule Mix.Utils do
         task = Task.async(fn -> read_httpc(path) |> checksum(opts) end)
         timeout = Keyword.get(opts, :timeout, 60_000)
 
-        case Task.yield(task, timeout) do
+        case Task.yield(task, timeout) || Task.shutdown(task, :brutal_kill) do
           {:ok, result} -> result
-          _ ->
-            Task.shutdown(task, :brutal_kill)
-            {:remote, "request timed out after #{timeout}ms"}
+          _ -> {:remote, "request timed out after #{timeout}ms"}
         end
 
       file?(path) ->

--- a/lib/mix/test/mix/tasks/archive_test.exs
+++ b/lib/mix/test/mix/tasks/archive_test.exs
@@ -133,6 +133,15 @@ defmodule Mix.Tasks.ArchiveTest do
     end
   end
 
+  test "archive install timeout" do
+    message = ~r[request timed out after 30000ms]
+
+    send(self(), {:mix_shell_input, :yes?, true})
+    assert_raise Mix.Error, message, fn ->
+      Mix.Tasks.Archive.Install.run(["https://10.0.0.0/unlikely-to-exist-0.1.0.ez"])
+    end
+  end
+
   test "archive update" do
     in_fixture("archive", fn ->
       # Install previous version

--- a/lib/mix/test/mix/tasks/archive_test.exs
+++ b/lib/mix/test/mix/tasks/archive_test.exs
@@ -134,11 +134,16 @@ defmodule Mix.Tasks.ArchiveTest do
   end
 
   test "archive install timeout" do
-    message = ~r[request timed out after 60000ms]
+    message = ~r[request timed out after 0ms]
 
     send(self(), {:mix_shell_input, :yes?, true})
+
     assert_raise Mix.Error, message, fn ->
-      Mix.Tasks.Archive.Install.run(["https://10.0.0.0/unlikely-to-exist-0.1.0.ez"])
+      Mix.Tasks.Archive.Install.run([
+        "http://10.0.0.0/unlikely-to-exist-0.1.0.ez",
+        "--timeout",
+        "0"
+      ])
     end
   end
 

--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -348,4 +348,18 @@ defmodule Mix.Tasks.EscriptTest do
   after
     purge([GitRepo, GitRepo.MixProject])
   end
+
+  test "escript install timeout" do
+    message = ~r[request timed out after 0ms]
+
+    send(self(), {:mix_shell_input, :yes?, true})
+
+    assert_raise Mix.Error, message, fn ->
+      Mix.Tasks.Escript.Install.run([
+        "http://10.0.0.0/unlikely-to-exist-0.1.0.ez",
+        "--timeout",
+        "0"
+      ])
+    end
+  end
 end

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -99,7 +99,7 @@ defmodule Mix.UtilsTest do
 
   # 10.0.0.0 is a non-routable address
   test "read_path timeouts requests" do
-    assert {:remote, :timeout} = Mix.Utils.read_path("http://10.0.0.0/", timeout: 0)
+    assert {:remote, "request timed out after 0ms"} = Mix.Utils.read_path("http://10.0.0.0/", timeout: 0)
   end
 
   defp assert_ebin_symlinked_or_copied(result) do

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -99,7 +99,8 @@ defmodule Mix.UtilsTest do
 
   # 10.0.0.0 is a non-routable address
   test "read_path timeouts requests" do
-    assert {:remote, "request timed out after 0ms"} = Mix.Utils.read_path("http://10.0.0.0/", timeout: 0)
+    assert {:remote, "request timed out after 0ms"} =
+             Mix.Utils.read_path("http://10.0.0.0/", timeout: 0)
   end
 
   defp assert_ebin_symlinked_or_copied(result) do

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -97,6 +97,11 @@ defmodule Mix.UtilsTest do
     assert Mix.Utils.proxy_config("https://example.com") == []
   end
 
+  # 10.0.0.0 is a non-routable address
+  test "read_path timeouts requests" do
+    assert {:remote, :timeout} = Mix.Utils.read_path("http://10.0.0.0/", timeout: 0)
+  end
+
   defp assert_ebin_symlinked_or_copied(result) do
     case result do
       {:ok, paths} ->


### PR DESCRIPTION
Add a default timeout of 30 seconds and add it as an option.
Test locally using an unroutable local address 10.0.0.0(it timeouts).

Should fix #8252

Edit: I might have to pass in the `HEX_HTTP_TIMEOUT=120` env option from where this is called.