### PR TITLE
Optimize Enum.join/2 with empty string

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1354,6 +1354,12 @@ defmodule Enum do
   @spec join(t, String.t()) :: String.t()
   def join(enumerable, joiner \\ "")
 
+  def join(enumerable, "") do
+    enumerable
+    |> map(&entry_to_string(&1))
+    |> IO.iodata_to_binary()
+  end
+
   def join(enumerable, joiner) when is_binary(joiner) do
     reduced =
       reduce(enumerable, :first, fn


### PR DESCRIPTION
Currently, enum join function adds empty strings to the list with reduce.

This fix adds a new condition to handle join with an empty string using Enum.map/2 - which is faster and consumes less memory (i guess 😃)

```elixir
## JoinBench
# benchmark name        iterations   average time
# join/2 patch 100          500000   6.02 µs/op
# join/2 master 100         100000   10.33 µs/op
# join/2 patch 1000          50000   52.06 µs/op
# join/2 master 1000         20000   88.07 µs/op
# join/2 patch 10000          5000   527.48 µs/op
# join/2 master 10000         2000   831.52 µs/op
# join/2 patch 100000          200   8555.66 µs/op
# join/2 master 100000         100   11012.25 µs/op
```
Tested with Elixir 1.10.0-dev (ee758f9) (compiled with Erlang/OTP 21)
[Benchmarks script](https://gist.github.com/omohokcoj/0b142cc09eb62eb201e30fd225e1f2b3)

The same optimization could be added to Enum.map_join/3 - but the results were inconsistent:
```elixir
## MapBench
# benchmark name            iterations   average time
# map_join/3 master 100          50000   52.64 µs/op
# map_join/3 patch 100           50000   55.40 µs/op
# map_join/3 master 1000          5000   596.73 µs/op
# map_join/3 patch 1000           5000   609.49 µs/op
# map_join/3 master 10000          200   7317.91 µs/op
# map_join/3 patch 10000           200   7887.60 µs/op
# map_join/3 patch 100000           20   79102.30 µs/op
# map_join/3 master 100000          20   85808.20 µs/op
```
Probably because map_intersperse_list/3 recursive function from map_join is faster than Enum.map/2 in some cases (even though Enum.map/2 uses :lists.map for lists which uses body recursion inside as well 🤔).