### PR TITLE
Update reference to IRC channel in CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -41,7 +41,7 @@ Explicit enforcement of the Code of Conduct applies to the official mediums oper
 
 * The [official GitHub projects][1] and code reviews.
 * The official elixir-lang mailing lists.
-* The **[#elixir-lang][2]** IRC channel on [Freenode][3].
+* The **#elixir** IRC channel on [Libera.Chat][2].
 
 Other Elixir activities (such as conferences, meetups, and unofficial forums) are encouraged to adopt this Code of Conduct. Such groups must provide their own contact information.
 
@@ -56,5 +56,4 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 This document was based on the Code of Conduct from the Go project with parts derived from Django's Code of Conduct, Rust's Code of Conduct and the Contributor Covenant.
 
 [1]: https://github.com/elixir-lang/
-[2]: https://webchat.freenode.net/?channels=#elixir-lang
-[3]: https://www.freenode.net
+[2]: https://libera.chat/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -41,7 +41,7 @@ Explicit enforcement of the Code of Conduct applies to the official mediums oper
 
 * The [official GitHub projects][1] and code reviews.
 * The official elixir-lang mailing lists.
-* The **#elixir** IRC channel on [Libera.Chat][2].
+* The **[#elixir][2]** IRC channel on [Libera.Chat][3].
 
 Other Elixir activities (such as conferences, meetups, and unofficial forums) are encouraged to adopt this Code of Conduct. Such groups must provide their own contact information.
 
@@ -56,4 +56,5 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 This document was based on the Code of Conduct from the Go project with parts derived from Django's Code of Conduct, Rust's Code of Conduct and the Contributor Covenant.
 
 [1]: https://github.com/elixir-lang/
-[2]: https://libera.chat/
+[2]: https://web.libera.chat/#elixir
+[3]: https://libera.chat/


### PR DESCRIPTION
There isn't currently an official Webchat for Libera, so I wanted to change the link to an IRCS protocol link. But it seems GitHub won't render it as a link even if I use an inline link style (see: https://github.com/github/markup/issues/426). So in the end I removed the channel link.