### PR TITLE
Add comment specyfing possible value of RELEASE_DISTRIBUTION inside env.{sh,bat}.eex

### DIFF
--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -73,6 +73,7 @@ defmodule Mix.Tasks.Release.Init do
     # Set the release to work across nodes. If using the long name format like
     # the one below (my_app@127.0.0.1), you need to also uncomment the
     # RELEASE_DISTRIBUTION variable below. Set it to "none" to disable distribution.
+    # Take note that RELEASE_DISTRIBUTION must be one of "name", "sname" or "none".
     # export RELEASE_DISTRIBUTION=name
     # export RELEASE_NODE=<%= @release.name %>@127.0.0.1
     """
@@ -254,7 +255,8 @@ defmodule Mix.Tasks.Release.Init do
     @echo off
     rem Set the release to work across nodes. If using the long name format like
     rem the one below (my_app@127.0.0.1), you need to also uncomment the
-    rem RELEASE_DISTRIBUTION variable below. Set it to "none" to disable distribution.
+    rem RELEASE_DISTRIBUTION variable below.
+    rem Take note that RELEASE_DISTRIBUTION must be one of "name", "sname" or "none".
     rem set RELEASE_DISTRIBUTION=name
     rem set RELEASE_NODE=<%= @release.name %>@127.0.0.1
     """

--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -72,8 +72,7 @@ defmodule Mix.Tasks.Release.Init do
 
     # Set the release to work across nodes. If using the long name format like
     # the one below (my_app@127.0.0.1), you need to also uncomment the
-    # RELEASE_DISTRIBUTION variable below. Set it to "none" to disable distribution.
-    # Take note that RELEASE_DISTRIBUTION must be one of "name", "sname" or "none".
+    # RELEASE_DISTRIBUTION variable below. Must be "sname", "name" or "none".
     # export RELEASE_DISTRIBUTION=name
     # export RELEASE_NODE=<%= @release.name %>@127.0.0.1
     """
@@ -255,8 +254,7 @@ defmodule Mix.Tasks.Release.Init do
     @echo off
     rem Set the release to work across nodes. If using the long name format like
     rem the one below (my_app@127.0.0.1), you need to also uncomment the
-    rem RELEASE_DISTRIBUTION variable below.
-    rem Take note that RELEASE_DISTRIBUTION must be one of "name", "sname" or "none".
+    rem RELEASE_DISTRIBUTION variable below. Must be "sname", "name" or "none".
     rem set RELEASE_DISTRIBUTION=name
     rem set RELEASE_NODE=<%= @release.name %>@127.0.0.1
     """


### PR DESCRIPTION
Using any other name there will cause release to fail - I think it's
good to have that information there - see f.e. #9195.