### PR TITLE
Set compiler options from Mix project when running tests

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -330,6 +330,7 @@ defmodule Mix.Tasks.Test do
 
     Mix.Task.run("compile", args)
     project = Mix.Project.config()
+    Code.compiler_options(project[:elixirc_options] || [])
 
     # Start cover after we load deps but before we start the app.
     cover =

--- a/lib/mix/test/fixtures/test_warnings/mix.exs
+++ b/lib/mix/test/fixtures/test_warnings/mix.exs
@@ -1,0 +1,12 @@
+defmodule TestWarnings.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :test_warnings,
+      version: "0.0.1",
+      elixirc_options: [warnings_as_errors: true],
+      test_pattern: "*_test_warnings.exs"
+    ]
+  end
+end

--- a/lib/mix/test/fixtures/test_warnings/test/a_test_warnings.exs
+++ b/lib/mix/test/fixtures/test_warnings/test/a_test_warnings.exs
@@ -1,0 +1,7 @@
+defmodule ATest do
+  use ExUnit.Case
+
+  test "a" do
+    unused_in_test = true
+  end
+end

--- a/lib/mix/test/fixtures/test_warnings/test/test_helper.exs
+++ b/lib/mix/test/fixtures/test_warnings/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -408,6 +408,14 @@ defmodule Mix.Tasks.TestTest do
     end
   end
 
+  test "with elixirc_options: [warnings_as_errors: true]" do
+    in_fixture("test_warnings", fn ->
+      output = mix(["test"])
+      assert output =~ "variable \"unused_in_test\" is unused"
+      assert output =~ "Compilation failed due to warnings"
+    end)
+  end
+
   defp receive_until_match(port, expected, acc) do
     receive do
       {^port, {:data, output}} ->


### PR DESCRIPTION
Ref: https://github.com/elixir-lang/elixir/pull/10255

Turns out that when `mix test` starts, it has the default compiler options, ignoring `:elixirc_options`. Notably, setting:

    elixirc_options: [warnings_as_errors: true]

doesn't have the desired effect of causing the task to fail when it encounter warnings _in tests_.

(Unfortunately, turns out the advice given in linked PR, `MIX_ENV=test mix do compile --warnings-as-errors, test` doesn't work either.)

This patch tries to fix that.