### PR TITLE
Set DateTime.from_unix precision to microseconds for units not divisible by 10

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -107,7 +107,7 @@ defmodule DateTime do
 
       iex> {:ok, datetime} = DateTime.from_unix(143_256_036_886_856, 1024)
       iex> datetime
-      #DateTime<6403-03-17 07:05:22.320Z>
+      #DateTime<6403-03-17 07:05:22.320312Z>
 
   Negative Unix times are supported, up to -62167219200 seconds,
   which is equivalent to "0000-01-01T00:00:00Z" or 0 Gregorian seconds.
@@ -161,7 +161,7 @@ defmodule DateTime do
       #DateTime<2015-05-25 13:26:08.868569Z>
 
       iex> DateTime.from_unix!(143_256_036_886_856, 1024)
-      #DateTime<6403-03-17 07:05:22.320Z>
+      #DateTime<6403-03-17 07:05:22.320312Z>
   """
   @spec from_unix!(integer, :native | System.time_unit(), Calendar.calendar()) :: t
   def from_unix!(integer, unit \\ :second, calendar \\ Calendar.ISO) do

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -766,15 +766,16 @@ defmodule Calendar.ISO do
   end
 
   defp precision_for_unit(unit) do
-    subsecond = div(System.convert_time_unit(1, :second, unit), 10)
-    precision_for_unit(subsecond, 0)
+    case System.convert_time_unit(1, :second, unit) do
+      1 -> 0
+      10 -> 1
+      100 -> 2
+      1_000 -> 3
+      10_000 -> 4
+      100_000 -> 5
+      _ -> 6
+    end
   end
-
-  defp precision_for_unit(0, precision), do: precision
-  defp precision_for_unit(_, 6), do: 6
-
-  defp precision_for_unit(number, precision),
-    do: precision_for_unit(div(number, 10), precision + 1)
 
   @doc false
   def naive_datetime_to_iso8601(

--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -181,6 +181,23 @@ defmodule DateTimeTest do
     assert DateTime.from_unix(-377_705_116_800_000_001, :microsecond) ==
              {:error, :invalid_unix_time}
 
+    assert DateTime.from_unix(143_256_036_886_856, 1024) ==
+             {:ok,
+              %DateTime{
+                calendar: Calendar.ISO,
+                day: 17,
+                hour: 7,
+                microsecond: {320_312, 6},
+                minute: 5,
+                month: 3,
+                second: 22,
+                std_offset: 0,
+                time_zone: "Etc/UTC",
+                utc_offset: 0,
+                year: 6403,
+                zone_abbr: "UTC"
+              }}
+
     max_datetime = %DateTime{
       calendar: Calendar.ISO,
       day: 31,


### PR DESCRIPTION
Before:

    DateTime.from_unix!(143_256_036_886_856, 1024).microsecond
    {320312, 3}

After:

    DateTime.from_unix!(143_256_036_886_856, 1024).microsecond
    {320312, 6}

---

Alternatively, should we truncate it to `{320, 3}`?