### PR TITLE
Include field names in generated type for records

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -585,7 +585,13 @@ defmodule Kernel.Typespec do
       {_, _, [name, fields | _]} when is_list(fields) ->
         types =
           :lists.map(
-            fn {field, _} -> Keyword.get(field_specs, field, quote(do: term())) end,
+            fn {field, _} ->
+              {:::, [],
+               [
+                 {field, [], nil},
+                 Keyword.get(field_specs, field, quote(do: term()))
+               ]}
+            end,
             fields
           )
 

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -521,8 +521,8 @@ defmodule TypespecTest do
       assert [type: {:my_type, type, []}] = types(bytecode)
       assert {:type, _, :tuple, [timestamp, term, foo]} = type
       assert {:atom, 0, :timestamp} = timestamp
-      assert {:type, 0, :term, []} = term
-      assert {:atom, 0, :foo} = foo
+      assert {:ann_type, 0, [{:var, 0, :date}, {:type, 0, :term, []}]} = term
+      assert {:ann_type, 0, [{:var, 0, :time}, {:atom, 0, :foo}]} = foo
     end
 
     test "@type with private record" do
@@ -535,7 +535,12 @@ defmodule TypespecTest do
 
       assert [type: {:my_type, type, []}] = types(bytecode)
       assert {:type, _, :tuple, args} = type
-      assert [{:atom, 0, :timestamp}, {:type, 0, :term, []}, {:atom, 0, :foo}] = args
+
+      assert [
+               {:atom, 0, :timestamp},
+               {:ann_type, 0, [{:var, 0, :date}, {:type, 0, :term, []}]},
+               {:ann_type, 0, [{:var, 0, :time}, {:atom, 0, :foo}]}
+             ] = args
     end
 
     test "@type with named record" do
@@ -549,8 +554,8 @@ defmodule TypespecTest do
       assert [type: {:my_type, type, []}] = types(bytecode)
       assert {:type, _, :tuple, [my_timestamp, term, foo]} = type
       assert {:atom, 0, :my_timestamp} = my_timestamp
-      assert {:type, 0, :term, []} = term
-      assert {:atom, 0, :foo} = foo
+      assert {:ann_type, 0, [{:var, 0, :date}, {:type, 0, :term, []}]} = term
+      assert {:ann_type, 0, [{:var, 0, :time}, {:atom, 0, :foo}]}
     end
 
     test "@type with undefined record" do


### PR DESCRIPTION
For this module:

    defmodule M do
      import Record
      @type t :: record(:r, foo: atom(), bar: integer())
      defrecord :r, [:foo, :bar]
    end

`@type t` is defined as the following:

Before this patch:

    @type t() :: {:r, atom(), integer()}

After this patch:

    @type t() :: {:r, foo :: atom(), bar :: integer()}

This is similar to loading record definition in Erlang shell:

    1> rr(file).
    [file_descriptor,file_info]
    2> rl(file_descriptor).
    -record(file_descriptor,{module :: module(),data :: term()}).
    ok