### PR TITLE
Fix canonical link in HTML docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ PREFIX ?= /usr/local
 TEST_FILES ?= "*_test.exs"
 SHARE_PREFIX ?= $(PREFIX)/share
 MAN_PREFIX ?= $(SHARE_PREFIX)/man
-CANONICAL := master/ # master/ or vMAJOR.MINOR/
+#CANONICAL := vMAJOR.MINOR/
+CANONICAL ?= master/
 ELIXIRC := bin/elixirc --ignore-module-conflict $(ELIXIRC_OPTS)
 ERLC := erlc -I lib/elixir/include
 ERL_MAKE := if [ -n "$(ERLC_OPTS)" ]; then ERL_COMPILER_OPTIONS=$(ERLC_OPTS) erl -make; else erl -make; fi


### PR DESCRIPTION
The comments would add space to the CANONICAL variable,
redering the link like
`<link rel="canonical" href="https://hexdocs.pm/elixir/v1.10/ /Kernel.html" />`