### PR TITLE
Remove StreamData-related stuff from the formatter configuration

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -98,7 +98,6 @@ defmodule Code.Formatter do
     defrecordp: 3,
 
     # Testing
-    all: :*,
     assert: 1,
     assert: 2,
     assert_in_delta: 3,
@@ -110,12 +109,8 @@ defmodule Code.Formatter do
     assert_receive: 3,
     assert_received: 1,
     assert_received: 2,
-    check: 1,
-    check: 2,
     doctest: 1,
     doctest: 2,
-    property: 1,
-    property: 2,
     refute: 1,
     refute: 2,
     refute_in_delta: 3,

--- a/lib/elixir/test/elixir/code_formatter/calls_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/calls_test.exs
@@ -415,33 +415,33 @@ defmodule Code.Formatter.CallsTest do
     end
 
     test "without parens on unique argument" do
-      assert_same "foo(all 1, 2, 3)"
-      assert_same "foo(bar, all(1, 2, 3))"
-      assert_same "check all 1, 2, 3"
-      assert_same "check foo, all(1, 2, 3)"
+      assert_same "foo(for 1, 2, 3)"
+      assert_same "foo(bar, for(1, 2, 3))"
+      assert_same "assert for 1, 2, 3"
+      assert_same "assert foo, for(1, 2, 3)"
 
       assert_same """
-      check all 1, 2, 3 do
+      assert for 1, 2, 3 do
         :ok
       end
       """
 
       assert_same """
-      check foo, all(1, 2, 3) do
+      assert foo, for(1, 2, 3) do
         :ok
       end
       """
 
       assert_same """
-      check all(1, 2, 3) do
+      assert for(1, 2, 3) do
         :ok
       end
       """
 
       assert_same """
-      check (all 1, 2, 3 do
-               :ok
-             end)
+      assert (for 1, 2, 3 do
+                :ok
+              end)
       """
     end
 


### PR DESCRIPTION
We're not including StreamData (https://github.com/whatyouhide/stream_data) in the standard library anymore. It doesn't make sense that we have StreamData functions in the default locals without parens of the formatter. Instead, we solve the problem on the StreamData side with  https://github.com/whatyouhide/stream_data/pull/124.