### PR TITLE
Remove `=>` operator from documentation

### DIFF
--- a/lib/elixir/pages/Operators.md
+++ b/lib/elixir/pages/Operators.md
@@ -22,7 +22,6 @@ Operator                                                                        
 `\|\|` `\|\|\|` `or`                                                                     | Left to right
 `&`                                                                                      | Unary
 `=`                                                                                      | Right to left
-`=>`                                                                                     | Right to left
 `\|`                                                                                     | Right to left
 `::`                                                                                     | Right to left
 `when`                                                                                   | Right to left

--- a/lib/elixir/pages/Operators.md
+++ b/lib/elixir/pages/Operators.md
@@ -22,6 +22,7 @@ Operator                                                                        
 `\|\|` `\|\|\|` `or`                                                                     | Left to right
 `&`                                                                                      | Unary
 `=`                                                                                      | Right to left
+`=>` (available only inside %{})                                                         | Right to left
 `\|`                                                                                     | Right to left
 `::`                                                                                     | Right to left
 `when`                                                                                   | Right to left

--- a/lib/elixir/pages/Operators.md
+++ b/lib/elixir/pages/Operators.md
@@ -22,7 +22,7 @@ Operator                                                                        
 `\|\|` `\|\|\|` `or`                                                                     | Left to right
 `&`                                                                                      | Unary
 `=`                                                                                      | Right to left
-`=>` (available only inside `%{}`)                                                       | Right to left
+`=>` (valid syntax only inside `%{}`)                                                    | Right to left
 `\|`                                                                                     | Right to left
 `::`                                                                                     | Right to left
 `when`                                                                                   | Right to left

--- a/lib/elixir/pages/Operators.md
+++ b/lib/elixir/pages/Operators.md
@@ -22,7 +22,7 @@ Operator                                                                        
 `\|\|` `\|\|\|` `or`                                                                     | Left to right
 `&`                                                                                      | Unary
 `=`                                                                                      | Right to left
-`=>` (available only inside %{})                                                         | Right to left
+`=>` (available only inside `%{}`)                                                       | Right to left
 `\|`                                                                                     | Right to left
 `::`                                                                                     | Right to left
 `when`                                                                                   | Right to left


### PR DESCRIPTION
I don't think this belongs in the Operators documentation.

- It is not a standalone operator, i.e. valid only in map syntax
- List of operators does not include `->`

```
iex(1)> quote do: a => b
** (SyntaxError) iex:1: syntax error before: '=>'
```