### PR TITLE
Update Enum.{random, shuffle}/1 docs to OTP 22

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2223,19 +2223,18 @@ defmodule Enum do
 
   ## Examples
 
-  The examples below use the `:exrop` pseudorandom algorithm since it's
-  the default from Erlang/OTP 20, however if you are using Erlang/OTP 22
-  or above then `:exsss` is the default algorithm. If you are using `:exsplus`,
+  The examples below use the `:exsss` pseudorandom algorithm since it's
+  the default from Erlang/OTP 22. If you are using `:exsplus`,
   then please update, as this algorithm is deprecated since Erlang/OTP 20.
 
       # Although not necessary, let's seed the random algorithm
-      iex> :rand.seed(:exrop, {101, 102, 103})
-      iex> Enum.random([1, 2, 3])
-      3
+      iex> :rand.seed(:exsss, {100, 101, 102})
       iex> Enum.random([1, 2, 3])
       2
+      iex> Enum.random([1, 2, 3])
+      1
       iex> Enum.random(1..1_000)
-      846
+      309
 
   """
   @spec random(t) :: element
@@ -2551,17 +2550,16 @@ defmodule Enum do
 
   ## Examples
 
-  The examples below use the `:exrop` pseudorandom algorithm since it's
-  the default from Erlang/OTP 20, however if you are using Erlang/OTP 22
-  or above then `:exsss` is the default algorithm. If you are using `:exsplus`,
+  The examples below use the `:exsss` pseudorandom algorithm since it's
+  the default from Erlang/OTP 22. If you are using `:exsplus`,
   then please update, as this algorithm is deprecated since Erlang/OTP 20.
 
       # Although not necessary, let's seed the random algorithm
-      iex> :rand.seed(:exrop, {1, 2, 3})
+      iex> :rand.seed(:exsss, {1, 2, 3})
       iex> Enum.shuffle([1, 2, 3])
-      [3, 1, 2]
+      [3, 2, 1]
       iex> Enum.shuffle([1, 2, 3])
-      [1, 3, 2]
+      [2, 1, 3]
 
   """
   @spec shuffle(t) :: list
@@ -3148,11 +3146,11 @@ defmodule Enum do
   ## Examples
 
       # Although not necessary, let's seed the random algorithm
-      iex> :rand.seed(:exrop, {1, 2, 3})
+      iex> :rand.seed(:exsss, {1, 2, 3})
       iex> Enum.take_random(1..10, 2)
-      [7, 2]
+      [3, 1]
       iex> Enum.take_random(?a..?z, 5)
-      'hypnt'
+      'mikel'
 
   """
   @spec take_random(t, non_neg_integer) :: list

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2224,8 +2224,7 @@ defmodule Enum do
   ## Examples
 
   The examples below use the `:exsss` pseudorandom algorithm since it's
-  the default from Erlang/OTP 22. If you are using `:exsplus`,
-  then please update, as this algorithm is deprecated since Erlang/OTP 20.
+  the default from Erlang/OTP 22:
 
       # Although not necessary, let's seed the random algorithm
       iex> :rand.seed(:exsss, {100, 101, 102})
@@ -2551,8 +2550,7 @@ defmodule Enum do
   ## Examples
 
   The examples below use the `:exsss` pseudorandom algorithm since it's
-  the default from Erlang/OTP 22. If you are using `:exsplus`,
-  then please update, as this algorithm is deprecated since Erlang/OTP 20.
+  the default from Erlang/OTP 22:
 
       # Although not necessary, let's seed the random algorithm
       iex> :rand.seed(:exsss, {1, 2, 3})

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -1443,9 +1443,9 @@ defmodule Stream do
   ## Examples
 
       # Although not necessary, let's seed the random algorithm
-      iex> :rand.seed(:exrop, {1, 2, 3})
+      iex> :rand.seed(:exsss, {1, 2, 3})
       iex> Stream.repeatedly(&:rand.uniform/0) |> Enum.take(3)
-      [0.7498295129076106, 0.06161655489244533, 0.7924073127680873]
+      [0.5455598952593053, 0.6039309974353404, 0.6684893034823949]
 
   """
   @spec repeatedly((() -> element)) :: Enumerable.t()


### PR DESCRIPTION
No longer use :exrop and :exsplus alogrithms in documentation.