### PR TITLE
Fix Macro.to_string for sigils

### DIFF
--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1623,9 +1623,9 @@ defmodule Kernel.WarningTest do
 
   test "struct comparisons" do
     expressions = [
-      ~s(~N"2018-01-28 12:00:00"),
-      ~s(~T"12:00:00"),
-      ~s(~D"2018-01-28"),
+      ~s(~N[2018-01-28 12:00:00]),
+      ~s(~T[12:00:00]),
+      ~s(~D[2018-01-28]),
       "%File.Stat{}"
     ]
 

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -326,18 +326,23 @@ defmodule MacroTest do
     end
 
     test "sigil call" do
-      assert Macro.to_string(quote(do: ~r"123")) == ~S/~r"123"/
-      assert Macro.to_string(quote(do: ~r"123"u)) == ~S/~r"123"u/
-      assert Macro.to_string(quote(do: ~r"\n123")) == ~S/~r"\\n123"/
+      assert Macro.to_string(quote(do: ~D[2019-10-31])) == ~S/~D[2019-10-31]/
+      assert Macro.to_string(quote(do: ~T[23:00:07.0])) == ~S/~T[23:00:07.0]/
+      assert Macro.to_string(quote(do: ~N[2019-10-31 23:00:07])) == ~S/~N[2019-10-31 23:00:07]/
+      assert Macro.to_string(quote(do: ~U[2019-10-31 19:59:03Z])) == ~S/~U[2019-10-31 19:59:03Z]/
 
-      assert Macro.to_string(quote(do: ~r"1#{two}3")) == ~S/~r"1#{two}3"/
-      assert Macro.to_string(quote(do: ~r"1#{two}3"u)) == ~S/~r"1#{two}3"u/
+      assert Macro.to_string(quote(do: ~r/123/)) == ~S"~r/123/"
+      assert Macro.to_string(quote(do: ~r/123/u)) == ~S"~r/123/u"
+      assert Macro.to_string(quote(do: ~r{\n123})) == ~S"~r/\\n123/"
 
-      assert Macro.to_string(quote(do: ~R"123")) == ~S/~R"123"/
-      assert Macro.to_string(quote(do: ~R"123"u)) == ~S/~R"123"u/
-      assert Macro.to_string(quote(do: ~R"\n123")) == ~S/~R"\n123"/
+      assert Macro.to_string(quote(do: ~r"1#{two}3")) == ~S"~r/1#{two}3/"
+      assert Macro.to_string(quote(do: ~r"1#{two}3"u)) == ~S"~r/1#{two}3/u"
 
-      assert Macro.to_string(quote(do: ~S["'(123)'"])) == ~S/~S["'(123)'"]/
+      assert Macro.to_string(quote(do: ~R"123")) == ~S"~R/123/"
+      assert Macro.to_string(quote(do: ~R"123"u)) == ~S"~R/123/u"
+      assert Macro.to_string(quote(do: ~R"\n123")) == ~S"~R/\n123/"
+
+      assert Macro.to_string(quote(do: ~S{"'(123)'"})) == ~S/~S["'(123)'"]/
 
       assert Macro.to_string(
                quote do

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -557,7 +557,7 @@ defmodule ExUnit.DiffTest do
   test "structs with inspect" do
     refute_diff(
       ~D[2017-10-01] = ~D[2017-10-02],
-      ~s/-~D"2017-10-01"-/,
+      ~s/-~D[2017-10-01]-/,
       "~D[2017-10-0+2+]"
     )
 
@@ -569,7 +569,7 @@ defmodule ExUnit.DiffTest do
 
     refute_diff(
       ~D[2017-10-02] = "2017-10-01",
-      ~s/-~D"2017-10-02"-/,
+      ~s/-~D[2017-10-02]-/,
       ~s/+"2017-10-01"+/
     )
   end

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -750,7 +750,7 @@ defmodule ExUnit.DocTestTest do
              8) doctest module ExUnit.DocTestTest.PatternMatching (8) (ExUnit.DocTestTest.PatternMatchingRunner)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 match (=) failed
-                code:  %{year: 2001, day: 1} = ~D"2000-01-01"
+                code:  %{year: 2001, day: 1} = ~D[2000-01-01]
                 left:  %{year: 2001, day: 1}
                 right: ~D[2000-01-01]
                 stacktrace:


### PR DESCRIPTION
Some sigils are commonly used with certain delimiters first, but in the
current implementation of Macro.to_string/1 it defaults all sigils to
using `"` as a delimiter. This changes things so that certain sigils are
shown with their "preferred" delimiters first.

Ideally I'd love if the delimiters for the given sigil were kept in the
AST metadata when compiled so we can always show the exact code that a
user input in places like ExUnit. At the moment when we show the `code`
block in ExUnit errors, if a sigil is used there it's not guaranteed to
show the actual code that the user input, but we can't do this at the
moment since we don't have the delimiter data in the AST. At least with
this change we're more likely to show users the correct delimiters.