### PR TITLE
Store overridable information more efficiently

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1067,18 +1067,7 @@ defmodule Module do
 
           clause ->
             neighbours = :elixir_locals.yank(tuple, module)
-            overridable_definitions = :elixir_overridable.overridable(module)
-
-            count =
-              case :maps.find(tuple, overridable_definitions) do
-                {:ok, {count, _, _, _}} -> count + 1
-                :error -> 1
-              end
-
-            overridable_definitions =
-              :maps.put(tuple, {count, clause, neighbours, false}, overridable_definitions)
-
-            :elixir_overridable.overridable(module, overridable_definitions)
+            :elixir_overridable.record_overridable(module, tuple, clause, neighbours)
         end
 
       other ->
@@ -1163,7 +1152,7 @@ defmodule Module do
   @spec overridable?(module, definition) :: boolean
   def overridable?(module, {function_name, arity} = tuple)
       when is_atom(function_name) and is_integer(arity) and arity >= 0 and arity <= 255 do
-    :maps.is_key(tuple, :elixir_overridable.overridable(module))
+    :elixir_overridable.overridable_for(module, tuple) != :not_overridable
   end
 
   @doc """

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -287,7 +287,6 @@ build(Line, File, Module, Lexical) ->
   Tables = {DataSet, DataBag},
   elixir_def:setup(Tables),
   elixir_locals:setup(Tables),
-  elixir_overridable:setup(Tables),
   Tuple = {Module, Tables, Line, File},
 
   Ref =
@@ -307,10 +306,10 @@ build(Line, File, Module, Lexical) ->
 
 eval_form(Line, Module, DataBag, Block, Vars, E) ->
   {Value, EE} = elixir_compiler:eval_forms(Block, Vars, E),
-  elixir_overridable:store_pending(Module),
+  elixir_overridable:store_not_overriden(Module),
   EV = elixir_env:linify({Line, elixir_env:reset_vars(EE)}),
   EC = eval_callbacks(Line, DataBag, before_compile, [EV], EV),
-  elixir_overridable:store_pending(Module),
+  elixir_overridable:store_not_overriden(Module),
   {Value, EC}.
 
 eval_callbacks(Line, DataBag, Name, Args, E) ->

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -228,7 +228,8 @@ build(Line, File, Module, Lexical) ->
   %% * {{type, Tuple}, ...}, {{opaque, Tuple}, ...}
   %% * {{callback, Tuple}, ...}, {{macrocallback, Tuple}, ...}
   %% * {{def, Tuple}, ...} (from elixir_def)
-  %% * {{import, Tuple}, ...} (from_elixir_locals)
+  %% * {{import, Tuple}, ...} (from_elixir_local)
+  %% * {{overridable, Tuple}, ...} (from elixir_overridable)
   %%
   DataSet = ets:new(Module, [set, public]),
 
@@ -240,6 +241,7 @@ build(Line, File, Module, Lexical) ->
   %% * {deprecated, ...}
   %% * {persisted_attributes, ...}
   %% * {defs, ...} (from elixir_def)
+  %% * {overridables, ...} (from elixir_overridable)
   %% * {{default, Name}, ...} (from elixir_def)
   %% * {{clauses, Tuple}, ...} (from elixir_def)
   %% * {reattach, ...} (from elixir_local)

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -228,7 +228,7 @@ build(Line, File, Module, Lexical) ->
   %% * {{type, Tuple}, ...}, {{opaque, Tuple}, ...}
   %% * {{callback, Tuple}, ...}, {{macrocallback, Tuple}, ...}
   %% * {{def, Tuple}, ...} (from elixir_def)
-  %% * {{import, Tuple}, ...} (from_elixir_local)
+  %% * {{import, Tuple}, ...} (from elixir_locals)
   %% * {{overridable, Tuple}, ...} (from elixir_overridable)
   %%
   DataSet = ets:new(Module, [set, public]),
@@ -244,8 +244,8 @@ build(Line, File, Module, Lexical) ->
   %% * {overridables, ...} (from elixir_overridable)
   %% * {{default, Name}, ...} (from elixir_def)
   %% * {{clauses, Tuple}, ...} (from elixir_def)
-  %% * {reattach, ...} (from elixir_local)
-  %% * {{local, Tuple}, ...} (from elixir_local)
+  %% * {reattach, ...} (from elixir_locals)
+  %% * {{local, Tuple}, ...} (from elixir_locals)
   %%
   DataBag = ets:new(Module, [duplicate_bag, public]),
 

--- a/lib/elixir/src/elixir_overridable.erl
+++ b/lib/elixir/src/elixir_overridable.erl
@@ -19,12 +19,12 @@ overridable_for(Module, Tuple) ->
 record_overridable(Module, Tuple, Def, Neighbours) ->
   {Set, Bag} = elixir_module:data_tables(Module),
 
-  case ets:lookup(Set, {overridable, Tuple}) of
-    [{_, Count, _, _, _}] ->
-      ets:insert(Set, {{overridable, Tuple}, Count + 1, Def, Neighbours, false});
-    [] ->
-      ets:insert_new(Set, {{overridable, Tuple}, 1, Def, Neighbours, false}),
-      ets:insert(Bag, {overridable, Tuple})
+  case ets:insert_new(Set, {{overridable, Tuple}, 1, Def, Neighbours, false}) of
+    true ->
+      ets:insert(Bag, {overridable, Tuple});
+    false ->
+      [{_, Count, _, _, _}] = ets:lookup(Set, {overridable, Tuple}),
+      ets:insert(Set, {{overridable, Tuple}, Count + 1, Def, Neighbours, false})
   end,
 
   ok.

--- a/lib/elixir/src/elixir_overridable.erl
+++ b/lib/elixir/src/elixir_overridable.erl
@@ -4,7 +4,7 @@
 -include("elixir.hrl").
 -define(overriden_pos, 5).
 
-overridable_for(Module) ->
+overridables_for(Module) ->
   {Set, _} = elixir_module:data_tables(Module),
   match_overridables(Set, '_').
 
@@ -84,7 +84,7 @@ name(Name, Count) when is_integer(Count) ->
 %% Error handling
 
 format_error({no_super, Module, {Name, Arity}}) ->
-  Bins   = [format_fa(Tuple) || {{overridable, Tuple}, _, _, _, _} <- overridable_for(Module)],
+  Bins   = [format_fa(Tuple) || {{overridable, Tuple}, _, _, _, _} <- overridables_for(Module)],
   Joined = 'Elixir.Enum':join(Bins, <<", ">>),
   io_lib:format("no super defined for ~ts/~B in module ~ts. Overridable functions available are: ~ts",
     [Name, Arity, elixir_aliases:inspect(Module), Joined]).

--- a/lib/elixir/src/elixir_overridable.erl
+++ b/lib/elixir/src/elixir_overridable.erl
@@ -1,72 +1,82 @@
 % Holds the logic responsible for defining overridable functions and handling super.
 -module(elixir_overridable).
--export([setup/1, overridable/1, overridable/2, super/4, store_pending/1, format_error/1]).
+-export([overridable_for/2, record_overridable/4, super/4, store_not_overriden/1, format_error/1]).
 -include("elixir.hrl").
--define(attr, {elixir, overridable}).
+-define(overriden_pos, 5).
 
-setup({DataSet, _DataBag}) ->
-  ets:insert(DataSet, {?attr, #{}}).
-
-overridable(Module) ->
+overridable_for(Module) ->
   {Set, _} = elixir_module:data_tables(Module),
-  ets:lookup_element(Set, ?attr, 2).
+  match_overridables(Set, '_').
 
-overridable(Module, Value) ->
+overridable_for(Module, Tuple) ->
   {Set, _} = elixir_module:data_tables(Module),
-  ets:insert(Set, {?attr, Value}).
 
-super(Meta, Module, Function, E) ->
-  case store(Module, Function, true) of
-    {_, _, _} = KindNameMeta ->
-      KindNameMeta;
-    error ->
-      elixir_errors:form_error(Meta, ?key(E, file), ?MODULE, {no_super, Module, Function})
+  case ets:lookup(Set, {overridable, Tuple}) of
+    [Overridable] -> Overridable;
+    [] -> not_overridable
   end.
 
-store_pending(Module) ->
+record_overridable(Module, Tuple, Def, Neighbours) ->
+  {Set, _} = elixir_module:data_tables(Module),
+
+  case ets:lookup(Set, {overridable, Tuple}) of
+    [{_, Count, Def, Neighbours, Overriden}] ->
+      ets:insert(Set, {{overridable, Tuple}, Count + 1, Def, Neighbours, Overriden});
+    [] ->
+      ets:insert_new(Set, {{overridable, Tuple}, 1, Def, Neighbours, false})
+  end,
+
+  ok.
+
+super(Meta, Module, Tuple, E) ->
+  {Set, _} = elixir_module:data_tables(Module),
+
+  case ets:lookup(Set, {overridable, Tuple}) of
+    [Overridable] ->
+      store(Set, Module, Tuple, Overridable, true);
+    [] ->
+      elixir_errors:form_error(Meta, ?key(E, file), ?MODULE, {no_super, Module, Tuple})
+  end.
+
+store_not_overriden(Module) ->
   {Set, _} = elixir_module:data_tables(Module),
 
   [begin
-    {_, _, _} = store(Module, Pair, false),
-    Pair
-   end || {Pair, {_, _, _, false}} <- maps:to_list(overridable(Module)),
-          not ets:member(Set, {def, Pair})].
+    {_, _, _} = store(Set, Module, Tuple, Overridable, false),
+    Tuple
+  end || {{_, Tuple}, _, _, _, _} = Overridable <- match_overridables(Set, false),
+          not ets:member(Set, {def, Tuple})].
 
 %% Private
 
-store(Module, Function, Hidden) ->
-  Overridable = overridable(Module),
-  case maps:find(Function, Overridable) of
-    {ok, {Count, Def, Neighbours, Overridden}} ->
-      {{{def, {Name, Arity}}, Kind, Meta, File, _Check,
-       {Defaults, _HasBody, _LastDefaults}}, Clauses} = Def,
+match_overridables(Set, OverridenSpec) ->
+  ets:match_object(Set, {{overridable, '_'}, '_', '_', '_', OverridenSpec}).
 
-      {FinalKind, FinalName, FinalArity, FinalClauses} =
-        case Hidden of
-          false ->
-            {Kind, Name, Arity, Clauses};
-          true when Kind == defmacro; Kind == defmacrop ->
-            {defmacrop, name(Name, Count), Arity, Clauses};
-          true ->
-            {defp, name(Name, Count), Arity, Clauses}
-        end,
+store(Set, Module, Tuple, {_, Count, Def, Neighbours, Overriden}, Hidden) ->
+  {{{def, {Name, Arity}}, Kind, Meta, File, _Check,
+   {Defaults, _HasBody, _LastDefaults}}, Clauses} = Def,
 
-      Tuple = {FinalName, FinalArity},
+  {FinalKind, FinalName, FinalArity, FinalClauses} =
+    case Hidden of
+      false ->
+        {Kind, Name, Arity, Clauses};
+      true when Kind == defmacro; Kind == defmacrop ->
+        {defmacrop, name(Name, Count), Arity, Clauses};
+      true ->
+        {defp, name(Name, Count), Arity, Clauses}
+    end,
 
-      case Overridden of
-        false ->
-          overridable(Module, maps:put(Function, {Count, Def, Neighbours, true}, Overridable)),
-          elixir_def:store_definition(false, FinalKind, Meta, FinalName, FinalArity,
-                                      File, Module, Defaults, FinalClauses),
-          elixir_locals:reattach(Tuple, FinalKind, Module, Function, Neighbours, Meta);
-        true ->
-          ok
-      end,
+  case Overriden of
+    false ->
+      ets:update_element(Set, {overridable, Tuple}, {?overriden_pos, true}),
+      elixir_def:store_definition(false, FinalKind, Meta, FinalName, FinalArity,
+                                  File, Module, Defaults, FinalClauses),
+      elixir_locals:reattach({FinalName, FinalArity}, FinalKind, Module, Tuple, Neighbours, Meta);
+    true ->
+      ok
+  end,
 
-      {FinalKind, FinalName, Meta};
-    error ->
-      error
-  end.
+  {FinalKind, FinalName, Meta}.
 
 name(Name, Count) when is_integer(Count) ->
   list_to_atom(atom_to_list(Name) ++ " (overridable " ++ integer_to_list(Count) ++ ")").
@@ -74,7 +84,7 @@ name(Name, Count) when is_integer(Count) ->
 %% Error handling
 
 format_error({no_super, Module, {Name, Arity}}) ->
-  Bins   = [format_fa(X) || {X, {_, _, _, _}} <- maps:to_list(overridable(Module))],
+  Bins   = [format_fa(Tuple) || {{overridable, Tuple}, _, _, _, _} <- overridable_for(Module)],
   Joined = 'Elixir.Enum':join(Bins, <<", ">>),
   io_lib:format("no super defined for ~ts/~B in module ~ts. Overridable functions available are: ~ts",
     [Name, Arity, elixir_aliases:inspect(Module), Joined]).

--- a/lib/elixir/src/elixir_overridable.erl
+++ b/lib/elixir/src/elixir_overridable.erl
@@ -20,8 +20,8 @@ record_overridable(Module, Tuple, Def, Neighbours) ->
   {Set, Bag} = elixir_module:data_tables(Module),
 
   case ets:lookup(Set, {overridable, Tuple}) of
-    [{_, Count, Def, Neighbours, Overriden}] ->
-      ets:insert(Set, {{overridable, Tuple}, Count + 1, Def, Neighbours, Overriden});
+    [{_, Count, _, _, _}] ->
+      ets:insert(Set, {{overridable, Tuple}, Count + 1, Def, Neighbours, false});
     [] ->
       ets:insert_new(Set, {{overridable, Tuple}, 1, Def, Neighbours, false}),
       ets:insert(Bag, {overridable, Tuple})


### PR DESCRIPTION
This is part of an ongoing effort to forbid overriding macros with functions and vice-versa. New checks will require the overridable information to be stored more efficiently.