### PR TITLE
Handle :compile.file/2 returning :error on OTP 24

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -100,9 +100,10 @@ defmodule Mix.Tasks.Compile.Erlang do
       file = Erlang.to_erl_file(Path.rootname(input, ".erl"))
 
       case :compile.file(file, erlc_options) do
-        {:error, :badarg} ->
+        # TODO: Don't handle {:error, :badarg} when we require OTP 24
+        error when error == :error or error == {:error, :badarg} ->
           message =
-            "Compiling Erlang #{inspect(file)} failed with ArgumentError, probably because of invalid :erlc_options"
+            "Compiling Erlang file #{inspect(file)} failed, probably because of invalid :erlc_options"
 
           Mix.raise(message)
 

--- a/lib/mix/test/mix/tasks/compile.erlang_test.exs
+++ b/lib/mix/test/mix/tasks/compile.erlang_test.exs
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Compile.ErlangTest do
   @tag erlc_options: [{:d, 'foo', 'bar'}]
   test "raises on invalid erlc_options" do
     in_fixture("compile_erlang", fn ->
-      assert_raise Mix.Error, ~r"failed with ArgumentError", fn ->
+      assert_raise Mix.Error, ~r"Compiling Erlang file '.*' failed", fn ->
         capture_io(fn ->
           Mix.Tasks.Compile.Erlang.run([])
         end)


### PR DESCRIPTION
Before OTP 24 when given invalid args, :compile.file/2 would return:

    iex(1)> :compile.file('a.erl', [{:d, 'foo', 'bar'}, :report])
    {:error, :badarg}

On OTP 24:

    iex(1)> :compile.file('a.erl', [{:d, 'foo', 'bar'}, :report])

    *** Internal compiler error ***
    exception error: bad argument
      in function  io_lib:format/2
         called as io_lib:format("badly formed '~s'",[{"foo","bar"}])
      in call from sys_messages:list_errors/3 (sys_messages.erl, line 53)
      in call from lists:foreach/2 (lists.erl, line 1342)
      in call from compile:comp_ret_err/1 (compile.erl, line 546)
      in call from compile:'-internal_fun/2-anonymous-0-'/2 (compile.erl, line 229)
      in call from compile:'-do_compile/2-anonymous-0-'/1 (compile.erl, line 219)
    :error