### PR TITLE
Update on_definition with Module.exists?/2 docs & test

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -439,10 +439,6 @@ defmodule Module do
     * the list of quoted guards
     * the quoted function body
 
-  Note the hook receives the quoted arguments and it is invoked before
-  the function is stored in the module. So `Module.defines?/2` will return
-  `false` for the first clause of every function.
-
   If the function/macro being defined has multiple clauses, the hook will
   be called for each clause.
 

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -158,6 +158,7 @@ defmodule ModuleTest do
     assert [{:foo, _, _}, {:bar, _, _}] = args
     assert [] = guards
     assert [do: {:+, _, [{:foo, _, nil}, {:bar, _, nil}]}] = expr
+    assert Module.defines?(env.module, {:hello, 2})
   end
 
   test "executes on definition callback" do


### PR DESCRIPTION
Closes #9351.

I wasn't sure how to update the docs and since we mention elsewhere we
receive quotes arguments I just remove the whole section.

Alternatively, here's my attempt at updating the docs:

> The hook is invoked after the function was stored in the module,
> this means that, for example, `Module.defines?/2` would always
> return `true` when invoked in this hook.