### PR TITLE
Ignore @typedoc attributes on bootstrap

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2898,7 +2898,7 @@ defmodule Kernel do
 
       # Typespecs attributes are currently special cased by the compiler
       name == :typedoc and not bootstrapped?(Kernel.Typespec) ->
-        nil
+        :ok
 
       is_list(args) and typespec?(name) ->
         case bootstrapped?(Kernel.Typespec) do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2897,6 +2897,9 @@ defmodule Kernel do
               "invalid write attribute syntax, you probably meant to use: @#{name} expression"
 
       # Typespecs attributes are currently special cased by the compiler
+      name == :typedoc and not bootstrapped?(Kernel.Typespec) ->
+        nil
+
       is_list(args) and typespec?(name) ->
         case bootstrapped?(Kernel.Typespec) do
           false ->


### PR DESCRIPTION
Typespec attributes are currently special cased by the compiler during bootstrap, but `@typedoc` attributes are not.

Because of that, in the bootstrap step, any `@typedoc` attribute present in modules compiled before `Kernel.Typespec` were emitting "unused attribute" warnings.

This was not spotted before because the `@` macro first checks if the Macro module is bootstrapped, otherwise any module attribute is ignored (`@typedoc` and `@type` included). By chance, no module between `Macro` and `Kernel.Typespec` had types until `Code.binding/0`
was introduced a few days ago.

Or, in other words, it removes this warning:

```
==> bootstrap (compile)
Compiled lib/elixir/lib/kernel.ex
Compiled lib/elixir/lib/macro/env.ex
Compiled lib/elixir/lib/keyword.ex
Compiled lib/elixir/lib/module.ex
Compiled lib/elixir/lib/list.ex
Compiled lib/elixir/lib/macro.ex
warning: module attribute @typedoc was set but no type follows it
  c:/Users/ContainerAdministrator/AppData/Local/Temp/cirrus-ci-build/lib/elixir/lib/code.ex:103
Compiled lib/elixir/lib/code.ex
```