### PR TITLE
Add Kernel.dbg/1-2

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5319,10 +5319,8 @@ defmodule Kernel do
   """
   @doc since: "1.9.0"
   defmacro dbg(expr, opts \\ []) do
-    inspect_opts =
-      opts
-      |> Keyword.get(:inspect, [])
-      |> Keyword.put_new(:pretty, true)
+    inspect_opts = Keyword.get(opts, :inspect, [])
+    inspect_opts = Keyword.put_new(inspect_opts, :pretty, true)
 
     label =
       case Keyword.get(opts, :label, Macro.to_string(expr)) do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5301,7 +5301,7 @@ defmodule Kernel do
 
       now = dbg Time.utc_now()
 
-  The `Time.utc_now()` expression is evaluated, it's result is bound to the
+  First, the `Time.utc_now()` expression is evaluated. Then, its result is bound to the
   `now` variable, and the following is printed:
 
       run.exs:1: Time.utc_now() #=> ~T[07:03:39.303151] (49µs)

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5308,13 +5308,15 @@ defmodule Kernel do
 
   ## Options
 
-    * `:device` - IO device to write the output to (default: `:stdio`)
+    * `:device` - IO device to write the output to. Defaults to `:stdio`
+
     * `:inspect` - list of options passed to `Kernel.inspect/2` to pretty-print
-      the result. See `Inspect.Opts` for a full list of options (default:
-      `[pretty: true]`)
+      the result. See `Inspect.Opts` for a full list of options. Defaults to
+      `[pretty: true]`
+
     * `:label` - print a given label instead of the expression. This is especially
-      useful for pipelines which can expand to very long expressions.
-      (default: `Macro.to_string(expr)`)
+      useful for pipelines which can expand to very long expressions. Defaults to
+      `Macro.to_string(expr)`
 
   """
   @doc since: "1.9.0"

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -2,6 +2,7 @@ Code.require_file("test_helper.exs", __DIR__)
 
 defmodule KernelTest do
   use ExUnit.Case, async: true
+  import ExUnit.CaptureIO
 
   doctest Kernel
 
@@ -1095,6 +1096,27 @@ defmodule KernelTest do
 
     assert_raise ArgumentError, ~r"reason: :non_utc_offset", fn ->
       Code.eval_string(~s{~U[2015-01-13 13:00:07+00:30]})
+    end
+  end
+
+  describe "dbg/2" do
+    test "with default options" do
+      assert capture_io(fn -> dbg(1 + 2) end) =~ "test/elixir/kernel_test.exs"
+      assert capture_io(fn -> dbg(1 + 2) end) =~ "1 + 2 #=> 3 ("
+      assert capture_io(fn -> dbg(1 + 2) end) =~ "µs)"
+    end
+
+    test "with IO device" do
+      assert capture_io(:stderr, fn -> dbg(1 + 2, device: :stderr) end) =~
+               "test/elixir/kernel_test.exs"
+    end
+
+    test "with inspect options" do
+      assert capture_io(fn -> dbg(1 + 2, inspect: [base: :binary]) end) =~ "1 + 2 #=> 0b11"
+    end
+
+    test "with label" do
+      assert capture_io(fn -> dbg(1 + 2, label: :custom) end) =~ "custom #=> 3"
     end
   end
 


### PR DESCRIPTION
Ref: https://groups.google.com/forum/#!topic/elixir-lang-core/bZaCMlrPYyo

## Examples:

    iex(1)> dbg Time.utc_now
    iex:1: Time.utc_now() #=> ~T[11:52:07.744334] (1ms)
    ~T[11:52:07.744334]

    iex(2)> 1..5 |> Enum.map(&dbg(&1 * 2)) |> Enum.sum()
    iex:2: x1 * 2 #=> 2 (2µs)
    iex:2: x1 * 2 #=> 4 (1µs)
    iex:2: x1 * 2 #=> 6 (1µs)
    iex:2: x1 * 2 #=> 8 (1µs)
    iex:2: x1 * 2 #=> 10 (1µs)
    30

    iex(1)> 1..5 |> Enum.map(&dbg(&1 * 2, inspect: [syntax_colors: [number: :blue]])) |> Enum.sum()
    iex:3: x1 * 2 #=> 2 (6µs)
    iex:3: x1 * 2 #=> 4 (1µs)
    iex:3: x1 * 2 #=> 6 (10µs)
    iex:3: x1 * 2 #=> 8 (1µs)
    iex:3: x1 * 2 #=> 10 (1µs)
    30

Since pipes are expanded we'll get this:

    iex(4)> Time.utc_now() |> to_string() |> String.slice(0, 5) |> dbg()
    iex:4: String.slice(to_string(Time.utc_now()), 0, 5) #=> "11:53" (28µs)
    "11:53"

We can overwrite the label as following:

    iex(5)> Time.utc_now() |> to_string() |> String.slice(0, 5) |> dbg(label: :pipe)
    iex:5: pipe #=> "11:54" (34µs)
    "11:54"

## Discussion

I'm not sure about calling it `dbg` as we tend not to shorten words like that but I couldn't think of a better name. If the macro is called `debug` there's a high chance it would conflict with an already existing function/macro that users have written and so calls like `import MyApp.Utils, debug: 2` would now break. I already ran into this issue when compiling a Hex package. By having somewhat cryptic name like this we minimise possible conflicts.

There's also an existing `:dbg` module in OTP which might make it a bit confusing.

Ideally I would have it as `IO.debug/2` but since it's a macro, we'd need to `require IO` first which would make it less convenient to use.

I found the time measurement to be extremely useful and that's why I'm including it by default. I wonder if there are any cases where it's undesirable? The only thing I can think of is when we're debugging local variables, the time measurement is useless then - we could detect that situation by looking whether given expression looks like a local variable and such is present in the context; thoughts? At the same time, I personally wouldn't mind always keeping time measurement by default.

Speaking of time measurement, I found myself using this feature as a very lightweight profiling tool and sometimes I think that's even bigger deal than basically IO.inspect on steroids. In some cases, however, I was only really interested in time measurement and printing the result was obfuscating things (e.g. printing large dataset when debugging an intermediate step in a pipeline). I've been using locally a very similar `Kernel.tc/2` function and liking it, so I'm curious what you think about that? Alternatively, perhaps there would be a `print_result: false` option?

```
iex> dbg Enum.reduce(1..20_000, &Kernel.*/2), print_result: false
iex:1: Enum.reduce(1..20000, &Kernel.*/2) (273ms)
```

I would personally prefer a `tc/2` function but it's yet another function on Kernel and it's even more cryptic.

In any case, I'd encourage playing with Kernel.dbg (and/or Kernel.tc) for a few weeks on a local Elixir checkout and reporting feedback! I've been using this for last few months and it basically replaced all my usage of `IO.inspect ..., label: ...` (and I use that thing a lot!)