### PR TITLE
Prevent calling non-async functions in async tests

### DIFF
--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -44,7 +44,7 @@ defmodule Clause do
 end
 
 defmodule EExTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   doctest EEx
   doctest EEx.Engine

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -117,15 +117,6 @@ defmodule CodeTest do
     Code.unrequire_files([fixture_path("code_sample.exs")])
   end
 
-  test "require_file/1 checker warning" do
-    output =
-      ExUnit.CaptureIO.capture_io(:stderr, fn ->
-        Code.require_file(fixture_path("checker_warning.exs"))
-      end)
-
-    assert output =~ "function clause will never match"
-  end
-
   describe "string_to_quoted/2" do
     test "converts strings to quoted expressions" do
       assert Code.string_to_quoted("1 + 2") == {:ok, {:+, [line: 1], [1, 2]}}

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1771,6 +1771,15 @@ defmodule Kernel.WarningTest do
     purge(TestMod)
   end
 
+  test "Code.require_file/1 checker warning" do
+    output =
+      capture_err(fn ->
+        Code.require_file(PathHelpers.fixture_path("checker_warning.exs"))
+      end)
+
+    assert output =~ "function clause will never match"
+  end
+
   defp purge(list) when is_list(list) do
     Enum.each(list, &purge/1)
   end

--- a/lib/elixir/test/elixir/protocol/consolidation_test.exs
+++ b/lib/elixir/test/elixir/protocol/consolidation_test.exs
@@ -7,7 +7,7 @@ files = Path.wildcard(PathHelpers.fixture_path("consolidation/*"))
 Kernel.ParallelCompiler.compile_to_path(files, path)
 
 defmodule Protocol.ConsolidationTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   alias Protocol.ConsolidationTest.{Sample, WithAny}
 
   defimpl WithAny, for: Map do
@@ -70,8 +70,8 @@ defmodule Protocol.ConsolidationTest do
 
     assert output =~ ~r"the .+WithAny protocol has already been consolidated"
   after
-    :code.purge(WithAny.Atom)
-    :code.delete(WithAny.Atom)
+    :code.purge(WithAny.Integer)
+    :code.delete(WithAny.Integer)
   end
 
   test "consolidated implementations without any" do


### PR DESCRIPTION
Capturing a named device other than `:stdio`, such as `:stderr`, happens globally and requires `async: false`.