### PR TITLE
Fix stop_supervised/1 for temporary children

### DIFF
--- a/lib/ex_unit/test/ex_unit/supervised_test.exs
+++ b/lib/ex_unit/test/ex_unit/supervised_test.exs
@@ -94,6 +94,12 @@ defmodule ExUnit.SupervisedTest do
     refute Process.alive?(pid)
   end
 
+  test "stops a temporary supervised process" do
+    {:ok, pid} = start_supervised({MyAgent, 0}, restart: :temporary)
+    assert stop_supervised(MyAgent) == :ok
+    refute Process.alive?(pid)
+  end
+
   test "stops! a supervised process" do
     {:ok, pid} = start_supervised({MyAgent, 0})
     assert stop_supervised!(MyAgent) == :ok


### PR DESCRIPTION
resolves #10440 