### PR TITLE
Log when .iex.exs file is loaded when starting IEx.

### DIFF
--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -238,6 +238,7 @@ defmodule IEx.Evaluator do
       env = :elixir.env_for_eval(state.env, file: path, line: 1)
       Process.put(:iex_imported_paths, MapSet.new([path]))
       {_result, binding, env} = :elixir.eval_forms(quoted, state.binding, env)
+      io_result("Loaded #{Path.relative_to_cwd(path)}")
       %{state | binding: binding, env: :elixir.env_for_eval(env, file: "iex", line: 1)}
     catch
       kind, error ->

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1087,7 +1087,8 @@ defmodule IEx.HelpersTest do
 
       with_file(["dot-iex-1", "dot-iex-2"], [dot_1, dot_2], fn ->
         assert capture_io(:stderr, fn ->
-                 assert capture_iex(":ok", [], dot_iex_path: "dot-iex-1") == ":ok"
+                 assert capture_iex(":ok", [], dot_iex_path: "dot-iex-1") ==
+                          "Loaded dot-iex-1\n:ok"
                end) =~ "dot-iex-2 was already imported, skipping circular file imports"
       end)
     end

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -181,7 +181,9 @@ defmodule IEx.InteractionTest do
     @tag :tmp_dir
     test "single .iex", %{tmp_dir: tmp_dir} do
       path = write_dot_iex!(tmp_dir, "dot-iex", "my_variable = 144")
-      assert capture_iex("my_variable", [], dot_iex_path: path) == "144"
+
+      assert capture_iex("my_variable", [], dot_iex_path: path) ==
+               "Loaded tmp/IEx.InteractionTest/test-.iex-single-.iex/dot-iex\n144"
     end
 
     @tag :tmp_dir
@@ -192,7 +194,9 @@ defmodule IEx.InteractionTest do
         write_dot_iex!(tmp_dir, "dot-iex", "import_file \"#{tmp_dir}/dot-iex-1\"\nmy_variable=14")
 
       input = "nested_var\nmy_variable\nputs \"hello\""
-      assert capture_iex(input, [], dot_iex_path: path) == "13\n14\nhello\n:ok"
+
+      assert capture_iex(input, [], dot_iex_path: path) ==
+               "Loaded tmp/IEx.InteractionTest/test-.iex-nested-.iex/dot-iex\n13\n14\nhello\n:ok"
     end
 
     @tag :tmp_dir


### PR DESCRIPTION
This simple enhancement came out of [this Phoenix PR](https://github.com/phoenixframework/phoenix/pull/4124) and the discussion about letting people know 1) that the `.iex.exs` file is even a feature and 2) that it has been loaded in the current session.

This PR simply outputs "Loaded .iex.exs" when a file is loaded. If the file is in a custom location, it will print the path relative to the current working directory.