### PR TITLE
Configure Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,67 @@
+env:
+  ELIXIR_ASSERT_TIMEOUT: 2000
+  LANG: C.UTF-8
+
+test_task:
+  container:
+    image: buildpack-deps:trusty
+
+  matrix:
+    - env:
+        OTP_RELEASE: OTP-22.1
+        CHECK_REPRODUCIBLE: true
+        CHECK_POSIX_COMPLIANT: true
+    - env:
+        OTP_RELEASE: OTP-22.0
+    - env:
+        OTP_RELEASE: OTP-21.3.8
+    - env:
+        OTP_RELEASE: OTP-21.2
+    - env:
+        OTP_RELEASE: OTP-21.1
+    - env:
+        OTP_RELEASE: OTP-21.0
+    - env:
+        OTP_RELEASE: maint
+      allow_failures: true
+    - env:
+        OTP_RELEASE: master
+      allow_failures: true
+
+  install_script:
+    - wget -O otp.tar.gz https://repo.hex.pm/builds/otp/ubuntu-14.04/${OTP_RELEASE}.tar.gz
+    - mkdir -p otp
+    - tar zxf otp.tar.gz -C otp --strip-components=1
+    - otp/Install -minimal $(pwd)/otp
+
+  test_script:
+    - PATH=$(pwd)/otp/bin:$PATH
+    - rm -rf .git
+    - ELIXIRC_OPTS="--warnings-as-errors" ERLC_OPTS="+warning_as_errors" make compile
+    - make test
+    - dialyzer -pa lib/elixir/ebin --build_plt --output_plt elixir.plt --apps lib/elixir/ebin/elixir.beam lib/elixir/ebin/Elixir.Kernel.beam
+
+    # Check for reproducible builds only in the latest OTP release
+    - if [ -n "$CHECK_REPRODUCIBLE" ]; then make check_reproducible; fi
+
+    # Check for POSIX compliant shell scripts
+    - if [ -n "$CHECK_POSIX_COMPLIANT" ]; then
+        apt update;
+        apt install -y shellcheck;
+        shellcheck -e SC2039,2086 bin/elixir && echo "bin/elixir is POSIX compliant";
+        shellcheck bin/elixirc && echo "bin/elixirc is POSIX compliant";
+        shellcheck bin/iex && echo "bin/iex is POSIX compliant";
+      fi
+
+test_windows_task:
+  windows_container:
+    matrix:
+      - image: fertapric/elixir-ci:otp-win64-22.0
+        os_version: 2019
+      - image: fertapric/elixir-ci:otp-win64-21.0.1
+        os_version: 2019
+
+  test_script:
+    - rmdir /s /q .git
+    - make
+    - make --keep-going test_erlang test_elixir


### PR DESCRIPTION
Elixir is migrating from Travis to Cirrus CI to have a single place to test against Unix, FreeBSD, and Windows.