### PR TITLE
Cleanup waiting map on Task.Supervised.stream/6

### DIFF
--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -312,7 +312,16 @@ defmodule Task.Supervised do
           stream_deliver({:cont, acc}, max + 1, spawned, delivered, waiting, next, config)
         else
           pair = deliver_now(result, acc, next, config)
-          stream_reduce(pair, max + 1, spawned, delivered + 1, waiting, next, config)
+
+          stream_reduce(
+            pair,
+            max + 1,
+            spawned,
+            delivered + 1,
+            Map.delete(waiting, position),
+            next,
+            config
+          )
         end
 
       # The monitor process died. We just cleanup the messages from the monitor

--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -312,16 +312,8 @@ defmodule Task.Supervised do
           stream_deliver({:cont, acc}, max + 1, spawned, delivered, waiting, next, config)
         else
           pair = deliver_now(result, acc, next, config)
-
-          stream_reduce(
-            pair,
-            max + 1,
-            spawned,
-            delivered + 1,
-            Map.delete(waiting, position),
-            next,
-            config
-          )
+          waiting = Map.delete(waiting, position)
+          stream_reduce(pair, max + 1, spawned, delivered + 1, waiting, next, config)
         end
 
       # The monitor process died. We just cleanup the messages from the monitor


### PR DESCRIPTION
Hi,

I found a memory leak issue when running Task.async_stream/2 with `ordered` options turned off for fetching large external data.

i can replicate with this code:
```
stream = Task.async_stream(
  Stream.cycle([1]),
  fn _ ->
    # Generate/fetch large data here
    Enum.map(1..1000, &(&1))
  end,
  max_concurrency: 10,
  ordered: false,
  timeout: 60_000
)
Stream.run(stream)
```
below attached memory usage from observer tool.
<img width="415" alt="observer_task_async" src="https://user-images.githubusercontent.com/7887954/108217987-ca536d00-7166-11eb-9524-a6d5ef14f7d8.png">

if my understanding is correct, the `waiting` map that stores the response from task should be cleaned like when `ordered` options turned on in [here](https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/task/supervised.ex#L400). Currently, it is not cleaned and leads to the response piling up and causing a memory leak.

These changes clean up the `waiting` map that has been delivered to the reducer function.