### PR TITLE
Ignore protocols when computing coverage data

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -40,6 +40,8 @@ defmodule Mix.Tasks.Test do
       # Each line is only considered once.
       #
       # We use ETS for performance, to avoid working with nested maps.
+      results = discard_protocol_definitions(results)
+
       table = :ets.new(__MODULE__, [:set, :private])
 
       try do
@@ -61,6 +63,14 @@ defmodule Mix.Tasks.Test do
       after
         :ets.delete(table)
       end
+    end
+
+    # protocol definitions have no testable code they shouldn't show up in coverage results
+    # see #8825
+    defp discard_protocol_definitions(coverage_results) do
+      Enum.reject(coverage_results, fn {{module, _}, _} ->
+        function_exported?(module, :__protocol__, 1)
+      end)
     end
 
     defp read_module_cover_results(table, module) do

--- a/lib/mix/test/fixtures/protocol_cover/lib/protocol_cover.ex
+++ b/lib/mix/test/fixtures/protocol_cover/lib/protocol_cover.ex
@@ -1,0 +1,7 @@
+defprotocol ProtocolCover do
+  def to_uppercase(string)
+end
+
+defimpl ProtocolCover, for: BitString do
+  def to_uppercase(string), do: String.upcase(string)
+end

--- a/lib/mix/test/fixtures/protocol_cover/mix.exs
+++ b/lib/mix/test/fixtures/protocol_cover/mix.exs
@@ -1,0 +1,11 @@
+defmodule ProtocolCover.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :protocol_cover,
+      version: "0.0.1",
+      test_pattern: "*_protocol_cover.exs"
+    ]
+  end
+end

--- a/lib/mix/test/fixtures/protocol_cover/test/test_helper.exs
+++ b/lib/mix/test/fixtures/protocol_cover/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/lib/mix/test/fixtures/protocol_cover/test/test_protocol_cover.exs
+++ b/lib/mix/test/fixtures/protocol_cover/test/test_protocol_cover.exs
@@ -1,0 +1,8 @@
+defmodule ProtocolCoverTest do
+  use ExUnit.Case
+
+  test "test String" do
+    string = "Test"
+    assert ProtocolCover.to_uppercase(string) == "TEST"
+  end
+end

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -144,6 +144,15 @@ defmodule Mix.Tasks.TestTest do
     end)
   end
 
+  test "--cover: doesn't count coverage for protocol definitions" do
+    in_fixture("protocol_cover", fn ->
+      output = mix(["test", "--cover"])
+
+      assert output =~ "100.00% | ProtocolCover.BitString"
+      assert output =~ "100.00% | Total"
+    end)
+  end
+
   test "--failed: loads only files with failures and runs just the failures" do
     in_fixture("test_failed", fn ->
       loading_only_passing_test_msg = "loading OnlyPassingTest"


### PR DESCRIPTION
Protocols have no "code" to run, hence shouldn't be considered
for coverage data. We could also just mark them as covered, but
I feel like discarding them is the better way as they really
don't have relevant code.

fixes #8825

As usual, thanks for elixir and all your hard work! :green_heart: :green_heart: :green_heart: 