### PR TITLE
ExUnit.Callbacks: Be explicit about the shape of a return value

### DIFF
--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -54,8 +54,8 @@ defmodule ExUnit.Callbacks do
 
   ## Context
 
-  If `setup_all` or `setup` return a keyword list, a map, or `{:ok,
-  keywords | map}`, the keyword list or map will be merged into the
+  If `setup_all` or `setup` return a keyword list, a map, or a tuple in the shape
+  of `{:ok, keyword() | map()}`, the keyword list or map will be merged into the
   current context and will be available in all subsequent `setup_all`,
   `setup`, and the `test` itself.
 


### PR DESCRIPTION
Be explicit and also used a valid typespec (`keywords` is not valid,
but `keyword` is).