### PR TITLE
List.to_string/1 improve error message and docs

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -870,11 +870,11 @@ defmodule List do
         raise ArgumentError, """
         cannot convert the given list to a string.
 
-        To be converted to a string, a list must contain only:
+        To be converted to a string, a list must only contain one of the following:
 
           * strings
           * integers representing Unicode code points
-          * or a list containing one of these three elements
+          * a list containing one of these three elements
 
         Please check the given list or call inspect/1 to get the list representation, got:
 

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -845,6 +845,13 @@ defmodule List do
   Converts a list of integers representing code points, lists or
   strings into a string.
 
+  To be converted to a string, a list must either be empty or only
+  contain the following elements:
+
+    * strings
+    * integers representing Unicode code points
+    * a list containing one of these three elements
+
   Notice that this function expects a list of integers representing
   UTF-8 code points. If you have a list of bytes, you must instead use
   the [`:binary` module](http://www.erlang.org/doc/man/binary.html).
@@ -859,6 +866,9 @@ defmodule List do
 
       iex> List.to_string([0x0064, "ee", ['p']])
       "deep"
+
+      iex> List.to_string([])
+      ""
 
   """
   @spec to_string(:unicode.charlist()) :: String.t()

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -870,7 +870,8 @@ defmodule List do
         raise ArgumentError, """
         cannot convert the given list to a string.
 
-        To be converted to a string, a list must only contain one of the following:
+        To be converted to a string, a list must either be empty or only
+        contain the following elements:
 
           * strings
           * integers representing Unicode code points

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -220,6 +220,8 @@ defmodule ListTest do
   test "to_string/1" do
     assert List.to_string([?æ, ?ß]) == "æß"
     assert List.to_string([?a, ?b, ?c]) == "abc"
+    assert List.to_string([]) == ""
+    assert List.to_string([[], []]) == ""
 
     assert_raise UnicodeConversionError, "invalid code point 57343", fn ->
       List.to_string([0xDFFF])


### PR DESCRIPTION
* Make List.to_string/1 error msg non-ambiguous and corrects it mentioning empty lists are valid
* Add elements allowed in List.to_string/1 to @doc
* add tests for empty lists