### PR TITLE
Proposal: Allow to configure secondary IEx prompt

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -338,7 +338,9 @@ defmodule IEx do
     * `:width`
     * `:history_size`
     * `:default_prompt`
+    * `:continuation_prompt`
     * `:alive_prompt`
+    * `:alive_continuation_prompt`
 
   They are discussed individually in the sections below.
 
@@ -420,7 +422,14 @@ defmodule IEx do
   The value is a keyword list with two possible keys representing prompt types:
 
     * `:default_prompt` - used when `Node.alive?/0` returns `false`
-    * `:alive_prompt`   - used when `Node.alive?/0` returns `true`
+
+    * `:continuation_prompt` - used when `Node.alive?/0` returns `false`
+      and more input is expected
+
+    * `:alive_prompt` - used when `Node.alive?/0` returns `true`
+
+    * `:alive_continuation_prompt` - used when `Node.alive?/0` returns
+      `true` and more input is expected
 
   The following values in the prompt string will be replaced appropriately:
 

--- a/lib/iex/lib/iex/config.ex
+++ b/lib/iex/lib/iex/config.ex
@@ -9,9 +9,9 @@ defmodule IEx.Config do
     :inspect,
     :history_size,
     :default_prompt,
-    :default_prompt2,
+    :continuation_prompt,
     :alive_prompt,
-    :alive_prompt2,
+    :alive_continuation_prompt,
     :width
   ]
 
@@ -46,16 +46,16 @@ defmodule IEx.Config do
     Application.fetch_env!(:iex, :default_prompt)
   end
 
-  def default_prompt2() do
-    Application.get_env(:iex, :default_prompt2, default_prompt())
+  def continuation_prompt() do
+    Application.get_env(:iex, :continuation_prompt, default_prompt())
   end
 
   def alive_prompt() do
     Application.fetch_env!(:iex, :alive_prompt)
   end
 
-  def alive_prompt2() do
-    Application.get_env(:iex, :alive_prompt2, alive_prompt())
+  def alive_continuation_prompt() do
+    Application.get_env(:iex, :alive_continuation_prompt, alive_prompt())
   end
 
   def color(color) do
@@ -193,9 +193,9 @@ defmodule IEx.Config do
   defp merge_option(:inspect, old, new) when is_list(new), do: Keyword.merge(old, new)
   defp merge_option(:history_size, _old, new) when is_integer(new), do: new
   defp merge_option(:default_prompt, _old, new) when is_binary(new), do: new
-  defp merge_option(:default_prompt2, _old, new) when is_binary(new), do: new
+  defp merge_option(:continuation_prompt, _old, new) when is_binary(new), do: new
   defp merge_option(:alive_prompt, _old, new) when is_binary(new), do: new
-  defp merge_option(:alive_prompt2, _old, new) when is_binary(new), do: new
+  defp merge_option(:alive_continuation_prompt, _old, new) when is_binary(new), do: new
   defp merge_option(:width, _old, new) when is_integer(new), do: new
 
   defp merge_option(key, _old, new) do

--- a/lib/iex/lib/iex/config.ex
+++ b/lib/iex/lib/iex/config.ex
@@ -4,7 +4,16 @@ defmodule IEx.Config do
 
   @table __MODULE__
   @agent __MODULE__
-  @keys [:colors, :inspect, :history_size, :default_prompt, :alive_prompt, :width]
+  @keys [
+    :colors,
+    :inspect,
+    :history_size,
+    :default_prompt,
+    :default_prompt2,
+    :alive_prompt,
+    :alive_prompt2,
+    :width
+  ]
 
   # Read API
 
@@ -37,8 +46,16 @@ defmodule IEx.Config do
     Application.fetch_env!(:iex, :default_prompt)
   end
 
+  def default_prompt2() do
+    Application.get_env(:iex, :default_prompt2, default_prompt())
+  end
+
   def alive_prompt() do
     Application.fetch_env!(:iex, :alive_prompt)
+  end
+
+  def alive_prompt2() do
+    Application.get_env(:iex, :alive_prompt2, alive_prompt())
   end
 
   def color(color) do
@@ -176,7 +193,9 @@ defmodule IEx.Config do
   defp merge_option(:inspect, old, new) when is_list(new), do: Keyword.merge(old, new)
   defp merge_option(:history_size, _old, new) when is_integer(new), do: new
   defp merge_option(:default_prompt, _old, new) when is_binary(new), do: new
+  defp merge_option(:default_prompt2, _old, new) when is_binary(new), do: new
   defp merge_option(:alive_prompt, _old, new) when is_binary(new), do: new
+  defp merge_option(:alive_prompt2, _old, new) when is_binary(new), do: new
   defp merge_option(:width, _old, new) when is_integer(new), do: new
 
   defp merge_option(key, _old, new) do

--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -117,6 +117,7 @@ defmodule IEx.Server do
   defp loop(state, evaluator, evaluator_ref) do
     self_pid = self()
     counter = state.counter
+
     {prompt_type, prefix} =
       if state.cache != [] do
         {:continuation_prompt, "..."}

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -90,7 +90,9 @@ defmodule IEx.InteractionTest do
 
   test "continuation prompt falls back to default prompt" do
     opts = [default_prompt: "prompt(%counter)>"]
-    assert capture_iex("[\n1\n]\n", opts, [], true) == "prompt(1)> prompt(1)> prompt(1)> [1]\nprompt(2)>"
+
+    assert capture_iex("[\n1\n]\n", opts, [], true) ==
+             "prompt(1)> prompt(1)> prompt(1)> [1]\nprompt(2)>"
   end
 
   if IO.ANSI.enabled?() do

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -83,6 +83,16 @@ defmodule IEx.InteractionTest do
     assert capture_iex("1\n", opts, [], true) == "prompt(1)> 1\nprompt(2)>"
   end
 
+  test "continuation prompt" do
+    opts = [default_prompt: "%prefix(%counter)>", continuation_prompt: "%prefix(%counter)>>>"]
+    assert capture_iex("[\n1\n]\n", opts, [], true) == "iex(1)> ...(1)>>> ...(1)>>> [1]\niex(2)>"
+  end
+
+  test "continuation prompt falls back to default prompt" do
+    opts = [default_prompt: "prompt(%counter)>"]
+    assert capture_iex("[\n1\n]\n", opts, [], true) == "prompt(1)> prompt(1)> prompt(1)> [1]\nprompt(2)>"
+  end
+
   if IO.ANSI.enabled?() do
     test "color" do
       opts = [colors: [enabled: true, eval_result: [:red]]]

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -88,13 +88,6 @@ defmodule IEx.InteractionTest do
     assert capture_iex("[\n1\n]\n", opts, [], true) == "iex(1)> ...(1)>>> ...(1)>>> [1]\niex(2)>"
   end
 
-  test "continuation prompt falls back to default prompt" do
-    opts = [default_prompt: "prompt(%counter)>"]
-
-    assert capture_iex("[\n1\n]\n", opts, [], true) ==
-             "prompt(1)> prompt(1)> prompt(1)> [1]\nprompt(2)>"
-  end
-
   if IO.ANSI.enabled?() do
     test "color" do
       opts = [colors: [enabled: true, eval_result: [:red]]]

--- a/lib/iex/test/test_helper.exs
+++ b/lib/iex/test/test_helper.exs
@@ -60,19 +60,13 @@ defmodule IEx.Case do
   IEx.Server.run to be used in the normal .iex loading process.
   """
   def capture_iex(input, options \\ [], server_options \\ [], capture_prompt \\ false) do
-    previous_configuration = IEx.configuration()
+    IEx.configure(options)
 
-    try do
-      IEx.configure(options)
-
-      ExUnit.CaptureIO.capture_io([input: input, capture_prompt: capture_prompt], fn ->
-        server_options = Keyword.put_new(server_options, :dot_iex_path, "")
-        IEx.Server.run(server_options)
-      end)
-      |> strip_iex()
-    after
-      IEx.configure(previous_configuration)
-    end
+    ExUnit.CaptureIO.capture_io([input: input, capture_prompt: capture_prompt], fn ->
+      server_options = Keyword.put_new(server_options, :dot_iex_path, "")
+      IEx.Server.run(server_options)
+    end)
+    |> strip_iex
   end
 
   defp strip_iex(string) do

--- a/lib/iex/test/test_helper.exs
+++ b/lib/iex/test/test_helper.exs
@@ -60,13 +60,19 @@ defmodule IEx.Case do
   IEx.Server.run to be used in the normal .iex loading process.
   """
   def capture_iex(input, options \\ [], server_options \\ [], capture_prompt \\ false) do
-    IEx.configure(options)
+    previous_configuration = IEx.configuration()
 
-    ExUnit.CaptureIO.capture_io([input: input, capture_prompt: capture_prompt], fn ->
-      server_options = Keyword.put_new(server_options, :dot_iex_path, "")
-      IEx.Server.run(server_options)
-    end)
-    |> strip_iex
+    try do
+      IEx.configure(options)
+
+      ExUnit.CaptureIO.capture_io([input: input, capture_prompt: capture_prompt], fn ->
+        server_options = Keyword.put_new(server_options, :dot_iex_path, "")
+        IEx.Server.run(server_options)
+      end)
+      |> strip_iex()
+    after
+      IEx.configure(previous_configuration)
+    end
   end
 
   defp strip_iex(string) do


### PR DESCRIPTION
Allow further customization of the IEx prompt.

It also introduces a new placeholder `%w` that is replaced by an empty string (whitespaces) of the same length than the main prompt. This placeholder is useful to write prompts that are copy-paste-able. This is how the default prompt looks like: 

```elixir
iex(1)> try do
...(1)>   :ok
...(1)> rescue
...(1)>   _ -> :error
...(1)> end
```

And this is how it would look like with `%w`:

```elixir
iex(1)> IEx.configure(default_prompt2: "%w")
:ok
iex(2)> try do
          :ok
        rescue
          _ -> :error
        end
:ok
```

This idea was inspired by [PostgreSQL's `PROMPT2` ](https://www.postgresql.org/docs/12/app-psql.html#APP-PSQL-PROMPTING), and the `%w` placeholder by an [upcoming feature in PostgreSQL 13](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=7f338369ca624ca6c2e4f579623274c88d325bce).

I went with "prompt2" since this is just a draft, we should probably revisit that name 🙂 