### PR TITLE
Updates documentation of capture operator with reference to Function.capture/3

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1609,6 +1609,8 @@ defmodule Kernel.SpecialForms do
 
       &local_function/1
 
+  See also `Function.capture/3`.
+
   ## Anonymous functions
 
   The capture operator can also be used to partially apply


### PR DESCRIPTION
The documentation of `Kernel.SpecialForms.&/1` is updated with a reference to `Function.capture/3`.


Fixes #8961.

