### PR TITLE
Add warning for blocks without = mark on EEx

### DIFF
--- a/lib/eex/lib/eex/engine.ex
+++ b/lib/eex/lib/eex/engine.ex
@@ -221,7 +221,9 @@ defmodule EEx.Engine do
   end
 
   defp check_for_blocks(ast) do
-    Macro.traverse(ast, %{inside_assign: false, block_count: 0},
+    Macro.traverse(
+      ast,
+      %{inside_assign: false, block_count: 0},
       fn
         {:__block__, _, _} = ast, %{inside_assign: false} = acc ->
           {ast, %{acc | block_count: acc.block_count + 1}}

--- a/lib/eex/test/eex/smart_engine_test.exs
+++ b/lib/eex/test/eex/smart_engine_test.exs
@@ -50,7 +50,7 @@ defmodule EEx.SmartEngineTest do
     assert stderr == ""
   end
 
-  test "show warning when opens a block and then does an assignment" do 
+  test "show warning when opens a block and then does an assignment" do
     stderr =
       ExUnit.CaptureIO.capture_io(:stderr, fn ->
         assert_eval("Foo", ~s/<%if true do %>Foo<% else %>Bar<% end %><% a = "Foo" %><%= a %>/)

--- a/lib/eex/test/eex/smart_engine_test.exs
+++ b/lib/eex/test/eex/smart_engine_test.exs
@@ -28,6 +28,37 @@ defmodule EEx.SmartEngineTest do
     assert_eval("1\n2\n3\n", "<%= for x <- [1, 2, 3] do %><%= x %>\n<% end %>")
   end
 
+  test "show warning when opening block" do
+    stderr =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        assert_eval("", "<% if true do %>Foo<% else %>Bar<% end %>")
+      end)
+
+    assert stderr =~ "contains blocks"
+  end
+
+  test "doesn't show warning when opening inline" do
+    assert_eval("", ~s/<% if true, do: "Foo", else: "Bar" %>/)
+  end
+
+  test "doesn't show warning when opening a block for an assignment" do
+    stderr =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        assert_eval("Foo", ~s/<%a = if true do %>Foo<% else %>Bar<% end %><%= a %>/)
+      end)
+
+    assert stderr == ""
+  end
+
+  test "show warning when opens a block and then does an assignment" do 
+    stderr =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        assert_eval("Foo", ~s/<%if true do %>Foo<% else %>Bar<% end %><% a = "Foo" %><%= a %>/)
+      end)
+
+    assert stderr =~ "contains blocks"
+  end
+
   test "preserves line numbers in assignments" do
     result = EEx.compile_string("foo\n<%= @hello %>", engine: EEx.SmartEngine)
 

--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -275,8 +275,8 @@ defmodule EExTest do
     end
 
     test "when nested end expression is found without a start expression" do
-      assert_raise EEx.SyntaxError, "nofile:1:30: unexpected end of expression <% end %>", fn ->
-        EEx.compile_string("foo <% if true do %><% end %><% end %>")
+      assert_raise EEx.SyntaxError, "nofile:1:31: unexpected end of expression <% end %>", fn ->
+        EEx.compile_string("foo <%= if true do %><% end %><% end %>")
       end
     end
 
@@ -524,7 +524,7 @@ defmodule EExTest do
        <% "a" in y -> %>
         Good
        <% true -> %>
-        <% if true do %>true<% else %>false<% end %>
+        <%= if true do %>true<% else %>false<% end %>
         Bad
       <% end %>
       """
@@ -578,7 +578,10 @@ defmodule EExTest do
       <%= 789 %>
       """
 
-      assert_eval("123\n\n789\n", string)
+      # supressing the warning emitted due to the unused buffer
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        assert_eval("123\n\n789\n", string)
+      end)
     end
 
     test "inside comprehensions" do


### PR DESCRIPTION
Closes #10536. Adds a small step which checks for blocks outside
assigns on unmarked tags. Warning to be defined, I've put a placeholder.