### PR TITLE
Optimize Enum.dedup/1

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -780,8 +780,18 @@ defmodule Enum do
 
   """
   @spec dedup(t) :: list
+  def dedup(enumerable) when is_list(enumerable) do
+    dedup_list(enumerable, []) |> :lists.reverse()
+  end
+
   def dedup(enumerable) do
-    dedup_by(enumerable, fn x -> x end)
+    Enum.reduce(enumerable, [], fn x, acc ->
+      case acc do
+        [^x, _] -> acc
+        _ -> [x | acc]
+      end
+    end)
+    |> :lists.reverse()
   end
 
   @doc """
@@ -3609,6 +3619,22 @@ defmodule Enum do
 
   defp any_list([], _) do
     false
+  end
+
+  # dedup
+
+  defp dedup_list([value | tail], acc) do
+    acc =
+      case acc do
+        [^value | _] -> acc
+        _ -> [value | acc]
+      end
+
+    dedup_list(tail, acc)
+  end
+
+  defp dedup_list([], acc) do
+    acc
   end
 
   ## drop


### PR DESCRIPTION
HI!

Similarly to previous PRs on `Enum.max/1` and `Enum.any?/1`, I noticed that `Enum.dedup/1` could also be implemented in a much more efficient way, since `Enum.dedup_by/2` needs to:
- call identities `fun` at every step
- use a tuple as `acc` instead of just a list

My [benchmarks](https://github.com/sabiwara/elixir_benches/blob/main/bench/fast_enum_dedup.results.txt) suggest a significant performance boost disregarding (either if there are duplicates or not), and the boost seems to be even more important [with the JIT](https://github.com/sabiwara/elixir_benches/blob/2f4e6bab25ee4a9ed97b0af108d65190e6ebcaef/bench/fast_enum_dedup.results.txt).