### PR TITLE
Fix the documentation for ExUnit.Assertions.assert/2

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -352,7 +352,7 @@ defmodule ExUnit.Assertions do
   ## END HELPERS
 
   @doc """
-  Asserts `value` is `true`, displaying the given `message` otherwise.
+  Asserts `value` is truthy, displaying the given `message` otherwise.
 
   ## Examples
 


### PR DESCRIPTION
The documentation for `assert/2` suggests that it behaves differently than `assert/1`, which is not the case.