### PR TITLE
No longer persist dynamically added logger backends

### DIFF
--- a/lib/ex_unit/test/ex_unit/capture_log_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_log_test.exs
@@ -84,17 +84,6 @@ defmodule ExUnit.CaptureLogTest do
     end
   end
 
-  test "exit with noproc when the logger is down" do
-    Logger.App.stop()
-    on_exit(fn -> Logger.App.start() end)
-
-    message = "cannot capture_log/2 because the :logger application was not started"
-
-    assert_raise RuntimeError, message, fn ->
-      capture_log(fn -> Logger.info("one") end)
-    end
-  end
-
   defp wait_capture_removal() do
     case :gen_event.which_handlers(Logger) do
       [Logger.Config] ->

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -581,7 +581,7 @@ defmodule Logger do
   Backends added by this function are not persisted. Therefore
   if the Logger application or supervision tree is restarted,
   the backend won't be available. If you need this guarantee,
-  the configure the backend via the application environment.
+  then configure the backend via the application environment.
 
   ## Options
 

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -590,7 +590,6 @@ defmodule Logger do
 
     case Logger.BackendSupervisor.watch(backend) do
       {:ok, _} = ok ->
-        update_backends(&[backend | List.delete(&1, backend)])
         ok
 
       {:error, {:already_started, _pid}} ->
@@ -613,13 +612,7 @@ defmodule Logger do
   @spec remove_backend(backend, keyword) :: :ok | {:error, term}
   def remove_backend(backend, opts \\ []) do
     _ = if opts[:flush], do: flush()
-    update_backends(&List.delete(&1, backend))
     Logger.BackendSupervisor.unwatch(backend)
-  end
-
-  defp update_backends(fun) do
-    backends = fun.(Application.get_env(:logger, :backends, []))
-    Application.put_env(:logger, :backends, backends)
   end
 
   @doc """

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -578,6 +578,11 @@ defmodule Logger do
   @doc """
   Adds a new backend.
 
+  Backends added by this function are not persisted. Therefore
+  if the Logger application or supervision tree is restarted,
+  the backend won't be available. If you need this guarantee,
+  the configure the backend via the application environment.
+
   ## Options
 
     * `:flush` - when `true`, guarantees all messages currently sent

--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -69,13 +69,14 @@ defmodule Logger.TranslatorTest do
   end
 
   setup_all do
+    backends = Application.get_env(:logger, :backends)
     sasl_reports? = Application.get_env(:logger, :handle_sasl_reports, false)
-    Application.put_env(:logger, :handle_sasl_reports, true)
 
     # Configure backend specific for tests to assert on metadata
     # We could rely exclusively on this backend and skip the console one
     # but using capture_log+console is desired as an integration test
-    Logger.add_backend(Logger.TestBackend)
+    Application.put_env(:logger, :backends, [Logger.TestBackend | backends])
+    Application.put_env(:logger, :handle_sasl_reports, true)
 
     # Restart the app but change the level before to avoid warnings
     level = Logger.level()
@@ -85,7 +86,7 @@ defmodule Logger.TranslatorTest do
     Logger.configure(level: level)
 
     on_exit(fn ->
-      Logger.remove_backend(Logger.TestBackend)
+      Application.put_env(:logger, :backends, backends)
       Application.put_env(:logger, :handle_sasl_reports, sasl_reports?)
       Logger.App.stop()
       Application.start(:logger)

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -41,7 +41,6 @@ defmodule LoggerTest do
 
   test "add_backend/1 and remove_backend/1" do
     assert :ok = Logger.remove_backend(:console)
-    assert Application.get_env(:logger, :backends) == []
     assert Logger.remove_backend(:console) == {:error, :not_found}
 
     assert capture_log(fn ->
@@ -49,9 +48,7 @@ defmodule LoggerTest do
            end) == ""
 
     assert {:ok, _pid} = Logger.add_backend(:console)
-    assert Application.get_env(:logger, :backends) == [:console]
     assert Logger.add_backend(:console) == {:error, :already_present}
-    assert Application.get_env(:logger, :backends) == [:console]
   end
 
   test "add_backend/1 with {module, id}" do


### PR DESCRIPTION
Otherwise it is impossible to dynamically remove them,
which partially defeats the point of adding them dynamically
in the first place.

Therefore this commit moves the whole dynamic backend
management to the user.

Closes #8213