### PR TITLE
Fix .iex.exs error behaviour #8618

### DIFF
--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -192,7 +192,7 @@ defmodule IEx.Evaluator do
       kind, error ->
         io_result("Error while evaluating: #{path}")
         print_error(kind, error, __STACKTRACE__)
-        System.halt(1)
+        state
     end
   end
 

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -108,6 +108,8 @@ defmodule IEx.InteractionTest do
              ~r/^#{exception}.+\n:this_is_still_working$/s
 
     refute capture_iex("1 + :atom\n:this_is_still_working") =~ ~r/erl_eval/s
+=======
+>>>>>>> 5229b0709... Remove redundant capture_io from "malformed .iex" iex test
   end
 
   test "exception while invoking conflicting helpers" do
@@ -183,9 +185,9 @@ defmodule IEx.InteractionTest do
 
     test "malformed .iex" do
       File.write!("dot-iex", "malformed")
-      capture_io(:stderr, fn ->
-        assert capture_iex("malformed", [], [dot_iex_path: "dot-iex"]) =~
-          ~r"\*\* \(CompileError\) iex:1: undefined function malformed\/0" end)
+
+      assert capture_iex("malformed", [], [dot_iex_path: "dot-iex"]) =~
+               "** (CompileError) iex:1: undefined function malformed/0"
     after
       File.rm("dot-iex")
     end

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -180,5 +180,14 @@ defmodule IEx.InteractionTest do
       File.rm("dot-iex-1")
       File.rm("dot-iex")
     end
-  end
+
+    test "malformed .iex" do
+      File.write!("dot-iex", "malformed")
+      capture_io(:stderr, fn ->
+        assert capture_iex("malformed", [], [dot_iex_path: "dot-iex"]) =~
+          ~r"\*\* \(CompileError\) iex:1: undefined function malformed\/0" end)
+    after
+      File.rm("dot-iex")
+    end
+
 end

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -184,8 +184,8 @@ defmodule IEx.InteractionTest do
     test "malformed .iex" do
       File.write!("dot-iex", "malformed")
 
-      assert capture_iex("malformed", [], dot_iex_path: "dot-iex") =~
-               "** (CompileError) iex:1: undefined function malformed/0"
+      assert capture_iex("1 + 2", [], dot_iex_path: "dot-iex") =~
+               "** (CompileError) dot-iex:1: undefined function malformed/0"
     after
       File.rm("dot-iex")
     end

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -108,8 +108,6 @@ defmodule IEx.InteractionTest do
              ~r/^#{exception}.+\n:this_is_still_working$/s
 
     refute capture_iex("1 + :atom\n:this_is_still_working") =~ ~r/erl_eval/s
-=======
->>>>>>> 5229b0709... Remove redundant capture_io from "malformed .iex" iex test
   end
 
   test "exception while invoking conflicting helpers" do
@@ -186,10 +184,10 @@ defmodule IEx.InteractionTest do
     test "malformed .iex" do
       File.write!("dot-iex", "malformed")
 
-      assert capture_iex("malformed", [], [dot_iex_path: "dot-iex"]) =~
+      assert capture_iex("malformed", [], dot_iex_path: "dot-iex") =~
                "** (CompileError) iex:1: undefined function malformed/0"
     after
       File.rm("dot-iex")
     end
-
+  end
 end


### PR DESCRIPTION
Loading .iex.exs with compile or runtime errors currently halts the system. 
This fix intended to print error message, but still run iex with default state.