### PR TITLE
Add Tzdata example to DateTime docs

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -35,6 +35,7 @@ defmodule DateTime do
   or by calling `Calendar.put_time_zone_database/1`:
 
       Calendar.put_time_zone_database(Tzdata.TimeZoneDatabase)
+
   """
 
   @enforce_keys [:year, :month, :day, :hour, :minute, :second] ++

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -25,12 +25,16 @@ defmodule DateTime do
   datetimes and returns `{:error, :utc_only_time_zone_database}`
   for any other time zone.
 
-  Other time zone databases (including ones provided by packages)
-  can be configure as default either via configuration:
+  Other time zone databases can also be configured. For example, to use the
+  [tzdata](https://hexdocs.pm/tzdata/) database, first make sure it is added as
+  a dependency in `mix.exs`.  It can then be configured either via
+  configuration:
 
-      config :elixir, :time_zone_database, CustomTimeZoneDatabase
+      config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
 
-  or by calling `Calendar.put_time_zone_database/1`.
+  or by calling `Calendar.put_time_zone_database/1`:
+
+      Calendar.put_time_zone_database(Tzdata.TimeZoneDatabase)
   """
 
   @enforce_keys [:year, :month, :day, :hour, :minute, :second] ++


### PR DESCRIPTION
Added an example of how to use `Tzdata` to the `DateTime` docs.

This was requested in #9148.

I hope replacing the `CustomTimeZoneDatabase` with `Tzdata.TimeZoneDatabase` isn't too much - I think it's still obvious what to do if you want to use an alternative database.

I think the comment about adding the dependency is necessary, because if you just configure the module name without actually adding the dependency, you won't get any errors until you try to use the calendar, and then it's not obvious what the problem is.

I also opened https://github.com/lau/tzdata/pull/85 to flesh out the Tzdata's HexDocs a bit, which I though would be helpful for people that get linked there from here.