### PR TITLE
Pass xref's compile args to compile task

### DIFF
--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -189,20 +189,12 @@ defmodule Mix.Tasks.Xref do
     min_cycle_size: :integer
   ]
 
-  @compile_args [
-    "--no-compile",
-    "--no-deps-check",
-    "--no-archives-check",
-    "--no-elixir-version-check"
-  ]
-
   @impl true
   def run(args) do
-    compile_args = for arg when arg in @compile_args <- args, do: arg
-    {opts, args} = OptionParser.parse!(args, strict: @switches)
-
-    Mix.Task.run("compile", compile_args)
+    Mix.Task.run("compile", args)
     Mix.Task.reenable("xref")
+
+    {opts, args} = OptionParser.parse!(args, strict: @switches)
 
     case args do
       ["callers", callee] ->

--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -189,10 +189,19 @@ defmodule Mix.Tasks.Xref do
     min_cycle_size: :integer
   ]
 
+  @compile_args [
+    "--no-compile",
+    "--no-deps-check",
+    "--no-archives-check",
+    "--no-elixir-version-check"
+  ]
+
   @impl true
   def run(args) do
+    compile_args = for arg when arg in @compile_args <- args, do: arg
     {opts, args} = OptionParser.parse!(args, strict: @switches)
-    Mix.Task.run("compile", args)
+
+    Mix.Task.run("compile", compile_args)
     Mix.Task.reenable("xref")
 
     case args do

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -587,6 +587,38 @@ defmodule Mix.Tasks.XrefTest do
       end)
     end
 
+    test "compiles project first by default" do
+      in_fixture("no_mixfile", fn ->
+        File.write!("lib/a.ex", """
+        defmodule A do
+          def a, do: :ok
+        end
+        """)
+
+        Mix.Tasks.Xref.run(["graph"])
+
+        assert "Compiling" <> _ = receive_until_no_messages([])
+      end)
+    end
+
+    test "passes args over to compile task" do
+      in_fixture("no_mixfile", fn ->
+        File.write!("lib/a.ex", """
+        defmodule A do
+          def a, do: :ok
+        end
+        """)
+
+        Mix.Task.run("compile")
+        Mix.Task.reenable("compile")
+        Mix.shell().flush()
+
+        Mix.Tasks.Xref.run(["graph", "--no-compile"])
+
+        refute String.starts_with?(receive_until_no_messages([]), "Compiling")
+      end)
+    end
+
     defp assert_graph(opts \\ [], expected) do
       in_fixture("no_mixfile", fn ->
         File.write!("lib/a.ex", """


### PR DESCRIPTION
`mix xref` task's module doc lists some arguments that are supposed to affect compilation, but they get stripped off by option parser before passing `args` to `compile` task.

In result, `compile` task is run with default arguments and project compilation is always _attempted_.

The PR fixes this.