### PR TITLE
Correct return types for c:Calendar.day_of_era/3

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -180,7 +180,7 @@ defmodule Calendar do
   @doc """
   Calculates the day and era from the given `year`, `month`, and `day`.
   """
-  @callback day_of_era(year, month, day) :: {day, era}
+  @callback day_of_era(year, month, day) :: {non_neg_integer(), era}
 
   @doc """
   Converts the date into a string according to the calendar.


### PR DESCRIPTION
As discussed in https://github.com/elixir-lang/elixir/commit/edd2c6f780532f6bed4addfd087a06172cc679b1#r31550243