### PR TITLE
Raise CompileError when trying to define reserved types

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -131,11 +131,18 @@ defmodule Kernel.Typespec do
     store_typespec(bag, kind, expr, pos)
   end
 
+  @reserved_signatures [{:required, 1}, {:optional, 1}]
   def deftypespec(kind, expr, line, file, module, pos)
       when kind in [:type, :typep, :opaque] do
     {set, bag} = :elixir_module.data_tables(module)
 
     case type_to_signature(expr) do
+      {name, arity} = signature when signature in @reserved_signatures ->
+        compile_error(
+          :elixir_locals.get_cached_env(pos),
+          "type #{name}/#{arity} is a reserved type and it cannot be defined"
+        )
+
       {name, arity} when kind == :typep ->
         {line, doc} = get_doc_info(set, :typedoc, line)
 

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -131,7 +131,7 @@ defmodule Kernel.Typespec do
     store_typespec(bag, kind, expr, pos)
   end
 
-  @reserved_signatures [{:required, 1}, {:optional, 1}]
+  @reserved_signatures [required: 1, optional: 1]
   def deftypespec(kind, expr, line, file, module, pos)
       when kind in [:type, :typep, :opaque] do
     {set, bag} = :elixir_module.data_tables(module)

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -837,27 +837,6 @@ defmodule TypespecTest do
                        @opaque optional(arg) :: any()
                      end
                    end
-
-      test_module do
-        assert @type(optional() :: any()) == :ok
-
-        @spec foo(optional()) :: any()
-        def foo(_), do: :ok
-      end
-
-      test_module do
-        assert @typep(optional() :: any()) == :ok
-
-        @spec foo(optional()) :: any()
-        def foo(_), do: :ok
-      end
-
-      test_module do
-        assert @opaque(optional() :: %{}) == :ok
-
-        @spec foo(optional()) :: any()
-        def foo(_), do: :ok
-      end
     end
 
     test "invalid remote @type with module attribute that does not evaluate to a module" do

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -789,6 +789,77 @@ defmodule TypespecTest do
       assert [{:atom, _, Keyword}, {:atom, _, :t}, [{:var, _, :value}]] = kw_with_value_args
     end
 
+    test "@type with a reserved signature" do
+      assert_raise CompileError,
+                   ~r"type required\/1 is a reserved type and it cannot be defined",
+                   fn ->
+                     test_module do
+                       @type required(arg) :: any()
+                     end
+                   end
+
+      assert_raise CompileError,
+                   ~r"type optional\/1 is a reserved type and it cannot be defined",
+                   fn ->
+                     test_module do
+                       @type optional(arg) :: any()
+                     end
+                   end
+
+      assert_raise CompileError,
+                   ~r"type required\/1 is a reserved type and it cannot be defined",
+                   fn ->
+                     test_module do
+                       @typep required(arg) :: any()
+                     end
+                   end
+
+      assert_raise CompileError,
+                   ~r"type optional\/1 is a reserved type and it cannot be defined",
+                   fn ->
+                     test_module do
+                       @typep optional(arg) :: any()
+                     end
+                   end
+
+      assert_raise CompileError,
+                   ~r"type required\/1 is a reserved type and it cannot be defined",
+                   fn ->
+                     test_module do
+                       @opaque required(arg) :: any()
+                     end
+                   end
+
+      assert_raise CompileError,
+                   ~r"type optional\/1 is a reserved type and it cannot be defined",
+                   fn ->
+                     test_module do
+                       @opaque optional(arg) :: any()
+                     end
+                   end
+
+      test_module do
+        assert @type(optional() :: any()) == :ok
+
+        @spec foo(optional()) :: any()
+        def foo(_), do: :ok
+      end
+
+      test_module do
+        assert @typep(optional() :: any()) == :ok
+
+        @spec foo(optional()) :: any()
+        def foo(_), do: :ok
+      end
+
+      test_module do
+        assert @opaque(optional() :: %{}) == :ok
+
+        @spec foo(optional()) :: any()
+        def foo(_), do: :ok
+      end
+    end
+
     test "invalid remote @type with module attribute that does not evaluate to a module" do
       assert_raise CompileError, ~r/\(@foo is "bar"\)/, fn ->
         test_module do


### PR DESCRIPTION
This PR updates `Typespec.deftypespec/6` to raise a compilation error when trying to define reserved types such as `required/1` and `optional/1` with `@type`, `@typep` and `@opaque`.

Closes #10263