### PR TITLE
Draft approach to conditionally define functions within module

### DIFF
--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -300,6 +300,7 @@ build(Line, File, Module) ->
     {optional_callbacks, [], accumulate},
 
     % Others
+    {if_available, nil, nil},
     {?counter_attr, 0}
   ]),
 

--- a/lib/elixir/test/elixir/module/if_available_attribute_test.exs
+++ b/lib/elixir/test/elixir/module/if_available_attribute_test.exs
@@ -1,0 +1,57 @@
+defmodule Module.IfAvailableAttributeTestTest do
+  use ExUnit.Case, async: true
+
+  defmodule IfAvailable do
+    # "Foo42 (conditional, false)"
+    @if_available Foo42
+    @spec foo(integer(), any()) :: integer()
+    def foo(i, _), do: 42 + i
+
+    @doc "Converts anything to integer"
+    @if_available Foo42
+    # "Foo42 (conditional, false)"
+    @spec foo(Foo42.t()) :: integer()
+    def foo(%Foo42{integer: i}), do: 42 + i
+
+    @if_available DateTime
+    # "DateTime (conditional, true)"
+    @spec foo(DateTime.t()) :: integer()
+    def foo(%DateTime{} = dt), do: 42 + DateTime.to_unix(dt)
+
+    # "integer (not conditional)"
+    @spec foo(integer()) :: integer()
+    def foo(i), do: 42 + i
+
+    #########################################################
+
+    @if_available Bar42
+    # "Bar42 (macro, conditional, false)"
+    defmacro bar(i), do: quote(do: unquote(i))
+
+    @if_available DateTime
+    # "DateTime (macro, conditional, true)"
+    defmacro bar(i, j), do: quote(do: unquote(i) + unquote(j))
+  end
+
+  test "functions" do
+    assert [foo: 1] == IfAvailable.__info__(:functions)
+
+    dt = DateTime.utc_now()
+    assert DateTime.to_unix(DateTime.add(dt, 42)) == IfAvailable.foo(dt)
+
+    assert 43 == IfAvailable.foo(1)
+
+    assert_raise UndefinedFunctionError,
+                 ~r/function Module\.IfAvailableAttributeTestTest\.IfAvailable.foo\/2 is undefined or private/,
+                 fn ->
+                   IfAvailable.foo(42, nil)
+                 end
+  end
+
+  test "macros" do
+    require IfAvailable
+
+    assert [bar: 2] == IfAvailable.__info__(:macros)
+    assert 43 == IfAvailable.bar(1, 42)
+  end
+end

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -60,8 +60,6 @@ defmodule IEx.Evaluator do
 
   @space " "
   @pipe_operators ~w(|> ~>> <<~ ~> <~ <~> <|>)
-  {lbo_before, lbo_after} =
-    Enum.split_with(@leading_binary_operators, &String.starts_with?(&1, @leading_binary))
 
   @doc false
   def parse(input, opts, buffer, leading_spaces \\ "")

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -60,6 +60,8 @@ defmodule IEx.Evaluator do
 
   @space " "
   @pipe_operators ~w(|> ~>> <<~ ~> <~ <~> <|>)
+  {lbo_before, lbo_after} =
+    Enum.split_with(@leading_binary_operators, &String.starts_with?(&1, @leading_binary))
 
   @doc false
   def parse(input, opts, buffer, leading_spaces \\ "")


### PR DESCRIPTION
This is by no mean a PR-proposed-to-merge, this is just sharing the idea. I feel easier explaining thoughts with code rather than plain English, that’s the only reason you see this as a PR, not an issue.

**Proposal:** a built-in module attribute allowing to conditionally include the next function to the compiled beam, based on the compile-time availability of some other module.

---

Consider the library that might conditionally rely on other libraries. For the sake of simplicity, let’s write the universal rounding tool.

```elixir
def round(i) when is_integer(i), do: i
def round(f) when is_float(f), do: Float.round(f)
```

Now we want to support rounding from `Decimal` but we don’t want to silently bring `Decimal` to the consumer of our library. So we do somewhat like

```elixir
if {:module, Decimal} == Code.ensure_compiled(Decimal) do
  def round(%Decimal{} = d), do: Decimal.round(d)
end
```

The above breaks indenting and might actually be written as

```elixir
@if_available Decimal
def round(%Decimal{} = d), do: Decimal.round(d)
```

The code in this PR is a draft implementation of this. Spec included to demonstrate the behaviour.

---

**Drawbacks**

There are many. 

1. To gracefully handle `spec` for this function, too many changes are needed; the provided code silly prints a warning for it
1. I was unable to figure out how to handle warnings about duplicate `@doc`
1. It might look a bit counter-intuitive that the function happens to appear in the code while it actually is not included in the beam.

---

I would be happy to discuss the general idea, better implementations or listen to “this is absolutely not needed.”