### PR TITLE
Add inspect_fun to Inspect.Opts

### DIFF
--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -54,7 +54,7 @@ defmodule Inspect.Opts do
       `:number`, `:atom`, `regex`, `:tuple`, `:map`, `:list`, and `:reset`.
       Colors can be any `t:IO.ANSI.ansidata/0` as accepted by `IO.ANSI.format/1`.
 
-    * `:inspect_fun` - a function to build algebra document, defaults to
+    * `:inspect_fun` (since v1.9.0) - a function to build algebra document, defaults to
       `Inspect.inspect/2`
 
   """

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -54,6 +54,9 @@ defmodule Inspect.Opts do
       `:number`, `:atom`, `regex`, `:tuple`, `:map`, `:list`, and `:reset`.
       Colors can be any `t:IO.ANSI.ansidata/0` as accepted by `IO.ANSI.format/1`.
 
+    * `:inspect_fun` - a function to build algebra document, defaults to
+      `Inspect.inspect/2`
+
   """
 
   # TODO: Remove :char_lists key on v2.0
@@ -67,7 +70,8 @@ defmodule Inspect.Opts do
             base: :decimal,
             pretty: false,
             safe: true,
-            syntax_colors: []
+            syntax_colors: [],
+            inspect_fun: &Inspect.inspect/2
 
   @type color_key :: atom
 
@@ -83,7 +87,8 @@ defmodule Inspect.Opts do
           base: :decimal | :binary | :hex | :octal,
           pretty: boolean,
           safe: boolean,
-          syntax_colors: [{color_key, IO.ANSI.ansidata()}]
+          syntax_colors: [{color_key, IO.ANSI.ansidata()}],
+          inspect_fun: (any, t -> Inspect.Algebra.t())
         }
 end
 
@@ -257,10 +262,10 @@ defmodule Inspect.Algebra do
   @spec to_doc(any, Inspect.Opts.t()) :: t
   def to_doc(term, opts)
 
-  def to_doc(%_{} = struct, %Inspect.Opts{} = opts) do
+  def to_doc(%_{} = struct, %Inspect.Opts{inspect_fun: fun} = opts) do
     if opts.structs do
       try do
-        Inspect.inspect(struct, opts)
+        fun.(struct, opts)
       rescue
         caught_exception ->
           # Because we try to raise a nice error message in case
@@ -299,8 +304,8 @@ defmodule Inspect.Algebra do
     end
   end
 
-  def to_doc(arg, %Inspect.Opts{} = opts) do
-    Inspect.inspect(arg, opts)
+  def to_doc(arg, %Inspect.Opts{inspect_fun: fun} = opts) do
+    fun.(arg, opts)
   end
 
   @doc ~S"""

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -54,8 +54,8 @@ defmodule Inspect.Opts do
       `:number`, `:atom`, `regex`, `:tuple`, `:map`, `:list`, and `:reset`.
       Colors can be any `t:IO.ANSI.ansidata/0` as accepted by `IO.ANSI.format/1`.
 
-    * `:inspect_fun` (since v1.9.0) - a function to build algebra document, defaults to
-      `Inspect.inspect/2`
+    * `:inspect_fun` (since v1.9.0) - a function to build algebra documents,
+      defaults to `Inspect.inspect/2`
 
   """
 

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -657,4 +657,26 @@ defmodule Inspect.OthersTest do
     assert inspect(~r" \\/ ") == "~r/ \\\\\\/ /"
     assert inspect(~r/hi/, syntax_colors: [regex: :red]) == "\e[31m~r/hi/\e[0m"
   end
+
+  test "inspect_fun" do
+    fun = fn
+      integer, _opts when is_integer(integer) ->
+        "<#{integer}>"
+
+      %URI{} = uri, _opts ->
+        "#URI<#{uri}>"
+
+      term, opts ->
+        Inspect.inspect(term, opts)
+    end
+
+    opts = [inspect_fun: fun]
+
+    assert inspect(1000, opts) == "<1000>"
+    assert inspect([1000], opts) == "[<1000>]"
+
+    uri = URI.parse("https://elixir-lang.org")
+    assert inspect(uri, opts) == "#URI<https://elixir-lang.org>"
+    assert inspect([uri], opts) == "[#URI<https://elixir-lang.org>]"
+  end
 end


### PR DESCRIPTION
Another stab at making inspecting more configurable. It differs from #8979 in that, instead of introducing global state, we add it as just another option which needs to be passed explicitly. Thus, the users will likely define their own `MyApp.inspect_opts()` and/or `MyApp.io_inspect()` wrappers to avoid repetition.

Let's see some use cases. First we configure IEx to use our custom function:

```elixir
iex> IEx.configure(inspect: [inspect_fun: &Pretty.inspect/2])
:ok
```

1. Pretty-printing integers (#4916)

   ```elixir
   iex> :math.pow(2, 32) |> trunc()
   4_294_967_296
   ```

2. Inspect tuples as records (#8534)

   ```elixir
   iex> {:foo, :bar}
   {:foo, :bar}

   iex> {:person, "Alice", 30}
   #person(name: "Alice", age: 30)
   ```

3. Overwrite struct's Inspect implementation

   ```elixir
   iex> URI.parse("https://elixir-lang.org")
   #URI<https://elixir-lang.org>
   ```

---

Code for the `Pretty.inspect/2` function:

<details>

```elixir
    defmodule Pretty do
      def inspect(integer, opts) when is_integer(integer) do
        PrettyIntegers.inspect(integer, opts)
      end

      def inspect(tuple, opts) when is_tuple(tuple) do
        records = %{
          {:person, 2} => [:name, :age]
        }

        PrettyTuples.inspect(tuple, records, opts)
      end

      def inspect(%URI{} = uri, _opts) do
        Inspect.Algebra.concat(["#URI<", URI.to_string(uri), ">"])
      end

      def inspect(term, opts) do
        Inspect.inspect(term, opts)
      end
    end

    defmodule PrettyIntegers do
      def inspect(term, %Inspect.Opts{base: :decimal}) do
        pretty_decimal(term, "_")
      end

      def inspect(term, %Inspect.Opts{base: base}) do
        Integer.to_string(term, base_to_value(base))
        |> prepend_prefix(base)
      end

      def pretty_decimal(n, separator) when n < 0 do
        "-" <> pretty_decimal(abs(n), separator)
      end

      def pretty_decimal(n, separator) when n >= 1000 do
        left = div(n, 1_000)
        right = rem(n, 1_000)
        right_str = :io_lib.format("~3..0B", [right]) |> IO.iodata_to_binary
        pretty_decimal(left, separator) <> separator <> right_str
      end

      def pretty_decimal(n, _) do
        Integer.to_string(n)
      end

      defp base_to_value(base) do
        case base do
          :binary  -> 2
          :octal   -> 8
          :hex     -> 16
        end
      end

      defp prepend_prefix(value, base) do
        prefix = case base do
          :binary -> "0b"
          :octal  -> "0o"
          :hex    -> "0x"
        end
        prefix <> value
      end
    end

    defmodule PrettyTuples do
      import Inspect.Algebra

      def inspect({}, _records, opts), do: inspect_tuple([], opts)

      def inspect(tuple, records, opts) do
        list = Tuple.to_list(tuple)
        [record_name | values] = list

        case record_fields(records, record_name, tuple) do
          {:ok, fields} ->
            inspect_record(record_name, fields, values, opts)

          _ ->
            inspect_tuple(list, opts)
        end
      end

      defp record_fields(records, record_name, tuple) do
        fields_size = tuple_size(tuple) - 1
        Map.fetch(records, {record_name, fields_size})
      end

      defp inspect_tuple(list, opts) do
        inspect("{", list, "}", &to_doc/2, :flex, opts)
      end

      defp inspect_record(record_name, fields, values, opts) do
        kwlist = Enum.zip(fields, values)
        inspect("##{record_name}(", kwlist, ")", &Inspect.List.keyword/2, :strict, opts)
      end

      defp inspect(open, list, close, fun, break, opts) do
        open = color(open, :tuple, opts)
        sep = color(",", :tuple, opts)
        close = color(close, :tuple, opts)
        container_opts = [separator: sep, break: break]
        container_doc(open, list, close, opts, fun, container_opts)
      end
    end
```

</details>