### PR TITLE
Add guard to Macro.to_string/2

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -617,7 +617,7 @@ defmodule Macro do
   def to_string(tree, fun \\ fn _ast, string -> string end)
 
   # Variables
-  def to_string({var, _, atom} = ast, fun) when is_atom(atom) do
+  def to_string({var, _, context} = ast, fun) when is_atom(var) and is_atom(context) do
     fun.(ast, Atom.to_string(var))
   end
 


### PR DESCRIPTION
Three-element tuples with an atom at the end raise an `ArgumentError` instead of using inspect (fallback):

```elixir
iex(1)> Macro.to_string({1, 2, :hello})
** (ArgumentError) argument error
    :erlang.atom_to_binary(1, :utf8)
    (elixir) lib/macro.ex:621: Macro.to_string/2
iex(1)> Macro.to_string({1, 2, :hello, 1})
"{1, 2, :hello, 1}"
```