### PR TITLE
Add mix format.gen command to generate .formatter.exs in current project

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -320,7 +320,8 @@ defmodule Mix.Tasks.Format do
     if no_entries_in_formatter_opts?(formatter_opts_and_subs) do
       Mix.raise(
         "Expected one or more files/patterns to be given to mix format " <>
-          "or for a .formatter.exs to exist with an :inputs or :subdirectories key"
+          "or for a .formatter.exs to exist with an :inputs or :subdirectories key." <>
+          "Run mix format.gen to generate a .formatter.exs"
       )
     end
 

--- a/lib/mix/lib/mix/tasks/format.gen.ex
+++ b/lib/mix/lib/mix/tasks/format.gen.ex
@@ -1,0 +1,16 @@
+defmodule Mix.Tasks.Format.Gen do
+  use Mix.Task
+
+  @shortdoc "Generates a .formatter.exs file in the current project"
+
+  @path ".formatter.exs"
+
+  @impl true
+  def run(_) do
+    cond do
+      File.exists?(@path) -> Mix.raise(@path <> " already exists")
+      File.exists?("apps/") -> File.write!(@path, Mix.Tasks.New.formatter_umbrella_template())
+      true -> File.write!(@path, Mix.Tasks.New.formatter_template())
+    end
+  end
+end

--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -252,20 +252,28 @@ defmodule Mix.Tasks.New do
   <% end %>
   """)
 
-  embed_template(:formatter, """
+  @formatter_template """
   # Used by "mix format"
   [
     inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
   ]
-  """)
+  """
 
-  embed_template(:formatter_umbrella, """
+  def formatter_template, do: @formatter_template
+
+  embed_template(:formatter, @formatter_template)
+
+  @formatter_umbrella_template """
   # Used by "mix format"
   [
     inputs: ["mix.exs", "config/*.exs"],
     subdirectories: ["apps/*"]
   ]
-  """)
+  """
+
+  def formatter_umbrella_template, do: @formatter_umbrella_template
+
+  embed_template(:formatter_umbrella, @formatter_umbrella_template)
 
   embed_template(:gitignore, """
   # The directory Mix will write compiled artifacts to.

--- a/lib/mix/test/mix/tasks/format.gen_test.exs
+++ b/lib/mix/test/mix/tasks/format.gen_test.exs
@@ -1,0 +1,58 @@
+Code.require_file("../../test_helper.exs", __DIR__)
+
+defmodule Mix.Tasks.Format.GenTest do
+  use MixTest.Case
+
+  @config_path ".formatter.exs"
+
+  describe "mix format.gen" do
+    test "already exists" do
+      in_tmp("format.gen exists", fn ->
+        Mix.Tasks.New.run(["hello_world"])
+
+        File.cd!("hello_world", fn ->
+          message = @config_path <> " already exists"
+
+          assert_raise Mix.Error, message, fn -> Mix.Tasks.Format.Gen.run([]) end
+        end)
+      end)
+    end
+
+    test "in umbrella" do
+      in_tmp("format.gen umbrella", fn ->
+        Mix.Tasks.New.run(["hello_world", "--umbrella"])
+
+        File.cd!("hello_world", fn ->
+          File.rm!(@config_path)
+
+          assert :ok == Mix.Tasks.Format.Gen.run([])
+
+          assert_file(@config_path, fn contents ->
+            assert contents == Mix.Tasks.New.formatter_umbrella_template()
+          end)
+        end)
+      end)
+    end
+
+    test "not in umbrella" do
+      in_tmp("format.gen not umbrella", fn ->
+        Mix.Tasks.New.run(["hello_world"])
+
+        File.cd!("hello_world", fn ->
+          File.rm!(@config_path)
+
+          assert :ok == Mix.Tasks.Format.Gen.run([])
+
+          assert_file(@config_path, fn contents ->
+            assert contents == Mix.Tasks.New.formatter_template()
+          end)
+        end)
+      end)
+    end
+  end
+
+  defp assert_file(file, match) do
+    assert File.regular?(file), "Expected #{file} to exist, but does not"
+    match.(File.read!(file))
+  end
+end


### PR DESCRIPTION
Adds a `mix format.gen` command to generate an appropriate `.formatter.exs` file in the current project. The file generated uses the same code as the one generated when running `mix new`, detecting umbrella projects and using the appropriate config. Useful for those older projects you jump into and `mix format` fails because formatter wasn't a thing back then.