### PR TITLE
Streamline get_and_update specs for Access for Kernel

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -2657,8 +2657,8 @@ defmodule Kernel do
   The `fun` argument receives the value of `key` (or `nil` if `key`
   is not present) and must return one of the following values:
 
-    * a two-element tuple `{get_value, new_value}`. In this case,
-      `get_value` is the retrieved value which can possibly be operated on before
+    * a two-element tuple `{current_value, new_value}`. In this case,
+      `current_value` is the retrieved value which can possibly be operated on before
       being returned. `new_value` is the new value to be stored under `key`.
 
     * `:pop`, which implies that the current value under `key`
@@ -2712,13 +2712,14 @@ defmodule Kernel do
   `Access.key/2`, and others as examples.
   """
   @spec get_and_update_in(
-          structure :: Access.t(),
+          structure,
           keys,
-          (term -> {get_value, update_value} | :pop)
-        ) :: {get_value, structure :: Access.t()}
-        when keys: nonempty_list(any),
-             get_value: var,
-             update_value: term
+          (term | nil -> {current_value, new_value} | :pop)
+        ) :: {current_value, new_structure :: structure}
+        when structure: Access.t(),
+             keys: nonempty_list(any),
+             current_value: Access.value(),
+             new_value: Access.value()
   def get_and_update_in(data, keys, fun)
 
   def get_and_update_in(data, [head], fun) when is_function(head, 3),

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -287,8 +287,8 @@ defmodule Keyword do
       {nil, [a: 1]}
 
   """
-  @spec get_and_update(t, key, (value -> {current_value, new_value :: value} | :pop)) ::
-          {current_value, value}
+  @spec get_and_update(t, key, (value | nil -> {current_value, new_value :: value} | :pop)) ::
+          {current_value, new_keywords :: t}
         when current_value: value
   def get_and_update(keywords, key, fun)
       when is_list(keywords) and is_atom(key),
@@ -351,8 +351,8 @@ defmodule Keyword do
       {1, []}
 
   """
-  @spec get_and_update!(t, key, (value -> {current_value, new_value :: value} | :pop)) ::
-          {current_value, t}
+  @spec get_and_update!(t, key, (value | nil -> {current_value, new_value :: value} | :pop)) ::
+          {current_value, new_keywords :: t}
         when current_value: value
   def get_and_update!(keywords, key, fun) do
     get_and_update!(keywords, key, fun, [])
@@ -929,7 +929,7 @@ defmodule Keyword do
       [a: 1, b: 11]
 
   """
-  @spec update(t, key, default :: value, (existing_value :: value -> updated_value :: value)) :: t
+  @spec update(t, key, default :: value, (existing_value :: value -> new_value :: value)) :: t
   def update(keywords, key, default, fun)
       when is_list(keywords) and is_atom(key) and is_function(fun, 1) do
     update_guarded(keywords, key, default, fun)

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -619,7 +619,7 @@ defmodule Map do
       %{a: 1, b: 11}
 
   """
-  @spec update(map, key, default :: value, (existing_value :: value -> updated_value :: value)) ::
+  @spec update(map, key, default :: value, (existing_value :: value -> new_value :: value)) ::
           map
   def update(map, key, default, fun) when is_function(fun, 1) do
     case map do
@@ -817,7 +817,7 @@ defmodule Map do
       ** (KeyError) key :b not found in: %{a: 1}
 
   """
-  @spec update!(map, key, (existing_value :: value -> updated_value :: value)) :: map
+  @spec update!(map, key, (existing_value :: value -> new_value :: value)) :: map
   def update!(map, key, fun) when is_function(fun, 1) do
     value = fetch!(map, key)
     put(map, key, fun.(value))
@@ -855,8 +855,8 @@ defmodule Map do
       {nil, %{a: 1}}
 
   """
-  @spec get_and_update(map, key, (value -> {current_value, new_value :: value} | :pop)) ::
-          {current_value, map}
+  @spec get_and_update(map, key, (value | nil -> {current_value, new_value :: value} | :pop)) ::
+          {current_value, new_map :: map}
         when current_value: value
   def get_and_update(map, key, fun) when is_function(fun, 1) do
     current = get(map, key)
@@ -897,7 +897,7 @@ defmodule Map do
       {1, %{}}
 
   """
-  @spec get_and_update!(map, key, (value -> {current_value, new_value :: value} | :pop)) ::
+  @spec get_and_update!(map, key, (value | nil -> {current_value, new_value :: value} | :pop)) ::
           {current_value, map}
         when current_value: value
   def get_and_update!(map, key, fun) when is_function(fun, 1) do


### PR DESCRIPTION
In the same fashion of PRs #10228 and #10223

Replaces:
- `get_values` with `current_value`
- `update_value` with `new_value`
- `data` with `new_data` when suitable

Adds nil as an argument term in the function spec.