### PR TITLE
Fix not being able to escape "|" inside a table (docstring)

### DIFF
--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -592,7 +592,7 @@ defmodule IO.ANSI.Docs do
     line
     |> String.trim(" ")
     |> String.trim("|")
-    |> String.split("|")
+    |> String.split(~r{(?<!\\)\|})
     |> Enum.map(&render_column(&1, options))
   end
 

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -553,12 +553,13 @@ defmodule IO.ANSI.DocsTest do
     test "table with escaped \"|\" inside cell" do
       table = "a | smth\\|smth_else | c\nd | e | f"
 
-      expected = """
-      a | smth|smth_else | c
-      d | e              | f
-      \e[0m
-      """
-      |> String.trim_trailing()
+      expected =
+        """
+        a | smth|smth_else | c
+        d | e              | f
+        \e[0m
+        """
+        |> String.trim_trailing()
 
       assert format_markdown(table) == expected
     end

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -550,6 +550,19 @@ defmodule IO.ANSI.DocsTest do
       assert format_markdown("a | b | c\nd | e") == "a | b | c\nd | e |  \n\e[0m"
     end
 
+    test "table with escaped \"|\" inside cell" do
+      table = "a | smth\\|smth_else | c\nd | e | f"
+
+      expected = """
+      a | smth|smth_else | c
+      d | e              | f
+      \e[0m
+      """
+      |> String.trim_trailing()
+
+      assert format_markdown(table) == expected
+    end
+
     test "table with last two columns empty" do
       table = """
       AAA |     |     |


### PR DESCRIPTION
Small issue when trying to include "|" character inside a table cell in docstring. There already is `String.replace("\\\|", "|")` inside `render_column/2` that I guess is supposed to convert escaped vertical bar back into "|" but `split_into_columns/2` does not check for escapes.