### PR TITLE
Add EditorConfig to core and generated projects

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ charset = utf-8
 indent_style = space
 indent_size = 2
 
-[*.erl]
+[*.{erl,hrl}]
 indent_style = space
 indent_size = 2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+end_of_line = true
+insert_final_newline = true
+charset = utf-8
+
+[*.{ex,exs}]
+indent_style = space
+indent_size = 2
+
+[*.erl]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-end_of_line = true
+end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 

--- a/lib/mix/test/mix/tasks/new_test.exs
+++ b/lib/mix/test/mix/tasks/new_test.exs
@@ -12,6 +12,10 @@ defmodule Mix.Tasks.NewTest do
         assert file =~ "version: \"0.1.0\""
       end)
 
+      assert_file("hello_world/.editorconfig", fn file ->
+        assert file =~ "root = true"
+      end)
+
       assert_file("hello_world/README.md", ~r/# HelloWorld\n/)
       assert_file("hello_world/.gitignore")
 
@@ -42,6 +46,10 @@ defmodule Mix.Tasks.NewTest do
         assert file =~ "app: :hello_world"
         assert file =~ "version: \"0.1.0\""
         assert file =~ "mod: {HelloWorld.Application, []}"
+      end)
+
+      assert_file("hello_world/.editorconfig", fn file ->
+        assert file =~ "root = true"
       end)
 
       assert_file("hello_world/README.md", ~r/# HelloWorld\n/)
@@ -88,6 +96,10 @@ defmodule Mix.Tasks.NewTest do
         assert file =~ "version: \"0.1.0\""
       end)
 
+      assert_file("HELLO_WORLD/.editorconfig", fn file ->
+        assert file =~ "root = true"
+      end)
+
       assert_file("HELLO_WORLD/README.md", ~r/# HelloWorld\n/)
       assert_file("HELLO_WORLD/.gitignore")
 
@@ -114,6 +126,10 @@ defmodule Mix.Tasks.NewTest do
         assert file =~ "apps_path: \"apps\""
       end)
 
+      assert_file("hello_world/.editorconfig", fn file ->
+        assert file =~ "root = true"
+      end)
+
       assert_file("hello_world/README.md", ~r/# HelloWorld\n/)
       assert_file("hello_world/.gitignore")
 
@@ -134,6 +150,10 @@ defmodule Mix.Tasks.NewTest do
         assert_file("hello_world/mix.exs", fn file ->
           assert file =~ "deps_path: \"../../deps\""
           assert file =~ "lockfile: \"../../mix.lock\""
+        end)
+
+        assert_file("hello_world/.editorconfig", fn file ->
+          refute file =~ "root = true"
         end)
 
         # Ensure formatting is setup and consistent.


### PR DESCRIPTION
EditorConfig is project that wants to provide simple format to configure
different editors in a way, that will provide similar output code in all
of them. [There is a lot of editors that support such configuration
file OOtB][2]. Other editors often have plugins that provides such
support.

Used options are:

Global:

- `insert_final_newline` is set to true to follow POSIX standard
- `charset` is defined to be UTF-8 for editors that use different
charset by default

For Elixir files:

- `indent_style` is set to `space` as it is enforced by `mix format`
- `indent_size` is set to `2` as it is enforced by `mix format`

Only other option worth considering is `max_line_length` that is
[supported by few official plugins][1], but as `Code.format_*` functions 
will not parse that file, I preferred to not set it by default to not 
introduce confusion.

[1]: https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#max_line_length
[2]: https://editorconfig.org/#download