### PR TITLE
Add shortcut built-in type nonempty_improper_list/0

### DIFF
--- a/lib/elixir/lib/code/typespec.ex
+++ b/lib/elixir/lib/code/typespec.ex
@@ -382,6 +382,10 @@ defmodule Code.Typespec do
     typespec_to_quoted({:type, line, :as_boolean, [arg]})
   end
 
+  defp remote_type(line, {:atom, _, :elixir}, {:atom, _, :nonempty_improper_list}, []) do
+    typespec_to_quoted({:type, line, :nonempty_improper_list, [{:any, [], []}, {:any, [], []}]})
+  end
+
   defp remote_type(line, {:atom, _, :elixir}, {:atom, _, :keyword}, args) do
     typespec_to_quoted({:type, line, :keyword, args})
   end

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -387,6 +387,7 @@ defmodule Kernel.Typespec do
   defp built_in_type?(:keyword, 0), do: true
   defp built_in_type?(:keyword, 1), do: true
   defp built_in_type?(:var, 0), do: true
+  defp built_in_type?(:nonempty_improper_list, 0), do: true
   defp built_in_type?(name, arity), do: :erl_internal.is_type(name, arity)
 
   defp ensure_no_defaults!(args) do
@@ -778,6 +779,10 @@ defmodule Kernel.Typespec do
 
   defp typespec({:as_boolean, _meta, [arg]}, vars, caller, state) do
     typespec(quote(do: :elixir.as_boolean(unquote(arg))), vars, caller, state)
+  end
+
+  defp typespec({:nonempty_improper_list, _meta, []}, vars, caller, state) do
+    typespec(quote(do: :elixir.nonempty_improper_list()), vars, caller, state)
   end
 
   defp typespec({:keyword, _meta, args}, vars, caller, state) when length(args) <= 1 do

--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -140,6 +140,7 @@ Built-in type           | Defined as
 `list()`                | `[any()]`
 `nonempty_list()`       | `nonempty_list(any())`
 `maybe_improper_list()` | `maybe_improper_list(any(), any())`
+`nonempty_improper_list()`       | `nonempty_improper_list(any(), any())`
 `nonempty_maybe_improper_list()` | `nonempty_maybe_improper_list(any(), any())`
 `mfa()`                 | `{module(), atom(), arity()}`
 `module()`              | `atom()`

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -11,11 +11,13 @@
 
 %% Top level types
 %% TODO: Remove char_list type by 2.0
--export_type([charlist/0, char_list/0, nonempty_charlist/0, struct/0, as_boolean/1, keyword/0, keyword/1]).
+-export_type([charlist/0, char_list/0, nonempty_charlist/0, struct/0, as_boolean/1,
+              nonempty_improper_list/0, keyword/0, keyword/1]).
 -type charlist() :: string().
 -type char_list() :: string().
 -type nonempty_charlist() :: nonempty_string().
 -type as_boolean(T) :: T.
+-type nonempty_improper_list() :: nonempty_improper_list(any(), any()).
 -type keyword() :: [{atom(), any()}].
 -type keyword(T) :: [{atom(), T}].
 -type struct() :: #{'__struct__' := atom(), atom() => any()}.

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -1283,6 +1283,10 @@ defmodule TypespecTest do
           {:built_in_nonempty_list, _, _} ->
             assert ast_string == "@type(built_in_nonempty_list() :: [...])"
 
+          {:built_in_nonempty_improper_list, _, _} ->
+            assert ast_string ==
+                     "@type(built_in_nonempty_improper_list() :: nonempty_improper_list(any(), any()))"
+
           _ ->
             assert ast_string == Macro.to_string(definition)
         end


### PR DESCRIPTION
Basic list types have built-in shortcuts:

  * `list(type)` has `list()` which is defined as `[any()]`
  * `nonempty_list(type)` has `nonempty_list()` defined as `nonempty_list(any())`
  * `maybe_improper_list(type1, type2)` has `maybe_improper_list()` defined as  `maybe_improper_list(any(), any())`
  * `nonempty_maybe_improper_list(type1, type2)` has `nonempty_maybe_improper_list()` defined as `nonempty_maybe_improper_list(any(), any())`

but
* `nonempty_improper_list(type1, type2)` doesn't have `nonempty_improper_list()` which should be  defined as `nonempty_improper_list(any(), any())`

This PR adds it.