### PR TITLE
Style mention to operating systems

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -6,7 +6,7 @@ defmodule File do
   to interact with files or IO devices, like `open/2`,
   `copy/3` and others. This module also provides higher
   level functions that work with filenames and have their naming
-  based on UNIX variants. For example, one can copy a file
+  based on Unix variants. For example, one can copy a file
   via `cp/3` and remove files and directories recursively
   via `rm_rf/1`.
 
@@ -722,7 +722,7 @@ defmodule File do
 
   Returns `:ok` in case of success, `{:error, reason}` otherwise.
 
-  Note: The command `mv` in Unix systems behaves differently depending on
+  Note: The command `mv` in Unix-like systems behaves differently depending on
   whether `source` is a file and the `destination` is an existing directory.
   We have chosen to explicitly disallow this behaviour.
 
@@ -778,7 +778,7 @@ defmodule File do
   or do a straight copy from a source to a destination without
   preserving modes, check `copy/3` instead.
 
-  Note: The command `cp` in Unix systems behaves differently depending on
+  Note: The command `cp` in Unix-like systems behaves differently depending on
   whether the destination is an existing directory or not. We have chosen to
   explicitly disallow copying to a destination which is a directory,
   and an error will be returned if tried.
@@ -846,7 +846,7 @@ defmodule File do
   success, `files_and_directories` lists all files and directories copied in no
   specific order. It returns `{:error, reason, file}` otherwise.
 
-  Note: The command `cp` in Unix systems behaves differently depending on
+  Note: The command `cp` in Unix-like systems behaves differently depending on
   whether `destination` is an existing directory or not. We have chosen to
   explicitly disallow this behaviour. If `source` is a `file` and `destination`
   is a directory, `{:error, :eisdir}` will be returned.
@@ -1243,7 +1243,7 @@ defmodule File do
   end
 
   # On Windows, symlinks are treated as directory and must be removed
-  # with rmdir/1. But on Unix, we remove them via rm/1. So we first try
+  # with rmdir/1. But on Unix-like systems, we remove them via rm/1. So we first try
   # to remove it as a directory and, if we get :enotdir, we fall back to
   # a file removal.
   defp do_rm_directory(path, {:ok, acc} = entry) do
@@ -1464,7 +1464,7 @@ defmodule File do
   @doc """
   Gets the current working directory.
 
-  In rare circumstances, this function can fail on Unix. It may happen
+  In rare circumstances, this function can fail on Unix-like systems. It may happen
   if read permissions do not exist for the parent directories of the
   current directory. For this reason, returns `{:ok, cwd}` in case
   of success, `{:error, reason}` otherwise.

--- a/lib/elixir/lib/file/stat.ex
+++ b/lib/elixir/lib/file/stat.ex
@@ -23,7 +23,7 @@ defmodule File.Stat do
     * `mtime` - the last time the file was written.
 
     * `ctime` - the interpretation of this time field depends on the operating
-      system. On Unix, it is the last time the file or the inode was changed.
+      system. On Unix-like operating systems, it is the last time the file or the inode was changed.
       In Windows, it is the time of creation.
 
     * `mode` - the file permissions.
@@ -35,17 +35,17 @@ defmodule File.Stat do
       In Windows, the number indicates a drive as follows: 0 means A:, 1 means
       B:, and so on.
 
-    * `minor_device` - only valid for character devices on Unix. In all other
+    * `minor_device` - only valid for character devices on Unix-like systems. In all other
       cases, this field is zero.
 
-    * `inode` - gives the inode number. On non-Unix file systems, this field
+    * `inode` - gives the inode number. On non-Unix-like file systems, this field
       will be zero.
 
-    * `uid` - indicates the owner of the file. Will be zero for non-Unix file
+    * `uid` - indicates the owner of the file. Will be zero for non-Unix-like file
       systems.
 
     * `gid` - indicates the group that owns the file. Will be zero for
-      non-Unix file systems.
+      non-Unix-like file systems.
 
   The time type returned in `atime`, `mtime`, and `ctime` is dependent on the
   time type set in options. `{:time, type}` where type can be `:local`,

--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -20,7 +20,7 @@ defmodule Path do
 
   ## Examples
 
-  ### Unix
+  ### Unix-like operating systems
 
       Path.absname("foo")
       #=> "/usr/local/foo"
@@ -188,7 +188,7 @@ defmodule Path do
 
   ## Examples
 
-  ### Unix
+  ### Unix-like operating systems
 
       Path.type("/")                #=> :absolute
       Path.type("/usr/local/bin")   #=> :absolute
@@ -216,7 +216,7 @@ defmodule Path do
 
   ## Examples
 
-  ### Unix
+  ### Unix-like operating systems
 
       Path.relative("/usr/local/bin")   #=> "usr/local/bin"
       Path.relative("usr/local/bin")    #=> "usr/local/bin"
@@ -560,7 +560,7 @@ defmodule Path do
   """
   @spec split(t) :: [binary]
 
-  # Work around a bug in Erlang on UNIX
+  # Work around a bug in Erlang on Unix-like operating systems
   def split(""), do: []
 
   def split(path) do

--- a/lib/elixir/lib/port.ex
+++ b/lib/elixir/lib/port.ex
@@ -20,7 +20,7 @@ defmodule Port do
       :ok
 
   In the example above, we have created a new port that executes the
-  program `cat`. `cat` is a program available on UNIX systems that
+  program `cat`. `cat` is a program available on Unix-like operating systems that
   receives data from multiple inputs and concatenates them in the output.
 
   After the port was created, we sent it two commands in the form of
@@ -124,7 +124,7 @@ defmodule Port do
   will have its stdin and stdout channels closed but **it won't be automatically
   terminated**.
 
-  While most UNIX command line tools will exit once its communication channels
+  While most Unix command line tools will exit once its communication channels
   are closed, not all command line applications will do so. You can easily check
   this by starting the port and then shutting down the VM and inspecting your
   operating system to see if the port process is still running.

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -335,7 +335,7 @@ defmodule System do
     1. the directory named by the TMPDIR environment variable
     2. the directory named by the TEMP environment variable
     3. the directory named by the TMP environment variable
-    4. `C:\TMP` on Windows or `/tmp` on Unix
+    4. `C:\TMP` on Windows or `/tmp` on Unix-like operating systems
     5. as a last resort, the current working directory
 
   Returns `nil` if none of the above are writable.
@@ -411,8 +411,8 @@ defmodule System do
   Locates an executable on the system.
 
   This function looks up an executable program given
-  its name using the environment variable PATH on Unix
-  and Windows. It also considers the proper executable
+  its name using the environment variable PATH on Windows and Unix-like
+  operating systems. It also considers the proper executable
   extension for each operating system, so for Windows it will try to
   lookup files with `.com`, `.cmd` or similar extensions.
   """
@@ -634,7 +634,7 @@ defmodule System do
   Returns the operating system PID for the current Erlang runtime system instance.
 
   Returns a string containing the (usually) numerical identifier for a process.
-  On UNIX, this is typically the return value of the `getpid()` system call.
+  On Unix-like operating systems, this is typically the return value of the `getpid()` system call.
   On Windows, the process ID as returned by the `GetCurrentProcessId()` system
   call is used.
 

--- a/lib/mix/lib/mix/local/installer.ex
+++ b/lib/mix/lib/mix/local/installer.ex
@@ -126,7 +126,7 @@ defmodule Mix.Local.Installer do
 
           You can download it either with your browser or via the command line.
 
-          On Unix (Linux, MacOS X):
+          On Unix-like operating systems (Linux, macOS):
 
               wget #{src}
 
@@ -134,7 +134,7 @@ defmodule Mix.Local.Installer do
 
               curl -o #{basename} #{src}
 
-          Windows (Win7 or later):
+          On Windows / PowerShell (Windows 7 or later):
 
               powershell -Command "Invoke-WebRequest #{src} -OutFile #{basename}"
 

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -44,7 +44,7 @@ defmodule Mix.Utils do
   Gets all paths defined in the MIX_PATH env variable.
 
   `MIX_PATH` may contain multiple paths. If on Windows, those
-  paths should be separated by `;`, if on Unix systems, use `:`.
+  paths should be separated by `;`, if on Unix-like systems, use `:`.
   """
   def mix_paths do
     if path = System.get_env("MIX_PATH") do


### PR DESCRIPTION
Use:
- macOS, instead of MacOS X;
- Windows 7, instead of Win7
- Unix, instead of UNIX
- Unix-like operating system or Unix-like system, instead of just Unix