### PR TITLE
Fix case when callback spec uses when clause

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -723,6 +723,13 @@ defmodule Protocol do
     {name, length(args)}
   end
 
+  defp callback_ast_to_fa(
+         {kind, {:when, _, [{:"::", _, [{name, _, args}, _return]}, _vars]}, _pos}
+       )
+       when kind in [:callback, :macrocallback] do
+    {name, length(args)}
+  end
+
   defp warn(message, env) do
     IO.warn(message, Macro.Env.stacktrace(env))
   end

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1158,10 +1158,16 @@ defmodule Kernel.WarningTest do
             @spec with_specs(any(), keyword()) :: tuple()
             def with_specs(term, options \\ [])
 
+            @spec with_specs_and_when(any(), opts) :: tuple() when opts: keyword
+            def with_specs_and_when(term, options \\ [])
+
             def without_specs(term, options \\ [])
 
             @callback foo(term) :: {:ok, term}
             @callback foo(term, keyword) :: {:ok, term, keyword}
+
+            @callback foo_when(x) :: {:ok, x} when x: term
+            @callback foo_when(x, opts) :: {:ok, x, opts} when x: term, opts: keyword
 
             @macrocallback bar(term) :: {:ok, term}
             @macrocallback bar(term, keyword) :: {:ok, term, keyword}
@@ -1177,6 +1183,12 @@ defmodule Kernel.WarningTest do
 
     assert message =~
              "cannot define @callback foo/2 inside protocol, use def/1 to outline your protocol definition\n  nofile:1"
+
+    assert message =~
+             "cannot define @callback foo_when/1 inside protocol, use def/1 to outline your protocol definition\n  nofile:1"
+
+    assert message =~
+             "cannot define @callback foo_when/2 inside protocol, use def/1 to outline your protocol definition\n  nofile:1"
 
     assert message =~
              "cannot define @macrocallback bar/1 inside protocol, use def/1 to outline your protocol definition\n  nofile:1"


### PR DESCRIPTION
This was causing an error:
** (FunctionClauseError) no function clause matching in Protocol.callback_ast_to_fa/1

Introduced in PR: #10912, commit: 485cc13946e5c24dd4c31ebb03e85876c33fa468