### PR TITLE
Add 'a' to {invalid_clauses, Name} error

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -1167,7 +1167,7 @@ format_error({op_ambiguity, Name, Arg}) ->
   io_lib:format(Message, [Name, 'Elixir.Macro':to_string(Arg), Name]);
 format_error({invalid_clauses, Name}) ->
   Message =
-    "the function \"~ts\" cannot handle clauses with the -> operator because it is not macro. "
+    "the function \"~ts\" cannot handle clauses with the -> operator because it is not a macro. "
     "Please make sure you are invoking the proper name and that it is a macro",
   io_lib:format(Message, [Name]);
 format_error({invalid_alias_for_as, Reason, Value}) ->


### PR DESCRIPTION
Fixed a small grammatical mistake in this error message.

Before:

> the function "case" cannot handle clauses with the -> operator because it is not macro. Please make sure you are invoking the proper name and that it is a macro

After:

> the function "case" cannot handle clauses with the -> operator because it is not **a** macro. Please make sure you are invoking the proper name and that it is a macro