### PR TITLE
 Optimize map udpates when there is no need for an update

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2182,6 +2182,7 @@ defmodule Kernel do
 
       {key, val}, acc ->
         case acc do
+          %{^key => ^val} -> acc
           %{^key => _} -> %{acc | key => val}
           _ -> acc
         end

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -322,7 +322,10 @@ defmodule Map do
   @spec replace(map, key, value) :: map
   def replace(map, key, value) do
     case map do
-      %{^key => _value} ->
+      %{^key => ^value} ->
+        map
+
+      %{^key => _current_value} ->
         put(map, key, value)
 
       %{} ->

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -208,6 +208,7 @@ defmodule KernelTest do
 
     user = struct(User, name: "meg")
     assert user == %User{name: "meg"}
+    assert struct(user, %{name: "meg"}) == user
 
     assert struct(user, unknown: "key") == user
     assert struct(user, %{name: "john"}) == %User{name: "john"}

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -193,6 +193,28 @@ defmodule MapTest do
              %{a: 1, b: 2, c: :x, d: 5}
   end
 
+  test "replace/3" do
+    map = %{c: 3, b: 2, a: 1}
+    assert Map.replace(map, :b, 10) == %{c: 3, b: 10, a: 1}
+    assert Map.replace(map, :a, 1) == map
+    assert Map.replace(map, :x, 1) == map
+    assert Map.replace(%{}, :x, 1) == %{}
+  end
+
+  test "replace!/3" do
+    map = %{c: 3, b: 2, a: 1}
+    assert Map.replace!(map, :b, 10) == %{c: 3, b: 10, a: 1}
+    assert Map.replace!(map, :a, 1) == map
+
+    assert_raise KeyError, "key :x not found in: %{a: 1, b: 2, c: 3}", fn ->
+      Map.replace!(map, :x, 10)
+    end
+
+    assert_raise KeyError, "key :x not found in: %{}", fn ->
+      Map.replace!(%{}, :x, 10)
+    end
+  end
+
   test "implements (almost) all functions in Keyword" do
     assert Keyword.__info__(:functions) -- Map.__info__(:functions) == [
              delete: 3,

--- a/lib/logger/lib/logger/handler.ex
+++ b/lib/logger/lib/logger/handler.ex
@@ -45,6 +45,7 @@ defmodule Logger.Handler do
     data =
       Enum.reduce(new_data, old_data, fn {k, v}, acc ->
         case acc do
+          %{^k => ^v} -> acc
           %{^k => _} -> %{acc | k => v}
           %{} -> acc
         end


### PR DESCRIPTION
I have meassured the changes in Map.replace/3 and when a new value
is different than the current value, there is no penalty,
but when the new value is the same as the current value, the existing
implementation is 50% slower than the one in this commit.