### PR TITLE
Return :error on decomposing regular tuples as calls

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -548,7 +548,6 @@ defmodule Macro do
   @spec decompose_call(t()) :: {atom, [t()]} | {t(), atom, [t()]} | :error
   def decompose_call(ast)
 
-  # regular tuples
   def decompose_call({:{}, _, args}) when is_list(args), do: :error
 
   def decompose_call({{:., _, [remote, function]}, _, args})

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -541,9 +541,15 @@ defmodule Macro do
       iex> Macro.decompose_call(quote(do: 42))
       :error
 
+      iex> Macro.decompose_call(quote(do: {:foo, [], []}))
+      :error
+
   """
   @spec decompose_call(t()) :: {atom, [t()]} | {t(), atom, [t()]} | :error
   def decompose_call(ast)
+
+  # regular tuples
+  def decompose_call({:{}, _, args}) when is_list(args), do: :error
 
   def decompose_call({{:., _, [remote, function]}, _, args})
       when is_tuple(remote) or is_atom(remote),

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -769,6 +769,8 @@ defmodule MacroTest do
     assert Macro.decompose_call(quote(do: :foo.foo(1, 2, 3))) == {:foo, :foo, [1, 2, 3]}
     assert Macro.decompose_call(quote(do: 1.(1, 2, 3))) == :error
     assert Macro.decompose_call(quote(do: "some string")) == :error
+    assert Macro.decompose_call(quote(do: {:foo, :bar, :baz})) == :error
+    assert Macro.decompose_call(quote(do: {:foo, :bar, :baz, 42})) == :error
   end
 
   describe "env" do


### PR DESCRIPTION
Since [`Macro.decompose_call/1`](https://hexdocs.pm/elixir/Macro.html?#decompose_call/1) is exported and documented, it would make sense to explicitly handle the case of passing quoted regular tuple as an argument, returning `:error` as it does for any other garbage (neither local nor remote call.)

