### PR TITLE
Optimize Enumerable.slice/1 for lists and maps

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3617,7 +3617,7 @@ defmodule Enum do
 
   defp slice_count_and_fun(enumerable) do
     case Enumerable.slice(enumerable) do
-      {:ok, count, fun} when is_function(fun) ->
+      {:ok, count, fun} when is_function(fun, 2) ->
         {count, fun}
 
       {:error, module} ->
@@ -3821,8 +3821,13 @@ defmodule Enum do
 end
 
 defimpl Enumerable, for: List do
+  def count([]), do: {:ok, 0}
   def count(_list), do: {:error, __MODULE__}
+
+  def member?([], _value), do: {:ok, false}
   def member?(_list, _value), do: {:error, __MODULE__}
+
+  def slice([]), do: {:ok, 0, fn _, _ -> [] end}
   def slice(_list), do: {:error, __MODULE__}
 
   def reduce(_list, {:halt, acc}, _fun), do: {:halted, acc}

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -214,7 +214,9 @@ defmodule EnumTest do
 
   test "empty?/1" do
     assert Enum.empty?([])
+    assert Enum.empty?(%{})
     refute Enum.empty?([1, 2, 3])
+    refute Enum.empty?(%{one: 1})
     refute Enum.empty?(1..3)
   end
 


### PR DESCRIPTION
Inspired by #10491
/cc @Strech 

```
$ mix run benchmarks/enumerable.exs 
Operating System: Linux
Number of Available Cores: 8
Available memory: 7.56 GB
Elixir 1.11.2
Erlang 23.0.4

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 2 s
memory time: 0 ns
parallel: 1
inputs: list_empty, list_100, list_10_000, map_empty, map_100, map_10_000

##### With input list_empty #####
Name                                     ips        average  deviation         median         99th %
patched: Enum.Patched.empty?/1      282.41 M        3.54 ns ±51809.11%           0 ns           0 ns
original: Enum.empty?/1             123.23 M        8.11 ns ±48821.41%           0 ns           0 ns

Comparison: 
patched: Enum.Patched.empty?/1      282.41 M
original: Enum.empty?/1             123.23 M - 2.29x slower +4.57 ns

##### With input list_100 #####
Name                                     ips        average  deviation         median         99th %
original: Enum.empty?/1             204.58 M        4.89 ns ±51505.75%           0 ns           0 ns
patched: Enum.Patched.empty?/1      192.61 M        5.19 ns ±49045.92%           0 ns           0 ns

Comparison: 
original: Enum.empty?/1             204.58 M
patched: Enum.Patched.empty?/1      192.61 M - 1.06x slower +0.30 ns

##### With input list_10_000 #####
Name                                     ips        average  deviation         median         99th %
patched: Enum.Patched.empty?/1      122.67 M        8.15 ns ±43292.02%           0 ns           0 ns
original: Enum.empty?/1              66.51 M       15.04 ns ±76256.13%           0 ns           0 ns

Comparison: 
patched: Enum.Patched.empty?/1      122.67 M
original: Enum.empty?/1              66.51 M - 1.84x slower +6.88 ns

##### With input map_empty #####
Name                                     ips        average  deviation         median         99th %
patched: Enum.Patched.empty?/1      164.11 M        6.09 ns ±84758.53%           0 ns           0 ns
original: Enum.empty?/1              14.42 M       69.33 ns ±35734.53%           0 ns           0 ns

Comparison: 
patched: Enum.Patched.empty?/1      164.11 M
original: Enum.empty?/1              14.42 M - 11.38x slower +63.24 ns

##### With input map_100 #####
Name                                     ips        average  deviation         median         99th %
original: Enum.empty?/1              18.97 M       52.70 ns ±38524.78%           0 ns           0 ns
patched: Enum.Patched.empty?/1       17.65 M       56.65 ns ±38410.95%           0 ns           0 ns

Comparison: 
original: Enum.empty?/1              18.97 M
patched: Enum.Patched.empty?/1       17.65 M - 1.07x slower +3.95 ns

##### With input map_10_000 #####
Name                                     ips        average  deviation         median         99th %
patched: Enum.Patched.empty?/1       23.51 M       42.53 ns ±30197.28%           0 ns           0 ns
original: Enum.empty?/1              19.79 M       50.53 ns ±29354.16%           0 ns           0 ns

Comparison: 
patched: Enum.Patched.empty?/1       23.51 M
original: Enum.empty?/1              19.79 M - 1.19x slower +8.00 ns

```