### PR TITLE
More typing improvements

### DIFF
--- a/lib/elixir/lib/module/types.ex
+++ b/lib/elixir/lib/module/types.ex
@@ -57,7 +57,7 @@ defmodule Module.Types do
   end
 
   defp warnings_from_clause(args, guards, body, def_expr, stack, context) do
-    head_stack = push_expr_stack(def_expr, stack)
+    head_stack = Unify.push_expr_stack(def_expr, stack)
 
     with {:ok, _types, context} <- Pattern.of_head(args, guards, head_stack, context),
          {:ok, _type, context} <- Expr.of_expr(body, stack, context) do

--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -109,8 +109,7 @@ defmodule Module.Types.Expr do
 
   # var
   def of_expr(var, _stack, context) when is_var(var) do
-    {type, context} = new_var(var, context)
-    {:ok, type, context}
+    {:ok, get_var!(var, context), context}
   end
 
   # {left, right}
@@ -375,6 +374,13 @@ defmodule Module.Types.Expr do
     with {:ok, _pattern_type, context} <- Pattern.of_pattern(pattern, stack, context),
          # TODO: Check that of_guard/3 returns a boolean
          {:ok, _guard_type, context} <- Pattern.of_guard(guards_to_or(guards), stack, context),
+         {:ok, _expr_type, context} <- of_expr(expr, stack, context),
+         do: {:ok, context}
+  end
+
+  defp for_clause({:<<>>, _, [{:<-, _, [pattern, expr]}]}, stack, context) do
+    # TODO: the compiler guarantees pattern is a binary but we need to check expr is a binary
+    with {:ok, _pattern_type, context} <- Pattern.of_pattern(pattern, stack, context),
          {:ok, _expr_type, context} <- of_expr(expr, stack, context),
          do: {:ok, context}
   end

--- a/lib/elixir/lib/module/types/helpers.ex
+++ b/lib/elixir/lib/module/types/helpers.ex
@@ -26,16 +26,6 @@ defmodule Module.Types.Helpers do
   def get_meta(_other), do: []
 
   @doc """
-  Push expression to stack.
-
-  The expression stack is used to give the context where a type variable
-  was refined when show a type conflict error.
-  """
-  def push_expr_stack(expr, stack) do
-    %{stack | last_expr: expr}
-  end
-
-  @doc """
   Like `Enum.reduce/3` but only continues while `fun` returns `{:ok, acc}`
   and stops on `{:error, reason}`.
   """

--- a/lib/elixir/lib/module/types/unify.ex
+++ b/lib/elixir/lib/module/types/unify.ex
@@ -302,6 +302,23 @@ defmodule Module.Types.Unify do
   defp error(type, reason, context), do: {:error, {type, reason, context}}
 
   @doc """
+  Push expression to stack.
+
+  The expression stack is used to give the context where a type variable
+  was refined when show a type conflict error.
+  """
+  def push_expr_stack(expr, stack) do
+    %{stack | last_expr: expr}
+  end
+
+  @doc """
+  Gets a variable.
+  """
+  def get_var!(var, context) do
+    Map.fetch!(context.vars, var_name(var))
+  end
+
+  @doc """
   Adds a variable to the typing context and returns its type variable.
   If the variable has already been added, return the existing type variable.
   """

--- a/lib/elixir/test/elixir/module/types/map_test.exs
+++ b/lib/elixir/test/elixir/module/types/map_test.exs
@@ -297,7 +297,7 @@ defmodule Module.Types.MapTest do
     end
   end
 
-  test "with bound var keys" do
+  test "map creation with bound var keys" do
     assert quoted_expr(
              [atom, bool, true = var],
              [is_atom(atom) and is_boolean(bool)],
@@ -341,7 +341,7 @@ defmodule Module.Types.MapTest do
                ]}}
   end
 
-  test "with unbound var keys" do
+  test "map creation with unbound var keys" do
     assert quoted_expr(
              [var, struct],
              (


### PR DESCRIPTION
1. Move push_expr_stack to unify and keep helpers typing free

2. Add get_var! when accessing variables so it helps us find
   variables that have not been properly processed

3. Properly process all variables found missing on step 2