### PR TITLE
Make default handler process Elixir logs

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -249,7 +249,7 @@ defmodule Logger do
   `Logger.metadata/1` applies to both, and so on.
 
   Elixir also supports formatting Erlang reports using Elixir syntax.
-  This can be controlled with two configurations:
+  This can be controlled with three configurations:
 
     * `:handle_otp_reports` - redirects OTP reports to `Logger` so
       they are formatted in Elixir terms. This effectively disables
@@ -262,6 +262,10 @@ defmodule Logger do
       in Erlang syntax until the Logger application kicks in.
       Defaults to `false`. This option only has an effect if
       `:handle_otp_reports` is true.
+
+    * `:use_erlang_default_handler` - add logging filter to `:default`
+      handler defined by the OTP. This option only has an effect if
+      `:handle_otp_reports` is false.
 
   For example, to configure `Logger` to redirect all Erlang messages using a
   `config/config.exs` file:

--- a/lib/logger/lib/logger/app.ex
+++ b/lib/logger/lib/logger/app.ex
@@ -9,6 +9,7 @@ defmodule Logger.App do
   def start(_type, _args) do
     start_options = Application.get_env(:logger, :start_options)
     otp_reports? = Application.fetch_env!(:logger, :handle_otp_reports)
+    use_erlang_default? = Application.fetch_env!(:logger, :use_erlang_default_handler)
     config = Logger.Counter.new()
 
     children = [
@@ -29,6 +30,16 @@ defmodule Logger.App do
           if otp_reports? do
             delete_erlang_handler()
           else
+            # Make default handler log messages sent from Elixir
+            if use_erlang_default? do
+              _ =
+                :logger.add_handler_filter(
+                  :default,
+                  :elixir_filter,
+                  {&:logger_filters.domain/2, {:log, :sub, [:elixir]}}
+                )
+            end
+
             []
           end
 

--- a/lib/logger/mix.exs
+++ b/lib/logger/mix.exs
@@ -22,6 +22,7 @@ defmodule Logger.MixProject do
         discard_threshold: 500,
         handle_otp_reports: true,
         handle_sasl_reports: false,
+        use_erlang_default_handler: false,
         discard_threshold_periodic_check: 30_000,
         discard_threshold_for_error_logger: 500,
         compile_time_purge_matching: [],


### PR DESCRIPTION
By default `default` handler will process messages coming only from `[opt, sasl]` and `[]` (empty) domain. This commit adds configuration option that will allow setting Logger to add additional filter to `default` handler, so Elixir messages will be logged as well.

Current workaround is to call

```elixir
:logger.add_handler_filter(
  :default,
  :elixir_filter,
  {&:logger_filters.domain/2, {:log, :sub, [:elixir]}
)
```

Somewhere in your application during startup, but that makes it lost log messages that happened between Logger startup and application startup, so for example early boot logs from all dependencies can be lost.

Now if user want to handle Elixir messages in `default` handler, then they need to use:

```elixir
config :logger,
  handle_otp_reports: false,
  use_erlang_default_handler: true
```