### PR TITLE
Fix invalid example for using erlang logger handler

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -467,8 +467,9 @@ defmodule Logger do
 
   Erlang/OTP handlers must be listed under your own application:
 
-      config :my_app, :logger,
-        [:handler, :name_of_the_handler, ACustomHandler, configuration = %{}]
+      config :my_app, :logger, [
+        {:handler, :name_of_the_handler, ACustomHandler, configuration = %{}}
+      ]
 
   And then explicitly attached in your `c:Application.start/2` callback:
 


### PR DESCRIPTION
The example for using a custom erlang logger handler is invalid, the handler must be enclosed in a tuple.
In version 1.11 it is already fixed for people still using 1.10 the documentation can be misreading.