### PR TITLE
Warn if @callback, @macrocallback and @optional_callbacks defined inside protocol

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -718,12 +718,12 @@ defmodule Protocol do
     end
   end
 
-  def __callback_ast_to_fa__({kind, {:"::", _, [{name, _, args}, _return]}, _pos})
-      when kind in [:callback, :macrocallback] do
+  defp callback_ast_to_fa({kind, {:"::", _, [{name, _, args}, _return]}, _pos})
+       when kind in [:callback, :macrocallback] do
     {name, length(args)}
   end
 
-  def __warn__(message, env) do
+  defp warn(message, env) do
     IO.warn(message, Macro.Env.stacktrace(env))
   end
 
@@ -732,7 +732,7 @@ defmodule Protocol do
     # Callbacks
     callbacks =
       :lists.map(
-        &Protocol.__callback_ast_to_fa__/1,
+        &callback_ast_to_fa/1,
         Module.get_attribute(env.module, :callback)
       )
 
@@ -740,7 +740,7 @@ defmodule Protocol do
 
     :lists.map(
       fn {name, arity} ->
-        Protocol.__warn__(
+        warn(
           "cannot define @callback #{name}/#{arity} inside protocol, use def/1 to outline your protocol definition",
           env
         )
@@ -751,13 +751,13 @@ defmodule Protocol do
     # Macro Callbacks
     macrocallbacks =
       :lists.map(
-        &Protocol.__callback_ast_to_fa__/1,
+        &callback_ast_to_fa/1,
         Module.get_attribute(env.module, :macrocallback)
       )
 
     :lists.map(
       fn {name, arity} ->
-        Protocol.__warn__(
+        warn(
           "cannot define @macrocallback #{name}/#{arity} inside protocol, use def/1 to outline your protocol definition",
           env
         )
@@ -769,7 +769,7 @@ defmodule Protocol do
     optional_callbacks = Module.get_attribute(env.module, :optional_callbacks)
 
     if length(optional_callbacks) > 0 do
-      Protocol.__warn__(
+      warn(
         "cannot define @optional_callbacks inside protocol, all of the protocol definitions are required",
         env
       )

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -728,53 +728,51 @@ defmodule Protocol do
   end
 
   # TODO: Convert the following warnings into errors future Elixir versions
-  defmacro __before_compile__(env) do
-    quote bind_quoted: [env: Macro.escape(env)] do
-      # Callbacks
-      callbacks =
-        :lists.map(
-          &Protocol.__callback_ast_to_fa__/1,
-          Module.get_attribute(__MODULE__, :callback)
-        )
-
-      functions = Module.get_attribute(__MODULE__, :functions)
-
+  def __before_compile__(env) do
+    # Callbacks
+    callbacks =
       :lists.map(
-        fn {name, arity} ->
-          Protocol.__warn__(
-            "cannot define @callback #{name}/#{arity} inside protocol, use def/1 to outline your protocol definition",
-            env
-          )
-        end,
-        callbacks -- functions
+        &Protocol.__callback_ast_to_fa__/1,
+        Module.get_attribute(env.module, :callback)
       )
 
-      # Macro Callbacks
-      macrocallbacks =
-        :lists.map(
-          &Protocol.__callback_ast_to_fa__/1,
-          Module.get_attribute(__MODULE__, :macrocallback)
-        )
+    functions = Module.get_attribute(env.module, :functions)
 
-      :lists.map(
-        fn {name, arity} ->
-          Protocol.__warn__(
-            "cannot define @macrocallback #{name}/#{arity} inside protocol, use def/1 to outline your protocol definition",
-            env
-          )
-        end,
-        macrocallbacks
-      )
-
-      # Optional Callbacks
-      optional_callbacks = Module.get_attribute(__MODULE__, :optional_callbacks)
-
-      if length(optional_callbacks) > 0 do
+    :lists.map(
+      fn {name, arity} ->
         Protocol.__warn__(
-          "cannot define @optional_callbacks inside protocol, all of the protocol definitions are required",
+          "cannot define @callback #{name}/#{arity} inside protocol, use def/1 to outline your protocol definition",
           env
         )
-      end
+      end,
+      callbacks -- functions
+    )
+
+    # Macro Callbacks
+    macrocallbacks =
+      :lists.map(
+        &Protocol.__callback_ast_to_fa__/1,
+        Module.get_attribute(env.module, :macrocallback)
+      )
+
+    :lists.map(
+      fn {name, arity} ->
+        Protocol.__warn__(
+          "cannot define @macrocallback #{name}/#{arity} inside protocol, use def/1 to outline your protocol definition",
+          env
+        )
+      end,
+      macrocallbacks
+    )
+
+    # Optional Callbacks
+    optional_callbacks = Module.get_attribute(env.module, :optional_callbacks)
+
+    if length(optional_callbacks) > 0 do
+      Protocol.__warn__(
+        "cannot define @optional_callbacks inside protocol, all of the protocol definitions are required",
+        env
+      )
     end
   end
 


### PR DESCRIPTION
Closes #10901

WIP because we need to improve the warning messages.

```elixir
defprotocol MyProtocol do
  @spec with_specs(any(), keyword()) :: tuple()
  def with_specs(term, options \\ [])

  def without_specs(term, options \\ [])

  @callback foo(term) :: {:ok, term}
  @callback foo(term, 1) :: {:ok, term}

  @macrocallback bar(term) :: {:ok, term}

  @optional_callbacks [foo: 1, with_specs: 2]

  @optional_callbacks [without_specs: 2, foo: 2]
end
```

```console
$ mix
Compiling 2 files (.ex)
warning: callback foo/2 defined inside protocol, which is discourage; please define it with the def/2.
  lib/my_protocol.ex:1: MyProtocol (module)

warning: callback foo/1 defined inside protocol, which is discourage; please define it with the def/2.
  lib/my_protocol.ex:1: MyProtocol (module)

warning: macrocallback bar/1 defined inside protocol, which is discourage; please define it with the def/2.
  lib/my_protocol.ex:1: MyProtocol (module)

warning: @optional_callbacks defined inside protocol, please do something else...
  lib/my_protocol.ex:1: MyProtocol (module)

Generated protocol_callbacks app
```
