### PR TITLE
Omit parens on calls with only do/end blocks (Macro.to_string)

### DIFF
--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -501,7 +501,7 @@ defmodule EExTest do
 
     test "begin/end" do
       assert_eval(
-        ~s[BODY(INIT:TEXT(foo):EQUAL(if() do\n  "BEGIN:TEXT(this):END"\nelse\n  "BEGIN:TEXT(that):END"\nend))],
+        ~s[BODY(INIT:TEXT(foo):EQUAL(if do\n  "BEGIN:TEXT(this):END"\nelse\n  "BEGIN:TEXT(that):END"\nend))],
         "foo <%= if do %>this<% else %>that<% end %>",
         [],
         engine: TestEngine

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -758,9 +758,13 @@ defmodule Macro do
       {list, last} = split_last(args)
 
       result =
-        case kw_blocks?(last) do
-          true -> call_to_string_with_args(target, list, fun) <> kw_blocks_to_string(last, fun)
-          false -> call_to_string_with_args(target, args, fun)
+        if kw_blocks?(last) do
+          case list do
+            [] -> call_to_string(target, fun) <> kw_blocks_to_string(last, fun)
+            _ -> call_to_string_with_args(target, list, fun) <> kw_blocks_to_string(last, fun)
+          end
+        else
+          call_to_string_with_args(target, args, fun)
         end
 
       fun.(ast, result)

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -293,7 +293,7 @@ defmodule MacroTest do
            end).bar([1, 2, 3])
         end
 
-      assert Macro.to_string(quoted) == "(foo() do\n  :ok\nend).bar([1, 2, 3])"
+      assert Macro.to_string(quoted) == "(foo do\n  :ok\nend).bar([1, 2, 3])"
     end
 
     test "atom remote call" do
@@ -453,7 +453,7 @@ defmodule MacroTest do
         end
 
       expected = """
-      try() do
+      try do
         foo
       rescue
         ArgumentError ->


### PR DESCRIPTION
Follow up of https://github.com/elixir-lang/elixir/issues/8078#issuecomment-412833448