### PR TITLE
Remove references to Erlang types

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -36,7 +36,7 @@ defmodule IO do
 
   @type device :: atom | pid
   @type nodata :: {:error, term} | :eof
-  @type chardata() :: :unicode.chardata()
+  @type chardata :: String.t() | maybe_improper_list(char | chardata, String.t() | [])
 
   defmacrop is_iodata(data) do
     quote do

--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -12,7 +12,7 @@ defmodule Path do
   that require it (like `wildcard/2` and `expand/1`).
   """
 
-  @type t :: :unicode.chardata()
+  @type t :: IO.chardata()
 
   @doc """
   Converts the given path to an absolute one. Unlike


### PR DESCRIPTION
I think it's nicer to link to Elixir types instead of Erlang types where
we can, and these are both places where we definitely can.