### PR TITLE
Rename a variable in Inspect documentation

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -26,8 +26,8 @@ defprotocol Inspect do
       defimpl Inspect, for: MapSet do
         import Inspect.Algebra
 
-        def inspect(dict, opts) do
-          concat(["#MapSet<", to_doc(MapSet.to_list(dict), opts), ">"])
+        def inspect(map_set, opts) do
+          concat(["#MapSet<", to_doc(MapSet.to_list(map_set), opts), ">"])
         end
       end
 


### PR DESCRIPTION
I think, to avoid confusion of MapSet being a Dict.