### PR TITLE
Remove unnecessary lists:reverse/1 call in Map.new

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -208,9 +208,7 @@ defmodule Map do
   end
 
   defp new_transform([], _fun, acc) do
-    acc
-    |> :lists.reverse()
-    |> :maps.from_list()
+    :maps.from_list(acc)
   end
 
   defp new_transform([element | rest], fun, acc) do


### PR DESCRIPTION
I noticed this `:lists.reverse/1` call in the inner `Map.new` functions. AFAIK this is unnecessary since, unlike lists, maps do not have order. Therefore, reversing a list should be irrelevant to creating a map from a list. Unless there's a very obscure detail about Erlang I'm missing 🙂

Thanks