### PR TITLE
Allow passing "Any" as the exception in ExUnits "assert_raise"

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -715,7 +715,8 @@ defmodule ExUnit.Assertions do
   @doc ~S"""
   Asserts the `exception` is raised during `function` execution with
   the expected `message`, which can be a `Regex` or an exact `String`.
-  Returns the rescued exception, fails otherwise.
+  Returns the rescued exception, fails otherwise. Use `Any` to match
+  all exceptions and only look at the message.
 
   ## Examples
 
@@ -725,6 +726,10 @@ defmodule ExUnit.Assertions do
 
       assert_raise RuntimeError, ~r/^today's lucky number is 0\.\d+!$/, fn ->
         raise "today's lucky number is #{:rand.uniform()}!"
+      end
+
+      assert_raise Any, "something went wrong", fn ->
+        raise ArgumentError, "something went wrong"
       end
 
   """
@@ -749,7 +754,8 @@ defmodule ExUnit.Assertions do
 
   @doc """
   Asserts the `exception` is raised during `function` execution.
-  Returns the rescued exception, fails otherwise.
+  Returns the rescued exception, fails otherwise. Use `Any` to
+  match all exceptions.
 
   ## Examples
 
@@ -766,6 +772,10 @@ defmodule ExUnit.Assertions do
         name = error.__struct__
 
         cond do
+          exception == Any ->
+            check_error_message(name, error)
+            error
+
           name == exception ->
             check_error_message(name, error)
             error

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -622,6 +622,11 @@ defmodule ExUnit.AssertionsTest do
     "test error" = error.message
   end
 
+  test "assert raise with any" do
+    error = assert_raise Any, fn -> raise ArgumentError, "test error" end
+    "test error" = error.message
+  end
+
   @compile {:no_warn_undefined, Not.Defined}
 
   test "assert raise with some other error" do


### PR DESCRIPTION
I recently had the need to only assert that a function I called crashed, but cannot pre-determine the exception type that will be raised.

As far as I have seen, ExUnit only allows hard coded exception types in `assert_raise`. For this reason I added a case to allow all types if the exception type is set to `Any`. (I chose `Any` because it is also used as the fallback in protocols, but this can easily be swapped out if preferred)

This change also has the nice side effect that it would now be possible to only test the exception message, regardless of its type for which I also added a doctest as an example.
