### PR TITLE
Numbers need to be unsigned to return themselves when quoted

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -808,14 +808,16 @@ defmodule Kernel.SpecialForms do
   quoted. They are:
 
       :sum         #=> Atoms
-      1            #=> Integers
-      2.0          #=> Floats
+      1            #=> Unsigned integers (*)
+      2.0          #=> Unsigned floats (*)
       [1, 2]       #=> Lists
       "strings"    #=> Strings
       {key, value} #=> Tuples with two elements
 
   Any other value, such as a map or a four-element tuple, must be escaped
   (`Macro.escape/1`) before being introduced into an AST.
+
+  _(*): By unsigned integers and floats we mean numbers without the `+` and `-` sign._
 
   ## Options
 


### PR DESCRIPTION
iex> quote do: [0, 1, 0.0, 1.0]
[0, 1, 0.0, 1.0]

iex> quote do: [-0, -1, -0.0, -1.0]
[
  {:-, [context: Elixir, import: Kernel], [0]},
  {:-, [context: Elixir, import: Kernel], [1]},
  {:-, [context: Elixir, import: Kernel], [0.0]},
  {:-, [context: Elixir, import: Kernel], [1.0]}
]

iex> quote do: [+0, +1, +0.0, +1.0]
[
  {:+, [context: Elixir, import: Kernel], [0]},
  {:+, [context: Elixir, import: Kernel], [1]},
  {:+, [context: Elixir, import: Kernel], [0.0]},
  {:+, [context: Elixir, import: Kernel], [1.0]}
]