### PR TITLE
Remove redundant clause in ExUnit.Formatter.format_sides/6

### DIFF
--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -386,9 +386,6 @@ defmodule ExUnit.Formatter do
 
         {left, right}
 
-      nil when formatter == :expr ->
-        {if_value(left, inspect), if_value(right, inspect)}
-
       nil ->
         {if_value(left, &code_multiline(&1, padding_size)), if_value(right, inspect)}
     end


### PR DESCRIPTION
The formatter argument is a function so never should be equal to :expr