### PR TITLE
use System.os_time

### DIFF
--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -33,7 +33,7 @@ defmodule Mix.Compilers.Elixir do
     # We fetch the time from before we read files so any future
     # change to files are still picked up by the compiler. This
     # timestamp is used when writing BEAM files and the manifest.
-    timestamp = :calendar.universal_time()
+    timestamp = System.os_time(:second)
     all_paths = MapSet.new(Mix.Utils.extract_files(srcs, exts))
 
     {all_modules, all_sources} = parse_manifest(manifest, dest)

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -33,7 +33,7 @@ defmodule Mix.Compilers.Elixir do
     # We fetch the time from before we read files so any future
     # change to files are still picked up by the compiler. This
     # timestamp is used when writing BEAM files and the manifest.
-    timestamp = System.os_time(:second)
+    timestamp = :calendar.universal_time()
     all_paths = MapSet.new(Mix.Utils.extract_files(srcs, exts))
 
     {all_modules, all_sources} = parse_manifest(manifest, dest)

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -176,7 +176,7 @@ defmodule Mix.Utils do
   (1970-01-01 00:00:00).
   """
   def last_modified_and_size(path) do
-    now = System.system_time(:second)
+    now = System.os_time(:second)
 
     case :elixir_utils.read_posix_mtime_and_size(path) do
       {:ok, mtime, size} when mtime > now ->


### PR DESCRIPTION
OS time must be used when comparing against file system timestamps.