### PR TITLE
Use acc type alias in spec of Enum.reduce/3

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2106,7 +2106,7 @@ defmodule Enum do
   operation cannot be expressed by any of the functions in the `Enum`
   module, developers will most likely resort to `reduce/3`.
   """
-  @spec reduce(t, any, (element, any -> any)) :: any
+  @spec reduce(t, any, (element, acc -> acc)) :: acc
   def reduce(enumerable, acc, fun) when is_list(enumerable) do
     :lists.foldl(fun, acc, enumerable)
   end


### PR DESCRIPTION
I was reading the docs for the `Enum` module, and noticed it defines an `acc() :: any()` type alias, which is used in the spec of `reduce/2`, but not in the one for `reduce/3`. I added it so that it's clearer which one of the reducer's arguments is the accumulator in `reduce/3` as well.