### PR TITLE
Adding tee/2 function to Kernel

### DIFF
--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -3,6 +3,8 @@ Code.require_file("../test_helper.exs", __DIR__)
 defmodule ExUnit.CaseTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureIO
+
   ExUnit.Case.register_attribute(__MODULE__, :foo)
   ExUnit.Case.register_attribute(__MODULE__, :bar, accumulate: true)
   ExUnit.Case.register_attribute(__MODULE__, :baz)
@@ -111,5 +113,30 @@ defmodule ExUnit.CaseTest do
         ExUnit.Case.register_attribute(__MODULE__, :foo, accumulate: true)
       end
     end
+  end
+
+  test "warns for using it twice with different options" do
+    assert capture_io(:stderr, fn ->
+        defmodule WarnsUsedTwice do
+          use ExUnit.Case
+          use ExUnit.Case, async: true
+        end
+      end) == ""
+
+    stderr =
+      capture_io(:stderr, fn ->
+        defmodule WarnsUsedTwice do
+          use ExUnit.Case
+          use ExUnit.Case, async: false
+        end
+      end)
+
+    assert stderr =~ """
+           ExUnit.Case was already used on this module ExUnit.CaseTest.WarnsUsedTwice \
+           with the options `[async: true]`.
+
+           Please make sure to set the right options on the first `use ExUnit.Case`, \
+           as they are not overriden by any subsequent calls.
+           """
   end
 end


### PR DESCRIPTION
This is a possible implementation to the `tee` function mentioned on
[elixir-core:7754] Proposal: Allow IO.inspect to accept a function as argument

https://groups.google.com/d/msgid/elixir-lang-core/CAGnRm4Ji7kAjv5i4_04AVp-hae4ghj1DgZx1zr%2B4LyGBYpj5_A%40mail.gmail.com

Maybe another `Kernel` function is not that good. But I think is a pretty useful
function to have it auto-imported.

PS: I didn't "eat my own dog food" yet because this might not be the implementation
you want. Once reviewed and approved we can think about the functions we can use
`tee/2` (like `IO.inspect/2`)