### PR TITLE
Fix KeyError custom message

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1255,6 +1255,10 @@ defmodule KeyError do
   end
 
   @impl true
+  def blame(exception = %{message: message}, stacktrace) when is_binary(message) do
+    {exception, stacktrace}
+  end
+
   def blame(exception = %{term: nil}, stacktrace) do
     message = message(exception.key, exception.term)
     {%{exception | message: message}, stacktrace}

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -731,6 +731,11 @@ defmodule ExceptionTest do
       assert %ArgumentError{message: "unexpected comté"} |> message == "unexpected comté"
     end
 
+    test "" do
+      assert %KeyError{} |> message == "key nil not found"
+      assert %KeyError{message: "key missed"} |> message == "key missed"
+    end
+
     test "Enum.OutOfBoundsError" do
       assert %Enum.OutOfBoundsError{} |> message == "out of bounds error"
 

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -731,7 +731,7 @@ defmodule ExceptionTest do
       assert %ArgumentError{message: "unexpected comté"} |> message == "unexpected comté"
     end
 
-    test "" do
+    test "KeyError" do
       assert %KeyError{} |> message == "key nil not found"
       assert %KeyError{message: "key missed"} |> message == "key missed"
     end


### PR DESCRIPTION
Bug:
iex(1)> raise KeyError, "My message"
** (KeyError) key nil not found

Fix:
iex(1)> raise KeyError, "My message"
** (KeyError) My message