### PR TITLE
Improve documentation for Config.Provider

### DIFF
--- a/lib/elixir/lib/config/provider.ex
+++ b/lib/elixir/lib/config/provider.ex
@@ -39,9 +39,15 @@ defmodule Config.Provider do
         end
       end
 
-  Then when specifying your release, you can specify the provider:
+  Then when specifying your release, you can specify the provider in
+  the release configuration:
 
-      config_providers: [{JSONConfigProvider, "/etc/config.json"}]
+      releases: [
+        demo: [
+          # ...,
+          config_providers: [{JSONConfigProvider, "/etc/config.json"}]
+        ]
+      ]
 
   Now once the system boots, it will invoke the provider early in
   the boot process, save the merged configuration to the disk, and


### PR DESCRIPTION
It's not necessarily clear where this configuration goes and even though it's explained in the docs for `mix release`, I figured it doesn't hurt to have it here too.