### PR TITLE
Preserve heredoc indentation metadata

### DIFF
--- a/lib/elixir/src/elixir_parser.yrl
+++ b/lib/elixir/src/elixir_parser.yrl
@@ -937,11 +937,21 @@ meta_with_indentation(Meta, nil) ->
 meta_with_indentation(Meta, Indentation) ->
   [{indentation, Indentation} | Meta].
 
-build_bin_heredoc({bin_heredoc, Location, Args}) ->
-  build_bin_string({bin_string, Location, Args}, delimiter(<<$", $", $">>)).
+build_bin_heredoc({bin_heredoc, Location, Indentation, Args}) ->
+  ExtraMeta =
+    case ?token_metadata() of
+      true -> [{delimiter, <<$", $", $">>}, {indentation, Indentation}];
+      false -> []
+    end,
+  build_bin_string({bin_string, Location, Args}, ExtraMeta).
 
-build_list_heredoc({list_heredoc, Location, Args}) ->
-  build_list_string({list_string, Location, Args}, delimiter(<<$', $', $'>>)).
+build_list_heredoc({list_heredoc, Location, Indentation, Args}) ->
+  ExtraMeta =
+    case ?token_metadata() of
+      true -> [{delimiter, <<$', $', $'>>}, {indentation, Indentation}];
+      false -> []
+    end,
+  build_list_string({list_string, Location, Args}, ExtraMeta).
 
 build_bin_string({bin_string, _Location, [H]} = Token, ExtraMeta) when is_binary(H) ->
   handle_literal(H, Token, ExtraMeta);

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -703,7 +703,7 @@ handle_heredocs(T, Line, Column, H, Scope, Tokens) ->
     {ok, NewLine, NewColumn, Parts, Rest, NewScope} ->
       case unescape_tokens(Parts, Line, Column, NewScope) of
         {ok, Unescaped} ->
-          Token = {heredoc_type(H), {Line, Column, nil}, Unescaped},
+          Token = {heredoc_type(H), {Line, Column, nil}, NewColumn - 4, Unescaped},
           tokenize(Rest, NewLine, NewColumn, NewScope, [Token | Tokens]);
 
         {error, Reason} ->

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -322,10 +322,10 @@ defmodule Kernel.ParserTest do
                 [[{:__block__, [token: "1", line: 1], [1]}]]}
 
       assert string_to_quoted.(~s("""\nhello\n""")) ==
-               {:__block__, [delimiter: ~s["""], line: 1], ["hello\n"]}
+               {:__block__, [delimiter: ~s["""], indentation: 0, line: 1], ["hello\n"]}
 
       assert string_to_quoted.("'''\nhello\n'''") ==
-               {:__block__, [delimiter: ~s['''], line: 1], ['hello\n']}
+               {:__block__, [delimiter: ~s['''], indentation: 0, line: 1], ['hello\n']}
 
       assert string_to_quoted.(~s[fn (1) -> "hello" end]) ==
                {:fn, [closing: [line: 1], line: 1],

--- a/lib/elixir/test/erlang/tokenizer_test.erl
+++ b/lib/elixir/test/erlang/tokenizer_test.erl
@@ -163,8 +163,8 @@ string_test() ->
   [{list_string, {1, 1, nil}, [<<"foo">>]}] = tokenize("'foo'").
 
 heredoc_test() ->
-  [{bin_heredoc, {1, 1, nil}, [<<"heredoc\n">>]}] = tokenize("\"\"\"\nheredoc\n\"\"\""),
-  [{bin_heredoc, {1, 1, nil}, [<<"heredoc\n">>]}, {';', {3, 5, 0}}] = tokenize("\"\"\"\n heredoc\n \"\"\";").
+  [{bin_heredoc, {1, 1, nil}, 0, [<<"heredoc\n">>]}] = tokenize("\"\"\"\nheredoc\n\"\"\""),
+  [{bin_heredoc, {1, 1, nil}, 1, [<<"heredoc\n">>]}, {';', {3, 5, 0}}] = tokenize("\"\"\"\n heredoc\n \"\"\";").
 
 empty_string_test() ->
   [{bin_string, {1, 1, nil}, [<<>>]}] = tokenize("\"\""),


### PR DESCRIPTION
Indentation metadata is preserved for heredoc sigils, but it's not considered for heredoc strings or charlists. It's reasonable since they're literals anyways, but using the `literal_encoder` option knowing the indentation of the node comes in handy.