### PR TITLE
Fix context in defdelagate/2 AST

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5225,7 +5225,7 @@ defmodule Kernel do
           opts
       end
 
-    quote bind_quoted: [funs: funs, opts: opts] do
+    quote bind_quoted: [funs: funs, opts: opts], context: __CALLER__.module do
       target =
         Keyword.get(opts, :to) || raise ArgumentError, "expected to: to be given as argument"
 

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -865,6 +865,15 @@ defmodule KernelTest do
       assert my_get(%{"foo" => "bar"}, "foo") == "bar"
       assert my_get(%{}, "foo", "not_found") == "not_found"
     end
+
+    test "context" do
+      {:defdelegate, meta, _} =
+        quote do
+          defdelegate reverse(list), to: Enum
+        end
+
+      assert Keyword.get(meta, :context) == KernelTest
+    end
   end
 
   describe "defmodule" do


### PR DESCRIPTION
Add context as the current module where it is defined.
Related issue: https://github.com/elixir-lang/elixir/issues/10593