### PR TITLE
Remove unnecessary try block in GenServer.reply

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -1114,12 +1114,8 @@ defmodule GenServer do
   def reply(client, reply)
 
   def reply({to, tag}, reply) when is_pid(to) do
-    try do
-      send(to, {tag, reply})
-      :ok
-    catch
-      _, _ -> :ok
-    end
+    send(to, {tag, reply})
+    :ok
   end
 
   @doc """


### PR DESCRIPTION
Based on Erlang reference [here](http://erlang.org/doc/reference_manual/expressions.html#send):

```
Sending a message to a pid never fails, even if the pid identifies a non-existing process.
```

We do not need try block anymore because there is a `is_pid(to)` guard, which was added from #4876.

Therefore, try block within `GenServer.reply` is unnecessary and [confusing](https://elixirforum.com/t/when-would-send-raise-an-error/18177). We should remove it.