### PR TITLE
Fix cryptic error when defimpl is defined without :for option

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4841,9 +4841,8 @@ defmodule Kernel do
   defmacro defimpl(name, opts, do_block \\ []) do
     merged = Keyword.merge(opts, do_block)
     merged = Keyword.put_new(merged, :for, __CALLER__.module)
-    for_option = Keyword.fetch!(merged, :for)
 
-    if for_option == nil do
+    if Keyword.fetch!(merged, :for) == nil do
       raise ArgumentError, "defimpl/3 expects a :for option when declared outside a module"
     end
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4843,7 +4843,7 @@ defmodule Kernel do
     merged = Keyword.put_new(merged, :for, __CALLER__.module)
     for_option = Keyword.fetch!(merged, :for)
 
-    if for_option == nil or for_option == [] do
+    if for_option == nil do
       raise ArgumentError, "defimpl/3 expects a :for option when declared outside a module"
     end
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4841,6 +4841,12 @@ defmodule Kernel do
   defmacro defimpl(name, opts, do_block \\ []) do
     merged = Keyword.merge(opts, do_block)
     merged = Keyword.put_new(merged, :for, __CALLER__.module)
+    for_option = Keyword.fetch!(merged, :for)
+
+    if for_option == nil or for_option == [] do
+      raise ArgumentError, "defimpl/3 expects a :for option when declared outside a module"
+    end
+
     Protocol.__impl__(name, merged)
   end
 

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -214,17 +214,6 @@ defmodule ProtocolTest do
 
       Code.eval_quoted(ast, [], %{__ENV__ | module: nil})
     end
-
-    assert_raise ArgumentError, msg, fn ->
-      ast =
-        quote do
-          defimpl Sample, for: [] do
-            def ok(_term), do: true
-          end
-        end
-
-      Code.eval_quoted(ast, [], %{__ENV__ | module: nil})
-    end
   end
 
   defp get_callbacks(beam, name, arity) do

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -205,9 +205,14 @@ defmodule ProtocolTest do
     msg = "defimpl/3 expects a :for option when declared outside a module"
 
     assert_raise ArgumentError, msg, fn ->
-      defimpl Sample do
-        def ok(_term), do: true
-      end
+      ast =
+        quote do
+          defimpl Sample do
+            def ok(_term), do: true
+          end
+        end
+
+      Code.eval_quoted(ast, [], %{__ENV__ | module: nil})
     end
   end
 

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -205,14 +205,9 @@ defmodule ProtocolTest do
     msg = "defimpl/3 expects a :for option when declared outside a module"
 
     assert_raise ArgumentError, msg, fn ->
-      ast =
-        quote do
-          defimpl Sample do
-            def ok(_term), do: true
-          end
-        end
-
-      Code.eval_quoted(ast, [], %{__ENV__ | module: nil})
+      defimpl Sample do
+        def ok(_term), do: true
+      end
     end
   end
 

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -201,6 +201,32 @@ defmodule ProtocolTest do
     assert Multi.test(:a) == :a
   end
 
+  test "defimpl without :for option when ouside a module" do
+    msg = "defimpl/3 expects a :for option when declared outside a module"
+
+    assert_raise ArgumentError, msg, fn ->
+      ast =
+        quote do
+          defimpl Sample do
+            def ok(_term), do: true
+          end
+        end
+
+      Code.eval_quoted(ast, [], %{__ENV__ | module: nil})
+    end
+
+    assert_raise ArgumentError, msg, fn ->
+      ast =
+        quote do
+          defimpl Sample, for: [] do
+            def ok(_term), do: true
+          end
+        end
+
+      Code.eval_quoted(ast, [], %{__ENV__ | module: nil})
+    end
+  end
+
   defp get_callbacks(beam, name, arity) do
     {:ok, callbacks} = Code.Typespec.fetch_callbacks(beam)
     List.keyfind(callbacks, {name, arity}, 0) |> elem(1)


### PR DESCRIPTION
When defimpl/3 is defined outside a module without a :for option, such as in the code bellow,
it will five a cryptic error.

```elixir
defprotocol A do
  def ok(term)
end

defimpl A do
  def ok(term), do: {:ok, term}
end
```

BEFORE FIX:
```
19:42:16.595 [error] Task #PID<0.187.0> started from #PID<0.95.0> terminating
** (CaseClauseError) no case clause matching: {:error, :not_a_protocol}
    (mix 1.11.2) lib/mix/tasks/compile.protocols.ex:141: Mix.Tasks.Compile.Protocols.consolidate/4
    (elixir 1.11.2) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
    (elixir 1.11.2) lib/task/supervised.ex:35: Task.Supervised.reply/5
    (stdlib 3.13.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Function: #Function<9.81221892/0 in Mix.Tasks.Compile.Protocols.consolidate/6>
    Args: []
** (EXIT from #PID<0.95.0>) an exception was raised:
    ** (CaseClauseError) no case clause matching: {:error, :not_a_protocol}
        (mix 1.11.2) lib/mix/tasks/compile.protocols.ex:141: Mix.Tasks.Compile.Protocols.consolidate/4
        (elixir 1.11.2) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
        (elixir 1.11.2) lib/task/supervised.ex:35: Task.Supervised.reply/5
        (stdlib 3.13.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```

AFTER FIX:
```
== Compilation error in file lib/broken2.ex ==
** (ArgumentError) defimpl/3 expects a :for option when declared outside a module
    (elixir 1.12.0-dev) lib/kernel.ex:4846: Kernel."MACRO-defimpl"/4
    (elixir 1.12.0-dev) expanding macro: Kernel.defimpl/2
    lib/broken2.ex:5: (file)
```