### PR TITLE
Improve Enum.chunk_while/4 docs to clarify `after_fun` semantics

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -485,12 +485,12 @@ defmodule Enum do
   as part of an accumulator, but were not emited as a chunk by `chunk_fun`.
   It must return:
 
-  * `{:cont, chunk, acc}` to emit a chunk. The chunk will be appended to the
-     list of already emitted chunks.
-  * `{:cont, acc}` to not emit a chunk
+    * `{:cont, chunk, acc}` to emit a chunk. The chunk will be appended to the
+      list of already emitted chunks.
+    * `{:cont, acc}` to not emit a chunk
 
-  (`acc` in `after_fun` return tuple is required by `chunk_every/4` to match
-  on the result, but is ignored.)
+  The `acc` in `after_fun` is required in order to mirror the tuple format
+  from `chunk_fun` but it will be discarded since the traversal is complete.
 
   Returns a list of emitted chunks.
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -509,6 +509,8 @@ defmodule Enum do
       ...> end
       iex> Enum.chunk_while(1..10, [], chunk_fun, after_fun)
       [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]
+      iex> Enum.chunk_while([1, 2, 3, 5, 7], [], chunk_fun, after_fun)
+      [[1, 2], [3, 5, 7]]
 
   """
   @doc since: "1.5.0"

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -525,7 +525,7 @@ defmodule Enum do
     {_, {res, acc}} =
       Enumerable.reduce(enumerable, {:cont, {[], acc}}, fn entry, {buffer, acc} ->
         case chunk_fun.(entry, acc) do
-          {:cont, emit, acc} -> {:cont, {[emit | buffer], acc}}
+          {:cont, chunk, acc} -> {:cont, {[chunk | buffer], acc}}
           {:cont, acc} -> {:cont, {buffer, acc}}
           {:halt, acc} -> {:halt, {buffer, acc}}
         end
@@ -533,7 +533,7 @@ defmodule Enum do
 
     case after_fun.(acc) do
       {:cont, _acc} -> :lists.reverse(res)
-      {:cont, elem, _acc} -> :lists.reverse([elem | res])
+      {:cont, chunk, _acc} -> :lists.reverse([chunk | res])
     end
   end
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -474,15 +474,25 @@ defmodule Enum do
   @doc """
   Chunks the `enumerable` with fine grained control when every chunk is emitted.
 
-  `chunk_fun` receives the current element and the accumulator and
-  must return `{:cont, chunk, acc}` to emit the given chunk and
-  continue with accumulator or `{:cont, acc}` to not emit any chunk
-  and continue with the return accumulator.
+  `chunk_fun` receives the current element and the accumulator and must return:
 
-  `after_fun` is invoked when iteration is done and must also return
-  `{:cont, chunk, acc}` or `{:cont, acc}`.
+    * `{:cont, chunk, acc}` to emit a chunk and continue with the accumulator
+    * `{:cont, acc}` to not emit any chunk and continue with the accumulator
+    * `{:halt, acc}` to halt chunking over the `enumerable`.
 
-  Returns a list of lists.
+  `after_fun` is invoked with the final accumulator when iteration is
+  finished (or `halt`ed) to handle any trailing elements that were returned
+  as part of an accumulator, but were not emited as a chunk by `chunk_fun`.
+  It must return:
+
+  * `{:cont, chunk, acc}` to emit a chunk. The chunk will be appended to the
+     list of already emitted chunks.
+  * `{:cont, acc}` to not emit a chunk
+
+  (`acc` in `after_fun` return tuple is required by `chunk_every/4` to match
+  on the result, but is ignored.)
+
+  Returns a list of emitted chunks.
 
   ## Examples
 

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -116,6 +116,8 @@ defmodule EnumTest do
              [[0], [1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]
 
     assert Enum.chunk_while([5, 7, 9, 11], [], chunk_fun, after_fun) == [[5, 7, 9]]
+
+    assert Enum.chunk_while([1, 2, 3, 5, 7], [], chunk_fun, after_fun) == [[1, 2], [3, 5, 7]]
   end
 
   test "concat/1" do

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -118,6 +118,15 @@ defmodule EnumTest do
     assert Enum.chunk_while([5, 7, 9, 11], [], chunk_fun, after_fun) == [[5, 7, 9]]
 
     assert Enum.chunk_while([1, 2, 3, 5, 7], [], chunk_fun, after_fun) == [[1, 2], [3, 5, 7]]
+
+    chunk_fn2 = fn
+      -1, acc -> {:cont, acc, 0}
+      i, acc -> {:cont, acc + i}
+    end
+
+    after_fn2 = fn acc -> {:cont, acc, 0} end
+
+    assert Enum.chunk_while([1, -1, 2, 3, -1, 4, 5, 6], 0, chunk_fn2, after_fn2) == [1, 5, 15]
   end
 
   test "concat/1" do


### PR DESCRIPTION
I found trying to understand `Enum.chunk_while/4` quite confusing, and needed to resort to reading the code to understand how the `after_fun` param semantics are intended to work. Have added my understanding to the docs for it, and made a couple of improvements to code readability, and added a couple of test cases covering extra cases.

- Updated docs to clarify
  - add `{:halt, acc}` tuple return doc for `chunk_fun`
  - explain `after_fun` semantics in more detail
  - format return tuples for `chunk_fun` and `after_fun` as markdown lists
  - added note that `acc` in `after_fun` return tuple is ignored
  - state `Enum.chunk_while/4` returns a list of *chunks*, not a list of lists (emitted chunks can be anything, not necessarily just lists)
- added example showing `after_fun`'s behaviour more clearly
- renamed variable names used in `chunk_fun` / `after_fun` matches to make them consistent with each other, and with the typespec of the functions
- added extra tests for `after_fun`
  - more explicitly exercising behaviour when acc has accumulated more elements
  - handling returning types other than just lists

