### PR TITLE
User defined types with the name `record` fail to compile in 1.8.0-rc.0

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -567,11 +567,12 @@ defmodule Kernel.Typespec do
   end
 
   # Handle records
-  defp typespec({:record, meta, [atom]}, vars, caller, state) when is_atom(atom) do
+  defp typespec({:record, meta, [atom]}, vars, caller, state) do
     typespec({:record, meta, [atom, []]}, vars, caller, state)
   end
 
-  defp typespec({:record, meta, [tag, field_specs]}, vars, caller, state) when is_atom(tag) do
+  defp typespec({:record, meta, [tag, field_specs]}, vars, caller, state)
+       when is_atom(tag) and is_list(field_specs) do
     # We cannot set a function name to avoid tracking
     # as a compile time dependency because for records it actually is one.
     case Macro.expand({tag, [], [{:{}, [], []}]}, caller) do
@@ -594,8 +595,9 @@ defmodule Kernel.Typespec do
     end
   end
 
-  defp typespec({:record, _meta, _args}, _vars, caller, _state) do
-    compile_error(caller, "invalid record specification, expected the record name to be an atom")
+  defp typespec({:record, _meta, [_tag, _field_specs]}, _vars, caller, _state) do
+    message = "invalid record specification, expected the record name to be an atom literal"
+    compile_error(caller, message)
   end
 
   # Handle ranges

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -571,12 +571,23 @@ defmodule TypespecTest do
       end
     end
 
-    test "@type with invalid record" do
-      assert_raise CompileError, ~r"invalid record specification", fn ->
+    test "@type with a record which declares the name as the type `atom` rather than an atom literal" do
+      assert_raise CompileError, ~r"expected the record name to be an atom literal", fn ->
         test_module do
-          @type my_type :: record(atom)
+          @type my_type :: record(atom, field: :foo)
         end
       end
+    end
+
+    test "@type can be named record" do
+      bytecode =
+        test_module do
+          @type record :: binary
+          @spec foo?(record) :: boolean
+          def foo?(_), do: true
+        end
+
+      assert [type: {:record, {:type, _, :binary, []}, []}] = types(bytecode)
     end
 
     test "@type with an invalid map notation" do


### PR DESCRIPTION
Closes https://github.com/elixir-lang/elixir/issues/8564

This is my first attempt to contribute code to elixir, so please forgive me if this PR is completely naive.

Besides adding the `is_list/1` guards, I have updated the error message to specify that record specifications must use an atom `literal` as the name, to make it clear that the type `atom` is also not valid.

