### PR TITLE
Improve Protocol.UndefinedError message...

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1154,16 +1154,13 @@ defmodule Protocol.UndefinedError do
       value_type(value) <> maybe_description(description) <> maybe_available(protocol)
   end
 
+  defp value_type(%{__struct__: struct}), do: "#{inspect(struct)} (a struct)"
   defp value_type(value) when is_atom(value), do: "Atom"
   defp value_type(value) when is_bitstring(value), do: "BitString"
   defp value_type(value) when is_float(value), do: "Float"
   defp value_type(value) when is_function(value), do: "Function"
   defp value_type(value) when is_integer(value), do: "Integer"
   defp value_type(value) when is_list(value), do: "List"
-
-  defp value_type(%{__struct__: struct} = user_defined_struct) when is_map(user_defined_struct),
-    do: "#{inspect(struct)} (a struct)"
-
   defp value_type(value) when is_map(value), do: "Map"
   defp value_type(value) when is_pid(value), do: "PID"
   defp value_type(value) when is_port(value), do: "Port"

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1175,8 +1175,8 @@ defmodule Protocol.UndefinedError do
         ". There are no implementations for this protocol."
 
       {:consolidated, types} ->
-        ". This protocol is implemented for the following type(s): "
-          <> Enum.map_join(types, ", ", &inspect/1)
+        ". This protocol is implemented for the following type(s): " <>
+          Enum.map_join(types, ", ", &inspect/1)
 
       :not_consolidated ->
         ""

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1150,9 +1150,23 @@ defmodule Protocol.UndefinedError do
 
   @impl true
   def message(%{protocol: protocol, value: value, description: description}) do
-    "protocol #{inspect(protocol)} not implemented for #{inspect(value)}" <>
-      maybe_description(description) <> maybe_available(protocol)
+    "protocol #{inspect(protocol)} not implemented for #{inspect(value)} of type #{
+      value_type(value)
+    }" <> maybe_description(description) <> maybe_available(protocol)
   end
+
+  defp value_type(value) when is_binary(value), do: "Binary"
+  defp value_type(value) when is_bitstring(value), do: "BitString"
+  defp value_type(value) when is_atom(value), do: "Atom"
+  defp value_type(value) when is_function(value), do: "Function"
+  defp value_type(value) when is_list(value), do: "List"
+  defp value_type(value) when is_map(value), do: "Map"
+  defp value_type(value) when is_pid(value), do: "PID"
+  defp value_type(value) when is_float(value), do: "Float"
+  defp value_type(value) when is_integer(value), do: "Integer"
+  defp value_type(value) when is_port(value), do: "Port"
+  defp value_type(value) when is_tuple(value), do: "Tuple"
+  defp value_type(value) when is_reference(value), do: "Reference"
 
   defp maybe_description(""), do: ""
   defp maybe_description(description), do: ", " <> description
@@ -1163,7 +1177,9 @@ defmodule Protocol.UndefinedError do
         ". There are no implementations for this protocol."
 
       {:consolidated, types} ->
-        ". This protocol is implemented for: #{Enum.map_join(types, ", ", &inspect/1)}"
+        ". This protocol is implemented for the following type(s): #{
+          Enum.map_join(types, ", ", &inspect/1)
+        }"
 
       :not_consolidated ->
         ""

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1150,12 +1150,10 @@ defmodule Protocol.UndefinedError do
 
   @impl true
   def message(%{protocol: protocol, value: value, description: description}) do
-    "protocol #{inspect(protocol)} not implemented for #{inspect(value)} of type #{
-      value_type(value)
-    }" <> maybe_description(description) <> maybe_available(protocol)
+    "protocol #{inspect(protocol)} not implemented for #{inspect(value)} of type " <>
+      value_type(value) <> maybe_description(description) <> maybe_available(protocol)
   end
 
-  defp value_type(value) when is_binary(value), do: "Binary"
   defp value_type(value) when is_bitstring(value), do: "BitString"
   defp value_type(value) when is_atom(value), do: "Atom"
   defp value_type(value) when is_function(value), do: "Function"
@@ -1177,9 +1175,8 @@ defmodule Protocol.UndefinedError do
         ". There are no implementations for this protocol."
 
       {:consolidated, types} ->
-        ". This protocol is implemented for the following type(s): #{
-          Enum.map_join(types, ", ", &inspect/1)
-        }"
+        ". This protocol is implemented for the following type(s): "
+          <> Enum.map_join(types, ", ", &inspect/1)
 
       :not_consolidated ->
         ""

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1154,21 +1154,21 @@ defmodule Protocol.UndefinedError do
       value_type(value) <> maybe_description(description) <> maybe_available(protocol)
   end
 
+  defp value_type(value) when is_atom(value), do: "Atom"
   defp value_type(value) when is_bitstring(value), do: "BitString"
+  defp value_type(value) when is_float(value), do: "Float"
+  defp value_type(value) when is_function(value), do: "Function"
+  defp value_type(value) when is_integer(value), do: "Integer"
+  defp value_type(value) when is_list(value), do: "List"
 
   defp value_type(%{__struct__: struct} = user_defined_struct) when is_map(user_defined_struct),
     do: "#{inspect(struct)} (a struct)"
 
-  defp value_type(value) when is_atom(value), do: "Atom"
-  defp value_type(value) when is_function(value), do: "Function"
-  defp value_type(value) when is_list(value), do: "List"
   defp value_type(value) when is_map(value), do: "Map"
   defp value_type(value) when is_pid(value), do: "PID"
-  defp value_type(value) when is_float(value), do: "Float"
-  defp value_type(value) when is_integer(value), do: "Integer"
   defp value_type(value) when is_port(value), do: "Port"
-  defp value_type(value) when is_tuple(value), do: "Tuple"
   defp value_type(value) when is_reference(value), do: "Reference"
+  defp value_type(value) when is_tuple(value), do: "Tuple"
 
   defp maybe_description(""), do: ""
   defp maybe_description(description), do: ", " <> description

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1155,6 +1155,10 @@ defmodule Protocol.UndefinedError do
   end
 
   defp value_type(value) when is_bitstring(value), do: "BitString"
+
+  defp value_type(%{__struct__: struct} = user_defined_struct) when is_map(user_defined_struct),
+    do: "#{inspect(struct)} (a struct)"
+
   defp value_type(value) when is_atom(value), do: "Atom"
   defp value_type(value) when is_function(value), do: "Function"
   defp value_type(value) when is_list(value), do: "List"

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -102,7 +102,7 @@ defmodule ProtocolTest do
   end
 
   test "protocol not implemented" do
-    message = "protocol ProtocolTest.Sample not implemented for :foo"
+    message = "protocol ProtocolTest.Sample not implemented for :foo of type Atom"
 
     assert_raise Protocol.UndefinedError, message, fn ->
       sample = Sample
@@ -431,8 +431,8 @@ defmodule Protocol.ConsolidationTest do
 
   test "protocol not implemented" do
     message =
-      "protocol Protocol.ConsolidationTest.Sample not implemented for :foo. " <>
-        "This protocol is implemented for: Protocol.ConsolidationTest.ImplStruct"
+      "protocol Protocol.ConsolidationTest.Sample not implemented for :foo of type Atom. " <>
+        "This protocol is implemented for the following type(s): Protocol.ConsolidationTest.ImplStruct"
 
     assert_raise Protocol.UndefinedError, message, fn ->
       sample = Sample

--- a/lib/elixir/test/elixir/string/chars_test.exs
+++ b/lib/elixir/test/elixir/string/chars_test.exs
@@ -101,7 +101,7 @@ defmodule String.Chars.ErrorsTest do
 
   test "bitstring" do
     message =
-      "protocol String.Chars not implemented for <<0, 1::size(4)>>, cannot convert a bitstring to a string"
+      "protocol String.Chars not implemented for <<0, 1::size(4)>> of type BitString, cannot convert a bitstring to a string"
 
     assert_raise Protocol.UndefinedError, message, fn ->
       to_string(<<1::size(12)-integer-signed>>)
@@ -109,7 +109,7 @@ defmodule String.Chars.ErrorsTest do
   end
 
   test "tuple" do
-    message = "protocol String.Chars not implemented for {1, 2, 3}"
+    message = "protocol String.Chars not implemented for {1, 2, 3} of type Tuple"
 
     assert_raise Protocol.UndefinedError, message, fn ->
       to_string({1, 2, 3})
@@ -117,7 +117,7 @@ defmodule String.Chars.ErrorsTest do
   end
 
   test "PID" do
-    message = ~r"^protocol String\.Chars not implemented for #PID<.+?>$"
+    message = ~r"^protocol String\.Chars not implemented for #PID<.+?> of type PID$"
 
     assert_raise Protocol.UndefinedError, message, fn ->
       to_string(self())
@@ -125,7 +125,7 @@ defmodule String.Chars.ErrorsTest do
   end
 
   test "ref" do
-    message = ~r"^protocol String\.Chars not implemented for #Reference<.+?>$"
+    message = ~r"^protocol String\.Chars not implemented for #Reference<.+?> of type Reference$"
 
     assert_raise Protocol.UndefinedError, message, fn ->
       to_string(make_ref()) == ""
@@ -133,7 +133,7 @@ defmodule String.Chars.ErrorsTest do
   end
 
   test "function" do
-    message = ~r"^protocol String\.Chars not implemented for #Function<.+?>$"
+    message = ~r"^protocol String\.Chars not implemented for #Function<.+?> of type Function$"
 
     assert_raise Protocol.UndefinedError, message, fn ->
       to_string(fn -> nil end)
@@ -142,7 +142,7 @@ defmodule String.Chars.ErrorsTest do
 
   test "port" do
     [port | _] = Port.list()
-    message = ~r"^protocol String\.Chars not implemented for #Port<.+?>$"
+    message = ~r"^protocol String\.Chars not implemented for #Port<.+?> of type Port$"
 
     assert_raise Protocol.UndefinedError, message, fn ->
       to_string(port)

--- a/lib/elixir/test/elixir/string/chars_test.exs
+++ b/lib/elixir/test/elixir/string/chars_test.exs
@@ -99,6 +99,10 @@ end
 defmodule String.Chars.ErrorsTest do
   use ExUnit.Case, async: true
 
+  defmodule Foo do
+    defstruct foo: "bar"
+  end
+
   test "bitstring" do
     message =
       "protocol String.Chars not implemented for <<0, 1::size(4)>> of type BitString, cannot convert a bitstring to a string"
@@ -146,6 +150,15 @@ defmodule String.Chars.ErrorsTest do
 
     assert_raise Protocol.UndefinedError, message, fn ->
       to_string(port)
+    end
+  end
+
+  test "user-defined struct" do
+    message =
+      "protocol String\.Chars not implemented for %String.Chars.ErrorsTest.Foo{foo: \"bar\"} of type String.Chars.ErrorsTest.Foo (a struct)"
+
+    assert_raise Protocol.UndefinedError, message, fn ->
+      to_string(%Foo{})
     end
   end
 end

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -382,9 +382,11 @@ defmodule LoggerTest do
   end
 
   test "logging something that is not a binary or chardata fails right away" do
-    assert_raise Protocol.UndefinedError, "protocol String.Chars not implemented for %{}", fn ->
-      Logger.log(:debug, %{})
-    end
+    assert_raise Protocol.UndefinedError,
+                 "protocol String.Chars not implemented for %{} of type Map",
+                 fn ->
+                   Logger.log(:debug, %{})
+                 end
 
     message =
       "cannot truncate chardata because it contains something that is not valid chardata: %{}"

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -384,9 +384,7 @@ defmodule LoggerTest do
   test "logging something that is not a binary or chardata fails right away" do
     assert_raise Protocol.UndefinedError,
                  "protocol String.Chars not implemented for %{} of type Map",
-                 fn ->
-                   Logger.log(:debug, %{})
-                 end
+                 fn -> Logger.log(:debug, %{}) end
 
     message =
       "cannot truncate chardata because it contains something that is not valid chardata: %{}"


### PR DESCRIPTION
when passing the module name of a struct

Addresses https://github.com/elixir-lang/elixir/issues/8532

EDIT: Just took a stab at this issue based on the comments I read, I was hoping to find a better way to infer the type of value, but I used guard clauses, open to suggestions of how to improve this if any....