### PR TITLE
Add :compressed to stream_modes spec

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -111,6 +111,7 @@ defmodule File do
   @type stream_mode ::
           encoding_mode()
           | :append
+          | :compressed
           | :trim_bom
           | {:read_ahead, pos_integer | false}
           | {:delayed_write, non_neg_integer, non_neg_integer}


### PR DESCRIPTION
`:compressed` is already passed through and supported here so that gzipped files can be streamed with e.g. `File.stream!("log.gz", [:compressed])`
Adding it to the spec also makes dialyzer happy when actively using it.