### PR TITLE
turn NimbleStrftime into a Calendar function

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -518,7 +518,7 @@ defmodule Calendar do
   defp parse("%" <> rest, datetime, format_options, acc),
     do: parse_modifiers(rest, nil, nil, {datetime, format_options, acc})
 
-  defp parse(<<char::binary-1, rest::binary>>, datetime, format_options, acc),
+  defp parse(<<char, rest::binary>>, datetime, format_options, acc),
     do: parse(rest, datetime, format_options, [char | acc])
 
   defp parse_modifiers("-" <> rest, width, nil, parser_data) do

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -370,7 +370,7 @@ defmodule Calendar do
   The datetime can be any of the Calendar types (`Time`, `Date`,
   `NaiveDateTime`, and `DateTime`) or any map, as long as they
   contain all of the relevant fields necessary for formatting.
-  For example, if you use `%Y` to format the year, the datatime
+  For example, if you use `%Y` to format the year, the datetime
   must have the `:year` field. Therefore, if you pass a `Time`,
   or a map without the `:year` field to a format that expects `%Y`,
   an error will be raised.
@@ -688,14 +688,14 @@ defmodule Calendar do
     parse(rest, datetime, format_options, [result | acc])
   end
 
-  # “AM” or “PM” (noon is “PM”, midnight as “AM”)
+  # "AM" or "PM" (noon is "PM", midnight as "AM")
   defp format_modifiers("p" <> rest, width, pad, datetime, format_options, acc) do
     result = datetime.hour |> am_pm(format_options) |> String.upcase() |> pad_leading(width, pad)
 
     parse(rest, datetime, format_options, [result | acc])
   end
 
-  # “am” or “pm” (noon is “pm”, midnight as “am”)
+  # "am" or "pm" (noon is "pm", midnight as "am")
   defp format_modifiers("P" <> rest, width, pad, datetime, format_options, acc) do
     result =
       datetime.hour

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -363,4 +363,504 @@ defmodule Calendar do
   def get_time_zone_database() do
     Application.get_env(:elixir, :time_zone_database, Calendar.UTCOnlyTimeZoneDatabase)
   end
+
+  @doc """
+  Formats received datetime into a string.
+
+  The datetime can be any of the Calendar types (`Time`, `Date`,
+  `NaiveDateTime`, and `DateTime`) or any map, as long as they
+  contain all of the relevant fields necessary for formatting.
+  For example, if you use `%Y` to format the year, the datatime
+  must have the `:year` field. Therefore, if you pass a `Time`,
+  or a map without the `:year` field to a format that expects `%Y`,
+  an error will be raised.
+
+  ## Options
+
+    * `:preferred_datetime` - a string for the preferred format to show datetimes,
+      it can't contain the `%c` format and defaults to `"%Y-%m-%d %H:%M:%S"`
+      if the option is not received
+
+    * `:preferred_date` - a string for the preferred format to show dates,
+      it can't contain the `%x` format and defaults to `"%Y-%m-%d"`
+      if the option is not received
+
+    * `:preferred_time` - a string for the preferred format to show times,
+      it can't contain the `%X` format and defaults to `"%H:%M:%S"`
+      if the option is not received
+
+    * `:am_pm_names` - a function that receives either `:am` or `:pm` and returns
+      the name of the period of the day, if the option is not received it defaults
+      to a function that returns `"am"` and `"pm"`, respectively
+
+    *  `:month_names` - a function that receives a number and returns the name of
+      the corresponding month, if the option is not received it defaults to a
+      function thet returns the month names in english
+
+    * `:abbreviated_month_names` - a function that receives a number and returns the
+      abbreviated name of the corresponding month, if the option is not received it
+      defaults to a function thet returns the abbreviated month names in english
+
+    * `:day_of_week_names` - a function that receives a number and returns the name of
+      the corresponding day of week, if the option is not received it defaults to a
+      function that returns the day of week names in english
+
+    * `:abbreviated_day_of_week_names` - a function that receives a number and returns
+      the abbreviated name of the corresponding day of week, if the option is not received
+      it defaults to a function that returns the abbreviated day of week names in english
+
+  ## Formatting syntax
+
+  The formatting syntax for strftime is a sequence of characters in the following format:
+
+      %<padding><width><format>
+
+  where:
+
+    * `%`: indicates the start of a formatted section
+    * `<padding>`: set the padding (see below)
+    * `<width>`: a number indicating the minimum size of the formatted section
+    * `<format>`: the format iself (see below)
+
+  ### Accepted padding options
+
+    * `-`: no padding, removes all padding from the format
+    * `_`: pad with spaces
+    * `0`: pad with zeroes
+
+  ### Accepted formats
+
+  The accepted formats are:
+
+  Format | Description                                                             | Examples (in ISO)
+  :----- | :-----------------------------------------------------------------------| :------------------------
+  a      | Abbreviated name of day                                                 | Mon
+  A      | Full name of day                                                        | Monday
+  b      | Abbreviated month name                                                  | Jan
+  B      | Full month name                                                         | January
+  c      | Preferred date+time representation                                      | 2018-10-17 12:34:56
+  d      | Day of the month                                                        | 01, 12
+  f      | Microseconds *(does not support width and padding modifiers)*           | 000000, 999999, 0123
+  H      | Hour using a 24-hour clock                                              | 00, 23
+  I      | Hour using a 12-hour clock                                              | 01, 12
+  j      | Day of the year                                                         | 001, 366
+  m      | Month                                                                   | 01, 12
+  M      | Minute                                                                  | 00, 59
+  p      | "AM" or "PM" (noon is "PM", midnight as "AM")                           | AM, PM
+  P      | "am" or "pm" (noon is "pm", midnight as "am")                           | am, pm
+  q      | Quarter                                                                 | 1, 2, 3, 4
+  S      | Second                                                                  | 00, 59, 60
+  u      | Day of the week                                                         | 1 (Monday), 7 (Sunday)
+  x      | Preferred date (without time) representation                            | 2018-10-17
+  X      | Preferred time (without date) representation                            | 12:34:56
+  y      | Year as 2-digits                                                        | 01, 01, 86, 18
+  Y      | Year                                                                    | -0001, 0001, 1986
+  z      | +hhmm/-hhmm time zone offset from UTC (empty string if naive)           | +0300, -0530
+  Z      | Time zone abbreviation (empty string if naive)                          | CET, BRST
+  %      | Literal "%" character                                                   | %
+
+  Any other character will be interpreted as an invalid format and raise an error
+
+  ## Examples
+
+  Without options:
+
+      iex> Calendar.strftime(~U[2019-08-26 13:52:06.0Z], "%y-%m-%d %I:%M:%S %p")
+      "19-08-26 01:52:06 PM"
+
+      iex> Calendar.strftime(~U[2019-08-26 13:52:06.0Z], "%a, %B %d %Y")
+      "Mon, August 26 2019"
+
+      iex> Calendar.strftime(~U[2019-08-26 13:52:06.0Z], "%c")
+      "2019-08-26 13:52:06"
+
+  With options:
+
+      iex> Calendar.strftime(~U[2019-08-26 13:52:06.0Z], "%c", preferred_datetime: "%H:%M:%S %d-%m-%y")
+      "13:52:06 26-08-19"
+
+      iex> Calendar.strftime(
+      ...>  ~U[2019-08-26 13:52:06.0Z],
+      ...>  "%A",
+      ...>  day_of_week_names: fn day_of_week ->
+      ...>    {"segunda-feira", "terça-feira", "quarta-feira", "quinta-feira",
+      ...>    "sexta-feira", "sábado", "domingo"}
+      ...>    |> elem(day_of_week - 1)
+      ...>  end
+      ...>)
+      "segunda-feira"
+
+      iex> Calendar.strftime(
+      ...>  ~U[2019-08-26 13:52:06.0Z],
+      ...>  "%B",
+      ...>  month_names: fn month ->
+      ...>    {"январь", "февраль", "март", "апрель", "май", "июнь",
+      ...>    "июль", "август", "сентябрь", "октябрь", "ноябрь", "декабрь"}
+      ...>    |> elem(month - 1)
+      ...>  end
+      ...>)
+      "август"
+  """
+  @spec strftime(map(), String.t(), keyword()) :: String.t()
+  def strftime(date_or_time_or_datetime, string_format, user_options \\ []) do
+    parse(
+      string_format,
+      date_or_time_or_datetime,
+      options(user_options),
+      []
+    )
+    |> IO.iodata_to_binary()
+  end
+
+  defp parse("", _datetime, _format_options, acc),
+    do: Enum.reverse(acc)
+
+  defp parse("%" <> rest, datetime, format_options, acc),
+    do: parse_modifiers(rest, nil, nil, {datetime, format_options, acc})
+
+  defp parse(<<char::binary-1, rest::binary>>, datetime, format_options, acc),
+    do: parse(rest, datetime, format_options, [char | acc])
+
+  defp parse_modifiers("-" <> rest, width, nil, parser_data) do
+    parse_modifiers(rest, width, "", parser_data)
+  end
+
+  defp parse_modifiers("0" <> rest, width, nil, parser_data) do
+    parse_modifiers(rest, width, ?0, parser_data)
+  end
+
+  defp parse_modifiers("_" <> rest, width, nil, parser_data) do
+    parse_modifiers(rest, width, ?\s, parser_data)
+  end
+
+  defp parse_modifiers(<<digit, rest::binary>>, width, pad, parser_data) when digit in ?0..?9 do
+    new_width =
+      case pad do
+        ?- -> 0
+        _ -> (width || 0) * 10 + (digit - ?0)
+      end
+
+    parse_modifiers(rest, new_width, pad, parser_data)
+  end
+
+  # set default padding if none was specfied
+  defp parse_modifiers(<<format, _::binary>> = rest, width, nil, parser_data) do
+    parse_modifiers(rest, width, default_pad(format), parser_data)
+  end
+
+  # set default width if none was specified
+  defp parse_modifiers(<<format, _::binary>> = rest, nil, pad, parser_data) do
+    parse_modifiers(rest, default_width(format), pad, parser_data)
+  end
+
+  defp parse_modifiers(rest, width, pad, {datetime, format_options, acc}) do
+    format_modifiers(rest, width, pad, datetime, format_options, acc)
+  end
+
+  defp am_pm(hour, format_options) when hour > 11 do
+    format_options.am_pm_names.(:pm)
+  end
+
+  defp am_pm(hour, format_options) when hour <= 11 do
+    format_options.am_pm_names.(:am)
+  end
+
+  defp default_pad(format) when format in 'aAbBpPZ', do: ?\s
+  defp default_pad(_format), do: ?0
+
+  defp default_width(format) when format in 'dHImMSy', do: 2
+  defp default_width(?j), do: 3
+  defp default_width(format) when format in 'Yz', do: 4
+  defp default_width(_format), do: 0
+
+  # Literally just %
+  defp format_modifiers("%" <> rest, width, pad, datetime, format_options, acc) do
+    parse(rest, datetime, format_options, [pad_leading("%", width, pad) | acc])
+  end
+
+  # Abbreviated name of day
+  defp format_modifiers("a" <> rest, width, pad, datetime, format_options, acc) do
+    result =
+      datetime
+      |> Date.day_of_week()
+      |> format_options.abbreviated_day_of_week_names.()
+      |> pad_leading(width, pad)
+
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Full name of day
+  defp format_modifiers("A" <> rest, width, pad, datetime, format_options, acc) do
+    result =
+      datetime
+      |> Date.day_of_week()
+      |> format_options.day_of_week_names.()
+      |> pad_leading(width, pad)
+
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Abbreviated month name
+  defp format_modifiers("b" <> rest, width, pad, datetime, format_options, acc) do
+    result =
+      datetime.month
+      |> format_options.abbreviated_month_names.()
+      |> pad_leading(width, pad)
+
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Full month name
+  defp format_modifiers("B" <> rest, width, pad, datetime, format_options, acc) do
+    result = datetime.month |> format_options.month_names.() |> pad_leading(width, pad)
+
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Preferred date+time representation
+  defp format_modifiers(
+         "c" <> _rest,
+         _width,
+         _pad,
+         _datetime,
+         %{preferred_datetime_invoked: true},
+         _acc
+       ) do
+    raise RuntimeError,
+          "tried to format preferred_datetime within another preferred_datetime format"
+  end
+
+  defp format_modifiers("c" <> rest, width, pad, datetime, format_options, acc) do
+    result =
+      format_options.preferred_datetime
+      |> parse(datetime, %{format_options | preferred_datetime_invoked: true}, [])
+      |> pad_preferred(width, pad)
+
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Day of the month
+  defp format_modifiers("d" <> rest, width, pad, datetime, format_options, acc) do
+    result = datetime.day |> Integer.to_string() |> pad_leading(width, pad)
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Microseconds
+  defp format_modifiers("f" <> rest, _width, _pad, datetime, format_options, acc) do
+    {microsecond, precision} = datetime.microsecond
+
+    result =
+      microsecond
+      |> Integer.to_string()
+      |> String.pad_leading(6, "0")
+      |> binary_part(0, max(precision, 1))
+
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Hour using a 24-hour clock
+  defp format_modifiers("H" <> rest, width, pad, datetime, format_options, acc) do
+    result = datetime.hour |> Integer.to_string() |> pad_leading(width, pad)
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Hour using a 12-hour clock
+  defp format_modifiers("I" <> rest, width, pad, datetime, format_options, acc) do
+    result = (rem(datetime.hour() + 23, 12) + 1) |> Integer.to_string() |> pad_leading(width, pad)
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Day of the year
+  defp format_modifiers("j" <> rest, width, pad, datetime, format_options, acc) do
+    result = datetime |> Date.day_of_year() |> Integer.to_string() |> pad_leading(width, pad)
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Month
+  defp format_modifiers("m" <> rest, width, pad, datetime, format_options, acc) do
+    result = datetime.month |> Integer.to_string() |> pad_leading(width, pad)
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Minute
+  defp format_modifiers("M" <> rest, width, pad, datetime, format_options, acc) do
+    result = datetime.minute |> Integer.to_string() |> pad_leading(width, pad)
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # “AM” or “PM” (noon is “PM”, midnight as “AM”)
+  defp format_modifiers("p" <> rest, width, pad, datetime, format_options, acc) do
+    result = datetime.hour |> am_pm(format_options) |> String.upcase() |> pad_leading(width, pad)
+
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # “am” or “pm” (noon is “pm”, midnight as “am”)
+  defp format_modifiers("P" <> rest, width, pad, datetime, format_options, acc) do
+    result =
+      datetime.hour
+      |> am_pm(format_options)
+      |> String.downcase()
+      |> pad_leading(width, pad)
+
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Quarter
+  defp format_modifiers("q" <> rest, width, pad, datetime, format_options, acc) do
+    result = datetime |> Date.quarter_of_year() |> Integer.to_string() |> pad_leading(width, pad)
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Second
+  defp format_modifiers("S" <> rest, width, pad, datetime, format_options, acc) do
+    result = datetime.second |> Integer.to_string() |> pad_leading(width, pad)
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Day of the week
+  defp format_modifiers("u" <> rest, width, pad, datetime, format_options, acc) do
+    result = datetime |> Date.day_of_week() |> Integer.to_string() |> pad_leading(width, pad)
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Preferred date (without time) representation
+  defp format_modifiers(
+         "x" <> _rest,
+         _width,
+         _pad,
+         _datetime,
+         %{preferred_date_invoked: true},
+         _acc
+       ) do
+    raise RuntimeError,
+          "tried to format preferred_date within another preferred_date format"
+  end
+
+  defp format_modifiers("x" <> rest, width, pad, datetime, format_options, acc) do
+    result =
+      format_options.preferred_date
+      |> parse(datetime, %{format_options | preferred_date_invoked: true}, [])
+      |> pad_preferred(width, pad)
+
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Preferred time (without date) representation
+  defp format_modifiers(
+         "X" <> _rest,
+         _width,
+         _pad,
+         _datetime,
+         %{preferred_time_invoked: true},
+         _acc
+       ) do
+    raise RuntimeError,
+          "tried to format preferred_time within another preferred_time format"
+  end
+
+  defp format_modifiers("X" <> rest, width, pad, datetime, format_options, acc) do
+    result =
+      format_options.preferred_time
+      |> parse(datetime, %{format_options | preferred_time_invoked: true}, [])
+      |> pad_preferred(width, pad)
+
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Year as 2-digits
+  defp format_modifiers("y" <> rest, width, pad, datetime, format_options, acc) do
+    result = datetime.year |> rem(100) |> Integer.to_string() |> pad_leading(width, pad)
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # Year
+  defp format_modifiers("Y" <> rest, width, pad, datetime, format_options, acc) do
+    result = datetime.year |> Integer.to_string() |> pad_leading(width, pad)
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  # +hhmm/-hhmm time zone offset from UTC (empty string if naive)
+  defp format_modifiers(
+         "z" <> rest,
+         width,
+         pad,
+         datetime = %{utc_offset: utc_offset, std_offset: std_offset},
+         format_options,
+         acc
+       ) do
+    absolute_offset = abs(utc_offset + std_offset)
+
+    offset_number =
+      Integer.to_string(div(absolute_offset, 3600) * 100 + rem(div(absolute_offset, 60), 60))
+
+    sign = if utc_offset + std_offset >= 0, do: "+", else: "-"
+    result = "#{sign}#{pad_leading(offset_number, width, pad)}"
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  defp format_modifiers("z" <> rest, _width, _pad, datetime, format_options, acc) do
+    parse(rest, datetime, format_options, ["" | acc])
+  end
+
+  # Time zone abbreviation (empty string if naive)
+  defp format_modifiers("Z" <> rest, width, pad, datetime, format_options, acc) do
+    result = datetime |> Map.get(:zone_abbr, "") |> pad_leading(width, pad)
+    parse(rest, datetime, format_options, [result | acc])
+  end
+
+  defp pad_preferred(result, width, pad) when length(result) < width do
+    pad_preferred([pad | result], width, pad)
+  end
+
+  defp pad_preferred(result, _width, _pad), do: result
+
+  defp pad_leading(string, count, padding) do
+    to_pad = count - byte_size(string)
+    if to_pad > 0, do: do_pad_leading(to_pad, padding, string), else: string
+  end
+
+  defp do_pad_leading(0, _, acc), do: acc
+
+  defp do_pad_leading(count, padding, acc),
+    do: do_pad_leading(count - 1, padding, [padding | acc])
+
+  defp options(user_options) do
+    default_options = %{
+      preferred_date: "%Y-%m-%d",
+      preferred_time: "%H:%M:%S",
+      preferred_datetime: "%Y-%m-%d %H:%M:%S",
+      am_pm_names: fn
+        :am -> "am"
+        :pm -> "pm"
+      end,
+      month_names: fn month ->
+        {"January", "February", "March", "April", "May", "June", "July", "August", "September",
+         "October", "November", "December"}
+        |> elem(month - 1)
+      end,
+      day_of_week_names: fn day_of_week ->
+        {"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"}
+        |> elem(day_of_week - 1)
+      end,
+      abbreviated_month_names: fn month ->
+        {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"}
+        |> elem(month - 1)
+      end,
+      abbreviated_day_of_week_names: fn day_of_week ->
+        {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"} |> elem(day_of_week - 1)
+      end,
+      preferred_datetime_invoked: false,
+      preferred_date_invoked: false,
+      preferred_time_invoked: false
+    }
+
+    Enum.reduce(user_options, default_options, fn {key, value}, acc ->
+      if Map.has_key?(acc, key) do
+        %{acc | key => value}
+      else
+        acc
+      end
+    end)
+  end
 end

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -1,0 +1,355 @@
+Code.require_file("test_helper.exs", __DIR__)
+
+defmodule CalendarTest do
+  use ExUnit.Case
+  doctest Calendar
+
+  describe "strftime/3" do
+    test "return received string if there is no datetime formatting to be found in it" do
+      assert Calendar.strftime(~N[2019-08-20 15:47:34.001], "muda string") == "muda string"
+    end
+
+    test "format all time zones blank when receiving a NaiveDateTime" do
+      assert Calendar.strftime(~N[2019-08-15 17:07:57.001], "%z%Z") == ""
+    end
+
+    test "raise error when trying to format a date with a map that has no date fields" do
+      time_without_date = %{hour: 15, minute: 47, second: 34, microsecond: {0, 0}}
+
+      assert_raise(KeyError, fn -> Calendar.strftime(time_without_date, "%x") end)
+    end
+
+    test "raise error when trying to format a time with a map that has no time fields" do
+      date_without_time = %{year: 2019, month: 8, day: 20}
+
+      assert_raise(KeyError, fn -> Calendar.strftime(date_without_time, "%X") end)
+    end
+
+    test "raise error when the format is invalid" do
+      assert_raise(FunctionClauseError, fn ->
+        Calendar.strftime(~N[2019-08-20 15:47:34.001], "%-2-ç")
+      end)
+    end
+
+    test "raise error when the preferred_datetime calls itself" do
+      assert_raise(RuntimeError, fn ->
+        Calendar.strftime(~N[2019-08-20 15:47:34.001], "%c", preferred_datetime: "%c")
+      end)
+    end
+
+    test "raise error when the preferred_date calls itself" do
+      assert_raise(RuntimeError, fn ->
+        Calendar.strftime(~N[2019-08-20 15:47:34.001], "%x", preferred_date: "%x")
+      end)
+    end
+
+    test "raise error when the preferred_time calls itself" do
+      assert_raise(RuntimeError, fn ->
+        Calendar.strftime(~N[2019-08-20 15:47:34.001], "%X", preferred_time: "%X")
+      end)
+    end
+
+    test "raise error when the preferred formats create a circular chain" do
+      assert_raise(RuntimeError, fn ->
+        Calendar.strftime(~N[2019-08-20 15:47:34.001], "%c",
+          preferred_datetime: "%x",
+          preferred_date: "%X",
+          preferred_time: "%c"
+        )
+      end)
+    end
+
+    test "format with no errors is the preferred formats are included multiple times on the same string" do
+      assert(
+        Calendar.strftime(~N[2019-08-15 17:07:57.001], "%c %c %x %x %X %X") ==
+          "2019-08-15 17:07:57 2019-08-15 17:07:57 2019-08-15 2019-08-15 17:07:57 17:07:57"
+      )
+    end
+
+    test "`-` removes padding" do
+      assert Calendar.strftime(~D[2019-01-01], "%-j") == "1"
+      assert Calendar.strftime(~T[17:07:57.001], "%-999M") == "7"
+    end
+
+    test "format time zones correctly when receiving a DateTime" do
+      datetime_with_zone = %DateTime{
+        year: 2019,
+        month: 8,
+        day: 15,
+        zone_abbr: "EEST",
+        hour: 17,
+        minute: 7,
+        second: 57,
+        microsecond: {0, 0},
+        utc_offset: 7200,
+        std_offset: 3600,
+        time_zone: "UK"
+      }
+
+      assert Calendar.strftime(datetime_with_zone, "%z %Z") == "+0300 EEST"
+    end
+
+    test "format AM and PM correctly on the %P and %p options" do
+      am_time_almost_pm = ~U[2019-08-26 11:59:59.001Z]
+      pm_time = ~U[2019-08-26 12:00:57.001Z]
+      pm_time_almost_am = ~U[2019-08-26 23:59:57.001Z]
+      am_time = ~U[2019-08-26 00:00:01.001Z]
+
+      assert Calendar.strftime(am_time_almost_pm, "%P %p") == "am AM"
+      assert Calendar.strftime(pm_time, "%P %p") == "pm PM"
+      assert Calendar.strftime(pm_time_almost_am, "%P %p") == "pm PM"
+      assert Calendar.strftime(am_time, "%P %p") == "am AM"
+    end
+
+    test "format all weekdays correctly with %A and %a formats" do
+      sunday = ~U[2019-08-25 11:59:59.001Z]
+      monday = ~U[2019-08-26 11:59:59.001Z]
+      tuesday = ~U[2019-08-27 11:59:59.001Z]
+      wednesday = ~U[2019-08-28 11:59:59.001Z]
+      thursday = ~U[2019-08-29 11:59:59.001Z]
+      friday = ~U[2019-08-30 11:59:59.001Z]
+      saturday = ~U[2019-08-31 11:59:59.001Z]
+
+      assert Calendar.strftime(sunday, "%A %a") == "Sunday Sun"
+      assert Calendar.strftime(monday, "%A %a") == "Monday Mon"
+      assert Calendar.strftime(tuesday, "%A %a") == "Tuesday Tue"
+      assert Calendar.strftime(wednesday, "%A %a") == "Wednesday Wed"
+      assert Calendar.strftime(thursday, "%A %a") == "Thursday Thu"
+      assert Calendar.strftime(friday, "%A %a") == "Friday Fri"
+      assert Calendar.strftime(saturday, "%A %a") == "Saturday Sat"
+    end
+
+    test "format all months correctly with the %B and %b formats" do
+      assert Calendar.strftime(%{month: 1}, "%B %b") == "January Jan"
+      assert Calendar.strftime(%{month: 2}, "%B %b") == "February Feb"
+      assert Calendar.strftime(%{month: 3}, "%B %b") == "March Mar"
+      assert Calendar.strftime(%{month: 4}, "%B %b") == "April Apr"
+      assert Calendar.strftime(%{month: 5}, "%B %b") == "May May"
+      assert Calendar.strftime(%{month: 6}, "%B %b") == "June Jun"
+      assert Calendar.strftime(%{month: 7}, "%B %b") == "July Jul"
+      assert Calendar.strftime(%{month: 8}, "%B %b") == "August Aug"
+      assert Calendar.strftime(%{month: 9}, "%B %b") == "September Sep"
+      assert Calendar.strftime(%{month: 10}, "%B %b") == "October Oct"
+      assert Calendar.strftime(%{month: 11}, "%B %b") == "November Nov"
+      assert Calendar.strftime(%{month: 12}, "%B %b") == "December Dec"
+    end
+
+    test "format all weekdays correctly on %A with day_of_week_names option" do
+      sunday = ~U[2019-08-25 11:59:59.001Z]
+      monday = ~U[2019-08-26 11:59:59.001Z]
+      tuesday = ~U[2019-08-27 11:59:59.001Z]
+      wednesday = ~U[2019-08-28 11:59:59.001Z]
+      thursday = ~U[2019-08-29 11:59:59.001Z]
+      friday = ~U[2019-08-30 11:59:59.001Z]
+      saturday = ~U[2019-08-31 11:59:59.001Z]
+
+      day_of_week_names = fn day_of_week ->
+        {"segunda-feira", "terça-feira", "quarta-feira", "quinta-feira", "sexta-feira", "sábado",
+         "domingo"}
+        |> elem(day_of_week - 1)
+      end
+
+      assert Calendar.strftime(sunday, "%A", day_of_week_names: day_of_week_names) ==
+               "domingo"
+
+      assert Calendar.strftime(monday, "%A", day_of_week_names: day_of_week_names) ==
+               "segunda-feira"
+
+      assert Calendar.strftime(tuesday, "%A", day_of_week_names: day_of_week_names) ==
+               "terça-feira"
+
+      assert Calendar.strftime(wednesday, "%A", day_of_week_names: day_of_week_names) ==
+               "quarta-feira"
+
+      assert Calendar.strftime(thursday, "%A", day_of_week_names: day_of_week_names) ==
+               "quinta-feira"
+
+      assert Calendar.strftime(friday, "%A", day_of_week_names: day_of_week_names) ==
+               "sexta-feira"
+
+      assert Calendar.strftime(saturday, "%A", day_of_week_names: day_of_week_names) ==
+               "sábado"
+    end
+
+    test "format all months correctly on the %B with month_names option" do
+      month_names = fn month ->
+        {"январь", "февраль", "март", "апрель", "май", "июнь", "июль", "август", "сентябрь",
+         "октябрь", "ноябрь", "декабрь"}
+        |> elem(month - 1)
+      end
+
+      assert Calendar.strftime(%{month: 1}, "%B", month_names: month_names) == "январь"
+      assert Calendar.strftime(%{month: 2}, "%B", month_names: month_names) == "февраль"
+      assert Calendar.strftime(%{month: 3}, "%B", month_names: month_names) == "март"
+      assert Calendar.strftime(%{month: 4}, "%B", month_names: month_names) == "апрель"
+      assert Calendar.strftime(%{month: 5}, "%B", month_names: month_names) == "май"
+      assert Calendar.strftime(%{month: 6}, "%B", month_names: month_names) == "июнь"
+      assert Calendar.strftime(%{month: 7}, "%B", month_names: month_names) == "июль"
+      assert Calendar.strftime(%{month: 8}, "%B", month_names: month_names) == "август"
+      assert Calendar.strftime(%{month: 9}, "%B", month_names: month_names) == "сентябрь"
+      assert Calendar.strftime(%{month: 10}, "%B", month_names: month_names) == "октябрь"
+      assert Calendar.strftime(%{month: 11}, "%B", month_names: month_names) == "ноябрь"
+      assert Calendar.strftime(%{month: 12}, "%B", month_names: month_names) == "декабрь"
+    end
+
+    test "format all weekdays correctly on the %a format with abbreviated_day_of_week_names option" do
+      sunday = ~U[2019-08-25 11:59:59.001Z]
+      monday = ~U[2019-08-26 11:59:59.001Z]
+      tuesday = ~U[2019-08-27 11:59:59.001Z]
+      wednesday = ~U[2019-08-28 11:59:59.001Z]
+      thursday = ~U[2019-08-29 11:59:59.001Z]
+      friday = ~U[2019-08-30 11:59:59.001Z]
+      saturday = ~U[2019-08-31 11:59:59.001Z]
+
+      abbreviated_day_of_week_names = fn day_of_week ->
+        {"seg", "ter", "qua", "qui", "sex", "sáb", "dom"}
+        |> elem(day_of_week - 1)
+      end
+
+      assert Calendar.strftime(sunday, "%a",
+               abbreviated_day_of_week_names: abbreviated_day_of_week_names
+             ) == "dom"
+
+      assert Calendar.strftime(monday, "%a",
+               abbreviated_day_of_week_names: abbreviated_day_of_week_names
+             ) == "seg"
+
+      assert Calendar.strftime(tuesday, "%a",
+               abbreviated_day_of_week_names: abbreviated_day_of_week_names
+             ) == "ter"
+
+      assert Calendar.strftime(wednesday, "%a",
+               abbreviated_day_of_week_names: abbreviated_day_of_week_names
+             ) == "qua"
+
+      assert Calendar.strftime(thursday, "%a",
+               abbreviated_day_of_week_names: abbreviated_day_of_week_names
+             ) == "qui"
+
+      assert Calendar.strftime(friday, "%a",
+               abbreviated_day_of_week_names: abbreviated_day_of_week_names
+             ) == "sex"
+
+      assert Calendar.strftime(saturday, "%a",
+               abbreviated_day_of_week_names: abbreviated_day_of_week_names
+             ) == "sáb"
+    end
+
+    test "format all months correctly on the %b format with abbreviated_month_names option" do
+      abbreviated_month_names = fn month ->
+        {"янв", "февр", "март", "апр", "май", "июнь", "июль", "авг", "сент", "окт", "нояб", "дек"}
+        |> elem(month - 1)
+      end
+
+      assert Calendar.strftime(%{month: 1}, "%b", abbreviated_month_names: abbreviated_month_names) ==
+               "янв"
+
+      assert Calendar.strftime(%{month: 2}, "%b", abbreviated_month_names: abbreviated_month_names) ==
+               "февр"
+
+      assert Calendar.strftime(%{month: 3}, "%b", abbreviated_month_names: abbreviated_month_names) ==
+               "март"
+
+      assert Calendar.strftime(%{month: 4}, "%b", abbreviated_month_names: abbreviated_month_names) ==
+               "апр"
+
+      assert Calendar.strftime(%{month: 5}, "%b", abbreviated_month_names: abbreviated_month_names) ==
+               "май"
+
+      assert Calendar.strftime(%{month: 6}, "%b", abbreviated_month_names: abbreviated_month_names) ==
+               "июнь"
+
+      assert Calendar.strftime(%{month: 7}, "%b", abbreviated_month_names: abbreviated_month_names) ==
+               "июль"
+
+      assert Calendar.strftime(%{month: 8}, "%b", abbreviated_month_names: abbreviated_month_names) ==
+               "авг"
+
+      assert Calendar.strftime(%{month: 9}, "%b", abbreviated_month_names: abbreviated_month_names) ==
+               "сент"
+
+      assert Calendar.strftime(%{month: 10}, "%b",
+               abbreviated_month_names: abbreviated_month_names
+             ) == "окт"
+
+      assert Calendar.strftime(%{month: 11}, "%b",
+               abbreviated_month_names: abbreviated_month_names
+             ) == "нояб"
+
+      assert Calendar.strftime(%{month: 12}, "%b",
+               abbreviated_month_names: abbreviated_month_names
+             ) == "дек"
+    end
+
+    test "microseconds format ignores padding and width options" do
+      datetime = ~U[2019-08-15 17:07:57.001234Z]
+      assert Calendar.strftime(datetime, "%f") == "001234"
+      assert Calendar.strftime(datetime, "%f") == Calendar.strftime(datetime, "%_20f")
+      assert Calendar.strftime(datetime, "%f") == Calendar.strftime(datetime, "%020f")
+      assert Calendar.strftime(datetime, "%f") == Calendar.strftime(datetime, "%-f")
+    end
+
+    test "microseconds format formats properly dates with different precisions" do
+      assert Calendar.strftime(~U[2019-08-15 17:07:57.5Z], "%f") == "5"
+      assert Calendar.strftime(~U[2019-08-15 17:07:57.45Z], "%f") == "45"
+      assert Calendar.strftime(~U[2019-08-15 17:07:57.345Z], "%f") == "345"
+      assert Calendar.strftime(~U[2019-08-15 17:07:57.2345Z], "%f") == "2345"
+      assert Calendar.strftime(~U[2019-08-15 17:07:57.12345Z], "%f") == "12345"
+      assert Calendar.strftime(~U[2019-08-15 17:07:57.012345Z], "%f") == "012345"
+    end
+
+    test "microseconds formats properly different precisions of zero" do
+      assert Calendar.strftime(~N[2019-08-15 17:07:57.0], "%f") == "0"
+      assert Calendar.strftime(~N[2019-08-15 17:07:57.00], "%f") == "00"
+      assert Calendar.strftime(~N[2019-08-15 17:07:57.000], "%f") == "000"
+      assert Calendar.strftime(~N[2019-08-15 17:07:57.0000], "%f") == "0000"
+      assert Calendar.strftime(~N[2019-08-15 17:07:57.00000], "%f") == "00000"
+      assert Calendar.strftime(~N[2019-08-15 17:07:57.000000], "%f") == "000000"
+    end
+
+    test "microseconds returns a single zero if there's no precision at all" do
+      assert Calendar.strftime(~N[2019-08-15 17:07:57], "%f") == "0"
+    end
+
+    test "return the formatted datetime when all format options and modifiers are received" do
+      assert Calendar.strftime(
+               ~U[2019-08-15 17:07:57.001Z],
+               "%04% %a %A %b %B %-3c %d %f %H %I %j %m %_5M %p %P %q %S %u %x %X %y %Y %z %Z"
+             ) ==
+               "000% Thu Thursday Aug August 2019-08-15 17:07:57 15 001 17 05 227 08     7 PM pm 3 57 4 2019-08-15 17:07:57 19 2019 +0000 UTC"
+    end
+
+    test "format according to received custom configs" do
+      assert Calendar.strftime(
+               ~U[2019-08-15 17:07:57.001Z],
+               "%A %a %p %B %b %c %x %X",
+               am_pm_names: fn
+                 :am -> "a"
+                 :pm -> "p"
+               end,
+               month_names: fn month ->
+                 {"Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto",
+                  "Setembro", "Outubro", "Novembro", "Dezembro"}
+                 |> elem(month - 1)
+               end,
+               day_of_week_names: fn day_of_week ->
+                 {"понедельник", "вторник", "среда", "четверг", "пятница", "суббота",
+                  "воскресенье"}
+                 |> elem(day_of_week - 1)
+               end,
+               abbreviated_month_names: fn month ->
+                 {"Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov",
+                  "Dez"}
+                 |> elem(month - 1)
+               end,
+               abbreviated_day_of_week_names: fn day_of_week ->
+                 {"ПНД", "ВТР", "СРД", "ЧТВ", "ПТН", "СБТ", "ВСК"}
+                 |> elem(day_of_week - 1)
+               end,
+               preferred_date: "%05Y-%m-%d",
+               preferred_time: "%M:%_3H%S",
+               preferred_datetime: "%%"
+             ) == "четверг ЧТВ P Agosto Ago % 02019-08-15 07: 1757"
+    end
+  end
+end

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -1,7 +1,7 @@
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule CalendarTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Calendar
 
   describe "strftime/3" do


### PR DESCRIPTION
This PR takes the functionality of `NimbleStrftime` and implements it as a function called `strftime` in the `Calendar` module.

closes #9503 