### PR TITLE
Tail-call recursion `guarded_pow`

### DIFF
--- a/lib/elixir/lib/integer.ex
+++ b/lib/elixir/lib/integer.ex
@@ -108,10 +108,11 @@ defmodule Integer do
   end
 
   # https://en.wikipedia.org/wiki/Exponentiation_by_squaring
-  defp guarded_pow(_, 0), do: 1
-  defp guarded_pow(b, 1), do: b
-  defp guarded_pow(b, e) when (e &&& 1) == 0, do: guarded_pow(b * b, e >>> 1)
-  defp guarded_pow(b, e), do: b * guarded_pow(b * b, e >>> 1)
+  defp guarded_pow(b, a \\ 1, e)
+  defp guarded_pow(_, _, 0), do: 1
+  defp guarded_pow(b, a, 1), do: b * a
+  defp guarded_pow(b, a, e) when (e &&& 1) == 0, do: guarded_pow(b * b, a, e >>> 1)
+  defp guarded_pow(b, a, e), do: guarded_pow(b * b, a * b, e >>> 1)
 
   @doc """
   Computes the modulo remainder of an integer division.


### PR DESCRIPTION
Noticed that the current implementation of `guarded_pow` would grow the stack by `n` function calls where `n == Integer.digits(e, 2) |> Enum.count(&(&1 == 1))`. Worked through refactoring the function to make it [iterative](https://github.com/thepeoplesbourgeois/passive_support/commit/30e0e2907eb4b3596f05a62eeafa24bb03cdf7b2?branch=30e0e2907eb4b3596f05a62eeafa24bb03cdf7b2&diff=unified#diff-97f7a84541b5395f07935eb65206f12d55394a9fc276e82b98e1c10ffffb9a81R90), which lead me to realize a way to [tail-call optimize it](https://github.com/thepeoplesbourgeois/passive_support/commit/f171b71231450d19e2f8597ac5c18d6985de8680#diff-97f7a84541b5395f07935eb65206f12d55394a9fc276e82b98e1c10ffffb9a81R87), but decided it'd be the most help to the most people if I suggested it as a change here.

Averaged running 1% to 25% slightly faster in nearly all cases during my [benchmarking](https://github.com/thepeoplesbourgeois/passive_support/commit/580eacbf4f1349bc6a986c4e70c57fad688c0d14). Benchee doesn't capture the amount of memory being used by recursion causing growth on the stack, so analyzing how well it runs in that regard proved challenging, but I'm pretty confident in saying it uses less memory than the body-recursive function.