### PR TITLE
Add --if-missing option to mix local.rebar

### DIFF
--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -115,7 +115,7 @@ defmodule Mix.Tasks.Local.Rebar do
 
     true
   end
-  
+
   defp install_from_s3(manager, list_url, escript_url, opts) do
     hex_mirror = Mix.Hex.mirror()
     list_url = hex_mirror <> list_url

--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -44,7 +44,7 @@ defmodule Mix.Tasks.Local.Rebar do
   to use for fetching `rebar` please set the `HEX_MIRROR` environment variable.
   """
 
-  @switches [force: :boolean, sha512: :string]
+  @switches [force: :boolean, sha512: :string, if_missing: :boolean]
 
   @impl true
   def run(argv) do
@@ -72,7 +72,7 @@ defmodule Mix.Tasks.Local.Rebar do
   defp install_from_path(manager, path, opts) do
     local = Mix.Rebar.local_rebar_path(manager)
 
-    if !skip_install?(manager, opts) && (opts[:force] || Mix.Generator.overwrite?(local)) do
+    if not skip_install?(manager, opts) && (opts[:force] || Mix.Generator.overwrite?(local)) do
       case Mix.Utils.read_path(path, opts) do
         {:ok, binary} ->
           File.mkdir_p!(Path.dirname(local))
@@ -105,7 +105,7 @@ defmodule Mix.Tasks.Local.Rebar do
   end
 
   defp install_from_s3(manager, list_url, escript_url, opts) do
-    if !skip_install?(manager, opts) do
+    if not skip_install?(manager, opts) do
       hex_mirror = Mix.Hex.mirror()
       list_url = hex_mirror <> list_url
 
@@ -122,7 +122,7 @@ defmodule Mix.Tasks.Local.Rebar do
   end
 
   defp skip_install?(manager, opts) do
-    Keyword.get(opts, :if_missing, false) &&
+    Keyword.get(opts, :if_missing, false) and
       manager
       |> Mix.Rebar.local_rebar_path()
       |> File.exists?()

--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -69,12 +69,6 @@ defmodule Mix.Tasks.Local.Rebar do
     end
   end
 
-  defp maybe_install_from_path(manager, path, opts) do
-    if not skip_install?(manager, opts) do
-      install_from_path(manager, path, opts)
-    end
-  end
-
   defp install_from_path(manager, path, opts) do
     local = Mix.Rebar.local_rebar_path(manager)
 
@@ -108,6 +102,12 @@ defmodule Mix.Tasks.Local.Rebar do
     end
 
     true
+  end
+
+  defp maybe_install_from_path(manager, path, opts) do
+    if not skip_install?(manager, opts) do
+      install_from_path(manager, path, opts)
+    end
   end
 
   defp maybe_install_from_s3(manager, list_url, escript_url, opts) do


### PR DESCRIPTION
`mix local.hex` has an `--if-missing` flag, but the option isn't available for `mix local.rebar`. This PR adds the same feature to `mix local.rebar`.