### PR TITLE
Revise use of link titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ With tests running and passing, you are ready to contribute to Elixir and
 We have saved some excellent pull requests we have received in the past in
 case you are looking for some examples:
 
-* [Implement Enum.member? - Pull Request](https://github.com/elixir-lang/elixir/pull/992)
-* [Add String.valid? - Pull Request](https://github.com/elixir-lang/elixir/pull/1058)
-* [Implement capture_io for ExUnit - Pull Request](https://github.com/elixir-lang/elixir/pull/1059)
+* [Implement Enum.member? - Pull request](https://github.com/elixir-lang/elixir/pull/992)
+* [Add String.valid? - Pull request](https://github.com/elixir-lang/elixir/pull/1058)
+* [Implement capture_io for ExUnit - Pull request](https://github.com/elixir-lang/elixir/pull/1059)
 
 ### Reviewing changes
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -127,19 +127,19 @@ defmodule Kernel do
   Elixir documentation also includes supporting documents under the
   "Pages" section. Those are:
 
-    * [Compatibility and Deprecations](compatibility-and-deprecations.md) - lists
+    * [Compatibility and deprecations](compatibility-and-deprecations.md) - lists
       compatibility between every Elixir version and Erlang/OTP, release schema;
       lists all deprecated functions, when they were deprecated and alternatives
-    * [Library Guidelines](library-guidelines.md) - general guidelines, anti-patterns,
+    * [Library guidelines](library-guidelines.md) - general guidelines, anti-patterns,
       and rules for those writing libraries
-    * [Naming Conventions](naming-conventions.md) - naming conventions for Elixir code
+    * [Naming conventions](naming-conventions.md) - naming conventions for Elixir code
     * [Operators](operators.md) - lists all Elixir operators and their precedences
-    * [Patterns and Guards](patterns-and-guards.md) - an introduction to patterns,
+    * [Patterns and guards](patterns-and-guards.md) - an introduction to patterns,
       guards, and extensions
-    * [Syntax Reference](syntax-reference.md) - the language syntax reference
+    * [Syntax reference](syntax-reference.md) - the language syntax reference
     * [Typespecs](typespecs.md)- types and function specifications, including list of types
-    * [Unicode Syntax](unicode-syntax.md) - outlines Elixir support for Unicode
-    * [Writing Documentation](writing-documentation.md) - guidelines for writing
+    * [Unicode syntax](unicode-syntax.md) - outlines Elixir support for Unicode
+    * [Writing documentation](writing-documentation.md) - guidelines for writing
       documentation in Elixir
 
   ## Guards
@@ -156,7 +156,7 @@ defmodule Kernel do
   or equal to 16. Guards also support joining multiple conditions with
   `and` and `or`. The whole guard is true if all guard expressions will
   evaluate to `true`. A more complete introduction to guards is available
-  [in the "Patterns and Guards" page](patterns-and-guards.md).
+  in the [Patterns and guards](patterns-and-guards.md) page.
 
   ## Structural comparison
 

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -365,8 +365,8 @@ defmodule Kernel.SpecialForms do
       ERL_COMPILER_OPTIONS=bin_opt_info mix compile
 
   To learn more about specific optimizations and performance considerations,
-  check out
-  [Erlang's Efficiency Guide on handling binaries](http://www.erlang.org/doc/efficiency_guide/binaryhandling.html).
+  check out the
+  ["Constructing and matching binaries" chapter of the Erlang's Efficiency Guide](http://www.erlang.org/doc/efficiency_guide/binaryhandling.html).
   """
   defmacro unquote(:<<>>)(args), do: error!([args])
 

--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -448,7 +448,7 @@ defmodule Process do
   If the process is already dead when calling `Process.monitor/1`, a
   `:DOWN` message is delivered immediately.
 
-  See [the need for monitoring](https://elixir-lang.org/getting-started/mix-otp/genserver.html#the-need-for-monitoring)
+  See ["The need for monitoring"](https://elixir-lang.org/getting-started/mix-otp/genserver.html#the-need-for-monitoring)
   for an example. See `:erlang.monitor/2` for more information.
 
   Inlined by the compiler.

--- a/lib/elixir/pages/library-guidelines.md
+++ b/lib/elixir/pages/library-guidelines.md
@@ -178,7 +178,7 @@ end
 
 That's because by reading the application in the module body and storing it in a module attribute, we are effectively reading the configuration at compile-time, which may become an issue when configuring the system later.
 
-If, for some reason, you must read the application environment at compile time, use `Application.compile_env/2`. Read [the "Compile-time environment" section of the Application docs](Application.html#module-compile-time-environment) for more information.
+If, for some reason, you must read the application environment at compile time, use `Application.compile_env/2`. Read [the "Compile-time environment" section of the `Application` module documentation](Application.html#module-compile-time-environment) for more information.
 
 ### Avoid `use` when an `import` is enough
 
@@ -226,7 +226,7 @@ While there are situations where `use SomeModule` is necessary, `use` should be 
 
 Although the previous section could be summarized as "avoid macros", both topics are important enough to deserve their own sections.
 
-To quote [the official guide on Macros](https://elixir-lang.org/getting-started/meta/macros.html):
+To quote [the official guide on macros](https://elixir-lang.org/getting-started/meta/macros.html):
 
 > Even though Elixir attempts its best to provide a safe environment for macros, the major responsibility of writing clean code with macros falls on developers. Macros are harder to write than ordinary Elixir functions and it's considered to be bad style to use them when they're not necessary. So write macros responsibly.
 >

--- a/lib/elixir/pages/syntax-reference.md
+++ b/lib/elixir/pages/syntax-reference.md
@@ -21,7 +21,7 @@ Integers (`1234`) and floats (`123.4`) in Elixir are represented as a sequence o
 
 ### Atoms
 
-Unquoted atoms start with a colon (`:`) which must be immediately followed by a Unicode letter or an underscore. The atom may continue using a sequence of Unicode letters, numbers, underscores, and `@`. Atoms may end in `!` or `?`. See [Unicode Syntax](unicode-syntax.md) for a formal specification. Valid unquoted atoms are: `:ok`, `:ISO8601`, and `:integer?`.
+Unquoted atoms start with a colon (`:`) which must be immediately followed by a Unicode letter or an underscore. The atom may continue using a sequence of Unicode letters, numbers, underscores, and `@`. Atoms may end in `!` or `?`. See [Unicode syntax](unicode-syntax.md) for a formal specification. Valid unquoted atoms are: `:ok`, `:ISO8601`, and `:integer?`.
 
 If the colon is immediately followed by a pair of double- or single-quotes surrounding the atom name, the atom is considered quoted. In contrast with an unquoted atom, this one can be made of any Unicode character (not only letters), such as `:'🌢 Elixir'`, `:"++olá++"`, and `:"123"`.
 
@@ -84,13 +84,13 @@ Structs built on the map syntax by passing the struct name between `%` and `{`. 
 
 ### Variables
 
-Variables in Elixir must start with an underscore or a Unicode letter that is not in uppercase or titlecase. The variable may continue using a sequence of Unicode letters, numbers, and underscores. Variables may end in `?` or `!`. See [Unicode Syntax](unicode-syntax.md) for a formal specification.
+Variables in Elixir must start with an underscore or a Unicode letter that is not in uppercase or titlecase. The variable may continue using a sequence of Unicode letters, numbers, and underscores. Variables may end in `?` or `!`. See [Unicode syntax](unicode-syntax.md) for a formal specification.
 
 [Elixir's naming conventions](naming-conventions.md) recommend variables to be in `snake_case` format.
 
 ### Non-qualified calls (local calls)
 
-Non-qualified calls, such as `add(1, 2)`, must start with an underscore or a Unicode letter that is not in uppercase or titlecase. The call may continue using a sequence of Unicode letters, numbers, and underscore. Calls may end in `?` or `!`. See [Unicode Syntax](unicode-syntax.md) for a formal specification.
+Non-qualified calls, such as `add(1, 2)`, must start with an underscore or a Unicode letter that is not in uppercase or titlecase. The call may continue using a sequence of Unicode letters, numbers, and underscore. Calls may end in `?` or `!`. See [Unicode syntax](unicode-syntax.md) for a formal specification.
 
 Parentheses for non-qualified calls are optional, except for zero-arity calls, which would then be ambiguous with variables. If parentheses are used, they must immediately follow the function name *without spaces*. For example, `add (1, 2)` is a syntax error, since `(1, 2)` is treated as an invalid block which is attempted to be given as a single argument to `add`.
 
@@ -102,7 +102,7 @@ As many programming languages, Elixir also support operators as non-qualified ca
 
 ### Qualified calls (remote calls)
 
-Qualified calls, such as `Math.add(1, 2)`, must start with an underscore or a Unicode letter that is not in uppercase or titlecase. The call may continue using a sequence of Unicode letters, numbers, and underscores. Calls may end in `?` or `!`. See [Unicode Syntax](unicode-syntax.md) for a formal specification.
+Qualified calls, such as `Math.add(1, 2)`, must start with an underscore or a Unicode letter that is not in uppercase or titlecase. The call may continue using a sequence of Unicode letters, numbers, and underscores. Calls may end in `?` or `!`. See [Unicode syntax](unicode-syntax.md) for a formal specification.
 
 [Elixir's naming conventions](naming-conventions.md) recommend calls to be in `snake_case` format.
 

--- a/lib/mix/lib/mix/tasks/archive.build.ex
+++ b/lib/mix/lib/mix/tasks/archive.build.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Archive.Build do
 
   @moduledoc """
   Builds an archive according to the specification of the
-  [Erlang Archive Format](http://www.erlang.org/doc/man/code.html).
+  [Erlang archive format](http://www.erlang.org/doc/man/code.html).
 
   Archives are meant to contain small projects, usually installed
   locally. Archives may be installed into a Mix environment by

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -968,7 +968,7 @@ defmodule Mix.Tasks.Release do
   Once `.appup`s are created, the next step is to create a `.relup`
   file with all instructions necessary to update the release itself.
   Erlang documentation does provide a chapter on
-  [Creating and Upgrading a Target System](http://erlang.org/doc/system_principles/create_target.html).
+  [Creating and upgrading a target system](http://erlang.org/doc/system_principles/create_target.html).
   [Learn You Some Erlang has a chapter on hot code upgrades](https://learnyousomeerlang.com/relups).
 
   Overall, there are many steps, complexities and assumptions made


### PR DESCRIPTION
It removes the use of indiscriminate title casing :P

Pages titles in Elixir pages are not title cased.