### PR TITLE
Change exit status for test failures to 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
   * [mix rebar] No longer support `sub_dirs` in Rebar 2 to help migration towards Rebar 3
   * [mix test] Support `--profile-require=time` to profile the time loading test files themselves
   * [mix test] Allow filtering modules from coverage using regex
-  * [mix test] Allow the exit code of ExUnit to be configured and set the default to 2
+  * [mix test] Allow the exit status of ExUnit to be configured and set the default to 2
   * [mix xref] Support multiple sinks and sources in `mix xref graph`
   * [mix xref] Add `--fail-above` option to `mix xref`
   * [mix xref] Add `--label compile-connected` to `mix xref`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
   * [mix rebar] No longer support `sub_dirs` in Rebar 2 to help migration towards Rebar 3
   * [mix test] Support `--profile-require=time` to profile the time loading test files themselves
   * [mix test] Allow filtering modules from coverage using regex
-  * [mix test] Change the exit code to 2 when using `--warnings-as-errors` and warnings are found
+  * [mix test] Allow the exit code of ExUnit to be configured and set the default to 2
   * [mix xref] Support multiple sinks and sources in `mix xref graph`
   * [mix xref] Add `--fail-above` option to `mix xref`
   * [mix xref] Add `--label compile-connected` to `mix xref`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
   * [mix rebar] No longer support `sub_dirs` in Rebar 2 to help migration towards Rebar 3
   * [mix test] Support `--profile-require=time` to profile the time loading test files themselves
   * [mix test] Allow filtering modules from coverage using regex
+  * [mix test] Change the exit code to 2 when using `--warnings-as-errors` and warnings are found
   * [mix xref] Support multiple sinks and sources in `mix xref graph`
   * [mix xref] Add `--fail-above` option to `mix xref`
   * [mix xref] Add `--label compile-connected` to `mix xref`

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -319,7 +319,6 @@ defmodule ExUnit do
     |> put_seed()
     |> put_slowest()
     |> put_max_cases()
-    |> put_exit_status()
   end
 
   @doc """
@@ -459,10 +458,6 @@ defmodule ExUnit do
     else
       opts
     end
-  end
-
-  defp put_exit_status(opts) do
-    Keyword.put_new(opts, :exit_status, 2)
   end
 
   defp max_cases(opts) do

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -206,7 +206,7 @@ defmodule ExUnit do
           %{failures: failures} = ExUnit.Runner.run(options, time)
 
           if failures > 0 do
-            System.at_exit(fn _ -> exit({:shutdown, Keyword.fetch!(options, :exit_code)}) end)
+            System.at_exit(fn _ -> exit({:shutdown, Keyword.fetch!(options, :exit_status)}) end)
           end
 
         _ ->
@@ -245,8 +245,8 @@ defmodule ExUnit do
     * `:exclude` - specifies which tests are run by skipping tests that match the
       filter;
 
-    * `:exit_code` - specifies an alternate exit code to use when the test suite
-      fails. Defaults to 2;
+    * `:exit_status` - specifies an alternate exit status to use when the test
+      suite fails. Defaults to 2;
 
     * `:failures_manifest_file` - specifies a path to the file used to store failures
       between runs;
@@ -319,7 +319,7 @@ defmodule ExUnit do
     |> put_seed()
     |> put_slowest()
     |> put_max_cases()
-    |> put_exit_code()
+    |> put_exit_status()
   end
 
   @doc """
@@ -461,8 +461,8 @@ defmodule ExUnit do
     end
   end
 
-  defp put_exit_code(opts) do
-    Keyword.put_new(opts, :exit_code, 2)
+  defp put_exit_status(opts) do
+    Keyword.put_new(opts, :exit_status, 2)
   end
 
   defp max_cases(opts) do

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -246,7 +246,7 @@ defmodule ExUnit do
       filter;
 
     * `:exit_code` - specifies an alternate exit code to use when the test suite
-      fails;
+      fails. Defaults to 2;
 
     * `:failures_manifest_file` - specifies a path to the file used to store failures
       between runs;

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -206,7 +206,7 @@ defmodule ExUnit do
           %{failures: failures} = ExUnit.Runner.run(options, time)
 
           if failures > 0 do
-            System.at_exit(fn _ -> exit({:shutdown, 1}) end)
+            System.at_exit(fn _ -> exit({:shutdown, Keyword.fetch!(options, :exit_code)}) end)
           end
 
         _ ->
@@ -244,6 +244,9 @@ defmodule ExUnit do
 
     * `:exclude` - specifies which tests are run by skipping tests that match the
       filter;
+
+    * `:exit_code` - specifies an alternate exit code to use when the test suite
+      fails;
 
     * `:failures_manifest_file` - specifies a path to the file used to store failures
       between runs;
@@ -316,6 +319,7 @@ defmodule ExUnit do
     |> put_seed()
     |> put_slowest()
     |> put_max_cases()
+    |> put_exit_code()
   end
 
   @doc """
@@ -455,6 +459,10 @@ defmodule ExUnit do
     else
       opts
     end
+  end
+
+  defp put_exit_code(opts) do
+    Keyword.put_new(opts, :exit_code, 2)
   end
 
   defp max_cases(opts) do

--- a/lib/ex_unit/mix.exs
+++ b/lib/ex_unit/mix.exs
@@ -23,6 +23,7 @@ defmodule ExUnit.MixProject do
         capture_log: false,
         colors: [],
         exclude: [],
+        exit_status: 2,
         formatters: [ExUnit.CLIFormatter],
         include: [],
         max_failures: :infinity,

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -792,6 +792,22 @@ defmodule ExUnitTest do
     end
   end
 
+  describe ":exit_code" do
+    test "defaults value to 2" do
+      configure_and_reload_on_exit([])
+      ExUnit.start(autorun: false)
+      config = ExUnit.configuration()
+      assert config[:exit_code] == 2
+    end
+
+    test "sets value of :exit_code" do
+      configure_and_reload_on_exit([])
+      ExUnit.start(exit_code: 5, autorun: false)
+      config = ExUnit.configuration()
+      assert config[:exit_code] == 5
+    end
+  end
+
   ##  Helpers
 
   defp run_with_filter(filters, cases) do

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -792,19 +792,19 @@ defmodule ExUnitTest do
     end
   end
 
-  describe ":exit_code" do
+  describe ":exit_status" do
     test "defaults value to 2" do
       configure_and_reload_on_exit([])
       ExUnit.start(autorun: false)
       config = ExUnit.configuration()
-      assert config[:exit_code] == 2
+      assert config[:exit_status] == 2
     end
 
-    test "sets value of :exit_code" do
+    test "sets value of :exit_status" do
       configure_and_reload_on_exit([])
-      ExUnit.start(exit_code: 5, autorun: false)
+      ExUnit.start(exit_status: 5, autorun: false)
       config = ExUnit.configuration()
-      assert config[:exit_code] == 5
+      assert config[:exit_status] == 5
     end
   end
 

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -113,7 +113,7 @@ defmodule Mix.Tasks.Test do
 
     * `--exclude` - excludes tests that match the filter
 
-    * `--exit-code` - use an alternate exit code to use when the test suite
+    * `--exit-status` - use an alternate exit status to use when the test suite
       fails (default is 2).
 
     * `--export-coverage` - the name of the file to export coverage results to.
@@ -179,7 +179,7 @@ defmodule Mix.Tasks.Test do
       Note that in trace mode test timeouts will be ignored as timeout is set to `:infinity`
 
     * `--warnings-as-errors` - (since v1.12.0) treats warnings as errors and returns a non-zero
-      exit code. This option only applies to test files. To treat warnings as errors during
+      exit status. This option only applies to test files. To treat warnings as errors during
       compilation and during tests, run:
           MIX_ENV=test mix do compile --warnings-as-errors, test --warnings-as-errors
 
@@ -408,7 +408,7 @@ defmodule Mix.Tasks.Test do
     preload_modules: :boolean,
     warnings_as_errors: :boolean,
     profile_require: :string,
-    exit_code: :integer
+    exit_status: :integer
   ]
 
   @cover [output: "cover", tool: Mix.Tasks.Test.Coverage]
@@ -536,7 +536,9 @@ defmodule Mix.Tasks.Test do
             raise_with_shell(shell, "\"mix test\" failed")
 
           failures > 0 ->
-            System.at_exit(fn _ -> exit({:shutdown, Keyword.fetch!(ex_unit_opts, :exit_code)}) end)
+            System.at_exit(fn _ ->
+              exit({:shutdown, Keyword.fetch!(ex_unit_opts, :exit_status)})
+            end)
 
           excluded == total and Keyword.has_key?(opts, :only) ->
             message = "The --only option was given to \"mix test\" but no test was executed"
@@ -606,7 +608,7 @@ defmodule Mix.Tasks.Test do
     :failures_manifest_file,
     :only_test_ids,
     :test_location_relative_path,
-    :exit_code
+    :exit_status
   ]
 
   @doc false
@@ -620,7 +622,7 @@ defmodule Mix.Tasks.Test do
       |> filter_opts(:only)
       |> formatter_opts()
       |> color_opts()
-      |> exit_code_opts()
+      |> exit_status_opts()
       |> Keyword.take(@option_keys)
       |> default_opts()
 
@@ -762,13 +764,13 @@ defmodule Mix.Tasks.Test do
     end
   end
 
-  defp exit_code_opts(opts) do
-    case Keyword.fetch(opts, :exit_code) do
-      {:ok, _code} ->
+  defp exit_status_opts(opts) do
+    case Keyword.fetch(opts, :exit_status) do
+      {:ok, _status} ->
         opts
 
       :error ->
-        Keyword.put(opts, :exit_code, 2)
+        Keyword.put(opts, :exit_status, 2)
     end
   end
 

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -765,13 +765,7 @@ defmodule Mix.Tasks.Test do
   end
 
   defp exit_status_opts(opts) do
-    case Keyword.fetch(opts, :exit_status) do
-      {:ok, _status} ->
-        opts
-
-      :error ->
-        Keyword.put(opts, :exit_status, 2)
-    end
+    Keyword.put_new(opts, :exit_status, 2)
   end
 
   defp require_test_helper(shell, dir) do

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -475,6 +475,8 @@ defmodule Mix.Tasks.TestTest do
   end
 
   describe "--exit-code" do
+    @describetag :unix
+
     test "returns custom exit code" do
       in_fixture("test_failed", fn ->
         {output, exit_code} = mix_code(["test", "--exit-code", "5"])

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -32,9 +32,14 @@ defmodule Mix.Tasks.TestTest do
       assert ex_unit_opts_from_given(formatter: "A.B") == [formatters: [A.B]]
     end
 
+    test "accepts custom :exit_code" do
+      assert {:exit_code, 5} in ex_unit_opts(exit_code: 5)
+    end
+
     test "includes some default options" do
       assert ex_unit_opts([]) == [
                autorun: false,
+               exit_code: 2,
                failures_manifest_file:
                  Path.join(Mix.Project.manifest_path(), ".mix_test_failures")
              ]
@@ -48,7 +53,7 @@ defmodule Mix.Tasks.TestTest do
     defp ex_unit_opts_from_given(passed) do
       passed
       |> ex_unit_opts()
-      |> Keyword.drop([:failures_manifest_file, :autorun])
+      |> Keyword.drop([:failures_manifest_file, :autorun, :exit_code])
     end
   end
 
@@ -465,6 +470,16 @@ defmodule Mix.Tasks.TestTest do
         refute output =~ "Test suite aborted after successful execution"
         output = mix(["test", "--failed"])
         assert output =~ "2 failures"
+      end)
+    end
+  end
+
+  describe "--exit-code" do
+    test "returns custom exit code" do
+      in_fixture("test_failed", fn ->
+        {output, exit_code} = mix_code(["test", "--exit-code", "5"])
+        assert output =~ "2 failures"
+        assert exit_code == 5
       end)
     end
   end

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -32,14 +32,14 @@ defmodule Mix.Tasks.TestTest do
       assert ex_unit_opts_from_given(formatter: "A.B") == [formatters: [A.B]]
     end
 
-    test "accepts custom :exit_code" do
-      assert {:exit_code, 5} in ex_unit_opts(exit_code: 5)
+    test "accepts custom :exit_status" do
+      assert {:exit_status, 5} in ex_unit_opts(exit_status: 5)
     end
 
     test "includes some default options" do
       assert ex_unit_opts([]) == [
                autorun: false,
-               exit_code: 2,
+               exit_status: 2,
                failures_manifest_file:
                  Path.join(Mix.Project.manifest_path(), ".mix_test_failures")
              ]
@@ -53,7 +53,7 @@ defmodule Mix.Tasks.TestTest do
     defp ex_unit_opts_from_given(passed) do
       passed
       |> ex_unit_opts()
-      |> Keyword.drop([:failures_manifest_file, :autorun, :exit_code])
+      |> Keyword.drop([:failures_manifest_file, :autorun, :exit_status])
     end
   end
 
@@ -474,14 +474,14 @@ defmodule Mix.Tasks.TestTest do
     end
   end
 
-  describe "--exit-code" do
+  describe "--exit-status" do
     @describetag :unix
 
-    test "returns custom exit code" do
+    test "returns custom exit status" do
       in_fixture("test_failed", fn ->
-        {output, exit_code} = mix_code(["test", "--exit-code", "5"])
+        {output, exit_status} = mix_code(["test", "--exit-status", "5"])
         assert output =~ "2 failures"
-        assert exit_code == 5
+        assert exit_status == 5
       end)
     end
   end


### PR DESCRIPTION
From [the mailing list conversation](https://groups.google.com/g/elixir-lang-core/c/KOrTrFvXxiM).

It is nice to be able to differentiate between different reasons for failure of a test suite, specifically whether the tests failed or `--warnings-as-errors` detected warnings. Currently, both failure reasons exit with code 1, but this change modifies the exit code of a `--warnings-as-errors` failure to 2.

I looked for a `/lib/mix/test/mix/compilers/test_test.exs` to modify, but it looks like there are no tests for this file. Let me know if you want me to add tests :grin: 