### PR TITLE
Fix IEx.Server test

### DIFF
--- a/lib/iex/test/iex/server_test.exs
+++ b/lib/iex/test/iex/server_test.exs
@@ -13,9 +13,7 @@ defmodule IEx.ServerTest do
     end
 
     test "env" do
-      assert capture_io("__ENV__.file", fn ->
-               IEx.Server.run(env: __ENV__)
-             end) =~ "server_test.exs"
+      assert capture_iex("__ENV__.file", [], env: __ENV__) =~ "server_test.exs"
     end
   end
 


### PR DESCRIPTION
Closes #8493 

I analyzed similar tests using `ExUnit.CaptureIO.capture_io`, and found out the culprit being the undocumented option in IEx.Server, `:dot_iex_path` which should be set to `""`.
I found more descriptive to use the helper `capture_iex`, than to pass `:dot_iex_path` as an option.

Should we document `:dot_iex_path` as an available option in IEx.Server docs?