### PR TITLE
Clarify mix local.hex documentation when both options are set

### DIFF
--- a/lib/mix/lib/mix/tasks/local.hex.ex
+++ b/lib/mix/lib/mix/tasks/local.hex.ex
@@ -25,7 +25,8 @@ defmodule Mix.Tasks.Local.Hex do
       intended to avoid repeatedly reinstalling Hex in automation when a script
       may be run multiple times
 
-  If both options are set, `--force` takes precedence.
+  If both options are set, the shell prompt is skipped and Hex is not
+  re-installed if it was already installed.
 
   ## Mirrors
 


### PR DESCRIPTION
I believe the documentation for the `mix local.hex` task is incorrect, or at least confusing.

It is written that:

> If both options are set, --force takes precedence.

I understand it as "if --force is set, then --if-missing is not considered" (the installation is forced whether Hex is already installed or not). In practice, it is not true, `--force` only bypasses the shell prompt. If it is not what the sentence means, then I don't understand it.

I suggest a simple rewrite of that sentence to match the current implementation and avoid ambiguity.