### PR TITLE
Use long attributes in make docs target + Use double-quotes around attribute values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,16 +175,16 @@ clean_residual_files:
 #==> Documentation tasks
 
 LOGO_PATH = $(shell test -f ../docs/logo.png && echo "--logo ../docs/logo.png")
-SOURCE_REF = $(shell tag="$(call GIT_TAG)" revision="$(call GIT_REVISION)"; echo "$${tag:-$$revision}\c")
+SOURCE_REF = $(shell tag="$(call GIT_TAG)" revision="$(call GIT_REVISION)"; echo "$${tag:-$$revision}")
 DOCS_FORMAT = html
-COMPILE_DOCS = bin/elixir ../ex_doc/bin/ex_doc "$(1)" "$(VERSION)" "lib/$(2)/ebin" --main "$(3)" --source-url "https://github.com/elixir-lang/elixir" --source-ref "$(call SOURCE_REF)" $(call LOGO_PATH) --output doc/$(2) --canonical https://hexdocs.pm/$(2)/$(CANONICAL) --homepage-url https://elixir-lang.org/docs.html --formatter "$(DOCS_FORMAT)" $(4)
+COMPILE_DOCS = bin/elixir ../ex_doc/bin/ex_doc "$(1)" "$(VERSION)" "lib/$(2)/ebin" --main "$(3)" --source-url "https://github.com/elixir-lang/elixir" --source-ref "$(call SOURCE_REF)" $(call LOGO_PATH) --output doc/$(2) --canonical "https://hexdocs.pm/$(2)/$(CANONICAL)" --homepage-url "https://elixir-lang.org/docs.html" --formatter "$(DOCS_FORMAT)" $(4)
 
 docs: compile ../ex_doc/bin/ex_doc docs_elixir docs_eex docs_mix docs_iex docs_ex_unit docs_logger
 
 docs_elixir: compile ../ex_doc/bin/ex_doc
 	@ echo "==> ex_doc (elixir)"
 	$(Q) rm -rf doc/elixir
-	$(call COMPILE_DOCS,Elixir,elixir,Kernel,--config lib/elixir/docs.exs)
+	$(call COMPILE_DOCS,Elixir,elixir,Kernel,--config "lib/elixir/docs.exs")
 
 docs_eex: compile ../ex_doc/bin/ex_doc
 	@ echo "==> ex_doc (eex)"

--- a/Makefile
+++ b/Makefile
@@ -177,14 +177,14 @@ clean_residual_files:
 LOGO_PATH = $(shell test -f ../docs/logo.png && echo "--logo ../docs/logo.png")
 SOURCE_REF = $(shell tag="$(call GIT_TAG)" revision="$(call GIT_REVISION)"; echo "$${tag:-$$revision}\c")
 DOCS_FORMAT = html
-COMPILE_DOCS = bin/elixir ../ex_doc/bin/ex_doc "$(1)" "$(VERSION)" "lib/$(2)/ebin" -m "$(3)" -u "https://github.com/elixir-lang/elixir" --source-ref "$(call SOURCE_REF)" $(call LOGO_PATH) -o doc/$(2) -n https://hexdocs.pm/$(2)/$(CANONICAL) -p https://elixir-lang.org/docs.html -f "$(DOCS_FORMAT)" $(4)
+COMPILE_DOCS = bin/elixir ../ex_doc/bin/ex_doc "$(1)" "$(VERSION)" "lib/$(2)/ebin" --main "$(3)" --source-url "https://github.com/elixir-lang/elixir" --source-ref "$(call SOURCE_REF)" $(call LOGO_PATH) --output doc/$(2) --canonical https://hexdocs.pm/$(2)/$(CANONICAL) --homepage-url https://elixir-lang.org/docs.html --formatter "$(DOCS_FORMAT)" $(4)
 
 docs: compile ../ex_doc/bin/ex_doc docs_elixir docs_eex docs_mix docs_iex docs_ex_unit docs_logger
 
 docs_elixir: compile ../ex_doc/bin/ex_doc
 	@ echo "==> ex_doc (elixir)"
 	$(Q) rm -rf doc/elixir
-	$(call COMPILE_DOCS,Elixir,elixir,Kernel,-c lib/elixir/docs.exs)
+	$(call COMPILE_DOCS,Elixir,elixir,Kernel,--config lib/elixir/docs.exs)
 
 docs_eex: compile ../ex_doc/bin/ex_doc
 	@ echo "==> ex_doc (eex)"


### PR DESCRIPTION
Use Elixir as a learning tool. Use long attributes to lower the barrier so users can
see the meaning of ExDoc command line attributes

Use double-quotes around attribute values in docs target in Makefile.

```
$ make docs
==> ex_doc (elixir)
bin/elixir ../ex_doc/bin/ex_doc "Elixir" "1.10.0-dev" "lib/elixir/ebin" --main "Kernel" --source-url "https://github.com/elixir-lang/elixir" --source-ref "bc4a5bd71be2a72fed02f7580bcbab4fa2625a35"  --output doc/elixir --canonical "https://hexdocs.pm/elixir/master/ " --homepage-url "https://elixir-lang.org/docs.html" --formatter "html" --config "lib/elixir/docs.exs"
==> ex_doc (eex)
bin/elixir ../ex_doc/bin/ex_doc "EEx" "1.10.0-dev" "lib/eex/ebin" --main "EEx" --source-url "https://github.com/elixir-lang/elixir" --source-ref "bc4a5bd71be2a72fed02f7580bcbab4fa2625a35"  --output doc/eex --canonical "https://hexdocs.pm/eex/master/ " --homepage-url "https://elixir-lang.org/docs.html" --formatter "html" 
==> ex_doc (mix)
bin/elixir ../ex_doc/bin/ex_doc "Mix" "1.10.0-dev" "lib/mix/ebin" --main "Mix" --source-url "https://github.com/elixir-lang/elixir" --source-ref "bc4a5bd71be2a72fed02f7580bcbab4fa2625a35"  --output doc/mix --canonical "https://hexdocs.pm/mix/master/ " --homepage-url "https://elixir-lang.org/docs.html" --formatter "html" 
==> ex_doc (iex)
bin/elixir ../ex_doc/bin/ex_doc "IEx" "1.10.0-dev" "lib/iex/ebin" --main "IEx" --source-url "https://github.com/elixir-lang/elixir" --source-ref "bc4a5bd71be2a72fed02f7580bcbab4fa2625a35"  --output doc/iex --canonical "https://hexdocs.pm/iex/master/ " --homepage-url "https://elixir-lang.org/docs.html" --formatter "html" 
==> ex_doc (ex_unit)
bin/elixir ../ex_doc/bin/ex_doc "ExUnit" "1.10.0-dev" "lib/ex_unit/ebin" --main "ExUnit" --source-url "https://github.com/elixir-lang/elixir" --source-ref "bc4a5bd71be2a72fed02f7580bcbab4fa2625a35"  --output doc/ex_unit --canonical "https://hexdocs.pm/ex_unit/master/ " --homepage-url "https://elixir-lang.org/docs.html" --formatter "html" 
==> ex_doc (logger)
bin/elixir ../ex_doc/bin/ex_doc "Logger" "1.10.0-dev" "lib/logger/ebin" --main "Logger" --source-url "https://github.com/elixir-lang/elixir" --source-ref "bc4a5bd71be2a
```