### PR TITLE
Revamp List.ascii_printable?/2

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -449,7 +449,7 @@ defmodule List do
   end
 
   @doc """
-  Checks if a list is a charlist made only of printable ASCII characters.
+  Checks if `list` is a charlist made only of printable ASCII characters.
 
   A printable charlist in Elixir contains only ASCII characters.
 
@@ -467,58 +467,63 @@ defmodule List do
       iex> List.ascii_printable?('abc' ++ [0], 2)
       true
 
-  Improper lists are not printable, even if made only of ascii characters:
+  Improper lists are not printable, even if made only of ASCII characters:
 
       iex> List.ascii_printable?('abc' ++ ?d)
       false
 
   """
   @doc since: "1.6.0"
-  def ascii_printable?(list, counter \\ :infinity)
+  @spec ascii_printable?(list, limit) :: boolean
+        when limit: :infinity | non_neg_integer
+  def ascii_printable?(list, limit \\ :infinity)
+      when is_list(list) and (limit == :infinity or (is_integer(limit) and limit >= 0)) do
+    ascii_printable_guarded?(list, limit)
+  end
 
-  def ascii_printable?(_, 0) do
+  defp ascii_printable_guarded?(_, 0) do
     true
   end
 
-  def ascii_printable?([char | rest], counter)
-      when is_integer(char) and char >= 32 and char <= 126 do
-    ascii_printable?(rest, decrement(counter))
+  defp ascii_printable_guarded?([char | rest], counter)
+       when is_integer(char) and char >= 32 and char <= 126 do
+    ascii_printable_guarded?(rest, decrement(counter))
   end
 
-  def ascii_printable?([?\n | rest], counter) do
-    ascii_printable?(rest, decrement(counter))
+  defp ascii_printable_guarded?([?\n | rest], counter) do
+    ascii_printable_guarded?(rest, decrement(counter))
   end
 
-  def ascii_printable?([?\r | rest], counter) do
-    ascii_printable?(rest, decrement(counter))
+  defp ascii_printable_guarded?([?\r | rest], counter) do
+    ascii_printable_guarded?(rest, decrement(counter))
   end
 
-  def ascii_printable?([?\t | rest], counter) do
-    ascii_printable?(rest, decrement(counter))
+  defp ascii_printable_guarded?([?\t | rest], counter) do
+    ascii_printable_guarded?(rest, decrement(counter))
   end
 
-  def ascii_printable?([?\v | rest], counter) do
-    ascii_printable?(rest, decrement(counter))
+  defp ascii_printable_guarded?([?\v | rest], counter) do
+    ascii_printable_guarded?(rest, decrement(counter))
   end
 
-  def ascii_printable?([?\b | rest], counter) do
-    ascii_printable?(rest, decrement(counter))
+  defp ascii_printable_guarded?([?\b | rest], counter) do
+    ascii_printable_guarded?(rest, decrement(counter))
   end
 
-  def ascii_printable?([?\f | rest], counter) do
-    ascii_printable?(rest, decrement(counter))
+  defp ascii_printable_guarded?([?\f | rest], counter) do
+    ascii_printable_guarded?(rest, decrement(counter))
   end
 
-  def ascii_printable?([?\e | rest], counter) do
-    ascii_printable?(rest, decrement(counter))
+  defp ascii_printable_guarded?([?\e | rest], counter) do
+    ascii_printable_guarded?(rest, decrement(counter))
   end
 
-  def ascii_printable?([?\a | rest], counter) do
-    ascii_printable?(rest, decrement(counter))
+  defp ascii_printable_guarded?([?\a | rest], counter) do
+    ascii_printable_guarded?(rest, decrement(counter))
   end
 
-  def ascii_printable?([], _counter), do: true
-  def ascii_printable?(_, _counter), do: false
+  defp ascii_printable_guarded?([], _counter), do: true
+  defp ascii_printable_guarded?(_, _counter), do: false
 
   @compile {:inline, decrement: 1}
   defp decrement(:infinity), do: :infinity

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -257,4 +257,23 @@ defmodule ListTest do
       List.improper?(%{})
     end
   end
+
+  describe "ascii_printable?/1" do
+    test "proper lists without limit" do
+      assert List.ascii_printable?([])
+      assert List.ascii_printable?('abc')
+      refute(List.ascii_printable?('abc' ++ [0]))
+      assert List.ascii_printable?('abc \a\b\e\f\n\r\t\v def')
+      refute List.ascii_printable?('mañana')
+    end
+
+    test "proper lists with limit" do
+      assert List.ascii_printable?([], 100)
+      assert List.ascii_printable?('abc' ++ [0], 2)
+    end
+
+    test "improper lists" do
+      refute List.ascii_printable?('abc' ++ ?d)
+    end
+  end
 end


### PR DESCRIPTION
- Simplify logic
- Add specs
- Validate specs with guards, raising on non-lists
- Add tests
- Correct documentation about improper lists
- Rename argument `counter` to `limit`