### PR TITLE
Track variable version globally

### DIFF
--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -71,7 +71,7 @@ defmodule Macro.Env do
            {%{optional(variable) => {var_version, var_type}},
             %{optional(variable) => {var_version, var_type}} | false}
   @typep unused_vars ::
-           %{optional({variable, var_version}) => non_neg_integer | false}
+           {%{optional({variable, var_version}) => non_neg_integer | false}, non_neg_integer}
   @typep prematch_vars ::
            %{optional(variable) => {var_version, var_type}} | :warn | :raise | :pin | :apply
   @typep tracers :: [module]
@@ -121,7 +121,7 @@ defmodule Macro.Env do
       prematch_vars: :warn,
       requires: [],
       tracers: [],
-      unused_vars: %{},
+      unused_vars: {%{}, 0},
       vars: []
     }
   end

--- a/lib/elixir/lib/module/types/helpers.ex
+++ b/lib/elixir/lib/module/types/helpers.ex
@@ -16,7 +16,7 @@ defmodule Module.Types.Helpers do
   @doc """
   Returns unique identifier for the current assignment of the variable.
   """
-  def var_name({name, meta, _context}), do: {name, Keyword.fetch!(meta, :version)}
+  def var_name({_name, meta, _context}), do: Keyword.fetch!(meta, :version)
 
   @doc """
   Push expression to stack.

--- a/lib/elixir/src/elixir_env.erl
+++ b/lib/elixir/src/elixir_env.erl
@@ -25,7 +25,7 @@ new() ->
     context_modules => [],                            %% modules defined in the current context
     vars => [],                                       %% a set of defined variables
     current_vars => {#{}, false},                     %% a tuple with maps of read and optional write current vars
-    unused_vars => #{},                               %% a map of unused vars
+    unused_vars => {#{}, 0},                          %% a map of unused vars and a version counter for vars
     prematch_vars => warn,                            %% controls behaviour outside and inside matches
     lexical_tracker => nil,                           %% lexical tracker PID
     contextual_vars => [],                            %% available contextual variables
@@ -42,8 +42,10 @@ linify(#{} = Env) ->
   Env.
 
 with_vars(Env, Vars) ->
-  Read = maps:from_list([{Var, 0} || Var <- Vars]),
-  Env#{vars := Vars, current_vars := {Read, false}, unused_vars := #{}}.
+  NumVars = length(Vars),
+  VarVersions = lists:zip(Vars, lists:seq(0, NumVars - 1)),
+  Read = maps:from_list(VarVersions),
+  Env#{vars := Vars, current_vars := {Read, false}, unused_vars := {#{}, NumVars}}.
 
 env_to_scope(#{context := Context}) ->
   #elixir_erl{context=Context}.
@@ -56,7 +58,7 @@ env_to_scope_with_vars(Env, Vars) ->
   }.
 
 reset_vars(Env) ->
-  Env#{vars := [], current_vars := {#{}, false}, unused_vars := #{}}.
+  Env#{vars := [], current_vars := {#{}, false}, unused_vars := {#{}, 0}}.
 
 %% SCOPE MERGING
 
@@ -83,17 +85,17 @@ merge_vars(V1, V2) ->
 
 %% UNUSED VARS
 
-reset_unused_vars(E) ->
-  E#{unused_vars := #{}}.
+reset_unused_vars(#{unused_vars := {_Unused, Version}} = E) ->
+  E#{unused_vars := {#{}, Version}}.
 
-check_unused_vars(#{unused_vars := Unused} = E) ->
+check_unused_vars(#{unused_vars := {Unused, _Version}} = E) ->
   [elixir_errors:form_warn([{line, Line}], E, ?MODULE, {unused_var, Name}) ||
     {{{Name, _}, _}, Line} <- maps:to_list(Unused), Line /= false, not_underscored(Name)],
   E.
 
-merge_and_check_unused_vars(E, #{unused_vars := ClauseUnused}) ->
-  #{current_vars := {Read, _}, unused_vars := Unused} = E,
-  E#{unused_vars := merge_and_check_unused_vars(Read, Unused, ClauseUnused, E)}.
+merge_and_check_unused_vars(E, #{unused_vars := {ClauseUnused, Version}}) ->
+  #{current_vars := {Read, _}, unused_vars := {Unused, _Version}} = E,
+  E#{unused_vars := {merge_and_check_unused_vars(Read, Unused, ClauseUnused, E), Version}}.
 
 merge_and_check_unused_vars(Current, Unused, ClauseUnused, E) ->
   maps:fold(fun({Var, Count} = Key, ClauseValue, Acc) ->

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -72,8 +72,8 @@ compile(Module, Block, Vars, #{line := Line, current_vars := {Read, _}} = Env) w
   %% point, the lexical tracker process is long gone.
   MaybeLexEnv =
     case ?key(Env, function) of
-      nil -> Env#{module := Module, current_vars := {Read, false}, unused_vars := #{}};
-      _   -> Env#{lexical_tracker := nil, function := nil, module := Module, current_vars := {Read, false}, unused_vars := #{}}
+      nil -> Env#{module := Module, current_vars := {Read, false}, unused_vars := {#{}, 0}};
+      _   -> Env#{lexical_tracker := nil, function := nil, module := Module, current_vars := {Read, false}, unused_vars := {#{}, 0}}
     end,
 
   case MaybeLexEnv of

--- a/lib/elixir/test/elixir/module/types/infer_test.exs
+++ b/lib/elixir/test/elixir/module/types/infer_test.exs
@@ -133,7 +133,7 @@ defmodule Module.Types.InferTest do
 
     test "vars" do
       assert {{:var, 0}, var_context} = new_var({:foo, [version: 0], nil}, new_context())
-      assert {{:var, 1}, var_context} = new_var({:bar, [version: 0], nil}, var_context)
+      assert {{:var, 1}, var_context} = new_var({:bar, [version: 1], nil}, var_context)
 
       assert {:ok, {:var, 0}, context} = unify({:var, 0}, :integer, var_context)
       assert Types.lift_type({:var, 0}, context) == :integer
@@ -168,7 +168,7 @@ defmodule Module.Types.InferTest do
 
     test "vars inside tuples" do
       assert {{:var, 0}, var_context} = new_var({:foo, [version: 0], nil}, new_context())
-      assert {{:var, 1}, var_context} = new_var({:bar, [version: 0], nil}, var_context)
+      assert {{:var, 1}, var_context} = new_var({:bar, [version: 1], nil}, var_context)
 
       assert {:ok, {:tuple, [{:var, 0}]}, context} =
                unify({:tuple, [{:var, 0}]}, {:tuple, [:integer]}, var_context)
@@ -196,8 +196,8 @@ defmodule Module.Types.InferTest do
 
     test "recursive type" do
       assert {{:var, 0}, var_context} = new_var({:foo, [version: 0], nil}, new_context())
-      assert {{:var, 1}, var_context} = new_var({:bar, [version: 0], nil}, var_context)
-      assert {{:var, 2}, var_context} = new_var({:baz, [version: 0], nil}, var_context)
+      assert {{:var, 1}, var_context} = new_var({:bar, [version: 1], nil}, var_context)
+      assert {{:var, 2}, var_context} = new_var({:baz, [version: 2], nil}, var_context)
 
       assert {:ok, {:var, _}, context} = unify({:var, 0}, {:var, 1}, var_context)
       assert {:ok, {:var, _}, context} = unify({:var, 1}, {:var, 0}, context)


### PR DESCRIPTION
Instead of incrementing the version for each variable individually we increment it globally for all variables. This means we can uniquely identify each variable assignment with only the version.