### PR TITLE
Fix `&//2` parsing issue

### DIFF
--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -715,14 +715,11 @@ handle_unary_op([$: | Rest], Line, Column, _Kind, Length, Op, Scope, Tokens) whe
   tokenize(Rest, Line, Column + Length + 1, Scope, [Token | Tokens]);
 
 handle_unary_op(Rest, Line, Column, Kind, Length, Op, Scope, Tokens) ->
-  case {strip_horizontal_space(Rest, 0), Tokens, Kind} of
-    {{[$/ | _] = Remaining, Extra}, [{capture_op, _, '&'} | _], _} ->
+  case {strip_horizontal_space(Rest, 0), Tokens} of
+    {{[$/ | _] = Remaining, Extra}, [{capture_op, _, '&'} | _]} ->
       Token = {identifier, {Line, Column, nil}, Op},
       tokenize(Remaining, Line, Column + Length + Extra, Scope, [Token | Tokens]);
-    {{[$/ | _] = Remaining, Extra}, _, dual_op} ->
-      Token = {identifier, {Line, Column, nil}, Op},
-      tokenize(Remaining, Line, Column + Length + Extra, Scope, [Token | Tokens]);
-    {{Remaining, Extra}, _, _} ->
+    {{Remaining, Extra}, _} ->
       Token = {Kind, {Line, Column, nil}, Op},
       tokenize(Remaining, Line, Column + Length + Extra, Scope, [Token | Tokens])
   end.

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -715,15 +715,14 @@ handle_unary_op([$: | Rest], Line, Column, _Kind, Length, Op, Scope, Tokens) whe
   tokenize(Rest, Line, Column + Length + 1, Scope, [Token | Tokens]);
 
 handle_unary_op(Rest, Line, Column, Kind, Length, Op, Scope, Tokens) ->
-  Token = case {strip_horizontal_space(Rest, 0), Kind} of
-    {{[$/, $/ | _] = Remaining, Extra}, capture_op} ->
-      {capture_op, {Line, Column, nil}, Op};
-    {{[$/ | _] = Remaining, Extra}, _} ->
-      {identifier, {Line, Column, nil}, Op};
+  case {strip_horizontal_space(Rest, 0), Tokens} of
+    {{[$/ | _] = Remaining, Extra}, [{capture_op, _, '&'} | _]} ->
+      Token = {identifier, {Line, Column, nil}, Op},
+      tokenize(Remaining, Line, Column + Length + Extra, Scope, [Token | Tokens]);
     {{Remaining, Extra}, _} ->
-      {Kind, {Line, Column, nil}, Op}
-  end,
-  tokenize(Remaining, Line, Column + Length + Extra, Scope, [Token | Tokens]).
+      Token = {Kind, {Line, Column, nil}, Op},
+      tokenize(Remaining, Line, Column + Length + Extra, Scope, [Token | Tokens])
+  end.
 
 handle_op([$: | Rest], Line, Column, _Kind, Length, Op, Scope, Tokens) when ?is_space(hd(Rest)) ->
   Token = {kw_identifier, {Line, Column, nil}, Op},

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -715,14 +715,15 @@ handle_unary_op([$: | Rest], Line, Column, _Kind, Length, Op, Scope, Tokens) whe
   tokenize(Rest, Line, Column + Length + 1, Scope, [Token | Tokens]);
 
 handle_unary_op(Rest, Line, Column, Kind, Length, Op, Scope, Tokens) ->
-  case strip_horizontal_space(Rest, 0) of
-    {[$/ | _] = Remaining, Extra} ->
-      Token = {identifier, {Line, Column, nil}, Op},
-      tokenize(Remaining, Line, Column + Length + Extra, Scope, [Token | Tokens]);
-    {Remaining, Extra} ->
-      Token = {Kind, {Line, Column, nil}, Op},
-      tokenize(Remaining, Line, Column + Length + Extra, Scope, [Token | Tokens])
-  end.
+  Token = case {strip_horizontal_space(Rest, 0), Kind} of
+    {{[$/, $/ | _] = Remaining, Extra}, capture_op} ->
+      {capture_op, {Line, Column, nil}, Op};
+    {{[$/ | _] = Remaining, Extra}, _} ->
+      {identifier, {Line, Column, nil}, Op};
+    {{Remaining, Extra}, _} ->
+      {Kind, {Line, Column, nil}, Op}
+  end,
+  tokenize(Remaining, Line, Column + Length + Extra, Scope, [Token | Tokens]).
 
 handle_op([$: | Rest], Line, Column, _Kind, Length, Op, Scope, Tokens) when ?is_space(hd(Rest)) ->
   Token = {kw_identifier, {Line, Column, nil}, Op},

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -715,11 +715,14 @@ handle_unary_op([$: | Rest], Line, Column, _Kind, Length, Op, Scope, Tokens) whe
   tokenize(Rest, Line, Column + Length + 1, Scope, [Token | Tokens]);
 
 handle_unary_op(Rest, Line, Column, Kind, Length, Op, Scope, Tokens) ->
-  case {strip_horizontal_space(Rest, 0), Tokens} of
-    {{[$/ | _] = Remaining, Extra}, [{capture_op, _, '&'} | _]} ->
+  case {strip_horizontal_space(Rest, 0), Tokens, Kind} of
+    {{[$/ | _] = Remaining, Extra}, [{capture_op, _, '&'} | _], _} ->
       Token = {identifier, {Line, Column, nil}, Op},
       tokenize(Remaining, Line, Column + Length + Extra, Scope, [Token | Tokens]);
-    {{Remaining, Extra}, _} ->
+    {{[$/ | _] = Remaining, Extra}, _, dual_op} ->
+      Token = {identifier, {Line, Column, nil}, Op},
+      tokenize(Remaining, Line, Column + Length + Extra, Scope, [Token | Tokens]);
+    {{Remaining, Extra}, _, _} ->
       Token = {Kind, {Line, Column, nil}, Op},
       tokenize(Remaining, Line, Column + Length + Extra, Scope, [Token | Tokens])
   end.

--- a/lib/elixir/test/elixir/code_formatter/operators_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/operators_test.exs
@@ -896,6 +896,7 @@ defmodule Code.Formatter.OperatorsTest do
       assert_same "&and/2"
       assert_same "& &&/2"
       assert_same "& &/1"
+      assert_same "&//2"
     end
 
     test "Module.remote/arity" do

--- a/lib/elixir/test/elixir/kernel/quote_test.exs
+++ b/lib/elixir/test/elixir/kernel/quote_test.exs
@@ -264,7 +264,7 @@ defmodule Kernel.QuoteTest do
   end
 
   test "operators slash arity" do
-    assert {:/, _, [{:+, _, _}, 2]} = quote(do: + / 2)
+    assert {:&, _, [{:/, _, [{:+, _, _}, 2]}]} = quote(do: & + / 2)
     assert {:/, _, [{:&&, _, _}, 3]} = quote(do: && / 3)
   end
 

--- a/lib/elixir/test/elixir/kernel/quote_test.exs
+++ b/lib/elixir/test/elixir/kernel/quote_test.exs
@@ -263,11 +263,6 @@ defmodule Kernel.QuoteTest do
     assert quote(do: &1.foo) == quote(do: &1.foo)
   end
 
-  test "operators slash arity" do
-    assert {:&, _, [{:/, _, [{:+, _, _}, 2]}]} = quote(do: & + / 2)
-    assert {:/, _, [{:&&, _, _}, 3]} = quote(do: && / 3)
-  end
-
   test "pipe precedence" do
     assert {:|>, _, [{:|>, _, [{:foo, _, _}, {:bar, _, _}]}, {:baz, _, _}]} =
              quote(do: foo |> bar |> baz)

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -231,6 +231,11 @@ capture_test() ->
    {mult_op, {1, 4, nil}, '/'},
    {int, {1, 5, 2}, "2"}] = tokenize("&/ /2").
 
+operator_slash_arity_test() ->
+  [{identifier,{1,1,nil},'+'},
+   {mult_op,{1,3,nil},'/'},
+   {int,{1,5,2},"2"}] = tokenize("+ / 2").
+
 vc_merge_conflict_test() ->
   {1, 1, "found an unexpected version control marker, please resolve the conflicts: ", "<<<<<<< HEAD"} =
     tokenize_error("<<<<<<< HEAD\n[1, 2, 3]").

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -231,11 +231,6 @@ capture_test() ->
    {mult_op, {1, 4, nil}, '/'},
    {int, {1, 5, 2}, "2"}] = tokenize("&/ /2").
 
-operator_slash_arity_test() ->
-  [{identifier,{1,1,nil},'+'},
-   {mult_op,{1,3,nil},'/'},
-   {int,{1,5,2},"2"}] = tokenize("+ / 2").
-
 vc_merge_conflict_test() ->
   {1, 1, "found an unexpected version control marker, please resolve the conflicts: ", "<<<<<<< HEAD"} =
     tokenize_error("<<<<<<< HEAD\n[1, 2, 3]").

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -209,7 +209,11 @@ capture_test() ->
    {unary_op, {1, 2, nil}, 'not'},
    {int, {1, 6, 1}, "1"},
    {',', {1, 7, 0}},
-   {int, {1, 9, 2}, "2"}] = tokenize("&not 1, 2").
+   {int, {1, 9, 2}, "2"}] = tokenize("&not 1, 2"),
+  [{capture_op, {1, 1, nil}, '&'},
+   {identifier, {1, 2, nil}, '/'},
+   {mult_op, {1, 3, nil}, '/'},
+   {int, {1, 4, 2}, "2"}] = tokenize("&//2").
 
 vc_merge_conflict_test() ->
   {1, 1, "found an unexpected version control marker, please resolve the conflicts: ", "<<<<<<< HEAD"} =

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -210,10 +210,26 @@ capture_test() ->
    {int, {1, 6, 1}, "1"},
    {',', {1, 7, 0}},
    {int, {1, 9, 2}, "2"}] = tokenize("&not 1, 2"),
+  [{capture_op,{1,1,nil},'&'},
+   {identifier,{1,3,nil},'&'},
+   {mult_op,{1,4,nil},'/'},
+   {int,{1,5,1},"1"}] = tokenize("& &/1"),
   [{capture_op, {1, 1, nil}, '&'},
    {identifier, {1, 2, nil}, '/'},
    {mult_op, {1, 3, nil}, '/'},
-   {int, {1, 4, 2}, "2"}] = tokenize("&//2").
+   {int, {1, 4, 2}, "2"}] = tokenize("&//2"),
+  [{capture_op, {1, 1, nil}, '&'},
+   {identifier, {1, 3, nil}, '/'},
+   {mult_op, {1, 4, nil}, '/'},
+   {int, {1, 5, 2}, "2"}] = tokenize("& //2"),
+  [{capture_op, {1, 1, nil}, '&'},
+   {identifier, {1, 3, nil}, '/'},
+   {mult_op, {1, 5, nil}, '/'},
+   {int, {1, 6, 2}, "2"}] = tokenize("& / /2"),
+  [{capture_op, {1, 1, nil}, '&'},
+   {identifier, {1, 2, nil}, '/'},
+   {mult_op, {1, 4, nil}, '/'},
+   {int, {1, 5, 2}, "2"}] = tokenize("&/ /2").
 
 vc_merge_conflict_test() ->
   {1, 1, "found an unexpected version control marker, please resolve the conflicts: ", "<<<<<<< HEAD"} =


### PR DESCRIPTION
Closes #10311

I am not 100% sure I'm not introducing any side effect for alternative syntax, but seems to be fixing the issue without failing other tests.

Before/after the change:

```erlang
- [{identifier, {1, 1, nil}, '&'},
+ [{capture_op, {1, 1, nil}, '&'},
```