### PR TITLE
Replace use of "item(s)" with "element(s)" in Enum module

### DIFF
--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -622,8 +622,8 @@ defmodule EExTest do
     list
     |> Enum.with_index()
     |> Enum.map(fn
-      {item, index} when rem(index, 2) == 0 -> a.(item)
-      {item, index} when rem(index, 2) == 1 -> b.(item)
+      {element index} when rem(index, 2) == 0 -> a.(element)
+      {element, index} when rem(index, 2) == 1 -> b.(element)
     end)
   end
 

--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -622,7 +622,7 @@ defmodule EExTest do
     list
     |> Enum.with_index()
     |> Enum.map(fn
-      {element index} when rem(index, 2) == 0 -> a.(element)
+      {element, index} when rem(index, 2) == 0 -> a.(element)
       {element, index} when rem(index, 2) == 1 -> b.(element)
     end)
   end

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -121,7 +121,7 @@ defprotocol Enumerable do
 
   Most of the operations in `Enum` are implemented in terms of reduce.
   This function should apply the given `t:reducer/0` function to each
-  item in the `enumerable` and proceed as expected by the returned
+  element in the `enumerable` and proceed as expected by the returned
   accumulator.
 
   See the documentation of the types `t:result/0` and `t:acc/0` for
@@ -276,9 +276,9 @@ defmodule Enum do
   end
 
   @doc """
-  Returns `true` if `fun.(item)` is truthy for all items in `enumerable`.
+  Returns `true` if `fun.(element)` is truthy for all elements in `enumerable`.
 
-  Iterates over the `enumerable` and invokes `fun` on each item. When an invocation
+  Iterates over the `enumerable` and invokes `fun` on each element. When an invocation
   of `fun` returns a falsy value (`false` or `nil`) iteration stops immediately and
   `false` is returned. In all other cases `true` is returned.
 
@@ -289,12 +289,12 @@ defmodule Enum do
 
       iex> Enum.all?([2, 3, 4], fn x -> rem(x, 2) == 0 end)
       false
-      
+
       iex> Enum.all?([], fn x -> x > 0 end)
       true
 
-  If no function is given, the truthiness of each item is checked during iteration.
-  When an item has a falsy value (`false` or `nil`) iteration stops immediately and
+  If no function is given, the truthiness of each element is checked during iteration.
+  When an element has a falsy value (`false` or `nil`) iteration stops immediately and
   `false` is returned. In all other cases `true` is returned.
 
       iex> Enum.all?([1, 2, 3])
@@ -302,7 +302,7 @@ defmodule Enum do
 
       iex> Enum.all?([1, nil, 3])
       false
-      
+
       iex> Enum.all?([])
       true
 
@@ -323,9 +323,9 @@ defmodule Enum do
   end
 
   @doc """
-  Returns `true` if `fun.(item)` is truthy for at least one item in `enumerable`.
+  Returns `true` if `fun.(element)` is truthy for at least one element in `enumerable`.
 
-  Iterates over the `enumerable` and invokes `fun` on each item. When an invocation
+  Iterates over the `enumerable` and invokes `fun` on each element. When an invocation
   of `fun` returns a truthy value (neither `false` nor `nil`) iteration stops
   immediately and `true` is returned. In all other cases `false` is returned.
 
@@ -336,12 +336,12 @@ defmodule Enum do
 
       iex> Enum.any?([2, 3, 4], fn x -> rem(x, 2) == 1 end)
       true
-      
+
       iex> Enum.any?([], fn x -> x > 0 end)
       false
 
-  If no function is given, the truthiness of each item is checked during iteration.
-  When an item has a truthy value (neither `false` nor `nil`) iteration stops
+  If no function is given, the truthiness of each element is checked during iteration.
+  When an element has a truthy value (neither `false` nor `nil`) iteration stops
   immediately and `true` is returned. In all other cases `false` is returned.
 
       iex> Enum.any?([false, false, false])
@@ -349,7 +349,7 @@ defmodule Enum do
 
       iex> Enum.any?([false, true, false])
       true
-      
+
       iex> Enum.any?([])
       false
 
@@ -425,7 +425,7 @@ defmodule Enum do
   def chunk_every(enumerable, count), do: chunk_every(enumerable, count, count, [])
 
   @doc """
-  Returns list of lists containing `count` items each, where
+  Returns list of lists containing `count` elements each, where
   each new chunk starts `step` elements into the `enumerable`.
 
   `step` is optional and, if not passed, defaults to `count`, i.e.
@@ -482,11 +482,11 @@ defmodule Enum do
 
   ## Examples
 
-      iex> chunk_fun = fn item, acc ->
-      ...>   if rem(item, 2) == 0 do
-      ...>     {:cont, Enum.reverse([item | acc]), []}
+      iex> chunk_fun = fn element, acc ->
+      ...>   if rem(element, 2) == 0 do
+      ...>     {:cont, Enum.reverse([element | acc]), []}
       ...>   else
-      ...>     {:cont, [item | acc]}
+      ...>     {:cont, [element | acc]}
       ...>   end
       ...> end
       iex> after_fun = fn
@@ -607,7 +607,7 @@ defmodule Enum do
   end
 
   @doc """
-  Returns the count of items in the `enumerable` for which `fun` returns
+  Returns the count of elements in the `enumerable` for which `fun` returns
   a truthy value.
 
   ## Examples
@@ -669,7 +669,7 @@ defmodule Enum do
   end
 
   @doc """
-  Drops the `amount` of items from the `enumerable`.
+  Drops the `amount` of elements from the `enumerable`.
 
   If a negative `amount` is given, the `amount` of last values will be dropped.
   The `enumerable` will be enumerated once to retrieve the proper index and
@@ -713,12 +713,12 @@ defmodule Enum do
   end
 
   @doc """
-  Returns a list of every `nth` item in the `enumerable` dropped,
+  Returns a list of every `nth` element in the `enumerable` dropped,
   starting with the first element.
 
-  The first item is always dropped, unless `nth` is 0.
+  The first element is always dropped, unless `nth` is 0.
 
-  The second argument specifying every `nth` item must be a non-negative
+  The second argument specifying every `nth` element must be a non-negative
   integer.
 
   ## Examples
@@ -746,7 +746,7 @@ defmodule Enum do
   end
 
   @doc """
-  Drops items at the beginning of the `enumerable` while `fun` returns a
+  Drops elements at the beginning of the `enumerable` while `fun` returns a
   truthy value.
 
   ## Examples
@@ -766,7 +766,7 @@ defmodule Enum do
   end
 
   @doc """
-  Invokes the given `fun` for each item in the `enumerable`.
+  Invokes the given `fun` for each element in the `enumerable`.
 
   Returns `:ok`.
 
@@ -924,7 +924,7 @@ defmodule Enum do
   @doc false
   @deprecated "Use Enum.filter/2 + Enum.map/2 or for comprehensions instead"
   def filter_map(enumerable, filter, mapper) when is_list(enumerable) do
-    for item <- enumerable, filter.(item), do: mapper.(item)
+    for element <- enumerable, filter.(element), do: mapper.(element)
   end
 
   def filter_map(enumerable, filter, mapper) do
@@ -934,8 +934,8 @@ defmodule Enum do
   end
 
   @doc """
-  Returns the first item for which `fun` returns a truthy value.
-  If no such item is found, returns `default`.
+  Returns the first element for which `fun` returns a truthy value.
+  If no such element is found, returns `default`.
 
   ## Examples
 
@@ -1062,7 +1062,7 @@ defmodule Enum do
   Maps and reduces an `enumerable`, flattening the given results (only one level deep).
 
   It expects an accumulator and a function that receives each enumerable
-  item, and must return a tuple containing a new enumerable (often a list)
+  element, and must return a tuple containing a new enumerable (often a list)
   with the new accumulator or a tuple with `:halt` as first element and
   the accumulator as second.
 
@@ -1288,7 +1288,7 @@ defmodule Enum do
 
   If `joiner` is not passed at all, it defaults to the empty binary.
 
-  All items in the `enumerable` must be convertible to a binary,
+  All elements in the `enumerable` must be convertible to a binary,
   otherwise an error is raised.
 
   ## Examples
@@ -1318,8 +1318,8 @@ defmodule Enum do
   end
 
   @doc """
-  Returns a list where each item is the result of invoking
-  `fun` on each corresponding item of `enumerable`.
+  Returns a list where each element is the result of invoking
+  `fun` on each corresponding element of `enumerable`.
 
   For maps, the function expects a key-value tuple.
 
@@ -1345,11 +1345,11 @@ defmodule Enum do
 
   @doc """
   Returns a list of results of invoking `fun` on every `nth`
-  item of `enumerable`, starting with the first element.
+  element of `enumerable`, starting with the first element.
 
-  The first item is always passed to the given function, unless `nth` is `0`.
+  The first element is always passed to the given function, unless `nth` is `0`.
 
-  The second argument specifying every `nth` item must be a non-negative
+  The second argument specifying every `nth` element must be a non-negative
   integer.
 
   If `nth` is `0`, then `enumerable` is directly converted to a list,
@@ -1390,7 +1390,7 @@ defmodule Enum do
   the same type as `joiner`.
   If `joiner` is not passed at all, it defaults to an empty binary.
 
-  All items returned from invoking the `mapper` must be convertible to
+  All elements returned from invoking the `mapper` must be convertible to
   a binary, otherwise an error is raised.
 
   ## Examples
@@ -1420,7 +1420,7 @@ defmodule Enum do
   end
 
   @doc """
-  Invokes the given function to each item in the `enumerable` to reduce
+  Invokes the given function to each element in the `enumerable` to reduce
   it to a single element, while keeping an accumulator.
 
   Returns a tuple where the first element is the mapped enumerable and
@@ -2036,8 +2036,8 @@ defmodule Enum do
 
   def reverse([]), do: []
   def reverse([_] = list), do: list
-  def reverse([item1, item2]), do: [item2, item1]
-  def reverse([item1, item2 | rest]), do: :lists.reverse(rest, [item2, item1])
+  def reverse([element1, element2]), do: [element2, element1]
+  def reverse([element1, element2 | rest]), do: :lists.reverse(rest, [element2, element1])
   def reverse(enumerable), do: reduce(enumerable, [], &[&1 | &2])
 
   @doc """
@@ -2461,12 +2461,12 @@ defmodule Enum do
   end
 
   @doc """
-  Takes an `amount` of items from the beginning or the end of the `enumerable`.
+  Takes an `amount` of elements from the beginning or the end of the `enumerable`.
 
-  If a positive `amount` is given, it takes the `amount` items from the
+  If a positive `amount` is given, it takes the `amount` elements from the
   beginning of the `enumerable`.
 
-  If a negative `amount` is given, the `amount` of items will be taken from the end.
+  If a negative `amount` is given, the `amount` of elements will be taken from the end.
   The `enumerable` will be enumerated once to retrieve the proper index and
   the remaining calculation is performed from the end.
 
@@ -2516,12 +2516,12 @@ defmodule Enum do
   end
 
   @doc """
-  Returns a list of every `nth` item in the `enumerable`,
+  Returns a list of every `nth` element in the `enumerable`,
   starting with the first element.
 
-  The first item is always included, unless `nth` is 0.
+  The first element is always included, unless `nth` is 0.
 
-  The second argument specifying every `nth` item must be a non-negative
+  The second argument specifying every `nth` element must be a non-negative
   integer.
 
   ## Examples
@@ -2549,7 +2549,7 @@ defmodule Enum do
   end
 
   @doc """
-  Takes `count` random items from `enumerable`.
+  Takes `count` random elements from `enumerable`.
 
   Notice this function will traverse the whole `enumerable` to
   get the random sublist.
@@ -2622,7 +2622,7 @@ defmodule Enum do
   end
 
   @doc """
-  Takes the items from the beginning of the `enumerable` while `fun` returns
+  Takes the elements from the beginning of the `enumerable` while `fun` returns
   a truthy value.
 
   ## Examples
@@ -2686,7 +2686,7 @@ defmodule Enum do
 
   @doc """
   Enumerates the `enumerable`, by removing the elements for which
-  function `fun` returned duplicate items.
+  function `fun` returned duplicate elements.
 
   The function `fun` maps every element to a term. Two elements are
   considered duplicates if the return value of `fun` is equal for
@@ -2718,7 +2718,7 @@ defmodule Enum do
   Opposite of `zip/2`. Extracts two-element tuples from the
   given `enumerable` and groups them together.
 
-  It takes an `enumerable` with items being two-element tuples and returns
+  It takes an `enumerable` with elements being two-element tuples and returns
   a tuple with two lists, each of which is formed by the first and
   second element of each tuple, respectively.
 

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -16,7 +16,7 @@ defmodule GenServer do
 
   Let's start with a code example and then explore the available callbacks.
   Imagine we want a GenServer that works like a stack, allowing us to push
-  and pop items:
+  and pop elements:
 
       defmodule Stack do
         use GenServer
@@ -34,8 +34,8 @@ defmodule GenServer do
         end
 
         @impl true
-        def handle_cast({:push, item}, state) do
-          {:noreply, [item | state]}
+        def handle_cast({:push, element}, state) do
+          {:noreply, [element | state]}
         end
       end
 
@@ -54,7 +54,7 @@ defmodule GenServer do
 
   We start our `Stack` by calling `start_link/2`, passing the module
   with the server implementation and its initial argument (a list
-  representing the stack containing the item `:hello`). We can primarily
+  representing the stack containing the element `:hello`). We can primarily
   interact with the server by sending two types of messages. **call**
   messages expect a reply from the server (and are therefore synchronous)
   while **cast** messages do not.
@@ -83,8 +83,8 @@ defmodule GenServer do
           GenServer.start_link(__MODULE__, default)
         end
 
-        def push(pid, item) do
-          GenServer.cast(pid, {:push, item})
+        def push(pid, element) do
+          GenServer.cast(pid, {:push, element})
         end
 
         def pop(pid) do
@@ -104,8 +104,8 @@ defmodule GenServer do
         end
 
         @impl true
-        def handle_cast({:push, item}, state) do
-          {:noreply, [item | state]}
+        def handle_cast({:push, element}, state) do
+          {:noreply, [element | state]}
         end
       end
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1310,8 +1310,8 @@ defmodule Kernel do
   Concatenates a proper list and a term, returning a list.
 
   The complexity of `a ++ b` is proportional to `length(a)`, so avoid repeatedly
-  appending to lists of arbitrary length, e.g. `list ++ [item]`.
-  Instead, consider prepending via `[item | rest]` and then reversing.
+  appending to lists of arbitrary length, e.g. `list ++ [element]`.
+  Instead, consider prepending via `[element | rest]` and then reversing.
 
   If the `right` operand is not a proper list, it returns an improper list.
   If the `left` operand is not a proper list, it raises `ArgumentError`.
@@ -1345,8 +1345,8 @@ defmodule Kernel do
   end
 
   @doc """
-  Removes the first occurrence of an item on the left list
-  for each item on the right.
+  Removes the first occurrence of an element on the left list
+  for each element on the right.
 
   The complexity of `a -- b` is proportional to `length(a) * length(b)`,
   meaning that it will be very slow if both `a` and `b` are long lists.
@@ -1466,7 +1466,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns `true` if the two items are equal.
+  Returns `true` if the two terms are equal.
 
   This operator considers 1 and 1.0 to be equal. For stricter
   semantics, use `===/2` instead.
@@ -1491,7 +1491,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns `true` if the two items are not equal.
+  Returns `true` if the two terms are not equal.
 
   This operator considers 1 and 1.0 to be equal. For match
   comparison, use `!==/2` instead.
@@ -1516,9 +1516,9 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns `true` if the two items are exactly equal.
+  Returns `true` if the two terms are exactly equal.
 
-  The items are only considered to be exactly equal if they
+  The terms are only considered to be exactly equal if they
   have the same value and are of the same type. For example,
   `1 == 1.0` returns `true`, but since they are of different
   types, `1 === 1.0` returns `false`.
@@ -1543,7 +1543,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns `true` if the two items are not exactly equal.
+  Returns `true` if the two terms are not exactly equal.
 
   All terms in Elixir can be compared with each other.
 
@@ -3140,7 +3140,7 @@ defmodule Kernel do
 
   In the example above, even though the right list has more entries than the
   left one, destructuring works fine. If the right list is smaller, the
-  remaining items are simply set to `nil`:
+  remaining elements are simply set to `nil`:
 
       iex> destructure([x, y, z], [1])
       iex> {x, y, z}

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -37,7 +37,7 @@ defmodule Kernel.SpecialForms do
 
   ## AST representation
 
-  Only two-item tuples are considered literals in Elixir and return themselves
+  Only two-element tuples are considered literals in Elixir and return themselves
   when quoted. Therefore, all other tuples are represented in the AST as calls to
   the `:{}` special form.
 

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -206,8 +206,8 @@ defmodule Map do
     |> :maps.from_list()
   end
 
-  defp new_transform([item | rest], fun, acc) do
-    new_transform(rest, fun, [fun.(item) | acc])
+  defp new_transform([element | rest], fun, acc) do
+    new_transform(rest, fun, [fun.(element) | acc])
   end
 
   @doc """

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -104,16 +104,16 @@ defmodule MapSet do
     :maps.from_list(acc)
   end
 
-  defp new_from_list([item | rest], acc) do
-    new_from_list(rest, [{item, @dummy_value} | acc])
+  defp new_from_list([element | rest], acc) do
+    new_from_list(rest, [{element, @dummy_value} | acc])
   end
 
   defp new_from_list_transform([], _fun, acc) do
     :maps.from_list(acc)
   end
 
-  defp new_from_list_transform([item | rest], fun, acc) do
-    new_from_list_transform(rest, fun, [{fun.(item), @dummy_value} | acc])
+  defp new_from_list_transform([element | rest], fun, acc) do
+    new_from_list_transform(rest, fun, [{fun.(element), @dummy_value} | acc])
   end
 
   @doc """
@@ -148,7 +148,7 @@ defmodule MapSet do
   def difference(map_set1, map_set2)
 
   # If the first set is less than twice the size of the second map,
-  # it is fastest to re-accumulate items in the first set that are not
+  # it is fastest to re-accumulate elements in the first set that are not
   # present in the second set.
   def difference(%MapSet{map: map1}, %MapSet{map: map2})
       when map_size(map1) < map_size(map2) * 2 do
@@ -161,7 +161,7 @@ defmodule MapSet do
   end
 
   # If the second set is less than half the size of the first set, it's fastest
-  # to simply iterate through each item in the second set, deleting them from
+  # to simply iterate through each element in the second set, deleting them from
   # the first set.
   def difference(%MapSet{map: map1} = map_set, %MapSet{map: map2}) do
     %{map_set | map: Map.drop(map1, Map.keys(map2))}

--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -115,7 +115,7 @@ defmodule OptionParser do
   Switches can be specified with modifiers, which change how
   they behave. The following modifiers are supported:
 
-    * `:keep` - keeps duplicated items instead of overriding them;
+    * `:keep` - keeps duplicated elements instead of overriding them;
       works with all types except `:count`. Specifying `switch_name: :keep`
       assumes the type of `:switch_name` will be `:string`.
 

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -4,7 +4,7 @@ defmodule Stream do
 
   Streams are composable, lazy enumerables (for an introduction on
   enumerables, see the `Enum` module). Any enumerable that generates
-  items one by one during enumeration is called a stream. For example,
+  elements one by one during enumeration is called a stream. For example,
   Elixir's `Range` is a stream:
 
       iex> range = 1..5
@@ -22,9 +22,9 @@ defmodule Stream do
       [3, 5, 7]
 
   Notice we started with a range and then we created a stream that is
-  meant to multiply each item in the range by 2. At this point, no
+  meant to multiply each element in the range by 2. At this point, no
   computation was done. Only when `Enum.map/2` is called we actually
-  enumerate over each item in the range, multiplying it by 2 and adding 1.
+  enumerate over each element in the range, multiplying it by 2 and adding 1.
   We say the functions in `Stream` are *lazy* and the functions in `Enum`
   are *eager*.
 
@@ -46,7 +46,7 @@ defmodule Stream do
       6
       #=> [2, 4, 6]
 
-  Notice that we first printed each item in the list, then multiplied each
+  Notice that we first printed each element in the list, then multiplied each
   element by 2 and finally printed each new value. In this example, the list
   was enumerated three times. Let's see an example with streams:
 
@@ -63,8 +63,8 @@ defmodule Stream do
       6
       #=> [2, 4, 6]
 
-  Although the end result is the same, the order in which the items were
-  printed changed! With streams, we print the first item and then print
+  Although the end result is the same, the order in which the elements were
+  printed changed! With streams, we print the first element and then print
   its double. In this example, the list was enumerated just once!
 
   That's what we meant when we said earlier that streams are composable,
@@ -150,7 +150,7 @@ defmodule Stream do
   def chunk_every(enum, count), do: chunk_every(enum, count, count, [])
 
   @doc """
-  Streams the enumerable in chunks, containing `count` items each,
+  Streams the enumerable in chunks, containing `count` elements each,
   where each new chunk starts `step` elements into the enumerable.
 
   `step` is optional and, if not passed, defaults to `count`, i.e.
@@ -217,11 +217,11 @@ defmodule Stream do
 
   ## Examples
 
-      iex> chunk_fun = fn item, acc ->
-      ...>   if rem(item, 2) == 0 do
-      ...>     {:cont, Enum.reverse([item | acc]), []}
+      iex> chunk_fun = fn element, acc ->
+      ...>   if rem(element, 2) == 0 do
+      ...>     {:cont, Enum.reverse([element | acc]), []}
       ...>   else
-      ...>     {:cont, [item | acc]}
+      ...>     {:cont, [element | acc]}
       ...>   end
       ...> end
       iex> after_fun = fn
@@ -254,9 +254,9 @@ defmodule Stream do
     fn entry, acc(head, [acc | after_fun], tail) ->
       case callback.(entry, acc) do
         {:cont, emit, acc} ->
-          # If we emit an item and then we have to halt,
+          # If we emit an element and then we have to halt,
           # we need to disable the after_fun callback to
-          # avoid emitting even more items.
+          # avoid emitting even more elements.
           case next(fun, emit, [head | tail]) do
             {:halt, [head | tail]} -> {:halt, acc(head, [acc | &{:cont, &1}], tail)}
             {command, [head | tail]} -> {command, acc(head, [acc | after_fun], tail)}
@@ -312,11 +312,11 @@ defmodule Stream do
   end
 
   @doc """
-  Lazily drops the next `n` items from the enumerable.
+  Lazily drops the next `n` elements from the enumerable.
 
-  If a negative `n` is given, it will drop the last `n` items from
+  If a negative `n` is given, it will drop the last `n` elements from
   the collection. Note that the mechanism by which this is implemented
-  will delay the emission of any item until `n` additional items have
+  will delay the emission of any element until `n` additional elements have
   been emitted by the enum.
 
   ## Examples
@@ -362,9 +362,9 @@ defmodule Stream do
   end
 
   @doc """
-  Creates a stream that drops every `nth` item from the enumerable.
+  Creates a stream that drops every `nth` element from the enumerable.
 
-  The first item is always dropped, unless `nth` is 0.
+  The first element is always dropped, unless `nth` is 0.
 
   `nth` must be a non-negative integer.
 
@@ -409,7 +409,7 @@ defmodule Stream do
   end
 
   @doc """
-  Executes the given function for each item.
+  Executes the given function for each element.
 
   Useful for adding side effects (like printing) to a stream.
 
@@ -485,7 +485,7 @@ defmodule Stream do
 
   The values emitted are an increasing counter starting at `0`.
   This operation will block the caller by the given interval
-  every time a new item is streamed.
+  every time a new element is streamed.
 
   Do not use this function to generate a sequence of numbers.
   If blocking the caller process is not necessary, use
@@ -563,9 +563,9 @@ defmodule Stream do
 
   @doc """
   Creates a stream that will apply the given function on
-  every `nth` item from the enumerable.
+  every `nth` element from the enumerable.
 
-  The first item is always passed to the given function.
+  The first element is always passed to the given function.
 
   `nth` must be a non-negative integer.
 
@@ -673,7 +673,7 @@ defmodule Stream do
   end
 
   @doc """
-  Lazily takes the next `count` items from the enumerable and stops
+  Lazily takes the next `count` elements from the enumerable and stops
   enumeration.
 
   If a negative `count` is given, the last `count` values will be taken.
@@ -710,9 +710,9 @@ defmodule Stream do
   end
 
   @doc """
-  Creates a stream that takes every `nth` item from the enumerable.
+  Creates a stream that takes every `nth` element from the enumerable.
 
-  The first item is always included, unless `nth` is 0.
+  The first element is always included, unless `nth` is 0.
 
   `nth` must be a non-negative integer.
 
@@ -760,7 +760,7 @@ defmodule Stream do
   Creates a stream that emits a single value after `n` milliseconds.
 
   The value emitted is `0`. This operation will block the caller by
-  the given time until the item is streamed.
+  the given time until the element is streamed.
 
   ## Examples
 
@@ -776,7 +776,7 @@ defmodule Stream do
   @doc """
   Transforms an existing stream.
 
-  It expects an accumulator and a function that receives each stream item
+  It expects an accumulator and a function that receives each stream element
   and an accumulator, and must return a tuple containing a new stream
   (often a list) with the new accumulator or a tuple with `:halt` as first
   element and the accumulator as second.
@@ -975,7 +975,7 @@ defmodule Stream do
   Keep in mind that, in order to know if an element is unique
   or not, this function needs to store all unique values emitted
   by the stream. Therefore, if the stream is infinite, the number
-  of items stored will grow infinitely, never being garbage-collected.
+  of elements stored will grow infinitely, never being garbage-collected.
 
   ## Examples
 
@@ -996,7 +996,7 @@ defmodule Stream do
 
   @doc """
   Creates a stream that only emits elements if they are unique, by removing the
-  elements for which function `fun` returned duplicate items.
+  elements for which function `fun` returned duplicate elements.
 
   The function `fun` maps every element to a term which is used to
   determine if two elements are duplicates.
@@ -1004,7 +1004,7 @@ defmodule Stream do
   Keep in mind that, in order to know if an element is unique
   or not, this function needs to store all unique values emitted
   by the stream. Therefore, if the stream is infinite, the number
-  of items stored will grow infinitely, never being garbage-collected.
+  of elements stored will grow infinitely, never being garbage-collected.
 
   ## Example
 
@@ -1021,7 +1021,7 @@ defmodule Stream do
   end
 
   @doc """
-  Creates a stream where each item in the enumerable will
+  Creates a stream where each element in the enumerable will
   be wrapped in a tuple alongside its index.
 
   If an `offset` is given, we will index from the given offset instead of from zero.
@@ -1346,7 +1346,7 @@ defmodule Stream do
   Successive values are generated by calling `next_fun` with the
   previous accumulator (the initial value being the result returned
   by `start_fun`) and it must return a tuple containing a list
-  of items to be emitted and the next accumulator. The enumeration
+  of elements to be emitted and the next accumulator. The enumeration
   finishes if it returns `{:halt, acc}`.
 
   As the name says, this function is useful to stream values from

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -428,9 +428,9 @@ defmodule Task do
 
   @doc """
   Returns a stream where the given function (`module` and `function_name`)
-  is mapped concurrently on each item in `enumerable`.
+  is mapped concurrently on each element in `enumerable`.
 
-  Each item of `enumerable` will be prepended to the given `args` and
+  Each element of `enumerable` will be prepended to the given `args` and
   processed by its own task. The tasks will be linked to an intermediate
   process that is then linked to the current process. This means a failure
   in a task terminates the current process and a failure in the current process
@@ -499,12 +499,12 @@ defmodule Task do
 
   @doc """
   Returns a stream that runs the given function `fun` concurrently
-  on each item in `enumerable`.
+  on each element in `enumerable`.
 
   Works the same as `async_stream/5` but with an anonymous function instead of a
   module-function-arguments tuple. `fun` must be a one-arity anonymous function.
 
-  Each `enumerable` item is passed as argument to the given function `fun` and
+  Each `enumerable` element is passed as argument to the given function `fun` and
   processed by its own task. The tasks will be linked to the current process,
   similarly to `async/1`.
 

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -239,9 +239,9 @@ defmodule Task.Supervisor do
 
   @doc """
   Returns a stream where the given function (`module` and `function`)
-  is mapped concurrently on each item in `enumerable`.
+  is mapped concurrently on each element in `enumerable`.
 
-  Each item will be prepended to the given `args` and processed by its
+  Each element will be prepended to the given `args` and processed by its
   own task. The tasks will be spawned under the given `supervisor` and
   linked to the current process, similarly to `async/4`.
 
@@ -298,9 +298,9 @@ defmodule Task.Supervisor do
 
   @doc """
   Returns a stream that runs the given function `fun` concurrently
-  on each item in `enumerable`.
+  on each element in `enumerable`.
 
-  Each item in `enumerable` is passed as argument to the given function `fun`
+  Each element in `enumerable` is passed as argument to the given function `fun`
   and processed by its own task. The tasks will be spawned under the given
   `supervisor` and linked to the current process, similarly to `async/2`.
 
@@ -315,9 +315,9 @@ defmodule Task.Supervisor do
 
   @doc """
   Returns a stream where the given function (`module` and `function`)
-  is mapped concurrently on each item in `enumerable`.
+  is mapped concurrently on each element in `enumerable`.
 
-  Each item in `enumerable` will be prepended to the given `args` and processed
+  Each element in `enumerable` will be prepended to the given `args` and processed
   by its own task. The tasks will be spawned under the given `supervisor` and
   will not be linked to the current process, similarly to `async_nolink/4`.
 
@@ -339,9 +339,9 @@ defmodule Task.Supervisor do
 
   @doc """
   Returns a stream that runs the given `function` concurrently on each
-  item in `enumerable`.
+  element in `enumerable`.
 
-  Each item in `enumerable` is passed as argument to the given function `fun`
+  Each element in `enumerable` is passed as argument to the given function `fun`
   and processed by its own task. The tasks will be spawned under the given
   `supervisor` and will not be linked to the current process, similarly to `async_nolink/2`.
 

--- a/lib/elixir/pages/Syntax Reference.md
+++ b/lib/elixir/pages/Syntax Reference.md
@@ -199,7 +199,7 @@ which is represented as a tuple with three elements:
 {:sum, meta, [1, 2, 3]}
 ```
 
-the first element is an atom (or another tuple), the second element is a list of two-item tuples with metadata (such as line numbers) and the third is a list of arguments.
+the first element is an atom (or another tuple), the second element is a list of two-element tuples with metadata (such as line numbers) and the third is a list of arguments.
 
 We can retrieve the AST for any Elixir expression by calling `quote`:
 

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -1666,7 +1666,7 @@ defmodule EnumTest.SideEffects do
     end
   end
 
-  test "take/2 with no item works as no-op" do
+  test "take/2 with no elements works as no-op" do
     iterator = File.stream!(fixture_path("unknown.txt"))
 
     assert Enum.take(iterator, 0) == []

--- a/lib/elixir/test/elixir/gen_server_test.exs
+++ b/lib/elixir/test/elixir/gen_server_test.exs
@@ -23,8 +23,8 @@ defmodule GenServerTest do
       {:reply, reason, state}
     end
 
-    def handle_cast({:push, item}, state) do
-      {:noreply, [item | state]}
+    def handle_cast({:push, element}, state) do
+      {:noreply, [element | state]}
     end
 
     def terminate(_reason, _state) do

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -1212,8 +1212,8 @@ defmodule StreamTest do
 
   defp inbox_stream({:cont, acc}, f) do
     receive do
-      {:stream, item} ->
-        inbox_stream(f.(item, acc), f)
+      {:stream, element} ->
+        inbox_stream(f.(element, acc), f)
     end
   end
 end

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -377,7 +377,7 @@ defmodule IEx.HelpersTest do
       c_h = "* def c(files, path \\\\ :in_memory)\n\nCompiles the given files."
 
       eq_h =
-        "* def left == right\n\n  @spec term() == term() :: boolean()\n\nguard: true\n\nReturns `true` if the two items are equal.\n\n"
+        "* def left == right\n\n  @spec term() == term() :: boolean()\n\nguard: true\n\nReturns `true` if the two terms are equal.\n\n"
 
       def_h =
         "* defmacro def(call, expr \\\\ nil)\n\nDefines a function with the given name and body."


### PR DESCRIPTION
Related to f451f9f63d6854eef0e828be08dd69786b6fd86d