### PR TITLE
add "since" doc metadata to System.otp_release/0

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -1009,6 +1009,7 @@ defmodule System do
   Returns the Erlang/OTP release number.
   """
   @spec otp_release :: String.t()
+  @doc since: "1.3.0"
   def otp_release do
     :erlang.list_to_binary(:erlang.system_info(:otp_release))
   end


### PR DESCRIPTION
```
$ docker run -it -v $(pwd):/project elixir:1.3.0 bash
root@983045508faf:/# elixir -e "IO.puts System.otp_release"
19
```

```
$ docker run -it -v $(pwd):/project elixir:1.2.6 bash
root@af8db535bb1e:/# elixir -e "IO.puts System.otp_release"
** (UndefinedFunctionError) undefined function System.otp_release/0
    (elixir) System.otp_release()
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
    (stdlib) erl_eval.erl:878: :erl_eval.expr_list/6
    (stdlib) erl_eval.erl:404: :erl_eval.expr/5
    (elixir) lib/code.ex:168: Code.eval_string/3
```

References:
- https://github.com/elixir-lang/elixir/commit/5533cc466559415f3ecd52424f2fa0371a56e0d4 - v1.3.0
- https://github.com/elixir-lang/elixir/commit/ea119f4c01cc158886ea432c7d7ffdfceefe9685 - v1.4.0 onwards