### PR TITLE
Fix t:Range.t/2

### DIFF
--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -96,7 +96,7 @@ defmodule Range do
   @type last :: integer
   @type step :: pos_integer | neg_integer
   @type t :: %__MODULE__{first: first, last: last, step: step}
-  @type t(first, last) :: %__MODULE__{first: first, last: last}
+  @type t(first, last) :: %__MODULE__{first: first, last: last, step: step}
 
   @doc """
   Creates a new range.


### PR DESCRIPTION
We need to be explicit and define the step field, otherwise IEx and ExDoc will spec it as "term()"

    (1)> t Range.t/2
    @type t(first, last) :: %Range{first: first, last: last, step: term()