### PR TITLE
mix release: only include the compiling host's exe by default.

### DIFF
--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -437,11 +437,12 @@ defmodule Mix.Tasks.Release do
 
     * `:include_executables_for` - a list of atoms detailing for which Operating
       Systems executable files should be generated for. By default, it is set to
-      `[:unix, :windows]`. You can customize those as follows:
+      `[:unix]` or `[:windows]` depending on the host machine.
+      You can customize those as follows:
 
           releases: [
             demo: [
-              include_executables_for: [:unix] # Or [:windows] or []
+              include_executables_for: [:unix, :windows] # Or []
             ]
           ]
 
@@ -1063,7 +1064,7 @@ defmodule Mix.Tasks.Release do
       #     elixir.bat
       #     iex
       #     iex.bat
-      {:executables, Keyword.get(release.options, :include_executables_for, [:unix, :windows])}
+      {:executables, Keyword.get(release.options, :include_executables_for, default_executable())}
       # lib/APP_NAME-APP_VSN/
       | Map.keys(release.applications)
     ]
@@ -1071,6 +1072,13 @@ defmodule Mix.Tasks.Release do
     |> Stream.run()
 
     copy_overlays(release)
+  end
+
+  defp default_executable() do
+    case :os.type() do
+      {:unix, _} -> [:unix]
+      {:win32, _} -> [:windows]
+    end
   end
 
   defp make_tar(release) do


### PR DESCRIPTION
Hi!
I will migrate to mix release from distillery at work soon, so I was trying things out. I think it would be better if mix release didn't include Windows config files and executables on Unix systems and vice versa. To me it looks cleaner and more sensible if the tool output doesn't mention a different system at all (by default.) If somebody really needs to release for both systems, they can easily do so just like the documentation describes it (updated in this PR.) I fixed two tests but only executed on Linux.

I guess mix release.init shouldn't create an env.bat.eex file on Unix either, or a *.sh file on Windows. I could correct that as well, but let's see what you think of this PR first.