### PR TITLE
Make the number of attempted function clauses in FunctionClauseError more obvious

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1062,6 +1062,8 @@ end
 defmodule FunctionClauseError do
   defexception [:module, :function, :arity, :kind, :args, :clauses]
 
+  @clause_limit 10
+
   @impl true
   def message(exception) do
     case exception do
@@ -1114,7 +1116,7 @@ defmodule FunctionClauseError do
 
     "\n\nThe following arguments were given to #{mfa}:\n" <>
       "#{format_args(args, inspect_fun)}" <>
-      "#{format_clauses(clauses, format_clause_fun)}"
+      "#{format_clauses(clauses, format_clause_fun, @clause_limit)}"
   end
 
   defp format_args(args, inspect_fun) do
@@ -1125,7 +1127,7 @@ defmodule FunctionClauseError do
     end)
   end
 
-  defp format_clauses(clauses, format_clause_fun, limit \\ 10)
+  defp format_clauses(clauses, format_clause_fun, limit)
   defp format_clauses(nil, _, _), do: ""
   defp format_clauses([], _, _), do: ""
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1107,46 +1107,45 @@ defmodule FunctionClauseError do
 
     mfa = Exception.format_mfa(module, function, arity)
 
-    formatted_args =
-      args
-      |> Enum.with_index(1)
-      |> Enum.map(fn {arg, i} ->
-        ["\n    # ", Integer.to_string(i), "\n    ", pad(inspect_fun.(arg)), "\n"]
-      end)
+    format_clause_fun = fn {args, guards} ->
+      code = Enum.reduce(guards, {function, [], args}, &{:when, [], [&2, &1]})
+      "    #{kind} " <> Macro.to_string(code, ast_fun) <> "\n"
+    end
 
-    formatted_clauses =
-      if clauses do
-        format_clause_fun = fn {args, guards} ->
-          code = Enum.reduce(guards, {function, [], args}, &{:when, [], [&2, &1]})
-          "    #{kind} " <> Macro.to_string(code, ast_fun) <> "\n"
-        end
-
-        top_10 =
-          clauses
-          |> Enum.take(10)
-          |> Enum.map(format_clause_fun)
-
-        clauses_not_shown = length(clauses) - 10
-
-        more_clauses =
-          cond do
-            clauses_not_shown == 1 -> ["    ...\n    (#{clauses_not_shown} clause not shown)\n"]
-            clauses_not_shown > 1 -> ["    ...\n    (#{clauses_not_shown} clauses not shown)\n"]
-            true -> []
-          end
-
-        [
-          "\nAttempted function clauses (showing #{length(top_10)} out of #{length(clauses)}):",
-          "\n\n",
-          top_10,
-          more_clauses
-        ]
-      else
-        ""
-      end
-
-    "\n\nThe following arguments were given to #{mfa}:\n#{formatted_args}#{formatted_clauses}"
+    "\n\nThe following arguments were given to #{mfa}:\n" <>
+      "#{format_args(args, inspect_fun)}" <>
+      "#{format_clauses(clauses, format_clause_fun)}"
   end
+
+  defp format_args(args, inspect_fun) do
+    args
+    |> Enum.with_index(1)
+    |> Enum.map(fn {arg, i} ->
+      [pad("\n# "), Integer.to_string(i), pad("\n"), pad(inspect_fun.(arg)), "\n"]
+    end)
+  end
+
+  defp format_clauses(clauses, format_clause_fun, limit \\ 10)
+  defp format_clauses(nil, _, _), do: ""
+  defp format_clauses([], _, _), do: ""
+
+  defp format_clauses(clauses, format_clause_fun, limit) do
+    top_clauses =
+      clauses
+      |> Enum.take(limit)
+      |> Enum.map(format_clause_fun)
+
+    [
+      "\nAttempted function clauses (showing #{length(top_clauses)} out of #{length(clauses)}):",
+      "\n\n",
+      top_clauses,
+      non_visible_clauses(length(clauses) - limit)
+    ]
+  end
+
+  defp non_visible_clauses(n) when n <= 0, do: []
+  defp non_visible_clauses(1), do: ["    ...\n    (1 clause not shown)\n"]
+  defp non_visible_clauses(n), do: ["    ...\n    (#{n} clauses not shown)\n"]
 
   defp pad(string) do
     String.replace(string, "\n", "\n    ")

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1126,10 +1126,20 @@ defmodule FunctionClauseError do
           |> Enum.take(10)
           |> Enum.map(format_clause_fun)
 
+        clauses_not_shown = length(clauses) - 10
+
+        more_clauses =
+          cond do
+            clauses_not_shown == 1 -> ["    ...\n    (#{clauses_not_shown} clause not shown)\n"]
+            clauses_not_shown > 1 -> ["    ...\n    (#{clauses_not_shown} clauses not shown)\n"]
+            true -> []
+          end
+
         [
           "\nAttempted function clauses (showing #{length(top_10)} out of #{length(clauses)}):",
           "\n\n",
-          top_10
+          top_10,
+          more_clauses
         ]
       else
         ""

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -771,6 +771,40 @@ defmodule ExceptionTest do
              """
     end
 
+    test "FunctionClauseError with blame and more than 10 clauses" do
+      {exception, _} =
+        Exception.blame(:error, :function_clause, [
+          {Macro, :to_string, [:invalid, :invalid], []}
+        ])
+
+      assert message(exception) =~ """
+             no function clause matching in Macro.to_string/2
+
+             The following arguments were given to Macro.to_string/2:
+
+                 # 1
+                 :invalid
+
+                 # 2
+                 :invalid
+
+             Attempted function clauses (showing 10 out of 24):
+
+                 def to_string(-{var, _, context} = ast-, fun) when -is_atom(var)- and -is_atom(context)-
+                 def to_string(-{:__aliases__, _, refs} = ast-, fun)
+                 def to_string(-{:__block__, _, [expr]} = ast-, fun)
+                 def to_string(-{:__block__, _, _} = ast-, fun)
+                 def to_string(-{:<<>>, _, parts} = ast-, fun)
+                 def to_string(-{:{}, _, args} = ast-, fun)
+                 def to_string(-{:%{}, _, args} = ast-, fun)
+                 def to_string(-{:%, _, [struct_name, map]} = ast-, fun)
+                 def to_string(-{:fn, _, [{:->, _, [_, tuple]}] = arrow} = ast-, fun) when -not(is_tuple(tuple))- or -elem(tuple, 0) != :__block__-
+                 def to_string(-{:fn, _, [{:->, _, _}] = block} = ast-, fun)
+                 ...
+                 (14 clauses not shown)
+             """
+    end
+
     test "ErlangError" do
       assert %ErlangError{original: :sample} |> message == "Erlang error: :sample"
     end


### PR DESCRIPTION
Ended up with @fertapric's suggestion but also appended the `...` as hinted at by @josevalim which ended up making the non visible clause section more obvious.

```
The following arguments were given to Macro.to_string/2:

    # 1
    :invalid

    # 2
    :invalid

Attempted function clauses (showing 10 out of 24):

    def to_string(-{var, _, context} = ast-, fun) when -is_atom(var)- and -is_atom(context)-
    def to_string(-{:__aliases__, _, refs} = ast-, fun)
    def to_string(-{:__block__, _, [expr]} = ast-, fun)
    def to_string(-{:__block__, _, _} = ast-, fun)
    def to_string(-{:<<>>, _, parts} = ast-, fun)
    def to_string(-{:{}, _, args} = ast-, fun)
    def to_string(-{:%{}, _, args} = ast-, fun)
    def to_string(-{:%, _, [struct_name, map]} = ast-, fun)
    def to_string(-{:fn, _, [{:->, _, [_, tuple]}] = arrow} = ast-, fun) when -not(is_tuple(tuple))- or -elem(tuple, 0) != :__block__-
    def to_string(-{:fn, _, [{:->, _, _}] = block} = ast-, fun)
    ...
    (14 clauses not shown)
```

Also refactored by extracting functions for `format_args`, `format_clauses` and `non_visible_clauses` and lifted the magic number 10 into a default argument.

This refactoring may bring us closer to being able to implement @kipcole9 's suggestion which would be great: to have a built in way to show all clauses if you need to. More work required to achieve this though.

Closes #9529