### PR TITLE
Add `Registry.delete_meta/2`

### DIFF
--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -1050,6 +1050,7 @@ defmodule Registry do
       :error
 
   """
+  @doc since: "1.11.0"
   @spec delete_meta(registry, meta_key) :: :ok
   def delete_meta(registry, key) when is_atom(registry) and (is_atom(key) or is_tuple(key)) do
     try do

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -1035,6 +1035,33 @@ defmodule Registry do
   end
 
   @doc """
+  Deletes registry metadata for the given `key` in `registry`.
+
+  ## Examples
+
+      iex> Registry.start_link(keys: :unique, name: Registry.DeleteMetaTest)
+      iex> Registry.put_meta(Registry.DeleteMetaTest, :custom_key, "custom_value")
+      :ok
+      iex> Registry.meta(Registry.DeleteMetaTest, :custom_key)
+      {:ok, "custom_value"}
+      iex> Registry.delete_meta(Registry.DeleteMetaTest, :custom_key)
+      :ok
+      iex> Registry.meta(Registry.DeleteMetaTest, :custom_key)
+      :error
+
+  """
+  @spec delete_meta(registry, meta_key) :: :ok
+  def delete_meta(registry, key) when is_atom(registry) and (is_atom(key) or is_tuple(key)) do
+    try do
+      :ets.delete(registry, key)
+      :ok
+    catch
+      :error, :badarg ->
+        raise ArgumentError, "unknown registry: #{inspect(registry)}"
+    end
+  end
+
+  @doc """
   Returns the number of registered keys in a registry.
   It runs in constant time.
 


### PR DESCRIPTION
Following up on this short discussion: https://groups.google.com/forum/#!topic/elixir-lang-core/t7zzNkQgADA , this PR implements `Registry.delete_meta/2`.

I went for `:ets.delete`, I think it makes sense because `put_meta` uses unique keys even with a `:duplicate` registry.

---

I wasn't sure about adding a `@doc since:` annotation so I left it out for now.

Regarding tests, `put_meta` seems to only have doctests so I did the same here.