### PR TITLE
Rewording the default arguments warnings

### DIFF
--- a/lib/elixir/src/elixir_locals.erl
+++ b/lib/elixir/src/elixir_locals.erl
@@ -121,13 +121,13 @@ format_error({function_conflict, {Receiver, {Name, Arity}}}) ->
     [elixir_aliases:inspect(Receiver), Name, Arity]);
 
 format_error({unused_args, {Name, Arity}}) ->
-  io_lib:format("default arguments in ~ts/~B are never used", [Name, Arity]);
+  io_lib:format("default values for the arguments in ~ts/~B are never used", [Name, Arity]);
 
 format_error({unused_args, {Name, Arity}, 1}) ->
-  io_lib:format("the first default argument in ~ts/~B is never used", [Name, Arity]);
+  io_lib:format("the default value for the first argument in ~ts/~B is never used", [Name, Arity]);
 
 format_error({unused_args, {Name, Arity}, Count}) ->
-  io_lib:format("the first ~B default arguments in ~ts/~B are never used", [Count, Name, Arity]);
+  io_lib:format("the default values for the first ~B arguments in ~ts/~B are never used", [Count, Name, Arity]);
 
 format_error({unused_def, {Name, Arity}, defp}) ->
   io_lib:format("function ~ts/~B is unused", [Name, Arity]);

--- a/lib/elixir/src/elixir_locals.erl
+++ b/lib/elixir/src/elixir_locals.erl
@@ -121,13 +121,13 @@ format_error({function_conflict, {Receiver, {Name, Arity}}}) ->
     [elixir_aliases:inspect(Receiver), Name, Arity]);
 
 format_error({unused_args, {Name, Arity}}) ->
-  io_lib:format("default values for the arguments in ~ts/~B are never used", [Name, Arity]);
+  io_lib:format("default values for the optional arguments in ~ts/~B are never used", [Name, Arity]);
 
 format_error({unused_args, {Name, Arity}, 1}) ->
-  io_lib:format("the default value for the first argument in ~ts/~B is never used", [Name, Arity]);
+  io_lib:format("the default value for the first optional argument in ~ts/~B is never used", [Name, Arity]);
 
 format_error({unused_args, {Name, Arity}, Count}) ->
-  io_lib:format("the default values for the first ~B arguments in ~ts/~B are never used", [Count, Name, Arity]);
+  io_lib:format("the default values for the first ~B optional arguments in ~ts/~B are never used", [Count, Name, Arity]);
 
 format_error({unused_def, {Name, Arity}, defp}) ->
   io_lib:format("function ~ts/~B is unused", [Name, Arity]);

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -455,7 +455,8 @@ defmodule Kernel.WarningTest do
                defp b(arg1 \\ 1, arg2 \\ 2, arg3 \\ 3), do: [arg1, arg2, arg3]
              end
              """)
-           end) =~ "the default value for the first optional argument in b/3 is never used\n  nofile:3"
+           end) =~
+             "the default value for the first optional argument in b/3 is never used\n  nofile:3"
 
     assert capture_err(fn ->
              Code.eval_string(~S"""

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -436,7 +436,7 @@ defmodule Kernel.WarningTest do
                defp b(arg1 \\ 1, arg2 \\ 2, arg3 \\ 3), do: [arg1, arg2, arg3]
              end
              """)
-           end) =~ "default arguments in b/3 are never used\n  nofile:3"
+           end) =~ "default values for the arguments in b/3 are never used\n  nofile:3"
 
     assert capture_err(fn ->
              Code.eval_string(~S"""
@@ -445,7 +445,8 @@ defmodule Kernel.WarningTest do
                defp b(arg1 \\ 1, arg2 \\ 2, arg3 \\ 3), do: [arg1, arg2, arg3]
              end
              """)
-           end) =~ "the first 2 default arguments in b/3 are never used\n  nofile:3"
+           end) =~
+             "the default values for the first 2 arguments in b/3 are never used\n  nofile:3"
 
     assert capture_err(fn ->
              Code.eval_string(~S"""
@@ -454,7 +455,7 @@ defmodule Kernel.WarningTest do
                defp b(arg1 \\ 1, arg2 \\ 2, arg3 \\ 3), do: [arg1, arg2, arg3]
              end
              """)
-           end) =~ "the first default argument in b/3 is never used\n  nofile:3"
+           end) =~ "the default value for the first argument in b/3 is never used\n  nofile:3"
 
     assert capture_err(fn ->
              Code.eval_string(~S"""
@@ -474,7 +475,7 @@ defmodule Kernel.WarningTest do
                defp b(arg1, arg2, arg3), do: [arg1, arg2, arg3]
              end
              """)
-           end) =~ "default arguments in b/3 are never used\n  nofile:3"
+           end) =~ "default values for the arguments in b/3 are never used\n  nofile:3"
 
     assert capture_err(fn ->
              Code.eval_string(~S"""
@@ -485,7 +486,8 @@ defmodule Kernel.WarningTest do
                defp b(arg1, arg2, arg3), do: [arg1, arg2, arg3]
              end
              """)
-           end) =~ "the first 2 default arguments in b/3 are never used\n  nofile:3"
+           end) =~
+             "the default values for the first 2 arguments in b/3 are never used\n  nofile:3"
   after
     purge([Sample1, Sample2, Sample3, Sample4, Sample5, Sample6])
   end

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -436,7 +436,7 @@ defmodule Kernel.WarningTest do
                defp b(arg1 \\ 1, arg2 \\ 2, arg3 \\ 3), do: [arg1, arg2, arg3]
              end
              """)
-           end) =~ "default values for the arguments in b/3 are never used\n  nofile:3"
+           end) =~ "default values for the optional arguments in b/3 are never used\n  nofile:3"
 
     assert capture_err(fn ->
              Code.eval_string(~S"""
@@ -446,7 +446,7 @@ defmodule Kernel.WarningTest do
              end
              """)
            end) =~
-             "the default values for the first 2 arguments in b/3 are never used\n  nofile:3"
+             "the default values for the first 2 optional arguments in b/3 are never used\n  nofile:3"
 
     assert capture_err(fn ->
              Code.eval_string(~S"""
@@ -455,7 +455,7 @@ defmodule Kernel.WarningTest do
                defp b(arg1 \\ 1, arg2 \\ 2, arg3 \\ 3), do: [arg1, arg2, arg3]
              end
              """)
-           end) =~ "the default value for the first argument in b/3 is never used\n  nofile:3"
+           end) =~ "the default value for the first optional argument in b/3 is never used\n  nofile:3"
 
     assert capture_err(fn ->
              Code.eval_string(~S"""
@@ -475,7 +475,7 @@ defmodule Kernel.WarningTest do
                defp b(arg1, arg2, arg3), do: [arg1, arg2, arg3]
              end
              """)
-           end) =~ "default values for the arguments in b/3 are never used\n  nofile:3"
+           end) =~ "default values for the optional arguments in b/3 are never used\n  nofile:3"
 
     assert capture_err(fn ->
              Code.eval_string(~S"""
@@ -487,7 +487,7 @@ defmodule Kernel.WarningTest do
              end
              """)
            end) =~
-             "the default values for the first 2 arguments in b/3 are never used\n  nofile:3"
+             "the default values for the first 2 optional arguments in b/3 are never used\n  nofile:3"
   after
     purge([Sample1, Sample2, Sample3, Sample4, Sample5, Sample6])
   end


### PR DESCRIPTION
Refs #10095 

I took the liberty of also rewording the other warnings about arguments with default values, so they all look alike.