### PR TITLE
Set correct value returned by `get_fun/2` callback

### DIFF
--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -99,7 +99,7 @@ defmodule Access do
   @type key :: any
   @type value :: any
 
-  @type get_fun(data, current_value) ::
+  @type get_fun(data) ::
           (:get, data, (term -> term) -> new_data :: container)
 
   @type get_and_update_fun(data, current_value) ::
@@ -107,7 +107,7 @@ defmodule Access do
              {current_value, new_data :: container} | :pop)
 
   @type access_fun(data, current_value) ::
-          get_fun(data, current_value) | get_and_update_fun(data, current_value)
+          get_fun(data) | get_and_update_fun(data, current_value)
 
   @doc """
   Invoked in order to access the value stored under `key` in the given term `term`.

--- a/lib/elixir/lib/access.ex
+++ b/lib/elixir/lib/access.ex
@@ -100,8 +100,7 @@ defmodule Access do
   @type value :: any
 
   @type get_fun(data, current_value) ::
-          (:get, data, (term -> term) ->
-             {current_value, new_data :: container})
+          (:get, data, (term -> term) -> new_data :: container)
 
   @type get_and_update_fun(data, current_value) ::
           (:get_and_update, data, (term -> term) ->


### PR DESCRIPTION
By looking at source of `Access.all/0` it seems that returned value by this function is `container()` instead of tuple `{val, container()}`.