### PR TITLE
Update Calendar.Holocene to_string/1 and parse_date/1

### DIFF
--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -13,6 +13,9 @@ defmodule DateTest do
     assert ~D[2000-01-01 Calendar.Holocene] ==
              %Date{calendar: Calendar.Holocene, year: 2000, month: 1, day: 1}
 
+    assert ~D[10001-01-01 Calendar.Holocene] ==
+             %Date{calendar: Calendar.Holocene, year: 10001, month: 1, day: 1}
+
     assert_raise ArgumentError,
                  ~s/cannot parse "2000-50-50" as Date for Calendar.ISO, reason: :invalid_date/,
                  fn -> Code.eval_string("~D[2000-50-50]") end
@@ -46,6 +49,12 @@ defmodule DateTest do
 
     date = %{~D[2000-01-01] | calendar: FakeCalendar}
     assert inspect(date) == "~D[1/1/2000 FakeCalendar]"
+  end
+
+  test "inspect/1 roundtrip to to_string/1" do
+    test_string = "~D[2000-01-01 Calendar.Holocene]"
+    {date, []} = Code.eval_string(test_string)
+    assert inspect(date) == test_string
   end
 
   test "compare/2" do

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -48,12 +48,6 @@ defmodule DateTest do
     assert inspect(date) == "~D[1/1/2000 FakeCalendar]"
   end
 
-  test "inspect/1 roundtrip to to_string/1" do
-    test_string = "~D[20001-01-01 Calendar.Holocene]"
-    {date, []} = Code.eval_string(test_string)
-    assert inspect(date) == test_string
-  end
-
   test "compare/2" do
     date1 = ~D[-0001-12-30]
     date2 = ~D[-0001-12-31]

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -10,11 +10,8 @@ defmodule DateTest do
     assert ~D[2000-01-01] ==
              %Date{calendar: Calendar.ISO, year: 2000, month: 1, day: 1}
 
-    assert ~D[2000-01-01 Calendar.Holocene] ==
-             %Date{calendar: Calendar.Holocene, year: 2000, month: 1, day: 1}
-
-    assert ~D[10001-01-01 Calendar.Holocene] ==
-             %Date{calendar: Calendar.Holocene, year: 10001, month: 1, day: 1}
+    assert ~D[20001-01-01 Calendar.Holocene] ==
+             %Date{calendar: Calendar.Holocene, year: 20001, month: 1, day: 1}
 
     assert_raise ArgumentError,
                  ~s/cannot parse "2000-50-50" as Date for Calendar.ISO, reason: :invalid_date/,
@@ -25,8 +22,8 @@ defmodule DateTest do
                  fn -> Code.eval_string("~D[2000-50-50 notalias]") end
 
     assert_raise ArgumentError,
-                 ~s/cannot parse "2000-50-50" as Date for Calendar.Holocene, reason: :invalid_date/,
-                 fn -> Code.eval_string("~D[2000-50-50 Calendar.Holocene]") end
+                 ~s/cannot parse "20001-50-50" as Date for Calendar.Holocene, reason: :invalid_date/,
+                 fn -> Code.eval_string("~D[20001-50-50 Calendar.Holocene]") end
 
     assert_raise UndefinedFunctionError, fn ->
       Code.eval_string("~D[2000-01-01 UnknownCalendar]")
@@ -52,7 +49,7 @@ defmodule DateTest do
   end
 
   test "inspect/1 roundtrip to to_string/1" do
-    test_string = "~D[2000-01-01 Calendar.Holocene]"
+    test_string = "~D[20001-01-01 Calendar.Holocene]"
     {date, []} = Code.eval_string(test_string)
     assert inspect(date) == test_string
   end

--- a/lib/elixir/test/elixir/calendar/holocene.exs
+++ b/lib/elixir/test/elixir/calendar/holocene.exs
@@ -80,8 +80,7 @@ defmodule Calendar.Holocene do
   end
 
   defp zero_pad(val, count) when val >= 0 do
-    num = Integer.to_string(val)
-    :binary.copy("0", max(count - byte_size(num), 0)) <> num
+    String.pad_leading("#{val}", count, ["0"])
   end
 
   defp zero_pad(val, count) do

--- a/lib/elixir/test/elixir/calendar/holocene.exs
+++ b/lib/elixir/test/elixir/calendar/holocene.exs
@@ -104,16 +104,8 @@ defmodule Calendar.Holocene do
   end
 
   @impl true
-  def valid_date?(year, month, day) when year >= 10_000 do
-    Calendar.ISO.valid_date?(year - 10_000, month, day)
-  end
-
-  def valid_date?(year, month, day) when year <= -10_000 do
-    Calendar.ISO.valid_date?(year + 10_000, month, day)
-  end
-
   def valid_date?(year, month, day) do
-    Calendar.ISO.valid_date?(year, month, day)
+    :calendar.valid_date(year, month, day)
   end
 
   @impl true

--- a/lib/elixir/test/elixir/calendar/holocene.exs
+++ b/lib/elixir/test/elixir/calendar/holocene.exs
@@ -24,13 +24,13 @@ defmodule Calendar.Holocene do
 
   @impl true
   def date_to_string(year, month, day) do
-    "#{year}-#{month}-#{day} (HE)"
+    "#{year}-#{zero_pad(month, 2)}-#{zero_pad(day, 2)}"
   end
 
   @impl true
   def naive_datetime_to_string(year, month, day, hour, minute, second, microsecond) do
-    "#{year}-#{month}-#{day}" <>
-      Calendar.ISO.time_to_string(hour, minute, second, microsecond) <> " (HE)"
+    "#{year}-#{zero_pad(month, 2)}-#{zero_pad(day, 2)}" <>
+      Calendar.ISO.time_to_string(hour, minute, second, microsecond)
   end
 
   @impl true
@@ -47,8 +47,9 @@ defmodule Calendar.Holocene do
         _utc_offset,
         _std_offset
       ) do
-    "#{year}-#{month}-#{day}" <>
-      Calendar.ISO.time_to_string(hour, minute, second, microsecond) <> " #{zone_abbr} (HE)"
+    "#{year}-#{zero_pad(month, 2)}-#{zero_pad(day, 2)}" <>
+      Calendar.ISO.time_to_string(hour, minute, second, microsecond) <>
+      " #{zone_abbr}"
   end
 
   @impl true
@@ -77,6 +78,52 @@ defmodule Calendar.Holocene do
       microsecond
     )
   end
+
+  defp zero_pad(val, count) when val >= 0 do
+    num = Integer.to_string(val)
+    :binary.copy("0", max(count - byte_size(num), 0)) <> num
+  end
+
+  defp zero_pad(val, count) do
+    "-" <> zero_pad(-val, count)
+  end
+
+  @impl true
+  def parse_date(string) do
+    {year, month, day} =
+      string
+      |> String.split("-")
+      |> Enum.map(&String.to_integer/1)
+      |> List.to_tuple()
+
+    if valid_date?(year, month, day) do
+      {:ok, {year, month, day}}
+    else
+      {:error, :invalid_date}
+    end
+  end
+
+  @impl true
+  def valid_date?(year, month, day) when year >= 10_000 do
+    Calendar.ISO.valid_date?(year - 10_000, month, day)
+  end
+
+  def valid_date?(year, month, day) when year <= -10_000 do
+    Calendar.ISO.valid_date?(year + 10_000, month, day)
+  end
+
+  def valid_date?(year, month, day) do
+    Calendar.ISO.valid_date?(year, month, day)
+  end
+
+  @impl true
+  defdelegate parse_time(string), to: Calendar.ISO
+
+  @impl true
+  defdelegate parse_naive_datetime(string), to: Calendar.ISO
+
+  @impl true
+  defdelegate parse_utc_datetime(string), to: Calendar.ISO
 
   @impl true
   defdelegate time_from_day_fraction(day_fraction), to: Calendar.ISO
@@ -107,21 +154,6 @@ defmodule Calendar.Holocene do
 
   @impl true
   defdelegate day_of_era(year, month, day), to: Calendar.ISO
-
-  @impl true
-  defdelegate parse_time(string), to: Calendar.ISO
-
-  @impl true
-  defdelegate parse_date(string), to: Calendar.ISO
-
-  @impl true
-  defdelegate parse_naive_datetime(string), to: Calendar.ISO
-
-  @impl true
-  defdelegate parse_utc_datetime(string), to: Calendar.ISO
-
-  @impl true
-  defdelegate valid_date?(year, month, day), to: Calendar.ISO
 
   @impl true
   defdelegate valid_time?(hour, minute, second, microsecond), to: Calendar.ISO


### PR DESCRIPTION
This commit updates the test Calendar.Holocene module:
1. to_string/1 removes the "Calendar.Holocene" annotation
in the output string. This is somewhat
problematic because calling `to_string/1` on a date now no
longer emits anything which identifies what calendar it is in.

2. Implements a simple `parse_date/1` function to allow
basic testing of years >= 10_000 and <= -10_000