### PR TITLE
Load vm-args for remote shell

### DIFF
--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -199,6 +199,7 @@ defmodule Mix.Tasks.Release.Init do
              $(release_distribution "rem-$(rand)-$RELEASE_NODE") \
              --boot "$REL_VSN_DIR/$RELEASE_BOOT_SCRIPT_CLEAN" \
              --boot-var RELEASE_LIB "$RELEASE_ROOT/lib" \
+             --vm-args "$RELEASE_VM_ARGS" \
              --remsh "$RELEASE_NODE"
         ;;
 


### PR DESCRIPTION
We're writing our own empd/distribution module, similar to https://www.erlang-solutions.com/blog/erlang-and-elixir-distribution-without-epmd.html .

In order to be able to attach to a remote console, we need to load the same `rel/vm.args` file as the running instance of the beam. I'm not sure if this would cause any unintended side effects.