### PR TITLE
Simplify regex in URI.parse/1

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -447,9 +447,7 @@ defmodule URI do
   def parse(string) when is_binary(string) do
     # From https://tools.ietf.org/html/rfc3986#appendix-B
     regex =
-      Regex.recompile!(
-        ~r/^(([a-z][a-z0-9\+\-\.]*):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/i
-      )
+      Regex.recompile!(~r{^(([a-z][a-z0-9+-.]*):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?}i)
 
     parts = Regex.run(regex, string)
 


### PR DESCRIPTION
It removes the unnecessary escaping.