### PR TITLE
Escape Unicode chars in doucmentation for String codepoints/1

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1531,7 +1531,7 @@ defmodule String do
     :binary.copy(subject, n)
   end
 
-  @doc """
+  @doc ~S"""
   Returns all code points in the string.
 
   For details about code points and graphemes, see the `String` module documentation.


### PR DESCRIPTION
Hexdocs for String.codepoints/1 has 5 examples. 

Fourth and fifth are different but in documentation the look the same. 

String.codepoints("é")
String.codepoints("é")

Unicode chars need to be escaped to distinguish them as intended in the source

String.codepoints("\u00e9")
String.codepoints("\u0065\u0301")

