### PR TITLE
`Map.values/2` to retrieve values in predicted order

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -132,7 +132,10 @@ defmodule Map do
   defdelegate keys(map), to: :maps
 
   @doc """
-  Returns all values from `map`.
+  Returns all values from `map`. Please note, that maps in `erlang` and `elixir`
+  are not ordered, meaning that the order of values would not be defined.
+
+  To retrieve a list of values in a predicted order, use `values/2`.
 
   Inlined by the compiler.
 
@@ -144,6 +147,21 @@ defmodule Map do
   """
   @spec values(map) :: [value]
   defdelegate values(map), to: :maps
+
+  @doc """
+  Returns all values from `map` for the keys given as the second argument.
+  The order of values is preserved.
+
+  ## Examples
+
+      iex> Map.values(%{a: 1, b: 2}, [:b, :a])
+      [2, 1]
+
+  """
+  @spec values(map, [key]) :: [value]
+  def values(map, keys) when is_map(map) and is_list(keys) do
+    for key <- keys, {:ok, value} <- [Map.fetch(map, key)], do: value
+  end
 
   @doc """
   Converts `map` to a list.

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -21,7 +21,7 @@ defmodule KeywordTest do
   end
 
   test "implements (almost) all functions in Map" do
-    assert Map.__info__(:functions) -- Keyword.__info__(:functions) == [from_struct: 1]
+    assert Map.__info__(:functions) -- Keyword.__info__(:functions) == [from_struct: 1, values: 2]
   end
 
   test "get_and_update/3 raises on bad return value from the argument function" do

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -247,6 +247,17 @@ defmodule MapTest do
     end
   end
 
+  test "values/2 preserving order" do
+    list = Enum.to_list(1..100)
+    map = list |> Enum.zip(list) |> Map.new()
+    reversed = Enum.reverse(list)
+
+    assert Map.values(map, list) == list
+    assert Map.values(map, [:unexpected | list]) == list
+    assert Map.values(map, [50]) == [50]
+    assert Map.values(map, reversed) == reversed
+  end
+
   defp empty_map(), do: %{}
 
   test "structs" do


### PR DESCRIPTION
`Map.values/1` delegates to `:maps.values/1` and since erlang maps are not ordered (when size is greater than 32,) the result of `Map.values(map)` might be confusing when `map_size(map) > 32`.

```elixir
list = Enum.to_list(1..33)
map = list |> Enum.zip(list) |> Map.new()

Map.values(map)   
#⇒ [33, 12, 23, 29, 30, 26, 31, 11, 9, …]
```

This PR provides `Map.values/2` function that accepts a list of keys to order returned values accordingly. This function might be particularly helpful when working with CSV-like inputs of considerable size using `Flow`, which is more friendly to maps in general and `key: {:key, name}` working with maps only in particular.

```elixir
Map.values(map, list)
#⇒ [1, 2, 3, 4, 5, 6, 7, 8, 9, …]
```

Despite this function might be easily implemented whenever needed outside of the core library, its existence would be a good hint reminding everybody that maps are not ordered and one should not rely on `Map.values/1` returning predictable and deterministic results.