### PR TITLE
Warn if duplicate key found in struct

### DIFF
--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -96,7 +96,7 @@ defmodule Kernel.Utils do
 
   # TODO: Make it raise on v2.0
     :lists.keysort(1, fields)
-    |> warn_on_duplicate_struct_key(nil)
+    |> warn_on_duplicate_struct_key()
 
     foreach = fn
       key when is_atom(key) ->
@@ -112,17 +112,17 @@ defmodule Kernel.Utils do
     {struct, enforce_keys, Module.get_attribute(module, :derive)}
   end
 
-  defp warn_on_duplicate_struct_key([], _) do
-    nil
+  defp warn_on_duplicate_struct_key([]) do
+    :ok
   end
 
-  defp warn_on_duplicate_struct_key([{key, _} | rest], key) do
-    IO.warn(~s(duplicate key #{inspect(key)} found in struct))
-    warn_on_duplicate_struct_key(rest, key)
+  defp warn_on_duplicate_struct_key([{key, _} | [{key, _} | _] = rest]) do
+    IO.warn("duplicate key #{inspect(key)} found in struct")
+    warn_on_duplicate_struct_key(rest)
   end
 
-  defp warn_on_duplicate_struct_key([{key, _} | rest], _) do
-    warn_on_duplicate_struct_key(rest, key)
+  defp warn_on_duplicate_struct_key([_ | rest]) do
+    warn_on_duplicate_struct_key(rest)
   end
 
   @doc """

--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -94,6 +94,10 @@ defmodule Kernel.Utils do
     fields = :lists.map(mapper, fields)
     enforce_keys = List.wrap(Module.get_attribute(module, :enforce_keys))
 
+  # TODO: Make it raise on v2.0
+    :lists.keysort(1, fields)
+    |> warn_on_duplicate_struct_key(nil)
+
     foreach = fn
       key when is_atom(key) ->
         :ok
@@ -106,6 +110,19 @@ defmodule Kernel.Utils do
 
     struct = :maps.put(:__struct__, module, :maps.from_list(fields))
     {struct, enforce_keys, Module.get_attribute(module, :derive)}
+  end
+
+  defp warn_on_duplicate_struct_key([], _) do
+    nil
+  end
+
+  defp warn_on_duplicate_struct_key([{key, _} | rest], key) do
+    IO.warn(~s(duplicate key #{inspect(key)} found in struct))
+    warn_on_duplicate_struct_key(rest, key)
+  end
+
+  defp warn_on_duplicate_struct_key([{key, _} | rest], _) do
+    warn_on_duplicate_struct_key(rest, key)
   end
 
   @doc """

--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -95,8 +95,7 @@ defmodule Kernel.Utils do
     enforce_keys = List.wrap(Module.get_attribute(module, :enforce_keys))
 
     # TODO: Make it raise on v2.0
-    :lists.keysort(1, fields)
-    |> warn_on_duplicate_struct_key()
+    warn_on_duplicate_struct_key(:lists.keysort(1, fields))
 
     foreach = fn
       key when is_atom(key) ->

--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -94,7 +94,7 @@ defmodule Kernel.Utils do
     fields = :lists.map(mapper, fields)
     enforce_keys = List.wrap(Module.get_attribute(module, :enforce_keys))
 
-  # TODO: Make it raise on v2.0
+    # TODO: Make it raise on v2.0
     :lists.keysort(1, fields)
     |> warn_on_duplicate_struct_key()
 

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1770,6 +1770,18 @@ defmodule Kernel.WarningTest do
     end
   end
 
+  test "defstruct warns with duplicate keys" do
+    assert capture_err(fn ->
+             Code.eval_string("""
+             defmodule TestMod do
+               defstruct [:foo, :foo, :bar]
+             end
+             """)
+           end) =~ "duplicate key :foo found in struct"
+  after
+    purge(TestMod)
+  end
+
   defp purge(list) when is_list(list) do
     Enum.each(list, &purge/1)
   end


### PR DESCRIPTION
Warning is the preferable solution for this, if we raise instead then it
is likely that there are some existing libraries that use duplicate
struct keys that will break.