### PR TITLE
Adds calendar.parse_date! to support calendar independent sigil_D

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -820,6 +820,35 @@ defmodule Calendar.ISO do
     "~T[" <> Calendar.ISO.time_to_string(hour, minute, second, microsecond) <> "]"
   end
 
+  @doc """
+  Implements date parsing in support of `Kernel.sigil_D/2` for
+  this calendar
+  """
+  @doc since: "1.10.0"
+  @impl true
+  @spec parse_date!(String.t()) ::
+          {
+            Calendar.year(),
+            Calendar.month(),
+            Calendar.day()
+          }
+          | no_return()
+
+  def parse_date!(<<?-, rest::binary>>) do
+    {year, month, day} = parse_date!(rest)
+    {-year, month, day}
+  end
+
+  def parse_date!(<<rest::binary>>) do
+    case Date.raw_from_iso8601(rest) do
+      {_year, _month, _day} = raw_date ->
+        raw_date
+
+      {:error, reason} ->
+        raise ArgumentError, Date.parse_error(rest, reason)
+    end
+  end
+
   defp offset_to_string(0, 0, "Etc/UTC", _format), do: "Z"
 
   defp offset_to_string(utc, std, _zone, format) do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5035,7 +5035,10 @@ defmodule Kernel do
   defmacro sigil_D(date_string, modifiers)
 
   defmacro sigil_D({:<<>>, _, [string]}, []) do
-    Macro.escape(Date.from_iso8601!(string))
+    {string, calendar} = Calendar.split_date_time_string(string, __CALLER__)
+    {year, month, day} = calendar.parse_date!(string)
+    {:ok, date} = Date.new(year, month, day, calendar)
+    Macro.escape(date)
   end
 
   @doc ~S"""

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -4,6 +4,8 @@ Code.require_file("fakes.exs", __DIR__)
 
 defmodule DateTest do
   use ExUnit.Case, async: true
+  alias Calendar.Holocene
+
   doctest Date
 
   test "to_string/1" do
@@ -21,7 +23,7 @@ defmodule DateTest do
     assert inspect(date) == "%Date{calendar: FakeCalendar, day: 1, month: 1, year: 2000}"
 
     date = %{~D[2000-01-01] | calendar: Calendar.Holocene}
-    assert inspect(date) == "2000-1-1 (HE)"
+    assert inspect(date) == "2000-01-01 Calendar.Holocene"
   end
 
   test "compare/2" do
@@ -103,4 +105,14 @@ defmodule DateTest do
     assert Date.diff(date1, date2) == -13
     assert Date.diff(date2, date1) == 13
   end
+
+  test "sigil_D for a calendar other than Calendar.ISO" do
+    assert %Date{year: 10001, month: 1, day: 1, calendar: Calendar.Holocene} ==
+             ~D[10001-01-01 Calendar.Holocene]
+  end
+
+  # test "sigil_D for an aliased calendar other than Calendar.ISO" do
+  #   assert %Date{year: 10001, month: 1, day: 1, calendar: Calendar.Holocene} ==
+  #            ~D[10001-01-01 Holocene]
+  # end
 end

--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -44,7 +44,7 @@ defmodule DateTimeTest do
     }
 
     datetime = %{datetime | calendar: Calendar.Holocene}
-    assert inspect(datetime) == "2000-2-29 23:00:07 BRM (HE)"
+    assert inspect(datetime) == "2000-02-29 23:00:07 BRM Calendar.Holocene"
   end
 
   test "from_iso8601/1 handles positive and negative offsets" do


### PR DESCRIPTION
This is an initial draft of an implementation to have sigils ~D, ~T, ~N and ~U be calendar independent. The intent is to capture comments and suggestions on the implementation approach since it will need to be replicated for `~T`, `~U` and `~N`.

### Open item

Based upon the discussions at [Elixir Forum](https://elixirforum.com/t/proposal-allow-calendar-to-be-specified-in-d-u-n-and-t-sigils/23156/32) the current implementation splits the sigil string on `\s` and if the last entry starts with a latin capital letter in the range `?A..?Z` it treats it as a calendar module name.

On reviewing tests I believe this may not be the right approach. From the `datetime` test suite we see:
```
assert inspect(datetime) == "2000-02-29 23:00:07 BRM Calendar.Holocene"
```
In attempting to parse this in the current implementation of `sigil_D/2` it would be ok. But if instead there was an attempt to parse `~U[2000-02-29 23:00:07 BRM]"` this would fail since `BRM` would be interpreted as calendar module.

Suggestions on how to format so that the calendar can always be unambiguously identified are welcome.

### Expanding a calendar module alias

There is also one failing test (commented out for now) that tests expanding a calendar alias in the sigil string. Calling `Macro.escape/2` isn't returning the results I expected so further investigation is required.

### Commit summary

1. Adjusts Kernel.sigil_D/2 to call calendar.parse_date!/1
2. Adds the callback parse_date!/1 to the Calendar behaviour
3. Implements parse_date!/1 in Calendar.ISO
4. Implements parse_date!/1 in Calendar.Holocene
5. Adds test for sigil_D/2 with Calendar.Holocene
6. Makes minor adjustment to Calendar.Holocene tests to
better align inspect and parse outputs/inputs consistent
with Calendar.ISO date padding