### PR TITLE
docs corrections for Mix.Generator.copy_file, Mix.Generator.copy_template

### DIFF
--- a/lib/mix/lib/mix/generator.ex
+++ b/lib/mix/lib/mix/generator.ex
@@ -71,7 +71,7 @@ defmodule Mix.Generator do
 
   ## Examples
 
-      iex> Mix.Generator.copy_file("source/gitignore", ".gitignore", "_build\ndeps\n")
+      iex> Mix.Generator.copy_file("source/gitignore", ".gitignore")
       * creating .gitignore
       true
 
@@ -97,7 +97,7 @@ defmodule Mix.Generator do
 
   ## Examples
 
-      iex> Mix.Generator.copy_template("source/gitignore", ".gitignore", [project_path: path])
+      iex> Mix.Generator.copy_template("source/gitignore", ".gitignore")
       * creating .gitignore
       true
 


### PR DESCRIPTION
The documentation for `Mix.Generator.copy_file` and `Mix.Generator.copy_template` had examples that do not match their function specs.

Related: should these examples be run as doctests?