### PR TITLE
Do not shallow clone Git repo in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 env:
-  CIRRUS_CLONE_DEPTH: 1
+  CIRRUS_CLONE_DEPTH: 50
   ELIXIR_ASSERT_TIMEOUT: 2000
   ELIXIRC_OPTS: "--warnings-as-errors"
   ERLC_OPTS: "+warnings_as_errors"


### PR DESCRIPTION
CIRRUS_CLONE_DEPTH is set to 50 (default value in Travis),
to avoid failure when auto-cancellation is enabled,
and a task needs to clone the git repo but a new commit has been added
to that branch. It will fail.

See this for more information
https://github.com/cirruslabs/cirrus-ci-docs/issues/532

More info:
https://stackoverflow.com/a/53857834

You can see a live example here: https://cirrus-ci.com/github/eksperimental/elixir/v6.0
Where the fist commit fails after second one is added. Third and fourth is after this fix.

/cc @fertapric 