### PR TITLE
Unset CDPATH while finding RELEASE_ROOT

### DIFF
--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -85,7 +85,7 @@ defmodule Mix.Tasks.Release.Init do
 
     SELF=$(readlink "$0" || true)
     if [ -z "$SELF" ]; then SELF="$0"; fi
-    RELEASE_ROOT="$(cd "$(dirname "$SELF")/.." && pwd -P)"
+    RELEASE_ROOT="$(CDPATH='' cd "$(dirname "$SELF")/.." && pwd -P)"
     export RELEASE_ROOT
     export RELEASE_NAME="${RELEASE_NAME:-"<%= @release.name %>"}"
     export RELEASE_VSN="${RELEASE_VSN:-"$(cut -d' ' -f2 "$RELEASE_ROOT/releases/start_erl.data")"}"


### PR DESCRIPTION
I keep running into #9835 when testing releases locally. This change fixes it without user intervention.

I considered piping the output of `cd` into `/dev/null`, but it struck me `CDPATH=''` was cleaner. WDYT?