### PR TITLE
Remove compilation warning in doctest in Kernel.binary_part/3

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -307,7 +307,7 @@ defmodule Kernel do
 
   An `ArgumentError` is raised when the length is outside of the binary:
 
-      iex> binary_part("Hello", 0, 10)
+      binary_part("Hello", 0, 10)
       ** (ArgumentError) argument error
 
   """


### PR DESCRIPTION
> warning: this expression will fail with ArgumentError
>   (for doctest at) lib/kernel.ex:310

It was introduced in  538a9a3 (#10370)