### PR TITLE
Fix for default leftover in Enum.chunk/3

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -408,7 +408,7 @@ defmodule Enum do
   @doc false
   @deprecated "Use Enum.chunk_every/3 instead"
   def chunk(enum, n, step) do
-    chunk_every(enum, n, step, nil)
+    chunk_every(enum, n, step, :discard)
   end
 
   @doc false

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -49,15 +49,12 @@ defmodule EnumTest do
 
   test "chunk/3" do
     enum = Enum
-    enumerable = [1, 2, 3, 4, 5]
-    assert enum.chunk(enumerable, 2, 1) == Enum.chunk_every(enumerable, 2, 1, :discard)
+    assert enum.chunk(1..5, 2, 1) == Enum.chunk_every(1..5, 2, 1, :discard)
   end
 
   test "chunk/4" do
     enum = Enum
-    enumerable = [1, 2, 3, 4, 5]
-    assert enum.chunk(enumerable, 2, 1, :discard) == [[1, 2], [2, 3], [3, 4], [4, 5]]
-    assert enum.chunk(enumerable, 2, 1, nil) == Enum.chunk_every(enumerable, 2, 1, :discard)
+    assert enum.chunk(1..5, 2, 1, nil) == Enum.chunk_every(1..5, 2, 1, :discard)
   end
 
   test "chunk_every/2" do

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -57,7 +57,7 @@ defmodule EnumTest do
     enum = Enum
     enumerable = [1, 2, 3, 4, 5]
     assert enum.chunk(enumerable, 2, 1, :discard) == [[1, 2], [2, 3], [3, 4], [4, 5]]
-    assert enum.chunk(enumerable, 2, 1, nil) == enum.chunk(enumerable, 2, 1, :discard)
+    assert enum.chunk(enumerable, 2, 1, nil) == Enum.chunk_every(enumerable, 2, 1, :discard)
   end
 
   test "chunk_every/2" do

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -50,7 +50,7 @@ defmodule EnumTest do
   test "chunk/3" do
     enum = Enum
     enumerable = [1, 2, 3, 4, 5]
-    assert enum.chunk(enumerable, 2, 1) == enum.chunk(enumerable, 2, 1, :discard)
+    assert enum.chunk(enumerable, 2, 1) == Enum.chunk_every(enumerable, 2, 1, :discard)
   end
 
   test "chunk/4" do

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -56,6 +56,15 @@ defmodule EnumTest do
     end)
   end
 
+  test "chunk/4" do
+    enumerable = [1, 2, 3, 4, 5]
+
+    capture_io(fn ->
+      assert Enum.chunk(enumerable, 2, 1, :discard) == [[1, 2], [2, 3], [3, 4], [4, 5]]
+      assert Enum.chunk(enumerable, 2, 1, nil) == Enum.chunk(enumerable, 2, 1, :discard)
+    end)
+  end
+
   test "chunk_every/2" do
     assert Enum.chunk_every([1, 2, 3, 4, 5], 2) == [[1, 2], [3, 4], [5]]
   end

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -2,6 +2,7 @@ Code.require_file("test_helper.exs", __DIR__)
 
 defmodule EnumTest do
   use ExUnit.Case, async: true
+  import ExUnit.CaptureIO
   doctest Enum
 
   defp assert_runs_enumeration_only_once(enum_fun) do
@@ -45,6 +46,14 @@ defmodule EnumTest do
     assert Enum.at([2, 4, 6], 4, :none) == :none
     assert Enum.at([2, 4, 6], -2) == 4
     assert Enum.at([2, 4, 6], -4) == nil
+  end
+
+  test "chunk/3" do
+    enumerable = [1, 2, 3, 4, 5]
+
+    capture_io(fn ->
+      assert Enum.chunk(enumerable, 2, 1) == Enum.chunk(enumerable, 2, 1, :discard)
+    end)
   end
 
   test "chunk_every/2" do

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -2,7 +2,6 @@ Code.require_file("test_helper.exs", __DIR__)
 
 defmodule EnumTest do
   use ExUnit.Case, async: true
-  import ExUnit.CaptureIO
   doctest Enum
 
   defp assert_runs_enumeration_only_once(enum_fun) do
@@ -49,20 +48,16 @@ defmodule EnumTest do
   end
 
   test "chunk/3" do
+    enum = Enum
     enumerable = [1, 2, 3, 4, 5]
-
-    capture_io(fn ->
-      assert Enum.chunk(enumerable, 2, 1) == Enum.chunk(enumerable, 2, 1, :discard)
-    end)
+    assert enum.chunk(enumerable, 2, 1) == enum.chunk(enumerable, 2, 1, :discard)
   end
 
   test "chunk/4" do
+    enum = Enum
     enumerable = [1, 2, 3, 4, 5]
-
-    capture_io(fn ->
-      assert Enum.chunk(enumerable, 2, 1, :discard) == [[1, 2], [2, 3], [3, 4], [4, 5]]
-      assert Enum.chunk(enumerable, 2, 1, nil) == Enum.chunk(enumerable, 2, 1, :discard)
-    end)
+    assert enum.chunk(enumerable, 2, 1, :discard) == [[1, 2], [2, 3], [3, 4], [4, 5]]
+    assert enum.chunk(enumerable, 2, 1, nil) == enum.chunk(enumerable, 2, 1, :discard)
   end
 
   test "chunk_every/2" do


### PR DESCRIPTION
Affects: `~> 1.7`, `~> 1.8` and `~> 1.9`
Fixes: #9506

The problem is caused by this commit: 11a0b39ad4a57236c9eb6bf17e5d46cc06621b8b

This means that it has been done when working on `v1.7.0-rc.0` for deprecating `Enum.chunk/4` in favor of `Enum.chunk_every/4`.