### PR TITLE
Preserve file mode when copying non-beam ebin files

### DIFF
--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -780,7 +780,10 @@ defmodule Mix.Release do
              {:ok, binary} <- strip_beam(File.read!(source_file), strip_options) do
           File.write!(target_file, binary)
         else
-          _ -> File.copy(source_file, target_file)
+          _ ->
+            # Use File.cp!/3 to preserve file mode for any executables stored
+            # in the ebin directory.
+            File.cp!(source_file, target_file)
         end
       end
 

--- a/lib/mix/test/mix/release_test.exs
+++ b/lib/mix/test/mix/release_test.exs
@@ -647,6 +647,19 @@ defmodule Mix.ReleaseTest do
       File.mkdir_p!(source)
       refute copy_ebin(release([]), source, tmp_path("mix_release"))
     end
+
+    test "preserves file mode" do
+      source = tmp_path("source_ebin")
+      source_so_path = Path.join(source, "libtest_nif.so")
+
+      File.mkdir_p!(source)
+      File.touch!(source_so_path)
+      File.chmod!(source_so_path, 0o755)
+
+      assert copy_ebin(release([]), source, tmp_path("mix_release"))
+
+      assert mode!(source_so_path) == mode!(tmp_path("mix_release/libtest_nif.so"))
+    end
   end
 
   describe "copy_app/2" do
@@ -759,6 +772,10 @@ defmodule Mix.ReleaseTest do
 
   defp size!(path) do
     File.stat!(path).size
+  end
+
+  defp mode!(path) do
+    File.stat!(path).mode
   end
 
   defp release(config) do


### PR DESCRIPTION
If a non-beam file in the ebin directory had execute permissions set,
those were lost when making a release. This switches the copy function
to `File.cp!/3` to preserve permissions.

Specifically, this affects the use of zigler with Nerves. Zigler
generates NIF shared libaries and stores them in the `ebin` directory.
The shared libraries had their execute mode bit set, but lost it on the
copy to the release. This affected the Nerves post-processing of all
firmware executables since Nerves uses the execute bit to identify
files that should be processed.

This also switches the copy call to the raising version like is done
when writing `.beam` files for consistency.
