### PR TITLE
Fix handling of empty user home flag in System.user_home/0

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -312,9 +312,14 @@ defmodule System do
   """
   @spec user_home() :: String.t() | nil
   def user_home do
-    {:ok, [[home] | _]} = :init.get_argument(:home)
-    encoding = :file.native_name_encoding()
-    :unicode.characters_to_binary(home, encoding, encoding)
+    case :init.get_argument(:home) do
+      {:ok, [[home] | _]} ->
+        encoding = :file.native_name_encoding()
+        :unicode.characters_to_binary(home, encoding, encoding)
+
+      _ ->
+        nil
+    end
   end
 
   @doc """


### PR DESCRIPTION
According to erlang documentation, :init.get_argument/1 returns :error when no value is associated with the flag: http://erlang.org/doc/man/init.html