### PR TITLE
Allow empty sigils as a syntactic sugar for UTC “now”

### DIFF
--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -13,6 +13,10 @@ defmodule DateTest do
     assert ~D[20001-01-01 Calendar.Holocene] ==
              %Date{calendar: Calendar.Holocene, year: 20001, month: 1, day: 1}
 
+    {now1, now2} = {Date.utc_today(), ~D[]}
+    # to be safe running at midnight
+    assert Date.diff(now1, now2) <= 1
+
     assert_raise ArgumentError,
                  ~s/cannot parse "2000-50-50" as Date for Calendar.ISO, reason: :invalid_date/,
                  fn -> Code.eval_string("~D[2000-50-50]") end

--- a/lib/elixir/test/elixir/calendar/time_test.exs
+++ b/lib/elixir/test/elixir/calendar/time_test.exs
@@ -13,6 +13,9 @@ defmodule TimeTest do
     assert ~T[12:34:56 Calendar.Holocene] ==
              %Time{calendar: Calendar.Holocene, hour: 12, minute: 34, second: 56}
 
+    {now1, now2} = {Time.utc_now(), ~T[]}
+    assert Time.diff(now1, now2) <= 2
+
     assert_raise ArgumentError,
                  ~s/cannot parse "12:34:65" as Time for Calendar.ISO, reason: :invalid_time/,
                  fn -> Code.eval_string("~T[12:34:65]") end

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1399,6 +1399,9 @@ defmodule KernelTest do
              zone_abbr: "UTC"
            }
 
+    {now1, now2} = {DateTime.utc_now(), ~U[]}
+    assert DateTime.diff(now1, now2) <= 2
+
     assert_raise ArgumentError, ~r"reason: :invalid_format", fn ->
       Code.eval_string(~s{~U[2015-01-13 13:00]})
     end


### PR DESCRIPTION
This PR provides syntactic sugar for date/time sigils as shown below

```elixir
# ~U[]s
DateTime.truncate(DateTime.utc_now(), :second)

# ~T[]m
Time.truncate(Time.utc_now(), :millisecond)

# ~D[]
Date.utc_today()
```