### PR TITLE
Fix markdown code block rendering on Patterns and Guards -page

### DIFF
--- a/lib/elixir/pages/patterns-and-guards.md
+++ b/lib/elixir/pages/patterns-and-guards.md
@@ -430,9 +430,9 @@ In the examples above, we have used the match operator (`=`) and function clause
 
 Note that the match operator (`=`) does *not* support guards:
 
-    ```elixir
-    {:ok, binary} = File.read("some/file")
-    ```
+```elixir
+{:ok, binary} = File.read("some/file")
+```
 
 ## Custom patterns and guards expressions
 


### PR DESCRIPTION
This PR fixes a tiny markdown rendering issue present on the Patterns and Guards -page, under the "Note that the match operator (=) does not support guards:" line.

Currently the docs are rendered with the markdown code block syntax being visible (as seen in both https://hexdocs.pm/elixir/master/patterns-and-guards.html and the source file itself, https://github.com/elixir-lang/elixir/blob/master/lib/elixir/pages/patterns-and-guards.md). 

The small change of whitespace in this PR allows the markdown to be rendered correctly.

Sanity-checked by rebuilding docs with `make docs` locally.
