### PR TITLE
Fix typo in Mix.Tasks.Test module document

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -113,7 +113,7 @@ defmodule Mix.Tasks.Test do
 
     * `--exclude` - excludes tests that match the filter
 
-    * `--export-coverage` - the name of the file to export coverage results too.
+    * `--export-coverage` - the name of the file to export coverage results to.
       Only has an effect when used with `--cover`
 
     * `--failed` - runs only tests that failed the last time they ran


### PR DESCRIPTION
The --export-coverage option specify the result files. This commit make it clear that it means the name of the file you want to export the result file to.