### PR TITLE
Update sigil_r use as per docs

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -371,7 +371,7 @@ defmodule Regex do
 
   ## Examples
 
-      iex> Regex.source(~r(foo))
+      iex> Regex.source(~r/foo/)
       "foo"
 
   """
@@ -385,7 +385,7 @@ defmodule Regex do
 
   ## Examples
 
-      iex> Regex.opts(~r(foo)m)
+      iex> Regex.opts(~r/foo/m)
       "m"
 
   """

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -296,17 +296,17 @@ defmodule RegexTest do
   end
 
   test "replace/3,4" do
-    assert Regex.replace(~r(d), "abc", "d") == "abc"
-    assert Regex.replace(~r(b), "abc", "d") == "adc"
-    assert Regex.replace(~r(b), "abc", "[\\0]") == "a[b]c"
+    assert Regex.replace(~r/d/, "abc", "d") == "abc"
+    assert Regex.replace(~r/b/, "abc", "d") == "adc"
+    assert Regex.replace(~r/b/, "abc", "[\\0]") == "a[b]c"
     assert Regex.replace(~r[(b)], "abc", "[\\1]") == "a[b]c"
     assert Regex.replace(~r[(b)], "abc", "[\\2]") == "a[]c"
     assert Regex.replace(~r[(b)], "abc", "[\\3]") == "a[]c"
-    assert Regex.replace(~r(b), "abc", "[\\g{0}]") == "a[b]c"
+    assert Regex.replace(~r/b/, "abc", "[\\g{0}]") == "a[b]c"
     assert Regex.replace(~r[(b)], "abc", "[\\g{1}]") == "a[b]c"
 
-    assert Regex.replace(~r(b), "abcbe", "d") == "adcde"
-    assert Regex.replace(~r(b), "abcbe", "d", global: false) == "adcbe"
+    assert Regex.replace(~r/b/, "abcbe", "d") == "adcde"
+    assert Regex.replace(~r/b/, "abcbe", "d", global: false) == "adcbe"
 
     assert Regex.replace(~r/ /, "first third", "\\second\\") == "first\\second\\third"
     assert Regex.replace(~r/ /, "first third", "\\\\second\\\\") == "first\\second\\third"

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -592,12 +592,12 @@ defmodule ExUnit.AssertionsTest do
   end
 
   test "assert regex match" do
-    true = assert "foo" =~ ~r(o)
+    true = assert "foo" =~ ~r/o/
   end
 
   test "assert regex match when no match" do
     try do
-      "This should never be tested" = assert "foo" =~ ~r(a)
+      "This should never be tested" = assert "foo" =~ ~r/a/
     rescue
       error in [ExUnit.AssertionError] ->
         "foo" = error.left
@@ -606,12 +606,12 @@ defmodule ExUnit.AssertionsTest do
   end
 
   test "refute regex match" do
-    false = refute "foo" =~ ~r(a)
+    false = refute "foo" =~ ~r/a/
   end
 
   test "refute regex match when match" do
     try do
-      "This should never be tested" = refute "foo" =~ ~r(o)
+      "This should never be tested" = refute "foo" =~ ~r/o/
     rescue
       error in [ExUnit.AssertionError] ->
         "foo" = error.left

--- a/lib/mix/test/mix/tasks/deps.git_test.exs
+++ b/lib/mix/test/mix/tasks/deps.git_test.exs
@@ -507,7 +507,7 @@ defmodule Mix.Tasks.DepsGitTest do
 
   defp get_git_repo_revs(repo) do
     File.cd!(fixture_path(repo), fn ->
-      Regex.split(~r(\r?\n), System.cmd("git", ["log", "--format=%H"]) |> elem(0))
+      Regex.split(~r/\r?\n/, System.cmd("git", ["log", "--format=%H"]) |> elem(0))
     end)
   end
 end

--- a/lib/mix/test/mix/tasks/local.public_keys_test.exs
+++ b/lib/mix/test/mix/tasks/local.public_keys_test.exs
@@ -44,7 +44,7 @@ defmodule Mix.Tasks.Local.PublicKeysTest do
   end
 
   test "raises on bad public keys on install" do
-    assert_raise Mix.Error, ~r(Could not decode public key:), fn ->
+    assert_raise Mix.Error, ~r/Could not decode public key:/, fn ->
       path = tmp_path("bad.pub")
       File.write!(path, "oops")
       send(self(), {:mix_shell_input, :yes?, true})

--- a/lib/mix/test/mix/tasks/profile.cprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.cprof_test.exs
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.Profile.CprofTest do
     in_tmp(context.test, fn ->
       assert capture_io(fn ->
                Cprof.run(["-e", @expr])
-             end) =~ ~r(String\.Chars\.Integer\.to_string\/1 *\d)
+             end) =~ ~r/String\.Chars\.Integer\.to_string\/1 *\d/
     end)
   end
 
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Profile.CprofTest do
 
       assert capture_io(fn ->
                Cprof.run([profile_script_name])
-             end) =~ ~r(String\.Chars\.Integer\.to_string\/1 *\d)
+             end) =~ ~r/String\.Chars\.Integer\.to_string\/1 *\d/
     end)
   end
 
@@ -32,7 +32,7 @@ defmodule Mix.Tasks.Profile.CprofTest do
     in_tmp(context.test, fn ->
       refute capture_io(fn ->
                Cprof.run(["--limit", "5", "-e", @expr])
-             end) =~ ~r(:erlang\.trace_pattern\/3 *\d)
+             end) =~ ~r/:erlang\.trace_pattern\/3 *\d/
     end)
   end
 
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.Profile.CprofTest do
     in_tmp(context.test, fn ->
       refute capture_io(fn ->
                Cprof.run(["--module", "Enum", "-e", @expr])
-             end) =~ ~r(String\.Chars\.Integer\.to_string\/1 *\d)
+             end) =~ ~r/String\.Chars\.Integer\.to_string\/1 *\d/
     end)
   end
 
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.Profile.CprofTest do
     in_tmp(context.test, fn ->
       refute capture_io(fn ->
                Cprof.run(["--matching", "Enum", "-e", @expr])
-             end) =~ ~r(String\.Chars\.Integer\.to_string\/1 *\d)
+             end) =~ ~r/String\.Chars\.Integer\.to_string\/1 *\d/
     end)
   end
 
@@ -56,7 +56,7 @@ defmodule Mix.Tasks.Profile.CprofTest do
     in_tmp(context.test, fn ->
       refute capture_io(fn ->
                Cprof.run(["--matching", "Enum.each", "-e", @expr])
-             end) =~ ~r(anonymous fn\/3 in Enum\.each\/2 *\d)
+             end) =~ ~r/anonymous fn\/3 in Enum\.each\/2 *\d/
     end)
   end
 
@@ -64,7 +64,7 @@ defmodule Mix.Tasks.Profile.CprofTest do
     in_tmp(context.test, fn ->
       assert capture_io(fn ->
                Cprof.run(["--matching", "Enum.each/8", "-e", @expr])
-             end) =~ ~r(Profile done over 0 matching functions)
+             end) =~ ~r/Profile done over 0 matching functions/
     end)
   end
 

--- a/lib/mix/test/mix/tasks/profile.eprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.eprof_test.exs
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.Profile.EprofTest do
     in_tmp(context.test, fn ->
       assert capture_io(fn ->
                Eprof.run(["-e", @expr])
-             end) =~ ~r(String\.Chars\.Integer\.to_string\/1\s+\d)
+             end) =~ ~r/String\.Chars\.Integer\.to_string\/1\s+\d/
     end)
   end
 
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.Profile.EprofTest do
     in_tmp(context.test, fn ->
       assert capture_io(fn ->
                Eprof.run(["-e", "spawn(fn -> #{@expr} end)"])
-             end) =~ ~r(String\.Chars\.Integer\.to_string\/1\s+\d)
+             end) =~ ~r/String\.Chars\.Integer\.to_string\/1\s+\d/
     end)
   end
 
@@ -31,7 +31,7 @@ defmodule Mix.Tasks.Profile.EprofTest do
 
       assert capture_io(fn ->
                Eprof.run([profile_script_name])
-             end) =~ ~r(String\.Chars\.Integer\.to_string\/1\s+\d)
+             end) =~ ~r/String\.Chars\.Integer\.to_string\/1\s+\d/
     end)
   end
 
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.Profile.EprofTest do
     in_tmp(context.test, fn ->
       assert capture_io(fn ->
                Eprof.run(["--sort", "calls", "-e", @expr])
-             end) =~ ~r(erlang\.apply\/2.*String\.Chars\.Integer\.to_string\/1)s
+             end) =~ ~r/erlang\.apply\/2.*String\.Chars\.Integer\.to_string\/1/s
     end)
   end
 
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.Profile.EprofTest do
     in_tmp(context.test, fn ->
       refute capture_io(fn ->
                Eprof.run(["--matching", "Enum", "-e", @expr])
-             end) =~ ~r(String\.Chars\.Integer\.to_string\/1)
+             end) =~ ~r/String\.Chars\.Integer\.to_string\/1/
     end)
   end
 
@@ -63,7 +63,7 @@ defmodule Mix.Tasks.Profile.EprofTest do
     in_tmp(context.test, fn ->
       refute capture_io(fn ->
                Eprof.run(["--matching", "Enum.each", "-e", @expr])
-             end) =~ ~r(anonymous fn\/3 in Enum\.each\/2)
+             end) =~ ~r/anonymous fn\/3 in Enum\.each\/2/
     end)
   end
 
@@ -71,7 +71,7 @@ defmodule Mix.Tasks.Profile.EprofTest do
     in_tmp(context.test, fn ->
       assert capture_io(fn ->
                Eprof.run(["--matching", "Enum.each/8", "-e", @expr])
-             end) =~ ~r(Profile done over 0 matching functions)
+             end) =~ ~r/Profile done over 0 matching functions/
     end)
   end
 

--- a/lib/mix/test/mix/tasks/profile.fprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.fprof_test.exs
@@ -42,10 +42,10 @@ defmodule Mix.Tasks.Profile.FprofTest do
         "spawn(fn -> Process.sleep(:infinity) end); Enum.each(1..5, fn(_) -> MapSet.new() end)"
 
       output = capture_io(fn -> Fprof.run(["-e", expr, "--details"]) end)
-      assert output =~ ~r(#{:erlang.pid_to_list(self())} +\d+ +\d+\.\d{3})
-      assert output =~ ~r(spawned by #{:erlang.pid_to_list(self())})
-      assert output =~ ~r(as :erlang.apply)
-      assert output =~ ~r(initial calls:)
+      assert output =~ ~r/#{:erlang.pid_to_list(self())} +\d+ +\d+\.\d{3}/
+      assert output =~ ~r/spawned by #{:erlang.pid_to_list(self())}/
+      assert output =~ ~r/as :erlang.apply/
+      assert output =~ ~r/initial calls:/
     end)
   end
 


### PR DESCRIPTION
As per docs https://github.com/elixir-lang/elixir/pull/11051, using `~r//` is recommended over using `~r()`. This PR updates the sigil_r delimiter used at multiple places.