### PR TITLE
Print which deps got unlocked

### DIFF
--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -354,6 +354,13 @@ defmodule Mix.Tasks.DepsTest do
       assert Mix.Dep.Lock.read() == %{whatever: "abcdef", ok: "abcdef"}
       Mix.Tasks.Deps.Unlock.run(["--unused"])
       assert Mix.Dep.Lock.read() == %{ok: "abcdef"}
+
+      output = """
+      Unlocked deps:
+      * whatever
+      """
+
+      assert_received {:mix_shell, :info, [^output]}
     end)
   end
 
@@ -366,6 +373,13 @@ defmodule Mix.Tasks.DepsTest do
       assert Mix.Dep.Lock.read() == %{another: "hash"}
       error = "warning: unknown dependency is not locked"
       assert_received {:mix_shell, :error, [^error]}
+
+      output = """
+      Unlocked deps:
+      * git_repo
+      """
+
+      assert_received {:mix_shell, :info, [^output]}
     end)
   end
 


### PR DESCRIPTION
Before this patch, we only printed which deps got unlocked when
`--filter` option was used. Now we do it everywhere else, that is
when passing specific apps to unlock and when using `--unused`.