### PR TITLE
Speedup Enum.min/1 and Enum.max/1 for lists

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1666,6 +1666,14 @@ defmodule Enum do
   end
 
   @doc false
+  def max(list = [_ | _]), do: :lists.max(list)
+
+  @doc false
+  def max(list = [_ | _], empty_fallback) when is_function(empty_fallback, 0) do
+    :lists.max(list)
+  end
+
+  @doc false
   @spec max(t, (() -> empty_result)) :: element | empty_result when empty_result: any
   def max(enumerable, empty_fallback) when is_function(empty_fallback, 0) do
     max(enumerable, &>=/2, empty_fallback)
@@ -1835,6 +1843,14 @@ defmodule Enum do
         end)
         |> elem(1)
     end
+  end
+
+  @doc false
+  def min(list = [_ | _]), do: :lists.min(list)
+
+  @doc false
+  def min(list = [_ | _], empty_fallback) when is_function(empty_fallback, 0) do
+    :lists.min(list)
   end
 
   @doc false


### PR DESCRIPTION
Hi!
This change should yield a ~4.5x speedup for lists according to [this benchmark](https://github.com/sabiwara/elixir_benches/blob/main/bench/enum_max.results.txt).

It is a bit tricky to add clauses to these functions given how the double defaults are set, but I think this change is quite small and optimizes for the more important use cases (non-empty lists, with or without `empty_fallback`).
If we want to optimize other enumerables, it should be possible as well but it would be a bigger change with much duplication (and probably a less noticeable impact).