### PR TITLE
Warn if underscored type variable is used more than once

### DIFF
--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1227,6 +1227,30 @@ defmodule Kernel.WarningTest do
       purge(Sample)
     end
 
+    test "underscored types variables" do
+      output =
+        capture_err(fn ->
+          Code.eval_string("""
+          defmodule Sample do
+            @type in_typespec_vars(_var1, _var1) :: atom
+            @type in_typespec(_var2) :: {atom, _var2}
+
+            @spec in_spec(_var3) :: {atom, _var3} when _var3: var
+            def in_spec(a), do: {:ok, a}
+          end
+          """)
+        end)
+
+      assert output =~ "nofile:2"
+      assert output =~ ~r/the underscored type variable "_var1" is used more than once/
+      assert output =~ "nofile:3"
+      assert output =~ ~r/the underscored type variable "_var2" is used more than once/
+      assert output =~ "nofile:5"
+      assert output =~ ~r/the underscored type variable "_var3" is used more than once/
+    after
+      purge(Sample)
+    end
+
     test "typedoc on typep" do
       assert capture_err(fn ->
                Code.eval_string("""


### PR DESCRIPTION
#8891 showed that underscored variables in type specifications are treated differently: the `singleton_typevar` error was not raised with underscored variables. 

The meaning of underscored variables in type specifications seems to be the same as regular underscored variables: values that are not meant to be used. The `singleton_typevar` could be seen as the type equivalent of the "unused variable" warning. Because of that, I think a warning should be emitted if an underscored type variables is used more than once.