### PR TITLE
Enable Access.at/1 to handle negative index

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -610,10 +610,16 @@ defmodule Access do
       iex> list = [%{name: "john"}, %{name: "mary"}]
       iex> get_in(list, [Access.at(1), :name])
       "mary"
+      iex> get_in(list, [Access.at(-1), :name])
+      "mary"
       iex> get_and_update_in(list, [Access.at(0), :name], fn prev ->
       ...>   {prev, String.upcase(prev)}
       ...> end)
       {"john", [%{name: "JOHN"}, %{name: "mary"}]}
+      iex> get_and_update_in(list, [Access.at(-1), :name], fn prev ->
+      ...>   {prev, String.upcase(prev)}
+      ...> end)
+      {"mary", [%{name: "john"}, %{name: "MARY"}]}
 
   `at/1` can also be used to pop elements out of a list or
   a key inside of a list:
@@ -634,19 +640,14 @@ defmodule Access do
       ...> end)
       {nil, [%{name: "john"}, %{name: "mary"}]}
 
-  An error is raised for negative indexes:
-
-      iex> get_in([], [Access.at(-1)])
-      ** (FunctionClauseError) no function clause matching in Access.at/1
-
   An error is raised if the accessed structure is not a list:
 
       iex> get_in(%{}, [Access.at(1)])
       ** (RuntimeError) Access.at/1 expected a list, got: %{}
 
   """
-  @spec at(non_neg_integer) :: access_fun(data :: list, get_value :: term)
-  def at(index) when is_integer(index) and index >= 0 do
+  @spec at(integer) :: access_fun(data :: list, get_value :: term)
+  def at(index) when is_integer(index) do
     fn op, data, next -> at(op, data, index, next) end
   end
 
@@ -669,7 +670,17 @@ defmodule Access do
     end
   end
 
-  defp get_and_update_at([head | rest], index, next, updates) do
+  defp get_and_update_at(list, index, next, updates)
+       when index < 0 and length(list) + index >= 0 do
+    get_and_update_at(list, length(list) + index, next, updates)
+  end
+
+  defp get_and_update_at(list, index, _next, _updates)
+       when index < 0 and length(list) + index < 0 do
+    {nil, list}
+  end
+
+  defp get_and_update_at([head | rest], index, next, updates) when index > 0 do
     get_and_update_at(rest, index - 1, next, [head | updates])
   end
 

--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -670,14 +670,14 @@ defmodule Access do
     end
   end
 
-  defp get_and_update_at(list, index, next, updates)
-       when index < 0 and length(list) + index >= 0 do
-    get_and_update_at(list, length(list) + index, next, updates)
-  end
+  defp get_and_update_at(list, index, next, updates) when index < 0 do
+    list_length = length(list)
 
-  defp get_and_update_at(list, index, _next, _updates)
-       when index < 0 and length(list) + index < 0 do
-    {nil, list}
+    if list_length + index >= 0 do
+      get_and_update_at(list, list_length + index, next, updates)
+    else
+      {nil, list}
+    end
   end
 
   defp get_and_update_at([head | rest], index, next, updates) when index > 0 do

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -122,4 +122,28 @@ defmodule AccessTest do
                [1, 2, 3]
     end
   end
+
+  describe "at/1" do
+    @test_list [1, 2, 3, 4, 5, 6]
+
+    test "returns element from the end if index is negative" do
+      assert get_in(@test_list, [Access.at(-2)]) == 5
+    end
+
+    test "returns nil if index is out of bounds counting from the end" do
+      assert get_in(@test_list, [Access.at(-10)]) == nil
+    end
+
+    test "updates the element counting from the end if index is negative" do
+      assert get_and_update_in(@test_list, [Access.at(-2)], fn prev ->
+               {prev, :foo}
+             end) == {5, [1, 2, 3, 4, :foo, 6]}
+    end
+
+    test "returns nil and does not update if index is out of bounds" do
+      assert get_and_update_in(@test_list, [Access.at(-10)], fn prev ->
+               {prev, :foo}
+             end) == {nil, [1, 2, 3, 4, 5, 6]}
+    end
+  end
 end


### PR DESCRIPTION
Enabling negative index as Enum.at/2 to keep it consistent, as Enum.at/2 returns nil if the index is out of bounds counting from the end.