### PR TITLE
Add missing unreserved character to URI document

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -234,7 +234,7 @@ defmodule URI do
   the following characters are unreserved:
 
     * Alphanumeric characters: `A-Z`, `a-z`, `0-9`
-    * `~`, `_`, `-`
+    * `~`, `_`, `-`, `.`
 
   ## Examples
 


### PR DESCRIPTION
According to RFC 3986, section 2.3, add missing unreserved character.
The implementation already includes it.