### PR TITLE
Change "vm" to uppercase in IEx.Helpers

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -499,7 +499,7 @@ defmodule IEx.Helpers do
 
   @runtime_info_topics [:system, :memory, :allocators, :limits, :applications]
   @doc """
-  Prints vm/runtime information such as versions, memory usage and statistics.
+  Prints VM/runtime information such as versions, memory usage and statistics.
   Additional topics are available via `runtime_info/1`.
   """
   @doc since: "1.5.0"

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -311,7 +311,7 @@ defmodule IEx.HelpersTest do
   end
 
   describe "runtime_info" do
-    test "shows vm information" do
+    test "shows VM information" do
       assert "\n## System and architecture" <> _ = capture_io(fn -> runtime_info() end)
     end
   end


### PR DESCRIPTION
VM is written in uppercase in other places.