### PR TITLE
Eliminate warning for an unused variable

### DIFF
--- a/lib/elixir/src/elixir_fn.erl
+++ b/lib/elixir/src/elixir_fn.erl
@@ -6,7 +6,7 @@
 %% Anonymous functions
 
 expand(Meta, Clauses, E) when is_list(Clauses) ->
-  Transformer = fun({_, _, [Left, Right]} = Clause, Acc) ->
+  Transformer = fun({_, _, [Left, _Right]} = Clause, Acc) ->
     case lists:any(fun is_invalid_arg/1, Left) of
       true ->
         form_error(Meta, ?key(E, file), ?MODULE, defaults_in_args);


### PR DESCRIPTION
Fix a warning that has started to occur because of a recent bug fix in
Erlang/OTP (using `fun M:F/A` could suppress warnings for unused
variables).