### PR TITLE
mix release: anyone who can read can execute

### DIFF
--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -1423,7 +1423,7 @@ defmodule Mix.Tasks.Release do
     end
   end
 
-  defp executable!(path), do: File.chmod!(path, 0o744)
+  defp executable!(path), do: File.chmod!(path, 0o755)
 
   # Helper functions
 


### PR DESCRIPTION
In the case where a mix release's results are owned by a different user than the one booting it, the binaries should be executable by anyone who can also read them.