### PR TITLE
Update docs to consistently use "keyword list"

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -2,7 +2,7 @@ defmodule Keyword do
   @moduledoc """
   A set of functions for working with keywords.
 
-  A keyword is a list of two-element tuples where the first
+  A keyword list is a list of two-element tuples where the first
   element of the tuple is an atom and the second element
   can be any value.
 
@@ -116,7 +116,7 @@ defmodule Keyword do
   def new, do: []
 
   @doc """
-  Creates a keyword from an enumerable.
+  Creates a keyword list from an enumerable.
 
   Duplicated entries are removed, the latest one prevails.
   Unlike `Enum.into(enumerable, [])`, `Keyword.new(enumerable)`
@@ -137,7 +137,7 @@ defmodule Keyword do
   end
 
   @doc """
-  Creates a keyword from an enumerable via the transformation function.
+  Creates a keyword list from an enumerable via the transformation function.
 
   Duplicated entries are removed, the latest one prevails.
   Unlike `Enum.into(enumerable, [], fun)`,

--- a/lib/elixir/pages/Syntax Reference.md
+++ b/lib/elixir/pages/Syntax Reference.md
@@ -451,7 +451,7 @@ Remember that, because lists and two-element tuples are quoted literals, by defi
 
 ### Keywords as last arguments
 
-Elixir also supports a syntax where if the last argument of a call is a keyword then the square brackets can be skipped. This means that the following:
+Elixir also supports a syntax where if the last argument of a call is a keyword list then the square brackets can be skipped. This means that the following:
 
 ```elixir
 if(condition, do: this, else: that)


### PR DESCRIPTION
As I understand it, "keyword" only refers to the [atom] keys of this data structure, and a "keyword list" refers to the data structure itself. This change makes the documentation consistent.

Arguably changing the module name to `KeywordList` would make sense too, since `Keyword.new` [perhaps unintuitively] creates a keyword list. But I definitely wouldn't argue for a breaking change! 😄 

Feel free to close if my understanding is wrong, and we should be using "keyword" and "keyword list" interchangeably!