### PR TITLE
Use argument instead of arg in error messages

### DIFF
--- a/lib/elixir/src/elixir_clauses.erl
+++ b/lib/elixir/src/elixir_clauses.erl
@@ -275,7 +275,7 @@ expand_rescue(Meta, [Arg], E) ->
       form_error(Meta, E, ?MODULE, invalid_rescue_clause)
   end;
 expand_rescue(Meta, _, E) ->
-  Error = {wrong_number_of_args_for_clause, "one arg", origin(Meta, 'try'), 'rescue'},
+  Error = {wrong_number_of_args_for_clause, "one argument", origin(Meta, 'try'), 'rescue'},
   form_error(Meta, E, ?MODULE, Error).
 
 %% rescue var
@@ -316,11 +316,11 @@ normalize_rescue(Other) ->
 expand_head(Meta, Kind, Key) ->
   fun
     ([{'when', _, [_, _, _ | _]}], E) ->
-      form_error(Meta, E, ?MODULE, {wrong_number_of_args_for_clause, "one arg", Kind, Key});
+      form_error(Meta, E, ?MODULE, {wrong_number_of_args_for_clause, "one argument", Kind, Key});
     ([_] = Args, E) ->
       head(Args, E);
     (_, E) ->
-      form_error(Meta, E, ?MODULE, {wrong_number_of_args_for_clause, "one arg", Kind, Key})
+      form_error(Meta, E, ?MODULE, {wrong_number_of_args_for_clause, "one argument", Kind, Key})
   end.
 
 %% Returns a function that expands arguments
@@ -330,7 +330,7 @@ expand_one(Meta, Kind, Key, Fun) ->
     ([_] = Args, E) ->
       Fun(Args, E);
     (_, E) ->
-      form_error(Meta, E, ?MODULE, {wrong_number_of_args_for_clause, "one arg", Kind, Key})
+      form_error(Meta, E, ?MODULE, {wrong_number_of_args_for_clause, "one argument", Kind, Key})
   end.
 
 %% Expands all -> pairs in a given key but do not keep the overall vars.

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -698,7 +698,7 @@ defmodule Kernel.ErrorsTest do
 
   test "invalid case clauses" do
     assert_eval_raise CompileError,
-                      "nofile:1: expected one arg for :do clauses (->) in \"case\"",
+                      "nofile:1: expected one argument for :do clauses (->) in \"case\"",
                       'case nil do 0, z when not is_nil(z) -> z end'
   end
 

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -1201,16 +1201,18 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "expects one argument in clauses" do
-      assert_raise CompileError, ~r"expected one arg for :do clauses \(->\) in \"cond\"", fn ->
-        code =
-          quote do
-            cond do
-              _, _ -> :ok
-            end
-          end
+      assert_raise CompileError,
+                   ~r"expected one argument for :do clauses \(->\) in \"cond\"",
+                   fn ->
+                     code =
+                       quote do
+                         cond do
+                           _, _ -> :ok
+                         end
+                       end
 
-        expand(code)
-      end
+                     expand(code)
+                   end
     end
 
     test "raises for invalid arguments" do
@@ -1384,16 +1386,18 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "expects exactly one argument in clauses" do
-      assert_raise CompileError, ~r"expected one arg for :do clauses \(->\) in \"case\"", fn ->
-        code =
-          quote do
-            case e do
-              _, _ -> :ok
-            end
-          end
+      assert_raise CompileError,
+                   ~r"expected one argument for :do clauses \(->\) in \"case\"",
+                   fn ->
+                     code =
+                       quote do
+                         case e do
+                           _, _ -> :ok
+                         end
+                       end
 
-        expand(code)
-      end
+                     expand(code)
+                   end
     end
 
     test "fails with invalid arguments" do
@@ -1596,18 +1600,20 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "expects on argument for do/after clauses" do
-      assert_raise CompileError, ~r"expected one arg for :do clauses \(->\) in \"receive\"", fn ->
-        code =
-          quote do
-            receive do
-              _, _ -> :ok
-            end
-          end
+      assert_raise CompileError,
+                   ~r"expected one argument for :do clauses \(->\) in \"receive\"",
+                   fn ->
+                     code =
+                       quote do
+                         receive do
+                           _, _ -> :ok
+                         end
+                       end
 
-        expand(code)
-      end
+                     expand(code)
+                   end
 
-      message = ~r"expected one arg for :after clauses \(->\) in \"receive\""
+      message = ~r"expected one argument for :after clauses \(->\) in \"receive\""
 
       assert_raise CompileError, message, fn ->
         code =
@@ -1863,18 +1869,20 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "expects exactly one argument in rescue clauses" do
-      assert_raise CompileError, ~r"expected one arg for :rescue clauses \(->\) in \"try\"", fn ->
-        code =
-          quote do
-            try do
-              x
-            rescue
-              _, _ -> :ok
-            end
-          end
+      assert_raise CompileError,
+                   ~r"expected one argument for :rescue clauses \(->\) in \"try\"",
+                   fn ->
+                     code =
+                       quote do
+                         try do
+                           x
+                         rescue
+                           _, _ -> :ok
+                         end
+                       end
 
-        expand(code)
-      end
+                     expand(code)
+                   end
     end
 
     test "expects an alias, a variable, or \"var in [alias]\" as the argument of rescue clauses" do

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -50,7 +50,7 @@ defmodule KernelTest do
       assert var == 2
     end
 
-    test "can be reassigned inside a multi-arg call" do
+    test "can be reassigned inside a multi-argument call" do
       id(:arg, var = 1)
       id(:arg, var)
       id(:arg, var = 2)


### PR DESCRIPTION
Avoid use of abbreviations in error messages