### PR TITLE
Use XDG directories if any will be used

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -249,7 +249,6 @@ defmodule Mix do
     * `MIX_TARGET` - specifies which target should be used. See [Targets](#module-targets)
     * `MIX_EXS` - changes the full path to the `mix.exs` file
     * `MIX_HOME` - path to Mix's home directory, stores configuration files and scripts used by Mix
-      (default: `~/.mix`)
     * `MIX_PATH` - appends extra code paths
     * `MIX_QUIET` - does not print information messages to the terminal
     * `MIX_REBAR` - path to rebar command that overrides the one Mix installs
@@ -257,15 +256,20 @@ defmodule Mix do
     * `MIX_REBAR3` - path to rebar3 command that overrides the one Mix installs
       (default: `~/.mix/rebar3`)
 
-  If `MIX_HOME` is not set then the environment variables `XDG_DATA_HOME` and
-  `XDG_CONFIG_HOME` will be used as directories for storage of data and
-  configuration respectively. If none of the variables are set the default
-  directory `~/.mix` will be used.
+  If `MIX_HOME` is not set then:
+
+  - If [XDG Base Directory][xdg-bds] configuration or data directory is present, or
+    `XDG_CONFIG_HOME` or `XDG_DATA_HOME` environment variables are present, then it
+    will follow mentioned specification (defaut to `~/.config/mix`
+    and `~/.local/share/mix` for config and data respectively).
+  - Fall back to the default `~/.mix` for both - configuration and data
 
   Environment variables that are not meant to hold a value (and act basically as
   flags) should be set to either `1` or `true`, for example:
 
       $ MIX_DEBUG=1 mix compile
+
+  [xdg-bds]: https://specifications.freedesktop.org/basedir-spec/latest/
 
   """
 

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -56,7 +56,7 @@ defmodule Mix.Utils do
 
   defp xdg? do
     File.dir?(xdg_dir(:user_config)) or
-      Enum.any?(~w[XDG_CONFIG_HOME XDG_DATA_HOME], &(not is_nil(System.get_env(&1))))
+      Enum.any?(~w[XDG_CONFIG_HOME XDG_DATA_HOME], &System.get_env/1)
   end
 
   @doc """

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -48,7 +48,7 @@ defmodule Mix.Utils do
     end
   end
 
-  defp xdg_dir(type), do: :filename.basedir(type, "mix", %{os: :linux})
+  defp xdg_dir(type), do: :filename.basedir(type, "mix", %{os: :unix})
 
   defp xdg? do
     File.dir?(xdg_dir(:user_config)) or

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -41,21 +41,18 @@ defmodule Mix.Utils do
     end
   end
 
-  defp mix_home_lookup([{env, suffix} | rest]) when is_binary(env) and is_binary(suffix) do
+  defp mix_home_lookup([env | rest]) when is_binary(env) do
     case System.get_env(env) do
       nil -> mix_home_lookup(rest)
-      dir -> Path.join(dir, suffix)
+      dir -> dir
     end
-  end
-
-  defp mix_home_lookup([env | rest]) when is_binary(env) do
-    mix_home_lookup([{env, ""} | rest])
   end
 
   defp xdg_dir(type), do: :filename.basedir(type, "mix", %{os: :linux})
 
   defp xdg? do
     File.dir?(xdg_dir(:user_config)) or
+      File.dir?(xdg_dir(:user_data)) or
       Enum.any?(~w[XDG_CONFIG_HOME XDG_DATA_HOME], &System.get_env/1)
   end
 

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -37,7 +37,7 @@ defmodule Mix.Utils do
   defp mix_home_lookup([{:system, type} | rest]) do
     case xdg?() do
       true -> xdg_dir(type)
-      _ -> mix_home_lookup(rest)
+      false -> mix_home_lookup(rest)
     end
   end
 


### PR DESCRIPTION
This will use XDG paths if any of these will be satisfied:

- `$XDG_CONFIG_HOME/mix` or `$XDG_DATA_HOME/mix` will exists
- `$XDG_CONFIG_HOME` or `$XDG_DATA_HOME` will be set

So it will not require to set both variables, just one. Additionally it will allow user to opt-in for using the XDG paths just by creating proper directory without setting variables.