### PR TITLE
Add GitHub actions workflow to send CI emails

### DIFF
--- a/.github/workflows/ci_email.yml
+++ b/.github/workflows/ci_email.yml
@@ -1,0 +1,16 @@
+on: check_suite
+name: CI email
+jobs:
+  sendEmail:
+    name: Send email
+    runs-on: ubuntu-latest
+    steps:
+    - name: Send email
+      uses: docker://fertapric/elixir-ci-email:latest
+      env:
+        APP_NAME: Cirrus CI
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MAIL_FROM: ci@elixir-lang.org
+        MAIL_HOST: smtp.sendgrid.net
+        MAIL_PASSWORD: ${{ secrets.CI_EMAIL_PASSWORD }}
+        MAIL_USERNAME: ${{ secrets.CI_EMAIL_USERNAME }}

--- a/.github/workflows/ci_email.yml
+++ b/.github/workflows/ci_email.yml
@@ -6,6 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Send email
+      # Source: https://github.com/elixir-lang/elixir-ci
       uses: docker://fertapric/elixir-ci-email:latest
       env:
         APP_NAME: Cirrus CI


### PR DESCRIPTION
This is the configuration to send an email whenever the Cirrus CI checks fail. The email is delivered to the author and committer of the commit, which should cover the cases of merging PRs, edits from GitHub UI, and so on.

We need to upgrade the Elixir repository to the new GitHub actions:

<img width="938" alt="Screen Shot 2019-09-06 at 15 56 30" src="https://user-images.githubusercontent.com/651203/64433537-f8ea9e80-d0be-11e9-8b21-6a30191935f5.png">

and configure the secrets `CI_EMAIL_USERNAME` and `CI_EMAIL_PASSWORD` under `Settings > Secrets`.
