### PR TITLE
add :minute, :hour, and :day to time units

### DIFF
--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -941,6 +941,25 @@ defmodule DateTimeTest do
                  microsecond: {123_456, 6}
                }
     end
+
+    test "add/2 with non erlang time_units" do
+      dt = DateTime.from_naive!(~N[2018-08-28 00:00:00], "Etc/UTC")
+
+      assert DateTime.add(dt, 4, :day) == %DateTime{
+               calendar: Calendar.ISO,
+               year: 2018,
+               month: 9,
+               day: 1,
+               hour: 0,
+               minute: 0,
+               second: 0,
+               std_offset: 0,
+               time_zone: "Etc/UTC",
+               zone_abbr: "UTC",
+               utc_offset: 0,
+               microsecond: {0, 0}
+             }
+    end
   end
 
   describe "to_iso8601" do

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -257,8 +257,10 @@ defmodule SystemTest do
   end
 
   test "convert_time_unit/3" do
-    time = System.monotonic_time(:nanosecond)
-    assert abs(System.convert_time_unit(time, :nanosecond, :microsecond)) < abs(time)
+    assert System.convert_time_unit(1, :second, :day) == 0
+    assert System.convert_time_unit(1, :second, :millisecond) == 1000
+    assert System.convert_time_unit(30, :minute, :second) == 1800
+    assert System.convert_time_unit(1, :day, :minute) == 1440
   end
 
   test "schedulers/0" do


### PR DESCRIPTION
Discussion and proposal: https://groups.google.com/g/elixir-lang-core/c/FEEwA2Pspzs/m/3_i7AKxCBQAJ

This PR adds `:day`, `:hour`, and `:minute` to `time_unit`, allowing it to be used for time conversion. Ideally this would be in the erlang/otp code, but after trying to find my way around that code base and realizing I would have to touch C code (and OS libraries), I decided this would be easier. It took me a couple tries to figure out the easiest / cleanest way to do this, and I'm pretty happy with this result.