### PR TITLE
Show ref information when getting or updating mix dependencies from git sources

### DIFF
--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -7,12 +7,14 @@ defmodule Mix.SCM.Git do
   end
 
   def format(opts) do
-    {ref_type, ref_value} = cond do
-      opts[:tag] -> {:tag, opts[:tag]}
-      opts[:branch] -> {:branch, opts[:branch]}
-      opts[:ref] -> {:ref, opts[:ref]}
-      true -> {nil, nil}
-    end
+    {ref_type, ref_value} =
+      cond do
+        opts[:tag] -> {:tag, opts[:tag]}
+        opts[:branch] -> {:branch, opts[:branch]}
+        opts[:ref] -> {:ref, opts[:ref]}
+        true -> {nil, nil}
+      end
+
     extra_info = if ref_type, do: " - #{ref_type}: #{ref_value}", else: ""
     "#{opts[:git]}#{extra_info}"
   end

--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -7,7 +7,14 @@ defmodule Mix.SCM.Git do
   end
 
   def format(opts) do
-    opts[:git]
+    {ref_type, ref_value} = cond do
+      opts[:tag] -> {:tag, opts[:tag]}
+      opts[:branch] -> {:branch, opts[:branch]}
+      opts[:ref] -> {:ref, opts[:ref]}
+      true -> {nil, nil}
+    end
+    extra_info = if ref_type, do: " - #{ref_type}: #{ref_value}", else: ""
+    "#{opts[:git]}#{extra_info}"
   end
 
   def format_lock(opts) do

--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -7,7 +7,7 @@ defmodule Mix.SCM.Git do
   end
 
   def format(opts) do
-    "#{opts[:git]} (#{get_opts_rev(opts)})"
+    "#{opts[:git]} - #{get_opts_rev(opts)}"
   end
 
   def format_lock(opts) do

--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -7,16 +7,7 @@ defmodule Mix.SCM.Git do
   end
 
   def format(opts) do
-    {ref_type, ref_value} =
-      cond do
-        opts[:tag] -> {:tag, opts[:tag]}
-        opts[:branch] -> {:branch, opts[:branch]}
-        opts[:ref] -> {:ref, opts[:ref]}
-        true -> {nil, nil}
-      end
-
-    extra_info = if ref_type, do: " - #{ref_type}: #{ref_value}", else: ""
-    "#{opts[:git]}#{extra_info}"
+    "#{opts[:git]} (#{get_opts_rev(opts)})"
   end
 
   def format_lock(opts) do

--- a/lib/mix/test/mix/scm/git_test.exs
+++ b/lib/mix/test/mix/scm/git_test.exs
@@ -34,8 +34,8 @@ defmodule Mix.SCM.GitTest do
     assert Mix.SCM.Git.format(Keyword.put(opts, :branch, "b")) ==
              "https://github.com/elixir-lang/some_dep.git - origin/b"
 
-    assert Mix.SCM.Git.format(Keyword.put(opts, :ref, "xx")) ==
-             "https://github.com/elixir-lang/some_dep.git - xx"
+    assert Mix.SCM.Git.format(Keyword.put(opts, :ref, "abcdef")) ==
+             "https://github.com/elixir-lang/some_dep.git - abcdef"
   end
 
   test "raises about conflicting Git checkout options" do

--- a/lib/mix/test/mix/scm/git_test.exs
+++ b/lib/mix/test/mix/scm/git_test.exs
@@ -22,6 +22,14 @@ defmodule Mix.SCM.GitTest do
     assert Mix.SCM.Git.equal?([git: "foo", lock: 1], git: "foo", lock: 2)
   end
 
+  test "get and update should display git checkout options along the url" do
+    opts = [git: "https://github.com/elixir-lang/some_dep.git"]
+    assert Mix.SCM.Git.format(opts) == "https://github.com/elixir-lang/some_dep.git (origin/master)"
+    assert Mix.SCM.Git.format(Keyword.put(opts, :tag, "v1")) == "https://github.com/elixir-lang/some_dep.git (v1)"
+    assert Mix.SCM.Git.format(Keyword.put(opts, :branch, "b")) == "https://github.com/elixir-lang/some_dep.git (origin/b)"
+    assert Mix.SCM.Git.format(Keyword.put(opts, :ref, "xx")) == "https://github.com/elixir-lang/some_dep.git (xx)"
+  end
+
   test "raises about conflicting Git checkout options" do
     assert_raise Mix.Error, ~r/You should specify only one of branch, ref or tag/, fn ->
       Mix.SCM.Git.accepts_options(nil, git: "/repo", branch: "master", tag: "0.1.0")

--- a/lib/mix/test/mix/scm/git_test.exs
+++ b/lib/mix/test/mix/scm/git_test.exs
@@ -26,16 +26,16 @@ defmodule Mix.SCM.GitTest do
     opts = [git: "https://github.com/elixir-lang/some_dep.git"]
 
     assert Mix.SCM.Git.format(opts) ==
-             "https://github.com/elixir-lang/some_dep.git (origin/master)"
+             "https://github.com/elixir-lang/some_dep.git - origin/master"
 
     assert Mix.SCM.Git.format(Keyword.put(opts, :tag, "v1")) ==
-             "https://github.com/elixir-lang/some_dep.git (v1)"
+             "https://github.com/elixir-lang/some_dep.git - v1"
 
     assert Mix.SCM.Git.format(Keyword.put(opts, :branch, "b")) ==
-             "https://github.com/elixir-lang/some_dep.git (origin/b)"
+             "https://github.com/elixir-lang/some_dep.git - origin/b"
 
     assert Mix.SCM.Git.format(Keyword.put(opts, :ref, "xx")) ==
-             "https://github.com/elixir-lang/some_dep.git (xx)"
+             "https://github.com/elixir-lang/some_dep.git - xx"
   end
 
   test "raises about conflicting Git checkout options" do

--- a/lib/mix/test/mix/scm/git_test.exs
+++ b/lib/mix/test/mix/scm/git_test.exs
@@ -24,10 +24,18 @@ defmodule Mix.SCM.GitTest do
 
   test "get and update should display git checkout options along the url" do
     opts = [git: "https://github.com/elixir-lang/some_dep.git"]
-    assert Mix.SCM.Git.format(opts) == "https://github.com/elixir-lang/some_dep.git (origin/master)"
-    assert Mix.SCM.Git.format(Keyword.put(opts, :tag, "v1")) == "https://github.com/elixir-lang/some_dep.git (v1)"
-    assert Mix.SCM.Git.format(Keyword.put(opts, :branch, "b")) == "https://github.com/elixir-lang/some_dep.git (origin/b)"
-    assert Mix.SCM.Git.format(Keyword.put(opts, :ref, "xx")) == "https://github.com/elixir-lang/some_dep.git (xx)"
+
+    assert Mix.SCM.Git.format(opts) ==
+             "https://github.com/elixir-lang/some_dep.git (origin/master)"
+
+    assert Mix.SCM.Git.format(Keyword.put(opts, :tag, "v1")) ==
+             "https://github.com/elixir-lang/some_dep.git (v1)"
+
+    assert Mix.SCM.Git.format(Keyword.put(opts, :branch, "b")) ==
+             "https://github.com/elixir-lang/some_dep.git (origin/b)"
+
+    assert Mix.SCM.Git.format(Keyword.put(opts, :ref, "xx")) ==
+             "https://github.com/elixir-lang/some_dep.git (xx)"
   end
 
   test "raises about conflicting Git checkout options" do


### PR DESCRIPTION
Adds reference information (tag, branch, commit hash) to the mix deps task when fetching dependencies from git.

Currently when getting or updating libs from git sources:

```
* Updating open_api_spex (https://github.com/open-api-spex/open_api_spex.git)
* Updating stripity_stripe (https://github.com/code-corps/stripity_stripe.git)
* Updating elixir_utils (git@github.com:DroverLtd/elixir_utils.git)
```

With this PR:

```
* Updating open_api_spex (https://github.com/open-api-spex/open_api_spex.git - origin/master)
* Updating stripity_stripe (https://github.com/code-corps/stripity_stripe.git - origin/master)
* Updating elixir_utils (git@github.com:DroverLtd/elixir_utils.git - 1.2.3)
```

The code can probably be much more optimised, suggestions welcomed :)