### PR TITLE
Ensure guard checks when expanding string interpolations

### DIFF
--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -137,13 +137,16 @@ compute_alignment(_, _, _) -> unknown.
 %% Expands the expression of a bitstring, that is, the LHS of :: or
 %% an argument of the bitstring (such as "foo" in "<<foo>>").
 
-expand_expr(_, {{'.', M1, [Mod, to_string]}, M2, [Arg]}, Fun, E)
+expand_expr(Meta, {{'.', M1, [Mod, to_string]}, M2, [Arg]}, Fun, E)
     when Mod == 'Elixir.Kernel'; Mod == 'Elixir.String.Chars' ->
   case Fun(Arg, E) of
     {EBin, EE} when is_binary(EBin) -> {EBin, EE};
-    {EArg, EE} -> {{{'.', M1, ['Elixir.String.Chars', to_string]}, M2, [EArg]}, EE}
+    _ -> do_expand_expr(Meta, {{'.', M1, ['Elixir.String.Chars', to_string]}, M2, [Arg]}, Fun, E)
   end;
 expand_expr(Meta, Component, Fun, E) ->
+  do_expand_expr(Meta, Component, Fun, E).
+
+do_expand_expr(Meta, Component, Fun, E) ->
   case Fun(Component, E) of
     {EComponent, _} when is_list(EComponent); is_atom(EComponent) ->
       ErrorE = env_for_error(E),

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -595,6 +595,20 @@ defmodule Kernel.ExpansionTest do
         expand(quote(do: fn arg when make_ref() -> arg end))
       end
     end
+
+    test "in guards with bitstrings" do
+      message = ~r"cannot invoke remote function String.Chars.to_string/1 inside guards"
+
+      assert_raise CompileError, message, fn ->
+        expand(
+          quote do
+            fn arg when <<:"Elixir.Kernel".to_string(arg)::binary, "foo">> == "argfoo" ->
+              arg
+            end
+          end
+        )
+      end
+    end
   end
 
   describe "comprehensions" do

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -600,6 +600,10 @@ defmodule Kernel.ExpansionTest do
       message = ~r"cannot invoke remote function String.Chars.to_string/1 inside guards"
 
       assert_raise CompileError, message, fn ->
+        expand(quote(do: fn arg when "#{arg}foo" == "argfoo" -> arg end))
+      end
+
+      assert_raise CompileError, message, fn ->
         expand(
           quote do
             fn arg when <<:"Elixir.Kernel".to_string(arg)::binary, "foo">> == "argfoo" ->


### PR DESCRIPTION
During the bitstring expansion, guard checks were avoided due to a special case for inlining binaries during interpolation. These changes ensure guards are checked.

Related to #8867 

