### PR TITLE
Add basic mix test partitioning

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -718,7 +718,10 @@ defmodule Mix.Tasks.Test do
     if File.exists?(file) do
       Code.require_file(file)
     else
-      raise_with_shell(shell, "Cannot run tests because test helper file #{inspect(file)} does not exist")
+      raise_with_shell(
+        shell,
+        "Cannot run tests because test helper file #{inspect(file)} does not exist"
+      )
     end
   end
 

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -302,11 +302,11 @@ defmodule Mix.Tasks.Test do
   Elixir instance, it is not always possible to run all tests concurrently. For
   example, some tests may rely on global resources.
 
-  For this reason, `mix test` all supports partitioning the test files across
+  For this reason, `mix test` supports partitioning the test files across
   different Elixir instances. This is done by setting the `--partitions` option
   to an integer, with the number of partitions, and setting the `MIX_TEST_PARTITION`
   environment variable to control which test partition that particular instance
-  is running. This can be also be useful if you want to distribute testing across
+  is running. This can also be useful if you want to distribute testing across
   multiple machines.
 
   For example, to split a test suite into 4 partitions and run them, you would

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -199,7 +199,7 @@ defmodule Mix.Tasks.Test do
 
   ## Configuration
 
-  These configurations can be set in the `def project` section of your `mix.exs:
+  These configurations can be set in the `def project` section of your `mix.exs`:
 
     * `:test_paths` - list of paths containing test files. Defaults to
       `["test"]` if the `test` directory exists; otherwise, it defaults to `[]`.

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -281,6 +281,20 @@ defmodule Mix.Tasks.TestTest do
                  "There are no tests to run"
       end)
     end
+
+    test "raises when no partition is given even with Mix.shell() change" do
+      in_fixture("test_stale", fn ->
+        File.write!("test/test_helper.exs", """
+        Mix.shell(Mix.Shell.Process)
+        ExUnit.start()
+        """)
+
+        assert_run_output(
+          ["--partitions", "4"],
+          "The MIX_TEST_PARTITION environment variable must be set"
+        )
+      end)
+    end
   end
 
   describe "logs and errors" do

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -268,6 +268,21 @@ defmodule Mix.Tasks.TestTest do
     end
   end
 
+  describe "--partitions" do
+    test "splits tests into partitions" do
+      in_fixture("test_stale", fn ->
+        assert mix(["test", "--partitions", "3"], [{"MIX_TEST_PARTITION", "1"}]) =~
+                 "1 test, 0 failures"
+
+        assert mix(["test", "--partitions", "3"], [{"MIX_TEST_PARTITION", "2"}]) =~
+                 "1 test, 0 failures"
+
+        assert mix(["test", "--partitions", "3"], [{"MIX_TEST_PARTITION", "3"}]) =~
+                 "There are no tests to run"
+      end)
+    end
+  end
+
   describe "logs and errors" do
     test "logs test absence for a project with no test paths" do
       in_fixture("test_stale", fn ->


### PR DESCRIPTION
This PR implements the functionality described on step #3 here: https://medium.com/@cblavier/how-we-improved-our-elixir-build-speed-by-5x-d45393c6700f

The rationale is: not all tests can run async (think about tests that change the current directory, for example) so having OS based parallelism is a great help. This can also be used to automate CIs. With this PR, you would be able to do:

    MIX_TEST_PARTITION=1 mix test --partitions 4
    MIX_TEST_PARTITION=2 mix test --partitions 4
    MIX_TEST_PARTITION=3 mix test --partitions 4
    MIX_TEST_PARTITION=4 mix test --partitions 4

Note the partition itself is given as an environment variable so it can, for example, be used to configure a database and other things in config files.

The current implementation simply partitions files but @wojtekmach suggested we can provide better heuristics in the future. For example, we can partition based on slowest tests, in case we want to use the manifest.

Thanks for sharing @cblavier!