### PR TITLE
Add note that System.stacktrace/0 will always return an empty list

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -587,7 +587,7 @@ defmodule System do
   `__STACKTRACE__/0` inside a rescue/catch. If you want to support
   earlier Elixir versions, move `System.stacktrace/0` inside a rescue/catch.
 
-  Since OTP 23 this always returns an empty list.
+  From Erlang/OTP 23+ this always returns an empty list.
 
   Note that the Erlang VM (and therefore this function) does not
   return the current stacktrace but rather the stacktrace of the

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -587,6 +587,8 @@ defmodule System do
   `__STACKTRACE__/0` inside a rescue/catch. If you want to support
   earlier Elixir versions, move `System.stacktrace/0` inside a rescue/catch.
 
+  Since OTP 23 this always returns an empty list.
+
   Note that the Erlang VM (and therefore this function) does not
   return the current stacktrace but rather the stacktrace of the
   latest exception. To retrieve the stacktrace of the current process,


### PR DESCRIPTION
Starting with OTP 23 erlang:get_stacktrace/0 will always return an
empty list. The function will be completely removed in OTP 24 - we
should plan appropriately for that.