### PR TITLE
Add Date.day_of_week/2, beginning_of_week/2, and end_of_week/2

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -167,8 +167,14 @@ defmodule Calendar do
 
   @doc """
   Calculates the day of the week from the given `year`, `month`, and `day`.
+
+  The `starting_on` represents the starting day of the week. All
+  calendars must support at least the `:default` value. They may
+  also support other values representing their days of the week.
   """
-  @callback day_of_week(year, month, day) :: day_of_week()
+  @callback day_of_week(year, month, day, starting_on :: :default | atom) ::
+              {day_of_week(), first_day_of_week :: non_neg_integer(),
+               last_day_of_week :: non_neg_integer()}
 
   @doc """
   Calculates the day of the year from the given `year`, `month`, and `day`.

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -723,7 +723,7 @@ defmodule Date do
   Calculates a date that is the first day of the week for the given `date`.
 
   If the day is already the first day of the week, it returns the
-  day itself. For the built-in ISO calendar, the week starts on monday.
+  day itself. For the built-in ISO calendar, the week starts on Monday.
   A weekday rather than `:default` can be given as `starting_on`.
 
   ## Examples
@@ -776,7 +776,7 @@ defmodule Date do
   Calculates a date that is the last day of the week for the given `date`.
 
   If the day is already the last day of the week, it returns the
-  day itself. For the built-in ISO calendar, the week ends on a sunday.
+  day itself. For the built-in ISO calendar, the week ends on Sunday.
   A weekday rather than `:default` can be given as `starting_on`.
 
   ## Examples

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -720,6 +720,114 @@ defmodule Date do
   end
 
   @doc """
+  Calculates a date that is the first day of the week for the given `date`.
+
+  If the day is already the first day of the week, it returns the
+  day itself. For the built-in ISO calendar, the week starts on monday.
+  A weekday rather than `:default` can be given as `starting_on`.
+
+  ## Examples
+
+      iex> Date.beginning_of_week(~D[2020-07-11])
+      ~D[2020-07-06]
+      iex> Date.beginning_of_week(~D[2020-07-06])
+      ~D[2020-07-06]
+      iex> Date.beginning_of_week(~D[2020-07-11], :sunday)
+      ~D[2020-07-05]
+      iex> Date.beginning_of_week(~D[2020-07-11], :saturday)
+      ~D[2020-07-11]
+      iex> Date.beginning_of_week(~N[2020-07-11 01:23:45])
+      ~D[2020-07-06]
+
+  """
+  @doc since: "1.11.0"
+  @spec beginning_of_week(Calendar.date(), starting_on :: :default | atom) :: Date.t()
+  def beginning_of_week(date, starting_on \\ :default)
+
+  def beginning_of_week(%{calendar: Calendar.ISO} = date, starting_on) do
+    %{year: year, month: month, day: day} = date
+    iso_days = Calendar.ISO.date_to_iso_days(year, month, day)
+
+    {year, month, day} =
+      case Calendar.ISO.iso_days_to_day_of_week(iso_days, starting_on) do
+        1 ->
+          {year, month, day}
+
+        day_of_week ->
+          Calendar.ISO.date_from_iso_days(iso_days - day_of_week + 1)
+      end
+
+    %Date{calendar: Calendar.ISO, year: year, month: month, day: day}
+  end
+
+  def beginning_of_week(%{calendar: calendar} = date, starting_on) do
+    %{year: year, month: month, day: day} = date
+
+    case calendar.day_of_week(year, month, day, starting_on) do
+      {day_of_week, day_of_week, _} ->
+        %Date{calendar: calendar, year: year, month: month, day: day}
+
+      {day_of_week, first_day_of_week, _} ->
+        add(date, -(day_of_week - first_day_of_week))
+    end
+  end
+
+  @doc """
+  Calculates a date that is the last day of the week for the given `date`.
+
+  If the day is already the last day of the week, it returns the
+  day itself. For the built-in ISO calendar, the week ends on a sunday.
+  A weekday rather than `:default` can be given as `starting_on`.
+
+  ## Examples
+
+      iex> Date.end_of_week(~D[2020-07-11])
+      ~D[2020-07-12]
+      iex> Date.end_of_week(~D[2020-07-05])
+      ~D[2020-07-05]
+      iex> Date.end_of_week(~D[2020-07-06], :sunday)
+      ~D[2020-07-11]
+      iex> Date.end_of_week(~D[2020-07-06], :sunday)
+      ~D[2020-07-11]
+      iex> Date.end_of_week(~D[2020-07-06], :saturday)
+      ~D[2020-07-10]
+      iex> Date.end_of_week(~N[2020-07-11 01:23:45])
+      ~D[2020-07-12]
+
+  """
+  @doc since: "1.11.0"
+  @spec end_of_week(Calendar.date(), starting_on :: :default | atom) :: Date.t()
+  def end_of_week(date, starting_on \\ :default)
+
+  def end_of_week(%{calendar: Calendar.ISO} = date, starting_on) do
+    %{year: year, month: month, day: day} = date
+    iso_days = Calendar.ISO.date_to_iso_days(year, month, day)
+
+    {year, month, day} =
+      case Calendar.ISO.iso_days_to_day_of_week(iso_days, starting_on) do
+        7 ->
+          {year, month, day}
+
+        day_of_week ->
+          Calendar.ISO.date_from_iso_days(iso_days + 7 - day_of_week)
+      end
+
+    %Date{calendar: Calendar.ISO, year: year, month: month, day: day}
+  end
+
+  def end_of_week(%{calendar: calendar} = date, starting_on) do
+    %{year: year, month: month, day: day} = date
+
+    case calendar.day_of_week(year, month, day, starting_on) do
+      {day_of_week, _, day_of_week} ->
+        %Date{calendar: calendar, year: year, month: month, day: day}
+
+      {day_of_week, _, last_day_of_week} ->
+        add(date, last_day_of_week - day_of_week)
+    end
+  end
+
+  @doc """
   Calculates the day of the year of a given `date`.
 
   Returns the day of the year as an integer. For the ISO 8601
@@ -827,6 +935,10 @@ defmodule Date do
 
       iex> Date.beginning_of_month(~D[2000-01-31])
       ~D[2000-01-01]
+      iex> Date.beginning_of_month(~D[2000-01-01])
+      ~D[2000-01-01]
+      iex> Date.beginning_of_month(~N[2000-01-31 01:23:45])
+      ~D[2000-01-01]
 
   """
   @doc since: "1.11.0"
@@ -841,6 +953,10 @@ defmodule Date do
   ## Examples
 
       iex> Date.end_of_month(~D[2000-01-01])
+      ~D[2000-01-31]
+      iex> Date.end_of_month(~D[2000-01-31])
+      ~D[2000-01-31]
+      iex> Date.end_of_month(~N[2000-01-01 01:23:45])
       ~D[2000-01-31]
 
   """

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -684,6 +684,11 @@ defmodule Date do
   calendar (the default), it is an integer from 1 to 7, where
   1 is Monday and 7 is Sunday.
 
+  An optional `starting_on` value may be supplied, which
+  configures the weekday the week starts on. The default value
+  for it is `:default`, which translates to `:monday` for the
+  built-in ISO calendar. Any other weekday may be given to.
+
   ## Examples
 
       iex> Date.day_of_week(~D[2016-10-31])
@@ -695,13 +700,23 @@ defmodule Date do
       iex> Date.day_of_week(~D[-0015-10-30])
       3
 
+      iex> Date.day_of_week(~D[2016-10-31], :sunday)
+      2
+      iex> Date.day_of_week(~D[2016-11-01], :sunday)
+      3
+      iex> Date.day_of_week(~N[2016-11-01 01:23:45], :sunday)
+      3
+      iex> Date.day_of_week(~D[-0015-10-30], :sunday)
+      4
+
   """
   @doc since: "1.4.0"
-  @spec day_of_week(Calendar.date()) :: Calendar.day()
-  def day_of_week(date)
+  @spec day_of_week(Calendar.date(), starting_on :: :default | atom) :: Calendar.day_of_week()
+  def day_of_week(date, starting_on \\ :default)
 
-  def day_of_week(%{calendar: calendar, year: year, month: month, day: day}) do
-    calendar.day_of_week(year, month, day)
+  def day_of_week(%{calendar: calendar, year: year, month: month, day: day}, starting_on) do
+    {day_of_week, _first, _last} = calendar.day_of_week(year, month, day, starting_on)
+    day_of_week
   end
 
   @doc """

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -44,6 +44,7 @@ defmodule Calendar.ISO do
   @type hour :: 0..23
   @type minute :: 0..59
   @type second :: 0..59
+  @type weekday :: :monday | :tuesday | :wednesday | :thursday | :friday | :saturday | :sunday
 
   @typedoc """
   Microseconds with stored precision.
@@ -619,42 +620,84 @@ defmodule Calendar.ISO do
     rem(year, 4) === 0 and (rem(year, 100) !== 0 or rem(year, 400) === 0)
   end
 
+  # TODO: Deprecate me on v1.15
+  @doc false
+  def day_of_week(year, month, day) do
+    day_of_week(year, month, day, :default) |> elem(0)
+  end
+
   @doc """
   Calculates the day of the week from the given `year`, `month`, and `day`.
 
-  It is an integer from 1 to 7, where 1 is Monday and 7 is Sunday.
+  It is an integer from 1 to 7, where 1 is the given `starting_on` weekday.
+  For example, if `starting_on` is set to `:monday`, then 1 is Monday and
+  7 is Sunday.
+
+  `starting_on` can also be `:default`, which is equivalent to `:monday`.
 
   ## Examples
 
-      iex> Calendar.ISO.day_of_week(2016, 10, 31)
-      1
-      iex> Calendar.ISO.day_of_week(2016, 11, 1)
-      2
-      iex> Calendar.ISO.day_of_week(2016, 11, 2)
-      3
-      iex> Calendar.ISO.day_of_week(2016, 11, 3)
-      4
-      iex> Calendar.ISO.day_of_week(2016, 11, 4)
-      5
-      iex> Calendar.ISO.day_of_week(2016, 11, 5)
-      6
-      iex> Calendar.ISO.day_of_week(2016, 11, 6)
-      7
-      iex> Calendar.ISO.day_of_week(-99, 1, 31)
-      4
+      iex> Calendar.ISO.day_of_week(2016, 10, 31, :monday)
+      {1, 1, 7}
+      iex> Calendar.ISO.day_of_week(2016, 11, 1, :monday)
+      {2, 1, 7}
+      iex> Calendar.ISO.day_of_week(2016, 11, 2, :monday)
+      {3, 1, 7}
+      iex> Calendar.ISO.day_of_week(2016, 11, 3, :monday)
+      {4, 1, 7}
+      iex> Calendar.ISO.day_of_week(2016, 11, 4, :monday)
+      {5, 1, 7}
+      iex> Calendar.ISO.day_of_week(2016, 11, 5, :monday)
+      {6, 1, 7}
+      iex> Calendar.ISO.day_of_week(2016, 11, 6, :monday)
+      {7, 1, 7}
+      iex> Calendar.ISO.day_of_week(-99, 1, 31, :monday)
+      {4, 1, 7}
+
+      iex> Calendar.ISO.day_of_week(2016, 10, 31, :sunday)
+      {2, 1, 7}
+      iex> Calendar.ISO.day_of_week(2016, 11, 1, :sunday)
+      {3, 1, 7}
+      iex> Calendar.ISO.day_of_week(2016, 11, 2, :sunday)
+      {4, 1, 7}
+      iex> Calendar.ISO.day_of_week(2016, 11, 3, :sunday)
+      {5, 1, 7}
+      iex> Calendar.ISO.day_of_week(2016, 11, 4, :sunday)
+      {6, 1, 7}
+      iex> Calendar.ISO.day_of_week(2016, 11, 5, :sunday)
+      {7, 1, 7}
+      iex> Calendar.ISO.day_of_week(2016, 11, 6, :sunday)
+      {1, 1, 7}
+      iex> Calendar.ISO.day_of_week(-99, 1, 31, :sunday)
+      {5, 1, 7}
+
+      iex> Calendar.ISO.day_of_week(2016, 10, 31, :saturday)
+      {3, 1, 7}
 
   """
-  @doc since: "1.4.0"
-  @spec day_of_week(year, month, day) :: day_of_week()
+  @doc since: "1.11.0"
+  @spec day_of_week(year, month, day, :default | weekday) :: {day_of_week(), 1, 7}
   @impl true
-  def day_of_week(year, month, day) do
-    date_to_iso_days(year, month, day)
-    |> iso_days_to_day_of_week()
+  def day_of_week(year, month, day, starting_on) do
+    day_of_week =
+      date_to_iso_days(year, month, day)
+      |> iso_days_to_day_of_week(day_of_week_offset(starting_on))
+
+    {day_of_week, 1, 7}
   end
 
-  defp iso_days_to_day_of_week(iso_days) do
-    Integer.mod(iso_days + 5, 7) + 1
+  defp iso_days_to_day_of_week(iso_days, offset) do
+    Integer.mod(iso_days + offset, 7) + 1
   end
+
+  defp day_of_week_offset(:default), do: 5
+  defp day_of_week_offset(:wednesday), do: 3
+  defp day_of_week_offset(:thursday), do: 2
+  defp day_of_week_offset(:friday), do: 1
+  defp day_of_week_offset(:saturday), do: 0
+  defp day_of_week_offset(:sunday), do: 6
+  defp day_of_week_offset(:monday), do: 5
+  defp day_of_week_offset(:tuesday), do: 4
 
   @doc """
   Calculates the day of the year from the given `year`, `month`, and `day`.

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -679,15 +679,13 @@ defmodule Calendar.ISO do
   @spec day_of_week(year, month, day, :default | weekday) :: {day_of_week(), 1, 7}
   @impl true
   def day_of_week(year, month, day, starting_on) do
-    day_of_week =
-      date_to_iso_days(year, month, day)
-      |> iso_days_to_day_of_week(day_of_week_offset(starting_on))
-
-    {day_of_week, 1, 7}
+    iso_days = date_to_iso_days(year, month, day)
+    {iso_days_to_day_of_week(iso_days, starting_on), 1, 7}
   end
 
-  defp iso_days_to_day_of_week(iso_days, offset) do
-    Integer.mod(iso_days + offset, 7) + 1
+  @doc false
+  def iso_days_to_day_of_week(iso_days, starting_on) do
+    Integer.mod(iso_days + day_of_week_offset(starting_on), 7) + 1
   end
 
   defp day_of_week_offset(:default), do: 5

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -71,14 +71,51 @@ defmodule DateTest do
   end
 
   test "day_of_week/1" do
-    assert Date.day_of_week(~D[2016-10-31]) == 1
-    assert Date.day_of_week(~D[2016-11-01]) == 2
-    assert Date.day_of_week(~D[2016-11-02]) == 3
-    assert Date.day_of_week(~D[2016-11-03]) == 4
-    assert Date.day_of_week(~D[2016-11-04]) == 5
-    assert Date.day_of_week(~D[2016-11-05]) == 6
-    assert Date.day_of_week(~D[2016-11-06]) == 7
-    assert Date.day_of_week(~D[2016-11-07]) == 1
+    assert Date.day_of_week(Calendar.Holocene.date(2016, 10, 31)) == 1
+    assert Date.day_of_week(Calendar.Holocene.date(2016, 11, 01)) == 2
+    assert Date.day_of_week(Calendar.Holocene.date(2016, 11, 02)) == 3
+    assert Date.day_of_week(Calendar.Holocene.date(2016, 11, 03)) == 4
+    assert Date.day_of_week(Calendar.Holocene.date(2016, 11, 04)) == 5
+    assert Date.day_of_week(Calendar.Holocene.date(2016, 11, 05)) == 6
+    assert Date.day_of_week(Calendar.Holocene.date(2016, 11, 06)) == 7
+    assert Date.day_of_week(Calendar.Holocene.date(2016, 11, 07)) == 1
+
+    assert Date.day_of_week(Calendar.Holocene.date(2016, 10, 30), :sunday) == 1
+    assert Date.day_of_week(Calendar.Holocene.date(2016, 10, 31), :sunday) == 2
+    assert Date.day_of_week(Calendar.Holocene.date(2016, 11, 01), :sunday) == 3
+    assert Date.day_of_week(Calendar.Holocene.date(2016, 11, 02), :sunday) == 4
+    assert Date.day_of_week(Calendar.Holocene.date(2016, 11, 03), :sunday) == 5
+    assert Date.day_of_week(Calendar.Holocene.date(2016, 11, 04), :sunday) == 6
+    assert Date.day_of_week(Calendar.Holocene.date(2016, 11, 05), :sunday) == 7
+    assert Date.day_of_week(Calendar.Holocene.date(2016, 11, 06), :sunday) == 1
+  end
+
+  test "beginning_of_week" do
+    assert Date.beginning_of_week(Calendar.Holocene.date(2020, 07, 11)) ==
+             Calendar.Holocene.date(2020, 07, 06)
+
+    assert Date.beginning_of_week(Calendar.Holocene.date(2020, 07, 06)) ==
+             Calendar.Holocene.date(2020, 07, 06)
+
+    assert Date.beginning_of_week(Calendar.Holocene.date(2020, 07, 11), :sunday) ==
+             Calendar.Holocene.date(2020, 07, 05)
+
+    assert Date.beginning_of_week(Calendar.Holocene.date(2020, 07, 11), :saturday) ==
+             Calendar.Holocene.date(2020, 07, 11)
+  end
+
+  test "end_of_week" do
+    assert Date.end_of_week(Calendar.Holocene.date(2020, 07, 11)) ==
+             Calendar.Holocene.date(2020, 07, 12)
+
+    assert Date.end_of_week(Calendar.Holocene.date(2020, 07, 05)) ==
+             Calendar.Holocene.date(2020, 07, 05)
+
+    assert Date.end_of_week(Calendar.Holocene.date(2020, 07, 05), :sunday) ==
+             Calendar.Holocene.date(2020, 07, 11)
+
+    assert Date.end_of_week(Calendar.Holocene.date(2020, 07, 05), :saturday) ==
+             Calendar.Holocene.date(2020, 07, 10)
   end
 
   test "convert/2" do

--- a/lib/elixir/test/elixir/calendar/holocene.exs
+++ b/lib/elixir/test/elixir/calendar/holocene.exs
@@ -132,7 +132,7 @@ defmodule Calendar.Holocene do
   defdelegate months_in_year(year), to: Calendar.ISO
 
   @impl true
-  defdelegate day_of_week(year, month, day), to: Calendar.ISO
+  defdelegate day_of_week(year, month, day, starting_on), to: Calendar.ISO
 
   @impl true
   defdelegate day_of_year(year, month, day), to: Calendar.ISO


### PR DESCRIPTION
This augments the Calendar behaviour by adding
a new function, `c:Calendar.day_of_week/4` which
supports a `starting_on` value with defaults and
calendar specific semantics.