### PR TITLE
Streamline test logs in umbrella applications

### DIFF
--- a/lib/mix/lib/mix/shell/io.ex
+++ b/lib/mix/lib/mix/shell/io.ex
@@ -11,9 +11,13 @@ defmodule Mix.Shell.IO do
   Prints the current application to the shell if it
   was not printed yet.
   """
-  def print_app do
+  def print_app(newline \\ true) do
     if name = Mix.Shell.printable_app_name() do
-      IO.puts("==> #{name}")
+      if newline do
+        IO.puts("==> #{name}")
+      else
+        IO.write("==> #{name} ")
+      end
     end
 
     :ok

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -402,7 +402,7 @@ defmodule Mix.Tasks.Test do
     # Start the app and configure ExUnit with command line options
     # before requiring test_helper.exs so that the configuration is
     # available in test_helper.exs
-    Mix.shell().print_app
+    Mix.shell().print_app(!Mix.Task.recursing?())
     app_start_args = if opts[:slowest], do: ["--preload-modules" | args], else: args
     Mix.Task.run("app.start", app_start_args)
 


### PR DESCRIPTION
Before this, each child app in an umbrella app had at least 7 newlines per child app in a test run. Because of this it didn't take many child apps for your test output to scroll way off the screen even on a fully successful `mix test`. This change streamlines the test output from a minimum of 7 down to a minimum of 2 lines when running in an umbrella.

Before:
![Screen Shot 2019-05-24 at 1 34 06 PM](https://user-images.githubusercontent.com/8557871/58346383-c3c88200-7e28-11e9-828a-0ef17c54fe71.png)

After:
![Screen Shot 2019-05-24 at 1 30 59 PM](https://user-images.githubusercontent.com/8557871/58346394-ca56f980-7e28-11e9-925e-38c15df7f495.png)


Note: The changes in `cli_formatter.ex` work but to remove the newline after printing the app name, I took a stab at changing `io.ex` and `test.ex`, however now `make test` fails on `ex_unit` without a useful error message and I am not sure exactly how to debug it.