### PR TITLE
Correct doc, add spec and update TODO comment in System.stacktrace/0

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -591,14 +591,14 @@ defmodule System do
   `__STACKTRACE__/0` inside a rescue/catch. If you want to support
   earlier Elixir versions, move `System.stacktrace/0` inside a rescue/catch.
 
-  From Erlang/OTP 23+ this always returns an empty list.
+  Starting from Erlang/OTP 23, this function will always return an empty list.
 
   Note that the Erlang VM (and therefore this function) does not
   return the current stacktrace but rather the stacktrace of the
   latest exception. To retrieve the stacktrace of the current process,
   use `Process.info(self(), :current_stacktrace)` instead.
   """
-  # TODO: Remove conditional once Erlang/OTP 23 is required
+  # TODO: Once Erlang/OTP 23 is required, remove conditional, and update @doc accordingly.
   # The warning is emitted by the compiler - so a @doc annotation is enough
   @doc deprecated: "Use __STACKTRACE__ instead"
   if function_exported?(:erlang, :get_stacktrace, 0) do


### PR DESCRIPTION
the documentation fix corrects the use of "from" and the ~plug~ plus suffix.