### PR TITLE
fix bug of only taking first app option in mix cmd

### DIFF
--- a/lib/mix/lib/mix/tasks/cmd.ex
+++ b/lib/mix/lib/mix/tasks/cmd.ex
@@ -50,7 +50,11 @@ defmodule Mix.Tasks.Cmd do
   @impl true
   def run(args) do
     {opts, args} = OptionParser.parse_head!(args, strict: @switches)
-    apps = Enum.map(List.wrap(opts[:app]), &String.to_atom/1)
+
+    apps =
+      opts
+      |> Keyword.get_values(:app)
+      |> Enum.map(&String.to_atom/1)
 
     if apps == [] or Mix.Project.config()[:app] in apps do
       cmd_opts = Keyword.take(opts, [:cd])

--- a/lib/mix/test/mix/tasks/cmd_test.exs
+++ b/lib/mix/test/mix/tasks/cmd_test.exs
@@ -24,7 +24,20 @@ defmodule Mix.Tasks.CmdTest do
     end)
   end
 
-  test "runs the command for each apps specified by app flag" do
+  test "runs the command for a single app specified by app flag" do
+    in_fixture("umbrella_dep/deps/umbrella", fn ->
+      Mix.Project.in_project(:umbrella, ".", fn _ ->
+        Mix.Task.run("cmd", ["--app", "bar", "echo", "hello"])
+        nl = os_newline()
+        assert_received {:mix_shell, :info, ["==> bar"]}
+        assert_received {:mix_shell, :run, ["hello" <> ^nl]}
+        refute_received {:mix_shell, :info, ["==> foo"]}
+        refute_received {:mix_shell, :run, ["hello" <> ^nl]}
+      end)
+    end)
+  end
+
+  test "runs the command for each app specified by app flag" do
     in_fixture("umbrella_dep/deps/umbrella", fn ->
       Mix.Project.in_project(:umbrella, ".", fn _ ->
         Mix.Task.run("cmd", ["--app", "bar", "--app", "foo", "echo", "hello"])

--- a/lib/mix/test/mix/tasks/cmd_test.exs
+++ b/lib/mix/test/mix/tasks/cmd_test.exs
@@ -24,6 +24,19 @@ defmodule Mix.Tasks.CmdTest do
     end)
   end
 
+  test "runs the command for each apps specified by app flag" do
+    in_fixture("umbrella_dep/deps/umbrella", fn ->
+      Mix.Project.in_project(:umbrella, ".", fn _ ->
+        Mix.Task.run("cmd", ["--app", "bar", "--app", "foo", "echo", "hello"])
+        nl = os_newline()
+        assert_received {:mix_shell, :info, ["==> bar"]}
+        assert_received {:mix_shell, :run, ["hello" <> ^nl]}
+        assert_received {:mix_shell, :info, ["==> foo"]}
+        assert_received {:mix_shell, :run, ["hello" <> ^nl]}
+      end)
+    end)
+  end
+
   test "only runs the cmd for specified apps" do
     in_fixture("umbrella_dep/deps/umbrella", fn ->
       Mix.Project.in_project(:umbrella, ".", fn _ ->

--- a/lib/mix/test/mix/tasks/cmd_test.exs
+++ b/lib/mix/test/mix/tasks/cmd_test.exs
@@ -37,19 +37,6 @@ defmodule Mix.Tasks.CmdTest do
     end)
   end
 
-  test "only runs the cmd for specified apps" do
-    in_fixture("umbrella_dep/deps/umbrella", fn ->
-      Mix.Project.in_project(:umbrella, ".", fn _ ->
-        Mix.Task.run("cmd", ["--app", "bar", "echo", "hello"])
-        nl = os_newline()
-        assert_received {:mix_shell, :info, ["==> bar"]}
-        assert_received {:mix_shell, :run, ["hello" <> ^nl]}
-        refute_received {:mix_shell, :info, ["==> foo"]}
-        refute_received {:mix_shell, :run, ["hello" <> ^nl]}
-      end)
-    end)
-  end
-
   test "only runs the cmd for specified apps and in specific directory" do
     in_fixture("umbrella_dep/deps/umbrella", fn ->
       Mix.Project.in_project(:umbrella, ".", fn _ ->


### PR DESCRIPTION
currently there is a bug when we run `mix cmd --app foo --app bar pwd`, only the first app option will be used.

This PR fix this. This is my first PR to Elixir so please let me know if there is anything I missed. I have ran `make format` and `make test`