### PR TITLE
Add describe and module attributes

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -551,8 +551,11 @@ defmodule ExUnit.Case do
 
   """
   @spec register_attribute(env, name :: atom, opts :: keyword) :: :ok
-  def register_attribute(env, name, opts \\ []) when is_atom(name) and is_list(opts) do
-    register_attribute(:ex_unit_registered_test_attributes, env, name, opts)
+  def register_attribute(env, name, opts \\ [])
+  def register_attribute(%{module: mod}, name, opts), do: register_attribute(mod, name, opts)
+
+  def register_attribute(mod, name, opts) when is_atom(mod) and is_atom(name) and is_list(opts) do
+    register_attribute(:ex_unit_registered_test_attributes, mod, name, opts)
   end
 
   @doc """
@@ -590,8 +593,15 @@ defmodule ExUnit.Case do
 
   """
   @spec register_describe_attribute(env, name :: atom, opts :: keyword) :: :ok
-  def register_describe_attribute(env, name, opts \\ []) when is_atom(name) and is_list(opts) do
-    register_attribute(:ex_unit_registered_describe_attributes, env, name, opts)
+  def register_describe_attribute(env, name, opts \\ [])
+
+  def register_describe_attribute(%{module: mod}, name, opts) do
+    register_describe_attribute(mod, name, opts)
+  end
+
+  def register_describe_attribute(mod, name, opts)
+      when is_atom(mod) and is_atom(name) and is_list(opts) do
+    register_attribute(:ex_unit_registered_describe_attributes, mod, name, opts)
   end
 
   @doc """
@@ -623,8 +633,15 @@ defmodule ExUnit.Case do
 
   """
   @spec register_module_attribute(env, name :: atom, opts :: keyword) :: :ok
-  def register_module_attribute(env, name, opts \\ []) when is_atom(name) and is_list(opts) do
-    register_attribute(:ex_unit_registered_module_attributes, env, name, opts)
+  def register_module_attribute(env, name, opts \\ [])
+
+  def register_module_attribute(%{module: mod}, name, opts) do
+    register_module_attribute(mod, name, opts)
+  end
+
+  def register_module_attribute(mod, name, opts)
+      when is_atom(mod) and is_atom(name) and is_list(opts) do
+    register_attribute(:ex_unit_registered_module_attributes, mod, name, opts)
   end
 
   defp register_attribute(type, %{module: module}, name, opts) do

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -525,11 +525,10 @@ defmodule ExUnit.Case do
   Registers a new attribute to be used during `ExUnit.Case` tests.
 
   The attribute values will be available through `context.registered`.
-  Registered values are cleared after each `ExUnit.Case.test/3` similar
+  Registered values are cleared after each `test/3` similar
   to `@tag`.
 
-  `Module.register_attribute/3` is used to register the attribute,
-  this function takes the same options.
+  This function takes the same options as `Module.register_attribute/3`.
 
   ## Examples
 
@@ -562,11 +561,10 @@ defmodule ExUnit.Case do
   Registers a new describe attribute to be used during `ExUnit.Case` tests.
 
   The attribute values will be available through `context.registered`.
-  Registered values are cleared after each `ExUnit.Case.describe/2` similar
+  Registered values are cleared after each `describe/2` similar
   to `@describetag`.
 
-  `Module.register_attribute/3` is used to register the attribute,
-  this function takes the same options.
+  This function takes the same options as `Module.register_attribute/3`.
 
   ## Examples
 
@@ -609,8 +607,7 @@ defmodule ExUnit.Case do
 
   The attribute values will be available through `context.registered`.
 
-  `Module.register_attribute/3` is used to register the attribute,
-  this function takes the same options.
+  This function takes the same options as `Module.register_attribute/3`.
 
   ## Examples
 
@@ -642,10 +639,6 @@ defmodule ExUnit.Case do
   def register_module_attribute(mod, name, opts)
       when is_atom(mod) and is_atom(name) and is_list(opts) do
     register_attribute(:ex_unit_registered_module_attributes, mod, name, opts)
-  end
-
-  defp register_attribute(type, %{module: module}, name, opts) do
-    register_attribute(type, module, name, opts)
   end
 
   defp register_attribute(type, mod, name, opts) do

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -424,12 +424,6 @@ defmodule ExUnit.Case do
       raise "@describetag must be set inside describe/2 blocks"
     end
 
-    for attribute <- Module.get_attribute(module, :ex_unit_registered_describe_attributes),
-        value = Module.get_attribute(module, attribute),
-        value not in [[], nil] do
-      raise "@#{attribute} must be set inside describe/2 blocks"
-    end
-
     Module.put_attribute(module, :ex_unit_describe, {line, message})
     Module.put_attribute(module, :ex_unit_used_describes, message)
     :ok

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -211,6 +211,8 @@ defmodule ExUnit.Case do
 
   """
 
+  @type env :: Module.t() | Macro.Env.t()
+
   @reserved [:module, :file, :line, :test, :async, :registered, :describe]
 
   @doc false
@@ -237,7 +239,9 @@ defmodule ExUnit.Case do
           :tag,
           :describetag,
           :moduletag,
-          :ex_unit_registered,
+          :ex_unit_registered_test_attributes,
+          :ex_unit_registered_describe_attributes,
+          :ex_unit_registered_module_attributes,
           :ex_unit_used_describes
         ]
 
@@ -389,6 +393,10 @@ defmodule ExUnit.Case do
       after
         @ex_unit_describe nil
         Module.delete_attribute(__MODULE__, :describetag)
+
+        for attribute <- Module.get_attribute(__MODULE__, :ex_unit_registered_describe_attributes) do
+          Module.delete_attribute(__MODULE__, attribute)
+        end
       end
     end
   end
@@ -414,6 +422,12 @@ defmodule ExUnit.Case do
 
     if Module.get_attribute(module, :describetag) != [] do
       raise "@describetag must be set inside describe/2 blocks"
+    end
+
+    for attribute <- Module.get_attribute(module, :ex_unit_registered_describe_attributes),
+        value = Module.get_attribute(module, attribute),
+        value not in [[], nil] do
+      raise "@#{attribute} must be set inside describe/2 blocks"
     end
 
     Module.put_attribute(module, :ex_unit_describe, {line, message})
@@ -459,8 +473,18 @@ defmodule ExUnit.Case do
               "\"use ExUnit.Case\" in the current module"
     end
 
-    registered_attributes = Module.get_attribute(mod, :ex_unit_registered)
-    registered = Map.new(registered_attributes, &{&1, Module.get_attribute(mod, &1)})
+    registered_attribute_keys = [
+      :ex_unit_registered_module_attributes,
+      :ex_unit_registered_describe_attributes,
+      :ex_unit_registered_test_attributes
+    ]
+
+    registered =
+      for key <- registered_attribute_keys,
+          attribute <- Module.get_attribute(mod, key),
+          into: %{} do
+        {attribute, Module.get_attribute(mod, attribute)}
+      end
 
     tag = Module.delete_attribute(mod, :tag)
     async = Module.get_attribute(mod, :ex_unit_async)
@@ -496,9 +520,9 @@ defmodule ExUnit.Case do
     test = %ExUnit.Test{name: name, case: mod, tags: tags, module: mod}
     Module.put_attribute(mod, :ex_unit_tests, test)
 
-    Enum.each(registered_attributes, fn attribute ->
+    for attribute <- Module.get_attribute(mod, :ex_unit_registered_test_attributes) do
       Module.delete_attribute(mod, attribute)
-    end)
+    end
 
     name
   end
@@ -532,15 +556,109 @@ defmodule ExUnit.Case do
       end
 
   """
-  def register_attribute(env, name, opts \\ [])
-
-  def register_attribute(%{module: module}, name, opts) do
-    register_attribute(module, name, opts)
+  @spec register_attribute(env, name :: atom, opts :: keyword) :: :ok
+  def register_attribute(env, name, opts \\ []) do
+    do_register_attribute(:ex_unit_registered_test_attributes, env, name, opts)
   end
 
-  def register_attribute(mod, name, opts) when is_atom(mod) and is_atom(name) and is_list(opts) do
+  @doc """
+  Registers a new describe attribute to be used during `ExUnit.Case` tests.
+
+  The attribute values will be available through `context.registered`.
+  Registered values are cleared after each `ExUnit.Case.describe/2` similar
+  to `@describetag`.
+
+  `Module.register_attribute/3` is used to register the attribute,
+  this function takes the same options.
+
+  ## Examples
+
+      defmodule MyTest do
+        use ExUnit.Case
+
+        ExUnit.Case.register_describe_attribute(__MODULE__, :describe_fixtures, accumulate: true)
+
+        describe "using custom attribute" do
+          @describe_fixtures :user
+          @describe_fixtures {:post, insert: false}
+
+          test "has attribute", context do
+            assert context.registered.describe_fixtures == [{:post, insert: false}, :user]
+          end
+        end
+
+        describe "custom attributes are cleared per describe" do
+          test "doesn't have attributes", context do
+            assert context.registered.describe_fixtures == []
+          end
+        end
+      end
+
+  """
+  @spec register_describe_attribute(env, name :: atom, opts :: keyword) :: :ok
+  def register_describe_attribute(env, name, opts \\ []) do
+    do_register_attribute(:ex_unit_registered_describe_attributes, env, name, opts)
+  end
+
+  @doc """
+  Registers a new module attribute to be used during `ExUnit.Case` tests.
+
+  The attribute values will be available through `context.registered`.
+
+  `Module.register_attribute/3` is used to register the attribute,
+  this function takes the same options.
+
+  ## Examples
+
+      defmodule MyTest do
+        use ExUnit.Case
+
+        ExUnit.Case.register_module_attribute(__MODULE__, :module_fixtures, accumulate: true)
+
+        @module_fixtures :user
+        @module_fixtures {:post, insert: false}
+
+        test "using custom attribute", context do
+          assert context.registered.fixtures == [{:post, insert: false}, :user]
+        end
+
+        test "still using custom attribute", context do
+          assert context.registered.fixtures == [{:post, insert: false}, :user]
+        end
+      end
+
+  """
+  @spec register_module_attribute(env, name :: atom, opts :: keyword) :: :ok
+  def register_module_attribute(env, name, opts \\ []) do
+    do_register_attribute(:ex_unit_registered_module_attributes, env, name, opts)
+  end
+
+  defp do_register_attribute(type, %{module: module}, name, opts) do
+    do_register_attribute(type, module, name, opts)
+  end
+
+  defp do_register_attribute(type, mod, name, opts)
+       when is_atom(type) and is_atom(mod) and is_atom(name) and is_list(opts) do
+    validate_registered_attribute!(type, mod, name)
     Module.register_attribute(mod, name, opts)
-    Module.put_attribute(mod, :ex_unit_registered, name)
+    Module.put_attribute(mod, type, name)
+  end
+
+  defp validate_registered_attribute!(type, mod, name) do
+    registered_attribute_keys = [
+      :ex_unit_registered_module_attributes,
+      :ex_unit_registered_describe_attributes,
+      :ex_unit_registered_test_attributes
+    ]
+
+    for key <- registered_attribute_keys,
+        type != key && name in Module.get_attribute(mod, key) do
+      raise "cannot register attribute #{inspect(name)} multiple times"
+    end
+
+    if Module.get_attribute(mod, name) do
+      raise "you must set @#{name} after it has been registered"
+    end
   end
 
   defp validate_tags(tags) do

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -551,8 +551,8 @@ defmodule ExUnit.Case do
 
   """
   @spec register_attribute(env, name :: atom, opts :: keyword) :: :ok
-  def register_attribute(env, name, opts \\ []) do
-    do_register_attribute(:ex_unit_registered_test_attributes, env, name, opts)
+  def register_attribute(env, name, opts \\ []) when is_atom(name) and is_list(opts) do
+    register_attribute(:ex_unit_registered_test_attributes, env, name, opts)
   end
 
   @doc """
@@ -590,8 +590,8 @@ defmodule ExUnit.Case do
 
   """
   @spec register_describe_attribute(env, name :: atom, opts :: keyword) :: :ok
-  def register_describe_attribute(env, name, opts \\ []) do
-    do_register_attribute(:ex_unit_registered_describe_attributes, env, name, opts)
+  def register_describe_attribute(env, name, opts \\ []) when is_atom(name) and is_list(opts) do
+    register_attribute(:ex_unit_registered_describe_attributes, env, name, opts)
   end
 
   @doc """
@@ -623,16 +623,15 @@ defmodule ExUnit.Case do
 
   """
   @spec register_module_attribute(env, name :: atom, opts :: keyword) :: :ok
-  def register_module_attribute(env, name, opts \\ []) do
-    do_register_attribute(:ex_unit_registered_module_attributes, env, name, opts)
+  def register_module_attribute(env, name, opts \\ []) when is_atom(name) and is_list(opts) do
+    register_attribute(:ex_unit_registered_module_attributes, env, name, opts)
   end
 
-  defp do_register_attribute(type, %{module: module}, name, opts) do
-    do_register_attribute(type, module, name, opts)
+  defp register_attribute(type, %{module: module}, name, opts) do
+    register_attribute(type, module, name, opts)
   end
 
-  defp do_register_attribute(type, mod, name, opts)
-       when is_atom(type) and is_atom(mod) and is_atom(name) and is_list(opts) do
+  defp register_attribute(type, mod, name, opts) do
     validate_registered_attribute!(type, mod, name)
     Module.register_attribute(mod, name, opts)
     Module.put_attribute(mod, type, name)
@@ -646,8 +645,8 @@ defmodule ExUnit.Case do
     ]
 
     for key <- registered_attribute_keys,
-        type != key && name in Module.get_attribute(mod, key) do
-      raise "cannot register attribute #{inspect(name)} multiple times"
+        type != key and name in Module.get_attribute(mod, key) do
+      raise ArgumentError, "cannot register attribute #{inspect(name)} multiple times"
     end
 
     if Module.get_attribute(mod, name) do

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -549,7 +549,7 @@ defmodule ExUnit.Case do
       end
 
   """
-  @spec register_attribute(env, name :: atom, opts :: keyword) :: :ok
+  @spec register_attribute(env, atom, keyword) :: :ok
   def register_attribute(env, name, opts \\ [])
   def register_attribute(%{module: mod}, name, opts), do: register_attribute(mod, name, opts)
 
@@ -590,7 +590,7 @@ defmodule ExUnit.Case do
       end
 
   """
-  @spec register_describe_attribute(env, name :: atom, opts :: keyword) :: :ok
+  @spec register_describe_attribute(env, atom, keyword) :: :ok
   def register_describe_attribute(env, name, opts \\ [])
 
   def register_describe_attribute(%{module: mod}, name, opts) do
@@ -629,7 +629,7 @@ defmodule ExUnit.Case do
       end
 
   """
-  @spec register_module_attribute(env, name :: atom, opts :: keyword) :: :ok
+  @spec register_module_attribute(env, atom, keyword) :: :ok
   def register_module_attribute(env, name, opts \\ [])
 
   def register_module_attribute(%{module: mod}, name, opts) do

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -82,20 +82,6 @@ defmodule ExUnit.CaseTest do
     end
   end
 
-  test "raises when registered describe attribute used outside describe" do
-    message = "@describe_foo must be set inside describe/2 blocks"
-
-    assert_raise RuntimeError, message, fn ->
-      defmodule DescribeAttributeOutsideDescribeTest do
-        use ExUnit.Case
-        ExUnit.Case.register_describe_attribute(__MODULE__, :describe_foo)
-        @describe_foo true
-        describe "" do
-        end
-      end
-    end
-  end
-
   test "registered module attributes are in context", context do
     assert context.registered.module_foo == :hello
     assert context.registered.module_bar == [:world]

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -94,7 +94,7 @@ defmodule ExUnit.CaseTest do
   end
 
   test "raises when same name is registered twice" do
-    assert_raise RuntimeError, "cannot register attribute :foo multiple times", fn ->
+    assert_raise ArgumentError, "cannot register attribute :foo multiple times", fn ->
       defmodule AcrossLevelDoubleRegisterTest do
         use ExUnit.Case
         ExUnit.Case.register_attribute(__MODULE__, :foo)

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -6,8 +6,16 @@ defmodule ExUnit.CaseTest do
   ExUnit.Case.register_attribute(__MODULE__, :foo)
   ExUnit.Case.register_attribute(__MODULE__, :bar, accumulate: true)
   ExUnit.Case.register_attribute(__MODULE__, :baz)
+  ExUnit.Case.register_describe_attribute(__MODULE__, :describe_foo)
+  ExUnit.Case.register_describe_attribute(__MODULE__, :describe_bar, accumulate: true)
+  ExUnit.Case.register_describe_attribute(__MODULE__, :describe_baz)
+  ExUnit.Case.register_module_attribute(__MODULE__, :module_foo)
+  ExUnit.Case.register_module_attribute(__MODULE__, :module_bar, accumulate: true)
+  ExUnit.Case.register_module_attribute(__MODULE__, :module_baz)
 
   @moduletag :moduletag
+  @module_foo :hello
+  @module_bar :world
 
   test "defines __ex_unit__" do
     assert %ExUnit.TestModule{name: __MODULE__, tests: tests} = __ex_unit__()
@@ -54,5 +62,68 @@ defmodule ExUnit.CaseTest do
   test "registered attributes are set per test", context do
     assert context.registered.foo == nil
     assert context.registered.bar == []
+  end
+
+  describe "with attributes" do
+    @describe_foo :hello
+    @describe_bar :world
+
+    test "registered subscribe attributes are in context", context do
+      assert context.registered.describe_foo == :hello
+      assert context.registered.describe_bar == [:world]
+      assert context.registered.describe_baz == nil
+    end
+  end
+
+  describe "without attributes" do
+    test "registered subscribe attributes are set per subscribe", context do
+      assert context.registered.describe_foo == nil
+      assert context.registered.describe_bar == []
+    end
+  end
+
+  test "raises when registered describe attribute used outside describe" do
+    message = "@describe_foo must be set inside describe/2 blocks"
+
+    assert_raise RuntimeError, message, fn ->
+      defmodule DescribeAttributeOutsideDescribeTest do
+        use ExUnit.Case
+        ExUnit.Case.register_describe_attribute(__MODULE__, :describe_foo)
+        @describe_foo true
+        describe "" do
+        end
+      end
+    end
+  end
+
+  test "registered module attributes are in context", context do
+    assert context.registered.module_foo == :hello
+    assert context.registered.module_bar == [:world]
+    assert context.registered.module_baz == nil
+  end
+
+  test "registered module attributes stay in context", context do
+    assert context.registered.module_foo == :hello
+    assert context.registered.module_bar == [:world]
+  end
+
+  test "raises when same name is registered twice" do
+    assert_raise RuntimeError, "cannot register attribute :foo multiple times", fn ->
+      defmodule AcrossLevelDoubleRegisterTest do
+        use ExUnit.Case
+        ExUnit.Case.register_attribute(__MODULE__, :foo)
+        ExUnit.Case.register_module_attribute(__MODULE__, :foo)
+      end
+    end
+  end
+
+  test "raises when attribute is set before being registered" do
+    assert_raise RuntimeError, "you must set @foo after it has been registered", fn ->
+      defmodule SetBeforeRegisterTest do
+        use ExUnit.Case
+        @foo true
+        ExUnit.Case.register_attribute(__MODULE__, :foo, accumulate: true)
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds `ExUnit.Case.register_describe_attribute/3` and `ExUnit.Case.register_module_attribute/3`.

This was initially discussed in this thread: https://groups.google.com/forum/#!topic/elixir-lang-core/WcLghqAmBE4