### PR TITLE
No longer redirect cross node Logger messages

### DIFF
--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -34,10 +34,6 @@ defmodule Logger.Backends.Console do
     {:ok, :ok, configure(options, state)}
   end
 
-  def handle_event({_level, gl, _event}, state) when node(gl) != node() do
-    {:ok, state}
-  end
-
   def handle_event({level, _gl, {Logger, msg, ts, md}}, state) do
     %{level: log_level, ref: ref, buffer_size: buffer_size, max_buffer: max_buffer} = state
 

--- a/lib/logger/lib/logger/config.ex
+++ b/lib/logger/lib/logger/config.ex
@@ -89,14 +89,6 @@ defmodule Logger.Config do
     {:ok, state}
   end
 
-  def handle_event({_type, gl, _msg} = event, state) when node(gl) != node() do
-    # Cross node messages are always async which also
-    # means this handler won't crash in case Logger
-    # is not installed in the other node.
-    :gen_event.notify({Logger, node(gl)}, event)
-    {:ok, state}
-  end
-
   def handle_event(_event, state) do
     state = update_counter(state, false)
     {:ok, state}


### PR DESCRIPTION
Prior to this patch, any command initiated by a remote
node would no be logger. So, for instance, if a node
executed a remote command such as "MyApp.prepare_for_shutdown"
and the function above executed some code and logged,
the logged would not appear in the node shutting down,
but instead it would be fully redirect to the caller,
which could be logging or not at all.

This makes sure the message always stays on the current
node. If you need output redirecting, then using I/O is
the best mechanism.