### PR TITLE
Deprecate `%{key => value}` in typespecs

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -1077,7 +1077,7 @@ defmodule Code do
           | {:error, :module_not_found | :chunk_not_found | {:invalid_chunk, binary}}
         when annotation: :erl_anno.anno(),
              beam_language: :elixir | :erlang | :lfe | :alpaca | atom(),
-             doc_content: %{binary => binary} | :none | :hidden,
+             doc_content: %{required(binary) => binary} | :none | :hidden,
              doc_element:
                {{kind :: atom, function_name :: atom, arity}, annotation, signature, doc_content,
                 metadata},

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -503,12 +503,12 @@ defmodule Kernel.Typespec do
           {{:type, line(meta2), :map_field_assoc, [arg1, arg2]}, state}
 
         {k, v}, state ->
-          # TODO: Warn on Elixir v1.8 (since v1.6 is the first version to drop support for 18 and
-          # older)
-          # warning =
-          #   "invalid map specification. %{foo => bar} is deprecated in favor of " <>
-          #   "%{required(foo) => bar} and %{optional(foo) => bar}."
-          # :elixir_errors.warn(caller.line, caller.file, warning)
+          warning =
+            "invalid map specification. %{foo => bar} is deprecated in favor of " <>
+              "%{required(foo) => bar} and %{optional(foo) => bar}."
+
+          :elixir_errors.warn(caller.line, caller.file, warning)
+
           {arg1, state} = typespec(k, vars, caller, state)
           {arg2, state} = typespec(v, vars, caller, state)
           {{:type, line(meta), :map_field_assoc, [arg1, arg2]}, state}

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -69,8 +69,8 @@ defmodule Macro.Env do
   @typep vars :: [variable]
   @typep var_type :: :term
   @typep var_version :: non_neg_integer
-  @typep unused_vars :: %{{variable, var_version} => non_neg_integer | false}
-  @typep current_vars :: %{variable => {var_version, var_type}}
+  @typep unused_vars :: %{optional({variable, var_version}) => non_neg_integer | false}
+  @typep current_vars :: %{optional(variable) => {var_version, var_type}}
   @typep prematch_vars :: current_vars | :warn | :raise | :pin | :apply
   @typep contextual_vars :: [atom]
 

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -128,7 +128,7 @@ defmodule URI do
       %{"percent" => "oh yes!", "starting" => "map"}
 
   """
-  @spec decode_query(binary, %{binary => binary}) :: %{binary => binary}
+  @spec decode_query(binary, %{optional(binary) => binary}) :: %{optional(binary) => binary}
   def decode_query(query, map \\ %{})
 
   # TODO: Remove on 2.0

--- a/lib/elixir/pages/Compatibility and Deprecations.md
+++ b/lib/elixir/pages/Compatibility and Deprecations.md
@@ -69,6 +69,7 @@ Elixir deprecations happen in 3 steps:
 
 Deprecated feature                               | Hard-deprecated in | Replaced by (available since)
 :----------------------------------------------- | :----------------- | :----------------------------
+`%{key => value}` in typespecs                   | [v1.8]        | `%{required(key) => value}` or `%{optional(key) => value}` (v1.4 and Erlang/OTP 19)
 Passing a non-empty list to `Enum.into/2`        | [v1.8]        | `Kernel.++/2` or `Keyword.merge/2` (v1.0)
 Passing a non-empty list to `:into` in `for`     | [v1.8]        | `Kernel.++/2` or `Keyword.merge/2` (v1.0)
 `:seconds`, `:milliseconds`, etc. as time units  | [v1.8]        | `:second`, `:millisecond`, etc. (v1.4)

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1353,6 +1353,22 @@ defmodule Kernel.WarningTest do
     after
       purge(Sample)
     end
+
+    test "invalid map specification" do
+      message =
+        "invalid map specification. %{foo => bar} is deprecated in favor of " <>
+          "%{required(foo) => bar} and %{optional(foo) => bar}."
+
+      assert capture_err(fn ->
+               Code.eval_string("""
+               defmodule Sample do
+                 @type my_type :: %{atom => integer}
+               end
+               """)
+             end) =~ message
+    after
+      purge(Sample)
+    end
   end
 
   test "attribute with no use" do

--- a/lib/ex_unit/lib/ex_unit/failures_manifest.ex
+++ b/lib/ex_unit/lib/ex_unit/failures_manifest.ex
@@ -2,7 +2,7 @@ defmodule ExUnit.FailuresManifest do
   @moduledoc false
 
   @type test_id :: {module, name :: atom}
-  @opaque t :: %{test_id => test_file :: Path.t()}
+  @opaque t :: %{optional(test_id) => test_file :: Path.t()}
 
   @manifest_vsn 1
 


### PR DESCRIPTION
`%{required(foo) => bar}` and `%{optional(foo) => bar}` should be used instead.