### PR TITLE
Propose Pin Operator with Unused Overridden Variable

### DIFF
--- a/lib/elixir/src/elixir_env.erl
+++ b/lib/elixir/src/elixir_env.erl
@@ -92,8 +92,8 @@ reset_unused_vars(#{unused_vars := {_Unused, Version}} = E) ->
   E#{unused_vars := {#{}, Version}}.
 
 check_unused_vars(#{unused_vars := {Unused, _Version}} = E) ->
-  [elixir_errors:form_warn([{line, Line}], E, ?MODULE, {unused_var, Name}) ||
-    {{Name, _}, Line} <- maps:to_list(Unused), Line /= false, is_unused_var(Name)],
+  [elixir_errors:form_warn([{line, Line}], E, ?MODULE, {unused_var, Name, Overridden}) ||
+    {{Name, _}, {Line, Overridden}} <- maps:to_list(Unused), is_unused_var(Name)],
   E.
 
 merge_and_check_unused_vars(E, #{unused_vars := {ClauseUnused, Version}}) ->
@@ -111,10 +111,11 @@ merge_and_check_unused_vars(Current, Unused, ClauseUnused, E) ->
 
       %% The parent doesn't know it and we didn't use it
       #{} when ClauseValue /= false ->
+        {Line, Overridden} = ClauseValue,
         case is_unused_var(Name) of
           true ->
-            Warn = {unused_var, Name},
-            elixir_errors:form_warn([{line, ClauseValue}], E, ?MODULE, Warn);
+            Warn = {unused_var, Name, Overridden},
+            elixir_errors:form_warn([{line, Line}], E, ?MODULE, Warn);
 
           false ->
             ok
@@ -138,10 +139,12 @@ is_compiler_var([$_]) -> true;
 is_compiler_var([Var | Rest]) when Var =:= $_; Var >= $A, Var =< $Z -> is_compiler_var(Rest);
 is_compiler_var(_) -> false.
 
-format_error({unused_var, Name}) ->
+format_error({unused_var, Name, Overridden}) ->
   case atom_to_list(Name) of
     "_" ++ _ ->
       io_lib:format("unknown compiler variable \"~ts\" (expected one of __MODULE__, __ENV__, __DIR__, __CALLER__, __STACKTRACE__)", [Name]);
+    _ when Overridden ->
+      io_lib:format("variable \"~ts\" is unused (there is a variable with the same name in the context, use the pin operator (^) to match on it or prefix this variable with underscore if it is not meant to be used)", [Name]);
     _ ->
       io_lib:format("variable \"~ts\" is unused (if the variable is not meant to be used, prefix it with an underscore)", [Name])
   end.

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -335,7 +335,7 @@ expand({Name, Meta, Kind}, #{context := match} = E) when is_atom(Name), is_atom(
 
     %% Variable is being overridden now
     #{Pair := _} ->
-      NewUnused = var_unused(Pair, Meta, Version, Unused),
+      NewUnused = var_unused(Pair, Meta, Version, Unused, true),
       NewReadCurrent = ReadCurrent#{Pair => Version},
       NewWriteCurrent = (WriteCurrent /= false) andalso WriteCurrent#{Pair => Version},
       Var = {Name, [{version, Version} | Meta], Kind},
@@ -344,7 +344,7 @@ expand({Name, Meta, Kind}, #{context := match} = E) when is_atom(Name), is_atom(
     %% Variable defined for the first time
     _ ->
       NewVars = ordsets:add_element(Pair, ?key(E, vars)),
-      NewUnused = var_unused(Pair, Meta, Version, Unused),
+      NewUnused = var_unused(Pair, Meta, Version, Unused, false),
       NewReadCurrent = ReadCurrent#{Pair => Version},
       NewWriteCurrent = (WriteCurrent /= false) andalso WriteCurrent#{Pair => Version},
       Var = {Name, [{version, Version} | Meta], Kind},
@@ -599,9 +599,9 @@ expand_args(Args, E) ->
 
 %% Match/var helpers
 
-var_unused({Name, Kind}, Meta, Version, Unused) ->
+var_unused({Name, Kind}, Meta, Version, Unused, Override) ->
   case (Kind == nil) andalso should_warn(Meta) of
-    true -> Unused#{{Name, Version} => ?line(Meta)};
+    true -> Unused#{{Name, Version} => {?line(Meta), Override}};
     false -> Unused
   end.
 


### PR DESCRIPTION
When rebinding a variable that is not later used, the warning
proposes to use the pin operator.

Fixes #10478