### PR TITLE
Inspect.Opts.custom_options

### DIFF
--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -57,6 +57,10 @@ defmodule Inspect.Opts do
     * `:inspect_fun` (since v1.9.0) - a function to build algebra documents,
       defaults to `Inspect.inspect/2`
 
+    * `:custom_bag` (since v1.9.0) - a keyword list storing custom user-defined
+      options; useful when implementing a protocol for nested structures to pass
+      the custom options through. All the non-default options passed to
+      `Kernel.inspect/2` will be put into this bag.
   """
 
   # TODO: Remove :char_lists key on v2.0
@@ -71,7 +75,8 @@ defmodule Inspect.Opts do
             pretty: false,
             safe: true,
             syntax_colors: [],
-            inspect_fun: &Inspect.inspect/2
+            inspect_fun: &Inspect.inspect/2,
+            custom_bag: []
 
   @type color_key :: atom
 
@@ -88,8 +93,33 @@ defmodule Inspect.Opts do
           pretty: boolean,
           safe: boolean,
           syntax_colors: [{color_key, IO.ANSI.ansidata()}],
-          inspect_fun: (any, t -> Inspect.Algebra.t())
+          inspect_fun: (any, t -> Inspect.Algebra.t()),
+          custom_bag: [{atom, any()}]
         }
+
+  def custom_bag(opts) do
+    Enum.reject(opts, fn
+      {k, _}
+      when k in [
+             :structs,
+             :binaries,
+             :charlists,
+             :char_lists,
+             :limit,
+             :printable_limit,
+             :width,
+             :base,
+             :pretty,
+             :safe,
+             :syntax_colors,
+             :inspect_fun
+           ] ->
+        true
+
+      _ ->
+        false
+    end)
+  end
 end
 
 defmodule Inspect.Error do

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -101,7 +101,7 @@ defmodule Inspect.Opts do
   @doc """
   Filters out all the default options, returning the custom options only.
   """
-  @spec filter_custom_options(keyword()) :: keyword()
+  @spec filter_custom_options(opts) :: opts when opts: keyword()
   def filter_custom_options(opts) do
     Keyword.drop(opts, [
       :structs,

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -61,7 +61,7 @@ defmodule Inspect.Opts do
       options. Useful when implementing the `Inspect` protocol for nested structs
       to pass the custom options through. All the non-default options passed to
       `Kernel.inspect/2` will be put into this list.
-      
+
   """
 
   # TODO: Remove :char_lists key on v2.0
@@ -98,6 +98,10 @@ defmodule Inspect.Opts do
           custom_options: keyword
         }
 
+  @doc """
+  Filters out all the default options, returning the custom options only.
+  """
+  @spec filter_custom_options(keyword()) :: keyword()
   def filter_custom_options(opts) do
     Keyword.drop(opts, [
       :structs,

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -59,8 +59,7 @@ defmodule Inspect.Opts do
 
     * `:custom_options` (since v1.9.0) - a keyword list storing custom user-defined
       options. Useful when implementing the `Inspect` protocol for nested structs
-      to pass the custom options through. All the non-default options passed to
-      `Kernel.inspect/2` will be put into this list.
+      to pass the custom options through.
 
   """
 

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -57,7 +57,7 @@ defmodule Inspect.Opts do
     * `:inspect_fun` (since v1.9.0) - a function to build algebra documents,
       defaults to `Inspect.inspect/2`
 
-    * `:custom_bag` (since v1.9.0) - a keyword list storing custom user-defined
+    * `:custom_options` (since v1.9.0) - a keyword list storing custom user-defined
       options; useful when implementing a protocol for nested structures to pass
       the custom options through. All the non-default options passed to
       `Kernel.inspect/2` will be put into this bag.
@@ -76,7 +76,7 @@ defmodule Inspect.Opts do
             safe: true,
             syntax_colors: [],
             inspect_fun: &Inspect.inspect/2,
-            custom_bag: []
+            custom_options: []
 
   @type color_key :: atom
 
@@ -94,10 +94,10 @@ defmodule Inspect.Opts do
           safe: boolean,
           syntax_colors: [{color_key, IO.ANSI.ansidata()}],
           inspect_fun: (any, t -> Inspect.Algebra.t()),
-          custom_bag: [{atom, any()}]
+          custom_options: [{atom, any()}]
         }
 
-  def custom_bag(opts) do
+  def custom_options(opts) do
     Enum.reject(opts, fn
       {k, _}
       when k in [

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -94,31 +94,24 @@ defmodule Inspect.Opts do
           safe: boolean,
           syntax_colors: [{color_key, IO.ANSI.ansidata()}],
           inspect_fun: (any, t -> Inspect.Algebra.t()),
-          custom_options: [{atom, any()}]
+          custom_options: keyword
         }
 
-  def custom_options(opts) do
-    Enum.reject(opts, fn
-      {k, _}
-      when k in [
-             :structs,
-             :binaries,
-             :charlists,
-             :char_lists,
-             :limit,
-             :printable_limit,
-             :width,
-             :base,
-             :pretty,
-             :safe,
-             :syntax_colors,
-             :inspect_fun
-           ] ->
-        true
-
-      _ ->
-        false
-    end)
+  def filter_custom_options(opts) do
+    Keyword.drop(opts, [
+      :structs,
+      :binaries,
+      :charlists,
+      :char_lists,
+      :limit,
+      :printable_limit,
+      :width,
+      :base,
+      :pretty,
+      :safe,
+      :syntax_colors,
+      :inspect_fun
+    ])
   end
 end
 

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -97,27 +97,6 @@ defmodule Inspect.Opts do
           inspect_fun: (any, t -> Inspect.Algebra.t()),
           custom_options: keyword
         }
-
-  @doc """
-  Filters out all the default options, returning the custom options only.
-  """
-  @spec filter_custom_options(opts) :: opts when opts: keyword()
-  def filter_custom_options(opts) do
-    Keyword.drop(opts, [
-      :structs,
-      :binaries,
-      :charlists,
-      :char_lists,
-      :limit,
-      :printable_limit,
-      :width,
-      :base,
-      :pretty,
-      :safe,
-      :syntax_colors,
-      :inspect_fun
-    ])
-  end
 end
 
 defmodule Inspect.Error do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2055,8 +2055,8 @@ defmodule Kernel do
   """
   @spec inspect(Inspect.t(), keyword) :: String.t()
   def inspect(term, opts \\ []) when is_list(opts) do
-    custom_bag = Inspect.Opts.custom_bag(opts)
-    opts = struct(Inspect.Opts, [{:custom_bag, custom_bag} | opts])
+    custom_options = Inspect.Opts.custom_options(opts)
+    opts = struct(Inspect.Opts, [{:custom_options, custom_options} | opts])
 
     limit =
       case opts.pretty do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2055,7 +2055,8 @@ defmodule Kernel do
   """
   @spec inspect(Inspect.t(), keyword) :: String.t()
   def inspect(term, opts \\ []) when is_list(opts) do
-    opts = struct(Inspect.Opts, opts)
+    custom_bag = Inspect.Opts.custom_bag(opts)
+    opts = struct(Inspect.Opts, [{:custom_bag, custom_bag} | opts])
 
     limit =
       case opts.pretty do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2055,7 +2055,7 @@ defmodule Kernel do
   """
   @spec inspect(Inspect.t(), keyword) :: String.t()
   def inspect(term, opts \\ []) when is_list(opts) do
-    custom_options = Inspect.Opts.custom_options(opts)
+    custom_options = Inspect.Opts.filter_custom_options(opts)
     opts = struct(Inspect.Opts, [{:custom_options, custom_options} | opts])
 
     limit =

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2055,8 +2055,7 @@ defmodule Kernel do
   """
   @spec inspect(Inspect.t(), keyword) :: String.t()
   def inspect(term, opts \\ []) when is_list(opts) do
-    custom_options = Inspect.Opts.filter_custom_options(opts)
-    opts = struct(Inspect.Opts, [{:custom_options, custom_options} | opts])
+    opts = struct(Inspect.Opts, opts)
 
     limit =
       case opts.pretty do

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -687,8 +687,8 @@ defmodule Inspect.OthersTest do
       import Inspect.Algebra
 
       def inspect(%Nested{nested: nested}, opts) do
-        indent = Keyword.get(opts.custom_bag, :indent, 2)
-        level = Keyword.get(opts.custom_bag, :level, 1)
+        indent = Keyword.get(opts.custom_options, :indent, 2)
+        level = Keyword.get(opts.custom_options, :level, 1)
 
         nested_str = Kernel.inspect(nested, level: level + 1, indent: indent + 2)
 
@@ -700,7 +700,7 @@ defmodule Inspect.OthersTest do
     end
   end
 
-  test "custom_bag" do
+  test "custom_options" do
     assert inspect(%Nested{nested: %Nested{nested: 42}}) ==
              "#Nested[#1/2]<\n  #Nested[#2/4]<\n    42\n  >\n>"
   end

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -679,4 +679,29 @@ defmodule Inspect.OthersTest do
     assert inspect(uri, opts) == "#URI<https://elixir-lang.org>"
     assert inspect([uri], opts) == "[#URI<https://elixir-lang.org>]"
   end
+
+  defmodule Nested do
+    defstruct nested: nil
+
+    defimpl Inspect do
+      import Inspect.Algebra
+
+      def inspect(%Nested{nested: nested}, opts) do
+        indent = Keyword.get(opts.custom_bag, :indent, 2)
+        level = Keyword.get(opts.custom_bag, :level, 1)
+
+        nested_str = Kernel.inspect(nested, level: level + 1, indent: indent + 2)
+
+        concat(
+          nest(line("#Nested[##{level}/#{indent}]<", nested_str), indent),
+          nest(line("", ">"), indent - 2)
+        )
+      end
+    end
+  end
+
+  test "custom_bag" do
+    assert inspect(%Nested{nested: %Nested{nested: 42}}) ==
+             "#Nested[#1/2]<\n  #Nested[#2/4]<\n    42\n  >\n>"
+  end
 end

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -690,7 +690,8 @@ defmodule Inspect.OthersTest do
         indent = Keyword.get(opts.custom_options, :indent, 2)
         level = Keyword.get(opts.custom_options, :level, 1)
 
-        nested_str = Kernel.inspect(nested, level: level + 1, indent: indent + 2)
+        nested_str =
+          Kernel.inspect(nested, custom_options: [level: level + 1, indent: indent + 2])
 
         concat(
           nest(line("#Nested[##{level}/#{indent}]<", nested_str), indent),


### PR DESCRIPTION
It’s easier to explain with code.

When `Inspect.inspect/2` is used with the nested structure, it sometimes makes sense to pass some custom additional options through the call stack. That might be a custom setting, meaningful for the inspected type only. For example, the level of nesting in the snippet in the test below.

I would propose the ability to pass any option to `Inspect.inspect/2` so that if it’s not a known default option, it’s being put in the newly introduced `custom_bag` struct field. It might play the role of the “accumulator,” so that all the nested objects of the same type (all objects aware of this particular option) might get it, and update in the nesting calls to `inspect/2`.

The test below should shed more light on how it might be used.