### PR TITLE
Allow for multiple paths for apps via apps_path config option

### DIFF
--- a/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/alt_apps/barfoo/lib/barfoo.ex
+++ b/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/alt_apps/barfoo/lib/barfoo.ex
@@ -1,0 +1,13 @@
+defmodule BarFoo do
+  def hello do
+    :world
+  end
+end
+
+defprotocol BarFoo.Protocol do
+  def to_uppercase(string)
+end
+
+defimpl BarFoo.Protocol, for: BitString do
+  def to_uppercase(string), do: String.upcase(string)
+end

--- a/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/alt_apps/barfoo/mix.exs
+++ b/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/alt_apps/barfoo/mix.exs
@@ -1,0 +1,13 @@
+defmodule BarFoo.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :barfoo,
+      version: "0.1.0",
+      # Choose something besides *_test.exs so that these test files don't
+      # get accidentally swept up into the actual Mix test suite.
+      test_pattern: "*_tests.exs"
+    ]
+  end
+end

--- a/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/alt_apps/barfoo/test/barfoo_tests.exs
+++ b/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/alt_apps/barfoo/test/barfoo_tests.exs
@@ -1,0 +1,8 @@
+defmodule BarFooTest do
+  use ExUnit.Case
+
+  test "greets the world" do
+    assert BarFoo.hello() == :world
+    assert BarFoo.Protocol.to_uppercase("foobar") == "FOOBAR"
+  end
+end

--- a/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/alt_apps/barfoo/test/test_helper.exs
+++ b/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/alt_apps/barfoo/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/alt_apps/foobar/lib/foobar.ex
+++ b/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/alt_apps/foobar/lib/foobar.ex
@@ -1,0 +1,5 @@
+defmodule FooBar do
+  def hello do
+    :world
+  end
+end

--- a/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/alt_apps/foobar/mix.exs
+++ b/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/alt_apps/foobar/mix.exs
@@ -1,0 +1,13 @@
+defmodule FooBar.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :foobar,
+      version: "0.1.0",
+      # Choose something besides *_test.exs so that these test files don't
+      # get accidentally swept up into the actual Mix test suite.
+      test_pattern: "*_tests.exs"
+    ]
+  end
+end

--- a/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/alt_apps/foobar/test/foobar_tests.exs
+++ b/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/alt_apps/foobar/test/foobar_tests.exs
@@ -1,0 +1,7 @@
+defmodule FooBarTest do
+  use ExUnit.Case
+
+  test "greets the world" do
+    assert FooBar.hello() == :world
+  end
+end

--- a/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/alt_apps/foobar/test/test_helper.exs
+++ b/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/alt_apps/foobar/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/lib/mix/test/mix/umbrella_test.exs
+++ b/lib/mix/test/mix/umbrella_test.exs
@@ -28,6 +28,21 @@ defmodule Mix.UmbrellaTest do
     end)
   end
 
+  test "apps_paths list with selection" do
+    in_fixture("umbrella_dep/deps/umbrella", fn ->
+      Mix.Project.in_project(
+        :umbrella,
+        ".",
+        [apps: [:foo, :foobar], apps_path: ["apps", "alt_apps"]],
+        fn _ ->
+          File.mkdir_p!("apps/errors")
+          File.write!("apps/errors/mix.exs", "raise :oops")
+          assert Mix.Project.apps_paths() == %{foobar: "alt_apps/foobar", foo: "apps/foo"}
+        end
+      )
+    end)
+  end
+
   test "umbrella app dir and the app name defined in mix.exs should be equal" do
     in_fixture("umbrella_dep/deps/umbrella", fn ->
       Mix.Project.in_project(:umbrella, ".", fn _ ->


### PR DESCRIPTION
First off, this definitely needs more documentation, but neither the `:apps_path` or `:apps` configuration options seem to be detailed anywhere but in `Mix.Project.apps_paths/1`.

Now, onto the thing. At work we want to organise our umbrella into a folder hierarchy that lets us more clearly separate different domains, such a service and library code. So, for example, we might want to do either of the following:

```
awesome_app1/ # umbrella app
  apps/services
  apps/libraries

awesome_app2/ # umbrella app
 services
 libraries
```

Currently mix doesn't really seem to play nice with this. You can only specify a single folder, and you can't nest things as there won't be any recursion. This code changes that.

Now you can specify any number of folders that can contain apps, with the only caveat being that you can *only* place Elixir applications in leaf folders. So you can do:

```
awesome_app1/ # umbrella app
  apps/services/foo # app
  apps/libraries/bar # app
```

But you cannot do:
```
awesome_app2/ # umbrella app
 apps/services/foo # app in a folder which contains a folder that is not an app
 apps/services/super_apps/bar # app nested in the same folder as an actual app
```

This code is backwards compatible.