### PR TITLE
Fix small typo for ceil behavior docs

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -354,7 +354,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns the smallest integer not greater than `number`.
+  Returns the smallest integer greater than or equal to `number`.
 
   If you want to perform ceil operation on other decimal places,
   use `Float.ceil/2` instead.
@@ -469,7 +469,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns the largest integer not greater than `number`.
+  Returns the largest integer smaller than or equal to `number`.
 
   If you want to perform floor operation on other decimal places,
   use `Float.floor/2` instead.


### PR DESCRIPTION
I got caught off-guard by the existing documentation, so I just wanted to submit a quick fix for it. Would be happy to switch to ```Returns the smallest integer greater than or equal to `number`.``` if that sounds better!