### PR TITLE
Add offset option to Regex.scan/3 and Regex.run/3

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -296,7 +296,7 @@ defmodule Regex do
       Defaults to `:binary`.
     * `:capture` - what to capture in the result. Check the moduledoc for `Regex`
       to see the possible capture values.
-    * `:offset` - specifies the starting offset to match in the given string.
+    * `:offset` - (since v1.12.0) specifies the starting offset to match in the given string.
       Defaults to zero.
 
   ## Examples
@@ -428,7 +428,7 @@ defmodule Regex do
       Defaults to `:binary`.
     * `:capture` - what to capture in the result. Check the moduledoc for `Regex`
       to see the possible capture values.
-    * `:offset` - specifies the starting offset to match in the given string.
+    * `:offset` - (since v1.12.0) specifies the starting offset to match in the given string.
       Defaults to zero.
 
   ## Examples

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -296,6 +296,8 @@ defmodule Regex do
       Defaults to `:binary`.
     * `:capture` - what to capture in the result. Check the moduledoc for `Regex`
       to see the possible capture values.
+    * `:offset` - specifies the starting offset to match in the given string.
+      Defaults to zero.
 
   ## Examples
 
@@ -315,8 +317,9 @@ defmodule Regex do
   def run(%Regex{} = regex, string, options) when is_binary(string) do
     return = Keyword.get(options, :return, :binary)
     captures = Keyword.get(options, :capture, :all)
+    offset = Keyword.get(options, :offset, 0)
 
-    case safe_run(regex, string, [{:capture, captures, return}]) do
+    case safe_run(regex, string, [{:capture, captures, return}, {:offset, offset}]) do
       :nomatch -> nil
       :match -> []
       {:match, results} -> results
@@ -425,6 +428,8 @@ defmodule Regex do
       Defaults to `:binary`.
     * `:capture` - what to capture in the result. Check the moduledoc for `Regex`
       to see the possible capture values.
+    * `:offset` - specifies the starting offset to match in the given string.
+      Defaults to zero.
 
   ## Examples
 
@@ -450,7 +455,8 @@ defmodule Regex do
   def scan(%Regex{} = regex, string, options) when is_binary(string) do
     return = Keyword.get(options, :return, :binary)
     captures = Keyword.get(options, :capture, :all)
-    options = [{:capture, captures, return}, :global]
+    offset = Keyword.get(options, :offset, 0)
+    options = [{:capture, captures, return}, :global, {:offset, offset}]
 
     case safe_run(regex, string, options) do
       :match -> []

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -182,6 +182,13 @@ defmodule RegexTest do
     assert Regex.run(~r"e", "abcd", return: :index) == nil
   end
 
+  test "run/3 with :offset" do
+    assert Regex.run(~r"^foo", "foobar", offset: 0) == ["foo"]
+    assert Regex.run(~r"^foo", "foobar", offset: 2) == nil
+    assert Regex.run(~r"^foo", "foobar", offset: 2, return: :index) == nil
+    assert Regex.run(~r"bar", "foobar", offset: 2, return: :index) == [{3, 3}]
+  end
+
   test "run/3 with regexes compiled in different systems" do
     assert Regex.run(@re_21_3_little, "abcd abce", capture: :all_names) == ["d"]
     assert Regex.run(@re_21_3_big, "abcd abce", capture: :all_names) == ["d"]
@@ -203,6 +210,11 @@ defmodule RegexTest do
     assert Regex.scan(~r/c(?<foo>d)/, "abcd", capture: :all_names) == [["d"]]
     assert Regex.scan(~r/c(?<foo>d)/, "no_match", capture: :all_names) == []
     assert Regex.scan(~r/c(?<foo>d|e)/, "abcd abce", capture: :all_names) == [["d"], ["e"]]
+  end
+
+  test "scan/2 with :offset" do
+    assert Regex.scan(~r"^foo", "foobar", offset: 0) == [["foo"]]
+    assert Regex.scan(~r"^foo", "foobar", offset: 1) == []
   end
 
   test "scan/2 with regexes compiled in different systems" do


### PR DESCRIPTION
This MR adds the [offset option](https://erlang.org/doc/man/re.html#run-3) to be internally used by `:re.run/3` in `Regex.scan/3` and `Regex.run/3` functions. 

The offset option specifies the starting position of the string in which the regex should start matching. It is different from simply slicing the string because of the `^` matcher:

```elixir
str = "foobar"
sliced_str = String.slice(str, 3, 3)

Regex.run(~r{^bar}, sliced_str) == ["bar"]
Regex.run(~r{^bar}, str, offset: 3) == nil
``` 

[(A more detailed example from python re docs, the offset is equivalent to the `pos` parameter there.)](https://docs.python.org/3/library/re.html#re.Pattern.search)

The offset option is somewhat already present in `Regex.scan` and `Regex.run` - it is just always implicitly defaulted to zero. 