### PR TITLE
Do not make Range.empty?/1 public

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -958,6 +958,10 @@ defmodule Enum do
     enumerable == []
   end
 
+  def empty?(_.._//_ = range) do
+    Range.__empty__?(range)
+  end
+
   def empty?(enumerable) do
     case Enumerable.slice(enumerable) do
       {:ok, value, _} ->
@@ -2026,7 +2030,7 @@ defmodule Enum do
   def min_max(enumerable, empty_fallback \\ fn -> raise Enum.EmptyError end)
 
   def min_max(first..last//step = range, empty_fallback) when is_function(empty_fallback, 0) do
-    if Range.empty?(range) do
+    if Range.__empty__?(range) do
       empty_fallback.()
     else
       last = last - rem(last - first, step)
@@ -3611,7 +3615,7 @@ defmodule Enum do
   end
 
   defp aggregate(first..last//step = range, fun, empty) do
-    if Range.empty?(range) do
+    if Range.__empty__?(range) do
       empty.()
     else
       last = last - rem(last - first, step)

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -150,25 +150,9 @@ defmodule Range do
             "non-zero integer, got: #{inspect(first)}..#{inspect(last)}//#{inspect(step)}"
   end
 
-  @doc """
-  Checks if the range is empty.
-
-  ## Examples
-
-      iex> Range.empty?(1..0//1)
-      true
-      iex> Range.empty?(0..1//-1)
-      true
-      iex> Range.empty?(1..0)
-      false
-      iex> Range.empty?(0..1)
-      false
-
-  """
-  @doc since: "1.12.0"
-  def empty?(first..last//step) when step > 0 and first > last, do: true
-  def empty?(first..last//step) when step < 0 and first < last, do: true
-  def empty?(_.._//_), do: false
+  def __empty__?(first..last//step) when step > 0 and first > last, do: true
+  def __empty__?(first..last//step) when step < 0 and first < last, do: true
+  def __empty__?(_.._//_), do: false
 
   @doc """
   Returns the size of the range.
@@ -197,9 +181,13 @@ defmodule Range do
 
   """
   @doc since: "1.12.0"
-  def size(first..last//step) when step > 0 and first > last, do: 0
-  def size(first..last//step) when step < 0 and first < last, do: 0
-  def size(first..last//step), do: abs(div(last - first, step)) + 1
+  def size(first..last//step = range) do
+    if __empty__?(range) do
+      0
+    else
+      abs(div(last - first, step)) + 1
+    end
+  end
 
   @doc """
   Checks if two ranges are disjoint.
@@ -242,7 +230,7 @@ defmodule Range do
   @doc since: "1.8.0"
   @spec disjoint?(t, t) :: boolean
   def disjoint?(first1..last1//step1 = range1, first2..last2//step2 = range2) do
-    if empty?(range1) or empty?(range2) do
+    if __empty__?(range1) or __empty__?(range2) do
       true
     else
       {first1, last1, step1} = normalize(first1, last1, step1)
@@ -273,7 +261,7 @@ defmodule Range do
     end
   end
 
-  @compile inline: [normalize: 3, empty?: 1]
+  @compile inline: [normalize: 3, __empty__?: 1]
   defp normalize(first, last, step) when first > last, do: {last, first, -step}
   defp normalize(first, last, step), do: {first, last, step}
 
@@ -309,7 +297,7 @@ defimpl Enumerable, for: Range do
 
   def member?(first..last//step = range, value) when is_integer(value) do
     cond do
-      Range.empty?(range) ->
+      Range.__empty__?(range) ->
         {:ok, false}
 
       first <= last ->


### PR DESCRIPTION
`Range.empty?/1` is renamed `Range.__empty__?/1`.

The reason is that `Range.empty?/`1 is overlapped by` Enum.empty?/`1, additionally
it can be checked with Range.size(range) == 0.

`Enum.empty?/1` is optimized to call this function.

`Range.size/1` is simplified by calling this function.