### PR TITLE
Make Module.open?/1 and family to match their docs

### DIFF
--- a/lib/elixir/src/elixir_code_server.erl
+++ b/lib/elixir/src/elixir_code_server.erl
@@ -9,8 +9,7 @@
   required=#{},
   mod_pool={[], [], 0},
   mod_ets=#{},
-  compilation_status=#{},
-  mod_opened=#{}
+  compilation_status=#{}
 }).
 
 call(Args) ->
@@ -27,7 +26,6 @@ start_link() ->
 init(ok) ->
   %% The table where we store module definitions
   _ = ets:new(elixir_modules, [set, protected, named_table, {read_concurrency, true}]),
-  _ = ets:new(elixir_opened_modules, [set, protected, named_table, {read_concurrency, true}]),
   {ok, #elixir_code_server{}}.
 
 handle_call({defmodule, Module, Pid, Tuple}, _From, Config) ->
@@ -132,7 +130,7 @@ handle_cast(Request, Config) ->
   {stop, {badcast, Request}, Config}.
 
 handle_info({'DOWN', Ref, process, _Pid, _Reason}, Config) ->
-  {noreply, undefmodule(Ref, unopenmodule(Ref, Config))};
+  {noreply, undefmodule(Ref, Config)};
 
 handle_info(_Msg, Config) ->
   {noreply, Config}.
@@ -146,12 +144,11 @@ code_change(_Old, Config, _Extra) ->
 compiler_module(I) ->
   list_to_atom("elixir_compiler_" ++ integer_to_list(I)).
 
-defmodule(Pid, Tuple, #elixir_code_server{mod_ets=ModEts, mod_opened=ModOpened} = Config) ->
+defmodule(Pid, Tuple, #elixir_code_server{mod_ets=ModEts} = Config) ->
   ets:insert(elixir_modules, Tuple),
-  ets:insert(elixir_opened_modules, Tuple),
   Ref = erlang:monitor(process, Pid),
   Mod = erlang:element(1, Tuple),
-  {Ref, Config#elixir_code_server{mod_opened=maps:put(Ref, Mod, ModOpened),mod_ets=maps:put(Ref, Mod, ModEts)}}.
+  {Ref, Config#elixir_code_server{mod_ets=maps:put(Ref, Mod, ModEts)}}.
 
 undefmodule(Ref, #elixir_code_server{mod_ets=ModEts} = Config) ->
   case maps:find(Ref, ModEts) of
@@ -162,11 +159,11 @@ undefmodule(Ref, #elixir_code_server{mod_ets=ModEts} = Config) ->
       Config
   end.
 
-unopenmodule(Ref, #elixir_code_server{mod_opened=ModOpened} = Config) ->
-  case maps:find(Ref, ModOpened) of
+unopenmodule(Ref, #elixir_code_server{mod_ets=ModEts} = Config) ->
+  case maps:find(Ref, ModEts) of
     {ok, Mod} ->
-      ets:delete(elixir_opened_modules, Mod),
-      Config#elixir_code_server{mod_opened=maps:remove(Ref, ModOpened)};
+      ets:update_element(elixir_modules, Mod, {5, false}),
+      Config;
     error ->
       Config
   end.

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -30,7 +30,7 @@ is_open(Module) ->
   ets:member(elixir_modules, Module).
 
 is_not_closing(Module) ->
-  ets:member(elixir_opened_modules, Module).
+  ets:lookup_element(elixir_modules, Module, 5).
 
 delete_definition_attributes(#{module := Module}, _, _, _, _, _) ->
   {DataSet, _} = data_tables(Module),
@@ -294,13 +294,13 @@ build(Line, File, Module) ->
   Tables = {DataSet, DataBag},
   elixir_def:setup(Tables),
   elixir_locals:setup(Tables),
-  Tuple = {Module, Tables, Line, File},
+  Tuple = {Module, Tables, Line, File, true},
 
   Ref =
     case elixir_code_server:call({defmodule, Module, self(), Tuple}) of
       {ok, ModuleRef} ->
         ModuleRef;
-      {error, {Module, _, OldLine, OldFile}} ->
+      {error, {Module, _, OldLine, OldFile, _}} ->
         ets:delete(DataSet),
         ets:delete(DataBag),
         Error = {module_in_definition, Module, OldFile, OldLine},

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -121,8 +121,9 @@ compile(Line, Module, Block, Vars, E) ->
     Binary = elixir_erl:compile(ModuleMap),
     warn_unused_attributes(File, DataSet, DataBag, PersistedAttributes),
     autoload_module(Module, Binary, CompileOpts, NE),
-    eval_callbacks(Line, DataBag, after_compile, [NE, Binary], NE),
     make_module_available(Module, Binary, ModuleMap),
+    elixir_code_server:call({undefmodule, Ref}),
+    eval_callbacks(Line, DataBag, after_compile, [NE, Binary], NE),
     {module, Module, Binary, Result}
   catch
     ?WITH_STACKTRACE(error, undef, Stacktrace)

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -77,7 +77,7 @@ defmodule ModuleTest do
     end
   end
 
-  test "module is not opened in __after_compile__/2 callback" do
+  test "module raises on write access attempts from __after_compile__/2" do
     contents =
       quote do
         @after_compile __MODULE__
@@ -92,6 +92,21 @@ defmodule ModuleTest do
                  fn ->
                    Module.create(ModuleTest.Raise, contents, __ENV__)
                  end
+  end
+
+  test "module supports read access to module from __after_compile__/2" do
+    contents =
+      quote do
+        @after_compile __MODULE__
+
+        @foo 42
+
+        def __after_compile__(%Macro.Env{module: module}, bin) when is_binary(bin) do
+          Module.get_attribute(module, :foo)
+        end
+      end
+
+    Module.create(ModuleTest.NoRaise, contents, __ENV__)
   end
 
   test "in memory modules are tagged as so" do

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -77,6 +77,23 @@ defmodule ModuleTest do
     end
   end
 
+  test "module is not opened in after_callback" do
+    contents =
+      quote do
+        @after_compile __MODULE__
+
+        def __after_compile__(%Macro.Env{module: module} = env, bin) when is_binary(bin) do
+          Module.put_attribute(module, :foo, 42)
+        end
+      end
+
+    assert_raise ArgumentError,
+                 "could not call Module.__put_attribute__/4 because the module ModuleTest.Raise is already compiled",
+                 fn ->
+                   Module.create(ModuleTest.Raise, contents, __ENV__)
+                 end
+  end
+
   test "in memory modules are tagged as so" do
     assert :code.which(__MODULE__) == ''
   end

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -77,12 +77,12 @@ defmodule ModuleTest do
     end
   end
 
-  test "module is not opened in after_callback" do
+  test "module is not opened in __after_compile__/2 callback" do
     contents =
       quote do
         @after_compile __MODULE__
 
-        def __after_compile__(%Macro.Env{module: module} = env, bin) when is_binary(bin) do
+        def __after_compile__(%Macro.Env{module: module}, bin) when is_binary(bin) do
           Module.put_attribute(module, :foo, 42)
         end
       end

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -440,7 +440,7 @@ defmodule ExUnit.Case do
 
   @doc false
   def __after_compile__(%{module: module}, _) do
-    if Module.get_attribute(module, :ex_unit_async) do
+    if Module.__info__(:attributes)[:ex_unit_async] do
       ExUnit.Server.add_async_module(module)
     else
       ExUnit.Server.add_sync_module(module)

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -440,7 +440,7 @@ defmodule ExUnit.Case do
 
   @doc false
   def __after_compile__(%{module: module}, _) do
-    if Module.__info__(:attributes)[:ex_unit_async] do
+    if Module.get_attribute(module, :ex_unit_async) do
       ExUnit.Server.add_async_module(module)
     else
       ExUnit.Server.add_sync_module(module)


### PR DESCRIPTION
This should be treated mostly as a proposal, but since it’s always easier to explain with code, I’ve created a PR.

Docs for `Module.open?/1` say:

```elixir
  @doc """
  Checks if a module is open.

  A module is "open" if it is currently being defined and its attributes and
  functions can be modified.
  """
  @spec open?(module) :: boolean
```

The above breaks contract if called from `__after_compile__/2` callback. What leads to the fact all the modifying functions, like `Module.put_attribute/3` are allowed and silently ignored. My concern is `Module.open?/1` should not return `true` from there, and it could have been fixed as proposed below, save for it might break the existing code (as might be seen in `lib/ex_unit/lib/ex_unit/case.ex` below.)

On the other hand, it’d always be a compilation time exception, which might be easily fixed provided it’s backed up with a good error message. OTOH, it might make external libraries to fail and I have zero ideas of how many of them.

The lightweight solution would be to raise from _modifying the module functions_, or to warn from there. I am not a big fan of breaking changes, but I am positive the deprecation and maybe raising in the future would be a proper and helpful change. After all, they did not work from there since day one.

Thoughts?