### PR TITLE
Add $callers tracking to Task

### DIFF
--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -192,7 +192,7 @@ defmodule Logger.Backends.Console do
   end
 
   defp take_metadata(metadata, :all) do
-    Keyword.drop(metadata, [:crash_reason])
+    Keyword.drop(metadata, [:crash_reason, :ancestors, :callers])
   end
 
   defp take_metadata(metadata, keys) do

--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -512,6 +512,8 @@ defmodule Logger.TranslatorTest do
 
     assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
 
+    assert is_pid(process_metadata[:pid])
+    assert is_list(process_metadata[:ancestors])
     assert process_metadata[:foo] == :bar
     assert {%RuntimeError{message: "oops"}, [_ | _]} = process_metadata[:crash_reason]
   end
@@ -634,7 +636,7 @@ defmodule Logger.TranslatorTest do
            Message Queue Length: 1
            Messages: \[:message\]
            Links: \[\]
-           Dictionary: \[\]
+           Dictionary: \["\$callers": \[#PID<\d+\.\d+\.\d+>\]\]
            Trapping Exits: false
            Status: :running
            Heap Size: \d+
@@ -644,6 +646,10 @@ defmodule Logger.TranslatorTest do
 
     assert_receive {:error, _pid, {Logger, ["Task " <> _ | _], _ts, task_metadata}}
     assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+
+    assert process_metadata[:pid] == task_metadata[:pid]
+    assert is_list(process_metadata[:callers])
+    assert is_list(process_metadata[:ancestors])
 
     assert {%RuntimeError{message: "oops"}, [_ | _]} = task_metadata[:crash_reason]
     assert {%RuntimeError{message: "oops"}, [_ | _]} = process_metadata[:crash_reason]


### PR DESCRIPTION
This allows us to track which process invoked the Task
besides its ancestors in the supervision tree.

Closes #7995