### PR TITLE
added missing spec for Mix.Project.consolidation_path/1

### DIFF
--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -590,6 +590,7 @@ defmodule Mix.Project do
       #=> "/path/to/project/_build/dev/consolidated"
 
   """
+  @spec consolidation_path(keyword) :: Path.t()
   def consolidation_path(config \\ config()) do
     if umbrella?(config) do
       Path.join(build_path(config), "consolidated")


### PR DESCRIPTION
It was the only function in this module that did not have spec.

Generally, most functions have typespec, but there are some that do not. Is there any rule when you do not add them?