### PR TITLE
Add 'significant' to child_spec()

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -515,6 +515,7 @@ defmodule Supervisor do
           required(:id) => atom() | term(),
           required(:start) => {module(), atom(), [term()]},
           optional(:restart) => :permanent | :transient | :temporary,
+          optional(:significant) => boolean(),
           optional(:shutdown) => timeout() | :brutal_kill,
           optional(:type) => :worker | :supervisor,
           optional(:modules) => [module()] | :dynamic


### PR DESCRIPTION
OTP-24.0 adds the `significant` option to `supervisor:child_spec()`. This was inlined in https://github.com/elixir-lang/elixir/commit/6632cab46641a66d6c983e6b0401f37ab922bbfc, so dialyzer (via dialyxir) doesn't see it.