### PR TITLE
Fix columns in tokenize of dot_call_op

### DIFF
--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -733,7 +733,7 @@ handle_dot([$., T | Rest], Line, Column, DotInfo, Scope, Tokens) when
 % ## Exception for .( as it needs to be treated specially in the parser
 handle_dot([$., $( | Rest], Line, Column, DotInfo, Scope, Tokens) ->
   TokensSoFar = add_token_with_eol({dot_call_op, DotInfo, '.'}, Tokens),
-  tokenize([$( | Rest], Line, Column + 2, Scope, TokensSoFar);
+  tokenize([$( | Rest], Line, Column, Scope, TokensSoFar);
 
 handle_dot([$., H | T] = Original, Line, Column, DotInfo, Scope, Tokens) when ?is_quote(H) ->
   case elixir_interpolation:extract(Line, Column + 1, Scope, true, T, H) of

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -140,6 +140,12 @@ dot_newline_operator_test() ->
    {identifier, {2, 1, nil}, '+'},
    {int, {2, 2, 1}, "1"}] = tokenize("foo.#bar\n+1").
 
+dot_call_operator_test() ->
+  [{identifier, {1, 1, nil}, f},
+   {dot_call_op, {1, 2, nil}, '.'},
+   {'(', {1, 3, nil}},
+   {')', {1, 4, nil}}] = tokenize("f.()").
+
 aliases_test() ->
   [{'alias', {1, 1, nil}, 'Foo'}] = tokenize("Foo"),
   [{'alias', {1, 1, nil}, 'Foo'},


### PR DESCRIPTION
`handle_dot` already gets the column of `(` from `strip_dot_space`.