### PR TITLE
Fixed Path.absname to correctly handle UNC paths on Windows

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -95,6 +95,8 @@ defmodule Path do
     absname(absname_join(name), cwd)
   end
 
+  @slash [?/, ?\\]
+
   # Joins a list
   defp absname_join([name1, name2 | rest]), do: absname_join([absname_join(name1, name2) | rest])
 
@@ -108,6 +110,11 @@ defmodule Path do
   defp do_absname_join(<<uc_letter, ?:, rest::binary>>, relativename, [], :win32)
        when uc_letter in ?A..?Z do
     do_absname_join(rest, relativename, [?:, uc_letter + ?a - ?A], :win32)
+  end
+
+  defp do_absname_join(<<c1, c2, rest::binary>>, relativename, [], :win32)
+       when c1 in @slash and c2 in @slash do
+    do_absname_join(rest, relativename, '//', :win32)
   end
 
   defp do_absname_join(<<?\\, rest::binary>>, relativename, result, :win32),
@@ -253,8 +260,6 @@ defmodule Path do
   defp unix_pathtype([?/ | relative]), do: {:absolute, relative}
   defp unix_pathtype([list | rest]) when is_list(list), do: unix_pathtype(list ++ rest)
   defp unix_pathtype(relative), do: {:relative, relative}
-
-  @slash [?/, ?\\]
 
   defp win32_pathtype([list | rest]) when is_list(list), do: win32_pathtype(list ++ rest)
 

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -39,6 +39,11 @@ defmodule PathTest do
   describe "Windows" do
     @describetag :windows
 
+    test "absname/1" do
+      assert Path.absname("//host/path") == "//host/path"
+      assert Path.absname("\\\\host\\path") == "//host/path"
+    end
+
     test "relative/1" do
       assert Path.relative("C:/usr/local/bin") == "usr/local/bin"
       assert Path.relative("C:\\usr\\local\\bin") == "usr\\local\\bin"
@@ -67,6 +72,9 @@ defmodule PathTest do
       assert Path.type("/usr/local/bin") == :volumerelative
       assert Path.type('usr/local/bin') == :relative
       assert Path.type("../usr/local/bin") == :relative
+
+      assert Path.type("//host/path") == :absolute
+      assert Path.type("\\\\host\\path") == :absolute
     end
 
     test "split/1" do

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -42,6 +42,8 @@ defmodule PathTest do
     test "absname/1" do
       assert Path.absname("//host/path") == "//host/path"
       assert Path.absname("\\\\host\\path") == "//host/path"
+      assert Path.absname("\\/host\\path") == "//host/path"
+      assert Path.absname("/\\host\\path") == "//host/path"
     end
 
     test "relative/1" do
@@ -75,6 +77,8 @@ defmodule PathTest do
 
       assert Path.type("//host/path") == :absolute
       assert Path.type("\\\\host\\path") == :absolute
+      assert Path.type("/\\host\\path") == :absolute
+      assert Path.type("\\/host\\path") == :absolute
     end
 
     test "split/1" do


### PR DESCRIPTION
absname was incorrectly converting `//host/path` to `/host/path`

Added Windows-only Unit Tests for:
* Path.absname for UNC path (fixed here)
* Path.type for UNC path (was already correct, but not tested)