### PR TITLE
Allow a sorting function on min/max/min_by/max_by

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1500,17 +1500,17 @@ defmodule Enum do
   end
 
   # TODO: Deprecate me on 1.14
-  defp max_sort_fun(empty_fallback, default_empty_callback)
-       when is_function(empty_fallback, 0) and is_function(default_empty_callback, 0),
+  defp max_sort_fun(empty_fallback, default_empty_fallback)
+       when is_function(empty_fallback, 0) and is_function(default_empty_fallback, 0),
        do: {&>=/2, empty_fallback}
 
-  defp max_sort_fun(sorter, empty_callback)
-       when is_function(sorter, 2) and is_function(empty_callback, 0),
-       do: {sorter, empty_callback}
+  defp max_sort_fun(sorter, empty_fallback)
+       when is_function(sorter, 2) and is_function(empty_fallback, 0),
+       do: {sorter, empty_fallback}
 
-  defp max_sort_fun(module, empty_callback)
-       when is_atom(module) and is_function(empty_callback, 0),
-       do: {&(module.compare(&1, &2) != :lt), empty_callback}
+  defp max_sort_fun(module, empty_fallback)
+       when is_atom(module) and is_function(empty_fallback, 0),
+       do: {&(module.compare(&1, &2) != :lt), empty_fallback}
 
   @doc """
   Returns the maximal element in the `enumerable` as calculated
@@ -1660,17 +1660,17 @@ defmodule Enum do
   end
 
   # TODO: Deprecate me on 1.14
-  defp min_sort_fun(empty_fallback, default_empty_callback)
-       when is_function(empty_fallback, 0) and is_function(default_empty_callback, 0),
+  defp min_sort_fun(empty_fallback, default_empty_fallback)
+       when is_function(empty_fallback, 0) and is_function(default_empty_fallback, 0),
        do: {&<=/2, empty_fallback}
 
-  defp min_sort_fun(sorter, empty_callback)
-       when is_function(sorter, 2) and is_function(empty_callback, 0),
-       do: {sorter, empty_callback}
+  defp min_sort_fun(sorter, empty_fallback)
+       when is_function(sorter, 2) and is_function(empty_fallback, 0),
+       do: {sorter, empty_fallback}
 
-  defp min_sort_fun(module, empty_callback)
-       when is_atom(module) and is_function(empty_callback, 0),
-       do: {&(module.compare(&1, &2) != :gt), empty_callback}
+  defp min_sort_fun(module, empty_fallback)
+       when is_atom(module) and is_function(empty_fallback, 0),
+       do: {&(module.compare(&1, &2) != :gt), empty_fallback}
 
   @doc """
   Returns the minimal element in the `enumerable` as calculated

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1473,11 +1473,11 @@ defmodule Enum do
       iex> Enum.max([~D[2017-03-31], ~D[2017-04-01]])
       ~D[2017-03-31]
 
-  In the example above, `max/2` returned April 1st instead of March 31st
+  In the example above, `max/2` returned March 31st instead of April 1st 
   because the structural comparison compares the day before the year.
   For this reason, most structs provide a "compare" function, such as
   `Date.compare/2`, which receives two structs and returns `:lt` (less than),
-  `:eq` (equal), and `:gt` (greather than). If you pass a module as the
+  `:eq` (equal), and `:gt` (greater than). If you pass a module as the
   sorting function, Elixir will automatically use the `compare/2` function
   of said module:
 
@@ -1485,7 +1485,7 @@ defmodule Enum do
       ~D[2017-04-01]
 
   Finally, if you don't want to raise on empty enumerables, you can pass
-  the empty callback:
+  the empty fallback:
 
       iex> Enum.max([], &>=/2, fn -> 0 end)
       0
@@ -1537,7 +1537,7 @@ defmodule Enum do
   comparison is structural and not semantic. Therefore, if you want
   to compare structs, most structs provide a "compare" function, such as
   `Date.compare/2`, which receives two structs and returns `:lt` (less than),
-  `:eq` (equal), and `:gt` (greather than). If you pass a module as the
+  `:eq` (equal), and `:gt` (greater than). If you pass a module as the
   sorting function, Elixir will automatically use the `compare/2` function
   of said module:
 
@@ -1550,7 +1550,7 @@ defmodule Enum do
       %{name: "Ellis", birthday: ~D[1943-05-11]}
 
   Finally, if you don't want to raise on empty enumerables, you can pass
-  the empty callback:
+  the empty fallback:
 
       iex> Enum.max_by([], &String.length/1, fn -> nil end)
       nil
@@ -1637,7 +1637,7 @@ defmodule Enum do
   because the structural comparison compares the day before the year.
   For this reason, most structs provide a "compare" function, such as
   `Date.compare/2`, which receives two structs and returns `:lt` (less than),
-  `:eq` (equal), and `:gt` (greather than). If you pass a module as the
+  `:eq` (equal), and `:gt` (greater than). If you pass a module as the
   sorting function, Elixir will automatically use the `compare/2` function
   of said module:
 
@@ -1645,7 +1645,7 @@ defmodule Enum do
       ~D[2017-03-31]
 
   Finally, if you don't want to raise on empty enumerables, you can pass
-  the empty callback:
+  the empty fallback:
 
       iex> Enum.min([], &<=/2, fn -> 0 end)
       0
@@ -1697,7 +1697,7 @@ defmodule Enum do
   comparison is structural and not semantic. Therefore, if you want
   to compare structs, most structs provide a "compare" function, such as
   `Date.compare/2`, which receives two structs and returns `:lt` (less than),
-  `:eq` (equal), and `:gt` (greather than). If you pass a module as the
+  `:eq` (equal), and `:gt` (greater than). If you pass a module as the
   sorting function, Elixir will automatically use the `compare/2` function
   of said module:
 
@@ -1710,7 +1710,7 @@ defmodule Enum do
       %{name: "Lovelace", birthday: ~D[1815-12-10]}
 
   Finally, if you don't want to raise on empty enumerables, you can pass
-  the empty callback:
+  the empty fallback:
 
       iex> Enum.min_by([], &String.length/1, fn -> nil end)
       nil

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -448,8 +448,8 @@ defmodule ExceptionTest do
                    * map/2
                    * max/1
                    * max/2
+                   * max/3
                    * min/1
-                   * min/2
              """
 
       assert blame_message(:erlang, & &1.gt_cookie()) == """


### PR DESCRIPTION
Prior to this PR, there was no convenient way of getting the earliest/latest calendar type nor get the min/max datatype driven by a calendar type.

This PR adds this functionality by allowing a sorter function in `min/max/min_by/max_by` and allowing a sorter function to be automatically derived with a module by using `compare/2`, similar to #9426 

This PR introduces, however, a future deprecation, since the empty callback has been moved one argument ahead. This deprecation will be emitted only in the future (if we choose to do so).