### PR TITLE
Always adding :debug_info on erlc_options

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -978,7 +978,7 @@ defmodule Code do
 
     * `:debug_info` - when `true`, retain debug information in the compiled
       module. This allows a developer to reconstruct the original source
-      code. Defaults to `false`.
+      code. Defaults to `true`.
 
     * `:ignore_module_conflict` - when `true`, override modules that were
       already defined without raising errors. Defaults to `false`.

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -729,7 +729,7 @@ defmodule Mix.Project do
       elixirc_paths: ["lib"],
       erlc_paths: ["src"],
       erlc_include_path: "include",
-      erlc_options: [:debug_info],
+      erlc_options: [],
       lockfile: "mix.lock",
       preferred_cli_env: [],
       start_permanent: false

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -74,7 +74,7 @@ defmodule Mix.Tasks.Compile.Erlang do
       Mix.raise(":erlc_options should be a list of options, got: #{inspect(erlc_options)}")
     end
 
-    erlc_options = erlc_options ++ [:return, :report, outdir: compile_path, i: include_path]
+    erlc_options = erlc_options ++ [:debug_info, :return, :report, outdir: compile_path, i: include_path]
 
     erlc_options =
       Enum.map(erlc_options, fn

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -74,7 +74,8 @@ defmodule Mix.Tasks.Compile.Erlang do
       Mix.raise(":erlc_options should be a list of options, got: #{inspect(erlc_options)}")
     end
 
-    erlc_options = erlc_options ++ [:debug_info, :return, :report, outdir: compile_path, i: include_path]
+    erlc_options =
+      erlc_options ++ [:debug_info, :return, :report, outdir: compile_path, i: include_path]
 
     erlc_options =
       Enum.map(erlc_options, fn

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -41,14 +41,19 @@ defmodule Mix.Tasks.Compile.Erlang do
       Defaults to `"include"`.
 
     * `:erlc_options` - compilation options that apply to Erlang's
-      compiler. Defaults to `[:debug_info]`.
+      compiler. Defaults to `[]`.
 
       For a complete list of options, see `:compile.file/2`.
 
-  For example, to configure the `erlc_options` for your Erlang project you
-  may run:
+  ### Important notice
 
-      erlc_options: [:debug_info, {:i, 'path/to/include'}]
+  The following options are always added to `:erlc_options` when running the compiler:
+
+      [:debug_info, :return, :report, outdir: compile_path, i: include_path]
+
+  You can set any of those options like this to override them:
+
+      erlc_options: [debug_info: false, return: false, i: my_includes]
 
   """
 

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -45,15 +45,10 @@ defmodule Mix.Tasks.Compile.Erlang do
 
       For a complete list of options, see `:compile.file/2`.
 
-  ### Important notice
+      The option `:debug_info` is always added to the end of it. You can
+      disable that using:
 
-  The following options are always added to `:erlc_options` when running the compiler:
-
-      [:debug_info, :return, :report, outdir: compile_path, i: include_path]
-
-  You can set any of those options like this to override them:
-
-      erlc_options: [debug_info: false, return: false, i: my_includes]
+          erlc_options: [debug_info: false]
 
   """
 

--- a/lib/mix/test/mix/tasks/compile.erlang_test.exs
+++ b/lib/mix/test/mix/tasks/compile.erlang_test.exs
@@ -185,7 +185,7 @@ defmodule Mix.Tasks.Compile.ErlangTest do
       {:ok, {module, [debug_info: {:debug_info_v1, backend, data}]}} =
         :beam_lib.chunks(binary, [:debug_info])
 
-      assert backend.debug_info(:elixir_v1, module, data, []) != {:error, :missing}
+      assert backend.debug_info(:erlang_v1, module, data, []) != {:error, :missing}
     end)
   end
 end

--- a/lib/mix/test/mix/tasks/compile.erlang_test.exs
+++ b/lib/mix/test/mix/tasks/compile.erlang_test.exs
@@ -182,10 +182,10 @@ defmodule Mix.Tasks.Compile.ErlangTest do
 
       binary = File.read!("_build/dev/lib/sample/ebin/b.beam")
 
-      {:ok, {module, [debug_info: {:debug_info_v1, backend, data}]}} =
+      {:ok, {_, [debug_info: {:debug_info_v1, _, {debug_info, _}}]}} =
         :beam_lib.chunks(binary, [:debug_info])
 
-      assert backend.debug_info(:erlang_v1, module, data, []) != {:error, :missing}
+      assert debug_info != :none
     end)
   end
 end

--- a/lib/mix/test/mix/tasks/compile.erlang_test.exs
+++ b/lib/mix/test/mix/tasks/compile.erlang_test.exs
@@ -174,4 +174,18 @@ defmodule Mix.Tasks.Compile.ErlangTest do
       assert output == ""
     end)
   end
+
+  @tag erlc_options: [{:warnings_as_errors, true}]
+  test "adds :debug_info to erlc_options by default" do
+    in_fixture("compile_erlang", fn ->
+      Mix.Tasks.Compile.Erlang.run([])
+
+      binary = File.read!("_build/dev/lib/sample/ebin/b.beam")
+
+      {:ok, {module, [debug_info: {:debug_info_v1, backend, data}]}} =
+        :beam_lib.chunks(binary, [:debug_info])
+
+      assert backend.debug_info(:elixir_v1, module, data, []) != {:error, :missing}
+    end)
+  end
 end


### PR DESCRIPTION
That way, if someone sets erlc_options to `[warnings_as_errors: true]`, `:debug_info` would still be on the options. To configure it to not save debug info, one should only add `debug_info: false` to erlc_options

Closes #9184 