### PR TITLE
Add a GitHub action to lint the Markdown.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint Markdown
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - run: npm install -g markdownlint-cli@0.23.2
+      - run: markdownlint '**/*.md' --ignore node_modules

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,32 @@
+# MD005 Inconsistent indentation for list items at the same level
+MD005: false
+
+# MD006 Consider starting bulleted lists at the beginning of the line
+MD006: false
+
+# MD007/ul-indent Unordered list indentation
+MD007: false
+
+# MD013 Line length
+MD013: false
+
+# MD024 Multiple headers with the same content
+MD024: false
+
+# MD026/no-trailing-punctuation Trailing punctuation in heading
+MD026: false
+
+# MD029 Ordered list item prefix
+MD029: false
+
+# MD033 Inline HTML
+MD033: false
+
+# MD038 Spaces inside code span elements
+MD038: false
+
+# MD040/fenced-code-language Fenced code blocks should have a language specified
+MD040: false
+
+# MD046 Code block style
+MD046: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![Elixir](https://github.com/elixir-lang/elixir-lang.github.com/raw/master/images/logo/logo.png)
-=========
+# ![Elixir](https://github.com/elixir-lang/elixir-lang.github.com/raw/master/images/logo/logo.png)
+
 [![CI](https://github.com/elixir-lang/elixir/workflows/CI/badge.svg?branch=master)](https://github.com/elixir-lang/elixir/actions?query=branch%3Amaster+workflow%3ACI) [![Build status](https://api.cirrus-ci.com/github/elixir-lang/elixir.svg?branch=master)](https://cirrus-ci.com/github/elixir-lang/elixir)
 
 Elixir is a dynamic, functional language designed for building scalable

--- a/lib/elixir/pages/library-guidelines.md
+++ b/lib/elixir/pages/library-guidelines.md
@@ -6,7 +6,7 @@ This document outlines general guidelines, anti-patterns, and rules for those wr
 
 You can create a new Elixir library by running the `mix new` command:
 
-    $ mix new my_library
+    mix new my_library
 
 The project name is given in the `snake_case` convention where all letters are lowercase and words are separate with underscores. This is the same convention used by variables, function names and atoms in Elixir. See the [Naming Conventions](naming-conventions.md) document for more information.
 


### PR DESCRIPTION
Add a Markdownlint config file.

Lint Markdown for rules:
MD003 - Header style
MD014 Dollar signs used before commands without showing output

https://www.npmjs.com/package/markdownlint-cli