### PR TITLE
Typo fix in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,7 +153,7 @@ ExUnit, our test framework, ships two small but important improvements: `ExUnit.
 assert %{"status" => 200, "body" => %{"key" => "foo"}} = json_payload
 ```
 
-Now imagine that `json_payload` is a large JSON blob and the `"key"` inside the `"body"` did not have value of `"foo"`. In previous Elixir versions, if the assertion failed, Elixir would print the right side and let you up to your own devices to figure out what went wrong. In Elixir v1.10, we diff the data structure against the pattern so you can see exactly which parts of the data matched the pattern and which ones did not. Note ExUnit already performed diffing when comparing data types, this new version adds diffing when matching data agaainst a pattern.
+Now imagine that `json_payload` is a large JSON blob and the `"key"` inside the `"body"` did not have value of `"foo"`. In previous Elixir versions, if the assertion failed, Elixir would print the right side and let you up to your own devices to figure out what went wrong. In Elixir v1.10, we diff the data structure against the pattern so you can see exactly which parts of the data matched the pattern and which ones did not. Note ExUnit already performed diffing when comparing data types, this new version adds diffing when matching data against a pattern.
 
 ## v1.10.0 (2020-01-27)
 


### PR DESCRIPTION
`against` instead of `agaainst`