### PR TITLE
Add support for stepped ranges

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -12,7 +12,7 @@ defmodule Code.Formatter do
   @empty empty()
   @ampersand_prec Code.Identifier.unary_op(:&) |> elem(1)
 
-  # Operator that are composed of multiple binary operators
+  # Operators that are composed of multiple binary operators
   @multi_binary_operators [:..//]
 
   # Operators that do not have space between operands

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -13,7 +13,7 @@ defmodule Code.Formatter do
   @ampersand_prec Code.Identifier.unary_op(:&) |> elem(1)
 
   # Operators that do not have space between operands
-  @no_space_binary_operators [:..]
+  @no_space_binary_operators [:.., :"//"]
 
   # Operators that do not have newline between operands (as well as => and keywords)
   @no_newline_binary_operators [:\\, :in]
@@ -319,7 +319,7 @@ defmodule Code.Formatter do
     {next_eol, comments, doc}
   end
 
-  # Special AST nodes from compiler feedback.
+  # Special AST nodes from compiler feedback
 
   defp quoted_to_algebra({{:special, :clause_args}, _meta, [args]}, _context, state) do
     {doc, state} = clause_args_to_algebra(args, state)
@@ -510,6 +510,11 @@ defmodule Code.Formatter do
   # left not in right
   defp quoted_to_algebra({:not, meta, [{:in, _, [left, right]}]}, context, state) do
     binary_op_to_algebra(:in, "not in", meta, left, right, context, state)
+  end
+
+  # 1..2//3
+  defp quoted_to_algebra({:..//, meta, [left, middle, right]}, context, state) do
+    quoted_to_algebra({:"//", meta, [{:.., meta, [left, middle]}, right]}, context, state)
   end
 
   defp quoted_to_algebra({:fn, meta, [_ | _] = clauses}, _context, state) do
@@ -2027,8 +2032,6 @@ defmodule Code.Formatter do
     {wrap_in_parens_if_operator(doc, ast), state}
   end
 
-  # TODO: We can remove this workaround once we remove
-  # ?rearrange_uop from the parser on v2.0.
   defp wrap_in_parens_if_operator(doc, {:__block__, _, [expr]}) do
     wrap_in_parens_if_operator(doc, expr)
   end

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -12,6 +12,9 @@ defmodule Code.Formatter do
   @empty empty()
   @ampersand_prec Code.Identifier.unary_op(:&) |> elem(1)
 
+  # Operator that are composed of multiple binary operators
+  @multi_binary_operators [:..//]
+
   # Operators that do not have space between operands
   @no_space_binary_operators [:.., :"//"]
 
@@ -2087,21 +2090,16 @@ defmodule Code.Formatter do
 
   defp binary_operator?(quoted) do
     case quoted do
-      {op, _, [_, _]} when is_atom(op) ->
-        Code.Identifier.binary_op(op) != :error
-
-      _ ->
-        false
+      {op, _, [_, _, _]} when op in @multi_binary_operators -> true
+      {op, _, [_, _]} when is_atom(op) -> Code.Identifier.binary_op(op) != :error
+      _ -> false
     end
   end
 
   defp unary_operator?(quoted) do
     case quoted do
-      {op, _, [_]} when is_atom(op) ->
-        Code.Identifier.unary_op(op) != :error
-
-      _ ->
-        false
+      {op, _, [_]} when is_atom(op) -> Code.Identifier.unary_op(op) != :error
+      _ -> false
     end
   end
 

--- a/lib/elixir/lib/code/identifier.ex
+++ b/lib/elixir/lib/code/identifier.ex
@@ -37,13 +37,14 @@ defmodule Code.Identifier do
       op in [:"::"] -> {:right, 60}
       op in [:|] -> {:right, 70}
       op in [:=] -> {:right, 100}
-      op in [:||, :|||, :or] -> {:left, 130}
-      op in [:&&, :&&&, :and] -> {:left, 140}
-      op in [:==, :!=, :=~, :===, :!==] -> {:left, 150}
-      op in [:<, :<=, :>=, :>] -> {:left, 160}
-      op in [:|>, :<<<, :>>>, :<~, :~>, :<<~, :~>>, :<~>, :<|>] -> {:left, 170}
-      op in [:in] -> {:left, 180}
-      op in [:^^^] -> {:left, 190}
+      op in [:||, :|||, :or] -> {:left, 120}
+      op in [:&&, :&&&, :and] -> {:left, 130}
+      op in [:==, :!=, :=~, :===, :!==] -> {:left, 140}
+      op in [:<, :<=, :>=, :>] -> {:left, 150}
+      op in [:|>, :<<<, :>>>, :<~, :~>, :<<~, :~>>, :<~>, :<|>] -> {:left, 160}
+      op in [:in] -> {:left, 170}
+      op in [:^^^] -> {:left, 180}
+      op in [:"//"] -> {:right, 190}
       op in [:++, :--, :.., :<>, :+++, :---] -> {:right, 200}
       op in [:+, :-] -> {:left, 210}
       op in [:*, :/] -> {:left, 220}
@@ -68,10 +69,11 @@ defmodule Code.Identifier do
       the ambiguity between the atom and the keyword identifier
 
     * `:not_callable` - an atom that cannot be used as a function call after the
-      `.` operator (for example, `:<<>>` is not callable because `Foo.<<>>` is a
-      syntax error); this category includes atoms like `:Foo`, since they are
-      valid identifiers but they need quotes to be used in function calls
-      (`Foo."Bar"`)
+      `.` operator. Those are typically AST nodes that are special forms (such as
+      `:%{}` and `:<<>>>`) as well as nodes that are ambiguous in calls (such as
+      `:..` and `:...`). This category also includes atoms like `:Foo`, since
+      they are valid identifiers but they need quotes to be used in function
+      calls (`Foo."Bar"`)
 
     * `:other` - any other atom (these are usually escaped when inspected, like
       `:"foo and bar"`)
@@ -81,10 +83,10 @@ defmodule Code.Identifier do
     charlist = Atom.to_charlist(atom)
 
     cond do
-      atom in [:%, :%{}, :{}, :<<>>, :..., :.., :., :->] ->
+      atom in [:%, :%{}, :{}, :<<>>, :..., :.., :., :..//, :->] ->
         :not_callable
 
-      atom in [:"::"] ->
+      atom in [:"::", :"//"] ->
         :not_atomable
 
       unary_op(atom) != :error or binary_op(atom) != :error ->

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -675,7 +675,6 @@ defmodule Enum do
   @doc """
   Counts the enumerable stopping at `limit`.
 
-
   This is useful for checking certain properties of the count of an enumerable
   without having to actually count the entire enumerable. For example, if you
   wanted to check that the count was exactly, at least, or more than a value.
@@ -2614,6 +2613,11 @@ defmodule Enum do
   @doc since: "1.6.0"
   @spec slice(t, Range.t()) :: list
   def slice(enumerable, first..last//step = index_range) do
+    # TODO: There are two features we can add to slicing ranges:
+    # 1. We can allow the step to be any positive number
+    # 2. We can allow slice and reverse at the same time. However, we can't
+    #    implement so right now. First we will have to raise if a decreasing
+    #    range is given on Elixir v2.0.
     if step == 1 or (step == -1 and first > last) do
       slice_range(enumerable, first, last)
     else
@@ -3003,10 +3007,10 @@ defmodule Enum do
   @spec sum(t) :: number
   def sum(enumerable)
 
-  def sum(first..last//_step = range) do
+  def sum(first..last//step = range) do
     range
     |> Range.size()
-    |> Kernel.*(first + last)
+    |> Kernel.*(first + last - rem(last - first, step))
     |> div(2)
   end
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2025,9 +2025,13 @@ defmodule Enum do
         when empty_result: any
   def min_max(enumerable, empty_fallback \\ fn -> raise Enum.EmptyError end)
 
-  def min_max(first..last//step, empty_fallback) when is_function(empty_fallback, 0) do
-    last = last - rem(last - first, step)
-    {Kernel.min(first, last), Kernel.max(first, last)}
+  def min_max(first..last//step = range, empty_fallback) when is_function(empty_fallback, 0) do
+    if Range.empty?(range) do
+      empty_fallback.()
+    else
+      last = last - rem(last - first, step)
+      {Kernel.min(first, last), Kernel.max(first, last)}
+    end
   end
 
   def min_max(enumerable, empty_fallback) when is_function(empty_fallback, 0) do
@@ -3524,12 +3528,16 @@ defmodule Enum do
     empty.()
   end
 
-  defp aggregate(first..last//step, fun, _empty) do
-    last = last - rem(last - first, step)
+  defp aggregate(first..last//step = range, fun, empty) do
+    if Range.empty?(range) do
+      empty.()
+    else
+      last = last - rem(last - first, step)
 
-    case fun.(first, last) do
-      true -> first
-      false -> last
+      case fun.(first, last) do
+        true -> first
+        false -> last
+      end
     end
   end
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2026,7 +2026,8 @@ defmodule Enum do
         when empty_result: any
   def min_max(enumerable, empty_fallback \\ fn -> raise Enum.EmptyError end)
 
-  def min_max(first..last, empty_fallback) when is_function(empty_fallback, 0) do
+  def min_max(first..last//step, empty_fallback) when is_function(empty_fallback, 0) do
+    last = last - rem(last - first, step)
     {Kernel.min(first, last), Kernel.max(first, last)}
   end
 
@@ -2352,12 +2353,8 @@ defmodule Enum do
     :lists.foldl(fun, acc, enumerable)
   end
 
-  def reduce(first..last, acc, fun) do
-    if first <= last do
-      reduce_range_inc(first, last, acc, fun)
-    else
-      reduce_range_dec(first, last, acc, fun)
-    end
+  def reduce(first..last//step, acc, fun) do
+    reduce_range(first, last, step, acc, fun)
   end
 
   def reduce(%_{} = enumerable, acc, fun) do
@@ -2616,13 +2613,20 @@ defmodule Enum do
   """
   @doc since: "1.6.0"
   @spec slice(t, Range.t()) :: list
-  def slice(enumerable, index_range)
+  def slice(enumerable, first..last//step = index_range) do
+    if step == 1 or (step == -1 and first > last) do
+      slice_range(enumerable, first, last)
+    else
+      raise ArgumentError,
+            "Enum.slice/2 does not accept ranges with custom steps, got: #{inspect(index_range)}"
+    end
+  end
 
-  def slice(enumerable, first..last) when last >= first and last >= 0 and first >= 0 do
+  defp slice_range(enumerable, first, last) when last >= first and last >= 0 and first >= 0 do
     slice_any(enumerable, first, last - first + 1)
   end
 
-  def slice(enumerable, first..last) do
+  defp slice_range(enumerable, first, last) do
     {count, fun} = slice_count_and_fun(enumerable)
     first = if first >= 0, do: first, else: first + count
     last = if last >= 0, do: last, else: last + count
@@ -2989,12 +2993,21 @@ defmodule Enum do
       iex> Enum.sum([1, 2, 3])
       6
 
+      iex> Enum.sum(1..10)
+      55
+
+      iex> Enum.sum(1..10//2)
+      25
+
   """
   @spec sum(t) :: number
   def sum(enumerable)
 
-  def sum(first..last) do
-    div((last + first) * (abs(last - first) + 1), 2)
+  def sum(first..last//_step = range) do
+    range
+    |> Range.size()
+    |> Kernel.*(first + last)
+    |> div(2)
   end
 
   def sum(enumerable) do
@@ -3507,7 +3520,9 @@ defmodule Enum do
     empty.()
   end
 
-  defp aggregate(first..last, fun, _empty) do
+  defp aggregate(first..last//step, fun, _empty) do
+    last = last - rem(last - first, step)
+
     case fun.(first, last) do
       true -> first
       false -> last
@@ -3783,20 +3798,14 @@ defmodule Enum do
 
   ## reduce
 
-  defp reduce_range_inc(first, first, acc, fun) do
-    fun.(first, acc)
+  defp reduce_range(first, last, step, acc, fun)
+       when step > 0 and first <= last
+       when step < 0 and first >= last do
+    reduce_range(first + step, last, step, fun.(first, acc), fun)
   end
 
-  defp reduce_range_inc(first, last, acc, fun) do
-    reduce_range_inc(first + 1, last, fun.(first, acc), fun)
-  end
-
-  defp reduce_range_dec(first, first, acc, fun) do
-    fun.(first, acc)
-  end
-
-  defp reduce_range_dec(first, last, acc, fun) do
-    reduce_range_dec(first - 1, last, fun.(first, acc), fun)
+  defp reduce_range(_first, _last, _step, acc, _fun) do
+    acc
   end
 
   defp reduce_enumerable(enumerable, acc, fun) do

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -252,8 +252,8 @@ defmodule Exception do
 
   defp rewrite_arg(arg) do
     Macro.prewalk(arg, fn
-      {:%{}, meta, [__struct__: Range, first: first, last: last]} ->
-        {:.., meta, [first, last]}
+      {:%{}, meta, [__struct__: Range, first: first, last: last, step: step]} ->
+        {:..//, meta, [first, last, step]}
 
       other ->
         other

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -463,6 +463,58 @@ defmodule Integer do
   defp gcd_positive(integer1, 0), do: integer1
   defp gcd_positive(integer1, integer2), do: gcd_positive(integer2, rem(integer1, integer2))
 
+  @doc """
+  Returns the extended greatest common divisor of the two given integers.
+
+  It uses the Extended Euclidean algorithm to return a three-element with the `gcd`
+  and the coefficients `m` and `n` of Bézout's identity such that:
+
+      gcd(a, b) = m*a + n*b
+
+  By convention, `extended_gcd(0, 0)` returns `{0, 0, 0}`.
+
+  ## Examples
+
+      iex> Integer.extended_gcd(240, 46)
+      {2, -9, 47}
+      iex> Integer.extended_gcd(46, 240)
+      {2, 47, -9}
+      iex> Integer.extended_gcd(-46, 240)
+      {2, -47, -9}
+      iex> Integer.extended_gcd(-46, -240)
+      {2, -47, 9}
+
+      iex> Integer.extended_gcd(14, 21)
+      {7, -1, 1}
+
+      iex> Integer.extended_gcd(10, 0)
+      {10, 1, 0}
+      iex> Integer.extended_gcd(0, 10)
+      {10, 0, 1}
+      iex> Integer.extended_gcd(0, 0)
+      {0, 0, 0}
+
+  """
+  @doc since: "1.12.0"
+  @spec extended_gcd(integer, integer) :: {non_neg_integer, integer, integer}
+  def extended_gcd(0, 0), do: {0, 0, 0}
+  def extended_gcd(0, n), do: {n, 0, 1}
+  def extended_gcd(n, 0), do: {n, 1, 0}
+
+  def extended_gcd(integer1, integer2) when is_integer(integer1) and is_integer(integer2) do
+    extended_gcd(integer2, integer1, 0, 1, 1, 0)
+  end
+
+  defp extended_gcd(r1, r0, s1, s0, t1, t0) do
+    div = div(r0, r1)
+
+    case r0 - div * r1 do
+      0 when r1 > 0 -> {r1, s1, t1}
+      0 when r1 < 0 -> {-r1, -s1, -t1}
+      r2 -> extended_gcd(r2, r1, s0 - div * s1, s1, t0 - div * t1, t1)
+    end
+  end
+
   @doc false
   @deprecated "Use Integer.to_charlist/1 instead"
   def to_char_list(integer), do: Integer.to_charlist(integer)

--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -466,7 +466,7 @@ defmodule Integer do
   @doc """
   Returns the extended greatest common divisor of the two given integers.
 
-  It uses the Extended Euclidean algorithm to return a three-element with the `gcd`
+  It uses the Extended Euclidean algorithm to return a three-element tuple with the `gcd`
   and the coefficients `m` and `n` of Bézout's identity such that:
 
       gcd(a, b) = m*a + n*b

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3707,6 +3707,7 @@ defmodule Kernel do
       []
 
   """
+  @doc since: "1.12.0"
   defmacro first..last//step do
     case bootstrapped?(Macro) do
       true ->

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3633,11 +3633,11 @@ defmodule Kernel do
   @doc """
   Creates a range from `first` to `last`.
 
-  If last is more than first, the range will be increasing from
+  If first is less than last, the range will be increasing from
   first to last. If first is equal to last, the range will contain
   one element, which is the number itself.
 
-  If first is less than last, the range will be decreasing from first
+  If first is more than last, the range will be decreasing from first
   to last, albeit this behaviour is deprecated. Instead prefer to
   explicitly list the step with `first..last//-1`.
 

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -969,7 +969,7 @@ defmodule Macro do
 
   def to_string({target, _, args} = ast, fun) when is_list(args) do
     with :error <- unary_call(ast, fun),
-         :error <- binary_call(ast, fun),
+         :error <- op_call(ast, fun),
          :error <- sigil_call(ast, fun) do
       {list, last} = split_last(args)
 
@@ -1143,7 +1143,14 @@ defmodule Macro do
     :error
   end
 
-  defp binary_call({op, _, [left, right]} = ast, fun) when is_atom(op) do
+  defp op_call({:..//, _, [left, middle, right]} = ast, fun) do
+    left = op_to_string(left, fun, :.., :left)
+    middle = op_to_string(middle, fun, :.., :right)
+    right = op_to_string(right, fun, :"//", :right)
+    {:ok, fun.(ast, left <> ".." <> middle <> "//" <> right)}
+  end
+
+  defp op_call({op, _, [left, right]} = ast, fun) when is_atom(op) do
     case Identifier.binary_op(op) do
       {_, _} ->
         left = op_to_string(left, fun, op, :left)
@@ -1156,7 +1163,7 @@ defmodule Macro do
     end
   end
 
-  defp binary_call(_, _) do
+  defp op_call(_, _) do
     :error
   end
 

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -3,21 +3,31 @@ defmodule Range do
   Ranges represent a sequence of one or many, ascending
   or descending, consecutive integers.
 
-  Ranges can be either increasing (`first <= last`) or
-  decreasing (`first > last`). Ranges are also always
-  inclusive.
+  Ranges are always inclusive and they may have custom
+  steps. The most common form of creating and matching
+  on ranges is via the `../2` and `..///3` macros,
+  auto-imported from `Kernel`:
 
-  A range is represented internally as a struct. However,
-  the most common form of creating and matching on ranges
-  is via the `../2` macro, auto-imported from `Kernel`:
+      iex> Enum.to_list(1..3)
+      [1, 2, 3]
+      iex> Enum.to_list(1..3//2)
+      [1, 3]
+      iex> Enum.to_list(3..1//-1)
+      [3, 2, 1]
 
-      iex> range = 1..3
-      1..3
-      iex> first..last = range
+  Intenrally, ranges are represented as structs:
+
+      iex> range = 1..9//2
+      1..9//2
+      iex> first..last//step = range
       iex> first
       1
       iex> last
-      3
+      9
+      iex> step
+      2
+      iex> range.step
+      2
 
   A range implements the `Enumerable` protocol, which means
   functions in the `Enum` module can be used to work with
@@ -60,7 +70,7 @@ defmodule Range do
   """
   @spec new(integer, integer) :: t
   def new(first, last) when is_integer(first) and is_integer(last) do
-    # TODO: Deprecate inferring a range with step of -1
+    # TODO: Deprecate inferring a range with step of -1 on Elixir v1.16
     step = if first <= last, do: 1, else: -1
     %Range{first: first, last: last, step: step}
   end
@@ -91,6 +101,36 @@ defmodule Range do
           "ranges (first..last//step) expect both sides to be integers and the step to be an integer " <>
             "different than zero, got: #{inspect(first)}..#{inspect(last)}//#{inspect(step)}"
   end
+
+  @doc """
+  Returns the size of the range.
+
+  ## Examples
+
+      iex> Range.size(1..10)
+      10
+      iex> Range.size(1..10//2)
+      5
+      iex> Range.size(1..10//3)
+      4
+      iex> Range.size(1..10//-1)
+      0
+
+      iex> Range.size(10..1)
+      10
+      iex> Range.size(10..1//-1)
+      10
+      iex> Range.size(10..1//-2)
+      5
+      iex> Range.size(10..1//-3)
+      4
+      iex> Range.size(10..1//1)
+      0
+
+  """
+  def size(first..last//step) when step > 0 and first > last, do: 0
+  def size(first..last//step) when step < 0 and first < last, do: 0
+  def size(first..last//step), do: abs(div(last - first, step)) + 1
 
   @doc """
   Checks if two ranges are disjoint.
@@ -127,63 +167,50 @@ defmodule Range do
 end
 
 defimpl Enumerable, for: Range do
-  def reduce(first..last, acc, fun) do
-    reduce(first, last, acc, fun, _up? = last >= first)
+  def reduce(first..last//step, acc, fun) do
+    reduce(first, last, acc, fun, step)
   end
 
-  defp reduce(_first, _last, {:halt, acc}, _fun, _up?) do
+  defp reduce(_first, _last, {:halt, acc}, _fun, _step) do
     {:halted, acc}
   end
 
-  defp reduce(first, last, {:suspend, acc}, fun, up?) do
-    {:suspended, acc, &reduce(first, last, &1, fun, up?)}
+  defp reduce(first, last, {:suspend, acc}, fun, step) do
+    {:suspended, acc, &reduce(first, last, &1, fun, step)}
   end
 
-  defp reduce(first, last, {:cont, acc}, fun, _up? = true) when first <= last do
-    reduce(first + 1, last, fun.(first, acc), fun, _up? = true)
-  end
-
-  defp reduce(first, last, {:cont, acc}, fun, _up? = false) when first >= last do
-    reduce(first - 1, last, fun.(first, acc), fun, _up? = false)
+  defp reduce(first, last, {:cont, acc}, fun, step)
+       when step > 0 and first <= last
+       when step < 0 and first >= last do
+    reduce(first + step, last, fun.(first, acc), fun, step)
   end
 
   defp reduce(_, _, {:cont, acc}, _fun, _up) do
     {:done, acc}
   end
 
-  def member?(first..last, value) when is_integer(value) do
+  def member?(first..last//step, value) when is_integer(value) do
     if first <= last do
-      {:ok, first <= value and value <= last}
+      {:ok, first <= value and value <= last and rem(value - first, step) == 0}
     else
-      {:ok, last <= value and value <= first}
+      {:ok, last <= value and value <= first and rem(value - first, step) == 0}
     end
   end
 
-  def member?(_.._, _value) do
+  def member?(_, _value) do
     {:ok, false}
   end
 
-  def count(first..last) do
-    if first <= last do
-      {:ok, last - first + 1}
-    else
-      {:ok, first - last + 1}
-    end
+  def count(range) do
+    {:ok, Range.size(range)}
   end
 
-  def slice(first..last) do
-    if first <= last do
-      {:ok, last - first + 1, &slice_asc(first + &1, &2)}
-    else
-      {:ok, first - last + 1, &slice_desc(first - &1, &2)}
-    end
+  def slice(first.._//step = range) do
+    {:ok, Range.size(range), &slice(first + &1 * step, step, &2)}
   end
 
-  defp slice_asc(current, 1), do: [current]
-  defp slice_asc(current, remaining), do: [current | slice_asc(current + 1, remaining - 1)]
-
-  defp slice_desc(current, 1), do: [current]
-  defp slice_desc(current, remaining), do: [current | slice_desc(current - 1, remaining - 1)]
+  defp slice(current, _step, 1), do: [current]
+  defp slice(current, step, remaining), do: [current | slice(current + step, step, remaining - 1)]
 end
 
 defimpl Inspect, for: Range do

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -15,7 +15,7 @@ defmodule Range do
       iex> Enum.to_list(3..1//-1)
       [3, 2, 1]
 
-  Intenrally, ranges are represented as structs:
+  Internally, ranges are represented as structs:
 
       iex> range = 1..9//2
       1..9//2
@@ -209,7 +209,7 @@ defmodule Range do
           false
 
         true ->
-          # We need to find the first intersection of two arithmethetical
+          # We need to find the first intersection of two arithmetic
           # progressions and see if they belong within the ranges
           # https://math.stackexchange.com/questions/1656120/formula-to-find-the-first-intersection-of-two-arithmetic-progressions
           {gcd, u, v} = Integer.extended_gcd(-step1, step2)

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2078,24 +2078,25 @@ defmodule String do
 
   """
   @spec slice(t, Range.t()) :: t
-
-  def slice(string, range)
-
-  def slice("", _.._), do: ""
-
-  def slice(string, first..-1) when is_binary(string) and is_integer(first) and first >= 0 do
-    case String.Unicode.split_at(string, first) do
-      {_, nil} ->
-        ""
-
-      {start_bytes, _} ->
-        binary_part(string, start_bytes, byte_size(string) - start_bytes)
+  def slice(string, first..last//step = range) when is_binary(string) do
+    if step == 1 or (step == -1 and first > last) do
+      slice_range(string, first, last)
+    else
+      raise ArgumentError,
+            "String.slice/2 does not accept ranges with custom steps, got: #{inspect(range)}"
     end
   end
 
-  def slice(string, first..last)
-      when is_binary(string) and is_integer(first) and is_integer(last) and first >= 0 and
-             last >= 0 do
+  defp slice_range("", _, _), do: ""
+
+  defp slice_range(string, first, -1) when first >= 0 do
+    case String.Unicode.split_at(string, first) do
+      {_, nil} -> ""
+      {start_bytes, _} -> binary_part(string, start_bytes, byte_size(string) - start_bytes)
+    end
+  end
+
+  defp slice_range(string, first, last) when first >= 0 and last >= 0 do
     if last >= first do
       slice(string, first, last - first + 1)
     else
@@ -2103,10 +2104,8 @@ defmodule String do
     end
   end
 
-  def slice(string, first..last)
-      when is_binary(string) and is_integer(first) and is_integer(last) do
-    {bytes, length} = do_acc_bytes(next_grapheme_size(string), [], 0)
-
+  defp slice_range(string, first, last) do
+    {bytes, length} = acc_bytes(next_grapheme_size(string), [], 0)
     first = add_if_negative(first, length)
     last = add_if_negative(last, length)
 
@@ -2116,21 +2115,25 @@ defmodule String do
       last = min(last + 1, length)
       bytes = Enum.drop(bytes, length - last)
       first = last - first
-      {length_bytes, start_bytes} = Enum.split(bytes, first)
-      binary_part(string, Enum.sum(start_bytes), Enum.sum(length_bytes))
+      {length_bytes, start_bytes} = split_bytes(bytes, 0, first)
+      binary_part(string, start_bytes, length_bytes)
     end
+  end
+
+  defp acc_bytes({size, rest}, bytes, length) do
+    acc_bytes(next_grapheme_size(rest), [size | bytes], length + 1)
+  end
+
+  defp acc_bytes(nil, bytes, length) do
+    {bytes, length}
   end
 
   defp add_if_negative(value, to_add) when value < 0, do: value + to_add
   defp add_if_negative(value, _to_add), do: value
 
-  defp do_acc_bytes({size, rest}, bytes, length) do
-    do_acc_bytes(next_grapheme_size(rest), [size | bytes], length + 1)
-  end
-
-  defp do_acc_bytes(nil, bytes, length) do
-    {bytes, length}
-  end
+  defp split_bytes(rest, acc, 0), do: {acc, Enum.sum(rest)}
+  defp split_bytes([], acc, _), do: {acc, 0}
+  defp split_bytes([head | tail], acc, count), do: split_bytes(tail, head + acc, count - 1)
 
   @doc """
   Returns `true` if `string` starts with any of the prefixes given.

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2079,6 +2079,11 @@ defmodule String do
   """
   @spec slice(t, Range.t()) :: t
   def slice(string, first..last//step = range) when is_binary(string) do
+    # TODO: There are two features we can add to slicing ranges:
+    # 1. We can allow the step to be any positive number
+    # 2. We can allow slice and reverse at the same time. However, we can't
+    #    implement so right now. First we will have to raise if a decreasing
+    #    range is given on Elixir v2.0.
     if step == 1 or (step == -1 and first > last) do
       slice_range(string, first, last)
     else

--- a/lib/elixir/pages/operators.md
+++ b/lib/elixir/pages/operators.md
@@ -22,7 +22,7 @@ Operator                                                                        
 `\|\|` `\|\|\|` `or`                                  | Left
 `=`                                                   | Right
 `&`                                                   | Unary
-`=>` (valid syntax only inside `%{}`)                 | Right
+`=>` (valid only inside `%{}`)                        | Right
 `\|`                                                  | Right
 `::`                                                  | Right
 `when`                                                | Right

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -718,7 +718,7 @@ build_op(AST, {_Kind, Location, '//'}, Right) ->
       {'..//', Meta, [Left, Middle, Right]};
 
     _ ->
-      return_error(meta_from_location(Location), "the range step operator (//) must immediatelly follow the range definition operator (..), for example: 1..9//2. Syntax error before: ", "'//'")
+      return_error(meta_from_location(Location), "the range step operator (//) must immediately follow the range definition operator (..), for example: 1..9//2. Syntax error before: ", "'//'")
   end;
 
 build_op({UOp, _, [Left]}, {_Kind, Location, 'in'}, Right) when ?rearrange_uop(UOp) ->

--- a/lib/elixir/test/elixir/code_formatter/operators_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/operators_test.exs
@@ -113,6 +113,7 @@ defmodule Code.Formatter.OperatorsTest do
   describe "ternary without space" do
     test "formats without spaces" do
       assert_format "1 .. 2 // 3", "1..2//3"
+      assert_same "(1..2//3).step"
     end
 
     test "never breaks" do

--- a/lib/elixir/test/elixir/code_formatter/operators_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/operators_test.exs
@@ -110,6 +110,16 @@ defmodule Code.Formatter.OperatorsTest do
     end
   end
 
+  describe "ternary without space" do
+    test "formats without spaces" do
+      assert_format "1 .. 2 // 3", "1..2//3"
+    end
+
+    test "never breaks" do
+      assert_same "123_456_789..987_654_321//147_268_369", @short_length
+    end
+  end
+
   describe "binary without newline" do
     test "formats without spaces" do
       assert_same "1 in 2"

--- a/lib/elixir/test/elixir/integer_test.exs
+++ b/lib/elixir/test/elixir/integer_test.exs
@@ -254,4 +254,15 @@ defmodule IntegerTest do
     assert Integer.gcd(-3, 0) == 3
     assert Integer.gcd(0, 0) == 0
   end
+
+  test "extended_gcd" do
+    # Poor's man properby based testing
+    for _ <- 1..100 do
+      left = :rand.uniform(1000)
+      right = :rand.uniform(1000)
+      {gcd, m, n} = Integer.extended_gcd(left, right)
+      assert Integer.gcd(left, right) == gcd
+      assert m * left + n * right == gcd
+    end
+  end
 end

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -47,7 +47,7 @@ defmodule Kernel.ParserTest do
 
     test "errors" do
       msg =
-        ~r/the range step operator \(\/\/\) must immediatelly follow the range definition operator \(\.\.\)/
+        ~r/the range step operator \(\/\/\) must immediately follow the range definition operator \(\.\.\)/
 
       assert_syntax_error(msg, "foo..bar baz//bat")
       assert_syntax_error(msg, "foo++bar//bat")

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -489,6 +489,10 @@ defmodule KernelTest do
     def fun_in(x) when x in @at_range, do: :at_range
     def fun_in(x) when x in [9 | [10, 11]], do: :list_cons
     def fun_in(x) when x in [12 | @at_list2], do: :list_cons_at
+    def fun_in(x) when x in 21..15//1, do: raise("oops positive")
+    def fun_in(x) when x in 15..21//-1, do: raise("oops negative")
+    def fun_in(x) when x in 15..21//2, do: :range_step_2
+    def fun_in(x) when x in 15..21//1, do: :range_step_1
     def fun_in(_), do: :none
 
     test "in function guard" do
@@ -506,6 +510,10 @@ defmodule KernelTest do
       assert fun_in(12) == :list_cons_at
       assert fun_in(13) == :list_cons_at
       assert fun_in(14) == :list_cons_at
+      assert fun_in(15) == :range_step_2
+      assert fun_in(16) == :range_step_1
+      assert fun_in(17) == :range_step_2
+      assert fun_in(22) == :none
 
       assert fun_in(0.0) == :none
       assert fun_in(1.0) == :none
@@ -520,12 +528,15 @@ defmodule KernelTest do
       assert fun_in(12.0) == :none
       assert fun_in(13.0) == :none
       assert fun_in(14.0) == :none
+      assert fun_in(15.0) == :none
+      assert fun_in(16.0) == :none
+      assert fun_in(17.0) == :none
     end
 
     def dynamic_in(x, y, z) when x in y..z, do: true
     def dynamic_in(_x, _y, _z), do: false
 
-    test "in dynamic function guard" do
+    test "in dynamic range function guard" do
       assert dynamic_in(1, 1, 3)
       assert dynamic_in(2, 1, 3)
       assert dynamic_in(3, 1, 3)
@@ -542,6 +553,33 @@ defmodule KernelTest do
       refute dynamic_in(2, 1.0, 3)
       refute dynamic_in(2, 1, 3.0)
       refute dynamic_in(2.0, 1, 3)
+    end
+
+    def dynamic_step_in(x, y, z, w) when x in y..z//w, do: true
+    def dynamic_step_in(_x, _y, _z, _w), do: false
+
+    test "in dynamic range with step function guard" do
+      assert dynamic_step_in(1, 1, 3, 1)
+      assert dynamic_step_in(2, 1, 3, 1)
+      assert dynamic_step_in(3, 1, 3, 1)
+
+      refute dynamic_step_in(1, 1, 3, -1)
+      refute dynamic_step_in(2, 1, 3, -1)
+      refute dynamic_step_in(3, 1, 3, -1)
+
+      assert dynamic_step_in(1, 3, 1, -1)
+      assert dynamic_step_in(2, 3, 1, -1)
+      assert dynamic_step_in(3, 3, 1, -1)
+
+      refute dynamic_step_in(1, 3, 1, 1)
+      refute dynamic_step_in(2, 3, 1, 1)
+      refute dynamic_step_in(3, 3, 1, 1)
+
+      assert dynamic_step_in(1, 1, 3, 2)
+      refute dynamic_step_in(2, 1, 3, 2)
+      assert dynamic_step_in(3, 1, 3, 2)
+      assert dynamic_step_in(3, 1, 4, 2)
+      refute dynamic_step_in(4, 1, 4, 2)
     end
 
     defmacrop case_in(x, y) do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -578,7 +578,7 @@ defmodule MacroTest do
     test "range" do
       assert Macro.to_string(quote(do: unquote(-1..+2))) == "-1..2"
       assert Macro.to_string(quote(do: Foo.integer()..3)) == "Foo.integer()..3"
-      # assert Macro.to_string(quote(do: unquote(-1..+2//-3))) == "-1..2//-3"
+      assert Macro.to_string(quote(do: unquote(-1..+2//-3))) == "-1..2//-3"
 
       assert Macro.to_string(quote(do: Foo.integer()..3//Bar.bat())) ==
                "Foo.integer()..3//Bar.bat()"

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -578,6 +578,10 @@ defmodule MacroTest do
     test "range" do
       assert Macro.to_string(quote(do: unquote(-1..+2))) == "-1..2"
       assert Macro.to_string(quote(do: Foo.integer()..3)) == "Foo.integer()..3"
+      # assert Macro.to_string(quote(do: unquote(-1..+2//-3))) == "-1..2//-3"
+
+      assert Macro.to_string(quote(do: Foo.integer()..3//Bar.bat())) ==
+               "Foo.integer()..3//Bar.bat()"
     end
 
     test "when" do

--- a/lib/elixir/test/elixir/range_test.exs
+++ b/lib/elixir/test/elixir/range_test.exs
@@ -28,54 +28,46 @@ defmodule RangeTest do
     end)
   end
 
-  test "precedence" do
-    assert Enum.to_list(1..(3 + 2)) == [1, 2, 3, 4, 5]
-    assert 1..3 |> Enum.to_list() == [1, 2, 3]
+  test "new" do
+    assert Range.new(1, 3) == 1..3//1
+    assert Range.new(3, 1) == 3..1//-1
+    assert Range.new(1, 3, 2) == 1..3//2
+    assert Range.new(3, 1, -2) == 3..1//-2
   end
 
   test "op" do
     assert (1..3).first == 1
     assert (1..3).last == 3
-  end
-
-  test "enum" do
-    refute Enum.empty?(1..1)
-
-    assert Enum.member?(1..3, 2)
-    refute Enum.member?(1..3, 0)
-    refute Enum.member?(1..3, 4)
-    refute Enum.member?(3..1, 0)
-    refute Enum.member?(3..1, 4)
-
-    assert Enum.count(1..3) == 3
-    assert Enum.count(3..1) == 3
-
-    assert Enum.map(1..3, &(&1 * 2)) == [2, 4, 6]
-    assert Enum.map(3..1, &(&1 * 2)) == [6, 4, 2]
+    assert (1..3).step == 1
+    assert (3..1).step == -1
+    assert (1..3//2).step == 2
   end
 
   test "inspect" do
     assert inspect(1..3) == "1..3"
-    assert inspect(3..1) == "3..1"
+    assert inspect(3..1) == "3..1//-1"
   end
 
-  test "integer only" do
+  test "limits are integer only" do
     first = 1.0
     last = 3.0
     message = "ranges (first..last) expect both sides to be integers, got: 1.0..3.0"
-
-    assert_raise ArgumentError, message, fn ->
-      Enum.map(first..last, &(&1 * 2))
-    end
+    assert_raise ArgumentError, message, fn -> first..last end
 
     first = []
     last = []
     message = "ranges (first..last) expect both sides to be integers, got: []..[]"
+    assert_raise ArgumentError, message, fn -> first..last end
+  end
 
-    assert_raise ArgumentError, message, fn ->
-      first..last
-      Enum.map(first..last, & &1)
-    end
+  test "step is a non-zero integer" do
+    step = 1.0
+    message = ~r"the step to be an integer different than zero"
+    assert_raise ArgumentError, message, fn -> 1..3//step end
+
+    step = 0
+    message = ~r"the step to be an integer different than zero"
+    assert_raise ArgumentError, message, fn -> 1..3//step end
   end
 
   describe "disjoint?" do


### PR DESCRIPTION
Proposal: https://gist.github.com/josevalim/da8f1630e5f515dc2b05aefdc5d01af7

Mailing list discussion: https://groups.google.com/g/elixir-lang-core/c/U5EhplEqda4

TODO:

  * [x] Add coverage for stepped ranges on Enum
  * [x] Fix Range.disjoint? to consider steps

Other notes:

  * With this PR, we can now support stepped ranges on `Enum.slice/2` and `String.slice/2`. For example:
    ```elixir
    iex> String.slice("Elixir", 0..-1//2)
    "Eii"
    ```
    This is not done in this PR. We could even support slice+reverse by having negative steps, such as:
    ```elixir
    iex> String.slice("Elixir", -1..0//-2)
    "rxl"
    ```
    but unfortunately we can't do so right now because 3..-1 has a negative step. Therefore, in order to support slice+reverse, we first need to raise for negative steps on Elixir v2.0 (which is not scheduled nor planned at the moment) and then add this feature later on.
