### PR TITLE
Fix autocomplete on atoms with `@`

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -415,7 +415,7 @@ defmodule Code do
       {kind, _, '..' ++ _, acc} -> alias_or_local_or_var(kind, acc)
       # Module attributes
       {:alias, _, '@' ++ _, _} -> :none
-      {:identifier, _, '@' ++ _, acc} -> {:module_attribute, acc}
+      {:identifier, _, '@', acc} -> {:module_attribute, acc}
       # Everything else
       {:alias, _, '.' ++ rest, acc} -> nested_alias(rest, acc)
       {:identifier, _, '.' ++ rest, acc} -> dot(rest, acc)
@@ -452,6 +452,12 @@ defmodule Code do
 
   defp check_identifier([h | _], _acc) when h in @non_identifier, do: :none
   defp check_identifier(rest, acc), do: rest_identifier(rest, acc)
+
+  # @ needs a special clause because it is an operator only if at word start,
+  # but can be used at middle of atoms
+  defp rest_identifier([?@ = h, s | rest], acc) do
+    rest_identifier([s | rest], [h | acc])
+  end
 
   defp rest_identifier([h | rest], acc) when h not in @non_identifier do
     rest_identifier(rest, [h | acc])

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -58,6 +58,7 @@ defmodule CodeTest do
       assert Code.cursor_context(":hello.wor") == {:dot, {:unquoted_atom, 'hello'}, 'wor'}
       assert Code.cursor_context(":hell@o.wor") == {:dot, {:unquoted_atom, 'hell@o'}, 'wor'}
       assert Code.cursor_context(":he@ll@o.wor") == {:dot, {:unquoted_atom, 'he@ll@o'}, 'wor'}
+      assert Code.cursor_context(":hell@@o.wor") == {:dot, {:unquoted_atom, 'hell@@o'}, 'wor'}
       assert Code.cursor_context("@hello.wor") == {:dot, {:module_attribute, 'hello'}, 'wor'}
 
       assert Code.cursor_context("nested.map.wor") ==
@@ -124,6 +125,7 @@ defmodule CodeTest do
       assert Code.cursor_context(":hello_wor") == {:unquoted_atom, 'hello_wor'}
       assert Code.cursor_context(":Óla_mundo") == {:unquoted_atom, 'Óla_mundo'}
       assert Code.cursor_context(":Ol@_mundo") == {:unquoted_atom, 'Ol@_mundo'}
+      assert Code.cursor_context(":Ol@") == {:unquoted_atom, 'Ol@'}
       assert Code.cursor_context("foo:hello_wor") == {:unquoted_atom, 'hello_wor'}
     end
 

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -56,6 +56,8 @@ defmodule CodeTest do
       assert Code.cursor_context("Hello.wor") == {:dot, {:alias, 'Hello'}, 'wor'}
       assert Code.cursor_context("hello.wor") == {:dot, {:var, 'hello'}, 'wor'}
       assert Code.cursor_context(":hello.wor") == {:dot, {:unquoted_atom, 'hello'}, 'wor'}
+      assert Code.cursor_context(":hell@o.wor") == {:dot, {:unquoted_atom, 'hell@o'}, 'wor'}
+      assert Code.cursor_context(":he@ll@o.wor") == {:dot, {:unquoted_atom, 'he@ll@o'}, 'wor'}
       assert Code.cursor_context("@hello.wor") == {:dot, {:module_attribute, 'hello'}, 'wor'}
 
       assert Code.cursor_context("nested.map.wor") ==
@@ -121,6 +123,7 @@ defmodule CodeTest do
       assert Code.cursor_context(":HelloWór") == {:unquoted_atom, 'HelloWór'}
       assert Code.cursor_context(":hello_wor") == {:unquoted_atom, 'hello_wor'}
       assert Code.cursor_context(":Óla_mundo") == {:unquoted_atom, 'Óla_mundo'}
+      assert Code.cursor_context(":Ol@_mundo") == {:unquoted_atom, 'Ol@_mundo'}
       assert Code.cursor_context("foo:hello_wor") == {:unquoted_atom, 'hello_wor'}
     end
 


### PR DESCRIPTION
Closes #11120.
Code.cursor_context/2 was misidentifying some atoms as module attributes. 