### PR TITLE
grammar suggestions for syntax reference

### DIFF
--- a/lib/elixir/pages/Syntax Reference.md
+++ b/lib/elixir/pages/Syntax Reference.md
@@ -221,7 +221,7 @@ end
 
 You can see that variables are also represented with a tuple, except the third element is an atom expressing the variable context.
 
-Over the next section, we will explore many of Elixir syntax constructs alongside their AST representation.
+Over the course of the next section, we will explore many of Elixir syntax constructs alongside their AST representation.
 
 ### Operators
 

--- a/lib/elixir/pages/Syntax Reference.md
+++ b/lib/elixir/pages/Syntax Reference.md
@@ -221,7 +221,7 @@ end
 
 You can see that variables are also represented with a tuple, except the third element is an atom expressing the variable context.
 
-Over the course of this section, we will explore many Elixir syntax constructs alongside their AST representation.
+Over the course of this section, we will explore many Elixir syntax constructs alongside their AST representations.
 
 ### Operators
 

--- a/lib/elixir/pages/Syntax Reference.md
+++ b/lib/elixir/pages/Syntax Reference.md
@@ -221,7 +221,7 @@ end
 
 You can see that variables are also represented with a tuple, except the third element is an atom expressing the variable context.
 
-Over the course of this section, we will explore many of Elixir syntax constructs alongside their AST representation.
+Over the course of this section, we will explore many Elixir syntax constructs alongside their AST representation.
 
 ### Operators
 

--- a/lib/elixir/pages/Syntax Reference.md
+++ b/lib/elixir/pages/Syntax Reference.md
@@ -221,7 +221,7 @@ end
 
 You can see that variables are also represented with a tuple, except the third element is an atom expressing the variable context.
 
-Over the course of the next section, we will explore many of Elixir syntax constructs alongside their AST representation.
+Over the course of this section, we will explore many of Elixir syntax constructs alongside their AST representation.
 
 ### Operators
 


### PR DESCRIPTION
"Over the course of the next section" sounds more natural to me than "over the next section".  "Over the next _________" usually has a temporal expression to fill in the blank, like "over the next 3 days" or "over the summer".  "Throughout the next section" or "In the next section" would also make sense and flow naturally.

I'm also suggesting changing the "next" to "this" because the sentence is inside the section being referred to.  The next section would be the section _after_ "The Elixir AST".

And "many of Elixir syntax constructs" could be changed in a few different ways:

* "many ~of~ Elixir syntax constructs" (remove the "of")
* "many of Elixir's syntax constructs"
* "many of the Elixir syntax constructs"

I felt the first one was clearest in both text and speech. (Having two adjacent S sounds with _Elixir's syntax_ is harder to understand if the text is read aloud.)  If you prefer another and want me to change the PR I'd be happy to.  

If you have any questions about my suggestions, please let me know.  

🇧🇷 A caso de você preferia, eu posso tentar falar disso em português, mas o meu português provavelmente não é tão bom como o seu inglês.  De todos modos, temos duas línguas ao nosso servicio.