### PR TITLE
Fix defstruct code formatting

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -2180,15 +2180,12 @@ defmodule Code.Formatter do
       {{_, arg_meta, _}, _} = hd(arg)
       first_line = line(arg_meta)
 
-      comment_before_first_line? =
-        Enum.any?(comments, fn {comment_line, _, _} ->
-          block_line < comment_line && comment_line <= first_line
-        end)
+      case Enum.drop_while(comments, fn {line, _, _} -> line <= block_line end) do
+        [{line, _, _} | _] when line <= first_line ->
+          {false, block}
 
-      if comment_before_first_line? do
-        {false, block}
-      else
-        {true, arg}
+        _ ->
+          {true, arg}
       end
     else
       {false, block}

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -1145,7 +1145,7 @@ defmodule Code.Formatter do
 
   defp call_args_to_algebra_no_blocks(meta, args, skip_parens?, list_to_keyword?, extra, state) do
     {left, right} = split_last(args)
-    {keyword?, right} = last_arg_to_keyword(right, list_to_keyword?)
+    {keyword?, right} = last_arg_to_keyword(right, list_to_keyword?, state.comments)
 
     context =
       if left == [] and not keyword? do
@@ -2169,17 +2169,33 @@ defmodule Code.Formatter do
   end
 
   # A literal list is a keyword or (... -> ...)
-  defp last_arg_to_keyword([_ | _] = arg, _list_to_keyword?) do
+  defp last_arg_to_keyword([_ | _] = arg, _list_to_keyword?, _comments) do
     {keyword?(arg), arg}
   end
 
   # This is a list of tuples, it can be converted to keywords.
-  defp last_arg_to_keyword({:__block__, _, [[_ | _] = arg]} = block, true) do
-    if keyword?(arg), do: {true, arg}, else: {false, block}
+  defp last_arg_to_keyword({:__block__, meta, [[_ | _] = arg]} = block, true, comments) do
+    if keyword?(arg) do
+      block_line = line(meta)
+      {{_, [{:line, first_line} | _], _}, _} = hd(arg)
+
+      comment_before_first_line? =
+        Enum.any?(comments, fn {comment_line, _, _} ->
+          block_line < comment_line && comment_line <= first_line
+        end)
+
+      if comment_before_first_line? do
+        {false, block}
+      else
+        {true, arg}
+      end
+    else
+      {false, block}
+    end
   end
 
   # Otherwise we don't have a keyword.
-  defp last_arg_to_keyword(arg, _list_to_keyword?) do
+  defp last_arg_to_keyword(arg, _list_to_keyword?, _comments) do
     {false, arg}
   end
 

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -1145,7 +1145,7 @@ defmodule Code.Formatter do
 
   defp call_args_to_algebra_no_blocks(meta, args, skip_parens?, list_to_keyword?, extra, state) do
     {left, right} = split_last(args)
-    {keyword?, right} = last_arg_to_keyword(right, list_to_keyword?, state.comments)
+    {keyword?, right} = last_arg_to_keyword(right, list_to_keyword?, skip_parens?, state.comments)
 
     context =
       if left == [] and not keyword? do
@@ -2169,31 +2169,41 @@ defmodule Code.Formatter do
   end
 
   # A literal list is a keyword or (... -> ...)
-  defp last_arg_to_keyword([_ | _] = arg, _list_to_keyword?, _comments) do
+  defp last_arg_to_keyword([_ | _] = arg, _list_to_keyword?, _skip_parens?, _comments) do
     {keyword?(arg), arg}
   end
 
   # This is a list of tuples, it can be converted to keywords.
-  defp last_arg_to_keyword({:__block__, meta, [[_ | _] = arg]} = block, true, comments) do
-    if keyword?(arg) do
-      block_line = line(meta)
-      {{_, arg_meta, _}, _} = hd(arg)
-      first_line = line(arg_meta)
+  defp last_arg_to_keyword(
+         {:__block__, meta, [[_ | _] = arg]} = block,
+         true,
+         skip_parens?,
+         comments
+       ) do
+    cond do
+      not keyword?(arg) ->
+        {false, block}
 
-      case Enum.drop_while(comments, fn {line, _, _} -> line <= block_line end) do
-        [{line, _, _} | _] when line <= first_line ->
-          {false, block}
+      skip_parens? ->
+        block_line = line(meta)
+        {{_, arg_meta, _}, _} = hd(arg)
+        first_line = line(arg_meta)
 
-        _ ->
-          {true, arg}
-      end
-    else
-      {false, block}
+        case Enum.drop_while(comments, fn {line, _, _} -> line <= block_line end) do
+          [{line, _, _} | _] when line <= first_line ->
+            {false, block}
+
+          _ ->
+            {true, arg}
+        end
+
+      true ->
+        {true, arg}
     end
   end
 
   # Otherwise we don't have a keyword.
-  defp last_arg_to_keyword(arg, _list_to_keyword?, _comments) do
+  defp last_arg_to_keyword(arg, _list_to_keyword?, _skip_parens?, _comments) do
     {false, arg}
   end
 

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -2177,7 +2177,8 @@ defmodule Code.Formatter do
   defp last_arg_to_keyword({:__block__, meta, [[_ | _] = arg]} = block, true, comments) do
     if keyword?(arg) do
       block_line = line(meta)
-      {{_, [{:line, first_line} | _], _}, _} = hd(arg)
+      {{_, arg_meta, _}, _} = hd(arg)
+      first_line = line(arg_meta)
 
       comment_before_first_line? =
         Enum.any?(comments, fn {comment_line, _, _} ->

--- a/lib/elixir/test/elixir/code_formatter/comments_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/comments_test.exs
@@ -1264,7 +1264,7 @@ defmodule Code.Formatter.CommentsTest do
   end
 
   describe "defstruct" do
-    test "has first field comments" do
+    test "with first field comments" do
       bad = ~S"""
       defmodule Foo do
         # defstruct
@@ -1296,7 +1296,39 @@ defmodule Code.Formatter.CommentsTest do
       assert_format bad, good
     end
 
-    test "no first field comment" do
+    test "with first field comments and defstruct has the parens" do
+      bad = ~S"""
+      defmodule Foo do
+        # defstruct
+        defstruct([ # foo
+          # 1. one
+          one: 1, # 2. one
+          # 1. two
+          # 2. two
+          two: 2
+        ])
+      end
+      """
+
+      good = ~S"""
+      defmodule Foo do
+        # defstruct
+        # foo
+        defstruct(
+          # 1. one
+          # 2. one
+          one: 1,
+          # 1. two
+          # 2. two
+          two: 2
+        )
+      end
+      """
+
+      assert_format bad, good
+    end
+
+    test "without first field comments" do
       bad = ~S"""
       defmodule Foo do
         # defstruct
@@ -1321,7 +1353,7 @@ defmodule Code.Formatter.CommentsTest do
       assert_format bad, good
     end
 
-    test "without comment" do
+    test "without field comments" do
       bad = ~S"""
       defmodule Foo do
         # defstruct
@@ -1341,7 +1373,6 @@ defmodule Code.Formatter.CommentsTest do
       """
 
       assert_format bad, good
-      assert_same good
     end
 
     test "without square brackets" do

--- a/lib/elixir/test/elixir/code_formatter/comments_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/comments_test.exs
@@ -1262,4 +1262,98 @@ defmodule Code.Formatter.CommentsTest do
       assert_format bad, good
     end
   end
+
+  describe "defstruct" do
+    test "has first field comments" do
+      bad = ~S"""
+      defmodule Foo do
+        # defstruct
+        defstruct [ # foo
+          # 1. one
+          one: 1, # 2. one
+          # 1. two
+          # 2. two
+          two: 2
+        ]
+      end
+      """
+
+      good = ~S"""
+      defmodule Foo do
+        # defstruct
+        # foo
+        defstruct [
+          # 1. one
+          # 2. one
+          one: 1,
+          # 1. two
+          # 2. two
+          two: 2
+        ]
+      end
+      """
+
+      assert_format bad, good
+    end
+
+    test "no first field comment" do
+      bad = ~S"""
+      defmodule Foo do
+        # defstruct
+        defstruct [
+          one: 1,
+          # 1. two
+          two: 2 # 2. two
+        ]
+      end
+      """
+
+      good = ~S"""
+      defmodule Foo do
+        # defstruct
+        defstruct one: 1,
+                  # 1. two
+                  # 2. two
+                  two: 2
+      end
+      """
+
+      assert_format bad, good
+    end
+
+    test "without comment" do
+      bad = ~S"""
+      defmodule Foo do
+        # defstruct
+        defstruct [
+          one: 1,
+          two: 2
+        ]
+      end
+      """
+
+      good = ~S"""
+      defmodule Foo do
+        # defstruct
+        defstruct one: 1,
+                  two: 2
+      end
+      """
+
+      assert_format bad, good
+      assert_same good
+    end
+
+    test "without square brackets" do
+      assert_same ~S"""
+      defmodule Foo do
+        # defstruct
+        defstruct one: 1,
+                  # 1. two
+                  # 2. two
+                  two: 2
+      end
+      """
+    end
+  end
 end


### PR DESCRIPTION
Currently,
When defining a struct as following
```elixir
defmodule Foo do
  defstruct [
    # a
    a: 1,
    # b
    b: 2
  ]
end
```
It will be formatted to
```elixir
defmodule Foo do
  defstruct a: 1,
            # a
            # b
            b: 2
end
```
I think when the first field has some comment, `defstruct` should keep the square brackets.