### PR TITLE
Use cat to create runtime configuration more reliably

### DIFF
--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -134,7 +134,7 @@ defmodule Mix.Tasks.Release.Init do
       if grep -q "RUNTIME_CONFIG=true" "$REL_VSN_DIR/sys.config"; then
         RELEASE_SYS_CONFIG="$RELEASE_TMP/$RELEASE_NAME-$RELEASE_VSN-$(date +%Y%m%d%H%M%S)-$(rand).runtime"
 
-        (mkdir -p "$RELEASE_TMP" && cp "$REL_VSN_DIR/sys.config" "$RELEASE_SYS_CONFIG.config" && chmod +w "$RELEASE_SYS_CONFIG.config") || (
+        (mkdir -p "$RELEASE_TMP" && cat "$REL_VSN_DIR/sys.config" >"$RELEASE_SYS_CONFIG.config") || (
           echo "ERROR: Cannot start release because it could not write $RELEASE_SYS_CONFIG.config" >&2
           exit 1
         )


### PR DESCRIPTION
As a follow up from #9339, this uses `cat` instead of `cp` to make sure that no peculiar permissions or symlink dereferencing happen with the resulting configuration file, and it is created with default current user permissions.