### PR TITLE
Make Version.Requirement public

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -110,11 +110,15 @@ defmodule Version do
     @moduledoc """
     A struct that holds version requirement information.
 
+    The struct fields are private and should not be accessed.
+
     See the "Requirements" section in the `Version` module
     for more information.
     """
 
     defstruct [:source, :matchspec, :compiled]
+
+    @typedoc false
     @type t :: %__MODULE__{source: String.t(), matchspec: :ets.match_spec(), compiled: boolean}
   end
 

--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -107,7 +107,13 @@ defmodule Version do
   @type t :: %__MODULE__{major: major, minor: minor, patch: patch, pre: pre, build: build}
 
   defmodule Requirement do
-    @moduledoc false
+    @moduledoc """
+    A struct that holds version requirement information.
+
+    See the "Requirements" section in the `Version` module
+    for more information.
+    """
+
     defstruct [:source, :matchspec, :compiled]
     @type t :: %__MODULE__{source: String.t(), matchspec: :ets.match_spec(), compiled: boolean}
   end

--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -118,8 +118,7 @@ defmodule Version do
 
     defstruct [:source, :matchspec, :compiled]
 
-    @typedoc false
-    @type t :: %__MODULE__{source: String.t(), matchspec: :ets.match_spec(), compiled: boolean}
+    @opaque t :: %__MODULE__{source: String.t(), matchspec: :ets.match_spec(), compiled: boolean}
   end
 
   defmodule InvalidRequirementError do


### PR DESCRIPTION
The `Version.Requirement` struct is mentioned in several places of the `Version` documentation, used as an argument of `Version.compile_requirement/1` and `Version.match?/3`, and returned as a result of `Version.parse_requirement/1` and `Version.parse_requirement!/1`.

In addition, ExDoc is currently linking to modules even if they are marked with `@moduledoc false` (that issue is being tracked in https://github.com/elixir-lang/ex_doc/issues/951), and produces "PAGE NOT FOUND" when clicking on the [`Version.Requirement` links.](https://hexdocs.pm/elixir/Version.html#parse_requirement/1)