### PR TITLE
Speed up Regex.replace/4 when there is no match

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -647,13 +647,12 @@ defmodule Regex do
 
   def replace(regex, string, replacement, options)
       when is_binary(string) and is_binary(replacement) and is_list(options) do
-    do_replace(regex, string, precompile_replacement(replacement), options)
+    do_replace(regex, string, replacement, options)
   end
 
   def replace(regex, string, replacement, options)
       when is_binary(string) and is_function(replacement) and is_list(options) do
-    {:arity, arity} = Function.info(replacement, :arity)
-    do_replace(regex, string, {replacement, arity}, options)
+    do_replace(regex, string, replacement, options)
   end
 
   defp do_replace(%Regex{} = regex, string, replacement, options) do
@@ -665,11 +664,17 @@ defmodule Regex do
         string
 
       {:match, [mlist | t]} when is_list(mlist) ->
-        apply_list(string, replacement, [mlist | t]) |> IO.iodata_to_binary()
+        apply_list(string, precompile_replacement(replacement), [mlist | t])
+        |> IO.iodata_to_binary()
 
       {:match, slist} ->
-        apply_list(string, replacement, [slist]) |> IO.iodata_to_binary()
+        apply_list(string, precompile_replacement(replacement), [slist]) |> IO.iodata_to_binary()
     end
+  end
+
+  defp precompile_replacement(replacement) when is_function(replacement) do
+    {:arity, arity} = Function.info(replacement, :arity)
+    {replacement, arity}
   end
 
   defp precompile_replacement(""), do: []


### PR DESCRIPTION
This PR postpones the call to `precompile_replacement/1` until `safe_run` identifies a match

- Background

    We had a slow Plug endpoint on production. (p99 ~400ms)
    In this endpoint, we'll read a file and then call `Regex.replace` on everyline in this file.
    By profiling this endpoint with `fprof`, we found the bottleneck is this `precompile_replacement/1` function inside a `Regex.replace` call. 

    Then we added a `Regex.match?` check before calling `Regex.replace`. 
    This optimization sped up the replace operation for at most 100ms (which is a ~30KB file with ~1500 lines that contain no matches, i.e. `Regex.replace` would be called 1500 times and all of them are no matches)

    We also tried using Erlang's `:re.replace` directly, which yielded a similar result (100ms boost for the worst case).
    (because `:re.replace` doesn't have a precompile step)

Let me know if I need to share a benchmark result for this optimization.
