### PR TITLE
Support compression on Registry

### DIFF
--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -863,6 +863,12 @@ defmodule RegistryTest do
     end
   end
 
+  test "raises if :compressed is not a boolean" do
+    assert_raise ArgumentError, ~r/expected :compressed to be a boolean, got/, fn ->
+      Registry.start_link(keys: :unique, name: :name, compressed: :fail)
+    end
+  end
+
   test "unregistration on crash with {registry, key, value} via tuple", %{registry: registry} do
     name = {:via, Registry, {registry, :name, :value}}
     spec = %{id: :foo, start: {Agent, :start_link, [fn -> raise "some error" end, [name: name]]}}


### PR DESCRIPTION
The original use case here is enabling a tuning option for Absinthe subscriptions. In testing this can improve memory usage by 3x for workloads where individual users submit a lot of subscriptions and therefore there is a lot of duplicate context content. Chatted w/ Jose about this a month or so ago, finally getting around to messing with it.