### PR TITLE
Raise error when attempting to run single line tests on multiple files

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -505,7 +505,11 @@ defmodule Mix.Tasks.Test do
   end
 
   defp parse_files(files, _test_paths) do
-    files
+    if Enum.any?(files, &match?({_, [_ | _]}, ExUnit.Filters.parse_path(&1))) do
+      Mix.raise("Line numbers can only be used when running a single test file")
+    else
+      files
+    end
   end
 
   defp parse_filters(opts, key) do

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -257,6 +257,38 @@ defmodule Mix.Tasks.TestTest do
     end)
   end
 
+  test "raises an exception if line numbers are given with multiple files" do
+    Mix.env(:test)
+
+    in_fixture("test_failed", fn ->
+      Mix.Project.in_project(:test_only_failures, ".", fn _ ->
+        # fails if a line number is given for one file
+        assert_raise(
+          Mix.Error,
+          "Line numbers can only be used when running a single test file",
+          fn ->
+            Mix.Tasks.Test.run([
+              "test/only_failing_test_failed.exs",
+              "test/passing_and_failing_test_failed.exs:4"
+            ])
+          end
+        )
+
+        # fails if a line number is given for both files
+        assert_raise(
+          Mix.Error,
+          "Line numbers can only be used when running a single test file",
+          fn ->
+            Mix.Tasks.Test.run([
+              "test/only_failing_test_failed.exs:4",
+              "test/passing_and_failing_test_failed.exs:4"
+            ])
+          end
+        )
+      end)
+    end)
+  end
+
   defp receive_until_match(port, expected, acc) do
     receive do
       {^port, {:data, output}} ->


### PR DESCRIPTION
Right now the behavior when trying to use the shorthand for running a
single test for multiple files is confusing. We're now explicitly
disallowing this by raising an error when this happens.

This is how it looks in a shell now:

```
$ ../elixir/bin/elixir ../elixir/bin/mix test test/benchee_test.exs:12 test/benchee/benchmark_test.exs:18
** (Mix) Line numbers can only be used when running a single test file
$ ../elixir/bin/elixir ../elixir/bin/mix test test/benchee_test.exs:12 test/benchee/benchmark_test.exs   
** (Mix) Line numbers can only be used when running a single test file
$ ../elixir/bin/elixir ../elixir/bin/mix test test/benchee_test.exs test/benchee/benchmark_test.exs:18 
** (Mix) Line numbers can only be used when running a single test file
$ ../elixir/bin/elixir ../elixir/bin/mix test test/benchee_test.exs test/benchee/benchmark_test.exs   
Excluding tags: [needs_fast_function_repetition: true]

........................................

Finished in 1.9 seconds
42 tests, 0 failures, 2 excluded

Randomized with seed 912767
```

Resolves #8678 