### PR TITLE
Raise for @describetag defined before use ExUnit.Case

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -223,11 +223,12 @@ defmodule ExUnit.Case do
       async = !!unquote(opts)[:async]
 
       unless Module.get_attribute(__MODULE__, :ex_unit_tests) do
-        moduletag_check = Module.get_attribute(__MODULE__, :moduletag)
-        tag_check = Module.get_attribute(__MODULE__, :tag)
+        tag_check =
+          [:moduletag, :describetag, :tag]
+          |> Enum.any?(&Module.get_attribute(__MODULE__, &1))
 
-        if moduletag_check || tag_check do
-          raise "you must set @tag and @moduletag after the call to \"use ExUnit.Case\""
+        if tag_check do
+          raise "you must set @tag, @describetag, and @moduletag after the call to \"use ExUnit.Case\""
         end
 
         attributes = [


### PR DESCRIPTION
I assume it's an oversight that `@describetag` wasn't being checked here?