### PR TITLE
Added additional guards for Keywords.merge/3.

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -704,8 +704,8 @@ defmodule Keyword do
   @spec merge(t, t) :: t
   def merge(keywords1, keywords2)
 
-  def merge(keywords1, []), do: keywords1
-  def merge([], keywords2), do: keywords2
+  def merge(keywords1, []) when is_list(keywords1), do: keywords1
+  def merge([], keywords2) when is_list(keywords2), do: keywords2
 
   def merge(keywords1, keywords2) when is_list(keywords1) and is_list(keywords2) do
     if keyword?(keywords2) do


### PR DESCRIPTION
Added guards to ensure only lists can be passed to `Keywords.merge/3`.

I thought about adding this change after realizing the `merge/3` method had inconsistent behavior...

```elixir
Keyword.merge([a: 1, b: 2], nil)
# ** (FunctionClauseError)

Keyword.merge([], nil)
# nil
```

What do you think?