### PR TITLE
Fix bug in Inspect.AlgebraTest

### DIFF
--- a/lib/elixir/test/elixir/inspect/algebra_test.exs
+++ b/lib/elixir/test/elixir/inspect/algebra_test.exs
@@ -126,7 +126,7 @@ defmodule Inspect.AlgebraTest do
     assert nest(empty(), :reset) == {:doc_nest, empty(), :reset, :always}
 
     # Consistent formatting
-    assert render(nest("a", :cursor), 80) == "a"
+    assert render(nest("a", :reset), 80) == "a"
     assert render(nest(nest(glue("a", "b"), :reset), 10), 2) == "a\nb"
     assert render(nest(nest(line("a", "b"), :reset), 10), 2) == "a\nb"
   end

--- a/lib/elixir/test/elixir/inspect/algebra_test.exs
+++ b/lib/elixir/test/elixir/inspect/algebra_test.exs
@@ -123,7 +123,7 @@ defmodule Inspect.AlgebraTest do
 
   test "reset nest doc" do
     # Consistent with definitions
-    assert nest(empty(), :cursor) == {:doc_nest, empty(), :cursor, :always}
+    assert nest(empty(), :reset) == {:doc_nest, empty(), :reset, :always}
 
     # Consistent formatting
     assert render(nest("a", :cursor), 80) == "a"


### PR DESCRIPTION
This looks like a copy-paste error. This test is supposed to test the `:reset` implementation, the previous one covers `:cursor` already.