### PR TITLE
Use Code.quoted_to_algebra on Macro.to_string

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -2188,7 +2188,7 @@ defmodule Code.Formatter do
   end
 
   defp force_args?(args) do
-    match?([_ | _], args) and force_args?(args, MapSet.new())
+    match?([_ | _], args) and force_args?(args, %{})
   end
 
   defp force_args?([[arg | _] | args], lines) do
@@ -2205,12 +2205,12 @@ defmodule Code.Formatter do
     cond do
       # Line may be missing from non-formatter AST
       is_nil(line) -> force_args?(args, lines)
-      MapSet.member?(lines, line) -> false
-      true -> force_args?(args, MapSet.put(lines, line))
+      Map.has_key?(lines, line) -> false
+      true -> force_args?(args, Map.put(lines, line, true))
     end
   end
 
-  defp force_args?([], lines), do: MapSet.size(lines) >= 2
+  defp force_args?([], lines), do: map_size(lines) >= 2
 
   defp force_keyword(doc, arg) do
     if force_args?(arg), do: force_unfit(doc), else: doc

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -555,7 +555,11 @@ defmodule Inspect.Algebra do
   @doc since: "1.6.0"
   @spec string(String.t()) :: doc_string
   def string(string) when is_binary(string) do
-    doc_string(string, String.length(string))
+    if function_exported?(String.Unicode, :length, 1) do
+      doc_string(string, String.Unicode.length(string))
+    else
+      doc_string(string, byte_size(string))
+    end
   end
 
   @doc ~S"""

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -555,11 +555,8 @@ defmodule Inspect.Algebra do
   @doc since: "1.6.0"
   @spec string(String.t()) :: doc_string
   def string(string) when is_binary(string) do
-    if function_exported?(String.Unicode, :length, 1) do
-      doc_string(string, String.Unicode.length(string))
-    else
-      doc_string(string, byte_size(string))
-    end
+    # Use :string for bootstrap reasons
+    doc_string(string, :string.length(string))
   end
 
   @doc ~S"""

--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -88,7 +88,7 @@ defmodule Kernel.CLI do
       case blamed do
         %FunctionClauseError{} ->
           formatted = Exception.format_banner(kind, reason, stacktrace)
-          padded_blame = pad(FunctionClauseError.blame(blamed, &inspect/1, &blame_match/2))
+          padded_blame = pad(FunctionClauseError.blame(blamed, &inspect/1, &blame_match/1))
           [formatted, padded_blame]
 
         _ ->
@@ -176,9 +176,8 @@ defmodule Kernel.CLI do
     IO.write(:stderr, format_error(kind, reason, stacktrace))
   end
 
-  defp blame_match(%{match?: true, node: node}, _), do: blame_ansi(:normal, "+", node)
-  defp blame_match(%{match?: false, node: node}, _), do: blame_ansi(:red, "-", node)
-  defp blame_match(_, string), do: string
+  defp blame_match(%{match?: true, node: node}), do: blame_ansi(:normal, "+", node)
+  defp blame_match(%{match?: false, node: node}), do: blame_ansi(:red, "-", node)
 
   defp blame_ansi(color, no_ansi, node) do
     if IO.ANSI.enabled?() do

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -812,6 +812,25 @@ defmodule Macro do
   @doc """
   Converts the given expression AST to a string.
 
+  This function discards all formatting of the original code.
+  See `Code.quoted_to_algebra/2` as a lower level function
+  with more control around formatting.
+
+  ## Examples
+
+      iex> Macro.to_string(quote(do: foo.bar(1, 2, 3)))
+      "foo.bar(1, 2, 3)"
+
+  """
+  @spec to_string(t()) :: String.t()
+  def to_string(tree) do
+    doc = Inspect.Algebra.format(Code.quoted_to_algebra(tree), :infinity)
+    IO.iodata_to_binary(doc)
+  end
+
+  @doc """
+  Converts the given expression AST to a string.
+
   The given `fun` is called for every node in the AST with two arguments: the
   AST of the node being printed and the string representation of that same
   node. The return value of this function is used as the final string
@@ -821,19 +840,17 @@ defmodule Macro do
 
   ## Examples
 
-      iex> Macro.to_string(quote(do: foo.bar(1, 2, 3)))
-      "foo.bar(1, 2, 3)"
-
-      iex> Macro.to_string(quote(do: 1 + 2), fn
-      ...>   1, _string -> "one"
-      ...>   2, _string -> "two"
-      ...>   _ast, string -> string
-      ...> end)
-      "one + two"
+      Macro.to_string(quote(do: 1 + 2), fn
+        1, _string -> "one"
+        2, _string -> "two"
+        _ast, string -> string
+      end)
+      #=> "one + two"
 
   """
+  @deprecated "Use Macro.to_string/1 instead"
   @spec to_string(t(), (t(), String.t() -> String.t())) :: String.t()
-  def to_string(tree, fun \\ fn _ast, string -> string end)
+  def to_string(tree, fun)
 
   # Variables
   def to_string({var, _, context} = ast, fun) when is_atom(var) and is_atom(context) do

--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -178,6 +178,8 @@ bootstrap_files() ->
      <<"lib/elixir/lib/access.ex">>,
      <<"lib/elixir/lib/io.ex">>,
      <<"lib/elixir/lib/system.ex">>,
+     <<"lib/elixir/lib/code/formatter.ex">>,
+     <<"lib/elixir/lib/code/normalizer.ex">>,
      <<"lib/elixir/lib/kernel/cli.ex">>,
      <<"lib/elixir/lib/kernel/error_handler.ex">>,
      <<"lib/elixir/lib/kernel/parallel_compiler.ex">>,

--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -545,7 +545,7 @@ signature_to_binary(Module, '__struct__', []) ->
   <<"%", ('Elixir.Kernel':inspect(Module))/binary, "{}">>;
 
 signature_to_binary(_, Name, Signature) ->
-  'Elixir.Macro':to_string({Name, [], Signature}).
+  'Elixir.Macro':to_string({Name, [{closing, []}], Signature}).
 
 checker_chunk(#{definitions := Definitions, deprecated := Deprecated, is_behaviour := IsBehaviour}) ->
   DeprecatedMap = maps:from_list(Deprecated),

--- a/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
@@ -11,6 +11,19 @@ defmodule Code.Normalizer.QuotedASTTest do
     test "local call" do
       assert quoted_to_string(quote(do: foo(1, 2, 3))) == "foo(1, 2, 3)"
       assert quoted_to_string(quote(do: foo([1, 2, 3]))) == "foo([1, 2, 3])"
+
+      # Mixing literals and non-literals
+      assert quoted_to_string(quote(do: foo(a, 2))) == "foo(a, 2)"
+      assert quoted_to_string(quote(do: foo(1, b))) == "foo(1, b)"
+
+      # Mixing literals and non-literals with line
+      assert quoted_to_string(quote(line: __ENV__.line, do: foo(a, 2))) == "foo(a, 2)"
+      assert quoted_to_string(quote(line: __ENV__.line, do: foo(1, b))) == "foo(1, b)"
+    end
+
+    test "local call no parens" do
+      assert quoted_to_string({:def, [], [1, 2]}) == "def 1, 2"
+      assert quoted_to_string({:def, [closing: []], [1, 2]}) == "def(1, 2)"
     end
 
     test "remote call" do
@@ -56,6 +69,7 @@ defmodule Code.Normalizer.QuotedASTTest do
     test "aliases call" do
       assert quoted_to_string(quote(do: Foo.Bar.baz(1, 2, 3))) == "Foo.Bar.baz(1, 2, 3)"
       assert quoted_to_string(quote(do: Foo.Bar.baz([1, 2, 3]))) == "Foo.Bar.baz([1, 2, 3])"
+      assert quoted_to_string(quote(do: ?0.Bar.baz([1, 2, 3]))) == "48.Bar.baz([1, 2, 3])"
       assert quoted_to_string(quote(do: Foo.bar(<<>>, []))) == "Foo.bar(<<>>, [])"
     end
 

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -957,7 +957,7 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "fails on block" do
-      message = ~r"invalid args for &, block expressions are not allowed, got: \(\n  1\n  2\n\)"
+      message = ~r"invalid args for &, block expressions are not allowed, got: 1\n2"
 
       assert_raise CompileError, message, fn ->
         code =
@@ -993,7 +993,7 @@ defmodule Kernel.ExpansionTest do
     end
 
     test "fails on nested capture" do
-      assert_raise CompileError, ~r"nested captures via & are not allowed: &\(&1\)", fn ->
+      assert_raise CompileError, ~r"nested captures via & are not allowed: & &1", fn ->
         expand(quote(do: &(& &1)))
       end
     end

--- a/lib/elixir/test/elixir/kernel/guard_test.exs
+++ b/lib/elixir/test/elixir/kernel/guard_test.exs
@@ -427,10 +427,8 @@ defmodule Kernel.GuardTest do
              """
 
       assert expand_defguard_to_string(:with_unused_vars, args, nil) == """
-             (
-               {arg1, arg2} = {1 + 1, 2 + 2}
-               :erlang.+(arg1, arg2)
-             )
+             {arg1, arg2} = {1 + 1, 2 + 2}
+             :erlang.+(arg1, arg2)
              """
     end
 

--- a/lib/elixir/test/elixir/kernel/guard_test.exs
+++ b/lib/elixir/test/elixir/kernel/guard_test.exs
@@ -442,10 +442,8 @@ defmodule Kernel.GuardTest do
              """
 
       assert expand_defguard_to_string(:with_reused_vars, args, nil) == """
-             (
-               {arg1, arg2, arg3} = {1 + 1, 2 + 2, 3 + 3}
-               :erlang.+(:erlang.+(:erlang.+(arg1, arg1), arg2), arg3)
-             )
+             {arg1, arg2, arg3} = {1 + 1, 2 + 2, 3 + 3}
+             :erlang.+(:erlang.+(:erlang.+(arg1, arg1), arg2), arg3)
              """
     end
 

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -646,7 +646,7 @@ defmodule Kernel.ParserTest do
       assert interpret.("f 1 + g h 2, 3") == "f(1 + g(h(2, 3)))"
 
       assert interpret.("assert [] = TestRepo.all from p in Post, where: p.title in ^[]") ==
-               "assert([] = TestRepo.all(from(p in Post, where: p.title in ^[])))"
+               "assert [] = TestRepo.all(from(p in Post, where: p.title in ^[]))"
     end
 
     test "invalid atom dot alias" do

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -727,14 +727,8 @@ defmodule KernelTest do
                ":erlang.andalso(:erlang.is_integer(var), :erlang.andalso(:erlang.>=(var, 1), :erlang.\"=<\"(var, 2)))"
 
       # Empty list
-      assert expand_to_string(quote(do: :x in [])) =~
-               ~S"""
-                 _ = :x
-                 false
-               """
-
-      assert expand_to_string(quote(do: :x in []), :guard) ==
-               "false"
+      assert expand_to_string(quote(do: :x in [])) =~ "_ = :x\nfalse"
+      assert expand_to_string(quote(do: :x in []), :guard) == "false"
 
       # Lists
       result = expand_to_string(quote(do: rand() in [1, 2]))

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -778,13 +778,10 @@ defmodule KernelTest do
 
     test "is optimized" do
       assert expand_to_string(quote(do: foo in [])) =~
-               ~S"""
-                 _ = foo
-                 false
-               """
+               "_ = foo\nfalse"
 
       assert expand_to_string(quote(do: foo in [foo])) =~
-               ~r/{arg1} = {foo}\n\s+:erlang."=:="\(foo, arg1\)\n/
+               "{arg1} = {foo}\n:erlang.\"=:=\"(foo, arg1)"
 
       assert expand_to_string(quote(do: foo in 0..1)) ==
                ":erlang.andalso(:erlang.is_integer(foo), :erlang.andalso(:erlang.>=(foo, 0), :erlang.\"=<\"(foo, 1)))"

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -265,18 +265,29 @@ defmodule MacroTest do
   end
 
   describe "to_string/1" do
+    test "converts quoted to string" do
+      assert Macro.to_string(quote do: hello(world)) == "hello(world)"
+    end
+  end
+
+  describe "to_string/2" do
+    defp macro_to_string(var, fun \\ fn _ast, string -> string end) do
+      module = Macro
+      module.to_string(var, fun)
+    end
+
     test "variable" do
-      assert Macro.to_string(quote(do: foo)) == "foo"
+      assert macro_to_string(quote(do: foo)) == "foo"
     end
 
     test "local call" do
-      assert Macro.to_string(quote(do: foo(1, 2, 3))) == "foo(1, 2, 3)"
-      assert Macro.to_string(quote(do: foo([1, 2, 3]))) == "foo([1, 2, 3])"
+      assert macro_to_string(quote(do: foo(1, 2, 3))) == "foo(1, 2, 3)"
+      assert macro_to_string(quote(do: foo([1, 2, 3]))) == "foo([1, 2, 3])"
     end
 
     test "remote call" do
-      assert Macro.to_string(quote(do: foo.bar(1, 2, 3))) == "foo.bar(1, 2, 3)"
-      assert Macro.to_string(quote(do: foo.bar([1, 2, 3]))) == "foo.bar([1, 2, 3])"
+      assert macro_to_string(quote(do: foo.bar(1, 2, 3))) == "foo.bar(1, 2, 3)"
+      assert macro_to_string(quote(do: foo.bar([1, 2, 3]))) == "foo.bar([1, 2, 3])"
 
       quoted =
         quote do
@@ -285,68 +296,68 @@ defmodule MacroTest do
            end).bar([1, 2, 3])
         end
 
-      assert Macro.to_string(quoted) == "(foo do\n  :ok\nend).bar([1, 2, 3])"
+      assert macro_to_string(quoted) == "(foo do\n  :ok\nend).bar([1, 2, 3])"
     end
 
     test "nullary remote call" do
-      assert Macro.to_string(quote do: foo.bar) == "foo.bar"
-      assert Macro.to_string(quote do: foo.bar()) == "foo.bar()"
+      assert macro_to_string(quote do: foo.bar) == "foo.bar"
+      assert macro_to_string(quote do: foo.bar()) == "foo.bar()"
     end
 
     test "atom remote call" do
-      assert Macro.to_string(quote(do: :foo.bar(1, 2, 3))) == ":foo.bar(1, 2, 3)"
+      assert macro_to_string(quote(do: :foo.bar(1, 2, 3))) == ":foo.bar(1, 2, 3)"
     end
 
     test "remote and fun call" do
-      assert Macro.to_string(quote(do: foo.bar().(1, 2, 3))) == "foo.bar().(1, 2, 3)"
-      assert Macro.to_string(quote(do: foo.bar().([1, 2, 3]))) == "foo.bar().([1, 2, 3])"
+      assert macro_to_string(quote(do: foo.bar().(1, 2, 3))) == "foo.bar().(1, 2, 3)"
+      assert macro_to_string(quote(do: foo.bar().([1, 2, 3]))) == "foo.bar().([1, 2, 3])"
     end
 
     test "unusual remote atom fun call" do
-      assert Macro.to_string(quote(do: Foo."42"())) == ~s/Foo."42"()/
-      assert Macro.to_string(quote(do: Foo."Bar"())) == ~s/Foo."Bar"()/
-      assert Macro.to_string(quote(do: Foo."bar baz"().""())) == ~s/Foo."bar baz"().""()/
-      assert Macro.to_string(quote(do: Foo."%{}"())) == ~s/Foo."%{}"()/
-      assert Macro.to_string(quote(do: Foo."..."())) == ~s/Foo."..."()/
+      assert macro_to_string(quote(do: Foo."42"())) == ~s/Foo."42"()/
+      assert macro_to_string(quote(do: Foo."Bar"())) == ~s/Foo."Bar"()/
+      assert macro_to_string(quote(do: Foo."bar baz"().""())) == ~s/Foo."bar baz"().""()/
+      assert macro_to_string(quote(do: Foo."%{}"())) == ~s/Foo."%{}"()/
+      assert macro_to_string(quote(do: Foo."..."())) == ~s/Foo."..."()/
     end
 
     test "atom fun call" do
-      assert Macro.to_string(quote(do: :foo.(1, 2, 3))) == ":foo.(1, 2, 3)"
+      assert macro_to_string(quote(do: :foo.(1, 2, 3))) == ":foo.(1, 2, 3)"
     end
 
     test "aliases call" do
-      assert Macro.to_string(quote(do: Foo.Bar.baz(1, 2, 3))) == "Foo.Bar.baz(1, 2, 3)"
-      assert Macro.to_string(quote(do: Foo.Bar.baz([1, 2, 3]))) == "Foo.Bar.baz([1, 2, 3])"
-      assert Macro.to_string(quote(do: Foo.bar(<<>>, []))) == "Foo.bar(<<>>, [])"
+      assert macro_to_string(quote(do: Foo.Bar.baz(1, 2, 3))) == "Foo.Bar.baz(1, 2, 3)"
+      assert macro_to_string(quote(do: Foo.Bar.baz([1, 2, 3]))) == "Foo.Bar.baz([1, 2, 3])"
+      assert macro_to_string(quote(do: Foo.bar(<<>>, []))) == "Foo.bar(<<>>, [])"
     end
 
     test "keyword call" do
-      assert Macro.to_string(quote(do: Foo.bar(foo: :bar))) == "Foo.bar(foo: :bar)"
-      assert Macro.to_string(quote(do: Foo.bar("Elixir.Foo": :bar))) == "Foo.bar([{Foo, :bar}])"
+      assert macro_to_string(quote(do: Foo.bar(foo: :bar))) == "Foo.bar(foo: :bar)"
+      assert macro_to_string(quote(do: Foo.bar("Elixir.Foo": :bar))) == "Foo.bar([{Foo, :bar}])"
     end
 
     test "sigil call" do
-      assert Macro.to_string(quote(do: ~r"123")) == ~S/~r"123"/
-      assert Macro.to_string(quote(do: ~r"\n123")) == ~S/~r"\n123"/
-      assert Macro.to_string(quote(do: ~r"12\"3")) == ~S/~r"12\"3"/
-      assert Macro.to_string(quote(do: ~r/12\/3/u)) == ~S"~r/12\/3/u"
-      assert Macro.to_string(quote(do: ~r{\n123})) == ~S/~r{\n123}/
-      assert Macro.to_string(quote(do: ~r((1\)(2\)3))) == ~S/~r((1\)(2\)3)/
-      assert Macro.to_string(quote(do: ~r{\n1{1\}23})) == ~S/~r{\n1{1\}23}/
-      assert Macro.to_string(quote(do: ~r|12\|3|)) == ~S"~r|12\|3|"
+      assert macro_to_string(quote(do: ~r"123")) == ~S/~r"123"/
+      assert macro_to_string(quote(do: ~r"\n123")) == ~S/~r"\n123"/
+      assert macro_to_string(quote(do: ~r"12\"3")) == ~S/~r"12\"3"/
+      assert macro_to_string(quote(do: ~r/12\/3/u)) == ~S"~r/12\/3/u"
+      assert macro_to_string(quote(do: ~r{\n123})) == ~S/~r{\n123}/
+      assert macro_to_string(quote(do: ~r((1\)(2\)3))) == ~S/~r((1\)(2\)3)/
+      assert macro_to_string(quote(do: ~r{\n1{1\}23})) == ~S/~r{\n1{1\}23}/
+      assert macro_to_string(quote(do: ~r|12\|3|)) == ~S"~r|12\|3|"
 
-      assert Macro.to_string(quote(do: ~r[1#{two}3])) == ~S/~r[1#{two}3]/
-      assert Macro.to_string(quote(do: ~r[1[#{two}\]3])) == ~S/~r[1[#{two}\]3]/
-      assert Macro.to_string(quote(do: ~r'1#{two}3'u)) == ~S/~r'1#{two}3'u/
+      assert macro_to_string(quote(do: ~r[1#{two}3])) == ~S/~r[1#{two}3]/
+      assert macro_to_string(quote(do: ~r[1[#{two}\]3])) == ~S/~r[1[#{two}\]3]/
+      assert macro_to_string(quote(do: ~r'1#{two}3'u)) == ~S/~r'1#{two}3'u/
 
-      assert Macro.to_string(quote(do: ~R"123")) == ~S/~R"123"/
-      assert Macro.to_string(quote(do: ~R"123"u)) == ~S/~R"123"u/
-      assert Macro.to_string(quote(do: ~R"\n123")) == ~S/~R"\n123"/
+      assert macro_to_string(quote(do: ~R"123")) == ~S/~R"123"/
+      assert macro_to_string(quote(do: ~R"123"u)) == ~S/~R"123"u/
+      assert macro_to_string(quote(do: ~R"\n123")) == ~S/~R"\n123"/
 
-      assert Macro.to_string(quote(do: ~S["'(123)'"])) == ~S/~S["'(123)'"]/
-      assert Macro.to_string(quote(do: ~s"#{"foo"}")) == ~S/~s"#{"foo"}"/
+      assert macro_to_string(quote(do: ~S["'(123)'"])) == ~S/~S["'(123)'"]/
+      assert macro_to_string(quote(do: ~s"#{"foo"}")) == ~S/~s"#{"foo"}"/
 
-      assert Macro.to_string(
+      assert macro_to_string(
                quote do
                  ~s"""
                  "\""foo"\""
@@ -354,7 +365,7 @@ defmodule MacroTest do
                end
              ) == ~s[~s"""\n"\\""foo"\\""\n"""]
 
-      assert Macro.to_string(
+      assert macro_to_string(
                quote do
                  ~s'''
                  '\''foo'\''
@@ -362,7 +373,7 @@ defmodule MacroTest do
                end
              ) == ~s[~s'''\n'\\''foo'\\''\n''']
 
-      assert Macro.to_string(
+      assert macro_to_string(
                quote do
                  ~s"""
                  "\"foo\""
@@ -370,7 +381,7 @@ defmodule MacroTest do
                end
              ) == ~s[~s"""\n"\\"foo\\""\n"""]
 
-      assert Macro.to_string(
+      assert macro_to_string(
                quote do
                  ~s'''
                  '\"foo\"'
@@ -378,7 +389,7 @@ defmodule MacroTest do
                end
              ) == ~s[~s'''\n'\\"foo\\"'\n''']
 
-      assert Macro.to_string(
+      assert macro_to_string(
                quote do
                  ~S"""
                  "123"
@@ -388,14 +399,14 @@ defmodule MacroTest do
     end
 
     test "tuple call" do
-      assert Macro.to_string(quote(do: alias(Foo.{Bar, Baz, Bong}))) ==
+      assert macro_to_string(quote(do: alias(Foo.{Bar, Baz, Bong}))) ==
                "alias(Foo.{Bar, Baz, Bong})"
 
-      assert Macro.to_string(quote(do: foo(Foo.{}))) == "foo(Foo.{})"
+      assert macro_to_string(quote(do: foo(Foo.{}))) == "foo(Foo.{})"
     end
 
     test "arrow" do
-      assert Macro.to_string(quote(do: foo(1, (2 -> 3)))) == "foo(1, (2 -> 3))"
+      assert macro_to_string(quote(do: foo(1, (2 -> 3)))) == "foo(1, (2 -> 3))"
     end
 
     test "block" do
@@ -424,11 +435,11 @@ defmodule MacroTest do
       )
       """
 
-      assert Macro.to_string(quoted) <> "\n" == expected
+      assert macro_to_string(quoted) <> "\n" == expected
     end
 
     test "not in" do
-      assert Macro.to_string(quote(do: false not in [])) == "false not in []"
+      assert macro_to_string(quote(do: false not in [])) == "false not in []"
     end
 
     test "if else" do
@@ -440,7 +451,7 @@ defmodule MacroTest do
       end
       """
 
-      assert Macro.to_string(quote(do: if(foo, do: bar, else: baz))) <> "\n" == expected
+      assert macro_to_string(quote(do: if(foo, do: bar, else: baz))) <> "\n" == expected
     end
 
     test "case" do
@@ -466,7 +477,7 @@ defmodule MacroTest do
       end
       """
 
-      assert Macro.to_string(quoted) <> "\n" == expected
+      assert macro_to_string(quoted) <> "\n" == expected
     end
 
     test "try" do
@@ -505,12 +516,12 @@ defmodule MacroTest do
       end
       """
 
-      assert Macro.to_string(quoted) <> "\n" == expected
+      assert macro_to_string(quoted) <> "\n" == expected
     end
 
     test "fn" do
-      assert Macro.to_string(quote(do: fn -> 1 + 2 end)) == "fn -> 1 + 2 end"
-      assert Macro.to_string(quote(do: fn x -> x + 1 end)) == "fn x -> x + 1 end"
+      assert macro_to_string(quote(do: fn -> 1 + 2 end)) == "fn -> 1 + 2 end"
+      assert macro_to_string(quote(do: fn x -> x + 1 end)) == "fn x -> x + 1 end"
 
       quoted =
         quote do
@@ -527,7 +538,7 @@ defmodule MacroTest do
       end
       """
 
-      assert Macro.to_string(quoted) <> "\n" == expected
+      assert macro_to_string(quoted) <> "\n" == expected
 
       quoted =
         quote do
@@ -551,9 +562,9 @@ defmodule MacroTest do
       end
       """
 
-      assert Macro.to_string(quoted) <> "\n" == expected
+      assert macro_to_string(quoted) <> "\n" == expected
 
-      assert Macro.to_string(quote(do: (fn x -> x end).(1))) == "(fn x -> x end).(1)"
+      assert macro_to_string(quote(do: (fn x -> x end).(1))) == "(fn x -> x end).(1)"
 
       quoted =
         quote do
@@ -572,23 +583,23 @@ defmodule MacroTest do
       end).(1)
       """
 
-      assert Macro.to_string(quoted) <> "\n" == expected
+      assert macro_to_string(quoted) <> "\n" == expected
     end
 
     test "range" do
-      assert Macro.to_string(quote(do: unquote(-1..+2))) == "-1..2"
-      assert Macro.to_string(quote(do: Foo.integer()..3)) == "Foo.integer()..3"
-      assert Macro.to_string(quote(do: unquote(-1..+2//-3))) == "-1..2//-3"
+      assert macro_to_string(quote(do: unquote(-1..+2))) == "-1..2"
+      assert macro_to_string(quote(do: Foo.integer()..3)) == "Foo.integer()..3"
+      assert macro_to_string(quote(do: unquote(-1..+2//-3))) == "-1..2//-3"
 
-      assert Macro.to_string(quote(do: Foo.integer()..3//Bar.bat())) ==
+      assert macro_to_string(quote(do: Foo.integer()..3//Bar.bat())) ==
                "Foo.integer()..3//Bar.bat()"
     end
 
     test "when" do
-      assert Macro.to_string(quote(do: (() -> x))) == "(() -> x)"
-      assert Macro.to_string(quote(do: (x when y -> z))) == "(x when y -> z)"
-      assert Macro.to_string(quote(do: (x, y when z -> w))) == "((x, y) when z -> w)"
-      assert Macro.to_string(quote(do: (x, y when z -> w))) == "((x, y) when z -> w)"
+      assert macro_to_string(quote(do: (() -> x))) == "(() -> x)"
+      assert macro_to_string(quote(do: (x when y -> z))) == "(x when y -> z)"
+      assert macro_to_string(quote(do: (x, y when z -> w))) == "((x, y) when z -> w)"
+      assert macro_to_string(quote(do: (x, y when z -> w))) == "((x, y) when z -> w)"
     end
 
     test "nested" do
@@ -609,132 +620,132 @@ defmodule MacroTest do
       end
       """
 
-      assert Macro.to_string(quoted) <> "\n" == expected
+      assert macro_to_string(quoted) <> "\n" == expected
     end
 
     test "operator precedence" do
-      assert Macro.to_string(quote(do: (1 + 2) * (3 - 4))) == "(1 + 2) * (3 - 4)"
-      assert Macro.to_string(quote(do: (1 + 2) * 3 - 4)) == "(1 + 2) * 3 - 4"
-      assert Macro.to_string(quote(do: 1 + 2 + 3)) == "1 + 2 + 3"
-      assert Macro.to_string(quote(do: 1 + 2 - 3)) == "1 + 2 - 3"
+      assert macro_to_string(quote(do: (1 + 2) * (3 - 4))) == "(1 + 2) * (3 - 4)"
+      assert macro_to_string(quote(do: (1 + 2) * 3 - 4)) == "(1 + 2) * 3 - 4"
+      assert macro_to_string(quote(do: 1 + 2 + 3)) == "1 + 2 + 3"
+      assert macro_to_string(quote(do: 1 + 2 - 3)) == "1 + 2 - 3"
     end
 
     test "capture operator" do
-      assert Macro.to_string(quote(do: &foo/0)) == "&foo/0"
-      assert Macro.to_string(quote(do: &Foo.foo/0)) == "&Foo.foo/0"
-      assert Macro.to_string(quote(do: &(&1 + &2))) == "&(&1 + &2)"
-      assert Macro.to_string(quote(do: & &1)) == "&(&1)"
-      assert Macro.to_string(quote(do: & &1.(:x))) == "&(&1.(:x))"
-      assert Macro.to_string(quote(do: (& &1).(:x))) == "(&(&1)).(:x)"
+      assert macro_to_string(quote(do: &foo/0)) == "&foo/0"
+      assert macro_to_string(quote(do: &Foo.foo/0)) == "&Foo.foo/0"
+      assert macro_to_string(quote(do: &(&1 + &2))) == "&(&1 + &2)"
+      assert macro_to_string(quote(do: & &1)) == "&(&1)"
+      assert macro_to_string(quote(do: & &1.(:x))) == "&(&1.(:x))"
+      assert macro_to_string(quote(do: (& &1).(:x))) == "(&(&1)).(:x)"
     end
 
     test "containers" do
-      assert Macro.to_string(quote(do: {})) == "{}"
-      assert Macro.to_string(quote(do: [])) == "[]"
-      assert Macro.to_string(quote(do: {1, 2, 3})) == "{1, 2, 3}"
-      assert Macro.to_string(quote(do: [1, 2, 3])) == "[1, 2, 3]"
-      assert Macro.to_string(quote(do: ["Elixir.Foo": :bar])) == "[{Foo, :bar}]"
-      assert Macro.to_string(quote(do: %{})) == "%{}"
-      assert Macro.to_string(quote(do: %{:foo => :bar})) == "%{foo: :bar}"
-      assert Macro.to_string(quote(do: %{:"Elixir.Foo" => :bar})) == "%{Foo => :bar}"
-      assert Macro.to_string(quote(do: %{{1, 2} => [1, 2, 3]})) == "%{{1, 2} => [1, 2, 3]}"
-      assert Macro.to_string(quote(do: %{map | "a" => "b"})) == "%{map | \"a\" => \"b\"}"
-      assert Macro.to_string(quote(do: [1, 2, 3])) == "[1, 2, 3]"
+      assert macro_to_string(quote(do: {})) == "{}"
+      assert macro_to_string(quote(do: [])) == "[]"
+      assert macro_to_string(quote(do: {1, 2, 3})) == "{1, 2, 3}"
+      assert macro_to_string(quote(do: [1, 2, 3])) == "[1, 2, 3]"
+      assert macro_to_string(quote(do: ["Elixir.Foo": :bar])) == "[{Foo, :bar}]"
+      assert macro_to_string(quote(do: %{})) == "%{}"
+      assert macro_to_string(quote(do: %{:foo => :bar})) == "%{foo: :bar}"
+      assert macro_to_string(quote(do: %{:"Elixir.Foo" => :bar})) == "%{Foo => :bar}"
+      assert macro_to_string(quote(do: %{{1, 2} => [1, 2, 3]})) == "%{{1, 2} => [1, 2, 3]}"
+      assert macro_to_string(quote(do: %{map | "a" => "b"})) == "%{map | \"a\" => \"b\"}"
+      assert macro_to_string(quote(do: [1, 2, 3])) == "[1, 2, 3]"
     end
 
     test "struct" do
-      assert Macro.to_string(quote(do: %Test{})) == "%Test{}"
-      assert Macro.to_string(quote(do: %Test{foo: 1, bar: 1})) == "%Test{foo: 1, bar: 1}"
-      assert Macro.to_string(quote(do: %Test{struct | foo: 2})) == "%Test{struct | foo: 2}"
-      assert Macro.to_string(quote(do: %Test{} + 1)) == "%Test{} + 1"
-      assert Macro.to_string(quote(do: %Test{foo(1)} + 2)) == "%Test{foo(1)} + 2"
+      assert macro_to_string(quote(do: %Test{})) == "%Test{}"
+      assert macro_to_string(quote(do: %Test{foo: 1, bar: 1})) == "%Test{foo: 1, bar: 1}"
+      assert macro_to_string(quote(do: %Test{struct | foo: 2})) == "%Test{struct | foo: 2}"
+      assert macro_to_string(quote(do: %Test{} + 1)) == "%Test{} + 1"
+      assert macro_to_string(quote(do: %Test{foo(1)} + 2)) == "%Test{foo(1)} + 2"
     end
 
     test "binary operators" do
-      assert Macro.to_string(quote(do: 1 + 2)) == "1 + 2"
-      assert Macro.to_string(quote(do: [1, 2 | 3])) == "[1, 2 | 3]"
-      assert Macro.to_string(quote(do: [h | t] = [1, 2, 3])) == "[h | t] = [1, 2, 3]"
-      assert Macro.to_string(quote(do: (x ++ y) ++ z)) == "(x ++ y) ++ z"
-      assert Macro.to_string(quote(do: (x +++ y) +++ z)) == "(x +++ y) +++ z"
+      assert macro_to_string(quote(do: 1 + 2)) == "1 + 2"
+      assert macro_to_string(quote(do: [1, 2 | 3])) == "[1, 2 | 3]"
+      assert macro_to_string(quote(do: [h | t] = [1, 2, 3])) == "[h | t] = [1, 2, 3]"
+      assert macro_to_string(quote(do: (x ++ y) ++ z)) == "(x ++ y) ++ z"
+      assert macro_to_string(quote(do: (x +++ y) +++ z)) == "(x +++ y) +++ z"
     end
 
     test "unary operators" do
-      assert Macro.to_string(quote(do: not 1)) == "not(1)"
-      assert Macro.to_string(quote(do: not foo)) == "not(foo)"
-      assert Macro.to_string(quote(do: -1)) == "-1"
-      assert Macro.to_string(quote(do: +(+1))) == "+(+1)"
-      assert Macro.to_string(quote(do: !(foo > bar))) == "!(foo > bar)"
-      assert Macro.to_string(quote(do: @foo(bar))) == "@foo(bar)"
-      assert Macro.to_string(quote(do: identity(&1))) == "identity(&1)"
+      assert macro_to_string(quote(do: not 1)) == "not(1)"
+      assert macro_to_string(quote(do: not foo)) == "not(foo)"
+      assert macro_to_string(quote(do: -1)) == "-1"
+      assert macro_to_string(quote(do: +(+1))) == "+(+1)"
+      assert macro_to_string(quote(do: !(foo > bar))) == "!(foo > bar)"
+      assert macro_to_string(quote(do: @foo(bar))) == "@foo(bar)"
+      assert macro_to_string(quote(do: identity(&1))) == "identity(&1)"
     end
 
     test "access" do
-      assert Macro.to_string(quote(do: a[b])) == "a[b]"
-      assert Macro.to_string(quote(do: a[1 + 2])) == "a[1 + 2]"
-      assert Macro.to_string(quote(do: (a || [a: 1])[:a])) == "(a || [a: 1])[:a]"
-      assert Macro.to_string(quote(do: Map.put(%{}, :a, 1)[:a])) == "Map.put(%{}, :a, 1)[:a]"
+      assert macro_to_string(quote(do: a[b])) == "a[b]"
+      assert macro_to_string(quote(do: a[1 + 2])) == "a[1 + 2]"
+      assert macro_to_string(quote(do: (a || [a: 1])[:a])) == "(a || [a: 1])[:a]"
+      assert macro_to_string(quote(do: Map.put(%{}, :a, 1)[:a])) == "Map.put(%{}, :a, 1)[:a]"
     end
 
     test "keyword list" do
-      assert Macro.to_string(quote(do: [a: a, b: b])) == "[a: a, b: b]"
-      assert Macro.to_string(quote(do: [a: 1, b: 1 + 2])) == "[a: 1, b: 1 + 2]"
-      assert Macro.to_string(quote(do: ["a.b": 1, c: 1 + 2])) == "[\"a.b\": 1, c: 1 + 2]"
+      assert macro_to_string(quote(do: [a: a, b: b])) == "[a: a, b: b]"
+      assert macro_to_string(quote(do: [a: 1, b: 1 + 2])) == "[a: 1, b: 1 + 2]"
+      assert macro_to_string(quote(do: ["a.b": 1, c: 1 + 2])) == "[\"a.b\": 1, c: 1 + 2]"
     end
 
     test "interpolation" do
-      assert Macro.to_string(quote(do: "foo#{bar}baz")) == ~S["foo#{bar}baz"]
+      assert macro_to_string(quote(do: "foo#{bar}baz")) == ~S["foo#{bar}baz"]
     end
 
     test "bit syntax" do
       ast = quote(do: <<1::8*4>>)
-      assert Macro.to_string(ast) == "<<1::8*4>>"
+      assert macro_to_string(ast) == "<<1::8*4>>"
 
       ast = quote(do: @type(foo :: <<_::8, _::_*4>>))
-      assert Macro.to_string(ast) == "@type(foo :: <<_::8, _::_*4>>)"
+      assert macro_to_string(ast) == "@type(foo :: <<_::8, _::_*4>>)"
 
       ast = quote(do: <<69 - 4::bits-size(8 - 4)-unit(1), 65>>)
-      assert Macro.to_string(ast) == "<<69 - 4::bits-size(8 - 4)-unit(1), 65>>"
+      assert macro_to_string(ast) == "<<69 - 4::bits-size(8 - 4)-unit(1), 65>>"
 
       ast = quote(do: <<(<<65>>), 65>>)
-      assert Macro.to_string(ast) == "<<(<<65>>), 65>>"
+      assert macro_to_string(ast) == "<<(<<65>>), 65>>"
 
       ast = quote(do: <<65, (<<65>>)>>)
-      assert Macro.to_string(ast) == "<<65, (<<65>>)>>"
+      assert macro_to_string(ast) == "<<65, (<<65>>)>>"
 
       ast = quote(do: for(<<(a::4 <- <<1, 2>>)>>, do: a))
-      assert Macro.to_string(ast) == "for(<<(a :: 4 <- <<1, 2>>)>>) do\n  a\nend"
+      assert macro_to_string(ast) == "for(<<(a :: 4 <- <<1, 2>>)>>) do\n  a\nend"
     end
 
     test "charlist" do
-      assert Macro.to_string(quote(do: [])) == "[]"
-      assert Macro.to_string(quote(do: 'abc')) == "'abc'"
+      assert macro_to_string(quote(do: [])) == "[]"
+      assert macro_to_string(quote(do: 'abc')) == "'abc'"
     end
 
     test "string" do
-      assert Macro.to_string(quote(do: "")) == ~S/""/
-      assert Macro.to_string(quote(do: "abc")) == ~S/"abc"/
-      assert Macro.to_string(quote(do: "#{"abc"}")) == ~S/"#{"abc"}"/
+      assert macro_to_string(quote(do: "")) == ~S/""/
+      assert macro_to_string(quote(do: "abc")) == ~S/"abc"/
+      assert macro_to_string(quote(do: "#{"abc"}")) == ~S/"#{"abc"}"/
     end
 
     test "last arg keyword list" do
-      assert Macro.to_string(quote(do: foo([]))) == "foo([])"
-      assert Macro.to_string(quote(do: foo(x: y))) == "foo(x: y)"
-      assert Macro.to_string(quote(do: foo(x: 1 + 2))) == "foo(x: 1 + 2)"
-      assert Macro.to_string(quote(do: foo(x: y, p: q))) == "foo(x: y, p: q)"
-      assert Macro.to_string(quote(do: foo(a, x: y, p: q))) == "foo(a, x: y, p: q)"
+      assert macro_to_string(quote(do: foo([]))) == "foo([])"
+      assert macro_to_string(quote(do: foo(x: y))) == "foo(x: y)"
+      assert macro_to_string(quote(do: foo(x: 1 + 2))) == "foo(x: 1 + 2)"
+      assert macro_to_string(quote(do: foo(x: y, p: q))) == "foo(x: y, p: q)"
+      assert macro_to_string(quote(do: foo(a, x: y, p: q))) == "foo(a, x: y, p: q)"
 
-      assert Macro.to_string(quote(do: {[]})) == "{[]}"
-      assert Macro.to_string(quote(do: {[a: b]})) == "{[a: b]}"
-      assert Macro.to_string(quote(do: {x, a: b})) == "{x, [a: b]}"
-      assert Macro.to_string(quote(do: foo(else: a))) == "foo(else: a)"
-      assert Macro.to_string(quote(do: foo(catch: a))) == "foo(catch: a)"
+      assert macro_to_string(quote(do: {[]})) == "{[]}"
+      assert macro_to_string(quote(do: {[a: b]})) == "{[a: b]}"
+      assert macro_to_string(quote(do: {x, a: b})) == "{x, [a: b]}"
+      assert macro_to_string(quote(do: foo(else: a))) == "foo(else: a)"
+      assert macro_to_string(quote(do: foo(catch: a))) == "foo(catch: a)"
     end
 
     test "with fun" do
-      assert Macro.to_string(quote(do: foo(1, 2, 3)), fn _, string -> ":#{string}:" end) ==
+      assert macro_to_string(quote(do: foo(1, 2, 3)), fn _, string -> ":#{string}:" end) ==
                ":foo(:1:, :2:, :3:):"
 
-      assert Macro.to_string(quote(do: Bar.foo(1, 2, 3)), fn _, string -> ":#{string}:" end) ==
+      assert macro_to_string(quote(do: Bar.foo(1, 2, 3)), fn _, string -> ":#{string}:" end) ==
                "::Bar:.foo(:1:, :2:, :3:):"
     end
   end
@@ -821,8 +832,8 @@ defmodule MacroTest do
       Macro.pipe(1, 2, 0)
     end
 
-    assert_raise ArgumentError, ~r"cannot pipe 1 into {:ok}", fn ->
-      Macro.pipe(1, {:ok}, 0)
+    assert_raise ArgumentError, ~r"cannot pipe 1 into \{2, 3\}", fn ->
+      Macro.pipe(1, {2, 3}, 0)
     end
 
     assert_raise ArgumentError, ~r"cannot pipe 1 into 1 \+ 1, the :\+ operator can", fn ->

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -1449,33 +1449,33 @@ defmodule TypespecTest do
         case type do
           # These cases do not translate directly to their own string version.
           {:basic_list_type, _, _} ->
-            assert ast_string == "@type(basic_list_type() :: [integer()])"
+            assert ast_string == "@type basic_list_type() :: [integer()]"
 
           {:basic_nonempty_list_type, _, _} ->
-            assert ast_string == "@type(basic_nonempty_list_type() :: [integer(), ...])"
+            assert ast_string == "@type basic_nonempty_list_type() :: [integer(), ...]"
 
           {:literal_empty_bitstring, _, _} ->
-            assert ast_string == "@type(literal_empty_bitstring() :: <<_::0>>)"
+            assert ast_string == "@type literal_empty_bitstring() :: <<_::0>>"
 
           {:literal_keyword_list_fixed_key, _, _} ->
-            assert ast_string == "@type(literal_keyword_list_fixed_key() :: [{:key, integer()}])"
+            assert ast_string == "@type literal_keyword_list_fixed_key() :: [{:key, integer()}]"
 
           {:literal_keyword_list_fixed_key2, _, _} ->
-            assert ast_string == "@type(literal_keyword_list_fixed_key2() :: [{:key, integer()}])"
+            assert ast_string == "@type literal_keyword_list_fixed_key2() :: [{:key, integer()}]"
 
           {:literal_struct_all_fields_any_type, _, _} ->
             assert ast_string ==
-                     "@type(literal_struct_all_fields_any_type() :: %TypespecTest.SomeStruct{key: term()})"
+                     "@type literal_struct_all_fields_any_type() :: %TypespecTest.SomeStruct{key: term()}"
 
           {:literal_struct_all_fields_key_type, _, _} ->
             assert ast_string ==
-                     "@type(literal_struct_all_fields_key_type() :: %TypespecTest.SomeStruct{key: integer()})"
+                     "@type literal_struct_all_fields_key_type() :: %TypespecTest.SomeStruct{key: integer()}"
 
           {:built_in_fun, _, _} ->
-            assert ast_string == "@type(built_in_fun() :: (... -> any()))"
+            assert ast_string == "@type built_in_fun() :: (... -> any())"
 
           {:built_in_nonempty_list, _, _} ->
-            assert ast_string == "@type(built_in_nonempty_list() :: [...])"
+            assert ast_string == "@type built_in_nonempty_list() :: [...]"
 
           _ ->
             assert ast_string == Macro.to_string(definition)

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -197,7 +197,7 @@ defmodule ExUnit.Formatter do
   defp format_exception(test, %FunctionClauseError{} = struct, stack, _width, formatter, _pad) do
     {blamed, stack} = Exception.blame(:error, struct, stack)
     banner = Exception.format_banner(:error, struct)
-    blamed = FunctionClauseError.blame(blamed, &inspect/1, &blame_match(&1, &2, formatter))
+    blamed = FunctionClauseError.blame(blamed, &inspect/1, &blame_match(&1, formatter))
     message = error_info(banner, formatter) <> "\n" <> pad(String.trim_leading(blamed, "\n"))
     {message <> format_code(test, stack, formatter), stack}
   end
@@ -292,14 +292,11 @@ defmodule ExUnit.Formatter do
     nil
   end
 
-  defp blame_match(%{match?: true, node: node}, _, _formatter),
+  defp blame_match(%{match?: true, node: node}, _formatter),
     do: Macro.to_string(node)
 
-  defp blame_match(%{match?: false, node: node}, _, formatter),
+  defp blame_match(%{match?: false, node: node}, formatter),
     do: formatter.(:blame_diff, Macro.to_string(node))
-
-  defp blame_match(_, string, _formatter),
-    do: string
 
   defp format_meta(fields, formatter, padding, padding_size) do
     for {label, value} <- fields, has_value?(value) do

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -73,7 +73,7 @@ defmodule ExUnit.AssertionsTest do
       "This should never be tested" = assert Value.falsy()
     rescue
       error in [ExUnit.AssertionError] ->
-        "assert(Value.falsy())" = error.expr |> Macro.to_string()
+        "assert Value.falsy()" = error.expr |> Macro.to_string()
         "Expected truthy, got nil" = error.message
     end
   end
@@ -107,7 +107,7 @@ defmodule ExUnit.AssertionsTest do
       error in [ExUnit.AssertionError] ->
         1 = error.right
         2 = error.left
-        "assert(1 + 1 == 1)" = error.expr |> Macro.to_string()
+        "assert 1 + 1 == 1" = error.expr |> Macro.to_string()
     end
   end
 
@@ -118,7 +118,7 @@ defmodule ExUnit.AssertionsTest do
       error in [ExUnit.AssertionError] ->
         1 = error.left
         2 = error.right
-        "assert(1 == 1 + 1)" = error.expr |> Macro.to_string()
+        "assert 1 == 1 + 1" = error.expr |> Macro.to_string()
     end
   end
 
@@ -147,7 +147,7 @@ defmodule ExUnit.AssertionsTest do
       raise "refute was supposed to fail"
     rescue
       error in [ExUnit.AssertionError] ->
-        "refute(Value.truthy())" = Macro.to_string(error.expr)
+        "refute Value.truthy()" = Macro.to_string(error.expr)
         "Expected false or nil, got :truthy" = error.message
     end
   end
@@ -203,7 +203,7 @@ defmodule ExUnit.AssertionsTest do
         "match (=) failed\n" <> "The following variables were pinned:\n" <> "  a = 1" =
           error.message
 
-        "assert({^a, 1} = Value.tuple())" = Macro.to_string(error.expr)
+        "assert {^a, 1} = Value.tuple()" = Macro.to_string(error.expr)
     end
   end
 
@@ -216,7 +216,7 @@ defmodule ExUnit.AssertionsTest do
     rescue
       error in [ExUnit.AssertionError] ->
         "match (=) failed" = error.message
-        "assert({^var!(a, Elixir), 1} = Value.tuple())" = Macro.to_string(error.expr)
+        "assert {^var!(a, Elixir), 1} = Value.tuple()" = Macro.to_string(error.expr)
     end
   end
 
@@ -228,7 +228,7 @@ defmodule ExUnit.AssertionsTest do
     rescue
       error in [ExUnit.AssertionError] ->
         "match (match?) failed" = error.message
-        "assert(match?({:ok, _}, error(true)))" = Macro.to_string(error.expr)
+        "assert match?({:ok, _}, error(true))" = Macro.to_string(error.expr)
         "{:error, true}" = Macro.to_string(error.right)
     end
   end
@@ -242,8 +242,7 @@ defmodule ExUnit.AssertionsTest do
       error in [ExUnit.AssertionError] ->
         "match (match?) failed" = error.message
 
-        "assert(match?(tuple when not(is_tuple(tuple)), error(true)))" =
-          Macro.to_string(error.expr)
+        "assert match?(tuple when not is_tuple(tuple), error(true))" = Macro.to_string(error.expr)
 
         "{:error, true}" = Macro.to_string(error.right)
     end
@@ -257,7 +256,7 @@ defmodule ExUnit.AssertionsTest do
     rescue
       error in [ExUnit.AssertionError] ->
         "match (match?) succeeded, but should have failed" = error.message
-        "refute(match?({:error, _}, error(true)))" = Macro.to_string(error.expr)
+        "refute match?({:error, _}, error(true))" = Macro.to_string(error.expr)
         "{:error, true}" = Macro.to_string(error.right)
     end
   end
@@ -271,7 +270,7 @@ defmodule ExUnit.AssertionsTest do
       error in [ExUnit.AssertionError] ->
         "match (match?) failed\nThe following variables were pinned:\n  a = 1" = error.message
 
-        "assert(match?({^a, 1}, Value.tuple()))" = Macro.to_string(error.expr)
+        "assert match?({^a, 1}, Value.tuple())" = Macro.to_string(error.expr)
     end
   end
 
@@ -288,7 +287,7 @@ defmodule ExUnit.AssertionsTest do
           a = 2\
         """ = error.message
 
-        "refute(match?({^a, 1}, Value.tuple()))" = Macro.to_string(error.expr)
+        "refute match?({^a, 1}, Value.tuple())" = Macro.to_string(error.expr)
     end
   end
 
@@ -385,7 +384,7 @@ defmodule ExUnit.AssertionsTest do
         Showing 1 of 1 message in the mailbox\
         """ = error.message
 
-        "assert_received({:status, ^status})" = Macro.to_string(error.expr)
+        "assert_received {:status, ^status}" = Macro.to_string(error.expr)
         "{:status, ^status}" = Macro.to_string(error.left)
     end
   end
@@ -405,7 +404,7 @@ defmodule ExUnit.AssertionsTest do
         Showing 1 of 1 message in the mailbox\
         """ = error.message
 
-        "assert_received({:status, ^status, ^status})" = Macro.to_string(error.expr)
+        "assert_received {:status, ^status, ^status}" = Macro.to_string(error.expr)
         "{:status, ^status, ^status}" = Macro.to_string(error.left)
         "\n\nAssertion failed" <> _ = Exception.message(error)
     end
@@ -428,7 +427,7 @@ defmodule ExUnit.AssertionsTest do
         Showing 1 of 1 message in the mailbox\
         """ = error.message
 
-        "assert_received({:status, ^status, ^other_status})" = Macro.to_string(error.expr)
+        "assert_received {:status, ^status, ^other_status}" = Macro.to_string(error.expr)
         "{:status, ^status, ^other_status}" = Macro.to_string(error.left)
     end
   end
@@ -441,7 +440,7 @@ defmodule ExUnit.AssertionsTest do
         "Assertion failed, no matching message after 0ms\nThe process mailbox is empty." =
           error.message
 
-        "assert_received(:hello)" = Macro.to_string(error.expr)
+        "assert_received :hello" = Macro.to_string(error.expr)
     end
   end
 
@@ -457,7 +456,7 @@ defmodule ExUnit.AssertionsTest do
         Showing 1 of 1 message in the mailbox\
         """ = error.message
 
-        "assert_received(:hello)" = Macro.to_string(error.expr)
+        "assert_received :hello" = Macro.to_string(error.expr)
         ":hello" = Macro.to_string(error.left)
     end
   end
@@ -474,7 +473,7 @@ defmodule ExUnit.AssertionsTest do
         Showing 10 of 11 messages in the mailbox\
         """ = error.message
 
-        "assert_received(x when x == :hello)" = Macro.to_string(error.expr)
+        "assert_received x when x == :hello" = Macro.to_string(error.expr)
         "x when x == :hello" = Macro.to_string(error.left)
     end
   end
@@ -522,7 +521,7 @@ defmodule ExUnit.AssertionsTest do
       error in [ExUnit.AssertionError] ->
         'foo' = error.left
         'bar' = error.right
-        "assert('foo' in 'bar')" = Macro.to_string(error.expr)
+        "assert 'foo' in 'bar'" = Macro.to_string(error.expr)
     end
   end
 
@@ -537,7 +536,7 @@ defmodule ExUnit.AssertionsTest do
       error in [ExUnit.AssertionError] ->
         'foo' = error.left
         ['foo', 'bar'] = error.right
-        "refute('foo' in ['foo', 'bar'])" = Macro.to_string(error.expr)
+        "refute 'foo' in ['foo', 'bar']" = Macro.to_string(error.expr)
     end
   end
 
@@ -556,7 +555,7 @@ defmodule ExUnit.AssertionsTest do
     rescue
       error in [ExUnit.AssertionError] ->
         "match (=) failed" = error.message
-        "assert({:ok, _} = error(true))" = Macro.to_string(error.expr)
+        "assert {:ok, _} = error(true)" = Macro.to_string(error.expr)
         "{:error, true}" = Macro.to_string(error.right)
     end
   end
@@ -567,7 +566,7 @@ defmodule ExUnit.AssertionsTest do
     rescue
       error in [ExUnit.AssertionError] ->
         "match (=) failed" = error.message
-        "assert({:ok, _x} = nil)" = Macro.to_string(error.expr)
+        "assert {:ok, _x} = nil" = Macro.to_string(error.expr)
         "nil" = Macro.to_string(error.right)
     end
   end
@@ -578,7 +577,7 @@ defmodule ExUnit.AssertionsTest do
     rescue
       error in [ExUnit.AssertionError] ->
         "Expected truthy, got nil" = error.message
-        "assert(_x = nil)" = Macro.to_string(error.expr)
+        "assert _x = nil" = Macro.to_string(error.expr)
     end
   end
 
@@ -587,7 +586,7 @@ defmodule ExUnit.AssertionsTest do
       "This should never be tested" = refute _ = ok(true)
     rescue
       error in [ExUnit.AssertionError] ->
-        "refute(_ = ok(true))" = Macro.to_string(error.expr)
+        "refute _ = ok(true)" = Macro.to_string(error.expr)
         "Expected false or nil, got {:ok, true}" = error.message
     end
   end
@@ -715,7 +714,7 @@ defmodule ExUnit.AssertionsTest do
     error in [ExUnit.AssertionError] ->
       1 = error.left
       2 = error.right
-      "assert(1 > 2)" = Macro.to_string(error.expr)
+      "assert 1 > 2" = Macro.to_string(error.expr)
   end
 
   test "assert less or equal than operator" do
@@ -726,7 +725,7 @@ defmodule ExUnit.AssertionsTest do
     "This should never be tested" = assert 2 <= 1
   rescue
     error in [ExUnit.AssertionError] ->
-      "assert(2 <= 1)" = Macro.to_string(error.expr)
+      "assert 2 <= 1" = Macro.to_string(error.expr)
       2 = error.left
       1 = error.right
   end

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -328,7 +328,7 @@ defmodule IEx.Evaluator do
         %FunctionClauseError{} ->
           {_, inspect_opts} = pop_in(IEx.inspect_opts()[:syntax_colors][:reset])
           banner = Exception.format_banner(kind, reason, stacktrace)
-          blame = FunctionClauseError.blame(blamed, &inspect(&1, inspect_opts), &blame_match/2)
+          blame = FunctionClauseError.blame(blamed, &inspect(&1, inspect_opts), &blame_match/1)
           [IEx.color(:eval_error, banner), pad(blame)]
 
         _ ->
@@ -343,9 +343,8 @@ defmodule IEx.Evaluator do
     "    " <> String.replace(string, "\n", "\n    ")
   end
 
-  defp blame_match(%{match?: true, node: node}, _), do: Macro.to_string(node)
-  defp blame_match(%{match?: false, node: node}, _), do: blame_ansi(:blame_diff, "-", node)
-  defp blame_match(_, string), do: string
+  defp blame_match(%{match?: true, node: node}), do: Macro.to_string(node)
+  defp blame_match(%{match?: false, node: node}), do: blame_ansi(:blame_diff, "-", node)
 
   defp blame_ansi(color, no_ansi, node) do
     case IEx.Config.color(color) do

--- a/lib/iex/lib/iex/introspection.ex
+++ b/lib/iex/lib/iex/introspection.ex
@@ -732,15 +732,10 @@ defmodule IEx.Introspection do
   ## Helpers
 
   defp format_typespec(definition, kind, nesting) do
-    string = "@#{kind} #{Macro.to_string(definition)}"
-
-    try do
-      string
-      |> Code.format_string!(line_length: IEx.width() - 2 * nesting)
-      |> IO.iodata_to_binary()
-    rescue
-      _ -> string
-    end
+    {:@, [], [{kind, [], [definition]}]}
+    |> Code.quoted_to_algebra()
+    |> Inspect.Algebra.format(IEx.Config.width())
+    |> IO.iodata_to_binary()
     |> color_prefix_with_line()
     |> indent(nesting)
   end

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -696,9 +696,9 @@ defmodule IEx.HelpersTest do
     test "lists all callbacks for an Erlang module" do
       output = capture_io(fn -> b(:gen_server) end)
 
-      assert output =~ "@callback handle_cast(request :: term(), state :: term()) ::"
-      assert output =~ "@callback handle_info(info :: :timeout | term(), state :: term()) ::"
       assert output =~ "@callback init(args :: term()) ::"
+      assert output =~ "@callback handle_cast("
+      assert output =~ "@callback handle_info("
     end
 
     test "lists all macrocallbacks for a module" do
@@ -780,7 +780,7 @@ defmodule IEx.HelpersTest do
                "@callback message(t()) :: String.t()\n\n"
 
       assert capture_io(fn -> b(:gen_server.handle_cast() / 2) end) =~
-               "@callback handle_cast(request :: term(), state :: term()) ::"
+               "@callback handle_cast("
     end
 
     test "prints callback documentation metadata" do


### PR DESCRIPTION
Still WIP. This helped find some bugs in the normalizer, which were fixed on master, and there are some formatting errors that need to be tackled for this to be ready. Finally, FunctionClauseError.blame relies on Macro.to_string/2, so that needs to be addressed too.