### PR TITLE
Add List.product function

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -920,6 +920,31 @@ defmodule List do
   end
 
   @doc """
+  Returns an list of all combinations of elements from given lists.
+
+  ## Examples
+
+      iex> List.product([1, 2, 3], ["A"])
+      [[[1, "A"]], [[2, "A"]], [[3, "A"]]]
+
+      iex> List.product([1, 2, 3], ["A"], fn a, b -> {a, b} end)
+      [[{1, "A"}], [{2, "A"}], [{3, "A"}]]
+  """
+  @spec product(list, list) :: list
+  def product(list1, list2) when is_list(list1) and is_list(list2) do
+    product(list1, list2, fn element1, element2 -> [element1, element2] end)
+  end
+
+  @spec product(list, list, (any, any -> any)) :: list
+  def product(list1, list2, fun) when is_list(list1) and is_list(list2) and is_function(fun) do
+    for elem1 <- list1 do
+      for elem2 <- list2 do
+        fun.(elem1, elem2)
+      end
+    end
+  end
+
+  @doc """
   Returns a keyword list that represents an *edit script*.
 
   The algorithm is outlined in the

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -217,6 +217,34 @@ defmodule ListTest do
     end
   end
 
+  test "product/2" do
+    assert List.product([1], ["A"]) == [[[1, "A"]]]
+    assert List.product([1, 2], [3, 4]) == [[[1, 3], [1, 4]], [[2, 3], [2, 4]]]
+
+    assert_raise FunctionClauseError, fn ->
+      List.product([1, 2], 1)
+    end
+  end
+
+  test "product/3" do
+    assert List.product([1], ["A"], fn el1, el2 -> {el1 * 3, el2} end) == [[{3, "A"}]]
+
+    assert List.product([1, 2], [3, 4], fn el1, el2 -> {el1, el2} end) == [
+             [{1, 3}, {1, 4}],
+             [{2, 3}, {2, 4}]
+           ]
+
+    assert List.product([10, 21], [1, 2], fn el1, el2 -> el1 * el2 end) == [[10, 20], [21, 42]]
+
+    assert_raise FunctionClauseError, fn ->
+      List.product([1, 2], 1, fn el1, el2 -> {el1, el2} end)
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      List.product([1, 2], [1], nil)
+    end
+  end
+
   describe "myers_difference/2" do
     test "follows paper implementation" do
       assert List.myers_difference([], []) == []


### PR DESCRIPTION
Hello :)
I found, that there are not analog of Ruby's Array#product (https://apidock.com/ruby/Array/product), so I've decided to fix this mistake :)

I guess that this is a useful function, and hope, you accept PR