### PR TITLE
Fix GenServer.cast/2 doc

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -983,14 +983,12 @@ defmodule GenServer do
   `c:handle_cast/2` will be called on the server to handle
   the request. In case the `server` is on a node which is
   not yet connected to the caller one, the semantics differ
-  depending on the used Erlang version.
-  Before OTP 21 the call is going to block until a connection
-  happens. This is different than the behaviour in OTP's
-  `:gen_server` where the message is sent by another process
-  in this case, which could cause messages to other nodes to
-  arrive out of order.
-  Starting with OTP 21 the call is not going to block, the
-  behaviour of `GenServer` and `:gen_server` is identical.
+  depending on the used Erlang/OTP version.
+
+  Before Erlang/OTP 21, the call is going to block until a
+  connection happens. This was made to address an ordering
+  bug in Erlang's own `:gen_server.cast/2`. Starting with
+  Erlang/OTP 21, both Erlang and Elixir do not block the call.
   """
   @spec cast(server, term) :: :ok
   def cast(server, request)

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -990,7 +990,7 @@ defmodule GenServer do
   in this case, which could cause messages to other nodes to
   arrive out of order.
   Starting with OTP 21 the call is not going to block, the
-  behaviour of `GenServer` and `:gen_server` is idendical.
+  behaviour of `GenServer` and `:gen_server` is identical.
   """
   @spec cast(server, term) :: :ok
   def cast(server, request)

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -986,9 +986,9 @@ defmodule GenServer do
   depending on the used Erlang/OTP version.
 
   Before Erlang/OTP 21, the call is going to block until a
-  connection happens. This was done to guarantee ordering
-  in Erlang's own `:gen_server.cast/2`. Starting with
-  Erlang/OTP 21, both Erlang and Elixir do not block the call.
+  connection happens. This was done to guarantee ordering.
+  Starting with Erlang/OTP 21, both Erlang and Elixir do
+  not block the call.
   """
   @spec cast(server, term) :: :ok
   def cast(server, request)

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -986,8 +986,8 @@ defmodule GenServer do
   depending on the used Erlang/OTP version.
 
   Before Erlang/OTP 21, the call is going to block until a
-  connection happens. This was made to address an ordering
-  bug in Erlang's own `:gen_server.cast/2`. Starting with
+  connection happens. This was done to guarantee ordering
+  in Erlang's own `:gen_server.cast/2`. Starting with
   Erlang/OTP 21, both Erlang and Elixir do not block the call.
   """
   @spec cast(server, term) :: :ok

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -982,11 +982,15 @@ defmodule GenServer do
 
   `c:handle_cast/2` will be called on the server to handle
   the request. In case the `server` is on a node which is
-  not yet connected to the caller one, the call is going to
-  block until a connection happens. This is different than
-  the behaviour in OTP's `:gen_server` where the message
-  is sent by another process in this case, which could cause
-  messages to other nodes to arrive out of order.
+  not yet connected to the caller one, the semantics differ
+  depending on the used Erlang version.
+  Before OTP 21 the call is going to block until a connection
+  happens. This is different than the behaviour in OTP's
+  `:gen_server` where the message is sent by another process
+  in this case, which could cause messages to other nodes to
+  arrive out of order.
+  Starting with OTP 21 the call is not going to block, the
+  behaviour of `GenServer` and `:gen_server` is idendical.
   """
   @spec cast(server, term) :: :ok
   def cast(server, request)


### PR DESCRIPTION
### Environment

* Elixir & Erlang/OTP versions (elixir --version): Elixir 1.7.4 (compiled with Erlang/OTP 21)
* Operating system: macOS 10.13.6

### Current behavior

The [docs of `GenServer.cast/2`][0] currently state: 

> `handle_cast/2` will be called on the server to handle the request. In case the `server` is on a node which is not yet connected to the caller one, the call is going to block until a connection happens. This is different than the behaviour in OTP's `:gen_server` where the message is sent by another process in this case, which could cause messages to other nodes to arrive out of order.

### Expected behavior

The above documentation is not correct when running on top of Erlang/OTP 21. In Erlang/OTP 21 the C implementation of `erlang:send/3` was changed to implement "truly asynchronous auto-connect", as described in the [otp\_src\_21.0-rc1.readme]:

> Truly asynchronous auto-connect. Earlier, when  
erlang:send was done toward an unconnected node, the  
function would not return until the connection setup  
had completed (or failed). Now the function returns  
directly after the signal has been enqueued and the  
connection setup started. 

As Elixir is using `erlang:send` this means that the semantics of `GenServer.cast/2` now depend on the underlying version of Erlang OTP. If Elixir is running on top of OTP 21 a cast to a remote, non-connected node is not going to block anymore but is going to return immediately (i.e. the semantics of casts are now identical in Erlang and Elixir). This also means the current documentation of [`GenServer.cast/2`][0] is incomplete.

The pull request changes the documentation to reflect this behaviour.


[0]: https://github.com/elixir-lang/elixir/blob/38f35fd4487748623492d4be477e37c978d8529a/lib/elixir/lib/gen_server.ex#L983
[otp\_src\_21.0-rc1.readme]: http://erlang.org/download/otp_src_21.0-rc1.readme