### PR TITLE
Fix specs in EEx.Tokenizer

### DIFF
--- a/lib/eex/lib/eex/tokenizer.ex
+++ b/lib/eex/lib/eex/tokenizer.ex
@@ -4,9 +4,10 @@ defmodule EEx.Tokenizer do
   @type content :: IO.chardata()
   @type line :: non_neg_integer
   @type marker :: '=' | '/' | '|' | ''
+  @type trimmed? :: boolean
   @type token ::
           {:text, content}
-          | {:expr | :start_expr | :middle_expr | :end_expr, line, marker, content}
+          | {:expr | :start_expr | :middle_expr | :end_expr, line, marker, content, trimmed?}
 
   @spaces [?\s, ?\t]
   @closing_brackets ')]}'
@@ -17,10 +18,10 @@ defmodule EEx.Tokenizer do
   It returns {:ok, list} with the following tokens:
 
     * `{:text, content}`
-    * `{:expr, line, marker, content}`
-    * `{:start_expr, line, marker, content}`
-    * `{:middle_expr, line, marker, content}`
-    * `{:end_expr, line, marker, content}`
+    * `{:expr, line, marker, content, trimmed?}`
+    * `{:start_expr, line, marker, content, trimmed?}`
+    * `{:middle_expr, line, marker, content, trimmed?}`
+    * `{:end_expr, line, marker, content, trimmed?}`
 
   Or `{:error, line, error}` in case of errors.
   """


### PR DESCRIPTION
Spec for t:token/0 was missing on element in the tuple

this created a series of Dialyzer errors when running `make dialyze`

`/elixir/lib/eex/lib/eex/compiler.ex:44: The pattern <[{'expr', _line@1, _mark@1, _chars@1, _} | _rest@1], _buffer@1, _scope@1, _state@1> can never match the type <[{'text',binary() | maybe_improper_list(any(),binary() | [])} | {'end_expr',non_neg_integer(),[any()],binary() | maybe_improper_list(any(),binary() | [])} | {'expr',non_neg_integer(),[any()],binary() | maybe_improper_list(any(),binary() | [])} | {'middle_expr',non_neg_integer(),[any()],binary() | maybe_improper_list(any(),binary() | [])} | {'start_expr',non_neg_integer(),[any()],binary() | maybe_improper_list(any(),binary() | [])}],_,[],#{'engine':=_, 'file':=_, 'line':=non_neg_integer(), 'quoted':=[], 'start_line':='nil'}>`