### PR TITLE
Fix reading whole file opened as :charlist

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -147,6 +147,12 @@ defmodule IO do
   @spec read(device, :all | :line | non_neg_integer) :: chardata | nodata
   def read(device \\ :stdio, line_or_chars)
 
+  def read(device, :all) when is_pid(device) do
+    is_binary = Keyword.get(:io.getopts(device), :binary, true)
+    acc = if is_binary, do: "", else: ''
+    do_read_all(map_dev(device), acc)
+  end
+
   def read(device, :all) do
     do_read_all(map_dev(device), "")
   end
@@ -162,6 +168,7 @@ defmodule IO do
   defp do_read_all(mapped_dev, acc) do
     case :io.get_line(mapped_dev, "") do
       line when is_binary(line) -> do_read_all(mapped_dev, acc <> line)
+      line when is_list(line) -> do_read_all(mapped_dev, acc ++ line)
       :eof -> acc
       other -> other
     end

--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -203,7 +203,7 @@ defmodule StringIO do
 
   defp io_request(from, reply_as, req, state) do
     {reply, state} = io_request(req, state)
-    io_reply(from, reply_as, to_reply(reply))
+    io_reply(from, reply_as, reply)
     state
   end
 
@@ -260,7 +260,7 @@ defmodule StringIO do
   end
 
   defp io_request(:getopts, state) do
-    {{:ok, [binary: true, encoding: state.encoding]}, state}
+    {[binary: true, encoding: state.encoding], state}
   end
 
   defp io_request({:get_geometry, :columns}, state) do
@@ -458,7 +458,4 @@ defmodule StringIO do
   defp io_reply(from, reply_as, reply) do
     send(from, {:io_reply, reply_as, reply})
   end
-
-  defp to_reply(list) when is_list(list), do: IO.chardata_to_string(list)
-  defp to_reply(other), do: other
 end

--- a/lib/elixir/test/elixir/fixtures/multiline_file.txt
+++ b/lib/elixir/test/elixir/fixtures/multiline_file.txt
@@ -1,0 +1,2 @@
+this is the first line
+this is the second line

--- a/lib/elixir/test/elixir/io_test.exs
+++ b/lib/elixir/test/elixir/io_test.exs
@@ -19,6 +19,12 @@ defmodule IOTest do
     assert File.close(file) == :ok
   end
 
+  test "read all charlist" do
+    {:ok, file} = File.open(Path.expand('fixtures/multiline_file.txt', __DIR__), [:charlist])
+    assert 'this is the first line\nthis is the second line\n' == IO.read(file, :all)
+    assert File.close(file) == :ok
+  end
+
   test "binread" do
     {:ok, file} = File.open(Path.expand('fixtures/utf8.txt', __DIR__))
     assert "Русский" == IO.binread(file, 14)

--- a/lib/ex_unit/test/ex_unit/capture_io_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_io_test.exs
@@ -279,7 +279,7 @@ defmodule ExUnit.CaptureIOTest do
 
   test "with getopts" do
     assert capture_io(fn ->
-             assert :io.getopts() == {:ok, [binary: true, encoding: :unicode]}
+             assert :io.getopts() == [binary: true, encoding: :unicode]
            end) == ""
   end
 


### PR DESCRIPTION
Hello, this code:
```elixir
{:ok, file} = File.open("file.txt"), [:charlist])
IO.read(file, :all)
```
would return only first line of  the file. While I was preparing fix for this case, I've encountered another problem. Namely `StringIO` does not comply with `:io.getopts/1` well, as it returns `{:ok. opts}` instead of just `opts`, so I've fixed it too.

I would say these are bugs, but fixing them risks breaking existing code that depends on this behaviour, and I am not sure how you usually handle such changes.

I think this PR fixes both issues I've mentioned above.