### PR TITLE
Access.fetch!/2 implemented

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -242,7 +242,7 @@ defmodule Access do
 
   ## Examples
 
-      iex> Access.fetch(%{name: "meg", age: 26}, :name)
+      iex> Access.fetch!(%{name: "meg", age: 26}, :name)
       "meg"
 
   """

--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -239,6 +239,12 @@ defmodule Access do
   @doc """
   Same as `fetch/2` but returns the term directly,
   or raises an `ArgumentError` exception if an error is returned.
+
+  ## Examples
+
+      iex> Access.fetch(%{name: "meg", age: 26}, :name)
+      "meg"
+
   """
   @spec fetch!(container, term) :: term
   def fetch!(container, key) do
@@ -247,9 +253,7 @@ defmodule Access do
         value
 
       :error ->
-        raise ArgumentError,
-              "the Access call for: " <>
-                inspect(container) <> " was not able to find: " <> inspect(key)
+        raise(KeyError, key: key, term: container)
     end
   end
 

--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -237,6 +237,23 @@ defmodule Access do
   end
 
   @doc """
+  Same as `fetch/2` but returns the term directly,
+  or raises an `ArgumentError` exception if an error is returned.
+  """
+  @spec fetch!(container, term) :: term
+  def fetch!(container, key) do
+    case fetch(container, key) do
+      {:ok, value} ->
+        value
+
+      :error ->
+        raise ArgumentError,
+              "the Access call for: " <>
+                inspect(container) <> " was not able to find: " <> inspect(key)
+    end
+  end
+
+  @doc """
   Gets the value for the given key in a container (a map, keyword
   list, or struct that implements the `Access` behaviour).
 

--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -249,11 +249,8 @@ defmodule Access do
   @spec fetch!(container, term) :: term
   def fetch!(container, key) do
     case fetch(container, key) do
-      {:ok, value} ->
-        value
-
-      :error ->
-        raise(KeyError, key: key, term: container)
+      {:ok, value} -> value
+      :error -> raise(KeyError, key: key, term: container)
     end
   end
 

--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -237,8 +237,8 @@ defmodule Access do
   end
 
   @doc """
-  Same as `fetch/2` but returns the term directly,
-  or raises an `ArgumentError` exception if an error is returned.
+  Same as `fetch/2` but returns the value directly,
+  or raises a `KeyError` exception if `key` is not found.
 
   ## Examples
 

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -99,6 +99,22 @@ defmodule AccessTest do
     end
   end
 
+  describe "fetch!/2" do
+    assert Access.fetch!(%{foo: :bar}, :foo) == :bar
+
+    assert_raise ArgumentError,
+                 ~r/the Access calls for keywords expect the key to be an atom/,
+                 fn ->
+                   Access.fetch!([], "foo")
+                 end
+
+    assert_raise ArgumentError,
+                 ~r/the Access call for: nil was not able to find: \"foo\"/,
+                 fn ->
+                   Access.fetch!(nil, "foo")
+                 end
+  end
+
   describe "filter/1" do
     @test_list [1, 2, 3, 4, 5, 6]
 

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -108,8 +108,8 @@ defmodule AccessTest do
                    Access.fetch!([], "foo")
                  end
 
-    assert_raise ArgumentError,
-                 ~r/the Access call for: nil was not able to find: \"foo\"/,
+    assert_raise KeyError,
+                 ~r/key \"foo\" not found/,
                  fn ->
                    Access.fetch!(nil, "foo")
                  end

--- a/lib/elixir/test/elixir/access_test.exs
+++ b/lib/elixir/test/elixir/access_test.exs
@@ -104,15 +104,11 @@ defmodule AccessTest do
 
     assert_raise ArgumentError,
                  ~r/the Access calls for keywords expect the key to be an atom/,
-                 fn ->
-                   Access.fetch!([], "foo")
-                 end
+                 fn -> Access.fetch!([], "foo") end
 
     assert_raise KeyError,
                  ~r/key \"foo\" not found/,
-                 fn ->
-                   Access.fetch!(nil, "foo")
-                 end
+                 fn -> Access.fetch!(nil, "foo") end
   end
 
   describe "filter/1" do


### PR DESCRIPTION
Hey all,

I noticed there's a `key!/1` but that's the only function in this module that supports a bang. I thought maybe `fetch/2` deserved the same love but I totally understand if not!

😄 