### PR TITLE
Document that File.cd/1 affects the BEAM globally

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1503,6 +1503,12 @@ defmodule File do
   @doc """
   Sets the current working directory.
 
+  The current working directory is set for the BEAM globally. This can lead to
+  race conditions if multiple processes are changing the current working
+  directory concurrently. To run an external command in a given directory
+  without changing the global current working directory, use the `:cd` option
+  of `System.cmd/3` and `Port.open/2`.
+
   Returns `:ok` if successful, `{:error, reason}` otherwise.
   """
   @spec cd(Path.t()) :: :ok | {:error, posix}


### PR DESCRIPTION
I was surprised that `File.cd/1` affects the BEAM globally, instead of just changing the directory for the current process. This adds some documentation regarding this behavior.