### PR TITLE
Allow function captures in pipelines

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -232,6 +232,10 @@ defmodule Macro do
     unpipe(right, unpipe(left, acc))
   end
 
+  defp unpipe({:&, _, [{:/, _, [func, 1]}]}, acc) do
+    [{func, 0} | acc]
+  end
+
   defp unpipe(other, acc) do
     [{other, 0} | acc]
   end

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1058,6 +1058,14 @@ defmodule KernelTest do
       assert Enum.map([1, 2, 3], &(&1 |> twice |> twice)) == [4, 8, 12]
     end
 
+    test "function capture" do
+      # We need to split this as `==` bounds stronger than `&foo/1` which was
+      # causing problems
+      pipe = [1, [2], 3] |> (&List.flatten/1)
+
+      assert pipe == [1, 2, 3]
+    end
+
     test "with anonymous functions" do
       assert 1 |> (&(&1 * 2)).() == 2
       assert [1] |> (&hd(&1)).() == 1


### PR DESCRIPTION
- [ ] Support `fn` in pipelines (it should raise if the function expects more than one argument)
- [x] Support `&local/1` and `&Mod.remote/1` in pipelines (raise if arity is not 1)
- [ ] Support `&` in pipelines (it should raise if there is a nested `&` or `&2`)
- [ ] Warn if piping to `a |> var` and there is such `var` in scope (either `var()` or `var.()` should be used)

Close #10154