### PR TITLE
Use parens in IO.puts/1 calls around the codebase

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1819,15 +1819,15 @@ defmodule Kernel.SpecialForms do
         do_something_that_may_fail(some_arg)
       rescue
         ArgumentError ->
-          IO.puts "Invalid argument given"
+          IO.puts("Invalid argument given")
       catch
         value ->
-          IO.puts "Caught #{inspect(value)}"
+          IO.puts("Caught #{inspect(value)}")
       else
         value ->
-          IO.puts "Success! The result was #{inspect(value)}"
+          IO.puts("Success! The result was #{inspect(value)}")
       after
-        IO.puts "This is printed regardless if it failed or succeeded"
+        IO.puts("This is printed regardless if it failed or succeeded")
       end
 
   The `rescue` clause is used to handle exceptions while the `catch`
@@ -1922,7 +1922,7 @@ defmodule Kernel.SpecialForms do
         throw(:some_value)
       catch
         thrown_value ->
-          IO.puts "A value was thrown: #{inspect(thrown_value)}"
+          IO.puts("A value was thrown: #{inspect(thrown_value)}")
       end
 
   ### Catching values of any kind
@@ -1935,14 +1935,14 @@ defmodule Kernel.SpecialForms do
         exit(:shutdown)
       catch
         :exit, value ->
-          IO.puts "Exited with value #{inspect(value)}"
+          IO.puts("Exited with value #{inspect(value)}")
       end
 
       try do
         exit(:shutdown)
       catch
         kind, value when kind in [:exit, :throw] ->
-          IO.puts "Caught exit or throw with value #{inspect(value)}"
+          IO.puts("Caught exit or throw with value #{inspect(value)}")
       end
 
   The `catch` clause also supports `:error` alongside `:exit` and `:throw` as
@@ -2114,7 +2114,7 @@ defmodule Kernel.SpecialForms do
         name when is_atom(name) ->
           name
         _ ->
-          IO.puts :stderr, "Unexpected message received"
+          IO.puts(:stderr, "Unexpected message received")
       end
 
   An optional `after` clause can be given in case the message was not
@@ -2126,10 +2126,10 @@ defmodule Kernel.SpecialForms do
         name when is_atom(name) ->
           name
         _ ->
-          IO.puts :stderr, "Unexpected message received"
+          IO.puts(:stderr, "Unexpected message received")
       after
         5000 ->
-          IO.puts :stderr, "No message in 5 seconds"
+          IO.puts(:stderr, "No message in 5 seconds")
       end
 
   The `after` clause can be specified even if there are no match clauses.

--- a/lib/elixir/pages/Writing Documentation.md
+++ b/lib/elixir/pages/Writing Documentation.md
@@ -32,7 +32,7 @@ Documentation in Elixir is usually attached to module attributes. Let's see an e
       """
       @doc since: "1.3.0"
       def world(name) do
-        IO.puts "hello #{name}"
+        IO.puts("hello #{name}")
       end
     end
 

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -106,8 +106,8 @@ defmodule Mix.Tasks.Release do
   If you want to invoke specific modules and functions in your release,
   you can do so in two ways: using `eval` or `rpc`.
 
-      bin/RELEASE_NAME eval "IO.puts :hello"
-      bin/RELEASE_NAME rpc "IO.puts :hello"
+      bin/RELEASE_NAME eval "IO.puts(:hello)"
+      bin/RELEASE_NAME rpc "IO.puts(:hello)"
 
   The `eval` command starts its own instance of the VM but without
   starting any of the applications in the release and without starting

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -42,7 +42,7 @@ defmodule Mix.CLITest do
         @shortdoc "Says hello"
 
         def run(_) do
-          IO.puts Mix.Project.get!.hello_world
+          IO.puts(Mix.Project.get!().hello_world())
           Mix.shell.info("This won't appear")
           Mix.raise("oops")
         end

--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -308,7 +308,7 @@ defmodule Mix.Tasks.EscriptTest do
       File.write!("lib/git_repo.ex", """
       defmodule GitRepo do
         def main(_argv) do
-          IO.puts "TEST"
+          IO.puts("TEST")
         end
       end
       """)

--- a/lib/mix/test/mix/tasks/run_test.exs
+++ b/lib/mix/test/mix/tasks/run_test.exs
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.RunTest do
   test "loads configuration", context do
     in_tmp(context.test, fn ->
       config = fixture_path("configs/good_config.exs")
-      expr = "IO.puts Application.get_env(:my_app, :key)"
+      expr = "IO.puts(Application.get_env(:my_app, :key))"
 
       output =
         capture_io(:stderr, fn ->


### PR DESCRIPTION
There were instances of `IO.puts/1` calls without parens throughout the whole codebase (in docs, code, tests). I removed most of them where it made sense to do so, so that users will find documentation and other things consistent with how the formatter behaves.