### PR TITLE
feat: add keyword validate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "elixirLS.projectDir": "./lib/elixir"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "elixirLS.projectDir": "./lib/elixir"
+}

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -315,7 +315,7 @@ defmodule Keyword do
       {:error, invalid_keys} ->
         keys =
           for value <- values,
-              do: if(is_atom(value), do: value, else: Kernel.elem(value, 0))
+              do: if(is_atom(value), do: value, else: elem(value, 0)
 
         raise ArgumentError,
               "unknown keys #{inspect(invalid_keys)} in #{inspect(keyword)}, the allowed keys are: #{inspect(keys)}"

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -215,6 +215,7 @@ defmodule Keyword do
       iex> Keyword.validate!([three: 3], [one: 1, two: 2])
       ** (ArgumentError) unknown key :three in [three: 3], expected one of [:one, :two]
   """
+  @doc since: "1.13.0"
   def validate!(keyword, values) when is_list(keyword) and is_list(values) do
     # We use two lists to avoid reversing/concatenating
     # lists in the middle of traversals.

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -313,7 +313,7 @@ defmodule Keyword do
       {:error, invalid_keys} ->
         keys =
           for value <- values,
-              do: if(is_atom(value), do: value, else: elem(value, 0)
+              do: if(is_atom(value), do: value, else: elem(value, 0))
 
         raise ArgumentError,
               "unknown keys #{inspect(invalid_keys)} in #{inspect(keyword)}, the allowed keys are: #{inspect(keys)}"

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -191,10 +191,80 @@ defmodule Keyword do
   keys and default values.
   The second argument must be a list of atoms, specifying
   a given key, or tuples specifying a key and a default value.
-  If any of the keys in the `keyword` is not defined on
-  `values`, it raises an error.
 
-  See also: `validate/2`
+  Raises upon invalid arguments
+
+  Possible return values:
+  * `{:ok, keyword}`: Success case. Returns the validated keyword with default values applied.
+  * `{:error, unknown_keys}`: Indicates the unknown keys found in the keyword
+
+  See also: `validate!/2`
+
+  ## Examples
+      iex> {:ok, result} = Keyword.validate([], [one: 1, two: 2])
+      iex> Enum.sort(result)
+      [one: 1, two: 2]
+
+      iex> {:ok, result} = Keyword.validate([two: 3], [one: 1, two: 2])
+      iex> Enum.sort(result)
+      [one: 1, two: 3]
+
+  If atoms are given, they are supported as keys but do not
+  provide a default value:
+
+      iex> {:ok, result} = Keyword.validate([], [:one, two: 2])
+      iex> Enum.sort(result)
+      [two: 2]
+
+      iex> {:ok, result} = Keyword.validate([one: 1], [:one, two: 2])
+      iex> Enum.sort(result)
+      [one: 1, two: 2]
+
+  Passing an unknown key returns an error:
+
+      iex> Keyword.validate([three: 3, four: 4], [one: 1, two: 2])
+      {:error, {:invalid_key, :three}}
+
+  Passing an invalid value in either argument raises
+
+      iex> Keyword.validate(%{three: 3}, [one: 1, two: 2])
+      ** (ArgumentError) expected a keyword list with keys [:one, :two], got: %{three: 3}
+
+      iex> Keyword.validate([:three], [one: 1, two: 2])
+      ** (ArgumentError) expected a keyword list with keys [:one, :two], got: [:three]
+
+      iex> Keyword.validate([three: 3], [:three, 3, :two])
+      ** (ArgumentError) expected the second argument to be a list of atoms or tuples, got item: 3
+  """
+  @doc since: "1.13.0"
+  @spec validate(keyword :: keyword(), values :: [atom() | {atom(), term()}]) ::
+          {:ok, keyword}
+          | {:error, {:invalid_key, term()}}
+  def validate(keyword, values) do
+    case validate!(keyword, values, [], []) do
+      {:ok, kw} ->
+        {:ok, kw}
+
+      {:badkey, key} ->
+        {:error, {:invalid_key, key}}
+
+      :badkey ->
+        keys =
+          for value <- values do
+            if is_atom(value) do
+              value
+            else
+              elem(value, 0)
+            end
+          end
+
+        raise ArgumentError,
+              "expected a keyword list with keys #{inspect(keys)}, got: #{inspect(keyword)}"
+    end
+  end
+
+  @doc """
+  Similar to `validate/2` but returns the keyword or raises an error.
 
   ## Examples
       iex> Keyword.validate!([], [one: 1, two: 2]) |> Enum.sort()
@@ -216,6 +286,8 @@ defmodule Keyword do
       ** (ArgumentError) unknown key :three in [three: 3], expected one of [:one, :two]
   """
   @doc since: "1.13.0"
+  @spec validate(keyword :: keyword(), values :: [atom() | {atom(), term()}]) ::
+          keyword | no_return
   def validate!(keyword, values) when is_list(keyword) and is_list(values) do
     # We use two lists to avoid reversing/concatenating
     # lists in the middle of traversals.
@@ -246,90 +318,6 @@ defmodule Keyword do
     end
   end
 
-  @doc """
-  Ensures the first argument is a `keyword` with the given
-  keys and default values.
-  The second argument must be a list of atoms, specifying
-  a given key, or tuples specifying a key and a default value.
-
-  Possible return values:
-  * `{:ok, keyword}`: Success case. Returns the validated keyword with default values applied.
-  * `{:error, :not_a_keyword}`: Indicates that the validated value is not a keyword.
-  * `{:error, :invalid_expected_values}`: Indicates that the expected values list is invalid.
-  * `{:error, {:invalid_key, key}}`: Indicates that a given key is not expected.
-
-  See also: `validate!/2`
-
-  ## Examples
-      iex> {:ok, result} = Keyword.validate([], [one: 1, two: 2])
-      iex> Enum.sort(result)
-      [one: 1, two: 2]
-
-      iex> {:ok, result} = Keyword.validate([two: 3], [one: 1, two: 2])
-      iex> Enum.sort(result)
-      [one: 1, two: 3]
-
-  If atoms are given, they are supported as keys but do not
-  provide a default value:
-
-      iex> {:ok, result} = Keyword.validate([], [:one, two: 2])
-      iex> Enum.sort(result)
-      [two: 2]
-
-      iex> {:ok, result} = Keyword.validate([one: 1], [:one, two: 2])
-      iex> Enum.sort(result)
-      [one: 1, two: 2]
-
-  Passing an unknown key returns an error:
-
-      iex> Keyword.validate([three: 3], [one: 1, two: 2])
-      {:error, {:invalid_key, :three}}
-
-  Passing an invalid value in either argument also returns errors
-
-      iex> Keyword.validate(%{three: 3}, [one: 1, two: 2])
-      {:error, :not_a_keyword}
-      iex> Keyword.validate([:three], [one: 1, two: 2])
-      {:error, :not_a_keyword}
-      iex> Keyword.validate([three: 3], [{"one", 1}, :two])
-      {:error, :invalid_expected_values}
-  """
-  @spec validate(keyword :: keyword(), values :: [atom() | {atom(), term()}]) ::
-          {:ok, keyword}
-          | {:error,
-             :not_a_keyword
-             | {:invalid_key, term()}
-             | :invalid_expected_values}
-  def validate(keyword, values) do
-    with :ok <- is_atom_or_tuple_list(values),
-         {:ok, kw} <- validate!(keyword, values, [], []) do
-      {:ok, kw}
-    else
-      :badkey ->
-        {:error, :not_a_keyword}
-
-      {:badkey, key} ->
-        {:error, {:invalid_key, key}}
-
-      {:error, :not_atom_or_tuple_list} ->
-        {:error, :invalid_expected_values}
-    end
-  end
-
-  defp is_atom_or_tuple_list(values) when is_list(values) do
-    validation_fn = fn
-      v when is_atom(v) -> true
-      {k, _} when is_atom(k) -> true
-      _ -> false
-    end
-
-    if Enum.all?(values, validation_fn) do
-      :ok
-    else
-      {:error, :not_atom_or_tuple_list}
-    end
-  end
-
   defp validate!([{key, _} = pair | keyword], values1, values2, acc) when is_atom(key) do
     case find_key!(key, values1, values2) do
       {values1, values2} ->
@@ -355,7 +343,7 @@ defmodule Keyword do
   end
 
   defp find_key!(key, [head | tail], acc) when key == head, do: {tail, acc}
-  defp find_key!(key, [{head, _} | tail], acc) when key == head, do: {tail, acc}
+  defp find_key!(key, [{head, _} | tail], acc) when key == head and is_atom(key), do: {tail, acc}
   defp find_key!(key, [head | tail], acc), do: find_key!(key, tail, [head | acc])
   defp find_key!(_key, [], _acc), do: :error
 
@@ -370,8 +358,8 @@ defmodule Keyword do
 
   defp move_pairs!([other | _], _) do
     raise ArgumentError,
-          "validate!/2 expects the second argument to be a list of atoms or tuples, " <>
-            "got: #{inspect(other)}"
+          "expected the second argument to be a list of atoms or tuples, " <>
+            "got item: #{inspect(other)}"
   end
 
   @doc """

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -193,11 +193,9 @@ defmodule Keyword do
   The second argument must be a list of atoms, specifying
   a given key, or tuples specifying a key and a default value.
 
-
-  It returns `{:ok, keyword}` in case the keyword list only has
-  the given keys with returns the validated keyword with default
-  values applied. Otherwise it returns `{:error, invalid_keys}`
-  with invalid keys.
+  If the keyword list has only the given keys, it returns
+  `{:ok, keyword}` with default values applied. Otherwise it
+  returns `{:error, invalid_keys}` with invalid keys.
 
   See also: `validate!/2`.
 
@@ -222,7 +220,7 @@ defmodule Keyword do
       iex> Enum.sort(result)
       [one: 1, two: 2]
 
-  Passing an unknown key returns an error:
+  Passing unknown keys returns an error:
 
       iex> Keyword.validate([three: 3, four: 4], [one: 1, two: 2])
       {:error, [:four, :three]}
@@ -300,7 +298,7 @@ defmodule Keyword do
       iex> Keyword.validate!([one: 1], [:one, two: 2]) |> Enum.sort()
       [one: 1, two: 2]
 
-  Passing an unknown key raises:
+  Passing unknown keys raises an error:
 
       iex> Keyword.validate!([three: 3], [one: 1, two: 2])
       ** (ArgumentError) unknown keys [:three] in [three: 3], the allowed keys are: [:one, :two]

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -189,10 +189,11 @@ defmodule Keyword do
   @doc """
   Ensures the first argument is a `keyword` with the given
   keys and default values.
+
   The second argument must be a list of atoms, specifying
   a given key, or tuples specifying a key and a default value.
 
-  Raises upon invalid arguments
+  Raises upon invalid arguments.
 
   Possible return values:
   * `{:ok, keyword}`: Success case. Returns the validated keyword with default values applied.
@@ -201,6 +202,7 @@ defmodule Keyword do
   See also: `validate!/2`
 
   ## Examples
+
       iex> {:ok, result} = Keyword.validate([], [one: 1, two: 2])
       iex> Enum.sort(result)
       [one: 1, two: 2]
@@ -224,22 +226,10 @@ defmodule Keyword do
 
       iex> Keyword.validate([three: 3, four: 4], [one: 1, two: 2])
       {:error, [:three, :four]}
-
-  Passing an invalid value in either argument raises
-
-      iex> Keyword.validate(%{three: 3}, [one: 1, two: 2])
-      ** (ArgumentError) expected a keyword list with keys [:one, :two], got: %{three: 3}
-
-      iex> Keyword.validate([:three], [one: 1, two: 2])
-      ** (ArgumentError) expected a keyword list with keys [:one, :two], got: [:three]
-
-      iex> Keyword.validate([three: 3], [:three, 3, :two])
-      ** (ArgumentError) expected the second argument to be a list of atoms or tuples, got item: 3
   """
   @doc since: "1.13.0"
-  @spec validate(keyword :: keyword(), values :: [atom() | {atom(), term()}]) ::
-          {:ok, keyword}
-          | {:error, [atom]}
+  @spec validate(keyword(), values :: [atom() | {atom(), term()}]) ::
+          {:ok, keyword()} | {:error, [atom]}
   def validate(keyword, values) when is_list(keyword) and is_list(values) do
     case validate(keyword, values, [], [], []) do
       {:error, :invalid_item} ->
@@ -326,6 +316,7 @@ defmodule Keyword do
   Similar to `validate/2` but returns the keyword or raises an error.
 
   ## Examples
+
       iex> Keyword.validate!([], [one: 1, two: 2]) |> Enum.sort()
       [one: 1, two: 2]
       iex> Keyword.validate!([two: 3], [one: 1, two: 2]) |> Enum.sort()
@@ -345,7 +336,7 @@ defmodule Keyword do
       ** (ArgumentError) unknown keys [:three] in [three: 3], the allowed keys are: [:one, :two]
   """
   @doc since: "1.13.0"
-  @spec validate!(keyword :: keyword(), values :: [atom() | {atom(), term()}]) :: keyword
+  @spec validate!(keyword(), values :: [atom() | {atom(), term()}]) :: keyword()
   def validate!(keyword, values) do
     case validate(keyword, values) do
       {:ok, kw} ->

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -300,9 +300,15 @@ defmodule Keyword do
   defp validate_apply_defaults(kw, defaults, valid_defaults \\ [])
 
   defp validate_apply_defaults(kw, [], valid_defaults), do: merge(valid_defaults, kw)
-  defp validate_apply_defaults(kw, [{k, _v} = item | t], valid_defaults) when is_atom(k), do: validate_apply_defaults(kw, t, [item | valid_defaults])
-  defp validate_apply_defaults(kw, [k | t], valid_defaults) when is_atom(k), do: validate_apply_defaults(kw, t, valid_defaults)
-  defp validate_apply_defaults(_kw, [val | _], _valid_defaults), do: validate_raise_on_invalid_value(val)
+
+  defp validate_apply_defaults(kw, [{k, _v} = item | t], valid_defaults) when is_atom(k),
+    do: validate_apply_defaults(kw, t, [item | valid_defaults])
+
+  defp validate_apply_defaults(kw, [k | t], valid_defaults) when is_atom(k),
+    do: validate_apply_defaults(kw, t, valid_defaults)
+
+  defp validate_apply_defaults(_kw, [val | _], _valid_defaults),
+    do: validate_raise_on_invalid_value(val)
 
   defp validate_raise_on_invalid_value(value) do
     raise ArgumentError,

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -260,7 +260,7 @@ defmodule Keyword do
 
   defp validate([pair | _], _values1, _values2, _acc, []) do
     raise ArgumentError,
-          "expected a keyword list as first argument, got invalid entry: #{inspect pair}"
+          "expected a keyword list as first argument, got invalid entry: #{inspect(pair)}"
   end
 
   defp find_key!(key, [key | rest], acc), do: {rest, acc}
@@ -315,7 +315,7 @@ defmodule Keyword do
       {:error, invalid_keys} ->
         keys =
           for value <- values,
-              do: if(is_atom(value), do: value, else: elem(value, 0))
+              do: if(is_atom(value), do: value, else: Kernel.elem(value, 0))
 
         raise ArgumentError,
               "unknown keys #{inspect(invalid_keys)} in #{inspect(keyword)}, the allowed keys are: #{inspect(keys)}"

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -315,7 +315,7 @@ defmodule Keyword do
       {:error, invalid_keys} ->
         keys =
           for value <- values,
-              do: Kernel.if(is_atom(value), do: value, else: Kernel.elem(value, 0))
+              do: if(is_atom(value), do: value, else: elem(value, 0))
 
         raise ArgumentError,
               "unknown keys #{inspect(invalid_keys)} in #{inspect(keyword)}, the allowed keys are: #{inspect(keys)}"

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -208,21 +208,11 @@ defmodule KeywordTest do
 
   test "validate/2 raises on invalid arguments" do
     assert_raise ArgumentError,
-                 "expected a keyword list with keys [:one, :two], got: %{three: 3}",
-                 fn ->
-                   Keyword.validate(%{three: 3}, one: 1, two: 2)
-                 end
+                 "expected a keyword list as first argument, got invalid entry: :three",
+                 fn -> Keyword.validate([:three], one: 1, two: 2) end
 
     assert_raise ArgumentError,
-                 "expected a keyword list with keys [:one, :two], got: [:three]",
-                 fn ->
-                   Keyword.validate([:three], one: 1, two: 2)
-                 end
-
-    assert_raise ArgumentError,
-                 "expected the second argument to be a list of atoms or tuples, got item: 3",
-                 fn ->
-                   Keyword.validate([three: 3], [:three, 3, :two])
-                 end
+                 "expected the second argument to be a list of atoms or tuples, got: 3",
+                 fn -> Keyword.validate([three: 3], [:three, 3, :two]) end
   end
 end

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -205,4 +205,24 @@ defmodule KeywordTest do
       assert_raise ArgumentError, error.message, fn -> Keyword.merge(arg1, arg2, fun) end
     end
   end
+
+  test "validate/2 raises on invalid arguments" do
+    assert_raise ArgumentError,
+                 "expected a keyword list with keys [:one, :two], got: %{three: 3}",
+                 fn ->
+                   Keyword.validate(%{three: 3}, one: 1, two: 2)
+                 end
+
+    assert_raise ArgumentError,
+                 "expected a keyword list with keys [:one, :two], got: [:three]",
+                 fn ->
+                   Keyword.validate([:three], one: 1, two: 2)
+                 end
+
+    assert_raise ArgumentError,
+                 "expected the second argument to be a list of atoms or tuples, got item: 3",
+                 fn ->
+                   Keyword.validate([three: 3], [:three, 3, :two])
+                 end
+  end
 end

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -223,7 +223,9 @@ defmodule MapTest do
              keyword?: 1,
              pop_first: 2,
              pop_first: 3,
-             pop_values: 2
+             pop_values: 2,
+             validate: 2,
+             validate!: 2
            ]
   end
 


### PR DESCRIPTION
This PR implements `Keyword.validate/2` and `Keyword.validate!/2` as discussed in the mailing list.

The original implementation for `validate!/2` can be found in [Nx.Defn.Kernel](https://github.com/elixir-nx/nx/blob/c8353de695a3d70dc6d518e0ab2ec832faa7df68/nx/lib/nx/defn/kernel.ex#L741)