### PR TITLE
Take --dot-iex into account after shell respawn

### DIFF
--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -242,8 +242,8 @@ defmodule IEx.Server do
     end
   end
 
-  defp handle_take_over({:respawn, evaluator}, _state, evaluator, evaluator_ref, input, _callback) do
-    rerun([], evaluator, evaluator_ref, input)
+  defp handle_take_over({:respawn, evaluator}, state, evaluator, evaluator_ref, input, _callback) do
+    rerun(state.evaluator_options, evaluator, evaluator_ref, input)
   end
 
   defp handle_take_over({:continue, evaluator}, state, evaluator, evaluator_ref, input, _callback) do
@@ -254,18 +254,18 @@ defmodule IEx.Server do
 
   defp handle_take_over(
          {:DOWN, evaluator_ref, :process, evaluator, :normal},
-         _state,
+         state,
          evaluator,
          evaluator_ref,
          input,
          _callback
        ) do
-    rerun([], evaluator, evaluator_ref, input)
+    rerun(state.evaluator_options, evaluator, evaluator_ref, input)
   end
 
   defp handle_take_over(
          {:DOWN, evaluator_ref, :process, evaluator, reason},
-         _state,
+         state,
          evaluator,
          evaluator_ref,
          input,
@@ -281,7 +281,7 @@ defmodule IEx.Server do
         io_error("** (IEx.Error) #{type} when printing EXIT message: #{inspect(detail)}")
     end
 
-    rerun([], evaluator, evaluator_ref, input)
+    rerun(state.evaluator_options, evaluator, evaluator_ref, input)
   end
 
   defp handle_take_over(_, state, _evaluator, _evaluator_ref, _input, callback) do


### PR DESCRIPTION
When the shell is respawned, as a result of `respawn/0`,` continue/0`, or taking a signal, the file given as `--dot-iex` argument is not evaluated. Worse, the default file (`./iex.exs` or `~/.iex.exs`) will be used if present.

The behaviour it is not consistent with normal use (no option and the default file).