### PR TITLE
add "since" doc metadata to File.rename/2

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -735,6 +735,7 @@ defmodule File do
       File.rename("samples", "tmp")
 
   """
+  @doc since: "1.1.0"
   @spec rename(Path.t(), Path.t()) :: :ok | {:error, posix}
   def rename(source, destination) do
     :file.rename(source, destination)


### PR DESCRIPTION
Elixir 1.1.0:
```
$ docker run -it hexpm/elixir:1.1.0-erlang-18.3.4-debian-stretch-20200224 bash
root@67c584a6bbed:/# elixir -e 'IO.inspect File.rename("", "")'
{:error, :enoent}
```

Elixir 1.0.5:
```
$ docker run -it hexpm/elixir:1.0.5-erlang-18.3.4-debian-jessie-20200224 bash
root@cb24db2cab8b:/# elixir -e 'IO.inspect File.rename("", "")'
** (UndefinedFunctionError) undefined function: File.rename/2
    (elixir) File.rename("", "")
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
    (stdlib) erl_eval.erl:878: :erl_eval.expr_list/6
    (stdlib) erl_eval.erl:404: :erl_eval.expr/5
    (elixir) lib/code.ex:131: Code.eval_string/3
```

Reference:
- https://github.com/elixir-lang/elixir/commit/5d7a7ec7f9ad07944c46c1cbaf10efe923dc64c0 - v1.1.0-rc.0 onwards