### PR TITLE
Fix prefix check when consolidating protocols

### DIFF
--- a/lib/mix/lib/mix/tasks/compile.protocols.ex
+++ b/lib/mix/lib/mix/tasks/compile.protocols.ex
@@ -113,7 +113,7 @@ defmodule Mix.Tasks.Compile.Protocols do
   end
 
   defp filter_otp(paths, otp) do
-    Enum.filter(paths, &(not :lists.prefix(&1, otp)))
+    Enum.filter(paths, &(not :lists.prefix(otp, &1)))
   end
 
   defp consolidate([], _paths, output, manifest, metadata, _opts) do


### PR DESCRIPTION
If I'm reading this line of code correctly it's intended to ignore any Erlang paths when looking for protocols and their implementations. However, the call order appears backwards to me.

With [:lists.prefix/2](https://erlang.org/doc/man/lists.html#prefix-2) the prefix is supposed to be the first argument. It's used correctly when [extracting protocols and implementations](https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/protocol.ex#L495) down the line.

That check when extracting protocols and implementations rejects any BEAM files in the directories missed by this check, so protocols still consolidate correctly. The `filter_otp/2` function just doesn't do anything as it stands right now.

How that looks on my machine:
```elixir
otp = :code.lib_dir()
#=> '/Users/brettbeatty/.asdf/installs/erlang/23.2.3/lib'

path = :code.get_path() |> Enum.at(8)
#=> '/Users/brettbeatty/.asdf/installs/erlang/23.2.3/lib/stdlib-3.14/ebin'

:lists.prefix(path, otp)
#=> false

:lists.prefix(otp, path)
#=> true
```

I'm not sure what the best way to test this change is since the end result is the same.