### PR TITLE
Store relative file in module definition

### DIFF
--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -151,12 +151,12 @@ spawned_compile(Map, Set, _Bag, TranslatedTypespecs) ->
 
   load_form(Map, Prefix, Forms, TypeSpecs, Chunks).
 
-dynamic_form(#{module := Module, line := Line, file := File, attributes := Attributes,
+dynamic_form(#{module := Module, line := Line, relative_file := RelativeFile, attributes := Attributes,
                definitions := Definitions, unreachable := Unreachable, compile_opts := Opts} = Map) ->
   {Def, Defmacro, Macros, Exports, Functions} =
     split_definition(Definitions, Unreachable, [], [], [], [], {[], []}),
 
-  Location = {elixir_utils:characters_to_list(elixir_utils:relative_to_cwd(File)), Line},
+  Location = {elixir_utils:characters_to_list(RelativeFile), Line},
   Prefix = [{attribute, Line, file, Location},
             {attribute, Line, module, Module},
             {attribute, Line, compile, [no_auto_import | Opts]}],

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -109,6 +109,7 @@ compile(Line, Module, Block, Vars, E) ->
       module => Module,
       line => Line,
       file => File,
+      relative_file => elixir_utils:relative_to_cwd(File),
       attributes => Attributes,
       definitions => AllDefinitions,
       unreachable => Unreachable,

--- a/lib/mix/test/mix/tasks/compile.protocols_test.exs
+++ b/lib/mix/test/mix/tasks/compile.protocols_test.exs
@@ -136,7 +136,7 @@ defmodule Mix.Tasks.Compile.ProtocolsTest do
           assert [{_, _, _, [file: 'lib/enum.ex'] ++ _} | _] = __STACKTRACE__
       else
         _ ->
-          flunk("Enum.map/2 should have failed")
+          flunk("Enumerable.impl_for!/1 should have failed")
       after
         :code.del_path('_build/dev/lib/sample/consolidated')
         :code.purge(Enumerable)


### PR DESCRIPTION
Prior to this patch, we would always compute the relative
path to the current working directory (CWD), but this meant
consolidated protocols would always get a full path since
they are always outside of their current working directory.
We address this by also storing the relative path in the
definition.

Closes #9095