### PR TITLE
Document escaping in eex more clearly

### DIFF
--- a/lib/eex/lib/eex.ex
+++ b/lib/eex/lib/eex.ex
@@ -76,6 +76,12 @@ defmodule EEx do
         This will never appear
       <% end %>
 
+  To escape eex in eex use `<%% content %>`. For example:
+
+      <%%= x + 3 %>
+
+  Will be rendered as `<%= x + 3 %>`
+
   Notice that different engines may have different rules
   for each tag. Other tags may be added in future versions.
 

--- a/lib/eex/lib/eex.ex
+++ b/lib/eex/lib/eex.ex
@@ -80,7 +80,7 @@ defmodule EEx do
 
       <%%= x + 3 %>
 
-  Will be rendered as `<%= x + 3 %>`
+  will be rendered as `<%= x + 3 %>`.
 
   Notice that different engines may have different rules
   for each tag. Other tags may be added in future versions.

--- a/lib/eex/lib/eex.ex
+++ b/lib/eex/lib/eex.ex
@@ -76,7 +76,7 @@ defmodule EEx do
         This will never appear
       <% end %>
 
-  To escape eex in eex use `<%% content %>`. For example:
+  To escape an EEx expression in EEx use `<%% content %>`. For example:
 
       <%%= x + 3 %>
 


### PR DESCRIPTION
When I was searching the eex docs I wasn't able to find any info about "escaping" and didn't realize that the `<%%` form was meant for escaping an eex expression inside of eex.