### PR TITLE
Warn if duplicate key is found in record

### DIFF
--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1774,7 +1774,7 @@ defmodule Kernel.WarningTest do
     assert capture_err(fn ->
              Code.eval_string("""
              defmodule TestMod do
-               defstruct [:foo, :foo, :bar]
+               defstruct [:foo, :bar, foo: 1]
              end
              """)
            end) =~ "duplicate key :foo found in struct"
@@ -1787,7 +1787,7 @@ defmodule Kernel.WarningTest do
              Code.eval_string("""
              defmodule TestMod do
                import Record
-               defrecord :r, [:foo, :foo, :bar]
+               defrecord :r, [:foo, :bar, foo: 1]
              end
              """)
            end) =~ "duplicate key :foo found in record"

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1782,7 +1782,7 @@ defmodule Kernel.WarningTest do
     purge(TestMod)
   end
 
-  test "duplicate keys" do
+  test "defrecord warns with duplicate keys" do
     assert capture_err(fn ->
              Code.eval_string("""
              defmodule TestMod do

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1782,6 +1782,19 @@ defmodule Kernel.WarningTest do
     purge(TestMod)
   end
 
+  test "duplicate keys" do
+    assert capture_err(fn ->
+             Code.eval_string("""
+             defmodule TestMod do
+               import Record
+               defrecord :r, [:foo, :foo, :bar]
+             end
+             """)
+           end) =~ "duplicate key :foo found in record"
+  after
+    purge(TestMod)
+  end
+
   defp purge(list) when is_list(list) do
     Enum.each(list, &purge/1)
   end

--- a/lib/elixir/test/elixir/record_test.exs
+++ b/lib/elixir/test/elixir/record_test.exs
@@ -2,6 +2,7 @@ Code.require_file("test_helper.exs", __DIR__)
 
 defmodule RecordTest do
   use ExUnit.Case, async: true
+  import ExUnit.CaptureIO
 
   require Record
   doctest Record
@@ -260,6 +261,15 @@ defmodule RecordTest do
         defrecord :r, [:a]
       end
     end
+  end
+
+  test "duplicate keys" do
+    assert capture_io(:stderr, fn ->
+             defmodule DuplicateKeys do
+               import Record
+               defrecord :r, [:a, :a]
+             end
+           end) =~ "duplicate key :a found in record"
   end
 
   test "macro and record with the same name defined" do

--- a/lib/elixir/test/elixir/record_test.exs
+++ b/lib/elixir/test/elixir/record_test.exs
@@ -2,7 +2,6 @@ Code.require_file("test_helper.exs", __DIR__)
 
 defmodule RecordTest do
   use ExUnit.Case, async: true
-  import ExUnit.CaptureIO
 
   require Record
   doctest Record
@@ -261,15 +260,6 @@ defmodule RecordTest do
         defrecord :r, [:a]
       end
     end
-  end
-
-  test "duplicate keys" do
-    assert capture_io(:stderr, fn ->
-             defmodule DuplicateKeys do
-               import Record
-               defrecord :r, [:a, :a]
-             end
-           end) =~ "duplicate key :a found in record"
   end
 
   test "macro and record with the same name defined" do


### PR DESCRIPTION
Similar to #9452 :D

Worth noting erlc errors on this too:

```
-record(r, {a, a}).
```

src/m.erl:2: field a already defined in record r