### PR TITLE
Refactor replace/4 to remove guards on replacement parameter

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -649,19 +649,7 @@ defmodule Regex do
 
   """
   @spec replace(t, String.t(), String.t() | (... -> String.t()), [term]) :: String.t()
-  def replace(regex, string, replacement, options \\ [])
-
-  def replace(regex, string, replacement, options)
-      when is_binary(string) and is_binary(replacement) and is_list(options) do
-    do_replace(regex, string, replacement, options)
-  end
-
-  def replace(regex, string, replacement, options)
-      when is_binary(string) and is_function(replacement) and is_list(options) do
-    do_replace(regex, string, replacement, options)
-  end
-
-  defp do_replace(%Regex{} = regex, string, replacement, options) do
+  def replace(%Regex{} = regex, string, replacement, options \\ []) do
     opts = if Keyword.get(options, :global) != false, do: [:global], else: []
     opts = [{:capture, :all, :index} | opts]
 
@@ -674,7 +662,8 @@ defmodule Regex do
         |> IO.iodata_to_binary()
 
       {:match, slist} ->
-        apply_list(string, precompile_replacement(replacement), [slist]) |> IO.iodata_to_binary()
+        apply_list(string, precompile_replacement(replacement), [slist])
+        |> IO.iodata_to_binary()
     end
   end
 

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -649,7 +649,8 @@ defmodule Regex do
 
   """
   @spec replace(t, String.t(), String.t() | (... -> String.t()), [term]) :: String.t()
-  def replace(%Regex{} = regex, string, replacement, options \\ []) do
+  def replace(%Regex{} = regex, string, replacement, options \\ [])
+      when is_binary(string) and is_list(options) do
     opts = if Keyword.get(options, :global) != false, do: [:global], else: []
     opts = [{:capture, :all, :index} | opts]
 


### PR DESCRIPTION
#10500 was shared in _Elixir Weekly, issue 232_ on December 24th, so I read the story and looked at the PR more than a month after it was merged! Looking at the diff, I realized the `is_function` guard was now useless because it was transferred to the `precompile_replacement/1` function.

We can get rid of the guard, the function header and the private `do_replace/4` all at ounce.

🎩 to @dsdshcym for encouraging me to push my first (of I hope many) PR to the language!