### PR TITLE
Request for feedback: formatted elixir's erlang code using erlfmt

### DIFF
--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -1,55 +1,66 @@
 -module(elixir_bitstring).
+
 -export([expand/4, format_error/1]).
+
 -import(elixir_errors, [form_error/4]).
+
 -include("elixir.hrl").
 
 expand_match(Expr, {E, OriginalE}) ->
-  {EExpr, EE} = elixir_expand:expand(Expr, E),
-  {EExpr, {EE, OriginalE}}.
+    {EExpr, EE} = elixir_expand:expand(Expr, E),
+    {EExpr, {EE, OriginalE}}.
 
 expand(Meta, Args, E, RequireSize) ->
-  case ?key(E, context) of
-    match ->
-      {EArgs, Alignment, {EA, _}} =
-        expand(Meta, fun expand_match/2, Args, [], {E, E}, 0, RequireSize),
+    case ?key(E, context) of
+        match ->
+            {EArgs, Alignment, {EA, _}} =
+                expand(Meta, fun expand_match/2, Args, [], {E, E}, 0, RequireSize),
 
-      case find_match(EArgs) of
-        false ->
-          {{'<<>>', [{alignment, Alignment} | Meta], EArgs}, EA};
-        Match ->
-          form_error(Meta, EA, ?MODULE, {nested_match, Match})
-      end;
-    _ ->
-      PairE = {elixir_env:prepare_write(E), E},
+            case find_match(EArgs) of
+                false ->
+                    {{'<<>>', [{alignment, Alignment} | Meta], EArgs}, EA};
+                Match ->
+                    form_error(Meta, EA, ?MODULE, {nested_match, Match})
+            end;
+        _ ->
+            PairE = {elixir_env:prepare_write(E), E},
 
-      {EArgs, Alignment, {EA, _}} =
-        expand(Meta, fun elixir_expand:expand_arg/2, Args, [], PairE, 0, RequireSize),
+            {EArgs, Alignment, {EA, _}} =
+                expand(Meta, fun elixir_expand:expand_arg/2, Args, [], PairE, 0, RequireSize),
 
-      {{'<<>>', [{alignment, Alignment} | Meta], EArgs}, elixir_env:close_write(EA, E)}
-  end.
+            {{'<<>>', [{alignment, Alignment} | Meta], EArgs}, elixir_env:close_write(EA, E)}
+    end.
 
 expand(_BitstrMeta, _Fun, [], Acc, E, Alignment, _RequireSize) ->
-  {lists:reverse(Acc), Alignment, E};
+    {lists:reverse(Acc), Alignment, E};
 expand(BitstrMeta, Fun, [{'::', Meta, [Left, Right]} | T], Acc, E, Alignment, RequireSize) ->
-  {ELeft, {EL, OriginalE}} = expand_expr(Meta, Left, Fun, E),
+    {ELeft, {EL, OriginalE}} = expand_expr(Meta, Left, Fun, E),
 
-  MatchOrRequireSize = RequireSize or is_match_size(T, EL),
-  EType = expr_type(ELeft),
-  {ERight, EAlignment, ES} = expand_specs(EType, Meta, Right, EL, OriginalE, MatchOrRequireSize),
+    MatchOrRequireSize = RequireSize or is_match_size(T, EL),
+    EType = expr_type(ELeft),
+    {ERight, EAlignment, ES} = expand_specs(EType, Meta, Right, EL, OriginalE, MatchOrRequireSize),
 
-  EAcc = concat_or_prepend_bitstring(Meta, ELeft, ERight, Acc, ES, MatchOrRequireSize),
-  expand(BitstrMeta, Fun, T, EAcc, {ES, OriginalE}, alignment(Alignment, EAlignment), RequireSize);
+    EAcc = concat_or_prepend_bitstring(Meta, ELeft, ERight, Acc, ES, MatchOrRequireSize),
+    expand(
+        BitstrMeta,
+        Fun,
+        T,
+        EAcc,
+        {ES, OriginalE},
+        alignment(Alignment, EAlignment),
+        RequireSize
+    );
 expand(BitstrMeta, Fun, [H | T], Acc, E, Alignment, RequireSize) ->
-  Meta = extract_meta(H, BitstrMeta),
-  {ELeft, {ES, OriginalE}} = expand_expr(Meta, H, Fun, E),
+    Meta = extract_meta(H, BitstrMeta),
+    {ELeft, {ES, OriginalE}} = expand_expr(Meta, H, Fun, E),
 
-  MatchOrRequireSize = RequireSize or is_match_size(T, ES),
-  EType = expr_type(ELeft),
-  ERight = infer_spec(EType, Meta),
+    MatchOrRequireSize = RequireSize or is_match_size(T, ES),
+    EType = expr_type(ELeft),
+    ERight = infer_spec(EType, Meta),
 
-  InferredMeta = [{inferred_bitstring_spec, true} | Meta],
-  EAcc = concat_or_prepend_bitstring(InferredMeta, ELeft, ERight, Acc, ES, MatchOrRequireSize),
-  expand(Meta, Fun, T, EAcc, {ES, OriginalE}, Alignment, RequireSize).
+    InferredMeta = [{inferred_bitstring_spec, true} | Meta],
+    EAcc = concat_or_prepend_bitstring(InferredMeta, ELeft, ERight, Acc, ES, MatchOrRequireSize),
+    expand(Meta, Fun, T, EAcc, {ES, OriginalE}, Alignment, RequireSize).
 
 extract_meta({_, Meta, _}, _) -> Meta;
 extract_meta(_, Meta) -> Meta.
@@ -72,43 +83,39 @@ infer_spec(integer, Meta) -> {integer, Meta, []};
 infer_spec(default, Meta) -> {integer, Meta, []}.
 
 concat_or_prepend_bitstring(_Meta, {'<<>>', _, []}, _ERight, Acc, _E, _RequireSize) ->
-  Acc;
+    Acc;
 concat_or_prepend_bitstring(Meta, {'<<>>', PartsMeta, Parts} = ELeft, ERight, Acc, E, RequireSize) ->
-  case E of
-    #{context := match} when RequireSize ->
-      case lists:last(Parts) of
-        {'::', SpecMeta, [Bin, {binary, _, []}]} when not is_binary(Bin) ->
-          form_error(SpecMeta, E, ?MODULE, unsized_binary);
-
-        {'::', SpecMeta, [_, {bitstring, _, []}]} ->
-          form_error(SpecMeta, E, ?MODULE, unsized_binary);
-
+    case E of
+        #{context := match} when RequireSize ->
+            case lists:last(Parts) of
+                {'::', SpecMeta, [Bin, {binary, _, []}]} when not is_binary(Bin) ->
+                    form_error(SpecMeta, E, ?MODULE, unsized_binary);
+                {'::', SpecMeta, [_, {bitstring, _, []}]} ->
+                    form_error(SpecMeta, E, ?MODULE, unsized_binary);
+                _ ->
+                    ok
+            end;
         _ ->
-          ok
-      end;
-    _ ->
-      ok
-  end,
+            ok
+    end,
 
-  case ERight of
-    {binary, _, []} ->
-      {alignment, Alignment} = lists:keyfind(alignment, 1, PartsMeta),
+    case ERight of
+        {binary, _, []} ->
+            {alignment, Alignment} = lists:keyfind(alignment, 1, PartsMeta),
 
-      if
-        Alignment == 0 ->
-          lists:reverse(Parts, Acc);
-
-        is_integer(Alignment) ->
-          form_error(Meta, E, ?MODULE, {unaligned_binary, ELeft});
-
-        true ->
-          [{'::', Meta, [ELeft, ERight]} | Acc]
-      end;
-    {bitstring, _, []} ->
-      lists:reverse(Parts, Acc)
-  end;
+            if
+                Alignment == 0 ->
+                    lists:reverse(Parts, Acc);
+                is_integer(Alignment) ->
+                    form_error(Meta, E, ?MODULE, {unaligned_binary, ELeft});
+                true ->
+                    [{'::', Meta, [ELeft, ERight]} | Acc]
+            end;
+        {bitstring, _, []} ->
+            lists:reverse(Parts, Acc)
+    end;
 concat_or_prepend_bitstring(Meta, ELeft, ERight, Acc, _E, _RequireSize) ->
-  [{'::', Meta, [ELeft, ERight]} | Acc].
+    [{'::', Meta, [ELeft, ERight]} | Acc].
 
 %% Handling of alignment
 
@@ -133,199 +140,215 @@ compute_alignment(_, _, _) -> unknown.
 %% If we are inside a match/guard, we inline interpolations explicitly,
 %% otherwise they are inlined by elixir_rewrite.erl.
 
-expand_expr(_Meta, {{'.', _, [Mod, to_string]}, _, [Arg]} = AST, Fun, {#{context := Context}, _} = E)
-    when Context /= nil, (Mod == 'Elixir.Kernel') orelse (Mod == 'Elixir.String.Chars') ->
-  case Fun(Arg, E) of
-    {EBin, EE} when is_binary(EBin) -> {EBin, EE};
-    _ -> Fun(AST, E) % Let it raise
-  end;
+expand_expr(
+    _Meta,
+    {{'.', _, [Mod, to_string]}, _, [Arg]} = AST,
+    Fun,
+    {#{context := Context}, _} = E
+) when Context /= nil, (Mod == 'Elixir.Kernel') orelse (Mod == 'Elixir.String.Chars') ->
+    case Fun(Arg, E) of
+        {EBin, EE} when is_binary(EBin) -> {EBin, EE};
+        % Let it raise
+        _ -> Fun(AST, E)
+    end;
 expand_expr(Meta, Component, Fun, E) ->
-  case Fun(Component, E) of
-    {EComponent, {ErrorE, _}} when is_list(EComponent); is_atom(EComponent) ->
-      form_error(Meta, ErrorE, ?MODULE, {invalid_literal, EComponent});
-    {_, _} = Expanded ->
-      Expanded
-  end.
+    case Fun(Component, E) of
+        {EComponent, {ErrorE, _}} when is_list(EComponent); is_atom(EComponent) ->
+            form_error(Meta, ErrorE, ?MODULE, {invalid_literal, EComponent});
+        {_, _} = Expanded ->
+            Expanded
+    end.
 
 %% Expands and normalizes types of a bitstring.
 
 expand_specs(ExprType, Meta, Info, E, OriginalE, RequireSize) ->
-  Default =
-    #{size => default,
-      unit => default,
-      sign => default,
-      type => default,
-      endianness => default},
-  {#{size := Size, unit := Unit, type := Type, endianness := Endianness, sign := Sign}, ES} =
-    expand_each_spec(Meta, unpack_specs(Info, []), Default, E, OriginalE),
-  MergedType = type(Meta, ExprType, Type, E),
-  validate_size_required(Meta, RequireSize, ExprType, MergedType, Size, ES),
-  SizeAndUnit = size_and_unit(Meta, ExprType, Size, Unit, ES),
-  Alignment = compute_alignment(MergedType, Size, Unit),
-  [H | T] = build_spec(Meta, Size, Unit, MergedType, Endianness, Sign, SizeAndUnit, ES),
-  {lists:foldl(fun(I, Acc) -> {'-', Meta, [Acc, I]} end, H, T), Alignment, ES}.
+    Default = #{
+        size => default,
+        unit => default,
+        sign => default,
+        type => default,
+        endianness => default
+    },
+    {#{size := Size, unit := Unit, type := Type, endianness := Endianness, sign := Sign}, ES} =
+        expand_each_spec(Meta, unpack_specs(Info, []), Default, E, OriginalE),
+    MergedType = type(Meta, ExprType, Type, E),
+    validate_size_required(Meta, RequireSize, ExprType, MergedType, Size, ES),
+    SizeAndUnit = size_and_unit(Meta, ExprType, Size, Unit, ES),
+    Alignment = compute_alignment(MergedType, Size, Unit),
+    [H | T] = build_spec(Meta, Size, Unit, MergedType, Endianness, Sign, SizeAndUnit, ES),
+    {lists:foldl(fun(I, Acc) -> {'-', Meta, [Acc, I]} end, H, T), Alignment, ES}.
 
 type(_, default, default, _) ->
-  integer;
+    integer;
 type(_, ExprType, default, _) ->
-  ExprType;
-type(_, binary, Type, _) when Type == binary; Type == bitstring; Type == utf8; Type == utf16; Type == utf32 ->
-  Type;
+    ExprType;
+type(_, binary, Type, _) when
+    Type == binary; Type == bitstring; Type == utf8; Type == utf16; Type == utf32
+->
+    Type;
 type(_, bitstring, Type, _) when Type == binary; Type == bitstring ->
-  Type;
-type(_, integer, Type, _) when Type == integer; Type == float; Type == utf8; Type == utf16; Type == utf32 ->
-  Type;
+    Type;
+type(_, integer, Type, _) when
+    Type == integer; Type == float; Type == utf8; Type == utf16; Type == utf32
+->
+    Type;
 type(_, float, Type, _) when Type == float ->
-  Type;
+    Type;
 type(_, default, Type, _) ->
-  Type;
+    Type;
 type(Meta, Other, Value, E) ->
-  form_error(Meta, E, ?MODULE, {bittype_mismatch, Value, Other, type}).
+    form_error(Meta, E, ?MODULE, {bittype_mismatch, Value, Other, type}).
 
 expand_each_spec(Meta, [{Expr, _, Args} = H | T], Map, E, OriginalE) when is_atom(Expr) ->
-  case validate_spec(Expr, Args) of
-    {Key, Arg} ->
-      {Value, EE} = expand_spec_arg(Arg, E, OriginalE),
-      validate_spec_arg(Meta, Key, Value, EE, OriginalE),
+    case validate_spec(Expr, Args) of
+        {Key, Arg} ->
+            {Value, EE} = expand_spec_arg(Arg, E, OriginalE),
+            validate_spec_arg(Meta, Key, Value, EE, OriginalE),
 
-      case maps:get(Key, Map) of
-        default -> ok;
-        Value -> ok;
-        Other -> form_error(Meta, E, ?MODULE, {bittype_mismatch, Value, Other, Key})
-      end,
+            case maps:get(Key, Map) of
+                default -> ok;
+                Value -> ok;
+                Other -> form_error(Meta, E, ?MODULE, {bittype_mismatch, Value, Other, Key})
+            end,
 
-      expand_each_spec(Meta, T, maps:put(Key, Value, Map), EE, OriginalE);
-    none ->
-      case 'Elixir.Macro':expand(H, elixir_env:linify({?line(Meta), E})) of
-        H ->
-          form_error(Meta, E, ?MODULE, {undefined_bittype, H});
-        NewTypes ->
-          expand_each_spec(Meta, unpack_specs(NewTypes, []) ++ T, Map, E, OriginalE)
-      end
-  end;
+            expand_each_spec(Meta, T, maps:put(Key, Value, Map), EE, OriginalE);
+        none ->
+            case 'Elixir.Macro':expand(H, elixir_env:linify({?line(Meta), E})) of
+                H ->
+                    form_error(Meta, E, ?MODULE, {undefined_bittype, H});
+                NewTypes ->
+                    expand_each_spec(Meta, unpack_specs(NewTypes, []) ++ T, Map, E, OriginalE)
+            end
+    end;
 expand_each_spec(Meta, [Expr | _], _Map, E, _OriginalE) ->
-  form_error(Meta, E, ?MODULE, {undefined_bittype, Expr});
+    form_error(Meta, E, ?MODULE, {undefined_bittype, Expr});
 expand_each_spec(_Meta, [], Map, E, _OriginalE) ->
-  {Map, E}.
+    {Map, E}.
 
 unpack_specs({'-', _, [H, T]}, Acc) ->
-  unpack_specs(H, unpack_specs(T, Acc));
+    unpack_specs(H, unpack_specs(T, Acc));
 unpack_specs({'*', _, [{'_', _, Atom}, Unit]}, Acc) when is_atom(Atom) ->
-  [{unit, [], [Unit]} | Acc];
+    [{unit, [], [Unit]} | Acc];
 unpack_specs({'*', _, [Size, Unit]}, Acc) ->
-  [{size, [], [Size]}, {unit, [], [Unit]} | Acc];
+    [{size, [], [Size]}, {unit, [], [Unit]} | Acc];
 unpack_specs(Size, Acc) when is_integer(Size) ->
-  [{size, [], [Size]} | Acc];
+    [{size, [], [Size]} | Acc];
 unpack_specs({Expr, Meta, Args}, Acc) when is_atom(Expr) ->
-  ListArgs = if is_atom(Args) -> []; is_list(Args) -> Args end,
-  [{Expr, Meta, ListArgs} | Acc];
+    ListArgs =
+        if
+            is_atom(Args) -> [];
+            is_list(Args) -> Args
+        end,
+    [{Expr, Meta, ListArgs} | Acc];
 unpack_specs(Other, Acc) ->
-  [Other | Acc].
+    [Other | Acc].
 
-validate_spec(big, [])       -> {endianness, big};
-validate_spec(little, [])    -> {endianness, little};
-validate_spec(native, [])    -> {endianness, native};
-validate_spec(size, [Size])  -> {size, Size};
-validate_spec(unit, [Unit])  -> {unit, Unit};
-validate_spec(integer, [])   -> {type, integer};
-validate_spec(float, [])     -> {type, float};
-validate_spec(binary, [])    -> {type, binary};
-validate_spec(bytes, [])     -> {type, binary};
+validate_spec(big, []) -> {endianness, big};
+validate_spec(little, []) -> {endianness, little};
+validate_spec(native, []) -> {endianness, native};
+validate_spec(size, [Size]) -> {size, Size};
+validate_spec(unit, [Unit]) -> {unit, Unit};
+validate_spec(integer, []) -> {type, integer};
+validate_spec(float, []) -> {type, float};
+validate_spec(binary, []) -> {type, binary};
+validate_spec(bytes, []) -> {type, binary};
 validate_spec(bitstring, []) -> {type, bitstring};
-validate_spec(bits, [])      -> {type, bitstring};
-validate_spec(utf8, [])      -> {type, utf8};
-validate_spec(utf16, [])     -> {type, utf16};
-validate_spec(utf32, [])     -> {type, utf32};
-validate_spec(signed, [])    -> {sign, signed};
-validate_spec(unsigned, [])  -> {sign, unsigned};
-validate_spec(_, _)          -> none.
+validate_spec(bits, []) -> {type, bitstring};
+validate_spec(utf8, []) -> {type, utf8};
+validate_spec(utf16, []) -> {type, utf16};
+validate_spec(utf32, []) -> {type, utf32};
+validate_spec(signed, []) -> {sign, signed};
+validate_spec(unsigned, []) -> {sign, unsigned};
+validate_spec(_, _) -> none.
 
 expand_spec_arg(Expr, E, _OriginalE) when is_atom(Expr); is_integer(Expr) ->
-  {Expr, E};
+    {Expr, E};
 expand_spec_arg(Expr, #{context := match} = E, _OriginalE) ->
-  {EExpr, EE} = elixir_expand:expand(Expr, E#{context := nil, prematch_vars := raise}),
-  {EExpr, EE#{context := match, prematch_vars := ?key(E, prematch_vars)}};
+    {EExpr, EE} = elixir_expand:expand(Expr, E#{context := nil, prematch_vars := raise}),
+    {EExpr, EE#{context := match, prematch_vars := ?key(E, prematch_vars)}};
 expand_spec_arg(Expr, E, OriginalE) ->
-  elixir_expand:expand(Expr, elixir_env:reset_read(E, OriginalE)).
+    elixir_expand:expand(Expr, elixir_env:reset_read(E, OriginalE)).
 
 validate_spec_arg(Meta, size, Value, E, OriginalE) ->
-  case Value of
-    {Var, VarMeta, Context} when is_atom(Var) and is_atom(Context) ->
-      Tuple = {Var, elixir_utils:var_context(VarMeta, Context)},
+    case Value of
+        {Var, VarMeta, Context} when is_atom(Var) and is_atom(Context) ->
+            Tuple = {Var, elixir_utils:var_context(VarMeta, Context)},
 
-      case is_valid_spec_arg_var(Tuple, E, OriginalE) of
-        true -> ok;
-        false -> form_error(Meta, E, ?MODULE, {undefined_var_in_spec, Value})
-      end;
-
-    _ when is_integer(Value) ->
-      ok;
-
-    _ ->
-      form_error(Meta, E, ?MODULE, {bad_size_argument, Value})
-  end;
+            case is_valid_spec_arg_var(Tuple, E, OriginalE) of
+                true -> ok;
+                false -> form_error(Meta, E, ?MODULE, {undefined_var_in_spec, Value})
+            end;
+        _ when is_integer(Value) ->
+            ok;
+        _ ->
+            form_error(Meta, E, ?MODULE, {bad_size_argument, Value})
+    end;
 validate_spec_arg(Meta, unit, Value, E, _OriginalE) when not is_integer(Value) ->
-  form_error(Meta, E, ?MODULE, {bad_unit_argument, Value});
+    form_error(Meta, E, ?MODULE, {bad_unit_argument, Value});
 validate_spec_arg(_Meta, _Key, _Value, _E, _OriginalE) ->
-  ok.
+    ok.
 
 is_valid_spec_arg_var(Var, E, #{context := match} = OriginalE) ->
-  case OriginalE of
-    #{prematch_vars := {#{Var := _}, _}} -> true;
-    _ -> is_var(Var, E) andalso not is_var(Var, OriginalE)
-  end;
+    case OriginalE of
+        #{prematch_vars := {#{Var := _}, _}} -> true;
+        _ -> is_var(Var, E) andalso not is_var(Var, OriginalE)
+    end;
 is_valid_spec_arg_var(_Var, _E, _OriginalE) ->
-  true.
+    true.
 
 is_var(Var, #{current_vars := {Read, _}}) ->
-  maps:is_key(Var, Read).
+    maps:is_key(Var, Read).
 
-validate_size_required(Meta, true, default, Type, default, E) when Type == binary; Type == bitstring ->
-  form_error(Meta, E, ?MODULE, unsized_binary);
+validate_size_required(Meta, true, default, Type, default, E) when
+    Type == binary; Type == bitstring
+->
+    form_error(Meta, E, ?MODULE, unsized_binary);
 validate_size_required(_, _, _, _, _, _) ->
-  ok.
+    ok.
 
 size_and_unit(Meta, bitstring, Size, Unit, E) when Size /= default; Unit /= default ->
-  form_error(Meta, E, ?MODULE, bittype_literal_bitstring);
+    form_error(Meta, E, ?MODULE, bittype_literal_bitstring);
 size_and_unit(Meta, binary, Size, Unit, E) when Size /= default; Unit /= default ->
-  form_error(Meta, E, ?MODULE, bittype_literal_string);
+    form_error(Meta, E, ?MODULE, bittype_literal_string);
 size_and_unit(_Meta, _ExprType, Size, Unit, _E) ->
-  add_arg(unit, Unit, add_arg(size, Size, [])).
+    add_arg(unit, Unit, add_arg(size, Size, [])).
 
 add_arg(_Key, default, Spec) -> Spec;
 add_arg(Key, Arg, Spec) -> [{Key, [], [Arg]} | Spec].
 
-build_spec(Meta, Size, Unit, Type, Endianness, Sign, Spec, E) when Type == utf8; Type == utf16; Type == utf32 ->
-  if
-    Size /= default; Unit /= default ->
-      form_error(Meta, E, ?MODULE, bittype_utf);
-    Sign /= default ->
-      form_error(Meta, E, ?MODULE, bittype_signed);
-    true ->
-      add_spec(Type, add_spec(Endianness, Spec))
-  end;
-
-build_spec(Meta, _Size, Unit, Type, _Endianness, Sign, Spec, E) when Type == binary; Type == bitstring ->
-  if
-    Type == bitstring, Unit /= default, Unit /= 1 ->
-      form_error(Meta, E, ?MODULE, {bittype_mismatch, Unit, 1, unit});
-    Sign /= default ->
-      form_error(Meta, E, ?MODULE, bittype_signed);
-    true ->
-      %% Endianness is supported but has no effect, so we just ignore it.
-      add_spec(Type, Spec)
-  end;
-
+build_spec(Meta, Size, Unit, Type, Endianness, Sign, Spec, E) when
+    Type == utf8; Type == utf16; Type == utf32
+->
+    if
+        Size /= default; Unit /= default ->
+            form_error(Meta, E, ?MODULE, bittype_utf);
+        Sign /= default ->
+            form_error(Meta, E, ?MODULE, bittype_signed);
+        true ->
+            add_spec(Type, add_spec(Endianness, Spec))
+    end;
+build_spec(Meta, _Size, Unit, Type, _Endianness, Sign, Spec, E) when
+    Type == binary; Type == bitstring
+->
+    if
+        Type == bitstring, Unit /= default, Unit /= 1 ->
+            form_error(Meta, E, ?MODULE, {bittype_mismatch, Unit, 1, unit});
+        Sign /= default ->
+            form_error(Meta, E, ?MODULE, bittype_signed);
+        true ->
+            %% Endianness is supported but has no effect, so we just ignore it.
+            add_spec(Type, Spec)
+    end;
 build_spec(Meta, Size, Unit, Type, Endianness, Sign, Spec, E) when Type == integer; Type == float ->
-  NumberSize = number_size(Size, Unit),
-  if
-    Type == float, is_integer(NumberSize), NumberSize /= 32, NumberSize /= 64 ->
-      form_error(Meta, E, ?MODULE, {bittype_float_size, NumberSize});
-    Size == default, Unit /= default ->
-      form_error(Meta, E, ?MODULE, bittype_unit);
-    true ->
-      add_spec(Type, add_spec(Endianness, add_spec(Sign, Spec)))
-  end.
+    NumberSize = number_size(Size, Unit),
+    if
+        Type == float, is_integer(NumberSize), NumberSize /= 32, NumberSize /= 64 ->
+            form_error(Meta, E, ?MODULE, {bittype_float_size, NumberSize});
+        Size == default, Unit /= default ->
+            form_error(Meta, E, ?MODULE, bittype_unit);
+        true ->
+            add_spec(Type, add_spec(Endianness, add_spec(Sign, Spec)))
+    end.
 
 number_size(Size, default) when is_integer(Size) -> Size;
 number_size(Size, Unit) when is_integer(Size) -> Size * Unit;
@@ -335,64 +358,72 @@ add_spec(default, Spec) -> Spec;
 add_spec(Key, Spec) -> [{Key, [], []} | Spec].
 
 find_match([{'=', _, [_Left, _Right]} = Expr | _Rest]) ->
-  Expr;
+    Expr;
 find_match([{_, _, Args} | Rest]) when is_list(Args) ->
-  case find_match(Args) of
-    false -> find_match(Rest);
-    Match -> Match
-  end;
+    case find_match(Args) of
+        false -> find_match(Rest);
+        Match -> Match
+    end;
 find_match([_Arg | Rest]) ->
-  find_match(Rest);
+    find_match(Rest);
 find_match([]) ->
-  false.
+    false.
 
 format_error({unaligned_binary, Expr}) ->
-  Message = "expected ~ts to be a binary but its number of bits is not divisible by 8",
-  io_lib:format(Message, ['Elixir.Macro':to_string(Expr)]);
+    Message = "expected ~ts to be a binary but its number of bits is not divisible by 8",
+    io_lib:format(Message, ['Elixir.Macro':to_string(Expr)]);
 format_error(unsized_binary) ->
-  "a binary field without size is only allowed at the end of a binary pattern, "
-  "at the right side of binary concatenation and and never allowed in binary generators. "
-  "The following examples are invalid:\n\n"
-  "    rest <> \"foo\"\n"
-  "    <<rest::binary, \"foo\">>\n\n"
-  "They are invalid because there is a bits/bitstring component not at the end. "
-  "However, the \"reverse\" would work:\n\n"
-  "    \"foo\" <> rest\n"
-  "    <<\"foo\", rest::binary>>\n\n";
+    "a binary field without size is only allowed at the end of a binary pattern, "
+    "at the right side of binary concatenation and and never allowed in binary generators. "
+    "The following examples are invalid:\n\n"
+    "    rest <> \"foo\"\n"
+    "    <<rest::binary, \"foo\">>\n\n"
+    "They are invalid because there is a bits/bitstring component not at the end. "
+    "However, the \"reverse\" would work:\n\n"
+    "    \"foo\" <> rest\n"
+    "    <<\"foo\", rest::binary>>\n\n";
 format_error(bittype_literal_bitstring) ->
-  "literal <<>> in bitstring supports only type specifiers, which must be one of: "
+    "literal <<>> in bitstring supports only type specifiers, which must be one of: "
     "binary or bitstring";
 format_error(bittype_literal_string) ->
-  "literal string in bitstring supports only endianness and type specifiers, which must be one of: "
+    "literal string in bitstring supports only endianness and type specifiers, which must be one of: "
     "little, big, native, utf8, utf16, utf32, bits, bytes, binary or bitstring";
 format_error(bittype_utf) ->
-  "size and unit are not supported on utf types";
+    "size and unit are not supported on utf types";
 format_error(bittype_signed) ->
-  "signed and unsigned specifiers are supported only on integer and float types";
+    "signed and unsigned specifiers are supported only on integer and float types";
 format_error(bittype_unit) ->
-  "integer and float types require a size specifier if the unit specifier is given";
+    "integer and float types require a size specifier if the unit specifier is given";
 format_error({bittype_float_size, Other}) ->
-  io_lib:format("float requires size*unit to be 32 or 64 (default), got: ~p", [Other]);
+    io_lib:format("float requires size*unit to be 32 or 64 (default), got: ~p", [Other]);
 format_error({invalid_literal, Literal}) ->
-  io_lib:format("invalid literal ~ts in <<>>", ['Elixir.Macro':to_string(Literal)]);
+    io_lib:format("invalid literal ~ts in <<>>", ['Elixir.Macro':to_string(Literal)]);
 format_error({undefined_bittype, Expr}) ->
-  io_lib:format("unknown bitstring specifier: ~ts", ['Elixir.Macro':to_string(Expr)]);
+    io_lib:format("unknown bitstring specifier: ~ts", ['Elixir.Macro':to_string(Expr)]);
 format_error({bittype_mismatch, Val1, Val2, Where}) ->
-  io_lib:format("conflicting ~ts specification for bit field: \"~p\" and \"~p\"", [Where, Val1, Val2]);
+    io_lib:format("conflicting ~ts specification for bit field: \"~p\" and \"~p\"", [
+        Where,
+        Val1,
+        Val2
+    ]);
 format_error({bad_unit_argument, Unit}) ->
-  io_lib:format("unit in bitstring expects an integer as argument, got: ~ts",
-                ['Elixir.Macro':to_string(Unit)]);
+    io_lib:format(
+        "unit in bitstring expects an integer as argument, got: ~ts",
+        ['Elixir.Macro':to_string(Unit)]
+    );
 format_error({bad_size_argument, Size}) ->
-  io_lib:format("size in bitstring expects an integer or a variable as argument, got: ~ts",
-                ['Elixir.Macro':to_string(Size)]);
+    io_lib:format(
+        "size in bitstring expects an integer or a variable as argument, got: ~ts",
+        ['Elixir.Macro':to_string(Size)]
+    );
 format_error({nested_match, Expr}) ->
-  Message =
-    "cannot pattern match inside a bitstring "
-      "that is already in match, got: ~ts",
-  io_lib:format(Message, ['Elixir.Macro':to_string(Expr)]);
+    Message =
+        "cannot pattern match inside a bitstring "
+        "that is already in match, got: ~ts",
+    io_lib:format(Message, ['Elixir.Macro':to_string(Expr)]);
 format_error({undefined_var_in_spec, Var}) ->
-  Message =
-    "undefined variable \"~ts\" in bitstring segment. If the size of the binary is a "
-      "variable, the variable must be defined prior to its use in the binary/bitstring match "
-      "itself, or outside the pattern match",
-  io_lib:format(Message, ['Elixir.Macro':to_string(Var)]).
+    Message =
+        "undefined variable \"~ts\" in bitstring segment. If the size of the binary is a "
+        "variable, the variable must be defined prior to its use in the binary/bitstring match "
+        "itself, or outside the pattern match",
+    io_lib:format(Message, ['Elixir.Macro':to_string(Var)]).

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -1,480 +1,480 @@
 %% Translate Elixir quoted expressions to Erlang Abstract Format.
 -module(elixir_erl_pass).
+
 -export([translate/2, translate_args/2]).
+
 -include("elixir.hrl").
 
 %% =
 
 translate({'=', Meta, [{'_', _, Atom}, Right]}, S) when is_atom(Atom) ->
-  {TRight, SR} = translate(Right, S),
-  {{match, ?ann(Meta), {var, ?ann(Meta), '_'}, TRight}, SR};
-
+    {TRight, SR} = translate(Right, S),
+    {{match, ?ann(Meta), {var, ?ann(Meta), '_'}, TRight}, SR};
 translate({'=', Meta, [Left, Right]}, S) ->
-  {TRight, SR} = translate(Right, S),
-  case elixir_erl_clauses:match(fun translate/2, Left, SR) of
-    {TLeft, #elixir_erl{extra_guards=ExtraGuards, context=Context} = SL0}
-        when ExtraGuards =/= [], Context =/= match ->
-      SL1 = SL0#elixir_erl{extra_guards=[]},
-      {ResultVarName, SL2} = elixir_erl_var:build('_', SL1),
-      Match = {match, ?ann(Meta), TLeft, TRight},
-      Generated = ?ann(?generated(Meta)),
-      ResultVar = {var, Generated, ResultVarName},
-      ResultMatch = {match, Generated, ResultVar, Match},
-      True = {atom, Generated, true},
-      Reason = {tuple, Generated, [{atom, Generated, badmatch}, ResultVar]},
-      RaiseExpr = ?remote(Generated, erlang, error, [Reason]),
-      GuardsExp = {'if', Generated, [
-        {clause, Generated, [], [ExtraGuards], [ResultVar]},
-        {clause, Generated, [], [[True]], [RaiseExpr]}
-      ]},
-      {{block, Generated, [ResultMatch, GuardsExp]}, SL2};
-
-    {TLeft, SL} ->
-      {{match, ?ann(Meta), TLeft, TRight}, SL}
-  end;
-
+    {TRight, SR} = translate(Right, S),
+    case elixir_erl_clauses:match(fun translate/2, Left, SR) of
+        {TLeft, #elixir_erl{extra_guards = ExtraGuards, context = Context} = SL0} when
+            ExtraGuards =/= [], Context =/= match
+        ->
+            SL1 = SL0#elixir_erl{extra_guards = []},
+            {ResultVarName, SL2} = elixir_erl_var:build('_', SL1),
+            Match = {match, ?ann(Meta), TLeft, TRight},
+            Generated = ?ann(?generated(Meta)),
+            ResultVar = {var, Generated, ResultVarName},
+            ResultMatch = {match, Generated, ResultVar, Match},
+            True = {atom, Generated, true},
+            Reason = {tuple, Generated, [{atom, Generated, badmatch}, ResultVar]},
+            RaiseExpr = ?remote(Generated, erlang, error, [Reason]),
+            GuardsExp =
+                {'if', Generated, [
+                    {clause, Generated, [], [ExtraGuards], [ResultVar]},
+                    {clause, Generated, [], [[True]], [RaiseExpr]}
+                ]},
+            {{block, Generated, [ResultMatch, GuardsExp]}, SL2};
+        {TLeft, SL} ->
+            {{match, ?ann(Meta), TLeft, TRight}, SL}
+    end;
 %% Containers
 
 translate({'{}', Meta, Args}, S) when is_list(Args) ->
-  {TArgs, SE} = translate_args(Args, S),
-  {{tuple, ?ann(Meta), TArgs}, SE};
-
+    {TArgs, SE} = translate_args(Args, S),
+    {{tuple, ?ann(Meta), TArgs}, SE};
 translate({'%{}', Meta, Args}, S) when is_list(Args) ->
-  translate_map(Meta, Args, S);
-
-translate({'%', Meta, [{'^', _, [{Name, _, Context}]} = Left, Right]}, S) when is_atom(Name), is_atom(Context) ->
-  translate_struct_var_name(Meta, Left, Right, S);
-
-translate({'%', Meta, [{Name, _, Context} = Left, Right]}, S) when is_atom(Name), is_atom(Context) ->
-  translate_struct_var_name(Meta, Left, Right, S);
-
+    translate_map(Meta, Args, S);
+translate({'%', Meta, [{'^', _, [{Name, _, Context}]} = Left, Right]}, S) when
+    is_atom(Name), is_atom(Context)
+->
+    translate_struct_var_name(Meta, Left, Right, S);
+translate({'%', Meta, [{Name, _, Context} = Left, Right]}, S) when
+    is_atom(Name), is_atom(Context)
+->
+    translate_struct_var_name(Meta, Left, Right, S);
 translate({'%', Meta, [Left, Right]}, S) ->
-  translate_struct(Meta, Left, Right, S);
-
+    translate_struct(Meta, Left, Right, S);
 translate({'<<>>', Meta, Args}, S) when is_list(Args) ->
-  translate_bitstring(Meta, Args, S);
-
+    translate_bitstring(Meta, Args, S);
 %% Blocks
 
 translate({'__block__', Meta, Args}, S) when is_list(Args) ->
-  {TArgs, SA} = translate_block(Args, [], S),
-  {{block, ?ann(Meta), TArgs}, SA};
-
+    {TArgs, SA} = translate_block(Args, [], S),
+    {{block, ?ann(Meta), TArgs}, SA};
 %% Compilation environment macros
 
 translate({'__CALLER__', Meta, Atom}, S) when is_atom(Atom) ->
-  {{var, ?ann(Meta), '__CALLER__'}, S#elixir_erl{caller=true}};
-
-translate({'__STACKTRACE__', Meta, Atom}, S = #elixir_erl{stacktrace=Var}) when is_atom(Atom) ->
-  {{var, ?ann(Meta), Var}, S};
-
+    {{var, ?ann(Meta), '__CALLER__'}, S#elixir_erl{caller = true}};
+translate({'__STACKTRACE__', Meta, Atom}, S = #elixir_erl{stacktrace = Var}) when is_atom(Atom) ->
+    {{var, ?ann(Meta), Var}, S};
 translate({'super', Meta, Args}, S) when is_list(Args) ->
-  %% In the expanded AST, super is used to invoke a function
-  %% in the current module originated from a default clause
-  %% or a super call.
-  {TArgs, SA} = translate_args(Args, S),
-  Ann = ?ann(Meta),
-  {super, {Kind, Name}} = lists:keyfind(super, 1, Meta),
+    %% In the expanded AST, super is used to invoke a function
+    %% in the current module originated from a default clause
+    %% or a super call.
+    {TArgs, SA} = translate_args(Args, S),
+    Ann = ?ann(Meta),
+    {super, {Kind, Name}} = lists:keyfind(super, 1, Meta),
 
-  if
-    Kind == defmacro; Kind == defmacrop ->
-      MacroName = elixir_utils:macro_name(Name),
-      {{call, Ann, {atom, Ann, MacroName}, [{var, Ann, '__CALLER__'} | TArgs]}, SA#elixir_erl{caller=true}};
-    Kind == def; Kind == defp ->
-      {{call, Ann, {atom, Ann, Name}, TArgs}, SA}
-  end;
-
+    if
+        Kind == defmacro; Kind == defmacrop ->
+            MacroName = elixir_utils:macro_name(Name),
+            {{call, Ann, {atom, Ann, MacroName}, [{var, Ann, '__CALLER__'} | TArgs]}, SA#elixir_erl{
+                    caller = true
+                }};
+        Kind == def; Kind == defp ->
+            {{call, Ann, {atom, Ann, Name}, TArgs}, SA}
+    end;
 %% Functions
 
-translate({'&', Meta, [{'/', _, [{{'.', _, [Remote, Fun]}, _, []}, Arity]}]}, S)
-    when is_atom(Fun), is_integer(Arity) ->
-  {TRemote, SR} = translate(Remote, S),
-  Ann = ?ann(Meta),
-  TFun = {atom, Ann, Fun},
-  TArity = {integer, Ann, Arity},
-  {{'fun', Ann, {function, TRemote, TFun, TArity}}, SR};
-translate({'&', Meta, [{'/', _, [{Fun, _, Atom}, Arity]}]}, S)
-    when is_atom(Fun), is_atom(Atom), is_integer(Arity) ->
-  case S of
-    #elixir_erl{expand_captures=true} ->
-      {Vars, SV} = lists:mapfoldl(fun(_, Acc) ->
-        {Var, _, AccS} = elixir_erl_var:assign(Meta, Acc),
-        {Var, AccS}
-      end, S, tl(lists:seq(0, Arity))),
-      translate({'fn', Meta, [{'->', Meta, [Vars, {Fun, Meta, Vars}]}]}, SV);
-
-    #elixir_erl{expand_captures=false} ->
-      {{'fun', ?ann(Meta), {function, Fun, Arity}}, S}
-  end;
-
+translate({'&', Meta, [{'/', _, [{{'.', _, [Remote, Fun]}, _, []}, Arity]}]}, S) when
+    is_atom(Fun), is_integer(Arity)
+->
+    {TRemote, SR} = translate(Remote, S),
+    Ann = ?ann(Meta),
+    TFun = {atom, Ann, Fun},
+    TArity = {integer, Ann, Arity},
+    {{'fun', Ann, {function, TRemote, TFun, TArity}}, SR};
+translate({'&', Meta, [{'/', _, [{Fun, _, Atom}, Arity]}]}, S) when
+    is_atom(Fun), is_atom(Atom), is_integer(Arity)
+->
+    case S of
+        #elixir_erl{expand_captures = true} ->
+            {Vars, SV} = lists:mapfoldl(
+                fun(_, Acc) ->
+                    {Var, _, AccS} = elixir_erl_var:assign(Meta, Acc),
+                    {Var, AccS}
+                end,
+                S,
+                tl(lists:seq(0, Arity))
+            ),
+            translate({'fn', Meta, [{'->', Meta, [Vars, {Fun, Meta, Vars}]}]}, SV);
+        #elixir_erl{expand_captures = false} ->
+            {{'fun', ?ann(Meta), {function, Fun, Arity}}, S}
+    end;
 translate({fn, Meta, Clauses}, S) ->
-  Transformer = fun({'->', CMeta, [ArgsWithGuards, Expr]}, Acc) ->
-    {Args, Guards} = elixir_utils:extract_splat_guards(ArgsWithGuards),
-    elixir_erl_clauses:clause(CMeta, fun translate_fn_match/2, Args, Expr, Guards, Acc)
-  end,
-  {TClauses, NS} = lists:mapfoldl(Transformer, S, Clauses),
-  {{'fun', ?ann(Meta), {clauses, TClauses}}, NS};
-
+    Transformer = fun({'->', CMeta, [ArgsWithGuards, Expr]}, Acc) ->
+        {Args, Guards} = elixir_utils:extract_splat_guards(ArgsWithGuards),
+        elixir_erl_clauses:clause(CMeta, fun translate_fn_match/2, Args, Expr, Guards, Acc)
+    end,
+    {TClauses, NS} = lists:mapfoldl(Transformer, S, Clauses),
+    {{'fun', ?ann(Meta), {clauses, TClauses}}, NS};
 %% Cond
 
 translate({'cond', CondMeta, [[{do, Clauses}]]}, S) ->
-  [{'->', Meta, [[Condition], _]} = H | T] = lists:reverse(Clauses),
+    [{'->', Meta, [[Condition], _]} = H | T] = lists:reverse(Clauses),
 
-  FirstMeta =
-    if
-      is_atom(Condition), Condition /= false, Condition /= nil -> ?generated(Meta);
-      true -> Meta
-    end,
+    FirstMeta =
+        if
+            is_atom(Condition), Condition /= false, Condition /= nil -> ?generated(Meta);
+            true -> Meta
+        end,
 
-  Error = {{'.', Meta, [erlang, error]}, Meta, [cond_clause]},
-  {Case, SC} = build_cond_clauses([H | T], Error, FirstMeta, S),
-  translate(replace_case_meta(CondMeta, Case), SC);
-
+    Error = {{'.', Meta, [erlang, error]}, Meta, [cond_clause]},
+    {Case, SC} = build_cond_clauses([H | T], Error, FirstMeta, S),
+    translate(replace_case_meta(CondMeta, Case), SC);
 %% Case
 
 translate({'case', Meta, [Expr, Opts]}, S) ->
-  translate_case(Meta, Expr, Opts, S);
-
+    translate_case(Meta, Expr, Opts, S);
 %% Try
 
 translate({'try', Meta, [Opts]}, S) ->
-  Do = proplists:get_value('do', Opts, nil),
-  {TDo, SB} = translate(Do, S),
+    Do = proplists:get_value('do', Opts, nil),
+    {TDo, SB} = translate(Do, S),
 
-  Catch = [Tuple || {X, _} = Tuple <- Opts, X == 'rescue' orelse X == 'catch'],
-  {TCatch, SC} = elixir_erl_try:clauses(Meta, Catch, SB),
+    Catch = [Tuple || {X, _} = Tuple <- Opts, X == 'rescue' orelse X == 'catch'],
+    {TCatch, SC} = elixir_erl_try:clauses(Meta, Catch, SB),
 
-  {TAfter, SA} = case lists:keyfind('after', 1, Opts) of
-    {'after', After} ->
-      {TBlock, SAExtracted} = translate(After, SC),
-      {unblock(TBlock), SAExtracted};
-    false ->
-      {[], SC}
-  end,
+    {TAfter, SA} =
+        case lists:keyfind('after', 1, Opts) of
+            {'after', After} ->
+                {TBlock, SAExtracted} = translate(After, SC),
+                {unblock(TBlock), SAExtracted};
+            false ->
+                {[], SC}
+        end,
 
-  Else = elixir_erl_clauses:get_clauses(else, Opts, match),
-  {TElse, SE} = elixir_erl_clauses:clauses(Else, SA),
-  {{'try', ?ann(Meta), unblock(TDo), TElse, TCatch, TAfter}, SE};
-
+    Else = elixir_erl_clauses:get_clauses(else, Opts, match),
+    {TElse, SE} = elixir_erl_clauses:clauses(Else, SA),
+    {{'try', ?ann(Meta), unblock(TDo), TElse, TCatch, TAfter}, SE};
 %% Receive
 
 translate({'receive', Meta, [Opts]}, S) ->
-  Do = elixir_erl_clauses:get_clauses(do, Opts, match),
+    Do = elixir_erl_clauses:get_clauses(do, Opts, match),
 
-  case lists:keyfind('after', 1, Opts) of
-    false ->
-      {TClauses, SC} = elixir_erl_clauses:clauses(Do, S),
-      {{'receive', ?ann(Meta), TClauses}, SC};
-    _ ->
-      After = elixir_erl_clauses:get_clauses('after', Opts, expr),
-      {TClauses, SC} = elixir_erl_clauses:clauses(Do ++ After, S),
-      {FClauses, TAfter} = elixir_utils:split_last(TClauses),
-      {_, _, [FExpr], _, FAfter} = TAfter,
-      {{'receive', ?ann(Meta), FClauses, FExpr, FAfter}, SC}
-  end;
-
+    case lists:keyfind('after', 1, Opts) of
+        false ->
+            {TClauses, SC} = elixir_erl_clauses:clauses(Do, S),
+            {{'receive', ?ann(Meta), TClauses}, SC};
+        _ ->
+            After = elixir_erl_clauses:get_clauses('after', Opts, expr),
+            {TClauses, SC} = elixir_erl_clauses:clauses(Do ++ After, S),
+            {FClauses, TAfter} = elixir_utils:split_last(TClauses),
+            {_, _, [FExpr], _, FAfter} = TAfter,
+            {{'receive', ?ann(Meta), FClauses, FExpr, FAfter}, SC}
+    end;
 %% Comprehensions and with
 
 translate({for, Meta, [_ | _] = Args}, S) ->
-  elixir_erl_for:translate(Meta, Args, true, S);
-
+    elixir_erl_for:translate(Meta, Args, true, S);
 translate({with, Meta, [_ | _] = Args}, S) ->
-  {Exprs, [{do, Do} | Opts]} = elixir_utils:split_last(Args),
-  {ElseClause, SE} = translate_with_else(Meta, Opts, S),
-  translate_with_do(Exprs, Do, ElseClause, SE);
-
+    {Exprs, [{do, Do} | Opts]} = elixir_utils:split_last(Args),
+    {ElseClause, SE} = translate_with_else(Meta, Opts, S),
+    translate_with_do(Exprs, Do, ElseClause, SE);
 %% Variables
 
-translate({'^', _, [{Name, VarMeta, Kind}]}, #elixir_erl{context=match} = S) when is_atom(Name), is_atom(Kind) ->
-  {Var, VS} = elixir_erl_var:translate(VarMeta, Name, Kind, S),
+translate({'^', _, [{Name, VarMeta, Kind}]}, #elixir_erl{context = match} = S) when
+    is_atom(Name), is_atom(Kind)
+->
+    {Var, VS} = elixir_erl_var:translate(VarMeta, Name, Kind, S),
 
-  case S#elixir_erl.extra of
-    pin_guard ->
-      {PinVarName, PS} = elixir_erl_var:build('_', VS),
-      Ann = ?ann(?generated(VarMeta)),
-      PinVar = {var, Ann, PinVarName},
-      Guard = {op, Ann, '=:=', Var, PinVar},
-      {PinVar, PS#elixir_erl{extra_guards=[Guard | PS#elixir_erl.extra_guards]}};
-    _ ->
-      {Var, VS}
-  end;
-
+    case S#elixir_erl.extra of
+        pin_guard ->
+            {PinVarName, PS} = elixir_erl_var:build('_', VS),
+            Ann = ?ann(?generated(VarMeta)),
+            PinVar = {var, Ann, PinVarName},
+            Guard = {op, Ann, '=:=', Var, PinVar},
+            {PinVar, PS#elixir_erl{extra_guards = [Guard | PS#elixir_erl.extra_guards]}};
+        _ ->
+            {Var, VS}
+    end;
 translate({Name, Meta, Kind}, S) when is_atom(Name), is_atom(Kind) ->
-  elixir_erl_var:translate(Meta, Name, Kind, S);
-
+    elixir_erl_var:translate(Meta, Name, Kind, S);
 %% Local calls
 
 translate({Name, Meta, Args}, S) when is_atom(Name), is_list(Meta), is_list(Args) ->
-  Ann = ?ann(Meta),
-  {TArgs, NS} = translate_args(Args, S),
-  {{call, Ann, {atom, Ann, Name}, TArgs}, NS};
-
+    Ann = ?ann(Meta),
+    {TArgs, NS} = translate_args(Args, S),
+    {{call, Ann, {atom, Ann, Name}, TArgs}, NS};
 %% Remote calls
 
-translate({{'.', _, [Left, Right]}, Meta, []}, #elixir_erl{context=guard} = S)
-    when is_tuple(Left), is_atom(Right), is_list(Meta) ->
-  {TLeft, SL}  = translate(Left, S),
-  Ann = ?ann(Meta),
-  TRight = {atom, Ann, Right},
-  {?remote(Ann, erlang, map_get, [TRight, TLeft]), SL};
+translate({{'.', _, [Left, Right]}, Meta, []}, #elixir_erl{context = guard} = S) when
+    is_tuple(Left), is_atom(Right), is_list(Meta)
+->
+    {TLeft, SL} = translate(Left, S),
+    Ann = ?ann(Meta),
+    TRight = {atom, Ann, Right},
+    {?remote(Ann, erlang, map_get, [TRight, TLeft]), SL};
+translate({{'.', _, [Left, Right]}, Meta, []}, S) when
+    is_tuple(Left), is_atom(Right), is_list(Meta)
+->
+    {TLeft, SL} = translate(Left, S),
+    Ann = ?ann(Meta),
+    TRight = {atom, Ann, Right},
 
-translate({{'.', _, [Left, Right]}, Meta, []}, S) when is_tuple(Left), is_atom(Right), is_list(Meta) ->
-  {TLeft, SL}  = translate(Left, S),
-  Ann = ?ann(Meta),
-  TRight = {atom, Ann, Right},
+    {Var, SV} = elixir_erl_var:build('_', SL),
+    TVar = {var, Ann, Var},
+    Generated = erl_anno:set_generated(true, Ann),
+    TError = {tuple, Ann, [{atom, Ann, badkey}, TRight, TVar]},
 
-  {Var, SV} = elixir_erl_var:build('_', SL),
-  TVar = {var, Ann, Var},
-  Generated = erl_anno:set_generated(true, Ann),
-  TError = {tuple, Ann, [{atom, Ann, badkey}, TRight, TVar]},
-
-  {{'case', Generated, TLeft, [
-    {clause, Generated,
-      [{map, Ann, [{map_field_exact, Ann, TRight, TVar}]}],
-      [],
-      [TVar]},
-    {clause, Generated,
-      [TVar],
-      [[?remote(Generated, erlang, is_map, [TVar])]],
-      [?remote(Ann, erlang, error, [TError])]},
-    {clause, Generated,
-      [TVar],
-      [],
-      [{call, Generated, {remote, Generated, TVar, TRight}, []}]}
-  ]}, SV};
-
-translate({{'.', _, [Left, Right]}, Meta, Args}, S)
-    when (is_tuple(Left) orelse is_atom(Left)), is_atom(Right), is_list(Meta), is_list(Args) ->
-  translate_remote(Left, Right, Meta, Args, S);
-
+    {{'case', Generated, TLeft, [
+            {clause, Generated, [{map, Ann, [{map_field_exact, Ann, TRight, TVar}]}], [], [TVar]},
+            {clause, Generated, [TVar], [[?remote(Generated, erlang, is_map, [TVar])]], [
+                ?remote(Ann, erlang, error, [TError])
+            ]},
+            {clause, Generated, [TVar], [], [
+                {call, Generated, {remote, Generated, TVar, TRight}, []}
+            ]}
+        ]},
+        SV};
+translate({{'.', _, [Left, Right]}, Meta, Args}, S) when
+    (is_tuple(Left) orelse is_atom(Left)), is_atom(Right), is_list(Meta), is_list(Args)
+->
+    translate_remote(Left, Right, Meta, Args, S);
 %% Anonymous function calls
 
 translate({{'.', _, [Expr]}, Meta, Args}, S) when is_list(Args) ->
-  {TExpr, SE} = translate(Expr, S),
-  {TArgs, SA} = translate_args(Args, SE),
-  {{call, ?ann(Meta), TExpr, TArgs}, SA};
-
+    {TExpr, SE} = translate(Expr, S),
+    {TArgs, SA} = translate_args(Args, SE),
+    {{call, ?ann(Meta), TExpr, TArgs}, SA};
 %% Literals
 
 translate(List, S) when is_list(List) ->
-  translate_list(List, S, []);
-
+    translate_list(List, S, []);
 translate({Left, Right}, S) ->
-  {TArgs, SE} = translate_args([Left, Right], S),
-  {{tuple, 0, TArgs}, SE};
-
+    {TArgs, SE} = translate_args([Left, Right], S),
+    {{tuple, 0, TArgs}, SE};
 translate(Other, S) ->
-  {elixir_erl:elixir_to_erl(Other), S}.
+    {elixir_erl:elixir_to_erl(Other), S}.
 
 %% Helpers
 
 translate_case(Meta, Expr, Opts, S) ->
-  Clauses = elixir_erl_clauses:get_clauses(do, Opts, match),
-  {TExpr, SE} = translate(Expr, S),
-  {TClauses, SC} = elixir_erl_clauses:clauses(Clauses, SE),
-  {{'case', ?ann(Meta), TExpr, TClauses}, SC}.
+    Clauses = elixir_erl_clauses:get_clauses(do, Opts, match),
+    {TExpr, SE} = translate(Expr, S),
+    {TClauses, SC} = elixir_erl_clauses:clauses(Clauses, SE),
+    {{'case', ?ann(Meta), TExpr, TClauses}, SC}.
 
-translate_list([{'|', _, [_, _]=Args}], Acc, List) ->
-  {[TLeft, TRight], TAcc} = lists:mapfoldl(fun translate/2, Acc, Args),
-  {build_list([TLeft | List], TRight), TAcc};
+translate_list([{'|', _, [_, _] = Args}], Acc, List) ->
+    {[TLeft, TRight], TAcc} = lists:mapfoldl(fun translate/2, Acc, Args),
+    {build_list([TLeft | List], TRight), TAcc};
 translate_list([H | T], Acc, List) ->
-  {TH, TAcc} = translate(H, Acc),
-  translate_list(T, TAcc, [TH | List]);
+    {TH, TAcc} = translate(H, Acc),
+    translate_list(T, TAcc, [TH | List]);
 translate_list([], Acc, List) ->
-  {build_list(List, {nil, 0}), Acc}.
+    {build_list(List, {nil, 0}), Acc}.
 
 build_list([H | T], Acc) ->
-  build_list(T, {cons, 0, H, Acc});
+    build_list(T, {cons, 0, H, Acc});
 build_list([], Acc) ->
-  Acc.
+    Acc.
 
 %% Pack a list of expressions from a block.
 unblock({'block', _, Exprs}) -> Exprs;
-unblock(Expr)                -> [Expr].
+unblock(Expr) -> [Expr].
 
 translate_fn_match(Arg, S) ->
-  {TArg, TS} = translate_args(Arg, S#elixir_erl{extra=pin_guard}),
-  {TArg, TS#elixir_erl{extra=S#elixir_erl.extra}}.
+    {TArg, TS} = translate_args(Arg, S#elixir_erl{extra = pin_guard}),
+    {TArg, TS#elixir_erl{extra = S#elixir_erl.extra}}.
 
 %% Translate args
 
 translate_args(Args, S) ->
-  lists:mapfoldl(fun translate/2, S, Args).
+    lists:mapfoldl(fun translate/2, S, Args).
 
 %% Translate blocks
 
 translate_block([], Acc, S) ->
-  {lists:reverse(Acc), S};
+    {lists:reverse(Acc), S};
 translate_block([H], Acc, S) ->
-  {TH, TS} = translate(H, S),
-  translate_block([], [TH | Acc], TS);
+    {TH, TS} = translate(H, S),
+    translate_block([], [TH | Acc], TS);
 translate_block([{'__block__', _Meta, Args} | T], Acc, S) when is_list(Args) ->
-  translate_block(Args ++ T, Acc, S);
+    translate_block(Args ++ T, Acc, S);
 translate_block([{for, Meta, [_ | _] = Args} | T], Acc, S) ->
-  {TH, TS} = elixir_erl_for:translate(Meta, Args, false, S),
-  translate_block(T, [TH | Acc], TS);
-translate_block([{'=', _, [{'_', _, Ctx}, {for, Meta, [_ | _] = Args}]} | T], Acc, S) when is_atom(Ctx) ->
-  {TH, TS} = elixir_erl_for:translate(Meta, Args, false, S),
-  translate_block(T, [TH | Acc], TS);
+    {TH, TS} = elixir_erl_for:translate(Meta, Args, false, S),
+    translate_block(T, [TH | Acc], TS);
+translate_block([{'=', _, [{'_', _, Ctx}, {for, Meta, [_ | _] = Args}]} | T], Acc, S) when
+    is_atom(Ctx)
+->
+    {TH, TS} = elixir_erl_for:translate(Meta, Args, false, S),
+    translate_block(T, [TH | Acc], TS);
 translate_block([H | T], Acc, S) ->
-  {TH, TS} = translate(H, S),
-  translate_block(T, [TH | Acc], TS).
+    {TH, TS} = translate(H, S),
+    translate_block(T, [TH | Acc], TS).
 
 %% Cond
 
 build_cond_clauses([{'->', NewMeta, [[Condition], Body]} | T], Acc, OldMeta, S) ->
-  {NewCondition, Truthy, Other, ST} = build_truthy_clause(NewMeta, Condition, Body, S),
-  Falsy = {'->', OldMeta, [[Other], Acc]},
-  Case = {'case', NewMeta, [NewCondition, [{do, [Truthy, Falsy]}]]},
-  build_cond_clauses(T, Case, NewMeta, ST);
+    {NewCondition, Truthy, Other, ST} = build_truthy_clause(NewMeta, Condition, Body, S),
+    Falsy = {'->', OldMeta, [[Other], Acc]},
+    Case = {'case', NewMeta, [NewCondition, [{do, [Truthy, Falsy]}]]},
+    build_cond_clauses(T, Case, NewMeta, ST);
 build_cond_clauses([], Acc, _, S) ->
-  {Acc, S}.
+    {Acc, S}.
 
 replace_case_meta(Meta, {'case', _, Args}) ->
-  {'case', Meta, Args};
+    {'case', Meta, Args};
 replace_case_meta(_Meta, Other) ->
-  Other.
+    Other.
 
 build_truthy_clause(Meta, Condition, Body, S) ->
-  case returns_boolean(Condition, Body) of
-    {NewCondition, NewBody} ->
-      {NewCondition, {'->', Meta, [[true], NewBody]}, false, S};
-    false ->
-      {Var, _, SV} = elixir_erl_var:assign(Meta, S),
-      Head = {'when', [], [Var,
-        {{'.', [], [erlang, 'andalso']}, [], [
-          {{'.', [], [erlang, '/=']}, [], [Var, nil]},
-          {{'.', [], [erlang, '/=']}, [], [Var, false]}
-        ]}
-      ]},
-      {Condition, {'->', Meta, [[Head], Body]}, {'_', [], nil}, SV}
-  end.
+    case returns_boolean(Condition, Body) of
+        {NewCondition, NewBody} ->
+            {NewCondition, {'->', Meta, [[true], NewBody]}, false, S};
+        false ->
+            {Var, _, SV} = elixir_erl_var:assign(Meta, S),
+            Head =
+                {'when', [], [
+                    Var,
+                    {{'.', [], [erlang, 'andalso']}, [], [
+                        {{'.', [], [erlang, '/=']}, [], [Var, nil]},
+                        {{'.', [], [erlang, '/=']}, [], [Var, false]}
+                    ]}
+                ]},
+            {Condition, {'->', Meta, [[Head], Body]}, {'_', [], nil}, SV}
+    end.
 
 %% In case a variable is defined to match in a condition
 %% but a condition returns boolean, we can replace the
 %% variable directly by the boolean result.
-returns_boolean({'=', _, [{Var, _, Ctx}, Condition]}, {Var, _, Ctx}) when is_atom(Var), is_atom(Ctx) ->
-  case elixir_utils:returns_boolean(Condition) of
-    true  -> {Condition, true};
-    false -> false
-  end;
-
+returns_boolean({'=', _, [{Var, _, Ctx}, Condition]}, {Var, _, Ctx}) when
+    is_atom(Var), is_atom(Ctx)
+->
+    case elixir_utils:returns_boolean(Condition) of
+        true -> {Condition, true};
+        false -> false
+    end;
 %% For all other cases, we check the condition but
 %% return both condition and body untouched.
 returns_boolean(Condition, Body) ->
-  case elixir_utils:returns_boolean(Condition) of
-    true  -> {Condition, Body};
-    false -> false
-  end.
+    case elixir_utils:returns_boolean(Condition) of
+        true -> {Condition, Body};
+        false -> false
+    end.
 
 %% with
 
 translate_with_else(Meta, [], S) ->
-  Ann = ?ann(?generated(Meta)),
-  {VarName, SC} = elixir_erl_var:build('_', S),
-  Var = {var, Ann, VarName},
-  {{clause, Ann, [Var], [], [Var]}, SC};
-translate_with_else(Meta, [{else, [{'->', _, [[{Var, VarMeta, Kind}], Clause]}]}], S) when is_atom(Var), is_atom(Kind) ->
-  Ann = ?ann(?generated(Meta)),
-  {ElseVarErl, SV} = elixir_erl_var:translate(VarMeta, Var, Kind, S#elixir_erl{context=match}),
-  {TranslatedClause, SC} = elixir_erl_pass:translate(Clause, SV#elixir_erl{context=nil}),
-  {{clause, Ann, [ElseVarErl], [], [TranslatedClause]}, SC};
+    Ann = ?ann(?generated(Meta)),
+    {VarName, SC} = elixir_erl_var:build('_', S),
+    Var = {var, Ann, VarName},
+    {{clause, Ann, [Var], [], [Var]}, SC};
+translate_with_else(Meta, [{else, [{'->', _, [[{Var, VarMeta, Kind}], Clause]}]}], S) when
+    is_atom(Var), is_atom(Kind)
+->
+    Ann = ?ann(?generated(Meta)),
+    {ElseVarErl, SV} = elixir_erl_var:translate(VarMeta, Var, Kind, S#elixir_erl{context = match}),
+    {TranslatedClause, SC} = elixir_erl_pass:translate(Clause, SV#elixir_erl{context = nil}),
+    {{clause, Ann, [ElseVarErl], [], [TranslatedClause]}, SC};
 translate_with_else(Meta, [{else, Else}], S) ->
-  Generated = ?generated(Meta),
-  {ElseVarEx, ElseVarErl, SE} = elixir_erl_var:assign(Generated, S),
-  {RaiseVar, _, SV} = elixir_erl_var:assign(Generated, SE),
+    Generated = ?generated(Meta),
+    {ElseVarEx, ElseVarErl, SE} = elixir_erl_var:assign(Generated, S),
+    {RaiseVar, _, SV} = elixir_erl_var:assign(Generated, SE),
 
-  RaiseExpr = {{'.', Generated, [erlang, error]}, Generated, [{with_clause, RaiseVar}]},
-  RaiseClause = {'->', Generated, [[RaiseVar], RaiseExpr]},
-  GeneratedElse = [build_generated_clause(Generated, ElseClause) || ElseClause <- Else],
+    RaiseExpr = {{'.', Generated, [erlang, error]}, Generated, [{with_clause, RaiseVar}]},
+    RaiseClause = {'->', Generated, [[RaiseVar], RaiseExpr]},
+    GeneratedElse = [build_generated_clause(Generated, ElseClause) || ElseClause <- Else],
 
-  Case = {'case', Generated, [ElseVarEx, [{do, GeneratedElse ++ [RaiseClause]}]]},
-  {TranslatedCase, SC} = elixir_erl_pass:translate(Case, SV),
-  {{clause, ?ann(Generated), [ElseVarErl], [], [TranslatedCase]}, SC}.
+    Case = {'case', Generated, [ElseVarEx, [{do, GeneratedElse ++ [RaiseClause]}]]},
+    {TranslatedCase, SC} = elixir_erl_pass:translate(Case, SV),
+    {{clause, ?ann(Generated), [ElseVarErl], [], [TranslatedCase]}, SC}.
 
 build_generated_clause(Generated, {'->', _, [Args, Clause]}) ->
-  NewArgs = [build_generated_clause_arg(Generated, Arg) || Arg <- Args],
-  {'->', Generated, [NewArgs, Clause]}.
+    NewArgs = [build_generated_clause_arg(Generated, Arg) || Arg <- Args],
+    {'->', Generated, [NewArgs, Clause]}.
 
 build_generated_clause_arg(Generated, Arg) ->
-  {Expr, Guards} = elixir_utils:extract_guards(Arg),
-  NewGuards = [build_generated_guard(Generated, Guard) || Guard <- Guards],
-  concat_guards(Generated, Expr, NewGuards).
+    {Expr, Guards} = elixir_utils:extract_guards(Arg),
+    NewGuards = [build_generated_guard(Generated, Guard) || Guard <- Guards],
+    concat_guards(Generated, Expr, NewGuards).
 
 build_generated_guard(Generated, {{'.', _, _} = Call, _, Args}) ->
-  {Call, Generated, [build_generated_guard(Generated, Arg) || Arg <- Args]};
+    {Call, Generated, [build_generated_guard(Generated, Arg) || Arg <- Args]};
 build_generated_guard(_, Expr) ->
-  Expr.
+    Expr.
 
 concat_guards(_Meta, Expr, []) ->
-  Expr;
+    Expr;
 concat_guards(Meta, Expr, [Guard | Tail]) ->
-  {'when', Meta, [Expr, concat_guards(Meta, Guard, Tail)]}.
+    {'when', Meta, [Expr, concat_guards(Meta, Guard, Tail)]}.
 
 translate_with_do([{'<-', Meta, [Left, Expr]} | Rest], Do, Else, S) ->
-  {Args, Guards} = elixir_utils:extract_guards(Left),
-  {TExpr, SR} = elixir_erl_pass:translate(Expr, S),
-  {TArgs, SA} = elixir_erl_clauses:match(fun elixir_erl_pass:translate/2, Args, SR),
-  TGuards = elixir_erl_clauses:guards(Guards, SA#elixir_erl.extra_guards, SA),
-  {TBody, SB} = translate_with_do(Rest, Do, Else, SA#elixir_erl{extra_guards=[]}),
+    {Args, Guards} = elixir_utils:extract_guards(Left),
+    {TExpr, SR} = elixir_erl_pass:translate(Expr, S),
+    {TArgs, SA} = elixir_erl_clauses:match(fun elixir_erl_pass:translate/2, Args, SR),
+    TGuards = elixir_erl_clauses:guards(Guards, SA#elixir_erl.extra_guards, SA),
+    {TBody, SB} = translate_with_do(Rest, Do, Else, SA#elixir_erl{extra_guards = []}),
 
-  Clause = {clause, ?ann(Meta), [TArgs], TGuards, unblock(TBody)},
-  {{'case', ?ann(?generated(Meta)), TExpr, [Clause, Else]}, SB};
+    Clause = {clause, ?ann(Meta), [TArgs], TGuards, unblock(TBody)},
+    {{'case', ?ann(?generated(Meta)), TExpr, [Clause, Else]}, SB};
 translate_with_do([Expr | Rest], Do, Else, S) ->
-  {TExpr, TS} = elixir_erl_pass:translate(Expr, S),
-  {TRest, RS} = translate_with_do(Rest, Do, Else, TS),
-  {{block, 0, [TExpr | unblock(TRest)]}, RS};
+    {TExpr, TS} = elixir_erl_pass:translate(Expr, S),
+    {TRest, RS} = translate_with_do(Rest, Do, Else, TS),
+    {{block, 0, [TExpr | unblock(TRest)]}, RS};
 translate_with_do([], Do, _Else, S) ->
-  elixir_erl_pass:translate(Do, S).
+    elixir_erl_pass:translate(Do, S).
 
 %% Maps and structs
 
 translate_struct_var_name(Meta, Name, Args, S0) ->
-  {{map, MapAnn, TArgs0}, S1} = translate_struct(Meta, Name, Args, S0),
-  {TArgs1, S2} = generate_struct_name_guard(TArgs0, [], S1),
-  {{map, MapAnn, TArgs1}, S2}.
+    {{map, MapAnn, TArgs0}, S1} = translate_struct(Meta, Name, Args, S0),
+    {TArgs1, S2} = generate_struct_name_guard(TArgs0, [], S1),
+    {{map, MapAnn, TArgs1}, S2}.
 
 translate_struct(Meta, Name, {'%{}', _, [{'|', _, [Update, Assocs]}]}, S) ->
-  Ann = ?ann(Meta),
-  Generated = erl_anno:set_generated(true, Ann),
-  {VarName, VS} = elixir_erl_var:build('_', S),
+    Ann = ?ann(Meta),
+    Generated = erl_anno:set_generated(true, Ann),
+    {VarName, VS} = elixir_erl_var:build('_', S),
 
-  Var = {var, Ann, VarName},
-  Map = {map, Ann, [{map_field_exact, Ann, {atom, Ann, '__struct__'}, {atom, Ann, Name}}]},
+    Var = {var, Ann, VarName},
+    Map = {map, Ann, [{map_field_exact, Ann, {atom, Ann, '__struct__'}, {atom, Ann, Name}}]},
 
-  Match = {match, Ann, Var, Map},
-  Error = {tuple, Ann, [{atom, Ann, badstruct}, {atom, Ann, Name}, Var]},
+    Match = {match, Ann, Var, Map},
+    Error = {tuple, Ann, [{atom, Ann, badstruct}, {atom, Ann, Name}, Var]},
 
-  {TUpdate, TU} = translate(Update, VS),
-  {TAssocs, TS} = translate_map(Meta, Assocs, {ok, Var}, TU),
+    {TUpdate, TU} = translate(Update, VS),
+    {TAssocs, TS} = translate_map(Meta, Assocs, {ok, Var}, TU),
 
-  {{'case', Generated, TUpdate, [
-    {clause, Ann, [Match], [], [TAssocs]},
-    {clause, Generated, [Var], [], [?remote(Ann, erlang, error, [Error])]}
-  ]}, TS};
+    {{'case', Generated, TUpdate, [
+            {clause, Ann, [Match], [], [TAssocs]},
+            {clause, Generated, [Var], [], [?remote(Ann, erlang, error, [Error])]}
+        ]},
+        TS};
 translate_struct(Meta, Name, {'%{}', _, Assocs}, S) ->
-  translate_map(Meta, [{'__struct__', Name}] ++ Assocs, none, S).
+    translate_map(Meta, [{'__struct__', Name}] ++ Assocs, none, S).
 
 translate_map(Meta, [{'|', _Meta, [Update, Assocs]}], S) ->
-  {TUpdate, SU} = translate(Update, S),
-  translate_map(Meta, Assocs, {ok, TUpdate}, SU);
+    {TUpdate, SU} = translate(Update, S),
+    translate_map(Meta, Assocs, {ok, TUpdate}, SU);
 translate_map(Meta, Assocs, S) ->
-  translate_map(Meta, Assocs, none, S).
+    translate_map(Meta, Assocs, none, S).
 
-translate_map(Meta, Assocs, TUpdate, #elixir_erl{extra=Extra} = S) ->
-  Op = translate_key_val_op(TUpdate, S),
-  Ann = ?ann(Meta),
+translate_map(Meta, Assocs, TUpdate, #elixir_erl{extra = Extra} = S) ->
+    Op = translate_key_val_op(TUpdate, S),
+    Ann = ?ann(Meta),
 
-  {TArgs, SA} = lists:mapfoldl(fun({Key, Value}, Acc0) ->
-    {TKey, Acc1} = translate(Key, Acc0#elixir_erl{extra=map_key}),
-    {TValue, Acc2} = translate(Value, Acc1#elixir_erl{extra=Extra}),
-    {{Op, Ann, TKey, TValue}, Acc2}
-  end, S, Assocs),
+    {TArgs, SA} = lists:mapfoldl(
+        fun({Key, Value}, Acc0) ->
+            {TKey, Acc1} = translate(Key, Acc0#elixir_erl{extra = map_key}),
+            {TValue, Acc2} = translate(Value, Acc1#elixir_erl{extra = Extra}),
+            {{Op, Ann, TKey, TValue}, Acc2}
+        end,
+        S,
+        Assocs
+    ),
 
-  build_map(Ann, TUpdate, TArgs, SA).
+    build_map(Ann, TUpdate, TArgs, SA).
 
-translate_key_val_op(_TUpdate, #elixir_erl{extra=map_key}) -> map_field_assoc;
-translate_key_val_op(_TUpdate, #elixir_erl{context=match}) -> map_field_exact;
+translate_key_val_op(_TUpdate, #elixir_erl{extra = map_key}) -> map_field_assoc;
+translate_key_val_op(_TUpdate, #elixir_erl{context = match}) -> map_field_exact;
 translate_key_val_op(none, _) -> map_field_assoc;
 translate_key_val_op(_, _) -> map_field_exact.
 
@@ -484,126 +484,126 @@ build_map(Ann, none, TArgs, SA) -> {{map, Ann, TArgs}, SA}.
 %% Translate bitstrings
 
 translate_bitstring(Meta, Args, S) ->
-  build_bitstr(Args, Meta, S, []).
+    build_bitstr(Args, Meta, S, []).
 
 build_bitstr([{'::', _, [H, V]} | T], Meta, S, Acc) ->
-  {Size, Types} = extract_bit_info(V, S#elixir_erl{context=nil}),
-  build_bitstr(T, Meta, S, Acc, H, Size, Types);
+    {Size, Types} = extract_bit_info(V, S#elixir_erl{context = nil}),
+    build_bitstr(T, Meta, S, Acc, H, Size, Types);
 build_bitstr([], Meta, S, Acc) ->
-  {{bin, ?ann(Meta), lists:reverse(Acc)}, S}.
+    {{bin, ?ann(Meta), lists:reverse(Acc)}, S}.
 
 build_bitstr(T, Meta, S, Acc, H, default, Types) when is_binary(H) ->
-  Element =
-    case requires_utf_conversion(Types) of
-      false ->
-        %% See explanation in elixir_erl:elixir_to_erl/1 to
-        %% know why we can simply convert the binary to a list.
-        {bin_element, ?ann(Meta), {string, 0, binary_to_list(H)}, default, default};
-      true ->
-        %% UTF types require conversion.
-        {bin_element, ?ann(Meta), {string, 0, elixir_utils:characters_to_list(H)}, default, Types}
-    end,
-  build_bitstr(T, Meta, S, [Element | Acc]);
-
+    Element =
+        case requires_utf_conversion(Types) of
+            false ->
+                %% See explanation in elixir_erl:elixir_to_erl/1 to
+                %% know why we can simply convert the binary to a list.
+                {bin_element, ?ann(Meta), {string, 0, binary_to_list(H)}, default, default};
+            true ->
+                %% UTF types require conversion.
+                {bin_element, ?ann(Meta), {string, 0, elixir_utils:characters_to_list(H)}, default,
+                    Types}
+        end,
+    build_bitstr(T, Meta, S, [Element | Acc]);
 build_bitstr(T, Meta, S, Acc, H, Size, Types) ->
-  {Expr, NS} = translate(H, S),
-  build_bitstr(T, Meta, NS, [{bin_element, ?ann(Meta), Expr, Size, Types} | Acc]).
+    {Expr, NS} = translate(H, S),
+    build_bitstr(T, Meta, NS, [{bin_element, ?ann(Meta), Expr, Size, Types} | Acc]).
 
 requires_utf_conversion([bitstring | _]) -> false;
 requires_utf_conversion([binary | _]) -> false;
 requires_utf_conversion(_) -> true.
 
 extract_bit_info({'-', _, [L, {size, _, [Size]}]}, S) ->
-  {extract_bit_size(Size, S), extract_bit_type(L, [])};
+    {extract_bit_size(Size, S), extract_bit_type(L, [])};
 extract_bit_info({size, _, [Size]}, S) ->
-  {extract_bit_size(Size, S), []};
+    {extract_bit_size(Size, S), []};
 extract_bit_info(L, _S) ->
-  {default, extract_bit_type(L, [])}.
+    {default, extract_bit_type(L, [])}.
 
 extract_bit_size(Size, S) ->
-  {TSize, _} = translate(Size, S),
-  TSize.
+    {TSize, _} = translate(Size, S),
+    TSize.
 
 extract_bit_type({'-', _, [L, R]}, Acc) ->
-  extract_bit_type(L, extract_bit_type(R, Acc));
+    extract_bit_type(L, extract_bit_type(R, Acc));
 extract_bit_type({unit, _, [Arg]}, Acc) ->
-  [{unit, Arg} | Acc];
+    [{unit, Arg} | Acc];
 extract_bit_type({Other, _, []}, Acc) ->
-  [Other | Acc].
+    [Other | Acc].
 
 %% Optimizations that are specific to Erlang and change
 %% the format of the AST.
 
 translate_remote('Elixir.String.Chars', to_string, Meta, [Arg], S) ->
-  {TArg, TS} = translate(Arg, S),
-  {VarName, VS} = elixir_erl_var:build('_', TS),
+    {TArg, TS} = translate(Arg, S),
+    {VarName, VS} = elixir_erl_var:build('_', TS),
 
-  Generated = ?ann(?generated(Meta)),
-  Var = {var, Generated, VarName},
-  Guard = ?remote(Generated, erlang, is_binary, [Var]),
-  Slow = ?remote(Generated, 'Elixir.String.Chars', to_string, [Var]),
-  Fast = Var,
+    Generated = ?ann(?generated(Meta)),
+    Var = {var, Generated, VarName},
+    Guard = ?remote(Generated, erlang, is_binary, [Var]),
+    Slow = ?remote(Generated, 'Elixir.String.Chars', to_string, [Var]),
+    Fast = Var,
 
-  {{'case', Generated, TArg, [
-    {clause, Generated, [Var], [[Guard]], [Fast]},
-    {clause, Generated, [Var], [], [Slow]}
-  ]}, VS};
+    {{'case', Generated, TArg, [
+            {clause, Generated, [Var], [[Guard]], [Fast]},
+            {clause, Generated, [Var], [], [Slow]}
+        ]},
+        VS};
 translate_remote(maps, put, Meta, [Key, Value, Map], S) ->
-  Ann = ?ann(Meta),
+    Ann = ?ann(Meta),
 
-  case translate_args([Key, Value, Map], S) of
-    {[TKey, TValue, {map, _, InnerMap, Pairs}], TS} ->
-      {{map, Ann, InnerMap, Pairs ++ [{map_field_assoc, Ann, TKey, TValue}]}, TS};
-
-    {[TKey, TValue, {map, _, Pairs}], TS} ->
-      {{map, Ann, Pairs ++ [{map_field_assoc, Ann, TKey, TValue}]}, TS};
-
-    {[TKey, TValue, TMap], TS} ->
-      {{map, Ann, TMap, [{map_field_assoc, Ann, TKey, TValue}]}, TS}
-  end;
+    case translate_args([Key, Value, Map], S) of
+        {[TKey, TValue, {map, _, InnerMap, Pairs}], TS} ->
+            {{map, Ann, InnerMap, Pairs ++ [{map_field_assoc, Ann, TKey, TValue}]}, TS};
+        {[TKey, TValue, {map, _, Pairs}], TS} ->
+            {{map, Ann, Pairs ++ [{map_field_assoc, Ann, TKey, TValue}]}, TS};
+        {[TKey, TValue, TMap], TS} ->
+            {{map, Ann, TMap, [{map_field_assoc, Ann, TKey, TValue}]}, TS}
+    end;
 translate_remote(maps, merge, Meta, [Map1, Map2], S) ->
-  Ann = ?ann(Meta),
+    Ann = ?ann(Meta),
 
-  case translate_args([Map1, Map2], S) of
-    {[{map, _, Pairs1}, {map, _, Pairs2}], TS} ->
-      {{map, Ann, Pairs1 ++ Pairs2}, TS};
-
-    {[{map, _, InnerMap1, Pairs1}, {map, _, Pairs2}], TS} ->
-      {{map, Ann, InnerMap1, Pairs1 ++ Pairs2}, TS};
-
-    {[TMap1, {map, _, Pairs2}], TS} ->
-      {{map, Ann, TMap1, Pairs2}, TS};
-
-    {[TMap1, TMap2], TS} ->
-      {{call, Ann, {remote, Ann, {atom, Ann, maps}, {atom, Ann, merge}}, [TMap1, TMap2]}, TS}
-  end;
+    case translate_args([Map1, Map2], S) of
+        {[{map, _, Pairs1}, {map, _, Pairs2}], TS} ->
+            {{map, Ann, Pairs1 ++ Pairs2}, TS};
+        {[{map, _, InnerMap1, Pairs1}, {map, _, Pairs2}], TS} ->
+            {{map, Ann, InnerMap1, Pairs1 ++ Pairs2}, TS};
+        {[TMap1, {map, _, Pairs2}], TS} ->
+            {{map, Ann, TMap1, Pairs2}, TS};
+        {[TMap1, TMap2], TS} ->
+            {{call, Ann, {remote, Ann, {atom, Ann, maps}, {atom, Ann, merge}}, [TMap1, TMap2]}, TS}
+    end;
 translate_remote(Left, Right, Meta, Args, S) ->
-  {TLeft, SL} = translate(Left, S),
-  {TArgs, SA} = lists:mapfoldl(fun translate/2, SL, Args),
+    {TLeft, SL} = translate(Left, S),
+    {TArgs, SA} = lists:mapfoldl(fun translate/2, SL, Args),
 
-  Ann    = ?ann(Meta),
-  Arity  = length(Args),
-  TRight = {atom, Ann, Right},
+    Ann = ?ann(Meta),
+    Arity = length(Args),
+    TRight = {atom, Ann, Right},
 
-  %% Rewrite Erlang function calls as operators so they
-  %% work in guards, matches and so on.
-  case (Left == erlang) andalso elixir_utils:guard_op(Right, Arity) of
-    true ->
-      case TArgs of
-        [TOne]       -> {{op, Ann, Right, TOne}, SA};
-        [TOne, TTwo] -> {{op, Ann, Right, TOne, TTwo}, SA}
-      end;
-    false ->
-      {{call, Ann, {remote, Ann, TLeft, TRight}, TArgs}, SA}
-  end.
+    %% Rewrite Erlang function calls as operators so they
+    %% work in guards, matches and so on.
+    case (Left == erlang) andalso elixir_utils:guard_op(Right, Arity) of
+        true ->
+            case TArgs of
+                [TOne] -> {{op, Ann, Right, TOne}, SA};
+                [TOne, TTwo] -> {{op, Ann, Right, TOne, TTwo}, SA}
+            end;
+        false ->
+            {{call, Ann, {remote, Ann, TLeft, TRight}, TArgs}, SA}
+    end.
 
-generate_struct_name_guard([{map_field_exact, Ann, {atom, _, '__struct__'} = Key, Var} | Rest], Acc, S0) ->
-  {ModuleVarName, S1} = elixir_erl_var:build('_', S0),
-  Generated = erl_anno:set_generated(true, Ann),
-  ModuleVar = {var, Generated, ModuleVarName},
-  Match = {match, Generated, ModuleVar, Var},
-  Guard = ?remote(Generated, erlang, is_atom, [ModuleVar]),
-  S2 = S1#elixir_erl{extra_guards=[Guard | S1#elixir_erl.extra_guards]},
-  {lists:reverse(Acc, [{map_field_exact, Ann, Key, Match} | Rest]), S2};
+generate_struct_name_guard(
+    [{map_field_exact, Ann, {atom, _, '__struct__'} = Key, Var} | Rest],
+    Acc,
+    S0
+) ->
+    {ModuleVarName, S1} = elixir_erl_var:build('_', S0),
+    Generated = erl_anno:set_generated(true, Ann),
+    ModuleVar = {var, Generated, ModuleVarName},
+    Match = {match, Generated, ModuleVar, Var},
+    Guard = ?remote(Generated, erlang, is_atom, [ModuleVar]),
+    S2 = S1#elixir_erl{extra_guards = [Guard | S1#elixir_erl.extra_guards]},
+    {lists:reverse(Acc, [{map_field_exact, Ann, Key, Match} | Rest]), S2};
 generate_struct_name_guard([Field | Rest], Acc, S) ->
-  generate_struct_name_guard(Rest, [Field | Acc], S).
+    generate_struct_name_guard(Rest, [Field | Acc], S).

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -1,504 +1,591 @@
 -module(elixir_module).
--export([file/1, data_tables/1, is_open/1, mode/1, delete_definition_attributes/6,
-         compile/4, expand_callback/6, format_error/1, compiler_modules/0,
-         write_cache/3, read_cache/2, next_counter/1]).
+
+-export([
+    file/1,
+    data_tables/1,
+    is_open/1,
+    mode/1,
+    delete_definition_attributes/6,
+    compile/4,
+    expand_callback/6,
+    format_error/1,
+    compiler_modules/0,
+    write_cache/3,
+    read_cache/2,
+    next_counter/1
+]).
+
 -include("elixir.hrl").
+
 -define(counter_attr, {elixir, counter}).
 
 %% Stores modules currently being defined by the compiler
 
 compiler_modules() ->
-  case erlang:get(elixir_compiler_modules) of
-    undefined -> [];
-    M when is_list(M) -> M
-  end.
+    case erlang:get(elixir_compiler_modules) of
+        undefined -> [];
+        M when is_list(M) -> M
+    end.
 
 put_compiler_modules([]) ->
-  erlang:erase(elixir_compiler_modules);
+    erlang:erase(elixir_compiler_modules);
 put_compiler_modules(M) when is_list(M) ->
-  erlang:put(elixir_compiler_modules, M).
+    erlang:put(elixir_compiler_modules, M).
 
 %% Table functions
 
 file(Module) ->
-  ets:lookup_element(elixir_modules, Module, 4).
+    ets:lookup_element(elixir_modules, Module, 4).
 
 data_tables(Module) ->
-  ets:lookup_element(elixir_modules, Module, 2).
+    ets:lookup_element(elixir_modules, Module, 2).
 
 is_open(Module) ->
-  ets:member(elixir_modules, Module).
+    ets:member(elixir_modules, Module).
 
 mode(Module) ->
-  try ets:lookup_element(elixir_modules, Module, 5) of
-    Mode -> Mode
-  catch
-    _:badarg -> closed
-  end.
+    try ets:lookup_element(elixir_modules, Module, 5) of
+        Mode -> Mode
+    catch
+        _:badarg -> closed
+    end.
 
 make_readonly(Module) ->
-  ets:update_element(elixir_modules, Module, {5, readonly}).
+    ets:update_element(elixir_modules, Module, {5, readonly}).
 
 delete_definition_attributes(#{module := Module}, _, _, _, _, _) ->
-  {DataSet, _} = data_tables(Module),
-  ets:delete(DataSet, doc),
-  ets:delete(DataSet, deprecated),
-  ets:delete(DataSet, impl).
+    {DataSet, _} = data_tables(Module),
+    ets:delete(DataSet, doc),
+    ets:delete(DataSet, deprecated),
+    ets:delete(DataSet, impl).
 
 write_cache(Module, Key, Value) ->
-  {DataSet, _} = data_tables(Module),
-  ets:insert(DataSet, {{cache, Key}, Value}).
+    {DataSet, _} = data_tables(Module),
+    ets:insert(DataSet, {{cache, Key}, Value}).
 
 read_cache(Module, Key) ->
-  {DataSet, _} = data_tables(Module),
-  ets:lookup_element(DataSet, {cache, Key}, 2).
-
-next_counter(nil) -> erlang:unique_integer();
-next_counter(Module) ->
-  try
     {DataSet, _} = data_tables(Module),
-    {Module, ets:update_counter(DataSet, ?counter_attr, 1)}
-  catch
-    _:_ -> erlang:unique_integer()
-  end.
+    ets:lookup_element(DataSet, {cache, Key}, 2).
+
+next_counter(nil) ->
+    erlang:unique_integer();
+next_counter(Module) ->
+    try
+        {DataSet, _} = data_tables(Module),
+        {Module, ets:update_counter(DataSet, ?counter_attr, 1)}
+    catch
+        _:_ -> erlang:unique_integer()
+    end.
 
 %% Compilation hook
 
-compile(Module, _Block, _Vars, #{line := Line, file := File}) when Module == nil; is_boolean(Module) ->
-  elixir_errors:form_error([{line, Line}], File, ?MODULE, {invalid_module, Module});
+compile(Module, _Block, _Vars, #{line := Line, file := File}) when
+    Module == nil; is_boolean(Module)
+->
+    elixir_errors:form_error([{line, Line}], File, ?MODULE, {invalid_module, Module});
 compile(Module, Block, Vars, Env) when is_atom(Module) ->
-  #{line := Line, current_vars := {Read, _}, function := Function} = Env,
+    #{line := Line, current_vars := {Read, _}, function := Function} = Env,
 
-  %% In case we are generating a module from inside a function,
-  %% we get rid of the lexical tracker information as, at this
-  %% point, the lexical tracker process is long gone.
-  ResetEnv = elixir_env:reset_unused_vars(Env),
+    %% In case we are generating a module from inside a function,
+    %% we get rid of the lexical tracker information as, at this
+    %% point, the lexical tracker process is long gone.
+    ResetEnv = elixir_env:reset_unused_vars(Env),
 
-  MaybeLexEnv =
-    case Function of
-      nil -> ResetEnv#{module := Module, current_vars := {Read, false}};
-      _   -> ResetEnv#{lexical_tracker := nil, tracers := [], function := nil, module := Module, current_vars := {Read, false}}
-    end,
+    MaybeLexEnv =
+        case Function of
+            nil ->
+                ResetEnv#{module := Module, current_vars := {Read, false}};
+            _ ->
+                ResetEnv#{
+                    lexical_tracker := nil,
+                    tracers := [],
+                    function := nil,
+                    module := Module,
+                    current_vars := {Read, false}
+                }
+        end,
 
-  case MaybeLexEnv of
-    #{lexical_tracker := nil} ->
-      elixir_lexical:run(
-        MaybeLexEnv,
-        fun(LexEnv) -> compile(Line, Module, Block, Vars, LexEnv) end,
-        fun(_LexEnv) -> ok end
-      );
-    _ ->
-      compile(Line, Module, Block, Vars, MaybeLexEnv)
-  end;
+    case MaybeLexEnv of
+        #{lexical_tracker := nil} ->
+            elixir_lexical:run(
+                MaybeLexEnv,
+                fun(LexEnv) -> compile(Line, Module, Block, Vars, LexEnv) end,
+                fun(_LexEnv) -> ok end
+            );
+        _ ->
+            compile(Line, Module, Block, Vars, MaybeLexEnv)
+    end;
 compile(Module, _Block, _Vars, #{line := Line, file := File}) ->
-  elixir_errors:form_error([{line, Line}], File, ?MODULE, {invalid_module, Module}).
+    elixir_errors:form_error([{line, Line}], File, ?MODULE, {invalid_module, Module}).
 
 compile(Line, Module, Block, Vars, E) ->
-  File = ?key(E, file),
-  check_module_availability(Line, File, Module),
+    File = ?key(E, file),
+    check_module_availability(Line, File, Module),
 
-  CompilerModules = compiler_modules(),
-  {Tables, Ref} = build(Line, File, Module),
-  {DataSet, DataBag} = Tables,
+    CompilerModules = compiler_modules(),
+    {Tables, Ref} = build(Line, File, Module),
+    {DataSet, DataBag} = Tables,
 
-  try
-    put_compiler_modules([Module | CompilerModules]),
-    elixir_env:trace({defmodule, [{line, Line}]}, E),
-    {Result, NE} = eval_form(Line, Module, DataBag, Block, Vars, E),
+    try
+        put_compiler_modules([Module | CompilerModules]),
+        elixir_env:trace({defmodule, [{line, Line}]}, E),
+        {Result, NE} = eval_form(Line, Module, DataBag, Block, Vars, E),
 
-    PersistedAttributes = ets:lookup_element(DataBag, persisted_attributes, 2),
-    Attributes = attributes(DataSet, DataBag, PersistedAttributes),
-    {AllDefinitions, Private} = elixir_def:fetch_definitions(File, Module),
+        PersistedAttributes = ets:lookup_element(DataBag, persisted_attributes, 2),
+        Attributes = attributes(DataSet, DataBag, PersistedAttributes),
+        {AllDefinitions, Private} = elixir_def:fetch_definitions(File, Module),
 
-    OnLoadAttribute = lists:keyfind(on_load, 1, Attributes),
-    NewPrivate = validate_on_load_attribute(OnLoadAttribute, AllDefinitions, Private, File, Line),
+        OnLoadAttribute = lists:keyfind(on_load, 1, Attributes),
+        NewPrivate = validate_on_load_attribute(
+            OnLoadAttribute,
+            AllDefinitions,
+            Private,
+            File,
+            Line
+        ),
 
-    Unreachable = elixir_locals:warn_unused_local(File, Module, AllDefinitions, NewPrivate),
-    elixir_locals:ensure_no_undefined_local(File, Module, AllDefinitions),
-    elixir_locals:ensure_no_import_conflict(File, Module, AllDefinitions),
+        Unreachable = elixir_locals:warn_unused_local(File, Module, AllDefinitions, NewPrivate),
+        elixir_locals:ensure_no_undefined_local(File, Module, AllDefinitions),
+        elixir_locals:ensure_no_import_conflict(File, Module, AllDefinitions),
 
-    %% We stop tracking locals here to avoid race conditions in case after_load
-    %% evaluates code in a separate process that may write to locals table.
-    elixir_locals:stop({DataSet, DataBag}),
-    make_readonly(Module),
+        %% We stop tracking locals here to avoid race conditions in case after_load
+        %% evaluates code in a separate process that may write to locals table.
+        elixir_locals:stop({DataSet, DataBag}),
+        make_readonly(Module),
 
-    (not elixir_config:get(bootstrap)) andalso
-     'Elixir.Module':check_behaviours_and_impls(E, DataSet, DataBag, AllDefinitions),
+        (not elixir_config:get(bootstrap)) andalso
+            'Elixir.Module':check_behaviours_and_impls(E, DataSet, DataBag, AllDefinitions),
 
-    RawCompileOpts = bag_lookup_element(DataBag, {accumulate, compile}, 2),
-    CompileOpts = validate_compile_opts(RawCompileOpts, AllDefinitions, Unreachable, File, Line),
+        RawCompileOpts = bag_lookup_element(DataBag, {accumulate, compile}, 2),
+        CompileOpts = validate_compile_opts(
+            RawCompileOpts,
+            AllDefinitions,
+            Unreachable,
+            File,
+            Line
+        ),
 
-    ModuleMap = #{
-      struct => get_struct(DataSet),
-      module => Module,
-      line => Line,
-      file => File,
-      relative_file => elixir_utils:relative_to_cwd(File),
-      attributes => Attributes,
-      definitions => AllDefinitions,
-      unreachable => Unreachable,
-      compile_opts => CompileOpts,
-      deprecated => get_deprecated(DataBag),
-      is_behaviour => is_behaviour(DataBag)
-    },
+        ModuleMap = #{
+            struct => get_struct(DataSet),
+            module => Module,
+            line => Line,
+            file => File,
+            relative_file => elixir_utils:relative_to_cwd(File),
+            attributes => Attributes,
+            definitions => AllDefinitions,
+            unreachable => Unreachable,
+            compile_opts => CompileOpts,
+            deprecated => get_deprecated(DataBag),
+            is_behaviour => is_behaviour(DataBag)
+        },
 
-    Binary = elixir_erl:compile(ModuleMap),
-    warn_unused_attributes(File, DataSet, DataBag, PersistedAttributes),
-    autoload_module(Module, Binary, CompileOpts, NE),
-    eval_callbacks(Line, DataBag, after_compile, [NE, Binary], NE),
-    make_module_available(Module, Binary, ModuleMap),
-    {module, Module, Binary, Result}
-  catch
-    error:undef:Stacktrace ->
-      case Stacktrace of
-        [{Module, Fun, Args, _Info} | _] = Stack when is_list(Args) ->
-          compile_undef(Module, Fun, length(Args), Stack);
-        [{Module, Fun, Arity, _Info} | _] = Stack ->
-          compile_undef(Module, Fun, Arity, Stack);
-        Stack ->
-          erlang:raise(error, undef, Stack)
-      end
-  after
-    put_compiler_modules(CompilerModules),
-    ets:delete(DataSet),
-    ets:delete(DataBag),
-    elixir_code_server:call({undefmodule, Ref})
-  end.
+        Binary = elixir_erl:compile(ModuleMap),
+        warn_unused_attributes(File, DataSet, DataBag, PersistedAttributes),
+        autoload_module(Module, Binary, CompileOpts, NE),
+        eval_callbacks(Line, DataBag, after_compile, [NE, Binary], NE),
+        make_module_available(Module, Binary, ModuleMap),
+        {module, Module, Binary, Result}
+    catch
+        error:undef:Stacktrace ->
+            case Stacktrace of
+                [{Module, Fun, Args, _Info} | _] = Stack when is_list(Args) ->
+                    compile_undef(Module, Fun, length(Args), Stack);
+                [{Module, Fun, Arity, _Info} | _] = Stack ->
+                    compile_undef(Module, Fun, Arity, Stack);
+                Stack ->
+                    erlang:raise(error, undef, Stack)
+            end
+    after
+        put_compiler_modules(CompilerModules),
+        ets:delete(DataSet),
+        ets:delete(DataBag),
+        elixir_code_server:call({undefmodule, Ref})
+    end.
 
 validate_compile_opts(Opts, Defs, Unreachable, File, Line) ->
-  lists:flatmap(fun (Opt) -> validate_compile_opt(Opt, Defs, Unreachable, File, Line) end, Opts).
+    lists:flatmap(fun(Opt) -> validate_compile_opt(Opt, Defs, Unreachable, File, Line) end, Opts).
 
 %% TODO: Make this an error on v2.0
 validate_compile_opt({parse_transform, Module} = Opt, _Defs, _Unreachable, File, Line) ->
-  elixir_errors:form_warn([{line, Line}], File, ?MODULE, {parse_transform, Module}),
-  [Opt];
+    elixir_errors:form_warn([{line, Line}], File, ?MODULE, {parse_transform, Module}),
+    [Opt];
 validate_compile_opt({inline, Inlines}, Defs, Unreachable, File, Line) ->
-  case validate_inlines(Inlines, Defs, Unreachable, []) of
-    {ok, []} -> [];
-    {ok, FilteredInlines} -> [{inline, FilteredInlines}];
-    {error, Def} -> elixir_errors:form_error([{line, Line}], File, ?MODULE, {bad_inline, Def})
-  end;
+    case validate_inlines(Inlines, Defs, Unreachable, []) of
+        {ok, []} -> [];
+        {ok, FilteredInlines} -> [{inline, FilteredInlines}];
+        {error, Def} -> elixir_errors:form_error([{line, Line}], File, ?MODULE, {bad_inline, Def})
+    end;
 validate_compile_opt(Opt, Defs, Unreachable, File, Line) when is_list(Opt) ->
-  validate_compile_opts(Opt, Defs, Unreachable, File, Line);
+    validate_compile_opts(Opt, Defs, Unreachable, File, Line);
 validate_compile_opt(Opt, _Defs, _Unreachable, _File, _Line) ->
-  [Opt].
+    [Opt].
 
 validate_inlines([Inline | Inlines], Defs, Unreachable, Acc) ->
-  case lists:keyfind(Inline, 1, Defs) of
-    false -> {error, Inline};
-    _ ->
-      case lists:member(Inline, Unreachable) of
-        true -> validate_inlines(Inlines, Defs, Unreachable, Acc);
-        false -> validate_inlines(Inlines, Defs, Unreachable, [Inline | Acc])
-      end
-  end;
-validate_inlines([], _Defs, _Unreachable, Acc) -> {ok, Acc}.
+    case lists:keyfind(Inline, 1, Defs) of
+        false ->
+            {error, Inline};
+        _ ->
+            case lists:member(Inline, Unreachable) of
+                true -> validate_inlines(Inlines, Defs, Unreachable, Acc);
+                false -> validate_inlines(Inlines, Defs, Unreachable, [Inline | Acc])
+            end
+    end;
+validate_inlines([], _Defs, _Unreachable, Acc) ->
+    {ok, Acc}.
 
 validate_on_load_attribute({on_load, Def}, Defs, Private, File, Line) ->
-  case lists:keyfind(Def, 1, Defs) of
-    false ->
-      elixir_errors:form_error([{line, Line}], File, ?MODULE, {undefined_on_load, Def});
-    {_, Kind, _, _} when Kind == def; Kind == defp ->
-      lists:keydelete(Def, 1, Private);
-    {_, WrongKind, _, _} ->
-      elixir_errors:form_error([{line, Line}], File, ?MODULE, {wrong_kind_on_load, Def, WrongKind})
-  end;
-validate_on_load_attribute(false, _Module, Private, _File, _Line) -> Private.
+    case lists:keyfind(Def, 1, Defs) of
+        false ->
+            elixir_errors:form_error([{line, Line}], File, ?MODULE, {undefined_on_load, Def});
+        {_, Kind, _, _} when Kind == def; Kind == defp ->
+            lists:keydelete(Def, 1, Private);
+        {_, WrongKind, _, _} ->
+            elixir_errors:form_error(
+                [{line, Line}],
+                File,
+                ?MODULE,
+                {wrong_kind_on_load, Def, WrongKind}
+            )
+    end;
+validate_on_load_attribute(false, _Module, Private, _File, _Line) ->
+    Private.
 
 is_behaviour(DataBag) ->
-  ets:member(DataBag, {accumulate, callback}) orelse ets:member(DataBag, {accumulate, macrocallback}).
+    ets:member(DataBag, {accumulate, callback}) orelse
+        ets:member(DataBag, {accumulate, macrocallback}).
 
 %% An undef error for a function in the module being compiled might result in an
 %% exception message suggesting the current module is not loaded. This is
 %% misleading so use a custom reason.
 compile_undef(Module, Fun, Arity, Stack) ->
-  case elixir_config:get(bootstrap) of
-    false ->
-      Opts = [{module, Module}, {function, Fun}, {arity, Arity},
-              {reason, 'function not available'}],
-      Exception = 'Elixir.UndefinedFunctionError':exception(Opts),
-      erlang:raise(error, Exception, Stack);
-    true ->
-      erlang:raise(error, undef, Stack)
-  end.
+    case elixir_config:get(bootstrap) of
+        false ->
+            Opts = [
+                {module, Module},
+                {function, Fun},
+                {arity, Arity},
+                {reason, 'function not available'}
+            ],
+            Exception = 'Elixir.UndefinedFunctionError':exception(Opts),
+            erlang:raise(error, Exception, Stack);
+        true ->
+            erlang:raise(error, undef, Stack)
+    end.
 
 %% Handle reserved modules and duplicates.
 
 check_module_availability(Line, File, Module) ->
-  Reserved = ['Elixir.Any', 'Elixir.BitString', 'Elixir.PID',
-              'Elixir.Reference', 'Elixir.Elixir', 'Elixir'],
+    Reserved = [
+        'Elixir.Any',
+        'Elixir.BitString',
+        'Elixir.PID',
+        'Elixir.Reference',
+        'Elixir.Elixir',
+        'Elixir'
+    ],
 
-  case lists:member(Module, Reserved) of
-    true  -> elixir_errors:form_error([{line, Line}], File, ?MODULE, {module_reserved, Module});
-    false -> ok
-  end,
+    case lists:member(Module, Reserved) of
+        true -> elixir_errors:form_error([{line, Line}], File, ?MODULE, {module_reserved, Module});
+        false -> ok
+    end,
 
-  case elixir_config:get(ignore_module_conflict) of
-    false ->
-      case code:ensure_loaded(Module) of
-        {module, _} ->
-          elixir_errors:form_warn([{line, Line}], File, ?MODULE, {module_defined, Module});
-        {error, _}  ->
-          ok
-      end;
-    true ->
-      ok
-  end.
+    case elixir_config:get(ignore_module_conflict) of
+        false ->
+            case code:ensure_loaded(Module) of
+                {module, _} ->
+                    elixir_errors:form_warn(
+                        [{line, Line}],
+                        File,
+                        ?MODULE,
+                        {module_defined, Module}
+                    );
+                {error, _} ->
+                    ok
+            end;
+        true ->
+            ok
+    end.
 
 %% Hook that builds both attribute and functions and set up common hooks.
 
 build(Line, File, Module) ->
-  %% In the set table we store:
-  %%
-  %% * {Attribute, Value, AccumulateOrReadOrUnreadline}
-  %% * {{elixir, ...}, ...}
-  %% * {{cache, ...}, ...}
-  %% * {{function, Tuple}, ...}, {{macro, Tuple}, ...}
-  %% * {{type, Tuple}, ...}, {{opaque, Tuple}, ...}
-  %% * {{callback, Tuple}, ...}, {{macrocallback, Tuple}, ...}
-  %% * {{def, Tuple}, ...} (from elixir_def)
-  %% * {{import, Tuple}, ...} (from elixir_locals)
-  %% * {{overridable, Tuple}, ...} (from elixir_overridable)
-  %%
-  DataSet = ets:new(Module, [set, public]),
+    %% In the set table we store:
+    %%
+    %% * {Attribute, Value, AccumulateOrReadOrUnreadline}
+    %% * {{elixir, ...}, ...}
+    %% * {{cache, ...}, ...}
+    %% * {{function, Tuple}, ...}, {{macro, Tuple}, ...}
+    %% * {{type, Tuple}, ...}, {{opaque, Tuple}, ...}
+    %% * {{callback, Tuple}, ...}, {{macrocallback, Tuple}, ...}
+    %% * {{def, Tuple}, ...} (from elixir_def)
+    %% * {{import, Tuple}, ...} (from elixir_locals)
+    %% * {{overridable, Tuple}, ...} (from elixir_overridable)
+    %%
+    DataSet = ets:new(Module, [set, public]),
 
-  %% In the bag table we store:
-  %%
-  %% * {{accumulate, Attribute}, ...} (includes typespecs)
-  %% * {warn_attributes, ...}
-  %% * {impls, ...}
-  %% * {deprecated, ...}
-  %% * {persisted_attributes, ...}
-  %% * {defs, ...} (from elixir_def)
-  %% * {overridables, ...} (from elixir_overridable)
-  %% * {{default, Name}, ...} (from elixir_def)
-  %% * {{clauses, Tuple}, ...} (from elixir_def)
-  %% * {reattach, ...} (from elixir_locals)
-  %% * {{local, Tuple}, ...} (from elixir_locals)
-  %%
-  DataBag = ets:new(Module, [duplicate_bag, public]),
+    %% In the bag table we store:
+    %%
+    %% * {{accumulate, Attribute}, ...} (includes typespecs)
+    %% * {warn_attributes, ...}
+    %% * {impls, ...}
+    %% * {deprecated, ...}
+    %% * {persisted_attributes, ...}
+    %% * {defs, ...} (from elixir_def)
+    %% * {overridables, ...} (from elixir_overridable)
+    %% * {{default, Name}, ...} (from elixir_def)
+    %% * {{clauses, Tuple}, ...} (from elixir_def)
+    %% * {reattach, ...} (from elixir_locals)
+    %% * {{local, Tuple}, ...} (from elixir_locals)
+    %%
+    DataBag = ets:new(Module, [duplicate_bag, public]),
 
-  ets:insert(DataSet, [
-    % {Key, Value, ReadOrUnreadLine}
-    {moduledoc, nil, nil},
+    ets:insert(DataSet, [
+        % {Key, Value, ReadOrUnreadLine}
+        {moduledoc, nil, nil},
 
-    % {Key, Value, accumulate}
-    {after_compile, [], accumulate},
-    {before_compile, [], accumulate},
-    {behaviour, [], accumulate},
-    {compile, [], accumulate},
-    {derive, [], accumulate},
-    {dialyzer, [], accumulate},
-    {external_resource, [], accumulate},
-    {on_definition, [], accumulate},
-    {type, [], accumulate},
-    {opaque, [], accumulate},
-    {typep, [], accumulate},
-    {spec, [], accumulate},
-    {callback, [], accumulate},
-    {macrocallback, [], accumulate},
-    {optional_callbacks, [], accumulate},
+        % {Key, Value, accumulate}
+        {after_compile, [], accumulate},
+        {before_compile, [], accumulate},
+        {behaviour, [], accumulate},
+        {compile, [], accumulate},
+        {derive, [], accumulate},
+        {dialyzer, [], accumulate},
+        {external_resource, [], accumulate},
+        {on_definition, [], accumulate},
+        {type, [], accumulate},
+        {opaque, [], accumulate},
+        {typep, [], accumulate},
+        {spec, [], accumulate},
+        {callback, [], accumulate},
+        {macrocallback, [], accumulate},
+        {optional_callbacks, [], accumulate},
 
-    % Others
-    {?counter_attr, 0}
-  ]),
+        % Others
+        {?counter_attr, 0}
+    ]),
 
-  Persisted = [behaviour, on_load, external_resource, dialyzer, vsn],
-  ets:insert(DataBag, [{persisted_attributes, Attr} || Attr <- Persisted]),
+    Persisted = [behaviour, on_load, external_resource, dialyzer, vsn],
+    ets:insert(DataBag, [{persisted_attributes, Attr} || Attr <- Persisted]),
 
-  OnDefinition =
-    case elixir_config:get(bootstrap) of
-      false -> {'Elixir.Module', compile_definition_attributes};
-      _ -> {elixir_module, delete_definition_attributes}
-    end,
-  ets:insert(DataBag, {{accumulate, on_definition}, OnDefinition}),
+    OnDefinition =
+        case elixir_config:get(bootstrap) of
+            false -> {'Elixir.Module', compile_definition_attributes};
+            _ -> {elixir_module, delete_definition_attributes}
+        end,
+    ets:insert(DataBag, {{accumulate, on_definition}, OnDefinition}),
 
-  %% Setup definition related modules
-  Tables = {DataSet, DataBag},
-  elixir_def:setup(Tables),
-  elixir_locals:setup(Tables),
-  Tuple = {Module, Tables, Line, File, all},
+    %% Setup definition related modules
+    Tables = {DataSet, DataBag},
+    elixir_def:setup(Tables),
+    elixir_locals:setup(Tables),
+    Tuple = {Module, Tables, Line, File, all},
 
-  Ref =
-    case elixir_code_server:call({defmodule, Module, self(), Tuple}) of
-      {ok, ModuleRef} ->
-        ModuleRef;
-      {error, {Module, _, OldLine, OldFile, _}} ->
-        ets:delete(DataSet),
-        ets:delete(DataBag),
-        Error = {module_in_definition, Module, OldFile, OldLine},
-        elixir_errors:form_error([{line, Line}], File, ?MODULE, Error)
-    end,
+    Ref =
+        case elixir_code_server:call({defmodule, Module, self(), Tuple}) of
+            {ok, ModuleRef} ->
+                ModuleRef;
+            {error, {Module, _, OldLine, OldFile, _}} ->
+                ets:delete(DataSet),
+                ets:delete(DataBag),
+                Error = {module_in_definition, Module, OldFile, OldLine},
+                elixir_errors:form_error([{line, Line}], File, ?MODULE, Error)
+        end,
 
-  {Tables, Ref}.
+    {Tables, Ref}.
 
 %% Handles module and callback evaluations.
 
 eval_form(Line, Module, DataBag, Block, Vars, E) ->
-  {Value, EE} = elixir_compiler:eval_forms(Block, Vars, E),
-  elixir_overridable:store_not_overridden(Module),
-  EV = elixir_env:linify({Line, elixir_env:reset_vars(EE)}),
-  EC = eval_callbacks(Line, DataBag, before_compile, [EV], EV),
-  elixir_overridable:store_not_overridden(Module),
-  {Value, EC}.
+    {Value, EE} = elixir_compiler:eval_forms(Block, Vars, E),
+    elixir_overridable:store_not_overridden(Module),
+    EV = elixir_env:linify({Line, elixir_env:reset_vars(EE)}),
+    EC = eval_callbacks(Line, DataBag, before_compile, [EV], EV),
+    elixir_overridable:store_not_overridden(Module),
+    {Value, EC}.
 
 eval_callbacks(Line, DataBag, Name, Args, E) ->
-  Callbacks = bag_lookup_element(DataBag, {accumulate, Name}, 2),
-  lists:foldl(fun({M, F}, Acc) ->
-    expand_callback(Line, M, F, Args, elixir_env:reset_vars(Acc),
-                    fun(AM, AF, AA) -> apply(AM, AF, AA) end)
-  end, E, Callbacks).
+    Callbacks = bag_lookup_element(DataBag, {accumulate, Name}, 2),
+    lists:foldl(
+        fun({M, F}, Acc) ->
+            expand_callback(
+                Line,
+                M,
+                F,
+                Args,
+                elixir_env:reset_vars(Acc),
+                fun(AM, AF, AA) -> apply(AM, AF, AA) end
+            )
+        end,
+        E,
+        Callbacks
+    ).
 
 expand_callback(Line, M, F, Args, E, Fun) ->
-  Meta = [{line, Line}, {required, true}],
+    Meta = [{line, Line}, {required, true}],
 
-  {EE, ET} = elixir_dispatch:dispatch_require(Meta, M, F, Args, E, fun(AM, AF, AA) ->
-    Fun(AM, AF, AA),
-    {ok, E}
-  end),
+    {EE, ET} = elixir_dispatch:dispatch_require(Meta, M, F, Args, E, fun(AM, AF, AA) ->
+        Fun(AM, AF, AA),
+        {ok, E}
+    end),
 
-  if
-    is_atom(EE) ->
-      ET;
-    true ->
-      try
-        {_Value, _Binding, EF} = elixir:eval_forms(EE, [], ET),
-        EF
-      catch
-        Kind:Reason:Stacktrace ->
-          Info = {M, F, length(Args), location(Line, E)},
-          erlang:raise(Kind, Reason, prune_stacktrace(Info, Stacktrace))
-      end
-  end.
+    if
+        is_atom(EE) ->
+            ET;
+        true ->
+            try
+                {_Value, _Binding, EF} = elixir:eval_forms(EE, [], ET),
+                EF
+            catch
+                Kind:Reason:Stacktrace ->
+                    Info = {M, F, length(Args), location(Line, E)},
+                    erlang:raise(Kind, Reason, prune_stacktrace(Info, Stacktrace))
+            end
+    end.
 
 %% Add attributes handling to the form
 
 attributes(DataSet, DataBag, PersistedAttributes) ->
-  [{Key, Value} || Key <- PersistedAttributes, Value <- lookup_attribute(DataSet, DataBag, Key)].
+    [{Key, Value} || Key <- PersistedAttributes, Value <- lookup_attribute(DataSet, DataBag, Key)].
 
 lookup_attribute(DataSet, DataBag, Key) when is_atom(Key) ->
-  case ets:lookup(DataSet, Key) of
-    [{_, _, accumulate}] -> bag_lookup_element(DataBag, {accumulate, Key}, 2);
-    [{_, _, unset}] -> [];
-    [{_, Value, _}] -> [Value];
-    [] -> []
-  end.
+    case ets:lookup(DataSet, Key) of
+        [{_, _, accumulate}] -> bag_lookup_element(DataBag, {accumulate, Key}, 2);
+        [{_, _, unset}] -> [];
+        [{_, Value, _}] -> [Value];
+        [] -> []
+    end.
 
 warn_unused_attributes(File, DataSet, DataBag, PersistedAttrs) ->
-  StoredAttrs = bag_lookup_element(DataBag, warn_attributes, 2),
-  %% This is the same list as in Module.put_attribute
-  %% without moduledoc which are never warned on.
-  Attrs = [doc, typedoc, impl, deprecated | StoredAttrs -- PersistedAttrs],
-  Query = [{{Attr, '_', '$1'}, [{is_integer, '$1'}], [[Attr, '$1']]} || Attr <- Attrs],
-  [elixir_errors:form_warn([{line, Line}], File, ?MODULE, {unused_attribute, Key})
-   || [Key, Line] <- ets:select(DataSet, Query)].
+    StoredAttrs = bag_lookup_element(DataBag, warn_attributes, 2),
+    %% This is the same list as in Module.put_attribute
+    %% without moduledoc which are never warned on.
+    Attrs = [doc, typedoc, impl, deprecated | StoredAttrs -- PersistedAttrs],
+    Query = [{{Attr, '_', '$1'}, [{is_integer, '$1'}], [[Attr, '$1']]} || Attr <- Attrs],
+    [
+        elixir_errors:form_warn([{line, Line}], File, ?MODULE, {unused_attribute, Key})
+        || [Key, Line] <- ets:select(DataSet, Query)
+    ].
 
 get_struct(Set) ->
-  case ets:lookup(Set, '__struct__') of
-    [] -> nil;
-    [{_, Struct, _}] ->
-      case ets:lookup(Set, enforce_keys) of
-        [] -> {Struct, []};
-        [{_, EnforceKeys, _}] when is_list(EnforceKeys) -> {Struct, EnforceKeys};
-        [{_, EnforceKeys, _}] -> {Struct, [EnforceKeys]}
-      end
-  end.
+    case ets:lookup(Set, '__struct__') of
+        [] ->
+            nil;
+        [{_, Struct, _}] ->
+            case ets:lookup(Set, enforce_keys) of
+                [] -> {Struct, []};
+                [{_, EnforceKeys, _}] when is_list(EnforceKeys) -> {Struct, EnforceKeys};
+                [{_, EnforceKeys, _}] -> {Struct, [EnforceKeys]}
+            end
+    end.
 
 get_deprecated(Bag) ->
-  lists:usort(bag_lookup_element(Bag, deprecated, 2)).
+    lists:usort(bag_lookup_element(Bag, deprecated, 2)).
 
 bag_lookup_element(Table, Name, Pos) ->
-  try
-    ets:lookup_element(Table, Name, Pos)
-  catch
-    error:badarg -> []
-  end.
+    try
+        ets:lookup_element(Table, Name, Pos)
+    catch
+        error:badarg -> []
+    end.
 
 %% Takes care of autoloading the module if configured.
 
 autoload_module(Module, Binary, Opts, E) ->
-  case proplists:get_value(autoload, Opts, true) of
-    true  -> code:load_binary(Module, beam_location(E), Binary);
-    false -> ok
-  end.
+    case proplists:get_value(autoload, Opts, true) of
+        true -> code:load_binary(Module, beam_location(E), Binary);
+        false -> ok
+    end.
 
 beam_location(#{module := Module}) ->
-  case get(elixir_compiler_dest) of
-    Dest when is_binary(Dest) ->
-      filename:join(elixir_utils:characters_to_list(Dest), atom_to_list(Module) ++ ".beam");
-    _ ->
-      ""
-  end.
+    case get(elixir_compiler_dest) of
+        Dest when is_binary(Dest) ->
+            filename:join(elixir_utils:characters_to_list(Dest), atom_to_list(Module) ++ ".beam");
+        _ ->
+            ""
+    end.
 
 %% Integration with elixir_compiler that makes the module available
 
 make_module_available(Module, Binary, ModuleMap) ->
-  case get(elixir_module_binaries) of
-    Current when is_list(Current) ->
-      put(elixir_module_binaries, [{Module, ModuleMap, Binary} | Current]);
-    _ ->
-      ok
-  end,
+    case get(elixir_module_binaries) of
+        Current when is_list(Current) ->
+            put(elixir_module_binaries, [{Module, ModuleMap, Binary} | Current]);
+        _ ->
+            ok
+    end,
 
-  case get(elixir_compiler_pid) of
-    undefined ->
-      ok;
-    PID ->
-      Ref = make_ref(),
-      PID ! {module_available, self(), Ref, get(elixir_compiler_file), Module, Binary, ModuleMap},
-      receive {Ref, ack} -> ok end
-  end.
+    case get(elixir_compiler_pid) of
+        undefined ->
+            ok;
+        PID ->
+            Ref = make_ref(),
+            PID !
+                {module_available, self(), Ref, get(elixir_compiler_file), Module, Binary,
+                    ModuleMap},
+            receive
+                {Ref, ack} -> ok
+            end
+    end.
 
 %% Error handling and helpers.
 
 %% We've reached the elixir_module or eval internals, skip it with the rest
 prune_stacktrace(Info, [{elixir, eval_forms, _, _} | _]) ->
-  [Info];
+    [Info];
 prune_stacktrace(Info, [{elixir_module, _, _, _} | _]) ->
-  [Info];
+    [Info];
 prune_stacktrace(Info, [H | T]) ->
-  [H | prune_stacktrace(Info, T)];
+    [H | prune_stacktrace(Info, T)];
 prune_stacktrace(Info, []) ->
-  [Info].
+    [Info].
 
 location(Line, E) ->
-  [{file, elixir_utils:characters_to_list(?key(E, file))}, {line, Line}].
+    [{file, elixir_utils:characters_to_list(?key(E, file))}, {line, Line}].
 
 format_error({unused_attribute, typedoc}) ->
-  "module attribute @typedoc was set but no type follows it";
+    "module attribute @typedoc was set but no type follows it";
 format_error({unused_attribute, doc}) ->
-  "module attribute @doc was set but no definition follows it";
+    "module attribute @doc was set but no definition follows it";
 format_error({unused_attribute, impl}) ->
-  "module attribute @impl was set but no definition follows it";
+    "module attribute @impl was set but no definition follows it";
 format_error({unused_attribute, deprecated}) ->
-  "module attribute @deprecated was set but no definition follows it";
+    "module attribute @deprecated was set but no definition follows it";
 format_error({unused_attribute, Attr}) ->
-  io_lib:format("module attribute @~ts was set but never used", [Attr]);
+    io_lib:format("module attribute @~ts was set but never used", [Attr]);
 format_error({invalid_module, Module}) ->
-  io_lib:format("invalid module name: ~ts", ['Elixir.Kernel':inspect(Module)]);
+    io_lib:format("invalid module name: ~ts", ['Elixir.Kernel':inspect(Module)]);
 format_error({module_defined, Module}) ->
-  Extra =
-    case code:which(Module) of
-      "" ->
-        " (current version defined in memory)";
-      Path when is_list(Path) ->
-        io_lib:format(" (current version loaded from ~ts)", [elixir_utils:relative_to_cwd(Path)]);
-      _ ->
-        ""
-    end,
-  io_lib:format("redefining module ~ts~ts", [elixir_aliases:inspect(Module), Extra]);
+    Extra =
+        case code:which(Module) of
+            "" ->
+                " (current version defined in memory)";
+            Path when is_list(Path) ->
+                io_lib:format(" (current version loaded from ~ts)", [
+                    elixir_utils:relative_to_cwd(Path)
+                ]);
+            _ ->
+                ""
+        end,
+    io_lib:format("redefining module ~ts~ts", [elixir_aliases:inspect(Module), Extra]);
 format_error({module_reserved, Module}) ->
-  io_lib:format("module ~ts is reserved and cannot be defined", [elixir_aliases:inspect(Module)]);
+    io_lib:format("module ~ts is reserved and cannot be defined", [elixir_aliases:inspect(Module)]);
 format_error({module_in_definition, Module, File, Line}) ->
-  io_lib:format("cannot define module ~ts because it is currently being defined in ~ts:~B",
-    [elixir_aliases:inspect(Module), elixir_utils:relative_to_cwd(File), Line]);
+    io_lib:format(
+        "cannot define module ~ts because it is currently being defined in ~ts:~B",
+        [elixir_aliases:inspect(Module), elixir_utils:relative_to_cwd(File), Line]
+    );
 format_error({bad_inline, {Name, Arity}}) ->
-  io_lib:format("inlined function ~ts/~B undefined", [Name, Arity]);
+    io_lib:format("inlined function ~ts/~B undefined", [Name, Arity]);
 format_error({undefined_on_load, {Name, Arity}}) ->
-  io_lib:format("@on_load function ~ts/~B is undefined", [Name, Arity]);
+    io_lib:format("@on_load function ~ts/~B is undefined", [Name, Arity]);
 format_error({wrong_kind_on_load, {Name, Arity}, WrongKind}) ->
-  io_lib:format("expected @on_load function ~ts/~B to be a function, got \"~ts\"",
-                [Name, Arity, WrongKind]);
+    io_lib:format(
+        "expected @on_load function ~ts/~B to be a function, got \"~ts\"",
+        [Name, Arity, WrongKind]
+    );
 format_error({parse_transform, Module}) ->
-  io_lib:format("@compile {:parse_transform, ~ts} is deprecated. Elixir will no longer support "
-                "Erlang-based transforms in future versions", [elixir_aliases:inspect(Module)]).
+    io_lib:format(
+        "@compile {:parse_transform, ~ts} is deprecated. Elixir will no longer support "
+        "Erlang-based transforms in future versions",
+        [elixir_aliases:inspect(Module)]
+    ).

--- a/lib/elixir/src/elixir_overridable.erl
+++ b/lib/elixir/src/elixir_overridable.erl
@@ -1,104 +1,133 @@
 % Holds the logic responsible for defining overridable functions and handling super.
 -module(elixir_overridable).
+
 -export([overridable_for/2, record_overridable/4, super/4, store_not_overridden/1, format_error/1]).
+
 -include("elixir.hrl").
+
 -define(overridden_pos, 5).
 
 overridables_for(Module) ->
-  {_, Bag} = elixir_module:data_tables(Module),
-  ets:lookup(Bag, overridables).
+    {_, Bag} = elixir_module:data_tables(Module),
+    ets:lookup(Bag, overridables).
 
 overridable_for(Module, Tuple) ->
-  {Set, _} = elixir_module:data_tables(Module),
+    {Set, _} = elixir_module:data_tables(Module),
 
-  case ets:lookup(Set, {overridable, Tuple}) of
-    [Overridable] -> Overridable;
-    [] -> not_overridable
-  end.
+    case ets:lookup(Set, {overridable, Tuple}) of
+        [Overridable] -> Overridable;
+        [] -> not_overridable
+    end.
 
 record_overridable(Module, Tuple, Def, Neighbours) ->
-  {Set, Bag} = elixir_module:data_tables(Module),
+    {Set, Bag} = elixir_module:data_tables(Module),
 
-  case ets:insert_new(Set, {{overridable, Tuple}, 1, Def, Neighbours, false}) of
-    true ->
-      ets:insert(Bag, {overridables, Tuple});
-    false ->
-      [{_, Count, PreviousDef, _, _}] = ets:lookup(Set, {overridable, Tuple}),
-      {{_, Kind, Meta, File, _, _}, _} = Def,
-      {{_, PreviousKind, _, _, _, _}, _} = PreviousDef,
-
-      case is_valid_kind(Kind, PreviousKind) of
+    case ets:insert_new(Set, {{overridable, Tuple}, 1, Def, Neighbours, false}) of
         true ->
-          ets:insert(Set, {{overridable, Tuple}, Count + 1, Def, Neighbours, false});
+            ets:insert(Bag, {overridables, Tuple});
         false ->
-          elixir_errors:form_error(Meta, File, ?MODULE, {bad_kind, Module, Tuple, Kind})
-      end
-  end,
+            [{_, Count, PreviousDef, _, _}] = ets:lookup(Set, {overridable, Tuple}),
+            {{_, Kind, Meta, File, _, _}, _} = Def,
+            {{_, PreviousKind, _, _, _, _}, _} = PreviousDef,
 
-  ok.
+            case is_valid_kind(Kind, PreviousKind) of
+                true ->
+                    ets:insert(Set, {{overridable, Tuple}, Count + 1, Def, Neighbours, false});
+                false ->
+                    elixir_errors:form_error(Meta, File, ?MODULE, {bad_kind, Module, Tuple, Kind})
+            end
+    end,
+
+    ok.
 
 super(Meta, Module, Tuple, E) ->
-  {Set, _} = elixir_module:data_tables(Module),
+    {Set, _} = elixir_module:data_tables(Module),
 
-  case ets:lookup(Set, {overridable, Tuple}) of
-    [Overridable] ->
-      store(Set, Module, Tuple, Overridable, true);
-    [] ->
-      elixir_errors:form_error(Meta, E, ?MODULE, {no_super, Module, Tuple})
-  end.
+    case ets:lookup(Set, {overridable, Tuple}) of
+        [Overridable] ->
+            store(Set, Module, Tuple, Overridable, true);
+        [] ->
+            elixir_errors:form_error(Meta, E, ?MODULE, {no_super, Module, Tuple})
+    end.
 
 store_not_overridden(Module) ->
-  {Set, Bag} = elixir_module:data_tables(Module),
+    {Set, Bag} = elixir_module:data_tables(Module),
 
-  lists:foreach(fun({_, Tuple}) ->
-    [Overridable] = ets:lookup(Set, {overridable, Tuple}),
+    lists:foreach(
+        fun({_, Tuple}) ->
+            [Overridable] = ets:lookup(Set, {overridable, Tuple}),
 
-    case ets:lookup(Set, {def, Tuple}) of
-      [] ->
-        store(Set, Module, Tuple, Overridable, false);
-      [{_, Kind, Meta, File, _, _}] ->
-        {{_, OverridableKind, _, _, _, _}, _} = element(3, Overridable),
+            case ets:lookup(Set, {def, Tuple}) of
+                [] ->
+                    store(Set, Module, Tuple, Overridable, false);
+                [{_, Kind, Meta, File, _, _}] ->
+                    {{_, OverridableKind, _, _, _, _}, _} = element(3, Overridable),
 
-        case is_valid_kind(Kind, OverridableKind) of
-          true -> ok;
-          false -> elixir_errors:form_error(Meta, File, ?MODULE, {bad_kind, Module, Tuple, Kind})
-        end
-    end
-  end, ets:lookup(Bag, overridables)).
+                    case is_valid_kind(Kind, OverridableKind) of
+                        true ->
+                            ok;
+                        false ->
+                            elixir_errors:form_error(
+                                Meta,
+                                File,
+                                ?MODULE,
+                                {bad_kind, Module, Tuple, Kind}
+                            )
+                    end
+            end
+        end,
+        ets:lookup(Bag, overridables)
+    ).
 
 %% Private
 
 store(Set, Module, Tuple, {_, Count, Def, Neighbours, Overridden}, Hidden) ->
-  {{{def, {Name, Arity}}, Kind, Meta, File, _Check,
-   {Defaults, _HasBody, _LastDefaults}}, Clauses} = Def,
+    {{{def, {Name, Arity}}, Kind, Meta, File, _Check, {Defaults, _HasBody, _LastDefaults}}, Clauses} =
+        Def,
 
-  {FinalKind, FinalName, FinalArity, FinalClauses} =
-    case Hidden of
-      false ->
-        {Kind, Name, Arity, Clauses};
-      true when Kind == defmacro; Kind == defmacrop ->
-        {defmacrop, name(Name, Count), Arity, Clauses};
-      true ->
-        {defp, name(Name, Count), Arity, Clauses}
+    {FinalKind, FinalName, FinalArity, FinalClauses} =
+        case Hidden of
+            false ->
+                {Kind, Name, Arity, Clauses};
+            true when Kind == defmacro; Kind == defmacrop ->
+                {defmacrop, name(Name, Count), Arity, Clauses};
+            true ->
+                {defp, name(Name, Count), Arity, Clauses}
+        end,
+
+    case Overridden of
+        false ->
+            ets:update_element(Set, {overridable, Tuple}, {?overridden_pos, true}),
+            elixir_def:store_definition(
+                false,
+                FinalKind,
+                Meta,
+                FinalName,
+                FinalArity,
+                File,
+                Module,
+                Defaults,
+                FinalClauses
+            ),
+            elixir_locals:reattach(
+                {FinalName, FinalArity},
+                FinalKind,
+                Module,
+                Tuple,
+                Neighbours,
+                Meta
+            );
+        true ->
+            ok
     end,
 
-  case Overridden of
-    false ->
-      ets:update_element(Set, {overridable, Tuple}, {?overridden_pos, true}),
-      elixir_def:store_definition(false, FinalKind, Meta, FinalName, FinalArity,
-                                  File, Module, Defaults, FinalClauses),
-      elixir_locals:reattach({FinalName, FinalArity}, FinalKind, Module, Tuple, Neighbours, Meta);
-    true ->
-      ok
-  end,
-
-  {FinalKind, FinalName, Meta}.
+    {FinalKind, FinalName, Meta}.
 
 name(Name, Count) when is_integer(Count) ->
-  list_to_atom(atom_to_list(Name) ++ " (overridable " ++ integer_to_list(Count) ++ ")").
+    list_to_atom(atom_to_list(Name) ++ " (overridable " ++ integer_to_list(Count) ++ ")").
 
 is_valid_kind(NewKind, PreviousKind) ->
-  is_macro(NewKind) =:= is_macro(PreviousKind).
+    is_macro(NewKind) =:= is_macro(PreviousKind).
 
 is_macro(defmacro) -> true;
 is_macro(defmacrop) -> true;
@@ -106,22 +135,27 @@ is_macro(_) -> false.
 
 %% Error handling
 format_error({bad_kind, Module, {Name, Arity}, Kind}) ->
-  case is_macro(Kind) of
-    true ->
-      io_lib:format("cannot override function (def, defp) ~ts/~B in module ~ts as a macro (defmacro, defmacrop)",
-        [Name, Arity, elixir_aliases:inspect(Module)]);
-    false ->
-      io_lib:format("cannot override macro (defmacro, defmacrop) ~ts/~B in module ~ts as a function (def, defp)",
-        [Name, Arity, elixir_aliases:inspect(Module)])
-  end;
-
+    case is_macro(Kind) of
+        true ->
+            io_lib:format(
+                "cannot override function (def, defp) ~ts/~B in module ~ts as a macro (defmacro, defmacrop)",
+                [Name, Arity, elixir_aliases:inspect(Module)]
+            );
+        false ->
+            io_lib:format(
+                "cannot override macro (defmacro, defmacrop) ~ts/~B in module ~ts as a function (def, defp)",
+                [Name, Arity, elixir_aliases:inspect(Module)]
+            )
+    end;
 format_error({no_super, Module, {Name, Arity}}) ->
-  Bins   = [format_fa(Tuple) || {_, Tuple} <- overridables_for(Module)],
-  Joined = 'Elixir.Enum':join(Bins, <<", ">>),
-  io_lib:format("no super defined for ~ts/~B in module ~ts. Overridable functions available are: ~ts",
-    [Name, Arity, elixir_aliases:inspect(Module), Joined]).
+    Bins = [format_fa(Tuple) || {_, Tuple} <- overridables_for(Module)],
+    Joined = 'Elixir.Enum':join(Bins, <<", ">>),
+    io_lib:format(
+        "no super defined for ~ts/~B in module ~ts. Overridable functions available are: ~ts",
+        [Name, Arity, elixir_aliases:inspect(Module), Joined]
+    ).
 
 format_fa({Name, Arity}) ->
-  A = 'Elixir.Code.Identifier':inspect_as_function(Name),
-  B = integer_to_binary(Arity),
-  <<A/binary, $/, B/binary>>.
+    A = 'Elixir.Code.Identifier':inspect_as_function(Name),
+    B = integer_to_binary(Arity),
+    <<A/binary, $/, B/binary>>.


### PR DESCRIPTION
This code is formatted using `erlfmt` version 0.9.0

We would like to hear what you think about this new code formatter for erlang and whether you think it is usable?

It seems that most erlang code in elixir already conform to the erlfmt style, which is pretty impressive on the part of the elixir developers for having such a consistent discipline.  It almost seems as if you have some tool, I am unaware of.

The biggest difference between the current and formatted code, seems to be the use of 2 spaces in the current code, vs erlfmt's use of 4 spaces. For context this decision is explained [here](https://github.com/WhatsApp/erlfmt/blob/master/doc/FormattingDecisionSpaces.md).

There are still other small differences, that would be valuable to get some feedback on.
Thank you for your time.