### PR TITLE
Add informative messages when running "make check_reproducible"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ check_reproducible: compile
 	$(Q) echo "==> Checking for reproducible builds..."
 	$(Q) rm -rf lib/*/tmp/ebin_reproducible/
 	$(call WRITE_SOURCE_DATE_EPOCH)
+	$(Q) echo "Moving compiled files to a temporary folder..."
 	$(Q) mkdir -p lib/elixir/tmp/ebin_reproducible/ \
 	              lib/eex/tmp/ebin_reproducible/ \
 	              lib/iex/tmp/ebin_reproducible/ \
@@ -140,6 +141,7 @@ check_reproducible: compile
 	$(Q) mv lib/iex/ebin/* lib/iex/tmp/ebin_reproducible/
 	$(Q) mv lib/logger/ebin/* lib/logger/tmp/ebin_reproducible/
 	$(Q) mv lib/mix/ebin/* lib/mix/tmp/ebin_reproducible/
+	$(Q) echo "Compiling again in order to compare files..."
 	SOURCE_DATE_EPOCH=$(call READ_SOURCE_DATE_EPOCH) $(MAKE) compile
 	$(Q) echo "Diffing..."
 	$(Q) diff -r lib/elixir/ebin/ lib/elixir/tmp/ebin_reproducible/


### PR DESCRIPTION
Output looks like this now.

```
$ make check_reproducible 
==> Checking for reproducible builds...
Moving compiled files to a temporary folder...
Compiling again in order to compare files...
SOURCE_DATE_EPOCH=1574379500 make compile
make[1]: Entering directory '/home/eksperimental/elixir'
Recompile: src/elixir_utils
...
Recompile: src/elixir_aliases
Recompile: src/elixir
Generated elixir.app
==> bootstrap (compile)
Compiled lib/elixir/lib/kernel.ex
Compiled lib/elixir/lib/macro/env.ex
..
Compiled lib/elixir/lib/kernel/parallel_compiler.ex
Compiled lib/elixir/lib/kernel/lexical_tracker.ex
make[2]: Entering directory '/home/eksperimental/elixir'
==> unicode (compile)
Compiling /home/eksperimental/elixir/lib/elixir/unicode/unicode.ex (it's taking more than 15s)
make[2]: Leaving directory '/home/eksperimental/elixir'
==> elixir (compile)
make[2]: Entering directory '/home/eksperimental/elixir'
Generated elixir.app
make[2]: Leaving directory '/home/eksperimental/elixir'
==> eex (compile)
==> mix (compile)
Generated mix app
==> logger (compile)
Generated logger app
Generated eex app
==> iex (compile)
Generated iex app
make[1]: Leaving directory '/home/eksperimental/elixir'
Diffing...
Binary files lib/elixir/ebin/Elixir.System.beam and lib/elixir/tmp/ebin_reproducible/Elixir.System.beam differ
Makefile:130: recipe for target 'check_reproducible' failed
make: *** [check_reproducible] Error 1
```