### PR TITLE
Replace exsplus with exrop the OTP 20 default pseudorandom algorithm

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2268,6 +2268,9 @@ defmodule Enum do
   the random value. Check its documentation for setting a
   different random algorithm or a different seed.
 
+  We use the `exrop` pseudorandom algorithm here since it's the default from OTP 20,
+  however if you are using OTP 22 or above then `exsss` is the default algorithm.
+
   ## Examples
 
       # Although not necessary, let's seed the random algorithm

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1109,7 +1109,7 @@ defmodule Enum do
 
       iex> Enum.frequencies(~w{ant buffalo ant ant buffalo dingo})
       %{"ant" => 3, "buffalo" => 2, "dingo" => 1}
-      
+
   """
   @doc since: "1.10.0"
   @spec frequencies(t) :: map
@@ -1127,10 +1127,10 @@ defmodule Enum do
   as the count of every element.
 
   ## Examples
-    
+
       iex> Enum.frequencies_by(~w{aa aA bb cc}, &String.downcase/1)
       %{"aa" => 2, "bb" => 1, "cc" => 1}
-    
+
       iex> Enum.frequencies_by(~w{aaa aA bbb cc c}, &String.length/1)
       %{3 => 2, 2 => 2, 1 => 1}
 
@@ -1540,7 +1540,7 @@ defmodule Enum do
       iex> Enum.max([~D[2017-03-31], ~D[2017-04-01]])
       ~D[2017-03-31]
 
-  In the example above, `max/2` returned March 31st instead of April 1st 
+  In the example above, `max/2` returned March 31st instead of April 1st
   because the structural comparison compares the day before the year.
   For this reason, most structs provide a "compare" function, such as
   `Date.compare/2`, which receives two structs and returns `:lt` (less than),
@@ -1954,13 +1954,13 @@ defmodule Enum do
   ## Examples
 
       # Although not necessary, let's seed the random algorithm
-      iex> :rand.seed(:exsplus, {101, 102, 103})
+      iex> :rand.seed(:exsss, {101, 102, 103})
       iex> Enum.random([1, 2, 3])
-      1
+      3
       iex> Enum.random([1, 2, 3])
       3
       iex> Enum.random(1..1_000)
-      556
+      735
 
   """
   @spec random(t) :: element
@@ -2268,11 +2268,11 @@ defmodule Enum do
   ## Examples
 
       # Although not necessary, let's seed the random algorithm
-      iex> :rand.seed(:exsplus, {1, 2, 3})
+      iex> :rand.seed(:exsss, {1, 2, 3})
+      iex> Enum.shuffle([1, 2, 3])
+      [3, 2, 1]
       iex> Enum.shuffle([1, 2, 3])
       [2, 1, 3]
-      iex> Enum.shuffle([1, 2, 3])
-      [2, 3, 1]
 
   """
   @spec shuffle(t) :: list
@@ -2809,11 +2809,11 @@ defmodule Enum do
   ## Examples
 
       # Although not necessary, let's seed the random algorithm
-      iex> :rand.seed(:exsplus, {1, 2, 3})
+      iex> :rand.seed(:exsss, {1, 2, 3})
       iex> Enum.take_random(1..10, 2)
-      [5, 4]
+      [3, 1]
       iex> Enum.take_random(?a..?z, 5)
-      'ipybz'
+      'mikel'
 
   """
   @spec take_random(t, non_neg_integer) :: list

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1954,13 +1954,13 @@ defmodule Enum do
   ## Examples
 
       # Although not necessary, let's seed the random algorithm
-      iex> :rand.seed(:exsss, {101, 102, 103})
+      iex> :rand.seed(:exrop, {101, 102, 103})
       iex> Enum.random([1, 2, 3])
       3
       iex> Enum.random([1, 2, 3])
-      3
+      2
       iex> Enum.random(1..1_000)
-      735
+      846
 
   """
   @spec random(t) :: element
@@ -2268,11 +2268,11 @@ defmodule Enum do
   ## Examples
 
       # Although not necessary, let's seed the random algorithm
-      iex> :rand.seed(:exsss, {1, 2, 3})
+      iex> :rand.seed(:exrop, {1, 2, 3})
       iex> Enum.shuffle([1, 2, 3])
-      [3, 2, 1]
+      [3, 1, 2]
       iex> Enum.shuffle([1, 2, 3])
-      [2, 1, 3]
+      [1, 3, 2]
 
   """
   @spec shuffle(t) :: list
@@ -2809,11 +2809,11 @@ defmodule Enum do
   ## Examples
 
       # Although not necessary, let's seed the random algorithm
-      iex> :rand.seed(:exsss, {1, 2, 3})
+      iex> :rand.seed(:exrop, {1, 2, 3})
       iex> Enum.take_random(1..10, 2)
-      [3, 1]
+      [7, 2]
       iex> Enum.take_random(?a..?z, 5)
-      'mikel'
+      'hypnt'
 
   """
   @spec take_random(t, non_neg_integer) :: list

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1953,9 +1953,10 @@ defmodule Enum do
 
   ## Examples
 
-  The examples below use the `exrop` pseudorandom algorithm since it's
-  the default from OTP 20, however if you are using OTP 22 or above then
-  `exsss` is the default algorithm.
+  The examples below use the `:exrop` pseudorandom algorithm since it's
+  the default from Erlang/OTP 20, however if you are using Erlang/OTP 22
+  or above then `:exsss` is the default algorithm. If you are using `:exsplus`,
+  then please update, as this algorithm is deprecated since Erlang/OTP 20.
 
       # Although not necessary, let's seed the random algorithm
       iex> :rand.seed(:exrop, {101, 102, 103})
@@ -2271,9 +2272,10 @@ defmodule Enum do
 
   ## Examples
 
-  The examples below use the `exrop` pseudorandom algorithm since it's
-  the default from OTP 20, however if you are using OTP 22 or above then
-  `exsss` is the default algorithm.
+  The examples below use the `:exrop` pseudorandom algorithm since it's
+  the default from Erlang/OTP 20, however if you are using Erlang/OTP 22
+  or above then `:exsss` is the default algorithm. If you are using `:exsplus`,
+  then please update, as this algorithm is deprecated since Erlang/OTP 20.
 
       # Although not necessary, let's seed the random algorithm
       iex> :rand.seed(:exrop, {1, 2, 3})

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1941,6 +1941,9 @@ defmodule Enum do
   the random value. Check its documentation for setting a
   different random algorithm or a different seed.
 
+  We use the `exrop` pseudorandom algorithm here since it's the default from OTP 20,
+  however if you are using OTP 22 or above then `exsss` is the default algorithm.
+
   The implementation is based on the
   [reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling#Relation_to_Fisher-Yates_shuffle)
   algorithm.

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1941,9 +1941,6 @@ defmodule Enum do
   the random value. Check its documentation for setting a
   different random algorithm or a different seed.
 
-  We use the `exrop` pseudorandom algorithm here since it's the default from OTP 20,
-  however if you are using OTP 22 or above then `exsss` is the default algorithm.
-
   The implementation is based on the
   [reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling#Relation_to_Fisher-Yates_shuffle)
   algorithm.
@@ -1955,6 +1952,10 @@ defmodule Enum do
   range (thus executing in constant time and constant memory).
 
   ## Examples
+
+  The examples below use the `exrop` pseudorandom algorithm since it's
+  the default from OTP 20, however if you are using OTP 22 or above then
+  `exsss` is the default algorithm.
 
       # Although not necessary, let's seed the random algorithm
       iex> :rand.seed(:exrop, {101, 102, 103})
@@ -2268,10 +2269,11 @@ defmodule Enum do
   the random value. Check its documentation for setting a
   different random algorithm or a different seed.
 
-  We use the `exrop` pseudorandom algorithm here since it's the default from OTP 20,
-  however if you are using OTP 22 or above then `exsss` is the default algorithm.
-
   ## Examples
+
+  The examples below use the `exrop` pseudorandom algorithm since it's
+  the default from OTP 20, however if you are using OTP 22 or above then
+  `exsss` is the default algorithm.
 
       # Although not necessary, let's seed the random algorithm
       iex> :rand.seed(:exrop, {1, 2, 3})

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1332,9 +1332,9 @@ defmodule Stream do
   ## Examples
 
       # Although not necessary, let's seed the random algorithm
-      iex> :rand.seed(:exsplus, {1, 2, 3})
+      iex> :rand.seed(:exsss, {1, 2, 3})
       iex> Stream.repeatedly(&:rand.uniform/0) |> Enum.take(3)
-      [0.40502929729990744, 0.45336720247823126, 0.04094511692041057]
+      [0.5455598952593053, 0.6039309974353404, 0.6684893034823949]
 
   """
   @spec repeatedly((() -> element)) :: Enumerable.t()

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1332,9 +1332,9 @@ defmodule Stream do
   ## Examples
 
       # Although not necessary, let's seed the random algorithm
-      iex> :rand.seed(:exsss, {1, 2, 3})
+      iex> :rand.seed(:exrop, {1, 2, 3})
       iex> Stream.repeatedly(&:rand.uniform/0) |> Enum.take(3)
-      [0.5455598952593053, 0.6039309974353404, 0.6684893034823949]
+      [0.7498295129076106, 0.06161655489244533, 0.7924073127680873]
 
   """
   @spec repeatedly((() -> element)) :: Enumerable.t()

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -629,19 +629,19 @@ defmodule EnumTest do
     # please note the order of following assertions is important
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1306, 421_106, 567_597}
-    :rand.seed(:exsss, seed1)
-    assert Enum.random([1, 2]) == 1
+    :rand.seed(:exrop, seed1)
     assert Enum.random([1, 2]) == 2
-    :rand.seed(:exsss, seed1)
-    assert Enum.random([1, 2]) == 1
+    assert Enum.random([1, 2]) == 2
+    :rand.seed(:exrop, seed1)
+    assert Enum.random([1, 2]) == 2
     assert Enum.random([1, 2, 3]) == 1
-    assert Enum.random([1, 2, 3, 4]) == 2
-    assert Enum.random([1, 2, 3, 4, 5]) == 3
-    :rand.seed(:exsss, seed2)
-    assert Enum.random([1, 2]) == 1
-    assert Enum.random([1, 2, 3]) == 2
-    assert Enum.random([1, 2, 3, 4]) == 4
-    assert Enum.random([1, 2, 3, 4, 5]) == 3
+    assert Enum.random([1, 2, 3, 4]) == 1
+    assert Enum.random([1, 2, 3, 4, 5]) == 2
+    :rand.seed(:exrop, seed2)
+    assert Enum.random([1, 2]) == 2
+    assert Enum.random([1, 2, 3]) == 1
+    assert Enum.random([1, 2, 3, 4]) == 1
+    assert Enum.random([1, 2, 3, 4, 5]) == 1
   end
 
   test "reduce/2" do
@@ -707,8 +707,8 @@ defmodule EnumTest do
 
   test "shuffle/1" do
     # set a fixed seed so the test can be deterministic
-    :rand.seed(:exsss, {1374, 347_975, 449_264})
-    assert Enum.shuffle([1, 2, 3, 4, 5]) == [1, 3, 4, 5, 2]
+    :rand.seed(:exrop, {1374, 347_975, 449_264})
+    assert Enum.shuffle([1, 2, 3, 4, 5]) == [3, 1, 4, 2, 5]
   end
 
   test "slice/2" do
@@ -1014,17 +1014,17 @@ defmodule EnumTest do
     # please note the order of following assertions is important
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1406, 421_106, 567_597}
-    :rand.seed(:exsss, seed1)
+    :rand.seed(:exrop, seed1)
     assert Enum.take_random([1, 2, 3], 1) == [3]
-    assert Enum.take_random([1, 2, 3], 2) == [3, 2]
-    assert Enum.take_random([1, 2, 3], 3) == [3, 1, 2]
-    assert Enum.take_random([1, 2, 3], 4) == [1, 3, 2]
-    :rand.seed(:exsss, seed2)
+    assert Enum.take_random([1, 2, 3], 2) == [2, 1]
+    assert Enum.take_random([1, 2, 3], 3) == [1, 2, 3]
+    assert Enum.take_random([1, 2, 3], 4) == [3, 1, 2]
+    :rand.seed(:exrop, seed2)
     assert Enum.take_random([1, 2, 3], 1) == [1]
-    assert Enum.take_random([1, 2, 3], 2) == [3, 1]
-    assert Enum.take_random([1, 2, 3], 3) == [3, 1, 2]
-    assert Enum.take_random([1, 2, 3], 4) == [2, 1, 3]
-    assert Enum.take_random([1, 2, 3], 129) == [2, 3, 1]
+    assert Enum.take_random([1, 2, 3], 2) == [1, 2]
+    assert Enum.take_random([1, 2, 3], 3) == [2, 3, 1]
+    assert Enum.take_random([1, 2, 3], 4) == [1, 3, 2]
+    assert Enum.take_random([1, 2, 3], 129) == [2, 1, 3]
 
     # assert that every item in the sample comes from the input list
     list = for _ <- 1..100, do: make_ref()
@@ -1442,14 +1442,14 @@ defmodule EnumTest.Range do
     # please note the order of following assertions is important
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1306, 421_106, 567_597}
-    :rand.seed(:exsss, seed1)
-    assert Enum.random(1..2) == 1
+    :rand.seed(:exrop, seed1)
+    assert Enum.random(1..2) == 2
     assert Enum.random(1..3) == 1
     assert Enum.random(3..1) == 2
 
-    :rand.seed(:exsss, seed2)
-    assert Enum.random(1..2) == 1
-    assert Enum.random(1..3) == 2
+    :rand.seed(:exrop, seed2)
+    assert Enum.random(1..2) == 2
+    assert Enum.random(1..3) == 1
   end
 
   test "reduce/2" do
@@ -1506,8 +1506,8 @@ defmodule EnumTest.Range do
 
   test "shuffle/1" do
     # set a fixed seed so the test can be deterministic
-    :rand.seed(:exsss, {1374, 347_975, 449_264})
-    assert Enum.shuffle(1..5) == [1, 3, 4, 5, 2]
+    :rand.seed(:exrop, {1374, 347_975, 449_264})
+    assert Enum.shuffle(1..5) == [3, 1, 4, 2, 5]
   end
 
   test "slice/2" do
@@ -1689,29 +1689,29 @@ defmodule EnumTest.Range do
     # please note the order of following assertions is important
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1406, 421_106, 567_597}
-    :rand.seed(:exsss, seed1)
+    :rand.seed(:exrop, seed1)
     assert Enum.take_random(1..3, 1) == [3]
-    :rand.seed(:exsss, seed1)
-    assert Enum.take_random(1..3, 2) == [3, 1]
-    :rand.seed(:exsss, seed1)
-    assert Enum.take_random(1..3, 3) == [3, 1, 2]
-    :rand.seed(:exsss, seed1)
-    assert Enum.take_random(1..3, 4) == [3, 1, 2]
-    :rand.seed(:exsss, seed1)
+    :rand.seed(:exrop, seed1)
+    assert Enum.take_random(1..3, 2) == [3, 2]
+    :rand.seed(:exrop, seed1)
+    assert Enum.take_random(1..3, 3) == [3, 2, 1]
+    :rand.seed(:exrop, seed1)
+    assert Enum.take_random(1..3, 4) == [3, 2, 1]
+    :rand.seed(:exrop, seed1)
     assert Enum.take_random(3..1, 1) == [1]
-    :rand.seed(:exsss, seed2)
+    :rand.seed(:exrop, seed2)
     assert Enum.take_random(1..3, 1) == [1]
-    :rand.seed(:exsss, seed2)
+    :rand.seed(:exrop, seed2)
     assert Enum.take_random(1..3, 2) == [1, 3]
-    :rand.seed(:exsss, seed2)
+    :rand.seed(:exrop, seed2)
     assert Enum.take_random(1..3, 3) == [1, 3, 2]
-    :rand.seed(:exsss, seed2)
+    :rand.seed(:exrop, seed2)
     assert Enum.take_random(1..3, 4) == [1, 3, 2]
 
     # make sure optimizations don't change fixed seeded tests
-    :rand.seed(:exsss, {101, 102, 103})
+    :rand.seed(:exrop, {101, 102, 103})
     one = Enum.take_random(1..100, 1)
-    :rand.seed(:exsss, {101, 102, 103})
+    :rand.seed(:exrop, {101, 102, 103})
     two = Enum.take_random(1..100, 2)
     assert hd(one) == hd(two)
   end
@@ -1770,12 +1770,12 @@ defmodule EnumTest.Map do
     map = %{a: 1, b: 2, c: 3}
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1406, 421_106, 567_597}
-    :rand.seed(:exsss, seed1)
-    assert Enum.random(map) == {:c, 3}
+    :rand.seed(:exrop, seed1)
+    assert Enum.random(map) == {:a, 1}
     assert Enum.random(map) == {:a, 1}
     assert Enum.random(map) == {:b, 2}
 
-    :rand.seed(:exsss, seed2)
+    :rand.seed(:exrop, seed2)
     assert Enum.random(map) == {:c, 3}
     assert Enum.random(map) == {:b, 2}
   end
@@ -1792,21 +1792,21 @@ defmodule EnumTest.Map do
     map = %{a: 1, b: 2, c: 3}
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1406, 421_106, 567_597}
-    :rand.seed(:exsss, seed1)
+    :rand.seed(:exrop, seed1)
     assert Enum.take_random(map, 1) == [c: 3]
-    :rand.seed(:exsss, seed1)
-    assert Enum.take_random(map, 2) == [c: 3, a: 1]
-    :rand.seed(:exsss, seed1)
-    assert Enum.take_random(map, 3) == [c: 3, a: 1, b: 2]
-    :rand.seed(:exsss, seed1)
-    assert Enum.take_random(map, 4) == [c: 3, a: 1, b: 2]
-    :rand.seed(:exsss, seed2)
+    :rand.seed(:exrop, seed1)
+    assert Enum.take_random(map, 2) == [c: 3, b: 2]
+    :rand.seed(:exrop, seed1)
+    assert Enum.take_random(map, 3) == [c: 3, b: 2, a: 1]
+    :rand.seed(:exrop, seed1)
+    assert Enum.take_random(map, 4) == [c: 3, b: 2, a: 1]
+    :rand.seed(:exrop, seed2)
     assert Enum.take_random(map, 1) == [a: 1]
-    :rand.seed(:exsss, seed2)
+    :rand.seed(:exrop, seed2)
     assert Enum.take_random(map, 2) == [a: 1, c: 3]
-    :rand.seed(:exsss, seed2)
+    :rand.seed(:exrop, seed2)
     assert Enum.take_random(map, 3) == [a: 1, c: 3, b: 2]
-    :rand.seed(:exsss, seed2)
+    :rand.seed(:exrop, seed2)
     assert Enum.take_random(map, 4) == [a: 1, c: 3, b: 2]
   end
 

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -629,19 +629,19 @@ defmodule EnumTest do
     # please note the order of following assertions is important
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1306, 421_106, 567_597}
-    :rand.seed(:exsplus, seed1)
+    :rand.seed(:exsss, seed1)
     assert Enum.random([1, 2]) == 1
     assert Enum.random([1, 2]) == 2
-    :rand.seed(:exsplus, seed1)
+    :rand.seed(:exsss, seed1)
+    assert Enum.random([1, 2]) == 1
+    assert Enum.random([1, 2, 3]) == 1
+    assert Enum.random([1, 2, 3, 4]) == 2
+    assert Enum.random([1, 2, 3, 4, 5]) == 3
+    :rand.seed(:exsss, seed2)
     assert Enum.random([1, 2]) == 1
     assert Enum.random([1, 2, 3]) == 2
-    assert Enum.random([1, 2, 3, 4]) == 1
-    assert Enum.random([1, 2, 3, 4, 5]) == 2
-    :rand.seed(:exsplus, seed2)
-    assert Enum.random([1, 2]) == 1
-    assert Enum.random([1, 2, 3]) == 3
-    assert Enum.random([1, 2, 3, 4]) == 2
-    assert Enum.random([1, 2, 3, 4, 5]) == 4
+    assert Enum.random([1, 2, 3, 4]) == 4
+    assert Enum.random([1, 2, 3, 4, 5]) == 3
   end
 
   test "reduce/2" do
@@ -707,8 +707,8 @@ defmodule EnumTest do
 
   test "shuffle/1" do
     # set a fixed seed so the test can be deterministic
-    :rand.seed(:exsplus, {1374, 347_975, 449_264})
-    assert Enum.shuffle([1, 2, 3, 4, 5]) == [2, 1, 3, 5, 4]
+    :rand.seed(:exsss, {1374, 347_975, 449_264})
+    assert Enum.shuffle([1, 2, 3, 4, 5]) == [1, 3, 4, 5, 2]
   end
 
   test "slice/2" do
@@ -1014,17 +1014,17 @@ defmodule EnumTest do
     # please note the order of following assertions is important
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1406, 421_106, 567_597}
-    :rand.seed(:exsplus, seed1)
-    assert Enum.take_random([1, 2, 3], 1) == [2]
-    assert Enum.take_random([1, 2, 3], 2) == [3, 1]
-    assert Enum.take_random([1, 2, 3], 3) == [1, 3, 2]
-    assert Enum.take_random([1, 2, 3], 4) == [2, 3, 1]
-    :rand.seed(:exsplus, seed2)
+    :rand.seed(:exsss, seed1)
     assert Enum.take_random([1, 2, 3], 1) == [3]
-    assert Enum.take_random([1, 2, 3], 2) == [1, 2]
-    assert Enum.take_random([1, 2, 3], 3) == [1, 2, 3]
+    assert Enum.take_random([1, 2, 3], 2) == [3, 2]
+    assert Enum.take_random([1, 2, 3], 3) == [3, 1, 2]
+    assert Enum.take_random([1, 2, 3], 4) == [1, 3, 2]
+    :rand.seed(:exsss, seed2)
+    assert Enum.take_random([1, 2, 3], 1) == [1]
+    assert Enum.take_random([1, 2, 3], 2) == [3, 1]
+    assert Enum.take_random([1, 2, 3], 3) == [3, 1, 2]
     assert Enum.take_random([1, 2, 3], 4) == [2, 1, 3]
-    assert Enum.take_random([1, 2, 3], 129) == [3, 2, 1]
+    assert Enum.take_random([1, 2, 3], 129) == [2, 3, 1]
 
     # assert that every item in the sample comes from the input list
     list = for _ <- 1..100, do: make_ref()
@@ -1442,14 +1442,14 @@ defmodule EnumTest.Range do
     # please note the order of following assertions is important
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1306, 421_106, 567_597}
-    :rand.seed(:exsplus, seed1)
+    :rand.seed(:exsss, seed1)
+    assert Enum.random(1..2) == 1
+    assert Enum.random(1..3) == 1
+    assert Enum.random(3..1) == 2
+
+    :rand.seed(:exsss, seed2)
     assert Enum.random(1..2) == 1
     assert Enum.random(1..3) == 2
-    assert Enum.random(3..1) == 1
-
-    :rand.seed(:exsplus, seed2)
-    assert Enum.random(1..2) == 1
-    assert Enum.random(1..3) == 3
   end
 
   test "reduce/2" do
@@ -1506,8 +1506,8 @@ defmodule EnumTest.Range do
 
   test "shuffle/1" do
     # set a fixed seed so the test can be deterministic
-    :rand.seed(:exsplus, {1374, 347_975, 449_264})
-    assert Enum.shuffle(1..5) == [2, 1, 3, 5, 4]
+    :rand.seed(:exsss, {1374, 347_975, 449_264})
+    assert Enum.shuffle(1..5) == [1, 3, 4, 5, 2]
   end
 
   test "slice/2" do
@@ -1689,29 +1689,29 @@ defmodule EnumTest.Range do
     # please note the order of following assertions is important
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1406, 421_106, 567_597}
-    :rand.seed(:exsplus, seed1)
-    assert Enum.take_random(1..3, 1) == [2]
-    :rand.seed(:exsplus, seed1)
-    assert Enum.take_random(1..3, 2) == [2, 3]
-    :rand.seed(:exsplus, seed1)
-    assert Enum.take_random(1..3, 3) == [2, 3, 1]
-    :rand.seed(:exsplus, seed1)
-    assert Enum.take_random(1..3, 4) == [2, 3, 1]
-    :rand.seed(:exsplus, seed1)
-    assert Enum.take_random(3..1, 1) == [2]
-    :rand.seed(:exsplus, seed2)
+    :rand.seed(:exsss, seed1)
     assert Enum.take_random(1..3, 1) == [3]
-    :rand.seed(:exsplus, seed2)
-    assert Enum.take_random(1..3, 2) == [3, 2]
-    :rand.seed(:exsplus, seed2)
-    assert Enum.take_random(1..3, 3) == [3, 2, 1]
-    :rand.seed(:exsplus, seed2)
-    assert Enum.take_random(1..3, 4) == [3, 2, 1]
+    :rand.seed(:exsss, seed1)
+    assert Enum.take_random(1..3, 2) == [3, 1]
+    :rand.seed(:exsss, seed1)
+    assert Enum.take_random(1..3, 3) == [3, 1, 2]
+    :rand.seed(:exsss, seed1)
+    assert Enum.take_random(1..3, 4) == [3, 1, 2]
+    :rand.seed(:exsss, seed1)
+    assert Enum.take_random(3..1, 1) == [1]
+    :rand.seed(:exsss, seed2)
+    assert Enum.take_random(1..3, 1) == [1]
+    :rand.seed(:exsss, seed2)
+    assert Enum.take_random(1..3, 2) == [1, 3]
+    :rand.seed(:exsss, seed2)
+    assert Enum.take_random(1..3, 3) == [1, 3, 2]
+    :rand.seed(:exsss, seed2)
+    assert Enum.take_random(1..3, 4) == [1, 3, 2]
 
     # make sure optimizations don't change fixed seeded tests
-    :rand.seed(:exsplus, {101, 102, 103})
+    :rand.seed(:exsss, {101, 102, 103})
     one = Enum.take_random(1..100, 1)
-    :rand.seed(:exsplus, {101, 102, 103})
+    :rand.seed(:exsss, {101, 102, 103})
     two = Enum.take_random(1..100, 2)
     assert hd(one) == hd(two)
   end
@@ -1770,14 +1770,14 @@ defmodule EnumTest.Map do
     map = %{a: 1, b: 2, c: 3}
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1406, 421_106, 567_597}
-    :rand.seed(:exsplus, seed1)
+    :rand.seed(:exsss, seed1)
+    assert Enum.random(map) == {:c, 3}
+    assert Enum.random(map) == {:a, 1}
+    assert Enum.random(map) == {:b, 2}
+
+    :rand.seed(:exsss, seed2)
     assert Enum.random(map) == {:c, 3}
     assert Enum.random(map) == {:b, 2}
-    assert Enum.random(map) == {:c, 3}
-
-    :rand.seed(:exsplus, seed2)
-    assert Enum.random(map) == {:a, 1}
-    assert Enum.random(map) == {:a, 1}
   end
 
   test "take_random/2" do
@@ -1792,22 +1792,22 @@ defmodule EnumTest.Map do
     map = %{a: 1, b: 2, c: 3}
     seed1 = {1406, 407_414, 139_258}
     seed2 = {1406, 421_106, 567_597}
-    :rand.seed(:exsplus, seed1)
-    assert Enum.take_random(map, 1) == [b: 2]
-    :rand.seed(:exsplus, seed1)
-    assert Enum.take_random(map, 2) == [b: 2, c: 3]
-    :rand.seed(:exsplus, seed1)
-    assert Enum.take_random(map, 3) == [b: 2, c: 3, a: 1]
-    :rand.seed(:exsplus, seed1)
-    assert Enum.take_random(map, 4) == [b: 2, c: 3, a: 1]
-    :rand.seed(:exsplus, seed2)
+    :rand.seed(:exsss, seed1)
     assert Enum.take_random(map, 1) == [c: 3]
-    :rand.seed(:exsplus, seed2)
-    assert Enum.take_random(map, 2) == [c: 3, b: 2]
-    :rand.seed(:exsplus, seed2)
-    assert Enum.take_random(map, 3) == [c: 3, b: 2, a: 1]
-    :rand.seed(:exsplus, seed2)
-    assert Enum.take_random(map, 4) == [c: 3, b: 2, a: 1]
+    :rand.seed(:exsss, seed1)
+    assert Enum.take_random(map, 2) == [c: 3, a: 1]
+    :rand.seed(:exsss, seed1)
+    assert Enum.take_random(map, 3) == [c: 3, a: 1, b: 2]
+    :rand.seed(:exsss, seed1)
+    assert Enum.take_random(map, 4) == [c: 3, a: 1, b: 2]
+    :rand.seed(:exsss, seed2)
+    assert Enum.take_random(map, 1) == [a: 1]
+    :rand.seed(:exsss, seed2)
+    assert Enum.take_random(map, 2) == [a: 1, c: 3]
+    :rand.seed(:exsss, seed2)
+    assert Enum.take_random(map, 3) == [a: 1, c: 3, b: 2]
+    :rand.seed(:exsss, seed2)
+    assert Enum.take_random(map, 4) == [a: 1, c: 3, b: 2]
   end
 
   test "reverse/1" do


### PR DESCRIPTION
Replace the deprecated `exsplus` pseudorandom algorithm with `exrop`,
which has been the default algorithm since OTP 20.

Although the `exsplus` still works it has been superceded and therefore
we should not be encouraging users to use it with examples in doctests.

It makes sense to use the new default everywhere rather than change doctests only.

`exsss` is the new default algorithm which was introduced in OTP 22 (see erlang/otp@4a08841). So once OTP 22 is the lowest Erlang version we should switch to it.

> Undocumented (old) algorithms are deprecated but still implemented
> so old code relying on them will produce the same pseudo random sequences as before.

See http://erlang.org/doc/man/rand.html for more detailed documentation.

This post further clarifies the timing of the changes:

https://groups.google.com/forum/#!topic/erlang-programming/Icw0pcIsnIY