### PR TITLE
Add List.Chars to bootstrap modules

### DIFF
--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -162,6 +162,7 @@ bootstrap_files() ->
      <<"lib/elixir/lib/string/chars.ex">>
     ],
     [
+     <<"lib/elixir/lib/list/chars.ex">>,
      <<"lib/elixir/lib/module/checker.ex">>,
      <<"lib/elixir/lib/module/locals_tracker.ex">>,
      <<"lib/elixir/lib/module/parallel_checker.ex">>,


### PR DESCRIPTION
If there is a compile error, `Kernel.ParallelCompiler` raises `** (UndefinedFunctionError) function List.Chars.to_charlist/1 is undefined (module List.Chars is not available)`.

Here is an example: https://github.com/fertapric/elixir/runs/875212343