### PR TITLE
Respect `subdirectories` config on mix format warn

### DIFF
--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -476,20 +476,14 @@ defmodule Mix.Tasks.FormatTest do
 
       Mix.Tasks.Format.run([])
 
-      message1 =
-        "Both .formatter.exs and lib/.formatter.exs specify the file lib/a.ex in their " <>
-          ":inputs option. To resolve the conflict, the configuration in .formatter.exs " <>
-          "will be ignored. Please change the list of :inputs in one of the formatter files " <>
-          "so only one of them matches lib/a.ex"
-
-      message2 =
+      message =
         "Both lib/.formatter.exs and foo/.formatter.exs specify the file lib/a.ex in their " <>
           ":inputs option. To resolve the conflict, the configuration in lib/.formatter.exs " <>
           "will be ignored. Please change the list of :inputs in one of the formatter files " <>
           "so only one of them matches lib/a.ex"
 
-      assert_received {:mix_shell, :error, [^message1]}
-      assert_received {:mix_shell, :error, [^message2]}
+      assert_received {:mix_shell, :error, [^message]}
+      refute_received {:mix_shell, :error, _any}
     end)
   end
 


### PR DESCRIPTION
For context: the related warning message was introduced by this PR: https://github.com/elixir-lang/elixir/pull/8323
For reference: https://hexdocs.pm/mix/master/Mix.Tasks.Format.html#module-formatting-options

There is a mix format option called `subdirectories` that should be considered to avoid unnecessary warning message as this option defines folders to be ignored.

Check this out:

```shell
$ cat .formatter.exs
[
  import_deps: [:ecto, :phoenix],
  inputs: ["*.{ex,exs}", "{config,lib,priv,test}/**/*.{ex,exs}"],
  subdirectories: ["priv/*/migrations"]
]
```

```shell
$ cat priv/repo/migrations/.formatter.exs
[
  import_deps: [:ecto_sql],
  inputs: ["*.exs"]
]
```

And here is the message that we can avoid as the config seems consistent with the documentation:

```shell
$ mix format
Both .formatter.exs and priv/repo/migrations/.formatter.exs specify the file priv/repo/migrations/.formatter.exs in their :inputs option. To resolve the conflict, the configuration in .formatter.exs will be ignored. Please change the list of :inputs in one of the formatter files so only one of them matches priv/repo/migrations/.formatter.exs
Both .formatter.exs and priv/repo/migrations/.formatter.exs specify the file priv/repo/migrations/20181105133308_create_users.exs in their :inputs option. To resolve the conflict, the configuration in .formatter.exs will be ignored. Please change the list of :inputs in one of the formatter files so only one of them matches priv/repo/migrations/20181105133308_create_users.exs
```