### PR TITLE
Genserver to track discarded counts of logs?

### DIFF
--- a/lib/logger/lib/logger/handler.ex
+++ b/lib/logger/lib/logger/handler.ex
@@ -80,6 +80,7 @@ defmodule Logger.Handler do
   def log(%{level: erl_level, msg: msg, meta: metadata}, %{config: config}) do
     case threshold(config) do
       :discard ->
+        # potential call to a genserver that keeps a periodic tally of how many messages have been discarded?
         :ok
 
       mode ->


### PR DESCRIPTION
I'm concerned there's no visibility into when logs are being discarded, would there be interest and support into adding a genserver that keeps track of discarded count and eventually logs that out?

It's scary to me that logs could be getting discarded without my knowledge currently.

I would be more than happy to implement this change.