### PR TITLE
Improved performance of List.last/1

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -291,6 +291,7 @@ defmodule List do
   """
   @spec last([]) :: nil
   @spec last([elem, ...]) :: elem when elem: var
+  def last([_, _, _, _, _, _, _, _ | tail]), do: last(tail)
   def last([]), do: nil
   def last([head]), do: head
   def last([_ | tail]), do: last(tail)

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -291,7 +291,15 @@ defmodule List do
   """
   @spec last([]) :: nil
   @spec last([elem, ...]) :: elem when elem: var
-  def last([_, _, _, _, _, _, _, _ | tail]), do: last(tail)
+  def last([_, _, _, _, _, _, _, _ | [_ | _] = tail]) do
+    # In the function head above we "skip" 8 elements at a time
+    # which reduces the number of recursions and increases
+    # performance for lists with length greater than 8.
+    # The `[_ | _] = tail` pattern keeps us from returning nil
+    # when the length of the list is divisible by 8 and keeps
+    # us from having to build any lists at all.
+    last(tail)
+  end
   def last([]), do: nil
   def last([head]), do: head
   def last([_ | tail]), do: last(tail)

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -291,16 +291,7 @@ defmodule List do
   """
   @spec last([]) :: nil
   @spec last([elem, ...]) :: elem when elem: var
-  def last([_, _, _, _, _, _, _, _ | [_ | _] = tail]) do
-    # In the function head above we "skip" 8 elements at a time
-    # which reduces the number of recursions and increases
-    # performance for lists with length greater than 8.
-    # The `[_ | _] = tail` pattern keeps us from returning nil
-    # when the length of the list is divisible by 8 and keeps
-    # us from having to build any lists at all.
-    last(tail)
-  end
-
+  @compile {:inline, last: 1}
   def last([]), do: nil
   def last([head]), do: head
   def last([_ | tail]), do: last(tail)

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -300,6 +300,7 @@ defmodule List do
     # us from having to build any lists at all.
     last(tail)
   end
+
   def last([]), do: nil
   def last([head]), do: head
   def last([_ | tail]), do: last(tail)


### PR DESCRIPTION

Recently, I saw a Benchee benchmark between `List.last(list)` and `list |> Enum.reverse() |> hd()` with a list of 10_000 items, and, curiously, the reverse-then-hd was faster. The reverse-then-hd code used more memory than `List.last/1` due to building a new list, but was nearly twice as fast. I was curious if "skipping" some elements could improve the performance of `List.last/1`.

In the code below `list_last_orig/1` is the same implementation as `List.last/1` and `list_last8/1` is the same as `Last.last/1` except the for an additional first function head that pattern matches on and discards the first 8 elements of the list then recurses.

It turns out my idea worked. When the number of elements is 8 or more `list_last8/1` was always faster than `list_last_orig/1`. In about half of the benchmark runs (I ran many) `list_last8/1` was faster than `enum_reverse_hd/1`. The implementation of `list_last8/1` has the exact memory usage as `list_last_orig/1` because neither implementation builds a list. The performance gain of `list_last8/1` seems to increase with list length. There is likely an upper limit, but I didn't have time to figure it out. I think the performance gain is probably due to fewer recursions, but once again I didn't have time to investigate further.

In this implementation I suspect that the number 8 is arbitrary and that this approach can work for any number of additionally skipped elements, or an implementation-specific number of skipped elements. It had occured to me to try a expontential approach (32, 16, 8, 4, 2) as well, but I wanted some feedback before proceeding.

Code:
```elixir
  def list_last_orig([]), do: nil
  def list_last_orig([last]), do: last
  def list_last_orig([_ | rest]), do: list_last_orig(rest)

  def list_last8([_, _, _, _, _, _, _, _| rest]), do: list_last8(rest)
  def list_last8([]), do: nil
  def list_last8([last]), do: last
  def list_last8([_ | rest]), do: list_last8(rest)

  def enum_reverse_hd([]), do: nil
  def enum_reverse_hd(list), do: list |> Enum.reverse() |> hd()

  def bench do
    Benchee.run(%{
        "enum_reverse_hd" => fn list -> enum_reverse_hd(list) end,
        "list_last_orig" => fn list -> list_last_orig(list) end,
        "list_last8" => fn list -> list_last8(list) end,
      },
      inputs: %{
        "empty" => [],
        "one" => [1],
        "five" => Enum.to_list(1..5),
        "eight" => Enum.to_list(1..8),
        "1h" => Enum.to_list(1..100),
        "1k" => Enum.to_list(1..1_000),
        "10k" => Enum.to_list(1..10_000),
        "100k" => Enum.to_list(1..100_000)
      },
      time: 10,
      memory_time: 2
    )
    :ok
  end
```

Results:
```
[00:02:31] elbow-jason@DESKTOP-CDAKR89 /home/elbow-jason/Workspace/elixirs/bird  
> env MIX_ENV=prod iex -S mix
Erlang/OTP 23 [erts-11.0.4] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe]

Interactive Elixir (1.11.0-rc.0) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> Bird.bench
Operating System: Linux
CPU Information: Intel(R) Core(TM) i7-6700 CPU @ 3.40GHz
Number of Available Cores: 8
Available memory: 15.95 GB
Elixir 1.11.0-rc.0
Erlang 23.0.4

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
parallel: 1
inputs: 100k, 10k, 1h, 1k, eight, empty, five, one
Estimated total run time: 5.60 min

Benchmarking enum_reverse_hd with input 100k...
Benchmarking enum_reverse_hd with input 10k...
Benchmarking enum_reverse_hd with input 1h...
Benchmarking enum_reverse_hd with input 1k...
Benchmarking enum_reverse_hd with input eight...
Benchmarking enum_reverse_hd with input empty...
Benchmarking enum_reverse_hd with input five...
Benchmarking enum_reverse_hd with input one...
Benchmarking list_last8 with input 100k...
Benchmarking list_last8 with input 10k...
Benchmarking list_last8 with input 1h...
Benchmarking list_last8 with input 1k...
Benchmarking list_last8 with input eight...
Benchmarking list_last8 with input empty...
Benchmarking list_last8 with input five...
Benchmarking list_last8 with input one...
Benchmarking list_last_orig with input 100k...
Benchmarking list_last_orig with input 10k...
Benchmarking list_last_orig with input 1h...
Benchmarking list_last_orig with input 1k...
Benchmarking list_last_orig with input eight...
Benchmarking list_last_orig with input empty...
Benchmarking list_last_orig with input five...
Benchmarking list_last_orig with input one...

##### With input 100k #####
Name                      ips        average  deviation         median         99th %
list_last8             3.55 K      281.50 μs    ±34.50%      267.50 μs      462.24 μs
enum_reverse_hd        2.85 K      351.30 μs    ±63.77%      233.20 μs      878.25 μs
list_last_orig         2.03 K      493.70 μs    ±13.88%      478.60 μs      703.94 μs

Comparison: 
list_last8             3.55 K
enum_reverse_hd        2.85 K - 1.25x slower +69.80 μs
list_last_orig         2.03 K - 1.75x slower +212.20 μs

Memory usage statistics:

Name               Memory usage
list_last8                  0 B
enum_reverse_hd        945280 B - ∞ x memory usage +945280 B
list_last_orig              0 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

##### With input 10k #####
Name                      ips        average  deviation         median         99th %
enum_reverse_hd       33.05 K       30.26 μs    ±57.40%       23.60 μs       85.10 μs
list_last8            28.42 K       35.19 μs    ±24.55%       32.70 μs       75.40 μs
list_last_orig        20.12 K       49.70 μs    ±22.13%       46.30 μs      101.30 μs

Comparison: 
enum_reverse_hd       33.05 K
list_last8            28.42 K - 1.16x slower +4.93 μs
list_last_orig        20.12 K - 1.64x slower +19.45 μs

Memory usage statistics:

Name               Memory usage
enum_reverse_hd         69296 B
list_last8                  0 B - 0.00x memory usage -69296 B
list_last_orig              0 B - 0.00x memory usage -69296 B

**All measurements for memory usage were the same**

##### With input 1h #####
Name                      ips        average  deviation         median         99th %
list_last8             2.51 M      397.95 ns  ±6561.82%         300 ns        1100 ns
enum_reverse_hd        1.81 M      551.99 ns ±10171.02%         200 ns        4300 ns
list_last_orig         1.63 M      615.01 ns  ±4359.50%         400 ns        2300 ns

Comparison: 
list_last8             2.51 M
enum_reverse_hd        1.81 M - 1.39x slower +154.05 ns
list_last_orig         1.63 M - 1.55x slower +217.07 ns

Memory usage statistics:

Name               Memory usage
list_last8                  0 B
enum_reverse_hd          1184 B - ∞ x memory usage +1184 B
list_last_orig              0 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

##### With input 1k #####
Name                      ips        average  deviation         median         99th %
list_last8           255.20 K        3.92 μs   ±533.18%        3.50 μs       17.80 μs
enum_reverse_hd      247.12 K        4.05 μs   ±975.07%        3.30 μs       18.60 μs
list_last_orig       193.67 K        5.16 μs    ±56.34%        4.40 μs       19.20 μs

Comparison: 
list_last8           255.20 K
enum_reverse_hd      247.12 K - 1.03x slower +0.128 μs
list_last_orig       193.67 K - 1.32x slower +1.24 μs

Memory usage statistics:

Name               Memory usage
list_last8                  0 B
enum_reverse_hd          4464 B - ∞ x memory usage +4464 B
list_last_orig              0 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

##### With input eight #####
Name                      ips        average  deviation         median         99th %
list_last8             7.37 M      135.68 ns ±18592.88%           0 ns         700 ns
list_last_orig         6.73 M      148.57 ns ±19224.45%           0 ns        1000 ns
enum_reverse_hd        4.83 M      207.10 ns ±13906.57%           0 ns         800 ns

Comparison: 
list_last8             7.37 M
list_last_orig         6.73 M - 1.09x slower +12.88 ns
enum_reverse_hd        4.83 M - 1.53x slower +71.42 ns

Memory usage statistics:

Name               Memory usage
list_last8                  0 B
list_last_orig              0 B - 1.00x memory usage +0 B
enum_reverse_hd           128 B - ∞ x memory usage +128 B

**All measurements for memory usage were the same**

##### With input empty #####
Name                      ips        average  deviation         median         99th %
list_last8             8.19 M      122.05 ns ±20674.32%           0 ns         600 ns
list_last_orig         8.04 M      124.44 ns ±20662.73%           0 ns         500 ns
enum_reverse_hd        7.99 M      125.14 ns ±20694.15%           0 ns         500 ns

Comparison: 
list_last8             8.19 M
list_last_orig         8.04 M - 1.02x slower +2.40 ns
enum_reverse_hd        7.99 M - 1.03x slower +3.09 ns

Memory usage statistics:

Name               Memory usage
list_last8                  0 B
list_last_orig              0 B - 1.00x memory usage +0 B
enum_reverse_hd             0 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

##### With input five #####
Name                      ips        average  deviation         median         99th %
list_last_orig         7.31 M      136.88 ns ±18622.59%           0 ns         600 ns
list_last8             7.14 M      140.04 ns ±18110.17%           0 ns         800 ns
enum_reverse_hd        6.55 M      152.78 ns  ±9064.86%           0 ns         800 ns

Comparison: 
list_last_orig         7.31 M
list_last8             7.14 M - 1.02x slower +3.16 ns
enum_reverse_hd        6.55 M - 1.12x slower +15.90 ns

Memory usage statistics:

Name               Memory usage
list_last_orig              0 B
list_last8                  0 B - 1.00x memory usage +0 B
enum_reverse_hd            80 B - ∞ x memory usage +80 B

**All measurements for memory usage were the same**

##### With input one #####
Name                      ips        average  deviation         median         99th %
list_last8             8.10 M      123.46 ns ±20513.17%           0 ns         500 ns
list_last_orig         8.06 M      124.02 ns ±20397.69%           0 ns         500 ns
enum_reverse_hd        7.50 M      133.28 ns ±19046.73%           0 ns         600 ns

Comparison: 
list_last8             8.10 M
list_last_orig         8.06 M - 1.00x slower +0.56 ns
enum_reverse_hd        7.50 M - 1.08x slower +9.82 ns

Memory usage statistics:

Name               Memory usage
list_last8                  0 B
list_last_orig              0 B - 1.00x memory usage +0 B
enum_reverse_hd             0 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**
```