### PR TITLE
Stricter link check in IO.ANSI.Docs module

### DIFF
--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -524,7 +524,7 @@ defmodule IO.ANSI.Docs do
   end
 
   defp escape_underlines_in_link(text) do
-    ~r{https?\S*}
+    ~r{https?://\S*}
     |> Regex.recompile!()
     |> Regex.replace(text, &String.replace(&1, "_", "\\_"))
   end

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -364,7 +364,7 @@ defmodule IO.ANSI.DocsTest do
              "  [id]: //example.com\n  [Elixir]:  https://elixir-lang.org"
   end
 
-  test "should not escape _ inside backtick" do
+  test "should not escape _ surrounded by backtick" do
     assert format("`https_proxy`") == "\e[36mhttps_proxy\e[0m\n\e[0m"
   end
 end

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -363,4 +363,8 @@ defmodule IO.ANSI.DocsTest do
     assert format("  [id]: //example.com\n  [Elixir]:  https://elixir-lang.org") ==
              "  [id]: //example.com\n  [Elixir]:  https://elixir-lang.org"
   end
+
+  test "should not escape _ inside backtick" do
+    assert format("`https_proxy`") == "\e[36mhttps_proxy\e[0m\n\e[0m"
+  end
 end

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -313,6 +313,10 @@ defmodule IO.ANSI.DocsTest do
              "\e[4memphasis\e[0m (https://en.wikipedia.org/wiki/ANSI_escape_code) more \e[4memphasis\e[0m\n\e[0m"
   end
 
+  test "escaping of underlines within links avoids false positives" do
+    assert format("`https_proxy`") == "\e[36mhttps_proxy\e[0m\n\e[0m"
+  end
+
   test "lone thing that looks like a table line isn't" do
     assert format("one\n2 | 3\ntwo\n") == "one 2 | 3 two\n\e[0m"
   end
@@ -362,9 +366,5 @@ defmodule IO.ANSI.DocsTest do
   test "one reference link label per line" do
     assert format("  [id]: //example.com\n  [Elixir]:  https://elixir-lang.org") ==
              "  [id]: //example.com\n  [Elixir]:  https://elixir-lang.org"
-  end
-
-  test "should not escape _ surrounded by backtick" do
-    assert format("`https_proxy`") == "\e[36mhttps_proxy\e[0m\n\e[0m"
   end
 end


### PR DESCRIPTION
This is a naive fix of formatting "`http_bar`", but will not fix "`http://elixir.org/foo_bar`".

Closes #8449 