### PR TITLE
Ensure inspect returns valid ~r// expressions

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -307,10 +307,17 @@ end
 
 defimpl Inspect, for: Regex do
   def inspect(regex, opts) do
-    {escaped, _} = Identifier.escape(regex.source, ?/, :infinity, &escape_map/1)
+    {escaped, _} =
+      regex.source
+      |> :elixir_interpolation.unescape_chars(&unescape_map/1)
+      |> Identifier.escape(?/, :infinity, &escape_map/1)
+
     source = IO.iodata_to_binary(['~r/', escaped, ?/, regex.opts])
     color(source, :regex, opts)
   end
+
+  defp unescape_map(?/), do: ?/
+  defp unescape_map(_), do: false
 
   defp escape_map(?\a), do: '\\a'
   defp escape_map(?\f), do: '\\f'

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -640,6 +640,8 @@ defmodule Inspect.OthersTest do
   test "regex" do
     assert inspect(~r(foo)m) == "~r/foo/m"
 
+    assert inspect(Regex.compile!("a\\/b")) == "~r/a\\/b/"
+
     assert inspect(Regex.compile!("\a\b\d\e\f\n\r\s\t\v/")) ==
              "~r/\\a\\x08\\x7F\\x1B\\f\\n\\r \\t\\v\\//"
 


### PR DESCRIPTION
This is an attempt to fix #8860 