### PR TITLE
add to mix elixirc_options: [ export_all: true ]

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -794,7 +794,7 @@ defmodule Code do
   """
   @spec available_compiler_options() :: [atom]
   def available_compiler_options do
-    [:docs, :debug_info, :ignore_module_conflict, :relative_paths, :warnings_as_errors]
+    [:docs, :debug_info, :ignore_module_conflict, :relative_paths, :warnings_as_errors, :export_all]
   end
 
   @doc """
@@ -841,6 +841,8 @@ defmodule Code do
 
     * `:warnings_as_errors` - causes compilation to fail when warnings are
       generated. Defaults to `false`.
+
+    * `:export_all` - Exports all functions in a module. Defaults to `false`.
 
   It returns the new map of compiler options.
 

--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -342,6 +342,11 @@ defmodule Kernel.CLI do
     parse_compiler(t, %{config | compiler_options: compiler_options})
   end
 
+  defp parse_compiler(["--export_all" | t], config) do
+    compiler_options = [{:export_all, true} | config.compiler_options]
+    parse_compiler(t, %{config | compiler_options: compiler_options})
+  end
+
   defp parse_compiler(["--verbose" | t], config) do
     parse_compiler(t, %{config | verbose_compile: true})
   end

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -51,6 +51,7 @@ start(_Type, _Args) ->
     docs => true,
     ignore_module_conflict => false,
     debug_info => true,
+    export_all => false,
     warnings_as_errors => false,
     relative_paths => true
   },

--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -441,9 +441,22 @@ attributes_form(Line, Attributes, Forms) ->
 % Loading forms
 
 load_form(#{file := File, compile_opts := Opts} = Map, Prefix, Forms, Specs, Chunks) ->
-  CompileOpts = extra_chunks_opts(Chunks, debug_opts(Map, Specs, Opts)),
+  CompileOpts = extra_chunks_opts(Chunks, debug_opts(Map, Specs, export_opts(Opts))),
   {_, Binary} = elixir_erl_compiler:forms(Prefix ++ Specs ++ Forms, File, CompileOpts),
   Binary.
+
+export_opts(Opts) ->
+  case take_export_opts(Opts) of
+    {true, Rest} -> [export_all, nowarn_export_all | Rest];
+    {false, Rest} -> Rest
+  end.
+
+take_export_opts(Opts) ->
+  case proplists:get_value(export_all, Opts) of
+    true -> {true, proplists:delete(export_all, Opts)};
+    false -> {false, proplists:delete(export_all, Opts)};
+    undefined -> {elixir_compiler:get_opt(export_all), Opts}
+  end.
 
 debug_opts(Map, Specs, Opts) ->
   case take_debug_opts(Opts) of

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -23,6 +23,7 @@ defmodule Mix.Tasks.Compile.Elixir do
     * `--ignore-module-conflict` - does not emit warnings if a module was previously defined
     * `--warnings-as-errors` - treats warnings in the current project as errors and
       return a non-zero exit code
+    * `--export-all` - export all functions in modules
     * `--long-compilation-threshold N` - sets the "long compilation" threshold
       (in seconds) to `N` (see the docs for `Kernel.ParallelCompiler.compile/2`)
     * `--all-warnings` - prints warnings even from files that do not need to be recompiled
@@ -46,6 +47,7 @@ defmodule Mix.Tasks.Compile.Elixir do
     warnings_as_errors: :boolean,
     ignore_module_conflict: :boolean,
     debug_info: :boolean,
+    export_all: :boolean,
     verbose: :boolean,
     long_compilation_threshold: :integer,
     all_warnings: :boolean


### PR DESCRIPTION
this is very useful for testing private functions. follows same logic as the already present debug_opts.