### PR TITLE
Remove :console backend from the application environment in Mix tests

### DIFF
--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -34,6 +34,7 @@ defmodule MixTest.Case do
   setup config do
     if apps = config[:apps] do
       Logger.remove_backend(:console)
+      Application.put_env(:logger, :backends, [])
     end
 
     on_exit(fn ->
@@ -52,6 +53,7 @@ defmodule MixTest.Case do
         end
 
         Logger.add_backend(:console, flush: true)
+        Application.put_env(:logger, :backends, [:console])
       end
     end)
 


### PR DESCRIPTION
Backends added or removed dynamically via `Logger.add_backend/2` or `Logger.remove_backend/2` are not persisted. Backends must be removed from the application environment explicitly.

It removes the `[info]` from the output of the tests.

```
==> mix (ex_unit)
Excluding tags: [windows: true]
........................................
11:44:08.368 [info]  Application foo exited: :stopped
11:44:08.368 [info]  Application bar exited: :stopped
..
11:44:08.806 [info]  Application foo exited: :stopped
11:44:08.806 [info]  Application bar exited: :stopped
...
11:44:09.626 [info]  Application foo exited: :stopped
11:44:09.626 [info]  Application bar exited: :stopped
......
11:44:12.480 [info]  Application foo exited: :stopped
11:44:12.480 [info]  Application bar exited: :stopped
......
11:44:14.665 [info]  Application foo exited: :stopped
11:44:14.666 [info]  Application bar exited: :stopped
............................................................................................................
11:45:19.952 [info]  Application sample exited: :stopped
.
11:45:20.493 [info]  Application sample exited: :stopped
.
11:45:21.023 [info]  Application sample exited: :stopped
.
11:45:21.367 [info]  Application sample exited: :stopped
.
11:45:21.674 [info]  Application sample exited: :stopped
...................................warning: redefining module Mix.MixProject (current version defined in memory)
  /home/travis/build/elixir-lang/elixir/lib/mix/mix.exs:1
...........................................................................warning: redefining module GitRepo (current version loaded from /home/travis/build/elixir-lang/elixir/lib/mix/tmp/Mix.Tasks.DepsGitTest/test gets and updates many levels deep dependencies/_build/dev/lib/git_repo/ebin/Elixir.GitRepo.beam)
  lib/git_repo.ex:2
.........
11:45:56.715 [info]  Application raw_sample exited: :stopped
........................................................................................
11:46:16.046 [info]  Application app_start_sample exited: :stopped
....
11:46:16.841 [info]  Application app_start_sample exited: :stopped
......................................................................................................................................
Finished in 172.1 seconds (5.8s on load, 166.3s on tests)
8 doctests, 506 tests, 0 failures
```