### PR TITLE
Make distinction of guard expressions and functions/operators

### DIFF
--- a/lib/elixir/pages/Guards.md
+++ b/lib/elixir/pages/Guards.md
@@ -4,7 +4,7 @@ Guards are a way to augment pattern matching with more complex checks. They are 
 
 Not all expressions are allowed in guard clauses, but only a handful of them. This is a deliberate choice. This way, Elixir (and Erlang) can make sure that nothing bad happens while executing guards and no mutations happen anywhere. It also allows the compiler to optimize the code related to guards efficiently.
 
-## List of allowed expressions
+## List of allowed functions and operators
 
 You can find the built-in list of guards [in the `Kernel` module](Kernel.html#guards). Here is an overview:
 
@@ -29,7 +29,7 @@ def empty_map?(map) when map_size(map) == 0, do: true
 def empty_map?(map) when is_map(map), do: false
 ```
 
-Guards start with the `when` keyword and are followed by one or more of the guard expressions defined above. Guard expressions must evaluate to `true` or `false`.
+Guards start with the `when` keyword and are followed by a guard expression. The clause will only be executed if the guard expression returns `true`. Multiple boolean conditions can be combined with `and` and `or`.
 
 Writing the `empty_map?/1` function by only using pattern matching would not be possible (as pattern matching on `%{}` would match *every* map, not empty maps).
 
@@ -64,13 +64,13 @@ In the example above, we show how guards can be used in function clauses. There 
     ```
 
   * custom guards can also be defined with `defguard/1` and `defguardp/1`.
-    A custom guard is always defined based on existing guards.
+    A custom guard is can only be defined based on existing guards.
 
-Other constructs are [`for`](`for/1`), [`with`](`with/1`), [`try/rescue/catch/else`](`try/1`), and the `match?/2`.
+Other constructs that support guards are [`for`](`for/1`), [`with`](`with/1`), [`try/rescue/catch/else`](`try/1`), and `match?/2`.
 
 ## Failing guards
 
-The whole guard is true if and only if all guard expressions evaluate to `true`. If any other value is returned, the guard fails. In particular, guards have no concept of "truthy" or "falsey".
+A function clause will only be executed if and only if its guard expression evaluate to `true`. If any other value is returned, the function clause will be skipped. In particular, guards have no concept of "truthy" or "falsey".
 
 For example, imagine a function that checks that the head of a list is not `nil`:
 
@@ -103,7 +103,7 @@ iex> tuple_size("hello")
 ** (ArgumentError) argument error
 ```
 
-However, when used in guards, the corresponding clause simply fails to match:
+However, when used in guards, the corresponding clause will fail to match instead of raising an error:
 
 ```elixir
 iex> case "hello" do
@@ -117,39 +117,7 @@ iex> case "hello" do
 
 In many cases, we can take advantage of this. In the code above, we used `tuple_size/1` to both check that the given value is a tuple *and* check its size (instead of using `is_tuple(something) and tuple_size(something) == 2`).
 
-## Defining custom guard expressions
-
-As mentioned before, only the expressions listed in this page are allowed in guards. However, we can take advantage of macros to write custom guards that can simplify our programs or make them more domain-specific. At the end of the day, what matters is that the *output* of the macros (which is what will be compiled) boils down to a combinations of the allowed expressions.
-
-Let's look at a quick case study: we want to check that a function argument is an even or odd integer. With pattern matching, this is impossible to do since there are infinite integers, and thus we can't pattern match on the single even/odd numbers. Let's focus on checking for even numbers since checking for odd ones is almost identical.
-
-Such a guard would look like this:
-
-```elixir
-def my_function(number) when is_integer(number) and rem(number, 2) == 0 do
-  # do stuff
-end
-```
-
-This would be repetitive to write every time we need this check, so, as mentioned at the beginning of this section, we can abstract this away using a macro. Remember that defining a function that performs this check wouldn't work because we can't use custom functions in guards. Use `defguard` and `defguardp` to create guard macros. Here's an example:
-
-```elixir
-defmodule MyInteger do
-  defguard is_even(value) when is_integer(value) and rem(value, 2) == 0
-end
-```
-
-and then:
-
-```elixir
-import MyInteger, only: [is_even: 1]
-
-def my_function(number) when is_even(number) do
-  # do stuff
-end
-```
-
-While it's possible to create custom guards with macros, it's recommended to define them using `defguard` and `defguardp` which perform additional compile-time checks.
+Since `tuple_size/1` will fail the whole guard if it is not given a tuple we recommend to call type-check functions such as `is_tuple/1` before if your guard has multiple conditions, alternatively your function clause can use multiple guards as shown in the next section.
 
 ## Multiple guards in the same clause
 
@@ -208,3 +176,37 @@ end
 Check.empty?(%{}) #=> true
 Check.empty?({}) #=> true
 ```
+
+## Defining custom guard expressions
+
+As mentioned before, only the expressions listed in this page are allowed in guards. However, we can take advantage of macros to write custom guards that can simplify our programs or make them more domain-specific. At the end of the day, what matters is that the *output* of the macros (which is what will be compiled) boils down to a combinations of the allowed expressions.
+
+Let's look at a quick case study: we want to check that a function argument is an even or odd integer. With pattern matching, this is impossible to do since there are infinite integers, and thus we can't pattern match on the single even/odd numbers. Let's focus on checking for even numbers since checking for odd ones is almost identical.
+
+Such a guard would look like this:
+
+```elixir
+def my_function(number) when is_integer(number) and rem(number, 2) == 0 do
+  # do stuff
+end
+```
+
+This would be repetitive to write every time we need this check, so, as mentioned at the beginning of this section, we can abstract this away using a macro. Remember that defining a function that performs this check wouldn't work because we can't use custom functions in guards. Use `defguard` and `defguardp` to create guard macros. Here's an example:
+
+```elixir
+defmodule MyInteger do
+  defguard is_even(value) when is_integer(value) and rem(value, 2) == 0
+end
+```
+
+and then:
+
+```elixir
+import MyInteger, only: [is_even: 1]
+
+def my_function(number) when is_even(number) do
+  # do stuff
+end
+```
+
+While it's possible to create custom guards with macros, it's recommended to define them using `defguard` and `defguardp` which perform additional compile-time checks.


### PR DESCRIPTION
* Clarify distinction of guard expressions and functions and operators.
* Recommend using type-check guard functions.
* Reorder sections such that the "multiple guards" section immediately follows the "errors in guards" section.