### PR TITLE
Improve MapSet comparison performance

### DIFF
--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -200,16 +200,10 @@ defmodule MapSet do
     |> none_in?(map2)
   end
 
-  defp none_in?([], _) do
-    true
-  end
+  @compile {:inline, [none_in?: 2]}
 
-  defp none_in?([key | rest], map2) do
-    case map2 do
-      %{^key => _} -> false
-      _ -> none_in?(rest, map2)
-    end
-  end
+  defp none_in?([], _), do: true
+  defp none_in?([key | rest], map2), do: not :erlang.is_map_key(key, map2) and none_in?(rest, map2)
 
   @doc """
   Checks if two sets are equal.

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -203,8 +203,6 @@ defmodule MapSet do
     |> none_in?(map2)
   end
 
-  @compile {:inline, [none_in?: 2]}
-
   defp none_in?(:none, _), do: true
 
   defp none_in?({key, _val, iter}, map2) do
@@ -316,8 +314,6 @@ defmodule MapSet do
   def subset?(%MapSet{map: map1}, %MapSet{map: map2}) do
     map_size(map1) <= map_size(map2) and all_in?(map1, map2)
   end
-
-  @compile {:inline, [all_in?: 2]}
 
   defp all_in?(:none, _), do: true
 

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -174,9 +174,10 @@ defmodule MapSet do
   defp filter_not_in([], _map2, acc), do: :maps.from_list(acc)
 
   defp filter_not_in([key | rest], map2, acc) do
-    case map2 do
-      %{^key => _} -> filter_not_in(rest, map2, acc)
-      _ -> filter_not_in(rest, map2, [{key, @dummy_value} | acc])
+    if :erlang.is_map_key(key, map2) do
+      filter_not_in(rest, map2, acc)
+    else
+      filter_not_in(rest, map2, [{key, @dummy_value} | acc])
     end
   end
 
@@ -260,7 +261,7 @@ defmodule MapSet do
   """
   @spec member?(t, value) :: boolean
   def member?(%MapSet{map: map}, value) do
-    match?(%{^value => _}, map)
+    :erlang.is_map_key(value, map)
   end
 
   @doc """
@@ -320,7 +321,7 @@ defmodule MapSet do
   defp map_subset?([], _), do: true
 
   defp map_subset?([key | rest], map2) do
-    match?(%{^key => _}, map2) and map_subset?(rest, map2)
+    :erlang.is_map_key(key, map2) and map_subset?(rest, map2)
   end
 
   @doc """

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -151,9 +151,8 @@ defmodule MapSet do
   @spec difference(t(val1), t(val2)) :: t(val1) when val1: value, val2: value
   def difference(map_set1, map_set2)
 
-  # If the first set is less than twice the size of the second map,
-  # it is fastest to re-accumulate elements in the first set that are not
-  # present in the second set.
+  # If the first set is less than twice the size of the second map, it is fastest
+  # to re-accumulate elements in the first set that are not present in the second set.
   def difference(%MapSet{map: map1}, %MapSet{map: map2})
       when map_size(map1) < map_size(map2) * 2 do
     map =


### PR DESCRIPTION
This changes the implementation of none_in?/2 (and a few other functions) from `match?` or a pin match to the :erlang.is_map_set/2 BIF. For `disjoint?/2` the result is 1.08x faster, according to benchmarks. Due to the use of `is_map_key` this change only works in Erlang 21.0+.

Benchmark using MapSets with 100 random keys, checking for a worst case match of the 100th key:

```
Operating System: macOS
CPU Information: Intel(R) Core(TM) i5-7360U CPU @ 2.30GHz
Number of Available Cores: 4
Available memory: 8 GB
Elixir 1.9.1
Erlang 22.0

Benchmark suite executing with the following configuration:
warmup: 1 s
time: 4 s
memory time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 10 s

Benchmarking CustomMapSet...
Benchmarking MapSet...

Name                   ips        average  deviation         median         99th %
CustomMapSet        3.20 M      312.87 ns  ±9070.45%           0 ns        1000 ns
MapSet              2.95 M      338.53 ns  ±8711.10%           0 ns        1000 ns

Comparison:
CustomMapSet        3.20 M
MapSet              2.95 M - 1.08x slower +25.66 ns
```

I also tested this with a `:maps.iterator/1` and `:maps.next/3` based version, but the results were a fair bit slower with a medium sized set:

```
Name                        ips        average  deviation         median         99th %
CustomMapSet             3.08 M      324.89 ns  ±8159.84%           0 ns        1000 ns
MapSet                   2.17 M      461.64 ns  ±4836.36%           0 ns        1000 ns
```

For a larger set using `iterator` may be worth it due to the constant memory usage.

Edit: I made some modifications to the benchmarks and checked with a larger set of 1000 items instead of 100. There is a much bigger improvement with an iterator:

```
Name                   ips        average  deviation         median         99th %
CustomMapSet        1.92 M        0.52 μs  ±4863.44%           0 μs           1 μs
MapSet             0.127 M        7.87 μs   ±107.59%           7 μs          27 μs

Comparison:
CustomMapSet        1.92 M
MapSet             0.127 M - 15.11x slower +7.35 μs
```