### PR TITLE
Optimize &super/arity and &super(&1)

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -204,6 +204,15 @@ expand({quote, Meta, [_, _]}, E) ->
 
 %% Functions
 
+expand({'&', Meta, [{super, SuperMeta, Args}]}, E) when is_list(Args) ->
+  {_Kind, Name, _} = resolve_super(Meta, length(Args), E),
+  expand({'&', Meta, [{Name, SuperMeta, Args}]}, E);
+
+expand({'&', Meta, [{'/', _, [{super, _, Context}, Arity]}]}, E) when is_atom(Context), is_integer(Arity) ->
+  assert_no_match_or_guard_scope(Meta, "&", E),
+  {_Kind, Name, _} = resolve_super(Meta, Arity, E),
+  {{'&', Meta, [{'/', [], [{Name, [], Context}, Arity]}]}, E};
+
 expand({'&', Meta, [Arg]}, E) ->
   assert_no_match_or_guard_scope(Meta, "&", E),
   case elixir_fn:capture(Meta, Arg, E) of
@@ -294,34 +303,9 @@ expand({with, Meta, [_ | _] = Args}, E) ->
 
 expand({super, Meta, Args}, E) when is_list(Args) ->
   assert_no_match_or_guard_scope(Meta, "super", E),
-  Module = assert_module_scope(Meta, super, E),
-  Function = assert_function_scope(Meta, super, E),
-  {_, Arity} = Function,
-
-  case length(Args) of
-    Arity ->
-      {Kind, Name, SuperMeta} = elixir_overridable:super(Meta, Module, Function, E),
-
-      %% TODO: Remove this on Elixir v2.0 and make all GenServer callbacks optional
-      case lists:keyfind(context, 1, SuperMeta) of
-        {context, 'Elixir.GenServer'} ->
-          Message =
-            io_lib:format(
-              "calling super for GenServer callback ~ts/~B is deprecated",
-              [element(1, Function), Arity]
-            ),
-
-          elixir_errors:erl_warn(?line(Meta), ?key(E, file), Message);
-
-        _ ->
-          ok
-      end,
-
-      {EArgs, EA} = expand_args(Args, E),
-      {{super, [{super, {Kind, Name}} | Meta], EArgs}, EA};
-    _ ->
-      form_error(Meta, ?key(E, file), ?MODULE, wrong_number_of_args_for_super)
-  end;
+  {Kind, Name, _} = resolve_super(Meta, length(Args), E),
+  {EArgs, EA} = expand_args(Args, E),
+  {{super, [{super, {Kind, Name}} | Meta], EArgs}, EA};
 
 %% Vars
 
@@ -527,6 +511,20 @@ expand_multi_alias_call(Kind, Meta, Base, Refs, Opts, E) ->
   end,
   lists:mapfoldl(Fun, EB, Refs).
 
+resolve_super(Meta, Arity, E) ->
+  Module = assert_module_scope(Meta, super, E),
+  Function = assert_function_scope(Meta, super, E),
+
+  case Function of
+    {_, Arity} ->
+      {Kind, Name, SuperMeta} = elixir_overridable:super(Meta, Module, Function, E),
+      maybe_warn_deprecated_super_in_gen_server_callback(Meta, Function, Arity, SuperMeta, E),
+      {Kind, Name, SuperMeta};
+
+    _ ->
+      form_error(Meta, ?key(E, file), ?MODULE, wrong_number_of_args_for_super)
+  end.
+
 expand_list([{'|', Meta, [_, _] = Args}], Fun, Acc, List) ->
   {EArgs, EAcc} = lists:mapfoldl(Fun, Acc, Args),
   expand_list([], Fun, EAcc, [{'|', Meta, EArgs} | List]);
@@ -630,6 +628,22 @@ maybe_warn_underscored_var_access(Meta, Name, Kind, E) ->
   case (Kind == nil) andalso should_warn(Meta) andalso atom_to_list(Name) of
     "_" ++ _ ->
       elixir_errors:form_warn(Meta, ?key(E, file), ?MODULE, {underscored_var_access, Name});
+    _ ->
+      ok
+  end.
+
+%% TODO: Remove this on Elixir v2.0 and make all GenServer callbacks optional
+maybe_warn_deprecated_super_in_gen_server_callback(Meta, Function, Arity, SuperMeta, E) ->
+  case lists:keyfind(context, 1, SuperMeta) of
+    {context, 'Elixir.GenServer'} ->
+      Message =
+        io_lib:format(
+          "calling super for GenServer callback ~ts/~B is deprecated",
+          [element(1, Function), Arity]
+        ),
+
+      elixir_errors:erl_warn(?line(Meta), ?key(E, file), Message);
+
     _ ->
       ok
   end.

--- a/lib/elixir/test/elixir/kernel/overridable_test.exs
+++ b/lib/elixir/test/elixir/kernel/overridable_test.exs
@@ -17,6 +17,14 @@ defmodule Kernel.Overridable do
     x + y
   end
 
+  def capture_super(x) do
+    x
+  end
+
+  defmacro capture_super_macro(x) do
+    x
+  end
+
   def many_clauses(0) do
     11
   end
@@ -41,6 +49,8 @@ defmodule Kernel.Overridable do
                  with_super: 0,
                  without_super: 0,
                  super_with_multiple_args: 2,
+                 capture_super: 1,
+                 capture_super_macro: 1,
                  many_clauses: 1,
                  locals: 0,
                  multiple_overrides: 0,
@@ -59,6 +69,14 @@ defmodule Kernel.Overridable do
 
   def super_with_multiple_args(x, y) do
     super(x, y * 2)
+  end
+
+  def capture_super(x) do
+    Enum.map(1..x, &super(&1)) ++ Enum.map(1..x, &super/1)
+  end
+
+  defmacro capture_super_macro(x) do
+    Enum.map(1..x, &super(&1)) ++ Enum.map(1..x, &super/1)
   end
 
   def many_clauses(2) do
@@ -226,6 +244,14 @@ defmodule Kernel.OverridableTest do
 
   test "calling super with multiple args" do
     assert Overridable.super_with_multiple_args(1, 2) == 5
+  end
+
+  test "calling super using function captures" do
+    assert Overridable.capture_super(5) == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
+  end
+
+  test "calling super of an overridable macro using function captures" do
+    assert Overridable.capture_super_macro(5) == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
   end
 
   test "overridable with many clauses" do

--- a/lib/elixir/test/elixir/kernel/overridable_test.exs
+++ b/lib/elixir/test/elixir/kernel/overridable_test.exs
@@ -268,6 +268,36 @@ defmodule Kernel.OverridableTest do
     purge(Kernel.OverridableOrder.Forwarding)
   end
 
+  test "invalid super call with different arity" do
+    message =
+      "nofile:4: super must be called with the same number of arguments as the current definition"
+
+    assert_raise CompileError, message, fn ->
+      Code.eval_string("""
+      defmodule Kernel.OverridableSuper.DifferentArities do
+        def bar(a), do: a
+        defoverridable bar: 1
+        def bar(_), do: super()
+      end
+      """)
+    end
+  end
+
+  test "invalid super capture with different arity" do
+    message =
+      "nofile:4: super must be called with the same number of arguments as the current definition"
+
+    assert_raise CompileError, message, fn ->
+      Code.eval_string("""
+      defmodule Kernel.OverridableSuperCapture.DifferentArities do
+        def bar(a), do: a
+        defoverridable bar: 1
+        def bar(_), do: (&super/0).()
+      end
+      """)
+    end
+  end
+
   test "does not allow to override a macro as a function" do
     message =
       "nofile:4: cannot override macro (defmacro, defmacrop) foo/0 in module " <>


### PR DESCRIPTION
Closes #8610 

The previous implementation was generating an unnecessary intermediate function when using `&super/arity`.

In addition, capture expressions using `super` with sequential value placeholders (`&n`) were not optimized like other functions. For example, the capture expression `&foo(&1, &2, &3)` is optimized to `&foo/3` because the value placeholders (`&n`) are sequential `&1, &2, &3`.