### PR TITLE
Improve assertions on the process mailbox

### DIFF
--- a/lib/ex_unit/examples/difference.exs
+++ b/lib/ex_unit/examples/difference.exs
@@ -183,4 +183,8 @@ defmodule Difference do
       assert_received one()
     end
   end
+
+  test "only one side with metadata" do
+    assert "one" != "one"
+  end
 end

--- a/lib/ex_unit/examples/difference.exs
+++ b/lib/ex_unit/examples/difference.exs
@@ -155,10 +155,32 @@ defmodule Difference do
   end
 
   describe "receive" do
+    test "no messages in the mailbox" do
+      assert_received x when x == :hello
+    end
+
+    test "only 1 message in the mailbox" do
+      send(self(), {:message, 1})
+
+      assert_received x when x == :hello
+    end
+
+    test "more than 1 messages in the mailbox" do
+      for i <- 1..2, do: send(self(), {:message, i})
+
+      assert_received x when x == :hello
+    end
+
     test "more than 10 messages in the mailbox" do
       for i <- 1..11, do: send(self(), {:message, i})
 
       assert_received x when x == :hello
+    end
+
+    test "macro" do
+      send(self(), 12)
+
+      assert_received one()
     end
   end
 end

--- a/lib/ex_unit/examples/difference.exs
+++ b/lib/ex_unit/examples/difference.exs
@@ -153,4 +153,12 @@ defmodule Difference do
       assert {_, 1} = {1, 2}
     end
   end
+
+  describe "receive" do
+    test "more than 10 messages in the mailbox" do
+      for i <- 1..11, do: send(self(), {:message, i})
+
+      assert_received x when x == :hello
+    end
+  end
 end

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -544,6 +544,9 @@ defmodule ExUnit.Assertions do
     else
       {message, mailbox} = format_mailbox(messages)
 
+      # The error contains a special `context` that will be transformed
+      # into `{:match, pins}` by the formatter to execute a diff for each
+      # message in the `mailbox`
       raise ExUnit.AssertionError,
         left: pattern,
         expr: code,

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -7,7 +7,6 @@ defmodule ExUnit.AssertionError do
 
   defexception left: @no_value,
                right: @no_value,
-               mailbox: @no_value,
                message: @no_value,
                expr: @no_value,
                args: @no_value,
@@ -545,19 +544,13 @@ defmodule ExUnit.Assertions do
     else
       {message, mailbox} = format_mailbox(messages)
 
-      mailbox =
-        case mailbox do
-          [] -> ExUnit.AssertionError.no_value()
-          _ -> {pattern, mailbox}
-        end
-
       raise ExUnit.AssertionError,
-        mailbox: mailbox,
+        left: pattern,
         expr: code,
         message:
           "Assertion failed, no matching message after #{timeout}ms" <>
             ExUnit.Assertions.__pins__(pins) <> message,
-        context: {:match, pins}
+        context: {:mailbox, pins, mailbox}
     end
   end
 

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -546,6 +546,12 @@ defmodule ExUnit.Assertions do
     else
       {message, mailbox} = format_mailbox(messages)
 
+      mailbox =
+        case mailbox do
+          [] -> ExUnit.AssertionError.no_value()
+          _ -> {pattern, mailbox}
+        end
+
       raise ExUnit.AssertionError,
         mailbox: mailbox,
         expr: code,

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -437,8 +437,6 @@ defmodule ExUnit.Assertions do
       send(self(), :bye)
       assert_received :hello, "Oh No!"
       ** (ExUnit.AssertionError) Oh No!
-      Process mailbox:
-        :bye
 
   You can also match against specific patterns:
 
@@ -906,8 +904,6 @@ defmodule ExUnit.Assertions do
       send(self(), :hello)
       refute_received :hello, "Oh No!"
       ** (ExUnit.AssertionError) Oh No!
-      Process mailbox:
-        :bye
 
   """
   defmacro refute_received(pattern, failure_message \\ nil) do

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -531,11 +531,10 @@ defmodule ExUnit.Assertions do
   @doc false
   def __timeout__(pattern, code, pins, pattern_finder, timeout) do
     {:messages, messages} = Process.info(self(), :messages)
-    binary = Macro.to_string(pattern)
 
     if Enum.any?(messages, pattern_finder) do
       """
-      Found message matching #{binary} after #{timeout}ms.
+      Found message matching #{Macro.to_string(pattern)} after #{timeout}ms.
 
       This means the message was delivered too close to the timeout value, you may want to either:
 

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -7,6 +7,7 @@ defmodule ExUnit.AssertionError do
 
   defexception left: @no_value,
                right: @no_value,
+               mailbox: @no_value,
                message: @no_value,
                expr: @no_value,
                args: @no_value,
@@ -416,7 +417,8 @@ defmodule ExUnit.Assertions do
              timeout \\ Application.fetch_env!(:ex_unit, :assert_receive_timeout),
              failure_message \\ nil
            ) do
-    assert_receive(pattern, timeout, failure_message, __CALLER__)
+    code = escape_quoted(:assert_receive, pattern)
+    assert_receive(pattern, timeout, failure_message, __CALLER__, code)
   end
 
   @doc """
@@ -446,19 +448,18 @@ defmodule ExUnit.Assertions do
 
   """
   defmacro assert_received(pattern, failure_message \\ nil) do
-    assert_receive(pattern, 0, failure_message, __CALLER__)
+    code = escape_quoted(:assert_received, pattern)
+    assert_receive(pattern, 0, failure_message, __CALLER__, code)
   end
 
-  defp assert_receive(pattern, timeout, failure_message, caller) do
-    binary = Macro.to_string(pattern)
-
+  defp assert_receive(pattern, timeout, failure_message, caller, code) do
     # Expand before extracting metadata
-    pattern = __expand_pattern__(pattern, caller)
-    vars = collect_vars_from_pattern(pattern)
-    pins = collect_pins_from_pattern(pattern, Macro.Env.vars(caller))
+    expanded_pattern = __expand_pattern__(pattern, caller)
+    vars = collect_vars_from_pattern(expanded_pattern)
+    pins = collect_pins_from_pattern(expanded_pattern, Macro.Env.vars(caller))
 
     pattern =
-      case pattern do
+      case expanded_pattern do
         {:when, meta, [left, right]} ->
           {:when, meta, [quote(do: unquote(left) = received), right]}
 
@@ -496,7 +497,8 @@ defmodule ExUnit.Assertions do
       failure_message ||
         quote do
           ExUnit.Assertions.__timeout__(
-            unquote(binary),
+            unquote(Macro.escape(expanded_pattern)),
+            unquote(code),
             unquote(pins),
             unquote(pattern_finder),
             timeout
@@ -527,8 +529,9 @@ defmodule ExUnit.Assertions do
     do: raise(ArgumentError, "timeout must be a non-negative integer, got: #{inspect(timeout)}")
 
   @doc false
-  def __timeout__(binary, pins, pattern_finder, timeout) do
+  def __timeout__(pattern, code, pins, pattern_finder, timeout) do
     {:messages, messages} = Process.info(self(), :messages)
+    binary = Macro.to_string(pattern)
 
     if Enum.any?(messages, pattern_finder) do
       """
@@ -541,8 +544,15 @@ defmodule ExUnit.Assertions do
            test_helper.exs by setting ExUnit.configure(assert_receive_timeout: ...)
       """
     else
-      "No message matching #{binary} after #{timeout}ms." <>
-        __pins__(pins) <> format_mailbox(messages)
+      {message, mailbox} = format_mailbox(messages)
+
+      raise ExUnit.AssertionError,
+        mailbox: mailbox,
+        expr: code,
+        message:
+          "Assertion failed, no matching message after #{timeout}ms" <>
+            ExUnit.Assertions.__pins__(pins) <> message,
+        context: {:match, pins}
     end
   end
 
@@ -560,24 +570,23 @@ defmodule ExUnit.Assertions do
 
   defp format_mailbox(messages) do
     length = length(messages)
+    mailbox = Enum.take(messages, -@max_mailbox_length)
 
-    mailbox =
-      messages
-      |> Enum.take(-@max_mailbox_length)
-      |> Enum.map_join(@indent, &inspect/1)
-
-    mailbox_message(length, @indent <> mailbox)
+    {mailbox_message(length), mailbox}
   end
 
-  defp mailbox_message(0, _mailbox), do: "\nThe process mailbox is empty."
+  defp mailbox_message(0), do: "\nThe process mailbox is empty."
 
-  defp mailbox_message(length, mailbox) when length > 10 do
-    "\nProcess mailbox:" <>
-      mailbox <> "\nShowing only last #{@max_mailbox_length} of #{length} messages."
+  defp mailbox_message(1) do
+    "\nShowing 1 of 1 message in the mailbox"
   end
 
-  defp mailbox_message(_length, mailbox) do
-    "\nProcess mailbox:" <> mailbox
+  defp mailbox_message(length) when length > @max_mailbox_length do
+    "\nShowing #{@max_mailbox_length} of #{length} messages in the mailbox"
+  end
+
+  defp mailbox_message(length) do
+    "\nShowing #{length} of #{length} messages in the mailbox"
   end
 
   defp collect_pins_from_pattern(expr, vars) do

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -532,15 +532,17 @@ defmodule ExUnit.Assertions do
     {:messages, messages} = Process.info(self(), :messages)
 
     if Enum.any?(messages, pattern_finder) do
-      """
-      Found message matching #{Macro.to_string(pattern)} after #{timeout}ms.
+      raise ExUnit.AssertionError,
+        expr: code,
+        message: """
+        Found message matching #{Macro.to_string(pattern)} after #{timeout}ms.
 
-      This means the message was delivered too close to the timeout value, you may want to either:
+        This means the message was delivered too close to the timeout value, you may want to either:
 
-        1. Give an increased timeout to `assert_receive/2`
-        2. Increase the default timeout to all `assert_receive` in your
-           test_helper.exs by setting ExUnit.configure(assert_receive_timeout: ...)
-      """
+          1. Give an increased timeout to `assert_receive/2`
+          2. Increase the default timeout to all `assert_receive` in your
+             test_helper.exs by setting ExUnit.configure(assert_receive_timeout: ...)
+        """
     else
       {message, mailbox} = format_mailbox(messages)
 

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -211,7 +211,12 @@ defmodule ExUnit.Diff do
     {diff_clause1, clause1_equivalent?} = diff_guard_clause(clause1, bindings)
     {diff_clause2, clause2_equivalent?} = diff_guard_clause(clause2, bindings)
 
-    equivalent? = clause1_equivalent? or clause2_equivalent?
+    equivalent? =
+      case op do
+        :and -> clause1_equivalent? and clause2_equivalent?
+        _other -> clause1_equivalent? or clause2_equivalent?
+      end
+
     diff = {op, [], [diff_clause1, diff_clause2]}
     {diff, equivalent?}
   end

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -216,7 +216,7 @@ defmodule ExUnit.Diff do
     {diff, equivalent?}
   end
 
-  defp diff_guard_clause(quoted, bindings)  do
+  defp diff_guard_clause(quoted, bindings) do
     expanded =
       Macro.prewalk(quoted, fn
         {_, [{:expanded, expanded} | _], _} -> expanded
@@ -984,7 +984,8 @@ defmodule ExUnit.Diff do
     container_to_algebra("[", list, "]", diff_wrapper, select_list_item_algebra(list))
   end
 
-  defp safe_to_algebra({op, _, [left, right]}, diff_wrapper) when op in [:<>, :++, :|, :when, :and, :or] do
+  defp safe_to_algebra({op, _, [left, right]}, diff_wrapper)
+       when op in [:<>, :++, :|, :when, :and, :or] do
     to_algebra(left, diff_wrapper)
     |> Algebra.concat(" #{op} ")
     |> Algebra.concat(to_algebra(right, diff_wrapper))

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -103,6 +103,10 @@ defmodule ExUnit.Diff do
     diff_string_concat(left, right, env)
   end
 
+  defp diff_quoted({:when, _, [_, _]} = left, right, env) do
+    diff_guard(left, right, env)
+  end
+
   defp diff_quoted({_, [{:expanded, expanded} | _], _} = left, right, env) do
     macro = Macro.update_meta(left, &Keyword.delete(&1, :expanded))
     diff_macro(macro, expanded, right, env)
@@ -183,6 +187,44 @@ defmodule ExUnit.Diff do
     {diff, post_env} = diff(expanded, right, env)
     diff_left = update_diff_meta(macro, !diff.equivalent?)
     {%{diff | left: diff_left}, post_env}
+  end
+
+  # Guards
+
+  defp diff_guard({:when, _, [expression, clause]}, right, env) do
+    {diff_expression, post_env} = diff_quoted(expression, right, env)
+
+    vars = Map.merge(post_env.pins, post_env.current_vars)
+    bindings = for {{name, _context}, value} <- vars, do: {name, value}
+    {diff_clause, clause_equivalent?} = diff_guard_clause(clause, bindings)
+
+    diff = %__MODULE__{
+      diff_expression
+      | left: {:when, [], [diff_expression.left, diff_clause]},
+        equivalent?: diff_expression.equivalent? && clause_equivalent?
+    }
+
+    {diff, post_env}
+  end
+
+  defp diff_guard_clause({op, _, [clause1, clause2]}, bindings) when op in [:when, :or, :and] do
+    {diff_clause1, clause1_equivalent?} = diff_guard_clause(clause1, bindings)
+    {diff_clause2, clause2_equivalent?} = diff_guard_clause(clause2, bindings)
+
+    equivalent? = clause1_equivalent? || clause2_equivalent?
+    diff = {op, [], [diff_clause1, diff_clause2]}
+    {diff, equivalent?}
+  end
+
+  defp diff_guard_clause(quoted, bindings)  do
+    expanded =
+      Macro.prewalk(quoted, fn
+        {_, [{:expanded, expanded} | _], _} -> expanded
+        other -> other
+      end)
+
+    {equivalent?, _bindings} = Code.eval_quoted(expanded, bindings)
+    {update_diff_meta(quoted, !equivalent?), equivalent?}
   end
 
   # Pins
@@ -942,7 +984,7 @@ defmodule ExUnit.Diff do
     container_to_algebra("[", list, "]", diff_wrapper, select_list_item_algebra(list))
   end
 
-  defp safe_to_algebra({op, _, [left, right]}, diff_wrapper) when op in [:<>, :++, :|] do
+  defp safe_to_algebra({op, _, [left, right]}, diff_wrapper) when op in [:<>, :++, :|, :when, :and, :or] do
     to_algebra(left, diff_wrapper)
     |> Algebra.concat(" #{op} ")
     |> Algebra.concat(to_algebra(right, diff_wrapper))

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -201,7 +201,7 @@ defmodule ExUnit.Diff do
     diff = %__MODULE__{
       diff_expression
       | left: {:when, [], [diff_expression.left, diff_clause]},
-        equivalent?: diff_expression.equivalent? && clause_equivalent?
+        equivalent?: diff_expression.equivalent? and clause_equivalent?
     }
 
     {diff, post_env}
@@ -211,7 +211,7 @@ defmodule ExUnit.Diff do
     {diff_clause1, clause1_equivalent?} = diff_guard_clause(clause1, bindings)
     {diff_clause2, clause2_equivalent?} = diff_guard_clause(clause2, bindings)
 
-    equivalent? = clause1_equivalent? || clause2_equivalent?
+    equivalent? = clause1_equivalent? or clause2_equivalent?
     diff = {op, [], [diff_clause1, diff_clause2]}
     {diff, equivalent?}
   end

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -312,6 +312,10 @@ defmodule ExUnit.Formatter do
     []
   end
 
+  defp format_context(%{context: {:mailbox, _pins, []}}, _, _, _) do
+    []
+  end
+
   defp format_context(
          %{left: left, context: {:mailbox, pins, mailbox}},
          formatter,

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -147,8 +147,7 @@ defmodule ExUnit.Formatter do
     {left, right} =
       format_sides(struct.left, struct.right, struct.context, formatter, inspect, side_width)
 
-    mailbox =
-      format_mailbox(struct.mailbox, struct.expr, struct.context, formatter, inspect, side_width)
+    mailbox = format_mailbox(struct.mailbox, struct.context, formatter, inspect, side_width)
 
     [
       note: if_value(struct.message, &format_message(&1, formatter)),
@@ -316,24 +315,23 @@ defmodule ExUnit.Formatter do
     |> Algebra.format(width)
   end
 
-  defp format_mailbox(@no_value, _, _, _, _, _) do
+  defp format_mailbox(@no_value, _, _, _, _) do
     @no_value
   end
 
-  defp format_mailbox(messages, {_, _, [pattern]}, context, formatter, inspect, width) do
+  defp format_mailbox({pattern, messages}, context, formatter, inspect, width) do
     formatted_mailbox =
       for message <- messages do
-        {left, right} = format_sides(pattern, message, context, formatter, inspect, width)
+        {left, right} = format_sides(pattern, message, context, formatter, inspect, width - 2)
 
-        formatted_item =
-          [pattern: left, value: right]
-          |> format_meta(formatter, 9)
-          |> make_into_lines(@counter_padding <> "  ")
-
-        ["\n", formatted_item]
+        [pattern: left, value: right]
+        |> format_meta(formatter, 9)
+        |> Enum.map(&["\n  ", @counter_padding, &1])
       end
 
-    IO.iodata_to_binary(formatted_mailbox)
+    formatted_mailbox
+    |> Enum.join("\n")
+    |> IO.iodata_to_binary()
   end
 
   defp format_sides(@no_value, @no_value, _, _, _, _) do

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -348,7 +348,7 @@ defmodule ExUnit.Formatter do
         ]
       end
 
-    [mailbox: formatted_mailbox]
+    [mailbox: Enum.join(formatted_mailbox, "\n")]
   end
 
   defp format_context(

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -308,10 +308,6 @@ defmodule ExUnit.Formatter do
     |> Algebra.format(width)
   end
 
-  defp format_context(%{left: @no_value, right: @no_value}, _, _, _, _) do
-    []
-  end
-
   defp format_context(%{context: {:mailbox, _pins, []}}, _, _, _, _) do
     []
   end

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -382,12 +382,12 @@ defmodule ExUnit.Formatter do
         {left, right}
 
       nil ->
-        {inspect.(left), inspect.(right)}
+        {if_value(left, inspect), if_value(right, inspect)}
     end
   end
 
   defp format_diff(left, right, context, formatter) do
-    if formatter.(:diff_enabled?, false) do
+    if has_value?(left) and has_value?(right) and formatter.(:diff_enabled?, false) do
       find_diff(left, right, context)
     end
   end

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -356,12 +356,12 @@ defmodule ExUnit.Formatter do
         {left, right}
 
       nil ->
-        {if_value(left, inspect), if_value(right, inspect)}
+        {inspect.(left), inspect.(right)}
     end
   end
 
   defp format_diff(left, right, context, formatter) do
-    if has_value?(left) and has_value?(right) and formatter.(:diff_enabled?, false) do
+    if formatter.(:diff_enabled?, false) do
       find_diff(left, right, context)
     end
   end

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -331,12 +331,13 @@ defmodule ExUnit.AssertionsTest do
     rescue
       error in [ExUnit.AssertionError] ->
         """
-        No message matching {:status, ^status} after 0ms.
+        Assertion failed, no matching message after 0ms
         The following variables were pinned:
           status = :valid
-        Process mailbox:
-          {:status, :invalid}\
+        Showing 1 of 1 message in the mailbox\
         """ = error.message
+
+        [{:status, :invalid}] = error.mailbox
     end
   end
 
@@ -349,12 +350,13 @@ defmodule ExUnit.AssertionsTest do
     rescue
       error in [ExUnit.AssertionError] ->
         """
-        No message matching {:status, ^status, ^status} after 0ms.
+        Assertion failed, no matching message after 0ms
         The following variables were pinned:
           status = :valid
-        Process mailbox:
-          {:status, :invalid, :invalid}\
+        Showing 1 of 1 message in the mailbox\
         """ = error.message
+
+        [{:status, :invalid, :invalid}] = error.mailbox
     end
   end
 
@@ -368,13 +370,14 @@ defmodule ExUnit.AssertionsTest do
     rescue
       error in [ExUnit.AssertionError] ->
         """
-        No message matching {:status, ^status, ^other_status} after 0ms.
+        Assertion failed, no matching message after 0ms
         The following variables were pinned:
           status = :valid
           other_status = :invalid
-        Process mailbox:
-          {:status, :invalid, :invalid}\
+        Showing 1 of 1 message in the mailbox\
         """ = error.message
+
+        [{:status, :invalid, :invalid}] = error.mailbox
     end
   end
 
@@ -383,7 +386,10 @@ defmodule ExUnit.AssertionsTest do
       "This should never be tested" = assert_received :hello
     rescue
       error in [ExUnit.AssertionError] ->
-        "No message matching :hello after 0ms.\nThe process mailbox is empty." = error.message
+        "Assertion failed, no matching message after 0ms\nThe process mailbox is empty." =
+          error.message
+
+        [] = error.mailbox
     end
   end
 
@@ -395,10 +401,11 @@ defmodule ExUnit.AssertionsTest do
     rescue
       error in [ExUnit.AssertionError] ->
         """
-        No message matching :hello after 0ms.
-        Process mailbox:
-          {:message, :not_expected, :at_all}\
+        Assertion failed, no matching message after 0ms
+        Showing 1 of 1 message in the mailbox\
         """ = error.message
+
+        [{:message, :not_expected, :at_all}] = error.mailbox
     end
   end
 
@@ -410,20 +417,22 @@ defmodule ExUnit.AssertionsTest do
     rescue
       error in [ExUnit.AssertionError] ->
         """
-        No message matching x when x == :hello after 0ms.
-        Process mailbox:
-          {:message, 2}
-          {:message, 3}
-          {:message, 4}
-          {:message, 5}
-          {:message, 6}
-          {:message, 7}
-          {:message, 8}
-          {:message, 9}
-          {:message, 10}
-          {:message, 11}
-        Showing only last 10 of 11 messages.\
+        Assertion failed, no matching message after 0ms
+        Showing 10 of 11 messages in the mailbox\
         """ = error.message
+
+        [
+          {:message, 2},
+          {:message, 3},
+          {:message, 4},
+          {:message, 5},
+          {:message, 6},
+          {:message, 7},
+          {:message, 8},
+          {:message, 9},
+          {:message, 10},
+          {:message, 11}
+        ] = error.mailbox
     end
   end
 

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -337,7 +337,8 @@ defmodule ExUnit.AssertionsTest do
         Showing 1 of 1 message in the mailbox\
         """ = error.message
 
-        [{:status, :invalid}] = error.mailbox
+        {pattern, [{:status, :invalid}]} = error.mailbox
+        "{:status, ^status}" = Macro.to_string(pattern)
     end
   end
 
@@ -356,7 +357,8 @@ defmodule ExUnit.AssertionsTest do
         Showing 1 of 1 message in the mailbox\
         """ = error.message
 
-        [{:status, :invalid, :invalid}] = error.mailbox
+        {pattern, [{:status, :invalid, :invalid}]} = error.mailbox
+        "{:status, ^status, ^status}" = Macro.to_string(pattern)
     end
   end
 
@@ -377,7 +379,8 @@ defmodule ExUnit.AssertionsTest do
         Showing 1 of 1 message in the mailbox\
         """ = error.message
 
-        [{:status, :invalid, :invalid}] = error.mailbox
+        {pattern, [{:status, :invalid, :invalid}]} = error.mailbox
+        "{:status, ^status, ^other_status}" = Macro.to_string(pattern)
     end
   end
 
@@ -389,7 +392,7 @@ defmodule ExUnit.AssertionsTest do
         "Assertion failed, no matching message after 0ms\nThe process mailbox is empty." =
           error.message
 
-        [] = error.mailbox
+        :ex_unit_no_meaningful_value = error.mailbox
     end
   end
 
@@ -405,7 +408,8 @@ defmodule ExUnit.AssertionsTest do
         Showing 1 of 1 message in the mailbox\
         """ = error.message
 
-        [{:message, :not_expected, :at_all}] = error.mailbox
+        {pattern, [{:message, :not_expected, :at_all}]} = error.mailbox
+        ":hello" = Macro.to_string(pattern)
     end
   end
 
@@ -421,18 +425,21 @@ defmodule ExUnit.AssertionsTest do
         Showing 10 of 11 messages in the mailbox\
         """ = error.message
 
-        [
-          {:message, 2},
-          {:message, 3},
-          {:message, 4},
-          {:message, 5},
-          {:message, 6},
-          {:message, 7},
-          {:message, 8},
-          {:message, 9},
-          {:message, 10},
-          {:message, 11}
-        ] = error.mailbox
+        {pattern,
+         [
+           {:message, 2},
+           {:message, 3},
+           {:message, 4},
+           {:message, 5},
+           {:message, 6},
+           {:message, 7},
+           {:message, 8},
+           {:message, 9},
+           {:message, 10},
+           {:message, 11}
+         ]} = error.mailbox
+
+        "x when x == :hello" = Macro.to_string(pattern)
     end
   end
 

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -337,8 +337,8 @@ defmodule ExUnit.AssertionsTest do
         Showing 1 of 1 message in the mailbox\
         """ = error.message
 
-        {pattern, [{:status, :invalid}]} = error.mailbox
-        "{:status, ^status}" = Macro.to_string(pattern)
+        "assert_received({:status, ^status})" = Macro.to_string(error.expr)
+        "{:status, ^status}" = Macro.to_string(error.left)
     end
   end
 
@@ -357,8 +357,8 @@ defmodule ExUnit.AssertionsTest do
         Showing 1 of 1 message in the mailbox\
         """ = error.message
 
-        {pattern, [{:status, :invalid, :invalid}]} = error.mailbox
-        "{:status, ^status, ^status}" = Macro.to_string(pattern)
+        "assert_received({:status, ^status, ^status})" = Macro.to_string(error.expr)
+        "{:status, ^status, ^status}" = Macro.to_string(error.left)
     end
   end
 
@@ -379,8 +379,8 @@ defmodule ExUnit.AssertionsTest do
         Showing 1 of 1 message in the mailbox\
         """ = error.message
 
-        {pattern, [{:status, :invalid, :invalid}]} = error.mailbox
-        "{:status, ^status, ^other_status}" = Macro.to_string(pattern)
+        "assert_received({:status, ^status, ^other_status})" = Macro.to_string(error.expr)
+        "{:status, ^status, ^other_status}" = Macro.to_string(error.left)
     end
   end
 
@@ -392,7 +392,7 @@ defmodule ExUnit.AssertionsTest do
         "Assertion failed, no matching message after 0ms\nThe process mailbox is empty." =
           error.message
 
-        :ex_unit_no_meaningful_value = error.mailbox
+        "assert_received(:hello)" = Macro.to_string(error.expr)
     end
   end
 
@@ -408,8 +408,8 @@ defmodule ExUnit.AssertionsTest do
         Showing 1 of 1 message in the mailbox\
         """ = error.message
 
-        {pattern, [{:message, :not_expected, :at_all}]} = error.mailbox
-        ":hello" = Macro.to_string(pattern)
+        "assert_received(:hello)" = Macro.to_string(error.expr)
+        ":hello" = Macro.to_string(error.left)
     end
   end
 
@@ -425,21 +425,8 @@ defmodule ExUnit.AssertionsTest do
         Showing 10 of 11 messages in the mailbox\
         """ = error.message
 
-        {pattern,
-         [
-           {:message, 2},
-           {:message, 3},
-           {:message, 4},
-           {:message, 5},
-           {:message, 6},
-           {:message, 7},
-           {:message, 8},
-           {:message, 9},
-           {:message, 10},
-           {:message, 11}
-         ]} = error.mailbox
-
-        "x when x == :hello" = Macro.to_string(pattern)
+        "assert_received(x when x == :hello)" = Macro.to_string(error.expr)
+        "x when x == :hello" = Macro.to_string(error.left)
     end
   end
 

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -643,6 +643,21 @@ defmodule ExUnit.DiffTest do
     refute_diff(pin_x() = 2, "-pin_x()-", "+2+", pins)
   end
 
+  test "guards" do
+    assert_diff((x when x == 0) = 0, x: 0)
+    assert_diff((x when x == 0 and is_integer(x)) = 0, x: 0)
+    assert_diff((x when x == 0 or x == 1) = 0, x: 0)
+    assert_diff((x when x == 0 when x == 1) = 0, x: 0)
+    assert_diff((x when one() == 1) = 0, x: 0)
+
+    refute_diff((x when x == 1) = 0, "x when -x == 1-", "0")
+    refute_diff((x when x == 0 and x == 1) = 0, "x when x == 0 and -x == 1-", "0")
+    refute_diff((x when x == 1 and x == 2) = 0, "x when -x == 1- and -x == 2-", "0")
+    refute_diff((x when x == 1 or x == 2) = 0, "x when -x == 1- or -x == 2-", "0")
+    refute_diff((x when x == 1 when x == 2) = 0, "x when -x == 1- when -x == 2-", "0")
+    refute_diff((x when x in [1, 2]) = 0, "x when -x in [1, 2]-", "0")
+  end
+
   test "charlists" do
     refute_diff(
       'fox hops over \'the dog' = 'fox jumps over the lazy cat',


### PR DESCRIPTION
Uses `ExUnit.Diff` to improve `ExUnit.Assertions.assert_receive/1` and `ExUnit.Assertions.assert_received/1`

The formatting slightly changed to accommodate the diffs and it's more similar to the other assertions

Closes #6248

