### PR TITLE
Improve improper lists typespecs readability

### DIFF
--- a/lib/elixir/pages/typespecs.md
+++ b/lib/elixir/pages/typespecs.md
@@ -59,12 +59,12 @@ The notation to represent the union of types is the pipe `|`. For example, the t
           | non_neg_integer()       # 0, 1, 2, 3, ...
           | pos_integer()           # 1, 2, 3, ...
 
-                                                        ## Lists
-          | list(type)                                  # proper list ([]-terminated)
-          | nonempty_list(type)                         # non-empty proper list
-          | maybe_improper_list(type1, type2)           # proper or improper list (type1 = contents, type2 = termination)
-          | nonempty_improper_list(type1, type2)        # improper list (type1 and type2 same as above)
-          | nonempty_maybe_improper_list(type1, type2)  # non-empty proper or improper list
+                                                                          ## Lists
+          | list(type)                                                    # proper list ([]-terminated)
+          | nonempty_list(type)                                           # non-empty proper list
+          | maybe_improper_list(content_type, termination_type)           # proper or improper list
+          | nonempty_improper_list(content_type, termination_type)        # improper list
+          | nonempty_maybe_improper_list(content_type, termination_type)  # non-empty proper or improper list
 
           | Literals                # Described in section "Literals"
           | BuiltIn                 # Described in section "Built-in types"


### PR DESCRIPTION
This is a follow up of #10780

As noted by @eksperimental, it would be more readable if `type1` and `type2` would be renamed instead of adding additional comments to clarify their meaning.
Additionally, `nonempty_maybe_improper_list/2` was left untouched in the previous PR.