### PR TITLE
Convert private is_iodata macro to a private guard

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -38,11 +38,7 @@ defmodule IO do
   @type nodata :: {:error, term} | :eof
   @type chardata :: String.t() | maybe_improper_list(char | chardata, String.t() | [])
 
-  defmacrop is_iodata(data) do
-    quote do
-      is_list(unquote(data)) or is_binary(unquote(data))
-    end
-  end
+  defguardp is_iodata(data) when is_list(data) or is_binary(data)
 
   @doc """
   Reads from the IO `device`.

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -490,8 +490,8 @@ defmodule IO do
 
   """
   @spec iodata_to_binary(iodata) :: binary
-  def iodata_to_binary(item) do
-    :erlang.iolist_to_binary(item)
+  def iodata_to_binary(iodata) do
+    :erlang.iolist_to_binary(iodata)
   end
 
   @doc """
@@ -506,8 +506,8 @@ defmodule IO do
 
   """
   @spec iodata_length(iodata) :: non_neg_integer
-  def iodata_length(item) do
-    :erlang.iolist_size(item)
+  def iodata_length(iodata) do
+    :erlang.iolist_size(iodata)
   end
 
   @doc false


### PR DESCRIPTION
I also sneaked in a minor change, see second commit.