### PR TITLE
Fix File module rename tests on PASE

### DIFF
--- a/lib/elixir/test/elixir/file_test.exs
+++ b/lib/elixir/test/elixir/file_test.exs
@@ -85,7 +85,7 @@ defmodule FileTest do
 
       try do
         File.mkdir_p(Path.join(dest, "a"))
-        assert File.rename(src, dest) == {:error, :eisdir}
+        assert File.rename(src, dest) in [{:error, :eisdir}, {:error, :eexist}]
         assert File.exists?(src)
         refute File.exists?(Path.join(dest, "file.txt"))
       after
@@ -245,7 +245,7 @@ defmodule FileTest do
 
       try do
         assert File.exists?(src)
-        assert File.rename(src, dest) == {:error, :einval}
+        assert File.rename(src, dest) in [{:error, :einval}, {:error, :eexist}]
         assert File.exists?(src)
       after
         File.rm_rf(src)


### PR DESCRIPTION
IBM i PASE implements rename in a slightly weird way due to it
wrapping the native syscall. Expect this in the File module's
rename test when expecting an error. Fixes #9858.

This should be the behaviour documented (different from
AIX, which it's emulating, and strange for POSIX):

https://www.ibm.com/support/knowledgecenter/ssw_ibm_i_74/apis/renameun.htm