### PR TITLE
Fix doc example for Protocol.derive/3

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -351,7 +351,7 @@ defmodule Protocol do
   ## Examples
 
       defprotocol Derivable do
-        def ok(a)
+        def ok(arg)
       end
 
       defimpl Derivable, for: Any do

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -373,12 +373,6 @@ defmodule Protocol do
       defmodule ImplStruct do
         @derive [Derivable]
         defstruct a: 0, b: 0
-
-        defimpl Sample do
-          def ok(struct) do
-            Unknown.undefined(struct)
-          end
-        end
       end
 
   Explicit derivations can now be called via `__deriving__`:

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -375,6 +375,9 @@ defmodule Protocol do
         defstruct a: 0, b: 0
       end
 
+      Derivable.ok(%ImplStruct{})
+      {:ok, %ImplStruct{a: 0, b: 0}, %ImplStruct{a: 0, b: 0}, []}
+
   Explicit derivations can now be called via `__deriving__`:
 
       # Explicitly derived via `__deriving__`


### PR DESCRIPTION
- Sample was not a defined Protocol in this example
- run this example in an iex session would cause `ArgumentError`

    ** (ArgumentError) Sample is not available


This PR also made some small changes to make the example more consistent and intuitive IMO.

A question: do we need to turn this example into a doctest? If so, I can also do that.