### PR TITLE
fix small typo in pipe operator's doc

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3730,7 +3730,7 @@ defmodule Kernel do
       "Hello" |> String.graphemes() |> Enum.reverse()
 
   The second limitation is that Elixir always pipes to a function
-  call. Therefore, to pipe into an anonymous function, you need the
+  call. Therefore, to pipe into an anonymous function, you need to
   invoke it:
 
       some_fun = &Regex.replace(~r/l/, &1, "L")


### PR DESCRIPTION
Caught this while having a look at the `Kernel.then/1` PR

Thank you for adding it!