### PR TITLE
Add mix deps.unlock --check-unused flag

### DIFF
--- a/lib/mix/lib/mix/tasks/deps.unlock.ex
+++ b/lib/mix/lib/mix/tasks/deps.unlock.ex
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Deps.Unlock do
         unused_apps = Mix.Dep.Lock.read() |> Map.drop(apps)
 
         unless unused_apps == %{} do
-          Mix.shell().error("warning: unused dependencies in mix.lock file")
+          Mix.raise("warning: unused dependencies in mix.lock file")
         end
 
       opts[:unused] ->

--- a/lib/mix/lib/mix/tasks/deps.unlock.ex
+++ b/lib/mix/lib/mix/tasks/deps.unlock.ex
@@ -41,9 +41,11 @@ defmodule Mix.Tasks.Deps.Unlock do
           |> Enum.sort()
 
         unless unused_apps == [] do
-          Mix.raise(
-            "Unused dependencies in mix.lock file: #{inspect(unused_apps, limit: :infinity)}"
-          )
+          Mix.raise("""
+          Unused dependencies in mix.lock file:
+
+          #{Enum.map_join(unused_apps, "\n", fn app -> "  * #{inspect(app)}" end)}
+          """)
         end
 
       opts[:unused] ->

--- a/lib/mix/lib/mix/tasks/deps.unlock.ex
+++ b/lib/mix/lib/mix/tasks/deps.unlock.ex
@@ -32,10 +32,17 @@ defmodule Mix.Tasks.Deps.Unlock do
 
       opts[:check_unused] ->
         apps = Mix.Dep.load_on_environment([]) |> Enum.map(& &1.app)
-        unused_apps = Mix.Dep.Lock.read() |> Map.drop(apps)
 
-        unless unused_apps == %{} do
-          Mix.raise("warning: unused dependencies in mix.lock file")
+        unused_apps =
+          Mix.Dep.Lock.read()
+          |> Map.drop(apps)
+          |> Map.keys()
+          |> Enum.sort()
+
+        unless unused_apps == [] do
+          Mix.raise(
+            "Unused dependencies in mix.lock file: #{inspect(unused_apps, limit: :infinity)}"
+          )
         end
 
       opts[:unused] ->

--- a/lib/mix/lib/mix/tasks/deps.unlock.ex
+++ b/lib/mix/lib/mix/tasks/deps.unlock.ex
@@ -11,11 +11,12 @@ defmodule Mix.Tasks.Deps.Unlock do
 
     * `dep1 dep2` - the name of dependencies to be unlocked
     * `--all` - unlocks all dependencies
-    * `--check-unused` - checks that the mix.lock file has no unused
-      dependencies. This is useful in pre-commit hooks and CI scripts
-      if you want to reject contributions with extra dependencies.
+    * `--filter` - unlocks only deps matching the given name
     * `--unused` - unlocks only unused dependencies (no longer mentioned
       in the `mix.exs` file)
+    * `--check-unused` - checks that the mix.lock file has no unused
+      dependencies. This is useful in pre-commit hooks and CI scripts
+      if you want to reject contributions with extra dependencies
 
   """
 

--- a/lib/mix/lib/mix/tasks/deps.unlock.ex
+++ b/lib/mix/lib/mix/tasks/deps.unlock.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Deps.Unlock do
     * `--filter` - unlocks only deps matching the given name
     * `--unused` - unlocks only unused dependencies (no longer mentioned
       in the `mix.exs` file)
-    * `--check-unused` - checks that the mix.lock file has no unused
+    * `--check-unused` - checks that the `mix.lock` file has no unused
       dependencies. This is useful in pre-commit hooks and CI scripts
       if you want to reject contributions with extra dependencies
 

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -308,6 +308,32 @@ defmodule Mix.Tasks.DepsTest do
     end)
   end
 
+  test "checks lock file has unused deps with --check-unused", context do
+    Mix.Project.push(DepsApp)
+
+    in_tmp(context.test, fn ->
+      Mix.Dep.Lock.write(%{whatever: "0.2.0", ok: "0.1.0"})
+      assert Mix.Dep.Lock.read() == %{whatever: "0.2.0", ok: "0.1.0"}
+      Mix.Tasks.Deps.Unlock.run(["--check-unused"])
+      assert Mix.Dep.Lock.read() == %{whatever: "0.2.0", ok: "0.1.0"}
+      error = "warning: unused dependencies in mix.lock file"
+      assert_received {:mix_shell, :error, [^error]}
+    end)
+  end
+
+  test "checks lock file has no unused deps with --check-unused", context do
+    Mix.Project.push(DepsApp)
+
+    in_tmp(context.test, fn ->
+      Mix.Dep.Lock.write(%{ok: "0.1.0"})
+      assert Mix.Dep.Lock.read() == %{ok: "0.1.0"}
+      Mix.Tasks.Deps.Unlock.run(["--check-unused"])
+      assert Mix.Dep.Lock.read() == %{ok: "0.1.0"}
+      error = "warning: unused dependencies in mix.lock file"
+      refute_received {:mix_shell, :error, [^error]}
+    end)
+  end
+
   test "unlocks unused deps", context do
     Mix.Project.push(DepsApp)
 

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -314,23 +314,17 @@ defmodule Mix.Tasks.DepsTest do
     in_tmp(context.test, fn ->
       Mix.Dep.Lock.write(%{whatever: "0.2.0", ok: "0.1.0"})
       assert Mix.Dep.Lock.read() == %{whatever: "0.2.0", ok: "0.1.0"}
-      Mix.Tasks.Deps.Unlock.run(["--check-unused"])
+      error = "warning: unused dependencies in mix.lock file"
+
+      assert_raise Mix.Error, error, fn ->
+        Mix.Tasks.Deps.Unlock.run(["--check-unused"])
+      end
+
       assert Mix.Dep.Lock.read() == %{whatever: "0.2.0", ok: "0.1.0"}
-      error = "warning: unused dependencies in mix.lock file"
-      assert_received {:mix_shell, :error, [^error]}
-    end)
-  end
 
-  test "checks lock file has no unused deps with --check-unused", context do
-    Mix.Project.push(DepsApp)
-
-    in_tmp(context.test, fn ->
       Mix.Dep.Lock.write(%{ok: "0.1.0"})
-      assert Mix.Dep.Lock.read() == %{ok: "0.1.0"}
       Mix.Tasks.Deps.Unlock.run(["--check-unused"])
       assert Mix.Dep.Lock.read() == %{ok: "0.1.0"}
-      error = "warning: unused dependencies in mix.lock file"
-      refute_received {:mix_shell, :error, [^error]}
     end)
   end
 

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -314,7 +314,7 @@ defmodule Mix.Tasks.DepsTest do
     in_tmp(context.test, fn ->
       Mix.Dep.Lock.write(%{whatever: "0.2.0", ok: "0.1.0"})
       assert Mix.Dep.Lock.read() == %{whatever: "0.2.0", ok: "0.1.0"}
-      error = "warning: unused dependencies in mix.lock file"
+      error = "Unused dependencies in mix.lock file: [:whatever]"
 
       assert_raise Mix.Error, error, fn ->
         Mix.Tasks.Deps.Unlock.run(["--check-unused"])

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -322,7 +322,7 @@ defmodule Mix.Tasks.DepsTest do
 
       assert Mix.Dep.Lock.read() == %{whatever: "0.2.0", ok: "0.1.0"}
 
-      Mix.Dep.Lock.write(%{ok: "0.1.0"})
+      Mix.Tasks.Deps.Unlock.run(["--unused"])
       Mix.Tasks.Deps.Unlock.run(["--check-unused"])
       assert Mix.Dep.Lock.read() == %{ok: "0.1.0"}
     end)

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -312,15 +312,21 @@ defmodule Mix.Tasks.DepsTest do
     Mix.Project.push(DepsApp)
 
     in_tmp(context.test, fn ->
-      Mix.Dep.Lock.write(%{whatever: "0.2.0", ok: "0.1.0"})
-      assert Mix.Dep.Lock.read() == %{whatever: "0.2.0", ok: "0.1.0"}
-      error = "Unused dependencies in mix.lock file: [:whatever]"
+      Mix.Dep.Lock.write(%{whatever: "0.2.0", something_else: "1.2.3", ok: "0.1.0"})
+      assert Mix.Dep.Lock.read() == %{whatever: "0.2.0", something_else: "1.2.3", ok: "0.1.0"}
+
+      error = """
+      Unused dependencies in mix.lock file:
+
+        * :something_else
+        * :whatever
+      """
 
       assert_raise Mix.Error, error, fn ->
         Mix.Tasks.Deps.Unlock.run(["--check-unused"])
       end
 
-      assert Mix.Dep.Lock.read() == %{whatever: "0.2.0", ok: "0.1.0"}
+      assert Mix.Dep.Lock.read() == %{whatever: "0.2.0", something_else: "1.2.3", ok: "0.1.0"}
 
       Mix.Tasks.Deps.Unlock.run(["--unused"])
       Mix.Tasks.Deps.Unlock.run(["--check-unused"])


### PR DESCRIPTION
Analogous to `mix format --check-formatted`, errors if there is any unused dependencies when running `mix deps.unlock --check-unused`. 

Apologies if there is supposed to be some pre discussion before opening this, but it seemed simple enough and fitting with other existing `mix` flags. 

As an aside, it seems like the `--filter` flag is undocumented. 