### PR TITLE
Recompile Kernel before bootstrapping stdlib

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -1308,7 +1308,7 @@ defmodule Code do
   @doc since: "1.11.0"
   @spec can_await_module_compilation? :: boolean
   def can_await_module_compilation? do
-    Process.info(self(), :error_handler) == {:error_handler, Kernel.ErrorHandler}
+    :erlang.process_info(self(), :error_handler) == {:error_handler, Kernel.ErrorHandler}
   end
 
   @doc false

--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -123,7 +123,11 @@ bootstrap() ->
   elixir_config:put(ignore_module_conflict, true),
   elixir_config:put(tracers, []),
   elixir_config:put(parser_options, []),
-  [bootstrap_file(File) || File <- bootstrap_main()].
+  {Init, Main} = bootstrap_files(),
+  [bootstrap_file(File) || File <- [<<"lib/elixir/lib/kernel.ex">> | Init]],
+  elixir_config:put(bootstrap, true),
+  elixir_config:put(docs, true),
+  [bootstrap_file(File) || File <- [<<"lib/elixir/lib/kernel.ex">> | Main]].
 
 bootstrap_file(File) ->
   try
@@ -136,45 +140,50 @@ bootstrap_file(File) ->
       erlang:halt(1)
   end.
 
-bootstrap_main() ->
-  [<<"lib/elixir/lib/kernel.ex">>,
-   <<"lib/elixir/lib/macro/env.ex">>,
-   <<"lib/elixir/lib/keyword.ex">>,
-   <<"lib/elixir/lib/module.ex">>,
-   <<"lib/elixir/lib/list.ex">>,
-   <<"lib/elixir/lib/macro.ex">>,
-   <<"lib/elixir/lib/kernel/typespec.ex">>,
-   <<"lib/elixir/lib/code.ex">>,
-   <<"lib/elixir/lib/code/identifier.ex">>,
-   <<"lib/elixir/lib/module/checker.ex">>,
-   <<"lib/elixir/lib/module/locals_tracker.ex">>,
-   <<"lib/elixir/lib/module/parallel_checker.ex">>,
-   <<"lib/elixir/lib/module/types/helpers.ex">>,
-   <<"lib/elixir/lib/module/types/infer.ex">>,
-   <<"lib/elixir/lib/module/types/pattern.ex">>,
-   <<"lib/elixir/lib/module/types/expr.ex">>,
-   <<"lib/elixir/lib/module/types.ex">>,
-   <<"lib/elixir/lib/kernel/utils.ex">>,
-   <<"lib/elixir/lib/exception.ex">>,
-   <<"lib/elixir/lib/protocol.ex">>,
-   <<"lib/elixir/lib/stream/reducers.ex">>,
-   <<"lib/elixir/lib/enum.ex">>,
-   <<"lib/elixir/lib/map.ex">>,
-   <<"lib/elixir/lib/inspect/algebra.ex">>,
-   <<"lib/elixir/lib/inspect.ex">>,
-   <<"lib/elixir/lib/access.ex">>,
-   <<"lib/elixir/lib/range.ex">>,
-   <<"lib/elixir/lib/regex.ex">>,
-   <<"lib/elixir/lib/string.ex">>,
-   <<"lib/elixir/lib/string/chars.ex">>,
-   <<"lib/elixir/lib/io.ex">>,
-   <<"lib/elixir/lib/path.ex">>,
-   <<"lib/elixir/lib/file.ex">>,
-   <<"lib/elixir/lib/system.ex">>,
-   <<"lib/elixir/lib/kernel/cli.ex">>,
-   <<"lib/elixir/lib/kernel/error_handler.ex">>,
-   <<"lib/elixir/lib/kernel/parallel_compiler.ex">>,
-   <<"lib/elixir/lib/kernel/lexical_tracker.ex">>].
+bootstrap_files() ->
+  {
+    [
+     <<"lib/elixir/lib/macro/env.ex">>,
+     <<"lib/elixir/lib/keyword.ex">>,
+     <<"lib/elixir/lib/module.ex">>,
+     <<"lib/elixir/lib/list.ex">>,
+     <<"lib/elixir/lib/macro.ex">>,
+     <<"lib/elixir/lib/kernel/typespec.ex">>,
+     <<"lib/elixir/lib/kernel/utils.ex">>,
+     <<"lib/elixir/lib/code.ex">>,
+     <<"lib/elixir/lib/code/identifier.ex">>,
+     <<"lib/elixir/lib/protocol.ex">>,
+     <<"lib/elixir/lib/stream/reducers.ex">>,
+     <<"lib/elixir/lib/enum.ex">>,
+     <<"lib/elixir/lib/regex.ex">>,
+     <<"lib/elixir/lib/inspect/algebra.ex">>,
+     <<"lib/elixir/lib/inspect.ex">>,
+     <<"lib/elixir/lib/string.ex">>,
+     <<"lib/elixir/lib/string/chars.ex">>
+    ],
+    [
+     <<"lib/elixir/lib/module/checker.ex">>,
+     <<"lib/elixir/lib/module/locals_tracker.ex">>,
+     <<"lib/elixir/lib/module/parallel_checker.ex">>,
+     <<"lib/elixir/lib/module/types/helpers.ex">>,
+     <<"lib/elixir/lib/module/types/infer.ex">>,
+     <<"lib/elixir/lib/module/types/pattern.ex">>,
+     <<"lib/elixir/lib/module/types/expr.ex">>,
+     <<"lib/elixir/lib/module/types.ex">>,
+     <<"lib/elixir/lib/exception.ex">>,
+     <<"lib/elixir/lib/path.ex">>,
+     <<"lib/elixir/lib/file.ex">>,
+     <<"lib/elixir/lib/map.ex">>,
+     <<"lib/elixir/lib/range.ex">>,
+     <<"lib/elixir/lib/access.ex">>,
+     <<"lib/elixir/lib/io.ex">>,
+     <<"lib/elixir/lib/system.ex">>,
+     <<"lib/elixir/lib/kernel/cli.ex">>,
+     <<"lib/elixir/lib/kernel/error_handler.ex">>,
+     <<"lib/elixir/lib/kernel/parallel_compiler.ex">>,
+     <<"lib/elixir/lib/kernel/lexical_tracker.ex">>
+    ]
+  }.
 
 binary_to_path({ModuleName, _ModuleMap, Binary}, CompilePath) ->
   Path = filename:join(CompilePath, atom_to_list(ModuleName) ++ ".beam"),


### PR DESCRIPTION
Before this patch, we could have slightly different
AST while compiling modules in parallel, depending
if modules were recompiled or not. Now we always
recompile Kernel before compiling the whole stdlib.

We used this opportunity to simplify bootstrap by
breaking it two steps. The first step is the minimal
necessary to compile Kernel itself. The second step
contains the whole compiler.

Closes #10000.