### PR TITLE
Fix ETS leak in Registry.register (#8611)

### DIFF
--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -922,6 +922,11 @@ defmodule Registry do
         ok
 
       {:error, {:already_registered, ^self}} = error ->
+        # This is an error for the :unique case, so there are two entries.
+        # :ets.delete_object deletes both since pid_ets is a :duplicate_bag so
+        # add one back.
+        true = :ets.delete_object(pid_ets, {self, key, key_ets})
+        true = :ets.insert(pid_ets, {self, key, key_ets})
         error
 
       {:error, _} = error ->


### PR DESCRIPTION
This fixes an issue where a registry's PIDPartition table would gain an
entry each time after the first call to Registry.register on a unique
registry.

The handler for :already_registered errors did not clean up the entry
that was initially added to the PIDPartition table. The fix is to delete
the new entry. Since the ets table is a duplicate_bag, it's not possible
to delete only the one entry. However, since the registry is :unique,
there was exactly one entry before the call so the code deletes all
matching entries and adds one back.