### PR TITLE
Support default value when reading inexistent module attribute

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2957,7 +2957,7 @@ defmodule Kernel do
     case function? do
       true ->
         value =
-          case Module.get_attribute(env.module, name, line) do
+          case Module.__get_attribute__(env.module, name, line) do
             {_, doc} when doc_attr? -> doc
             other -> other
           end
@@ -2973,7 +2973,7 @@ defmodule Kernel do
 
       false when doc_attr? ->
         quote do
-          case Module.get_attribute(__MODULE__, unquote(name), unquote(line)) do
+          case Module.__get_attribute__(__MODULE__, unquote(name), unquote(line)) do
             {_, doc} -> doc
             other -> other
           end
@@ -2981,7 +2981,7 @@ defmodule Kernel do
 
       false ->
         quote do
-          Module.get_attribute(__MODULE__, unquote(name), unquote(line))
+          Module.__get_attribute__(__MODULE__, unquote(name), unquote(line))
         end
     end
   end

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2939,12 +2939,12 @@ defmodule Kernel do
         arg = {env.line, arg}
 
         quote do
-          Module.put_attribute(__MODULE__, unquote(name), unquote(arg), unquote(line))
+          Module.__put_attribute__(__MODULE__, unquote(name), unquote(arg), unquote(line))
         end
 
       true ->
         quote do
-          Module.put_attribute(__MODULE__, unquote(name), unquote(arg), unquote(line))
+          Module.__put_attribute__(__MODULE__, unquote(name), unquote(arg), unquote(line))
         end
     end
   end

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1209,15 +1209,21 @@ defmodule Module do
         Module.put_attribute(__MODULE__, :value, 1)
         Module.get_attribute(__MODULE__, :value) #=> 1
 
+        Module.get_attribute(__MODULE__, :value, :default) #=> 1
+        Module.get_attribute(__MODULE__, :not_found, :default) #=> :default
+
         Module.register_attribute(__MODULE__, :value, accumulate: true)
         Module.put_attribute(__MODULE__, :value, 1)
         Module.get_attribute(__MODULE__, :value) #=> [1]
       end
 
   """
-  @spec get_attribute(module, atom) :: term
-  def get_attribute(module, key) when is_atom(module) and is_atom(key) do
-    get_attribute(module, key, nil)
+  @spec get_attribute(module, atom, term) :: term
+  def get_attribute(module, key, default \\ nil) when is_atom(module) and is_atom(key) do
+    case __get_attribute__(module, key, nil) do
+      nil -> default
+      value -> value
+    end
   end
 
   @doc """
@@ -1751,7 +1757,7 @@ defmodule Module do
   @doc false
   # Used internally by Kernel's @.
   # This function is private and must be used only internally.
-  def get_attribute(module, key, line) when is_atom(key) do
+  def __get_attribute__(module, key, line) when is_atom(key) do
     assert_not_compiled!(
       {:get_attribute, 2},
       module,

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1178,7 +1178,7 @@ defmodule Module do
   """
   @spec put_attribute(module, atom, term) :: :ok
   def put_attribute(module, key, value) when is_atom(module) and is_atom(key) do
-    put_attribute(module, key, value, nil)
+    __put_attribute__(module, key, value, nil)
   end
 
   @doc """
@@ -1794,7 +1794,7 @@ defmodule Module do
   @doc false
   # Used internally by Kernel's @.
   # This function is private and must be used only internally.
-  def put_attribute(module, key, value, line) when is_atom(key) do
+  def __put_attribute__(module, key, value, line) when is_atom(key) do
     assert_not_compiled!(__ENV__.function, module)
     {set, bag} = data_tables_for(module)
     value = preprocess_attribute(key, value)

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -438,7 +438,7 @@ defmodule ModuleTest do
   end
 
   describe "get_attribute/3" do
-    test "returns a list when the attribute is marked as `accummulate`" do
+    test "returns a list when the attribute is marked as `accummulate: true`" do
       in_module do
         Module.register_attribute(__MODULE__, :value, accumulate: true)
         Module.put_attribute(__MODULE__, :value, 1)
@@ -448,7 +448,7 @@ defmodule ModuleTest do
       end
     end
 
-    test "returns the value of the attribute if this exists" do
+    test "returns the value of the attribute if it exists" do
       in_module do
         Module.put_attribute(__MODULE__, :attribute, 1)
         assert Module.get_attribute(__MODULE__, :attribute) == 1

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -436,4 +436,30 @@ defmodule ModuleTest do
       Module.get_attribute(Enum, :moduledoc)
     end
   end
+
+  describe "get_attribute/{2,3}" do
+    test "returns a list when the attribute is marked as `accummulate`" do
+      in_module do
+        Module.register_attribute(__MODULE__, :value, accumulate: true)
+        Module.put_attribute(__MODULE__, :value, 1)
+        assert Module.get_attribute(__MODULE__, :value) == [1]
+        Module.put_attribute(__MODULE__, :value, 2)
+        assert Module.get_attribute(__MODULE__, :value) == [2, 1]
+      end
+    end
+
+    test "returns the value of the attribute if this exists" do
+      in_module do
+        Module.put_attribute(__MODULE__, :attribute, 1)
+        assert Module.get_attribute(__MODULE__, :attribute) == 1
+        assert Module.get_attribute(__MODULE__, :attribute, :default) == 1
+      end
+    end
+
+    test "returns the passed default if the attribute does not exist" do
+      in_module do
+        assert Module.get_attribute(__MODULE__, :attribute, :default) == :default
+      end
+    end
+  end
 end

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -437,7 +437,7 @@ defmodule ModuleTest do
     end
   end
 
-  describe "get_attribute/{2,3}" do
+  describe "get_attribute/3" do
     test "returns a list when the attribute is marked as `accummulate`" do
       in_module do
         Module.register_attribute(__MODULE__, :value, accumulate: true)


### PR DESCRIPTION
This PR permits to provide a default value as the third argument to `Module.get_attribute`.