### PR TITLE
Implement static_atom_encoder option

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -669,7 +669,7 @@ defmodule Code do
 
   When `static_atom_encoder: &my_encoder/2` is passed as an argument,
   `my_encoder/2` is called every time the tokenizer needs to create a
-  'static' atom. Static atoms are atoms in the AST that function as
+  "static" atom. Static atoms are atoms in the AST that function as
   aliases, remote calls, local calls, variable names, regular atoms
   and keyword lists.
 

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -651,7 +651,8 @@ defmodule Code do
       Defaults to `false`.
 
     * `:static_atom_encoder` - The static atom encoder function, see
-      the section below. The `:static_atom_encoder` option overrides
+      the ["The `:static_atom_encoder` function" section](module-the-static_atom_encoder-function)
+      below. The `:static_atom_encoder` option overrides
       the `:existing_atoms_only` option.
 
     * `:warn_on_unnecessary_quotes` - when `false`, does not warn

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -652,7 +652,9 @@ defmodule Code do
 
     * `:static_atom_encoder` - The static atom encoder function, see
       "The `:static_atom_encoder` function" section below. This option
-      overrides the `:existing_atoms_only` option.
+      overrides the `:existing_atoms_only` behaviour for static atoms
+      but `:existing_atoms_only` is still used for dynamic atoms, such
+      as atoms with interpolations.
 
     * `:warn_on_unnecessary_quotes` - when `false`, does not warn
       when atoms, keywords or calls have unnecessary quotes on

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -651,9 +651,9 @@ defmodule Code do
       Defaults to `false`.
 
     * `:static_atom_encoder` - The static atom encoder function, see
-      the ["The `:static_atom_encoder` function" section](module-the-static_atom_encoder-function)
-      below. The `:static_atom_encoder` option overrides
-      the `:existing_atoms_only` option.
+      ["The `:static_atom_encoder`
+      function"](#string_to_quoted/2-the-static_atom_encoder-function) section
+      below. This option overrides the `:existing_atoms_only` option.
 
     * `:warn_on_unnecessary_quotes` - when `false`, does not warn
       when atoms, keywords or calls have unnecessary quotes on
@@ -685,11 +685,15 @@ defmodule Code do
   if you want to use the Elixir parser in a user-facing situation, but
   you don't want to exhaust the atom table.
 
-  When the encoder fails for some reason, it must return `{:error,
-  reason :: binary}`. The atom encoder is not called for *all* atoms
-  that are present in the AST: it won't be invoked for operators,
-  syntax keywords (fn, do, etc), and neither for atoms containing
-  interpolations.
+  The atom encoder is not called for *all* atoms that are present in
+  the AST. It won't be invoked for the following atoms:
+
+    * operators (`:+`, `:-`, and so on)
+
+    * syntax keywords (`fn`, `do`, `else`, and so on)
+
+    * atoms containing interpolation (`:"\#{1 + 1} is two"`), as these
+      atoms are constructed at runtime.
 
   """
   @spec string_to_quoted(List.Chars.t(), keyword) ::

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -651,9 +651,8 @@ defmodule Code do
       Defaults to `false`.
 
     * `:static_atom_encoder` - The static atom encoder function, see
-      ["The `:static_atom_encoder`
-      function"](#string_to_quoted/2-the-static_atom_encoder-function) section
-      below. This option overrides the `:existing_atoms_only` option.
+      "The `:static_atom_encoder` function" section below. This option
+      overrides the `:existing_atoms_only` option.
 
     * `:warn_on_unnecessary_quotes` - when `false`, does not warn
       when atoms, keywords or calls have unnecessary quotes on

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -684,10 +684,11 @@ defmodule Code do
   if you want to use the Elixir parser in a user-facing situation, but
   you don't want to exhaust the atom table.
 
-  When the encoder fails for some reason, it should return `{:error,
-  reason :: String.t}`. The atom encoder is not called for *all* atoms
+  When the encoder fails for some reason, it must return `{:error,
+  reason :: binary}`. The atom encoder is not called for *all* atoms
   that are present in the AST: it won't be invoked for operators,
-  syntax keywords (fn, etc), and for atoms containing interpolations.
+  syntax keywords (fn, do, etc), and neither for atoms containing
+  interpolations.
 
   """
   @spec string_to_quoted(List.Chars.t(), keyword) ::

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -650,6 +650,10 @@ defmodule Code do
       when non-existing atoms are found by the tokenizer.
       Defaults to `false`.
 
+    * `:static_atom_encoder` - The static atom encoder function, see
+      the section below. The `:static_atom_encoder` option overrides
+      the `:existing_atoms_only` option.
+
     * `:warn_on_unnecessary_quotes` - when `false`, does not warn
       when atoms, keywords or calls have unnecessary quotes on
       them. Defaults to `true`.
@@ -659,6 +663,32 @@ defmodule Code do
   The opposite of converting a string to its quoted form is
   `Macro.to_string/2`, which converts a quoted form to a string/binary
   representation.
+
+  ## The `:static_atom_encoder` function
+
+  When `static_atom_encoder: &my_encoder/2` is passed as an argument,
+  `my_encoder/2` is called every time the tokenizer needs to create a
+  'static' atom. Static atoms are atoms in the AST that function as
+  aliases, remote calls, local calls, variable names, regular atoms
+  and keyword lists.
+
+  The encoder function will receive the atom name (as a binary) and a
+  keyword list with the current file, line and column. It must return
+  `{:ok, token :: term} | {:error, reason :: binary}`.
+
+  The encoder function is supposed to create an atom from the given
+  string. It is required to return either `{:ok, term}`, where term is
+  an atom. It is possible to return something else than an atom,
+  however, in that case the AST is no longer "valid" in that it cannot
+  be used to compile or evaluate Elixir code. A use case for this is
+  if you want to use the Elixir parser in a user-facing situation, but
+  you don't want to exhaust the atom table.
+
+  When the encoder fails for some reason, it should return `{:error,
+  reason :: String.t}`. The atom encoder is not called for *all* atoms
+  that are present in the AST: it won't be invoked for operators,
+  syntax keywords (fn, etc), and for atoms containing interpolations.
+
   """
   @spec string_to_quoted(List.Chars.t(), keyword) ::
           {:ok, Macro.t()} | {:error, {line :: pos_integer, term, term}}

--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -33,6 +33,7 @@
   unescape=true,
   check_terminators=true,
   existing_atoms_only=false,
+  static_atoms_encoder=nil,
   preserve_comments=nil,
   identifier_tokenizer=elixir_tokenizer,
   indentation=0,

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -816,8 +816,8 @@ unsafe_to_atom(Part, Line, Column, #elixir_tokenizer{static_atoms_encoder=Static
   case StaticAtomsEncoder(Value, Metadata) of
     {ok, Term} ->
       {ok, Term};
-    {error, Reason} ->
-      {error, {Line, Column, Reason, Part}}
+    {error, Reason} when is_binary(Reason) ->
+      {error, {Line, Column, elixir_utils:characters_to_list(Reason) ++ ": ", elixir_utils:characters_to_list(Part)}}
   end;
 unsafe_to_atom(Part, Line, Column, #elixir_tokenizer{}) when
     is_binary(Part) andalso byte_size(Part) > 255;

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -156,10 +156,11 @@ defmodule CodeTest do
     test "supports static_atoms_encoder" do
       ref = make_ref()
 
-      encoder = fn "there_is_no_such_atom", metadata ->
-        assert metadata[:line] == 1
-        assert metadata[:column] == 1
-        assert metadata[:file] == "nofile"
+      encoder = fn atom, meta ->
+        assert atom == "there_is_no_such_atom"
+        assert meta[:line] == 1
+        assert meta[:column] == 1
+        assert meta[:file] == "nofile"
         {:ok, {:my, "atom", ref}}
       end
 

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -177,6 +177,15 @@ defmodule CodeTest do
                Code.string_to_quoted(":there_is_no_such_atom", static_atoms_encoder: encoder)
     end
 
+    test "returns an error tuple on long atoms, even when using static_atoms_encoder" do
+      atom = String.duplicate("a", 256)
+
+      encoder = fn atom, _meta -> {:ok, atom} end
+
+      assert Code.string_to_quoted(atom, static_atoms_encoder: encoder) ==
+               {:error, {1, "atom length must be less than system limit: ", atom}}
+    end
+
     test "extended static_atoms_encoder" do
       encoder = fn string, _metadata ->
         try do

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -168,6 +168,15 @@ defmodule CodeTest do
                Code.string_to_quoted(":there_is_no_such_atom", static_atoms_encoder: encoder)
     end
 
+    test "static_atoms_encoder, error case" do
+      encoder = fn _atom, _meta ->
+        {:error, "Invalid atom name"}
+      end
+
+      assert {:error, {1, "Invalid atom name: ", "there_is_no_such_atom"}} =
+               Code.string_to_quoted(":there_is_no_such_atom", static_atoms_encoder: encoder)
+    end
+
     test "extended static_atoms_encoder" do
       encoder = fn string, _metadata ->
         try do


### PR DESCRIPTION
This PR introduces the `static_atom_encoder` option to `Code.string_to_quoted/2`, as described in [this elixir-lang-core thread](https://groups.google.com/forum/#!topic/elixir-lang-core/1A0kOswSB7U).

I think it is ready for review; code, docs and 2 added tests.