### PR TITLE
Fix release tar when include_erts is false

### DIFF
--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -1033,7 +1033,9 @@ defmodule Mix.Tasks.Release do
         lib_dirs ++ release_files
 
     files =
-      Enum.map(dirs, &{String.to_charlist(&1), String.to_charlist(Path.join(release.path, &1))})
+      dirs
+      |> Enum.filter(&File.exists?(Path.join(release.path, &1)))
+      |> Enum.map(&{String.to_charlist(&1), String.to_charlist(Path.join(release.path, &1))})
 
     File.rm(out_path)
     :ok = :erl_tar.create(String.to_charlist(out_path), files, [:dereference, :compressed])


### PR DESCRIPTION
Ref #9567 

Now explicitly excludes `erts-x.x` dir and erlang libs when building a tar for a release that has `include_erts: false`.

Otherwise building the tar would fail with `:enoent`.

I'm not sure if this is the correct place to filter out the erlang libs. It feels like they should not be part of `release.applications` at all.