### PR TITLE
improve speed of extract_files

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -468,8 +468,8 @@ defmodule Mix.Tasks.Test do
 
     # Finally parse, require and load the files
     test_files = parse_files(files, shell, test_paths)
-    test_pattern = project[:test_pattern] || "*_test.exs"
-    warn_test_pattern = project[:warn_test_pattern] || "*_test.ex"
+    test_pattern = project[:test_pattern] || "_test.exs"
+    warn_test_pattern = project[:warn_test_pattern] || "_test.ex"
 
     matched_test_files =
       test_files

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -212,6 +212,11 @@ defmodule Mix.Utils do
   recursively for files with the given extensions or matching
   the given patterns.
   """
+  def extract_files(paths, [first | _] = exts) when is_atom(first),
+    do: extract_files(paths, Enum.map(exts, &"#{&1}"))
+
+  def extract_files(paths, exts) when is_atom(exts), do: extract_files(paths, "#{exts}")
+
   def extract_files(paths, exts) do
     Enum.reduce(paths, [], fn item, acc ->
       if String.ends_with?(item, exts) do

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -213,9 +213,9 @@ defmodule Mix.Utils do
   the given patterns.
   """
   def extract_files(paths, [first | _] = exts) when is_atom(first),
-    do: extract_files(paths, Enum.map(exts, &"#{&1}"))
+    do: extract_files(paths, Enum.map(exts, &".#{&1}"))
 
-  def extract_files(paths, exts) when is_atom(exts), do: extract_files(paths, "#{exts}")
+  def extract_files(paths, exts) when is_atom(exts), do: extract_files(paths, ".#{exts}")
 
   def extract_files(paths, exts) do
     Enum.reduce(paths, [], fn item, acc ->

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -216,6 +216,7 @@ defmodule Mix.Utils do
     do: extract_files(paths, Enum.map(exts, &".#{&1}"))
 
   def extract_files(paths, exts) when is_atom(exts), do: extract_files(paths, ".#{exts}")
+  def extract_files(paths, "*" <> ext), do: extract_files(paths, ext)
 
   def extract_files(paths, exts) do
     Enum.reduce(paths, [], fn item, acc ->

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -45,7 +45,7 @@ defmodule Mix.UtilsTest do
   end
 
   test "extract files" do
-    files = Mix.Utils.extract_files([Path.join(fixture_path(), "archive")], "*.ex")
+    files = Mix.Utils.extract_files([Path.join(fixture_path(), "archive")], ".ex")
     assert length(files) == 1
     assert Path.basename(hd(files)) == "local.sample.ex"
   end


### PR DESCRIPTION
This improves the speed of extract files by at least 50%, many times even more than that. However, it does lose the ability to pass in a wildcard to Path.wildcard, it can only filter on extension. 