### PR TITLE
Add :turkic mode option to String case functions

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -286,7 +286,7 @@ defmodule String do
   @typedoc "Pattern used in functions like `replace/4` and `split/3`"
   @type pattern :: t | [t] | :binary.cp()
 
-  @conditional_mappings [:greek]
+  @conditional_mappings [:greek, :turkic]
 
   @doc """
   Checks if a string contains only printable characters up to `character_limit`.
@@ -759,10 +759,10 @@ defmodule String do
   @doc """
   Converts all characters in the given string to uppercase according to `mode`.
 
-  `mode` may be `:default`, `:ascii` or `:greek`. The `:default` mode considers
+  `mode` may be `:default`, `:ascii`, `:greek` or `:turkic`. The `:default` mode considers
   all non-conditional transformations outlined in the Unicode standard. `:ascii`
   uppercases only the letters a to z. `:greek` includes the context sensitive
-  mappings found in Greek.
+  mappings found in Greek. `:turkic` properly handles the letter i with the dotless variant.
 
   ## Examples
 
@@ -782,8 +782,16 @@ defmodule String do
       iex> String.upcase("olá", :ascii)
       "OLá"
 
+  And `:turkic` properly handles the letter i with the dotless variant:
+
+      iex> String.upcase("ıi")
+      "II"
+
+      iex> String.upcase("ıi", :turkic)
+      "Iİ"
+
   """
-  @spec upcase(t, :default | :ascii | :greek) :: t
+  @spec upcase(t, :default | :ascii | :greek | :turkic) :: t
   def upcase(string, mode \\ :default)
 
   def upcase("", _mode) do
@@ -811,10 +819,10 @@ defmodule String do
   @doc """
   Converts all characters in the given string to lowercase according to `mode`.
 
-  `mode` may be `:default`, `:ascii` or `:greek`. The `:default` mode considers
+  `mode` may be `:default`, `:ascii`, `:greek` or `:turkic`. The `:default` mode considers
   all non-conditional transformations outlined in the Unicode standard. `:ascii`
   lowercases only the letters A to Z. `:greek` includes the context sensitive
-  mappings found in Greek.
+  mappings found in Greek. `:turkic` properly handles the letter i with the dotless variant.
 
   ## Examples
 
@@ -834,7 +842,7 @@ defmodule String do
       iex> String.downcase("OLÁ", :ascii)
       "olÁ"
 
-  And `:greek` properly handles the context sensitive sigma in Greek:
+  The `:greek` mode properly handles the context sensitive sigma in Greek:
 
       iex> String.downcase("ΣΣ")
       "σσ"
@@ -842,8 +850,16 @@ defmodule String do
       iex> String.downcase("ΣΣ", :greek)
       "σς"
 
+  And `:turkic` properly handles the letter i with the dotless variant:
+
+      iex> String.downcase("Iİ")
+      "ii̇"
+
+      iex> String.downcase("Iİ", :turkic)
+      "ıi"
+
   """
-  @spec downcase(t, :default | :ascii | :greek) :: t
+  @spec downcase(t, :default | :ascii | :greek | :turkic) :: t
   def downcase(string, mode \\ :default)
 
   def downcase("", _mode) do
@@ -872,10 +888,10 @@ defmodule String do
   Converts the first character in the given string to
   uppercase and the remainder to lowercase according to `mode`.
 
-  `mode` may be `:default`, `:ascii` or `:greek`. The `:default` mode considers
+  `mode` may be `:default`, `:ascii`, `:greek` or `:turkic`. The `:default` mode considers
   all non-conditional transformations outlined in the Unicode standard. `:ascii`
   capitalizes only the letters A to Z. `:greek` includes the context sensitive
-  mappings found in Greek.
+  mappings found in Greek. `:turkic` properly handles the letter i with the dotless variant.
 
   ## Examples
 
@@ -889,7 +905,7 @@ defmodule String do
       "Olá"
 
   """
-  @spec capitalize(t, :default | :ascii | :greek) :: t
+  @spec capitalize(t, :default | :ascii | :greek | :turkic) :: t
   def capitalize(string, mode \\ :default)
 
   def capitalize(<<char, rest::binary>>, :ascii) do

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -153,6 +153,10 @@ defmodule StringTest do
     assert String.upcase("olá", :ascii) == "OLá"
   end
 
+  test "upcase/1 with turkic" do
+    assert String.upcase("ıi", :turkic) == "Iİ"
+  end
+
   test "downcase/1" do
     assert String.downcase("123 ABcD 456 EfG HIJ ( %$#) KL MNOP @ QRST = -_ UVWXYZ") ==
              "123 abcd 456 efg hij ( %$#) kl mnop @ qrst = -_ uvwxyz"
@@ -185,6 +189,12 @@ defmodule StringTest do
     assert String.downcase("OLÁ", :ascii) == "olÁ"
   end
 
+  test "downcase/1 with turkic" do
+    assert String.downcase("Iİ", :turkic) == "ıi"
+    assert String.downcase("İ", :turkic) == "i"
+    assert String.downcase("İ") == "i̇"
+  end
+
   test "capitalize/1" do
     assert String.capitalize("") == ""
     assert String.capitalize("abc") == "Abc"
@@ -208,6 +218,11 @@ defmodule StringTest do
   test "capitalize/1 with ascii" do
     assert String.capitalize("àáâ", :ascii) == "àáâ"
     assert String.capitalize("aáA", :ascii) == "Aáa"
+  end
+
+  test "capitalize/1 with turkic" do
+    assert String.capitalize("iii", :turkic) == "İii"
+    assert String.capitalize("ııı", :turkic) == "Iıı"
   end
 
   test "replace_leading/3" do

--- a/lib/elixir/unicode/properties.ex
+++ b/lib/elixir/unicode/properties.ex
@@ -160,6 +160,27 @@ defmodule String.Casing do
 
   # Downcase
 
+  # Letter I variants for Turkic languages
+  @letter_I <<0x0049::utf8>>
+  @dotless_letter_i <<0x0131::utf8>>
+  @letter_i <<0x0069::utf8>>
+  @letter_I_dot_above <<0x0130::utf8>>
+  @combining_dot_above <<0x0307::utf8>>
+
+  # Turkic İ -> i
+  def downcase(<<unquote(@letter_I), unquote(@combining_dot_above), rest::bits>>, acc, :turkic) do
+    downcase(rest, [@letter_i | acc], :turkic)
+  end
+
+  def downcase(<<unquote(@letter_I_dot_above), rest::bits>>, acc, :turkic) do
+    downcase(rest, [@letter_i | acc], :turkic)
+  end
+
+  # Turkic I -> ı
+  def downcase(<<unquote(@letter_I), rest::bits>>, acc, :turkic) do
+    downcase(rest, [@dotless_letter_i | acc], :turkic)
+  end
+
   @conditional_downcase [
     sigma = <<0x03A3::utf8>>
   ]
@@ -237,6 +258,11 @@ defmodule String.Casing do
 
   # Upcase
 
+  # Turkic i -> İ
+  def upcase(<<unquote(@letter_i), rest::bits>>, acc, :turkic) do
+    upcase(rest, [@letter_I_dot_above | acc], :turkic)
+  end
+
   for {codepoint, upper, _lower, _title} <- codes, upper && upper != codepoint do
     def upcase(<<unquote(codepoint), rest::bits>>, acc, mode) do
       upcase(rest, [unquote(upper) | acc], mode)
@@ -252,6 +278,11 @@ defmodule String.Casing do
   # Titlecase once
 
   def titlecase_once("", _mode), do: {"", ""}
+
+  # Turkic i -> İ
+  def titlecase_once(<<@letter_i, rest::binary>>, :turkic) do
+    {@letter_I_dot_above, rest}
+  end
 
   for {codepoint, _upper, _lower, title} <- codes, title && title != codepoint do
     def titlecase_once(unquote(codepoint) <> rest, _mode) do


### PR DESCRIPTION
EDIT: ~This PR fixes a little error in the current unconditional mapping of the "Latin capital letter i with dot above" in SpecialCasing.txt which has an error.~ SpecialCasing.txt is left to its original since its generated by Unicode.

It also adds proper handling of case manipulation of the letter i and its dotless version existing in the Turkish language.
Handling is now done according to the SpecialCasing.txt from here http://www.unicode.org/Public/UCD/latest/ucd/SpecialCasing.txt