### PR TITLE
Add `identifier_location` and `last` metadata

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -801,7 +801,7 @@ expand_remote(Receiver, DotMeta, Right, Meta, Args, #{context := Context} = E, E
       AttachedDotMeta = attach_context_module(Receiver, DotMeta, E),
 
       is_atom(Receiver) andalso
-        elixir_env:trace({remote_function, DotMeta, Receiver, Right, length(Args)}, E),
+        elixir_env:trace({remote_function, Meta, Receiver, Right, length(Args)}, E),
 
       {EArgs, {EA, _}} = lists:mapfoldl(fun expand_arg/2, {EL, E}, Args),
 

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -830,7 +830,7 @@ build_alias({'alias', Location, Alias}) ->
   Meta = meta_from_location(Location),
   MetaWithExtra =
     case ?token_metadata() of
-      true -> lists:keystore(last, 1, Meta, {last, meta_from_location(Location)});
+      true -> [{last, meta_from_location(Location)} | Meta];
       false -> Meta
     end,
   {'__aliases__', MetaWithExtra, [Alias]}.
@@ -848,7 +848,7 @@ build_dot_alias(Dot, Expr, {'alias', SegmentLocation, Right}) ->
   Meta = meta_from_token(Dot),
   MetaWithExtra =
     case ?token_metadata() of
-      true -> lists:keystore(last, 1, Meta, {last, meta_from_location(SegmentLocation)});
+      true -> [{last, meta_from_location(SegmentLocation)} | Meta];
       false -> Meta
     end,
   {'__aliases__', MetaWithExtra, [Expr, Right]}.

--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -827,14 +827,31 @@ end_of_expression(Location) ->
 %% Dots
 
 build_alias({'alias', Location, Alias}) ->
-  {'__aliases__', meta_from_location(Location), [Alias]}.
+  Meta = meta_from_location(Location),
+  MetaWithExtra =
+    case ?token_metadata() of
+      true -> lists:keystore(last, 1, Meta, {last, meta_from_location(Location)});
+      false -> Meta
+    end,
+  {'__aliases__', MetaWithExtra, [Alias]}.
 
-build_dot_alias(_Dot, {'__aliases__', Meta, Left}, {'alias', _, Right}) ->
-  {'__aliases__', Meta, Left ++ [Right]};
+build_dot_alias(_Dot, {'__aliases__', Meta, Left}, {'alias', SegmentLocation, Right}) ->
+  MetaWithExtra =
+    case ?token_metadata() of
+      true -> lists:keystore(last, 1, Meta, {last, meta_from_location(SegmentLocation)});
+      false -> Meta
+    end,
+  {'__aliases__', MetaWithExtra, Left ++ [Right]};
 build_dot_alias(_Dot, Atom, Right) when is_atom(Atom) ->
   error_bad_atom(Right);
-build_dot_alias(Dot, Expr, {'alias', _, Right}) ->
-  {'__aliases__', meta_from_token(Dot), [Expr, Right]}.
+build_dot_alias(Dot, Expr, {'alias', SegmentLocation, Right}) ->
+  Meta = meta_from_token(Dot),
+  MetaWithExtra =
+    case ?token_metadata() of
+      true -> lists:keystore(last, 1, Meta, {last, meta_from_location(SegmentLocation)});
+      false -> Meta
+    end,
+  {'__aliases__', MetaWithExtra, [Expr, Right]}.
 
 build_dot_container(Dot, Left, Right, Extra) ->
   Meta = meta_from_token(Dot),

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -337,6 +337,17 @@ defmodule Kernel.ParserTest do
                    ]}
                 ]}
     end
+
+    test "adds identifier_location for qualified identifiers" do
+      string_to_quoted = &Code.string_to_quoted!(&1, token_metadata: true)
+
+      assert string_to_quoted.("foo.\nbar") ==
+               {{:., [line: 1],
+                 [
+                   {:foo, [line: 1], nil},
+                   :bar
+                 ]}, [no_parens: true, identifier_location: [line: 2], line: 1], []}
+    end
   end
 
   describe "token missing errors" do

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -355,19 +355,12 @@ defmodule Kernel.ParserTest do
                    :bar
                  ]}, [no_parens: true, line: 3, column: 1], []}
 
-      assert string_to_quoted.(~s[Integer.\nis_odd(1)]) ==
-               {{:., [line: 1, column: 8],
+      assert string_to_quoted.(~s[Foo.\nbar(1)]) ==
+               {{:., [line: 1, column: 4],
                  [
-                   {:__aliases__, [last: [line: 1, column: 1], line: 1, column: 1], [:Integer]},
-                   :is_odd
-                 ]}, [closing: [line: 2, column: 9], line: 2, column: 1], [1]}
-
-      assert string_to_quoted.(~s[Integer.\nparse("1")]) ==
-               {{:., [line: 1, column: 8],
-                 [
-                   {:__aliases__, [last: [line: 1, column: 1], line: 1, column: 1], [:Integer]},
-                   :parse
-                 ]}, [closing: [line: 2, column: 10], line: 2, column: 1], ["1"]}
+                   {:__aliases__, [last: [line: 1, column: 1], line: 1, column: 1], [:Foo]},
+                   :bar
+                 ]}, [closing: [line: 2, column: 6], line: 2, column: 1], [1]}
     end
 
     test "adds metadata for the last alias segment" do

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -348,6 +348,18 @@ defmodule Kernel.ParserTest do
                    :bar
                  ]}, [no_parens: true, identifier_location: [line: 2], line: 1], []}
     end
+
+    test "adds metadata for the last alias segment" do
+      string_to_quoted = &Code.string_to_quoted!(&1, token_metadata: true)
+
+      assert string_to_quoted.("Foo") == {:__aliases__, [line: 1, last: [line: 1]], [:Foo]}
+
+      assert string_to_quoted.("Foo.\nBar\n.\nBaz") ==
+               {:__aliases__, [line: 1, last: [line: 4]], [:Foo, :Bar, :Baz]}
+
+      assert string_to_quoted.("foo.\nBar\n.\nBaz") ==
+               {:__aliases__, [line: 1, last: [line: 4]], [{:foo, [line: 1], nil}, :Bar, :Baz]}
+    end
   end
 
   describe "token missing errors" do

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -352,13 +352,13 @@ defmodule Kernel.ParserTest do
     test "adds metadata for the last alias segment" do
       string_to_quoted = &Code.string_to_quoted!(&1, token_metadata: true)
 
-      assert string_to_quoted.("Foo") == {:__aliases__, [line: 1, last: [line: 1]], [:Foo]}
+      assert string_to_quoted.("Foo") == {:__aliases__, [last: [line: 1], line: 1], [:Foo]}
 
       assert string_to_quoted.("Foo.\nBar\n.\nBaz") ==
-               {:__aliases__, [line: 1, last: [line: 4]], [:Foo, :Bar, :Baz]}
+               {:__aliases__, [last: [line: 4], line: 1], [:Foo, :Bar, :Baz]}
 
       assert string_to_quoted.("foo.\nBar\n.\nBaz") ==
-               {:__aliases__, [line: 1, last: [line: 4]], [{:foo, [line: 1], nil}, :Bar, :Baz]}
+               {:__aliases__, [last: [line: 4], line: 1], [{:foo, [line: 1], nil}, :Bar, :Baz]}
     end
   end
 

--- a/lib/elixir/test/elixir/kernel/tracers_test.exs
+++ b/lib/elixir/test/elixir/kernel/tracers_test.exs
@@ -102,11 +102,11 @@ defmodule Kernel.TracersTest do
 
     assert_receive {{:remote_macro, meta, Integer, :is_odd, 1}, _}
     assert meta[:line] == 2
-    assert meta[:column] == 15
+    assert meta[:column] == 16
 
     assert_receive {{:remote_function, meta, Integer, :parse, 1}, _}
     assert meta[:line] == 3
-    assert meta[:column] == 18
+    assert meta[:column] == 19
   end
 
   test "traces remote via captures" do


### PR DESCRIPTION
This adds `identifier_locaiton` metadata to qualified identifiers and `last` metadata to aliases, as discussed in [this proposal](https://groups.google.com/u/1/g/elixir-lang-core/c/6APSoyKdKIc)