### PR TITLE
add @doc since: "1.12.0"

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -1763,6 +1763,7 @@ defmodule Code do
   @doc """
   Same as `ensure_loaded/1` but raises if the module cannot be loaded.
   """
+  @doc since: "1.12.0"
   @spec ensure_loaded!(module) :: module
   def ensure_loaded!(module) do
     case ensure_loaded(module) do


### PR DESCRIPTION
Would you please do review?
If I mistake start/end point branch, please comment to me.

I think that Code.ensure_loaded!/1 is added from 1.12.0.
@doc since: "1.12.0" is unnecessary here, so I also think that there may be nothing now.
If I shall waste your time, I apologize.