### PR TITLE
Do not explicitly recompile regexes, fallback to binary matching

### DIFF
--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -525,15 +525,11 @@ defmodule IO.ANSI.Docs do
 
   defp escape_underlines_in_link(text) do
     # Regular expression adapted from https://tools.ietf.org/html/rfc3986#appendix-B
-    ~r{[a-z][a-z0-9\+\-\.]*://\S*}i
-    |> Regex.recompile!()
-    |> Regex.replace(text, &String.replace(&1, "_", "\\_"))
+    Regex.replace(~r{[a-z][a-z0-9\+\-\.]*://\S*}i, text, &String.replace(&1, "_", "\\_"))
   end
 
   defp remove_square_brackets_in_link(text) do
-    ~r{\[([^\]]*?)\]\((.*?)\)}
-    |> Regex.recompile!()
-    |> Regex.replace(text, "\\1 (\\2)")
+    Regex.replace(~r{\[([^\]]*?)\]\((.*?)\)}, text, "\\1 (\\2)")
   end
 
   # We have four entries: **, *, _ and `.

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -452,8 +452,7 @@ defmodule URI do
 
   def parse(string) when is_binary(string) do
     # From https://tools.ietf.org/html/rfc3986#appendix-B
-    regex =
-      Regex.recompile!(~r{^(([a-z][a-z0-9\+\-\.]*):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?}i)
+    regex = ~r{^(([a-z][a-z0-9\+\-\.]*):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?}i
 
     parts = Regex.run(regex, string)
 
@@ -486,7 +485,7 @@ defmodule URI do
 
   # Split an authority into its userinfo, host and port parts.
   defp split_authority(string) do
-    regex = Regex.recompile!(~r/(^(.*)@)?(\[[a-zA-Z0-9:.]*\]|[^:]*)(:(\d*))?/)
+    regex = ~r/(^(.*)@)?(\[[a-zA-Z0-9:.]*\]|[^:]*)(:(\d*))?/
     components = Regex.run(regex, string || "")
 
     destructure [_, _, userinfo, host, _, port], components

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -414,7 +414,7 @@ defmodule ExUnit.DocTest do
         message = "Doctest did not compile, got: #{ex_message}"
 
         message =
-          if e.__struct__ == TokenMissingError and expr =~ Regex.recompile!(@opaque_type_regex) do
+          if e.__struct__ == TokenMissingError and expr =~ @opaque_type_regex do
             message <>
               """
               . If you are planning to assert on the result of an iex> expression \

--- a/lib/logger/lib/logger/formatter.ex
+++ b/lib/logger/lib/logger/formatter.ex
@@ -89,7 +89,7 @@ defmodule Logger.Formatter do
   def compile({mod, fun}) when is_atom(mod) and is_atom(fun), do: {mod, fun}
 
   def compile(str) when is_binary(str) do
-    regex = Regex.recompile!(~r/(?<head>)\$[a-z]+(?<tail>)/)
+    regex = ~r/(?<head>)\$[a-z]+(?<tail>)/
 
     for part <- Regex.split(regex, str, on: [:head, :tail], trim: true) do
       case part do

--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -68,7 +68,7 @@ defmodule Mix.Release do
   def from_config!(name, config, overrides) do
     {name, apps, opts} = find_release(name, config)
 
-    unless Atom.to_string(name) =~ Regex.recompile!(~r/^[a-z][a-z0-9_]*$/) do
+    unless Atom.to_string(name) =~ ~r/^[a-z][a-z0-9_]*$/ do
       Mix.raise(
         "Invalid release name. A release name must start with a lowercase ASCII letter, " <>
           "followed by lowercase ASCII letters, numbers, or underscores, got: #{inspect(name)}"

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -167,7 +167,7 @@ defmodule Mix.Tasks.New do
   end
 
   defp check_application_name!(name, inferred?) do
-    unless name =~ Regex.recompile!(~r/^[a-z][a-z0-9_]*$/) do
+    unless name =~ ~r/^[a-z][a-z0-9_]*$/ do
       Mix.raise(
         "Application name must start with a lowercase ASCII letter, followed by " <>
           "lowercase ASCII letters, numbers, or underscores, got: #{inspect(name)}" <>
@@ -182,7 +182,7 @@ defmodule Mix.Tasks.New do
   end
 
   defp check_mod_name_validity!(name) do
-    unless name =~ Regex.recompile!(~r/^[A-Z]\w*(\.[A-Z]\w*)*$/) do
+    unless name =~ ~r/^[A-Z]\w*(\.[A-Z]\w*)*$/ do
       Mix.raise(
         "Module name must be a valid Elixir alias (for example: Foo.Bar), got: #{inspect(name)}"
       )


### PR DESCRIPTION
Related #9040 

Regexes used to be precompiled to binary values during code compilation. These binary values may be incompatible with different operating systems and OTP releases. That's why an explicit `Regex.recompile/1` or `Regex.recompile!/1` was required.

Regexes now fallback to binary matching if the precompiled binary is not compatible with the runtime version.