### PR TITLE
Give capability to take over the shell without asking the user

### DIFF
--- a/lib/iex/lib/iex/pry.ex
+++ b/lib/iex/lib/iex/pry.ex
@@ -59,7 +59,7 @@ defmodule IEx.Pry do
       end
 
     # We cannot use colors because IEx may be off
-    case IEx.Broker.take_over(location, whereami, [evaluator: self()] ++ opts) do
+    case IEx.Broker.take_over([location, whereami], [evaluator: self()] ++ opts) do
       {:ok, server, group_leader} ->
         IEx.Evaluator.init(:no_ack, server, group_leader, opts)
 


### PR DESCRIPTION
`iex` v1.10 (v1.9 was oldest I tried) had a capability to takeover in a way that a user was not prompted.

After changes in commit 9413dcc57336a9bbac1a6d12ad2c0e32c929754b this stopped working for me, and the question is always asked.

In the code before above change when `identifier=true` i got the desired effect in a useful trick allowing to integrate elixir shell with legacy (non-elixir) interfaces, all in one terminal.

For interested and to motivate having such capability in IEx code in short how the idea was realized:
When `iex` starts, a line in `.iex.exs` calls some bootstrap code to plug a custom evaluator. That evaluator is really a bridge between the iex server and the standard elixir evaluator. When that bridge gets an expression to evaluate starting with an invalid character (.e.g. dot) for elixir syntax, it directs such expression to non-elixir evaluator associated with the legacy interface.

NOTE: I do not use `IEx.Broker.take_over/2` directly, but I do similar what is does.

Changes in short:
- retained name, the _identifier_ (_take_identifier_ in server code), can either be `iodata` (`[location, whereami]`) or `boolean`
- explicit use of boolean in `IEx.Server.take_over?/4`