### PR TITLE
Add `--app` opt to `mix test`

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -148,6 +148,8 @@ defmodule Mix.Tasks.Test do
 
   ## Command line options
 
+    * `--app` - runs test only on specified app(s). May specify multiple apps with
+      multiple `--app` flags.
     * `--color` - enables color in the output
     * `--cover` - runs coverage tool. See "Coverage" section below
     * `--exclude` - excludes tests that match the filter
@@ -296,6 +298,7 @@ defmodule Mix.Tasks.Test do
   """
 
   @switches [
+    app: :keep,
     force: :boolean,
     color: :boolean,
     cover: :boolean,
@@ -326,7 +329,16 @@ defmodule Mix.Tasks.Test do
   @impl true
   def run(args) do
     {opts, files} = OptionParser.parse!(args, strict: @switches)
+    apps = Keyword.get_values(opts, :app)
 
+    if apps == [] or Atom.to_string(Mix.Project.config()[:app]) in apps do
+      run(args, opts, files)
+    else
+      :ok
+    end
+  end
+
+  defp run(args, opts, files) do
     if opts[:listen_on_stdin] do
       System.at_exit(fn _ ->
         IO.gets(:stdio, "")

--- a/lib/mix/test/fixtures/umbrella_app/apps/bar/lib/bar.ex
+++ b/lib/mix/test/fixtures/umbrella_app/apps/bar/lib/bar.ex
@@ -1,0 +1,13 @@
+defmodule Bar do
+  def hello do
+    :world
+  end
+end
+
+defprotocol Bar.Protocol do
+  def to_uppercase(string)
+end
+
+defimpl Bar.Protocol, for: BitString do
+  def to_uppercase(string), do: String.upcase(string)
+end

--- a/lib/mix/test/fixtures/umbrella_app/apps/bar/mix.exs
+++ b/lib/mix/test/fixtures/umbrella_app/apps/bar/mix.exs
@@ -1,0 +1,13 @@
+defmodule Bar.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :bar,
+      version: "0.1.0",
+      # Choose something besides *_test.exs so that these test files don't
+      # get accidentally swept up into the actual Mix test suite.
+      test_pattern: "*_tests.exs"
+    ]
+  end
+end

--- a/lib/mix/test/fixtures/umbrella_app/apps/bar/test/bar_tests.exs
+++ b/lib/mix/test/fixtures/umbrella_app/apps/bar/test/bar_tests.exs
@@ -1,0 +1,8 @@
+defmodule BarTest do
+  use ExUnit.Case
+
+  test "greets the world" do
+    assert Bar.hello() == :world
+    assert Bar.Protocol.to_uppercase("foo") == "FOO"
+  end
+end

--- a/lib/mix/test/fixtures/umbrella_app/apps/bar/test/test_helper.exs
+++ b/lib/mix/test/fixtures/umbrella_app/apps/bar/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/lib/mix/test/fixtures/umbrella_app/apps/foo/lib/foo.ex
+++ b/lib/mix/test/fixtures/umbrella_app/apps/foo/lib/foo.ex
@@ -1,0 +1,5 @@
+defmodule Foo do
+  def hello do
+    :world
+  end
+end

--- a/lib/mix/test/fixtures/umbrella_app/apps/foo/mix.exs
+++ b/lib/mix/test/fixtures/umbrella_app/apps/foo/mix.exs
@@ -1,0 +1,13 @@
+defmodule Foo.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :foo,
+      version: "0.1.0",
+      # Choose something besides *_test.exs so that these test files don't
+      # get accidentally swept up into the actual Mix test suite.
+      test_pattern: "*_tests.exs"
+    ]
+  end
+end

--- a/lib/mix/test/fixtures/umbrella_app/apps/foo/test/foo_tests.exs
+++ b/lib/mix/test/fixtures/umbrella_app/apps/foo/test/foo_tests.exs
@@ -1,0 +1,7 @@
+defmodule FooTest do
+  use ExUnit.Case
+
+  test "greets the world" do
+    assert Foo.hello() == :world
+  end
+end

--- a/lib/mix/test/fixtures/umbrella_app/apps/foo/test/test_helper.exs
+++ b/lib/mix/test/fixtures/umbrella_app/apps/foo/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/lib/mix/test/fixtures/umbrella_app/mix.exs
+++ b/lib/mix/test/fixtures/umbrella_app/mix.exs
@@ -1,0 +1,9 @@
+defmodule UmbrellaCover.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      apps_path: "apps"
+    ]
+  end
+end

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -152,6 +152,28 @@ defmodule Mix.Tasks.TestTest do
     end)
   end
 
+  test "--app: only runs specified app" do
+    in_fixture("umbrella_app", fn ->
+      output = mix(["test", "--app", "foo"])
+      # Runs foo
+      assert output =~ "==> foo\n.\n\nFinished in"
+
+      # Doesn't run bar
+      refute output =~ "==> bar\n.\n\nFinished in"
+    end)
+  end
+
+  test "--app: runs multiple specified apps" do
+    in_fixture("umbrella_app", fn ->
+      output = mix(["test", "--app", "foo", "--app", "bar"])
+      # Runs foo
+      assert output =~ "==> foo\n.\n\nFinished in"
+
+      # Runs bar
+      assert output =~ "==> bar\n.\n\nFinished in"
+    end)
+  end
+
   test "--failed: loads only files with failures and runs just the failures" do
     in_fixture("test_failed", fn ->
       loading_only_passing_test_msg = "loading OnlyPassingTest"


### PR DESCRIPTION
When included, only runs tests for specified apps.
Supports multiple entries.
Modeled after `mix cmd --app`.

Open to suggestions for how to test this functionality.