### PR TITLE
Mix.install/2: Recover from deps.get failures

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -582,12 +582,12 @@ defmodule Mix do
     :ok = Mix.ProjectStack.push(__MODULE__.InstallProject, config, "nofile")
 
     try do
-      dir? = File.dir?(dir)
+      run_deps? = not File.dir?(Path.join(dir, "_build"))
       File.mkdir_p!(dir)
 
       File.cd!(dir, fn ->
-        unless dir? do
-          Mix.Task.run("deps.get")
+        if run_deps? do
+          Mix.Task.rerun("deps.get")
         end
 
         Mix.Task.run("compile")


### PR DESCRIPTION
Closes #10957

I couldn't reproduce it with a test. I tried the following but it passed before & after the patch.

    test "recover from deps errors", %{tmp_dir: tmp_dir} do
      assert_raise Mix.Error, fn ->
        Mix.install([
          {:bad, path: Path.join(tmp_dir, "install_test")}
        ])
      end

      Mix.install([
        {:install_test, path: Path.join(tmp_dir, "install_test")}
      ])

      assert apply(InstallTest, :hello, []) == :world
    end

Manual test shows it seems to work well:

    ~% rm -rf ~/.cache/mix && iex
    Erlang/OTP 24 [RELEASE CANDIDATE 2] [erts-11.2] [source-25b1520b77] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

    Interactive Elixir (1.13.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
    iex(1)> Mix.install(decimal: "~ 2.0")
    ** (Mix.Error) Required version "~ 2.0" for package decimal is incorrectly specified (from: mix.exs)
        (mix 1.13.0-dev) lib/mix.ex:454: Mix.raise/2
        (hex 0.21.2) lib/hex/remote_converger.ex:189: Hex.RemoteConverger.verify_package_req/4
        (elixir 1.13.0-dev) lib/enum.ex:927: Enum."-each/2-lists^foreach/1-0-"/2
        (hex 0.21.2) lib/hex/remote_converger.ex:172: Hex.RemoteConverger.verify_input/2
        (hex 0.21.2) lib/hex/remote_converger.ex:42: Hex.RemoteConverger.converge/2
        (mix 1.13.0-dev) lib/mix/dep/converger.ex:95: Mix.Dep.Converger.all/4
        (mix 1.13.0-dev) lib/mix/dep/converger.ex:51: Mix.Dep.Converger.converge/4
        (mix 1.13.0-dev) lib/mix/dep/fetcher.ex:16: Mix.Dep.Fetcher.all/3
    iex(1)> Mix.install(decimal: "~> 2.0")
    Resolving Hex dependencies...
    Dependency resolution completed:
    New:
      decimal 2.0.0
    * Getting decimal (Hex package)
    ==> decimal
    Compiling 4 files (.ex)
    Generated decimal app
    :ok
    iex(2)> Decimal.new 42
    #Decimal<42>
