### PR TITLE
Allow StringIO to set encoding

### DIFF
--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -21,13 +21,18 @@ defmodule StringIO do
   `string` will be the initial input of the newly created
   device.
 
-  If the `:capture_prompt` option is set to `true`,
-  prompts (specified as arguments to `IO.get*` functions)
-  are captured in the output.
-
   The device will be created and sent to the function given.
   When the function returns, the device will be closed. The final
   result will be a tuple with `:ok` and the result of the function.
+
+  ## Options
+
+    * `:capture_prompt` - if set to `true`, prompts (specified as
+      arguments to `IO.get*` functions) are captured in the output.
+      Defaults to `false`.
+
+    * `:encoding` (since v1.10.0) - encoding of the IO device. Allowed
+    values are `:unicode` (default) and `:latin1`.
 
   ## Examples
 
@@ -169,7 +174,8 @@ defmodule StringIO do
   @impl true
   def init({string, options}) do
     capture_prompt = options[:capture_prompt] || false
-    {:ok, %{encoding: :unicode, input: string, output: "", capture_prompt: capture_prompt}}
+    encoding = options[:encoding] || :unicode
+    {:ok, %{encoding: encoding, input: string, output: "", capture_prompt: capture_prompt}}
   end
 
   @impl true

--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -32,7 +32,7 @@ defmodule StringIO do
       Defaults to `false`.
 
     * `:encoding` (since v1.10.0) - encoding of the IO device. Allowed
-    values are `:unicode` (default) and `:latin1`.
+      values are `:unicode` (default) and `:latin1`.
 
   ## Examples
 

--- a/lib/elixir/test/elixir/string_io_test.exs
+++ b/lib/elixir/test/elixir/string_io_test.exs
@@ -162,6 +162,19 @@ defmodule StringIOTest do
     assert StringIO.contents(pid) == {"", binary}
   end
 
+  test "IO.binwrite with bytes" do
+    {:ok, pid} = StringIO.open("")
+    assert IO.binwrite(pid, <<127, 128>>) == :ok
+    assert StringIO.contents(pid) == {"", <<127, 194, 128>>}
+  end
+
+  test "IO.binwrite with bytes and latin1 encoding" do
+    {:ok, pid} = StringIO.open("")
+    assert :io.setopts(pid, encoding: :latin1) == :ok
+    assert IO.binwrite(pid, <<127, 128>>) == :ok
+    assert StringIO.contents(pid) == {"", <<127, 128>>}
+  end
+
   test "IO.puts" do
     {:ok, pid} = StringIO.open("")
     assert IO.puts(pid, "abc") == :ok

--- a/lib/elixir/test/elixir/string_io_test.exs
+++ b/lib/elixir/test/elixir/string_io_test.exs
@@ -169,8 +169,7 @@ defmodule StringIOTest do
   end
 
   test "IO.binwrite with bytes and latin1 encoding" do
-    {:ok, pid} = StringIO.open("")
-    assert :io.setopts(pid, encoding: :latin1) == :ok
+    {:ok, pid} = StringIO.open("", encoding: :latin1)
     assert IO.binwrite(pid, <<127, 128>>) == :ok
     assert StringIO.contents(pid) == {"", <<127, 128>>}
   end

--- a/lib/ex_unit/test/ex_unit/capture_io_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_io_test.exs
@@ -86,6 +86,16 @@ defmodule ExUnit.CaptureIOTest do
            end) == "a"
   end
 
+  test "with fwrite" do
+    assert capture_io(fn ->
+             :io.fwrite(<<127, 128>>)
+           end) == <<127, 194, 128>>
+
+    assert capture_io([encoding: :latin1], fn ->
+             :io.fwrite(<<127, 128>>)
+           end) == <<127, 128>>
+  end
+
   test "with get chars" do
     assert capture_io(fn ->
              :io.get_chars(">", 3)


### PR DESCRIPTION
Before this patch, the encoding was always unicode. This means the
following behaviour:

    iex> {:ok, pid} = StringIO.open("")
    iex> IO.binwrite(pid, <<127, 128>>)
    iex> StringIO.contents(pid)
    {"", <<127, 194, 128>>}

One example where this may be problematic is when using
`ExUnit.CaptureIO`, e.g. we're testing that a given function outputs
binary to stdout. Currently, we have a similar issue:

    iex> ExUnit.CaptureIO.capture_io(fn -> IO.binwrite(<<127, 128>>) end)
    <<127, 194, 128>>

With this patch we can do the following:

    iex> ExUnit.CaptureIO.capture_io(fn ->
    ...>   :ok = :io.setopts(Process.group_leader(), encoding: :latin1)
    ...>   IO.binwrite(<<127, 128>>)
    ...> end)
    <<127, 128>>

If this is accepted, I'm wondering if it would be useful to set the
encoding on `StringIO.open/2` and/or in `ExUnit.CaptureIO.capture_io/2`.
As @ericmj mentioned, there could be a new `CaptureIO.capture_bin_io/2`
function too.

All that being said, an alternative approach is the following:

    iex> output = ExUnit.CaptureIO.capture_io(fn -> IO.binwrite(<<127, 128>>) end)
    iex> :unicode.characters_to_binary(output, :unicode, :latin1)
    <<127, 128>>

So it could be a matter of documentation instead.