### PR TITLE
Replace bin/start by release/RELEASE_VSN/env

### DIFF
--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -549,7 +549,7 @@ defmodule Mix.Tasks.Release do
         start_erl.data
       tmp/
 
-  ## Environment variablees
+  ## Environment variables
 
   The system sets different environment variables. The following variables
   are set early on and can only be read by `env.sh` and `env.bat`:

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -1000,9 +1000,9 @@ defmodule Mix.Tasks.Release do
     Release created at #{path}!
 
         # To start your system
-        #{path}/bin/start
+        #{cmd} start
 
-    Check bin/start for more information. Once the release is running:
+    Once the release is running:
 
         # To connect to it remotely
         #{cmd} remote
@@ -1048,17 +1048,15 @@ defmodule Mix.Tasks.Release do
     File.mkdir_p!(bin_path)
 
     for os <- include_executables_for do
-      {start, start_fun, clis} = cli_for(os, release)
-      start_path = Path.join(bin_path, start)
-      start_template_path = Path.join("rel", start <> ".eex")
+      {env, env_fun, clis} = cli_for(os, release)
+      env_path = Path.join(release.version_path, env)
+      env_template_path = Path.join("rel", env <> ".eex")
 
-      if File.exists?(start_template_path) do
-        copy_template(start_template_path, start_path, [release: release], force: true)
+      if File.exists?(env_template_path) do
+        copy_template(env_template_path, env_path, [release: release], force: true)
       else
-        File.write!(start_path, start_fun.(release))
+        File.write!(env_path, env_fun.(release))
       end
-
-      executable!(start_path)
 
       for {filename, contents} <- clis do
         path = Path.join(bin_path, filename)
@@ -1079,11 +1077,11 @@ defmodule Mix.Tasks.Release do
   end
 
   defp cli_for(:unix, release) do
-    {"start", &start_template(release: &1), [{"#{release.name}", cli_template(release: release)}]}
+    {"env.sh", &env_template(release: &1), [{"#{release.name}", cli_template(release: release)}]}
   end
 
   defp cli_for(:windows, release) do
-    {"start.bat", &start_bat_template(release: &1),
+    {"env.bat", &env_bat_template(release: &1),
      [{"#{release.name}.bat", cli_bat_template(release: release)}]}
   end
 
@@ -1120,8 +1118,8 @@ defmodule Mix.Tasks.Release do
   defp executable!(path), do: File.chmod!(path, 0o744)
 
   embed_template(:vm_args, Mix.Tasks.Release.Init.vm_args_text())
-  embed_template(:start, Mix.Tasks.Release.Init.start_text())
+  embed_template(:env, Mix.Tasks.Release.Init.env_text())
   embed_template(:cli, Mix.Tasks.Release.Init.cli_text())
-  embed_template(:start_bat, Mix.Tasks.Release.Init.start_bat_text())
+  embed_template(:env_bat, Mix.Tasks.Release.Init.env_bat_text())
   embed_template(:cli_bat, Mix.Tasks.Release.Init.cli_bat_text())
 end

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -47,18 +47,13 @@ defmodule Mix.Tasks.Release do
 
   ## Running the release
 
-  Once a release is assembled, you can start it by calling `bin/start`
-  inside the release. In production, you would do:
+  Once a release is assembled, you can start it by calling
+  `bin/RELEASE_NAME start` inside the release. In production, you would do:
 
       MIX_ENV=prod mix release
-      _build/prod/rel/my_app/bin/start
+      _build/prod/rel/my_app/bin/my_app start
 
-  `bin/start` is a very short script that invokes the proper instruction
-  on `bin/RELEASE_NAME`. You can customize `bin/start` in any way you want,
-  see the "Customization" section, but you are not supposed to change
-  `bin/RELEASE_NAME`.
-
-  `bin/start` will start the system connected to the current standard
+  `bin/my_app start` will start the system connected to the current standard
   input/output, where logs are also written to by default. This is the
   preferred way to run the system. Many tools, such as `systemd`, platforms
   as a service, such as Heroku, and many containers platforms, such as Docker,
@@ -66,9 +61,10 @@ defmodule Mix.Tasks.Release do
   the log contents elsewhere. Those tools and platforms also take care
   of restarting the system in case it crashes.
 
-  For those looking for alternate ways of running the system, you can
-  run it as a daemon on Unix-like system or install it as a service on
-  Windows. Then we list all commands supported by `bin/RELEASE_NAME`.
+  You can also execute one-off commands, run the release as a daemon on
+  Unix-like system, or install it as a service on Windows. We will take a
+  look at those next. You can also list all available commands by invoking
+  `bin/RELEASE_NAME`.
 
   ### One-off commands (eval and rpc)
 
@@ -94,8 +90,7 @@ defmodule Mix.Tasks.Release do
 
   ### Daemon mode (Unix-like)
 
-  If you open up `bin/start`, you will also see there is an option to
-  run the release in daemon mode written as a comment:
+  You can run the release in daemon mode written as a comment:
 
       bin/RELEASE_NAME daemon_iex
 
@@ -103,7 +98,7 @@ defmodule Mix.Tasks.Release do
   [run_erl](http://erlang.org/doc/man/run_erl.html). You may also
   want to enable [heart](http://erlang.org/doc/man/heart.html)
   in daemon mode so it automatically restarts the system in case
-  of crashes. See the generated `bin/start`.
+  of crashes. See the generated `releases/RELEASE_VSN/env.sh` file.
 
   The daemon will write all of its standard output to the "tmp/log/"
   directory in the release root. A developer can also attach
@@ -116,7 +111,7 @@ defmodule Mix.Tasks.Release do
 
   You can customize the tmp directory used both for logging and for
   piping in daemon mode by setting the `RELEASE_TMP` environment
-  variable on `bin/start`. See the "Customization" section.
+  variable. See the "Customization" section.
 
   ### Services mode (Windows)
 
@@ -144,7 +139,7 @@ defmodule Mix.Tasks.Release do
 
   The `install` command must be executed as an administrator.
 
-  ## `bin/RELEASE_NAME` commands
+  ### `bin/RELEASE_NAME` commands
 
   The following commands are supported by `bin/RELEASE_NAME`:
 
@@ -217,7 +212,7 @@ defmodule Mix.Tasks.Release do
       cd my_app_source
       mix deps.get --only prod
       MIX_ENV=prod mix release
-      _build/prod/rel/my_app/bin/start
+      _build/prod/rel/my_app/bin/my_app start
 
   If you prefer, you can also compile the release to a separate directory,
   so you can erase all source after the release is assembled:
@@ -228,7 +223,7 @@ defmodule Mix.Tasks.Release do
       MIX_ENV=prod mix release --path ../my_app_release
       cd ../my_app_release
       rm -rf ../my_app_source
-      bin/start
+      bin/my_app start
 
   However, this option can be expensive if you have multiple production
   nodes or if the release assembling process is a long one, as each node
@@ -243,7 +238,7 @@ defmodule Mix.Tasks.Release do
   pipeline by calling `MIX_ENV=prod mix release` and push the artifact
   to S3 or any other network storage. To perform the deployment, your
   production machines can fetch the deployment from the network storage
-  and run the `bin/start` script.
+  and run `bin/my_app start`.
 
   Another mechanism to automate deployments is to use images, such as
   Amazon Machine Images, or container platforms, such as Docker.
@@ -389,21 +384,21 @@ defmodule Mix.Tasks.Release do
   config file will be written to "tmp" directory inside the release every
   time the system boots. You can configure the "tmp" directory by setting
   the `RELEASE_TMP` environment variable, either explicitly or inside your
-  `bin/start` script.
+  `releases/RELEASE_VSN/env.sh` (or `env.bat` on Windows).
 
-  The `bin/start` script can also be used to perform limited runtime
-  configuration via Erlang `-app` flags. For example, if you want to make
-  sure the Erlang distribution listens only to a given port known at runtime,
-  you can set the following in your `bin/start` script:
+  The `releases/RELEASE_VSN/env.sh` script can also be used to perform
+  limited runtime configuration via Erlang `-app` flags. For example, if
+  you want to make sure the Erlang Distribution listens only on a given
+  port known at runtime, you can set the following:
 
       export ELIXIR_ERL_OPTIONS="-kernel inet_dist_listen_min $BEAM_PORT inet_dist_listen_max $BEAM_PORT"
 
-  Or for Windows, in your `bin/start.bat`:
+  Or for Windows, in your `releases/RELEASE_VSN/env.bat`:
 
       set ELIXIR_ERL_OPTIONS=-kernel inet_dist_listen_min %BEAM_PORT% inet_dist_listen_max %BEAM_PORT%
 
   See the "Customization" section to learn exactly how to provide a custom
-  `bin/start`.
+  `releases/RELEASE_VSN/env.sh` file.
 
   ### Config providers
 
@@ -454,40 +449,41 @@ defmodule Mix.Tasks.Release do
         ]
       ]
 
-  ### vm.args and bin/start
+  ### vm.args and env.sh (env.bat)
 
   Developers may want to customize the VM flags and environment variables
   given when the release starts. This is typically done by customizing
   two files inside your release: `releases/RELEASE_VSN/vm.args` and
-  `bin/start` (or `bin/start.bat` on Windows).
+  `releases/RELEASE_VSN/env.sh` (or `env.bat` on Windows).
 
   However, instead of modifying those files after the release is built,
   the simplest way to customize those files is by running `mix release.init`.
-  The Mix task will copy custom `rel/vm.args.eex`, `rel/start.eex`, and
-  `rel/start.bat.eex` files to your project root. You can modify those
+  The Mix task will copy custom `rel/vm.args.eex`, `rel/env.sh.eex`, and
+  `rel/env.bat.eex` files to your project root. You can modify those
   files and they will be evaluated every time you perform a new release.
   Those file are regular EEx templates and they have a single assign,
   called `@release`, with the `Mix.Release` struct.
 
-  The `vm.args` will be evaluated and copied per release version,
-  inside `releases/RELEASE_VSN/vm.args`. In there you can set all flags
-  known by the `erl` command: http://erlang.org/doc/man/erl.html
+  The `vm.args` may contain any of the VM flags be known by the `erl`
+  command: http://erlang.org/doc/man/erl.html
 
-  The `bin/start` is shared across all released versions. It is the
-  entry point to start your release. In there, you can set the
-  environment variables such as `RELEASE_NODE`, `RELEASE_COOKIE`,
+  The `env.sh` and `env.bat` is used to set environment variables.
+  In there, you can set vars such as `RELEASE_NODE`, `RELEASE_COOKIE`,
   and `RELEASE_TMP` to customize your node name, cookie and tmp
-  directory respectively.
+  directory respectively. Whenever `env.sh` or `env.bat` is invoked,
+  the variables `RELEASE_ROOT`, `RELEASE_NAME`, `RELEASE_VSN`, and
+  `RELEASE_COMMAND` have already been set, so you can rely on them.
+  See the section on environment variables for more information.
 
-  Furthermore, while `vm.args` is static, you can use `bin/start`
-  to dynamically set VM options or to perform simple application
-  configuration. For example, if you want to make sure the Erlang
-  distribution listens only to a given port known at runtime, you
-  can set the following in your `bin/start` script:
+  Furthermore, while `vm.args` is static, you can use `env.sh` and
+  `env.bat` to dynamically set VM options or to perform simple
+  application configuration. For example, if you want to make sure
+  the Erlang Distribution listens only on a given port known at
+  runtime, you can set the following:
 
       export ELIXIR_ERL_OPTIONS="-kernel inet_dist_listen_min $BEAM_PORT inet_dist_listen_max $BEAM_PORT"
 
-  Or for Windows, in your `bin/start.bat`:
+  Or for Windows, in your `env.bat`:
 
       set ELIXIR_ERL_OPTIONS="-kernel inet_dist_listen_min %BEAM_PORT% inet_dist_listen_max %BEAM_PORT%"
 
@@ -521,13 +517,12 @@ defmodule Mix.Tasks.Release do
   field can also be used to verify if the step was set before or
   after assembling the release.
 
-  ## Directory structure and environment variables
+  ## Directory structure
 
   A release is organized as follows:
 
       bin/
         RELEASE_NAME
-        start
       erts-ERTS_VSN/
       lib/
         APP_NAME-APP_VSN/
@@ -538,7 +533,11 @@ defmodule Mix.Tasks.Release do
         RELEASE_VSN/
           consolidated/
           elixir
+          elixir.bat
+          env.bat
+          env.sh
           iex
+          iex.bat
           releases.exs
           start.boot
           start.script
@@ -550,32 +549,39 @@ defmodule Mix.Tasks.Release do
         start_erl.data
       tmp/
 
-  Furthermore, the system sets the following environment variables.
-  Many of them can be set, either directly in your production nodes
-  or inside the `bin/start` script:
+  ## Environment variablees
+
+  The system sets different environment variables. The following variables
+  are set early on and can only be read by `env.sh` and `env.bat`:
 
     * `RELEASE_ROOT` - points to the root of the release. If the system
       includes ERTS, then it is the same as `:code.root_dir/0`. This
       variable is always computed and it cannot be set to a custom value
 
+    * `RELEASE_COMMAND` - the command given to the release, such as `"start"`,
+      `"remote"`, `"eval"`, etc. This is typically accessed inside `env.sh`
+      and `env.bat` to set different environment variables under different
+      conditions. Note, however, that `RELEASE_COMMAND` has not been
+      validated by the time `env.sh` and `env.bat` are called, so it may
+      be empty or contain invalid values. This variable is always computed
+      and it cannot be set to a custom value
+
     * `RELEASE_NAME` - the name of the release. It can be set to a custom
-      value
+      value when invoking the release
 
     * `RELEASE_VSN` - the version of the release, otherwise the latest
-      version is used. It can be set to a custom value. The custom value
-      must be an existing release version in the `releases/` directory
+      version is used. It can be set to a custom value when invoking the
+      release. The custom value must be an existing release version in
+      the `releases/` directory
+
+  The following variables can be set before you invoke the release or
+  inside `env.sh` and `env.bat`:
 
     * `RELEASE_COOKIE` - the release cookie. By default uses the value
-      in `releases/COOKIE`. It can be set to a custom value. Remember that,
-      if you change the value of this environment variable, the custom
-      value must also be set whenever you attempt to connect to the
-      running node via the `remote` or `rpc`commands
+      in `releases/COOKIE`. It can be set to a custom value
 
     * `RELEASE_NODE` - the release node name, in the format `name@host`.
-      It can be set to a custom value. Remember that, if you change the
-      value of this environment variable, the custom value must also be
-      set whenever you attempt to connect to the running node via the
-      `remote` or `rpc`commands
+      It can be set to a custom value
 
     * `RELEASE_VM_ARGS` - the location of the vm.args file. It can be set
       to a custom path

--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -61,6 +61,8 @@ defmodule Mix.Tasks.Release.Init do
   @doc false
   def env_text,
     do: ~S"""
+    #!/bin/sh
+
     # Sets and enables heart (recommended only in daemon mode)
     # if [ "$RELEASE_COMMAND" = "daemon" ] || [ "$RELEASE_COMMAND" = "daemon_iex" ]; then
     #   HEART_COMMAND="$RELEASE_ROOT/bin/$RELEASE_NAME $RELEASE_COMMAND"
@@ -84,7 +86,7 @@ defmodule Mix.Tasks.Release.Init do
     export RELEASE_COMMAND="$1"
 
     REL_VSN_DIR="$RELEASE_ROOT/releases/$RELEASE_VSN"
-    source "$REL_VSN_DIR/env.sh"
+    . "$REL_VSN_DIR/env.sh"
 
     export RELEASE_COOKIE=${RELEASE_COOKIE:-"$(cat "$RELEASE_ROOT/releases/COOKIE")"}
     export RELEASE_NODE=${RELEASE_NODE:-"$RELEASE_NAME@127.0.0.1"}

--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -16,25 +16,26 @@ defmodule Mix.Tasks.Release.Init do
   import Mix.Generator
 
   @switches [
-    force: :boolean,
+    overwrite: :boolean,
     quiet: :boolean
-  ]
-
-  @aliases [
-    f: :force
   ]
 
   @impl true
   def run(args) do
-    {opts, args} = OptionParser.parse!(args, strict: @switches, aliases: @aliases)
+    {opts, args} = OptionParser.parse!(args, strict: @switches)
+
+    generator_opts = [
+      force: Keyword.get(opts, :overwrite, false),
+      quiet: Keyword.get(opts, :quiet, false)
+    ]
 
     if args != [] do
       Mix.raise("Expected \"mix release.init\" without arguments, got: #{inspect(args)}")
     end
 
-    create_file("rel/vm.args.eex", vm_args_text(), opts)
-    create_file("rel/start.eex", start_text(), opts)
-    create_file("rel/start.bat.eex", start_bat_text(), opts)
+    create_file("rel/vm.args.eex", vm_args_text(), generator_opts)
+    create_file("rel/env.sh.eex", env_text(), generator_opts)
+    create_file("rel/env.bat.eex", env_bat_text(), generator_opts)
     :ok
   end
 
@@ -58,19 +59,14 @@ defmodule Mix.Tasks.Release.Init do
     """
 
   @doc false
-  def start_text,
+  def env_text,
     do: ~S"""
-    #!/bin/sh
-    set -e
-
     # Sets and enables heart (recommended only in daemon mode)
-    # HEART_COMMAND="$(dirname "$0")/start"
-    # export HEART_COMMAND
-    # export ELIXIR_ERL_OPTIONS="-heart"
-
-    # To start your system using IEx: "$(dirname "$0")/<%= @release.name %>" start_iex
-    # To start it as a daemon using IEx: "$(dirname "$0")/<%= @release.name %>" daemon_iex
-    "$(dirname "$0")/<%= @release.name %>" start
+    # if [ "$RELEASE_COMMAND" = "daemon" ] || [ "$RELEASE_COMMAND" = "daemon_iex" ]; then
+    #   HEART_COMMAND="$RELEASE_ROOT/bin/$RELEASE_NAME $RELEASE_COMMAND"
+    #   export HEART_COMMAND
+    #   export ELIXIR_ERL_OPTIONS="-heart"
+    # fi
     """
 
   @doc false
@@ -85,11 +81,15 @@ defmodule Mix.Tasks.Release.Init do
     export RELEASE_ROOT
     export RELEASE_NAME="${RELEASE_NAME:-"<%= @release.name %>"}"
     export RELEASE_VSN="${RELEASE_VSN:-"$(cut -d' ' -f2 "$RELEASE_ROOT/releases/start_erl.data")"}"
+    export RELEASE_COMMAND="$1"
+
+    REL_VSN_DIR="$RELEASE_ROOT/releases/$RELEASE_VSN"
+    source "$REL_VSN_DIR/env.sh"
+
     export RELEASE_COOKIE=${RELEASE_COOKIE:-"$(cat "$RELEASE_ROOT/releases/COOKIE")"}
     export RELEASE_NODE=${RELEASE_NODE:-"$RELEASE_NAME@127.0.0.1"}
     export RELEASE_TMP=${RELEASE_TMP:-"$RELEASE_ROOT/tmp"}
-    export RELEASE_VM_ARGS=${RELEASE_VM_ARGS:-"$RELEASE_ROOT/releases/$RELEASE_VSN/vm.args"}
-    REL_VSN_DIR="$RELEASE_ROOT/releases/$RELEASE_VSN"
+    export RELEASE_VM_ARGS=${RELEASE_VM_ARGS:-"$REL_VSN_DIR/vm.args"}
 
     rand () {
       od -t xS -N 2 -A n /dev/urandom | tr -d " \n"
@@ -217,11 +217,9 @@ defmodule Mix.Tasks.Release.Init do
     """
 
   @doc false
-  def start_bat_text,
+  def env_bat_text,
     do: ~S"""
     @echo off
-    rem To start your system using IEx: %~dp0/<%= @release.name %> start_iex
-    %~dp0/<%= @release.name %> start
     """
 
   @doc false
@@ -237,11 +235,14 @@ defmodule Mix.Tasks.Release.Init do
 
     if not defined RELEASE_NAME (set RELEASE_NAME=<%= @release.name %>)
     if not defined RELEASE_VSN (for /f "tokens=1,2" %%K in (!RELEASE_ROOT!\releases\start_erl.data) do (set ERTS_VSN=%%K) && (set RELEASE_VSN=%%L))
+    set RELEASE_COMMAND=%~1
+    set REL_VSN_DIR=!RELEASE_ROOT!\releases\!RELEASE_VSN!
+    call !REL_VSN_DIR!/env.bat
+
     if not defined RELEASE_COOKIE (set /p RELEASE_COOKIE=<!RELEASE_ROOT!\releases\COOKIE)
     if not defined RELEASE_NODE (set RELEASE_NODE=!RELEASE_NAME!@127.0.0.1)
     if not defined RELEASE_TMP (set RELEASE_TMP=!RELEASE_ROOT!\tmp)
-    if not defined RELEASE_VM_ARGS (set RELEASE_VM_ARGS=!RELEASE_ROOT!\releases\!RELEASE_VSN!\vm.args)
-    set REL_VSN_DIR=!RELEASE_ROOT!\releases\!RELEASE_VSN!
+    if not defined RELEASE_VM_ARGS (set RELEASE_VM_ARGS=!REL_VSN_DIR!\vm.args)
     set RELEASE_SYS_CONFIG=!REL_VSN_DIR!\sys
 
     if "%~1" == "start" (set "REL_EXEC=elixir" && set "REL_EXTRA=--no-halt" && set "REL_GOTO=start")

--- a/lib/mix/test/mix/tasks/release.init_test.exs
+++ b/lib/mix/test/mix/tasks/release.init_test.exs
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.Release.InitTest do
     end)
   end
 
-  test "can be set to --ovewrite and --quiet" do
+  test "can be set to --overwrite and --quiet" do
     in_tmp("release_init", fn ->
       Mix.Task.run("release.init", ["--overwrite", "--quiet"])
       Mix.Task.run("release.init", ["--overwrite", "--quiet"])

--- a/lib/mix/test/mix/tasks/release.init_test.exs
+++ b/lib/mix/test/mix/tasks/release.init_test.exs
@@ -7,21 +7,22 @@ defmodule Mix.Tasks.Release.InitTest do
     in_tmp("release_init", fn ->
       Mix.Task.run("release.init", [])
       assert_received {:mix_shell, :info, ["* creating rel/vm.args.eex"]}
-      assert_received {:mix_shell, :info, ["* creating rel/start.eex"]}
-      assert_received {:mix_shell, :info, ["* creating rel/start.bat.eex"]}
+      assert_received {:mix_shell, :info, ["* creating rel/env.sh.eex"]}
+      assert_received {:mix_shell, :info, ["* creating rel/env.bat.eex"]}
 
       assert File.exists?("rel/vm.args.eex")
-      assert File.read!("rel/start.eex") =~ "<%= @release.name %>"
-      assert File.read!("rel/start.bat.eex") =~ "<%= @release.name %>"
+      assert File.exists?("rel/env.sh.eex")
+      assert File.exists?("rel/env.bat.eex")
     end)
   end
 
-  test "can be set to --force and --quiet" do
+  test "can be set to --ovewrite and --quiet" do
     in_tmp("release_init", fn ->
-      Mix.Task.run("release.init", ["--force", "--quiet"])
+      Mix.Task.run("release.init", ["--overwrite", "--quiet"])
+      Mix.Task.run("release.init", ["--overwrite", "--quiet"])
       refute_received {:mix_shell, :info, ["* creating rel/vm.args.eex"]}
-      refute_received {:mix_shell, :info, ["* creating rel/start.eex"]}
-      refute_received {:mix_shell, :info, ["* creating rel/start.bat.eex"]}
+      refute_received {:mix_shell, :info, ["* creating rel/env.sh.eex"]}
+      refute_received {:mix_shell, :info, ["* creating rel/env.bat.eex"]}
     end)
   end
 


### PR DESCRIPTION
Today, the place for setting environment variables in a release
is inside bin/start. The issue with this approach is that, if you
set something like RELEASE_NODE or RELEASE_COOKIE inside
bin/start, and then you run a command such as  `bin/release remote`,
we won't be able to connect to the running node.

This is addressed by introducing `release/RELEASE_VSN/env`
that will be invoked early in the release process. The goal of
this script is to set up environment variables.

This has the advantage of those variables being set per version,
instead of being shared across all releases, which gives us more
independence between versions.

By doing this change, we effectively remove the need for bin/start.
It is important to note that hot code swapping requires bin/start,
but those performing hot code swapping can add it manually.

Closes #8987.