### PR TITLE
Fix logger translator with otp-24 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp_release: ['OTP-23.0', 'OTP-22.3', 'OTP-22.0', 'OTP-21.3.8', 'OTP-21.0']
+        otp_release: ['OTP-24.0', 'OTP-23.0', 'OTP-22.3', 'OTP-22.0', 'OTP-21.3.8', 'OTP-21.0']
         development: [false]
         include:
           - otp_release: master

--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -357,14 +357,21 @@ defmodule Logger.Translator do
     []
   end
 
-  defp child_debug(:debug, restart_type: restart, shutdown: shutdown, child_type: type) do
-    ["\nRestart: ", inspect(restart), "\nShutdown: ", inspect(shutdown)] ++
-      ["\nType: ", inspect(type)]
+  defp child_debug(:debug, opts) do
+    for {key, value} <- opts do
+      child_debug_key(key, value)
+    end
   end
 
   defp child_debug(_min_level, _child) do
     []
   end
+
+  defp child_debug_key(:restart_type, value), do: ["\nRestart: " | inspect(value)]
+  defp child_debug_key(:shutdown, value), do: ["\nShutdown: " | inspect(value)]
+  defp child_debug_key(:child_type, value), do: ["\nType: " | inspect(value)]
+  defp child_debug_key(:significant, value), do: if(value, do: "\nSignificant: true", else: [])
+  defp child_debug_key(_, _), do: []
 
   defp report_crash(min_level, [[{:initial_call, initial_call} | crashed], linked]) do
     mfa = initial_call_to_mfa(initial_call)


### PR DESCRIPTION
Cherry-picked dac1b43688324f95ddd4f8642b31ee9afa75aea4 and also add OTP-24 to the CI matrix since is officially supported from v1.11.4 onwards.

Related to #11221 .