### PR TITLE
Fix release pid RPC tests

### DIFF
--- a/lib/mix/test/mix/tasks/release_test.exs
+++ b/lib/mix/test/mix/tasks/release_test.exs
@@ -281,10 +281,11 @@ defmodule Mix.Tasks.ReleaseTest do
         open_port(script, ['start'])
         wait_until_decoded(Path.join(root, "RELEASE_BOOTED"))
         assert System.cmd(script, ["rpc", "ReleaseTest.hello_world"]) == {"hello world\n", 0}
-        assert System.cmd(script, ["stop"]) == {"", 0}
 
         assert {pid, 0} = System.cmd(script, ["pid"])
         assert pid != "\n"
+
+        assert System.cmd(script, ["stop"]) == {"", 0}
       end)
     end)
   end


### PR DESCRIPTION
Addresses #9167.

The port was closed before calling `System.cmd(script, ["pid"])`, resulting in `--rpc-eval : RPC failed with reason :nodedown` errors.

As mentioned in the issue thread, I am not completely sure why the tests pass on [certain platforms](https://cloud.drone.io/alpinelinux/aports/7875/), while they seemingly shouldn't.