### PR TITLE
Documentation wording improved for List.Chars moduledoc

### DIFF
--- a/lib/elixir/lib/list/chars.ex
+++ b/lib/elixir/lib/list/chars.ex
@@ -3,7 +3,7 @@ defprotocol List.Chars do
   The `List.Chars` protocol is responsible for
   converting a structure to a charlist (only if applicable).
 
-  The only function required to be implemented is
+  The only function that must be implemented is
   `to_charlist/1` which does the conversion.
 
   The `to_charlist/1` function automatically imported


### PR DESCRIPTION
I thought the phrase "required to be implemented" was a little bit awkward. Here's an improvement IMHO!