### PR TITLE
Warn if ?\lettter is used but there is no such escape sequence

### DIFF
--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1249,13 +1249,11 @@ defmodule Kernel.WarningTest do
     purge(Sample)
   end
 
-  test "no warning on necessary code point escape" do
-    assert capture_err(fn ->
-             Code.eval_string("?\\n")
-           end) == ""
-  end
-
   test "warning on unnecessary code point escape" do
+    assert capture_err(fn ->
+             Code.eval_string("?\\n + ?\\\\")
+           end) == ""
+
     assert capture_err(fn ->
              Code.eval_string("?\\w")
            end) =~ "unknown escape sequence ?\\w, use ?w instead"

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1249,6 +1249,18 @@ defmodule Kernel.WarningTest do
     purge(Sample)
   end
 
+  test "no warning on necessary code point escape" do
+    assert capture_err(fn ->
+             Code.eval_string("?\\n")
+           end) == ""
+  end
+
+  test "warning on unnecessary code point escape" do
+    assert capture_err(fn ->
+             Code.eval_string("?\\w")
+           end) =~ "unknown escape sequence ?\\w, use ?w instead"
+  end
+
   test "warning on code point escape" do
     assert capture_err(fn ->
              Code.eval_string("? ")

--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -167,7 +167,7 @@ defmodule ExUnit.Diff do
   end
 
   defp diff_value(left, right, env) when is_binary(left) and is_binary(right) do
-    diff_string(left, right, ?\", env)
+    diff_string(left, right, ?", env)
   end
 
   defp diff_value(left, right, env) do
@@ -751,7 +751,7 @@ defmodule ExUnit.Diff do
   end
 
   defp diff_string_concat(left, nil, indexes, _left_length, right, env) do
-    {parsed_diff, parsed_post_env} = diff_string(left, right, ?\", env)
+    {parsed_diff, parsed_post_env} = diff_string(left, right, ?", env)
     left_diff = rebuild_concat_string(parsed_diff.left, nil, indexes)
 
     diff = %__MODULE__{parsed_diff | left: left_diff}
@@ -760,7 +760,7 @@ defmodule ExUnit.Diff do
 
   defp diff_string_concat(left, quoted, indexes, left_length, right, env) do
     {parsed_right, continue_right} = String.split_at(right, left_length)
-    {parsed_diff, parsed_post_env} = diff_string(left, parsed_right, ?\", env)
+    {parsed_diff, parsed_post_env} = diff_string(left, parsed_right, ?", env)
     {quoted_diff, quoted_post_env} = diff(quoted, continue_right, parsed_post_env)
 
     diff =


### PR DESCRIPTION
This resolves #11028

I don't write a ton of Erlang, so it's entirely possible that this isn't very idiomatic code, and I'm happy to go back and rework anything as requested :)