### PR TITLE
add missing "`" to Mix.Release docs

### DIFF
--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -150,7 +150,7 @@ defmodule Mix.Tasks.Release do
   In addition to matching the target triple, it is also important that the
   target has all of the system packages that your application will need at
   runtime. A common one is the need for OpenSSL when building an application
-  that uses `:crypto` or `:ssl, which is dynamically linked to ERTS. The other
+  that uses `:crypto` or `:ssl`, which is dynamically linked to ERTS. The other
   common source for native dependencies like this comes from dependencies
   containing NIFs (natively-implemented functions) which may expect to
   dynamically link to libraries they use.


### PR DESCRIPTION
You can see it missing here: https://hexdocs.pm/mix/master/Mix.Tasks.Release.html#module-requirements