### PR TITLE
Reject invalid line numbers in ExUnit filters

### DIFF
--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -35,6 +35,7 @@ defmodule ExUnit.Filters do
 
         line_numbers =
           reversed_line_numbers
+          |> Enum.reject(&invalid_line_number?/1)
           |> Enum.reverse()
           |> Enum.map(&{:line, &1})
 
@@ -46,6 +47,18 @@ defmodule ExUnit.Filters do
         {path, line_numbers}
     end
   end
+
+  defp invalid_line_number?("0") do
+    IO.warn("invalid line number given as ExUnit filter: 0", [])
+    true
+  end
+
+  defp invalid_line_number?("-" <> _ = num) do
+    IO.warn("invalid line number given as ExUnit filter: #{num}", [])
+    true
+  end
+
+  defp invalid_line_number?(_), do: false
 
   @doc """
   Normalizes `include` and `exclude` filters to remove duplicates

--- a/lib/ex_unit/test/ex_unit/filters_test.exs
+++ b/lib/ex_unit/test/ex_unit/filters_test.exs
@@ -227,5 +227,14 @@ defmodule ExUnit.FiltersTest do
 
     assert ExUnit.Filters.parse_path("C:\\some\\path.exs:123:456notalinenumber456") ==
              {"C:\\some\\path.exs:123:456notalinenumber456", []}
+
+    output =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        assert ExUnit.Filters.parse_path("test/some/path.exs:123:0:-789:456") ==
+                 {"test/some/path.exs", [exclude: [:test], include: [line: "123", line: "456"]]}
+      end)
+
+    assert output =~ "invalid line number given as ExUnit filter: 0"
+    assert output =~ "invalid line number given as ExUnit filter: -789"
   end
 end


### PR DESCRIPTION
Now if folks give line numbers that are 0 or less, we show a warning and
reject those bad line numbers.

Resolves #9727 