### PR TITLE
Add second example for Stream.resource/3

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1383,6 +1383,21 @@ defmodule Stream do
         fn file -> File.close(file) end
       )
 
+      iex> Stream.resource(
+      ...>  fn ->
+      ...>    {:ok, pid} = StringIO.open("string")
+      ...>    pid
+      ...>  end,
+      ...>  fn pid ->
+      ...>    case IO.getn(pid, "", 1) do
+      ...>      :eof -> {:halt, pid}
+      ...>      char -> {[char], pid}
+      ...>    end
+      ...>  end,
+      ...>  fn pid -> StringIO.close(pid) end
+      ...> ) |> Enum.to_list()
+      ["s", "t", "r", "i", "n", "g"]
+
   """
   @spec resource((() -> acc), (acc -> {[element], acc} | {:halt, acc}), (acc -> term)) ::
           Enumerable.t()


### PR DESCRIPTION
After reading docs about Stream.resource/3 I had a feeling that they should be more hands-on.

So, I added a second example of usage - which should clearly demonstrate how it's working. And it's also a doctest :)