### PR TITLE
Copy upstream documentation change about regex ascii character class deficiency

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -107,7 +107,6 @@ defmodule Regex do
 
     * alnum - Letters and digits
     * alpha - Letters
-    * ascii - Character codes 0-127
     * blank - Space or tab only
     * cntrl - Control characters
     * digit - Decimal digits (same as \\d)
@@ -119,6 +118,11 @@ defmodule Regex do
     * upper - Uppercase letters
     * word  - "Word" characters (same as \w)
     * xdigit - Hexadecimal digits
+   
+  There is another character class, `ascii`, that erroneously matches
+  Latin-1 characters instead of the 0-127 range specified by POSIX. This
+  cannot be fixed without altering the behaviour of other classes, so we
+  recommend matching the range with `[\\0-\x7f]` instead.
 
   Note the behaviour of those classes may change according to the Unicode
   and other modifiers:


### PR DESCRIPTION
See:
https://github.com/erlang/otp/pull/4551/files