### PR TITLE
Mention single-element ranges in range definition

### DIFF
--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -49,6 +49,10 @@ defmodule Range do
       iex> -10..-10//1 |> Enum.to_list()
       [-10]
 
+      # Regardless the step the range will not be empty
+      iex> 5..5//-42 |> Enum.to_list()
+      [5]
+
   An increasing range `first..last//step` is a range from
   `first` to `last` increasing by `step` where  `step` must be a positive
   integer and all values `v` must be `first <= v and v < last`. Therefore, a range

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -39,17 +39,41 @@ defmodule Range do
 
   ## Definition
 
+  A single-element range `first..last//step` is a rangewhere
+  `first == last` and `step` must be either a positive or a
+  negative integer. For example `5..5//1`, and `-10..-10//1`.
+
+      iex> 5..5//1 |> Enum.to_list()
+      [5]
+
+      iex> -10..-10//1 |> Enum.to_list()
+      [-10]
+
   An increasing range `first..last//step` is a range from
   `first` to `last` increasing by `step` where  `step` must be a positive
-  integer and all values `v` must be `first <= v and v <= last`. Therefore, a range
+  integer and all values `v` must be `first <= v and v < last`. Therefore, a range
   `10..0//1` is an empty range because there is no value `v`
-  that is `10 <= v and v <= 0`.
+  that is `10 <= v and v < 0`.
+
+      iex> 3..5//1 |> Enum.to_list()
+      [3, 4, 5]
+
+      iex> 10..0//1 |> Enum.to_list()
+      []
+
 
   Similarly, a decreasing range `first..last//step` is a range
   from `first` to `last` decreasing by `step` where `step` must be a negative
-  integer and  values `v` must be `first >= v and v >= last`. Therefore, a range
+  integer and  values `v` must be `first >= v and v > last`. Therefore, a range
   `0..10//-1` is an empty range because there is no value `v`
-  that is `0 >= v and v >= 10`.
+  that is `0 >= v and v > 10`.
+
+      iex> 6..4//-1 |> Enum.to_list()
+      [6, 5, 4]
+
+      iex> 0..10//-1 |> Enum.to_list()
+      []
+
 
   ## Representation
 

--- a/lib/elixir/test/elixir/range_test.exs
+++ b/lib/elixir/test/elixir/range_test.exs
@@ -70,6 +70,13 @@ defmodule RangeTest do
     assert_raise ArgumentError, message, fn -> 1..3//step end
   end
 
+  test "single-element ranges" do
+    assert Enum.to_list(10..10//1) == [10]
+    assert Enum.to_list(10..10//-1) == [10]
+    assert Enum.to_list(10..10//42) == [10]
+    assert Enum.to_list(10..10//-42)== [10]
+  end
+
   describe "disjoint?" do
     test "returns true for disjoint ranges" do
       assert_disjoint(1..5, 6..9)


### PR DESCRIPTION
It is kind of confusing to think of single-element ranges either as increasing and decreasing as per the previous definition.

It got me thinking when `5..5//1` had one element, why `5..5//-1` had one element too. 