### PR TITLE
:manager from dependency definition should override SCM

### DIFF
--- a/lib/mix/lib/mix/dep/converger.ex
+++ b/lib/mix/lib/mix/dep/converger.ex
@@ -345,7 +345,7 @@ defmodule Mix.Dep.Converger do
   end
 
   defp opts_equal?(opts1, opts2) do
-    keys = ~w(app env compile)a
+    keys = ~w(app env compile manager)a
     Enum.all?(keys, &(Keyword.fetch(opts1, &1) == Keyword.fetch(opts2, &1)))
   end
 


### PR DESCRIPTION
The manager for a child dependency is set based on the following rules:

  1. Set in dependency definition
  2. From SCM, so that Hex dependencies of a rebar project can be compiled
     with mix
  3. From the parent dependency, used for rebar dependencies from git
  4. Inferred from files in dependency (mix.exs, rebar.config, Makefile)

To reproduce the fixed issue, use the follow dependency definition:

```elixir
    [
     {:hackney, "~> 1.15.2"},
     {:ssl_verify_fun, "~> 1.1.5", manager: :rebar3, override: true}
    ]
```