### PR TITLE
Fix formatter removing nested parens on function with generated name

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -1079,7 +1079,7 @@ defmodule Code.Formatter do
   defp local_to_algebra(fun, meta, args, context, state) when is_atom(fun) do
     skip_parens =
       cond do
-        meta?(meta, :closing) -> :required
+        meta?(meta, :closing) -> :skip_if_only_do_end
         local_without_parens?(fun, args, state) -> :skip_unless_many_args
         true -> :skip_if_do_end
       end
@@ -1097,9 +1097,10 @@ defmodule Code.Formatter do
     {doc, state}
   end
 
-  # parens may one of:
+  # parens may be one of:
   #
   #   * :skip_unless_many_args - skips parens unless we are the argument context
+  #   * :skip_if_only_do_end - skip parens if we are do-end and the only arg
   #   * :skip_if_do_end - skip parens if we are do-end
   #   * :required - never skip parens
   #
@@ -1115,11 +1116,16 @@ defmodule Code.Formatter do
 
     if blocks = do_end_blocks(meta, last, state) do
       {call_doc, state} =
-        if rest == [] do
-          {" do", state}
-        else
-          no_parens? = parens != :required
-          call_args_to_algebra_no_blocks(meta, rest, no_parens?, list_to_keyword?, " do", state)
+        case rest do
+          [] when parens == :required ->
+            {"() do", state}
+
+          [] ->
+            {" do", state}
+
+          _ ->
+            no_parens? = parens not in [:required, :skip_if_only_do_end]
+            call_args_to_algebra_no_blocks(meta, rest, no_parens?, list_to_keyword?, " do", state)
         end
 
       {blocks_doc, state} = do_end_blocks_to_algebra(blocks, state)

--- a/lib/elixir/test/elixir/code_formatter/calls_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/calls_test.exs
@@ -450,6 +450,12 @@ defmodule Code.Formatter.CallsTest do
       assert_same "unquote(call)(one, two)"
 
       assert_same """
+      unquote(call)() do
+        :ok
+      end
+      """
+
+      assert_same """
       unquote(call)(one, two) do
         :ok
       end
@@ -666,6 +672,11 @@ defmodule Code.Formatter.CallsTest do
     test "call on call" do
       assert_same "foo.bar(call)()"
       assert_same "foo.bar(call)(one, two)"
+
+      assert_same """
+      foo.bar(call)() do
+      end
+      """
 
       assert_same """
       foo.bar(call)(one, two) do


### PR DESCRIPTION
This is intended to fix #9204.

Since I haven't contributed to the formatter before and I am not completely satisfied with this solution, I marked this as WIP. The PR does solve the problem by not removing the parens before the `do` block when being called from the `remote_to_algebra` clause that matches calls as described in the issue. **However**, I am not entirely sure how long `state` is carried around and if just adding a flag to it (that is not reset) has any unintended side effects.  (Tests are passing, but still)

Is there a more idiomatic way of passing a "flag" for this special case to `call_args_to_algebra` without modifying the state?