### PR TITLE
Use "code point" instead of "codepoint"

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -98,14 +98,14 @@ defmodule IO do
 
   Erlang and Elixir also have the idea of `t:chardata/0`. Chardata is very
   similar to IO data: the only difference is that integers in IO data represent
-  bytes while integers in chardata represent Unicode codepoints. Bytes
-  (`t:byte/0`) are integers in the `0..255` range, while Unicode codepoints
+  bytes while integers in chardata represent Unicode code points. Bytes
+  (`t:byte/0`) are integers in the `0..255` range, while Unicode code points
   (`t:char/0`) are integers in the range `0..0x10FFFF`. The `IO` module provides
   the `chardata_to_string/1` function for chardata as the "counter-part" of the
   `iodata_to_binary/1` function for IO data.
 
   If you try to use `iodata_to_binary/1` on chardata, it will result in an
-  argument error. For example, let's try to put a codepoint that is not
+  argument error. For example, let's try to put a code point that is not
   representable with one byte, like `?π`, inside IO data:
 
       iex> IO.iodata_to_binary(["The symbol for pi is: ", ?π])

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -61,8 +61,8 @@ defmodule String do
   strings, as introducing an invalid byte sequence would
   make the string invalid. If you have to introduce a
   character by its hexdecimal representation, it is best
-  to work with Unicode Codepoints, such as `\uNNNN`. In fact,
-  understanding Unicode Codepoints can be essential when doing
+  to work with Unicode code points, such as `\uNNNN`. In fact,
+  understanding Unicode code points can be essential when doing
   low-level manipulations of string, so let's explore them in
   detail next.
 
@@ -221,7 +221,7 @@ defmodule String do
       "olá"
 
   Finally, to convert a String into a list of integers
-  codepoints, usually known as "char lists", you can call
+  code points, usually known as "char lists", you can call
   `Strig.to_charlist`:
 
       iex> String.to_charlist("olá")


### PR DESCRIPTION
That's the term it is used in the Unicode standard.
related commit 99d919e0c881c1d346dde9273c059360fdfd2f57