### PR TITLE
Add module sigil

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -389,7 +389,7 @@ end
 
 defimpl Inspect, for: PID do
   def inspect(pid, _opts) do
-    "#PID" <> IO.iodata_to_binary(:erlang.pid_to_list(pid))
+    "~PID" <> IO.iodata_to_binary(:erlang.pid_to_list(pid))
   end
 end
 

--- a/lib/elixir/lib/pid.ex
+++ b/lib/elixir/lib/pid.ex
@@ -1,0 +1,5 @@
+defmodule PID do
+  defmacro __sigil__({:<<>>, _, [string]}, _) do
+    :erlang.list_to_pid('<#{string}>')
+  end
+end

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -1,4 +1,8 @@
 defmodule URI do
+  defmacro __sigil__({:<<>>, _, [string]}, []) do
+    Macro.escape(URI.parse(string))
+  end
+
   @moduledoc """
   Utilities for working with URIs.
 

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -27,6 +27,11 @@ expand({'%', Meta, [Left, Right]}, E) ->
 expand({'<<>>', Meta, Args}, E) ->
   elixir_bitstring:expand(Meta, Args, E, false);
 
+expand({'module_sigil', Meta, [Module, String, Modifiers]}, E) ->
+  Alias = {'__aliases__', [{alias, false}], [Module]},
+  RE = E#{requires := ordsets:add_element(Module, ?key(E, requires))},
+  expand({{'.', Meta, [Alias, '__sigil__']}, [], [{'<<>>', Meta, String}, Modifiers]}, RE);
+
 expand({'->', Meta, _Args}, E) ->
   form_error(Meta, E, ?MODULE, unhandled_arrow_op);
 

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -216,7 +216,7 @@ compile_undef(Module, Fun, Arity, Stack) ->
 %% Handle reserved modules and duplicates.
 
 check_module_availability(Line, File, Module) ->
-  Reserved = ['Elixir.Any', 'Elixir.BitString', 'Elixir.PID',
+  Reserved = ['Elixir.Any', 'Elixir.BitString',
               'Elixir.Reference', 'Elixir.Elixir', 'Elixir'],
 
   case lists:member(Module, Reserved) of

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -31,7 +31,7 @@ Terminals
   identifier kw_identifier kw_identifier_safe kw_identifier_unsafe bracket_identifier
   paren_identifier do_identifier block_identifier
   fn 'end' alias
-  atom atom_safe atom_unsafe bin_string list_string sigil
+  atom atom_safe atom_unsafe bin_string list_string sigil module_sigil
   bin_heredoc list_heredoc
   dot_call_op op_identifier
   comp_op at_op unary_op and_op or_op arrow_op match_op in_op in_match_op
@@ -259,6 +259,7 @@ access_expr -> bin_heredoc : build_bin_heredoc('$1').
 access_expr -> list_heredoc : build_list_heredoc('$1').
 access_expr -> bit_string : '$1'.
 access_expr -> sigil : build_sigil('$1').
+access_expr -> module_sigil : build_module_sigil('$1').
 access_expr -> atom : handle_literal(?exprs('$1'), '$1', delimiter(<<$:>>)).
 access_expr -> atom_safe : build_quoted_atom('$1', true, delimiter(<<$:>>)).
 access_expr -> atom_unsafe : build_quoted_atom('$1', false, delimiter(<<$:>>)).
@@ -875,6 +876,11 @@ build_sigil({sigil, Location, Sigil, Parts, Modifiers, Delimiter}) ->
   {list_to_atom("sigil_" ++ [Sigil]),
    MetaWithDelimiter,
    [{'<<>>', Meta, string_parts(Parts)}, Modifiers]}.
+
+%% TODO: handle delimiter
+build_module_sigil({module_sigil, Location, Sigil, Parts, Modifiers, _Delimiter}) ->
+  Meta = meta_from_location(Location),
+  {module_sigil, Meta, [list_to_atom("Elixir." ++ Sigil), string_parts(Parts), Modifiers]}.
 
 build_bin_heredoc({bin_heredoc, Location, Args}) ->
   build_bin_string({bin_string, Location, Args}, delimiter(<<$", $", $">>)).

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -213,6 +213,32 @@ tokenize([$~, S, H | T] = Original, Line, Column, Scope, Tokens) when ?is_sigil(
       interpolation_error(Reason, Original, Tokens, " (for sigil ~ts starting at line ~B)", [Sigil, Line])
   end;
 
+tokenize([$~, A, B | C] = Original, Line, Column, Scope, Tokens) when ?is_upcase(A) andalso
+                                                                          (?is_upcase(B) orelse
+                                                                          ?is_downcase(B)) ->
+  {S, [H | T]} = lists:splitwith(fun(X) -> X /= $[ andalso
+                                           X /= ${ andalso
+                                           X /= $( andalso
+                                           X /= $" andalso
+                                           X /= $' andalso
+                                           X /= $< andalso
+                                           X /= $| andalso
+                                           X /= $/
+                                 end, [A, B | C]),
+  case elixir_interpolation:extract(Line, Column + 3, Scope, false, T, sigil_terminator(H)) of
+    {NewLine, NewColumn, Parts, Rest} ->
+      {Final, Modifiers} = collect_modifiers(Rest, []),
+      Token = {module_sigil, {Line, Column, nil}, S, tokens_to_binary(Parts), Modifiers, <<H>>},
+      NewColumnWithModifiers = NewColumn + length(Modifiers),
+      tokenize(Final, NewLine, NewColumnWithModifiers, Scope, [Token | Tokens]);
+
+    {error, Reason} ->
+      Sigil = [$~ | S] ++ [H],
+      interpolation_error(Reason, Original, Tokens, " (for sigil ~ts starting at line ~B)",
+                          [Sigil, Line])
+  end;
+
+
 tokenize([$~, S, H | _] = Original, Line, Column, _Scope, Tokens) when ?is_upcase(S) orelse ?is_downcase(S) ->
   MessageString =
     "\"~ts\" (column ~p, code point U+~4.16.0B). The available delimiters are: "

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -5,6 +5,10 @@ defmodule URITest do
 
   doctest URI
 
+  test "sigil" do
+    assert %URI{host: "elixir-lang.org"} = ~URI"https://elixir-lang.org"
+  end
+
   test "encode/1,2" do
     assert URI.encode("4_test.is-s~") == "4_test.is-s~"
 


### PR DESCRIPTION
This is a proof-of-concept for adding module-based sigils to Elixir. Before improving implementation and writing docs and tests I'd like to see if this could be added to Elixir. Hope the PR is helpful to test different possible implementations of this idea.

This topic was mentioned a few times over the years, most recently on: https://groups.google.com/forum/#!topic/elixir-lang-core/C7-QgKKu1Mw. In that topic I mentioned a few possible use cases for the sigil that are perhaps worth repeating:

```
URI[https://elixir-lang.org]
Decimal[1]
Complex[0, 1]
Ratio[1, 3]
MapSet[1, 2, 3] # let's ignore this for now
Money[100 USD]
Date.Range[2019-01-01/12-31]
```

Looking forward to feedback about proposal as well as the implementation.