### PR TITLE
Fix Mix.Tasks.Compile.App output message

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -170,7 +170,7 @@ defmodule Mix.Tasks.Compile.App do
 
       Mix.Project.ensure_structure()
       File.write!(target, IO.chardata_to_string(contents))
-      Mix.shell().info("Generated #{app} app")
+      Mix.shell().info("Generated #{app}.app")
       {:ok, []}
     else
       {:noop, []}

--- a/lib/mix/test/mix/rebar_test.exs
+++ b/lib/mix/test/mix/rebar_test.exs
@@ -331,7 +331,7 @@ defmodule Mix.RebarTest do
 
         Mix.Tasks.Deps.Compile.run([])
         assert_received {:mix_shell, :info, ["==> rebar_dep"]}
-        assert_received {:mix_shell, :info, ["Generated rebar_dep app"]}
+        assert_received {:mix_shell, :info, ["Generated rebar_dep.app"]}
         assert File.regular?("_build/dev/lib/rebar_dep/ebin/rebar_dep.app")
       end)
     after

--- a/lib/mix/test/mix/tasks/compile_test.exs
+++ b/lib/mix/test/mix/tasks/compile_test.exs
@@ -76,7 +76,7 @@ defmodule Mix.Tasks.CompileTest do
       assert File.regular?("_build/dev/lib/sample/ebin/Elixir.A.beam")
       assert File.regular?("_build/dev/lib/sample/ebin/sample.app")
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
-      assert_received {:mix_shell, :info, ["Generated sample app"]}
+      assert_received {:mix_shell, :info, ["Generated sample.app"]}
       assert File.regular?("_build/dev/lib/sample/consolidated/Elixir.Enumerable.beam")
 
       # Noop

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -96,7 +96,7 @@ defmodule Mix.Tasks.XrefTest do
 
       output = """
       Compiling 2 files (.ex)
-      Generated sample app
+      Generated sample.app
       lib/b.ex (runtime)
       """
 
@@ -122,7 +122,7 @@ defmodule Mix.Tasks.XrefTest do
 
       output = """
       Compiling 2 files (.ex)
-      Generated sample app
+      Generated sample.app
       lib/a.ex (runtime)
       """
 
@@ -147,7 +147,7 @@ defmodule Mix.Tasks.XrefTest do
 
       output = """
       Compiling 2 files (.ex)
-      Generated sample app
+      Generated sample.app
       lib/a.ex (compile)
       lib/b.ex (compile)
       """
@@ -445,7 +445,7 @@ defmodule Mix.Tasks.XrefTest do
 
         assert Mix.Task.run("xref", opts ++ ["graph"]) == :ok
 
-        assert "Compiling 4 files (.ex)\nGenerated sample app\n" <> result =
+        assert "Compiling 4 files (.ex)\nGenerated sample.app\n" <> result =
                  receive_until_no_messages([])
 
         assert normalize_graph_output(result) == normalize_graph_output(expected)

--- a/lib/mix/test/mix/umbrella_test.exs
+++ b/lib/mix/test/mix/umbrella_test.exs
@@ -63,10 +63,10 @@ defmodule Mix.UmbrellaTest do
         Mix.Task.run("compile", ["--verbose"])
 
         assert_received {:mix_shell, :info, ["==> bar"]}
-        assert_received {:mix_shell, :info, ["Generated bar app"]}
+        assert_received {:mix_shell, :info, ["Generated bar.app"]}
         assert File.regular?("_build/dev/lib/bar/ebin/Elixir.Bar.beam")
         assert_received {:mix_shell, :info, ["==> foo"]}
-        assert_received {:mix_shell, :info, ["Generated foo app"]}
+        assert_received {:mix_shell, :info, ["Generated foo.app"]}
         assert File.regular?("_build/dev/lib/foo/ebin/Elixir.Foo.beam")
 
         # Ensure foo was loaded and in the same env as Mix.env
@@ -83,8 +83,8 @@ defmodule Mix.UmbrellaTest do
     in_fixture("umbrella_dep/deps/umbrella", fn ->
       Mix.Project.in_project(:umbrella, ".", fn _ ->
         Mix.Task.run("compile", ["--verbose"])
-        assert_received {:mix_shell, :info, ["Generated bar app"]}
-        assert_received {:mix_shell, :info, ["Generated foo app"]}
+        assert_received {:mix_shell, :info, ["Generated bar.app"]}
+        assert_received {:mix_shell, :info, ["Generated foo.app"]}
         assert File.regular?("_build/dev/consolidated/Elixir.Enumerable.beam")
         purge([Enumerable])
 
@@ -125,8 +125,8 @@ defmodule Mix.UmbrellaTest do
         end
 
         Mix.Task.run("umbrella.recur")
-        assert_received {:mix_shell, :info, ["Generated bar app"]}
-        assert_received {:mix_shell, :info, ["Generated foo app"]}
+        assert_received {:mix_shell, :info, ["Generated bar.app"]}
+        assert_received {:mix_shell, :info, ["Generated foo.app"]}
         assert File.regular?("_build/dev/consolidated/Elixir.Enumerable.beam")
         purge([Enumerable])
 
@@ -381,8 +381,8 @@ defmodule Mix.UmbrellaTest do
           assert catch_exit(Mix.Task.run("compile", ["--verbose"]))
         end)
 
-        refute_received {:mix_shell, :info, ["Generated foo app"]}
-        refute_received {:mix_shell, :info, ["Generated bar app"]}
+        refute_received {:mix_shell, :info, ["Generated foo.app"]}
+        refute_received {:mix_shell, :info, ["Generated bar.app"]}
         refute Code.ensure_loaded?(Bar)
       end)
     end)
@@ -392,8 +392,8 @@ defmodule Mix.UmbrellaTest do
     in_fixture("umbrella_dep/deps/umbrella/apps", fn ->
       Mix.Project.in_project(:bar, "bar", fn _ ->
         Mix.Task.run("compile", ["--verbose"])
-        assert_received {:mix_shell, :info, ["Generated foo app"]}
-        assert_received {:mix_shell, :info, ["Generated bar app"]}
+        assert_received {:mix_shell, :info, ["Generated foo.app"]}
+        assert_received {:mix_shell, :info, ["Generated bar.app"]}
         assert File.regular?("_build/dev/lib/foo/ebin/Elixir.Foo.beam")
         assert File.regular?("_build/dev/lib/bar/ebin/Elixir.Bar.beam")
 


### PR DESCRIPTION
When compiling Elixir, the "Generated" message was not consistent.
"Generated elixir.app" for Elixir and "Generated mix app",
for the rest.

```
Generated elixir.app
==> mix (compile)
Generated mix app
==> ex_unit (compile)
Generated ex_unit app
```

This commits add the "."