### PR TITLE
Improves module documentation of DynamicSupervisor

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -58,7 +58,7 @@ defmodule DynamicSupervisor do
       end
 
   See the `Supervisor` docs for a discussion of when you may want to use
-  module-based supervisors. The `@doc` annotation immediately preceding
+  module-based supervisors. A `@doc` annotation immediately preceding
   `use DynamicSupervisor` will be attached to the generated `child_spec/1`
   function.
 


### PR DESCRIPTION
Fixes #9075, by changing the in module documentation about 'module-based supervisors' `The @doc ...` to `A @doc ...`.