### PR TITLE
Handle non-printable arguments in StringIO gracefully

### DIFF
--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -279,6 +279,8 @@ defmodule StringIO do
       {_, _, _} ->
         {{:error, req}, state}
     end
+  rescue
+    ArgumentError -> {{:error, req}, state}
   end
 
   ## get_chars

--- a/lib/elixir/test/elixir/string_io_test.exs
+++ b/lib/elixir/test/elixir/string_io_test.exs
@@ -137,6 +137,14 @@ defmodule StringIOTest do
     assert StringIO.contents(pid) == {"", "あいう"}
   end
 
+  test "IO.write with non-printable arguments" do
+    {:ok, pid} = StringIO.open("")
+
+    assert_raise ArgumentError, fn ->
+      IO.write(pid, [<<1::1>>])
+    end
+  end
+
   test "IO.binwrite" do
     {:ok, pid} = StringIO.open("")
     assert IO.binwrite(pid, "foo") == :ok
@@ -158,6 +166,14 @@ defmodule StringIOTest do
     {:ok, pid} = StringIO.open("")
     assert IO.puts(pid, "abc") == :ok
     assert StringIO.contents(pid) == {"", "abc\n"}
+  end
+
+  test "IO.puts with non-printable arguments" do
+    {:ok, pid} = StringIO.open("")
+
+    assert_raise ArgumentError, fn ->
+      IO.puts(pid, [<<1::1>>])
+    end
   end
 
   test "IO.inspect" do


### PR DESCRIPTION
Related to #8507 

Non-printable arguments were killing the StringIO process, which was killing the Logger handler associated to it. That was causing some errors when users were running their test suites with `capture_log: true`, because the proxy (logger handler) was not there when `ExUnit.CaptureLog` was trying to remove it.