### PR TITLE
add `Task.completed/1`

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -442,6 +442,48 @@ defmodule Task do
   end
 
   @doc """
+  Starts a task that immediately completes with the given `result`.
+
+  Unlike `async/1`, this task does not spawn a linked process. It can
+  be awaited or yielded like any other task.
+
+  ## Usage
+
+  In some cases, it is useful to create a "completed" task that represents
+  a task that has already run and generated a result. For example, when
+  processing data you may be able to determine that certain inputs are
+  invalid before dispatching them for further processing:
+
+      def process(data) do
+        tasks =
+          for entry <- data do
+            if invalid_input?(entry) do
+              Task.completed({:error, :invalid_input})
+            else
+              Task.async(fn -> further_process(entry) end)
+            end
+          end
+
+        Task.await_many(tasks)
+      end
+
+  In many cases, `Task.completed/1` may be avoided in favor of returning the
+  result directly.  You should generally only require this variant when working
+  with mixed asynchrony, when a group of inputs will be handled partially
+  synchronously and partially asynchronously.
+  """
+  @spec completed(any) :: t
+  def completed(result) do
+    ref = make_ref()
+    owner = self()
+
+    # "complete" the task immediately
+    send(owner, {ref, result})
+
+    %Task{pid: nil, ref: ref, owner: owner}
+  end
+
+  @doc """
   Returns a stream where the given function (`module` and `function_name`)
   is mapped concurrently on each element in `enumerable`.
 

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -148,6 +148,15 @@ defmodule TaskTest do
     assert_receive :done
   end
 
+  test "completed/1" do
+    task = Task.completed(:done)
+    assert task.__struct__ == Task
+
+    refute task.pid
+
+    assert Task.await(task) == :done
+  end
+
   test "start_link/1" do
     parent = self()
     fun = fn -> wait_and_send(parent, :done) end


### PR DESCRIPTION
This PR implements the new `Task` function `Task.completed/1` as proposed in the [elixir-lang group](https://groups.google.com/g/elixir-lang-core/c/ickqmBBoSMk/m/EGp507x9AAAJ?utm_medium=email&utm_source=footer).

This function models a task that immediately completes with a known result. As documented in the `@doc` block, it's a useful convenience when working with groups of asynchronous tasks where some inputs may have a result that can be determined without actually running the task. Here's a quick example:

```elixir
def process(data) do
  tasks =
    for entry <- data do
      if invalid_input?(entry) do
        Task.completed({:error, :invalid_input})
      else
        Task.async(fn -> further_process(entry) end)
      end
    end

  Task.await_many(tasks)
end
```

Here are a couple links to prior art in .NET:

https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.completedtask?view=net-5.0

https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.fromresult?view=net-5.0

Credit for the idea goes to @lukebakken.