### PR TITLE
Several fixes in Code.format_{string,file}!/2

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -613,7 +613,7 @@ defmodule Code do
   the latter.
   """
   @doc since: "1.6.0"
-  @spec format_string!(binary, keyword) :: iodata
+  @spec format_string!(binary, keyword) :: [binary]
   def format_string!(string, opts \\ []) when is_binary(string) and is_list(opts) do
     line_length = Keyword.get(opts, :line_length, 98)
     algebra = Code.Formatter.to_algebra!(string, opts)
@@ -630,8 +630,7 @@ defmodule Code do
   @spec format_file!(binary, keyword) :: iodata
   def format_file!(file, opts \\ []) when is_binary(file) and is_list(opts) do
     string = File.read!(file)
-    formatted = format_string!(string, [file: file, line: 1] ++ opts)
-    [formatted, ?\n]
+    format_string!(string, [file: file, line: 1] ++ opts) ++ [?\n]
   end
 
   @doc """

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -961,7 +961,6 @@ defmodule Inspect.Algebra do
   defp fits?(w, k, b?, [{i, m, doc_group(x, _)} | t]),
     do: fits?(w, k, b?, [{i, m, x} | {:tail, b?, t}])
 
-  @spec format(integer | :infinity, integer, [{integer, mode, t}]) :: [binary]
   defp format(_, _, []), do: []
   defp format(w, k, [{_, _, :doc_nil} | t]), do: format(w, k, t)
   defp format(w, _, [{i, _, :doc_line} | t]), do: [indent(i) | format(w, i, t)]


### PR DESCRIPTION
Dialyzer's errors:
lib/code.ex:616: The specification for 'Elixir.Code':'format_string!'/2 states that the function might also return
          binary() but the inferred return is
          [binary()]
lib/code.ex:630: The specification for 'Elixir.Code':'format_file!'/2 states that the function might also return
          binary() but the inferred return is
          [[binary()] | 10, ...]

lead make the changes