### PR TITLE
Error on undefined variables in bitstring segments

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -246,13 +246,13 @@ defmodule Kernel.SpecialForms do
       iex> {name, species}
       {"Frank", "Walrus"}
 
-  And the variable can be defined in the match itself:
+  And the variable can be defined in the match itself (prior to its use):
 
       iex> <<name_size::size(8), name::binary-size(name_size), " the ", species::binary>> = <<5, "Frank the Walrus">>
       iex> {name, species}
       {"Frank", "Walrus"}
 
-  However, the size cannot be defined outside the binary/bitstring match:
+  However, the size cannot be defined in the match outside the binary/bitstring match:
 
       {name_size, <<name::binary-size(name_size), _rest::binary>>} = {5, <<"Frank the Walrus">>}
       ** (CompileError): undefined variable "name_size" in bitstring segment

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -252,6 +252,11 @@ defmodule Kernel.SpecialForms do
       iex> {name, species}
       {"Frank", "Walrus"}
 
+  However, the size cannot be defined outside the binary/bitstring match:
+
+      {name_size, <<name::binary-size(name_size), _rest::binary>>} = {5, <<"Frank the Walrus">>}
+      ** (CompileError): undefined variable "name_size" in bitstring segment
+
   Failing to specify the size for the non-last causes compilation to fail:
 
       <<name::binary, " the ", species::binary>> = <<"Frank the Walrus">>

--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -395,5 +395,6 @@ format_error({nested_match, Expr}) ->
 format_error({undefined_var_in_spec, Var}) ->
   Message =
     "undefined variable \"~ts\" in bitstring segment. If the size of the binary is a "
-      "variable, the variable must be defined prior to the pattern match",
+      "variable, the variable must be defined prior to its use in the binary/bitstring match "
+      "itself, or outside the pattern match",
   io_lib:format(Message, ['Elixir.Macro':to_string(Var)]).

--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -7,7 +7,7 @@ expand(Meta, Args, E, RequireSize) ->
   case ?key(E, context) of
     match ->
       {EArgs, Alignment, EE} =
-        expand(Meta, fun elixir_expand:expand/2, Args, [], E, 0, RequireSize),
+        expand(Meta, fun elixir_expand:expand/2, Args, [], E, ?key(E, prematch_vars), 0, RequireSize),
 
       case find_match(EArgs) of
         false ->
@@ -17,14 +17,15 @@ expand(Meta, Args, E, RequireSize) ->
       end;
     _ ->
       {EArgs, Alignment, {_EC, EV}} =
-        expand(Meta, fun elixir_expand:expand_arg/2, Args, [], {E, E}, 0, RequireSize),
+        expand(Meta, fun elixir_expand:expand_arg/2, Args, [], {E, E}, nomatch, 0, RequireSize),
       {{'<<>>', [{alignment, Alignment} | Meta], EArgs}, EV}
   end.
 
-expand(_BitstrMeta, _Fun, [], Acc, E, Alignment, _RequireSize) ->
+expand(_BitstrMeta, _Fun, [], Acc, E, _SpecVars, Alignment, _RequireSize) ->
   {lists:reverse(Acc), Alignment, E};
-expand(BitstrMeta, Fun, [{'::', Meta, [Left, Right]} | T], Acc, E, Alignment, RequireSize) ->
+expand(BitstrMeta, Fun, [{'::', Meta, [Left, Right]} | T], Acc, E, SpecVars, Alignment, RequireSize) ->
   {ELeft, EL} = expand_expr(Meta, Left, Fun, E),
+  ESpecVars = update_spec_vars(E, EL, SpecVars),
 
   %% Variables defined outside the binary can be accounted
   %% on subparts, however we can't assign new variables.
@@ -38,7 +39,7 @@ expand(BitstrMeta, Fun, [{'::', Meta, [Left, Right]} | T], Acc, E, Alignment, Re
     end,
 
   EType = expr_type(ELeft),
-  {ERight, EAlignment, ES} = expand_specs(EType, Meta, Right, EM, RequireSize or MatchSize),
+  {ERight, EAlignment, ES} = expand_specs(EType, Meta, Right, EM, SpecVars, RequireSize or MatchSize),
 
   EE =
     case EL of
@@ -65,15 +66,17 @@ expand(BitstrMeta, Fun, [{'::', Meta, [Left, Right]} | T], Acc, E, Alignment, Re
         prepend_unless_bitstring_in_match(EType, Meta, ELeft, ERight, Acc, E)
     end,
 
-  expand(BitstrMeta, Fun, T, EAcc, EE, alignment(Alignment, EAlignment), RequireSize);
-expand(BitstrMeta, Fun, [{_, Meta, _} = H | T], Acc, E, Alignment, RequireSize) ->
+  expand(BitstrMeta, Fun, T, EAcc, EE, ESpecVars, alignment(Alignment, EAlignment), RequireSize);
+expand(BitstrMeta, Fun, [{_, Meta, _} = H | T], Acc, E, SpecVars, Alignment, RequireSize) ->
   {Expr, ES} = expand_expr(Meta, H, Fun, E),
   {EAcc, EAlignment} = wrap_expr(Expr, Acc),
-  expand(BitstrMeta, Fun, T, EAcc, ES, alignment(Alignment, EAlignment), RequireSize);
-expand(Meta, Fun, [H | T], Acc, E, Alignment, RequireSize) ->
+  ESpecVars = update_spec_vars(E, ES, SpecVars),
+  expand(BitstrMeta, Fun, T, EAcc, ES, ESpecVars, alignment(Alignment, EAlignment), RequireSize);
+expand(Meta, Fun, [H | T], Acc, E, SpecVars, Alignment, RequireSize) ->
   {Expr, ES} = expand_expr(Meta, H, Fun, E),
   {EAcc, EAlignment} = wrap_expr(Expr, Acc),
-  expand(Meta, Fun, T, EAcc, ES, alignment(Alignment, EAlignment), RequireSize).
+  ESpecVars = update_spec_vars(E, ES, SpecVars),
+  expand(Meta, Fun, T, EAcc, ES, ESpecVars, alignment(Alignment, EAlignment), RequireSize).
 
 prepend_unless_bitstring_in_match(Type, Meta, Left, Right, Acc, E) ->
   Expr = {'::', Meta, [Left, Right]},
@@ -157,7 +160,7 @@ env_for_error(E) -> E.
 
 %% Expands and normalizes types of a bitstring.
 
-expand_specs(ExprType, Meta, Info, E, RequireSize) ->
+expand_specs(ExprType, Meta, Info, E, SpecVars, RequireSize) ->
   Default =
     #{size => default,
       unit => default,
@@ -165,7 +168,7 @@ expand_specs(ExprType, Meta, Info, E, RequireSize) ->
       type => default,
       endianness => default},
   {#{size := Size, unit := Unit, type := Type, endianness := Endianness, sign := Sign}, ES} =
-    expand_each_spec(Meta, unpack_specs(Info, []), Default, E),
+    expand_each_spec(Meta, unpack_specs(Info, []), Default, E, SpecVars),
   MergedType = type(Meta, ExprType, Type, E),
   validate_size_required(Meta, RequireSize, ExprType, MergedType, Size, ES),
   SizeAndUnit = size_and_unit(Meta, ExprType, Size, Unit, ES),
@@ -190,11 +193,11 @@ type(_, default, Type, _) ->
 type(Meta, Other, Value, E) ->
   form_error(Meta, ?key(E, file), ?MODULE, {bittype_mismatch, Value, Other, type}).
 
-expand_each_spec(Meta, [{Expr, _, Args} = H | T], Map, E) when is_atom(Expr) ->
+expand_each_spec(Meta, [{Expr, _, Args} = H | T], Map, E, SpecVars) when is_atom(Expr) ->
   case validate_spec(Expr, Args) of
     {Key, Arg} ->
       {Value, EE} = expand_spec_arg(Arg, E),
-      validate_spec_arg(Meta, Key, Value, EE),
+      validate_spec_arg(Meta, Key, Value, EE, SpecVars),
 
       case maps:get(Key, Map) of
         default -> ok;
@@ -202,18 +205,18 @@ expand_each_spec(Meta, [{Expr, _, Args} = H | T], Map, E) when is_atom(Expr) ->
         Other -> form_error(Meta, ?key(E, file), ?MODULE, {bittype_mismatch, Value, Other, Key})
       end,
 
-      expand_each_spec(Meta, T, maps:put(Key, Value, Map), EE);
+      expand_each_spec(Meta, T, maps:put(Key, Value, Map), EE, SpecVars);
     none ->
       case 'Elixir.Macro':expand(H, elixir_env:linify({?line(Meta), E})) of
         H ->
           form_error(Meta, ?key(E, file), ?MODULE, {undefined_bittype, H});
         NewTypes ->
-          expand_each_spec(Meta, unpack_specs(NewTypes, []) ++ T, Map, E)
+          expand_each_spec(Meta, unpack_specs(NewTypes, []) ++ T, Map, E, SpecVars)
       end
   end;
-expand_each_spec(Meta, [Expr | _], _Map, E) ->
+expand_each_spec(Meta, [Expr | _], _Map, E, _SpecVars) ->
   form_error(Meta, ?key(E, file), ?MODULE, {undefined_bittype, Expr});
-expand_each_spec(_Meta, [], Map, E) ->
+expand_each_spec(_Meta, [], Map, E, _SpecVars) ->
   {Map, E}.
 
 unpack_specs({'-', _, [H, T]}, Acc) ->
@@ -251,15 +254,23 @@ validate_spec(_, _)          -> none.
 expand_spec_arg(Expr, E) when is_atom(Expr); is_integer(Expr) -> {Expr, E};
 expand_spec_arg(Expr, E) -> elixir_expand:expand(Expr, E).
 
-validate_spec_arg(Meta, size, Value, E) ->
+validate_spec_arg(Meta, size, Value, E, SpecVars) ->
   case Value of
-    {Var, _, Context} when is_atom(Var) and is_atom(Context) -> ok;
-    _ when is_integer(Value) -> ok;
-    _ -> form_error(Meta, ?key(E, file), ?MODULE, {bad_size_argument, Value})
+    {Var, _, Context} when is_atom(Var) and is_atom(Context) ->
+      case is_map(SpecVars) andalso not maps:is_key({Var, Context}, SpecVars) of
+        true -> form_error(Meta, ?key(E, file), ?MODULE, {undefined_var_in_spec, Value});
+        false -> ok
+      end;
+
+    _ when is_integer(Value) ->
+      ok;
+
+    _ ->
+      form_error(Meta, ?key(E, file), ?MODULE, {bad_size_argument, Value})
   end;
-validate_spec_arg(Meta, unit, Value, E) when not is_integer(Value) ->
+validate_spec_arg(Meta, unit, Value, E, _SpecVars) when not is_integer(Value) ->
   form_error(Meta, ?key(E, file), ?MODULE, {bad_unit_argument, Value});
-validate_spec_arg(_Meta, _Key, _Value, _E) ->
+validate_spec_arg(_Meta, _Key, _Value, _E, _SpecVars) ->
   ok.
 
 validate_size_required(Meta, true, default, Type, default, E) when Type == binary; Type == bitstring ->
@@ -328,6 +339,11 @@ find_match([_Arg | Rest]) ->
 find_match([]) ->
   false.
 
+update_spec_vars(_, _, nomatch) ->
+  nomatch;
+update_spec_vars(#{current_vars := C1}, #{current_vars := C2}, SpecVars) ->
+  maps:merge(SpecVars, maps:filter(fun(K, _V) -> not maps:is_key(K, C1) end, C2)).
+
 format_error({unaligned_bitstring_in_match, Expr}) ->
   Message =
     "cannot verify size of binary expression in match. "
@@ -375,4 +391,9 @@ format_error({nested_match, Expr}) ->
   Message =
     "cannot pattern match inside a bitstring "
       "that is already in match, got: ~ts",
-  io_lib:format(Message, ['Elixir.Macro':to_string(Expr)]).
+  io_lib:format(Message, ['Elixir.Macro':to_string(Expr)]);
+format_error({undefined_var_in_spec, Var}) ->
+  Message =
+    "undefined variable \"~ts\" in bitstring segment. If the size of the binary is a "
+      "variable, the variable must be defined prior to the pattern match",
+  io_lib:format(Message, ['Elixir.Macro':to_string(Var)]).

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -2394,6 +2394,24 @@ defmodule Kernel.ExpansionTest do
       expand(code)
     end
 
+    assert_raise CompileError, ~r/undefined variable "foo"/, fn ->
+      code =
+        quote do
+          fn <<_::size(foo), foo::size(8)>> -> :ok end
+        end
+
+      expand(code)
+    end
+
+    assert_raise CompileError, ~r/undefined variable "foo" in bitstring segment/, fn ->
+      code =
+        quote do
+          fn foo, <<_::size(foo)>> -> :ok end
+        end
+
+      expand(code)
+    end
+
     message = ~r"size in bitstring expects an integer or a variable as argument, got: foo()"
 
     assert_raise CompileError, message, fn ->


### PR DESCRIPTION
Closes #8589 

Binary/bitstring matching allows to dynamically define the `size` of the binary in certain conditions:

  * if the `size` variable is defined prior to the pattern match:

        iex> size = 8
        iex> <<a::size(size), rest::binary>> = "hello"
        iex> a
        104

  * if the `size` variable is matched within the same binary/bitstring match, prior to its use:

        iex> <<name_size::size(8), name::binary-size(name_size), _rest::binary>> = <<5, "Frank the Walrus">>
        iex> name
        "Frank"

Other cases are considered illegal patterns, for example:

    {name_size, <<name::binary-size(name_size), _rest::binary>>} = {5, "Frank the Walrus"}

This commit raises a `CompileError: undefined variable ...` for such cases.