### PR TITLE
Ensure :name is given in Registry.start_link/1

### DIFF
--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -316,11 +316,17 @@ defmodule Registry do
             "expected :keys to be given and be one of :unique or :duplicate, got: #{inspect(keys)}"
     end
 
-    name = Keyword.get(options, :name)
+    name =
+      case Keyword.fetch(options, :name) do
+        {:ok, name} when is_atom(name) ->
+          name
 
-    unless Keyword.has_key?(options, :name) and is_atom(name) do
-      raise ArgumentError, "expected :name to be given and to be an atom, got: #{inspect(name)}"
-    end
+        {:ok, other} ->
+          raise ArgumentError, "expected :name to be an atom, got: #{inspect(other)}"
+
+        :error ->
+          raise ArgumentError, "expected :name option to be present"
+      end
 
     meta = Keyword.get(options, :meta, [])
 

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -318,7 +318,7 @@ defmodule Registry do
 
     name = Keyword.get(options, :name)
 
-    unless is_atom(name) do
+    unless Keyword.has_key?(options, :name) and is_atom(name) do
       raise ArgumentError, "expected :name to be given and to be an atom, got: #{inspect(name)}"
     end
 

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -602,7 +602,7 @@ defmodule RegistryTest do
   end
 
   test "raises if :name is missing" do
-    assert_raise ArgumentError, ~r/expected :name/, fn ->
+    assert_raise ArgumentError, ~r/expected :name option to be present/, fn ->
       Registry.start_link(keys: :unique)
     end
   end

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -601,6 +601,12 @@ defmodule RegistryTest do
     assert %{id: Registry} = Registry.child_spec([])
   end
 
+  test "raises if :name is missing" do
+    assert_raise ArgumentError, ~r/expected :name/, fn ->
+      Registry.start_link(keys: :unique)
+    end
+  end
+
   defp register_task(registry, key, value) do
     parent = self()
 

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -607,6 +607,12 @@ defmodule RegistryTest do
     end
   end
 
+  test "raises if :name is not an atom" do
+    assert_raise ArgumentError, ~r/expected :name to be an atom, got/, fn ->
+      Registry.start_link(keys: :unique, name: [])
+    end
+  end
+
   defp register_task(registry, key, value) do
     parent = self()
 


### PR DESCRIPTION
## Issue

Currently when omitting a `:name` when starting `Registry` it will be named `nil`. 

Small example:
```elixir
Interactive Elixir (1.9.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> {:ok, _pid} = Registry.start_link(keys: :unique)
{:ok, #PID<0.102.0>}
iex(2)> {:ok, _pid} = Registry.register(nil, :foo, :bar)
{:ok, #PID<0.103.0>}
iex(3)> [{_pid, val}] = Registry.lookup(nil, :foo)
[{#PID<0.100.0>, :bar}]
```

This seems to be because this line defaults `name` to `nil`:
https://github.com/elixir-lang/elixir/blob/3680e8535548cd5f928af52d92ba104eccbd6e50/lib/elixir/lib/registry.ex#L319 

## Solution

I added `Keyword.has_key?(options, :name)` to the check below the mentioned line to ensure that a name actually was given.
https://github.com/elixir-lang/elixir/blob/3680e8535548cd5f928af52d92ba104eccbd6e50/lib/elixir/lib/registry.ex#L321

Small example
```elixir
Interactive Elixir (1.9.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> Registry.start_link(keys: :unique)
** (ArgumentError) expected :name to be given and to be an atom, got: nil
    (elixir) lib/elixir/lib/registry.ex:322: Registry.start_link/1
```

It would also be possible to default it to a non-atom value, but that would probably make the error message even more misleading.

### Notes

* The error message will be `expected :name to be given and to be an atom, got: nil` then.
But `nil` is a valid name! It just was not explicitly given.

Would another `unless/2` with a more explicit error message be appropriate?

* I also added a test for this.
  As there are none for the other options this might not be necessary, or misplaced.