### PR TITLE
Update string_to_quoted spec

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -829,7 +829,7 @@ defmodule Code do
 
   """
   @spec string_to_quoted(List.Chars.t(), keyword) ::
-          {:ok, Macro.t()} | {:error, {line :: pos_integer, term, term}}
+          {:ok, Macro.t()} | {:error, {location :: keyword, term, term}}
   def string_to_quoted(string, opts \\ []) when is_list(opts) do
     file = Keyword.get(opts, :file, "nofile")
     line = Keyword.get(opts, :line, 1)


### PR DESCRIPTION
`tokens_to_quoted` got recently updated to include column in addition to line number [here](https://github.com/elixir-lang/elixir/commit/e1e8f9afec953b39e4c850d57e051aae42742d21#diff-eae311b342cce703529f4fd9e82d6c03R357)
Because of this spec for `string_to_quoted` no longer matched the return from `tokens_to_quoted` causing dialyzer errors.
Found by https://github.com/michallepicki/elixir-lang-dialyzer-runs/runs/982880951?check_suite_focus=true