### PR TITLE
Place Version.Requirement module under Basic Types in docs.exs

### DIFF
--- a/lib/elixir/docs.exs
+++ b/lib/elixir/docs.exs
@@ -26,7 +26,8 @@
       Time,
       Tuple,
       URI,
-      Version
+      Version,
+      Version.Requirement
     ],
     "Collections & Enumerables": [
       Access,


### PR DESCRIPTION
As of now, it was floating around at the same level as Kernel and Kernel.SpecialForms