### PR TITLE
Updates on DynamicSupervisor.start_child/2

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -286,7 +286,7 @@ defmodule DynamicSupervisor do
   Dynamically adds a child specification to `supervisor` and starts that child.
 
   `child_spec` should be a valid child specification as detailed in the
-  "child_spec/1" section of the documentation for `Supervisor`. The child
+  "Child specification" section of the documentation for `Supervisor`. The child
   process will be started as defined in the child specification.
 
   If the child process start function returns `{:ok, child}` or `{:ok, child,
@@ -306,7 +306,13 @@ defmodule DynamicSupervisor do
   this function returns `{:error, :max_children}`.
   """
   @doc since: "1.6.0"
-  @spec start_child(Supervisor.supervisor(), Supervisor.child_spec() | {module, term} | module) ::
+  @spec start_child(
+          Supervisor.supervisor(),
+          Supervisor.child_spec()
+          | {module, term}
+          | module
+          | (old_erlang_child_spec :: :supervisor.child_spec())
+        ) ::
           on_start_child()
   def start_child(supervisor, {_, _, _, _, _, _} = child_spec) do
     validate_and_start_child(supervisor, child_spec)

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -108,8 +108,8 @@ defmodule Supervisor do
   The child specification describes how the supervisor starts, shuts down,
   and restarts child processes.
 
-  The child specification contains 6 keys. The first two are required,
-  and the remaining ones are optional:
+  The child specification is a map which contains 6 elements. The first two keys
+  in the following list are required, and the remaining ones are optional:
 
     * `:id` - any term used to identify the child specification
       internally by the supervisor; defaults to the given module.
@@ -131,8 +131,8 @@ defmodule Supervisor do
     * `:type` - specifies that the child process is a `:worker` or a
       `:supervisor`. This key is optional and defaults to `:worker`.
 
-  There is a sixth key, `:modules`, that is rarely changed. It is set
-  automatically based on the value in `:start`.
+  There is a sixth key, `:modules`, which is optional and is rarely changed.
+  It is set automatically based on the `:start` value.
 
   Let's understand what the `:shutdown` and `:restart` options control.
 


### PR DESCRIPTION
- Changes to its specs to reflect deprecated child spec.
- Changes to the code so not it fails with FunctionClauseError if child_spec
  doesn't match the spec.
- Documentation fixes.