### PR TITLE
Add preferred_cli_target

### DIFF
--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -67,8 +67,12 @@ defmodule Mix.Project do
     * `:preferred_cli_env` - a keyword list of `{task, env}` tuples where `task`
       is the task name as an atom (for example, `:"deps.get"`) and `env` is the
       preferred environment (for example, `:test`). This option overrides what
-      specified by the tasks with the `@preferred_cli_env` attribute (see the
+      is specified by the tasks with the `@preferred_cli_env` attribute (see the
       docs for `Mix.Task`). Defaults to `[]`.
+
+    * `:preferred_cli_target` - a keyword list of `{task, target}` tuples where
+      `task` is the task name as an atom (for example, `:test`) and `target`
+      is the preferred target (for example, `:host`). Defaults to `[]`.
 
   For more options, keep an eye on the documentation for single Mix tasks; good
   examples are the `Mix.Tasks.Compile` task and all the specific compiler tasks

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -143,6 +143,32 @@ defmodule Mix.CLITest do
     System.delete_env("MIX_EXS")
   end
 
+  test "target config defaults to the tasks's preferred cli target", context do
+    in_tmp(context.test, fn ->
+      File.write!("custom.exs", """
+      defmodule P do
+        use Mix.Project
+        def project, do: [app: :p, version: "0.1.0", preferred_cli_target: [test_task: :other]]
+      end
+
+      defmodule Mix.Tasks.TestTask do
+        use Mix.Task
+
+        def run(args) do
+          IO.inspect {Mix.target, args}
+        end
+      end
+      """)
+
+      System.put_env("MIX_EXS", "custom.exs")
+
+      output = mix(["test_task", "a", "b", "c"])
+      assert output =~ ~s({:other, ["a", "b", "c"]})
+    end)
+  after
+    System.delete_env("MIX_EXS")
+  end
+
   test "new with tests and cover" do
     in_tmp("new_with_tests", fn ->
       output = mix(~w[new .])

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -143,7 +143,7 @@ defmodule Mix.CLITest do
     System.delete_env("MIX_EXS")
   end
 
-  test "target config defaults to the tasks's preferred cli target", context do
+  test "target config defaults to the user's preferred cli target", context do
     in_tmp(context.test, fn ->
       File.write!("custom.exs", """
       defmodule P do


### PR DESCRIPTION
This PR addresses a common issue with running mix tasks, primarily `mix test` when `MIX_TARGET` is set to a value other than `:host`. This is why the behavior mimics that of `preferred_cli_env` with the exception that this will not be able to be overridden by setting `MIX_TARGET`. I feel that this behavior is okay because `mix` is a tool that is _always_ running on your `:host`. Therefore, you should be able to specify, in the task module or project config which target the tasks should run under, no matter what the target. If this behavior needs to be overridden, it could be done by setting `preferred_cli_target` in the `Mix.Project.config`.

The common pain is that `MIX_TARGET` is typically something that you `export` which then makes running `mix test` painful because it attempts to load dependencies that may be set for `targets: @not_host`. This inevitably leads to `MIX_TARGET=host mix test` which adds a hurdle for promoting good test practices.