### PR TITLE
Don't add compile-time dependency on defdelegate

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4931,6 +4931,18 @@ defmodule Kernel do
   defmacro defdelegate(funs, opts) do
     funs = Macro.escape(funs, unquote: true)
 
+    # don't add compile-time dependency on :to
+    opts =
+      with true <- is_list(opts),
+           {:ok, target} <- Keyword.fetch(opts, :to),
+           {:__aliases__, _, _} <- target do
+        target = Macro.expand(target, %{__CALLER__ | lexical_tracker: nil})
+        Keyword.replace!(opts, :to, target)
+      else
+        _ ->
+          opts
+      end
+
     quote bind_quoted: [funs: funs, opts: opts] do
       target =
         Keyword.get(opts, :to) || raise ArgumentError, "expected to: to be given as argument"

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4936,7 +4936,7 @@ defmodule Kernel do
       with true <- is_list(opts),
            {:ok, target} <- Keyword.fetch(opts, :to),
            {:__aliases__, _, _} <- target do
-        target = Macro.expand(target, %{__CALLER__ | lexical_tracker: nil})
+        target = Macro.expand(target, %{__CALLER__ | function: {:__info__, 1}})
         Keyword.replace!(opts, :to, target)
       else
         _ ->

--- a/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
+++ b/lib/elixir/test/elixir/kernel/lexical_tracker_test.exs
@@ -126,4 +126,21 @@ defmodule Kernel.LexicalTrackerTest do
     refute Foo.Bar in runtime
     refute Foo.Bar in compile
   end
+
+  test "defdelegate with literal does not add compile dependency" do
+    {{compile, _structs, _runtime, _}, _binding} =
+      Code.eval_string("""
+      defmodule Kernel.LexicalTrackerTest.Defdelegate do
+        defdelegate a, to: A
+
+        opts = [to: B]
+        defdelegate b, opts
+
+        Kernel.LexicalTracker.references(__ENV__.lexical_tracker)
+      end |> elem(3)
+      """)
+
+    refute A in compile
+    assert B in compile
+  end
 end


### PR DESCRIPTION
The dependency doesn't seem needed in this case.

We go through extra hoops to maintain backwards compatibility,
`opts` does not have to be a compile-time list and :to does not have
to be a literal.

An easy way to see this optimization is:

    defmodule A do
      defdelegate f(), to: B
    end

    defmodule B do
      def f() do
        :ok
      end
    end

    $ touch lib/b.ex && mix compile --verbose
    Compiling 1 file (.ex)
    Compiled lib/b.ex

vs:

    defmodule A do
      opts = [to: B]
      defdelegate f(), opts
    end

    defmodule B do
      def f() do
        :ok
      end
    end

    $ touch lib/b.ex && mix compile --verbose
    Compiling 2 files (.ex)
    Compiled lib/b.ex
    Compiled lib/a.ex