### PR TITLE
Do not allow defmodule with special atoms

### DIFF
--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -54,6 +54,8 @@ next_counter(Module) ->
 
 %% Compilation hook
 
+compile(Module, _Block, _Vars, #{line := Line, file := File}) when Module == nil; is_boolean(Module) ->
+  elixir_errors:form_error([{line, Line}], File, ?MODULE, {invalid_module, Module});
 compile(Module, Block, Vars, #{line := Line} = Env) when is_atom(Module) ->
   %% In case we are generating a module from inside a function,
   %% we get rid of the lexical tracker information as, at this

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -627,6 +627,20 @@ defmodule KernelTest do
     end
   end
 
+  describe "defmodule" do
+    test "does not accept special atoms as module names" do
+      special_atoms = [nil, true, false]
+
+      Enum.each(special_atoms, fn special_atom ->
+        msg = ~r"invalid module name: #{inspect(special_atom)}"
+
+        assert_raise CompileError, msg, fn ->
+          defmodule special_atom, do: :ok
+        end
+      end)
+    end
+  end
+
   describe "access" do
     defmodule StructAccess do
       defstruct [:foo, :bar]


### PR DESCRIPTION
Follow up on #9030

```elixir
 defmodule true do end
** (CompileError) iex:1: invalid module name: true
    (stdlib) erl_eval.erl:680: :erl_eval.do_apply/6
    (iex) lib/iex/evaluator.ex:257: IEx.Evaluator.handle_eval/5
    (iex) lib/iex/evaluator.ex:237: IEx.Evaluator.do_eval/3
    (iex) lib/iex/evaluator.ex:215: IEx.Evaluator.eval/3
    (iex) lib/iex/evaluator.ex:103: IEx.Evaluator.loop/1
    (iex) lib/iex/evaluator.ex:27: IEx.Evaluator.init/4
```