### PR TITLE
Implements Enum.zip_with and Stream.zip_with

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3242,12 +3242,9 @@ defmodule Enum do
   end
 
   @doc """
-  Zips corresponding elements from a finite collection of enumerables into a new
-
-  Zips two collections together by passing the corresponding element from each collection to the
-  provided fun. Returns a new list that contains the result of that fun for each pair of elements.
-
-  The zipping finishes as soon as any enumerable in the given collection completes.
+  Zips corresponding elements from a finite collection of enumerables into a new enumerable which
+  is built by calling zip_fun with the first element from each enumerable, then the with the
+  second element and so on until any one of the enums runs out of elements.
 
   ## Examples
 
@@ -3257,8 +3254,8 @@ defmodule Enum do
   @spec zip_with(t, (term, term -> term)) :: [term]
   def zip_with([], _fun), do: []
 
-  def zip_with(enumerables, fun) do
-    Stream.zip_with(enumerables, fun)
+  def zip_with(enumerables, zip_fun) do
+    Stream.zip_with(enumerables, zip_fun)
     |> Enum.to_list()
   end
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3215,10 +3215,13 @@ defmodule Enum do
   end
 
   @doc """
-  Zips two collections together by passing the corresponding element from each collection to the
-  provided fun. Returns a new list that contains the result of that fun for each pair of elements.
+  Zips corresponding elements from two enumerables into a new enumerable, transforming them with
+  zip_fun as it goes.
 
-  The zipping finishes as soon as any enumerable in the given collection completes.
+  The corresponding elements from each collection are passed to the provided zip_fun in turn.
+  Returns a new list that contains the result of calling zip_fun for each pair of elements.
+
+  The zipping finishes as soon as any enumerable runs out of elements.
 
   ## Examples
 
@@ -3231,26 +3234,38 @@ defmodule Enum do
       iex> Enum.zip_with([1, 2, 5, 6], [3, 4], fn x, y -> x + y end)
       [4, 6]
   """
+  @doc since: "1.12.0"
   @spec zip_with(t, t, (term, term -> term)) :: [term]
-  def zip_with(enumerable1, enumerable2, fun)
+  def zip_with(enumerable1, enumerable2, zip_fun)
       when is_list(enumerable1) and is_list(enumerable2) do
-    zip_list(enumerable1, enumerable2, fun)
+    zip_list(enumerable1, enumerable2, zip_fun)
   end
 
-  def zip_with(enumerable1, enumerable2, fun) do
-    zip_with([enumerable1, enumerable2], fun)
+  def zip_with(enumerable1, enumerable2, zip_fun) do
+    # zip_with/2 passes a list to the zip_fun containing the nth element from each enumerable
+    # That's different from zip_with/3 where each element is a different argument to the zip_fun
+    # The apply ensures that zip_fun it gets the right number of arguments.
+    zip_with([enumerable1, enumerable2], &apply(zip_fun, &1))
   end
 
   @doc """
-  Zips corresponding elements from a finite collection of enumerables into a new enumerable which
-  is built by calling zip_fun with the first element from each enumerable, then the with the
-  second element and so on until any one of the enums runs out of elements.
+  Zips corresponding elements from a finite collection of enumerables into a new enumerable,
+  transforming them with zip_fun as it goes.
+
+  The nth element from each enumerable is put into a list then passed to zip_fun. The result of
+  zip_fun determines the nth element in the returned enumerable.
+
+  Zipping finishes as soon as any enumerable runs out of elements.
 
   ## Examples
 
       iex> Enum.zip_with([[1, 2], [3, 4], [5, 6]], fn [x, y, z] -> x + y + z end)
       [9, 12]
+
+      iex> Enum.zip_with([[1, 2], [3, 4]], fn [x, y] -> x + y end)
+      [4, 6]
   """
+  @doc since: "1.12.0"
   @spec zip_with(t, (term, term -> term)) :: [term]
   def zip_with([], _fun), do: []
 

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -1142,6 +1142,42 @@ defmodule EnumTest do
     assert Enum.zip([[], [], [], []]) == []
     assert Enum.zip(%{}) == []
   end
+
+  test "zip_with/3" do
+    assert Enum.zip_with([1, 2], [3, 4], fn a, b -> a * b end) == [3, 8]
+    assert Enum.zip_with([:a, :b], [1, 2], &{&1, &2}) == [{:a, 1}, {:b, 2}]
+    assert Enum.zip_with([:a, :b], [1, 2, 3, 4], &{&1, &2}) == [{:a, 1}, {:b, 2}]
+    assert Enum.zip_with([:a, :b, :c, :d], [1, 2], &{&1, &2}) == [{:a, 1}, {:b, 2}]
+
+    assert Enum.zip_with([], [1], &{&1, &2}) == []
+    assert Enum.zip_with([1], [], &{&1, &2}) == []
+    assert Enum.zip_with([], [], &{&1, &2}) == []
+  end
+
+  test "zip_with/2" do
+    zip_fun = fn items -> List.to_tuple(items) end
+
+    assert Enum.zip_with([[:a, :b], [1, 2], ["foo", "bar"]], zip_fun) == [
+             {:a, 1, "foo"},
+             {:b, 2, "bar"}
+           ]
+
+    assert Enum.zip_with([[:a, :b], [1, 2, 3, 4], ["foo", "bar", "baz", "qux"]], zip_fun) ==
+             [{:a, 1, "foo"}, {:b, 2, "bar"}]
+
+    assert Enum.zip_with([[:a, :b, :c, :d], [1, 2], ["foo", "bar", "baz", "qux"]], zip_fun) ==
+             [{:a, 1, "foo"}, {:b, 2, "bar"}]
+
+    assert Enum.zip_with([[:a, :b, :c, :d], [1, 2, 3, 4], ["foo", "bar"]], zip_fun) ==
+             [{:a, 1, "foo"}, {:b, 2, "bar"}]
+
+    assert Enum.zip_with([1..10, ["foo", "bar"]], zip_fun) == [{1, "foo"}, {2, "bar"}]
+    assert Enum.zip_with([], zip_fun) == []
+    assert Enum.zip_with([[]], zip_fun) == []
+    assert Enum.zip_with([[1]], zip_fun) == [{1}]
+    assert Enum.zip_with([[], [], [], []], zip_fun) == []
+    assert Enum.zip_with(%{}, zip_fun) == []
+  end
 end
 
 defmodule EnumTest.Range do

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -1148,19 +1148,45 @@ defmodule EnumTest do
     assert Enum.zip_with([:a, :b], [1, 2], &{&1, &2}) == [{:a, 1}, {:b, 2}]
     assert Enum.zip_with([:a, :b], [1, 2, 3, 4], &{&1, &2}) == [{:a, 1}, {:b, 2}]
     assert Enum.zip_with([:a, :b, :c, :d], [1, 2], &{&1, &2}) == [{:a, 1}, {:b, 2}]
-
     assert Enum.zip_with([], [1], &{&1, &2}) == []
     assert Enum.zip_with([1], [], &{&1, &2}) == []
     assert Enum.zip_with([], [], &{&1, &2}) == []
+
+    # Ranges
+    assert Enum.zip_with(1..6, 3..4, fn a, b -> a + b end) == [4, 6]
+    assert Enum.zip_with([1, 2, 5, 6], 3..4, fn a, b -> a + b end) == [4, 6]
+    assert Enum.zip_with(fn _, _ -> {:cont, [1, 2]} end, 3..4, fn a, b -> a + b end) == [4, 6]
+    assert Enum.zip_with(1..1, 0..0, fn a, b -> a + b end) == [1]
+
+    # Date.range
+    week_1 = Date.range(~D[2020-10-12], ~D[2020-10-16])
+    week_2 = Date.range(~D[2020-10-19], ~D[2020-10-23])
+
+    result =
+      Enum.zip_with(week_1, week_2, fn a, b ->
+        Date.day_of_week(a) + Date.day_of_week(b)
+      end)
+
+    assert result == [2, 4, 6, 8, 10]
+
+    #  MAPS
+    result = Enum.zip_with(%{a: 7, c: 9}, 3..4, fn {key, value}, b -> {key, value + b} end)
+    assert result == [a: 10, c: 13]
+
+    colour_1 = %{r: 176, g: 175, b: 255}
+    colour_2 = %{r: 12, g: 176, b: 176}
+
+    result = Enum.zip_with(colour_1, colour_2, fn {k, left}, {k, right} -> {k, left + right} end)
+    assert result == [b: 431, g: 351, r: 188]
   end
 
   test "zip_with/2" do
     zip_fun = fn items -> List.to_tuple(items) end
+    result = Enum.zip_with([[:a, :b], [1, 2], ["foo", "bar"]], zip_fun)
+    assert result == [{:a, 1, "foo"}, {:b, 2, "bar"}]
 
-    assert Enum.zip_with([[:a, :b], [1, 2], ["foo", "bar"]], zip_fun) == [
-             {:a, 1, "foo"},
-             {:b, 2, "bar"}
-           ]
+    lots = Enum.zip_with([[:a, :b], [1, 2], ["foo", "bar"], %{a: :b, c: :d}], zip_fun)
+    assert lots == [{:a, 1, "foo", {:a, :b}}, {:b, 2, "bar", {:c, :d}}]
 
     assert Enum.zip_with([[:a, :b], [1, 2, 3, 4], ["foo", "bar", "baz", "qux"]], zip_fun) ==
              [{:a, 1, "foo"}, {:b, 2, "bar"}]
@@ -1177,6 +1203,41 @@ defmodule EnumTest do
     assert Enum.zip_with([[1]], zip_fun) == [{1}]
     assert Enum.zip_with([[], [], [], []], zip_fun) == []
     assert Enum.zip_with(%{}, zip_fun) == []
+    assert Enum.zip_with([[1, 2, 5, 6], 3..4], fn [x, y] -> x + y end) == [4, 6]
+
+    # Ranges
+    assert Enum.zip_with([1..6, 3..4], fn [a, b] -> a + b end) == [4, 6]
+    assert Enum.zip_with([[1, 2, 5, 6], 3..4], fn [a, b] -> a + b end) == [4, 6]
+    assert Enum.zip_with([fn _, _ -> {:cont, [1, 2]} end, 3..4], fn [a, b] -> a + b end) == [4, 6]
+    assert Enum.zip_with([1..1, 0..0], fn [a, b] -> a + b end) == [1]
+
+    # Date.range
+    week_1 = Date.range(~D[2020-10-12], ~D[2020-10-16])
+    week_2 = Date.range(~D[2020-10-19], ~D[2020-10-23])
+
+    result =
+      Enum.zip_with([week_1, week_2], fn [a, b] ->
+        Date.day_of_week(a) + Date.day_of_week(b)
+      end)
+
+    assert result == [2, 4, 6, 8, 10]
+
+    #  MAPS
+    result = Enum.zip_with([%{a: 7, c: 9}, 3..4], fn [{key, value}, b] -> {key, value + b} end)
+    assert result == [a: 10, c: 13]
+
+    colour_1 = %{r: 176, g: 175, b: 255}
+    colour_2 = %{r: 12, g: 176, b: 176}
+
+    result =
+      Enum.zip_with([colour_1, colour_2], fn [{k, left}, {k, right}] -> {k, left + right} end)
+
+    assert result == [b: 431, g: 351, r: 188]
+
+    assert Enum.zip_with([%{a: :b, c: :d}, %{e: :f, g: :h}], & &1) == [
+             [a: :b, e: :f],
+             [c: :d, g: :h]
+           ]
   end
 end
 

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -1169,16 +1169,21 @@ defmodule StreamTest do
              [{1, :a}, {2, :b}, {3, :c}, {4, :a}, {5, :b}, {6, :c}]
   end
 
-  test "zip_with/2" do
+  test "zip_with/3" do
     concat = Stream.concat(1..3, 4..6)
     cycle = Stream.cycle([:a, :b, :c])
-    zip_fun = &List.to_tuple/1
+    zip_fun = &List.to_tuple([&1, &2])
 
     assert Stream.zip_with(concat, cycle, zip_fun) |> Enum.to_list() ==
              [{1, :a}, {2, :b}, {3, :c}, {4, :a}, {5, :b}, {6, :c}]
+
+    stream = Stream.concat(1..3, 4..6)
+    other_stream = fn _, _ -> {:cont, [1, 2]} end
+    result = Stream.zip_with(stream, other_stream, fn a, b -> a + b end) |> Enum.to_list()
+    assert result == [2, 4]
   end
 
-  test "zip_with/1" do
+  test "zip_with/2" do
     concat = Stream.concat(1..3, 4..6)
     cycle = Stream.cycle([:a, :b, :c])
     zip_fun = &List.to_tuple/1
@@ -1201,7 +1206,7 @@ defmodule StreamTest do
            ]
   end
 
-  test "zip_with/1 does not leave streams suspended" do
+  test "zip_with/2 does not leave streams suspended" do
     zip_with_fun = &List.to_tuple/1
 
     stream =
@@ -1230,7 +1235,7 @@ defmodule StreamTest do
     assert Process.get(:stream_zip_with)
   end
 
-  test "zip_with/1 does not leave streams suspended on halt" do
+  test "zip_with/2 does not leave streams suspended on halt" do
     zip_with_fun = &List.to_tuple/1
 
     stream =
@@ -1247,7 +1252,7 @@ defmodule StreamTest do
     assert Process.get(:stream_zip_with) == :done
   end
 
-  test "zip_with/1 closes on inner error" do
+  test "zip_with/2 closes on inner error" do
     zip_with_fun = &List.to_tuple/1
     stream = Stream.into([1, 2, 3], %Pdict{})
 
@@ -1259,7 +1264,7 @@ defmodule StreamTest do
     assert Process.get(:stream_done)
   end
 
-  test "zip_with/1 closes on outer error" do
+  test "zip_with/2 closes on outer error" do
     zip_with_fun = &List.to_tuple/1
 
     stream =

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -1169,6 +1169,81 @@ defmodule StreamTest do
              [{1, :a}, {2, :b}, {3, :c}, {4, :a}, {5, :b}, {6, :c}]
   end
 
+  test "zip_with/2" do
+    concat = Stream.concat(1..3, 4..6)
+    cycle = Stream.cycle([:a, :b, :c])
+    zip_fun = &List.to_tuple/1
+    assert Stream.zip_with(concat, cycle, zip_fun) |> Enum.to_list() ==
+             [{1, :a}, {2, :b}, {3, :c}, {4, :a}, {5, :b}, {6, :c}]
+  end
+
+  test "zip_with/1" do
+    concat = Stream.concat(1..3, 4..6)
+    cycle = Stream.cycle([:a, :b, :c])
+    zip_fun = &List.to_tuple/1
+
+    assert Stream.zip_with([concat, cycle], zip_fun) |> Enum.to_list() ==
+             [{1, :a}, {2, :b}, {3, :c}, {4, :a}, {5, :b}, {6, :c}]
+
+    assert Stream.chunk_every([0, 1, 2, 3], 2) |> Stream.zip_with(zip_fun) |> Enum.to_list() ==
+             [{0, 2}, {1, 3}]
+
+    stream = %HaltAcc{acc: 1..3}
+    assert Stream.zip_with([1..3, stream], zip_fun) |> Enum.to_list() == [{1, 1}, {2, 2}, {3, 3}]
+
+    range_cycle = Stream.cycle(1..2)
+    assert Stream.zip_with([1..3, range_cycle], zip_fun) |> Enum.to_list() == [{1, 1}, {2, 2}, {3, 1}]
+  end
+
+  test "zip_with/1 does not leave streams suspended" do
+    zip_with_fun = &List.to_tuple/1
+    stream =
+      Stream.resource(fn -> 1 end, fn acc -> {[acc], acc + 1} end, fn _ ->
+        Process.put(:stream_zip_with, true)
+      end)
+
+    Process.put(:stream_zip_with, false)
+    assert Stream.zip_with([[:a, :b, :c], stream],zip_with_fun) |> Enum.to_list() == [a: 1, b: 2, c: 3]
+    assert Process.get(:stream_zip_with)
+
+    Process.put(:stream_zip_with, false)
+    assert Stream.zip_with([stream, [:a, :b, :c]],zip_with_fun) |> Enum.to_list() == [{1, :a}, {2, :b}, {3, :c}]
+    assert Process.get(:stream_zip_with)
+  end
+
+  test "zip_with/1 does not leave streams suspended on halt" do
+    zip_with_fun = &List.to_tuple/1
+    stream =
+      Stream.resource(fn -> 1 end, fn acc -> {[acc], acc + 1} end, fn _ ->
+        Process.put(:stream_zip_with, :done)
+      end)
+
+    assert Stream.zip_with([[:a, :b, :c, :d, :e], stream],zip_with_fun) |> Enum.take(3) == [a: 1, b: 2, c: 3]
+
+    assert Process.get(:stream_zip_with) == :done
+  end
+
+  test "zip_with/1 closes on inner error" do
+    zip_with_fun = &List.to_tuple/1
+    stream = Stream.into([1, 2, 3], %Pdict{})
+    stream = Stream.zip_with([stream, Stream.map([:a, :b, :c], fn _ -> throw(:error) end)],zip_with_fun)
+
+    Process.put(:stream_done, false)
+    assert catch_throw(Enum.to_list(stream)) == :error
+    assert Process.get(:stream_done)
+  end
+
+  test "zip_with/1 closes on outer error" do
+    zip_with_fun = &List.to_tuple/1
+    stream =
+      Stream.zip_with([Stream.into([1, 2, 3], %Pdict{}), [:a, :b, :c]],zip_with_fun)
+      |> Stream.map(fn _ -> throw(:error) end)
+
+    Process.put(:stream_done, false)
+    assert catch_throw(Enum.to_list(stream)) == :error
+    assert Process.get(:stream_done)
+  end
+
   test "zip/1" do
     concat = Stream.concat(1..3, 4..6)
     cycle = Stream.cycle([:a, :b, :c])


### PR DESCRIPTION
This is my first stab at this so comments very welcome. 

Feature Request thread is here: https://groups.google.com/u/1/g/elixir-lang-core/c/mwBRUILsVHA

My basic approach was that the current zip/1 and zip/2 functions can be implemented by zip_with by doing this:

```elixir
zip(enums) do
  zip_with(enums, &List.to_tuple/1)
end
```

To implement zip_with/2 the zip_fun you pass to it will get a list of each of the elements from each enumerable we are zipping. This seemed okay, but it differs from what zip/3 does, where each element from the collection being zipped is a different argument to the zipping fun.

I think that's okay but happy to change them to both be consistent with each other.
