### PR TITLE
Add Module.to_string

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1388,6 +1388,22 @@ defmodule Module do
     raise ArgumentError, "expected an Elixir module, got: #{inspect(original)}"
   end
 
+  @doc """
+  Converts a module name to a string.
+
+  ## Examples
+
+      iex> Module.to_string(Example.Module)
+      "Example.Module"
+  """
+  @spec to_string(module) :: String.t()
+  def to_string(module) when is_atom(module) do
+    case Atom.to_string(module) do
+      "Elixir." <> name -> name
+      _ -> raise ArgumentError, "expected an Elixir module, got: #{inspect(module)}"
+    end
+  end
+
   @doc false
   @deprecated "Use @doc instead"
   def add_doc(module, line, kind, {name, arity}, signature \\ [], doc) do

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -256,6 +256,15 @@ defmodule ModuleTest do
     assert Module.concat(Module.split(module)) == module
   end
 
+  test "to_string" do
+    module = Very.Long.Module.Name.And.Even.Longer
+    assert Module.to_string(module) == "Very.Long.Module.Name.And.Even.Longer"
+
+    assert_raise ArgumentError, "expected an Elixir module, got: :just_an_atom", fn ->
+      Module.to_string(:just_an_atom)
+    end
+  end
+
   test "__MODULE__" do
     assert Code.eval_string("__MODULE__.Foo") |> elem(0) == Foo
   end


### PR DESCRIPTION
This works similar to `Atom.to_string`, but trims off the `Elixir.` prefix for module names.

**Motivation**

We have similar code in our codebase for handing this and I've seen similar functionality in other libraries. So it seemed fairly reasonable to open a PR to discuss the change.

**Outstanding question:**

`MyModule |> Module.to_string() |> Module.split()` doesn't work, do we need to support this? Since `Module.split()` accepts a string it seems like it should work, but on the other hand you don't need the `Module.to_string()` call since you could just do `MyModule |> Module.split()`. 