### PR TITLE
Rename Mix.Tasks.Escript.Build option to `:strip_beams`

### DIFF
--- a/lib/mix/test/mix/tasks/escript_test.exs
+++ b/lib/mix/test/mix/tasks/escript_test.exs
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.EscriptTest do
       [
         app: :escript_test_with_debug_info,
         version: "0.0.1",
-        escript: [main_module: EscriptTest, strip_beam: false]
+        escript: [main_module: EscriptTest, strip_beams: false]
       ]
     end
   end


### PR DESCRIPTION
In [`Mix.Tasks.Release`](https://github.com/elixir-lang/elixir/blob/master/lib/mix/lib/mix/tasks/release.ex#L371) this option is referred to as `:strip_beams`. And even in [this modules doc](https://github.com/elixir-lang/elixir/blob/master/lib/mix/lib/mix/tasks/escript.build.ex#L34) it is referenced to look at `:strip_beams` option. However, the implementation here only uses the singular `:strip_beam` (and is the only place to do so).

This actually caused a bit of confusion in https://github.com/nerves-project/nerves/pull/443.

So this just simply changes that option and updates the doc to match how it is used elsewhere.