### PR TITLE
build: update to a supported FreeBSD version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -130,11 +130,11 @@ test_windows_task:
 test_freebsd_task:
   <<: *DEFAULT_TEST_SETTINGS
 
-  name: FreeBSD 12.0
+  name: FreeBSD 12.1
   alias: FreeBSD Stable
 
   freebsd_instance:
-    image_family: freebsd-12-0
+    image_family: freebsd-12-1
     cpu: 8
     memory: 7424Mi
 


### PR DESCRIPTION
currently [cirrus fails all FreeBSD tests](https://github.com/elixir-lang/elixir/pull/9942/checks?check_run_id=590253510) with this:

```
pkg install -y erlang git gmake
Updating FreeBSD repository catalogue...
Fetching meta.txz: . done
pkg: repository meta /var/db/pkg/FreeBSD.meta has wrong version 2
repository FreeBSD has no meta file, using default settings
Fetching packagesite.txz: .......... done
pkg: repository meta /var/db/pkg/FreeBSD.meta has wrong version 2
pkg: Repository FreeBSD load error: meta cannot be loaded No error: 0
Unable to open created repository FreeBSD
Unable to update repository FreeBSD
Error updating repositories!
Exit status: 3
```

this is because FreeBSD 12.0 is obsolete and the official package mirrors
don't have erlang etc available anymore. We need to move to 12.1 which is
for the moment the latest official release. I'll keep these updated in future as
well. If there's interest in extending this to cover the other FreeBSD versions
(11.x and the master branch 13.0-CURRENT) let me know and I will send
PRs for the rest.

```
Supported Releases

    Production: 12.1, 11.3
    Upcoming: 11.4
    Upcoming: 12.2
```