### PR TITLE
Add `--warnings-as-errors` flag to `mix test`

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -196,6 +196,8 @@ defmodule Mix.Tasks.Test do
     * `--timeout` - sets the timeout for the tests
     * `--trace` - runs tests with detailed reporting. Automatically sets `--max-cases` to `1`.
       Note that in trace mode test timeouts will be ignored as timeout is set to `:infinity`
+    * `--warnings-as-errors` - treats warnings in the current project and tests as errors and
+      return a non-zero exit code
 
   ## Configuration
 
@@ -362,6 +364,7 @@ defmodule Mix.Tasks.Test do
     formatter: :keep,
     slowest: :integer,
     partitions: :integer,
+    warnings_as_errors: :boolean,
     preload_modules: :boolean
   ]
 
@@ -424,6 +427,11 @@ defmodule Mix.Tasks.Test do
             preferred_cli_env: ["test.another": :test]
       """)
     end
+
+    # Apply valid compiler options
+    opts
+    |> Keyword.take(Code.available_compiler_options())
+    |> Code.compiler_options()
 
     Mix.Task.run("loadpaths", args)
 

--- a/lib/mix/test/fixtures/test_warning/mix.exs
+++ b/lib/mix/test/fixtures/test_warning/mix.exs
@@ -1,0 +1,11 @@
+defmodule TestWarning.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :test_warning,
+      version: "0.0.1",
+      test_pattern: "*_test_warning.exs"
+    ]
+  end
+end

--- a/lib/mix/test/fixtures/test_warning/test/a_test_warning.exs
+++ b/lib/mix/test/fixtures/test_warning/test/a_test_warning.exs
@@ -1,0 +1,8 @@
+defmodule ATest do
+  use ExUnit.Case
+
+  test "f" do
+    a = :warn_unused_variable
+    assert true
+  end
+end

--- a/lib/mix/test/fixtures/test_warning/test/test_helper.exs
+++ b/lib/mix/test/fixtures/test_warning/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -297,6 +297,26 @@ defmodule Mix.Tasks.TestTest do
     end
   end
 
+  describe "--warnings-as-errors" do
+    test "makes the test compilation fail" do
+      in_fixture("test_warning", fn ->
+        output = mix(["test"])
+        assert output =~ "warning: variable \"a\" is unused"
+        assert output =~ "1 test, 0 failures"
+
+        refute output =~
+                 "Compilation failed due to warnings while using the --warnings-as-errors option"
+
+        output = mix(["test", "--warnings-as-errors"])
+        assert output =~ "warning: variable \"a\" is unused"
+        refute output =~ "1 test, 0 failures"
+
+        assert output =~
+                 "Compilation failed due to warnings while using the --warnings-as-errors option"
+      end)
+    end
+  end
+
   describe "logs and errors" do
     test "logs test absence for a project with no test paths" do
       in_fixture("test_stale", fn ->


### PR DESCRIPTION
This flag, copied over from `mix compile`, will make the compilation fail if the app itself or the tests throw any warnings.

The scaffolding is ready to allow setting other compiler parameters from `mix test` flags.

See #6476