### PR TITLE
add Enum.every?

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -374,6 +374,58 @@ defmodule Enum do
   end
 
   @doc """
+  Returns `true` if `fun.(element)` is truthy for all elements in `enumerable`.
+
+  Iterates over the `enumerable` and invokes `fun` on each element. When an invocation
+  of `fun` returns a falsy value (neither `false` nor `nil`) iteration stops
+  immediately and `false` is returned. In all other cases `true` is returned.
+
+  ## Examples
+
+      iex> Enum.every?([2, 4, 6], fn x -> rem(x, 2) == 1 end)
+      false
+
+      iex> Enum.every?([2, 3, 4], fn x -> rem(x, 2) == 1 end)
+      false
+
+      iex> Enum.every?([2, 4, 6], fn x -> x < 10 end)
+      true
+
+      iex> Enum.every?([])
+      false
+
+  If no function is given, the truthiness of each element is checked during iteration.
+  When an element has a falsy value (neither `false` nor `nil`) iteration stops
+  immediately and `false` is returned. In all other cases `true` is returned.
+
+      iex> Enum.every?([false, false, false])
+      false
+
+      iex> Enum.every?([false, true, false])
+      false
+
+      iex> Enum.every?([2, 4, 6], fn x -> x < 10 end)
+      true
+
+      iex> Enum.every?([])
+      false
+  """
+  @spec every?(t, (element -> as_boolean(term))) :: boolean
+
+  def every?(enumerable, fun \\ fn x -> x end)
+
+  def every?(enumerable, fun) when is_list(enumerable) do
+    every_list(enumerable, fun)
+  end
+
+  def every?(enumerable, fun) do
+    Enumerable.reduce(enumerable, {:cont, true}, fn entry, _ ->
+      if fun.(entry), do: {:cont, true}, else: {:halt, false}
+    end)
+    |> elem(1)
+  end
+
+  @doc """
   Finds the element at the given `index` (zero-based).
 
   Returns `default` if `index` is out of bounds.
@@ -3535,6 +3587,24 @@ defmodule Enum do
   end
 
   defp any_list([], _) do
+    false
+  end
+
+  ## every?
+
+  defp every_list([_], _) do
+    true
+  end
+
+  defp every_list([h | t], fun) do
+    if fun.(h) do
+      every_list(t, fun)
+    else
+      false
+    end
+  end
+
+  defp every_list([], _) do
     false
   end
 

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -236,6 +236,19 @@ defmodule EnumTest do
     end
   end
 
+  test "every?/2" do
+    assert Enum.every?([:some, :some, :some], fn v -> v == :some end)
+    refute Enum.every?([:some, :other, :some], fn v -> v == :some end)
+
+    assert Enum.every?([2, 4, 6], fn x -> x < 10 end)
+    refute Enum.every?([2, 4, 6], fn x -> x > 10 end)
+
+    assert Enum.every?([true, true, true])
+    refute Enum.every?([false, false, false])
+
+    refute Enum.every?([])
+  end
+
   test "empty?/1" do
     assert Enum.empty?([])
     assert Enum.empty?(%{})


### PR DESCRIPTION
Returns `true` if `fun.(element)` is truthy for all elements in `enumerable`.

Which differs from `Enum.all?` and `Enum.any?`. Example:

`Enum.all?` - Returns `true` when a empty enumerable is given;
`Enum.any?` - Returns `false` when a empty enumerable is given, but
every member on the list needs to return `true`, otherwise is `false`.

I think we can cover edge cases like this one:

https://github.com/elixir-lang/elixir/issues/1508