### PR TITLE
Add List.ends_with?/2

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -741,6 +741,41 @@ defmodule List do
   end
 
   @doc """
+  Returns `true` if `list` ends with the given `tail` list; otherwise returns `false`.
+
+  If `tail` is an empty list, it returns `true`.
+
+  ### Examples
+
+      iex> List.ends_with?('this is a charlist', 'a charlist')
+      true
+
+      iex> List.ends_with?([1, 2, 3], [2, 3])
+      true
+
+      iex> List.ends_with?([2, 3], [1, 2, 3])
+      false
+
+      iex> List.ends_with?([:alpha], [])
+      true
+
+      iex> List.ends_with?([], [:alpha])
+      false
+
+  """
+  @doc since: "1.10.0"
+  @spec ends_with?(nonempty_list, nonempty_list) :: boolean
+  @spec ends_with?(list, []) :: true
+  @spec ends_with?([], nonempty_list) :: false
+  def ends_with?(list, tail)
+
+  def ends_with?(list, []) when is_list(list), do: true
+  def ends_with?([], tail) when is_list(tail), do: false
+
+  def ends_with?(list, tail) when is_list(list) and is_list(tail),
+    do: starts_with?(:lists.reverse(list), :lists.reverse(tail))
+
+  @doc """
   Returns `true` if `list` starts with the given `prefix` list; otherwise returns `false`.
 
   If `prefix` is an empty list, it returns `true`.

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -183,6 +183,46 @@ defmodule ListTest do
     assert List.pop_at([1, 2, 3], -4) == {nil, [1, 2, 3]}
   end
 
+  describe "ends_with?/2" do
+    test "list and suffix are equal" do
+      assert List.ends_with?([], [])
+      assert List.ends_with?([1], [1])
+      assert List.ends_with?([1, 2, 3], [1, 2, 3])
+    end
+
+    test "proper lists" do
+      refute List.ends_with?([1], [1, 2])
+      assert List.ends_with?([1, 2, 3], [2, 3])
+      refute List.ends_with?([1, 2, 3], [1, 2])
+      refute List.ends_with?([1, 2, 3], [1, 2, 3, 4])
+    end
+
+    test "list is empty" do
+      refute List.ends_with?([], [1])
+      refute List.ends_with?([], [1, 2])
+    end
+
+    test "suffix is empty" do
+      assert List.ends_with?([1], [])
+      assert List.ends_with?([1, 2], [])
+      assert List.ends_with?([1, 2, 3], [])
+    end
+
+    test "only accepts proper lists" do
+      assert_raise FunctionClauseError, fn ->
+        List.ends_with?([1], [1 | 2])
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        List.ends_with?([1 | 2], [2])
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        List.ends_with?([1, 2], 2)
+      end
+    end
+  end
+
   describe "starts_with?/2" do
     test "list and prefix are equal" do
       assert List.starts_with?([], [])


### PR DESCRIPTION
We have `String.starts_with?/2`, `String.ends_with?/2`, and `List.starts_with?/2`, but we are missing `List.ends_with?/2`.

I'm bypassing sending this proposal to the mailing list because I think it's kind of unnecessary but I can do if needed.