### PR TITLE
Add missing typespecs to Macro.underscore/1 and Macro.do_underscore/2

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1422,7 +1422,6 @@ defmodule Macro do
     ""
   end
 
-  @spec do_underscore(String.t(), char) :: String.t()
   defp do_underscore(<<h, t, rest::binary>>, _)
        when h >= ?A and h <= ?Z and not (t >= ?A and t <= ?Z) and t != ?. and t != ?_ do
     <<?_, to_lower_char(h), t>> <> do_underscore(rest, t)

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1408,6 +1408,7 @@ defmodule Macro do
       "Hello10"
 
   """
+  @spec underscore(atom | String.t()) :: String.t()
   def underscore(atom) when is_atom(atom) do
     "Elixir." <> rest = Atom.to_string(atom)
     underscore(rest)
@@ -1421,6 +1422,7 @@ defmodule Macro do
     ""
   end
 
+  @spec do_underscore(String.t(), char) :: String.t()
   defp do_underscore(<<h, t, rest::binary>>, _)
        when h >= ?A and h <= ?Z and not (t >= ?A and t <= ?Z) and t != ?. and t != ?_ do
     <<?_, to_lower_char(h), t>> <> do_underscore(rest, t)


### PR DESCRIPTION
Was poking around in the `Macro` module and realized these functions were missing `@spec`s.