### PR TITLE
Point to the proper docs in the consolidation warning

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -917,7 +917,7 @@ defmodule Protocol do
         "the #{inspect(protocol)} protocol has already been consolidated, an " <>
           "implementation for #{inspect(for)} has no effect. If you want to " <>
           "implement protocols after compilation or during tests, check the " <>
-          "\"Consolidation\" section in the documentation for Kernel.defprotocol/2"
+          "\"Consolidation\" section in the Protocol module documentation"
 
       IO.warn(message, Macro.Env.stacktrace(env))
     end


### PR DESCRIPTION
The docs are on the module nowadays: https://hexdocs.pm/elixir/master/Protocol.html#module-consolidation