### PR TITLE
Map.get_indifferent/3 returns a key's value, whether the key is…

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -533,7 +533,7 @@ defmodule Map do
     do_try_alt_keytype(map, key, String.to_atom(key), default)
   end
 
-  defp try_alt_keytype(%{}, key, default), do: default
+  defp try_alt_keytype(%{}, _key, default), do: default
 
   defp try_alt_keytype(other, key, default),
     do: :erlang.error({:badmap, other}, [other, key, default])

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -511,6 +511,10 @@ defmodule Map do
       3
       iex> Map.get_indifferent(%{"a" => 1}, "a", 7)
       1
+      iex> Map.get_indifferent(%{1920 => "Women's suffrage"}, 1920, "League of Women Voters founded")
+      "Women's suffrage"
+      iex> Map.get_indifferent(%{1945 => "V-E Day"}, 1918, "Wrong war")
+      "Wrong war"
 
   """
   @spec get_indifferent(map, key, value) :: value
@@ -528,6 +532,11 @@ defmodule Map do
   defp try_alt_keytype(map, key, default) when is_binary(key) do
     do_try_alt_keytype(map, key, String.to_atom(key), default)
   end
+
+  defp try_alt_keytype(%{}, key, default), do: default
+
+  defp try_alt_keytype(other, key, default),
+    do: :erlang.error({:badmap, other}, [other, key, default])
 
   defp do_try_alt_keytype(map, key, alt_keytype, default) do
     case map do

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -21,7 +21,11 @@ defmodule KeywordTest do
   end
 
   test "implements (almost) all functions in Map" do
-    assert Map.__info__(:functions) -- Keyword.__info__(:functions) == [from_struct: 1]
+    assert Map.__info__(:functions) -- Keyword.__info__(:functions) == [
+             from_struct: 1,
+             get_indifferent: 2,
+             get_indifferent: 3
+           ]
   end
 
   test "get_and_update/3 raises on bad return value from the argument function" do


### PR DESCRIPTION
…present as a string or an atom

Long-time Elixir user/fan. First-time caller. I want to thank everyone involved in creating & maintaining Elixir!!! You have greatly improved my programming life.

I found myself writing some messy code today because I didn't know whether the data structure I was given had string or atom keys. I hope this might be useful to others.

I have tried to minimize the probability that calling this function would create a new atom, but I would totally understand if this PR gets rejected for this reason.

There is no way to create a `Keyword` equivalent for this function because keyword lists have only atoms as their first tuple elements.

Cheers,

James