### PR TITLE
Add Kernel.is_struct/2

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2250,7 +2250,7 @@ defmodule Kernel do
       #=> false
 
       is_struct(1..2, "Range")
-      #=> ** (ArgumentError) invalid struct_type attribute. It expected a module or an atom, got: "Range"
+      ** (ArgumentError) invalid struct_type attribute. It expected a module or an atom, got: "Range"
 
   """
   @doc since: "1.10.0", guard: true


### PR DESCRIPTION
This is my take on how to make `is_struct/2` raise when not an atom is provided as its second argument.

The user cannot tell from the stacktrace that it is a macro working behind the scenes in case an ArgumentError is raised.

```elixir
defmodule A do
  def a(), do: {B.b()}
end

defmodule B do
  def b(), do: {C.c()}
end

defmodule C do
  def c(), do: {D.d()}
end

defmodule D do
  def d(), do: is_struct(1..2, 1)
end
```

```elixir
iex(1)> A.a()
** (ArgumentError) invalid struct_type attribute. It expected a module or an atom, got: 1
    (elixir 1.10.0-dev) /home/eksperimental/test_elixir/is_struct/lib/is_struct.ex:14: Kernel.is_struct/2
    (is_struct 0.1.0) lib/is_struct.ex:10: C.c/0
    (is_struct 0.1.0) lib/is_struct.ex:6: B.b/0
    (is_struct 0.1.0) lib/is_struct.ex:2: A.a/0
iex(1)> D.d
** (ArgumentError) invalid struct_type attribute. It expected a module or an atom, got: 1
    (elixir 1.10.0-dev) /home/eksperimental/test_elixir/is_struct/lib/is_struct.ex:14: Kernel.is_struct/2
    (stdlib 3.9.2) erl_eval.erl:680: :erl_eval.do_apply/6
    (iex 1.10.0-dev) lib/iex/evaluator.ex:260: IEx.Evaluator.handle_eval/5
    (iex 1.10.0-dev) lib/iex/evaluator.ex:240: IEx.Evaluator.do_eval/3
    (iex 1.10.0-dev) lib/iex/evaluator.ex:218: IEx.Evaluator.eval/3
```