### PR TITLE
Fixes output of deps.unlock when dependency is not locked

### DIFF
--- a/lib/mix/lib/mix/tasks/deps.unlock.ex
+++ b/lib/mix/lib/mix/tasks/deps.unlock.ex
@@ -92,9 +92,9 @@ defmodule Mix.Tasks.Deps.Unlock do
   end
 
   defp unlock(lock, apps) do
-    lock |> Map.drop(apps) |> Mix.Dep.Lock.write()
-
     unless apps == [] do
+      lock |> Map.drop(apps) |> Mix.Dep.Lock.write()
+
       Mix.shell().info("""
       Unlocked deps:
       * #{Enum.join(apps, "\n* ")}

--- a/lib/mix/lib/mix/tasks/deps.unlock.ex
+++ b/lib/mix/lib/mix/tasks/deps.unlock.ex
@@ -94,9 +94,11 @@ defmodule Mix.Tasks.Deps.Unlock do
   defp unlock(lock, apps) do
     lock |> Map.drop(apps) |> Mix.Dep.Lock.write()
 
-    Mix.shell().info("""
-    Unlocked deps:
-    * #{Enum.join(apps, "\n* ")}
-    """)
+    unless apps == [] do
+      Mix.shell().info("""
+      Unlocked deps:
+      * #{Enum.join(apps, "\n* ")}
+      """)
+    end
   end
 end

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -396,20 +396,13 @@ defmodule Mix.Tasks.DepsTest do
     end)
   end
 
-  test "unlocking a dep that is not locked does not output a blank line", context do
+  test "unlocking a dep that is not locked is a no-op", context do
     in_tmp(context.test, fn ->
       Mix.Project.push(DepsApp)
-
       Mix.Tasks.Deps.Unlock.run(["unlocked_dep"])
 
       assert_received {:mix_shell, :error, ["warning: unlocked_dep dependency is not locked"]}
-
-      refuted_output = """
-      Unlocked deps:
-      * unlocked_dep
-      """
-
-      refute_received {:mix_shell, :info, [^refuted_output]}
+      refute_received {:mix_shell, :info, [_]}
     end)
   end
 

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -396,6 +396,23 @@ defmodule Mix.Tasks.DepsTest do
     end)
   end
 
+  test "unlocking a dep that is not locked does not output a blank line", context do
+    in_tmp(context.test, fn ->
+      Mix.Project.push(DepsApp)
+
+      Mix.Tasks.Deps.Unlock.run(["unlocked_dep"])
+
+      assert_received {:mix_shell, :error, ["warning: unlocked_dep dependency is not locked"]}
+
+      refuted_output = """
+      Unlocked deps:
+      * unlocked_dep
+      """
+
+      refute_received {:mix_shell, :info, [^refuted_output]}
+    end)
+  end
+
   test "unlocks specific deps", context do
     in_tmp(context.test, fn ->
       Mix.Project.push(DepsApp)


### PR DESCRIPTION
Current behaviour:
![image](https://user-images.githubusercontent.com/773380/132770275-fc7a2192-de57-467c-9263-9b5825653732.png)

Does not output empty line with * when no dependencies were unlocked
Adds test for that behaviour