### PR TITLE
Remove error handling of empty escript name in Mix.Tasks.Escript.Build.escriptize/2

### DIFF
--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -136,14 +136,6 @@ defmodule Mix.Tasks.Escript.Build do
     filename = escript_opts[:path] || script_name
     main = escript_opts[:main_module]
 
-    unless script_name do
-      error_message =
-        "Could not generate escript, no name given, " <>
-          "set :name escript option or :app in the project settings"
-
-      Mix.raise(error_message)
-    end
-
     unless main do
       error_message =
         "Could not generate escript, please set :main_module " <>


### PR DESCRIPTION
When no name was provided, project :app name is being used