### PR TITLE
Update `Enum.zip_reduce/3` docs

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3574,9 +3574,10 @@ defmodule Enum do
   end
 
   @doc """
-  Reduces a over all of the given enums, halting as soon as any enumerable is empty.
+  Reduces over all of the given enumerables, halting as soon as any enumerable is 
+  empty.
 
-  The reducer will receive 2 args, a list of elements (one from each enum) and the
+  The reducer will receive 2 args: a list of elements (one from each enum) and the
   accumulator.
 
   In practice, the behaviour provided by this function can be achieved with:


### PR DESCRIPTION
This PR tries to improve the docs for `Enum.zip_reduce/3` by copying the starting line from `Enum.zip_reduce/4` to make docs clearer.