### PR TITLE
Add sigil completion to code fragment

### DIFF
--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -75,36 +75,35 @@ defmodule Code.Fragment do
     * `{:local_call, charlist}` - the context is a local (import or local)
       call, such as `hello_world(` and `hello_world `
 
-    * `{:module_attribute, charlist}` - the context is a module attribute, such
-      as `@hello_wor`
+    * `{:module_attribute, charlist}` - the context is a module attribute,
+      such as `@hello_wor`
 
-    * `{:operator, charlist}` (since v1.13.0) - the context is an operator,
-      such as `+` or `==`. Note textual operators, such as `when` do not
-      appear as operators but rather as `:local_or_var`. `@` is never an
-      `:operator` and always a `:module_attribute`
+    * `{:operator, charlist}` - the context is an operator, such as `+` or
+      `==`. Note textual operators, such as `when` do not appear as operators
+      but rather as `:local_or_var`. `@` is never an `:operator` and always a
+      `:module_attribute`
 
-    * `{:operator_arity, charlist}` (since v1.13.0)  - the context is an
-      operator arity, which is an operator followed by /, such as `+/`,
-      `not/` or `when/`
+    * `{:operator_arity, charlist}` - the context is an operator arity, which
+      is an operator followed by /, such as `+/`, `not/` or `when/`
 
-    * `{:operator_call, charlist}` (since v1.13.0)  - the context is an
-      operator call, which is an operator followed by space, such as
-      `left + `, `not ` or `x when `
+    * `{:operator_call, charlist}` - the context is an operator call, which is
+      an operator followed by space, such as `left + `, `not ` or `x when `
 
     * `:none` - no context possible
+
+    * `{:sigil, charlist}` - the context is a sigil. It may be either the beginning
+      of a sigil, such as `~s"foo"`, or an operator starting with `~`, such as
+      `~>` and `~>>`. At the moment, `charlist` is always an empty list
 
     * `{:unquoted_atom, charlist}` - the context is an unquoted atom. This
       can be any atom or an atom representing a module
 
   ## Limitations
 
-    * The current algorithm only considers the last line of the input.
-      This means it will also show suggestions inside strings, heredocs,
-      etc, which is intentional as it helps with doctests, references,
-      and more
-
-    * Context does not yet track `alias A.{B`, structs, nor sigils
-
+  The current algorithm only considers the last line of the input. This means
+  it will also show suggestions inside strings, heredocs, etc, which is
+  intentional as it helps with doctests, references, and more. Other functions
+  may be added in the future that consider the tree-structure of the code.
   """
   @doc since: "1.13.0"
   @spec cursor_context(List.Chars.t(), keyword()) ::
@@ -364,6 +363,9 @@ defmodule Code.Fragment do
 
       match?([?. | rest] when rest == [] or hd(rest) != ?., rest) ->
         dot(tl(rest), dot_count + 1, acc)
+
+      acc == '~' ->
+        {{:sigil, ''}, count}
 
       true ->
         {{:operator, acc}, count}

--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -364,6 +364,7 @@ defmodule Code.Fragment do
       {{:alias, _} = prev, count} -> {{:dot, prev, acc}, count}
       {{:dot, _, _} = prev, count} -> {{:dot, prev, acc}, count}
       {{:module_attribute, _} = prev, count} -> {{:dot, prev, acc}, count}
+      {{:struct, acc}, count} -> {{:struct, acc ++ '.'}, count}
       {_, _} -> {:none, 0}
     end
   end

--- a/lib/elixir/src/elixir_tokenizer.erl
+++ b/lib/elixir/src/elixir_tokenizer.erl
@@ -590,6 +590,10 @@ tokenize("\r\n" ++ Rest, Line, Column, Scope, Tokens) ->
 
 % Others
 
+tokenize([$%, $( | Rest], Line, Column, _Scope, Tokens) ->
+  Reason = {Line, Column, "expected %{ to define a map, got: ", [$%, $(]},
+  {error, Reason, Rest, Tokens};
+
 tokenize([$%, $[ | Rest], Line, Column, _Scope, Tokens) ->
   Reason = {Line, Column, "expected %{ to define a map, got: ", [$%, $[]},
   {error, Reason, Rest, Tokens};

--- a/lib/elixir/test/elixir/code_fragment_test.exs
+++ b/lib/elixir/test/elixir/code_fragment_test.exs
@@ -132,6 +132,7 @@ defmodule CodeFragmentTest do
       assert CF.cursor_context("::%") == {:struct, ''}
 
       assert CF.cursor_context("%HelloWor") == {:struct, 'HelloWor'}
+      assert CF.cursor_context("%Hello.") == {:struct, 'Hello.'}
       assert CF.cursor_context("%Hello.Wor") == {:struct, 'Hello.Wor'}
       assert CF.cursor_context("% Hello . Wor") == {:struct, 'Hello.Wor'}
     end

--- a/lib/elixir/test/elixir/code_fragment_test.exs
+++ b/lib/elixir/test/elixir/code_fragment_test.exs
@@ -614,6 +614,46 @@ defmodule CodeFragmentTest do
              }
     end
 
+    test "sigil" do
+      assert CF.surround_context("~", {1, 1}) == :none
+      assert CF.surround_context("~~r", {1, 1}) == :none
+      assert CF.surround_context("~~r", {1, 2}) == :none
+
+      assert CF.surround_context("~~~", {1, 1}) == %{
+               begin: {1, 1},
+               context: {:operator, '~~~'},
+               end: {1, 4}
+             }
+
+      assert CF.surround_context("~r/foo/", {1, 1}) == %{
+               begin: {1, 1},
+               context: {:sigil, 'r'},
+               end: {1, 3}
+             }
+
+      assert CF.surround_context("~r/foo/", {1, 2}) == %{
+               begin: {1, 1},
+               context: {:sigil, 'r'},
+               end: {1, 3}
+             }
+
+      assert CF.surround_context("~r/foo/", {1, 3}) == :none
+
+      assert CF.surround_context("~r<foo>", {1, 1}) == %{
+               begin: {1, 1},
+               context: {:sigil, 'r'},
+               end: {1, 3}
+             }
+
+      assert CF.surround_context("~r<foo>", {1, 2}) == %{
+               begin: {1, 1},
+               context: {:sigil, 'r'},
+               end: {1, 3}
+             }
+
+      assert CF.surround_context("~r<foo>", {1, 3}) == :none
+    end
+
     test "dot operator" do
       for i <- 4..7 do
         assert CF.surround_context("Foo.<<<", {1, i}) == %{

--- a/lib/elixir/test/elixir/code_fragment_test.exs
+++ b/lib/elixir/test/elixir/code_fragment_test.exs
@@ -212,6 +212,9 @@ defmodule CodeFragmentTest do
 
     test "sigil" do
       assert CF.cursor_context("~") == {:sigil, ''}
+      assert CF.cursor_context("~r") == {:sigil, 'r'}
+      assert CF.cursor_context("~r/") == :none
+      assert CF.cursor_context("~r<") == :none
       assert CF.cursor_context("~ ") == :none
     end
 

--- a/lib/elixir/test/elixir/code_fragment_test.exs
+++ b/lib/elixir/test/elixir/code_fragment_test.exs
@@ -194,9 +194,7 @@ defmodule CodeFragmentTest do
     end
 
     test "incomplete operators" do
-      assert CF.cursor_context("~") == {:operator, '~'}
       assert CF.cursor_context("~~") == {:operator, '~~'}
-      assert CF.cursor_context("~ ") == :none
       assert CF.cursor_context("~~ ") == :none
       assert CF.cursor_context("^^") == {:operator, '^^'}
       assert CF.cursor_context("^^ ") == :none
@@ -210,6 +208,11 @@ defmodule CodeFragmentTest do
       assert CF.cursor_context("Foo.^^") == {:dot, {:alias, 'Foo'}, '^^'}
       assert CF.cursor_context("Foo . ^^") == {:dot, {:alias, 'Foo'}, '^^'}
       assert CF.cursor_context("Foo.^^ ") == :none
+    end
+
+    test "sigil" do
+      assert CF.cursor_context("~") == {:sigil, ''}
+      assert CF.cursor_context("~ ") == :none
     end
 
     test "module attribute" do

--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -74,8 +74,11 @@ defmodule IEx.Autocomplete do
       {:operator_call, _operator} ->
         expand_local_or_var("", shell)
 
-      {:sigil, ''} ->
+      {:sigil, []} ->
         expand_sigil(shell)
+
+      {:sigil, [_]} ->
+        {:yes, [], ~w|" """ ' ''' \( / < [ { \||c}
 
       # {:module_attribute, charlist}
       # :none

--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -80,6 +80,9 @@ defmodule IEx.Autocomplete do
       {:sigil, [_]} ->
         {:yes, [], ~w|" """ ' ''' \( / < [ { \||c}
 
+      {:struct, struct} ->
+        expand_structs(List.to_string(struct), shell)
+
       # {:module_attribute, charlist}
       # :none
       _ ->
@@ -166,7 +169,7 @@ defmodule IEx.Autocomplete do
 
   defp expand_dot(path, hint, exact?, shell) do
     case expand_dot_path(path, shell) do
-      {:ok, mod} when is_atom(mod) and hint == "" -> expand_aliases(mod, "", [], true)
+      {:ok, mod} when is_atom(mod) and hint == "" -> expand_dot_aliases(mod)
       {:ok, mod} when is_atom(mod) -> expand_require(mod, hint, exact?)
       {:ok, map} when is_map(map) -> expand_map_field_access(map, hint)
       _ -> no()
@@ -210,8 +213,16 @@ defmodule IEx.Autocomplete do
     end
   end
 
+  defp expand_dot_aliases(mod) do
+    all = match_elixir_modules(mod, "") ++ match_module_funs(get_module_funs(mod), "", false)
+    format_expansion(all, "")
+  end
+
   defp expand_require(mod, hint, exact?) do
-    format_expansion(match_module_funs(get_module_funs(mod), hint, exact?), hint)
+    mod
+    |> get_module_funs()
+    |> match_module_funs(hint, exact?)
+    |> format_expansion(hint)
   end
 
   ## Expand local or var
@@ -251,37 +262,51 @@ defmodule IEx.Autocomplete do
   end
 
   defp match_erlang_modules(hint) do
-    for mod <- match_modules(hint, true), usable_as_unquoted_module?(mod) do
-      %{kind: :module, name: mod, type: :erlang}
+    for mod <- match_modules(hint, false), usable_as_unquoted_module?(mod) do
+      %{kind: :module, name: mod}
     end
   end
 
   ## Elixir modules
 
+  defp expand_structs(hint, shell) do
+    aliases =
+      for {alias, mod} <- aliases_from_env(shell),
+          [name] = Module.split(alias),
+          String.starts_with?(name, hint),
+          has_struct?(mod),
+          do: %{kind: :struct, name: name}
+
+    modules =
+      for "Elixir." <> name = full_name <- match_modules("Elixir." <> hint, true),
+          String.starts_with?(name, hint),
+          mod = String.to_atom(full_name),
+          has_struct?(mod),
+          do: %{kind: :struct, name: name}
+
+    format_expansion(aliases ++ modules, hint)
+  end
+
+  defp has_struct?(mod) do
+    Code.ensure_loaded?(mod) and function_exported?(mod, :__struct__, 1) and
+      not function_exported?(mod, :exception, 1)
+  end
+
   defp expand_aliases(all, shell) do
     case String.split(all, ".") do
       [hint] ->
-        aliases = match_aliases(hint, shell)
-        expand_aliases(Elixir, hint, aliases, false)
+        all = match_aliases(hint, shell) ++ match_elixir_modules(Elixir, hint)
+        format_expansion(all, hint)
 
       parts ->
         hint = List.last(parts)
         list = Enum.take(parts, length(parts) - 1)
 
         case value_from_alias(list, shell) do
-          {:ok, alias} -> expand_aliases(alias, hint, [], false)
+          {:ok, alias} -> match_elixir_modules(alias, hint) |> format_expansion(hint)
           :error -> no()
         end
     end
-  end
-
-  defp expand_aliases(mod, hint, aliases, include_funs?) do
-    aliases
-    |> Kernel.++(match_elixir_modules(mod, hint))
-    |> Kernel.++(
-      if include_funs?, do: match_module_funs(get_module_funs(mod), hint, false), else: []
-    )
-    |> format_expansion(hint)
   end
 
   defp value_from_alias([name | rest], shell) when is_binary(name) do
@@ -299,10 +324,10 @@ defmodule IEx.Autocomplete do
   end
 
   defp match_aliases(hint, shell) do
-    for {alias, _mod} <- aliases_from_env(shell),
+    for {alias, module} <- aliases_from_env(shell),
         [name] = Module.split(alias),
         String.starts_with?(name, hint) do
-      %{kind: :module, type: :alias, name: name}
+      %{kind: :module, name: name, module: module}
     end
   end
 
@@ -317,7 +342,7 @@ defmodule IEx.Autocomplete do
         name = Enum.at(parts, depth - 1),
         valid_alias_piece?("." <> name),
         uniq: true,
-        do: %{kind: :module, type: :elixir, name: name}
+        do: %{kind: :module, name: name}
   end
 
   defp valid_alias_piece?(<<?., char, rest::binary>>) when char in ?A..?Z,
@@ -343,7 +368,7 @@ defmodule IEx.Autocomplete do
 
   defp format_expansion([uniq], hint) do
     case to_hint(uniq, hint) do
-      "" -> yes("", to_uniq_entries(uniq))
+      "" -> yes("", to_entries(uniq))
       hint -> yes(hint, [])
     end
   end
@@ -376,8 +401,8 @@ defmodule IEx.Autocomplete do
     Code.Identifier.classify(String.to_atom(name)) != :other
   end
 
-  defp match_modules(hint, root) do
-    get_modules(root)
+  defp match_modules(hint, elixir_root?) do
+    get_modules(elixir_root?)
     |> Enum.sort()
     |> Enum.dedup()
     |> Enum.drop_while(&(not String.starts_with?(&1, hint)))
@@ -531,28 +556,26 @@ defmodule IEx.Autocomplete do
     [name]
   end
 
-  defp to_uniq_entries(%{kind: kind} = fun) when kind in [:function, :sigil] do
-    to_entries(fun)
+  # Add extra character only if pressing tab when done
+  defp to_hint(%{kind: :module, name: hint}, hint) do
+    "."
   end
 
-  defp to_uniq_entries(%{kind: _}) do
-    []
-  end
-
-  defp to_hint(%{kind: :module, name: name}, hint) when name == hint do
-    format_hint(name, name) <> "."
-  end
-
-  defp to_hint(%{kind: :map_key, name: name, value_is_map: true}, hint) when name == hint do
-    format_hint(name, hint) <> "."
-  end
-
-  defp to_hint(%{kind: :dir, name: hint}, hint) do
-    "/"
+  defp to_hint(%{kind: :map_key, name: hint, value_is_map: true}, hint) do
+    "."
   end
 
   defp to_hint(%{kind: :file, name: hint}, hint) do
     "\""
+  end
+
+  # Add extra character whenever possible
+  defp to_hint(%{kind: :dir, name: name}, hint) do
+    format_hint(name, hint) <> "/"
+  end
+
+  defp to_hint(%{kind: :struct, name: name}, hint) do
+    format_hint(name, hint) <> "{"
   end
 
   defp to_hint(%{kind: _, name: name}, hint) do
@@ -616,43 +639,39 @@ defmodule IEx.Autocomplete do
   defp path_fragment([?" | _], _acc), do: []
   defp path_fragment([h | t], acc), do: path_fragment(t, [h | acc])
 
-  defp expand_path(path_fragment) do
-    path = List.to_string(path_fragment)
-    dir = Path.dirname(path_fragment)
-
+  defp expand_path(path) do
     path
-    |> ls_prefix(dir)
+    |> List.to_string()
+    |> ls_prefix()
     |> Enum.map(fn path ->
       %{
         kind: if(File.dir?(path), do: :dir, else: :file),
         name: Path.basename(path)
       }
     end)
-    |> format_expansion(path_hint(path, dir))
+    |> format_expansion(path_hint(path))
   end
 
-  defp path_hint(path, dir) do
-    path_size = byte_size(path)
-    dir_size = byte_size(dir)
-
-    if path_size == dir_size do
+  defp path_hint(path) do
+    if List.last(path) in [?/, ?\\] do
       ""
     else
-      binary_part(path, dir_size + 1, path_size - (dir_size + 1))
+      Path.basename(path)
     end
   end
 
   defp prefix_from_dir(".", <<c, _::binary>>) when c != ?., do: ""
   defp prefix_from_dir(dir, _fragment), do: dir
 
-  defp ls_prefix(path_fragment, dir) do
-    prefix = prefix_from_dir(dir, path_fragment)
+  defp ls_prefix(path) do
+    dir = Path.dirname(path)
+    prefix = prefix_from_dir(dir, path)
 
     case File.ls(dir) do
       {:ok, list} ->
         list
         |> Enum.map(&Path.join(prefix, &1))
-        |> Enum.filter(&String.starts_with?(&1, path_fragment))
+        |> Enum.filter(&String.starts_with?(&1, path))
 
       _ ->
         []

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -192,6 +192,18 @@ defmodule IEx.AutocompleteTest do
     assert expand('++/') == {:yes, '', ['++/2']}
   end
 
+  test "sigil completion" do
+    {:yes, '', sigils} = expand('~')
+    assert '~C (sigil_C)' in sigils
+
+    eval("import Bitwise")
+    {:yes, '', sigils} = expand('~')
+    assert '~~~/1' in sigils
+
+    assert expand('~~') == {:yes, '~', []}
+    assert expand('~~~') == {:yes, '', ['~~~/1']}
+  end
+
   test "function completion using a variable bound to a module" do
     eval("mod = String")
     assert expand('mod.print') == {:yes, 'able?', []}

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -195,6 +195,9 @@ defmodule IEx.AutocompleteTest do
   test "sigil completion" do
     {:yes, '', sigils} = expand('~')
     assert '~C (sigil_C)' in sigils
+    {:yes, '', sigils} = expand('~r')
+    assert '"' in sigils
+    assert '(' in sigils
 
     eval("import Bitwise")
     {:yes, '', sigils} = expand('~')

--- a/lib/iex/test/iex/autocomplete_test.exs
+++ b/lib/iex/test/iex/autocomplete_test.exs
@@ -377,7 +377,20 @@ defmodule IEx.AutocompleteTest do
   end
 
   test "completion for struct names" do
-    assert expand('%IEx.AutocompleteTest.MyStr') == {:yes, 'uct', []}
+    assert {:yes, '', entries} = expand('%')
+    assert 'URI' in entries
+    assert 'IEx.History' in entries
+    assert 'IEx.State' in entries
+
+    assert {:yes, '', entries} = expand('%IEx.')
+    assert 'IEx.History' in entries
+    assert 'IEx.State' in entries
+
+    assert expand('%IEx.AutocompleteTe') == {:yes, 'st.MyStruct{', []}
+    assert expand('%IEx.AutocompleteTest.MyStr') == {:yes, 'uct{', []}
+
+    eval("alias IEx.AutocompleteTest.MyStruct")
+    assert expand('%MyStr') == {:yes, 'uct{', []}
   end
 
   test "completion for struct keys" do
@@ -435,7 +448,7 @@ defmodule IEx.AutocompleteTest do
     assert expand('"#{dir}/single1') == {:yes, '"', []}
     assert expand('"#{dir}/fi') == {:yes, 'le', []}
     assert expand('"#{dir}/file') == path_autocompletion(dir, "file")
-    assert expand('"#{dir}/d') == {:yes, 'ir', []}
+    assert expand('"#{dir}/d') == {:yes, 'ir/', []}
     assert expand('"#{dir}/dir') == {:yes, '/', []}
     assert expand('"#{dir}/dir/') == {:yes, 'file', []}
     assert expand('"#{dir}/dir/file') == dir |> Path.join("dir") |> path_autocompletion("file")


### PR DESCRIPTION
This is still WIP but there is a part where I can already collect feedback, which is how to show sigils in IEx. I decided to show the `~CHAR` with the function name in parentheses, so there is a mapping between what is autocompleted and what is invoked:

![Screenshot 2021-08-21 at 19 05 22](https://user-images.githubusercontent.com/9582/130329838-dab8db82-a86e-452b-987f-9d15b55155f3.png)
