### PR TITLE
Add IO.warn_once/3

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -351,6 +351,11 @@ defmodule IO do
 
   It returns `:ok` if it succeeds.
 
+  Make sure to not call this function at the tail of another function,
+  due to tail call optimization a stacktrace entry would not be added
+  and the trace would incorrectly trimmed. As a workaround you can add
+  the `:ok` term after the `IO.warn("message")` call.
+
   ## Examples
 
       IO.warn("variable bar is unused")

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -351,10 +351,10 @@ defmodule IO do
 
   It returns `:ok` if it succeeds.
 
-  Make sure to not call this function at the tail of another function,
-  due to tail call optimization a stacktrace entry would not be added
-  and the trace would incorrectly trimmed. As a workaround you can add
-  the `:ok` term after the `IO.warn("message")` call.
+  Do not call this function at the tail of another function. Due to tail
+  call optimization, a stacktrace entry would not be added and the
+  stacktrace would be incorrectly trimmed. Therefore make sure at least
+  one expression (or an atom such as `:ok`) follows the `IO.warn/1` call.
 
   ## Examples
 

--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -334,6 +334,18 @@ defmodule IO do
     )
   end
 
+  @doc false
+  def warn_once(key, message, stacktrace_drop_levels) do
+    {:current_stacktrace, stacktrace} = Process.info(self(), :current_stacktrace)
+    stacktrace = Enum.drop(stacktrace, stacktrace_drop_levels)
+
+    if :elixir_config.warn(key, stacktrace) do
+      warn(message, stacktrace)
+    else
+      :ok
+    end
+  end
+
   @doc """
   Writes a `message` to stderr, along with the current stacktrace.
 

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -823,8 +823,10 @@ defmodule Supervisor do
   end
 
   def start_child(supervisor, args) when is_list(args) do
-    IO.warn(
-      "Supervisor.start_child/2 with a list of args is deprecated, please use DynamicSupervisor instead"
+    IO.warn_once(
+      {__MODULE__, :start_child},
+      "Supervisor.start_child/2 with a list of args is deprecated, please use DynamicSupervisor instead",
+      _stacktrace_drop_levels = 2
     )
 
     call(supervisor, {:start_child, args})

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -1071,15 +1071,12 @@ defmodule System do
   end
 
   defp warn(unit, replacement_unit) do
-    {:current_stacktrace, stacktrace} = Process.info(self(), :current_stacktrace)
-    stacktrace = Enum.drop(stacktrace, 3)
-
-    :elixir_config.warn({System, unit}, stacktrace) &&
-      IO.warn(
-        "deprecated time unit: #{inspect(unit)}. A time unit should be " <>
-          ":second, :millisecond, :microsecond, :nanosecond, or a positive integer",
-        stacktrace
-      )
+    IO.warn_once(
+      {__MODULE__, unit},
+      "deprecated time unit: #{inspect(unit)}. A time unit should be " <>
+        ":second, :millisecond, :microsecond, :nanosecond, or a positive integer",
+      _stacktrace_drop_levels = 4
+    )
 
     replacement_unit
   end


### PR DESCRIPTION
I only added it for `Supervisor.start_child/2` but I think this can be useful for almost all cases where we call `IO.warn/2` at runtime. It is also rare that we call `IO.warn/2` with a stacktrace which I also think would be an improvement.

Should I go through the other calls to `IO.warn/2` and do the same change?