### PR TITLE
Remove duplicated typespec on t:GenServer.server/0

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -723,7 +723,7 @@ defmodule GenServer do
   This is either a plain PID or a value representing a registered name.
   See the "Name registration" section of this document for more information.
   """
-  @type server :: pid | name | {atom, node} | {:via, registry :: module(), key :: term()}
+  @type server :: pid | name | {atom, node}
 
   @typedoc """
   Tuple describing the client of a call request.


### PR DESCRIPTION
`{:via, module, term}` is covered by the type `name`

Related: https://github.com/elixir-lang/elixir/pull/9082