### PR TITLE
Use "code point" instead of "codepoint"

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -316,7 +316,7 @@ defmodule IO do
   Gets a number of bytes from IO device `:stdio`.
 
   If `:stdio` is a Unicode device, `count` implies
-  the number of Unicode codepoints to be retrieved.
+  the number of Unicode code points to be retrieved.
   Otherwise, `count` is the number of raw bytes to be retrieved.
 
   See `IO.getn/3` for a description of return values.
@@ -338,7 +338,7 @@ defmodule IO do
   Gets a number of bytes from the IO `device`.
 
   If the IO `device` is a Unicode device, `count` implies
-  the number of Unicode codepoints to be retrieved.
+  the number of Unicode code points to be retrieved.
   Otherwise, `count` is the number of raw bytes to be retrieved.
 
   It returns:
@@ -440,7 +440,7 @@ defmodule IO do
   end
 
   @doc """
-  Converts chardata (a list of integers representing codepoints,
+  Converts chardata (a list of integers representing code points,
   lists and strings) into a string.
 
   In case the conversion fails, it raises an `UnicodeConversionError`.

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -192,7 +192,7 @@ defmodule Kernel.SpecialForms do
       iex> <<102, rest::binary>>
       "foo"
 
-  The `utf8`, `utf16`, and `utf32` types are for Unicode codepoints. They
+  The `utf8`, `utf16`, and `utf32` types are for Unicode code points. They
   can also be applied to literal strings and charlists:
 
       iex> <<"foo"::utf16>>

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -71,7 +71,7 @@ defmodule List do
   ## Charlists
 
   If a list is made of non-negative integers, where each integer represents a
-  Unicode codepoint, the list can also be called a charlist. These integers
+  Unicode code point, the list can also be called a charlist. These integers
   must:
 
     * be within the range `0..0x10FFFF` (`0..1_114_111`);
@@ -731,7 +731,7 @@ defmodule List do
   Converts a charlist to an atom.
 
   Elixir supports conversions from charlists which contains any Unicode
-  codepoint.
+  code point.
 
   Inlined by the compiler.
 
@@ -754,7 +754,7 @@ defmodule List do
   if the atom does not exist.
 
   Elixir supports conversions from charlists which contains any Unicode
-  codepoint.
+  code point.
 
   Inlined by the compiler.
 
@@ -842,11 +842,11 @@ defmodule List do
   end
 
   @doc """
-  Converts a list of integers representing codepoints, lists or
+  Converts a list of integers representing code points, lists or
   strings into a string.
 
   Notice that this function expects a list of integers representing
-  UTF-8 codepoints. If you have a list of bytes, you must instead use
+  UTF-8 code points. If you have a list of bytes, you must instead use
   the [`:binary` module](http://www.erlang.org/doc/man/binary.html).
 
   ## Examples
@@ -873,7 +873,7 @@ defmodule List do
         To be converted to a string, a list must contain only:
 
           * strings
-          * integers representing Unicode codepoints
+          * integers representing Unicode code points
           * or a list containing one of these three elements
 
         Please check the given list or call inspect/1 to get the list representation, got:
@@ -893,11 +893,11 @@ defmodule List do
   end
 
   @doc """
-  Converts a list of integers representing codepoints, lists or
+  Converts a list of integers representing code points, lists or
   strings into a charlist.
 
   Notice that this function expects a list of integers representing
-  UTF-8 codepoints. If you have a list of bytes, you must instead use
+  UTF-8 code points. If you have a list of bytes, you must instead use
   the [`:binary` module](http://www.erlang.org/doc/man/binary.html).
 
   ## Examples
@@ -925,7 +925,7 @@ defmodule List do
         To be converted to a charlist, a list must contain only:
 
           * strings
-          * integers representing Unicode codepoints
+          * integers representing Unicode code points
           * or a list containing one of these three elements
 
         Please check the given list or call inspect/1 to get the list representation, got:

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -502,7 +502,7 @@ defmodule Macro do
 
   In this setup, Elixir will escape the following: `\0`, `\a`, `\b`,
   `\d`, `\e`, `\f`, `\n`, `\r`, `\s`, `\t` and `\v`. Bytes can be
-  given as hexadecimals via `\xNN` and Unicode Codepoints as
+  given as hexadecimals via `\xNN` and Unicode code points as
   `\uNNNN` escapes.
 
   This function is commonly used on sigil implementations
@@ -531,7 +531,7 @@ defmodule Macro do
   ## Map
 
   The map must be a function. The function receives an integer
-  representing the codepoint of the character it wants to unescape.
+  representing the code point of the character it wants to unescape.
   Here is the default mapping function implemented by Elixir:
 
       def unescape_map(unicode), do: true
@@ -552,8 +552,8 @@ defmodule Macro do
   If the `unescape_map/1` function returns `false`, the char is
   not escaped and the backslash is kept in the string.
 
-  Hexadecimals and Unicode codepoints will be escaped if the map
-  function returns `true` for `?x`. Unicode codepoints if the map
+  Hexadecimals and Unicode code points will be escaped if the map
+  function returns `true` for `?x`. Unicode code points if the map
   function returns `true` for `?u`.
 
   ## Examples

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -4,15 +4,15 @@ defmodule String do
   @moduledoc ~S"""
   A String in Elixir is a UTF-8 encoded binary.
 
-  ## Codepoints and grapheme cluster
+  ## Code points and grapheme cluster
 
   The functions in this module act according to the Unicode
   Standard, version 11.0.0.
 
-  As per the standard, a codepoint is a single Unicode Character,
+  As per the standard, a code point is a single Unicode Character,
   which may be represented by one or more bytes.
 
-  For example, the codepoint "é" is two bytes:
+  For example, the code point "é" is two bytes:
 
       iex> byte_size("é")
       2
@@ -24,9 +24,9 @@ defmodule String do
 
   Furthermore, this module also presents the concept of grapheme cluster
   (from now on referenced as graphemes). Graphemes can consist of multiple
-  codepoints that may be perceived as a single character by readers. For
-  example, "é" can be represented either as a single "e with acute" codepoint
-  or as the letter "e" followed by a "combining acute accent" (two codepoints):
+  code points that may be perceived as a single character by readers. For
+  example, "é" can be represented either as a single "e with acute" code point
+  or as the letter "e" followed by a "combining acute accent" (two code points):
 
       iex> string = "\u0065\u0301"
       iex> byte_size(string)
@@ -62,7 +62,7 @@ defmodule String do
 
   To act according to the Unicode Standard, many functions
   in this module run in linear time, as they need to traverse
-  the whole string considering the proper Unicode codepoints.
+  the whole string considering the proper Unicode code points.
 
   For example, `String.length/1` will take longer as
   the input grows. On the other hand, `Kernel.byte_size/1` always runs
@@ -110,7 +110,7 @@ defmodule String do
   it could still be improved. In this case, since we want to
   extract a substring from a string, we can use `Kernel.byte_size/1`
   and `Kernel.binary_part/3` as there is no chance we will slice in
-  the middle of a codepoint made of more than one byte:
+  the middle of a code point made of more than one byte:
 
       iex> take_prefix = fn full, prefix ->
       ...>   base = byte_size(prefix)
@@ -132,18 +132,18 @@ defmodule String do
   On the other hand, if you want to dynamically slice a string
   based on an integer value, then using `String.slice/3` is the
   best option as it guarantees we won't incorrectly split a valid
-  codepoint into multiple bytes.
+  code point into multiple bytes.
 
-  ## Integer codepoints
+  ## Integer code points
 
-  Although codepoints could be represented as integers, this
-  module represents all codepoints as strings. For example:
+  Although code points could be represented as integers, this
+  module represents all code points as strings. For example:
 
       iex> String.codepoints("olá")
       ["o", "l", "á"]
 
   There are a couple of ways to retrieve a character integer
-  codepoint. One may use the `?` construct:
+  code point. One may use the `?` construct:
 
       iex> ?o
       111
@@ -157,7 +157,7 @@ defmodule String do
       iex> aacute
       225
 
-  As we have seen above, codepoints can be inserted into
+  As we have seen above, code points can be inserted into
   a string by their hexadecimal code:
 
       "ol\u0061\u0301" #=>
@@ -168,11 +168,11 @@ defmodule String do
   The UTF-8 encoding is self-synchronizing. This means that
   if malformed data (i.e., data that is not possible according
   to the definition of the encoding) is encountered, only one
-  codepoint needs to be rejected.
+  code point needs to be rejected.
 
   This module relies on this behaviour to ignore such invalid
   characters. For example, `length/1` will return
-  a correct result even if an invalid codepoint is fed into it.
+  a correct result even if an invalid code point is fed into it.
 
   In other words, this module expects invalid data to be detected
   elsewhere, usually when retrieving data from the external source.
@@ -212,10 +212,10 @@ defmodule String do
   """
   @type t :: binary
 
-  @typedoc "A UTF-8 codepoint. It may be one or more bytes."
+  @typedoc "A UTF-8 code point. It may be one or more bytes."
   @type codepoint :: t
 
-  @typedoc "Multiple codepoints that may be perceived as a single character by readers"
+  @typedoc "Multiple code points that may be perceived as a single character by readers"
   @type grapheme :: t
 
   @typedoc "Pattern used in functions like `replace/3` and `split/2`"
@@ -1452,9 +1452,9 @@ defmodule String do
   end
 
   @doc """
-  Returns all codepoints in the string.
+  Returns all code points in the string.
 
-  For details about codepoints and graphemes, see the `String` module documentation.
+  For details about code points and graphemes, see the `String` module documentation.
 
   ## Examples
 
@@ -1478,9 +1478,9 @@ defmodule String do
   defdelegate codepoints(string), to: String.Unicode
 
   @doc ~S"""
-  Returns the next codepoint in a string.
+  Returns the next code point in a string.
 
-  The result is a tuple with the codepoint and the
+  The result is a tuple with the code point and the
   remainder of the string or `nil` in case
   the string reached its end.
 
@@ -1625,7 +1625,7 @@ defmodule String do
   The algorithm is outlined in the [Unicode Standard Annex #29,
   Unicode Text Segmentation](http://www.unicode.org/reports/tr29/).
 
-  For details about codepoints and graphemes, see the `String` module documentation.
+  For details about code points and graphemes, see the `String` module documentation.
 
   ## Examples
 
@@ -2121,7 +2121,7 @@ defmodule String do
   Converts a string into a charlist.
 
   Specifically, this function takes a UTF-8 encoded binary and returns a list of its integer
-  codepoints. It is similar to `codepoints/1` except that the latter returns a list of codepoints as
+  code points. It is similar to `codepoints/1` except that the latter returns a list of code points as
   strings.
 
   In case you need to work with bytes, take a look at the
@@ -2158,7 +2158,7 @@ defmodule String do
   By default, the maximum number of atoms is `1_048_576`. This limit
   can be raised or lowered using the VM option `+t`.
 
-  The maximum atom size is of 255 Unicode codepoints.
+  The maximum atom size is of 255 Unicode code points.
 
   Inlined by the compiler.
 
@@ -2176,7 +2176,7 @@ defmodule String do
   @doc """
   Converts a string to an existing atom.
 
-  The maximum atom size is of 255 Unicode codepoints.
+  The maximum atom size is of 255 Unicode code points.
 
   Inlined by the compiler.
 

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -510,7 +510,7 @@ defmodule Task do
 
   ## Example
 
-  Count the codepoints in each string asynchronously, then add the counts together using reduce.
+  Count the code points in each string asynchronously, then add the counts together using reduce.
 
       iex> strings = ["long string", "longer string", "there are many of these"]
       iex> stream = Task.async_stream(strings, fn text -> text |> String.codepoints() |> Enum.count() end)

--- a/lib/elixir/pages/Syntax Reference.md
+++ b/lib/elixir/pages/Syntax Reference.md
@@ -58,7 +58,7 @@ Strings are always represented as themselves in the AST.
 
 ### Charlists
 
-Charlists in Elixir are written in single-quotes, such as `'foo'`. Any single-quote inside the string must be escaped with `\ `. Charlists are made of non-negative integers, where each integer represents a Unicode codepoint.
+Charlists in Elixir are written in single-quotes, such as `'foo'`. Any single-quote inside the string must be escaped with `\ `. Charlists are made of non-negative integers, where each integer represents a Unicode code point.
 
 Multi-line charlists are written with three single-quotes (`'''`), the same multi-line strings are.
 
@@ -378,7 +378,7 @@ end
 
 All of the constructs above are part of Elixir's syntax and have their own representation as part of the Elixir AST. This section will discuss the remaining constructs that "desugar" to one of the constructs explored above. In other words, the constructs below can be represented in more than one way in your Elixir code and retain AST equivalence.
 
-### Integers in other bases and Unicode codepoints
+### Integers in other bases and Unicode code points
 
 Elixir allows integers to contain `_` to separate digits and provides conveniences to represent integers in other bases:
 
@@ -396,7 +396,7 @@ Elixir allows integers to contain `_` to separate digits and provides convenienc
 #=> 170 (Binary base)
 
 ?é
-#=> 233 (Unicode codepoint)
+#=> 233 (Unicode code point)
 ```
 
 Those constructs exist only at the syntax level. All of the examples above are represented as their underlying integers in the AST.

--- a/lib/elixir/pages/Unicode Syntax.md
+++ b/lib/elixir/pages/Unicode Syntax.md
@@ -2,7 +2,7 @@
 
 Elixir supports Unicode throughout the language.
 
-Quoted identifiers, such as strings (`"olá"`) and charlists (`'olá'`), support Unicode since Elixir v1.0. Strings are UTF-8 encoded. Charlists are lists of Unicode codepoints. In such cases, the contents are kept as written by developers, without any transformation.
+Quoted identifiers, such as strings (`"olá"`) and charlists (`'olá'`), support Unicode since Elixir v1.0. Strings are UTF-8 encoded. Charlists are lists of Unicode code points. In such cases, the contents are kept as written by developers, without any transformation.
 
 Elixir also supports Unicode in identifiers since Elixir v1.5, as defined in the [Unicode Annex #31](http://unicode.org/reports/tr31/). The focus of this document is to describe how Elixir implements the requirements outlined in the Unicode Annex. These requirements are referred to as R1, R6 and so on.
 
@@ -26,7 +26,7 @@ and `<Continue>` uses the same categories as the spec but restricts them to the 
 >
 > In set notation: `[\p{ID_Start}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\p{Other_ID_Continue}-\p{Pattern_Syntax}-\p{Pattern_White_Space}]`
 
-`<Ending>` is an addition specific to Elixir that includes only the codepoints `?` (003F) and `!` (0021).
+`<Ending>` is an addition specific to Elixir that includes only the code points `?` (003F) and `!` (0021).
 
 The spec also provides a `<Medial>` set but Elixir does not include any character on this set. Therefore the identifier rule has been simplified to consider this.
 
@@ -36,19 +36,19 @@ Elixir does not allow the use of ZWJ or ZWNJ in identifiers and therefore does n
 
 Atoms in Elixir follow the identifier rule above with the following modifications:
 
-  * `<Start>` includes the codepoint `_` (005F)
-  * `<Continue>` includes the codepoint `@` (0040)
+  * `<Start>` includes the code point `_` (005F)
+  * `<Continue>` includes the code point `@` (0040)
 
 ### Variables
 
 Variables in Elixir follow the identifier rule above with the following modifications:
 
-  * `<Start>` includes the codepoint `_` (005F)
+  * `<Start>` includes the code point `_` (005F)
   * `<Start>` must not include Lu (letter uppercase) and Lt (letter titlecase) characters
 
 ## R3. Pattern_White_Space and Pattern_Syntax Characters
 
-Elixir supports only codepoints `\t` (0009), `\n` (000A), `\r` (000D) and `\s` (0020) as whitespace and therefore does not follow requirement R3. R3 requires a wider variety of whitespace and syntax characters to be supported.
+Elixir supports only code points `\t` (0009), `\n` (000A), `\r` (000D) and `\s` (0020) as whitespace and therefore does not follow requirement R3. R3 requires a wider variety of whitespace and syntax characters to be supported.
 
 ## R6. Filtered Normalized Identifiers
 
@@ -56,6 +56,6 @@ Identifiers in Elixir are case sensitive.
 
 Elixir requires all atoms and variables to be in NFC form. Any other form will fail with a relevant error message. Quoted-atoms and strings can, however, be in any form and are not verified by the parser.
 
-In other words, the atom `:josé` can only be written with the codepoints `006A 006F 0073 00E9`. Using another normalization form will lead to a tokenizer error. On the other hand, `:"josé"` may be written as `006A 006F 0073 00E9` or `006A 006F 0073 0065 0301`, since it is written between quotes.
+In other words, the atom `:josé` can only be written with the code points `006A 006F 0073 00E9`. Using another normalization form will lead to a tokenizer error. On the other hand, `:"josé"` may be written as `006A 006F 0073 00E9` or `006A 006F 0073 0065 0301`, since it is written between quotes.
 
 Choosing requirement R6 automatically excludes requirements R4, R5 and R7.

--- a/lib/elixir/src/elixir_interpolation.erl
+++ b/lib/elixir/src/elixir_interpolation.erl
@@ -133,31 +133,31 @@ unescape_hex(<<A, B, Rest/binary>>, Map, Acc) when ?is_hex(A), ?is_hex(B) ->
 %% TODO: Remove deprecated sequences on v2.0
 
 unescape_hex(<<A, Rest/binary>>, Map, Acc) when ?is_hex(A) ->
-  io:format(standard_error, "warning: \\xH inside strings/sigils/chars is deprecated, please use \\xHH (byte) or \\uHHHH (codepoint) instead~n", []),
+  io:format(standard_error, "warning: \\xH inside strings/sigils/chars is deprecated, please use \\xHH (byte) or \\uHHHH (code point) instead~n", []),
   append_codepoint(Rest, Map, [A], Acc, 16);
 
 unescape_hex(<<${, A, $}, Rest/binary>>, Map, Acc) when ?is_hex(A) ->
-  io:format(standard_error, "warning: \\x{H*} inside strings/sigils/chars is deprecated, please use \\xHH (byte) or \\uHHHH (codepoint) instead~n", []),
+  io:format(standard_error, "warning: \\x{H*} inside strings/sigils/chars is deprecated, please use \\xHH (byte) or \\uHHHH (code point) instead~n", []),
   append_codepoint(Rest, Map, [A], Acc, 16);
 
 unescape_hex(<<${, A, B, $}, Rest/binary>>, Map, Acc) when ?is_hex(A), ?is_hex(B) ->
-  io:format(standard_error, "warning: \\x{H*} inside strings/sigils/chars is deprecated, please use \\xHH (byte) or \\uHHHH (codepoint) instead~n", []),
+  io:format(standard_error, "warning: \\x{H*} inside strings/sigils/chars is deprecated, please use \\xHH (byte) or \\uHHHH (code point) instead~n", []),
   append_codepoint(Rest, Map, [A, B], Acc, 16);
 
 unescape_hex(<<${, A, B, C, $}, Rest/binary>>, Map, Acc) when ?is_hex(A), ?is_hex(B), ?is_hex(C) ->
-  io:format(standard_error, "warning: \\x{H*} inside strings/sigils/chars is deprecated, please use \\xHH (byte) or \\uHHHH (codepoint) instead~n", []),
+  io:format(standard_error, "warning: \\x{H*} inside strings/sigils/chars is deprecated, please use \\xHH (byte) or \\uHHHH (code point) instead~n", []),
   append_codepoint(Rest, Map, [A, B, C], Acc, 16);
 
 unescape_hex(<<${, A, B, C, D, $}, Rest/binary>>, Map, Acc) when ?is_hex(A), ?is_hex(B), ?is_hex(C), ?is_hex(D) ->
-  io:format(standard_error, "warning: \\x{H*} inside strings/sigils/chars is deprecated, please use \\xHH (byte) or \\uHHHH (codepoint) instead~n", []),
+  io:format(standard_error, "warning: \\x{H*} inside strings/sigils/chars is deprecated, please use \\xHH (byte) or \\uHHHH (code point) instead~n", []),
   append_codepoint(Rest, Map, [A, B, C, D], Acc, 16);
 
 unescape_hex(<<${, A, B, C, D, E, $}, Rest/binary>>, Map, Acc) when ?is_hex(A), ?is_hex(B), ?is_hex(C), ?is_hex(D), ?is_hex(E) ->
-  io:format(standard_error, "warning: \\x{H*} inside strings/sigils/chars is deprecated, please use \\xHH (byte) or \\uHHHH (codepoint) instead~n", []),
+  io:format(standard_error, "warning: \\x{H*} inside strings/sigils/chars is deprecated, please use \\xHH (byte) or \\uHHHH (code point) instead~n", []),
   append_codepoint(Rest, Map, [A, B, C, D, E], Acc, 16);
 
 unescape_hex(<<${, A, B, C, D, E, F, $}, Rest/binary>>, Map, Acc) when ?is_hex(A), ?is_hex(B), ?is_hex(C), ?is_hex(D), ?is_hex(E), ?is_hex(F) ->
-  io:format(standard_error, "warning: \\x{H*} inside strings/sigils/chars is deprecated, please use \\xHH (byte) or \\uHHHH (codepoint) instead~n", []),
+  io:format(standard_error, "warning: \\x{H*} inside strings/sigils/chars is deprecated, please use \\xHH (byte) or \\uHHHH (code point) instead~n", []),
   append_codepoint(Rest, Map, [A, B, C, D, E, F], Acc, 16);
 
 unescape_hex(<<_/binary>>, _Map, _Acc) ->
@@ -196,7 +196,7 @@ append_codepoint(Rest, Map, List, Acc, Base) ->
     Binary -> unescape_chars(Rest, Map, Binary)
   catch
     error:badarg ->
-      Msg = <<"invalid or reserved Unicode codepoint ", (integer_to_binary(Codepoint))/binary>>,
+      Msg = <<"invalid or reserved Unicode code point ", (integer_to_binary(Codepoint))/binary>>,
       error('Elixir.ArgumentError':exception([{message, Msg}]))
   end.
 

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -213,7 +213,7 @@ tokenize([$~, S, H | T] = Original, Line, Column, Scope, Tokens) when ?is_sigil(
 
 tokenize([$~, S, H | _] = Original, Line, Column, _Scope, Tokens) when ?is_upcase(S) orelse ?is_downcase(S) ->
   MessageString =
-    "\"~ts\" (column ~p, codepoint U+~4.16.0B). The available delimiters are: "
+    "\"~ts\" (column ~p, code point U+~4.16.0B). The available delimiters are: "
     "//, ||, \"\", '', (), [], {}, <>",
   Message = io_lib:format(MessageString, [[H], Column + 2, H]),
   {error, {Line, Column, "invalid sigil delimiter: ", Message}, Original, Tokens};
@@ -234,7 +234,7 @@ tokenize([$?, $\\, H | T], Line, Column, Scope, Tokens) ->
 tokenize([$?, Char | T], Line, Column, Scope, Tokens) ->
   case handle_char(Char) of
     {Escape, Name} ->
-      Msg = io_lib:format("found ? followed by codepoint 0x~.16B (~ts), please use ?~ts instead",
+      Msg = io_lib:format("found ? followed by code point 0x~.16B (~ts), please use ?~ts instead",
                           [Char, Name, Escape]),
       elixir_errors:erl_warn(Line, Scope#elixir_tokenizer.file, Msg);
     false ->
@@ -579,7 +579,7 @@ tokenize(String, Line, Column, Scope, Tokens) ->
   end.
 
 unexpected_token([T | Rest], Line, Column, Tokens) ->
-  Message = io_lib:format("\"~ts\" (column ~p, codepoint U+~4.16.0B)", [[T], Column, T]),
+  Message = io_lib:format("\"~ts\" (column ~p, code point U+~4.16.0B)", [[T], Column, T]),
   {error, {Line, Column, "unexpected token: ", Message}, Rest, Tokens}.
 
 tokenize_eol(Rest, Line, Scope, Tokens) ->
@@ -1108,8 +1108,8 @@ tokenize_identifier(String, Line, Column, Scope) ->
       RightCodepoints = list_to_codepoint_hex(Right),
       WrongCodepoints = list_to_codepoint_hex(Wrong),
       Message = io_lib:format("Elixir expects unquoted Unicode atoms, variables, and calls to be in NFC form.\n\n"
-                              "Got:\n\n    \"~ts\" (codepoints~ts)\n\n"
-                              "Expected:\n\n    \"~ts\" (codepoints~ts)\n\n"
+                              "Got:\n\n    \"~ts\" (code points~ts)\n\n"
+                              "Expected:\n\n    \"~ts\" (code points~ts)\n\n"
                               "Syntax error before: ",
                               [Wrong, WrongCodepoints, Right, RightCodepoints]),
       {error, {Line, Column, Message, Wrong}};
@@ -1374,7 +1374,7 @@ keyword('catch')  -> block;
 keyword(_) -> false.
 
 invalid_character_error(What, Char) ->
-  io_lib:format("invalid character \"~ts\" (codepoint U+~4.16.0B) in ~ts: ", [[Char], Char, What]).
+  io_lib:format("invalid character \"~ts\" (code point U+~4.16.0B) in ~ts: ", [[Char], Char, What]).
 
 invalid_do_error(Prefix) ->
   {Prefix, ". In case you wanted to write a \"do\" expression, "

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -31,7 +31,7 @@ defmodule Kernel.ErrorsTest do
 
   test "invalid token" do
     assert_eval_raise SyntaxError,
-                      "nofile:1: unexpected token: \"\u200B\" (column 7, codepoint U+200B)",
+                      "nofile:1: unexpected token: \"\u200B\" (column 7, code point U+200B)",
                       '[foo: \u200B]\noops'
   end
 
@@ -80,7 +80,7 @@ defmodule Kernel.ErrorsTest do
 
   test "invalid identifier" do
     message = fn name ->
-      "nofile:1: invalid character \"@\" (codepoint U+0040) in identifier: #{name}"
+      "nofile:1: invalid character \"@\" (code point U+0040) in identifier: #{name}"
     end
 
     assert_eval_raise SyntaxError, message.("foo@"), 'foo@'
@@ -88,20 +88,20 @@ defmodule Kernel.ErrorsTest do
     assert_eval_raise SyntaxError, message.("foo@bar"), 'foo@bar'
 
     message = fn name ->
-      "nofile:1: invalid character \"@\" (codepoint U+0040) in alias: #{name}"
+      "nofile:1: invalid character \"@\" (code point U+0040) in alias: #{name}"
     end
 
     assert_eval_raise SyntaxError, message.("Foo@"), 'Foo@'
     assert_eval_raise SyntaxError, message.("Foo@bar"), 'Foo@bar'
 
-    message = "nofile:1: invalid character \"!\" (codepoint U+0021) in alias: Foo!"
+    message = "nofile:1: invalid character \"!\" (code point U+0021) in alias: Foo!"
     assert_eval_raise SyntaxError, message, 'Foo!'
 
-    message = "nofile:1: invalid character \"?\" (codepoint U+003F) in alias: Foo?"
+    message = "nofile:1: invalid character \"?\" (code point U+003F) in alias: Foo?"
     assert_eval_raise SyntaxError, message, 'Foo?'
 
     message =
-      "nofile:1: invalid character \"ó\" (codepoint U+00F3) in alias (only ASCII characters are allowed): Foó"
+      "nofile:1: invalid character \"ó\" (code point U+00F3) in alias (only ASCII characters are allowed): Foó"
 
     assert_eval_raise SyntaxError, message, 'Foó'
 
@@ -110,11 +110,11 @@ defmodule Kernel.ErrorsTest do
 
     Got:
 
-        "foó" \(codepoints 0x0066 0x006F 0x006F 0x0301\)
+        "foó" \(code points 0x0066 0x006F 0x006F 0x0301\)
 
     Expected:
 
-        "foó" \(codepoints 0x0066 0x006F 0x00F3\)
+        "foó" \(code points 0x0066 0x006F 0x00F3\)
 
     """
 

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1124,10 +1124,10 @@ defmodule Kernel.WarningTest do
     purge(Sample2)
   end
 
-  test "warning on codepoint escape" do
+  test "warning on code point escape" do
     assert capture_err(fn ->
              Code.eval_string("? ")
-           end) =~ "found ? followed by codepoint 0x20 (space), please use ?\\s instead"
+           end) =~ "found ? followed by code point 0x20 (space), please use ?\\s instead"
   end
 
   test "duplicated docs in the same clause" do

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -221,4 +221,4 @@ sigil_terminator_test() ->
 
 invalid_sigil_delimiter_test() ->
   {1, 1, "invalid sigil delimiter: ", Message} = tokenize_error("~s\\"),
-  true = lists:prefix("\"\\\" (column 3, codepoint U+005C)", lists:flatten(Message)).
+  true = lists:prefix("\"\\\" (column 3, code point U+005C)", lists:flatten(Message)).

--- a/lib/elixir/unicode/unicode.ex
+++ b/lib/elixir/unicode/unicode.ex
@@ -278,7 +278,7 @@ defmodule String.Unicode do
     {acc, string}
   end
 
-  # Codepoints
+  # Code points
 
   def next_codepoint(<<cp::utf8, rest::binary>>) do
     {<<cp::utf8>>, rest}

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -526,7 +526,7 @@ defmodule ExUnit.DocTestTest do
     assert output =~ """
              8) doctest ExUnit.DocTestTest.Invalid.dedented_past_fence/0 (8) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:189: unexpected token: "`" (column 5, codepoint U+0060)
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:189: unexpected token: "`" (column 5, code point U+0060)
                 code: 3
                           ```
                 stacktrace:
@@ -536,7 +536,7 @@ defmodule ExUnit.DocTestTest do
     assert output =~ """
              9) doctest ExUnit.DocTestTest.Invalid.indented_not_enough/0 (9) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:173: unexpected token: "`" (column 1, codepoint U+0060)
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:173: unexpected token: "`" (column 1, code point U+0060)
                 code: 3
                       `
                 stacktrace:
@@ -546,7 +546,7 @@ defmodule ExUnit.DocTestTest do
     assert output =~ """
             10) doctest ExUnit.DocTestTest.Invalid.indented_too_much/0 (10) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:181: unexpected token: "`" (column 3, codepoint U+0060)
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:181: unexpected token: "`" (column 3, code point U+0060)
                 code: 3
                         ```
                 stacktrace:

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -133,7 +133,7 @@ defimpl IEx.Info, for: List do
     description = """
     This is a list of integers that is printed as a sequence of characters
     delimited by single quotes because all the integers in it represent printable
-    ASCII characters. Conventionally, a list of Unicode codepoints is known as a
+    ASCII characters. Conventionally, a list of Unicode code points is known as a
     charlist and a list of ASCII characters is a subset of it.
     """
 
@@ -188,7 +188,7 @@ defimpl IEx.Info, for: BitString do
   defp info_string(bitstring) do
     description = """
     This is a string: a UTF-8 encoded binary. It's printed surrounded by
-    "double quotes" because all UTF-8 encoded codepoints in it are printable.
+    "double quotes" because all UTF-8 encoded code points in it are printable.
     """
 
     [
@@ -205,7 +205,7 @@ defimpl IEx.Info, for: BitString do
     desc = """
     This is a string: a UTF-8 encoded binary. It's printed with the `<<>>`
     syntax (as opposed to double quotes) because it contains non-printable
-    UTF-8 encoded codepoints (the first non-printable codepoint being
+    UTF-8 encoded code points (the first non-printable code point being
     `#{inspect(first_non_printable)}`).
     """
 

--- a/lib/iex/test/iex/info_test.exs
+++ b/lib/iex/test/iex/info_test.exs
@@ -87,7 +87,7 @@ defmodule IEx.InfoTest do
       assert get_key(info, "Byte size") == 7
       assert description =~ "This is a string"
       assert description =~ "It's printed with the `<<>>`"
-      assert description =~ "the first non-printable codepoint being\n`<<0>>`"
+      assert description =~ "the first non-printable code point being\n`<<0>>`"
     end
 
     test "binary" do

--- a/lib/logger/lib/logger/formatter.ex
+++ b/lib/logger/lib/logger/formatter.ex
@@ -47,7 +47,7 @@ defmodule Logger.Formatter do
   @replacement "�"
 
   @doc """
-  Prunes non-valid UTF-8 codepoints.
+  Prunes non-valid UTF-8 code points.
 
   Typically called after formatting when the data cannot be printed.
   """

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -6,7 +6,7 @@ defmodule Logger.Utils do
 
   There is a chance we truncate in the middle of a grapheme
   cluster but we never truncate in the middle of a binary
-  codepoint. For this reason, truncation is not exact.
+  code point. For this reason, truncation is not exact.
   """
   @spec truncate(IO.chardata(), non_neg_integer) :: IO.chardata()
   def truncate(chardata, :infinity) when is_binary(chardata) or is_list(chardata) do
@@ -69,7 +69,7 @@ defmodule Logger.Utils do
 
   defp fix_binary(binary) do
     # Use a thirteen-bytes offset to look back in the binary.
-    # This should allow at least two codepoints of 6 bytes.
+    # This should allow at least two code points of 6 bytes.
     suffix_size = min(byte_size(binary), 13)
     prefix_size = byte_size(binary) - suffix_size
     <<prefix::binary-size(prefix_size), suffix::binary-size(suffix_size)>> = binary

--- a/lib/mix/lib/mix/tasks/app.tree.ex
+++ b/lib/mix/lib/mix/tasks/app.tree.ex
@@ -19,10 +19,10 @@ defmodule Mix.Tasks.App.Tree do
 
     * `--format` - Can be set to one of either:
 
-      * `pretty` - uses Unicode codepoints for formatting the tree.
+      * `pretty` - uses Unicode code points for formatting the tree.
         This is the default except on Windows.
 
-      * `plain` - does not use Unicode codepoints for formatting the tree.
+      * `plain` - does not use Unicode code points for formatting the tree.
         This is the default on Windows.
 
       * `dot` - produces a DOT graph description of the application tree

--- a/lib/mix/lib/mix/tasks/deps.tree.ex
+++ b/lib/mix/lib/mix/tasks/deps.tree.ex
@@ -21,10 +21,10 @@ defmodule Mix.Tasks.Deps.Tree do
 
     * `--format` - Can be set to one of either:
 
-      * `pretty` - uses Unicode codepoints for formatting the tree.
+      * `pretty` - uses Unicode code points for formatting the tree.
         This is the default except on Windows.
 
-      * `plain` - does not use Unicode codepoints for formatting the tree.
+      * `plain` - does not use Unicode code points for formatting the tree.
         This is the default on Windows.
 
       * `dot` - produces a DOT graph description of the dependency tree


### PR DESCRIPTION
That's the term it is used in the Unicode standard.

/cc @fertapric 