### PR TITLE
Ensure we're testing the actual assignment metadata

### DIFF
--- a/lib/eex/test/eex/smart_engine_test.exs
+++ b/lib/eex/test/eex/smart_engine_test.exs
@@ -35,10 +35,13 @@ defmodule EEx.SmartEngineTest do
     Macro.prewalk(result, fn
       {_left, meta, [_, :hello]} ->
         assert Keyword.get(meta, :line) == 2
+        send(self(), :found)
 
-      _ ->
-        :ok
+      node ->
+        node
     end)
+
+    assert_received :found
   end
 
   defp assert_eval(expected, actual, binding \\ []) do

--- a/lib/eex/test/eex/smart_engine_test.exs
+++ b/lib/eex/test/eex/smart_engine_test.exs
@@ -29,12 +29,12 @@ defmodule EEx.SmartEngineTest do
     assert_eval("1\n2\n3\n", "<%= for x <- [1, 2, 3] do %><%= x %>\n<% end %>")
   end
 
-  test "preserves line numbers" do
-    result = EEx.compile_string("<%= @hello %>", engine: EEx.SmartEngine)
+  test "preserves line numbers in assignments" do
+    result = EEx.compile_string("foo\n<%= @hello %>", engine: EEx.SmartEngine)
 
     Macro.prewalk(result, fn
-      {_left, meta, _right} ->
-        assert Keyword.get(meta, :line, 0) in [0, 1]
+      {_left, meta, [_, :hello]} ->
+        assert Keyword.get(meta, :line) == 2
 
       _ ->
         :ok


### PR DESCRIPTION
The existing test was not actually testing anything, as
the default argument to Keyword.get/3, 0, matched one of the
expected values.