### PR TITLE
Fix documentation for `Macro.quoted_literal?`

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1639,7 +1639,7 @@ defmodule Macro do
   def quoted_literal?(list) when is_list(list), do: Enum.all?(list, &quoted_literal?/1)
 
   def quoted_literal?(term),
-    do: is_atom(term) or is_number(term) or is_binary(term) or is_function(term)
+    do: is_atom(term) or is_number(term) or is_binary(term)
 
   @doc """
   Receives an AST node and expands it until it can no longer

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1602,7 +1602,7 @@ defmodule Macro do
   @doc """
   Returns `true` if the given quoted expression represents a quoted literal.
 
-  Atoms, numbers, and functions are always literals. Binaries, lists, tuples,
+  Atoms and numbers are always literals. Binaries, lists, tuples,
   maps, and structs are only literals if all of their terms are also literals.
 
   ## Examples


### PR DESCRIPTION
Functions are not literals, even `fn` and `&` ones

```
iex(1)> Macro.quoted_literal? quote(do: func())
false
iex(2)> Macro.quoted_literal? quote(do: func)
false
iex(3)> Macro.quoted_literal? quote(do: func(1, 2, 3))
false
iex(4)> Macro.quoted_literal? quote(do: fn x -> x end)
false
iex(5)> Macro.quoted_literal? quote(do: (& &1))
false
iex(6)> Macro.quoted_literal? quote(do: def(f(x), [do: x]))
false
```