### PR TITLE
Update docs for Kernel.SpecialForms.case/2

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1752,13 +1752,17 @@ defmodule Kernel.SpecialForms do
 
       value = 7
 
-      case result do
-        :ok -> value = value + 1
-        :error -> value = value - 1
+      case lucky? do
+        false -> value = 13
+        true -> true
       end
 
       value
       #=> 7
+
+  In the example above, `value` is going to be `7` regardless of the value of
+  `lucky?`. The variable `value` bound in the clause and the variable `value`
+  bound in the outer context are two entirely separate variables.
 
   If you want to pattern match against an existing variable,
   you need to use the `^/1` operator:

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -1737,8 +1737,7 @@ defmodule Kernel.SpecialForms do
 
   ## Variable handling
 
-  Notice that variables bound in a clause "head" do not leak to the
-  outer context:
+  Notice that variables bound in a clause do not leak to the outer context:
 
       case data do
         {:ok, value} -> value
@@ -1748,23 +1747,18 @@ defmodule Kernel.SpecialForms do
       value
       #=> unbound variable value
 
-  However, variables explicitly bound in the clause "body" are
-  accessible from the outer context:
+  When binding variables with the same names as variables in the outer context,
+  the variables in the outer context are not affected.
 
       value = 7
 
-      case lucky? do
-        false -> value = 13
-        true -> true
+      case result do
+        :ok -> value = value + 1
+        :error -> value = value - 1
       end
 
       value
-      #=> 7 or 13
-
-  In the example above, `value` is going to be `7` or `13` depending on
-  the value of `lucky?`. In case `value` has no previous value before
-  case, clauses that do not explicitly bind a value have the variable
-  bound to `nil`.
+      #=> 7
 
   If you want to pattern match against an existing variable,
   you need to use the `^/1` operator:


### PR DESCRIPTION
In the docs for `case/2`, there's a [section about variable scope](https://hexdocs.pm/elixir/Kernel.SpecialForms.html#case/2-variable-handling) that doesn't seem accurate to me:

> However, variables explicitly bound in the clause "body" are accessible from the outer context:
> ```elixir
> value = 7
>
> case lucky? do
>   false -> value = 13
>   true -> true
> end
>
> value
> #=> 7 or 13
> ```

When attempting the `lucky? = false` case in IEx, `value` in the outer context is `7`, not `13`:

```elixir
Erlang/OTP 22 [erts-10.4] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe]

Interactive Elixir (1.9.1) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> lucky? = false
false
iex(2)> value = 7
7
iex(3)> case lucky? do
...(3)>   false -> value = 13
...(3)>   true -> true
...(3)> end
warning: variable "value" is unused (if the variable is not meant to be used, prefix it with an underscore)
  iex:4

13
iex(4)> value
7
```

I drafted some pretty minimal corrections. Would it be helpful to also include an example of rebinding `value` to the result?