### PR TITLE
Rely on modification time and hash to determine modified sources

### DIFF
--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -463,7 +463,8 @@ defmodule Mix.Compilers.Elixir do
     source =
       source(
         source,
-        digest: digest(file),
+        # We preserve the digest if the file is recompiled but not changed
+        digest: source(source, :digest) || digest(file),
         compile_references: compile_references,
         export_references: export_references,
         runtime_references: runtime_references,

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -195,7 +195,39 @@ defmodule Mix.Tasks.Compile.ElixirTest do
     end)
   end
 
-  test "compiles mtime changed files" do
+  test "compiles mtime changed files if content changed but not length" do
+    in_fixture("no_mixfile", fn ->
+      assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
+      assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+      assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+
+      Mix.shell().flush
+      purge([A, B])
+
+      same_length_content = "lib/a.ex" |> File.read!() |> String.replace("A", "Z")
+      File.write!("lib/a.ex", same_length_content)
+      future = {{2038, 1, 1}, {0, 0, 0}}
+      File.touch!("lib/a.ex", future)
+      Mix.Tasks.Compile.Elixir.run(["--verbose"])
+
+      message =
+        "warning: mtime (modified time) for \"lib/a.ex\" was set to the future, resetting to now"
+
+      assert_received {:mix_shell, :error, [^message]}
+
+      message =
+        "warning: mtime (modified time) for \"lib/b.ex\" was set to the future, resetting to now"
+
+      refute_received {:mix_shell, :error, [^message]}
+      assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+      refute_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+
+      File.touch!("_build/dev/lib/sample/.mix/compile.elixir", future)
+      assert Mix.Tasks.Compile.Elixir.run([]) == {:noop, []}
+    end)
+  end
+
+  test "does not recompile mtime changed but identical files" do
     in_fixture("no_mixfile", fn ->
       assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
@@ -217,7 +249,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
         "warning: mtime (modified time) for \"lib/b.ex\" was set to the future, resetting to now"
 
       refute_received {:mix_shell, :error, [^message]}
-      assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+      refute_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
       refute_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
 
       File.touch!("_build/dev/lib/sample/.mix/compile.elixir", future)

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -257,8 +257,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       Mix.shell().flush
       purge([A, B])
 
-      future = {{2038, 1, 1}, {0, 0, 0}}
-      File.touch!("lib/b.ex", future)
+      force_recompilation("lib/b.ex")
       Mix.Tasks.Compile.Elixir.run(["--verbose"])
 
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
@@ -283,7 +282,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
 
       Code.put_compiler_option(:ignore_module_conflict, true)
       Code.compile_file("lib/b.ex")
-      File.touch!("lib/a.ex", {{2038, 1, 1}, {0, 0, 0}})
+      force_recompilation("lib/a.ex")
 
       Mix.Tasks.Compile.Elixir.run(["--verbose"])
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
@@ -472,8 +471,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
       purge([A, B])
 
-      future = {{2038, 1, 1}, {0, 0, 0}}
-      File.touch!("lib/a.ex", future)
+      force_recompilation("lib/a.ex")
 
       assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
@@ -615,8 +613,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       Mix.shell().flush
       purge([A, B])
 
-      future = {{2038, 1, 1}, {0, 0, 0}}
-      File.touch!("lib/a.ex", future)
+      force_recompilation("lib/a.ex")
       Mix.Tasks.Compile.Elixir.run(["--verbose"])
 
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -68,12 +68,12 @@ defmodule Mix.Tasks.TestTest do
         assert_stale_run_output("2 tests, 0 failures")
 
         set_all_mtimes()
-        File.touch!("lib/b.ex")
+        force_recompilation("lib/b.ex")
 
         assert_stale_run_output("1 test, 0 failures")
 
         set_all_mtimes()
-        File.touch!("lib/a.ex")
+        force_recompilation("lib/a.ex")
 
         assert_stale_run_output("2 tests, 0 failures")
       end)

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -179,6 +179,10 @@ defmodule MixTest.Case do
     ])
   end
 
+  def force_recompilation(file) do
+    File.write!(file, File.read!(file) <> "\n")
+  end
+
   defp mix_executable do
     Path.expand("../../../bin/mix", __DIR__)
   end


### PR DESCRIPTION
As discussed [on the mailing list](https://groups.google.com/g/elixir-lang-core/c/8-30JVn_8M0/m/hUWxonjwAQAJ), I think this adds the right check by hashing the content, but I'm lacking tests.

Does it look like I'm on the right track?