### PR TITLE
Do not allow to override macros as functions (and vice-versa)

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4405,6 +4405,8 @@ defmodule Kernel do
   An overridable function is lazily defined, allowing a developer to override
   it.
 
+  Macros cannot be overridden as functions and vice-versa.
+
   ## Example
 
       defmodule DefaultMod do


### PR DESCRIPTION
Overriding a macro as a function (and vice-versa) might produce undesired effects.

For example, it's not clear if the following code should or should not raise:

```elixir
defmodule Foo do
  def foo, do: bar()
  defmacro bar, do: :ok
  defoverridable bar: 0
  def bar, do: :ok
end
```

On top of that, `super` does not currently work for such cases.