### PR TITLE
Do not crash when diffing nested structs with @enforce_keys

### DIFF
--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -638,8 +638,13 @@ defmodule ExUnit.Diff do
 
     if left && Enum.all?(kw, fn {k, _} -> Map.has_key?(left, k) end) do
       if Macro.quoted_literal?(kw) do
-        {eval_kw, []} = Code.eval_quoted(kw, [])
-        diff_quoted_struct(struct!(left, eval_kw), kw, right, struct1, env)
+        try do
+          {eval_kw, []} = Code.eval_quoted(kw, [])
+          diff_quoted_struct(struct!(left, eval_kw), kw, right, struct1, env)
+        rescue
+          _ ->
+            diff_map(kw, right, struct1, maybe_struct(right), env)
+        end
       else
         diff_map(kw, right, struct1, maybe_struct(right), env)
       end


### PR DESCRIPTION
When diffing nested structs with `@enforce_keys` ex_unit crashes with ArgumentError
```
12:19:03.931 [error] Task #PID<0.524.0> started from #PID<0.510.0> terminating
** (ArgumentError) the following keys must also be given when building struct BugReproTest.MyStruct: [:name]
    expanding struct: BugReproTest.MyStruct.__struct__/1
    nofile:38: (file)
Function: &ExUnit.Diff.compute/3
    Args: [{:%, [line: 38], [BugReproTest.OtherStruct, {:%{}, [line: 38], [map: {:%, [line: 38], [BugReproTest.MyStruct, {:%{}, [line: 38], [id: 123]}]}]}]}, %BugReproTest.OtherStruct{map: %BugReproTest.MyStruct{id: 124, name: "asda"}}, {:match, []}]
```
Reproducible in elixir 1.10, 1.11-dev
```
defmodule BugReproTest do
  use ExUnit.Case, async: true

  defmodule OtherStruct do
    defstruct [
      :map
    ]
  end

  defmodule MyStruct do
    @enforce_keys [
      :id,
      :name
    ]
    defstruct [
      :id,
      :name
    ]
  end

  test "work 1" do
    assert %MyStruct{id: 123} = %MyStruct{id: 124, name: "asda"}
  end

  test "work 2" do
    assert [%MyStruct{id: 123}] = [%MyStruct{id: 124, name: "asda"}]
  end

  test "work 3" do
    assert {%MyStruct{id: 123}} = {%MyStruct{id: 124, name: "asda"}}
  end

  test "work 4" do
    assert %{map: %MyStruct{id: 123}} = %{map: %MyStruct{id: 124, name: "asda"}}
  end

  test "crash 1" do
    assert %OtherStruct{map: %MyStruct{id: 123}} = %OtherStruct{
             map: %MyStruct{id: 124, name: "asda"}
           }
  end

  test "crash 2" do
    assert %OtherStruct{map: [%MyStruct{id: 123}]} = %OtherStruct{
             map: [%MyStruct{id: 124, name: "asda"}]
           }
  end

  test "crash 3" do
    assert %OtherStruct{map: %{123 => [%MyStruct{id: 123}]}} = %OtherStruct{
             map: %{123 => %MyStruct{id: 124, name: "asda"}}
           }
  end
end
```

This PR adds fallback if `Code.eval_quoted` call fails.