### PR TITLE
Prevent using wrong test context

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -316,7 +316,7 @@ defmodule ExUnit.Case do
   @doc """
   Defines a test with `message`.
 
-  The test may also define a `var`, which will pattern match
+  The test may also define a `var` or map, which will pattern match
   on the test context. For more information on contexts, see
   `ExUnit.Callbacks`.
 
@@ -328,6 +328,10 @@ defmodule ExUnit.Case do
 
   """
   defmacro test(message, var \\ quote(do: _), contents) do
+    unless is_tuple(var) do
+      raise "expected map or variable as context, got: #{inspect(Macro.to_string(var))}"
+    end
+
     contents =
       case contents do
         [do: block] ->

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -316,8 +316,8 @@ defmodule ExUnit.Case do
   @doc """
   Defines a test with `message`.
 
-  The test may also define a `var` or map, which will pattern match
-  on the test context. For more information on contexts, see
+  The test may also define a pattern, which will matched
+  against the test context. For more information on contexts, see
   `ExUnit.Callbacks`.
 
   ## Examples

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -112,6 +112,18 @@ defmodule ExUnit.CaseTest do
       end
     end
   end
+
+  test "raises when context is a keyword list" do
+    assert_raise RuntimeError, "expected map or variable as context, got: \"[conn: conn]\"", fn ->
+      defmodule KeywordContextTest do
+        use ExUnit.Case
+
+        test "I made a typo", conn: conn do
+          assert true
+        end
+      end
+    end
+  end
 end
 
 defmodule ExUnit.DoubleCaseTest1 do


### PR DESCRIPTION
Hi folks,

Hope you're doing well :D

Yesterday I got bitten by a small "typo" I made Friday and although it didn't take me long to figure out my mistake, I think folks new to Elixir/ExUnits inner working might take longer to figure it out. I hope we can address that by returning a more "friendly" error. Please consider this PR as proposed solution, I'm open to discuss/change it. Also I didn't take the official route by discussing this first on ML, so feel free to close this for whatever reason you see fit 

My example:

```elixir

setup do
  user = Thing.AuthFixtures.user_fixture()
  [user: user]
end

test "list_invites/0 returns all invites", user: user do
  assert ...
end
```

> ## output
> 
> 1) test invites list_invites/0 returns all invites (Thing.AccountsTest)
> test/thing/accounts_test.exs:19
> ** (FunctionClauseError) no function clause matching in Thing.AccountsTest."test invites list_invites/0 returns all invites"/1
> 
> The following arguments were given to Thing.AccountsTest."test invites list_invites/0 returns all invites"/1:
> 
>     # 1
>     %{async: false, case: Thing.AccountsTest, describe: "invites", describe_line: 6, .. etc, user: #Thing.Auth.User<__meta__: #Ecto.Schema.Metadata<:loaded, "users">, ...>}

The "issue" is tests always get a map as context, but setup blocks can return a different shape (result tuple, keyword list, map) which _I think_ can confuse people
