### PR TITLE
Add fallback clauses in defs for stepless ranges

### DIFF
--- a/lib/elixir/test/elixir/range_test.exs
+++ b/lib/elixir/test/elixir/range_test.exs
@@ -2,11 +2,25 @@ Code.require_file("test_helper.exs", __DIR__)
 
 defmodule RangeTest do
   use ExUnit.Case, async: true
+  import ExUnit.CaptureIO
 
   doctest Range
 
   defp reverse(first..last) do
     last..first
+  end
+
+  @doc false
+  def stepless(first..last//_step) do
+    %{__struct__: Range, first: first, last: last}
+  end
+
+  defmacrop capture_err(fun_string) do
+    quote bind_quoted: [fun_string: fun_string, env: Macro.escape(__CALLER__)] do
+      capture_io(:stderr, fn ->
+        Code.eval_string(fun_string, [], env)
+      end)
+    end
   end
 
   defp assert_disjoint(r1, r2) do
@@ -92,6 +106,48 @@ defmodule RangeTest do
       assert_overlap(-7..-5, -5..-1)
 
       assert Range.disjoint?(1..1, 1..1) == false
+    end
+  end
+
+  describe "Old stepless format" do
+    test "Range functions" do
+      assert_disjoint(stepless(1..5), stepless(6..9))
+
+      # skip warning in deprecated functions
+      capture_err(~S"""
+        Range.range?(1..5)
+        Range.range?(__MODULE__.stepless(1..5))
+
+        range = 1..5//2
+        bad_range = %{range | step: 0}
+        Range.range?(bad_range)
+      """)
+    end
+
+    test "Inspect protocol" do
+      assert inspect(stepless(1..5)) == "1..5"
+    end
+
+    test "Enum module" do
+      old_range = stepless(1..3)
+
+      assert Enum.min_max(old_range)
+      assert Enum.count(old_range)
+      assert Enum.member?(old_range, 3)
+      assert Enum.reduce(old_range, [], fn x, acc -> [x | acc] end)
+
+      assert Enum.slice(old_range, 5..10)
+      assert Enum.slice(old_range, old_range)
+      assert Enum.slice(5..10, old_range)
+      assert Enum.slice(old_range, 5..10)
+
+      assert Enum.slice(old_range, 5, 10)
+
+      assert Enum.sum(old_range)
+      assert Enum.max(old_range)
+      assert Enum.max_by(old_range, fn x -> :math.pow(-2, x) end)
+      assert Enum.min(old_range)
+      assert Enum.min_by(old_range, fn x -> :math.pow(-2, x) end)
     end
   end
 end


### PR DESCRIPTION
If a library manually built the ranges, and runs on Elixir v12.0
it will crash as the ranges will not pattern match first..last//step.

This commit adds a fallback clause to all functions that introduce
the new range syntax.

Tests are added.