### PR TITLE
Update description of formatter in Mix.Tasks.Test moduledoc

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -165,7 +165,7 @@ defmodule Mix.Tasks.Test do
     * `--failed` - runs only tests that failed the last time they ran
     * `--force` - forces compilation regardless of modification times
     * `--formatter` - sets the formatter module that will print the results.
-      Defaults to `ExUnit.CLIFormatter`
+      Defaults to ExUnit's built-in CLI formatter
     * `--include` - includes tests that match the filter
     * `--listen-on-stdin` - runs tests, and then listens on stdin. Receiving a newline will
       result in the tests being run again. Very useful when combined with `--stale` and


### PR DESCRIPTION
Fixes #9221

#### Before (with broken formatter link):
![Screen Shot 2019-07-13 at 16 29 09](https://user-images.githubusercontent.com/24971740/61176132-b1aec880-a5bb-11e9-8335-3a9f13893a7e.png)

#### After(newly generated Mix.Tasks.Test docs)
![Screen Shot 2019-07-13 at 22 02 06](https://user-images.githubusercontent.com/24971740/61176145-d5720e80-a5bb-11e9-9144-84e8286af0e5.png)
