### PR TITLE
Preserve metadata on regular blocks

### DIFF
--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -40,10 +40,11 @@ defmodule Code.Normalizer do
     meta = patch_meta_line(meta, state.parent_meta)
     inner_meta = patch_meta_line(inner_meta, meta)
 
-    {:__block__, meta, [[{:__block__, inner_meta, normalize_args(args, %{state | parent_meta: inner_meta})}]]}
+    {:__block__, meta,
+     [[{:__block__, inner_meta, normalize_args(args, %{state | parent_meta: inner_meta})}]]}
   end
 
-  # Normalized charlists
+  # Normalized lists
   defp do_normalize({:__block__, meta, [charlist]} = quoted, state)
        when is_list(charlist) do
     if Keyword.has_key?(meta, :delimiter) do

--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -29,12 +29,14 @@ defmodule Code.Normalizer do
   end
 
   # Skip normalized charlists
-  defp do_normalize({:__block__, meta, [charlist]} = quoted, state)
+  defp do_normalize({:__block__, meta, [charlist] = args} = quoted, state)
        when is_list(charlist) do
     if Keyword.has_key?(meta, :delimiter) do
       quoted
     else
-      do_normalize(charlist, state)
+      # If it's not a charlist, only normalize the args
+      meta = patch_meta_line(meta, state.parent_meta)
+      {:__block__, meta, normalize_args(args, %{state | parent_meta: meta})}
     end
   end
 

--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -45,8 +45,8 @@ defmodule Code.Normalizer do
   end
 
   # Normalized lists
-  defp do_normalize({:__block__, meta, [charlist]} = quoted, state)
-       when is_list(charlist) do
+  defp do_normalize({:__block__, meta, [list]} = quoted, state)
+       when is_list(list) do
     if Keyword.has_key?(meta, :delimiter) do
       # If it's a charlist, skip it
       quoted
@@ -54,7 +54,7 @@ defmodule Code.Normalizer do
       # If it's a regular list, then normalize the args
       meta = patch_meta_line(meta, state.parent_meta)
 
-      args = normalize_args([charlist], %{state | parent_meta: meta})
+      args = normalize_args([list], %{state | parent_meta: meta})
 
       {:__block__, meta, args}
     end

--- a/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
@@ -477,7 +477,7 @@ defmodule Code.Normalizer.FormatterASTTest do
       assert_same ~S"""
       defp sample do
         [
-          # {:a, "~> 0.1.2"}
+          # comment
           {:b, "~> 1.2"}
         ]
       end

--- a/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
@@ -472,5 +472,16 @@ defmodule Code.Normalizer.FormatterASTTest do
       # comment
       """
     end
+
+    test "blocks with keyword list" do
+      assert_same ~S"""
+      defp sample do
+        [
+          # {:a, "~> 0.1.2"}
+          {:b, "~> 1.2"}
+        ]
+      end
+      """
+    end
   end
 end


### PR DESCRIPTION
This is work in progress. I found this bug while playing around with the idea of a `mix deps.add` task. Blocks were normalized as if they were lists, and metadata was lost, breaking the comments placement.