### PR TITLE
Includes an example of how to use ANSI functions to format output

### DIFF
--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -36,6 +36,7 @@ defmodule IO.ANSI do
 
       IO.puts(IO.ANSI.format([:blue_background, "Example"]))
 
+  In case ANSI is disabled, the ANSI escape sequences are simply discarded.
   """
 
   import IO.ANSI.Sequence

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -28,7 +28,7 @@ defmodule IO.ANSI do
   these functions is to concatenate their output with text.
 
       formatted_text = IO.ANSI.blue_background() <> "Example" <> IO.ANSI.reset()
-      IO.puts formatted_text
+      IO.puts(formatted_text)
 
   A higher level and more convenient API is also available via `IO.ANSI.format/1`,
   where you use atoms to represent each ANSI escape sequence:

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -33,7 +33,7 @@ defmodule IO.ANSI do
   A higher level and more convenient API is also available via `IO.ANSI.format/1`,
   where you use atoms to represent each ANSI escape sequence:
 
-      IO.puts IO.ANSI.format [:blue_background, "Example", :reset]
+      IO.puts(IO.ANSI.format([:blue_background, "Example", :reset]))
 
   """
 

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -21,6 +21,15 @@ defmodule IO.ANSI do
   [ANSI escape sequences](https://en.wikipedia.org/wiki/ANSI_escape_code)
   are characters embedded in text used to control formatting, color, and
   other output options on video text terminals.
+
+  ## Examples
+
+  Because the ANSI escape sequences are embedded in text, the normal usage of
+  these functions is to concatenate their output with text.
+  ```
+  formatted_text = IO.ANSI.blue_background() <> "Example" <> IO.ANSI.reset()
+  IO.puts formatted_text
+  ```
   """
 
   import IO.ANSI.Sequence

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -26,10 +26,15 @@ defmodule IO.ANSI do
 
   Because the ANSI escape sequences are embedded in text, the normal usage of
   these functions is to concatenate their output with text.
-  ```
-  formatted_text = IO.ANSI.blue_background() <> "Example" <> IO.ANSI.reset()
-  IO.puts formatted_text
-  ```
+
+      formatted_text = IO.ANSI.blue_background() <> "Example" <> IO.ANSI.reset()
+      IO.puts formatted_text
+
+  A higher level and more convenient API is also available via `IO.ANSI.format/1`,
+  where you use atoms to represent each ANSI escape sequence:
+
+      IO.puts IO.ANSI.format [:blue_background, "Example", :reset]
+
   """
 
   import IO.ANSI.Sequence

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -31,7 +31,8 @@ defmodule IO.ANSI do
       IO.puts(formatted_text)
 
   A higher level and more convenient API is also available via `IO.ANSI.format/1`,
-  where you use atoms to represent each ANSI escape sequence:
+  where you use atoms to represent each ANSI escape sequence and by default 
+  checks if ANSI is enabled:
 
       IO.puts(IO.ANSI.format([:blue_background, "Example"]))
 

--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -33,7 +33,7 @@ defmodule IO.ANSI do
   A higher level and more convenient API is also available via `IO.ANSI.format/1`,
   where you use atoms to represent each ANSI escape sequence:
 
-      IO.puts(IO.ANSI.format([:blue_background, "Example", :reset]))
+      IO.puts(IO.ANSI.format([:blue_background, "Example"]))
 
   """
 


### PR DESCRIPTION
Unless you know exactly what ANSI codes are and how they work, the existing documentation page doesn't offer many clues to people who just want to colorize their terminal output.

This PR includes an example demonstrating how to use the functions.