### PR TITLE
Optimize String.codepoints

### DIFF
--- a/lib/elixir/unicode/unicode.ex
+++ b/lib/elixir/unicode/unicode.ex
@@ -304,15 +304,17 @@ defmodule String.Unicode do
     nil
   end
 
-  def codepoints(binary) when is_binary(binary) do
-    do_codepoints(next_codepoint(binary))
+  def codepoints(string) when is_binary(string) do
+    do_codepoints(string)
   end
 
-  defp do_codepoints({c, rest}) do
-    [c | do_codepoints(next_codepoint(rest))]
+  defp do_codepoints(<<codepoint::utf8, rest::bits>>) do
+    [<<codepoint::utf8>> | do_codepoints(rest)]
   end
 
-  defp do_codepoints(nil) do
-    []
+  defp do_codepoints(<<byte, rest::bits>>) do
+    [<<byte>> | do_codepoints(rest)]
   end
+
+  defp do_codepoints(<<>>), do: []
 end


### PR DESCRIPTION
Benchmarking against the following script. It seems to be more efficient in memory and speed.

```elixir
inputs =
  %{
    "Short ASCII" => "abcdefghjklmnopqrstuvwxyz",
    "Short UTF-8" => "葡萄美酒夜光杯 欲饮琵琶马上催 醉卧沙场君莫笑 古来征战几人回",
    "Long ASCII" => String.duplicate("abcdefghjklmnopqrstuvwxyz", 1000),
    "Long UTF-8" => String.duplicate("葡萄美酒夜光杯 欲饮琵琶马上催 醉卧沙场君莫笑 古来征战几人回", 1000),
  }

bench_options = [
  time: 5,
  memory_time: 2,
  inputs: inputs
]

Benchee.run(
  %{
    "String (master)" => fn input -> String.codepoints(input) end,
    "String (qcam)" => fn input -> String2.codepoints(input) end
  },
  bench_options
)
```

```
Operating System: macOS
CPU Information: Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz
Number of Available Cores: 4
Available memory: 16 GB
Elixir 1.10.2
Erlang 23.0.3

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 2 s
parallel: 1
inputs: Long ASCII, Long UTF-8, Short ASCII, Short UTF-8
Estimated total run time: 1.20 min

Benchmarking String (master) with input Long ASCII...
Benchmarking String (master) with input Long UTF-8...
Benchmarking String (master) with input Short ASCII...
Benchmarking String (master) with input Short UTF-8...
Benchmarking String (qcam) with input Long ASCII...
Benchmarking String (qcam) with input Long UTF-8...
Benchmarking String (qcam) with input Short ASCII...
Benchmarking String (qcam) with input Short UTF-8...

##### With input Long ASCII #####
Name                      ips        average  deviation         median         99th %
String (qcam)          653.73        1.53 ms    ±19.02%        1.49 ms        2.33 ms
String (master)        189.43        5.28 ms    ±25.65%        5.19 ms        9.20 ms

Comparison:
String (qcam)          653.73
String (master)        189.43 - 3.45x slower +3.75 ms

Memory usage statistics:

Name               Memory usage
String (qcam)           0.95 MB
String (master)         3.43 MB - 3.60x memory usage +2.48 MB

**All measurements for memory usage were the same**

##### With input Long UTF-8 #####
Name                      ips        average  deviation         median         99th %
String (qcam)          460.07        2.17 ms    ±12.48%        2.11 ms        3.11 ms
String (master)        145.95        6.85 ms    ±25.11%        6.79 ms       12.70 ms

Comparison:
String (qcam)          460.07
String (master)        145.95 - 3.15x slower +4.68 ms

Memory usage statistics:

Name               Memory usage
String (qcam)           1.18 MB
String (master)         4.26 MB - 3.60x memory usage +3.07 MB

**All measurements for memory usage were the same**

##### With input Short ASCII #####
Name                      ips        average  deviation         median         99th %
String (qcam)        544.02 K        1.84 μs  ±1313.27%           2 μs           5 μs
String (master)      265.31 K        3.77 μs   ±540.25%           3 μs          10 μs

Comparison:
String (qcam)        544.02 K
String (master)      265.31 K - 2.05x slower +1.93 μs

Memory usage statistics:

Name               Memory usage
String (qcam)           1.02 KB
String (master)         3.34 KB - 3.29x memory usage +2.33 KB

**All measurements for memory usage were the same**

##### With input Short UTF-8 #####
Name                      ips        average  deviation         median         99th %
String (qcam)        385.71 K        2.59 μs  ±1198.62%           2 μs           6 μs
String (master)      174.83 K        5.72 μs   ±392.65%           4 μs          16 μs

Comparison:
String (qcam)        385.71 K
String (master)      174.83 K - 2.21x slower +3.13 μs

Memory usage statistics:

Name               Memory usage
String (qcam)           1.25 KB
String (master)         4.63 KB - 3.71x memory usage +3.38 KB

**All measurements for memory usage were the same**
```