### PR TITLE
Improvements in .cirrus.yml and increase execution speed

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,9 @@
 env:
-  ELIXIR_ASSERT_TIMEOUT: 2000
-  LANG: C.UTF-8
   CIRRUS_CLONE_DEPTH: 1
+  ELIXIR_ASSERT_TIMEOUT: 2000
+  ELIXIRC_OPTS: "--warnings-as-errors"
+  ERLC_OPTS: "+warning_as_errors"
+  LANG: C.UTF-8
 
 test_linux_task:
   name: Linux, ${OTP_RELEASE}, Ubuntu 14.04
@@ -12,8 +14,6 @@ test_linux_task:
     memory: 1500Mi
 
   env:
-    ELIXIRC_OPTS: "--warnings-as-errors"
-    ERLC_OPTS: "+warning_as_errors"
     PATH: "${CIRRUS_WORKING_DIR}/otp/bin:${PATH}"
 
   matrix:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ env:
   LANG: C.UTF-8
 
 test_linux_task:
-  name: Test (Linux - Ubuntu 14.04) / ${OTP_RELEASE}
+  name: Linux, ${OTP_RELEASE}, Ubuntu 14.04
 
   container:
     image: buildpack-deps:trusty
@@ -83,18 +83,22 @@ test_linux_task:
     fi
 
 test_windows_task:
-  name: Test (Windows Server 2019)
+  name: Windows, OTP-${OTP_RELEASE}, Windows Server 2019
+
+  matrix:
+    - env:
+        OTP_RELEASE: 22.0
+        OS_VERSION: 2019
+
+    - env:
+        OTP_RELEASE: 21.0.1
+        OS_VERSION: 2019
 
   windows_container:
+    image: fertapric/elixir-ci:otp-win64-${OTP_RELEASE}
+    os_version: ${OS_VERSION}
     cpu: 8
     memory: 1500Mi
-
-    matrix:
-      - image: fertapric/elixir-ci:otp-win64-22.0
-        os_version: 2019
-
-      - image: fertapric/elixir-ci:otp-win64-21.0.1
-        os_version: 2019
 
   install_script:
     - rmdir /s /q .git

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,15 +2,25 @@ env:
   ELIXIR_ASSERT_TIMEOUT: 2000
   LANG: C.UTF-8
 
-test_task:
+test_linux_task:
+  name: Test (Linux - Ubuntu 14.04) / ${OTP_RELEASE}
+
   container:
     image: buildpack-deps:trusty
+    cpu: 8
+    memory: 1500Mi
+
+  env:
+    PATH: "${CIRRUS_WORKING_DIR}/otp/bin:${PATH}"
+    ELIXIRC_OPTS: "--warnings-as-errors"
+    ERLC_OPTS: "+warning_as_errors"
 
   matrix:
     - env:
         OTP_RELEASE: OTP-22.1
         CHECK_REPRODUCIBLE: true
         CHECK_POSIX_COMPLIANT: true
+        TEST_FORMATTED: true
     - env:
         OTP_RELEASE: OTP-22.0
     - env:
@@ -34,36 +44,64 @@ test_task:
     - wget -O otp.tar.gz https://repo.hex.pm/builds/otp/ubuntu-14.04/${OTP_RELEASE}.tar.gz
     - mkdir -p otp
     - tar zxf otp.tar.gz -C otp --strip-components=1
-    - otp/Install -minimal $(pwd)/otp
-
-  test_script:
-    - PATH=$(pwd)/otp/bin:$PATH
+    - otp/Install -minimal ${CIRRUS_WORKING_DIR}/otp
     - rm -rf .git
-    - ELIXIRC_OPTS="--warnings-as-errors" ERLC_OPTS="+warning_as_errors" make compile
-    - make test
-    - dialyzer -pa lib/elixir/ebin --build_plt --output_plt elixir.plt --apps lib/elixir/ebin/elixir.beam lib/elixir/ebin/Elixir.Kernel.beam
+    - make compile
 
-    # Check for reproducible builds only in the latest OTP release
-    - if [ -n "$CHECK_REPRODUCIBLE" ]; then make check_reproducible; fi
+  info_script:
+    - bin/elixir --version
 
-    # Check for POSIX compliant shell scripts
-    - if [ -n "$CHECK_POSIX_COMPLIANT" ]; then
-        apt update;
-        apt install -y shellcheck;
-        shellcheck -e SC2039,2086 bin/elixir && echo "bin/elixir is POSIX compliant";
-        shellcheck bin/elixirc && echo "bin/elixirc is POSIX compliant";
-        shellcheck bin/iex && echo "bin/iex is POSIX compliant";
-      fi
+  test_formatted_script: |
+    if [ -n "$TEST_FORMATTED" ]; then
+      make test_formatted && echo "All files found to be properly formatted."
+    else
+      echo "No need for this test in this Erlang/OTP version."
+    fi
+
+  dialyzer_script: dialyzer -pa lib/elixir/ebin --build_plt --output_plt elixir.plt --apps lib/elixir/ebin/elixir.beam lib/elixir/ebin/Elixir.Kernel.beam
+
+  test_erlang_script: make test_erlang
+
+  test_elixir_script: make test_elixir
+
+  check_posix_compliant_script: |
+    if [ -n "$CHECK_POSIX_COMPLIANT" ]; then
+      apt update
+      apt install -y shellcheck
+      shellcheck -e SC2039,2086 bin/elixir && echo "bin/elixir is POSIX compliant"
+      shellcheck bin/elixirc && echo "bin/elixirc is POSIX compliant"
+      shellcheck bin/iex && echo "bin/iex is POSIX compliant"
+    else
+      echo "No need for this check in this Erlang/OTP version."
+    fi
+
+  check_reproducible_script: |
+    if [ -n "$CHECK_REPRODUCIBLE" ]; then
+      make check_reproducible
+    else
+      echo "No need for this check in this Erlang/OTP version."
+    fi
 
 test_windows_task:
+  name: Test (Windows Server 2019)
+
   windows_container:
+    cpu: 8
+    memory: 1500Mi
+
     matrix:
       - image: fertapric/elixir-ci:otp-win64-22.0
         os_version: 2019
+
       - image: fertapric/elixir-ci:otp-win64-21.0.1
         os_version: 2019
 
-  test_script:
+  install_script:
     - rmdir /s /q .git
-    - make
+    - make compile
+
+  info_script:
+    - bin/elixir --version
+
+  test_script:
     - make --keep-going test_erlang test_elixir

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,7 +49,7 @@ test_linux_task:
     - rm -rf .git
     - make compile
 
-  info_script: bin/elixir --version
+  build_info_script: bin/elixir --version
 
   test_formatted_script: |
     if [ -n "$TEST_FORMATTED" ]; then
@@ -104,7 +104,7 @@ test_windows_task:
     - rmdir /s /q .git
     - make compile
 
-  info_script: bin/elixir --version
+  build_info_script: bin/elixir --version
 
   test_erlang_script: make --keep-going test_erlang
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,7 +21,6 @@ test_linux_task:
         OTP_RELEASE: OTP-22.1
         CHECK_POSIX_COMPLIANT: true
         CHECK_REPRODUCIBLE: true
-        TEST_FORMATTED: true
     - env:
         OTP_RELEASE: OTP-22.0
     - env:
@@ -51,12 +50,9 @@ test_linux_task:
 
   build_info_script: bin/elixir --version
 
-  test_formatted_script: |
-    if [ -n "$TEST_FORMATTED" ]; then
-      make test_formatted && echo "All files found to be properly formatted."
-    else
-      echo "The format of the Elixir code is only checked in the last stable Erlang/OTP version."
-    fi
+  test_formatted_script:
+    - make test_formatted && \
+      echo "All files found to be properly formatted."
 
   dialyzer_script: dialyzer -pa lib/elixir/ebin --build_plt --output_plt elixir.plt --apps lib/elixir/ebin/elixir.beam lib/elixir/ebin/Elixir.Kernel.beam
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -55,7 +55,7 @@ test_linux_task:
     if [ -n "$TEST_FORMATTED" ]; then
       make test_formatted && echo "All files found to be properly formatted."
     else
-      echo "No need for this test in this Erlang/OTP version."
+      echo "The format of the Elixir code is only checked in the last stable Erlang/OTP version."
     fi
 
   dialyzer_script: dialyzer -pa lib/elixir/ebin --build_plt --output_plt elixir.plt --apps lib/elixir/ebin/elixir.beam lib/elixir/ebin/Elixir.Kernel.beam
@@ -72,14 +72,14 @@ test_linux_task:
       shellcheck bin/elixirc && echo "bin/elixirc is POSIX compliant"
       shellcheck bin/iex && echo "bin/iex is POSIX compliant"
     else
-      echo "No need for this check in this Erlang/OTP version."
+      echo "The format of the shell scripts is only checked in the last stable Erlang/OTP version."
     fi
 
   check_reproducible_script: |
     if [ -n "$CHECK_REPRODUCIBLE" ]; then
       make check_reproducible
     else
-      echo "No need for this check in this Erlang/OTP version."
+      echo "The format reproducibility of the build is only checked in the last stable Erlang/OTP version."
     fi
 
 test_windows_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -48,8 +48,7 @@ test_linux_task:
     - rm -rf .git
     - make compile
 
-  info_script:
-    - bin/elixir --version
+  info_script: bin/elixir --version
 
   test_formatted_script: |
     if [ -n "$TEST_FORMATTED" ]; then
@@ -104,8 +103,8 @@ test_windows_task:
     - rmdir /s /q .git
     - make compile
 
-  info_script:
-    - bin/elixir --version
+  info_script: bin/elixir --version
 
   test_erlang_script: make --keep-going test_erlang
+
   test_elixir_script: make --keep-going test_elixir

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -107,5 +107,5 @@ test_windows_task:
   info_script:
     - bin/elixir --version
 
-  test_script:
-    - make --keep-going test_erlang test_elixir
+  test_erlang_script: make --keep-going test_erlang
+  test_elixir_script: make --keep-going test_elixir

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,15 +12,15 @@ test_linux_task:
     memory: 1500Mi
 
   env:
-    PATH: "${CIRRUS_WORKING_DIR}/otp/bin:${PATH}"
     ELIXIRC_OPTS: "--warnings-as-errors"
     ERLC_OPTS: "+warning_as_errors"
+    PATH: "${CIRRUS_WORKING_DIR}/otp/bin:${PATH}"
 
   matrix:
     - env:
         OTP_RELEASE: OTP-22.1
-        CHECK_REPRODUCIBLE: true
         CHECK_POSIX_COMPLIANT: true
+        CHECK_REPRODUCIBLE: true
         TEST_FORMATTED: true
     - env:
         OTP_RELEASE: OTP-22.0

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,7 @@
 env:
   ELIXIR_ASSERT_TIMEOUT: 2000
   LANG: C.UTF-8
+  CIRRUS_CLONE_DEPTH: 1
 
 test_linux_task:
   name: Linux, ${OTP_RELEASE}, Ubuntu 14.04

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,7 +11,7 @@ test_linux_task:
   container:
     image: buildpack-deps:trusty
     cpu: 8
-    memory: 1500Mi
+    memory: 1536Mi
 
   env:
     PATH: "${CIRRUS_WORKING_DIR}/otp/bin:${PATH}"
@@ -93,8 +93,8 @@ test_windows_task:
   windows_container:
     image: fertapric/elixir-ci:otp-win64-${OTP_RELEASE}
     os_version: ${OS_VERSION}
-    cpu: 8
-    memory: 1500Mi
+    cpu: 4
+    memory: 3840Mi
 
   install_script:
     - rmdir /s /q .git

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -52,7 +52,7 @@ test_linux_task:
 
   test_formatted_script:
     - make test_formatted &&
-      echo "All Elixir source code files found to be properly formatted."
+      echo "All Elixir source code files are properly formatted."
 
   dialyzer_script: dialyzer -pa lib/elixir/ebin --build_plt --output_plt elixir.plt --apps lib/elixir/ebin/elixir.beam lib/elixir/ebin/Elixir.Kernel.beam
 
@@ -104,7 +104,7 @@ test_windows_task:
 
   test_formatted_script:
     - make test_formatted &&
-      echo "All Elixir source code files found to be properly formatted."
+      echo "All Elixir source code files are properly formatted."
 
   test_erlang_script: make --keep-going test_erlang
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,8 +51,8 @@ test_linux_task:
   build_info_script: bin/elixir --version
 
   test_formatted_script:
-    - make test_formatted && \
-      echo "All files found to be properly formatted."
+    - make test_formatted &&
+      echo "All Elixir source code files found to be properly formatted."
 
   dialyzer_script: dialyzer -pa lib/elixir/ebin --build_plt --output_plt elixir.plt --apps lib/elixir/ebin/elixir.beam lib/elixir/ebin/Elixir.Kernel.beam
 
@@ -101,6 +101,10 @@ test_windows_task:
     - make compile
 
   build_info_script: bin/elixir --version
+
+  test_formatted_script:
+    - make test_formatted &&
+      echo "All Elixir source code files found to be properly formatted."
 
   test_erlang_script: make --keep-going test_erlang
 

--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,7 @@ zips: Precompiled.zip Docs.zip
 
 #==> Test tasks
 
+# If you modify this task, please update .cirrus.yml accordinly
 test: test_formatted test_erlang test_elixir
 
 test_windows: test test_taskkill

--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ zips: Precompiled.zip Docs.zip
 
 #==> Test tasks
 
-# If you modify this task, please update .cirrus.yml accordinly
+# If you modify this task, please update .cirrus.yml accordingly
 test: test_formatted test_erlang test_elixir
 
 test_windows: test test_taskkill


### PR DESCRIPTION
 Improvements in .cirrus.yml and increase execution speed
    
    - Make use of $CIRRUS_WORKING_DIR instead of spawning a new process with $(pwd).
    - Only run the Elixir formatter, in the latest OTP version, in the same fashion of
      CHECK_POSIX_COMPLIANT and CHECK_REPRODUCIBLE.
    - TEST_FORMATTED environmetal variable added.
    - move fast executing scripts, such as "dialyzer" to the top of the list.
    - move "rm -rf .git" and "make compile" to the install script.
    - Put each command their own named scripts (i.e., test_formatted_script, dialyzer_script, test_erlang_script, test_elixir_script, check_posix_compliant_script, check_reproducible_script).
    - Split in the Windows task, the test_script into install_script and test_script, to mimic the scripts in the test_linux_task.
    - Messages added on success or when tests are skipped, so the user is better informed in the CI results page.
    - Added script that shows the output of `elixir --version`.
    - Left a comment in "test" task in Makefile to update accoringly .cirrus.yml if updated.
    
    Speed increase: The building times for the Linux builds have been reduced considerable, to 5 minutes. Sadly, setting the number of cpus for Windows doesn't work, and it takes 13 minutes to build.
    
    - CPU increased from the default value of 2, to 8
    - Memory decreased from the default value of 4GB, to 1500MiB (bringing it to a minimum needed, to speed up the
      scheduling in the CI).
    
    See the results in:
    https://cirrus-ci.com/build/6585376826720256

/cc @fertapric 