### PR TITLE
Make regexes fall back to binary matching on incompatible runtime version

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -136,9 +136,10 @@ defmodule Regex do
   host (via `mix releases` or similar) with a matching OTP, OS and architecture
   as as the target.
 
-  However, if you find yourself in a scenario where cross-compilation is
-  necessary, you can manually invoke `Regex.recompile/1` or `Regex.recompile!/1`
-  to perform a runtime version check and recompile the regex if necessary.
+  If you know you are running on a different system that the current one AND
+  you are doing multiple matches with the regex, you can manually invoke
+  `Regex.recompile/1` or `Regex.recompile!/1` to perform a runtime version
+  check and recompile the regex if necessary.
   """
 
   defstruct re_pattern: nil, source: "", opts: "", re_version: ""

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -128,11 +128,11 @@ defmodule Regex do
   ## Precompilation
 
   Regular expressions built with sigil are precompiled and stored in `.beam`
-  files. Precompiled regexes are not guaranteed to be compatible between OSes
-  and OTP releases. This is rarely a problem, as most Elixir code shared
-  during development is compiled on the target (such as dependencies, archives,
-  and escripts) and, when running in production, the code must either be
-  compiled on the target (via `mix compile` or similar) or released on the
+  files. Precompiled regexes will be checked in runtime and may work slower
+  between OSes and OTP releases. This is rarely a problem, as most Elixir code
+  shared during development is compiled on the target (such as dependencies,
+  archives, and escripts) and, when running in production, the code must either
+  be compiled on the target (via `mix compile` or similar) or released on the
   host (via `mix releases` or similar) with a matching OTP, OS and architecture
   as as the target.
 
@@ -264,8 +264,8 @@ defmodule Regex do
 
   """
   @spec match?(t, String.t()) :: boolean
-  def match?(%Regex{re_pattern: compiled}, string) when is_binary(string) do
-    :re.run(string, compiled, [{:capture, :none}]) == :match
+  def match?(%Regex{} = regex, string) when is_binary(string) do
+    safe_run(regex, string, [{:capture, :none}]) == :match
   end
 
   @doc """
@@ -312,11 +312,11 @@ defmodule Regex do
   @spec run(t, binary, [term]) :: nil | [binary] | [{integer, integer}]
   def run(regex, string, options \\ [])
 
-  def run(%Regex{re_pattern: compiled}, string, options) when is_binary(string) do
+  def run(%Regex{} = regex, string, options) when is_binary(string) do
     return = Keyword.get(options, :return, :binary)
     captures = Keyword.get(options, :capture, :all)
 
-    case :re.run(string, compiled, [{:capture, captures, return}]) do
+    case safe_run(regex, string, [{:capture, captures, return}]) do
       :nomatch -> nil
       :match -> []
       {:match, results} -> results
@@ -397,7 +397,17 @@ defmodule Regex do
 
   """
   @spec names(t) :: [String.t()]
-  def names(%Regex{re_pattern: re_pattern}) do
+  def names(%Regex{re_pattern: compiled, re_version: version, source: source}) do
+    re_pattern =
+      case version() do
+        ^version ->
+          compiled
+
+        _ ->
+          {:ok, recompiled} = :re.compile(source)
+          recompiled
+      end
+
     {:namelist, names} = :re.inspect(re_pattern, :namelist)
     names
   end
@@ -437,15 +447,26 @@ defmodule Regex do
   @spec scan(t, String.t(), [term]) :: [[String.t()]]
   def scan(regex, string, options \\ [])
 
-  def scan(%Regex{re_pattern: compiled}, string, options) when is_binary(string) do
+  def scan(%Regex{} = regex, string, options) when is_binary(string) do
     return = Keyword.get(options, :return, :binary)
     captures = Keyword.get(options, :capture, :all)
     options = [{:capture, captures, return}, :global]
 
-    case :re.run(string, compiled, options) do
+    case safe_run(regex, string, options) do
       :match -> []
       :nomatch -> []
       {:match, results} -> results
+    end
+  end
+
+  defp safe_run(
+         %Regex{re_pattern: compiled, source: source, re_version: version},
+         string,
+         options
+       ) do
+    case version() do
+      ^version -> :re.run(string, compiled, options)
+      _ -> :re.run(string, source, options)
     end
   end
 
@@ -508,11 +529,11 @@ defmodule Regex do
     end
   end
 
-  def split(%Regex{re_pattern: compiled}, string, opts)
+  def split(%Regex{} = regex, string, opts)
       when is_binary(string) and is_list(opts) do
     on = Keyword.get(opts, :on, :first)
 
-    case :re.run(string, compiled, [:global, capture: on]) do
+    case safe_run(regex, string, [:global, capture: on]) do
       {:match, matches} ->
         index = parts_to_index(Keyword.get(opts, :parts, :infinity))
         trim = Keyword.get(opts, :trim, false)
@@ -634,11 +655,11 @@ defmodule Regex do
     do_replace(regex, string, {replacement, arity}, options)
   end
 
-  defp do_replace(%Regex{re_pattern: compiled}, string, replacement, options) do
+  defp do_replace(%Regex{} = regex, string, replacement, options) do
     opts = if Keyword.get(options, :global) != false, do: [:global], else: []
     opts = [{:capture, :all, :index} | opts]
 
-    case :re.run(string, compiled, opts) do
+    case safe_run(regex, string, opts) do
       :nomatch ->
         string
 

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -129,7 +129,7 @@ defmodule Regex do
 
   Regular expressions built with sigil are precompiled and stored in `.beam`
   files. Precompiled regexes will be checked in runtime and may work slower
-  between OSes and OTP releases. This is rarely a problem, as most Elixir code
+  between operating systems and OTP releases. This is rarely a problem, as most Elixir code
   shared during development is compiled on the target (such as dependencies,
   archives, and escripts) and, when running in production, the code must either
   be compiled on the target (via `mix compile` or similar) or released on the

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -136,7 +136,7 @@ defmodule Regex do
   host (via `mix releases` or similar) with a matching OTP, OS and architecture
   as as the target.
 
-  If you know you are running on a different system that the current one AND
+  If you know you are running on a different system that the current one and
   you are doing multiple matches with the regex, you can manually invoke
   `Regex.recompile/1` or `Regex.recompile!/1` to perform a runtime version
   check and recompile the regex if necessary.

--- a/lib/elixir/src/elixir.app.src
+++ b/lib/elixir/src/elixir.app.src
@@ -5,5 +5,5 @@
  {registered, [elixir_config, elixir_code_server]},
  {applications, [kernel,stdlib,compiler]},
  {mod, {elixir,[]}},
- {env, [{ansi_enabled, false}, {time_zone_database, 'Elixir.Calendar.UTCOnlyTimeZoneDatabase'}]}
+ {env, [{check_endianness, true}, {ansi_enabled, false}, {time_zone_database, 'Elixir.Calendar.UTCOnlyTimeZoneDatabase'}]}
 ]}.

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -31,7 +31,11 @@ start(_Type, _Args) ->
   preload_common_modules(),
   set_stdio_and_stderr_to_binary_and_maybe_utf8(),
   check_file_encoding(Encoding),
-  check_endianness(),
+
+  case application:get_env(elixir, check_endianness, true) of
+    true  -> check_endianness();
+    false -> ok
+  end,
 
   Tokenizer = case code:ensure_loaded('Elixir.String.Tokenizer') of
     {module, Mod} -> Mod;

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -3,6 +3,39 @@ Code.require_file("test_helper.exs", __DIR__)
 defmodule RegexTest do
   use ExUnit.Case, async: true
 
+  @re_21_3_little %Regex{
+    re_pattern:
+      {:re_pattern, 1, 0, 0,
+       <<69, 82, 67, 80, 94, 0, 0, 0, 0, 0, 0, 0, 17, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255,
+         255, 99, 0, 0, 0, 0, 0, 1, 0, 0, 0, 64, 0, 6, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 102, 111, 111, 0, 131, 0, 20, 29, 99, 133,
+         0, 7, 0, 1, 29, 100, 119, 0, 5, 29, 101, 120, 0, 12, 120, 0, 20, 0>>},
+    re_version: {"8.42 2018-03-20", :little},
+    source: "c(?<foo>d|e)"
+  }
+
+  @re_21_3_big %Regex{
+    re_pattern:
+      {:re_pattern, 1, 0, 0,
+       <<80, 67, 82, 69, 0, 0, 0, 86, 0, 0, 0, 0, 0, 0, 0, 17, 255, 255, 255, 255, 255, 255, 255,
+         255, 0, 99, 0, 0, 0, 0, 0, 1, 0, 0, 0, 56, 0, 6, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 1, 102, 111, 111, 0, 131, 0, 20, 29, 99, 133, 0, 7, 0, 1, 29, 100, 119,
+         0, 5, 29, 101, 120, 0, 12, 120, 0, 20, 0>>},
+    re_version: {"8.42 2018-03-20", :big},
+    source: "c(?<foo>d|e)"
+  }
+
+  @re_19_3_little %Regex{
+    re_pattern:
+      {:re_pattern, 1, 0, 0,
+       <<69, 82, 67, 80, 94, 0, 0, 0, 0, 0, 0, 0, 17, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255,
+         255, 99, 0, 0, 0, 0, 0, 1, 0, 0, 0, 64, 0, 6, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 102, 111, 111, 0, 125, 0, 20, 29, 99, 127,
+         0, 7, 0, 1, 29, 100, 113, 0, 5, 29, 101, 114, 0, 12, 114, 0, 20, 0>>},
+    re_version: {"8.33 2013-05-29", :little},
+    source: "c(?<foo>d|e)"
+  }
+
   doctest Regex
 
   test "multiline" do
@@ -155,6 +188,12 @@ defmodule RegexTest do
     assert Regex.run(~r"e", "abcd", return: :index) == nil
   end
 
+  test "run/3 with regexes compiled in different systems" do
+    assert Regex.run(@re_21_3_little, "abcd abce", capture: :all_names) == ["d"]
+    assert Regex.run(@re_21_3_big, "abcd abce", capture: :all_names) == ["d"]
+    assert Regex.run(@re_19_3_little, "abcd abce", capture: :all_names) == ["d"]
+  end
+
   test "scan/2" do
     assert Regex.scan(~r"c(d|e)", "abcd abce") == [["cd", "d"], ["ce", "e"]]
     assert Regex.scan(~r"c(?:d|e)", "abcd abce") == [["cd"], ["ce"]]
@@ -166,6 +205,12 @@ defmodule RegexTest do
     assert Regex.scan(~r/c(?<foo>d)/, "abcd", capture: :all_names) == [["d"]]
     assert Regex.scan(~r/c(?<foo>d)/, "no_match", capture: :all_names) == []
     assert Regex.scan(~r/c(?<foo>d|e)/, "abcd abce", capture: :all_names) == [["d"], ["e"]]
+  end
+
+  test "scan/2 with regexes compiled in different systems" do
+    assert Regex.scan(@re_21_3_little, "abcd abce", capture: :all_names) == [["d"], ["e"]]
+    assert Regex.scan(@re_21_3_big, "abcd abce", capture: :all_names) == [["d"], ["e"]]
+    assert Regex.scan(@re_19_3_little, "abcd abce", capture: :all_names) == [["d"], ["e"]]
   end
 
   test "split/2,3" do

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -319,7 +319,6 @@ defmodule Mix.Tasks.Escript.Build do
 
         defp load_config(config) do
           each_fun = fn {app, kw} ->
-            :application.load(app)
             set_env_fun = fn {k, v} -> :application.set_env(app, k, v, persistent: true) end
             :lists.foreach(set_env_fun, kw)
           end

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -319,6 +319,7 @@ defmodule Mix.Tasks.Escript.Build do
 
         defp load_config(config) do
           each_fun = fn {app, kw} ->
+            :application.load(app)
             set_env_fun = fn {k, v} -> :application.set_env(app, k, v, persistent: true) end
             :lists.foreach(set_env_fun, kw)
           end
@@ -385,9 +386,9 @@ defmodule Mix.Tasks.Escript.Build do
           :erlang.halt(1)
       end
 
+      load_config(@config)
       case :application.ensure_all_started(:elixir) do
         {:ok, _} ->
-          load_config(@config)
           start_app(@app)
           args = Enum.map(args, &List.to_string(&1))
           Kernel.CLI.run(fn _ -> @module.main(args) end)


### PR DESCRIPTION
Related to discussion: https://groups.google.com/forum/#!topic/elixir-lang-core/CgFdxIONvGg

## Current implementation
Regexes are precompiled to binary values during code compilation.
These binary values may be incompatible between different PCRE versions
and OS endianness. This makes code less portable to achieve slight
performance improvement.

## Proposed changes
PCRE version and endianness are parts of Regex structure and may be
checked in runtime.

This PR adds this check and makes regex execution fall back to binary
matching if versions are incompatible.

## Notes

This slightly reduces performance (around 5% for simple regexes) for
compatible versions because there is an additional version read.

Also for incompatible versions it's as fast as binary matching.

I'm not sure if there should be additional options to not check for version,
having that option would make matching slightly faster.

Also probably the endianness warning should be removed or modified,
because technically now all code is portable, although not so performant.

Also I'm not sure about the doc string regarding recompiles. Recompile will
still help for performance reasons, but not necessary to make things correct
and may not improve performance for one-off matches.