### PR TITLE
Update Map.update example to use full lambda syntax on first example

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -604,7 +604,7 @@ defmodule Map do
 
   ## Examples
 
-      iex> Map.update(%{a: 1}, :a, 13, fn existing -> existing * 2 end)
+      iex> Map.update(%{a: 1}, :a, 13, fn existing_value -> existing_value * 2 end)
       %{a: 2}
       iex> Map.update(%{a: 1}, :b, 11, &(&1 * 2))
       %{a: 1, b: 11}

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -604,7 +604,7 @@ defmodule Map do
 
   ## Examples
 
-      iex> Map.update(%{a: 1}, :a, 13, &(&1 * 2))
+      iex> Map.update(%{a: 1}, :a, 13, fn existing -> existing * 2 end)
       %{a: 2}
       iex> Map.update(%{a: 1}, :b, 11, &(&1 * 2))
       %{a: 1, b: 11}


### PR DESCRIPTION
Hello.

I was training a new person today and he was very confused on the &(&...) syntax for updating in Map.update.

I have changed the first example to use the full lambda syntax so that it is more clear that the argument should be a regular lambda with an output and that the value is set to the return value of this function.