### PR TITLE
Add support for NO_COLOR environment variable

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -206,8 +206,8 @@ SCRIPT_PATH=$(dirname "$SELF")
 if [ "$OSTYPE" = "cygwin" ]; then SCRIPT_PATH=$(cygpath -m "$SCRIPT_PATH"); fi
 if [ "$MODE" != "iex" ]; then ERL="-noshell -s elixir start_cli $ERL"; fi
 
-if [ "$OS" != "Windows_NT" ]; then
-  if test -t 1 -a -t 2; then ERL="-elixir ansi_enabled true $ERL"; fi
+if [ "$OS" != "Windows_NT" -a -t 1 -a -t 2 -a "$NO_COLOR" != "" ]; then
+  ERL="-elixir ansi_enabled true $ERL"
 fi
 
 ERTS_BIN=

--- a/bin/elixir
+++ b/bin/elixir
@@ -206,8 +206,8 @@ SCRIPT_PATH=$(dirname "$SELF")
 if [ "$OSTYPE" = "cygwin" ]; then SCRIPT_PATH=$(cygpath -m "$SCRIPT_PATH"); fi
 if [ "$MODE" != "iex" ]; then ERL="-noshell -s elixir start_cli $ERL"; fi
 
-if [ "$OS" != "Windows_NT" ] && [ -t 1 ] && [ -t 2 ] && [ ! -z "$NO_COLOR" ]; then
-  ERL="-elixir ansi_enabled true $ERL"
+if [ "$OS" != "Windows_NT" ] && [ -n "$NO_COLOR" ]; then
+  if test -t 1 -a -t 2; then ERL="-elixir ansi_enabled true $ERL"; fi
 fi
 
 ERTS_BIN=

--- a/bin/elixir
+++ b/bin/elixir
@@ -206,7 +206,7 @@ SCRIPT_PATH=$(dirname "$SELF")
 if [ "$OSTYPE" = "cygwin" ]; then SCRIPT_PATH=$(cygpath -m "$SCRIPT_PATH"); fi
 if [ "$MODE" != "iex" ]; then ERL="-noshell -s elixir start_cli $ERL"; fi
 
-if [ "$OS" != "Windows_NT" -a -t 1 -a -t 2 -a "$NO_COLOR" != "" ]; then
+if [ "$OS" != "Windows_NT" ] && [ -t 1 ] && [ -t 2 ] && [ ! -z "$NO_COLOR" ]; then
   ERL="-elixir ansi_enabled true $ERL"
 fi
 


### PR DESCRIPTION
This is an implementation of [`NO_COLOR`][1] initiative that proposes single environment variable to prevent using colours in terminal. While I do not use that, I think that some people can be interested in such functionality.

[1]: https://no-color.org