### PR TITLE
Default to UTC in DateTime.from_naive,from_naive!

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -247,7 +247,7 @@ defmodule DateTime do
 
   def from_naive(
         naive_datetime,
-        time_zone,
+        time_zone \\ "Etc/UTC",
         time_zone_database \\ Calendar.get_time_zone_database()
       )
 
@@ -370,7 +370,7 @@ defmodule DateTime do
         ) :: t
   def from_naive!(
         naive_datetime,
-        time_zone,
+        time_zone \\ "Etc/UTC",
         time_zone_database \\ Calendar.get_time_zone_database()
       ) do
     case from_naive(naive_datetime, time_zone, time_zone_database) do


### PR DESCRIPTION
This is especially useful in tests where all we have to do now is write:

```elixir
DateTime.from_naive!(~N[2019-01-01 00:00:00])
```

Of course all we're doing here is typing less characters than explicitly setting UTC, so I think this PR is more of an opening to a discussion if making this more convenient is worth pursuing. If this is annoying to people, I believe a suggestion at some point was to have users write their own wrappers for this function (e.g. a custom ~Z sigil)