### PR TITLE
Break Macro.Env apart

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4529,7 +4529,7 @@ defmodule Kernel do
           :elixir_quote.escape(block, :default, false)
       end
 
-    module_vars = :lists.map(&module_var/1, :maps.keys(elem(env.current_vars, 0)))
+    module_vars = :lists.map(&module_var/1, :maps.keys(env.versioned_vars))
 
     quote do
       unquote(with_alias)

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -3500,7 +3500,7 @@ defmodule Kernel do
           end
 
         try do
-          :elixir_quote.escape(value, :default, false)
+          :elixir_quote.escape(value, :none, false)
         rescue
           ex in [ArgumentError] ->
             raise ArgumentError,
@@ -4526,7 +4526,7 @@ defmodule Kernel do
           quote(do: Kernel.LexicalTracker.read_cache(unquote(pid), unquote(integer)))
 
         %{} ->
-          :elixir_quote.escape(block, :default, false)
+          :elixir_quote.escape(block, :none, false)
       end
 
     module_vars = :lists.map(&module_var/1, :maps.keys(env.versioned_vars))
@@ -4781,12 +4781,12 @@ defmodule Kernel do
 
     unquoted_call = :elixir_quote.has_unquotes(call)
     unquoted_expr = :elixir_quote.has_unquotes(expr)
-    escaped_call = :elixir_quote.escape(call, :default, true)
+    escaped_call = :elixir_quote.escape(call, :none, true)
 
     escaped_expr =
       case unquoted_expr do
         true ->
-          :elixir_quote.escape(expr, :default, true)
+          :elixir_quote.escape(expr, :none, true)
 
         false ->
           key = :erlang.unique_integer()

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4364,7 +4364,7 @@ defmodule Kernel do
   defmacro var!({name, meta, atom}, context) when is_atom(name) and is_atom(atom) do
     # Remove counter and force them to be vars
     meta = :lists.keydelete(:counter, 1, meta)
-    meta = :lists.keystore(:var, 1, meta, {:var, true})
+    meta = :lists.keystore(:if_undefined, 1, meta, {:if_undefined, :raise})
 
     case Macro.expand(context, __CALLER__) do
       context when is_atom(context) ->

--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -226,7 +226,7 @@ defmodule Kernel.Utils do
   def defguard(args, expr, env) do
     {^args, vars} = extract_refs_from_args(args)
     env = :elixir_env.with_vars(%{env | context: :guard}, vars)
-    {expr, _scope} = :elixir_expand.expand(expr, env)
+    {expr, _, _} = :elixir_expand.expand(expr, :elixir_env.env_to_ex(env), env)
 
     quote do
       case Macro.Env.in_guard?(__CALLER__) do

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1534,7 +1534,10 @@ defmodule Macro do
           []
         end
 
-      expand = :elixir_dispatch.expand_import(meta, {atom, length(args)}, args, env, extra, true)
+      s = :elixir_env.env_to_ex(env)
+
+      expand =
+        :elixir_dispatch.expand_import(meta, {atom, length(args)}, args, s, env, extra, true)
 
       case expand do
         {:ok, receiver, quoted} ->
@@ -1565,7 +1568,9 @@ defmodule Macro do
         {original, false}
 
       true ->
-        expand = :elixir_dispatch.expand_require(meta, receiver, {right, length(args)}, args, env)
+        s = :elixir_env.env_to_ex(env)
+        name_arity = {right, length(args)}
+        expand = :elixir_dispatch.expand_require(meta, receiver, name_arity, args, s, env)
 
         case expand do
           {:ok, receiver, quoted} ->

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -604,8 +604,7 @@ defmodule Macro do
 
     * `:prune_metadata` - when true, removes metadata from escaped AST
       nodes. Note this option changes the semantics of escaped code and
-      it should only be used when escaping ASTs, never values. Defaults
-      to false.
+      it should only be used when escaping ASTs. Defaults to false.
 
       As an example, `ExUnit` stores the AST of every assertion, so when
       an assertion fails we can show code snippets to users. Without this
@@ -613,7 +612,8 @@ defmodule Macro do
       MD5 of the module bytecode, because the AST contains metadata,
       such as counters, specific to the compilation environment. By pruning
       the metadata, we ensure that the module is deterministic and reduce
-      the amount of data `ExUnit` needs to keep around.
+      the amount of data `ExUnit` needs to keep around. Only the minimal
+      amount of metadata is kept, such as `:line` and `:no_parens`.
 
   ## Comparison to `Kernel.SpecialForms.quote/2`
 
@@ -644,7 +644,7 @@ defmodule Macro do
   @spec escape(term, keyword) :: t()
   def escape(expr, opts \\ []) do
     unquote = Keyword.get(opts, :unquote, false)
-    kind = if Keyword.get(opts, :prune_metadata, false), do: :prune_metadata, else: :default
+    kind = if Keyword.get(opts, :prune_metadata, false), do: :prune_metadata, else: :none
     :elixir_quote.escape(expr, kind, unquote)
   end
 

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -36,15 +36,16 @@ defmodule Macro.Env do
     * `macros` - a list of macros imported from each module
     * `module` - the current module name
     * `requires` - the list of required modules
+    * `tracers` - the list of compilations tracers (see the `Code` module for more info)
 
   The following fields are private to Elixir's macro expansion mechanism and
   must not be accessed directly:
 
-    * `contextual_vars`
-    * `current_vars`
     * `lexical_tracker`
+    * `versioned_vars`
+
+    * `current_vars`
     * `prematch_vars`
-    * `tracers`
     * `unused_vars`
 
   """
@@ -62,7 +63,6 @@ defmodule Macro.Env do
   @type requires :: [module]
   @type variable :: {atom, atom | term}
 
-  @typep contextual_vars :: [atom]
   @typep current_vars ::
            {%{optional(variable) => var_version}, %{optional(variable) => var_version} | false}
   @typep unused_vars ::
@@ -81,7 +81,6 @@ defmodule Macro.Env do
           aliases: aliases,
           context: context,
           context_modules: context_modules,
-          contextual_vars: contextual_vars,
           current_vars: current_vars,
           file: file,
           function: name_arity | nil,
@@ -105,7 +104,6 @@ defmodule Macro.Env do
       aliases: [],
       context: nil,
       context_modules: [],
-      contextual_vars: [],
       current_vars: {%{}, %{}},
       file: "nofile",
       function: nil,

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -36,16 +36,15 @@ defmodule Macro.Env do
     * `macros` - a list of macros imported from each module
     * `module` - the current module name
     * `requires` - the list of required modules
-    * `tracers` - the list of compilations tracers (see the `Code` module for more info)
 
   The following fields are private to Elixir's macro expansion mechanism and
   must not be accessed directly:
 
     * `lexical_tracker`
+    * `tracers`
     * `versioned_vars`
 
     * `current_vars`
-    * `prematch_vars`
     * `unused_vars`
 
   """
@@ -61,9 +60,9 @@ defmodule Macro.Env do
   @type macros :: [{module, [name_arity]}]
   @type name_arity :: {atom, arity}
   @type requires :: [module]
-  @type tracers :: [module]
   @type variable :: {atom, atom | term}
 
+  @typep tracers :: [module]
   @typep var_version :: non_neg_integer
   @typep versioned_vars :: %{optional(variable) => var_version}
 
@@ -71,12 +70,6 @@ defmodule Macro.Env do
            {%{optional(variable) => var_version}, %{optional(variable) => var_version} | false}
   @typep unused_vars ::
            {%{optional({atom, var_version}) => non_neg_integer | false}, non_neg_integer}
-  @typep prematch_vars ::
-           {%{optional(variable) => var_version}, non_neg_integer}
-           | :warn
-           | :raise
-           | :pin
-           | :apply
 
   @type t :: %{
           __struct__: __MODULE__,
@@ -92,7 +85,6 @@ defmodule Macro.Env do
           macro_aliases: macro_aliases,
           macros: macros,
           module: module,
-          prematch_vars: prematch_vars,
           unused_vars: unused_vars,
           requires: requires,
           tracers: tracers,
@@ -116,7 +108,6 @@ defmodule Macro.Env do
       macro_aliases: [],
       macros: [],
       module: nil,
-      prematch_vars: :warn,
       requires: [],
       tracers: [],
       unused_vars: {%{}, 0},
@@ -171,12 +162,8 @@ defmodule Macro.Env do
   Returns a `Macro.Env` in the match context.
   """
   @spec to_match(t) :: t
-  def to_match(%{__struct__: Macro.Env, context: :match} = env) do
-    env
-  end
-
-  def to_match(%{__struct__: Macro.Env, current_vars: {read, _}, unused_vars: {_, counter}} = env) do
-    %{env | context: :match, prematch_vars: {read, counter}}
+  def to_match(%{__struct__: Macro.Env} = env) do
+    %{env | context: :match}
   end
 
   @doc """

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -44,9 +44,6 @@ defmodule Macro.Env do
     * `tracers`
     * `versioned_vars`
 
-    * `current_vars`
-    * `unused_vars`
-
   """
 
   @type aliases :: [{module, module}]
@@ -66,17 +63,11 @@ defmodule Macro.Env do
   @typep var_version :: non_neg_integer
   @typep versioned_vars :: %{optional(variable) => var_version}
 
-  @typep current_vars ::
-           {%{optional(variable) => var_version}, %{optional(variable) => var_version} | false}
-  @typep unused_vars ::
-           {%{optional({atom, var_version}) => non_neg_integer | false}, non_neg_integer}
-
   @type t :: %{
           __struct__: __MODULE__,
           aliases: aliases,
           context: context,
           context_modules: context_modules,
-          current_vars: current_vars,
           file: file,
           function: name_arity | nil,
           functions: functions,
@@ -85,7 +76,6 @@ defmodule Macro.Env do
           macro_aliases: macro_aliases,
           macros: macros,
           module: module,
-          unused_vars: unused_vars,
           requires: requires,
           tracers: tracers,
           versioned_vars: versioned_vars
@@ -99,7 +89,6 @@ defmodule Macro.Env do
       aliases: [],
       context: nil,
       context_modules: [],
-      current_vars: {%{}, %{}},
       file: "nofile",
       function: nil,
       functions: [],
@@ -110,7 +99,6 @@ defmodule Macro.Env do
       module: nil,
       requires: [],
       tracers: [],
-      unused_vars: {%{}, 0},
       versioned_vars: %{}
     }
   end

--- a/lib/elixir/lib/macro/env.ex
+++ b/lib/elixir/lib/macro/env.ex
@@ -64,18 +64,16 @@ defmodule Macro.Env do
 
   @typep contextual_vars :: [atom]
   @typep current_vars ::
-           {%{optional(variable) => {var_version, var_type}},
-            %{optional(variable) => {var_version, var_type}} | false}
+           {%{optional(variable) => var_version}, %{optional(variable) => var_version} | false}
   @typep unused_vars ::
            {%{optional({atom, var_version}) => non_neg_integer | false}, non_neg_integer}
   @typep prematch_vars ::
-           {%{optional(variable) => {var_version, var_type}}, non_neg_integer}
+           {%{optional(variable) => var_version}, non_neg_integer}
            | :warn
            | :raise
            | :pin
            | :apply
   @typep tracers :: [module]
-  @typep var_type :: :term
   @typep var_version :: non_neg_integer
 
   @type t :: %{

--- a/lib/elixir/lib/module/locals_tracker.ex
+++ b/lib/elixir/lib/module/locals_tracker.ex
@@ -71,8 +71,9 @@ defmodule Module.LocalsTracker do
     :ok
   end
 
-  # Collecting all conflicting imports with the given functions
-  @doc false
+  @doc """
+  Collect all conflicting imports with the given functions
+  """
   def collect_imports_conflicts({set, _bag}, all_defined) do
     for {pair, _, meta, _} <- all_defined, n = out_neighbour(set, {:import, pair}) do
       {meta, {n, pair}}

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -242,10 +242,10 @@ eval_quoted(Tree, Binding, #{line := Line} = E) ->
 
 eval_forms(Tree, Binding, Opts) when is_list(Opts) ->
   eval_forms(Tree, Binding, env_for_eval(Opts));
-eval_forms(Tree, RawBinding, OE) ->
+eval_forms(Tree, RawBinding, OrigE) ->
   {Vars, Binding} = normalize_binding(RawBinding, [], []),
-  E = elixir_env:with_vars(OE, Vars),
-  {_, S} = elixir_env:env_to_scope(E),
+  E = elixir_env:with_vars(OrigE, Vars),
+  {_, S} = elixir_env:env_to_erl(E),
   {Erl, NewE, NewS} = quoted_to_erl(Tree, E, S),
 
   case Erl of
@@ -325,11 +325,11 @@ merge_stacktrace([StackItem | Stacktrace], CurrentStack) ->
 %% Converts a quoted expression to Erlang abstract format
 
 quoted_to_erl(Quoted, E) ->
-  {_, S} = elixir_env:env_to_scope(E),
+  {_, S} = elixir_env:env_to_erl(E),
   quoted_to_erl(Quoted, E, S).
 
 quoted_to_erl(Quoted, Env, Scope) ->
-  {Expanded, NewEnv} = elixir_expand:expand(Quoted, Env),
+  {Expanded, _, NewEnv} = elixir_expand:expand(Quoted, elixir_env:env_to_ex(Env), Env),
   {Erl, NewScope} = elixir_erl_pass:translate(Expanded, Scope),
   {Erl, NewEnv, NewScope}.
 

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -246,7 +246,7 @@ eval_forms(Tree, RawBinding, OrigE) ->
   {Vars, Binding} = normalize_binding(RawBinding, [], []),
   E = elixir_env:with_vars(OrigE, Vars),
   {_, S} = elixir_env:env_to_erl(E),
-  {Erl, NewE, NewS} = quoted_to_erl(Tree, E, S),
+  {Erl, NewErlS, NewExS, NewE} = quoted_to_erl(Tree, E, S),
 
   case Erl of
     {atom, _, Atom} ->
@@ -261,7 +261,7 @@ eval_forms(Tree, RawBinding, OrigE) ->
 
       ErlBinding = elixir_erl_var:load_binding(Binding, E, S),
       {value, Value, NewBinding} = recur_eval(Exprs, ErlBinding, NewE),
-      {Value, elixir_erl_var:dump_binding(NewBinding, NewE, NewS), NewE}
+      {Value, elixir_erl_var:dump_binding(NewBinding, NewExS, NewErlS), NewE}
   end.
 
 normalize_binding([{Key, Value} | Binding], Vars, Acc) when is_atom(Key) ->
@@ -329,9 +329,9 @@ quoted_to_erl(Quoted, E) ->
   quoted_to_erl(Quoted, E, S).
 
 quoted_to_erl(Quoted, Env, Scope) ->
-  {Expanded, _, NewEnv} = elixir_expand:expand(Quoted, elixir_env:env_to_ex(Env), Env),
-  {Erl, NewScope} = elixir_erl_pass:translate(Expanded, Scope),
-  {Erl, NewEnv, NewScope}.
+  {Expanded, NewExS, NewEnv} = elixir_expand:expand(Quoted, elixir_env:env_to_ex(Env), Env),
+  {Erl, NewErlS} = elixir_erl_pass:translate(Expanded, Scope),
+  {Erl, NewErlS, NewExS, NewEnv}.
 
 %% Converts a given string (charlist) into quote expression
 

--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -8,7 +8,9 @@
 -record(elixir_ex, {
   caller=false,            %% stores if __CALLER__ is allowed
   prematch=warn,           %% {Read, Counter} | warn | raise | pin
-  stacktrace=false         %% stores if __STACKTRACE__ is allowed
+  stacktrace=false,        %% stores if __STACKTRACE__ is allowed
+  unused={#{}, 0},         %% a map of unused vars and a version counter for vars
+  vars={#{}, false}        %% a tuple with maps of read and optional write current vars
 }).
 
 -record(elixir_erl, {

--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -6,6 +6,8 @@
 -define(remote(Ann, Module, Function, Args), {call, Ann, {remote, Ann, {atom, Ann, Module}, {atom, Ann, Function}}, Args}).
 
 -record(elixir_ex, {
+  caller=false,            %% stores if __CALLER__ is allowed
+  stacktrace=false         %% stores if __STACKTRACE__ is allowed
 }).
 
 -record(elixir_erl, {

--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -5,6 +5,9 @@
 -define(var_context, ?MODULE).
 -define(remote(Ann, Module, Function, Args), {call, Ann, {remote, Ann, {atom, Ann, Module}, {atom, Ann, Function}}, Args}).
 
+-record(elixir_ex, {
+}).
+
 -record(elixir_erl, {
   context=nil,             %% can be match, guards or nil
   extra=nil,               %% extra information about the context, like pin_guard and map_key

--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -7,6 +7,7 @@
 
 -record(elixir_ex, {
   caller=false,            %% stores if __CALLER__ is allowed
+  prematch=warn,           %% {Read, Counter} | warn | raise | pin
   stacktrace=false         %% stores if __STACKTRACE__ is allowed
 }).
 

--- a/lib/elixir/src/elixir_aliases.erl
+++ b/lib/elixir/src/elixir_aliases.erl
@@ -56,10 +56,12 @@ expand({'__aliases__', Meta, _} = Alias, #{aliases := Aliases, macro_aliases := 
 
 expand({'__aliases__', Meta, [H | T]}, Aliases, E) when is_atom(H) ->
   Lookup  = list_to_atom("Elixir." ++ atom_to_list(H)),
+
   Counter = case lists:keyfind(counter, 1, Meta) of
     {counter, C} -> C;
     _ -> nil
   end,
+
   case lookup(Lookup, Aliases, Counter) of
     Lookup -> [H | T];
     Atom ->

--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -198,7 +198,7 @@ expand_each_spec(Meta, [{Expr, _, Args} = H | T], Map, S, E, OriginalE) when is_
 
       expand_each_spec(Meta, T, maps:put(Key, Value, Map), SE, EE, OriginalE);
     none ->
-      case 'Elixir.Macro':expand(H, elixir_env:linify({?line(Meta), E})) of
+      case 'Elixir.Macro':expand(H, E#{line := ?line(Meta)}) of
         H ->
           form_error(Meta, E, ?MODULE, {undefined_bittype, H});
         NewTypes ->

--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -3,15 +3,15 @@
 -import(elixir_errors, [form_error/4]).
 -include("elixir.hrl").
 
-expand_match(Expr, S, {E, OriginalE}) ->
+expand_match(Expr, {S, OriginalS}, E) ->
   {EExpr, SE, EE} = elixir_expand:expand(Expr, S, E),
-  {EExpr, SE, {EE, OriginalE}}.
+  {EExpr, {SE, OriginalS}, EE}.
 
 expand(Meta, Args, S, E, RequireSize) ->
   case ?key(E, context) of
     match ->
-      {EArgs, Alignment, SA, {EA, _}} =
-        expand(Meta, fun expand_match/3, Args, [], S, {E, E}, 0, RequireSize),
+      {EArgs, Alignment, {SA, _}, EA} =
+        expand(Meta, fun expand_match/3, Args, [], {S, S}, E, 0, RequireSize),
 
       case find_match(EArgs) of
         false ->
@@ -20,28 +20,28 @@ expand(Meta, Args, S, E, RequireSize) ->
           form_error(Meta, EA, ?MODULE, {nested_match, Match})
       end;
     _ ->
-      PairE = {elixir_env:prepare_write(E), E},
+      PairS = {elixir_env:prepare_write(S), S},
 
-      {EArgs, Alignment, SA, {EA, _}} =
-        expand(Meta, fun elixir_expand:expand_arg/3, Args, [], S, PairE, 0, RequireSize),
+      {EArgs, Alignment, {SA, _}, EA} =
+        expand(Meta, fun elixir_expand:expand_arg/3, Args, [], PairS, E, 0, RequireSize),
 
-      {{'<<>>', [{alignment, Alignment} | Meta], EArgs}, SA, elixir_env:close_write(EA, E)}
+      {{'<<>>', [{alignment, Alignment} | Meta], EArgs}, elixir_env:close_write(SA, S), EA}
   end.
 
 expand(_BitstrMeta, _Fun, [], Acc, S, E, Alignment, _RequireSize) ->
   {lists:reverse(Acc), Alignment, S, E};
 expand(BitstrMeta, Fun, [{'::', Meta, [Left, Right]} | T], Acc, S, E, Alignment, RequireSize) ->
-  {ELeft, SL, {EL, OriginalE}} = expand_expr(Meta, Left, Fun, S, E),
+  {ELeft, {SL, OriginalS}, EL} = expand_expr(Meta, Left, Fun, S, E),
 
   MatchOrRequireSize = RequireSize or is_match_size(T, EL),
   EType = expr_type(ELeft),
-  {ERight, EAlignment, SS, ES} = expand_specs(EType, Meta, Right, SL, EL, OriginalE, MatchOrRequireSize),
+  {ERight, EAlignment, SS, ES} = expand_specs(EType, Meta, Right, SL, OriginalS, EL, MatchOrRequireSize),
 
   EAcc = concat_or_prepend_bitstring(Meta, ELeft, ERight, Acc, ES, MatchOrRequireSize),
-  expand(BitstrMeta, Fun, T, EAcc, SS, {ES, OriginalE}, alignment(Alignment, EAlignment), RequireSize);
+  expand(BitstrMeta, Fun, T, EAcc, {SS, OriginalS}, ES, alignment(Alignment, EAlignment), RequireSize);
 expand(BitstrMeta, Fun, [H | T], Acc, S, E, Alignment, RequireSize) ->
   Meta = extract_meta(H, BitstrMeta),
-  {ELeft, SS, {ES, OriginalE}} = expand_expr(Meta, H, Fun, S, E),
+  {ELeft, {SS, OriginalS}, ES} = expand_expr(Meta, H, Fun, S, E),
 
   MatchOrRequireSize = RequireSize or is_match_size(T, ES),
   EType = expr_type(ELeft),
@@ -49,7 +49,7 @@ expand(BitstrMeta, Fun, [H | T], Acc, S, E, Alignment, RequireSize) ->
 
   InferredMeta = [{inferred_bitstring_spec, true} | Meta],
   EAcc = concat_or_prepend_bitstring(InferredMeta, ELeft, ERight, Acc, ES, MatchOrRequireSize),
-  expand(Meta, Fun, T, EAcc, SS, {ES, OriginalE}, Alignment, RequireSize).
+  expand(Meta, Fun, T, EAcc, {SS, OriginalS}, ES, Alignment, RequireSize).
 
 extract_meta({_, Meta, _}, _) -> Meta;
 extract_meta(_, Meta) -> Meta.
@@ -133,7 +133,7 @@ compute_alignment(_, _, _) -> unknown.
 %% If we are inside a match/guard, we inline interpolations explicitly,
 %% otherwise they are inlined by elixir_rewrite.erl.
 
-expand_expr(_Meta, {{'.', _, [Mod, to_string]}, _, [Arg]} = AST, Fun, S, {#{context := Context}, _} = E)
+expand_expr(_Meta, {{'.', _, [Mod, to_string]}, _, [Arg]} = AST, Fun, S, #{context := Context} = E)
     when Context /= nil, (Mod == 'Elixir.Kernel') orelse (Mod == 'Elixir.String.Chars') ->
   case Fun(Arg, S, E) of
     {EBin, SE, EE} when is_binary(EBin) -> {EBin, SE, EE};
@@ -141,7 +141,7 @@ expand_expr(_Meta, {{'.', _, [Mod, to_string]}, _, [Arg]} = AST, Fun, S, {#{cont
   end;
 expand_expr(Meta, Component, Fun, S, E) ->
   case Fun(Component, S, E) of
-    {EComponent, _, {ErrorE, _}} when is_list(EComponent); is_atom(EComponent) ->
+    {EComponent, _, ErrorE} when is_list(EComponent); is_atom(EComponent) ->
       form_error(Meta, ErrorE, ?MODULE, {invalid_literal, EComponent});
     {_, _, _} = Expanded ->
       Expanded
@@ -149,7 +149,7 @@ expand_expr(Meta, Component, Fun, S, E) ->
 
 %% Expands and normalizes types of a bitstring.
 
-expand_specs(ExprType, Meta, Info, S, E, OriginalE, RequireSize) ->
+expand_specs(ExprType, Meta, Info, S, OriginalS, E, RequireSize) ->
   Default =
     #{size => default,
       unit => default,
@@ -157,7 +157,7 @@ expand_specs(ExprType, Meta, Info, S, E, OriginalE, RequireSize) ->
       type => default,
       endianness => default},
   {#{size := Size, unit := Unit, type := Type, endianness := Endianness, sign := Sign}, SS, ES} =
-    expand_each_spec(Meta, unpack_specs(Info, []), Default, S, E, OriginalE),
+    expand_each_spec(Meta, unpack_specs(Info, []), Default, S, OriginalS, E),
 
   MergedType = type(Meta, ExprType, Type, E),
   validate_size_required(Meta, RequireSize, ExprType, MergedType, Size, ES),
@@ -184,11 +184,11 @@ type(_, default, Type, _) ->
 type(Meta, Other, Value, E) ->
   form_error(Meta, E, ?MODULE, {bittype_mismatch, Value, Other, type}).
 
-expand_each_spec(Meta, [{Expr, _, Args} = H | T], Map, S, E, OriginalE) when is_atom(Expr) ->
+expand_each_spec(Meta, [{Expr, _, Args} = H | T], Map, S, OriginalS, E) when is_atom(Expr) ->
   case validate_spec(Expr, Args) of
     {Key, Arg} ->
-      {Value, SE, EE} = expand_spec_arg(Arg, S, E, OriginalE),
-      validate_spec_arg(Meta, Key, Value, S, EE, OriginalE),
+      {Value, SE, EE} = expand_spec_arg(Arg, S, OriginalS, E),
+      validate_spec_arg(Meta, Key, Value, SE, OriginalS, EE),
 
       case maps:get(Key, Map) of
         default -> ok;
@@ -196,18 +196,20 @@ expand_each_spec(Meta, [{Expr, _, Args} = H | T], Map, S, E, OriginalE) when is_
         Other -> form_error(Meta, E, ?MODULE, {bittype_mismatch, Value, Other, Key})
       end,
 
-      expand_each_spec(Meta, T, maps:put(Key, Value, Map), SE, EE, OriginalE);
+      expand_each_spec(Meta, T, maps:put(Key, Value, Map), SE, OriginalS, EE);
+
     none ->
       case 'Elixir.Macro':expand(H, E#{line := ?line(Meta)}) of
         H ->
           form_error(Meta, E, ?MODULE, {undefined_bittype, H});
+
         NewTypes ->
-          expand_each_spec(Meta, unpack_specs(NewTypes, []) ++ T, Map, S, E, OriginalE)
+          expand_each_spec(Meta, unpack_specs(NewTypes, []) ++ T, Map, S, OriginalS, E)
       end
   end;
-expand_each_spec(Meta, [Expr | _], _Map, _S, E, _OriginalE) ->
+expand_each_spec(Meta, [Expr | _], _Map, _S, _OriginalS, E) ->
   form_error(Meta, E, ?MODULE, {undefined_bittype, Expr});
-expand_each_spec(_Meta, [], Map, S, E, _OriginalE) ->
+expand_each_spec(_Meta, [], Map, S, _OriginalS, E) ->
   {Map, S, E}.
 
 unpack_specs({'-', _, [H, T]}, Acc) ->
@@ -242,20 +244,20 @@ validate_spec(signed, [])    -> {sign, signed};
 validate_spec(unsigned, [])  -> {sign, unsigned};
 validate_spec(_, _)          -> none.
 
-expand_spec_arg(Expr, S, E, _OriginalE) when is_atom(Expr); is_integer(Expr) ->
+expand_spec_arg(Expr, S, _OriginalS, E) when is_atom(Expr); is_integer(Expr) ->
   {Expr, S, E};
-expand_spec_arg(Expr, S, #{context := match} = E, _OriginalE) ->
+expand_spec_arg(Expr, S, _OriginalS, #{context := match} = E) ->
   {EExpr, SE, EE} = elixir_expand:expand(Expr, S#elixir_ex{prematch=raise}, E#{context := nil}),
   {EExpr, SE#elixir_ex{prematch=S#elixir_ex.prematch}, EE#{context := match}};
-expand_spec_arg(Expr, S, E, OriginalE) ->
-  elixir_expand:expand(Expr, S, elixir_env:reset_read(E, OriginalE)).
+expand_spec_arg(Expr, S, OriginalS, E) ->
+  elixir_expand:expand(Expr, elixir_env:reset_read(S, OriginalS), E).
 
-validate_spec_arg(Meta, size, Value, S, E, OriginalE) ->
+validate_spec_arg(Meta, size, Value, S, OriginalS, E) ->
   case Value of
     {Var, VarMeta, Context} when is_atom(Var) and is_atom(Context) ->
       Tuple = {Var, elixir_utils:var_context(VarMeta, Context)},
 
-      case is_valid_spec_arg_var(Tuple, S, E, OriginalE) of
+      case is_valid_spec_arg_var(Tuple, S, OriginalS, E) of
         true -> ok;
         false -> form_error(Meta, E, ?MODULE, {undefined_var_in_spec, Value})
       end;
@@ -266,20 +268,20 @@ validate_spec_arg(Meta, size, Value, S, E, OriginalE) ->
     _ ->
       form_error(Meta, E, ?MODULE, {bad_size_argument, Value})
   end;
-validate_spec_arg(Meta, unit, Value, _S, E, _OriginalE) when not is_integer(Value) ->
+validate_spec_arg(Meta, unit, Value, _S, _OriginalS, E) when not is_integer(Value) ->
   form_error(Meta, E, ?MODULE, {bad_unit_argument, Value});
-validate_spec_arg(_Meta, _Key, _Value, _S, _E, _OriginalE) ->
+validate_spec_arg(_Meta, _Key, _Value, _S, _OriginalS, _E) ->
   ok.
 
-is_valid_spec_arg_var(Var, S, E, #{context := match} = OriginalE) ->
+is_valid_spec_arg_var(Var, S, OriginalS, #{context := match}) ->
   case S#elixir_ex.prematch of
     {#{Var := _}, _} -> true;
-    _ -> is_var(Var, E) andalso not is_var(Var, OriginalE)
+    _ -> is_var(Var, S) andalso not is_var(Var, OriginalS)
   end;
-is_valid_spec_arg_var(_Var, _S, _E, _OriginalE) ->
+is_valid_spec_arg_var(_Var, _S, _OriginalS, _E) ->
   true.
 
-is_var(Var, #{current_vars := {Read, _}}) ->
+is_var(Var, #elixir_ex{vars={Read, _}}) ->
   maps:is_key(Var, Read).
 
 validate_size_required(Meta, true, default, Type, default, E) when Type == binary; Type == bitstring ->

--- a/lib/elixir/src/elixir_bootstrap.erl
+++ b/lib/elixir/src/elixir_bootstrap.erl
@@ -35,7 +35,7 @@
    {defmodule, 2},
    {defp, 2}].
 
-define({Line, E}, Kind, Call, Expr) ->
+define({Line, _S, E}, Kind, Call, Expr) ->
   UC = elixir_quote:has_unquotes(Call),
   UE = elixir_quote:has_unquotes(Expr),
   EscapedCall = elixir_quote:escape(Call, default, true),

--- a/lib/elixir/src/elixir_bootstrap.erl
+++ b/lib/elixir/src/elixir_bootstrap.erl
@@ -19,7 +19,7 @@
 'MACRO-defmacrop'(Caller, Call, Expr) -> define(Caller, defmacrop, Call, Expr).
 
 'MACRO-defmodule'(_Caller, Alias, [{do, Block}]) ->
-  Escaped = elixir_quote:escape(Block, default, false),
+  Escaped = elixir_quote:escape(Block, none, false),
   Args = [Alias, Escaped, [], env()],
   {{'.', [], [elixir_module, compile]}, [], Args}.
 
@@ -38,8 +38,8 @@
 define({Line, _S, E}, Kind, Call, Expr) ->
   UC = elixir_quote:has_unquotes(Call),
   UE = elixir_quote:has_unquotes(Expr),
-  EscapedCall = elixir_quote:escape(Call, default, true),
-  EscapedExpr = elixir_quote:escape(Expr, default, true),
+  EscapedCall = elixir_quote:escape(Call, none, true),
+  EscapedExpr = elixir_quote:escape(Expr, none, true),
   Args = [Kind, not(UC or UE), EscapedCall, EscapedExpr, elixir_locals:cache_env(E#{line := Line})],
   {{'.', [], [elixir_def, store_definition]}, [], Args}.
 

--- a/lib/elixir/src/elixir_clauses.erl
+++ b/lib/elixir/src/elixir_clauses.erl
@@ -252,10 +252,10 @@ expand_try(Meta, {Key, _}, _S, E) ->
   form_error(Meta, E, ?MODULE, {unexpected_option, 'try', Key}).
 
 expand_clauses_with_stacktrace(Meta, Fun, Clauses, S, E) ->
-  OldContextualVars = ?key(E, contextual_vars),
-  ES = E#{contextual_vars := ['__STACKTRACE__' | OldContextualVars]},
-  {Ret, S, EE} = expand_clauses(Meta, 'try', Fun, Clauses, S, ES),
-  {Ret, S, EE#{contextual_vars := OldContextualVars}}.
+  OldStacktrace = S#elixir_ex.stacktrace,
+  SS = S#elixir_ex{stacktrace=true},
+  {Ret, SE, EE} = expand_clauses(Meta, 'try', Fun, Clauses, SS, E),
+  {Ret, SE#elixir_ex{stacktrace=OldStacktrace}, EE}.
 
 expand_catch(_Meta, [_] = Args, S, E) ->
   head(Args, S, E);

--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -48,8 +48,8 @@ eval_forms(Forms, Args, E) ->
   end.
 
 compile(Quoted, ArgsList, E) ->
-  {Expanded, _SE, EE} = elixir_expand:expand(Quoted, elixir_env:env_to_ex(E), E),
-  elixir_env:check_unused_vars(EE),
+  {Expanded, SE, EE} = elixir_expand:expand(Quoted, elixir_env:env_to_ex(E), E),
+  elixir_env:check_unused_vars(SE, EE),
 
   {Module, Fun, Purgeable} =
     elixir_erl_compiler:spawn(fun() -> spawned_compile(Expanded, E) end),

--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -48,17 +48,17 @@ eval_forms(Forms, Args, E) ->
   end.
 
 compile(Quoted, ArgsList, E) ->
-  Args = list_to_tuple(ArgsList),
-  {Expanded, EE} = elixir_expand:expand(Quoted, E),
+  {Expanded, _SE, EE} = elixir_expand:expand(Quoted, elixir_env:env_to_ex(E), E),
   elixir_env:check_unused_vars(EE),
 
   {Module, Fun, Purgeable} =
     elixir_erl_compiler:spawn(fun() -> spawned_compile(Expanded, E) end),
 
+  Args = list_to_tuple(ArgsList),
   {dispatch(Module, Fun, Args, Purgeable), EE}.
 
 spawned_compile(ExExprs, #{line := Line, file := File} = E) ->
-  {Vars, S} = elixir_env:env_to_scope(E),
+  {Vars, S} = elixir_env:env_to_erl(E),
   {ErlExprs, _} = elixir_erl_pass:translate(ExExprs, S),
 
   Module = retrieve_compiler_module(),

--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -181,9 +181,10 @@ store_definition(Meta, Kind, CheckClauses, Name, Arity, DefaultsArgs, Guards, Bo
   Tuple.
 
 env_for_expansion(Kind, Tuple, E) when Kind =:= defmacro; Kind =:= defmacrop ->
-  {elixir_env:env_to_ex(E), E#{function := Tuple, contextual_vars := ['__CALLER__']}};
+  S = elixir_env:env_to_ex(E),
+  {S#elixir_ex{caller=true}, E#{function := Tuple}};
 env_for_expansion(_Kind, Tuple, E) ->
-  {elixir_env:env_to_ex(E), E#{function := Tuple, contextual_vars := []}}.
+  {elixir_env:env_to_ex(E), E#{function := Tuple}}.
 
 retrieve_location(Location, Module) ->
   {Set, _} = elixir_module:data_tables(Module),

--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -162,10 +162,10 @@ store_definition(Kind, CheckClauses, Call, Body, Pos) ->
 store_definition(Meta, Kind, CheckClauses, Name, Arity, DefaultsArgs, Guards, Body, File, ER) ->
   Module = ?key(ER, module),
   Tuple = {Name, Arity},
-  E = env_for_expansion(Kind, Tuple, ER),
+  {S, E} = env_for_expansion(Kind, Tuple, ER),
 
-  {Args, Defaults} = unpack_defaults(Kind, Meta, Name, DefaultsArgs, E),
-  Clauses = [elixir_clauses:def(Clause, E) ||
+  {Args, Defaults} = unpack_defaults(Kind, Meta, Name, DefaultsArgs, S, E),
+  Clauses = [elixir_clauses:def(Clause, S, E) ||
              Clause <- def_to_clauses(Kind, Meta, Args, Guards, Body, E)],
 
   DefaultsLength = length(Defaults),
@@ -181,9 +181,9 @@ store_definition(Meta, Kind, CheckClauses, Name, Arity, DefaultsArgs, Guards, Bo
   Tuple.
 
 env_for_expansion(Kind, Tuple, E) when Kind =:= defmacro; Kind =:= defmacrop ->
-  E#{function := Tuple, contextual_vars := ['__CALLER__']};
+  {elixir_env:env_to_ex(E), E#{function := Tuple, contextual_vars := ['__CALLER__']}};
 env_for_expansion(_Kind, Tuple, E) ->
-  E#{function := Tuple, contextual_vars := []}.
+  {elixir_env:env_to_ex(E), E#{function := Tuple, contextual_vars := []}}.
 
 retrieve_location(Location, Module) ->
   {Set, _} = elixir_module:data_tables(Module),
@@ -259,26 +259,26 @@ store_definition(Check, Kind, Meta, Name, Arity, File, Module, Defaults, Clauses
 
 %% Handling of defaults
 
-unpack_defaults(Kind, Meta, Name, Args, E) ->
-  Expanded = expand_defaults(Args, E#{context := nil}),
-  unpack_defaults(Kind, Meta, Name, Expanded, [], []).
+unpack_defaults(Kind, Meta, Name, Args, S, E) ->
+  Expanded = expand_defaults(Args, S, E#{context := nil}),
+  unpack_expanded(Kind, Meta, Name, Expanded, [], []).
 
-unpack_defaults(Kind, Meta, Name, [{'\\\\', DefaultMeta, [Expr, _]} | T] = List, Acc, Clauses) ->
+unpack_expanded(Kind, Meta, Name, [{'\\\\', DefaultMeta, [Expr, _]} | T] = List, Acc, Clauses) ->
   Base = match_defaults(Acc, length(Acc), []),
   {Args, Invoke} = extract_defaults(List, length(Base), [], []),
   Clause = {Meta, Base ++ Args, [], {super, [{super, {Kind, Name}} | DefaultMeta], Base ++ Invoke}},
-  unpack_defaults(Kind, Meta, Name, T, [Expr | Acc], [Clause | Clauses]);
-unpack_defaults(Kind, Meta, Name, [H | T], Acc, Clauses) ->
-  unpack_defaults(Kind, Meta, Name, T, [H | Acc], Clauses);
-unpack_defaults(_Kind, _Meta, _Name, [], Acc, Clauses) ->
+  unpack_expanded(Kind, Meta, Name, T, [Expr | Acc], [Clause | Clauses]);
+unpack_expanded(Kind, Meta, Name, [H | T], Acc, Clauses) ->
+  unpack_expanded(Kind, Meta, Name, T, [H | Acc], Clauses);
+unpack_expanded(_Kind, _Meta, _Name, [], Acc, Clauses) ->
   {lists:reverse(Acc), lists:reverse(Clauses)}.
 
-expand_defaults([{'\\\\', Meta, [Expr, Default]} | Args], E) ->
-  {ExpandedDefault, _} = elixir_expand:expand(Default, E),
-  [{'\\\\', Meta, [Expr, ExpandedDefault]} | expand_defaults(Args, E)];
-expand_defaults([Arg | Args], E) ->
-  [Arg | expand_defaults(Args, E)];
-expand_defaults([], _E) ->
+expand_defaults([{'\\\\', Meta, [Expr, Default]} | Args], S, E) ->
+  {ExpandedDefault, _, _} = elixir_expand:expand(Default, S, E),
+  [{'\\\\', Meta, [Expr, ExpandedDefault]} | expand_defaults(Args, S, E)];
+expand_defaults([Arg | Args], S, E) ->
+  [Arg | expand_defaults(Args, S, E)];
+expand_defaults([], _S, _E) ->
   [].
 
 extract_defaults([{'\\\\', _, [_Expr, Default]} | T], Counter, NewArgs, NewInvoke) ->

--- a/lib/elixir/src/elixir_dispatch.erl
+++ b/lib/elixir/src/elixir_dispatch.erl
@@ -98,11 +98,8 @@ dispatch_import(Meta, Name, Args, S, E, Callback) ->
   end.
 
 %% TODO: Remove this rewrite when we require Erlang/OTP 23+
-dispatch_require(_Meta, 'Elixir.System', stacktrace, [], S, #{contextual_vars := Vars} = E, Callback) ->
-  case lists:member('__STACKTRACE__', Vars) of
-    true -> {{'__STACKTRACE__', [], nil}, S, E};
-    false -> Callback('Elixir.System', stacktrace, [])
-  end;
+dispatch_require(_Meta, 'Elixir.System', stacktrace, [], #elixir_ex{stacktrace=true} = S, E, _Callback) ->
+  {{'__STACKTRACE__', [], nil}, S, E};
 
 dispatch_require(Meta, Receiver, Name, Args, S, E, Callback) when is_atom(Receiver) ->
   Arity = length(Args),

--- a/lib/elixir/src/elixir_dispatch.erl
+++ b/lib/elixir/src/elixir_dispatch.erl
@@ -2,9 +2,9 @@
 %% This module access the information stored on the scope
 %% by elixir_import and therefore assumes it is normalized (ordsets)
 -module(elixir_dispatch).
--export([dispatch_import/5, dispatch_require/6,
+-export([dispatch_import/6, dispatch_require/7,
   require_function/5, import_function/4,
-  expand_import/6, expand_require/5,
+  expand_import/7, expand_require/6,
   default_functions/0, default_macros/0, default_requires/0,
   find_import/4, format_error/1]).
 -include("elixir.hrl").
@@ -86,50 +86,50 @@ remote_function(Meta, Receiver, Name, Arity, E) ->
 
 %% Dispatches
 
-dispatch_import(Meta, Name, Args, E, Callback) ->
+dispatch_import(Meta, Name, Args, S, E, Callback) ->
   Arity = length(Args),
-  case expand_import(Meta, {Name, Arity}, Args, E, [], false) of
+  case expand_import(Meta, {Name, Arity}, Args, S, E, [], false) of
     {ok, Receiver, Quoted} ->
-      expand_quoted(Meta, Receiver, Name, Arity, Quoted, E);
+      expand_quoted(Meta, Receiver, Name, Arity, Quoted, S, E);
     {ok, Receiver, NewName, NewArgs} ->
-      elixir_expand:expand({{'.', Meta, [Receiver, NewName]}, Meta, NewArgs}, E);
+      elixir_expand:expand({{'.', Meta, [Receiver, NewName]}, Meta, NewArgs}, S, E);
     error ->
       Callback()
   end.
 
 %% TODO: Remove this rewrite when we require Erlang/OTP 23+
-dispatch_require(_Meta, 'Elixir.System', stacktrace, [], #{contextual_vars := Vars} = E, Callback) ->
+dispatch_require(_Meta, 'Elixir.System', stacktrace, [], S, #{contextual_vars := Vars} = E, Callback) ->
   case lists:member('__STACKTRACE__', Vars) of
-    true -> {{'__STACKTRACE__', [], nil}, E};
+    true -> {{'__STACKTRACE__', [], nil}, S, E};
     false -> Callback('Elixir.System', stacktrace, [])
   end;
 
-dispatch_require(Meta, Receiver, Name, Args, E, Callback) when is_atom(Receiver) ->
+dispatch_require(Meta, Receiver, Name, Args, S, E, Callback) when is_atom(Receiver) ->
   Arity = length(Args),
 
   case elixir_rewrite:inline(Receiver, Name, Arity) of
     {AR, AN} ->
       Callback(AR, AN, Args);
     false ->
-      case expand_require(Meta, Receiver, {Name, Arity}, Args, E) of
-        {ok, Receiver, Quoted} -> expand_quoted(Meta, Receiver, Name, Arity, Quoted, E);
+      case expand_require(Meta, Receiver, {Name, Arity}, Args, S, E) of
+        {ok, Receiver, Quoted} -> expand_quoted(Meta, Receiver, Name, Arity, Quoted, S, E);
         error -> Callback(Receiver, Name, Args)
       end
   end;
 
-dispatch_require(_Meta, Receiver, Name, Args, _E, Callback) ->
+dispatch_require(_Meta, Receiver, Name, Args, _S, _E, Callback) ->
   Callback(Receiver, Name, Args).
 
 %% Macros expansion
 
-expand_import(Meta, {Name, Arity} = Tuple, Args, E, Extra, External) ->
+expand_import(Meta, {Name, Arity} = Tuple, Args, S, E, Extra, External) ->
   Module = ?key(E, module),
   Function = ?key(E, function),
   Dispatch = find_dispatch(Meta, Tuple, Extra, E),
 
   case Dispatch of
     {import, _} ->
-      do_expand_import(Meta, Tuple, Args, Module, E, Dispatch);
+      do_expand_import(Meta, Tuple, Args, Module, S, E, Dispatch);
     _ ->
       AllowLocals = External orelse ((Function /= nil) andalso (Function /= Tuple)),
       Local = AllowLocals andalso
@@ -144,17 +144,17 @@ expand_import(Meta, {Name, Arity} = Tuple, Args, E, Extra, External) ->
 
         %% There is no local. Dispatch the import.
         _ when Local == false ->
-          do_expand_import(Meta, Tuple, Args, Module, E, Dispatch);
+          do_expand_import(Meta, Tuple, Args, Module, S, E, Dispatch);
 
         %% Dispatch to the local.
         _ ->
           elixir_env:trace({local_macro, Meta, Name, Arity}, E),
           elixir_locals:record_local(Tuple, Module, Function, Meta, true),
-          {ok, Module, expand_macro_fun(Meta, Local, Module, Name, Args, E)}
+          {ok, Module, expand_macro_fun(Meta, Local, Module, Name, Args, S, E)}
       end
   end.
 
-do_expand_import(Meta, {Name, Arity} = Tuple, Args, Module, E, Result) ->
+do_expand_import(Meta, {Name, Arity} = Tuple, Args, Module, S, E, Result) ->
   case Result of
     {function, Receiver} ->
       elixir_env:trace({imported_function, Meta, Receiver, Name, Arity}, E),
@@ -164,9 +164,9 @@ do_expand_import(Meta, {Name, Arity} = Tuple, Args, Module, E, Result) ->
       check_deprecated(Meta, macro, Receiver, Name, Arity, E),
       elixir_env:trace({imported_macro, Meta, Receiver, Name, Arity}, E),
       elixir_locals:record_import(Tuple, Receiver, Module, ?key(E, function)),
-      {ok, Receiver, expand_macro_named(Meta, Receiver, Name, Arity, Args, E)};
+      {ok, Receiver, expand_macro_named(Meta, Receiver, Name, Arity, Args, S, E)};
     {import, Receiver} ->
-      case expand_require([{required, true} | Meta], Receiver, Tuple, Args, E) of
+      case expand_require([{required, true} | Meta], Receiver, Tuple, Args, S, E) of
         {ok, _, _} = Response -> Response;
         error -> {ok, Receiver, Name, Args}
       end;
@@ -179,14 +179,14 @@ do_expand_import(Meta, {Name, Arity} = Tuple, Args, Module, E, Result) ->
       error
   end.
 
-expand_require(Meta, Receiver, {Name, Arity} = Tuple, Args, E) ->
+expand_require(Meta, Receiver, {Name, Arity} = Tuple, Args, S, E) ->
   Required = (Receiver == ?key(E, module)) orelse required(Meta) orelse is_element(Receiver, ?key(E, requires)),
 
   case is_element(Tuple, get_macros(Receiver, Required)) of
     true when Required ->
       check_deprecated(Meta, macro, Receiver, Name, Arity, E),
       elixir_env:trace({remote_macro, Meta, Receiver, Name, Arity}, E),
-      {ok, Receiver, expand_macro_named(Meta, Receiver, Name, Arity, Args, E)};
+      {ok, Receiver, expand_macro_named(Meta, Receiver, Name, Arity, Args, S, E)};
     true ->
       Info = {unrequired_module, {Receiver, Name, length(Args)}},
       elixir_errors:form_error(Meta, E, ?MODULE, Info);
@@ -197,7 +197,7 @@ expand_require(Meta, Receiver, {Name, Arity} = Tuple, Args, E) ->
 
 %% Expansion helpers
 
-expand_macro_fun(Meta, Fun, Receiver, Name, Args, E) ->
+expand_macro_fun(Meta, Fun, Receiver, Name, Args, _S, E) ->
   Line = ?line(Meta),
   EArg = {Line, E},
 
@@ -211,20 +211,19 @@ expand_macro_fun(Meta, Fun, Receiver, Name, Args, E) ->
       erlang:raise(Kind, Reason, prune_stacktrace(Stacktrace, MFA, Info, {ok, EArg}))
   end.
 
-expand_macro_named(Meta, Receiver, Name, Arity, Args, E) ->
+expand_macro_named(Meta, Receiver, Name, Arity, Args, S, E) ->
   ProperName  = elixir_utils:macro_name(Name),
   ProperArity = Arity + 1,
   Fun         = fun Receiver:ProperName/ProperArity,
-  expand_macro_fun(Meta, Fun, Receiver, Name, Args, E).
+  expand_macro_fun(Meta, Fun, Receiver, Name, Args, S, E).
 
-expand_quoted(Meta, Receiver, Name, Arity, Quoted, E) ->
+expand_quoted(Meta, Receiver, Name, Arity, Quoted, S, E) ->
   Line = ?line(Meta),
   Next = elixir_module:next_counter(?key(E, module)),
 
   try
-    elixir_expand:expand(
-      elixir_quote:linify_with_context_counter(Line, {Receiver, Next}, Quoted),
-      E)
+    ToExpand = elixir_quote:linify_with_context_counter(Line, {Receiver, Next}, Quoted),
+    elixir_expand:expand(ToExpand, S, E)
   catch
     Kind:Reason:Stacktrace ->
       MFA  = {Receiver, elixir_utils:macro_name(Name), Arity+1},

--- a/lib/elixir/src/elixir_dispatch.erl
+++ b/lib/elixir/src/elixir_dispatch.erl
@@ -194,9 +194,9 @@ expand_require(Meta, Receiver, {Name, Arity} = Tuple, Args, S, E) ->
 
 %% Expansion helpers
 
-expand_macro_fun(Meta, Fun, Receiver, Name, Args, _S, E) ->
+expand_macro_fun(Meta, Fun, Receiver, Name, Args, S, E) ->
   Line = ?line(Meta),
-  EArg = {Line, E},
+  EArg = {Line, S, E},
 
   try
     apply(Fun, [EArg | Args])

--- a/lib/elixir/src/elixir_env.erl
+++ b/lib/elixir/src/elixir_env.erl
@@ -27,7 +27,6 @@ new() ->
     unused_vars => {#{}, 0},                          %% a map of unused vars and a version counter for vars
     prematch_vars => warn,                            %% controls behaviour outside and inside matches
     lexical_tracker => nil,                           %% lexical tracker PID
-    contextual_vars => [],                            %% available contextual variables
     tracers => []                                     %% available compilation tracers
   }.
 

--- a/lib/elixir/src/elixir_env.erl
+++ b/lib/elixir/src/elixir_env.erl
@@ -26,7 +26,6 @@ new() ->
     versioned_vars => #{},                            %% a map of vars with their latest versions
     current_vars => {#{}, false},                     %% a tuple with maps of read and optional write current vars
     unused_vars => {#{}, 0},                          %% a map of unused vars and a version counter for vars
-    prematch_vars => warn,                            %% controls behaviour outside and inside matches
     lexical_tracker => nil,                           %% lexical tracker PID
     tracers => []                                     %% available compilation tracers
   }.
@@ -50,11 +49,8 @@ reset_vars(Env) ->
 
 %% CONVERSIONS
 
-% def to_match(%{__struct__: Macro.Env, current_vars: {read, _}, unused_vars: {_, counter}} = env) do
-%   %{env | context: :match, prematch_vars: {read, counter}}
-% end
-env_to_ex(#{context := match}) ->
-  #elixir_ex{};
+env_to_ex(#{context := match, current_vars := {Read, _}, unused_vars := {_, Counter}}) ->
+  #elixir_ex{prematch={Read, Counter}};
 env_to_ex(#{}) ->
   #elixir_ex{}.
 

--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -221,7 +221,7 @@ translate_clause(Kind, {Meta, Args, Guards, Body}, ExpandCaptures) ->
         true  ->
           FBody = {'match', Ann,
             {'var', Ann, '__CALLER__'},
-            ?remote(Ann, elixir_env, linify, [{var, Ann, '_@CALLER'}])
+            ?remote(Ann, elixir_env, to_caller, [{var, Ann, '_@CALLER'}])
           },
           setelement(5, MClause, [FBody | element(5, TClause)]);
         false ->

--- a/lib/elixir/src/elixir_erl_var.erl
+++ b/lib/elixir/src/elixir_erl_var.erl
@@ -44,7 +44,7 @@ build_name(Name, Count) -> list_to_atom("_" ++ atom_to_list(Name) ++ "@" ++ inte
 
 %% BINDINGS
 
-load_binding(Binding, #{current_vars := {ExVars, _}}, #elixir_erl{var_names=ErlVars}) ->
+load_binding(Binding, #{versioned_vars := ExVars}, #elixir_erl{var_names=ErlVars}) ->
   %% TODO: Remove me once we require Erlang/OTP 24+
   %% Also revisit dump_binding below and remove the vars field for simplicity.
   Mod =
@@ -62,7 +62,7 @@ load_binding(Binding, #{current_vars := {ExVars, _}}, #elixir_erl{var_names=ErlV
 
   Mod:from_list(KV).
 
-dump_binding(Binding, #{current_vars := {ExVars, _}}, #elixir_erl{var_names=ErlVars}) ->
+dump_binding(Binding, #elixir_ex{vars={ExVars, _}}, #elixir_erl{var_names=ErlVars}) ->
   maps:fold(fun
     ({Var, Kind} = Pair, Version, Acc) when is_atom(Kind) ->
       Key = case Kind of
@@ -73,6 +73,7 @@ dump_binding(Binding, #{current_vars := {ExVars, _}}, #elixir_erl{var_names=ErlV
       ErlName = maps:get(Version, ErlVars),
       Value = find_binding(ErlName, Binding),
       [{Key, Value} | Acc];
+
     (_, _, Acc) ->
       Acc
   end, [], ExVars).

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -1,152 +1,153 @@
 -module(elixir_expand).
--export([expand/2, expand_args/2, expand_arg/2, format_error/1]).
+-export([expand/3, expand_args/3, expand_arg/3, format_error/1]).
 -import(elixir_errors, [form_error/4]).
 -include("elixir.hrl").
 
 %% =
 
-expand({'=', Meta, [Left, Right]}, E) ->
+expand({'=', Meta, [Left, Right]}, S, E) ->
   assert_no_guard_scope(Meta, "=", E),
-  {ERight, ER} = expand(Right, E),
-  {ELeft, EL} = elixir_clauses:match(fun expand/2, Left, ER, E),
+  {ERight, SR, ER} = expand(Right, S, E),
+  {ELeft, SL, EL} = elixir_clauses:match(fun expand/3, Left, SR, ER, E),
   refute_parallel_bitstring_match(ELeft, ERight, E, ?key(E, context) == match),
-  {{'=', Meta, [ELeft, ERight]}, EL};
+  {{'=', Meta, [ELeft, ERight]}, SL, EL};
 
 %% Literal operators
 
-expand({'{}', Meta, Args}, E) ->
-  {EArgs, EA} = expand_args(Args, E),
-  {{'{}', Meta, EArgs}, EA};
+expand({'{}', Meta, Args}, S, E) ->
+  {EArgs, SA, EA} = expand_args(Args, S, E),
+  {{'{}', Meta, EArgs}, SA, EA};
 
-expand({'%{}', Meta, Args}, E) ->
-  elixir_map:expand_map(Meta, Args, E);
+expand({'%{}', Meta, Args}, S, E) ->
+  elixir_map:expand_map(Meta, Args, S, E);
 
-expand({'%', Meta, [Left, Right]}, E) ->
-  elixir_map:expand_struct(Meta, Left, Right, E);
+expand({'%', Meta, [Left, Right]}, S, E) ->
+  elixir_map:expand_struct(Meta, Left, Right, S, E);
 
-expand({'<<>>', Meta, Args}, E) ->
-  elixir_bitstring:expand(Meta, Args, E, false);
+expand({'<<>>', Meta, Args}, S, E) ->
+  elixir_bitstring:expand(Meta, Args, S, E, false);
 
-expand({'->', Meta, _Args}, E) ->
+expand({'->', Meta, _Args}, _S, E) ->
   form_error(Meta, E, ?MODULE, unhandled_arrow_op);
 
 %% __block__
 
-expand({'__block__', _Meta, []}, E) ->
-  {nil, E};
-expand({'__block__', _Meta, [Arg]}, E) ->
-  expand(Arg, E);
-expand({'__block__', Meta, Args}, E) when is_list(Args) ->
-  {EArgs, EA} = expand_block(Args, [], Meta, E),
-  {{'__block__', Meta, EArgs}, EA};
+expand({'__block__', _Meta, []}, S, E) ->
+  {nil, S, E};
+expand({'__block__', _Meta, [Arg]}, S, E) ->
+  expand(Arg, S, E);
+expand({'__block__', Meta, Args}, S, E) when is_list(Args) ->
+  {EArgs, SA, EA} = expand_block(Args, [], Meta, S, E),
+  {{'__block__', Meta, EArgs}, SA, EA};
 
 %% __aliases__
 
-expand({'__aliases__', _, _} = Alias, E) ->
-  expand_aliases(Alias, E, true);
+expand({'__aliases__', _, _} = Alias, S, E) ->
+  expand_aliases(Alias, S, E, true);
 
 %% alias
 
-expand({Kind, Meta, [{{'.', _, [Base, '{}']}, _, Refs} | Rest]}, E)
+expand({Kind, Meta, [{{'.', _, [Base, '{}']}, _, Refs} | Rest]}, S, E)
     when Kind == alias; Kind == require; Kind == import ->
   case Rest of
     [] ->
-      expand_multi_alias_call(Kind, Meta, Base, Refs, [], E);
+      expand_multi_alias_call(Kind, Meta, Base, Refs, [], S, E);
     [Opts] ->
       case lists:keymember(as, 1, Opts) of
         true ->
           form_error(Meta, E, ?MODULE, as_in_multi_alias_call);
         false ->
-          expand_multi_alias_call(Kind, Meta, Base, Refs, Opts, E)
+          expand_multi_alias_call(Kind, Meta, Base, Refs, Opts, S, E)
       end
   end;
-expand({alias, Meta, [Ref]}, E) ->
-  expand({alias, Meta, [Ref, []]}, E);
-expand({alias, Meta, [Ref, Opts]}, E) ->
+expand({alias, Meta, [Ref]}, S, E) ->
+  expand({alias, Meta, [Ref, []]}, S, E);
+expand({alias, Meta, [Ref, Opts]}, S, E) ->
   assert_no_match_or_guard_scope(Meta, "alias", E),
-  {ERef, ER} = expand_without_aliases_report(Ref, E),
-  {EOpts, ET}  = expand_opts(Meta, alias, [as, warn], no_alias_opts(Opts), ER),
+  {ERef, SR, ER} = expand_without_aliases_report(Ref, S, E),
+  {EOpts, ST, ET} = expand_opts(Meta, alias, [as, warn], no_alias_opts(Opts), SR, ER),
 
   if
     is_atom(ERef) ->
-      {ERef, expand_alias(Meta, true, ERef, EOpts, ET)};
+      {ERef, ST, expand_alias(Meta, true, ERef, EOpts, ET)};
     true ->
       form_error(Meta, E, ?MODULE, {expected_compile_time_module, alias, Ref})
   end;
 
-expand({require, Meta, [Ref]}, E) ->
-  expand({require, Meta, [Ref, []]}, E);
-expand({require, Meta, [Ref, Opts]}, E) ->
+expand({require, Meta, [Ref]}, S, E) ->
+  expand({require, Meta, [Ref, []]}, S, E);
+expand({require, Meta, [Ref, Opts]}, S, E) ->
   assert_no_match_or_guard_scope(Meta, "require", E),
 
-  {ERef, ER} = expand_without_aliases_report(Ref, E),
-  {EOpts, ET}  = expand_opts(Meta, require, [as, warn], no_alias_opts(Opts), ER),
+  {ERef, SR, ER} = expand_without_aliases_report(Ref, S, E),
+  {EOpts, ST, ET}  = expand_opts(Meta, require, [as, warn], no_alias_opts(Opts), SR, ER),
 
   if
     is_atom(ERef) ->
       elixir_aliases:ensure_loaded(Meta, ERef, ET),
-      {ERef, expand_require(Meta, ERef, EOpts, ET)};
+      {ERef, ST, expand_require(Meta, ERef, EOpts, ET)};
     true ->
       form_error(Meta, E, ?MODULE, {expected_compile_time_module, require, Ref})
   end;
 
-expand({import, Meta, [Left]}, E) ->
-  expand({import, Meta, [Left, []]}, E);
+expand({import, Meta, [Left]}, S, E) ->
+  expand({import, Meta, [Left, []]}, S, E);
 
-expand({import, Meta, [Ref, Opts]}, E) ->
+expand({import, Meta, [Ref, Opts]}, S, E) ->
   assert_no_match_or_guard_scope(Meta, "import", E),
-  {ERef, ER} = expand_without_aliases_report(Ref, E),
-  {EOpts, ET}  = expand_opts(Meta, import, [only, except, warn], Opts, ER),
+  {ERef, SR, ER} = expand_without_aliases_report(Ref, S, E),
+  {EOpts, ST, ET} = expand_opts(Meta, import, [only, except, warn], Opts, SR, ER),
 
   if
     is_atom(ERef) ->
       elixir_aliases:ensure_loaded(Meta, ERef, ET),
       {Functions, Macros} = elixir_import:import(Meta, ERef, EOpts, ET),
-      {ERef, expand_require(Meta, ERef, EOpts, ET#{functions := Functions, macros := Macros})};
+      {ERef, ST, expand_require(Meta, ERef, EOpts, ET#{functions := Functions, macros := Macros})};
     true ->
       form_error(Meta, E, ?MODULE, {expected_compile_time_module, import, Ref})
   end;
 
 %% Compilation environment macros
 
-expand({'__MODULE__', _, Atom}, E) when is_atom(Atom) ->
-  {?key(E, module), E};
-expand({'__DIR__', _, Atom}, E) when is_atom(Atom) ->
-  {filename:dirname(?key(E, file)), E};
-expand({'__CALLER__', Meta, Atom} = Caller, E) when is_atom(Atom) ->
+expand({'__MODULE__', _, Atom}, S, E) when is_atom(Atom) ->
+  {?key(E, module), S, E};
+expand({'__DIR__', _, Atom}, S, E) when is_atom(Atom) ->
+  {filename:dirname(?key(E, file)), S, E};
+expand({'__CALLER__', Meta, Atom} = Caller, S, E) when is_atom(Atom) ->
   assert_contextual_var(Meta, '__CALLER__', E, caller_not_allowed),
-  {Caller, E};
-expand({'__STACKTRACE__', Meta, Atom} = Stacktrace, E) when is_atom(Atom) ->
+  {Caller, S, E};
+expand({'__STACKTRACE__', Meta, Atom} = Stacktrace, S, E) when is_atom(Atom) ->
   assert_contextual_var(Meta, '__STACKTRACE__', E, stacktrace_not_allowed),
-  {Stacktrace, E};
-expand({'__ENV__', Meta, Atom}, #{context := match} = E) when is_atom(Atom) ->
+  {Stacktrace, S, E};
+expand({'__ENV__', Meta, Atom}, _S, #{context := match} = E) when is_atom(Atom) ->
   form_error(Meta, E, ?MODULE, env_not_allowed);
-expand({'__ENV__', Meta, Atom}, E) when is_atom(Atom) ->
-  {maybe_escape_map(escape_env_entries(Meta, E)), E};
-expand({{'.', DotMeta, [{'__ENV__', Meta, Atom}, Field]}, CallMeta, []}, E) when is_atom(Atom), is_atom(Field) ->
-  Env = escape_env_entries(Meta, E),
+expand({'__ENV__', Meta, Atom}, S, E) when is_atom(Atom) ->
+  {maybe_escape_map(escape_env_entries(Meta, S, E)), S, E};
+expand({{'.', DotMeta, [{'__ENV__', Meta, Atom}, Field]}, CallMeta, []}, S, E)
+    when is_atom(Atom), is_atom(Field) ->
+  Env = escape_env_entries(Meta, S, E),
   case maps:is_key(Field, Env) of
-    true  -> {maps:get(Field, Env), E};
-    false -> {{{'.', DotMeta, [maybe_escape_map(Env), Field]}, CallMeta, []}, E}
+    true  -> {maps:get(Field, Env), S, E};
+    false -> {{{'.', DotMeta, [maybe_escape_map(Env), Field]}, CallMeta, []}, S, E}
   end;
 
 %% Quote
 
-expand({Unquote, Meta, [_]}, E) when Unquote == unquote; Unquote == unquote_splicing ->
+expand({Unquote, Meta, [_]}, _S, E) when Unquote == unquote; Unquote == unquote_splicing ->
   form_error(Meta, E, ?MODULE, {unquote_outside_quote, Unquote});
 
-expand({quote, Meta, [Opts]}, E) when is_list(Opts) ->
+expand({quote, Meta, [Opts]}, S, E) when is_list(Opts) ->
   case lists:keyfind(do, 1, Opts) of
     {do, Do} ->
-      expand({quote, Meta, [lists:keydelete(do, 1, Opts), [{do, Do}]]}, E);
+      expand({quote, Meta, [lists:keydelete(do, 1, Opts), [{do, Do}]]}, S, E);
     false ->
       form_error(Meta, E, ?MODULE, {missing_option, 'quote', [do]})
   end;
 
-expand({quote, Meta, [_]}, E) ->
+expand({quote, Meta, [_]}, _S, E) ->
   form_error(Meta, E, ?MODULE, {invalid_args, 'quote'});
 
-expand({quote, Meta, [Opts, Do]}, E) when is_list(Do) ->
+expand({quote, Meta, [Opts, Do]}, S, E) when is_list(Do) ->
   Exprs =
     case lists:keyfind(do, 1, Do) of
       {do, Expr} -> Expr;
@@ -154,7 +155,7 @@ expand({quote, Meta, [Opts, Do]}, E) when is_list(Do) ->
     end,
 
   ValidOpts = [context, location, line, file, unquote, bind_quoted, generated],
-  {EOpts, ET} = expand_opts(Meta, quote, ValidOpts, Opts, E),
+  {EOpts, ST, ET} = expand_opts(Meta, quote, ValidOpts, Opts, S, E),
 
   Context = proplists:get_value(context, EOpts, case ?key(E, module) of
     nil -> 'Elixir';
@@ -184,66 +185,66 @@ expand({quote, Meta, [Opts, Do]}, E) when is_list(Do) ->
 
   {Q, Prelude} = elixir_quote:build(Meta, Line, File, Context, Unquote, Generated),
   Quoted = elixir_quote:quote(Meta, Exprs, Binding, Q, Prelude, ET),
-  expand(Quoted, ET);
+  expand(Quoted, ST, ET);
 
-expand({quote, Meta, [_, _]}, E) ->
+expand({quote, Meta, [_, _]}, _S, E) ->
   form_error(Meta, E, ?MODULE, {invalid_args, 'quote'});
 
 %% Functions
 
-expand({'&', Meta, [{super, SuperMeta, Args} = Expr]}, E) when is_list(Args) ->
+expand({'&', Meta, [{super, SuperMeta, Args} = Expr]}, S, E) when is_list(Args) ->
   assert_no_match_or_guard_scope(Meta, "&", E),
 
   case resolve_super(Meta, length(Args), E) of
     {Kind, Name, _} when Kind == def; Kind == defp ->
-      expand_fn_capture(Meta, {Name, SuperMeta, Args}, E);
+      expand_fn_capture(Meta, {Name, SuperMeta, Args}, S, E);
     _ ->
-      expand_fn_capture(Meta, Expr, E)
+      expand_fn_capture(Meta, Expr, S, E)
   end;
 
-expand({'&', Meta, [{'/', _, [{super, _, Context}, Arity]} = Expr]}, E) when is_atom(Context), is_integer(Arity) ->
+expand({'&', Meta, [{'/', _, [{super, _, Context}, Arity]} = Expr]}, S, E) when is_atom(Context), is_integer(Arity) ->
   assert_no_match_or_guard_scope(Meta, "&", E),
 
   case resolve_super(Meta, Arity, E) of
     {Kind, Name, _} when Kind == def; Kind == defp ->
-      {{'&', Meta, [{'/', [], [{Name, [], Context}, Arity]}]}, E};
+      {{'&', Meta, [{'/', [], [{Name, [], Context}, Arity]}]}, S, E};
     _ ->
-      expand_fn_capture(Meta, Expr, E)
+      expand_fn_capture(Meta, Expr, S, E)
   end;
 
-expand({'&', Meta, [Arg]}, E) ->
+expand({'&', Meta, [Arg]}, S, E) ->
   assert_no_match_or_guard_scope(Meta, "&", E),
-  expand_fn_capture(Meta, Arg, E);
+  expand_fn_capture(Meta, Arg, S, E);
 
-expand({fn, Meta, Pairs}, E) ->
+expand({fn, Meta, Pairs}, S, E) ->
   assert_no_match_or_guard_scope(Meta, "fn", E),
-  elixir_fn:expand(Meta, Pairs, E);
+  elixir_fn:expand(Meta, Pairs, S, E);
 
 %% Case/Receive/Try
 
-expand({'cond', Meta, [Opts]}, E) ->
+expand({'cond', Meta, [Opts]}, S, E) ->
   assert_no_match_or_guard_scope(Meta, "cond", E),
   assert_no_underscore_clause_in_cond(Opts, E),
-  {EClauses, EC} = elixir_clauses:'cond'(Meta, Opts, E),
-  {{'cond', Meta, [EClauses]}, EC};
+  {EClauses, SC, EC} = elixir_clauses:'cond'(Meta, Opts, S, E),
+  {{'cond', Meta, [EClauses]}, SC, EC};
 
-expand({'case', Meta, [Expr, Options]}, E) ->
+expand({'case', Meta, [Expr, Options]}, S, E) ->
   assert_no_match_or_guard_scope(Meta, "case", E),
-  expand_case(Meta, Expr, Options, E);
+  expand_case(Meta, Expr, Options, S, E);
 
-expand({'receive', Meta, [Opts]}, E) ->
+expand({'receive', Meta, [Opts]}, S, E) ->
   assert_no_match_or_guard_scope(Meta, "receive", E),
-  {EClauses, EC} = elixir_clauses:'receive'(Meta, Opts, E),
-  {{'receive', Meta, [EClauses]}, EC};
+  {EClauses, SC, EC} = elixir_clauses:'receive'(Meta, Opts, S, E),
+  {{'receive', Meta, [EClauses]}, SC, EC};
 
-expand({'try', Meta, [Opts]}, E) ->
+expand({'try', Meta, [Opts]}, S, E) ->
   assert_no_match_or_guard_scope(Meta, "try", E),
-  {EClauses, EC} = elixir_clauses:'try'(Meta, Opts, E),
-  {{'try', Meta, [EClauses]}, EC};
+  {EClauses, SC, EC} = elixir_clauses:'try'(Meta, Opts, S, E),
+  {{'try', Meta, [EClauses]}, SC, EC};
 
 %% Comprehensions
 
-expand({for, Meta, [_ | _] = Args}, E) ->
+expand({for, Meta, [_ | _] = Args}, S, E) ->
   assert_no_match_or_guard_scope(Meta, "for", E),
 
   {Cases, Block} =
@@ -269,55 +270,55 @@ expand({for, Meta, [_ | _] = Args}, E) ->
         form_error(Meta, E, ?MODULE, {missing_option, for, [do]})
     end,
 
-  {EOpts, EO} = expand(Opts, elixir_env:reset_unused_vars(E)),
-  {ECases, EC} = lists:mapfoldl(fun expand_for/2, EO, Cases),
+  {EOpts, SO, EO} = expand(Opts, S, elixir_env:reset_unused_vars(E)),
+  {ECases, SC, EC} = elixir_env:mapfold(fun expand_for/3, SO, EO, Cases),
   assert_generator_start(Meta, ECases, E),
 
-  {EExpr, EE} =
+  {EExpr, SE, EE} =
     case validate_for_options(EOpts, false, false, false) of
-      {ok, MaybeReduce} -> expand_for_do_block(Meta, Expr, EC, MaybeReduce);
+      {ok, MaybeReduce} -> expand_for_do_block(Meta, Expr, SC, EC, MaybeReduce);
       {error, Error} -> form_error(Meta, E, ?MODULE, Error)
     end,
 
-  {{for, Meta, ECases ++ [[{do, EExpr} | EOpts]]}, elixir_env:merge_and_check_unused_vars(E, EE)};
+  {{for, Meta, ECases ++ [[{do, EExpr} | EOpts]]}, SE, elixir_env:merge_and_check_unused_vars(E, EE)};
 
 %% With
 
-expand({with, Meta, [_ | _] = Args}, E) ->
+expand({with, Meta, [_ | _] = Args}, S, E) ->
   assert_no_match_or_guard_scope(Meta, "with", E),
-  elixir_clauses:with(Meta, Args, E);
+  elixir_clauses:with(Meta, Args, S, E);
 
 %% Super
 
-expand({super, Meta, Args}, E) when is_list(Args) ->
+expand({super, Meta, Args}, S, E) when is_list(Args) ->
   assert_no_match_or_guard_scope(Meta, "super", E),
   {Kind, Name, _} = resolve_super(Meta, length(Args), E),
-  {EArgs, EA} = expand_args(Args, E),
-  {{super, [{super, {Kind, Name}} | Meta], EArgs}, EA};
+  {EArgs, SA, EA} = expand_args(Args, S, E),
+  {{super, [{super, {Kind, Name}} | Meta], EArgs}, SA, EA};
 
 %% Vars
 
-expand({'^', Meta, [Arg]}, #{context := match} = E) ->
+expand({'^', Meta, [Arg]}, S, #{context := match} = E) ->
   #{current_vars := {_ReadCurrent, WriteCurrent}, prematch_vars := {Prematch, _}} = E,
 
   %% We need to rollback to a no match context.
   NoMatchE = E#{context := nil, current_vars := {Prematch, WriteCurrent}, prematch_vars := pin},
 
-  case expand(Arg, NoMatchE) of
-    {{Name, _, Kind} = Var, #{unused_vars := Unused}} when is_atom(Name), is_atom(Kind) ->
-      {{'^', Meta, [Var]}, E#{unused_vars := Unused}};
+  case expand(Arg, S, NoMatchE) of
+    {{Name, _, Kind} = Var, _, #{unused_vars := Unused}} when is_atom(Name), is_atom(Kind) ->
+      {{'^', Meta, [Var]}, S, E#{unused_vars := Unused}};
     _ ->
       form_error(Meta, E, ?MODULE, {invalid_arg_for_pin, Arg})
   end;
-expand({'^', Meta, [Arg]}, E) ->
+expand({'^', Meta, [Arg]}, _S, E) ->
   form_error(Meta, E, ?MODULE, {pin_outside_of_match, Arg});
 
-expand({'_', _Meta, Kind} = Var, #{context := match} = E) when is_atom(Kind) ->
-  {Var, E};
-expand({'_', Meta, Kind}, E) when is_atom(Kind) ->
+expand({'_', _Meta, Kind} = Var, S, #{context := match} = E) when is_atom(Kind) ->
+  {Var, S, E};
+expand({'_', Meta, Kind}, _S, E) when is_atom(Kind) ->
   form_error(Meta, E, ?MODULE, unbound_underscore);
 
-expand({Name, Meta, Kind}, #{context := match} = E) when is_atom(Name), is_atom(Kind) ->
+expand({Name, Meta, Kind}, S, #{context := match} = E) when is_atom(Name), is_atom(Kind) ->
   #{
     current_vars := {ReadCurrent, WriteCurrent},
     unused_vars := {Unused, Version},
@@ -332,7 +333,7 @@ expand({Name, Meta, Kind}, #{context := match} = E) when is_atom(Name), is_atom(
       maybe_warn_underscored_var_repeat(Meta, Name, Kind, E),
       NewUnused = var_used(Pair, VarVersion, Unused),
       Var = {Name, [{version, VarVersion} | Meta], Kind},
-      {Var, E#{unused_vars := {NewUnused, Version}}};
+      {Var, S, E#{unused_vars := {NewUnused, Version}}};
 
     %% Variable is being overridden now
     #{Pair := _} ->
@@ -340,7 +341,7 @@ expand({Name, Meta, Kind}, #{context := match} = E) when is_atom(Name), is_atom(
       NewReadCurrent = ReadCurrent#{Pair => Version},
       NewWriteCurrent = (WriteCurrent /= false) andalso WriteCurrent#{Pair => Version},
       Var = {Name, [{version, Version} | Meta], Kind},
-      {Var, E#{current_vars := {NewReadCurrent, NewWriteCurrent}, unused_vars := {NewUnused, Version + 1}}};
+      {Var, S, E#{current_vars := {NewReadCurrent, NewWriteCurrent}, unused_vars := {NewUnused, Version + 1}}};
 
     %% Variable defined for the first time
     _ ->
@@ -348,10 +349,10 @@ expand({Name, Meta, Kind}, #{context := match} = E) when is_atom(Name), is_atom(
       NewReadCurrent = ReadCurrent#{Pair => Version},
       NewWriteCurrent = (WriteCurrent /= false) andalso WriteCurrent#{Pair => Version},
       Var = {Name, [{version, Version} | Meta], Kind},
-      {Var, E#{current_vars := {NewReadCurrent, NewWriteCurrent}, unused_vars := {NewUnused, Version + 1}}}
+      {Var, S, E#{current_vars := {NewReadCurrent, NewWriteCurrent}, unused_vars := {NewUnused, Version + 1}}}
   end;
 
-expand({Name, Meta, Kind}, E) when is_atom(Name), is_atom(Kind) ->
+expand({Name, Meta, Kind}, S, E) when is_atom(Name), is_atom(Kind) ->
   #{current_vars := {ReadCurrent, _WriteCurrent}, unused_vars := {Unused, Version}} = E,
   Pair = {Name, elixir_utils:var_context(Meta, Kind)},
 
@@ -359,7 +360,7 @@ expand({Name, Meta, Kind}, E) when is_atom(Name), is_atom(Kind) ->
     #{Pair := PairVersion} ->
       maybe_warn_underscored_var_access(Meta, Name, Kind, E),
       Var = {Name, [{version, PairVersion} | Meta], Kind},
-      {Var, E#{unused_vars := {var_used(Pair, PairVersion, Unused), Version}}};
+      {Var, S, E#{unused_vars := {var_used(Pair, PairVersion, Unused), Version}}};
 
     _ ->
       %% TODO: Remove this check on v2.0 as we can always raise undefined_var
@@ -372,7 +373,7 @@ expand({Name, Meta, Kind}, E) when is_atom(Name), is_atom(Kind) ->
             warn ->
               %% TODO: Remove warn option on v2.0
               elixir_errors:form_warn(Meta, E, ?MODULE, {unknown_variable, Name}),
-              expand({Name, Meta, []}, E);
+              expand({Name, Meta, []}, S, E);
 
             raise ->
               form_error(Meta, E, ?MODULE, {undefined_var, Name, Kind});
@@ -381,92 +382,91 @@ expand({Name, Meta, Kind}, E) when is_atom(Name), is_atom(Kind) ->
               form_error(Meta, E, ?MODULE, {undefined_var_pin, Name, Kind});
 
             apply ->
-              expand({Name, Meta, []}, E)
+              expand({Name, Meta, []}, S, E)
           end
       end
   end;
 
 %% Local calls
 
-expand({Atom, Meta, Args}, E) when is_atom(Atom), is_list(Meta), is_list(Args) ->
+expand({Atom, Meta, Args}, S, E) when is_atom(Atom), is_list(Meta), is_list(Args) ->
   assert_no_ambiguous_op(Atom, Meta, Args, E),
 
-  elixir_dispatch:dispatch_import(Meta, Atom, Args, E, fun() ->
-    expand_local(Meta, Atom, Args, E)
+  elixir_dispatch:dispatch_import(Meta, Atom, Args, S, E, fun() ->
+    expand_local(Meta, Atom, Args, S, E)
   end);
 
 %% Remote calls
 
-expand({{'.', DotMeta, [Left, Right]}, Meta, Args}, E)
+expand({{'.', DotMeta, [Left, Right]}, Meta, Args}, S, E)
     when (is_tuple(Left) orelse is_atom(Left)), is_atom(Right), is_list(Meta), is_list(Args) ->
-  {ELeft, EL} = expand(Left, elixir_env:prepare_write(E)),
+  {ELeft, SL, EL} = expand(Left, S, elixir_env:prepare_write(E)),
 
-  elixir_dispatch:dispatch_require(Meta, ELeft, Right, Args, EL, fun(AR, AF, AA) ->
-    expand_remote(AR, DotMeta, AF, Meta, AA, E, EL)
+  elixir_dispatch:dispatch_require(Meta, ELeft, Right, Args, S, EL, fun(AR, AF, AA) ->
+    expand_remote(AR, DotMeta, AF, Meta, AA, SL, E, EL)
   end);
 
 %% Anonymous calls
 
-expand({{'.', DotMeta, [Expr]}, Meta, Args}, E) when is_list(Args) ->
+expand({{'.', DotMeta, [Expr]}, Meta, Args}, S, E) when is_list(Args) ->
   assert_no_match_or_guard_scope(Meta, "anonymous call", E),
 
-  case expand_args([Expr | Args], E) of
-    {[EExpr | _], _} when is_atom(EExpr) ->
+  case expand_args([Expr | Args], S, E) of
+    {[EExpr | _], _, _} when is_atom(EExpr) ->
       form_error(Meta, E, ?MODULE, {invalid_function_call, EExpr});
 
-    {[EExpr | EArgs], EA} ->
-      {{{'.', DotMeta, [EExpr]}, Meta, EArgs}, EA}
+    {[EExpr | EArgs], SA, EA} ->
+      {{{'.', DotMeta, [EExpr]}, Meta, EArgs}, SA, EA}
   end;
 
 %% Invalid calls
 
-expand({_, Meta, Args} = Invalid, E) when is_list(Meta) and is_list(Args) ->
+expand({_, Meta, Args} = Invalid, _S, E) when is_list(Meta) and is_list(Args) ->
   form_error(Meta, E, ?MODULE, {invalid_call, Invalid});
-
-expand({_, _, _} = Tuple, E) ->
-  form_error([{line, 0}], ?key(E, file), ?MODULE, {invalid_quoted_expr, Tuple});
 
 %% Literals
 
-expand({Left, Right}, E) ->
-  {[ELeft, ERight], EE} = expand_args([Left, Right], E),
-  {{ELeft, ERight}, EE};
+expand({Left, Right}, S, E) ->
+  {[ELeft, ERight], SE, EE} = expand_args([Left, Right], S, E),
+  {{ELeft, ERight}, SE, EE};
 
-expand(List, #{context := match} = E) when is_list(List) ->
-  expand_list(List, fun expand/2, E, []);
+expand(List, S, #{context := match} = E) when is_list(List) ->
+  expand_list(List, fun expand/3, S, E, []);
 
-expand(List, E) when is_list(List) ->
-  {EArgs, {EE, _}} = expand_list(List, fun expand_arg/2, {elixir_env:prepare_write(E), E}, []),
-  {EArgs, elixir_env:close_write(EE, E)};
+expand(List, S, E) when is_list(List) ->
+  {EArgs, SE, {EE, _}} =
+    expand_list(List, fun expand_arg/3, S, {elixir_env:prepare_write(E), E}, []),
 
-expand(Function, E) when is_function(Function) ->
+  {EArgs, SE, elixir_env:close_write(EE, E)};
+
+expand(Function, S, E) when is_function(Function) ->
   case (erlang:fun_info(Function, type) == {type, external}) andalso
        (erlang:fun_info(Function, env) == {env, []}) of
     true ->
-      {elixir_quote:fun_to_quoted(Function), E};
+      {elixir_quote:fun_to_quoted(Function), S, E};
     false ->
       form_error([{line, 0}], ?key(E, file), ?MODULE, {invalid_quoted_expr, Function})
   end;
 
-expand(Pid, E) when is_pid(Pid) ->
+expand(Pid, S, E) when is_pid(Pid) ->
   case ?key(E, function) of
     nil ->
-      {Pid, E};
+      {Pid, S, E};
     Function ->
       %% TODO: Make me an error on v2.0
       elixir_errors:form_warn([], E, ?MODULE, {invalid_pid_in_function, Pid, Function}),
       {Pid, E}
   end;
 
-expand(Other, E) when is_number(Other); is_atom(Other); is_binary(Other) ->
-  {Other, E};
+expand(Other, S, E) when is_number(Other); is_atom(Other); is_binary(Other) ->
+  {Other, S, E};
 
-expand(Other, E) ->
+expand(Other, _S, E) ->
   form_error([{line, 0}], ?key(E, file), ?MODULE, {invalid_quoted_expr, Other}).
 
 %% Helpers
 
-escape_env_entries(Meta, #{current_vars := {Read, Write}, unused_vars := {Unused, Version}} = Env0) ->
+escape_env_entries(Meta, _S, #{current_vars := {Read, Write}, unused_vars := {Unused, Version}} = Env0) ->
   Env1 = case Env0 of
     #{function := nil} -> Env0;
     _ -> Env0#{lexical_tracker := nil, tracers := []}
@@ -481,17 +481,21 @@ escape_env_entries(Meta, #{current_vars := {Read, Write}, unused_vars := {Unused
 maybe_escape_map(#{} = Map) -> {'%{}', [], maps:to_list(Map)};
 maybe_escape_map(Other) -> Other.
 
-expand_multi_alias_call(Kind, Meta, Base, Refs, Opts, E) ->
-  {BaseRef, EB} = expand_without_aliases_report(Base, E),
+expand_multi_alias_call(Kind, Meta, Base, Refs, Opts, S, E) ->
+  {BaseRef, SB, EB} = expand_without_aliases_report(Base, S, E),
+
   Fun = fun
-    ({'__aliases__', _, Ref}, ER) ->
-      expand({Kind, Meta, [elixir_aliases:concat([BaseRef | Ref]), Opts]}, ER);
-    (Ref, ER) when is_atom(Ref) ->
-      expand({Kind, Meta, [elixir_aliases:concat([BaseRef, Ref]), Opts]}, ER);
-    (Other, _ER) ->
+    ({'__aliases__', _, Ref}, SR, ER) ->
+      expand({Kind, Meta, [elixir_aliases:concat([BaseRef | Ref]), Opts]}, SR, ER);
+
+    (Ref, SR, ER) when is_atom(Ref) ->
+      expand({Kind, Meta, [elixir_aliases:concat([BaseRef, Ref]), Opts]}, SR, ER);
+
+    (Other, _SR, _ER) ->
       form_error(Meta, E, ?MODULE, {expected_compile_time_module, Kind, Other})
   end,
-  lists:mapfoldl(Fun, EB, Refs).
+
+  elixir_env:mapfold(Fun, SB, EB, Refs).
 
 resolve_super(Meta, Arity, E) ->
   Module = assert_module_scope(Meta, super, E),
@@ -507,37 +511,37 @@ resolve_super(Meta, Arity, E) ->
       form_error(Meta, E, ?MODULE, wrong_number_of_args_for_super)
   end.
 
-expand_fn_capture(Meta, Arg, E) ->
-  case elixir_fn:capture(Meta, Arg, E) of
-    {{remote, Remote, Fun, Arity}, EE} ->
+expand_fn_capture(Meta, Arg, S, E) ->
+  case elixir_fn:capture(Meta, Arg, S, E) of
+    {{remote, Remote, Fun, Arity}, SE, EE} ->
       is_atom(Remote) andalso
         elixir_env:trace({remote_function, Meta, Remote, Fun, Arity}, E),
       AttachedMeta = attach_context_module(Remote, Meta, E),
-      {{'&', AttachedMeta, [{'/', [], [{{'.', [], [Remote, Fun]}, [], []}, Arity]}]}, EE};
-    {{local, Fun, Arity}, #{function := nil}} ->
+      {{'&', AttachedMeta, [{'/', [], [{{'.', [], [Remote, Fun]}, [], []}, Arity]}]}, SE, EE};
+    {{local, Fun, Arity}, _SE, #{function := nil}} ->
       form_error(Meta, E, ?MODULE, {undefined_local_capture, Fun, Arity});
-    {{local, Fun, Arity}, EE} ->
-      {{'&', Meta, [{'/', [], [{Fun, [], nil}, Arity]}]}, EE};
-    {expand, Expr, EE} ->
-      expand(Expr, EE)
+    {{local, Fun, Arity}, SE, EE} ->
+      {{'&', Meta, [{'/', [], [{Fun, [], nil}, Arity]}]}, SE, EE};
+    {expand, Expr, SE, EE} ->
+      expand(Expr, SE, EE)
   end.
 
-expand_list([{'|', Meta, [_, _] = Args}], Fun, Acc, List) ->
-  {EArgs, EAcc} = lists:mapfoldl(Fun, Acc, Args),
-  expand_list([], Fun, EAcc, [{'|', Meta, EArgs} | List]);
-expand_list([H | T], Fun, Acc, List) ->
-  {EArg, EAcc} = Fun(H, Acc),
-  expand_list(T, Fun, EAcc, [EArg | List]);
-expand_list([], _Fun, Acc, List) ->
-  {lists:reverse(List), Acc}.
+expand_list([{'|', Meta, [_, _] = Args}], Fun, S, E, List) ->
+  {EArgs, SAcc, EAcc} = elixir_env:mapfold(Fun, S, E, Args),
+  expand_list([], Fun, SAcc, EAcc, [{'|', Meta, EArgs} | List]);
+expand_list([H | T], Fun, S, E, List) ->
+  {EArg, SAcc, EAcc} = Fun(H, S, E),
+  expand_list(T, Fun, SAcc, EAcc, [EArg | List]);
+expand_list([], _Fun, S, E, List) ->
+  {lists:reverse(List), S, E}.
 
-expand_block([], Acc, _Meta, E) ->
-  {lists:reverse(Acc), E};
-expand_block([H], Acc, Meta, E) ->
-  {EH, EE} = expand(H, E),
-  expand_block([], [EH | Acc], Meta, EE);
-expand_block([H | T], Acc, Meta, E) ->
-  {EH, EE} = expand(H, E),
+expand_block([], Acc, _Meta, S, E) ->
+  {lists:reverse(Acc), S, E};
+expand_block([H], Acc, Meta, S, E) ->
+  {EH, SE, EE} = expand(H, S, E),
+  expand_block([], [EH | Acc], Meta, SE, EE);
+expand_block([H | T], Acc, Meta, S, E) ->
+  {EH, SE, EE} = expand(H, S, E),
 
   %% Note that checks rely on the code BEFORE expansion
   %% instead of relying on Erlang checks.
@@ -552,11 +556,12 @@ expand_block([H | T], Acc, Meta, E) ->
   case is_useless_building(H, EH, Meta) of
     {UselessMeta, UselessTerm} ->
       elixir_errors:form_warn(UselessMeta, E, ?MODULE, UselessTerm);
+
     false ->
       ok
   end,
 
-  expand_block(T, [EH | Acc], Meta, EE).
+  expand_block(T, [EH | Acc], Meta, SE, EE).
 
 %% Note that we don't handle atoms on purpose. They are common
 %% when unquoting AST and it is unlikely that we would catch
@@ -584,20 +589,20 @@ is_useless_building(_, _, _) ->
 %%   3
 %%
 %% However, lexical information is.
-expand_arg(Arg, Acc) when is_number(Arg); is_atom(Arg); is_binary(Arg); is_pid(Arg) ->
-  {Arg, Acc};
-expand_arg(Arg, {Acc, E}) ->
-  {EArg, EAcc} = expand(Arg, elixir_env:reset_read(Acc, E)),
-  {EArg, {EAcc, E}}.
+expand_arg(Arg, S, Acc) when is_number(Arg); is_atom(Arg); is_binary(Arg); is_pid(Arg) ->
+  {Arg, S, Acc};
+expand_arg(Arg, S, {Acc, E}) ->
+  {EArg, SAcc, EAcc} = expand(Arg, S, elixir_env:reset_read(Acc, E)),
+  {EArg, SAcc, {EAcc, E}}.
 
-expand_args([Arg], E) ->
-  {EArg, EE} = expand(Arg, E),
-  {[EArg], EE};
-expand_args(Args, #{context := match} = E) ->
-  lists:mapfoldl(fun expand/2, E, Args);
-expand_args(Args, E) ->
-  {EArgs, {EA, _}} = lists:mapfoldl(fun expand_arg/2, {elixir_env:prepare_write(E), E}, Args),
-  {EArgs, elixir_env:close_write(EA, E)}.
+expand_args([Arg], S, E) ->
+  {EArg, SE, EE} = expand(Arg, S, E),
+  {[EArg], SE, EE};
+expand_args(Args, S, #{context := match} = E) ->
+  elixir_env:mapfold(fun expand/3, S, E, Args);
+expand_args(Args, S, E) ->
+  {EArgs, SA, {EA, _}} = elixir_env:mapfold(fun expand_arg/3, S, {elixir_env:prepare_write(E), E}, Args),
+  {EArgs, SA, elixir_env:close_write(EA, E)}.
 
 %% Match/var helpers
 
@@ -653,8 +658,8 @@ should_warn(Meta) ->
 
 %% Case
 
-expand_case(Meta, Expr, Opts, E) ->
-  {EExpr, EE} = expand(Expr, E),
+expand_case(Meta, Expr, Opts, S, E) ->
+  {EExpr, SE, EE} = expand(Expr, S, E),
 
   ROpts =
     case proplists:get_value(optimize_boolean, Meta, false) of
@@ -668,8 +673,8 @@ expand_case(Meta, Expr, Opts, E) ->
         Opts
     end,
 
-  {EOpts, EO} = elixir_clauses:'case'(Meta, ROpts, EE),
-  {{'case', Meta, [EExpr, EOpts]}, EO}.
+  {EOpts, SO, EO} = elixir_clauses:'case'(Meta, ROpts, SE, EE),
+  {{'case', Meta, [EExpr, EOpts]}, SO, EO}.
 
 rewrite_case_clauses([{do, [
   {'->', FalseMeta, [
@@ -717,25 +722,28 @@ validate_for_options([], Into, Uniq, {reduce, _}) when Into /= false; Uniq /= fa
 validate_for_options([], _Into, _Uniq, Reduce) ->
   {ok, Reduce}.
 
-expand_for_do_block(Meta, Expr, E, false) ->
+expand_for_do_block(Meta, Expr, S, E, false) ->
   case Expr of
     [{'->', _, _} | _] -> form_error(Meta, E, ?MODULE, for_without_reduce_bad_block);
-    _ -> expand(Expr, E)
+    _ -> expand(Expr, S, E)
   end;
-expand_for_do_block(Meta, Clauses, E, {reduce, _}) ->
-  Transformer = fun({_, _, [Left, _Right]} = Clause, Acc) ->
+expand_for_do_block(Meta, Clauses, S, E, {reduce, _}) ->
+  Transformer = fun({_, _, [Left, _Right]} = Clause, SA, EA) ->
     case Left of
       [_] ->
-        EReset = elixir_env:reset_unused_vars(Acc),
-        {EClause, EAcc} = elixir_clauses:clause(Meta, fn, fun elixir_clauses:head/2, Clause, EReset),
-        {EClause, elixir_env:merge_and_check_unused_vars(Acc, EAcc)};
+        EReset = elixir_env:reset_unused_vars(EA),
+
+        {EClause, SC, EC} =
+          elixir_clauses:clause(Meta, fn, fun elixir_clauses:head/3, Clause, SA, EReset),
+
+        {EClause, SC, elixir_env:merge_and_check_unused_vars(EA, EC)};
       _ ->
         form_error(Meta, E, ?MODULE, for_with_reduce_bad_block)
     end
   end,
 
   case Clauses of
-    [{'->', _, _} | _] -> lists:mapfoldl(Transformer, E, Clauses);
+    [{'->', _, _} | _] -> elixir_env:mapfold(Transformer, S, E, Clauses);
     _ -> form_error(Meta, E, ?MODULE, for_with_reduce_bad_block)
   end.
 
@@ -772,29 +780,29 @@ assert_arg_with_no_clauses(Name, Meta, [{Key, Value} | Rest], E) when is_atom(Ke
 assert_arg_with_no_clauses(_Name, _Meta, _Arg, _E) ->
   ok.
 
-expand_local(Meta, Name, Args, #{module := Module, function := Function, context := nil} = E)
+expand_local(Meta, Name, Args, S, #{module := Module, function := Function, context := nil} = E)
     when Function /= nil ->
   assert_no_clauses(Name, Meta, Args, E),
   Arity = length(Args),
   elixir_env:trace({local_function, Meta, Name, Arity}, E),
   elixir_locals:record_local({Name, Arity}, Module, Function, Meta, false),
-  {EArgs, EA} = expand_args(Args, E),
-  {{Name, Meta, EArgs}, EA};
-expand_local(Meta, Name, Args, E) when Name == '|'; Name == '::' ->
+  {EArgs, SA, EA} = expand_args(Args, S, E),
+  {{Name, Meta, EArgs}, SA, EA};
+expand_local(Meta, Name, Args, _S, E) when Name == '|'; Name == '::' ->
   form_error(Meta, E, ?MODULE, {undefined_function, Name, Args});
-expand_local(Meta, Name, Args, #{function := nil} = E) ->
+expand_local(Meta, Name, Args, _S, #{function := nil} = E) ->
   form_error(Meta, E, ?MODULE, {undefined_function, Name, Args});
-expand_local(Meta, Name, Args, #{context := Context} = E) when Context == match; Context == guard ->
+expand_local(Meta, Name, Args, _S, #{context := Context} = E) when Context == match; Context == guard ->
   form_error(Meta, E, ?MODULE, {invalid_local_invocation, Context, {Name, Meta, Args}}).
 
 %% Remote
 
-expand_remote(Receiver, DotMeta, Right, Meta, Args, #{context := Context} = E, EL) when is_atom(Receiver) or is_tuple(Receiver) ->
+expand_remote(Receiver, DotMeta, Right, Meta, Args, S, #{context := Context} = E, EL) when is_atom(Receiver) or is_tuple(Receiver) ->
   assert_no_clauses(Right, Meta, Args, E),
 
   case {Context, lists:keyfind(no_parens, 1, Meta)} of
     {guard, {no_parens, true}} when is_tuple(Receiver) ->
-      {{{'.', DotMeta, [Receiver, Right]}, Meta, []}, EL};
+      {{{'.', DotMeta, [Receiver, Right]}, Meta, []}, S, EL};
 
     {guard, _} when is_tuple(Receiver) ->
       form_error(Meta, E, ?MODULE, {parens_map_lookup_guard, Receiver, Right});
@@ -805,17 +813,17 @@ expand_remote(Receiver, DotMeta, Right, Meta, Args, #{context := Context} = E, E
       is_atom(Receiver) andalso
         elixir_env:trace({remote_function, Meta, Receiver, Right, length(Args)}, E),
 
-      {EArgs, {EA, _}} = lists:mapfoldl(fun expand_arg/2, {EL, E}, Args),
+      {EArgs, SA, {EA, _}} = elixir_env:mapfold(fun expand_arg/3, S, {EL, E}, Args),
 
       case rewrite(Context, Receiver, AttachedDotMeta, Right, Meta, EArgs) of
         {ok, Rewritten} ->
           maybe_warn_comparison(Rewritten, Args, E),
-          {Rewritten, elixir_env:close_write(EA, E)};
+          {Rewritten, SA, elixir_env:close_write(EA, E)};
         {error, Error} ->
           form_error(Meta, E, elixir_rewrite, Error)
       end
   end;
-expand_remote(Receiver, DotMeta, Right, Meta, Args, E, _) ->
+expand_remote(Receiver, DotMeta, Right, Meta, Args, _S, E, _) ->
   Call = {{'.', DotMeta, [Receiver, Right]}, Meta, Args},
   form_error(Meta, E, ?MODULE, {invalid_call, Call}).
 
@@ -885,10 +893,10 @@ is_comparison_expression(_Other) -> false.
 
 %% Lexical helpers
 
-expand_opts(Meta, Kind, Allowed, Opts, E) ->
-  {EOpts, EE} = expand(Opts, E),
+expand_opts(Meta, Kind, Allowed, Opts, S, E) ->
+  {EOpts, SE, EE} = expand(Opts, S, E),
   validate_opts(Meta, Kind, Allowed, EOpts, EE),
-  {EOpts, EE}.
+  {EOpts, SE, EE}.
 
 validate_opts(Meta, Kind, Allowed, Opts, E) when is_list(Opts) ->
   [begin
@@ -958,25 +966,25 @@ expand_as({as, Other}, Meta, _IncludeByDefault, _Ref, E) ->
 
 %% Aliases
 
-expand_without_aliases_report({'__aliases__', _, _} = Alias, E) ->
-  expand_aliases(Alias, E, false);
-expand_without_aliases_report(Other, E) ->
-  expand(Other, E).
+expand_without_aliases_report({'__aliases__', _, _} = Alias, S, E) ->
+  expand_aliases(Alias, S, E, false);
+expand_without_aliases_report(Other, S, E) ->
+  expand(Other, S, E).
 
-expand_aliases({'__aliases__', Meta, _} = Alias, E, Report) ->
+expand_aliases({'__aliases__', Meta, _} = Alias, S, E, Report) ->
   case elixir_aliases:expand(Alias, E) of
     Receiver when is_atom(Receiver) ->
       Report andalso elixir_env:trace({alias_reference, Meta, Receiver}, E),
-      {Receiver, E};
+      {Receiver, S, E};
 
     Aliases ->
-      {EAliases, EA} = expand_args(Aliases, E),
+      {EAliases, SA, EA} = expand_args(Aliases, S, E),
 
       case lists:all(fun is_atom/1, EAliases) of
         true ->
           Receiver = elixir_aliases:concat(EAliases),
           Report andalso elixir_env:trace({alias_reference, Meta, Receiver}, E),
-          {Receiver, EA};
+          {Receiver, SA, EA};
         false ->
           form_error(Meta, E, ?MODULE, {invalid_alias, Alias})
       end
@@ -984,25 +992,25 @@ expand_aliases({'__aliases__', Meta, _} = Alias, E, Report) ->
 
 %% Comprehensions
 
-expand_for({'<-', Meta, [Left, Right]}, E) ->
-  {ERight, ER} = expand(Right, E),
+expand_for({'<-', Meta, [Left, Right]}, S, E) ->
+  {ERight, SR, ER} = expand(Right, S, E),
   EM = elixir_env:reset_read(ER, E),
-  {[ELeft], EL} = elixir_clauses:head([Left], EM),
-  {{'<-', Meta, [ELeft, ERight]}, EL};
-expand_for({'<<>>', Meta, Args} = X, E) when is_list(Args) ->
+  {[ELeft], SL, EL} = elixir_clauses:head([Left], SR, EM),
+  {{'<-', Meta, [ELeft, ERight]}, SL, EL};
+expand_for({'<<>>', Meta, Args} = X, S, E) when is_list(Args) ->
   case elixir_utils:split_last(Args) of
     {LeftStart, {'<-', OpMeta, [LeftEnd, Right]}} ->
-      {ERight, ER} = expand(Right, E),
+      {ERight, SR, ER} = expand(Right, S, E),
       EM = elixir_env:reset_read(ER, E),
-      {ELeft, EL} = elixir_clauses:match(fun(BArg, BE) ->
-        elixir_bitstring:expand(Meta, BArg, BE, true)
-      end, LeftStart ++ [LeftEnd], EM, EM),
-      {{'<<>>', [], [{'<-', OpMeta, [ELeft, ERight]}]}, EL};
+      {ELeft, SL, EL} = elixir_clauses:match(fun(BArg, BS, BE) ->
+        elixir_bitstring:expand(Meta, BArg, BS, BE, true)
+      end, LeftStart ++ [LeftEnd], SR, EM, EM),
+      {{'<<>>', [], [{'<-', OpMeta, [ELeft, ERight]}]}, SL, EL};
     _ ->
-      expand(X, E)
+      expand(X, S, E)
   end;
-expand_for(X, E) ->
-  expand(X, E).
+expand_for(X, S, E) ->
+  expand(X, S, E).
 
 assert_generator_start(_, [{'<-', _, [_, _]} | _], _) ->
   ok;

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -479,6 +479,7 @@ escape_env_entries(Meta, _S, #{current_vars := {Read, Write}, unused_vars := {Un
   Env1#{
     current_vars := {maybe_escape_map(Read), maybe_escape_map(Write)},
     unused_vars := {maybe_escape_map(Unused), Version},
+    versioned_vars := maybe_escape_map(Read),
     line := ?line(Meta)
   }.
 

--- a/lib/elixir/src/elixir_fn.erl
+++ b/lib/elixir/src/elixir_fn.erl
@@ -1,28 +1,28 @@
 -module(elixir_fn).
--export([capture/3, expand/3, format_error/1]).
+-export([capture/4, expand/4, format_error/1]).
 -import(elixir_errors, [form_error/4]).
 -include("elixir.hrl").
 
 %% Anonymous functions
 
-expand(Meta, Clauses, E) when is_list(Clauses) ->
-  Transformer = fun({_, _, [Left, _Right]} = Clause, Acc) ->
+expand(Meta, Clauses, S, E) when is_list(Clauses) ->
+  Transformer = fun({_, _, [Left, _Right]} = Clause, SA, EA) ->
     case lists:any(fun is_invalid_arg/1, Left) of
       true ->
         form_error(Meta, E, ?MODULE, defaults_in_args);
       false ->
-        EReset = elixir_env:reset_unused_vars(Acc),
-        {EClause, EAcc} = elixir_clauses:clause(Meta, fn, fun elixir_clauses:head/2, Clause, EReset),
-        {EClause, elixir_env:merge_and_check_unused_vars(Acc, EAcc)}
+        EReset = elixir_env:reset_unused_vars(EA),
+        {EClause, SAcc, EAcc} = elixir_clauses:clause(Meta, fn, fun elixir_clauses:head/3, Clause, SA, EReset),
+        {EClause, SAcc, elixir_env:merge_and_check_unused_vars(EA, EAcc)}
     end
   end,
 
-  {EClauses, EE} = lists:mapfoldl(Transformer, E, Clauses),
+  {EClauses, SE, EE} = elixir_env:mapfold(Transformer, S, E, Clauses),
   EArities = [fn_arity(Args) || {'->', _, [Args, _]} <- EClauses],
 
   case lists:usort(EArities) of
     [_] ->
-      {{fn, Meta, EClauses}, EE};
+      {{fn, Meta, EClauses}, SE, EE};
     _ ->
       form_error(Meta, E, ?MODULE, clauses_with_different_arities)
   end.
@@ -35,51 +35,52 @@ fn_arity(Args) -> length(Args).
 
 %% Capture
 
-capture(Meta, {'/', _, [{{'.', _, [M, F]} = Dot, DotMeta, []}, A]}, E) when is_atom(F), is_integer(A) ->
+capture(Meta, {'/', _, [{{'.', _, [M, F]} = Dot, DotMeta, []}, A]}, S, E) when is_atom(F), is_integer(A) ->
   Args = args_from_arity(Meta, A, E),
   handle_capture_possible_warning(Meta, DotMeta, M, F, A, E),
-  capture_require(Meta, {Dot, Meta, Args}, E, true);
+  capture_require(Meta, {Dot, Meta, Args}, S, E, true);
 
-capture(Meta, {'/', _, [{F, _, C}, A]}, E) when is_atom(F), is_integer(A), is_atom(C) ->
+capture(Meta, {'/', _, [{F, _, C}, A]}, S, E) when is_atom(F), is_integer(A), is_atom(C) ->
   Args = args_from_arity(Meta, A, E),
-  capture_import(Meta, {F, Meta, Args}, E, true);
+  capture_import(Meta, {F, Meta, Args}, S, E, true);
 
-capture(Meta, {{'.', _, [_, Fun]}, _, Args} = Expr, E) when is_atom(Fun), is_list(Args) ->
-  capture_require(Meta, Expr, E, is_sequential_and_not_empty(Args));
+capture(Meta, {{'.', _, [_, Fun]}, _, Args} = Expr, S, E) when is_atom(Fun), is_list(Args) ->
+  capture_require(Meta, Expr, S, E, is_sequential_and_not_empty(Args));
 
-capture(Meta, {{'.', _, [_]}, _, Args} = Expr, E) when is_list(Args) ->
-  capture_expr(Meta, Expr, E, false);
+capture(Meta, {{'.', _, [_]}, _, Args} = Expr, S, E) when is_list(Args) ->
+  capture_expr(Meta, Expr, S, E, false);
 
-capture(Meta, {'__block__', _, [Expr]}, E) ->
-  capture(Meta, Expr, E);
+capture(Meta, {'__block__', _, [Expr]}, S, E) ->
+  capture(Meta, Expr, S, E);
 
-capture(Meta, {'__block__', _, _} = Expr, E) ->
+capture(Meta, {'__block__', _, _} = Expr, _S, E) ->
   form_error(Meta, E, ?MODULE, {block_expr_in_capture, Expr});
 
-capture(Meta, {Atom, _, Args} = Expr, E) when is_atom(Atom), is_list(Args) ->
-  capture_import(Meta, Expr, E, is_sequential_and_not_empty(Args));
+capture(Meta, {Atom, _, Args} = Expr, S, E) when is_atom(Atom), is_list(Args) ->
+  capture_import(Meta, Expr, S, E, is_sequential_and_not_empty(Args));
 
-capture(Meta, {Left, Right}, E) ->
-  capture(Meta, {'{}', Meta, [Left, Right]}, E);
+capture(Meta, {Left, Right}, S, E) ->
+  capture(Meta, {'{}', Meta, [Left, Right]}, S, E);
 
-capture(Meta, List, E) when is_list(List) ->
-  capture_expr(Meta, List, E, is_sequential_and_not_empty(List));
+capture(Meta, List, S, E) when is_list(List) ->
+  capture_expr(Meta, List, S, E, is_sequential_and_not_empty(List));
 
-capture(Meta, Integer, E) when is_integer(Integer) ->
+capture(Meta, Integer, _S, E) when is_integer(Integer) ->
   form_error(Meta, E, ?MODULE, {capture_arg_outside_of_capture, Integer});
 
-capture(Meta, Arg, E) ->
+capture(Meta, Arg, _S, E) ->
   invalid_capture(Meta, Arg, E).
 
-capture_import(Meta, {Atom, ImportMeta, Args} = Expr, E, Sequential) ->
+capture_import(Meta, {Atom, ImportMeta, Args} = Expr, S, E, Sequential) ->
   Res = Sequential andalso
         elixir_dispatch:import_function(ImportMeta, Atom, length(Args), E),
-  handle_capture(Res, Meta, Expr, E, Sequential).
+  handle_capture(Res, Meta, Expr, S, E, Sequential).
 
-capture_require(Meta, {{'.', DotMeta, [Left, Right]}, RequireMeta, Args}, E, Sequential) ->
+capture_require(Meta, {{'.', DotMeta, [Left, Right]}, RequireMeta, Args}, S, E, Sequential) ->
   case escape(Left, E, []) of
     {EscLeft, []} ->
-      {ELeft, EE} = elixir_expand:expand(EscLeft, E),
+      {ELeft, SE, EE} = elixir_expand:expand(EscLeft, S, E),
+
       Res = Sequential andalso case ELeft of
         {Name, _, Context} when is_atom(Name), is_atom(Context) ->
           {remote, ELeft, Right, length(Args)};
@@ -88,28 +89,30 @@ capture_require(Meta, {{'.', DotMeta, [Left, Right]}, RequireMeta, Args}, E, Seq
         _ ->
           false
       end,
-      handle_capture(Res, Meta, {{'.', DotMeta, [ELeft, Right]}, RequireMeta, Args},
-                     EE, Sequential);
+
+      Dot = {{'.', DotMeta, [ELeft, Right]}, RequireMeta, Args},
+      handle_capture(Res, Meta, Dot, SE, EE, Sequential);
+
     {EscLeft, Escaped} ->
-      capture_expr(Meta, {{'.', DotMeta, [EscLeft, Right]}, RequireMeta, Args},
-                   E, Escaped, Sequential)
+      Dot = {{'.', DotMeta, [EscLeft, Right]}, RequireMeta, Args},
+      capture_expr(Meta, Dot, S, E, Escaped, Sequential)
   end.
 
-handle_capture(false, Meta, Expr, E, Sequential) ->
-  capture_expr(Meta, Expr, E, Sequential);
-handle_capture(LocalOrRemote, _Meta, _Expr, E, _Sequential) ->
-  {LocalOrRemote, E}.
+handle_capture(false, Meta, Expr, S, E, Sequential) ->
+  capture_expr(Meta, Expr, S, E, Sequential);
+handle_capture(LocalOrRemote, _Meta, _Expr, S, E, _Sequential) ->
+  {LocalOrRemote, S, E}.
 
-capture_expr(Meta, Expr, E, Sequential) ->
-  capture_expr(Meta, Expr, E, [], Sequential).
-capture_expr(Meta, Expr, E, Escaped, Sequential) ->
+capture_expr(Meta, Expr, S, E, Sequential) ->
+  capture_expr(Meta, Expr, S, E, [], Sequential).
+capture_expr(Meta, Expr, S, E, Escaped, Sequential) ->
   case escape(Expr, E, Escaped) of
     {_, []} when not Sequential ->
       invalid_capture(Meta, Expr, E);
     {EExpr, EDict} ->
       EVars = validate(Meta, EDict, 1, E),
       Fn = {fn, Meta, [{'->', Meta, [EVars, EExpr]}]},
-      {expand, Fn, E}
+      {expand, Fn, S, E}
   end.
 
 invalid_capture(Meta, Arg, E) ->

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -26,7 +26,7 @@ expand_struct(Meta, Left, {'%{}', MapMeta, MapArgs}, S, #{context := Context} = 
           Struct = load_struct(Meta, ELeft, [Assocs], AssocKeys, EE),
           Keys = ['__struct__'] ++ AssocKeys,
           WithoutKeys = maps:to_list(maps:without(Keys, Struct)),
-          StructAssocs = elixir_quote:escape(WithoutKeys, default, false),
+          StructAssocs = elixir_quote:escape(WithoutKeys, none, false),
           {{'%', Meta, [ELeft, {'%{}', MapMeta, StructAssocs ++ Assocs}]}, SE, EE};
 
         {_, _, Assocs} -> %% Update or match

--- a/lib/elixir/src/elixir_map.erl
+++ b/lib/elixir/src/elixir_map.erl
@@ -1,22 +1,22 @@
 -module(elixir_map).
--export([expand_map/3, expand_struct/4, format_error/1, load_struct/5]).
+-export([expand_map/4, expand_struct/5, format_error/1, load_struct/5]).
 -import(elixir_errors, [form_error/4, form_warn/4]).
 -include("elixir.hrl").
 
-expand_map(Meta, [{'|', UpdateMeta, [Left, Right]}], #{context := nil} = E) ->
-  {[ELeft | ERight], EE} = elixir_expand:expand_args([Left | Right], E),
+expand_map(Meta, [{'|', UpdateMeta, [Left, Right]}], S, #{context := nil} = E) ->
+  {[ELeft | ERight], SE, EE} = elixir_expand:expand_args([Left | Right], S, E),
   validate_kv(Meta, ERight, Right, E),
-  {{'%{}', Meta, [{'|', UpdateMeta, [ELeft, ERight]}]}, EE};
-expand_map(Meta, [{'|', _, [_, _]}] = Args, #{context := Context, file := File}) ->
+  {{'%{}', Meta, [{'|', UpdateMeta, [ELeft, ERight]}]}, SE, EE};
+expand_map(Meta, [{'|', _, [_, _]}] = Args, _S, #{context := Context, file := File}) ->
   form_error(Meta, File, ?MODULE, {update_syntax_in_wrong_context, Context, {'%{}', Meta, Args}});
-expand_map(Meta, Args, E) ->
-  {EArgs, EE} = elixir_expand:expand_args(Args, E),
+expand_map(Meta, Args, S, E) ->
+  {EArgs, SE, EE} = elixir_expand:expand_args(Args, S, E),
   validate_kv(Meta, EArgs, Args, E),
-  {{'%{}', Meta, EArgs}, EE}.
+  {{'%{}', Meta, EArgs}, SE, EE}.
 
-expand_struct(Meta, Left, {'%{}', MapMeta, MapArgs}, #{context := Context} = E) ->
+expand_struct(Meta, Left, {'%{}', MapMeta, MapArgs}, S, #{context := Context} = E) ->
   CleanMapArgs = clean_struct_key_from_map_args(Meta, MapArgs, E),
-  {[ELeft, ERight], EE} = elixir_expand:expand_args([Left, {'%{}', MapMeta, CleanMapArgs}], E),
+  {[ELeft, ERight], SE, EE} = elixir_expand:expand_args([Left, {'%{}', MapMeta, CleanMapArgs}], S, E),
 
   case validate_struct(ELeft, Context) of
     true when is_atom(ELeft) ->
@@ -27,15 +27,15 @@ expand_struct(Meta, Left, {'%{}', MapMeta, MapArgs}, #{context := Context} = E) 
           Keys = ['__struct__'] ++ AssocKeys,
           WithoutKeys = maps:to_list(maps:without(Keys, Struct)),
           StructAssocs = elixir_quote:escape(WithoutKeys, default, false),
-          {{'%', Meta, [ELeft, {'%{}', MapMeta, StructAssocs ++ Assocs}]}, EE};
+          {{'%', Meta, [ELeft, {'%{}', MapMeta, StructAssocs ++ Assocs}]}, SE, EE};
 
         {_, _, Assocs} -> %% Update or match
           _ = load_struct(Meta, ELeft, [], [K || {K, _} <- Assocs], EE),
-          {{'%', Meta, [ELeft, ERight]}, EE}
+          {{'%', Meta, [ELeft, ERight]}, SE, EE}
       end;
 
     true ->
-      {{'%', Meta, [ELeft, ERight]}, EE};
+      {{'%', Meta, [ELeft, ERight]}, SE, EE};
 
     false when Context == match ->
       form_error(Meta, E, ?MODULE, {invalid_struct_name_in_match, ELeft});
@@ -43,7 +43,7 @@ expand_struct(Meta, Left, {'%{}', MapMeta, MapArgs}, #{context := Context} = E) 
     false ->
       form_error(Meta, E, ?MODULE, {invalid_struct_name, ELeft})
   end;
-expand_struct(Meta, _Left, Right, E) ->
+expand_struct(Meta, _Left, Right, _S, E) ->
   form_error(Meta, E, ?MODULE, {non_map_after_struct, Right}).
 
 clean_struct_key_from_map_args(Meta, [{'|', PipeMeta, [Left, MapAssocs]}], E) ->

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -359,7 +359,7 @@ build(Line, File, Module) ->
 eval_form(Line, Module, DataBag, Block, Vars, E) ->
   {Value, EE} = elixir_compiler:eval_forms(Block, Vars, E),
   elixir_overridable:store_not_overridden(Module),
-  EV = elixir_env:linify({Line, elixir_env:reset_vars(EE)}),
+  EV = (elixir_env:reset_vars(EE))#{line := Line},
   EC = eval_callbacks(Line, DataBag, before_compile, [EV], EV),
   elixir_overridable:store_not_overridden(Module),
   {Value, EC}.

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -333,14 +333,13 @@ defmodule Kernel.ExpansionTest do
 
       assert expand(code)
 
-      message = ~r"expected \"a\" to expand to an existing variable or be part of a match"
+      message = ~r"undefined variable \"a\""
 
       assert_raise CompileError, message, fn ->
         expand(quote(do: var!(a)))
       end
 
-      message =
-        ~r"expected \"a\" \(context Unknown\) to expand to an existing variable or be part of a match"
+      message = ~r"undefined variable \"a\" \(context Unknown\)"
 
       assert_raise CompileError, message, fn ->
         expand(quote(do: var!(a, Unknown)))

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -2814,7 +2814,8 @@ defmodule Kernel.ExpansionTest do
     end)
 
     receive do
-      {:expand_env, {expr, _, env}} ->
+      {:expand_env, {expr, scope, env}} ->
+        env = :elixir_env.to_caller({env.line, scope, env})
         {clean_meta(expr, [:version, :inferred_bitstring_spec]), env}
     end
   end

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -273,10 +273,6 @@ defmodule Kernel.ExpansionTest do
   end
 
   describe "=" do
-    test "sets context to match" do
-      assert expand(quote(do: __ENV__.context = :match)) == quote(do: :match = :match)
-    end
-
     test "defines vars" do
       {output, env} = expand_env(quote(do: a = 1), __ENV__)
       assert output == quote(do: a = 1)

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -79,7 +79,8 @@ defmodule Kernel.ExpansionTest do
 
   defp expand_with_version(expr) do
     env = :elixir_env.reset_vars(__ENV__)
-    elem(:elixir_expand.expand(expr, env), 0)
+    {expr, _, _} = :elixir_expand.expand(expr, :elixir_env.env_to_ex(env), env)
+    expr
   end
 
   describe "__block__" do
@@ -2809,11 +2810,12 @@ defmodule Kernel.ExpansionTest do
 
   defp expand_env(expr, env) do
     ExUnit.CaptureIO.capture_io(:stderr, fn ->
-      send(self(), {:expand_env, :elixir_expand.expand(expr, env)})
+      send(self(), {:expand_env, :elixir_expand.expand(expr, :elixir_env.env_to_ex(env), env)})
     end)
 
     receive do
-      {:expand_env, {expr, env}} -> {clean_meta(expr, [:version, :inferred_bitstring_spec]), env}
+      {:expand_env, {expr, _, env}} ->
+        {clean_meta(expr, [:version, :inferred_bitstring_spec]), env}
     end
   end
 end

--- a/lib/elixir/test/elixir/kernel/import_test.exs
+++ b/lib/elixir/test/elixir/kernel/import_test.exs
@@ -174,6 +174,28 @@ defmodule Kernel.ImportTest do
     end
   end
 
+  test "import lexical on for" do
+    for x <- [1, 2, 3], x > 10 do
+      import List
+      flatten([1, [2], 3])
+      flunk()
+    end
+
+    # Buggy local duplicate is untouched
+    assert duplicate([1], 2) == [1]
+  end
+
+  test "import lexical on with" do
+    with true <- false do
+      import List
+      flatten([1, [2], 3])
+      flunk()
+    end
+
+    # Buggy local duplicate is untouched
+    assert duplicate([1], 2) == [1]
+  end
+
   test "import lexical on try" do
     try do
       import List

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -817,32 +817,6 @@ defmodule Kernel.ParserTest do
     end
   end
 
-  describe "down to Erlang" do
-    test "contains of non-literals" do
-      assert to_erl!("{:ok, make_ref()}") ==
-               {:tuple, 1,
-                [
-                  {:atom, 0, :ok},
-                  {:call, 1, {:remote, 1, {:atom, 0, :erlang}, {:atom, 1, :make_ref}}, []}
-                ]}
-
-      assert to_erl!("[:ok, make_ref()]") ==
-               {:cons, 1, {:atom, 0, :ok},
-                {:cons, 1,
-                 {:call, 1, {:remote, 1, {:atom, 0, :erlang}, {:atom, 1, :make_ref}}, []},
-                 {nil, 0}}}
-    end
-
-    defp to_erl!(code) do
-      {expr, _, _} =
-        code
-        |> Code.string_to_quoted!()
-        |> :elixir.quoted_to_erl(:elixir.env_for_eval([]))
-
-      expr
-    end
-  end
-
   defp parse!(string), do: Code.string_to_quoted!(string)
 
   defp assert_token_missing(given_message, string) do

--- a/lib/elixir/test/elixir/module/types/pattern_test.exs
+++ b/lib/elixir/test/elixir/module/types/pattern_test.exs
@@ -36,7 +36,7 @@ defmodule Module.Types.PatternTest do
         other -> other
       end)
 
-    {ast, _env} = :elixir_expand.expand(fun, __ENV__)
+    {ast, _, _} = :elixir_expand.expand(fun, :elixir_env.env_to_ex(__ENV__), __ENV__)
     {:fn, _, [{:->, _, [[{:when, _, [patterns, guards]}], _]}]} = ast
     {patterns, guards}
   end

--- a/lib/elixir/test/elixir/module/types/type_helper.exs
+++ b/lib/elixir/test/elixir/module/types/type_helper.exs
@@ -30,7 +30,7 @@ defmodule TypeHelper do
         fn unquote(patterns) when unquote(guards) -> unquote(expr) end
       end
 
-    {ast, _env} = :elixir_expand.expand(fun, env)
+    {ast, _, _} = :elixir_expand.expand(fun, :elixir_env.env_to_ex(env), env)
     {:fn, _, [{:->, _, [[{:when, _, [patterns, guards]}], body]}]} = ast
     {patterns, guards, body}
   end

--- a/lib/elixir/test/elixir/port_test.exs
+++ b/lib/elixir/test/elixir/port_test.exs
@@ -28,7 +28,7 @@ defmodule PortTest do
   end
 
   defp expand(expr, env) do
-    {expr, _env} = :elixir_expand.expand(expr, env)
+    {expr, _, _} = :elixir_expand.expand(expr, :elixir_env.env_to_ex(env), env)
     expr
   end
 end

--- a/lib/elixir/test/elixir/process_test.exs
+++ b/lib/elixir/test/elixir/process_test.exs
@@ -118,7 +118,7 @@ defmodule ProcessTest do
   end
 
   defp expand(expr, env) do
-    {expr, _env} = :elixir_expand.expand(expr, env)
+    {expr, _, _} = :elixir_expand.expand(expr, :elixir_env.env_to_ex(env), env)
     expr
   end
 end

--- a/lib/elixir/test/erlang/control_test.erl
+++ b/lib/elixir/test/erlang/control_test.erl
@@ -3,7 +3,7 @@
 
 to_erl(String) ->
   Forms = elixir:'string_to_quoted!'(String, 1, 1, <<"nofile">>, []),
-  {Expr, _, _} = elixir:quoted_to_erl(Forms, elixir:env_for_eval([])),
+  {Expr, _, _, _} = elixir:quoted_to_erl(Forms, elixir:env_for_eval([])),
   Expr.
 
 cond_line_test() ->

--- a/lib/elixir/test/erlang/test_helper.erl
+++ b/lib/elixir/test/erlang/test_helper.erl
@@ -27,7 +27,7 @@ run_and_remove(Fun, Modules) ->
 % Throws an error with the Erlang Abstract Form from the Elixir string
 throw_elixir(String) ->
   Forms = elixir:'string_to_quoted!'(String, 1, 1, <<"nofile">>, []),
-  {Expr, _, _} = elixir:quoted_to_erl(Forms, elixir:env_for_eval([])),
+  {Expr, _, _, _} = elixir:quoted_to_erl(Forms, elixir:env_for_eval([])),
   erlang:error(io:format("~p~n", [Expr])).
 
 % Throws an error with the Erlang Abstract Form from the Erlang string

--- a/lib/iex/lib/iex/pry.ex
+++ b/lib/iex/lib/iex/pry.ex
@@ -231,8 +231,8 @@ defmodule IEx.Pry do
         end
       end
 
-    {{:case, _, [_, [do: [{:->, [], [[condition], _]}]]]}, _} =
-      :elixir_expand.expand(to_expand, env)
+    {{:case, _, [_, [do: [{:->, [], [[condition], _]}]]]}, _, _} =
+      :elixir_expand.expand(to_expand, :elixir_env.env_to_ex(env), env)
 
     condition
   end

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -194,14 +194,6 @@ defmodule IEx.InteractionTest do
       input = "nested_var\nmy_variable\nputs \"hello\""
       assert capture_iex(input, [], dot_iex_path: path) == "13\n14\nhello\n:ok"
     end
-
-    @tag :tmp_dir
-    test "malformed .iex", %{tmp_dir: tmp_dir} do
-      path = write_dot_iex!(tmp_dir, "dot-iex", "malformed")
-
-      assert capture_iex("1 + 2", [], dot_iex_path: path) =~
-               "dot-iex:1: undefined function malformed/0"
-    end
   end
 
   defp write_dot_iex!(tmp_dir, name, contents) do


### PR DESCRIPTION
Previously, the internal Elixir expansion pass worked directly on
`Macro.Env`. However, this poised an issue, if we want to track
more information in the pass, we ended up exposing it on
`Macro.Env`, making it larger, and potentially slowing down
operations such as `__ENV__` serialization.

This commit refactors the expansion pass to work with two
structures, the `Macro.Env` struct and a `#elixir_ex{}` record.