### PR TITLE
Do not consider modules that are no longer cover compiled

### DIFF
--- a/lib/mix/test/fixtures/umbrella_cover/apps/bar/lib/bar.ex
+++ b/lib/mix/test/fixtures/umbrella_cover/apps/bar/lib/bar.ex
@@ -3,3 +3,11 @@ defmodule Bar do
     :world
   end
 end
+
+defprotocol Bar.Protocol do
+  def to_uppercase(string)
+end
+
+defimpl Bar.Protocol, for: BitString do
+  def to_uppercase(string), do: String.upcase(string)
+end

--- a/lib/mix/test/fixtures/umbrella_cover/apps/bar/test/bar_tests.exs
+++ b/lib/mix/test/fixtures/umbrella_cover/apps/bar/test/bar_tests.exs
@@ -2,6 +2,7 @@ defmodule BarTest do
   use ExUnit.Case
 
   test "greets the world" do
-    assert Foo.hello() == :world
+    assert Bar.hello() == :world
+    assert Bar.Protocol.to_uppercase("foo") == "FOO"
   end
 end

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -143,7 +143,7 @@ defmodule Mix.CLITest do
     System.delete_env("MIX_EXS")
   end
 
-  test "new with tests" do
+  test "new with tests and cover" do
     in_tmp("new_with_tests", fn ->
       output = mix(~w[new .])
       assert output =~ "* creating lib/new_with_tests.ex"

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -129,26 +129,26 @@ defmodule Mix.Tasks.TestTest do
 
       # For bar, we do regular --cover and also test protocols
       assert output =~ """
-      Generating cover results ...
+             Generating cover results ...
 
-      Percentage | Module
-      -----------|--------------------------
-         100.00% | Bar
-         100.00% | Bar.Protocol.BitString
-      -----------|--------------------------
-         100.00% | Total
-      """
+             Percentage | Module
+             -----------|--------------------------
+                100.00% | Bar
+                100.00% | Bar.Protocol.BitString
+             -----------|--------------------------
+                100.00% | Total
+             """
 
       # For foo, we do regular --cover and test it does not include bar
       assert output =~ """
-      Generating cover results ...
+             Generating cover results ...
 
-      Percentage | Module
-      -----------|--------------------------
-         100.00% | Foo
-      -----------|--------------------------
-         100.00% | Total
-      """
+             Percentage | Module
+             -----------|--------------------------
+                100.00% | Foo
+             -----------|--------------------------
+                100.00% | Total
+             """
     end)
   end
 

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -123,24 +123,32 @@ defmodule Mix.Tasks.TestTest do
     end)
   end
 
-  test "--cover: in an umbrella application, reports on the coverage of each app's modules exactly once" do
+  test "--cover: reports the coverage of each app's modules in an umbrella" do
     in_fixture("umbrella_cover", fn ->
       output = mix(["test", "--cover"])
 
-      occurrences_of_bar_coverage =
-        output
-        |> String.split("100.00% | Bar")
-        |> length()
-        |> (&(&1 - 1)).()
+      # For bar, we do regular --cover and also test protocols
+      assert output =~ """
+      Generating cover results ...
 
-      occurrences_of_foo_coverage =
-        output
-        |> String.split("100.00% | Foo")
-        |> length()
-        |> (&(&1 - 1)).()
+      Percentage | Module
+      -----------|--------------------------
+         100.00% | Bar
+         100.00% | Bar.Protocol.BitString
+      -----------|--------------------------
+         100.00% | Total
+      """
 
-      assert occurrences_of_bar_coverage == 1
-      assert occurrences_of_foo_coverage == 1
+      # For foo, we do regular --cover and test it does not include bar
+      assert output =~ """
+      Generating cover results ...
+
+      Percentage | Module
+      -----------|--------------------------
+         100.00% | Foo
+      -----------|--------------------------
+         100.00% | Total
+      """
     end)
   end
 


### PR DESCRIPTION
The main issue is that Cover no longer considers protocols to
be cover compiled at the end of suite, which was causing protocols
to be taken into account when considering Total but they were not
listed individually. 

By only considering cover compiled modules when computing the results,
it automatically removes protocols and it should also apply for future cases.
The umbrella --cover test was improved to be more assertive and also
list protocols.

Closes #8825