### PR TITLE
IEx h: sort results by arity

### DIFF
--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -283,6 +283,7 @@ defmodule IEx.Introspection do
             true ->
               module.module_info(:exports)
           end
+          |> Enum.sort_by(fn {_function_name, arity} -> arity end)
 
         result =
           for {^function, arity} <- exports,

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -283,7 +283,7 @@ defmodule IEx.Introspection do
             true ->
               module.module_info(:exports)
           end
-          |> Enum.sort_by(fn {_function_name, arity} -> arity end)
+          |> Enum.sort()
 
         result =
           for {^function, arity} <- exports,

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -343,6 +343,12 @@ defmodule IEx.HelpersTest do
              """
 
       assert capture_io(fn -> h(:timer.send_interval()) end) == """
+             * :timer.send_interval/2
+
+               @spec send_interval(time, message) :: {:ok, tRef} | {:error, reason}
+                     when time: time(), message: term(), tRef: tref(), reason: term()
+
+             Module was compiled without docs. Showing only specs.
              * :timer.send_interval/3
 
                @spec send_interval(time, pid, message) :: {:ok, tRef} | {:error, reason}
@@ -351,12 +357,6 @@ defmodule IEx.HelpersTest do
                           message: term(),
                           tRef: tref(),
                           reason: term()
-
-             Module was compiled without docs. Showing only specs.
-             * :timer.send_interval/2
-
-               @spec send_interval(time, message) :: {:ok, tRef} | {:error, reason}
-                     when time: time(), message: term(), tRef: tref(), reason: term()
 
              Module was compiled without docs. Showing only specs.
              """


### PR DESCRIPTION
The results were not sorted, when calling:
h Module.function_name

Example:

```
iex)> h :erlang.float_to_binary
                           :erlang.float_to_binary/2

  @spec float_to_binary(float, options) :: binary()
        when float: float(),
             options: [option],
             option:
               {:decimals, decimals :: 0..253}
               | {:scientific, decimals :: 0..249}
               | :compact

Module was compiled without docs. Showing only specs.

                           :erlang.float_to_binary/1

  @spec float_to_binary(float) :: binary() when float: float()

Module was compiled without docs. Showing only specs.
```

Now the results are sorted by arity.