### PR TITLE
Add catch-all clause to Protocol.callback_ast_to_fa/1

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -730,10 +730,17 @@ defmodule Protocol do
     {{name, length(args)}, meta}
   end
 
+  defp callback_ast_to_fa({kind, _, _pos}) when kind in [:callback, :macrocallback] do
+    {nil, nil}
+  end
+
   defp callback_metas(module, kind)
        when kind in [:callback, :macrocallback] do
-    :lists.map(&callback_ast_to_fa/1, Module.get_attribute(module, kind))
-    |> :maps.from_list()
+    metas =
+      :lists.map(&callback_ast_to_fa/1, Module.get_attribute(module, kind))
+      |> :maps.from_list()
+
+    :maps.remove(nil, metas)
   end
 
   defp get_callback_line(fa, metas),

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -720,27 +720,24 @@ defmodule Protocol do
 
   defp callback_ast_to_fa({kind, {:"::", meta, [{name, _, args}, _return]}, _pos})
        when kind in [:callback, :macrocallback] do
-    {{name, length(args)}, meta}
+    [{{name, length(args)}, meta}]
   end
 
   defp callback_ast_to_fa(
          {kind, {:when, _, [{:"::", meta, [{name, _, args}, _return]}, _vars]}, _pos}
        )
        when kind in [:callback, :macrocallback] do
-    {{name, length(args)}, meta}
+    [{{name, length(args)}, meta}]
   end
 
   defp callback_ast_to_fa({kind, _, _pos}) when kind in [:callback, :macrocallback] do
-    {nil, nil}
+    []
   end
 
   defp callback_metas(module, kind)
        when kind in [:callback, :macrocallback] do
-    metas =
-      :lists.map(&callback_ast_to_fa/1, Module.get_attribute(module, kind))
-      |> :maps.from_list()
-
-    :maps.remove(nil, metas)
+    :lists.flatmap(&callback_ast_to_fa/1, Module.get_attribute(module, kind))
+    |> :maps.from_list()
   end
 
   defp get_callback_line(fa, metas),

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -283,9 +283,9 @@ defmodule ProtocolTest do
                  "nofile:2: type specification missing return type: foo(term)",
                  fn ->
                    Code.eval_string("""
-                     defprotocol WithMalformedCallback do
-                       @callback foo(term)
-                     end
+                   defprotocol WithMalformedCallback do
+                     @callback foo(term)
+                   end
                    """)
                  end
   end

--- a/lib/elixir/test/elixir/protocol_test.exs
+++ b/lib/elixir/test/elixir/protocol_test.exs
@@ -277,6 +277,18 @@ defmodule ProtocolTest do
                    end
                  end
   end
+
+  test "malformed @callback raises with CompileError" do
+    assert_raise CompileError,
+                 "nofile:2: type specification missing return type: foo(term)",
+                 fn ->
+                   Code.eval_string("""
+                     defprotocol WithMalformedCallback do
+                       @callback foo(term)
+                     end
+                   """)
+                 end
+  end
 end
 
 defmodule Protocol.DebugInfoTest do


### PR DESCRIPTION
Related discussion: https://github.com/elixir-lang/elixir/pull/10927#issuecomment-823279830

While trying to break things, I have come up with this issue.

```elixir
defprotocol AProtocol do
  def foo(term)
  @callback bar(term)
end
```

The code above raised:
```
== Compilation error in file lib/a_protocol.ex ==
** (FunctionClauseError) no function clause matching in Protocol.callback_ast_to_fa/1

    The following arguments were given to Protocol.callback_ast_to_fa/1:

        # 1
        {:callback, {:bar, [line: 4], [{:term, [line: 4], nil}]}, {AProtocol, {4, 1}}}

    Attempted function clauses (showing 2 out of 2):

        defp callback_ast_to_fa({kind, {:"::", meta, [{name, _, args}, _return]}, _pos}) when kind === :callback or kind === :macrocallback
        defp callback_ast_to_fa({kind, {:when, _, [{:"::", meta, [{name, _, args}, _return]}, _vars]}, _pos}) when kind === :callback or kind === :macrocallback

    (elixir 1.13.0-dev) lib/protocol.ex:721: Protocol.callback_ast_to_fa/1
    (stdlib 3.13.2) lists.erl:1243: :lists.map/2
    (elixir 1.13.0-dev) lib/protocol.ex:735: Protocol.callback_metas/2
    (elixir 1.13.0-dev) lib/protocol.ex:754: Protocol.__before_compile__/1
    (stdlib 3.13.2) lists.erl:1267: :lists.foldl/3
```

while before the introduction of this recent feature it would raise.:
```
== Compilation error in file lib/a_protocol.ex ==
** (CompileError) lib/a_protocol.ex:4: type specification missing return type: bar(term)
    (elixir 1.11.4) lib/kernel/typespec.ex:911: Kernel.Typespec.compile_error/2
    (stdlib 3.13.2) lists.erl:1358: :lists.mapfoldl/3
    (stdlib 3.13.2) lists.erl:1359: :lists.mapfoldl/3
    (elixir 1.11.4) lib/kernel/typespec.ex:237: Kernel.Typespec.translate_typespecs_for_module/2
    (elixir 1.11.4) src/elixir_erl_compiler.erl:12: anonymous fn/3 in :elixir_erl_compiler.spawn/2
```

This commit implements a catch-all clause for `Protocol.callback_ast_to_fa/1`, so the compiler would raise on malformed specs.