### PR TITLE
Execute callbacks on :elixir_compiler after all warnings are emitted

### DIFF
--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -15,10 +15,11 @@ quoted(Forms, File, Callback) ->
     put(elixir_module_binaries, []),
     Env = (elixir_env:new())#{line := 1, file := File, tracers := elixir_config:get(tracers)},
 
-    elixir_lexical:run(Env, fun(#{lexical_tracker := Pid} = LexicalEnv) ->
-      eval_forms(Forms, [], LexicalEnv),
-      Callback(File, Pid)
-    end),
+    elixir_lexical:run(
+      Env,
+      fun (LexicalEnv) -> eval_forms(Forms, [], LexicalEnv) end,
+      fun (#{lexical_tracker := Pid}) -> Callback(File, Pid) end
+    ),
 
     lists:reverse(get(elixir_module_binaries))
   after

--- a/lib/elixir/src/elixir_lexical.erl
+++ b/lib/elixir/src/elixir_lexical.erl
@@ -13,8 +13,8 @@ run(#{tracers := Tracers} = E, ExecutionCallback, AfterExecutionCallback) ->
 
       try ExecutionCallback(LexEnv) of
         Res ->
-          warn_unused_aliases(Pid, E),
-          warn_unused_imports(Pid, E),
+          warn_unused_aliases(Pid, LexEnv),
+          warn_unused_imports(Pid, LexEnv),
           AfterExecutionCallback(LexEnv),
           Res
       after

--- a/lib/elixir/src/elixir_lexical.erl
+++ b/lib/elixir/src/elixir_lexical.erl
@@ -23,7 +23,8 @@ run(#{tracers := Tracers} = E, ExecutionCallback, AfterExecutionCallback) ->
       end;
 
     true ->
-      ExecutionCallback(E)
+      ExecutionCallback(E),
+      AfterExecutionCallback(E)
   end.
 
 trace({import, Meta, Module, Opts}, #{lexical_tracker := Pid}) ->

--- a/lib/elixir/src/elixir_lexical.erl
+++ b/lib/elixir/src/elixir_lexical.erl
@@ -1,19 +1,21 @@
 %% Module responsible for tracking lexical information.
 -module(elixir_lexical).
--export([run/2, with_file/3, trace/2, format_error/1]).
+-export([run/3, with_file/3, trace/2, format_error/1]).
 -include("elixir.hrl").
 
 -define(tracker, 'Elixir.Kernel.LexicalTracker').
 
-run(#{tracers := Tracers} = E, Callback) ->
+run(#{tracers := Tracers} = E, ExecutionCallback, AfterExecutionCallback) ->
   case elixir_config:get(bootstrap) of
     false ->
       {ok, Pid} = ?tracker:start_link(),
+      LexEnv = E#{lexical_tracker := Pid, tracers := [?MODULE | Tracers]},
 
-      try Callback(E#{lexical_tracker := Pid, tracers := [?MODULE | Tracers]}) of
+      try ExecutionCallback(LexEnv) of
         Res ->
           warn_unused_aliases(Pid, E),
           warn_unused_imports(Pid, E),
+          AfterExecutionCallback(LexEnv),
           Res
       after
         unlink(Pid),
@@ -21,7 +23,7 @@ run(#{tracers := Tracers} = E, Callback) ->
       end;
 
     true ->
-      Callback(E)
+      ExecutionCallback(E)
   end.
 
 trace({import, Meta, Module, Opts}, #{lexical_tracker := Pid}) ->
@@ -35,7 +37,7 @@ trace({import, Meta, Module, Opts}, #{lexical_tracker := Pid}) ->
 
   ?tracker:add_import(Pid, Module, Only, ?line(Meta), Imported and should_warn(Meta, Opts)),
   ok;
-trace({alias, Meta, _Old, New, Opts}, #{lexical_tracker := Pid}) ->  
+trace({alias, Meta, _Old, New, Opts}, #{lexical_tracker := Pid}) ->
   ?tracker:add_alias(Pid, New, ?line(Meta), should_warn(Meta, Opts)),
   ok;
 trace({alias_expansion, _Meta, Lookup, _Result}, #{lexical_tracker := Pid}) ->

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -78,9 +78,11 @@ compile(Module, Block, Vars, #{line := Line, current_vars := {Current, _}} = Env
 
   case MaybeLexEnv of
     #{lexical_tracker := nil} ->
-      elixir_lexical:run(MaybeLexEnv, fun(LexEnv) ->
-        compile(Line, Module, Block, Vars, LexEnv)
-      end);
+      elixir_lexical:run(
+        MaybeLexEnv,
+        fun(LexEnv) -> compile(Line, Module, Block, Vars, LexEnv) end,
+        fun(_LexEnv) -> ok end
+      );
     _ ->
       compile(Line, Module, Block, Vars, MaybeLexEnv)
   end;

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -514,6 +514,34 @@ defmodule Mix.Tasks.Compile.ElixirTest do
     end)
   end
 
+  test "returns warning diagnostics for unused imports" do
+    in_fixture("no_mixfile", fn ->
+      File.write!("lib/a.ex", """
+      defmodule A do
+        import B
+      end
+      """)
+
+      File.write!("lib/b.ex", """
+      defmodule B do
+        def foo, do: :ok
+      end
+      """)
+
+      diagnostic = %Diagnostic{
+        file: Path.absname("lib/a.ex"),
+        severity: :warning,
+        position: 2,
+        compiler_name: "Elixir",
+        message: "unused import B"
+      }
+
+      capture_io(:stderr, fn ->
+        assert {:ok, [^diagnostic]} = Mix.Tasks.Compile.Elixir.run([])
+      end)
+    end)
+  end
+
   test "returns error diagnostics", context do
     in_tmp(context.test, fn ->
       File.mkdir_p!("lib")


### PR DESCRIPTION
Currently the callbacks on :elixir_compiler are called before the warnings of unused aliases and imports are emitted, causing the messages to not consumed during the compilation. This commit changes `:elixir_lexical.run/2` to `:elixir_lexical.run/3` splitting the callback in two, one during the execution to evaluate the forms and another to be called after all the warnings are emitted.

Fixes #9440