### PR TITLE
Fix bug in Calendar.ISO.day_of_era/3 typespec

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -23,6 +23,11 @@ defmodule Calendar do
   @type day_of_week :: non_neg_integer
   @type era :: non_neg_integer
 
+  @typedoc """
+  A tuple representing the `day` and the `era`.
+  """
+  @type day_of_era :: {day :: non_neg_integer(), era}
+
   @type hour :: non_neg_integer
   @type minute :: non_neg_integer
   @type second :: non_neg_integer
@@ -175,7 +180,7 @@ defmodule Calendar do
   @doc """
   Calculates the day and era from the given `year`, `month`, and `day`.
   """
-  @callback day_of_era(year, month, day) :: {non_neg_integer(), era}
+  @callback day_of_era(year, month, day) :: day_of_era()
 
   @doc """
   Converts the date into a string according to the calendar.

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -736,7 +736,7 @@ defmodule Calendar.ISO do
 
   """
   @doc since: "1.8.0"
-  @spec day_of_era(year, month, day) :: {day, era}
+  @spec day_of_era(year, month, day) :: Calendar.day_of_era()
   @impl true
   def day_of_era(year, month, day) when is_year_CE(year) do
     day = date_to_iso_days(year, month, day) - @iso_epoch + 1


### PR DESCRIPTION
Additionally, it introduces t:Calendar.day_of_era/0.