### PR TITLE
Support non zero decimals string in String.to_float/1

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2276,12 +2276,12 @@ defmodule String do
   def to_float(string) do
     case String.at(string, 0) == "." do
       true ->
-        ("0" <> string)
-        |> :erlang.binary_to_float()
+        "0" <> string
 
       false ->
-        :erlang.binary_to_float(string)
+        string
     end
+    |> :erlang.binary_to_float()
   end
 
   @doc """

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2272,7 +2272,9 @@ defmodule String do
       #=> ** (ArgumentError) argument error
 
   """
+
   @spec to_float(String.t()) :: float
+  @compile {:inline, to_float: 1}
   def to_float(string) do
     case String.at(string, 0) == "." do
       true ->

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2265,13 +2265,23 @@ defmodule String do
       iex> String.to_float("3.0")
       3.0
 
+      iex> String.to_float(".7")
+      0.7
+
       String.to_float("3")
       #=> ** (ArgumentError) argument error
 
   """
   @spec to_float(String.t()) :: float
   def to_float(string) do
-    :erlang.binary_to_float(string)
+    case String.at(string, 0) == "." do
+      true ->
+        ("0" <> string)
+        |> :erlang.binary_to_float()
+
+      false ->
+        :erlang.binary_to_float(string)
+    end
   end
 
   @doc """

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -160,7 +160,6 @@ inline(?process, unlink, 1) -> {erlang, unlink};
 inline(?process, unregister, 1) -> {erlang, unregister};
 
 inline(?string, duplicate, 2) -> {binary, copy};
-inline(?string, to_float, 1) -> {erlang, binary_to_float};
 inline(?string, to_integer, 1) -> {erlang, binary_to_integer};
 inline(?string, to_integer, 2) -> {erlang, binary_to_integer};
 

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -709,6 +709,7 @@ defmodule StringTest do
 
   test "to_float/1" do
     assert String.to_float("3.0") == 3.0
+    assert String.to_float(".7") == 0.7
 
     three = fn -> "3" end
     assert_raise ArgumentError, fn -> String.to_float(three.()) end


### PR DESCRIPTION
Adds capability for `String.to_float/1` to convert string represented decimals that don't contain leading digits such as ".767" which neither `String.to_float/1` or `Float.parse/1` currently.