### PR TITLE
Fix returning errors in Module.Types.Expr.of_expr

### DIFF
--- a/lib/elixir/lib/module/types/expr.ex
+++ b/lib/elixir/lib/module/types/expr.ex
@@ -254,7 +254,7 @@ defmodule Module.Types.Expr do
 
     case result do
       :ok -> {:ok, :dynamic, context}
-      {:error, reason} -> {:error, reason}
+      :error -> {:error, context}
     end
   end
 
@@ -278,7 +278,7 @@ defmodule Module.Types.Expr do
 
     case result do
       :ok -> {:ok, :dynamic, context}
-      {:error, reason} -> {:error, reason}
+      :error -> {:error, context}
     end
   end
 


### PR DESCRIPTION
Fixes small mistake detected by dialyzer:

```
lib/module/types/expr.ex:257: The pattern 
          {'error', _reason@1} can never match the type 
          'error'

lib/module/types/expr.ex:281: The pattern 
          {'error', _reason@1} can never match the type 
          'error'
```