### PR TITLE
Code.unrequire_files/1: Adding a guard helps preventing wrong input

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -178,7 +178,7 @@ defmodule Code do
   """
   @doc since: "1.7.0"
   @spec unrequire_files([binary]) :: :ok
-  def unrequire_files(files) do
+  def unrequire_files(files) when is_list(files) do
     :elixir_code_server.cast({:unrequire_files, files})
   end
 


### PR DESCRIPTION
I accidentally inputted a string into Code.unrequire_files/1, obviously that failed. 
Somewhere deep in erlang it gave an argument error. This error didn't immediately tell me it was expecting a List instead of a String:

```
** (ArgumentError) argument error
    (stdlib 3.11.2) maps.erl:293: :maps.without("some_file.exs", %{"/Users/tomhoenderdos/.asdf/installs/elixir/1.10.2/bin/mix" => [], "some_file.exs" => true})
    (elixir 1.10.2) src/elixir_code_server.erl:112: :elixir_code_server.handle_cast/2
    (stdlib 3.11.2) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib 3.11.2) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib 3.11.2) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: {:"$gen_cast", {:unrequire_files, "some_file.exs"}}
```

Trying to make it a bit better by adding a guard, so that the input always needs to be a list :)
