### PR TITLE
Remove the URI example for `mix archive.install` help text

### DIFF
--- a/lib/mix/lib/mix/tasks/archive.install.ex
+++ b/lib/mix/lib/mix/tasks/archive.install.ex
@@ -18,7 +18,6 @@ defmodule Mix.Tasks.Archive.Install do
 
       mix archive.install archive.ez
       mix archive.install path/to/archive.ez
-      mix archive.install https://example.com/my_archive.ez
       mix archive.install git https://path/to/git/repo
       mix archive.install git https://path/to/git/repo branch git_branch
       mix archive.install git https://path/to/git/repo tag git_tag


### PR DESCRIPTION
This makes the `mix archive.install` help text consistent with the other changes from
commit 4b6b81098628f5f539a91b56357575293ca2bf55 and the `mix escript.install` help text.

Without a PR or any real description to explain this being intentional, the diff seems to imply that this may have been overlooked.