### PR TITLE
Deep clean the .erl files generated by yecc/leex.

### DIFF
--- a/lib/mix/lib/mix/tasks/clean.ex
+++ b/lib/mix/lib/mix/tasks/clean.ex
@@ -36,9 +36,16 @@ defmodule Mix.Tasks.Clean do
       |> Path.join("*#{opts[:only]}")
 
     if opts[:deps] do
-      build
-      |> Path.wildcard()
-      |> Enum.each(&File.rm_rf/1)
+      deps_paths =
+        Mix.Project.deps_paths()
+        |> Map.values()
+        |> Enum.map(&Path.join(&1, "**/*.erl"))
+
+      for path <- [build] ++ deps_paths do
+        path
+        |> Path.wildcard()
+        |> Enum.each(&File.rm_rf/1)
+      end
     else
       build
       |> Path.join("lib/#{Mix.Project.config()[:app]}")

--- a/lib/mix/test/mix/tasks/clean_test.exs
+++ b/lib/mix/test/mix/tasks/clean_test.exs
@@ -27,12 +27,14 @@ defmodule Mix.Tasks.CleanTest do
       File.mkdir_p!("_build/dev/lib/sample")
       File.mkdir_p!("_build/test/lib/sample")
       File.mkdir_p!("_build/dev/lib/ok")
+      File.touch!("deps/ok/priv/compiled.erl")
 
       Mix.Tasks.Clean.run([])
       refute File.exists?("_build/dev/lib/sample/consolidated")
       refute File.exists?("_build/dev/lib/sample")
       refute File.exists?("_build/test/lib/sample")
       assert File.exists?("_build/dev/lib/ok")
+      assert File.exists?("deps/ok/priv/compiled.erl")
     end)
   end
 
@@ -43,10 +45,12 @@ defmodule Mix.Tasks.CleanTest do
 
       Mix.Tasks.Clean.run(["--deps", "--only", "dev"])
       refute File.exists?("_build/dev")
+      refute File.exists?("deps/ok/priv/compiled.erl")
       assert File.exists?("_build/test")
 
       Mix.Tasks.Clean.run(["--deps"])
       refute File.exists?("_build/test")
+      refute File.exists?("deps/ok/priv/compiled.erl")
     end)
   end
 end


### PR DESCRIPTION
When cleaning with --deps flag, iterate over dependencies and remove generated .erl files.

This feature was discussed in #8262.