### PR TITLE
Raise instead of crashing on when trying to use list operators in guards

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1354,12 +1354,9 @@ defmodule Kernel do
       [1, 2 | 3]
 
   """
-  @spec list ++ list :: list
-  defmacro left ++ right do
-    case __CALLER__.context do
-      :guard -> invalid_guard!("++")
-      _ -> quote(do: :erlang.++(unquote(left), unquote(right)))
-    end
+  @spec list ++ term :: maybe_improper_list
+  def left ++ right do
+    :erlang.++(left, right)
   end
 
   @doc """
@@ -1399,11 +1396,8 @@ defmodule Kernel do
 
   """
   @spec list -- list :: list
-  defmacro left -- right do
-    case __CALLER__.context do
-      :guard -> invalid_guard!("--")
-      _ -> quote(do: :erlang.--(unquote(left), unquote(right)))
-    end
+  def left -- right do
+    :erlang.--(left, right)
   end
 
   @doc """
@@ -5650,9 +5644,16 @@ defmodule Kernel do
 
   defp assert_no_match_or_guard_scope(context, exp) do
     case context do
-      :match -> invalid_match!(exp)
-      :guard -> invalid_guard!(exp)
-      _ -> :ok
+      :match ->
+        invalid_match!(exp)
+
+      :guard ->
+        raise ArgumentError,
+              "invalid expression in guard, #{exp} is not allowed in guards. " <>
+                "To learn more about guards, visit: https://hexdocs.pm/elixir/patterns-and-guards.html"
+
+      _ ->
+        :ok
     end
   end
 
@@ -5660,12 +5661,6 @@ defmodule Kernel do
     raise ArgumentError,
           "invalid expression in match, #{exp} is not allowed in patterns " <>
             "such as function clauses, case clauses or on the left side of the = operator"
-  end
-
-  defp invalid_guard!(exp) do
-    raise ArgumentError,
-          "invalid expression in guard, #{exp} is not allowed in guards. " <>
-            "To learn more about guards, visit: https://hexdocs.pm/elixir/patterns-and-guards.html"
   end
 
   # Helper to handle the :ok | :error tuple returned from :elixir_interpolation.unescape_tokens

--- a/lib/elixir/src/elixir_utils.erl
+++ b/lib/elixir/src/elixir_utils.erl
@@ -27,9 +27,9 @@ guard_op('orelse', 2) ->
 guard_op(Op, Arity) ->
   try erl_internal:op_type(Op, Arity) of
     arith -> true;
-    list  -> true;
     comp  -> true;
     bool  -> true;
+    list  -> false;
     send  -> false
   catch
     _:_ -> false

--- a/lib/elixir/test/elixir/kernel/guard_test.exs
+++ b/lib/elixir/test/elixir/kernel/guard_test.exs
@@ -310,13 +310,13 @@ defmodule Kernel.GuardTest do
         end
       end
 
-      assert_raise ArgumentError, ~r"invalid expression in guard, \+\+ is not allowed", fn ->
+      assert_raise CompileError, "cannot invoke remote function :erlang.++/2 inside guards", fn ->
         defmodule ListSubtractionUsage do
           defguard foo(list) when list ++ []
         end
       end
 
-      assert_raise ArgumentError, ~r"invalid expression in guard, -- is not allowed", fn ->
+      assert_raise CompileError, "cannot invoke remote function :erlang.--/2 inside guards", fn ->
         defmodule ListSubtractionUsage do
           defguard foo(list) when list -- []
         end

--- a/lib/elixir/test/elixir/kernel/guard_test.exs
+++ b/lib/elixir/test/elixir/kernel/guard_test.exs
@@ -310,6 +310,18 @@ defmodule Kernel.GuardTest do
         end
       end
 
+      assert_raise ArgumentError, ~r"invalid expression in guard, \+\+ is not allowed", fn ->
+        defmodule ListSubtractionUsage do
+          defguard foo(list) when list ++ []
+        end
+      end
+
+      assert_raise ArgumentError, ~r"invalid expression in guard, -- is not allowed", fn ->
+        defmodule ListSubtractionUsage do
+          defguard foo(list) when list -- []
+        end
+      end
+
       assert_raise CompileError, ~r"invalid expression in guard", fn ->
         defmodule LocalCallUsage do
           defguard foo(local, call) when local.(call)

--- a/lib/elixir/test/elixir/kernel/guard_test.exs
+++ b/lib/elixir/test/elixir/kernel/guard_test.exs
@@ -310,13 +310,13 @@ defmodule Kernel.GuardTest do
         end
       end
 
-      assert_raise CompileError, "cannot invoke remote function :erlang.++/2 inside guards", fn ->
+      assert_raise CompileError, ~r"cannot invoke remote function :erlang.++/2 inside guards", fn ->
         defmodule ListSubtractionUsage do
           defguard foo(list) when list ++ []
         end
       end
 
-      assert_raise CompileError, "cannot invoke remote function :erlang.--/2 inside guards", fn ->
+      assert_raise CompileError, ~r"cannot invoke remote function :erlang.--/2 inside guards", fn ->
         defmodule ListSubtractionUsage do
           defguard foo(list) when list -- []
         end

--- a/lib/elixir/test/elixir/kernel/guard_test.exs
+++ b/lib/elixir/test/elixir/kernel/guard_test.exs
@@ -310,13 +310,13 @@ defmodule Kernel.GuardTest do
         end
       end
 
-      assert_raise CompileError, ~r"cannot invoke remote function :erlang.++/2 inside guards", fn ->
+      assert_raise CompileError, ~r"cannot invoke remote function :erlang\.\+\+/2 inside guards", fn ->
         defmodule ListSubtractionUsage do
           defguard foo(list) when list ++ []
         end
       end
 
-      assert_raise CompileError, ~r"cannot invoke remote function :erlang.--/2 inside guards", fn ->
+      assert_raise CompileError, ~r"cannot invoke remote function :erlang\.\-\-/2 inside guards", fn ->
         defmodule ListSubtractionUsage do
           defguard foo(list) when list -- []
         end

--- a/lib/elixir/test/elixir/kernel/guard_test.exs
+++ b/lib/elixir/test/elixir/kernel/guard_test.exs
@@ -310,17 +310,21 @@ defmodule Kernel.GuardTest do
         end
       end
 
-      assert_raise CompileError, ~r"cannot invoke remote function :erlang\.\+\+/2 inside guards", fn ->
-        defmodule ListSubtractionUsage do
-          defguard foo(list) when list ++ []
-        end
-      end
+      assert_raise CompileError,
+                   ~r"cannot invoke remote function :erlang\.\+\+/2 inside guards",
+                   fn ->
+                     defmodule ListSubtractionUsage do
+                       defguard foo(list) when list ++ []
+                     end
+                   end
 
-      assert_raise CompileError, ~r"cannot invoke remote function :erlang\.\-\-/2 inside guards", fn ->
-        defmodule ListSubtractionUsage do
-          defguard foo(list) when list -- []
-        end
-      end
+      assert_raise CompileError,
+                   ~r"cannot invoke remote function :erlang\.\-\-/2 inside guards",
+                   fn ->
+                     defmodule ListSubtractionUsage do
+                       defguard foo(list) when list -- []
+                     end
+                   end
 
       assert_raise CompileError, ~r"invalid expression in guard", fn ->
         defmodule LocalCallUsage do


### PR DESCRIPTION
https://github.com/elixir-lang/elixir/issues/10361.

This pull request adds the functionality to raise instead of crashing when trying to use list operators in guard clauses.

```
❯ bin/iex                                                                                                                                                                                                                                                                                                     19:57:43
Erlang/OTP 23 [erts-11.0.2] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [hipe] [dtrace]

Interactive Elixir (1.12.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> defmodule Foo do
...(1)>   def check(value) do
...(1)>     case value do
...(1)>       list when list ++ [1] -> list
...(1)>     end
...(1)>   end
...(1)> end
** (ArgumentError) invalid expression in guard, ++ is not allowed in guards. To learn more about guards, visit: https://hexdocs.pm/elixir/patterns-and-guards.html
    (elixir 1.12.0-dev) lib/kernel.ex:5662: Kernel.invalid_guard!/1
    (elixir 1.12.0-dev) expanding macro: Kernel.++/2
    iex:4: Foo.check/1
```