### PR TITLE
Warn on trailing commas in word list

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5198,17 +5198,15 @@ defmodule Kernel do
       true ->
         parts = String.split(string)
 
-        :lists.foreach(
-          fn part ->
-            if :binary.last(part) == ?, do
-              IO.warn(
-                "item \"#{part}\" in word list has a trailing comma; was this intentional?",
-                stacktrace
-              )
-            end
-          end,
-          parts
-        )
+        parts_with_trailing_comma = :lists.filter(&(:binary.last(&1) == ?,), parts)
+
+        if parts_with_trailing_comma != [] do
+          IO.warn(
+            "The sigils ~w/~W do not allow trailing commas at the end of each word. " <>
+              "If the comma is necessary, define a regular list with [...], otherwise remove the comma.",
+            stacktrace
+          )
+        end
 
         case mod do
           ?s -> parts

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5201,7 +5201,7 @@ defmodule Kernel do
           stacktrace = Macro.Env.stacktrace(caller)
 
           IO.warn(
-            "The sigils ~w/~W do not allow trailing commas at the end of each word. " <>
+            "the sigils ~w/~W do not allow trailing commas at the end of each word. " <>
               "If the comma is necessary, define a regular list with [...], otherwise remove the comma.",
             stacktrace
           )

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5220,20 +5220,6 @@ defmodule Kernel do
         parts =
           quote do
             parts = String.split(unquote(string))
-
-            :lists.foreach(
-              fn part ->
-                if :binary.last(part) == ?, do
-                  IO.warn(
-                    "item \"#{part}\" in word list has a trailing comma; was this intentional?",
-                    unquote(Macro.escape(stacktrace))
-                  )
-                end
-              end,
-              parts
-            )
-
-            parts
           end
 
         case mod do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5195,6 +5195,15 @@ defmodule Kernel do
       true ->
         parts = String.split(string)
 
+        :lists.foreach(
+          fn part ->
+            if :binary.last(part) == ?, do
+              IO.warn("item \"#{part}\" in word list has a trailing comma; was this intentional?")
+            end
+          end,
+          parts
+        )
+
         case mod do
           ?s -> parts
           ?a -> :lists.map(&String.to_atom/1, parts)
@@ -5202,7 +5211,23 @@ defmodule Kernel do
         end
 
       false ->
-        parts = quote(do: String.split(unquote(string)))
+        parts =
+          quote do
+            parts = String.split(unquote(string))
+
+            :lists.foreach(
+              fn part ->
+                if :binary.last(part) == ?, do
+                  IO.warn(
+                    "item \"#{part}\" in word list has a trailing comma; was this intentional?"
+                  )
+                end
+              end,
+              parts
+            )
+
+            parts
+          end
 
         case mod do
           ?s -> parts

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5215,10 +5215,7 @@ defmodule Kernel do
         end
 
       false ->
-        parts =
-          quote do
-            parts = String.split(unquote(string))
-          end
+        parts = quote(do: String.split(unquote(string)))
 
         case mod do
           ?s -> parts

--- a/lib/elixir/test/elixir/kernel/sigils_test.exs
+++ b/lib/elixir/test/elixir/kernel/sigils_test.exs
@@ -195,7 +195,7 @@ bar) in ["foo\\\nbar", "foo\\\r\nbar"]
              end
              """)
            end) =~
-             "item \"foo,\" in word list has a trailing comma; was this intentional?"
+             "The sigils ~w/~W do not allow trailing commas"
 
     assert capture_err(fn -> Kernel.SigilsTest.Runtime_ws.run() end) == ""
 
@@ -206,7 +206,7 @@ bar) in ["foo\\\nbar", "foo\\\r\nbar"]
              end
              """)
            end) =~
-             "item \"foo,\" in word list has a trailing comma; was this intentional?"
+             "The sigils ~w/~W do not allow trailing commas"
 
     assert capture_err(fn -> Kernel.SigilsTest.Runtime_wa.run() end) == ""
 
@@ -217,7 +217,7 @@ bar) in ["foo\\\nbar", "foo\\\r\nbar"]
              end
              """)
            end) =~
-             "item \"foo,\" in word list has a trailing comma; was this intentional?"
+             "The sigils ~w/~W do not allow trailing commas"
 
     assert capture_err(fn -> Kernel.SigilsTest.Runtime_wc.run() end) == ""
 
@@ -228,7 +228,7 @@ bar) in ["foo\\\nbar", "foo\\\r\nbar"]
              end
              """)
            end) =~
-             "item \"foo,\" in word list has a trailing comma; was this intentional?"
+             "The sigils ~w/~W do not allow trailing commas"
 
     assert capture_err(fn -> Kernel.SigilsTest.Runtime_Ws.run() end) == ""
 
@@ -239,7 +239,7 @@ bar) in ["foo\\\nbar", "foo\\\r\nbar"]
              end
              """)
            end) =~
-             "item \"foo,\" in word list has a trailing comma; was this intentional?"
+             "The sigils ~w/~W do not allow trailing commas"
 
     assert capture_err(fn -> Kernel.SigilsTest.Runtime_Wa.run() end) == ""
 
@@ -250,7 +250,7 @@ bar) in ["foo\\\nbar", "foo\\\r\nbar"]
              end
              """)
            end) =~
-             "item \"foo,\" in word list has a trailing comma; was this intentional?"
+             "The sigils ~w/~W do not allow trailing commas"
 
     assert capture_err(fn -> Kernel.SigilsTest.Runtime_Wc.run() end) == ""
   end
@@ -262,7 +262,7 @@ bar) in ["foo\\\nbar", "foo\\\r\nbar"]
              Kernel.SigilsTest.Macros.sigil_ws_macro()
              """)
            end) =~
-             "item \"foo,\" in word list has a trailing comma; was this intentional?"
+             "The sigils ~w/~W do not allow trailing commas"
 
     assert capture_err(fn ->
              Code.compile_string("""
@@ -270,7 +270,7 @@ bar) in ["foo\\\nbar", "foo\\\r\nbar"]
              Kernel.SigilsTest.Macros.sigil_wa_macro()
              """)
            end) =~
-             "item \"foo,\" in word list has a trailing comma; was this intentional?"
+             "The sigils ~w/~W do not allow trailing commas"
 
     assert capture_err(fn ->
              Code.compile_string("""
@@ -278,7 +278,7 @@ bar) in ["foo\\\nbar", "foo\\\r\nbar"]
              Kernel.SigilsTest.Macros.sigil_wc_macro()
              """)
            end) =~
-             "item \"foo,\" in word list has a trailing comma; was this intentional?"
+             "The sigils ~w/~W do not allow trailing commas"
 
     assert capture_err(fn ->
              Code.compile_string("""
@@ -286,7 +286,7 @@ bar) in ["foo\\\nbar", "foo\\\r\nbar"]
              Kernel.SigilsTest.Macros.sigil_Ws_macro()
              """)
            end) =~
-             "item \"bar,\" in word list has a trailing comma; was this intentional?"
+             "The sigils ~w/~W do not allow trailing commas"
 
     assert capture_err(fn ->
              Code.compile_string("""
@@ -294,7 +294,7 @@ bar) in ["foo\\\nbar", "foo\\\r\nbar"]
              Kernel.SigilsTest.Macros.sigil_Wa_macro()
              """)
            end) =~
-             "item \"bar,\" in word list has a trailing comma; was this intentional?"
+             "The sigils ~w/~W do not allow trailing commas"
 
     assert capture_err(fn ->
              Code.compile_string("""
@@ -302,7 +302,7 @@ bar) in ["foo\\\nbar", "foo\\\r\nbar"]
              Kernel.SigilsTest.Macros.sigil_Wc_macro()
              """)
            end) =~
-             "item \"bar,\" in word list has a trailing comma; was this intentional?"
+             "The sigils ~w/~W do not allow trailing commas"
   end
 
   test "sigils matching" do

--- a/lib/elixir/test/elixir/kernel/sigils_test.exs
+++ b/lib/elixir/test/elixir/kernel/sigils_test.exs
@@ -1,73 +1,7 @@
 Code.require_file("../test_helper.exs", __DIR__)
 
-defmodule Kernel.SigilsTest.Macros do
-  defmacro sigil_ws_macro do
-    quote do
-      ~w(foo, bar baz)s
-    end
-  end
-
-  defmacro sigil_Ws_macro do
-    quote do
-      ~W(foo bar, baz)s
-    end
-  end
-
-  defmacro sigil_wc_macro do
-    quote do
-      ~w(foo, bar baz)c
-    end
-  end
-
-  defmacro sigil_Wc_macro do
-    quote do
-      ~W(foo bar, baz)c
-    end
-  end
-
-  defmacro sigil_wa_macro do
-    quote do
-      ~w(foo, bar baz)a
-    end
-  end
-
-  defmacro sigil_Wa_macro do
-    quote do
-      ~W(foo bar, baz)a
-    end
-  end
-end
-
-defmodule Kernel.SigilsTest.Runtime_ws do
-  def run, do: :this_stub_will_be_replaced_below
-end
-
-defmodule Kernel.SigilsTest.Runtime_wa do
-  def run, do: :this_stub_will_be_replaced_below
-end
-
-defmodule Kernel.SigilsTest.Runtime_wc do
-  def run, do: :this_stub_will_be_replaced_below
-end
-
-defmodule Kernel.SigilsTest.Runtime_Ws do
-  def run, do: :this_stub_will_be_replaced_below
-end
-
-defmodule Kernel.SigilsTest.Runtime_Wa do
-  def run, do: :this_stub_will_be_replaced_below
-end
-
-defmodule Kernel.SigilsTest.Runtime_Wc do
-  def run, do: :this_stub_will_be_replaced_below
-end
-
 defmodule Kernel.SigilsTest do
   use ExUnit.Case, async: true
-
-  defp capture_err(fun) do
-    ExUnit.CaptureIO.capture_io(:stderr, fun)
-  end
 
   test "sigil s" do
     assert ~s(foo) == "foo"
@@ -185,31 +119,6 @@ bar) in ["foo\\\nbar", "foo\\\r\nbar"]
 
     assert ~W(Foo #{Bar})a == [:Foo, :"\#{Bar}"]
     assert ~W(Foo.Bar.Baz)a == [:"Foo.Bar.Baz"]
-  end
-
-  @compile {:no_warn_undefined, Kernel.SigilsTest.TrailingComma}
-
-  test "sigil w/W warns on trailing comma at compile time, not runtime" do
-    for sigil <- ~w(w W),
-        modifier <- ~w(a s c) do
-      assert capture_err(fn ->
-               Code.compile_string("""
-               defmodule Kernel.SigilsTest.TrailingComma do
-                 def run, do: ~#{sigil}(foo, bar baz)#{modifier}
-               end
-               """)
-             end) =~
-               "The sigils ~w/~W do not allow trailing commas"
-
-      assert capture_err(fn -> Kernel.SigilsTest.TrailingComma.run() end) == ""
-
-      purge(Kernel.SigilsTest.TrailingComma)
-    end
-  end
-
-  defp purge(module) do
-    :code.purge(module)
-    :code.delete(module)
   end
 
   test "sigils matching" do

--- a/lib/elixir/test/elixir/kernel/sigils_test.exs
+++ b/lib/elixir/test/elixir/kernel/sigils_test.exs
@@ -38,6 +38,30 @@ defmodule Kernel.SigilsTest.Macros do
   end
 end
 
+defmodule Kernel.SigilsTest.Runtime_ws do
+  def run, do: :this_stub_will_be_replaced_below
+end
+
+defmodule Kernel.SigilsTest.Runtime_wa do
+  def run, do: :this_stub_will_be_replaced_below
+end
+
+defmodule Kernel.SigilsTest.Runtime_wc do
+  def run, do: :this_stub_will_be_replaced_below
+end
+
+defmodule Kernel.SigilsTest.Runtime_Ws do
+  def run, do: :this_stub_will_be_replaced_below
+end
+
+defmodule Kernel.SigilsTest.Runtime_Wa do
+  def run, do: :this_stub_will_be_replaced_below
+end
+
+defmodule Kernel.SigilsTest.Runtime_Wc do
+  def run, do: :this_stub_will_be_replaced_below
+end
+
 defmodule Kernel.SigilsTest do
   use ExUnit.Case, async: true
 
@@ -163,24 +187,72 @@ bar) in ["foo\\\nbar", "foo\\\r\nbar"]
     assert ~W(Foo.Bar.Baz)a == [:"Foo.Bar.Baz"]
   end
 
-  test "sigil w/W warns on trailing comma" do
-    assert capture_err(fn -> Code.eval_string("~w(foo, bar baz)s") end) =~
+  test "sigil w/W warns on trailing comma at compile time, not runtime" do
+    assert capture_err(fn ->
+             Code.compile_string("""
+             defmodule Kernel.SigilsTest.Runtime_ws do
+               def run, do: ~w(foo, bar baz)s
+             end
+             """)
+           end) =~
              "item \"foo,\" in word list has a trailing comma; was this intentional?"
 
-    assert capture_err(fn -> Code.eval_string("~w(foo, bar baz)a") end) =~
+    assert capture_err(fn -> Kernel.SigilsTest.Runtime_ws.run() end) == ""
+
+    assert capture_err(fn ->
+             Code.compile_string("""
+             defmodule Kernel.SigilsTest.Runtime_wa do
+               def run, do: ~w(foo, bar baz)s
+             end
+             """)
+           end) =~
              "item \"foo,\" in word list has a trailing comma; was this intentional?"
 
-    assert capture_err(fn -> Code.eval_string("~w(foo, bar baz)c") end) =~
+    assert capture_err(fn -> Kernel.SigilsTest.Runtime_wa.run() end) == ""
+
+    assert capture_err(fn ->
+             Code.compile_string("""
+             defmodule Kernel.SigilsTest.Runtime_wc do
+               def run, do: ~w(foo, bar baz)s
+             end
+             """)
+           end) =~
              "item \"foo,\" in word list has a trailing comma; was this intentional?"
 
-    assert capture_err(fn -> Code.eval_string("~W(foo bar, baz)s") end) =~
-             "item \"bar,\" in word list has a trailing comma; was this intentional?"
+    assert capture_err(fn -> Kernel.SigilsTest.Runtime_wc.run() end) == ""
 
-    assert capture_err(fn -> Code.eval_string("~W(foo bar, baz)a") end) =~
-             "item \"bar,\" in word list has a trailing comma; was this intentional?"
+    assert capture_err(fn ->
+             Code.compile_string("""
+             defmodule Kernel.SigilsTest.Runtime_Ws do
+               def run, do: ~w(foo, bar baz)s
+             end
+             """)
+           end) =~
+             "item \"foo,\" in word list has a trailing comma; was this intentional?"
 
-    assert capture_err(fn -> Code.eval_string("~W(foo bar, baz)c") end) =~
-             "item \"bar,\" in word list has a trailing comma; was this intentional?"
+    assert capture_err(fn -> Kernel.SigilsTest.Runtime_Ws.run() end) == ""
+
+    assert capture_err(fn ->
+             Code.compile_string("""
+             defmodule Kernel.SigilsTest.Runtime_Wa do
+               def run, do: ~w(foo, bar baz)s
+             end
+             """)
+           end) =~
+             "item \"foo,\" in word list has a trailing comma; was this intentional?"
+
+    assert capture_err(fn -> Kernel.SigilsTest.Runtime_Wa.run() end) == ""
+
+    assert capture_err(fn ->
+             Code.compile_string("""
+             defmodule Kernel.SigilsTest.Runtime_Wc do
+               def run, do: ~w(foo, bar baz)s
+             end
+             """)
+           end) =~
+             "item \"foo,\" in word list has a trailing comma; was this intentional?"
+
+    assert capture_err(fn -> Kernel.SigilsTest.Runtime_Wc.run() end) == ""
   end
 
   test "sigil w/W warns on trailing comma inside macro" do

--- a/lib/elixir/test/elixir/kernel/sigils_test.exs
+++ b/lib/elixir/test/elixir/kernel/sigils_test.exs
@@ -212,56 +212,6 @@ bar) in ["foo\\\nbar", "foo\\\r\nbar"]
     :code.delete(module)
   end
 
-  test "sigil w/W warns on trailing comma inside macro" do
-    assert capture_err(fn ->
-             Code.compile_string("""
-             require Kernel.SigilsTest.Macros
-             Kernel.SigilsTest.Macros.sigil_ws_macro()
-             """)
-           end) =~
-             "The sigils ~w/~W do not allow trailing commas"
-
-    assert capture_err(fn ->
-             Code.compile_string("""
-             require Kernel.SigilsTest.Macros
-             Kernel.SigilsTest.Macros.sigil_wa_macro()
-             """)
-           end) =~
-             "The sigils ~w/~W do not allow trailing commas"
-
-    assert capture_err(fn ->
-             Code.compile_string("""
-             require Kernel.SigilsTest.Macros
-             Kernel.SigilsTest.Macros.sigil_wc_macro()
-             """)
-           end) =~
-             "The sigils ~w/~W do not allow trailing commas"
-
-    assert capture_err(fn ->
-             Code.compile_string("""
-             require Kernel.SigilsTest.Macros
-             Kernel.SigilsTest.Macros.sigil_Ws_macro()
-             """)
-           end) =~
-             "The sigils ~w/~W do not allow trailing commas"
-
-    assert capture_err(fn ->
-             Code.compile_string("""
-             require Kernel.SigilsTest.Macros
-             Kernel.SigilsTest.Macros.sigil_Wa_macro()
-             """)
-           end) =~
-             "The sigils ~w/~W do not allow trailing commas"
-
-    assert capture_err(fn ->
-             Code.compile_string("""
-             require Kernel.SigilsTest.Macros
-             Kernel.SigilsTest.Macros.sigil_Wc_macro()
-             """)
-           end) =~
-             "The sigils ~w/~W do not allow trailing commas"
-  end
-
   test "sigils matching" do
     assert ~s(f\(oo) == "f(oo"
     assert ~s(fo\)o) == "fo)o"

--- a/lib/elixir/test/elixir/kernel/sigils_test.exs
+++ b/lib/elixir/test/elixir/kernel/sigils_test.exs
@@ -187,72 +187,29 @@ bar) in ["foo\\\nbar", "foo\\\r\nbar"]
     assert ~W(Foo.Bar.Baz)a == [:"Foo.Bar.Baz"]
   end
 
+  @compile {:no_warn_undefined, Kernel.SigilsTest.TrailingComma}
+
   test "sigil w/W warns on trailing comma at compile time, not runtime" do
-    assert capture_err(fn ->
-             Code.compile_string("""
-             defmodule Kernel.SigilsTest.Runtime_ws do
-               def run, do: ~w(foo, bar baz)s
-             end
-             """)
-           end) =~
-             "The sigils ~w/~W do not allow trailing commas"
+    for sigil <- ~w(w W),
+        modifier <- ~w(a s c) do
+      assert capture_err(fn ->
+               Code.compile_string("""
+               defmodule Kernel.SigilsTest.TrailingComma do
+                 def run, do: ~#{sigil}(foo, bar baz)#{modifier}
+               end
+               """)
+             end) =~
+               "The sigils ~w/~W do not allow trailing commas"
 
-    assert capture_err(fn -> Kernel.SigilsTest.Runtime_ws.run() end) == ""
+      assert capture_err(fn -> Kernel.SigilsTest.TrailingComma.run() end) == ""
 
-    assert capture_err(fn ->
-             Code.compile_string("""
-             defmodule Kernel.SigilsTest.Runtime_wa do
-               def run, do: ~w(foo, bar baz)s
-             end
-             """)
-           end) =~
-             "The sigils ~w/~W do not allow trailing commas"
+      purge(Kernel.SigilsTest.TrailingComma)
+    end
+  end
 
-    assert capture_err(fn -> Kernel.SigilsTest.Runtime_wa.run() end) == ""
-
-    assert capture_err(fn ->
-             Code.compile_string("""
-             defmodule Kernel.SigilsTest.Runtime_wc do
-               def run, do: ~w(foo, bar baz)s
-             end
-             """)
-           end) =~
-             "The sigils ~w/~W do not allow trailing commas"
-
-    assert capture_err(fn -> Kernel.SigilsTest.Runtime_wc.run() end) == ""
-
-    assert capture_err(fn ->
-             Code.compile_string("""
-             defmodule Kernel.SigilsTest.Runtime_Ws do
-               def run, do: ~w(foo, bar baz)s
-             end
-             """)
-           end) =~
-             "The sigils ~w/~W do not allow trailing commas"
-
-    assert capture_err(fn -> Kernel.SigilsTest.Runtime_Ws.run() end) == ""
-
-    assert capture_err(fn ->
-             Code.compile_string("""
-             defmodule Kernel.SigilsTest.Runtime_Wa do
-               def run, do: ~w(foo, bar baz)s
-             end
-             """)
-           end) =~
-             "The sigils ~w/~W do not allow trailing commas"
-
-    assert capture_err(fn -> Kernel.SigilsTest.Runtime_Wa.run() end) == ""
-
-    assert capture_err(fn ->
-             Code.compile_string("""
-             defmodule Kernel.SigilsTest.Runtime_Wc do
-               def run, do: ~w(foo, bar baz)s
-             end
-             """)
-           end) =~
-             "The sigils ~w/~W do not allow trailing commas"
-
-    assert capture_err(fn -> Kernel.SigilsTest.Runtime_Wc.run() end) == ""
+  defp purge(module) do
+    :code.purge(module)
+    :code.delete(module)
   end
 
   test "sigil w/W warns on trailing comma inside macro" do

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1754,6 +1754,28 @@ defmodule Kernel.WarningTest do
     purge([Sample])
   end
 
+  @compile {:no_warn_undefined, Kernel.WarningTest.WSigilTrailingComma}
+
+  test "sigil w/W warns on trailing comma at compile time, not runtime" do
+    for sigil <- ~w(w W),
+        modifier <- ~w(a s c) do
+      output =
+        capture_err(fn ->
+          Code.compile_string("""
+          defmodule Kernel.WarningTest.WSigilTrailingComma do
+            def run, do: ~#{sigil}(foo, bar baz)#{modifier}
+          end
+          """)
+        end)
+
+      assert output =~ "The sigils ~w/~W do not allow trailing commas"
+
+      assert capture_err(fn -> Kernel.WarningTest.WSigilTrailingComma.run() end) == ""
+
+      purge(Kernel.WarningTest.WSigilTrailingComma)
+    end
+  end
+
   defp purge(list) when is_list(list) do
     Enum.each(list, &purge/1)
   end

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1766,7 +1766,7 @@ defmodule Kernel.WarningTest do
           Macro.expand(ast, __ENV__)
         end)
 
-      assert output =~ "The sigils ~w/~W do not allow trailing commas"
+      assert output =~ "the sigils ~w/~W do not allow trailing commas"
     end
   end
 


### PR DESCRIPTION
When creating word lists (e.g., `~w(foo bar baz)`), it is a common mistake to insert trailing commas for some or all parts of the list (e.g., `~w(foo, bar, baz)`).  This PR introduces a warning when such trailing commas are encountered, in macros and regular code:

```
iex> ~w(hello, world)
warning: item "hello," in word list has a trailing comma; was this intentional?
  iex:1: (file)

["hello,", "world"]
```