### PR TITLE
Fix typo on test name

### DIFF
--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -543,7 +543,7 @@ defmodule RegistryTest do
         assert Registry.keys(registry, self()) == []
       end
 
-      test "unregistes with no entries", %{registry: registry} do
+      test "unregisters with no entries", %{registry: registry} do
         assert Registry.unregister(registry, "hello") == :ok
       end
 


### PR DESCRIPTION
- `unregistes` 👎 
- `unregisters` 👍