### PR TITLE
Remove Integer.to_string/1 and Integer.to_charlist/1

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -271,12 +271,13 @@ defmodule Integer do
 
   @doc """
   Returns a binary which corresponds to the text representation
-  of `integer`.
+  of `integer` in the given `base`.
+
+  `base` can be an integer between 2 and 36. If no `base` is given, it defaults to `10`.
 
   Inlined by the compiler.
 
   ## Examples
-
       iex> Integer.to_string(123)
       "123"
 
@@ -289,22 +290,6 @@ defmodule Integer do
       iex> Integer.to_string(0123)
       "123"
 
-  """
-  @spec to_string(integer) :: String.t()
-  def to_string(integer) do
-    :erlang.integer_to_binary(integer)
-  end
-
-  @doc """
-  Returns a binary which corresponds to the text representation
-  of `integer` in the given `base`.
-
-  `base` can be an integer between 2 and 36.
-
-  Inlined by the compiler.
-
-  ## Examples
-
       iex> Integer.to_string(100, 16)
       "64"
 
@@ -316,12 +301,14 @@ defmodule Integer do
 
   """
   @spec to_string(integer, 2..36) :: String.t()
-  def to_string(integer, base) do
+  def to_string(integer, base \\ 10) do
     :erlang.integer_to_binary(integer, base)
   end
 
   @doc """
-  Returns a charlist which corresponds to the text representation of the given `integer`.
+  Returns a charlist which corresponds to the text representation of `integer` in the given `base`.
+
+  `base` can be an integer between 2 and 36. If no `base` is given, it defaults to `10`.
 
   Inlined by the compiler.
 
@@ -339,21 +326,6 @@ defmodule Integer do
       iex> Integer.to_charlist(0123)
       '123'
 
-  """
-  @spec to_charlist(integer) :: charlist
-  def to_charlist(integer) do
-    :erlang.integer_to_list(integer)
-  end
-
-  @doc """
-  Returns a charlist which corresponds to the text representation of `integer` in the given `base`.
-
-  `base` can be an integer between 2 and 36.
-
-  Inlined by the compiler.
-
-  ## Examples
-
       iex> Integer.to_charlist(100, 16)
       '64'
 
@@ -365,7 +337,7 @@ defmodule Integer do
 
   """
   @spec to_charlist(integer, 2..36) :: charlist
-  def to_charlist(integer, base) do
+  def to_charlist(integer, base \\ 10) do
     :erlang.integer_to_list(integer, base)
   end
 

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -154,7 +154,7 @@ defmodule IntegerTest do
     assert_raise ArgumentError, "invalid base nil", fn -> Integer.parse("2", nil) end
   end
 
-  test "to_string/1" do
+  test "to_string/2" do
     assert Integer.to_string(42) == "42"
     assert Integer.to_string(+42) == "42"
     assert Integer.to_string(-42) == "-42"
@@ -165,9 +165,7 @@ defmodule IntegerTest do
         Integer.to_string(n)
       end
     end
-  end
 
-  test "to_string/2" do
     assert Integer.to_string(42, 2) == "101010"
     assert Integer.to_string(42, 10) == "42"
     assert Integer.to_string(42, 16) == "2A"
@@ -192,7 +190,9 @@ defmodule IntegerTest do
     end
   end
 
-  test "to_charlist/1" do
+  test "to_charlist/2" do
+    module = Integer
+
     assert Integer.to_charlist(42) == '42'
     assert Integer.to_charlist(+42) == '42'
     assert Integer.to_charlist(-42) == '-42'
@@ -203,14 +203,10 @@ defmodule IntegerTest do
         Integer.to_charlist(n)
       end
     end
-  end
 
-  test "to_char_list/1" do
-    module = Integer
     assert module.to_char_list(42) == '42'
-  end
+    assert module.to_char_list(42, 2) == '101010'
 
-  test "to_charlist/2" do
     assert Integer.to_charlist(42, 2) == '101010'
     assert Integer.to_charlist(42, 10) == '42'
     assert Integer.to_charlist(42, 16) == '2A'
@@ -233,11 +229,6 @@ defmodule IntegerTest do
         Integer.to_charlist(n, n)
       end
     end
-  end
-
-  test "to_char_list/2" do
-    module = Integer
-    assert module.to_char_list(42, 2) == '101010'
   end
 
   test "gcd/2" do


### PR DESCRIPTION
They are not needed, since they are covered by their /2 version.