### PR TITLE
Fix unregistration crash

### DIFF
--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -261,9 +261,8 @@ defmodule Registry do
   end
 
   @doc false
-  def unregister_name({registry, key}) do
-    unregister(registry, key)
-  end
+  def unregister_name({registry, key}), do: unregister(registry, key)
+  def unregister_name({registry, key, _value}), do: unregister(registry, key)
 
   ## Registry API
 

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -863,6 +863,13 @@ defmodule RegistryTest do
     end
   end
 
+  test "unregistration on crash with {registry, key, value} via tuple", %{registry: registry} do
+    name = {:via, Registry, {registry, :name, :value}}
+    spec = %{id: :foo, start: {Agent, :start_link, [fn -> raise "some error" end, [name: name]]}}
+    assert {:error, {error, _childspec}} = start_supervised(spec)
+    assert {%RuntimeError{message: "some error"}, _stacktrace} = error
+  end
+
   defp register_task(registry, key, value) do
     parent = self()
 


### PR DESCRIPTION
This PR fixes a bug which happens if a process started with `name: {:via, Registry, {registry_name, process_name, value}}` crashes during the startup. In this case, instead of the original error, a no function clause exception happens in the Registry module. Minimal example:

```
iex> Registry.start_link(keys: :unique, name: Foo)
iex> Agent.start_link(fn -> raise "foo" end, name: {:via, Registry, {Foo, :name, :value}})

** (EXIT from #PID<0.105.0>) shell process exited with reason: an exception was raised:
    ** (FunctionClauseError) no function clause matching in Registry.unregister_name/1
        (elixir 1.10.2) lib/registry.ex:264: Registry.unregister_name({Foo, :name, :value})
```