### PR TITLE
Add asc/desc and compare support to Enum.sort

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2328,7 +2328,7 @@ defmodule Enum do
   For this reason, most structs provide a "compare" function, such as
   `Date.compare/2`, which receives two structs and returns `:lt` (less than),
   `:eq` (equal), and `:gt` (greather than). If you pass a module as the
-  sorting function, Elixir will automatically use the `compare` function
+  sorting function, Elixir will automatically use the `compare/2` function
   of said module:
 
       iex> dates = [~D[2019-01-01], ~D[2020-03-02], ~D[2019-06-06]]
@@ -2336,7 +2336,7 @@ defmodule Enum do
       [~D[2019-01-01], ~D[2019-06-06], ~D[2020-03-02]]
 
   To retrieve all dates in descending order, you can wrap the module in
-  a tuple with `:asc` or `:desc` as first argument:
+  a tuple with `:asc` or `:desc` as first element:
 
       iex> dates = [~D[2019-01-01], ~D[2020-03-02], ~D[2019-06-06]]
       iex> Enum.sort(dates, {:asc, Date})
@@ -2380,7 +2380,7 @@ defmodule Enum do
   `sort_by/3` differs from `sort/2` in that it only calculates the
   comparison value for each element in the enumerable once instead of
   once for each element in each comparison. If the same function is
-  being called on both elements, it's more effiicient to use `sort_by/3`.
+  being called on both elements, it's more efficient to use `sort_by/3`.
 
   ## Examples
 
@@ -2405,11 +2405,11 @@ defmodule Enum do
       iex> Enum.sort_by(["some", "kind", "of", "monster"], &byte_size/1, :desc)
       ["monster", "some", "kind", "of"]
 
-  As in `sort/2`, avoid using the default sorted to sort structs, as by default
+  As in `sort/2`, avoid using the default sorting function to sort structs, as by default
   it performs structural comparison instead of a semantic one. In such cases,
   you shall pass a sorting function as third element or any module that implements
-  a `compare` function. For example, to sort users by their birthday in both
-  ascending and descending order respectivelly:
+  a `compare/2` function. For example, to sort users by their birthday in both
+  ascending and descending order respectively:
 
       iex> users = [
       ...>   %{name: "Ellis", birthday: ~D[1943-05-11]},

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2278,8 +2278,8 @@ defmodule Enum do
   Sorts the `enumerable` by the given function.
 
   This function uses the merge sort algorithm. The given function should compare
-  two arguments, and return `true` if the first argument is **less than or equal to**
-  the second one.
+  two arguments, and return `true` if the first argument precedes or is in the
+  same place as the second one.
 
   ## Examples
 

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -680,27 +680,148 @@ defmodule EnumTest do
   end
 
   test "sort/2" do
-    assert Enum.sort([5, 3, 2, 4, 1], &(&1 > &2)) == [5, 4, 3, 2, 1]
+    assert Enum.sort([5, 3, 2, 4, 1], &(&1 >= &2)) == [5, 4, 3, 2, 1]
+    assert Enum.sort([5, 3, 2, 4, 1], :asc) == [1, 2, 3, 4, 5]
+    assert Enum.sort([5, 3, 2, 4, 1], :desc) == [5, 4, 3, 2, 1]
+  end
+
+  test "sort/2 with module" do
+    assert Enum.sort([~D[2020-01-01], ~D[2018-01-01], ~D[2019-01-01]], Date) ==
+             [~D[2018-01-01], ~D[2019-01-01], ~D[2020-01-01]]
+
+    assert Enum.sort([~D[2020-01-01], ~D[2018-01-01], ~D[2019-01-01]], {:asc, Date}) ==
+             [~D[2018-01-01], ~D[2019-01-01], ~D[2020-01-01]]
+
+    assert Enum.sort([~D[2020-01-01], ~D[2018-01-01], ~D[2019-01-01]], {:desc, Date}) ==
+             [~D[2020-01-01], ~D[2019-01-01], ~D[2018-01-01]]
   end
 
   test "sort_by/3" do
     collection = [
-      [other_data: 1, sorted_data: 5],
-      [other_data: 3, sorted_data: 4],
-      [other_data: 4, sorted_data: 3],
-      [other_data: 2, sorted_data: 2],
-      [other_data: 5, sorted_data: 1]
+      [sorted_data: 4],
+      [sorted_data: 5],
+      [sorted_data: 2],
+      [sorted_data: 1],
+      [sorted_data: 3]
     ]
 
-    assert Enum.sort_by(collection, & &1[:sorted_data]) == [
-             [other_data: 5, sorted_data: 1],
+    asc = [
+      [sorted_data: 1],
+      [sorted_data: 2],
+      [sorted_data: 3],
+      [sorted_data: 4],
+      [sorted_data: 5]
+    ]
+
+    desc = [
+      [sorted_data: 5],
+      [sorted_data: 4],
+      [sorted_data: 3],
+      [sorted_data: 2],
+      [sorted_data: 1]
+    ]
+
+    assert Enum.sort_by(collection, & &1[:sorted_data]) == asc
+    assert Enum.sort_by(collection, & &1[:sorted_data], :asc) == asc
+    assert Enum.sort_by(collection, & &1[:sorted_data], &>=/2) == desc
+    assert Enum.sort_by(collection, & &1[:sorted_data], :desc) == desc
+  end
+
+  test "sort_by/3 with stable sorting" do
+    collection = [
+      [other_data: 2, sorted_data: 4],
+      [other_data: 1, sorted_data: 5],
+      [other_data: 2, sorted_data: 2],
+      [other_data: 3, sorted_data: 1],
+      [other_data: 4, sorted_data: 3]
+    ]
+
+    # Stable sorting
+    assert Enum.sort_by(collection, & &1[:other_data]) == [
+             [other_data: 1, sorted_data: 5],
+             [other_data: 2, sorted_data: 4],
              [other_data: 2, sorted_data: 2],
-             [other_data: 4, sorted_data: 3],
-             [other_data: 3, sorted_data: 4],
-             [other_data: 1, sorted_data: 5]
+             [other_data: 3, sorted_data: 1],
+             [other_data: 4, sorted_data: 3]
            ]
 
-    assert Enum.sort_by(collection, & &1[:sorted_data], &>=/2) == collection
+    assert Enum.sort_by(collection, & &1[:other_data]) ==
+             Enum.sort_by(collection, & &1[:other_data], :asc)
+
+    assert Enum.sort_by(collection, & &1[:other_data], &</2) == [
+             [other_data: 1, sorted_data: 5],
+             [other_data: 2, sorted_data: 2],
+             [other_data: 2, sorted_data: 4],
+             [other_data: 3, sorted_data: 1],
+             [other_data: 4, sorted_data: 3]
+           ]
+
+    assert Enum.sort_by(collection, & &1[:other_data], :desc) == [
+             [other_data: 4, sorted_data: 3],
+             [other_data: 3, sorted_data: 1],
+             [other_data: 2, sorted_data: 4],
+             [other_data: 2, sorted_data: 2],
+             [other_data: 1, sorted_data: 5]
+           ]
+  end
+
+  test "sort_by/3 with module" do
+    collection = [
+      [sorted_data: ~D[2010-01-05]],
+      [sorted_data: ~D[2010-01-04]],
+      [sorted_data: ~D[2010-01-03]],
+      [sorted_data: ~D[2010-01-02]],
+      [sorted_data: ~D[2010-01-01]]
+    ]
+
+    assert Enum.sort_by(collection, & &1[:sorted_data], Date) == [
+             [sorted_data: ~D[2010-01-01]],
+             [sorted_data: ~D[2010-01-02]],
+             [sorted_data: ~D[2010-01-03]],
+             [sorted_data: ~D[2010-01-04]],
+             [sorted_data: ~D[2010-01-05]]
+           ]
+
+    assert Enum.sort_by(collection, & &1[:sorted_data], Date) ==
+             assert(Enum.sort_by(collection, & &1[:sorted_data], {:asc, Date}))
+
+    assert Enum.sort_by(collection, & &1[:sorted_data], {:desc, Date}) == [
+             [sorted_data: ~D[2010-01-05]],
+             [sorted_data: ~D[2010-01-04]],
+             [sorted_data: ~D[2010-01-03]],
+             [sorted_data: ~D[2010-01-02]],
+             [sorted_data: ~D[2010-01-01]]
+           ]
+  end
+
+  test "sort_by/3 with module and stable sorting" do
+    collection = [
+      [other_data: ~D[2010-01-02], sorted_data: 4],
+      [other_data: ~D[2010-01-01], sorted_data: 5],
+      [other_data: ~D[2010-01-02], sorted_data: 2],
+      [other_data: ~D[2010-01-03], sorted_data: 1],
+      [other_data: ~D[2010-01-04], sorted_data: 3]
+    ]
+
+    # Stable sorting
+    assert Enum.sort_by(collection, & &1[:other_data], Date) == [
+             [other_data: ~D[2010-01-01], sorted_data: 5],
+             [other_data: ~D[2010-01-02], sorted_data: 4],
+             [other_data: ~D[2010-01-02], sorted_data: 2],
+             [other_data: ~D[2010-01-03], sorted_data: 1],
+             [other_data: ~D[2010-01-04], sorted_data: 3]
+           ]
+
+    assert Enum.sort_by(collection, & &1[:other_data], Date) ==
+             Enum.sort_by(collection, & &1[:other_data], {:asc, Date})
+
+    assert Enum.sort_by(collection, & &1[:other_data], {:desc, Date}) == [
+             [other_data: ~D[2010-01-04], sorted_data: 3],
+             [other_data: ~D[2010-01-03], sorted_data: 1],
+             [other_data: ~D[2010-01-02], sorted_data: 4],
+             [other_data: ~D[2010-01-02], sorted_data: 2],
+             [other_data: ~D[2010-01-01], sorted_data: 5]
+           ]
   end
 
   test "split/2" do
@@ -1379,10 +1500,15 @@ defmodule EnumTest.Range do
     assert Enum.sort(3..1, &(&1 > &2)) == [3, 2, 1]
     assert Enum.sort(2..1, &(&1 > &2)) == [2, 1]
     assert Enum.sort(1..1, &(&1 > &2)) == [1]
+
+    assert Enum.sort(3..1, :asc) == [1, 2, 3]
+    assert Enum.sort(3..1, :desc) == [3, 2, 1]
   end
 
   test "sort_by/2" do
     assert Enum.sort_by(3..1, & &1) == [1, 2, 3]
+    assert Enum.sort_by(3..1, & &1, :asc) == [1, 2, 3]
+    assert Enum.sort_by(3..1, & &1, :desc) == [3, 2, 1]
   end
 
   test "split/2" do


### PR DESCRIPTION
Before this PR, sorting dates, decimals, and other structs was
somewhat awkward:

    Enum.sort(dates, &(Date.compare(&1, &2) != :lt)) # ascending
    Enum.sort(dates, &(Date.compare(&1, &2) != :gt)) # descending

Sorting a user by dates, decimals, and other structs was equally
verbose:

    Enum.sort_by(users, &(&1.birthday), &(Date.compare(&1, &2) != :lt)) # ascending
    Enum.sort_by(users, &(&1.birthday), &(Date.compare(&1, &2) != :gt)) # descending

Even a general sort in reverse required passing &>=/2 as an argument,
which is not clear in intent:

    Enum.sort(list, &>=/2) # descending

This PR addresses this by:

  1. Allow `:asc` and `:desc` to be given as sorting functions.

  2. Allow a module to be given to sort, which will automatically
    compare/2. The module can also be wrapped in a :asc/:desc tuple.

All of the examples above can be written as:

    Enum.sort(dates, Date) # ascending
    Enum.sort(dates, {:desc, Date}) # descending
    Enum.sort_by(users, &(&1.birthday), Date) # ascending
    Enum.sort_by(users, &(&1.birthday), {:desc, Date}) # descending
    Enum.sort(list, :desc) # descending