### PR TITLE
Fix dialyzer errors caused by erl_anno:anno type being opaque

### DIFF
--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -85,15 +85,15 @@ code_mod(Fun, Expr, Line, File, Module, Vars) when is_binary(File), is_integer(L
   Tuple = {tuple, Line, [{var, Line, Var} || {_, Var} <- Vars]},
   Relative = elixir_utils:relative_to_cwd(File),
 
-  [{attribute, Line, file, {elixir_utils:characters_to_list(Relative), 1}},
-   {attribute, Line, module, Module},
-   {attribute, Line, compile, no_auto_import},
-   {attribute, Line, export, [{Fun, 1}, {'__RELATIVE__', 0}]},
-   {function, Line, Fun, 1, [
-     {clause, Line, [Tuple], [], [Expr]}
+  [{attribute, erl_anno:new(Line), file, {elixir_utils:characters_to_list(Relative), 1}},
+   {attribute, erl_anno:new(Line), module, Module},
+   {attribute, erl_anno:new(Line), compile, no_auto_import},
+   {attribute, erl_anno:new(Line), export, [{Fun, 1}, {'__RELATIVE__', 0}]},
+   {function, erl_anno:new(Line), Fun, 1, [
+     {clause, erl_anno:new(Line), [Tuple], [], [Expr]}
    ]},
-   {function, Line, '__RELATIVE__', 0, [
-     {clause, Line, [], [], [elixir_erl:elixir_to_erl(Relative)]}
+   {function, erl_anno:new(Line), '__RELATIVE__', 0, [
+     {clause, erl_anno:new(Line), [], [], [elixir_erl:elixir_to_erl(Relative)]}
    ]}].
 
 retrieve_compiler_module() ->

--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -82,18 +82,19 @@ code_fun(nil) -> '__FILE__';
 code_fun(_)   -> '__MODULE__'.
 
 code_mod(Fun, Expr, Line, File, Module, Vars) when is_binary(File), is_integer(Line) ->
-  Tuple = {tuple, Line, [{var, Line, Var} || {_, Var} <- Vars]},
+  Ann = erl_anno:new(Line),
+  Tuple = {tuple, Ann, [{var, Ann, Var} || {_, Var} <- Vars]},
   Relative = elixir_utils:relative_to_cwd(File),
 
-  [{attribute, erl_anno:new(Line), file, {elixir_utils:characters_to_list(Relative), 1}},
-   {attribute, erl_anno:new(Line), module, Module},
-   {attribute, erl_anno:new(Line), compile, no_auto_import},
-   {attribute, erl_anno:new(Line), export, [{Fun, 1}, {'__RELATIVE__', 0}]},
-   {function, erl_anno:new(Line), Fun, 1, [
-     {clause, erl_anno:new(Line), [Tuple], [], [Expr]}
+  [{attribute, Ann, file, {elixir_utils:characters_to_list(Relative), 1}},
+   {attribute, Ann, module, Module},
+   {attribute, Ann, compile, no_auto_import},
+   {attribute, Ann, export, [{Fun, 1}, {'__RELATIVE__', 0}]},
+   {function, Ann, Fun, 1, [
+     {clause, Ann, [Tuple], [], [Expr]}
    ]},
-   {function, erl_anno:new(Line), '__RELATIVE__', 0, [
-     {clause, erl_anno:new(Line), [], [], [elixir_erl:elixir_to_erl(Relative)]}
+   {function, Ann, '__RELATIVE__', 0, [
+     {clause, Ann, [], [], [elixir_erl:elixir_to_erl(Relative)]}
    ]}].
 
 retrieve_compiler_module() ->

--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -43,7 +43,7 @@ get_ann(Opts) when is_list(Opts) ->
 get_ann([{generated, true} | T], _, Line) -> get_ann(T, true, Line);
 get_ann([{line, Line} | T], Gen, _) when is_integer(Line) -> get_ann(T, Gen, Line);
 get_ann([_ | T], Gen, Line) -> get_ann(T, Gen, Line);
-get_ann([], Gen, Line) -> erl_anno:set_generated(Gen, Line).
+get_ann([], Gen, Line) -> erl_anno:set_generated(Gen, erl_anno:new(Line)).
 
 %% Converts an Elixir definition to an anonymous function.
 
@@ -68,31 +68,31 @@ invoke_local(Module, ErlName, Args) ->
 %% Converts Elixir quoted literals to Erlang AST.
 
 elixir_to_erl(Tree) when is_tuple(Tree) ->
-  {tuple, 0, [elixir_to_erl(X) || X <- tuple_to_list(Tree)]};
+  {tuple, erl_anno:new(0), [elixir_to_erl(X) || X <- tuple_to_list(Tree)]};
 elixir_to_erl([]) ->
-  {nil, 0};
+  {nil, erl_anno:new(0)};
 elixir_to_erl(<<>>) ->
-  {bin, 0, []};
+  {bin, erl_anno:new(0), []};
 elixir_to_erl(Tree) when is_list(Tree) ->
   elixir_to_erl_cons(Tree);
 elixir_to_erl(Tree) when is_atom(Tree) ->
-  {atom, 0, Tree};
+  {atom, erl_anno:new(0), Tree};
 elixir_to_erl(Tree) when is_integer(Tree) ->
-  {integer, 0, Tree};
+  {integer, erl_anno:new(0), Tree};
 elixir_to_erl(Tree) when is_float(Tree) ->
-  {float, 0, Tree};
+  {float, erl_anno:new(0), Tree};
 elixir_to_erl(Tree) when is_binary(Tree) ->
   %% Note that our binaries are UTF-8 encoded and we are converting
   %% to a list using binary_to_list. The reason for this is that Erlang
   %% considers a string in a binary to be encoded in latin1, so the bytes
   %% are not changed in any fashion.
-  {bin, 0, [{bin_element, 0, {string, 0, binary_to_list(Tree)}, default, default}]};
+  {bin, erl_anno:new(0), [{bin_element, erl_anno:new(0), {string, erl_anno:new(0), binary_to_list(Tree)}, default, default}]};
 elixir_to_erl(Pid) when is_pid(Pid) ->
   ?remote(0, erlang, binary_to_term, [elixir_erl:elixir_to_erl(term_to_binary(Pid))]);
 elixir_to_erl(_Other) ->
   error(badarg).
 
-elixir_to_erl_cons([H | T]) -> {cons, 0, elixir_to_erl(H), elixir_to_erl_cons(T)};
+elixir_to_erl_cons([H | T]) -> {cons, erl_anno:new(0), elixir_to_erl(H), elixir_to_erl_cons(T)};
 elixir_to_erl_cons(T) -> elixir_to_erl(T).
 
 %% Returns a scope for translation.

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -468,7 +468,7 @@ translate_map(Meta, Assocs, TUpdate, #elixir_erl{extra=Extra} = S) ->
   {TArgs, SA} = lists:mapfoldl(fun({Key, Value}, Acc0) ->
     {TKey, Acc1} = translate(Key, Acc0#elixir_erl{extra=map_key}),
     {TValue, Acc2} = translate(Value, Acc1#elixir_erl{extra=Extra}),
-    {{Op, ?ann(Meta), TKey, TValue}, Acc2}
+    {{Op, Ann, TKey, TValue}, Acc2}
   end, S, Assocs),
 
   build_map(Ann, TUpdate, TArgs, SA).


### PR DESCRIPTION
- Use erl_anno:new instead of integers for line numbers when generating erlang AST (fixes #9948 )
- Remove unnecessary ?ann macro call