### PR TITLE
Improve a comment in env.sh.eex for releases

### DIFF
--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -66,8 +66,8 @@ defmodule Mix.Tasks.Release.Init do
     #   export ELIXIR_ERL_OPTIONS="-heart"
     # fi
 
-    # Set the release to work across nodes. If using the long name format like the
-    # one below (my_app@127.0.0.1), you need to also uncomment the
+    # Set the release to work across nodes. If using the long name format like
+    # the one below (my_app@127.0.0.1), you need to also uncomment the
     # RELEASE_DISTRIBUTION variable below.
     # export RELEASE_DISTRIBUTION=name
     # export RELEASE_NODE=<%= @release.name %>@127.0.0.1
@@ -232,7 +232,9 @@ defmodule Mix.Tasks.Release.Init do
   def env_bat_text,
     do: ~S"""
     @echo off
-    rem Set the release to work across nodes
+    rem Set the release to work across nodes. If using the long name format like
+    rem the one below (my_app@127.0.0.1), you need to also uncomment the
+    rem RELEASE_DISTRIBUTION variable below.
     rem set RELEASE_DISTRIBUTION=name
     rem set RELEASE_NODE=<%= @release.name %>@127.0.0.1
     """

--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -66,7 +66,7 @@ defmodule Mix.Tasks.Release.Init do
     #   export ELIXIR_ERL_OPTIONS="-heart"
     # fi
 
-    # Set the release to work across nodes. If using a long name like the
+    # Set the release to work across nodes. If using the long name format like the
     # one below (my_app@127.0.0.1), you need to also uncomment the
     # RELEASE_DISTRIBUTION variable below.
     # export RELEASE_DISTRIBUTION=name

--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -66,7 +66,9 @@ defmodule Mix.Tasks.Release.Init do
     #   export ELIXIR_ERL_OPTIONS="-heart"
     # fi
 
-    # Set the release to work across nodes
+    # Set the release to work across nodes. If using a long name like the
+    # one below (my_app@127.0.0.1), you need to also uncomment the
+    # RELEASE_DISTRIBUTION variable below.
     # export RELEASE_DISTRIBUTION=name
     # export RELEASE_NODE=<%= @release.name %>@127.0.0.1
     """


### PR DESCRIPTION
When reading the file, it's not clear why uncommenting `RELEASE_NODE` fails and it fails with a message that is not easy to act on (`Can't set short node name!\nPlease check your configuration`).