### PR TITLE
Minor doc changes in Collectable protocol moduledoc

### DIFF
--- a/lib/elixir/lib/collectable.ex
+++ b/lib/elixir/lib/collectable.ex
@@ -41,7 +41,7 @@ defprotocol Collectable do
   implementation for `MapSet`. In this implementation "collecting" elements
   simply means inserting them in the set through `MapSet.put/2`.
 
-      defimpl Collectable do
+      defimpl Collectable, for: MapSet do
         def into(original) do
           collector_fun = fn
             set, {:cont, elem} -> MapSet.put(set, elem)


### PR DESCRIPTION
In the example, add the type the protocol is implemented for (`MapSet`).

When reading the documentation is not obvious that this code is extracted from the `MapSet` module and therefore the `for: MapSet` is redundant.
