### PR TITLE
Remove redundant pad handling in Calendar.parse_modifiers

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -536,11 +536,7 @@ defmodule Calendar do
   end
 
   defp parse_modifiers(<<digit, rest::binary>>, width, pad, parser_data) when digit in ?0..?9 do
-    new_width =
-      case pad do
-        ?- -> 0
-        _ -> (width || 0) * 10 + (digit - ?0)
-      end
+    new_width = (width || 0) * 10 + (digit - ?0)
 
     parse_modifiers(rest, new_width, pad, parser_data)
   end


### PR DESCRIPTION
The - padding is already handled at line 526

This was suggested by dialyzer :)