### PR TITLE
Update type spec for IEx.color/2 to indicate that it works with iodata

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -484,7 +484,7 @@ defmodule IEx do
 
   ANSI escapes in `string` are not processed in any way.
   """
-  @spec color(atom(), String.t()) :: String.t()
+  @spec color(atom(), iodata()) :: iodata()
   def color(color, string) do
     case IEx.Config.color(color) do
       nil ->


### PR DESCRIPTION
This fixes a few dialyzer errors, e.g. in IEx.Introspection.open/1
or in IEx.Helpers.print_pane/1