### PR TITLE
Fix warning message in app requirement

### DIFF
--- a/lib/mix/lib/mix/compilers/application_tracer.ex
+++ b/lib/mix/lib/mix/compilers/application_tracer.ex
@@ -120,7 +120,7 @@ defmodule Mix.Compilers.ApplicationTracer do
     in your mix.exs
 
       3. In case you don't want to add a requirement to :#{app}, you may \
-    optionally skip this warning by adding [xref: [exclude: #{inspect(module)}] \
+    optionally skip this warning by adding [xref: [exclude: #{inspect(module)}]] \
     to your "def project" in mix.exs
     """
   end


### PR DESCRIPTION
It was missing a closing square bracket.

Previously it was saying

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: :crypto] to your "def project" in mix.exs

Now

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: :crypto]] to your "def project" in mix.exs