### PR TITLE
Make MapSet.t not be an opaque type to allow pattern matching on it

### DIFF
--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -54,7 +54,8 @@ defmodule MapSet do
 
   @type value :: term
 
-  @opaque t(value) :: %__MODULE__{map: %{optional(value) => []}}
+  @typep internal_representation(value) :: %__MODULE__{map: %{optional(value) => []}}
+  @type t(value) :: internal_representation(value)
   @type t :: t(term)
 
   # TODO: Remove version key on v2.0


### PR DESCRIPTION
Instead of using an opaque type, private type (@typep) declaration can be used to hide the representation