### PR TITLE
Updated Enumerable implementation for Stream

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1584,7 +1584,7 @@ defmodule Stream do
 end
 
 defimpl Enumerable, for: Stream do
-  @compile :inline_list_funs
+  @compile :inline_list_funcs
 
   def count(_lazy), do: {:error, __MODULE__}
 


### PR DESCRIPTION
`:inline_list_funs` → `:inline_list_funcs` as per https://erlang.org/doc/man/compile.html#inlining-of-list-functions.

I believe this is the only instance.