### PR TITLE
Unify code path in String.split

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -420,7 +420,7 @@ defmodule String do
     end
   end
 
-  def split(string, pattern, []) when is_tuple(pattern) or is_binary(string) do
+  def split(string, pattern, []) when is_binary(string) do
     :binary.split(string, pattern, [:global])
   end
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -420,15 +420,18 @@ defmodule String do
     end
   end
 
-  def split(string, pattern, []) when is_binary(string) do
-    :binary.split(string, pattern, [:global])
-  end
-
   def split(string, pattern, options) when is_binary(string) do
     parts = Keyword.get(options, :parts, :infinity)
     trim = Keyword.get(options, :trim, false)
-    pattern = maybe_compile_pattern(pattern)
-    split_each(string, pattern, trim, parts_to_index(parts))
+
+    case {parts, trim} do
+      {:infinity, false} ->
+        :binary.split(string, pattern, [:global])
+
+      _ ->
+        pattern = maybe_compile_pattern(pattern)
+        split_each(string, pattern, trim, parts_to_index(parts))
+    end
   end
 
   defp parts_to_index(:infinity), do: 0


### PR DESCRIPTION
When calling `String.split` with options `parts` and/or `trim` explicitly
set to default values, different code path was taken in comparison to when
no options were given. The alternate code path has some performance
penalties as shown below, so it's better that the
"simple" case is handled always the same way.
```
iex(1)> lines = for _ <- 1..1_000_000, do: "a,b"

iex(2)> :timer.tc(fn -> Enum.each(lines, &String.split(&1, ",")) end)
{2254104, :ok}

iex(3)> :timer.tc(fn -> Enum.each(lines, &String.split(&1, ",", trim: false)) end)
{61426180, :ok}
```