### PR TITLE
Parallelize compile.erlang

### DIFF
--- a/lib/mix/lib/mix/compilers/erlang.ex
+++ b/lib/mix/lib/mix/compilers/erlang.ex
@@ -12,6 +12,15 @@ defmodule Mix.Compilers.Erlang do
 
   `mappings` should be a list of tuples in the form of `{src, dest}` paths.
 
+  ## Options
+
+    * `:force` - forces compilation regardless of modification times
+
+    * `:parallel` - if `true` all files will be compiled in parallel,
+      otherwise the given list of source file names will be compiled
+      in parallel, all other files are compiled serially before the
+      parallel files
+
   ## Examples
 
   For example, a simple compiler for Lisp Flavored Erlang
@@ -74,6 +83,16 @@ defmodule Mix.Compilers.Erlang do
   A `manifest` file and a `callback` to be invoked for each src/dest pair
   must be given. A src/dest pair where destination is `nil` is considered
   to be up to date and won't be (re-)compiled.
+
+  ## Options
+
+    * `:force` - forces compilation regardless of modification times
+
+    * `:parallel` - if `true` all files will be compiled in parallel,
+      otherwise the given list of source file names will be compiled
+      in parallel, all other files are compiled serially before the
+      parallel files
+
   """
   def compile(manifest, mappings, opts \\ [], callback) do
     compile(manifest, mappings, :erl, opts, callback)
@@ -119,16 +138,21 @@ defmodule Mix.Compilers.Erlang do
       # and what not).
       Code.prepend_path(Mix.Project.compile_path())
 
-      parallel_sources = opts[:parallel] || MapSet.new()
-
       {parallel, serial} =
-        Enum.split_with(stale, fn {source, _target} -> source in parallel_sources end)
+        case opts[:parallel] || false do
+          true -> {stale, []}
+          false -> {[], stale}
+          parallel -> Enum.split_with(stale, fn {source, _target} -> source in parallel end)
+        end
 
       serial_results = Enum.map(serial, &do_compile(&1, callback, timestamp, verbose))
 
       parallel_results =
         parallel
-        |> Task.async_stream(&do_compile(&1, callback, timestamp, verbose), timeout: :infinity)
+        |> Task.async_stream(&do_compile(&1, callback, timestamp, verbose),
+          timeout: :infinity,
+          ordered: false
+        )
         |> Enum.map(fn {:ok, result} -> result end)
 
       # Compile stale files and print the results

--- a/lib/mix/lib/mix/shell/process.ex
+++ b/lib/mix/lib/mix/shell/process.ex
@@ -64,7 +64,7 @@ defmodule Mix.Shell.Process do
   """
   def print_app do
     if name = Mix.Shell.printable_app_name() do
-      send(self(), {:mix_shell, :info, ["==> #{name}"]})
+      send(message_target(), {:mix_shell, :info, ["==> #{name}"]})
     end
   end
 
@@ -73,7 +73,7 @@ defmodule Mix.Shell.Process do
   """
   def info(message) do
     print_app()
-    send(self(), {:mix_shell, :info, [format(message)]})
+    send(message_target(), {:mix_shell, :info, [format(message)]})
     :ok
   end
 
@@ -82,7 +82,7 @@ defmodule Mix.Shell.Process do
   """
   def error(message) do
     print_app()
-    send(self(), {:mix_shell, :error, [format(message)]})
+    send(message_target(), {:mix_shell, :error, [format(message)]})
     :ok
   end
 
@@ -112,7 +112,7 @@ defmodule Mix.Shell.Process do
   """
   def prompt(message) do
     print_app()
-    send(self(), {:mix_shell, :prompt, [message]})
+    send(message_target(), {:mix_shell, :prompt, [message]})
 
     receive do
       {:mix_shell_input, :prompt, response} -> response
@@ -140,7 +140,7 @@ defmodule Mix.Shell.Process do
   """
   def yes?(message) do
     print_app()
-    send(self(), {:mix_shell, :yes?, [message]})
+    send(message_target(), {:mix_shell, :yes?, [message]})
 
     receive do
       {:mix_shell_input, :yes?, response} -> response
@@ -158,7 +158,14 @@ defmodule Mix.Shell.Process do
 
     Mix.Shell.cmd(command, opts, fn data ->
       if print_app?, do: print_app()
-      send(self(), {:mix_shell, :run, [data]})
+      send(message_target(), {:mix_shell, :run, [data]})
     end)
+  end
+
+  defp message_target() do
+    case Process.get(:"$callers") do
+      [parent | _] -> parent
+      _ -> self()
+    end
   end
 end

--- a/lib/mix/lib/mix/tasks/compile.leex.ex
+++ b/lib/mix/lib/mix/tasks/compile.leex.ex
@@ -54,6 +54,8 @@ defmodule Mix.Tasks.Compile.Leex do
       Mix.raise(":leex_options should be a list of options, got: #{inspect(options)}")
     end
 
+    opts = [parallel: true] ++ opts
+
     Erlang.compile(manifest(), mappings, :xrl, :erl, opts, fn input, output ->
       Erlang.ensure_application!(:parsetools, input)
       options = options ++ @forced_opts ++ [scannerfile: Erlang.to_erl_file(output)]

--- a/lib/mix/lib/mix/tasks/compile.yecc.ex
+++ b/lib/mix/lib/mix/tasks/compile.yecc.ex
@@ -54,6 +54,8 @@ defmodule Mix.Tasks.Compile.Yecc do
       Mix.raise(":yecc_options should be a list of options, got: #{inspect(options)}")
     end
 
+    opts = [parallel: true] ++ opts
+
     Erlang.compile(manifest(), mappings, :yrl, :erl, opts, fn input, output ->
       Erlang.ensure_application!(:parsetools, input)
       options = options ++ @forced_opts ++ [parserfile: Erlang.to_erl_file(output)]


### PR DESCRIPTION
Improves the compilation time of [erlang-jose](https://github.com/potatosalad/erlang-jose) from 3.7s to 1.6s and increases CPU utilization from 125% to 400% on my machine.

Closes #10690.