### PR TITLE
Compile time error when aliasing non-Elixir modules without :as

### DIFF
--- a/lib/elixir/src/elixir_aliases.erl
+++ b/lib/elixir/src/elixir_aliases.erl
@@ -112,8 +112,13 @@ wait_for_module(Module) ->
 %% Receives an atom and returns the last bit as an alias.
 
 last(Atom) ->
-  Last = last(lists:reverse(atom_to_list(Atom)), []),
-  list_to_atom("Elixir." ++ Last).
+  case atom_to_list(Atom) of
+    ("Elixir." ++ [FirstLetter | _]) = List when FirstLetter >= $A, FirstLetter =< $Z ->
+      Last = last(lists:reverse(List), []),
+      {ok, list_to_atom("Elixir." ++ Last)};
+    _ ->
+      error
+  end.
 
 last([$. | _], Acc) -> Acc;
 last([H | T], Acc)  -> last(T, [H | Acc]);

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -1127,7 +1127,7 @@ format_error(unhandled_arrow_op) ->
 format_error(as_in_multi_alias_call) ->
   ":as option is not supported by multi-alias call";
 format_error({invalid_alias_module, Ref}) ->
-  io_lib:format("invalid alias module, expected an Elixir module, got: ~ts. To alias other BEAM languages modules, use the :as option",
+  io_lib:format("alias cannot be inferred automatically for module: ~ts, please use the :as option. Implicit aliasing is only supported with Elixir modules",
                 ['Elixir.Macro':to_string(Ref)]);
 format_error({expected_compile_time_module, Kind, GivenTerm}) ->
   io_lib:format("invalid argument for ~ts, expected a compile time atom or alias, got: ~ts",

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -154,6 +154,13 @@ defmodule Kernel.ExpansionTest do
       assert_raise CompileError, message, fn ->
         expand(quote(do: alias(:lists, as: :"Elixir.foobar")))
       end
+
+      message =
+        ~r"invalid alias module, expected an Elixir module, got: :lists. To alias other BEAM languages modules, use the :as option"
+
+      assert_raise CompileError, message, fn ->
+        expand(quote(do: alias(:lists)))
+      end
     end
 
     test "invalid expansion" do

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -156,7 +156,7 @@ defmodule Kernel.ExpansionTest do
       end
 
       message =
-        ~r"invalid alias module, expected an Elixir module, got: :lists. To alias non-Elixir modules, use the :as option"
+        ~r"alias cannot be inferred automatically for module: :lists, please use the :as option"
 
       assert_raise CompileError, message, fn ->
         expand(quote(do: alias(:lists)))

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -156,7 +156,7 @@ defmodule Kernel.ExpansionTest do
       end
 
       message =
-        ~r"invalid alias module, expected an Elixir module, got: :lists. To alias other BEAM languages modules, use the :as option"
+        ~r"invalid alias module, expected an Elixir module, got: :lists. To alias non-Elixir modules, use the :as option"
 
       assert_raise CompileError, message, fn ->
         expand(quote(do: alias(:lists)))


### PR DESCRIPTION
Fixes #11000 

Not proficient erlang dev here, so a detailed review would really be welcome.