### PR TITLE
Use GitHub Actions for Windows CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,38 +9,6 @@ test_template: &DEFAULT_TEST_SETTINGS
   # don't cancel the task execution if it's master or a release branch
   auto_cancellation: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH !=~ 'v\d+\.\d+.*'
 
-test_windows_task:
-  <<: *DEFAULT_TEST_SETTINGS
-
-  name: Windows, OTP-${OTP_RELEASE}, Windows Server 2019
-  alias: Windows Stable
-
-  matrix:
-    - env:
-        OS_VERSION: 2019
-        OTP_RELEASE: 22.0
-
-  windows_container:
-    image: fertapric/elixir-ci:otp-win64-${OTP_RELEASE}
-    os_version: ${OS_VERSION}
-    cpu: 4
-    memory: 6GB
-
-  install_script:
-    - rmdir /s /q .git
-    - make compile
-
-  build_info_script: bin/elixir --version
-
-  test_formatted_script:
-    - make test_formatted &&
-      echo "All Elixir source code files are properly formatted."
-
-  test_erlang_script: make --keep-going test_erlang
-
-  test_elixir_script: make --keep-going test_elixir
-
-
 test_freebsd_task:
   <<: *DEFAULT_TEST_SETTINGS
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
   LANG: C.UTF-8
 
 jobs:
-  test:
+  test_linux:
     name: Linux, ${{ matrix.otp_release }}, Ubuntu 16.04
     continue-on-error: ${{ matrix.development }}
     strategy:
@@ -51,6 +51,38 @@ jobs:
       - name: Check reproducible builds
         run: taskset 1 make check_reproducible
         if: matrix.otp_release == 'OTP-23.0'
+
+  test_windows:
+    name: Windows, OTP-${{ matrix.otp_release }}, Windows Server 2019
+    strategy:
+      matrix:
+        otp_release: ['22.0']
+    runs-on: windows-2019
+    steps:
+      - name: Configure Git
+        run: git config --global core.autocrlf input
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 50
+      - name: Cache Erlang/OTP package
+        uses: actions/cache@v2
+        with:
+          path: C:\Users\runneradmin\AppData\Local\Temp\chocolatey\erlang
+          key: OTP-${{ matrix.otp_release }}-windows-2019
+      - name: Install Erlang/OTP
+        run: choco install -y erlang --version ${{ matrix.otp_release }}
+      - name: Compile Elixir
+        run: |
+          remove-item '.git' -recurse -force
+          make compile
+      - name: Build info
+        run: bin/elixir --version
+      - name: Check format
+        run: make test_formatted && echo "All Elixir source code files are properly formatted."
+      - name: Erlang test suite
+        run: make --keep-going test_erlang
+      - name: Elixir test suite
+        run: make --keep-going test_elixir
 
   check_posix_compliant:
     name: Check POSIX-compliant


### PR DESCRIPTION
Here are some benefits of moving to GitHub
Actions:

  * The Docker image `fertapric/elixir-ci:*` is no longer needed.

  * Build times has been reduced ~50%: current times are ~20 mins, and with GitHub Actions ~10 mins.

  * Jobs seem to be scheduled faster: a few seconds compared to minutes.

  * Running instances seem more stable: I have not experienced `ExUnit.TimeoutError` errors nor memory allocation issues.