### PR TITLE
Make Enum.any?/1 and Enum.all?/1 faster

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -280,6 +280,36 @@ defmodule Enum do
   end
 
   @doc """
+  Returns `true` if  all elements in `enumerable` are truthy.
+
+  When an element has a falsy value (`false` or `nil`) iteration stops immediately
+  and `false` is returned. In all other cases `true` is returned.
+
+  ## Examples
+
+      iex> Enum.all?([1, 2, 3])
+      true
+
+      iex> Enum.all?([1, nil, 3])
+      false
+
+      iex> Enum.all?([])
+      true
+
+  """
+  @spec all?(t) :: boolean
+  def all?(enumerable) when is_list(enumerable) do
+    all_list(enumerable)
+  end
+
+  def all?(enumerable) do
+    Enumerable.reduce(enumerable, {:cont, true}, fn entry, _ ->
+      if entry, do: {:cont, true}, else: {:halt, false}
+    end)
+    |> elem(1)
+  end
+
+  @doc """
   Returns `true` if `fun.(element)` is truthy for all elements in `enumerable`.
 
   Iterates over `enumerable` and invokes `fun` on each element. If `fun` ever
@@ -302,24 +332,8 @@ defmodule Enum do
   which `fun` returns a falsy value, so the result must be `true`. This is a
   well-defined logical argument for empty collections.
 
-  If no function is given, the truthiness of each element is checked during iteration.
-  When an element has a falsy value (`false` or `nil`) iteration stops immediately and
-  `false` is returned. In all other cases `true` is returned.
-
-      iex> Enum.all?([1, 2, 3])
-      true
-
-      iex> Enum.all?([1, nil, 3])
-      false
-
-      iex> Enum.all?([])
-      true
-
   """
   @spec all?(t, (element -> as_boolean(term))) :: boolean
-
-  def all?(enumerable, fun \\ fn x -> x end)
-
   def all?(enumerable, fun) when is_list(enumerable) do
     all_list(enumerable, fun)
   end
@@ -327,6 +341,36 @@ defmodule Enum do
   def all?(enumerable, fun) do
     Enumerable.reduce(enumerable, {:cont, true}, fn entry, _ ->
       if fun.(entry), do: {:cont, true}, else: {:halt, false}
+    end)
+    |> elem(1)
+  end
+
+  @doc """
+  Returns `true` if at least one element in `enumerable` is truthy.
+
+  When an element has a truthy value (neither `false` nor `nil`) iteration stops
+  immediately and `true` is returned. In all other cases `false` is returned.
+
+  ## Examples
+
+      iex> Enum.any?([false, false, false])
+      false
+
+      iex> Enum.any?([false, true, false])
+      true
+
+      iex> Enum.any?([])
+      false
+
+  """
+  @spec any?(t) :: boolean
+  def any?(enumerable) when is_list(enumerable) do
+    any_list(enumerable)
+  end
+
+  def any?(enumerable) do
+    Enumerable.reduce(enumerable, {:cont, false}, fn entry, _ ->
+      if entry, do: {:halt, true}, else: {:cont, false}
     end)
     |> elem(1)
   end
@@ -349,24 +393,8 @@ defmodule Enum do
       iex> Enum.any?([], fn x -> x > 0 end)
       false
 
-  If no function is given, the truthiness of each element is checked during iteration.
-  When an element has a truthy value (neither `false` nor `nil`) iteration stops
-  immediately and `true` is returned. In all other cases `false` is returned.
-
-      iex> Enum.any?([false, false, false])
-      false
-
-      iex> Enum.any?([false, true, false])
-      true
-
-      iex> Enum.any?([])
-      false
-
   """
   @spec any?(t, (element -> as_boolean(term))) :: boolean
-
-  def any?(enumerable, fun \\ fn x -> x end)
-
   def any?(enumerable, fun) when is_list(enumerable) do
     any_list(enumerable, fun)
   end
@@ -3517,6 +3545,18 @@ defmodule Enum do
 
   ## all?
 
+  defp all_list([h | t]) do
+    if h do
+      all_list(t)
+    else
+      false
+    end
+  end
+
+  defp all_list([]) do
+    true
+  end
+
   defp all_list([h | t], fun) do
     if fun.(h) do
       all_list(t, fun)
@@ -3530,6 +3570,18 @@ defmodule Enum do
   end
 
   ## any?
+
+  defp any_list([h | t]) do
+    if h do
+      true
+    else
+      any_list(t)
+    end
+  end
+
+  defp any_list([]) do
+    false
+  end
 
   defp any_list([h | t], fun) do
     if fun.(h) do


### PR DESCRIPTION
Hi! This might be a controversial PR, I'm opening it for discussion.

I found out that the use of the identity function as a default param (`fun \\ fn x -> x end`) for functions that are iterating over a collection, especially in the `Enum` module, can be adding quite some overhead in some cases.

For most functions which are building some new data structures, like `Enum.group_by/2`, this overhead is fairly small.
But for functions that are mostly reading, the speedup obtained by declaring different arity functions separately is pretty huge:
- [a dedicated Enum.all?/1 is about 3x faster than the current one](https://github.com/sabiwara/elixir_benches/blob/main/bench/fast_enum_all.results.txt) for lists
- [:lists.max/1 is about 4.5x faster than Enum.max/1](https://github.com/sabiwara/elixir_benches/blob/main/bench/enum_max.results.txt) for lists, hinting that implementing `Enum.max/1` separately could make it much faster
- [Enum.uniq/1 speedup](https://github.com/sabiwara/elixir_benches/blob/main/bench/fast_enum_uniq.results.txt) depends on whether there are many duplicates or not. If yes, the speedup can be quite substantive as well since this is mostly read-only

There are however cons to this approach:
- Code duplication
- Makes it a different function in the doc, which might be less clear?

Would there be any smart alternative way to benefit from the speedup without these drawbacks, using meta programming or optimizing the `fun \\ fn x -> x end` pattern at the compiler level?

I decided to open a PR for `Enum.any?` and `Enum.all?`. I think these might actually be clearer as separate functions, since the documentation was already split in two blocks.
What do you think?