### PR TITLE
Fixed guard typespec in Registry

### DIFF
--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -198,7 +198,7 @@ defmodule Registry do
   @type match_pattern :: atom | term
 
   @typedoc "A guard to be evaluated when matching on objects in a registry"
-  @type guard :: {atom | term}
+  @type guard :: atom | tuple
 
   @typedoc "A list of guards to be evaluated when matching on objects in a registry"
   @type guards :: [guard] | []


### PR DESCRIPTION
The guard typespec was a one-tuple of atom or term, which is
incorrect. It's either an atom or a tuple.