### PR TITLE
Added regex documentation for named character classes.

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -103,28 +103,40 @@ defmodule Regex do
 
     * `list(binary)` - a list of named captures to capture
 
-  ## Posix character classes
+  ## Character classes
 
-  There are several built in named character classes these are used by enclosing the name in [: :], this must be in a group [...] for example:
+  Regex supports several built in named character classes. These are used by
+  enclosing the class name in `[: :]` inside a group. For example:
 
-      String.match?("123", ~r/[[:alnum:]]/)
+      iex> String.match?("123", ~r/^[[:alnum:]]+$/)
+      true
+      iex> String.match?("123 456", ~r/^[[:alnum:][:blank:]]+$/)
+      true
 
-  The supported names are:
+  The supported class names are:
 
-  * alnum - Letters and digits
-  * alpha - Letters
-  * ascii - Character codes 0-127
-  * blank - Space or tab only
-  * cntrl - Control characters
-  * digit - Decimal digits (same as \\d)
-  * graph - Printing characters, excluding space
-  * lower - Lowercase letters
-  * print - Printing characters, including space
-  * punct - Printing characters, excluding letters, digits, and space
-  * space - Whitespace (the same as \\s from PCRE 8.34)
-  * upper - Uppercase letters
-  * word  - "Word" characters (same as \\w)
-  * xdigit - Hexadecimal digits
+    * alnum - Letters and digits
+    * alpha - Letters
+    * ascii - Character codes 0-127
+    * blank - Space or tab only
+    * cntrl - Control characters
+    * digit - Decimal digits (same as \\d)
+    * graph - Printing characters, excluding space
+    * lower - Lowercase letters
+    * print - Printing characters, including space
+    * punct - Printing characters, excluding letters, digits, and space
+    * space - Whitespace (the same as \s from PCRE 8.34)
+    * upper - Uppercase letters
+    * word  - "Word" characters (same as \w)
+    * xdigit - Hexadecimal digits
+
+  Note the behaviour of those classes may change according to the Unicode
+  and other modifiers:
+
+      iex> String.match?("josé", ~r/^[[:lower:]]+$/)
+      false
+      iex> String.match?("josé", ~r/^[[:lower:]]+$/u)
+      true
 
   """
 

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -103,6 +103,29 @@ defmodule Regex do
 
     * `list(binary)` - a list of named captures to capture
 
+  ## Posix character classes
+
+  There are several built in named character classes these are used by enclosing the name in [: :], this must be in a group [...] for example:
+
+      String.match?("123", ~r/[[:alnum:]]/)
+
+  The supported names are:
+
+  * alnum - Letters and digits
+  * alpha - Letters
+  * ascii - Character codes 0-127
+  * blank - Space or tab only
+  * cntrl - Control characters
+  * digit - Decimal digits (same as \\d)
+  * graph - Printing characters, excluding space
+  * lower - Lowercase letters
+  * print - Printing characters, including space
+  * punct - Printing characters, excluding letters, digits, and space
+  * space - Whitespace (the same as \\s from PCRE 8.34)
+  * upper - Uppercase letters
+  * word  - "Word" characters (same as \\w)
+  * xdigit - Hexadecimal digits
+
   """
 
   defstruct re_pattern: nil, source: "", opts: "", re_version: ""


### PR DESCRIPTION
I am an Elixir mentor on Exercism.io.

Several of my students can't find the documentation for character classes in Regex.
I have added a section copied from the erlang Regex docs to make this easier to find.