### PR TITLE
Keep backwards compatibility on Range and Date.Range

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2066,6 +2066,12 @@ defmodule Enum do
     end
   end
 
+  # TODO: Remove me on v2.0
+  def min_max(%{__struct__: Range, first: first, last: last} = range, empty_fallback) do
+    step = if first <= last, do: 1, else: -1
+    min_max(Map.put(range, :step, step), empty_fallback)
+  end
+
   def min_max(enumerable, empty_fallback) when is_function(empty_fallback, 0) do
     first_fun = &[&1 | &1]
 
@@ -2390,6 +2396,12 @@ defmodule Enum do
     reduce_range(first, last, step, acc, fun)
   end
 
+  # TODO: Remove me on v2.0
+  def reduce(%{__struct__: Range, first: first, last: last} = range, acc, fun) do
+    step = if first <= last, do: 1, else: -1
+    reduce(Map.put(range, :step, step), acc, fun)
+  end
+
   def reduce(%_{} = enumerable, acc, fun) do
     reduce_enumerable(enumerable, acc, fun)
   end
@@ -2660,6 +2672,12 @@ defmodule Enum do
       raise ArgumentError,
             "Enum.slice/2 does not accept ranges with custom steps, got: #{inspect(index_range)}"
     end
+  end
+
+  # TODO: Remove me on v2.0
+  def slice(enumerable, %{__struct__: Range, first: first, last: last} = index_range) do
+    step = if first <= last, do: 1, else: -1
+    slice(enumerable, Map.put(index_range, :step, step))
   end
 
   defp slice_range(enumerable, first, last) when last >= first and last >= 0 and first >= 0 do
@@ -3048,6 +3066,12 @@ defmodule Enum do
     |> Range.size()
     |> Kernel.*(first + last - rem(last - first, step))
     |> div(2)
+  end
+
+  # TODO: Remove me on v2.0
+  def sum(%{__struct__: Range, first: first, last: last} = range) do
+    step = if first <= last, do: 1, else: -1
+    sum(Map.put(range, :step, step))
   end
 
   def sum(enumerable) do
@@ -3669,6 +3693,12 @@ defmodule Enum do
           false -> last
         end
     end
+  end
+
+  # TODO: Remove me on v2.0
+  defp aggregate(%{__struct__: Range, first: first, last: last} = range, fun, empty) do
+    step = if first <= last, do: 1, else: -1
+    aggregate(Map.put(range, :step, step), fun, empty)
   end
 
   defp aggregate(enumerable, fun, empty) do

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2066,12 +2066,6 @@ defmodule Enum do
     end
   end
 
-  # TODO: Remove me on v2.0
-  def min_max(%{__struct__: Range, first: first, last: last} = range, empty_fallback) do
-    step = if first <= last, do: 1, else: -1
-    min_max(Map.put(range, :step, step), empty_fallback)
-  end
-
   def min_max(enumerable, empty_fallback) when is_function(empty_fallback, 0) do
     first_fun = &[&1 | &1]
 
@@ -2394,12 +2388,6 @@ defmodule Enum do
 
   def reduce(first..last//step, acc, fun) do
     reduce_range(first, last, step, acc, fun)
-  end
-
-  # TODO: Remove me on v2.0
-  def reduce(%{__struct__: Range, first: first, last: last} = range, acc, fun) do
-    step = if first <= last, do: 1, else: -1
-    reduce(Map.put(range, :step, step), acc, fun)
   end
 
   def reduce(%_{} = enumerable, acc, fun) do
@@ -3068,12 +3056,6 @@ defmodule Enum do
     |> div(2)
   end
 
-  # TODO: Remove me on v2.0
-  def sum(%{__struct__: Range, first: first, last: last} = range) do
-    step = if first <= last, do: 1, else: -1
-    sum(Map.put(range, :step, step))
-  end
-
   def sum(enumerable) do
     reduce(enumerable, 0, &+/2)
   end
@@ -3693,12 +3675,6 @@ defmodule Enum do
           false -> last
         end
     end
-  end
-
-  # TODO: Remove me on v2.0
-  defp aggregate(%{__struct__: Range, first: first, last: last} = range, fun, empty) do
-    step = if first <= last, do: 1, else: -1
-    aggregate(Map.put(range, :step, step), fun, empty)
   end
 
   defp aggregate(enumerable, fun, empty) do

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -261,11 +261,6 @@ defmodule Exception do
       {:%{}, meta, [__struct__: Range, first: first, last: last, step: step]} ->
         {:"..//", meta, [first, last, step]}
 
-      # TODO: Remove me on v2.0
-      {:%{}, meta, [__struct__: Range, first: first, last: last]} ->
-        step = if first <= last, do: 1, else: -1
-        {:"..//", meta, [first, last, step]}
-
       other ->
         other
     end)

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -261,6 +261,11 @@ defmodule Exception do
       {:%{}, meta, [__struct__: Range, first: first, last: last, step: step]} ->
         {:"..//", meta, [first, last, step]}
 
+      # TODO: Remove me on v2.0
+      {:%{}, meta, [__struct__: Range, first: first, last: last]} ->
+        step = if first <= last, do: 1, else: -1
+        {:"..//", meta, [first, last, step]}
+
       other ->
         other
     end)

--- a/lib/elixir/test/elixir/calendar/date_range_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_range_test.exs
@@ -141,4 +141,71 @@ defmodule Date.RangeTest do
       Date.range(~D[2000-01-01], ~D[2000-01-31], step)
     end
   end
+
+  describe "old date ranges" do
+    test "inspect" do
+      asc = %{
+        __struct__: Date.Range,
+        first: ~D[2021-07-14],
+        first_in_iso_days: 738_350,
+        last: ~D[2021-07-17],
+        last_in_iso_days: 738_353
+      }
+
+      desc = %{
+        __struct__: Date.Range,
+        first: ~D[2021-07-17],
+        first_in_iso_days: 738_353,
+        last: ~D[2021-07-14],
+        last_in_iso_days: 738_350
+      }
+
+      assert inspect(asc) == "#DateRange<~D[2021-07-14], ~D[2021-07-17]>"
+      assert inspect(desc) == "#DateRange<~D[2021-07-17], ~D[2021-07-14], -1>"
+    end
+
+    test "enumerable" do
+      asc = %{
+        __struct__: Date.Range,
+        first: ~D[2021-07-14],
+        first_in_iso_days: 738_350,
+        last: ~D[2021-07-17],
+        last_in_iso_days: 738_353
+      }
+
+      desc = %{
+        __struct__: Date.Range,
+        first: ~D[2021-07-17],
+        first_in_iso_days: 738_353,
+        last: ~D[2021-07-14],
+        last_in_iso_days: 738_350
+      }
+
+      # member? implementations tests also empty?
+      assert Enumerable.member?(asc, ~D[2021-07-15])
+      assert {:ok, 4, _} = Enumerable.slice(asc)
+
+      assert Enum.reduce(asc, [], fn x, acc -> [x | acc] end) == [
+               ~D[2021-07-17],
+               ~D[2021-07-16],
+               ~D[2021-07-15],
+               ~D[2021-07-14]
+             ]
+
+      assert Enum.count(asc) == 4
+
+      # member? implementations tests also empty?
+      assert Enumerable.member?(desc, ~D[2021-07-15])
+      assert {:ok, 4, _} = Enumerable.slice(desc)
+
+      assert Enum.reduce(desc, [], fn x, acc -> [x | acc] end) == [
+               ~D[2021-07-14],
+               ~D[2021-07-15],
+               ~D[2021-07-16],
+               ~D[2021-07-17]
+             ]
+
+      assert Enum.count(desc) == 4
+    end
+  end
 end

--- a/lib/elixir/test/elixir/range_test.exs
+++ b/lib/elixir/test/elixir/range_test.exs
@@ -96,6 +96,14 @@ defmodule RangeTest do
   end
 
   describe "old ranges" do
+    test "inspect" do
+      asc = %{__struct__: Range, first: 1, last: 3}
+      desc = %{__struct__: Range, first: 3, last: 1}
+
+      assert inspect(asc) == "1..3"
+      assert inspect(desc) == "3..1//-1"
+    end
+
     test "enum" do
       asc = %{__struct__: Range, first: 1, last: 3}
       desc = %{__struct__: Range, first: 3, last: 1}

--- a/lib/elixir/test/elixir/range_test.exs
+++ b/lib/elixir/test/elixir/range_test.exs
@@ -104,11 +104,23 @@ defmodule RangeTest do
       assert Enum.member?(asc, 2)
       assert Enum.count(asc) == 3
       assert Enum.drop(asc, 1) == [2, 3]
+      assert Enum.slice([1, 2, 3, 4, 5, 6], asc) == [2, 3, 4]
+      # testing private Enum.aggregate
+      assert Enum.max(asc) == 3
+      assert Enum.sum(asc) == 6
+      assert Enum.min_max(asc) == {1, 3}
+      assert Enum.reduce(asc, 0, fn a, b -> a + b end) == 6
 
       assert Enum.to_list(desc) == [3, 2, 1]
       assert Enum.member?(desc, 2)
       assert Enum.count(desc) == 3
       assert Enum.drop(desc, 1) == [2, 1]
+      assert Enum.slice([1, 2, 3, 4, 5, 6], desc) == []
+      # testing private Enum.aggregate
+      assert Enum.max(desc) == 3
+      assert Enum.sum(desc) == 6
+      assert Enum.min_max(desc) == {1, 3}
+      assert Enum.reduce(desc, 0, fn a, b -> a + b end) == 6
     end
 
     test "string" do


### PR DESCRIPTION
Fixes https://github.com/elixir-lang/elixir/issues/11110
Handles cases not covered by https://github.com/elixir-lang/elixir/commit/13ba96be3cef5e4325fc3570f65e2eef4cce9314

There are 2 more usages but those look safe. If I understand it correctly they happen only on compile time
- https://github.com/elixir-lang/elixir/blob/58ca6524f88bfe7e963deafe0e7d6aa07a568003/lib/elixir/lib/kernel.ex#L4071
- https://github.com/elixir-lang/elixir/blob/58ca6524f88bfe7e963deafe0e7d6aa07a568003/lib/elixir/lib/kernel.ex#L4077