### PR TITLE
Extend functions/macros not allowed inside Protocols

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -678,14 +678,18 @@ defmodule Protocol do
         # We don't allow function definition inside protocols
         import Kernel,
           except: [
-            defmacrop: 1,
-            defmacrop: 2,
-            defmacro: 1,
-            defmacro: 2,
+            def: 1,
+            def: 2,
             defp: 1,
             defp: 2,
-            def: 1,
-            def: 2
+            defdelegate: 2,
+            defexception: 1,
+            defguard: 1,
+            defguardp: 1,
+            defmacro: 1,
+            defmacro: 2,
+            defmacrop: 1,
+            defmacrop: 2
           ]
 
         # Import the new dsl that holds the new def

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -262,6 +262,33 @@ defmodule ProtocolTest do
                    end
                  end
   end
+
+  test "cannot define function definitions inside protocol" do
+    assert_raise CompileError, ~r"undefined function def/2", fn ->
+      defprotocol Foo do
+        def bar(arg), do: arg
+      end
+    end
+
+    assert_raise CompileError, ~r"undefined function defdelegate/2", fn ->
+      defprotocol Foo do
+        defdelegate reverse(list), to: Enum
+      end
+    end
+
+    assert_raise CompileError, ~r"undefined function defmacro/2", fn ->
+      defprotocol Foo do
+        defmacro __using__(options) do
+        end
+      end
+    end
+
+    assert_raise CompileError, ~r"undefined function defguard/1", fn ->
+      defprotocol Foo do
+        defguard is_something(arg) when arg == :something
+      end
+    end
+  end
 end
 
 defmodule Protocol.DebugInfoTest do

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -262,33 +262,6 @@ defmodule ProtocolTest do
                    end
                  end
   end
-
-  test "cannot define function definitions inside protocol" do
-    assert_raise CompileError, ~r"undefined function def/2", fn ->
-      defprotocol Foo do
-        def bar(arg), do: arg
-      end
-    end
-
-    assert_raise CompileError, ~r"undefined function defdelegate/2", fn ->
-      defprotocol Foo do
-        defdelegate reverse(list), to: Enum
-      end
-    end
-
-    assert_raise CompileError, ~r"undefined function defmacro/2", fn ->
-      defprotocol Foo do
-        defmacro __using__(options) do
-        end
-      end
-    end
-
-    assert_raise CompileError, ~r"undefined function defguard/1", fn ->
-      defprotocol Foo do
-        defguard is_something(arg) when arg == :something
-      end
-    end
-  end
 end
 
 defmodule Protocol.DebugInfoTest do


### PR DESCRIPTION
Add to the list: defexception/1, defdelegate/2, defguard/1, defguardp/1