### PR TITLE
Add parser_options to EEx.Compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 #### EEx
 
+  * [Code] Added `:parser_options` to EEx functions
+
 #### Elixir
 
   * [Code] Add `Code.string_to_quoted_with_comments/2` and `Code.quoted_to_algebra/2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### EEx
 
-  * [Code] Added `:parser_options` to EEx functions
+  * [Code] Add `:parser_options` to EEx functions
 
 #### Elixir
 

--- a/lib/eex/lib/eex.ex
+++ b/lib/eex/lib/eex.ex
@@ -48,6 +48,9 @@ defmodule EEx do
     * `:trim` - if `true`, trims whitespace left and right of quotation as
       long as at least one newline is present. All subsequent newlines and
       spaces are removed but one newline is retained. Defaults to `false`.
+    * `:parser_options` - allow customizing the parsed code that is generated.
+      See `Code.string_to_quoted/2` for available options. Note that the options
+      `:file`, `:line` and `:column` are ignored if passed in.
 
   ## Engine
 

--- a/lib/eex/lib/eex.ex
+++ b/lib/eex/lib/eex.ex
@@ -51,6 +51,7 @@ defmodule EEx do
     * `:parser_options` - allow customizing the parsed code that is generated.
       See `Code.string_to_quoted/2` for available options. Note that the options
       `:file`, `:line` and `:column` are ignored if passed in.
+      Defaults to `Code.get_compiler_option(:parser_options)` (which defaults to `[]` if not set).
 
   ## Engine
 

--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -16,7 +16,7 @@ defmodule EEx.Compiler do
     column = 1
     indentation = opts[:indentation] || 0
     trim = opts[:trim] || false
-    parser_options = opts[:parser_options] || []
+    parser_options = opts[:parser_options] || Code.get_compiler_option(:parser_options)
     tokenizer_options = %{trim: trim, indentation: indentation}
 
     case EEx.Tokenizer.tokenize(source, line, column, tokenizer_options) do
@@ -28,7 +28,7 @@ defmodule EEx.Compiler do
           quoted: [],
           start_line: nil,
           start_column: nil,
-          parser_options: Code.get_compiler_option(:parser_options) ++ parser_options
+          parser_options: parser_options
         }
 
         init = state.engine.init(opts)

--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -16,6 +16,7 @@ defmodule EEx.Compiler do
     column = 1
     indentation = opts[:indentation] || 0
     trim = opts[:trim] || false
+    parser_options = opts[:parser_options] || []
     tokenizer_options = %{trim: trim, indentation: indentation}
 
     case EEx.Tokenizer.tokenize(source, line, column, tokenizer_options) do
@@ -27,7 +28,7 @@ defmodule EEx.Compiler do
           quoted: [],
           start_line: nil,
           start_column: nil,
-          parser_options: Code.get_compiler_option(:parser_options)
+          parser_options: Code.get_compiler_option(:parser_options) ++ parser_options
         }
 
         init = state.engine.init(opts)

--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -719,7 +719,7 @@ defmodule EExTest do
   end
 
   describe "parser options" do
-    test "are used" do
+    test "customizes parsed code" do
       atoms_encoder = fn "not_jose", _ -> {:ok, :jose} end
 
       assert_eval("valid", "<%= not_jose %>", [jose: "valid"],

--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -718,6 +718,16 @@ defmodule EExTest do
     end
   end
 
+  describe "parser options" do
+    test "are used" do
+      atoms_encoder = fn "not_jose", _ -> {:ok, :jose} end
+
+      assert_eval("valid", "<%= not_jose %>", [jose: "valid"],
+        parser_options: [static_atoms_encoder: atoms_encoder]
+      )
+    end
+  end
+
   defp assert_eval(expected, actual, binding \\ [], opts \\ []) do
     opts = Keyword.merge([file: __ENV__.file, engine: opts[:engine] || EEx.Engine], opts)
     result = EEx.eval_string(actual, binding, opts)


### PR DESCRIPTION
As per https://groups.google.com/g/elixir-lang-core/c/Z-C2PFRwyw4
This PR adds the `:parser_options` option to `EEx.Compiler` which allows passing in custom options without having to modify the global options through `Code.put_compiler_option/2`
