### PR TITLE
Clarify what type1 and type2 mean in maybe_improper_list typespec

### DIFF
--- a/lib/elixir/pages/typespecs.md
+++ b/lib/elixir/pages/typespecs.md
@@ -62,8 +62,8 @@ The notation to represent the union of types is the pipe `|`. For example, the t
                                                         ## Lists
           | list(type)                                  # proper list ([]-terminated)
           | nonempty_list(type)                         # non-empty proper list
-          | maybe_improper_list(type1, type2)           # proper or improper list
-          | nonempty_improper_list(type1, type2)        # improper list
+          | maybe_improper_list(type1, type2)           # proper or improper list (type1 = contents, type2 = termination)
+          | nonempty_improper_list(type1, type2)        # improper list (type1 and typ2 same as above)
           | nonempty_maybe_improper_list(type1, type2)  # non-empty proper or improper list
 
           | Literals                # Described in section "Literals"


### PR DESCRIPTION
The typespecs for `maybe_improper_list` and `nonempty_improper_list` have little documentation, both in Elixir and Erlang docs. While the name is self-explanatory, the meaning of `type1` amd `type2` in the expression `maybe_improper_list(type1, type2)` is not clarified.

The [Erlang docs on typespecs](https://erlang.org/doc/reference_manual/typespec.html) have the following comments:
```erlang
| maybe_improper_list(Type1, Type2)    %% Type1=contents, Type2=termination
| nonempty_improper_list(Type1, Type2) %% Type1 and Type2 as above
```

This PR just mirrors these two comments in the Elixir docs.