### PR TITLE
Include Erlang severity level to Logger metadata

### DIFF
--- a/lib/logger/lib/logger/handler.ex
+++ b/lib/logger/lib/logger/handler.ex
@@ -91,7 +91,11 @@ defmodule Logger.Handler do
 
           {message, %{gl: gl} = metadata} ->
             timestamp = Map.get_lazy(metadata, :time, fn -> :os.system_time(:microsecond) end)
-            metadata = erlang_metadata_to_elixir_metadata(metadata)
+
+            metadata =
+              erlang_metadata_to_elixir_metadata(metadata)
+              |> Keyword.put(:erl_level, erl_level)
+
             %{truncate: truncate, utc_log: utc_log?} = config
 
             event = {

--- a/lib/logger/test/logger/handler_test.exs
+++ b/lib/logger/test/logger/handler_test.exs
@@ -107,6 +107,25 @@ defmodule Logger.HandlerTest do
     assert capture_log(fn -> :logger.debug('ok') end) =~ "[debug] ok"
   end
 
+  test "include Erlang severity level information" do
+    Logger.configure_backend(:console, metadata: [:erl_level])
+
+    assert capture_log(fn -> :logger.emergency('ok') end) =~ "erl_level=emergency"
+    assert capture_log(fn -> :logger.alert('ok') end) =~ "erl_level=alert"
+    assert capture_log(fn -> :logger.critical('ok') end) =~ "erl_level=critical"
+    assert capture_log(fn -> :logger.error('ok') end) =~ "erl_level=error"
+    assert capture_log(fn -> :logger.warning('ok') end) =~ "erl_level=warning"
+    assert capture_log(fn -> :logger.info('ok') end) =~ "erl_level=info"
+    assert capture_log(fn -> :logger.debug('ok') end) =~ "erl_level=debug"
+
+    [:emergency, :alert, :critical, :error, :warning, :notice, :info, :debug]
+    |> Enum.each(fn level ->
+      assert capture_log(fn -> :logger.log(level, 'ok') end) =~ "erl_level=#{level}"
+    end)
+  after
+    Logger.configure_backend(:console, metadata: [])
+  end
+
   test "calls report_cb/1 when supplied" do
     report = %{foo: "bar"}
 


### PR DESCRIPTION
HI,
Elixir integrate new log levels (notice, critical, alert, and emergency) but this information "_is lost for 'compatibility with pre 1.10 backends'_"

In logger/handler.ex there is a 'TODO':
_# TODO: Remove this mapping once we remove old Logger Backends (v2.0)_

So in the meantime is possible to maintain the original level information almost in the metadata inserting an additional key/value `{:erl_level, real_level}` in order to be able to post-process/filter logs by the 'real severity level'.

