### PR TITLE
Add powershell environment to iex documentation

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -48,6 +48,10 @@ defmodule IEx do
 
       set ERL_AFLAGS "-kernel shell_history enabled"
 
+  On Windows10 / Powershell:
+
+      $env:ERL_AFLAGS = "-kernel shell_history enabled"
+
   ## Expressions in IEx
 
   As an interactive shell, IEx evaluates expressions. This has some


### PR DESCRIPTION
As requested at:  https://github.com/elixir-lang/elixir/pull/8508#discussion_r240724685

If someone else could please test to verify, it works here but I don't know if work did anything to the powershell on these computers and I don't have Windows anywhere else to test.

Actually... just downloaded powershell onto linux as well (should this section just be called powershell since PS works on many OS's now?) and tested it there as well, looks good:
```powershell
PS /home/overminddl1/elixir/elixir> $env:ERL_AFLAGS = "-kernel shell_history enabled"
PS /home/overminddl1/elixir/elixir> $env:ERL_AFLAGS                                  
-kernel shell_history enabled
PS /home/overminddl1/elixir/elixir> bash -c 'echo $ERL_AFLAGS'                       
-kernel shell_history enabled
```