### PR TITLE
Only error for duplicate map keys in matches

### DIFF
--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -87,7 +87,13 @@ validate_match_key(_, _, _) ->
 validate_not_repeated(Meta, Key, Used, E) ->
   case is_literal(Key) andalso Used of
     #{Key := true} ->
-      form_error(Meta, ?key(E, file), ?MODULE, {repeated_key, Key});
+      case E of
+        #{context := match} ->
+          form_error(Meta, ?key(E, file), ?MODULE, {repeated_key, Key});
+        _ ->
+          form_warn(Meta, ?key(E, file), ?MODULE, {repeated_key, Key}),
+          Used
+      end;
 
     #{} ->
       Used#{Key => true};

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -1227,22 +1227,12 @@ defmodule Kernel.ErrorsTest do
 
   test "duplicate map keys" do
     assert_eval_raise CompileError, "nofile:1: key :a will be overridden in map", """
-      %{a: :b, a: :c}
-    """
-
-    assert_eval_raise CompileError, "nofile:1: key :a will be overridden in map", """
       %{a: :b, a: :c} = %{a: :c}
     """
 
-    assert_eval_raise CompileError, "nofile:1: key :m will be overridden in map", """
-      %{m: :n, m: :o, m: :p}
+    assert_eval_raise CompileError, "nofile:1: key :a will be overridden in map", """
+      %{a: :b, a: :c, a: :d} = %{a: :c}
     """
-
-    assert_eval_raise CompileError, "nofile:1: key 1 will be overridden in map", """
-      %{1 => 2, 1 => 3}
-    """
-
-    assert map_size(%{System.unique_integer() => 1, System.unique_integer() => 2}) == 2
   end
 
   defp bad_remote_call(x), do: x.foo

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -578,6 +578,23 @@ defmodule Kernel.WarningTest do
     purge(Sample)
   end
 
+  test "duplicate map keys" do
+    output =
+      capture_err(fn ->
+        defmodule DuplicateMapKeys do
+          assert %{a: :b, a: :c} == %{a: :c}
+          assert %{m: :n, m: :o, m: :p} == %{m: :p}
+          assert %{1 => 2, 1 => 3} == %{1 => 3}
+        end
+      end)
+
+    assert output =~ "key :a will be overridden in map"
+    assert output =~ "key :m will be overridden in map"
+    assert output =~ "key 1 will be overridden in map"
+
+    assert map_size(%{System.unique_integer() => 1, System.unique_integer() => 2}) == 2
+  end
+
   test "unused guard" do
     assert capture_err(fn ->
              Code.eval_string("""


### PR DESCRIPTION
In matches we will error:

    %{a: :b, a: :c} = %{a: :b}

In normal expressions we will only warn:

    %{a: :b, a: :c}

Closes https://github.com/elixir-lang/elixir/issues/9737.