### PR TITLE
Deprecate non-atom keys on put_env, get_env, fetch_env*, delete_env

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -618,6 +618,7 @@ defmodule Application do
   """
   @spec get_env(app, key, value) :: value
   def get_env(app, key, default \\ nil) when is_atom(app) do
+    maybe_warn_on_app_env_key(key)
     :application.get_env(app, key, default)
   end
 
@@ -628,6 +629,8 @@ defmodule Application do
   """
   @spec fetch_env(app, key) :: {:ok, value} | :error
   def fetch_env(app, key) when is_atom(app) do
+    maybe_warn_on_app_env_key(key)
+
     case :application.get_env(app, key) do
       {:ok, value} -> {:ok, value}
       :undefined -> :error
@@ -689,6 +692,7 @@ defmodule Application do
   """
   @spec put_env(app, key, value, timeout: timeout, persistent: boolean) :: :ok
   def put_env(app, key, value, opts \\ []) when is_atom(app) do
+    maybe_warn_on_app_env_key(key)
     :application.set_env(app, key, value, opts)
   end
 
@@ -734,8 +738,16 @@ defmodule Application do
   """
   @spec delete_env(app, key, timeout: timeout, persistent: boolean) :: :ok
   def delete_env(app, key, opts \\ []) when is_atom(app) do
+    maybe_warn_on_app_env_key(key)
     :application.unset_env(app, key, opts)
   end
+
+  # TODO: turn warning into error on Elixir v2.0
+  defp maybe_warn_on_app_env_key(key) when is_atom(key),
+    do: :ok
+
+  defp maybe_warn_on_app_env_key(key),
+    do: IO.warn("passing non-atom as application env key is deprecated (got: `#{inspect(key)}`)")
 
   @doc """
   Ensures the given `app` is started.

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -747,7 +747,7 @@ defmodule Application do
     do: :ok
 
   defp maybe_warn_on_app_env_key(app, key) do
-    message = "passing non-atom as application env key is deprecated (got: `#{inspect(key)}`)"
+    message = "passing non-atom as application env key is deprecated, got: #{inspect(key)}"
     IO.warn_once({Application, :key, app, key}, message, _stacktrace_drop_levels = 2)
   end
 

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -618,7 +618,7 @@ defmodule Application do
   """
   @spec get_env(app, key, value) :: value
   def get_env(app, key, default \\ nil) when is_atom(app) do
-    maybe_warn_on_app_env_key(key)
+    maybe_warn_on_app_env_key(app, key)
     :application.get_env(app, key, default)
   end
 
@@ -629,7 +629,7 @@ defmodule Application do
   """
   @spec fetch_env(app, key) :: {:ok, value} | :error
   def fetch_env(app, key) when is_atom(app) do
-    maybe_warn_on_app_env_key(key)
+    maybe_warn_on_app_env_key(app, key)
 
     case :application.get_env(app, key) do
       {:ok, value} -> {:ok, value}
@@ -692,7 +692,7 @@ defmodule Application do
   """
   @spec put_env(app, key, value, timeout: timeout, persistent: boolean) :: :ok
   def put_env(app, key, value, opts \\ []) when is_atom(app) do
-    maybe_warn_on_app_env_key(key)
+    maybe_warn_on_app_env_key(app, key)
     :application.set_env(app, key, value, opts)
   end
 
@@ -738,16 +738,18 @@ defmodule Application do
   """
   @spec delete_env(app, key, timeout: timeout, persistent: boolean) :: :ok
   def delete_env(app, key, opts \\ []) when is_atom(app) do
-    maybe_warn_on_app_env_key(key)
+    maybe_warn_on_app_env_key(app, key)
     :application.unset_env(app, key, opts)
   end
 
   # TODO: turn warning into error on Elixir v2.0
-  defp maybe_warn_on_app_env_key(key) when is_atom(key),
+  defp maybe_warn_on_app_env_key(_app, key) when is_atom(key),
     do: :ok
 
-  defp maybe_warn_on_app_env_key(key),
-    do: IO.warn("passing non-atom as application env key is deprecated (got: `#{inspect(key)}`)")
+  defp maybe_warn_on_app_env_key(app, key) do
+    message = "passing non-atom as application env key is deprecated (got: `#{inspect(key)}`)"
+    IO.warn_once({Application, :key, app, key}, message, _stacktrace_drop_levels = 2)
+  end
 
   @doc """
   Ensures the given `app` is started.

--- a/lib/elixir/test/elixir/application_test.exs
+++ b/lib/elixir/test/elixir/application_test.exs
@@ -41,7 +41,7 @@ defmodule ApplicationTest do
     end)
 
     assert_deprecated(fn ->
-      assert Application.fetch_env(:elixir, [:a, :b]) == {:ok, :c}
+      assert Application.fetch_env!(:elixir, [:a, :b]) == :c
     end)
   after
     assert_deprecated(fn ->

--- a/lib/elixir/test/elixir/application_test.exs
+++ b/lib/elixir/test/elixir/application_test.exs
@@ -43,10 +43,6 @@ defmodule ApplicationTest do
     assert_deprecated(fn ->
       assert Application.fetch_env(:elixir, [:a, :b]) == {:ok, :c}
     end)
-
-    assert_deprecated(fn ->
-      assert Application.fetch_env!(:elixir, [:a, :b]) == :c
-    end)
   after
     assert_deprecated(fn ->
       Application.delete_env(:elixir, [:a, :b])

--- a/lib/elixir/test/elixir/application_test.exs
+++ b/lib/elixir/test/elixir/application_test.exs
@@ -4,6 +4,7 @@ defmodule ApplicationTest do
   use ExUnit.Case, async: true
 
   import PathHelpers
+  import ExUnit.CaptureIO
 
   test "application environment" do
     assert_raise ArgumentError, ~r/because the application was not loaded\/started/, fn ->
@@ -28,6 +29,32 @@ defmodule ApplicationTest do
     assert Application.get_env(:elixir, :unknown, :default) == :default
   after
     Application.delete_env(:elixir, :unknown)
+  end
+
+  test "deprecated non-atom keys" do
+    assert_deprecated(fn ->
+      Application.put_env(:elixir, [:a, :b], :c)
+    end)
+
+    assert_deprecated(fn ->
+      assert Application.get_env(:elixir, [:a, :b]) == :c
+    end)
+
+    assert_deprecated(fn ->
+      assert Application.fetch_env(:elixir, [:a, :b]) == {:ok, :c}
+    end)
+
+    assert_deprecated(fn ->
+      assert Application.fetch_env!(:elixir, [:a, :b]) == :c
+    end)
+  after
+    assert_deprecated(fn ->
+      Application.delete_env(:elixir, [:a, :b])
+    end)
+  end
+
+  defp assert_deprecated(fun) do
+    assert capture_io(:stderr, fun) =~ ~r/passing non-atom as application env key is deprecated/
   end
 
   describe "compile environment" do

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -892,7 +892,7 @@ defmodule Logger do
     :logger.macro_log(%{}, level, msg, add_elixir_domain(metadata))
   end
 
-  # TODO: Remove that in Elixir 2.0
+  # TODO: Remove that in Elixir v2.0
   def __do_log__(level, other, metadata) do
     IO.warn(
       "passing #{inspect(other)} to Logger is deprecated, expected a map, a keyword list, a binary, or an iolist"


### PR DESCRIPTION
Typespecs already required an atom key but it was never enforced by
code. We're doing this because we eventually would like to support
passing a _path_ like:

    Application.get_env(:myapp, [:key, :foo, :bar])

and this way we will be consistent with recently added
`Application.compile_env/3`.

Another way to solve this issue, not part of this PR, is deprecate
`get_env`, `fetch_env` and `fetch_env!` in favour of a new `env/3` &
`env!/2` or `runtime_env/3` & `runtime_env!/2`.  The downside is we won't
have the `fetch_` (non-raising) function but fwiw we don't have it for
`compile_env` either. (If we deprecate, it should be on a really long
cycle becasue they are so ubiquitous. But if we start printing
deprecation warnings in libraries it's probably for the better. ;-))