### PR TITLE
Suggest quotes in the executables help where appropriate 

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -2,17 +2,17 @@
 if [ $# -eq 0 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
   echo "Usage: `basename $0` [options] [.exs file] [data]
 
-  -e COMMAND                  Evaluates the given command (*)
-  -r FILE                     Requires the given files/patterns (*)
+  -e \"COMMAND\"                Evaluates the given command (*)
+  -r \"FILE\"                   Requires the given files/patterns (*)
   -S SCRIPT                   Finds and executes the given script in PATH
-  -pr FILE                    Requires the given files/patterns in parallel (*)
-  -pa PATH                    Prepends the given path to Erlang code path (*)
-  -pz PATH                    Appends the given path to Erlang code path (*)
+  -pr \"FILE\"                  Requires the given files/patterns in parallel (*)
+  -pa \"PATH\"                  Prepends the given path to Erlang code path (*)
+  -pz \"PATH\"                  Appends the given path to Erlang code path (*)
 
   --app APP                   Starts the given app and its dependencies (*)
   --cookie COOKIE             Sets a cookie for this distributed node
   --detached                  Starts the Erlang VM detached from console
-  --erl SWITCHES              Switches to be passed down to Erlang (*)
+  --erl \"SWITCHES\"            Switches to be passed down to Erlang (*)
   --help, -h                  Prints this message and exits
   --hidden                    Makes a hidden node
   --logger-otp-reports BOOL   Enables or disables OTP reporting

--- a/bin/elixir.bat
+++ b/bin/elixir.bat
@@ -10,17 +10,17 @@ goto parseopts
 :documentation
 echo Usage: %~nx0 [options] [.exs file] [data]
 echo.
-echo   -e COMMAND                  Evaluates the given command (*)
-echo   -r FILE                     Requires the given files/patterns (*)
+echo   -e "COMMAND"                Evaluates the given command (*)
+echo   -r "FILE"                   Requires the given files/patterns (*)
 echo   -S SCRIPT                   Finds and executes the given script in PATH
-echo   -pr FILE                    Requires the given files/patterns in parallel (*)
-echo   -pa PATH                    Prepends the given path to Erlang code path (*)
-echo   -pz PATH                    Appends the given path to Erlang code path (*)
+echo   -pr "FILE"                  Requires the given files/patterns in parallel (*)
+echo   -pa "PATH"                  Prepends the given path to Erlang code path (*)
+echo   -pz "PATH"                  Appends the given path to Erlang code path (*)
 echo.
 echo   --app APP                   Starts the given app and its dependencies (*)
 echo   --cookie COOKIE             Sets a cookie for this distributed node
 echo   --detached                  Starts the Erlang VM detached from console
-echo   --erl SWITCHES              Switches to be passed down to Erlang (*)
+echo   --erl "SWITCHES"            Switches to be passed down to Erlang (*)
 echo   --help, -h                  Prints this message and exits
 echo   --hidden                    Makes a hidden node
 echo   --logger-otp-reports BOOL   Enables or disables OTP reporting

--- a/bin/iex
+++ b/bin/iex
@@ -2,17 +2,17 @@
 if [ $# -gt 0 ] && ([ "$1" = "--help" ] || [ "$1" = "-h" ]); then
   echo "Usage: `basename $0` [options] [.exs file] [data]
 
-  -e COMMAND                  Evaluates the given command (*)
-  -r FILE                     Requires the given files/patterns (*)
+  -e \"COMMAND\"                Evaluates the given command (*)
+  -r \"FILE\"                   Requires the given files/patterns (*)
   -S SCRIPT                   Finds and executes the given script in PATH
-  -pr FILE                    Requires the given files/patterns in parallel (*)
-  -pa PATH                    Prepends the given path to Erlang code path (*)
-  -pz PATH                    Appends the given path to Erlang code path (*)
+  -pr \"FILE\"                  Requires the given files/patterns in parallel (*)
+  -pa \"PATH\"                  Prepends the given path to Erlang code path (*)
+  -pz \"PATH\"                  Appends the given path to Erlang code path (*)
 
   --app APP                   Starts the given app and its dependencies (*)
   --cookie COOKIE             Sets a cookie for this distributed node
   --detached                  Starts the Erlang VM detached from console
-  --erl SWITCHES              Switches to be passed down to Erlang (*)
+  --erl \"SWITCHES\"            Switches to be passed down to Erlang (*)
   --help, -h                  Prints this message and exits
   --hidden                    Makes a hidden node
   --logger-otp-reports BOOL   Enables or disables OTP reporting

--- a/bin/iex.bat
+++ b/bin/iex.bat
@@ -9,17 +9,17 @@ goto run
 :documentation
 echo Usage: %~nx0 [options] [.exs file] [data]
 echo.
-echo   -e COMMAND                  Evaluates the given command (*)
-echo   -r FILE                     Requires the given files/patterns (*)
+echo   -e "COMMAND"                Evaluates the given command (*)
+echo   -r "FILE"                   Requires the given files/patterns (*)
 echo   -S SCRIPT                   Finds and executes the given script in PATH
-echo   -pr FILE                    Requires the given files/patterns in parallel (*)
-echo   -pa PATH                    Prepends the given path to Erlang code path (*)
-echo   -pz PATH                    Appends the given path to Erlang code path (*)
+echo   -pr "FILE"                  Requires the given files/patterns in parallel (*)
+echo   -pa "PATH"                  Prepends the given path to Erlang code path (*)
+echo   -pz "PATH"                  Appends the given path to Erlang code path (*)
 echo.
 echo   --app APP                   Starts the given app and its dependencies (*)
 echo   --cookie COOKIE             Sets a cookie for this distributed node
 echo   --detached                  Starts the Erlang VM detached from console
-echo   --erl SWITCHES              Switches to be passed down to Erlang (*)
+echo   --erl "SWITCHES"            Switches to be passed down to Erlang (*)
 echo   --help, -h                  Prints this message and exits
 echo   --hidden                    Makes a hidden node
 echo   --logger-otp-reports BOOL   Enables or disables OTP reporting


### PR DESCRIPTION
The rationale is that those options should almost always be given in quotes so by adding the quotes in the documentation we can signal the intent.