### PR TITLE
Adding support for being more granular when stripping beam files

### DIFF
--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -790,9 +790,11 @@ defmodule Mix.Release do
   The exact chunks that are kept are not documented and may change in
   future versions.
   """
-  @spec strip_beam(binary(), List.t()) :: {:ok, binary} | {:error, :beam_lib, term}
-  def strip_beam(binary, options \\ [keep: []]) when is_list(options) do
-    case :beam_lib.chunks(binary, Enum.uniq(@significant_chunks ++ options[:keep]), [
+  @spec strip_beam(binary(), keyword()) :: {:ok, binary()} | {:error, :beam_lib, term()}
+  def strip_beam(binary, options \\ []) when is_list(options) do
+    chunks_to_keep = Keyword.get(options, :keep, [])
+
+    case :beam_lib.chunks(binary, Enum.uniq(@significant_chunks ++ chunks_to_keep), [
            :allow_missing_chunks
          ]) do
       {:ok, {_, chunks}} ->
@@ -810,7 +812,7 @@ defmodule Mix.Release do
   end
 
   @doc false
-  @spec parse_strip_beams_option(true | false | Keyword.t()) :: {true | false, List.t() | nil}
+  @spec parse_strip_beams_option(true | false | keyword()) :: {true | false, keyword() | nil}
   def parse_strip_beams_option(option) do
     case option do
       [keep: exceptions] when is_list(exceptions) -> {true, [keep: exceptions]}

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -161,7 +161,7 @@ defmodule Mix.Tasks.Escript.Build do
     # use default true if neither are present.
     #
     # TODO: Deprecate :strip_beam option on v1.13
-    {strip_beams?, chunks_to_keep} =
+    {strip_beams?, strip_options} =
       escript_opts
       |> Keyword.get_lazy(:strip_beams, fn ->
         Keyword.get(escript_opts, :strip_beam, true)
@@ -177,7 +177,7 @@ defmodule Mix.Tasks.Escript.Build do
       |> Map.merge(consolidated_paths(project))
 
     tuples = gen_main(project, escript_mod, main, app, language) ++ read_beams(beam_paths)
-    tuples = if strip_beams?, do: strip_beams(tuples, chunks_to_keep), else: tuples
+    tuples = if strip_beams?, do: strip_beams(tuples, strip_options), else: tuples
 
     case :zip.create('mem', tuples, [:memory]) do
       {:ok, {'mem', zip}} ->

--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -271,10 +271,10 @@ defmodule Mix.Tasks.Escript.Build do
     end)
   end
 
-  defp strip_beams(tuples, exceptions) do
+  defp strip_beams(tuples, strip_options) do
     for {basename, maybe_beam} <- tuples do
       with ".beam" <- Path.extname(basename),
-           {:ok, binary} <- Mix.Release.strip_beam(maybe_beam, exceptions) do
+           {:ok, binary} <- Mix.Release.strip_beam(maybe_beam, strip_options) do
         {basename, binary}
       else
         _ -> {basename, maybe_beam}

--- a/lib/mix/test/mix/release_test.exs
+++ b/lib/mix/test/mix/release_test.exs
@@ -692,14 +692,12 @@ defmodule Mix.ReleaseTest do
       assert {:error, :beam_lib, {:missing_chunk, _, 'Dbgi'}} = :beam_lib.chunks(beam, ['Dbgi'])
       assert {:error, :beam_lib, {:missing_chunk, _, 'Docs'}} = :beam_lib.chunks(beam, ['Docs'])
     end
-  end
 
-  describe "strip_beam/2" do
     test "can keep docs and debug info, if requested" do
       {:ok, beam} =
         Path.join(@eex_ebin, "Elixir.EEx.beam")
         |> File.read!()
-        |> strip_beam(['Docs', 'Dbgi'])
+        |> strip_beam(keep: ['Docs', 'Dbgi'])
 
       assert {:ok, {EEx, [{'Dbgi', _}]}} = :beam_lib.chunks(beam, ['Dbgi'])
       assert {:ok, {EEx, [{'Docs', _}]}} = :beam_lib.chunks(beam, ['Docs'])

--- a/lib/mix/test/mix/release_test.exs
+++ b/lib/mix/test/mix/release_test.exs
@@ -694,6 +694,18 @@ defmodule Mix.ReleaseTest do
     end
   end
 
+  describe "strip_beam/2" do
+    test "can keep docs and debug info, if requested" do
+      {:ok, beam} =
+        Path.join(@eex_ebin, "Elixir.EEx.beam")
+        |> File.read!()
+        |> strip_beam(['Docs', 'Dbgi'])
+
+      assert {:ok, {EEx, [{'Dbgi', _}]}} = :beam_lib.chunks(beam, ['Dbgi'])
+      assert {:ok, {EEx, [{'Docs', _}]}} = :beam_lib.chunks(beam, ['Docs'])
+    end
+  end
+
   describe "included applications" do
     test "are included in the release", context do
       in_tmp(context.test, fn ->


### PR DESCRIPTION
This PR attempts to add a bit more granular control over what gets stripped from the BEAM files, when the strip_beams option is set to true in the mix release options.

For now it allows passing a couple of exceptions in a list, namely :docs and :debug_info. The exceptions passed in the options will *not* get stripped from the BEAM files.

For reference: https://github.com/elixir-lang/elixir/issues/10122

Be gentle on me, it's my first one :)