### PR TITLE
Remove undocumented process flags

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -708,8 +708,6 @@ defmodule Process do
   @spec flag(:message_queue_data, :erlang.message_queue_data()) :: :erlang.message_queue_data()
   @spec flag(:min_bin_vheap_size, non_neg_integer) :: non_neg_integer
   @spec flag(:min_heap_size, non_neg_integer) :: non_neg_integer
-  @spec flag(:monitor_nodes, term) :: term
-  @spec flag({:monitor_nodes, term()}, term) :: term
   @spec flag(:priority, priority_level) :: priority_level
   @spec flag(:save_calls, 0..10000) :: 0..10000
   @spec flag(:sensitive, boolean) :: boolean


### PR DESCRIPTION
Erlang [deliberately omitted](https://github.com/erlang/otp/blob/51d33208b08a257b59a64a35a953bb44c864f115/erts/preloaded/src/erlang.erl#L2251-L2253) `:monitor_nodes` from `process_flag/2` docs. 

To avoid confusion, `Process.flag/2` docs should omit these flags too .