### PR TITLE
Improve documentation for utc_offset and std_offset fields.

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -68,12 +68,15 @@ defmodule Calendar do
   @typedoc "The time zone abbreviation (for example, CET or CEST or BST, and such)"
   @type zone_abbr :: String.t()
 
-  @typedoc "The time zone UTC offset in seconds for standard time. See also `t:std_offset/0`."
+  @typedoc """
+  The time zone UTC offset in seconds for standard time.
+
+  See also `t:std_offset/0`.
+  """
   @type utc_offset :: integer
 
   @typedoc """
   The time zone standard offset in seconds (typically not zero in summer times).
-  
   It must be added to `t:utc_offset/0` to get the total offset from UTC used for "wall time".
   """
   @type std_offset :: integer

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -68,10 +68,13 @@ defmodule Calendar do
   @typedoc "The time zone abbreviation (for example, CET or CEST or BST, and such)"
   @type zone_abbr :: String.t()
 
-  @typedoc "The time zone UTC offset in seconds"
+  @typedoc "The time zone UTC offset in seconds for standard time. See also `std_offset`."
   @type utc_offset :: integer
 
-  @typedoc "The time zone standard offset in seconds (not zero in summer times)"
+  @typedoc """
+  The time zone standard offset in seconds (typically not zero in summer times). Is added to
+  `utc_offset` to get the total offset from UTC used for "wall time".
+  """
   @type std_offset :: integer
 
   @typedoc "Any map/struct that contains the date fields"

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -68,12 +68,13 @@ defmodule Calendar do
   @typedoc "The time zone abbreviation (for example, CET or CEST or BST, and such)"
   @type zone_abbr :: String.t()
 
-  @typedoc "The time zone UTC offset in seconds for standard time. See also `std_offset`."
+  @typedoc "The time zone UTC offset in seconds for standard time. See also `t:std_offset/0`."
   @type utc_offset :: integer
 
   @typedoc """
-  The time zone standard offset in seconds (typically not zero in summer times). Is added to
-  `utc_offset` to get the total offset from UTC used for "wall time".
+  The time zone standard offset in seconds (typically not zero in summer times).
+  
+  It must be added to `t:utc_offset/0` to get the total offset from UTC used for "wall time".
   """
   @type std_offset :: integer
 

--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -77,6 +77,7 @@ defmodule Calendar do
 
   @typedoc """
   The time zone standard offset in seconds (typically not zero in summer times).
+
   It must be added to `t:utc_offset/0` to get the total offset from UTC used for "wall time".
   """
   @type std_offset :: integer


### PR DESCRIPTION
There is a good question here: https://stackoverflow.com/questions/61566269/utc-offset-in-elixir-return-incorrect-offset-for-time-zones

Both `utc_offset` and `std_offset` are used to get wall time. Some users may look at `utc_offset` and think that this is the total offset from UTC to get wall time even in summer time.