### PR TITLE
Fix nfd cluster columns

### DIFF
--- a/lib/elixir/src/elixir_interpolation.erl
+++ b/lib/elixir/src/elixir_interpolation.erl
@@ -52,12 +52,21 @@ extract(Line, Column, Scope, true, [$#, ${ | Rest], Buffer, Output, Last) ->
   end;
 
 extract(Line, Column, Scope, Interpol, [$\\, Char | Rest], Buffer, Output, Last) ->
-  extract(Line, Column+2, Scope, Interpol, Rest, [Char, $\\ | Buffer], Output, Last);
+  extract(Line, Column + 2, Scope, Interpol, Rest, [Char, $\\ | Buffer], Output, Last);
 
 %% Catch all clause
 
 extract(Line, Column, Scope, Interpol, [Char | Rest], Buffer, Output, Last) ->
-  extract(Line, Column + 1, Scope, Interpol, Rest, [Char | Buffer], Output, Last).
+  NewRest =
+    case Rest of
+      [$\r, $\n | _T] ->
+        Rest;
+
+      _ ->
+        unicode_util:gc(Rest)
+    end,
+
+  extract(Line, Column + 1, Scope, Interpol, NewRest, [Char | Buffer], Output, Last).
 
 %% Handle newlines. Heredocs require special attention
 

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -224,6 +224,12 @@ defmodule Kernel.ParserTest do
       foo = {:foo, [line: 1, column: 1], nil}
       bar = {:bar, [line: 1, column: 7], nil}
       assert string_to_quoted.("foo + bar") == {:ok, {:+, [line: 1, column: 5], [foo, bar]}}
+
+      nfd_jose = [106, 111, 115, 101, 769]
+      nfc_jose = [106, 111, 115, 233]
+      context = [line: 1, column: 8]
+      assert string_to_quoted.("'josé' = 1") == {:ok, {:=, context, [nfd_jose, 1]}}
+      assert string_to_quoted.("'josé' = 1") == {:ok, {:=, context, [nfc_jose, 1]}}
     end
   end
 


### PR DESCRIPTION
- [x] Add tests for NFD vs NFC cases with columns
- [x] Add spaces between `Column + 2`
- [x] Add new validation to disregard `\r\n` tokens on cluster
- [x] Add `unicode_util:gc/1` to clusterize NFD symbols

Fix #11142