### PR TITLE
Fix typespec for Calendar.ISO.year_of_era/1

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -669,7 +669,7 @@ defmodule Calendar.ISO do
 
   """
   @doc since: "1.8.0"
-  @spec year_of_era(year) :: {year, era :: 0..1}
+  @spec year_of_era(year) :: {pos_integer(), era :: 0..1}
   @impl true
   def year_of_era(year) when is_integer(year) and year > 0 do
     {year, 1}


### PR DESCRIPTION
The return `year` is always a positive number

Dialyzer was giving this error:

> lib/calendar/iso.ex:672: Type specification 'Elixir.Calendar.ISO':year_of_era(year()) -> {year(),era::0..1} is a supertype of the success typing: 'Elixir.Calendar.ISO':year_of_era
          (integer()) -> {pos_integer(), 0 | 1}