### PR TITLE
Display all values in logs

### DIFF
--- a/lib/logger/lib/logger/formatter.ex
+++ b/lib/logger/lib/logger/formatter.ex
@@ -182,6 +182,7 @@ defmodule Logger.Formatter do
 
   defp metadata(:time, _), do: nil
   defp metadata(:gl, _), do: nil
+  defp metadata(:report_cb, _), do: nil
 
   defp metadata(_, nil), do: nil
   defp metadata(_, string) when is_binary(string), do: string
@@ -218,5 +219,16 @@ defmodule Logger.Formatter do
     Exception.format_mfa(mod, fun, arity)
   end
 
-  defp metadata(_, _), do: nil
+  defp metadata(_, list) when is_list(list) do
+    :erlang.list_to_binary(list)
+  rescue
+    ArgumentError -> inspect(list)
+  end
+
+  defp metadata(_, data) do
+    case String.Chars.impl_for(data) do
+      nil -> inspect(data)
+      module -> module.to_string(data)
+    end
+  end
 end

--- a/lib/logger/test/logger/formatter_test.exs
+++ b/lib/logger/test/logger/formatter_test.exs
@@ -77,12 +77,12 @@ defmodule Logger.FormatterTest do
              "2014-12-30 12:06:30.100"
   end
 
-  test "format discards unknown formats" do
+  test "format inspects unknown formats" do
     compiled = compile("$metadata $message")
     metadata = [ancestors: [self()], crash_reason: {:some, :tuple}, foo: :bar]
 
-    assert format(compiled, :error, "hello", nil, metadata) ==
-             [["foo", 61, "bar", 32], " ", "hello"]
+    assert to_string(format(compiled, :error, "hello", nil, metadata)) =~
+             ~r(ancestors=\[#PID<\d+\.\d+\.\d+>\] crash_reason={:some, :tuple} foo=bar\s+hello)
   end
 
   test "padding takes account of length of level" do


### PR DESCRIPTION
In pre-1.10 versions all values were inspected in default formatter (if there was no other formatting setting yet). Such change was unintended breaking change, and this should fix that to match "old" behaviour.