### PR TITLE
Deal with lists with more than 1023 elements on the right hand side of in/2

### DIFF
--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -374,13 +374,17 @@ defmodule KernelTest do
   end
 
   describe "in/2" do
-    test "too large list in guards" do
-      assert_raise ArgumentError, ~r"in/2 supports only up to 1023 elements", fn ->
-        defmodule TooLargeList do
-          @list List.duplicate([:ok], 1024)
-          def value(value) when value in @list, do: :ok
-        end
+    test "lists in guards largen than 1023" do
+      defmodule LargeList do
+        @list Enum.map(1..2500, &to_string(&1))
+        def has?(value) when value in @list, do: true
+        def has?(_), do: false
       end
+
+      assert LargeList.has?("1") == true
+      assert LargeList.has?("1000") == true
+      assert LargeList.has?("2500") == true
+      assert LargeList.has?("2501") == false
     end
 
     test "with literals on right side" do


### PR DESCRIPTION
When dealing with lists with more than 1023 elements,
the VM will crash, so we split the list in chunks of 1023 elements,
and we fold them into one long expression.

Solves #10114

/cc @amalbuquerque 