### PR TITLE
Struct updating docs

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2435,7 +2435,7 @@ defmodule Kernel do
       put_in(opts, [:foo, :bar], :baz)
 
   This also works with nested structs and the `struct.path.to.value` way to specify
-  paths"
+  paths:
 
       put_in(struct.foo.bar, :baz)
 
@@ -2512,7 +2512,7 @@ defmodule Kernel do
       update_in(opts, [:foo, :bar], &(&1 + 1))
 
   This also works with nested structs and the `struct.path.to.value` way to specify
-  paths"
+  paths:
 
       update_in(struct.foo.bar, &(&1 + 1))
 
@@ -2555,7 +2555,7 @@ defmodule Kernel do
       get_and_update_in(opts, [:foo, :bar], &{&1, &1 + 1})
 
   This also works with nested structs and the `struct.path.to.value` way to specify
-  paths"
+  paths:
 
       get_and_update_in(struct.foo.bar, &{&1, &1 + 1})
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2434,6 +2434,11 @@ defmodule Kernel do
 
       put_in(opts, [:foo, :bar], :baz)
 
+  This also works with nested structs and the `struct.path.to.value` way to specify
+  paths"
+
+      put_in(struct.foo.bar, :baz)
+
   Note that in order for this macro to work, the complete path must always
   be visible by this macro. For more information about the supported path
   expressions, please check `get_and_update_in/2` docs.
@@ -2506,6 +2511,11 @@ defmodule Kernel do
 
       update_in(opts, [:foo, :bar], &(&1 + 1))
 
+  This also works with nested structs and the `struct.path.to.value` way to specify
+  paths"
+
+      update_in(struct.foo.bar, &(&1 + 1))
+
   Note that in order for this macro to work, the complete path must always
   be visible by this macro. For more information about the supported path
   expressions, please check `get_and_update_in/2` docs.
@@ -2543,6 +2553,11 @@ defmodule Kernel do
   Is equivalent to:
 
       get_and_update_in(opts, [:foo, :bar], &{&1, &1 + 1})
+
+  This also works with nested structs and the `struct.path.to.value` way to specify
+  paths"
+
+      get_and_update_in(struct.foo.bar, &{&1, &1 + 1})
 
   Note that in order for this macro to work, the complete path must always
   be visible by this macro. See the Paths section below.


### PR DESCRIPTION
I felt that the option to use `update_in/2`/`put_in/2` & `get_and_update_in/2` with structs wasn't really prominent in the docs while I believe it's very important and a great feature.

Tried to highlight it a bit more in all of these that it also works.

Happy for feedback about wording, example change or what not.

I wanted to add doc tests but my doctests always ended up telling me `Foooo.__struct__/1 is undefined, cannot expand struct Foooo` (double checked module/struct definition and usage of course)

so I felt just adding them to the tests was best.

Thanks for all your work :clap: 