### PR TITLE
Support sparse patterns in Mix.SCM.Git

### DIFF
--- a/lib/mix/lib/mix/scm/git.ex
+++ b/lib/mix/lib/mix/scm/git.ex
@@ -31,10 +31,7 @@ defmodule Mix.SCM.Git do
   end
 
   def accepts_options(_app, opts) do
-    opts =
-      opts
-      |> Keyword.put(:checkout, opts[:dest])
-      |> sparse_opts()
+    opts = Keyword.put(opts, :checkout, opts[:dest])
 
     cond do
       gh = opts[:github] ->
@@ -135,18 +132,10 @@ defmodule Mix.SCM.Git do
     get_lock(opts)
   end
 
-  defp sparse_opts(opts) do
-    if opts[:sparse] do
-      dest = Path.join(opts[:dest], opts[:sparse])
-      Keyword.put(opts, :dest, dest)
-    else
-      opts
-    end
-  end
-
   defp sparse_toggle(opts) do
     cond do
       sparse = opts[:sparse] ->
+        sparse = if is_list(sparse), do: Enum.join(sparse, "\n"), else: sparse
         sparse_check(git_version())
         git!(["--git-dir=.git", "config", "core.sparsecheckout", "true"])
         File.mkdir_p!(".git/info")

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -307,6 +307,8 @@ unless File.dir?(target) do
   end
   """)
 
+  File.write!(Path.join(subdir, "lib/to_be_excluded"), "## Auto-generated empty fixture")
+
   File.cd!(target, fn ->
     System.cmd("git", ~w[add .])
     System.cmd("git", ~w[commit -m "lib"])


### PR DESCRIPTION
`git sparse-checkout` supports the same pattern matching as `.gitignore` files (see [this article](https://github.blog/2020-01-17-bring-your-monorepo-down-to-size-with-sparse-checkout/#cone-mode-restricted-patterns-improve-performance) for details). However, the current implementation of the `:sparse` option with mix breaks if you try to use a pattern:

```elixir
{:sparse_test, github: "jjcarstens/sparse_test", sparse: "lib/**/*.ex"}
```
 
```
> my_app √ % mix deps.get                                                                                                                                                                         
* Updating sparse_test (https://github.com/jjcarstens/sparse_test.git)
origin/HEAD set to main
** (File.Error) could not touch "/Users/jonjon/repos/my_app/deps/sparse_test/lib/**/*.ex/.fetch": no such file or directory
    (elixir 1.12.1) lib/file.ex:602: File.touch!/2
    (mix 1.12.1) lib/mix/dep/fetcher.ex:78: Mix.Dep.Fetcher.do_fetch/3
    (mix 1.12.1) lib/mix/dep/converger.ex:190: Mix.Dep.Converger.all/9
    (mix 1.12.1) lib/mix/dep/converger.ex:201: Mix.Dep.Converger.all/9
    (mix 1.12.1) lib/mix/dep/converger.ex:123: Mix.Dep.Converger.all/7
    (mix 1.12.1) lib/mix/dep/converger.ex:72: Mix.Dep.Converger.all/4
    (mix 1.12.1) lib/mix/dep/converger.ex:51: Mix.Dep.Converger.converge/4
    (mix 1.12.1) lib/mix/dep/fetcher.ex:16: Mix.Dep.Fetcher.all/3
```

This is because `:sparse` is being added to `:dest` option which later on attempts to be created via a `touch`, but patterns are not supported.

So this instead removes the update of the `:dest` option and uses the `:sparse` option only when needed. As a bonus, this also adds support for including multiple patterns as a list in `:sparse` to create more complex sparse checkouts as needed.