### PR TITLE
Code.Typespec: handle column in anno on newer OTP versions

### DIFF
--- a/lib/elixir/lib/code/typespec.ex
+++ b/lib/elixir/lib/code/typespec.ex
@@ -417,11 +417,5 @@ defmodule Code.Typespec do
     :error
   end
 
-  defp meta(line) when is_integer(line) do
-    [line: line]
-  end
-
-  defp meta({line, _column}) when is_integer(line) do
-    [line: line]
-  end
+  defp meta(anno), do: [line: :erl_anno.line(anno)]
 end


### PR DESCRIPTION
I noticed this crash:

    iex(1)> h :binary.decode_hex
    ** (ArgumentError) invalid runtime value for option :line in quote, got: {412, 14}
        (elixir 1.13.0-dev) src/elixir_quote.erl:59: :elixir_quote.validate_runtime/2
        (elixir 1.13.0-dev) lib/code/typespec.ex:294: Code.Typespec.typespec_to_quoted/1
        (elixir 1.13.0-dev) lib/code/typespec.ex:39: anonymous fn/2 in Code.Typespec.spec_to_quoted/2
        (elixir 1.13.0-dev) lib/enum.ex:2386: Enum."-reduce/3-lists^foldl/2-0-"/3
        (elixir 1.13.0-dev) lib/code/typespec.ex:38: Code.Typespec.spec_to_quoted/2
        (iex 1.13.0-dev) lib/iex/introspection.ex:483: anonymous fn/2 in IEx.Introspection.get_spec/3
        (elixir 1.13.0-dev) lib/enum.ex:1583: Enum."-map/2-lists^map/1-0-"/2
        (iex 1.13.0-dev) lib/iex/introspection.ex:482: IEx.Introspection.get_spec/3

It can be reproduced with the test included in the patch. It failed the following way on OTP 24:

    1) test erlang module (TypespecTest)
       lib/elixir/test/elixir/typespec_test.exs:1523
       Assertion with == failed
       code:  assert Code.Typespec.type_to_quoted(type) == {:"::", [], [{:t, [], [{:x, [line: line], nil}]}, [{:x, [line: line], nil}]]}
       left:  {:"::", [], [{:t, [], [{:x, [line: {5, 9}], nil}]}, [{:x, [line: {5, 20}], nil}]]}
       right: {:"::", [], [{:t, [], [{:x, [line: 5], nil}]}, [{:x, [line: 5], nil}]]}
       stacktrace:
         lib/elixir/test/elixir/typespec_test.exs:1538: (test)
