### PR TITLE
Improve docs for using Application.get_env/3

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -611,13 +611,18 @@ defmodule Application do
 
   Our database engine used by `:my_app` needs to know what databases exist, and
   what the database configurations are. The database engine can make a call to
-  `get_env(:my_app, :my_app_databases)` to retrieve the list of databases (specified
-  by module names).
+  `Application.get_env(:my_app, :my_app_databases, [])` to retrieve the list of
+  databases (specified by module names).
 
-  Our database engine can then traverse each repository in the list and then
-  call `get_env(:my_app, Databases.RepoOne)` and so forth to retrieve the
-  configuration of each one. Also, you can retrieve a specific key from
-  `Databases.RepoOne` by accessing `get_env(:my_app, Databases.RepoOne)[:ip]`.
+  The engine can then traverse each repository in the list and call
+  `Application.get_env(:my_app, Databases.RepoOne)` and so forth to retrieve the
+  configuration of each one. In this case, each configuration will be a keyword
+  list, so you can use the functions in the `Keyword` module or even the `Access`
+  module to traverse it, for example:
+
+      config = Application.get_env(:my_app, Databases.RepoOne)
+      config[:ip]
+
   """
   @spec get_env(app, key, value) :: value
   def get_env(app, key, default \\ nil) when is_atom(app) do

--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -612,9 +612,12 @@ defmodule Application do
   Our database engine used by `:my_app` needs to know what databases exist, and
   what the database configurations are. The database engine can make a call to
   `get_env(:my_app, :my_app_databases)` to retrieve the list of databases (specified
-  by module names). Our database engine can then traverse each repository in the
-  list and then call `get_env(:my_app, Databases.RepoOne)` and so forth to retrieve
-  the configuration of each one.
+  by module names).
+
+  Our database engine can then traverse each repository in the list and then
+  call `get_env(:my_app, Databases.RepoOne)` and so forth to retrieve the
+  configuration of each one. Also, you can retrieve a specific key from
+  `Databases.RepoOne` by accessing `get_env(:my_app, Databases.RepoOne)[:ip]`.
   """
   @spec get_env(app, key, value) :: value
   def get_env(app, key, default \\ nil) when is_atom(app) do


### PR DESCRIPTION
Hi,

I found myself wanting to access a specific attribute of a configuration option such as `Application.get_env(:hello, HelloWeb.Endpoint)[:signing_salt]` but the documentation didn't cover this syntax.

It took around half an hour of Googling, scouring the docs and ultimately finding a StackOverflow answer to get the correct answer. I think this extra context on how I arrived at a solution was necessary to include in this PR comment because the SO thread at https://stackoverflow.com/questions/35725536/how-to-read-config-variable-in-phoenix-elixir shows a bunch of upvotes and a marked answer for an incorrect solution.

So I figured I'd open a PR here to clarify the docs to demonstrate this usage example.

I broke up the existing paragraph into 2 paragraphs because it wrapped to 6 lines of text in the HTML form of the docs and started to look a bit cluttered.