### PR TITLE
redact username/password in mix output log

### DIFF
--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -8,11 +8,10 @@ defmodule Mix.SCM.Git do
 
   def format(opts) do
     if rev = get_opts_rev(opts) do
-      "#{opts[:git]} - #{rev}"
+      "#{redact_uri(opts[:git])} - #{rev}"
     else
-      opts[:git]
+      redact_uri(opts[:git])
     end
-    |> redact_git_url
   end
 
   def format_lock(opts) do
@@ -187,7 +186,7 @@ defmodule Mix.SCM.Git do
   defp validate_git_options(opts) do
     err =
       "You should specify only one of branch, ref or tag, and only once. " <>
-        "Error on Git dependency: #{opts[:git]}"
+        "Error on Git dependency: #{redact_uri(opts[:git])}"
 
     validate_single_uniq(opts, [:branch, :ref, :tag], err)
   end
@@ -233,13 +232,10 @@ defmodule Mix.SCM.Git do
     end
   end
 
-  defp redact_git_url(url) do
-    cond do
-      String.match?(url, ~r'https://[^:]+:[^:@]+@.+'i) ->
-        String.replace(url, ~r'https://[^:]+:[^:@]+(?=@.+)'i, "https://****:****")
-
-      true ->
-        url
+  defp redact_uri(git) do
+    case URI.parse(git) do
+      %{userinfo: nil} -> git
+      uri -> URI.to_string(%{uri | userinfo: "****:****"})
     end
   end
 

--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -12,6 +12,7 @@ defmodule Mix.SCM.Git do
     else
       opts[:git]
     end
+    |> redact_git_url
   end
 
   def format_lock(opts) do
@@ -229,6 +230,16 @@ defmodule Mix.SCM.Git do
       "origin/#{branch}"
     else
       opts[:ref] || opts[:tag]
+    end
+  end
+
+  defp redact_git_url(url) do
+    cond do
+      String.match?(url, ~r'https://[^:]+:[^:@]+@.+'i) ->
+        String.replace(url, ~r'https://[^:]+:[^:@]+(?=@.+)'i, "https://****:****")
+
+      true ->
+        url
     end
   end
 

--- a/lib/mix/test/mix/scm/git_test.exs
+++ b/lib/mix/test/mix/scm/git_test.exs
@@ -38,6 +38,13 @@ defmodule Mix.SCM.GitTest do
              "https://github.com/elixir-lang/some_dep.git - abcdef"
   end
 
+  test "redacts username password from urls" do
+    opts = [git: "https://username:password@github.com/elixir-lang/some_dep.git"]
+
+    assert Mix.SCM.Git.format(opts) ==
+             "https://****:****@github.com/elixir-lang/some_dep.git"
+  end
+
   test "raises about conflicting Git checkout options" do
     assert_raise Mix.Error, ~r/You should specify only one of branch, ref or tag/, fn ->
       Mix.SCM.Git.accepts_options(nil, git: "/repo", branch: "master", tag: "0.1.0")

--- a/lib/mix/test/mix/scm/git_test.exs
+++ b/lib/mix/test/mix/scm/git_test.exs
@@ -39,10 +39,15 @@ defmodule Mix.SCM.GitTest do
   end
 
   test "redacts username password from urls" do
-    opts = [git: "https://username:password@github.com/elixir-lang/some_dep.git"]
+    url = "https://username:password@github.com/elixir-lang/some_dep.git"
+    opts = [git: url]
 
     assert Mix.SCM.Git.format(opts) ==
              "https://****:****@github.com/elixir-lang/some_dep.git"
+
+    assert_raise Mix.Error, ~r/[*]{4}:[*]{4}/, fn ->
+      Mix.SCM.Git.accepts_options(nil, git: url, branch: "master", branch: "develop")
+    end
   end
 
   test "raises about conflicting Git checkout options" do


### PR DESCRIPTION
ok so let's consider I'm doing things ahem, the _wrong_ _way_ and don't have proper ssh keys set up for a private github repository. So instead of doing things the right way I slap something silly into my mix.exs file such as

```elixir
{ :my_repo, git: "https://USERNAME:#{System.get_env("GITHUB_TOKEN")}@github.com/gregors/my_repo.git }
```

Now where would I get such an idea? Maybe reading old things [like this](https://stephenbussey.com/2018/02/05/sourcing-libraries-from-private-github.html)

Now if one were going to do this, you end up seeing logs being displayed such as 
```bash
Getting apex (https://USERNAME:password@github.com/gregors/my_repo.git)
```

That's no good, we don't want our username and password ending up in log files (even if it does end up in our lock file ahem)

I know there's a quiet option for mix logging, but I think we should try to redact that info when possible.  I've  added some code & tests to highlight my goal. Additional knowledge and feedback greatly appreciated.