### PR TITLE
Use System.os_time/1 in the Erlang compiler as well

### DIFF
--- a/lib/mix/lib/mix/compilers/erlang.ex
+++ b/lib/mix/lib/mix/compilers/erlang.ex
@@ -82,7 +82,7 @@ defmodule Mix.Compilers.Erlang do
     stale = for {:stale, src, dest} <- mappings, do: {src, dest}
 
     # Get the previous entries from the manifest
-    timestamp = :calendar.universal_time()
+    timestamp = System.os_time(:second)
     entries = read_manifest(manifest)
 
     # Files to remove are the ones in the manifest

--- a/lib/mix/lib/mix/tasks/compile.xref.ex
+++ b/lib/mix/lib/mix/tasks/compile.xref.ex
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Compile.Xref do
   end
 
   defp run_xref do
-    timestamp = :calendar.universal_time()
+    timestamp = System.os_time(:second)
     warnings = Mix.Tasks.Xref.warnings([])
     write_manifest(warnings, timestamp)
     warnings


### PR DESCRIPTION
Follow up on 499446737ea0008bbb1c69a3e2f953fc7e1fedae that already did it for the Elixir compiler.