### PR TITLE
Support autolinks in IO.ANSI docs

### DIFF
--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -785,8 +785,14 @@ defmodule IO.ANSI.Docs do
 
   defp handle_links(text) do
     text
+    |> trim_lt_gt_signs_in_link
     |> remove_square_brackets_in_link
     |> escape_underlines_in_link
+  end
+
+  defp trim_lt_gt_signs_in_link(text) do
+    # Regular expression adapted from https://tools.ietf.org/html/rfc3986#appendix-B
+    Regex.replace(~r{<([a-z][a-z0-9\+\-\.]*://\S*)>}i, text, "\\1", global: false)
   end
 
   defp escape_underlines_in_link(text) do

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -487,6 +487,16 @@ defmodule IO.ANSI.DocsTest do
       assert format_markdown("  [id]: //example.com\n  [Elixir]:  https://elixir-lang.org") ==
                "  [id]: //example.com\n  [Elixir]:  https://elixir-lang.org"
     end
+
+    test "autolinks" do
+      result =
+        format_markdown(
+          "Visit <https://en.wikipedia.org/wiki/ANSI_escape_code> for more information"
+        )
+
+      assert result ==
+               "Visit https://en.wikipedia.org/wiki/ANSI_escape_code for more information\n\e[0m"
+    end
   end
 
   describe "markdown tables" do


### PR DESCRIPTION
This will deal with Markdown autolinks (URLs surrounded by <..>),
supported by almost all Markdown parsers,
so links are correctly displayed in IEx.

Reference:
https://spec.commonmark.org/0.29/#autolinks