### PR TITLE
Returning microseconds on `NaiveDateTime.to_gregorian_seconds`

### DIFF
--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -819,13 +819,13 @@ defmodule NaiveDateTime do
   ## Examples
 
       iex> NaiveDateTime.to_gregorian_seconds(~N[0000-01-01 00:00:01])
-      1
+      {1, 0}
       iex> NaiveDateTime.to_gregorian_seconds(~N[2020-05-01 00:26:31.005])
-      63_755_511_991
+      {63_755_511_991, 5000}
 
   """
   @doc since: "1.11.0"
-  @spec to_gregorian_seconds(Calendar.naive_datetime()) :: integer()
+  @spec to_gregorian_seconds(Calendar.naive_datetime()) :: {integer(), integer()}
   def to_gregorian_seconds(%{
         calendar: calendar,
         year: year,
@@ -848,7 +848,7 @@ defmodule NaiveDateTime do
       )
 
     seconds_in_day = seconds_from_day_fraction(day_fraction)
-    days * @seconds_per_day + seconds_in_day
+    {days * @seconds_per_day + seconds_in_day, microsecond}
   end
 
   @doc """

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -825,7 +825,7 @@ defmodule NaiveDateTime do
 
   """
   @doc since: "1.11.0"
-  @spec to_gregorian_seconds(Calendar.naive_datetime()) :: {integer(), integer()}
+  @spec to_gregorian_seconds(Calendar.naive_datetime()) :: {integer(), non_neg_integer()}
   def to_gregorian_seconds(%{
         calendar: calendar,
         year: year,

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -814,7 +814,7 @@ defmodule NaiveDateTime do
   end
 
   @doc """
-  Converts a `NaiveDateTime` struct to a number of gregorian seconds.
+  Converts a `NaiveDateTime` struct to a number of gregorian seconds and microseconds.
 
   ## Examples
 

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -402,16 +402,16 @@ defmodule Time do
   ## Examples
 
       iex> Time.to_seconds_after_midnight(~T[23:30:15])
-      84615
+      {84615, 0}
       iex> Time.to_seconds_after_midnight(~N[2010-04-17 23:30:15.999])
-      84615
+      {84615, 999000}
 
   """
   @doc since: "1.11.0"
   @spec to_seconds_after_midnight(Calendar.time()) :: integer()
-  def to_seconds_after_midnight(time) do
+  def to_seconds_after_midnight(%{microsecond: {microsecond, _precision}} = time) do
     iso_days = {0, to_day_fraction(time)}
-    Calendar.ISO.iso_days_to_unit(iso_days, :second)
+    {Calendar.ISO.iso_days_to_unit(iso_days, :second), microsecond}
   end
 
   @doc """

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -410,7 +410,7 @@ defmodule Time do
 
   """
   @doc since: "1.11.0"
-  @spec to_seconds_after_midnight(Calendar.time()) :: integer()
+  @spec to_seconds_after_midnight(Calendar.time()) :: {integer(), integer()}
   def to_seconds_after_midnight(%{microsecond: {microsecond, _precision}} = time) do
     iso_days = {0, to_day_fraction(time)}
     {Calendar.ISO.iso_days_to_unit(iso_days, :second), microsecond}

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -399,6 +399,8 @@ defmodule Time do
   @doc """
   Converts a `Time` struct to a number of seconds after midnight.
 
+  The returned value is a two-element tuple with the number of seconds and microseconds.
+
   ## Examples
 
       iex> Time.to_seconds_after_midnight(~T[23:30:15])

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -410,7 +410,7 @@ defmodule Time do
 
   """
   @doc since: "1.11.0"
-  @spec to_seconds_after_midnight(Calendar.time()) :: {integer(), integer()}
+  @spec to_seconds_after_midnight(Calendar.time()) :: {integer(), non_neg_integer()}
   def to_seconds_after_midnight(%{microsecond: {microsecond, _precision}} = time) do
     iso_days = {0, to_day_fraction(time)}
     {Calendar.ISO.iso_days_to_unit(iso_days, :second), microsecond}


### PR DESCRIPTION
Discussed in #10061 