### PR TITLE
Raise ArgumentError in Keyword.keys when list is not a keyword list

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -436,7 +436,7 @@ defmodule Keyword do
       [:a, :b, :a]
 
       iex> Keyword.keys([{:a, 1}, {"b", 2}, {:c, 3}])
-      ** (ArgumentError) expected a keyword list, but an element in the list is not a keyword; got: {"b", 2}
+      ** (ArgumentError) expected a keyword list, but an element in the list is not a two-element tuple with an atom key; got: {"b", 2}
 
   """
   @spec keys(t) :: [key]
@@ -448,7 +448,7 @@ defmodule Keyword do
 
         element ->
           raise ArgumentError,
-                "expected a keyword list, but an element in the list is not a keyword; got: #{
+                "expected a keyword list, but an element in the list is not a two-element tuple with an atom key; got: #{
                   inspect(element)
                 }"
       end,

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -436,7 +436,7 @@ defmodule Keyword do
       [:a, :b, :a]
 
       iex> Keyword.keys([{:a, 1}, {"b", 2}, {:c, 3}])
-      ** (ArgumentError) expected a keyword list, but an element in the list is not a two-element tuple with an atom as its first element, got: {"b", 2}
+      ** (ArgumentError) expected a keyword list, but an entry in the list is not a two-element tuple with an atom as its first element, got: {"b", 2}
 
   """
   @spec keys(t) :: [key]
@@ -452,7 +452,7 @@ defmodule Keyword do
     catch
       element ->
         raise ArgumentError,
-              "expected a keyword list, but an element in the list is not a two-element tuple with an atom as its first element, " <>
+              "expected a keyword list, but an entry in the list is not a two-element tuple with an atom as its first element, " <>
                 "got: #{inspect(element)}"
     end
   end

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -444,27 +444,16 @@ defmodule Keyword do
     try do
       :lists.map(
         fn
-          {key, _} when is_atom(key) ->
-            key
-
-          element ->
-            throw(element)
+          {key, _} when is_atom(key) -> key
+          element -> throw(element)
         end,
         keywords
       )
     catch
       element ->
-        stacktrace =
-          Enum.drop_while(__STACKTRACE__, fn
-            {Keyword, :keys, 1, _} -> false
-            {Keyword, _, _, _} -> true
-          end)
-
-        reraise ArgumentError,
-                "expected a keyword list, but an element in the list is not a two-element tuple with its first element being an atom; got: #{
-                  inspect(element)
-                }",
-                stacktrace
+        raise ArgumentError,
+              "expected a keyword list, but an element in the list is not a two-element tuple with an atom key as first element, " <>
+                "got: #{inspect(element)}"
     end
   end
 

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -436,7 +436,7 @@ defmodule Keyword do
       [:a, :b, :a]
 
       iex> Keyword.keys([{:a, 1}, {"b", 2}, {:c, 3}])
-      ** (ArgumentError) expected a keyword list, but an element in the list is not a two-element tuple with its first element being an atom; got: {"b", 2}
+      ** (ArgumentError) expected a keyword list, but an element in the list is not a two-element tuple with an atom as its first element, got: {"b", 2}
 
   """
   @spec keys(t) :: [key]
@@ -452,7 +452,7 @@ defmodule Keyword do
     catch
       element ->
         raise ArgumentError,
-              "expected a keyword list, but an element in the list is not a two-element tuple with an atom key as first element, " <>
+              "expected a keyword list, but an element in the list is not a two-element tuple with an atom as its first element, " <>
                 "got: #{inspect(element)}"
     end
   end

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -431,13 +431,29 @@ defmodule Keyword do
 
       iex> Keyword.keys(a: 1, b: 2)
       [:a, :b]
+
       iex> Keyword.keys(a: 1, b: 2, a: 3)
       [:a, :b, :a]
+
+      iex> Keyword.keys([{:a, 1}, {"b", 2}, {:c, 3}])
+      ** (ArgumentError) expected a keyword list, but an element in the list is not a keyword; got: {"b", 2}
 
   """
   @spec keys(t) :: [key]
   def keys(keywords) when is_list(keywords) do
-    :lists.map(fn {k, _} when is_atom(k) -> k end, keywords)
+    :lists.map(
+      fn
+        {key, _} when is_atom(key) ->
+          key
+
+        element ->
+          raise ArgumentError,
+                "expected a keyword list, but an element in the list is not a keyword; got: #{
+                  inspect(element)
+                }"
+      end,
+      keywords
+    )
   end
 
   @doc """


### PR DESCRIPTION
Previously it would return something like this:

** (FunctionClauseError) no function clause matching in anonymous fn/1 in Keyword.keys/1

    The following arguments were given to anonymous fn/1 in Keyword.keys/1:

        # 1
        {"fetch/2", {:fetch, 2}}

Closes #10010, and it improves 3fd68ef62a90f3b914ed2e881e5d152431f78bbc