### PR TITLE
Document all built-in types internally

### DIFF
--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -100,10 +100,10 @@ defmodule Module.Types.Expr do
 
   # __STACKTRACE__
   def of_expr({:__STACKTRACE__, _meta, var_context}, _stack, context) when is_atom(var_context) do
-    file = {:tuple, [{:atom, :file}, {:list, :integer}]}
-    line = {:tuple, [{:atom, :line}, :integer]}
+    file = {:tuple, 2, [{:atom, :file}, {:list, :integer}]}
+    line = {:tuple, 2, [{:atom, :line}, :integer]}
     file_line = {:list, {:union, [file, line]}}
-    type = {:list, {:tuple, [:atom, :atom, :integer, file_line]}}
+    type = {:list, {:tuple, 4, [:atom, :atom, :integer, file_line]}}
     {:ok, type, context}
   end
 
@@ -123,7 +123,7 @@ defmodule Module.Types.Expr do
     stack = push_expr_stack(expr, stack)
 
     case map_reduce_ok(exprs, context, &of_expr(&1, stack, &2)) do
-      {:ok, types, context} -> {:ok, {:tuple, types}, context}
+      {:ok, types, context} -> {:ok, {:tuple, length(types), types}, context}
       {:error, reason} -> {:error, reason}
     end
   end

--- a/lib/elixir/lib/module/types/pattern.ex
+++ b/lib/elixir/lib/module/types/pattern.ex
@@ -149,7 +149,7 @@ defmodule Module.Types.Pattern do
     stack = push_expr_stack(expr, stack)
 
     case map_reduce_ok(exprs, context, &of_pattern(&1, stack, &2)) do
-      {:ok, types, context} -> {:ok, {:tuple, types}, context}
+      {:ok, types, context} -> {:ok, {:tuple, length(types), types}, context}
       {:error, reason} -> {:error, reason}
     end
   end

--- a/lib/elixir/test/elixir/module/types/expr_test.exs
+++ b/lib/elixir/test/elixir/module/types/expr_test.exs
@@ -36,9 +36,9 @@ defmodule Module.Types.ExprTest do
   end
 
   test "tuple" do
-    assert quoted_expr({}) == {:ok, {:tuple, []}}
-    assert quoted_expr({:a}) == {:ok, {:tuple, [{:atom, :a}]}}
-    assert quoted_expr({:a, 123}) == {:ok, {:tuple, [{:atom, :a}, :integer]}}
+    assert quoted_expr({}) == {:ok, {:tuple, 0, []}}
+    assert quoted_expr({:a}) == {:ok, {:tuple, 1, [{:atom, :a}]}}
+    assert quoted_expr({:a, 123}) == {:ok, {:tuple, 2, [{:atom, :a}, :integer]}}
   end
 
   # Use module attribute to avoid formatter adding parentheses
@@ -80,11 +80,13 @@ defmodule Module.Types.ExprTest do
                )
              ) == {:ok, :binary}
 
-      assert quoted_expr([foo], {<<foo::integer>>, foo}) == {:ok, {:tuple, [:binary, :integer]}}
-      assert quoted_expr([foo], {<<foo::binary>>, foo}) == {:ok, {:tuple, [:binary, :binary]}}
+      assert quoted_expr([foo], {<<foo::integer>>, foo}) ==
+               {:ok, {:tuple, 2, [:binary, :integer]}}
+
+      assert quoted_expr([foo], {<<foo::binary>>, foo}) == {:ok, {:tuple, 2, [:binary, :binary]}}
 
       assert quoted_expr([foo], {<<foo::utf8>>, foo}) ==
-               {:ok, {:tuple, [:binary, {:union, [:integer, :binary]}]}}
+               {:ok, {:tuple, 2, [:binary, {:union, [:integer, :binary]}]}}
 
       assert {:error, {:unable_unify, {:integer, :binary, _}}} =
                quoted_expr(
@@ -101,8 +103,8 @@ defmodule Module.Types.ExprTest do
 
   test "variables" do
     assert quoted_expr([foo], foo) == {:ok, {:var, 0}}
-    assert quoted_expr([foo], {foo}) == {:ok, {:tuple, [{:var, 0}]}}
-    assert quoted_expr([foo, bar], {foo, bar}) == {:ok, {:tuple, [{:var, 0}, {:var, 1}]}}
+    assert quoted_expr([foo], {foo}) == {:ok, {:tuple, 1, [{:var, 0}]}}
+    assert quoted_expr([foo, bar], {foo, bar}) == {:ok, {:tuple, 2, [{:var, 0}, {:var, 1}]}}
   end
 
   test "pattern match" do

--- a/lib/elixir/test/elixir/module/types/pattern_test.exs
+++ b/lib/elixir/test/elixir/module/types/pattern_test.exs
@@ -105,9 +105,9 @@ defmodule Module.Types.PatternTest do
     end
 
     test "tuple" do
-      assert quoted_pattern({}) == {:ok, {:tuple, []}}
-      assert quoted_pattern({:a}) == {:ok, {:tuple, [{:atom, :a}]}}
-      assert quoted_pattern({:a, 123}) == {:ok, {:tuple, [{:atom, :a}, :integer]}}
+      assert quoted_pattern({}) == {:ok, {:tuple, 0, []}}
+      assert quoted_pattern({:a}) == {:ok, {:tuple, 1, [{:atom, :a}]}}
+      assert quoted_pattern({:a, 123}) == {:ok, {:tuple, 2, [{:atom, :a}, :integer]}}
     end
 
     test "map" do
@@ -190,9 +190,9 @@ defmodule Module.Types.PatternTest do
       assert quoted_pattern(<<123::utf8>>) == {:ok, :binary}
       assert quoted_pattern(<<"foo"::utf8>>) == {:ok, :binary}
 
-      assert quoted_pattern({<<foo::integer>>, foo}) == {:ok, {:tuple, [:binary, :integer]}}
-      assert quoted_pattern({<<foo::binary>>, foo}) == {:ok, {:tuple, [:binary, :binary]}}
-      assert quoted_pattern({<<foo::utf8>>, foo}) == {:ok, {:tuple, [:binary, :integer]}}
+      assert quoted_pattern({<<foo::integer>>, foo}) == {:ok, {:tuple, 2, [:binary, :integer]}}
+      assert quoted_pattern({<<foo::binary>>, foo}) == {:ok, {:tuple, 2, [:binary, :binary]}}
+      assert quoted_pattern({<<foo::utf8>>, foo}) == {:ok, {:tuple, 2, [:binary, :integer]}}
 
       assert {:error, {:unable_unify, {:binary, :integer, _}}} =
                quoted_pattern(<<foo::binary-0, foo::integer>>)
@@ -200,24 +200,24 @@ defmodule Module.Types.PatternTest do
 
     test "variables" do
       assert quoted_pattern(foo) == {:ok, {:var, 0}}
-      assert quoted_pattern({foo}) == {:ok, {:tuple, [{:var, 0}]}}
-      assert quoted_pattern({foo, bar}) == {:ok, {:tuple, [{:var, 0}, {:var, 1}]}}
+      assert quoted_pattern({foo}) == {:ok, {:tuple, 1, [{:var, 0}]}}
+      assert quoted_pattern({foo, bar}) == {:ok, {:tuple, 2, [{:var, 0}, {:var, 1}]}}
 
       assert quoted_pattern(_) == {:ok, :dynamic}
-      assert quoted_pattern({_ = 123, _}) == {:ok, {:tuple, [:integer, :dynamic]}}
+      assert quoted_pattern({_ = 123, _}) == {:ok, {:tuple, 2, [:integer, :dynamic]}}
     end
 
     test "assignment" do
       assert quoted_pattern(x = y) == {:ok, {:var, 0}}
       assert quoted_pattern(x = 123) == {:ok, :integer}
-      assert quoted_pattern({foo}) == {:ok, {:tuple, [{:var, 0}]}}
-      assert quoted_pattern({x = y}) == {:ok, {:tuple, [{:var, 0}]}}
+      assert quoted_pattern({foo}) == {:ok, {:tuple, 1, [{:var, 0}]}}
+      assert quoted_pattern({x = y}) == {:ok, {:tuple, 1, [{:var, 0}]}}
 
       assert quoted_pattern(x = y = 123) == {:ok, :integer}
       assert quoted_pattern(x = 123 = y) == {:ok, :integer}
       assert quoted_pattern(123 = x = y) == {:ok, :integer}
 
-      assert {:error, {:unable_unify, {{:tuple, [var: 0]}, {:var, 0}, _}}} =
+      assert {:error, {:unable_unify, {{:tuple, 1, [var: 0]}, {:var, 0}, _}}} =
                quoted_pattern({x} = x)
     end
   end
@@ -258,7 +258,7 @@ defmodule Module.Types.PatternTest do
       assert quoted_head([x = y, y = z, z = :foo]) ==
                {:ok, [{:atom, :foo}, {:atom, :foo}, {:atom, :foo}]}
 
-      assert {:error, {:unable_unify, {{:tuple, [var: 1]}, {:var, 0}, _}}} =
+      assert {:error, {:unable_unify, {{:tuple, 1, [var: 1]}, {:var, 0}, _}}} =
                quoted_head([{x} = y, {y} = x])
     end
 

--- a/lib/elixir/test/elixir/module/types/types_test.exs
+++ b/lib/elixir/test/elixir/module/types/types_test.exs
@@ -4,43 +4,6 @@ defmodule Module.Types.TypesTest do
   use ExUnit.Case, async: true
   alias Module.Types
 
-  test "format_type/1" do
-    assert Types.format_type(:binary, false) == "binary()"
-    assert Types.format_type({:atom, true}, false) == "true"
-    assert Types.format_type({:atom, :atom}, false) == ":atom"
-    assert Types.format_type({:list, :binary}, false) == "[binary()]"
-    assert Types.format_type({:tuple, []}, false) == "{}"
-    assert Types.format_type({:tuple, [:integer]}, false) == "{integer()}"
-
-    assert Types.format_type({:map, []}, true) == "map()"
-    assert Types.format_type({:map, [{:required, {:atom, :foo}, :atom}]}, true) == "map()"
-
-    assert Types.format_type({:map, []}, false) ==
-             "%{}"
-
-    assert Types.format_type({:map, [{:required, {:atom, :foo}, :atom}]}, false) ==
-             "%{foo: atom()}"
-
-    assert Types.format_type({:map, [{:required, :integer, :atom}]}, false) ==
-             "%{integer() => atom()}"
-
-    assert Types.format_type({:map, [{:optional, :integer, :atom}]}, false) ==
-             "%{optional(integer()) => atom()}"
-
-    assert Types.format_type({:map, [{:optional, {:atom, :foo}, :atom}]}, false) ==
-             "%{optional(:foo) => atom()}"
-
-    assert Types.format_type({:map, [{:required, {:atom, :__struct__}, {:atom, Struct}}]}, false) ==
-             "%Struct{}"
-
-    assert Types.format_type(
-             {:map,
-              [{:required, {:atom, :__struct__}, {:atom, Struct}}, {:required, :integer, :atom}]},
-             false
-           ) ==
-             "%Struct{integer() => atom()}"
-  end
-
   test "expr_to_string/1" do
     assert Types.expr_to_string({1, 2}) == "{1, 2}"
     assert Types.expr_to_string(quote(do: Foo.bar(arg))) == "Foo.bar(arg)"


### PR DESCRIPTION
Also document which functions must be changed once
new types are introduced and which functions must
handle them.

Make sure all of these functions comply to the spec
and improve performance for tuples.