### PR TITLE
Link to Typespec docs from Module documentation

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -350,6 +350,8 @@ defmodule Module do
       behaviour callbacks are optional
     * `@impl` - declares an implementation of a callback function or macro
 
+  For detailed documentation, see the [typespec documentation](typespecs.md).
+
   ### Custom attributes
 
   In addition to the built-in attributes outlined above, custom attributes may


### PR DESCRIPTION
In other places in the `Module` documentation this is referenced, but it's a bit hard to find when you're in this section, and this section's documentation on these attribute is a bit limited.