### PR TITLE
chore: fix callbacks amount in GenServer docs

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -61,7 +61,7 @@ defmodule GenServer do
 
   Every time you do a `GenServer.call/3`, the client will send a message
   that must be handled by the `c:handle_call/3` callback in the GenServer.
-  A `cast/2` message must be handled by `c:handle_cast/2`. There are 7 possible
+  A `cast/2` message must be handled by `c:handle_cast/2`. There are 8 possible
   callbacks to be implemented when you use a `GenServer`. The only required
   callback is `c:init/1`.
 


### PR DESCRIPTION
I guess that the original text was introduced before
`handle_continue/2`, but now the `GenServer` behaviour define 8
callbacks:

* code_change/3
* format_status/2
* handle_call/3
* handle_cast/2
* handle_continue/2
* handle_info/2
* init/1
* terminate/2