### PR TITLE
Don't trigger ExDoc warnings on compatibility-and-deprecations page

### DIFF
--- a/lib/elixir/docs.exs
+++ b/lib/elixir/docs.exs
@@ -4,6 +4,7 @@
   groups_for_functions: [
     Guards: & &1[:guard] == true
   ],
+  skip_undefined_reference_warnings_on: ["compatibility-and-deprecations"],
   groups_for_modules: [
     # [Kernel, Kernel.SpecialForms],
 


### PR DESCRIPTION
Ref https://github.com/elixir-lang/ex_doc/pull/930