### PR TITLE
Revamp capture_io for named devices to be async

### DIFF
--- a/lib/ex_unit/lib/ex_unit/capture_io.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_io.ex
@@ -169,21 +169,20 @@ defmodule ExUnit.CaptureIO do
 
       {:error, {:changed_encoding, current_encoding}} ->
         raise ArgumentError, """
-        Attempted to change the encoding already set for the captured named device `#{
-          inspect(device)
-        }`
+        attempted to change the encoding for a currently captured device #{inspect(device)}.
+
         Currently set as: #{inspect(current_encoding)}
         Given: #{inspect(encoding)}
 
-        If you need to use multiple encodings on a captured named device, you cannot
-        run your test asynchronously.
+        If you need to use multiple encodings on a captured device, you cannot \
+        run your test asynchronously
         """
 
       {:error, :input_on_already_captured_device} ->
         raise ArgumentError,
-              "Attempted to give an input #{inspect(input)} for a currently captured named device `#{
-                inspect(device)
-              }`"
+              "attempted to give an input #{inspect(input)} for a currently captured device " <>
+                "#{inspect(device)}. If you need to give an input to a captured device, " <>
+                "you cannot run your test asynchronously"
     end
   end
 

--- a/lib/ex_unit/lib/ex_unit/capture_io.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_io.ex
@@ -159,7 +159,7 @@ defmodule ExUnit.CaptureIO do
       {:ok, ref} ->
         try do
           fun.()
-          ExUnit.CaptureServer.device_output(ref)
+          ExUnit.CaptureServer.device_output(device, ref)
         after
           ExUnit.CaptureServer.device_capture_off(ref)
         end

--- a/lib/ex_unit/lib/ex_unit/capture_io.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_io.ex
@@ -166,6 +166,24 @@ defmodule ExUnit.CaptureIO do
 
       {:error, :no_device} ->
         raise "could not find IO device registered at #{inspect(device)}"
+
+      {:error, {:changed_encoding, current_encoding}} ->
+        raise ArgumentError, """
+        Attempted to change the encoding already set for the captured named device `#{
+          inspect(device)
+        }`
+        Currently set as: #{inspect(current_encoding)}
+        Given: #{inspect(encoding)}
+
+        If you need to use multiple encodings on a captured named device, you cannot
+        run your test asynchronously.
+        """
+
+      {:error, :input_on_already_captured_device} ->
+        raise ArgumentError,
+              "Attempted to give an input #{inspect(input)} for a currently captured named device `#{
+                inspect(device)
+              }`"
     end
   end
 

--- a/lib/ex_unit/lib/ex_unit/capture_io.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_io.ex
@@ -154,23 +154,18 @@ defmodule ExUnit.CaptureIO do
   defp do_capture_io(device, options, fun) do
     input = Keyword.get(options, :input, "")
     encoding = Keyword.get(options, :encoding, :unicode)
-    {:ok, string_io} = StringIO.open(input, encoding: encoding)
 
-    case ExUnit.CaptureServer.device_capture_on(device, string_io) do
+    case ExUnit.CaptureServer.device_capture_on(device, encoding, input) do
       {:ok, ref} ->
         try do
-          do_capture_io(string_io, fun)
+          fun.()
+          ExUnit.CaptureServer.device_output(ref)
         after
           ExUnit.CaptureServer.device_capture_off(ref)
         end
 
       {:error, :no_device} ->
-        _ = StringIO.close(string_io)
         raise "could not find IO device registered at #{inspect(device)}"
-
-      {:error, :already_captured} ->
-        _ = StringIO.close(string_io)
-        raise "IO device registered at #{inspect(device)} is already captured"
     end
   end
 

--- a/lib/ex_unit/lib/ex_unit/capture_io.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_io.ex
@@ -35,10 +35,20 @@ defmodule ExUnit.CaptureIO do
   process and therefore can be done concurrently.
 
   However, the capturing of any other named device, such as `:stderr`,
-  happens globally and requires `async: false`.
+  happens globally and persists until the function has ended. While this means
+  it is safe to run your tests with `async: true` in many cases, captured output
+  may include output from a different test and care must be taken when using
+  `capture_io` with a named process asynchronously.
 
-  A developer can set a string as an input. The default input
-  is an empty string.
+  A developer can set a string as an input. The default input is an empty
+  string. If capturing a named device asynchronously, an input can only be given
+  to the first capture. Any further capture that is given to a capture on that
+  device will raise an exception and would indicate that the test should be run
+  synchronously.
+
+  Similarly, once a capture on a named device has begun, the encoding on that
+  device cannot be changed in a subsequent concurrent capture. An error will
+  be raised in this case.
 
   ## IO devices
 

--- a/lib/ex_unit/lib/ex_unit/capture_server.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_server.ex
@@ -85,7 +85,7 @@ defmodule ExUnit.CaptureServer do
   end
 
   defp capture_device(name, encoding, "", %{devices: devices} = config, caller)
-       when :erlang.is_map_key(name, devices) do
+       when is_map_key(devices, name) do
     case Map.get(devices, name) do
       %{encoding: ^encoding} = device ->
         {_, output} = StringIO.contents(device.pid)

--- a/lib/ex_unit/lib/ex_unit/capture_server.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_server.ex
@@ -100,7 +100,7 @@ defmodule ExUnit.CaptureServer do
   end
 
   defp capture_device(name, _, _, %{devices: devices} = config, _)
-       when :erlang.is_map_key(name, devices) do
+       when is_map_key(devices, name) do
     {:reply, {:error, :input_on_already_captured_device}, config}
   end
 


### PR DESCRIPTION
I hope @fertapric doesn't mind that I took a swing at this one. I just now saw that he was assigned...

With this change all StringIO stuff for named devices has been moved to the CaptureServer and we start a single StringIO for a given named device. All further captures on that device share the same StringIO, until all captures on that device have finished, at which time the StringIO is closed.

Async output from the device will be mixed in with other output, but we will offset from when a capture is first started to try and avoid too much unintended output being included in the captured output.

One thing that's a little tricky is that with the single StringIO, we only set the encoding once when the StringIO is first spawned. There's definitely some additional documentation or something that needs to come with this. Maybe if you need to set the encoding for named devices to anything other than `:unicode` then you can't do async capture_io?

Resolves #9508 