### PR TITLE
Simplify t:Registry.guards/0

### DIFF
--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -201,7 +201,7 @@ defmodule Registry do
   @type guard :: atom | tuple
 
   @typedoc "A list of guards to be evaluated when matching on objects in a registry"
-  @type guards :: [guard] | []
+  @type guards :: [guard]
 
   @typedoc "A pattern used to representing the output format part of a match spec"
   @type body :: [atom | tuple]


### PR DESCRIPTION
The first commit removes the redundant use of `[]` in the `guards/0` typespec.
~The second commit removes the unnecessary typespec `guard/0`, since we can do away as we do with the `body/0` and the others.~