### PR TITLE
Fix ExUnit format

### DIFF
--- a/lib/ex_unit/lib/ex_unit/failures_manifest.ex
+++ b/lib/ex_unit/lib/ex_unit/failures_manifest.ex
@@ -1,7 +1,7 @@
 defmodule ExUnit.FailuresManifest do
   @moduledoc false
 
-  @opaque t :: %{optional(ExUnit.test_id) => test_file :: Path.t()}
+  @opaque t :: %{optional(ExUnit.test_id()) => test_file :: Path.t()}
 
   @manifest_vsn 1
 
@@ -15,7 +15,7 @@ defmodule ExUnit.FailuresManifest do
     |> MapSet.new()
   end
 
-  @spec failed_test_ids(t) :: MapSet.t(ExUnit.test_id)
+  @spec failed_test_ids(t) :: MapSet.t(ExUnit.test_id())
   def failed_test_ids(%{} = manifest) do
     manifest
     |> Map.keys()


### PR DESCRIPTION
Run `make format` to fix failing build:

![Screenshot from 2020-07-15 08-27-51](https://user-images.githubusercontent.com/11598866/87486428-45572100-c676-11ea-9e4c-599a69d9be33.png)

(I'm sorry if this is overkill to open a PR for this, I don't have much experience contributing on open source :bow:)