### PR TITLE
Avoid hyphen at EOL

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -258,8 +258,8 @@ defmodule URI do
   @doc """
   Percent-escapes all characters that require escaping in `string`.
 
-  This means reserved characters, such as `:` and `/`, and the so-
-  called unreserved characters, which have the same meaning both
+  This means reserved characters, such as `:` and `/`, and the
+  so-called unreserved characters, which have the same meaning both
   escaped and unescaped, won't be escaped by default.
 
   See `encode_www_form` if you are interested in escaping reserved

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Escript.Build do
   developers and not as a deployment mechanism. For running live
   systems, consider using `mix run` or building releases. See
   the `Application` module for more information on systems
-  life- cycles.
+  life-cycles.
 
   By default, this task starts the current application. If this
   is not desired, set the `:app` configuration to nil.

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -23,8 +23,8 @@ defmodule Mix.Tasks.Escript.Build do
   Escripts should be used as a mechanism to share scripts between
   developers and not as a deployment mechanism. For running live
   systems, consider using `mix run` or building releases. See
-  the `Application` module for more information on systems life-
-  cycles.
+  the `Application` module for more information on systems
+  life- cycles.
 
   By default, this task starts the current application. If this
   is not desired, set the `:app` configuration to nil.


### PR DESCRIPTION
Avoid splitting words that contain a hyphen into two lines,
since a space is added when docs are rendered in IEx and ExDoc.

Command used to detect this bug:

$ ag -- "\w-\n"