### PR TITLE
Ensure unconstrained rebar deps generate valid mix specifications.

### DIFF
--- a/lib/mix/lib/mix/rebar.ex
+++ b/lib/mix/lib/mix/rebar.ex
@@ -105,7 +105,7 @@ defmodule Mix.Rebar do
   # Translate a Rebar dependency declaration to a Mix declaration
   # From http://www.rebar3.org/docs/dependencies#section-declaring-dependencies
   defp parse_dep(app) when is_atom(app) do
-    {app, nil, override: true}
+    {app, override: true}
   end
 
   defp parse_dep({app, req}) when is_list(req) do

--- a/lib/mix/test/mix/rebar_test.exs
+++ b/lib/mix/test/mix/rebar_test.exs
@@ -111,6 +111,9 @@ defmodule Mix.RebarTest do
 
       assert parse_dep({:git_rebar, '', {:git, @git_rebar_charlist, {:ref, '64691eb'}}}) ==
                {:git_rebar, ~r"", override: true, git: @git_rebar_string, ref: "64691eb"}
+
+      assert parse_dep({:git_rebar, {:git, @git_rebar_charlist, {:ref, '64691eb'}}}) ==
+               {:git_rebar, override: true, git: @git_rebar_string, ref: "64691eb"}
     end
   end
 

--- a/lib/mix/test/mix/rebar_test.exs
+++ b/lib/mix/test/mix/rebar_test.exs
@@ -112,8 +112,7 @@ defmodule Mix.RebarTest do
       assert parse_dep({:git_rebar, '', {:git, @git_rebar_charlist, {:ref, '64691eb'}}}) ==
                {:git_rebar, ~r"", override: true, git: @git_rebar_string, ref: "64691eb"}
 
-      assert parse_dep({:git_rebar, {:git, @git_rebar_charlist, {:ref, '64691eb'}}}) ==
-               {:git_rebar, override: true, git: @git_rebar_string, ref: "64691eb"}
+      assert parse_dep(:git_rebar) == {:git_rebar, override: true}
     end
   end
 


### PR DESCRIPTION
Not super sure of this, but noticed #11062 and thought I'd take a stab at it.

Fixes #11062.