### PR TITLE
Add option to inspect tuples as records

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -236,7 +236,7 @@ defimpl Inspect, for: Tuple do
     [record_name | values] = list
 
     case record_fields(opts.records, record_name, tuple) do
-      {:ok, fields} ->
+      {:ok, {_module, fields}} ->
         inspect_record(record_name, fields, values, opts)
 
       _ ->
@@ -245,18 +245,8 @@ defimpl Inspect, for: Tuple do
   end
 
   defp record_fields(records, record_name, tuple) do
-    with {:ok, fields} <- Map.fetch(records, record_name),
-         validate_fields(fields, records),
-         true <- length(fields) == tuple_size(tuple) - 1,
-         do: {:ok, fields}
-  end
-
-  defp validate_fields(fields, _records) when is_list(fields), do: true
-
-  defp validate_fields(fields, records) do
-    raise ArgumentError,
-          "expected a list of field names, got #{Kernel.inspect(fields)}" <>
-            " in #{Kernel.inspect(records)}"
+    fields_size = tuple_size(tuple) - 1
+    Map.fetch(records, {record_name, fields_size})
   end
 
   defp inspect_tuple(list, opts) do

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -80,6 +80,13 @@ defmodule Inspect.Opts do
       iex> person(name: "Alice", email: "alice@example.com") |> inspect(opts)
       "#person(name: \"Alice\", email: \"alice@example.com\")"
 
+  Some functions, e.g. `IEx.configure/1`, provide a way to automatically extract
+  record fields from the modules that define them:
+
+      iex> IEx.configure(inspect: [records: %{person: Records}])
+      iex> person(name: "Alice", email: "alice@example.com")
+      #person(name: "Alice", email: "alice@example.com")
+
   """
 
   # TODO: Remove :char_lists key on v2.0

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -34,13 +34,8 @@ defmodule Inspect.Opts do
 
     * `:pretty` - if set to `true` enables pretty printing, defaults to `false`.
 
-    * `:records` - map of records that should be formatted, defaults to `%{}`.
-
-       For example, if we have a `{:person, "Alice", "alice@example.com"}` record,
-       by default it would be formatted as any other tuple.
-       By setting `[records: %{person: [:name, :email]}]` it would be formatted as:
-
-          #person(name: "Alice", email: "alice@example.com")
+    * `:records` - map of records and their fields that should be formatted,
+      defaults to `%{}`. See section "Records" below for more information.
 
     * `:width` - defaults to 80 characters, used when pretty is `true` or when
       printing to IO devices. Set to 0 to force each item to be printed on its
@@ -61,6 +56,29 @@ defmodule Inspect.Opts do
       each type (for example, `[number: :red, atom: :blue]`). Types can include
       `:number`, `:atom`, `regex`, `:tuple`, `:map`, `:list`, and `:reset`.
       Colors can be any `t:IO.ANSI.ansidata/0` as accepted by `IO.ANSI.format/1`.
+
+  ## Records
+
+  The `:records` option allows to format tuples as records.
+
+  Let's say we have a `person` record defined in `Records` module.
+
+      defmodule Records do
+        import Record
+        defrecord :person, [:name, :email]
+      end
+
+  Since record is just a tuple, by default it's formatted as such:
+
+      iex> import Records
+      iex> person(name: "Alice", email: "alice@example.com")
+      {:person, "Alice", "alice@example.com"}
+
+  By setting the `:records` option we can ensure they will be formatted as records:
+
+      iex> opts = [records: %{person: [:name, :email]}]
+      iex> person(name: "Alice", email: "alice@example.com") |> inspect(opts)
+      "#person(name: \"Alice\", email: \"alice@example.com\")"
 
   """
 

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -34,6 +34,14 @@ defmodule Inspect.Opts do
 
     * `:pretty` - if set to `true` enables pretty printing, defaults to `false`.
 
+    * `:records` - map of records that should be formatted, defaults to `%{}`.
+
+       For example, if we have a `{:person, "Alice", "alice@example.com"}` record,
+       by default it would be formatted as any other tuple.
+       By setting `[records: %{person: [:name, :email]}]` it would be formatted as:
+
+          #person(name: "Alice", email: "alice@example.com")
+
     * `:width` - defaults to 80 characters, used when pretty is `true` or when
       printing to IO devices. Set to 0 to force each item to be printed on its
       own line. If you don't want to limit the number of items to a particular
@@ -66,6 +74,7 @@ defmodule Inspect.Opts do
             width: 80,
             base: :decimal,
             pretty: false,
+            records: %{},
             safe: true,
             syntax_colors: []
 
@@ -82,6 +91,7 @@ defmodule Inspect.Opts do
           width: pos_integer | :infinity,
           base: :decimal | :binary | :hex | :octal,
           pretty: boolean,
+          records: %{optional(atom) => [atom()]},
           safe: boolean,
           syntax_colors: [{color_key, IO.ANSI.ansidata()}]
         }

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -113,6 +113,18 @@ defmodule Inspect.Opts do
           safe: boolean,
           syntax_colors: [{color_key, IO.ANSI.ansidata()}]
         }
+
+  @doc false
+  def normalize_records(records) do
+    Enum.into(records, %{}, fn
+      {record_name, fields} when is_list(fields) ->
+        {record_name, fields}
+
+      {record_name, module} when is_atom(module) ->
+        fields = module.__record__(record_name)
+        {record_name, fields}
+    end)
+  end
 end
 
 defmodule Inspect.Error do

--- a/lib/elixir/lib/record.ex
+++ b/lib/elixir/lib/record.ex
@@ -277,6 +277,10 @@ defmodule Record do
       defmacro unquote(name)(record, args) do
         Record.__access__(unquote(tag), unquote(fields), record, args, __CALLER__)
       end
+
+      def __record__(unquote(name)) do
+        unquote(Keyword.keys(fields))
+      end
     end
   end
 

--- a/lib/elixir/test/elixir/inspect/algebra_test.exs
+++ b/lib/elixir/test/elixir/inspect/algebra_test.exs
@@ -280,3 +280,21 @@ defmodule Inspect.AlgebraTest do
     assert sm.([empty() | "b"]) |> render(80) == "[b]"
   end
 end
+
+defmodule Inspect.OptsTest do
+  use ExUnit.Case, async: true
+
+  require Record
+  Record.defrecord(:person, [:name])
+
+  describe "normalize_records/1" do
+    test "with fields" do
+      assert Inspect.Opts.normalize_records(person: [:name]) == %{person: [:name]}
+      assert Inspect.Opts.normalize_records(%{person: [:name]}) == %{person: [:name]}
+    end
+
+    test "with module" do
+      assert Inspect.Opts.normalize_records(person: __MODULE__) == %{person: [:name]}
+    end
+  end
+end

--- a/lib/elixir/test/elixir/inspect/algebra_test.exs
+++ b/lib/elixir/test/elixir/inspect/algebra_test.exs
@@ -284,17 +284,27 @@ end
 defmodule Inspect.OptsTest do
   use ExUnit.Case, async: true
 
-  require Record
-  Record.defrecord(:person, [:name])
+  defmodule Person1 do
+    require Record
+    Record.defrecord(:person, [:name])
+  end
+
+  defmodule Person2 do
+    require Record
+    Record.defrecord(:person, [:name, :email])
+  end
 
   describe "normalize_records/1" do
     test "with fields" do
-      assert Inspect.Opts.normalize_records(person: [:name]) == %{person: [:name]}
-      assert Inspect.Opts.normalize_records(%{person: [:name]}) == %{person: [:name]}
+      normalized = %{{:person, 1} => {Person1, [:name]}}
+      assert Inspect.Opts.normalize_records(normalized) == normalized
     end
 
     test "with module" do
-      assert Inspect.Opts.normalize_records(person: __MODULE__) == %{person: [:name]}
+      assert Inspect.Opts.normalize_records(person: Person1, person: Person2) == %{
+               {:person, 1} => {Person1, [:name]},
+               {:person, 2} => {Person2, [:name, :email]}
+             }
     end
   end
 end

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -271,10 +271,8 @@ defmodule Inspect.TupleTest do
     test "invalid fields in inspect opts" do
       opts = [records: %{person: :bad}]
       person = person(name: "Alice", email: "alice@example.com")
-
-      assert_raise ArgumentError, "expected a list of field names, got :bad in %{person: :bad}", fn ->
-        inspect(person, opts)
-      end
+      expected_message = "expected a list of field names, got :bad in %{person: :bad}"
+      assert_raise ArgumentError, expected_message, fn -> inspect(person, opts) end
     end
 
     test "colors" do

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -268,6 +268,15 @@ defmodule Inspect.TupleTest do
       assert inspect({:person, "Alice"}, opts) == ~s|{:person, "Alice"}|
     end
 
+    test "invalid fields in inspect opts" do
+      opts = [records: %{person: :bad}]
+      person = person(name: "Alice", email: "alice@example.com")
+
+      assert_raise ArgumentError, "expected a list of field names, got :bad in %{person: :bad}", fn ->
+        inspect(person, opts)
+      end
+    end
+
     test "colors" do
       opts = [
         records: %{person: [:name, :email]},

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -251,6 +251,35 @@ defmodule Inspect.TupleTest do
     assert inspect({:x, :y}, opts) ==
              "\e[32m{\e[36m\e[31m:x\e[36m\e[32m,\e[36m \e[31m:y\e[36m\e[32m}\e[36m"
   end
+
+  require Record
+  Record.defrecord(:person, [:name, :email])
+
+  describe "records" do
+    test "matching tuple" do
+      opts = [records: %{person: [:name, :email]}]
+      person = person(name: "Alice", email: "alice@example.com")
+      assert inspect(person, opts) == ~s|#person(name: "Alice", email: "alice@example.com")|
+    end
+
+    test "no match" do
+      opts = [records: %{person: [:name, :email]}]
+      assert inspect({:person}, opts) == ~s|{:person}|
+      assert inspect({:person, "Alice"}, opts) == ~s|{:person, "Alice"}|
+    end
+
+    test "colors" do
+      opts = [
+        records: %{person: [:name, :email]},
+        syntax_colors: [tuple: :green, reset: :cyan, atom: :red]
+      ]
+
+      person = person(name: "Alice", email: "alice@example.com")
+
+      assert inspect(person, opts) ==
+               "\e[32m#person(\e[36m\e[31mname:\e[36m \"Alice\"\e[32m,\e[36m \e[31memail:\e[36m \"alice@example.com\"\e[32m)\e[36m"
+    end
+  end
 end
 
 defmodule Inspect.ListTest do

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -257,27 +257,20 @@ defmodule Inspect.TupleTest do
 
   describe "records" do
     test "matching tuple" do
-      opts = [records: %{person: [:name, :email]}]
+      opts = [records: %{{:person, 2} => {__MODULE__, [:name, :email]}}]
       person = person(name: "Alice", email: "alice@example.com")
       assert inspect(person, opts) == ~s|#person(name: "Alice", email: "alice@example.com")|
     end
 
     test "no match" do
-      opts = [records: %{person: [:name, :email]}]
+      opts = [records: %{{:person, 2} => {__MODULE__, [:name, :email]}}]
       assert inspect({:person}, opts) == ~s|{:person}|
       assert inspect({:person, "Alice"}, opts) == ~s|{:person, "Alice"}|
     end
 
-    test "invalid fields in inspect opts" do
-      opts = [records: %{person: :bad}]
-      person = person(name: "Alice", email: "alice@example.com")
-      expected_message = "expected a list of field names, got :bad in %{person: :bad}"
-      assert_raise ArgumentError, expected_message, fn -> inspect(person, opts) end
-    end
-
     test "colors" do
       opts = [
-        records: %{person: [:name, :email]},
+        records: %{{:person, 2} => {__MODULE__, [:name, :email]}},
         syntax_colors: [tuple: :green, reset: :cyan, atom: :red]
       ]
 

--- a/lib/elixir/test/elixir/record_test.exs
+++ b/lib/elixir/test/elixir/record_test.exs
@@ -127,6 +127,16 @@ defmodule RecordTest do
     refute match?(user(_: "other"), user())
   end
 
+  test "__record__/1" do
+    assert __record__(:timestamp) == [:date, :time]
+    assert __record__(:user) == [:name, :age]
+
+    # private record
+    assert_raise FunctionClauseError, fn ->
+      __record__(:certificate)
+    end
+  end
+
   Record.defrecord(
     :defaults,
     struct: ~D[2016-01-01],

--- a/lib/iex/lib/iex/config.ex
+++ b/lib/iex/lib/iex/config.ex
@@ -112,6 +112,7 @@ defmodule IEx.Config do
     Application.get_env(:iex, :inspect, [])
     |> Keyword.put_new_lazy(:width, &width/0)
     |> update_syntax_colors()
+    |> Keyword.update(:records, %{}, &Inspect.Opts.normalize_records(&1))
   end
 
   defp update_syntax_colors(opts) do


### PR DESCRIPTION
Proposal: https://groups.google.com/forum/#!topic/elixir-lang-core/UlQIfOgNdK0

* Add `:records` key to `Inspect.Opts`

* Update `Inspect.Tuple` to format tuples as records
  if they are found in `opts.records`

* `defrecord` macro now defines a `__record__/1` function

Elixir example:

```elixir
# grab module from a manifest
iex -S mix
iex> [manifest] = Mix.Tasks.Compile.Elixir.manifests()
iex> module = Mix.Compilers.Elixir.read_manifest(manifest, "") |> hd()

iex> module
{:module, String.Chars.Decimal, {:impl, String.Chars}, ["lib/decimal.ex"],
 "Elixir.String.Chars.Decimal.beam", nil, nil}

iex> IEx.configure(inspect: [records: [module: Mix.Compilers.Elixir]])
iex> module
#module(
  module: String.Chars.Decimal,
  kind: {:impl, String.Chars},
  sources: ["lib/decimal.ex"],
  beam: "Elixir.String.Chars.Decimal.beam",
  binary: nil,
  struct: nil
)
```

Erlang example:

```elixir
# grab `file_info` record fields
iex> records = for {name, fields} <- Record.extract_all(from_lib: "kernel/include/file.hrl"), into: %{}, do: {{name, length(fields)}, {nil, Keyword.keys(fields)}
iex> inspect_opts = [records: records]
iex> {:ok, file_info} = :file.read_file_info("README.md")
iex> IO.inspect(file_info, inspect_opts)
#file_info(
  size: 4712,
  type: :regular,
  access: :read_write,
  atime: {{2018, 11, 27}, {13, 56, 3}},
  mtime: {{2018, 11, 23}, {22, 42, 6}},
  ctime: {{2018, 11, 23}, {22, 42, 6}},
  mode: 33188,
  links: 1,
  major_device: 16777223,
  minor_device: 0,
  inode: 5936255,
  uid: 501,
  gid: 20
)
{:file_info, 4712, :regular, :read_write, {{2018, 11, 27}, {13, 56, 3}},
 {{2018, 11, 23}, {22, 42, 6}}, {{2018, 11, 23}, {22, 42, 6}}, 33188, 1,
 16777223, 0, 5936255, 501, 20}
```

Possible future work:

  * [x] Make it easier to extract record fields from Elixir modules

  * Support `:only` and `:except` options, similarly to `@derive {Inspect, ...}`, e.g.:

    ```elixir
    iex> inspect_opts = %{module: {Mix.Compilers.Elixir, only: [:module]}}
    iex> IO.inspect(module)
    #module(module: String.Chars.Decimal, ...)
    ```