### PR TITLE
Removed struct() from list of Basic Types in Typespecs.md

### DIFF
--- a/lib/elixir/pages/Typespecs.md
+++ b/lib/elixir/pages/Typespecs.md
@@ -50,7 +50,6 @@ The notation to represent the union of types is the pipe `|`. For example, the t
           | pid()                   # process identifier
           | port()                  # port identifier
           | reference()
-          | struct()                # any struct
           | tuple()                 # tuple of any size
 
                                     ## Numbers


### PR DESCRIPTION
fixes: #9522
ping: @ericmj 

Initially added in this commit: f1d4d5b034bd47d6488b808766f25a3f6fd82683

> Good find. It should only be listed in built-in types.