### PR TITLE
String.Casing.Guards.{is_lowercase/1, is_uppercase/1}

### DIFF
--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -185,6 +185,36 @@ defmodule StringTest do
     assert String.downcase("OLÁ", :ascii) == "olÁ"
   end
 
+  require String.Casing.Guards
+
+  test "assert is_lowercase/1" do
+    "olá"
+    |> String.normalize(:nfc)
+    |> String.codepoints()
+    |> Enum.each(&assert(String.Casing.Guards.is_lowercase(&1)))
+  end
+
+  test "refute is_lowercase/1" do
+    "OLÁ"
+    |> String.normalize(:nfc)
+    |> String.codepoints()
+    |> Enum.each(&refute(String.Casing.Guards.is_lowercase(&1)))
+  end
+
+  test "assert is_uppercase/1" do
+    "OLÁ"
+    |> String.normalize(:nfc)
+    |> String.codepoints()
+    |> Enum.each(&assert(String.Casing.Guards.is_uppercase(&1)))
+  end
+
+  test "refute is_uppercase/1" do
+    "olá"
+    |> String.normalize(:nfc)
+    |> String.codepoints()
+    |> Enum.each(&refute(String.Casing.Guards.is_uppercase(&1)))
+  end
+
   test "capitalize/1" do
     assert String.capitalize("") == ""
     assert String.capitalize("abc") == "Abc"

--- a/lib/elixir/unicode/properties.ex
+++ b/lib/elixir/unicode/properties.ex
@@ -151,6 +151,29 @@ defmodule String.Casing do
       end
     end)
 
+  # Guards
+
+  [lowers, uppers] =
+    codes
+    |> Enum.reduce([[], []], fn
+      {_codepoint, upper, lower, _title}, [lowers, uppers] ->
+        [[lower | lowers], [upper | uppers]]
+    end)
+    |> Enum.map(&MapSet.new/1)
+    |> Enum.map(&MapSet.delete(&1, nil))
+    |> Enum.map(&MapSet.to_list/1)
+    |> Enum.map(&Enum.chunk_every(&1, 700))
+    |> Enum.map(fn chunks ->
+      for chunk <- chunks do
+        {:in, [context: Elixir, import: Kernel], [{:value, [], nil}, chunk]}
+      end
+    end)
+
+  defmodule Guards do
+    defguard is_lowercase(value) when unquote({:or, [context: Elixir, import: Kernel], lowers})
+    defguard is_uppercase(value) when unquote({:or, [context: Elixir, import: Kernel], uppers})
+  end
+
   # Downcase
 
   @conditional_downcase [


### PR DESCRIPTION
To parse strings with full Unicode support it’s useful to have guards `is_lowercase/1` and `is_uppercase/1` for codepoints.

I could produce my own library that would parse `"SpecialCasing.txt"` on its own but this would be a code duplication. Also, `String.Casing` module does not export anything to make it possible to reuse. I am not sure if the existence of these guards makes sense in the Elixir core, but it sounds like where it actually belongs.

It would be easier to explain the reasons with the code, hence this PR. If it’ll be found of any value, I could provide docs etc.