### PR TITLE
Add test for showing docs of callback with multiple clauses

### DIFF
--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -413,7 +413,7 @@ defmodule IEx.Introspection do
     |> Enum.any?(&match?({_, ^fun, ^arity}, elem(&1, 0)))
   end
 
-  defp get_docs(mod, kinds) do
+  def get_docs(mod, kinds) do
     case Code.fetch_docs(mod) do
       {:docs_v1, _, _, _, _, _, docs} ->
         for {{kind, _, _}, _, _, _, _} = doc <- docs, kind in kinds, do: doc

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -659,14 +659,17 @@ defmodule IEx.HelpersTest do
              """
     end
 
-    test "lists callback with multiple clauses" do
+    test "callback with multiple clauses" do
       filename = "multiple_clauses_callback.ex"
 
       content = """
       defmodule MultipleClauseCallback do
-        @doc "callback"
+        @doc "A callback"
         @callback test(:foo) :: integer
         @callback test(:bar) :: [integer]
+
+        @doc "Another callback"
+        @callback test2(:foo) :: integer
       end
       """
 
@@ -676,6 +679,25 @@ defmodule IEx.HelpersTest do
         assert capture_io(fn -> b(MultipleClauseCallback) end) =~ """
                @callback test(:foo) :: integer()
                @callback test(:bar) :: [integer()]
+
+               @callback test2(:foo) :: integer()
+               """
+
+        IO.inspect IEx.Introspection.get_docs(MultipleClauseCallback, [:callback])
+
+        # This passes. Don't need that in final test as it's redundant with other tests below
+        assert capture_io(fn -> b(MultipleClauseCallback.test2) end) =~ """
+               @callback test2(:foo) :: integer()
+
+               Another callback
+               """
+
+        # This fails:
+        assert capture_io(fn -> b(MultipleClauseCallback.test) end) =~ """
+               @callback test(:foo) :: integer()
+               @callback test(:bar) :: [integer()]
+
+               A callback
                """
       end)
     after


### PR DESCRIPTION
We've introduced showing of multiple callback clauses in https://github.com/elixir-lang/elixir/pull/6641.

I noticed that docs are not attached to these multiple clauses though, see inline comments.