### PR TITLE
titlecase support for string module

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -835,6 +835,29 @@ defmodule String do
   defp downcase_ascii(<<>>), do: []
 
   @doc """
+  Capitalizes the first character of all the words in a string according to `mode`.
+
+  `mode` may be `:default`, `:ascii` or `:greek`. The `:default` mode considers
+  all non-conditional transformations outlined in the Unicode standard. `:ascii`
+  lowercases only the letters A to Z. `:greek` includes the context sensitive
+  mappings found in Greek.
+
+  ## Examples
+      iex> String.titlecase("hello world")
+      "Hello World"
+  """
+  @spec titlecase(t, :default | :ascii | :greek) :: t
+  def titlecase(string, mode \\ :default)
+
+  def titlecase("", _mode), do: ""
+
+  def titlecase(string, mode) when is_binary(string) do
+    string
+    |> split
+    |> Enum.map_join(" ", &capitalize(&1, mode))
+  end
+
+  @doc """
   Converts the first character in the given string to
   uppercase and the remainder to lowercase according to `mode`.
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -835,16 +835,18 @@ defmodule String do
   defp downcase_ascii(<<>>), do: []
 
   @doc """
-  Capitalizes the first character of all the words in a string according to `mode`.
+  Capitalizes the first character of all the words in `string` according to `mode`.
 
-  `mode` may be `:default`, `:ascii` or `:greek`. The `:default` mode considers
+  `mode` may be `:default`, `:ascii`, or `:greek`. The `:default` mode considers
   all non-conditional transformations outlined in the Unicode standard. `:ascii`
-  lowercases only the letters A to Z. `:greek` includes the context sensitive
+  lowercases only the letters `A` to `Z`. `:greek` includes the context-sensitive
   mappings found in Greek.
 
   ## Examples
+
       iex> String.titlecase("hello world")
       "Hello World"
+
   """
   @spec titlecase(t, :default | :ascii | :greek) :: t
   def titlecase(string, mode \\ :default)
@@ -853,7 +855,7 @@ defmodule String do
 
   def titlecase(string, mode) when is_binary(string) do
     string
-    |> split
+    |> split()
     |> Enum.map_join(" ", &capitalize(&1, mode))
   end
 

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -185,6 +185,26 @@ defmodule StringTest do
     assert String.downcase("OLÁ", :ascii) == "olÁ"
   end
 
+  test "titlecase/1" do
+    assert String.titlecase("") == ""
+    assert String.titlecase("abc ABC 1ABC") == "Abc Abc 1abc"
+    assert String.titlecase("_aBc1") == "_abc1"
+    assert String.titlecase(" aBc1") == "Abc1"
+
+    assert String.titlecase("hello world, elixir is awesome. Thank you.") ==
+             "Hello World, Elixir Is Awesome. Thank You."
+  end
+
+  test "titlecase/1 with UTF-8" do
+    assert String.titlecase("àáâ ÀÁÂ ÂÁÀ") == "Àáâ Àáâ Âáà"
+    assert String.titlecase("òóôõö ÒÓÔÕÖ") == "Òóôõö Òóôõö"
+    assert String.titlecase("ﬁn") == "Fin"
+  end
+
+  test "titlecase/1 with ascii" do
+    assert String.titlecase("àáâ aáA", :ascii) == "àáâ Aáa"
+  end
+
   test "capitalize/1" do
     assert String.capitalize("") == ""
     assert String.capitalize("abc") == "Abc"


### PR DESCRIPTION
closes #9999

I am unaware of other cases that might fail String.titlecase/2 . If there is then please do let me know.