### PR TITLE
[Proposal] Make tap/2 and then/2 macros

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1147,10 +1147,11 @@ defmodule Kernel do
 
   """
   @doc since: "1.12.0"
-  @spec tap(value, (value -> any)) :: value when value: var
-  def tap(value, fun) when is_function(fun, 1) do
-    fun.(value)
-    value
+  defmacro tap(value, fun) do
+    quote bind_quoted: [fun: fun, value: value] do
+      fun.(value)
+      value
+    end
   end
 
   @doc """
@@ -2495,8 +2496,11 @@ defmodule Kernel do
       2
   """
   @doc since: "1.12.0"
-  @spec then(value, (value -> result)) :: result when value: var, result: var
-  def then(value, fun) when is_function(fun, 1), do: fun.(value)
+  defmacro then(value, fun) do
+    quote do
+      unquote(fun).(unquote(value))
+    end
+  end
 
   @doc """
   Gets a value from a nested structure.

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -421,7 +421,7 @@ defmodule KernelTest do
   test "then/2" do
     assert 1 |> then(fn x -> x * 2 end) == 2
 
-    assert_raise FunctionClauseError, fn ->
+    assert_raise BadArityError, fn ->
       1 |> then(fn x, y -> x * y end)
     end
   end


### PR DESCRIPTION
This PR is a proposal for discussion. The original discussion on the mailing list can be found [here](
https://groups.google.com/u/1/g/elixir-lang-core/c/OhtFggrEHfU/m/BO6x5XleDAAJ)

The idea is to make `Kernel.tap/2` and `Kernel.then/2` macros instead of functions, in order to remove the runtime overhead.
This might be an overkill optimization, but since it is in the Kernel I thought it could make sense.

Looking forward to knowing your thoughts!