### PR TITLE
Raise ArgumentError on GenServer.call/3 invalid timeout

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -989,6 +989,18 @@ defmodule GenServer do
   element.
   """
   @spec call(server, term, timeout) :: term
+  def call(_server, _request, timeout)
+      when (not is_integer(timeout) or timeout < 0) and timeout != :infinity do
+    raise ArgumentError, """
+    expected timeout to be one of the following:
+
+    * integer greater than 0
+    * atom :infinity
+
+    Got: #{inspect(timeout)}
+    """
+  end
+
   def call(server, request, timeout \\ 5000) do
     case whereis(server) do
       nil ->

--- a/lib/elixir/test/elixir/gen_server_test.exs
+++ b/lib/elixir/test/elixir/gen_server_test.exs
@@ -145,6 +145,25 @@ defmodule GenServerTest do
              {{:nodedown, :bogus_node}, {GenServer, :call, [{:stack, :bogus_node}, :pop, 5000]}}
   end
 
+  test "call/3 with invalid timeouts" do
+    {:ok, pid} = GenServer.start_link(Stack, [:hello])
+
+    {:links, links} = Process.info(self(), :links)
+    assert pid in links
+
+    assert_raise ArgumentError, fn ->
+      GenServer.call(pid, :pop, nil)
+    end
+
+    assert_raise ArgumentError, fn ->
+      GenServer.call(pid, :pop, :invalid)
+    end
+
+    assert_raise ArgumentError, fn ->
+      GenServer.call(pid, :pop, 4.2)
+    end
+  end
+
   test "nil name" do
     {:ok, pid} = GenServer.start_link(Stack, [:hello], name: nil)
     assert Process.info(pid, :registered_name) == {:registered_name, []}


### PR DESCRIPTION
While using a GenServer I was debugging an issue for some hours together with a colleague (shout out @dcaixinha). Eventually, I got to understand the issue was due to passing `nil` as the timeout to `GenServer`, implicitly. `poolboy` was being used, and we were configuring the timeout via an environment variable (the value of which was being fetched with a typo from `Application.get_env(:my_app, :confyg)`). This yielded `nil` and thus caused the following somewhat cryptic error:

```elixir
iex> defmodule Stack do
  use GenServer

  def init(args) do
    {:ok, args}
  end

  def handle_call(:pop, _from, [h | t]) do
    {:reply, h, t}
  end
end

iex> {:ok, pid} = GenServer.start_link(Stack, [])

iex> GenServer.call(pid, :pop, nil)
** (FunctionClauseError) no function clause matching in :gen.call/4

    The following arguments were given to :gen.call/4:

        # 1
        #PID<0.157.0>

        # 2
        :"$gen_call"

        # 3
        :pop

        # 4
        nil

    (stdlib) gen.erl:152: :gen.call/4
    (elixir) lib/gen_server.ex:986: GenServer.call/3
```

Discussion here: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/elixir-lang-core/t8W9sM84eJY