### PR TITLE
Add documentation for `Kernel.apply/x` regarding when not to use it

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -276,6 +276,10 @@ defmodule Kernel do
   Invokes the given anonymous function `fun` with the list of
   arguments `args`.
 
+  If the number of arguments and the function name are known at compile time,
+  use `fun.(arg_1, arg_2, ..., arg_n)` instead of
+  `apply(fun, [arg_1, arg_2, ..., arg_n])`.
+
   Inlined by the compiler.
 
   ## Examples
@@ -296,6 +300,10 @@ defmodule Kernel do
   `apply/3` is used to invoke functions where the module, function
   name or arguments are defined dynamically at runtime. For this
   reason, you can't invoke macros using `apply/3`, only functions.
+
+  If the number of arguments and the function name are known at compile time,
+  use `module.function(arg_1, arg_2, ..., arg_n)` instead of
+  `apply(module, :function, [arg_1, arg_2, ..., arg_n])`.
 
   Inlined by the compiler.
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -276,8 +276,8 @@ defmodule Kernel do
   Invokes the given anonymous function `fun` with the list of
   arguments `args`.
 
-  If the number of arguments is known at compile time,
-  use `fun.(arg_1, arg_2, ..., arg_n)` instead of
+  If the number of arguments is known at compile time, prefer
+  `fun.(arg_1, arg_2, ..., arg_n)` as it is clearer than
   `apply(fun, [arg_1, arg_2, ..., arg_n])`.
 
   Inlined by the compiler.
@@ -302,7 +302,7 @@ defmodule Kernel do
   reason, you can't invoke macros using `apply/3`, only functions.
 
   If the number of arguments and the function name are known at compile time,
-  use `module.function(arg_1, arg_2, ..., arg_n)` instead of
+  prefer `module.function(arg_1, arg_2, ..., arg_n)` as it is clearer than
   `apply(module, :function, [arg_1, arg_2, ..., arg_n])`.
 
   Inlined by the compiler.

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -276,7 +276,7 @@ defmodule Kernel do
   Invokes the given anonymous function `fun` with the list of
   arguments `args`.
 
-  If the number of arguments and the function name are known at compile time,
+  If the number of arguments is known at compile time,
   use `fun.(arg_1, arg_2, ..., arg_n)` instead of
   `apply(fun, [arg_1, arg_2, ..., arg_n])`.
 


### PR DESCRIPTION
Add usage documentation to `Kernel.apply/2` and `Kernel.apply/3` to let developers know to use it only when they don't know the arity of the function or the name of the function. 

Similar to [this erlang documentation](https://erlang.org/doc/man/erlang.html#apply-3). Specifically this line:
> If the number of arguments are known at compile time, the call is better written as Module:Function(Arg1, Arg2, ..., ArgN).