### PR TITLE
Remove Dialyzer errors in Application module

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -347,19 +347,11 @@ defmodule Application do
     :start_phases
   ]
 
-  application_key_specs = fn ->
-    {:ok, ast} =
-      @application_keys
-      |> Enum.map(fn key -> ":#{key}" end)
-      |> Enum.join(" | ")
-      |> Code.string_to_quoted()
-
-    ast
-  end
+  application_key_specs = Enum.reduce(@application_keys, &{:|, [], [&1, &2]})
 
   @type app :: atom
   @type key :: atom
-  @type application_key :: unquote(application_key_specs.())
+  @type application_key :: unquote(application_key_specs)
   @type value :: term
   @type state :: term
   @type start_type :: :normal | {:takeover, node} | {:failover, node}


### PR DESCRIPTION
We were getting the "Type specification ... is a supertype of the success typing" error

/elixir/lib/elixir/lib/application.ex:367: Type specification 'Elixir.Application':spec(app()) -> [{key(),value()}] | 'nil' is a supertype of the success typing: 'Elixir.Application':spec(atom()) -> 'nil' | [{'applications' | 'description' | 'env' | 'id' | 'included_applications' | 'maxP' | 'maxT' | 'mod' | 'modules' | 'registered' | 'start_phases' | 'vsn',_}]
/elixir/lib/elixir/lib/application.ex:382: Type specification 'Elixir.Application':spec(app(),key()) -> value() | 'nil' is a supertype of the success typing: 'Elixir.Application':spec(atom(),'applications' | 'description' | 'id' | 'included_applications' | 'maxP' | 'maxT' | 'mod' | 'modules' | 'registered' | 'start_phases' | 'vsn') -> any()