### PR TITLE
Add List.intersection/2

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -637,6 +637,28 @@ defmodule List do
   end
 
   @doc """
+  Returns a list containing only the elements that `list1` and `list2` have in
+  common.
+
+  ## Examples
+
+      iex> List.intersection([1, 2, 3, 4, 5], [3, 4, 5, 6, 7])
+      [3, 4, 5]
+
+      iex> List.intersection([4, 2, 5, 3, 1], [12, 1, 9, 5, 0])
+      [5, 1]
+
+      iex> List.intersection([1, 2, 3, 4, 5], [6, 7, 8, 9, 0])
+      []
+
+  """
+  @spec intersection(list(), list()) :: list()
+  def intersection(list1, list2) do
+    temp = list1 -- list2
+    list1 -- temp
+  end
+
+  @doc """
   Returns a list with a replaced value at the specified `index`.
 
   Negative indices indicate an offset from the end of the `list`.

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -335,4 +335,25 @@ defmodule ListTest do
       assert List.ascii_printable?('abc' ++ ?d, 3)
     end
   end
+
+  describe "intersection/2" do
+    test "returns the common elements" do
+      list1 = Enum.to_list(1..10)
+      list2 = Enum.to_list(5..15)
+
+      assert List.intersection(list1, list2) == [5, 6, 7, 8, 9, 10]
+      assert List.intersection(list2, list1) == [5, 6, 7, 8, 9, 10]
+      assert List.intersection(list1, [0, 2, 4, 6, 8, 10, 12]) == [2, 4, 6, 8, 10]
+      assert List.intersection(list1, [0, 12, 4, 8, 2, 10, 6]) == [2, 4, 6, 8, 10]
+      assert List.intersection([0, 12, 4, 8, 2, 10, 6], list1) == [4, 8, 2, 10, 6]
+      assert List.intersection(list1, list1) == list1
+    end
+
+    test "when there are no common elements, returns an empty list" do
+      assert List.intersection([1, 2, 3], [4, 5, 6]) == []
+      assert List.intersection([1, 2, 3], []) == []
+      assert List.intersection([], [1, 2, 3]) == []
+      assert List.intersection([], []) == []
+    end
+  end
 end


### PR DESCRIPTION
Add `List.intersection/2` that returns a list containing only common elements in two lists. 

Inspired by https://hexdocs.pm/miss/Miss.List.html#intersection/2. 