### PR TITLE
fix: docs for <>/2 operator

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1883,6 +1883,8 @@ defmodule Kernel do
   @doc """
   Binary concatenation operator. Concatenates two binaries.
 
+  Raises an `ArgumentError` if one of the sides aren't binaries.
+
   ## Examples
 
       iex> "foo" <> "bar"
@@ -1895,7 +1897,7 @@ defmodule Kernel do
       iex> x
       "bar"
 
-  `x <> "bar" = "foobar"` would have resulted in a `CompileError` exception.
+  `x <> "bar" = "foobar"` would result in an `ArgumentError` exception.
 
   """
   defmacro left <> right do


### PR DESCRIPTION
Add exception details for docs.

When using `<>/2` for pattern matching, the match should always happen on the RHS (right hand side) var, if it doesn't, then you'll get an ArgumentError with:
```
** (ArgumentError) the left argument of <> operator inside a match should always be a literal binary because its size can't be verified. Got: x
```
