### PR TITLE
Refine docstring for String.duplicate

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1595,7 +1595,7 @@ defmodule String do
   @compile {:inline, duplicate: 2}
 
   @doc """
-  Returns a string `subject` duplicated `n` times.
+  Returns a string `subject` repeated `n` times.
 
   Inlined by the compiler.
 


### PR DESCRIPTION
Duplicate `n` times might sound unusual to some. This commit changes the docstring for `String.duplicate` to use repeat.

See also https://lodash.com/docs/4.17.15#repeat .

It might be worth renaming / aliasing the method in the future.