### PR TITLE
Improve Mix.Config docs to point to the Elixir library for Config and Config.Reader

### DIFF
--- a/lib/mix/lib/mix/config.ex
+++ b/lib/mix/lib/mix/config.ex
@@ -5,6 +5,9 @@ defmodule Mix.Config do
   @moduledoc ~S"""
   A simple configuration API and functions for managing config files.
 
+  This module is deprecated, use `Elixir.Config` and `Elixir.Config.Reader`
+  instead.
+
   ## Setting configuration
 
   Most commonly, this module is used to define your own configuration:

--- a/lib/mix/lib/mix/config.ex
+++ b/lib/mix/lib/mix/config.ex
@@ -5,8 +5,8 @@ defmodule Mix.Config do
   @moduledoc ~S"""
   A simple configuration API and functions for managing config files.
 
-  This module is deprecated, use `Elixir.Config` and `Elixir.Config.Reader`
-  instead.
+  This module is deprecated, use the modules `Config` and `Config.Reader`
+  from Elixir's standard library instead.
 
   ## Setting configuration
 


### PR DESCRIPTION
I have added a line to add a link to the `Config` and `Config.Reader` module inside the Elixir library. I also added the Elixir namespace inside the links, to make it explicit it is in another library, although it will be the standard library. I know that it is not the "normal" style for linking, but it caused some confusion on my end to find out that it moved completely to another library.