### PR TITLE
Use --module value when setting up filenames in mix new

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -93,6 +93,8 @@ defmodule Mix.Tasks.New do
       version: get_version(System.version())
     ]
 
+    mod_filename = Macro.underscore(mod)
+
     create_file("README.md", readme_template(assigns))
     create_file(".formatter.exs", formatter_template(assigns))
     create_file(".gitignore", gitignore_template(assigns))
@@ -107,15 +109,15 @@ defmodule Mix.Tasks.New do
     create_file("config/config.exs", config_template(assigns))
 
     create_directory("lib")
-    create_file("lib/#{app}.ex", lib_template(assigns))
+    create_file("lib/#{mod_filename}.ex", lib_template(assigns))
 
     if opts[:sup] do
-      create_file("lib/#{app}/application.ex", lib_app_template(assigns))
+      create_file("lib/#{mod_filename}/application.ex", lib_app_template(assigns))
     end
 
     create_directory("test")
     create_file("test/test_helper.exs", test_helper_template(assigns))
-    create_file("test/#{app}_test.exs", test_template(assigns))
+    create_file("test/#{mod_filename}_test.exs", test_template(assigns))
 
     """
 

--- a/lib/mix/test/mix/tasks/new_test.exs
+++ b/lib/mix/test/mix/tasks/new_test.exs
@@ -71,6 +71,15 @@ defmodule Mix.Tasks.NewTest do
     end)
   end
 
+  test "new with --module uses the module name also for naming the files in lib and test" do
+    in_tmp("new_with_module", fn ->
+      Mix.Tasks.New.run([".", "--sup", "--module", "MyTestModule"])
+      assert_file("lib/my_test_module.ex", ~r/defmodule MyTestModule do/)
+      assert_file("lib/my_test_module/application.ex", ~r/defmodule MyTestModule.Application do/)
+      assert_file("test/my_test_module_test.exs", ~r/defmodule MyTestModuleTest do/)
+    end)
+  end
+
   test "new with --app" do
     in_tmp("new app", fn ->
       Mix.Tasks.New.run(["HELLO_WORLD", "--app", "hello_world"])


### PR DESCRIPTION
The module name was used in the templates, but the app name was used for
the file names. Now the module name is used for both.

For example:

```bash
mkdir foo
cd foo
mix new . --module Bar
```

...creates a `Bar` module as expected, but the module's filename is `lib/foo.ex`. This, of course, should be `lib/bar.ex` instead. The reason for the wrong filename is that the code currently uses the (inferred) app name when creating the file, which in this case is `foo`.