### PR TITLE
add guard to String.replace/4 for better error messages

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1409,7 +1409,7 @@ defmodule String do
     end
   end
 
-  def replace(subject, pattern, replacement, options) when is_binary(subject) do
+  def replace(subject, pattern, replacement, options) when is_binary(subject) and is_list(options) do
     if insert = Keyword.get(options, :insert_replaced) do
       IO.warn(
         "String.replace/4 with :insert_replaced option is deprecated. " <>

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -446,6 +446,14 @@ defmodule StringTest do
     end
   end
 
+  describe "replace/4" do
+    test "with incorrect params" do
+      assert_raise FunctionClauseError, "no function clause matching in String.replace/4", fn ->
+        String.replace("a,b,c", "a,b,c", ",", "")
+      end
+    end
+  end
+
   test "duplicate/2" do
     assert String.duplicate("abc", 0) == ""
     assert String.duplicate("abc", 1) == "abc"


### PR DESCRIPTION
I noticed a [conversation on the elixir google groups](https://groups.google.com/forum/#!topic/elixir-lang-core/XRxRaO_HPZQ) about adding better error handling on `String.replace`. This PR adds in the functionality discussed, along with a test. 

The current way the error is handled:
```
** (FunctionClauseError) no function clause matching in Keyword.get/3

     The following arguments were given to Keyword.get/3:

         # 1
         ""

         # 2
         :insert_replaced

         # 3
         nil

     Attempted function clauses (showing 1 out of 1):

         def get(keywords, key, default) when is_list(keywords) and is_atom(key)

     code: assert String.replace("a,b,c", ",", ",", "") == true
     stacktrace:
       (elixir 1.10.0-dev) lib/keyword.ex:193: Keyword.get/3
       (elixir 1.10.0-dev) lib/elixir/lib/string.ex:1414: String.replace/4
       lib/elixir/test/elixir/string_test.exs:449: (test)
```


After this change:
```
** (FunctionClauseError) no function clause matching in String.replace/4

     The following arguments were given to String.replace/4:

         # 1
         "a,b,c"

         # 2
         ","

         # 3
         ","

         # 4
         ""

     Attempted function clauses (showing 5 out of 5):

         def replace(subject, %{__struct__: Regex} = regex, replacement, options) when is_binary(replacement) or is_function(replacement, 1)
         def replace(subject, "", "", _) when is_binary(subject)
         def replace(subject, "", replacement, options) when is_binary(subject) and is_binary(replacement)
         def replace(subject, "", replacement, options) when is_binary(subject) and is_function(replacement, 1)
         def replace(subject, pattern, replacement, options) when is_binary(subject) and is_list(options)

     code: assert String.replace("a,b,c", ",", ",", "") == true
     stacktrace:
       (elixir 1.10.0-dev) lib/elixir/lib/string.ex:1385: String.replace/4
       lib/elixir/test/elixir/string_test.exs:449: (test)
```

Thanks for all the work you all do