### PR TITLE
Fix bug: move :indentation from sigil meta to binary meta

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -868,15 +868,16 @@ build_access(Expr, {List, Location}) ->
 
 build_sigil({sigil, Location, Sigil, Parts, Modifiers, Indentation, Delimiter}) ->
   Meta = meta_from_location(Location),
-  SigilMeta = sigil_meta(Meta, Delimiter, Indentation),
+  MetaWithDelimiter = [{delimiter, Delimiter} | Meta],
+  MetaWithIndentation = meta_with_indentation(Meta, Indentation),
   {list_to_atom("sigil_" ++ [Sigil]),
-   SigilMeta,
-   [{'<<>>', Meta, string_parts(Parts)}, Modifiers]}.
+   MetaWithDelimiter,
+   [{'<<>>', MetaWithIndentation, string_parts(Parts)}, Modifiers]}.
 
-sigil_meta(Meta, Delimiter, nil) ->
-  [{delimiter, Delimiter} | Meta];
-sigil_meta(Meta, Delimiter, Indentation) ->
-  [{delimiter, Delimiter}, {indentation, Indentation} | Meta].
+meta_with_indentation(Meta, nil) ->
+  Meta;
+meta_with_indentation(Meta, Indentation) ->
+  [{indentation, Indentation} | Meta].
 
 build_bin_heredoc({bin_heredoc, Location, Args}) ->
   build_bin_string({bin_string, Location, Args}, delimiter(<<$", $", $">>)).

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -249,18 +249,18 @@ defmodule CodeTest do
       assert string_to_quoted.("~r\"foo\"") ==
                {:sigil_r, [delimiter: "\"", line: 1], [{:<<>>, [line: 1], ["foo"]}, []]}
 
-      meta = [delimiter: "\"\"\"", indentation: 0, line: 1]
-      args = {:sigil_S, meta, [{:<<>>, [line: 1], ["sigil heredoc\n"]}, []]}
+      meta = [delimiter: "\"\"\"", line: 1]
+      args = {:sigil_S, meta, [{:<<>>, [indentation: 0, line: 1], ["sigil heredoc\n"]}, []]}
       assert string_to_quoted.("~S\"\"\"\nsigil heredoc\n\"\"\"") == args
 
-      meta = [delimiter: "'''", indentation: 0, line: 1]
-      args = {:sigil_S, meta, [{:<<>>, [line: 1], ["sigil heredoc\n"]}, []]}
+      meta = [delimiter: "'''", line: 1]
+      args = {:sigil_S, meta, [{:<<>>, [indentation: 0, line: 1], ["sigil heredoc\n"]}, []]}
       assert string_to_quoted.("~S'''\nsigil heredoc\n'''") == args
     end
 
     test "heredoc indentation" do
-      meta = [delimiter: "'''", indentation: 2, line: 1]
-      args = {:sigil_S, meta, [{:<<>>, [line: 1], ["  sigil heredoc\n"]}, []]}
+      meta = [delimiter: "'''", line: 1]
+      args = {:sigil_S, meta, [{:<<>>, [indentation: 2, line: 1], ["  sigil heredoc\n"]}, []]}
       assert Code.string_to_quoted!("~S'''\n    sigil heredoc\n  '''") == args
     end
   end


### PR DESCRIPTION
We need it there so we can retrieve it like this:

    defmacro sigil_E({:<<>>, meta, [expr]}, []) do
      options = [
        line: __CALLER__.line + 1,
        indentation: meta[:indentation] || 0
      ]

      EEx.compile_string(expr, options)
    end