### PR TITLE
raise FunctionClauseError when passing invalid arguments to Date.compare/2

### DIFF
--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -500,8 +500,8 @@ defmodule Date do
     end
   end
 
-  def compare(date1, date2) do
-    if Calendar.compatible_calendars?(date1.calendar, date2.calendar) do
+  def compare(%{calendar: calendar1} = date1, %{calendar: calendar2} = date2) do
+    if Calendar.compatible_calendars?(calendar1, calendar2) do
       case {to_iso_days(date1), to_iso_days(date2)} do
         {first, second} when first > second -> :gt
         {first, second} when first < second -> :lt


### PR DESCRIPTION
I accidentally passed a `nil` value to `Date.compare/2` and got an UndefinedFunctionError:

```elixir
iex(41)> Date.compare Date.utc_today, nil
** (UndefinedFunctionError) function nil.calendar/0 is undefined. If you are using the dot syntax, such as map.field or module.function(), make sure the left side of the dot is an atom or a map
    nil.calendar()
    (elixir 1.11.1) lib/calendar/date.ex:504: Date.compare/2
```

I think a FunctionClauseError would be more appropriate (and helpful) as it would provide a nice hint about what went wrong, similar to convert:
```elixir
iex(1)> Date.convert nil, Date.utc_today()
** (FunctionClauseError) no function clause matching in Date.convert/2    
    
    The following arguments were given to Date.convert/2:
    
        # 1
        nil
    
        # 2
        ~D[2021-03-08]
    
    Attempted function clauses (showing 2 out of 2):
    
        def convert(%{calendar: calendar, year: year, month: month, day: day}, calendar)
        def convert(%{calendar: calendar} = date, target_calendar)
    
    (elixir 1.11.1) lib/calendar/date.ex:541: Date.convert/2
```

Hope this helps.