### PR TITLE
Add backwards compatibility for rel/vm.args

### DIFF
--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -1076,10 +1076,15 @@ defmodule Mix.Tasks.Release do
   end
 
   defp make_vm_args(release, path) do
-    if File.exists?("rel/vm.args.eex") do
-      copy_template("rel/vm.args.eex", path, [release: release], force: true)
-    else
-      File.write!(path, vm_args_template(release: release))
+    cond do
+      File.exists?("rel/vm.args.eex") ->
+        copy_template("rel/vm.args.eex", path, [release: release], force: true)
+
+      File.exists?("rel/vm.args") ->
+        copy_file("rel/vm.args", path, force: true)
+
+      true ->
+        File.write!(path, vm_args_template(release: release))
     end
 
     :ok

--- a/lib/mix/test/mix/tasks/release_test.exs
+++ b/lib/mix/test/mix/tasks/release_test.exs
@@ -36,6 +36,21 @@ defmodule Mix.Tasks.ReleaseTest do
       end)
     end
 
+    test "rel with vm.args" do
+      in_fixture("release_test", fn ->
+        Mix.Project.in_project(:release_test, ".", fn _ ->
+          File.mkdir_p!("rel")
+          File.write!("rel/vm.args", "TEST")
+
+          root = Path.absname("_build/dev/rel/release_test")
+          Mix.Task.run("release")
+          assert_received {:mix_shell, :info, ["* assembling release_test-0.1.0 on MIX_ENV=dev"]}
+
+          assert root |> Path.join("releases/0.1.0/vm.args") |> File.read!() == "TEST"
+        end)
+      end)
+    end
+
     test "steps" do
       in_fixture("release_test", fn ->
         last_step = fn release ->


### PR DESCRIPTION
A lot of existing Nerves apps have a `rel/vm.args` file. As part of our upgrade instructions, we will be advocating this file be renamed. Overlooking this step can cause ill effects when running new firmware on the target. I think it might be safer if we look for `vm.args.eex` then `vm.args`.