### PR TITLE
Fix git default branch warnings

### DIFF
--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -223,8 +223,9 @@ Enum.each(fixtures, fn fixture ->
 end)
 
 ## Generate Git repo fixtures
-System.cmd("git", ~w[config --global user.email "mix@example.com"])
-System.cmd("git", ~w[config --global user.name "mix-repo"])
+System.cmd("git", ~w[config --global user.email mix@example.com])
+System.cmd("git", ~w[config --global user.name mix-repo])
+System.cmd("git", ~w[config --global init.defaultBranch not-main])
 
 # Git repo
 target = Path.expand("fixtures/git_repo", __DIR__)


### PR DESCRIPTION
Includes the fix for Windows by removing redundant quotes.