### PR TITLE
Improve performance of Enum.with_index/2

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3084,10 +3084,18 @@ defmodule Enum do
   """
   @spec with_index(t, integer) :: [{element, index}]
   def with_index(enumerable, offset \\ 0) do
-    map_reduce(enumerable, offset, fn x, acc ->
-      {{x, acc}, acc + 1}
-    end)
-    |> elem(0)
+    enumerable
+    |> to_list()
+    |> do_with_index(offset)
+  end
+
+  @spec do_with_index(list, integer) :: [{element, index}]
+  defp do_with_index([], _) do
+    []
+  end
+
+  defp do_with_index([head | tail], index) do
+    [{head, index} | do_with_index(tail, index + 1)]
   end
 
   @doc """


### PR DESCRIPTION
This is a proposed refactor of `Enum.with_index/2` with the goal of improving performance so that it is faster and consumes less memory.

I've created a small repository that benchmarks the current implementation with the new one [here](https://github.com/andersonmcook/with_index).

I've included my own benchmarks in the README, but would love if someone could replicate or disprove my results.

## Benchmarking Synopsis
- List: The updated function is approximately twice as fast and uses half the memory.
- Map: The updated function is approximately twice as fast and uses half the memory.
- MapSet: The updated function is moderately faster and uses moderately less memory.
- Range: The updated function is moderately faster and uses moderately less memory.
- Stream: The updated function is minimally faster and uses minimally less memory.

I realize this is a PR that nobody has asked for and the gains I've seen may not be universal, so I won't get my feelings hurt if this does not get merged. :)