### PR TITLE
Document atom comparison

### DIFF
--- a/lib/elixir/pages/operators.md
+++ b/lib/elixir/pages/operators.md
@@ -113,6 +113,7 @@ The collection types are compared using the following rules:
 * Maps are compared by size, then by keys in ascending term order, then by values in key order. In the specific case of maps' key ordering, integers are always considered to be less than floats.
 * Lists are compared element by element.
 * Bitstrings are compared byte by byte, incomplete bytes are compared bit by bit.
+* Atoms are compared using their string value, codepoint by codepoint.
 
 ## Custom and overridden operators
 


### PR DESCRIPTION
Currently how atoms are compared is not described in the Elixir docs, or at least (not where I would expect).

Sentence is copied from the erlang docs:
https://erlang.org/doc/reference_manual/expressions.html#term-comparisons