### PR TITLE
Fixing bug in Enum.dedup/1

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -787,7 +787,7 @@ defmodule Enum do
   def dedup(enumerable) do
     Enum.reduce(enumerable, [], fn x, acc ->
       case acc do
-        [^x, _] -> acc
+        [^x | _] -> acc
         _ -> [x | acc]
       end
     end)

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -184,6 +184,18 @@ defmodule EnumTest do
     assert Enum.dedup([nil]) == [nil]
   end
 
+  test "dedup/1 with streams" do
+    dedup_stream = fn list -> list |> Stream.map(& &1) |> Enum.dedup() end
+
+    assert dedup_stream.([1, 1, 2, 1, 1, 2, 1]) == [1, 2, 1, 2, 1]
+    assert dedup_stream.([2, 1, 1, 2, 1]) == [2, 1, 2, 1]
+    assert dedup_stream.([1, 2, 3, 4]) == [1, 2, 3, 4]
+    assert dedup_stream.([1, 1.0, 2.0, 2]) == [1, 1.0, 2.0, 2]
+    assert dedup_stream.([]) == []
+    assert dedup_stream.([nil, nil, true, {:value, true}]) == [nil, true, {:value, true}]
+    assert dedup_stream.([nil]) == [nil]
+  end
+
   test "dedup_by/2" do
     assert Enum.dedup_by([{1, :x}, {2, :y}, {2, :z}, {1, :x}], fn {x, _} -> x end) ==
              [{1, :x}, {2, :y}, {1, :x}]


### PR DESCRIPTION
Hi. I just noticed that `Enum.dedup/1` isn't working properly on non-list enumerables in the 1.12-rc.0.

```elixir
[1, 1, 0, 2] |> Stream.map(& &1) |> Enum.dedup()
[1, 1, 0, 2]
```

After investigating, I realized this was a bug I introduced myself in a previous PR :see_no_evil:.
Really sorry for that.