### PR TITLE
Compile charlist interpolation more efficiently 

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5135,9 +5135,8 @@ defmodule Kernel do
     String.to_charlist(:elixir_interpolation.unescape_chars(string))
   end
 
-  defmacro sigil_c({:<<>>, meta, pieces}, []) do
-    binary = {:<<>>, meta, unescape_tokens(pieces)}
-    quote(do: String.to_charlist(unquote(binary)))
+  defmacro sigil_c({:<<>>, _meta, pieces}, []) do
+    quote(do: List.to_charlist(unquote(unescape_list_tokens(pieces))))
   end
 
   @doc """
@@ -5398,6 +5397,15 @@ defmodule Kernel do
       {:ok, unescaped_tokens} -> unescaped_tokens
       {:error, reason} -> raise ArgumentError, to_string(reason)
     end
+  end
+
+  defp unescape_list_tokens(tokens) do
+    escape = fn
+      {:::, _, [expr, _]} -> expr
+      binary when is_binary(binary) -> :elixir_interpolation.unescape_chars(binary)
+    end
+
+    :lists.map(escape, tokens)
   end
 
   @doc false

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -883,7 +883,7 @@ build_list_string({list_string, Location, Args}, ExtraMeta) ->
       true -> ExtraMeta ++ Meta;
       false -> Meta
     end,
-  {{'.', Meta, ['Elixir.String', to_charlist]}, Meta, [{'<<>>', MetaWithExtra, string_parts(Args)}]}.
+  {{'.', Meta, ['Elixir.List', to_charlist]}, MetaWithExtra, [charlist_parts(Args)]}.
 
 build_quoted_atom({_, _Location, [H]} = Token, Safe, ExtraMeta) when is_binary(H) ->
   Op = binary_to_atom_op(Safe),
@@ -899,6 +899,19 @@ build_quoted_atom({_, Location, Args}, Safe, ExtraMeta) ->
 
 binary_to_atom_op(true)  -> binary_to_existing_atom;
 binary_to_atom_op(false) -> binary_to_atom.
+
+charlist_parts(Parts) ->
+  [charlist_part(Part) || Part <- Parts].
+charlist_part(Binary) when is_binary(Binary) ->
+  Binary;
+charlist_part({{Line, _, EndLine}, Tokens}) ->
+  Form = string_tokens_parse(Tokens),
+  Meta =
+    case ?formatter_metadata() of
+      true -> [{line, Line}, {end_line, EndLine}];
+      false -> [{line, Line}]
+    end,
+  {{'.', Meta, ['Elixir.Kernel', to_string]}, Meta, [Form]}.
 
 string_parts(Parts) ->
   [string_part(Part) || Part <- Parts].


### PR DESCRIPTION
Today charlist interpolation is quivalent to calling `String.to_charlist`
on the equivalent string interpolation. It can be more efficient by
leveraging chardata support in the `:unicode` module and encoding as a
list of literal binaries and results of `Kernel.to_string` calls for the
interpolated segments.

The PR also adds a `List.to_charlist` function that accepts a nested list of chardata and returns a flattened charlist.