### PR TITLE
Add "namespaces" guidance to library guidelines

### DIFF
--- a/lib/elixir/pages/library-guidelines.md
+++ b/lib/elixir/pages/library-guidelines.md
@@ -182,9 +182,11 @@ If, for some reason, you must read the application environment at compile time, 
 
 ### Avoid defining modules that are not in your "namespace"
 
-Even though Elixir does not formally have the concept of namespaces, a library should use its name as a "prefix" for all of its modules (except for special cases like mix tasks). For example if the library name is `MyLib`, then all of its modules should start with the `MyLib` prefix, for example `MyLib.User`, `MyLib.SubModule`, and `MyLib.Application`.
+Even though Elixir does not formally have the concept of namespaces, a library should use its name as a "prefix" for all of its modules (except for special cases like mix tasks). For example if the library's OTP application name is `:my_lib`, then all of its modules should start with the `MyLib` prefix, for example `MyLib.User`, `MyLib.SubModule`, and `MyLib.Application`.
 
-This is important because the BEAM can only load one instance of a module at a time. So if there are multiple libraries that define the same module, then they are incompatible with each other due to this limitation. By always using the library name as a prefix this is avoided since this avoids module name clashes due to the unique prefix.
+This is important because the Erlang VM can only load one instance of a module at a time. So if there are multiple libraries that define the same module, then they are incompatible with each other due to this limitation. By always using the library name as a prefix, it avoids module name clashes due to the unique prefix.
+
+Furthermore, when writing a library that is extension of another library, you should avoid defining modules inside the parent's library namespace. For example, if you are writing a package that adds authentication to [`Plug`](https://github.com/elixir-plug/plug) called `plug_auth`, the modules should be namespaced under `PlugAuth` instead of `Plug.Auth`, so it avoid conflicts with `Plug` if it were to ever define its own authentication functionality.
 
 ### Avoid `use` when an `import` is enough
 

--- a/lib/elixir/pages/library-guidelines.md
+++ b/lib/elixir/pages/library-guidelines.md
@@ -180,6 +180,12 @@ That's because by reading the application in the module body and storing it in a
 
 If, for some reason, you must read the application environment at compile time, use `Application.compile_env/2`. Read [the "Compile-time environment" section of the `Application` module documentation](Application.html#module-compile-time-environment) for more information.
 
+### Avoid defining modules that are not in your "namespace"
+
+Even though Elixir does not formally have the concept of namespaces, a library should use its name as a "prefix" for all of its modules (except for special cases like mix tasks). For example if the library name is `MyLib`, then all of its modules should start with the `MyLib` prefix, for example `MyLib.User`, `MyLib.SubModule`, and `MyLib.Application`.
+
+This is important because the BEAM can only load one instance of a module at a time. So if there are multiple libraries that define the same module, then they are incompatible with each other due to this limitation. By always using the library name as a prefix this is avoided since this avoids module name clashes due to the unique prefix.
+
 ### Avoid `use` when an `import` is enough
 
 A library should not provide `use MyLib` functionality if all `use MyLib` does is to `import`/`alias` the module itself. For example, this is an anti-pattern:

--- a/lib/elixir/pages/library-guidelines.md
+++ b/lib/elixir/pages/library-guidelines.md
@@ -186,7 +186,7 @@ Even though Elixir does not formally have the concept of namespaces, a library s
 
 This is important because the Erlang VM can only load one instance of a module at a time. So if there are multiple libraries that define the same module, then they are incompatible with each other due to this limitation. By always using the library name as a prefix, it avoids module name clashes due to the unique prefix.
 
-Furthermore, when writing a library that is extension of another library, you should avoid defining modules inside the parent's library namespace. For example, if you are writing a package that adds authentication to [`Plug`](https://github.com/elixir-plug/plug) called `plug_auth`, the modules should be namespaced under `PlugAuth` instead of `Plug.Auth`, so it avoid conflicts with `Plug` if it were to ever define its own authentication functionality.
+Furthermore, when writing a library that is an extension of another library, you should avoid defining modules inside the parent's library namespace. For example, if you are writing a package that adds authentication to [`Plug`](https://github.com/elixir-plug/plug) called `plug_auth`, its modules should be namespaced under `PlugAuth` instead of `Plug.Auth`, so it avoid conflicts with `Plug` if it were to ever define its own authentication functionality.
 
 ### Avoid `use` when an `import` is enough
 


### PR DESCRIPTION
This came up on the Elixir Slack a few days ago. This is a bit of institutional knowledge that is not currently captured in writing
anywhere (as far as I can tell), but it is important guidance for the health of the Elixir ecosystem. cc: @ericmj

Related: https://github.com/hexpm/hexpm/pull/1018