### PR TITLE
Improve error message for `BadFunctionError`

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -788,6 +788,10 @@ defmodule BadFunctionError do
   defexception [:term]
 
   @impl true
+  def message(%{term: term}) when is_function(term) do
+    "function #{inspect(term)} is invalid, likely because it points to an old version of the code"
+  end
+
   def message(exception) do
     "expected a function, got: #{inspect(exception.term)}"
   end


### PR DESCRIPTION
Now if the term is a function that couldn't be found because it's
referencing an anonymous function from a previous version of a given
module, it says as much instead of saying it expected a function.

Resolves #8406 