### PR TITLE
Kernel.tap/2: Explicitly ignore return value for compatibility with Dialyzer unmatched_returns

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1195,7 +1195,7 @@ defmodule Kernel do
   @doc since: "1.12.0"
   defmacro tap(value, fun) do
     quote bind_quoted: [fun: fun, value: value] do
-      fun.(value)
+      _ = fun.(value)
       value
     end
   end


### PR DESCRIPTION
When the `unmatched_returns` option of Dialyzer is enabled, functions which can return more than a single value must be explicitly matched against. This fixes `Kernel.tap/2` to be compatible with that option.