### PR TITLE
Clarify that `elixirc_options` in supports all the command line options

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -32,11 +32,11 @@ defmodule Mix.Tasks.Compile.Elixir do
     * `:elixirc_paths` - directories to find source files.
       Defaults to `["lib"]`.
 
-    * `:elixirc_options` - compilation options that apply to Elixir's compiler. They are
-      the same as the command line options listed above. They must be specified as atoms
-      and use underscores instead of dashes (for example, `:debug_info`). Uses the same defaults 
-      as `elixirc`. These options can always be overridden from the command line according 
-      to the options above.
+    * `:elixirc_options` - compilation options that apply to Elixir's compiler.
+      They are the same as the command line options listed above. They must be specified
+      as atoms and use underscores instead of dashes (for example, `:debug_info`). These
+      options can always be overridden from the command line and they have the same defaults
+      as their command line counterparts, as documented above.
 
   """
 

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Compile.Elixir do
 
     * `:elixirc_options` - compilation options that apply to Elixir's compiler. They are
       the same as the command line options listed above. They must be specified as atoms
-      and use underscores instead of dashes (e.g. `:debug_info`). Uses the same defaults 
+      and use underscores instead of dashes (for example, `:debug_info`). Uses the same defaults 
       as `elixirc`. These options can always be overridden from the command line according 
       to the options above.
 

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -32,11 +32,11 @@ defmodule Mix.Tasks.Compile.Elixir do
     * `:elixirc_paths` - directories to find source files.
       Defaults to `["lib"]`.
 
-    * `:elixirc_options` - compilation options that apply
-      to Elixir's compiler. They are the same as the command line options listed above.
-      They must be specified as atoms and use underscores instead of dashes (e.g. 
-      `:debug_info`). By default, uses the same defaults as `elixirc` and they can always
-      be overridden from the command line according to the options above.
+    * `:elixirc_options` - compilation options that apply to Elixir's compiler. They are
+      the same as the command line options listed above. They must be specified as atoms
+      and use underscores instead of dashes (e.g. `:debug_info`). Uses the same defaults 
+      as `elixirc`. These options can always be overridden from the command line according 
+      to the options above.
 
   """
 

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -33,10 +33,10 @@ defmodule Mix.Tasks.Compile.Elixir do
       Defaults to `["lib"]`.
 
     * `:elixirc_options` - compilation options that apply
-      to Elixir's compiler, they are: `:ignore_module_conflict`,
-      `:docs` and `:debug_info`. By default, uses the same
-      defaults as `elixirc` and they can always be overridden from
-      the command line according to the options above.
+      to Elixir's compiler. They are the same as the command line options listed above.
+      They must be specified as atoms and use underscores instead of dashes (e.g. 
+      `:debug_info`). By default, uses the same defaults as `elixirc` and they can always
+      be overridden from the command line according to the options above.
 
   """
 


### PR DESCRIPTION
The documentation listed three options that `elixirc_options` supported, but the
code supports all the available options. I replaced the three options listed in
the docs with a sentence saying all the command line options are supported by
`elixirc_options`.