### PR TITLE
Add Registry.to_list/1

### DIFF
--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -204,10 +204,10 @@ defmodule Registry do
   @type guards :: [guard] | []
 
   @typedoc "A pattern used to representing the output format part of a match spec"
-  @type select :: [atom | tuple]
+  @type body :: [atom | tuple]
 
   @typedoc "A full match spec used when selecting objects in the registry"
-  @type spec :: [{match_pattern, guards, select}]
+  @type spec :: [{match_pattern, guards, body}]
 
   ## Via callbacks
 
@@ -1148,7 +1148,7 @@ defmodule Registry do
   Refer to the documentation for `match/3` for more information on how match specs work.
   Avoid usage of special match variables `:"$_"` and `:"$$"`, because it might not work as expected.
 
-  Note that for large registries with many partitions this will be costly as it builds the list by
+  Note that for large registries with many partitions this will be costly as it builds the result by
   concatenating all the partitions.
 
   ## Examples

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -1166,8 +1166,8 @@ defmodule Registry do
       iex> Registry.start_link(keys: :unique, name: Registry.SelectAllTest)
       iex> {:ok, _} = Registry.register(Registry.SelectAllTest, "hello", :value)
       iex> {:ok, _} = Registry.register(Registry.SelectAllTest, "world", :value)
-      iex> Registry.select(Registry.SelectAllTest, [{{:"$1", :_, :_}, [], [:"$1"]}]) |> Enum.sort()
-      ["hello", "world"]
+      iex> Registry.select(Registry.SelectAllTest, [{{:"$1", :_, :_}, [], [:"$1"]}])
+      ["world", "hello"]
 
   """
   @doc since: "1.x.x"

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -1189,7 +1189,7 @@ defmodule Registry do
       ["world", "hello"]
 
   """
-  @doc since: "1.x.x"
+  @doc since: "1.9.0"
   @spec select(registry, spec) :: [term]
   def select(registry, spec)
       when is_atom(registry) and is_list(spec) do
@@ -1201,7 +1201,7 @@ defmodule Registry do
 
           _ ->
             raise ArgumentError,
-                  "invalid arguments, got: #{inspect(registry)} and #{inspect(spec)}"
+                  "invalid match specification in Registry.select/2: #{inspect(spec)}"
         end
       end
 

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -1176,8 +1176,12 @@ defmodule Registry do
     spec =
       for part <- spec do
         case part do
-          {{key, pid, value}, guards, select} -> {{key, {pid, value}}, guards, select}
-          part -> part
+          {{key, pid, value}, guards, select} ->
+            {{key, {pid, value}}, guards, select}
+
+          _ ->
+            raise ArgumentError,
+                  "invalid arguments, got: #{inspect(registry)} and #{inspect(spec)}"
         end
       end
 

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -203,6 +203,12 @@ defmodule Registry do
   @typedoc "A list of guards to be evaluated when matching on objects in a registry"
   @type guards :: [guard] | []
 
+  @typedoc "A pattern used to representing the output format part of a match spec"
+  @type select :: [atom | tuple]
+
+  @typedoc "A full match spec used when selecting objects in the registry"
+  @type spec :: [{match_pattern, guards, select}]
+
   ## Via callbacks
 
   @doc false
@@ -1137,100 +1143,52 @@ defmodule Registry do
   end
 
   @doc """
-  Returns a list of tuples in the shape of `{key, pid, value}`.
+  Allows selecting key, pid and values registered using full match specs.
 
   Note that for large registries with many partitions this will be costly as it builds the list by
   concatenating all the partitions.
 
   ## Examples
 
-  Registering under a unique registry does not allow multiple entries:
+  This example shows how to get everything from the registry.
 
-      iex> Registry.start_link(keys: :unique, name: Registry.UniqueListTest)
-      iex> Registry.to_list(Registry.UniqueListTest)
-      []
-      iex> {:ok, _} = Registry.register(Registry.UniqueListTest, "hello", :world)
-      iex> Registry.to_list(Registry.UniqueListTest)
-      [{"hello", self(), :world}]
+      iex> Registry.start_link(keys: :unique, name: Registry.SelectAllTest)
+      iex> {:ok, _} = Registry.register(Registry.SelectAllTest, "hello", :value)
+      iex> {:ok, _} = Registry.register(Registry.SelectAllTest, "world", :value)
+      iex> Registry.select(Registry.SelectAllTest, [{{:"$1", :"$2", :"$3"}, [], [{{:"$1", :"$2", :"$3"}}]}])
+      [{"world", self(), :value}, {"hello", self(), :value}]
 
-  to_list on a duplicate registry returns each entry separately:
+  Get all keys in the registry.
 
-      iex> Registry.start_link(keys: :duplicate, name: Registry.DuplicateListTest)
-      iex> {:ok, _} = Registry.register(Registry.DuplicateListTest, "hello", :world)
-      iex> {:ok, _} = Registry.register(Registry.DuplicateListTest, "hello", :other)
-      iex> Registry.to_list(Registry.DuplicateListTest)
-      [{"hello", self(), :world}, {"hello", self(), :other}]
-
-  """
-  @doc since: "1.x.x"
-  @spec to_list(registry) :: [{key, pid, value}]
-  def to_list(registry)
-      when is_atom(registry) do
-    to_list_internal(registry, :_, [])
-  end
-
-  @doc """
-  Returns a list of tuples in the shape of `{key, pid, value}`, filtered by a match pattern and
-  optional guards.
-
-  Note that for large registries with many partitions this will be costly as it builds the list by
-  concatenating all the partitions.
-
-  ## Examples
-
-  This example shows registering the current process under two different keys and using a match pattern to
-  limit results.
-
-      iex> Registry.start_link(keys: :unique, name: Registry.ListMatchTest)
-      iex> {:ok, _} = Registry.register(Registry.ListMatchTest, "hello", :value)
-      iex> {:ok, _} = Registry.register(Registry.ListMatchTest, "world", :value)
-      iex> Registry.to_list_match(Registry.ListMatchTest, {"world", :_, :_})
-      [{"world", self(), :value}]
-
-  You can also supply guards for more advanced filtering. This shows a guard limiting results
-  to only ones where value is greater than 1.
-
-      iex> Registry.start_link(keys: :unique, name: Registry.ListMatchTest)
-      iex> {:ok, _} = Registry.register(Registry.ListMatchTest, "hello", 1)
-      iex> {:ok, _} = Registry.register(Registry.ListMatchTest, "world", 2)
-      iex> Registry.to_list_match(Registry.ListMatchTest, {:_, :_, :"$1"}, [{:<, 1, :"$1"}])
-      [{"world", self(), 2}]
+      iex> Registry.start_link(keys: :unique, name: Registry.SelectAllTest)
+      iex> {:ok, _} = Registry.register(Registry.SelectAllTest, "hello", :value)
+      iex> {:ok, _} = Registry.register(Registry.SelectAllTest, "world", :value)
+      iex> Registry.select(Registry.SelectAllTest, [{{:"$1", :_, :_}, [], [:"$1"]}]) |> Enum.sort()
+      ["hello", "world"]
 
   """
   @doc since: "1.x.x"
-  @spec to_list_match(registry, match_pattern, guards) :: [{key, pid, value}]
-  def to_list_match(registry, pattern, guards \\ [])
-      when is_atom(registry) and is_list(guards) do
-    to_list_internal(registry, pattern, guards)
-  end
-
-  defp to_list_internal(registry, pattern, guards) do
-    pattern = to_internal_pattern(pattern)
-    spec = [{pattern, guards, [:"$_"]}]
+  @spec select(registry, spec) :: [term]
+  def select(registry, spec) do
+    spec = to_internal_spec(spec)
 
     case key_info!(registry) do
       {_kind, partitions, nil} ->
         Enum.flat_map(0..(partitions - 1), fn partition_index ->
           :ets.select(key_ets!(registry, partition_index), spec)
-          |> Enum.map(&to_entry/1)
         end)
 
       {_kind, 1, key_ets} ->
         :ets.select(key_ets, spec)
-        |> Enum.map(&to_entry/1)
     end
   end
 
-  defp to_internal_pattern({key, pid, value}) do
-    {key, {pid, value}}
+  defp to_internal_spec([{{key, pid, value}, guards, select}]) do
+    [{{key, {pid, value}}, guards, select}]
   end
 
-  defp to_internal_pattern(pattern) do
-    pattern
-  end
-
-  defp to_entry({key, {pid, value}}) do
-    {key, pid, value}
+  defp to_internal_spec(spec) do
+    spec
   end
 
   ## Helpers

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -1172,7 +1172,8 @@ defmodule Registry do
   """
   @doc since: "1.x.x"
   @spec select(registry, spec) :: [term]
-  def select(registry, spec) do
+  def select(registry, spec)
+      when is_atom(registry) and is_list(spec) do
     spec =
       for part <- spec do
         case part do

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -1143,13 +1143,15 @@ defmodule Registry do
   end
 
   @doc """
-  Allows selecting key, pid and values registered using full match specs.
-  The match spec consists of a list of three part tuples, in the shape of `[{match_pattern, guards, body}]`.
+  Select key, pid, and values registered using full match specs.
 
-  The first part, the match pattern, must be an atom or a tuple that will match the structure of the
-  the data stored in the registry, which is `{key, pid, value}`. The atom `:_` can be used to ignore a given
-  value or tuple element, while the atom `:"$1"` can be used to temporarily assign part
-  of pattern to a variable for a subsequent comparison. This can be combined like `{:"$1", :_, :_}`.
+  The `spec` consists of a list of three part tuples, in the shape of `[{match_pattern, guards, body}]`.
+
+  The first part, the match pattern, must be a tuple that will match the structure of the
+  the data stored in the registry, which is `{key, pid, value}`. The atom `:_` can be used to
+  ignore a given value or tuple element, while the atom `:"$1"` can be used to temporarily
+  assign part of pattern to a variable for a subsequent comparison. This can be combined
+  like `{:"$1", :_, :_}`.
 
   The second part, the guards, is a list of conditions that allow filtering the results.
   Each guard is a tuple, which describes checks that should be passed by assigned part of pattern.
@@ -1158,11 +1160,12 @@ defmodule Registry do
 
   The third part, the body, is a list of shapes of the returned entries. Like guards, you have access to
   assigned variables like `:"$1"`, which you can combine with hardcoded values to freely shape entries
-  Note that tuples have to be wrapped in an additional tuple. To get a result format like `%{key: key, pid: pid, value: value}`,
-  assuming you bound those variables in order in the match part, you would provide a body like `[%{key: :"$1", pid: :"$2", value: :"$3"}]`.
-  Like guards, you can use some operations like `:element` to modify the output format.
+  Note that tuples have to be wrapped in an additional tuple. To get a result format like
+  `%{key: key, pid: pid, value: value}`, assuming you bound those variables in order in the match part,
+  you would provide a body like `[%{key: :"$1", pid: :"$2", value: :"$3"}]`. Like guards, you can use
+  some operations like `:element` to modify the output format.
 
-  Avoid usage of special match variables `:"$_"` and `:"$$"`, because they might not work as expected.
+  Do not use special match variables `:"$_"` and `:"$$"`, because they might not work as expected.
 
   Note that for large registries with many partitions this will be costly as it builds the result by
   concatenating all the partitions.

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -1144,9 +1144,25 @@ defmodule Registry do
 
   @doc """
   Allows selecting key, pid and values registered using full match specs.
+  The match spec consists of a list of three part tuples, in the shape of `[{match_pattern, guards, body}]`.
 
-  Refer to the documentation for `match/3` for more information on how match specs work.
-  Avoid usage of special match variables `:"$_"` and `:"$$"`, because it might not work as expected.
+  The first part, the match pattern, must be an atom or a tuple that will match the structure of the
+  the data stored in the registry, which is `{key, pid, value}`. The atom `:_` can be used to ignore a given
+  value or tuple element, while the atom `:"$1"` can be used to temporarily assign part
+  of pattern to a variable for a subsequent comparison. This can be combined like `{:"$1", :_, :_}`.
+
+  The second part, the guards, is a list of conditions that allow filtering the results.
+  Each guard is a tuple, which describes checks that should be passed by assigned part of pattern.
+  For example the `$1 > 1` guard condition would be expressed as the `{:>, :"$1", 1}` tuple.
+  Please note that guard conditions will work only for assigned variables like `:"$1"`, `:"$2"`, etc.
+
+  The third part, the body, is a list of shapes of the returned entries. Like guards, you have access to
+  assigned variables like `:"$1"`, which you can combine with hardcoded values to freely shape entries
+  Note that tuples have to be wrapped in an additional tuple. To get a result format like `%{key: key, pid: pid, value: value}`,
+  assuming you bound those variables in order in the match part, you would provide a body like `[%{key: :"$1", pid: :"$2", value: :"$3"}]`.
+  Like guards, you can use some operations like `:element` to modify the output format.
+
+  Avoid usage of special match variables `:"$_"` and `:"$$"`, because they might not work as expected.
 
   Note that for large registries with many partitions this will be costly as it builds the result by
   concatenating all the partitions.

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -346,6 +346,18 @@ defmodule RegistryTest do
                    {{:"$1", :_, {:_, :"$2", :_}}, [{:is_atom, :"$2"}], [:"$1"]}
                  ])
       end
+
+      test "select allows multiple specs", %{registry: registry} do
+        {:ok, _} = Registry.register(registry, "hello", :value)
+        {:ok, _} = Registry.register(registry, "world", :value)
+
+        assert ["hello", "world"] ==
+                 Registry.select(registry, [
+                   {{"hello", :_, :_}, [], [{:element, 1, :"$_"}]},
+                   {{"world", :_, :_}, [], [{:element, 1, :"$_"}]}
+                 ])
+                 |> Enum.sort()
+      end
     end
   end
 
@@ -718,6 +730,18 @@ defmodule RegistryTest do
                  Registry.select(registry, [
                    {{:"$1", :_, {:_, :"$2", :_}}, [{:is_atom, :"$2"}], [:"$1"]}
                  ])
+      end
+
+      test "select allows multiple specs", %{registry: registry} do
+        {:ok, _} = Registry.register(registry, "hello", :value)
+        {:ok, _} = Registry.register(registry, "world", :value)
+
+        assert ["hello", "world"] ==
+                 Registry.select(registry, [
+                   {{"hello", :_, :_}, [], [{:element, 1, :"$_"}]},
+                   {{"world", :_, :_}, [], [{:element, 1, :"$_"}]}
+                 ])
+                 |> Enum.sort()
       end
     end
   end

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -356,6 +356,12 @@ defmodule RegistryTest do
                  ])
                  |> Enum.sort()
       end
+
+      test "raises on incorrect shape of match spec", %{registry: registry} do
+        assert_raise ArgumentError, fn ->
+          Registry.select(registry, [{:_, [], []}])
+        end
+      end
     end
   end
 

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -263,7 +263,7 @@ defmodule RegistryTest do
       end
 
       test "empty list for empty registry", %{registry: registry} do
-        assert Registry.select(registry, [{{:_}, [], [:"$_"]}]) == []
+        assert Registry.select(registry, [{{:_, :_, :_}, [], [:"$_"]}]) == []
       end
 
       test "select all", %{registry: registry} do
@@ -294,8 +294,6 @@ defmodule RegistryTest do
                  Registry.select(registry, [
                    {{:"$1", :"$2", value}, [], [{{:"$1", :"$2", {value}}}]}
                  ])
-
-        assert [:exists] == Registry.select(registry, [{:_, [], [:exists]}])
 
         assert [] ==
                  Registry.select(registry, [
@@ -649,7 +647,7 @@ defmodule RegistryTest do
       end
 
       test "empty list for empty registry", %{registry: registry} do
-        assert Registry.select(registry, [{{:_}, [], [:"$_"]}]) == []
+        assert Registry.select(registry, [{{:_, :_, :_}, [], [:"$_"]}]) == []
       end
 
       test "select all", %{registry: registry} do
@@ -679,8 +677,6 @@ defmodule RegistryTest do
                  Registry.select(registry, [
                    {{:"$1", :"$2", value}, [], [{{:"$1", :"$2", {value}}}]}
                  ])
-
-        assert [:exists] == Registry.select(registry, [{:_, [], [:exists]}])
 
         assert [] ==
                  Registry.select(registry, [

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -263,52 +263,88 @@ defmodule RegistryTest do
       end
 
       test "empty list for empty registry", %{registry: registry} do
-        assert Registry.to_list(registry) == []
+        assert Registry.select(registry, [{{:_}, [], [:"$_"]}]) == []
       end
 
-      test "to list", %{registry: registry} do
+      test "select all", %{registry: registry} do
         name = {:via, Registry, {registry, "hello"}}
         {:ok, pid} = Agent.start_link(fn -> 0 end, name: name)
         {:ok, _} = Registry.register(registry, "world", :value)
 
-        assert Registry.to_list(registry) |> Enum.sort() ==
+        assert Registry.select(registry, [{{:"$1", :"$2", :"$3"}, [], [{{:"$1", :"$2", :"$3"}}]}])
+               |> Enum.sort() ==
                  [{"hello", pid, nil}, {"world", self(), :value}]
       end
 
-      test "to_list_match supports match patterns", %{registry: registry} do
+      test "select supports full match specs", %{registry: registry} do
         value = {1, :atom, 1}
         {:ok, _} = Registry.register(registry, "hello", value)
-        assert [{"hello", self(), value}] == Registry.to_list_match(registry, {"hello", :_, :_})
-        assert [{"hello", self(), value}] == Registry.to_list_match(registry, {:_, self(), :_})
-        assert [{"hello", self(), value}] == Registry.to_list_match(registry, {:_, :_, value})
-        assert [{"hello", self(), value}] == Registry.to_list_match(registry, :_)
-        assert [] == Registry.to_list_match(registry, {"world", :_, :_})
-        assert [] == Registry.to_list_match(registry, {:_, :_, {1.0, :_, :_}})
 
         assert [{"hello", self(), value}] ==
-                 Registry.to_list_match(registry, {:_, :_, {:_, :atom, :_}})
+                 Registry.select(registry, [
+                   {{"hello", :"$2", :"$3"}, [], [{{"hello", :"$2", :"$3"}}]}
+                 ])
+
+        assert [{"hello", self(), value}] ==
+                 Registry.select(registry, [
+                   {{:"$1", self(), :"$3"}, [], [{{:"$1", self(), :"$3"}}]}
+                 ])
+
+        assert [{"hello", self(), value}] ==
+                 Registry.select(registry, [
+                   {{:"$1", :"$2", value}, [], [{{:"$1", :"$2", {value}}}]}
+                 ])
+
+        assert [:exists] == Registry.select(registry, [{:_, [], [:exists]}])
+
+        assert [] ==
+                 Registry.select(registry, [
+                   {{"world", :"$2", :"$3"}, [], [{{"world", :"$2", :"$3"}}]}
+                 ])
+
+        assert [] == Registry.select(registry, [{{:"$1", :"$2", {1.0, :_, :_}}, [], [:"$_"]}])
+
+        assert [{"hello", self(), value}] ==
+                 Registry.select(registry, [
+                   {{:"$1", :"$2", {:"$3", :atom, :"$4"}}, [],
+                    [{{:"$1", :"$2", {{:"$3", :atom, :"$4"}}}}]}
+                 ])
 
         assert [{"hello", self(), {1, :atom, 1}}] ==
-                 Registry.to_list_match(registry, {:_, :_, {:"$1", :_, :"$1"}})
+                 Registry.select(registry, [
+                   {{:"$1", :"$2", {:"$3", :"$4", :"$3"}}, [],
+                    [{{:"$1", :"$2", {{:"$3", :"$4", :"$3"}}}}]}
+                 ])
 
         value2 = %{a: "a", b: "b"}
         {:ok, _} = Registry.register(registry, "world", value2)
 
-        assert [{"world", self(), %{a: "a", b: "b"}}] ==
-                 Registry.to_list_match(registry, {"world", self(), %{b: "b"}})
+        assert [:match] ==
+                 Registry.select(registry, [{{"world", self(), %{b: "b"}}, [], [:match]}])
+
+        assert ["hello", "world"] ==
+                 Registry.select(registry, [{{:"$1", :_, :_}, [], [:"$1"]}]) |> Enum.sort()
       end
 
-      test "to_list_match supports guard conditions", %{registry: registry} do
+      test "select supports guard conditions", %{registry: registry} do
         value = {1, :atom, 2}
         {:ok, _} = Registry.register(registry, "hello", value)
 
         assert [{"hello", self(), {1, :atom, 2}}] ==
-                 Registry.to_list_match(registry, {:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 1}])
+                 Registry.select(registry, [
+                   {{:"$1", :"$2", {:"$3", :"$4", :"$5"}}, [{:>, :"$5", 1}],
+                    [{{:"$1", :"$2", {{:"$3", :"$4", :"$5"}}}}]}
+                 ])
 
-        assert [] == Registry.to_list_match(registry, {:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 2}])
+        assert [] ==
+                 Registry.select(registry, [
+                   {{:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 2}], [:"$_"]}
+                 ])
 
-        assert [{"hello", self(), {1, :atom, 2}}] ==
-                 Registry.to_list_match(registry, {:_, :_, {:_, :"$1", :_}}, [{:is_atom, :"$1"}])
+        assert ["hello"] ==
+                 Registry.select(registry, [
+                   {{:"$1", :_, {:_, :"$2", :_}}, [{:is_atom, :"$2"}], [:"$1"]}
+                 ])
       end
     end
   end
@@ -601,51 +637,87 @@ defmodule RegistryTest do
       end
 
       test "empty list for empty registry", %{registry: registry} do
-        assert Registry.to_list(registry) == []
+        assert Registry.select(registry, [{{:_}, [], [:"$_"]}]) == []
       end
 
-      test "to list", %{registry: registry} do
+      test "select all", %{registry: registry} do
         {:ok, _} = Registry.register(registry, "hello", :value)
         {:ok, _} = Registry.register(registry, "hello", :value)
 
-        assert Registry.to_list(registry) ==
+        assert Registry.select(registry, [{{:"$1", :"$2", :"$3"}, [], [{{:"$1", :"$2", :"$3"}}]}])
+               |> Enum.sort() ==
                  [{"hello", self(), :value}, {"hello", self(), :value}]
       end
 
-      test "to_list_match supports match patterns", %{registry: registry} do
+      test "select supports full match specs", %{registry: registry} do
         value = {1, :atom, 1}
         {:ok, _} = Registry.register(registry, "hello", value)
-        assert [{"hello", self(), value}] == Registry.to_list_match(registry, {"hello", :_, :_})
-        assert [{"hello", self(), value}] == Registry.to_list_match(registry, {:_, self(), :_})
-        assert [{"hello", self(), value}] == Registry.to_list_match(registry, {:_, :_, value})
-        assert [{"hello", self(), value}] == Registry.to_list_match(registry, :_)
-        assert [] == Registry.to_list_match(registry, {"world", :_, :_})
-        assert [] == Registry.to_list_match(registry, {:_, :_, {1.0, :_, :_}})
 
         assert [{"hello", self(), value}] ==
-                 Registry.to_list_match(registry, {:_, :_, {:_, :atom, :_}})
+                 Registry.select(registry, [
+                   {{"hello", :"$2", :"$3"}, [], [{{"hello", :"$2", :"$3"}}]}
+                 ])
+
+        assert [{"hello", self(), value}] ==
+                 Registry.select(registry, [
+                   {{:"$1", self(), :"$3"}, [], [{{:"$1", self(), :"$3"}}]}
+                 ])
+
+        assert [{"hello", self(), value}] ==
+                 Registry.select(registry, [
+                   {{:"$1", :"$2", value}, [], [{{:"$1", :"$2", {value}}}]}
+                 ])
+
+        assert [:exists] == Registry.select(registry, [{:_, [], [:exists]}])
+
+        assert [] ==
+                 Registry.select(registry, [
+                   {{"world", :"$2", :"$3"}, [], [{{"world", :"$2", :"$3"}}]}
+                 ])
+
+        assert [] == Registry.select(registry, [{{:"$1", :"$2", {1.0, :_, :_}}, [], [:"$_"]}])
+
+        assert [{"hello", self(), value}] ==
+                 Registry.select(registry, [
+                   {{:"$1", :"$2", {:"$3", :atom, :"$4"}}, [],
+                    [{{:"$1", :"$2", {{:"$3", :atom, :"$4"}}}}]}
+                 ])
 
         assert [{"hello", self(), {1, :atom, 1}}] ==
-                 Registry.to_list_match(registry, {:_, :_, {:"$1", :_, :"$1"}})
+                 Registry.select(registry, [
+                   {{:"$1", :"$2", {:"$3", :"$4", :"$3"}}, [],
+                    [{{:"$1", :"$2", {{:"$3", :"$4", :"$3"}}}}]}
+                 ])
 
         value2 = %{a: "a", b: "b"}
-        {:ok, _} = Registry.register(registry, "hello", value2)
+        {:ok, _} = Registry.register(registry, "world", value2)
 
-        assert [{"hello", self(), {1, :atom, 1}}, {"hello", self(), %{a: "a", b: "b"}}] ==
-                 Registry.to_list_match(registry, {"hello", :_, :_})
+        assert [:match] ==
+                 Registry.select(registry, [{{"world", self(), %{b: "b"}}, [], [:match]}])
+
+        assert ["hello", "world"] ==
+                 Registry.select(registry, [{{:"$1", :_, :_}, [], [:"$1"]}]) |> Enum.sort()
       end
 
-      test "to_list_match supports guard conditions", %{registry: registry} do
+      test "select supports guard conditions", %{registry: registry} do
         value = {1, :atom, 2}
         {:ok, _} = Registry.register(registry, "hello", value)
 
         assert [{"hello", self(), {1, :atom, 2}}] ==
-                 Registry.to_list_match(registry, {:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 1}])
+                 Registry.select(registry, [
+                   {{:"$1", :"$2", {:"$3", :"$4", :"$5"}}, [{:>, :"$5", 1}],
+                    [{{:"$1", :"$2", {{:"$3", :"$4", :"$5"}}}}]}
+                 ])
 
-        assert [] == Registry.to_list_match(registry, {:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 2}])
+        assert [] ==
+                 Registry.select(registry, [
+                   {{:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 2}], [:"$_"]}
+                 ])
 
-        assert [{"hello", self(), {1, :atom, 2}}] ==
-                 Registry.to_list_match(registry, {:_, :_, {:_, :"$1", :_}}, [{:is_atom, :"$1"}])
+        assert ["hello"] ==
+                 Registry.select(registry, [
+                   {{:"$1", :_, {:_, :"$2", :_}}, [{:is_atom, :"$2"}], [:"$1"]}
+                 ])
       end
     end
   end

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -261,6 +261,19 @@ defmodule RegistryTest do
         {:ok, pid} = Agent.start_link(fn -> 0 end, name: name)
         assert Registry.lookup(registry, "hello") == [{pid, :value}]
       end
+
+      test "empty list for empty registry", %{registry: registry} do
+        assert Registry.to_list(registry) == []
+      end
+
+      test "to list", %{registry: registry} do
+        name = {:via, Registry, {registry, "hello"}}
+        {:ok, pid} = Agent.start_link(fn -> 0 end, name: name)
+        {:ok, _} = Registry.register(registry, "world", :value)
+
+        assert Registry.to_list(registry) |> Enum.sort() ==
+                 [{"hello", {pid, nil}}, {"world", {self(), :value}}]
+      end
     end
   end
 
@@ -549,6 +562,18 @@ defmodule RegistryTest do
           name = {:via, Registry, {registry, "hello"}}
           Agent.start_link(fn -> 0 end, name: name)
         end
+      end
+
+      test "empty list for empty registry", %{registry: registry} do
+        assert Registry.to_list(registry) == []
+      end
+
+      test "to list", %{registry: registry} do
+        {:ok, _} = Registry.register(registry, "hello", :value)
+        {:ok, _} = Registry.register(registry, "hello", :value)
+
+        assert Registry.to_list(registry) ==
+                 [{"hello", {self(), :value}}, {"hello", {self(), :value}}]
       end
     end
   end


### PR DESCRIPTION
I've implemented a bare minimum of the feature discussed in the [mailing list](https://groups.google.com/forum/m/#!topic/elixir-lang-core/FyRAyqJZIPs). I didn't focus too much on the tests or documentation since it's still being discussed.

As for a `match` version, I'm unsure of how to handle the match specs. The format of the data that you'd want to match on is, in the table, `{key, {pid, value}}` which we might not want to leak to the outside. In the case of `count_match` it's simpler, it only allows matching on the value and the provided match spec is wrapped to match the table.

Because of the uncertainty around the shape of the match specs I skipped remapping the data from `{key, {pid, value}}`, but a "flat" tuple like `{key, pid, value}` is probably preferable.

I'd like to try out a stream version, since it's similarly simple but avoids the list concatenations in the case of partitions. Maybe even implementing the `to_list` version with a stream under the hood would be preferable?