### PR TITLE
Allow using XDG-conforming path for IEx config

### DIFF
--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -224,7 +224,8 @@ defmodule IEx.Evaluator do
       if path do
         [path]
       else
-        Enum.map([".iex.exs", "~/.iex.exs"], &Path.expand/1)
+        xdg_config = Path.join(:filename.basedir(:user_config, :elixir, %{os: :linux}), "iex.exs")
+        Enum.map([".iex.exs", xdg_config, "~/.iex.exs"], &Path.expand/1)
       end
 
     path = Enum.find(candidates, &File.regular?/1)


### PR DESCRIPTION
This adds new path - `$XDG_CONFIG_HOME/elixir/iex.exs` as a possible path for the configuration of IEx. If this file exists it will have higher priority over `$HOME/.iex.exs`.