### PR TITLE
User "true or false" instead of the other way around

### DIFF
--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -125,7 +125,7 @@ Built-in type           | Defined as
 `as_boolean(t)`         | `t`
 `binary()`              | `<<_::_*8>>`
 `bitstring()`           | `<<_::_*1>>`
-`boolean()`             | `false` \| `true`
+`boolean()`             | `true` \| `false`
 `byte()`                | `0..255`
 `char()`                | `0..0x10FFFF`
 `charlist()`            | `[char()]`


### PR DESCRIPTION
While "false or true" is alphabetically ordered, the most common
way it is used in the English language is "true or false" and this
is the only one reference in Elixir core that we say "false or true".