### PR TITLE
Added Path.expand tilde expansion for certain user

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -685,14 +685,9 @@ defmodule Path do
 
   defp resolve_home(rest) do
     case {rest, major_os_type()} do
-      {"\\" <> _, :win32} ->
-        System.user_home!() <> rest
-
-      {"/" <> _, _} ->
-        System.user_home!() <> rest
-
-      _ ->
-        expand_user_home(rest)
+      {"\\" <> _, :win32} -> System.user_home!() <> rest
+      {"/" <> _, _} -> System.user_home!() <> rest
+      _ -> expand_user_home(rest)
     end
   end
 

--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -685,9 +685,26 @@ defmodule Path do
 
   defp resolve_home(rest) do
     case {rest, major_os_type()} do
-      {"\\" <> _, :win32} -> System.user_home!() <> rest
-      {"/" <> _, _} -> System.user_home!() <> rest
-      _ -> "~" <> rest
+      {"\\" <> _, :win32} ->
+        System.user_home!() <> rest
+
+      {"/" <> _, _} ->
+        System.user_home!() <> rest
+
+      _ ->
+        expand_user_home(rest)
+    end
+  end
+
+  defp expand_user_home(from_user) do
+    [user | rest] = String.split(from_user, "/")
+    rest = Enum.join(rest, "/")
+    user_home = "/home/" <> user
+
+    if File.dir?(user_home) do
+      user_home <> "/" <> rest
+    else
+      "~" <> from_user
     end
   end
 


### PR DESCRIPTION
I am of the opinion that `~user` should expand to `/home/user` so I added a  function which, first verifies whether `/home/user` exists and then expands if it does exist.
Since this is an expand  command and, the way I see it, it's supposed to mimic shell behaviour, I believe this should be the default behaviour.

I attach a screenshot of the comparison between shell expansion and default expansion with Path.expand before my added changes.
![image](https://user-images.githubusercontent.com/56790511/111467575-7f545780-871c-11eb-9308-94a31801f285.png)
