### PR TITLE
Reject (even more) invalid line numbers in ExUnit filters

### DIFF
--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -54,9 +54,11 @@ defmodule ExUnit.Filters do
         {num, ""} -> num <= 0
         _ -> true
       end
+
     if invalid do
       IO.warn("invalid line number given as ExUnit filter: #{arg}", [])
     end
+
     invalid
   end
 

--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -27,23 +27,35 @@ defmodule ExUnit.Filters do
       [part] ->
         {part, []}
 
-      [path | line_numbers] ->
+      parts ->
+        {reversed_line_numbers, reversed_path_parts} =
+          parts
+          |> Enum.reverse()
+          |> Enum.split_while(&match?({_, ""}, Integer.parse(&1)))
+
         line_numbers =
-          line_numbers
-          |> Enum.flat_map(&line_number_argument/1)
+          reversed_line_numbers
+          |> Enum.reject(&invalid_line_number?/1)
+          |> Enum.reverse()
+          |> Enum.map(&{:line, &1})
+
+        path =
+          reversed_path_parts
+          |> Enum.reverse()
+          |> Enum.join(":")
 
         {path, line_numbers}
     end
   end
 
-  defp line_number_argument(arg) do
+  defp invalid_line_number?(arg) do
     case Integer.parse(arg) do
       {num, ""} when num > 0 ->
-        [line: arg]
+        false
 
       _ ->
         IO.warn("invalid line number given as ExUnit filter: #{arg}", [])
-        []
+        true
     end
   end
 

--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -27,35 +27,23 @@ defmodule ExUnit.Filters do
       [part] ->
         {part, []}
 
-      parts ->
-        {reversed_line_numbers, reversed_path_parts} =
-          parts
-          |> Enum.reverse()
-          |> Enum.split_while(&match?({_, ""}, Integer.parse(&1)))
-
+      [path | line_numbers] ->
         line_numbers =
-          reversed_line_numbers
-          |> Enum.reject(&invalid_line_number?/1)
-          |> Enum.reverse()
-          |> Enum.map(&{:line, &1})
-
-        path =
-          reversed_path_parts
-          |> Enum.reverse()
-          |> Enum.join(":")
+          line_numbers
+          |> Enum.flat_map(&line_number_argument/1)
 
         {path, line_numbers}
     end
   end
 
-  defp invalid_line_number?(arg) do
+  defp line_number_argument(arg) do
     case Integer.parse(arg) do
       {num, ""} when num > 0 ->
-        false
+        [line: arg]
 
       _ ->
         IO.warn("invalid line number given as ExUnit filter: #{arg}", [])
-        true
+        []
     end
   end
 

--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -48,17 +48,16 @@ defmodule ExUnit.Filters do
     end
   end
 
-  defp invalid_line_number?("0") do
-    IO.warn("invalid line number given as ExUnit filter: 0", [])
-    true
+  defp invalid_line_number?(arg) do
+    invalid =
+      case Integer.parse(arg) do
+        {num, ""} -> num <= 0
+      end
+    if invalid do
+      IO.warn("invalid line number given as ExUnit filter: #{arg}", [])
+    end
+    invalid
   end
-
-  defp invalid_line_number?("-" <> _ = num) do
-    IO.warn("invalid line number given as ExUnit filter: #{num}", [])
-    true
-  end
-
-  defp invalid_line_number?(_), do: false
 
   @doc """
   Normalizes `include` and `exclude` filters to remove duplicates

--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -49,17 +49,14 @@ defmodule ExUnit.Filters do
   end
 
   defp invalid_line_number?(arg) do
-    invalid =
-      case Integer.parse(arg) do
-        {num, ""} -> num <= 0
-        _ -> true
-      end
+    case Integer.parse(arg) do
+      {num, ""} when num > 0 ->
+        false
 
-    if invalid do
-      IO.warn("invalid line number given as ExUnit filter: #{arg}", [])
+      _ ->
+        IO.warn("invalid line number given as ExUnit filter: #{arg}", [])
+        true
     end
-
-    invalid
   end
 
   @doc """

--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -52,6 +52,7 @@ defmodule ExUnit.Filters do
     invalid =
       case Integer.parse(arg) do
         {num, ""} -> num <= 0
+        _ -> true
       end
     if invalid do
       IO.warn("invalid line number given as ExUnit filter: #{arg}", [])

--- a/lib/ex_unit/test/ex_unit/filters_test.exs
+++ b/lib/ex_unit/test/ex_unit/filters_test.exs
@@ -230,12 +230,11 @@ defmodule ExUnit.FiltersTest do
 
     output =
       ExUnit.CaptureIO.capture_io(:stderr, fn ->
-        assert ExUnit.Filters.parse_path("test/some/path.exs:123:0:-789:456:1L") ==
+        assert ExUnit.Filters.parse_path("test/some/path.exs:123:0:-789:456") ==
                  {"test/some/path.exs", [exclude: [:test], include: [line: "123", line: "456"]]}
       end)
 
     assert output =~ "invalid line number given as ExUnit filter: 0"
     assert output =~ "invalid line number given as ExUnit filter: -789"
-    assert output =~ "invalid line number given as ExUnit filter: 1L"
   end
 end

--- a/lib/ex_unit/test/ex_unit/filters_test.exs
+++ b/lib/ex_unit/test/ex_unit/filters_test.exs
@@ -230,11 +230,12 @@ defmodule ExUnit.FiltersTest do
 
     output =
       ExUnit.CaptureIO.capture_io(:stderr, fn ->
-        assert ExUnit.Filters.parse_path("test/some/path.exs:123:0:-789:456") ==
+        assert ExUnit.Filters.parse_path("test/some/path.exs:123:0:-789:456:1L") ==
                  {"test/some/path.exs", [exclude: [:test], include: [line: "123", line: "456"]]}
       end)
 
     assert output =~ "invalid line number given as ExUnit filter: 0"
     assert output =~ "invalid line number given as ExUnit filter: -789"
+    assert output =~ "invalid line number given as ExUnit filter: 1L"
   end
 end


### PR DESCRIPTION
If one call `mix test foo:arg` where `arg` are not natural numbers, we show a warning and reject those bad line numbers.

Extends https://github.com/elixir-lang/elixir/pull/9729 and further resolves #9727

