### PR TITLE
Use timer function instead of manually calculating milliseconds

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -242,8 +242,7 @@ defmodule GenServer do
         end
 
         defp schedule_work do
-          # In 2 hours
-          Process.send_after(self(), :work, 2 * 60 * 60 * 1000)
+          Process.send_after(self(), :work, :timer.hours(2))
         end
       end
 

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -242,7 +242,9 @@ defmodule GenServer do
         end
 
         defp schedule_work do
-          Process.send_after(self(), :work, :timer.hours(2))
+          # We schedule the work to happen in 2 hours (written in milliseconds).
+          # Alternatively, one might write :timer.hours(2)
+          Process.send_after(self(), :work, 2 * 60 * 60 * 1000)
         end
       end
 


### PR DESCRIPTION
If we use the function, we don't need the comment explaining that the millis make up for 2 hours.