### PR TITLE
Add IO.ANSI.clear_scrollback/0

### DIFF
--- a/lib/elixir/lib/io/ansi.ex
+++ b/lib/elixir/lib/io/ansi.ex
@@ -31,7 +31,7 @@ defmodule IO.ANSI do
       IO.puts(formatted_text)
 
   A higher level and more convenient API is also available via `IO.ANSI.format/1`,
-  where you use atoms to represent each ANSI escape sequence and by default 
+  where you use atoms to represent each ANSI escape sequence and by default
   checks if ANSI is enabled:
 
       IO.puts(IO.ANSI.format([:blue_background, "Example"]))
@@ -215,6 +215,9 @@ defmodule IO.ANSI do
 
   @doc "Clears screen."
   defsequence(:clear, "2", "J")
+
+  @doc "Clears scrollback buffer."
+  defsequence(:clear_scrollback, "3", "J")
 
   @doc "Clears line."
   defsequence(:clear_line, "2", "K")


### PR DESCRIPTION
This control sequence clears the whole scrollback buffer in xterm and other terminal applications. It is particularly useful in conjunction with `clear/0` when we want to print something continuously without polluting the buffer.

* https://en.wikipedia.org/wiki/ANSI_escape_code#Terminal_output_sequences
* https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Functions-using-CSI-_-ordered-by-the-final-character_s_