### PR TITLE
Remove TODO to make tests async

### DIFF
--- a/lib/eex/test/eex/smart_engine_test.exs
+++ b/lib/eex/test/eex/smart_engine_test.exs
@@ -1,8 +1,7 @@
 Code.require_file("../test_helper.exs", __DIR__)
 
 defmodule EEx.SmartEngineTest do
-  # TODO: Make this async: true once capture_io is removed
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   test "evaluates simple string" do
     assert_eval("foo bar", "foo bar")


### PR DESCRIPTION
I found this TODO that said we should make this `async: true` once
capture_io was updated, and now that it is I'm removing the TODO and
making it async.