### PR TITLE
Fix bug of only first cmd is ran in alias list for umbrella project

### DIFF
--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -385,9 +385,14 @@ defmodule Mix.Task do
 
     cond do
       recursive && Mix.Project.umbrella?() ->
-        Mix.ProjectStack.recur(fn ->
-          recur(fn _ -> run(task, args) end)
-        end)
+        res =
+          Mix.ProjectStack.recur(fn ->
+            recur(fn _ -> run(task, args) end)
+          end)
+
+        Mix.TasksServer.delete_many([{:task, task, proj}])
+
+        res
 
       not recursive && Mix.ProjectStack.recursing() ->
         Mix.ProjectStack.on_recursing_root(fn -> run(task, args) end)

--- a/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/mix.exs
+++ b/lib/mix/test/fixtures/umbrella_dep/deps/umbrella/mix.exs
@@ -2,6 +2,14 @@ defmodule Umbrella.MixProject do
   use Mix.Project
 
   def project do
-    [apps_path: "apps"]
+    [
+      apps_path: "apps",
+      aliases: [
+        test_cmd: [
+          "cmd echo hello",
+          "cmd echo hola"
+        ]
+      ]
+    ]
   end
 end

--- a/lib/mix/test/mix/aliases_test.exs
+++ b/lib/mix/test/mix/aliases_test.exs
@@ -59,4 +59,22 @@ defmodule Mix.AliasesTest do
              Mix.Task.rerun("help", ["test"]) == "Hello, World!"
            end) =~ "mix test"
   end
+
+  test "run list alias with multiple cmd in umbrella" do
+    Mix.Project.pop()
+
+    in_fixture("umbrella_dep/deps/umbrella", fn ->
+      Mix.Project.in_project(:umbrella, ".", fn _ ->
+        Mix.Task.run("test_cmd", [])
+
+        nl = os_newline()
+        assert_received {:mix_shell, :info, ["==> bar"]}
+        assert_received {:mix_shell, :run, ["hello" <> ^nl]}
+        assert_received {:mix_shell, :run, ["hola" <> ^nl]}
+        assert_received {:mix_shell, :info, ["==> foo"]}
+        assert_received {:mix_shell, :run, ["hello" <> ^nl]}
+        assert_received {:mix_shell, :run, ["hola" <> ^nl]}
+      end)
+    end)
+  end
 end


### PR DESCRIPTION
For umbrella project, if you define alias like the following in root mix.exs and ran `mix test_cmd`. only the first cmd `echo hello` will be ran. This PR fix this. Note that I am not sure if there is a better/cleaner way to create umbrella fixture for it. 

```
      aliases: [
        test_cmd: [
          "cmd echo hello",
          "cmd echo hola"
        ]
```