### PR TITLE
Make Code.ensure_loaded/compiled error return consistent on CS/CI FS

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -1224,9 +1224,14 @@ defmodule Code do
       iex> Code.ensure_loaded(DoesNotExist)
       {:error, :nofile}
 
+      iex> Code.ensure_loaded(Elixir)
+      {:error, :nofile}
+
   """
   @spec ensure_loaded(module) ::
           {:module, module} | {:error, :embedded | :badfile | :nofile | :on_load_failure}
+  def ensure_loaded(Elixir), do: {:error, :nofile}
+
   def ensure_loaded(module) when is_atom(module) do
     :code.ensure_loaded(module)
   end
@@ -1278,6 +1283,8 @@ defmodule Code do
   @spec ensure_compiled(module) ::
           {:module, module}
           | {:error, :embedded | :badfile | :nofile | :on_load_failure | :unavailable}
+  def ensure_compiled(Elixir), do: {:error, :nofile}
+
   def ensure_compiled(module) when is_atom(module) do
     case :code.ensure_loaded(module) do
       {:error, :nofile} = error ->

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -467,11 +467,13 @@ defmodule CodeTest do
   test "ensure_loaded?/1" do
     assert Code.ensure_loaded?(__MODULE__)
     refute Code.ensure_loaded?(Code.NoFile)
+    refute Code.ensure_loaded?(Elixir)
   end
 
   test "ensure_compiled/1" do
     assert Code.ensure_compiled(__MODULE__) == {:module, __MODULE__}
     assert Code.ensure_compiled(Code.NoFile) == {:error, :nofile}
+    assert Code.ensure_compiled(Elixir) == {:error, :nofile}
   end
 
   test "put_compiler_option/2 validates options" do


### PR DESCRIPTION
On case sensitive filesystems
```
Code.ensure_loaded(Elixir)
{:error, :nofile}
```
On case insensitive filesystems
```
Code.ensure_loaded(Elixir)
{:error, :badfile}
12:33:13.307 [error] Loading of /Users/elixir/bin/../lib/elixir/ebin/Elixir.beam failed: :badfile

 
12:33:13.307 [error] beam/beam_load.c(1440): Error loading module 'Elixir':
  BEAM file exists but it defines a module named elixir

```