### PR TITLE
IO.ANSI.Docs - Properly render quote blocks

### DIFF
--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -208,11 +208,14 @@ defmodule IO.ANSI.Docs do
   defp write_quote(lines, indent, options) do
     lines
     |> Enum.reverse()
-    |> Enum.map_join("\n#{indent}", fn line ->
-      [color(:doc_quote, options), "> ", IO.ANSI.reset(), format_text(line, options)]
+    |> Enum.join(" ")
+    |> format_text(options)
+    |> String.split(@spaces)
+    # -2 for the leading `> `
+    |> wrap_text(options[:width] - byte_size(indent) - 2, indent, false)
+    |> Enum.map_join("\n", fn line ->
+      [indent, color(:doc_quote, options), "> ", IO.ANSI.reset(), line]
     end)
-    # There is no special style for quotes, as such we simply use IO.puts;
-    # a special quotes style would clash with inline styling (bold, italics etc.)
     |> IO.puts()
 
     newline_after_block()

--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -515,9 +515,23 @@ defmodule IO.ANSI.Docs do
   end
 
   defp write_with_wrap(words, available, indent, first) do
+    words
+    |> wrap_text(available, indent, first)
+    |> Enum.join("\n")
+    |> IO.puts()
+  end
+
+  defp wrap_text(words, available, ident, first, wrapped_lines \\ [])
+
+  defp wrap_text([], _available, _indent, _first, wrapped_lines) do
+    Enum.reverse(wrapped_lines)
+  end
+
+  defp wrap_text(words, available, indent, first, wrapped_lines) do
     {words, rest} = take_words(words, available, [])
-    IO.puts(if(first, do: "", else: indent) <> Enum.join(words, " "))
-    write_with_wrap(rest, available, indent, false)
+    line = if(first, do: "", else: indent) <> Enum.join(words, " ")
+
+    wrap_text(rest, available, indent, false, [line | wrapped_lines])
   end
 
   defp take_words([word | words], available, acc) do

--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -14,7 +14,6 @@ defmodule IO.ANSI.Docs do
     * `:doc_code`          - code blocks (cyan)
     * `:doc_headings`      - h1, h2, h3, h4, h5, h6 headings (yellow)
     * `:doc_metadata`      - documentation metadata keys (yellow)
-    * `:doc_quote`         - quotes (light black, italic)
     * `:doc_inline_code`   - inline code (cyan)
     * `:doc_table_heading` - the style for table headings
     * `:doc_title`         - top level heading (reverse, yellow)
@@ -32,7 +31,6 @@ defmodule IO.ANSI.Docs do
       doc_code: [:cyan],
       doc_headings: [:yellow],
       doc_metadata: [:yellow],
-      doc_quote: [],
       doc_inline_code: [:cyan],
       doc_table_heading: [:reverse],
       doc_title: [:reverse, :yellow],
@@ -229,7 +227,9 @@ defmodule IO.ANSI.Docs do
         "#{quote_text}\n" <>
         quote_box
 
-    write(:doc_quote, quote_block, options)
+    # There is no special style for quotes, as such we simply use IO.puts;
+    # a special quotes style would clash with inline styling (bold, italics etc.)
+    IO.puts(quote_block)
     newline_after_block()
   end
 

--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -205,9 +205,11 @@ defmodule IO.ANSI.Docs do
 
   defp write_quote(lines, indent, options) do
     formatted_lines_with_length =
-      lines
-      |> Enum.map(&format_text(&1, options))
-      |> Enum.map(&{&1, length_without_escape(&1, 0)})
+      Enum.map(lines, fn line ->
+        formatted_line = format_text(line, options)
+
+        {formatted_line, length_without_escape(formatted_line, 0)}
+      end)
 
     {_line, max_length} = Enum.max_by(formatted_lines_with_length, fn {_, length} -> length end)
 

--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -139,7 +139,7 @@ defmodule IO.ANSI.Docs do
     write_heading(heading, rest, text, indent, options)
   end
 
-  defp process(["> " <> line | rest], text, indent, options) do
+  defp process(["> " <> _ = line | rest], text, indent, options) do
     write_text(text, indent, options)
     process_quote(rest, [line], indent, options)
   end
@@ -194,7 +194,7 @@ defmodule IO.ANSI.Docs do
     write_quote(lines, indent, options)
   end
 
-  defp process_quote(["> " <> line | rest], lines, indent, options) do
+  defp process_quote(["> " <> _ = line | rest], lines, indent, options) do
     process_quote(rest, [line | lines], indent, options)
   end
 
@@ -204,34 +204,13 @@ defmodule IO.ANSI.Docs do
   end
 
   defp write_quote(lines, indent, options) do
-    formatted_lines_with_length =
-      Enum.map(lines, fn line ->
-        formatted_line = format_text(line, options)
-
-        {formatted_line, length_without_escape(formatted_line, 0)}
-      end)
-
-    {_line, max_length} = Enum.max_by(formatted_lines_with_length, fn {_, length} -> length end)
-
-    quote_text =
-      formatted_lines_with_length
-      |> Enum.reverse()
-      |> Enum.map_join("\n#{indent}", fn {line, length} ->
-        padding = String.duplicate(" ", max_length - length)
-
-        "| " <> line <> padding <> " |"
-      end)
-
-    quote_box = indent <> "+-" <> String.duplicate("-", max_length) <> "-+"
-
-    quote_block =
-      "#{quote_box}\n" <>
-        "#{quote_text}\n" <>
-        quote_box
-
+    lines
+    |> Enum.reverse()
+    |> Enum.map_join("\n#{indent}", &format_text(&1, options))
     # There is no special style for quotes, as such we simply use IO.puts;
     # a special quotes style would clash with inline styling (bold, italics etc.)
-    IO.puts(quote_block)
+    |> IO.puts()
+
     newline_after_block()
   end
 

--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -14,6 +14,7 @@ defmodule IO.ANSI.Docs do
     * `:doc_code`          - code blocks (cyan)
     * `:doc_headings`      - h1, h2, h3, h4, h5, h6 headings (yellow)
     * `:doc_metadata`      - documentation metadata keys (yellow)
+    * `:doc_quote`         - leading quote character `> ` (light black)
     * `:doc_inline_code`   - inline code (cyan)
     * `:doc_table_heading` - the style for table headings
     * `:doc_title`         - top level heading (reverse, yellow)
@@ -31,6 +32,7 @@ defmodule IO.ANSI.Docs do
       doc_code: [:cyan],
       doc_headings: [:yellow],
       doc_metadata: [:yellow],
+      doc_quote: [:light_black],
       doc_inline_code: [:cyan],
       doc_table_heading: [:reverse],
       doc_title: [:reverse, :yellow],
@@ -139,7 +141,7 @@ defmodule IO.ANSI.Docs do
     write_heading(heading, rest, text, indent, options)
   end
 
-  defp process(["> " <> _ = line | rest], text, indent, options) do
+  defp process(["> " <> line | rest], text, indent, options) do
     write_text(text, indent, options)
     process_quote(rest, [line], indent, options)
   end
@@ -194,7 +196,7 @@ defmodule IO.ANSI.Docs do
     write_quote(lines, indent, options)
   end
 
-  defp process_quote(["> " <> _ = line | rest], lines, indent, options) do
+  defp process_quote(["> " <> line | rest], lines, indent, options) do
     process_quote(rest, [line | lines], indent, options)
   end
 
@@ -206,7 +208,9 @@ defmodule IO.ANSI.Docs do
   defp write_quote(lines, indent, options) do
     lines
     |> Enum.reverse()
-    |> Enum.map_join("\n#{indent}", &format_text(&1, options))
+    |> Enum.map_join("\n#{indent}", fn line ->
+      [color(:doc_quote, options), "> ", IO.ANSI.reset(), format_text(line, options)]
+    end)
     # There is no special style for quotes, as such we simply use IO.puts;
     # a special quotes style would clash with inline styling (bold, italics etc.)
     |> IO.puts()

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -57,8 +57,15 @@ defmodule IO.ANSI.DocsTest do
     assert result == "\e[33m### wibble\e[0m\n\e[0m\ntext\n\e[0m"
   end
 
-  test "single-line quote block is converted" do
-    result = format("line\n\n> normal *italics* `code`\n\nline2\n")
+  test "short single-line quote block is converted into single-line quote" do
+    result =
+      format(
+        "line\n" <>
+          "\n" <>
+          "> normal *italics* `code`\n" <>
+          "\n" <>
+          "line2\n"
+      )
 
     assert result ==
              "line\n" <>
@@ -69,15 +76,45 @@ defmodule IO.ANSI.DocsTest do
                "\e[0m"
   end
 
-  test "multi-line quote block is converted" do
-    result = format("line\n\n> normal\n> *italics* \n> `code`\n\nline2\n")
+  test "short multi-line quote block is converted into single-line quote" do
+    result =
+      format(
+        "line\n" <>
+          "\n" <>
+          "> normal\n" <>
+          "> *italics* \n" <>
+          "> `code`\n" <>
+          "\n" <>
+          "line2\n"
+      )
 
     assert result ==
              "line\n" <>
                "\e[0m\n" <>
-               "\e[90m> \e[0mnormal\n" <>
-               "\e[90m> \e[0m\e[1mitalics\e[0m\n" <>
-               "\e[90m> \e[0m\e[36mcode\e[0m\n" <>
+               "\e[90m> \e[0mnormal \e[1mitalics\e[0m \e[36mcode\e[0m\n" <>
+               "\e[0m\n" <>
+               "line2\n" <>
+               "\e[0m"
+  end
+
+  test "long multi-line quote block is converted into wrapped multi-line quote" do
+    result =
+      format(
+        "line\n" <>
+          "\n" <>
+          "> normal\n" <>
+          "> *italics*\n" <>
+          "> `code` \n" <>
+          "> some-extremly-long-word-which-can-not-possibly-fit-into-the-previous-line\n" <>
+          "\n" <>
+          "line2\n"
+      )
+
+    assert result ==
+             "line\n" <>
+               "\e[0m\n" <>
+               "\e[90m> \e[0mnormal \e[1mitalics\e[0m \e[36mcode\e[0m\n" <>
+               "\e[90m> \e[0msome-extremly-long-word-which-can-not-possibly-fit-into-the-previous-line\n" <>
                "\e[0m\n" <>
                "line2\n" <>
                "\e[0m"

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -57,6 +57,36 @@ defmodule IO.ANSI.DocsTest do
     assert result == "\e[33m### wibble\e[0m\n\e[0m\ntext\n\e[0m"
   end
 
+  test "single-line quote block is converted" do
+    result = format("line\n\n> normal *italics* `code`\n\nline2\n")
+
+    assert result ==
+             "line\n" <>
+               "\e[0m\n" <>
+               "+---------------------+\n" <>
+               "| normal \e[1mitalics\e[0m \e[36mcode\e[0m |\n" <>
+               "+---------------------+\e[0m\n" <>
+               "\e[0m\n" <>
+               "line2\n" <>
+               "\e[0m"
+  end
+
+  test "multi-line quote block is converted" do
+    result = format("line\n\n> normal\n> *italics* \n> `code`\n\nline2\n")
+
+    assert result ==
+             "line\n" <>
+               "\e[0m\n" <>
+               "+---------+\n" <>
+               "| normal  |\n" <>
+               "| \e[1mitalics\e[0m |\n" <>
+               "| \e[36mcode\e[0m    |\n" <>
+               "+---------+\e[0m\n" <>
+               "\e[0m\n" <>
+               "line2\n" <>
+               "\e[0m"
+  end
+
   test "code block is converted" do
     result = format("line\n\n    code\n    code2\n\nline2\n")
     assert result == "line\n\e[0m\n\e[36m    code\n    code2\e[0m\n\e[0m\nline2\n\e[0m"

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -63,9 +63,7 @@ defmodule IO.ANSI.DocsTest do
     assert result ==
              "line\n" <>
                "\e[0m\n" <>
-               "+---------------------+\n" <>
-               "| normal \e[1mitalics\e[0m \e[36mcode\e[0m |\n" <>
-               "+---------------------+\n" <>
+               "> normal \e[1mitalics\e[0m \e[36mcode\e[0m\n" <>
                "\e[0m\n" <>
                "line2\n" <>
                "\e[0m"
@@ -77,11 +75,9 @@ defmodule IO.ANSI.DocsTest do
     assert result ==
              "line\n" <>
                "\e[0m\n" <>
-               "+---------+\n" <>
-               "| normal  |\n" <>
-               "| \e[1mitalics\e[0m |\n" <>
-               "| \e[36mcode\e[0m    |\n" <>
-               "+---------+\n" <>
+               "> normal\n" <>
+               "> \e[1mitalics\e[0m\n" <>
+               "> \e[36mcode\e[0m\n" <>
                "\e[0m\n" <>
                "line2\n" <>
                "\e[0m"

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -59,91 +59,99 @@ defmodule IO.ANSI.DocsTest do
 
   test "short single-line quote block is converted into single-line quote" do
     result =
-      format(
-        "line\n" <>
-          "\n" <>
-          "> normal *italics* `code`\n" <>
-          "\n" <>
-          "line2\n"
-      )
+      format("""
+      line
+
+      > normal *italics* `code`
+
+      line2
+      """)
 
     assert result ==
-             "line\n" <>
-               "\e[0m\n" <>
-               "\e[90m> \e[0mnormal \e[1mitalics\e[0m \e[36mcode\e[0m\n" <>
-               "\e[0m\n" <>
-               "line2\n" <>
-               "\e[0m"
+             """
+             line
+             \e[0m
+             \e[90m> \e[0mnormal \e[1mitalics\e[0m \e[36mcode\e[0m
+             \e[0m
+             line2
+             \e[0m\
+             """
   end
 
   test "short multi-line quote block is converted into single-line quote" do
     result =
-      format(
-        "line\n" <>
-          "\n" <>
-          "> normal\n" <>
-          "> *italics* \n" <>
-          "> `code`\n" <>
-          "\n" <>
-          "line2\n"
-      )
+      format("""
+      line
+
+      > normal
+      > *italics*
+      > `code`
+
+      line2
+      """)
 
     assert result ==
-             "line\n" <>
-               "\e[0m\n" <>
-               "\e[90m> \e[0mnormal \e[1mitalics\e[0m \e[36mcode\e[0m\n" <>
-               "\e[0m\n" <>
-               "line2\n" <>
-               "\e[0m"
+             """
+             line
+             \e[0m
+             \e[90m> \e[0mnormal \e[1mitalics\e[0m \e[36mcode\e[0m
+             \e[0m
+             line2
+             \e[0m\
+             """
   end
 
   test "long multi-line quote block is converted into wrapped multi-line quote" do
     result =
-      format(
-        "line\n" <>
-          "\n" <>
-          "> normal\n" <>
-          "> *italics*\n" <>
-          "> `code` \n" <>
-          "> some-extremly-long-word-which-can-not-possibly-fit-into-the-previous-line\n" <>
-          "\n" <>
-          "line2\n"
-      )
+      format("""
+      line
+
+      > normal
+      > *italics*
+      > `code`
+      > some-extremly-long-word-which-can-not-possibly-fit-into-the-previous-line
+
+      line2
+      """)
 
     assert result ==
-             "line\n" <>
-               "\e[0m\n" <>
-               "\e[90m> \e[0mnormal \e[1mitalics\e[0m \e[36mcode\e[0m\n" <>
-               "\e[90m> \e[0msome-extremly-long-word-which-can-not-possibly-fit-into-the-previous-line\n" <>
-               "\e[0m\n" <>
-               "line2\n" <>
-               "\e[0m"
+             """
+             line
+             \e[0m
+             \e[90m> \e[0mnormal \e[1mitalics\e[0m \e[36mcode\e[0m
+             \e[90m> \e[0msome-extremly-long-word-which-can-not-possibly-fit-into-the-previous-line
+             \e[0m
+             line2
+             \e[0m\
+             """
   end
 
   test "multi-line quote block containing empty lines is converted into wrapped multi-line quote" do
     result =
-      format(
-        "line\n" <>
-          "\n" <>
-          "> normal\n" <>
-          "> *italics*\n" <>
-          ">\n" <>
-          "> `code` \n" <>
-          "> some-extremly-long-word-which-can-not-possibly-fit-into-the-previous-line\n" <>
-          "\n" <>
-          "line2\n"
-      )
+      format("""
+      line
+
+      > normal
+      > *italics*
+      >
+      > `code`
+      > some-extremly-long-word-which-can-not-possibly-fit-into-the-previous-line
+
+      line2
+      """)
 
     assert result ==
-             "line\n" <>
-               "\e[0m\n" <>
-               "\e[90m> \e[0mnormal \e[1mitalics\e[0m\n" <>
-               "\e[90m> \e[0m\n" <>
-               "\e[90m> \e[0m\e[36mcode\e[0m\n" <>
-               "\e[90m> \e[0msome-extremly-long-word-which-can-not-possibly-fit-into-the-previous-line\n" <>
-               "\e[0m\n" <>
-               "line2\n" <>
-               "\e[0m"
+             """
+             line
+             \e[0m
+             \e[90m> \e[0mnormal \e[1mitalics\e[0m
+             \e[90m> \e[0m
+             \e[90m> \e[0m\e[36mcode\e[0m
+             \e[90m> \e[0msome-extremly-long-word-which-can-not-possibly-fit-into-the-previous-line
+             \e[0m
+             line2
+             \e[0m\
+             """
   end
 
   test "code block is converted" do

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -65,7 +65,7 @@ defmodule IO.ANSI.DocsTest do
                "\e[0m\n" <>
                "+---------------------+\n" <>
                "| normal \e[1mitalics\e[0m \e[36mcode\e[0m |\n" <>
-               "+---------------------+\e[0m\n" <>
+               "+---------------------+\n" <>
                "\e[0m\n" <>
                "line2\n" <>
                "\e[0m"
@@ -81,7 +81,7 @@ defmodule IO.ANSI.DocsTest do
                "| normal  |\n" <>
                "| \e[1mitalics\e[0m |\n" <>
                "| \e[36mcode\e[0m    |\n" <>
-               "+---------+\e[0m\n" <>
+               "+---------+\n" <>
                "\e[0m\n" <>
                "line2\n" <>
                "\e[0m"

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -63,7 +63,7 @@ defmodule IO.ANSI.DocsTest do
     assert result ==
              "line\n" <>
                "\e[0m\n" <>
-               "> normal \e[1mitalics\e[0m \e[36mcode\e[0m\n" <>
+               "\e[90m> \e[0mnormal \e[1mitalics\e[0m \e[36mcode\e[0m\n" <>
                "\e[0m\n" <>
                "line2\n" <>
                "\e[0m"
@@ -75,9 +75,9 @@ defmodule IO.ANSI.DocsTest do
     assert result ==
              "line\n" <>
                "\e[0m\n" <>
-               "> normal\n" <>
-               "> \e[1mitalics\e[0m\n" <>
-               "> \e[36mcode\e[0m\n" <>
+               "\e[90m> \e[0mnormal\n" <>
+               "\e[90m> \e[0m\e[1mitalics\e[0m\n" <>
+               "\e[90m> \e[0m\e[36mcode\e[0m\n" <>
                "\e[0m\n" <>
                "line2\n" <>
                "\e[0m"

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -120,6 +120,32 @@ defmodule IO.ANSI.DocsTest do
                "\e[0m"
   end
 
+  test "multi-line quote block containing empty lines is converted into wrapped multi-line quote" do
+    result =
+      format(
+        "line\n" <>
+          "\n" <>
+          "> normal\n" <>
+          "> *italics*\n" <>
+          ">\n" <>
+          "> `code` \n" <>
+          "> some-extremly-long-word-which-can-not-possibly-fit-into-the-previous-line\n" <>
+          "\n" <>
+          "line2\n"
+      )
+
+    assert result ==
+             "line\n" <>
+               "\e[0m\n" <>
+               "\e[90m> \e[0mnormal \e[1mitalics\e[0m\n" <>
+               "\e[90m> \e[0m\n" <>
+               "\e[90m> \e[0m\e[36mcode\e[0m\n" <>
+               "\e[90m> \e[0msome-extremly-long-word-which-can-not-possibly-fit-into-the-previous-line\n" <>
+               "\e[0m\n" <>
+               "line2\n" <>
+               "\e[0m"
+  end
+
   test "code block is converted" do
     result = format("line\n\n    code\n    code2\n\nline2\n")
     assert result == "line\n\e[0m\n\e[36m    code\n    code2\e[0m\n\e[0m\nline2\n\e[0m"


### PR DESCRIPTION
## Issue

This PR introduces markdown quote block handling in `IO.ANSI.Docs`, for blocks such as this:

```markdown
> first line of quote
> second line of __quote__
> third line of `quote`
```

Before this a quote was simply rendered as text which lead to the above quote looking like this:

\> first line of quote > second line of __quote__ > third line of `quote`

An example of this in the Elixir codebase can [be seen in `Access` (link to code)](https://github.com/elixir-lang/elixir/blob/055526057ac9992cc1df87441357c4e56d45235d/lib/elixir/lib/access.ex#L46-L55). Which got rendered like this in `iex`:

![image](https://user-images.githubusercontent.com/2647626/71721186-767faa80-2e24-11ea-8ef0-47b2a5126905.png)

## Solution

Instead of defining a specific quote style (such as `doc_quote`) - which clashes with inline styling of text - this solution instead renders the quote's content in an ASCII-art box. As such the quote from above would be rendered like this:

```
+----------------------+
| first line of quote  |
| second line of quote |
| third line of quote  |
+----------------------+
```

With this change the quote from [`Access`](https://github.com/elixir-lang/elixir/blob/055526057ac9992cc1df87441357c4e56d45235d/lib/elixir/lib/access.ex#L46-L55) now gets rendered like this:

![image](https://user-images.githubusercontent.com/2647626/71721254-b5adfb80-2e24-11ea-9a54-81aaf00b8167.png)
