### PR TITLE
Add default and enforce keys in Version struct

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -95,7 +95,9 @@ defmodule Version do
   """
 
   import Kernel, except: [match?: 2]
-  defstruct [:major, :minor, :patch, :pre, :build]
+
+  @enforce_keys [:major, :minor, :patch]
+  defstruct [:major, :minor, :patch, :build, pre: []]
 
   @type version :: String.t() | t
   @type requirement :: String.t() | Version.Requirement.t()

--- a/lib/elixir/test/elixir/version_test.exs
+++ b/lib/elixir/test/elixir/version_test.exs
@@ -116,6 +116,7 @@ defmodule VersionTest do
     assert Version.parse!("1.0.0-dev+lol") |> to_string == "1.0.0-dev+lol"
     assert Version.parse!("1.0.0-0") |> to_string == "1.0.0-0"
     assert Version.parse!("1.0.0-rc.0") |> to_string == "1.0.0-rc.0"
+    assert %Version{major: 1, minor: 0, patch: 0} |> to_string() == "1.0.0"
   end
 
   test "match?/2 with invalid versions" do


### PR DESCRIPTION
String.Char.to_string/1 was failing due to unexpected`nil` value in `pre` field.

I did not know if tests were necessary or not, but it seems like added line will raise without a fix.

Related to #9885