### PR TITLE
Use double-quotes around sections when referring to them

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2573,7 +2573,7 @@ defmodule Kernel do
       get_and_update_in(struct.foo.bar, &{&1, &1 + 1})
 
   Note that in order for this macro to work, the complete path must always
-  be visible by this macro. See the Paths section below.
+  be visible by this macro. See the "Paths" section below.
 
   ## Examples
 

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -832,7 +832,7 @@ defmodule Kernel.SpecialForms do
     * `:line` - sets the quoted expressions to have the given line.
 
     * `:location` - when set to `:keep`, keeps the current line and file from
-      quote. Read the Stacktrace information section below for more information.
+      quote. Read the "Stacktrace information" section below for more information.
 
     * `:unquote` - when `false`, disables unquoting. This means any `unquote`
       call will be kept as is in the AST, instead of replaced by the `unquote`


### PR DESCRIPTION
[ci skip]