### PR TITLE
Introduce a type hint system

### DIFF
--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -429,7 +429,7 @@ defmodule Module.Types do
   defp format_message_hint(:inferred_bitstring_spec) do
     """
     HINT: all expressions given to binaries are assumed to be of type \
-    integer unless said otherwise. For example, <<expr>> assumes "expr" \
+    integer() unless said otherwise. For example, <<expr>> assumes "expr" \
     is an integer. Pass a modifier, such as <<expr::float>> or <<expr::binary>>, \
     to change the default behaviour.
 

--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -214,6 +214,7 @@ defmodule Module.Types do
       true ->
         simplify_left? = simplify_type?(left, right)
         simplify_right? = simplify_type?(right, left)
+
         {traces, hints} = format_traces(traces, simplify_left? or simplify_right?)
 
         [
@@ -257,7 +258,9 @@ defmodule Module.Types do
   end
 
   defp format_traces(traces, simplify?) do
-    Enum.map_reduce(traces, [], fn
+    traces
+    |> Enum.reverse()
+    |> Enum.map_reduce([], fn
       {var, {:type, type, expr, location}}, hints ->
         {hint, hints} = format_type_hint(type, expr, hints)
 

--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -196,83 +196,38 @@ defmodule Module.Types do
 
   def format_warning({:unable_unify, left, right, {location, expr, traces}}) do
     cond do
-      (match?({:ok, _}, map_dot(expr)) and (map_type?(left) and atom_type?(right))) or
-          (atom_type?(left) and map_type?(right)) ->
-        {:ok, {map, field}} = map_dot(expr)
-
-        """
-        parentheses are required when dynamically invoking zero-arity functions \
-        #{format_expr(expr, location)}\
-        "#{expr_to_string(map)}" is an atom and you attempted to fetch the field \
-        #{field}. Make sure that "#{expr_to_string(map)}" is a map or add parentheses \
-        to invoke a function instead:
-
-            #{indent(expr_to_string(invert_parens(expr)))}
-
-        Conflict found at\
-        """
-
-      (match?({:ok, _}, remote_call(expr)) and (map_type?(left) and atom_type?(right))) or
-          (atom_type?(left) and map_type?(right)) ->
-        {:ok, {module, fun}} = remote_call(expr)
-
-        """
-        parentheses are not allowed when fetching fields from a map \
-        #{format_expr(expr, location)}\
-        "#{expr_to_string(module)}" is a map and you attempted to invoke the function \
-        #{fun}/0. Make sure that "#{expr_to_string(module)}" is an atom or remove \
-        parentheses to fetch a field:
-
-            #{indent(expr_to_string(invert_parens(expr)))}
-
-        Conflict found at\
-        """
-
       map_type?(left) and map_type?(right) and match?({:ok, _}, missing_field(left, right)) ->
         {:ok, atom} = missing_field(left, right)
 
         # Drop the last trace which is the expression map.foo
         traces = Enum.drop(traces, 1)
+        {traces, hints} = format_traces(traces, false)
 
         [
           "undefined field \"#{atom}\" ",
           format_expr(expr, location),
-          format_traces(traces),
+          traces,
+          format_message_hints(hints),
           "Conflict found at"
         ]
 
       true ->
+        simplify_left? = simplify_type?(left, right)
+        simplify_right? = simplify_type?(right, left)
+        {traces, hints} = format_traces(traces, simplify_left? or simplify_right?)
+
         [
           "incompatible types:\n\n    ",
-          format_types(left, right),
+          format_type(left, simplify_left?),
+          " !~ ",
+          format_type(right, simplify_right?),
           "\n\n",
           format_expr(expr, location),
-          format_traces(traces),
+          traces,
+          format_message_hints(hints),
           "Conflict found at"
         ]
     end
-  end
-
-  defp map_dot(expr) do
-    with {{:., _meta1, [map, field]}, meta2, []} <- expr,
-         true <- Keyword.get(meta2, :no_parens, false) do
-      {:ok, {map, field}}
-    else
-      _ -> :error
-    end
-  end
-
-  defp remote_call(expr) do
-    with {{:., _meta1, [module, field]}, meta2, []} <- expr,
-         false <- Keyword.get(meta2, :no_parens, false) do
-      {:ok, {module, field}}
-    else
-      _ -> :error
-    end
-  end
-
-  defp invert_parens({{:., meta1, [expr1, expr2]}, meta2, []}) do
-    {{:., meta1, [expr1, expr2]}, Keyword.update(meta2, :no_parens, true, &not/1), []}
   end
 
   defp missing_field(
@@ -297,39 +252,125 @@ defmodule Module.Types do
     end
   end
 
-  defp format_types(left, right) do
-    cond do
-      map_type?(left) and not map_type?(right) ->
-        [format_simplified_map(left), " !~ ", format_type(right)]
-
-      not map_type?(left) and map_type?(right) ->
-        [format_type(left), " !~ ", format_simplified_map(right)]
-
-      true ->
-        [format_type(left), " !~ ", format_type(right)]
-    end
+  defp format_traces([], _simplify?) do
+    {[], []}
   end
 
-  defp map_type?({:map, _}), do: true
-  defp map_type?(_other), do: false
+  defp format_traces(traces, simplify?) do
+    Enum.map_reduce(traces, [], fn
+      {var, {:type, type, expr, location}}, hints ->
+        {hint, hints} = format_type_hint(type, expr, hints)
 
-  defp atom_type?(:atom), do: true
-  defp atom_type?(:boolean), do: true
-  defp atom_type?({:atom, _}), do: false
-  defp atom_type?(_other), do: false
+        trace = [
+          "where \"",
+          Macro.to_string(var),
+          "\" was given the type ",
+          format_type(type, simplify?),
+          hint,
+          " in:\n\n    # ",
+          format_location(location),
+          "    ",
+          indent(expr_to_string(expr)),
+          "\n\n"
+        ]
 
-  defp format_simplified_map({:map, pairs}) do
+        {trace, hints}
+
+      {var1, {:var, var2, expr, location}}, hints ->
+        trace = [
+          "where \"",
+          Macro.to_string(var1),
+          "\" was given the same type as \"",
+          Macro.to_string(var2),
+          "\" in:\n\n    # ",
+          format_location(location),
+          "    ",
+          indent(expr_to_string(expr)),
+          "\n\n"
+        ]
+
+        {trace, hints}
+    end)
+  end
+
+  defp format_location({file, line, _mfa}) do
+    format_location({file, line})
+  end
+
+  defp format_location({file, line}) do
+    file = Path.relative_to_cwd(file)
+    line = if line, do: [Integer.to_string(line)], else: []
+    [file, ?:, line, ?\n]
+  end
+
+  ## TYPE FORMATTING
+
+  defp simplify_type?(type, other) do
+    map_type?(type) and not map_type?(other)
+  end
+
+  @doc false
+  def format_type({:map, pairs}, true) do
     case List.keyfind(pairs, {:atom, :__struct__}, 1) do
       {:required, {:atom, :__struct__}, {:atom, struct}} ->
         "%#{inspect(struct)}{}"
-
-      {:required, {:atom, :__struct__}, {:var, _} = var} ->
-        "%#{format_type(var)}{}"
 
       _ ->
         "map()"
     end
   end
+
+  def format_type({:union, types}, simplify?) do
+    "#{Enum.map_join(types, " | ", &format_type(&1, simplify?))}"
+  end
+
+  def format_type({:tuple, types}, simplify?) do
+    "{#{Enum.map_join(types, ", ", &format_type(&1, simplify?))}}"
+  end
+
+  def format_type({:list, type}, simplify?) do
+    "[#{format_type(type, simplify?)}]"
+  end
+
+  def format_type({:map, pairs}, false) do
+    case List.keytake(pairs, {:atom, :__struct__}, 1) do
+      {{:required, {:atom, :__struct__}, {:atom, struct}}, pairs} ->
+        "%#{inspect(struct)}{#{format_map_pairs(pairs)}}"
+
+      _ ->
+        "%{#{format_map_pairs(pairs)}}"
+    end
+  end
+
+  def format_type({:atom, literal}, _simplify?) do
+    inspect(literal)
+  end
+
+  def format_type({:var, index}, _simplify?) do
+    "var#{index}"
+  end
+
+  def format_type(atom, _simplify?) when is_atom(atom) do
+    "#{atom}()"
+  end
+
+  defp format_map_pairs(pairs) do
+    {atoms, others} = Enum.split_with(pairs, &match?({:required, {:atom, _}, _}, &1))
+    {required, optional} = Enum.split_with(others, &match?({:required, _, _}, &1))
+
+    Enum.map_join(atoms ++ required ++ optional, ", ", fn
+      {:required, {:atom, atom}, right} ->
+        "#{atom}: #{format_type(right, false)}"
+
+      {:required, left, right} ->
+        "#{format_type(left, false)} => #{format_type(right, false)}"
+
+      {:optional, left, right} ->
+        "optional(#{format_type(left, false)}) => #{format_type(right, false)}"
+    end)
+  end
+
+  ## EXPRESSION FORMATTING
 
   defp format_expr(nil, _location) do
     []
@@ -345,110 +386,11 @@ defmodule Module.Types do
     ]
   end
 
-  defp format_traces([]) do
-    []
-  end
-
-  defp format_traces(traces) do
-    Enum.map(traces, fn
-      {var, {:type, type, expr, location}} ->
-        [
-          "where \"",
-          Macro.to_string(var),
-          "\" was given the type ",
-          Module.Types.format_type(type),
-          " in:\n\n    # ",
-          format_location(location),
-          "    ",
-          indent(expr_to_string(expr)),
-          "\n\n"
-        ]
-
-      {var1, {:var, var2, expr, location}} ->
-        [
-          "where \"",
-          Macro.to_string(var1),
-          "\" was given the same type as \"",
-          Macro.to_string(var2),
-          "\" in:\n\n    # ",
-          format_location(location),
-          "    ",
-          indent(expr_to_string(expr)),
-          "\n\n"
-        ]
-    end)
-  end
-
-  defp format_location({file, line, _mfa}) do
-    format_location({file, line})
-  end
-
-  defp format_location({file, line}) do
-    file = Path.relative_to_cwd(file)
-    line = if line, do: [Integer.to_string(line)], else: []
-    [file, ?:, line, ?\n]
-  end
-
-  @doc false
-  def format_type({:union, types}) do
-    "#{Enum.map_join(types, " | ", &format_type/1)}"
-  end
-
-  def format_type({:tuple, types}) do
-    "{#{Enum.map_join(types, ", ", &format_type/1)}}"
-  end
-
-  def format_type({:list, type}) do
-    "[#{format_type(type)}]"
-  end
-
-  def format_type({:map, pairs}) do
-    case List.keytake(pairs, {:atom, :__struct__}, 1) do
-      {{:required, {:atom, :__struct__}, {:atom, struct}}, pairs} ->
-        "%#{inspect(struct)}{#{format_map_pairs(pairs)}}"
-
-      _ ->
-        "%{#{format_map_pairs(pairs)}}"
-    end
-  end
-
-  def format_type({:atom, literal}) do
-    inspect(literal)
-  end
-
-  def format_type({:var, index}) do
-    "var#{index}"
-  end
-
-  def format_type(atom) when is_atom(atom) do
-    "#{atom}()"
-  end
-
-  defp format_map_pairs(pairs) do
-    {atoms, others} = Enum.split_with(pairs, &match?({:required, {:atom, _}, _}, &1))
-    {required, optional} = Enum.split_with(others, &match?({:required, _, _}, &1))
-
-    Enum.map_join(atoms ++ required ++ optional, ", ", fn
-      {:required, {:atom, atom}, right} ->
-        "#{atom}: #{format_type(right)}"
-
-      {:required, left, right} ->
-        "#{format_type(left)} => #{format_type(right)}"
-
-      {:optional, left, right} ->
-        "optional(#{format_type(left)}) => #{format_type(right)}"
-    end)
-  end
-
   @doc false
   def expr_to_string(expr) do
     expr
     |> reverse_rewrite()
     |> Macro.to_string()
-  end
-
-  defp indent(string) do
-    String.replace(string, "\n", "    \n")
   end
 
   defp reverse_rewrite(guard) do
@@ -466,4 +408,72 @@ defmodule Module.Types do
       {mod, fun, args} -> {{:., [], [mod, fun]}, meta, args}
     end
   end
+
+  ## Hints
+
+  defp format_message_hints(hints) do
+    hints |> Enum.uniq() |> Enum.reverse() |> Enum.map(&format_message_hint/1)
+  end
+
+  defp format_message_hint(:dynamic_dot) do
+    """
+    HINT: "var.field" (without parentheses) implies "var" is a map() while \
+    "var.fun()" (with parentheses) implies "var" is an atom()
+
+    """
+  end
+
+  defp format_type_hint(type, expr, hints) do
+    case format_type_hint(type, expr) do
+      {message, hint} -> {message, [hint | hints]}
+      :error -> {[], hints}
+    end
+  end
+
+  defp format_type_hint(type, expr) do
+    cond do
+      dynamic_map_dot?(type, expr) ->
+        {" (due to calling var.field)", :dynamic_dot}
+
+      dynamic_remote_call?(type, expr) ->
+        {" (due to calling var.fun())", :dynamic_dot}
+
+      true ->
+        :error
+    end
+  end
+
+  defp dynamic_map_dot?(type, expr) do
+    with true <- map_type?(type),
+         {{:., _meta1, [_map, _field]}, meta2, []} <- expr,
+         true <- Keyword.get(meta2, :no_parens, false) do
+      true
+    else
+      _ -> false
+    end
+  end
+
+  defp dynamic_remote_call?(type, expr) do
+    with true <- atom_type?(type),
+         {{:., _meta1, [_module, _field]}, meta2, []} <- expr,
+         false <- Keyword.get(meta2, :no_parens, false) do
+      true
+    else
+      _ -> false
+    end
+  end
+
+  ## Formatting helpers
+
+  defp indent(string) do
+    String.replace(string, "\n", "    \n")
+  end
+
+  defp map_type?({:map, _}), do: true
+  defp map_type?(_other), do: false
+
+  defp atom_type?(:atom), do: true
+  defp atom_type?(:boolean), do: true
+  defp atom_type?({:atom, _}), do: false
+  defp atom_type?(_other), do: false
 end

--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -429,7 +429,7 @@ defmodule Module.Types do
   defp format_message_hint(:inferred_bitstring_spec) do
     """
     HINT: all expressions given to binaries are assumed to be of type \
-    integer unless said otherwise. For example, <<expr>> assumes \"expr\" \
+    integer unless said otherwise. For example, <<expr>> assumes "expr" \
     is an integer. Pass a modifier, such as <<expr::float>> or <<expr::binary>>, \
     to change the default behaviour.
 

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -34,13 +34,8 @@ defmodule Module.Types.Expr do
   end
 
   # <<...>>>
-  def of_expr({:<<>>, _meta, args} = expr, stack, context) do
-    stack = push_expr_stack(expr, stack)
-
-    result =
-      reduce_ok(args, context, fn expr, context ->
-        of_binary(expr, stack, context, &of_expr/3)
-      end)
+  def of_expr({:<<>>, _meta, args}, stack, context) do
+    result = of_binary(args, stack, context, &of_expr/3)
 
     case result do
       {:ok, context} -> {:ok, :binary, context}

--- a/lib/elixir/lib/module/types/helpers.ex
+++ b/lib/elixir/lib/module/types/helpers.ex
@@ -46,10 +46,6 @@ defmodule Module.Types.Helpers do
       {:ok, acc} ->
         do_reduce_ok(tail, acc, fun)
 
-      result when elem(result, 0) == :ok ->
-        result = Tuple.delete_at(result, 0)
-        do_reduce_ok(tail, result, fun)
-
       {:error, reason} ->
         {:error, reason}
     end

--- a/lib/elixir/lib/module/types/pattern.ex
+++ b/lib/elixir/lib/module/types/pattern.ex
@@ -33,13 +33,8 @@ defmodule Module.Types.Pattern do
   end
 
   # <<...>>>
-  def of_pattern({:<<>>, _meta, args} = expr, stack, context) do
-    stack = push_expr_stack(expr, stack)
-
-    result =
-      reduce_ok(args, context, fn expr, context ->
-        of_binary(expr, stack, context, &of_pattern/3)
-      end)
+  def of_pattern({:<<>>, _meta, args}, stack, context) do
+    result = of_binary(args, stack, context, &of_pattern/3)
 
     case result do
       {:ok, context} -> {:ok, :binary, context}

--- a/lib/elixir/test/elixir/module/checker_test.exs
+++ b/lib/elixir/test/elixir/module/checker_test.exs
@@ -1022,7 +1022,7 @@ defmodule Module.CheckerTest do
           <<foo>>
 
       HINT: all expressions given to binaries are assumed to be of type \
-      integer unless said otherwise. For example, <<expr>> assumes "expr" \
+      integer() unless said otherwise. For example, <<expr>> assumes "expr" \
       is an integer. Pass a modifier, such as <<expr::float>> or <<expr::binary>>, \
       to change the default behaviour.
 

--- a/lib/elixir/test/elixir/module/checker_test.exs
+++ b/lib/elixir/test/elixir/module/checker_test.exs
@@ -974,12 +974,12 @@ defmodule Module.CheckerTest do
           # a.ex:2
           :foo = x
 
-      where \"x\" was given the type :foo in:
+      where "x" was given the type :foo in:
 
           # a.ex:2
           :foo = x
 
-      where \"x\" was given the type integer() in:
+      where "x" was given the type integer() in:
 
           # a.ex:2
           is_integer(x)
@@ -1011,12 +1011,12 @@ defmodule Module.CheckerTest do
           # a.ex:2
           <<foo>>
 
-      where \"foo\" was given the type integer() in:
+      where "foo" was given the type integer() in:
 
           # a.ex:2
           <<foo>>
 
-      where \"foo\" was given the type binary() in:
+      where "foo" was given the type binary() in:
 
           # a.ex:2
           is_binary(foo)
@@ -1046,12 +1046,12 @@ defmodule Module.CheckerTest do
           # a.ex:2
           <<foo::integer()>>
 
-      where \"foo\" was given the type integer() in:
+      where "foo" was given the type integer() in:
 
           # a.ex:2
           <<foo::integer()>>
 
-      where \"foo\" was given the type binary() in:
+      where "foo" was given the type binary() in:
 
           # a.ex:2
           is_binary(foo)
@@ -1093,10 +1093,13 @@ defmodule Module.CheckerTest do
           # a.ex:4
           :atom = foo
 
-      where "foo" was given the type %{bar: var1, optional(dynamic()) => dynamic()} in:
+      where "foo" was given the type map() (due to calling var.field) in:
 
           # a.ex:3
           foo.bar
+
+      HINT: "var.field" (without parentheses) implies "var" is a map() while \
+      "var.fun()" (with parentheses) implies "var" is an atom()
 
       Conflict found at
         a.ex:4: A.a/1
@@ -1119,15 +1122,27 @@ defmodule Module.CheckerTest do
       }
 
       warning = """
-      warning: parentheses are required when dynamically invoking zero-arity functions in expression:
+      warning: incompatible types:
+
+          map() !~ atom()
+
+      in expression:
 
           # a.ex:4
           module.__struct__
 
-      "module" is an atom and you attempted to fetch the field __struct__. Make sure that \
-      "module" is a map or add parentheses to invoke a function instead:
+      where "module" was given the type map() (due to calling var.field) in:
 
-          module.__struct__()
+          # a.ex:4
+          module.__struct__
+
+      where "module" was given the type atom() in:
+
+          # a.ex:3
+          %module{}
+
+      HINT: "var.field" (without parentheses) implies "var" is a map() while \
+      "var.fun()" (with parentheses) implies "var" is an atom()
 
       Conflict found at
         a.ex:4: A.a/1
@@ -1149,15 +1164,26 @@ defmodule Module.CheckerTest do
       }
 
       warning = """
-      warning: parentheses are not allowed when fetching fields from a map in expression:
+      warning: incompatible types:
+
+          map() !~ atom()
+
+      in expression:
 
           # a.ex:3
           foo.__struct__()
 
-      "foo" is a map and you attempted to invoke the function __struct__/0. Make sure that \
-      "foo" is an atom or remove parentheses to fetch a field:
+      where "foo" was given the type atom() (due to calling var.fun()) in:
 
-          foo.__struct__
+          # a.ex:3
+          foo.__struct__()
+
+      where "foo" was given the type map() in:
+
+          # a.ex:2
+          is_map(foo)
+
+      HINT: "var.field" (without parentheses) implies "var" is a map() while "var.fun()" (with parentheses) implies "var" is an atom()
 
       Conflict found at
         a.ex:3: A.a/1

--- a/lib/elixir/test/elixir/module/checker_test.exs
+++ b/lib/elixir/test/elixir/module/checker_test.exs
@@ -1022,7 +1022,7 @@ defmodule Module.CheckerTest do
           <<foo>>
 
       HINT: all expressions given to binaries are assumed to be of type \
-      integer unless said otherwise. For example, <<expr>> assumes \"expr\" \
+      integer unless said otherwise. For example, <<expr>> assumes "expr" \
       is an integer. Pass a modifier, such as <<expr::float>> or <<expr::binary>>, \
       to change the default behaviour.
 

--- a/lib/elixir/test/elixir/module/checker_test.exs
+++ b/lib/elixir/test/elixir/module/checker_test.exs
@@ -747,15 +747,15 @@ defmodule Module.CheckerTest do
           # a.ex:2
           var = "abc"
 
-      where "var" was given the type binary() in:
-
-          # a.ex:2
-          var = "abc"
-
       where "var" was given the type integer() in:
 
           # a.ex:2
           var = 123
+
+      where "var" was given the type binary() in:
+
+          # a.ex:2
+          var = "abc"
 
       Conflict found at
         a.ex:2: A.a/2
@@ -782,17 +782,17 @@ defmodule Module.CheckerTest do
       in expression:
 
           # a.ex:2
-          <<var::integer(), var::binary()>>
-
-      where "var" was given the type binary() in:
-
-          # a.ex:2
-          <<var::integer(), var::binary()>>
+          <<..., var::binary()>>
 
       where "var" was given the type integer() in:
 
           # a.ex:2
-          <<var::integer(), var::binary()>>
+          <<var::integer(), ...>>
+
+      where "var" was given the type binary() in:
+
+          # a.ex:2
+          <<..., var::binary()>>
 
       Conflict found at
         a.ex:2: A.a/1
@@ -853,15 +853,15 @@ defmodule Module.CheckerTest do
           # a.ex:2
           is_integer(var) and is_binary(var)
 
-      where "var" was given the type binary() in:
-
-          # a.ex:2
-          is_binary(var)
-
       where "var" was given the type integer() in:
 
           # a.ex:2
           is_integer(var)
+
+      where "var" was given the type binary() in:
+
+          # a.ex:2
+          is_binary(var)
 
       Conflict found at
         a.ex:2: A.a/1
@@ -890,20 +890,20 @@ defmodule Module.CheckerTest do
           # a.ex:2
           is_integer(x) and is_binary(y)
 
-      where "x" was given the type integer() in:
+      where "y" was given the same type as "x" in:
 
           # a.ex:2
-          is_integer(x)
+          x = y
 
       where "y" was given the type binary() in:
 
           # a.ex:2
           is_binary(y)
 
-      where "y" was given the same type as "x" in:
+      where "x" was given the type integer() in:
 
           # a.ex:2
-          x = y
+          is_integer(x)
 
       Conflict found at
         a.ex:2: A.a/1
@@ -932,20 +932,20 @@ defmodule Module.CheckerTest do
           # a.ex:2
           is_integer(x) and is_binary(y) and is_boolean(z)
 
-      where "x" was given the type integer() in:
+      where "y" was given the same type as "x" in:
 
           # a.ex:2
-          is_integer(x)
+          x = y
 
       where "y" was given the type binary() in:
 
           # a.ex:2
           is_binary(y)
 
-      where "y" was given the same type as "x" in:
+      where "x" was given the type integer() in:
 
           # a.ex:2
-          x = y
+          is_integer(x)
 
       Conflict found at
         a.ex:2: A.a/2
@@ -974,15 +974,15 @@ defmodule Module.CheckerTest do
           # a.ex:2
           :foo = x
 
-      where "x" was given the type :foo in:
-
-          # a.ex:2
-          :foo = x
-
       where "x" was given the type integer() in:
 
           # a.ex:2
           is_integer(x)
+
+      where "x" was given the type :foo in:
+
+          # a.ex:2
+          :foo = x
 
       Conflict found at
         a.ex:2: A.a/1
@@ -1011,15 +1011,15 @@ defmodule Module.CheckerTest do
           # a.ex:2
           <<foo>>
 
-      where "foo" was given the type integer() in:
-
-          # a.ex:2
-          <<foo>>
-
       where "foo" was given the type binary() in:
 
           # a.ex:2
           is_binary(foo)
+
+      where "foo" was given the type integer() in:
+
+          # a.ex:2
+          <<foo>>
 
       Conflict found at
         a.ex:2: A.a/1
@@ -1046,15 +1046,15 @@ defmodule Module.CheckerTest do
           # a.ex:2
           <<foo::integer()>>
 
-      where "foo" was given the type integer() in:
-
-          # a.ex:2
-          <<foo::integer()>>
-
       where "foo" was given the type binary() in:
 
           # a.ex:2
           is_binary(foo)
+
+      where "foo" was given the type integer() in:
+
+          # a.ex:2
+          <<foo::integer()>>
 
       Conflict found at
         a.ex:2: A.a/1
@@ -1088,15 +1088,15 @@ defmodule Module.CheckerTest do
           # a.ex:4
           :atom = foo
 
-      where "foo" was given the type :atom in:
-
-          # a.ex:4
-          :atom = foo
-
       where "foo" was given the type map() (due to calling var.field) in:
 
           # a.ex:3
           foo.bar
+
+      where "foo" was given the type :atom in:
+
+          # a.ex:4
+          :atom = foo
 
       HINT: "var.field" (without parentheses) implies "var" is a map() while \
       "var.fun()" (with parentheses) implies "var" is an atom()
@@ -1131,15 +1131,15 @@ defmodule Module.CheckerTest do
           # a.ex:4
           module.__struct__
 
-      where "module" was given the type map() (due to calling var.field) in:
-
-          # a.ex:4
-          module.__struct__
-
       where "module" was given the type atom() in:
 
           # a.ex:3
           %module{}
+
+      where "module" was given the type map() (due to calling var.field) in:
+
+          # a.ex:4
+          module.__struct__
 
       HINT: "var.field" (without parentheses) implies "var" is a map() while \
       "var.fun()" (with parentheses) implies "var" is an atom()
@@ -1173,17 +1173,18 @@ defmodule Module.CheckerTest do
           # a.ex:3
           foo.__struct__()
 
-      where "foo" was given the type atom() (due to calling var.fun()) in:
-
-          # a.ex:3
-          foo.__struct__()
-
       where "foo" was given the type map() in:
 
           # a.ex:2
           is_map(foo)
 
-      HINT: "var.field" (without parentheses) implies "var" is a map() while "var.fun()" (with parentheses) implies "var" is an atom()
+      where "foo" was given the type atom() (due to calling var.fun()) in:
+
+          # a.ex:3
+          foo.__struct__()
+
+      HINT: "var.field" (without parentheses) implies "var" is a map() while \
+      "var.fun()" (with parentheses) implies "var" is an atom()
 
       Conflict found at
         a.ex:3: A.a/1

--- a/lib/elixir/test/elixir/module/checker_test.exs
+++ b/lib/elixir/test/elixir/module/checker_test.exs
@@ -1021,6 +1021,11 @@ defmodule Module.CheckerTest do
           # a.ex:2
           <<foo>>
 
+      HINT: all expressions given to binaries are assumed to be of type \
+      integer unless said otherwise. For example, <<expr>> assumes \"expr\" \
+      is an integer. Pass a modifier, such as <<expr::float>> or <<expr::binary>>, \
+      to change the default behaviour.
+
       Conflict found at
         a.ex:2: A.a/1
 

--- a/lib/elixir/test/elixir/module/types/pattern_test.exs
+++ b/lib/elixir/test/elixir/module/types/pattern_test.exs
@@ -84,7 +84,7 @@ defmodule Module.Types.PatternTest do
 
       assert {:<<>>, _,
               [
-                {:"::", _, [{:foo, _, nil}, {:integer, _, []}]},
+                {:..., _, _},
                 {:"::", _, [{:foo, _, nil}, {:binary, _, []}]}
               ]} = expr
 

--- a/lib/elixir/test/elixir/module/types_test.exs
+++ b/lib/elixir/test/elixir/module/types_test.exs
@@ -288,28 +288,38 @@ defmodule Module.TypesTest do
   end
 
   test "format_type/1" do
-    assert Types.format_type(:binary) == "binary()"
-    assert Types.format_type({:atom, true}) == "true"
-    assert Types.format_type({:atom, :atom}) == ":atom"
-    assert Types.format_type({:list, :binary}) == "[binary()]"
-    assert Types.format_type({:tuple, []}) == "{}"
-    assert Types.format_type({:tuple, [:integer]}) == "{integer()}"
-    assert Types.format_type({:map, []}) == "%{}"
-    assert Types.format_type({:map, [{:required, {:atom, :foo}, :atom}]}) == "%{foo: atom()}"
-    assert Types.format_type({:map, [{:required, :integer, :atom}]}) == "%{integer() => atom()}"
+    assert Types.format_type(:binary, false) == "binary()"
+    assert Types.format_type({:atom, true}, false) == "true"
+    assert Types.format_type({:atom, :atom}, false) == ":atom"
+    assert Types.format_type({:list, :binary}, false) == "[binary()]"
+    assert Types.format_type({:tuple, []}, false) == "{}"
+    assert Types.format_type({:tuple, [:integer]}, false) == "{integer()}"
 
-    assert Types.format_type({:map, [{:optional, :integer, :atom}]}) ==
+    assert Types.format_type({:map, []}, true) == "map()"
+    assert Types.format_type({:map, [{:required, {:atom, :foo}, :atom}]}, true) == "map()"
+
+    assert Types.format_type({:map, []}, false) ==
+             "%{}"
+
+    assert Types.format_type({:map, [{:required, {:atom, :foo}, :atom}]}, false) ==
+             "%{foo: atom()}"
+
+    assert Types.format_type({:map, [{:required, :integer, :atom}]}, false) ==
+             "%{integer() => atom()}"
+
+    assert Types.format_type({:map, [{:optional, :integer, :atom}]}, false) ==
              "%{optional(integer()) => atom()}"
 
-    assert Types.format_type({:map, [{:optional, {:atom, :foo}, :atom}]}) ==
+    assert Types.format_type({:map, [{:optional, {:atom, :foo}, :atom}]}, false) ==
              "%{optional(:foo) => atom()}"
 
-    assert Types.format_type({:map, [{:required, {:atom, :__struct__}, {:atom, Struct}}]}) ==
+    assert Types.format_type({:map, [{:required, {:atom, :__struct__}, {:atom, Struct}}]}, false) ==
              "%Struct{}"
 
     assert Types.format_type(
              {:map,
-              [{:required, {:atom, :__struct__}, {:atom, Struct}}, {:required, :integer, :atom}]}
+              [{:required, {:atom, :__struct__}, {:atom, Struct}}, {:required, :integer, :atom}]},
+             false
            ) ==
              "%Struct{integer() => atom()}"
   end


### PR DESCRIPTION
Instead of trying to assuming that a certain usage of a type is the correct one, we keep the unification message agnostic and add hints to the message.

Each message may have multiple hints, as they are computed alongside the trace. The traces are also reversed in order to keep the order they are added.

Here is how the new warning for dot access look like:

    warning: incompatible types:

        map() !~ atom()

    in expression:

        # a.ex:4
        module.__struct__

    where "module" was given the type map() (due to calling var.field) in:

        # a.ex:4
        module.__struct__

    where "module" was given the type atom() in:

        # a.ex:3
        %module{}

    HINT: "var.field" (without parentheses) implies "var" is a map() while
    "var.fun()" (with parentheses) implies "var" is an atom()

    Conflict found at
      a.ex:4: A.a/1

And here is the hint for binaries:

    warning: incompatible types:

        binary() !~ integer()

    in expression:

        # a.ex:2
        <<foo>>

    where "foo" was given the type binary() in:

        # a.ex:2
        is_binary(foo)

    where "foo" was given the type integer() in:

        # a.ex:2
        <<foo>>

    HINT: all expressions given to binaries are assumed to be of type
    integer unless said otherwise. For example, <<expr>> assumes "expr" 
    is an integer. Pass a modifier, such as <<expr::float>> or <<expr::binary>>, 
    to change the default behaviour.

    Conflict found at
      a.ex:2: A.a/1