### PR TITLE
Report the correct line number when raising inside of a macro

### DIFF
--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -649,6 +649,12 @@ defmodule Kernel.ParallelCompiler do
     end
   end
 
+  defp get_line(file, _reason, [{_, _, _, [file: 'expanding macro']}, {_, _, _, info} | _]) do
+    if Keyword.get(info, :file) == to_charlist(Path.relative_to_cwd(file)) do
+      Keyword.get(info, :line)
+    end
+  end
+
   defp get_line(file, _reason, [{_, _, _, info} | _]) do
     if Keyword.get(info, :file) == to_charlist(Path.relative_to_cwd(file)) do
       Keyword.get(info, :line)


### PR DESCRIPTION
I've noticed when an exception is raised inside of a macro, the resulting compiler diagnostic has `position: nil`. You can reproduce this issue by invoking the `from` macro from Ecto.Query like so:
```
def list_products do
  from(p in Product, order_whoops: p.id) |> Repo.all()
end
```

I tracked it down and found that when I `raise "error"` in a macro, the compiler receives a :file_error with the following arguments:
```
file: “/path/to/lib/b.ex”
kind: :error
reason: %RuntimeError{message: “error”}
stack: [
   {A, :custom_macro, 0, [file: ‘expanding macro’]},
   {B, :__MODULE__, 0, [file: ‘lib/b.ex’, line: 3]},
   ...
]
```

There was no function clause for get_line that matched that particular stacktrace. Adding one fixes this issue.