### PR TITLE
Update Task.async docs

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -625,12 +625,11 @@ defmodule Task do
       `Process.monitor/1`. If you receive the `:DOWN` message without a
       a reply, it means the task crashed
 
-  Another consideration to have in mind is that tasks are always linked
-  to their callers and you may not want the GenServer to crash if the
-  task crashes. Therefore, it is preferrable to use `Task.Supervisor.async_nolink/3`
-  instead of `Task.async/1` inside OTP behaviours. For completenes,
-  here is an example of a GenServer that start tasks and handles their
-  results:
+  Another consideration to have in mind is that tasks started by `Task.async/1`
+  are always linked to their callers and you may not want the GenServer to
+  crash if the task crashes. Therefore, it is preferrable to instead use
+  `Task.Supervisor.async_nolink/3` inside OTP behaviours. For completenes, here
+  is an example of a GenServer that start tasks and handles their results:
 
       defmodule GenServerTaskExample do
         use GenServer


### PR DESCRIPTION
before it read:

> Another consideration to have in mind is that tasks are always linked to their callers

This isn't true for e.g. `Task.start`. However, since it's docs for `await/2`, I guess it is implied that we're talking about tasks started by `async/1`, I thought it might be worth clarifying but maybe it's unnecessary :)