### PR TITLE
Configurable inspect function

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -206,14 +206,14 @@ defimpl Inspect, for: List do
         container_doc(open, term, close, opts, &keyword/2, separator: sep, break: :strict)
 
       true ->
-        container_doc(open, term, close, opts, &to_doc/2, separator: sep)
+        container_doc(open, term, close, opts, Inspect.Algebra.get_inspect_fun(), separator: sep)
     end
   end
 
   @doc false
   def keyword({key, value}, opts) do
     key = color(Identifier.inspect_as_key(key), :atom, opts)
-    concat(key, concat(" ", to_doc(value, opts)))
+    concat(key, concat(" ", Inspect.Algebra.get_inspect_fun().(value, opts)))
   end
 
   @doc false
@@ -234,7 +234,8 @@ defimpl Inspect, for: Tuple do
     sep = color(",", :tuple, opts)
     close = color("}", :tuple, opts)
     container_opts = [separator: sep, break: :flex]
-    container_doc(open, Tuple.to_list(tuple), close, opts, &to_doc/2, container_opts)
+    to_doc = Inspect.Algebra.get_inspect_fun()
+    container_doc(open, Tuple.to_list(tuple), close, opts, to_doc, container_opts)
   end
 end
 
@@ -261,7 +262,8 @@ defimpl Inspect, for: Map do
   end
 
   defp to_map({key, value}, opts, sep) do
-    concat(concat(to_doc(key, opts), sep), to_doc(value, opts))
+    to_doc = Inspect.Algebra.get_inspect_fun()
+    concat(concat(to_doc.(key, opts), sep), to_doc.(value, opts))
   end
 end
 

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -206,14 +206,14 @@ defimpl Inspect, for: List do
         container_doc(open, term, close, opts, &keyword/2, separator: sep, break: :strict)
 
       true ->
-        container_doc(open, term, close, opts, Inspect.Algebra.get_inspect_fun(), separator: sep)
+        container_doc(open, term, close, opts, get_inspect_fun(), separator: sep)
     end
   end
 
   @doc false
   def keyword({key, value}, opts) do
     key = color(Identifier.inspect_as_key(key), :atom, opts)
-    concat(key, concat(" ", Inspect.Algebra.get_inspect_fun().(value, opts)))
+    concat(key, concat(" ", get_inspect_fun().(value, opts)))
   end
 
   @doc false
@@ -234,8 +234,7 @@ defimpl Inspect, for: Tuple do
     sep = color(",", :tuple, opts)
     close = color("}", :tuple, opts)
     container_opts = [separator: sep, break: :flex]
-    to_doc = Inspect.Algebra.get_inspect_fun()
-    container_doc(open, Tuple.to_list(tuple), close, opts, to_doc, container_opts)
+    container_doc(open, Tuple.to_list(tuple), close, opts, get_inspect_fun(), container_opts)
   end
 end
 
@@ -262,7 +261,7 @@ defimpl Inspect, for: Map do
   end
 
   defp to_map({key, value}, opts, sep) do
-    to_doc = Inspect.Algebra.get_inspect_fun()
+    to_doc = get_inspect_fun()
     concat(concat(to_doc.(key, opts), sep), to_doc.(value, opts))
   end
 end

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -250,11 +250,27 @@ defmodule Inspect.Algebra do
 
   # Elixir + Inspect.Opts conveniences
 
+  @doc """
+  Gets the current inspect function.
+
+  See `put_inspect_fun/1` for more information.
+  """
+  @doc since: "1.9.0"
+  @spec get_inspect_fun() :: (any, Inspect.Opts.t() -> t)
   def get_inspect_fun() do
     # using :application instead of Application due to bootstrapping
     :application.get_env(:elixir, :inspect_fun, &to_doc/2)
   end
 
+  @doc """
+  Sets the current inspect function.
+
+  By default, functions like `Kernel.inspect/2`, `IO.inspect/2` etc
+  use `Inspect.Algebra.to_doc/2` to build an algebra document. This
+  function allows to use a custom function instead.
+  """
+  @doc since: "1.9.0"
+  @spec put_inspect_fun((any, Inspect.Opts.t() -> t)) :: :ok
   def put_inspect_fun(inspect_fun) when is_function(inspect_fun, 2) do
     :application.set_env(:elixir, :inspect_fun, inspect_fun)
   end

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -250,6 +250,15 @@ defmodule Inspect.Algebra do
 
   # Elixir + Inspect.Opts conveniences
 
+  def get_inspect_fun() do
+    # using :application instead of Application due to bootstrapping
+    :application.get_env(:elixir, :inspect_fun, &to_doc/2)
+  end
+
+  def put_inspect_fun(inspect_fun) when is_function(inspect_fun, 2) do
+    :application.set_env(:elixir, :inspect_fun, inspect_fun)
+  end
+
   @doc """
   Converts an Elixir term to an algebra document
   according to the `Inspect` protocol.

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -392,7 +392,8 @@ defmodule IO do
   def inspect(device, item, opts) when is_list(opts) do
     label = if label = opts[:label], do: [to_chardata(label), ": "], else: []
     opts = struct(Inspect.Opts, opts)
-    doc = Inspect.Algebra.group(Inspect.Algebra.to_doc(item, opts))
+    inspect_fun = Inspect.Algebra.get_inspect_fun()
+    doc = Inspect.Algebra.group(inspect_fun.(item, opts))
     chardata = Inspect.Algebra.format(doc, opts.width)
     puts(device, [label, chardata])
     item

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2056,6 +2056,7 @@ defmodule Kernel do
   @spec inspect(Inspect.t(), keyword) :: String.t()
   def inspect(term, opts \\ []) when is_list(opts) do
     opts = struct(Inspect.Opts, opts)
+    inspect_fun = Inspect.Algebra.get_inspect_fun()
 
     limit =
       case opts.pretty do
@@ -2063,7 +2064,7 @@ defmodule Kernel do
         false -> :infinity
       end
 
-    doc = Inspect.Algebra.group(Inspect.Algebra.to_doc(term, opts))
+    doc = Inspect.Algebra.group(inspect_fun.(term, opts))
     IO.iodata_to_binary(Inspect.Algebra.format(doc, limit))
   end
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2057,6 +2057,7 @@ defmodule Kernel do
   def inspect(term, opts \\ []) when is_list(opts) do
     opts = struct(Inspect.Opts, opts)
     inspect_fun = Inspect.Algebra.get_inspect_fun()
+    doc = Inspect.Algebra.group(inspect_fun.(term, opts))
 
     limit =
       case opts.pretty do
@@ -2064,7 +2065,6 @@ defmodule Kernel do
         false -> :infinity
       end
 
-    doc = Inspect.Algebra.group(inspect_fun.(term, opts))
     IO.iodata_to_binary(Inspect.Algebra.format(doc, limit))
   end
 

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -159,6 +159,7 @@ defimpl Inspect, for: Range do
   import Inspect.Algebra
 
   def inspect(first..last, opts) do
-    concat([to_doc(first, opts), "..", to_doc(last, opts)])
+    to_doc = Inspect.Algebra.get_inspect_fun()
+    concat([to_doc.(first, opts), "..", to_doc.(last, opts)])
   end
 end

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1590,6 +1590,7 @@ defimpl Inspect, for: Stream do
 
   def inspect(%{enum: enum, funs: funs}, opts) do
     inner = [enum: enum, funs: Enum.reverse(funs)]
-    concat(["#Stream<", to_doc(inner, opts), ">"])
+    to_doc = Inspect.Algebra.get_inspect_fun()
+    concat(["#Stream<", to_doc.(inner, opts), ">"])
   end
 end

--- a/lib/elixir/test/elixir/inspect/algebra_test.exs
+++ b/lib/elixir/test/elixir/inspect/algebra_test.exs
@@ -296,6 +296,7 @@ defmodule Inspect.AlgebraTest do
     Inspect.Algebra.put_inspect_fun(fun)
     assert Inspect.Algebra.get_inspect_fun() == fun
     assert inspect(%Custom{}) == "#Custom<>"
+    assert inspect([%Custom{}]) == "[#Custom<>]"
   after
     Inspect.Algebra.put_inspect_fun(&Inspect.Algebra.to_doc/2)
   end

--- a/lib/elixir/test/elixir/inspect/algebra_test.exs
+++ b/lib/elixir/test/elixir/inspect/algebra_test.exs
@@ -279,4 +279,24 @@ defmodule Inspect.AlgebraTest do
     assert sm.(["a" | empty()]) |> render(80) == "[a]"
     assert sm.([empty() | "b"]) |> render(80) == "[b]"
   end
+
+  defmodule Custom do
+    defstruct []
+  end
+
+  test "put_inspect_fun/1" do
+    fun = fn
+      %Custom{}, _opts ->
+        "#Custom<>"
+
+      term, opts ->
+        Inspect.Algebra.to_doc(term, opts)
+    end
+
+    Inspect.Algebra.put_inspect_fun(fun)
+    assert Inspect.Algebra.get_inspect_fun() == fun
+    assert inspect(%Custom{}) == "#Custom<>"
+  after
+    Inspect.Algebra.put_inspect_fun(&Inspect.Algebra.to_doc/2)
+  end
 end

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -162,7 +162,7 @@ defmodule Logger.Utils do
   defp inspect_width(_, width), do: width
 
   defp inspect_data([data | _], opts) do
-    inspect_fun = Inspect.Algebra.get_inspect_fun()
+    inspect_fun = &Inspect.Algebra.to_doc/2
     Inspect.Algebra.format(inspect_fun.(data, opts), opts.width)
   end
 

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -162,9 +162,8 @@ defmodule Logger.Utils do
   defp inspect_width(_, width), do: width
 
   defp inspect_data([data | _], opts) do
-    data
-    |> Inspect.Algebra.to_doc(opts)
-    |> Inspect.Algebra.format(opts.width)
+    inspect_fun = Inspect.Algebra.get_inspect_fun()
+    Inspect.Algebra.format(inspect_fun.(data, opts), opts.width)
   end
 
   @doc """


### PR DESCRIPTION
Before this patch, `Kernel.inspect`, `IO.inspect` etc were using `Inspect.Algebra.to_doc/2` to build algebra document. This commit introduces an ability to swap out this function via `Inspect.Algebra.get_inspect_fun/0` and `Inspect.Algebra.put_inspect_fun/1`.

Let's see some use cases. First we configure Elixir to use a custom function:

   ```elixir
    iex> Inspect.Algebra.put_inspect_fun(&Pretty.to_doc/2)
    :ok
   ```

1. Pretty-printing integers (#4916)

     ```elixir
     iex> :math.pow(2, 32) |> trunc()
     4_294_967_296
     ```

2. Inspect tuples as records (#8534)

     ```elixir
     iex> {:foo, :bar}
     {:foo, :bar}

     iex> {:person, "Alice", 30}
    #person(name: "Alice", age: 30)
   ```

3. Overwrite struct's Inspect implementation

     ```elixir
     iex> URI.parse("https://elixir-lang.org")
     #URI<https://elixir-lang.org>
   ```

---

Code for the `Pretty.to_doc` function:

<details>

```elixir
    defmodule Pretty do
      def to_doc(integer, opts) when is_integer(integer) do
        PrettyIntegers.inspect(integer, opts)
      end

      def to_doc(tuple, opts) when is_tuple(tuple) do
        records = %{
          {:person, 2} => [:name, :age]
        }

        PrettyTuples.inspect(tuple, records, opts)
      end

      def to_doc(%URI{} = uri, _opts) do
        Inspect.Algebra.concat(["#URI<", URI.to_string(uri), ">"])
      end

      def to_doc(term, opts) do
        Inspect.Algebra.to_doc(term, opts)
      end
    end

    defmodule PrettyIntegers do
      def inspect(term, %Inspect.Opts{base: :decimal}) do
        pretty_decimal(term, "_")
      end

      def inspect(term, %Inspect.Opts{base: base}) do
        Integer.to_string(term, base_to_value(base))
        |> prepend_prefix(base)
      end

      def pretty_decimal(n, separator) when n < 0 do
        "-" <> pretty_decimal(abs(n), separator)
      end

      def pretty_decimal(n, separator) when n >= 1000 do
        left = div(n, 1_000)
        right = rem(n, 1_000)
        right_str = :io_lib.format("~3..0B", [right]) |> IO.iodata_to_binary
        pretty_decimal(left, separator) <> separator <> right_str
      end

      def pretty_decimal(n, _) do
        Integer.to_string(n)
      end

      defp base_to_value(base) do
        case base do
          :binary  -> 2
          :octal   -> 8
          :hex     -> 16
        end
      end

      defp prepend_prefix(value, base) do
        prefix = case base do
          :binary -> "0b"
          :octal  -> "0o"
          :hex    -> "0x"
        end
        prefix <> value
      end
    end

    defmodule PrettyTuples do
      import Inspect.Algebra

      def inspect({}, _records, opts), do: inspect_tuple([], opts)

      def inspect(tuple, records, opts) do
        list = Tuple.to_list(tuple)
        [record_name | values] = list

        case record_fields(records, record_name, tuple) do
          {:ok, fields} ->
            inspect_record(record_name, fields, values, opts)

          _ ->
            inspect_tuple(list, opts)
        end
      end

      defp record_fields(records, record_name, tuple) do
        fields_size = tuple_size(tuple) - 1
        Map.fetch(records, {record_name, fields_size})
      end

      defp inspect_tuple(list, opts) do
        inspect("{", list, "}", &to_doc/2, :flex, opts)
      end

      defp inspect_record(record_name, fields, values, opts) do
        kwlist = Enum.zip(fields, values)
        inspect("##{record_name}(", kwlist, ")", &Inspect.List.keyword/2, :strict, opts)
      end

      defp inspect(open, list, close, fun, break, opts) do
        open = color(open, :tuple, opts)
        sep = color(",", :tuple, opts)
        close = color(close, :tuple, opts)
        container_opts = [separator: sep, break: break]
        container_doc(open, list, close, opts, fun, container_opts)
      end
    end
```

</details>