### PR TITLE
IEx.Helpers.h: Support `<b>` and `<strong>` tags in erlang+html format

### DIFF
--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -194,6 +194,10 @@ defmodule IO.ANSI.Docs do
     inline_text("*", traverse_erlang_html(entries, indent, options), options)
   end
 
+  defp traverse_erlang_html({tag, _, entries}, indent, options) when tag in [:strong, :b] do
+    inline_text("**", traverse_erlang_html(entries, indent, options), options)
+  end
+
   defp traverse_erlang_html({:code, _, entries}, indent, options) do
     inline_text("`", traverse_erlang_html(entries, indent, options), options)
   end
@@ -295,7 +299,7 @@ defmodule IO.ANSI.Docs do
   end
 
   defp inline_html?(binary) when is_binary(binary), do: true
-  defp inline_html?({tag, _, _}) when tag in [:a, :code, :em, :i, :br], do: true
+  defp inline_html?({tag, _, _}) when tag in [:a, :code, :em, :i, :strong, :b, :br], do: true
   defp inline_html?(_), do: false
 
   ## Markdown

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -701,6 +701,11 @@ defmodule IO.ANSI.DocsTest do
       assert format_erlang([{:em, [], ["Hello"]}]) == "\e[1mHello\e[0m"
       assert format_erlang([{:em, [], ["Hello"]}], enabled: false) == "*Hello*"
 
+      assert format_erlang([{:b, [], ["Hello"]}]) == "\e[1mHello\e[0m"
+      assert format_erlang([{:b, [], ["Hello"]}], enabled: false) == "**Hello**"
+      assert format_erlang([{:strong, [], ["Hello"]}]) == "\e[1mHello\e[0m"
+      assert format_erlang([{:strong, [], ["Hello"]}], enabled: false) == "**Hello**"
+
       assert format_erlang([{:code, [], ["Hello"]}]) == "\e[36mHello\e[0m"
       assert format_erlang([{:code, [], ["Hello"]}], enabled: false) == "`Hello`"
     end


### PR DESCRIPTION
Ref:

> `-type chunk_element_inline_type() :: a | code | strong | b | em | i.`

https://erlang.org/doc/apps/erl_docgen/doc_storage.html#eep-48--documentation-storage-and-format
