### PR TITLE
Introduce Range.t/3 type

### DIFF
--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -97,6 +97,7 @@ defmodule Range do
   @type step :: pos_integer | neg_integer
   @type t :: %__MODULE__{first: first, last: last, step: step}
   @type t(first, last) :: %__MODULE__{first: first, last: last}
+  @type t(first, last, step) :: %__MODULE__{first: first, last: last, step: step}
 
   @doc """
   Creates a new range.


### PR DESCRIPTION
We should probably deprecate t/2 when we hard deprecate the old range format.