### PR TITLE
Small improvement on mix local docs

### DIFF
--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -11,8 +11,8 @@ defmodule Mix.Tasks.Local.Rebar do
   @moduledoc """
   Fetches a copy of `rebar` or `rebar3` from the given path or URL.
 
-  It defaults to safely download a Rebar copy from  Hex's CDN.
-  However, a URL can be given as argument, usually for an existing
+  It defaults to safely download a Rebar copy from Hex's CDN.
+  However, a URL can be given as an argument, usually for an existing
   local copy of Rebar:
 
       mix local.rebar rebar path/to/rebar


### PR DESCRIPTION
while reading the docs noticed a small improved that could be made into this paragraph.

- Remove extra white space.
- add an for the `argument`