### PR TITLE
Improve IEx.Introspection.h/1 error message

### DIFF
--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -352,7 +352,7 @@ defmodule IEx.Introspection do
     )
 
     puts_error(
-      "If instead of accessing documentation you would like to more information about a value " <>
+      "If instead of accessing documentation you would like more information about a value " <>
         "or about the result of an expression, use the \"i\" helper instead"
     )
 


### PR DESCRIPTION
Hi all, 

this removes an extraneous `to` from a `puts_error` message:

`would like to more information` → `would like more information`

(I also considered changing it to `would like to see more information`...if that makes more sense, please let me know.

Cheers!