### PR TITLE
Fix translating erl compiler errors to diagnostics on OTP 24

### DIFF
--- a/lib/mix/lib/mix/compilers/erlang.ex
+++ b/lib/mix/lib/mix/compilers/erlang.ex
@@ -271,7 +271,18 @@ defmodule Mix.Compilers.Erlang do
   defp to_diagnostics(warnings_or_errors, severity) do
     for {file, issues} <- warnings_or_errors,
         {line, module, data} <- issues do
-      position = if is_integer(line) and line >= 1, do: line
+      position =
+        case line do
+          # TODO: remove when we require OTP 24
+          line when is_integer(line) and line >= 1 ->
+            line
+
+          {line, _column} when is_integer(line) and line >= 1 ->
+            line
+
+          _ ->
+            nil
+        end
 
       %Mix.Task.Compiler.Diagnostic{
         file: Path.absname(file),

--- a/lib/mix/test/mix/umbrella_test.exs
+++ b/lib/mix/test/mix/umbrella_test.exs
@@ -477,6 +477,7 @@ defmodule Mix.UmbrellaTest do
   test "reloads app in app tracer if .app changes" do
     in_fixture("umbrella_dep/deps/umbrella/apps", fn ->
       deps = [{:foo, in_umbrella: true}]
+
       Mix.Project.in_project(:bar, "bar", [deps: deps], fn _ ->
         Mix.Task.run("compile", ["--verbose"])
         mtime = File.stat!("../foo/lib/foo.ex").mtime


### PR DESCRIPTION
The compiler previously emitted just `line` and now emits `{line, column}`.

The diagnostic struct accepts as position either:

    nil
    line
    {start_line, start_col, end_line, end_col}

so we could have used the `column` to create the 4-tuple but we don't have enough information to do that correctly, we don't know where the column or line ends.
