### PR TITLE
More examples for Kernel.function_exported?/3

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3405,9 +3405,14 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> function_exported?(Enum, :member?, 2)
+      iex> function_exported?(Enum, :map, 2)
       true
 
+      iex> function_exported?(Enum, :map, 200)
+      false
+
+      iex> function_exported?(List, :to_string, 1)
+      true
   """
   @spec function_exported?(module, atom, arity) :: boolean
   def function_exported?(module, function, arity) do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3408,7 +3408,7 @@ defmodule Kernel do
       iex> function_exported?(Enum, :map, 2)
       true
 
-      iex> function_exported?(Enum, :map, 200)
+      iex> function_exported?(Enum, :map, 10)
       false
 
       iex> function_exported?(List, :to_string, 1)


### PR DESCRIPTION
I personally found the current docs for [function_exported/3](https://hexdocs.pm/elixir/Kernel.html#function_exported?/3) a bit odd. 
```elixir
iex> function_exported?(Enum, :member?, 2)
true
```
Initially I thought the example given with the second parameter was an option. I read it as if the following. "Is there a function in Enum with 2 arity?". I later realised that it was referring to `Enum.member?/2` thanks to @Gazler so I added some more examples that I believe are more memorable functions that aren't close to common option names.