### PR TITLE
Reorganize documentation sections

### DIFF
--- a/lib/elixir/docs.exs
+++ b/lib/elixir/docs.exs
@@ -2,7 +2,7 @@
 [
   extras: Path.wildcard("lib/elixir/pages/*.md") ++ ["CHANGELOG.md"],
   groups_for_functions: [
-    Guards: & &1[:guard] == true
+    Guards: &(&1[:guard] == true)
   ],
   skip_undefined_reference_warnings_on: ["lib/elixir/pages/compatibility-and-deprecations.md"],
   groups_for_modules: [
@@ -53,11 +53,11 @@
       StringIO,
       System
     ],
-    "Calendar": [
-      Calendar,
-      Calendar.ISO,
-      Calendar.TimeZoneDatabase,
-      Calendar.UTCOnlyTimeZoneDatabase
+    "Code & Macros": [
+      Code,
+      Kernel.ParallelCompiler,
+      Macro,
+      Macro.Env
     ],
     "Processes & Applications": [
       Agent,
@@ -74,21 +74,23 @@
       Task,
       Task.Supervisor
     ],
+    Calendars: [
+      Calendar,
+      Calendar.ISO,
+      Calendar.TimeZoneDatabase,
+      Calendar.UTCOnlyTimeZoneDatabase
+    ],
     Protocols: [
+      Inspect.Algebra,
+      Inspect.Opts,
+      Protocol
+    ],
+    "Protocol Implementations": [
       Collectable,
       Enumerable,
       Inspect,
-      Inspect.Algebra,
-      Inspect.Opts,
       List.Chars,
-      Protocol,
       String.Chars
-    ],
-    "Code & Macros": [
-      Code,
-      Kernel.ParallelCompiler,
-      Macro,
-      Macro.Env
     ]
 
     ## Automatically detected groups


### PR DESCRIPTION
1. Protocols have been split into two separate sections: "Protocols" and "Protocol Implementations"
	 It was kind of difficult to spot what are the actual modules for working with protocols, the same goes for the implementations.

2. "Calendar" section renamed "Calendars". Follows the style of the other sections which are in plural.

3. Sections have been reordered:
	- "Calendars" section moved. I have the felling that Calendar and Protocols are not as general as the other modules, so I have moved them to the bottom of the list.
	- "Code & Macros" the same for this section which IMO had to be higher up in the list.

The section order looks like this:

- Basic Types
- Collections & Enumerables
- IO & System
- Code & Macros
- Processes & Applications
- Calendars
- Protocols
- Protocol Implementations
- Deprecated
- Exceptions

4. Run the formatter on docs.exs