### PR TITLE
Raise when passing an empty list instead of clauses

### DIFF
--- a/lib/elixir/src/elixir_clauses.erl
+++ b/lib/elixir/src/elixir_clauses.erl
@@ -308,7 +308,7 @@ expand_clauses(Meta, Kind, Fun, Clauses, E) ->
   NewKind = origin(Meta, Kind),
   expand_clauses_origin(Meta, NewKind, Fun, Clauses, E).
 
-expand_clauses_origin(Meta, Kind, Fun, {Key, Clauses}, E) when is_list(Clauses) ->
+expand_clauses_origin(Meta, Kind, Fun, {Key, [_ | _] = Clauses}, E) when is_list(Clauses) ->
   Transformer = fun(Clause, Acc) ->
     {EClause, EAcc} = clause(Meta, {Kind, Key}, Fun, Clause, Acc),
     {EClause, elixir_env:merge_and_check_unused_vars(Acc, EAcc)}

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -815,6 +815,10 @@ defmodule Kernel.ExpansionTest do
       assert_raise CompileError, ~r"expected -> clauses for :else in \"with\"", fn ->
         expand(quote(do: with(_ <- true, do: :ok, else: :error)))
       end
+
+      assert_raise CompileError, ~r"expected -> clauses for :else in \"with\"", fn ->
+        expand(quote(do: with(_ <- true, do: :ok, else: [])))
+      end
     end
 
     test "fails for invalid options" do
@@ -1853,6 +1857,19 @@ defmodule Kernel.ExpansionTest do
         expand(code)
       end
 
+      assert_raise CompileError, ~r"expected -> clauses for :rescue in \"try\"", fn ->
+        code =
+          quote do
+            try do
+              e
+            rescue
+              []
+            end
+          end
+
+        expand(code)
+      end
+
       assert_raise CompileError, ~r"expected -> clauses for :catch in \"try\"", fn ->
         code =
           quote do
@@ -1873,6 +1890,19 @@ defmodule Kernel.ExpansionTest do
               e
             catch
               [:not, :clauses]
+            end
+          end
+
+        expand(code)
+      end
+
+      assert_raise CompileError, ~r"expected -> clauses for :catch in \"try\"", fn ->
+        code =
+          quote do
+            try do
+              e
+            catch
+              []
             end
           end
 
@@ -1903,6 +1933,21 @@ defmodule Kernel.ExpansionTest do
               _ -> :ok
             else
               [:not, :clauses]
+            end
+          end
+
+        expand(code)
+      end
+
+      assert_raise CompileError, ~r"expected -> clauses for :else in \"try\"", fn ->
+        code =
+          quote do
+            try do
+              e
+            catch
+              _ -> :ok
+            else
+              []
             end
           end
 


### PR DESCRIPTION
This fixes an edge case in which the compiler will process an
empty list value (`[]`) as a block with no clauses, which is not
possible.

Here is an example:

    with {:ok, value} <- Map.fetch(%{a: 1}, :a) do
      value
    else
      []
    end

With this change, the code above will not compile.