### PR TITLE
Shorten is_struct/2 Macro Expansion for Atom Literals

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2373,17 +2373,22 @@ defmodule Kernel do
   defmacro is_struct(term, name) do
     case __CALLER__.context do
       nil ->
-        quote do
-          case unquote(name) do
-            name when is_atom(name) ->
-              case unquote(term) do
-                %{__struct__: ^name} -> true
-                _ -> false
-              end
+        case Macro.expand(name, __CALLER__) do
+          name when is_atom(name) ->
+            quote do
+              match?(%{__struct__: unquote(name)}, unquote(term))
+            end
 
-            _ ->
-              raise ArgumentError
-          end
+          _ ->
+            quote do
+              case unquote(name) do
+                name when is_atom(name) ->
+                  match?(%{__struct__: ^name}, unquote(term))
+
+                _ ->
+                  raise ArgumentError
+              end
+            end
         end
 
       :match ->

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2373,22 +2373,17 @@ defmodule Kernel do
   defmacro is_struct(term, name) do
     case __CALLER__.context do
       nil ->
-        case Macro.expand(name, __CALLER__) do
-          name when is_atom(name) ->
-            quote do
-              match?(%{__struct__: unquote(name)}, unquote(term))
-            end
-
-          _ ->
-            quote do
-              case unquote(name) do
-                name when is_atom(name) ->
-                  match?(%{__struct__: ^name}, unquote(term))
-
-                _ ->
-                  raise ArgumentError
+        quote generated: true do
+          case unquote(name) do
+            name when is_atom(name) ->
+              case unquote(term) do
+                %{__struct__: ^name} -> true
+                _ -> false
               end
-            end
+
+            _ ->
+              raise ArgumentError
+          end
         end
 
       :match ->

--- a/lib/elixir/test/elixir/fixtures/dialyzer/is_struct.ex
+++ b/lib/elixir/test/elixir/fixtures/dialyzer/is_struct.ex
@@ -1,0 +1,9 @@
+defmodule Dialyzer.IsStruct do
+  def map_literal_atom_literal() do
+    is_struct(%Macro.Env{}, Macro.Env)
+  end
+
+  def arg_atom_literal(arg) do
+    is_struct(arg, Macro.Env)
+  end
+end

--- a/lib/elixir/test/elixir/kernel/dialyzer_test.exs
+++ b/lib/elixir/test/elixir/kernel/dialyzer_test.exs
@@ -147,6 +147,11 @@ defmodule Kernel.DialyzerTest do
     assert_dialyze_no_warnings!(context)
   end
 
+  test "no warning on is_struct/2", context do
+    copy_beam!(context, Dialyzer.IsStruct)
+    assert_dialyze_no_warnings!(context)
+  end
+
   defp copy_beam!(context, module) do
     name = "#{module}.beam"
     File.cp!(Path.join(context.base_dir, name), Path.join(context.outdir, name))

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -341,7 +341,6 @@ defmodule KernelTest do
   defp struct_or_map?(arg, name) when is_struct(arg, name) or is_map(arg), do: true
   defp struct_or_map?(_arg, _name), do: false
 
-  defp atom(), do: Macro.Env
   defp not_atom(), do: "not atom"
 
   test "is_struct/2" do
@@ -355,7 +354,6 @@ defmodule KernelTest do
     assert struct?(%{__struct__: "foo"}, Macro.Env) == false
     assert struct?([], Macro.Env) == false
     assert struct?(%{}, Macro.Env) == false
-    assert struct?(%Macro.Env{}, atom()) == true
 
     assert_raise ArgumentError, "argument error", fn ->
       is_struct(%{}, not_atom())

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -341,6 +341,7 @@ defmodule KernelTest do
   defp struct_or_map?(arg, name) when is_struct(arg, name) or is_map(arg), do: true
   defp struct_or_map?(_arg, _name), do: false
 
+  defp atom(), do: Macro.Env
   defp not_atom(), do: "not atom"
 
   test "is_struct/2" do
@@ -354,6 +355,7 @@ defmodule KernelTest do
     assert struct?(%{__struct__: "foo"}, Macro.Env) == false
     assert struct?([], Macro.Env) == false
     assert struct?(%{}, Macro.Env) == false
+    assert struct?(%Macro.Env{}, atom()) == true
 
     assert_raise ArgumentError, "argument error", fn ->
       is_struct(%{}, not_atom())


### PR DESCRIPTION
The macro expansion for `is_struct/2` includes a `case` that checks for whether the second argument (`name`) is an atom, and raises `ArgumentError` if not. This is sometimes, maybe even usually, known at compile time, and the second clause of the generated case is simply dead code. Dialyzer warns about this.

```
The pattern
:variable_

can never match, because previous clauses completely cover the type
MyApp.MyModule.
```

The change is simply to check to see whether "name" is known to be an atom at compile-time, and if so not to generate the case at all but simply perform the map `__struct__` key check.