### PR TITLE
Added @impl to application.ex generated by mix new

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -435,6 +435,7 @@ defmodule Mix.Tasks.New do
 
     use Application
 
+    @impl true
     def start(_type, _args) do
       children = [
         # Starts a worker by calling: <%= @mod %>.Worker.start_link(arg)

--- a/lib/mix/test/mix/tasks/new_test.exs
+++ b/lib/mix/test/mix/tasks/new_test.exs
@@ -55,6 +55,7 @@ defmodule Mix.Tasks.NewTest do
       assert_file("hello_world/lib/hello_world/application.ex", fn file ->
         assert file =~ "defmodule HelloWorld.Application do"
         assert file =~ "use Application"
+        assert file =~ "@impl true"
         assert file =~ "Supervisor.start_link(children, opts)"
       end)
 


### PR DESCRIPTION
Whenever I create a new project with `mix new app_name --sup`, https://github.com/akoutmos/doctor validation will fail since the generated `application.ex` file doesn't have correct documentation. Not to say that my personal library should dictate how Elixir core does things....but more so I just noticed that for correctness, the generated `application.ex` file should annotate which functions satisfy the `Application` behaviour.

Thanks in advance for any feedback :)