### PR TITLE
Change type to link to Elixir docs [ci-skip]

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -310,7 +310,7 @@ defmodule DynamicSupervisor do
   this function returns `{:error, :max_children}`.
   """
   @doc since: "1.6.0"
-  @spec start_child(Supervisor.supervisor(), :supervisor.child_spec() | {module, term} | module) ::
+  @spec start_child(Supervisor.supervisor(), Supervisor.child_spec() | {module, term} | module) ::
           on_start_child()
   def start_child(supervisor, {_, _, _, _, _, _} = child_spec) do
     validate_and_start_child(supervisor, child_spec)


### PR DESCRIPTION
Since we have an Elixir type for `Supervisor.child_spec()` it's better
to link to that instead of the Erlang type docs.