### PR TITLE
update `mix test --failed` test comment

### DIFF
--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -214,7 +214,9 @@ defmodule Mix.Tasks.TestTest do
         System.put_env("PASS_FAILING_TESTS", "true")
         assert mix(["test", "--failed"]) =~ "2 tests, 0 failures"
 
-        # Nothing should get run if we try it again since everything is passing.
+        # All tests should be run if we try it again with no failing tests.
+        # This prevents `mix test --failed` from passing in cases where
+        # `mix test` had a compilation error before having failing tests.
         output = mix(["test", "--failed"])
         assert output =~ "No pending --failed tests, re-running all available tests..."
         assert output =~ "4 tests, 0 failures"

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -217,6 +217,7 @@ defmodule Mix.Tasks.TestTest do
         # All tests should be run if we try it again with no failing tests.
         # This prevents `mix test --failed` from passing in cases where
         # `mix test` had a compilation error before having failing tests.
+        # It also provides a better workflow as you can always run with --failed.
         output = mix(["test", "--failed"])
         assert output =~ "No pending --failed tests, re-running all available tests..."
         assert output =~ "4 tests, 0 failures"


### PR DESCRIPTION
this became outdated with the recent changes to `mix test --failed`
to run all tests when there are no failing tests.