### PR TITLE
Add parse_date/parse_naive_datetime/parse_utc_datetime to Calendar behaviour

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -284,6 +284,8 @@ defmodule Calendar do
   @doc """
   Parses the string representation for a naive datetime returned by
   `c:naive_datetime_to_string/7` into a naive-datetime-tuple.
+
+  The given string may contain a timezone offset but it is ignored.
   """
   @callback parse_naive_datetime(String.t()) ::
               {:ok, {year, month, day, hour, minute, second, microsecond}}

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -265,7 +265,6 @@ defmodule Calendar do
   """
   @callback valid_time?(hour, minute, second, microsecond) :: boolean
 
-
   @doc """
   Parses the string representation for a time returned by `c:time_to_string/4`
   into a time-tuple.

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -265,6 +265,15 @@ defmodule Calendar do
   """
   @callback valid_time?(hour, minute, second, microsecond) :: boolean
 
+
+  @doc """
+  Parses the string representation for a time returned by `c:time_to_string/4`
+  into a time-tuple.
+  """
+  @callback parse_time(String.t()) ::
+              {:ok, {hour, minute, second, microsecond}}
+              | {:error, atom}
+
   @doc """
   Parses the string representation for a date returned by `c:date_to_string/3`
   into a date-tuple.

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -265,6 +265,33 @@ defmodule Calendar do
   """
   @callback valid_time?(hour, minute, second, microsecond) :: boolean
 
+  @doc """
+  Parses the string representation for a date returned by `c:date_to_string/3`
+  into a date-tuple.
+  """
+  @callback parse_date(String.t()) ::
+              {:ok, {year, month, day}}
+              | {:error, atom}
+
+  @doc """
+  Parses the string representation for a naive datetime returned by
+  `c:naive_datetime_to_string/7` into a naive-datetime-tuple.
+  """
+  @callback parse_naive_datetime(String.t()) ::
+              {:ok, {year, month, day, hour, minute, second, microsecond}}
+              | {:error, atom}
+
+  @doc """
+  Parses the string representation for a UTC datetime returned by
+  `c:datetime_to_string/11` into a datetime-tuple.
+
+  The effective `Datetime` created by the result of this function
+  will be in UTC with the given `utc_offset`.
+  """
+  @callback parse_utc_datetime(String.t()) ::
+              {:ok, {year, month, day, hour, minute, second, microsecond}, utc_offset}
+              | {:error, atom}
+
   # General Helpers
 
   @doc """

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -291,11 +291,11 @@ defmodule Calendar do
               | {:error, atom}
 
   @doc """
-  Parses the string representation for a UTC datetime returned by
+  Parses the string representation for a datetime returned by
   `c:datetime_to_string/11` into a datetime-tuple.
 
-  The effective `Datetime` created by the result of this function
-  will be in UTC with the given `utc_offset`.
+  The returned datetime must be in UTC. The original `utc_offset`
+  it was written in must be returned in the result.
   """
   @callback parse_utc_datetime(String.t()) ::
               {:ok, {year, month, day, hour, minute, second, microsecond}, utc_offset}

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -748,12 +748,11 @@ defmodule Date do
   end
 
   defimpl Inspect do
-    def inspect(%{calendar: Calendar.ISO, year: year, month: month, day: day}, _) do
-      "~D[" <> Calendar.ISO.date_to_string(year, month, day) <> "]"
+    def inspect(%{calendar: calendar, year: year, month: month, day: day}, _) do
+      "~D[" <> calendar.date_to_string(year, month, day) <> suffix(calendar) <> "]"
     end
 
-    def inspect(date, opts) do
-      Inspect.Any.inspect(date, opts)
-    end
+    defp suffix(Calendar.ISO), do: ""
+    defp suffix(calendar), do: " " <> inspect(calendar)
   end
 end

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -263,30 +263,9 @@ defmodule Date do
 
   """
   @spec from_iso8601(String.t(), Calendar.calendar()) :: {:ok, t} | {:error, atom}
-  def from_iso8601(string, calendar \\ Calendar.ISO)
-
-  def from_iso8601(<<?-, rest::binary>>, calendar) do
-    with {:ok, %{year: year} = date} <- raw_from_iso8601(rest, calendar) do
-      {:ok, %{date | year: -year}}
-    end
-  end
-
-  def from_iso8601(<<rest::binary>>, calendar) do
-    raw_from_iso8601(rest, calendar)
-  end
-
-  [match_date, guard_date, read_date] = Calendar.ISO.__match_date__()
-
-  defp raw_from_iso8601(string, calendar) do
-    with unquote(match_date) <- string,
-         true <- unquote(guard_date) do
-      {year, month, day} = unquote(read_date)
-
-      with {:ok, date} <- new(year, month, day, Calendar.ISO) do
-        convert(date, calendar)
-      end
-    else
-      _ -> {:error, :invalid_format}
+  def from_iso8601(string, calendar \\ Calendar.ISO) do
+    with {:ok, {year, month, day}} <- Calendar.ISO.parse_date(string) do
+      convert(%Date{year: year, month: month, day: day}, calendar)
     end
   end
 

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -770,7 +770,6 @@ defmodule DateTime do
       second: second,
       microsecond: microsecond,
       time_zone: time_zone,
-      zone_abbr: zone_abbr,
       utc_offset: utc_offset,
       std_offset: std_offset
     } = datetime

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -775,20 +775,10 @@ defmodule DateTime do
       std_offset: std_offset
     } = datetime
 
-    Calendar.ISO.datetime_to_iso8601(
-      year,
-      month,
-      day,
-      hour,
-      minute,
-      second,
-      microsecond,
-      time_zone,
-      zone_abbr,
-      utc_offset,
-      std_offset,
-      format
-    )
+    Calendar.ISO.date_to_string(year, month, day, format) <>
+      "T" <>
+      Calendar.ISO.time_to_string(hour, minute, second, microsecond, format) <>
+      Calendar.ISO.offset_to_string(utc_offset, std_offset, time_zone, format)
   end
 
   def to_iso8601(%{calendar: _} = datetime, format) when format in [:extended, :basic] do

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -844,50 +844,19 @@ defmodule DateTime do
   def from_iso8601(string, calendar \\ Calendar.ISO) do
     with {:ok, {year, month, day, hour, minute, second, microsecond}, offset} <-
            Calendar.ISO.parse_utc_datetime(string) do
-      datetime =
-        if offset == 0 do
-          %DateTime{
-            year: year,
-            month: month,
-            day: day,
-            hour: hour,
-            minute: minute,
-            second: second,
-            microsecond: microsecond,
-            std_offset: 0,
-            utc_offset: 0,
-            zone_abbr: "UTC",
-            time_zone: "Etc/UTC"
-          }
-        else
-          day_fraction = Calendar.ISO.time_to_day_fraction(hour, minute, second, {0, 0})
-
-          {{year, month, day}, {hour, minute, second, _}} =
-            case apply_tz_offset({0, day_fraction}, offset) do
-              {0, day_fraction} ->
-                {{year, month, day}, Calendar.ISO.time_from_day_fraction(day_fraction)}
-
-              {extra_days, day_fraction} ->
-                base_days = Calendar.ISO.date_to_iso_days(year, month, day)
-
-                {Calendar.ISO.date_from_iso_days(base_days + extra_days),
-                 Calendar.ISO.time_from_day_fraction(day_fraction)}
-            end
-
-          %DateTime{
-            year: year,
-            month: month,
-            day: day,
-            hour: hour,
-            minute: minute,
-            second: second,
-            microsecond: microsecond,
-            std_offset: 0,
-            utc_offset: 0,
-            zone_abbr: "UTC",
-            time_zone: "Etc/UTC"
-          }
-        end
+      datetime = %DateTime{
+        year: year,
+        month: month,
+        day: day,
+        hour: hour,
+        minute: minute,
+        second: second,
+        microsecond: microsecond,
+        std_offset: 0,
+        utc_offset: 0,
+        zone_abbr: "UTC",
+        time_zone: "Etc/UTC"
+      }
 
       with {:ok, converted} <- convert(datetime, calendar) do
         {:ok, converted, offset}

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1298,7 +1298,7 @@ defmodule DateTime do
   end
 
   defimpl Inspect do
-    def inspect(%{calendar: Calendar.ISO} = datetime, _) do
+    def inspect(datetime, _) do
       %{
         year: year,
         month: month,
@@ -1310,11 +1310,12 @@ defmodule DateTime do
         time_zone: time_zone,
         zone_abbr: zone_abbr,
         utc_offset: utc_offset,
-        std_offset: std_offset
+        std_offset: std_offset,
+        calendar: calendar
       } = datetime
 
       formatted =
-        Calendar.ISO.datetime_to_string(
+        calendar.datetime_to_string(
           year,
           month,
           day,
@@ -1330,15 +1331,14 @@ defmodule DateTime do
 
       case datetime do
         %{utc_offset: 0, std_offset: 0, time_zone: "Etc/UTC"} ->
-          "~U[" <> formatted <> "]"
+          "~U[" <> formatted <> suffix(calendar) <> "]"
 
         _ ->
-          "#DateTime<" <> formatted <> ">"
+          "#DateTime<" <> formatted <> suffix(calendar) <> ">"
       end
     end
 
-    def inspect(datetime, opts) do
-      Inspect.Any.inspect(datetime, opts)
-    end
+    defp suffix(Calendar.ISO), do: ""
+    defp suffix(calendar), do: " " <> inspect(calendar)
   end
 end

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -71,7 +71,37 @@ defmodule Calendar.ISO do
       ]
     end
 
-  @doc false
+  @doc """
+  Parses a time string.
+
+  ## Examples
+
+      iex> Calendar.ISO.parse_time("23:50:07")
+      {:ok, {23, 50, 7, {0, 0}}}
+      iex> Calendar.ISO.parse_time("23:50:07Z")
+      {:ok, {23, 50, 7, {0, 0}}}
+      iex> Calendar.ISO.parse_time("T23:50:07Z")
+      {:ok, {23, 50, 7, {0, 0}}}
+
+      iex> Calendar.ISO.parse_time("23:50:07,0123456")
+      {:ok, {23, 50, 7, {12345, 6}}}
+      iex> Calendar.ISO.parse_time("23:50:07.0123456")
+      {:ok, {23, 50, 7, {12345, 6}}}
+      iex> Calendar.ISO.parse_time("23:50:07.123Z")
+      {:ok, {23, 50, 7, {123000, 3}}}
+
+      iex> Calendar.ISO.parse_time("2015:01:23 23-50-07")
+      {:error, :invalid_format}
+      iex> Calendar.ISO.parse_time("23:50:07A")
+      {:error, :invalid_format}
+      iex> Calendar.ISO.parse_time("23:50:07.")
+      {:error, :invalid_format}
+      iex> Calendar.ISO.parse_time("23:50:61")
+      {:error, :invalid_time}
+
+  """
+  @doc since: "1.10.0"
+  @impl true
   def parse_time("T" <> string) when is_binary(string),
     do: do_parse_time(string)
 

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -899,6 +899,28 @@ defmodule Calendar.ISO do
       zone_to_string(utc_offset, std_offset, zone_abbr, time_zone)
   end
 
+  @doc false
+  def offset_to_string(0, 0, "Etc/UTC", _format), do: "Z"
+
+  def offset_to_string(utc, std, _zone, format) do
+    total = utc + std
+    second = abs(total)
+    minute = second |> rem(3600) |> div(60)
+    hour = div(second, 3600)
+    format_offset(total, hour, minute, format)
+  end
+
+  defp format_offset(total, hour, minute, :extended) do
+    sign(total) <> zero_pad(hour, 2) <> ":" <> zero_pad(minute, 2)
+  end
+
+  defp format_offset(total, hour, minute, :basic) do
+    sign(total) <> zero_pad(hour, 2) <> zero_pad(minute, 2)
+  end
+
+  defp zone_to_string(_, _, _, "Etc/UTC"), do: ""
+  defp zone_to_string(_, _, abbr, zone), do: " " <> abbr <> " " <> zone
+
   @doc """
   Determines if the date given is valid according to the proleptic Gregorian calendar.
 
@@ -958,27 +980,6 @@ defmodule Calendar.ISO do
     {0, 1}
   end
 
-  defp offset_to_string(0, 0, "Etc/UTC", _format), do: "Z"
-
-  defp offset_to_string(utc, std, _zone, format) do
-    total = utc + std
-    second = abs(total)
-    minute = second |> rem(3600) |> div(60)
-    hour = div(second, 3600)
-    format_offset(total, hour, minute, format)
-  end
-
-  defp format_offset(total, hour, minute, :extended) do
-    sign(total) <> zero_pad(hour, 2) <> ":" <> zero_pad(minute, 2)
-  end
-
-  defp format_offset(total, hour, minute, :basic) do
-    sign(total) <> zero_pad(hour, 2) <> zero_pad(minute, 2)
-  end
-
-  defp zone_to_string(_, _, _, "Etc/UTC"), do: ""
-  defp zone_to_string(_, _, abbr, zone), do: " " <> abbr <> " " <> zone
-
   defp sign(total) when total < 0, do: "-"
   defp sign(_), do: "+"
 
@@ -1018,42 +1019,6 @@ defmodule Calendar.ISO do
       100_000 -> 5
       _ -> 6
     end
-  end
-
-  @doc false
-  def naive_datetime_to_iso8601(
-        year,
-        month,
-        day,
-        hour,
-        minute,
-        second,
-        microsecond,
-        format \\ :extended
-      ) do
-    date_to_string(year, month, day, format) <>
-      "T" <> time_to_string(hour, minute, second, microsecond, format)
-  end
-
-  @doc false
-  def datetime_to_iso8601(
-        year,
-        month,
-        day,
-        hour,
-        minute,
-        second,
-        microsecond,
-        time_zone,
-        _zone_abbr,
-        utc_offset,
-        std_offset,
-        format \\ :extended
-      ) do
-    date_to_string(year, month, day, format) <>
-      "T" <>
-      time_to_string(hour, minute, second, microsecond, format) <>
-      offset_to_string(utc_offset, std_offset, time_zone, format)
   end
 
   defp parse_microsecond("." <> rest) do

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -534,35 +534,21 @@ defmodule NaiveDateTime do
 
   """
   @spec from_iso8601(String.t(), Calendar.calendar()) :: {:ok, t} | {:error, atom}
-  def from_iso8601(string, calendar \\ Calendar.ISO)
-
-  def from_iso8601(<<?-, rest::binary>>, calendar) do
-    with {:ok, %{year: year} = naive_datetime} <- raw_from_iso8601(rest, calendar) do
-      {:ok, %{naive_datetime | year: -year}}
-    end
-  end
-
-  def from_iso8601(<<rest::binary>>, calendar) do
-    raw_from_iso8601(rest, calendar)
-  end
-
-  @sep [?\s, ?T]
-  [match_date, guard_date, read_date] = Calendar.ISO.__match_date__()
-  [match_time, guard_time, read_time] = Calendar.ISO.__match_time__()
-
-  defp raw_from_iso8601(string, calendar) do
-    with <<unquote(match_date), sep, unquote(match_time), rest::binary>> <- string,
-         true <- unquote(guard_date) and sep in @sep and unquote(guard_time),
-         {microsec, rest} <- Calendar.ISO.parse_microsecond(rest),
-         {_offset, ""} <- Calendar.ISO.parse_offset(rest) do
-      {year, month, day} = unquote(read_date)
-      {hour, min, sec} = unquote(read_time)
-
-      with {:ok, iso_naive_dt} <- new(year, month, day, hour, min, sec, microsec, Calendar.ISO) do
-        convert(iso_naive_dt, calendar)
-      end
-    else
-      _ -> {:error, :invalid_format}
+  def from_iso8601(string, calendar \\ Calendar.ISO) do
+    with {:ok, {year, month, day, hour, minute, second, microsecond}} <-
+           Calendar.ISO.parse_naive_datetime(string) do
+      convert(
+        %NaiveDateTime{
+          year: year,
+          month: month,
+          day: day,
+          hour: hour,
+          minute: minute,
+          second: second,
+          microsecond: microsecond
+        },
+        calendar
+      )
     end
   end
 

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -914,7 +914,7 @@ defmodule NaiveDateTime do
   end
 
   defimpl Inspect do
-    def inspect(%{calendar: Calendar.ISO} = naive_datetime, _) do
+    def inspect(naive_datetime, _) do
       %{
         year: year,
         month: month,
@@ -922,17 +922,17 @@ defmodule NaiveDateTime do
         hour: hour,
         minute: minute,
         second: second,
-        microsecond: microsecond
+        microsecond: microsecond,
+        calendar: calendar
       } = naive_datetime
 
       formatted =
-        Calendar.ISO.naive_datetime_to_string(year, month, day, hour, minute, second, microsecond)
+        calendar.naive_datetime_to_string(year, month, day, hour, minute, second, microsecond)
 
-      "~N[" <> formatted <> "]"
+      "~N[" <> formatted <> suffix(calendar) <> "]"
     end
 
-    def inspect(naive, opts) do
-      Inspect.Any.inspect(naive, opts)
-    end
+    defp suffix(Calendar.ISO), do: ""
+    defp suffix(calendar), do: " " <> inspect(calendar)
   end
 end

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -626,16 +626,8 @@ defmodule NaiveDateTime do
       microsecond: microsecond
     } = naive_datetime
 
-    Calendar.ISO.naive_datetime_to_iso8601(
-      year,
-      month,
-      day,
-      hour,
-      minute,
-      second,
-      microsecond,
-      format
-    )
+    Calendar.ISO.date_to_string(year, month, day, format) <>
+      "T" <> Calendar.ISO.time_to_string(hour, minute, second, microsecond, format)
   end
 
   def to_iso8601(%{calendar: _} = naive_datetime, format) when format in [:basic, :extended] do

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -675,20 +675,20 @@ defmodule Time do
   end
 
   defimpl Inspect do
-    def inspect(%{calendar: Calendar.ISO} = time, _) do
+    def inspect(time, _) do
       %{
         hour: hour,
         minute: minute,
         second: second,
         microsecond: microsecond,
-        calendar: Calendar.ISO
+        calendar: calendar
       } = time
 
-      "~T[" <> Calendar.ISO.time_to_string(hour, minute, second, microsecond) <> "]"
+      "~T[" <>
+        calendar.time_to_string(hour, minute, second, microsecond) <> suffix(calendar) <> "]"
     end
 
-    def inspect(time, opts) do
-      Inspect.Any.inspect(time, opts)
-    end
+    defp suffix(Calendar.ISO), do: ""
+    defp suffix(calendar), do: " " <> inspect(calendar)
   end
 end

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -213,30 +213,12 @@ defmodule Time do
 
   """
   @spec from_iso8601(String.t(), Calendar.calendar()) :: {:ok, t} | {:error, atom}
-  def from_iso8601(string, calendar \\ Calendar.ISO)
-
-  def from_iso8601(<<?T, rest::binary>>, calendar) do
-    raw_from_iso8601(rest, calendar)
-  end
-
-  def from_iso8601(<<rest::binary>>, calendar) do
-    raw_from_iso8601(rest, calendar)
-  end
-
-  [match_time, guard_time, read_time] = Calendar.ISO.__match_time__()
-
-  defp raw_from_iso8601(string, calendar) do
-    with <<unquote(match_time), rest::binary>> <- string,
-         true <- unquote(guard_time),
-         {microsec, rest} <- Calendar.ISO.parse_microsecond(rest),
-         {_offset, ""} <- Calendar.ISO.parse_offset(rest) do
-      {hour, min, sec} = unquote(read_time)
-
-      with {:ok, utc_time} <- new(hour, min, sec, microsec, Calendar.ISO) do
-        convert(utc_time, calendar)
-      end
-    else
-      _ -> {:error, :invalid_format}
+  def from_iso8601(string, calendar \\ Calendar.ISO) do
+    with {:ok, {hour, minute, second, microsecond}} <- Calendar.ISO.parse_time(string) do
+      convert(
+        %Time{hour: hour, minute: minute, second: second, microsecond: microsecond},
+        calendar
+      )
     end
   end
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5021,6 +5021,21 @@ defmodule Kernel do
   @doc ~S"""
   Handles the sigil `~D` for dates.
 
+  By default, this sigil uses the built-in `Calendar.ISO`, which
+  requires dates to be written in the ISO8601 format:
+
+      ~D[yyyy-mm-dd]
+
+  such as:
+
+      ~D[2015-01-13]
+
+  If you are using alternative calendars, any representation can
+  be used as long as you follow the representation by a single space
+  and the calendar name:
+
+      ~D[SOME-REPRESENTATION My.Alternative.Calendar]
+
   The lower case `~d` variant does not exist as interpolation
   and escape characters are not useful for date sigils.
 
@@ -5041,6 +5056,23 @@ defmodule Kernel do
 
   @doc ~S"""
   Handles the sigil `~T` for times.
+
+  By default, this sigil uses the built-in `Calendar.ISO`, which
+  requires times to be written in the ISO8601 format:
+
+      ~T[hh:mm:ss]
+      ~T[hh:mm:ss.ssssss]
+
+  such as:
+
+      ~T[13:00:07]
+      ~T[13:00:07.123]
+
+  If you are using alternative calendars, any representation can
+  be used as long as you follow the representation by a single space
+  and the calendar name:
+
+      ~T[SOME-REPRESENTATION My.Alternative.Calendar]
 
   The lower case `~t` variant does not exist as interpolation
   and escape characters are not useful for time sigils.
@@ -5073,10 +5105,29 @@ defmodule Kernel do
   @doc ~S"""
   Handles the sigil `~N` for naive date times.
 
+  By default, this sigil uses the built-in `Calendar.ISO`, which
+  requires naive datetimes to be written in the ISO8601 format:
+
+      ~N[yyyy-mm-dd hh:mm:ss]
+      ~N[yyyy-mm-dd hh:mm:ss.ssssss]
+      ~N[yyyy-mm-ddThh:mm:ss.ssssss]
+
+  such as:
+
+      ~N[2015-01-13 13:00:07]
+      ~N[2015-01-13T13:00:07.123]
+
+  If you are using alternative calendars, any representation can
+  be used as long as you follow the representation by a single space
+  and the calendar name:
+
+      ~N[SOME-REPRESENTATION My.Alternative.Calendar]
+
   The lower case `~n` variant does not exist as interpolation
   and escape characters are not useful for date time sigils.
 
-  More information on naive date times can be found in the `NaiveDateTime` module.
+  More information on naive date times can be found in the
+  `NaiveDateTime` module.
 
   ## Examples
 
@@ -5107,11 +5158,29 @@ defmodule Kernel do
   @doc ~S"""
   Handles the sigil `~U` to create a UTC `DateTime`.
 
+  By default, this sigil uses the built-in `Calendar.ISO`, which
+  requires naive datetimes to be written in the ISO8601 format:
+
+      ~U[yyyy-mm-dd hh:mm:ssZ]
+      ~U[yyyy-mm-dd hh:mm:ss.ssssssZ]
+      ~U[yyyy-mm-ddThh:mm:ss.ssssss+00:00]
+
+  such as:
+
+      ~U[2015-01-13 13:00:07Z]
+      ~U[2015-01-13T13:00:07.123+00:00]
+
+  If you are using alternative calendars, any representation can
+  be used as long as you follow the representation by a single space
+  and the calendar name:
+
+      ~U[SOME-REPRESENTATION My.Alternative.Calendar]
+
+  The given `datetime_string` must include "Z" or "00:00" offset
+  which marks it as UTC, otherwise an error is raised.
+
   The lower case `~u` variant does not exist as interpolation
   and escape characters are not useful for date time sigils.
-
-  The given `datetime_string` must include "Z" or "00:00" offset which marks it
-  as UTC, otherwise an error is raised.
 
   More information on date times can be found in the `DateTime` module.
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5106,7 +5106,7 @@ defmodule Kernel do
   Handles the sigil `~N` for naive date times.
 
   By default, this sigil uses the built-in `Calendar.ISO`, which
-  requires naive datetimes to be written in the ISO8601 format:
+  requires naive date times to be written in the ISO8601 format:
 
       ~N[yyyy-mm-dd hh:mm:ss]
       ~N[yyyy-mm-dd hh:mm:ss.ssssss]
@@ -5159,7 +5159,7 @@ defmodule Kernel do
   Handles the sigil `~U` to create a UTC `DateTime`.
 
   By default, this sigil uses the built-in `Calendar.ISO`, which
-  requires naive datetimes to be written in the ISO8601 format:
+  requires UTC date times to be written in the ISO8601 format:
 
       ~U[yyyy-mm-dd hh:mm:ssZ]
       ~U[yyyy-mm-dd hh:mm:ss.ssssssZ]

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5153,7 +5153,8 @@ defmodule Kernel do
 
   defp parse_with_calendar!(string, fun, context) do
     {calendar, string} = extract_calendar(string)
-    {calendar |> apply(fun, [string]) |> maybe_raise!(calendar, context, string), calendar}
+    result = apply(calendar, fun, [string])
+    {maybe_raise!(result, calendar, context, string), calendar}
   end
 
   defp extract_calendar(string) do

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -40,7 +40,7 @@ defmodule DateTest do
     assert Date.to_string(%{date | calendar: FakeCalendar}) == "1/1/2000"
   end
 
-  test "Kernel.inspect/1" do
+  test "inspect/1" do
     assert inspect(~D[2000-01-01]) == "~D[2000-01-01]"
     assert inspect(~D[-0100-12-31]) == "~D[-0100-12-31]"
 

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -10,8 +10,8 @@ defmodule DateTest do
     assert ~D[2000-01-01] ==
              %Date{calendar: Calendar.ISO, year: 2000, month: 1, day: 1}
 
-    assert ~D[2000-01-01 Calendar.Holocene] ==
-             %Date{calendar: Calendar.Holocene, year: 2000, month: 1, day: 1}
+    assert ~D[20001-01-01 Calendar.Holocene] ==
+             %Date{calendar: Calendar.Holocene, year: 20001, month: 1, day: 1}
 
     assert_raise ArgumentError,
                  ~s/cannot parse "2000-50-50" as Date for Calendar.ISO, reason: :invalid_date/,
@@ -22,8 +22,8 @@ defmodule DateTest do
                  fn -> Code.eval_string("~D[2000-50-50 notalias]") end
 
     assert_raise ArgumentError,
-                 ~s/cannot parse "2000-50-50" as Date for Calendar.Holocene, reason: :invalid_date/,
-                 fn -> Code.eval_string("~D[2000-50-50 Calendar.Holocene]") end
+                 ~s/cannot parse "20001-50-50" as Date for Calendar.Holocene, reason: :invalid_date/,
+                 fn -> Code.eval_string("~D[20001-50-50 Calendar.Holocene]") end
 
     assert_raise UndefinedFunctionError, fn ->
       Code.eval_string("~D[2000-01-01 UnknownCalendar]")

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -6,11 +6,38 @@ defmodule DateTest do
   use ExUnit.Case, async: true
   doctest Date
 
-  test "to_string/1" do
-    assert to_string(~D[2000-01-01]) == "2000-01-01"
+  test "sigil_D" do
+    assert ~D[2000-01-01] ==
+             %Date{calendar: Calendar.ISO, year: 2000, month: 1, day: 1}
 
-    date = %{~D[2000-01-01] | calendar: FakeCalendar}
-    assert to_string(date) == "boom"
+    assert ~D[2000-01-01 Calendar.Holocene] ==
+             %Date{calendar: Calendar.Holocene, year: 2000, month: 1, day: 1}
+
+    assert_raise ArgumentError,
+                 ~s/cannot parse "2000-50-50" as Date for Calendar.ISO, reason: :invalid_date/,
+                 fn -> Code.eval_string("~D[2000-50-50]") end
+
+    assert_raise ArgumentError,
+                 ~s/cannot parse "2000-50-50 notalias" as Date for Calendar.ISO, reason: :invalid_format/,
+                 fn -> Code.eval_string("~D[2000-50-50 notalias]") end
+
+    assert_raise ArgumentError,
+                 ~s/cannot parse "2000-50-50" as Date for Calendar.Holocene, reason: :invalid_date/,
+                 fn -> Code.eval_string("~D[2000-50-50 Calendar.Holocene]") end
+
+    assert_raise UndefinedFunctionError, fn ->
+      Code.eval_string("~D[2000-01-01 UnknownCalendar]")
+    end
+  end
+
+  test "to_string/1" do
+    date = ~D[2000-01-01]
+    assert to_string(date) == "2000-01-01"
+    assert Date.to_string(date) == "2000-01-01"
+    assert Date.to_string(Map.from_struct(date)) == "2000-01-01"
+
+    assert to_string(%{date | calendar: FakeCalendar}) == "1/1/2000"
+    assert Date.to_string(%{date | calendar: FakeCalendar}) == "1/1/2000"
   end
 
   test "Kernel.inspect/1" do
@@ -18,7 +45,7 @@ defmodule DateTest do
     assert inspect(~D[-0100-12-31]) == "~D[-0100-12-31]"
 
     date = %{~D[2000-01-01] | calendar: FakeCalendar}
-    assert inspect(date) == "%Date{calendar: FakeCalendar, day: 1, month: 1, year: 2000}"
+    assert inspect(date) == "~D[1/1/2000 FakeCalendar]"
   end
 
   test "compare/2" do

--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -136,6 +136,33 @@ defmodule DateTimeTest do
              "29/2/2000F23::0::7 Brazil/Manaus BRM -12600 3600"
   end
 
+  test "inspect/1" do
+    utc_datetime = ~U[2000-01-01 23:00:07.005Z]
+    assert inspect(utc_datetime) == "~U[2000-01-01 23:00:07.005Z]"
+
+    assert inspect(%{utc_datetime | calendar: FakeCalendar}) ==
+             "~U[1/1/2000F23::0::7 Etc/UTC UTC 0 0 FakeCalendar]"
+
+    datetime = %DateTime{
+      year: 2000,
+      month: 2,
+      day: 29,
+      zone_abbr: "BRM",
+      hour: 23,
+      minute: 0,
+      second: 7,
+      microsecond: {0, 0},
+      utc_offset: -12600,
+      std_offset: 3600,
+      time_zone: "Brazil/Manaus"
+    }
+
+    assert inspect(datetime) == "#DateTime<2000-02-29 23:00:07-02:30 BRM Brazil/Manaus>"
+
+    assert inspect(%{datetime | calendar: FakeCalendar}) ==
+             "#DateTime<29/2/2000F23::0::7 Brazil/Manaus BRM -12600 3600 FakeCalendar>"
+  end
+
   test "from_iso8601/1 handles positive and negative offsets" do
     assert DateTime.from_iso8601("2015-01-24T09:50:07-10:00") |> elem(1) ==
              %DateTime{

--- a/lib/elixir/test/elixir/calendar/fakes.exs
+++ b/lib/elixir/test/elixir/calendar/fakes.exs
@@ -1,8 +1,28 @@
 defmodule FakeCalendar do
-  def date_to_string(_, _, _), do: "boom"
-  def time_to_string(_, _, _, _), do: "boom"
-  def naive_datetime_to_string(_, _, _, _, _, _, _), do: "boom"
-  def datetime_to_string(_, _, _, _, _, _, _, _, _, _), do: "boom"
+  def time_to_string(hour, minute, second, _), do: "#{hour}::#{minute}::#{second}"
+  def date_to_string(year, month, day), do: "#{day}/#{month}/#{year}"
+
+  def naive_datetime_to_string(year, month, day, hour, minute, second, microsecond) do
+    date_to_string(year, month, day) <> "F" <> time_to_string(hour, minute, second, microsecond)
+  end
+
+  def datetime_to_string(
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        microsecond,
+        time_zone,
+        abbr,
+        utc_offset,
+        std_offset
+      ) do
+    naive_datetime_to_string(year, month, day, hour, minute, second, microsecond) <>
+      " #{time_zone} #{abbr} #{utc_offset} #{std_offset}"
+  end
+
   def day_rollover_relative_to_midnight_utc, do: {123_456, 123_457}
 end
 

--- a/lib/elixir/test/elixir/calendar/holocene.exs
+++ b/lib/elixir/test/elixir/calendar/holocene.exs
@@ -24,13 +24,13 @@ defmodule Calendar.Holocene do
 
   @impl true
   def date_to_string(year, month, day) do
-    "#{year}-#{month}-#{day} (HE)"
+    "#{year}-#{zero_pad(month, 2)}-#{zero_pad(day, 2)}"
   end
 
   @impl true
   def naive_datetime_to_string(year, month, day, hour, minute, second, microsecond) do
-    "#{year}-#{month}-#{day}" <>
-      Calendar.ISO.time_to_string(hour, minute, second, microsecond) <> " (HE)"
+    "#{year}-#{zero_pad(month, 2)}-#{zero_pad(day, 2)}" <>
+      Calendar.ISO.time_to_string(hour, minute, second, microsecond)
   end
 
   @impl true
@@ -47,8 +47,9 @@ defmodule Calendar.Holocene do
         _utc_offset,
         _std_offset
       ) do
-    "#{year}-#{month}-#{day}" <>
-      Calendar.ISO.time_to_string(hour, minute, second, microsecond) <> " #{zone_abbr} (HE)"
+    "#{year}-#{zero_pad(month, 2)}-#{zero_pad(day, 2)}" <>
+      Calendar.ISO.time_to_string(hour, minute, second, microsecond) <>
+      " #{zone_abbr}"
   end
 
   @impl true
@@ -77,6 +78,43 @@ defmodule Calendar.Holocene do
       microsecond
     )
   end
+
+  defp zero_pad(val, count) when val >= 0 do
+    String.pad_leading("#{val}", count, ["0"])
+  end
+
+  defp zero_pad(val, count) do
+    "-" <> zero_pad(-val, count)
+  end
+
+  @impl true
+  def parse_date(string) do
+    {year, month, day} =
+      string
+      |> String.split("-")
+      |> Enum.map(&String.to_integer/1)
+      |> List.to_tuple()
+
+    if valid_date?(year, month, day) do
+      {:ok, {year, month, day}}
+    else
+      {:error, :invalid_date}
+    end
+  end
+
+  @impl true
+  def valid_date?(year, month, day) do
+    :calendar.valid_date(year, month, day)
+  end
+
+  @impl true
+  defdelegate parse_time(string), to: Calendar.ISO
+
+  @impl true
+  defdelegate parse_naive_datetime(string), to: Calendar.ISO
+
+  @impl true
+  defdelegate parse_utc_datetime(string), to: Calendar.ISO
 
   @impl true
   defdelegate time_from_day_fraction(day_fraction), to: Calendar.ISO
@@ -107,21 +145,6 @@ defmodule Calendar.Holocene do
 
   @impl true
   defdelegate day_of_era(year, month, day), to: Calendar.ISO
-
-  @impl true
-  defdelegate parse_time(string), to: Calendar.ISO
-
-  @impl true
-  defdelegate parse_date(string), to: Calendar.ISO
-
-  @impl true
-  defdelegate parse_naive_datetime(string), to: Calendar.ISO
-
-  @impl true
-  defdelegate parse_utc_datetime(string), to: Calendar.ISO
-
-  @impl true
-  defdelegate valid_date?(year, month, day), to: Calendar.ISO
 
   @impl true
   defdelegate valid_time?(hour, minute, second, microsecond), to: Calendar.ISO

--- a/lib/elixir/test/elixir/calendar/holocene.exs
+++ b/lib/elixir/test/elixir/calendar/holocene.exs
@@ -109,6 +109,9 @@ defmodule Calendar.Holocene do
   defdelegate day_of_era(year, month, day), to: Calendar.ISO
 
   @impl true
+  defdelegate parse_time(string), to: Calendar.ISO
+
+  @impl true
   defdelegate parse_date(string), to: Calendar.ISO
 
   @impl true

--- a/lib/elixir/test/elixir/calendar/holocene.exs
+++ b/lib/elixir/test/elixir/calendar/holocene.exs
@@ -109,9 +109,16 @@ defmodule Calendar.Holocene do
   defdelegate day_of_era(year, month, day), to: Calendar.ISO
 
   @impl true
-  def valid_date?(year, month, day) do
-    :calendar.valid_date(year, month, day)
-  end
+  defdelegate parse_date(string), to: Calendar.ISO
+
+  @impl true
+  defdelegate parse_naive_datetime(string), to: Calendar.ISO
+
+  @impl true
+  defdelegate parse_utc_datetime(string), to: Calendar.ISO
+
+  @impl true
+  defdelegate valid_date?(year, month, day), to: Calendar.ISO
 
   @impl true
   defdelegate valid_time?(hour, minute, second, microsecond), to: Calendar.ISO

--- a/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
@@ -92,7 +92,7 @@ defmodule NaiveDateTimeTest do
     assert to_string(ndt) == "1/1/2000F23::0::7"
   end
 
-  test "Kernel.inspect/1" do
+  test "inspect/1" do
     assert inspect(~N[2000-01-01 23:00:07.005]) == "~N[2000-01-01 23:00:07.005]"
     assert inspect(~N[-0100-12-31 23:00:07.005]) == "~N[-0100-12-31 23:00:07.005]"
 

--- a/lib/elixir/test/elixir/calendar/time_test.exs
+++ b/lib/elixir/test/elixir/calendar/time_test.exs
@@ -40,7 +40,7 @@ defmodule TimeTest do
     assert Time.to_string(%{time | calendar: FakeCalendar}) == "23::0::7"
   end
 
-  test "Kernel.inspect/1" do
+  test "inspect/1" do
     assert inspect(~T[23:00:07.005]) == "~T[23:00:07.005]"
 
     time = %{~T[23:00:07.005] | calendar: FakeCalendar}


### PR DESCRIPTION
This is the first step in the extended sigils.

It is similar to what @kipcole9 had but I moved the whole `from_iso8601` code to the `Calendar.ISO` module. Also, the idea is that the parsing functions will be counterparts to the `_to_string` functions, so we don't need to have both `_to_string` and `_inspect`. Once we inspect each date, we will automatically inspect them as:

    "#{calendar.type_to_string(...)} #{calendar}"

Without special handling for Calendar.ISO (except by hiding the Calendar.ISO part).

I still need to do a couple things to finish this:

  * [x] Add parse_time to the contract too
  * [x] Change the sigils to use the calendar callback
  * [x] Support calendars in the sigils (both when building and when parsing)

Initial feedback is welcome before we move forward, especially on the function names.

/cc @kipcole9 @wojtekmach 