### PR TITLE
Add Task.await_many

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -671,10 +671,10 @@ defmodule Task do
       ^timeout_ref ->
         exit({:timeout, {__MODULE__, :await_many, [tasks, timeout]}})
 
-      {:DOWN, ref, _, proc, reason} when :erlang.is_map_key(ref, awaiting) ->
+      {:DOWN, ref, _, proc, reason} when is_map_key(awaiting, ref) ->
         exit({reason(reason, proc), {__MODULE__, :await_many, [tasks, timeout]}})
 
-      {ref, reply} when :erlang.is_map_key(ref, awaiting) ->
+      {ref, reply} when is_map_key(awaiting, ref) ->
         Process.demonitor(ref, [:flush])
 
         await_many(

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -352,35 +352,6 @@ defmodule TaskTest do
                catch_exit(Task.await_many(tasks))
     end
 
-    @compile {:no_warn_undefined, :module_does_not_exist}
-
-    test "exits immediately on task undef module error" do
-      Process.flag(:trap_exit, true)
-
-      tasks = [
-        %Task{ref: make_ref(), owner: self(), pid: nil},
-        Task.async(&:module_does_not_exist.undef/0)
-      ]
-
-      assert {exit_status, mfa} = catch_exit(Task.await_many(tasks))
-      assert {:undef, [{:module_does_not_exist, :undef, _, _} | _]} = exit_status
-      assert {Task, :await_many, [^tasks, 5000]} = mfa
-    end
-
-    @compile {:no_warn_undefined, {TaskTest, :undef, 0}}
-
-    test "exits immediately on task undef function error" do
-      Process.flag(:trap_exit, true)
-
-      tasks = [
-        %Task{ref: make_ref(), owner: self(), pid: nil},
-        Task.async(&TaskTest.undef/0)
-      ]
-
-      assert {{:undef, [{TaskTest, :undef, _, _} | _]}, {Task, :await_many, [^tasks, 5000]}} =
-               catch_exit(Task.await_many(tasks))
-    end
-
     test "exits immediately on :noconnection" do
       tasks = [
         %Task{ref: make_ref(), owner: self(), pid: nil},

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -273,7 +273,12 @@ defmodule TaskTest do
   end
 
   describe "await_many/2" do
-    test "returns replies in input order" do
+    test "returns list of replies" do
+      tasks = for val <- [1, 3, 9], do: Task.async(fn -> val end)
+      assert Task.await_many(tasks) == [1, 3, 9]
+    end
+
+    test "returns replies in input order ignoring response order" do
       refs = [ref_1 = make_ref(), ref_2 = make_ref(), ref_3 = make_ref()]
       tasks = Enum.map(refs, fn ref -> %Task{ref: ref, owner: self(), pid: nil} end)
       send(self(), {ref_2, 3})

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -387,6 +387,7 @@ defmodule TaskTest do
         %Task{ref: make_ref(), owner: self(), pid: nil},
         %Task{ref: ref = make_ref(), owner: self(), pid: self()}
       ]
+
       send(self(), {:DOWN, ref, :process, self(), :noconnection})
       assert catch_exit(Task.await_many(tasks)) |> elem(0) == {:nodedown, :nonode@nohost}
     end
@@ -396,6 +397,7 @@ defmodule TaskTest do
         %Task{ref: make_ref(), owner: self(), pid: nil},
         %Task{ref: ref = make_ref(), owner: self(), pid: nil}
       ]
+
       send(self(), {:DOWN, ref, :process, {:name, :node}, :noconnection})
       assert catch_exit(Task.await_many(tasks)) |> elem(0) == {:nodedown, :node}
     end

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -272,7 +272,6 @@ defmodule TaskTest do
     end
   end
 
-  @tag timeout: 10
   describe "await_many/2" do
     test "returns replies in input order" do
       refs = [ref_1 = make_ref(), ref_2 = make_ref(), ref_3 = make_ref()]


### PR DESCRIPTION
Adds a new function `Task.await_many` per [the proposal](https://groups.google.com/forum/#!topic/elixir-lang-core/9QQNIZMzWVE).

I'm still learning my way around the low-level process model, so it's possible I've made mistakes with the process management.

I also ended up doing some data shuffling in the interest of returning an ordered list but keeping a constant access time while constructing it. Maybe there's a better way to handle that, but if so it has escaped me.