### PR TITLE
.gitignore improvements

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -273,6 +273,9 @@ defmodule Mix.Tasks.New do
   # The directory Mix will write compiled artifacts to.
   /_build/
 
+  # The directory for Elixir Language Server temporary files
+  **/.elixir_ls
+
   # If you run "mix test --cover", coverage assets end up here.
   /cover/
 


### PR DESCRIPTION
## The problem

I've found some kind of growing trend of increasing artifact files in Elixir's repositories [(for example here)](https://github.com/imeraj/Phoenix_Playground/tree/master/1.4/rumbl)  and even Hex packages [(here in repo also)](https://hex.pm/packages/asura) that are more or less used and views by the community.

While this kind of a "problem" is a result of carelessness and haste, it seems that automation can help avoiding this kind of problem.

## Solution

The solution seems to be more or less cleared: `.gitignore` file, that is generated during calling `mix new` task can be expanded.

## Possible disadvantages

It's definitely impossible to predict every possible artifact, that can appear in someone's code.
Thus, every line in ".gitignore" should be kindly discussed by the community.

## Proposal
I'm trying to start the discussion with **PR** instrument in order to concretize the problem and directly point out the place of possible code modifications. I will appreciate any comments here, with any possible additions to .gitignore, some arguments to extend it or not to do this.

I'm definitely don't insist on concrete modifications, but I believe that **.gitignore** modification can improve development experience for Elixir developers.