### PR TITLE
Regex.split/3 documentation and tests for :include_captures and :parts

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -490,7 +490,8 @@ defmodule Regex do
       affect the splitting process.
 
     * `:include_captures` - when `true`, includes in the result the matches of
-      the regular expression. Defaults to `false`.
+      the regular expression. The matches are not counted towards the maximum
+      number of parts if combined with the `:parts` option. Defaults to `false`.
 
   ## Examples
 

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -267,6 +267,18 @@ defmodule RegexTest do
 
     assert Regex.split(~r/a/, "abc", include_captures: true) == ["", "a", "bc"]
     assert Regex.split(~r/c/, "abc", include_captures: true) == ["ab", "c", ""]
+
+    assert Regex.split(~r/[Ei]/, "Elixir", include_captures: true, parts: 2) ==
+             ["", "E", "lixir"]
+
+    assert Regex.split(~r/[Ei]/, "Elixir", include_captures: true, parts: 3) ==
+             ["", "E", "l", "i", "xir"]
+
+    assert Regex.split(~r/[Ei]/, "Elixir", include_captures: true, parts: 2, trim: true) ==
+             ["E", "lixir"]
+
+    assert Regex.split(~r/[Ei]/, "Elixir", include_captures: true, parts: 3, trim: true) ==
+             ["E", "l", "i", "xir"]
   end
 
   test "replace/3,4" do


### PR DESCRIPTION
As discussed in #9219, this PR keeps the current behaviour, but documents it. :)