### PR TITLE
Correct protocol error, when @fallback_to_any true and no implementation for Any

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -767,12 +767,27 @@ defmodule Protocol do
       @spec impl_for!(term) :: atom
       if any_impl_for do
         Kernel.def impl_for!(data) do
-          impl_for(data)
+          try do
+            impl_for(data)
+          rescue
+            UndefinedFunctionError ->
+              raise_impl_for(data)
+          else
+            nil ->
+              raise_impl_for(data)
+
+            result ->
+              result
+          end
         end
       else
         Kernel.def impl_for!(data) do
-          impl_for(data) || raise(Protocol.UndefinedError, protocol: __MODULE__, value: data)
+          impl_for(data) || raise_impl_for(data)
         end
+      end
+
+      Kernel.defp raise_impl_for(value) do
+        raise(Protocol.UndefinedError, protocol: __MODULE__, value: value)
       end
 
       # Internal handler for Structs

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -720,7 +720,9 @@ defmodule Protocol do
               unquote(__MODULE__.Any).__impl__(:target)
             rescue
               UndefinedFunctionError ->
-                nil
+                reraise Protocol.UndefinedError,
+                        [protocol: unquote(__MODULE__), value: :how_do_i_pass_this_value?],
+                        __STACKTRACE__
             end
           end
         else

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -25,6 +25,13 @@ defmodule ProtocolTest do
 
   @with_any_binary with_any_binary
 
+  {_, _, with_fallback_to_any_without_any_binary, _} =
+    defprotocol WithFallbackToAnyWithoutAny do
+      @fallback_to_any true
+      @doc "Ok"
+      def ok(term)
+    end
+
   defprotocol Derivable do
     def ok(a)
   end
@@ -103,12 +110,24 @@ defmodule ProtocolTest do
     assert WithAny.impl_for(self()) == WithAny.Any
   end
 
-  test "protocol not implemented" do
-    message = "protocol ProtocolTest.Sample not implemented for :foo of type Atom"
+  describe "protocol not implemented" do
+    test "@falback_to_any false" do
+      message = "protocol ProtocolTest.Sample not implemented for :foo of type Atom"
 
-    assert_raise Protocol.UndefinedError, message, fn ->
-      sample = Sample
-      sample.ok(:foo)
+      assert_raise Protocol.UndefinedError, message, fn ->
+        sample = Sample
+        sample.ok(:foo)
+      end
+    end
+
+    test "@falback_to_any true" do
+      message =
+        "protocol ProtocolTest.WithFallbackToAnyWithoutAny not implemented for :foo of type Atom"
+
+      assert_raise Protocol.UndefinedError, message, fn ->
+        sample = WithFallbackToAnyWithoutAny
+        sample.ok(:foo)
+      end
     end
   end
 


### PR DESCRIPTION
given
```elixir
defprotocol WithFallBackToAnyFalse do
  def foo(term)
end

defprotocol WithFallBackToAnyTrue do
  @fallback_to_any true

  def foo(term)
end

```
before the fix:

```
iex> WithFallBackToAnyFalse.foo([])
** (Protocol.UndefinedError) protocol WithFallBackToAnyFalse not implemented for [] of type List. There are no implementations for this protocol.

iex> WithFallBackToAnyTrue.foo([])
** (UndefinedFunctionError) function nil.foo/1 is undefined

```
after the fix:

```
iex> WithFallBackToAnyTrue.foo([])
** (Protocol.UndefinedError) protocol WithFallBackToAnyTrue not implemented for [] of type List, while @fallback_to_any has been set to true, the implementation for Any is missing. There are no implementations for this protocol.
```