### PR TITLE
Translate process crash on node

### DIFF
--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -126,6 +126,19 @@ defmodule Logger.Translator do
 
         {:ok, msg, metadata}
 
+      {'Error in process ' ++ _, [pid, node, {reason, stack}]} ->
+        reason = Exception.normalize(:error, reason, stack)
+
+        msg = [
+          "Process ",
+          inspect(pid),
+          " on node ",
+          inspect(node),
+          " raised an exception" | format(:error, reason, stack)
+        ]
+
+        {:ok, msg, [crash_reason: exit_reason(:error, reason, stack)]}
+
       {'Error in process ' ++ _, [pid, {reason, stack}]} ->
         reason = Exception.normalize(:error, reason, stack)
         msg = ["Process ", inspect(pid), " raised an exception" | format(:error, reason, stack)]

--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -981,6 +981,19 @@ defmodule Logger.TranslatorTest do
     assert {:stop, [_ | _]} = process_metadata[:crash_reason]
   end
 
+  test "translates process crash with erts" do
+    assert {:ok, msg, meta} =
+             Logger.Translator.translate(
+               :error,
+               :error,
+               :format,
+               {'Error in process ~p on node ~p with exit value:~n~p~n',
+                [self(), :"name@127.0.0.1", {:badarith, [{:erlang, :/, [1, 0], []}]}]}
+             )
+
+    assert Keyword.get(meta, :crash_reason)
+  end
+
   test "reports :undefined MFA properly" do
     defmodule WeirdFunctionNamesGenServer do
       use GenServer


### PR DESCRIPTION
Background on this is that a user of the `sentry` library was seeing a difference in behaviour of reported process crashes when running an application as a Distillery release vs. `iex -S mix` (https://github.com/getsentry/sentry-elixir/issues/337)

Sentry implements a Logger backend, but wasn't receiving events with `:crash_reason` metadata for the process crash running a Distillery release.  After some digging and reaching some of the limits of my current understanding, it appears that Erlang prints a different message format with erts, as seen here?
https://github.com/erlang/otp/blob/master/erts/emulator/beam/beam_emu.c#L1591-L1594

```c
int alive = erts_is_alive;
erts_dsprintf_buf_t *dsbufp = erts_create_logger_dsbuf();

erts_dsprintf(dsbufp, "Error in process ~p ");
if (alive)
    erts_dsprintf(dsbufp, "on node ~p ");
erts_dsprintf(dsbufp, "with exit value:~n~p~n");
```

I think ultimately it leads to not matching in the `Logger.Translator`, since it ends up with an extra formatted argument, and a format of:

```erlang
 "Error in process ~p on node ~p with exit value:~n~p~n"
```

I tested my patched version and then things behaved as expected, but I was not sure on the best way to test with the erts stuff involved.