### PR TITLE
Use default_release option when name is not given to mix release

### DIFF
--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -158,10 +158,16 @@ defmodule Mix.Release do
         {name, opts}
 
       [_ | _] ->
-        Mix.raise(
-          "\"mix release\" was invoked without a name but there are multiple releases. " <>
-            "Please call \"mix release NAME\" or set :default_release in your project configuration"
-        )
+        case Keyword.get(config, :default_release) do
+          nil ->
+            Mix.raise(
+              "\"mix release\" was invoked without a name but there are multiple releases. " <>
+                "Please call \"mix release NAME\" or set :default_release in your project configuration"
+            )
+
+          name ->
+            lookup_release(name, config)
+        end
     end
   end
 

--- a/lib/mix/test/mix/release_test.exs
+++ b/lib/mix/test/mix/release_test.exs
@@ -80,7 +80,7 @@ defmodule Mix.ReleaseTest do
     test "uses chosen release via the default_release" do
       release =
         from_config!(
-          :bar,
+          nil,
           config(
             default_release: :bar,
             releases: [foo: [version: "0.2.0"], bar: [version: "0.3.0"]]


### PR DESCRIPTION
The docs say:

> If mix release, without a name, is invoked and there are multiple names, an error will be raised unless you set default_release: NAME at the root of your project configuration.

But it turns out that the value is not actually used.

```sh
$ mix new bug
* creating README.md
* creating .formatter.exs
* creating .gitignore
* creating mix.exs
* creating lib
* creating lib/bug.ex
* creating test
* creating test/test_helper.exs
* creating test/bug_test.exs

Your Mix project was created successfully.
You can use "mix" to compile it, test it, and more:

    cd bug
    mix test

Run "mix help" for more commands.
$ cd bug 
$ nano mix.exs
$ cat mix.exs 
defmodule Bug.MixProject do
  use Mix.Project

  def project do
    [
      app: :bug,
      version: "0.1.0",
      elixir: "~> 1.9",
      start_permanent: Mix.env() == :prod,
      deps: deps(),
      default_release: :dev,
      releases: [dev: [], prod: []]
    ]
  end

  # Run "mix help compile.app" to learn about applications.
  def application do
    [
      extra_applications: [:logger]
    ]
  end

  # Run "mix help deps" to learn about dependencies.
  defp deps do
    [
      # {:dep_from_hexpm, "~> 0.3.0"},
      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
    ]
  end
end
$ mix release
Compiling 1 file (.ex)
Generated bug app
** (Mix) "mix release" was invoked without a name but there are multiple releases. Please call "mix release NAME" or set :default_release in your project configuration
$ mix release dev
* assembling dev-0.1.0 on MIX_ENV=dev
* skipping runtime configuration (config/releases.exs not found)

Release created at _build/dev/rel/dev!

    # To start your system
    _build/dev/rel/dev/bin/dev start

Once the release is running:

    # To connect to it remotely
    _build/dev/rel/dev/bin/dev remote

    # To stop it gracefully (you may also send SIGINT/SIGTERM)
    _build/dev/rel/dev/bin/dev stop

To list all commands:

    _build/dev/rel/dev/bin/dev
```