### PR TITLE
Remove trailing spaces from Markdown.

### DIFF
--- a/lib/elixir/pages/patterns-and-guards.md
+++ b/lib/elixir/pages/patterns-and-guards.md
@@ -427,7 +427,7 @@ In the examples above, we have used the match operator (`=`) and function clause
   * [`receive`](`receive/1`) supports patterns and guards to match on the received messages.
 
   * custom guards can also be defined with `defguard/1` and `defguardp/1`. A custom guard can only be defined based on existing guards.
-  
+
 Note that the match operator (`=`) does *not* support guards:
 
     ```elixir


### PR DESCRIPTION
MD009 Trailing spaces

https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md