### PR TITLE
Add :nfkd and :nfkc forms to String.normalize/2

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -682,8 +682,9 @@ defmodule String do
 
   Invalid Unicode codepoints are skipped and the remaining of
   the string is converted. If you want the algorith to stop
-  and return on invalid codepoint, use `:unicode.characters_to_nfd_binary/1`
-  and `:unicode.characters_to_nfc_binary/1` instead.
+  and return on invalid codepoint, use `:unicode.characters_to_nfd_binary/1`,
+  `:unicode.characters_to_nfc_binary/1`, `:unicode.characters_to_nfkd_binary/1`,
+  and `:unicode.characters_to_nfkc_binary/1` instead.
 
   Normalization forms `:nfkc` and `:nfkd` should not be blindly applied
   to arbitrary text. Because they erase many formatting distinctions,

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -685,6 +685,11 @@ defmodule String do
   and return on invalid codepoint, use `:unicode.characters_to_nfd_binary/1`
   and `:unicode.characters_to_nfc_binary/1` instead.
 
+  Normalization forms `:nfkc` and `:nfkd` should not be blindly applied
+  to arbitrary text. Because they erase many formatting distinctions,
+  they will prevent round-trip conversion to and from many legacy
+  character sets.
+
   ## Forms
 
   The supported forms are:
@@ -697,6 +702,14 @@ defmodule String do
     * `:nfc` - Normalization Form Canonical Composition.
       Characters are decomposed and then recomposed by canonical equivalence.
 
+    * `:nfkd` - Normalization Form Compatibility Decomposition.
+      Characters are decomposed by compatibility equivalence, and
+      multiple combining characters are arranged in a specific
+      order.
+
+    * `:nfkc` - Normalization Form Compatibility Composition.
+      Characters are decomposed and then recomposed by compatibility equivalence.
+
   ## Examples
 
       iex> String.normalize("yêṩ", :nfd)
@@ -704,6 +717,12 @@ defmodule String do
 
       iex> String.normalize("leña", :nfc)
       "leña"
+
+      iex> String.normalize("ﬁ", :nfkd)
+      "fi"
+
+      iex> String.normalize("fi", :nfkc)
+      "fi"
 
   """
   def normalize(string, form)
@@ -719,6 +738,20 @@ defmodule String do
     case :unicode.characters_to_nfc_binary(string) do
       string when is_binary(string) -> string
       {:error, good, <<head, rest::binary>>} -> good <> <<head>> <> normalize(rest, :nfc)
+    end
+  end
+
+  def normalize(string, :nfkd) do
+    case :unicode.characters_to_nfkd_binary(string) do
+      string when is_binary(string) -> string
+      {:error, good, <<head, rest::binary>>} -> good <> <<head>> <> normalize(rest, :nfkd)
+    end
+  end
+
+  def normalize(string, :nfkc) do
+    case :unicode.characters_to_nfkc_binary(string) do
+      string when is_binary(string) -> string
+      {:error, good, <<head, rest::binary>>} -> good <> <<head>> <> normalize(rest, :nfkc)
     end
   end
 

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -765,6 +765,11 @@ defmodule StringTest do
     assert String.normalize(<<216, 15>>, :nfc) == <<216, 15>>
     assert String.normalize(<<216, 15>>, :nfd) == <<216, 15>>
 
+    assert String.normalize(<<15, 216>>, :nfkc) == <<15, 216>>
+    assert String.normalize(<<15, 216>>, :nfkd) == <<15, 216>>
+    assert String.normalize(<<216, 15>>, :nfkc) == <<216, 15>>
+    assert String.normalize(<<216, 15>>, :nfkd) == <<216, 15>>
+
     ## Cases from NormalizationTest.txt
 
     # 05B8 05B9 05B1 0591 05C3 05B0 05AC 059F
@@ -794,6 +799,7 @@ defmodule StringTest do
     # 115B9 0334 115AF
     # SIDDHAM VOWEL SIGN AI, COMBINING TILDE OVERLAY, SIDDHAM VOWEL SIGN AA
     assert String.normalize("𑖹̴𑖯", :nfc) == "𑖹̴𑖯"
+
     # HEBREW ACCENT ETNAHTA, HEBREW PUNCTUATION SOF PASUQ, HEBREW POINT SHEVA,
     # HEBREW ACCENT ILUY, HEBREW ACCENT QARNEY PARA
     assert String.normalize("ֱָֹ֑׃ְ֬֟", :nfc) == "ֱָֹ֑׃ְ֬֟"
@@ -823,5 +829,25 @@ defmodule StringTest do
     # 115B9 0334 115AF
     # SIDDHAM VOWEL SIGN AI, COMBINING TILDE OVERLAY, SIDDHAM VOWEL SIGN AA
     assert String.normalize("𑖹̴𑖯", :nfc) == "𑖹̴𑖯"
+
+    # (ﬀ; ﬀ; ﬀ; ff; ff; ) LATIN SMALL LIGATURE FF
+    # FB00;FB00;FB00;0066 0066;0066 0066;
+    assert String.normalize("ﬀ", :nfkd) == "\u0066\u0066"
+
+    # (ﬂ; ﬂ; ﬂ; fl; fl; ) LATIN SMALL LIGATURE FL
+    # FB02;FB02;FB02;0066 006C;0066 006C;
+    assert String.normalize("ﬂ", :nfkd) == "\u0066\u006C"
+
+    # (ﬅ; ﬅ; ﬅ; st; st; ) LATIN SMALL LIGATURE LONG S T
+    # FB05;FB05;FB05;0073 0074;0073 0074;
+    assert String.normalize("ﬅ", :nfkd) == "\u0073\u0074"
+
+    # (ﬆ; ﬆ; ﬆ; st; st; ) LATIN SMALL LIGATURE ST
+    # FB06;FB06;FB06;0073 0074;0073 0074;
+    assert String.normalize("\u0073\u0074", :nfkc) == "\u0073\u0074"
+
+    # (ﬓ; ﬓ; ﬓ; մն; մն; ) ARMENIAN SMALL LIGATURE MEN NOW
+    # FB13;FB13;FB13;0574 0576;0574 0576;
+    assert String.normalize("\u0073\u0074", :nfkc) == "\u0073\u0074"
   end
 end

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -848,6 +848,6 @@ defmodule StringTest do
 
     # (ﬓ; ﬓ; ﬓ; մն; մն; ) ARMENIAN SMALL LIGATURE MEN NOW
     # FB13;FB13;FB13;0574 0576;0574 0576;
-    assert String.normalize("\u0073\u0074", :nfkc) == "\u0073\u0074"
+    assert String.normalize("\u0574\u0576", :nfkc) == "\u0574\u0576"
   end
 end


### PR DESCRIPTION
1. Added `:nfkd` and `:nfkc` normalisation forms to `String.normalize/2`
2. Added two doctests which illustrate non-roundtrip behaviour
3. Added warning that these normalisation forms do not round-trip
4. Updated the description with the 2 additional Erlang functions referenced

I did not add any unit tests since that would now seem to be testing Erlang's implementation - let me know if you would like some additional tests added however.