### PR TITLE
Fix recently introduced bug in NO_COLOR feature

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -207,7 +207,7 @@ if [ "$OSTYPE" = "cygwin" ]; then SCRIPT_PATH=$(cygpath -m "$SCRIPT_PATH"); fi
 if [ "$MODE" != "iex" ]; then ERL="-noshell -s elixir start_cli $ERL"; fi
 
 if [ "$OS" != "Windows_NT" ] && [ -z "$NO_COLOR" ]; then
-  if test -t 1 && test -t 2; then ERL="-elixir ansi_enabled true $ERL"; fi
+  if test -t 1 -a -t 2; then ERL="-elixir ansi_enabled true $ERL"; fi
 fi
 
 ERTS_BIN=

--- a/bin/elixir
+++ b/bin/elixir
@@ -206,8 +206,8 @@ SCRIPT_PATH=$(dirname "$SELF")
 if [ "$OSTYPE" = "cygwin" ]; then SCRIPT_PATH=$(cygpath -m "$SCRIPT_PATH"); fi
 if [ "$MODE" != "iex" ]; then ERL="-noshell -s elixir start_cli $ERL"; fi
 
-if [ "$OS" != "Windows_NT" ] && [ -n "$NO_COLOR" ]; then
-  if test -t 1 -a -t 2; then ERL="-elixir ansi_enabled true $ERL"; fi
+if [ "$OS" != "Windows_NT" ] && [ -z "$NO_COLOR" ]; then
+  if test -t 1 && test -t 2; then ERL="-elixir ansi_enabled true $ERL"; fi
 fi
 
 ERTS_BIN=


### PR DESCRIPTION
Before this fix, colors are disabled in my shell, and NO_COLOR variable is unset.

Fixes a bug introduced in 499781d5dd304964981fce093ae7d1ade56d4351 (#9550)
where the variable is checked to be set, when it should be the opposite.

Additionally it removes the use of the "-a" as suggested in the POSIX
especifications
The Open Group Base Specifications Issue 7, 2018 edition
https://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html

"-a" is becoming obsolete and it may be removed in future versions.

> ...in cases where maximal portability is of concern, replace:
> test expr1 -a expr2
> with:
> test expr1 && test expr2

/cc @hauleth @josevalim @wojtekmach 