### PR TITLE
Fix shell script: double quote to prevent globbing and word splitting.

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -211,7 +211,7 @@ if [ "$OS" != "Windows_NT" ] && [ -z "$NO_COLOR" ]; then
 fi
 
 ERTS_BIN=
-set -- "$ERTS_BIN$ERL_EXEC" -pa "$SCRIPT_PATH"/../lib/*/ebin $ELIXIR_ERL_OPTIONS $ERL "$@"
+set -- "$ERTS_BIN$ERL_EXEC" -pa "$SCRIPT_PATH"/../lib/*/ebin "$ELIXIR_ERL_OPTIONS" "$ERL" "$@"
 
 if [ -n "$RUN_ERL_PIPE" ]; then
   ESCAPED=""


### PR DESCRIPTION
Checked with ShellCheck.
https://www.shellcheck.net/

https://github.com/koalaman/shellcheck/wiki/SC2086