### PR TITLE
Clarify String.next_codepoint/1 re invalid UTF-8

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1494,15 +1494,20 @@ defmodule String do
   remainder of the string or `nil` in case
   the string reached its end.
 
-  As with other functions in the String module, this
-  function does not check for the validity of the codepoint.
-  That said, if an invalid codepoint is found, it will
-  be returned by this function.
+  As with other functions in the `String` module, `next_codepoint/1`
+  works with binaries that are invalid UTF-8. If the string starts
+  with a sequence of bytes that is not valid in UTF-8 encoding, the
+  first element of the returned tuple is a binary with the first byte.
 
   ## Examples
 
       iex> String.next_codepoint("olá")
       {"o", "lá"}
+
+      {first, rest} = String.next_codepoint("\x80\x80invalid UTF-8")
+      {<<128>>, <<128, 105, 110, 118, 97, 108, 105, 100>>}
+      String.next_codepoint(rest)
+      {<<128>>, "invalid UTF-8"}
 
   ## Comparison with binary pattern matching
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1487,7 +1487,7 @@ defmodule String do
   @spec codepoints(t) :: [codepoint]
   defdelegate codepoints(string), to: String.Unicode
 
-  @doc """
+  @doc ~S"""
   Returns the next codepoint in a string.
 
   The result is a tuple with the codepoint and the
@@ -1504,10 +1504,11 @@ defmodule String do
       iex> String.next_codepoint("olá")
       {"o", "lá"}
 
-      {first, rest} = String.next_codepoint("\x80\x80invalid UTF-8")
-      {<<128>>, <<128, 105, 110, 118, 97, 108, 105, 100>>}
-      String.next_codepoint(rest)
-      {<<128>>, "invalid UTF-8"}
+      iex> invalid = "\x80\x80OK" # first two bytes are invalid in UTF-8
+      iex> {_, rest} = String.next_codepoint(invalid)
+      {<<128>>, <<128, 79, 75>>}
+      iex> String.next_codepoint(rest)
+      {<<128>>, "OK"}
 
   ## Comparison with binary pattern matching
 

--- a/lib/elixir/unicode/unicode.ex
+++ b/lib/elixir/unicode/unicode.ex
@@ -284,8 +284,8 @@ defmodule String.Unicode do
     {<<cp::utf8>>, rest}
   end
 
-  def next_codepoint(<<cp, rest::binary>>) do
-    {<<cp>>, rest}
+  def next_codepoint(<<byte, rest::binary>>) do
+    {<<byte>>, rest}
   end
 
   def next_codepoint(<<>>) do


### PR DESCRIPTION
The current wording talks about the "validity of a codepoint", and says that `String.next_codepoint/1` might return an "invalid codepoint" (of which byte length?).

I think this may be confusing, because codepoints are valid by definition. Codepoints are encoded as sequences of bytes that make sense as a unit according to UTF-8. If the sequence of bytes does not make sense, you don't have a codepoint.

Let me propose this rewording, in which we carefully avoid "codepoint" and talk just bytes.

The example is not a doctest because I could not make it pass, it raised `UnicodeConversionError`.