### PR TITLE
include callers in translated Logger metadata for Task

### DIFF
--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -112,7 +112,8 @@ defmodule Task.Supervised do
           %{
             domain: [:otp, :elixir],
             error_logger: %{tag: :error_msg},
-            report_cb: &__MODULE__.format_report/1
+            report_cb: &__MODULE__.format_report/1,
+            callers: Process.get(:"$callers")
           }
         )
 


### PR DESCRIPTION
Discussed with @josevalim a bit, and this is to be able to get callers from Logger metadata

Things I'm not sure on: Whether new test should be written, or if there are other modules (GenServer?) that could also do this.