### PR TITLE
mix deps.compile: Copy priv/ before compilation

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -587,6 +587,7 @@ defmodule Mix do
 
     config = [
       version: "0.1.0",
+      build_embedded: false,
       build_per_environment: true,
       build_path: "_build",
       lockfile: "mix.lock",

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -234,7 +234,7 @@ defmodule Mix.Tasks.Deps.Compile do
 
     # Copy priv/ after compilation too if it was created then
     if File.exists?(dep_priv) and not File.exists?(build_priv) do
-      Mix.Utils.symlink_or_copy(config[:build_embedded] == true, dep_priv, build_priv)
+      Mix.Utils.symlink_or_copy(config[:build_embedded], dep_priv, build_priv)
     end
 
     Code.prepend_path(Path.join(build_path, "ebin"))

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -218,19 +218,19 @@ defmodule Mix.Tasks.Deps.Compile do
     File.write!(config_path, rebar_config(dep))
 
     build_ebin = Path.join(build_path, "ebin")
-    hard_copy? = config[:build_embedded]
+    hard_copy? = config[:build_embedded] == true
 
     # For Rebar3, we need to copy the source/ebin to the target/ebin
     # before we run the command given that REBAR_BARE_COMPILER_OUTPUT_DIR
     # writes directly to _build.
     #
-    # TODO: We still symlink ebin by default for backwards compatibility.
+    # TODO: We still symlink ebin/ by default for backwards compatibility.
     # This partially negates the effects of REBAR_BARE_COMPILER_OUTPUT_DIR
     # if an ebin diretory exists, so we should consider disabling it in future
     # releases when rebar3 v3.14+ is reasonably adopted.
     Mix.Utils.symlink_or_copy(hard_copy?, Path.join(dep_path, "ebin"), build_ebin)
 
-    # We also need to copy include before compilation, since the -include(...)
+    # We also need to copy include/ before compilation, since the -include(...)
     # directive looks in the current working directory.
     Mix.Utils.symlink_or_copy(
       hard_copy?,
@@ -238,16 +238,19 @@ defmodule Mix.Tasks.Deps.Compile do
       Path.join(build_path, "include")
     )
 
+    source_priv_dir = Path.join(dep_path, "priv")
+    target_priv_dir = Path.join(build_path, "priv")
+
+    # Copy priv/ before compilation in case it is used in parse transforms
+    Mix.Utils.symlink_or_copy(hard_copy?, source_priv_dir, target_priv_dir)
+
     # Compile the project
     do_command(dep, config, cmd, false, env)
 
-    # After compilation, we symlink/copy priv. This should be fine because
-    # Rebar projects cannot read from lib_dir until after compilation.
-    Mix.Utils.symlink_or_copy(
-      hard_copy?,
-      Path.join(dep_path, "priv"),
-      Path.join(build_path, "priv")
-    )
+    # Copy priv/ after compilation too if it was created then
+    unless File.exists?(target_priv_dir) do
+      Mix.Utils.symlink_or_copy(hard_copy?, source_priv_dir, target_priv_dir)
+    end
 
     Code.prepend_path(build_ebin)
     true

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -237,7 +237,7 @@ defmodule Mix.Tasks.Deps.Compile do
       Mix.Utils.symlink_or_copy(config[:build_embedded] == true, dep_priv, build_priv)
     end
 
-    Code.prepend_path(build_ebin)
+    Code.prepend_path(Path.join(build_path, "ebin"))
     true
   end
 

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -198,7 +198,7 @@ defmodule Mix.Tasks.Deps.Compile do
     true
   end
 
-defp do_rebar3(%Mix.Dep{opts: opts} = dep, config) do
+  defp do_rebar3(%Mix.Dep{opts: opts} = dep, config) do
     dep_path = opts[:dest]
     build_path = opts[:build]
 


### PR DESCRIPTION
With this patch, and the commit just before it (f4f44e2), we can correctly mix install both of these packages:

```elixir
Mix.install [
  :certifi,
  :erqwest
]

IO.inspect :certifi.cacertfile()

:ok = :erqwest.start_client(:default)
IO.inspect :erqwest.get(:default, "https://hex.pm/api", %{headers: [{"user-agent", "erqwest"}]})
```