### PR TITLE
Correct the @since attribute for {Keyword, Map}.replace3

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -627,7 +627,7 @@ defmodule Keyword do
       [a: 1]
 
   """
-  @doc since: "1.11.0"
+  @doc since: "1.5.0"
   @spec replace(t, key, value) :: t
   def replace(keywords, key, value) when is_list(keywords) and is_atom(key) do
     case :lists.keyfind(key, 1, keywords) do

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -314,7 +314,7 @@ defmodule Map do
       %{a: 1}
 
   """
-  @doc since: "1.11.0"
+  @doc since: "1.5.0"
   @spec replace(map, key, value) :: map
   def replace(map, key, value) do
     case map do


### PR DESCRIPTION
They have been undeprecated in 284881c370a241042ad5be88914446f893383f42,
but the functions have been available in the language, beside de deprecation warning, since v1.5.0
when they made their way into the language in 3f88ab745eed2209007e9ff872b15fc5df252867