### PR TITLE
Add Keyword.pop!/2 and Map.pop!/2

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -955,6 +955,32 @@ defmodule Keyword do
   end
 
   @doc """
+  Returns the first value for `key` and removes all associated antries in the keyword list,
+  raising if `key` is not present.
+
+  This function behaves like `pop/3`, but raises in cases the `key` is not present in the
+  given `keywords`.
+
+  ## Examples
+
+      iex> Keyword.pop!([a: 1], :a)
+      {1, []}
+      iex> Keyword.pop!([a: 1, a: 2], :a)
+      {1, []}
+      iex> Keyword.pop!([a: 1], :b)
+      ** (KeyError) key :b not found in: [a: 1]
+
+  """
+  @doc since: "1.10.0"
+  @spec pop!(t, key) :: {value, t}
+  def pop!(keywords, key) when is_list(keywords) and is_atom(key) do
+    case fetch(keywords, key) do
+      {:ok, value} -> {value, delete(keywords, key)}
+      :error -> raise KeyError, key: key, term: keywords
+    end
+  end
+
+  @doc """
   Returns all values for `key` and removes all associated entries in the keyword list.
 
   It returns a tuple where the first element is a list of values for `key` and the

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -653,7 +653,7 @@ defmodule Map do
 
   """
   @doc since: "1.10.0"
-  @spec pop(map, key) :: {value, map}
+  @spec pop!(map, key) :: {value, map}
   def pop!(map, key) do
     case :maps.take(key, map) do
       {_, _} = tuple -> tuple

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -637,6 +637,31 @@ defmodule Map do
   end
 
   @doc """
+  Returns and removes the value associated with `key` in `map` or raises
+  if `key` is not present.
+
+  Behaves the same as `pop/3` but raises if `key` is not present in `map`.
+
+  ## Examples
+
+      iex> Map.pop!(%{a: 1}, :a)
+      {1, %{}}
+      iex> Map.pop!(%{a: 1, b: 2}, :a)
+      {1, %{b: 2}}
+      iex> Map.pop!(%{a: 1}, :b)
+      ** (KeyError) key :b not found in: %{a: 1}
+
+  """
+  @doc since: "1.10.0"
+  @spec pop(map, key) :: {value, map}
+  def pop!(map, key) do
+    case :maps.take(key, map) do
+      {_, _} = tuple -> tuple
+      :error -> raise KeyError, key: key, term: map
+    end
+  end
+
+  @doc """
   Lazily returns and removes the value associated with `key` in `map`.
 
   If `key` is present in `map` with value `value`, `{value, new_map}` is


### PR DESCRIPTION
These function behave like their non-bang counterparts except that they raise when the key is not present. This can be useful for option handling in order to extract an option and raise at the same time if it's not there. Note that this is mostly useful when not having the key there is an unrecoverable error (for example, because you already validated options): if you want to return a nice error to the user, `pop_lazy/3` with a `raise` in the third-argument function might be a better idea.