### PR TITLE
Use ID and not id

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1679,7 +1679,7 @@ defmodule File do
   end
 
   @doc """
-  Changes the group given by the group id `gid`
+  Changes the group given by the group ID `gid`
   for a given `file`. Returns `:ok` on success, or
   `{:error, reason}` on failure.
   """
@@ -1707,7 +1707,7 @@ defmodule File do
   end
 
   @doc """
-  Changes the owner given by the user id `uid`
+  Changes the owner given by the user ID `uid`
   for a given `file`. Returns `:ok` on success,
   or `{:error, reason}` on failure.
   """

--- a/lib/elixir/lib/port.ex
+++ b/lib/elixir/lib/port.ex
@@ -261,7 +261,7 @@ defmodule Port do
   where:
 
     * `ref` is a monitor reference returned by this function;
-    * `object` is either the `port` being monitored (when monitoring by port id)
+    * `object` is either the `port` being monitored (when monitoring by port ID)
     or `{name, node}` (when monitoring by a port name);
     * `reason` is the exit reason.
 

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -796,7 +796,7 @@ defmodule Supervisor do
   `child_spec` should be a valid child specification. The child process will
   be started as defined in the child specification.
 
-  If a child specification with the specified id already exists, `child_spec` is
+  If a child specification with the specified ID already exists, `child_spec` is
   discarded and this function returns an error with `:already_started` or
   `:already_present` if the corresponding child process is running or not,
   respectively.
@@ -830,7 +830,7 @@ defmodule Supervisor do
   end
 
   @doc """
-  Terminates the given child identified by child id.
+  Terminates the given child identified by `child_id`.
 
   The process is terminated, if there's one. The child specification is
   kept unless the child is temporary.
@@ -840,7 +840,7 @@ defmodule Supervisor do
   Use `delete_child/2` to remove the child specification.
 
   If successful, this function returns `:ok`. If there is no child
-  specification for the given child id, this function returns
+  specification for the given child ID, this function returns
   `{:error, :not_found}`.
   """
   @spec terminate_child(supervisor, term()) :: :ok | {:error, error}

--- a/lib/elixir/lib/supervisor/spec.ex
+++ b/lib/elixir/lib/supervisor/spec.ex
@@ -127,7 +127,7 @@ defmodule Supervisor.Spec do
   @typedoc "Supported module values"
   @type modules :: :dynamic | [module]
 
-  @typedoc "Supported id values"
+  @typedoc "Supported ID values"
   @type child_id :: term
 
   @typedoc "The supervisor specification"
@@ -196,7 +196,7 @@ defmodule Supervisor.Spec do
   defp assert_unique_ids([id | rest]) do
     if id in rest do
       raise ArgumentError,
-            "duplicated id #{inspect(id)} found in the supervisor specification, " <>
+            "duplicated ID #{inspect(id)} found in the supervisor specification, " <>
               "please explicitly pass the :id option when defining this worker/supervisor"
     else
       assert_unique_ids(rest)

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -533,7 +533,7 @@ defmodule System do
 
   Returns a string containing the (usually) numerical identifier for a process.
   On UNIX, this is typically the return value of the `getpid()` system call.
-  On Windows, the process id as returned by the `GetCurrentProcessId()` system
+  On Windows, the process ID as returned by the `GetCurrentProcessId()` system
   call is used.
 
   ## Examples

--- a/lib/elixir/test/elixir/supervisor/spec_test.exs
+++ b/lib/elixir/test/elixir/supervisor/spec_test.exs
@@ -52,7 +52,7 @@ defmodule Supervisor.SpecTest do
     assert supervise(children, options) == {:ok, {{:one_for_all, 1, 1}, children}}
   end
 
-  test "supervise/2 with duplicated ids" do
+  test "supervise/2 with duplicated IDs" do
     children = [worker(GenEvent, []), worker(GenEvent, [])]
 
     assert_raise ArgumentError, fn ->

--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -96,7 +96,7 @@ defmodule ExUnit.Filters do
 
     * A set of files that contain tests that failed the last time they ran.
       The paths are absolute paths.
-    * A set of test ids that failed the last time they ran
+    * A set of test IDs that failed the last time they ran
 
   """
   @spec failure_info(Path.t()) :: {MapSet.t(Path.t()), MapSet.t(FailuresManifest.test_id())}

--- a/lib/ex_unit/test/ex_unit/failures_manifest_test.exs
+++ b/lib/ex_unit/test/ex_unit/failures_manifest_test.exs
@@ -26,7 +26,7 @@ defmodule ExUnit.FailuresManifestTest do
   end
 
   describe "failed_test_ids/1" do
-    test "returns the set of failed test ids" do
+    test "returns the set of failed test IDs" do
       manifest =
         new()
         |> put_test(failed_1 = new_test(@failed))

--- a/lib/ex_unit/test/ex_unit/supervised_test.exs
+++ b/lib/ex_unit/test/ex_unit/supervised_test.exs
@@ -71,7 +71,7 @@ defmodule ExUnit.SupervisedTest do
     refute Process.whereis(MyAgent)
   end
 
-  test "starts a supervised process with id checks" do
+  test "starts a supervised process with ID checks" do
     {:ok, pid} = start_supervised({MyAgent, 0})
     assert {:error, {:already_started, ^pid}} = start_supervised({MyAgent, 0})
     assert {:error, {{:already_started, ^pid}, _}} = start_supervised({MyAgent, 0}, id: :another)

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -665,12 +665,12 @@ defmodule IEx do
 
     * `IEx.Helpers.break!/2` - sets up a breakpoint for a given `Mod.fun/arity`
     * `IEx.Helpers.break!/4` - sets up a breakpoint for the given module, function, arity
-    * `IEx.Helpers.breaks/0` - prints all breakpoints and their ids
+    * `IEx.Helpers.breaks/0` - prints all breakpoints and their IDs
     * `IEx.Helpers.continue/0` - continues until the next breakpoint in the same shell
     * `IEx.Helpers.open/0` - opens editor on the current breakpoint
     * `IEx.Helpers.remove_breaks/0` - removes all breakpoints in all modules
     * `IEx.Helpers.remove_breaks/1` - removes all breakpoints in a given module
-    * `IEx.Helpers.reset_break/1` - sets the number of stops on the given id to zero
+    * `IEx.Helpers.reset_break/1` - sets the number of stops on the given ID to zero
     * `IEx.Helpers.reset_break/3` - sets the number of stops on the given module, function, arity to zero
     * `IEx.Helpers.respawn/0` - starts a new shell (breakpoints will ask for permission once more)
     * `IEx.Helpers.whereami/1` - shows the current location

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -949,9 +949,9 @@ defmodule IEx.Helpers do
 
   @doc """
   Sets the number of pending stops in the breakpoint
-  with the given id to zero.
+  with the given `id` to zero.
 
-  Returns `:ok` if there is such breakpoint id. `:not_found`
+  Returns `:ok` if there is such breakpoint ID. `:not_found`
   otherwise.
 
   Note the module remains "instrumented" on reset. If you would

--- a/lib/iex/lib/iex/pry.ex
+++ b/lib/iex/lib/iex/pry.ex
@@ -248,7 +248,7 @@ defmodule IEx.Pry do
   end
 
   @doc """
-  Resets the breaks on a given breakpoint id.
+  Resets the breaks on a given breakpoint ID.
   """
   @spec reset_break(id) :: :ok | :not_found
   def reset_break(id) when is_integer(id) do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -52,7 +52,7 @@ defmodule IEx.HelpersTest do
       assert IEx.Pry.breaks() == [{1, URI, {:decode_query, 2}, 1}]
     end
 
-    test "resets breaks on the given id" do
+    test "resets breaks on the given ID" do
       assert break!(URI, :decode_query, 2) == 1
       assert reset_break(1) == :ok
       assert IEx.Pry.breaks() == [{1, URI, {:decode_query, 2}, 0}]

--- a/lib/iex/test/iex/pry_test.exs
+++ b/lib/iex/test/iex/pry_test.exs
@@ -68,13 +68,13 @@ defmodule IEx.PryTest do
       assert [_, _] = IEx.Pry.breaks()
     end
 
-    test "returns id when breakpoint is already set" do
+    test "returns ID when breakpoint is already set" do
       assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
       assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
       assert [_] = IEx.Pry.breaks()
     end
 
-    test "returns id even when breakpoint is already set on deinstrument" do
+    test "returns ID even when breakpoint is already set on deinstrument" do
       assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
       deinstrument!(URI)
       assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
@@ -121,7 +121,7 @@ defmodule IEx.PryTest do
   end
 
   describe "reset_break" do
-    test "resets break for given id" do
+    test "resets break for given ID" do
       assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
       assert IEx.Pry.reset_break(1) == :ok
       assert IEx.Pry.breaks() == [{1, URI, {:decode_query, 2}, 0}]
@@ -144,14 +144,14 @@ defmodule IEx.PryTest do
       assert IEx.Pry.reset_break(URI, :decode_query, 2) == :not_found
     end
 
-    test "returns not_found if id is deinstrumented" do
+    test "returns not_found if ID is deinstrumented" do
       assert IEx.Pry.break(URI, :decode_query, 2) == {:ok, 1}
       deinstrument!(URI)
       assert IEx.Pry.reset_break(1) == :not_found
       assert IEx.Pry.breaks() == []
     end
 
-    test "returns not_found if id has no break" do
+    test "returns not_found if ID has no break" do
       assert IEx.Pry.reset_break(1) == :not_found
     end
   end

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -230,7 +230,7 @@ defmodule Mix.Tasks.Compile.App do
 
       {:id, value} ->
         unless is_list(value) do
-          Mix.raise("Application id (:id) is not a character list, got: " <> inspect(value))
+          Mix.raise("Application ID (:id) is not a character list, got: " <> inspect(value))
         end
 
       {:vsn, value} ->


### PR DESCRIPTION
The command used to detect these entries:
ag -s "\b(?<![/:{_\[.])ids?(?![}:_\]])(?!\(\))(?!enti)(?!ea)(?!iom)(?!x)"  --elixir