### PR TITLE
Improve Operators documentation

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1564,8 +1564,8 @@ defmodule Enum do
   In the example above, `max/2` returned March 31st instead of April 1st
   because the structural comparison compares the day before the year.
   For this reason, most structs provide a "compare" function, such as
-  `Date.compare/2`, which receives two structs and returns `:lt` (less than),
-  `:eq` (equal), and `:gt` (greater than). If you pass a module as the
+  `Date.compare/2`, which receives two structs and returns `:lt` (less-than),
+  `:eq` (equal to), and `:gt` (greater-than). If you pass a module as the
   sorting function, Elixir will automatically use the `compare/2` function
   of said module:
 
@@ -1624,8 +1624,8 @@ defmodule Enum do
   The fact this function uses Erlang's term ordering means that the
   comparison is structural and not semantic. Therefore, if you want
   to compare structs, most structs provide a "compare" function, such as
-  `Date.compare/2`, which receives two structs and returns `:lt` (less than),
-  `:eq` (equal), and `:gt` (greater than). If you pass a module as the
+  `Date.compare/2`, which receives two structs and returns `:lt` (less-than),
+  `:eq` (equal to), and `:gt` (greater-than). If you pass a module as the
   sorting function, Elixir will automatically use the `compare/2` function
   of said module:
 
@@ -1738,8 +1738,8 @@ defmodule Enum do
   In the example above, `min/2` returned April 1st instead of March 31st
   because the structural comparison compares the day before the year.
   For this reason, most structs provide a "compare" function, such as
-  `Date.compare/2`, which receives two structs and returns `:lt` (less than),
-  `:eq` (equal), and `:gt` (greater than). If you pass a module as the
+  `Date.compare/2`, which receives two structs and returns `:lt` (less-than),
+  `:eq` (equal to), and `:gt` (greater-than). If you pass a module as the
   sorting function, Elixir will automatically use the `compare/2` function
   of said module:
 
@@ -1798,8 +1798,8 @@ defmodule Enum do
   The fact this function uses Erlang's term ordering means that the
   comparison is structural and not semantic. Therefore, if you want
   to compare structs, most structs provide a "compare" function, such as
-  `Date.compare/2`, which receives two structs and returns `:lt` (less than),
-  `:eq` (equal), and `:gt` (greater than). If you pass a module as the
+  `Date.compare/2`, which receives two structs and returns `:lt` (less-than),
+  `:eq` (equal to), and `:gt` (greater-than). If you pass a module as the
   sorting function, Elixir will automatically use the `compare/2` function
   of said module:
 
@@ -1905,8 +1905,8 @@ defmodule Enum do
   The fact this function uses Erlang's term ordering means that the
   comparison is structural and not semantic. Therefore, if you want
   to compare structs, most structs provide a "compare" function, such as
-  `Date.compare/2`, which receives two structs and returns `:lt` (less than),
-  `:eq` (equal), and `:gt` (greater than). If you pass a module as the
+  `Date.compare/2`, which receives two structs and returns `:lt` (less-than),
+  `:eq` (equal to), and `:gt` (greater-than). If you pass a module as the
   sorting function, Elixir will automatically use the `compare/2` function
   of said module:
 
@@ -2575,8 +2575,8 @@ defmodule Enum do
   we want.
 
   For this reason, most structs provide a "compare" function, such as
-  `Date.compare/2`, which receives two structs and returns `:lt` (less than),
-  `:eq` (equal), and `:gt` (greater than). If you pass a module as the
+  `Date.compare/2`, which receives two structs and returns `:lt` (less-than),
+  `:eq` (equal to), and `:gt` (greater-than). If you pass a module as the
   sorting function, Elixir will automatically use the `compare/2` function
   of said module:
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1989,7 +1989,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Regular expression or sub-string match operator. Matches the term on the `left`
+  Text-based match operator. Matches the term on the `left`
   against the regular expression or string on the `right`.
 
   If `right` is a regular expression, returns `true` if `left` matches right.

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1193,7 +1193,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Arithmetic addition.
+  Arithmetic addition operator.
 
   Allowed in guard tests. Inlined by the compiler.
 
@@ -1213,7 +1213,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Arithmetic subtraction.
+  Arithmetic subtraction operator.
 
   Allowed in guard tests. Inlined by the compiler.
 
@@ -1233,7 +1233,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Arithmetic unary plus.
+  Arithmetic plus unary operator.
 
   Allowed in guard tests. Inlined by the compiler.
 
@@ -1251,7 +1251,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Arithmetic unary minus.
+  Arithmetic minus unary operator.
 
   Allowed in guard tests. Inlined by the compiler.
 
@@ -1271,7 +1271,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Arithmetic multiplication.
+  Arithmetic multiplication operator.
 
   Allowed in guard tests. Inlined by the compiler.
 
@@ -1291,7 +1291,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Arithmetic division.
+  Arithmetic division operator.
 
   The result is always a float. Use `div/2` and `rem/2` if you want
   an integer division or the remainder.
@@ -1322,7 +1322,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Concatenates a proper list and a term, returning a list.
+  List concatenation operator. Concatenates a proper list and a term, returning a list.
 
   The complexity of `a ++ b` is proportional to `length(a)`, so avoid repeatedly
   appending to lists of arbitrary length, for example, `list ++ [element]`.
@@ -1360,7 +1360,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Removes the first occurrence of an element on the left list
+  List subtraction operator. Removes the first occurrence of an element on the left list
   for each element on the right.
 
   Before Erlang/OTP 22, the complexity of `a -- b` was proportional to
@@ -1391,7 +1391,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Boolean not.
+  Strictly boolean not operator.
 
   `arg` must be a boolean; if it's not, an `ArgumentError` exception is raised.
 
@@ -1411,7 +1411,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns `true` if left is less than right.
+  Less-than operator. Returns `true` if left is less than right.
 
   All terms in Elixir can be compared with each other.
 
@@ -1430,7 +1430,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns `true` if left is more than right.
+  Greater-than operator. Returns `true` if left is more than right.
 
   All terms in Elixir can be compared with each other.
 
@@ -1449,7 +1449,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns `true` if left is less than or equal to right.
+  Less-than or equal to operator. Returns `true` if left is less than or equal to right.
 
   All terms in Elixir can be compared with each other.
 
@@ -1468,7 +1468,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns `true` if left is more than or equal to right.
+  Greater-than or equal to operator. Returns `true` if left is more than or equal to right.
 
   All terms in Elixir can be compared with each other.
 
@@ -1487,7 +1487,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns `true` if the two terms are equal.
+  Equal to operator. Returns `true` if the two terms are equal.
 
   This operator considers 1 and 1.0 to be equal. For stricter
   semantics, use `===/2` instead.
@@ -1512,7 +1512,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns `true` if the two terms are not equal.
+  Not equal to operator. Returns `true` if the two terms are not equal.
 
   This operator considers 1 and 1.0 to be equal. For match
   comparison, use `!==/2` instead.
@@ -1537,7 +1537,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns `true` if the two terms are exactly equal.
+  Strictly equal to operator. Returns `true` if the two terms are exactly equal.
 
   The terms are only considered to be exactly equal if they
   have the same value and are of the same type. For example,
@@ -1564,7 +1564,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns `true` if the two terms are not exactly equal.
+  Strictly not equal to operator. Returns `true` if the two terms are not exactly equal.
 
   All terms in Elixir can be compared with each other.
 
@@ -1635,7 +1635,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Boolean or.
+  Strictly boolean or operator.
 
   If `left` is `true`, returns `true`; otherwise returns `right`.
 
@@ -1663,7 +1663,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Boolean and.
+  Strictly boolean and operator.
 
   If `left` is `false`, returns `false`; otherwise returns `right`.
 
@@ -1702,7 +1702,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Boolean not.
+  Boolean not operator.
 
   Receives any argument (not just booleans) and returns `true` if the argument
   is `false` or `nil`; returns `false` otherwise.
@@ -1747,7 +1747,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Concatenates two binaries.
+  Binary concatenation operator. Concatenates two binaries.
 
   ## Examples
 
@@ -1989,11 +1989,12 @@ defmodule Kernel do
   end
 
   @doc """
-  Matches the term on the `left` against the regular expression or string on the
-  `right`.
+  Regular expression or sub-string match operator. Matches the term on the `left`
+  against the regular expression or string on the `right`.
 
-  Returns `true` if `left` matches `right` (if it's a regular expression)
-  or contains `right` (if it's a string).
+  If `right` is a regular expression, returns `true` if `left` matches right.
+
+  If `right` is a string, returns `true` if `left` contains `right`.
 
   ## Examples
 
@@ -2003,11 +2004,17 @@ defmodule Kernel do
       iex> "abcd" =~ ~r/e/
       false
 
+      iex> "abcd" =~ ~r//
+      true
+
       iex> "abcd" =~ "bc"
       true
 
       iex> "abcd" =~ "ad"
       false
+
+      iex> "abcd" =~ "abcd"
+      true
 
       iex> "abcd" =~ ""
       true
@@ -3656,7 +3663,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Checks if the element on the left-hand side is a member of the
+  Membership operator. Checks if the element on the left-hand side is a member of the
   collection on the right-hand side.
 
   ## Examples

--- a/lib/elixir/pages/operators.md
+++ b/lib/elixir/pages/operators.md
@@ -37,7 +37,7 @@ Elixir provides the following built-in operators that are defined as functions t
   * [`+`](`+/1`) and [`-`](`-/1`) - unary positive/negative
   * [`!`](`!/1`) and [`not`](`not/1`) - relaxed and strict logical not
   * [`*`](`*/2`), [`/`](`//2`), [`+`](`+/2`), and [`-`](`-/2`) - arithmetic
-  * [`++`](`++/2`) and [`--`](`--/2`) - list concatenation and pruning
+  * [`++`](`++/2`) and [`--`](`--/2`) - list concatenation and subtraction
   * [`..`](`../2`) - range creation
   * [`<>`](`<>/2`) - binary concatenation
   * [`in`](`in/2`) and [`not in`](`in/2`) - shorthands for [`Enum.member?`](`Enum.member?/2`)
@@ -70,14 +70,14 @@ Finally, these operators appear in the precedence table above but are only meani
 
 Elixir provides the following built-in comparison operators (all of which can be used in guards):
 
-  * [`==`](`==/2`) - equality
-  * [`===`](`===/2`) - strict equality
-  * [`!=`](`!=/2`) - inequality
-  * [`!==`](`!==/2`) - strict inequality
-  * [`<`](`</2`) - less than
-  * [`>`](`>/2`) - greater than
-  * [`<=`](`<=/2`) - less than or equal
-  * [`>=`](`>=/2`) - greater than or equal
+  * [`==`](`==/2`) - equal to
+  * [`===`](`===/2`) - strictly equal to
+  * [`!=`](`!=/2`) - inequal to
+  * [`!==`](`!==/2`) - strictly inequal to
+  * [`<`](`</2`) - less-than
+  * [`>`](`>/2`) - greater-than
+  * [`<=`](`<=/2`) - less-than or equal to
+  * [`>=`](`>=/2`) - greater-than or equal to
 
 The only difference between [`==`](`==/2`) and [`===`](`===/2`) is that [`===`](`===/2`) is strict when it comes to comparing integers and floats:
 

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -695,11 +695,11 @@ defmodule ExUnit.AssertionsTest do
       """ <> _ = error.message
   end
 
-  test "assert greater than operator" do
+  test "assert greater-than operator" do
     true = assert 2 > 1
   end
 
-  test "assert greater than operator error" do
+  test "assert greater-than operator error" do
     "This should never be tested" = assert 1 > 2
   rescue
     error in [ExUnit.AssertionError] ->


### PR DESCRIPTION
- Use "less-than", "greater-than", and "equal to" operators. This the actual name used by Wikipedia and Unicode.
- Give a name to every opertor in Kernel. Mention it at the beggining of the first paragraph, so it appears in the summary.
- Minor improvements here and there.