### PR TITLE
Add EditorConfig to provide uniform indent rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ charset = utf-8
 indent_style = space
 indent_size = 2
 
-[*.erl]
+[*.{erl,hrl}]
 indent_style = space
 indent_size = 2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+end_of_line = true
+insert_final_newline = true
+charset = utf-8
+
+[*.{ex,exs}]
+indent_style = space
+indent_size = 2
+
+[*.erl]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
This is especially needed for Erlang where most common style use 4 spaces instead of 2 like Elixir code does.