### PR TITLE
IO.ANSI.Docs: Make regex in escape_underlines_in_link/1 handle all schemes

### DIFF
--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -524,7 +524,8 @@ defmodule IO.ANSI.Docs do
   end
 
   defp escape_underlines_in_link(text) do
-    ~r{https?://\S*}
+    # Regular expression adapted from https://tools.ietf.org/html/rfc3986#appendix-B
+    ~r{[a-z][a-z0-9+-.]*://\S*}i
     |> Regex.recompile!()
     |> Regex.replace(text, &String.replace(&1, "_", "\\_"))
   end

--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -525,7 +525,7 @@ defmodule IO.ANSI.Docs do
 
   defp escape_underlines_in_link(text) do
     # Regular expression adapted from https://tools.ietf.org/html/rfc3986#appendix-B
-    ~r{[a-z][a-z0-9+-.]*://\S*}i
+    ~r{[a-z][a-z0-9\+\-\.]*://\S*}i
     |> Regex.recompile!()
     |> Regex.replace(text, &String.replace(&1, "_", "\\_"))
   end

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -302,8 +302,12 @@ defmodule IO.ANSI.DocsTest do
   test "escaping of underlines within links" do
     result = format("(https://en.wikipedia.org/wiki/ANSI_escape_code)")
     assert result == "(https://en.wikipedia.org/wiki/ANSI_escape_code)\n\e[0m"
+
     result = format("[ANSI escape code](https://en.wikipedia.org/wiki/ANSI_escape_code)")
     assert result == "ANSI escape code (https://en.wikipedia.org/wiki/ANSI_escape_code)\n\e[0m"
+
+    result = format("(ftp://example.com/ANSI_escape_code.zip)")
+    assert result == "(ftp://example.com/ANSI_escape_code.zip)\n\e[0m"
   end
 
   test "escaping of underlines within links does not escape surrounding text" do


### PR DESCRIPTION
It follows the same rules as URI.parse/1
Related to #8494