### PR TITLE
Optimize Enum.intersperse/2

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1365,6 +1365,13 @@ defmodule Enum do
 
   """
   @spec intersperse(t, element) :: list
+  def intersperse(enumerable, element) when is_list(enumerable) do
+    case enumerable do
+      [] -> []
+      list -> intersperse_non_empty_list(list, element)
+    end
+  end
+
   def intersperse(enumerable, element) do
     list =
       enumerable
@@ -3733,6 +3740,14 @@ defmodule Enum do
 
   defp flat_map_list([], _fun) do
     []
+  end
+
+  ## intersperse
+
+  defp intersperse_non_empty_list([head], _separator), do: [head]
+
+  defp intersperse_non_empty_list([head | rest], separator) do
+    [head, separator | intersperse_non_empty_list(rest, separator)]
   end
 
   ## map_intersperse

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1350,7 +1350,7 @@ defmodule Enum do
   end
 
   @doc """
-  Intersperses `element` between each element of the enumeration.
+  Intersperses `separator` between each element of the enumeration.
 
   ## Examples
 
@@ -1365,20 +1365,20 @@ defmodule Enum do
 
   """
   @spec intersperse(t, element) :: list
-  def intersperse(enumerable, element) when is_list(enumerable) do
+  def intersperse(enumerable, separator) when is_list(enumerable) do
     case enumerable do
       [] -> []
-      list -> intersperse_non_empty_list(list, element)
+      list -> intersperse_non_empty_list(list, separator)
     end
   end
 
-  def intersperse(enumerable, element) do
+  def intersperse(enumerable, separator) do
     list =
       enumerable
-      |> reduce([], fn x, acc -> [x, element | acc] end)
+      |> reduce([], fn x, acc -> [x, separator | acc] end)
       |> :lists.reverse()
 
-    # Head is a superfluous intersperser element
+    # Head is a superfluous separator
     case list do
       [] -> []
       [_ | t] -> t


### PR DESCRIPTION
Hi! `Enum.map_intersperse/3` had an optimized version for lists, but `Enum.interspese/2` didn't.
This optimization can speedup by a factor of ~2x according to [this benchmark](https://github.com/sabiwara/elixir_benches/blob/jit/bench/fast_enum_intersperse.results.txt) (JIT).
I also renamed the `element` param to `separator` to be consistent with `map_intersperse` (which is also clearer IMO).