### PR TITLE
Make it possible to disable regex precompilation.

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4995,13 +4995,26 @@ defmodule Kernel do
 
   defmacro sigil_r({:<<>>, _meta, [string]}, options) when is_binary(string) do
     binary = :elixir_interpolation.unescape_chars(string, &Regex.unescape_map/1)
-    regex = Regex.compile!(binary, :binary.list_to_bin(options))
+    bin_options = :binary.list_to_bin(options)
+
+    regex = case Mix.Project.config()[:plain_regex] do
+      true ->
+        Regex.compile_plain!(binary, bin_options)
+      _ ->
+        Regex.compile!(binary, bin_options)
+    end
     Macro.escape(regex)
   end
 
   defmacro sigil_r({:<<>>, meta, pieces}, options) do
     binary = {:<<>>, meta, unescape_tokens(pieces, &Regex.unescape_map/1)}
-    quote(do: Regex.compile!(unquote(binary), unquote(:binary.list_to_bin(options))))
+    bin_options = :binary.list_to_bin(options)
+    case Mix.Project.config()[:plain_regex] do
+      true ->
+        quote(do: Regex.compile_plain!(unquote(binary), unquote(bin_options)))
+      _ ->
+        quote(do: Regex.compile!(unquote(binary), unquote(bin_options)))
+    end
   end
 
   @doc ~S"""
@@ -5021,7 +5034,13 @@ defmodule Kernel do
   defmacro sigil_R(term, modifiers)
 
   defmacro sigil_R({:<<>>, _meta, [string]}, options) when is_binary(string) do
-    regex = Regex.compile!(string, :binary.list_to_bin(options))
+    bin_options = :binary.list_to_bin(options)
+    regex = case Mix.Project.config()[:plain_regex] do
+      true ->
+        Regex.compile_plain!(string, bin_options)
+      _ ->
+        Regex.compile!(string, bin_options)
+    end
     Macro.escape(regex)
   end
 


### PR DESCRIPTION
## Current state of things

By default regex strings are compiled on code compilation stage.
This makes it harder to produce packages which would work with different
erlang versions and on different platforms.
Also the runtime prints a warning message, when starting, if code is running
on a system with different endianness. This can make users anxious.

This can be solved on the code level by recompiling regexes in runtime, but
that requires code hygiene, which may be harder to maintain and also does not
protect from regexes in dependencies.

## Proposal

This pull requests proposes to have a build configuration, which will
disable regex precompilation by having a plain binary in the `re_pattern` field of regex structure.

Binary works well with `re` functions, all except `inspect`, so there is not
that much changes required.

## Open questions

I wonder if there is a way to mark the code package containing precompiled
regexes to print or suppress the endiannes warning?

I specify the setting in `Mix.Project.config`, but this may not be the best place to do that. Is there a way to pass build configuration to dependencies?

I'm fully open to any corrections and requests regarding the code, as long as the solution works.

TODO:

Tests and docs.