### PR TITLE
Optimize binary pattern matching in Integer.parse

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -233,7 +233,7 @@ defmodule Integer do
     raise ArgumentError, "invalid base #{inspect(base)}"
   end
 
-  def parse(binary, base) do
+  def parse(binary, base) when is_binary(binary) do
     case count_digits(binary, base) do
       0 ->
         :error
@@ -244,14 +244,14 @@ defmodule Integer do
     end
   end
 
-  defp count_digits(<<sign, rest::binary>>, base) when sign in '+-' do
+  defp count_digits(<<sign, rest::bits>>, base) when sign in '+-' do
     case count_digits_nosign(rest, base, 1) do
       1 -> 0
       count -> count
     end
   end
 
-  defp count_digits(<<rest::binary>>, base) do
+  defp count_digits(<<rest::bits>>, base) do
     count_digits_nosign(rest, base, 0)
   end
 
@@ -261,13 +261,13 @@ defmodule Integer do
       char <- chars do
     digit = char + diff
 
-    defp count_digits_nosign(<<unquote(char), rest::binary>>, base, count)
+    defp count_digits_nosign(<<unquote(char), rest::bits>>, base, count)
          when base > unquote(digit) do
       count_digits_nosign(rest, base, count + 1)
     end
   end
 
-  defp count_digits_nosign(<<_::binary>>, _, count), do: count
+  defp count_digits_nosign(<<_::bits>>, _, count), do: count
 
   # TODO: Remove Integer.to_string/1 once the minimum supported version is
   #       Erlang/OTP 22, since it is covered by the now BIF Integer.to_string/2.


### PR DESCRIPTION
Matching with `is_binary/1` once is a slight performance gain, only noticable on long numbers. It also makes the `FunctionClauseError` more clear (which is for most users and newcomers the bigger benefit I think).

`is_binary`:
```elixir
iex> Integer.parse <<0::size(1)>>
** (FunctionClauseError) no function clause matching in Integer.parse/2    
    
    The following arguments were given to Integer.parse/2:
    
        # 1
        <<0::size(1)>>
    
        # 2
        10
    
    Attempted function clauses (showing 2 out of 2):
    
        def parse(_binary, base) when not(is_integer(base) and (base >= 2 and base <= 36))
        def parse(binary, base) when is_binary(binary)
    
    (elixir) lib/integer.ex:237: Integer.parse/2
```
`::binary`:
```elixir
iex> Integer.parse <<0::size(1)>>
** (FunctionClauseError) no function clause matching in Integer.count_digits/2    
    
    The following arguments were given to Integer.count_digits/2:
    
        # 1
        <<0::size(1)>>
    
        # 2
        10
    
    Attempted function clauses (showing 2 out of 2):
     
        defp count_digits(<<sign::integer(), rest::binary()>>, base) when sign === 45 or sign === 43
        defp count_digits(<<rest::binary()>>, base)
    
    (elixir) lib/integer.ex:247: Integer.count_digits/2
    (elixir) lib/integer.ex:237: Integer.parse/2
```

These are the results I got with Benchee:
```elixir
Benchee.run(
  %{
    "is_binary 1234567890" => fn -> Integer.parse2("1234567890") end,
    "::binary 1234567890" => fn -> Integer.parse("1234567890") end
  }
)
```

```
Operating System: macOS
CPU Information: Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
Number of Available Cores: 8
Available memory: 16 GB
Elixir 1.9.0
Erlang 21.3

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 14 s

Benchmarking ::binary 1234567890...
Benchmarking is_binary 1234567890...

Name                           ips        average  deviation         median         99th %
is_binary 1234567890        2.03 M      491.91 ns  ±5152.68%           0 ns        1000 ns
::binary 1234567890         1.94 M      515.23 ns  ±5024.92%           0 ns        1000 ns

Comparison: 
is_binary 1234567890        2.03 M
::binary 1234567890         1.94 M - 1.05x slower +23.32 ns
```