### PR TITLE
update function convert_time_unit document

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -940,7 +940,7 @@ defmodule System do
   unit before you display them to humans.
 
   To determine how many seconds the `:native` unit represents in your current
-  runtime, you can can call this function to convert 1 second to the `:native`
+  runtime, you can call this function to convert 1 second to the `:native`
   time unit: `System.convert_time_unit(1, :second, :native)`.
   """
   @spec convert_time_unit(integer, time_unit | :native, time_unit | :native) :: integer


### PR DESCRIPTION
1.Remove the additional word 'can'.
2.Add the System.convert_time_unit(1, :second, :native) return value so people have clear idea about  the two units.