### PR TITLE
Restrict step in t:Range.t/2

### DIFF
--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -96,7 +96,7 @@ defmodule Range do
   @type last :: integer
   @type step :: pos_integer | neg_integer
   @type t :: %__MODULE__{first: first, last: last, step: step}
-  @type t(first, last) :: %__MODULE__{first: first, last: last, step: step}
+  @type t(first, last) :: %__MODULE__{first: first, last: last, step: 1 | -1}
 
   @doc """
   Creates a new range.


### PR DESCRIPTION
It improves the changes introduced in 95a6792 (#10833)
As a range defined with only first and last fields should be a consecutive sequence of integers.