### PR TITLE
Add RELEASE_BOOT_SCRIPT and RELEASE_BOOT_SCRIPT_CLEAN

### DIFF
--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -667,17 +667,17 @@ defmodule Mix.Tasks.Release do
       not running on Erlang/OTP 22 or later, you must set `RELEASE_NODE`
       to `RELEASE_NAME@127.0.0.1` with an IP or a known host
 
-    * `RELEASE_BOOT_SCRIPT` - The name of the boot script to use when starting
+    * `RELEASE_BOOT_SCRIPT` - the name of the boot script to use when starting
       the release. This script is used when running commands such as `start` and
       `daemon`. The boot script is expected to be located at the
-      path `releases/RELEASE_VSN/RELEASE_BOOT_SCRIPT.boot`. Defaults to `start`.
+      path `releases/RELEASE_VSN/RELEASE_BOOT_SCRIPT.boot`. Defaults to `start`
 
-    * `RELEASE_BOOT_SCRIPT_CLEAN` - The name of the boot script used when
+    * `RELEASE_BOOT_SCRIPT_CLEAN` - the name of the boot script used when
       starting the release clean, without your application or its dependencies.
       This script is used by commands such as `eval`, `rpc`, and `remote`.
       The boot script is expected to be located at the path
       `releases/RELEASE_VSN/RELEASE_BOOT_SCRIPT_CLEAN.boot`. Defaults
-      to `start_clean`.
+      to `start_clean`
 
   ## Umbrellas
 

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -667,6 +667,18 @@ defmodule Mix.Tasks.Release do
       not running on Erlang/OTP 22 or later, you must set `RELEASE_NODE`
       to `RELEASE_NAME@127.0.0.1` with an IP or a known host
 
+    * `RELEASE_BOOT_SCRIPT` - The name of the boot script to use when starting
+      the release. This script is used when running commands such as `start` and
+      `daemon`. The boot script is expected to be located at the
+      path `releases/RELEASE_VSN/RELEASE_BOOT_SCRIPT.boot`. Defaults to `start`.
+
+    * `RELEASE_BOOT_SCRIPT_CLEAN` - The name of the boot script used when
+      starting the release clean, without your application or its dependencies.
+      This script is used by commands such as `eval`, `rpc`, and `remote`.
+      The boot script is expected to be located at the path
+      `releases/RELEASE_VSN/RELEASE_BOOT_SCRIPT_CLEAN.boot`. Defaults
+      to `start_clean`.
+
   ## Umbrellas
 
   Releases are well integrated with umbrella projects, allowing you to

--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -94,6 +94,8 @@ defmodule Mix.Tasks.Release.Init do
     export RELEASE_TMP="${RELEASE_TMP:-"$RELEASE_ROOT/tmp"}"
     export RELEASE_VM_ARGS="${RELEASE_VM_ARGS:-"$REL_VSN_DIR/vm.args"}"
     export RELEASE_DISTRIBUTION="${RELEASE_DISTRIBUTION:-"sname"}"
+    export RELEASE_BOOT_SCRIPT="${RELEASE_BOOT_SCRIPT:-"start"}"
+    export RELEASE_BOOT_SCRIPT_CLEAN="${RELEASE_BOOT_SCRIPT_CLEAN:-"start_clean"}"
 
     rand () {
       od -t xS -N 2 -A n /dev/urandom | tr -d " \n"
@@ -103,7 +105,7 @@ defmodule Mix.Tasks.Release.Init do
       exec "$REL_VSN_DIR/elixir" \
            --hidden --cookie "$RELEASE_COOKIE" \
            --$RELEASE_DISTRIBUTION "rpc-$(rand)-$RELEASE_NODE" \
-           --boot "$REL_VSN_DIR/start_clean" \
+           --boot "$REL_VSN_DIR/$RELEASE_BOOT_SCRIPT_CLEAN" \
            --boot-var RELEASE_LIB "$RELEASE_ROOT/lib" \
            --rpc-eval "$RELEASE_NODE" "$1"
     }
@@ -117,7 +119,7 @@ defmodule Mix.Tasks.Release.Init do
            --$RELEASE_DISTRIBUTION "$RELEASE_NODE" \
            --erl "-mode $RELEASE_MODE" \
            --erl-config "$RELEASE_SYS_CONFIG" \
-           --boot "$REL_VSN_DIR/start" \
+           --boot "$REL_VSN_DIR/$RELEASE_BOOT_SCRIPT" \
            --boot-var RELEASE_LIB "$RELEASE_ROOT/lib" \
            --vm-args "$RELEASE_VM_ARGS" "$@"
     }
@@ -164,7 +166,7 @@ defmodule Mix.Tasks.Release.Init do
         exec "$REL_VSN_DIR/elixir" \
            --cookie "$RELEASE_COOKIE" \
            --erl-config "$RELEASE_SYS_CONFIG" \
-           --boot "$REL_VSN_DIR/start_clean" \
+           --boot "$REL_VSN_DIR/$RELEASE_BOOT_SCRIPT_CLEAN" \
            --boot-var RELEASE_LIB "$RELEASE_ROOT/lib" \
            --vm-args "$RELEASE_VM_ARGS" --eval "$2"
         ;;
@@ -173,7 +175,7 @@ defmodule Mix.Tasks.Release.Init do
         exec "$REL_VSN_DIR/iex" \
              --werl --hidden --cookie "$RELEASE_COOKIE" \
              --$RELEASE_DISTRIBUTION "rem-$(rand)-$RELEASE_NODE" \
-             --boot "$REL_VSN_DIR/start_clean" \
+             --boot "$REL_VSN_DIR/$RELEASE_BOOT_SCRIPT_CLEAN" \
              --boot-var RELEASE_LIB "$RELEASE_ROOT/lib" \
              --remsh "$RELEASE_NODE"
         ;;
@@ -256,6 +258,8 @@ defmodule Mix.Tasks.Release.Init do
     if not defined RELEASE_TMP (set RELEASE_TMP=!RELEASE_ROOT!\tmp)
     if not defined RELEASE_VM_ARGS (set RELEASE_VM_ARGS=!REL_VSN_DIR!\vm.args)
     if not defined RELEASE_DISTRIBUTION (set RELEASE_DISTRIBUTION=sname)
+    if not defined RELEASE_BOOT_SCRIPT (set RELEASE_BOOT_SCRIPT=start)
+    if not defined RELEASE_BOOT_SCRIPT (set RELEASE_BOOT_SCRIPT_CLEAN=start_clean)
     set RELEASE_SYS_CONFIG=!REL_VSN_DIR!\sys
 
     if "%~1" == "start" (set "REL_EXEC=elixir" && set "REL_EXTRA=--no-halt" && set "REL_GOTO=start")
@@ -321,7 +325,7 @@ defmodule Mix.Tasks.Release.Init do
       --!RELEASE_DISTRIBUTION! "!RELEASE_NODE!" ^
       --erl "-mode !RELEASE_MODE!" ^
       --erl-config "!RELEASE_SYS_CONFIG!" ^
-      --boot "!REL_VSN_DIR!\start" ^
+      --boot "!REL_VSN_DIR!\!RELEASE_BOOT_SCRIPT!" ^
       --boot-var RELEASE_LIB "!RELEASE_ROOT!\lib" ^
       --vm-args "!RELEASE_VM_ARGS!"
     goto end
@@ -331,7 +335,7 @@ defmodule Mix.Tasks.Release.Init do
       --eval "%~2" ^
       --cookie "!RELEASE_COOKIE!" ^
       --erl-config "!RELEASE_SYS_CONFIG!" ^
-      --boot "!REL_VSN_DIR!\start_clean" ^
+      --boot "!REL_VSN_DIR!\!RELEASE_BOOT_SCRIPT_CLEAN!" ^
       --boot-var RELEASE_LIB "!RELEASE_ROOT!\lib" ^
       --vm-args "!RELEASE_VM_ARGS!"
     goto end
@@ -340,7 +344,7 @@ defmodule Mix.Tasks.Release.Init do
     "!REL_VSN_DIR!\iex.bat" ^
       --werl --hidden --cookie "!RELEASE_COOKIE!" ^
       --!RELEASE_DISTRIBUTION! "rem-!RANDOM!-!RELEASE_NODE!" ^
-      --boot "!REL_VSN_DIR!\start_clean" ^
+      --boot "!REL_VSN_DIR!\!RELEASE_BOOT_SCRIPT_CLEAN!" ^
       --boot-var RELEASE_LIB "!RELEASE_ROOT!\lib" ^
       --remsh "!RELEASE_NODE!"
     goto end
@@ -349,7 +353,7 @@ defmodule Mix.Tasks.Release.Init do
     "!REL_VSN_DIR!\elixir.bat" ^
       --hidden --cookie "!RELEASE_COOKIE!" ^
       --!RELEASE_DISTRIBUTION! "rpc-!RANDOM!-!RELEASE_NODE!" ^
-      --boot "!REL_VSN_DIR!\start_clean" ^
+      --boot "!REL_VSN_DIR!\!RELEASE_BOOT_SCRIPT_CLEAN!" ^
       --boot-var RELEASE_LIB "!RELEASE_ROOT!\lib" ^
       --rpc-eval "!RELEASE_NODE!" "!REL_RPC!"
     goto end


### PR DESCRIPTION
Elixir releases offer a mechanism for generating custom boot scripts in addition to `start` and `start_clean`. This is done by adding a key value pair to the `boot_scripts` map in the `Mix.Release` struct. The generated executables currently do not offer a means for using this boot script. This PR adds the environment variables `RELEASE_BOOT_SCRIPT` and `RELEASE_BOOT_SCRIPT_CLEAN` providing overrides for `start` and `start_clean`.