### PR TITLE
Add deprecation warning for Kernel.apply/2 as it is going to be remov…

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -259,7 +259,7 @@ defmodule Kernel do
       4
 
   """
-  @spec apply(fun, [any]) :: any
+  @deprecated "Use Kernel.apply/3 instead"
   def apply(fun, args) do
     :erlang.apply(fun, args)
   end


### PR DESCRIPTION
…ed from erlang

There's a warning there saying that it is marked for removal so it makes sense to me to deprecate it in Elixir!

Source:  http://erlang.org/doc/man/erlang.html#apply-2