### PR TITLE
Exclude tests that require epmd on Windows

### DIFF
--- a/lib/elixir/test/elixir/test_helper.exs
+++ b/lib/elixir/test/elixir/test_helper.exs
@@ -84,7 +84,7 @@ defmodule CodeFormatterHelpers do
 end
 
 assert_timeout = String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT") || "500")
-epmd_exclude = if match?({_, 0}, System.cmd("epmd", ["-daemon"])), do: [], else: [epmd: true]
+epmd_exclude = if match?({:win32, _}, :os.type()), do: [epmd: true], else: []
 os_exclude = if PathHelpers.windows?(), do: [unix: true], else: [windows: true]
 
 ExUnit.start(

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -6,7 +6,7 @@ Logger.remove_backend(:console)
 Application.put_env(:logger, :backends, [])
 
 os_exclude = if match?({:win32, _}, :os.type()), do: [unix: true], else: [windows: true]
-epmd_exclude = if match?({_, 0}, System.cmd("epmd", ["-daemon"])), do: [], else: [epmd: true]
+epmd_exclude = if match?({:win32, _}, :os.type()), do: [epmd: true], else: []
 ExUnit.start(trace: "--trace" in System.argv(), exclude: epmd_exclude ++ os_exclude)
 
 unless {1, 7, 4} <= Mix.SCM.Git.git_version() do


### PR DESCRIPTION
Temporary disable those test on Windows since the `epmd` daemon is failing to start in some Windows setups.

This is a temporary fix to not block the migration to Cirrus CI