### PR TITLE
Use :elixir_aliases.inspect/1 with module aliases

### DIFF
--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -225,13 +225,12 @@ format_error({inaccessible_struct, Module}) ->
   Message =
     "cannot access struct ~ts, the struct was not yet defined or the struct is "
     "being accessed in the same context that defines it",
-  io_lib:format(Message, ['Elixir.Macro':to_string(Module)]);
+  io_lib:format(Message, [elixir_aliases:inspect(Module)]);
 format_error({undefined_struct, Module, Arity}) ->
-  StringName = 'Elixir.Macro':to_string(Module),
-  io_lib:format("~ts.__struct__/~p is undefined, cannot expand struct ~ts",
-                [StringName, Arity, StringName]);
+  Name = elixir_aliases:inspect(Module),
+  io_lib:format("~ts.__struct__/~p is undefined, cannot expand struct ~ts", [Name, Arity, Name]);
 format_error({unknown_key_for_struct, Module, Key}) ->
   io_lib:format("unknown key ~ts for struct ~ts",
-                ['Elixir.Macro':to_string(Key), 'Elixir.Macro':to_string(Module)]);
+                ['Elixir.Macro':to_string(Key), elixir_aliases:inspect(Module)]);
 format_error(ignored_struct_key_in_struct) ->
   "key :__struct__ is ignored when using structs".


### PR DESCRIPTION
The `Module` variable in these cases is guaranteed to be a module alias.

Follow up of https://github.com/elixir-lang/elixir/pull/8864#discussion_r263304032