### PR TITLE
Remove tracers before prying

### DIFF
--- a/lib/iex/lib/iex/pry.ex
+++ b/lib/iex/lib/iex/pry.ex
@@ -36,6 +36,8 @@ defmodule IEx.Pry do
     opts = [
       binding: binding,
       dot_iex_path: "",
+      # Remove all tracers because the tracer code is most
+      # likely stale by the time we are prying the code.
       env: %{env | tracers: []},
       prefix: "pry",
       stacktrace: prune_stacktrace(stacktrace)

--- a/lib/iex/lib/iex/pry.ex
+++ b/lib/iex/lib/iex/pry.ex
@@ -36,7 +36,7 @@ defmodule IEx.Pry do
     opts = [
       binding: binding,
       dot_iex_path: "",
-      env: env,
+      env: %{env | tracers: []},
       prefix: "pry",
       stacktrace: prune_stacktrace(stacktrace)
     ]


### PR DESCRIPTION
Fixes the following error inside pry:

    ** (ArgumentError) argument error
    (stdlib 3.13) :ets.member(Mix.Compilers.ApplicationTracer, IEx.Helpers)
        (mix 1.11.0-dev) lib/mix/compilers/application_tracer.ex:31: Mix.Compilers.ApplicationTracer.trace/2
        (elixir 1.11.0-dev) src/elixir_env.erl:36: :elixir_env."-trace/2-lc$^0/1-0-"/3
        (elixir 1.11.0-dev) src/elixir_env.erl:36: :elixir_env.trace/2
        (elixir 1.11.0-dev) src/elixir_dispatch.erl:161: :elixir_dispatch.do_expand_import/6
        (elixir 1.11.0-dev) src/elixir_dispatch.erl:91: :elixir_dispatch.dispatch_import/5