### PR TITLE
Allow integer time units for DateTime.from_unix!/2

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -160,6 +160,8 @@ defmodule DateTime do
       iex> DateTime.from_unix!(1_432_560_368_868_569, :microsecond)
       #DateTime<2015-05-25 13:26:08.868569Z>
 
+      iex> DateTime.from_unix!(143_256_036_886_856, 1024)
+      #DateTime<6403-03-17 07:05:22.320Z>
   """
   @spec from_unix!(integer, :native | System.time_unit(), Calendar.calendar()) :: t
   def from_unix!(integer, unit \\ :second, calendar \\ Calendar.ISO) when is_atom(unit) do

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -164,7 +164,7 @@ defmodule DateTime do
       #DateTime<6403-03-17 07:05:22.320Z>
   """
   @spec from_unix!(integer, :native | System.time_unit(), Calendar.calendar()) :: t
-  def from_unix!(integer, unit \\ :second, calendar \\ Calendar.ISO) when is_atom(unit) do
+  def from_unix!(integer, unit \\ :second, calendar \\ Calendar.ISO) do
     case from_unix(integer, unit, calendar) do
       {:ok, datetime} ->
         datetime

--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -216,6 +216,14 @@ defmodule DateTimeTest do
     }
 
     assert DateTime.from_unix(-1, :microsecond) == {:ok, minus_datetime}
+
+    assert_raise ArgumentError, fn ->
+      DateTime.from_unix(0, :unknown_atom)
+    end
+
+    assert_raise ArgumentError, fn ->
+      DateTime.from_unix(0, "invalid type")
+    end
   end
 
   test "from_unix!/2" do
@@ -239,6 +247,14 @@ defmodule DateTimeTest do
 
     assert_raise ArgumentError, fn ->
       DateTime.from_unix!(-377_705_116_801)
+    end
+
+    assert_raise ArgumentError, fn ->
+      DateTime.from_unix!(0, :unknown_atom)
+    end
+
+    assert_raise ArgumentError, fn ->
+      DateTime.from_unix!(0, "invalid type")
     end
   end
 


### PR DESCRIPTION
Currently, if you call `DateTime.from_unix!/2` with an integer time unit, it raises a `FunctionClauseError`.

```elixir
iex(1)> DateTime.from_unix!(143_256_036_886_856, 1024)
** (FunctionClauseError) no function clause matching in DateTime.from_unix!/3

    The following arguments were given to DateTime.from_unix!/3:

        # 1
        143256036886856

        # 2
        1024

        # 3
        Calendar.ISO

    Attempted function clauses (showing 1 out of 1):

        def from_unix!(integer, unit, calendar) when is_atom(unit)

    (elixir) lib/calendar/datetime.ex:165: DateTime.from_unix!/3
```

However this works fine with `DateTime.from_unix/2`.

``` elixir
iex(2)> DateTime.from_unix(143_256_036_886_856, 1024)
{:ok, #DateTime<6403-03-17 07:05:22.320Z>}
```

Also, when passing a time unit of an invalid type, there are some inconsistencies.
```elixir
iex(4)> DateTime.from_unix!(1, "invalid type")
** (FunctionClauseError) no function clause matching in DateTime.from_unix!/3

    The following arguments were given to DateTime.from_unix!/3:

        # 1
        1

        # 2
        "invalid type"

        # 3
        Calendar.ISO

    Attempted function clauses (showing 1 out of 1):

        def from_unix!(integer, unit, calendar) when is_atom(unit)

    (elixir) lib/calendar/datetime.ex:165: DateTime.from_unix!/3
```

```elixir
iex(4)> DateTime.from_unix(1, "invalid type")
** (ArgumentError) unsupported time unit. Expected :second, :millisecond, :microsecond, :nanosecond, or a positive integer, got "invalid type"
    (elixir) lib/system.ex:903: System.normalize_time_unit/1
    (elixir) lib/system.ex:763: System.convert_time_unit/3
    (elixir) lib/calendar/iso.ex:703: Calendar.ISO.from_unix/2
    (elixir) lib/calendar/datetime.ex:118: DateTime.from_unix/3
```
This change removes the `is_atom(unit)` check from `DateTime.from_unix!/2` and lets the error be raised by `System.convert_time_unit/3`.