### PR TITLE
Map filter

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1338,7 +1338,7 @@ defmodule Keyword do
 
   defp do_filter([], _fun), do: []
 
-  defp do_filter([entry | entries], fun) do
+  defp do_filter([{_, _} = entry | entries], fun) do
     if fun.(entry) do
       [entry | do_filter(entries, fun)]
     else
@@ -1366,7 +1366,7 @@ defmodule Keyword do
 
   defp do_reject([], _fun), do: []
 
-  defp do_reject([entry | entries], fun) do
+  defp do_reject([{_, _} = entry | entries], fun) do
     if fun.(entry) do
       do_reject(entries, fun)
     else

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1334,15 +1334,17 @@ defmodule Keyword do
   @doc since: "1.13.0"
   @spec filter(t, ({key, value} -> as_boolean(term))) :: t
   def filter(keywords, fun) when is_list(keywords) and is_function(fun, 1) do
-    boolean_fun =
-      fn element ->
-        case fun.(element) do
-          x when x in [false, nil] -> false
-          _ -> true
-        end
-      end
+    do_filter(keywords, fun)
+  end
 
-    :lists.filter(boolean_fun, keywords)
+  defp do_filter([], _fun), do: []
+
+  defp do_filter([element | vals], fun) do
+    if fun.(element) do
+      [element | do_filter(vals, fun)]
+    else
+      do_filter(vals, fun)
+    end
   end
 
   @doc """
@@ -1361,14 +1363,16 @@ defmodule Keyword do
   @doc since: "1.13.0"
   @spec reject(t, ({key, value} -> as_boolean(term))) :: t
   def reject(keywords, fun) when is_list(keywords) and is_function(fun, 1) do
-    boolean_fun =
-    fn element ->
-      case fun.(element) do
-        x when x in [false, nil] -> true
-        _ -> false
-      end
-    end
+    do_reject(keywords, fun)
+  end
 
-    :lists.filter(boolean_fun, keywords)
+  defp do_reject([], _fun), do: []
+
+  defp do_reject([element | vals], fun) do
+    if fun.(element) do
+      do_reject(vals, fun)
+    else
+      [element | do_reject(vals, fun)]
+    end
   end
 end

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1318,9 +1318,8 @@ defmodule Keyword do
   end
 
   @doc """
-  Filters `keywords` i.e. returns a keyword list containing
-  only the elements from `keywords` for which the function
-  `fun` returns a truthy value.
+  Returns a keyword list containing only the elements from `keywords`
+  for which the function `fun` returns a truthy value.
 
   See also `reject/2` which discards all elements where the function
   returns a truthy value.

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1334,7 +1334,7 @@ defmodule Keyword do
   @doc since: "1.13.0"
   @spec filter(t, ({key, value} -> as_boolean(term))) :: t
   def filter(keywords, fun) when is_list(keywords) and is_function(fun, 1) do
-    :lists.filter(keywords, fun)
+    :lists.filter(fun, keywords)
   end
 
   @doc """
@@ -1353,6 +1353,6 @@ defmodule Keyword do
   @doc since: "1.13.0"
   @spec reject(t, ({key, value} -> as_boolean(term))) :: t
   def reject(keywords, fun) when is_list(keywords) and is_function(fun, 1) do
-    :lists.filter(keywords, &(not fun.(&1)))
+    :lists.filter(&(not fun.(&1)), keywords)
   end
 end

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1350,8 +1350,7 @@ defmodule Keyword do
   Returns a keyword list excluding the entries from `keywords`
   for which the function `fun` returns a truthy value.
 
-  See also `filter/2` which discards all entries where the function
-  returns a falsy value.
+  See also `filter/2`.
 
   ## Examples
 

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1316,4 +1316,43 @@ defmodule Keyword do
   def size(keywords) do
     length(keywords)
   end
+
+  @doc """
+  Filters `keywords` i.e. returns a keyword list containing
+  only the elements from `keywords` for which the function
+  `fun` returns a truthy value.
+
+  See also `reject/2` which discards all elements where the function
+  returns a truthy value.
+
+  ## Examples
+
+      iex> Keyword.filter([one: 1, two: 2, three: 3], fn {_key, val} -> rem(val, 2) == 1 end)
+      [one: 1, three: 3]
+
+  """
+  @doc since: "1.13.0"
+  @spec filter(t, ({key, value} -> as_boolean(term))) :: t
+  def filter(keywords, fun) when is_list(keywords) and is_function(fun, 1) do
+    :lists.filter(keywords, fun)
+  end
+
+  @doc """
+  Returns a keyword list excluding the elements from `keywords`
+  for which the function `fun` returns a truthy value.
+
+  See also `filter/2` which discards all elements where the function
+  returns a falsy value.
+
+  ## Examples
+
+      iex> Keyword.reject([one: 1, two: 2, three: 3], fn {_key, val} -> rem(val, 2) == 1 end)
+      [two: 2]
+
+  """
+  @doc since: "1.13.0"
+  @spec reject(t, ({key, value} -> as_boolean(term))) :: t
+  def reject(keywords, fun) when is_list(keywords) and is_function(fun, 1) do
+    :lists.filter(keywords, &(not fun.(&1)))
+  end
 end

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1334,7 +1334,15 @@ defmodule Keyword do
   @doc since: "1.13.0"
   @spec filter(t, ({key, value} -> as_boolean(term))) :: t
   def filter(keywords, fun) when is_list(keywords) and is_function(fun, 1) do
-    :lists.filter(fun, keywords)
+    boolean_fun =
+      fn element ->
+        case fun.(element) do
+          x when x in [false, nil] -> false
+          _ -> true
+        end
+      end
+
+    :lists.filter(boolean_fun, keywords)
   end
 
   @doc """
@@ -1353,6 +1361,14 @@ defmodule Keyword do
   @doc since: "1.13.0"
   @spec reject(t, ({key, value} -> as_boolean(term))) :: t
   def reject(keywords, fun) when is_list(keywords) and is_function(fun, 1) do
-    :lists.filter(&(not fun.(&1)), keywords)
+    boolean_fun =
+    fn element ->
+      case fun.(element) do
+        x when x in [false, nil] -> true
+        _ -> false
+      end
+    end
+
+    :lists.filter(boolean_fun, keywords)
   end
 end

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1377,7 +1377,7 @@ defmodule Keyword do
   end
 
   @doc """
-  Maps the function `fun` over all `{key, value}`-elements in `keywords`,
+  Maps the function `fun` over all key-value pairs in `keywords`,
   returning a keyword list with all the values replaced with
   the result of the function.
 

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1318,10 +1318,10 @@ defmodule Keyword do
   end
 
   @doc """
-  Returns a keyword list containing only the elements from `keywords`
+  Returns a keyword list containing only the entries from `keywords`
   for which the function `fun` returns a truthy value.
 
-  See also `reject/2` which discards all elements where the function
+  See also `reject/2` which discards all entries where the function
   returns a truthy value.
 
   ## Examples
@@ -1338,19 +1338,19 @@ defmodule Keyword do
 
   defp do_filter([], _fun), do: []
 
-  defp do_filter([element | vals], fun) do
-    if fun.(element) do
-      [element | do_filter(vals, fun)]
+  defp do_filter([entry | entries], fun) do
+    if fun.(entry) do
+      [entry | do_filter(entries, fun)]
     else
-      do_filter(vals, fun)
+      do_filter(entries, fun)
     end
   end
 
   @doc """
-  Returns a keyword list excluding the elements from `keywords`
+  Returns a keyword list excluding the entries from `keywords`
   for which the function `fun` returns a truthy value.
 
-  See also `filter/2` which discards all elements where the function
+  See also `filter/2` which discards all entries where the function
   returns a falsy value.
 
   ## Examples
@@ -1367,11 +1367,11 @@ defmodule Keyword do
 
   defp do_reject([], _fun), do: []
 
-  defp do_reject([element | vals], fun) do
-    if fun.(element) do
-      do_reject(vals, fun)
+  defp do_reject([entry | entries], fun) do
+    if fun.(entry) do
+      do_reject(entries, fun)
     else
-      [element | do_reject(vals, fun)]
+      [entry | do_reject(entries, fun)]
     end
   end
 

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1375,4 +1375,28 @@ defmodule Keyword do
       [element | do_reject(vals, fun)]
     end
   end
+
+  @doc """
+  Maps the function `fun` over all `{key, value}`-elements in `keywords`,
+  returning a keyword list with all the values replaced with
+  the result of the function.
+
+  ## Examples
+
+      iex> Keyword.map([one: 1, two: 2, three: 3], fn {_key, val} -> to_string(val) end)
+      [one: "1", two: "2", three: "3"]
+
+  """
+  @doc since: "1.13.0"
+  @spec map(t, ({key, value} -> value)) :: t
+  def map(keywords, fun) when is_list(keywords) and is_function(fun, 1) do
+    do_map(keywords, fun)
+  end
+
+  defp do_map([], _fun), do: []
+
+  defp do_map([{key, value} | rest], fun) do
+    new_value = fun.({key, value})
+    [{key, new_value} | do_map(rest, fun)]
+  end
 end

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -1045,6 +1045,31 @@ defmodule Map do
     end
   end
 
+  @doc """
+  Maps the function `fun` over all `{key, value}`-elements in `map`, returning a map
+  with all the values replaced with the result of the function.
+
+  ## Examples
+
+      iex> Map.map(%{1 => "joe", 2 => "mike", 3 => "robert"}, fn {_key, val} -> String.capitalize(val) end)
+      %{1 => "Joe", 2 => "Mike", 3 => "Robert"}
+
+  """
+  @doc since: "1.13.0"
+  @spec map(map, ({key, value} -> value)) :: map
+  def map(map, fun) when is_map(map) and is_function(fun, 1) do
+    iter = iterator(map)
+    next = next(iter)
+    :maps.from_list(do_map(next, fun))
+  end
+
+  defp do_map(:none, _fun), do: []
+
+  defp do_map({key, value, iter}, fun) do
+    new_value = fun.({key, value})
+    [{key, new_value} | do_map(next(iter), fun)]
+  end
+
   # Inlined version of `:maps.iterator/1`
   defp iterator(map) when is_map(map), do: [0 | map]
 

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -982,7 +982,6 @@ defmodule Map do
   `Map.filter/2` is faster than using `map |> Enum.filter(fun) |> Enum.into(%{})`,
   as no intermediate list is being built.
 
-
   See also `reject/2` which discards all elements where the
   function returns a truthy value.
 

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -1071,12 +1071,14 @@ defmodule Map do
   end
 
   # Inlined version of `:maps.iterator/1`
+  @compile {:inline, iterator: 1}
   defp iterator(map) when is_map(map), do: [0 | map]
 
   # Inlined version of `:maps.next/1`
+  @compile {:inline, next: 1}
   defp next({key, val, iter}), do: {key, val, iter}
 
-  defp next([path | map]) when is_integer(path) and is_map(map),
+  defp next([path | map]),
     do: :erts_internal.map_next(path, map, :iterator)
 
   defp next(:none), do: :none

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -1013,8 +1013,6 @@ defmodule Map do
   @doc """
   Returns map excluding the elements from `map` for which
   the function `fun` returns a truthy value.
-
-
   `Map.reject/2` is faster than using `map |> Enum.reject(fun) |> Enum.into(%{})`,
   as no intermediate list is being built.
 

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -973,11 +973,11 @@ defmodule Map do
   end
 
   @doc """
-  Filters `map`, i.e. returns a map containing only those pairs for
-  which `fun` returns a truthy value.
+  Returns a map containing only those pairs from `map`
+  for which `fun` returns a truthy value.
 
   `fun` receives the key and value of each of the
-  elements in the map as a `{key, value}` tuple.
+  elements in the map as a key-value pair.
 
   `Map.filter/2` is faster than using `map |> Enum.filter(fun) |> Enum.into(%{})`,
   as no intermediate list is being built.

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -973,8 +973,8 @@ defmodule Map do
   end
 
   @doc """
-  Filters `map`, i.e. returns a map containing
-  only those elements for which the function `fun` returns a truthy value.
+  Filters `map`, i.e. returns a map containing only those pairs for
+  which `fun` returns a truthy value.
 
   `fun` receives the key and value of each of the
   elements in the map as a `{key, value}` tuple.

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -1014,8 +1014,7 @@ defmodule Map do
   `Map.reject/2` is faster than using `map |> Enum.reject(fun) |> Enum.into(%{})`,
   as no intermediate list is being built.
 
-  See also `filter/2` which discards all elements where the
-  function returns a falsy value.
+  See also `filter/2`.
 
   ## Examples
 

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -1000,6 +1000,7 @@ defmodule Map do
   end
 
   defp do_filter(:none, _fun), do: []
+
   defp do_filter({key, value, iter}, fun) do
     if fun.({key, value}) do
       [{key, value} | do_filter(next(iter), fun)]
@@ -1033,6 +1034,7 @@ defmodule Map do
   end
 
   defp do_reject(:none, _fun), do: []
+
   defp do_reject({key, value, iter}, fun) do
     if fun.({key, value}) do
       do_reject(next(iter), fun)
@@ -1043,10 +1045,13 @@ defmodule Map do
 
   # Inlined version of `:maps.iterator/1`
   defp iterator(map) when is_map(map), do: [0 | map]
-  defp iterator(_other), do: raise BadMapError
+  defp iterator(_other), do: raise(BadMapError)
 
   # Inlined version of `:maps.next/1`
   defp next({key, val, iter}), do: {key, val, iter}
-  defp next([path | map]) when is_integer(path) and is_map(map), do: :erts_internal.map_next(path, map, :iterator)
+
+  defp next([path | map]) when is_integer(path) and is_map(map),
+    do: :erts_internal.map_next(path, map, :iterator)
+
   defp next(:none), do: :none
 end

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -988,11 +988,12 @@ defmodule Map do
 
   ## Examples
 
-      iex> Map.filter(%{one: 1, two: 2, three: 3}, fn x -> rem(x, 2) == 1 end)
+      iex> Map.filter(%{one: 1, two: 2, three: 3}, fn {_key, val} -> rem(val, 2) == 1 end)
       %{one: 1, three: 3}
 
   """
-  @since "1.13.0"
+  @doc since: "1.13.0"
+  @spec filter(map, ({key, value} -> as_boolean(term))) :: map
   def filter(map, fun) when is_map(map) and is_function(fun, 1) do
     iter = iterator(map)
     next = next(iter)
@@ -1022,11 +1023,12 @@ defmodule Map do
 
   ## Examples
 
-      iex> Map.reject(%{one: 1, two: 2, three: 3}, fn x -> rem(x, 2) == 1 end)
+      iex> Map.reject(%{one: 1, two: 2, three: 3}, fn {_key, val} -> rem(val, 2) == 1 end)
       %{two: 2}
 
   """
-  @since "1.13.0"
+  @doc since: "1.13.0"
+  @spec reject(map, ({key, value} -> as_boolean(term))) :: map
   def reject(map, fun) when is_map(map) and is_function(fun, 1) do
     iter = iterator(map)
     next = next(iter)

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -1047,7 +1047,6 @@ defmodule Map do
 
   # Inlined version of `:maps.iterator/1`
   defp iterator(map) when is_map(map), do: [0 | map]
-  defp iterator(_other), do: raise(BadMapError)
 
   # Inlined version of `:maps.next/1`
   defp next({key, val, iter}), do: {key, val, iter}

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -1010,8 +1010,7 @@ defmodule Map do
   end
 
   @doc """
-  Returns map excluding the elements from `map` for which
-  the function `fun` returns a truthy value.
+  Returns map excluding the pairs from `map` for which `fun` returns a truthy value.
   `Map.reject/2` is faster than using `map |> Enum.reject(fun) |> Enum.into(%{})`,
   as no intermediate list is being built.
 

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -1046,7 +1046,7 @@ defmodule Map do
   end
 
   @doc """
-  Maps the function `fun` over all `{key, value}`-elements in `map`, returning a map
+  Maps the function `fun` over all key-value pairs in `map`, returning a map
   with all the values replaced with the result of the function.
 
   ## Examples


### PR DESCRIPTION
PR is based on [this proposal](https://groups.google.com/g/elixir-lang-core/c/oDIt4mKUc6A).


- [x] Implementation of `Map.filter/2` and `Map.reject/2`.
- [x] Implementation of the analogous `Keyword.filter/2` and `Keyword.reject/2`
- [x] `Map.map/2`
- [x] `Keyword.map/2`

### Questions:

- `:maps.filter/2` [supports a map iterator](https://github.com/erlang/otp/blob/master/lib/stdlib/src/maps.erl#L302) as first parameter. As we're not currently exposing map iterators through the `Map` module at all, my assumption is that this support is not required for `Map.filter/2` etc., simplifying the code a little. Is this correct?
- `:maps.filter/2`'s source code has [some error handling/decorating](https://github.com/erlang/otp/blob/master/lib/stdlib/src/maps.erl#L312). I'm not 100% sure how to convert this to Elixir code. Is this already handled by Elixir's own `FunctionClause`-handling where "function clauses that were tried" are printed? We might be able to [remove this line](https://github.com/elixir-lang/elixir/pull/11239/files#diff-17d8120ee6e35ed2a465a5e10985eeb91b64f54b38347daf429cc20d1c85df85R1050) from the implementation, maybe?