### PR TITLE
Document the `$callers` tracking that is new in Elixir 1.8

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -158,7 +158,7 @@ defmodule Task do
   ## Distributed tasks
 
   Since Elixir provides a `Task.Supervisor`, it is easy to use one
-  to dynamically spawn tasks across nodes:
+  to dynamically start tasks across nodes:
 
       # On the remote node
       Task.Supervisor.start_link(name: MyApp.DistSupervisor)
@@ -176,43 +176,34 @@ defmodule Task do
 
   ## Ancestor and Caller Tracking
 
-  Whenever you spawn a new process, Elixir annotates the parent of that process
-  through the $ancestors key. This information can be used by instrumentation
-  tools to track the relationship between events occurring within multiple
-  processes. However, many times, tracking only the $ancestors is not enough.
+  Whenever you start a new process, Elixir annotates the parent of that process
+  through the `$ancestors` key in the process dictionary. This is often used to
+  track the hierarchy inside a supervision tree.
 
   For example, we recommend developers to always start tasks under a supervisor.
-  This provides more visibility and allows us to control how those tasks are
+  This provides more visibility and allows you to control how those tasks are
   terminated when a node shuts down. That might look something like
   `Task.Supervisor.start_child(MySupervisor, task_specification)`. This means
-  that, although your code is the one who invokes the task, the actual parent of
-  the task would be the supervisor, as the supervisor is the one spawning it. We
-  would list the supervisor as one of the $ancestors for the task, but the
-  relationship between your code and the task is lost.
+  that, although your code is the one who invokes the task, the actual ancestor of
+  the task is the supervisor, as the supervisor is the one effectively starting it.
 
-  Starting in Elixir v1.8, we now track the relationship between your code and
-  the task via the $callers key in the process dictionary, which aligns well
-  with the existing $ancestors key. Therefore, assuming the Task.Supervisor call
+  To track the relationship between your code and the task, we use the `$callers`
+  key in the process dictionary. Therefore, assuming the `Task.Supervisor` call
   above, we have:
 
-  ```
-  [your code] -- calls --> [supervisor] ---- spawns --> [task]
-  ```
+      [your code] -- calls --> [supervisor] ---- spawns --> [task]
 
   Which means we store the following relationships:
 
-  ```
-  [your code]              [supervisor] <-- ancestor -- [task]
-  ^                                                  |
-  |--------------------- caller ---------------------|
-  ```
+      [your code]              [supervisor] <-- ancestor -- [task]
+          ^                                                  |
+          |--------------------- caller ---------------------|
 
   The list of callers of the current process can be retrieved from the Process
-  dictionary: `Process.get(:"$callers")`. This will return either:
-  * `nil`: indicates that this was not a process spawned by the `Task` module
-  * `[pid]`: Where `pid` is the PID that spawed the current process
-  * `[pid_n, pid2, pid1]`: Where `pid_n` is the PID that spawned the current
-    process, `pid2` spawned `pid_n`, and `pid2` was spawned by `pid1`
+  dictionary with `Process.get(:"$callers")`. This will return either `nil` or
+  a list `[pid_n, ..., pid2, pid1]` with at least one entry Where `pid_n` is
+  the PID that called the current process, `pid2` called `pid_n`, and `pid2` was
+  called by `pid1`.
   """
 
   @doc """


### PR DESCRIPTION
The majority of the text was taken from the release notes:
https://elixir-lang.org/blog/2019/01/14/elixir-v1-8-0-released/

The example at the end is my own.