### PR TITLE
Do not update packages on FreeBSD (CI)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -143,7 +143,6 @@ test_freebsd_task:
     LC_ALL: en_US.UTF-8
 
   install_script:
-    - sudo pkg update
     - pkg install -y erlang git gmake
     - rm -rf .git
     - gmake compile


### PR DESCRIPTION
FreeBSD builds are failing because `pkg` refuses to install 
new packages that were built using more recent OS versions. 

The build does not update the packages to avoid that error.