### PR TITLE
Optimize performance of dynamic dispatching for non-consolidated protocols

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -497,10 +497,11 @@ defmodule Protocol do
           target = Module.concat(__MODULE__, mod)
 
           Kernel.def impl_for(data) when :erlang.unquote(guard)(data) do
-            case Code.ensure_compiled?(unquote(target)) and
-                   function_exported?(unquote(target), :__impl__, 1) do
-              true -> unquote(target).__impl__(:target)
-              false -> unquote(any_impl_for)
+            try do
+              unquote(target).__impl__(:target)
+            rescue
+              UndefinedFunctionError ->
+                unquote(any_impl_for)
             end
           end
         end,
@@ -533,9 +534,11 @@ defmodule Protocol do
       Kernel.defp struct_impl_for(struct) do
         target = Module.concat(__MODULE__, struct)
 
-        case Code.ensure_compiled?(target) and function_exported?(target, :__impl__, 1) do
-          true -> target.__impl__(:target)
-          false -> unquote(any_impl_for)
+        try do
+          target.__impl__(:target)
+        rescue
+          UndefinedFunctionError ->
+            unquote(any_impl_for)
         end
       end
 


### PR DESCRIPTION
Hi!

During troubleshooting an issue in our system (*), I noticed that non-consolidated protocols require one round trip of message exchange between the code server process per invocation.
I'm not sure why it's necessary; couldn't it be a scalability bottleneck?
Simple try-rescue gives me the following performance benefit for sequential execution:

- Before the change

  ```ex
  iex(1)> t = System.system_time(:millisecond); Enum.each(1..10_000_000, &inspect/1); System.system_time(:millisecond) - t
  22177
  ```

- After the change

  ```ex
  iex(1)> t = System.system_time(:millisecond); Enum.each(1..10_000_000, &inspect/1); System.system_time(:millisecond) - t
  5247
  ```

Probably I'm missing some important role of `Code.ensure_compiled?/1` and `function_exported?/3`?
In that case feel free to reject this PR but please tell me the reason for my curiosity :)
Thank you!

---

(*)
We recently encountered a trouble in which one node in our system was seriously damaged by cascading effect of the following issues:
(Our system relies on dynamic module loading and thus not consolidates protocols)

1. Our NFS mount became unreachable from one of our instances (we are using AWS EFS and it's an EFS issue).
2. In that instance an I/O operation on the NFS volume was issued by our system.
   Then the erts efile port driver was hanged indefinitely.
   Not only accesses to the NFS volume but also accesses to non-NFS volumes were mostly blocked.
   (It seems that in Erlang/OTP 21.x unresponsive NFS volume won't affect I/O operations on non-NFS volumes. Our system is currently using Erlang/OTP 20.x.)
3. Then a code reloading occurred (beam files reside on a non-NFS disk) and it triggered an I/O within code server process, making the code server unresponsive.
4. All invocations of protocol dispatching are blocked.
