### PR TITLE
Doc) Remove missing link and ambiguous expression

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2073,7 +2073,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Creates and updates structs.
+  Creates and updates a struct.
 
   The `struct` argument may be an atom (which defines `defstruct`)
   or a `struct` itself. The second argument is any `Enumerable` that

--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -153,7 +153,7 @@ Built-in type           | Defined as
 
 ### Remote types
 
-Any module is also able to define its own types and the modules in Elixir are no exception. For example, the `Range` module defines a [`t/0`](t:Range.t/0) type that represents a range: this type can be referred to as `t:Range.t/0`. In a similar fashion, a string is `t:String.t/0`, any enumerable can be `t:Enum.t/0`, and so on.
+Any module is also able to define its own types and the modules in Elixir are no exception. For example, the `Range` module defines a `t/0` type that represents a range: this type can be referred to as `t:Range.t/0`. In a similar fashion, a string is `t:String.t/0`, any enumerable can be `t:Enum.t/0`, and so on.
 
 ### Maps
 


### PR DESCRIPTION
This PR updates documentation.

- `Kernel.struct/2` doesn't work with multiple structs.
- In the `Typespecs` page, the `t/0` of `Range` doesn't link a proper Range type; instead create `file:///T:/Range.t/0` which is unexpected. And the actual `Range.t/0` is duplicated in the same sentence.