### PR TITLE
docs: GenServer.start_link/3 instead of GenServer.start_link/2

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -52,7 +52,7 @@ defmodule GenServer do
       GenServer.call(pid, :pop)
       #=> :world
 
-  We start our `Stack` by calling `start_link/2`, passing the module
+  We start our `Stack` by calling `start_link/3`, passing the module
   with the server implementation and its initial argument (a list
   representing the stack containing the element `:hello`). We can primarily
   interact with the server by sending two types of messages. **call**


### PR DESCRIPTION
as We were saying: `Although in the example above we have used` `GenServer.start_link/3` at: https://github.com/elixir-lang/elixir/blob/3e453df186f474a3a74223ebba972d2006f34fc4/lib/elixir/lib/gen_server.ex#L70
And I didn't see `GenServer.start_link/2` exists.
