### PR TITLE
Fix old consolidated protocols being used in test coverage when protocol consolidation is disabled.

### DIFF
--- a/lib/mix/lib/mix/project.ex
+++ b/lib/mix/lib/mix/project.ex
@@ -137,7 +137,7 @@ defmodule Mix.Project do
     [
       build_embedded: config[:build_embedded],
       build_per_environment: config[:build_per_environment],
-      consolidate_protocols: false,
+      consolidate_protocols: config[:consolidate_protocols],
       consolidation_path: consolidation_path(config),
       deps_path: deps_path(config),
       env_path: build_path(config)


### PR DESCRIPTION
It appears that running tests with code coverage will use consolidated protocols (if they exist) regardless if protocol consolidation is enabled. I have a repo that reliably reproduces this here: https://github.com/baseballlover723/mix_consolidate_protocols.

I only tested this with turning protocol consolidation on and off, but I would presume that this would cause issues if the protocol is changed.

I'm not sure if https://github.com/elixir-lang/elixir/issues/3152 (https://github.com/elixir-lang/elixir/commit/6b7bf013f5b40f8fe05df201c52f23fd0f0f0944) is still an issue, or if its just vestigial at this point.

Another course of action could be to modify `mix clean` to clean the consolidated protocols, because it currently doesn't for umbrella projects (unsure about non umbrella projects)