### PR TITLE
Allow setting custom exit code on Mix error

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -430,10 +430,14 @@ defmodule Mix do
 
   @doc """
   Raises a Mix error that is nicely formatted.
+
+  ## Options
+
+  - `:exit_code` - defines exit code value, defaults to `1`
   """
-  @spec raise(binary, keyword) :: no_return
+  @spec raise(binary, [exit_code: non_neg_integer()]) :: no_return
   def raise(message, opts \\ []) when is_binary(message) do
-    Kernel.raise(Mix.Error, mix: Keyword.get(opts, :code, 1), message: message)
+    Kernel.raise(Mix.Error, mix: Keyword.get(opts, :exit_code, 1), message: message)
   end
 
   @doc """

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -431,9 +431,9 @@ defmodule Mix do
   @doc """
   Raises a Mix error that is nicely formatted.
   """
-  @spec raise(binary) :: no_return
-  def raise(message) when is_binary(message) do
-    Kernel.raise(Mix.Error, mix: true, message: message)
+  @spec raise(binary, keyword) :: no_return
+  def raise(message, opts \\ []) when is_binary(message) do
+    Kernel.raise(Mix.Error, mix: Keyword.get(opts, :code, 1), message: message)
   end
 
   @doc """

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -433,7 +433,7 @@ defmodule Mix do
 
   ## Options
 
-  - `:exit_code` - defines exit code value, defaults to `1`
+    * `:exit_code` - defines exit code value, defaults to `1`
   """
   @spec raise(binary, [exit_code: non_neg_integer()]) :: no_return
   def raise(message, opts \\ []) when is_binary(message) do

--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -86,14 +86,23 @@ defmodule Mix.CLI do
       # We only rescue exceptions in the Mix namespace, all
       # others pass through and will explode on the users face
       exception ->
-        if Map.get(exception, :mix, false) and not Mix.debug?() do
-          mod = exception.__struct__ |> Module.split() |> Enum.at(0, "Mix")
-          Mix.shell().error("** (#{mod}) #{Exception.message(exception)}")
-          exit({:shutdown, 1})
-        else
-          reraise exception, __STACKTRACE__
+        case {Mix.debug?(), Map.get(exception, :mix, false)} do
+          {false, true} ->
+            simplified_exception(exception, 1)
+
+          {false, code} when code in 0..255 ->
+            simplified_exception(exception, code)
+
+          _ ->
+            reraise exception, __STACKTRACE__
         end
     end
+  end
+
+  defp simplified_exception(%name{} = exception, code) do
+    mod = name |> Module.split() |> Enum.at(0, "Mix")
+    Mix.shell().error("** (#{mod}) #{Exception.message(exception)}")
+    exit({:shutdown, code})
   end
 
   defp env_variable_activated?(name) do

--- a/lib/mix/lib/mix/cli.ex
+++ b/lib/mix/lib/mix/cli.ex
@@ -100,7 +100,7 @@ defmodule Mix.CLI do
   end
 
   defp simplified_exception(%name{} = exception, code) do
-    mod = name |> Module.split() |> Enum.at(0, "Mix")
+    mod = name |> Module.split() |> hd()
     Mix.shell().error("** (#{mod}) #{Exception.message(exception)}")
     exit({:shutdown, code})
   end

--- a/lib/mix/lib/mix/exceptions.ex
+++ b/lib/mix/lib/mix/exceptions.ex
@@ -86,5 +86,5 @@ defmodule Mix.NoProjectError do
 end
 
 defmodule Mix.Error do
-  defexception [:message, mix: true]
+  defexception [:message, mix: 1]
 end

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -19,6 +19,32 @@ defmodule Mix.CLITest do
     end)
   end
 
+  test "Mix.raise/2 can set exit code", %{tmp_dir: tmp_dir} do
+    File.cd!(tmp_dir, fn ->
+      File.mkdir_p!("lib")
+
+      File.write!("mix.exs", """
+      defmodule MyProject do
+        use Mix.Project
+
+        def project do
+          [app: :my_project, version: "0.0.1", aliases: aliases()]
+        end
+
+        defp aliases do
+          [
+            custom: &error(&1, exit_code: 99),
+          ]
+        end
+
+        defp error(_args, opts), do: Mix.raise("oops", opts)
+      end
+      """)
+
+      assert {_, 99} = mix_code(~w[custom])
+    end)
+  end
+
   test "compiles and invokes simple task from CLI", %{tmp_dir: tmp_dir} do
     File.cd!(tmp_dir, fn ->
       File.mkdir_p!("lib")

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -160,8 +160,12 @@ defmodule MixTest.Case do
   end
 
   def mix(args, envs \\ []) when is_list(args) do
+    mix_code(args, envs) |> elem(0)
+  end
+
+  def mix_code(args, envs \\ []) when is_list(args) do
     args = ["-r", mix_executable(), "--" | args]
-    System.cmd(elixir_executable(), args, stderr_to_stdout: true, env: envs) |> elem(0)
+    System.cmd(elixir_executable(), args, stderr_to_stdout: true, env: envs)
   end
 
   def mix_port(args, envs \\ []) when is_list(args) do


### PR DESCRIPTION
It is sometimes useful and desirable to have different exit code on
different errors (for example 1 on server error, 2 on connection error,
and so on). This change adds new field to the `Mix.Error` exception -
`code` that will be then used as an exit code value.