### PR TITLE
Do not pattern match on opaque MapSet.t type in Mix.Tasks.Test.filter_to_allowed_files/2

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -556,7 +556,7 @@ defmodule Mix.Tasks.Test do
 
   defp filter_to_allowed_files(matched_test_files, nil), do: matched_test_files
 
-  defp filter_to_allowed_files(matched_test_files, %MapSet{} = allowed_files) do
+  defp filter_to_allowed_files(matched_test_files, allowed_files) do
     Enum.filter(matched_test_files, &MapSet.member?(allowed_files, Path.expand(&1)))
   end
 


### PR DESCRIPTION
This pattern match is not used for control flow, and passing in something different than a MapSet will cause this function to raise in a very similar fashion in the next line in MapSet.member?/2.

This is the only place where any opaque type is being pattern matched on in the elixir codebase right now.