### PR TITLE
Fix remaining warning translations for OTP 24

### DIFF
--- a/lib/mix/lib/mix/compilers/erlang.ex
+++ b/lib/mix/lib/mix/compilers/erlang.ex
@@ -271,18 +271,7 @@ defmodule Mix.Compilers.Erlang do
   defp to_diagnostics(warnings_or_errors, severity) do
     for {file, issues} <- warnings_or_errors,
         {line, module, data} <- issues do
-      position =
-        case line do
-          # TODO: remove when we require OTP 24
-          line when is_integer(line) and line >= 1 ->
-            line
-
-          {line, _column} when is_integer(line) and line >= 1 ->
-            line
-
-          _ ->
-            nil
-        end
+      position = line(line)
 
       %Mix.Task.Compiler.Diagnostic{
         file: Path.absname(file),
@@ -299,7 +288,12 @@ defmodule Mix.Compilers.Erlang do
     for {_, warnings} <- entries,
         {file, issues} <- warnings,
         {line, module, message} <- issues do
-      IO.puts("#{file}:#{line}: Warning: #{module.format_error(message)}")
+      IO.puts("#{file}:#{line(line)}: Warning: #{module.format_error(message)}")
     end
   end
+
+  defp line({line, _column}) when is_integer(line) and line >= 1, do: line
+  # TODO: remove when we require OTP 24
+  defp line(line) when is_integer(line) and line >= 1, do: line
+  defp line(_), do: nil
 end

--- a/lib/mix/test/mix/tasks/compile.yecc_test.exs
+++ b/lib/mix/test/mix/tasks/compile.yecc_test.exs
@@ -23,10 +23,12 @@ defmodule Mix.Tasks.Compile.YeccTest do
         assert %Mix.Task.Compiler.Diagnostic{
                  compiler_name: "yecc",
                  file: ^file,
-                 message: "syntax error before: '.'",
+                 message: message,
                  position: 1,
                  severity: :error
                } = diagnostic
+
+        assert message =~ "syntax error before: "
       end)
 
       assert File.regular?("src/test_ok.erl")


### PR DESCRIPTION
Yecc error message changed so we need to loosen up our assertion:

OTP 23

    iex> iex
    Erlang/OTP 23 [erts-11.1.7] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1]

    Interactive Elixir (1.11.3) - press Ctrl+C to exit (type h() ENTER for help)
    iex(1)> :yecc.file('f.yrl')
    f.yrl:1: syntax error before: '.'
    :error

OTP 24

    iex> iex
    Erlang/OTP 24 [DEVELOPMENT] [erts-11.1.7] [source-802d2c5083] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1]

    Interactive Elixir (1.12.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
    iex(1)> :yecc.file('f.yrl')
    f.yrl:1:5: syntax error before: .

    :error
