### PR TITLE
add special fn case to signature_to_binary

### DIFF
--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -531,7 +531,7 @@ get_type_docs(Set, Types) ->
 signature_to_binary(_Module, Name, _Signature) when Name == '__aliases__'; Name == '__block__' ->
   <<(atom_to_binary(Name, utf8))/binary, "(args)">>;
 
-signature_to_binary(_Module, Name, _Signature) when Name == fn -> 
+signature_to_binary(_Module, fn, _Signature) -> 
   <<"fn">>;
 
 signature_to_binary(_Module, Name, _Signature)

--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -531,6 +531,9 @@ get_type_docs(Set, Types) ->
 signature_to_binary(_Module, Name, _Signature) when Name == '__aliases__'; Name == '__block__' ->
   <<(atom_to_binary(Name, utf8))/binary, "(args)">>;
 
+signature_to_binary(_Module, Name, _Signature) when Name == fn -> 
+  <<"fn">>;
+
 signature_to_binary(_Module, Name, _Signature)
     when Name == '__CALLER__'; Name == '__DIR__'; Name == '__ENV__';
          Name == '__MODULE__'; Name == '__STACKTRACE__'; Name == '%{}' ->

--- a/lib/elixir/test/elixir/kernel/docs_test.exs
+++ b/lib/elixir/test/elixir/kernel/docs_test.exs
@@ -308,8 +308,8 @@ defmodule Kernel.DocsTest do
            ] = Enum.sort(function_docs)
   end
 
-  describe "fecth docs handles special cases correct" do
-    test "fn docs are correct" do
+  describe "special signatures" do
+    test "fn" do
       {:docs_v1, _, _, _, _, _, docs} = Code.fetch_docs(Kernel.SpecialForms)
       {_, _, fn_docs, _, _} = Enum.find(docs, &match?({_, :fn, 1}, elem(&1, 0)))
       assert fn_docs == ["fn"]

--- a/lib/elixir/test/elixir/kernel/docs_test.exs
+++ b/lib/elixir/test/elixir/kernel/docs_test.exs
@@ -307,4 +307,12 @@ defmodule Kernel.DocsTest do
              {{:fuz, 0}, :none}
            ] = Enum.sort(function_docs)
   end
+
+  describe "fecth docs handles special cases correct" do
+    test "fn docs are correct" do
+      {:docs_v1, _, _, _, _, _, docs} = Code.fetch_docs(Kernel.SpecialForms)
+      {_, _, fn_docs, _, _} = Enum.find(docs, &match?({_, :fn, 1}, elem(&1, 0)))
+      assert fn_docs == ["fn"]
+    end
+  end
 end


### PR DESCRIPTION
Handles the special fn case in the signature_to_binary function. As of now I hardcoded the signature of fn, I am not sure this is the intended behavior? 
Fixes #8428
