### PR TITLE
Make KeyError.message/2 private

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1178,7 +1178,7 @@ defmodule KeyError do
   def message(exception = %{message: nil}), do: message(exception.key, exception.term)
   def message(%{message: message}), do: message
 
-  def message(key, term) do
+  defp message(key, term) do
     message = "key #{inspect(key)} not found"
 
     if term != nil do


### PR DESCRIPTION
It was introduced in https://github.com/elixir-lang/elixir/pull/7803, looks like it was accidentally made public (no docs, no specs)

It shipped in Elixir v1.7 so technically this would be a breaking change. I'm happy to deprecate/doc false it instead.