### PR TITLE
Improve docs in Module functions and raise errors

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -986,8 +986,8 @@ defmodule Module do
   @doc """
   Returns all functions and macros defined in `module`.
 
-  It returns a list with all functions and macros, public and private
-  defined, in the shape of `[{name, arity}, ...]`.
+  It returns a list with all defined functions and macros, public and private,
+  in the shape of `[{name, arity}, ...]`.
 
   This function can only be used on modules that have not yet been compiled.
   Use the `c:Module.__info__/1` callback to get the public functions and macros in

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1,9 +1,4 @@
 defmodule Module do
-  @extra_error_msg_defines? "Use Kernel.function_exported?/3 and Kernel.macro_exported?/3 " <>
-                              "to check for public functions and macros instead"
-
-  @extra_error_msg_definitions_in "Use the Module.__info__/1 callback to get public functions and macros instead"
-
   @moduledoc ~S'''
   Provides functions to deal with modules during compilation time.
 
@@ -497,6 +492,11 @@ defmodule Module do
 
   @typep definition :: {atom, arity}
   @typep def_kind :: :def | :defp | :defmacro | :defmacrop
+
+  @extra_error_msg_defines? "Use Kernel.function_exported?/3 and Kernel.macro_exported?/3 " <>
+                              "to check for public functions and macros instead"
+
+  @extra_error_msg_definitions_in "Use the Module.__info__/1 callback to get public functions and macros instead"
 
   @doc """
   Provides runtime information about functions, macros, and other information

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1,4 +1,9 @@
 defmodule Module do
+  @extra_error_msg_defines? "Use Kernel.function_exported?/3 and Kernel.macro_exported?/3 " <>
+                              "to check for public functions and macros instead"
+
+  @extra_error_msg_definitions_in "Use the Module.__info__/1 callback to get public functions and macros instead"
+
   @moduledoc ~S'''
   Provides functions to deal with modules during compilation time.
 
@@ -899,8 +904,6 @@ defmodule Module do
   # Otherwise, returns a generic guess
   defp merge_signature({_, meta, _}, _newer, i), do: {:"arg#{i}", meta, Elixir}
 
-  @extra_error_msg_defines? "Use Kernel.function_exported?/3 and Kernel.macro_exported?/3 " <>
-                              "to check for public functions and macros instead"
   @doc """
   Checks if the module defines the given function or macro.
 
@@ -982,7 +985,6 @@ defmodule Module do
     Kernel.Typespec.spec_to_callback(module, definition)
   end
 
-  @extra_error_msg_definitions_in "Use the Module.__info__/1 callback to get public functions and macros instead"
   @doc """
   Returns all functions and macros defined in `module`.
 
@@ -1029,7 +1031,7 @@ defmodule Module do
   @spec definitions_in(module, def_kind) :: [definition]
   def definitions_in(module, def_kind)
       when is_atom(module) and def_kind in [:def, :defp, :defmacro, :defmacrop] do
-    assert_not_compiled!(__ENV__.function, module)
+    assert_not_compiled!(__ENV__.function, module, @extra_error_msg_definitions_in)
     {set, _} = data_tables_for(module)
     :lists.concat(:ets.match(set, {{:def, :"$1"}, def_kind, :_, :_, :_, :_}))
   end

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -750,7 +750,7 @@ defmodule Kernel.ErrorsTest do
 
   test "already compiled module" do
     assert_eval_raise ArgumentError,
-                      "could not call eval_quoted with argument Record " <>
+                      "could not call Module.eval_quoted/4 with module argument Record " <>
                         "because the module is already compiled",
                       'Module.eval_quoted Record, quote(do: 1), [], file: __ENV__.file'
   end

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -750,8 +750,7 @@ defmodule Kernel.ErrorsTest do
 
   test "already compiled module" do
     assert_eval_raise ArgumentError,
-                      "could not call Module.eval_quoted/4 with module argument Record " <>
-                        "because the module is already compiled",
+                      "could not call Module.eval_quoted/4 because the module Record is already compiled",
                       'Module.eval_quoted Record, quote(do: 1), [], file: __ENV__.file'
   end
 

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -236,8 +236,8 @@ defmodule MacroTest do
 
     test "does not expand module attributes" do
       message =
-        "could not call get_attribute with argument #{inspect(__MODULE__)} " <>
-          "because the module is already compiled"
+        "could not call Module.get_attribute/2 with module argument #{inspect(__MODULE__)} " <>
+          "because the module is already compiled. Use the Module.__info__/1 callback or Code.fetch_docs/1 instead"
 
       assert_raise ArgumentError, message, fn ->
         Macro.expand_once(quote(do: @foo), __ENV__)

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -236,8 +236,8 @@ defmodule MacroTest do
 
     test "does not expand module attributes" do
       message =
-        "could not call Module.get_attribute/2 with module argument #{inspect(__MODULE__)} " <>
-          "because the module is already compiled. Use the Module.__info__/1 callback or Code.fetch_docs/1 instead"
+        "could not call Module.get_attribute/2 because the module #{inspect(__MODULE__)} " <>
+          "is already compiled. Use the Module.__info__/1 callback or Code.fetch_docs/1 instead"
 
       assert_raise ArgumentError, message, fn ->
         Macro.expand_once(quote(do: @foo), __ENV__)

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -426,4 +426,14 @@ defmodule ModuleTest do
   after
     purge(Foo)
   end
+
+  test "raise when called with already compiled module" do
+    message =
+      "could not call Module.get_attribute/2 with module argument Enum because the module is already compiled. " <>
+        "Use the Module.__info__/1 callback or Code.fetch_docs/1 instead"
+
+    assert_raise ArgumentError, message, fn ->
+      Module.get_attribute(Enum, :moduledoc)
+    end
+  end
 end

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -429,7 +429,7 @@ defmodule ModuleTest do
 
   test "raise when called with already compiled module" do
     message =
-      "could not call Module.get_attribute/2 with module argument Enum because the module is already compiled. " <>
+      "could not call Module.get_attribute/2 because the module Enum is already compiled. " <>
         "Use the Module.__info__/1 callback or Code.fetch_docs/1 instead"
 
     assert_raise ArgumentError, message, fn ->


### PR DESCRIPTION
It offers alternatives to every possible function that has an equivalent
function for compiled modules.

It shows the mfa of the called function in the error message,
since before it only showed the function name.