### PR TITLE
Improve type check error message

### DIFF
--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -258,7 +258,7 @@ defmodule Module.Types do
 
   def format_warning({:unable_unify, left, right, expr, traces}) do
     [
-      "function clause will never match, found incompatibility:\n\n    ",
+      "incompatible types:\n\n    ",
       format_type(left),
       " !~ ",
       format_type(right),

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -111,7 +111,7 @@ defmodule CodeTest do
         Code.compile_file(PathHelpers.fixture_path("checker_warning.exs"))
       end)
 
-    assert output =~ "function clause will never match"
+    assert output =~ "incompatible types"
   end
 
   test "require_file/1" do

--- a/lib/elixir/test/elixir/module/checker_test.exs
+++ b/lib/elixir/test/elixir/module/checker_test.exs
@@ -674,7 +674,7 @@ defmodule Module.CheckerTest do
       }
 
       warning = """
-      warning: function clause will never match, found incompatibility:
+      warning: incompatible types:
 
           integer() !~ binary()
 
@@ -710,7 +710,7 @@ defmodule Module.CheckerTest do
       }
 
       warning = """
-      warning: function clause will never match, found incompatibility:
+      warning: incompatible types:
 
           integer() !~ binary()
 
@@ -746,7 +746,7 @@ defmodule Module.CheckerTest do
       }
 
       warning = """
-      warning: function clause will never match, found incompatibility:
+      warning: incompatible types:
 
           {var0} !~ var0
 
@@ -777,7 +777,7 @@ defmodule Module.CheckerTest do
       }
 
       warning = """
-      warning: function clause will never match, found incompatibility:
+      warning: incompatible types:
 
           integer() !~ binary()
 
@@ -813,7 +813,7 @@ defmodule Module.CheckerTest do
       }
 
       warning = """
-      warning: function clause will never match, found incompatibility:
+      warning: incompatible types:
 
           integer() !~ binary()
 


### PR DESCRIPTION
A type error may not always cause a clause to fail.

Related to #9700.