### PR TITLE
Added `default` option to `Mix.Shell.IO.yes?`

### DIFF
--- a/lib/mix/lib/mix/shell.ex
+++ b/lib/mix/lib/mix/shell.ex
@@ -44,7 +44,7 @@ defmodule Mix.Shell do
   @doc """
   Prompts the user for confirmation.
   """
-  @callback yes?(message :: binary) :: boolean
+  @callback yes?(message :: binary, options :: keyword) :: boolean
 
   @doc """
   Prints the current application to the shell if

--- a/lib/mix/lib/mix/shell/io.ex
+++ b/lib/mix/lib/mix/shell/io.ex
@@ -46,10 +46,20 @@ defmodule Mix.Shell.IO do
   end
 
   @doc """
-  Prints a message and asks the user if they want to proceed.
+  Prints a message and asks the user to confirm if they
+  want to proceed. The user must type and submit one of
+  "y", "yes", "Y", "YES" or "Yes".
 
-  The user must press Enter or type one of "y", "yes", "Y", "YES"
-  or "Yes".
+  The user may also press Enter; this can be configured
+  to either accept or reject the prompt. The latter case
+  may be useful for a potentially dangerous operation that
+  should require explicit confirmation from the user.
+
+  ## Options
+
+  * `:default` - (:yes or :no) if `:yes` pressing Enter
+    accepts the prompt; if `:no` pressing Enter rejects
+    the prompt instead. Defaults to `:yes`.
 
   ## Examples
 
@@ -58,10 +68,27 @@ defmodule Mix.Shell.IO do
       end
 
   """
-  def yes?(message) do
+  @spec yes?(String.t(), default: :yes | :no) :: boolean()
+  def yes?(message, options \\ []) do
+    default = Keyword.get(options, :default, :yes)
+
+    unless default in [:yes, :no] do
+      raise ArgumentError,
+            "expected :default to be either :yes or :no, got: #{inspect(default)}"
+    end
+
+    answers = ["y", "Y", "yes", "YES", "Yes"]
+
+    {prompt, accepted_answers} =
+      case default do
+        :yes -> {" [Yn] ", ["" | answers]}
+        :no -> {" [yN] ", answers}
+      end
+
     print_app()
-    answer = IO.gets(message <> " [Yn] ")
-    is_binary(answer) and String.trim(answer) in ["", "y", "Y", "yes", "YES", "Yes"]
+
+    answer = IO.gets(message <> prompt)
+    is_binary(answer) and String.trim(answer) in accepted_answers
   end
 
   defp red(message) do

--- a/lib/mix/lib/mix/shell/io.ex
+++ b/lib/mix/lib/mix/shell/io.ex
@@ -57,9 +57,9 @@ defmodule Mix.Shell.IO do
 
   ## Options
 
-  * `:default` - (:yes or :no) if `:yes` pressing Enter
-    accepts the prompt; if `:no` pressing Enter rejects
-    the prompt instead. Defaults to `:yes`.
+    * `:default` - (:yes or :no) if `:yes` pressing Enter
+      accepts the prompt; if `:no` pressing Enter rejects
+      the prompt instead. Defaults to `:yes`.
 
   ## Examples
 

--- a/lib/mix/lib/mix/shell/io.ex
+++ b/lib/mix/lib/mix/shell/io.ex
@@ -68,7 +68,6 @@ defmodule Mix.Shell.IO do
       end
 
   """
-  @spec yes?(String.t(), default: :yes | :no) :: boolean()
   def yes?(message, options \\ []) do
     default = Keyword.get(options, :default, :yes)
 

--- a/lib/mix/lib/mix/shell/process.ex
+++ b/lib/mix/lib/mix/shell/process.ex
@@ -133,19 +133,19 @@ defmodule Mix.Shell.Process do
 
   ## Example
 
-      # Send the response to self() first so that yes?/1 will be able to read it
+      # Send the response to self() first so that yes?/2 will be able to read it
       send(self(), {:mix_shell_input, :yes?, true})
       Mix.shell().yes?("Are you sure you want to continue?")
 
   """
-  def yes?(message) do
+  def yes?(message, _options \\ []) do
     print_app()
     send(message_target(), {:mix_shell, :yes?, [message]})
 
     receive do
       {:mix_shell_input, :yes?, response} -> response
     after
-      0 -> raise "no shell process input given for yes?/1"
+      0 -> raise "no shell process input given for yes?/2"
     end
   end
 

--- a/lib/mix/lib/mix/shell/quiet.ex
+++ b/lib/mix/lib/mix/shell/quiet.ex
@@ -32,12 +32,23 @@ defmodule Mix.Shell.Quiet do
   defdelegate prompt(message), to: Mix.Shell.IO
 
   @doc """
-  Prints a message and asks the user if they want to proceed.
+  Prints a message and asks the user to confirm if they
+  want to proceed. The user must type and submit one of
+  "y", "yes", "Y", "YES" or "Yes".
 
-  The user must press Enter or type one of "y", "yes", "Y", "YES" or
-  "Yes".
+  The user may also press Enter; this can be configured
+  to either accept or reject the prompt. The latter case
+  may be useful for a potentially dangerous operation that
+  should require explicit confirmation from the user.
+
+  ## Options
+
+    * `:default` - (:yes or :no) if `:yes` pressing Enter
+      accepts the prompt; if `:no` pressing Enter rejects
+      the prompt instead. Defaults to `:yes`.
+
   """
-  defdelegate yes?(message), to: Mix.Shell.IO
+  defdelegate yes?(message, options), to: Mix.Shell.IO
 
   @doc """
   Executes the given command quietly without outputting anything.

--- a/lib/mix/lib/mix/shell/quiet.ex
+++ b/lib/mix/lib/mix/shell/quiet.ex
@@ -48,7 +48,7 @@ defmodule Mix.Shell.Quiet do
       the prompt instead. Defaults to `:yes`.
 
   """
-  defdelegate yes?(message, options), to: Mix.Shell.IO
+  defdelegate yes?(message, options \\ []), to: Mix.Shell.IO
 
   @doc """
   Executes the given command quietly without outputting anything.

--- a/lib/mix/test/mix/shell/io_test.exs
+++ b/lib/mix/test/mix/shell/io_test.exs
@@ -18,7 +18,7 @@ defmodule Mix.Shell.IOTest do
            end) =~ "hello"
   end
 
-  test "asks the user with yes?" do
+  test "asks the user with yes? with implicit default option" do
     assert capture_io("\n", fn -> yes?("Ok?") end) == "Ok? [Yn] "
     assert capture_io("\n", fn -> assert yes?("Ok?") end)
     assert capture_io("Yes", fn -> assert yes?("Ok?") end)
@@ -27,6 +27,36 @@ defmodule Mix.Shell.IOTest do
 
     assert capture_io("n", fn -> refute yes?("Ok?") end)
     assert capture_io("", fn -> refute yes?("Ok?") end)
+  end
+
+  test "asks the user with yes? using :yes as default option" do
+    assert capture_io("\n", fn -> yes?("Ok?", default: :yes) end) == "Ok? [Yn] "
+    assert capture_io("\n", fn -> assert yes?("Ok?", default: :yes) end)
+    assert capture_io("Yes", fn -> assert yes?("Ok?", default: :yes) end)
+    assert capture_io("yes", fn -> assert yes?("Ok?", default: :yes) end)
+    assert capture_io("y", fn -> assert yes?("Ok?", default: :yes) end)
+
+    assert capture_io("n", fn -> refute yes?("Ok?") end)
+    assert capture_io("", fn -> refute yes?("Ok?") end)
+  end
+
+  test "asks the user with yes? using :no as default option" do
+    assert capture_io("\n", fn -> yes?("Ok?", default: :no) end) == "Ok? [yN] "
+    assert capture_io("Yes", fn -> assert yes?("Ok?", default: :no) end)
+    assert capture_io("yes", fn -> assert yes?("Ok?", default: :no) end)
+    assert capture_io("y", fn -> assert yes?("Ok?", default: :no) end)
+
+    assert capture_io("\n", fn -> refute yes?("Ok?", default: :no) end)
+    assert capture_io("n", fn -> refute yes?("Ok?", default: :no) end)
+    assert capture_io("", fn -> refute yes?("Ok?", default: :no) end)
+  end
+
+  test "asks the user with yes? and raise exception where default option is not valid" do
+    message = "expected :default to be either :yes or :no, got: :other"
+
+    assert_raise ArgumentError, message, fn ->
+      capture_io("\n", fn -> yes?("Ok?", default: :other) end)
+    end
   end
 
   test "runs a given command" do


### PR DESCRIPTION
Hello 👋 

As [proposed](https://groups.google.com/g/elixir-lang-core/c/yMn-Z4SqhEc) in the core mailing list, this is a change that adds an option to change the default behaviour of the `Enter` key as input for `Mix.Shell.IO.yes?`.

Currently, a user can simply press`Enter` to accept the prompt. The proposed change allows this this action to reject the prompt instead. Its rationale is to provide the option to enforce an explicit confirmation from the user, which may be a desirable safety net if accepting the prompt is for a potentially dangerous or irreversible operation.

As suggested by @josevalim the option would be `default: :yes | :no`; e.g:

```elixir
if Mix.Shell.IO.yes?("Delete everything? [yN]", default: :no) do
  delete_everything!()
end

if Mix.Shell.IO.yes?("Accept non-destructive action? [Yn]", default: :yes) do
  # ...
end
```

As well as changing the default behaviour of `Enter` the prompt also changes according to convention; i.e: `[Yn]` or `[yN]`

The implicit behaviour of this option is `:yes` to preserve existing functionality.

A couple of questions:

1. I added a spec, there are no other specs in this module however, so I can remove this if required (or add specs to other functions?)
2. Accepted values are `["y", "Y", "yes", "YES", "Yes"]`. Should this be case sensitive? I am currently operating under the assumption that this is an explicit allowlist for a reason.

This is my first Elixir PR so I welcome all feedback. Thanks!