### PR TITLE
Fix mix escript.build docs

### DIFF
--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -68,7 +68,7 @@ defmodule Mix.Tasks.Escript.Build do
 
     * `:strip_beams` - if `true` strips BEAM code in the escript to remove chunks
       unnecessary at runtime, such as debug information and documentation.
-      Can be set to [keep: ['Docs', 'Dbgi']] to strip while keeping some chunks
+      Can be set to `[keep: ["Docs", "Dbgi"]]` to strip while keeping some chunks
       that would otherwise be stripped, like docs, and debug info, for instance.
       Defaults to `true`.
 


### PR DESCRIPTION
This is just small change to the documentation to avoid copy-paste errors due to the single quotes.

Not saying this just happened to me, of course! /s