### PR TITLE
Improves given example and adds "implicit try" for searches

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4147,7 +4147,7 @@ defmodule Kernel do
 
       def convert(number) do
         String.to_integer(number)
-      catch
+      rescue
         e in ArgumentError -> {:error, e.message}
       end
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4135,20 +4135,20 @@ defmodule Kernel do
   ## `rescue`/`catch`/`after`/`else`
 
   Function bodies support `rescue`, `catch`, `after`, and `else` as `Kernel.SpecialForms.try/1`
-  does. For example, the following two functions are equivalent:
+  does (known as "implicit try"). For example, the following two functions are equivalent:
 
-      def format(value) do
+      def convert(number) do
         try do
-          format!(value)
-        catch
-          :exit, reason -> {:error, reason}
+          String.to_integer(number)
+        rescue
+          e in ArgumentError -> {:error, e.message}
         end
       end
 
-      def format(value) do
-        format!(value)
+      def convert(number) do
+        String.to_integer(number)
       catch
-        :exit, reason -> {:error, reason}
+        e in ArgumentError -> {:error, e.message}
       end
 
   """


### PR DESCRIPTION
I had no idea that the `def` macro supported these "implicit try" structures until Credo warned me about it.  This is related to https://github.com/elixir-lang/elixir/pull/5442

I just wanted a full working example in there.