### PR TITLE
Remove warnings in test in latest Git version

### DIFF
--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -142,7 +142,7 @@ defmodule Mix.Tasks.DepsTest do
 
     in_fixture("deps_status", fn ->
       File.cd!("deps/ok", fn ->
-        System.cmd("git", ~w[-c core.hooksPath='' init])
+        System.cmd("git", ~w[-c core.hooksPath='' -c init.defaultBranch='main' init])
       end)
 
       Mix.Tasks.Deps.run([])


### PR DESCRIPTION
The warning would be:
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint: 	git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint: 	git branch -m <name>