### PR TITLE
Fix Kernel.in/2

### DIFF
--- a/lib/elixir/test/elixir/kernel/guard_test.exs
+++ b/lib/elixir/test/elixir/kernel/guard_test.exs
@@ -270,7 +270,7 @@ defmodule Kernel.GuardTest do
     test "fails on expressions not allowed in guards" do
       # Slightly unique errors
 
-      assert_raise ArgumentError, ~r{invalid args for operator "in"}, fn ->
+      assert_raise ArgumentError, ~r{invalid right argument for operator "in"}, fn ->
         defmodule RuntimeListUsage do
           defguard foo(bar, baz) when bar in baz
         end

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -753,9 +753,7 @@ defmodule MacroTest do
     test "to_match/1" do
       quote = quote(do: x in [])
 
-      assert {{:., _, [{:__aliases__, _, [Elixir, :Enum]}, :member?]}, _, _} =
-               Macro.expand_once(quote, __ENV__)
-
+      assert {{:., _, [:lists, :member]}, _, _} = Macro.expand_once(quote, __ENV__)
       assert Macro.expand_once(quote, Macro.Env.to_match(__ENV__)) == false
     end
   end


### PR DESCRIPTION
Some big improvements to the in/2 operator.

1)  Optimize code when context is nil. Previously it was optimized as if for guards,
when it was not needed, ending up it code that was unnecessarily verbose and unoptimized.

previously:

    iex> quote do 1 in [1, 2, 3] end |> Macro.expand(__ENV__) |> Macro.to_string()
    "(\n  var = 1\n  :erlang.orelse(:erlang.\"=:=\"(var, 2), :erlang.orelse(:erlang.\"=:=\"(var, 3), :erlang.\"=:=\"(var, 1)))\n)"

now:

    iex>  quote do 1 in [1, 2, 3] end |> Macro.expand(__ENV__) |> Macro.to_string()
    "(\n  var = 1\n  :lists.member(var, [1, 2, 3])\n)"

2) Keep order of elements in Kernel.in/2:
The order of elements was not being kept (not doing as it was said in the docs).
Now it is guaranteed that the elements are compared in the same order they were given.

previously:

    iex> quote do 1 in [1, 2, 3] end |> Macro.expand(Map.put(__ENV__, :context, :guard)) |> Macro.to_string()
    ":erlang.orelse(:erlang.\"=:=\"(1, 2), :erlang.orelse(:erlang.\"=:=\"(1, 3), :erlang.\"=:=\"(1, 1)))"

now:

    iex>  quote do 1 in [1, 2, 3] end |> Macro.expand(Map.put(__ENV__, :context, :guard)) |> Macro.to_string()
    ":erlang.orelse(:erlang.orelse(:erlang.\"=:=\"(1, 1), :erlang.\"=:=\"(1, 2)), :erlang.\"=:=\"(1, 3))"

A special case is optimized when using the cons operator, and the last cell cannot be determined at compile time, and the order is still maintained:

    iex> quote do :x in [1, 2 | some_call.([4, 3])] end |> Macro.expand(__ENV__) |> Macro.to_string()
    "(\n  {arg0} = {some_call.([4, 3])}\n  (\n    var = :x\n    :erlang.orelse(:lists.member(var, [1, 2]), :lists.member(var, arg0))\n  )\n)"

3) Error message improved from: invalid args for operator "in"...
to: invalid right argument for operator "in"...

4) Multiple tests added to check for generated code when using guards and when not