### PR TITLE
IEx helper "i" lists Implemented Protocols sorted alphabetically

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -493,6 +493,7 @@ defmodule IEx.Helpers do
     |> Protocol.extract_protocols()
     |> Enum.uniq()
     |> Enum.reject(fn protocol -> is_nil(protocol.impl_for(term)) end)
+    |> Enum.sort()
     |> Enum.map_join(", ", &inspect/1)
   end
 


### PR DESCRIPTION
Before:

```iex
iex(1)> i [1 | 2]
Term
  [1 | 2]
Data type
  List
Reference modules
  List
Implemented protocols
  IEx.Info, String.Chars, Enumerable, Inspect, List.Chars, Collectable
```

Now:

```iex
iex(1)> i [1 | 2]
Term
  [1 | 2]
Data type
  List
Reference modules
  List
Implemented protocols
  Collectable, Enumerable, IEx.Info, Inspect, List.Chars, String.Chars
```