### PR TITLE
fix: concatenation errors

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -1550,16 +1550,6 @@ defmodule ErlangError do
     {nil, nil, nil}
   end
 
-  defp error_info(:badarg, [{:erlang, :byte_size, _, _} | _]) do
-    {:ok,
-     """
-       * 1st argument: not a bitstring
-
-     This typically happens when calling Kernel.byte_size/1 with an invalid argument
-     or when performing binary concatenation with <> and one of the arguments is not a binary\
-     """}
-  end
-
   defp error_info(erl_exception, stacktrace) do
     with [{module, _, args_or_arity, opts} | _] <- stacktrace,
          %{} = error_info <- opts[:error_info] do

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -205,17 +205,17 @@ defmodule CodeTest do
       end
     end
 
-    test "raises streamlined argument errors" do
+    test "raises ArgumentError for <> operator" do
       assert_raise ArgumentError,
-                   ~r"argument error while evaluating at line 1",
+                   ~r"expected binary argument in <> operator",
                    fn -> Code.eval_string("a <> b", a: :a, b: :b) end
 
       assert_raise ArgumentError,
-                   ~r"argument error while evaluating example.ex at line 1",
+                   ~r"expected binary argument in <> operator",
                    fn -> Code.eval_string("a <> b", [a: :a, b: :b], file: "example.ex") end
 
       assert_raise ArgumentError,
-                   ~r"argument error while evaluating example.ex between lines 1 and 2",
+                   ~r"expected binary argument in <> operator",
                    fn -> Code.eval_string("a <>\nb", [a: :a, b: :b], file: "example.ex") end
     end
   end

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -2485,12 +2485,6 @@ defmodule Kernel.ExpansionTest do
     test "merges binaries" do
       import Kernel, except: [-: 2]
 
-      assert expand(quote(do: "foo" <> x)) |> clean_meta([:alignment]) ==
-               quote(do: <<"foo"::binary(), x()::binary()>>)
-
-      assert expand(quote(do: "foo" <> <<x::size(4), y::size(4)>>)) |> clean_meta([:alignment]) ==
-               quote(do: <<"foo"::binary(), x()::integer()-size(4), y()::integer()-size(4)>>)
-
       assert expand(quote(do: <<"foo", <<x::size(4), y::size(4)>>::binary>>))
              |> clean_meta([:alignment]) ==
                quote(do: <<"foo"::binary(), x()::integer()-size(4), y()::integer()-size(4)>>)

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -83,6 +83,46 @@ defmodule KernelTest do
     end
   end
 
+  describe "<>/2" do
+    test "works with literal binaries" do
+      assert "concate" <> "nation" == "concatenation"
+      assert "123" <> "456" == "123456"
+    end
+
+    test "works with runtime binaries" do
+      a = "concate"
+      b = "nation"
+
+      assert a <> b == "concatenation"
+      assert b <> a == "nationconcate"
+      assert b <> b == "nationnation"
+
+      defmodule Test.Utils do
+        def concate_string(a, b), do: a <> b
+      end
+
+      assert Test.Utils.concate_string("it ", "works!") == "it works!"
+      assert Test.Utils.concate_string(a, b) == "concatenation"
+    end
+
+    test "fails with non-binaries but a sweet error" do
+      a = "concate"
+      b = 2
+
+      assert_raise ArgumentError, "expected binary argument in <> operator", fn ->
+        a <> b
+      end
+
+      assert_raise ArgumentError, "expected binary argument in <> operator", fn ->
+        b <> a
+      end
+
+      assert_raise ArgumentError, "expected binary argument in <> operator", fn ->
+        b <> b
+      end
+    end
+  end
+
   test "=~/2" do
     assert "abcd" =~ ~r/c(d)/ == true
     assert "abcd" =~ ~r/e/ == false


### PR DESCRIPTION
Currently the concat operator has variant responses for different scenarios, for example:

```elixir
# Using literals
iex> "" <> 1
** (ArgumentError) expected binary argument in <> operator but got: 1

# Using non-literals
iex> a = ""
iex> b = 3
iex> a <> B
** (ArgumentError) argument error while evaluating iex at line 2

# Using variables that are going to be solved at runtime
defmodule T do
  def f(a, b), do: a <> b  
end

iex> a = ""
iex> b = 2
iex> T.f(a, b)
# badarg error
* 1st argument: not a bitstring     This typically happens when calling Kernel.byte_size/1 with an invalid argument     or when performing binary concatenation with &lt;&gt; and one of the arguments is not a binary\

iex> T.f(b, a)
...
# just a generic error that doesn't fit any of the cases above
```

Because of that, I wanted to leave these changes here as a suggestion to improve the development experience.

The idea is to "double-check" the left and right side hands at the end, in order to ensure that both sides are binaries.

And since it's going add a couple of checks and validations into the generated AST, we wouldn't be able to compare concat operations with merging binaries operations, I'm not sure if this is a problem at all. (?)

Also, this is only going to affect operations that aren't in guard/match context; otherwise it's the same as it was before.


What do you think?