### PR TITLE
Add since doc to String#myers_difference/2

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2604,6 +2604,7 @@ defmodule String do
       [eq: "fox ", del: "ho", ins: "jum", eq: "ps over the ", del: "dog", ins: "lazy cat"]
 
   """
+  @doc since: "1.3.0"
   @spec myers_difference(t, t) :: [{:eq | :ins | :del, t}]
   def myers_difference(string1, string2) do
     graphemes(string1)


### PR DESCRIPTION
The `String#myers_difference/2` function was created by df5ac21cb469d7f8b5710fb5615ed378233ce6be on v1.3.0 :) 