### PR TITLE
Fix mix.release raising error when src is missing in erts_source

### DIFF
--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -672,9 +672,10 @@ defmodule Mix.Release do
 
   def copy_erts(release) do
     destination = Path.join(release.path, "erts-#{release.erts_version}")
+    erts_source_contents = File.ls!(release.erts_source)
     File.mkdir_p!(destination)
 
-    for dir <- ~w(bin include lib src) do
+    for dir <- ~w(bin include lib src), dir in erts_source_contents do
       source = Path.join(release.erts_source, dir)
       target = Path.join(destination, dir)
       File.cp_r!(source, target, fn _, _ -> false end)


### PR DESCRIPTION
Fixes issue described in #9702 

I have no idea how to write a test for this case, any guidance?