### PR TITLE
Add inspect/2 callback for Calendar

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -271,7 +271,7 @@ defmodule Calendar do
   The implementation must define inspect for `Date.t()`, `DateTime.t()` and
   `NaiveDateTime.t()` structs.
   """
-  @callback inspect(Time.t() | Date.t() | DateTime.t() | MaiveDateTime.t(), Inspect.Opts.t()) ::
+  @callback inspect(Time.t() | Date.t() | DateTime.t() | NaiveDateTime.t(), Inspect.Opts.t()) ::
               String.t()
 
   # General Helpers

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -291,7 +291,7 @@ defmodule Calendar do
               microsecond,
               Inspect.Opts.t()
             ) ::
-              String.t()
+              Inspect.Algebra.t()
 
   @doc """
   Implements inspect for a datetime.

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -267,19 +267,17 @@ defmodule Calendar do
 
   @doc """
   Implements inspect for a date.
-
   """
   @callback inspect_date(year, month, day, Inspect.Opts.t()) :: Inspect.Algebra.t()
 
   @doc """
   Implements inspect for a time.
-
   """
-  @callback inspect_time(hour, minute, second, microsecond, Inspect.Opts.t()) :: Inspect.Algebra.t()
+  @callback inspect_time(hour, minute, second, microsecond, Inspect.Opts.t()) ::
+              Inspect.Algebra.t()
 
   @doc """
   Implements inspect for a naive datetime.
-
   """
   @callback inspect_naive_datetime(
               year,
@@ -295,7 +293,6 @@ defmodule Calendar do
 
   @doc """
   Implements inspect for a datetime.
-
   """
   @callback inspect_datetime(
               year,

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -265,6 +265,15 @@ defmodule Calendar do
   """
   @callback valid_time?(hour, minute, second, microsecond) :: boolean
 
+  @doc """
+  Implements inspect for dates, datetimes and naive_datetimes.
+
+  If implemented, must define inspect for `Date.t()`, `DateTime.t()` and
+  `NaiveDateTime.t()` structs.
+  """
+  @callback inspect(date | datetime | naive_datetime, Inspect.Opts.t()) :: String.t()
+  @optional_callbacks inspect: 2
+
   # General Helpers
 
   @doc """

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -269,7 +269,7 @@ defmodule Calendar do
   Implements inspect for a date.
 
   """
-  @callback inspect_date(year, month, day, Inspect.Opts.t()) :: String.t()
+  @callback inspect_date(year, month, day, Inspect.Opts.t()) :: Inspect.Algebra.t()
 
   @doc """
   Implements inspect for a time.

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -266,13 +266,51 @@ defmodule Calendar do
   @callback valid_time?(hour, minute, second, microsecond) :: boolean
 
   @doc """
-  Implements inspect for times, dates, datetimes, and "naive" datetimes.
+  Implements inspect for a date.
 
-  The implementation must define inspect for `Date.t()`, `DateTime.t()` and
-  `NaiveDateTime.t()` structs.
   """
-  @callback inspect(Time.t() | Date.t() | DateTime.t() | NaiveDateTime.t(), Inspect.Opts.t()) ::
+  @callback inspect_date(year, month, day, Inspect.Opts.t()) :: String.t()
+
+  @doc """
+  Implements inspect for a time.
+
+  """
+  @callback inspect_time(hour, minute, second, microsecond, Inspect.Opts.t()) :: String.t()
+
+  @doc """
+  Implements inspect for a naive datetime.
+
+  """
+  @callback inspect_naive_datetime(
+              year,
+              month,
+              day,
+              hour,
+              minute,
+              second,
+              microsecond,
+              Inspect.Opts.t()
+            ) ::
               String.t()
+
+  @doc """
+  Implements inspect for a datetime.
+
+  """
+  @callback inspect_datetime(
+              year,
+              month,
+              day,
+              hour,
+              minute,
+              second,
+              microsecond,
+              time_zone,
+              zone_abbr,
+              utc_offset,
+              std_offset,
+              Inspect.Opts.t()
+            ) :: String.t()
 
   # General Helpers
 

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -310,7 +310,7 @@ defmodule Calendar do
               utc_offset,
               std_offset,
               Inspect.Opts.t()
-            ) :: String.t()
+            ) :: Inspect.Algebra.t()
 
   # General Helpers
 

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -271,7 +271,8 @@ defmodule Calendar do
   The implementation must define inspect for `Date.t()`, `DateTime.t()` and
   `NaiveDateTime.t()` structs.
   """
-  @callback inspect(time | date | datetime | naive_datetime, Inspect.Opts.t()) :: String.t()
+  @callback inspect(Time.t() | Date.t() | DateTime.t() | MaiveDateTime.t(), Inspect.Opts.t()) ::
+              String.t()
 
   # General Helpers
 

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -275,7 +275,7 @@ defmodule Calendar do
   Implements inspect for a time.
 
   """
-  @callback inspect_time(hour, minute, second, microsecond, Inspect.Opts.t()) :: String.t()
+  @callback inspect_time(hour, minute, second, microsecond, Inspect.Opts.t()) :: Inspect.Algebra.t()
 
   @doc """
   Implements inspect for a naive datetime.

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -268,11 +268,10 @@ defmodule Calendar do
   @doc """
   Implements inspect for dates, datetimes and naive_datetimes.
 
-  If implemented, must define inspect for `Date.t()`, `DateTime.t()` and
+  The implementation must define inspect for `Date.t()`, `DateTime.t()` and
   `NaiveDateTime.t()` structs.
   """
   @callback inspect(date | datetime | naive_datetime, Inspect.Opts.t()) :: String.t()
-  @optional_callbacks inspect: 2
 
   # General Helpers
 

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -769,10 +769,6 @@ defmodule Date do
   end
 
   defimpl Inspect do
-    def inspect(%{calendar: Calendar.ISO, year: year, month: month, day: day}, _) do
-      "~D[" <> Calendar.ISO.date_to_string(year, month, day) <> "]"
-    end
-
     def inspect(%{calendar: calendar} = date, opts) do
       if Code.ensure_loaded?(calendar) && function_exported?(calendar, :inspect, 2) do
         calendar.inspect(date, opts)

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -769,7 +769,7 @@ defmodule Date do
   end
 
   defimpl Inspect do
-    def inspect(%{calendar: calendar, year: _year, month: _month, day: _day} = date, opts) do
+    def inspect(%{calendar: calendar} = date, opts) do
       calendar.inspect(date, opts)
     end
   end

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -769,7 +769,7 @@ defmodule Date do
   end
 
   defimpl Inspect do
-    def inspect(%{calendar: calendar} = date, opts) do
+    def inspect(%{calendar: calendar, year: _year, month: _month, day: _day} = date, opts) do
       calendar.inspect(date, opts)
     end
   end

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -773,8 +773,12 @@ defmodule Date do
       "~D[" <> Calendar.ISO.date_to_string(year, month, day) <> "]"
     end
 
-    def inspect(date, opts) do
-      Inspect.Any.inspect(date, opts)
+    def inspect(%{calendar: calendar} = date, opts) do
+      if Code.ensure_loaded?(calendar) && function_exported?(calendar, :inspect, 2) do
+        calendar.inspect(date, opts)
+      else
+        Inspect.Any.inspect(date, opts)
+      end
     end
   end
 end

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -769,8 +769,8 @@ defmodule Date do
   end
 
   defimpl Inspect do
-    def inspect(%{calendar: calendar} = date, opts) do
-      calendar.inspect(date, opts)
+    def inspect(%{calendar: calendar, year: year, month: month, day: day}, opts) do
+      calendar.inspect_date(year, month, day, opts)
     end
   end
 end

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -770,11 +770,7 @@ defmodule Date do
 
   defimpl Inspect do
     def inspect(%{calendar: calendar} = date, opts) do
-      if Code.ensure_loaded?(calendar) && function_exported?(calendar, :inspect, 2) do
-        calendar.inspect(date, opts)
-      else
-        Inspect.Any.inspect(date, opts)
-      end
+      calendar.inspect(date, opts)
     end
   end
 end

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1369,11 +1369,7 @@ defmodule DateTime do
 
   defimpl Inspect do
     def inspect(%{calendar: calendar} = datetime, opts) do
-      if Code.ensure_loaded?(calendar) && function_exported?(calendar, :inspect, 2) do
-        calendar.inspect(datetime, opts)
-      else
-        Inspect.Any.inspect(datetime, opts)
-      end
+      calendar.inspect(datetime, opts)
     end
   end
 end

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1368,45 +1368,6 @@ defmodule DateTime do
   end
 
   defimpl Inspect do
-    def inspect(%{calendar: Calendar.ISO} = datetime, _) do
-      %{
-        year: year,
-        month: month,
-        day: day,
-        hour: hour,
-        minute: minute,
-        second: second,
-        microsecond: microsecond,
-        time_zone: time_zone,
-        zone_abbr: zone_abbr,
-        utc_offset: utc_offset,
-        std_offset: std_offset
-      } = datetime
-
-      formatted =
-        Calendar.ISO.datetime_to_string(
-          year,
-          month,
-          day,
-          hour,
-          minute,
-          second,
-          microsecond,
-          time_zone,
-          zone_abbr,
-          utc_offset,
-          std_offset
-        )
-
-      case datetime do
-        %{utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"} ->
-          "~U[" <> formatted <> "]"
-
-        _ ->
-          "#DateTime<" <> formatted <> ">"
-      end
-    end
-
     def inspect(%{calendar: calendar} = datetime, opts) do
       if Code.ensure_loaded?(calendar) && function_exported?(calendar, :inspect, 2) do
         calendar.inspect(datetime, opts)

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1369,7 +1369,34 @@ defmodule DateTime do
 
   defimpl Inspect do
     def inspect(%{calendar: calendar} = datetime, opts) do
-      calendar.inspect(datetime, opts)
+      %{
+        year: year,
+        month: month,
+        day: day,
+        hour: hour,
+        minute: minute,
+        second: second,
+        microsecond: microsecond,
+        time_zone: time_zone,
+        zone_abbr: zone_abbr,
+        utc_offset: utc_offset,
+        std_offset: std_offset
+      } = datetime
+
+      calendar.inspect_datetime(
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        microsecond,
+        time_zone,
+        zone_abbr,
+        utc_offset,
+        std_offset,
+        opts
+      )
     end
   end
 end

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1368,7 +1368,23 @@ defmodule DateTime do
   end
 
   defimpl Inspect do
-    def inspect(%{calendar: calendar} = datetime, opts) do
+    def inspect(
+          %{
+            calendar: calendar,
+            year: _year,
+            month: _month,
+            day: _day,
+            hour: _hour,
+            minute: _minute,
+            second: _second,
+            microsecond: _microsecond,
+            time_zone: _time_zone,
+            zone_abbr: _zone_abbr,
+            utc_offset: _utc_offset,
+            std_offset: _std_offset
+          } = datetime,
+          opts
+        ) do
       calendar.inspect(datetime, opts)
     end
   end

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1368,23 +1368,7 @@ defmodule DateTime do
   end
 
   defimpl Inspect do
-    def inspect(
-          %{
-            calendar: calendar,
-            year: _year,
-            month: _month,
-            day: _day,
-            hour: _hour,
-            minute: _minute,
-            second: _second,
-            microsecond: _microsecond,
-            time_zone: _time_zone,
-            zone_abbr: _zone_abbr,
-            utc_offset: _utc_offset,
-            std_offset: _std_offset
-          } = datetime,
-          opts
-        ) do
+    def inspect(%{calendar: calendar} = datetime, opts) do
       calendar.inspect(datetime, opts)
     end
   end

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1407,8 +1407,12 @@ defmodule DateTime do
       end
     end
 
-    def inspect(datetime, opts) do
-      Inspect.Any.inspect(datetime, opts)
+    def inspect(%{calendar: calendar} = datetime, opts) do
+      if Code.ensure_loaded?(calendar) && function_exported?(calendar, :inspect, 2) do
+        calendar.inspect(datetime, opts)
+      else
+        Inspect.Any.inspect(datetime, opts)
+      end
     end
   end
 end

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -716,36 +716,54 @@ defmodule Calendar.ISO do
   end
 
   @doc """
-  Implements the inspect protocol delegated from
-  `Date`, `Time`, `DateTime` and `NaiveDateTime`.
+  Implements the inspect protocol for a date
+  delegated from `Date`.
 
   """
   @doc since: "1.10.0"
   @impl true
-  @spec inspect(
-          Date.t() | Time.t() | DateTime.t() | NaiveDateTime.t(),
-          Inspect.Opts.t()
-        ) :: String.t()
-  def inspect(%Date{calendar: __MODULE__} = date, _) do
-    %{year: year, month: month, day: day} = date
+  @spec inspect_date(Calendar.year(), Calendar.month(), Calendar.day(), Inspect.Opts.t()) ::
+          String.t()
+  def inspect_date(year, month, day, _) do
     "~D[" <> date_to_string(year, month, day) <> "]"
   end
 
-  def inspect(%DateTime{calendar: __MODULE__} = datetime, _) do
-    %{
-      year: year,
-      month: month,
-      day: day,
-      hour: hour,
-      minute: minute,
-      second: second,
-      microsecond: microsecond,
-      time_zone: time_zone,
-      zone_abbr: zone_abbr,
-      utc_offset: utc_offset,
-      std_offset: std_offset
-    } = datetime
+  @doc """
+  Implements the inspect protocol for a datetime
+  delegated from `DateTime`.
 
+  """
+  @doc since: "1.10.0"
+  @impl true
+  @spec inspect_datetime(
+          Calendar.year(),
+          Calendar.month(),
+          Calendar.day(),
+          Calendar.hour(),
+          Calendar.minute(),
+          Calendar.second(),
+          Calendar.microsecond(),
+          Calendar.time_zone(),
+          Calendar.zone_abbr(),
+          Calendar.utc_offset(),
+          Calendar.std_offset(),
+          Inspect.Opts.t()
+        ) ::
+          String.t()
+  def inspect_datetime(
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        microsecond,
+        time_zone,
+        zone_abbr,
+        utc_offset,
+        std_offset,
+        _opts
+      ) do
     formatted =
       datetime_to_string(
         year,
@@ -761,40 +779,59 @@ defmodule Calendar.ISO do
         std_offset
       )
 
-    case datetime do
-      %{utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"} ->
-        "~U[" <> formatted <> "]"
-
-      _ ->
-        "#DateTime<" <> formatted <> ">"
+    if utc_offset == 0 && std_offset == 0 && time_zone == "Etc/UTC" do
+      "~U[" <> formatted <> "]"
+    else
+      "#DateTime<" <> formatted <> ">"
     end
   end
 
-  def inspect(%NaiveDateTime{calendar: __MODULE__} = naive_datetime, _) do
-    %{
-      year: year,
-      month: month,
-      day: day,
-      hour: hour,
-      minute: minute,
-      second: second,
-      microsecond: microsecond
-    } = naive_datetime
+  @doc """
+  Implements the inspect protocol for a naive
+  datetime delegated from `NaiveDateTime`.
 
+  """
+  @doc since: "1.10.0"
+  @impl true
+  @spec inspect_naive_datetime(
+          Calendar.year(),
+          Calendar.month(),
+          Calendar.day(),
+          Calendar.hour(),
+          Calendar.minute(),
+          Calendar.second(),
+          Calendar.microsecond(),
+          Inspect.Opts.t()
+        ) ::
+          String.t()
+  def inspect_naive_datetime(year, month, day, hour, minute, second, microsecond, _opts) do
     formatted = naive_datetime_to_string(year, month, day, hour, minute, second, microsecond)
 
     "~N[" <> formatted <> "]"
   end
 
-  def inspect(%Time{calendar: __MODULE__} = time, _) do
-    %{
-      hour: hour,
-      minute: minute,
-      second: second,
-      microsecond: microsecond,
-      calendar: Calendar.ISO
-    } = time
+  @doc """
+  Implements the inspect protocol for a time
+  delegated from `Time`.
 
+  """
+  @doc since: "1.10.0"
+  @impl true
+  @spec inspect_time(
+          Calendar.hour(),
+          Calendar.minute(),
+          Calendar.second(),
+          Calendar.microsecond(),
+          Inspect.Opts.t()
+        ) ::
+          String.t()
+  def inspect_time(
+        hour,
+        minute,
+        second,
+        microsecond,
+        _opts
+      ) do
     "~T[" <> Calendar.ISO.time_to_string(hour, minute, second, microsecond) <> "]"
   end
 

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -726,12 +726,12 @@ defmodule Calendar.ISO do
           Calendar.date() | Calendar.time() | Calendar.datetime() | Calendar.naive_datetime(),
           Inspect.Opts.t()
         ) :: String.t()
-  def inspect(%Date{} = date, _) do
+  def inspect(%Date{calendar: __MODULE__} = date, _) do
     %{year: year, month: month, day: day} = date
     "~D[" <> date_to_string(year, month, day) <> "]"
   end
 
-  def inspect(%DateTime{} = datetime, _) do
+  def inspect(%DateTime{calendar: __MODULE__} = datetime, _) do
     %{
       year: year,
       month: month,
@@ -770,7 +770,7 @@ defmodule Calendar.ISO do
     end
   end
 
-  def inspect(%NaiveDateTime{} = naive_datetime, _) do
+  def inspect(%NaiveDateTime{calendar: __MODULE__} = naive_datetime, _) do
     %{
       year: year,
       month: month,
@@ -786,7 +786,7 @@ defmodule Calendar.ISO do
     "~N[" <> formatted <> "]"
   end
 
-  def inspect(%Time{} = time, _) do
+  def inspect(%Time{calendar: __MODULE__} = time, _) do
     %{
       hour: hour,
       minute: minute,

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -824,7 +824,7 @@ defmodule Calendar.ISO do
           Calendar.microsecond(),
           Inspect.Opts.t()
         ) ::
-          String.t()
+          Inspect.Algebra.t()
   def inspect_time(
         hour,
         minute,

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -803,7 +803,7 @@ defmodule Calendar.ISO do
           Calendar.microsecond(),
           Inspect.Opts.t()
         ) ::
-          String.t()
+          Inspect.Algebra.t()
   def inspect_naive_datetime(year, month, day, hour, minute, second, microsecond, _opts) do
     formatted = naive_datetime_to_string(year, month, day, hour, minute, second, microsecond)
 

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -749,7 +749,7 @@ defmodule Calendar.ISO do
           Calendar.std_offset(),
           Inspect.Opts.t()
         ) ::
-          String.t()
+          Inspect.Algebra.t()
   def inspect_datetime(
         year,
         month,

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -723,7 +723,7 @@ defmodule Calendar.ISO do
   @doc since: "1.10.0"
   @impl true
   @spec inspect(
-          Calendar.date() | Calendar.time() | Calendar.datetime() | Calendar.naive_datetime(),
+          Date.t() | Time.t() | DateTime.t() | NaiveDateTime.t(),
           Inspect.Opts.t()
         ) :: String.t()
   def inspect(%Date{calendar: __MODULE__} = date, _) do

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -726,26 +726,24 @@ defmodule Calendar.ISO do
           Calendar.date() | Calendar.time() | Calendar.datetime() | Calendar.naive_datetime(),
           Inspect.Opts.t()
         ) :: String.t()
-  def inspect(%Date{} = date, _) do
-    %{year: year, month: month, day: day} = date
-    "~D[" <> date_to_string(year, month, day) <> "]"
-  end
 
-  def inspect(%DateTime{} = datetime, _) do
-    %{
-      year: year,
-      month: month,
-      day: day,
-      hour: hour,
-      minute: minute,
-      second: second,
-      microsecond: microsecond,
-      time_zone: time_zone,
-      zone_abbr: zone_abbr,
-      utc_offset: utc_offset,
-      std_offset: std_offset
-    } = datetime
-
+  def inspect(
+        %{
+          year: year,
+          month: month,
+          day: day,
+          hour: hour,
+          minute: minute,
+          second: second,
+          microsecond: microsecond,
+          time_zone: time_zone,
+          zone_abbr: zone_abbr,
+          utc_offset: utc_offset,
+          std_offset: std_offset,
+          calendar: Calendar.ISO
+        } = datetime,
+        _opts
+      ) do
     formatted =
       datetime_to_string(
         year,
@@ -770,32 +768,39 @@ defmodule Calendar.ISO do
     end
   end
 
-  def inspect(%NaiveDateTime{} = naive_datetime, _) do
-    %{
-      year: year,
-      month: month,
-      day: day,
-      hour: hour,
-      minute: minute,
-      second: second,
-      microsecond: microsecond
-    } = naive_datetime
-
+  def inspect(
+        %{
+          year: year,
+          month: month,
+          day: day,
+          hour: hour,
+          minute: minute,
+          second: second,
+          microsecond: microsecond,
+          calendar: Calendar.ISO
+        },
+        _opts
+      ) do
     formatted = naive_datetime_to_string(year, month, day, hour, minute, second, microsecond)
 
     "~N[" <> formatted <> "]"
   end
 
-  def inspect(%Time{} = time, _) do
-    %{
-      hour: hour,
-      minute: minute,
-      second: second,
-      microsecond: microsecond,
-      calendar: Calendar.ISO
-    } = time
-
+  def inspect(
+        %{
+          hour: hour,
+          minute: minute,
+          second: second,
+          microsecond: microsecond,
+          calendar: Calendar.ISO
+        },
+        _opts
+      ) do
     "~T[" <> Calendar.ISO.time_to_string(hour, minute, second, microsecond) <> "]"
+  end
+
+  def inspect(%{year: year, month: month, day: day, calendar: Calendar.ISO}, _) do
+    "~D[" <> date_to_string(year, month, day) <> "]"
   end
 
   defp offset_to_string(0, 0, "Etc/UTC", _format), do: "Z"

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -726,24 +726,26 @@ defmodule Calendar.ISO do
           Calendar.date() | Calendar.time() | Calendar.datetime() | Calendar.naive_datetime(),
           Inspect.Opts.t()
         ) :: String.t()
+  def inspect(%Date{} = date, _) do
+    %{year: year, month: month, day: day} = date
+    "~D[" <> date_to_string(year, month, day) <> "]"
+  end
 
-  def inspect(
-        %{
-          year: year,
-          month: month,
-          day: day,
-          hour: hour,
-          minute: minute,
-          second: second,
-          microsecond: microsecond,
-          time_zone: time_zone,
-          zone_abbr: zone_abbr,
-          utc_offset: utc_offset,
-          std_offset: std_offset,
-          calendar: Calendar.ISO
-        } = datetime,
-        _opts
-      ) do
+  def inspect(%DateTime{} = datetime, _) do
+    %{
+      year: year,
+      month: month,
+      day: day,
+      hour: hour,
+      minute: minute,
+      second: second,
+      microsecond: microsecond,
+      time_zone: time_zone,
+      zone_abbr: zone_abbr,
+      utc_offset: utc_offset,
+      std_offset: std_offset
+    } = datetime
+
     formatted =
       datetime_to_string(
         year,
@@ -768,39 +770,32 @@ defmodule Calendar.ISO do
     end
   end
 
-  def inspect(
-        %{
-          year: year,
-          month: month,
-          day: day,
-          hour: hour,
-          minute: minute,
-          second: second,
-          microsecond: microsecond,
-          calendar: Calendar.ISO
-        },
-        _opts
-      ) do
+  def inspect(%NaiveDateTime{} = naive_datetime, _) do
+    %{
+      year: year,
+      month: month,
+      day: day,
+      hour: hour,
+      minute: minute,
+      second: second,
+      microsecond: microsecond
+    } = naive_datetime
+
     formatted = naive_datetime_to_string(year, month, day, hour, minute, second, microsecond)
 
     "~N[" <> formatted <> "]"
   end
 
-  def inspect(
-        %{
-          hour: hour,
-          minute: minute,
-          second: second,
-          microsecond: microsecond,
-          calendar: Calendar.ISO
-        },
-        _opts
-      ) do
-    "~T[" <> Calendar.ISO.time_to_string(hour, minute, second, microsecond) <> "]"
-  end
+  def inspect(%Time{} = time, _) do
+    %{
+      hour: hour,
+      minute: minute,
+      second: second,
+      microsecond: microsecond,
+      calendar: Calendar.ISO
+    } = time
 
-  def inspect(%{year: year, month: month, day: day, calendar: Calendar.ISO}, _) do
-    "~D[" <> date_to_string(year, month, day) <> "]"
+    "~T[" <> Calendar.ISO.time_to_string(hour, minute, second, microsecond) <> "]"
   end
 
   defp offset_to_string(0, 0, "Etc/UTC", _format), do: "Z"

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -816,13 +816,7 @@ defmodule Calendar.ISO do
           Calendar.microsecond(),
           Inspect.Opts.t()
         ) :: Inspect.Algebra.t()
-  def inspect_time(
-        hour,
-        minute,
-        second,
-        microsecond,
-        _opts
-      ) do
+  def inspect_time(hour, minute, second, microsecond, _opts) do
     "~T[" <> Calendar.ISO.time_to_string(hour, minute, second, microsecond) <> "]"
   end
 

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -715,6 +715,77 @@ defmodule Calendar.ISO do
     {0, 1}
   end
 
+  @doc """
+  Implements the inspect protocol delegated from
+  `Date`, `DateTime` and `NaiveDateTime`.
+
+  """
+  @doc since: "1.10.0"
+  @impl true
+  @spec inspect(
+          Calendar.date() | Calendar.datetime() | Calendar.naive_datetime(),
+          Inspect.Opts.t()
+        ) :: String.t()
+  def inspect(%Date{} = date, _) do
+    %{year: year, month: month, day: day} = date
+    "~D[" <> date_to_string(year, month, day) <> "]"
+  end
+
+  def inspect(%DateTime{} = datetime, _) do
+    %{
+      year: year,
+      month: month,
+      day: day,
+      hour: hour,
+      minute: minute,
+      second: second,
+      microsecond: microsecond,
+      time_zone: time_zone,
+      zone_abbr: zone_abbr,
+      utc_offset: utc_offset,
+      std_offset: std_offset
+    } = datetime
+
+    formatted =
+      datetime_to_string(
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        microsecond,
+        time_zone,
+        zone_abbr,
+        utc_offset,
+        std_offset
+      )
+
+    case datetime do
+      %{utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"} ->
+        "~U[" <> formatted <> "]"
+
+      _ ->
+        "#DateTime<" <> formatted <> ">"
+    end
+  end
+
+  def inspect(%NaiveDateTime{} = naive_datetime, _) do
+    %{
+      year: year,
+      month: month,
+      day: day,
+      hour: hour,
+      minute: minute,
+      second: second,
+      microsecond: microsecond
+    } = naive_datetime
+
+    formatted = naive_datetime_to_string(year, month, day, hour, minute, second, microsecond)
+
+    "~N[" <> formatted <> "]"
+  end
+
   defp offset_to_string(0, 0, "Etc/UTC", _format), do: "Z"
 
   defp offset_to_string(utc, std, _zone, format) do

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -723,7 +723,7 @@ defmodule Calendar.ISO do
   @doc since: "1.10.0"
   @impl true
   @spec inspect_date(Calendar.year(), Calendar.month(), Calendar.day(), Inspect.Opts.t()) ::
-          String.t()
+          Inspect.Algebra.t()
   def inspect_date(year, month, day, _) do
     "~D[" <> date_to_string(year, month, day) <> "]"
   end

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -716,9 +716,7 @@ defmodule Calendar.ISO do
   end
 
   @doc """
-  Implements the inspect protocol for a date
-  delegated from `Date`.
-
+  Implements the `Inspect` protocol for `Date` in this calendar
   """
   @doc since: "1.10.0"
   @impl true
@@ -729,9 +727,7 @@ defmodule Calendar.ISO do
   end
 
   @doc """
-  Implements the inspect protocol for a datetime
-  delegated from `DateTime`.
-
+  Implements the `Inspect` protocol for `DateTime` in this calendar
   """
   @doc since: "1.10.0"
   @impl true
@@ -787,9 +783,7 @@ defmodule Calendar.ISO do
   end
 
   @doc """
-  Implements the inspect protocol for a naive
-  datetime delegated from `NaiveDateTime`.
-
+  Implements the `Inspect` protocol for `NaiveDateTime` in this calendar
   """
   @doc since: "1.10.0"
   @impl true
@@ -811,9 +805,7 @@ defmodule Calendar.ISO do
   end
 
   @doc """
-  Implements the inspect protocol for a time
-  delegated from `Time`.
-
+  Implements the `Inspect` protocol for `Time` in this calendar
   """
   @doc since: "1.10.0"
   @impl true
@@ -823,8 +815,7 @@ defmodule Calendar.ISO do
           Calendar.second(),
           Calendar.microsecond(),
           Inspect.Opts.t()
-        ) ::
-          Inspect.Algebra.t()
+        ) :: Inspect.Algebra.t()
   def inspect_time(
         hour,
         minute,

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -717,13 +717,13 @@ defmodule Calendar.ISO do
 
   @doc """
   Implements the inspect protocol delegated from
-  `Date`, `DateTime` and `NaiveDateTime`.
+  `Date`, `Time`, `DateTime` and `NaiveDateTime`.
 
   """
   @doc since: "1.10.0"
   @impl true
   @spec inspect(
-          Calendar.date() | Calendar.datetime() | Calendar.naive_datetime(),
+          Calendar.date() | Calendar.time() | Calendar.datetime() | Calendar.naive_datetime(),
           Inspect.Opts.t()
         ) :: String.t()
   def inspect(%Date{} = date, _) do
@@ -784,6 +784,18 @@ defmodule Calendar.ISO do
     formatted = naive_datetime_to_string(year, month, day, hour, minute, second, microsecond)
 
     "~N[" <> formatted <> "]"
+  end
+
+  def inspect(%Time{} = time, _) do
+    %{
+      hour: hour,
+      minute: minute,
+      second: second,
+      microsecond: microsecond,
+      calendar: Calendar.ISO
+    } = time
+
+    "~T[" <> Calendar.ISO.time_to_string(hour, minute, second, microsecond) <> "]"
   end
 
   defp offset_to_string(0, 0, "Etc/UTC", _format), do: "Z"

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -936,19 +936,7 @@ defmodule NaiveDateTime do
   end
 
   defimpl Inspect do
-    def inspect(
-          %{
-            calendar: calendar,
-            year: _year,
-            month: _month,
-            day: _day,
-            hour: _hour,
-            minute: _minute,
-            second: _second,
-            microsecond: _microsecond
-          } = naive_datetime,
-          opts
-        ) do
+    def inspect(%{calendar: calendar} = naive_datetime, opts) do
       calendar.inspect(naive_datetime, opts)
     end
   end

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -936,7 +936,19 @@ defmodule NaiveDateTime do
   end
 
   defimpl Inspect do
-    def inspect(%{calendar: calendar} = naive_datetime, opts) do
+    def inspect(
+          %{
+            calendar: calendar,
+            year: _year,
+            month: _month,
+            day: _day,
+            hour: _hour,
+            minute: _minute,
+            second: _second,
+            microsecond: _microsecond
+          } = naive_datetime,
+          opts
+        ) do
       calendar.inspect(naive_datetime, opts)
     end
   end

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -936,8 +936,20 @@ defmodule NaiveDateTime do
   end
 
   defimpl Inspect do
-    def inspect(%{calendar: calendar} = naive_datetime, opts) do
-      calendar.inspect(naive_datetime, opts)
+    def inspect(
+          %{
+            calendar: calendar,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute,
+            second: second,
+            microsecond: microsecond
+          },
+          opts
+        ) do
+      calendar.inspect_naive_datetime(year, month, day, hour, minute, second, microsecond, opts)
     end
   end
 end

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -953,8 +953,12 @@ defmodule NaiveDateTime do
       "~N[" <> formatted <> "]"
     end
 
-    def inspect(naive, opts) do
-      Inspect.Any.inspect(naive, opts)
+    def inspect(%{calendar: calendar} = naive_datetime, opts) do
+      if Code.ensure_loaded?(calendar) && function_exported?(calendar, :inspect, 2) do
+        calendar.inspect(naive_datetime, opts)
+      else
+        Inspect.Any.inspect(naive_datetime, opts)
+      end
     end
   end
 end

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -937,11 +937,7 @@ defmodule NaiveDateTime do
 
   defimpl Inspect do
     def inspect(%{calendar: calendar} = naive_datetime, opts) do
-      if Code.ensure_loaded?(calendar) && function_exported?(calendar, :inspect, 2) do
-        calendar.inspect(naive_datetime, opts)
-      else
-        Inspect.Any.inspect(naive_datetime, opts)
-      end
+      calendar.inspect(naive_datetime, opts)
     end
   end
 end

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -936,23 +936,6 @@ defmodule NaiveDateTime do
   end
 
   defimpl Inspect do
-    def inspect(%{calendar: Calendar.ISO} = naive_datetime, _) do
-      %{
-        year: year,
-        month: month,
-        day: day,
-        hour: hour,
-        minute: minute,
-        second: second,
-        microsecond: microsecond
-      } = naive_datetime
-
-      formatted =
-        Calendar.ISO.naive_datetime_to_string(year, month, day, hour, minute, second, microsecond)
-
-      "~N[" <> formatted <> "]"
-    end
-
     def inspect(%{calendar: calendar} = naive_datetime, opts) do
       if Code.ensure_loaded?(calendar) && function_exported?(calendar, :inspect, 2) do
         calendar.inspect(naive_datetime, opts)

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -693,12 +693,17 @@ defmodule Time do
   end
 
   defimpl Inspect do
-    def inspect(%{calendar: calendar} = time, opts) do
-      calendar.inspect(time, opts)
-    end
-
-    def inspect(time, opts) do
-      Inspect.Any.inspect(time, opts)
+    def inspect(
+          %{
+            hour: hour,
+            minute: minute,
+            second: second,
+            microsecond: microsecond,
+            calendar: calendar
+          },
+          opts
+        ) do
+      calendar.inspect_time(hour, minute, second, microsecond, opts)
     end
   end
 end

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -693,12 +693,17 @@ defmodule Time do
   end
 
   defimpl Inspect do
-    def inspect(%{calendar: calendar} = time, opts) do
+    def inspect(
+          %{
+            hour: _hour,
+            minute: _minute,
+            second: _second,
+            microsecond: _microsecond,
+            calendar: calendar
+          } = time,
+          opts
+        ) do
       calendar.inspect(time, opts)
-    end
-
-    def inspect(time, opts) do
-      Inspect.Any.inspect(time, opts)
     end
   end
 end

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -693,16 +693,8 @@ defmodule Time do
   end
 
   defimpl Inspect do
-    def inspect(%{calendar: Calendar.ISO} = time, _) do
-      %{
-        hour: hour,
-        minute: minute,
-        second: second,
-        microsecond: microsecond,
-        calendar: Calendar.ISO
-      } = time
-
-      "~T[" <> Calendar.ISO.time_to_string(hour, minute, second, microsecond) <> "]"
+    def inspect(%{calendar: calendar} = time, opts) do
+      calendar.inspect(time, opts)
     end
 
     def inspect(time, opts) do

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -693,17 +693,12 @@ defmodule Time do
   end
 
   defimpl Inspect do
-    def inspect(
-          %{
-            hour: _hour,
-            minute: _minute,
-            second: _second,
-            microsecond: _microsecond,
-            calendar: calendar
-          } = time,
-          opts
-        ) do
+    def inspect(%{calendar: calendar} = time, opts) do
       calendar.inspect(time, opts)
+    end
+
+    def inspect(time, opts) do
+      Inspect.Any.inspect(time, opts)
     end
   end
 end

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -19,6 +19,9 @@ defmodule DateTest do
 
     date = %{~D[2000-01-01] | calendar: FakeCalendar}
     assert inspect(date) == "%Date{calendar: FakeCalendar, day: 1, month: 1, year: 2000}"
+
+    date = %{~D[2000-01-01] | calendar: Calendar.Holocene}
+    assert inspect(date) == "2000-1-1 (HE)"
   end
 
   test "compare/2" do

--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -28,6 +28,25 @@ defmodule DateTimeTest do
              "2000-02-29 23:00:07-02:30 BRM Brazil/Manaus"
   end
 
+  test "Kernel.inspect/1" do
+    datetime = %DateTime{
+      year: 2000,
+      month: 2,
+      day: 29,
+      zone_abbr: "BRM",
+      hour: 23,
+      minute: 0,
+      second: 7,
+      microsecond: {0, 0},
+      utc_offset: -12600,
+      std_offset: 3600,
+      time_zone: "Brazil/Manaus"
+    }
+
+    datetime = %{datetime | calendar: Calendar.Holocene}
+    assert inspect(datetime) == "2000-2-29 23:00:07 BRM (HE)"
+  end
+
   test "from_iso8601/1 handles positive and negative offsets" do
     assert DateTime.from_iso8601("2015-01-24T09:50:07-10:00") |> elem(1) ==
              %DateTime{

--- a/lib/elixir/test/elixir/calendar/fakes.exs
+++ b/lib/elixir/test/elixir/calendar/fakes.exs
@@ -5,8 +5,13 @@ defmodule FakeCalendar do
   def datetime_to_string(_, _, _, _, _, _, _, _, _, _), do: "boom"
   def day_rollover_relative_to_midnight_utc, do: {123_456, 123_457}
 
-  def inspect(date_or_datetime, opts) do
-    Inspect.Any.inspect(date_or_datetime, opts)
+  def inspect_date(_year, _month, _day, _) do
+    "%Date{calendar: FakeCalendar, day: 1, month: 1, year: 2000}"
+  end
+
+  def inspect_naive_datetime(_year, _month, _day, _hour, _minute, _second, _microsecond, _) do
+    "%NaiveDateTime{calendar: FakeCalendar, day: 1, hour: 23, " <>
+      "microsecond: {5000, 3}, minute: 0, month: 1, second: 7, year: 2000}"
   end
 end
 

--- a/lib/elixir/test/elixir/calendar/fakes.exs
+++ b/lib/elixir/test/elixir/calendar/fakes.exs
@@ -4,6 +4,10 @@ defmodule FakeCalendar do
   def naive_datetime_to_string(_, _, _, _, _, _, _), do: "boom"
   def datetime_to_string(_, _, _, _, _, _, _, _, _, _), do: "boom"
   def day_rollover_relative_to_midnight_utc, do: {123_456, 123_457}
+
+  def inspect(date_or_datetime, opts) do
+    Inspect.Any.inspect(date_or_datetime, opts)
+  end
 end
 
 defmodule FakeTimeZoneDatabase do

--- a/lib/elixir/test/elixir/calendar/holocene.exs
+++ b/lib/elixir/test/elixir/calendar/holocene.exs
@@ -47,7 +47,7 @@ defmodule Calendar.Holocene do
         _utc_offset,
         _std_offset
       ) do
-    "#{year}-#{month}-#{day}" <>
+    "#{year}-#{month}-#{day} " <>
       Calendar.ISO.time_to_string(hour, minute, second, microsecond) <> " #{zone_abbr} (HE)"
   end
 
@@ -69,6 +69,65 @@ defmodule Calendar.Holocene do
   def naive_datetime_to_iso_days(year, month, day, hour, minute, second, microsecond) do
     Calendar.ISO.naive_datetime_to_iso_days(
       year - 10000,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      microsecond
+    )
+  end
+
+  @impl true
+  def inspect(%Date{year: year, month: month, day: day}, _opts) do
+    date_to_string(year, month, day)
+  end
+
+  def inspect(
+        %DateTime{
+          year: year,
+          month: month,
+          day: day,
+          hour: hour,
+          minute: minute,
+          second: second,
+          microsecond: microsecond,
+          time_zone: time_zone,
+          zone_abbr: zone_abbr,
+          utc_offset: utc_offset,
+          std_offset: std_offset
+        },
+        _opts
+      ) do
+    datetime_to_string(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      microsecond,
+      time_zone,
+      zone_abbr,
+      utc_offset,
+      std_offset
+    )
+  end
+
+  def inspect(
+        %NaiveDateTime{
+          year: year,
+          month: month,
+          day: day,
+          hour: hour,
+          minute: minute,
+          second: second,
+          microsecond: microsecond
+        },
+        _opts
+      ) do
+    naive_datetime_to_string(
+      year,
       month,
       day,
       hour,

--- a/lib/elixir/test/elixir/calendar/holocene.exs
+++ b/lib/elixir/test/elixir/calendar/holocene.exs
@@ -79,8 +79,6 @@ defmodule Calendar.Holocene do
   end
 
   @impl true
-  @spec inspect_date(Calendar.year(), Calendar.month(), Calendar.day(), Inspect.Opts.t()) ::
-          String.t()
   def inspect_date(year, month, day, _) do
     date_to_string(year, month, day)
   end

--- a/lib/elixir/test/elixir/calendar/holocene.exs
+++ b/lib/elixir/test/elixir/calendar/holocene.exs
@@ -79,24 +79,25 @@ defmodule Calendar.Holocene do
   end
 
   @impl true
-  def inspect(%Date{year: year, month: month, day: day}, _opts) do
+  @spec inspect_date(Calendar.year(), Calendar.month(), Calendar.day(), Inspect.Opts.t()) ::
+          String.t()
+  def inspect_date(year, month, day, _) do
     date_to_string(year, month, day)
   end
 
-  def inspect(
-        %DateTime{
-          year: year,
-          month: month,
-          day: day,
-          hour: hour,
-          minute: minute,
-          second: second,
-          microsecond: microsecond,
-          time_zone: time_zone,
-          zone_abbr: zone_abbr,
-          utc_offset: utc_offset,
-          std_offset: std_offset
-        },
+  @impl true
+  def inspect_datetime(
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        microsecond,
+        time_zone,
+        zone_abbr,
+        utc_offset,
+        std_offset,
         _opts
       ) do
     datetime_to_string(
@@ -114,27 +115,20 @@ defmodule Calendar.Holocene do
     )
   end
 
-  def inspect(
-        %NaiveDateTime{
-          year: year,
-          month: month,
-          day: day,
-          hour: hour,
-          minute: minute,
-          second: second,
-          microsecond: microsecond
-        },
+  @impl true
+  def inspect_naive_datetime(year, month, day, hour, minute, second, microsecond, _opts) do
+    naive_datetime_to_string(year, month, day, hour, minute, second, microsecond)
+  end
+
+  @impl true
+  def inspect_time(
+        hour,
+        minute,
+        second,
+        microsecond,
         _opts
       ) do
-    naive_datetime_to_string(
-      year,
-      month,
-      day,
-      hour,
-      minute,
-      second,
-      microsecond
-    )
+    Calendar.ISO.time_to_string(hour, minute, second, microsecond)
   end
 
   @impl true

--- a/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
@@ -22,6 +22,9 @@ defmodule NaiveDateTimeTest do
     assert inspect(ndt) ==
              "%NaiveDateTime{calendar: FakeCalendar, day: 1, hour: 23, " <>
                "microsecond: {5000, 3}, minute: 0, month: 1, second: 7, year: 2000}"
+
+    ndt = %{~N[2000-01-01 23:00:07.005] | calendar: Calendar.Holocene}
+    assert inspect(ndt == "~N[-0100-12-31 23:00:07.005] (HE)")
   end
 
   test "compare/2" do

--- a/lib/elixir/test/elixir/calendar/time_test.exs
+++ b/lib/elixir/test/elixir/calendar/time_test.exs
@@ -10,6 +10,11 @@ defmodule TimeTest do
     assert to_string(~T[23:00:07.005]) == "23:00:07.005"
   end
 
+  test "inspect/2" do
+    holocene_time = %{~T[23:00:07.005] | calendar: Calendar.Holocene}
+    assert inspect(holocene_time) == "23:00:07.005"
+  end
+
   test "Kernel.inspect/1" do
     assert inspect(~T[23:00:07.005]) == "~T[23:00:07.005]"
   end


### PR DESCRIPTION
PR based upon the conversation at https://elixirforum.com/t/how-to-support-multiple-week-calendars-in-elixir/18783/10

Date, Time, DateTime and NaiveDateTime implement the
`Inspect` protocol with a specific implementation
for `Calendar.ISO`.

This commit introduces a required callback, `inspect/2`
required in all modules implementing the `Calendar` 
behaviour.

Calendars implementing `inspect/2` must ensure
the implementation caters for `Date`, `Time`, `DateTime` and
`NaiveDateTime` structs.