### PR TITLE
Make release's boot scripts deterministic

### DIFF
--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -529,7 +529,9 @@ defmodule Mix.Release do
         build_app_for_release(app, mode, properties)
       end
 
-    {:ok, {:release, {to_charlist(name), to_charlist(version)}, {:erts, erts_version}, rel_apps}}
+    {:ok,
+     {:release, {to_charlist(name), to_charlist(version)}, {:erts, erts_version},
+      Enum.sort(rel_apps)}}
   catch
     {:error, message} -> {:error, message}
   end

--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -317,12 +317,14 @@ defmodule Mix.Release do
   end
 
   defp build_start_boot(all_apps, specified_apps) do
-    specified_apps ++
-      for(
-        {app, props} <- all_apps,
-        not List.keymember?(specified_apps, app, 0),
-        do: {app, default_mode(props)}
-      )
+    Enum.sort(
+      specified_apps ++
+        for(
+          {app, props} <- all_apps,
+          not List.keymember?(specified_apps, app, 0),
+          do: {app, default_mode(props)}
+        )
+    )
   end
 
   defp default_mode(props) do
@@ -529,9 +531,7 @@ defmodule Mix.Release do
         build_app_for_release(app, mode, properties)
       end
 
-    {:ok,
-     {:release, {to_charlist(name), to_charlist(version)}, {:erts, erts_version},
-      Enum.sort(rel_apps)}}
+    {:ok, {:release, {to_charlist(name), to_charlist(version)}, {:erts, erts_version}, rel_apps}}
   catch
     {:error, message} -> {:error, message}
   end

--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -335,7 +335,6 @@ defmodule Mix.Release do
     for({app, _mode} <- boot, do: {app, :none})
     |> Keyword.put(:stdlib, :permanent)
     |> Keyword.put(:kernel, :permanent)
-    |> Enum.sort()
   end
 
   defp validate_steps!(steps) do

--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -335,6 +335,7 @@ defmodule Mix.Release do
     for({app, _mode} <- boot, do: {app, :none})
     |> Keyword.put(:stdlib, :permanent)
     |> Keyword.put(:kernel, :permanent)
+    |> Enum.sort()
   end
 
   defp validate_steps!(steps) do

--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -317,14 +317,14 @@ defmodule Mix.Release do
   end
 
   defp build_start_boot(all_apps, specified_apps) do
-    Enum.sort(
-      specified_apps ++
+    specified_apps ++
+      Enum.sort(
         for(
           {app, props} <- all_apps,
           not List.keymember?(specified_apps, app, 0),
           do: {app, default_mode(props)}
         )
-    )
+      )
   end
 
   defp default_mode(props) do

--- a/lib/mix/test/mix/release_test.exs
+++ b/lib/mix/test/mix/release_test.exs
@@ -337,13 +337,13 @@ defmodule Mix.ReleaseTest do
               [
                 {:release, {'demo', '0.1.0'}, {:erts, @erts_version},
                  [
-                   {:kernel, _, :permanent},
-                   {:stdlib, _, :permanent},
+                   {:compiler, _, :permanent},
                    {:elixir, @elixir_version, :permanent},
-                   {:sasl, _, :permanent},
-                   {:mix, @elixir_version, :permanent},
                    {:iex, @elixir_version, :none},
-                   {:compiler, _, :permanent}
+                   {:kernel, _, :permanent},
+                   {:mix, @elixir_version, :permanent},
+                   {:sasl, _, :permanent},
+                   {:stdlib, _, :permanent}
                  ]}
               ]} = :file.consult(@boot_script_path <> ".rel")
 

--- a/lib/mix/test/mix/release_test.exs
+++ b/lib/mix/test/mix/release_test.exs
@@ -227,13 +227,13 @@ defmodule Mix.ReleaseTest do
       release = release([])
 
       assert release.boot_scripts.start == [
-               kernel: :permanent,
-               stdlib: :permanent,
+               compiler: :permanent,
                elixir: :permanent,
-               sasl: :permanent,
-               mix: :permanent,
                iex: :none,
-               compiler: :permanent
+               kernel: :permanent,
+               mix: :permanent,
+               sasl: :permanent,
+               stdlib: :permanent
              ]
     end
 
@@ -242,28 +242,28 @@ defmodule Mix.ReleaseTest do
       release = release(applications: [eex: :permanent])
 
       assert release.boot_scripts.start == [
-               kernel: :permanent,
-               stdlib: :permanent,
-               elixir: :permanent,
-               sasl: :permanent,
+               compiler: :permanent,
                eex: :permanent,
-               mix: :permanent,
+               elixir: :permanent,
                iex: :none,
-               compiler: :permanent
+               kernel: :permanent,
+               mix: :permanent,
+               sasl: :permanent,
+               stdlib: :permanent
              ]
 
       # Unless explicitly given
       release = release(applications: [mix: :permanent, eex: :permanent])
 
       assert release.boot_scripts.start == [
-               kernel: :permanent,
-               stdlib: :permanent,
-               elixir: :permanent,
-               sasl: :permanent,
-               mix: :permanent,
+               compiler: :permanent,
                eex: :permanent,
+               elixir: :permanent,
                iex: :none,
-               compiler: :permanent
+               kernel: :permanent,
+               mix: :permanent,
+               sasl: :permanent,
+               stdlib: :permanent
              ]
     end
 
@@ -279,13 +279,13 @@ defmodule Mix.ReleaseTest do
       release = release([])
 
       assert release.boot_scripts.start_clean == [
-               kernel: :permanent,
-               stdlib: :permanent,
+               compiler: :none,
                elixir: :none,
-               sasl: :none,
-               mix: :none,
                iex: :none,
-               compiler: :none
+               kernel: :permanent,
+               mix: :none,
+               sasl: :none,
+               stdlib: :permanent
              ]
     end
   end
@@ -417,7 +417,7 @@ defmodule Mix.ReleaseTest do
       {:error, message} = make_boot_script(release, @boot_script_path, release.boot_scripts.start)
 
       assert message =~
-               "Application :stdlib has mode :permanent but it depends on :kernel which is set to :load"
+               "Application :compiler has mode :permanent but it depends on :kernel which is set to :load"
 
       release = release(applications: [elixir: :none])
       {:error, message} = make_boot_script(release, @boot_script_path, release.boot_scripts.start)

--- a/lib/mix/test/mix/release_test.exs
+++ b/lib/mix/test/mix/release_test.exs
@@ -227,13 +227,13 @@ defmodule Mix.ReleaseTest do
       release = release([])
 
       assert release.boot_scripts.start == [
-               compiler: :permanent,
-               elixir: :permanent,
-               iex: :none,
                kernel: :permanent,
-               mix: :permanent,
+               stdlib: :permanent,
+               elixir: :permanent,
                sasl: :permanent,
-               stdlib: :permanent
+               mix: :permanent,
+               iex: :none,
+               compiler: :permanent
              ]
     end
 
@@ -242,28 +242,28 @@ defmodule Mix.ReleaseTest do
       release = release(applications: [eex: :permanent])
 
       assert release.boot_scripts.start == [
-               compiler: :permanent,
-               eex: :permanent,
-               elixir: :permanent,
-               iex: :none,
                kernel: :permanent,
-               mix: :permanent,
+               stdlib: :permanent,
+               elixir: :permanent,
                sasl: :permanent,
-               stdlib: :permanent
+               eex: :permanent,
+               mix: :permanent,
+               iex: :none,
+               compiler: :permanent
              ]
 
       # Unless explicitly given
       release = release(applications: [mix: :permanent, eex: :permanent])
 
       assert release.boot_scripts.start == [
-               compiler: :permanent,
-               eex: :permanent,
-               elixir: :permanent,
-               iex: :none,
                kernel: :permanent,
-               mix: :permanent,
+               stdlib: :permanent,
+               elixir: :permanent,
                sasl: :permanent,
-               stdlib: :permanent
+               mix: :permanent,
+               eex: :permanent,
+               iex: :none,
+               compiler: :permanent
              ]
     end
 
@@ -279,13 +279,13 @@ defmodule Mix.ReleaseTest do
       release = release([])
 
       assert release.boot_scripts.start_clean == [
-               compiler: :none,
-               elixir: :none,
-               iex: :none,
                kernel: :permanent,
-               mix: :none,
+               stdlib: :permanent,
+               elixir: :none,
                sasl: :none,
-               stdlib: :permanent
+               mix: :none,
+               iex: :none,
+               compiler: :none
              ]
     end
   end
@@ -337,13 +337,13 @@ defmodule Mix.ReleaseTest do
               [
                 {:release, {'demo', '0.1.0'}, {:erts, @erts_version},
                  [
-                   {:compiler, _, :permanent},
-                   {:elixir, @elixir_version, :permanent},
-                   {:iex, @elixir_version, :none},
                    {:kernel, _, :permanent},
-                   {:mix, @elixir_version, :permanent},
+                   {:stdlib, _, :permanent},
+                   {:elixir, @elixir_version, :permanent},
                    {:sasl, _, :permanent},
-                   {:stdlib, _, :permanent}
+                   {:mix, @elixir_version, :permanent},
+                   {:iex, @elixir_version, :none},
+                   {:compiler, _, :permanent}
                  ]}
               ]} = :file.consult(@boot_script_path <> ".rel")
 
@@ -417,7 +417,7 @@ defmodule Mix.ReleaseTest do
       {:error, message} = make_boot_script(release, @boot_script_path, release.boot_scripts.start)
 
       assert message =~
-               "Application :compiler has mode :permanent but it depends on :kernel which is set to :load"
+               "Application :stdlib has mode :permanent but it depends on :kernel which is set to :load"
 
       release = release(applications: [elixir: :none])
       {:error, message} = make_boot_script(release, @boot_script_path, release.boot_scripts.start)


### PR DESCRIPTION
`mix.release` generates undeterministic boot script inside the release. This PR sorts applications list before this script is generated. 

More informations here: https://github.com/nerves-project/shoehorn/issues/30
