### PR TITLE
Remove anonymous function examples

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -755,8 +755,6 @@ defmodule Logger do
   ## Examples
 
       Logger.warn("knob turned too far to the right")
-      Logger.warn(fn -> "dynamically calculated warning" end)
-      Logger.warn(fn -> {"dynamically calculated warning", [additional: :metadata]} end)
 
   """
   # TODO: Deprecate it in favour of `warning/1-2` macro
@@ -772,8 +770,6 @@ defmodule Logger do
   ## Examples
 
       Logger.info("mission accomplished")
-      Logger.info(fn -> "dynamically calculated info" end)
-      Logger.info(fn -> {"dynamically calculated info", [additional: :metadata]} end)
 
   """
   defmacro info(chardata_or_fun, metadata \\ []) do
@@ -788,8 +784,6 @@ defmodule Logger do
   ## Examples
 
       Logger.error("oops")
-      Logger.error(fn -> "dynamically calculated error" end)
-      Logger.error(fn -> {"dynamically calculated error", [additional: :metadata]} end)
 
   """
   defmacro error(chardata_or_fun, metadata \\ []) do
@@ -804,8 +798,6 @@ defmodule Logger do
   ## Examples
 
       Logger.debug("hello?")
-      Logger.debug(fn -> "dynamically calculated debug" end)
-      Logger.debug(fn -> {"dynamically calculated debug", [additional: :metadata]} end)
 
   """
   defmacro debug(chardata_or_fun, metadata \\ []) do


### PR DESCRIPTION
Since Elixir only evaluate Logger macro arguments when the message will be logged, we should remove these examples since they might confuse people reading the docs into thinking that they should still wrap their log statements.