### PR TITLE
Support throw in DocTest

### DIFF
--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -80,6 +80,12 @@ defmodule ExUnit.DocTestTest.GoodModule do
   #MapSet<[:a, :b, :c]>
   """
   def inspect2_test, do: :ok
+
+  @doc """
+  iex> (fn() -> throw :bad end).()
+  ** (throw) :bad
+  """
+  def throw_test, do: :ok
 end
 |> ExUnit.BeamHelpers.write_beam()
 
@@ -91,6 +97,14 @@ defmodule ExUnit.DocTestTest.MultipleExceptions do
   ** (ArithmeticError) bad argument in arithmetic expression
   """
   def two_exceptions, do: :ok
+
+  @doc """
+  iex> (fn() -> throw :foo end).()
+  ** (throw) :foo
+  iex> (fn() -> throw :bar end).()
+  ** (throw) :bar
+  """
+  def two_throws, do: :ok
 end
 |> ExUnit.BeamHelpers.write_beam()
 
@@ -175,6 +189,9 @@ defmodule ExUnit.DocTestTest.Invalid do
 
       iex> raise "oops"
       ** (RuntimeError) hello
+
+      iex> throw :foo
+      ** (throw) :bar
 
   """
 


### PR DESCRIPTION
## What it does

Currently DocTest does not support `throw` case. It detects the string format in the expectation, but it try to use `Exception.throw` as exception module, not treating it as throw.

With this PR, it supports `throw` correctly. For example, the following can be used in the doctest.

```elixir
iex> (fn () -> throw :bad end).()
** (throw) :bad
```

Probably in most cases throw is only for local return inside a function call (and its private function calls), not across public function calls... but since `throw` is a feature actually, I guess it would be a good addition.

## To do / Questions

- I added a separate function body for `{:error, :throw, message}` instead of making changes in the existing function for `{:error, exception, message}`
- I added test cases but 1) I couldn't figure out how to fix tests (e.g. it needs updating line numbers somewhere) and 2) Not sure I added them to the right modules.

Feel free to edit the PR.