### PR TITLE
Ensure project's Logger config is used when running Mix tasks

### DIFF
--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -76,6 +76,8 @@ defmodule Mix.CLI do
     try do
       ensure_no_slashes(name)
       Mix.Task.run("loadconfig")
+      # Restart Logger so it uses the configuration of the project.
+      restart_logger()
       Mix.Task.run(name, args)
     rescue
       # We only rescue exceptions in the Mix namespace, all
@@ -88,6 +90,13 @@ defmodule Mix.CLI do
         else
           reraise exception, __STACKTRACE__
         end
+    end
+  end
+
+  defp restart_logger do
+    if Process.whereis(Logger) do
+      Logger.App.stop()
+      :ok = Logger.App.start()
     end
   end
 

--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -96,7 +96,7 @@ defmodule Mix.CLI do
   end
 
   defp logger_configured? do
-    Enum.member?(Mix.ProjectStack.config_apps(), :logger)
+    :logger in Mix.ProjectStack.config_apps()
   end
 
   defp restart_logger do

--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -1,6 +1,8 @@
 defmodule Mix.CLI do
   @moduledoc false
 
+  @compile {:no_warn_undefined, Logger.App}
+
   @doc """
   Runs Mix according to the command line arguments.
   """
@@ -77,7 +79,7 @@ defmodule Mix.CLI do
       ensure_no_slashes(name)
       Mix.Task.run("loadconfig")
       # Restart Logger so it uses the configuration of the project.
-      restart_logger()
+      if logger_configured?(), do: restart_logger()
       Mix.Task.run(name, args)
     rescue
       # We only rescue exceptions in the Mix namespace, all
@@ -91,6 +93,10 @@ defmodule Mix.CLI do
           reraise exception, __STACKTRACE__
         end
     end
+  end
+
+  defp logger_configured? do
+    Enum.member?(Mix.ProjectStack.config_apps(), :logger)
   end
 
   defp restart_logger do

--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -79,7 +79,7 @@ defmodule Mix.CLI do
       ensure_no_slashes(name)
       Mix.Task.run("loadconfig")
       # Restart Logger so it uses the configuration of the project.
-      restart_logger()
+      if logger_configured?(), do: restart_logger()
       Mix.Task.run(name, args)
     rescue
       # We only rescue exceptions in the Mix namespace, all
@@ -93,6 +93,10 @@ defmodule Mix.CLI do
           reraise exception, __STACKTRACE__
         end
     end
+  end
+
+  defp logger_configured? do
+    :logger in Mix.ProjectStack.config_apps()
   end
 
   defp restart_logger do

--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -94,6 +94,7 @@ defmodule Mix.CLI do
   end
 
   defp restart_logger do
+    # Mix should not depend directly on Logger, that's why we first check if it's loaded.
     if Process.whereis(Logger) do
       Logger.App.stop()
       :ok = Logger.App.start()

--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -79,7 +79,7 @@ defmodule Mix.CLI do
       ensure_no_slashes(name)
       Mix.Task.run("loadconfig")
       # Restart Logger so it uses the configuration of the project.
-      if logger_configured?(), do: restart_logger()
+      restart_logger()
       Mix.Task.run(name, args)
     rescue
       # We only rescue exceptions in the Mix namespace, all
@@ -93,10 +93,6 @@ defmodule Mix.CLI do
           reraise exception, __STACKTRACE__
         end
     end
-  end
-
-  defp logger_configured? do
-    :logger in Mix.ProjectStack.config_apps()
   end
 
   defp restart_logger do

--- a/lib/mix/lib/mix/tasks/app.start.ex
+++ b/lib/mix/lib/mix/tasks/app.start.ex
@@ -188,21 +188,20 @@ defmodule Mix.Tasks.App.Start do
 
   defp logger_dependency?([app | apps], checked_apps) do
     deps =
-      List.wrap(Application.spec(app, :applications)) ++
-        List.wrap(Application.spec(app, :included_applications))
+      List.wrap(Application.spec(app, :included_applications)) ++
+        List.wrap(Application.spec(app, :applications))
 
-    case deps do
-      [] ->
+    cond do
+      deps == [] ->
         logger_dependency?(apps, [app | checked_apps])
 
-      _ ->
-        if :logger in deps do
-          true
-        else
-          checked_apps = [app | checked_apps]
-          new_apps = (deps -- apps) -- checked_apps
-          logger_dependency?(apps ++ new_apps, checked_apps)
-        end
+      :logger in deps ->
+        true
+
+      true ->
+        checked_apps = [app | checked_apps]
+        new_apps = (deps -- apps) -- checked_apps
+        logger_dependency?(apps ++ new_apps, checked_apps)
     end
   end
 

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -67,6 +67,45 @@ defmodule Mix.CLITest do
     end)
   end
 
+  test "runs the task using the Logger configuration of the project", context do
+    in_tmp(context.test, fn ->
+      File.mkdir_p!("lib")
+
+      File.write!("mix.exs", """
+      defmodule MyProject do
+        use Mix.Project
+
+        def project do
+          [app: :my_project, version: "0.0.1"]
+        end
+      end
+      """)
+
+      File.mkdir_p!("config")
+
+      File.write!("config/config.exs", """
+      import Config
+
+      config :logger, :console, format: "TEST[$level] $message\n"
+      """)
+
+      File.write!("lib/hello.ex", """
+      defmodule Mix.Tasks.LogHello do
+        use Mix.Task
+
+        require Logger
+
+        def run(_) do
+          Logger.info("HELLO")
+        end
+      end
+      """)
+
+      contents = mix(~w[log_hello])
+      assert contents =~ "TEST[info] HELLO\n"
+    end)
+  end
+
   test "no task error", context do
     in_tmp(context.test, fn ->
       contents = mix(~w[no_task])

--- a/lib/mix/test/mix/tasks/app.start_test.exs
+++ b/lib/mix/test/mix/tasks/app.start_test.exs
@@ -104,8 +104,8 @@ defmodule Mix.Tasks.App.StartTest do
     end)
   end
 
-  test "start does nothing if app is nil" do
-    assert Mix.Tasks.App.Start.start([app: nil], []) == :ok
+  test "start does nothing if no apps are given" do
+    assert Mix.Tasks.App.Start.start([], :temporary) == :ok
   end
 
   test "allows type to be configured" do
@@ -144,7 +144,7 @@ defmodule Mix.Tasks.App.StartTest do
           "returned an error: :bye"
 
       assert_raise Mix.Error, message, fn ->
-        Mix.Tasks.App.Start.start([app: :return_sample], [])
+        Mix.Tasks.App.Start.start([:return_sample], :temporary)
       end
     end)
   end
@@ -165,7 +165,7 @@ defmodule Mix.Tasks.App.StartTest do
           "        Mix.Tasks.App.StartTest.ReturnApp.start/2"
 
       assert_raise Mix.Error, message, fn ->
-        Mix.Tasks.App.Start.start([app: :return_sample], [])
+        Mix.Tasks.App.Start.start([:return_sample], :temporary)
       end
     end)
   end
@@ -183,7 +183,7 @@ defmodule Mix.Tasks.App.StartTest do
           "returned a bad value: :bad"
 
       assert_raise Mix.Error, message, fn ->
-        Mix.Tasks.App.Start.start([app: :return_sample], [])
+        Mix.Tasks.App.Start.start([:return_sample], :temporary)
       end
     end)
   end
@@ -216,7 +216,7 @@ defmodule Mix.Tasks.App.StartTest do
           "Mix.Tasks.App.StartTest.ExitApp.start(:normal, :bye)\n" <> "    ** (EXIT) :bye"
 
       assert_raise Mix.Error, message, fn ->
-        Mix.Tasks.App.Start.start([app: :exit_sample], [])
+        Mix.Tasks.App.Start.start([:exit_sample], :temporary)
       end
     end)
   end
@@ -233,7 +233,7 @@ defmodule Mix.Tasks.App.StartTest do
           "Mix.Tasks.App.StartTest.ExitApp.start(:normal, :normal)\n" <> "    ** (EXIT) normal"
 
       assert_raise Mix.Error, message, fn ->
-        Mix.Tasks.App.Start.start([app: :exit_sample], [])
+        Mix.Tasks.App.Start.start([:exit_sample], :temporary)
       end
     end)
   end


### PR DESCRIPTION
Part of the configuration of the Logger can be changed dynamically but other part is only used at start. For example, the `:console` backend is implemented with `gen_event`, and its configuration is only read on `init` to build the state.

Logger is first started by Elixir using its default configuration, but the project's configuration is not used fully until the Logger application is restarted. This usually happens when the application is started, but not all Mix tasks do such thing.

This commit ensures that Logger is restarted before calling any Mix task.