### PR TITLE
Add List.append/1 and List.append/2

### DIFF
--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -229,6 +229,46 @@ defmodule List do
   end
 
   @doc """
+  Append the given `list` of nested lists to create one list.
+
+  ## Examples
+
+      iex> List.append([[1, 2], [3, 4]])
+      [1, 2, 3, 4]
+
+      iex> List.append([[1, 2], [3], [4, 5]])
+      [1, 2, 3, 4, 5]
+
+      iex> List.append([[], [1, 2], []])
+      [1, 2]
+
+  """
+  @spec append(deep_list) :: list when deep_list: [list()]
+  def append(list) do
+    :lists.append(list)
+  end
+
+  @doc """
+  Append `tail` list to the given `list`.
+
+  ## Examples
+
+      iex> List.append([1, 2, 3], [4, 5, 6])
+      [1, 2, 3, 4, 5, 6]
+
+      iex> List.append([], [1, 2 ,3])
+      [1, 2, 3]
+
+      iex> List.append([1, 2, 3], [])
+      [1, 2, 3]
+
+  """
+  @spec append(list(), list()) :: list()
+  def append(list, tail) do
+    :lists.append(list, tail)
+  end
+
+  @doc """
   Folds (reduces) the given list from the left with
   a function. Requires an accumulator.
 

--- a/lib/elixir/test/elixir/list_test.exs
+++ b/lib/elixir/test/elixir/list_test.exs
@@ -52,6 +52,20 @@ defmodule ListTest do
     assert List.flatten([1, [], 2], [3, [], 4]) == [1, 2, 3, [], 4]
   end
 
+  test "append/1" do
+    assert List.append([1, 2], [3, 4]) == [1, 2, 3, 4]
+    assert List.append([[1, 2], []]) == [1, 2]
+    assert List.append([[], [1, 2]]) == [1, 2]
+    assert List.append([[1, 2], [3], [4], [5]]) == [1, 2, 3, 4, 5]
+  end
+
+  test "append/2" do
+    assert List.append([1, 2, 3], [4, 5]) == [1, 2, 3, 4, 5]
+    assert List.append([1, [2], 3], [4, 5]) == [1, [2], 3, 4, 5]
+    assert List.append([[1, [2], 3]], [4, 5]) == [[1, [2], 3], 4, 5]
+    assert List.append([1, [], 2], [3, [], 4]) == [1, [], 2, 3, [], 4]
+  end
+
   test "foldl/3" do
     assert List.foldl([1, 2, 3], 0, fn x, y -> x + y end) == 6
     assert List.foldl([1, 2, 3], 10, fn x, y -> x + y end) == 16


### PR DESCRIPTION
> lists:flatten/1 builds an entirely new list. It is therefore expensive, and even more expensive than the ++ operator (which copies its left argument, but not its right argument).

source: https://erlang.org/doc/efficiency_guide/listHandling.html#deep-and-flat-lists

I think it could be usefull in with `Keyword.get_values/2` for example

```elixir
iex> [opts: [key1: 1], other_key: 2, opts: [key3: 3]]
...> |> Keyword.get_values(:opts)
...> |> List.append()
[key1: 1, key3: 3]
```

I do some benchmark to check how fast it could be, here the result

### `list:flatten/1` vs `list:append/1`

```
Operating System: macOS
CPU Information: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
Number of Available Cores: 8
Available memory: 16 GB
Elixir 1.11.3
Erlang 23.2.7

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 14 s

Benchmarking list_append...
Benchmarking list_flatten...

Name                   ips        average  deviation         median         99th %
list_append         3.97 M      251.88 ns  ±3304.54%           0 ns        1000 ns
list_flatten        2.40 M      417.37 ns  ±6865.67%           0 ns        1000 ns

Comparison:
list_append         3.97 M
list_flatten        2.40 M - 1.66x slower +165.49 ns
```

source:

```elixir
Benchee.run(%{
  list_flatten: fn -> :lists.flatten([[1, 2], [3, 4]]) == [1, 2, 3, 4] end,
  list_append: fn -> :lists.append([[1, 2], [3, 4]]) == [1, 2, 3, 4] end
})

```