### PR TITLE
Add `__mix_recompile__?/0` callback

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -248,8 +248,9 @@ defmodule Module do
   attribute allows the module to annotate which external resources
   have been used.
 
-  Tools like Mix may use this information to ensure the module is
-  recompiled in case any of the external resources change.
+  Tools may use this information to ensure the module is recompiled
+  in case any of the external resources change, see for example:
+  [`mix compile.elixir`](https://hexdocs.pm/mix/Mix.Tasks.Compile.Elixir.html).
 
   ### `@file`
 

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -351,7 +351,7 @@ defmodule Mix.Compilers.Elixir do
         kind: kind,
         sources: module_sources,
         struct: struct,
-        recompile?: recompile_module?(module)
+        recompile?: function_exported?(module, :__mix_recompile__?, 0)
       )
 
     modules = prepend_or_merge(modules, module, module(:module), module, existing_module?)

--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -1,11 +1,11 @@
 defmodule Mix.Compilers.Elixir do
   @moduledoc false
 
-  @manifest_vsn 5
+  @manifest_vsn 6
 
   import Record
 
-  defrecord :module, [:module, :kind, :sources, :struct]
+  defrecord :module, [:module, :kind, :sources, :struct, :recompile?]
 
   defrecord :source,
     source: nil,
@@ -77,12 +77,21 @@ defmodule Mix.Compilers.Elixir do
               into: mtimes_and_sizes(all_sources),
               do: {path, Mix.Utils.last_modified_and_size(path)}
 
-        # Plus the sources that have changed in disk
+        modules_to_recompile =
+          for module(module: module, recompile?: true) <- all_modules,
+              recompile_module?(module),
+              into: %{},
+              do: {module, true}
+
+        # Plus the sources that have changed on disk or any modules associated with them need to
+        # be recompiled
         changed =
-          for source(source: source, external: external, size: size) <- all_sources,
+          for source(source: source, external: external, size: size, modules: modules) <-
+                all_sources,
               {last_mtime, last_size} = Map.fetch!(sources_stats, source),
               times = Enum.map(external, &(sources_stats |> Map.fetch!(&1) |> elem(0))),
-              size != last_size or Mix.Utils.stale?([last_mtime | times], [modified]),
+              size != last_size or Mix.Utils.stale?([last_mtime | times], [modified]) or
+                Enum.any?(modules, &Map.has_key?(modules_to_recompile, &1)),
               do: source
 
         changed = new_paths ++ changed
@@ -341,12 +350,19 @@ defmodule Mix.Compilers.Elixir do
         module: module,
         kind: kind,
         sources: module_sources,
-        struct: struct
+        struct: struct,
+        recompile?: recompile_module?(module)
       )
 
     modules = prepend_or_merge(modules, module, module(:module), module, existing_module?)
     put_compiler_info({modules, structs, [source | sources], pending_modules, pending_structs})
     :ok
+  end
+
+  defp recompile_module?(module) do
+    Code.ensure_loaded?(module) and
+      function_exported?(module, :__mix_recompile__?, 0) and
+      module.__mix_recompile__?()
   end
 
   defp prepend_or_merge(collection, key, pos, value, true) do

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -32,7 +32,7 @@ defmodule Mix.Tasks.Compile.Elixir do
         end
 
         def __mix_recompile__?() do
-          Path.wildcard("*.txt") |> :erlang.md5() == unquote(paths_hash)
+          Path.wildcard("*.txt") |> :erlang.md5() != unquote(paths_hash)
         end
       end
 

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -15,6 +15,29 @@ defmodule Mix.Tasks.Compile.Elixir do
   Note it is important to recompile a file's dependencies as
   there are often compile time dependencies between them.
 
+  ## `__mix_recompile__?/0`
+
+  A module may export a `__mix_recompile__?/0` function that can cause the module to be recompiled
+  using custom rules. For example, `@external_resource` already adds a compile-time dependency on
+  an external file, however to depend on a _dynamic_ list of files we can do:
+
+      defmodule MyModule do
+        paths = Path.wildcard("*.txt")
+        paths_hash = :erlang.md5(paths)
+
+        for path <- paths do
+          @external_resource path
+        end
+
+        def __mix_recompile__?() do
+          Path.wildcard("*.txt") |> :erlang.md5() == unquote(paths_hash)
+        end
+      end
+
+  Compiler calls `__mix_recompile__?/0` for every module being compiled (or previously compiled)
+  and thus it is is very important to do there as little work as possible to not slow down the
+  compilation.
+
   ## Command line options
 
     * `--verbose` - prints each file being compiled

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -17,25 +17,23 @@ defmodule Mix.Tasks.Compile.Elixir do
 
   ## `__mix_recompile__?/0`
 
-  A module may export a `__mix_recompile__?/0` function that can cause the module to be recompiled
-  using custom rules. For example, `@external_resource` already adds a compile-time dependency on
-  an external file, however to depend on a _dynamic_ list of files we can do:
+  A module may export a `__mix_recompile__?/0` function that can
+  cause the module to be recompiled using custom rules. For example,
+  `@external_resource` already adds a compile-time dependency on an
+  external file, however to depend on a _dynamic_ list of files we
+  can do:
 
-      defmodule MyModule do
-        paths = Path.wildcard("*.txt")
-        paths_hash = :erlang.md5(paths)
+      defmodule MyModule do paths = Path.wildcard("*.txt")
+      paths_hash = :erlang.md5(paths)
 
-        for path <- paths do
-          @external_resource path
-        end
+        for path <- paths do @external_resource path end
 
-        def __mix_recompile__?() do
-          Path.wildcard("*.txt") |> :erlang.md5() == unquote(paths_hash)
-        end
-      end
+        def __mix_recompile__?() do Path.wildcard("*.txt") |>
+        :erlang.md5() == unquote(paths_hash) end end
 
-  Compiler calls `__mix_recompile__?/0` for every module being compiled (or previously compiled)
-  and thus it is is very important to do there as little work as possible to not slow down the
+  Compiler calls `__mix_recompile__?/0` for every module being
+  compiled (or previously compiled) and thus it is is very important
+  to do there as little work as possible to not slow down the
   compilation.
 
   ## Command line options

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -37,7 +37,7 @@ defmodule Mix.Tasks.Compile.Elixir do
       end
 
   Compiler calls `__mix_recompile__?/0` for every module being
-  compiled (or previously compiled) and thus it is is very important
+  compiled (or previously compiled) and thus it is very important
   to do there as little work as possible to not slow down the
   compilation.
 

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -39,6 +39,9 @@ defmodule Mix.Tasks.Compile.Elixir do
   to do there as little work as possible to not slow down the
   compilation.
 
+  If module has `@compile {:autoload, false}`, `__mix_recompile__?/0` will
+  not be used.
+
   ## Command line options
 
     * `--verbose` - prints each file being compiled

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -27,7 +27,9 @@ defmodule Mix.Tasks.Compile.Elixir do
         paths = Path.wildcard("*.txt")
         paths_hash = :erlang.md5(paths)
 
-        for path <- paths do @external_resource path end
+        for path <- paths do
+          @external_resource path
+        end
 
         def __mix_recompile__?() do
           Path.wildcard("*.txt") |> :erlang.md5() == unquote(paths_hash)

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -23,13 +23,16 @@ defmodule Mix.Tasks.Compile.Elixir do
   external file, however to depend on a _dynamic_ list of files we
   can do:
 
-      defmodule MyModule do paths = Path.wildcard("*.txt")
-      paths_hash = :erlang.md5(paths)
+      defmodule MyModule do
+        paths = Path.wildcard("*.txt")
+        paths_hash = :erlang.md5(paths)
 
         for path <- paths do @external_resource path end
 
-        def __mix_recompile__?() do Path.wildcard("*.txt") |>
-        :erlang.md5() == unquote(paths_hash) end end
+        def __mix_recompile__?() do
+          Path.wildcard("*.txt") |> :erlang.md5() == unquote(paths_hash)
+        end
+      end
 
   Compiler calls `__mix_recompile__?/0` for every module being
   compiled (or previously compiled) and thus it is is very important

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -470,7 +470,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
     end)
   end
 
-  test "recompiles modules with __mix_recompile__?" do
+  test "recompiles modules with __mix_recompile__?/0" do
     in_fixture("no_mixfile", fn ->
       File.write!("lib/a.ex", """
       defmodule A do
@@ -484,10 +484,19 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       end
       """)
 
+      File.write!("lib/c.ex", """
+      defmodule C do
+        @compile {:autoload, false}
+
+        def __mix_recompile__?(), do: true
+      end
+      """)
+
       assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
-      assert_received {:mix_shell, :info, ["Compiling 2 files (.ex)"]}
+      assert_received {:mix_shell, :info, ["Compiling 3 files (.ex)"]}
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
       assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+      assert_received {:mix_shell, :info, ["Compiled lib/c.ex"]}
 
       assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
       assert_received {:mix_shell, :info, ["Compiling 1 file (.ex)"]}

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -470,6 +470,35 @@ defmodule Mix.Tasks.Compile.ElixirTest do
     end)
   end
 
+  test "recompiles modules with __mix_recompile__?" do
+    in_fixture("no_mixfile", fn ->
+      File.write!("lib/a.ex", """
+      defmodule A do
+        def __mix_recompile__?(), do: true
+      end
+      """)
+
+      File.write!("lib/b.ex", """
+      defmodule B do
+        def __mix_recompile__?(), do: false
+      end
+      """)
+
+      assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
+      assert_received {:mix_shell, :info, ["Compiling 2 files (.ex)"]}
+      assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+      assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+
+      assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
+      assert_received {:mix_shell, :info, ["Compiling 1 file (.ex)"]}
+      assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+
+      File.rm!("lib/a.ex")
+      assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
+      refute_received _
+    end)
+  end
+
   test "does not treat remote typespecs as compile time dependencies" do
     in_fixture("no_mixfile", fn ->
       File.write!("lib/b.ex", """


### PR DESCRIPTION
This is inspired by `mix compile.phoenix` which turns out wasn't really Phoenix specific :)
https://github.com/phoenixframework/phoenix/blob/v1.4.16/lib/mix/tasks/compile.phoenix.ex