### PR TITLE
(WIP) Do not allow to override macros with functions and vice-versa

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4633,6 +4633,8 @@ defmodule Kernel do
   An overridable function is lazily defined, allowing a developer to override
   it.
 
+  Macros cannot be overridden by functions and vice-versa.
+
   ## Example
 
       defmodule DefaultMod do

--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -60,6 +60,7 @@ fetch_definitions(File, Module) ->
   end,
 
   {All, Private} = fetch_definition(Entries, File, Module, Set, Bag, [], []),
+  elixir_overridable:ensure_no_kind_conflict(File, Module, All),
   Unreachable = elixir_locals:warn_unused_local(File, Module, All, Private),
   elixir_locals:ensure_no_undefined_local(File, Module, All),
   elixir_locals:ensure_no_import_conflict(File, Module, All),

--- a/lib/elixir/test/elixir/kernel/overridable_test.exs
+++ b/lib/elixir/test/elixir/kernel/overridable_test.exs
@@ -218,6 +218,34 @@ defmodule Kernel.OverridableTest do
     purge(Kernel.OverridableOrder.Forwarding)
   end
 
+  test "does not allow to override a function with a macro" do
+    assert_raise CompileError, "nofile:4: cannot override macro foo/0 with a function", fn ->
+      Code.eval_string("""
+      defmodule Kernel.OverridableMacro.FunctionOverride do
+        defmacro foo(), do: :ok
+        defoverridable foo: 0
+        def foo(), do: :invalid
+      end
+      """)
+    end
+
+    purge(Kernel.OverridableMacro.FunctionOverride)
+  end
+
+  test "does not allow to override a macro with a function" do
+    assert_raise CompileError, "nofile:4: cannot override function foo/0 with a macro", fn ->
+      Code.eval_string("""
+      defmodule Kernel.OverridableFunction.MacroOverride do
+        def foo(), do: :ok
+        defoverridable foo: 0
+        defmacro foo(), do: :invalid
+      end
+      """)
+    end
+
+    purge(Kernel.OverridableFunction.MacroOverride)
+  end
+
   test "undefined functions can't be marked as overridable" do
     message = "cannot make function foo/2 overridable because it was not defined"
 


### PR DESCRIPTION
Overriding a macro with a function (and vice-versa) might produce undesired effects.

For example, it's not clear if the following code should or should not raise:

```elixir
defmodule Foo do
  def foo, do: bar()
  defmacro bar, do: :ok
  defoverridable bar: 0
  def bar, do: :ok
end
```

On top of that, the current implementation of `super` does not work for such cases.