### PR TITLE
--paths= in rebar3 bare compile fixes subcommand splitting on comma bug

### DIFF
--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -183,7 +183,7 @@ defmodule Mix.Tasks.Deps.Compile do
     lib_path = Path.join(config[:env_path], "lib/*/ebin")
 
     env = [{"REBAR_CONFIG", config_path}, {"TERM", "dumb"}]
-    cmd = "#{rebar_cmd(dep)} bare compile --paths #{inspect(lib_path)}"
+    cmd = "#{rebar_cmd(dep)} bare compile --paths=#{inspect(lib_path)}"
 
     File.mkdir_p!(dep_path)
     File.write!(config_path, rebar_config(dep))


### PR DESCRIPTION
@ferd breaks down the issue here https://github.com/erlang/rebar3/issues/2102#issuecomment-500081989

But basically we need to use `--paths=` to get around an issue with how we use subscommands and getopt that can't at this time be fixed on the rebar3 side.