### PR TITLE
Fix normalization of partial keyword list elements

### DIFF
--- a/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
@@ -469,6 +469,10 @@ defmodule Code.Normalizer.QuotedASTTest do
       assert quoted_to_string(quote(do: [a: 1, b: 1 + 2])) == "[a: 1, b: 1 + 2]"
       assert quoted_to_string(quote(do: ["a.b": 1, c: 1 + 2])) == "[\"a.b\": 1, c: 1 + 2]"
 
+      tuple = {{:__block__, [format: :keyword], [:a]}, {:b, [], nil}}
+      assert quoted_to_string([tuple, :foo, tuple]) == "[{:a, b}, :foo, a: b]"
+      assert quoted_to_string([tuple, :foo, {:c, :d}, tuple]) == "[{:a, b}, :foo, c: :d, a: b]"
+
       # Not keyword lists
       assert quoted_to_string(quote(do: [{binary(), integer()}])) == "[{binary(), integer()}]"
     end


### PR DESCRIPTION
The Elixir.Normalizer lets us feed any arbitrary AST to the formatter, but if the user provides a list, and an element is a 2-tuple that is not one of the last elements, and the first element is a wrapped atom with `format: :keyword` metadata, then the formatter will happily print it as a keyword list element, despite it being invalid syntax, for example:
```elixir
iex> opts = [literal_encoder: &{:ok, {:__block__, &2, [&1]}}]
iex> {_, _, [[tuple]]} = Code.string_to_quoted("[a: b]", opts)
iex> Macro.to_string([tuple, :not_a_tuple, tuple])
"[a: b, :not_a_tuple, a: b]"
```
With this PR we would get the expected output:
```elixir
iex> Macro.to_string([tuple, :not_a_tuple, tuple])
"[{:a, b}, :not_a_tuple, a: b]"
```