### PR TITLE
Fix Code.Typespec.spec_to_quoted/2 when union in  %{__struct__:} is used

### DIFF
--- a/lib/elixir/lib/code/typespec.ex
+++ b/lib/elixir/lib/code/typespec.ex
@@ -273,13 +273,13 @@ defmodule Code.Typespec do
           {{:optional, [], [typespec_to_quoted(k)]}, typespec_to_quoted(v)}
       end)
 
-    {struct, fields} = Keyword.pop(fields, :__struct__)
-    map = {:%{}, [line: line], fields}
+    case List.keytake(fields, :__struct__, 0) do
+      {{:__struct__, struct}, fields_pruned} when is_atom(struct) and struct != nil ->
+        map_pruned = {:%{}, [line: line], fields_pruned}
+        {:%, [line: line], [struct, map_pruned]}
 
-    if struct do
-      {:%, [line: line], [struct, map]}
-    else
-      map
+      _ ->
+        {:%{}, [line: line], fields}
     end
   end
 


### PR DESCRIPTION
Originally reported in ExDoc.
https://github.com/elixir-lang/ex_doc/issues/1239

Code.Typespec.spec_to_quoted/2 wouldn't know how to deal with a union inside a
map with __struct__ key, such as in:

`@spec foo(%{__struct__: Foo | Bar}) :: any()`

/cc @ericmj @zdcthomas