### PR TITLE
Improve readability: Fix minor detail Enumerable doc

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -4,10 +4,7 @@ defprotocol Enumerable do
 
   When you invoke a function in the `Enum` module, the first argument
   is usually a collection that must implement this protocol.
-  For example, the expression:
-
-      Enum.map([1, 2, 3], &(&1 * 2))
-
+  For example, the expression `Enum.map([1, 2, 3], &(&1 * 2))` 
   invokes `Enumerable.reduce/3` to perform the reducing operation that
   builds a mapped list by calling the mapping function `&(&1 * 2)` on
   every element in the collection and consuming the element with an


### PR DESCRIPTION
Convert the code block into an inline, so it is part of the paragraph.
Before the paragraph was split by the codeblock.

Before:
![image](https://user-images.githubusercontent.com/9133420/115719366-a288ad00-a341-11eb-8605-c846500bf407.png)

After: 
![image](https://user-images.githubusercontent.com/9133420/115719316-97ce1800-a341-11eb-86e0-d3d67fea40be.png)
