### PR TITLE
Make sentence about log levels more clear

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -57,7 +57,7 @@ defmodule Logger do
     * `:debug` - for debug-related messages
 
   For example, `:info` takes precedence over `:debug`. If your log
-  level is set to `:info`, `:info`, `:warning`, and all above it will
+  level is set to `:info` then all `:info`, `:notice` and above will
   be passed to backends. If your log level is set to `:alert`, only
   `:alert` and `:emergency` will be printed.
 


### PR DESCRIPTION
I believe the `:info, :info` part was a bit confusing followed by `:warning` therefore skipping `:notice`.

Thank you for reviewing!