### PR TITLE
Make mix.release script rand() work with busybox

### DIFF
--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -104,7 +104,7 @@ defmodule Mix.Tasks.Release.Init do
     export RELEASE_BOOT_SCRIPT_CLEAN="${RELEASE_BOOT_SCRIPT_CLEAN:-"start_clean"}"
 
     rand () {
-      od -t xS -N 2 -A n /dev/urandom | tr -d " \n"
+      dd count=1 bs=2 if=/dev/urandom 2> /dev/null | od -x | awk 'NR==1{print $2}'
     }
 
     release_distribution () {


### PR DESCRIPTION
Combining dd, od and awk with the common arguments found in busybox and GNU coreutils as well BSD the function rand() can make correct id.

This is based on
https://github.com/erlware/relx/commit/200e12815ef665338cea1280244e9c4f9dfa06b9
and
https://github.com/erlware/relx/pull/828

I ran into this when adding a mix release to a minimal yocto image using https://github.com/meta-erlang/meta-erlang and a busybox with undefined CONFIG_DESKTOP.