### PR TITLE
Add documentation for Access syntax and multi alias AST representation

### DIFF
--- a/lib/elixir/pages/syntax-reference.md
+++ b/lib/elixir/pages/syntax-reference.md
@@ -374,17 +374,6 @@ end
 #=> {:fn, [], [{:->, [], [[1, 2], 3]}, {:->, [], [[4, 5], 6]}]}
 ```
 
-### Access syntax
-
-The access syntax (`foo[:bar]`) is represented by a `{:., [], [Access, :get]}` call, and the arguments are the ones used to call `Access.get/3`:
-
-```elixir
-quote do
-  foo[:bar]
-end
-#=> {{:., [], [Access, :get]}, [], [{:foo, [], Elixir}, :bar]}
-```
-
 ### Multi alias
 
 Multi alias (`Foo.{Bar, Baz}`) is represented by a `{:., [], [base_alias, :{}]}` call, where the `base_alias` represents the left hand side of the dot, and the arguments represent the elements inside the curly braces:

--- a/lib/elixir/pages/syntax-reference.md
+++ b/lib/elixir/pages/syntax-reference.md
@@ -374,6 +374,28 @@ end
 #=> {:fn, [], [{:->, [], [[1, 2], 3]}, {:->, [], [[4, 5], 6]}]}
 ```
 
+### Access syntax
+
+The access syntax (`foo[:bar]`) is represented by a `{:., [], [Access, :get]}` call, and the arguments are the ones used to call `Access.get/3`:
+
+```elixir
+quote do
+  foo[:bar]
+end
+#=> {{:., [], [Access, :get]}, [], [{:foo, [], Elixir}, :bar]}
+```
+
+### Multi alias
+
+Multi alias (`Foo.{Bar, Baz}`) is represented by a `{:., [], [base_alias, :{}]}` call, where the `base_alias` represents the left hand side of the dot, and the arguments represent the elements inside the curly braces:
+
+```elixir
+quote do
+  Foo.{Bar, Baz}
+end
+#=> {{:., [], [{:__aliases__, [], [:Foo]}, :{}]}, [], [{:__aliases__, [], [:Bar]}, {:__aliases__, [], [:Baz]}]}
+```
+
 ## Syntactic sugar
 
 All of the constructs above are part of Elixir's syntax and have their own representation as part of the Elixir AST. This section will discuss the remaining constructs that "desugar" to one of the constructs explored above. In other words, the constructs below can be represented in more than one way in your Elixir code and retain AST equivalence.

--- a/lib/elixir/pages/syntax-reference.md
+++ b/lib/elixir/pages/syntax-reference.md
@@ -374,9 +374,9 @@ end
 #=> {:fn, [], [{:->, [], [[1, 2], 3]}, {:->, [], [[4, 5], 6]}]}
 ```
 
-### Multi alias
+### Qualified tuples
 
-Multi alias (`Foo.{Bar, Baz}`) is represented by a `{:., [], [base_alias, :{}]}` call, where the `base_alias` represents the left hand side of the dot, and the arguments represent the elements inside the curly braces:
+Qualified tuples (`foo.{bar, baz}`) is represented by a `{:., [], [expr, :{}]}` call, where the `expr` represents the left hand side of the dot, and the arguments represent the elements inside the curly braces. This is used in Elixir to provide multi aliases:
 
 ```elixir
 quote do


### PR DESCRIPTION
While studying the Elixir AST, I found that Elixir docs were lacking regarding some AST constructs like the Access and Multi alias calls.

In this PR I'm addinng a bit of documentation on what I found by experimenting, the rest of the context can be found in this Elixir Forum thread: https://elixirforum.com/t/is-there-a-complete-elixir-ast-reference/38923

This message: https://elixirforum.com/t/is-there-a-complete-elixir-ast-reference/38923/8 mentions the case of `foo()()`, but while it's easy to demonstrate with a code snippet, I'm not sure about how to clearly explain it in the docs.
I'm copying it here:
> > My interest however was in the cases where the first element in that 3-tuple is another 3-tuple.
>
> Yes, in any situation where you have call on the left hand of `()` (call) operator. There aren’t many of these, only 2 to be exact:
>
> 1. `.` operator, like `mod.func()`
> 2. another call, like `foo()()`
>
> Of course 2nd option is possible in only 1 situation, `unquote(atom)()`, and will fail to compile in any other case, however it is possible to have such construct in the `quote`.
>
> ```
> quote do: foo()()
> # => {{:foo, [], []}, [], []}
> ```
>
> To see how it work when `unquote/1` is used you need to disable unquoting first:
>
> ```
> quote [unquote: false], do: unquote(:foo)()
> # => {{:unquote, [], [:foo]}, [], []}
> ```

Finally, I'd like to also add documentation about the resolution context (the last element in the variables AST tuple and `context` key in other nodes' metadata), but I'm not sure about where's the best place to do it. There's little information about it and it's scattered in the Syntax reference and the `quote/2` and `Macro.Env` docs.