### PR TITLE
Use one-based var names in Types

### DIFF
--- a/lib/elixir/lib/module/types/unify.ex
+++ b/lib/elixir/lib/module/types/unify.ex
@@ -830,8 +830,8 @@ defmodule Module.Types.Unify do
     inspect(literal)
   end
 
-  def format_type({:var, index}, _simplify?) do
-    "var#{index}"
+  def format_type({:var, index}, _simplify?) when is_integer(index) do
+    "var#{index + 1}"
   end
 
   def format_type(atom, _simplify?) when is_atom(atom) do

--- a/lib/elixir/lib/module/types/unify.ex
+++ b/lib/elixir/lib/module/types/unify.ex
@@ -830,7 +830,7 @@ defmodule Module.Types.Unify do
     inspect(literal)
   end
 
-  def format_type({:var, index}, _simplify?) when is_integer(index) do
+  def format_type({:var, index}, _simplify?) do
     "var#{index + 1}"
   end
 

--- a/lib/elixir/test/elixir/module/types/types_test.exs
+++ b/lib/elixir/test/elixir/module/types/types_test.exs
@@ -144,14 +144,14 @@ defmodule Module.Types.TypesTest do
       assert string == """
              incompatible types:
 
-                 {var0} !~ var0
+                 {var1} !~ var1
 
              in expression:
 
                  # types_test.ex:1
                  {var} = var
 
-             where "var" was given the type {var0} in:
+             where "var" was given the type {var1} in:
 
                  # types_test.ex:1
                  {var} = var


### PR DESCRIPTION
In the same fashion as generated arguments 30373382ec2183d316f14b6ec6a99225855c6d8d
