### PR TITLE
Fix module inspect on case insensitive filesystems

### DIFF
--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -51,7 +51,7 @@ defimpl IEx.Info, for: Atom do
       {^atom, beam, _path} ->
         info = :beam_lib.info(beam)
 
-        {:ok, atom} == Keyword.fetch(info, :module)
+        Keyword.fetch(info, :module) == {:ok, atom}
     end
   end
 

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -49,13 +49,9 @@ defimpl IEx.Info, for: Atom do
         Code.ensure_loaded?(atom)
 
       {^atom, beam, _path} ->
-        module_name =
-          beam
-          |> :beam_lib.info()
-          # Prevent match on `nil`
-          |> Keyword.get(:module, 0)
+        info = :beam_lib.info(beam)
 
-        module_name == atom
+        match?({:ok, ^atom}, Keyword.fetch(info, :module))
     end
   end
 

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -51,7 +51,7 @@ defimpl IEx.Info, for: Atom do
       {^atom, beam, _path} ->
         info = :beam_lib.info(beam)
 
-        match?({:ok, ^atom}, Keyword.fetch(info, :module))
+        {:ok, atom} == Keyword.fetch(info, :module)
     end
   end
 

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -50,7 +50,6 @@ defimpl IEx.Info, for: Atom do
 
       {^atom, beam, _path} ->
         info = :beam_lib.info(beam)
-
         Keyword.fetch(info, :module) == {:ok, atom}
     end
   end

--- a/lib/iex/test/iex/info_test.exs
+++ b/lib/iex/test/iex/info_test.exs
@@ -61,7 +61,7 @@ defmodule IEx.InfoTest do
           Info.info(Datetime)
         end)
 
-      assert "" == log_output
+      assert log_output == ""
     end
   end
 

--- a/lib/iex/test/iex/info_test.exs
+++ b/lib/iex/test/iex/info_test.exs
@@ -56,12 +56,7 @@ defmodule IEx.InfoTest do
     end
 
     test "do not log errors if module exists with different casing" do
-      log_output =
-        capture_log(fn ->
-          Info.info(Datetime)
-        end)
-
-      assert log_output == ""
+      assert capture_log(fn -> Info.info(Datetime) end) == ""
     end
   end
 

--- a/lib/iex/test/iex/info_test.exs
+++ b/lib/iex/test/iex/info_test.exs
@@ -3,6 +3,8 @@ Code.require_file("../test_helper.exs", __DIR__)
 defmodule IEx.InfoTest do
   use ExUnit.Case
 
+  import ExUnit.CaptureLog
+
   alias IEx.Info
 
   defmodule Foo do
@@ -51,6 +53,15 @@ defmodule IEx.InfoTest do
 
     test "regular atom" do
       assert Info.info(:foo) == [{"Data type", "Atom"}, {"Reference modules", "Atom"}]
+    end
+
+    test "do not log errors if module exists with different casing" do
+      log_output =
+        capture_log(fn ->
+          Info.info(Datetime)
+        end)
+
+      assert "" == log_output
     end
   end
 


### PR DESCRIPTION
Earlier this outputted error messages when loaded module that existed
with different casing, ex.:

    iex> i Datetime

Caused errors to be shown. Now this checks if there is module file
defines module with the same name as the provided atom to prevent such
cases.

Close #8780 