### PR TITLE
Add guards to IO.puts/2 and IO.inspect/3

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -122,6 +122,7 @@ defmodule IO do
   @type nodata :: {:error, term} | :eof
   @type chardata :: String.t() | maybe_improper_list(char | chardata, String.t() | [])
 
+  defguardp is_device(term) when is_atom(term) or is_pid(term)
   defguardp is_iodata(data) when is_list(data) or is_binary(data)
 
   @doc """
@@ -280,7 +281,7 @@ defmodule IO do
 
   """
   @spec puts(device, chardata | String.Chars.t()) :: :ok
-  def puts(device \\ :stdio, item) do
+  def puts(device \\ :stdio, item) when is_device(device) do
     :io.put_chars(map_dev(device), [to_chardata(item), ?\n])
   end
 
@@ -415,7 +416,7 @@ defmodule IO do
   See `inspect/2` for a full list of options.
   """
   @spec inspect(device, item, keyword) :: item when item: var
-  def inspect(device, item, opts) when is_list(opts) do
+  def inspect(device, item, opts) when is_device(device) and is_list(opts) do
     label = if label = opts[:label], do: [to_chardata(label), ": "], else: []
     opts = Inspect.Opts.new(opts)
     doc = Inspect.Algebra.group(Inspect.Algebra.to_doc(item, opts))


### PR DESCRIPTION
Adds is_device private guard cheking the argument is a device.

The use case is that I have wasted a lot of time trying to figure out why I wasn't able to print an IO.ANSI string.

I was executing `IO.inspect(term, printable_limit: :infinity)` on a big string, and I switched to IO.puts to see how it looked, 
`IO.puts(term, printable_limit: :infinity)`,  I was getting a cryptic CaseClause error not matching. Long story short, `IO.puts` does not take options, and the first argument is a device, not the term to inspect/print. So this guard will guide you in the right path.