### PR TITLE
#8562 Fix: added IEx warning when using --remsh with 'dumb' terminal

### DIFF
--- a/lib/iex/lib/iex/cli.ex
+++ b/lib/iex/lib/iex/cli.ex
@@ -53,6 +53,13 @@ defmodule IEx.CLI do
     if tty_works?() do
       :user_drv.start([:"tty_sl -c -e", tty_args()])
     else
+      if get_remsh(:init.get_plain_arguments()) do
+        IO.puts(
+          :stderr,
+          "warning: Connecting to a remote node via --remsh is not possible using the 'dumb' terminal"
+        )
+      end
+
       :application.set_env(:stdlib, :shell_prompt_func, {__MODULE__, :prompt})
       :user.start()
       local_start()

--- a/lib/iex/lib/iex/cli.ex
+++ b/lib/iex/lib/iex/cli.ex
@@ -56,7 +56,7 @@ defmodule IEx.CLI do
       if get_remsh(:init.get_plain_arguments()) do
         IO.puts(
           :stderr,
-          "warning: Connecting to a remote node via --remsh is not possible using the 'dumb' terminal"
+          "warning: the --remsh option will be ignored because IEx is running on limited shell"
         )
       end
 


### PR DESCRIPTION
Fixes #8562: IEx should print a warning when using --remsh with "dumb" terminal