### PR TITLE
Fix Code.Typespec.typespec_to_quoted conversion for variable

### DIFF
--- a/lib/elixir/lib/code/typespec.ex
+++ b/lib/elixir/lib/code/typespec.ex
@@ -329,7 +329,7 @@ defmodule Code.Typespec do
   end
 
   defp typespec_to_quoted({:var, line, var}) do
-    {erl_to_ex_var(var), line, nil}
+    {erl_to_ex_var(var), [line: line], nil}
   end
 
   defp typespec_to_quoted({:op, line, op, arg}) do


### PR DESCRIPTION
Based on [Elixir AST doc](https://github.com/elixir-lang/elixir/blob/3f661b0166f31ef5d1fe8d45d4bc114984c3b434/lib/elixir/pages/Syntax%20Reference.md#the-elixir-ast), the second element of Elixir variable AST tuple should be a keyword list as meta data. For example, `quote do: x` would be evaluated to `{:x, [], Elixir}`.

When `Code.Typespec.typespec_to_quoted` converts specs or types from erlang abstract format to Elixir quoted ast, it should convert `line` (integer) to `[line: line]` (keyword list) for variable.

Related historical commit: https://github.com/elixir-lang/elixir/commit/89cbe93bba82fb0262e9ee66bc7c8fdd07751bdc#diff-6de4b356bc9d4e3d07f1e5731fbe7d23L453 (might just missed this one)