### PR TITLE
Optimize Enum.concat/1 for lists of lists

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3780,7 +3780,7 @@ defmodule Enum do
 
   defp concat_enum(enum) do
     fun = &[&1 | &2]
-    enum |> Enum.reduce([], &Enum.reduce(&1, &2, fun)) |> :lists.reverse()
+    enum |> reduce([], &reduce(&1, &2, fun)) |> :lists.reverse()
   end
 
   # dedup

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -599,8 +599,11 @@ defmodule Enum do
   """
   @spec concat(t) :: t
   def concat(enumerables) do
-    fun = &[&1 | &2]
-    enumerables |> reduce([], &reduce(&1, &2, fun)) |> :lists.reverse()
+    if is_list(enumerables) and :lists.all(&is_list/1, enumerables) do
+      concat_list(enumerables)
+    else
+      concat_enum(enumerables)
+    end
   end
 
   @doc """
@@ -625,7 +628,7 @@ defmodule Enum do
   end
 
   def concat(left, right) do
-    concat([left, right])
+    concat_enum([left, right])
   end
 
   @doc """
@@ -3767,6 +3770,17 @@ defmodule Enum do
 
   defp any_list([], _) do
     false
+  end
+
+  ## concat
+
+  defp concat_list(enumerables) do
+    :lists.append(enumerables)
+  end
+
+  defp concat_enum(enumerables) do
+    fun = &[&1 | &2]
+    enumerables |> reduce([], &reduce(&1, &2, fun)) |> :lists.reverse()
   end
 
   # dedup

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -598,12 +598,12 @@ defmodule Enum do
 
   """
   @spec concat(t) :: t
-  def concat(enumerables) do
-    if is_list(enumerables) and :lists.all(&is_list/1, enumerables) do
-      concat_list(enumerables)
-    else
-      concat_enum(enumerables)
-    end
+  def concat(list) when is_list(list) do
+    concat_list(list)
+  end
+
+  def concat(enums) do
+    concat_enum(enums)
   end
 
   @doc """
@@ -3774,13 +3774,13 @@ defmodule Enum do
 
   ## concat
 
-  defp concat_list(enumerables) do
-    :lists.append(enumerables)
-  end
+  defp concat_list([h | t]) when is_list(h), do: h ++ concat_list(t)
+  defp concat_list([h | t]), do: concat_enum([h | t])
+  defp concat_list([]), do: []
 
-  defp concat_enum(enumerables) do
+  defp concat_enum(enum) do
     fun = &[&1 | &2]
-    enumerables |> reduce([], &reduce(&1, &2, fun)) |> :lists.reverse()
+    enum |> Enum.reduce([], &Enum.reduce(&1, &2, fun)) |> :lists.reverse()
   end
 
   # dedup


### PR DESCRIPTION
This is building off the closed pull request here: https://github.com/elixir-lang/elixir/pull/11034, where it was observed that `:lists.append/1` out performs `Enum.concat/1` for lists of lists. 

I've made a change so that `:lists.append/1` is used when a list of lists is passed into `Enum.concat/1`, otherwise it will default to the previous implementation. 

I've run some benchmarks of my own that confirm the insights from the previous pull request: https://github.com/greg-rychlewski/concat-test/blob/master/benchmark.exs.

Here is the output for the benchmarks:

```
##### With input large #####
Name               ips        average  deviation         median         99th %
proposal        709.45        1.41 ms    ±40.08%        1.30 ms        4.12 ms
master          376.83        2.65 ms    ±27.31%        2.49 ms        5.39 ms

Comparison: 
proposal        709.45
master          376.83 - 1.88x slower +1.24 ms

##### With input medium #####
Name               ips        average  deviation         median         99th %
proposal       13.91 K       71.90 μs    ±38.63%       64.99 μs      161.99 μs
master          5.64 K      177.17 μs    ±21.97%      159.99 μs      290.99 μs

Comparison: 
proposal       13.91 K
master          5.64 K - 2.46x slower +105.27 μs

##### With input small #####
Name               ips        average  deviation         median         99th %
proposal        1.17 M        0.86 μs  ±3090.98%        0.99 μs        0.99 μs
master          0.46 M        2.15 μs  ±1285.91%        1.99 μs        3.99 μs

Comparison: 
proposal        1.17 M
master          0.46 M - 2.51x slower +1.29 μs
``` 

