### PR TITLE
Display the actual doctest code when doctset fails

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -9,7 +9,8 @@ defmodule ExUnit.AssertionError do
                right: @no_value,
                message: @no_value,
                expr: @no_value,
-               args: @no_value
+               args: @no_value,
+               doctest: @no_value
 
   @doc """
   Indicates no meaningful value for a field.

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -277,8 +277,8 @@ defmodule ExUnit.DocTest do
     end
 
     tests =
-      Enum.map(exprs, fn {expr, expected} ->
-        test_case_content(expr, expected, location, stack)
+      Enum.map(exprs, fn {expr, expected, formatted} ->
+        test_case_content(expr, expected, location, stack, formatted)
       end)
 
     {:__block__, [], test_import(module, do_import) ++ tests}
@@ -286,12 +286,12 @@ defmodule ExUnit.DocTest do
 
   defp multiple_exceptions?(exprs) do
     Enum.count(exprs, fn
-      {_, {:error, _, _}} -> true
+      {_, {:error, _, _}, _} -> true
       _ -> false
     end) > 1
   end
 
-  defp test_case_content(expr, {:test, expected}, location, stack) do
+  defp test_case_content(expr, {:test, expected}, location, stack, formatted) do
     expr_ast = string_to_quoted(location, stack, expr)
     expected_ast = string_to_quoted(location, stack, expected)
 
@@ -303,14 +303,15 @@ defmodule ExUnit.DocTest do
           :ok
 
         actual ->
-          expr = "#{unquote(String.trim(expr))} === #{unquote(String.trim(expected))}"
+          expr = unquote(formatted <> "\n" <> expected)
+
           error = [message: "Doctest failed", expr: expr, left: actual, right: expected]
           reraise ExUnit.AssertionError, error, unquote(stack)
       end
     end
   end
 
-  defp test_case_content(expr, {:inspect, expected}, location, stack) do
+  defp test_case_content(expr, {:inspect, expected}, location, stack, _formatted) do
     expr_ast =
       quote do
         inspect(unquote(string_to_quoted(location, stack, expr)))
@@ -333,7 +334,7 @@ defmodule ExUnit.DocTest do
     end
   end
 
-  defp test_case_content(expr, {:error, exception, message}, location, stack) do
+  defp test_case_content(expr, {:error, exception, message}, location, stack, _formatted) do
     expr_ast = string_to_quoted(location, stack, expr)
 
     quote do
@@ -471,7 +472,7 @@ defmodule ExUnit.DocTest do
   defp extract_tests(line_no, doc, module) do
     all_lines = String.split(doc, "\n", trim: false)
     lines = adjust_indent(all_lines, line_no + 1, module)
-    extract_tests(lines, "", "", [], true, module)
+    extract_tests(lines, "", "", [], true, module, "")
   end
 
   @iex_prompt ["iex>", "iex("]
@@ -577,19 +578,19 @@ defmodule ExUnit.DocTest do
 
   @fences ["```", "~~~"]
 
-  defp extract_tests(lines, expr_acc, expected_acc, acc, new_test, module)
+  defp extract_tests(lines, expr_acc, expected_acc, acc, new_test, module, formatted)
 
-  defp extract_tests([], "", "", [], _, _) do
+  defp extract_tests([], "", "", [], _, _, _) do
     []
   end
 
-  defp extract_tests([], "", "", acc, _, _) do
+  defp extract_tests([], "", "", acc, _, _, _) do
     Enum.reverse(acc)
   end
 
   # End of input and we've still got a test pending.
-  defp extract_tests([], expr_acc, expected_acc, [test | rest], _, _) do
-    test = add_expr(test, expr_acc, expected_acc)
+  defp extract_tests([], expr_acc, expected_acc, [test | rest], _, _, formatted) do
+    test = add_expr(test, expr_acc, expected_acc, formatted)
     Enum.reverse([test | rest])
   end
 
@@ -600,47 +601,82 @@ defmodule ExUnit.DocTest do
          expected_acc,
          [test | rest],
          new_test,
-         module
+         module,
+         formatted
        )
        when expr_acc != "" and expected_acc != "" do
-    test = add_expr(test, expr_acc, expected_acc)
-    extract_tests(list, "", "", [test | rest], new_test, module)
+    test = add_expr(test, expr_acc, expected_acc, formatted)
+    extract_tests(list, "", "", [test | rest], new_test, module, "")
   end
 
   # Store expr_acc and start a new test case.
-  defp extract_tests([{"iex>" <> string, line_no} | lines], "", expected_acc, acc, true, module) do
+  defp extract_tests(
+         [{"iex>" <> string = line, line_no} | lines],
+         "",
+         expected_acc,
+         acc,
+         true,
+         module,
+         _
+       ) do
     test = %{line: line_no, fun_arity: nil, exprs: []}
-    extract_tests(lines, string, expected_acc, [test | acc], false, module)
+    extract_tests(lines, string, expected_acc, [test | acc], false, module, line)
   end
 
   # Store expr_acc.
-  defp extract_tests([{"iex>" <> string, _} | lines], "", expected_acc, acc, false, module) do
-    extract_tests(lines, string, expected_acc, acc, false, module)
+  defp extract_tests(
+         [{"iex>" <> string = line, _} | lines],
+         "",
+         expected_acc,
+         acc,
+         false,
+         module,
+         _
+       ) do
+    extract_tests(lines, string, expected_acc, acc, false, module, line)
   end
 
   # Still gathering expr_acc. Synonym for the next clause.
   defp extract_tests(
-         [{"iex>" <> string, _} | lines],
+         [{"iex>" <> string = line, _} | lines],
          expr_acc,
          expected_acc,
          acc,
          new_test,
-         module
+         module,
+         formatted
        ) do
-    extract_tests(lines, expr_acc <> "\n" <> string, expected_acc, acc, new_test, module)
+    extract_tests(
+      lines,
+      expr_acc <> "\n" <> string,
+      expected_acc,
+      acc,
+      new_test,
+      module,
+      formatted <> "\n" <> line
+    )
   end
 
   # Still gathering expr_acc. Synonym for the previous clause.
   defp extract_tests(
-         [{"...>" <> string, _} | lines],
+         [{"...>" <> string = line, _} | lines],
          expr_acc,
          expected_acc,
          acc,
          new_test,
-         module
+         module,
+         formatted
        )
        when expr_acc != "" do
-    extract_tests(lines, expr_acc <> "\n" <> string, expected_acc, acc, new_test, module)
+    extract_tests(
+      lines,
+      expr_acc <> "\n" <> string,
+      expected_acc,
+      acc,
+      new_test,
+      module,
+      formatted <> "\n" <> line
+    )
   end
 
   # Expression numbers are simply skipped.
@@ -650,10 +686,11 @@ defmodule ExUnit.DocTest do
          expected_acc,
          acc,
          new_test,
-         module
+         module,
+         formatted
        ) do
     new_line = {"iex" <> skip_iex_number(string, module, line_no, line), line_no}
-    extract_tests([new_line | lines], expr_acc, expected_acc, acc, new_test, module)
+    extract_tests([new_line | lines], expr_acc, expected_acc, acc, new_test, module, formatted)
   end
 
   # Expression numbers are simply skipped redux.
@@ -663,15 +700,16 @@ defmodule ExUnit.DocTest do
          expected_acc,
          acc,
          new_test,
-         module
+         module,
+         formatted
        ) do
     new_line = {"..." <> skip_iex_number(string, module, line_no, line), line_no}
-    extract_tests([new_line | lines], expr_acc, expected_acc, acc, new_test, module)
+    extract_tests([new_line | lines], expr_acc, expected_acc, acc, new_test, module, formatted)
   end
 
   # Skip empty or documentation line.
-  defp extract_tests([_ | lines], "", "", acc, _, module) do
-    extract_tests(lines, "", "", acc, true, module)
+  defp extract_tests([_ | lines], "", "", acc, _, module, _formatted) do
+    extract_tests(lines, "", "", acc, true, module, "")
   end
 
   # Encountered end of fenced code block, store pending test
@@ -681,26 +719,51 @@ defmodule ExUnit.DocTest do
          expected_acc,
          [test | rest],
          _new_test,
-         module
+         module,
+         formatted
        )
        when fence in @fences and expr_acc != "" do
-    test = add_expr(test, expr_acc, expected_acc)
-    extract_tests(lines, "", "", [test | rest], true, module)
+    test = add_expr(test, expr_acc, expected_acc, formatted)
+    extract_tests(lines, "", "", [test | rest], true, module, "")
   end
 
   # Encountered an empty line, store pending test
-  defp extract_tests([{"", _} | lines], expr_acc, expected_acc, [test | rest], _new_test, module) do
-    test = add_expr(test, expr_acc, expected_acc)
-    extract_tests(lines, "", "", [test | rest], true, module)
+  defp extract_tests(
+         [{"", _} | lines],
+         expr_acc,
+         expected_acc,
+         [test | rest],
+         _new_test,
+         module,
+         formatted
+       ) do
+    test = add_expr(test, expr_acc, expected_acc, formatted)
+    extract_tests(lines, "", "", [test | rest], true, module, "")
   end
 
   # Finally, parse expected_acc.
-  defp extract_tests([{expected, _} | lines], expr_acc, "", acc, new_test, module) do
-    extract_tests(lines, expr_acc, expected, acc, new_test, module)
+  defp extract_tests([{expected, _} | lines], expr_acc, "", acc, new_test, module, formatted) do
+    extract_tests(lines, expr_acc, expected, acc, new_test, module, formatted)
   end
 
-  defp extract_tests([{expected, _} | lines], expr_acc, expected_acc, acc, new_test, module) do
-    extract_tests(lines, expr_acc, expected_acc <> "\n" <> expected, acc, new_test, module)
+  defp extract_tests(
+         [{expected, _} | lines],
+         expr_acc,
+         expected_acc,
+         acc,
+         new_test,
+         module,
+         formatted
+       ) do
+    extract_tests(
+      lines,
+      expr_acc,
+      expected_acc <> "\n" <> expected,
+      acc,
+      new_test,
+      module,
+      formatted
+    )
   end
 
   defp skip_iex_number(")>" <> string, _module, _line_no, _line) do
@@ -722,8 +785,8 @@ defmodule ExUnit.DocTest do
     %{test | fun_arity: fa, exprs: Enum.reverse(exprs)}
   end
 
-  defp add_expr(%{exprs: exprs} = test, expr, expected) do
-    %{test | exprs: [{expr, tag_expected(expected)} | exprs]}
+  defp add_expr(%{exprs: exprs} = test, expr, expected, formatted) do
+    %{test | exprs: [{expr, tag_expected(expected), formatted} | exprs]}
   end
 
   defp tag_expected(string) do

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -304,14 +304,7 @@ defmodule ExUnit.DocTest do
 
         actual ->
           doctest = unquote("\n" <> formatted <> "\n" <> expected)
-
-          last_exp =
-            unquote(expr)
-            |> String.split("\n")
-            |> List.last()
-            |> String.trim()
-
-          expr = "#{last_exp} === #{unquote(String.trim(expected))}"
+          expr = "#{unquote(String.trim(expr))} === #{unquote(String.trim(expected))}"
 
           error = [
             message: "Doctest failed",

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -143,6 +143,7 @@ defmodule ExUnit.Formatter do
 
     [
       note: if_value(struct.message, &format_message(&1, formatter)),
+      doctest: if_value(struct.doctest, &code_multiline(&1, padding_size)),
       code: if_value(struct.expr, &code_multiline(&1, padding_size)),
       code: unless_value(struct.expr, fn -> get_code(test, stack) || @no_value end),
       arguments: if_value(struct.args, &format_args(&1, width)),

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -135,11 +135,11 @@ end
 defmodule ExUnit.DocTestTest.Invalid do
   @moduledoc """
 
-  iex> 1 + * 1
-  1
+      iex> 1 + * 1
+      1
 
-  iex> 1 + hd(List.flatten([1]))
-  3
+      iex> 1 + hd(List.flatten([1]))
+      3
 
       iex> a = "This is an egregiously long text string."
       iex> b = ~r{an egregiously long}
@@ -471,8 +471,10 @@ defmodule ExUnit.DocTestTest do
              2) doctest module ExUnit.DocTestTest.Invalid (2) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 Doctest failed
-                code:  iex> 1 + hd(List.flatten([1]))
+                doctest:
+                       iex> 1 + hd(List.flatten([1]))
                        3
+                code:  1 + hd(List.flatten([1])) === 3
                 left:  2
                 right: 3
                 stacktrace:
@@ -483,11 +485,13 @@ defmodule ExUnit.DocTestTest do
              3) doctest module ExUnit.DocTestTest.Invalid (3) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 Doctest failed
-                code:  iex> a = "This is an egregiously long text string."
+                doctest:
+                       iex> a = "This is an egregiously long text string."
                        iex> b = ~r{an egregiously long}
                        iex> c = "a slightly shorter"
                        iex> String.replace(a, b, c)
                        "This is a much shorter text string."
+                code:  String.replace(a, b, c) === "This is a much shorter text string."
                 left:  "This is a slightly shorter text string."
                 right: "This is a much shorter text string."
                 stacktrace:
@@ -498,6 +502,9 @@ defmodule ExUnit.DocTestTest do
              4) doctest module ExUnit.DocTestTest.Invalid (4) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 Doctest failed
+                doctest:
+                       iex> :oops
+                       "#MapSet<[]>"
                 code:  inspect(:oops) === "#MapSet<[]>"
                 left:  ":oops"
                 right: "#MapSet<[]>"
@@ -518,6 +525,9 @@ defmodule ExUnit.DocTestTest do
              6) doctest module ExUnit.DocTestTest.Invalid (6) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 Doctest failed: expected exception WhatIsThis but got RuntimeError with message "oops"
+                doctest:
+                      iex> raise "oops"
+                      ** (WhatIsThis) "oops"
                 code: raise "oops"
                 stacktrace:
                   test/ex_unit/doc_test_test.exs:156: ExUnit.DocTestTest.Invalid (module)
@@ -531,6 +541,9 @@ defmodule ExUnit.DocTestTest do
                   "hello"
                 actual:
                   "oops"
+                doctest:
+                      iex> raise "oops"
+                      ** (RuntimeError) "hello"
                 code: raise "oops"
                 stacktrace:
                   test/ex_unit/doc_test_test.exs:159: ExUnit.DocTestTest.Invalid (module)

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -491,7 +491,10 @@ defmodule ExUnit.DocTestTest do
                        iex> c = "a slightly shorter"
                        iex> String.replace(a, b, c)
                        "This is a much shorter text string."
-                code:  String.replace(a, b, c) === "This is a much shorter text string."
+                code:  a = "This is an egregiously long text string."
+                        b = ~r{an egregiously long}
+                        c = "a slightly shorter"
+                        String.replace(a, b, c) === "This is a much shorter text string."
                 left:  "This is a slightly shorter text string."
                 right: "This is a much shorter text string."
                 stacktrace:

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -135,11 +135,11 @@ end
 defmodule ExUnit.DocTestTest.Invalid do
   @moduledoc """
 
-      iex> 1 + * 1
-      1
+  iex> 1 + * 1
+  1
 
-      iex> 1 + hd(List.flatten([1]))
-      3
+  iex> 1 + hd(List.flatten([1]))
+  3
 
       iex> a = "This is an egregiously long text string."
       iex> b = ~r{an egregiously long}
@@ -471,7 +471,8 @@ defmodule ExUnit.DocTestTest do
              2) doctest module ExUnit.DocTestTest.Invalid (2) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 Doctest failed
-                code:  1 + hd(List.flatten([1])) === 3
+                code:  iex> 1 + hd(List.flatten([1]))
+                       3
                 left:  2
                 right: 3
                 stacktrace:
@@ -482,10 +483,11 @@ defmodule ExUnit.DocTestTest do
              3) doctest module ExUnit.DocTestTest.Invalid (3) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 Doctest failed
-                code:  a = "This is an egregiously long text string."
-                        b = ~r{an egregiously long}
-                        c = "a slightly shorter"
-                        String.replace(a, b, c) === "This is a much shorter text string."
+                code:  iex> a = "This is an egregiously long text string."
+                       iex> b = ~r{an egregiously long}
+                       iex> c = "a slightly shorter"
+                       iex> String.replace(a, b, c)
+                       "This is a much shorter text string."
                 left:  "This is a slightly shorter text string."
                 right: "This is a much shorter text string."
                 stacktrace:

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -141,6 +141,12 @@ defmodule ExUnit.DocTestTest.Invalid do
       iex> 1 + hd(List.flatten([1]))
       3
 
+      iex> a = "This is an egregiously long text string."
+      iex> b = ~r{an egregiously long}
+      iex> c = "a slightly shorter"
+      iex> String.replace(a, b, c)
+      "This is a much shorter text string."
+
       iex> :oops
       #MapSet<[]>
 
@@ -476,9 +482,12 @@ defmodule ExUnit.DocTestTest do
              3) doctest module ExUnit.DocTestTest.Invalid (3) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 Doctest failed
-                code:  inspect(:oops) === "#MapSet<[]>"
-                left:  ":oops"
-                right: "#MapSet<[]>"
+                code:  a = "This is an egregiously long text string."
+                        b = ~r{an egregiously long}
+                        c = "a slightly shorter"
+                        String.replace(a, b, c) === "This is a much shorter text string."
+                left:  "This is a slightly shorter text string."
+                right: "This is a much shorter text string."
                 stacktrace:
                   test/ex_unit/doc_test_test.exs:144: ExUnit.DocTestTest.Invalid (module)
            """
@@ -486,23 +495,34 @@ defmodule ExUnit.DocTestTest do
     assert output =~ """
              4) doctest module ExUnit.DocTestTest.Invalid (4) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                ** (UndefinedFunctionError) function Hello.world/0 is undefined (module Hello is not available)
-                stacktrace:
-                  Hello.world()
-                  (for doctest at) test/ex_unit/doc_test_test.exs:147: (test)
-           """
-
-    assert output =~ """
-             5) doctest module ExUnit.DocTestTest.Invalid (5) (ExUnit.DocTestTest.ActuallyCompiled)
-                test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest failed: expected exception WhatIsThis but got RuntimeError with message "oops"
-                code: raise "oops"
+                Doctest failed
+                code:  inspect(:oops) === "#MapSet<[]>"
+                left:  ":oops"
+                right: "#MapSet<[]>"
                 stacktrace:
                   test/ex_unit/doc_test_test.exs:150: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
+             5) doctest module ExUnit.DocTestTest.Invalid (5) (ExUnit.DocTestTest.ActuallyCompiled)
+                test/ex_unit/doc_test_test.exs:#{doctest_line}
+                ** (UndefinedFunctionError) function Hello.world/0 is undefined (module Hello is not available)
+                stacktrace:
+                  Hello.world()
+                  (for doctest at) test/ex_unit/doc_test_test.exs:153: (test)
+           """
+
+    assert output =~ """
              6) doctest module ExUnit.DocTestTest.Invalid (6) (ExUnit.DocTestTest.ActuallyCompiled)
+                test/ex_unit/doc_test_test.exs:#{doctest_line}
+                Doctest failed: expected exception WhatIsThis but got RuntimeError with message "oops"
+                code: raise "oops"
+                stacktrace:
+                  test/ex_unit/doc_test_test.exs:156: ExUnit.DocTestTest.Invalid (module)
+           """
+
+    assert output =~ """
+             7) doctest module ExUnit.DocTestTest.Invalid (7) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 Doctest failed: wrong message for RuntimeError
                 expected:
@@ -511,72 +531,72 @@ defmodule ExUnit.DocTestTest do
                   "oops"
                 code: raise "oops"
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:153: ExUnit.DocTestTest.Invalid (module)
-           """
-
-    assert output =~ """
-             7) doctest ExUnit.DocTestTest.Invalid.a/0 (7) (ExUnit.DocTestTest.ActuallyCompiled)
-                test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:159: syntax error before: '*'
-                code: 1 + * 1
-                stacktrace:
                   test/ex_unit/doc_test_test.exs:159: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
-             8) doctest ExUnit.DocTestTest.Invalid.dedented_past_fence/0 (8) (ExUnit.DocTestTest.ActuallyCompiled)
-                test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:189: unexpected token: "`" (column 5, code point U+0060)
-                code: 3
-                          ```
-                stacktrace:
-                  test/ex_unit/doc_test_test.exs:188: ExUnit.DocTestTest.Invalid (module)
-           """
-
-    assert output =~ """
-             9) doctest ExUnit.DocTestTest.Invalid.indented_not_enough/0 (9) (ExUnit.DocTestTest.ActuallyCompiled)
-                test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:173: unexpected token: "`" (column 1, code point U+0060)
-                code: 3
-                      `
-                stacktrace:
-                  test/ex_unit/doc_test_test.exs:172: ExUnit.DocTestTest.Invalid (module)
-           """
-
-    assert output =~ """
-            10) doctest ExUnit.DocTestTest.Invalid.indented_too_much/0 (10) (ExUnit.DocTestTest.ActuallyCompiled)
-                test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:181: unexpected token: "`" (column 3, code point U+0060)
-                code: 3
-                        ```
-                stacktrace:
-                  test/ex_unit/doc_test_test.exs:180: ExUnit.DocTestTest.Invalid (module)
-           """
-
-    assert output =~ """
-            11) doctest ExUnit.DocTestTest.Invalid.invalid_utf8/0 (11) (ExUnit.DocTestTest.ActuallyCompiled)
-                test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (UnicodeConversionError) invalid encoding starting at <<255, 34, 41>>
-                stacktrace:
-                  test/ex_unit/doc_test_test.exs:195: ExUnit.DocTestTest.Invalid (module)
-           """
-
-    assert output =~ """
-            12) doctest ExUnit.DocTestTest.Invalid.misplaced_opaque_type/0 (12) (ExUnit.DocTestTest.ActuallyCompiled)
-                test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (TokenMissingError) test/ex_unit/doc_test_test.exs:201: missing terminator: } (for "{" starting at line 201). If you are planning to assert on the result of an iex> expression which contains a value inspected as #Name<...>, please make sure the inspected value is placed at the beginning of the expression; otherwise Elixir will treat it as a comment due to the leading sign #.
-                code: {:ok, #MapSet<[1, 2, 3]>}
-                stacktrace:
-                  test/ex_unit/doc_test_test.exs:201: ExUnit.DocTestTest.Invalid (module)
-           """
-
-    assert output =~ """
-            13) doctest ExUnit.DocTestTest.Invalid.b/0 (13) (ExUnit.DocTestTest.ActuallyCompiled)
+             8) doctest ExUnit.DocTestTest.Invalid.a/0 (8) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:165: syntax error before: '*'
                 code: 1 + * 1
                 stacktrace:
                   test/ex_unit/doc_test_test.exs:165: ExUnit.DocTestTest.Invalid (module)
+           """
+
+    assert output =~ """
+             9) doctest ExUnit.DocTestTest.Invalid.dedented_past_fence/0 (9) (ExUnit.DocTestTest.ActuallyCompiled)
+                test/ex_unit/doc_test_test.exs:#{doctest_line}
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:195: unexpected token: "`" (column 5, code point U+0060)
+                code: 3
+                          ```
+                stacktrace:
+                  test/ex_unit/doc_test_test.exs:194: ExUnit.DocTestTest.Invalid (module)
+           """
+
+    assert output =~ """
+            10) doctest ExUnit.DocTestTest.Invalid.indented_not_enough/0 (10) (ExUnit.DocTestTest.ActuallyCompiled)
+                test/ex_unit/doc_test_test.exs:#{doctest_line}
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:179: unexpected token: "`" (column 1, code point U+0060)
+                code: 3
+                      `
+                stacktrace:
+                  test/ex_unit/doc_test_test.exs:178: ExUnit.DocTestTest.Invalid (module)
+           """
+
+    assert output =~ """
+            11) doctest ExUnit.DocTestTest.Invalid.indented_too_much/0 (11) (ExUnit.DocTestTest.ActuallyCompiled)
+                test/ex_unit/doc_test_test.exs:#{doctest_line}
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:187: unexpected token: "`" (column 3, code point U+0060)
+                code: 3
+                        ```
+                stacktrace:
+                  test/ex_unit/doc_test_test.exs:186: ExUnit.DocTestTest.Invalid (module)
+           """
+
+    assert output =~ """
+            12) doctest ExUnit.DocTestTest.Invalid.invalid_utf8/0 (12) (ExUnit.DocTestTest.ActuallyCompiled)
+                test/ex_unit/doc_test_test.exs:#{doctest_line}
+                Doctest did not compile, got: (UnicodeConversionError) invalid encoding starting at <<255, 34, 41>>
+                stacktrace:
+                  test/ex_unit/doc_test_test.exs:201: ExUnit.DocTestTest.Invalid (module)
+           """
+
+    assert output =~ """
+            13) doctest ExUnit.DocTestTest.Invalid.misplaced_opaque_type/0 (13) (ExUnit.DocTestTest.ActuallyCompiled)
+                test/ex_unit/doc_test_test.exs:#{doctest_line}
+                Doctest did not compile, got: (TokenMissingError) test/ex_unit/doc_test_test.exs:207: missing terminator: } (for "{" starting at line 207). If you are planning to assert on the result of an iex> expression which contains a value inspected as #Name<...>, please make sure the inspected value is placed at the beginning of the expression; otherwise Elixir will treat it as a comment due to the leading sign #.
+                code: {:ok, #MapSet<[1, 2, 3]>}
+                stacktrace:
+                  test/ex_unit/doc_test_test.exs:207: ExUnit.DocTestTest.Invalid (module)
+           """
+
+    assert output =~ """
+            14) doctest ExUnit.DocTestTest.Invalid.b/0 (14) (ExUnit.DocTestTest.ActuallyCompiled)
+                test/ex_unit/doc_test_test.exs:#{doctest_line}
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:171: syntax error before: '*'
+                code: 1 + * 1
+                stacktrace:
+                  test/ex_unit/doc_test_test.exs:171: ExUnit.DocTestTest.Invalid (module)
            """
   end
 


### PR DESCRIPTION
Modify docs test to show the actual doctest code according to #8889. 

I am not sure this is the way best way to do it, maybe it is a bit overkill to pass the the formatted doctest code around like this. An other solution would simply be to append iex> to the lines in expr. Let me know what you think? 