### PR TITLE
Add style remark in String.next_codepoint/1

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1504,6 +1504,23 @@ defmodule String do
       iex> String.next_codepoint("olá")
       {"o", "lá"}
 
+  ## Comparison with binary pattern matching
+
+  Binary pattern matching provides a similar way to decompose
+  a string:
+
+      iex> <<codepoint::utf8, rest::binary>> = "Elixir"
+      "Elixir"
+      iex> codepoint
+      69
+      iex> rest
+      "lixir"
+
+  though not entirely equivalent because `codepoint` comes as
+  an integer, and the pattern won't match invalid UTF-8.
+
+  Binary pattern matching, however, is simpler and more efficient,
+  so pick the option that better suits your use case.
   """
   @compile {:inline, next_codepoint: 1}
   @spec next_codepoint(t) :: {codepoint, t} | nil


### PR DESCRIPTION
I believe this recommendation might be good from some chats with @josevalim this week, but I am not 100% sure.

Let me optimistically propose it. This week in AoC I used this function and would have benefited from this remark when reading the documentation of `String.next_codepoint/1`. And if it is not good, I'll learn something.

Regarding the code fences in the examples, I have seen docs don't generally use them, but seemed appropriate in this case. Of course, let me know if you'd prefer a different doctestable example.