### PR TITLE
chore(Enum): :lists.foreach already returns an :ok atom, so we don't …

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -874,7 +874,6 @@ defmodule Enum do
   @spec each(t, (element -> any)) :: :ok
   def each(enumerable, fun) when is_list(enumerable) do
     :lists.foreach(fun, enumerable)
-    :ok
   end
 
   def each(enumerable, fun) do


### PR DESCRIPTION
…need to add another one

As per the erlang docs, this function already returns an `:ok` atom, so we don't need to do it twice.

https://erlang.org/doc/man/lists.html#foreach-2