### PR TITLE
Update valid? for docs

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1751,6 +1751,8 @@ defmodule String do
 
   """
   @spec valid?(t) :: boolean
+  def valid?(string)
+  
   def valid?(<<string::binary>>), do: valid_utf8?(string)
   def valid?(_), do: false
 


### PR DESCRIPTION
Small nit, but the docs for `valid?/1` render with an ambiguous `arg1` rather than following the rest of the API with `string`: https://hexdocs.pm/elixir/1.12/String.html#valid?/1