### PR TITLE
Optimize Enum.zip/2

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -4228,13 +4228,12 @@ defmodule Enum do
 
   ## zip
 
-  defp zip_list(list1, list2, acc) when list1 == [] or list2 == [] do
-    :lists.reverse(acc)
-  end
-
   defp zip_list([head1 | next1], [head2 | next2], acc) do
     zip_list(next1, next2, [{head1, head2} | acc])
   end
+
+  defp zip_list([], _, acc), do: :lists.reverse(acc)
+  defp zip_list(_, [], acc), do: :lists.reverse(acc)
 
   defp zip_with_list([head1 | next1], [head2 | next2], fun) do
     [fun.(head1, head2) | zip_with_list(next1, next2, fun)]

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3435,7 +3435,7 @@ defmodule Enum do
   """
   @spec zip(t, t) :: [{any, any}]
   def zip(enumerable1, enumerable2) when is_list(enumerable1) and is_list(enumerable2) do
-    zip_list(enumerable1, enumerable2)
+    zip_list(enumerable1, enumerable2, [])
   end
 
   def zip(enumerable1, enumerable2) do
@@ -3508,7 +3508,7 @@ defmodule Enum do
   @spec zip_with(t, t, (enum1_elem :: term, enum2_elem :: term -> term)) :: [term]
   def zip_with(enumerable1, enumerable2, zip_fun)
       when is_list(enumerable1) and is_list(enumerable2) and is_function(zip_fun, 2) do
-    zip_list(enumerable1, enumerable2, zip_fun)
+    zip_with_list(enumerable1, enumerable2, zip_fun)
   end
 
   def zip_with(enumerable1, enumerable2, zip_fun) when is_function(zip_fun, 2) do
@@ -4228,16 +4228,20 @@ defmodule Enum do
 
   ## zip
 
-  defp zip_list(enumerable1, enumerable2) do
-    zip_list(enumerable1, enumerable2, fn x, y -> {x, y} end)
+  defp zip_list(list1, list2, acc) when list1 == [] or list2 == [] do
+    :lists.reverse(acc)
   end
 
-  defp zip_list([head1 | next1], [head2 | next2], fun) do
-    [fun.(head1, head2) | zip_list(next1, next2, fun)]
+  defp zip_list([head1 | next1], [head2 | next2], acc) do
+    zip_list(next1, next2, [{head1, head2} | acc])
   end
 
-  defp zip_list(_, [], _fun), do: []
-  defp zip_list([], _, _fun), do: []
+  defp zip_with_list([head1 | next1], [head2 | next2], fun) do
+    [fun.(head1, head2) | zip_with_list(next1, next2, fun)]
+  end
+
+  defp zip_with_list(_, [], _fun), do: []
+  defp zip_with_list([], _, _fun), do: []
 
   defp zip_reduce_list([head1 | next1], [head2 | next2], acc, fun) do
     zip_reduce_list(next1, next2, fun.(head1, head2, acc), fun)


### PR DESCRIPTION
Hi! I noticed that the generic implementation of `Enum.zip/2` relying on `zip_with` with an anonymous function was significantly slower on lists than having dedicated private functions.
Some quick benchmarks suggest a speedup of 2.5~3x compared to the current implementation:
https://github.com/sabiwara/elixir_benches/blob/main/bench/fast_enum_zip.results.txt

Note: I went with a tail-recursive implementation, but I benchmarked [a body-recursive version](https://github.com/sabiwara/elixir_benches/commit/608d9fd786061e8d719331f9a706770fc8062796) as well and it seems noticeably slower (due to the JIT?) so I kept the former.