### PR TITLE
Show Erlang docs directly in the shell

### DIFF
--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -136,8 +136,7 @@ defmodule IO.ANSI.Docs do
     end
   end
 
-  defp traverse_erlang_html({:div, attributes, entries}, indent, options) do
-    class = attributes[:class]
+  defp traverse_erlang_html({:div, [class: class] ++ _, entries}, indent, options) do
     prefix = indent <> quote_prefix(options)
 
     content =
@@ -221,7 +220,6 @@ defmodule IO.ANSI.Docs do
 
   defp traverse_erlang_html({:dt, _, entries}, indent, options) do
     ["#{indent}  ", @bullet_text | handle_erlang_html_text(entries, indent <> "    ", options)]
-    |> newline_cons()
   end
 
   defp traverse_erlang_html({:dd, _, entries}, indent, options) do
@@ -251,6 +249,17 @@ defmodule IO.ANSI.Docs do
         ". " | handle_erlang_html_text(lines, indent <> "     ", options)
       ]
     end
+  end
+
+  defp traverse_erlang_html({tag, _, entries}, indent, options) do
+    [
+      indent <> "<#{tag}>\n",
+      traverse_erlang_html(entries, indent <> "    ", options)
+      |> IO.iodata_to_binary()
+      |> String.trim_trailing(),
+      "\n" <> indent <> "</#{tag}>"
+    ]
+    |> newline_cons()
   end
 
   defp newline_cons(text) do

--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -150,7 +150,8 @@ defmodule IO.ANSI.Docs do
       prefix,
       class |> to_string() |> String.upcase(),
       "\n#{prefix}\n#{prefix}" | String.replace(content, "\n", "\n#{prefix}")
-    ] |> newline_cons()
+    ]
+    |> newline_cons()
   end
 
   defp traverse_erlang_html({:p, _, entries}, indent, options) do

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -4,8 +4,8 @@ defmodule IO.ANSI.DocsTest do
   use ExUnit.Case, async: true
   import ExUnit.CaptureIO
 
-  def format_heading(str) do
-    capture_io(fn -> IO.ANSI.Docs.print_heading(str, []) end) |> String.trim_trailing()
+  def format_headings(list) do
+    capture_io(fn -> IO.ANSI.Docs.print_headings(list, []) end) |> String.trim_trailing()
   end
 
   def format_metadata(map) do
@@ -18,10 +18,19 @@ defmodule IO.ANSI.DocsTest do
 
   describe "heading" do
     test "is formatted" do
-      result = format_heading("wibble")
+      result = format_headings(["foo"])
       assert String.starts_with?(result, "\e[0m\n\e[7m\e[33m")
       assert String.ends_with?(result, "\e[0m\n\e[0m")
-      assert String.contains?(result, " wibble ")
+      assert String.contains?(result, " foo ")
+    end
+
+    test "multiple entries formatted" do
+      result = format_headings(["foo", "bar"])
+      assert :binary.matches(result, "\e[0m\n\e[7m\e[33m") |> length == 2
+      assert String.starts_with?(result, "\e[0m\n\e[7m\e[33m")
+      assert String.ends_with?(result, "\e[0m\n\e[0m")
+      assert String.contains?(result, " foo ")
+      assert String.contains?(result, " bar ")
     end
   end
 

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -13,7 +13,12 @@ defmodule IO.ANSI.DocsTest do
   end
 
   def format_markdown(str, opts \\ []) do
-    capture_io(fn -> IO.ANSI.Docs.print(str, "text/markdown", opts) end) |> String.trim_trailing()
+    capture_io(fn -> IO.ANSI.Docs.print(str, "text/markdown", opts) end)
+    |> String.trim_trailing()
+  end
+
+  def format_erlang(str, opts \\ []) do
+    capture_io(fn -> IO.ANSI.Docs.print(str, "application/erlang+html", opts) end)
   end
 
   describe "heading" do
@@ -547,6 +552,187 @@ defmodule IO.ANSI.DocsTest do
         |> String.trim_trailing()
 
       assert format_markdown(table) == expected
+    end
+  end
+
+  describe "erlang" do
+    @hello_world [{:p, [], ["Hello"]}, {:p, [], ["World"]}]
+
+    test "text" do
+      assert format_erlang("Hello world") == "Hello world"
+    end
+
+    test "skips line breaks" do
+      assert format_erlang([{:p, [], ["Hello"]}, {:br, [], []}, {:p, [], ["World"]}]) ==
+               "Hello\n\nWorld\n\n"
+    end
+
+    test "paragraphs" do
+      assert format_erlang(@hello_world) == "Hello\n\nWorld\n\n"
+    end
+
+    test "code chunks" do
+      code = """
+      def foo do
+        :bar
+      end\
+      """
+
+      assert format_erlang({:pre, [], [{:code, [], [code]}]}) == """
+                 def foo do
+                   :bar
+                 end
+
+             """
+    end
+
+    test "unordered lists" do
+      assert format_erlang([{:ul, [], [{:li, [], ["Hello"]}, {:li, [], ["World"]}]}]) ==
+               "  • Hello\n\n  • World\n\n"
+
+      assert format_erlang([{:ul, [], [{:li, [], [@hello_world]}]}]) ==
+               "  • Hello\n\n    World\n\n"
+
+      assert format_erlang([
+               {:ul, [], [{:li, [], [{:p, [], ["Hello"]}]}, {:li, [], [{:p, [], ["World"]}]}]}
+             ]) ==
+               "  • Hello\n\n  • World\n\n"
+    end
+
+    test "ordered lists" do
+      assert format_erlang([{:ol, [], [{:li, [], ["Hello"]}, {:li, [], ["World"]}]}]) ==
+               "  1. Hello\n\n  2. World\n\n"
+
+      assert format_erlang([
+               {:ol, [], [{:li, [], [{:p, [], ["Hello"]}]}, {:li, [], [{:p, [], ["World"]}]}]}
+             ]) ==
+               "  1. Hello\n\n  2. World\n\n"
+    end
+
+    test "admonition blocks" do
+      assert format_erlang([{:div, [class: "warning"], @hello_world}]) == """
+             \e[90m> \e[0mWARNING
+             \e[90m> \e[0m
+             \e[90m> \e[0mHello
+             \e[90m> \e[0m
+             \e[90m> \e[0mWorld
+
+             """
+    end
+
+    test "headers" do
+      assert format_erlang([{:h1, [], ["Hello"]}]) ==
+               "\e[33m# Hello\e[0m\n\n"
+
+      assert format_erlang([{:h2, [], ["Hello"]}]) ==
+               "\e[33m## Hello\e[0m\n\n"
+
+      assert format_erlang([{:h3, [], ["Hello"]}]) ==
+               "\e[33m### Hello\e[0m\n\n"
+
+      assert format_erlang([{:h4, [], ["Hello"]}]) ==
+               "\e[33m#### Hello\e[0m\n\n"
+
+      assert format_erlang([{:h5, [], ["Hello"]}]) ==
+               "\e[33m##### Hello\e[0m\n\n"
+
+      assert format_erlang([{:h6, [], ["Hello"]}]) ==
+               "\e[33m###### Hello\e[0m\n\n"
+
+      assert format_erlang([{:h1, [], [{:code, [], ["Hello"]}]}]) ==
+               "\e[33m# \e[36mHello\e[0m\e[0m\n\n"
+
+      assert format_erlang([{:h2, [], [{:code, [], ["Hello"]}]}]) ==
+               "\e[33m## \e[36mHello\e[0m\e[0m\n\n"
+
+      assert format_erlang([{:h3, [], [{:code, [], ["Hello"]}]}]) ==
+               "\e[33m### \e[36mHello\e[0m\e[0m\n\n"
+
+      assert format_erlang([{:h4, [], [{:code, [], ["Hello"]}]}]) ==
+               "\e[33m#### \e[36mHello\e[0m\e[0m\n\n"
+
+      assert format_erlang([{:h5, [], [{:code, [], ["Hello"]}]}]) ==
+               "\e[33m##### \e[36mHello\e[0m\e[0m\n\n"
+
+      assert format_erlang([{:h6, [], [{:code, [], ["Hello"]}]}]) ==
+               "\e[33m###### \e[36mHello\e[0m\e[0m\n\n"
+    end
+
+    test "inline tags" do
+      assert format_erlang([{:i, [], ["Hello"]}]) == "\e[4mHello\e[0m"
+      assert format_erlang([{:i, [], ["Hello"]}], enabled: false) == "_Hello_"
+
+      assert format_erlang([{:em, [], ["Hello"]}]) == "\e[1mHello\e[0m"
+      assert format_erlang([{:em, [], ["Hello"]}], enabled: false) == "*Hello*"
+
+      assert format_erlang([{:code, [], ["Hello"]}]) == "\e[36mHello\e[0m"
+      assert format_erlang([{:code, [], ["Hello"]}], enabled: false) == "`Hello`"
+    end
+
+    test "inline tags within paragraphs" do
+      assert format_erlang([{:p, [], [[{:em, [], ["Hello"]}, {:code, [], ["World"]}]]}]) ==
+               "\e[1mHello\e[0m\e[36mWorld\e[0m"
+    end
+
+    test "inline tags within list item" do
+      assert format_erlang([
+               {:ul, [], [{:li, [], [{:em, [], ["Hello"]}, {:code, [], ["World"]}]}]}
+             ]) ==
+               "  • \e[1mHello\e[0m\e[36mWorld\e[0m\n\n"
+    end
+
+    test "links" do
+      assert format_erlang([{:a, [], ["Hello"]}]) == "Hello"
+      assert format_erlang([{:a, [href: "foo/bar"], ["Hello"]}]) == "Hello (foo/bar)"
+    end
+
+    test "definition lists" do
+      assert format_erlang([{:dl, [], [[{:dt, [], ["Hello"]}, {:dd, [], ["World"]}]]}]) == """
+               • Hello
+
+                 World
+
+             """
+    end
+
+    test "typespecs" do
+      assert format_erlang([{:ul, [class: "types"], [{:li, [], ["Hello"]}, {:li, [], ["World"]}]}]) ==
+               """
+               Typespecs:
+
+                   Hello
+                   World
+
+               """
+    end
+
+    test "extra markup" do
+      assert format_erlang([{:p, [], ["Hello"]}, {:unknown, [], ["Unknown"]}, {:p, [], ["World"]}]) ==
+               """
+               Hello
+
+               <unknown>
+               Unknown
+               </unknown>
+
+               World
+
+               """
+
+      assert format_erlang([
+               {:p, [], ["Hello"]},
+               {:unknown, [], [{:p, [], ["Unknown"]}]},
+               {:p, [], ["World"]}
+             ]) == """
+             Hello
+
+             <unknown>
+                 Unknown
+             </unknown>
+
+             World
+
+             """
     end
   end
 

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -326,27 +326,8 @@ defmodule IEx.HelpersTest do
     end
 
     test "prints non-Elixir module specs" do
-      assert capture_io(fn -> h(:timer.nonexistent_function()) end) ==
-               ":timer was not compiled with docs\n"
-
-      assert capture_io(fn -> h(:timer.nonexistent_function() / 1) end) ==
-               ":timer was not compiled with docs\n"
-
-      assert capture_io(fn -> h(:erlang.trace_pattern()) end) ==
-               ":erlang was not compiled with docs\n"
-
-      assert capture_io(fn -> h(:erlang.trace_pattern() / 2) end) ==
-               ":erlang was not compiled with docs\n"
-
-      assert capture_io(fn -> h(:timer.sleep() / 1) end) == """
-
-                                              :timer.sleep/1
-
-               @spec sleep(time) :: :ok when time: timeout()
-
-             Module was compiled without docs. Showing only specs.
-
-             """
+      assert capture_io(fn -> h(:timer.sleep() / 1) end) =~
+               "@spec sleep(time) :: :ok when time: timeout()"
     end
 
     test "prints module documentation" do
@@ -355,9 +336,6 @@ defmodule IEx.HelpersTest do
 
       assert capture_io(fn -> h(:whatever) end) ==
                "Could not load module :whatever, got: nofile\n"
-
-      assert capture_io(fn -> h(:lists) end) ==
-               ":lists was not compiled with docs\n"
     end
 
     test "prints function/macro documentation" do

--- a/lib/mix/lib/mix/tasks/help.ex
+++ b/lib/mix/lib/mix/tasks/help.ex
@@ -100,7 +100,7 @@ defmodule Mix.Tasks.Help do
   end
 
   defp print_doc(task, {doc, location, note}, opts) do
-    IO.ANSI.Docs.print_heading("mix #{task}", opts)
+    IO.ANSI.Docs.print_headings(["mix #{task}"], opts)
     IO.ANSI.Docs.print(doc, "text/markdown", opts)
     IO.puts("Location: #{location}")
     note && IO.puts("") && IO.ANSI.Docs.print(note, "text/markdown", opts)


### PR DESCRIPTION
Erlang/OTP 23 implements EEP 48, which allows us to show Erlang docs directly in IEx:

https://asciinema.org/a/1Kqwwkn0wMl0feePvWQwHe85G

This PR is tracking the development of said feature.