### PR TITLE
Make tests pass in 2020

### DIFF
--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -123,7 +123,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       Mix.shell().flush
       purge([A, B])
 
-      future = {{2020, 1, 1}, {0, 0, 0}}
+      future = {{2038, 1, 1}, {0, 0, 0}}
       File.touch!("lib/a.ex", future)
       Mix.Tasks.Compile.Elixir.run(["--verbose"])
 
@@ -176,7 +176,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       Mix.shell().flush
       purge([A, B])
 
-      future = {{2020, 1, 1}, {0, 0, 0}}
+      future = {{2038, 1, 1}, {0, 0, 0}}
       File.touch!("lib/b.ex", future)
       Mix.Tasks.Compile.Elixir.run(["--verbose"])
 
@@ -225,7 +225,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       purge([A, B])
 
       # Update local existing resource
-      File.touch!("lib/a.eex", {{2030, 1, 1}, {0, 0, 0}})
+      File.touch!("lib/a.eex", {{2038, 1, 1}, {0, 0, 0}})
       assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
       refute_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
@@ -237,7 +237,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       purge([A, B])
 
       # Update external existing resource
-      File.touch!(tmp, {{2030, 1, 1}, {0, 0, 0}})
+      File.touch!(tmp, {{2038, 1, 1}, {0, 0, 0}})
       assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
       refute_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
@@ -327,7 +327,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
       purge([A, B])
 
-      future = {{2020, 1, 1}, {0, 0, 0}}
+      future = {{2038, 1, 1}, {0, 0, 0}}
       File.touch!("lib/a.ex", future)
 
       assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
@@ -432,7 +432,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       Mix.shell().flush
       purge([A, B])
 
-      future = {{2020, 1, 1}, {0, 0, 0}}
+      future = {{2038, 1, 1}, {0, 0, 0}}
       File.touch!("lib/a.ex", future)
       Mix.Tasks.Compile.Elixir.run(["--verbose"])
 

--- a/lib/mix/test/mix/tasks/compile.xref_test.exs
+++ b/lib/mix/test/mix/tasks/compile.xref_test.exs
@@ -44,7 +44,7 @@ defmodule Mix.Tasks.Compile.XrefTest do
       end)
 
       [manifest] = Mix.Tasks.Compile.Elixir.manifests()
-      future = {{2020, 1, 1}, {0, 0, 0}}
+      future = {{2038, 1, 1}, {0, 0, 0}}
       File.touch!(manifest, future)
 
       Mix.Task.reenable("xref")

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -368,7 +368,7 @@ defmodule Mix.Tasks.FormatTest do
       [inputs: "a.ex"]
       """)
 
-      File.touch!("lib/sub/.formatter.exs", {{2030, 1, 1}, {0, 0, 0}})
+      File.touch!("lib/sub/.formatter.exs", {{2038, 1, 1}, {0, 0, 0}})
       Mix.Tasks.Format.run([])
 
       assert File.read!("lib/sub/a.ex") == """
@@ -388,7 +388,7 @@ defmodule Mix.Tasks.FormatTest do
       other_fun :baz
       """)
 
-      File.touch!("lib/extra/.formatter.exs", {{2030, 1, 1}, {0, 0, 0}})
+      File.touch!("lib/extra/.formatter.exs", {{2038, 1, 1}, {0, 0, 0}})
       Mix.Tasks.Format.run([])
 
       formatter_opts = Mix.Tasks.Format.formatter_opts_for_file("lib/extra/a.ex")

--- a/lib/mix/test/mix/tasks/loadconfig_test.exs
+++ b/lib/mix/test/mix/tasks/loadconfig_test.exs
@@ -63,7 +63,7 @@ defmodule Mix.Tasks.LoadconfigTest do
       assert Mix.Project.config_mtime() > mtime
 
       # Touching it should not have any deadlocks
-      File.touch!(config, {{2030, 1, 1}, {0, 0, 0}})
+      File.touch!(config, {{2038, 1, 1}, {0, 0, 0}})
       Mix.Task.run("loadconfig", [config])
       assert config in Mix.Project.config_files()
       assert Mix.Project.config_mtime() > mtime

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -38,8 +38,8 @@ defmodule Mix.UtilsTest do
   end
 
   test "extract stale" do
-    # 2030-01-01 00:00:00
-    time = 1_893_456_000
+    # 2038-01-01 00:00:00
+    time = 2_145_916_800
     assert Mix.Utils.extract_stale([__ENV__.file], [time]) == []
 
     # 2000-01-01 00:00:00


### PR DESCRIPTION
using only 2038 to keep 32-bit UNIX systems happy.

Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future.
The usual offset is +15 years, because that is how long I expect some software will be used in some places.