### PR TITLE
Update Enum.find/2 documentation

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -939,14 +939,14 @@ defmodule Enum do
 
   ## Examples
 
-      iex> Enum.find([2, 4, 6], fn x -> rem(x, 2) == 1 end)
-      nil
-
-      iex> Enum.find([2, 4, 6], 0, fn x -> rem(x, 2) == 1 end)
-      0
-
       iex> Enum.find([2, 3, 4], fn x -> rem(x, 2) == 1 end)
       3
+      
+      iex> Enum.find([2, 4, 6], fn x -> rem(x, 2) == 1 end)
+      nil
+      
+      iex> Enum.find([2, 4, 6], 0, fn x -> rem(x, 2) == 1 end)
+      0
 
   """
   @spec find(t, default, (element -> any)) :: element | default

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -944,7 +944,6 @@ defmodule Enum do
       
       iex> Enum.find([2, 4, 6], fn x -> rem(x, 2) == 1 end)
       nil
-      
       iex> Enum.find([2, 4, 6], 0, fn x -> rem(x, 2) == 1 end)
       0
 


### PR DESCRIPTION
I found the order of the examples a bit confusing, because on other examples it starts with the 'success' examples first. The default 0 example in the middle had me looking a few times before I understood what the result should be.