### PR TITLE
Docs: Replace UTF-8 code point with Unicode code point

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -898,7 +898,7 @@ defmodule List do
     * a list containing one of these three elements
 
   Notice that this function expects a list of integers representing
-  UTF-8 code points. If you have a list of bytes, you must instead use
+  Unicode code points. If you have a list of bytes, you must instead use
   the [`:binary` module](http://www.erlang.org/doc/man/binary.html).
 
   ## Examples
@@ -949,11 +949,11 @@ defmodule List do
   end
 
   @doc """
-  Converts a list of integers representing code points, lists or
+  Converts a list of integers representing Unicode code points, lists or
   strings into a charlist.
 
   Notice that this function expects a list of integers representing
-  UTF-8 code points. If you have a list of bytes, you must instead use
+  Unicode code points. If you have a list of bytes, you must instead use
   the [`:binary` module](http://www.erlang.org/doc/man/binary.html).
 
   ## Examples

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -276,7 +276,7 @@ defmodule String do
   """
   @type t :: binary
 
-  @typedoc "A UTF-8 code point. It may be one or more bytes."
+  @typedoc "A single Unicode code point encoded in UTF-8. It may be one or more bytes."
   @type codepoint :: t
 
   @typedoc "Multiple code points that may be perceived as a single character by readers"

--- a/lib/logger/lib/logger/formatter.ex
+++ b/lib/logger/lib/logger/formatter.ex
@@ -47,7 +47,7 @@ defmodule Logger.Formatter do
   @replacement "�"
 
   @doc """
-  Prunes non-valid UTF-8 code points.
+  Prunes invalid Unicode code points from lists and invalid UTF-8 bytes.
 
   Typically called after formatting when the data cannot be printed.
   """


### PR DESCRIPTION
Unicode operates with "code points" and UTF-8 is an encoding which represents "code points" as bytes.