### PR TITLE
Set runtime config as false when not rebooting

### DIFF
--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -426,7 +426,7 @@ defmodule Mix.Release do
     ]
 
     init = Config.Provider.init(release.config_providers, config_path, opts)
-    {Config.Reader.merge(sys_config, [elixir: [config_providers: init]] ++ extra_config), true}
+    {Config.Reader.merge(sys_config, [elixir: [config_providers: init]] ++ extra_config), reboot?}
   end
 
   defp start_distribution(%{options: opts}) do

--- a/lib/mix/test/mix/release_test.exs
+++ b/lib/mix/test/mix/release_test.exs
@@ -521,7 +521,7 @@ defmodule Mix.ReleaseTest do
     test "writes the given sys_config without reboot" do
       release = release(config_providers: @providers, reboot_system_after_config: false)
       assert make_sys_config(release, [kernel: [key: :value]], "/foo/bar/bat") == :ok
-      assert File.read!(@sys_config) =~ "%% RUNTIME_CONFIG=true"
+      assert File.read!(@sys_config) =~ "%% RUNTIME_CONFIG=false"
       {:ok, [config]} = :file.consult(@sys_config)
       assert %Config.Provider{} = provider = config[:elixir][:config_providers]
       refute provider.reboot_after_config


### PR DESCRIPTION
This allows the release skip the creation of unnecessary runtime files during the execution of the clis