### PR TITLE
Fix truncate docs for millisecond precision

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1157,7 +1157,7 @@ defmodule DateTime do
 
   @doc """
   Returns the given datetime with the microsecond field truncated to the given
-  precision (`:microsecond`, `millisecond` or `:second`).
+  precision (`:microsecond`, `:millisecond` or `:second`).
 
   The given datetime is returned unchanged if it already has lower precision than
   the given precision.


### PR DESCRIPTION
Single character fix marking `:millisecond` as an atom to match `:second` and `:microsecond`.