### PR TITLE
Addition to @shortdoc documentation

### DIFF
--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -40,7 +40,6 @@ defmodule Mix.Task do
   Define the `@shortdoc` attribute if you wish to make the task
   publicly visible on `mix help`. Omit this attribute if you do
   not want your task to be listed via `mix help`.
-  
   The `@moduledoc` attribute may override `@shortdoc`. The task
   will not appear in `mix help` if documentation for the entire
   module is hidden with `@moduledoc false`.

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -40,6 +40,10 @@ defmodule Mix.Task do
   Define the `@shortdoc` attribute if you wish to make the task
   publicly visible on `mix help`. Omit this attribute if you do
   not want your task to be listed via `mix help`.
+  
+  The `@moduledoc` attribute may override `@shortdoc`. The task
+  will not appear in `mix help` if documentation for the entire
+  module is hidden with `@moduledoc false`.
 
   If a task has requirements, they can be listed using the
   `@requirements` attribute. For example:


### PR DESCRIPTION
Hi there 👋 

I was creating a mix task and noticed that when `@moduledoc false` is set, it overrides the stated behaviour of `@shortdoc`:

> Define the @shortdoc attribute if you wish to make the task publicly visible on mix help. Omit this attribute if you do not want your task to be listed via mix help.

In other words, the task will not appear via `mix help` if `@moduledoc false` even if a `@shortdoc` is set.

I was a bit surprised by this until I read [Hiding Internal Modules and Functions](https://hexdocs.pm/elixir/writing-documentation.html#hiding-internal-modules-and-functions). In retrospect, it makes perfect sense.

However, this was not obvious to me solely in the context of the mix documentation alone — and implies knowledge of behaviour documented elsewhere. So I figured a clarifying addition to the `Mix.Task` documentation  paragraph might be helpful?