### PR TITLE
Optimize generated code for catch-all else clauses

### DIFF
--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -379,6 +379,10 @@ translate_with_else(Meta, [], S) ->
   {VarName, _, SC} = elixir_erl_var:build('_', S),
   Var = {var, Ann, VarName},
   {{clause, Ann, [Var], [], [Var]}, SC};
+translate_with_else(Meta, [{else, [{'->', _, [[{Var, _, Ctx}], Clause]}]}], S) when is_atom(Var), is_atom(Ctx) ->
+  {ElseVarErl, SV} = elixir_erl_var:assign(Meta, Var, Ctx, S),
+  {TranslatedClause, SC} = elixir_erl_pass:translate(Clause, SV),
+  {{clause, Meta, [ElseVarErl], [], [TranslatedClause]}, SC};
 translate_with_else(Meta, [{else, Else}], S) ->
   Generated = ?generated(Meta),
   ElseVarEx = {else, Generated, ?var_context},


### PR DESCRIPTION
Elixir's `with` is expanded into a series of nested cases. For example, this code:

```elixir
with {:ok, a} <- fun_a(),
     {:ok, b} <- fun_b() do
  wa = fun_w(a)
  wb = fun_w(b)
else
  error -> {:c, error}
end
```
would be expanded to something similar to this:

```elixir
case fun_a() do
  {:ok, a} ->
    case fun_b() do
      {:ok, b} ->
        wa = fun_w(a)
        wb = fun_w(b)

      var1 ->
        case var1 do
          error -> {:c, error}
          var2 -> error({with_clause, var2})
        end
    end

  var1 ->
    case var1 do
      error -> {:c, error}
      var2 -> error({with_clause, var2})
    end
end
```

The generated code can be optimized for else clauses that only contain a single catch-all clause (a variable that would bind everything). Applying this optimization, the code of the example above would be:

```elixir
case fun_a() do
  {:ok, a} ->
    case fun_b() do
      {:ok, b} ->
        wa = fun_w(a)
        wb = fun_w(b)

      error -> 
        {:c, error}
    end

  error -> 
    {:c, error}
end
```