### PR TITLE
iex: Do not autocomplete private types

### DIFF
--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -445,10 +445,11 @@ defmodule IEx.Autocomplete do
   defp get_module_types(mod) do
     if ensure_loaded?(mod) do
       case Code.Typespec.fetch_types(mod) do
-        {:ok, specs} ->
-          Enum.map(specs, fn {_kind, {name, _, args}} ->
+        {:ok, types} ->
+          for {kind, {name, _, args}} <- types,
+              kind in [:type, :opaque] do
             {name, length(args)}
-          end)
+          end
 
         :error ->
           []


### PR DESCRIPTION
Ref: https://github.com/elixir-lang/elixir/pull/9110#issuecomment-498299548

> There's one thing somewhat related to this PR which is how we handle typeps, currently we display them in the list:
>
>     iex(2)> t :filelib
>     @typep filename() :: :file.name()

> but if we want to show just that type, it errors given its private:
>
>     iex(3)> t :filelib.filename
>     No type information for :filelib.filename was found or :filelib.filename is private

Btw, according to https://github.com/elixir-lang/elixir/issues/2612 we still want to list typeps, in this PR we'll just not autocomplete them.
