### PR TITLE
Return [{mod, bin}] from Code.compile_file/2, require_file/2, load_file/2

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -1447,6 +1447,6 @@ defmodule Code do
   defp verify_loaded(loaded) do
     maps_binaries = Enum.map(loaded, fn {_module, map, binary} -> {map, binary} end)
     Module.ParallelChecker.verify(maps_binaries, [])
-    Enum.map(loaded, fn {module, map, _binary} -> {module, map} end)
+    Enum.map(loaded, fn {module, _map, binary} -> {module, binary} end)
   end
 end

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -103,12 +103,18 @@ defmodule CodeTest do
   test "compile_file/1" do
     assert Code.compile_file(fixture_path("code_sample.exs")) == []
     refute fixture_path("code_sample.exs") in Code.required_files()
+
+    assert [{CompileSample, binary}] = Code.compile_file(fixture_path("compile_sample.ex"))
+    assert is_binary(binary)
+  after
+    :code.purge(CompileSample)
+    :code.delete(CompileSample)
   end
 
   test "compile_file/1 also emits checker warnings" do
     output =
       ExUnit.CaptureIO.capture_io(:stderr, fn ->
-        Code.compile_file(PathHelpers.fixture_path("checker_warning.exs"))
+        Code.compile_file(fixture_path("checker_warning.exs"))
       end)
 
     assert output =~ "incompatible types"
@@ -122,8 +128,13 @@ defmodule CodeTest do
     Code.unrequire_files([fixture_path("code_sample.exs")])
     refute fixture_path("code_sample.exs") in Code.required_files()
     assert Code.require_file(fixture_path("code_sample.exs")) != nil
+
+    assert [{CompileSample, binary}] = Code.require_file(fixture_path("compile_sample.ex"))
+    assert is_binary(binary)
   after
-    Code.unrequire_files([fixture_path("code_sample.exs")])
+    Code.unrequire_files([fixture_path("code_sample.exs"), fixture_path("compile_sample.ex")])
+    :code.purge(CompileSample)
+    :code.delete(CompileSample)
   end
 
   describe "string_to_quoted/2" do


### PR DESCRIPTION
This was the documented behaviour on 1.9 that was broken on v1.10: (version `git` is this branch)

    $ cat a.ex
    defmodule A, do: nil

    $ for v in 1.9.4-otp-22 1.10.2-otp-22 git; do asdf local elixir $v && echo $v; elixir -e 'IO.inspect Code.compile_file("a.ex")'; done
    1.9.4-otp-22
    [{A, <<70, 79, ...>>}
    1.10.2-otp-22
    [{A, %{attributes: [], ...}]
    git
    [{A, <<70, 79, ...>>}

    $ for v in 1.9.4-otp-22 1.10.2-otp-22 git; do asdf local elixir $v && echo $v; elixir -e 'IO.inspect Code.require_file("a.ex")'; done
    1.9.4-otp-22
    [{A, <<70, 79, ...>>}]
    1.10.2-otp-22
    [{A, %{attributes: [], ...}]
    git
    [{A, <<70, 79, ...>>}]

    $ for v in 1.9.4-otp-22 1.10.2-otp-22 git; do asdf local elixir $v && echo $v; elixir -e 'IO.inspect Code.load_file("a.ex")'; done
    1.9.4-otp-22
    [{A, <<70, 79, ...>>}]
    1.10.2-otp-22
    warning: Code.load_file/1 is deprecated. Use Code.require_file/2 or Code.compile_file/2 instead
      nofile:1

    [{A, %{attributes: [], ...}]
    git
    warning: Code.load_file/1 is deprecated. Use Code.require_file/2 or Code.compile_file/2 instead
      nofile:1

    [{A, <<70, 79, ...>>}]