### PR TITLE
Fix return value of Calendar.Time.convert/2 typespec

### DIFF
--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -481,7 +481,7 @@ defmodule Time do
 
   """
   @doc since: "1.5.0"
-  @spec convert(Calendar.time(), Calendar.calendar()) :: {:ok, t} | {:error, atom}
+  @spec convert(Calendar.time(), Calendar.calendar()) :: {:ok, t}
 
   # Keep it multiline for proper function clause errors.
   def convert(


### PR DESCRIPTION
It will never return `{:error, atom}`

Dialyzer's error:
 lib/calendar/time.ex:484: The specification for 'Elixir.Time':convert/2 states that the function might also return
          {'error', atom()} but the inferred return is
          {'ok',
           #{'__struct__' := 'Elixir.Time',
             'calendar' := _,
             'hour' := _,
             'microsecond' := _,
             'minute' := _,
             'second' := _}}