### PR TITLE
Add Module.reserved_attributes/0

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -335,6 +335,16 @@ defmodule Module do
         @vsn "1.0"
       end
 
+  ### Struct attributes
+
+    * `@derive` - derives an implementation for the given protocol for the
+      struct defined in the current module
+
+    * `@enforce_keys` - ensures the given keys are always set when building
+      the struct defined in the current module
+
+  See `Kernel.defstruct/1` for more information on building and using structs.
+
   ### Typespec attributes
 
   The following attributes are part of typespecs and are also built-in in
@@ -630,10 +640,12 @@ defmodule Module do
         doc: "Specifies which behaviour callbacks and macro behaviour callbacks are optional."
       },
       derive: %{
-        doc: "Derive the `Any` implementation of the given protocol."
+        doc:
+          "Derives an implementation for the given protocol for the struct defined in the current module."
       },
       enforce_keys: %{
-        doc: "Ensures the given keys are always set when building the struct."
+        doc:
+          "Ensures the given keys are always set when building the struct defined in the current module."
       }
     }
   end

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -628,6 +628,12 @@ defmodule Module do
       },
       optional_callbacks: %{
         doc: "Specifies which behaviour callbacks and macro behaviour callbacks are optional."
+      },
+      derive: %{
+        doc: "Derive the `Any` implementation of the given protocol."
+      },
+      enforce_keys: %{
+        doc: "Ensures the given keys are always set when building the struct."
       }
     }
   end

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -335,15 +335,15 @@ defmodule Module do
         @vsn "1.0"
       end
 
-  ### `@derive`
+  ### Struct attributes
 
-  Derives an implementation for the given protocol for the struct defined in
-  the current module. See `Kernel.defstruct/1 for more information.
+    * `@derive` - derives an implementation for the given protocol for the
+      struct defined in the current module
 
-  ### `@enforce_keys`
+    * `@enforce_keys` - ensures the given keys are always set when building
+      the struct defined in the current module
 
-  Ensures the given keys are always set when building the struct defined in
-  the current module. See `Kernel.defstruct/1` for more information.
+  See `Kernel.defstruct/1` for more information on building and using structs.
 
   ### Typespec attributes
 

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -544,7 +544,7 @@ defmodule Module do
   @callback __info__(:module) :: module()
 
   @doc """
-  Returns information about built-in module attributes used by Elixir.
+  Returns information about module attributes used by Elixir.
 
   See the "Module attributes" section in the module documentation for more
   information on each attribute.
@@ -559,7 +559,7 @@ defmodule Module do
 
   """
   @doc since: "1.13.0"
-  def builtin_attributes() do
+  def reserved_attributes() do
     %{
       after_compile: %{
         doc: "A hook that will be invoked right after the current module is compiled."

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -544,6 +544,95 @@ defmodule Module do
   @callback __info__(:module) :: module()
 
   @doc """
+  Returns information about built-in module attributes used by Elixir.
+
+  See the "Module attributes" section in the module documentation for more
+  information on each attribute.
+
+  ## Examples
+
+      iex> map = Module.builtin_attributes()
+      iex> Map.has_key?(map, :moduledoc)
+      true
+      iex> Map.has_key?(map, :doc)
+      true
+
+  """
+  @doc since: "1.13.0"
+  def builtin_attributes() do
+    %{
+      after_compile: %{
+        doc: "A hook that will be invoked right after the current module is compiled."
+      },
+      before_compile: %{
+        doc: "A hook that will be invoked before the module is compiled."
+      },
+      behaviour: %{
+        doc: "Specifies that the current module implements a given behaviour."
+      },
+      on_definition: %{
+        doc:
+          "A hook that will be invoked when each function or macro in the current module is defined."
+      },
+      impl: %{
+        doc: "Declares an implementation of a callback function or macro."
+      },
+      compile: %{
+        doc: "Defines options for module compilation."
+      },
+      deprecated: %{
+        doc: "Provides the deprecation reason for a function."
+      },
+      moduledoc: %{
+        doc: "Provides documentation for the current module."
+      },
+      doc: %{
+        doc: "Provides documentation for a function/macro/callback."
+      },
+      typedoc: %{
+        doc: "Provides documentation for a type."
+      },
+      dialyzer: %{
+        doc: "Defines Dialyzer warnings to request or suppress."
+      },
+      external_resource: %{
+        doc: "Specifies an external resource for the current module."
+      },
+      file: %{
+        doc:
+          "Changes the filename used in stacktraces for the function or macro that follows the attribute."
+      },
+      on_load: %{
+        doc: "A hook that will be invoked whenever the module is loaded."
+      },
+      vsn: %{
+        doc: "Specify the module version."
+      },
+      type: %{
+        doc: "Defines a type to be used in `@spec`."
+      },
+      typep: %{
+        doc: "Defines a private type to be used in `@spec`."
+      },
+      opaque: %{
+        doc: "Defines an opaque type to be used in `@spec`."
+      },
+      spec: %{
+        doc: "Provides a specification for a function."
+      },
+      callback: %{
+        doc: "Provides a specification for a behaviour callback."
+      },
+      macrocallback: %{
+        doc: "Provides a specification for a macro behaviour callback."
+      },
+      optional_callbacks: %{
+        doc: "Specifies which behaviour callbacks and macro behaviour callbacks are optional."
+      }
+    }
+  end
+
+  @doc """
   Checks if a module is open.
 
   A module is "open" if it is currently being defined and its attributes and

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -335,15 +335,15 @@ defmodule Module do
         @vsn "1.0"
       end
 
-  ### Struct attributes
+  ### `@derive`
 
-    * `@derive` - derives an implementation for the given protocol for the
-      struct defined in the current module
+  Derives an implementation for the given protocol for the struct defined in
+  the current module. See `Kernel.defstruct/1 for more information.
 
-    * `@enforce_keys` - ensures the given keys are always set when building
-      the struct defined in the current module
+  ### `@enforce_keys`
 
-  See `Kernel.defstruct/1` for more information on building and using structs.
+  Ensures the given keys are always set when building the struct defined in
+  the current module. See `Kernel.defstruct/1` for more information.
 
   ### Typespec attributes
 

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -551,7 +551,7 @@ defmodule Module do
 
   ## Examples
 
-      iex> map = Module.builtin_attributes()
+      iex> map = Module.reserved_attributes()
       iex> Map.has_key?(map, :moduledoc)
       true
       iex> Map.has_key?(map, :doc)

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -568,7 +568,7 @@ defmodule Module do
       true
 
   """
-  @doc since: "1.13.0"
+  @doc since: "1.12.0"
   def reserved_attributes() do
     %{
       after_compile: %{


### PR DESCRIPTION
Worth mentioning that we have also a few more standard attributes:

  - `@tag` for ExUnit
  - `@shortdoc` for Mix

but since they are not part of Elixir, they are not included in this list.

cc @msaraiva 