### PR TITLE
Use Erlang's logger timestamp

### DIFF
--- a/lib/logger/lib/logger/handler.ex
+++ b/lib/logger/lib/logger/handler.ex
@@ -84,7 +84,7 @@ defmodule Logger.Handler do
 
       mode ->
         level = erlang_level_to_elixir_level(erl_level)
-        timestamp = Map.get_lazy(metadata, :time, &:logger.timestamp/0)
+        timestamp = Map.get_lazy(metadata, :time, fn -> :os.system_time(:microsecond) end)
 
         case do_log(level, msg, metadata, config) do
           :skip ->

--- a/lib/logger/lib/logger/handler.ex
+++ b/lib/logger/lib/logger/handler.ex
@@ -84,6 +84,7 @@ defmodule Logger.Handler do
 
       mode ->
         level = erlang_level_to_elixir_level(erl_level)
+        timestamp = Map.get_lazy(metadata, :time, &:logger.timestamp/0)
 
         case do_log(level, msg, metadata, config) do
           :skip ->
@@ -96,7 +97,8 @@ defmodule Logger.Handler do
             event = {
               level,
               gl,
-              {Logger, truncate(message, truncate), Logger.Utils.timestamp(utc_log?), metadata}
+              {Logger, truncate(message, truncate), Logger.Utils.timestamp(timestamp, utc_log?),
+               metadata}
             }
 
             notify(mode, event)

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -170,7 +170,7 @@ defmodule Logger.Utils do
   @doc """
   Returns a timestamp that includes milliseconds.
   """
-  def timestamp(timestamp \\ :logger.timestamp(), utc_log?) do
+  def timestamp(timestamp \\ :os.system_time(:microsecond), utc_log?) do
     micro = rem(timestamp, 1_000_000)
 
     {date, {hours, minutes, seconds}} =

--- a/lib/logger/lib/logger/utils.ex
+++ b/lib/logger/lib/logger/utils.ex
@@ -170,13 +170,13 @@ defmodule Logger.Utils do
   @doc """
   Returns a timestamp that includes milliseconds.
   """
-  def timestamp(utc_log?) do
-    {_, _, micro} = now = :os.timestamp()
+  def timestamp(timestamp \\ :logger.timestamp(), utc_log?) do
+    micro = rem(timestamp, 1_000_000)
 
     {date, {hours, minutes, seconds}} =
       case utc_log? do
-        true -> :calendar.now_to_universal_time(now)
-        false -> :calendar.now_to_local_time(now)
+        true -> :calendar.system_time_to_universal_time(timestamp, :microsecond)
+        false -> :calendar.system_time_to_local_time(timestamp, :microsecond)
       end
 
     {date, {hours, minutes, seconds, div(micro, 1000)}}


### PR DESCRIPTION
Instead of generating new timestamp on each log message use existing `time` entry from `:logger.metadata()`.

Ref #9465