### PR TITLE
Allow users to tag doctests with options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,6 @@
   * [Kernel] Add `is_struct/2` guard
   * [Kernel] Support `map.field` syntax in guards
 
-#### ExUnit
-
-  * [DocTest] Accept `:tags` as an option to `doctest/2`
-
 ### 2. Bug fixes
 
 ### 3. Soft-deprecations (no warnings emitted)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   * [Kernel] Add `is_struct/2` guard
   * [Kernel] Support `map.field` syntax in guards
 
+#### ExUnit
+
+  * [DocTest] Accept `:tags` as an option to `doctest/2`
+
 ### 2. Bug fixes
 
 ### 3. Soft-deprecations (no warnings emitted)

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -187,6 +187,9 @@ defmodule ExUnit.DocTest do
       should be set to `false` and a full `Module.function` construct should be
       used.
 
+    * `:tags` - a list of tags to apply to the generated tests. All tests generated
+       will have all of the given tags applied to them.
+
   ## Examples
 
       doctest MyModule, except: [:moduledoc, trick_fun: 1]
@@ -208,6 +211,7 @@ defmodule ExUnit.DocTest do
 
         for {name, test} <- ExUnit.DocTest.__doctests__(module, opts) do
           @file file
+          @tag Keyword.get(opts, :tags, [])
           doc = ExUnit.Case.register_test(env, :doctest, name, [])
           def unquote(doc)(_), do: unquote(test)
         end

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -187,8 +187,7 @@ defmodule ExUnit.DocTest do
       should be set to `false` and a full `Module.function` construct should be
       used.
 
-    * `:tags` - a list of tags to apply to the generated tests. All tests generated
-       will have all of the given tags applied to them.
+    * `:tags` - a list of tags to apply to all generated doctests.
 
   ## Examples
 

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -211,7 +211,9 @@ defmodule ExUnit.DocTest do
 
         for {name, test} <- ExUnit.DocTest.__doctests__(module, opts) do
           @file file
-          @tag Keyword.get(opts, :tags, [])
+          if tags = Keyword.get(opts, :tags) do
+            @tag tags
+          end
           doc = ExUnit.Case.register_test(env, :doctest, name, [])
           def unquote(doc)(_), do: unquote(test)
         end

--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -210,10 +210,11 @@ defmodule ExUnit.DocTest do
         file = ExUnit.DocTest.__file__(module)
 
         for {name, test} <- ExUnit.DocTest.__doctests__(module, opts) do
-          @file file
           if tags = Keyword.get(opts, :tags) do
             @tag tags
           end
+
+          @file file
           doc = ExUnit.Case.register_test(env, :doctest, name, [])
           def unquote(doc)(_), do: unquote(test)
         end

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -470,6 +470,19 @@ defmodule ExUnit.DocTestTest do
     refute output =~ "doctest"
   end
 
+  test "allows users to tag doctests with configuration options" do
+    defmodule TaggedTests do
+      use ExUnit.Case
+      doctest ExUnit.DocTestTest.SomewhatGoodModuleWithOnly, tags: [skip: true], import: true
+    end
+
+    ExUnit.Server.modules_loaded()
+    output = capture_io(fn -> ExUnit.run() end)
+
+    assert output =~ "0 failures"
+    assert output =~ "2 skipped"
+  end
+
   test "doctest failures" do
     # When adding or removing lines above this line, the tests below will
     # fail because we are explicitly asserting some doctest lines from


### PR DESCRIPTION
Now users can pass tags as options to doctests.