### PR TITLE
Fix since doc for mix cmd task

### DIFF
--- a/lib/mix/lib/mix/tasks/cmd.ex
+++ b/lib/mix/lib/mix/tasks/cmd.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Cmd do
     * `--app` - limit running the command to the given app. This option
       may be given multiple times
 
-    * `--cd` - (since v1.11.0) the directory to run the command in
+    * `--cd` - (since v1.10.4) the directory to run the command in
 
   ## Zombie operating system processes
 


### PR DESCRIPTION
Noticed this was already backported to 1.10.4, so if that was intentional, let's update the docs :)

(PS. Should I set the base to v1.10?)