### PR TITLE
Enum.intersperse: Return early for empty enumerables

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1222,15 +1222,16 @@ defmodule Enum do
   """
   @spec intersperse(t, element) :: list
   def intersperse(enumerable, element) do
-    list =
-      enumerable
-      |> reduce([], fn x, acc -> [x, element | acc] end)
-      |> :lists.reverse()
+    if count(enumerable) > 0 do
+      # Head is a superfluous intersperser element
+      [_ | t] =
+        enumerable
+        |> reduce([], fn x, acc -> [x, element | acc] end)
+        |> :lists.reverse()
 
-    # Head is a superfluous intersperser element
-    case list do
-      [] -> []
-      [_ | t] -> t
+      t
+    else
+      []
     end
   end
 


### PR DESCRIPTION
The codepath involving `reduce` and `reverse` seems like an overhead for empty Enumerables. This PR suggests to return early with empty list, skipping these functions.