### PR TITLE
Add MIX_BUILD_ROOT to config the "_build" dir

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -238,6 +238,9 @@ defmodule Mix do
 
     * `MIX_ARCHIVES` - specifies the directory into which the archives should be installed
       (default: `~/.mix/archives`)
+    * `MIX_BUILD_ROOT` - sets the root directory where build artifacts
+      should be written to. For example, "_build". If `MIX_BUILD_PATH` is set, this
+      option is ignored.
     * `MIX_BUILD_PATH` - sets the project `Mix.Project.build_path/0` config. This option
       must always point to a subdirectory inside a temporary directory. For instance,
       never "/tmp" or "_build" but "_build/PROD" or "/tmp/PROD", as required by Mix

--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -526,7 +526,7 @@ defmodule Mix.Project do
   end
 
   defp env_path(config) do
-    dir = config[:build_path] || "_build"
+    dir = System.get_env("MIX_BUILD_ROOT") || config[:build_path] || "_build"
     subdir = build_target() <> build_per_environment(config)
     Path.expand(dir <> "/" <> subdir)
   end

--- a/lib/mix/test/mix/project_test.exs
+++ b/lib/mix/test/mix/project_test.exs
@@ -47,6 +47,13 @@ defmodule Mix.ProjectTest do
       System.delete_env("MIX_BUILD_PATH")
     end
 
+    test "considers MIX_BUILD_ROOT" do
+      System.put_env("MIX_BUILD_ROOT", "_build_root")
+      assert Mix.Project.build_path() == Path.join(File.cwd!(), "_build_root/dev")
+    after
+      System.delete_env("MIX_BUILD_ROOT")
+    end
+
     test "considers MIX_DEPS_PATH" do
       System.put_env("MIX_DEPS_PATH", "test_deps_path")
       assert Mix.Project.deps_path() == Path.join(File.cwd!(), "test_deps_path")


### PR DESCRIPTION
The goal is to make it easier to change the path of the `_build` directory.

Mix currently supports `MIX_BUILD_PATH` to customize where the build artifacts are written to. One thing to keep in mind is that `MIX_BUILD_PATH` expects the final path and it's up to the user to use different paths per environment. `MIX_BUILD_PATH` is not equivalent to the `_build` directory, it's equivalent to the `_build/<env>` directory.

Mix also allows to configure the path of the `_build` directory using the `:build_path` configuration of `Mix.Project`, but that is meant to be used by umbrella applications:

> In a non-umbrella context, configuring this has undesirable side-effects (such as skipping some compiler checks) and should be avoided.

https://github.com/elixir-lang/elixir/blob/295f4a705230f297b03d77c72561c038c5a682c1/lib/mix/lib/mix/tasks/app.config.ex#L46-L55

Finally, `Mix.Project` also uses `:env_path` to configure the build path, but that option is not documented and it's marked as
"private" in the code.

Side note: I find it a bit confusing that the `:build_path` option does not expect the same value as the `MIX_BUILD_PATH` env var.
