### PR TITLE
Fix copy paste mistake in String.capitalize docs

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -874,7 +874,7 @@ defmodule String do
 
   `mode` may be `:default`, `:ascii` or `:greek`. The `:default` mode considers
   all non-conditional transformations outlined in the Unicode standard. `:ascii`
-  uppercases only the letters A to Z. `:greek` includes the context sensitive
+  capitalizes only the letters A to Z. `:greek` includes the context sensitive
   mappings found in Greek.
 
   ## Examples

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -874,7 +874,7 @@ defmodule String do
 
   `mode` may be `:default`, `:ascii` or `:greek`. The `:default` mode considers
   all non-conditional transformations outlined in the Unicode standard. `:ascii`
-  lowercases only the letters A to Z. `:greek` includes the context sensitive
+  uppercases only the letters A to Z. `:greek` includes the context sensitive
   mappings found in Greek.
 
   ## Examples


### PR DESCRIPTION
String.capitalize uppercases first letter.
Looks like a copy-paste mistake from the function above it :)