### PR TITLE
Use inspect/1 with values returned by __struct__/*

### DIFF
--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -216,11 +216,11 @@ format_error({not_kv_pair, Expr}) ->
 format_error({non_map_after_struct, Expr}) ->
   io_lib:format("expected struct to be followed by a map, got: ~ts",
                 ['Elixir.Macro':to_string(Expr)]);
-format_error({invalid_struct_return_value, Module, Arity, Expr}) ->
+format_error({invalid_struct_return_value, Module, Arity, Value}) ->
   Message =
     "expected ~ts.__struct__/~p to return a map with a :__struct__ key that holds the "
     "name of the struct (atom), got: ~ts",
-  io_lib:format(Message, [elixir_aliases:inspect(Module), Arity, 'Elixir.Macro':to_string(Expr)]);
+  io_lib:format(Message, [elixir_aliases:inspect(Module), Arity, 'Elixir.Kernel':inspect(Value)]);
 format_error({inaccessible_struct, Module}) ->
   Message =
     "cannot access struct ~ts, the struct was not yet defined or the struct is "


### PR DESCRIPTION
`__struct__/0,1` is not meant to return an AST. Using `Macro.to_string/1` might lead to incorrect error messages:

```elixir
    defmodule MyStruct do
      def __struct__, do: {:ok, :one, :two}
      def __struct__(_), do: {:ok, :one, :two}
    end

    iex> %MyStruct{}
    ** (CompileError) iex:2: expected MyStruct.__struct__/1 to return a map with a :__struct__ key that holds the name of the struct (atom), got: ok
```

Follow up of https://github.com/elixir-lang/elixir/pull/8864#discussion_r263334936 (I thought I was going to find more occurrences 😅)