### PR TITLE
Configurable protocol consolidation timeout

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.protocols.ex
+++ b/lib/mix/lib/mix/tasks/compile.protocols.ex
@@ -125,12 +125,10 @@ defmodule Mix.Tasks.Compile.Protocols do
   defp consolidate(protocols, paths, output, manifest, metadata, opts) do
     File.mkdir_p!(output)
 
-    consolidate_protocols_timeout = Application.get_env(:mix, :consolidate_protocols_timeout, 30000)
-
     protocols
     |> Enum.uniq()
     |> Enum.map(&Task.async(fn -> consolidate(&1, paths, output, opts) end))
-    |> Enum.map(&Task.await(&1, consolidate_protocols_timeout))
+    |> Enum.map(&Task.await(&1, :infinity))
 
     write_manifest(manifest, metadata)
     :ok

--- a/lib/mix/lib/mix/tasks/compile.protocols.ex
+++ b/lib/mix/lib/mix/tasks/compile.protocols.ex
@@ -125,10 +125,12 @@ defmodule Mix.Tasks.Compile.Protocols do
   defp consolidate(protocols, paths, output, manifest, metadata, opts) do
     File.mkdir_p!(output)
 
+    consolidate_protocols_timeout = Application.get_env(:mix, :consolidate_protocols_timeout, 30000)
+
     protocols
     |> Enum.uniq()
     |> Enum.map(&Task.async(fn -> consolidate(&1, paths, output, opts) end))
-    |> Enum.map(&Task.await(&1, 30000))
+    |> Enum.map(&Task.await(&1, consolidate_protocols_timeout))
 
     write_manifest(manifest, metadata)
     :ok


### PR DESCRIPTION
Allow protocol consolidation to be configurable
with a default timeout value of 30 seconds.