### PR TITLE
generate error for unused "do" expression in EEx

### DIFF
--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -69,8 +69,7 @@ defmodule EEx.Compiler do
        ) do
     if mark != '=' do
       message =
-        "the contents of this \"do\" expression won't be output without the \"<%=\" modifier; if this was intentional " <>
-          "(if the block only has side-effects), please move its contents inside the expression"
+        "the contents of this expression won't be output unless the EEx block starts with \"<%=\""
 
       :elixir_errors.erl_warn(start_line, state.file, message)
     end

--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -67,6 +67,14 @@ defmodule EEx.Compiler do
          scope,
          state
        ) do
+    if mark != '=' do
+      message =
+        "the contents of this \"do\" expression won't be output without the \"<%=\" modifier; if this was intentional " <>
+          "(if the block only has side-effects), please move its contents inside the expression"
+
+      :elixir_errors.erl_warn(start_line, state.file, message)
+    end
+
     {contents, line, rest} = look_ahead_middle(rest, start_line, chars)
 
     {contents, rest} =

--- a/lib/eex/test/eex/smart_engine_test.exs
+++ b/lib/eex/test/eex/smart_engine_test.exs
@@ -49,16 +49,7 @@ defmodule EEx.SmartEngineTest do
         assert_eval("", "<% if true do %>I'm invisible!<% end %>", assigns: %{})
       end)
 
-    assert stderr =~ "the contents of this \"do\" expression won't be output"
-  end
-
-  test "no error with \"do\" block with \"<%=\" modifier" do
-    stderr =
-      ExUnit.CaptureIO.capture_io(:stderr, fn ->
-        assert_eval("I've appeared!", "<%= if true do %>I've appeared!<% end %>", assigns: %{})
-      end)
-
-    refute stderr =~ "the contents of this \"do\" expression won't be output"
+    assert stderr =~ "the contents of this expression won't be output"
   end
 
   defp assert_eval(expected, actual, binding \\ []) do

--- a/lib/eex/test/eex/smart_engine_test.exs
+++ b/lib/eex/test/eex/smart_engine_test.exs
@@ -43,6 +43,24 @@ defmodule EEx.SmartEngineTest do
     assert_received :found
   end
 
+  test "error with unused \"do\" block without \"<%=\" modifier" do
+    stderr =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        assert_eval("", "<% if true do %>I'm invisible!<% end %>", assigns: %{})
+      end)
+
+    assert stderr =~ "the contents of this \"do\" expression won't be output"
+  end
+
+  test "no error with \"do\" block with \"<%=\" modifier" do
+    stderr =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        assert_eval("I've appeared!", "<%= if true do %>I've appeared!<% end %>", assigns: %{})
+      end)
+
+    refute stderr =~ "the contents of this \"do\" expression won't be output"
+  end
+
   defp assert_eval(expected, actual, binding \\ []) do
     result = EEx.eval_string(actual, binding, file: __ENV__.file, engine: EEx.SmartEngine)
     assert result == expected


### PR DESCRIPTION
This PR adds a new compilation error when EEx encounters a `do` expression without the `<%=` modifier, since this is nearly always unintentional. For example, take this block:

```eex
<% if @password %>
Temporary Password: <%= @password %>
<% else %>
Sign in with your existing password.
<% end %
```

At first glance, all seems well, and in the context of a full application it may take quite some time to work out that nothing is being output because you're missing the `<%=` opening tag. The only case I can think of where a `do` block is valid without the `<%=` opening tag is something like this:

```eex
<% if @condition do %>
  <% some_side_effect() %>
<% end %>
```

...but this could trivially be refactored to the (IMO) cleaner:

```eex
<% if @condition do
  some_side_effect()
end %>
```

Credit to @halostatue for suggesting this https://groups.google.com/g/elixir-lang-core/c/FKA9PancUm0/m/KzkT1vWuAAAJ

Closes #10536.