### PR TITLE
Add arities to `is_function` guards

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -795,7 +795,7 @@ defmodule Access do
   """
   @doc since: "1.6.0"
   @spec filter((term -> boolean)) :: access_fun(data :: list, get_value :: list)
-  def filter(func) when is_function(func) do
+  def filter(func) when is_function(func, 1) do
     fn op, data, next -> filter(op, data, func, next) end
   end
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1292,7 +1292,7 @@ defmodule Enum do
   """
   @doc since: "1.10.0"
   @spec frequencies_by(t, (element -> any)) :: map
-  def frequencies_by(enumerable, key_fun) when is_function(key_fun) do
+  def frequencies_by(enumerable, key_fun) when is_function(key_fun, 1) do
     reduce(enumerable, %{}, fn entry, acc ->
       key = key_fun.(entry)
 
@@ -1323,7 +1323,7 @@ defmodule Enum do
   @spec group_by(t, (element -> any), (element -> any)) :: map
   def group_by(enumerable, key_fun, value_fun \\ fn x -> x end)
 
-  def group_by(enumerable, key_fun, value_fun) when is_function(key_fun) do
+  def group_by(enumerable, key_fun, value_fun) when is_function(key_fun, 1) do
     reduce(reverse(enumerable), %{}, fn entry, acc ->
       key = key_fun.(entry)
       value = value_fun.(entry)

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -235,7 +235,7 @@ defmodule List do
 
   """
   @spec foldl([elem], acc, (elem, acc -> acc)) :: acc when elem: var, acc: var
-  def foldl(list, acc, fun) when is_list(list) and is_function(fun) do
+  def foldl(list, acc, fun) when is_list(list) and is_function(fun, 2) do
     :lists.foldl(fun, acc, list)
   end
 
@@ -250,7 +250,7 @@ defmodule List do
 
   """
   @spec foldr([elem], acc, (elem, acc -> acc)) :: acc when elem: var, acc: var
-  def foldr(list, acc, fun) when is_list(list) and is_function(fun) do
+  def foldr(list, acc, fun) when is_list(list) and is_function(fun, 2) do
     :lists.foldr(fun, acc, list)
   end
 
@@ -691,7 +691,8 @@ defmodule List do
 
   """
   @spec update_at([elem], integer, (elem -> any)) :: list when elem: var
-  def update_at(list, index, fun) when is_list(list) and is_function(fun) and is_integer(index) do
+  def update_at(list, index, fun)
+      when is_list(list) and is_function(fun, 1) and is_integer(index) do
     if index < 0 do
       case length(list) + index do
         index when index < 0 -> list
@@ -1058,7 +1059,7 @@ defmodule List do
   @spec myers_difference(list, list, (term, term -> script | nil)) :: script
         when script: [{:eq | :ins | :del | :diff, list}]
   def myers_difference(list1, list2, diff_script)
-      when is_list(list1) and is_list(list2) and is_function(diff_script) do
+      when is_list(list1) and is_list(list2) and is_function(diff_script, 2) do
     myers_difference_with_diff_script(list1, list2, diff_script)
   end
 


### PR DESCRIPTION
Hi! I spotted several `is_function` guards that are not checking for the arity, but where the actual function signature clearly expects a specific arity. This PR makes these guards more specific.