### PR TITLE
Support anonymous function in pipeline

### DIFF
--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1061,6 +1061,16 @@ defmodule KernelTest do
     test "with anonymous functions" do
       assert 1 |> (&(&1 * 2)).() == 2
       assert [1] |> (&hd(&1)).() == 1
+
+      pipe = "foobar" |> fn x -> Regex.replace(~r/foo/, x, "baz") end
+      assert pipe == "bazbar"
+
+      message =
+        "cannot pipe 1 into an anonymous function that expects 2-arity. Anonymous functions in pipes only support 1-arity"
+
+      assert_raise ArgumentError, message, fn ->
+        1 |> fn _, _ -> :ok end
+      end
     end
 
     defp twice(a), do: a * 2


### PR DESCRIPTION
This commit rewrites `fn` into `case` in pipeline. With this change now
we can support using anonymous function in pipeline, like so:

```
string
|> fn x -> Regex.replace(~r/bar/, x, "baz") end
```

Raise error if anonymous functions in pipeline expect more than 1-arity.

Fixes #10154.