### PR TITLE
WIP: prototyping Macro.to_string/1 enhancement

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -780,6 +780,10 @@ defmodule Macro do
     fun.(ast, "defmacro " <> to_string({macro_name, context, args}, fun) <> " do\nend")
   end
 
+  def to_string({:defmodule, _, [{module_name, context, args} | _rest]} = ast, fun) do
+    fun.(ast, "defmodule " <> to_string({module_name, context, args}, fun) <> " do\nend")
+  end
+
   # Bits containers
   def to_string({:<<>>, _, parts} = ast, fun) do
     if interpolated?(ast) do
@@ -1146,15 +1150,7 @@ defmodule Macro do
   defp call_to_string_with_args(target, args, fun) do
     target = call_to_string(target, fun)
     args = args_to_string(args, fun)
-    format_call(target, args)
-  end
-
-  defp format_call(target, args) do
-    case target do
-      "defmodule" -> target <> " " <> args
-      "def" -> target <> " " <> args
-      _ -> target <> "(" <> args <> ")"
-    end
+    target <> "(" <> args <> ")"
   end
 
   defp call_to_string_for_atom(atom) do

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -775,6 +775,11 @@ defmodule Macro do
     fun.(ast, "(\n  " <> block <> "\n)")
   end
 
+  # Macro definition
+  def to_string({:defmacro, _, [{macro_name, context, args} | _rest]} = ast, fun) do
+    fun.(ast, "defmacro " <> to_string({macro_name, context, args}, fun) <> " do\nend")
+  end
+
   # Bits containers
   def to_string({:<<>>, _, parts} = ast, fun) do
     if interpolated?(ast) do
@@ -1141,7 +1146,15 @@ defmodule Macro do
   defp call_to_string_with_args(target, args, fun) do
     target = call_to_string(target, fun)
     args = args_to_string(args, fun)
-    target <> "(" <> args <> ")"
+    format_call(target, args)
+  end
+
+  defp format_call(target, args) do
+    case target do
+      "defmodule" -> target <> " " <> args
+      "def" -> target <> " " <> args
+      _ -> target <> "(" <> args <> ")"
+    end
   end
 
   defp call_to_string_for_atom(atom) do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -274,6 +274,32 @@ defmodule MacroTest do
       assert Macro.to_string(quote(do: foo([1, 2, 3]))) == "foo([1, 2, 3])"
     end
 
+    test "macro definition" do
+      assert Macro.to_string(
+               quote(
+                 do:
+                   defmacro no_op_macro_with_zero_args() do
+                   end
+               )
+             ) == "defmacro no_op_macro_with_zero_args() do\nend"
+
+      assert Macro.to_string(
+               quote(
+                 do:
+                   defmacro no_op_macro_with_one_args(_arg_1) do
+                   end
+               )
+             ) == "defmacro no_op_macro_with_one_args(_arg_1) do\nend"
+
+      assert Macro.to_string(
+               quote(
+                 do:
+                   defmacro no_op_macro_with_two_args(_arg_1, _arg_2) do
+                   end
+               )
+             ) == "defmacro no_op_macro_with_two_args(_arg_1, _arg_2) do\nend"
+    end
+
     test "remote call" do
       assert Macro.to_string(quote(do: foo.bar(1, 2, 3))) == "foo.bar(1, 2, 3)"
       assert Macro.to_string(quote(do: foo.bar([1, 2, 3]))) == "foo.bar([1, 2, 3])"
@@ -554,8 +580,8 @@ defmodule MacroTest do
         end
 
       expected = """
-      defmodule(Foo) do
-        def(foo) do
+      defmodule Foo do
+        def foo do
           1 + 1
         end
       end


### PR DESCRIPTION
# AST with macro definitions yield different strings than macro invocations

I am working on a mix task that does mutations on the quoted expression returned by `Code.string_to_quoted/1`. I would like to be able to use `Macro.to_string/1` to convert the new quoted expression back into code. So I made a start on implementing this behavior, but I have hit a snag.

Currently, `Macro.to_string/1` is used by the code documentation mechanism to generate a header for macros. The current code I am working on modifies the `Macro` module to act as I expect, however I am seeing the test title "prints function/macro documentation" located at `iex/test/iex/helpers_test.exs:377` fail. 

```
actual: * defmacro def call, expr \\ nil
expected: * defmacro def(call, expr \\ nil)
```

Clearly I’m misunderstanding how the document generation works. Could you point me in the right direction?

Thanks
Steve