### PR TITLE
typo in documentation: Library Guidelines

### DIFF
--- a/lib/elixir/pages/Library Guidelines.md
+++ b/lib/elixir/pages/Library Guidelines.md
@@ -265,7 +265,7 @@ defmodule MyApp.Application do
   def start(_type, _args) do
     children = [
       # Starts a worker by calling: MyApp.Worker.start_link(arg)
-      # {MyApp.Worker, arg},
+      # {MyApp.Worker, arg}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/elixir/pages/Library Guidelines.md
+++ b/lib/elixir/pages/Library Guidelines.md
@@ -256,23 +256,22 @@ and then defining a `my_app/application.ex` file with the following template:
 
 ```elixir
 defmodule MyApp.Application do
-    # See https://hexdocs.pm/elixir/Application.html
-    # for more information on OTP Applications
-    @moduledoc false
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
+  @moduledoc false
 
-    use Application
+  use Application
 
-    def start(_type, _args) do
-      children = [
-        # Starts a worker by calling: MyApp.Worker.start_link(arg)
-        # {MyApp.Worker, arg},
-      ]
+  def start(_type, _args) do
+    children = [
+      # Starts a worker by calling: MyApp.Worker.start_link(arg)
+      # {MyApp.Worker, arg},
+    ]
 
-      # See https://hexdocs.pm/elixir/Supervisor.html
-      # for other strategies and supported options
-      opts = [strategy: :one_for_one, name: MyApp.Supervisor]
-      Supervisor.start_link(children, opts)
-    end
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: MyApp.Supervisor]
+    Supervisor.start_link(children, opts)
   end
 end
 ```


### PR DESCRIPTION
unexpected `end` in Application template