### PR TITLE
Support ISO8601 timestamps with reduced accuracy

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -799,10 +799,11 @@ defmodule DateTime do
   defp raw_from_iso8601(string, calendar, is_year_negative) do
     with <<unquote(match_date), sep, unquote(match_time), rest::binary>> <- string,
          true <- unquote(guard_date) and sep in @sep and unquote(guard_time),
+         {second, rest} <- Calendar.ISO.parse_second(rest),
          {microsecond, rest} <- Calendar.ISO.parse_microsecond(rest),
          {offset, ""} <- Calendar.ISO.parse_offset(rest) do
       {year, month, day} = unquote(read_date)
-      {hour, minute, second} = unquote(read_time)
+      {hour, minute} = unquote(read_time)
       year = if is_year_negative, do: -year, else: year
 
       cond do

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -63,13 +63,12 @@ defmodule Calendar.ISO do
   def __match_time__ do
     quote do
       [
-        <<h1, h2, ?:, i1, i2, ?:, s1, s2>>,
+        <<h1, h2, ?:, i1, i2>>,
         h1 >= ?0 and h1 <= ?9 and h2 >= ?0 and h2 <= ?9 and i1 >= ?0 and i1 <= ?9 and i2 >= ?0 and
-          i2 <= ?9 and s1 >= ?0 and s1 <= ?9 and s2 >= ?0 and s2 <= ?9,
+          i2 <= ?9,
         {
           (h1 - ?0) * 10 + (h2 - ?0),
-          (i1 - ?0) * 10 + (i2 - ?0),
-          (s1 - ?0) * 10 + (s2 - ?0)
+          (i1 - ?0) * 10 + (i2 - ?0)
         }
       ]
     end
@@ -811,6 +810,21 @@ defmodule Calendar.ISO do
       "T" <>
       time_to_string(hour, minute, second, microsecond, format) <>
       offset_to_string(utc_offset, std_offset, time_zone, format)
+  end
+
+  @doc false
+  def parse_second(<<?:, s1, s2, rest::binary>>) do
+    case s1 >= ?0 and s1 <= ?9 and s2 >= ?0 and s2 <= ?9 do
+      true ->
+        {(s1 - ?0) * 10 + (s2 - ?0), rest}
+
+      false ->
+        :error
+    end
+  end
+
+  def parse_second(rest) do
+    {0, rest}
   end
 
   @doc false

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -553,10 +553,11 @@ defmodule NaiveDateTime do
   defp raw_from_iso8601(string, calendar) do
     with <<unquote(match_date), sep, unquote(match_time), rest::binary>> <- string,
          true <- unquote(guard_date) and sep in @sep and unquote(guard_time),
+         {sec, rest} <- Calendar.ISO.parse_second(rest),
          {microsec, rest} <- Calendar.ISO.parse_microsecond(rest),
          {_offset, ""} <- Calendar.ISO.parse_offset(rest) do
       {year, month, day} = unquote(read_date)
-      {hour, min, sec} = unquote(read_time)
+      {hour, min} = unquote(read_time)
 
       with {:ok, iso_naive_dt} <- new(year, month, day, hour, min, sec, microsec, Calendar.ISO) do
         convert(iso_naive_dt, calendar)

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -228,9 +228,10 @@ defmodule Time do
   defp raw_from_iso8601(string, calendar) do
     with <<unquote(match_time), rest::binary>> <- string,
          true <- unquote(guard_time),
+         {sec, rest} <- Calendar.ISO.parse_second(rest),
          {microsec, rest} <- Calendar.ISO.parse_microsecond(rest),
          {_offset, ""} <- Calendar.ISO.parse_offset(rest) do
-      {hour, min, sec} = unquote(read_time)
+      {hour, min} = unquote(read_time)
 
       with {:ok, utc_time} <- new(hour, min, sec, microsec, Calendar.ISO) do
         convert(utc_time, calendar)

--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -152,6 +152,23 @@ defmodule DateTimeTest do
              }
   end
 
+  test "from_iso8601 handles times without seconds" do
+    assert DateTime.from_iso8601("2015-01-24T09:50-10:00") |> elem(1) ==
+             %DateTime{
+               microsecond: {0, 0},
+               month: 1,
+               std_offset: 0,
+               time_zone: "Etc/UTC",
+               utc_offset: 0,
+               year: 2015,
+               zone_abbr: "UTC",
+               day: 24,
+               hour: 19,
+               minute: 50,
+               second: 0
+             }
+  end
+
   test "from_iso8601 handles invalid date, time, formats correctly" do
     assert DateTime.from_iso8601("2015-01-23T23:50:07") == {:error, :missing_offset}
     assert DateTime.from_iso8601("2015-01-23 23:50:61") == {:error, :invalid_time}

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1086,6 +1086,10 @@ defmodule KernelTest do
            }
 
     assert_raise ArgumentError, ~r"reason: :invalid_format", fn ->
+      Code.eval_string(~s{~U[2015-01-13 13:000]})
+    end
+
+    assert_raise ArgumentError, ~r"reason: :missing_offset", fn ->
       Code.eval_string(~s{~U[2015-01-13 13:00]})
     end
 


### PR DESCRIPTION
The ISO 8601 in its **"Representations with reduced accuracy"** section specifies that the `hh:mm` is a valid time representation.

The [DateTime.from_iso8601/1](https://hexdocs.pm/elixir/DateTime.html#from_iso8601/2) function is expected to **"Parse the extended 'Date and time of day' format described by ISO 8601:2004."**. However, this function fails to parse `ISO 8601` date and time strings if no seconds are provided (e.g. `2019-04-19T13:30Z`).

```elixir
iex(1)> DateTime.from_iso8601("2019-04-19T13:30Z")
{:error, :invalid_format}
```
This PR updates the `DateTime`, `Calendar.ISO` and `Time` modules to add support for ISO 8601 representations with reduced accuracy.

```elixir
iex(1)> DateTime.from_iso8601("2019-04-19T13:30Z")
{:ok, ~U[2019-04-19 13:30:00Z], 0}
```

Note that the `2019-04-19T13:30` string used to return an `invalid format` error, but the same date is now returning a `missing offset` error instead.

We came across this issue when we connected our Scala and Elixir services together. Our Scala service is using [LocalDateTime.toString()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/LocalDateTime.html#toString()) to convert ISO8601 timestamps to strings.

> Outputs this date-time as a String, such as 2007-12-03T10:15:30.
> The output will be one of the following ISO-8601 formats:
>
> * uuuu-MM-dd'T'HH:mm
> * uuuu-MM-dd'T'HH:mm:ss
> * uuuu-MM-dd'T'HH:mm:ss.SSS
> * uuuu-MM-dd'T'HH:mm:ss.SSSSSS
> * uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS
> 
> The format used will be the shortest that outputs the full value of the time where the omitted parts  are implied to be zero.