### PR TITLE
Ensure reproducible builds (boostrapping issue)

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4426,14 +4426,18 @@ defmodule Kernel do
         defoverridable message: 1
 
         @impl true
-        def exception(msg) when is_binary(msg) do
+        def exception(msg) when Kernel.is_binary(msg) do
           exception(message: msg)
         end
       end
 
       # TODO: Change the implementation on v2.0 to simply call Kernel.struct!/2
+      # Calls to Kernel functions must be fully-qualified to ensure
+      # reproducible builds; otherwise, this macro will generate ASTs
+      # with different metadata (:import, :context) depending on if
+      # it is the bootstrapped version or not.
       @impl true
-      def exception(args) when is_list(args) do
+      def exception(args) when Kernel.is_list(args) do
         struct = __struct__()
         {valid, invalid} = Enum.split_with(args, fn {k, _} -> Map.has_key?(struct, k) end)
 
@@ -4444,9 +4448,9 @@ defmodule Kernel do
           _ ->
             IO.warn(
               "the following fields are unknown when raising " <>
-                "#{inspect(__MODULE__)}: #{inspect(invalid)}. " <>
+                "#{Kernel.inspect(__MODULE__)}: #{Kernel.inspect(invalid)}. " <>
                 "Please make sure to only give known fields when raising " <>
-                "or redefine #{inspect(__MODULE__)}.exception/1 to " <>
+                "or redefine #{Kernel.inspect(__MODULE__)}.exception/1 to " <>
                 "discard unknown fields. Future Elixir versions will raise on " <>
                 "unknown fields given to raise/2"
             )


### PR DESCRIPTION
During bootstrap, the generated AST for the `defexception` macro does not include import metadata when calling to Kernel functions without using the qualified name. That's not the case when the Kernel is later recompiled.

When compiling the standard library, exceptions like `FunctionClauseError` were generating different ASTs (different metadata) depending on if they were compiled with the bootstrapped Kernel or the later compiled one.

This was spotted during the migration to Cirrus CI, in which the `check_reproducible` check was failing. I managed to create a "BEAM diff" (PR upcoming) that showed these results:

```
94,95c94
<                 {{:., [], [:erlang, :is_list]},
<                  [line: 1063, context: Kernel, import: Kernel],
---
>                 {{:., [], [:erlang, :is_list]}, [line: 1063],
163,168c162,163
<                                     {{:., [], [Kernel, :inspect]},
<                                      [
<                                        line: 1063,
<                                        context: Kernel,
<                                        import: Kernel
<                                      ], [FunctionClauseError]},
---
>                                     {{:., [], [Kernel, :inspect]}, [line: 1063],
>                                      [FunctionClauseError]},
174,179c169
<                                     {{:., [], [Kernel, :inspect]},
<                                      [
<                                        line: 1063,
<                                        context: Kernel,
<                                        import: Kernel
<                                      ],
---
>                                     {{:., [], [Kernel, :inspect]}, [line: 1063],
199,204c189,190
<                                     {{:., [], [Kernel, :inspect]},
<                                      [
<                                        line: 1063,
<                                        context: Kernel,
<                                        import: Kernel
<                                      ], [FunctionClauseError]},
---
>                                     {{:., [], [Kernel, :inspect]}, [line: 1063],
>                                      [FunctionClauseError]},
```