### PR TITLE
Remove typespecs from private functions

### DIFF
--- a/lib/elixir/lib/dict.ex
+++ b/lib/elixir/lib/dict.ex
@@ -433,7 +433,6 @@ defmodule Dict do
     target(dict).to_list(dict)
   end
 
-  @spec unsupported_dict(t) :: no_return
   defp unsupported_dict(dict) do
     raise ArgumentError, "unsupported dict: #{inspect(dict)}"
   end

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -961,7 +961,6 @@ defmodule Inspect.Algebra do
   defp fits?(w, k, b?, [{i, m, doc_group(x, _)} | t]),
     do: fits?(w, k, b?, [{i, m, x} | {:tail, b?, t}])
 
-  @spec format(integer | :infinity, integer, [{integer, mode, t}]) :: [binary]
   defp format(_, _, []), do: []
   defp format(w, k, [{_, _, :doc_nil} | t]), do: format(w, k, t)
   defp format(w, _, [{i, _, :doc_line} | t]), do: [indent(i) | format(w, i, t)]


### PR DESCRIPTION
The command used to find the offending lines is:
`$ ag "@spec [^\n]+\n\s+def[a-z]*?p "`