### PR TITLE
Add support for new rebar3 output dir option

### DIFF
--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -189,7 +189,10 @@ defmodule Mix.Tasks.Deps.Compile do
     lib_path = Path.join(config[:env_path], "lib/*/ebin")
 
     env = [{"REBAR_CONFIG", config_path}, {"TERM", "dumb"}]
-    cmd = "#{rebar_cmd(dep)} bare compile --paths=#{inspect(lib_path)}"
+
+    # n.b., This enviroment variable is only honored by rebar3 >= 3.14
+    System.put_env("REBAR_BARE_COMPILER_OUTPUT_DIR", dep_path)
+    cmd = "#{rebar_cmd(dep)} bare compile --paths #{lib_path}"
 
     File.mkdir_p!(dep_path)
     File.write!(config_path, rebar_config(dep))

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -188,10 +188,13 @@ defmodule Mix.Tasks.Deps.Compile do
     config_path = Path.join(dep_path, "mix.rebar.config")
     lib_path = Path.join(config[:env_path], "lib/*/ebin")
 
-    env = [{"REBAR_CONFIG", config_path}, {"TERM", "dumb"}]
+    # n.b., REBAR_BARE_COMPILER_OUTPUT_DIR is only honored by rebar3 >= 3.14
+    env = [
+      {"REBAR_CONFIG", config_path},
+      {"TERM", "dumb"},
+      {"REBAR_BARE_COMPILER_OUTPUT_DIR", dep_path}
+    ]
 
-    # n.b., This enviroment variable is only honored by rebar3 >= 3.14
-    System.put_env("REBAR_BARE_COMPILER_OUTPUT_DIR", dep_path)
     cmd = "#{rebar_cmd(dep)} bare compile --paths #{lib_path}"
 
     File.mkdir_p!(dep_path)

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -188,7 +188,7 @@ defmodule Mix.Tasks.Deps.Compile do
     config_path = Path.join(dep_path, "mix.rebar.config")
     lib_path = Path.join(config[:env_path], "lib/*/ebin")
 
-    # n.b., REBAR_BARE_COMPILER_OUTPUT_DIR is only honored by rebar3 >= 3.14
+    # REBAR_BARE_COMPILER_OUTPUT_DIR is only honored by rebar3 >= 3.14
     env = [
       {"REBAR_CONFIG", config_path},
       {"TERM", "dumb"},


### PR DESCRIPTION
rebar3 as of 3.13.2 now supports a --output directory option which allows mix going forward to use said option and put build artifacts in _build which should result and less rebuilding of artifacts and/or better caching of artifacts. Details here: https://github.com/erlang/rebar3/pull/2237

 In order to make use of said feature we must put a variable in the system's environment that shall hold the desired output path. rebar3 will recognize said environment variable going forward starting at version 3.14 (yet to be released).

- Updated Mix.Tasks.Deps.Compile to put REBAR_BARE_COMPILER_OUTPUT_DIR in system env with the dependency path as the value for use by rebar3.