### PR TITLE
Fix error message for import :except option

### DIFF
--- a/lib/elixir/src/elixir_import.erl
+++ b/lib/elixir/src/elixir_import.erl
@@ -171,10 +171,14 @@ format_error({invalid_option, Option}) ->
   Message = "invalid :~s option for import, expected a keyword list with integer values",
   io_lib:format(Message, [Option]);
 
-format_error({invalid_option, Option, Value}) ->
-  Message = "invalid :~s option for import, expected value to be an atom :functions, :macros"
+format_error({invalid_option, only, Value}) ->
+  Message = "invalid :only option for import, expected value to be an atom :functions, :macros"
   ", or a list literal, got: ~s",
-  io_lib:format(Message, [Option, 'Elixir.Macro':to_string(Value)]);
+  io_lib:format(Message, ['Elixir.Macro':to_string(Value)]);
+
+format_error({invalid_option, except, Value}) ->
+  Message = "invalid :except option for import, expected value to be a list literal, got: ~s",
+  io_lib:format(Message, ['Elixir.Macro':to_string(Value)]);
 
 format_error({special_form_conflict, {Receiver, Name, Arity}}) ->
   io_lib:format("cannot import ~ts.~ts/~B because it conflicts with Elixir special forms",

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -872,9 +872,8 @@ defmodule Kernel.ErrorsTest do
 
   test "ensure valid import :except option" do
     assert_eval_raise CompileError,
-                      "nofile:3: invalid :except option for import, expected value to be an atom " <>
-                        ":functions, :macros, or a list literal, got: " <>
-                        "Module.__get_attribute__(Kernel.ErrorsTest.Only, :x, 3)",
+                      "nofile:3: invalid :except option for import, expected value to be a list " <>
+                        "literal, got: Module.__get_attribute__(Kernel.ErrorsTest.Only, :x, 3)",
                       '''
                       defmodule Kernel.ErrorsTest.Only do
                         @x [flatten: 1]


### PR DESCRIPTION
Before this patch we had:

    iex> import Kernel, except: :macros
    ** (CompileError) iex:1: invalid :except option for import, expected value to be an atom :functions, :macros, or a list literal, got: :macros
        (elixir 1.11.0-dev) src/elixir_import.erl:84: :elixir_import.calculate/6
        (elixir 1.11.0-dev) src/elixir_import.erl:24: :elixir_import.import/4