### PR TITLE
Inline types not exported from their erlang modules

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -418,7 +418,8 @@ defmodule DynamicSupervisor do
   """
   @doc since: "1.6.0"
   @spec which_children(Supervisor.supervisor()) :: [
-          {:undefined, pid | :restarting, :worker | :supervisor, :supervisor.modules()}
+          # module() | :dynamic here because :supervisor.modules() is not exported
+          {:undefined, pid | :restarting, :worker | :supervisor, module() | :dynamic}
         ]
   def which_children(supervisor) do
     call(supervisor, :which_children)

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -705,7 +705,8 @@ defmodule Process do
   """
   @spec flag(:error_handler, module) :: module
   @spec flag(:max_heap_size, heap_size) :: heap_size
-  @spec flag(:message_queue_data, :erlang.message_queue_data()) :: :erlang.message_queue_data()
+  # :off_heap | :on_heap twice because :erlang.message_queue_data() is not exported
+  @spec flag(:message_queue_data, :off_heap | :on_heap) :: :off_heap | :on_heap
   @spec flag(:min_bin_vheap_size, non_neg_integer) :: non_neg_integer
   @spec flag(:min_heap_size, non_neg_integer) :: non_neg_integer
   @spec flag(:priority, priority_level) :: priority_level

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -929,7 +929,8 @@ defmodule Supervisor do
 
   """
   @spec which_children(supervisor) :: [
-          {term() | :undefined, child | :restarting, :worker | :supervisor, :supervisor.modules()}
+          # inlining module() | :dynamic here because :supervisor.modules() is not exported
+          {term() | :undefined, child | :restarting, :worker | :supervisor, module() | :dynamic}
         ]
   def which_children(supervisor) do
     call(supervisor, :which_children)

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -27,8 +27,10 @@ defmodule Task.Supervisor do
   @typedoc "Option values used by `start_link`"
   @type option ::
           DynamicSupervisor.option()
-          | {:restart, :supervisor.restart()}
-          | {:shutdown, :supervisor.shutdown()}
+          # :permanent | :transient | :temporary here because :supervisor.restart() is not exported
+          | {:restart, :permanent | :transient | :temporary}
+          # :brutal_kill | timeout() here because :supervisor.shutdown() is not exported
+          | {:shutdown, :brutal_kill | timeout()}
 
   @doc false
   def child_spec(opts) when is_list(opts) do

--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -777,7 +777,21 @@ defmodule Mix.Release do
   The exact chunks that are kept are not documented and may change in
   future versions.
   """
-  @spec strip_beam(binary()) :: {:ok, binary} | {:error, :beam_lib, :beam_lib.chnk_rsn()}
+  @type chunkid :: nonempty_charlist()
+  @type info_rsn() ::
+          {:chunk_too_big, :file.filename(), chunkid(), chunk_size :: non_neg_integer(),
+           file_size :: non_neg_integer()}
+          | {:invalid_beam_file, :file.filename(), position :: non_neg_integer()}
+          | {:invalid_chunk, :file.filename(), chunkid()}
+          | {:missing_chunk, :file.filename(), chunkid()}
+          | {:not_a_beam_file, :file.filename()}
+          | {:file_error, :file.filename(), :file.posix()}
+  @type chnk_rsn() ::
+          {:unknown_chunk, :file.filename(), atom()}
+          | {:key_missing_or_invalid, :file.filename(), :abstract_code | :debug_info}
+          | info_rsn()
+  # inlining chnk_rsn() here because :beam_lib.chnk_rsn() is not exported
+  @spec strip_beam(binary()) :: {:ok, binary} | {:error, :beam_lib, chnk_rsn()}
   def strip_beam(binary) do
     case :beam_lib.chunks(binary, @significant_chunks, [:allow_missing_chunks]) do
       {:ok, {_, chunks}} ->

--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -777,21 +777,7 @@ defmodule Mix.Release do
   The exact chunks that are kept are not documented and may change in
   future versions.
   """
-  @type chunkid :: nonempty_charlist()
-  @type info_rsn() ::
-          {:chunk_too_big, :file.filename(), chunkid(), chunk_size :: non_neg_integer(),
-           file_size :: non_neg_integer()}
-          | {:invalid_beam_file, :file.filename(), position :: non_neg_integer()}
-          | {:invalid_chunk, :file.filename(), chunkid()}
-          | {:missing_chunk, :file.filename(), chunkid()}
-          | {:not_a_beam_file, :file.filename()}
-          | {:file_error, :file.filename(), :file.posix()}
-  @type chnk_rsn() ::
-          {:unknown_chunk, :file.filename(), atom()}
-          | {:key_missing_or_invalid, :file.filename(), :abstract_code | :debug_info}
-          | info_rsn()
-  # inlining chnk_rsn() here because :beam_lib.chnk_rsn() is not exported
-  @spec strip_beam(binary()) :: {:ok, binary} | {:error, :beam_lib, chnk_rsn()}
+  @spec strip_beam(binary()) :: {:ok, binary} | {:error, :beam_lib, term}
   def strip_beam(binary) do
     case :beam_lib.chunks(binary, @significant_chunks, [:allow_missing_chunks]) do
       {:ok, {_, chunks}} ->


### PR DESCRIPTION
This commit fixes the following errors from dialyzer analysis:
```
Unknown types:
  beam_lib:chnk_rsn/0
  erlang:message_queue_data/0
  supervisor:modules/0
  supervisor:restart/0
  supervisor:shutdown/0
```

I'm not sure if this is the right way to fix these. In my view, using unexported types is similar to accessing private APIs. Maybe there is no reason for these types not to be exported and this should be fixed upstream by exporting them? Or maybe this is a hint that Elixir is indeed accessing "private" APIs in some of these cases? Or maybe this approach is fine?