### PR TITLE
Add `trace` logger level

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -48,6 +48,7 @@ defmodule Logger do
 
   The supported levels, ordered by precedence, are:
 
+    * `:trace` - for logging any messages, too verbose for other levels
     * `:debug` - for debug-related messages
     * `:info` - for information of any kind
     * `:warn` - for warnings
@@ -262,6 +263,8 @@ defmodule Logger do
     * `:enabled` - boolean value that allows for switching the
       coloring on and off. Defaults to: `IO.ANSI.enabled?/0`
 
+    * `:trace` - color for trace messages. Defaults to: `:green`
+
     * `:debug` - color for debug messages. Defaults to: `:cyan`
 
     * `:info` - color for info messages. Defaults to: `:normal`
@@ -439,9 +442,9 @@ defmodule Logger do
 
   @type backend :: :gen_event.handler()
   @type message :: IO.chardata() | String.Chars.t()
-  @type level :: :error | :info | :warn | :debug
+  @type level :: :error | :info | :warn | :debug | :trace
   @type metadata :: keyword()
-  @levels [:error, :info, :warn, :debug]
+  @levels [:error, :info, :warn, :debug, :trace]
 
   @metadata :logger_metadata
   @compile {:inline, __metadata__: 0}
@@ -799,6 +802,22 @@ defmodule Logger do
   end
 
   @doc """
+  Logs a trace message.
+
+  Returns `:ok` or an `{:error, reason}` tuple.
+
+  ## Examples
+
+      Logger.trace("hello?")
+      Logger.trace(fn -> "dynamically calculated trace" end)
+      Logger.trace(fn -> {"dynamically calculated trace", [additional: :metadata]} end)
+
+  """
+  defmacro trace(chardata_or_fun, metadata \\ []) do
+    maybe_log(:trace, chardata_or_fun, metadata, __CALLER__)
+  end
+
+  @doc """
   Logs a message with the given `level`.
 
   Returns `:ok` or an `{:error, reason}` tuple.
@@ -881,7 +900,7 @@ defmodule Logger do
 
         env_level
       else
-        :debug
+        :trace
       end
 
     if Logger.Config.compare_levels(level, min_level) != :lt do

--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -128,6 +128,7 @@ defmodule Logger.Backends.Console do
     colors = Keyword.get(config, :colors, [])
 
     %{
+      trace: Keyword.get(colors, :trace, :green),
       debug: Keyword.get(colors, :debug, :cyan),
       info: Keyword.get(colors, :info, :normal),
       warn: Keyword.get(colors, :warn, :yellow),

--- a/lib/logger/lib/logger/config.ex
+++ b/lib/logger/lib/logger/config.ex
@@ -35,10 +35,11 @@ defmodule Logger.Config do
     if level_to_number(left) > level_to_number(right), do: :gt, else: :lt
   end
 
-  defp level_to_number(:debug), do: 0
-  defp level_to_number(:info), do: 1
-  defp level_to_number(:warn), do: 2
-  defp level_to_number(:error), do: 3
+  defp level_to_number(:trace), do: 0
+  defp level_to_number(:debug), do: 1
+  defp level_to_number(:info), do: 2
+  defp level_to_number(:warn), do: 3
+  defp level_to_number(:error), do: 4
 
   def translation_data do
     read_data!(@data_key)

--- a/lib/logger/lib/logger/formatter.ex
+++ b/lib/logger/lib/logger/formatter.ex
@@ -173,6 +173,7 @@ defmodule Logger.Formatter do
 
   defp output(other, _, _, _, _), do: other
 
+  defp levelpad(:trace), do: ""
   defp levelpad(:debug), do: ""
   defp levelpad(:info), do: " "
   defp levelpad(:warn), do: " "

--- a/lib/logger/test/logger/backends/console_test.exs
+++ b/lib/logger/test/logger/backends/console_test.exs
@@ -145,6 +145,11 @@ defmodule Logger.Backends.ConsoleTest do
 
     assert capture_log(fn -> Logger.error("hello") end) ==
              IO.ANSI.cyan() <> "hello" <> IO.ANSI.reset()
+
+    Logger.configure_backend(:console, colors: [trace: :cyan])
+
+    assert capture_log(:trace, fn -> Logger.error("hello") end) ==
+             IO.ANSI.cyan() <> "hello" <> IO.ANSI.reset()
   end
 
   test "uses colors from metadata" do

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -162,25 +162,49 @@ defmodule LoggerTest do
   end
 
   test "compare_levels/2" do
+    assert Logger.compare_levels(:trace, :trace) == :eq
+    assert Logger.compare_levels(:trace, :debug) == :lt
+    assert Logger.compare_levels(:trace, :info) == :lt
+    assert Logger.compare_levels(:trace, :warn) == :lt
+    assert Logger.compare_levels(:trace, :error) == :lt
+
+    assert Logger.compare_levels(:debug, :trace) == :gt
     assert Logger.compare_levels(:debug, :debug) == :eq
     assert Logger.compare_levels(:debug, :info) == :lt
     assert Logger.compare_levels(:debug, :warn) == :lt
     assert Logger.compare_levels(:debug, :error) == :lt
 
+    assert Logger.compare_levels(:info, :trace) == :gt
     assert Logger.compare_levels(:info, :debug) == :gt
     assert Logger.compare_levels(:info, :info) == :eq
     assert Logger.compare_levels(:info, :warn) == :lt
     assert Logger.compare_levels(:info, :error) == :lt
 
+    assert Logger.compare_levels(:warn, :trace) == :gt
     assert Logger.compare_levels(:warn, :debug) == :gt
     assert Logger.compare_levels(:warn, :info) == :gt
     assert Logger.compare_levels(:warn, :warn) == :eq
     assert Logger.compare_levels(:warn, :error) == :lt
 
+    assert Logger.compare_levels(:error, :trace) == :gt
     assert Logger.compare_levels(:error, :debug) == :gt
     assert Logger.compare_levels(:error, :info) == :gt
     assert Logger.compare_levels(:error, :warn) == :gt
     assert Logger.compare_levels(:error, :error) == :eq
+  end
+
+  test "trace/2" do
+    assert capture_log(:trace, fn ->
+             assert Logger.trace("hello", []) == :ok
+           end) =~ msg_with_meta("[trace] hello")
+
+    assert capture_log(:info, fn ->
+             assert Logger.trace("hello", []) == :ok
+           end) == ""
+
+    assert capture_log(:info, fn ->
+             assert Logger.trace(raise("not invoked"), []) == :ok
+           end) == ""
   end
 
   test "debug/2" do


### PR DESCRIPTION
When working with Elixir logger, we actually had an issue with missing `trace` logging level.

As we can see, for example, in log4j, often used is logging level with even more verbosity than `debug` - `trace` [link](https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/Level.html#TRACE). It's pretty useful for fine-graning logging information, which would otherwise put a lot of junk into developer console. Adding it alleviates the issue of manually adding, and removing logging statement (which is tedious). 

Together with compile-level removal of logger statements, I think it may be a nice addition to Elixir Logger.

In conclusion: This PR adds `trace` logger level, for logging info too verbose for debug level (and not always wanted even in dev mode)