### PR TITLE
Recompile only necessary deps whenever config/lock change

### DIFF
--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -30,19 +30,19 @@ defmodule Mix.Compilers.Elixir do
   between modules, which helps it recompile only the modules that
   have changed at runtime.
   """
-  def compile(manifest, srcs, dest, exts, force, deps_changed?, new_cache_key, stale, opts) do
+  def compile(manifest, srcs, dest, deps_changed?, new_cache_key, stale, opts) do
     # We fetch the time from before we read files so any future
     # change to files are still picked up by the compiler. This
     # timestamp is used when writing BEAM files and the manifest.
     timestamp = System.os_time(:second)
-    all_paths = Mix.Utils.extract_files(srcs, exts)
+    all_paths = Mix.Utils.extract_files(srcs, [:ex])
 
     {all_modules, all_sources, all_local_exports, old_cache_key, old_lock, old_config} =
       parse_manifest(manifest, dest)
 
     {force?, write?, stale, new_lock, new_config} =
       cond do
-        !!force or is_nil(old_lock) or is_nil(old_config) or old_cache_key != new_cache_key ->
+        !!opts[:force] or is_nil(old_lock) or is_nil(old_config) or old_cache_key != new_cache_key ->
           {true, true, stale, Enum.sort(Mix.Dep.Lock.read()),
            Enum.sort(Mix.Tasks.Loadconfig.read_compile())}
 
@@ -103,7 +103,7 @@ defmodule Mix.Compilers.Elixir do
     if opts[:all_warnings], do: show_warnings(sources)
 
     if stale != [] do
-      Mix.Utils.compiling_n(length(stale), hd(exts))
+      Mix.Utils.compiling_n(length(stale), :ex)
       Mix.Project.ensure_structure()
       true = Code.prepend_path(dest)
 

--- a/lib/mix/lib/mix/project_stack.ex
+++ b/lib/mix/lib/mix/project_stack.ex
@@ -145,11 +145,11 @@ defmodule Mix.ProjectStack do
     end)
   end
 
-  @spec compile_env([term] | :unset) :: [term] | :unset
+  @spec compile_env([term] | nil) :: [term] | nil
   def compile_env(compile_env) do
     update_stack(fn
       [h | t] -> {h.compile_env, [%{h | compile_env: compile_env} | t]}
-      [] -> {:unset, []}
+      [] -> {nil, []}
     end)
   end
 
@@ -255,7 +255,7 @@ defmodule Mix.ProjectStack do
           config_files: [manifest_file | parent_config],
           config_mtime: nil,
           after_compiler: %{},
-          compile_env: :unset
+          compile_env: nil
         }
 
         {:ok, {[project | stack], []}}

--- a/lib/mix/lib/mix/tasks/compile.app.ex
+++ b/lib/mix/lib/mix/tasks/compile.app.ex
@@ -177,8 +177,8 @@ defmodule Mix.Tasks.Compile.App do
   end
 
   defp load_compile_env(current_properties) do
-    case Mix.ProjectStack.compile_env(:unset) do
-      :unset -> Keyword.get(current_properties, :compile_env, [])
+    case Mix.ProjectStack.compile_env(nil) do
+      nil -> Keyword.get(current_properties, :compile_env, [])
       list -> list
     end
   end

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -104,9 +104,8 @@ defmodule Mix.Tasks.Compile.Elixir do
     manifest = manifest()
     manifest_last_modified = Mix.Utils.last_modified(manifest)
 
-    force =
-      opts[:force] ||
-        Mix.Utils.stale?([Mix.Project.config_mtime()], [manifest_last_modified])
+    force = opts[:force]
+    deps_changed? = Mix.Utils.stale?([Mix.Project.config_mtime()], [manifest_last_modified])
 
     stale =
       if Mix.Utils.stale?(Mix.Tasks.Compile.Erlang.manifests(), [manifest_last_modified]),
@@ -127,7 +126,17 @@ defmodule Mix.Tasks.Compile.Elixir do
       |> tracers_opts(tracers)
       |> profile_opts()
 
-    Mix.Compilers.Elixir.compile(manifest, srcs, dest, [:ex], stale, cache_key, force, opts)
+    Mix.Compilers.Elixir.compile(
+      manifest,
+      srcs,
+      dest,
+      [:ex],
+      force,
+      deps_changed?,
+      cache_key,
+      stale,
+      opts
+    )
   end
 
   @impl true

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -104,7 +104,6 @@ defmodule Mix.Tasks.Compile.Elixir do
     manifest = manifest()
     manifest_last_modified = Mix.Utils.last_modified(manifest)
 
-    force = opts[:force]
     deps_changed? = Mix.Utils.stale?([Mix.Project.config_mtime()], [manifest_last_modified])
 
     stale =
@@ -126,17 +125,7 @@ defmodule Mix.Tasks.Compile.Elixir do
       |> tracers_opts(tracers)
       |> profile_opts()
 
-    Mix.Compilers.Elixir.compile(
-      manifest,
-      srcs,
-      dest,
-      [:ex],
-      force,
-      deps_changed?,
-      cache_key,
-      stale,
-      opts
-    )
+    Mix.Compilers.Elixir.compile(manifest, srcs, dest, deps_changed?, cache_key, stale, opts)
   end
 
   @impl true

--- a/lib/mix/lib/mix/tasks/loadconfig.ex
+++ b/lib/mix/lib/mix/tasks/loadconfig.ex
@@ -44,11 +44,16 @@ defmodule Mix.Tasks.Loadconfig do
   end
 
   @doc false
+  def read_compile() do
+    Mix.State.read_cache(__MODULE__) || []
+  end
+
+  @doc false
   # Loads compile-time configuration, they support imports, and are not deep merged.
   def load_compile(file) do
     {config, files} = Config.Reader.read_imports!(file, env: Mix.env(), target: Mix.target())
     Mix.ProjectStack.loaded_config(persist_apps(config, file), files)
-    config
+    Mix.State.write_cache(__MODULE__, config)
   end
 
   @doc false

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -250,6 +250,8 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       refute_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
       assert File.stat!("_build/dev/lib/sample/.mix/compile.elixir").mtime > @old_time
     end)
+  after
+    Application.delete_env(:sample, :foo, persistent: true)
   end
 
   test "recompiles files when lock changes" do

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -10,6 +10,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
     :ok
   end
 
+  @old_time {{2010, 1, 1}, {0, 0, 0}}
   @elixir_otp_version {System.version(), :erlang.system_info(:otp_release)}
 
   test "compiles a project without per environment build" do
@@ -149,18 +150,35 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
       assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
 
-      Mix.Task.clear()
-      File.touch!("_build/dev/lib/sample/.mix/compile.elixir", {{2010, 1, 1}, {0, 0, 0}})
+      File.touch!("_build/dev/lib/sample/.mix/compile.elixir", @old_time)
       assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
       refute_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+
+      # Now remove the dependency
+      File.write!("lib/a.ex", """
+      defmodule A do
+      end
+      """)
+
+      File.touch!("_build/dev/lib/sample/.mix/compile.elixir", @old_time)
+      assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
+      assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+      refute_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+
+      # Making the manifest olds returns :ok, but does not recompile
+      File.touch!("_build/dev/lib/sample/.mix/compile.elixir", @old_time)
+      assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
+      refute_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+      refute_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+      assert File.stat!("_build/dev/lib/sample/.mix/compile.elixir").mtime > @old_time
     end)
   end
 
   test "recompiles files when config changes" do
     in_fixture("no_mixfile", fn ->
       Mix.Project.push(MixTest.Case.Sample, __ENV__.file)
-      Process.put({MixTest.Case.Sample, :application}, [extra_applications: [:logger]])
+      Process.put({MixTest.Case.Sample, :application}, extra_applications: [:logger])
       File.mkdir_p!("config")
 
       File.write!("lib/a.ex", """
@@ -174,7 +192,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
 
       recompile = fn ->
-        File.touch!("_build/dev/lib/sample/.mix/compile.elixir", {{2010, 1, 1}, {0, 0, 0}})
+        File.touch!("_build/dev/lib/sample/.mix/compile.elixir", @old_time)
         Mix.ProjectStack.pop()
         Mix.Project.push(MixTest.Case.Sample, __ENV__.file)
         Mix.Tasks.Loadconfig.load_compile("config/config.exs")
@@ -219,6 +237,80 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       assert recompile.() == {:ok, []}
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
       assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+
+      # Changing an unknown dependency returns :ok but does not recompile
+      File.write!("config/config.exs", """
+      import Config
+      config :sample, :foo, :bar
+      config :unknown, :unknown, :unknown
+      """)
+
+      assert recompile.() == {:ok, []}
+      refute_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+      refute_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+      assert File.stat!("_build/dev/lib/sample/.mix/compile.elixir").mtime > @old_time
+    end)
+  end
+
+  test "recompiles files when lock changes" do
+    in_fixture("no_mixfile", fn ->
+      Mix.Project.push(MixTest.Case.Sample, __ENV__.file)
+      Process.put({MixTest.Case.Sample, :application}, extra_applications: [:logger])
+
+      File.write!("lib/a.ex", """
+      defmodule A do
+        _ = Logger.metadata()
+      end
+      """)
+
+      assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
+      assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+      assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+
+      recompile = fn ->
+        File.touch!("_build/dev/lib/sample/.mix/compile.elixir", @old_time)
+        Mix.ProjectStack.pop()
+        Mix.Project.push(MixTest.Case.Sample, __ENV__.file)
+        Mix.Tasks.WillRecompile.run([])
+        Mix.Tasks.Compile.Elixir.run(["--verbose"])
+      end
+
+      # Adding to lock recompiles
+      File.write!("mix.lock", """
+      %{"logger": :unused}
+      """)
+
+      assert recompile.() == {:ok, []}
+      assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+      refute_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+
+      # Changing lock recompiles
+      File.write!("mix.lock", """
+      %{"logger": :another}
+      """)
+
+      assert recompile.() == {:ok, []}
+      assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+      refute_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+
+      # Removing a lock fully recompiles
+      File.write!("mix.lock", """
+      %{}
+      """)
+
+      assert recompile.() == {:ok, []}
+      assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+      assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+
+      # Adding an unknown dependency returns :ok but does not recompile
+      File.write!("mix.lock", """
+      %{"unknown": :unknown}
+      """)
+
+      assert recompile.() == {:ok, []}
+      refute_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
+      refute_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
+      assert File.stat!("_build/dev/lib/sample/.mix/compile.elixir").mtime > @old_time
     end)
   end
 
@@ -244,7 +336,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       assert_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
 
       Mix.Task.clear()
-      File.touch!("_build/dev/lib/sample/.mix/compile.elixir", {{2010, 1, 1}, {0, 0, 0}})
+      File.touch!("_build/dev/lib/sample/.mix/compile.elixir", @old_time)
 
       assert Mix.Tasks.Compile.run(["--verbose"]) == {:ok, []}
       assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
@@ -266,13 +358,13 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       File.write!("_build/dev/lib/sample/consolidated/.to_be_removed", "")
       manifest_data = :erlang.term_to_binary({:v1, "0.0.0", nil})
       File.write!("_build/dev/lib/sample/.mix/compile.elixir_scm", manifest_data)
-      File.touch!("_build/dev/lib/sample/.mix/compile.elixir_scm", {{2010, 1, 1}, {0, 0, 0}})
+      File.touch!("_build/dev/lib/sample/.mix/compile.elixir_scm", @old_time)
 
       Mix.Tasks.Compile.run([])
       assert Mix.Dep.ElixirSCM.read() == {:ok, @elixir_otp_version, Mix.SCM.Path}
 
       assert File.stat!("_build/dev/lib/sample/.mix/compile.elixir_scm").mtime >
-               {{2010, 1, 1}, {0, 0, 0}}
+               @old_time
 
       refute File.exists?("_build/dev/lib/sample/consolidated/.to_be_removed")
     end)
@@ -290,13 +382,13 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       Mix.Task.clear()
       manifest_data = :erlang.term_to_binary({1, @elixir_otp_version, :another})
       File.write!("_build/dev/lib/sample/.mix/compile.elixir_scm", manifest_data)
-      File.touch!("_build/dev/lib/sample/.mix/compile.elixir_scm", {{2010, 1, 1}, {0, 0, 0}})
+      File.touch!("_build/dev/lib/sample/.mix/compile.elixir_scm", @old_time)
 
       Mix.Tasks.Compile.run([])
       assert Mix.Dep.ElixirSCM.read() == {:ok, @elixir_otp_version, Mix.SCM.Path}
 
       assert File.stat!("_build/dev/lib/sample/.mix/compile.elixir_scm").mtime >
-               {{2010, 1, 1}, {0, 0, 0}}
+               @old_time
     end)
   end
 
@@ -432,7 +524,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
   test "compiles size changed files" do
     in_fixture("no_mixfile", fn ->
       Mix.Project.push(MixTest.Case.Sample)
-      past = {{2010, 1, 1}, {0, 0, 0}}
+      past = @old_time
       File.touch!("lib/a.ex", past)
 
       assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:ok, []}
@@ -547,7 +639,7 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       refute_received {:mix_shell, :info, ["Compiled lib/b.ex"]}
 
       # Does not update on old existing resource
-      File.touch!("lib/a.eex", {{2010, 1, 1}, {0, 0, 0}})
+      File.touch!("lib/a.eex", @old_time)
       assert Mix.Tasks.Compile.Elixir.run(["--verbose"]) == {:noop, []}
       Mix.shell().flush
       purge([A, B])

--- a/lib/mix/test/mix/tasks/deps.git_test.exs
+++ b/lib/mix/test/mix/tasks/deps.git_test.exs
@@ -192,42 +192,6 @@ defmodule Mix.Tasks.DepsGitTest do
     purge([GitRepo, GitRepo.MixProject])
   end
 
-  test "recompiles the project when a dep is fetched" do
-    in_fixture("no_mixfile", fn ->
-      Mix.Project.push(GitApp)
-
-      Mix.Tasks.Deps.Get.run([])
-      assert File.exists?("deps/git_repo/.fetch")
-
-      # We can compile just fine
-      assert Mix.Tasks.Compile.run(["--verbose"]) == {:ok, []}
-
-      # Clear up to prepare for the update
-      Mix.Task.clear()
-      Mix.shell().flush
-      purge([A, B, GitRepo])
-
-      # Update will mark the update required
-      Mix.Tasks.Deps.Update.run(["git_repo"])
-      assert File.exists?("deps/git_repo/.fetch")
-      # Ensure timestamp differs
-      ensure_touched("deps/git_repo/.fetch")
-
-      # mix deps.compile is required...
-      Mix.Tasks.Deps.run([])
-      msg = "  the dependency build is outdated, please run \"mix deps.compile\""
-      assert_received {:mix_shell, :info, [^msg]}
-
-      # But also ran automatically
-      Mix.Tasks.Compile.run(["--verbose"])
-      assert_received {:mix_shell, :info, ["Compiled lib/a.ex"]}
-      assert File.exists?("_build/dev/lib/git_repo/.mix/compile.fetch")
-      :ok
-    end)
-  after
-    purge([A, B, GitRepo, GitRepo.MixProject])
-  end
-
   test "all dependencies are up to date" do
     in_fixture("no_mixfile", fn ->
       Mix.Project.push(GitApp)

--- a/lib/mix/test/mix/umbrella_test.exs
+++ b/lib/mix/test/mix/umbrella_test.exs
@@ -478,9 +478,7 @@ defmodule Mix.UmbrellaTest do
 
         Mix.Task.clear()
         Application.unload(:foo)
-
-        mtime = File.stat!("_build/dev/lib/bar/.mix/compile.elixir").mtime
-        ensure_touched("../foo/lib/foo.ex", mtime)
+        ensure_touched("../foo/lib/foo.ex", "_build/dev/lib/bar/.mix/compile.elixir")
 
         assert Mix.Task.run("compile", ["--verbose"]) == {:ok, []}
         assert_receive {:mix_shell, :info, ["Compiled lib/bar.ex"]}
@@ -508,8 +506,10 @@ defmodule Mix.UmbrellaTest do
         # Mark protocol as outdated
         File.touch!("_build/dev/lib/bar/consolidated/Elixir.Foo.beam", {{2010, 1, 1}, {0, 0, 0}})
 
-        mtime = File.stat!("_build/dev/lib/bar/.mix/compile.protocols").mtime
-        ensure_touched("_build/dev/lib/foo/ebin/Elixir.Foo.beam", mtime)
+        ensure_touched(
+          "_build/dev/lib/foo/ebin/Elixir.Foo.beam",
+          "_build/dev/lib/bar/.mix/compile.protocols"
+        )
 
         assert Mix.Tasks.Compile.Protocols.run([]) == :ok
 

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -136,10 +136,14 @@ defmodule MixTest.Case do
   end
 
   def ensure_touched(file) do
-    ensure_touched(file, File.stat!(file).mtime)
+    ensure_touched(file, file)
   end
 
-  def ensure_touched(file, current) do
+  def ensure_touched(file, current) when is_binary(current) do
+    ensure_touched(file, File.stat!(current).mtime)
+  end
+
+  def ensure_touched(file, current) when is_tuple(current) do
     File.touch!(file)
     mtime = File.stat!(file).mtime
 


### PR DESCRIPTION
Whenever there is a change to the lock file or the config file, we will now only recompile the code that depends on the dependencies that changed (or that depends on any dependency that depends on the dependency that changed).

With the improvements in #11190, it means that we now only get a full recompilation when:

1. an app is removed from the lock file
2. when you change the configuration for your own app in config/config.exs (or an imported file from there)
3. when you change elixirc_options/elixirc_paths

This is currently WIP, tests still pending.