### PR TITLE
Introduce MIX_XDG

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -258,7 +258,7 @@ defmodule Mix do
       (default: `~/.mix/rebar3`)
     * `MIX_XDG` - asks Mix to follow the [XDG Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
       for its home directory and configuration files. This behaviour needs to
-      be opt-in due to backwards compatibilit.y `MIX_HOME` has higher preference
+      be opt-in due to backwards compatibility. `MIX_HOME` has higher preference
       than `MIX_XDG`. If none of the variables are set, the default directory
       `~/.mix` will be used
 

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -256,11 +256,11 @@ defmodule Mix do
       (default: `~/.mix/rebar`)
     * `MIX_REBAR3` - path to rebar3 command that overrides the one Mix installs
       (default: `~/.mix/rebar3`)
-
-  If `MIX_HOME` is not set then the environment variables `XDG_DATA_HOME` and
-  `XDG_CONFIG_HOME` will be used as directories for storage of data and
-  configuration respectively. If none of the variables are set the default
-  directory `~/.mix` will be used.
+    * `MIX_XDG` - asks Mix to follow the [XDG Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+      for its home directory and configuration files. This behaviour needs to
+      be opt-in due to backwards compatibilit.y `MIX_HOME` has higher preference
+      than `MIX_XDG`. If none of the variables are set, the default directory
+      `~/.mix` will be used
 
   Environment variables that are not meant to hold a value (and act basically as
   flags) should be set to either `1` or `true`, for example:

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -37,7 +37,7 @@ defmodule Mix.Utils do
       dir = System.get_env("MIX_HOME") ->
         dir
 
-      System.get_env("MIX_XDG") ->
+      System.get_env("MIX_XDG") in ["1", "true"]->
         :filename.basedir(xdg, "mix", %{os: :unix})
 
       true ->

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -15,7 +15,7 @@ defmodule Mix.Utils do
   stored there.
   """
   def mix_home do
-    mix_home_xdg_lookup("XDG_DATA_HOME")
+    mix_home_xdg_lookup(:user_data)
   end
 
   @doc """
@@ -23,20 +23,25 @@ defmodule Mix.Utils do
 
   Possible locations:
 
-   * `~/.mix`
-   * `MIX_HOME`
-   * `XDG_CONFIG_HOME/mix`
+     * `XDG_CONFIG_HOME/mix`
+     * `MIX_HOME`
+     * `~/.mix`
 
   """
   def mix_config do
-    mix_home_xdg_lookup("XDG_CONFIG_HOME")
+    mix_home_xdg_lookup(:user_config)
   end
 
   defp mix_home_xdg_lookup(xdg) do
-    case {System.get_env("MIX_HOME"), System.get_env(xdg)} do
-      {directory, _} when is_binary(directory) -> directory
-      {nil, directory} when is_binary(directory) -> Path.join(directory, "mix")
-      {nil, nil} -> Path.expand("~/.mix")
+    cond do
+      dir = System.get_env("MIX_HOME") ->
+        dir
+
+      System.get_env("MIX_XDG") ->
+        :filename.basedir(xdg, "mix", %{os: :unix})
+
+      true ->
+        Path.expand("~/.mix")
     end
   end
 

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -37,7 +37,7 @@ defmodule Mix.Utils do
       dir = System.get_env("MIX_HOME") ->
         dir
 
-      System.get_env("MIX_XDG") in ["1", "true"]->
+      System.get_env("MIX_XDG") in ["1", "true"] ->
         :filename.basedir(xdg, "mix", %{os: :unix})
 
       true ->

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -23,8 +23,8 @@ defmodule Mix.Utils do
 
   Possible locations:
 
-     * `XDG_CONFIG_HOME/mix`
      * `MIX_HOME`
+     * `XDG_CONFIG_HOME/mix` (if `MIX_XDG` is set)
      * `~/.mix`
 
   """

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -13,14 +13,12 @@ defmodule Mix.UtilsTest do
 
     # Clear all variables to get a reproducible test
     System.delete_env("MIX_HOME")
-    System.delete_env("XDG_DATA_HOME")
-    System.delete_env("XDG_CONFIG_HOME")
+    System.delete_env("MIX_XDG")
 
     # Reset Env Variables
     on_exit(fn ->
       System.put_env("MIX_HOME", mix_home)
-      System.delete_env("XDG_DATA_HOME")
-      System.delete_env("XDG_CONFIG_HOME")
+      System.delete_env("MIX_XDG")
     end)
   end
 
@@ -124,15 +122,16 @@ defmodule Mix.UtilsTest do
   end
 
   describe "mix_home/0" do
-    test "prefers MIX_HOME over XDG_DATA_HOME" do
+    test "prefers MIX_HOME over MIX_XDG" do
       System.put_env("MIX_HOME", "mix_home")
-      System.put_env("XDG_DATA_HOME", "xdg_data_home")
+      System.put_env("MIX_XDG", "true")
       assert "mix_home" = Mix.Utils.mix_home()
     end
 
+    @tag :unix
     test "falls back to XDG_DATA_HOME/mix" do
-      System.put_env("XDG_DATA_HOME", "xdg_data_home")
-      assert "xdg_data_home/mix" == Mix.Utils.mix_home()
+      System.put_env("MIX_XDG", "1")
+      assert Mix.Utils.mix_home() == :filename.basedir(:user_data, "mix", %{os: :unix})
     end
 
     test "falls back to $HOME/.mix" do
@@ -141,15 +140,16 @@ defmodule Mix.UtilsTest do
   end
 
   describe "mix_config/0" do
-    test "prefers MIX_HOME over XDG_CONFIG_HOME" do
+    test "prefers MIX_HOME over MIX_XDG" do
       System.put_env("MIX_HOME", "mix_home")
-      System.put_env("XDG_CONFIG_HOME", "xdg_data_home")
+      System.put_env("MIX_XDG", "true")
       assert "mix_home" = Mix.Utils.mix_config()
     end
 
+    @tag :unix
     test "falls back to XDG_CONFIG_HOME/mix" do
-      System.put_env("XDG_CONFIG_HOME", "xdg_config_home")
-      assert "xdg_config_home/mix" == Mix.Utils.mix_config()
+      System.put_env("MIX_XDG", "1")
+      assert Mix.Utils.mix_config() == :filename.basedir(:user_config, "mix", %{os: :unix})
     end
 
     test "falls back to $HOME/.mix" do


### PR DESCRIPTION
Unfortunately we cannot support XDG out of the box due to backwards compatibility. Today we already allow you to opt-in but it requires setting multiple environment variables. This makes the opt-in API much simpler.

We had lengthy previous discussions on this topic and on backwards compatibility, I am not planning to rehash those points here. [See this comment for a summary](https://github.com/elixir-lang/elixir/pull/9942#discussion_r409569099). For the complete discussion, search for XDG in previous issues and PRs.

If you would like to give feedback in this issue, please let me know which option you prefer:

  1. This PR
  2. Keep things as is (no changes)
  3. Remove XDG support since we can't do it automatically

If the conversation derails, as it has happened in the past, then I will make an executive decision. :) Thank you!
