### PR TITLE
Improve behaviour documentation

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -56,6 +56,9 @@ defmodule Module do
   If the behaviour changes or `URI.HTTP` does not implement
   one of the callbacks, a warning will be raised.
 
+  For detailed documentation, see the
+  [behaviour typespec documentation](typespecs.html#behaviours).
+
   ### `@impl`
 
   To aid in the correct implementation of behaviours, you may optionally declare

--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -262,7 +262,7 @@ Elixir's standard library contains a few frequently used behaviours such as `Gen
 
 The `@callback` and `@optional_callback` attributes are used to create a `behaviour_info/1` function available on the defining module. This function can be used to retrieve the callbacks and optional callbacks defined by that module.
 
-For example, for the `MyBehaviour` module defined in `Optional callbacks` above:
+For example, for the `MyBehaviour` module defined in "Optional callbacks" above:
 
     MyBehaviour.behaviour_info(:callbacks)
     #=> [vital_fun: 0, "MACRO-non_vital_macro": 2, non_vital_fun: 0]

--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -264,10 +264,10 @@ The `@callback` and `@optional_callback` attributes are used to create a `behavi
 
 For example, for the `MyBehaviour` module defined in `Optional callbacks` above:
 
-    > MyBehaviour.behaviour_info(:callbacks)
-    [vital_fun: 0, "MACRO-non_vital_macro": 2, non_vital_fun: 0]
-    > MyBehaviour.behaviour_info(:optional_callbacks)
-    ["MACRO-non_vital_macro": 2, non_vital_fun: 0]
+    MyBehaviour.behaviour_info(:callbacks)
+    #=> [vital_fun: 0, "MACRO-non_vital_macro": 2, non_vital_fun: 0]
+    MyBehaviour.behaviour_info(:optional_callbacks)
+    #=> ["MACRO-non_vital_macro": 2, non_vital_fun: 0]
 
 When using `iex`, the `IEx.Helpers.b/1` helper is also available.
 

--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -258,6 +258,19 @@ If a callback module that implements a given behaviour doesn't export all the fu
 
 Elixir's standard library contains a few frequently used behaviours such as `GenServer`, `Supervisor`, and `Application`.
 
+### Inspecting behaviours
+
+The `@callback` and `@optional_callback` attributes are used to create a `behaviour_info/1` function available on the defining module. This function can be used to retrieve the callbacks and optional callbacks defined by that module.
+
+For example, for the `MyBehaviour` module defined in `Optional callbacks` above:
+
+    > MyBehaviour.behaviour_info(:callbacks)
+    [vital_fun: 0, "MACRO-non_vital_macro": 2, non_vital_fun: 0]
+    > MyBehaviour.behaviour_info(:optional_callbacks)
+    ["MACRO-non_vital_macro": 2, non_vital_fun: 0]
+
+When using `iex`, the `IEx.Helpers.b/1` helper is also available.
+
 ## The `string()` type
 
 Elixir discourages the use of the `string()` type. The `string()` type refers to Erlang strings, which are known as "charlists" in Elixir. They do not refer to Elixir strings, which are UTF-8 encoded binaries. To avoid confusion, if you attempt to use the type `string()`, Elixir will emit a warning. You should use `charlist()`, `nonempty_charlist()`, `binary()` or `String.t()` accordingly, or any of the several literal representations for these types.


### PR DESCRIPTION
I was doing some work with behaviours and found the documentation about how to inspect a behaviour a little lacking (resulting in me asking [this SO question](https://stackoverflow.com/questions/57653216/elixir-testing-ensure-a-module-defines-a-callback)), so I've added some information to the Typespec docs, and also linked there from the behaviour section of `Module` docs.

* Add a link from `Module` to the relevant section of the Typespec docs.
* Add an `Inspecting behviours` section to the Typespec docs that
  documents how to inspect the behaviours. This information is so far
  only available in the deprecated `Behaviour` module or the Erlang docs.