### PR TITLE
List.to_integer docs include the max value for base

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -857,6 +857,8 @@ defmodule List do
 
   Inlined by the compiler.
 
+  The base needs to be between 2 and 36.
+
   ## Examples
 
       iex> List.to_integer('3FF', 16)

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -857,7 +857,7 @@ defmodule List do
 
   Inlined by the compiler.
 
-  The base needs to be between 2 and 36.
+  The base needs to be between `2` and `36`.
 
   ## Examples
 


### PR DESCRIPTION
I think this is an important detail to include in the documentation because the error when the base it greater than 36 is cryptic.

```
iex(3)> List.to_integer('3FF', 37)
** (ArgumentError) argument error
    :erlang.list_to_integer('3FF', 37)
```

💚 