### PR TITLE
Make 'make test_formatter' compatible with Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,11 @@ TEST_EBIN = lib/elixir/test/ebin
 TEST_ERLS = $(addprefix $(TEST_EBIN)/, $(addsuffix .beam, $(basename $(notdir $(wildcard $(TEST_ERL)/*.erl)))))
 
 test_formatted: compile
-	bin/elixir bin/mix format --check-formatted
+	$(Q) if [ "$(OS)" = "Windows_NT" ]; then \
+		cmd //C call ./bin/mix.bat format --check-formatted; \
+	else \
+		bin/elixir bin/mix format --check-formatted; \
+	fi
 
 test_erlang: compile $(TEST_ERLS)
 	@ echo "==> elixir (eunit)"


### PR DESCRIPTION
The current version is not compatible because of the path separators. It fails with the error:

    'bin' is not recognized as an internal or external command,
    operable program or batch file.

I tested those changes in Cirrus CI and it worked. [Here](https://cirrus-ci.com/task/6207090706612224) is an example of the formatter failing after intentionally introducing an unformatted code; and [another example](https://cirrus-ci.com/task/5038407389020160) with the formatter passing.