### PR TITLE
Fix parsing Markdown links for h function (fix #8629)

### DIFF
--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -531,7 +531,7 @@ defmodule IO.ANSI.Docs do
   end
 
   defp remove_square_brackets_in_link(text) do
-    ~r{\[(.*?)\]\((.*?)\)}
+    ~r{\[([^\]]*?)\]\((.*?)\)}
     |> Regex.recompile!()
     |> Regex.replace(text, "\\1 (\\2)")
   end

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -321,6 +321,11 @@ defmodule IO.ANSI.DocsTest do
     assert format("`https_proxy`") == "\e[36mhttps_proxy\e[0m\n\e[0m"
   end
 
+  test "escaping of several Markdown links in one line" do
+    assert format("[List](`List`) (`[1, 2, 3]`), [Map](`Map`)") ==
+             "List (\e[36mList\e[0m) (\e[36m[1, 2, 3]\e[0m), Map (\e[36mMap\e[0m)\n\e[0m"
+  end
+
   test "lone thing that looks like a table line isn't" do
     assert format("one\n2 | 3\ntwo\n") == "one 2 | 3 two\n\e[0m"
   end


### PR DESCRIPTION
I've nailed down the bug described in #8629
The case was that `.*?` could be more eager than expected when it is followed by other statement.