### PR TITLE
Remove unneeded blank lines from Markdown.

### DIFF
--- a/lib/elixir/pages/patterns-and-guards.md
+++ b/lib/elixir/pages/patterns-and-guards.md
@@ -382,7 +382,6 @@ Check.empty?({})
 
 In the examples above, we have used the match operator (`=`) and function clauses to showcase patterns and guards respectively. Here is the list of the built-in constructs in Elixir that support patterns and guards.
 
-
   * `match?/2`:
 
     ```elixir
@@ -428,7 +427,6 @@ In the examples above, we have used the match operator (`=`) and function clause
   * [`receive`](`receive/1`) supports patterns and guards to match on the received messages.
 
   * custom guards can also be defined with `defguard/1` and `defguardp/1`. A custom guard can only be defined based on existing guards.
-  
   
 Note that the match operator (`=`) does *not* support guards:
 


### PR DESCRIPTION
MD012 Multiple consecutive blank lines.

https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md