### PR TITLE
Standardize use of verbs in bulleted lists

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -294,7 +294,7 @@ defmodule Regex do
 
   ## Options
 
-    * `:return` - set to `:index` to return byte index and match length.
+    * `:return` - when set to `:index`, returns byte index and match length.
       Defaults to `:binary`.
     * `:capture` - what to capture in the result. Check the moduledoc for `Regex`
       to see the possible capture values.
@@ -330,7 +330,7 @@ defmodule Regex do
 
   ## Options
 
-    * `:return` - set to `:index` to return byte index and match length.
+    * `:return` - when set to `:index`, returns byte index and match length.
       Defaults to `:binary`.
 
   ## Examples
@@ -423,7 +423,7 @@ defmodule Regex do
 
   ## Options
 
-    * `:return` - set to `:index` to return byte index and match length.
+    * `:return` - when set to `:index`, returns byte index and match length.
       Defaults to `:binary`.
     * `:capture` - what to capture in the result. Check the moduledoc for `Regex`
       to see the possible capture values.

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -300,7 +300,7 @@ defmodule Registry do
 
   The registry requires the following keys:
 
-    * `:keys` - choose if keys are `:unique` or `:duplicate`
+    * `:keys` - chooses if keys are `:unique` or `:duplicate`
     * `:name` - the name of the registry and its tables
 
   The following keys are optional:

--- a/lib/mix/lib/mix/generator.ex
+++ b/lib/mix/lib/mix/generator.ex
@@ -12,7 +12,7 @@ defmodule Mix.Generator do
   ## Options
 
     * `:force` - forces creation without a shell prompt
-    * `:quiet` - do not log command output
+    * `:quiet` - does not log command output
 
   ## Examples
 
@@ -42,7 +42,7 @@ defmodule Mix.Generator do
 
   ## Options
 
-    * `:quiet` - do not log command output
+    * `:quiet` - does not log command output
 
   ## Examples
 
@@ -67,7 +67,7 @@ defmodule Mix.Generator do
   ## Options
 
     * `:force` - forces copying without a shell prompt
-    * `:quiet` - do not log command output
+    * `:quiet` - does not log command output
 
   ## Examples
 
@@ -93,7 +93,7 @@ defmodule Mix.Generator do
   ## Options
 
     * `:force` - forces copying without a shell prompt
-    * `:quiet` - do not log command output
+    * `:quiet` - does not log command output
 
   ## Examples
 

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -898,7 +898,7 @@ defmodule Mix.Tasks.Release do
     * `--no-compile` - does not compile before assembling the release
     * `--overwrite` - if there is an existing release version, overwrite it
     * `--path` - the path of the release
-    * `--quiet` - do not write progress to the standard output
+    * `--quiet` - does not write progress to the standard output
     * `--version` - the version of the release
 
   """


### PR DESCRIPTION
* Use imperative verbs in bulleted lists
* Use "does not" instead of "do not" in bulleted lists

Related: 690c2c40c948564f7db5fccfd66246ed78c6fe8d

[ci skip]