### PR TITLE
Fix `Path.relative_to/2` when referencing self

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -313,11 +313,18 @@ defmodule Path do
       iex> Path.relative_to("/usr/local/foo", "/etc")
       "/usr/local/foo"
 
+      iex> Path.relative_to("/usr/local/foo", "/usr/local/foo")
+      "."
+
   """
   @spec relative_to(t, t) :: binary
   def relative_to(path, from) do
     path = IO.chardata_to_string(path)
     relative_to(split(path), split(from), path)
+  end
+
+  defp relative_to(path, path, _original) do
+    "."
   end
 
   defp relative_to([h | t1], [h | t2], original) do

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -193,7 +193,9 @@ defmodule PathTest do
     assert Path.relative_to("/usr/local/foo", "/usr/local") == "foo"
     assert Path.relative_to("/usr/local/foo", "/") == "usr/local/foo"
     assert Path.relative_to("/usr/local/foo", "/etc") == "/usr/local/foo"
-    assert Path.relative_to("/usr/local/foo", "/usr/local/foo") == "/usr/local/foo"
+    assert Path.relative_to("/usr/local/foo", "/usr/local/foo") == "."
+    assert Path.relative_to("/usr/local/foo/", "/usr/local/foo") == "."
+    assert Path.relative_to("/usr/local/foo", "/usr/local/foo/") == "."
 
     assert Path.relative_to("usr/local/foo", "usr/local") == "foo"
     assert Path.relative_to("usr/local/foo", "etc") == "usr/local/foo"


### PR DESCRIPTION
Hello, 

Unless my reasoning is wrong, there might be a bug
in `Path.relative_to/2` implementation.

The assumption I'm making is `relative_to` should always
return a path of type `:relative`.

Thus, if `relative_to` argument points at `path`, the
result should be relative.

Currently it's:

    iex(1)> Path.relative_to('/foo/bar', '/foo/bar') |> Path.type()
    :absolute

This patch fixes it, so it's:

    iex(1)> Path.relative_to('/foo/bar', '/foo/bar')
    "."
    iex(2)> Path.type(v(1))
    :relative

Similar code in python:

    In [1]: os.path.relpath('/foo/bar', start='/foo/bar')
    Out[1]: '.'

And in ruby:

    > Pathname.new('/foo/bar').relative_path_from(Pathname.new('/foo/bar')).to_s
    => "."

