### PR TITLE
Add ability to filter by more than one line number

### DIFF
--- a/lib/ex_unit/test/ex_unit/filters_test.exs
+++ b/lib/ex_unit/test/ex_unit/filters_test.exs
@@ -215,13 +215,15 @@ defmodule ExUnit.FiltersTest do
              {"C:\\some\\path.exs", [exclude: [:test], include: [line: "123", line: "456"]]}
 
     assert ExUnit.Filters.parse_path("test/some/path.exs:123notalinenumber123:456") ==
-             {"test/some/path.exs:123notalinenumber123:456", []}
+             {"test/some/path.exs:123notalinenumber123",
+              [exclude: [:test], include: [line: "456"]]}
 
     assert ExUnit.Filters.parse_path("test/some/path.exs:123:456notalinenumber456") ==
              {"test/some/path.exs:123:456notalinenumber456", []}
 
     assert ExUnit.Filters.parse_path("C:\\some\\path.exs:123notalinenumber123:456") ==
-             {"C:\\some\\path.exs:123notalinenumber123:456", []}
+             {"C:\\some\\path.exs:123notalinenumber123",
+              [exclude: [:test], include: [line: "456"]]}
 
     assert ExUnit.Filters.parse_path("C:\\some\\path.exs:123:456notalinenumber456") ==
              {"C:\\some\\path.exs:123:456notalinenumber456", []}

--- a/lib/ex_unit/test/ex_unit/filters_test.exs
+++ b/lib/ex_unit/test/ex_unit/filters_test.exs
@@ -207,5 +207,23 @@ defmodule ExUnit.FiltersTest do
 
     assert ExUnit.Filters.parse_path("C:\\some\\path.exs:123notreallyalinenumber123") ==
              {"C:\\some\\path.exs:123notreallyalinenumber123", []}
+
+    assert ExUnit.Filters.parse_path("test/some/path.exs:123:456") ==
+             {"test/some/path.exs", [exclude: [:test], include: [line: "123", line: "456"]]}
+
+    assert ExUnit.Filters.parse_path("C:\\some\\path.exs:123:456") ==
+             {"C:\\some\\path.exs", [exclude: [:test], include: [line: "123", line: "456"]]}
+
+    assert ExUnit.Filters.parse_path("test/some/path.exs:123notalinenumber123:456") ==
+             {"test/some/path.exs:123notalinenumber123:456", []}
+
+    assert ExUnit.Filters.parse_path("test/some/path.exs:123:456notalinenumber456") ==
+             {"test/some/path.exs:123:456notalinenumber456", []}
+
+    assert ExUnit.Filters.parse_path("C:\\some\\path.exs:123notalinenumber123:456") ==
+             {"C:\\some\\path.exs:123notalinenumber123:456", []}
+
+    assert ExUnit.Filters.parse_path("C:\\some\\path.exs:123:456notalinenumber456") ==
+             {"C:\\some\\path.exs:123:456notalinenumber456", []}
   end
 end

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -216,21 +216,28 @@ defmodule Mix.Tasks.Test do
 
   It differs in that the test suite will fail if no tests are executed when the `--only` option is used.
 
-  In case a single file is being tested, it is possible to pass a specific
-  line number:
+  In case a single file is being tested, it is possible to pass one or more specific
+  line numbers to run only those given tests:
 
       mix test test/some/particular/file_test.exs:12
 
   Which is equivalent to:
 
-      mix test --only line:12 test/some/particular/file_test.exs
+      mix test --exclude test --include line:12 test/some/particular/file_test.exs
 
-  If the given line starts a `describe` block, the line filter runs all tests in it.
+  Or:
+
+      mix test test/some/particular/file_test.exs:12:24
+
+  Which is equivalent to:
+
+      mix test --exclude test --include line:12 --include line:24 test/some/particular/file_test.exs
+
+  If a given line starts a `describe` block, that line filter runs all tests in it.
   Otherwise, it runs the closest test on or before the given line number.
 
   Note that in the case where a single file contains more than one test module (test case),
-  the line filter applies to every test case before the given line number. Thus, more
-  than one test might be executed for the run.
+  the line filters apply to every test case before the given line number.
 
   ## Configuration
 


### PR DESCRIPTION
As [discussed in the mailing list](https://groups.google.com/d/msg/elixir-lang-core/7yejSvr0RMM/Cfv5JXDnBgAJ), here's a PR that will allow a
shorthand for filtering ExUnit tests by more than one line number at a
time.

For now this doesn't address the question of running single tests in
more than one file since that would be a much larger change. If we do
want to allow that, we can add it later on, but it should be an addition
to the work here, not a replacement.