### PR TITLE
Include all relevant OTP apps when building dialyzer PLT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ PLT = .elixir.plt
 
 $(PLT):
 	@ echo "==> Building PLT with Elixir's dependencies..."
-	$(Q) dialyzer -Wunknown --output_plt $(PLT) --build_plt --apps erts kernel stdlib compiler syntax_tools parsetools tools ssl inets crypto runtime_tools ftp tftp mnesia public_key asn1 hipe sasl
+	$(Q) dialyzer --output_plt $(PLT) --build_plt --apps erts kernel stdlib compiler syntax_tools parsetools tools ssl inets crypto runtime_tools ftp tftp mnesia public_key asn1 hipe sasl
 
 clean_plt:
 	$(Q) rm -f $(PLT)

--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ PLT = .elixir.plt
 
 $(PLT):
 	@ echo "==> Building PLT with Elixir's dependencies..."
-	$(Q) dialyzer --output_plt $(PLT) --build_plt --apps erts kernel stdlib compiler syntax_tools parsetools tools ssl inets
+	$(Q) dialyzer -Wunknown --output_plt $(PLT) --build_plt --apps erts kernel stdlib compiler syntax_tools parsetools tools ssl inets crypto runtime_tools ftp tftp mnesia public_key asn1 hipe sasl
 
 clean_plt:
 	$(Q) rm -f $(PLT)


### PR DESCRIPTION
This commit fixes many "Unknown function" and "Unknown type" dialyzer errors
visible when generating the dialyzer PLT and when running dialyzer analysis.
Because all "unknown" erros during PLT generation have been fixed, it also
adds an additional -Wunknown flag to PLT generation command, which will
cause it to fail when any of such errors appear again during this step.

Errors fixed during building PLT:
```
Unknown functions:
  crypto:block_decrypt/4
  crypto:block_encrypt/4
  crypto:compute_key/4
  crypto:crypto_one_time_aead/7
  crypto:ec_curves/0
  crypto:exor/2
  crypto:generate_key/2
  crypto:hash/2
  crypto:hmac/3
  crypto:mod_pow/3
  crypto:private_decrypt/4
  crypto:private_encrypt/4
  crypto:sign/4
  crypto:start/0
  crypto:stream_decrypt/2
  crypto:stream_encrypt/2
  crypto:stream_init/2
  crypto:strong_rand_bytes/1
  crypto:supports/0
  dbg:ctp/1
  dbg:p/2
  dbg:stop/0
  dbg:tp/2
  dbg:tpl/2
  dbg:tpl/3
  dbg:trace_client/3
  dbg:trace_port/2
  dbg:tracer/0
  dbg:tracer/2
  ftp:start_service/1
  ftp:start_standalone/1
  ftp:stop_service/1
  hipe:compile/4
  mnesia:delete/1
  mnesia:delete_object/1
  mnesia:match_object/1
  mnesia:read/1
  mnesia:transaction/1
  mnesia:write/1
  pubkey_cert_records:namedCurves/1
  public_key:compute_key/2
  public_key:compute_key/3
  public_key:decrypt_private/3
  public_key:decrypt_public/3
  public_key:der_decode/2
  public_key:encrypt_private/3
  public_key:encrypt_public/3
  public_key:generate_key/1
  public_key:pem_decode/1
  public_key:pem_entry_decode/1
  public_key:pem_entry_decode/2
  public_key:pkix_crl_issuer/1
  public_key:pkix_crl_verify/2
  public_key:pkix_crls_validate/3
  public_key:pkix_decode_cert/2
  public_key:pkix_dist_point/1
  public_key:pkix_dist_points/1
  public_key:pkix_encode/3
  public_key:pkix_is_fixed_dh_cert/1
  public_key:pkix_is_issuer/2
  public_key:pkix_is_self_signed/1
  public_key:pkix_issuer_id/2
  public_key:pkix_match_dist_point/2
  public_key:pkix_normalize_name/1
  public_key:pkix_path_validation/3
  public_key:pkix_sign_types/1
  public_key:pkix_verify/2
  public_key:pkix_verify_hostname/2
  public_key:pkix_verify_hostname/3
  public_key:short_name_hash/1
  public_key:sign/3
  public_key:sign/4
  public_key:verify/4
  public_key:verify/5
  tftp:start_service/1
  tftp:start_standalone/1
  tftp:stop_service/1
Unknown types:
  crypto:engine_ref/0
  crypto:key_id/0
  crypto:password/0
  public_key:der_encoded/0
  public_key:oid/0
  public_key:private_key/0
```

Errors fixed when running analysis:
```
Unknown functions:
  crypto:hash/2
  crypto:strong_rand_bytes/1
  public_key:pem_decode/1
  public_key:pem_entry_decode/1
  public_key:verify/4
  systools:make_script/2
  systools:script2boot/1
```