### PR TITLE
Use heredocs for top-level executables' usage docs

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -2,22 +2,23 @@
 set -e
 
 if [ $# -eq 0 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
-  echo "Usage: $(basename "$0") [options] [.exs file] [data]
+  cat <<USAGE >&2
+Usage: $(basename "$0") [options] [.exs file] [data]
 
 ## General options
 
-  -e \"COMMAND\"                 Evaluates the given command (*)
+  -e "COMMAND"                 Evaluates the given command (*)
   -h, --help                   Prints this message and exits
-  -r \"FILE\"                    Requires the given files/patterns (*)
+  -r "FILE"                    Requires the given files/patterns (*)
   -S SCRIPT                    Finds and executes the given script in \$PATH
-  -pr \"FILE\"                   Requires the given files/patterns in parallel (*)
-  -pa \"PATH\"                   Prepends the given path to Erlang code path (*)
-  -pz \"PATH\"                   Appends the given path to Erlang code path (*)
+  -pr "FILE"                   Requires the given files/patterns in parallel (*)
+  -pa "PATH"                   Prepends the given path to Erlang code path (*)
+  -pz "PATH"                   Appends the given path to Erlang code path (*)
   -v, --version                Prints Elixir version and exits
 
   --app APP                    Starts the given app and its dependencies (*)
-  --erl \"SWITCHES\"             Switches to be passed down to Erlang (*)
-  --eval \"COMMAND\"             Evaluates the given command, same as -e (*)
+  --erl "SWITCHES"             Switches to be passed down to Erlang (*)
+  --eval "COMMAND"             Evaluates the given command, same as -e (*)
   --logger-otp-reports BOOL    Enables or disables OTP reporting
   --logger-sasl-reports BOOL   Enables or disables SASL reporting
   --no-halt                    Does not halt the Erlang VM after execution
@@ -33,24 +34,25 @@ The following options are related to node distribution.
   --cookie COOKIE              Sets a cookie for this distributed node
   --hidden                     Makes a hidden node
   --name NAME                  Makes and assigns a name to the distributed node
-  --rpc-eval NODE \"COMMAND\"    Evaluates the given command on the given remote node (*)
+  --rpc-eval NODE "COMMAND"    Evaluates the given command on the given remote node (*)
   --sname NAME                 Makes and assigns a short name to the distributed node
 
 ## Release options
 
 The following options are generally used under releases.
 
-  --boot \"FILE\"                Uses the given FILE.boot to start the system
-  --boot-var VAR \"VALUE\"       Makes \$VAR available as VALUE to FILE.boot (*)
-  --erl-config \"FILE\"          Loads configuration in FILE.config written in Erlang (*)
-  --pipe-to \"PIPEDIR\" \"LOGDIR\" Starts the Erlang VM as a named PIPEDIR and LOGDIR
-  --vm-args \"FILE\"             Passes the contents in file as arguments to the VM
+  --boot "FILE"                Uses the given FILE.boot to start the system
+  --boot-var VAR "VALUE"       Makes \$VAR available as VALUE to FILE.boot (*)
+  --erl-config "FILE"          Loads configuration in FILE.config written in Erlang (*)
+  --pipe-to "PIPEDIR" "LOGDIR" Starts the Erlang VM as a named PIPEDIR and LOGDIR
+  --vm-args "FILE"             Passes the contents in file as arguments to the VM
 
 --pipe-to starts Elixir detached from console (Unix-like only).
 It will attempt to create PIPEDIR and LOGDIR if they don't exist.
 See run_erl to learn more. To reattach, run: to_erl PIPEDIR.
 
-** Options marked with (*) can be given more than once." >&2
+** Options marked with (*) can be given more than once.
+USAGE
   exit 1
 fi
 

--- a/bin/elixirc
+++ b/bin/elixirc
@@ -2,7 +2,8 @@
 set -e
 
 if [ $# -eq 0 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
-  echo "Usage: $(basename "$0") [elixir switches] [compiler switches] [.ex files]
+  cat <<USAGE >&2
+Usage: $(basename "$0") [elixir switches] [compiler switches] [.ex files]
 
   -h, --help                Prints this message and exits
   -o                        The directory to output compiled files
@@ -16,7 +17,8 @@ if [ $# -eq 0 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
 
 Options given after -- are passed down to the executed code.
 Options can be passed to the Erlang runtime using \$ELIXIR_ERL_OPTIONS.
-Options can be passed to the Erlang compiler using \$ERL_COMPILER_OPTIONS." >&2
+Options can be passed to the Erlang compiler using \$ERL_COMPILER_OPTIONS.
+USAGE
   exit 1
 fi
 

--- a/bin/iex
+++ b/bin/iex
@@ -2,15 +2,17 @@
 set -e
 
 if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
-  echo "Usage: $(basename "$0") [options] [.exs file] [data]
+  cat <<USAGE >&2
+Usage: $(basename "$0") [options] [.exs file] [data]
 
 The following options are exclusive to IEx:
 
-  --dot-iex \"PATH\"    Overrides default .iex.exs file and uses path instead;
+  --dot-iex "PATH"    Overrides default .iex.exs file and uses path instead;
                       path can be empty, then no file will be loaded
   --remsh NAME        Connects to a node using a remote shell
 
-It accepts all other options listed by \"elixir --help\"." >&2
+It accepts all other options listed by "elixir --help".
+USAGE
   exit 1
 fi
 


### PR DESCRIPTION
This PR proposes using heredocs for the usage docs of the top-level executables.

Benefits I see:

* No need to escape double quotes within the literal.
* The rightmost column with descriptions is now vertically aligned in the source code, matching easily what the user will get printed.
* The end of the literal is obvious.
* The redirection to standard error is visible upfront.

AFAIK this is portable across different Unix shells, including `sh`.