### PR TITLE
Add `did you mean` to error for unfound CLI option

### DIFF
--- a/lib/elixir/test/elixir/option_parser_test.exs
+++ b/lib/elixir/test/elixir/option_parser_test.exs
@@ -96,8 +96,15 @@ defmodule OptionParserTest do
   end
 
   test "parse!/2 raises an exception for an unknown option using strict" do
-    assert_raise OptionParser.ParseError, "1 error found!\n--doc : Unknown option", fn ->
+    msg = "1 error found!\n--doc : Unknown option. Did you mean --docs?"
+
+    assert_raise OptionParser.ParseError, msg, fn ->
       argv = ["--source", "from_docs/", "--doc", "show"]
+      OptionParser.parse!(argv, strict: [source: :string, docs: :string])
+    end
+
+    assert_raise OptionParser.ParseError, "1 error found!\n--foo : Unknown option", fn ->
+      argv = ["--source", "from_docs/", "--foo", "show"]
       OptionParser.parse!(argv, strict: [source: :string, docs: :string])
     end
   end


### PR DESCRIPTION
I typed `mix test --fauled` repeatedly and found the error could
be improved. This change adds the `did you mean` suggestion with the
most likely match to the error message.

The `0.8` cutoff is pulled from the exceptions.ex file.