### PR TITLE
Backport OTP 24 compatibility patches to v1.11

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -233,9 +233,9 @@ defmodule Kernel.SpecialForms do
 
   Sizes for types are a bit more nuanced. The default size for integers is 8.
 
-  For floats, it is 64. For floats, `size * unit` must result in 32 or 64,
+  For floats, it is 64. For floats, `size * unit` must result in 16, 32, or 64,
   corresponding to [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point)
-  binary32 and binary64, respectively.
+  binary16, binary32, and binary64, respectively.
 
   For binaries, the default is the size of the binary. Only the last binary in a
   match can use the default size. All others must have their size specified

--- a/lib/elixir/src/elixir_erl_compiler.erl
+++ b/lib/elixir/src/elixir_erl_compiler.erl
@@ -132,6 +132,17 @@ custom_format(sys_core_fold, nomatch_guard) ->
   "this check/guard will always yield the same result";
 
 %% Handle literal eval failures
+custom_format(sys_core_fold, {eval_failure, {Mod, Name, Arity}, Error}) ->
+  #{'__struct__' := Struct} = 'Elixir.Exception':normalize(error, Error),
+  {ExMod, ExName, ExArgs} = elixir_rewrite:erl_to_ex(Mod, Name, lists:duplicate(Arity, nil)),
+  Call = 'Elixir.Exception':format_mfa(ExMod, ExName, length(ExArgs)),
+  Trimmed = case Call of
+              <<"Kernel.", Rest/binary>> -> Rest;
+              _ -> Call
+            end,
+  ["the call to ", Trimmed, " will fail with ", elixir_aliases:inspect(Struct)];
+
+%% TODO: remove when we require OTP 24
 custom_format(sys_core_fold, {eval_failure, Error}) ->
   #{'__struct__' := Struct} = 'Elixir.Exception':normalize(error, Error),
   ["this expression will fail with ", elixir_aliases:inspect(Struct)];

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -931,6 +931,15 @@ defmodule Kernel.WarningTest do
     purge(Sample)
   end
 
+  # TODO: Simplify when we require OTP 24
+  if System.otp_release() >= "24" do
+    @argument_error_message "the call to :erlang.atom_to_binary/2"
+    @arithmetic_error_message "the call to +/2"
+  else
+    @argument_error_message "this expression"
+    @arithmetic_error_message "this expression"
+  end
+
   test "eval failure warning" do
     assert capture_err(fn ->
              Code.eval_string("""
@@ -938,7 +947,7 @@ defmodule Kernel.WarningTest do
                def foo, do: Atom.to_string "abc"
              end
              """)
-           end) =~ ~r"this expression will fail with ArgumentError\n.*nofile:2"
+           end) =~ "#{@argument_error_message} will fail with ArgumentError\n  nofile:2"
 
     assert capture_err(fn ->
              Code.eval_string("""
@@ -946,7 +955,7 @@ defmodule Kernel.WarningTest do
                def foo, do: 1 + nil
              end
              """)
-           end) =~ ~r"this expression will fail with ArithmeticError\n.*nofile:2"
+           end) =~ "#{@arithmetic_error_message} will fail with ArithmeticError\n  nofile:2"
   after
     purge([Sample1, Sample2])
   end

--- a/lib/mix/lib/mix/compilers/erlang.ex
+++ b/lib/mix/lib/mix/compilers/erlang.ex
@@ -271,7 +271,18 @@ defmodule Mix.Compilers.Erlang do
   defp to_diagnostics(warnings_or_errors, severity) do
     for {file, issues} <- warnings_or_errors,
         {line, module, data} <- issues do
-      position = if is_integer(line) and line >= 1, do: line
+      position =
+        case line do
+          # TODO: remove when we require OTP 24
+          line when is_integer(line) and line >= 1 ->
+            line
+
+          {line, _column} when is_integer(line) and line >= 1 ->
+            line
+
+          _ ->
+            nil
+        end
 
       %Mix.Task.Compiler.Diagnostic{
         file: Path.absname(file),

--- a/lib/mix/lib/mix/compilers/erlang.ex
+++ b/lib/mix/lib/mix/compilers/erlang.ex
@@ -271,18 +271,7 @@ defmodule Mix.Compilers.Erlang do
   defp to_diagnostics(warnings_or_errors, severity) do
     for {file, issues} <- warnings_or_errors,
         {line, module, data} <- issues do
-      position =
-        case line do
-          # TODO: remove when we require OTP 24
-          line when is_integer(line) and line >= 1 ->
-            line
-
-          {line, _column} when is_integer(line) and line >= 1 ->
-            line
-
-          _ ->
-            nil
-        end
+      position = line(line)
 
       %Mix.Task.Compiler.Diagnostic{
         file: Path.absname(file),
@@ -299,7 +288,12 @@ defmodule Mix.Compilers.Erlang do
     for {_, warnings} <- entries,
         {file, issues} <- warnings,
         {line, module, message} <- issues do
-      IO.puts("#{file}:#{line}: Warning: #{module.format_error(message)}")
+      IO.puts("#{file}:#{line(line)}: Warning: #{module.format_error(message)}")
     end
   end
+
+  defp line({line, _column}) when is_integer(line) and line >= 1, do: line
+  # TODO: remove when we require OTP 24
+  defp line(line) when is_integer(line) and line >= 1, do: line
+  defp line(_), do: nil
 end

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -100,9 +100,10 @@ defmodule Mix.Tasks.Compile.Erlang do
       file = Erlang.to_erl_file(Path.rootname(input, ".erl"))
 
       case :compile.file(file, erlc_options) do
-        {:error, :badarg} ->
+        # TODO: Don't handle {:error, :badarg} when we require OTP 24
+        error when error == :error or error == {:error, :badarg} ->
           message =
-            "Compiling Erlang #{inspect(file)} failed with ArgumentError, probably because of invalid :erlc_options"
+            "Compiling Erlang file #{inspect(file)} failed, probably because of invalid :erlc_options"
 
           Mix.raise(message)
 

--- a/lib/mix/test/mix/tasks/compile.erlang_test.exs
+++ b/lib/mix/test/mix/tasks/compile.erlang_test.exs
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Compile.ErlangTest do
   @tag erlc_options: [{:d, 'foo', 'bar'}]
   test "raises on invalid erlc_options" do
     in_fixture("compile_erlang", fn ->
-      assert_raise Mix.Error, ~r"failed with ArgumentError", fn ->
+      assert_raise Mix.Error, ~r"Compiling Erlang file '.*' failed", fn ->
         capture_io(fn ->
           Mix.Tasks.Compile.Erlang.run([])
         end)

--- a/lib/mix/test/mix/tasks/compile.yecc_test.exs
+++ b/lib/mix/test/mix/tasks/compile.yecc_test.exs
@@ -23,10 +23,12 @@ defmodule Mix.Tasks.Compile.YeccTest do
         assert %Mix.Task.Compiler.Diagnostic{
                  compiler_name: "yecc",
                  file: ^file,
-                 message: "syntax error before: '.'",
+                 message: message,
                  position: 1,
                  severity: :error
                } = diagnostic
+
+        assert message =~ "syntax error before: "
       end)
 
       assert File.regular?("src/test_ok.erl")


### PR DESCRIPTION
- Update Erlang warnings translation (#10694)
- Fix translating erl compiler errors to diagnostics on OTP 24 (#10719)
- Fix remaining warning translations for OTP 24 (#10720)
- Support 16bit floats in bitstrings (#10740)
- Handle :compile.file/2 returning :error on OTP 24 (#10742)
