### PR TITLE
is_exception/1 guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,7 +218,7 @@ To wrap it all up, `Mix` also includes a new task called `mix app.config`. This 
 
 ## Other improvements
 
-Elixir v1.11 adds the `is_struct/2`, `is_exception/1` and `is_exception/2` guards and also includes support for `map.field` syntax in guards.
+Elixir v1.11 adds the `is_struct/2`, `is_exception/1`, and `is_exception/2` guards and also includes support for `map.field` syntax in guards.
 
 The Calendar module now includes the `Calendar.strftime/3` function, which provides datetime formatting based on the `strftime` format. All Calendar types also got new conversion functions from and to gregorian timestamps, such as: `Date.from_gregorian_days/2` and `NaiveDateTime.to_gregorian_seconds/1`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,7 +218,7 @@ To wrap it all up, `Mix` also includes a new task called `mix app.config`. This 
 
 ## Other improvements
 
-Elixir v1.11 adds the `is_struct/2` and `is_exception/1` guards and also includes support for `map.field` syntax in guards.
+Elixir v1.11 adds the `is_struct/2`, `is_exception/1` and `is_exception/2` guards and also includes support for `map.field` syntax in guards.
 
 The Calendar module now includes the `Calendar.strftime/3` function, which provides datetime formatting based on the `strftime` format. All Calendar types also got new conversion functions from and to gregorian timestamps, such as: `Date.from_gregorian_days/2` and `NaiveDateTime.to_gregorian_seconds/1`.
 
@@ -246,7 +246,7 @@ Mix also includes a new task, `mix test.coverage`, which generates aggregated co
   * [Config] Allow `import_config` to be disabled for some configuration files
   * [Enum] Allow a sorting function on `Enum.min_max_by/3,4`, including the new `compare/2` conventions
   * [Kernel] Add `is_struct/2` guard
-  * [Kernel] Add `is_exception/1` guard
+  * [Kernel] Add `is_exception/1` and `is_exception/2` guards
   * [Kernel] Support `map.field` syntax in guards
   * [Kernel] Add `+++` and `---` with right associativity to the list of custom operators
   * [Kernel.ParallelCompiler] Report individual file compilation times when `profile: :time` is given

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,7 +218,7 @@ To wrap it all up, `Mix` also includes a new task called `mix app.config`. This 
 
 ## Other improvements
 
-Elixir v1.11 adds the `is_struct/2` guard and also includes support for `map.field` syntax in guards.
+Elixir v1.11 adds the `is_struct/2` and `is_exception/1` guards and also includes support for `map.field` syntax in guards.
 
 The Calendar module now includes the `Calendar.strftime/3` function, which provides datetime formatting based on the `strftime` format. All Calendar types also got new conversion functions from and to gregorian timestamps, such as: `Date.from_gregorian_days/2` and `NaiveDateTime.to_gregorian_seconds/1`.
 
@@ -246,6 +246,7 @@ Mix also includes a new task, `mix test.coverage`, which generates aggregated co
   * [Config] Allow `import_config` to be disabled for some configuration files
   * [Enum] Allow a sorting function on `Enum.min_max_by/3,4`, including the new `compare/2` conventions
   * [Kernel] Add `is_struct/2` guard
+  * [Kernel] Add `is_exception/1` guard
   * [Kernel] Support `map.field` syntax in guards
   * [Kernel] Add `+++` and `---` with right associativity to the list of custom operators
   * [Kernel.ParallelCompiler] Report individual file compilation times when `profile: :time` is given

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2320,7 +2320,7 @@ defmodule Kernel do
       nil ->
         quote do
           case unquote(term) do
-            %{__exception__: true} -> true
+            %_{__exception__: true} -> true
             _ -> false
           end
         end
@@ -2330,7 +2330,55 @@ defmodule Kernel do
 
       :guard ->
         quote do
-          is_map(unquote(term)) and :erlang.is_map_key(:__exception__, unquote(term)) and
+          is_map(unquote(term)) and :erlang.is_map_key(:__struct__, unquote(term)) and
+            is_atom(:erlang.map_get(:__struct__, unquote(term))) and
+            :erlang.is_map_key(:__exception__, unquote(term)) and
+            :erlang.map_get(:__exception__, unquote(term)) == true
+        end
+    end
+  end
+
+  @doc """
+  Returns true if `term` is an exception of `name`; otherwise returns `false`.
+
+  Allowed in guard tests.
+
+  ## Examples
+
+      iex> is_exception(%RuntimeError{}, RuntimeError)
+      true
+
+      iex> is_exception(%RuntimeError{}, Macro.Env)
+      false
+
+  """
+  @doc since: "1.11.0", guard: true
+  defmacro is_exception(term, name) do
+    case __CALLER__.context do
+      nil ->
+        quote do
+          case unquote(name) do
+            name when is_atom(name) ->
+              case unquote(term) do
+                %{__struct__: ^name, __exception__: true} -> true
+                _ -> false
+              end
+
+            _ ->
+              raise ArgumentError
+          end
+        end
+
+      :match ->
+        invalid_match!(:is_exception)
+
+      :guard ->
+        quote do
+          is_map(unquote(term)) and
+            (is_atom(unquote(name)) or :fail) and
+            :erlang.is_map_key(:__struct__, unquote(term)) and
+            :erlang.map_get(:__struct__, unquote(term)) == unquote(name) and
+            :erlang.is_map_key(:__exception__, unquote(term)) and
             :erlang.map_get(:__exception__, unquote(term)) == true
         end
     end

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2301,6 +2301,42 @@ defmodule Kernel do
   end
 
   @doc """
+  Returns true if `term` is an exception; otherwise returns `false`.
+
+  Allowed in guard tests.
+
+  ## Examples
+
+      iex> is_exception(%RuntimeError{})
+      true
+
+      iex> is_exception(%{})
+      false
+
+  """
+  @doc since: "1.11.0", guard: true
+  defmacro is_exception(term) do
+    case __CALLER__.context do
+      nil ->
+        quote do
+          case unquote(term) do
+            %{__exception__: true} -> true
+            _ -> false
+          end
+        end
+
+      :match ->
+        invalid_match!(:is_exception)
+
+      :guard ->
+        quote do
+          is_map(unquote(term)) and :erlang.is_map_key(:__exception__, unquote(term)) and
+            :erlang.map_get(:__exception__, unquote(term)) == true
+        end
+    end
+  end
+
+  @doc """
   Gets a value from a nested structure.
 
   Uses the `Access` module to traverse the structures

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -388,6 +388,35 @@ defmodule KernelTest do
     assert exception_or_map?(10) == false
   end
 
+  defp exception?(arg, name) when is_exception(arg, name), do: true
+  defp exception?(_arg, _name), do: false
+
+  defp exception_or_map?(arg, name) when is_exception(arg, name) or is_map(arg), do: true
+  defp exception_or_map?(_arg, _name), do: false
+
+  test "is_exception/2" do
+    assert is_exception(%{}, RuntimeError) == false
+    assert is_exception([], RuntimeError) == false
+    assert is_exception(%RuntimeError{}, RuntimeError) == true
+    assert is_exception(%RuntimeError{}, Macro.Env) == false
+    assert exception?(%RuntimeError{}, RuntimeError) == true
+    assert exception?(%RuntimeError{}, Macro.Env) == false
+    assert exception?(%{__exception__: "foo"}, "foo") == false
+    assert exception?(%{__exception__: "foo"}, RuntimeError) == false
+    assert exception?([], RuntimeError) == false
+    assert exception?(%{}, RuntimeError) == false
+
+    assert_raise ArgumentError, "argument error", fn ->
+      is_exception(%{}, not_atom())
+    end
+  end
+
+  test "is_exception/2 and other match works" do
+    assert exception_or_map?(%{}, "foo") == false
+    assert exception_or_map?(%{}, RuntimeError) == true
+    assert exception_or_map?(%RuntimeError{}, RuntimeError) == true
+  end
+
   test "if/2 boolean optimization does not leak variables during expansion" do
     if false do
       :ok

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -365,6 +365,29 @@ defmodule KernelTest do
     assert struct_or_map?(%Macro.Env{}, Macro.Env) == true
   end
 
+  defp exception?(arg) when is_exception(arg), do: true
+  defp exception?(_arg), do: false
+
+  defp exception_or_map?(arg) when is_exception(arg) or is_map(arg), do: true
+  defp exception_or_map?(_arg), do: false
+
+  test "is_exception/1" do
+    assert is_exception(%{}) == false
+    assert is_exception([]) == false
+    assert is_exception(%RuntimeError{}) == true
+    assert is_exception(%{__exception__: "foo"}) == false
+    assert exception?(%RuntimeError{}) == true
+    assert exception?(%{__exception__: "foo"}) == false
+    assert exception?([]) == false
+    assert exception?(%{}) == false
+  end
+
+  test "is_exception/1 and other match works" do
+    assert exception_or_map?(%RuntimeError{}) == true
+    assert exception_or_map?(%{}) == true
+    assert exception_or_map?(10) == false
+  end
+
   test "if/2 boolean optimization does not leak variables during expansion" do
     if false do
       :ok


### PR DESCRIPTION
@josevalim posted [#66](https://elixirforum.com/t/discussion-incorporating-erlang-otp-21-map-guards-in-elixir/14816/66?u=eiji) on forum at `Mar 23, 9:13 AM`:
> (…) is_exception was not implemented but a PR is welcome.

- [x] Added `is_exception/1` guard (based on `Exception.exception?/1` and `Kernel.is_struct/1`)
- [x] Added tests (based on `is_struct/1` tests)
- [x] Updated `CHANGELOG.md`

cc @josevalim 