### PR TITLE
Add `:tar` option for releases to create a tarball

### DIFF
--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -25,7 +25,8 @@ defmodule Mix.Release do
       and `term` is the value given to it on `c:Config.Provider.init/1`
     * `:options` - a keyword list with all other user supplied release options
     * `:steps` - a list of functions that receive the release and returns a release.
-      Must also contain the atom `:assemble` which is the internal assembling step
+      Must also contain the atom `:assemble` which is the internal assembling step.
+      May also contain the atom `:tar` to create a tarball of the release.
 
   """
   defstruct [
@@ -335,12 +336,14 @@ defmodule Mix.Release do
   end
 
   defp validate_steps!(steps) do
-    if not is_list(steps) or Enum.any?(steps, &(&1 != :assemble and not is_function(&1, 1))) do
+    valid_atoms = [:assemble, :tar]
+
+    if not is_list(steps) or Enum.any?(steps, &(&1 not in valid_atoms and not is_function(&1, 1))) do
       Mix.raise("""
         The :steps option must be a list of:
 
         * anonymous function that receives one argument
-        * the atom :assemble
+        * the atom :assemble or :tar
 
       Got: #{inspect(steps)}
       """)
@@ -348,6 +351,14 @@ defmodule Mix.Release do
 
     if Enum.count(steps, &(&1 == :assemble)) != 1 do
       Mix.raise("The :steps option must contain the atom :assemble once, got: #{inspect(steps)}")
+    end
+
+    if :assemble in Enum.drop_while(steps, &(&1 != :tar)) do
+      Mix.raise("The :tar step must come after :assemble")
+    end
+
+    if Enum.count(steps, &(&1 == :tar)) > 1 do
+      Mix.raise("The :steps option can only contain the atom :tar once")
     end
 
     :ok

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -1027,10 +1027,9 @@ defmodule Mix.Tasks.Release do
       end)
 
     release_files =
-      Path.join(release.path, "releases")
-      |> File.ls!()
-      |> Enum.filter(&(!File.dir?(Path.join([release.path, "releases", &1]))))
-      |> Enum.map(&Path.join("releases", &1))
+      for basename <- File.ls!(Path.join(release.path, "releases")),
+          not File.dir?(Path.join([release.path, "releases", basename])),
+          do: Path.join("releases", basename)
 
     dirs =
       ["bin", Path.join("releases", release.version), "erts-#{release.erts_version}"] ++

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -494,9 +494,7 @@ defmodule Mix.Tasks.Release do
   will receive a `Mix.Release` struct and must return the same or
   an updated `Mix.Release` struct. It is also possible to build a tarball
   of the release by passing the `:tar` step anywhere after `:assemble`.
-  The tarball is created in `_build/MIX_ENV/rel/RELEASE_NAME/releases/RELEASE_VSN/RELEASE_NAME.tar.gz`
-
-
+  The tarball is created in `_build/MIX_ENV/rel/RELEASE_NAME-RELEASE_VSN.tar.gz`
 
   See `Mix.Release` for more documentation on the struct and which
   fields can be modified. Note that `:steps` field itself can be
@@ -1016,8 +1014,8 @@ defmodule Mix.Tasks.Release do
   end
 
   defp make_tar(release) do
-    tar_filename = "#{release.name}.tar.gz"
-    out_path = Path.join(release.path, tar_filename)
+    tar_filename = "#{release.name}-#{release.version}.tar.gz"
+    out_path = Path.join([release.path, "..", "..", tar_filename]) |> Path.expand()
     info(release, [:green, "* building ", :reset, out_path])
 
     lib_dirs =
@@ -1038,8 +1036,8 @@ defmodule Mix.Tasks.Release do
     files =
       Enum.map(dirs, &{String.to_charlist(&1), String.to_charlist(Path.join(release.path, &1))})
 
+    File.rm(out_path)
     :ok = :erl_tar.create(String.to_charlist(out_path), files, [:dereference, :compressed])
-    :ok = File.rename(out_path, Path.join(release.version_path, tar_filename))
     release
   end
 

--- a/lib/mix/test/mix/release_test.exs
+++ b/lib/mix/test/mix/release_test.exs
@@ -184,6 +184,14 @@ defmodule Mix.ReleaseTest do
                    fn -> release(steps: [:assemble, :assemble]) end
 
       assert_raise Mix.Error,
+                   ~r"The :tar step must come after :assemble",
+                   fn -> release(steps: [:tar, :assemble]) end
+
+      assert_raise Mix.Error,
+                   ~r"The :steps option can only contain the atom :tar once",
+                   fn -> release(steps: [:assemble, :tar, :tar]) end
+
+      assert_raise Mix.Error,
                    ~r"The :steps option must be",
                    fn -> release(steps: [:foo]) end
     end

--- a/lib/mix/test/mix/tasks/release_test.exs
+++ b/lib/mix/test/mix/tasks/release_test.exs
@@ -52,15 +52,12 @@ defmodule Mix.Tasks.ReleaseTest do
           File.touch(Path.join(ignored_release_path, "ignored"))
 
           Mix.Task.run("release")
-          message = "* building #{root}/demo.tar.gz"
+          tar_path = Path.expand(Path.join([root, "..", "..", "demo-0.1.0.tar.gz"]))
+          message = "* building #{tar_path}"
           assert_received {:mix_shell, :info, [^message]}
-          assert root |> Path.join("releases/0.1.0/demo.tar.gz") |> File.exists?()
+          assert File.exists?(tar_path)
 
-          {:ok, files} =
-            root
-            |> Path.join("releases/0.1.0/demo.tar.gz")
-            |> String.to_charlist()
-            |> :erl_tar.table([:compressed])
+          {:ok, files} = String.to_charlist(tar_path) |> :erl_tar.table([:compressed])
 
           files = Enum.map(files, &to_string/1)
           files_with_versions = File.ls!(Path.join(root, "lib"))

--- a/lib/mix/test/mix/tasks/release_test.exs
+++ b/lib/mix/test/mix/tasks/release_test.exs
@@ -41,8 +41,17 @@ defmodule Mix.Tasks.ReleaseTest do
         config = [releases: [demo: [steps: [:assemble, :tar]]]]
 
         Mix.Project.in_project(:release_test, ".", config, fn _ ->
-          Mix.Task.run("release")
           root = Path.absname("_build/#{Mix.env()}/rel/demo")
+
+          ignored_app_path = Path.join([root, "lib", "ignored_app-0.1.0", "ebin"])
+          File.mkdir_p!(ignored_app_path)
+          File.touch(Path.join(ignored_app_path, "ignored_app.app"))
+
+          ignored_release_path = Path.join([root, "releases", "ignored_dir"])
+          File.mkdir_p!(ignored_release_path)
+          File.touch(Path.join(ignored_release_path, "ignored"))
+
+          Mix.Task.run("release")
           message = "* building #{root}/demo.tar.gz"
           assert_received {:mix_shell, :info, [^message]}
           assert root |> Path.join("releases/0.1.0/demo.tar.gz") |> File.exists?()
@@ -54,13 +63,21 @@ defmodule Mix.Tasks.ReleaseTest do
             |> :erl_tar.table([:compressed])
 
           files = Enum.map(files, &to_string/1)
+          files_with_versions = File.ls!(Path.join(root, "lib"))
 
           assert "bin/demo" in files
           assert "releases/0.1.0/sys.config" in files
           assert "releases/0.1.0/vm.args" in files
           assert "releases/COOKIE" in files
           assert "releases/start_erl.data" in files
-          assert "lib/release_test-0.1.0/priv/hello" in files
+
+          for dir <- files_with_versions -- ["ignored_app-0.1.0"] do
+            [name | _] = String.split(dir, "-")
+            assert "lib/#{dir}/ebin/#{name}.app" in files
+          end
+
+          refute "lib/ignored_app-0.1.0/ebin/ignored_app.app" in files
+          refute "releases/ignored_dir/ignored" in files
         end)
       end)
     end


### PR DESCRIPTION
Closes #9289

There are a couple of points worth discussing.

@ericmj mentioned using :systools, even if we want to change that, the tests, docs and validations in this PR should still be valid.

Currently the step is simply called `:tar`. Not sure if we want to use a different name, or allow users to build the tar in a different location (something like `{:tar, "some/path/for/myapp.tar.gz"}`