### PR TITLE
Update docs of Task.async_stream to talk more about side effects

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -461,7 +461,7 @@ defmodule Task do
       to false disables the need to buffer at the cost of removing ordering.
       This is also useful when you're using the tasks only for the side effects.
       Note that regardless of what `:ordered` is set to, the tasks will
-      process asynchronously. If you need to depend on the order of side effects,
+      process asynchronously. If you need to process elements in order,
       consider using `Enum.map/2` or `Enum.each/2` instead. Defaults to `true`.
 
     * `:timeout` - the maximum amount of time (in milliseconds or `:infinity`)

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -456,8 +456,9 @@ defmodule Task do
       at the same time. Defaults to `System.schedulers_online/0`.
 
     * `:ordered` - whether the results should be returned in the same order
-      as the input stream. This option is useful when you have large
-      streams and don't want to buffer results before they are delivered.
+      as the input stream. When the output is ordered, Elixir may need to
+      buffer results to emit them in the original order. Setting this option
+      to false disables the need to buffer at the cost of removing ordering.
       This is also useful when you're using the tasks only for the side effects.
       Note that regardless of what `:ordered` is set to, the tasks will
       process asynchronously. If you need to depend on the order of side effects,

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -458,8 +458,10 @@ defmodule Task do
     * `:ordered` - whether the results should be returned in the same order
       as the input stream. This option is useful when you have large
       streams and don't want to buffer results before they are delivered.
-      This is also useful when you're using the tasks for side effects.
-      Defaults to `true`.
+      This is also useful when you're using the tasks only for the side effects.
+      Note that regardless of what `:ordered` is set to, the tasks will
+      process asynchronously. If you need to depend on the order of side effects,
+      consider using `Enum.map/2` or `Enum.each/2` instead. Defaults to `true`.
 
     * `:timeout` - the maximum amount of time (in milliseconds or `:infinity`)
       each task is allowed to execute for. Defaults to `5000`.


### PR DESCRIPTION
Per the discussion [here](https://elixirforum.com/t/clarification-on-ordered-for-task-async-stream/34482/2) on the forums, I have updated the docs of `Task.async_stream` to be a little more clear on why you may want to use `ordered: false`. This is my first draft at improving the wording, so if it still seems unclear let me know and I can do a little more editing. 