### PR TITLE
Use type-check when it's an adjective

### DIFF
--- a/lib/elixir/lib/module/types/infer.ex
+++ b/lib/elixir/lib/module/types/infer.ex
@@ -315,7 +315,7 @@ defmodule Module.Types.Infer do
   ]
 
   @doc """
-  Refines the type variables in the typing context using type check guards
+  Refines the type variables in the typing context using type-check guards
   such as `is_integer/1`.
   """
   def of_guard({{:., _, [:erlang, :andalso]}, _, [left, right]} = expr, stack, context) do
@@ -468,7 +468,7 @@ defmodule Module.Types.Infer do
 
   defp and_guard_sources(left, right) do
     Map.merge(left, right, fn _index, left, right ->
-      # When the failing guard function wont fail due to type check function before it,
+      # When the failing guard function wont fail due to type-check function before it,
       # for example: is_list(x) and length(x)
       if :guarded in left and :fail in right do
         [:guarded_fail]

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -131,7 +131,7 @@ defmodule String do
 
     * `Kernel.binary_part/3` - retrieves part of the binary
     * `Kernel.bit_size/1` and `Kernel.byte_size/1` - size related functions
-    * `Kernel.is_bitstring/1` and `Kernel.is_binary/1` - type-checking function
+    * `Kernel.is_bitstring/1` and `Kernel.is_binary/1` - type-check function
     * Plus a number of functions for working with binaries (bytes)
       in the [`:binary` module](http://www.erlang.org/doc/man/binary.html)
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -131,7 +131,7 @@ defmodule String do
 
     * `Kernel.binary_part/3` - retrieves part of the binary
     * `Kernel.bit_size/1` and `Kernel.byte_size/1` - size related functions
-    * `Kernel.is_bitstring/1` and `Kernel.is_binary/1` - type checking function
+    * `Kernel.is_bitstring/1` and `Kernel.is_binary/1` - type-checking function
     * Plus a number of functions for working with binaries (bytes)
       in the [`:binary` module](http://www.erlang.org/doc/man/binary.html)
 


### PR DESCRIPTION
As noun or verbs it is spelled "type check"

[ci skip]