### PR TITLE
Start the VM in interactive mode for rpc/eval/remote

### DIFF
--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -622,6 +622,10 @@ defmodule Mix.Tasks.Release do
       files to. It can be set to a custom directory. It defaults to
       `$RELEASE_ROOT/tmp`
 
+    * `RELEASE_MODE` - if the release should start in embedded or
+      interactive mode. Defaults to "embedded". It applies only to
+      start/daemon/install commands
+
     * `RELEASE_DISTRIBUTION` - how do we want to run the distribution.
       Using `name` (long names) or `sname` (short names). Defaults to
       `sname` which allows access only within the current system.

--- a/lib/mix/test/fixtures/release_test/lib/release_test.ex
+++ b/lib/mix/test/fixtures/release_test/lib/release_test.ex
@@ -13,6 +13,7 @@ defmodule ReleaseTest do
       release_node: System.get_env("RELEASE_NODE"),
       release_vsn: System.get_env("RELEASE_VSN"),
       cookie_env: cookie,
+      mode: :code.get_mode(),
       node: node(),
       root_dir: :code.root_dir() |> to_string(),
       static_config: Application.fetch_env(:release_test, :static),

--- a/lib/mix/test/mix/tasks/release_test.exs
+++ b/lib/mix/test/mix/tasks/release_test.exs
@@ -130,6 +130,7 @@ defmodule Mix.Tasks.ReleaseTest do
         assert %{
                  app_dir: app_dir,
                  cookie_env: ^cookie,
+                 mode: :embedded,
                  node: release_node("release_test"),
                  protocols_consolidated?: true,
                  release_name: "release_test",
@@ -188,6 +189,7 @@ defmodule Mix.Tasks.ReleaseTest do
         open_port(Path.join(root, "bin/runtime_config"), ['start'])
 
         assert %{
+                 mode: :embedded,
                  node: release_node("runtime_config"),
                  protocols_consolidated?: true,
                  release_name: "runtime_config",
@@ -238,6 +240,7 @@ defmodule Mix.Tasks.ReleaseTest do
         assert %{
                  app_dir: app_dir,
                  cookie_env: "abcdefghijk",
+                 mode: :embedded,
                  node: release_node("demo"),
                  protocols_consolidated?: true,
                  release_name: "demo",
@@ -303,6 +306,7 @@ defmodule Mix.Tasks.ReleaseTest do
 
         assert %{
                  cookie_env: "abcdefghij",
+                 mode: :interactive,
                  node: :nonode@nohost,
                  protocols_consolidated?: true,
                  release_name: "eval",
@@ -331,6 +335,7 @@ defmodule Mix.Tasks.ReleaseTest do
         assert wait_until_evaled(Path.join(root, "RELEASE_BOOTED")) == %{
                  app_dir: Path.join(root, "lib/release_test-0.1.0"),
                  cookie_env: "abcdefghij",
+                 mode: :embedded,
                  node: :"permanent2@#{@hostname}",
                  protocols_consolidated?: true,
                  release_name: "permanent2",


### PR DESCRIPTION
This speeds up boot time and decreases memory use.