### PR TITLE
Deduplicate relative paths in protocol consolidation

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -463,14 +463,12 @@ defmodule Protocol do
         do: mod
   end
 
-  defp list_dir(path) when is_list(path) do
+  defp list_dir(path) do
     case :file.list_dir(path) do
       {:ok, files} -> files
       _ -> []
     end
   end
-
-  defp list_dir(path), do: list_dir(to_charlist(path))
 
   defp extract_from_file(path, file, prefix, callback) do
     if :lists.prefix(prefix, file) and :filename.extension(file) == '.beam' do
@@ -478,7 +476,7 @@ defmodule Protocol do
     end
   end
 
-  defp extract_from_beam(file, callback) do
+  defp extract_from_beam(file, callback) when is_list(file) do
     case :beam_lib.chunks(file, [:attributes]) do
       {:ok, {module, [attributes: attributes]}} ->
         callback.(module, attributes)
@@ -486,6 +484,10 @@ defmodule Protocol do
       _ ->
         nil
     end
+  end
+
+  defp extract_from_beam(file, callback) do
+    extract_from_beam(to_charlist(file), callback)
   end
 
   @doc """

--- a/lib/mix/lib/mix/tasks/compile.protocols.ex
+++ b/lib/mix/lib/mix/tasks/compile.protocols.ex
@@ -109,11 +109,19 @@ defmodule Mix.Tasks.Compile.Protocols do
   end
 
   defp consolidation_paths do
-    filter_otp(:code.get_path(), :code.lib_dir())
+    :code.get_path()
+    |> filter_otp(:code.lib_dir())
+    |> filter_duplicates()
   end
 
   defp filter_otp(paths, otp) do
-    Enum.filter(paths, &(not :lists.prefix(&1, otp)))
+    Enum.filter(paths, &(not :lists.prefix(otp, &1)))
+  end
+
+  defp filter_duplicates(paths) do
+    paths
+    |> Enum.map(&Path.expand/1)
+    |> Enum.uniq()
   end
 
   defp consolidate([], _paths, output, manifest, metadata, _opts) do


### PR DESCRIPTION
The issue I was having in my environment (which you can replicate using nix with `nix-shell -p elixir`)  was that `:code.get_path()` returns duplicate paths for the elixir lib in the form:
```
.../elixir/bin/../lib/elixir/ebin
.../elixir/lib/elixir/ebin
```

This caused duplicate protocol implementations to be found and a bunch of warnings were getting spit out at every compile, but I think it would be better for elixir to handle these cases gracefully.

The main addition here calls `Path.expand/1` on every path and then `Enum.uniq/1` to remove duplicates. I also noticed the args were flipped in `:lists.prefix/2` for removing the OTP paths. Passing String paths to `Protocol.extract_impls/2` then caused an issue (even though the typespec says it accepts Strings) because `:beam_lib.chunks/2` only accepts charlist paths. Incidently, I noticed that `:file.list_dir/1` DOES accept either type, so I removed the unnecessary guard.