### PR TITLE
Fix spec for Enum.zip_with/2

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3266,7 +3266,7 @@ defmodule Enum do
       [4, 6]
   """
   @doc since: "1.12.0"
-  @spec zip_with(t, (term, term -> term)) :: [term]
+  @spec zip_with(t, ([term] -> term)) :: [term]
   def zip_with([], _fun), do: []
 
   def zip_with(enumerables, zip_fun) do


### PR DESCRIPTION
Wrong spec was detected by Dialyzer:

    lib/enum.ex:3248: The call 'Elixir.Enum':zip_with
             ([any(), ...],
              fun((_) -> any())) breaks the contract 
              (t(), fun((term(), term()) -> term())) -> [term()]
