### PR TITLE
IEx path autocompletion

### DIFF
--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -603,7 +603,7 @@ defmodule IEx.Autocomplete do
   defp expand_path(path_fragment, possible_paths) do
     expansions =
       Enum.map(possible_paths, fn {path, dir?} ->
-        {completion_part(path_fragment, path, dir?), to_charlist(Path.basename(path))}
+        {completion_part(path_fragment, path, dir?), String.to_charlist(Path.basename(path))}
       end)
 
     case expansions do
@@ -611,12 +611,12 @@ defmodule IEx.Autocomplete do
         no()
 
       [{unique, _}] ->
-        {:yes, to_charlist(unique), []}
+        {:yes, String.to_charlist(unique), []}
 
       list ->
         {completions, filenames} = Enum.unzip(list)
         common_prefix_size = :binary.longest_common_prefix(completions)
-        hint = completions |> hd() |> binary_part(0, common_prefix_size) |> to_charlist()
+        hint = completions |> hd() |> binary_part(0, common_prefix_size) |> String.to_charlist()
         {:yes, hint, filenames}
     end
   end

--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -580,15 +580,17 @@ defmodule IEx.Autocomplete do
   defp collect_path_fragment([?" | t], acc), do: return_path_fragment(t, acc)
   defp collect_path_fragment([h | t], acc), do: collect_path_fragment(t, [h | acc])
 
-  # scan the rest of the `expr`, returns `acc` if no other `"` is found, 
+  # scans the rest of the `expr`, returns `acc` if no other `"` is found, 
   # fallback to `discard_path_fragment` otherwise
   defp return_path_fragment([], acc), do: acc
+  defp return_path_fragment([?", ?\\ | t], acc), do: return_path_fragment(t, [?\\, ?" | acc])
   defp return_path_fragment([?" | t], acc), do: discard_path_fragment(t, acc)
   defp return_path_fragment([_ | t], acc), do: return_path_fragment(t, acc)
 
-  # scan the rest of the `expr`, discards `acc` if no other `"` is found, 
+  # scans the rest of the `expr`, discards `acc` if no other `"` is found, 
   # fallback to `return_path_fragment` otherwise
   defp discard_path_fragment([], _acc), do: []
+  defp discard_path_fragment([?", ?\\ | t], acc), do: discard_path_fragment(t, [?\\, ?" | acc])
   defp discard_path_fragment([?" | t], acc), do: return_path_fragment(t, acc)
   defp discard_path_fragment([_ | t], acc), do: discard_path_fragment(t, acc)
 

--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -20,7 +20,7 @@ defmodule IEx.Autocomplete do
   Some of the expansion has to be use the current shell
   environment, which is found via the broker.
   """
-  def expand(code , shell \\ IEx.Broker.shell()) do
+  def expand(code, shell \\ IEx.Broker.shell()) do
     case path_fragment(code) do
       [] -> expand_code(code, shell)
       path -> expand_path(path)
@@ -594,11 +594,11 @@ defmodule IEx.Autocomplete do
 
     path
     |> ls_prefix(dir)
-    |> Enum.map(fn path -> 
+    |> Enum.map(fn path ->
       %{
-        kind: (if File.dir?(path), do: :dir, else: :file), 
+        kind: if(File.dir?(path), do: :dir, else: :file),
         name: Path.basename(path)
-      } 
+      }
     end)
     |> format_expansion(path_hint(path, dir))
   end

--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -23,7 +23,7 @@ defmodule IEx.Autocomplete do
   def expand(code , shell \\ IEx.Broker.shell()) do
     case path_fragment(code) do
       [] -> expand_code(code, shell)
-      path -> expand_path(code)
+      path -> expand_path(path)
     end
   end
 
@@ -576,24 +576,12 @@ defmodule IEx.Autocomplete do
   # collects the fragment and store it on `acc`, calls `return_path_fragment` 
   # when it finds a `"`, discards `acc` otherwise
   defp collect_path_fragment([], _acc), do: []
-  defp collect_path_fragment([?", ?\\ | t], acc), do: collect_path_fragment(t, [?\\, ?" | acc])
   defp collect_path_fragment([?{, ?# | _rest], _acc), do: []
-  defp collect_path_fragment([?" | t], acc), do: return_path_fragment(t, acc)
+  defp collect_path_fragment([?", ?\\ | t], acc), do: collect_path_fragment(t, [?\\, ?" | acc])
+  defp collect_path_fragment([?/, ?., ?" | _], acc), do: [?., ?/ | acc]
+  defp collect_path_fragment([?/, ?" | _], acc), do: [?/ | acc]
+  defp collect_path_fragment([?" | _], _acc), do: []
   defp collect_path_fragment([h | t], acc), do: collect_path_fragment(t, [h | acc])
-
-  # scans the rest of the `expr`, returns `acc` if no other `"` is found, 
-  # fallback to `discard_path_fragment` otherwise
-  defp return_path_fragment([], acc), do: acc
-  defp return_path_fragment([?", ?\\ | t], acc), do: return_path_fragment(t, [?\\, ?" | acc])
-  defp return_path_fragment([?" | t], acc), do: discard_path_fragment(t, acc)
-  defp return_path_fragment([_ | t], acc), do: return_path_fragment(t, acc)
-
-  # scans the rest of the `expr`, discards `acc` if no other `"` is found, 
-  # fallback to `return_path_fragment` otherwise
-  defp discard_path_fragment([], _acc), do: []
-  defp discard_path_fragment([?", ?\\ | t], acc), do: discard_path_fragment(t, [?\\, ?" | acc])
-  defp discard_path_fragment([?" | t], acc), do: return_path_fragment(t, acc)
-  defp discard_path_fragment([_ | t], acc), do: discard_path_fragment(t, acc)
 
   defp expand_path(path_fragment) do
     path_fragment = List.to_string(path_fragment)

--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -589,24 +589,21 @@ defmodule IEx.Autocomplete do
 
   defp path_fragment(:possible_path, [], _acc), do: []
 
-  defp path_fragment(:possible_path, [?", ?\\ | rest], acc) do
-    path_fragment(:possible_path, rest, [?\\, ?" | acc])
-  end
+  defp path_fragment(:possible_path, [?", ?\\ | rest], acc), 
+    do: path_fragment(:possible_path, rest, [?\\, ?" | acc])
 
   defp path_fragment(:possible_path, [?{, ?# | _rest], _acc), do: []
 
-  defp path_fragment(:possible_path, [?" | rest], acc) do
-    path_fragment(:assume_not_path, rest, acc)
-  end
+  defp path_fragment(:possible_path, [?" | rest], acc), 
+    do: path_fragment(:assume_not_path, rest, acc)
 
-  defp path_fragment(:possible_path, [h | rest], acc) do
-    path_fragment(:possible_path, rest, [h | acc])
-  end
+  defp path_fragment(:possible_path, [h | rest], acc), 
+    do: path_fragment(:possible_path, rest, [h | acc])
 
-  defp expand_path(path) do
-    fragment = to_string(path)
-    possible_paths = find_possible_paths(fragment)
-    expand_path(fragment, possible_paths)
+  defp expand_path(path_fragment) do
+    path_fragment = to_string(path_fragment)
+    possible_paths = find_possible_paths(path_fragment)
+    expand_path(path_fragment, possible_paths)
   end
 
   defp expand_path(path_fragment, possible_paths) do
@@ -646,15 +643,15 @@ defmodule IEx.Autocomplete do
   defp common_prefix([h | t1], [h | t2], acc), do: common_prefix(t1, t2, [h | acc])
   defp common_prefix(_, _, acc), do: Enum.reverse(acc)
 
-  defp ls_prefix(fragment) do
-    dir = Path.dirname(fragment)
-    prefix = prefix_from_dir(dir, fragment)
+  defp ls_prefix(path_fragment) do
+    dir = Path.dirname(path_fragment)
+    prefix = prefix_from_dir(dir, path_fragment)
 
     case File.ls(dir) do
       {:ok, list} ->
         list
-        |> Enum.map(&Path.join(prefix, &1))
-        |> Enum.filter(&String.starts_with?(&1, fragment))
+        |> Stream.map(&Path.join(prefix, &1))
+        |> Stream.filter(&String.starts_with?(&1, path_fragment))
 
       _ ->
         []

--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -21,9 +21,9 @@ defmodule IEx.Autocomplete do
   environment, which is found via the broker.
   """
   def expand(code , shell \\ IEx.Broker.shell()) do
-    case expand_code(code, shell) do
-      {:yes, _, _} = result -> result
-      _ -> expand_path(code)
+    case path_fragment(code) do
+      [] -> expand_code(code, shell)
+      path -> expand_path(code)
     end
   end
 
@@ -595,16 +595,10 @@ defmodule IEx.Autocomplete do
   defp discard_path_fragment([?" | t], acc), do: return_path_fragment(t, acc)
   defp discard_path_fragment([_ | t], acc), do: discard_path_fragment(t, acc)
 
-  defp expand_path(code) do
-    case path_fragment(code) do
-      [] ->
-        no()
-
-      path_fragment ->
-        path_fragment = List.to_string(path_fragment)
-        possible_paths = find_possible_paths(path_fragment)
-        expand_path(path_fragment, possible_paths)
-    end
+  defp expand_path(path_fragment) do
+    path_fragment = List.to_string(path_fragment)
+    possible_paths = find_possible_paths(path_fragment)
+    expand_path(path_fragment, possible_paths)
   end
 
   defp expand_path(path_fragment, possible_paths) do

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -403,10 +403,23 @@ defmodule IEx.AutocompleteTest do
   @tag :tmp_dir
   test "path completion inside strings", %{tmp_dir: dir} do
     File.cd!(dir)
-    dir |> Path.join("file1") |> File.touch()
-    assert expand('".') == {:yes, '/file1"', ['file2', 'file1']}
-    dir |> Path.join("file2") |> File.touch()
-    assert expand('".') == {:yes, [], []}
+
+    try do
+      File.touch("./single")
+      assert expand('".') == {:yes, '/single"', []}
+    after
+      File.rm("./single")
+    end
+
+    try do
+      File.touch("./file1")
+      File.touch("./file2")
+      assert expand('".') == {:yes, '/file', ['file2', 'file1']}
+    after
+      File.rm("./file1")
+      File.rm("./file2")
+    end
+
     assert {:yes, [], [_ | _]} = expand('"/')
   end
 end

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -410,10 +410,14 @@ defmodule IEx.AutocompleteTest do
     dir |> Path.join("dir/file4") |> File.touch()
 
     assert expand('"#{dir}/') == {:yes, '', ['file2', 'single1', 'dir', 'file1']}
-    assert expand('"#{dir}/sin') == {:yes, 'gle1"', []}
-    assert expand('"#{dir}/fi') == {:yes, 'le', ['file2', 'file1']}
-    assert expand('"#{dir}/d') == {:yes, 'ir/', []}
-    assert expand('"#{dir}/dir/') == {:yes, 'file', ['file3', 'file4']}
+    assert expand('"#{dir}/sin') == {:yes, 'gle1', []}
+    assert expand('"#{dir}/single1') == {:yes, '"', []}
+    assert expand('"#{dir}/fi') == {:yes, 'le', []}
+    assert expand('"#{dir}/file') == {:yes, '', ['file2', 'file1']}
+    assert expand('"#{dir}/d') == {:yes, 'ir', []}
+    assert expand('"#{dir}/dir') == {:yes, '/', []}
+    assert expand('"#{dir}/dir/') == {:yes, 'file', []}
+    assert expand('"#{dir}/dir/file') == {:yes, '', ['file3', 'file4']}
     assert expand('"#{dir}/dir/#\{Str') == {:yes, '', ['Stream', 'String', 'StringIO']}
 
     {:yes, [], list} = expand('"./')

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -399,4 +399,14 @@ defmodule IEx.AutocompleteTest do
     assert expand('take(') == {:yes, '', ['take(enumerable, amount)']}
     assert expand('derive(') == {:yes, '', ['derive(protocol, module, options \\\\ [])']}
   end
+
+  @tag :tmp_dir
+  test "path completion inside strings", %{tmp_dir: dir} do
+    File.cd!(dir)
+    dir |> Path.join("file1") |> File.touch()
+    assert expand('".') == {:yes, '/file1"', ['file2', 'file1']}
+    dir |> Path.join("file2") |> File.touch()
+    assert expand('".') == {:yes, [], []}
+    assert {:yes, [], [_ | _]} = expand('"/')
+  end
 end

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -404,45 +404,36 @@ defmodule IEx.AutocompleteTest do
   test "path completion inside strings", %{tmp_dir: dir} do
     File.cd!(dir)
 
-    try do
-      File.touch("./single1")
-      File.touch("./file1")
-      File.touch("./file2")
-      File.mkdir("./dir")
-      File.touch("./dir/file3")
-      File.touch("./dir/file4")
+    File.touch("./single1")
+    File.touch("./file1")
+    File.touch("./file2")
+    File.mkdir("./dir")
+    File.touch("./dir/file3")
+    File.touch("./dir/file4")
 
-      assert expand('".') == {:yes, '/', ['file2', 'single1', 'dir', 'file1']}
-      assert expand('"./sin') == {:yes, 'gle1"', []}
-      assert expand('"./fi') == {:yes, 'le', ['file2', 'file1']}
-      assert expand('"./d') == {:yes, 'ir/', []}
-      assert expand('"./dir/') == {:yes, 'file', ['file3', 'file4']}
-      assert expand('"./dir/#\{Str') == {:yes, '', ['Stream', 'String', 'StringIO']}
+    assert expand('".') == {:yes, '/', ['file2', 'single1', 'dir', 'file1']}
+    assert expand('"./sin') == {:yes, 'gle1"', []}
+    assert expand('"./fi') == {:yes, 'le', ['file2', 'file1']}
+    assert expand('"./d') == {:yes, 'ir/', []}
+    assert expand('"./dir/') == {:yes, 'file', ['file3', 'file4']}
+    assert expand('"./dir/#\{Str') == {:yes, '', ['Stream', 'String', 'StringIO']}
 
-      {:yes, [], list} = expand('"/')
-      assert is_list(list)
+    {:yes, [], list} = expand('"/')
+    assert is_list(list)
 
-      case :os.type() do
-        {:win32, _} ->
-          assert 'Users' in list
-          assert 'Windows' in list
+    case :os.type() do
+      {:win32, _} ->
+        assert 'Users' in list
+        assert 'Windows' in list
 
-        _ ->
-          assert 'bin' in list
-          assert 'etc' in list
-          assert 'opt' in list
-          assert 'var' in list
-      end
-
-      default_expand = expand('{')
-      assert expand('"./dir/#\{') == default_expand
-    after
-      File.rm("./single1")
-      File.rm("./file1")
-      File.rm("./file2")
-      File.rm("./dir/file3")
-      File.rm("./dir/file4")
-      File.rm("./dir")
+      _ ->
+        assert 'bin' in list
+        assert 'etc' in list
+        assert 'opt' in list
+        assert 'var' in list
     end
+
+    default_expand = expand('{')
+    assert expand('"./dir/#\{') == default_expand
   end
 end

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -411,7 +411,7 @@ defmodule IEx.AutocompleteTest do
     File.touch("./dir/file3")
     File.touch("./dir/file4")
 
-    assert expand('".') == {:yes, '/', ['file2', 'single1', 'dir', 'file1']}
+    assert expand('"./') == {:yes, '', ['file2', 'single1', 'dir', 'file1']}
     assert expand('"./sin') == {:yes, 'gle1"', []}
     assert expand('"./fi') == {:yes, 'le', ['file2', 'file1']}
     assert expand('"./d') == {:yes, 'ir/', []}
@@ -433,7 +433,7 @@ defmodule IEx.AutocompleteTest do
         assert 'var' in list
     end
 
-    default_expand = expand('{')
-    assert expand('"./dir/#\{') == default_expand
+    assert expand('"./dir/#\{') == expand('{')
+    assert expand('Path.join("./foo", is_') == expand('is_')
   end
 end


### PR DESCRIPTION
Supporting path autocompletion on strings that start with `".` or `"/`.

Thanks @fhunleth, this PR is basically a hard copy of what you have on your toolshed project.

Closes #10888 