### PR TITLE
Close unclosed backquotes (backticks)

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2316,7 +2316,7 @@ defmodule Enum do
 
   For this reason, most structs provide a "compare" function, such as
   `Date.compare/2`, which receives two structs and returns `:lt` (less than),
-  `:eq` (equal), and `:gt (greather than). For example, to sort dates
+  `:eq` (equal), and `:gt` (greather than). For example, to sort dates
   increasingly, one would do:
 
       iex> dates = [~D[2019-01-01], ~D[2020-03-02], ~D[2019-06-06]]

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -10,7 +10,7 @@ defmodule String do
 
   In case a string must have a double-quote in itself,
   the double quotes must be escaped with a backslash,
-  for example: `"this is a string with \"double quotes\"".
+  for example: `"this is a string with \"double quotes\""`.
 
   You can concatenate two strings with the `<>/2` operator:
 


### PR DESCRIPTION
ExDoc was giving the following errors:
> lib/elixir/lib/string.ex:250: warning: Closing unclosed backquotes ` at end of input
> lib/elixir/lib/enum.ex:2319: warning: Closing unclosed backquotes ` at end of input