### PR TITLE
Better format Elixir exceptions in Erlang

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -43,10 +43,16 @@ defmodule Exception do
   @callback blame(t, stacktrace) :: {t, stacktrace}
   @optional_callbacks [blame: 2]
 
+  @doc false
+  # Callback for formatting Erlang exceptions
+  def format_error(%struct{} = exception, _stacktrace) do
+    %{general: message(exception), reason: "#" <> Atom.to_string(struct)}
+  end
+
   @doc """
   Returns `true` if the given `term` is an exception.
   """
-  # TODO: Remove this on Elixir v1.15
+  # TODO: Deprecate this on Elixir v1.15
   @doc deprecated: "Use Kernel.is_exception/1 instead"
   def exception?(term)
   def exception?(%_{__exception__: true}), do: true

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1963,26 +1963,35 @@ defmodule Kernel do
         false -> message
       end
 
+    fun =
+      case :erlang.system_info(:otp_release) >= '24' do
+        true ->
+          fn x ->
+            quote do
+              :erlang.error(unquote(x), :none, error_info: %{module: Exception})
+            end
+          end
+
+        false ->
+          fn x ->
+            quote do
+              :erlang.error(unquote(x))
+            end
+          end
+      end
+
     case message do
       message when is_binary(message) ->
-        quote do
-          :erlang.error(RuntimeError.exception(unquote(message)))
-        end
+        fun.(quote do: RuntimeError.exception(unquote(message)))
 
       {:<<>>, _, _} = message ->
-        quote do
-          :erlang.error(RuntimeError.exception(unquote(message)))
-        end
+        fun.(quote do: RuntimeError.exception(unquote(message)))
 
       alias when is_atom(alias) ->
-        quote do
-          :erlang.error(unquote(alias).exception([]))
-        end
+        fun.(quote do: unquote(alias).exception([]))
 
       _ ->
-        quote do
-          :erlang.error(Kernel.Utils.raise(unquote(message)))
-        end
+        fun.(quote do: Kernel.Utils.raise(unquote(message)))
     end
   end
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1963,7 +1963,7 @@ defmodule Kernel do
         false -> message
       end
 
-    fun =
+    erlang_error =
       case :erlang.system_info(:otp_release) >= '24' do
         true ->
           fn x ->
@@ -1982,16 +1982,16 @@ defmodule Kernel do
 
     case message do
       message when is_binary(message) ->
-        fun.(quote do: RuntimeError.exception(unquote(message)))
+        erlang_error.(quote do: RuntimeError.exception(unquote(message)))
 
       {:<<>>, _, _} = message ->
-        fun.(quote do: RuntimeError.exception(unquote(message)))
+        erlang_error.(quote do: RuntimeError.exception(unquote(message)))
 
       alias when is_atom(alias) ->
-        fun.(quote do: unquote(alias).exception([]))
+        erlang_error.(quote do: unquote(alias).exception([]))
 
       _ ->
-        fun.(quote do: Kernel.Utils.raise(unquote(message)))
+        erlang_error.(quote do: Kernel.Utils.raise(unquote(message)))
     end
   end
 

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -9,20 +9,6 @@ defmodule ExceptionTest do
 
   doctest Exception
 
-  test "raising preserves the stacktrace" do
-    stacktrace =
-      try do
-        raise "a"
-      rescue
-        _ -> hd(__STACKTRACE__)
-      end
-
-    file = __ENV__.file |> Path.relative_to_cwd() |> String.to_charlist()
-
-    assert {__MODULE__, :"test raising preserves the stacktrace", _, [file: ^file, line: 15]} =
-             stacktrace
-  end
-
   test "message/1" do
     defmodule BadException do
       def message(exception) do

--- a/lib/elixir/test/elixir/kernel/quote_test.exs
+++ b/lib/elixir/test/elixir/kernel/quote_test.exs
@@ -349,7 +349,7 @@ defmodule Kernel.QuoteTest.ErrorsTest do
       RuntimeError ->
         mod = Kernel.QuoteTest.ErrorsTest
         file = __ENV__.file |> Path.relative_to_cwd() |> String.to_charlist()
-        assert [{^mod, :will_raise, 2, [file: ^file, line: @line]} | _] = __STACKTRACE__
+        assert [{^mod, :will_raise, 2, [file: ^file, line: @line] ++ _} | _] = __STACKTRACE__
     else
       _ -> flunk("expected failure")
     end
@@ -363,7 +363,7 @@ defmodule Kernel.QuoteTest.ErrorsTest do
       RuntimeError ->
         mod = Kernel.QuoteTest.ErrorsTest
         file = __ENV__.file |> Path.relative_to_cwd() |> String.to_charlist()
-        assert [{^mod, _, _, [file: ^file, line: @line]} | _] = __STACKTRACE__
+        assert [{^mod, _, _, [file: ^file, line: @line] ++ _} | _] = __STACKTRACE__
     else
       _ -> flunk("expected failure")
     end

--- a/lib/elixir/test/elixir/kernel/raise_test.exs
+++ b/lib/elixir/test/elixir/kernel/raise_test.exs
@@ -12,6 +12,20 @@ defmodule Kernel.RaiseTest do
   @compile {:no_warn_undefined, DoNotExist}
   @trace [{:foo, :bar, 0, []}]
 
+  test "raise preserves the stacktrace" do
+    stacktrace =
+      try do
+        raise "a"
+      rescue
+        _ -> hd(__STACKTRACE__)
+      end
+
+    file = __ENV__.file |> Path.relative_to_cwd() |> String.to_charlist()
+
+    assert {__MODULE__, :"test raise preserves the stacktrace", _, [file: ^file, line: 18] ++ _} =
+             stacktrace
+  end
+
   test "raise message" do
     assert_raise RuntimeError, "message", fn ->
       raise "message"
@@ -55,20 +69,6 @@ defmodule Kernel.RaiseTest do
       var = struct()
       raise var
     end
-  end
-
-  test "raise preserves the stacktrace" do
-    stacktrace =
-      try do
-        raise "a"
-      rescue
-        _ -> hd(__STACKTRACE__)
-      end
-
-    file = __ENV__.file |> Path.relative_to_cwd() |> String.to_charlist()
-
-    assert {__MODULE__, :"test raise preserves the stacktrace", _, [file: ^file, line: 63] ++ _} =
-             stacktrace
   end
 
   if :erlang.system_info(:otp_release) >= '24' do


### PR DESCRIPTION
This PR uses EEP 54 so Elixir exceptions are nicely
formatted by Erlang callers. Take this code:

    raise "this is a test"

Before:

    ** exception error: #{'__exception__' => true,
                          '__struct__' => 'Elixir.RuntimeError',
                          message => <<"this is a test">>}
       in function  'Elixir.Foo':bar/0 (iex, line 2)

After:

    ** exception error: #Elixir.RuntimeError
       in function  'Elixir.Foo':bar/0 (iex, line 2)
          *** this is a test

This depends on https://github.com/erlang/otp/pull/4764.