### PR TITLE
Path module will always return a binary() type

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -5,7 +5,8 @@ defmodule Path do
 
   The functions in this module may receive a chardata as
   argument (i.e. a string or a list of characters / string)
-  and will always return a string (encoded in UTF-8).
+  and will always return a string (encoded in UTF-8). If a binary
+  is given, in whatever encoding, its encoding will be kept.
 
   The majority of the functions in this module do not
   interact with the file system, except for a few functions


### PR DESCRIPTION
If you give a binary to Path that is not utf-8 encoded, it will preserve it as is

related to #10897