### PR TITLE
Fix typo (`s/InstalTest/InstallTest`)

### DIFF
--- a/lib/mix/test/mix_test.exs
+++ b/lib/mix/test/mix_test.exs
@@ -62,7 +62,7 @@ defmodule MixTest do
     assert :install_test in started_apps
     assert apply(InstallTest, :hello, []) == :world
   after
-    :code.purge(InstalTest)
+    :code.purge(InstallTest)
     :code.delete(InstallTest)
     Application.stop(:install_test)
     Application.unload(:install_test)


### PR DESCRIPTION
Thanks for the `Mix.install/1`! :raised_hands: 