### PR TITLE
Adds note: data structure in first position in Protocol

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -47,6 +47,10 @@ defmodule Protocol do
   `size` information on lists, rather its value needs to be
   computed with `length`.
 
+  Note that the data structure you are implementing the protocol for
+  need to be in the first argument to the functions defined in the
+  protocol.
+
   It is possible to implement protocols for all Elixir types:
 
     * Structs (see below)

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -47,8 +47,8 @@ defmodule Protocol do
   `size` information on lists, rather its value needs to be
   computed with `length`.
 
-  Note that the data structure you are implementing the protocol for
-  need to be in the first argument to the functions defined in the
+  The data structure you are implementing the protocol for
+  must be the first argument to all functions defined in the
   protocol.
 
   It is possible to implement protocols for all Elixir types:


### PR DESCRIPTION
Just got bitten by this.

I am not sure this is the best place to put it nor the best wording. I do think it deserve a note.

In a protocol, the data structure we are abstracting need to be the first argument in all the protocol functions. Could not find it written in the doc elsewhere