### PR TITLE
CI: Upgrade FreeBSD to 12.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,11 +12,11 @@ test_template: &DEFAULT_TEST_SETTINGS
 test_freebsd_task:
   <<: *DEFAULT_TEST_SETTINGS
 
-  name: FreeBSD 12.1
+  name: FreeBSD 12.2
   alias: FreeBSD Stable
 
   freebsd_instance:
-    image_family: freebsd-12-1
+    image_family: freebsd-12-2
     cpu: 8
     memory: 7424Mi
 


### PR DESCRIPTION
This should also fix the problems with the Erlang installation that happened on 12.1.