### PR TITLE
Doctest to generate tests also from @typedoc

### DIFF
--- a/lib/ex_unit/lib/ex_unit/doc_test.ex
+++ b/lib/ex_unit/lib/ex_unit/doc_test.ex
@@ -493,7 +493,7 @@ defmodule ExUnit.DocTest do
   end
 
   defp extract_from_doc({{kind, _, _}, _, _, doc, _}, _module)
-       when kind not in [:function, :macro] or doc in [:none, :hidden],
+       when kind not in [:function, :macro, :type] or doc in [:none, :hidden],
        do: []
 
   defp extract_from_doc({{_, name, arity}, annotation, _, %{"en" => doc}, _}, module) do

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -213,6 +213,12 @@ defmodule ExUnit.DocTestTest.Invalid do
       {:ok, #MapSet<[1, 2, 3]>}
   """
   def misplaced_opaque_type, do: :ok
+
+  @typedoc """
+      iex> 1 + * 1
+      1
+  """
+  @type t :: any()
 end
 |> write_beam
 
@@ -422,7 +428,7 @@ defmodule ExUnit.DocTestTest.PatternMatching do
       # false assertions do not accidentally raise
       iex> false = (List.flatten([]) != [])
   """
-  def starting_line(), do: 392
+  def starting_line(), do: 398
 end
 |> write_beam
 
@@ -664,6 +670,17 @@ defmodule ExUnit.DocTestTest do
                   1
                 stacktrace:
                   test/ex_unit/doc_test_test.exs:176: ExUnit.DocTestTest.Invalid (module)
+           """
+
+    assert output =~ """
+            15) doctest ExUnit.DocTestTest.Invalid.t/0 (15) (ExUnit.DocTestTest.ActuallyCompiled)
+                test/ex_unit/doc_test_test.exs:#{doctest_line}
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:218: syntax error before: '*'
+                doctest:
+                  iex> 1 + * 1
+                  1
+                stacktrace:
+                  test/ex_unit/doc_test_test.exs:218: ExUnit.DocTestTest.Invalid (module)
            """
   end
 


### PR DESCRIPTION
This PR allows generating tests from example codes in `@typedoc` with doctest, related this topic:
https://elixirforum.com/t/doctest-with-typedoc/31772