### PR TITLE
Allow maps with required fields for to_date and to_time functions.

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -583,6 +583,9 @@ defmodule DateTime do
   Because `Date` does not hold time nor time zone information,
   data will be lost during the conversion.
 
+  In addition to a `DateTime` any map containing the required fields can be
+  passed to this function. This includes `Date` or a `NaiveDateTime`.
+
   ## Examples
 
       iex> dt = %DateTime{year: 2000, month: 2, day: 29, zone_abbr: "CET",
@@ -591,10 +594,15 @@ defmodule DateTime do
       iex> DateTime.to_date(dt)
       ~D[2000-02-29]
 
+      iex> DateTime.to_date(~D[2000-02-29])
+      ~D[2000-02-29]
+      iex> DateTime.to_date(~N[2000-02-29 01:23:45.67])
+      ~D[2000-02-29]
+
   """
-  @spec to_date(Calendar.datetime()) :: Date.t()
-  def to_date(datetime) do
-    %{year: year, month: month, day: day, calendar: calendar} = datetime
+  @spec to_date(Calendar.date()) :: Date.t()
+  def to_date(map_with_date) do
+    %{year: year, month: month, day: day, calendar: calendar} = map_with_date
     %Date{year: year, month: month, day: day, calendar: calendar}
   end
 
@@ -604,6 +612,9 @@ defmodule DateTime do
   Because `Time` does not hold date nor time zone information,
   data will be lost during the conversion.
 
+  Also accepts other maps that contain the necessary time fields.
+  Including `Time` and `NaiveDateTime` structs.
+
   ## Examples
 
       iex> dt = %DateTime{year: 2000, month: 2, day: 29, zone_abbr: "CET",
@@ -612,11 +623,16 @@ defmodule DateTime do
       iex> DateTime.to_time(dt)
       ~T[23:00:07.0]
 
+      iex> DateTime.to_time(~N[2000-01-01 23:00:07.0])
+      ~T[23:00:07.0]
+      iex> DateTime.to_time(~T[23:00:07.0])
+      ~T[23:00:07.0]
+
   """
-  @spec to_time(Calendar.datetime()) :: Time.t()
-  def to_time(datetime) do
+  @spec to_time(Calendar.time()) :: Time.t()
+  def to_time(map_with_time) do
     %{hour: hour, minute: minute, second: second, microsecond: microsecond, calendar: calendar} =
-      datetime
+      map_with_time
 
     %Time{
       hour: hour,

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -391,21 +391,9 @@ defmodule NaiveDateTime do
       ~D[2002-01-13]
 
   """
-  @spec to_date(Calendar.naive_datetime()) :: Date.t()
-  def to_date(%NaiveDateTime{year: year, month: month, day: day, calendar: calendar}) do
-    %Date{year: year, month: month, day: day, calendar: calendar}
-  end
-
-  def to_date(%{
-        year: year,
-        month: month,
-        day: day,
-        calendar: calendar,
-        hour: _,
-        minute: _,
-        second: _,
-        microsecond: _
-      }) do
+  @spec to_date(Calendar.date()) :: Date.t()
+  def to_date(map_with_date) do
+    %{year: year, month: month, day: day, calendar: calendar} = map_with_date
     %Date{year: year, month: month, day: day, calendar: calendar}
   end
 
@@ -421,35 +409,11 @@ defmodule NaiveDateTime do
       ~T[23:00:07]
 
   """
-  @spec to_time(Calendar.naive_datetime()) :: Time.t()
-  def to_time(%NaiveDateTime{} = naive_datetime) do
-    %{
-      hour: hour,
-      minute: minute,
-      second: second,
-      microsecond: microsecond,
-      calendar: calendar
-    } = naive_datetime
+  @spec to_time(Calendar.time()) :: Time.t()
+  def to_time(map_with_time) do
+    %{hour: hour, minute: minute, second: second, microsecond: microsecond, calendar: calendar} =
+      map_with_time
 
-    %Time{
-      hour: hour,
-      minute: minute,
-      second: second,
-      microsecond: microsecond,
-      calendar: calendar
-    }
-  end
-
-  def to_time(%{
-        year: _,
-        month: _,
-        day: _,
-        calendar: calendar,
-        hour: hour,
-        minute: minute,
-        second: second,
-        microsecond: microsecond
-      }) do
     %Time{
       hour: hour,
       minute: minute,

--- a/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
@@ -192,7 +192,7 @@ defmodule NaiveDateTimeTest do
     }
 
     assert NaiveDateTime.to_date(dt) == ~D[2000-02-29]
-    assert catch_error(NaiveDateTime.to_date(~D[2000-02-29]))
+    assert NaiveDateTime.to_date(~D[2000-02-29]) == ~D[2000-02-29]
   end
 
   test "to_time/2 with datetime" do
@@ -211,6 +211,6 @@ defmodule NaiveDateTimeTest do
     }
 
     assert NaiveDateTime.to_time(dt) == ~T[23:00:07.003000]
-    assert catch_error(NaiveDateTime.to_time(~T[00:00:00.000000]))
+    assert NaiveDateTime.to_time(~T[00:00:00.000000]) == ~T[00:00:00.000000]
   end
 end


### PR DESCRIPTION
`DateTime`/`NaiveDateTime.to_date` functions do not need any information
about time to convert to a date. Just a map. The same goes for `to_time`
and date or time zone information.

This allows for instance passing in a list of mixed data: e.g. both
Date and DateTime to the same function.

The functions do the same thing already except for NaiveDateTime "artificially" requiring a NaiveDateTime struct. The other functions in the module only require a map instead of a struct. So only requiring a map with be more consistent in that respect.

It would be cool to have in 1.8. This way we can say that all of the functions just require a map and does not arbitrarily require certain structs for certain functions.