### PR TITLE
Fix unused variable warnings

### DIFF
--- a/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
+++ b/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
@@ -230,7 +230,7 @@ defmodule Kernel.ParallelCompilerTest do
           """
         )
 
-      assert {:ok, modules, []} = Kernel.ParallelCompiler.compile([foo, bar])
+      assert {:ok, _modules, []} = Kernel.ParallelCompiler.compile([foo, bar])
       assert Enum.sort([FooCircular, BarCircular]) == [BarCircular, FooCircular]
     after
       purge([FooCircular, BarCircular])

--- a/lib/elixir/test/elixir/kernel/tracers_test.exs
+++ b/lib/elixir/test/elixir/kernel/tracers_test.exs
@@ -125,7 +125,7 @@ defmodule Kernel.TracersTest do
     end
     """)
 
-    assert_receive {{:defmodule, meta}, %{module: Sample}}
+    assert_receive {{:defmodule, _meta}, %{module: Sample}}
 
     assert_receive {{:local_macro, meta, :foo, 1}, _}
     assert meta[:line] == 4

--- a/lib/elixir/test/elixir/module/types/infer_test.exs
+++ b/lib/elixir/test/elixir/module/types/infer_test.exs
@@ -147,11 +147,11 @@ defmodule Module.Types.InferTest do
 
       assert {:ok, {:var, 0}, context} = unify({:var, 0}, :integer, var_context)
       assert {:ok, {:var, 1}, context} = unify({:var, 1}, :integer, context)
-      assert {:ok, {:var, _}, context} = unify({:var, 0}, {:var, 1}, context)
+      assert {:ok, {:var, _}, _context} = unify({:var, 0}, {:var, 1}, context)
 
       assert {:ok, {:var, 0}, context} = unify({:var, 0}, :integer, var_context)
       assert {:ok, {:var, 1}, context} = unify({:var, 1}, :integer, context)
-      assert {:ok, {:var, _}, context} = unify({:var, 1}, {:var, 0}, context)
+      assert {:ok, {:var, _}, _context} = unify({:var, 1}, {:var, 0}, context)
 
       assert {:ok, {:var, 0}, context} = unify({:var, 0}, :integer, var_context)
       assert {:ok, {:var, 1}, context} = unify({:var, 1}, :binary, context)
@@ -178,7 +178,7 @@ defmodule Module.Types.InferTest do
       assert {:ok, {:var, 0}, context} = unify({:var, 0}, :integer, var_context)
       assert {:ok, {:var, 1}, context} = unify({:var, 1}, :integer, context)
 
-      assert {:ok, {:tuple, [{:var, _}]}, context} =
+      assert {:ok, {:tuple, [{:var, _}]}, _context} =
                unify({:tuple, [{:var, 0}]}, {:tuple, [{:var, 1}]}, context)
 
       assert {:ok, {:var, 1}, context} = unify({:var, 1}, {:tuple, [{:var, 0}]}, var_context)
@@ -200,11 +200,11 @@ defmodule Module.Types.InferTest do
       assert {{:var, 2}, var_context} = new_var({:baz, [version: 2], nil}, var_context)
 
       assert {:ok, {:var, _}, context} = unify({:var, 0}, {:var, 1}, var_context)
-      assert {:ok, {:var, _}, context} = unify({:var, 1}, {:var, 0}, context)
+      assert {:ok, {:var, _}, _context} = unify({:var, 1}, {:var, 0}, context)
 
       assert {:ok, {:var, _}, context} = unify({:var, 0}, {:var, 1}, var_context)
       assert {:ok, {:var, _}, context} = unify({:var, 1}, {:var, 2}, context)
-      assert {:ok, {:var, _}, context} = unify({:var, 2}, {:var, 0}, context)
+      assert {:ok, {:var, _}, _context} = unify({:var, 2}, {:var, 0}, context)
 
       assert {:ok, {:var, _}, context} = unify({:var, 0}, {:var, 1}, var_context)
 

--- a/lib/elixir/test/elixir/module/types/pattern_test.exs
+++ b/lib/elixir/test/elixir/module/types/pattern_test.exs
@@ -225,10 +225,10 @@ defmodule Module.Types.PatternTest do
     assert {:ok, :dynamic, context} = quoted_guard([x], elem(x, 0))
     assert Types.lift_type({:var, 0}, context) == :tuple
 
-    assert {:ok, {:atom, true}, context} = quoted_guard([], true)
-    assert {:ok, {:atom, false}, context} = quoted_guard([], false)
-    assert {:ok, {:atom, :fail}, context} = quoted_guard([], :fail)
-    assert {:ok, :boolean, context} = quoted_guard([], is_atom(true or :fail))
+    assert {:ok, {:atom, true}, _context} = quoted_guard([], true)
+    assert {:ok, {:atom, false}, _context} = quoted_guard([], false)
+    assert {:ok, {:atom, :fail}, _context} = quoted_guard([], :fail)
+    assert {:ok, :boolean, _context} = quoted_guard([], is_atom(true or :fail))
 
     assert {:error, {_, {:unable_unify, :tuple, :boolean, _, _}, _}} =
              quoted_guard([x], is_tuple(x) and is_boolean(x))

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -383,7 +383,9 @@ defmodule RegistryTest do
         assert is_pid(pid)
         assert sum_pid_entries(registry, partitions) == 2
 
-        assert {:error, {:already_registered, pid}} = Registry.register(registry, "hello", :value)
+        assert {:error, {:already_registered, _pid}} =
+                 Registry.register(registry, "hello", :value)
+
         assert sum_pid_entries(registry, partitions) == 2
       end
 

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -298,9 +298,9 @@ defmodule TaskTest do
       send(self(), {other_ref, :z})
       send(self(), {:DOWN, other_ref, :process, 1, :goodbye})
       assert Task.await_many(tasks) == [:a, :b]
-      assert_received other_ref
-      assert_received {other_ref, :z}
-      assert_received {:DOWN, other_ref, :process, 1, :goodbye}
+      assert_received ^other_ref
+      assert_received {^other_ref, :z}
+      assert_received {:DOWN, ^other_ref, :process, 1, :goodbye}
     end
 
     test "ignores additional messages after reply" do
@@ -310,7 +310,7 @@ defmodule TaskTest do
       send(self(), {ref_2, :other})
       send(self(), {ref_1, :a})
       assert Task.await_many(tasks) == [:a, :b]
-      assert_received {ref_2, :other}
+      assert_received {^ref_2, :other}
     end
 
     test "exits on timeout" do

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -511,7 +511,7 @@ defmodule TypespecTest do
           @type my_type :: %TypespecSample{hello: :world}
         end
 
-      assert [type: {:my_type, type, []}] = types(bytecode)
+      assert [type: {:my_type, _type, []}] = types(bytecode)
     end
 
     test "@type with undefined struct" do
@@ -595,7 +595,7 @@ defmodule TypespecTest do
         end
 
       assert [type: {:my_type, type, []}] = types(bytecode)
-      assert {:type, _, :tuple, [my_timestamp, term, foo]} = type
+      assert {:type, _, :tuple, [my_timestamp, term, _foo]} = type
       assert {:atom, 0, :my_timestamp} = my_timestamp
       assert {:ann_type, 0, [{:var, 0, :date}, {:type, 0, :term, []}]} = term
       assert {:ann_type, 0, [{:var, 0, :time}, {:atom, 0, :foo}]}

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -651,7 +651,7 @@ defmodule ExUnit.Assertions do
   end
 
   defp mark_as_generated(vars) do
-    for {name, meta, context} <- vars, do: {name, [generated: true] ++ meta, context }
+    for {name, meta, context} <- vars, do: {name, [generated: true] ++ meta, context}
   end
 
   @doc false

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -157,16 +157,16 @@ defmodule ExUnit.AssertionsTest do
 
   test "assert match with unused var" do
     assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
-      Code.eval_string("""
-      defmodule ExSample do
-        import ExUnit.Assertions
+             Code.eval_string("""
+             defmodule ExSample do
+               import ExUnit.Assertions
 
-        def run do
-          {2, 1} = assert {2, var} = ExUnit.AssertionsTest.Value.tuple()
-        end
-      end
-      """)
-    end) =~ "variable \"var\" is unused"
+               def run do
+                 {2, 1} = assert {2, var} = ExUnit.AssertionsTest.Value.tuple()
+               end
+             end
+             """)
+           end) =~ "variable \"var\" is unused"
   after
     :code.delete(ExSample)
     :code.purge(ExSample)

--- a/lib/logger/test/logger/translator_test.exs
+++ b/lib/logger/test/logger/translator_test.exs
@@ -246,9 +246,9 @@ defmodule Logger.TranslatorTest do
            end) =~ "Client"
 
     assert_receive {:error, _pid,
-                    {Logger, [["GenServer " <> _ | _] | _], _ts, gen_server_metadata}}
+                    {Logger, [["GenServer " <> _ | _] | _], _ts, _gen_server_metadata}}
 
-    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, _process_metadata}}
   end
 
   test "translates :gen_event crashes" do
@@ -879,7 +879,7 @@ defmodule Logger.TranslatorTest do
            """
 
     assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
-    assert_receive {:error, _pid, {Logger, ["Child " | _], _ts, child_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Child " | _], _ts, _child_metadata}}
     assert {:stop, [_ | _]} = process_metadata[:crash_reason]
   end
 
@@ -963,7 +963,7 @@ defmodule Logger.TranslatorTest do
   end
 
   test "translates process crash with erts" do
-    assert {:ok, msg, meta} =
+    assert {:ok, _msg, meta} =
              Logger.Translator.translate(
                :error,
                :error,
@@ -998,7 +998,7 @@ defmodule Logger.TranslatorTest do
     assert log =~ ~s(Start Call: Logger.TranslatorTest.WeirdFunctionNamesGenServer."start link"/?)
     assert_receive {:error, _pid, {Logger, ["GenServer " <> _ | _], _ts, server_metadata}}
     assert_receive {:error, _pid, {Logger, ["Process " | _], _ts, process_metadata}}
-    assert_receive {:error, _pid, {Logger, ["Child " | _], _ts, child_metadata}}
+    assert_receive {:error, _pid, {Logger, ["Child " | _], _ts, _child_metadata}}
 
     assert {%RuntimeError{message: "oops"}, [_ | _]} = server_metadata[:crash_reason]
     assert {%RuntimeError{message: "oops"}, [_ | _]} = process_metadata[:crash_reason]

--- a/lib/mix/test/mix/release_test.exs
+++ b/lib/mix/test/mix/release_test.exs
@@ -228,8 +228,8 @@ defmodule Mix.ReleaseTest do
       assert %Mix.Release{
                name: :foo,
                version: "0.1.0",
-               path: path,
-               version_path: version_path
+               path: _path,
+               version_path: _version_path
              } = from_config!(nil, config, [])
     end
   end

--- a/lib/mix/test/mix/tasks/release_test.exs
+++ b/lib/mix/test/mix/tasks/release_test.exs
@@ -577,7 +577,7 @@ defmodule Mix.Tasks.ReleaseTest do
                  protocols_consolidated?: true,
                  release_name: "eval",
                  release_node: "eval",
-                 release_root: root,
+                 release_root: ^root,
                  release_vsn: "0.1.0",
                  runtime_config: {:ok, :was_set},
                  static_config: {:ok, :was_set}


### PR DESCRIPTION
This needs to be reviewed carefully, in some tests the intention was to
ignore the variable but in some to match against an existing one. I
tried my best to figure out which was which.

There is one thing left which is a false positive for this test:

    test "greets the world" do
      assert <<len::8, _::size(len)-binary>> = <<3, "foo">>
    end

Produces this:

    warning: variable "len" is unused (if the variable is not meant to be used, prefix it with an underscore)
      test/foo_test.exs:6: FooTest."test greets the world"/1

I wasn't able to fix this so any help appreciated!