### PR TITLE
Update Erlang warnings translation

### DIFF
--- a/lib/elixir/src/elixir_erl_compiler.erl
+++ b/lib/elixir/src/elixir_erl_compiler.erl
@@ -135,6 +135,11 @@ custom_format(sys_core_fold, nomatch_guard) ->
   "this check/guard will always yield the same result";
 
 %% Handle literal eval failures
+custom_format(sys_core_fold, {eval_failure, _Call, Error}) ->
+  #{'__struct__' := Struct} = 'Elixir.Exception':normalize(error, Error),
+  ["this expression will fail with ", elixir_aliases:inspect(Struct)];
+
+%% TODO: remove when we require OTP 24
 custom_format(sys_core_fold, {eval_failure, Error}) ->
   #{'__struct__' := Struct} = 'Elixir.Exception':normalize(error, Error),
   ["this expression will fail with ", elixir_aliases:inspect(Struct)];

--- a/lib/elixir/src/elixir_erl_compiler.erl
+++ b/lib/elixir/src/elixir_erl_compiler.erl
@@ -135,9 +135,9 @@ custom_format(sys_core_fold, nomatch_guard) ->
   "this check/guard will always yield the same result";
 
 %% Handle literal eval failures
-custom_format(sys_core_fold, {eval_failure, {_, {Name, Arity}}, Error}) ->
+custom_format(sys_core_fold, {eval_failure, {Mod, Name, Arity}, Error}) ->
   #{'__struct__' := Struct} = 'Elixir.Exception':normalize(error, Error),
-  Call = io_lib:format("~s/~p", [Name, Arity]),
+  Call = io_lib:format("~s.~s/~p", [elixir_aliases:inspect(Mod), Name, Arity]),
   ["the call to " ++ Call ++ " will fail with ", elixir_aliases:inspect(Struct)];
 
 %% TODO: remove when we require OTP 24

--- a/lib/elixir/src/elixir_erl_compiler.erl
+++ b/lib/elixir/src/elixir_erl_compiler.erl
@@ -135,9 +135,10 @@ custom_format(sys_core_fold, nomatch_guard) ->
   "this check/guard will always yield the same result";
 
 %% Handle literal eval failures
-custom_format(sys_core_fold, {eval_failure, _Call, Error}) ->
+custom_format(sys_core_fold, {eval_failure, {_, {Name, Arity}}, Error}) ->
   #{'__struct__' := Struct} = 'Elixir.Exception':normalize(error, Error),
-  ["this expression will fail with ", elixir_aliases:inspect(Struct)];
+  Call = io_lib:format("~s/~p", [Name, Arity]),
+  ["the call to " ++ Call ++ " will fail with ", elixir_aliases:inspect(Struct)];
 
 %% TODO: remove when we require OTP 24
 custom_format(sys_core_fold, {eval_failure, Error}) ->

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -977,7 +977,7 @@ defmodule Kernel.WarningTest do
   # TODO: Simplify when we require OTP 24
   if System.otp_release() >= "24" do
     @argument_error_message "the call to :erlang.atom_to_binary/2"
-    @arithmetic_error_message "the call to :erlang.+/2"
+    @arithmetic_error_message "the call to +/2"
   else
     @argument_error_message "this expression"
     @arithmetic_error_message "this expression"

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -974,9 +974,10 @@ defmodule Kernel.WarningTest do
     purge(Sample)
   end
 
+  # TODO: Simplify when we require OTP 24
   if System.otp_release() >= "24" do
-    @argument_error_message "the call to atom_to_binary/2"
-    @arithmetic_error_message "the call to +/2"
+    @argument_error_message "the call to :erlang.atom_to_binary/2"
+    @arithmetic_error_message "the call to :erlang.+/2"
   else
     @argument_error_message "this expression"
     @arithmetic_error_message "this expression"

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -974,6 +974,14 @@ defmodule Kernel.WarningTest do
     purge(Sample)
   end
 
+  if System.otp_release() >= "24" do
+    @argument_error_message "the call to atom_to_binary/2"
+    @arithmetic_error_message "the call to +/2"
+  else
+    @argument_error_message "this expression"
+    @arithmetic_error_message "this expression"
+  end
+
   test "eval failure warning" do
     assert capture_err(fn ->
              Code.eval_string("""
@@ -981,7 +989,7 @@ defmodule Kernel.WarningTest do
                def foo, do: Atom.to_string "abc"
              end
              """)
-           end) =~ ~r"this expression will fail with ArgumentError\n.*nofile:2"
+           end) =~ "#{@argument_error_message} will fail with ArgumentError\n  nofile:2"
 
     assert capture_err(fn ->
              Code.eval_string("""
@@ -989,7 +997,7 @@ defmodule Kernel.WarningTest do
                def foo, do: 1 + nil
              end
              """)
-           end) =~ ~r"this expression will fail with ArithmeticError\n.*nofile:2"
+           end) =~ "#{@arithmetic_error_message} will fail with ArithmeticError\n  nofile:2"
   after
     purge([Sample1, Sample2])
   end


### PR DESCRIPTION
Since https://github.com/erlang/otp/commit/8ecc648df22dbfe9dd68a3e2b968ba2b6a2ca7fe instead of `{eval_failure, Reason}` we'd get `{eval_failure, Call, Reason}`.