### PR TITLE
adds @since to the System module

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -988,6 +988,7 @@ defmodule System do
   Inlined by the compiler.
   """
   @spec os_time() :: integer
+  @doc since: "1.3.0"
   def os_time do
     :os.system_time()
   end
@@ -999,6 +1000,7 @@ defmodule System do
   with no limitation and is not monotonic.
   """
   @spec os_time(time_unit) :: integer
+  @doc since: "1.3.0"
   def os_time(unit) do
     :os.system_time(normalize_time_unit(unit))
   end
@@ -1015,6 +1017,7 @@ defmodule System do
   Returns the number of schedulers in the VM.
   """
   @spec schedulers :: pos_integer
+  @doc since: "1.3.0"
   def schedulers do
     :erlang.system_info(:schedulers)
   end
@@ -1023,6 +1026,7 @@ defmodule System do
   Returns the number of schedulers online in the VM.
   """
   @spec schedulers_online :: pos_integer
+  @doc since: "1.3.0"
   def schedulers_online do
     :erlang.system_info(:schedulers_online)
   end


### PR DESCRIPTION
System.os_time, System.schedulers, System.schedulers_online were added in 1.3.0, which i know because i tried to use them on an earlier system.