### PR TITLE
Support binary path in Protocol.extract_impls/2

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -459,6 +459,7 @@ defmodule Protocol do
 
   defp extract_matching_by_attribute(paths, prefix, callback) do
     for path <- paths,
+        path = to_charlist(path),
         file <- list_dir(path),
         mod = extract_from_file(path, file, prefix, callback),
         do: mod
@@ -470,8 +471,6 @@ defmodule Protocol do
       _ -> []
     end
   end
-
-  defp list_dir(path), do: list_dir(to_charlist(path))
 
   defp extract_from_file(path, file, prefix, callback) do
     if :lists.prefix(prefix, file) and :filename.extension(file) == '.beam' do

--- a/lib/elixir/test/elixir/protocol/consolidation_test.exs
+++ b/lib/elixir/test/elixir/protocol/consolidation_test.exs
@@ -149,8 +149,14 @@ defmodule Protocol.ConsolidationTest do
     assert Inspect in protos
   end
 
-  test "consolidation extracts implementations" do
+  test "consolidation extracts implementations with charlist path" do
     protos = Protocol.extract_impls(Enumerable, [:code.lib_dir(:elixir, :ebin)])
+    assert List in protos
+    assert Function in protos
+  end
+
+  test "consolidation extracts implementations with binary path" do
+    protos = Protocol.extract_impls(Enumerable, [Application.app_dir(:elixir, "ebin")])
     assert List in protos
     assert Function in protos
   end


### PR DESCRIPTION
How to reproduce:

This works:

```elixir
    iex> path = :code.lib_dir(:elixir, :ebin)
    iex> mods = Protocol.extract_impls(Enumerable, [path])
    iex> List in mods
    true
```

This does not work

```elixir
    iex> path = Application.app_dir(:elixir, "ebin")
    iex> mods = Protocol.extract_impls(Enumerable, [path])
    iex> List in mods
    false
```

However the spec says:

```elixir
iex(1)> h Protocol.extract_impls

                       def extract_impls(protocol, paths)

  @spec extract_impls(module(), [charlist() | String.t()]) :: [atom()]
```

And it accepts also a `String.t()`