### PR TITLE
Ensure Erlang-based Mix compilers (erlang, leex, yecc) set valid position on diagnostics

### DIFF
--- a/lib/mix/lib/mix/compilers/erlang.ex
+++ b/lib/mix/lib/mix/compilers/erlang.ex
@@ -271,9 +271,11 @@ defmodule Mix.Compilers.Erlang do
   defp to_diagnostics(warnings_or_errors, severity) do
     for {file, issues} <- warnings_or_errors,
         {line, module, data} <- issues do
+      position = if is_integer(line) and line >= 1, do: line
+
       %Mix.Task.Compiler.Diagnostic{
         file: Path.absname(file),
-        position: line,
+        position: position,
         message: to_string(module.format_error(data)),
         severity: severity,
         compiler_name: to_string(module),


### PR DESCRIPTION
The `Mix.Task.Compiler.Diagnostic` spec allows position to be `nil`, but the yecc compiler was sometimes setting it to `:none` which violates the spec.