### PR TITLE
Optimize Enum.unzip/1 for lists

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3349,6 +3349,15 @@ defmodule Enum do
 
   """
   @spec unzip(t) :: {[element], [element]}
+
+  def unzip([_ | _] = list) do
+    :lists.reverse(list) |> unzip([], [])
+  end
+
+  def unzip([]) do
+    {[], []}
+  end
+
   def unzip(enumerable) do
     {list1, list2} =
       reduce(enumerable, {[], []}, fn {el1, el2}, {list1, list2} ->
@@ -3356,6 +3365,14 @@ defmodule Enum do
       end)
 
     {:lists.reverse(list1), :lists.reverse(list2)}
+  end
+
+  defp unzip([{el1, el2} | reversed_list], list1, list2) do
+    unzip(reversed_list, [el1 | list1], [el2 | list2])
+  end
+
+  defp unzip([], list1, list2) do
+    {list1, list2}
   end
 
   @doc """


### PR DESCRIPTION
The existing unzip implementation is generic for all enumerable types. However, large optimizations are available if the input is a list.

First, instead of doing two reverse operations at the end, we can do one at the beginning. This optimization is unavailable in the existing generic implementation in order to avoid materializing an enumerable that might be generated lazily.

Second, we can accumulate the two output lists in two separate parameters, rather than in the reduce function's single accumulator. This avoids generating a tuple per input element that would just be matched away and discarded.

Testing with Benchfella shows a roughly 2x to 3x performance improvement depending on the size of the list.