### PR TITLE
Make List.last/1 deal with improper lists and improve specs

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -235,6 +235,8 @@ defmodule List do
   @doc """
   Returns the last element in `list` or `nil` if `list` is empty.
 
+  It accepts improper lists.
+
   ## Examples
 
       iex> List.last([])
@@ -246,11 +248,18 @@ defmodule List do
       iex> List.last([1, 2, 3])
       3
 
+      iex> List.last([1, 2, 3 | 4])
+      4
   """
+  @spec last([]) :: nil
   @spec last([elem]) :: nil | elem when elem: var
-  def last([]), do: nil
-  def last([head]), do: head
-  def last([_ | tail]), do: last(tail)
+  @spec last(nonempty_improper_list(any, tail)) :: tail when tail: var
+  def last(list) when is_list(list), do: last_guarded(list)
+
+  defp last_guarded([]), do: nil
+  defp last_guarded([head]), do: head
+  defp last_guarded([_ | tail]), do: last_guarded(tail)
+  defp last_guarded(improper_list_tail), do: improper_list_tail
 
   @doc """
   Receives a list of tuples and returns the first tuple

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -75,6 +75,8 @@ defmodule ListTest do
     assert List.last([]) == nil
     assert List.last([1]) == 1
     assert List.last([1, 2, 3]) == 3
+    assert List.last([1, 2, 3 | 4]) == 4
+    assert List.last([1, 2, 3 | [4, 5 | 6]]) == 6
   end
 
   test "zip/1" do


### PR DESCRIPTION
Now List.last/1 deals with improper lists same way as Kernel.tl/1 does.

Spec is more specific when list is empty.