### PR TITLE
Update GitHub issue template with mailing list link

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,15 +1,15 @@
 ### Precheck
 
 * Do not use the issues tracker for help or support (try Elixir Forum, Stack Overflow, IRC, etc.)
-* For proposing a new feature, please start a discussion on the Elixir Core mailing list
+* For proposing a new feature, please start a discussion on the Elixir Core mailing list: https://groups.google.com/group/elixir-lang-core
 * For bugs, do a quick search and make sure the bug has not yet been reported
 * Please disclose security vulnerabilities privately at elixir-security@googlegroups.com
 * Finally, be nice and have fun!
 
 ### Environment
 
-* Elixir & Erlang/OTP versions (elixir --version): 
-* Operating system: 
+* Elixir & Erlang/OTP versions (elixir --version):
+* Operating system:
 
 ### Current behavior
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -8,8 +8,8 @@
 
 ### Environment
 
-* Elixir & Erlang/OTP versions (elixir --version):
-* Operating system:
+* Elixir & Erlang/OTP versions (elixir --version): 
+* Operating system: 
 
 ### Current behavior
 


### PR DESCRIPTION
It could be useful to link directly to the mailing list in the GitHub issue template.

The same linking as we do in the Elixir website, see https://elixir-lang.org/development.html