### PR TITLE
Add column information to assigns in EEx templates

### DIFF
--- a/lib/eex/lib/eex/engine.ex
+++ b/lib/eex/lib/eex/engine.ex
@@ -119,11 +119,21 @@ defmodule EEx.Engine do
   @spec handle_assign(Macro.t()) :: Macro.t()
   def handle_assign({:@, meta, [{name, _, atom}]}) when is_atom(name) and is_atom(atom) do
     line = meta[:line] || 0
+
     quote(line: line, do: EEx.Engine.fetch_assign!(var!(assigns), unquote(name)))
+    |> maybe_put_column(meta[:column])
   end
 
   def handle_assign(arg) do
     arg
+  end
+
+  defp maybe_put_column(quoted, nil) do
+    quoted
+  end
+
+  defp maybe_put_column(quoted, column) do
+    Macro.update_meta(quoted, &Keyword.put(&1, :column, column))
   end
 
   @doc false


### PR DESCRIPTION
Ref: https://github.com/elixir-lang/elixir/pull/9712#issuecomment-650289294
cc @JMurphyWeb


Before this patch we had:

    iex> Code.put_compiler_option(:parser_options, columns: true)
    iex> {_, _, [{_, _, [_, {_, _, [x]}]}, _]} = EEx.compile_string("<%= foo(@hi) %>"); x
    {:foo, [line: 1, column: 5],
     [
       {{:., [line: 1],
         [{:__aliases__, [line: 1, alias: false], [:EEx, :Engine]}, :fetch_assign!]},
        [line: 1],
        [
          {:var!, [line: 1, context: EEx.Engine, import: Kernel],
           [{:assigns, [line: 1], EEx.Engine}]},
          :hi
        ]}
     ]}

Note, no column information on the assign access.

After this patch we have:

    {:foo, [line: 1, column: 5],
     [
       {{:., [line: 1],
         [{:__aliases__, [line: 1, alias: false], [:EEx, :Engine]}, :fetch_assign!]},
        [column: 9, line: 1],
        [
          {:var!, [line: 1, context: EEx.Engine, import: Kernel],
           [{:assigns, [line: 1], EEx.Engine}]},
          :hi
        ]}
     ]}

(note: `[line: ..., column: ...]` vs `[column: ..., line: ...]` hence
sorting in the test.)

I'm not sure if other nodes in the AST should also get the column,
I suppose it's fine to add it to the `EEx.Engine` one, but not sure if
it is appropriate to add it to the `fetch_assign!` and `var!` ones
as the column offset would be artificial. For the reason, maybe we
shouldn't change the column information after all.