### PR TITLE
Add doc example for :"Elixir.AnAtom"

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -566,6 +566,9 @@ defmodule Kernel do
       iex> is_atom("true")
       false
 
+      iex> is_atom(AnAtom)
+      true
+
   """
   @doc guard: true
   @spec is_atom(term) :: boolean

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -563,11 +563,11 @@ defmodule Kernel do
       iex> is_atom(:name)
       true
 
-      iex> is_atom("true")
-      false
-
       iex> is_atom(AnAtom)
       true
+
+      iex> is_atom("true")
+      false
 
   """
   @doc guard: true


### PR DESCRIPTION
Add doc example for atoms like module names.