### PR TITLE
Support basic datetime format in Calendar.ISO parsing functions

### DIFF
--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -126,7 +126,7 @@ defmodule Calendar.ISO do
       {:ok, {-2015, 1, 23, 23, 50, 7, {0, 0}}, 0}
       iex> Calendar.ISO.parse_utc_datetime("+2015-01-23 23:50:07Z")
       {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}, 0}
-      
+
   """
 
   @behaviour Calendar
@@ -214,9 +214,9 @@ defmodule Calendar.ISO do
           y4 <= ?9 and m1 >= ?0 and m1 <= ?9 and m2 >= ?0 and m2 <= ?9 and d1 >= ?0 and d1 <= ?9 and
           d2 >= ?0 and d2 <= ?9,
         {
-          List.to_integer([y1, y2, y3, y4]),
-          List.to_integer([m1, m2]),
-          List.to_integer([d1, d2])
+          (y1 - ?0) * 1000 + (y2 - ?0) * 100 + (y3 - ?0) * 10 + (y4 - ?0),
+          (m1 - ?0) * 10 + (m2 - ?0),
+          (d1 - ?0) * 10 + (d2 - ?0)
         }
       ]
     end
@@ -229,9 +229,9 @@ defmodule Calendar.ISO do
         h1 >= ?0 and h1 <= ?9 and h2 >= ?0 and h2 <= ?9 and i1 >= ?0 and i1 <= ?9 and i2 >= ?0 and
           i2 <= ?9 and s1 >= ?0 and s1 <= ?9 and s2 >= ?0 and s2 <= ?9,
         {
-          List.to_integer([h1, h2]),
-          List.to_integer([i1, i2]),
-          List.to_integer([s1, s2])
+          (h1 - ?0) * 10 + (h2 - ?0),
+          (i1 - ?0) * 10 + (i2 - ?0),
+          (s1 - ?0) * 10 + (s2 - ?0)
         }
       ]
     end
@@ -339,7 +339,7 @@ defmodule Calendar.ISO do
 
       iex> Calendar.ISO.parse_date("2015-01-23")
       {:ok, {2015, 1, 23}}
-      
+
       iex> Calendar.ISO.parse_date("2015:01:23")
       {:error, :invalid_format}
       iex> Calendar.ISO.parse_date("2015-01-32")

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -60,17 +60,12 @@ defmodule Calendar.ISO do
       iex> Calendar.ISO.parse_naive_datetime("20150123 235007")
       {:error, :invalid_format}
 
-  Parsing can be restricted to basic or extend formats or relaxed to all variations.
+  Parsing can be restricted to basic or extend formats.
 
       iex> Calendar.ISO.parse_naive_datetime("20150123 235007Z", :basic)
       {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}}
       iex> Calendar.ISO.parse_naive_datetime("20150123 235007Z", :extended)
       {:error, :invalid_format}
-
-      iex> Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07", :any)
-      {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}}
-      iex> Calendar.ISO.parse_naive_datetime("20150123 235007", :any)
-      {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}}
 
   Only calendar dates are supported in parsing; ordinal and week dates are not.
 
@@ -188,11 +183,6 @@ defmodule Calendar.ISO do
   @microseconds_per_second 1_000_000
   @parts_per_day @seconds_per_day * @microseconds_per_second
 
-  @formats [:any, :basic, :extended]
-  @default_format :extended
-  @basic_formats [:any, :basic]
-  @ext_formats [:any, :extended]
-
   @datetime_seps [?\s, ?T]
   @ext_date_sep ?-
   @ext_time_sep ?:
@@ -273,20 +263,18 @@ defmodule Calendar.ISO do
   @doc since: "1.10.0"
   @impl true
   def parse_time(string) when is_binary(string),
-    do: parse_time(string, @default_format)
+    do: parse_time(string, :extended)
 
   @doc """
   Parses a time `string` according to a given `format`.
 
-  Formats can one of: `:any`, `:basic`, or `:extended`.
+  The `format` can either be `:basic` or `:extended`.
 
   For more information on supported strings, see how this
   module implements [ISO 8601](#module-iso-8601-compliance).
 
   ## Examples
 
-      iex> Calendar.ISO.parse_time("235007", :any)
-      {:ok, {23, 50, 7, {0, 0}}}
       iex> Calendar.ISO.parse_time("235007", :basic)
       {:ok, {23, 50, 7, {0, 0}}}
       iex> Calendar.ISO.parse_time("235007", :extended)
@@ -294,20 +282,20 @@ defmodule Calendar.ISO do
 
   """
   @doc since: "1.12.0"
-  def parse_time("T" <> string, format) when is_binary(string) and format in @formats,
+  def parse_time("T" <> string, format) when is_binary(string),
     do: do_parse_time(string, format)
 
-  def parse_time(string, format) when is_binary(string) and format in @formats,
+  def parse_time(string, format) when is_binary(string),
     do: do_parse_time(string, format)
 
-  defp do_parse_time(<<unquote(match_basic_time), rest::binary>>, format)
-       when unquote(guard_time) and format in @basic_formats do
+  defp do_parse_time(<<unquote(match_basic_time), rest::binary>>, :basic)
+       when unquote(guard_time) do
     {hour, minute, second} = unquote(read_time)
     parse_formatted_time(hour, minute, second, rest)
   end
 
-  defp do_parse_time(<<unquote(match_ext_time), rest::binary>>, format)
-       when unquote(guard_time) and format in @ext_formats do
+  defp do_parse_time(<<unquote(match_ext_time), rest::binary>>, :extended)
+       when unquote(guard_time) do
     {hour, minute, second} = unquote(read_time)
     parse_formatted_time(hour, minute, second, rest)
   end
@@ -349,20 +337,18 @@ defmodule Calendar.ISO do
   @doc since: "1.10.0"
   @impl true
   def parse_date(string) when is_binary(string),
-    do: parse_date(string, @default_format)
+    do: parse_date(string, :extended)
 
   @doc """
   Parses a date `string` according to a given `format`.
 
-  Formats can one of: `:any`, `:basic`, or `:extended`.
+  The `format` can either be `:basic` or `:extended`.
 
   For more information on supported strings, see how this
   module implements [ISO 8601](#module-iso-8601-compliance).
 
   ## Examples
 
-      iex> Calendar.ISO.parse_date("20150123", :any)
-      {:ok, {2015, 1, 23}}
       iex> Calendar.ISO.parse_date("20150123", :basic)
       {:ok, {2015, 1, 23}}
       iex> Calendar.ISO.parse_date("20150123", :extended)
@@ -370,23 +356,21 @@ defmodule Calendar.ISO do
 
   """
   @doc since: "1.12.0"
-  def parse_date("-" <> string, format) when is_binary(string) and format in @formats,
+  def parse_date("-" <> string, format) when is_binary(string),
     do: do_parse_date(string, -1, format)
 
-  def parse_date("+" <> string, format) when is_binary(string) and format in @formats,
+  def parse_date("+" <> string, format) when is_binary(string),
     do: do_parse_date(string, 1, format)
 
-  def parse_date(string, format) when is_binary(string) and format in @formats,
+  def parse_date(string, format) when is_binary(string),
     do: do_parse_date(string, 1, format)
 
-  defp do_parse_date(unquote(match_basic_date), multiplier, format)
-       when unquote(guard_date) and format in @basic_formats do
+  defp do_parse_date(unquote(match_basic_date), multiplier, :basic) when unquote(guard_date) do
     {year, month, day} = unquote(read_date)
     parse_formatted_date(year, month, day, multiplier)
   end
 
-  defp do_parse_date(unquote(match_ext_date), multiplier, format)
-       when unquote(guard_date) and format in @ext_formats do
+  defp do_parse_date(unquote(match_ext_date), multiplier, :extended) when unquote(guard_date) do
     {year, month, day} = unquote(read_date)
     parse_formatted_date(year, month, day, multiplier)
   end
@@ -429,20 +413,18 @@ defmodule Calendar.ISO do
   @doc since: "1.10.0"
   @impl true
   def parse_naive_datetime(string) when is_binary(string),
-    do: parse_naive_datetime(string, @default_format)
+    do: parse_naive_datetime(string, :extended)
 
   @doc """
   Parses a naive datetime `string` according to a given `format`.
 
-  Formats can one of: `:any`, `:basic`, or `:extended`.
+  The `format` can either be `:basic` or `:extended`.
 
   For more information on supported strings, see how this
   module implements [ISO 8601](#module-iso-8601-compliance).
 
   ## Examples
 
-      iex> Calendar.ISO.parse_naive_datetime("20150123 235007", :any)
-      {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}}
       iex> Calendar.ISO.parse_naive_datetime("20150123 235007", :basic)
       {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}}
       iex> Calendar.ISO.parse_naive_datetime("20150123 235007", :extended)
@@ -450,22 +432,21 @@ defmodule Calendar.ISO do
 
   """
   @doc since: "1.12.0"
-  def parse_naive_datetime("-" <> string, format) when is_binary(string) and format in @formats,
+  def parse_naive_datetime("-" <> string, format) when is_binary(string),
     do: do_parse_naive_datetime(string, -1, format)
 
-  def parse_naive_datetime("+" <> string, format) when is_binary(string) and format in @formats,
+  def parse_naive_datetime("+" <> string, format) when is_binary(string),
     do: do_parse_naive_datetime(string, 1, format)
 
-  def parse_naive_datetime(string, format) when is_binary(string) and format in @formats,
+  def parse_naive_datetime(string, format) when is_binary(string),
     do: do_parse_naive_datetime(string, 1, format)
 
   defp do_parse_naive_datetime(
          <<unquote(match_basic_date), datetime_sep, unquote(match_basic_time), rest::binary>>,
          multiplier,
-         format
+         :basic
        )
-       when unquote(guard_date) and datetime_sep in @datetime_seps and unquote(guard_time) and
-              format in @basic_formats do
+       when unquote(guard_date) and datetime_sep in @datetime_seps and unquote(guard_time) do
     {year, month, day} = unquote(read_date)
     {hour, minute, second} = unquote(read_time)
     parse_formatted_naive_datetime(year, month, day, hour, minute, second, rest, multiplier)
@@ -474,10 +455,9 @@ defmodule Calendar.ISO do
   defp do_parse_naive_datetime(
          <<unquote(match_ext_date), datetime_sep, unquote(match_ext_time), rest::binary>>,
          multiplier,
-         format
+         :extended
        )
-       when unquote(guard_date) and datetime_sep in @datetime_seps and unquote(guard_time) and
-              format in @ext_formats do
+       when unquote(guard_date) and datetime_sep in @datetime_seps and unquote(guard_time) do
     {year, month, day} = unquote(read_date)
     {hour, minute, second} = unquote(read_time)
     parse_formatted_naive_datetime(year, month, day, hour, minute, second, rest, multiplier)
@@ -528,20 +508,18 @@ defmodule Calendar.ISO do
   @doc since: "1.10.0"
   @impl true
   def parse_utc_datetime(string) when is_binary(string),
-    do: parse_utc_datetime(string, @default_format)
+    do: parse_utc_datetime(string, :extended)
 
   @doc """
   Parses a UTC datetime `string` according to a given `format`.
 
-  Formats can one of: `:any`, `:basic`, or `:extended`.
+  The `format` can either be `:basic` or `:extended`.
 
   For more information on supported strings, see how this
   module implements [ISO 8601](#module-iso-8601-compliance).
 
   ## Examples
 
-      iex> Calendar.ISO.parse_utc_datetime("20150123 235007Z", :any)
-      {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}, 0}
       iex> Calendar.ISO.parse_utc_datetime("20150123 235007Z", :basic)
       {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}, 0}
       iex> Calendar.ISO.parse_utc_datetime("20150123 235007Z", :extended)
@@ -549,22 +527,21 @@ defmodule Calendar.ISO do
 
   """
   @doc since: "1.12.0"
-  def parse_utc_datetime("-" <> string, format) when is_binary(string) and format in @formats,
+  def parse_utc_datetime("-" <> string, format) when is_binary(string),
     do: do_parse_utc_datetime(string, -1, format)
 
-  def parse_utc_datetime("+" <> string, format) when is_binary(string) and format in @formats,
+  def parse_utc_datetime("+" <> string, format) when is_binary(string),
     do: do_parse_utc_datetime(string, 1, format)
 
-  def parse_utc_datetime(string, format) when is_binary(string) and format in @formats,
+  def parse_utc_datetime(string, format) when is_binary(string),
     do: do_parse_utc_datetime(string, 1, format)
 
   defp do_parse_utc_datetime(
          <<unquote(match_basic_date), datetime_sep, unquote(match_basic_time), rest::binary>>,
          multiplier,
-         format
+         :basic
        )
-       when unquote(guard_date) and datetime_sep in @datetime_seps and unquote(guard_time) and
-              format in @basic_formats do
+       when unquote(guard_date) and datetime_sep in @datetime_seps and unquote(guard_time) do
     {year, month, day} = unquote(read_date)
     {hour, minute, second} = unquote(read_time)
     parse_formatted_utc_datetime(year, month, day, hour, minute, second, rest, multiplier)
@@ -573,10 +550,9 @@ defmodule Calendar.ISO do
   defp do_parse_utc_datetime(
          <<unquote(match_ext_date), datetime_sep, unquote(match_ext_time), rest::binary>>,
          multiplier,
-         format
+         :extended
        )
-       when unquote(guard_date) and datetime_sep in @datetime_seps and unquote(guard_time) and
-              format in @ext_formats do
+       when unquote(guard_date) and datetime_sep in @datetime_seps and unquote(guard_time) do
     {year, month, day} = unquote(read_date)
     {hour, minute, second} = unquote(read_time)
     parse_formatted_utc_datetime(year, month, day, hour, minute, second, rest, multiplier)

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -33,7 +33,7 @@ defmodule Calendar.ISO do
   `Calendar.strftime/2` allows you to format datetimes however else you desire.
 
   Other optional ISO 8601 features; such as ordinal dates, week dates,
-  durations, time intervals, truncated representations, and reduced precision;
+  durations, time intervals, and reduced precision;
   are not supported by the parser or formatters.
 
   ### Extensions

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -237,6 +237,9 @@ defmodule Calendar.ISO do
   def parse_date("-" <> string) when is_binary(string),
     do: parse_date(string, -1)
 
+  def parse_date("+" <> string) when is_binary(string),
+    do: parse_date(string, 1)
+
   def parse_date(string) when is_binary(string),
     do: parse_date(string, 1)
 
@@ -307,6 +310,9 @@ defmodule Calendar.ISO do
   def parse_naive_datetime("-" <> string) when is_binary(string),
     do: parse_naive_datetime(string, -1)
 
+  def parse_naive_datetime("+" <> string) when is_binary(string),
+    do: parse_naive_datetime(string, 1)
+
   def parse_naive_datetime(string) when is_binary(string),
     do: parse_naive_datetime(string, 1)
 
@@ -370,6 +376,9 @@ defmodule Calendar.ISO do
   @impl true
   def parse_utc_datetime("-" <> string) when is_binary(string),
     do: parse_utc_datetime(string, -1)
+
+  def parse_utc_datetime("+" <> string) when is_binary(string),
+    do: parse_utc_datetime(string, 1)
 
   def parse_utc_datetime(string) when is_binary(string),
     do: parse_utc_datetime(string, 1)

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -30,11 +30,12 @@ defmodule Calendar.ISO do
 
   ### Features
 
-  The standard library supports a minimalistic set of possible ISO 8601 features.
+  The standard library supports a minimal set of possible ISO 8601 features.
   Specifically, the parser only supports calendar dates and the extended format.
 
   However, you can still format datetimes with `NaiveDateTime.to_iso8601/2`
   and `DateTime.to_iso8601/2` to produce either basic or extended formatted strings.
+  `Calendar.strftime/2` allows you to format datetimes however else you desire.
 
   Other optional ISO 8601 features; such as ordinal dates, week dates,
   durations, time intervals, truncated representations, and reduced precision;
@@ -45,8 +46,8 @@ defmodule Calendar.ISO do
   The parser and formatter adopt one ISO 8601 extension: extended year notation.
 
   This allows dates to be prefixed with a `+` or `-` sign, extending the range of
-  expressible years from the default (`0000..9999`) to `-9999..9999`. Years are still
-  restricted to four digits.
+  expressible years from the default (`0000..9999`) to `-9999..9999`. Elixir still
+  restricts years in this format to four digits.
   """
 
   @behaviour Calendar

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -327,48 +327,13 @@ defmodule Calendar.ISO do
 
       iex> Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07")
       {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}}
-      iex> Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07")
-      {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}}
-      iex> Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07Z")
+      iex> Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07Z")
       {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}}
 
       iex> Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07.0")
       {:ok, {2015, 1, 23, 23, 50, 7, {0, 1}}}
       iex> Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07,0123456")
       {:ok, {2015, 1, 23, 23, 50, 7, {12345, 6}}}
-      iex> Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07.0123456")
-      {:ok, {2015, 1, 23, 23, 50, 7, {12345, 6}}}
-      iex> Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07.123Z")
-      {:ok, {2015, 1, 23, 23, 50, 7, {123000, 3}}}
-
-      iex> Calendar.ISO.parse_naive_datetime("-2015-01-23 23:50:07")
-      {:ok, {-2015, 1, 23, 23, 50, 7, {0, 0}}}
-      iex> Calendar.ISO.parse_naive_datetime("+2015-01-23 23:50:07")
-      {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}}
-
-      iex> Calendar.ISO.parse_naive_datetime("2015-01-23P23:50:07")
-      {:error, :invalid_format}
-      iex> Calendar.ISO.parse_naive_datetime("2015:01:23 23-50-07")
-      {:error, :invalid_format}
-      iex> Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07A")
-      {:error, :invalid_format}
-      iex> Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:61")
-      {:error, :invalid_time}
-      iex> Calendar.ISO.parse_naive_datetime("2015-01-32 23:50:07")
-      {:error, :invalid_date}
-
-      iex> Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07.123+02:30")
-      {:ok, {2015, 1, 23, 23, 50, 7, {123000, 3}}}
-      iex> Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07.123+00:00")
-      {:ok, {2015, 1, 23, 23, 50, 7, {123000, 3}}}
-      iex> Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07.123-02:30")
-      {:ok, {2015, 1, 23, 23, 50, 7, {123000, 3}}}
-      iex> Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07.123-00:00")
-      {:error, :invalid_format}
-      iex> Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07.123-00:60")
-      {:error, :invalid_format}
-      iex> Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07.123-24:00")
-      {:error, :invalid_format}
 
   """
   @doc since: "1.10.0"

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -249,9 +249,6 @@ defmodule Calendar.ISO do
   For more information on supported strings, see how this
   module implements [ISO 8601](#module-iso-8601-compliance).
 
-  For more information on supported strings, see how this
-  module implements [ISO 8601](#module-iso-8601-compliance).
-
   ## Examples
 
       iex> Calendar.ISO.parse_time("23:50:07")
@@ -326,9 +323,6 @@ defmodule Calendar.ISO do
   For more information on supported strings, see how this
   module implements [ISO 8601](#module-iso-8601-compliance).
 
-  For more information on supported strings, see how this
-  module implements [ISO 8601](#module-iso-8601-compliance).
-
   ## Examples
 
       iex> Calendar.ISO.parse_date("2015-01-23")
@@ -397,9 +391,6 @@ defmodule Calendar.ISO do
 
   @doc """
   Parses a naive datetime `string` in the `:extended` format.
-
-  For more information on supported strings, see how this
-  module implements [ISO 8601](#module-iso-8601-compliance).
 
   For more information on supported strings, see how this
   module implements [ISO 8601](#module-iso-8601-compliance).
@@ -498,9 +489,6 @@ defmodule Calendar.ISO do
 
   @doc """
   Parses a UTC datetime `string` in the `:extended` format.
-
-  For more information on supported strings, see how this
-  module implements [ISO 8601](#module-iso-8601-compliance).
 
   For more information on supported strings, see how this
   module implements [ISO 8601](#module-iso-8601-compliance).

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -280,10 +280,7 @@ defmodule Calendar.ISO do
 
       iex> Calendar.ISO.parse_date("2015-01-23")
       {:ok, {2015, 1, 23}}
-      iex> Calendar.ISO.parse_date("-2015-01-23")
-      {:ok, {-2015, 1, 23}}
-      iex> Calendar.ISO.parse_date("+2015-01-23")
-      {:ok, {2015, 1, 23}}
+
       iex> Calendar.ISO.parse_date("2015:01:23")
       {:error, :invalid_format}
       iex> Calendar.ISO.parse_date("2015-01-32")

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -23,6 +23,18 @@ defmodule Calendar.ISO do
   The formatting of dates in `NaiveDateTime.to_iso8601/1` and `DateTime.to_iso8601/1`
   do produce specification-compliant string representations using the `T` separator.
 
+  #### Examples
+
+      iex> Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07.0123456")
+      {:ok, {2015, 1, 23, 23, 50, 7, {12345, 6}}}
+      iex> Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07.0123456")
+      {:ok, {2015, 1, 23, 23, 50, 7, {12345, 6}}}
+
+      iex> Calendar.ISO.parse_utc_datetime("2015-01-23 23:50:07.0123456Z")
+      {:ok, {2015, 1, 23, 23, 50, 7, {12345, 6}}, 0}
+      iex> Calendar.ISO.parse_utc_datetime("2015-01-23T23:50:07.0123456Z")
+      {:ok, {2015, 1, 23, 23, 50, 7, {12345, 6}}, 0}
+
   ### Features
 
   The standard library supports a minimal set of possible ISO 8601 features.
@@ -32,9 +44,49 @@ defmodule Calendar.ISO do
   and `DateTime.to_iso8601/2` to produce either basic or extended formatted strings.
   `Calendar.strftime/2` allows you to format datetimes however else you desire.
 
-  Other optional ISO 8601 features; such as ordinal dates, week dates,
-  durations, time intervals, and reduced precision;
-  are not supported by the parser or formatters.
+  Other optional ISO 8601 features; such as ordinal dates, week dates, and reduced
+  precision (except for milliseconds); are not supported by the parser or formatters.
+
+  No functions exist to parse ISO 8601 durations or time intervals.
+
+  #### Examples
+
+  Only the extended format is supported in parsing; the basic format is not.
+
+      iex> Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07.0123456")
+      {:ok, {2015, 1, 23, 23, 50, 7, {12345, 6}}}
+      iex> Calendar.ISO.parse_naive_datetime("20150123T235007.0123456")
+      {:error, :invalid_format}
+
+  Only calendar dates are supported in parsing; ordinal and week dates are not.
+
+      iex> Calendar.ISO.parse_date("2015-04-15")
+      {:ok, {2015, 4, 15}}
+      iex> Calendar.ISO.parse_date("2015-105")
+      {:error, :invalid_format}
+      iex> Calendar.ISO.parse_date("2015-W16")
+      {:error, :invalid_format}
+      iex> Calendar.ISO.parse_date("2015-W016-3")
+      {:error, :invalid_format}
+
+  Reduced precision is supported for only milliseconds;
+  years, months, days, hours, minutes, and seconds must be fully specified.
+
+      iex> Calendar.ISO.parse_date("2015-04-15")
+      {:ok, {2015, 4, 15}}
+      iex> Calendar.ISO.parse_date("2015-04")
+      {:error, :invalid_format}
+      iex> Calendar.ISO.parse_date("2015")
+      {:error, :invalid_format}
+
+      iex> Calendar.ISO.parse_time("23:50:07.0123456")
+      {:ok, {23, 50, 7, {12345, 6}}}
+      iex> Calendar.ISO.parse_time("23:50:07")
+      {:ok, {23, 50, 7, {0, 0}}}
+      iex> Calendar.ISO.parse_time("23:50")
+      {:error, :invalid_format}
+      iex> Calendar.ISO.parse_time("23")
+      {:error, :invalid_format}
 
   ### Extensions
 
@@ -43,6 +95,24 @@ defmodule Calendar.ISO do
   This allows dates to be prefixed with a `+` or `-` sign, extending the range of
   expressible years from the default (`0000..9999`) to `-9999..9999`. Elixir still
   restricts years in this format to four digits.
+
+  #### Examples
+
+      iex> Calendar.ISO.parse_date("-2015-01-23")
+      {:ok, {-2015, 1, 23}}
+      iex> Calendar.ISO.parse_date("+2015-01-23")
+      {:ok, {2015, 1, 23}}
+
+      iex> Calendar.ISO.parse_naive_datetime("-2015-01-23 23:50:07")
+      {:ok, {-2015, 1, 23, 23, 50, 7, {0, 0}}}
+      iex> Calendar.ISO.parse_naive_datetime("+2015-01-23 23:50:07")
+      {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}}
+
+      iex> Calendar.ISO.parse_utc_datetime("-2015-01-23 23:50:07Z")
+      {:ok, {-2015, 1, 23, 23, 50, 7, {0, 0}}, 0}
+      iex> Calendar.ISO.parse_utc_datetime("+2015-01-23 23:50:07Z")
+      {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}, 0}
+
   """
 
   @behaviour Calendar
@@ -162,6 +232,9 @@ defmodule Calendar.ISO do
   @doc """
   Parses a time string.
 
+  For more information on supported strings, see how this
+  module implements [ISO 8601](#module-iso-8601-compliance).
+
   ## Examples
 
       iex> Calendar.ISO.parse_time("23:50:07")
@@ -216,6 +289,9 @@ defmodule Calendar.ISO do
   @doc """
   Parses a date string.
 
+  For more information on supported strings, see how this
+  module implements [ISO 8601](#module-iso-8601-compliance).
+
   ## Examples
 
       iex> Calendar.ISO.parse_date("2015-01-23")
@@ -259,6 +335,9 @@ defmodule Calendar.ISO do
 
   @doc """
   Parses a naive datetime string.
+
+  For more information on supported strings, see how this
+  module implements [ISO 8601](#module-iso-8601-compliance).
 
   ## Examples
 
@@ -345,6 +424,9 @@ defmodule Calendar.ISO do
 
   @doc """
   Parses a UTC datetime string.
+
+  For more information on supported strings, see how this
+  module implements [ISO 8601](#module-iso-8601-compliance).
 
   ## Examples
 

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -379,33 +379,14 @@ defmodule Calendar.ISO do
 
   ## Examples
 
-      iex> Calendar.ISO.parse_utc_datetime("2015-01-23T23:50:07Z")
+      iex> Calendar.ISO.parse_utc_datetime("2015-01-23 23:50:07Z")
       {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}, 0}
 
-      iex> Calendar.ISO.parse_utc_datetime("2015-01-23T23:50:07.123+02:30")
-      {:ok, {2015, 1, 23, 21, 20, 7, {123000, 3}}, 9000}
+      iex> Calendar.ISO.parse_utc_datetime("2015-01-23 23:50:07+02:30")
+      {:ok, {2015, 1, 23, 21, 20, 7, {0, 0}}, 9000}
 
-      iex> Calendar.ISO.parse_utc_datetime("2015-01-23T23:50:07,123+02:30")
-      {:ok, {2015, 1, 23, 21, 20, 7, {123000, 3}}, 9000}
-
-      iex> Calendar.ISO.parse_utc_datetime("-2015-01-23T23:50:07Z")
-      {:ok, {-2015, 1, 23, 23, 50, 7, {0, 0}}, 0}
-
-      iex> Calendar.ISO.parse_utc_datetime("-2015-01-23T23:50:07,123+02:30")
-      {:ok, {-2015, 1, 23, 21, 20, 7, {123000, 3}}, 9000}
-      iex> Calendar.ISO.parse_utc_datetime("+2015-01-23T23:50:07Z")
-      {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}, 0}
-
-      iex> Calendar.ISO.parse_utc_datetime("2015-01-23P23:50:07")
-      {:error, :invalid_format}
-      iex> Calendar.ISO.parse_utc_datetime("2015-01-23T23:50:07")
+      iex> Calendar.ISO.parse_utc_datetime("2015-01-23 23:50:07")
       {:error, :missing_offset}
-      iex> Calendar.ISO.parse_utc_datetime("2015-01-23 23:50:61")
-      {:error, :invalid_time}
-      iex> Calendar.ISO.parse_utc_datetime("2015-01-32 23:50:07")
-      {:error, :invalid_date}
-      iex> Calendar.ISO.parse_utc_datetime("2015-01-23T23:50:07.123-00:00")
-      {:error, :invalid_format}
 
   """
   @doc since: "1.10.0"

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -14,11 +14,6 @@ defmodule Calendar.ISO do
   to selectively implement most parts of it. The choices Elixir makes here
   are catalogued below.
 
-  ### Deviations
-
-  ISO 8601 allows times and datetimes to specify 24:00:00 as the zero hour of the next day.
-  This notation is not supported by Elixir.
-
   ### Additions
 
   ISO 8601 does not allow a whitespace instead of `T` as a separator

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -1,22 +1,52 @@
 defmodule Calendar.ISO do
   @moduledoc """
-  A calendar implementation that follows to ISO 8601.
+  The default calendar implementation, a Gregorian calendar following ISO 8601.
 
-  This calendar implements the proleptic Gregorian calendar and
+  This calendar implements a proleptic Gregorian calendar and
   is therefore compatible with the calendar used in most countries
   today. The proleptic means the Gregorian rules for leap years are
   applied for all time, consequently the dates give different results
   before the year 1583 from when the Gregorian calendar was adopted.
 
-  Given this is the default calendar used by Elixir, it has one
-  difference compared to the ISO8601 specification in that it allows
-  a whitespace instead of `T` as a separator between date and times
-  both when parsing and formatting. Strict formatting can be done
-  by using the `to_iso8601` found in `NaiveDateTime` and `DateTime`.
+  ## ISO 8601 compliance
 
-  Note that while ISO 8601 allows times and datetimes to specify
-  24:00:00 as the zero hour of the next day, this notation is not
-  supported by Elixir.
+  The ISO 8601 specification is feature-rich, but allows applications
+  to selectively implement most parts of it. The choices Elixir makes here
+  are catalogued below.
+
+  ### Deviations
+
+  ISO 8601 allows times and datetimes to specify 24:00:00 as the zero hour of the next day.
+  This notation is not supported by Elixir.
+
+  ### Additions
+
+  ISO 8601 does not allow a whitespace instead of `T` as a separator
+  between date and times, both when parsing and formatting.
+  This is a common enough representation, Elixir allows it during parsing.
+
+  The formatting of dates in `NaiveDateTime.to_iso8601/1` and `DateTime.to_iso8601/1`
+  do produce specification-compliant string representations using the `T` separator.
+
+  ### Features
+
+  The standard library supports a minimalistic set of possible ISO 8601 features.
+  Specifically, the parser only supports calendar dates and the extended format.
+
+  However, you can still format datetimes with `NaiveDateTime.to_iso8601/2`
+  and `DateTime.to_iso8601/2` to produce either basic or extended formatted strings.
+
+  Other optional ISO 8601 features; such as ordinal dates, week dates,
+  durations, time intervals, truncated representations, and reduced precision;
+  are not supported by the parser or formatters.
+
+  ### Extensions
+
+  The parser and formatter adopt one ISO 8601 extension: extended year notation.
+
+  This allows dates to be prefixed with a `+` or `-` sign, extending the range of
+  expressible years from the default (`0000..9999`) to `-9999..9999`. Years are still
+  restricted to four digits.
   """
 
   @behaviour Calendar

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -227,6 +227,8 @@ defmodule Calendar.ISO do
       {:ok, {2015, 1, 23}}
       iex> Calendar.ISO.parse_date("-2015-01-23")
       {:ok, {-2015, 1, 23}}
+      iex> Calendar.ISO.parse_date("+2015-01-23")
+      {:ok, {2015, 1, 23}}
       iex> Calendar.ISO.parse_date("2015:01:23")
       {:error, :invalid_format}
       iex> Calendar.ISO.parse_date("2015-01-32")
@@ -280,6 +282,11 @@ defmodule Calendar.ISO do
       {:ok, {2015, 1, 23, 23, 50, 7, {12345, 6}}}
       iex> Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07.123Z")
       {:ok, {2015, 1, 23, 23, 50, 7, {123000, 3}}}
+
+      iex> Calendar.ISO.parse_naive_datetime("-2015-01-23 23:50:07")
+      {:ok, {-2015, 1, 23, 23, 50, 7, {0, 0}}}
+      iex> Calendar.ISO.parse_naive_datetime("+2015-01-23 23:50:07")
+      {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}}
 
       iex> Calendar.ISO.parse_naive_datetime("2015-01-23P23:50:07")
       {:error, :invalid_format}
@@ -360,6 +367,8 @@ defmodule Calendar.ISO do
 
       iex> Calendar.ISO.parse_utc_datetime("-2015-01-23T23:50:07,123+02:30")
       {:ok, {-2015, 1, 23, 21, 20, 7, {123000, 3}}, 9000}
+      iex> Calendar.ISO.parse_utc_datetime("+2015-01-23T23:50:07Z")
+      {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}, 0}
 
       iex> Calendar.ISO.parse_utc_datetime("2015-01-23P23:50:07")
       {:error, :invalid_format}

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -244,22 +244,6 @@ defmodule Calendar.ISO do
       iex> Calendar.ISO.parse_time("T23:50:07Z")
       {:ok, {23, 50, 7, {0, 0}}}
 
-      iex> Calendar.ISO.parse_time("23:50:07,0123456")
-      {:ok, {23, 50, 7, {12345, 6}}}
-      iex> Calendar.ISO.parse_time("23:50:07.0123456")
-      {:ok, {23, 50, 7, {12345, 6}}}
-      iex> Calendar.ISO.parse_time("23:50:07.123Z")
-      {:ok, {23, 50, 7, {123000, 3}}}
-
-      iex> Calendar.ISO.parse_time("2015:01:23 23-50-07")
-      {:error, :invalid_format}
-      iex> Calendar.ISO.parse_time("23:50:07A")
-      {:error, :invalid_format}
-      iex> Calendar.ISO.parse_time("23:50:07.")
-      {:error, :invalid_format}
-      iex> Calendar.ISO.parse_time("23:50:61")
-      {:error, :invalid_time}
-
   """
   @doc since: "1.10.0"
   @impl true

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -18,8 +18,12 @@ defmodule DateTest do
                  fn -> Code.eval_string("~D[2000-50-50]") end
 
     assert_raise ArgumentError,
-                 ~s/cannot parse "2000-50-50 notalias" as Date for Calendar.ISO, reason: :invalid_format/,
-                 fn -> Code.eval_string("~D[2000-50-50 notalias]") end
+                 ~s/cannot parse "2000-04-15 notalias" as Date for Calendar.ISO, reason: :invalid_format/,
+                 fn -> Code.eval_string("~D[2000-04-15 notalias]") end
+
+    assert_raise ArgumentError,
+                 ~s/cannot parse "20010415" as Date for Calendar.ISO, reason: :invalid_format/,
+                 fn -> Code.eval_string(~s{~D[20010415]}) end
 
     assert_raise ArgumentError,
                  ~s/cannot parse "20001-50-50" as Date for Calendar.Holocene, reason: :invalid_date/,

--- a/lib/elixir/test/elixir/calendar/iso_test.exs
+++ b/lib/elixir/test/elixir/calendar/iso_test.exs
@@ -236,7 +236,7 @@ defmodule Calendar.ISOTest do
       assert Calendar.ISO.parse_naive_datetime("2015-01-32 23:50:07") == {:error, :invalid_date}
     end
 
-    test "ignores timezone data but requires valid ones" do
+    test "ignores offset data but requires valid ones" do
       assert Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07.123+02:30") ==
                {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}}
 
@@ -254,6 +254,56 @@ defmodule Calendar.ISOTest do
 
       assert Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07.123-24:00") ==
                {:error, :invalid_format}
+    end
+
+    test "supports both spaces and 'T' as datetime separators" do
+      assert Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07") ==
+               {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}}
+
+      assert Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07") ==
+               {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}}
+    end
+
+    test "supports basic and extended formats by default" do
+      assert Calendar.ISO.parse_naive_datetime("20150123 235007.123") ==
+               {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}}
+
+      assert Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07.123") ==
+               {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}}
+    end
+
+    test "errors on mixed basic and extended formats" do
+      assert Calendar.ISO.parse_naive_datetime("20150123 23:50:07.123") ==
+               {:error, :invalid_format}
+
+      assert Calendar.ISO.parse_naive_datetime("2015-01-23 235007.123") ==
+               {:error, :invalid_format}
+    end
+  end
+
+  describe "parse_naive_datetime/2" do
+    test "allows accepting either format" do
+      assert Calendar.ISO.parse_naive_datetime("20150123 235007.123", :any) ==
+               {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}}
+
+      assert Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07.123", :any) ==
+               {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}}
+    end
+
+    test "allows enforcing basic formats" do
+      assert Calendar.ISO.parse_naive_datetime("20150123 235007.123", :basic) ==
+               {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}}
+
+      assert Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07.123", :basic) ==
+               {:error, :invalid_format}
+    end
+
+    test "allows enforcing extended formats" do
+      assert Calendar.ISO.parse_naive_datetime("20150123 235007.123", :extended) ==
+               {:error, :invalid_format}
+
+      assert Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07.123", :extended) ==
+               {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}}
     end
   end
 

--- a/lib/elixir/test/elixir/calendar/iso_test.exs
+++ b/lib/elixir/test/elixir/calendar/iso_test.exs
@@ -121,8 +121,8 @@ defmodule Calendar.ISOTest do
   end
 
   describe "parse_date/1" do
-    test "supports both basic and extended formats by default" do
-      assert Calendar.ISO.parse_date("20150123") == {:ok, {2015, 1, 23}}
+    test "supports both only extended format by default" do
+      assert Calendar.ISO.parse_date("20150123") == {:error, :invalid_format}
       assert Calendar.ISO.parse_date("2015-01-23") == {:ok, {2015, 1, 23}}
     end
   end
@@ -145,8 +145,8 @@ defmodule Calendar.ISOTest do
   end
 
   describe "parse_time/1" do
-    test "supports both basic and extended formats" do
-      assert Calendar.ISO.parse_time("235007") == {:ok, {23, 50, 7, {0, 0}}}
+    test "supports only extended format by default" do
+      assert Calendar.ISO.parse_time("235007") == {:error, :invalid_format}
       assert Calendar.ISO.parse_time("23:50:07") == {:ok, {23, 50, 7, {0, 0}}}
     end
 
@@ -264,9 +264,9 @@ defmodule Calendar.ISOTest do
                {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}}
     end
 
-    test "supports basic and extended formats by default" do
+    test "supports only extended format by default" do
       assert Calendar.ISO.parse_naive_datetime("20150123 235007.123") ==
-               {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}}
+               {:error, :invalid_format}
 
       assert Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07.123") ==
                {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}}
@@ -349,9 +349,9 @@ defmodule Calendar.ISOTest do
                {:ok, {2015, 1, 23, 23, 50, 7, {0, 0}}, 0}
     end
 
-    test "supports basic and extended formats by default" do
+    test "supports only extended format by default" do
       assert Calendar.ISO.parse_utc_datetime("20150123 235007.123Z") ==
-               {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}, 0}
+               {:error, :invalid_format}
 
       assert Calendar.ISO.parse_utc_datetime("2015-01-23 23:50:07.123Z") ==
                {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}, 0}
@@ -389,6 +389,26 @@ defmodule Calendar.ISOTest do
 
       assert Calendar.ISO.parse_utc_datetime("2015-01-23 23:50:07.123Z", :extended) ==
                {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}, 0}
+    end
+
+    test "errors on mixed basic and extended formats" do
+      assert Calendar.ISO.parse_utc_datetime("20150123 23:50:07.123Z", :any) ==
+               {:error, :invalid_format}
+
+      assert Calendar.ISO.parse_utc_datetime("20150123 23:50:07.123Z", :basic) ==
+               {:error, :invalid_format}
+
+      assert Calendar.ISO.parse_utc_datetime("20150123 23:50:07.123Z", :extended) ==
+               {:error, :invalid_format}
+
+      assert Calendar.ISO.parse_utc_datetime("2015-01-23 235007.123Z", :any) ==
+               {:error, :invalid_format}
+
+      assert Calendar.ISO.parse_utc_datetime("2015-01-23 235007.123Z", :basic) ==
+               {:error, :invalid_format}
+
+      assert Calendar.ISO.parse_utc_datetime("2015-01-23 235007.123Z", :extended) ==
+               {:error, :invalid_format}
     end
   end
 end

--- a/lib/elixir/test/elixir/calendar/iso_test.exs
+++ b/lib/elixir/test/elixir/calendar/iso_test.exs
@@ -192,4 +192,14 @@ defmodule Calendar.ISOTest do
       assert Calendar.ISO.parse_naive_datetime("2015-01-23T23:50:07.123-24:00") == {:error, :invalid_format}
     end
   end
+
+  describe "parse_utc_datetime/1" do
+    test "recognizes various errors" do
+      Calendar.ISO.parse_utc_datetime("2015-01-23T23:50:07.123-00:00") == {:error, :invalid_format}
+      Calendar.ISO.parse_utc_datetime("2015-01-23P23:50:07") == {:error, :invalid_format}
+      Calendar.ISO.parse_utc_datetime("2015-01-23T23:50:07") == {:error, :missing_offset}
+      Calendar.ISO.parse_utc_datetime("2015-01-23 23:50:61") == {:error, :invalid_time}
+      Calendar.ISO.parse_utc_datetime("2015-01-32 23:50:07") == {:error, :invalid_date}
+    end
+  end
 end

--- a/lib/elixir/test/elixir/calendar/iso_test.exs
+++ b/lib/elixir/test/elixir/calendar/iso_test.exs
@@ -121,7 +121,12 @@ defmodule Calendar.ISOTest do
   end
 
   describe "parse_time/1" do
-    test "ignores timezone data but requires valid ones" do
+    test "supports both basic and extended formats" do
+      assert Calendar.ISO.parse_time("235007") == {:ok, {23, 50, 7, {0, 0}}}
+      assert Calendar.ISO.parse_time("23:50:07") == {:ok, {23, 50, 7, {0, 0}}}
+    end
+
+    test "ignores offset data but requires valid ones" do
       assert Calendar.ISO.parse_time("23:50:07Z") == {:ok, {23, 50, 7, {0, 0}}}
       assert Calendar.ISO.parse_time("23:50:07+01:00") == {:ok, {23, 50, 7, {0, 0}}}
 
@@ -173,6 +178,23 @@ defmodule Calendar.ISOTest do
       assert Calendar.ISO.parse_time("23:59:61") == {:error, :invalid_time}
       assert Calendar.ISO.parse_time("23:61:59") == {:error, :invalid_time}
       assert Calendar.ISO.parse_time("25:59:59") == {:error, :invalid_time}
+    end
+  end
+
+  describe "parse_time/2" do
+    test "allows enforcing basic formats" do
+      assert Calendar.ISO.parse_time("235007", :basic) == {:ok, {23, 50, 7, {0, 0}}}
+      assert Calendar.ISO.parse_time("23:50:07", :basic) == {:error, :invalid_format}
+    end
+
+    test "allows enforcing extended formats" do
+      assert Calendar.ISO.parse_time("235007", :extended) == {:error, :invalid_format}
+      assert Calendar.ISO.parse_time("23:50:07", :extended) == {:ok, {23, 50, 7, {0, 0}}}
+    end
+
+    test "allows accepting either format" do
+      assert Calendar.ISO.parse_time("235007", :any) == {:ok, {23, 50, 7, {0, 0}}}
+      assert Calendar.ISO.parse_time("23:50:07", :any) == {:ok, {23, 50, 7, {0, 0}}}
     end
   end
 

--- a/lib/elixir/test/elixir/calendar/iso_test.exs
+++ b/lib/elixir/test/elixir/calendar/iso_test.exs
@@ -138,9 +138,9 @@ defmodule Calendar.ISOTest do
       assert Calendar.ISO.parse_date("2015-01-23", :extended) == {:ok, {2015, 1, 23}}
     end
 
-    test "allows accepting either format" do
-      assert Calendar.ISO.parse_date("20150123", :any) == {:ok, {2015, 1, 23}}
-      assert Calendar.ISO.parse_date("2015-01-23", :any) == {:ok, {2015, 1, 23}}
+    test "errors on other format names" do
+      assert Calendar.ISO.parse_date("20150123", :other) == {:error, :invalid_format}
+      assert Calendar.ISO.parse_date("2015-01-23", :other) == {:error, :invalid_format}
     end
   end
 
@@ -216,9 +216,9 @@ defmodule Calendar.ISOTest do
       assert Calendar.ISO.parse_time("23:50:07", :extended) == {:ok, {23, 50, 7, {0, 0}}}
     end
 
-    test "allows accepting either format" do
-      assert Calendar.ISO.parse_time("235007", :any) == {:ok, {23, 50, 7, {0, 0}}}
-      assert Calendar.ISO.parse_time("23:50:07", :any) == {:ok, {23, 50, 7, {0, 0}}}
+    test "errors on other format names" do
+      assert Calendar.ISO.parse_time("235007", :other) == {:error, :invalid_format}
+      assert Calendar.ISO.parse_time("23:50:07", :other) == {:error, :invalid_format}
     end
   end
 
@@ -282,14 +282,6 @@ defmodule Calendar.ISOTest do
   end
 
   describe "parse_naive_datetime/2" do
-    test "allows accepting either format" do
-      assert Calendar.ISO.parse_naive_datetime("20150123 235007.123", :any) ==
-               {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}}
-
-      assert Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07.123", :any) ==
-               {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}}
-    end
-
     test "allows enforcing basic formats" do
       assert Calendar.ISO.parse_naive_datetime("20150123 235007.123", :basic) ==
                {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}}
@@ -304,6 +296,11 @@ defmodule Calendar.ISOTest do
 
       assert Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07.123", :extended) ==
                {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}}
+    end
+
+    test "errors on other format names" do
+      assert Calendar.ISO.parse_naive_datetime("20150123 235007.123", :other) == {:error, :invalid_format}
+      assert Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07.123", :other) == {:error, :invalid_format}
     end
   end
 
@@ -367,14 +364,6 @@ defmodule Calendar.ISOTest do
   end
 
   describe "parse_utc_datetime/2" do
-    test "allows accepting either format" do
-      assert Calendar.ISO.parse_utc_datetime("20150123 235007.123Z", :any) ==
-               {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}, 0}
-
-      assert Calendar.ISO.parse_utc_datetime("2015-01-23 23:50:07.123Z", :any) ==
-               {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}, 0}
-    end
-
     test "allows enforcing basic formats" do
       assert Calendar.ISO.parse_utc_datetime("20150123 235007.123Z", :basic) ==
                {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}, 0}
@@ -391,17 +380,16 @@ defmodule Calendar.ISOTest do
                {:ok, {2015, 1, 23, 23, 50, 7, {123_000, 3}}, 0}
     end
 
-    test "errors on mixed basic and extended formats" do
-      assert Calendar.ISO.parse_utc_datetime("20150123 23:50:07.123Z", :any) ==
-               {:error, :invalid_format}
+    test "errors on other format names" do
+      assert Calendar.ISO.parse_naive_datetime("20150123 235007.123Z", :other) == {:error, :invalid_format}
+      assert Calendar.ISO.parse_naive_datetime("2015-01-23 23:50:07.123Z", :other) == {:error, :invalid_format}
+    end
 
+    test "errors on mixed basic and extended formats" do
       assert Calendar.ISO.parse_utc_datetime("20150123 23:50:07.123Z", :basic) ==
                {:error, :invalid_format}
 
       assert Calendar.ISO.parse_utc_datetime("20150123 23:50:07.123Z", :extended) ==
-               {:error, :invalid_format}
-
-      assert Calendar.ISO.parse_utc_datetime("2015-01-23 235007.123Z", :any) ==
                {:error, :invalid_format}
 
       assert Calendar.ISO.parse_utc_datetime("2015-01-23 235007.123Z", :basic) ==

--- a/lib/elixir/test/elixir/calendar/iso_test.exs
+++ b/lib/elixir/test/elixir/calendar/iso_test.exs
@@ -120,6 +120,30 @@ defmodule Calendar.ISOTest do
     Calendar.ISO.date_from_iso_days(iso_days)
   end
 
+  describe "parse_date/1" do
+    test "supports both basic and extended formats by default" do
+      assert Calendar.ISO.parse_date("20150123") == {:ok, {2015, 1, 23}}
+      assert Calendar.ISO.parse_date("2015-01-23") == {:ok, {2015, 1, 23}}
+    end
+  end
+
+  describe "parse_date/2" do
+    test "allows enforcing basic formats" do
+      assert Calendar.ISO.parse_date("20150123", :basic) == {:ok, {2015, 1, 23}}
+      assert Calendar.ISO.parse_date("2015-01-23", :basic) == {:error, :invalid_format}
+    end
+
+    test "allows enforcing extended formats" do
+      assert Calendar.ISO.parse_date("20150123", :extended) == {:error, :invalid_format}
+      assert Calendar.ISO.parse_date("2015-01-23", :extended) == {:ok, {2015, 1, 23}}
+    end
+
+    test "allows accepting either format" do
+      assert Calendar.ISO.parse_date("20150123", :any) == {:ok, {2015, 1, 23}}
+      assert Calendar.ISO.parse_date("2015-01-23", :any) == {:ok, {2015, 1, 23}}
+    end
+  end
+
   describe "parse_time/1" do
     test "supports both basic and extended formats" do
       assert Calendar.ISO.parse_time("235007") == {:ok, {23, 50, 7, {0, 0}}}

--- a/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/naive_datetime_test.exs
@@ -60,6 +60,10 @@ defmodule NaiveDateTimeTest do
                  fn -> Code.eval_string("~N[2001-01-01T12:34:65]") end
 
     assert_raise ArgumentError,
+                 ~s/cannot parse "20010101 123456" as NaiveDateTime for Calendar.ISO, reason: :invalid_format/,
+                 fn -> Code.eval_string(~s{~N[20010101 123456]}) end
+
+    assert_raise ArgumentError,
                  ~s/cannot parse "2001-01-01 12:34:56 notalias" as NaiveDateTime for Calendar.ISO, reason: :invalid_format/,
                  fn -> Code.eval_string("~N[2001-01-01 12:34:56 notalias]") end
 

--- a/lib/elixir/test/elixir/calendar/time_test.exs
+++ b/lib/elixir/test/elixir/calendar/time_test.exs
@@ -18,6 +18,10 @@ defmodule TimeTest do
                  fn -> Code.eval_string("~T[12:34:65]") end
 
     assert_raise ArgumentError,
+                 ~s/cannot parse "123456" as Time for Calendar.ISO, reason: :invalid_format/,
+                 fn -> Code.eval_string("~T[123456]") end
+
+    assert_raise ArgumentError,
                  ~s/cannot parse "12:34:56 notalias" as Time for Calendar.ISO, reason: :invalid_format/,
                  fn -> Code.eval_string("~T[12:34:56 notalias]") end
 

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1366,6 +1366,10 @@ defmodule KernelTest do
       Code.eval_string(~s{~U[2015-01-13 13:00]})
     end
 
+    assert_raise ArgumentError, ~r"reason: :invalid_format", fn ->
+      Code.eval_string(~s{~U[20150113 130007Z]})
+    end
+
     assert_raise ArgumentError, ~r"reason: :missing_offset", fn ->
       Code.eval_string(~s{~U[2015-01-13 13:00:07]})
     end


### PR DESCRIPTION
This PR adds support for an optional second parameter to `Calendar.ISO` parsing functions, allowing them to parse the `:basic` format as well as the (default) `:extended`.