### PR TITLE
Use docs canonical version in all built-in apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ clean_residual_files:
 LOGO_PATH = $(shell test -f ../docs/logo.png && echo "--logo ../docs/logo.png")
 SOURCE_REF = $(shell tag="$(call GIT_TAG)" revision="$(call GIT_REVISION)"; echo "$${tag:-$$revision}")
 DOCS_FORMAT = html
-COMPILE_DOCS = bin/elixir ../ex_doc/bin/ex_doc "$(1)" "$(VERSION)" "lib/$(2)/ebin" --main "$(3)" --source-url "https://github.com/elixir-lang/elixir" --source-ref "$(call SOURCE_REF)" $(call LOGO_PATH) --output doc/$(2) --canonical "https://hexdocs.pm/$(2)/$(CANONICAL)" --homepage-url "https://elixir-lang.org/docs.html" --formatter "$(DOCS_FORMAT)" $(4)
+COMPILE_DOCS = CANONICAL=$(CANONICAL) bin/elixir ../ex_doc/bin/ex_doc "$(1)" "$(VERSION)" "lib/$(2)/ebin" --main "$(3)" --source-url "https://github.com/elixir-lang/elixir" --source-ref "$(call SOURCE_REF)" $(call LOGO_PATH) --output doc/$(2) --canonical "https://hexdocs.pm/$(2)/$(CANONICAL)" --homepage-url "https://elixir-lang.org/docs.html" --formatter "$(DOCS_FORMAT)" $(4)
 
 docs: compile ../ex_doc/bin/ex_doc docs_elixir docs_eex docs_mix docs_iex docs_ex_unit docs_logger
 
@@ -192,27 +192,27 @@ docs_elixir: compile ../ex_doc/bin/ex_doc
 docs_eex: compile ../ex_doc/bin/ex_doc
 	@ echo "==> ex_doc (eex)"
 	$(Q) rm -rf doc/eex
-	$(call COMPILE_DOCS,EEx,eex,EEx)
+	$(call COMPILE_DOCS,EEx,eex,EEx,--config "lib/mix/docs.exs")
 
 docs_mix: compile ../ex_doc/bin/ex_doc
 	@ echo "==> ex_doc (mix)"
 	$(Q) rm -rf doc/mix
-	$(call COMPILE_DOCS,Mix,mix,Mix)
+	$(call COMPILE_DOCS,Mix,mix,Mix,--config "lib/mix/docs.exs")
 
 docs_iex: compile ../ex_doc/bin/ex_doc
 	@ echo "==> ex_doc (iex)"
 	$(Q) rm -rf doc/iex
-	$(call COMPILE_DOCS,IEx,iex,IEx)
+	$(call COMPILE_DOCS,IEx,iex,IEx,--config "lib/mix/docs.exs")
 
 docs_ex_unit: compile ../ex_doc/bin/ex_doc
 	@ echo "==> ex_doc (ex_unit)"
 	$(Q) rm -rf doc/ex_unit
-	$(call COMPILE_DOCS,ExUnit,ex_unit,ExUnit)
+	$(call COMPILE_DOCS,ExUnit,ex_unit,ExUnit,--config "lib/mix/docs.exs")
 
 docs_logger: compile ../ex_doc/bin/ex_doc
 	@ echo "==> ex_doc (logger)"
 	$(Q) rm -rf doc/logger
-	$(call COMPILE_DOCS,Logger,logger,Logger)
+	$(call COMPILE_DOCS,Logger,logger,Logger,--config "lib/mix/docs.exs")
 
 ../ex_doc/bin/ex_doc:
 	@ echo "ex_doc is not found in ../ex_doc as expected. See README for more information."

--- a/lib/elixir/docs.exs
+++ b/lib/elixir/docs.exs
@@ -1,6 +1,16 @@
 # Returns config for Elixir docs
+
+canonical = System.fetch_env!("CANONICAL")
+
 [
   extras: Path.wildcard("lib/elixir/pages/*.md") ++ ["CHANGELOG.md"],
+  deps: [
+    eex: "https://hexdocs.pm/eex/#{canonical}",
+    ex_unit: "https://hexdocs.pm/ex_unit/#{canonical}",
+    iex: "https://hexdocs.pm/iex/#{canonical}",
+    logger: "https://hexdocs.pm/logger/#{canonical}",
+    mix: "https://hexdocs.pm/mix/#{canonical}"
+  ],
   groups_for_functions: [
     Guards: &(&1[:guard] == true)
   ],

--- a/lib/mix/docs.exs
+++ b/lib/mix/docs.exs
@@ -1,0 +1,12 @@
+canonical = System.fetch_env!("CANONICAL")
+
+[
+  deps: [
+    eex: "https://hexdocs.pm/eex/#{canonical}",
+    elixir: "https://hexdocs.pm/elixir/#{canonical}",
+    ex_unit: "https://hexdocs.pm/ex_unit/#{canonical}",
+    iex: "https://hexdocs.pm/iex/#{canonical}",
+    logger: "https://hexdocs.pm/logger/#{canonical}",
+    mix: "https://hexdocs.pm/mix/#{canonical}"
+  ]
+]


### PR DESCRIPTION
Before:

https://hexdocs.pm/elixir/1.12.0-rc.0/changelog.html contains links like:

    [`Mix.install/2`](https://hexdocs.pm/mix/Mix.html#install/2)

which currently 404.

After:

https://hexdocs.pm/elixir/1.12.0-rc.0/changelog.html would contain:

    [`Mix.install/2`](https://hexdocs.pm/mix/1.12/Mix.html#install/2)

(it requires https://github.com/elixir-lang/elixir/pull/10871 too)

See demo: http://wojtekmach.pl/docs/elixir/1.12/elixir/changelog.html