### PR TITLE
Document operators on the Operators page

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -161,6 +161,9 @@ defprotocol Enumerable do
 
   Otherwise it should return `{:error, __MODULE__}` and a default algorithm
   built on top of `reduce/3` that runs in linear time will be used.
+
+  The [`in`](`in/2`) and [`not in`](`in/2`) operators work by calling this
+  function.
   """
   @spec member?(t, term) :: {:ok, boolean} | {:error, module}
   def member?(enumerable, element)
@@ -1672,6 +1675,9 @@ defmodule Enum do
       iex> Enum.member?([:a, :b, :c], :d)
       false
 
+
+  The [`in`](`in/2`) and [`not in`](`in/2`) operators work by calling this
+  function.
   """
   @spec member?(t, element) :: boolean
   def member?(enumerable, element) when is_list(enumerable) do

--- a/lib/elixir/pages/Operators.md
+++ b/lib/elixir/pages/Operators.md
@@ -68,7 +68,7 @@ Finally, these operators appear in the precedence table above but are only meani
 
 ## Comparison operators
 
-Elixir provides the following built-in comparison operators:
+Elixir provides the following built-in comparison operators (all of which can be overridden or used in guards):
 
   * [`==`](`==/2`) - equality
   * [`===`](`===/2`) - strict equality

--- a/lib/elixir/pages/Operators.md
+++ b/lib/elixir/pages/Operators.md
@@ -68,7 +68,7 @@ Finally, these operators appear in the precedence table above but are only meani
 
 ## Comparison operators
 
-Elixir provides the following built-in comparison operators (all of which can be overridden or used in guards):
+Elixir provides the following built-in comparison operators (all of which can be used in guards):
 
   * [`==`](`==/2`) - equality
   * [`===`](`===/2`) - strict equality

--- a/lib/elixir/pages/Operators.md
+++ b/lib/elixir/pages/Operators.md
@@ -29,6 +29,41 @@ Operator                                                                        
 `when`                                                                                   | Right to left
 `<-` `\\`                                                                                | Left to right
 
+## General operators
+
+Elixir provides the following built-in operators that are defined as functions that can be overridden:
+
+  * [`@`](`@/1`) - module attribute definition and access
+  * [`+`](`+/1`) and [`-`](`-/1`) - unary positive/negative
+  * [`!`](`!/1`) and [`not`](`not/1`) - relaxed and strict logical not
+  * [`*`](`*/2`), [`/`](`//2`), [`+`](`+/2`), and [`-`](`-/2`) - arithmetic
+  * [`++`](`++/2`) and [`--`](`--/2`) - list concatenation and pruning
+  * [`..`](`../2`) - range creation
+  * [`<>`](`<>/2`) - binary concatenation
+  * [`in`](`in/2`) and [`not in`](`in/2`) - shorthand for [`Enum.member?`](`Enum.member?/2`)
+  * [`|>`](`|>/2`) - function pipeline
+  * [`=~`](`=~/2`) - shorthand for [`Regex.match?/2`](`Regex.match?/2`)
+  * [`&&`](`&&/2`) and [`and`](`and/2`) - relaxed and strict logical and
+  * [`||`](`||/2`) and [`or`](`or/2`) - relaxed and strict logical or
+
+Some other operators are special forms and cannot be overridden:
+
+  * [`^`](`^/1`) - pin
+  * [`.`](`./2`) - remote and anonymous calls, and alias join
+  * [`=`](`=/2`) - match
+  * [`&`](`&/1`) - function capture
+  * [`::`](Kernel.SpecialForms.html#::/2) - type
+
+There are a few operators that Elixir parses but doesn't actually use.
+See [Custom and overridden operators](#custom-and-overridden-operators) below for a list.
+
+Finally, these operators appear in the precedence table above but are only meaningful within certain other constructs:
+
+  * `=>` - see [`%{}`](`%{}/1`)
+  * `when` - see [Guards](patterns-and-guards.html#guards)
+  * `<-` - see [`for`](`for/1`) and [`with`](`with/1`)
+  * `\\` - see [Default arguments](Kernel.html#def/2-default-arguments)
+
 ## Comparison operators
 
 Elixir provides the following built-in comparison operators:

--- a/lib/elixir/pages/Operators.md
+++ b/lib/elixir/pages/Operators.md
@@ -41,7 +41,7 @@ Many of them can be used in guards; see the [list of allowed guard functions and
   * [`++`](`++/2`) and [`--`](`--/2`) - list concatenation and pruning
   * [`..`](`../2`) - range creation
   * [`<>`](`<>/2`) - binary concatenation
-  * [`in`](`in/2`) and [`not in`](`in/2`) - shorthand for [`Enum.member?`](`Enum.member?/2`)
+  * [`in`](`in/2`) and [`not in`](`in/2`) - shorthands for [`Enum.member?`](`Enum.member?/2`)
   * [`|>`](`|>/2`) - function pipeline
   * [`=~`](`=~/2`) - shorthand for [`Regex.match?/2`](`Regex.match?/2`)
   * [`&&`](`&&/2`) and [`and`](`and/2`) - relaxed and strict logical and

--- a/lib/elixir/pages/Operators.md
+++ b/lib/elixir/pages/Operators.md
@@ -31,7 +31,8 @@ Operator                                                                        
 
 ## General operators
 
-Elixir provides the following built-in operators that are defined as functions that can be overridden:
+Elixir provides the following built-in operators that are defined as functions that can be overridden.
+Many of them can be used in guards; see the [list of allowed guard functions and operators](patterns-and-guards.html#list-of-allowed-functions-and-operators).
 
   * [`@`](`@/1`) - module attribute definition and access
   * [`+`](`+/1`) and [`-`](`-/1`) - unary positive/negative

--- a/lib/elixir/pages/Operators.md
+++ b/lib/elixir/pages/Operators.md
@@ -47,6 +47,9 @@ Many of them can be used in guards; see the [list of allowed guard functions and
   * [`&&`](`&&/2`) and [`and`](`and/2`) - relaxed and strict logical and
   * [`||`](`||/2`) and [`or`](`or/2`) - relaxed and strict logical or
 
+Additionally, there are a few other operators that Elixir parses but doesn't actually use.
+See [Custom and overridden operators](#custom-and-overridden-operators) below for a list.
+
 Some other operators are special forms and cannot be overridden:
 
   * [`^`](`^/1`) - pin
@@ -55,10 +58,7 @@ Some other operators are special forms and cannot be overridden:
   * [`&`](`&/1`) - function capture
   * [`::`](Kernel.SpecialForms.html#::/2) - type
 
-There are a few operators that Elixir parses but doesn't actually use.
-See [Custom and overridden operators](#custom-and-overridden-operators) below for a list.
-
-Finally, these operators appear in the precedence table above but are only meaningful within certain other constructs:
+Finally, these operators appear in the precedence table above but are only meaningful within certain constructs:
 
   * `=>` - see [`%{}`](`%{}/1`)
   * `when` - see [Guards](patterns-and-guards.html#guards)

--- a/lib/elixir/pages/Operators.md
+++ b/lib/elixir/pages/Operators.md
@@ -31,8 +31,7 @@ Operator                                                                        
 
 ## General operators
 
-Elixir provides the following built-in operators that are defined as functions that can be overridden.
-Many of them can be used in guards; see the [list of allowed guard functions and operators](patterns-and-guards.html#list-of-allowed-functions-and-operators).
+Elixir provides the following built-in operators that are defined as functions that can be overridden:
 
   * [`@`](`@/1`) - module attribute definition and access
   * [`+`](`+/1`) and [`-`](`-/1`) - unary positive/negative
@@ -47,8 +46,10 @@ Many of them can be used in guards; see the [list of allowed guard functions and
   * [`&&`](`&&/2`) and [`and`](`and/2`) - relaxed and strict logical and
   * [`||`](`||/2`) and [`or`](`or/2`) - relaxed and strict logical or
 
+Many of those can be used in guards; consult the [list of allowed guard functions and operators](patterns-and-guards.html#list-of-allowed-functions-and-operators).
+
 Additionally, there are a few other operators that Elixir parses but doesn't actually use.
-See [Custom and overridden operators](#custom-and-overridden-operators) below for a list.
+See [Custom and overridden operators](#custom-and-overridden-operators) below for a list and for guidelines about their use.
 
 Some other operators are special forms and cannot be overridden:
 


### PR DESCRIPTION
Currently, the [Operators page](https://hexdocs.pm/elixir/1.10.2/operators.html) includes a precedence table, plus information about comparison operators and customization/overriding. It really should have documentation for *all* of the operators, or at least pointers to that documentation (especially since the [Syntax reference page](https://hexdocs.pm/elixir/1.10.2/syntax-reference.html#operators) points you there for a "full reference"). This change fixes that situation.

I'm an Elixir newbie, so I may be wrong about some of the details here. Please point out anything I got wrong!

(Also: I noticed this when I was trying to learn the actual semantics and allowable usage of `in` and `not in`, and it took me a long time to finally find their documentation under Kernel / Guards. So I also added short notes to `Enum.member?/2` and `Enumerable.member?/2` for other newcomers like me.)