### PR TITLE
Interpolate module attributes in match assertions

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -696,6 +696,9 @@ defmodule ExUnit.Assertions do
       {:__aliases__, _, _} = expr ->
         Macro.expand(expr, caller)
 
+      {:@, _, [{attribute, _, _}]} ->
+        caller.module |> Module.get_attribute(attribute) |> Macro.escape()
+
       {left, meta, right} = expr ->
         case Macro.expand(expr, caller) do
           ^expr -> expr

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -182,6 +182,16 @@ defmodule ExUnit.AssertionsTest do
     assert vec(x: ^x, y: ^y) = vec(x: x, y: y, z: z)
   end
 
+  @test_mod_attribute %{key: :value}
+  test "assert match with module attribute" do
+    try do
+      assert {@test_mod_attribute, 1} = Value.tuple()
+    rescue
+      error in [ExUnit.AssertionError] ->
+        assert "{%{key: :value}, 1}" == Macro.to_string(error.left)
+    end
+  end
+
   test "assert match with pinned variable" do
     a = 1
     {2, 1} = assert {2, ^a} = Value.tuple()


### PR DESCRIPTION
This will interpolate the value of module attributes in match assertions
in ExUnit. Basically, the old diff would look like this:

```
  1) test assert match with module attribute (ExUnit.AssertionsTest)
     test/ex_unit/assertions_test.exs:186
     match (=) failed
     code:  assert {2, @test_mod_attribute} = Value.tuple()
     left:  {2, @test_mod_attribute}
     right: {2, 1}
     stacktrace:
       test/ex_unit/assertions_test.exs:187: (test)
```

And now it will look like this:

```
  1) test assert match with module attribute (ExUnit.AssertionsTest)
     test/ex_unit/assertions_test.exs:186
     match (=) failed
     code:  assert {2, @test_mod_attribute} = Value.tuple()
     left:  {2, 2}
     right: {2, 1}
     stacktrace:
       test/ex_unit/assertions_test.exs:187: (test)
```

Resolves #10675 