### PR TITLE
Correct title of section

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -183,7 +183,7 @@ defmodule Mix.Tasks.Test do
     * `--only` - runs only tests that match the filter
     * `--partitions` - sets the amount of partitions to split tests in. This option
       requires the `MIX_TEST_PARTITION` environment variable to be set. See the
-      "Operating system processes partitioning" section for more information
+      "Operating system process partitioning" section for more information
     * `--preload-modules` - preloads all modules defined in applications
     * `--raise` - raises if the test suite failed
     * `--seed` - seeds the random number generator used to randomize the order of tests;


### PR DESCRIPTION
In 6fb8efc6482d5c8526c507b91cd0982d221ec08c I accidentally
changed the title of the section
"OS Processes Partitioning" to
"Operating system process partitioning"
(notice "process" is in singular). Since "partitioning"
is the noun, and the rest are adjective, I think "process"
should be in singular.

This PR changes the reference to the section with the new title.