### PR TITLE
Invalidate a module's tests if an on_exit hook errors in setup_all

### DIFF
--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -146,13 +146,18 @@ defmodule ExUnit.CLIFormatter do
         {:module_finished, %ExUnit.TestModule{state: {:failed, failures}} = test_module},
         config
       ) do
-    tests_length = length(test_module.tests)
+    # The failed tests have already contributed to the counter,
+    # so we should only add the successful tests to the count
+    config =
+      update_in(config.failure_counter, fn counter ->
+        counter + Enum.count(test_module.tests, &is_nil(&1.state))
+      end)
 
     formatted =
       format_test_all_failure(
         test_module,
         failures,
-        config.failure_counter + tests_length,
+        config.failure_counter,
         config.width,
         &formatter(&1, &2, config)
       )

--- a/lib/ex_unit/test/ex_unit/callbacks_test.exs
+++ b/lib/ex_unit/test/ex_unit/callbacks_test.exs
@@ -150,6 +150,27 @@ defmodule ExUnit.CallbacksTest do
     assert capture_io(fn -> ExUnit.run() end) =~ ">) killed"
   end
 
+  test "invalidates all tests when on_exit errors within setup_all" do
+    defmodule InvalidatesTestsOnExitErrorTest do
+      use ExUnit.Case
+
+      setup_all do
+        on_exit(fn -> raise "boom" end)
+        :ok
+      end
+
+      test "succeeds" do
+        assert true
+      end
+
+      test "fails" do
+        assert false
+      end
+    end
+
+    assert capture_io(fn -> ExUnit.run() end) =~ "2 tests, 2 failures"
+  end
+
   defp no_formatters! do
     ExUnit.configure(formatters: [])
     on_exit(fn -> ExUnit.configure(formatters: [ExUnit.CLIFormatter]) end)


### PR DESCRIPTION
This resolves #10974

There's two separate changes here, and I've tried to summarize them in their respective commits.

The first commit fixes the count emitted by the `ExUnit.CLIFormatter`, in the event that a module's tests are invalidated. This seemed to be a simple case of properly updating the `failure_counter` when a module finishes with an error, taking care to not double-count the failed tests.

The second commit fixes the exit code emitted when a module's tests are invalidated, and also ensures that those invalidated tests are added to the `ExUnit.FailuresManifest`. This is a very similar change, and modifies `ExUnit.RunnerStats` to handle `:module_finished` messages, by invalidating any tests within a failed module.

I've never worked with the `ExUnit` codebase before, so it's entirely possible that these changes aren't in the right places, or that there's better fixes possible. If that's the case, I'm happy to adjust this PR as needed :)