### PR TITLE
add function Enum.slice for enumerable made by Stream.unfold

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2341,6 +2341,17 @@ defmodule Enum do
   @spec slice(t, Range.t()) :: list
   def slice(enumerable, index_range)
 
+  def slice(enumerable, first..last) when is_function(enumerable) do
+    amount = last - first + 1
+
+    if amount > 0 and first >= 0 and last >= 0 do
+      slice_any(enumerable, first, amount)
+    else
+      raise ArgumentError
+
+    end
+  end
+
   def slice(enumerable, first..last) do
     {count, fun} = slice_count_and_fun(enumerable)
     corr_first = if first >= 0, do: first, else: first + count

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2334,6 +2334,7 @@ defmodule Enum do
 
   def slice(enumerable, first..last) when first >= 0 and last >= 0 do
     amount = last - first + 1
+
     if amount > 0 do
       slice_any(enumerable, first, amount)
     else

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2350,7 +2350,9 @@ defmodule Enum do
   then takes `amount` of elements, returning as many elements as possible if
   there are not enough elements.
 
-  A negative `start_index` cannot be passed.
+  A negative `start_index` can be passed, which means the `enumerable` is
+  enumerated once and the index is counted from the end (for example,
+  `-1` starts slicing from the last element).
 
   It returns `[]` if `amount` is `0` or if `start_index` is out of bounds.
 
@@ -2366,16 +2368,24 @@ defmodule Enum do
       iex> Enum.slice(1..10, 5, 0)
       []
 
-      # out of bound start index
+      # using a negative start index
+      iex> Enum.slice(1..10, -6, 3)
+      [5, 6, 7]
+
+      # out of bound start index (positive)
       iex> Enum.slice(1..10, 10, 5)
       []
 
+      # out of bound start index (negative)
+      iex> Enum.slice(1..10, -11, 5)
+      []
+
   """
-  @spec slice(t, non_neg_integer, non_neg_integer) :: list
+  @spec slice(t, index, non_neg_integer) :: list
   def slice(_enumerable, start_index, 0) when is_integer(start_index), do: []
 
   def slice(enumerable, start_index, amount)
-      when is_integer(start_index) and is_integer(amount) and amount >= 0 and start_index >= 0 do
+      when is_integer(start_index) and is_integer(amount) and amount >= 0 do
     slice_any(enumerable, start_index, amount)
   end
 
@@ -2560,8 +2570,7 @@ defmodule Enum do
           t,
           (element -> mapped_element),
           (element, element -> boolean) | :asc | :desc | module() | {:asc | :desc, module()}
-        ) ::
-          list
+        ) :: list
         when mapped_element: element
   def sort_by(enumerable, mapper, sorter \\ &<=/2) do
     enumerable

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2302,8 +2302,7 @@ defmodule Enum do
   elements before `index_range.first` (zero-base), then takes elements
   until element `index_range.last` (inclusively).
 
-  Indexes are normalized, meaning that negative indexes will be counted
-  from the end (for example, `-1` means the last element of the `enumerable`).
+  Negative indexes cannot be passed.
 
   If `index_range.last` is out of bounds, then it is assigned as the index
   of the last element.
@@ -2320,14 +2319,6 @@ defmodule Enum do
       iex> Enum.slice(1..10, 5..20)
       [6, 7, 8, 9, 10]
 
-      # last five elements (negative indexes)
-      iex> Enum.slice(1..30, -5..-1)
-      [26, 27, 28, 29, 30]
-
-      # last five elements (mixed positive and negative indexes)
-      iex> Enum.slice(1..30, 25..-1)
-      [26, 27, 28, 29, 30]
-
       # out of bounds
       iex> Enum.slice(1..10, 11..20)
       []
@@ -2341,24 +2332,10 @@ defmodule Enum do
   @spec slice(t, Range.t()) :: list
   def slice(enumerable, index_range)
 
-  def slice(enumerable, first..last) when is_function(enumerable) do
+  def slice(enumerable, first..last) when first >= 0 and last >= 0 do
     amount = last - first + 1
-
-    if amount > 0 and first >= 0 and last >= 0 do
+    if amount > 0 do
       slice_any(enumerable, first, amount)
-    else
-      raise ArgumentError
-    end
-  end
-
-  def slice(enumerable, first..last) do
-    {count, fun} = slice_count_and_fun(enumerable)
-    corr_first = if first >= 0, do: first, else: first + count
-    corr_last = if last >= 0, do: last, else: last + count
-    amount = corr_last - corr_first + 1
-
-    if corr_first >= 0 and corr_first < count and amount > 0 do
-      fun.(corr_first, Kernel.min(amount, count - corr_first))
     else
       []
     end
@@ -2372,9 +2349,7 @@ defmodule Enum do
   then takes `amount` of elements, returning as many elements as possible if
   there are not enough elements.
 
-  A negative `start_index` can be passed, which means the `enumerable` is
-  enumerated once and the index is counted from the end (for example,
-  `-1` starts slicing from the last element).
+  A negative `start_index` cannot be passed.
 
   It returns `[]` if `amount` is `0` or if `start_index` is out of bounds.
 
@@ -2390,24 +2365,16 @@ defmodule Enum do
       iex> Enum.slice(1..10, 5, 0)
       []
 
-      # using a negative start index
-      iex> Enum.slice(1..10, -6, 3)
-      [5, 6, 7]
-
-      # out of bound start index (positive)
+      # out of bound start index
       iex> Enum.slice(1..10, 10, 5)
       []
 
-      # out of bound start index (negative)
-      iex> Enum.slice(1..10, -11, 5)
-      []
-
   """
-  @spec slice(t, index, non_neg_integer) :: list
+  @spec slice(t, non_neg_integer, non_neg_integer) :: list
   def slice(_enumerable, start_index, 0) when is_integer(start_index), do: []
 
   def slice(enumerable, start_index, amount)
-      when is_integer(start_index) and is_integer(amount) and amount >= 0 do
+      when is_integer(start_index) and is_integer(amount) and amount >= 0 and start_index >= 0 do
     slice_any(enumerable, start_index, amount)
   end
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2348,7 +2348,6 @@ defmodule Enum do
       slice_any(enumerable, first, amount)
     else
       raise ArgumentError
-
     end
   end
 

--- a/lib/elixir/test/elixir/calendar/date_range_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_range_test.exs
@@ -38,12 +38,10 @@ defmodule Date.RangeTest do
   describe "Enum.slice/3" do
     test "for ascending range" do
       assert Enum.slice(@asc_range, 3, 3) == [~D[2000-01-04], ~D[2000-01-05], ~D[2000-01-06]]
-      assert Enum.slice(@asc_range, -3, 3) == [~D[2000-12-30], ~D[2000-12-31], ~D[2001-01-01]]
     end
 
     test "for descending range" do
       assert Enum.slice(@desc_range, 3, 3) == [~D[2000-12-29], ~D[2000-12-28], ~D[2000-12-27]]
-      assert Enum.slice(@desc_range, -3, 3) == [~D[2000-01-03], ~D[2000-01-02], ~D[2000-01-01]]
     end
   end
 

--- a/lib/elixir/test/elixir/calendar/date_range_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_range_test.exs
@@ -38,10 +38,12 @@ defmodule Date.RangeTest do
   describe "Enum.slice/3" do
     test "for ascending range" do
       assert Enum.slice(@asc_range, 3, 3) == [~D[2000-01-04], ~D[2000-01-05], ~D[2000-01-06]]
+      assert Enum.slice(@asc_range, -3, 3) == [~D[2000-12-30], ~D[2000-12-31], ~D[2001-01-01]]
     end
 
     test "for descending range" do
       assert Enum.slice(@desc_range, 3, 3) == [~D[2000-12-29], ~D[2000-12-28], ~D[2000-12-27]]
+      assert Enum.slice(@desc_range, -3, 3) == [~D[2000-01-03], ~D[2000-01-02], ~D[2000-01-01]]
     end
   end
 

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -716,28 +716,13 @@ defmodule EnumTest do
     assert Enum.slice(list, 0..0) == [1]
     assert Enum.slice(list, 0..1) == [1, 2]
     assert Enum.slice(list, 0..2) == [1, 2, 3]
-    assert Enum.slice(list, 1, 2) == [2, 3]
-    assert Enum.slice(list, 1, 0) == []
-    assert Enum.slice(list, 2, 5) == [3, 4, 5]
-    assert Enum.slice(list, 2, 6) == [3, 4, 5]
-    assert Enum.slice(list, 5, 5) == []
-    assert Enum.slice(list, 6, 5) == []
-    assert Enum.slice(list, 6, 0) == []
-    assert Enum.slice(list, -6, 0) == []
-    assert Enum.slice(list, -6, 5) == []
-    assert Enum.slice(list, -2, 5) == [4, 5]
-    assert Enum.slice(list, -3, 1) == [3]
 
     assert_raise FunctionClauseError, fn ->
-      Enum.slice(list, 0, -1)
+      Enum.slice(list, 0..-2)
     end
 
     assert_raise FunctionClauseError, fn ->
-      Enum.slice(list, 0.99, 0)
-    end
-
-    assert_raise FunctionClauseError, fn ->
-      Enum.slice(list, 0, 0.99)
+      Enum.slice(list, -2..0)
     end
   end
 
@@ -753,13 +738,13 @@ defmodule EnumTest do
     assert Enum.slice(list, 5, 5) == []
     assert Enum.slice(list, 6, 5) == []
     assert Enum.slice(list, 6, 0) == []
-    assert Enum.slice(list, -6, 0) == []
-    assert Enum.slice(list, -6, 5) == []
-    assert Enum.slice(list, -2, 5) == [4, 5]
-    assert Enum.slice(list, -3, 1) == [3]
 
     assert_raise FunctionClauseError, fn ->
       Enum.slice(list, 0, -1)
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Enum.slice(list, -2, 1)
     end
 
     assert_raise FunctionClauseError, fn ->
@@ -1522,11 +1507,6 @@ defmodule EnumTest.Range do
     assert Enum.slice(1..5, 5..5) == []
     assert Enum.slice(1..5, 6..5) == []
     assert Enum.slice(1..5, 6..0) == []
-    assert Enum.slice(1..5, -6..0) == []
-    assert Enum.slice(1..5, -6..5) == []
-    assert Enum.slice(1..5, -5..-1) == [1, 2, 3, 4, 5]
-    assert Enum.slice(1..5, -5..-3) == [1, 2, 3]
-    assert Enum.slice(1..5, -6..-1) == []
 
     assert_raise ArgumentError, fn ->
       x = 1.1
@@ -1536,6 +1516,14 @@ defmodule EnumTest.Range do
     assert_raise ArgumentError, fn ->
       x = 1.9
       Enum.slice(1..5, 1..x)
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Enum.slice(1..5, 1..-1)
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Enum.slice(1..5, -1..1)
     end
 
     assert Enum.slice(5..1, 0..0) == [5]
@@ -1549,11 +1537,6 @@ defmodule EnumTest.Range do
     assert Enum.slice(5..1, 5..5) == []
     assert Enum.slice(5..1, 6..5) == []
     assert Enum.slice(5..1, 6..0) == []
-    assert Enum.slice(5..1, -6..0) == []
-    assert Enum.slice(5..1, -6..5) == []
-    assert Enum.slice(5..1, -5..-1) == [5, 4, 3, 2, 1]
-    assert Enum.slice(5..1, -5..-3) == [5, 4, 3]
-    assert Enum.slice(5..1, -6..-1) == []
   end
 
   test "slice/3" do
@@ -1567,13 +1550,13 @@ defmodule EnumTest.Range do
     assert Enum.slice(1..5, 5, 5) == []
     assert Enum.slice(1..5, 6, 5) == []
     assert Enum.slice(1..5, 6, 0) == []
-    assert Enum.slice(1..5, -6, 0) == []
-    assert Enum.slice(1..5, -6, 5) == []
-    assert Enum.slice(1..5, -2, 5) == [4, 5]
-    assert Enum.slice(1..5, -3, 1) == [3]
 
     assert_raise FunctionClauseError, fn ->
       Enum.slice(1..5, 0, -1)
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Enum.slice(1..5, -1, 2)
     end
 
     assert_raise FunctionClauseError, fn ->
@@ -1595,8 +1578,6 @@ defmodule EnumTest.Range do
     assert Enum.slice(5..1, 5, 5) == []
     assert Enum.slice(5..1, 6, 5) == []
     assert Enum.slice(5..1, 6, 0) == []
-    assert Enum.slice(5..1, -6, 0) == []
-    assert Enum.slice(5..1, -6, 5) == []
   end
 
   test "sort/1" do
@@ -1851,34 +1832,18 @@ defmodule EnumTest.Map do
     assert Enum.slice(map, 0..0) == [a: 1]
     assert Enum.slice(map, 0..1) == [a: 1, b: 2]
     assert Enum.slice(map, 0..2) == [a: 1, b: 2, c: 3]
+
+    assert_raise FunctionClauseError, fn ->
+      Enum.slice(map, 0..-1)
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Enum.slice(map, -1..0)
+    end
   end
 
   test "slice/3" do
     map = %{a: 1, b: 2, c: 3, d: 4, e: 5}
-    assert Enum.slice(map, 1, 2) == [b: 2, c: 3]
-    assert Enum.slice(map, 1, 0) == []
-    assert Enum.slice(map, 2, 5) == [c: 3, d: 4, e: 5]
-    assert Enum.slice(map, 2, 6) == [c: 3, d: 4, e: 5]
-    assert Enum.slice(map, 5, 5) == []
-    assert Enum.slice(map, 6, 5) == []
-    assert Enum.slice(map, 6, 0) == []
-    assert Enum.slice(map, -6, 0) == []
-    assert Enum.slice(map, -6, 5) == []
-    assert Enum.slice(map, -2, 5) == [d: 4, e: 5]
-    assert Enum.slice(map, -3, 1) == [c: 3]
-
-    assert_raise FunctionClauseError, fn ->
-      Enum.slice(map, 0, -1)
-    end
-
-    assert_raise FunctionClauseError, fn ->
-      Enum.slice(map, 0.99, 0)
-    end
-
-    assert_raise FunctionClauseError, fn ->
-      Enum.slice(map, 0, 0.99)
-    end
-
     assert Enum.slice(map, 0, 0) == []
     assert Enum.slice(map, 0, 1) == [a: 1]
     assert Enum.slice(map, 0, 2) == [a: 1, b: 2]
@@ -1889,13 +1854,13 @@ defmodule EnumTest.Map do
     assert Enum.slice(map, 5, 5) == []
     assert Enum.slice(map, 6, 5) == []
     assert Enum.slice(map, 6, 0) == []
-    assert Enum.slice(map, -6, 0) == []
-    assert Enum.slice(map, -6, 5) == []
-    assert Enum.slice(map, -2, 5) == [d: 4, e: 5]
-    assert Enum.slice(map, -3, 1) == [c: 3]
 
     assert_raise FunctionClauseError, fn ->
       Enum.slice(map, 0, -1)
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Enum.slice(map, -1, 2)
     end
 
     assert_raise FunctionClauseError, fn ->

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -352,8 +352,7 @@ defmodule EnumTest do
     assert Enum.map_every([], 2, fn x -> x * 2 end) == []
     assert Enum.map_every([1, 2], 2, fn x -> x * 2 end) == [2, 2]
 
-    assert Enum.map_every([1, 2, 3], 0, fn _x -> raise "should not be invoked" end) ==
-             [1, 2, 3]
+    assert Enum.map_every([1, 2, 3], 0, fn _x -> raise "should not be invoked" end) == [1, 2, 3]
 
     assert Enum.map_every(1..3, 1, fn x -> x * 2 end) == [2, 4, 6]
 
@@ -738,13 +737,13 @@ defmodule EnumTest do
     assert Enum.slice(list, 5, 5) == []
     assert Enum.slice(list, 6, 5) == []
     assert Enum.slice(list, 6, 0) == []
+    assert Enum.slice(list, -6, 0) == []
+    assert Enum.slice(list, -6, 5) == []
+    assert Enum.slice(list, -2, 5) == [4, 5]
+    assert Enum.slice(list, -3, 1) == [3]
 
     assert_raise FunctionClauseError, fn ->
       Enum.slice(list, 0, -1)
-    end
-
-    assert_raise FunctionClauseError, fn ->
-      Enum.slice(list, -2, 1)
     end
 
     assert_raise FunctionClauseError, fn ->
@@ -1550,13 +1549,13 @@ defmodule EnumTest.Range do
     assert Enum.slice(1..5, 5, 5) == []
     assert Enum.slice(1..5, 6, 5) == []
     assert Enum.slice(1..5, 6, 0) == []
+    assert Enum.slice(1..5, -6, 0) == []
+    assert Enum.slice(1..5, -6, 5) == []
+    assert Enum.slice(1..5, -2, 5) == [4, 5]
+    assert Enum.slice(1..5, -3, 1) == [3]
 
     assert_raise FunctionClauseError, fn ->
       Enum.slice(1..5, 0, -1)
-    end
-
-    assert_raise FunctionClauseError, fn ->
-      Enum.slice(1..5, -1, 2)
     end
 
     assert_raise FunctionClauseError, fn ->
@@ -1578,6 +1577,8 @@ defmodule EnumTest.Range do
     assert Enum.slice(5..1, 5, 5) == []
     assert Enum.slice(5..1, 6, 5) == []
     assert Enum.slice(5..1, 6, 0) == []
+    assert Enum.slice(5..1, -6, 0) == []
+    assert Enum.slice(5..1, -6, 5) == []
   end
 
   test "sort/1" do
@@ -1854,13 +1855,13 @@ defmodule EnumTest.Map do
     assert Enum.slice(map, 5, 5) == []
     assert Enum.slice(map, 6, 5) == []
     assert Enum.slice(map, 6, 0) == []
+    assert Enum.slice(map, -6, 0) == []
+    assert Enum.slice(map, -6, 5) == []
+    assert Enum.slice(map, -2, 5) == [d: 4, e: 5]
+    assert Enum.slice(map, -3, 1) == [c: 3]
 
     assert_raise FunctionClauseError, fn ->
       Enum.slice(map, 0, -1)
-    end
-
-    assert_raise FunctionClauseError, fn ->
-      Enum.slice(map, -1, 2)
     end
 
     assert_raise FunctionClauseError, fn ->


### PR DESCRIPTION
This fixes issue #9653 
This issue happened because of Enum.slice /2 count elements.

Stream.cycle() return Function in Stream.unfold/2, So, add function Enum.slice for enumerable made by Stream.unfold
I make function return ArgumentError when passed negative index_range.