### PR TITLE
Clarification in documentation for Enum.chunk_while/4

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -471,7 +471,7 @@ defmodule Enum do
   Chunks the `enumerable` with fine grained control when every chunk is emitted.
 
   `chunk_fun` receives the current element and the accumulator and
-  must return `{:cont, element, acc}` to emit the given chunk and
+  must return `{:cont, chunk, acc}` to emit the given chunk and
   continue with accumulator or `{:cont, acc}` to not emit any chunk
   and continue with the return accumulator.
 


### PR DESCRIPTION
**What**
Small update to documentation for `Enum.chunk_while/4`.

**Why**
When using `Enum.chunk_while` for the first time, this portion of the documentation confused me and I ended up returning individual elements in my `chunk_fun` instead of the whole chunk of data.