### PR TITLE
Comparable protocol

### DIFF
--- a/lib/elixir/lib/comp.ex
+++ b/lib/elixir/lib/comp.ex
@@ -1,0 +1,599 @@
+defprotocol Comparable do
+  @moduledoc """
+  Protocol that describes comparison of two terms
+  """
+
+  @fallback_to_any true
+  @type t :: Comparable.t()
+  @type ord :: :gt | :lt | :eq
+
+  @doc """
+  Function to compare term or given type with any other term
+
+  ## Examples
+
+  ```
+  iex> 2 > 1
+  true
+  iex> Comparable.compare(2, 1)
+  :gt
+  iex> 1 < 2
+  true
+  iex> Comparable.compare(1, 2)
+  :lt
+  iex> 1 == 1
+  true
+  iex> Comparable.compare(1, 1)
+  :eq
+
+  iex> {1, 2, 3} > {1, 2}
+  true
+  iex> Comparable.compare({1, 2, 3}, {1, 2})
+  :gt
+  iex> {1, 2} < {1, 2, 3}
+  true
+  iex> Comparable.compare({1, 2}, {1, 2, 3})
+  :lt
+  iex> {1, 2} == {1, 2}
+  true
+  iex> Comparable.compare({1, 2}, {1, 2})
+  :eq
+
+  iex> {1, 2, 3} > {1, 1000}
+  true
+  iex> Comparable.compare({1, 2, 3}, {1, 1000})
+  :gt
+  iex> {1, 1000} < {1, 2, 3}
+  true
+  iex> Comparable.compare({1, 1000}, {1, 2, 3})
+  :lt
+  iex> {1, 2} < {1, 1000}
+  true
+  iex> Comparable.compare({1, 2}, {1, 1000})
+  :lt
+
+  iex> [1, 2, 3] > [1, 2]
+  true
+  iex> Comparable.compare([1, 2, 3], [1, 2])
+  :gt
+  iex> [1, 2] < [1, 2, 3]
+  true
+  iex> Comparable.compare([1, 2], [1, 2, 3])
+  :lt
+  iex> [1, 2] == [1, 2]
+  true
+  iex> Comparable.compare([1, 2], [1, 2])
+  :eq
+
+  iex> [1, 2, 3] < [1, 1000]
+  true
+  iex> Comparable.compare([1, 2, 3], [1, 1000])
+  :lt
+  iex> [1, 1000] > [1, 2, 3]
+  true
+  iex> Comparable.compare([1, 1000], [1, 2, 3])
+  :gt
+  iex> [1, 2] < [1, 1000]
+  true
+  iex> Comparable.compare([1, 2], [1, 1000])
+  :lt
+
+  iex> %{z: 1000} < %{a: 1, b: 1}
+  true
+  iex> Comparable.compare(%{z: 1000}, %{a: 1, b: 1})
+  :lt
+  iex> %{a: 1, z: 1} > %{a: 1000, b: 1000}
+  true
+  iex> Comparable.compare(%{a: 1, z: 1}, %{a: 1000, b: 1000})
+  :gt
+  iex> %{a: 1, b: 1} == %{a: 1, b: 1}
+  true
+  iex> Comparable.compare(%{a: 1, b: 1}, %{a: 1, b: 1})
+  :eq
+
+  iex> %{a: 1, b: 1, c: 1000} < %{a: 1, b: 1000, c: 1}
+  true
+  iex> Comparable.compare(%{a: 1, b: 1, c: 1000}, %{a: 1, b: 1000, c: 1})
+  :lt
+
+  iex> {:ok, dt} = NaiveDateTime.new(2000, 1, 1, 0, 0, 0)
+  {:ok, ~N[2000-01-01 00:00:00]}
+  iex> NaiveDateTime.compare(NaiveDateTime.add(dt, 1, :microsecond), NaiveDateTime.add(dt, 1, :second))
+  :lt
+  iex> Comparable.compare(NaiveDateTime.add(dt, 1, :microsecond), NaiveDateTime.add(dt, 1, :second))
+  :lt
+
+  iex> Comparable.compare(%URI{host: "1"}, %URI{host: "2"})
+  :lt
+  iex> {:ok, dt} = NaiveDateTime.new(2000, 1, 1, 0, 0, 0)
+  {:ok, ~N[2000-01-01 00:00:00]}
+  iex> Comparable.compare(%URI{host: "1"}, dt)
+  :lt
+  iex> Comparable.compare(%URI{host: "1"}, self())
+  :gt
+  iex> Comparable.compare(self(), %URI{host: "1"})
+  :lt
+  ```
+  """
+  @spec compare(t, term) :: ord
+  def compare(t, term)
+end
+
+defmodule Comp do
+  @moduledoc """
+  Provides utilities to implement `Comparable` protocol and work with `Comparable` types
+  """
+
+  @type left :: Comparable.t()
+  @type right :: term
+
+  defmacro gt, do: :gt
+  defmacro lt, do: :lt
+  defmacro eq, do: :eq
+
+  @doc """
+  Helper to auto-generate clauses where right term may have a type other than left term
+  """
+  defmacro deffallback do
+    quote do
+      def compare(left, right) when left > right, do: unquote(__MODULE__).gt()
+      def compare(left, right) when left < right, do: unquote(__MODULE__).lt()
+    end
+  end
+
+  @doc """
+  Enables <~>, <|>, >>>, <<<, ~>>, <<~ infix shortcuts and
+  Comp.gt, Comp.lt, Comp.eq macro
+  """
+  defmacro __using__(_) do
+    quote do
+      require Comp
+      import Comp, only: [<~>: 2, <|>: 2, >>>: 2, <<<: 2, ~>>: 2, <<~: 2]
+    end
+  end
+
+  @doc """
+  Infix shortcut for `Comp.equal?/2`
+
+  ## Examples
+
+  ```
+  iex> use Comp
+  Comp
+  iex> 1 <~> 1
+  true
+  iex> 1 <~> :hello
+  false
+  ```
+  """
+  defmacro left <~> right do
+    quote do
+      unquote(left)
+      |> Comp.equal?(unquote(right))
+    end
+  end
+
+  @doc """
+  Infix shortcut for `Comp.not_equal?/2`
+
+  ## Examples
+
+  ```
+  iex> use Comp
+  Comp
+  iex> 1 <|> 1
+  false
+  iex> 1 <|> :hello
+  true
+  ```
+  """
+  defmacro left <|> right do
+    quote do
+      unquote(left)
+      |> Comp.not_equal?(unquote(right))
+    end
+  end
+
+  @doc """
+  Infix shortcut for `Comp.greater_than?/2`
+
+  ## Examples
+
+  ```
+  iex> use Comp
+  Comp
+  iex> 1 >>> 1
+  false
+  iex> 1 >>> 2
+  false
+  iex> 2 >>> 1
+  true
+  ```
+  """
+  defmacro left >>> right do
+    quote do
+      unquote(left)
+      |> Comp.greater_than?(unquote(right))
+    end
+  end
+
+  @doc """
+  Infix shortcut for `Comp.less_than?/2`
+
+  ## Examples
+
+  ```
+  iex> use Comp
+  Comp
+  iex> 1 <<< 1
+  false
+  iex> 1 <<< 2
+  true
+  iex> 2 <<< 1
+  false
+  ```
+  """
+  defmacro left <<< right do
+    quote do
+      unquote(left)
+      |> Comp.less_than?(unquote(right))
+    end
+  end
+
+  @doc """
+  Infix shortcut for `Comp.greater_or_equal?/2`
+
+  ## Examples
+
+  ```
+  iex> use Comp
+  Comp
+  iex> 1 ~>> 1
+  true
+  iex> 1 ~>> 2
+  false
+  iex> 2 ~>> 1
+  true
+  ```
+  """
+  defmacro left ~>> right do
+    quote do
+      unquote(left)
+      |> Comp.greater_or_equal?(unquote(right))
+    end
+  end
+
+  @doc """
+  Infix shortcut for `Comp.less_or_equal?/2`
+
+  ## Examples
+
+  ```
+  iex> use Comp
+  Comp
+  iex> 1 <<~ 1
+  true
+  iex> 1 <<~ 2
+  true
+  iex> 2 <<~ 1
+  false
+  ```
+  """
+  defmacro left <<~ right do
+    quote do
+      unquote(left)
+      |> Comp.less_or_equal?(unquote(right))
+    end
+  end
+
+  @doc """
+  Is left term equal to right term?
+
+  ## Examples
+
+  ```
+  iex> Comp.equal?(1, 1)
+  true
+  iex> Comp.equal?(1, :hello)
+  false
+  ```
+  """
+  @spec equal?(left, right) :: boolean
+  def equal?(left, right) do
+    Comparable.compare(left, right) == eq()
+  end
+
+  @doc """
+  Is left term not equal to right term?
+
+  ## Examples
+
+  ```
+  iex> Comp.not_equal?(1, 1)
+  false
+  iex> Comp.not_equal?(1, :hello)
+  true
+  ```
+  """
+  @spec not_equal?(left, right) :: boolean
+  def not_equal?(left, right) do
+    Comparable.compare(left, right) != eq()
+  end
+
+  @doc """
+  Is left term greater than right term?
+
+  ## Examples
+
+  ```
+  iex> Comp.greater_than?(1, 1)
+  false
+  iex> Comp.greater_than?(1, 2)
+  false
+  iex> Comp.greater_than?(2, 1)
+  true
+  """
+  @spec greater_than?(left, right) :: boolean
+  def greater_than?(left, right) do
+    Comparable.compare(left, right) == gt()
+  end
+
+  @doc """
+  Is left term less than right term?
+
+  ## Examples
+
+  ```
+  iex> Comp.less_than?(1, 1)
+  false
+  iex> Comp.less_than?(1, 2)
+  true
+  iex> Comp.less_than?(2, 1)
+  false
+  """
+  @spec less_than?(left, right) :: boolean
+  def less_than?(left, right) do
+    Comparable.compare(left, right) == lt()
+  end
+
+  @doc """
+  Is left term greater or equal to right term?
+
+  ## Examples
+
+  ```
+  iex> Comp.greater_or_equal?(1, 1)
+  true
+  iex> Comp.greater_or_equal?(1, 2)
+  false
+  iex> Comp.greater_or_equal?(2, 1)
+  true
+  """
+  @spec greater_or_equal?(left, right) :: boolean
+  def greater_or_equal?(left, right) do
+    Comparable.compare(left, right) != lt()
+  end
+
+  @doc """
+  Is left term less or equal to right term?
+
+  ## Examples
+
+  ```
+  iex> Comp.less_or_equal?(1, 1)
+  true
+  iex> Comp.less_or_equal?(1, 2)
+  true
+  iex> Comp.less_or_equal?(2, 1)
+  false
+  """
+  @spec less_or_equal?(left, right) :: boolean
+  def less_or_equal?(left, right) do
+    Comparable.compare(left, right) != gt()
+  end
+
+  @doc """
+  Returns the biggest of the two given terms, if terms are equal - then the first one is returned
+
+  ## Examples
+
+  ```
+  iex> Comp.max(1, 1)
+  1
+  iex> Comp.max(1, 2)
+  2
+  iex> Comp.max(2, 1)
+  2
+  ```
+  """
+  @spec max(left, right) :: left | right
+  def max(left, right) do
+    left
+    |> Comparable.compare(right)
+    |> case do
+      gt() -> left
+      lt() -> right
+      eq() -> left
+    end
+  end
+
+  @doc """
+  Returns the smallest of the two given terms, if terms are equal - then the first one is returned
+
+  ## Examples
+
+  ```
+  iex> Comp.min(1, 1)
+  1
+  iex> Comp.min(1, 2)
+  1
+  iex> Comp.min(2, 1)
+  1
+  ```
+  """
+  @spec min(left, right) :: left | right
+  def min(left, right) do
+    left
+    |> Comparable.compare(right)
+    |> case do
+      gt() -> right
+      lt() -> left
+      eq() -> left
+    end
+  end
+
+  @doc """
+  Compare left and right term
+
+  ## Examples
+
+  ```
+  iex> Comp.compare(1, 2)
+  :lt
+  iex> Comp.compare(2, 1)
+  :gt
+  iex> Comp.compare(1, 1)
+  :eq
+  ```
+  """
+  @spec compare(left, right) :: Comparable.ord()
+  def compare(left, right) do
+    Comparable.compare(left, right)
+  end
+end
+
+[
+  Atom,
+  BitString,
+  Float,
+  Function,
+  Integer,
+  PID,
+  Port,
+  Reference
+]
+|> Enum.each(fn t ->
+  defimpl Comparable, for: t do
+    require Comp
+
+    def compare(left, right) do
+      cond do
+        left > right -> Comp.gt()
+        left < right -> Comp.lt()
+        true -> Comp.eq()
+      end
+    end
+  end
+end)
+
+defimpl Comparable, for: Tuple do
+  require Comp
+
+  def compare(left, right) when is_tuple(right) do
+    left_length = tuple_size(left)
+    right_length = tuple_size(right)
+
+    cond do
+      left_length > right_length ->
+        Comp.gt()
+
+      left_length < right_length ->
+        Comp.lt()
+
+      true ->
+        left
+        |> Tuple.to_list()
+        |> Comparable.compare(right |> Tuple.to_list())
+    end
+  end
+
+  Comp.deffallback()
+end
+
+defimpl Comparable, for: Map do
+  require Comp
+
+  def compare(left, %{} = right) do
+    left_length = map_size(left)
+    right_length = map_size(right)
+
+    cond do
+      left_length > right_length ->
+        Comp.gt()
+
+      left_length < right_length ->
+        Comp.lt()
+
+      true ->
+        left
+        |> Map.keys()
+        |> Comparable.compare(right |> Map.keys())
+        |> case do
+          res when res in [Comp.gt(), Comp.lt()] ->
+            res
+
+          Comp.eq() ->
+            left
+            |> Map.values()
+            |> Comparable.compare(right |> Map.values())
+        end
+    end
+  end
+
+  Comp.deffallback()
+end
+
+defimpl Comparable, for: List do
+  require Comp
+
+  def compare(left, right) when is_list(right) do
+    left
+    |> Stream.zip(right)
+    |> Enum.reduce_while(Comp.eq(), fn {lx, rx}, Comp.eq() ->
+      lx
+      |> Comparable.compare(rx)
+      |> case do
+        res when res in [Comp.gt(), Comp.lt()] -> {:halt, res}
+        Comp.eq() = res -> {:cont, res}
+      end
+    end)
+    |> case do
+      res when res in [Comp.gt(), Comp.lt()] ->
+        res
+
+      Comp.eq() ->
+        left_length = length(left)
+        right_length = length(right)
+
+        cond do
+          left_length > right_length -> Comp.gt()
+          left_length < right_length -> Comp.lt()
+          true -> Comp.eq()
+        end
+    end
+  end
+
+  Comp.deffallback()
+end
+
+defimpl Comparable, for: Any do
+  require Comp
+
+  def compare(%struct{} = left, %struct{} = right) do
+    left
+    |> Map.from_struct()
+    |> Comparable.compare(right |> Map.from_struct())
+  end
+
+  Comp.deffallback()
+end
+
+defimpl Comparable, for: NaiveDateTime do
+  require Comp
+
+  def compare(left, %NaiveDateTime{} = right) do
+    NaiveDateTime.compare(left, right)
+  end
+
+  Comp.deffallback()
+end

--- a/lib/elixir/test/elixir/comp_test.exs
+++ b/lib/elixir/test/elixir/comp_test.exs
@@ -1,0 +1,6 @@
+Code.require_file("test_helper.exs", __DIR__)
+
+defmodule CompTest do
+  use ExUnit.Case, async: true
+  doctest Comp
+end


### PR DESCRIPTION
# Comparable

Elixir protocol which describes how two Elixir terms can be compared. There are cases when we want to compare two terms of some data type not just by term value according standard Erlang/Elixir [ordering rules](https://hexdocs.pm/elixir/operators.html#term-ordering) but to use some meaningful business logic to do comparison. Main purpose of this pull request is to provide extended versions of standard kernel functions like `==/2`, `!=/2`, `>/2`, `</2`, `>=/2`, `<=/2` which will rely on Comparable protocol implementation for given type. Protocol itself is very similar to [Ord](http://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Ord.html) type class in Haskell.

## Real example

Kernel Elixir comparison functions work pretty fine with standard numeric types like `integer` or `float` (and it works even in nested terms like `map`):

```elixir
iex> %{a: 1} == %{a: 1.0}
true
```

But if we try to apply Kernel equality function to terms containing custom [Decimal](https://hex.pm/packages/decimal) numbers it will not work so good:

```elixir
iex(1)> %{a: Decimal.new("1")} == %{a: Decimal.new("1.0")}
false
```

This is because **the same** decimal number can be presented **as different Elixir term**:

```elixir
iex> Decimal.new("1") |> Map.from_struct
%{coef: 1, exp: 0, sign: 1}
iex> Decimal.new("1.0") |> Map.from_struct
%{coef: 10, exp: -1, sign: 1}
```

And here `Comparable` protocol can help us, let's implement it for `Decimal` type using existing `Decimal.compare/2` helper:

```elixir
defimpl Comparable, for: Decimal do
  require Comp

  def compare(left, %Decimal{} = right) do
    left
    |> Decimal.compare(right)
    |> case do
      %Decimal{coef: 1, sign: 1} ->
        Comp.gt()

      %Decimal{coef: 1, sign: -1} ->
        Comp.lt()

      %Decimal{coef: 0} ->
        Comp.eq()

      %Decimal{coef: :qNaN} ->
        raise(
          "can't apply Comparable protocol to left = #{inspect(left)} and right = #{
            inspect(right)
          }"
        )
    end
  end

  Comp.deffallback()
end
```

where `Comp.deffallback/0` is simple helper to auto-generate clauses where **right** term is not a `Decimal` (it's just fallback to standard Kernel implementation).

And when protocol for `Decimal` type is implemented, we can use `Comp.equal?/2` utility function instead of Kernel `==/2`:

```elixir
iex> Comp.equal?(%{a: Decimal.new("1")}, %{a: Decimal.new("1.0")})
true
```

which works as expected according **meaning** of `Decimal` numbers instead of just term **values**. Comparison based on  `Comparable` protocol is very useful when for example we compare big nested structures which contain `Decimals` or other custom types (like `Date`, `Time`, `NaiveDateTime`, `URI` etc) in nested collections like lists, maps, tuples or other data types:

```elixir
iex> x0 = %{a: [%{b: Decimal.new("1")}]}
%{a: [%{b: #Decimal<1>}]}
iex> x1 = %{a: [%{b: Decimal.new("1.0")}]}
%{a: [%{b: #Decimal<1.0>}]}
iex> x0 == x1
false
iex> Comp.equal?(x0, x1)
true
```

## Utilities

`Comp` module provides utilities not only for equality, but for other comparison operations as well. Also it provides infix shortcuts for these utilities:

| Kernel.fn/2 | Comp.fn/2 | Comp infix shortcut |
|-------------|-----------|---------------------|
| x == y | Comp.equal?(x, y) | x <~> y |
| x != y | Comp.not_equal?(x, y) | x <&#124;> y |
| x > y | Comp.greater_than?(x, y) | x >>> y |
| x < y | Comp.less_than?(x, y) | x <<< y |
| x >= y | Comp.greater_or_equal?(x, y) | x ~>> y |
| x <= y | Comp.less_or_equal?(x, y) | x <<~ y |
| max(x, y) | Comp.max(x, y) |
| min(x, y) | Comp.min(x, y) |

Example of infix shortcuts usage:

```elixir
iex> use Comp
Comp
iex> Decimal.new("1") <~> Decimal.new("1.0")
true
iex> Decimal.new("1") <|> Decimal.new("2")
true
iex> Decimal.new("2") >>> Decimal.new("1")
true
iex> Decimal.new("1") <<< Decimal.new("2")
true
iex> Decimal.new("1") ~>> Decimal.new("1.0")
true
iex> Decimal.new("1") <<~ Decimal.new("1.0")
true
```

Also there is simple `Comp.compare/2` function if you want to work directly with `Ord` enum values:

```elixir
iex> Comp.compare(1, 1)
:eq
iex> Comp.compare(1, 2)
:lt
iex> Comp.compare(2, 1)
:gt
```

## DIscussion 

`Comparable` protocol features discussion in Elixir mailing list
https://groups.google.com/forum/#!topic/elixir-lang-core/eE_mMWKdVYY