### PR TITLE
Allow mix deps.compile to ignore umbrella apps

### DIFF
--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -191,6 +191,18 @@ defmodule Mix.Tasks.DepsTest do
     end)
   end
 
+  test "doesn't compile any umbrella apps if --skip-umbrella-children given" do
+    in_fixture("umbrella_dep/deps/umbrella", fn ->
+      Mix.Project.in_project(:umbrella, ".", fn _ ->
+        refute File.exists?("_build/dev/lib/foo/ebin")
+        refute File.exists?("_build/dev/lib/bar/ebin")
+        Mix.Tasks.Deps.Compile.run(["--skip-umbrella-children"])
+        refute File.exists?("_build/dev/lib/foo/ebin")
+        refute File.exists?("_build/dev/lib/bar/ebin")
+      end)
+    end)
+  end
+
   ## deps.loadpaths
 
   test "checks list of dependencies and their status with success" do


### PR DESCRIPTION
This addresses the problem outlined in
https://github.com/elixir-lang/elixir/issues/7519

`mix deps.compile` can be a good way of caching builds
in a CI environment. Also it's good contain the warnings of the `mix
deps.compile` from the ones of `mix compile`.