### PR TITLE
Fix optional callback blame hint

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1064,7 +1064,9 @@ defmodule UndefinedFunctionError do
   end
 
   defp expects_callback?(behaviour, function, arity) do
-    callbacks = behaviour.behaviour_info(:callbacks)
+    callbacks =
+      behaviour.behaviour_info(:callbacks) -- behaviour.behaviour_info(:optional_callbacks)
+
     Enum.member?(callbacks, {function, arity})
   end
 


### PR DESCRIPTION
Previously it was wrongly hinting that the
behaviour Behaviour expected a private or undefined function to be present,
when the callback was optional.