### PR TITLE
Add :as_tuples option to keyword inspect

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -175,6 +175,7 @@ defimpl Inspect, for: List do
     %Inspect.Opts{
       charlists: lists,
       char_lists: lists_deprecated,
+      keywords: keywords,
       printable_limit: printable_limit
     } = opts
 
@@ -213,7 +214,13 @@ defimpl Inspect, for: List do
         IO.iodata_to_binary(inspected)
 
       keyword?(term) ->
-        container_doc(open, term, close, opts, &keyword/2, separator: sep, break: :strict)
+        case keywords do
+          :as_keywords ->
+            container_doc(open, term, close, opts, &keyword/2, separator: sep, break: :strict)
+
+          :as_tuples ->
+            container_doc(open, term, close, opts, &to_doc/2, separator: sep, break: :strict)
+        end
 
       true ->
         container_doc(open, term, close, opts, &to_doc/2, separator: sep)

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -34,6 +34,10 @@ defmodule Inspect.Opts do
     * `:inspect_fun` (since v1.9.0) - a function to build algebra documents.
       Defaults to `Inspect.inspect/2`.
 
+    * `:keywords` TODO: (since vx.x.x) - when `:as_keywords` all keyword lists are
+      printed in Elixir's syntax sugar [key: :value],  when `:as_tuples` all keyword
+      lists are printed in two-element tuples [{:key, :value}].
+
     * `:limit` - limits the number of items that are inspected for tuples,
       bitstrings, maps, lists and any other collection of items, with the exception of
       printable strings and printable charlists which use the `:printable_limit` option.
@@ -79,6 +83,7 @@ defmodule Inspect.Opts do
             charlists: :infer,
             custom_options: [],
             inspect_fun: &Inspect.inspect/2,
+            keywords: :as_keywords,
             limit: 50,
             pretty: false,
             printable_limit: 4096,
@@ -97,6 +102,7 @@ defmodule Inspect.Opts do
           charlists: :infer | :as_lists | :as_charlists,
           custom_options: keyword,
           inspect_fun: (any, t -> Inspect.Algebra.t()),
+          keywords: :as_keywords | :as_tuples,
           limit: non_neg_integer | :infinity,
           pretty: boolean,
           printable_limit: non_neg_integer | :infinity,

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -315,6 +315,16 @@ defmodule Inspect.ListTest do
     assert inspect([0], charlists: :as_lists) == "[0]"
   end
 
+  test "opt as tuples" do
+    assert inspect([a: 1], keywords: :as_tuples) == "[{:a, 1}]"
+    assert inspect([a: 1, b: 2], keywords: :as_tuples) == "[{:a, 1}, {:b, 2}]"
+    assert inspect([a: 1, a: 2, b: 2], keywords: :as_tuples) == "[{:a, 1}, {:a, 2}, {:b, 2}]"
+    assert inspect(["123": 1], keywords: :as_tuples) == ~s([{:"123", 1}])
+
+    assert inspect([foo: [1, 2, 3], baz: [4, 5, 6]], keywords: :as_tuples, pretty: true, width: 20) ==
+             "[\n  {:foo, [1, 2, 3]},\n  {:baz, [4, 5, 6]}\n]"
+  end
+
   test "non printable" do
     assert inspect([{:b, 1}, {:a, 1}]) == "[b: 1, a: 1]"
   end


### PR DESCRIPTION
Something someone was asking if there was the ability to do in the Elixir Slack, and I was surprised there wasn't a way to do. 