### PR TITLE
Handle local deps change on recompile() in iex

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -122,6 +122,9 @@ defmodule IEx.Helpers do
     Mix.Task.reenable("compile")
     Mix.Task.reenable("compile.all")
     Mix.Task.reenable("compile.protocols")
+    Mix.Task.reenable("deps.loadpaths")
+    Mix.Task.reenable("deps.precompile")
+    Mix.Task.reenable("loadpaths")
     compilers = config[:compilers] || Mix.compilers()
     Enum.each(compilers, &Mix.Task.reenable("compile.#{&1}"))
   end

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -428,6 +428,7 @@ defmodule Mix.Task do
     recursive = (module = get(task)) && recursive(module)
 
     Mix.TasksServer.delete_many([{:task, task, proj}, {:alias, task, proj}])
+    Mix.TasksServer.delete_task_for_all_projects({:task, task})
 
     cond do
       recursive && Mix.Project.umbrella?() ->

--- a/lib/mix/lib/mix/tasks_server.ex
+++ b/lib/mix/lib/mix/tasks_server.ex
@@ -25,6 +25,21 @@ defmodule Mix.TasksServer do
     Agent.update(@name, &Map.drop(&1, many), @timeout)
   end
 
+  def delete_task_for_all_projects({:task, task}) do
+    Agent.update(
+      @name,
+      fn map ->
+        map
+        |> Enum.reject(fn
+          {{:task, ^task, _}, _} -> true
+          _ -> false
+        end)
+        |> Enum.into(%{})
+      end,
+      @timeout
+    )
+  end
+
   def clear() do
     Agent.update(@name, fn _ -> %{} end, @timeout)
   end


### PR DESCRIPTION
This PR fixes issue #9746.

I'm not sure if this is the right approach or is there are tests for the recompile feature - let me know :)

Example behaviour after this commit:
```
$ iex -S mix
Erlang/OTP 22 [erts-10.6.1] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [hipe]

==> dep2
Compiling 1 file (.ex)
Interactive Elixir (1.11.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> recompile
:noop
iex(2)> Dep2.hello
:worldXZXXZZZZ2
iex(3)> recompile
==> dep2
Compiling 1 file (.ex)
:ok
iex(4)> Dep2.hello
:w
iex(5)>
```