### PR TITLE
undo change removing assigns from Mix.Generator.copy_template docs

### DIFF
--- a/lib/mix/lib/mix/generator.ex
+++ b/lib/mix/lib/mix/generator.ex
@@ -97,7 +97,8 @@ defmodule Mix.Generator do
 
   ## Examples
 
-      iex> Mix.Generator.copy_template("source/gitignore", ".gitignore", [project_path: path])
+      iex> assigns = [project_path: path]
+      iex> Mix.Generator.copy_template("source/gitignore", ".gitignore", assigns)
       * creating .gitignore
       true
 

--- a/lib/mix/lib/mix/generator.ex
+++ b/lib/mix/lib/mix/generator.ex
@@ -97,7 +97,7 @@ defmodule Mix.Generator do
 
   ## Examples
 
-      iex> assigns = [project_path: path]
+      iex> assigns = [project_path: "/Users/joe/newproject"]
       iex> Mix.Generator.copy_template("source/gitignore", ".gitignore", assigns)
       * creating .gitignore
       true

--- a/lib/mix/lib/mix/generator.ex
+++ b/lib/mix/lib/mix/generator.ex
@@ -97,7 +97,7 @@ defmodule Mix.Generator do
 
   ## Examples
 
-      iex> Mix.Generator.copy_template("source/gitignore", ".gitignore")
+      iex> Mix.Generator.copy_template("source/gitignore", ".gitignore", [project_path: path])
       * creating .gitignore
       true
 


### PR DESCRIPTION
Reverts a bad docs change that removed a necessary argument from the code example for `Mix.Generator.copy_template`.

I took `[project_path: path]` to be the `opts` parameter, but it was actually `assigns`. 😳 