### PR TITLE
Make the wildcard example equivalent with `Mix.Config` in an umbrella project

### DIFF
--- a/lib/elixir/lib/config.ex
+++ b/lib/elixir/lib/config.ex
@@ -55,7 +55,7 @@ defmodule Config do
 
   It has to be replaced by:
 
-      for config <- "apps/*/config/config.exs" |> Path.expand() |> Path.wildcard() do
+      for config <- "../apps/*/config/config.exs" |> Path.expand(__DIR__) |> Path.wildcard() do
         import_config config
       end
 


### PR DESCRIPTION
The current method to get wildcard paths is misleading, as it only works when you start your project from the project root. If someone is in an umbrella project and start a child app, the lookup method won't get any configs, and the result maybe quite confusing.

This PR changed the example to make the example code works completely equivalent with the `Mix.Config` example.