### PR TITLE
Use correct return value from report_cb/2

### DIFF
--- a/lib/logger/lib/logger/handler.ex
+++ b/lib/logger/lib/logger/handler.ex
@@ -232,7 +232,7 @@ defmodule Logger.Handler do
     translate_fallback(:format, callback.(data), meta, truncate)
   end
 
-  defp translate_fallback(:report, {:logger, data}, %{report_cb: callback} = meta, truncate)
+  defp translate_fallback(:report, {:logger, data}, %{report_cb: callback}, _truncate)
        when is_function(callback, 2) do
     translator_opts =
       struct(Inspect.Opts, Application.fetch_env!(:logger, :translator_inspect_opts))
@@ -243,7 +243,7 @@ defmodule Logger.Handler do
       single_line: false
     }
 
-    translate_fallback(:format, callback.(data, opts), meta, truncate)
+    callback.(data, opts)
   end
 
   defp translate_fallback(:format, {format, args}, _meta, truncate) do

--- a/lib/logger/test/logger/handler_test.exs
+++ b/lib/logger/test/logger/handler_test.exs
@@ -147,6 +147,6 @@ defmodule Logger.HandlerTest do
   defp format_report(report, opts) do
     send(self(), {:format, report, opts})
 
-    {'~p', [report]}
+    inspect(report)
   end
 end


### PR DESCRIPTION
Earlier it assumed that the return type is the same as in `report_cb/1` which is not true. `report_cb/1` returns format string and data while `report_cb/2` returns already formatted string.