### PR TITLE
Explicitly mention that def and defmacro define public functions/macros

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3995,7 +3995,7 @@ defmodule Kernel do
   defp module_var({name, kind}), do: {name, [counter: kind, generated: true], nil}
 
   @doc ~S"""
-  Defines a function with the given name and body.
+  Defines a public function with the given name and body.
 
   ## Examples
 
@@ -4137,7 +4137,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Defines a macro with the given name and body.
+  Defines a public macro with the given name and body.
 
   Macros must be defined before its usage.
 

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -382,7 +382,7 @@ defmodule IEx.HelpersTest do
         "* def left == right\n\n  @spec term() == term() :: boolean()\n\nguard: true\n\nReturns `true` if the two terms are equal.\n\n"
 
       def_h =
-        "* defmacro def(call, expr \\\\ [])\n\nDefines a function with the given name and body."
+        "* defmacro def(call, expr \\\\ [])\n\nDefines a public function with the given name and body."
 
       assert capture_io(fn -> h(IEx.Helpers.pwd() / 0) end) =~ pwd_h
       assert capture_io(fn -> h(IEx.Helpers.c() / 2) end) =~ c_h


### PR DESCRIPTION
The concept of "public functions" is used in other parts of the module, but it is never mentioned how these functions are created.