### PR TITLE
Add docs for truthy/falsy values

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -173,6 +173,42 @@ defmodule Kernel do
 
   Those functions will be explicitly marked in their docs as
   "inlined by the compiler".
+  
+  ## Truthy and falsy values
+  
+  Besides the booleans `true` and `false` Elixir also has the
+  concept of a "truthy" or "falsy" value.
+
+    *  a value is truthy when it is neither `false` nor `nil`
+    *  a value is falsy when it is `false` or `nil`
+    
+  Elixir has functions, like `and/2`, that *only* work with
+  booleans, but also functions that work with these
+  truthy/falsy values, like `&&/2` and `!/1`.
+
+  ### Examples
+  
+  We can check the truthiness of a value by using the `!/1`
+  function twice.
+
+  Truthy values:
+  
+      iex> !!true
+      true
+      iex> !!5
+      true
+      iex> !![1,2]
+      true
+      iex> !!"foo"
+      true
+      
+  Falsy values (of which there are exactly two):  
+  
+      iex> !!false
+      false
+      iex> !!nil
+      false
+    
   """
 
   # We need this check only for bootstrap purposes.

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -173,9 +173,9 @@ defmodule Kernel do
 
   Those functions will be explicitly marked in their docs as
   "inlined by the compiler".
-  
+
   ## Truthy and falsy values
-  
+
   Besides the booleans `true` and `false` Elixir also has the
   concept of a "truthy" or "falsy" value.
 
@@ -187,12 +187,12 @@ defmodule Kernel do
   truthy/falsy values, like `&&/2` and `!/1`.
 
   ### Examples
-  
+
   We can check the truthiness of a value by using the `!/1`
   function twice.
 
   Truthy values:
-  
+
       iex> !!true
       true
       iex> !!5
@@ -203,7 +203,7 @@ defmodule Kernel do
       true
       
   Falsy values (of which there are exactly two):  
-  
+
       iex> !!false
       false
       iex> !!nil


### PR DESCRIPTION
In a number of places in the docs (`!/`, `&&/2`, `Enum.all?`) the
concept of a truthy/falsy value is mentioned and briefly explained.
I propose to have single place for that explanation and point to it
from those other places.

I'm not sure if this is the right location though :-)