### PR TITLE
Augment documentation for `Kernel.match?/2`; counsel caution when using the pin operator

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3247,20 +3247,21 @@ defmodule Kernel do
 
   Furthermore, please exercise caution when using the pin operator.
 
-      iex> match?(%{x: 1}, %{x: 1, y: 2})
-      true
-      iex> attrs = %{x: 1}
-      iex> match?(^attrs, %{x: 1, y: 2})
-      false
+      match?(%{x: 1}, %{x: 1, y: 2})
+      #=> true
+
+      attrs = %{x: 1}
+      match?(^attrs, %{x: 1, y: 2})
+      #=> false
 
   As a reminder, the pin operator binds _values,_ not _patterns_ (on the BEAM,
   patterns cannot be stored or composed in variables, as patterns are not a data
   type). Such behavior is not specific to `Kernel.match/2`. The following code
   will throw an exception:
 
-      iex> attrs = %{x: 1}
-      iex> ^attrs = %{x: 1, y: 2}
-      ** (MatchError) no match of right hand side value: %{x: 1, y: 2}
+      attrs = %{x: 1}
+      ^attrs = %{x: 1, y: 2}
+      #=> (MatchError) no match of right hand side value: %{x: 1, y: 2}
 
   """
   defmacro match?(pattern, expr) do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3245,6 +3245,23 @@ defmodule Kernel do
       iex> binding()
       []
 
+  Furthermore, please exercise caution when using the pin operator.
+
+      iex> match?(%{x: 1}, %{x: 1, y: 2})
+      true
+      iex> attrs = %{x: 1}
+      iex> match?(^attrs, %{x: 1, y: 2})
+      false
+
+  As a reminder, the pin operator binds _values,_ not _patterns_ (on the BEAM,
+  patterns cannot be stored or composed in variables, as patterns are not a data
+  type). Such behavior is not specific to `Kernel.match/2`. The following code
+  will throw an exception:
+
+      iex> attrs = %{x: 1}
+      iex> ^attrs = %{x: 1, y: 2}
+      ** (MatchError) no match of right hand side value: %{x: 1, y: 2}
+
   """
   defmacro match?(pattern, expr) do
     success =

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3245,7 +3245,7 @@ defmodule Kernel do
       iex> binding()
       []
 
-  Furthermore, please exercise caution when using the pin operator.
+  Furthermore, remember the pin operator matches _values_, not _patterns_:
 
       match?(%{x: 1}, %{x: 1, y: 2})
       #=> true
@@ -3254,10 +3254,10 @@ defmodule Kernel do
       match?(^attrs, %{x: 1, y: 2})
       #=> false
 
-  As a reminder, the pin operator binds _values,_ not _patterns_ (on the BEAM,
-  patterns cannot be stored or composed in variables, as patterns are not a data
-  type). Such behaviour is not specific to `Kernel.match/2`. The following code
-  will throw an exception:
+  The pin operator will check if the values are equal, using `===/2`, while
+  patterns have their own rules when matching maps, lists, and so forth.
+  Such behaviour is not specific to `match?/2`. The following code also
+  throws an exception:
 
       attrs = %{x: 1}
       ^attrs = %{x: 1, y: 2}

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3256,7 +3256,7 @@ defmodule Kernel do
 
   As a reminder, the pin operator binds _values,_ not _patterns_ (on the BEAM,
   patterns cannot be stored or composed in variables, as patterns are not a data
-  type). Such behavior is not specific to `Kernel.match/2`. The following code
+  type). Such behaviour is not specific to `Kernel.match/2`. The following code
   will throw an exception:
 
       attrs = %{x: 1}


### PR DESCRIPTION
## Description

This PR serves:

- To augment the annotation surrounding `Kernel.match?/2`; and specifically,
- To counsel caution when using the pin operator, namely by citing a misuse of the pin operator. 

## Context

I initially posted the [following question](https://elixir-lang.slack.com/archives/C03EPRA3B/p1626111373286800) in the `#general` channel of Elixir Slack:

> I’m curious why:
> 
> ```
> iex> match?(%{x: 1, y: 2}, %{x: 1, y: 2, z: 3})
> true
> iex> attrs = %{x: 1, y: 2}
> iex> match?(^attrs, %{x: 1, y: 2, z: 3})
> false
> ```
>
> ?

@LostKobrakai helped me to understand that I was misusing the pin operator. I've reworked @LostKobrakai's comments from Slack into the proposed annotations. 

The behaviour has snagged me a few times, and hence, I'm wondering whether we might augment the documentation surrounding `Kernel.match/2`? If only to help guide others who also misuse the pin operator? 

If you all find the enclosed annotations impertinent, I understand that, too! Thank you. 