### PR TITLE
Default the mix target to :host when empty

### DIFF
--- a/lib/mix/lib/mix/state.ex
+++ b/lib/mix/lib/mix/state.ex
@@ -12,11 +12,19 @@ defmodule Mix.State do
   def init() do
     %{
       shell: Mix.Shell.IO,
-      env: String.to_atom(System.get_env("MIX_ENV") || "dev"),
-      target: String.to_atom(System.get_env("MIX_TARGET") || "host"),
+      env: from_env("MIX_ENV", :dev),
+      target: from_env("MIX_TARGET", :host),
       scm: [Mix.SCM.Git, Mix.SCM.Path],
       cache: :ets.new(@name, [:public, :set, :named_table, read_concurrency: true])
     }
+  end
+
+  defp from_env(varname, default) do
+    case System.get_env(varname) do
+      nil -> default
+      "" -> default
+      value -> String.to_atom(value)
+    end
   end
 
   def fetch(key) do

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -198,6 +198,30 @@ defmodule Mix.CLITest do
     System.delete_env("MIX_EXS")
   end
 
+  test "env config and target use defaults when empty", %{tmp_dir: tmp_dir} do
+    File.cd!(tmp_dir, fn ->
+      File.write!("custom.exs", """
+      defmodule P do
+        use Mix.Project
+        def project, do: [app: :p, version: "0.1.0"]
+      end
+      """)
+
+      System.put_env("MIX_ENV", "")
+      System.put_env("MIX_TARGET", "")
+      System.put_env("MIX_EXS", "custom.exs")
+
+      output =
+        mix(["run", "-e", "IO.inspect {Mix.env(), Mix.target(), System.argv()}", "--", "a", "b"])
+
+      assert output =~ ~s({:dev, :host, ["a", "b"]})
+    end)
+  after
+    System.delete_env("MIX_ENV")
+    System.delete_env("MIX_TARGET")
+    System.delete_env("MIX_EXS")
+  end
+
   @tag tmp_dir: "new_with_tests"
   test "new with tests and cover", %{tmp_dir: tmp_dir} do
     File.cd!(tmp_dir, fn ->


### PR DESCRIPTION
It seems that it's an easy mistake to set `$MIX_TARGET` to be empty
rather than unset it. The intention is to compile the project for the
host and it happens when switching between target and host. While this
seems like it should be easy to catch, it can trip up Nerves users since
Mix targets aren't well used in other contexts.

This commit also protects against `$MIX_ENV` being set to the empty
string for consistency.

Finally, tests were added for verifying that the mix targets gets set
and for the case that this code change addresses.