### PR TITLE
update  capture option doc

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -86,7 +86,8 @@ defmodule Regex do
 
     * `:none` - does not return matching subpatterns at all
 
-    * `:all_names` - captures all names in the Regex
+    * `:all_names` - captures all named subpattern matches in the Regex as a list
+      ordered **alphabetically** by the names of the subpatterns
 
     * `list(binary)` - a list of named captures to capture
 


### PR DESCRIPTION
this PR is a little update on the `Regex` documentation to inform that the `:all_names` capture option brings the results as a list ordered alphabetically by the `subpattern` names