### PR TITLE
remove a confusing arg for Code.eval_quoted/3 in Mix.Dep.Lock

### DIFF
--- a/lib/mix/lib/mix/dep/lock.ex
+++ b/lib/mix/lib/mix/dep/lock.ex
@@ -17,7 +17,7 @@ defmodule Mix.Dep.Lock do
     with {:ok, contents} <- File.read(lockfile),
          assert_no_merge_conflicts_in_lockfile(lockfile, contents),
          {:ok, quoted} <- Code.string_to_quoted(contents, opts),
-         {%{} = lock, _binding} <- Code.eval_quoted(quoted, opts) do
+         {%{} = lock, _binding} <- Code.eval_quoted(quoted) do
       lock
     else
       _ -> %{}

--- a/lib/mix/lib/mix/dep/lock.ex
+++ b/lib/mix/lib/mix/dep/lock.ex
@@ -17,7 +17,7 @@ defmodule Mix.Dep.Lock do
     with {:ok, contents} <- File.read(lockfile),
          assert_no_merge_conflicts_in_lockfile(lockfile, contents),
          {:ok, quoted} <- Code.string_to_quoted(contents, opts),
-         {%{} = lock, _binding} <- Code.eval_quoted(quoted) do
+         {%{} = lock, _binding} <- Code.eval_quoted(quoted, [], opts) do
       lock
     else
       _ -> %{}


### PR DESCRIPTION
I think it is confusing and unnecessary to pass `opts` for `Code.string_to_quoted/2` to `Code.eval_quoted/3` as its second argument `binding`.
Removing the argument can save a bit of computation while keeping the intended functionality.