### PR TITLE
make Child Specification section of Supervisor documentation a bit more accurate

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -108,7 +108,7 @@ defmodule Supervisor do
   The child specification describes how the supervisor starts, shuts down,
   and restarts child processes.
 
-  The child specification is a map which contains 6 elements. The first two keys
+  The child specification is a map with 2 to 6 elements. The first two keys
   in the following list are required, and the remaining ones are optional:
 
     * `:id` - any term used to identify the child specification

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -108,7 +108,7 @@ defmodule Supervisor do
   The child specification describes how the supervisor starts, shuts down,
   and restarts child processes.
 
-  The child specification is a map with 2 to 6 elements. The first two keys
+  The child specification is a map containing up to 6 elements. The first two keys
   in the following list are required, and the remaining ones are optional:
 
     * `:id` - any term used to identify the child specification


### PR DESCRIPTION
Nit picking, but why not?

Alternatives considered:
- The child specification is a map **which contains 2–6** elements.
- The child specification is a map **which contains 2 to 6** elements.
- The child specification is a map **which may contain up to** 6 elements.
- The child specification is a map **containing up to** 6 elements.