### PR TITLE
Fix missing backtick in mix.release struct docs

### DIFF
--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -8,7 +8,7 @@ defmodule Mix.Release do
 
     * `:name` - the name of the release as an atom
     * `:version` - the version of the release as a string or
-       `{:from_app, app_name}
+       `{:from_app, app_name}`
     * `:path` - the path to the release root
     * `:version_path` - the path to the release version inside the release
     * `:applications` - a map of application with their definitions


### PR DESCRIPTION
Minor inconvenience, from this little [comment](https://github.com/elixir-lang/elixir/commit/b43a6a923e2cbf641421ad10f98b67485bc83548#r34634308).