### PR TITLE
Fix hiding mix format errors with stdin

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -467,6 +467,11 @@ defmodule Mix.Tasks.Format do
     :ok
   end
 
+  defp check!({[{:exit, :stdin, exception, stacktrace} | _], _not_equivalent, _not_formatted}) do
+    Mix.shell().error("mix format failed for stdin")
+    reraise exception, stacktrace
+  end
+
   defp check!({[{:exit, file, exception, stacktrace} | _], _not_equivalent, _not_formatted}) do
     Mix.shell().error("mix format failed for file: #{Path.relative_to_cwd(file)}")
     reraise exception, stacktrace

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -518,4 +518,16 @@ defmodule Mix.Tasks.FormatTest do
       assert_received {:mix_shell, :error, ["mix format failed for file: a.ex"]}
     end)
   end
+
+  test "raises SyntaxError when parsing invalid stdin", context do
+    in_tmp(context.test, fn ->
+      assert_raise SyntaxError, ~r"stdin:1: syntax error before: '='", fn ->
+        capture_io("defmodule <%= module %>.Bar do end", fn ->
+          Mix.Tasks.Format.run(["-"])
+        end)
+      end
+
+      assert_received {:mix_shell, :error, ["mix format failed for stdin"]}
+    end)
+  end
 end


### PR DESCRIPTION
Running `echo 'defmodule <%= module %>.Bar do end' | mix format -` produces the following results:

```
** (FunctionClauseError) no function clause matching in IO.chardata_to_string/1

    The following arguments were given to IO.chardata_to_string/1:

        # 1
        :stdin

    Attempted function clauses (showing 2 out of 2):

        def chardata_to_string(string) when is_binary(string)
        def chardata_to_string(list) when is_list(list)

    (elixir) lib/io.ex:461: IO.chardata_to_string/1
    (elixir) lib/path.ex:312: Path.relative_to/2
    (mix) lib/mix/tasks/format.ex:450: Mix.Tasks.Format.check!/1
    (mix) lib/mix/task.ex:316: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:79: Mix.CLI.run_task/2
```

It is hiding actual errors. The following error should be output.

```
** (SyntaxError) stdin:1: syntax error before: '='
stacktrace:
  (elixir) lib/code.ex:553: Code.format_string!/2
  (mix) lib/mix/tasks/format.ex:418: Mix.Tasks.Format.format_file/2
  (elixir) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
  (elixir) lib/task/supervised.ex:35: Task.Supervised.reply/5
  (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```