### PR TITLE
Pass a valid os option to filename:basedir/3

### DIFF
--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -38,7 +38,7 @@ defmodule Mix.Utils do
         dir
 
       System.get_env("MIX_XDG") in ["1", "true"] ->
-        :filename.basedir(xdg, "mix", %{os: :unix})
+        :filename.basedir(xdg, "mix", %{os: :linux})
 
       true ->
         Path.expand("~/.mix")

--- a/lib/mix/test/mix/utils_test.exs
+++ b/lib/mix/test/mix/utils_test.exs
@@ -131,7 +131,7 @@ defmodule Mix.UtilsTest do
     @tag :unix
     test "falls back to XDG_DATA_HOME/mix" do
       System.put_env("MIX_XDG", "1")
-      assert Mix.Utils.mix_home() == :filename.basedir(:user_data, "mix", %{os: :unix})
+      assert Mix.Utils.mix_home() == :filename.basedir(:user_data, "mix", %{os: :linux})
     end
 
     test "falls back to $HOME/.mix" do
@@ -149,7 +149,7 @@ defmodule Mix.UtilsTest do
     @tag :unix
     test "falls back to XDG_CONFIG_HOME/mix" do
       System.put_env("MIX_XDG", "1")
-      assert Mix.Utils.mix_config() == :filename.basedir(:user_config, "mix", %{os: :unix})
+      assert Mix.Utils.mix_config() == :filename.basedir(:user_config, "mix", %{os: :linux})
     end
 
     test "falls back to $HOME/.mix" do


### PR DESCRIPTION
unix is not one of the documented options and will get interpreted as linux