### PR TITLE
Make spec of `c:run/1` match the documentation

### DIFF
--- a/lib/mix/lib/mix/task.compiler.ex
+++ b/lib/mix/lib/mix/task.compiler.ex
@@ -85,7 +85,7 @@ defmodule Mix.Task.Compiler do
   produces errors, warnings, or any other diagnostic information,
   it should return a tuple with the status and a list of diagnostics.
   """
-  @callback run([binary]) :: {status, [Diagnostic.t()]}
+  @callback run([binary]) :: status | {status, [Diagnostic.t()]}
 
   @doc """
   Lists manifest files for the compiler.


### PR DESCRIPTION
Earlier it failed Dialyzer tests as the example in docs returned value
different from one expected by callback definition.