### PR TITLE
Introduce IEx.Server.run/1

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -773,7 +773,7 @@ defmodule IEx do
       :ok = start_iex()
       :ok = set_expand_fun()
       :ok = run_after_spawn()
-      IEx.Server.start(opts, mfa)
+      IEx.Server.run_from_shell(opts, mfa)
     end)
   end
 

--- a/lib/iex/lib/iex/app.ex
+++ b/lib/iex/lib/iex/app.ex
@@ -4,7 +4,7 @@ defmodule IEx.App do
   use Application
 
   def start(_type, _args) do
-    children = [IEx.Config, IEx.Pry]
+    children = [IEx.Config, IEx.Broker, IEx.Pry]
     Supervisor.start_link(children, strategy: :one_for_one, name: IEx.Supervisor)
   end
 end

--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -1,7 +1,7 @@
 defmodule IEx.Autocomplete do
   @moduledoc false
 
-  def expand(expr, server \\ IEx.Server)
+  def expand(expr, server \\ IEx.Broker)
 
   def expand('', server) do
     expand_variable_or_import("", server)

--- a/lib/iex/lib/iex/broker.ex
+++ b/lib/iex/lib/iex/broker.ex
@@ -121,13 +121,13 @@ defmodule IEx.Broker do
     {:reply, :ok, state}
   end
 
-  def handle_call({:accept, {ref, _server_ref}, leader}, {server, _}, state) do
+  def handle_call({:accept, {ref, _server_ref}, group_leader}, {server, _}, state) do
     case pop_in(state.takeovers[ref]) do
       {nil, state} ->
         {:reply, {:error, :already_accepted}, state}
 
       {{from, _}, state} ->
-        GenServer.reply(from, {:ok, server, leader})
+        GenServer.reply(from, {:ok, server, group_leader})
         {:reply, :ok, state}
     end
   end

--- a/lib/iex/lib/iex/broker.ex
+++ b/lib/iex/lib/iex/broker.ex
@@ -6,6 +6,8 @@ defmodule IEx.Broker do
 
   use GenServer
 
+  ## Shell API
+
   @doc """
   Finds the IEx server running inside `:user_drv`, on this node exclusively.
   """
@@ -85,6 +87,7 @@ defmodule IEx.Broker do
 
   ## Callbacks
 
+  @impl true
   def init(:ok) do
     state = %{
       servers: %{},
@@ -94,6 +97,7 @@ defmodule IEx.Broker do
     {:ok, state}
   end
 
+  @impl true
   def handle_call({:take_over, identifier, opts}, {_, ref} = from, state) do
     case servers(state) do
       [] ->
@@ -136,6 +140,7 @@ defmodule IEx.Broker do
     end
   end
 
+  @impl true
   def handle_info({:DOWN, server_ref, _, _, _}, state) do
     {_pid, state} = pop_in(state.servers[server_ref])
 

--- a/lib/iex/lib/iex/broker.ex
+++ b/lib/iex/lib/iex/broker.ex
@@ -65,7 +65,7 @@ defmodule IEx.Broker do
   @doc """
   Client responds to a takeover request.
 
-  Note we need to pass the broker pid to support remote shells.
+  The broker's PID is needed to support remote shells.
   """
   @spec respond(pid, take_ref, boolean()) :: :ok | {:error, :refused | :already_accepted}
   def respond(broker_pid, take_ref, true) do

--- a/lib/iex/lib/iex/broker.ex
+++ b/lib/iex/lib/iex/broker.ex
@@ -1,0 +1,175 @@
+defmodule IEx.Broker do
+  @moduledoc false
+  @name IEx.Broker
+
+  @type take_ref :: {takeover_ref :: reference(), server_ref :: reference()}
+
+  use GenServer
+
+  @doc """
+  Finds the IEx server running inside `:user_drv`, on this node exclusively.
+  """
+  @spec shell :: pid | nil
+  def shell() do
+    # Locate top group leader, always registered as user
+    # can be implemented by group (normally) or user
+    # (if oldshell or noshell)
+    if user = Process.whereis(:user) do
+      case :group.interfaces(user) do
+        # Old or no shell
+        [] ->
+          case :user.interfaces(user) do
+            [] -> nil
+            [shell: shell] -> shell
+          end
+
+        # Get current group from user_drv
+        [user_drv: user_drv] ->
+          case :user_drv.interfaces(user_drv) do
+            [] -> nil
+            [current_group: group] -> :group.interfaces(group)[:shell]
+          end
+      end
+    end
+  end
+
+  @doc """
+  Finds the evaluator and server running inside `:user_drv`, on this node exclusively.
+  """
+  @spec evaluator :: {evaluator :: pid, server :: pid} | nil
+  def evaluator() do
+    if pid = shell() do
+      {:dictionary, dictionary} = Process.info(pid, :dictionary)
+      {dictionary[:evaluator], pid}
+    end
+  end
+
+  ## Broker API
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: @name)
+  end
+
+  @doc """
+  Register an IEx server in the broker.
+
+  All instances, except shell ones, are registered.
+  """
+  @spec register(pid) :: :ok
+  def register(pid) do
+    GenServer.call(@name, {:register, pid})
+  end
+
+  @doc """
+  Respond to a broker take over request.
+
+  Note we need to pass the broker pid to support remote shells.
+  """
+  @spec respond(pid, take_ref, boolean()) :: :ok | {:error, :refused | :already_accepted}
+  def respond(broker_pid, take_ref, true) do
+    GenServer.call(broker_pid, {:accept, take_ref, Process.group_leader()})
+  end
+
+  def respond(broker_pid, take_ref, false) do
+    GenServer.call(broker_pid, {:refuse, take_ref})
+  end
+
+  @doc """
+  Client requests a take over.
+  """
+  @spec take_over(binary, keyword) :: {:ok, pid, pid} | {:error, :no_iex | :refused}
+  def take_over(identifier, opts) do
+    GenServer.call(@name, {:take_over, identifier, opts}, :infinity)
+  end
+
+  ## Callbacks
+
+  def init(:ok) do
+    state = %{
+      servers: %{},
+      takeovers: %{}
+    }
+
+    {:ok, state}
+  end
+
+  def handle_call({:take_over, identifier, opts}, {_, ref} = from, state) do
+    case servers(state) do
+      [] ->
+        {:reply, {:error, :no_iex}, state}
+
+      servers ->
+        server_refs =
+          for {server_ref, server_pid} <- servers do
+            send(server_pid, {:take_over, self(), {ref, server_ref}, identifier, opts})
+            server_ref
+          end
+
+        state = put_in(state.takeovers[ref], {from, server_refs})
+        {:noreply, state}
+    end
+  end
+
+  def handle_call({:register, pid}, _from, state) do
+    ref = Process.monitor(pid)
+    state = put_in(state.servers[ref], pid)
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:accept, {ref, _server_ref}, leader}, {server, _}, state) do
+    case pop_in(state.takeovers[ref]) do
+      {nil, state} ->
+        {:reply, {:error, :already_accepted}, state}
+
+      {{from, _}, state} ->
+        GenServer.reply(from, {:ok, server, leader})
+        {:reply, :ok, state}
+    end
+  end
+
+  def handle_call({:refuse, {ref, server_ref}}, _from, state) do
+    if takeover = state.takeovers[ref] do
+      {:reply, {:error, :refused}, refuse(state, ref, takeover, server_ref)}
+    else
+      {:reply, {:error, :refused}, state}
+    end
+  end
+
+  def handle_info({:DOWN, server_ref, _, _, _}, state) do
+    {_pid, state} = pop_in(state.servers[server_ref])
+
+    state =
+      Enum.reduce(state.takeovers, state, fn {ref, takeover}, state ->
+        refuse(state, ref, takeover, server_ref)
+      end)
+
+    {:noreply, state}
+  end
+
+  defp refuse(state, ref, {from, server_refs}, server_ref) do
+    case List.delete(server_refs, server_ref) do
+      [] ->
+        {_, state} = pop_in(state.takeovers[ref])
+        GenServer.reply(from, {:error, :refused})
+        state
+
+      server_refs ->
+        put_in(state.takeovers[ref], {from, server_refs})
+    end
+  end
+
+  defp servers(state) do
+    if pid = local_or_remote_shell() do
+      [{Process.monitor(pid), pid} | Enum.to_list(state.servers)]
+    else
+      Enum.to_list(state.servers)
+    end
+  end
+
+  defp local_or_remote_shell() do
+    Enum.find_value([node() | Node.list()], fn node ->
+      server = :rpc.call(node, IEx.Broker, :shell, [])
+      if is_pid(server), do: server
+    end)
+  end
+end

--- a/lib/iex/lib/iex/broker.ex
+++ b/lib/iex/lib/iex/broker.ex
@@ -77,7 +77,8 @@ defmodule IEx.Broker do
   @doc """
   Client requests a take over.
   """
-  @spec take_over(binary, keyword) :: {:ok, pid, pid} | {:error, :no_iex | :refused}
+  @spec take_over(binary, keyword) ::
+          {:ok, server :: pid, group_leader :: pid} | {:error, :no_iex | :refused}
   def take_over(identifier, opts) do
     GenServer.call(@name, {:take_over, identifier, opts}, :infinity)
   end

--- a/lib/iex/lib/iex/broker.ex
+++ b/lib/iex/lib/iex/broker.ex
@@ -77,7 +77,7 @@ defmodule IEx.Broker do
   end
 
   @doc """
-  Client requests a take over.
+  Client requests a takeover.
   """
   @spec take_over(binary, keyword) ::
           {:ok, server :: pid, group_leader :: pid} | {:error, :no_iex | :refused}

--- a/lib/iex/lib/iex/broker.ex
+++ b/lib/iex/lib/iex/broker.ex
@@ -53,7 +53,7 @@ defmodule IEx.Broker do
   end
 
   @doc """
-  Register an IEx server in the broker.
+  Registers an IEx server in the broker.
 
   All instances, except shell ones, are registered.
   """

--- a/lib/iex/lib/iex/broker.ex
+++ b/lib/iex/lib/iex/broker.ex
@@ -63,7 +63,7 @@ defmodule IEx.Broker do
   end
 
   @doc """
-  Respond to a broker take over request.
+  Client responds to a takeover request.
 
   Note we need to pass the broker pid to support remote shells.
   """

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -14,6 +14,9 @@ defmodule IEx.Evaluator do
     old_leader = Process.group_leader()
     Process.group_leader(self(), leader)
 
+    old_server = Process.get(:iex_server)
+    Process.put(:iex_server, server)
+
     evaluator = Process.get(:iex_evaluator)
     Process.put(:iex_evaluator, command)
 
@@ -24,6 +27,12 @@ defmodule IEx.Evaluator do
       loop(state)
     after
       Process.group_leader(self(), old_leader)
+
+      if old_server do
+        Process.put(:iex_server, old_server)
+      else
+        Process.delete(:iex_server)
+      end
 
       cond do
         is_nil(evaluator) ->

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -828,8 +828,8 @@ defmodule IEx.Helpers do
   Respawns the current shell by starting a new shell process.
   """
   def respawn do
-    if whereis = IEx.Server.whereis() do
-      send(whereis, {:respawn, self()})
+    if iex_server = Process.get(:iex_server) do
+      send(iex_server, {:respawn, self()})
     end
 
     dont_display_result()
@@ -852,8 +852,8 @@ defmodule IEx.Helpers do
   """
   @doc since: "1.5.0"
   def continue do
-    if whereis = IEx.Server.whereis() do
-      send(whereis, {:continue, self()})
+    if iex_server = Process.get(:iex_server) do
+      send(iex_server, {:continue, self()})
     end
 
     dont_display_result()

--- a/lib/iex/lib/iex/pry.ex
+++ b/lib/iex/lib/iex/pry.ex
@@ -69,9 +69,9 @@ defmodule IEx.Pry do
       end
 
     # We cannot use colors because IEx may be off
-    case IEx.Server.take_over(request, opts) do
-      :ok ->
-        :ok
+    case IEx.Broker.take_over(request, [evaluator: self()] ++ opts) do
+      {:ok, server, leader} ->
+        IEx.Evaluator.init(:no_ack, server, leader, opts)
 
       {:error, :no_iex} ->
         extra =

--- a/lib/iex/lib/iex/pry.ex
+++ b/lib/iex/lib/iex/pry.ex
@@ -70,8 +70,8 @@ defmodule IEx.Pry do
 
     # We cannot use colors because IEx may be off
     case IEx.Broker.take_over(request, [evaluator: self()] ++ opts) do
-      {:ok, server, leader} ->
-        IEx.Evaluator.init(:no_ack, server, leader, opts)
+      {:ok, server, group_leader} ->
+        IEx.Evaluator.init(:no_ack, server, group_leader, opts)
 
       {:error, :no_iex} ->
         extra =

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -5,7 +5,7 @@ defmodule IEx.InteractionTest do
 
   test "whole output" do
     assert capture_io("IO.puts \"Hello world\"", fn ->
-             IEx.Server.start([dot_iex_path: ""], {IEx, :dont_display_result, []})
+             IEx.Server.run(dot_iex_path: "")
            end) =~
              "Interactive Elixir (#{System.version()}) - press Ctrl+C to exit (type h() ENTER for help)" <>
                "\niex(1)> Hello world\n:ok\niex(2)>"

--- a/lib/iex/test/iex/server_test.exs
+++ b/lib/iex/test/iex/server_test.exs
@@ -113,17 +113,8 @@ defmodule IEx.ServerTest do
 
       send(evaluator1, :run)
       send(evaluator2, :run)
-      reply1 = Task.await(server1)
-      reply2 = Task.await(server2)
-
-      # We can have races, so make sure reply1 was first.
-      # This means we won't assert quite what we expect but
-      # we may have better luck next time.
-      {accepted, refused} =
-        if reply1 =~ ":inside_pry", do: {reply1, reply2}, else: {reply2, reply1}
-
-      assert accepted =~ ":inside_pry"
-      assert refused =~ "undefined function iex_context"
+      assert Task.await(server1) =~ ":inside_pry"
+      assert Task.await(server2) =~ "undefined function iex_context"
 
       assert Task.await(client) == :ok
     end
@@ -137,17 +128,8 @@ defmodule IEx.ServerTest do
 
       send(evaluator1, :run)
       send(evaluator2, :run)
-      reply1 = Task.await(server1)
-      reply2 = Task.await(server2)
-
-      # We can have races, so make sure reply1 was first.
-      # This means we won't assert quite what we expect but
-      # we may have better luck next time.
-      {accepted, refused} =
-        if reply1 =~ ":inside_pry", do: {reply1, reply2}, else: {reply2, reply1}
-
-      assert accepted =~ ":inside_pry"
-      assert refused =~ "undefined function iex_context"
+      assert Task.await(server1) =~ "undefined function iex_context"
+      assert Task.await(server2) =~ ":inside_pry"
 
       assert Task.await(client) == :ok
     end

--- a/lib/iex/test/iex/server_test.exs
+++ b/lib/iex/test/iex/server_test.exs
@@ -3,65 +3,185 @@ Code.require_file("../test_helper.exs", __DIR__)
 defmodule IEx.ServerTest do
   use IEx.Case
 
+  require IEx
+
   describe "options" do
     test "prefix" do
       assert capture_io(fn ->
-               boot(prefix: "pry")
+               IEx.Server.run(prefix: "pry")
              end) =~ "pry(1)> "
     end
 
     test "env" do
       assert capture_io("__ENV__.file", fn ->
-               boot(env: __ENV__)
+               IEx.Server.run(env: __ENV__)
              end) =~ "server_test.exs"
     end
   end
 
-  describe "take_over" do
-    test "allows takeover of the shell during boot" do
-      assert capture_io("Y\na+b", fn ->
-               server = self()
-
-               boot([], fn ->
-                 opts = [prefix: "dbg", binding: [a: 1, b: 2]]
-                 IEx.Server.take_over("iex:13", opts, server)
-               end)
-             end) =~ "dbg(1)> "
-    end
-
-    test "continues if takeover is refused" do
-      assert capture_io("N\n", fn ->
-               server = self()
-
-               boot([], fn ->
-                 opts = [prefix: "dbg", binding: [a: 1, b: 2]]
-                 IEx.Server.take_over("iex:13", opts, server)
-               end)
-             end) =~ "iex(1)> "
-    end
-
-    test "fails if callback during boot fails" do
+  describe "pry" do
+    test "no sessions" do
       assert capture_io(fn ->
-               boot([], fn -> exit(0) end)
-             end) == ""
+               require IEx
+               assert IEx.pry() == {:error, :no_iex}
+             end) =~ "Is an IEx shell running?"
     end
 
-    test "fails when there is no shell" do
-      assert IEx.Server.take_over("iex:13", []) == {:error, :no_iex}
+    test "inside evaluator itself" do
+      assert capture_iex("require IEx; IEx.pry") =~ "Break reached"
     end
-  end
 
-  test "pry wraps around takeover" do
-    require IEx
+    test "outside of the evaluator with acceptance", config do
+      Process.register(self(), config.test)
 
-    assert capture_io(fn ->
-             assert IEx.pry() == {:error, :no_iex}
-           end) =~ "Is an IEx shell running?"
+      {server, evaluator} = pry_session(config.test, "Y\niex_context")
+      client = pry_request(1)
+      send(evaluator, :run)
+
+      assert Task.await(server) =~ ":inside_pry"
+      assert Task.await(client) == :ok
+    end
+
+    test "outside of the evaluator with refusal", config do
+      Process.register(self(), config.test)
+
+      {server, evaluator} = pry_session(config.test, "N\niex_context")
+      client = pry_request(1)
+      send(evaluator, :run)
+
+      assert Task.await(client) == {:error, :refused}
+      assert Task.await(server) =~ "undefined function iex_context"
+    end
+
+    test "outside of the evaluator with crash", config do
+      Process.register(self(), config.test)
+
+      {server, _evaluator} = pry_session(config.test, "iex_context")
+      client = pry_request(1)
+
+      _ = Task.shutdown(server, :brutal_kill)
+      assert Task.await(client) == {:error, :refused}
+    end
+
+    test "outside of the evaluator with double acceptance", config do
+      Process.register(self(), config.test)
+
+      {server1, evaluator1} = pry_session(config.test, "Y\niex_context")
+      {server2, evaluator2} = pry_session(config.test, "Y\niex_context")
+      client = pry_request(2)
+
+      send(evaluator1, :run)
+      send(evaluator2, :run)
+      reply1 = Task.await(server1)
+      reply2 = Task.await(server2)
+
+      {accepted, refused} =
+        if reply1 =~ ":inside_pry", do: {reply1, reply2}, else: {reply2, reply1}
+
+      assert accepted =~ ":inside_pry"
+      assert refused =~ "** session was already accepted elsewhere"
+      assert refused =~ "undefined function iex_context"
+
+      assert Task.await(client) == :ok
+    end
+
+    test "outside of the evaluator with double refusal", config do
+      Process.register(self(), config.test)
+
+      {server1, evaluator1} = pry_session(config.test, "N\niex_context")
+      {server2, evaluator2} = pry_session(config.test, "N\niex_context")
+      client = pry_request(2)
+
+      send(evaluator1, :run)
+      send(evaluator2, :run)
+      reply1 = Task.await(server1)
+      reply2 = Task.await(server2)
+
+      assert reply1 =~ "undefined function iex_context"
+      assert reply2 =~ "undefined function iex_context"
+
+      assert Task.await(client) == {:error, :refused}
+    end
+
+    test "outside of the evaluator with acceptance and then refusal", config do
+      Process.register(self(), config.test)
+
+      {server1, evaluator1} = pry_session(config.test, "Y\niex_context")
+      {server2, evaluator2} = pry_session(config.test, "N\niex_context")
+      client = pry_request(2)
+
+      send(evaluator1, :run)
+      send(evaluator2, :run)
+      reply1 = Task.await(server1)
+      reply2 = Task.await(server2)
+
+      # We can have races, so make sure reply1 was first.
+      # This means we won't assert quite what we expect but
+      # we may have better luck next time.
+      {accepted, refused} =
+        if reply1 =~ ":inside_pry", do: {reply1, reply2}, else: {reply2, reply1}
+
+      assert accepted =~ ":inside_pry"
+      assert refused =~ "undefined function iex_context"
+
+      assert Task.await(client) == :ok
+    end
+
+    test "outside of the evaluator with refusal and then acceptance", config do
+      Process.register(self(), config.test)
+
+      {server1, evaluator1} = pry_session(config.test, "N\niex_context")
+      {server2, evaluator2} = pry_session(config.test, "Y\niex_context")
+      client = pry_request(2)
+
+      send(evaluator1, :run)
+      send(evaluator2, :run)
+      reply1 = Task.await(server1)
+      reply2 = Task.await(server2)
+
+      # We can have races, so make sure reply1 was first.
+      # This means we won't assert quite what we expect but
+      # we may have better luck next time.
+      {accepted, refused} =
+        if reply1 =~ ":inside_pry", do: {reply1, reply2}, else: {reply2, reply1}
+
+      assert accepted =~ ":inside_pry"
+      assert refused =~ "undefined function iex_context"
+
+      assert Task.await(client) == :ok
+    end
   end
 
   # Helpers
 
-  defp boot(opts, callback \\ fn -> nil end) do
-    IEx.Server.start(Keyword.merge([dot_iex_path: ""], opts), {:erlang, :apply, [callback, []]})
+  defp pry_session(name, session) do
+    task =
+      Task.async(fn ->
+        capture_iex("""
+        send(#{inspect(name)}, {:running, self()})
+        receive do: (:run -> :ok)
+        #{session}
+        """)
+      end)
+
+    assert_receive {:running, evaluator}
+    {task, evaluator}
+  end
+
+  defp pry_request(how_many) do
+    :erlang.trace(Process.whereis(IEx.Broker), true, [:send, tracer: self()])
+    :erlang.trace_pattern(:send, [{[:_, {:take_over, :_, :_, :_, :_}], [], []}], [])
+
+    task =
+      Task.async(fn ->
+        iex_context = :inside_pry
+        IEx.pry()
+      end)
+
+    for _ <- 1..how_many do
+      assert_receive {:trace, _, :send, _, _}
+    end
+
+    task
   end
 end

--- a/lib/iex/test/iex/server_test.exs
+++ b/lib/iex/test/iex/server_test.exs
@@ -22,7 +22,6 @@ defmodule IEx.ServerTest do
   describe "pry" do
     test "no sessions" do
       assert capture_io(fn ->
-               require IEx
                assert IEx.pry() == {:error, :no_iex}
              end) =~ "Is an IEx shell running?"
     end

--- a/lib/iex/test/test_helper.exs
+++ b/lib/iex/test/test_helper.exs
@@ -57,14 +57,14 @@ defmodule IEx.Case do
   Options, if provided, will be set before the eval loop is started.
 
   If you provide server options, it will be passed to
-  IEx.Server.start to be used in the normal .iex loading process.
+  IEx.Server.run to be used in the normal .iex loading process.
   """
   def capture_iex(input, options \\ [], server_options \\ [], capture_prompt \\ false) do
     IEx.configure(options)
 
     ExUnit.CaptureIO.capture_io([input: input, capture_prompt: capture_prompt], fn ->
       server_options = Keyword.put_new(server_options, :dot_iex_path, "")
-      IEx.Server.start(server_options, {IEx, :dont_display_result, []})
+      IEx.Server.run(server_options)
     end)
     |> strip_iex
   end


### PR DESCRIPTION
Since now there may be multiple servers running,
we also introduced IEx.Broker to negociate pry
requests across multiple sessions.

Shell sessions though are tracked separately from
the remaining ones, as we delegate the shell control
to Erlang's user_drv.

Closes #8203.