### PR TITLE
Add String.chunk_by/2

### DIFF
--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -680,6 +680,13 @@ defmodule StringTest do
              [<<6>>, "ab", <<5>>, "cdef", <<3, 0>>]
   end
 
+  test "chunk_by/2" do
+    assert String.chunk_by("", &Function.identity/1) == []
+    assert String.chunk_by("aaa", &(&1 != "a")) == ["aaa"]
+    assert String.chunk_by("ababa", &(&1 == "a")) == ["a", "b", "a", "b", "a"]
+    assert String.chunk_by("abcdef", &(&1 < "d")) == ["abc", "def"]
+  end
+
   test "starts_with?/2" do
     assert String.starts_with?("hello", "he")
     assert String.starts_with?("hello", "hello")


### PR DESCRIPTION
### Motivation

I posted this concept to the [Elixir mailing list](https://groups.google.com/g/elixir-lang-core/c/4pUwugz9Oa0), but unfortunately did not elicit much feedback.

The goal is to add a generalized version of `String.chunk/2` that can be used to succinctly describe breaking a string into groups of codepoints that share some characteristic. This makes it inherently very similar to [`Enum.chunk_by/1`](https://hexdocs.pm/elixir/Enum.html#chunk_by/2). `String.chunk/2` presently only supports chunking based on the `String.valid?/1` and `String.printable?/2` functions.

Some examples of problems that benefit from this function include:
- Wrapping text on word boundaries, while preserving the whitespace between words.
- Finding the longest sequence of repeated characters.
- Breaking a string into it's ASCII and non-ASCII parts.

### Approach

- There is very little new code here, as most of the code that forms `String.chunk_by/2` was previously in `String.chunk/2`.
- `String.chunk/2` now simply finds it's chunking function based on the second parameter and calls `String.chunk_by/2`.
- The logic inside of `do_chunk` was lightly modified such that the `flag` does not need to be a boolean, but can be anything comparable.