### PR TITLE
Additional changes to ExUnit trace

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -119,17 +119,17 @@ defmodule ExUnit do
 
     It is received by formatters and contains the following fields:
 
-      * `:name`  - the test module name
       * `:file`  - the file of the test module
+      * `:name`  - the test module name
       * `:state` - the test error state (see `t:ExUnit.state/0`)
       * `:tests` - all tests in this module
 
     """
-    defstruct [:name, :state, :file, tests: []]
+    defstruct [:file, :name, :state, tests: []]
 
     @type t :: %__MODULE__{
-            name: module,
             file: binary(),
+            name: module,
             state: ExUnit.state(),
             tests: [ExUnit.Test.t()]
           }

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -470,7 +470,7 @@ defmodule ExUnit.Case do
   defmacro __before_compile__(_) do
     quote do
       def __ex_unit__ do
-        %ExUnit.TestModule{name: __MODULE__, file: __ENV__.file, tests: @ex_unit_tests}
+        %ExUnit.TestModule{file: __ENV__.file, name: __MODULE__, tests: @ex_unit_tests}
       end
     end
   end


### PR DESCRIPTION
- Include file:line to slowest test results.
  Additionally it changes the order of the module, so it is consistent with the rest
  of the results.
- Print line number while test is being executed.
- Sort struct and spec fields alphabetically.

Related: fbfc8d2fd04c97c7fbfe7e35a482f76b67fbe3a4, #10232