### PR TITLE
`String.split/3`: special case some additional arguments

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -494,6 +494,12 @@ defmodule String do
       {:infinity, false} ->
         :binary.split(string, pattern, [:global])
 
+      {:infinity, true} ->
+        :binary.split(string, pattern, [:global, :trim_all])
+
+      {2, false} ->
+        :binary.split(string, pattern)
+
       _ ->
         pattern = maybe_compile_pattern(pattern)
         split_each(string, pattern, trim, parts_to_index(parts))


### PR DESCRIPTION
- `[parts: :infinity, trim: true]` can use the `trim_all` argument to
`:binary.split/3`
- `[parts: 2, trim: false]` can use the basic `:binary.split/2` behavior