### PR TITLE
Add defmodule/2 to default locals_without_parens list

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -77,6 +77,7 @@ defmodule Code.Formatter do
     defmacro: 2,
     defmacrop: 1,
     defmacrop: 2,
+    defmodule: 2,
     defdelegate: 2,
     defexception: 1,
     defoverridable: 1,


### PR DESCRIPTION
Closes https://github.com/elixir-lang/elixir/issues/9006

I'm not sure if this needs any additional test coverage. I couldn't find anything specific for the current list of Kernel macros.