### PR TITLE
Update erlang.org links

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -163,7 +163,7 @@ defmodule Application do
   In the sections above, we have configured an application in the
   `application/0` section of the `mix.exs` file. Ultimately, Mix will use
   this configuration to create an [*application resource
-  file*](http://www.erlang.org/doc/man/application.html), which is a file called
+  file*](https://erlang.org/doc/man/application.html), which is a file called
   `APP_NAME.app`. For example, the application resource file of the OTP
   application `ex_unit` is called `ex_unit.app`.
 
@@ -268,9 +268,9 @@ defmodule Application do
 
   For further details on applications please check the documentation of the
   [`:application` Erlang module](`:application`), and the
-  [Applications](http://www.erlang.org/doc/design_principles/applications.html)
+  [Applications](https://erlang.org/doc/design_principles/applications.html)
   section of the [OTP Design Principles User's
-  Guide](http://erlang.org/doc/design_principles/users_guide.html).
+  Guide](https://erlang.org/doc/design_principles/users_guide.html).
   """
 
   @doc """

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -1323,7 +1323,7 @@ defmodule Code do
   file.
 
   It returns the term stored in the documentation chunk in the format defined by
-  [EEP 48](http://erlang.org/eep/eeps/eep-0048.html) or `{:error, reason}` if
+  [EEP 48](https://erlang.org/eep/eeps/eep-0048.html) or `{:error, reason}` if
   the chunk is not available.
 
   ## Examples
@@ -1426,7 +1426,7 @@ defmodule Code do
   @doc ~S"""
   Deprecated function to retrieve old documentation format.
 
-  Elixir v1.7 adopts [EEP 48](http://erlang.org/eep/eeps/eep-0048.html)
+  Elixir v1.7 adopts [EEP 48](https://erlang.org/eep/eeps/eep-0048.html)
   which is a new documentation format meant to be shared across all
   BEAM languages. The old format, used by `Code.get_docs/2`, is no
   longer available, and therefore this function always returns `nil`.

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -312,7 +312,7 @@ defmodule GenServer do
 
   ## Debugging with the :sys module
 
-  GenServers, as [special processes](http://erlang.org/doc/design_principles/spec_proc.html),
+  GenServers, as [special processes](https://erlang.org/doc/design_principles/spec_proc.html),
   can be debugged using the [`:sys` module](`:sys`).
   Through various hooks, this module allows developers to introspect the state of
   the process and trace system events that happen during its execution, such as
@@ -402,7 +402,7 @@ defmodule GenServer do
 
     * [GenServer - Elixir's Getting Started Guide](https://elixir-lang.org/getting-started/mix-otp/genserver.html)
     * [`:gen_server` module documentation](`:gen_server`)
-    * [gen_server Behaviour - OTP Design Principles](http://www.erlang.org/doc/design_principles/gen_server_concepts.html)
+    * [gen_server Behaviour - OTP Design Principles](https://erlang.org/doc/design_principles/gen_server_concepts.html)
     * [Clients and Servers - Learn You Some Erlang for Great Good!](http://learnyousomeerlang.com/clients-and-servers)
 
   """

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -366,7 +366,7 @@ defmodule Kernel.SpecialForms do
 
   To learn more about specific optimizations and performance considerations,
   check out the
-  ["Constructing and matching binaries" chapter of the Erlang's Efficiency Guide](http://www.erlang.org/doc/efficiency_guide/binaryhandling.html).
+  ["Constructing and matching binaries" chapter of the Erlang's Efficiency Guide](https://erlang.org/doc/efficiency_guide/binaryhandling.html).
   """
   defmacro unquote(:<<>>)(args), do: error!([args])
 

--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -415,7 +415,7 @@ defmodule StringIO do
   defp list_to_binary(data, :unicode) when is_list(data), do: List.to_string(data)
   defp list_to_binary(data, :latin1) when is_list(data), do: :erlang.list_to_binary(data)
 
-  # From http://erlang.org/doc/apps/stdlib/io_protocol.html: result can be any
+  # From https://erlang.org/doc/apps/stdlib/io_protocol.html: result can be any
   # Erlang term, but if it is a list(), the I/O server can convert it to a binary().
   defp get_until_result(data, encoding) when is_list(data), do: list_to_binary(data, encoding)
   defp get_until_result(data, _), do: data

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -43,7 +43,7 @@ defmodule System do
       system time may not match in case of time warps although the VM works towards
       aligning them. This time is not monotonic (i.e., it may decrease)
       as its behaviour is configured [by the VM time warp
-      mode](http://www.erlang.org/doc/apps/erts/time_correction.html#Time_Warp_Modes);
+      mode](https://erlang.org/doc/apps/erts/time_correction.html#Time_Warp_Modes);
 
     * `monotonic_time/0` - a monotonically increasing time provided
       by the Erlang VM.
@@ -58,7 +58,7 @@ defmodule System do
 
   For a more complete rundown on the VM support for different
   times, see the [chapter on time and time
-  correction](http://www.erlang.org/doc/apps/erts/time_correction.html)
+  correction](https://erlang.org/doc/apps/erts/time_correction.html)
   in the Erlang docs.
   """
 

--- a/lib/elixir/pages/typespecs.md
+++ b/lib/elixir/pages/typespecs.md
@@ -36,7 +36,7 @@ In the example above, this happens:
 
 ## Types and their syntax
 
-The syntax Elixir provides for type specifications is similar to [the one in Erlang](http://www.erlang.org/doc/reference_manual/typespec.html). Most of the built-in types provided in Erlang (for example, `pid()`) are expressed in the same way: `pid()` (or simply `pid`). Parameterized types (such as `list(integer)`) are supported as well and so are remote types (such as `Enum.t`). Integers and atom literals are allowed as types (for example, `1`, `:atom`, or `false`). All other types are built out of unions of predefined types. Some shorthands are allowed, such as `[...]`, `<<>>`, and `{...}`.
+The syntax Elixir provides for type specifications is similar to [the one in Erlang](https://erlang.org/doc/reference_manual/typespec.html). Most of the built-in types provided in Erlang (for example, `pid()`) are expressed in the same way: `pid()` (or simply `pid`). Parameterized types (such as `list(integer)`) are supported as well and so are remote types (such as `Enum.t`). Integers and atom literals are allowed as types (for example, `1`, `:atom`, or `false`). All other types are built out of unions of predefined types. Some shorthands are allowed, such as `[...]`, `<<>>`, and `{...}`.
 
 The notation to represent the union of types is the pipe `|`. For example, the typespec `type :: atom() | pid() | tuple()` creates a type `type` that can be either an `atom`, a `pid`, or a `tuple`. This is usually called a [sum type](https://en.wikipedia.org/wiki/Tagged_union) in other languages
 

--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -86,7 +86,7 @@ defmodule Mix.Tasks.Profile.Fprof do
   the total time spent in the function was 50ms.
 
   For a detailed explanation it's worth reading the analysis in
-  [Erlang/OTP documentation for fprof](http://www.erlang.org/doc/man/fprof.html#analysis).
+  [Erlang/OTP documentation for fprof](https://erlang.org/doc/man/fprof.html#analysis).
 
   ## Caveats
 

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -171,8 +171,8 @@ defmodule Mix.Tasks.Release do
       bin/RELEASE_NAME daemon
 
   In daemon mode, the system is started on the background via
-  [`run_erl`](http://erlang.org/doc/man/run_erl.html). You may also
-  want to enable [`heart`](http://erlang.org/doc/man/heart.html)
+  [`run_erl`](https://erlang.org/doc/man/run_erl.html). You may also
+  want to enable [`heart`](https://erlang.org/doc/man/heart.html)
   in daemon mode so it automatically restarts the system in case
   of crashes. See the generated `releases/RELEASE_VSN/env.sh` file.
 
@@ -195,7 +195,7 @@ defmodule Mix.Tasks.Release do
 
   While daemons are not available on Windows, it is possible to install a
   released system as a service on Windows with the help of
-  [`erlsrv`](http://erlang.org/doc/man/erlsrv.html). This can be done by
+  [`erlsrv`](https://erlang.org/doc/man/erlsrv.html). This can be done by
   running:
 
       bin/RELEASE_NAME install
@@ -533,7 +533,7 @@ defmodule Mix.Tasks.Release do
   called `@release`, with the `Mix.Release` struct.
 
   The `vm.args` file may contain any of the VM flags accepted by the [`erl`
-  command](http://erlang.org/doc/man/erl.html).
+  command](https://erlang.org/doc/man/erl.html).
 
   The `env.sh` and `env.bat` is used to set environment variables.
   In there, you can set vars such as `RELEASE_NODE`, `RELEASE_COOKIE`,
@@ -964,13 +964,13 @@ defmodule Mix.Tasks.Release do
   hot code upgrade it. This is one of the many steps necessary
   to perform hot code upgrades and it must be taken into account by
   every process and application being upgraded in the system.
-  The [`.appup` cookbook](http://erlang.org/doc/design_principles/appup_cookbook.html)
+  The [`.appup` cookbook](https://erlang.org/doc/design_principles/appup_cookbook.html)
   provides a good reference and more examples.
 
   Once `.appup`s are created, the next step is to create a `.relup`
   file with all instructions necessary to update the release itself.
   Erlang documentation does provide a chapter on
-  [Creating and upgrading a target system](http://erlang.org/doc/system_principles/create_target.html).
+  [Creating and upgrading a target system](https://erlang.org/doc/system_principles/create_target.html).
   [Learn You Some Erlang has a chapter on hot code upgrades](https://learnyousomeerlang.com/relups).
 
   Overall, there are many steps, complexities and assumptions made

--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -41,7 +41,7 @@ defmodule Mix.Tasks.Release.Init do
   @doc false
   def vm_args_text,
     do: ~S"""
-    ## Customize flags given to the VM: http://erlang.org/doc/man/erl.html
+    ## Customize flags given to the VM: https://erlang.org/doc/man/erl.html
     ## -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
 
     ## Number of dirty schedulers doing IO work (file, sockets, and others)

--- a/man/mix.1
+++ b/man/mix.1
@@ -129,8 +129,8 @@ Allows locking down the project dependencies with a proper version range before 
 .El
 .Sh REFERENCES
 .Bl -tag -width Ds
-.It [1] http://www.erlang.org/doc/man/code.html#id103620
-.It [2] http://www.erlang.org/doc/design_principles/applications.html
+.It [1] https://erlang.org/doc/man/code.html#id103620
+.It [2] https://erlang.org/doc/design_principles/applications.html
 .El
 .Sh SEE ALSO
 .Xr elixir 1 ,


### PR DESCRIPTION
Consistently use https://erlang.org
See also ExDoc PR: https://github.com/elixir-lang/ex_doc/pull/1335