### PR TITLE
Deprioritize Linux Development tasks in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,6 +20,7 @@ test_linux_task:
 
   matrix:
     - name: Linux, ${OTP_RELEASE}, Ubuntu 14.04
+      alias: Linux Stable
       matrix:
         - env:
             CHECK_POSIX_COMPLIANT: true
@@ -37,8 +38,11 @@ test_linux_task:
             OTP_RELEASE: OTP-21.0
 
     - name: Linux, OTP-${OTP_RELEASE}, development, Ubuntu 14.04
+      alias: Linux Development
       allow_failures: true
       skip_notifications: true
+      depends_on:
+        - Linux Stable
       matrix:
         - env:
             OTP_RELEASE: master
@@ -86,6 +90,7 @@ test_linux_task:
 
 test_windows_task:
   name: Windows, OTP-${OTP_RELEASE}, Windows Server 2019
+  alias: Windows Stable
 
   # don't cancel the task execution if it's master or a release branch
   auto_cancellation: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH !=~ 'v\d+\.\d+.*'


### PR DESCRIPTION
Add depends_on to Linux Development task in CI.
Initially shared by @fkorotkov
https://github.com/elixir-lang/elixir/pull/9585

Implemented now that Cirrus CI supports the `alias` field.
https://github.com/cirruslabs/cirrus-ci-docs/issues/527

Thank you @fkorotkov

Note: given the current setup, Linux Development doesn't
depend on Windows Stable, due do the latter taking way
longer than the rest. When new stable tasks are added,
they should depend on them, as in the case of the upcoming
FreeBSD task.