### PR TITLE
Adding System.fetch/2

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -447,13 +447,37 @@ defmodule System do
     end
   end
 
+  @doc """
+  Returns the value of the given environment variable or the supplied default value.
+
+  If the environment variable `varname` is set, then the value is returned.
+  If `varname` is not set, then the supplied `default` value is returned.
+  If the default value is an integer, then the `varname` value will be cast
+  from a string to an integer. If an exception occurs, the default value
+  will be returned.
+
+  ## Examples
+
+      iex> System.fetch_env("PORT", "7000")
+      "4000"
+
+      iex> System.fetch_env("PORT", 10)
+      4000
+
+      iex> System.fetch_env("NOT_SET", "7000")
+      "7000"
+
+      iex> System.fetch_env("NOT_SET", 10)
+      10
+
+  """
   @spec fetch_env(String.t(), String.t() | integer()) :: String.t() | integer()
   def fetch_env(varname, default) when is_integer(default) do
     case fetch_env(varname) do
       :error -> default
       {:ok, value} -> String.to_integer(value)
     end
-    rescue
+  rescue
     _ -> default
   end
 

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -447,6 +447,23 @@ defmodule System do
     end
   end
 
+  @spec fetch_env(String.t(), String.t() | integer()) :: String.t() | integer()
+  def fetch_env(varname, default) when is_integer(default) do
+    case fetch_env(varname) do
+      :error -> default
+      {:ok, value} -> String.to_integer(value)
+    end
+    rescue
+    _ -> default
+  end
+
+  def fetch_env(varname, default) when is_binary(default) do
+    case fetch_env(varname) do
+      :error -> default
+      {:ok, value} -> value
+    end
+  end
+
   @doc """
   Returns the value of the given environment variable or `:error` if not found.
 

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -53,6 +53,8 @@ defmodule SystemTest do
   test "*_env/*" do
     assert System.get_env(@test_var) == nil
     assert System.fetch_env(@test_var) == :error
+    assert System.fetch_env(@test_var, 10) == 10
+    assert System.fetch_env(@test_var, "DEFAULT") == "DEFAULT"
 
     message = "could not fetch environment variable #{inspect(@test_var)} because it is not set"
     assert_raise ArgumentError, message, fn -> System.fetch_env!(@test_var) end
@@ -63,6 +65,8 @@ defmodule SystemTest do
     assert System.get_env()[@test_var] == "SAMPLE"
     assert System.fetch_env(@test_var) == {:ok, "SAMPLE"}
     assert System.fetch_env!(@test_var) == "SAMPLE"
+    assert System.fetch_env(@test_var, "DEFAULT") == "SAMPLE"
+    assert System.fetch_env(@test_var, 1) == 1
 
     System.delete_env(@test_var)
     assert System.get_env(@test_var) == nil
@@ -73,6 +77,9 @@ defmodule SystemTest do
     assert_raise ArgumentError, ~r[cannot execute System.put_env/2 for key with \"=\"], fn ->
       System.put_env("FOO=BAR", "BAZ")
     end
+
+    System.put_env(@test_var, "15")
+    assert System.fetch_env(@test_var, 10) == 15
   end
 
   test "cmd/2 raises for null bytes" do


### PR DESCRIPTION
Fetch env by `varname ` and return a default if the `varname` is not set. Handle `String.to_integer` inferred from default type