### PR TITLE
[WIP] IEx: Special case "i" helper for improper lists

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -522,6 +522,23 @@ defmodule List do
   defp decrement(counter), do: counter - 1
 
   @doc """
+  Returns `true` if `list` is an improper list. Otherwise returns `false`.
+
+  ## Examples
+
+     iex> List.improper?([1, 2 | 3])
+     true
+
+     iex> List.improper?([1, 2, 3])
+     false
+
+  """
+  @doc since: "1.8.0"
+  @spec improper?(list) :: boolean
+  def improper?(list) when is_list(list) and length(list) >= 0, do: false
+  def improper?(list) when is_list(list), do: true
+
+  @doc """
   Returns a list with `value` inserted at the specified `index`.
 
   Note that `index` is capped at the list length. Negative indices

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -185,7 +185,7 @@ defmodule ListTest do
       assert List.starts_with?([1, 2, 3], [])
     end
 
-    test "only accepts lists" do
+    test "only accepts proper lists" do
       message = "no function clause matching in List.starts_with?/2"
 
       assert_raise FunctionClauseError, message, fn ->
@@ -241,6 +241,20 @@ defmodule ListTest do
 
       assert List.myers_difference([3, 2, 0, 2], [2, 2, 1, 0, 2]) ==
                [del: [3], eq: [2], ins: [2, 1], eq: [0, 2]]
+    end
+  end
+
+  test "improper?/1" do
+    assert List.improper?([1 | 2])
+    assert List.improper?([1, 2, 3 | 4])
+    refute List.improper?([])
+    refute List.improper?([1])
+    refute List.improper?([[1]])
+    refute List.improper?([1, 2])
+    refute List.improper?([1, 2, 3])
+
+    assert_raise FunctionClauseError, fn ->
+      List.improper?(%{})
     end
   end
 end

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -122,6 +122,7 @@ defimpl IEx.Info, for: List do
         list == [] -> info_list(list)
         List.ascii_printable?(list) -> info_charlist(list)
         Keyword.keyword?(list) -> info_kw_list(list)
+        List.improper?(list) -> info_improper_list(list)
         true -> info_list(list)
       end
 
@@ -151,6 +152,20 @@ defimpl IEx.Info, for: List do
     """
 
     [{"Description", description}, {"Reference modules", "Keyword, List"}]
+  end
+
+  defp info_improper_list(_improper_list) do
+    description = """
+    This is what is referred to as an "improper list". An improper list is a
+    list which its last tail is not to an empty list. For example: [1, 2, 3]
+    is a proper list, as it is equivalent to [1, 2, 3 | []], as opposed to
+    [1, 2 | 3] which is an improper list since its last tail returns 3.
+    """
+
+    [
+      {"Description", description},
+      {"Reference modules", "List"}
+    ]
   end
 
   defp info_list(_list) do


### PR DESCRIPTION
Related discussion: https://github.com/elixir-lang/elixir/pull/8469#issuecomment-444784727

I had to create a List.improper?/1 in the same fashion of Keyword.keyword? and List.ascii_printable?

Please do not squash these two commits when merging.
