### PR TITLE
Add System.fetch_env/1 and System.fetch_env!/1

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -421,6 +421,15 @@ defmodule System do
   The returned value of the environment variable
   `varname` is a string, or `nil` if the environment
   variable is undefined.
+
+  ## Examples
+
+      iex> System.get_env("PORT")
+      "4000"
+
+      iex> System.get_env("NOT_DEFINED")
+      nil
+
   """
   @spec get_env(String.t()) :: String.t() | nil
   def get_env(varname) when is_binary(varname) do
@@ -428,6 +437,51 @@ defmodule System do
       false -> nil
       other -> List.to_string(other)
     end
+  end
+
+  @doc """
+  Returns the value of the given environment variable or `:error` if not found.
+
+  If `varname` is a defined environment variable, then `{:ok, value}` is returned
+  where `value` is a string. If `varname` is not defined, `:error` is returned.
+
+  ## Examples
+
+      iex> System.fetch_env("PORT")
+      {:ok, "4000"}
+
+      iex> System.fetch_env("NOT_DEFINED")
+      :error
+
+  """
+  @doc since: "1.9.0"
+  @spec fetch_env(String.t()) :: {:ok, String.t()} | :error
+  def fetch_env(varname) when is_binary(varname) do
+    case :os.getenv(String.to_charlist(varname)) do
+      false -> :error
+      other -> {:ok, List.to_string(other)}
+    end
+  end
+
+  @doc """
+  Returns the value of the given environment variable or raises if not found.
+
+  Same as `get_env/1` but raises instead of returning `nil` when the variable is
+  not defined.
+
+  ## Examples
+
+      iex> System.fetch_env!("PORT")
+      "4000"
+
+      iex> System.fetch_env!("NOT_DEFINED")
+      ** (RuntimeError) environment variable "NOT_DEFINED" is not defined
+
+  """
+  @doc since: "1.9.0"
+  @spec fetch_env!(String.t()) :: String.t()
+  def fetch_env!(varname) when is_binary(varname) do
+    get_env(varname) || raise "environment variable #{inspect(varname)} is not defined"
   end
 
   @doc """

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -481,7 +481,9 @@ defmodule System do
   @doc since: "1.9.0"
   @spec fetch_env!(String.t()) :: String.t()
   def fetch_env!(varname) when is_binary(varname) do
-    get_env(varname) || raise "environment variable #{inspect(varname)} is not defined"
+    get_env(varname) ||
+      raise ArgumentError,
+            "could not fetch environment variable #{inspect(varname)} because it is not set"
   end
 
   @doc """

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -54,9 +54,8 @@ defmodule SystemTest do
     assert System.get_env(@test_var) == nil
     assert System.fetch_env(@test_var) == :error
 
-    assert_raise RuntimeError, "environment variable #{inspect(@test_var)} is not defined", fn ->
-      System.fetch_env!(@test_var)
-    end
+    message = "could not fetch environment variable #{inspect(@test_var)} because it is not set"
+    assert_raise ArgumentError, message, fn -> System.fetch_env!(@test_var) end
 
     System.put_env(@test_var, "SAMPLE")
 

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -52,9 +52,18 @@ defmodule SystemTest do
 
   test "*_env/*" do
     assert System.get_env(@test_var) == nil
+    assert System.fetch_env(@test_var) == :error
+
+    assert_raise RuntimeError, "environment variable #{inspect(@test_var)} is not defined", fn ->
+      System.fetch_env!(@test_var)
+    end
+
     System.put_env(@test_var, "SAMPLE")
+
     assert System.get_env(@test_var) == "SAMPLE"
     assert System.get_env()[@test_var] == "SAMPLE"
+    assert System.fetch_env(@test_var) == {:ok, "SAMPLE"}
+    assert System.fetch_env!(@test_var) == "SAMPLE"
 
     System.delete_env(@test_var)
     assert System.get_env(@test_var) == nil


### PR DESCRIPTION
This PR adds the `System.fetch_env/1` and `System.fetch_env!/1` functions as per the discussion in https://groups.google.com/forum/#!topic/elixir-lang-core/QGxEibK4y7Q.

I chose to keep using the same underlying implementation for `fetch_env/1` as the one for `get_env/1` because the number of lines would have been the same but we would have added one function call.