### PR TITLE
Better Git diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 lib/elixir/test/elixir/fixtures/*.txt text eol=lf
+*.ex diff=elixir
+*.exs diff=elixir


### PR DESCRIPTION
In Git 2.25 there comes native support for Elixir definitions. That will
make `git diff --function-context` work properly. Additionally it makes
diff headers to contain name of enclosing function.

I hope that this will work in GitHub diffs as well.