### PR TITLE
WIP: Fix return value of Calendar.Time.convert/2

### DIFF
--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -505,7 +505,10 @@ defmodule Time do
     {:ok, time}
   end
 
-  def convert(%{microsecond: {_, precision}} = time, calendar) do
+  def convert(
+        %{hour: _, minute: _, second: _, microsecond: {_, precision}} = time,
+        calendar
+      ) do
     {hour, minute, second, {microsecond, _}} =
       time
       |> to_day_fraction()
@@ -520,6 +523,18 @@ defmodule Time do
     }
 
     {:ok, time}
+  end
+
+  def convert(
+        %{
+          hour: _,
+          minute: _,
+          second: _,
+          microsecond: _
+        },
+        _calendar
+      ) do
+    {:error, :unrecognized_time_format}
   end
 
   @doc """


### PR DESCRIPTION
It would never return `{:error, atom}`,

Dialyzer's errors:
```
 lib/calendar/time.ex:484: The specification for 'Elixir.Time':convert/2 states that the function might also return
          {'error', atom()} but the inferred return is
          {'ok',
           #{'__struct__' := 'Elixir.Time',
             'calendar' := _,
             'hour' := _,
             'microsecond' := _,
             'minute' := _,
             'second' := _}}

lib/calendar/time.ex:546: The pattern
          {'error', _reason@1} can never match the type
          {'ok',
           #{'__struct__' := 'Elixir.Time',
             'calendar' := atom(),
             'hour' := non_neg_integer(),
             'microsecond' := {char(), 0 | 1 | 2 | 3 | 4 | 5 | 6},
             'minute' := non_neg_integer(),
             'second' := non_neg_integer()}}
```

so it also fixes convert!/2