### PR TITLE
Clearer documentation for GenServer timeouts

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -414,7 +414,7 @@ defmodule GenServer do
 
   Returning `{:ok, state, timeout}` is similar to `{:ok, state}`,
   except that it also sets a timeout. See the "Timeouts" section
-  in the module documentation.
+  in the module documentation for more information.
 
   Returning `{:ok, state, :hibernate}` is similar to `{:ok, state}`
   except the process is hibernated before entering the loop. See

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -251,16 +251,17 @@ defmodule GenServer do
   ## Timeouts
 
   The return value of `c:init/1` or any of the `handle_*` callbacks may include
-  a timeout value in milliseconds; if not, `:infinity` is assumed. Each time a
-  timeout is set, it replaces the previously set timeout.
+  a timeout value in milliseconds; if not, `:infinity` is assumed.
+  The timeout can be used to detect a lull in incoming messages.
 
   If the process has no messages waiting when the timeout is set and the
   number of given milliseconds pass without any message arriving,
   then `handle_info/2` will be called with `:timeout` as the first argument.
+  The timeout is cleared if any message is waiting or arrives before the timeout.
 
-  Because the timeout is cleared by each received message, even a timeout of `0` milliseconds
-  is not guaranteed to execute. To take another action immediately and
-  unconditionally, use a `:continue` instruction.
+  Because a message may arrive before the timeout is set, even a timeout of `0`
+  milliseconds is not guaranteed to execute. To take another action immediately
+  and unconditionally, use a `:continue` instruction.
 
   ## When (not) to use a GenServer
 

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -260,7 +260,7 @@ defmodule GenServer do
 
   Because the timeout is cleared by each received message, even a timeout of `0` milliseconds
   is not guaranteed to execute. To take another action immediately and
-  unconditionally, use a `continue` instruction.
+  unconditionally, use a `:continue` instruction.
 
   ## When (not) to use a GenServer
 

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -464,7 +464,7 @@ defmodule GenServer do
 
   Returning `{:reply, reply, new_state, timeout}` is similar to
   `{:reply, reply, new_state}` except that it also sets a timeout.
-  See the "Timeouts" section in the module documentation.
+  See the "Timeouts" section in the module documentation for more information.
 
   Returning `{:reply, reply, new_state, :hibernate}` is similar to
   `{:reply, reply, new_state}` except the process is hibernated and will
@@ -531,7 +531,7 @@ defmodule GenServer do
 
   Returning `{:noreply, new_state, timeout}` is similar to `{:noreply, new_state}`
   except that it also sets a timeout. See the "Timeouts" section in the module
-  documentation.
+  documentation for more information.
 
   Returning `{:noreply, new_state, :hibernate}` is similar to
   `{:noreply, new_state}` except the process is hibernated before continuing the

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -258,7 +258,7 @@ defmodule GenServer do
   number of given milliseconds pass without any message arriving,
   then `handle_info/2` will be called with `:timeout` as the first argument.
 
-  Because the timeout is cleared by each message received, even a timeout of `0`
+  Because the timeout is cleared by each received message, even a timeout of `0` milliseconds
   is not guaranteed to execute. To take another action immediately and
   unconditionally, use a `continue` instruction.
 

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -255,7 +255,7 @@ defmodule GenServer do
   timeout is set, it replaces the previously set timeout.
 
   If the process has no messages waiting when the timeout is set and the
-  number of millseconds specified pass without any message arriving,
+  number of given milliseconds pass without any message arriving,
   `handle_info(:timeout, new_state)` will be called.
 
   Because the timeout is cleared by each message received, even a timeout of `0`

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -248,6 +248,20 @@ defmodule GenServer do
         end
       end
 
+  ## Timeouts
+
+  The return value of `c:init/1` or any of the `handle_*` callbacks may include
+  a timeout value in milliseconds; if not, `:infinity` is assumed. Each time a
+  timeout is set, it replaces the previously set timeout.
+
+  If the process has no messages waiting when the timeout is set, and if the
+  number of millseconds specified pass without any message arriving,
+  `handle_info(:timeout, new_state)` will be called.
+
+  Because the timeout is cleared by each message received, even a timeout of `0`
+  is not guaranteed to execute. To take another action immediately and
+  unconditionally, use a `continue` instruction.
+
   ## When (not) to use a GenServer
 
   So far, we have learned that a `GenServer` can be used as a supervised process
@@ -396,9 +410,9 @@ defmodule GenServer do
   Returning `{:ok, state}` will cause `start_link/3` to return
   `{:ok, pid}` and the process to enter its loop.
 
-  Returning `{:ok, state, timeout}` is similar to `{:ok, state}`
-  except `handle_info(:timeout, state)` will be called after `timeout`
-  milliseconds if no messages are received within the timeout.
+  Returning `{:ok, state, timeout}` is similar to `{:ok, state}`,
+  except that it also sets a timeout. See the "Timeouts" section
+  in the module documentation.
 
   Returning `{:ok, state, :hibernate}` is similar to `{:ok, state}`
   except the process is hibernated before entering the loop. See
@@ -447,8 +461,8 @@ defmodule GenServer do
   caller and continues the loop with new state `new_state`.
 
   Returning `{:reply, reply, new_state, timeout}` is similar to
-  `{:reply, reply, new_state}` except `handle_info(:timeout, new_state)` will be
-  called after `timeout` milliseconds if no messages are received.
+  `{:reply, reply, new_state}` except that it also sets a timeout.
+  See the "Timeouts" section in the module documentation.
 
   Returning `{:reply, reply, new_state, :hibernate}` is similar to
   `{:reply, reply, new_state}` except the process is hibernated and will
@@ -513,9 +527,9 @@ defmodule GenServer do
 
   Returning `{:noreply, new_state}` continues the loop with new state `new_state`.
 
-  Returning `{:noreply, new_state, timeout}` is similar to
-  `{:noreply, new_state}` except `handle_info(:timeout, new_state)` will be
-  called after `timeout` milliseconds if no messages are received.
+  Returning `{:noreply, new_state, timeout}` is similar to `{:noreply, new_state}`
+  except that it also sets a timeout. See the "Timeouts" section in the module
+  documentation.
 
   Returning `{:noreply, new_state, :hibernate}` is similar to
   `{:noreply, new_state}` except the process is hibernated before continuing the

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -256,7 +256,7 @@ defmodule GenServer do
 
   If the process has no messages waiting when the timeout is set and the
   number of given milliseconds pass without any message arriving,
-  `handle_info(:timeout, new_state)` will be called.
+  then `handle_info/2` will be called with `:timeout` as the first argument.
 
   Because the timeout is cleared by each message received, even a timeout of `0`
   is not guaranteed to execute. To take another action immediately and

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -257,7 +257,8 @@ defmodule GenServer do
   If the process has no messages waiting when the timeout is set and the
   number of given milliseconds pass without any message arriving,
   then `handle_info/2` will be called with `:timeout` as the first argument.
-  The timeout is cleared if any message is waiting or arrives before the timeout.
+  The timeout is cleared if any message is waiting or arrives before the
+  given timeout.
 
   Because a message may arrive before the timeout is set, even a timeout of `0`
   milliseconds is not guaranteed to execute. To take another action immediately

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -254,7 +254,7 @@ defmodule GenServer do
   a timeout value in milliseconds; if not, `:infinity` is assumed. Each time a
   timeout is set, it replaces the previously set timeout.
 
-  If the process has no messages waiting when the timeout is set, and if the
+  If the process has no messages waiting when the timeout is set and the
   number of millseconds specified pass without any message arriving,
   `handle_info(:timeout, new_state)` will be called.
 


### PR DESCRIPTION
I thought it was unclear what would happen if a timeout of `0` were set
but messages were already waiting.