### PR TITLE
Add a better error message when overriding an umbrella dependency

### DIFF
--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -368,10 +368,17 @@ defmodule Mix.Dep do
       "\n  Ensure they match or specify one of the above in your deps and set \"override: true\""
   end
 
-  def format_status(%Mix.Dep{app: app, status: {:overridden, other}} = dep) do
-    "the dependency #{app} in #{Path.relative_to_cwd(dep.from)} is overriding a child dependency:\n" <>
-      "#{dep_status(dep)}#{dep_status(other)}" <>
-      "\n  Ensure they match or specify one of the above in your deps and set \"override: true\""
+  def format_status(%Mix.Dep{app: app, opts: opts, status: {:overridden, %Mix.Dep{opts: other_opts} = other}} = dep) do
+    problem = "the dependency #{app} in #{Path.relative_to_cwd(dep.from)} is overriding a child dependency:\n" <>
+    "#{dep_status(dep)}#{dep_status(other)}"
+
+    resolution = case Keyword.get(opts, :in_umbrella) || Keyword.get(other_opts, :in_umbrella) do
+      true ->
+        "It is not possible to override a dependency within an umbrella app. " <>
+        "Either ensure the above dependencies match, or move them out of the umbrella"
+      _ -> "Ensure they match or specify one of the above in your deps and set \"override: true\""
+    end
+    problem <> "\n" <> resolution
   end
 
   def format_status(%Mix.Dep{status: {:unavailable, _}, scm: scm}) do


### PR DESCRIPTION
I wasn't able to get the tests working for this - If someone with a better understanding of how to set up a proper umbrella fixture wants to add a test, this would be great.

I did verify manually that the changes work as expected:

### Output in an umbrella project

> ~/scratch/my_umbrella (master)$ mix deps.get
> Dependencies have diverged:
> * a (apps/a)
>   the dependency a in mix.exs is overriding a child dependency:
> 
>   > In mix.exs:
>     {:a, [path: "apps/a", from_umbrella: true, env: :dev]}
> 
>   > In apps/b/mix.exs:
>     {:a, [path: "../a", in_umbrella: true, env: :test, override: true]}
> 
> It is not possible to override a dependency within an umbrella app. Either ensure the above dependencies match, or move them out of the umbrella
> ** (Mix) Can't continue due to errors on dependencies