### PR TITLE
Optimize Enum.join/3 for lists

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1508,14 +1508,14 @@ defmodule Enum do
   @spec join(t, String.t()) :: String.t()
   def join(enumerable, joiner \\ "")
 
-  def join(enumerable, joiner) when is_list(enumerable) and is_binary(joiner) do
-    join_list(enumerable, joiner)
-  end
-
   def join(enumerable, "") do
     enumerable
     |> map(&entry_to_string(&1))
     |> IO.iodata_to_binary()
+  end
+
+  def join(enumerable, joiner) when is_list(enumerable) and is_binary(joiner) do
+    join_list(enumerable, joiner)
   end
 
   def join(enumerable, joiner) when is_binary(joiner) do
@@ -3759,18 +3759,9 @@ defmodule Enum do
   defp join_list([], _joiner), do: ""
 
   defp join_list(list, joiner) do
-    case joiner do
-      "" -> do_join_list(list, [])
-      _ -> join_non_empty_list(list, joiner, [])
-    end
+    join_non_empty_list(list, joiner, [])
     |> :lists.reverse()
     |> IO.iodata_to_binary()
-  end
-
-  defp do_join_list([], acc), do: acc
-
-  defp do_join_list([first | rest], acc) do
-    do_join_list(rest, [entry_to_string(first) | acc])
   end
 
   defp join_non_empty_list([first], _joiner, acc), do: [entry_to_string(first) | acc]

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1508,6 +1508,10 @@ defmodule Enum do
   @spec join(t, String.t()) :: String.t()
   def join(enumerable, joiner \\ "")
 
+  def join(enumerable, joiner) when is_list(enumerable) and is_binary(joiner) do
+    join_list(enumerable, joiner)
+  end
+
   def join(enumerable, "") do
     enumerable
     |> map(&entry_to_string(&1))
@@ -3748,6 +3752,31 @@ defmodule Enum do
 
   defp intersperse_non_empty_list([head | rest], separator) do
     [head, separator | intersperse_non_empty_list(rest, separator)]
+  end
+
+  ## join
+
+  defp join_list([], _joiner), do: ""
+
+  defp join_list(list, joiner) do
+    case joiner do
+      "" -> do_join_list(list, [])
+      _ -> join_non_empty_list(list, joiner, [])
+    end
+    |> :lists.reverse()
+    |> IO.iodata_to_binary()
+  end
+
+  defp do_join_list([], acc), do: acc
+
+  defp do_join_list([first | rest], acc) do
+    do_join_list(rest, [entry_to_string(first) | acc])
+  end
+
+  defp join_non_empty_list([first], _joiner, acc), do: [entry_to_string(first) | acc]
+
+  defp join_non_empty_list([first | rest], joiner, acc) do
+    join_non_empty_list(rest, joiner, [joiner, entry_to_string(first) | acc])
   end
 
   ## map_intersperse


### PR DESCRIPTION
Hi again. I tried to see if `Enum.join` could be improved as well for lists, and it seems that this version can be ~40% faster [with the JIT](https://github.com/sabiwara/elixir_benches/blob/jit/bench/fast_enum_join.results.txt), ~30% [with OTP23](https://github.com/sabiwara/elixir_benches/blob/main/bench/fast_enum_join.results.txt).
Note: I first tried [with body recursion](https://github.com/sabiwara/elixir_benches/commit/ed9c364a5c41a8beed8190898d3a3602c8ab8375), but the result was not so convincing: TCO seems to make a noticeable difference, especially the JIT seems to like it.