### PR TITLE
Allow for match assertions in doctests

### DIFF
--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -61,11 +61,15 @@ defmodule ExUnit.DocTest do
       2
 
   If you don't want to assert for every result in a doctest, you can omit
-  the result:
+  the result in the middle of expressions:
 
       iex> pid = spawn(fn -> :ok end)
       iex> is_pid(pid)
       true
+
+  As well as at the end:
+
+      iex> Mod.do_a_call_that_should_not_raise!(...)
 
   This is useful when the result is something variable (like a PID in the
   example above) or when the result is a complicated data structure and you

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -507,10 +507,6 @@ defmodule ExUnit.DocTest do
     adjust_indent(:text, lines, line_no, [], 0, module)
   end
 
-  defp adjust_indent(:after_prompt, [], line_no, _adjusted_lines, _indent, module) do
-    raise_incomplete_doctest(line_no, module)
-  end
-
   defp adjust_indent(_kind, [], _line_no, adjusted_lines, _indent, _module) do
     Enum.reverse(adjusted_lines)
   end
@@ -868,11 +864,4 @@ defmodule ExUnit.DocTest do
 
   defp insert_match_assertion(ast),
     do: ast
-
-  defp raise_incomplete_doctest(line_no, module) do
-    raise Error,
-      line: line_no,
-      module: module,
-      message: "expected non-blank line to follow iex> prompt"
-  end
 end

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -61,7 +61,7 @@ defmodule ExUnit.DocTest do
       2
 
   If you don't want to assert for every result in a doctest, you can omit
-  the result in the middle of expressions:
+  the result. You can do so between expressions:
 
       iex> pid = spawn(fn -> :ok end)
       iex> is_pid(pid)

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -159,6 +159,8 @@ defmodule ExUnit.DocTestTest.Invalid do
       iex> raise "oops"
       ** (RuntimeError) hello
 
+      iex> %{a: _} = Map.put(%{b: :c}, :d, :e)
+
   """
 
   @doc """
@@ -550,6 +552,19 @@ defmodule ExUnit.DocTestTest do
            """
 
     assert output =~ """
+             8) doctest module ExUnit.DocTestTest.Invalid (8) (ExUnit.DocTestTest.ActuallyCompiled)
+             test/ex_unit/doc_test_test.exs:#{doctest_line}
+             match (=) failed
+             doctest:
+               iex> %{a: _} = Map.put(%{b: :c}, :d, :e)
+             left:  %{a: _}
+             right: %{b: :c, d: :e}
+
+             stacktrace:
+               test/ex_unit/doc_test_test.exs:162: ExUnit.DocTestTest.Invalid (module)
+           """
+
+    assert output =~ """
              8) doctest ExUnit.DocTestTest.Invalid.a/0 (8) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:165: syntax error before: '*'
@@ -625,6 +640,8 @@ defmodule ExUnit.DocTestTest do
                 stacktrace:
                   test/ex_unit/doc_test_test.exs:171: ExUnit.DocTestTest.Invalid (module)
            """
+
+
   end
 
   test "IEx prefix contains a number" do

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -291,6 +291,9 @@ end
 
 defmodule ExUnit.DocTestTest.Incomplete do
   @doc ~S'''
+      iex> [first | _] = [1,2,3]
+      iex> # This is a comment
+      iex> first
       iex> fn -> %{} = %{a: :b} end
 
   '''
@@ -423,10 +426,23 @@ defmodule ExUnit.DocTestTest.PatternMatching do
 
   """
 
+  def starting_line(), do: 405
+
   @doc """
     iex> {1, 2, :three} = tuple()
 
     iex> {1, _, _} = tuple()
+
+    iex> num = 2 - 2
+    iex> adder = fn int ->
+    ...>   int + 1
+    ...> end
+    iex> num =
+    iex>   adder.(num)
+    iex> {^num, _, _} =
+    iex> # Comments can be here as well
+    iex>
+    iex>   {adder.(0), adder.(1), :three}
 
     iex> tuple = tuple()
     iex> tuple
@@ -696,6 +712,7 @@ defmodule ExUnit.DocTestTest do
     end
 
     doctest_line = __ENV__.line - 3
+    starting_line = ExUnit.DocTestTest.PatternMatching.starting_line()
 
     ExUnit.configure(seed: 0, colors: [enabled: false])
     ExUnit.Server.modules_loaded()
@@ -710,7 +727,7 @@ defmodule ExUnit.DocTestTest do
                 left:  {1, 2}
                 right: {1, 3}
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:406: ExUnit.DocTestTest.PatternMatching (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 4}: ExUnit.DocTestTest.PatternMatching (module)
            """
 
     assert output =~ """
@@ -723,7 +740,7 @@ defmodule ExUnit.DocTestTest do
                 left:  {1, 2}
                 right: {1, 3}
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:408: ExUnit.DocTestTest.PatternMatching (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 6}: ExUnit.DocTestTest.PatternMatching (module)
            """
 
     assert output =~ """
@@ -735,7 +752,7 @@ defmodule ExUnit.DocTestTest do
                 left:  "Hello, world"
                 right: "Hello world"
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:411: ExUnit.DocTestTest.PatternMatching (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 9}: ExUnit.DocTestTest.PatternMatching (module)
            """
 
     assert output =~ """
@@ -747,7 +764,7 @@ defmodule ExUnit.DocTestTest do
                 left:  "Hello, " <> _
                 right: "Hello world"
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:413: ExUnit.DocTestTest.PatternMatching (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 11}: ExUnit.DocTestTest.PatternMatching (module)
            """
 
     assert output =~ """
@@ -759,7 +776,7 @@ defmodule ExUnit.DocTestTest do
                 left:  [:a | _]
                 right: [:b, :a]
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:415: ExUnit.DocTestTest.PatternMatching (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 13}: ExUnit.DocTestTest.PatternMatching (module)
            """
 
     assert output =~ """
@@ -774,7 +791,7 @@ defmodule ExUnit.DocTestTest do
                 left:  [^atom | _]
                 right: [:b, :a]
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:417: ExUnit.DocTestTest.PatternMatching (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 15}: ExUnit.DocTestTest.PatternMatching (module)
            """
 
     assert output =~ """
@@ -786,7 +803,7 @@ defmodule ExUnit.DocTestTest do
                 left:  %{b: _, d: :e}
                 right: %{a: :c, d: :e}
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:420: ExUnit.DocTestTest.PatternMatching (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 18}: ExUnit.DocTestTest.PatternMatching (module)
            """
 
     assert output =~ """
@@ -798,7 +815,7 @@ defmodule ExUnit.DocTestTest do
                 left:  %{year: 2001, day: 1}
                 right: ~D[2000-01-01]
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:422: ExUnit.DocTestTest.PatternMatching (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 20}: ExUnit.DocTestTest.PatternMatching (module)
            """
   end
 

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -294,12 +294,6 @@ defmodule ExUnit.DocTestTest.FencedHeredocs do
 end
 |> write_beam
 
-defmodule ExUnit.DocTestTest.IncompleteNoTrailingNewLine do
-  @doc "iex> 3 + 4"
-  def test_fun, do: :ok
-end
-|> write_beam
-
 defmodule ExUnit.DocTestTest.FenceIncomplete do
   @doc ~S'''
   ```
@@ -428,7 +422,7 @@ defmodule ExUnit.DocTestTest.PatternMatching do
       # false assertions do not accidentally raise
       iex> false = (List.flatten([]) != [])
   """
-  def starting_line(), do: 398
+  def starting_line(), do: 392
 end
 |> write_beam
 
@@ -865,18 +859,6 @@ defmodule ExUnit.DocTestTest do
       defmodule NeverCompiled do
         import ExUnit.DocTest
         doctest ExUnit.DocTestTest.IndentationNotEnough
-      end
-    end
-  end
-
-  test "fails with improper termination not ending in new line" do
-    message =
-      ~r[test/ex_unit/doc_test_test\.exs:\d+: expected non-blank line to follow iex> prompt]
-
-    assert_raise ExUnit.DocTest.Error, message, fn ->
-      defmodule NeverCompiled do
-        import ExUnit.DocTest
-        doctest ExUnit.DocTestTest.IncompleteNoTrailingNewLine
       end
     end
   end

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -444,7 +444,6 @@ defmodule ExUnit.DocTestTest do
   doctest ExUnit.DocTestTest.IndentationHeredocs
   doctest ExUnit.DocTestTest.FencedHeredocs
   doctest ExUnit.DocTestTest.Haiku
-  doctest ExUnit.DocTestTest.PatternMatching, only: [tuple: 0, map: 0], import: true
 
   import ExUnit.CaptureIO
 
@@ -757,6 +756,8 @@ defmodule ExUnit.DocTestTest do
                 stacktrace:
                   (for doctest at) test/ex_unit/doc_test_test.exs:#{starting_line + 20}: (test)
            """
+
+    assert output =~ "10 doctests, 8 failures"
   end
 
   test "IEx prefix contains a number" do

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -11,6 +11,11 @@ defmodule ExUnit.DocTestTest.GoodModule do
   """
   def one, do: 1
 
+  @doc """
+  iex> List.flatten([])
+  """
+  def only_call, do: :ok
+
   @doc ~S"""
   iex> ~S(f#{o}o)
   "f\#{o}o"
@@ -289,18 +294,6 @@ defmodule ExUnit.DocTestTest.FencedHeredocs do
 end
 |> write_beam
 
-defmodule ExUnit.DocTestTest.Incomplete do
-  @doc ~S'''
-      iex> [first | _] = [1,2,3]
-      iex> # This is a comment
-      iex> first
-      iex> fn -> %{} = %{a: :b} end
-
-  '''
-  def test_fun, do: :ok
-end
-|> write_beam
-
 defmodule ExUnit.DocTestTest.IncompleteNoTrailingNewLine do
   @doc "iex> 3 + 4"
   def test_fun, do: :ok
@@ -404,75 +397,38 @@ end
 
 defmodule ExUnit.DocTestTest.PatternMatching do
   @moduledoc """
-  The doctests below test failures so we can assert on the failure messages.
+  The doctests below test pattern matching failures.
 
-    iex> {1, 2}={1, 3}
+      iex> {1, 2}={1, 3}
 
-    iex> tuple = {1, 3}
-    iex> {1, 2} = tuple
+      iex> tuple = {1, 3}
+      iex> {1, 2} = tuple
 
-    iex> "Hello, world" = "Hello world"
+      iex> "Hello, world" = "Hello world"
 
-    iex> "Hello, " <> _ = "Hello world"
+      iex> "Hello, " <> _ = "Hello world"
 
-    iex> [:a | _] = [:b, :a]
+      iex> [:a | _] = [:b, :a]
 
-    iex> atom = :a
-    iex> [^atom | _] = [:b, :a]
+      iex> atom = :a
+      iex> [^atom | _] = [:b, :a]
 
-    iex> %{b: _, d: :e} = %{a: :c, d: :e}
+      iex> %{b: _, d: :e} = %{a: :c, d: :e}
 
-    iex> %{year: 2001, day: 1} = ~D[2000-01-01]
+      iex> %{year: 2001, day: 1} = ~D[2000-01-01]
 
+      iex> adder = fn int -> int + 1 end
+      iex> num =
+      ...>   adder.(0)
+      iex> {^num, _, _} =
+      ...> # Comments can be here as well
+      ...>
+      ...>   {adder.(0), adder.(1), :three}
+
+      # false assertions do not accidentally raise
+      iex> false = (List.flatten([]) != [])
   """
-
-  def starting_line(), do: 405
-
-  @doc """
-    iex> {1, 2, :three} = tuple()
-
-    iex> {1, _, _} = tuple()
-
-    iex> num = 2 - 2
-    iex> adder = fn int ->
-    ...>   int + 1
-    ...> end
-    iex> num =
-    iex>   adder.(num)
-    iex> {^num, _, _} =
-    iex> # Comments can be here as well
-    iex>
-    iex>   {adder.(0), adder.(1), :three}
-
-    iex> tuple = tuple()
-    iex> tuple
-    {1, 2, :three}
-
-    iex> {_, _, three} = tuple()
-    iex> three
-    :three
-
-    iex> num = 1
-    iex> num = num + 1
-    iex> {_, ^num, :three} = tuple()
-
-    iex> tuple = tuple()
-    iex> {1, 2, _} = tuple
-
-  """
-  def tuple(), do: {1, 2, :three}
-
-  @doc """
-
-    iex> %{} = map()
-
-    iex> %{a: _} = map()
-
-    iex> d = [:d]
-    iex> %{"c" => ^d} = map()
-
-  """
-  def map(), do: %{:a => "b", "c" => [:d]}
+  def starting_line(), do: 398
 end
 |> write_beam
 
@@ -539,12 +495,12 @@ defmodule ExUnit.DocTestTest do
     assert output =~ """
              1) doctest module ExUnit.DocTestTest.Invalid (1) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:138: syntax error before: '*'
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:143: syntax error before: '*'
                 doctest:
                   iex> 1 + * 1
                   1
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:138: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:143: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
@@ -558,7 +514,7 @@ defmodule ExUnit.DocTestTest do
                 left:  2
                 right: 3
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:141: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:146: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
@@ -575,7 +531,7 @@ defmodule ExUnit.DocTestTest do
                 left:  "This is a slightly shorter text string."
                 right: "This is a much shorter text string."
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:144: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:149: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
@@ -589,7 +545,7 @@ defmodule ExUnit.DocTestTest do
                 left:  ":oops"
                 right: "#MapSet<[]>"
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:150: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:155: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
@@ -598,7 +554,7 @@ defmodule ExUnit.DocTestTest do
                 ** (UndefinedFunctionError) function Hello.world/0 is undefined (module Hello is not available)
                 stacktrace:
                   Hello.world()
-                  (for doctest at) test/ex_unit/doc_test_test.exs:153: (test)
+                  (for doctest at) test/ex_unit/doc_test_test.exs:158: (test)
            """
 
     assert output =~ """
@@ -609,7 +565,7 @@ defmodule ExUnit.DocTestTest do
                   iex> raise "oops"
                   ** (WhatIsThis) "oops"
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:156: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:161: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
@@ -624,54 +580,54 @@ defmodule ExUnit.DocTestTest do
                   iex> raise "oops"
                   ** (RuntimeError) "hello"
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:159: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:164: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
              8) doctest ExUnit.DocTestTest.Invalid.a/0 (8) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:165: syntax error before: '*'
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:170: syntax error before: '*'
                 doctest:
                   iex> 1 + * 1
                   1
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:165: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:170: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
              9) doctest ExUnit.DocTestTest.Invalid.dedented_past_fence/0 (9) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:195: unexpected token: "`" (column 5, code point U+0060)
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:200: unexpected token: "`" (column 5, code point U+0060)
                 doctest:
                   iex> 1 + 2
                   3
                       ```
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:194: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:199: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
             10) doctest ExUnit.DocTestTest.Invalid.indented_not_enough/0 (10) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:179: unexpected token: "`" (column 1, code point U+0060)
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:184: unexpected token: "`" (column 1, code point U+0060)
                 doctest:
                   iex> 1 + 2
                   3
                   `
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:178: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:183: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
             11) doctest ExUnit.DocTestTest.Invalid.indented_too_much/0 (11) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:187: unexpected token: "`" (column 3, code point U+0060)
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:192: unexpected token: "`" (column 3, code point U+0060)
                 doctest:
                   iex> 1 + 2
                   3
                     ```
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:186: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:191: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
@@ -679,29 +635,29 @@ defmodule ExUnit.DocTestTest do
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 Doctest did not compile, got: (UnicodeConversionError) invalid encoding starting at <<255, 34, 41>>
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:201: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:206: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
             13) doctest ExUnit.DocTestTest.Invalid.misplaced_opaque_type/0 (13) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (TokenMissingError) test/ex_unit/doc_test_test.exs:207: missing terminator: } (for "{" starting at line 207). If you are planning to assert on the result of an iex> expression which contains a value inspected as #Name<...>, please make sure the inspected value is placed at the beginning of the expression; otherwise Elixir will treat it as a comment due to the leading sign #.
+                Doctest did not compile, got: (TokenMissingError) test/ex_unit/doc_test_test.exs:212: missing terminator: } (for "{" starting at line 212). If you are planning to assert on the result of an iex> expression which contains a value inspected as #Name<...>, please make sure the inspected value is placed at the beginning of the expression; otherwise Elixir will treat it as a comment due to the leading sign #.
                 doctest:
                   iex> {:ok, MapSet.new([1, 2, 3])}
                   {:ok, #MapSet<[1, 2, 3]>}
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:207: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:212: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
             14) doctest ExUnit.DocTestTest.Invalid.b/0 (14) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:171: syntax error before: '*'
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:176: syntax error before: '*'
                 doctest:
                   iex> 1 + * 1
                   1
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:171: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:176: ExUnit.DocTestTest.Invalid (module)
            """
   end
 
@@ -722,61 +678,55 @@ defmodule ExUnit.DocTestTest do
              1) doctest module ExUnit.DocTestTest.PatternMatching (1) (ExUnit.DocTestTest.PatternMatchingRunner)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 match (=) failed
-                doctest:
-                  iex> {1, 2}={1, 3}
+                code:  {1, 2} = {1, 3}
                 left:  {1, 2}
                 right: {1, 3}
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line + 4}: ExUnit.DocTestTest.PatternMatching (module)
+                  (for doctest at) test/ex_unit/doc_test_test.exs:#{starting_line + 4}: (test)
            """
 
     assert output =~ """
              2) doctest module ExUnit.DocTestTest.PatternMatching (2) (ExUnit.DocTestTest.PatternMatchingRunner)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 match (=) failed
-                doctest:
-                  iex> tuple = {1, 3}
-                  iex> {1, 2} = tuple
+                code:  {1, 2} = tuple
                 left:  {1, 2}
                 right: {1, 3}
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line + 6}: ExUnit.DocTestTest.PatternMatching (module)
+                  (for doctest at) test/ex_unit/doc_test_test.exs:#{starting_line + 7}: (test)
            """
 
     assert output =~ """
              3) doctest module ExUnit.DocTestTest.PatternMatching (3) (ExUnit.DocTestTest.PatternMatchingRunner)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 match (=) failed
-                doctest:
-                  iex> "Hello, world" = "Hello world"
+                code:  "Hello, world" = "Hello world"
                 left:  "Hello, world"
                 right: "Hello world"
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line + 9}: ExUnit.DocTestTest.PatternMatching (module)
+                  (for doctest at) test/ex_unit/doc_test_test.exs:#{starting_line + 9}: (test)
            """
 
     assert output =~ """
              4) doctest module ExUnit.DocTestTest.PatternMatching (4) (ExUnit.DocTestTest.PatternMatchingRunner)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 match (=) failed
-                doctest:
-                  iex> "Hello, " <> _ = "Hello world"
+                code:  "Hello, " <> _ = "Hello world"
                 left:  "Hello, " <> _
                 right: "Hello world"
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line + 11}: ExUnit.DocTestTest.PatternMatching (module)
+                  (for doctest at) test/ex_unit/doc_test_test.exs:#{starting_line + 11}: (test)
            """
 
     assert output =~ """
              5) doctest module ExUnit.DocTestTest.PatternMatching (5) (ExUnit.DocTestTest.PatternMatchingRunner)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 match (=) failed
-                doctest:
-                  iex> [:a | _] = [:b, :a]
+                code:  [:a | _] = [:b, :a]
                 left:  [:a | _]
                 right: [:b, :a]
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line + 13}: ExUnit.DocTestTest.PatternMatching (module)
+                  (for doctest at) test/ex_unit/doc_test_test.exs:#{starting_line + 13}: (test)
            """
 
     assert output =~ """
@@ -785,37 +735,33 @@ defmodule ExUnit.DocTestTest do
                 match (=) failed
                 The following variables were pinned:
                   atom = :a
-                doctest:
-                  iex> atom = :a
-                  iex> [^atom | _] = [:b, :a]
+                code:  [^atom | _] = [:b, :a]
                 left:  [^atom | _]
                 right: [:b, :a]
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line + 15}: ExUnit.DocTestTest.PatternMatching (module)
+                  (for doctest at) test/ex_unit/doc_test_test.exs:#{starting_line + 16}: (test)
            """
 
     assert output =~ """
              7) doctest module ExUnit.DocTestTest.PatternMatching (7) (ExUnit.DocTestTest.PatternMatchingRunner)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 match (=) failed
-                doctest:
-                  iex> %{b: _, d: :e} = %{a: :c, d: :e}
+                code:  %{b: _, d: :e} = %{a: :c, d: :e}
                 left:  %{b: _, d: :e}
                 right: %{a: :c, d: :e}
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line + 18}: ExUnit.DocTestTest.PatternMatching (module)
+                  (for doctest at) test/ex_unit/doc_test_test.exs:#{starting_line + 18}: (test)
            """
 
     assert output =~ """
              8) doctest module ExUnit.DocTestTest.PatternMatching (8) (ExUnit.DocTestTest.PatternMatchingRunner)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 match (=) failed
-                doctest:
-                  iex> %{year: 2001, day: 1} = ~D[2000-01-01]
+                code:  %{year: 2001, day: 1} = ~D"2000-01-01"
                 left:  %{year: 2001, day: 1}
                 right: ~D[2000-01-01]
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line + 20}: ExUnit.DocTestTest.PatternMatching (module)
+                  (for doctest at) test/ex_unit/doc_test_test.exs:#{starting_line + 20}: (test)
            """
   end
 
@@ -919,18 +865,6 @@ defmodule ExUnit.DocTestTest do
       defmodule NeverCompiled do
         import ExUnit.DocTest
         doctest ExUnit.DocTestTest.IndentationNotEnough
-      end
-    end
-  end
-
-  test "fails with improper termination" do
-    message =
-      ~r[test/ex_unit/doc_test_test\.exs:\d+: expected non-blank line to follow iex> prompt]
-
-    assert_raise ExUnit.DocTest.Error, message, fn ->
-      defmodule NeverCompiled do
-        import ExUnit.DocTest
-        doctest ExUnit.DocTestTest.Incomplete
       end
     end
   end


### PR DESCRIPTION
This is related to this discussion on the mailing list: https://groups.google.com/forum/m/#!msg/elixir-lang-core/06HZwKG8E8k/KeDneED9AwAJ

This allows devs to now use proper pattern matching assertions in doctests, complete with the nice colored diff in the event of a failure. Here are some screenshots of how these tests look now when they fail (and with color on in the ExUnit config).

![diff1](https://user-images.githubusercontent.com/8422484/69799881-698feb80-11d4-11ea-93cf-694fe95283db.png)
![diff2](https://user-images.githubusercontent.com/8422484/69799894-73195380-11d4-11ea-819f-b81b2e6f7b57.png)

This is currently missing documentation, but I'll tack that commit on once folks think this behavior looks good so I know what to document 😉 