### PR TITLE
Provide better errors with invalid dates in Calendar.ISO

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -213,7 +213,7 @@ defmodule Calendar.ISO do
   end
 
   def date_to_iso_days(year, month, day) when year in -9999..9999 do
-    ensure_day_in_month(year, month, day)
+    ensure_day_in_month!(year, month, day)
 
     days_in_previous_years(year) + days_before_month(month) + leap_day_offset(year, month) + day -
       1
@@ -366,7 +366,7 @@ defmodule Calendar.ISO do
   @impl true
   def day_of_year(year, month, day)
       when is_integer(year) and is_integer(month) and is_integer(day) do
-    ensure_day_in_month(year, month, day)
+    ensure_day_in_month!(year, month, day)
     days_before_month(month) + leap_day_offset(year, month) + day
   end
 
@@ -994,7 +994,7 @@ defmodule Calendar.ISO do
     {hour, minute, second}
   end
 
-  defp ensure_day_in_month(year, month, day) do
+  defp ensure_day_in_month!(year, month, day) do
     if day < 1 or day > days_in_month(year, month) do
       raise ArgumentError, "invalid date: #{date_to_string(year, month, day)}"
     end

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -213,7 +213,7 @@ defmodule Calendar.ISO do
   end
 
   def date_to_iso_days(year, month, day) when year in -9999..9999 do
-    if day > days_in_month(year, month), do: raise(ArgumentError, "invalid date")
+    ensure_day_in_month(year, month, day)
 
     days_in_previous_years(year) + days_before_month(month) + leap_day_offset(year, month) + day -
       1
@@ -366,7 +366,7 @@ defmodule Calendar.ISO do
   @impl true
   def day_of_year(year, month, day)
       when is_integer(year) and is_integer(month) and is_integer(day) do
-    if day > days_in_month(year, month), do: raise(ArgumentError, "invalid date")
+    ensure_day_in_month(year, month, day)
     days_before_month(month) + leap_day_offset(year, month) + day
   end
 
@@ -992,5 +992,11 @@ defmodule Calendar.ISO do
     {minute, second} = div_mod(rest_seconds, @seconds_per_minute)
 
     {hour, minute, second}
+  end
+
+  defp ensure_day_in_month(year, month, day) do
+    if day < 1 or day > days_in_month(year, month) do
+      raise ArgumentError, "invalid date: #{date_to_string(year, month, day)}"
+    end
   end
 end

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -213,7 +213,7 @@ defmodule Calendar.ISO do
   end
 
   def date_to_iso_days(year, month, day) when year in -9999..9999 do
-    true = day <= days_in_month(year, month)
+    if day > days_in_month(year, month), do: raise(ArgumentError, "invalid date")
 
     days_in_previous_years(year) + days_before_month(month) + leap_day_offset(year, month) + day -
       1
@@ -366,7 +366,7 @@ defmodule Calendar.ISO do
   @impl true
   def day_of_year(year, month, day)
       when is_integer(year) and is_integer(month) and is_integer(day) do
-    true = day <= days_in_month(year, month)
+    if day > days_in_month(year, month), do: raise(ArgumentError, "invalid date")
     days_before_month(month) + leap_day_offset(year, month) + day
   end
 

--- a/lib/elixir/test/elixir/calendar/iso_test.exs
+++ b/lib/elixir/test/elixir/calendar/iso_test.exs
@@ -69,7 +69,7 @@ defmodule Calendar.ISOTest do
   describe "day_of_year/3" do
     test "raises with invalid dates" do
       assert_raise ArgumentError, "invalid date", fn ->
-        Calendar.ISO.day_of_era(2018, 2, 30)
+        Calendar.ISO.day_of_year(2018, 2, 30)
       end
     end
   end

--- a/lib/elixir/test/elixir/calendar/iso_test.exs
+++ b/lib/elixir/test/elixir/calendar/iso_test.exs
@@ -42,6 +42,38 @@ defmodule Calendar.ISOTest do
     end
   end
 
+  describe "naive_datetime_to_iso_days/7" do
+    test "raises with invalid dates" do
+      assert_raise ArgumentError, "invalid date", fn ->
+        Calendar.ISO.naive_datetime_to_iso_days(2018, 2, 30, 0, 0, 0, 0)
+      end
+    end
+  end
+
+  describe "day_of_week/3" do
+    test "raises with invalid dates" do
+      assert_raise ArgumentError, "invalid date", fn ->
+        Calendar.ISO.day_of_week(2018, 2, 30)
+      end
+    end
+  end
+
+  describe "day_of_era/3" do
+    test "raises with invalid dates" do
+      assert_raise ArgumentError, "invalid date", fn ->
+        Calendar.ISO.day_of_era(2018, 2, 30)
+      end
+    end
+  end
+
+  describe "day_of_year/3" do
+    test "raises with invalid dates" do
+      assert_raise ArgumentError, "invalid date", fn ->
+        Calendar.ISO.day_of_era(2018, 2, 30)
+      end
+    end
+  end
+
   defp iso_day_roundtrip(year, month, day) do
     iso_days = Calendar.ISO.date_to_iso_days(year, month, day)
     Calendar.ISO.date_from_iso_days(iso_days)

--- a/lib/elixir/test/elixir/calendar/iso_test.exs
+++ b/lib/elixir/test/elixir/calendar/iso_test.exs
@@ -44,32 +44,48 @@ defmodule Calendar.ISOTest do
 
   describe "naive_datetime_to_iso_days/7" do
     test "raises with invalid dates" do
-      assert_raise ArgumentError, "invalid date", fn ->
+      assert_raise ArgumentError, "invalid date: 2018-02-30", fn ->
         Calendar.ISO.naive_datetime_to_iso_days(2018, 2, 30, 0, 0, 0, 0)
+      end
+
+      assert_raise ArgumentError, "invalid date: 2017-11--03", fn ->
+        Calendar.ISO.naive_datetime_to_iso_days(2017, 11, -3, 0, 0, 0, 0)
       end
     end
   end
 
   describe "day_of_week/3" do
     test "raises with invalid dates" do
-      assert_raise ArgumentError, "invalid date", fn ->
+      assert_raise ArgumentError, "invalid date: 2018-02-30", fn ->
         Calendar.ISO.day_of_week(2018, 2, 30)
+      end
+
+      assert_raise ArgumentError, "invalid date: 2017-11-00", fn ->
+        Calendar.ISO.day_of_week(2017, 11, 0)
       end
     end
   end
 
   describe "day_of_era/3" do
     test "raises with invalid dates" do
-      assert_raise ArgumentError, "invalid date", fn ->
+      assert_raise ArgumentError, "invalid date: 2018-02-30", fn ->
         Calendar.ISO.day_of_era(2018, 2, 30)
+      end
+
+      assert_raise ArgumentError, "invalid date: 2017-11-00", fn ->
+        Calendar.ISO.day_of_era(2017, 11, 0)
       end
     end
   end
 
   describe "day_of_year/3" do
     test "raises with invalid dates" do
-      assert_raise ArgumentError, "invalid date", fn ->
+      assert_raise ArgumentError, "invalid date: 2018-02-30", fn ->
         Calendar.ISO.day_of_year(2018, 2, 30)
+      end
+
+      assert_raise ArgumentError, "invalid date: 2017-11-00", fn ->
+        Calendar.ISO.day_of_year(2017, 11, 0)
       end
     end
   end


### PR DESCRIPTION
As discussed in https://github.com/elixir-lang/elixir/pull/8460/files#r238752220

Provides more information than the previous `MatchError`:

```
** (MatchError) no match of right hand side value: false
```