### PR TITLE
Add example for Path.dirname/1

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -401,6 +401,9 @@ defmodule Path do
       iex> Path.dirname("/foo/bar/")
       "/foo/bar"
 
+      iex> Path.dirname("bar.ex")
+      "."
+
   """
   @spec dirname(t) :: binary
   def dirname(path) do


### PR DESCRIPTION
Found this out while debugging, thought it would be nice to mention this in the docs.