### PR TITLE
Fix Code.Fragment.surround_context/3 range for spaced identifiers

### DIFF
--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -245,20 +245,26 @@ defmodule Code.Fragment do
       {:unquoted_atom, acc, count} ->
         {{:unquoted_atom, acc}, count}
 
-      {:alias, '.' ++ rest, acc, count} when rest == [] or hd(rest) != ?. ->
-        nested_alias(rest, count + 1, acc)
+      {:alias, rest, acc, count} ->
+        case strip_spaces(rest, count) do
+          {'.' ++ rest, count} when rest == [] or hd(rest) != ?. ->
+            nested_alias(rest, count + 1, acc)
 
-      {:identifier, '.' ++ rest, acc, count} when rest == [] or hd(rest) != ?. ->
-        dot(rest, count + 1, acc)
-
-      {:alias, _, acc, count} ->
-        {{:alias, acc}, count}
+          _ ->
+            {{:alias, acc}, count}
+        end
 
       {:identifier, _, acc, count} when call_op? and acc in @textual_operators ->
         {{:operator, acc}, count}
 
-      {:identifier, _, acc, count} ->
-        {{:local_or_var, acc}, count}
+      {:identifier, rest, acc, count} ->
+        case strip_spaces(rest, count) do
+          {'.' ++ rest, count} when rest == [] or hd(rest) != ?. ->
+            dot(rest, count + 1, acc)
+
+          _ ->
+            {{:local_or_var, acc}, count}
+        end
     end
   end
 
@@ -312,7 +318,6 @@ defmodule Code.Fragment do
         if ?@ in extra do
           :none
         else
-          {rest, count} = strip_spaces(rest, count)
           {kind, rest, acc, count}
         end
 

--- a/lib/elixir/test/elixir/code_fragment_test.exs
+++ b/lib/elixir/test/elixir/code_fragment_test.exs
@@ -284,6 +284,16 @@ defmodule CodeFragmentTest do
 
       assert CF.surround_context("hello_wo", {1, 9}) == :none
 
+      for i <- 2..9 do
+        assert CF.surround_context(" hello_wo", {1, i}) == %{
+                 context: {:local_or_var, 'hello_wo'},
+                 begin: {1, 2},
+                 end: {1, 10}
+               }
+      end
+
+      assert CF.surround_context(" hello_wo", {1, 10}) == :none
+
       for i <- 1..6 do
         assert CF.surround_context("hello!", {1, i}) == %{
                  context: {:local_or_var, 'hello!'},
@@ -468,6 +478,16 @@ defmodule CodeFragmentTest do
       end
 
       assert CF.surround_context("HelloWor", {1, 9}) == :none
+
+      for i <- 2..9 do
+        assert CF.surround_context(" HelloWor", {1, i}) == %{
+                 context: {:alias, 'HelloWor'},
+                 begin: {1, 2},
+                 end: {1, 10}
+               }
+      end
+
+      assert CF.surround_context(" HelloWor", {1, 10}) == :none
 
       for i <- 1..9 do
         assert CF.surround_context("Hello.Wor", {1, i}) == %{


### PR DESCRIPTION
Before:

```ex
iex(1)> Code.Fragment.surround_context(" Enum", {1, 4})
%{begin: {1, 1}, context: {:alias, 'Enum'}, end: {1, 6}}
```

After:

```ex
iex(1)> Code.Fragment.surround_context(" Enum", {1, 4})
%{begin: {1, 2}, context: {:alias, 'Enum'}, end: {1, 6}}
```