### PR TITLE
Require scheme in URIs

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -740,7 +740,7 @@ defimpl String.Chars, for: URI do
             "got: #{inspect(uri)}"
   end
 
-  def to_string(%{scheme: nil}) do
+  def to_string(%{scheme: scheme}) when is_nil(scheme) or scheme == "" do
     raise ArgumentError, ":scheme is required and cannot be nil"
   end
 

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -741,7 +741,7 @@ defimpl String.Chars, for: URI do
   end
 
   def to_string(%{scheme: scheme}) when is_nil(scheme) or scheme == "" do
-    raise ArgumentError, ":scheme is required and cannot be nil"
+    raise ArgumentError, ":scheme is required and cannot be nil or empty"
   end
 
   def to_string(%{scheme: scheme, port: port, path: path, query: query, fragment: fragment} = uri) do

--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -631,19 +631,20 @@ defmodule URI do
   used if the `:host` is `nil`. Otherwise, the `:userinfo`, `:host`, and `:port` will
   be used.
 
-      iex> URI.to_string(%URI{authority: "foo@example.com:80"})
-      "//foo@example.com:80"
+      iex> URI.to_string(%URI{scheme: "http", authority: "foo@example.com:80"})
+      "http://foo@example.com:80"
 
-      iex> URI.to_string(%URI{userinfo: "bar", host: "example.org", port: 81})
-      "//bar@example.org:81"
+      iex> URI.to_string(%URI{scheme: "http", userinfo: "bar", host: "example.org", port: 81})
+      "http://bar@example.org:81"
 
       iex> URI.to_string(%URI{
+      ...>   scheme: "http",
       ...>   authority: "foo@example.com:80",
       ...>   userinfo: "bar",
       ...>   host: "example.org",
       ...>   port: 81
       ...> })
-      "//bar@example.org:81"
+      "http://bar@example.org:81"
 
   """
   @spec to_string(t) :: binary
@@ -737,6 +738,10 @@ defimpl String.Chars, for: URI do
     raise ArgumentError,
           ":path in URI must be nil or an absolute path if :host or :authority are given, " <>
             "got: #{inspect(uri)}"
+  end
+
+  def to_string(%{scheme: nil}) do
+    raise ArgumentError, ":scheme is required and cannot be nil"
   end
 
   def to_string(%{scheme: scheme, port: port, path: path, query: query, fragment: fragment} = uri) do

--- a/lib/elixir/test/elixir/string/chars_test.exs
+++ b/lib/elixir/test/elixir/string/chars_test.exs
@@ -90,9 +90,6 @@ defmodule String.Chars.URITest do
   test "uri" do
     uri = URI.parse("http://google.com")
     assert String.Chars.to_string(uri) == "http://google.com"
-
-    uri_no_host = URI.parse("/foo/bar")
-    assert String.Chars.to_string(uri_no_host) == "/foo/bar"
   end
 end
 

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -370,14 +370,20 @@ defmodule URITest do
 
     assert_raise ArgumentError,
                  ~r":path in URI must be nil or an absolute path if :host or :authority are given",
-                 fn -> %URI{scheme: "http", authority: "foo.com", path: "hello/123"} |> URI.to_string() end
+                 fn ->
+                   %URI{scheme: "http", authority: "foo.com", path: "hello/123"}
+                   |> URI.to_string()
+                 end
 
     assert_raise ArgumentError,
-                ~r":scheme is required and cannot be nil or empty",
-                fn -> %URI{host: "foo.com", path: "/hello/123"} |> URI.to_string() end
+                 ~r":scheme is required and cannot be nil or empty",
+                 fn -> %URI{host: "foo.com", path: "/hello/123"} |> URI.to_string() end
+
     assert_raise ArgumentError,
-                ~r":scheme is required and cannot be nil or empty",
-                fn -> %URI{scheme: "", host: "foo.com", path: "/hello/123"} |> URI.to_string() end
+                 ~r":scheme is required and cannot be nil or empty",
+                 fn ->
+                   %URI{scheme: "", host: "foo.com", path: "/hello/123"} |> URI.to_string()
+                 end
   end
 
   test "merge/2" do

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -375,6 +375,9 @@ defmodule URITest do
     assert_raise ArgumentError,
                 ~r":scheme is required and cannot be nil",
                 fn -> %URI{host: "foo.com", path: "/hello/123"} |> URI.to_string() end
+    assert_raise ArgumentError,
+                ~r":scheme is required and cannot be nil",
+                fn -> %URI{scheme: "", host: "foo.com", path: "/hello/123"} |> URI.to_string() end
   end
 
   test "merge/2" do

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -359,25 +359,22 @@ defmodule URITest do
     assert to_string(URI.parse("http://google.com/elixir")) == "http://google.com/elixir"
     assert to_string(URI.parse("http://google.com?q=lol")) == "http://google.com?q=lol"
     assert to_string(URI.parse("http://google.com?q=lol#omg")) == "http://google.com?q=lol#omg"
-    assert to_string(URI.parse("//google.com/elixir")) == "//google.com/elixir"
-    assert to_string(URI.parse("//google.com:8080/elixir")) == "//google.com:8080/elixir"
-    assert to_string(URI.parse("//user:password@google.com/")) == "//user:password@google.com/"
     assert to_string(URI.parse("http://[2001:db8::]:8080")) == "http://[2001:db8::]:8080"
     assert to_string(URI.parse("http://[2001:db8::]")) == "http://[2001:db8::]"
 
     assert URI.to_string(URI.parse("http://google.com")) == "http://google.com"
     assert URI.to_string(URI.parse("gid:hello/123")) == "gid:hello/123"
 
-    assert URI.to_string(URI.parse("//user:password@google.com/")) ==
-             "//user:password@google.com/"
+    assert URI.to_string(URI.parse("http://user:password@google.com/")) ==
+             "http://user:password@google.com/"
 
     assert_raise ArgumentError,
                  ~r":path in URI must be nil or an absolute path if :host or :authority are given",
-                 fn -> %URI{authority: "foo.com", path: "hello/123"} |> URI.to_string() end
+                 fn -> %URI{scheme: "http", authority: "foo.com", path: "hello/123"} |> URI.to_string() end
 
     assert_raise ArgumentError,
-                 ~r":path in URI must be nil or an absolute path if :host or :authority are given",
-                 fn -> %URI{host: "foo.com", path: "hello/123"} |> URI.to_string() end
+                ~r":scheme is required and cannot be nil",
+                fn -> %URI{host: "foo.com", path: "/hello/123"} |> URI.to_string() end
   end
 
   test "merge/2" do

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -373,10 +373,10 @@ defmodule URITest do
                  fn -> %URI{scheme: "http", authority: "foo.com", path: "hello/123"} |> URI.to_string() end
 
     assert_raise ArgumentError,
-                ~r":scheme is required and cannot be nil",
+                ~r":scheme is required and cannot be nil or empty",
                 fn -> %URI{host: "foo.com", path: "/hello/123"} |> URI.to_string() end
     assert_raise ArgumentError,
-                ~r":scheme is required and cannot be nil",
+                ~r":scheme is required and cannot be nil or empty",
                 fn -> %URI{scheme: "", host: "foo.com", path: "/hello/123"} |> URI.to_string() end
   end
 


### PR DESCRIPTION

I ran into an issue involving unexpected behavior from the URI module. The URI module does not appear to follow the specification with respect to the scheme of a URL. This can cause inconsistencies when operating with other tools and libraries that accept URIs.

According to the [spec](https://tools.ietf.org/html/rfc3986#section-3):
> The scheme and path components are required, though the path may be empty (no characters).

However, the URI module doesn't check if the scheme is provided, nor does it set a default scheme. If you don't specify a manual scheme, it comes out like `//abc.com`. I think it should throw an `ArgumentError` to match the existing behavior for checking the correctness of the path component before turning the URI into a string.