### PR TITLE
Add more variants to Process.spawn_opt type

### DIFF
--- a/lib/elixir/lib/process.ex
+++ b/lib/elixir/lib/process.ex
@@ -383,10 +383,13 @@ defmodule Process do
   @type spawn_opt ::
           :link
           | :monitor
+          | {:monitor, :erlang.monitor_option()}
           | {:priority, :low | :normal | :high}
           | {:fullsweep_after, non_neg_integer}
           | {:min_heap_size, non_neg_integer}
           | {:min_bin_vheap_size, non_neg_integer}
+          | {:max_heap_size, heap_size}
+          | {:message_queue_data, :off_heap | :on_heap}
   @type spawn_opts :: [spawn_opt]
 
   @doc """


### PR DESCRIPTION
See https://erlang.org/doc/man/erlang.html#spawn_opt-2 as reference

Monitor tuple option seems to have been added rather recently,
it's missing in OTP 23.0 docs:
https://erlang.org/documentation/doc-11.0-rc2/erts-11.0/doc/html/erlang.html#spawn_opt-2

There are more types exported from the erlang module now, possibly
Elixir could reference those in more places, but I think it's fine
to copy / inline the simple ones because they may not be exported
in older Erlang/OTP versions that Elixir still supports. (and it's clearer
since they may be hard to find and there is no auto link)