### PR TITLE
Fix @spec for `GenServer.code_change/3`

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -667,8 +667,7 @@ defmodule GenServer do
   @callback code_change(old_vsn, state :: term, extra :: term) ::
               {:ok, new_state :: term}
               | {:error, reason :: term}
-              | {:down, term}
-            when old_vsn: term
+            when old_vsn: term | {:down, term}
 
   @doc """
   Invoked in some cases to retrieve a formatted version of the `GenServer` status.


### PR DESCRIPTION
As we can see [here](http://erlang.org/doc/man/gen_server.html#Module:code_change-3),
the function returns `{:ok, new_state} | {:error, reason}` while the
old version can either be old version or `{:down, current version}`