### PR TITLE
Make comment unambiguous

### DIFF
--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -57,7 +57,7 @@ defmodule MapSet do
   @opaque t(value) :: %__MODULE__{map: %{optional(value) => []}}
   @type t :: t(term)
 
-  # TODO: Remove version key on v2.0
+  # TODO: Remove version key on Elixir v2.0
   defstruct map: %{}, version: 2
 
   @doc """


### PR DESCRIPTION
The v2.0 could be interpreted as if it's referring to the defstruct version, which by the way it is already number 2.