### PR TITLE
Expose more formatter functions in the `Code` module

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -1360,6 +1360,11 @@ defmodule Code do
 
     * `:comments` - the list of comments associated with the quoted expression.
       Defaults to `[]`.
+
+    * `:escape` - when `true`, escaped sequences like `\n` will be escaped into
+      `\\n`. If the `:unescape` option was set to `false` when using
+      `string_to_quoted/2`, setting this option to `false` will prevent it from
+      escaping the sequences twice. Defaults to `true`.
   """
   @spec quoted_to_algebra(Macro.t(), keyword) :: Inspect.Algebra.t()
   def quoted_to_algebra(quoted, opts \\ []) do

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -1100,6 +1100,11 @@ defmodule Code do
     * `:columns` - when `true`, attach a `:column` key to the quoted
       metadata. Defaults to `false`.
 
+    * `:unescape` - when `false`, preserves escaped sequences. For example,
+      `"null byte\\t\\x00"` will be kept as is instead of being converted to a
+      bit string literal. This is useful in combination with
+      `quoted_to_algebra/2`. Defaults to `true`.
+
     * `:existing_atoms_only` - when `true`, raises an error
       when non-existing atoms are found by the tokenizer.
       Defaults to `false`.
@@ -1310,8 +1315,25 @@ defmodule Code do
   @doc """
   Converts a quoted expression to an algebra document.
 
-  Supports both regular AST and the extended AST documented in
-  `string_to_quoted_with_comments/2`.
+  The elixir AST does not contain metadata for literals like strings, lists, or
+  tuples with two elements, which means that the produced algebra document will
+  not respect all of the user preferences and comments may be misplaced.
+  To get better results, you can use the `:token_metadata`, `:escape` and
+  `:literal_encoder` options to `string_to_quoted/2` to provide additional
+  information to the formatter:
+
+      [
+        literal_encoder: &{:ok, {:__block__, &2, [&1]}},
+        token_metadata: true,
+        unescape: false
+      ]
+
+  This will produce an AST that contains information such as `do` blocks start
+  and end lines or sigil delimiters, and by wrapping literals in blocks they can
+  now hold metadata like line number, string delimiter and escaped sequences, or
+  integer formatting(ie `0x2a` instead of `47`). This is especially useful if
+  you're doing source code manipulation, where it's important to preserve user
+  choices and comments placing.
 
   ## Options
 

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -1360,7 +1360,7 @@ defmodule Code do
   @spec quoted_to_algebra(Macro.t(), keyword) :: Inspect.Algebra.t()
   def quoted_to_algebra(quoted, opts \\ []) do
     quoted
-    |> Code.Normalizer.normalize()
+    |> Code.Normalizer.normalize(opts)
     |> Code.Formatter.to_algebra(opts)
   end
 

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -989,7 +989,7 @@ defmodule Code do
         token_metadata: true
       ] ++ opts
 
-    {forms, comments} = Code.string_to_quoted_with_comments!(string, to_quoted_opts)
+    {forms, comments} = string_to_quoted_with_comments!(string, to_quoted_opts)
 
     to_algebra_opts =
       [

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -1308,6 +1308,24 @@ defmodule Code do
   defp previous_eol_count(_), do: 0
 
   @doc """
+  Converts a quoted expression to an algebra document.
+
+  Supports both regular AST and the extended AST documented in
+  `string_to_quoted_with_comments/2`.
+
+  ## Options
+
+    * `:comments` - the list of comments associated with the quoted expression.
+      Defaults to `[]`.
+  """
+  @spec quoted_to_algebra(Macro.t(), keyword) :: Inspect.Algebra.t()
+  def quoted_to_algebra(quoted, opts \\ []) do
+    quoted
+    |> Code.Normalizer.normalize()
+    |> Code.Formatter.quoted_expression_to_algebra(opts)
+  end
+
+  @doc """
   Evals the given file.
 
   Accepts `relative_to` as an argument to tell where the file is located.

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -191,47 +191,20 @@ defmodule Code.Formatter do
   end
 
   @doc """
-  Converts `string` to an algebra document.
-
-  Returns `{:ok, doc}` or `{:error, parser_error}`.
-
-  See `Code.format_string!/2` for the list of options.
+  Converts the quoted expression into an algebra document
   """
-  def to_algebra(string, opts \\ []) when is_binary(string) and is_list(opts) do
-    to_quoted_opts = [
-      unescape: false,
-      warn_on_unnecessary_quotes: false,
-      literal_encoder: &{:ok, {:__block__, &2, [&1]}},
-      token_metadata: true
-    ]
+  def to_algebra(quoted, opts \\ []) do
+    comments = Keyword.get(opts, :comments, [])
 
-    with {:ok, forms, comments} <- Code.string_to_quoted_with_comments(string, to_quoted_opts) do
-      state =
-        comments
-        |> Enum.map(&format_comment/1)
-        |> gather_comments()
-        |> state(opts)
+    state =
+      comments
+      |> Enum.map(&format_comment/1)
+      |> gather_comments()
+      |> state(opts)
 
-      {doc, _} = block_to_algebra(forms, @min_line, @max_line, state)
-      {:ok, doc}
-    end
-  end
+    {doc, _} = block_to_algebra(quoted, @min_line, @max_line, state)
 
-  @doc """
-  Converts `string` to an algebra document.
-
-  Raises if the `string` cannot be parsed.
-
-  See `Code.format_string!/2` for the list of options.
-  """
-  def to_algebra!(string, opts \\ []) do
-    case to_algebra(string, opts) do
-      {:ok, doc} ->
-        doc
-
-      {:error, {location, error, token}} ->
-        :elixir_errors.parse_error(location, Keyword.get(opts, :file, "nofile"), error, token)
-    end
+    doc
   end
 
   defp state(comments, opts) do
@@ -246,19 +219,6 @@ defmodule Code.Formatter do
       operand_nesting: 2,
       comments: comments
     }
-  end
-
-  @doc """
-  Converts the quoted expression into an algebra document
-  """
-  def quoted_expression_to_algebra(quoted, opts \\ []) do
-    comments = Keyword.get(opts, :comments, [])
-
-    state = state(comments, opts)
-
-    {doc, _} = block_to_algebra(quoted, @min_line, @max_line, state)
-
-    {:ok, doc}
   end
 
   defp format_comment(%{text: text} = comment) do

--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -13,66 +13,72 @@ defmodule Code.Normalizer do
   """
   def normalize(quoted, opts \\ []) do
     line = Keyword.get(opts, :line, 1)
+    escape = Keyword.get(opts, :escape, true)
 
-    do_normalize(quoted, line: line)
+    state = %{
+      escape: escape,
+      parent_meta: [line: line]
+    }
+
+    do_normalize(quoted, state)
   end
 
   # Skip normalized literals
-  defp do_normalize({:__block__, _, [literal]} = quoted, _parent_meta) when is_literal(literal) do
+  defp do_normalize({:__block__, _, [literal]} = quoted, _state) when is_literal(literal) do
     quoted
   end
 
   # Skip normalized charlists
-  defp do_normalize({:__block__, meta, [charlist]} = quoted, parent_meta)
+  defp do_normalize({:__block__, meta, [charlist]} = quoted, state)
        when is_list(charlist) do
     if Keyword.has_key?(meta, :delimiter) do
       quoted
     else
-      do_normalize(charlist, parent_meta)
+      do_normalize(charlist, state)
     end
   end
 
   # Only normalize the first argument of an alias if it's not an atom
-  defp do_normalize({:__aliases, meta, [first | rest]}, parent_meta) when not is_atom(first) do
-    meta = patch_meta_line(meta, parent_meta)
-    first = do_normalize(first, meta)
+  defp do_normalize({:__aliases, meta, [first | rest]}, state) when not is_atom(first) do
+    meta = patch_meta_line(meta, state.parent_meta)
+    first = do_normalize(first, %{state | paret_meta: meta})
     {:__aliases__, meta, [first | rest]}
   end
 
-  defp do_normalize({:__aliases__, _, _} = quoted, _parent_meta) do
+  defp do_normalize({:__aliases__, _, _} = quoted, _state) do
     quoted
   end
 
   # Skip captured arguments like &1
-  defp do_normalize({:&, meta, [term]}, parent_meta) when is_integer(term) do
-    meta = patch_meta_line(meta, parent_meta)
+  defp do_normalize({:&, meta, [term]}, state) when is_integer(term) do
+    meta = patch_meta_line(meta, state.parent_meta)
     {:&, meta, [term]}
   end
 
   # Ranges
-  defp do_normalize(left..right//step, parent_meta) do
-    left = do_normalize(left, parent_meta)
-    right = do_normalize(right, parent_meta)
+  defp do_normalize(left..right//step, state) do
+    left = do_normalize(left, state)
+    right = do_normalize(right, state)
 
-    meta = [line: parent_meta[:line]]
+    meta = [line: state.parent_meta[:line]]
 
     if step == 1 do
       {:.., meta, [left, right]}
     else
-      step = do_normalize(step, parent_meta)
+      step = do_normalize(step, state)
       {:"..//", meta, [left, right, step]}
     end
   end
 
   # Bit containers
-  defp do_normalize({:<<>>, meta, parts} = quoted, parent_meta) do
-    meta = patch_meta_line(meta, parent_meta)
+  defp do_normalize({:<<>>, meta, parts} = quoted, state) do
+    meta = patch_meta_line(meta, state.parent_meta)
 
     parts =
       if interpolated?(quoted) do
-        normalize_interpolation_parts(parts, meta)
+        normalize_interpolation_parts(parts, %{state | parent_meta: meta})
       else
-        Enum.map(parts, &do_normalize(&1, meta))
+        Enum.map(parts, &do_normalize(&1, %{state | parent_meta: meta}))
       end
 
     {:<<>>, meta, parts}
@@ -81,53 +87,53 @@ defmodule Code.Normalizer do
   # Skip atoms with interpolations
   defp do_normalize(
          {{:., _, [:erlang, :binary_to_atom]}, _, [{:<<>>, _, _}, :utf8]} = quoted,
-         _parent_meta
+         _state
        ) do
     quoted
   end
 
   # Skip charlists with interpolations
-  defp do_normalize({{:., _, [List, :to_charlist]}, _, _} = quoted, _parent_meta) do
+  defp do_normalize({{:., _, [List, :to_charlist]}, _, _} = quoted, _state) do
     quoted
   end
 
   # Don't normalize the `Access` atom in access syntax
-  defp do_normalize({:., meta, [Access, :get]}, parent_meta) do
-    meta = patch_meta_line(meta, parent_meta)
+  defp do_normalize({:., meta, [Access, :get]}, state) do
+    meta = patch_meta_line(meta, state.parent_meta)
     {:., meta, [Access, :get]}
   end
 
   # Only normalize the left side of the dot operator
   # The right hand side is an atom in the AST but it's not an atom literal, so
   # it should not be wrapped
-  defp do_normalize({:., meta, [left, right]}, parent_meta) do
-    meta = patch_meta_line(meta, parent_meta)
+  defp do_normalize({:., meta, [left, right]}, state) do
+    meta = patch_meta_line(meta, state.parent_meta)
 
-    left = do_normalize(left, meta)
+    left = do_normalize(left, %{state | parent_meta: meta})
 
     {:., meta, [left, right]}
   end
 
   # A list of left to right arrows is not considered as a list literal, so it's
   # not wrapped
-  defp do_normalize([{:->, _, _} | _] = quoted, parent_meta) do
-    Enum.map(quoted, &do_normalize(&1, parent_meta))
+  defp do_normalize([{:->, _, _} | _] = quoted, state) do
+    Enum.map(quoted, &do_normalize(&1, state))
   end
 
   # left -> right
-  defp do_normalize({:->, meta, [left, right]}, parent_meta) do
-    meta = patch_meta_line(meta, parent_meta)
+  defp do_normalize({:->, meta, [left, right]}, state) do
+    meta = patch_meta_line(meta, state.parent_meta)
 
-    left = Enum.map(left, &do_normalize(&1, meta))
-    right = do_normalize(right, meta)
+    left = Enum.map(left, &do_normalize(&1, %{state | parent_meta: meta}))
+    right = do_normalize(right, %{state | parent_meta: meta})
     {:->, meta, [left, right]}
   end
 
   # Maps
-  defp do_normalize({:%{}, meta, args}, parent_meta) do
+  defp do_normalize({:%{}, meta, args}, state) do
     meta =
       if meta == [] do
-        line = parent_meta[:line]
+        line = state.parent_meta[:line]
         [line: line, closing: [line: line]]
       else
         meta
@@ -137,56 +143,64 @@ defmodule Code.Normalizer do
       case args do
         [{:|, pipe_meta, [left, right]}] ->
           left = do_normalize(left, meta)
-          {_, _, right} = do_normalize(right, meta)
+          {_, _, right} = do_normalize(right, %{state | parent_meta: meta})
           [{:|, pipe_meta, [left, right]}]
 
         [{_, _, _} = call] ->
-          [do_normalize(call, meta)]
+          [do_normalize(call, %{state | parent_meta: meta})]
 
         args ->
-          normalize_map_args(args, meta)
+          normalize_map_args(args, %{state | parent_meta: meta})
       end
 
     {:%{}, meta, args}
   end
 
   # Sigils
-  defp do_normalize({sigil, meta, [{:<<>>, _, _} = string, modifiers]} = quoted, parent_meta)
+  defp do_normalize({sigil, meta, [{:<<>>, _, _} = string, modifiers]} = quoted, state)
        when is_atom(sigil) do
     case Atom.to_string(sigil) do
       <<"sigil_", _name>> ->
-        {sigil, meta, [do_normalize(string, meta), modifiers]}
+        {sigil, meta, [do_normalize(string, %{state | parent_meta: meta}), modifiers]}
 
       _ ->
-        normalize_call(quoted, parent_meta)
+        normalize_call(quoted, state)
     end
   end
 
   # Calls
-  defp do_normalize({_, _, args} = quoted, parent_meta) when is_list(args) do
-    normalize_call(quoted, parent_meta)
+  defp do_normalize({_, _, args} = quoted, state) when is_list(args) do
+    normalize_call(quoted, state)
   end
 
   # Integers, floats, atoms
-  defp do_normalize(x, parent_meta) when is_literal(x) do
-    meta = [line: parent_meta[:line]]
+  defp do_normalize(literal, state) when is_literal(literal) do
+    meta = [line: state.parent_meta[:line]]
 
     meta =
-      if not is_atom(x) do
-        Keyword.put(meta, :token, Macro.to_string(x))
+      if is_integer(literal) or is_float(literal) do
+        Keyword.put(meta, :token, inspect(literal))
       else
         meta
       end
 
     meta =
-      if not is_nil(parent_meta[:format]) do
-        Keyword.put(meta, :format, parent_meta[:format])
+      if not is_nil(state.parent_meta[:format]) do
+        Keyword.put(meta, :format, state.parent_meta[:format])
       else
         meta
       end
 
-    if module_atom?(x) do
-      "Elixir." <> segments = Atom.to_string(x)
+    literal =
+      if is_binary(literal) and state.escape do
+        {string, _} = Code.Identifier.escape(literal, ?")
+        IO.iodata_to_binary(string)
+      else
+        literal
+      end
+
+    if module_atom?(literal) do
+      "Elixir." <> segments = Atom.to_string(literal)
 
       segments =
         segments
@@ -195,58 +209,58 @@ defmodule Code.Normalizer do
 
       {:__aliases__, meta, segments}
     else
-      {:__block__, meta, [x]}
+      {:__block__, meta, [literal]}
     end
   end
 
   # 2-tuples
-  defp do_normalize({left, right}, parent_meta) do
-    meta = [line: parent_meta[:line]]
+  defp do_normalize({left, right}, state) do
+    meta = [line: state.parent_meta[:line]]
 
-    left_parent_meta =
+    left_state =
       if is_atom(left) and not module_atom?(left) do
-        Keyword.put(parent_meta, :format, :keyword)
+        %{state | parent_meta: Keyword.put(state.parent_meta, :format, :keyword)}
       else
-        meta
+        %{state | parent_meta: meta}
       end
 
     {:__block__, meta,
      [
-       {do_normalize(left, left_parent_meta), do_normalize(right, parent_meta)}
+       {do_normalize(left, left_state), do_normalize(right, state)}
      ]}
   end
 
   # Lists
-  defp do_normalize(list, parent_meta) when is_list(list) do
+  defp do_normalize(list, state) when is_list(list) do
     if !Enum.empty?(list) and List.ascii_printable?(list) do
       # It's a charlist
-      {:__block__, [line: parent_meta[:line], delimiter: "'"], [list]}
+      {:__block__, [line: state.parent_meta[:line], delimiter: "'"], [list]}
     else
-      meta = [line: parent_meta[:line], closing: [line: parent_meta[:line]]]
+      meta = [line: state.parent_meta[:line], closing: [line: state.parent_meta[:line]]]
 
-      args = normalize_list_elements(list, parent_meta)
+      args = normalize_list_elements(list, state)
 
       {:__block__, meta, [args]}
     end
   end
 
   # Everything else
-  defp do_normalize(quoted, _parent_meta) do
+  defp do_normalize(quoted, _state) do
     quoted
   end
 
-  defp normalize_call({form, meta, args}, parent_meta) do
+  defp normalize_call({form, meta, args}, state) do
     # Only normalize the form if it's a qualified call
     form =
       if is_atom(form) do
         form
       else
-        do_normalize(form, meta)
+        do_normalize(form, %{state | parent_meta: meta})
       end
 
     meta =
       if meta == [] do
-        line = parent_meta[:line]
+        line = state.parent_meta[:line]
         [line: line, closing: [line: line]]
       else
         meta
@@ -254,29 +268,29 @@ defmodule Code.Normalizer do
 
     cond do
       Keyword.has_key?(meta, :do) ->
-        normalize_kw_blocks(form, meta, args)
+        normalize_kw_blocks(form, meta, args, state)
 
       match?([{:do, _} | _], List.last(args)) ->
-        line = parent_meta[:line]
+        line = state.parent_meta[:line]
         meta = [do: [line: line], end: [line: line]]
 
-        normalize_kw_blocks(form, meta, args)
+        normalize_kw_blocks(form, meta, args, state)
 
       true ->
-        args = Enum.map(args, &do_normalize(&1, meta))
+        args = Enum.map(args, &do_normalize(&1, %{state | parent_meta: state.parent_meta}))
 
         {form, meta, args}
     end
   end
 
-  defp normalize_interpolation_parts(parts, _meta) do
+  defp normalize_interpolation_parts(parts, state) do
     Enum.map(parts, fn
       {:"::", interpolation_meta,
        [
          {{:., dot_meta, [Kernel, :to_string]}, middle_meta, [middle]},
          {:binary, binary_meta, context}
        ]} ->
-        middle = do_normalize(middle, dot_meta)
+        middle = do_normalize(middle, %{state | parent_meta: dot_meta})
 
         {:"::", interpolation_meta,
          [
@@ -289,32 +303,32 @@ defmodule Code.Normalizer do
     end)
   end
 
-  defp normalize_map_args([{key, value} | rest], parent_meta) do
+  defp normalize_map_args([{key, value} | rest], state) do
     key =
       cond do
         is_atom(key) and not module_atom?(key) ->
-          meta = [format: :keyword, line: parent_meta[:line]]
+          meta = [format: :keyword, line: state.parent_meta[:line]]
           {:__block__, meta, [key]}
 
         true ->
-          do_normalize(key, parent_meta)
+          do_normalize(key, state)
       end
 
-    value = do_normalize(value, parent_meta)
+    value = do_normalize(value, state)
 
-    [{key, value} | normalize_map_args(rest, parent_meta)]
+    [{key, value} | normalize_map_args(rest, state)]
   end
 
   defp normalize_map_args([], _) do
     []
   end
 
-  defp normalize_kw_blocks(form, meta, args) do
+  defp normalize_kw_blocks(form, meta, args, state) do
     {kw_blocks, leading_args} = List.pop_at(args, -1)
 
     kw_blocks =
       Enum.map(kw_blocks, fn {tag, block} ->
-        block = do_normalize(block, meta)
+        block = do_normalize(block, %{state | parent_meta: meta})
 
         block =
           case block do
@@ -332,19 +346,19 @@ defmodule Code.Normalizer do
         {tag, block}
       end)
 
-    {_, _, [leading_args]} = do_normalize(leading_args, meta)
+    {_, _, [leading_args]} = do_normalize(leading_args, %{state | parent_meta: meta})
 
     {form, meta, leading_args ++ [kw_blocks]}
   end
 
-  defp normalize_list_elements(elems, parent_meta, keyword? \\ false)
+  defp normalize_list_elements(elems, state, keyword? \\ false)
 
-  defp normalize_list_elements([[{_, _, [{_, _}]}] = first | rest], parent_meta, keyword?) do
+  defp normalize_list_elements([[{_, _, [{_, _}]}] = first | rest], state, keyword?) do
     # Skip already normalized 2-tuples
-    [first | normalize_list_elements(rest, parent_meta, keyword?)]
+    [first | normalize_list_elements(rest, state, keyword?)]
   end
 
-  defp normalize_list_elements([{left, right} | rest], parent_meta, keyword?) do
+  defp normalize_list_elements([{left, right} | rest], state, keyword?) do
     keyword? =
       if not keyword? do
         Enum.empty?(rest) or Inspect.List.keyword?(rest)
@@ -354,25 +368,25 @@ defmodule Code.Normalizer do
 
     module_atom? = module_atom?(left)
 
-    left = do_normalize(left, parent_meta)
-    right = do_normalize(right, parent_meta)
+    left = do_normalize(left, state)
+    right = do_normalize(right, state)
 
     pair =
       if keyword? and not module_atom? do
         left = Macro.update_meta(left, &Keyword.put(&1, :format, :keyword))
         {left, right}
       else
-        {:__block__, [line: parent_meta[:line]], [{left, right}]}
+        {:__block__, [line: state.parent_meta[:line]], [{left, right}]}
       end
 
-    [pair | normalize_list_elements(rest, parent_meta, keyword?)]
+    [pair | normalize_list_elements(rest, state, keyword?)]
   end
 
-  defp normalize_list_elements([first | rest], parent_meta, keyword?) do
-    [do_normalize(first, parent_meta) | normalize_list_elements(rest, parent_meta, keyword?)]
+  defp normalize_list_elements([first | rest], state, keyword?) do
+    [do_normalize(first, state) | normalize_list_elements(rest, state, keyword?)]
   end
 
-  defp normalize_list_elements([], _parent_meta, _keyword?) do
+  defp normalize_list_elements([], _state, _keyword?) do
     []
   end
 

--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -414,7 +414,7 @@ defmodule Code.Normalizer do
       {string, _} = Code.Identifier.escape(string, ?")
       IO.iodata_to_binary(string)
     else
-      String.trim(inspect(string), "\"")
+      inspect(string)
     end
   end
 

--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -192,7 +192,7 @@ defmodule Code.Normalizer do
       end
 
     literal =
-      if is_binary(literal) and state.escape do
+      if is_binary(literal) and state.escape == true do
         {string, _} = Code.Identifier.escape(literal, ?")
         IO.iodata_to_binary(string)
       else

--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -428,7 +428,7 @@ defmodule Code.Normalizer do
   end
 
   defp maybe_escape_literal(string, %{escape: true}) when is_binary(string) do
-    {string, _} = Code.Identifier.escape(string, nil)
+    {string, _} = Code.Identifier.escape(string, -1)
     IO.iodata_to_binary(string)
   end
 

--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -22,21 +22,13 @@ defmodule Code.Normalizer do
     quoted
   end
 
-  defp do_normalize({:__block__, meta, args} = quoted, _parent_meta) do
-    if Keyword.has_key?(meta, :format) do
-      quoted
-    else
-      {:__block__, meta, Enum.map(args, &do_normalize(&1, meta))}
-    end
+  # Only normalize the first argument of an alias if it's not an atom
+  defp do_normalize({:__aliases, meta, [first | rest]}, _parent_meta) when not is_atom(first) do
+    first = do_normalize(first, meta)
+    {:__aliases__, meta, [first | rest]}
   end
 
-  # Skip aliases so the module segment atoms don't get wrapped
   defp do_normalize({:__aliases__, _, _} = quoted, _parent_meta) do
-    quoted
-  end
-
-  # Skip qualified tuples left hand side
-  defp do_normalize({:., _, [_, :{}]} = quoted, _parent_meta) do
     quoted
   end
 

--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -331,14 +331,14 @@ defmodule Code.Normalizer do
 
     module_atom? = module_atom?(left)
 
+    left = do_normalize(left, parent_meta)
+    right = do_normalize(right, parent_meta)
+
     pair =
       if keyword? and not module_atom? do
-        {_, _, [{left, right}]} = do_normalize({left, right}, parent_meta)
         left = Macro.update_meta(left, &Keyword.put(&1, :format, :keyword))
         {left, right}
       else
-        left = do_normalize(left, parent_meta)
-        right = do_normalize(right, parent_meta)
         {:__block__, [line: parent_meta[:line]], [{left, right}]}
       end
 

--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -232,7 +232,7 @@ defmodule Code.Normalizer do
     if list != [] and List.ascii_printable?(list) do
       # It's a charlist
       list =
-        if state.escape == true do
+        if state.escape do
           {string, _} = Code.Identifier.escape(IO.chardata_to_string(list), ?')
           IO.iodata_to_binary(string) |> to_charlist()
         else

--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -234,6 +234,13 @@ defmodule Code.Normalizer do
   defp do_normalize(list, state) when is_list(list) do
     if !Enum.empty?(list) and List.ascii_printable?(list) do
       # It's a charlist
+      list =
+        if state.escape == true do
+          {string, _} = Code.Identifier.escape(IO.chardata_to_string(list), ?')
+          IO.iodata_to_binary(string) |> to_charlist()
+        else
+          list
+        end
       {:__block__, [line: state.parent_meta[:line], delimiter: "'"], [list]}
     else
       meta = [line: state.parent_meta[:line], closing: [line: state.parent_meta[:line]]]

--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -1,0 +1,246 @@
+defmodule Code.Normalizer do
+  @moduledoc false
+
+  defguard is_literal(x)
+           when is_integer(x) or
+                  is_float(x) or
+                  is_binary(x) or
+                  is_atom(x)
+
+  @doc """
+  Wraps literals in the quoted expression to conform to the AST format expected
+  by the formatter.
+  """
+  def normalize(quoted, opts \\ []) do
+    line = Keyword.get(opts, :line, 1)
+
+    do_normalize(quoted, line: line)
+  end
+
+  # Skip already wrapped blocks
+  defp do_normalize({:__block__, _, [literal]} = quoted, _parent_meta) when is_literal(literal) do
+    quoted
+  end
+
+  defp do_normalize({:__block__, meta, args} = quoted, _parent_meta) do
+    if Keyword.has_key?(meta, :format) do
+      quoted
+    else
+      {:__block__, meta, Enum.map(args, &do_normalize(&1, meta))}
+    end
+  end
+
+  # Skip aliases so the module segment atoms don't get wrapped
+  defp do_normalize({:__aliases__, _, _} = quoted, _parent_meta) do
+    quoted
+  end
+
+  # Skip qualified tuples left hand side
+  defp do_normalize({:., _, [_, :{}]} = quoted, _parent_meta) do
+    quoted
+  end
+
+  # Don't normalize the `Access` atom in access syntax
+  defp do_normalize({:., _, [Access, :get]} = quoted, _parent_meta) do
+    quoted
+  end
+
+  # Only normalize the left side of the dot operator
+  # The right hand side is an atom in the AST but it's not an atom literal, so
+  # it should not be wrapped
+  defp do_normalize({:., meta, [left, right]}, _parent_meta) do
+    {:., meta, [do_normalize(left, meta), right]}
+  end
+
+  # A list of left to right arrows is not considered as a list literal, so it's
+  # not wrapped
+  defp do_normalize([{:->, _, _} | _] = quoted, parent_meta) do
+    Enum.map(quoted, &do_normalize(&1, parent_meta))
+  end
+
+  # left -> right
+  defp do_normalize({:->, meta, [left, right]}, _parent_meta) do
+    left = Enum.map(left, &do_normalize(&1, meta))
+    right = do_normalize(right, meta)
+    {:->, meta, [left, right]}
+  end
+
+  # Maps
+  defp do_normalize({:%{}, meta, args}, _parent_meta) do
+    args = Enum.map(args, &do_normalize(&1, meta))
+
+    args =
+      case args do
+        # Unwrap the right hand side if we're in an update syntax
+        [{:|, pipe_meta, [left, {_, _, [right]}]}] ->
+          [{:|, pipe_meta, [left, right]}]
+
+        # Unwrap args so we have 2-tuples instead of blocks
+        [{_, _, args}] ->
+          args
+
+        args ->
+          args
+      end
+
+    {:%{}, meta, args}
+  end
+
+  # If a keyword list is an argument of a guard, we need to drop the block
+  # wrapping
+  defp do_normalize({:when, meta, args} = _quoted, _parent_meta) do
+    args =
+      Enum.map(args, fn
+        arg when is_list(arg) ->
+          {_, _, [arg]} = do_normalize(arg, meta)
+          arg
+
+        arg ->
+          do_normalize(arg, meta)
+      end)
+
+    {:when, meta, args}
+  end
+
+  # Calls
+  defp do_normalize({form, meta, args}, _parent_meta) when is_list(args) do
+    # Only normalize the form if it's a qualified call
+    form =
+      if is_atom(form) do
+        form
+      else
+        do_normalize(form, meta)
+      end
+
+    cond do
+      Keyword.has_key?(meta, :do) ->
+        {last_arg, leading_args} = List.pop_at(args, -1)
+
+        last_arg =
+          Enum.map(last_arg, fn {tag, block} ->
+            block = do_normalize(block, meta)
+
+            block =
+              case block do
+                {_, _, [[{:->, _, _} | _] = block]} -> block
+                block -> block
+              end
+
+            # Only wrap the tag if it isn't already wrapped
+            tag =
+              case tag do
+                {:__block__, _, _} -> tag
+                _ -> {:__block__, [line: meta[:line]], [tag]}
+              end
+
+            {tag, block}
+          end)
+
+        {_, _, [leading_args]} = do_normalize(leading_args, meta)
+
+        {form, meta, leading_args ++ [last_arg]}
+
+      true ->
+        args = Enum.map(args, &do_normalize(&1, meta))
+
+        {form, meta, args}
+    end
+  end
+
+  # Integers, floats, atoms
+  defp do_normalize(x, parent_meta) when is_literal(x) do
+    meta = [line: parent_meta[:line]]
+
+    meta =
+      if not is_atom(x) do
+        Keyword.put(meta, :token, Macro.to_string(x))
+      else
+        meta
+      end
+
+    meta =
+      if not is_nil(parent_meta[:format]) do
+        Keyword.put(meta, :format, parent_meta[:format])
+      else
+        meta
+      end
+
+    {:__block__, meta, [x]}
+  end
+
+  # 2-tuples
+  defp do_normalize({left, right}, parent_meta) do
+    meta = [line: parent_meta[:line]]
+
+    left_parent_meta =
+      if is_atom(left) do
+        Keyword.put(parent_meta, :format, :keyword)
+      else
+        meta
+      end
+
+    {:__block__, meta,
+     [
+       {do_normalize(left, left_parent_meta), do_normalize(right, parent_meta)}
+     ]}
+  end
+
+  # Lists
+  defp do_normalize(list, parent_meta) when is_list(list) do
+    if !Enum.empty?(list) and List.ascii_printable?(list) do
+      # It's a charlist
+      {:__block__, [line: parent_meta[:line], delimiter: "'"], [list]}
+    else
+      meta = [line: parent_meta[:line], closing: [line: parent_meta[:line]]]
+
+      args = normalize_list_elements(list, parent_meta)
+
+      {:__block__, meta, [args]}
+    end
+  end
+
+  # Everything else
+  defp do_normalize(quoted, _parent_meta) do
+    quoted
+  end
+
+  defp normalize_list_elements(elems, parent_meta, keyword? \\ false)
+
+  defp normalize_list_elements([[{_, _, [{_, _}]}] = first | rest], parent_meta, keyword?) do
+    # Skip already normalized 2-tuples
+    [first | normalize_list_elements(rest, parent_meta, keyword?)]
+  end
+
+  defp normalize_list_elements([{left, right} | rest], parent_meta, keyword?) do
+    keyword? =
+      if not keyword? do
+        Enum.empty?(rest) or keyword?(rest)
+      else
+        keyword?
+      end
+
+    pair =
+      if keyword? do
+        {_, _, [{left, right}]} = do_normalize({left, right}, parent_meta)
+        left = Macro.update_meta(left, &Keyword.put(&1, :format, :keyword))
+        {left, right}
+      else
+        left = do_normalize(left, parent_meta)
+        right = do_normalize(right, parent_meta)
+        {:__block__, [line: parent_meta[:line]], [{left, right}]}
+      end
+
+    [pair | normalize_list_elements(rest, parent_meta, keyword?)]
+  end
+
+  defp normalize_list_elements([first | rest], parent_meta, keyword?) do
+    [do_normalize(first, parent_meta) | normalize_list_elements(rest, parent_meta, keyword?)]
+  end
+
+  defp normalize_list_elements([], _parent_meta, _keyword?) do
+    []
+  end
+
+  defp keyword?([{_, _} | list]), do: keyword?(list)
+  defp keyword?(rest), do: rest == []
+end

--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -233,7 +233,7 @@ defmodule Code.Normalizer do
       # It's a charlist
       list =
         if state.escape do
-          {string, _} = Code.Identifier.escape(IO.chardata_to_string(list), ?')
+          {string, _} = Code.Identifier.escape(IO.chardata_to_string(list), -1)
           IO.iodata_to_binary(string) |> to_charlist()
         else
           list
@@ -413,7 +413,7 @@ defmodule Code.Normalizer do
   end
 
   defp maybe_escape_literal(string, %{escape: true}) when is_binary(string) do
-    {string, _} = Code.Identifier.escape(string, ?")
+    {string, _} = Code.Identifier.escape(string, nil)
     IO.iodata_to_binary(string)
   end
 

--- a/lib/elixir/test/elixir/code_normalizer/comments_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/comments_test.exs
@@ -1,0 +1,66 @@
+Code.require_file("../test_helper.exs", __DIR__)
+
+defmodule Code.Normalizer.IntegrationTest do
+  use ExUnit.Case, async: true
+
+  import CodeNormalizerHelpers
+
+  describe "preserves comments formatting" do
+    test "before and after expressions" do
+      assert_same """
+      # before comment
+      :hello
+      """
+
+      assert_same """
+      :hello
+      # after comment
+      """
+
+      assert_same """
+      # before comment
+      :hello
+      # after comment
+      """
+    end
+
+    test "empty comment" do
+      assert_same """
+      #
+      :foo
+      """
+    end
+
+    test "before and after expressions with newlines" do
+      assert_same """
+      # before comment
+      # second line
+
+      :hello
+
+      # middle comment 1
+
+      #
+
+      # middle comment 2
+
+      :world
+
+      # after comment
+      # second line
+      """
+    end
+
+    test "interpolation with comment outside before and after" do
+      assert_same ~S"""
+      # comment
+      IO.puts("Hello #{world}")
+      """
+
+      assert_same ~S"""
+      IO.puts("Hello #{world}")
+      # comment
+      """
+    end
+  end
+end

--- a/lib/elixir/test/elixir/code_normalizer/general_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/general_test.exs
@@ -518,7 +518,7 @@ defmodule Code.Normalizer.GeneralTest do
 
       assert quoted_to_string(quote(do: :"foo\n#{bar}\tbaz")) == ~S[:"foo\n#{bar}\tbaz"]
 
-      assert quoted_to_string(quote(do: :"foo\"bar"), escape: false) == ~s[:"foo\\"bar"]
+      assert quoted_to_string(quote(do: :"foo\"bar"), escape: false) == ~S[:"foo\"bar"]
       assert quoted_to_string(quote(do: :"foo\"bar")) == ~S[:"foo\\"bar"]
 
       assert quoted_to_string(quote(do: :"one\n\"#{2}\"\nthree"), escape: false) ==

--- a/lib/elixir/test/elixir/code_normalizer/general_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/general_test.exs
@@ -525,9 +525,9 @@ defmodule Code.Normalizer.GeneralTest do
       assert quoted_to_string(quote(do: :"foo#{~s/\n/}bar")) == ~S[:"foo#{~s/\n/}bar"]
 
       assert quoted_to_string(quote(do: :"one\n\"#{2}\"\nthree"), escape: false) ==
-               ~s[:"one\n\\"\#{2}\\"\nthree"]
+               ~s[:"one\n\"\#{2}\"\nthree"]
 
-      assert quoted_to_string(quote(do: :"one\n\"#{2}\"\nthree")) == ~S[:"one\n\\"#{2}\\"\nthree"]
+      assert quoted_to_string(quote(do: :"one\n\"#{2}\"\nthree")) == ~S[:"one\n\"#{2}\"\nthree"]
     end
   end
 

--- a/lib/elixir/test/elixir/code_normalizer/general_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/general_test.exs
@@ -512,6 +512,11 @@ defmodule Code.Normalizer.GeneralTest do
       assert quoted_to_string(quote(do: :"a\nb\tc")) == ~S/:"a\nb\tc"/
     end
 
+    test "atoms with non printable characters" do
+      assert quoted_to_string(quote(do: :"\x00\x01\x10"), escape: false) == ~s/:"\0\x01\x10"/
+      assert quoted_to_string(quote(do: :"\x00\x01\x10")) == ~S/:"\0\x01\x10"/
+    end
+
     test "atoms with interpolations" do
       assert quoted_to_string(quote(do: :"foo\n#{bar}\tbaz"), escape: false) ==
                ~s[:"foo\n\#{bar}\tbaz"]

--- a/lib/elixir/test/elixir/code_normalizer/general_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/general_test.exs
@@ -551,12 +551,16 @@ defmodule Code.Normalizer.GeneralTest do
     end
   end
 
-  test "quoted_to_algebra/2 escapes strings" do
-    quoted =
-      quote do
-        "foo\nbar"
-      end
+  describe "quoted_to_algebra/2 escapes" do
+    test "strings" do
+      assert quoted_to_string(quote(do: "\a\b\d\e\f\n\r\t\v"), escape: false) ==
+               ~s|"\a\b\d\e\f\n\r\t\v"|
 
-    assert quoted_to_string(quoted, escape: true) == "\"foo\\nbar\""
+      assert quoted_to_string(quote(do: "\a\b\d\e\f\n\r\t\v")) ==
+               ~s|"\\a\\b\\d\\e\\f\\n\\r\\t\\v"|
+
+      assert quoted_to_string(quote(do: "\x00\x01\x10"), escape: false) == ~s|"\0\x01\x10"|
+      assert quoted_to_string(quote(do: "\x00\x01\x10")) == ~s|"\\0\\x01\\x10"|
+    end
   end
 end

--- a/lib/elixir/test/elixir/code_normalizer/general_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/general_test.exs
@@ -526,7 +526,9 @@ defmodule Code.Normalizer.GeneralTest do
       assert quoted_to_string(quote(do: :"foo\"bar"), escape: false) == ~S[:"foo\"bar"]
       assert quoted_to_string(quote(do: :"foo\"bar")) == ~S[:"foo\\"bar"]
 
-      assert quoted_to_string(quote(do: :"foo#{~s/\n/}bar"), escape: false) == ~S[:"foo#{~s/\n/}bar"]
+      assert quoted_to_string(quote(do: :"foo#{~s/\n/}bar"), escape: false) ==
+               ~S[:"foo#{~s/\n/}bar"]
+
       assert quoted_to_string(quote(do: :"foo#{~s/\n/}bar")) == ~S[:"foo#{~s/\n/}bar"]
 
       assert quoted_to_string(quote(do: :"one\n\"#{2}\"\nthree"), escape: false) ==

--- a/lib/elixir/test/elixir/code_normalizer/general_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/general_test.exs
@@ -491,7 +491,7 @@ defmodule Code.Normalizer.GeneralTest do
 
     test "strings with non printable characters" do
       assert quoted_to_string(quote(do: "\x00\x01\x10"), escape: false) == ~s/"\x00\x01\x10"/
-      assert quoted_to_string(quote(do: "\x00\x01\x10")) == ~s/"<<0, 1, 16>>"/
+      assert quoted_to_string(quote(do: "\x00\x01\x10")) == ~S/"\0\x01\x10"/
     end
 
     test "charlists with slash escapes" do
@@ -520,6 +520,9 @@ defmodule Code.Normalizer.GeneralTest do
 
       assert quoted_to_string(quote(do: :"foo\"bar"), escape: false) == ~S[:"foo\"bar"]
       assert quoted_to_string(quote(do: :"foo\"bar")) == ~S[:"foo\\"bar"]
+
+      assert quoted_to_string(quote(do: :"foo#{~s/\n/}bar"), escape: false) == ~S[:"foo#{~s/\n/}bar"]
+      assert quoted_to_string(quote(do: :"foo#{~s/\n/}bar")) == ~S[:"foo#{~s/\n/}bar"]
 
       assert quoted_to_string(quote(do: :"one\n\"#{2}\"\nthree"), escape: false) ==
                ~s[:"one\n\\"\#{2}\\"\nthree"]

--- a/lib/elixir/test/elixir/code_normalizer/general_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/general_test.exs
@@ -511,7 +511,9 @@ defmodule Code.Normalizer.GeneralTest do
       assert quoted_to_string(quote(do: 'one #{2} three'), escape: false) == ~S/'one #{2} three'/
       assert quoted_to_string(quote(do: 'one #{2} three')) == ~S/'one #{2} three'/
 
-      assert quoted_to_string(quote(do: 'one\n\'#{2}\'\nthree'), escape: false) == ~s['one\n\\'\#{2}\\'\nthree']
+      assert quoted_to_string(quote(do: 'one\n\'#{2}\'\nthree'), escape: false) ==
+               ~s['one\n\\'\#{2}\\'\nthree']
+
       assert quoted_to_string(quote(do: 'one\n\'#{2}\'\nthree')) == ~S['one\n\'#{2}\'\nthree']
     end
 

--- a/lib/elixir/test/elixir/code_normalizer/general_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/general_test.exs
@@ -524,7 +524,7 @@ defmodule Code.Normalizer.GeneralTest do
       assert quoted_to_string(quote(do: :"foo\n#{bar}\tbaz")) == ~S[:"foo\n#{bar}\tbaz"]
 
       assert quoted_to_string(quote(do: :"foo\"bar"), escape: false) == ~S[:"foo\"bar"]
-      assert quoted_to_string(quote(do: :"foo\"bar")) == ~S[:"foo\\"bar"]
+      assert quoted_to_string(quote(do: :"foo\"bar")) == ~S[:"foo\"bar"]
 
       assert quoted_to_string(quote(do: :"foo#{~s/\n/}bar"), escape: false) ==
                ~S[:"foo#{~s/\n/}bar"]
@@ -532,7 +532,7 @@ defmodule Code.Normalizer.GeneralTest do
       assert quoted_to_string(quote(do: :"foo#{~s/\n/}bar")) == ~S[:"foo#{~s/\n/}bar"]
 
       assert quoted_to_string(quote(do: :"one\n\"#{2}\"\nthree"), escape: false) ==
-               ~s[:"one\n\"\#{2}\"\nthree"]
+               ~s[:"one\n\\"\#{2}\\"\nthree"]
 
       assert quoted_to_string(quote(do: :"one\n\"#{2}\"\nthree")) == ~S[:"one\n\"#{2}\"\nthree"]
     end

--- a/lib/elixir/test/elixir/code_normalizer/general_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/general_test.exs
@@ -5,8 +5,8 @@ defmodule Code.Normalizer.GeneralTest do
 
   import CodeNormalizerHelpers
 
-  defp quoted_to_string(quoted) do
-    {:ok, doc} = Code.quoted_to_algebra(quoted)
+  defp quoted_to_string(quoted, opts \\ []) do
+    doc = Code.quoted_to_algebra(quoted, opts)
 
     Inspect.Algebra.format(doc, 98)
     |> IO.iodata_to_binary()
@@ -549,5 +549,12 @@ defmodule Code.Normalizer.GeneralTest do
       '''rsa
       """
     end
+  end
+
+  test "quoted_to_algebra/2 escapes strings" do
+    quoted = quote do
+      "foo\nbar"
+    end
+    assert quoted_to_string(quoted, escape: true) == "\"foo\\nbar\""
   end
 end

--- a/lib/elixir/test/elixir/code_normalizer/general_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/general_test.exs
@@ -552,9 +552,11 @@ defmodule Code.Normalizer.GeneralTest do
   end
 
   test "quoted_to_algebra/2 escapes strings" do
-    quoted = quote do
-      "foo\nbar"
-    end
+    quoted =
+      quote do
+        "foo\nbar"
+      end
+
     assert quoted_to_string(quoted, escape: true) == "\"foo\\nbar\""
   end
 end

--- a/lib/elixir/test/elixir/code_normalizer/general_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/general_test.exs
@@ -562,5 +562,13 @@ defmodule Code.Normalizer.GeneralTest do
       assert quoted_to_string(quote(do: "\x00\x01\x10"), escape: false) == ~s|"\0\x01\x10"|
       assert quoted_to_string(quote(do: "\x00\x01\x10")) == ~s|"\\0\\x01\\x10"|
     end
+
+    test "charlists" do
+      assert quoted_to_string(quote(do: '\a\b\e\n\r\t\v'), escape: false) ==
+               ~s|'\a\b\e\n\r\t\v'|
+
+      assert quoted_to_string(quote(do: '\a\b\e\n\r\t\v')) ==
+               ~s|'\\a\\b\\e\\n\\r\\t\\v'|
+    end
   end
 end

--- a/lib/elixir/test/elixir/code_normalizer/general_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/general_test.exs
@@ -507,6 +507,14 @@ defmodule Code.Normalizer.GeneralTest do
       assert quoted_to_string(quote(do: '\x00\x01\x10')) == ~S/[0, 1, 16]/
     end
 
+    test "charlists with interpolations" do
+      assert quoted_to_string(quote(do: 'one #{2} three'), escape: false) == ~S/'one #{2} three'/
+      assert quoted_to_string(quote(do: 'one #{2} three')) == ~S/'one #{2} three'/
+
+      assert quoted_to_string(quote(do: 'one\n\'#{2}\'\nthree'), escape: false) == ~s['one\n\\'\#{2}\\'\nthree']
+      assert quoted_to_string(quote(do: 'one\n\'#{2}\'\nthree')) == ~S['one\n\'#{2}\'\nthree']
+    end
+
     test "atoms" do
       assert quoted_to_string(quote(do: :"a\nb\tc"), escape: false) == ~s/:"a\nb\tc"/
       assert quoted_to_string(quote(do: :"a\nb\tc")) == ~S/:"a\nb\tc"/

--- a/lib/elixir/test/elixir/code_normalizer/literals_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/literals_test.exs
@@ -1,0 +1,304 @@
+Code.require_file("../test_helper.exs", __DIR__)
+
+defmodule Code.Normalizer.LiteralsTest do
+  use ExUnit.Case, async: true
+
+  import CodeNormalizerHelpers
+
+  describe "integers" do
+    test "in decimal base" do
+      assert_same "0"
+      assert_same "100"
+      assert_same "007"
+      assert_same "10000"
+      assert_same "100_00"
+    end
+
+    test "in binary base" do
+      assert_same "0b0"
+      assert_same "0b1"
+      assert_same "0b101"
+      assert_same "0b01"
+      assert_same "0b111_111"
+    end
+
+    test "in octal base" do
+      assert_same "0o77"
+      assert_same "0o0"
+      assert_same "0o01"
+      assert_same "0o777_777"
+    end
+
+    test "in hex base" do
+      assert_same "0x1"
+      assert_same "0x01"
+    end
+
+    test "as chars" do
+      assert_same "?a"
+      assert_same "?1"
+      assert_same "?è"
+      assert_same "??"
+      assert_same "?\\\\"
+      assert_same "?\\s"
+      assert_same "?🎾"
+    end
+  end
+
+  describe "floats" do
+    test "with normal notation" do
+      assert_same "0.0"
+      assert_same "1.0"
+      assert_same "123.456"
+      assert_same "0.0000001"
+      assert_same "001.100"
+      assert_same "0_10000_0.000_000"
+    end
+
+    test "with scientific notation" do
+      assert_same "1.0e1"
+      assert_same "1.0e-1"
+      assert_same "1.0e01"
+      assert_same "1.0e-01"
+      assert_same "001.100e-010"
+      assert_same "0_100_0000.100e-010"
+    end
+  end
+
+  describe "atoms" do
+    test "true, false, nil" do
+      assert_same "nil"
+      assert_same "true"
+      assert_same "false"
+    end
+
+    test "without escapes" do
+      assert_same ~S[:foo]
+    end
+
+    test "with escapes" do
+      assert_same ~S[:"f\a\b\ro"]
+    end
+
+    test "with unicode" do
+      assert_same ~S[:ólá]
+    end
+
+    test "does not reformat aliases" do
+      assert_same ~S[:"Elixir.String"]
+    end
+
+    test "quoted operators" do
+      assert_same ~S[:"::"]
+      assert_same ~S[:"..//"]
+      assert_same ~S{["..//": 1]}
+    end
+
+    test "with interpolation" do
+      assert_same ~S[:"one #{2} three"]
+    end
+
+    test "with escapes and interpolation" do
+      assert_same ~S[:"one\n\"#{2}\"\nthree"]
+    end
+  end
+
+  describe "strings" do
+    test "without escapes" do
+      assert_same ~S["foo"]
+    end
+
+    test "with escapes" do
+      assert_same ~S["\x0A"]
+      assert_same ~S["f\a\b\ro"]
+      assert_same ~S["double \" quote"]
+    end
+
+    test "keeps literal new lines" do
+      assert_same """
+      "fo
+      o"
+      """
+    end
+
+    test "with interpolation" do
+      assert_same ~S["one #{} three"]
+      assert_same ~S["one #{2} three"]
+    end
+
+    test "with escaped interpolation" do
+      assert_same ~S["one\#{two}three"]
+    end
+
+    test "with escapes and interpolation" do
+      assert_same ~S["one\n\"#{2}\"\nthree"]
+    end
+  end
+
+  describe "charlists" do
+    test "without escapes" do
+      assert_same ~S['']
+      assert_same ~S[' ']
+      assert_same ~S['foo']
+    end
+
+    test "with escapes" do
+      assert_same ~S['f\a\b\ro']
+      assert_same ~S['single \' quote']
+    end
+
+    test "keeps literal new lines" do
+      assert_same """
+      'fo
+      o'
+      """
+    end
+
+    test "with interpolation" do
+      assert_same ~S['one #{2} three']
+    end
+
+    test "with escape and interpolation" do
+      assert_same ~S['one\n\'#{2}\'\nthree']
+    end
+  end
+
+  describe "string heredocs" do
+    test "without escapes" do
+      assert_same ~S'''
+      """
+      hello
+      """
+      '''
+    end
+
+    test "with escapes" do
+      assert_same ~S'''
+      """
+      f\a\b\ro
+      """
+      '''
+
+      assert_same ~S'''
+      """
+      multiple "\"" quotes
+      """
+      '''
+    end
+
+    test "with interpolation" do
+      assert_same ~S'''
+      """
+      one
+      #{2}
+      three
+      """
+      '''
+
+      assert_same ~S'''
+      """
+      one
+      "
+      #{2}
+      "
+      three
+      """
+      '''
+    end
+
+    test "nested with empty lines" do
+      assert_same ~S'''
+      nested do
+        """
+
+        foo
+
+
+        bar
+
+        """
+      end
+      '''
+    end
+
+    test "nested with empty lines and interpolation" do
+      assert_same ~S'''
+      nested do
+        """
+
+        #{foo}
+
+
+        #{bar}
+
+        """
+      end
+      '''
+
+      assert_same ~S'''
+      nested do
+        """
+        #{foo}
+
+
+        #{bar}
+        """
+      end
+      '''
+    end
+
+    test "with escaped new lines" do
+      assert_same ~S'''
+      """
+      one\
+      #{"two"}\
+      three\
+      """
+      '''
+    end
+  end
+
+  describe "charlist heredocs" do
+    test "without escapes" do
+      assert_same ~S"""
+      '''
+      hello
+      '''
+      """
+    end
+
+    test "with escapes" do
+      assert_same ~S"""
+      '''
+      f\a\b\ro
+      '''
+      """
+
+      assert_same ~S"""
+      '''
+      multiple "\"" quotes
+      '''
+      """
+    end
+
+    test "with interpolation" do
+      assert_same ~S"""
+      '''
+      one
+      #{2}
+      three
+      '''
+      """
+
+      assert_same ~S"""
+      '''
+      one
+      "
+      #{2}
+      "
+      three
+      '''
+      """
+    end
+  end
+end

--- a/lib/elixir/test/elixir/code_normalizer_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer_test.exs
@@ -1,364 +1,476 @@
 Code.require_file("test_helper.exs", __DIR__)
 
 defmodule Code.NormalizerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
-  alias Code.Normalizer
+  defp quoted_to_string(quoted) do
+    {:ok, doc} = Code.quoted_to_algebra(quoted)
 
-  test "integers" do
-    normalized = Normalizer.normalize(10)
-
-    assert {:__block__, meta, [10]} = normalized
-    assert Keyword.has_key?(meta, :line)
-    assert meta[:token] == "10"
+    Inspect.Algebra.format(doc, 98)
+    |> IO.iodata_to_binary()
   end
 
-  test "floats" do
-    normalized = Normalizer.normalize(10.42)
+  describe "to_string/1" do
+    test "variable" do
+      assert quoted_to_string(quote(do: foo)) == "foo"
+    end
 
-    assert {:__block__, meta, [10.42]} = normalized
-    assert Keyword.has_key?(meta, :line)
-    assert meta[:token] == "10.42"
-  end
+    test "local call" do
+      assert quoted_to_string(quote(do: foo(1, 2, 3))) == "foo(1, 2, 3)"
+      assert quoted_to_string(quote(do: foo([1, 2, 3]))) == "foo([1, 2, 3])"
+    end
 
-  test "atoms" do
-    normalized = Normalizer.normalize(:hello)
+    test "remote call" do
+      assert quoted_to_string(quote(do: foo.bar(1, 2, 3))) == "foo.bar(1, 2, 3)"
+      assert quoted_to_string(quote(do: foo.bar([1, 2, 3]))) == "foo.bar([1, 2, 3])"
 
-    assert {:__block__, meta, [:hello]} = normalized
-    assert Keyword.has_key?(meta, :line)
-  end
-
-  test "strings" do
-    normalized = Normalizer.normalize("hello world")
-
-    assert {:__block__, meta, ["hello world"]} = normalized
-    assert Keyword.has_key?(meta, :line)
-    assert meta[:token] == ~s["hello world"]
-  end
-
-  test "charlists" do
-    normalized = Normalizer.normalize('hello world')
-
-    assert {:__block__, meta, ['hello world']} = normalized
-    assert Keyword.has_key?(meta, :line)
-    assert meta[:delimiter] == "'"
-  end
-
-  test "two elements tuples" do
-    normalized = Normalizer.normalize({:foo, :bar})
-
-    assert {:__block__, meta,
-            [
-              {
-                {:__block__, left_meta, [:foo]},
-                {:__block__, right_meta, [:bar]}
-              }
-            ]} = normalized
-
-    assert Keyword.has_key?(meta, :line)
-    assert Keyword.has_key?(left_meta, :line)
-    assert Keyword.has_key?(right_meta, :line)
-  end
-
-  test "regular lists" do
-    normalized = Normalizer.normalize([1, 2, 3])
-
-    assert {:__block__, meta,
-            [
-              [
-                {:__block__, first_meta, [1]},
-                {:__block__, second_meta, [2]},
-                {:__block__, third_meta, [3]}
-              ]
-            ]} = normalized
-
-    metas = [meta, first_meta, second_meta, third_meta]
-
-    assert Enum.all?(metas, &Keyword.has_key?(&1, :line))
-
-    assert [line: _] = meta[:closing]
-
-    assert first_meta[:token] == "1"
-    assert second_meta[:token] == "2"
-    assert third_meta[:token] == "3"
-  end
-
-  test "keyword lists" do
-    quoted = Code.string_to_quoted!("[a: :b, c: :d]")
-    normalized = Normalizer.normalize(quoted)
-
-    assert {:__block__, meta,
-            [
-              [
-                {{:__block__, first_key_meta, [:a]}, {:__block__, _, [:b]}},
-                {{:__block__, second_key_meta, [:c]}, {:__block__, _, [:d]}}
-              ]
-            ]} = normalized
-
-    assert Keyword.has_key?(meta, :line)
-    assert get_in(meta, [:closing, :line]) |> is_integer()
-    assert first_key_meta[:format] == :keyword
-    assert second_key_meta[:format] == :keyword
-  end
-
-  test "list with keyword list as last element" do
-    quoted = Code.string_to_quoted!("[1, {:a, :b}, 2, c: :d, e: :f]")
-    normalized = Normalizer.normalize(quoted)
-
-    assert {:__block__, _,
-            [
-              [
-                {:__block__, _, [1]},
-                {:__block__, _,
-                 [
-                   {
-                     {:__block__, a_meta, [:a]},
-                     {:__block__, _, [:b]}
-                   }
-                 ]},
-                {:__block__, _, [2]},
-                {{:__block__, c_meta, [:c]}, {:__block__, _, [:d]}},
-                {{:__block__, e_meta, [:e]}, {:__block__, _, [:f]}}
-              ]
-            ]} = normalized
-
-    refute a_meta[:format] == :keyword
-
-    assert c_meta[:format] == :keyword
-    assert e_meta[:format] == :keyword
-  end
-
-  test "keyword list in guard with ommited square brackets" do
-    quoted = Code.string_to_quoted!("a when foo: :bar, baz: :qux")
-    normalized = Normalizer.normalize(quoted)
-
-    assert {:when, _,
-            [
-              {:a, _, _},
-              [
-                {{:__block__, _, [:foo]}, {:__block__, _, [:bar]}},
-                {{:__block__, _, [:baz]}, {:__block__, _, [:qux]}}
-              ]
-            ]} = normalized
-  end
-
-  test "maps" do
-    quoted = Code.string_to_quoted!("%{foo: :bar}")
-    normalized = Normalizer.normalize(quoted)
-
-    assert {:%{}, _,
-            [
-              {{:__block__, key_meta, [:foo]}, {:__block__, _, [:bar]}}
-            ]} = normalized
-
-    assert Keyword.get(key_meta, :format) == :keyword
-  end
-
-  test "map with update syntax" do
-    quoted = Code.string_to_quoted!("%{base | foo: :bar}")
-    normalized = Normalizer.normalize(quoted)
-
-    assert {:%{}, _,
-            [
-              {:|, _,
-               [
-                 {:base, _, _},
-                 [{{:__block__, key_meta, [:foo]}, {:__block__, _, [:bar]}}]
-               ]}
-            ]} = normalized
-
-    assert Keyword.get(key_meta, :format) == :keyword
-  end
-
-  test "aliases are skipped" do
-    quoted = Code.string_to_quoted!("Foo.Bar")
-    normalized = Normalizer.normalize(quoted)
-
-    assert quoted == normalized
-  end
-
-  test "`Access` in access syntax is skipped" do
-    quoted = Code.string_to_quoted!("foo[:bar]")
-    normalized = Normalizer.normalize(quoted)
-
-    assert {
-             {:., _, [Access, :get]},
-             _,
-             [
-               {:foo, _, _},
-               {:__block__, _, [:bar]}
-             ]
-           } = normalized
-  end
-
-  test "only the left side of a dot call is normalized" do
-    quoted = Code.string_to_quoted!("foo.bar()")
-    normalized = Normalizer.normalize(quoted)
-
-    assert {{:., _, [{:foo, _, _}, :bar]}, _, []} = normalized
-  end
-
-  test "do blocks" do
-    quoted =
-      Code.string_to_quoted!("""
-      case do
-        :ok
-      end
-      """)
-
-    normalized = Normalizer.normalize(quoted)
-
-    assert {:case, _,
-            [
-              {:__block__, _,
-               [
-                 [
-                   {{:__block__, _, [:do]}, {:__block__, _, [:ok]}}
-                 ]
-               ]}
-            ]} = normalized
-  end
-
-  test "do block when token_metadata: true" do
-    quoted =
-      Code.string_to_quoted!(
-        """
-        case do
-          :ok
+      quoted =
+        quote do
+          (foo do
+             :ok
+           end).bar([1, 2, 3])
         end
-        """,
-        token_metadata: true
+
+      assert quoted_to_string(quoted) == "(foo do\n   :ok\n end).bar([1, 2, 3])"
+    end
+
+    test "nullary remote call" do
+      assert quoted_to_string(quote do: foo.bar) == "foo.bar"
+      assert quoted_to_string(quote do: foo.bar()) == "foo.bar()"
+    end
+
+    test "atom remote call" do
+      assert quoted_to_string(quote(do: :foo.bar(1, 2, 3))) == ":foo.bar(1, 2, 3)"
+    end
+
+    test "remote and fun call" do
+      assert quoted_to_string(quote(do: foo.bar().(1, 2, 3))) == "foo.bar().(1, 2, 3)"
+      assert quoted_to_string(quote(do: foo.bar().([1, 2, 3]))) == "foo.bar().([1, 2, 3])"
+    end
+
+    test "unusual remote atom fun call" do
+      assert quoted_to_string(quote(do: Foo."42"())) == ~s/Foo."42"()/
+      assert quoted_to_string(quote(do: Foo."Bar"())) == ~s/Foo."Bar"()/
+      assert quoted_to_string(quote(do: Foo."bar baz"().""())) == ~s/Foo."bar baz"().""()/
+      assert quoted_to_string(quote(do: Foo."%{}"())) == ~s/Foo."%{}"()/
+      assert quoted_to_string(quote(do: Foo."..."())) == ~s/Foo."..."()/
+    end
+
+    test "atom fun call" do
+      assert quoted_to_string(quote(do: :foo.(1, 2, 3))) == ":foo.(1, 2, 3)"
+    end
+
+    test "aliases call" do
+      assert quoted_to_string(quote(do: Foo.Bar.baz(1, 2, 3))) == "Foo.Bar.baz(1, 2, 3)"
+      assert quoted_to_string(quote(do: Foo.Bar.baz([1, 2, 3]))) == "Foo.Bar.baz([1, 2, 3])"
+      assert quoted_to_string(quote(do: Foo.bar(<<>>, []))) == "Foo.bar(<<>>, [])"
+    end
+
+    test "keyword call" do
+      assert quoted_to_string(quote(do: Foo.bar(foo: :bar))) == "Foo.bar(foo: :bar)"
+      assert quoted_to_string(quote(do: Foo.bar("Elixir.Foo": :bar))) == "Foo.bar([{Foo, :bar}])"
+    end
+
+    test "sigil call" do
+      assert quoted_to_string(quote(do: ~r"123")) == ~S/~r"123"/
+      assert quoted_to_string(quote(do: ~r"\n123")) == ~S/~r"\n123"/
+      assert quoted_to_string(quote(do: ~r"12\"3")) == ~S/~r"12\"3"/
+      assert quoted_to_string(quote(do: ~r/12\/3/u)) == ~S"~r/12\/3/u"
+      assert quoted_to_string(quote(do: ~r{\n123})) == ~S/~r{\n123}/
+      assert quoted_to_string(quote(do: ~r((1\)(2\)3))) == ~S/~r((1\)(2\)3)/
+      assert quoted_to_string(quote(do: ~r{\n1{1\}23})) == ~S/~r{\n1{1\}23}/
+      assert quoted_to_string(quote(do: ~r|12\|3|)) == ~S"~r|12\|3|"
+
+      assert quoted_to_string(quote(do: ~r[1#{two}3])) == ~S/~r[1#{two}3]/
+      assert quoted_to_string(quote(do: ~r|1[#{two}]3|)) == ~S/~r|1[#{two}]3|/
+      assert quoted_to_string(quote(do: ~r'1#{two}3'u)) == ~S/~r'1#{two}3'u/
+
+      assert quoted_to_string(quote(do: ~R"123")) == ~S/~R"123"/
+      assert quoted_to_string(quote(do: ~R"123"u)) == ~S/~R"123"u/
+      assert quoted_to_string(quote(do: ~R"\n123")) == ~S/~R"\n123"/
+
+      assert quoted_to_string(quote(do: ~S["'(123)'"])) == ~S/~S["'(123)'"]/
+      assert quoted_to_string(quote(do: ~s"#{"foo"}")) == ~S/~s"#{"foo"}"/
+
+      assert quoted_to_string(
+               quote do
+                 ~s"""
+                 "\""foo"\""
+                 """
+               end
+             ) == ~s[~s"""\n"\\""foo"\\""\n"""]
+
+      assert quoted_to_string(
+               quote do
+                 ~s'''
+                 '\''foo'\''
+                 '''
+               end
+             ) == ~s[~s'''\n'\\''foo'\\''\n''']
+
+      assert quoted_to_string(
+               quote do
+                 ~s"""
+                 "\"foo\""
+                 """
+               end
+             ) == ~s[~s"""\n"\\"foo\\""\n"""]
+
+      assert quoted_to_string(
+               quote do
+                 ~s'''
+                 '\"foo\"'
+                 '''
+               end
+             ) == ~s[~s'''\n'\\"foo\\"'\n''']
+
+      assert quoted_to_string(
+               quote do
+                 ~S"""
+                 "123"
+                 """
+               end
+             ) == ~s[~S"""\n"123"\n"""]
+    end
+
+    test "tuple call" do
+      assert quoted_to_string(quote(do: alias(Foo.{Bar, Baz, Bong}))) ==
+               "alias Foo.{Bar, Baz, Bong}"
+
+      assert quoted_to_string(quote(do: foo(Foo.{}))) == "foo(Foo.{})"
+    end
+
+    test "arrow" do
+      assert quoted_to_string(quote(do: foo(1, (2 -> 3)))) == "foo(1, (2 -> 3))"
+    end
+
+    test "block" do
+      quoted =
+        quote do
+          1
+          2
+
+          (
+            :foo
+            :bar
+          )
+
+          3
+        end
+
+      expected = """
+      1
+      2
+
+      (
+        :foo
+        :bar
       )
 
-    normalized = Normalizer.normalize(quoted)
+      3
+      """
 
-    assert {:case, meta,
-            [
-              [
-                {{:__block__, _, [:do]}, {:__block__, _, [:ok]}}
-              ]
-            ]} = normalized
+      assert quoted_to_string(quoted) <> "\n" == expected
+    end
 
-    assert [line: _] = Keyword.get(meta, :do)
-    assert [line: _] = Keyword.get(meta, :end)
-  end
+    test "not in" do
+      assert quoted_to_string(quote(do: false not in [])) == "false not in []"
+    end
 
-  test "function with arguments and do block" do
-    quoted =
-      Code.string_to_quoted!("""
-      foo(:bar) do
-        :ok
-      end
-      """)
-
-    normalized = Normalizer.normalize(quoted)
-
-    assert {:foo, _,
-            [
-              {:__block__, _, [:bar]},
-              {:__block__, _,
-               [
-                 [{{:__block__, _, [:do]}, {:__block__, _, [:ok]}}]
-               ]}
-            ]} = normalized
-  end
-
-  test "do, else, catch, rescue and after blocks" do
-    quoted =
-      Code.string_to_quoted!("""
-      foo do
-        :in_do
+    test "if else" do
+      expected = """
+      if foo do
+        bar
       else
-        :in_else
+        baz
+      end
+      """
+
+      assert quoted_to_string(quote(do: if(foo, do: bar, else: baz))) <> "\n" == expected
+    end
+
+    test "case" do
+      quoted =
+        quote do
+          case foo do
+            true ->
+              0
+
+            false ->
+              1
+              2
+          end
+        end
+
+      expected = """
+      case foo do
+        true ->
+          0
+
+        false ->
+          1
+          2
+      end
+      """
+
+      assert quoted_to_string(quoted) <> "\n" == expected
+    end
+
+    test "try" do
+      quoted =
+        quote do
+          try do
+            foo
+          catch
+            _, _ ->
+              2
+          rescue
+            ArgumentError ->
+              1
+          after
+            4
+          else
+            _ ->
+              3
+          end
+        end
+
+      expected = """
+      try do
+        foo
       catch
-        :in_catch
+        _, _ -> 2
       rescue
-        :in_rescue
+        ArgumentError -> 1
       after
-        :in_after
+        4
+      else
+        _ -> 3
       end
-      """)
+      """
 
-    normalized = Normalizer.normalize(quoted)
+      assert quoted_to_string(quoted) <> "\n" == expected
+    end
 
-    assert {:foo, _,
-            [
-              {:__block__, _,
-               [
-                 [
-                   {{:__block__, _, [:do]}, {:__block__, _, [:in_do]}},
-                   {{:__block__, _, [:else]}, {:__block__, _, [:in_else]}},
-                   {{:__block__, _, [:catch]}, {:__block__, _, [:in_catch]}},
-                   {{:__block__, _, [:rescue]}, {:__block__, _, [:in_rescue]}},
-                   {{:__block__, _, [:after]}, {:__block__, _, [:in_after]}}
-                 ]
-               ]}
-            ]} = normalized
-  end
+    test "fn" do
+      assert quoted_to_string(quote(do: fn -> 1 + 2 end)) == "fn -> 1 + 2 end"
+      assert quoted_to_string(quote(do: fn x -> x + 1 end)) == "fn x -> x + 1 end"
 
-  test "left to right arrows" do
-    quoted =
-      Code.string_to_quoted!("""
-      case do
-        :left -> :right
+      quoted =
+        quote do
+          fn x ->
+            y = x + 1
+            y
+          end
+        end
+
+      expected = """
+      fn x ->
+        y = x + 1
+        y
       end
-      """)
+      """
 
-    normalized = Normalizer.normalize(quoted)
+      assert quoted_to_string(quoted) <> "\n" == expected
 
-    assert {:case, _,
-            [
-              {:__block__, _,
-               [
-                 [
-                   {{:__block__, _, [:do]},
-                    [
-                      {:->, _,
-                       [
-                         [{:__block__, _, [:left]}],
-                         {:__block__, _, [:right]}
-                       ]}
-                    ]}
-                 ]
-               ]}
-            ]} = normalized
-  end
+      quoted =
+        quote do
+          fn
+            x ->
+              y = x + 1
+              y
 
-  test "left to right arrow with multiple arguments" do
-    quoted =
-      Code.string_to_quoted!("""
-      case do
-        :foo, :bar -> :baz
+            z ->
+              z
+          end
+        end
+
+      expected = """
+      fn
+        x ->
+          y = x + 1
+          y
+
+        z ->
+          z
       end
-      """)
+      """
 
-    normalized = Normalizer.normalize(quoted)
+      assert quoted_to_string(quoted) <> "\n" == expected
 
-    assert {:case, _,
-            [
-              {:__block__, _,
-               [
-                 [
-                   {{:__block__, _, [:do]},
-                    [
-                      {:->, _,
-                       [
-                         [
-                           {:__block__, _, [:foo]},
-                           {:__block__, _, [:bar]}
-                         ],
-                         {:__block__, _, [:baz]}
-                       ]}
-                    ]}
-                 ]
-               ]}
-            ]} = normalized
-  end
+      assert quoted_to_string(quote(do: (fn x -> x end).(1))) == "(fn x -> x end).(1)"
 
-  test "unqualified call's form is skipped" do
-    quoted = Code.string_to_quoted!("foo()")
-    normalized = Normalizer.normalize(quoted)
+      quoted =
+        quote do
+          (fn
+             %{} -> :map
+             _ -> :other
+           end).(1)
+        end
 
-    assert {:foo, _, []} = normalized
+      expected = """
+      (fn
+         %{} -> :map
+         _ -> :other
+       end).(1)
+      """
+
+      assert quoted_to_string(quoted) <> "\n" == expected
+    end
+
+    test "range" do
+      assert quoted_to_string(quote(do: unquote(-1..+2))) == "-1..2"
+      assert quoted_to_string(quote(do: Foo.integer()..3)) == "Foo.integer()..3"
+      assert quoted_to_string(quote(do: unquote(-1..+2//-3))) == "-1..2//-3"
+
+      assert quoted_to_string(quote(do: Foo.integer()..3//Bar.bat())) ==
+               "Foo.integer()..3//Bar.bat()"
+    end
+
+    test "when" do
+      assert quoted_to_string(quote(do: (() -> x))) == "(() -> x)"
+      assert quoted_to_string(quote(do: (x when y -> z))) == "(x when y -> z)"
+      assert quoted_to_string(quote(do: (x, y when z -> w))) == "(x, y when z -> w)"
+      assert quoted_to_string(quote(do: (x, y when z -> w))) == "(x, y when z -> w)"
+    end
+
+    test "nested" do
+      quoted =
+        quote do
+          defmodule Foo do
+            def foo do
+              1 + 1
+            end
+          end
+        end
+
+      expected = """
+      defmodule Foo do
+        def foo do
+          1 + 1
+        end
+      end
+      """
+
+      assert quoted_to_string(quoted) <> "\n" == expected
+    end
+
+    test "operator precedence" do
+      assert quoted_to_string(quote(do: (1 + 2) * (3 - 4))) == "(1 + 2) * (3 - 4)"
+      assert quoted_to_string(quote(do: (1 + 2) * 3 - 4)) == "(1 + 2) * 3 - 4"
+      assert quoted_to_string(quote(do: 1 + 2 + 3)) == "1 + 2 + 3"
+      assert quoted_to_string(quote(do: 1 + 2 - 3)) == "1 + 2 - 3"
+    end
+
+    test "capture operator" do
+      assert quoted_to_string(quote(do: &foo/0)) == "&foo/0"
+      assert quoted_to_string(quote(do: &Foo.foo/0)) == "&Foo.foo/0"
+      assert quoted_to_string(quote(do: &(&1 + &2))) == "&(&1 + &2)"
+      assert quoted_to_string(quote(do: & &1)) == "& &1"
+      assert quoted_to_string(quote(do: & &1.(:x))) == "& &1.(:x)"
+      assert quoted_to_string(quote(do: (& &1).(:x))) == "(& &1).(:x)"
+    end
+
+    test "containers" do
+      assert quoted_to_string(quote(do: {})) == "{}"
+      assert quoted_to_string(quote(do: [])) == "[]"
+      assert quoted_to_string(quote(do: {1, 2, 3})) == "{1, 2, 3}"
+      assert quoted_to_string(quote(do: [1, 2, 3])) == "[1, 2, 3]"
+      assert quoted_to_string(quote(do: ["Elixir.Foo": :bar])) == "[{Foo, :bar}]"
+      assert quoted_to_string(quote(do: %{})) == "%{}"
+      assert quoted_to_string(quote(do: %{:foo => :bar})) == "%{foo: :bar}"
+      assert quoted_to_string(quote(do: %{:"Elixir.Foo" => :bar})) == "%{Foo => :bar}"
+      assert quoted_to_string(quote(do: %{{1, 2} => [1, 2, 3]})) == "%{{1, 2} => [1, 2, 3]}"
+      assert quoted_to_string(quote(do: %{map | "a" => "b"})) == "%{map | \"a\" => \"b\"}"
+      assert quoted_to_string(quote(do: [1, 2, 3])) == "[1, 2, 3]"
+    end
+
+    test "struct" do
+      assert quoted_to_string(quote(do: %Test{})) == "%Test{}"
+      assert quoted_to_string(quote(do: %Test{foo: 1, bar: 1})) == "%Test{foo: 1, bar: 1}"
+      assert quoted_to_string(quote(do: %Test{struct | foo: 2})) == "%Test{struct | foo: 2}"
+      assert quoted_to_string(quote(do: %Test{} + 1)) == "%Test{} + 1"
+      assert quoted_to_string(quote(do: %Test{foo(1)} + 2)) == "%Test{foo(1)} + 2"
+    end
+
+    test "binary operators" do
+      assert quoted_to_string(quote(do: 1 + 2)) == "1 + 2"
+      assert quoted_to_string(quote(do: [1, 2 | 3])) == "[1, 2 | 3]"
+      assert quoted_to_string(quote(do: [h | t] = [1, 2, 3])) == "[h | t] = [1, 2, 3]"
+      assert quoted_to_string(quote(do: (x ++ y) ++ z)) == "(x ++ y) ++ z"
+      assert quoted_to_string(quote(do: (x +++ y) +++ z)) == "(x +++ y) +++ z"
+    end
+
+    test "unary operators" do
+      assert quoted_to_string(quote(do: not 1)) == "not 1"
+      assert quoted_to_string(quote(do: not foo)) == "not foo"
+      assert quoted_to_string(quote(do: -1)) == "-1"
+      assert quoted_to_string(quote(do: +(+1))) == "+(+1)"
+      assert quoted_to_string(quote(do: !(foo > bar))) == "!(foo > bar)"
+      assert quoted_to_string(quote(do: @foo(bar))) == "@foo bar"
+      assert quoted_to_string(quote(do: identity(&1))) == "identity(&1)"
+    end
+
+    test "access" do
+      assert quoted_to_string(quote(do: a[b])) == "a[b]"
+      assert quoted_to_string(quote(do: a[1 + 2])) == "a[1 + 2]"
+      assert quoted_to_string(quote(do: (a || [a: 1])[:a])) == "(a || [a: 1])[:a]"
+      assert quoted_to_string(quote(do: Map.put(%{}, :a, 1)[:a])) == "Map.put(%{}, :a, 1)[:a]"
+    end
+
+    test "keyword list" do
+      assert quoted_to_string(quote(do: [a: a, b: b])) == "[a: a, b: b]"
+      assert quoted_to_string(quote(do: [a: 1, b: 1 + 2])) == "[a: 1, b: 1 + 2]"
+      assert quoted_to_string(quote(do: ["a.b": 1, c: 1 + 2])) == "[\"a.b\": 1, c: 1 + 2]"
+    end
+
+    test "interpolation" do
+      assert quoted_to_string(quote(do: "foo#{bar}baz")) == ~S["foo#{bar}baz"]
+    end
+
+    test "bit syntax" do
+      ast = quote(do: <<1::8*4>>)
+      assert quoted_to_string(ast) == "<<1::8*4>>"
+
+      ast = quote(do: @type(foo :: <<_::8, _::_*4>>))
+      assert quoted_to_string(ast) == "@type foo :: <<_::8, _::_*4>>"
+
+      ast = quote(do: <<69 - 4::bits-size(8 - 4)-unit(1), 65>>)
+      assert quoted_to_string(ast) == "<<69 - 4::bits-size(8 - 4)-unit(1), 65>>"
+
+      ast = quote(do: <<(<<65>>), 65>>)
+      assert quoted_to_string(ast) == "<<(<<65>>), 65>>"
+
+      ast = quote(do: <<65, (<<65>>)>>)
+      assert quoted_to_string(ast) == "<<65, (<<65>>)>>"
+
+      ast = quote(do: for(<<(a::4 <- <<1, 2>>)>>, do: a))
+      assert quoted_to_string(ast) == "for <<(a::4 <- <<1, 2>>)>> do\n  a\nend"
+    end
+
+    test "charlist" do
+      assert quoted_to_string(quote(do: [])) == "[]"
+      assert quoted_to_string(quote(do: 'abc')) == "'abc'"
+    end
+
+    test "string" do
+      assert quoted_to_string(quote(do: "")) == ~S/""/
+      assert quoted_to_string(quote(do: "abc")) == ~S/"abc"/
+      assert quoted_to_string(quote(do: "#{"abc"}")) == ~S/"#{"abc"}"/
+    end
+
+    test "last arg keyword list" do
+      assert quoted_to_string(quote(do: foo([]))) == "foo([])"
+      assert quoted_to_string(quote(do: foo(x: y))) == "foo(x: y)"
+      assert quoted_to_string(quote(do: foo(x: 1 + 2))) == "foo(x: 1 + 2)"
+      assert quoted_to_string(quote(do: foo(x: y, p: q))) == "foo(x: y, p: q)"
+      assert quoted_to_string(quote(do: foo(a, x: y, p: q))) == "foo(a, x: y, p: q)"
+
+      assert quoted_to_string(quote(do: {[]})) == "{[]}"
+      assert quoted_to_string(quote(do: {[a: b]})) == "{[a: b]}"
+      assert quoted_to_string(quote(do: {x, a: b})) == "{x, [a: b]}"
+      assert quoted_to_string(quote(do: foo(else: a))) == "foo(else: a)"
+      assert quoted_to_string(quote(do: foo(catch: a))) == "foo(catch: a)"
+    end
   end
 end

--- a/lib/elixir/test/elixir/code_normalizer_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer_test.exs
@@ -1,0 +1,364 @@
+Code.require_file("test_helper.exs", __DIR__)
+
+defmodule Code.NormalizerTest do
+  use ExUnit.Case
+
+  alias Code.Normalizer
+
+  test "integers" do
+    normalized = Normalizer.normalize(10)
+
+    assert {:__block__, meta, [10]} = normalized
+    assert Keyword.has_key?(meta, :line)
+    assert meta[:token] == "10"
+  end
+
+  test "floats" do
+    normalized = Normalizer.normalize(10.42)
+
+    assert {:__block__, meta, [10.42]} = normalized
+    assert Keyword.has_key?(meta, :line)
+    assert meta[:token] == "10.42"
+  end
+
+  test "atoms" do
+    normalized = Normalizer.normalize(:hello)
+
+    assert {:__block__, meta, [:hello]} = normalized
+    assert Keyword.has_key?(meta, :line)
+  end
+
+  test "strings" do
+    normalized = Normalizer.normalize("hello world")
+
+    assert {:__block__, meta, ["hello world"]} = normalized
+    assert Keyword.has_key?(meta, :line)
+    assert meta[:token] == ~s["hello world"]
+  end
+
+  test "charlists" do
+    normalized = Normalizer.normalize('hello world')
+
+    assert {:__block__, meta, ['hello world']} = normalized
+    assert Keyword.has_key?(meta, :line)
+    assert meta[:delimiter] == "'"
+  end
+
+  test "two elements tuples" do
+    normalized = Normalizer.normalize({:foo, :bar})
+
+    assert {:__block__, meta,
+            [
+              {
+                {:__block__, left_meta, [:foo]},
+                {:__block__, right_meta, [:bar]}
+              }
+            ]} = normalized
+
+    assert Keyword.has_key?(meta, :line)
+    assert Keyword.has_key?(left_meta, :line)
+    assert Keyword.has_key?(right_meta, :line)
+  end
+
+  test "regular lists" do
+    normalized = Normalizer.normalize([1, 2, 3])
+
+    assert {:__block__, meta,
+            [
+              [
+                {:__block__, first_meta, [1]},
+                {:__block__, second_meta, [2]},
+                {:__block__, third_meta, [3]}
+              ]
+            ]} = normalized
+
+    metas = [meta, first_meta, second_meta, third_meta]
+
+    assert Enum.all?(metas, &Keyword.has_key?(&1, :line))
+
+    assert [line: _] = meta[:closing]
+
+    assert first_meta[:token] == "1"
+    assert second_meta[:token] == "2"
+    assert third_meta[:token] == "3"
+  end
+
+  test "keyword lists" do
+    quoted = Code.string_to_quoted!("[a: :b, c: :d]")
+    normalized = Normalizer.normalize(quoted)
+
+    assert {:__block__, meta,
+            [
+              [
+                {{:__block__, first_key_meta, [:a]}, {:__block__, _, [:b]}},
+                {{:__block__, second_key_meta, [:c]}, {:__block__, _, [:d]}}
+              ]
+            ]} = normalized
+
+    assert Keyword.has_key?(meta, :line)
+    assert get_in(meta, [:closing, :line]) |> is_integer()
+    assert first_key_meta[:format] == :keyword
+    assert second_key_meta[:format] == :keyword
+  end
+
+  test "list with keyword list as last element" do
+    quoted = Code.string_to_quoted!("[1, {:a, :b}, 2, c: :d, e: :f]")
+    normalized = Normalizer.normalize(quoted)
+
+    assert {:__block__, _,
+            [
+              [
+                {:__block__, _, [1]},
+                {:__block__, _,
+                 [
+                   {
+                     {:__block__, a_meta, [:a]},
+                     {:__block__, _, [:b]}
+                   }
+                 ]},
+                {:__block__, _, [2]},
+                {{:__block__, c_meta, [:c]}, {:__block__, _, [:d]}},
+                {{:__block__, e_meta, [:e]}, {:__block__, _, [:f]}}
+              ]
+            ]} = normalized
+
+    refute a_meta[:format] == :keyword
+
+    assert c_meta[:format] == :keyword
+    assert e_meta[:format] == :keyword
+  end
+
+  test "keyword list in guard with ommited square brackets" do
+    quoted = Code.string_to_quoted!("a when foo: :bar, baz: :qux")
+    normalized = Normalizer.normalize(quoted)
+
+    assert {:when, _,
+            [
+              {:a, _, _},
+              [
+                {{:__block__, _, [:foo]}, {:__block__, _, [:bar]}},
+                {{:__block__, _, [:baz]}, {:__block__, _, [:qux]}}
+              ]
+            ]} = normalized
+  end
+
+  test "maps" do
+    quoted = Code.string_to_quoted!("%{foo: :bar}")
+    normalized = Normalizer.normalize(quoted)
+
+    assert {:%{}, _,
+            [
+              {{:__block__, key_meta, [:foo]}, {:__block__, _, [:bar]}}
+            ]} = normalized
+
+    assert Keyword.get(key_meta, :format) == :keyword
+  end
+
+  test "map with update syntax" do
+    quoted = Code.string_to_quoted!("%{base | foo: :bar}")
+    normalized = Normalizer.normalize(quoted)
+
+    assert {:%{}, _,
+            [
+              {:|, _,
+               [
+                 {:base, _, _},
+                 [{{:__block__, key_meta, [:foo]}, {:__block__, _, [:bar]}}]
+               ]}
+            ]} = normalized
+
+    assert Keyword.get(key_meta, :format) == :keyword
+  end
+
+  test "aliases are skipped" do
+    quoted = Code.string_to_quoted!("Foo.Bar")
+    normalized = Normalizer.normalize(quoted)
+
+    assert quoted == normalized
+  end
+
+  test "`Access` in access syntax is skipped" do
+    quoted = Code.string_to_quoted!("foo[:bar]")
+    normalized = Normalizer.normalize(quoted)
+
+    assert {
+             {:., _, [Access, :get]},
+             _,
+             [
+               {:foo, _, _},
+               {:__block__, _, [:bar]}
+             ]
+           } = normalized
+  end
+
+  test "only the left side of a dot call is normalized" do
+    quoted = Code.string_to_quoted!("foo.bar()")
+    normalized = Normalizer.normalize(quoted)
+
+    assert {{:., _, [{:foo, _, _}, :bar]}, _, []} = normalized
+  end
+
+  test "do blocks" do
+    quoted =
+      Code.string_to_quoted!("""
+      case do
+        :ok
+      end
+      """)
+
+    normalized = Normalizer.normalize(quoted)
+
+    assert {:case, _,
+            [
+              {:__block__, _,
+               [
+                 [
+                   {{:__block__, _, [:do]}, {:__block__, _, [:ok]}}
+                 ]
+               ]}
+            ]} = normalized
+  end
+
+  test "do block when token_metadata: true" do
+    quoted =
+      Code.string_to_quoted!(
+        """
+        case do
+          :ok
+        end
+        """,
+        token_metadata: true
+      )
+
+    normalized = Normalizer.normalize(quoted)
+
+    assert {:case, meta,
+            [
+              [
+                {{:__block__, _, [:do]}, {:__block__, _, [:ok]}}
+              ]
+            ]} = normalized
+
+    assert [line: _] = Keyword.get(meta, :do)
+    assert [line: _] = Keyword.get(meta, :end)
+  end
+
+  test "function with arguments and do block" do
+    quoted =
+      Code.string_to_quoted!("""
+      foo(:bar) do
+        :ok
+      end
+      """)
+
+    normalized = Normalizer.normalize(quoted)
+
+    assert {:foo, _,
+            [
+              {:__block__, _, [:bar]},
+              {:__block__, _,
+               [
+                 [{{:__block__, _, [:do]}, {:__block__, _, [:ok]}}]
+               ]}
+            ]} = normalized
+  end
+
+  test "do, else, catch, rescue and after blocks" do
+    quoted =
+      Code.string_to_quoted!("""
+      foo do
+        :in_do
+      else
+        :in_else
+      catch
+        :in_catch
+      rescue
+        :in_rescue
+      after
+        :in_after
+      end
+      """)
+
+    normalized = Normalizer.normalize(quoted)
+
+    assert {:foo, _,
+            [
+              {:__block__, _,
+               [
+                 [
+                   {{:__block__, _, [:do]}, {:__block__, _, [:in_do]}},
+                   {{:__block__, _, [:else]}, {:__block__, _, [:in_else]}},
+                   {{:__block__, _, [:catch]}, {:__block__, _, [:in_catch]}},
+                   {{:__block__, _, [:rescue]}, {:__block__, _, [:in_rescue]}},
+                   {{:__block__, _, [:after]}, {:__block__, _, [:in_after]}}
+                 ]
+               ]}
+            ]} = normalized
+  end
+
+  test "left to right arrows" do
+    quoted =
+      Code.string_to_quoted!("""
+      case do
+        :left -> :right
+      end
+      """)
+
+    normalized = Normalizer.normalize(quoted)
+
+    assert {:case, _,
+            [
+              {:__block__, _,
+               [
+                 [
+                   {{:__block__, _, [:do]},
+                    [
+                      {:->, _,
+                       [
+                         [{:__block__, _, [:left]}],
+                         {:__block__, _, [:right]}
+                       ]}
+                    ]}
+                 ]
+               ]}
+            ]} = normalized
+  end
+
+  test "left to right arrow with multiple arguments" do
+    quoted =
+      Code.string_to_quoted!("""
+      case do
+        :foo, :bar -> :baz
+      end
+      """)
+
+    normalized = Normalizer.normalize(quoted)
+
+    assert {:case, _,
+            [
+              {:__block__, _,
+               [
+                 [
+                   {{:__block__, _, [:do]},
+                    [
+                      {:->, _,
+                       [
+                         [
+                           {:__block__, _, [:foo]},
+                           {:__block__, _, [:bar]}
+                         ],
+                         {:__block__, _, [:baz]}
+                       ]}
+                    ]}
+                 ]
+               ]}
+            ]} = normalized
+  end
+
+  test "unqualified call's form is skipped" do
+    quoted = Code.string_to_quoted!("foo()")
+    normalized = Normalizer.normalize(quoted)
+
+    assert {:foo, _, []} = normalized
+  end
+end

--- a/lib/elixir/test/elixir/test_helper.exs
+++ b/lib/elixir/test/elixir/test_helper.exs
@@ -86,30 +86,30 @@ end
 defmodule CodeNormalizerHelpers do
   defmacro assert_same(good, opts \\ []) do
     quote bind_quoted: [good: good, opts: opts], location: :keep do
-      line_length = Keyword.get(opts, :line_length, 98)
-      good = String.trim(good)
-
-      expected = IO.iodata_to_binary(Code.format_string!(good, opts))
-
-      to_quoted_opts =
-        [
-          literal_encoder: &{:ok, {:__block__, &2, [&1]}},
-          token_metadata: true,
-          unescape: false
-        ] ++ opts
-
-      {quoted, comments} = Code.string_to_quoted_with_comments!(good, to_quoted_opts)
-
-      to_algebra_opts = [comments: comments] ++ opts
-
-      doc = Code.quoted_to_algebra(quoted, to_algebra_opts)
-
-      actual =
-        Inspect.Algebra.format(doc, line_length)
-        |> IO.iodata_to_binary()
-
-      assert actual == expected
+      assert IO.iodata_to_binary(Code.format_string!(good, opts)) ==
+        CodeNormalizerHelpers.string_to_string(good, opts)
     end
+  end
+
+  def string_to_string(good, opts) do
+    line_length = Keyword.get(opts, :line_length, 98)
+    good = String.trim(good)
+
+    to_quoted_opts =
+      [
+        literal_encoder: &{:ok, {:__block__, &2, [&1]}},
+        token_metadata: true,
+        unescape: false
+      ] ++ opts
+
+    {quoted, comments} = Code.string_to_quoted_with_comments!(good, to_quoted_opts)
+
+    to_algebra_opts = [comments: comments] ++ opts
+
+    quoted
+    |> Code.quoted_to_algebra(to_algebra_opts)
+    |> Inspect.Algebra.format(line_length)
+    |> IO.iodata_to_binary()
   end
 end
 

--- a/lib/elixir/test/elixir/test_helper.exs
+++ b/lib/elixir/test/elixir/test_helper.exs
@@ -91,16 +91,18 @@ defmodule CodeNormalizerHelpers do
 
       expected = IO.iodata_to_binary(Code.format_string!(good, opts))
 
-      quoted_opts =
+      to_quoted_opts =
         [
           literal_encoder: &{:ok, {:__block__, &2, [&1]}},
           token_metadata: true,
           unescape: false
         ] ++ opts
 
-      {:ok, quoted, comments} = Code.string_to_quoted_with_comments(good, quoted_opts)
+      {quoted, comments} = Code.string_to_quoted_with_comments!(good, to_quoted_opts)
 
-      {:ok, doc} = Code.quoted_to_algebra(quoted, comments: comments)
+      to_algebra_opts = [comments: comments] ++ opts
+
+      doc = Code.quoted_to_algebra(quoted, to_algebra_opts)
 
       actual =
         Inspect.Algebra.format(doc, line_length)

--- a/lib/elixir/test/elixir/test_helper.exs
+++ b/lib/elixir/test/elixir/test_helper.exs
@@ -87,7 +87,7 @@ defmodule CodeNormalizerHelpers do
   defmacro assert_same(good, opts \\ []) do
     quote bind_quoted: [good: good, opts: opts], location: :keep do
       assert IO.iodata_to_binary(Code.format_string!(good, opts)) ==
-        CodeNormalizerHelpers.string_to_string(good, opts)
+               CodeNormalizerHelpers.string_to_string(good, opts)
     end
   end
 
@@ -104,7 +104,7 @@ defmodule CodeNormalizerHelpers do
 
     {quoted, comments} = Code.string_to_quoted_with_comments!(good, to_quoted_opts)
 
-    to_algebra_opts = [comments: comments] ++ opts
+    to_algebra_opts = [comments: comments, escape: false] ++ opts
 
     quoted
     |> Code.quoted_to_algebra(to_algebra_opts)


### PR DESCRIPTION
This adds `quoted_to_algebra/2` to the `Code` module, as discussed in [this proposal](https://groups.google.com/u/1/g/elixir-lang-core/c/-8CPorfVTxg).

I feel the testing can be improved, if so I would like some guidance.