### PR TITLE
Change List.Chars.to_charlist to return empty list when given nil

### DIFF
--- a/lib/elixir/lib/list/chars.ex
+++ b/lib/elixir/lib/list/chars.ex
@@ -24,6 +24,8 @@ defprotocol List.Chars do
 end
 
 defimpl List.Chars, for: Atom do
+  def to_charlist(nil), do: ''
+
   def to_charlist(atom), do: Atom.to_charlist(atom)
 end
 

--- a/lib/elixir/test/elixir/list/chars_test.exs
+++ b/lib/elixir/test/elixir/list/chars_test.exs
@@ -6,6 +6,12 @@ defmodule List.Chars.AtomTest do
   test "basic" do
     assert to_charlist(:foo) == 'foo'
   end
+
+  test "true false nil" do
+    assert to_charlist(false) == 'false'
+    assert to_charlist(true) == 'true'
+    assert to_charlist(nil) == ''
+  end
 end
 
 defmodule List.Chars.BitStringTest do


### PR DESCRIPTION
Presently, `List.Chars.to_charlist/1` returns `'nil'` when passed `nil`, which feels sort of odd to me. I believe that the canonical character list form of `nil` should be an empty list, similar to how `String.Chars.to_string/1` returns an empty string when passed `nil`.

I added a test around the new behavior, of course, and also around the handling of `true` and `false` since they are also special atoms (though they are handled well by the existing code :smile:).