### PR TITLE
Stremaline specs in Kernel.{tap, then}/2

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1147,7 +1147,7 @@ defmodule Kernel do
 
   """
   @doc since: "1.12.0"
-  @spec tap(x, (x -> any)) :: x when x: var
+  @spec tap(value, (value -> any)) :: value when value: var
   def tap(value, fun) when is_function(fun, 1) do
     fun.(value)
     value
@@ -2495,7 +2495,7 @@ defmodule Kernel do
       2
   """
   @doc since: "1.12.0"
-  @spec then(x, (x -> result)) :: result when result: var, x: var
+  @spec then(value, (value -> result)) :: result when value: var, result: var
   def then(value, fun) when is_function(fun, 1), do: fun.(value)
 
   @doc """


### PR DESCRIPTION
x is not used anywhere in the specs. Use name of argument instead.

/cc @Eiji7, @v0idpwn 