### PR TITLE
Fix mix tests on older git versions

### DIFF
--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -225,7 +225,6 @@ end)
 ## Generate Git repo fixtures
 System.cmd("git", ~w[config --global user.email "mix@example.com"])
 System.cmd("git", ~w[config --global user.name "mix-repo"])
-System.cmd("git", ~w[config --global init.defaultBranch main])
 
 # Git repo
 target = Path.expand("fixtures/git_repo", __DIR__)
@@ -242,9 +241,8 @@ unless File.dir?(target) do
     System.cmd("git", ~w[init])
     System.cmd("git", ~w[add .])
     System.cmd("git", ~w[commit -m "bad"])
-    System.cmd("git", ~w[checkout -q -b development])
-    System.cmd("git", ~w[symbolic-ref HEAD refs/heads/development])
-    System.cmd("git", ~w[branch -d main])
+    System.cmd("git", ~w[checkout -q -b main])
+    System.cmd("git", ~w[symbolic-ref HEAD refs/heads/main])
   end)
 
   File.write!(Path.join(target, "mix.exs"), """
@@ -334,6 +332,8 @@ unless File.dir?(target) do
     System.cmd("git", ~w[init])
     System.cmd("git", ~w[add .])
     System.cmd("git", ~w[commit -m without-dep])
+    System.cmd("git", ~w[checkout -q -b main])
+    System.cmd("git", ~w[symbolic-ref HEAD refs/heads/main])
   end)
 
   File.write!(Path.join(target, "mix.exs"), """
@@ -387,6 +387,8 @@ unless File.dir?(target) do
     System.cmd("git", ~w[init])
     System.cmd("git", ~w[add .])
     System.cmd("git", ~w[commit -m "ok"])
+    System.cmd("git", ~w[checkout -q -b main])
+    System.cmd("git", ~w[symbolic-ref HEAD refs/heads/main])
   end)
 end
 


### PR DESCRIPTION
The configuration init.defaultBranch is a recent addition to git. When
it's not available the tests will fail because the wrong branch is
created.