### PR TITLE
[Discussion] Add Calendar callbacks and Calendar.ISO implementations

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -137,6 +137,26 @@ defmodule Calendar do
   @callback day_of_week(year, month, day) :: non_neg_integer()
 
   @doc """
+  Calculates the day of the year from the given `year`, `month`, and `day`.
+  """
+  @callback day_of_year(year, month, day) :: non_neg_integer()
+
+  @doc """
+  Calculates the quarter of the year from the given `year`, `month`, and `day`.
+  """
+  @callback quarter_of_year(year, month, day) :: non_neg_integer()
+
+  @doc """
+  Calculates the year and era from the given `year`.
+  """
+  @callback year_of_era(year) :: {year, era :: non_neg_integer()}
+
+  @doc """
+  Calculates the day and era from the given `year`, `month`, and `day`.
+  """
+  @callback day_of_era(year, month, day) :: {day, era :: non_neg_integer()}
+
+  @doc """
   Converts the date into a string according to the calendar.
   """
   @callback date_to_string(year, month, day) :: String.t()

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -711,6 +711,54 @@ defmodule Date do
     calendar.quarter_of_year(year, month, day)
   end
 
+  @doc """
+  Calculates the year-of-era and era for a given
+  calendar year.
+
+  Returns a tuple `{year, era}` representing the
+  year within the era and the era number.
+
+  ## Examples
+
+      iex> Date.year_of_era(~D[0001-01-01])
+      {1, 1}
+      iex> Date.year_of_era(~D[0000-12-31])
+      {1, 0}
+      iex> Date.year_of_era(~D[-0001-01-01])
+      {2, 0}
+
+  """
+  @doc since: "1.8.0"
+  @spec year_of_era(Calendar.date) :: {Calendar.year, non_neg_integer()}
+  def year_of_era(date)
+
+  def year_of_era(%{calendar: calendar, year: year}) do
+    calendar.year_of_era(year)
+  end
+
+  @doc """
+  Calculates the day-of-era and era for a given
+  calendar `date`.
+
+  Returns a tuple `{day, era}` representing the
+  day within the era and the era number.
+
+  ## Examples
+
+    iex> Date.day_of_era(~D[0001-01-01])
+    {1, 1}
+    iex> Date.day_of_era(~D[0000-12-31])
+    {1, 0}
+
+  """
+  @doc since: "1.8.0"
+  @spec day_of_era(Calendar.date) :: {Calendar.day, non_neg_integer()}
+  def day_of_era(date)
+
+  def day_of_era(%{calendar: calendar, year: year, month: month, day: day}) do
+    calendar.day_of_era(year, month, day)
+  end
+
   ## Helpers
 
   defimpl String.Chars do

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -659,6 +659,58 @@ defmodule Date do
     calendar.day_of_week(year, month, day)
   end
 
+  @doc """
+  Calculates the day of the year of a given `date`.
+
+  Returns the day of the year as an integer. For the ISO 8601
+  calendar (the default), it is an integer from 1 to 366.
+
+  ## Examples
+
+      iex> Date.day_of_year(~D[2016-01-01])
+      1
+      iex> Date.day_of_year(~D[2016-11-01])
+      306
+      iex> Date.day_of_year(~D[-0015-10-30])
+      303
+      iex> Date.day_of_year(~D[2004-12-31])
+      366
+
+  """
+  @doc since: "1.8.0"
+  @spec day_of_year(Calendar.date()) :: non_neg_integer()
+  def day_of_year(date)
+
+  def day_of_year(%{calendar: calendar, year: year, month: month, day: day}) do
+    calendar.day_of_year(year, month, day)
+  end
+
+  @doc """
+  Calculates the quarter of the year of a given `date`.
+
+  Returns the day of the year as an integer. For the ISO 8601
+  calendar (the default), it is an integer from 1 to 4.
+
+  ## Examples
+
+      iex> Date.quarter_of_year(~D[2016-10-31])
+      4
+      iex> Date.quarter_of_year(~D[2016-01-01])
+      1
+      iex> Date.quarter_of_year(~N[2016-04-01 01:23:45])
+      2
+      iex> Date.quarter_of_year(~D[-0015-09-30])
+      3
+
+  """
+  @doc since: "1.8.0"
+  @spec quarter_of_year(Calendar.date()) :: non_neg_integer()
+  def quarter_of_year(date)
+
+  def quarter_of_year(%{calendar: calendar, year: year, month: month, day: day}) do
+    calendar.quarter_of_year(year, month, day)
+  end
+
   ## Helpers
 
   defimpl String.Chars do

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -383,7 +383,7 @@ defmodule Calendar.ISO do
 
   """
   @doc since: "1.8.0"
-  @spec quarter_of_year(year, month, day) :: Calendar.quarter()
+  @spec quarter_of_year(year, month, day) :: 1..4
   @impl true
   def quarter_of_year(year, month, day)
       when is_integer(year) and is_integer(month) and is_integer(day) do

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -358,7 +358,7 @@ defmodule Calendar.ISO do
 
   """
   @doc since: "1.8.0"
-  @spec day_of_year(year, month, day) :: day
+  @spec day_of_year(year, month, day) :: 1..366
   @impl true
   def day_of_year(year, month, day)
       when is_integer(year) and is_integer(month) and is_integer(day) do

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -37,6 +37,11 @@ defmodule Calendar.ISO do
 
   @months_in_year 12
 
+  # The ISO epoch starts, in this implementation,
+  # with ~D[0000-01-01]. Era "1" starts
+  # on ~D[0001-01-01] which is 366 days later.
+  @iso_epoch 366
+
   @doc false
   def __match_date__ do
     quote do
@@ -335,6 +340,122 @@ defmodule Calendar.ISO do
   def day_of_week(year, month, day)
       when is_integer(year) and is_integer(month) and is_integer(day) do
     Integer.mod(date_to_iso_days(year, month, day) + 5, 7) + 1
+  end
+
+  @doc """
+  Calculates the day of the year from the given `year`, `month`, and `day`.
+
+  It is an integer from 1 to 366.
+
+  ## Examples
+
+      iex> Calendar.ISO.day_of_year(2016, 1, 31)
+      31
+      iex> Calendar.ISO.day_of_year(-99, 2, 1)
+      32
+      iex> Calendar.ISO.day_of_year(2018, 2, 28)
+      59
+
+  """
+  @doc since: "1.8.0"
+  @spec day_of_year(year, month, day) :: day
+  @impl true
+  def day_of_year(year, month, day)
+      when is_integer(year) and is_integer(month) and is_integer(day) do
+    date_to_iso_days(year, month, day) - date_to_iso_days(year, 1, 1) + 1
+  end
+
+  @doc """
+  Calculates the quarter of the year from the given `year`, `month`, and `day`.
+
+  It is an integer from 1 to 4.
+
+  ## Examples
+
+      iex> Calendar.ISO.quarter_of_year(2016, 1, 31)
+      1
+      iex> Calendar.ISO.quarter_of_year(2016, 4, 3)
+      2
+      iex> Calendar.ISO.quarter_of_year(-99, 9, 31)
+      3
+      iex> Calendar.ISO.quarter_of_year(2018, 12, 28)
+      4
+
+  """
+  @doc since: "1.8.0"
+  @spec quarter_of_year(year, month, day) :: Calendar.quarter()
+  @impl true
+  def quarter_of_year(year, month, day)
+      when is_integer(year) and is_integer(month) and is_integer(day) do
+    cond do
+      month <= 3 -> 1
+      month <= 6 -> 2
+      month <= 9 -> 3
+      true -> 4
+    end
+  end
+
+  @doc """
+  Calculates the year and era from the given `year`.
+
+  The ISO calendar has two eras: the current era which
+  starts in year 1 and is defined as era "1". And a
+  second era for those years less than 1 defined as
+  era "0".
+
+  ## Examples
+
+      iex> Calendar.ISO.year_of_era(1)
+      {1, 1}
+      iex> Calendar.ISO.year_of_era(2018)
+      {2018, 1}
+      iex> Calendar.ISO.year_of_era(0)
+      {1, 0}
+      iex> Calendar.ISO.year_of_era(-1)
+      {2, 0}
+
+  """
+  @doc since: "1.8.0"
+  @spec year_of_era(year) :: {year, era :: non_neg_integer()}
+  @impl true
+  def year_of_era(year) when is_integer(year) and year > 0 do
+    {year, 1}
+  end
+
+  def year_of_era(year) when is_integer(year) and year < 1 do
+    {abs(year) + 1, 0}
+  end
+
+  @doc """
+  Calculates the day and era from the given `year`, `month`, and `day`.
+
+  ## Examples
+
+      iex> Calendar.ISO.day_of_era(0, 1, 1)
+      {366, 0}
+      iex> Calendar.ISO.day_of_era(1, 1, 1)
+      {1, 1}
+      iex> Calendar.ISO.day_of_era(0, 12, 31)
+      {1, 0}
+      iex> Calendar.ISO.day_of_era(0, 12, 30)
+      {2, 0}
+      iex> Calendar.ISO.day_of_era(-1, 12, 31)
+      {367, 0}
+
+  """
+  @doc since: "1.8.0"
+  @spec day_of_era(year, month, day) :: {day, era :: non_neg_integer()}
+  @impl true
+  def day_of_era(year, month, day)
+      when is_integer(year) and is_integer(month) and is_integer(day) and year > 0 do
+    day = date_to_iso_days(year, month, day) - @iso_epoch + 1
+    {day, 1}
+  end
+
+  def day_of_era(year, month, day)
+      when is_integer(year) and is_integer(month) and is_integer(day) and year < 1 do
+    day = abs(date_to_iso_days(year, month, day) - @iso_epoch)
+    {day, 0}
   end
 
   @doc """

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -444,7 +444,7 @@ defmodule Calendar.ISO do
 
   """
   @doc since: "1.8.0"
-  @spec day_of_era(year, month, day) :: {day, era :: non_neg_integer()}
+  @spec day_of_era(year, month, day) :: {day :: pos_integer(), era :: 0..1}
   @impl true
   def day_of_era(year, month, day)
       when is_integer(year) and is_integer(month) and is_integer(day) and year > 0 do

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -416,7 +416,7 @@ defmodule Calendar.ISO do
 
   """
   @doc since: "1.8.0"
-  @spec year_of_era(year) :: {year, era :: non_neg_integer()}
+  @spec year_of_era(year) :: {year, era :: 0..1}
   @impl true
   def year_of_era(year) when is_integer(year) and year > 0 do
     {year, 1}

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -53,6 +53,21 @@ defmodule DateTest do
     assert Date.day_of_week(~D[2016-11-06]) == 7
   end
 
+  test "day_of_year/1" do
+    assert Date.day_of_year(~D[2004-03-01]) == 61
+    assert Date.day_of_year(~D[2004-12-31]) == 366
+    assert Date.day_of_year(~D[2015-03-01]) == 60
+    assert Date.day_of_year(~D[2018-01-01]) == 1
+    assert Date.day_of_year(~D[2018-12-31]) == 365
+  end
+
+  test "quarter_of_year/1" do
+    assert Date.quarter_of_year(~D[2004-03-01]) == 1
+    assert Date.quarter_of_year(~D[2015-04-01]) == 2
+    assert Date.quarter_of_year(~D[2018-09-01]) == 3
+    assert Date.quarter_of_year(~D[2004-12-31]) == 4
+  end
+
   test "convert/2" do
     assert Date.convert(~D[2000-01-01], Calendar.Holocene) ==
              {:ok, Calendar.Holocene.date(12000, 01, 01)}

--- a/lib/elixir/test/elixir/calendar/holocene.exs
+++ b/lib/elixir/test/elixir/calendar/holocene.exs
@@ -97,6 +97,18 @@ defmodule Calendar.Holocene do
   defdelegate day_of_week(year, month, day), to: Calendar.ISO
 
   @impl true
+  defdelegate day_of_year(year, month, day), to: Calendar.ISO
+
+  @impl true
+  defdelegate quarter_of_year(year, month, day), to: Calendar.ISO
+
+  @impl true
+  defdelegate year_of_era(year), to: Calendar.ISO
+
+  @impl true
+  defdelegate day_of_era(year, month, day), to: Calendar.ISO
+
+  @impl true
   def valid_date?(year, month, day) do
     :calendar.valid_date(year, month, day)
   end


### PR DESCRIPTION
This PR adds 4 of the proposed new `Calendar` callbacks and implementation in the `Calendar.ISO` calendar module.  The `week_in_year/3` and `week_in_month/3` implementations are close, I wasn't happy with my previous implementation.

* day_of_year/3
* quarter_of_year/3
* year_of_era/1
* day_of_era/3