### PR TITLE
Improve docs for `sigil_r`

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5603,7 +5603,7 @@ defmodule Kernel do
       iex> Regex.match?(~r/a#{:b}c/, "abc")
       true
 
-  While the `r` sigil allows parens and brackets to be used as delimiters,
+  While the `~r` sigil allows parens and brackets to be used as delimiters,
   it is preferred to use `"` or `/` to avoid escaping conflicts with reserved
   regex characters:
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5603,16 +5603,15 @@ defmodule Kernel do
       iex> Regex.match?(~r/a#{:b}c/, "abc")
       true
 
-  Note that using `~r()` might raise an exception if you try to escape
-  parentheses, so typically `~r//` or `~r""` are preferred. `~r[]` also works
-  fine:
+  While the `r` sigil allows parens and brackets to be used as delimiters,
+  it is preferred to use `"` or `/` to avoid escaping conflicts with reserved
+  regex characters:
 
       iex> Regex.match?(~r(\(foo\)), "(foo)")
       ** (Regex.CompileError) unmatched parentheses at position 5
       iex> Regex.match?(~r/\(foo\)/, "(foo)")
       true
-      iex> Regex.match?(~r[\(foo\)], "(foo)")
-      true
+
   """
   defmacro sigil_r(term, modifiers)
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5587,7 +5587,7 @@ defmodule Kernel do
     quote(do: List.to_charlist(unquote(unescape_list_tokens(pieces))))
   end
 
-  @doc """
+  @doc ~S"""
   Handles the sigil `~r` for regular expressions.
 
   It returns a regular expression pattern, unescaping characters and replacing

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5597,12 +5597,22 @@ defmodule Kernel do
 
   ## Examples
 
-      iex> Regex.match?(~r(foo), "foo")
+      iex> Regex.match?(~r/foo/, "foo")
       true
 
       iex> Regex.match?(~r/a#{:b}c/, "abc")
       true
 
+  Note that using `~r()` might raise an exception if you try to escape
+  parentheses, so typically `~r//` or `~r""` are preferred. `~r[]` also works
+  fine:
+
+      iex> Regex.match?(~r(\(foo\)), "(foo)")
+      ** (Regex.CompileError) unmatched parentheses at position 5
+      iex> Regex.match?(~r/\(foo\)/, "(foo)")
+      true
+      iex> Regex.match?(~r[\(foo\)], "(foo)")
+      true
   """
   defmacro sigil_r(term, modifiers)
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5605,13 +5605,7 @@ defmodule Kernel do
 
   While the `~r` sigil allows parens and brackets to be used as delimiters,
   it is preferred to use `"` or `/` to avoid escaping conflicts with reserved
-  regex characters:
-
-      iex> Regex.match?(~r(\(foo\)), "(foo)")
-      ** (Regex.CompileError) unmatched parentheses at position 5
-      iex> Regex.match?(~r/\(foo\)/, "(foo)")
-      true
-
+  regex characters.
   """
   defmacro sigil_r(term, modifiers)
 


### PR DESCRIPTION
A per #11050, this PR improves the docs on `sigil_r` to notice that using `~r()` and trying to match escaped parentheses will raise an exception, so any other enclosing character is recommended, specially `~r//` and `~r""`.