### PR TITLE
Add `--short-version` to Elixir CLI

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -10,7 +10,7 @@ Usage: $(basename "$0") [options] [.exs file] [data]
   -e "COMMAND"                 Evaluates the given command (*)
   -h, --help                   Prints this message and exits
   -r "FILE"                    Requires the given files/patterns (*)
-  -S SCRIPT                    Finds and executes the given script in \$PATH
+  -S SCRIPT                    Finds and executes the given script in \$PATH
   -pr "FILE"                   Requires the given files/patterns in parallel (*)
   -pa "PATH"                   Prepends the given path to Erlang code path (*)
   -pz "PATH"                   Appends the given path to Erlang code path (*)

--- a/bin/elixir
+++ b/bin/elixir
@@ -14,8 +14,9 @@ Usage: $(basename "$0") [options] [.exs file] [data]
   -pr "FILE"                   Requires the given files/patterns in parallel (*)
   -pa "PATH"                   Prepends the given path to Erlang code path (*)
   -pz "PATH"                   Appends the given path to Erlang code path (*)
-  -v, --version                Prints Elixir version and exits
+  -v, --version                Prints Elixir version information and exits
 
+  --short-version              Prints Elixir version and exits, much faster than --version
   --app APP                    Starts the given app and its dependencies (*)
   --erl "SWITCHES"             Switches to be passed down to Erlang (*)
   --eval "COMMAND"             Evaluates the given command, same as -e (*)
@@ -65,6 +66,15 @@ readlink_f () {
     echo "$(pwd -P)/$filename"
   fi
 }
+
+SELF=$(readlink_f "$0")
+SCRIPT_PATH=$(dirname "$SELF")
+
+if [ "$1" = "--short-version" ]; then
+  cat "$SCRIPT_PATH/../VERSION"
+  echo # always emit newline after version
+  exit 0
+fi
 
 # Stores static Erlang arguments and --erl (which is passed as is)
 ERL=""
@@ -199,9 +209,6 @@ while [ $I -ge 0 ]; do
   set -- "$VAL" "$@"
   I=$((I - 1))
 done
-
-SELF=$(readlink_f "$0")
-SCRIPT_PATH=$(dirname "$SELF")
 
 if [ "$OSTYPE" = "cygwin" ]; then SCRIPT_PATH=$(cygpath -m "$SCRIPT_PATH"); fi
 if [ "$MODE" != "iex" ]; then ERL="-noshell -s elixir start_cli $ERL"; fi

--- a/bin/elixir.bat
+++ b/bin/elixir.bat
@@ -1,10 +1,15 @@
 @if defined ELIXIR_CLI_ECHO (@echo on) else (@echo off)
+
+rem Designates the path to the current script
+set SCRIPT_PATH=%~dp0
+
 setlocal enabledelayedexpansion
-if    ""%1""==""""       goto documentation
-if /I ""%1""==""--help"" goto documentation
-if /I ""%1""==""-h""     goto documentation
-if /I ""%1""==""/h""     goto documentation
-if    ""%1""==""/?""     goto documentation
+if    ""%1""==""""                goto documentation
+if /I ""%1""==""--help""          goto documentation
+if /I ""%1""==""-h""              goto documentation
+if /I ""%1""==""/h""              goto documentation
+if    ""%1""==""/?""              goto documentation
+if /I ""%1""==""--short-version"" goto shortversion
 goto parseopts
 
 :documentation
@@ -19,8 +24,9 @@ echo   -S SCRIPT                    Finds and executes the given script in $PATH
 echo   -pr "FILE"                   Requires the given files/patterns in parallel (*)
 echo   -pa "PATH"                   Prepends the given path to Erlang code path (*)
 echo   -pz "PATH"                   Appends the given path to Erlang code path (*)
-echo   -v, --version                Prints Elixir version and exits
+echo   -v, --version                Prints Elixir version information and exits
 echo.
+echo   --short-version              Prints Elixir version and exits, much faster than --version
 echo   --app APP                    Starts the given app and its dependencies (*)
 echo   --erl "SWITCHES"             Switches to be passed down to Erlang (*)
 echo   --eval "COMMAND"             Evaluates the given command, same as -e (*)
@@ -56,6 +62,11 @@ echo.
 echo ** Options marked with (*) can be given more than once.
 goto end
 
+:shortversion
+type "!SCRIPT_PATH!..\VERSION"
+echo.
+goto end
+
 :parseopts
 
 rem Parameters for Elixir
@@ -72,9 +83,6 @@ set endLoop=0
 
 rem Designates which mode / Elixir component to run as
 set runMode="elixir"
-
-rem Designates the path to the current script
-set SCRIPT_PATH=%~dp0
 
 rem Designates the path to the ERTS system
 set ERTS_BIN=

--- a/lib/elixir/test/elixir/cli_test.exs
+++ b/lib/elixir/test/elixir/cli_test.exs
@@ -1,0 +1,24 @@
+Code.require_file("test_helper.exs", __DIR__)
+
+defmodule Elixir.CLITest do
+  use ExUnit.Case
+
+  import PathHelpers
+
+  test "--help smoke test" do
+    output = elixir(~w[--help])
+    assert output =~ "Usage: elixir"
+  end
+
+  test "--version smoke test" do
+    output = elixir(~w[--version])
+    assert output =~ ~r/Erlang\/OTP [0-9]+ \[.+]/
+    assert output =~ ~r/Elixir [1-9]\.[0-9]+\.[0-9]+.*\(compiled with Erlang\/OTP [0-9]+\)/
+  end
+
+  test "--short-version smoke test" do
+    output = elixir(~w[--short-version])
+    assert output =~ ~r/^[1-9]\.[0-9]+\.[0-9]+(?:-dev)?\n$/m
+    refute output =~ "Erlang"
+  end
+end


### PR DESCRIPTION
Adds `--short-version` to Elixir CLI which outputs only the Elixir version stored in `VERSION`, making it much faster for tools to get the Elixir version.

Speed comparison:

```bash
➜ time bin/elixir --version
Erlang/OTP 24 [erts-12.0.3] [source] [64-bit] [smp:16:16] [ds:16:16:10] [async-threads:1] [jit]

Elixir 1.13.0-dev (1dd059d) (compiled with Erlang/OTP 24)
bin/elixir --version  0.40s user 0.13s system 171% cpu 0.313 total

➜ time bin/elixir --short-version
1.13.0-dev
bin/elixir --short-version  0.01s user 0.00s system 101% cpu 0.008 total
```

Windows PowerShell:

```
PS> Measure-Command { .\bin\elixir.bat --short-version | Out-Default }
1.13.0-dev

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 32
Ticks             : 324577
```

Closes #11146
CC @atavistock thanks for reporting the issue!