### PR TITLE
Fix container algebra on diffs

### DIFF
--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -1007,12 +1007,18 @@ defmodule ExUnit.Diff do
     docs =
       list
       |> Enum.map(&item_to_algebra.(&1, diff_wrapper))
-      |> Algebra.fold_doc(&Algebra.flex_glue(&1, ", ", &2))
+      |> Algebra.fold_doc(&join_docs/2)
       |> Algebra.nest(1)
 
     [open, docs, close]
     |> Algebra.concat()
     |> Algebra.group()
+  end
+
+  defp join_docs(doc1, doc2) do
+    doc1
+    |> Algebra.concat(",")
+    |> Algebra.flex_glue(doc2)
   end
 
   defp struct_to_algebra(quoted, diff_wrapper) do


### PR DESCRIPTION
When the elements of the container are too big and rendered in different lines, the separator is missing.
This change fixes that.

References #9259