### PR TITLE
Fix redirection to null on windows

### DIFF
--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -270,11 +270,11 @@ defmodule Mix.Tasks.Release.Init do
     )
 
     if not "!REL_GOTO!" == "" (
-      findstr "RUNTIME_CONFIG=true" "!RELEASE_SYS_CONFIG!.config" >nil 2>&1 && (
+      findstr "RUNTIME_CONFIG=true" "!RELEASE_SYS_CONFIG!.config" >nul 2>&1 && (
         for /f "skip=1" %%X in ('wmic os get localdatetime') do if not defined TIMESTAMP set TIMESTAMP=%%X
         set RELEASE_SYS_CONFIG=!RELEASE_TMP!\!RELEASE_NAME!-!RELEASE_VSN!-!TIMESTAMP:~0,11!-!RANDOM!.runtime
-        mkdir "!RELEASE_TMP!" >nil
-        copy /y "!REL_VSN_DIR!\sys.config" "!RELEASE_SYS_CONFIG!.config" >nil || (
+        mkdir "!RELEASE_TMP!" >nul
+        copy /y "!REL_VSN_DIR!\sys.config" "!RELEASE_SYS_CONFIG!.config" >nul || (
           echo Cannot start release because it could not write to "!RELEASE_SYS_CONFIG!.config"
           goto end
         )


### PR DESCRIPTION
Concerning generated `bin/xxx.bat` from `mix release`.
Otherwise I got a file called `nil` within my directory, after starting a release.
In my case with the contents of `1 file(s) copied.`

I think there aren't any tests regarding this change, but I'm not 100% sure.
Please review, as this is my very first contribution.