### PR TITLE
make Mix.Dep.diverged?/1 catch :divergedreq

### DIFF
--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -476,7 +476,7 @@ defmodule Mix.Dep do
   """
   def diverged?(%Mix.Dep{status: {:overridden, _}}), do: true
   def diverged?(%Mix.Dep{status: {:diverged, _}}), do: true
-  def diverged?(%Mix.Dep{status: {:divergedreq, _}}), do: true
+  def diverged?(%Mix.Dep{status: {:divergedreq, _, _}}), do: true
   def diverged?(%Mix.Dep{status: {:divergedonly, _}}), do: true
   def diverged?(%Mix.Dep{status: {:divergedtargets, _}}), do: true
   def diverged?(%Mix.Dep{}), do: false


### PR DESCRIPTION
Hi!
Status for `:divergedreq` is a 3-tuple.
https://github.com/elixir-lang/elixir/blob/1faf6787092d2822a2f294394aab48c7ed0c3e00/lib/mix/lib/mix/dep/converger.ex#L257