### PR TITLE
Add guards to Calendar.strftime/3

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -503,7 +503,8 @@ defmodule Calendar do
   """
   @doc since: "1.11.0"
   @spec strftime(map(), String.t(), keyword()) :: String.t()
-  def strftime(date_or_time_or_datetime, string_format, user_options \\ []) do
+  def strftime(date_or_time_or_datetime, string_format, user_options \\ [])
+      when is_map(date_or_time_or_datetime) and is_binary(string_format) do
     parse(
       string_format,
       date_or_time_or_datetime,


### PR DESCRIPTION
This improves the error message when we accidentally use the wrong order
of arguments.

Before

    iex(1)> Calendar.strftime("%h", Time.utc_now())
    ** (FunctionClauseError) no function clause matching in Calendar.parse/4

        The following arguments were given to Calendar.parse/4:

            # 1
            ~T[12:26:18.591978]

            # 2
            "%h"

            # 3
            %{
              abbreviated_day_of_week_names: #Function<4.80759775/1 in Calendar.options/1>,
              abbreviated_month_names: #Function<3.80759775/1 in Calendar.options/1>,
              am_pm_names: #Function<0.80759775/1 in Calendar.options/1>,
              day_of_week_names: #Function<2.80759775/1 in Calendar.options/1>,
              month_names: #Function<1.80759775/1 in Calendar.options/1>,
              preferred_date: "%Y-%m-%d",
              preferred_date_invoked: false,
              preferred_datetime: "%Y-%m-%d %H:%M:%S",
              preferred_datetime_invoked: false,
              preferred_time: "%H:%M:%S",
              preferred_time_invoked: false
            }

            # 4
            []

        Attempted function clauses (showing 3 out of 3):

            defp parse("", _datetime, _format_options, acc)
            defp parse(<<"%", rest::binary()>>, datetime, format_options, acc)
            defp parse(<<char, rest::binary()>>, datetime, format_options, acc)

        (elixir 1.11.0-dev) lib/calendar.ex:516: Calendar.parse/4
        (elixir 1.11.0-dev) lib/calendar.ex:507: Calendar.strftime/3

After:

    iex(1)> Calendar.strftime("%h", Time.utc_now())
    ** (FunctionClauseError) no function clause matching in Calendar.strftime/3

        The following arguments were given to Calendar.strftime/3:

            # 1
            "%h"

            # 2
            ~T[12:28:04.638790]

            # 3
            []

        Attempted function clauses (showing 1 out of 1):

            def strftime(date_or_time_or_datetime, string_format, user_options) when is_map(date_or_time_or_datetime) and is_binary(string_format)

        (elixir 1.11.0-dev) lib/calendar.ex:506: Calendar.strftime/3