### PR TITLE
Allow developers to choose between sname and name in releases

### DIFF
--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -253,6 +253,7 @@ defmodule Kernel.CLI do
   end
 
   defp parse_shared(["--rpc-eval", node, h | t], config) do
+    node = append_hostname(node)
     parse_shared(t, %{config | commands: [{:rpc_eval, node, h} | config.commands]})
   end
 
@@ -266,6 +267,13 @@ defmodule Kernel.CLI do
 
   defp parse_shared(list, config) do
     {list, config}
+  end
+
+  defp append_hostname(node) do
+    case :string.find(node, "@") do
+      :nomatch -> node <> :string.find(Atom.to_string(node()), "@")
+      _ -> node
+    end
   end
 
   defp expand_code_path(path) do

--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -74,6 +74,11 @@ defmodule Kernel.CLI.RPCTest do
     assert rpc_eval("IO.puts :ok") == "ok\n"
   end
 
+  test "invokes command on remote node without host" do
+    node = "cli-rpc#{System.unique_integer()}"
+    assert elixir('--name #{node}@127.0.0.1 --rpc-eval #{node} "IO.puts :ok"') == "ok\n"
+  end
+
   test "properly formats errors" do
     assert String.starts_with?(rpc_eval(":erlang.throw 1"), "** (throw) 1")
     assert String.starts_with?(rpc_eval(":erlang.error 1"), "** (ErlangError) Erlang error: 1")

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -626,8 +626,8 @@ defmodule Mix.Tasks.Release do
       Using `name` (long names) or `sname` (short names). Defaults to
       `sname` which allows access only within the current system.
       `name` allows external connections. If `name` is used and you are
-      running on a version earlier than Erlang/OTP 22+, you must set
-      `RELEASE_NODE` to `RELEASE_NAME@127.0.0.1` or another appropriate host
+      not running on Erlang/OTP 22 or later, you must set `RELEASE_NODE`
+      to `RELEASE_NAME@127.0.0.1` with an IP or a known host
 
   ## Umbrellas
 

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -622,6 +622,13 @@ defmodule Mix.Tasks.Release do
       files to. It can be set to a custom directory. It defaults to
       `$RELEASE_ROOT/tmp`
 
+    * `RELEASE_DISTRIBUTION` - how do we want to run the distribution.
+      Using `name` or `sname` (short names). Defaults to `sname` which
+      allows access only within the current system. `name` allows external
+      connections. If `name` is used and you are running on a version
+      earlier than Erlang/OTP 22+, you must set `RELEASE_NODE` to
+      `RELEASE_NODE=RELEASE_NAME@127.0.0.1` or another appropriate host
+
   ## Umbrellas
 
   Releases are well integrated with umbrella projects, allowing you to

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -623,11 +623,11 @@ defmodule Mix.Tasks.Release do
       `$RELEASE_ROOT/tmp`
 
     * `RELEASE_DISTRIBUTION` - how do we want to run the distribution.
-      Using `name` or `sname` (short names). Defaults to `sname` which
-      allows access only within the current system. `name` allows external
-      connections. If `name` is used and you are running on a version
-      earlier than Erlang/OTP 22+, you must set `RELEASE_NODE` to
-      `RELEASE_NODE=RELEASE_NAME@127.0.0.1` or another appropriate host
+      Using `name` (long names) or `sname` (short names). Defaults to
+      `sname` which allows access only within the current system.
+      `name` allows external connections. If `name` is used and you are
+      running on a version earlier than Erlang/OTP 22+, you must set
+      `RELEASE_NODE` to `RELEASE_NAME@127.0.0.1` or another appropriate host
 
   ## Umbrellas
 

--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -252,7 +252,7 @@ defmodule Mix.Tasks.Release.Init do
     call !REL_VSN_DIR!/env.bat
 
     if not defined RELEASE_COOKIE (set /p RELEASE_COOKIE=<!RELEASE_ROOT!\releases\COOKIE)
-    if not defined RELEASE_NODE (set RELEASE_NODE=!RELEASE_NAME!@127.0.0.1)
+    if not defined RELEASE_NODE (set RELEASE_NODE=!RELEASE_NAME!)
     if not defined RELEASE_TMP (set RELEASE_TMP=!RELEASE_ROOT!\tmp)
     if not defined RELEASE_VM_ARGS (set RELEASE_VM_ARGS=!REL_VSN_DIR!\vm.args)
     if not defined RELEASE_DISTRIBUTION (set RELEASE_DISTRIBUTION=sname)

--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -71,7 +71,7 @@ defmodule Mix.Tasks.Release.Init do
 
     # Set the release to work across nodes
     # export RELEASE_DISTRIBUTION=name
-    # export RELEASE_NAME=<%= @release.name %>@127.0.0.1
+    # export RELEASE_NODE=<%= @release.name %>@127.0.0.1
     """
 
   @doc false
@@ -231,7 +231,7 @@ defmodule Mix.Tasks.Release.Init do
     @echo off
     rem Set the release to work across nodes
     rem set RELEASE_DISTRIBUTION=name
-    rem set RELEASE_NAME=<%= @release.name %>@127.0.0.1
+    rem set RELEASE_NODE=<%= @release.name %>@127.0.0.1
     """
 
   @doc false

--- a/lib/mix/test/mix/tasks/release_test.exs
+++ b/lib/mix/test/mix/tasks/release_test.exs
@@ -4,6 +4,9 @@ defmodule Mix.Tasks.ReleaseTest do
   use MixTest.Case
 
   @erts_version :erlang.system_info(:version)
+  @hostname :inet_db.gethostname()
+
+  defmacrop release_node(name), do: :"#{name}@#{@hostname}"
 
   describe "customize" do
     test "rel with eex" do
@@ -127,10 +130,10 @@ defmodule Mix.Tasks.ReleaseTest do
         assert %{
                  app_dir: app_dir,
                  cookie_env: ^cookie,
-                 node: :"release_test@127.0.0.1",
+                 node: release_node("release_test"),
                  protocols_consolidated?: true,
                  release_name: "release_test",
-                 release_node: "release_test@127.0.0.1",
+                 release_node: "release_test",
                  release_root: release_root,
                  release_vsn: "0.1.0",
                  root_dir: root_dir,
@@ -185,10 +188,10 @@ defmodule Mix.Tasks.ReleaseTest do
         open_port(Path.join(root, "bin/runtime_config"), ['start'])
 
         assert %{
-                 node: :"runtime_config@127.0.0.1",
+                 node: release_node("runtime_config"),
                  protocols_consolidated?: true,
                  release_name: "runtime_config",
-                 release_node: "runtime_config@127.0.0.1",
+                 release_node: "runtime_config",
                  release_vsn: "0.1.0",
                  static_config: {:ok, :was_set},
                  runtime_config: {:ok, :was_set},
@@ -235,10 +238,10 @@ defmodule Mix.Tasks.ReleaseTest do
         assert %{
                  app_dir: app_dir,
                  cookie_env: "abcdefghijk",
-                 node: :"demo@127.0.0.1",
+                 node: release_node("demo"),
                  protocols_consolidated?: true,
                  release_name: "demo",
-                 release_node: "demo@127.0.0.1",
+                 release_node: "demo",
                  release_root: release_root,
                  release_vsn: "0.2.0",
                  root_dir: root_dir,
@@ -303,7 +306,7 @@ defmodule Mix.Tasks.ReleaseTest do
                  node: :nonode@nohost,
                  protocols_consolidated?: true,
                  release_name: "eval",
-                 release_node: "eval@127.0.0.1",
+                 release_node: "eval",
                  release_root: root,
                  release_vsn: "0.1.0",
                  static_config: {:ok, :was_set},
@@ -328,10 +331,10 @@ defmodule Mix.Tasks.ReleaseTest do
         assert wait_until_evaled(Path.join(root, "RELEASE_BOOTED")) == %{
                  app_dir: Path.join(root, "lib/release_test-0.1.0"),
                  cookie_env: "abcdefghij",
-                 node: :"permanent2@127.0.0.1",
+                 node: :"permanent2@#{@hostname}",
                  protocols_consolidated?: true,
                  release_name: "permanent2",
-                 release_node: "permanent2@127.0.0.1",
+                 release_node: "permanent2",
                  release_root: root,
                  release_vsn: "0.1.0",
                  root_dir: :code.root_dir() |> to_string(),
@@ -343,7 +346,7 @@ defmodule Mix.Tasks.ReleaseTest do
 
         assert wait_until(fn ->
                  File.read!(Path.join(root, "tmp/log/erlang.log.1")) =~
-                   "iex(permanent2@127.0.0.1)1> "
+                   "iex(permanent2@#{@hostname})1> "
                end)
 
         assert System.cmd(script, ["rpc", "ReleaseTest.hello_world"]) == {"hello world\n", 0}


### PR DESCRIPTION
We default to --sname which provides safer security defaults.

/cc @tsloughter @wojtekmach 