### PR TITLE
Enum.intersperse: Return early for empty enumerables

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1221,6 +1221,10 @@ defmodule Enum do
 
   """
   @spec intersperse(t, element) :: list
+  def intersperse(enumerable, element)
+
+  def intersperse(enumerable, element) when count(enumerable) == 0, do: []
+
   def intersperse(enumerable, element) do
     list =
       enumerable


### PR DESCRIPTION
The codepath involving `reduce`, `reverse` and pattern matching in `case` seems like an overhead for empty Enumerables. This PR suggests to return early with empty list, skipping these functions.



