### PR TITLE
Update enum.ex docs for find_value

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -995,12 +995,13 @@ defmodule Enum do
   @doc """
   Similar to `find/3`, but returns the value of the function
   invocation instead of the element itself.
-  An element is considered to be found when the result ist truthy (!= nil or != false).
+
+  An element is considered to be found when the result is truthy (neither `nil` nor `false`).
 
   ## Examples
 
       iex> Enum.find_value([2, 3, 4], fn x ->
-      ...>   if x > 2, do: x*x
+      ...>   if x > 2, do: x * x
       ...> end)
       9
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -998,18 +998,18 @@ defmodule Enum do
   An element is considered to be found when the result ist truthy (!= nil or != false).
 
   ## Examples
-      
+
       iex> Enum.find_value([2, 3, 4], fn x ->
       ...>   if x > 2, do: x*x
       ...> end)
       9
-      
+
       iex> Enum.find_value([2, 4, 6], fn x -> rem(x, 2) == 1 end)
       nil
 
       iex> Enum.find_value([2, 3, 4], fn x -> rem(x, 2) == 1 end)
       true
-      
+
       iex> Enum.find_value([1, 2, 3], "no bools!", &is_boolean/1)
       "no bools!"
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -996,7 +996,8 @@ defmodule Enum do
   Similar to `find/3`, but returns the value of the function
   invocation instead of the element itself.
 
-  An element is considered to be found when the result is truthy (neither `nil` nor `false`).
+  The return value is considered to be found when the result is truthy
+  (neither `nil` nor `false`).
 
   ## Examples
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -995,15 +995,21 @@ defmodule Enum do
   @doc """
   Similar to `find/3`, but returns the value of the function
   invocation instead of the element itself.
+  An element is considered to be found when the result ist truthy (!= nil or != false).
 
   ## Examples
-
+      
+      iex> Enum.find_value([2, 3, 4], fn x ->
+      ...>   if x > 2, do: x*x
+      ...> end)
+      9
+      
       iex> Enum.find_value([2, 4, 6], fn x -> rem(x, 2) == 1 end)
       nil
 
       iex> Enum.find_value([2, 3, 4], fn x -> rem(x, 2) == 1 end)
       true
-
+      
       iex> Enum.find_value([1, 2, 3], "no bools!", &is_boolean/1)
       "no bools!"
 


### PR DESCRIPTION
Optimised `Enum.find_value` docs to show a case that better differentiates it from the alternatives.