### PR TITLE
Replace `mix xref warnings` with `mix xref deprecated` in Module docs

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -137,7 +137,7 @@ defmodule Module do
       end
 
   The Mix compiler automatically looks for calls to deprecated modules
-  and emit warnings during compilation, computed via `mix xref warnings`.
+  and emit warnings during compilation, computed via `mix xref deprecated`.
 
   Using the `@deprecated` attribute will also be reflected in the
   documentation of the given function and macro. You can choose between

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -137,7 +137,7 @@ defmodule Module do
       end
 
   The Mix compiler automatically looks for calls to deprecated modules
-  and emit warnings during compilation, computed via `mix xref deprecated`.
+  and emit warnings during compilation.
 
   Using the `@deprecated` attribute will also be reflected in the
   documentation of the given function and macro. You can choose between


### PR DESCRIPTION
As it apparantly was renamed in bb08b415d4852e8f7ae47ebe5421742ce611a6b6