### PR TITLE
Do not call Logger.configure on config_change callback.

### DIFF
--- a/lib/logger/lib/logger/app.ex
+++ b/lib/logger/lib/logger/app.ex
@@ -62,11 +62,9 @@ defmodule Logger.App do
 
   @doc false
   def config_change(changed, _new, _removed) do
-    # All other config has already been persisted
-    # NOTE: when sending other config this function might deadlock
+    # All other config has already been persisted, we only need to
+    # update the level and reload the logger state.
     Logger.configure(Keyword.take(changed, [:level]))
-
-    ## TODO: propagate config update without blocking calls to application_controller
   end
 
   @doc """

--- a/lib/logger/lib/logger/app.ex
+++ b/lib/logger/lib/logger/app.ex
@@ -62,7 +62,18 @@ defmodule Logger.App do
 
   @doc false
   def config_change(changed, _new, _removed) do
-    Logger.configure(changed)
+    case changed[:level] do
+      nil ->
+        :ok
+
+      level ->
+        :logger.set_primary_config(
+          :level,
+          Logger.Handler.elixir_level_to_erlang_level(level)
+        )
+    end
+
+    ## TODO: propagate config update without blocking calls to application_controller
   end
 
   @doc """

--- a/lib/logger/lib/logger/app.ex
+++ b/lib/logger/lib/logger/app.ex
@@ -62,16 +62,9 @@ defmodule Logger.App do
 
   @doc false
   def config_change(changed, _new, _removed) do
-    case changed[:level] do
-      nil ->
-        :ok
-
-      level ->
-        :logger.set_primary_config(
-          :level,
-          Logger.Handler.elixir_level_to_erlang_level(level)
-        )
-    end
+    # All other config has already been persisted
+    # NOTE: when sending other config this function might deadlock
+    Logger.configure(Keyword.take(changed, [:level]))
 
     ## TODO: propagate config update without blocking calls to application_controller
   end

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -647,7 +647,8 @@ defmodule LoggerTest do
     :ok = Logger.configure(level: :debug)
 
     try do
-      assert Logger.App.config_change([level: :error], [], []) === :ok
+      assert Application.put_env(:logger, :level, :error) === :ok
+      assert :application_controller.config_change(logger: [level: :debug]) === :ok
       assert Logger.level() === :error
     after
       Logger.configure(level: :debug)


### PR DESCRIPTION
## The issue

The `config_change` callback is called from `application_controller` process,
which is receiving env updates on `Application.put_env`.
`Logger.configure` does a blocking call to the `Logger` process, which calls
`Application.put_env`

This causes a crash on logger config update.
If logs are synchronous, failing logger will call itself to report a crash and get stuck.

The issue happens in live upgrade with releases and due to high frequency of logs
the Logger switches to the sync mode and gets blocked, blocking all logging processes.

## The change

Removed `Logger.config` from config change. It cannot work anyway.

Main purpose of Logger.configure is to put env into the app config and
`config_change` is called when env is already updated.

## To reproduce the issue

```
> iex
Erlang/OTP 23 [erts-11.0.1] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [hipe]

Interactive Elixir (1.10.4) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> :application_controller.config_change([logger: [sync_threshold: 10]])
iex(2)>
15:57:53.153 [error] :gen_event handler Logger.Config installed in Logger terminating
** (stop) exited in: :gen_server.call(:application_controller, {:set_env, :logger, :sync_threshold, 20, []}, 5000)
    ** (EXIT) time out
Last message: {:configure, [sync_threshold: 20]}
State: {{:counters, {:atomics, #Reference<0.1770916926.3473539076.1817>}}, :log, 500, 30000}

15:57:53.157 [error] GenServer #PID<0.104.0> terminating
** (stop) {:EXIT, {:timeout, {:gen_server, :call, [:application_controller, {:set_env, :logger, :sync_threshold, 20, []}, 5000]}}}
Last message: {:gen_event_EXIT, Logger.Config, {:EXIT, {:timeout, {:gen_server, :call, [:application_controller, {:set_env, :logger, :sync_threshold, 20, []}, 5000]}}}}
State: Logger.Config

```


If synchronous threshold is in effect it may cause a deadlock:

```
iex(5)> Logger.configure([{:sync_threshold, 0}])
:ok
:application_controller.config_change([logger: [sync_threshold: 10]])
{:error,
 [
   EXIT: {:timeout,
    {:gen_event, :call,
     [Logger, Logger.Config, {:configure, [sync_threshold: 0]}]}}
 ]}
iex(4)> pid = spawn(fn -> Logger.info("foo") end)
iex(5)> Process.info(pid)
[
  current_function: {:gen, :do_call, 4},
  initial_call: {:erlang, :apply, 2},
  status: :waiting,
  message_queue_len: 0,
  links: [],
  dictionary: [],
  trap_exit: false,
  error_handler: :error_handler,
  priority: :normal,
  group_leader: #PID<0.66.0>,
  total_heap_size: 609,
  heap_size: 233,
  stack_size: 28,
  reductions: 456,
  garbage_collection: [
    max_heap_size: %{error_logger: true, kill: true, size: 0},
    min_bin_vheap_size: 46422,
    min_heap_size: 233,
    fullsweep_after: 65535,
    minor_gcs: 3
  ],
  suspending: []
]
iex(6)> Process.info(Process.whereis(Logger))
[
  registered_name: Logger,
  current_function: {:gen, :do_call, 4},
  initial_call: {:proc_lib, :init_p, 5},
  status: :waiting,
  message_queue_len: 3,
  links: [#PID<0.104.0>, #PID<0.106.0>, #PID<0.102.0>],
  dictionary: [
    "$initial_call": {:gen_event, :init_it, 6},
    "$ancestors": [Logger.Supervisor, #PID<0.101.0>]
  ],
  trap_exit: true,
  error_handler: :error_handler,
  priority: :normal,
  group_leader: #PID<0.100.0>,
  total_heap_size: 1055,
  heap_size: 987,
  stack_size: 51,
  reductions: 26611,
  garbage_collection: [
    max_heap_size: %{error_logger: true, kill: true, size: 0},
    min_bin_vheap_size: 46422,
    min_heap_size: 233,
    fullsweep_after: 65535,
    minor_gcs: 0
  ],
  suspending: []
]
```

As you can see, the `Logger` process is stuck in `:gen.do_call`.


## To follow up

To properly handle `config_change` if that's necessary, the app should call some other handler which would update the internal state, but not call `Application.put_env`
