### PR TITLE
Fix divergedreq error when update changes requirement and version

### DIFF
--- a/lib/mix/lib/mix/dep.ex
+++ b/lib/mix/lib/mix/dep.ex
@@ -66,7 +66,7 @@ defmodule Mix.Dep do
           scm: Mix.SCM.t(),
           app: atom,
           requirement: String.t() | Regex.t() | nil,
-          status: atom,
+          status: {:ok, String.t() | nil} | atom | tuple,
           opts: keyword,
           top_level: boolean,
           manager: :rebar | :rebar3 | :mix | :make | nil,


### PR DESCRIPTION
The fix is to mark the dependency for compilation in the Fetcher (by
touching .fetch) so that the Loader wont read the version from the .app
file.

Fixes #9806.