### PR TITLE
Add verb to IO.ANSI.format/2 doc

### DIFF
--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -237,7 +237,7 @@ defmodule IO.ANSI do
   The named sequences are represented by atoms.
 
   An optional boolean parameter can be passed to enable or disable
-  emitting actual ANSI codes. When `false`, no ANSI codes will emitted.
+  emitting actual ANSI codes. When `false`, no ANSI codes will be emitted.
   By default checks if ANSI is enabled using the `enabled?/0` function.
 
   ## Examples


### PR DESCRIPTION
Hi all, and happy New Year.

This adds a missing verb, from `will emitted` to `will be emitted`, in `IO.ANSI.format/2`'s doc.

Cheers!