### PR TITLE
Mix.install/2: Add :elixir option

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -498,6 +498,9 @@ defmodule Mix do
     * `:consolidate_protocols` - if `true`, runs protocol
       consolidation via the `mix compile.protocols` task (Default: `true`)
 
+    * `:elixir` - if set, ensures the current Elixir version matches the given
+      version requirement (Default: `nil`)
+
   ## Examples
 
       Mix.install([
@@ -514,6 +517,16 @@ defmodule Mix do
 
     if Mix.Project.get() do
       Mix.raise("Mix.install/2 cannot be used inside a Mix project")
+    end
+
+    elixir_requirement = opts[:elixir]
+    elixir_version = System.version()
+
+    if !!elixir_requirement and not Version.match?(elixir_version, elixir_requirement) do
+      Mix.raise(
+        "Mix.install/2 declared it supports only Elixir #{elixir_requirement} " <>
+          "but you're running on Elixir #{elixir_version}"
+      )
     end
 
     deps =

--- a/lib/mix/test/mix_test.exs
+++ b/lib/mix/test/mix_test.exs
@@ -57,6 +57,17 @@ defmodule MixTest do
       ])
     end
 
+    test "can't call with Elixir version mismatch", %{tmp_dir: tmp_dir} do
+      assert_raise Mix.Error, ~r"Mix.install/2 declared it supports only Elixir ~> 2.0", fn ->
+        Mix.install(
+          [
+            {:install_test, path: Path.join(tmp_dir, "install_test")}
+          ],
+          elixir: "~> 2.0"
+        )
+      end
+    end
+
     test "can't call with same deps and force", %{tmp_dir: tmp_dir} do
       Mix.install([
         {:install_test, path: Path.join(tmp_dir, "install_test")}


### PR DESCRIPTION
This is especially useful for scripts that depend on features from libraries that are only available on specific Elixir versions.
