### PR TITLE
Add functions Map.with/2 and Map.without/2

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -897,4 +897,21 @@ defmodule Map do
   def size(map) do
     map_size(map)
   end
+
+  @doc """
+  Returns a new map without keys through list and their associated values from map.
+
+  Any key in list that does not exist in map is ignored
+
+  ## Examples
+
+      iex> Map.without(%{a: 1, b: 2, c: 3}, [:a, :b])
+      %{c: 3}
+
+  """
+
+  @spec without(map, list) :: map
+  def without(%{} = map, keys) when is_list(keys) do
+    :maps.without(keys, map)
+  end
 end

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -21,7 +21,10 @@ defmodule KeywordTest do
   end
 
   test "implements (almost) all functions in Map" do
-    assert Map.__info__(:functions) -- Keyword.__info__(:functions) == [from_struct: 1]
+    assert Map.__info__(:functions) -- Keyword.__info__(:functions) == [
+             from_struct: 1,
+             without: 2
+           ]
   end
 
   test "get_and_update/3 raises on bad return value from the argument function" do

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -194,6 +194,10 @@ defmodule MapTest do
              %{a: 1, b: 2, c: :x, d: 5}
   end
 
+  test "without/2" do
+    assert Map.without(%{a: 1, b: 2, c: 3}, [:a, :b]) == %{c: 3}
+  end
+
   test "implements (almost) all functions in Keyword" do
     assert Keyword.__info__(:functions) -- Map.__info__(:functions) ==
              [delete: 3, delete_first: 2, get_values: 2, keyword?: 1, pop_first: 2, pop_first: 3]


### PR DESCRIPTION
Hi.
There are functions with/2 and without/2 in erlang stdlib, but there are not in Elixir, so I add wrappers for them.
It would be great to use them in Elixir style, for example: use them with pipe operator.

What do you think?
I am looking forward feedback.
Have a nice day!