### PR TITLE
Do not overwrite existent ERTS files in release

### DIFF
--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -452,7 +452,7 @@ defmodule Mix.Release do
   def copy_erts(release) do
     destination = Path.join(release.path, "erts-#{release.erts_version}")
     File.mkdir_p!(destination)
-    File.cp_r!(release.erts_source, destination)
+    File.cp_r!(release.erts_source, destination, fn _, _ -> false end)
 
     _ = File.rm(Path.join(destination, "bin/erl"))
     _ = File.rm(Path.join(destination, "bin/erl.ini"))


### PR DESCRIPTION
Releases can include the Erlang Runtime System (ERTS), copying it by default from the ERTS installation of the machine. If the ERTS files were previously copied, the files are overwritten. However, some package managers install ERTS files without writing permissions, and once those files are copied they cannot be overwritten.

Because of that, a test was failing on my local machine:

```
  1) test requires confirmation if release already exists unless forcing (Mix.Tasks.ReleaseTest)
     /Users/fertapric/Dropbox/OSS/elixir/lib/mix/test/mix/tasks/release_test.exs:207
     ** (EXIT from #PID<0.4861.0>) an exception was raised:
         ** (File.CopyError) could not copy recursively from "/usr/local/Cellar/erlang/21.2.2/lib/erlang/erts-10.2.1" to "/Users/fertapric/Dropbox/OSS/elixir/lib/mix/tmp/Mix.Tasks.ReleaseTest/test requires confirmation if release already exists unless forcing/_build/dev/rel/release_test/erts-10.2.1". /usr/local/Cellar/erlang/21.2.2/lib/erlang/erts-10.2.1/bin/erl_child_setup: permission denied
             (elixir) lib/file.ex:892: File.cp_r!/3
             (mix) lib/mix/release.ex:455: Mix.Release.copy_erts/1
             (mix) lib/mix/tasks/release.ex:759: Mix.Tasks.Release.copy/2
             (elixir) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
             (elixir) lib/task/supervised.ex:35: Task.Supervised.reply/5
             (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```