### PR TITLE
Remove project_plugins from dependency rebar.config

### DIFF
--- a/lib/mix/lib/mix/rebar.ex
+++ b/lib/mix/lib/mix/rebar.ex
@@ -75,16 +75,17 @@ defmodule Mix.Rebar do
 
   @doc """
   Updates Rebar configuration to be more suitable for dependencies.
-
-  Drops `warnings_as_errors` from `erl_opts`.
   """
   def dependency_config(config) do
-    Enum.map(config, fn
+    Enum.flat_map(config, fn
       {:erl_opts, opts} ->
-        {:erl_opts, List.delete(opts, :warnings_as_errors)}
+        [{:erl_opts, List.delete(opts, :warnings_as_errors)}]
+
+      {:project_plugins, _} ->
+        []
 
       other ->
-        other
+        [other]
     end)
   end
 

--- a/lib/mix/test/fixtures/rebar_dep/rebar.config.script
+++ b/lib/mix/test/fixtures/rebar_dep/rebar.config.script
@@ -1,6 +1,7 @@
 CFG1 = CONFIG ++
 [{'SCRIPT', SCRIPT}] ++
 [{erl_opts, [warnings_as_errors]}] ++
+[{project_plugins, [remove_me]}] ++
 [{deps, [{git_rebar, "0.1..*", {git, filename:absname("../../test/fixtures/git_rebar"), master}}]}].
 
 case {os:getenv("FILE_FROM_ENV"), os:getenv("CONTENTS_FROM_ENV")} of

--- a/lib/mix/test/mix/rebar_test.exs
+++ b/lib/mix/test/mix/rebar_test.exs
@@ -154,7 +154,9 @@ defmodule Mix.RebarTest do
       dep_config = Mix.Rebar.dependency_config(config)
 
       assert config[:erl_opts] == [:warnings_as_errors]
+      assert config[:project_plugins] == [:remove_me]
       assert dep_config[:erl_opts] == []
+      refute dep_config[:project_plugins]
     end
   end
 


### PR DESCRIPTION
This will avoid fetching unnecessary plugins when using rebar3 dependencies.

This should not be back-ported to the `v1.8` branch.