### PR TITLE
Optimize String.valid?

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1712,11 +1712,12 @@ defmodule String do
 
   """
   @spec valid?(t) :: boolean
-  def valid?(string)
-
-  def valid?(<<_::utf8, t::binary>>), do: valid?(t)
-  def valid?(<<>>), do: true
+  def valid?(<<string::binary>>), do: valid_utf8?(string)
   def valid?(_), do: false
+
+  defp valid_utf8?(<<_::utf8, rest::bits>>), do: valid_utf8?(rest)
+  defp valid_utf8?(<<>>), do: true
+  defp valid_utf8?(_), do: false
 
   @doc false
   @deprecated "Use String.valid?/1 instead"


### PR DESCRIPTION
For 1000 bytes string, a very simple benchmark on my computer shows that it's ~20% faster.

```
iex> Enum.map(1..5000, fn _ -> :timer.tc(fn -> A.valid?(data) end) |> elem(0) end) |> Enum.sum()
678553
iex> Enum.map(1..5000, fn _ -> :timer.tc(fn -> String.valid?(data) end) |> elem(0) end) |> Enum.sum()
868434
```