### PR TITLE
Add `--shortest` option to `mix xref graph`

### DIFF
--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -449,6 +449,14 @@ defmodule Mix.Tasks.XrefTest do
       """)
     end
 
+    test "shortest sink and source" do
+      assert_graph(~w[--source lib/a.ex --sink lib/e.ex --shortest], """
+      lib/a.ex
+      `-- lib/b.ex (compile)
+          `-- lib/e.ex (compile)
+      """)
+    end
+
     test "with dynamic module" do
       in_fixture("no_mixfile", fn ->
         File.write!("lib/a.ex", """


### PR DESCRIPTION
This option is available when `--source` and `--sink` are specified
and reduces the graph to the shortest path between the source and sink.

Prior discussion [in elixirforum](https://elixirforum.com/t/how-to-get-a-simple-path-from-xref-graph/39501/2)