### PR TITLE
Make url parse more robust

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -339,9 +339,6 @@ defmodule URI do
   @spec decode(binary) :: binary
   def decode(uri) do
     unpercent(uri, "", false)
-  catch
-    :malformed_uri ->
-      raise ArgumentError, "malformed URI #{inspect(uri)}"
   end
 
   @doc """
@@ -356,9 +353,6 @@ defmodule URI do
   @spec decode_www_form(binary) :: binary
   def decode_www_form(string) when is_binary(string) do
     unpercent(string, "", true)
-  catch
-    :malformed_uri ->
-      raise ArgumentError, "malformed URI #{inspect(string)}"
   end
 
   defp unpercent(<<?+, tail::binary>>, acc, spaces = true) do
@@ -367,9 +361,10 @@ defmodule URI do
 
   defp unpercent(<<?%, hex1, hex2, tail::binary>>, acc, spaces) do
     unpercent(tail, <<acc::binary, bsl(hex_to_dec(hex1), 4) + hex_to_dec(hex2)>>, spaces)
+  catch
+    :already_unpercent ->
+      unpercent(<<hex1, hex2, tail::binary>>, <<acc::binary, ?%>>, spaces)
   end
-
-  defp unpercent(<<?%, _::binary>>, _acc, _spaces), do: throw(:malformed_uri)
 
   defp unpercent(<<head, tail::binary>>, acc, spaces) do
     unpercent(tail, <<acc::binary, head>>, spaces)
@@ -380,7 +375,7 @@ defmodule URI do
   defp hex_to_dec(n) when n in ?A..?F, do: n - ?A + 10
   defp hex_to_dec(n) when n in ?a..?f, do: n - ?a + 10
   defp hex_to_dec(n) when n in ?0..?9, do: n - ?0
-  defp hex_to_dec(_n), do: throw(:malformed_uri)
+  defp hex_to_dec(_n), do: throw(:already_unpercent)
 
   @doc """
   Parses a well-formed URI reference into its components.

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -60,23 +60,15 @@ defmodule URITest do
     assert URI.decode("%0D%0A%26%3C%25%3E%22%20%E3%82%86") == "\r\n&<%>\" ゆ"
     assert URI.decode("%2f%41%4a%55") == "/AJU"
     assert URI.decode("4_t+st.is-s~") == "4_t+st.is-s~"
-
-    assert_raise ArgumentError, ~R/malformed URI/, fn ->
-      URI.decode("% invalid")
-    end
-
-    assert_raise ArgumentError, ~R/malformed URI/, fn ->
-      URI.decode("invalid%")
-    end
+    assert URI.decode("%%") == "%%"
+    assert URI.decode("%H") == "%H"
+    assert URI.decode("%%%20HI") == "%% HI"
   end
 
   test "decode_www_form/1" do
     assert URI.decode_www_form("%3Eval+ue%2B") == ">val ue+"
     assert URI.decode_www_form("%E3%82%86+") == "ゆ "
-
-    assert_raise ArgumentError, fn ->
-      URI.decode_www_form("%ZZ")
-    end
+    assert URI.decode_www_form("%%7E+ZZ") == "%~ ZZ"
   end
 
   describe "parse/1" do


### PR DESCRIPTION
- We can not guarantee someone use a strictly normalized url.
- Allow invalid escaped chars which prefixed by `%` like Python's urllib.parse.unquote.
```python
>>> from urllib.parse import unquote
>>> unquote('up%%2525increase%20rate')
'up%%25increase rate'
```
- So we should parse `"%{%20%7E"` to `"%{ ~"` other than raise error
```elixir
iex> URI.decode("up%%2525increase%20rate")
** (ArgumentError) malformed URI "up%%2525increase%20rate"
    (elixir 1.10.1) lib/uri.ex:344: URI.decode/1
```
