### PR TITLE
Registration of ErlangHandler spec mismatch

### DIFF
--- a/lib/logger/lib/logger/app.ex
+++ b/lib/logger/lib/logger/app.ex
@@ -95,7 +95,7 @@ defmodule Logger.App do
   end
 
   defp add_elixir_handler(sasl_reports?) do
-    config = %{level: :debug, sasl_reports?: sasl_reports?}
+    config = %{level: :debug, config: %{sasl_reports?: sasl_reports?}}
     :logger.add_handler(Logger, Logger.ErlangHandler, config)
   end
 

--- a/lib/logger/lib/logger/erlang_handler.ex
+++ b/lib/logger/lib/logger/erlang_handler.ex
@@ -4,11 +4,12 @@ defmodule Logger.ErlangHandler do
   @doc """
   Hook required by `:logger`.
   """
-  def log(%{meta: %{domain: [:otp, :sasl | _]}}, %{sasl_reports?: false}) do
+  @spec log(:logger.log_event(), :logger.handler_config()) :: any()
+  def log(%{meta: %{domain: [:otp, :sasl | _]}}, %{config: %{sasl_reports?: false}}) do
     :ok
   end
 
-  def log(%{meta: %{domain: [:supervisor_report]}}, %{sasl_reports?: false}) do
+  def log(%{meta: %{domain: [:supervisor_report]}}, %{config: %{sasl_reports?: false}}) do
     :ok
   end
 


### PR DESCRIPTION
The Dialyzer was issuing a warining on `logger:add_handler/3` call as
the key `sasl_reports?` should not be in root map but rather within
`config` key of the map.