### PR TITLE
Fix typos in IEx modules' docs

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -761,7 +761,7 @@ defmodule IEx do
   ## Callbacks
 
   # This is a callback invoked by Erlang shell utilities
-  # when someone press Ctrl+G and adds 's Elixir.IEx'.
+  # when someone presses Ctrl+G and adds 's Elixir.IEx'.
   @doc false
   def start(opts \\ [], mfa \\ {IEx, :dont_display_result, []}) do
     spawn(fn ->

--- a/lib/iex/lib/iex/pry.ex
+++ b/lib/iex/lib/iex/pry.ex
@@ -166,7 +166,7 @@ defmodule IEx.Pry do
   @doc """
   Sets up a breakpoint on the given module/function/args with the given `guard`.
 
-  It requires an `env` to be given to make the expension of the guards.
+  It requires an `env` to be given to make the expansion of the guards.
   """
   @spec break(module, function, [Macro.t()], Macro.t(), Macro.Env.t(), pos_integer) ::
           {:ok, id()} | {:error, break_error()}


### PR DESCRIPTION
Hi all, just two little typos I found while studying Elixir's source.

Cheers!