### PR TITLE
Clarify syntax for prepending an element to a list

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -15,7 +15,7 @@ defmodule List do
       iex> [1, true, 2, false, 3, true] -- [true, false]
       [1, 2, 3, true]
 
-  An element can be prepended to a list with the pipe (`|`) syntax:
+  An element can be prepended to a list using `|`:
 
       iex> new = 0
       iex> list = [1, 2, 3]

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -15,6 +15,13 @@ defmodule List do
       iex> [1, true, 2, false, 3, true] -- [true, false]
       [1, 2, 3, true]
 
+  An element can be prepended to a list with the pipe (`|`) syntax:
+
+      iex> new = 0
+      iex> list = [1, 2, 3]
+      iex> [new | list]
+      [0, 1, 2, 3]
+
   Lists in Elixir are effectively linked lists, which means
   they are internally represented in pairs containing the
   head and the tail of a list:


### PR DESCRIPTION
I've looked through the Getting Started guide and the List docs but I was unable to find anywhere that makes it clear that this is the syntax to add an element to the head of a list. The closest I could find is later in the same section where speed of prepending vs appending is discussed. However, there and throughout the docs it is only implicitly used.

This PR is just a suggestion for how an explanation of the list prepend syntax could be added.

I was also considering a further sentence stating that the reverse does not work as expected as it will create an improper list.