### PR TITLE
Use default args in Calendar.ISO.time_to_string/*

### DIFF
--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -343,7 +343,7 @@ defmodule Date do
 
   def to_iso8601(%{calendar: Calendar.ISO} = date, format) when format in [:basic, :extended] do
     %{year: year, month: month, day: day} = date
-    Calendar.ISO.date_to_iso8601(year, month, day, format)
+    Calendar.ISO.date_to_string(year, month, day, format)
   end
 
   def to_iso8601(%{calendar: _} = date, format) when format in [:basic, :extended] do

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -552,7 +552,7 @@ defmodule Calendar.ISO do
 
   By default, returns datetimes formatted in the "extended" format,
   for human readability. It also supports the "basic" format
-  through passing the `:basic` option.
+  by passing the `:basic` option.
 
   ## Examples
 

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -597,7 +597,7 @@ defmodule Calendar.ISO do
 
   By default, returns datetimes formatted in the "extended" format,
   for human readability. It also supports the "basic" format
-  through passing the `:basic` option.
+  by passing the `:basic` option.
 
   ## Examples
 

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -517,7 +517,7 @@ defmodule Calendar.ISO do
 
   By default, returns dates formatted in the "extended" format,
   for human readability. It also supports the "basic" format
-  through passing the `:basic` option.
+  by passing the `:basic` option.
 
   ## Examples
 

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -466,7 +466,7 @@ defmodule Calendar.ISO do
 
   By default, returns times formatted in the "extended" format,
   for human readability. It also supports the "basic" format
-  through passing the `:basic` option.
+  by passing the `:basic` option.
 
   ## Examples
 

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -464,6 +464,10 @@ defmodule Calendar.ISO do
   @doc """
   Converts the given time into a string.
 
+  By default, returns times formatted in the "extended" format,
+  for human readability. It also supports the "basic" format
+  through passing the `:basic` option.
+
   ## Examples
 
       iex> Calendar.ISO.time_to_string(2, 2, 2, {2, 6})
@@ -473,30 +477,13 @@ defmodule Calendar.ISO do
       iex> Calendar.ISO.time_to_string(2, 2, 2, {2, 0})
       "02:02:02"
 
-  """
-  @doc since: "1.5.0"
-  @spec time_to_string(
-          Calendar.hour(),
-          Calendar.minute(),
-          Calendar.second(),
-          Calendar.microsecond()
-        ) :: String.t()
-  @impl true
-  def time_to_string(hour, minute, second, microsecond) do
-    time_to_string(hour, minute, second, microsecond, :extended)
-  end
-
-  @doc """
-  Converts the given time into a string in the given format.
-
-  ## Examples
-
       iex> Calendar.ISO.time_to_string(2, 2, 2, {2, 6}, :basic)
       "020202.000002"
       iex> Calendar.ISO.time_to_string(2, 2, 2, {2, 6}, :extended)
       "02:02:02.000002"
 
   """
+  @impl true
   @doc since: "1.5.0"
   @spec time_to_string(
           Calendar.hour(),
@@ -505,6 +492,8 @@ defmodule Calendar.ISO do
           Calendar.microsecond(),
           :basic | :extended
         ) :: String.t()
+  def time_to_string(hour, minute, second, microsecond, format \\ :extended)
+
   def time_to_string(hour, minute, second, {_, 0}, format) do
     time_to_string_format(hour, minute, second, format)
   end

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -777,16 +777,6 @@ defmodule Calendar.ISO do
     do: precision_for_unit(div(number, 10), precision + 1)
 
   @doc false
-  def date_to_iso8601(year, month, day, format \\ :extended) do
-    date_to_string(year, month, day, format)
-  end
-
-  @doc false
-  def time_to_iso8601(hour, minute, second, microsecond, format \\ :extended) do
-    time_to_string(hour, minute, second, microsecond, format)
-  end
-
-  @doc false
   def naive_datetime_to_iso8601(
         year,
         month,

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -301,7 +301,7 @@ defmodule Time do
       microsecond: microsecond
     } = time
 
-    Calendar.ISO.time_to_iso8601(hour, minute, second, microsecond, format)
+    Calendar.ISO.time_to_string(hour, minute, second, microsecond, format)
   end
 
   def to_iso8601(%{calendar: _} = time, format) when format in [:extended, :basic] do

--- a/lib/elixir/test/elixir/calendar/iso_test.exs
+++ b/lib/elixir/test/elixir/calendar/iso_test.exs
@@ -35,10 +35,10 @@ defmodule Calendar.ISOTest do
     end
   end
 
-  describe "date_to_iso8601/4" do
+  describe "date_to_string/4" do
     test "handles years > 9999" do
-      assert Calendar.ISO.date_to_iso8601(10000, 1, 1, :basic) == "100000101"
-      assert Calendar.ISO.date_to_iso8601(10000, 1, 1, :extended) == "10000-01-01"
+      assert Calendar.ISO.date_to_string(10000, 1, 1, :basic) == "100000101"
+      assert Calendar.ISO.date_to_string(10000, 1, 1, :extended) == "10000-01-01"
     end
   end
 


### PR DESCRIPTION
Closes #8705 and #8706 