### PR TITLE
Improve URI docs & tests for IPv6 literals (#10896)

### DIFF
--- a/lib/elixir/lib/uri.ex
+++ b/lib/elixir/lib/uri.ex
@@ -477,6 +477,11 @@ defmodule URI do
   When a URI is given without a port, the value returned by
   `URI.default_port/1` for the URI's scheme is used for the `:port` field.
 
+  When a URI hostname is an IPv6 literal, it has the `[]` unwrapped before
+  being stored in the `:host` field. This doesn't match the formal grammar
+  for hostnames, which requires the `[]` to be preserved, according to
+  [RFC 3986, appendix A](https://tools.ietf.org/html/rfc3986#appendix-A)
+
   If a `%URI{}` struct is given to this function, this function returns it
   unmodified.
 
@@ -530,6 +535,17 @@ defmodule URI do
         userinfo: nil
       }
 
+      iex> URI.parse("//[fe80::]/")
+      %URI{
+        authority: "[fe80::]",
+        fragment: nil,
+        host: "fe80::",
+        path: "/",
+        port: nil,
+        query: nil,
+        scheme: nil,
+        userinfo: nil
+      }
   """
   @spec parse(t | binary) :: t
   def parse(%URI{} = uri), do: uri
@@ -588,6 +604,9 @@ defmodule URI do
   defp nillify_query(_other), do: nil
 
   # Split an authority into its userinfo, host and port parts.
+  #
+  # Note that the host field is returned *without* [] even if, according to
+  # RFC3986 grammar, a native IPv6 address requires them.
   defp split_authority("") do
     {nil, nil, nil, nil}
   end

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -285,6 +285,8 @@ defmodule URITest do
         "1080::8:800:200C:417A",
         # multicast
         "FF01::101",
+        # link-local
+        "fe80::",
         # abbreviated
         "2607:f3f0:2:0:216:3cff:fef0:174a",
         # mixed hex case


### PR DESCRIPTION
The URI module is not quite in compliance with the canonical RFC3986,
when handling IPv6 literal hostnames. These should be stored with
`[]` included. This is handled correctly in the authority field, but
not in the hostname field.

We can't change this behaviour now, so add doc & test.

closes #10896

```
$ bin/elixir lib/elixir/test/elixir/uri_test.exs
Excluding tags: [windows: true]

........................................................

Finished in 1.2 seconds (1.1s on load, 0.04s async, 0.00s sync)
32 doctests, 24 tests, 0 failures

Randomized with seed 555840
```

NB `gmake docs` fails here, but I think this is a previous commit. Using elixir /master/:

```
gmake docs
==> ex_doc (elixir)
CANONICAL=master/ bin/elixir ../ex_doc/bin/ex_doc "Elixir" "1.13.0-dev" "lib/elixir/ebin" --main "Kernel" --source-url "https://github.com/elixir-lang/elixir" --source-ref "2d2cf356cbcaf2607f8f7f356b42def43ad7540f"  --output doc/elixir --canonical "https://hexdocs.pm/elixir/master/" --homepage-url "https://elixir-lang.org/docs.html" --formatter "html" --config "lib/elixir/docs.exs"
** (FunctionClauseError) no function clause matching in Enumerable.Range.slice/1    
    
    The following arguments were given to Enumerable.Range.slice/1:
    
        # 1
        %Inspect.Error{message: "got FunctionClauseError with message \"no function clause matching in Inspect.Range.inspect/2\" while inspecting %{__struct__: Range, first: 48, last: 57}"}
    
    Attempted function clauses (showing 1 out of 1):
    
        def slice(first.._//step = range)
    
    (elixir 1.13.0-dev) lib/range.ex:315: Enumerable.Range.slice/1
    (elixir 1.13.0-dev) lib/enum.ex:2251: Enum.random/1
    (elixir 1.13.0-dev) lib/enum.ex:1557: anonymous fn/3 in Enum.map/2
    (elixir 1.13.0-dev) lib/enum.ex:3898: Enum.reduce_range/5
    (elixir 1.13.0-dev) lib/enum.ex:2360: Enum.map/2
    (makeup 1.0.5) lib/makeup/lexer/groups.ex:327: Makeup.Lexer.Groups.random_prefix/1
    (makeup_elixir 0.15.0) lib/makeup/lexers/elixir_lexer.ex:596: Makeup.Lexers.ElixirLexer.lex/2
    (makeup 1.0.5) lib/makeup.ex:37: Makeup.highlight_inner_html/2
gmake: *** [Makefile:190: docs_elixir] Error 1
```