### PR TITLE
No longer generate config for mix new

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -106,9 +106,6 @@ defmodule Mix.Tasks.New do
       create_file("mix.exs", mix_exs_template(assigns))
     end
 
-    create_directory("config")
-    create_file("config/config.exs", config_template(assigns))
-
     create_directory("lib")
     create_file("lib/#{mod_filename}.ex", lib_template(assigns))
 
@@ -388,60 +385,25 @@ defmodule Mix.Tasks.New do
   end
   """)
 
-  embed_template(:config, ~S"""
-  # This file is responsible for configuring your application
-  # and its dependencies with the aid of the Mix.Config module.
-  use Mix.Config
-
-  # This configuration is loaded before any dependency and is restricted
-  # to this project. If another project depends on this project, this
-  # file won't be loaded nor affect the parent project. For this reason,
-  # if you want to provide default values for your application for
-  # third-party users, it should be done in your "mix.exs" file.
-
-  # You can configure your application as:
-  #
-  #     config :<%= @app %>, key: :value
-  #
-  # and access this configuration in your application as:
-  #
-  #     Application.get_env(:<%= @app %>, :key)
-  #
-  # You can also configure a third-party app:
-  #
-  #     config :logger, level: :info
-  #
-
-  # It is also possible to import configuration files, relative to this
-  # directory. For example, you can emulate configuration per environment
-  # by uncommenting the line below and defining dev.exs, test.exs and such.
-  # Configuration from the imported file will override the ones defined
-  # here (which is why it is important to import them last).
-  #
-  #     import_config "#{Mix.env()}.exs"
-  """)
-
   embed_template(:config_umbrella, ~S"""
-  # This file is responsible for configuring your application
-  # and its dependencies with the aid of the Mix.Config module.
+  # This file is responsible for configuring your umbrella
+  # and **all applications** and their dependencies with the
+  # help of Mix.Config.
+  #
+  # Note that all applications in your umbrella share the
+  # same configuration and dependencies, which is why they
+  # all use the same configuration file. If you want different
+  # configurations or dependencies per app, it is best to
+  # move said applications out of the umbrella.
   use Mix.Config
 
-  # By default, the umbrella project as well as each child
-  # application will require this configuration file, as
-  # configuration and dependencies are shared in an umbrella
-  # project. While one could configure all applications here,
-  # we prefer to keep the configuration of each individual
-  # child application in their own app, but all other
-  # dependencies, regardless if they belong to one or multiple
-  # apps, should be configured in the umbrella to avoid confusion.
-  import_config "../apps/*/config/config.exs"
-
-  # Sample configuration (overrides the imported configuration above):
+  # Sample configuration:
   #
   #     config :logger, :console,
   #       level: :info,
   #       format: "$date $time [$level] $metadata$message\n",
   #       metadata: [:user_id]
+  #
   """)
 
   embed_template(:lib, """

--- a/lib/mix/lib/mix/tasks/profile.cprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.cprof.ex
@@ -29,7 +29,6 @@ defmodule Mix.Tasks.Profile.Cprof do
     * `--matching` - only profile calls matching the given `Module.function/arity` pattern
     * `--limit` - filters out any results with a call count less than the limit
     * `--module` - filters out any results not pertaining to the given module
-    * `--config`, `-c` - loads the given configuration file
     * `--eval`, `-e` - evaluate the given code
     * `--require`, `-r` - requires pattern before running the command
     * `--parallel`, `-p` - makes all requires parallel

--- a/lib/mix/lib/mix/tasks/profile.eprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.eprof.ex
@@ -30,7 +30,6 @@ defmodule Mix.Tasks.Profile.Eprof do
     * `--calls` - filters out any results with a call count lower than this
     * `--time` - filters out any results that took lower than specified (in µs)
     * `--sort` - sorts the results by `time` or `calls` (default: `time`)
-    * `--config`, `-c` - loads the given configuration file
     * `--eval`, `-e` - evaluates the given code
     * `--require`, `-r` - requires pattern before running the command
     * `--parallel`, `-p` - makes all requires parallel

--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -27,7 +27,6 @@ defmodule Mix.Tasks.Profile.Fprof do
     * `--callers` - prints detailed information about immediate callers and called functions
     * `--details` - includes profile data for each profiled process
     * `--sort key` - sorts the output by given key: `acc` (default) or `own`
-    * `--config`, `-c`  - loads the given configuration file
     * `--eval`, `-e` - evaluates the given code
     * `--require`, `-r` - requires pattern before running the command
     * `--parallel`, `-p` - makes all requires parallel

--- a/lib/mix/lib/mix/tasks/run.ex
+++ b/lib/mix/lib/mix/tasks/run.ex
@@ -45,7 +45,6 @@ defmodule Mix.Tasks.Run do
 
   ## Command-line options
 
-    * `--config`, `-c`  - loads the given configuration file
     * `--eval`, `-e` - evaluates the given code
     * `--require`, `-r` - executes the given pattern/file
     * `--parallel`, `-p` - makes all requires parallel
@@ -155,6 +154,12 @@ defmodule Mix.Tasks.Run do
   defp process_config(opts) do
     Enum.each(opts, fn
       {:config, value} ->
+        # TODO: Remove on v2.0.
+        IO.warn(
+          "the --config flag is deprecated. If you need to handle multiple configurations, " <>
+            "it is preferrable to dynamically import them in your config files"
+        )
+
         Mix.Task.run("loadconfig", [value])
 
       _ ->

--- a/lib/mix/test/mix/tasks/run_test.exs
+++ b/lib/mix/test/mix/tasks/run_test.exs
@@ -11,17 +11,6 @@ defmodule Mix.Tasks.RunTest do
     Mix.Project.push(MixTest.Case.Sample)
   end
 
-  test "loads configuration", context do
-    in_tmp(context.test, fn ->
-      config = fixture_path("configs/good_config.exs")
-      expr = "IO.puts Application.get_env(:my_app, :key)"
-      output = capture_io(fn -> Mix.Task.run("run", ["--config", config, "--eval", expr]) end)
-      assert output == "value\n"
-    end)
-  after
-    Application.delete_env(:my_app, :key)
-  end
-
   test "run requires files before evaling commands", context do
     git_repo = fixture_path("git_repo/lib/git_repo.ex")
 

--- a/lib/mix/test/mix/tasks/run_test.exs
+++ b/lib/mix/test/mix/tasks/run_test.exs
@@ -11,6 +11,23 @@ defmodule Mix.Tasks.RunTest do
     Mix.Project.push(MixTest.Case.Sample)
   end
 
+  test "loads configuration", context do
+    in_tmp(context.test, fn ->
+      config = fixture_path("configs/good_config.exs")
+      expr = "IO.puts Application.get_env(:my_app, :key)"
+
+      output =
+        capture_io(:stderr, fn ->
+          assert capture_io(fn -> Mix.Task.run("run", ["--config", config, "--eval", expr]) end) ==
+                   "value\n"
+        end)
+
+      assert output =~ "deprecated"
+    end)
+  after
+    Application.delete_env(:my_app, :key)
+  end
+
   test "run requires files before evaling commands", context do
     git_repo = fixture_path("git_repo/lib/git_repo.ex")
 


### PR DESCRIPTION
The fact we explicitly told developers to configure their
application in the config file and access it with
`Application.get_env/2`, probably led many to rely on
the application environment when better options are
available.

Furthermore, `mix new` is mostly used for libraries,
where config is even less important, as configuration
from libraries is not transitive.

Developers that need the config, can simply add it back
by calling:

    echo "use Mix.Config" > config/config.exs

This commit removes config for new apps and deprecate
the `--config` flag, which cannot perform deep merges.
Note we do keep the config for umbrellas, as umbrellas
are about applications and not libraries (plus we need
the umbrella children to share and point to an existing
config).

Closes #8815.
Closes #8811.