### PR TITLE
DynamicSupervisor.handle_child_restart/2 callback.

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -555,11 +555,7 @@ defmodule DynamicSupervisor do
             is_tuple(name) -> name
           end
 
-        state = %DynamicSupervisor{
-          mod: mod,
-          args: init_arg,
-          name: name
-        }
+        state = %DynamicSupervisor{mod: mod, args: init_arg, name: name}
 
         case init(state, flags) do
           {:ok, state} -> {:ok, state}

--- a/lib/elixir/lib/supervisor/default.ex
+++ b/lib/elixir/lib/supervisor/default.ex
@@ -4,4 +4,6 @@ defmodule Supervisor.Default do
   def init(args) do
     args
   end
+
+  def handle_child_restart(_old_pid, _new_pid), do: :ok
 end

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -483,4 +483,8 @@ defmodule Task.Supervisor do
       end
     end)
   end
+
+  @impl true
+  @doc false
+  def handle_child_restart(_old_pid, _new_pid), do: :ok
 end


### PR DESCRIPTION
**Intent** under some circumstances we might need to send messages to the processes supervised by `DynamicSupervisor`. That is possible while the child started with `DynamicSupervisor.start_child/2` is alive (since `start_child/2` returns PID back.) Once it crashes, the `DynamicSupervisor` restarts it. The PID changes and our code loses track of that process forever.

We cannot simply name all the children because the name must be an atom and if there are many short-lived processes, we risk to DoS attack the VM with atoms.

To make it easier to manage I would like to introduce `DynamicSupervisor.handle_child_restart/2` overridable callback. The default implementation would be noop, but module-based `DynamicSupervisor`s might override it to receive `old_pid` and `new_pid` to update the application-specific internal mapping and keep the ability to send messages to the processes supervised by `DynamicSupervisor`.

**Caveats** I was forced to update both `Supervisor.Default` and `Task.Supervisor` to implement noop callback, because they do not `use DynamicSupervisor`. I frankly don’t think it’s crucial.

What is worse, all the custom implementations of `DynamicSupervisor` behaviour might get broken. That might be handled by an explicit check whether the callback implementation is indeed defined from `maybe_callback_child_restart/3`, but this would slow it down a bit.

Thoughts?