### PR TITLE
Add documentation about ExUnit.Test.time

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -92,7 +92,7 @@ defmodule ExUnit do
       * `:name` - the test name
       * `:module` - the test module
       * `:state` - the finished test state (see `t:ExUnit.state/0`)
-      * `:time` - the duration of the test's runtime (in microseconds)
+      * `:time` - the duration in microseconds of the test's runtime
       * `:tags` - the test tags
       * `:logs` - the captured logs
 

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -92,7 +92,7 @@ defmodule ExUnit do
       * `:name` - the test name
       * `:module` - the test module
       * `:state` - the finished test state (see `t:ExUnit.state/0`)
-      * `:time` - the time to run the test
+      * `:time` - the duration of the test's runtime (in microseconds)
       * `:tags` - the test tags
       * `:logs` - the captured logs
 


### PR DESCRIPTION
Now we're specifying what that integer actually represents -
microseconds!