### PR TITLE
Add left out clarification in Enumerable count

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -188,7 +188,8 @@ defprotocol Enumerable do
   will become too expensive.
 
   On the other hand, the `count/1` function in this protocol should be
-  implemented whenever you can count the number of elements in the collection.
+  implemented whenever you can count the number of elements in the collection without
+  traversing it.
   """
   @spec slice(t) ::
           {:ok, size :: non_neg_integer(), slicing_fun()}


### PR DESCRIPTION
Mention that when we say that "you can count" is
without traversing the whole collection.
This was left out in 4a1e4481a3714cc48597b6f55242ca6413cade4d