### PR TITLE
Fix `@impl` warning when defdelegate is used

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5248,7 +5248,9 @@ defmodule Kernel do
 
         @doc delegate_to: {target, as, :erlang.length(as_args)}
 
-        def unquote(name)(unquote_splicing(args)) do
+        # Build the call AST by hand so it doesn't get a
+        # context and it warns on things like missing @impl
+        def unquote({name, [line: __ENV__.line], args}) do
           unquote(target).unquote(as)(unquote_splicing(as_args))
         end
       end


### PR DESCRIPTION
Fixes #10593

Fixing bug #10593 unveiled another bug, which is that we are not setting the context as the one where `defdelegate/2` is being called from so since the macro is defined in Kernel, this is the module that was being set.
That is fixed, but the commit fixes the initial issue publish, but when using a behaviour instead of a protocol, it will not work.

The best solution which will be more performant is if we can annotate the AST code generated by the `defdelegate/2` macro with the keyword `delegated: true, but updating the meta field in the AST when returning did not work.