### PR TITLE
Make clear Stream.transform is *only* about shape transformation

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -809,13 +809,13 @@ defmodule Stream do
   many of the functions defined in this module. For example, we can implement
   `Stream.take(enum, n)` as follows:
 
-      iex> enum = 1..100
+      iex> enum = 1001..9999
       iex> n = 3
       iex> stream = Stream.transform(enum, 0, fn i, acc ->
       ...>   if acc < n, do: {[i], acc + 1}, else: {:halt, acc}
       ...> end)
       iex> Enum.to_list(stream)
-      [1, 2, 3]
+      [1001, 1002, 1003]
 
   """
   @spec transform(Enumerable.t(), acc, fun) :: Enumerable.t()

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -793,7 +793,7 @@ defmodule Stream do
   end
 
   @doc """
-  Transforms an existing stream.
+  Transforms shape an existing stream.
 
   It expects an accumulator and a function that receives each stream element
   and an accumulator, and must return a tuple containing a new stream
@@ -803,6 +803,8 @@ defmodule Stream do
   Note: this function is similar to `Enum.flat_map_reduce/3` except the
   latter returns both the flat list and accumulator, while this one returns
   only the stream.
+
+  Original elements of the stream will not be modified.
 
   ## Examples
 

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -793,18 +793,15 @@ defmodule Stream do
   end
 
   @doc """
-  Transforms shape an existing stream.
+  Transforms an existing stream.
 
   It expects an accumulator and a function that receives each stream element
-  and an accumulator, and must return a tuple containing a new stream
-  (often a list) with the new accumulator or a tuple with `:halt` as first
-  element and the accumulator as second.
+  and an accumulator. It must return a tuple, where the first element is a new
+  stream (often a list) or the atom `:halt`, and the second element is the
+  accumulator to be used by the next element, if any, in both cases.
 
-  Note: this function is similar to `Enum.flat_map_reduce/3` except the
-  latter returns both the flat list and accumulator, while this one returns
-  only the stream.
-
-  Original elements of the stream will not be modified.
+  Note: this function is equivalent to `Enum.flat_map_reduce/3`, except this
+  function does not return the accumulator once the stream is procecssed.
 
   ## Examples
 


### PR DESCRIPTION
Was clear that it modifed stream shape.  *However*, we thought changing element return was also possible.

Took a little bit of tinkering, discussion with @tonyvanriet, and finally looking at implementation before we realized the accumulator was discarded.

Am happy to have the PR discarded or language changed.  Just want to prevent the same misunderstanding for future readers of the docs. 