### PR TITLE
Ensure the struct name matches the given module

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2173,8 +2173,16 @@ defmodule Kernel do
     Enum.reduce(fields, struct, fun)
   end
 
-  defp validate_struct!(%{__struct__: module} = struct, _module, _arity) when is_atom(module) do
+  defp validate_struct!(%{__struct__: module} = struct, module, _arity) do
     struct
+  end
+
+  defp validate_struct!(%{__struct__: struct_name}, module, arity) when is_atom(struct_name) do
+    error_message =
+      "expected struct name returned by #{inspect(module)}.__struct__/#{arity} to be " <>
+        "#{inspect(module)}, got: #{inspect(struct_name)}"
+
+    :erlang.error(ArgumentError.exception(error_message))
   end
 
   defp validate_struct!(expr, module, arity) do

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -155,8 +155,10 @@ load_struct(Meta, Name, Args, E) ->
         end
     end
   of
-    #{'__struct__' := Module} = Struct when is_atom(Module) ->
+    #{'__struct__' := Name} = Struct ->
       Struct;
+    #{'__struct__' := StructName} when is_atom(StructName) ->
+      form_error(Meta, ?key(E, file), ?MODULE, {struct_name_mismatch, Name, Arity, StructName});
     Other ->
       form_error(Meta, ?key(E, file), ?MODULE, {invalid_struct_return_value, Name, Arity, Other})
   catch
@@ -216,6 +218,10 @@ format_error({not_kv_pair, Expr}) ->
 format_error({non_map_after_struct, Expr}) ->
   io_lib:format("expected struct to be followed by a map, got: ~ts",
                 ['Elixir.Macro':to_string(Expr)]);
+format_error({struct_name_mismatch, Module, Arity, StructName}) ->
+  Name = elixir_aliases:inspect(Module),
+  Message = "expected struct name returned by ~ts.__struct__/~p to be ~ts, got: ~ts",
+  io_lib:format(Message, [Name, Arity, Name, elixir_aliases:inspect(StructName)]);
 format_error({invalid_struct_return_value, Module, Arity, Value}) ->
   Message =
     "expected ~ts.__struct__/~p to return a map with a :__struct__ key that holds the "

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -534,6 +534,34 @@ defmodule Kernel.ErrorsTest do
       struct(InvalidStructKey, foo: 1)
     end
 
+    invalid_struct_name_error =
+      ~r"expected struct name returned by Kernel.ErrorsTest.InvalidStructName.__struct__/(0|1) to be Kernel.ErrorsTest.InvalidStructName, got: InvalidName"
+
+    defmodule InvalidStructName do
+      def __struct__, do: %{__struct__: InvalidName}
+      def __struct__(_), do: %{__struct__: InvalidName}
+
+      assert_raise CompileError, invalid_struct_name_error, fn ->
+        Macro.struct!(__MODULE__, __ENV__)
+      end
+    end
+
+    assert_eval_raise CompileError,
+                      invalid_struct_name_error,
+                      '%#{InvalidStructName}{} = %{}'
+
+    assert_eval_raise CompileError,
+                      invalid_struct_name_error,
+                      '%#{InvalidStructName}{}'
+
+    assert_raise ArgumentError, invalid_struct_name_error, fn ->
+      struct(InvalidStructName)
+    end
+
+    assert_raise ArgumentError, invalid_struct_name_error, fn ->
+      struct(InvalidStructName, foo: 1)
+    end
+
     defmodule GoodStruct do
       defstruct name: "john"
     end

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -211,7 +211,7 @@ defmodule MapTest do
 
   defmodule ExternalUser do
     def __struct__ do
-      %{__struct__: ThisDoesNotLeak, name: "john", age: 27}
+      %{__struct__: __MODULE__, name: "john", age: 27}
     end
 
     def __struct__(kv) do


### PR DESCRIPTION
This change fixes inconsistencies when building structs: if the struct was built using the map syntax the `:__struct__` key was overridden by the given module name; however, if the struct was built using `struct/1,2` the `:__struct__` key was kept.

For example:

```elixir
defmodule X do
  defstruct [:x]
end

defmodule Y do
  defdelegate __struct__, to: X
  defdelegate __struct__(args), to: X
end

iex> %Y{}
%Y{x: nil}

iex> struct(Y)
%X{x: nil}
```

Closes #8800 