### PR TITLE
Speed up Enum.empty?/1 x3 times for Map

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -815,6 +815,10 @@ defmodule Enum do
     enumerable == []
   end
 
+  def empty?(enumerable) when is_map(enumerable) do
+    enumerable == %{}
+  end
+
   def empty?(enumerable) do
     case Enumerable.slice(enumerable) do
       {:ok, value, _} ->

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -214,7 +214,9 @@ defmodule EnumTest do
 
   test "empty?/1" do
     assert Enum.empty?([])
+    assert Enum.empty?(%{})
     refute Enum.empty?([1, 2, 3])
+    refute Enum.empty?(%{one: 1})
     refute Enum.empty?(1..3)
   end
 


### PR DESCRIPTION
Hey guys, thanks a lot for the awesome project 🤗 

I would like to speed up a bit `Enum.empty?/1`. I understand that in most cases we can use pattern matching to separate cases with empty maps, but for cases when we prefer to use module method improvement will be at least 3 times faster.

<details>
  <summary>Benchmarking code</summary>

```elixir
defmodule EnumPatch do
  def empty?(enumerable) when is_map(enumerable), do: enumerable == %{}
end

range = 1..1_000

Benchee.run(
  %{
    "Enum.empty?(input)" => fn input ->
      for _ <- range, do: Enum.empty?(input)
    end,
    "EnumPatch.empty?(input)" => fn input ->
      for _ <- range, do: EnumPatch.empty?(input)
    end
  },
  time: 10,
  warmup: 5,
  inputs: %{
    "0 elements" => %{},
    "1 element" => %{one: 1},
    "100 elements" =>
      Enum.reduce(1..100, %{}, fn element, memo ->
        Map.put(memo, Integer.to_string(element), element)
      end)
  }
)
```
</details>

<details>
  <summary>Elixir 1.9.4 results</summary>

```text
Operating System: macOS
CPU Information: Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz
Number of Available Cores: 8
Available memory: 16 GB
Elixir 1.9.4
Erlang 21.3.8

Benchmark suite executing with the following configuration:
warmup: 5 s
time: 10 s
memory time: 0 ns
parallel: 1
inputs: 0 elements, 1 element, 100 elements
Estimated total run time: 1.50 min

Benchmarking Enum.empty?(input) with input 0 elements...
Benchmarking Enum.empty?(input) with input 1 element...
Benchmarking Enum.empty?(input) with input 100 elements...
Benchmarking EnumPatch.empty?(input) with input 0 elements...
Benchmarking EnumPatch.empty?(input) with input 1 element...
Benchmarking EnumPatch.empty?(input) with input 100 elements...

##### With input 0 elements #####
Name                              ips        average  deviation         median         99th %
EnumPatch.empty?(input)       21.10 K       47.38 μs    ±16.62%       44.98 μs       76.98 μs
Enum.empty?(input)             7.11 K      140.64 μs    ±16.68%      135.98 μs      228.98 μs

Comparison: 
EnumPatch.empty?(input)       21.10 K
Enum.empty?(input)             7.11 K - 2.97x slower +93.26 μs

##### With input 1 element #####
Name                              ips        average  deviation         median         99th %
EnumPatch.empty?(input)       21.92 K       45.62 μs    ±15.96%       43.98 μs       70.98 μs
Enum.empty?(input)             7.03 K      142.31 μs    ±19.14%      138.98 μs      220.98 μs

Comparison: 
EnumPatch.empty?(input)       21.92 K
Enum.empty?(input)             7.03 K - 3.12x slower +96.69 μs

##### With input 100 elements #####
Name                              ips        average  deviation         median         99th %
EnumPatch.empty?(input)       21.77 K       45.94 μs    ±17.44%       43.98 μs       73.98 μs
Enum.empty?(input)             6.21 K      161.06 μs    ±12.52%      157.98 μs      231.98 μs

Comparison: 
EnumPatch.empty?(input)       21.77 K
Enum.empty?(input)             6.21 K - 3.51x slower +115.12 μs
```
</details>

<details>
  <summary>Elixir 1.11.2 results</summary>

```text
Operating System: macOS
CPU Information: Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz
Number of Available Cores: 8
Available memory: 16 GB
Elixir 1.11.2
Erlang 21.3.8

Benchmark suite executing with the following configuration:
warmup: 5 s
time: 10 s
memory time: 0 ns
parallel: 1
inputs: 0 elements, 1 element, 100 elements
Estimated total run time: 1.50 min

Benchmarking Enum.empty?(input) with input 0 elements...
Benchmarking Enum.empty?(input) with input 1 element...
Benchmarking Enum.empty?(input) with input 100 elements...
Benchmarking EnumPatch.empty?(input) with input 0 elements...
Benchmarking EnumPatch.empty?(input) with input 1 element...
Benchmarking EnumPatch.empty?(input) with input 100 elements...

##### With input 0 elements #####
Name                              ips        average  deviation         median         99th %
EnumPatch.empty?(input)       20.37 K       49.09 μs    ±23.02%          46 μs          94 μs
Enum.empty?(input)             6.53 K      153.07 μs    ±25.21%         142 μs         305 μs

Comparison: 
EnumPatch.empty?(input)       20.37 K
Enum.empty?(input)             6.53 K - 3.12x slower +103.98 μs

##### With input 1 element #####
Name                              ips        average  deviation         median         99th %
EnumPatch.empty?(input)       20.92 K       47.79 μs    ±34.02%          44 μs          99 μs
Enum.empty?(input)             6.50 K      153.78 μs    ±20.86%         144 μs         306 μs

Comparison: 
EnumPatch.empty?(input)       20.92 K
Enum.empty?(input)             6.50 K - 3.22x slower +105.99 μs

##### With input 100 elements #####
Name                              ips        average  deviation         median         99th %
EnumPatch.empty?(input)       21.54 K       46.43 μs    ±20.45%          44 μs          83 μs
Enum.empty?(input)             5.76 K      173.66 μs    ±18.15%         164 μs         321 μs

Comparison: 
EnumPatch.empty?(input)       21.54 K
Enum.empty?(input)             5.76 K - 3.74x slower +127.23 μs
```
</details>

Truncated Elixir 1.11.2 results

```text
##### With input 0 elements #####
Name                              ips        average  deviation         median         99th %
EnumPatch.empty?(input)       20.37 K       49.09 μs    ±23.02%          46 μs          94 μs
Enum.empty?(input)             6.53 K      153.07 μs    ±25.21%         142 μs         305 μs

Comparison: 
EnumPatch.empty?(input)       20.37 K
Enum.empty?(input)             6.53 K - 3.12x slower +103.98 μs

##### With input 1 element #####
Name                              ips        average  deviation         median         99th %
EnumPatch.empty?(input)       20.92 K       47.79 μs    ±34.02%          44 μs          99 μs
Enum.empty?(input)             6.50 K      153.78 μs    ±20.86%         144 μs         306 μs

Comparison: 
EnumPatch.empty?(input)       20.92 K
Enum.empty?(input)             6.50 K - 3.22x slower +105.99 μs

##### With input 100 elements #####
Name                              ips        average  deviation         median         99th %
EnumPatch.empty?(input)       21.54 K       46.43 μs    ±20.45%          44 μs          83 μs
Enum.empty?(input)             5.76 K      173.66 μs    ±18.15%         164 μs         321 μs
```


I'm not sure is backporting is the way with Elixir, but it can be backported and if any help with patches needed, I'm happy to support

---

If this PR goes well, I can take a look into a few other functions like `Enum.any?/1` which special cases can be extended to handle maps separate (or I can add it into this PR)