### PR TITLE
Avoid race condition in test

### DIFF
--- a/lib/mix/test/mix/umbrella_test.exs
+++ b/lib/mix/test/mix/umbrella_test.exs
@@ -94,7 +94,7 @@ defmodule Mix.UmbrellaTest do
     end)
   end
 
-  test "recompiles umbrella on conffig hange" do
+  test "recompiles umbrella on config change" do
     in_fixture("umbrella_dep/deps/umbrella", fn ->
       Mix.Project.in_project(:umbrella, ".", fn _ ->
         Mix.Task.run("compile", [])

--- a/lib/mix/test/mix/umbrella_test.exs
+++ b/lib/mix/test/mix/umbrella_test.exs
@@ -98,15 +98,15 @@ defmodule Mix.UmbrellaTest do
     in_fixture("umbrella_dep/deps/umbrella", fn ->
       Mix.Project.in_project(:umbrella, ".", fn _ ->
         Mix.Task.run("compile", [])
-        bar = File.stat!("_build/dev/lib/bar/ebin/Elixir.Bar.beam").mtime
-        foo = File.stat!("_build/dev/lib/foo/ebin/Elixir.Foo.beam").mtime
+        bar = File.stat!("_build/dev/lib/bar/.mix/compile.elixir").mtime
+        foo = File.stat!("_build/dev/lib/foo/.mix/compile.elixir").mtime
 
-        ensure_touched("mix.exs")
+        ensure_touched("mix.exs", max(foo, bar))
 
         Mix.Task.clear()
         Mix.Task.run("compile", [])
-        assert File.stat!("_build/dev/lib/bar/ebin/Elixir.Bar.beam").mtime > bar
-        assert File.stat!("_build/dev/lib/foo/ebin/Elixir.Foo.beam").mtime > foo
+        assert File.stat!("_build/dev/lib/bar/.mix/compile.elixir").mtime > bar
+        assert File.stat!("_build/dev/lib/foo/.mix/compile.elixir").mtime > foo
       end)
     end)
   end

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -136,7 +136,6 @@ defmodule MixTest.Case do
     File.touch!(file)
 
     unless File.stat!(file).mtime > current do
-      Process.sleep(1000)
       ensure_touched(file, current)
     end
   end

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -136,6 +136,7 @@ defmodule MixTest.Case do
     File.touch!(file)
 
     unless File.stat!(file).mtime > current do
+      Process.sleep(1000)
       ensure_touched(file, current)
     end
   end


### PR DESCRIPTION
A test is failing and it looks like the test assumes that recompilation takes at least 1 second. Because the mtime has a granularity of 1 second. Some times the compared times are equal and fails the test. Example: https://travis-ci.org/elixir-lang/elixir/jobs/606593844#L285

This adds a 1 second delay in the test.