### PR TITLE
WIP: Fix bug with formatting of maps in ExUnit output without color

### DIFF
--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -298,6 +298,18 @@ defmodule ExUnit.Formatter do
     code_multiline(Macro.to_string(expr), padding_size)
   end
 
+  defp inspect_multiline({op, context, args} = ast, padding_size, width)
+       when is_atom(op) and is_list(context) and is_list(args) do
+    case Macro.validate(ast) do
+      :ok ->
+        {literal, _} = Code.eval_quoted(ast)
+        inspect_multiline(literal, padding_size, width)
+
+      _ ->
+        inspect_multiline(ast, padding_size, width)
+    end
+  end
+
   defp inspect_multiline(expr, padding_size, width) do
     width = if width == :infinity, do: width, else: width - padding_size
 

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -216,6 +216,18 @@ defmodule ExUnit.FormatterTest do
            """
   end
 
+  test "formats map matches correctly" do
+    failure = [{:error, catch_assertion(assert %{a: :b} = %{a: :c}), []}]
+
+    assert format_test_all_failure(test_module(), failure, 1, :infinity, &formatter/2) =~ """
+             1) Hello: failure on setup_all callback, all tests have been invalidated
+                match (=) failed
+                code:  assert %{a: :b} = %{a: :c}
+                left:  %{a: :b}
+                right: %{a: :c}
+           """
+  end
+
   test "formats assertions with operators with column limit" do
     failure = [{:error, catch_assertion(assert [1, 2, 3] == [4, 5, 6]), []}]
 


### PR DESCRIPTION
Because maps are the only things that are displayed like literals but
aren't parsed as literals in the AST, they weren't being displayed
correctly in ExUnit diffs when they weren't being parsed for the
pattern diff (when users turn color off in ExUnit config).

I ran into this while working on #9608, and here are screenshots of
the before and after behavior. I'm betting this happened when the
pattern diffing was introduced and the `left` in an assertion error
changed from being a value to either a value or a pattern.

I'd love to be able to avoid `Code.eval_quoted/1`, but that seemed
like the best/only option here.

![old_failure](https://user-images.githubusercontent.com/8422484/69811336-28a4d080-11ee-11ea-9415-872aa325cda9.png)
![after](https://user-images.githubusercontent.com/8422484/69811344-2b072a80-11ee-11ea-8b87-ddb122b6f708.png)
