### PR TITLE
Move printing test seed to beginning of test run

### DIFF
--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -28,6 +28,7 @@ defmodule ExUnit.CLIFormatter do
   end
 
   def handle_cast({:suite_started, _opts}, config) do
+    IO.puts("\nRandomized with seed #{config.seed}")
     {:noreply, config}
   end
 
@@ -283,8 +284,6 @@ defmodule ExUnit.CLIFormatter do
       config.invalid_counter > 0 -> IO.puts(invalid(message, config))
       true -> IO.puts(success(message, config))
     end
-
-    IO.puts("\nRandomized with seed #{config.seed}")
   end
 
   defp if_true(value, false, _fun), do: value

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -227,7 +227,7 @@ defmodule Mix.Tasks.TestTest do
       in_fixture("test_stale", fn ->
         port = mix_port(~w[test --stale --listen-on-stdin])
 
-        assert receive_until_match(port, "seed", "") =~ "2 tests"
+        assert receive_until_match(port, "failures", "") =~ "2 tests"
 
         Port.command(port, "\n")
 
@@ -255,7 +255,7 @@ defmodule Mix.Tasks.TestTest do
 
         Port.command(port, "\n")
 
-        assert receive_until_match(port, "seed", "") =~ "2 tests"
+        assert receive_until_match(port, "failures", "") =~ "2 tests"
 
         File.write!("test/b_test_stale.exs", """
         defmodule BTest do
@@ -284,7 +284,7 @@ defmodule Mix.Tasks.TestTest do
 
         Port.command(port, "\n")
 
-        assert receive_until_match(port, "seed", "") =~ "2 tests"
+        assert receive_until_match(port, "failures", "") =~ "2 tests"
       end)
     end
   end
@@ -382,23 +382,27 @@ defmodule Mix.Tasks.TestTest do
                Paths given to "mix test" did not match any directory/file: apps/unknown_app/test
                """
 
-        output = mix(["test", "apps/bar/test/bar_tests.exs"])
+        output = mix(["test", "apps/bar/test/bar_tests.exs", "--seed", "1"])
 
         assert output =~ """
                ==> bar
+
+               Randomized with seed 1
                .
                """
 
         refute output =~ "==> foo"
         refute output =~ "Paths given to \"mix test\" did not match any directory/file"
 
-        output = mix(["test", "apps/bar/test/bar_tests.exs:10"])
+        output = mix(["test", "apps/bar/test/bar_tests.exs:10", "--seed", "1"])
 
         assert output =~ """
                ==> bar
                Excluding tags: [:test]
                Including tags: [line: \"10\"]
 
+
+               Randomized with seed 1
                .
                """
 


### PR DESCRIPTION
Came across this proposal on the forums to move printing the seed of the
test suite to the beginning of the test run. This was actually
something I wished for recently when encountering a weird issue
in our codebase which caused all of our non async tests to fail and
each synchronous test would take 60 seconds before timing out. With
a few hundred synchronous tests this took quite some time for the
suite to finish and I wanted to grab the seed to replicate it.

https://groups.google.com/g/elixir-lang-core/c/sP8DiY1zMFQ

## Example
```
==> ex_unit (ex_unit)

Randomized with seed 411332
................................................................................................................................................................................................................................................................................................................................................................................
```