### PR TITLE
Disallow streaming with max_concurrency=0

### DIFF
--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -177,6 +177,10 @@ defmodule Task.Supervised do
   def stream(enumerable, acc, reducer, mfa, options, spawn) do
     next = &Enumerable.reduce(enumerable, &1, fn x, acc -> {:suspend, [x | acc]} end)
     max_concurrency = Keyword.get(options, :max_concurrency, System.schedulers_online())
+
+    (is_integer(max_concurrency) && max_concurrency > 0) ||
+      raise ArgumentError, "max_concurrency supplied must be greater than zero!"
+
     ordered? = Keyword.get(options, :ordered, true)
     timeout = Keyword.get(options, :timeout, 5000)
     on_timeout = Keyword.get(options, :on_timeout, :exit)

--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -178,8 +178,8 @@ defmodule Task.Supervised do
     next = &Enumerable.reduce(enumerable, &1, fn x, acc -> {:suspend, [x | acc]} end)
     max_concurrency = Keyword.get(options, :max_concurrency, System.schedulers_online())
 
-    if is_integer(max_concurrency) and max_concurrency <= 0 do
-      raise ArgumentError, ":max_concurrency must be greater than zero"
+    unless is_integer(max_concurrency) and max_concurrency > 0 do
+      raise ArgumentError, ":max_concurrency must be an integer greater than zero"
     end
 
     ordered? = Keyword.get(options, :ordered, true)

--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -178,8 +178,9 @@ defmodule Task.Supervised do
     next = &Enumerable.reduce(enumerable, &1, fn x, acc -> {:suspend, [x | acc]} end)
     max_concurrency = Keyword.get(options, :max_concurrency, System.schedulers_online())
 
-    (is_integer(max_concurrency) && max_concurrency > 0) ||
-      raise ArgumentError, "max_concurrency supplied must be greater than zero!"
+    if is_integer(max_concurrency) and max_concurrency <= 0 do
+      raise ArgumentError, ":max_concurrency must be greater than zero"
+    end
 
     ordered? = Keyword.get(options, :ordered, true)
     timeout = Keyword.get(options, :timeout, 5000)

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -718,7 +718,7 @@ defmodule TaskTest do
     end
 
     test "does not allow streaming with max_concurrency = 0" do
-      assert_raise ArgumentError, fn ->
+      assert_raise ArgumentError, ":max_concurrency must be greater than zero", fn ->
         Task.async_stream([1], fn _ -> :ok end, max_concurrency: 0) |> Enum.to_list()
       end
     end

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -717,6 +717,12 @@ defmodule TaskTest do
       [ok: :ok] = Task.async_stream([1], fn _ -> :ok end, timeout: :infinity) |> Enum.to_list()
     end
 
+    test "does not allow streaming with max_concurrency = 0" do
+      assert_raise ArgumentError, fn ->
+        Task.async_stream([1], fn _ -> :ok end, max_concurrency: 0) |> Enum.to_list()
+      end
+    end
+
     test "streams with fake down messages on the inbox" do
       parent = self()
 

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -718,7 +718,7 @@ defmodule TaskTest do
     end
 
     test "does not allow streaming with max_concurrency = 0" do
-      assert_raise ArgumentError, ":max_concurrency must be greater than zero", fn ->
+      assert_raise ArgumentError, ":max_concurrency must be an integer greater than zero", fn ->
         Task.async_stream([1], fn _ -> :ok end, max_concurrency: 0) |> Enum.to_list()
       end
     end


### PR DESCRIPTION
:wave: 

I was working with some code computing `max_concurrency` dynamically and stumbled upon indefinitely blocking call when the value supplied was zero.

```elixir
Task.async_stream(1..1000, fn x -> IO.inspect(x) end, max_concurrency: 0) |> Enum.to_list()
```