### PR TITLE
Rework docs to allow calling `import_config/1` in releases

### DIFF
--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -579,7 +579,7 @@ defmodule Mix.Tasks.Release do
   Your `config/releases.exs` file needs to follow three important rules:
 
     * It MUST `import Config` at the top instead of the deprecated `use Mix.Config`
-    * It MUST NOT import any other configuration file via `import_file`
+    * It MUST NOT import any other configuration file via `import_config`
     * It MUST NOT access `Mix` in any way, as `Mix` is a build tool and it not
       available inside releases
 


### PR DESCRIPTION
This is actually a question in form of documentation patch 😀.

I was surprised that the docs of the `release` task forbid usage of `import_config/1` with a "MUST NOT" (it said `import_file`, but I guess it means `import_config`).

The `Config` module is unrelated to Mix and looking at the source code of `import_config/1` I see no technical reason it cannot run in releases. So my guess is that the intention of the docs was to rule out common Mix config use cases for `import_config/1` —probably written having the transition from `Mix.Config` in mind—, but perhaps the wording ended up being unnecessarily restrictive ruling out _any_ kind of invocation.

Then, I connected that suspicion with a need to avoid duplication between `config/config.exs` and `config/releases.exs`.

In my project everything that can be configured using env vars is configured that way for all environments and releases. For example,

```elixir
config :avrora, registry_url: System.fetch_env!("AVRO_REGISTRY_URL")
```

is the same in both files and so are a dozen others. Duplicating this is not only extra work, but also error-prone since you need to remember to keep both files in sync.

So, one solution that occurred to me this afternoon is to ship `priv/common_config.exs` and import it as the documentation patch explains.

Hot or not? :)