### PR TITLE
Configure Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,75 @@
+env:
+  ELIXIR_ASSERT_TIMEOUT: 2000
+  LANG: C.UTF-8
+
+test_task:
+  container:
+    image: buildpack-deps:trusty
+
+  matrix:
+    - env:
+        OTP_RELEASE: OTP-22.0
+        CHECK_REPRODUCIBLE: true
+        CHECK_POSIX_COMPLIANT: true
+    - env:
+        OTP_RELEASE: OTP-21.3.8
+    - env:
+        OTP_RELEASE: OTP-21.2
+    - env:
+        OTP_RELEASE: OTP-21.1
+    - env:
+        OTP_RELEASE: OTP-21.0
+    - env:
+        OTP_RELEASE: OTP-20.3
+    - env:
+        OTP_RELEASE: OTP-20.2
+    - env:
+        OTP_RELEASE: OTP-20.1
+    - env:
+        OTP_RELEASE: OTP-20.0
+    - env:
+        OTP_RELEASE: maint
+      allow_failures: true
+    - env:
+        OTP_RELEASE: master
+      allow_failures: true
+
+  install_script:
+    - wget -O otp.tar.gz https://repo.hex.pm/builds/otp/ubuntu-14.04/${OTP_RELEASE}.tar.gz
+    - mkdir -p otp
+    - tar zxf otp.tar.gz -C otp --strip-components=1
+    - otp/Install -minimal $(pwd)/otp
+
+  test_script:
+    - PATH=$(pwd)/otp/bin:$PATH
+    - rm -rf .git
+    - ELIXIRC_OPTS="--warnings-as-errors" ERLC_OPTS="+warning_as_errors" make compile
+    - make test
+    - dialyzer -pa lib/elixir/ebin --build_plt --output_plt elixir.plt --apps lib/elixir/ebin/elixir.beam lib/elixir/ebin/Elixir.Kernel.beam
+
+    # Check for reproducible builds only in the latest OTP release
+    - if [ -n "$CHECK_REPRODUCIBLE" ]; then make check_reproducible; fi
+
+    # Check for POSIX compliant shell scripts
+    - if [ -n "$CHECK_POSIX_COMPLIANT" ]; then
+        apt update;
+        apt install -y shellcheck;
+        shellcheck -e SC2039,2086 bin/elixir && echo "bin/elixir is POSIX compliant";
+        shellcheck bin/elixirc && echo "bin/elixirc is POSIX compliant";
+        shellcheck bin/iex && echo "bin/iex is POSIX compliant";
+      fi
+
+test_windows_task:
+  windows_container:
+    matrix:
+      - image: fertapric/elixir-ci:otp-win64-22.0
+        os_version: 2019
+      - image: fertapric/elixir-ci:otp-win64-21.0.1
+        os_version: 2019
+      - image: fertapric/elixir-ci:otp-win64-20.0
+        os_version: 2019
+
+  test_script:
+    - rmdir /s /q .git
+    - make
+    - make --keep-going test_erlang test_elixir


### PR DESCRIPTION
This configures Cirrus CI so we can test it before fully migrating to it.

In order for this to work, Cirrus CI must be configured first in the GitHub marketplace: https://cirrus-ci.org/guide/quick-start/

A few notes:

* Unfortunately, sending emails when the build fails requires a bit more configuration than with a regular CI. The official way is to use GitHub actions: https://github.com/cirrus-actions/email, and that requires an email account from which the emails would be sent.
* Test in Windows are not using `make test_windows` to avoid executing `make test_formatted` that causes problems with the path separators.
* The Docker images for the Windows builds are hosted under [my personal account](https://hub.docker.com/r/fertapric/elixir-ci). 