### PR TITLE
Specify that Mix.raise/2 is available from 1.12+

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -429,14 +429,24 @@ defmodule Mix do
   end
 
   @doc """
+  Raises a Mix error that is nicely formatted, defaulting to exit code `1`.
+  """
+  @spec raise(binary) :: no_return
+  def raise(message) do
+    raise(message, exit_code: 1)
+  end
+
+  @doc """
   Raises a Mix error that is nicely formatted.
 
   ## Options
 
     * `:exit_code` - defines exit code value, defaults to `1`
+
   """
-  @spec raise(binary, exit_code: non_neg_integer()) :: no_return
-  def raise(message, opts \\ []) when is_binary(message) do
+  @doc since: "1.12.0"
+  @spec raise(binary, [option]) :: no_return when option: {:exit_code, non_neg_integer()}
+  def raise(message, opts) when is_binary(message) and is_list(opts) do
     Kernel.raise(Mix.Error, mix: Keyword.get(opts, :exit_code, 1), message: message)
   end
 

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -272,6 +272,8 @@ defmodule Mix do
 
   use Application
 
+  import Kernel, except: [raise: 2]
+
   @doc false
   def start do
     {:ok, _} = Application.ensure_all_started(:mix)
@@ -433,7 +435,7 @@ defmodule Mix do
   """
   @spec raise(binary) :: no_return
   def raise(message) do
-    raise(message, exit_code: 1)
+    __MODULE__.raise(message, exit_code: 1)
   end
 
   @doc """

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -447,7 +447,7 @@ defmodule Mix do
 
   """
   @doc since: "1.12.0"
-  @spec raise(binary, [option]) :: no_return when option: {:exit_code, non_neg_integer()}
+  @spec raise(binary, exit_code: non_neg_integer()) :: no_return
   def raise(message, opts) when is_binary(message) and is_list(opts) do
     Kernel.raise(Mix.Error, mix: Keyword.get(opts, :exit_code, 1), message: message)
   end


### PR DESCRIPTION
`Mix.raise/2` was introduced in https://github.com/elixir-lang/elixir/pull/10463 but by using default arguments, we were not making it at all clear that the `/2` version will only be available from 1.12.0. I'd rather have a couple more lines of code and be perfectly clear here. :)