### PR TITLE
Implement Map.take_in/2

### DIFF
--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -21,7 +21,7 @@ defmodule KeywordTest do
   end
 
   test "implements (almost) all functions in Map" do
-    assert Map.__info__(:functions) -- Keyword.__info__(:functions) == [from_struct: 1]
+    assert Map.__info__(:functions) -- Keyword.__info__(:functions) == [from_struct: 1, take_in: 2]
   end
 
   test "get_and_update/3 raises on bad return value from the argument function" do

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -21,7 +21,10 @@ defmodule KeywordTest do
   end
 
   test "implements (almost) all functions in Map" do
-    assert Map.__info__(:functions) -- Keyword.__info__(:functions) == [from_struct: 1, take_in: 2]
+    assert Map.__info__(:functions) -- Keyword.__info__(:functions) == [
+             from_struct: 1,
+             take_in: 2
+           ]
   end
 
   test "get_and_update/3 raises on bad return value from the argument function" do

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -103,8 +103,15 @@ defmodule MapTest do
   end
 
   test "take_in/2" do
-    assert Map.take_in(%{a: 1, b: %{c: 10, d: %{e: 5, f: 3}}}, [b: [d: [:f]]]) == %{b: %{d: %{f: 3}}}
-    assert Map.take_in(%{a: 1, b: %{c: 10, d: %{e: 5, f: 3}}}, []) == %{a: 1, b: %{c: 10, d: %{e: 5, f: 3}}}
+    assert Map.take_in(%{a: 1, b: %{c: 10, d: %{e: 5, f: 3}}}, b: [d: [:f]]) == %{
+             b: %{d: %{f: 3}}
+           }
+
+    assert Map.take_in(%{a: 1, b: %{c: 10, d: %{e: 5, f: 3}}}, []) == %{
+             a: 1,
+             b: %{c: 10, d: %{e: 5, f: 3}}
+           }
+
     assert_raise BadMapError, fn -> Map.take_in(:foo, []) end
   end
 

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -102,6 +102,12 @@ defmodule MapTest do
     assert_raise BadMapError, fn -> Map.take(:foo, []) end
   end
 
+  test "take_in/2" do
+    assert Map.take_in(%{a: 1, b: %{c: 10, d: %{e: 5, f: 3}}}, [b: [d: [:f]]]) == %{b: %{d: %{f: 3}}}
+    assert Map.take_in(%{a: 1, b: %{c: 10, d: %{e: 5, f: 3}}}, []) == %{a: 1, b: %{c: 10, d: %{e: 5, f: 3}}}
+    assert_raise BadMapError, fn -> Map.take_in(:foo, []) end
+  end
+
   test "drop/2" do
     assert Map.drop(%{a: 1, b: 2, c: 3}, [:b, :c]) == %{a: 1}
     assert_raise BadMapError, fn -> Map.drop(:foo, []) end


### PR DESCRIPTION
Support of Map.take_in/2 to extract values using nested keys (recursively).

I think it may be useful when you only want a part of the map -- mostly when its deep nested map (i.e KV stores, DB engines, etc..) to reduce memory footprint with copy and message passing.