### PR TITLE
Add support for :hour and :minute time units

### DIFF
--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -491,7 +491,7 @@ defmodule Time do
   @doc since: "1.6.0"
   @spec add(Calendar.time(), integer, time_unit()) :: t()
   def add(%{calendar: calendar} = time, number, unit \\ :second) when is_integer(number) do
-    total = time_to_microseconds(time) + convert_time_unit(number, unit)
+    total = time_to_microseconds(time) + time_unit_to_microseconds(number, unit)
     parts = Integer.mod(total, @parts_per_day)
     {hour, minute, second, microsecond} = calendar.time_from_day_fraction({parts, @parts_per_day})
 
@@ -779,9 +779,11 @@ defmodule Time do
 
   ## Helpers
 
-  defp convert_time_unit(number, :hour), do: convert_time_unit(number * 60 * 60, :second)
-  defp convert_time_unit(number, :minute), do: convert_time_unit(number * 60, :second)
-  defp convert_time_unit(number, unit), do: System.convert_time_unit(number, unit, :microsecond)
+  defp time_unit_to_microseconds(number, :hour), do: convert_time_unit(number * 60 * 60, :second)
+  defp time_unit_to_microseconds(number, :minute), do: convert_time_unit(number * 60, :second)
+
+  defp time_unit_to_microseconds(number, unit),
+    do: System.convert_time_unit(number, unit, :microsecond)
 
   defp to_day_fraction(%{
          hour: hour,

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -779,8 +779,11 @@ defmodule Time do
 
   ## Helpers
 
-  defp time_unit_to_microseconds(number, :hour), do: convert_time_unit(number * 60 * 60, :second)
-  defp time_unit_to_microseconds(number, :minute), do: convert_time_unit(number * 60, :second)
+  defp time_unit_to_microseconds(number, :hour),
+    do: time_unit_to_microseconds(number * 60 * 60, :second)
+
+  defp time_unit_to_microseconds(number, :minute),
+    do: time_unit_to_microseconds(number * 60, :second)
 
   defp time_unit_to_microseconds(number, unit),
     do: System.convert_time_unit(number, unit, :microsecond)

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -666,6 +666,10 @@ defmodule Time do
   additional information about a date or time zone is ignored when calculating
   the difference.
 
+  The `unit` controls the measurement unit for the returned value.
+  The `unit` conversion always truncates lower units. For example, a
+  difference of 90 seconds will be returned as 1 if `:minute` is given.
+
   If the first time value is earlier than the second, a negative number is
   returned. The answer can be returned in any `unit` available from
   `t:time_unit/0`. All units are treated as `Calendar.ISO` units.

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -704,17 +704,24 @@ defmodule Time do
       iex> Time.diff(~T[12:30:12], ~T[11:00:00], :hour)
       1
 
+      iex> Time.diff(~T[00:01:20], ~T[00:00:40], :minute)
+      0
+
   """
   @doc since: "1.5.0"
   @spec diff(Calendar.time(), Calendar.time(), time_unit()) :: integer()
   def diff(time1, time2, unit \\ :second)
 
   def diff(%{calendar: Calendar.ISO} = time1, %{calendar: Calendar.ISO} = time2, :hour) do
-    time1.hour - time2.hour
+    time1
+    |> diff(time2, :second)
+    |> div(3600)
   end
 
   def diff(%{calendar: Calendar.ISO} = time1, %{calendar: Calendar.ISO} = time2, :minute) do
-    (time1.hour - time2.hour) * 60 + (time1.minute - time2.minute)
+    time1
+    |> diff(time2, :second)
+    |> div(60)
   end
 
   def diff(

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -489,7 +489,11 @@ defmodule Time do
 
   """
   @doc since: "1.6.0"
+<<<<<<< HEAD
   @spec add(Calendar.time(), integer, time_unit()) :: t
+=======
+  @spec add(Calendar.time(), integer, time_unit()) :: t()
+>>>>>>> 6a49c4288... Add support for :hour and :minute time units
   def add(%{calendar: calendar} = time, number, unit \\ :second) when is_integer(number) do
     total = time_to_microseconds(time) + convert_time_unit(number, unit)
     parts = Integer.mod(total, @parts_per_day)
@@ -702,7 +706,7 @@ defmodule Time do
 
   """
   @doc since: "1.5.0"
-  @spec diff(Calendar.time(), Calendar.time(), time_unit()) :: integer
+  @spec diff(Calendar.time(), Calendar.time(), time_unit()) :: integer()
   def diff(time1, time2, unit \\ :second)
 
   def diff(%{calendar: Calendar.ISO} = time1, %{calendar: Calendar.ISO} = time2, :hour) do

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -489,11 +489,7 @@ defmodule Time do
 
   """
   @doc since: "1.6.0"
-<<<<<<< HEAD
-  @spec add(Calendar.time(), integer, time_unit()) :: t
-=======
   @spec add(Calendar.time(), integer, time_unit()) :: t()
->>>>>>> 6a49c4288... Add support for :hour and :minute time units
   def add(%{calendar: calendar} = time, number, unit \\ :second) when is_integer(number) do
     total = time_to_microseconds(time) + convert_time_unit(number, unit)
     parts = Integer.mod(total, @parts_per_day)


### PR DESCRIPTION
This enhances time unit aware functions in the `Time` module so that they can operate on `:hour` and `:minute`, along with standard `System.time_unit/0` values. This eliminates the need to convert all values to seconds, which allows more expressive time manipulation.

Along with changes to `Time.add/3` and `Time.diff/3`, this adds a new extended `time_unit` type to `Time`.