### PR TITLE
Update Enum.min_max_by/3 spec after #10033

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1902,6 +1902,9 @@ defmodule Enum do
       nil
 
   """
+  @spec min_max_by(t, (element -> any), (element, element -> boolean) | module()) ::
+          {element, element} | empty_result
+        when empty_result: any
   @spec min_max_by(t, (element -> any), (() -> empty_result)) :: {element, element} | empty_result
         when empty_result: any
   @spec min_max_by(


### PR DESCRIPTION
#10033 added a third argument sorter_or_empty_fallback with a default value. To not break compatibility with existing code it also added a function clause that checks third argument's type with a guard and calls Enum.min_max_by/4 with appropriate arguments.

This PR fixes the following dialyzer warnings:

- In user code, e.g. `Enum.min_max_by([1, 2, 3], fn x -> x end, fn -> raise(Enum.EmptyError) end)`:
```
The function call will not succeed.
Enum.min_max_by([1, 2, 3], (_ -> any()), (() -> none()))
will never return since it differs in arguments with
positions 3rd from the success typing arguments:
(any(), (_ -> any()), atom() | (_, _ -> boolean()))
````


- When running dialyzer on Elixir itself:
```
Invalid type specification for function 'Elixir.Enum':min_max_by/3. The success typing is 
(_, fun((_) -> any()), atom() | fun((_, _) -> boolean())) -> any()
```