### PR TITLE
Fix spec for Mix.ProjectStack.compile_env/1

### DIFF
--- a/lib/mix/lib/mix/project_stack.ex
+++ b/lib/mix/lib/mix/project_stack.ex
@@ -105,7 +105,7 @@ defmodule Mix.ProjectStack do
     end)
   end
 
-  @spec compile_env([term]) :: [term]
+  @spec compile_env([term] | :unset) :: [term] | :unset
   def compile_env(compile_env) do
     update_stack(fn
       [h | t] -> {h.compile_env, [%{h | compile_env: compile_env} | t]}


### PR DESCRIPTION
This function is getting called with :unset in Mix.Tasks.Compile.App.load_compile_env/1