### PR TITLE
Fix uncommented `...` in periodic task GenServer documentation

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -234,7 +234,7 @@ defmodule GenServer do
         @impl true
         def handle_info(:work, state) do
           # Do the desired work here
-          ...
+          # ...
 
           # Reschedule once more
           schedule_work()


### PR DESCRIPTION
Howdy!

I mentor a lot of folks in Elixir day to day and find myself using this doc with a lot of introductions to GenServers. I recently noticed it stopped working when I would paste directly into the REPL. It looks like these were added in commit b230541fae but before then the only note was commented. In the interest of copy-pasteability for the documentation (especially in IEx) I figured this would be an improvement.