### PR TITLE
Use :os.env/0 in System.get_env if available

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -604,12 +604,21 @@ defmodule System do
   Variable names and their values are strings.
   """
   @spec get_env() :: %{optional(String.t()) => String.t()}
-  def get_env do
-    Enum.into(:os.getenv(), %{}, fn var ->
-      var = IO.chardata_to_string(var)
-      [k, v] = String.split(var, "=", parts: 2)
-      {k, v}
-    end)
+
+  if function_exported?(:os, :env, 0) do
+    def get_env do
+      Map.new(:os.env(), fn {k, v} ->
+        {IO.chardata_to_string(k), IO.chardata_to_string(v)}
+      end)
+    end
+  else
+    def get_env do
+      Enum.into(:os.getenv(), %{}, fn var ->
+        var = IO.chardata_to_string(var)
+        [k, v] = String.split(var, "=", parts: 2)
+        {k, v}
+      end)
+    end
   end
 
   @doc """

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -603,16 +603,14 @@ defmodule System do
   The returned value is a map containing name-value pairs.
   Variable names and their values are strings.
   """
+  # TODO: Remove this once we require Erlang/OTP 24+
   @spec get_env() :: %{optional(String.t()) => String.t()}
-
-  if function_exported?(:os, :env, 0) do
-    def get_env do
+  def get_env do
+    if function_exported?(:os, :env, 0) do
       Map.new(:os.env(), fn {k, v} ->
         {IO.chardata_to_string(k), IO.chardata_to_string(v)}
       end)
-    end
-  else
-    def get_env do
+    else
       Enum.into(:os.getenv(), %{}, fn var ->
         var = IO.chardata_to_string(var)
         [k, v] = String.split(var, "=", parts: 2)

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -597,6 +597,9 @@ defmodule System do
     end
   end
 
+  # TODO: Remove this once we require Erlang/OTP 24+
+  @compile {:no_warn_undefined, {:os, :env, 0}}
+
   @doc """
   Returns all system environment variables.
 


### PR DESCRIPTION
Ref https://github.com/elixir-lang/elixir/issues/10433

`:os.env/0` is available in [OTP 24](https://erlang.org/download/OTP-24.0-rc1.README) as OTP-16793

Note that the CI matrix doesn't include OTP 24 yet.