### PR TITLE
Test not only rebar3

### DIFF
--- a/lib/mix/test/mix/rebar_test.exs
+++ b/lib/mix/test/mix/rebar_test.exs
@@ -219,15 +219,15 @@ defmodule Mix.RebarTest do
     end
 
     test "gets and compiles dependencies for Rebar" do
-      Mix.Project.push(RebarAsDep)
+      Mix.Project.push(RebarAsDepWithEnv)
 
       in_tmp("get and compile dependencies for Rebar", fn ->
         Mix.Tasks.Deps.Get.run([])
         assert_received {:mix_shell, :info, ["* Getting git_rebar" <> _]}
 
         Mix.Tasks.Deps.Compile.run([])
-        assert_received {:mix_shell, :run, ["===> Compiling git_rebar\n"]}
-        assert_received {:mix_shell, :run, ["===> Compiling rebar_dep\n"]}
+        assert_received {:mix_shell, :run, ["==> git_rebar (compile)\n"]}
+        assert_received {:mix_shell, :run, ["==> rebar_dep (compile)\n"]}
         assert :git_rebar.any_function() == :ok
         assert :rebar_dep.any_function() == :ok
 


### PR DESCRIPTION
The PR is going to fix the bug which makes the Mix tests use only rebar3 when they should test Mix with both rebar and rebar3.

How to check that the bug really exists.
* Remove `./lib/mix/test/fixtures/rebar3`.
* Apply the patch (see below), removing the tests related to rebar3.
* Run the tests and `gets and compiles dependencies for Rebar` should fail.

Patch:

```
--- elixir-lang-1.9.1.dfsg.orig/lib/mix/test/mix/rebar_test.exs
+++ elixir-lang-1.9.1.dfsg/lib/mix/test/mix/rebar_test.exs
@@ -33,39 +33,6 @@ defmodule Mix.RebarTest do
     end
   end
 
-  defmodule Rebar3AsDep do
-    def project do
-      [
-        app: :rebar_as_dep,
-        version: "0.1.0",
-        deps: [
-          {
-            :rebar_dep,
-            path: MixTest.Case.tmp_path("rebar_dep"),
-            app: false,
-            manager: :rebar3,
-            system_env: [{"FILE_FROM_ENV", "rebar-test-rebar3"}, {"CONTENTS_FROM_ENV", "rebar3"}]
-          }
-        ]
-      ]
-    end
-  end
-
-  defmodule RebarOverrideAsDep do
-    def project do
-      [
-        app: :rebar_as_dep,
-        version: "0.1.0",
-        deps: [
-          {
-            :rebar_override,
-            path: MixTest.Case.tmp_path("rebar_override"), app: false, manager: :rebar3
-          }
-        ]
-      ]
-    end
-  end
-
   describe "load_config/1" do
     test "loads rebar.config" do
       path = MixTest.Case.fixture_path("rebar_dep")
@@ -181,12 +148,6 @@ defmodule Mix.RebarTest do
   end
 
   describe "integration with Mix" do
-    test "inherits Rebar manager" do
-      Mix.Project.push(Rebar3AsDep)
-      deps = Mix.Dep.load_on_environment([])
-      assert Enum.all?(deps, &(&1.manager == :rebar3))
-    end
-
     test "parses Rebar dependencies from rebar.config" do
       Mix.Project.push(RebarAsDep)
 
@@ -202,19 +163,6 @@ defmodule Mix.RebarTest do
              end)
     end
 
-    test "handles Rebar overrides" do
-      Mix.Project.push(RebarOverrideAsDep)
-
-      in_tmp("Rebar overrides", fn ->
-        Mix.Tasks.Deps.Get.run([])
-
-        assert Mix.Dep.load_on_environment([]) |> Enum.map(& &1.app) ==
-                 [:git_repo, :git_rebar, :rebar_override]
-      end)
-    after
-      purge([GitRepo.MixProject])
-    end
-
     test "gets and compiles dependencies for Rebar" do
       Mix.Project.push(RebarAsDep)
 
@@ -263,54 +211,6 @@ defmodule Mix.RebarTest do
       end)
     end
 
-    test "gets and compiles dependencies for Rebar3" do
-      Mix.Project.push(Rebar3AsDep)
-
-      in_tmp("get and compile dependencies for Rebar3", fn ->
-        Mix.Tasks.Deps.Get.run([])
-        assert_received {:mix_shell, :info, ["* Getting git_rebar " <> _]}
-
-        Mix.Tasks.Deps.Compile.run([])
-        assert_received {:mix_shell, :run, ["===> Compiling git_rebar\n"]}
-        assert_received {:mix_shell, :run, ["===> Compiling rebar_dep\n"]}
-        assert :git_rebar.any_function() == :ok
-        assert :rebar_dep.any_function() == :ok
-
-        load_paths =
-          Mix.Dep.load_on_environment([])
-          |> Enum.map(&Mix.Dep.load_paths(&1))
-          |> Enum.concat()
-
-        assert File.exists?("_build/dev/lib/rebar_dep/ebin/rebar_dep.beam")
-        assert File.exists?("_build/dev/lib/git_rebar/ebin/git_rebar.beam")
-
-        # Assert we have no .mix/compile.lock as a .mix/compile.lock
-        # means we check for the Elixir version on every command.
-        refute File.exists?("_build/dev/lib/rebar_dep/.mix/compile.lock")
-        refute File.exists?("_build/dev/lib/git_rebar/.mix/compile.lock")
-
-        assert Enum.any?(load_paths, &String.ends_with?(&1, "git_rebar/ebin"))
-        assert Enum.any?(load_paths, &String.ends_with?(&1, "rebar_dep/ebin"))
-      end)
-    end
-
-    # We run only on Unix because Windows has a hard time
-    # removing the Rebar executable after executed.
-    @tag [unix: true]
-    test "applies variables from :system_env option when compiling dependencies for Rebar3" do
-      Mix.Project.push(Rebar3AsDep)
-
-      in_tmp("applies variables from system_env for Rebar3", fn ->
-        expected_file = Path.join(tmp_path("rebar_dep"), "rebar-test-rebar3")
-        File.rm(expected_file)
-
-        Mix.Tasks.Deps.Get.run([])
-        Mix.Tasks.Deps.Compile.run([])
-
-        assert {:ok, "rebar3"} = File.read(expected_file)
-      end)
-    end
-
     test "gets and compiles dependencies for Rebar with Mix" do
       Mix.Project.push(RebarAsDep)
 
--- elixir-lang-1.9.1.dfsg.orig/lib/mix/test/test_helper.exs
+++ elixir-lang-1.9.1.dfsg/lib/mix/test/test_helper.exs
@@ -186,8 +186,6 @@ System.delete_env("XDG_CONFIG_HOME")
 
 rebar = System.get_env("REBAR") || Path.expand("fixtures/rebar", __DIR__)
 File.cp!(rebar, Path.join(home, "rebar"))
-rebar = System.get_env("REBAR3") || Path.expand("fixtures/rebar3", __DIR__)
-File.cp!(rebar, Path.join(home, "rebar3"))
 
 ## Copy fixtures to tmp
 
```