### PR TITLE
Preserve user choice on parenthesis before do block

### DIFF
--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -284,7 +284,7 @@ defmodule Code.Normalizer do
       end
 
     meta =
-      if is_nil(meta[:no_parens]) and is_nil(meta[:closing]) and
+      if is_nil(meta[:no_parens]) and is_nil(meta[:closing]) and is_nil(meta[:do]) and
            not Code.Formatter.local_without_parens?(form, arity, state.locals_without_parens) do
         [closing: [line: meta[:line]]] ++ meta
       else

--- a/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
@@ -344,6 +344,22 @@ defmodule Code.Normalizer.FormatterASTTest do
     end
   end
 
+  describe "preserves user choice on parenthesis" do
+    test "in functions with do blocks" do
+      assert_same(~S"""
+      foo Bar do
+        :ok
+      end
+      """)
+
+      assert_same(~S"""
+      foo(Bar) do
+        :ok
+      end
+      """)
+    end
+  end
+
   describe "preserves formatting for sigils" do
     test "without interpolation" do
       assert_same ~S[~s(foo)]


### PR DESCRIPTION
The normalizer adds a `:closing` line to calls even if there is a `do` block, forcing the formatter to add parenthesis. So for code like this one:
```elixir
module DemoMod do
  def foo, do: :bar
end
```
`Code.quoted_to_algebra` will produce this code:
```elixir
module(DemoMod) do
  def foo, do: :bar
end
```
While `Code.format_string!` will produce the output without parenthesis.

I added a check to not force the `:closing` metadata to calls if the call has `:do` metadata.