### PR TITLE
Load app from dependencies path when it is a project dependency

### DIFF
--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -91,14 +91,15 @@ defmodule Mix.Release do
     {include_erts, opts} = Keyword.pop(opts, :include_erts, true)
     {erts_source, erts_lib_dir, erts_version} = erts_data(include_erts)
 
-    loaded_apps = apps |> Keyword.keys() |> load_apps(%{}, erts_lib_dir, :maybe)
+    apps_lock = Mix.Dep.Lock.read()
+    loaded_apps = apps |> Keyword.keys() |> load_apps(apps_lock, %{}, erts_lib_dir, :maybe)
 
     # Make sure IEx is either an active part of the release or add it as none.
     {loaded_apps, apps} =
       if Map.has_key?(loaded_apps, :iex) do
         {loaded_apps, apps}
       else
-        {load_apps([:iex], loaded_apps, erts_lib_dir, :maybe), apps ++ [iex: :none]}
+        {load_apps([:iex], apps_lock, loaded_apps, erts_lib_dir, :maybe), apps ++ [iex: :none]}
       end
 
     start_boot = build_start_boot(loaded_apps, apps)
@@ -265,13 +266,13 @@ defmodule Mix.Release do
     end
   end
 
-  defp load_apps(apps, seen, otp_root, included) do
+  defp load_apps(apps, apps_lock, seen, otp_root, included) do
     for app <- apps, reduce: seen do
       seen ->
         if reentrant_seen = reentrant(seen, app, included) do
           reentrant_seen
         else
-          load_app(app, seen, otp_root, included)
+          load_app(app, apps_lock, seen, otp_root, included)
         end
     end
   end
@@ -297,30 +298,44 @@ defmodule Mix.Release do
     end
   end
 
-  defp load_app(app, seen, otp_root, included) do
-    path = Path.join(otp_root, "#{app}-*")
+  defp load_app(app, apps_lock, seen, otp_root, included) do
+    case apps_lock[app] do
+      {:hex, _, version, _, _, _, _, _} ->
+        %{path: path, otp_app?: otp_app?} = app_path(otp_root, app, version)
+        do_load_app(app, path, apps_lock, seen, otp_root, otp_app?, included)
+
+      _ ->
+        %{path: path, otp_app?: otp_app?} = app_path(otp_root, app)
+        do_load_app(app, path, apps_lock, seen, otp_root, otp_app?, included)
+    end
+  end
+
+  defp app_path(otp_root, app, version \\ "*") do
+    path = Path.join(otp_root, "#{app}-#{version}")
 
     case Path.wildcard(path) do
       [] ->
         case :code.lib_dir(app) do
           {:error, :bad_name} -> Mix.raise("Could not find application #{inspect(app)}")
-          path -> do_load_app(app, path, seen, otp_root, false, included)
+          path -> %{path: path, otp_app?: false}
         end
 
       paths ->
         path = paths |> Enum.sort() |> List.last()
-        do_load_app(app, to_charlist(path), seen, otp_root, true, included)
+        %{path: to_charlist(path), otp_app?: true}
     end
   end
 
-  defp do_load_app(app, path, seen, otp_root, otp_app?, included) do
+  defp do_load_app(app, path, apps_lock, seen, otp_root, otp_app?, included) do
     case :file.consult(Path.join(path, "ebin/#{app}.app")) do
       {:ok, terms} ->
         [{:application, ^app, properties}] = terms
         value = [path: path, otp_app?: otp_app?, included: included] ++ properties
         seen = Map.put(seen, app, value)
-        seen = load_apps(Keyword.get(properties, :applications, []), seen, otp_root, false)
-        load_apps(Keyword.get(properties, :included_applications, []), seen, otp_root, true)
+        applications = Keyword.get(properties, :applications, [])
+        seen = load_apps(applications, apps_lock, seen, otp_root, false)
+        included_applications = Keyword.get(properties, :included_applications, [])
+        load_apps(included_applications, apps_lock, seen, otp_root, true)
 
       {:error, reason} ->
         Mix.raise("Could not load #{app}.app. Reason: #{inspect(reason)}")


### PR DESCRIPTION
I made a spike in my job to use the built-in mix releases instead of distillery.
The release was built fine but it broke when I tried to boot it because a different version of cowboy was packed into it.
The fix was rather easy, I just removed the system package, which was mistakenly installed, from our base Docker image.
Finding the problem was not so straightforward for me though. So, I am suggesting in this PR some way to prevent this to happen and have a message early on about the problem. What do you think?

PS. I am not sure how to test such thing.