### PR TITLE
Clarify `Path.extname/1` doc(test)s (#11023)

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -426,20 +426,15 @@ defmodule Path do
   @doc """
   Returns the extension of the last component of `path`.
 
-  Note that when the filename consists only of a file
-  extension (like ".gitignore"), `Path.extname/1` will
-  return an empty string (""), and not ".gitignore". 
+  The behaviour of this function changed in Erlang/OTP 24 for filenames
+  starting with a dot and without an extension. For example, for a file
+  named ".gitignore", `extname/1` now returns an empty string, while it
+  would return ".gitignore" in previous Erlang/OTP versions. This was
+  done to match the behaviour of `rootname/1`, which would return
+  ".gitignore" as its name (and therefore it cannot also be an extension).
 
-  The original behavior (in Erlang/OTP 23) was to treat
-  ".x" as having the file extension ".x", but this was
-  considered a bug on their end and has been fixed
-  (in Erlang/OTP 24). 
-
-  If you want to extract the full filename of a path
-  like "~/foo/bar/.gitignore", you should use
-  `Path.basename/1` instead. `Path.extname/1` extracts
-  just the file extension, and `Path.basename/1` extracts
-  the just the filename (excluding the path to it). 
+  See `basename/1` and `rootname/1` for related functions to extract
+  information from paths.
 
   ## Examples
 
@@ -447,12 +442,6 @@ defmodule Path do
       ".erl"
 
       iex> Path.extname("~/foo/bar")
-      ""
-      
-      iex> Path.extname(".gitignore")
-      ""
-      
-      iex> Path.extname("~/foo/bar/.gitignore")
       ""
 
   """

--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -425,6 +425,21 @@ defmodule Path do
 
   @doc """
   Returns the extension of the last component of `path`.
+  
+  Note that when the filename consists only of a file
+  extension (like ".gitignore"), `Path.extname/1` will
+  return an empty string (""), and not ".gitignore". 
+  
+  The original behavior (in Erlang/OTP 23) was to treat
+  ".x" as having the file extension ".x", but this was
+  considered a bug on their end and has been fixed
+  (in Erlang/OTP 24). 
+  
+  If you want to extract the full filename of a path
+  like "~/foo/bar/.gitignore", you should use
+  `Path.basename/1` instead. `Path.extname/1` extracts
+  just the file extension, and `Path.basename/1` extracts
+  the just the filename (excluding the path to it). 
 
   ## Examples
 
@@ -432,6 +447,12 @@ defmodule Path do
       ".erl"
 
       iex> Path.extname("~/foo/bar")
+      ""
+      
+      iex> Path.extname(".gitignore")
+      ""
+      
+      iex> Path.extname("~/foo/bar/.gitignore")
       ""
 
   """

--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -425,16 +425,16 @@ defmodule Path do
 
   @doc """
   Returns the extension of the last component of `path`.
-  
+
   Note that when the filename consists only of a file
   extension (like ".gitignore"), `Path.extname/1` will
   return an empty string (""), and not ".gitignore". 
-  
+
   The original behavior (in Erlang/OTP 23) was to treat
   ".x" as having the file extension ".x", but this was
   considered a bug on their end and has been fixed
   (in Erlang/OTP 24). 
-  
+
   If you want to extract the full filename of a path
   like "~/foo/bar/.gitignore", you should use
   `Path.basename/1` instead. `Path.extname/1` extracts


### PR DESCRIPTION
Documentation update for #11023 

Clarify the behavior of `Path.extname/1` in docstrings and doctests, namely how it behaves when given a filename that is just a file extension (like ".gitignore"). I also mentioned when you might want to use `Path.basename/1` instead, which was brought up by @josevalim in the associated issue (#11023).