### PR TITLE
Fix ambiguity on Path.expand/1 docs

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -152,8 +152,8 @@ defmodule Path do
 
   ## Examples
 
-      Path.expand("/foo/bar/../bar")
-      #=> "/foo/bar"
+      Path.expand("/foo/bar/../baz")
+      #=> "/foo/baz"
 
   """
   @spec expand(t) :: binary


### PR DESCRIPTION
I think it is appropriate to change the current example so as to avoid any misleading interpretation.