### PR TITLE
Improve the error message when apply fails

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -733,7 +733,7 @@ defmodule ArgumentError do
 
         not is_atom(function) ->
           "you attempted to apply #{inspect(function)} on module #{inspect(module)}. " <>
-            "However `#{inspect(function)}` is not a function. Functions (the second argument " <>
+            "However #{inspect(function)} is not a function. Functions (the second argument " <>
             "of apply) must always be an atom"
 
         not is_list(args) ->

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -722,7 +722,7 @@ defmodule ArgumentError do
       cond do
         # Note that args may be an empty list even if they were supplied
         not is_atom(module) and is_atom(function) and args == [] ->
-          "you attempted to apply the function #{inspect(function)} on #{inspect(module)}. " <>
+          "you attempted to apply a function named #{inspect(function)} on #{inspect(module)}. " <>
             "If you are using Kernel.apply/3, make sure the module is an atom. " <>
             "If you are using the dot syntax, such as map.field or module.function(), " <>
             "make sure the left side of the dot is an atom or a map"
@@ -732,12 +732,12 @@ defmodule ArgumentError do
             "Modules (the first argument of apply) must always be an atom"
 
         not is_atom(function) ->
-          "you attempted to apply #{inspect(function)} on module #{inspect(module)}. " <>
-            "However #{inspect(function)} is not a function. Functions (the second argument " <>
+          "you attempted to apply a function named #{inspect(function)} on module #{inspect(module)}. " <>
+            "However #{inspect(function)} is not a valid function name. Function names (the second argument " <>
             "of apply) must always be an atom"
 
         not is_list(args) ->
-          "you attempted to apply the function #{inspect(function)} on module #{inspect(module)} " <>
+          "you attempted to apply a function named #{inspect(function)} on module #{inspect(module)} " <>
             "with arguments #{inspect(args)}. Arguments (the third argument of apply) must always be a list"
       end
 

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -722,8 +722,8 @@ defmodule ArgumentError do
       cond do
         # Note that args may be an empty list even if they were supplied
         not is_atom(module) and is_atom(function) and args == [] ->
-          "you attempted to apply #{inspect(function)} on #{inspect(module)}. " <>
-            "If you are using apply/3, make sure the module is an atom. " <>
+          "you attempted to apply the function #{inspect(function)} on #{inspect(module)}. " <>
+            "If you are using Kernel.apply/3, make sure the module is an atom. " <>
             "If you are using the dot syntax, such as map.field or module.function(), " <>
             "make sure the left side of the dot is an atom or a map"
 
@@ -733,10 +733,11 @@ defmodule ArgumentError do
 
         not is_atom(function) ->
           "you attempted to apply #{inspect(function)} on module #{inspect(module)}. " <>
-            "Functions (the second argument of apply) must always be an atom"
+            "However `#{inspect(function)}` is not a function. Functions (the second argument " <>
+            "of apply) must always be an atom"
 
         not is_list(args) ->
-          "you attempted to apply #{inspect(function)} on module #{inspect(module)} " <>
+          "you attempted to apply the function #{inspect(function)} on module #{inspect(module)} " <>
             "with arguments #{inspect(args)}. Arguments (the third argument of apply) must always be a list"
       end
 

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -408,21 +408,21 @@ defmodule ExceptionTest do
 
     test "annotates badarg on apply" do
       assert blame_message([], & &1.foo) ==
-               "you attempted to apply the function :foo on []. If you are using Kernel.apply/3, make sure " <>
+               "you attempted to apply a function named :foo on []. If you are using Kernel.apply/3, make sure " <>
                  "the module is an atom. If you are using the dot syntax, such as " <>
                  "map.field or module.function(), make sure the left side of the dot is an atom or a map"
 
       assert blame_message([], &apply(&1, :foo, [])) ==
-               "you attempted to apply the function :foo on []. If you are using Kernel.apply/3, make sure " <>
+               "you attempted to apply a function named :foo on []. If you are using Kernel.apply/3, make sure " <>
                  "the module is an atom. If you are using the dot syntax, such as " <>
                  "map.field or module.function(), make sure the left side of the dot is an atom or a map"
 
       assert blame_message([], &apply(Kernel, &1, [1, 2])) ==
-               "you attempted to apply [] on module Kernel. However [] is not a function. Functions " <>
-                 "(the second argument of apply) must always be an atom"
+               "you attempted to apply a function named [] on module Kernel. However [] is not a valid function name. " <>
+                 "Function names (the second argument of apply) must always be an atom"
 
       assert blame_message(123, &apply(Kernel, :+, &1)) ==
-               "you attempted to apply the function :+ on module Kernel with arguments 123. " <>
+               "you attempted to apply a function named :+ on module Kernel with arguments 123. " <>
                  "Arguments (the third argument of apply) must always be a list"
     end
 

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -418,7 +418,7 @@ defmodule ExceptionTest do
                  "map.field or module.function(), make sure the left side of the dot is an atom or a map"
 
       assert blame_message([], &apply(Kernel, &1, [1, 2])) ==
-               "you attempted to apply [] on module Kernel. However `[]` is not a function. Functions " <>
+               "you attempted to apply [] on module Kernel. However [] is not a function. Functions " <>
                  "(the second argument of apply) must always be an atom"
 
       assert blame_message(123, &apply(Kernel, :+, &1)) ==

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -408,20 +408,21 @@ defmodule ExceptionTest do
 
     test "annotates badarg on apply" do
       assert blame_message([], & &1.foo) ==
-               "you attempted to apply :foo on []. If you are using apply/3, make sure " <>
+               "you attempted to apply the function :foo on []. If you are using Kernel.apply/3, make sure " <>
                  "the module is an atom. If you are using the dot syntax, such as " <>
                  "map.field or module.function(), make sure the left side of the dot is an atom or a map"
 
       assert blame_message([], &apply(&1, :foo, [])) ==
-               "you attempted to apply :foo on []. If you are using apply/3, make sure " <>
+               "you attempted to apply the function :foo on []. If you are using Kernel.apply/3, make sure " <>
                  "the module is an atom. If you are using the dot syntax, such as " <>
                  "map.field or module.function(), make sure the left side of the dot is an atom or a map"
 
       assert blame_message([], &apply(Kernel, &1, [1, 2])) ==
-               "you attempted to apply [] on module Kernel. Functions (the second argument of apply) must always be an atom"
+               "you attempted to apply [] on module Kernel. However `[]` is not a function. Functions " <>
+                 "(the second argument of apply) must always be an atom"
 
       assert blame_message(123, &apply(Kernel, :+, &1)) ==
-               "you attempted to apply :+ on module Kernel with arguments 123. " <>
+               "you attempted to apply the function :+ on module Kernel with arguments 123. " <>
                  "Arguments (the third argument of apply) must always be a list"
     end
 


### PR DESCRIPTION
Not all elixir developers may understand what "apply" means in this case.  Especially if they are beginners and are not using
`Kernel.apply/3` directly (but instead using `.` to call the function or if this is being raised by library code).

However, calling `:foo` a function (example from the tests) isn't quite right (as it is an atom that could represent a function when paired with a module) so the wording could probably be improved further.