### PR TITLE
Reload kernel handlers before application starts

### DIFF
--- a/lib/logger/lib/logger/app.ex
+++ b/lib/logger/lib/logger/app.ex
@@ -25,6 +25,8 @@ defmodule Logger.App do
       {:ok, sup} ->
         primary_config = add_elixir_handler(otp_reports?, config)
 
+        :logger.add_handlers(:logger)
+
         default_handlers =
           if otp_reports? do
             delete_erlang_handler()

--- a/lib/mix/lib/mix/tasks/app.start.ex
+++ b/lib/mix/lib/mix/tasks/app.start.ex
@@ -76,6 +76,8 @@ defmodule Mix.Tasks.App.Start do
       # Mix should not depend directly on Logger, that's why we first check if it's loaded.
       if not logger_dependency?(apps) && Process.whereis(Logger), do: Logger.App.stop()
 
+      :logger.add_handlers(:kernel)
+
       start(apps, type(config, opts))
 
       # If there is a build path, we will let the application


### PR DESCRIPTION
However I do not know how this will work with filters and module levels.
I think that these will need to be handled separately.

Close #9545