### PR TITLE
Fix spec for Mix.Local.Installer.parse_args/2

### DIFF
--- a/lib/mix/lib/mix/local/installer.ex
+++ b/lib/mix/lib/mix/local/installer.ex
@@ -171,7 +171,7 @@ defmodule Mix.Local.Installer do
   @doc """
   Receives `argv` and `opts` from options parsing and returns an `install_spec`.
   """
-  @spec parse_args([String.t()], keyword) :: install_spec
+  @spec parse_args([String.t()], keyword) :: install_spec | {:error, String.t}
   def parse_args(argv, opts)
 
   def parse_args([], _opts) do

--- a/lib/mix/lib/mix/local/installer.ex
+++ b/lib/mix/lib/mix/local/installer.ex
@@ -171,7 +171,7 @@ defmodule Mix.Local.Installer do
   @doc """
   Receives `argv` and `opts` from options parsing and returns an `install_spec`.
   """
-  @spec parse_args([String.t()], keyword) :: install_spec | {:error, String.t}
+  @spec parse_args([String.t()], keyword) :: install_spec | {:error, String.t()}
   def parse_args(argv, opts)
 
   def parse_args([], _opts) do


### PR DESCRIPTION
The function can also return an {:error, message} tuple when parsing is not successful