### PR TITLE
Add CHANGELOG.md to docs

### DIFF
--- a/lib/elixir/docs.exs
+++ b/lib/elixir/docs.exs
@@ -1,6 +1,6 @@
 # Returns config for Elixir docs
 [
-  extras: Path.wildcard("lib/elixir/pages/*.md"),
+  extras: Path.wildcard("lib/elixir/pages/*.md") ++ ["CHANGELOG.md"],
   groups_for_functions: [
     Guards: & &1[:guard] == true
   ],


### PR DESCRIPTION
Rendering it gives us syntax highlighting, auto-linking, sidebar sections, and more. See how v1.10 changelog would be rendered: http://wojtekmach.pl/otp_docs/elixir/elixir/changelog.html

We could duplicate this changelog to mix/, eex/, etc but I opted not to.