### PR TITLE
WIP: prototyping Macro.to_string/1 enhancement

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1141,7 +1141,15 @@ defmodule Macro do
   defp call_to_string_with_args(target, args, fun) do
     target = call_to_string(target, fun)
     args = args_to_string(args, fun)
-    target <> "(" <> args <> ")"
+    format_call(target, args)
+  end
+
+  defp format_call(target, args) do
+    case target do
+      "defmodule" -> target <> " " <> args
+      "def" -> target <> " " <> args
+      _ -> target <> "(" <> args <> ")"
+    end
   end
 
   defp call_to_string_for_atom(atom) do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -554,8 +554,8 @@ defmodule MacroTest do
         end
 
       expected = """
-      defmodule(Foo) do
-        def(foo) do
+      defmodule Foo do
+        def foo do
           1 + 1
         end
       end


### PR DESCRIPTION
I am attempting to write a mix task that converts code to a quoted expression, does a transformation, and then converts it back to a string using the `Macro.to_string/1`. 

Currently `def` and `defmodule` macro arguments are surrounded with parenthesises via the aforementioned function. I want to discuss the potential of modifying how `Macro.to_string/1` works to no generate code in this way. 

I hit a wrinkle with the test 'iex/helper_test.exs:377', I am not quite sure how the test titled "prints function/macro documentation" works. It fails on line 390 when looking up the help documentation of the `def` macro.

Would you be willing to help me understand this? 

