### PR TITLE
Deprecate atom-based supervisor child spec

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -223,15 +223,7 @@ defmodule Supervisor do
 
       use GenServer, restart: :transient
 
-  Finally, note it is also possible to simply pass the `Stack` module as
-  a child:
-
-      children = [
-        Stack
-      ]
-
-  When only the module name is given, it is equivalent to `{Stack, []}`.
-  By replacing the map specification by `{Stack, [:hello]}` or `Stack`, we keep
+  By replacing the map specification by `{Stack, [:hello]}`, we keep
   the child specification encapsulated in the `Stack` module, using the default
   implementation defined by `use GenServer`. We can now share our `Stack` worker
   with other developers and they can add it directly to their supervision tree
@@ -241,11 +233,12 @@ defmodule Supervisor do
 
     * a map representing the child specification itself - as outlined in the
       "Child specification" section
-    * a tuple with a module as first element and the start argument as second -
-      such as `{Stack, [:hello]}`. In this case, `Stack.child_spec([:hello])`
-      is called to retrieve the child specification
-    * a module - such as `Stack`. In this case, `Stack.child_spec([])`
-      is called to retrieve the child specification
+    * a two-element tuple with a module as first element and the start argument
+      as second - such as `{Stack, [:hello]}`. In this case,
+      `Stack.child_spec([:hello])` is called to retrieve the child specification
+    * Finally, note Elixir supports Erlang old child specifications, which are
+      made by tuples of 6 elements, but their usage is discouraged in both Erlang
+      and Elixir
 
   If you need to convert a tuple or a module child specification to a map or
   modify a child specification, you can use the `Supervisor.child_spec/2` function.
@@ -292,7 +285,7 @@ defmodule Supervisor do
   at the top of your supervision tree as:
 
       children = [
-        MyApp.Supervisor
+        {MyApp.Supervisor, []}
       ]
 
       Supervisor.start_link(children, strategy: :one_for_one)
@@ -616,6 +609,11 @@ defmodule Supervisor do
   end
 
   defp init_child(module) when is_atom(module) do
+    IO.warn(
+      "passing a module as a Supervisor child spec is deprecated, " <>
+        "instead of `#{inspect(module)}`, please pass `#{inspect({module, []})}`"
+    )
+
     init_child({module, []})
   end
 

--- a/lib/elixir/test/elixir/supervisor_test.exs
+++ b/lib/elixir/test/elixir/supervisor_test.exs
@@ -70,16 +70,13 @@ defmodule SupervisorTest do
   end
 
   test "child_spec/2" do
-    assert Supervisor.child_spec(Task, []) ==
-             %{id: Task, restart: :temporary, start: {Task, :start_link, [[]]}}
-
     assert Supervisor.child_spec({Task, :foo}, []) ==
              %{id: Task, restart: :temporary, start: {Task, :start_link, [:foo]}}
 
     assert Supervisor.child_spec(%{id: Task}, []) == %{id: Task}
 
     assert Supervisor.child_spec(
-             Task,
+             {Task, []},
              id: :foo,
              start: {:foo, :bar, []},
              restart: :permanent,
@@ -89,13 +86,13 @@ defmodule SupervisorTest do
     message = ~r"The module SupervisorTest was given as a child.*\nbut it does not implement"m
 
     assert_raise ArgumentError, message, fn ->
-      Supervisor.child_spec(SupervisorTest, [])
+      Supervisor.child_spec({SupervisorTest, []}, [])
     end
 
     message = ~r"The module Unknown was given as a child.*but it does not exist"m
 
     assert_raise ArgumentError, message, fn ->
-      Supervisor.child_spec(Unknown, [])
+      Supervisor.child_spec({Unknown, []}, [])
     end
 
     message = ~r"supervisors expect each child to be one of"
@@ -108,7 +105,7 @@ defmodule SupervisorTest do
   test "init/2" do
     flags = %{intensity: 3, period: 5, strategy: :one_for_one}
     children = [%{id: Task, restart: :temporary, start: {Task, :start_link, [[]]}}]
-    assert Supervisor.init([Task], strategy: :one_for_one) == {:ok, {flags, children}}
+    assert Supervisor.init([{Task, []}], strategy: :one_for_one) == {:ok, {flags, children}}
 
     flags = %{intensity: 1, period: 2, strategy: :one_for_all}
     children = [%{id: Task, restart: :temporary, start: {Task, :start_link, [:foo]}}]
@@ -135,7 +132,7 @@ defmodule SupervisorTest do
       {Task, {Task, :start_link, []}, :permanent, 5000, :worker, [Task]}
     ]
 
-    assert Supervisor.init([Task, worker(Task, [])], strategy: :one_for_one) ==
+    assert Supervisor.init([{Task, []}, worker(Task, [])], strategy: :one_for_one) ==
              {:ok, {flags, children}}
   end
 

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -159,9 +159,9 @@ defmodule ExUnit do
   @doc false
   def start(_type, []) do
     children = [
-      ExUnit.Server,
-      ExUnit.CaptureServer,
-      ExUnit.OnExitHandler
+      {ExUnit.Server, []},
+      {ExUnit.CaptureServer, []},
+      {ExUnit.OnExitHandler, []}
     ]
 
     opts = [strategy: :one_for_one, name: ExUnit.Supervisor]

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -300,11 +300,14 @@ defmodule ExUnit.Callbacks do
   given to `Supervisor.start_link/2`. For example, if your application
   starts a supervision tree by running:
 
-      Supervisor.start_link([MyServer, {OtherSupervisor, ...}], ...)
+      Supervisor.start_link([
+        {MyServer, []},
+        {OtherSupervisor, :initial_value}
+      ], ...)
 
   You can start those processes under test in isolation by running:
 
-      start_supervised(MyServer)
+      start_supervised({MyServer, []})
       start_supervised({OtherSupervisor, :initial_value})
 
   A keyword list can also be given if there is a need to change

--- a/lib/ex_unit/test/ex_unit/supervised_test.exs
+++ b/lib/ex_unit/test/ex_unit/supervised_test.exs
@@ -49,7 +49,7 @@ defmodule ExUnit.SupervisedTest do
   end
 
   test "starts a supervised process that terminates before on_exit" do
-    {:ok, pid} = start_supervised(MyAgent)
+    {:ok, pid} = start_supervised({MyAgent, 0})
     assert Process.alive?(pid)
     on_exit(fn -> refute Process.alive?(pid) end)
   end

--- a/lib/iex/lib/iex/app.ex
+++ b/lib/iex/lib/iex/app.ex
@@ -4,7 +4,12 @@ defmodule IEx.App do
   use Application
 
   def start(_type, _args) do
-    children = [IEx.Config, IEx.Broker, IEx.Pry]
+    children = [
+      {IEx.Config, []},
+      {IEx.Broker, []},
+      {IEx.Pry, []}
+    ]
+
     Supervisor.start_link(children, strategy: :one_for_one, name: IEx.Supervisor)
   end
 end

--- a/lib/logger/lib/logger/app.ex
+++ b/lib/logger/lib/logger/app.ex
@@ -24,7 +24,7 @@ defmodule Logger.App do
         modules: :dynamic
       },
       {Logger.Watcher, {Logger, Logger.Config, []}},
-      Logger.BackendSupervisor
+      {Logger.BackendSupervisor, []}
       | otp_children
     ]
 

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -262,7 +262,12 @@ defmodule Mix do
 
   @doc false
   def start(_type, []) do
-    children = [Mix.State, Mix.TasksServer, Mix.ProjectStack]
+    children = [
+      {Mix.State, []},
+      {Mix.TasksServer, []},
+      {Mix.ProjectStack, []}
+    ]
+
     opts = [strategy: :one_for_one, name: Mix.Supervisor, max_restarts: 0]
     Supervisor.start_link(children, opts)
   end


### PR DESCRIPTION
This is for discussion.

The fact we support both `MyApp.Repo` and `{MyApp.Repo, arg}`, where `MyApp.Repo` is  the same as `{MyApp.Repo, []}`, have been historically confusing. For instance, folks when using `MyApp.Repo` believe `start_link/0` will be invoked. Other times, developers are just unaware of the relationship between both formats.

The argument for supporting the atom-based ones is readability. For example, in a Phoenix app:

    children = [
      MyApp.Repo,
      MyApp.Endpoint
    ]

However, having a unique format is more consistent without a large impact to readability:

    children = [
      {MyApp.Repo, []},
      {MyApp.Endpoint, []}
    ]

Finally, because Elixir v1.9 (the one coming in July/2019) will deprecate the old child specification, we want to make sure the current child specification is where we want it to be.