### PR TITLE
Unify error handling and compiler deadlock checking

### DIFF
--- a/lib/elixir/lib/gen_event.ex
+++ b/lib/elixir/lib/gen_event.ex
@@ -324,14 +324,7 @@ defmodule GenEvent do
 
   def init_it(starter, parent, name, _mod, _args, options) do
     Process.put(:"$initial_call", {__MODULE__, :init_it, 6})
-
-    debug =
-      if function_exported?(:gen, :debug_options, 2) do
-        :gen.debug_options(name, options)
-      else
-        :gen.debug_options(options)
-      end
-
+    debug = :gen.debug_options(name, options)
     :proc_lib.init_ack(starter, {:ok, self()})
     loop(parent, name(name), [], debug, false)
   end

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -301,15 +301,22 @@ defmodule IO do
   """
   @spec warn(chardata | String.Chars.t(), Exception.stacktrace()) :: :ok
   def warn(message, []) do
-    :elixir_errors.io_warn(nil, nil, [to_chardata(message), ?\n])
+    message = [to_chardata(message), ?\n]
+    :elixir_errors.io_warn(nil, nil, message, message)
   end
 
   def warn(message, [{_, _, _, opts} | _] = stacktrace) do
+    message = to_chardata(message)
     formatted_trace = Enum.map_join(stacktrace, "\n  ", &Exception.format_stacktrace_entry(&1))
-    message = [to_chardata(message), ?\n, "  ", formatted_trace, ?\n]
     line = opts[:line]
     file = opts[:file]
-    :elixir_errors.io_warn(line, file && List.to_string(file), message)
+
+    :elixir_errors.io_warn(
+      line,
+      file && List.to_string(file),
+      message,
+      [message, ?\n, "  ", formatted_trace, ?\n]
+    )
   end
 
   @doc """

--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -114,7 +114,7 @@ defmodule Kernel.Utils do
   def announce_struct(module) do
     case :erlang.get(:elixir_compiler_pid) do
       :undefined -> :ok
-      pid -> send(pid, {:struct_available, module})
+      pid -> send(pid, {:available, :struct, module})
     end
   end
 

--- a/lib/elixir/src/elixir_aliases.erl
+++ b/lib/elixir/src/elixir_aliases.erl
@@ -99,7 +99,7 @@ ensure_loaded(Meta, Ref, E) ->
           end;
         false -> unloaded_module
       end,
-      elixir_errors:form_error(Meta, ?key(E, file), ?MODULE, {Kind, Ref})
+      elixir_errors:form_error(Meta, E, ?MODULE, {Kind, Ref})
   end.
 
 %% Receives an atom and returns the last bit as an alias.

--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -122,7 +122,7 @@ allows_fast_compilation(_) ->
 
 bootstrap() ->
   {ok, _} = application:ensure_all_started(elixir),
-  Update = fun(Old) -> maps:merge(Old, #{docs => false, relative_paths => false}) end,
+  Update = fun(Old) -> maps:merge(Old, #{docs => false, relative_paths => false, ignore_module_conflict => true}) end,
   _ = elixir_config:update(compiler_options, Update),
   _ = elixir_config:put(bootstrap, true),
   [bootstrap_file(File) || File <- bootstrap_main()].

--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -229,7 +229,7 @@ def_to_clauses(Kind, Meta, Args, Guards, Body, E) ->
     {do, _} ->
       [{Meta, Args, Guards, {'try', [{origin,  Kind} | Meta], [Body]}}];
     false ->
-      elixir_errors:form_error(Meta, ?key(E, file), elixir_expand, {missing_option, Kind, [do]})
+      elixir_errors:form_error(Meta, E, elixir_expand, {missing_option, Kind, [do]})
   end.
 
 run_on_definition_callbacks(Kind, Module, Name, Args, Guards, Body, E) ->
@@ -353,7 +353,7 @@ warn_bodiless_function(_Check, Meta, File, _Module, Kind, Tuple) ->
 
 check_args_for_function_head(Meta, Args, E) ->
   [begin
-     elixir_errors:form_error(Meta, ?key(E, file), ?MODULE, invalid_args_for_function_head)
+     elixir_errors:form_error(Meta, E, ?MODULE, invalid_args_for_function_head)
    end || Arg <- Args, invalid_arg(Arg)].
 
 invalid_arg({Name, _, Kind}) when is_atom(Name), is_atom(Kind) -> false;
@@ -363,7 +363,7 @@ check_previous_defaults(Meta, Module, Name, Arity, Kind, Defaults, E) ->
   {_Set, Bag} = elixir_module:data_tables(Module),
   Matches = ets:lookup(Bag, {default, Name}),
   [begin
-     elixir_errors:form_error(Meta, ?key(E, file), ?MODULE,
+     elixir_errors:form_error(Meta, E, ?MODULE,
        {defs_with_defaults, Kind, Name, Arity, A})
    end || {_, A, D} <- Matches, A /= Arity, D /= 0, defaults_conflict(A, D, Arity, Defaults)].
 

--- a/lib/elixir/src/elixir_env.erl
+++ b/lib/elixir/src/elixir_env.erl
@@ -105,7 +105,7 @@ merge_vars(V1, V2) ->
 %% UNUSED VARS
 
 check_unused_vars(#{unused_vars := Unused} = E) ->
-  [elixir_errors:form_warn([{line, Line}], ?key(E, file), ?MODULE, {unused_var, Name}) ||
+  [elixir_errors:form_warn([{line, Line}], E, ?MODULE, {unused_var, Name}) ||
     {{{Name, _}, _}, Line} <- maps:to_list(Unused), Line /= false, not_underscored(Name)],
   E.
 
@@ -141,7 +141,7 @@ merge_and_check_unused_vars(Unused, ClauseUnused, E) ->
             case not_underscored(Name) of
               true ->
                 Warn = {unused_var, Name},
-                elixir_errors:form_warn([{line, ClauseValue}], ?key(E, file), ?MODULE, Warn);
+                elixir_errors:form_warn([{line, ClauseValue}], E, ?MODULE, Warn);
 
               false ->
                 ok

--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -5,37 +5,50 @@
 %% the line number to be none (as it may happen in some erlang errors).
 -module(elixir_errors).
 -export([compile_error/3, compile_error/4,
-         form_error/4, form_warn/4, parse_error/4, erl_warn/3, io_warn/3]).
+         form_error/4, form_warn/4, parse_error/4, erl_warn/3, io_warn/4]).
 -include("elixir.hrl").
 
+%% Low-level warning, should be used only from Erlang passes.
 -spec erl_warn(non_neg_integer() | none, unicode:chardata(), unicode:chardata()) -> ok.
 erl_warn(none, File, Warning) ->
   erl_warn(0, File, Warning);
 erl_warn(Line, File, Warning) when is_integer(Line), is_binary(File) ->
-  send_warning(File, Line, Warning),
-  print_warning([Warning, "\n  ", file_format(Line, File), $\n]).
+  io_warn(Line, File, Warning, [Warning, "\n  ", file_format(Line, File), $\n]).
 
--spec io_warn(non_neg_integer() | nil, unicode:chardata() | nil, unicode:chardata()) -> ok.
-io_warn(Line, File, Message) when is_integer(Line) or (Line == nil), is_binary(File) or (File == nil) ->
-  send_warning(File, Line, Message),
-  print_warning(Message).
-
-warning_prefix() ->
-  case application:get_env(elixir, ansi_enabled) of
-    {ok, true} -> <<"\e[33mwarning: \e[0m">>;
-    _ -> <<"warning: ">>
-  end.
+%% Low-level warning, all other warnings are built on top of it.
+-spec io_warn(non_neg_integer() | nil, unicode:chardata() | nil, unicode:chardata(), unicode:chardata()) -> ok.
+io_warn(Line, File, LogMessage, PrintMessage) when is_integer(Line) or (Line == nil), is_binary(File) or (File == nil) ->
+  send_warning(Line, File, LogMessage),
+  print_warning(PrintMessage).
 
 %% General forms handling.
 
--spec form_error(list(), binary(), module(), any()) -> no_return().
+-spec form_error(list(), binary() | #{file := binary()}, module(), any()) -> no_return().
+form_error(Meta, #{file := File}, Module, Desc) ->
+  compile_error(Meta, File, Module:format_error(Desc));
 form_error(Meta, File, Module, Desc) ->
   compile_error(Meta, File, Module:format_error(Desc)).
 
--spec form_warn(list(), binary(), module(), any()) -> ok.
-form_warn(Meta, File, Module, Desc) when is_list(Meta) ->
-  {MetaFile, MetaLine} = meta_location(Meta, File),
-  erl_warn(MetaLine, MetaFile, Module:format_error(Desc)).
+-spec form_warn(list(), binary() | #{file := binary()}, module(), any()) -> ok.
+form_warn(Meta, File, Module, Desc) when is_list(Meta), is_binary(File) ->
+  do_form_warn(Meta, File, #{}, Module:format_error(Desc));
+form_warn(Meta, #{file := File} = E, Module, Desc) when is_list(Meta) ->
+  do_form_warn(Meta, File, E, Module:format_error(Desc)).
+
+do_form_warn(Meta, GivenFile, E, Warning) ->
+  {File, Line} = meta_location(Meta, GivenFile),
+
+  Location =
+    case E of
+      #{function := {Name, Arity}, module := Module} ->
+        [file_format(Line, File), ": ", 'Elixir.Exception':format_mfa(Module, Name, Arity)];
+      #{module := Module} when Module /= nil ->
+        [file_format(Line, File), ": ", elixir_aliases:inspect(Module)];
+      #{} ->
+        file_format(Line, File)
+    end,
+
+  io_warn(Line, File, Warning, [Warning, "\n  ", Location, $\n]).
 
 %% Compilation error.
 
@@ -47,8 +60,7 @@ compile_error(Meta, File, Message) when is_binary(Message) ->
   raise(MetaLine, MetaFile, 'Elixir.CompileError', Message);
 compile_error(Meta, File, Message) when is_list(Message) ->
   {MetaFile, MetaLine} = meta_location(Meta, File),
-  raise(MetaLine, MetaFile, 'Elixir.CompileError',
-        elixir_utils:characters_to_binary(Message)).
+  raise(MetaLine, MetaFile, 'Elixir.CompileError', elixir_utils:characters_to_binary(Message)).
 
 compile_error(Meta, File, Format, Args) when is_list(Format)  ->
   compile_error(Meta, File, io_lib:format(Format, Args)).
@@ -114,11 +126,17 @@ parse_erl_term(Term) ->
 
 %% Helpers
 
+warning_prefix() ->
+  case application:get_env(elixir, ansi_enabled) of
+    {ok, true} -> <<"\e[33mwarning: \e[0m">>;
+    _ -> <<"warning: ">>
+  end.
+
 print_warning(Message) ->
   io:put_chars(standard_error, [warning_prefix(), Message, $\n]),
   ok.
 
-send_warning(File, Line, Message) ->
+send_warning(Line, File, Message) ->
   CompilerPid = get(elixir_compiler_pid),
   if
     CompilerPid =/= undefined ->

--- a/lib/elixir/src/elixir_import.erl
+++ b/lib/elixir/src/elixir_import.erl
@@ -38,7 +38,7 @@ import_macros(Force, Meta, Ref, Opts, E) ->
       {ok, Macros} ->
         Macros;
       error when Force ->
-        elixir_errors:form_error(Meta, ?key(E, file), ?MODULE, {no_macros, Ref});
+        elixir_errors:form_error(Meta, E, ?MODULE, {no_macros, Ref});
       error ->
         []
     end

--- a/lib/elixir/src/elixir_overridable.erl
+++ b/lib/elixir/src/elixir_overridable.erl
@@ -44,7 +44,7 @@ super(Meta, Module, Tuple, E) ->
     [Overridable] ->
       store(Set, Module, Tuple, Overridable, true);
     [] ->
-      elixir_errors:form_error(Meta, ?key(E, file), ?MODULE, {no_super, Module, Tuple})
+      elixir_errors:form_error(Meta, E, ?MODULE, {no_super, Module, Tuple})
   end.
 
 store_not_overriden(Module) ->

--- a/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
+++ b/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
@@ -219,12 +219,12 @@ defmodule Kernel.ParallelCompilerTest do
           "parallel_ensure_nodeadlock",
           foo: """
           defmodule FooCircular do
-            {:error, :deadlock} = Code.ensure_compiled(BarCircular)
+            {:error, _} = Code.ensure_compiled(BarCircular)
           end
           """,
           bar: """
           defmodule BarCircular do
-            {:error, :deadlock} = Code.ensure_compiled(FooCircular)
+            {:error, _} = Code.ensure_compiled(FooCircular)
           end
           """
         )

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -515,9 +515,11 @@ defmodule Mix.Compilers.Elixir do
         split_manifest(data, compile_path)
 
       [v | data] when is_integer(v) ->
-        for module <- data,
-            is_record(module, :module),
-            do: File.rm(Path.join(compile_path, module(module, :beam)))
+        for module <- data, is_record(module, :module) do
+          File.rm(Path.join(compile_path, module(module, :beam)))
+          :code.purge(module(module, :module))
+          :code.delete(module(module, :module))
+        end
 
         {[], []}
 

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -452,15 +452,13 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       # First compilation should print unused variable warning
       import ExUnit.CaptureIO
 
-      output =
-        capture_io(:standard_error, fn ->
-          Mix.Tasks.Compile.Elixir.run([]) == :ok
-        end)
+      assert capture_io(:standard_error, fn ->
+               Mix.Tasks.Compile.Elixir.run([]) == :ok
+             end) =~ "variable \"unused\" is unused"
 
-      # Should also print warning
       assert capture_io(:standard_error, fn ->
                Mix.Tasks.Compile.Elixir.run(["--all-warnings"])
-             end) == output
+             end) =~ "variable \"unused\" is unused"
 
       # Should not print warning once fixed
       File.write!("lib/a.ex", """


### PR DESCRIPTION
This makes it so we also include the `function/arity` in the
warnings stacktraces and makes the compiler more deterministic.