### PR TITLE
Adjust @type body for Registry to match erlang ets match_spec Result

### DIFF
--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -204,7 +204,7 @@ defmodule Registry do
   @type guards :: [guard]
 
   @typedoc "A pattern used to representing the output format part of a match spec"
-  @type body :: [atom | tuple]
+  @type body :: [term]
 
   @typedoc "A full match spec used when selecting objects in the registry"
   @type spec :: [{match_pattern, guards, body}]


### PR DESCRIPTION
Per the docs for [Registry.select/2](https://hexdocs.pm/elixir/Registry.html#select/2) you can provide a map for the body part of the spec, currently body is defined as `[atom | tuple]`, I've changed this now to `[term]` to match the erlang match_spec Result used by :ets.select/2

Thinking that perhaps `@type guard` should also be changed to term to match the erlang match_spec as well though?