### PR TITLE
Clarify which home directory is referred to by `~` in `~/.iex.exs`.

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -274,7 +274,7 @@ defmodule IEx do
   When starting, IEx looks for a local `.iex.exs` file (located in the current
   working directory), then a global one (located at `~/.iex.exs` where the `~`
   in this case represents the user that _started the application_, not necessarily
-  the user invoking IEx) ) and loads the first one it finds (if any). The code
+  the user invoking IEx) and loads the first one it finds (if any). The code
   in the loaded `.iex.exs` file is evaluated in the shell's context. So, for
   instance, any modules that are loaded or variables that are bound in the
   `.iex.exs` file will be available in the shell after it has booted.

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -272,11 +272,12 @@ defmodule IEx do
   ## The .iex.exs file
 
   When starting, IEx looks for a local `.iex.exs` file (located in the current
-  working directory), then a global one (located at `~/.iex.exs`) and loads the
-  first one it finds (if any). The code in the loaded `.iex.exs` file is
-  evaluated in the shell's context. So, for instance, any modules that are
-  loaded or variables that are bound in the `.iex.exs` file will be available in the
-  shell after it has booted.
+  working directory), then a global one (located at `~/.iex.exs` where the `~`
+  in this case represents the user that _started the application_, not necessarily
+  the user invoking IEx) ) and loads the first one it finds (if any). The code
+  in the loaded `.iex.exs` file is evaluated in the shell's context. So, for
+  instance, any modules that are loaded or variables that are bound in the
+  `.iex.exs` file will be available in the shell after it has booted.
 
   For example, take the following `.iex.exs` file:
 

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -272,14 +272,17 @@ defmodule IEx do
   ## The .iex.exs file
 
   When starting, IEx looks for a local `.iex.exs` file (located in the current
-  working directory), then a global one (located at `~/.iex.exs` where the `~`
-  in this case represents the user that _started the application_, not necessarily
-  the user invoking IEx) and loads the first one it finds (if any). The code
-  in the loaded `.iex.exs` file is evaluated in the shell's context. So, for
-  instance, any modules that are loaded or variables that are bound in the
+  working directory), then a global one (located at `~/.iex.exs`) and loads the
+  first one it finds (if any). Note the location of the `.iex.exs` files, both
+  in the current directory and the global one, are taken relative to the user
+  that started the application, not to the user that is connecting to the node in
+  case of remote IEx connections.
+
+  The code in the loaded `.iex.exs` file is evaluated in the shell's context.
+  For instance, any modules that are loaded or variables that are bound in the
   `.iex.exs` file will be available in the shell after it has booted.
 
-  For example, take the following `.iex.exs` file:
+  Take the following `.iex.exs` file:
 
       # Load another ".iex.exs" file
       import_file("~/.iex.exs")


### PR DESCRIPTION
I'm accustomed to the use of `~` to represent the home directory of the person executing a command in a shell. Since that's apparently not the case when connecting to a node via `remote_console` it seems worth clarifying. 