### PR TITLE
bugfix(elixir): Do not show warning when `super` is in `GenServer.child_spec/1`

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -631,7 +631,13 @@ maybe_warn_underscored_var_access(Meta, Name, Kind, E) ->
 maybe_warn_deprecated_super_in_gen_server_callback(Meta, Function, SuperMeta, E) ->
   case lists:keyfind(context, 1, SuperMeta) of
     {context, 'Elixir.GenServer'} ->
-      elixir_errors:form_warn(Meta, E, ?MODULE, {super_in_genserver, Function});
+      case Function of
+        {child_spec, 1} ->
+          ok;
+
+        _ ->
+          elixir_errors:form_warn(Meta, E, ?MODULE, {super_in_genserver, Function})
+      end;
 
     _ ->
       ok

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1723,7 +1723,7 @@ defmodule Kernel.WarningTest do
     end
   end
 
-  test "deprecated GenServer super" do
+  test "deprecated GenServer super on callbacks" do
     assert capture_err(fn ->
              Code.eval_string("""
              defmodule Sample do
@@ -1735,6 +1735,22 @@ defmodule Kernel.WarningTest do
              end
              """)
            end) =~ "calling super for GenServer callback handle_call/3 is deprecated"
+  after
+    purge(Sample)
+  end
+
+  test "super is allowed on GenServer.child_spec/1" do
+    refute capture_err(fn ->
+             Code.eval_string("""
+             defmodule Sample do
+               use GenServer
+
+               def child_spec(opts) do
+                 super(opts)
+               end
+             end
+             """)
+           end) =~ "calling super for GenServer callback child_spec/1 is deprecated"
   after
     purge(Sample)
   end


### PR DESCRIPTION
The original goal[1] was to deprecate the usage of `super` on every `GenServer`
callback, but `child_spec/1` is not a callback, it's a default implementation
that can be re-implemented.

This commit removes the _deprecation warning_ when someone use `super` in
`GenServer.child_spec/1`.

Fixes: #10415

[1] https://github.com/elixir-lang/elixir/commit/c024b0eeb2dc69a759fe5ceeb1c8216d58ae9386#diff-ed0344c13ed25389035f337d94902894R301-R316