### PR TITLE
fix test failures when `MIX_TARGET` is set with a non-empty value

### DIFF
--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -5,6 +5,12 @@ defmodule Mix.CLITest do
 
   @moduletag :tmp_dir
 
+  setup_all do
+    System.delete_env("MIX_ENV")
+    System.delete_env("MIX_TARGET")
+    System.delete_env("MIX_EXS")
+  end
+
   test "default task" do
     in_fixture("no_mixfile", fn ->
       File.write!("mix.exs", """

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -6,9 +6,7 @@ defmodule Mix.CLITest do
   @moduletag :tmp_dir
 
   setup_all do
-    System.delete_env("MIX_ENV")
     System.delete_env("MIX_TARGET")
-    System.delete_env("MIX_EXS")
   end
 
   test "default task" do

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -5,10 +5,6 @@ defmodule Mix.CLITest do
 
   @moduletag :tmp_dir
 
-  setup_all do
-    System.delete_env("MIX_TARGET")
-  end
-
   test "default task" do
     in_fixture("no_mixfile", fn ->
       File.write!("mix.exs", """

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -20,6 +20,7 @@ System.delete_env("https_proxy")
 System.delete_env("HTTP_PROXY")
 System.delete_env("HTTPS_PROXY")
 System.delete_env("MIX_ENV")
+System.delete_env("MIX_TARGET")
 
 defmodule MixTest.Case do
   use ExUnit.CaseTemplate


### PR DESCRIPTION
I got several tests in `lib/mix/test/mix/cli_text.exs` failed when I had an environment variable named `MIX_TARGET` with a non-empty value (e.g. `rpi3` for Nerves). It's because tmporary directories are created with wrong names like `_build/rpi3_test/lib/` not as `_build/test/lib/.`

```shell
$ bin/elixir lib/mix/test/mix/cli_test.exs
Excluding tags: [windows: true]

.

  1) test default task (Mix.CLITest)
     lib/mix/test/mix/cli_test.exs:8
     Expected truthy, got false
     code: assert File.regular?("_build/dev/lib/p/ebin/Elixir.A.beam")
     stacktrace:
       lib/mix/test/mix/cli_test.exs:18: anonymous fn/0 in Mix.CLITest."test default task"/1
       (elixir 1.12.0-dev) lib/file.ex:1554: File.cd!/2
       lib/mix/test/test_helper.exs:126: MixTest.Case.in_fixture/3
       lib/mix/test/mix/cli_test.exs:9: (test)



  2) test new --sup with tests (Mix.CLITest)
     lib/mix/test/mix/cli_test.exs:240
     Expected truthy, got false
     code: assert File.regular?("_build/test/lib/sup_with_tests/ebin/Elixir.SupWithTests.beam")
     stacktrace:
       lib/mix/test/mix/cli_test.exs:246: anonymous fn/0 in Mix.CLITest."test new --sup with tests"/1
       (elixir 1.12.0-dev) lib/file.ex:1554: File.cd!/2
       lib/mix/test/mix/cli_test.exs:241: (test)



  3) test new with tests and cover (Mix.CLITest)
     lib/mix/test/mix/cli_test.exs:226
     Expected truthy, got false
     code: assert File.regular?("_build/test/lib/new_with_tests/ebin/Elixir.NewWithTests.beam")
     stacktrace:
       lib/mix/test/mix/cli_test.exs:232: anonymous fn/0 in Mix.CLITest."test new with tests and cover"/1
       (elixir 1.12.0-dev) lib/file.ex:1554: File.cd!/2
       lib/mix/test/mix/cli_test.exs:227: (test)

........

Finished in 12.9 seconds (0.4s on load, 12.5s on tests)
12 tests, 3 failures

Randomized with seed 442085
```

To protect the tests from being compromised by the environment variables that the user who executes the test may have, we could delete them before the test is executed.

```elixir
setup_all do
  System.delete_env("MIX_TARGET")
end
```

Then I can see the tests finished successfully.

```shell
$ bin/elixir lib/mix/test/mix/cli_test.exs
Excluding tags: [windows: true]

.............

Finished in 12.2 seconds (0.4s on load, 11.7s on tests)
13 tests, 0 failures

Randomized with seed 943678
```

