### PR TITLE
Add compare support to Enum.sort and add Enum.sort_reverse*

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2436,6 +2436,7 @@ defmodule Enum do
       [3, 2, 1]
 
   """
+  @doc since: "1.10.0"
   @spec sort_reverse(t) :: list
   def sort_reverse(enumerable) do
     sort(enumerable, &(&1 >= &2))
@@ -2492,6 +2493,7 @@ defmodule Enum do
       [~D[2020-03-02], ~D[2019-06-06], ~D[2019-01-01]]
 
   """
+  @doc since: "1.10.0"
   @spec sort_reverse(t, (element, element -> boolean)) :: list
   def sort_reverse(enumerable, fun) do
     sort(enumerable, to_sort_reverse_fun(fun))
@@ -2550,6 +2552,7 @@ defmodule Enum do
         %{name: "Lovelace", birthday: ~D[1815-12-10]}
       ]
   """
+  @doc since: "1.10.0"
   @spec sort_reverse_by(
           t,
           (element -> mapped_element),

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -680,27 +680,133 @@ defmodule EnumTest do
   end
 
   test "sort/2" do
-    assert Enum.sort([5, 3, 2, 4, 1], &(&1 > &2)) == [5, 4, 3, 2, 1]
+    assert Enum.sort([5, 3, 2, 4, 1], &(&1 >= &2)) == [5, 4, 3, 2, 1]
+  end
+
+  test "sort/2 with module" do
+    assert Enum.sort([~D[2020-01-01], ~D[2018-01-01], ~D[2019-01-01]], Date) ==
+             [~D[2018-01-01], ~D[2019-01-01], ~D[2020-01-01]]
   end
 
   test "sort_by/3" do
     collection = [
       [other_data: 1, sorted_data: 5],
-      [other_data: 3, sorted_data: 4],
+      [other_data: 2, sorted_data: 4],
       [other_data: 4, sorted_data: 3],
       [other_data: 2, sorted_data: 2],
-      [other_data: 5, sorted_data: 1]
+      [other_data: 3, sorted_data: 1]
     ]
 
     assert Enum.sort_by(collection, & &1[:sorted_data]) == [
-             [other_data: 5, sorted_data: 1],
+             [other_data: 3, sorted_data: 1],
              [other_data: 2, sorted_data: 2],
              [other_data: 4, sorted_data: 3],
-             [other_data: 3, sorted_data: 4],
+             [other_data: 2, sorted_data: 4],
              [other_data: 1, sorted_data: 5]
            ]
 
     assert Enum.sort_by(collection, & &1[:sorted_data], &>=/2) == collection
+
+    assert Enum.sort_by(collection, & &1[:other_data]) == [
+             [other_data: 1, sorted_data: 5],
+             [other_data: 2, sorted_data: 4],
+             [other_data: 2, sorted_data: 2],
+             [other_data: 3, sorted_data: 1],
+             [other_data: 4, sorted_data: 3]
+           ]
+
+    assert Enum.sort_by(collection, & &1[:other_data], &</2) == [
+             [other_data: 1, sorted_data: 5],
+             [other_data: 2, sorted_data: 2],
+             [other_data: 2, sorted_data: 4],
+             [other_data: 3, sorted_data: 1],
+             [other_data: 4, sorted_data: 3]
+           ]
+  end
+
+  test "sort_by/3 with module" do
+    collection = [
+      [other_data: 1, sorted_data: ~D[2010-01-05]],
+      [other_data: 2, sorted_data: ~D[2010-01-04]],
+      [other_data: 4, sorted_data: ~D[2010-01-03]],
+      [other_data: 2, sorted_data: ~D[2010-01-02]],
+      [other_data: 3, sorted_data: ~D[2010-01-01]]
+    ]
+
+    assert Enum.sort_by(collection, & &1[:sorted_data], Date) == [
+             [other_data: 3, sorted_data: ~D[2010-01-01]],
+             [other_data: 2, sorted_data: ~D[2010-01-02]],
+             [other_data: 4, sorted_data: ~D[2010-01-03]],
+             [other_data: 2, sorted_data: ~D[2010-01-04]],
+             [other_data: 1, sorted_data: ~D[2010-01-05]]
+           ]
+  end
+
+  test "sort_reverse/1" do
+    assert Enum.sort_reverse([1, 2, 3, 4, 5]) == [5, 4, 3, 2, 1]
+  end
+
+  test "sort_reverse/2" do
+    assert Enum.sort_reverse([5, 3, 2, 4, 1], &(&1 < &2)) == [5, 4, 3, 2, 1]
+  end
+
+  test "sort_reverse/2 with module" do
+    assert Enum.sort_reverse([~D[2020-01-01], ~D[2018-01-01], ~D[2019-01-01]], Date) ==
+             [~D[2020-01-01], ~D[2019-01-01], ~D[2018-01-01]]
+  end
+
+  test "sort_reverse_by/3" do
+    collection = [
+      [other_data: 1, sorted_data: 5],
+      [other_data: 2, sorted_data: 4],
+      [other_data: 4, sorted_data: 3],
+      [other_data: 2, sorted_data: 2],
+      [other_data: 3, sorted_data: 1]
+    ]
+
+    assert Enum.sort_reverse_by(collection, & &1[:sorted_data]) == collection
+
+    assert Enum.sort_reverse_by(collection, & &1[:sorted_data], &>/2) == [
+             [other_data: 3, sorted_data: 1],
+             [other_data: 2, sorted_data: 2],
+             [other_data: 4, sorted_data: 3],
+             [other_data: 2, sorted_data: 4],
+             [other_data: 1, sorted_data: 5]
+           ]
+
+    assert Enum.sort_reverse_by(collection, & &1[:other_data]) == [
+             [other_data: 4, sorted_data: 3],
+             [other_data: 3, sorted_data: 1],
+             [other_data: 2, sorted_data: 4],
+             [other_data: 2, sorted_data: 2],
+             [other_data: 1, sorted_data: 5]
+           ]
+
+    assert Enum.sort_reverse_by(collection, & &1[:other_data], &<=/2) == [
+             [other_data: 4, sorted_data: 3],
+             [other_data: 3, sorted_data: 1],
+             [other_data: 2, sorted_data: 2],
+             [other_data: 2, sorted_data: 4],
+             [other_data: 1, sorted_data: 5]
+           ]
+  end
+
+  test "sort_reverse_by/3 with module" do
+    collection = [
+      [other_data: 3, sorted_data: ~D[2010-01-01]],
+      [other_data: 2, sorted_data: ~D[2010-01-02]],
+      [other_data: 4, sorted_data: ~D[2010-01-03]],
+      [other_data: 2, sorted_data: ~D[2010-01-04]],
+      [other_data: 1, sorted_data: ~D[2010-01-05]]
+    ]
+
+    assert Enum.sort_reverse_by(collection, & &1[:sorted_data], Date) == [
+             [other_data: 1, sorted_data: ~D[2010-01-05]],
+             [other_data: 2, sorted_data: ~D[2010-01-04]],
+             [other_data: 4, sorted_data: ~D[2010-01-03]],
+             [other_data: 2, sorted_data: ~D[2010-01-02]],
+             [other_data: 3, sorted_data: ~D[2010-01-01]]
+           ]
   end
 
   test "split/2" do
@@ -1383,6 +1489,22 @@ defmodule EnumTest.Range do
 
   test "sort_by/2" do
     assert Enum.sort_by(3..1, & &1) == [1, 2, 3]
+  end
+
+  test "sort_reverse/1" do
+    assert Enum.sort_reverse(3..1) == [3, 2, 1]
+    assert Enum.sort_reverse(2..1) == [2, 1]
+    assert Enum.sort_reverse(1..1) == [1]
+  end
+
+  test "sort_reverse/2" do
+    assert Enum.sort_reverse(3..1, &(&1 > &2)) == [1, 2, 3]
+    assert Enum.sort_reverse(2..1, &(&1 > &2)) == [1, 2]
+    assert Enum.sort_reverse(1..1, &(&1 > &2)) == [1]
+  end
+
+  test "sort_reverse_by/2" do
+    assert Enum.sort_reverse_by(3..1, & &1) == [3, 2, 1]
   end
 
   test "split/2" do


### PR DESCRIPTION
Before this PR, sorting dates, decimals, and other structs was
somewhat awkward:

    Enum.sort(dates, &(Date.compare(&1, &2) != :lt)) # ascending
    Enum.sort(dates, &(Date.compare(&1, &2) != :gt)) # descending

Sorting a user by dates, decimals, and other structs was equally
verbose:

    Enum.sort_by(users, &(&1.birthday), &(Date.compare(&1, &2) != :lt)) # ascending
    Enum.sort_by(users, &(&1.birthday), &(Date.compare(&1, &2) != :gt)) # descending

Even a general sort in reverse required passing &>=/2 as an argument,
which is not clear in intent:

    Enum.sort(list, &>=/2) # descending

This PR addresses this by adding two features:

  1. Sorting funtions now accept a module as sorter. The compare/2
     function of said modules are then used for sorting.

  2. `sort_reverse*` functions were added to complement the
     functionality above

All of the examples above can be written as:

    Enum.sort(dates, Date) # ascending
    Enum.sort_reverse(dates, Date) # descending
    Enum.sort_by(users, &(&1.birthday), Date) # ascending
    Enum.sort_reverse_by(users, &(&1.birthday), Date) # descending
    Enum.sort_reverse(list) # descending

The reason why we picked `sort_reverse` instead of `sort_descending`
is because a sorting funtion can still be given to `sort_reverse`, which
means a descending function will return an ascending result (i.e. the
reverse).