### PR TITLE
Fix typespec of Macro.Env.t

### DIFF
--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -85,7 +85,7 @@ defmodule Macro.Env do
           aliases: aliases,
           functions: functions,
           macros: macros,
-          macro_aliases: aliases,
+          macro_aliases: macro_aliases,
           context_modules: context_modules,
           vars: vars,
           unused_vars: unused_vars,


### PR DESCRIPTION
This PR addresses the cause of dialyzer warnings because of the `macro_aliases` field of `Macro.Env` struct.