### PR TITLE
System.otp_release now includes the full release number

### DIFF
--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -229,10 +229,11 @@ defmodule SystemTest do
 
   test "otp_release/0" do
     otp_release = System.otp_release()
-    assert is_binary(System.otp_release())
-    version = otp_release |> Version.parse!()
+    major = otp_release |> String.split(".") |> List.to_tuple() |> elem(0)
 
-    assert version.major == :erlang.system_info(:otp_release) |> List.to_integer()
-    assert version.major >= 20
+    assert is_binary(System.otp_release())
+
+    assert major == :erlang.system_info(:otp_release) |> List.to_string()
+    assert major >= 20
   end
 end

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -228,6 +228,11 @@ defmodule SystemTest do
   end
 
   test "otp_release/0" do
+    otp_release = System.otp_release()
     assert is_binary(System.otp_release())
+    version = otp_release |> Version.parse!()
+
+    assert version.major == :erlang.system_info(:otp_release) |> List.to_integer()
+    assert version.major >= 20
   end
 end

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -542,7 +542,7 @@ defmodule IEx.Helpers do
     print_pane("System and architecture")
 
     print_entry("Elixir version", System.version())
-    print_entry("Erlang/OTP version", :erlang.system_info(:otp_release))
+    print_entry("Erlang/OTP version", System.otp_release())
     print_entry("ERTS version", :erlang.system_info(:version))
     print_entry("Compiled for", :erlang.system_info(:system_architecture))
     print_entry("Schedulers", :erlang.system_info(:schedulers))


### PR DESCRIPTION
Now it returns for example "21.0.6" instead of "21" as before.