### PR TITLE
add note about optional mix dependencies not being started

### DIFF
--- a/lib/mix/lib/mix/tasks/deps.ex
+++ b/lib/mix/lib/mix/tasks/deps.ex
@@ -72,7 +72,8 @@ defmodule Mix.Tasks.Deps do
       other project that depends on the current project won't be forced to
       use the optional dependency. However, if the other project includes
       the optional dependency on its own, the requirements and options
-      specified here will also be applied.
+      specified here will also be applied. Optional dependencies will _not_
+      be started by the application.
 
     * `:only` - the dependency is made available only in the given environments,
       useful when declaring dev- or test-only dependencies; by default the


### PR DESCRIPTION
This has been a repeated source of confusion and while the feature makes sense there's no note of the fact that this behavior occurs anywhere. Let me know if I should flesh this out a little more.