### PR TITLE
ExUnit: produce nice assertion errors with the pipe operator

### DIFF
--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -493,6 +493,34 @@ defmodule ExUnit.AssertionsTest do
     end
   end
 
+  test "assert pipe when truthy" do
+    assert %{foo: 'bar'} |> Map.equal?(%{foo: 'bar'})
+  end
+
+  test "assert pipe when falsy" do
+    try do
+      value = %{foo: 2}
+      "This should never be tested" = assert %{foo: 1} |> Map.equal?(value)
+    rescue
+      error in [ExUnit.AssertionError] ->
+        [%{foo: 1}, %{foo: 2}] = error.args
+        "Expected Map.equal?/2 to return truthy, got false" = error.message
+        "assert(%{foo: 1} |> Map.equal?(value))" = Macro.to_string(error.expr)
+    end
+  end
+
+  test "assert multiple pipes when falsy" do
+    try do
+      value = %{foo: 2}
+      "This should never be tested" = assert %{} |> Map.put(:foo, 1) |> Map.equal?(value)
+    rescue
+      error in [ExUnit.AssertionError] ->
+        [%{foo: 1}, %{foo: 2}] = error.args
+        "Expected Map.equal?/2 to return truthy, got false" = error.message
+        "assert(%{} |> Map.put(:foo, 1) |> Map.equal?(value))" = Macro.to_string(error.expr)
+    end
+  end
+
   test "refute in when is not member" do
     false = refute 'baz' in ['foo', 'bar']
   end


### PR DESCRIPTION
With the following code:

```elixir
value = %{n: 2}
assert %{n: 1} |> Map.equal?(value)
```

Instead of just indicating that it expected truthy and got false, the following helpful error is produced:

    Expected Map.equal?/2 to return truthy, got false
    code: assert %{n: 1} |> Map.equal?(value)
    arguments:

       # 1
       %{n: 1}

       # 2
       %{n: 2}

I tried to make this work because I thought it was a shame that `assert fun(arg1, arg2)` produces a nice assertion error, but not `assert arg1 |> fun(arg2)` (the values of the arguments are not shown in the error).

I was writing functions to compare a date from an API to an expected date, and wanted to be able to write assertions in a functional style like this, without an additional library:

```elixir
assert created_at |> just_after?(now, within: 500, unit: :millisecond)
```

I also made the error message explicitly indicate the function's name and arity. You could argue it is redundant since the code of the assertion is shown, but I thought it could be helpful.

All that said, I am a total Elixir beginner and I wrote this by trial and error, with little to no understanding of what I just did with macros. I have no idea whether this will work in all cases or whether it's a bad idea because "you just shouldn't do that". Please do not hesitate to tell me why it may be a bad idea or how to improve it.