### PR TITLE
Improve documentation on charlists

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -97,24 +97,8 @@ defmodule List do
       [1097, 1098, 1099]
 
   You can use the `IEx.Helpers.i/1` helper to get a condensed rundown on
-  charlists in IEx when you encounter them:
-
-      > i 'abc'
-      Term
-        'abc'
-      Data type
-        List
-      Description
-        This is a list of integers that is printed as a sequence of characters
-        delimited by single quotes because all the integers in it represent printable
-        ASCII characters. Conventionally, a list of Unicode code points is known as a
-        charlist and a list of ASCII characters is a subset of it.
-      Raw representation
-        [97, 98, 99]
-      Reference modules
-        List
-      Implemented protocols
-        Collectable, Enumerable, IEx.Info, Inspect, List.Chars, String.Chars
+  charlists in IEx when you encounter them, which shows you the type, description
+  and also the raw representation in one single summary.
 
   The rationale behind this behaviour is to better support
   Erlang libraries which may return text as charlists

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -88,6 +88,34 @@ defmodule List do
       iex> 'abc'
       'abc'
 
+  Even though the representation changed the raw data does remain a list of
+  numbers, which can be handled as such:
+
+      iex> inspect('abc', charlists: :as_list)
+      "[97, 98, 99]"
+      iex> Enum.map('abc', fn num -> 1000 + num end)
+      [1097, 1098, 1099]
+
+  You can use the `IEx.Helpers.i/1` helper to get a condensed rundown on
+  charlists in iex when you encounter them:
+
+      iex> i 'abc'
+      Term
+        'abc'
+      Data type
+        List
+      Description
+        This is a list of integers that is printed as a sequence of characters
+        delimited by single quotes because all the integers in it represent printable
+        ASCII characters. Conventionally, a list of Unicode code points is known as a
+        charlist and a list of ASCII characters is a subset of it.
+      Raw representation
+        [97, 98, 99]
+      Reference modules
+        List
+      Implemented protocols
+        Collectable, Enumerable, IEx.Info, Inspect, List.Chars, String.Chars
+
   The rationale behind this behaviour is to better support
   Erlang libraries which may return text as charlists
   instead of Elixir strings. One example of such functions

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -97,7 +97,7 @@ defmodule List do
       [1097, 1098, 1099]
 
   You can use the `IEx.Helpers.i/1` helper to get a condensed rundown on
-  charlists in iex when you encounter them:
+  charlists in IEx when you encounter them:
 
       > i 'abc'
       Term

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -118,8 +118,9 @@ defmodule List do
 
   The rationale behind this behaviour is to better support
   Erlang libraries which may return text as charlists
-  instead of Elixir strings. One example of such functions
-  is `Application.loaded_applications/0`:
+  instead of Elixir strings. In Erlang charlists are the default
+  way of handling strings, while in Elixir it's binaries. One
+  example of such functions is `Application.loaded_applications/0`:
 
       Application.loaded_applications()
       #=>  [

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -88,7 +88,7 @@ defmodule List do
       iex> 'abc'
       'abc'
 
-  Even though the representation changed the raw data does remain a list of
+  Even though the representation changed, the raw data does remain a list of
   numbers, which can be handled as such:
 
       iex> inspect('abc', charlists: :as_list)
@@ -118,7 +118,7 @@ defmodule List do
 
   The rationale behind this behaviour is to better support
   Erlang libraries which may return text as charlists
-  instead of Elixir strings. In Erlang charlists are the default
+  instead of Elixir strings. In Erlang, charlists are the default
   way of handling strings, while in Elixir it's binaries. One
   example of such functions is `Application.loaded_applications/0`:
 

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -99,7 +99,7 @@ defmodule List do
   You can use the `IEx.Helpers.i/1` helper to get a condensed rundown on
   charlists in iex when you encounter them:
 
-      iex> i 'abc'
+      > i 'abc'
       Term
         'abc'
       Data type


### PR DESCRIPTION
Questions on charlists are probably the most common ones of beginners in elixir. I know we have quite a few resources on it, but I don't feel we have a concise common place to link to when trying to help people confused by their first encounter.

https://elixir-lang.org/getting-started/binaries-strings-and-char-lists.html
This is already good, but it deals with charlists from the direction of someone dealing with a string and wanting to deal with a string, while most often beginners are surprised by their lists of numbers getting turned into a string. I think it's good the way it is as part of the getting started guides, but doesn't serve well as point to link surprised people to.

https://github.com/elixir-lang/elixir/wiki/FAQ#4-why-is-my-list-of-integers-printed-as-a-string
This is linked by the `!charlists` shortcut on the slack together with some [discussion](https://groups.google.com/forum/#!msg/elixir-lang-talk/0xxH9HxdQnU/LHgK8elhEQAJ). It's not super elaborate and often people still need to double down on the lessons to be learned. 

I tried to add the most important bits to the docs on charlists in the `List` module.

1. Double down on the fact that charlists are just "representation" and stuff is still the list of numbers people expected their data to be.
2. Hint to `IEx.Helpers.i/1`, because it's imo the most concise way to prove to people that a charlist is a list and that their numbers are still there in the raw representation. It seems a bit meta to include a documentation helper result in documentation, but I guess it should work well.
3. I think there's no need to link to discussions behind why charlists work the way they work beyond what is already in the docs on `List`. I feel what Slack links to is probably more confusing than helpful to beginners.

