### PR TITLE
Add Enum.find!

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1121,6 +1121,7 @@ defmodule Enum do
       ** (Enum.NotFoundError) not found error
 
   """
+  @doc since: "1.12.0"
   @spec find!(t, (element -> any)) :: element
   def find!(enumerable, fun)
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1330,6 +1330,10 @@ defmodule Enum.EmptyError do
   defexception message: "empty error"
 end
 
+defmodule Enum.NotFoundError do
+  defexception message: "not found error"
+end
+
 defmodule File.Error do
   defexception [:reason, :path, action: ""]
 

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -291,6 +291,14 @@ defmodule EnumTest do
     assert Enum.find([2, 3, 4], fn x -> rem(x, 2) == 1 end) == 3
   end
 
+  test "find!/2" do
+    assert_raise Enum.NotFoundError,
+                 "not found error",
+                 fn -> Enum.find!([2, 4, 6], fn x -> rem(x, 2) == 1 end) end
+
+    assert Enum.find!([2, 3, 4], fn x -> rem(x, 2) == 1 end) == 3
+  end
+
   test "find_index/2" do
     assert Enum.find_index([2, 4, 6], fn x -> rem(x, 2) == 1 end) == nil
     assert Enum.find_index([2, 3, 4], fn x -> rem(x, 2) == 1 end) == 1
@@ -1487,6 +1495,15 @@ defmodule EnumTest.Range do
     assert Enum.find(2..6, fn x -> rem(x, 2) == 1 end) == 3
     assert Enum.find(2..6, fn _ -> false end) == nil
     assert Enum.find(2..6, 0, fn _ -> false end) == 0
+  end
+
+  test "find!/2" do
+    assert Enum.find!(2..6, fn x -> rem(x, 2) == 0 end) == 2
+    assert Enum.find!(2..6, fn x -> rem(x, 2) == 1 end) == 3
+
+    assert_raise Enum.NotFoundError, "not found error", fn ->
+      Enum.find!(2..6, fn _ -> false end)
+    end
   end
 
   test "find_index/2" do


### PR DESCRIPTION
When you are expecting at least one value to exist in `Enum.find`, you currently have to either implement your own default/nil check, or risk passing a nil or some other bad value on to the rest of your code, causing a confusing failure elsewhere (nil creep). Being able to simply call `Enum.find!` instead of `Enum.find` would allow you to efficiently ensure the code stops (let it crash) in an unexpected state.