### PR TITLE
Formatter plugins

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -142,55 +142,6 @@ defmodule Code.Formatter do
   @do_end_keywords [:rescue, :catch, :else, :after]
 
   @doc """
-  Checks if two strings are equivalent.
-  """
-  def equivalent(string1, string2) when is_binary(string1) and is_binary(string2) do
-    quoted1 = :elixir.string_to_quoted!(to_charlist(string1), 1, 1, "nofile", [])
-    quoted2 = :elixir.string_to_quoted!(to_charlist(string2), 1, 1, "nofile", [])
-
-    case not_equivalent(quoted1, quoted2) do
-      {left, right} -> {:error, left, right}
-      nil -> :ok
-    end
-  end
-
-  defp not_equivalent({:__block__, _, [left]}, right) do
-    not_equivalent(left, right)
-  end
-
-  defp not_equivalent(left, {:__block__, _, [right]}) do
-    not_equivalent(left, right)
-  end
-
-  defp not_equivalent({:__block__, _, []}, nil) do
-    nil
-  end
-
-  defp not_equivalent(nil, {:__block__, _, []}) do
-    nil
-  end
-
-  defp not_equivalent([left | lefties], [right | righties]) do
-    not_equivalent(left, right) || not_equivalent(lefties, righties)
-  end
-
-  defp not_equivalent({left_name, _, left_args}, {right_name, _, right_args}) do
-    not_equivalent(left_name, right_name) || not_equivalent(left_args, right_args)
-  end
-
-  defp not_equivalent({left1, left2}, {right1, right2}) do
-    not_equivalent(left1, right1) || not_equivalent(left2, right2)
-  end
-
-  defp not_equivalent(side, side) do
-    nil
-  end
-
-  defp not_equivalent(left, right) do
-    {left, right}
-  end
-
-  @doc """
   Converts the quoted expression into an algebra document.
   """
   def to_algebra(quoted, opts \\ []) do

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -188,8 +188,8 @@ defmodule Code.Formatter do
         else
           _ ->
             raise ArgumentError,
-                  ":sigils must be a keyword list with uppercased letters as key and an anonymous " <>
-                    "function expecting a single argument as value, got: #{inspect(sigils)}"
+                  ":sigils must be a keyword list with a single uppercased letter as key and an " <>
+                    "anonymous function expecting a single argument as value, got: #{inspect(sigils)}"
         end
       end)
 

--- a/lib/elixir/test/elixir/code_formatter/general_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/general_test.exs
@@ -115,6 +115,70 @@ defmodule Code.Formatter.GeneralTest do
                   """,
                   @short_length
     end
+
+    test "with custom formatting" do
+      bad = """
+      ~W/foo  bar  baz/
+      """
+
+      good = """
+      ~W/foo bar baz/
+      """
+
+      formatter = & &1 |> String.split(~r/ +/) |> Enum.join(" ")
+      assert_format bad, good, sigils: [W: formatter]
+
+      bad = """
+      var = ~W/foo  bar  baz/abc
+      """
+
+      good = """
+      var = ~W/foo bar baz/abc
+      """
+
+      formatter = & &1 |> String.split(~r/ +/) |> Enum.join(" ")
+      assert_format bad, good, sigils: [W: formatter]
+    end
+
+    test "with custom formatting on heredocs" do
+      bad = """
+      ~W'''
+      foo  bar  baz
+      '''
+      """
+
+      good = """
+      ~W'''
+      foo bar baz
+      '''
+      """
+
+      formatter = & &1 |> String.split(~r/ +/) |> Enum.join(" ")
+      assert_format bad, good, sigils: [W: formatter]
+
+      bad = """
+      if true do
+        ~W'''
+        foo
+        bar
+        baz
+        '''abc
+      end
+      """
+
+      good = """
+      if true do
+        ~W'''
+        foo
+        bar
+        baz
+        '''abc
+      end
+      """
+
+      formatter = & &1 |> String.split(~r/ +/) |> Enum.join("\n")
+      assert_format bad, good, sigils: [W: formatter]
+    end
   end
 
   describe "anonymous functions" do

--- a/lib/elixir/test/elixir/code_formatter/general_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/general_test.exs
@@ -125,7 +125,7 @@ defmodule Code.Formatter.GeneralTest do
       ~W/foo bar baz/
       """
 
-      formatter = & &1 |> String.split(~r/ +/) |> Enum.join(" ")
+      formatter = &(&1 |> String.split(~r/ +/) |> Enum.join(" "))
       assert_format bad, good, sigils: [W: formatter]
 
       bad = """
@@ -136,7 +136,7 @@ defmodule Code.Formatter.GeneralTest do
       var = ~W/foo bar baz/abc
       """
 
-      formatter = & &1 |> String.split(~r/ +/) |> Enum.join(" ")
+      formatter = &(&1 |> String.split(~r/ +/) |> Enum.join(" "))
       assert_format bad, good, sigils: [W: formatter]
     end
 
@@ -153,7 +153,7 @@ defmodule Code.Formatter.GeneralTest do
       '''
       """
 
-      formatter = & &1 |> String.split(~r/ +/) |> Enum.join(" ")
+      formatter = &(&1 |> String.split(~r/ +/) |> Enum.join(" "))
       assert_format bad, good, sigils: [W: formatter]
 
       bad = """
@@ -176,7 +176,7 @@ defmodule Code.Formatter.GeneralTest do
       end
       """
 
-      formatter = & &1 |> String.split(~r/ +/) |> Enum.join("\n")
+      formatter = &(&1 |> String.split(~r/ +/) |> Enum.join("\n"))
       assert_format bad, good, sigils: [W: formatter]
     end
   end

--- a/lib/mix/lib/mix/tasks/deps.loadpaths.ex
+++ b/lib/mix/lib/mix/tasks/deps.loadpaths.ex
@@ -35,22 +35,10 @@ defmodule Mix.Tasks.Deps.Loadpaths do
     end
 
     unless "--no-load-deps" in args do
-      load_paths =
-        for dep <- all,
-            path <- Mix.Dep.load_paths(dep) do
-          _ = Code.prepend_path(path)
-          path
-        end
-
-      # If the build is per environment, we should be able to look
-      # at all dependencies and remove the builds that no longer
-      # have a dependency defined for them.
-      #
-      # Note that we require the build_path to be nil. If it is not nil,
-      # it means the build_path is shared so we don't delete entries.
-      unless "--no-deps-check" in args or config[:build_path] != nil or
-               config[:build_per_environment] == false do
-        prune_deps(config, load_paths)
+      for dep <- all,
+          path <- Mix.Dep.load_paths(dep) do
+        _ = Code.prepend_path(path)
+        path
       end
     end
   end
@@ -70,19 +58,6 @@ defmodule Mix.Tasks.Deps.Loadpaths do
           Mix.raise("Invalid Elixir version requirement #{req} in mix.exs file")
       end
     end
-  end
-
-  defp prune_deps(config, load_paths) do
-    config
-    |> Mix.Project.build_path()
-    |> Path.join("lib/*/ebin")
-    |> Path.wildcard()
-    |> List.delete(config[:app] && Mix.Project.compile_path(config))
-    |> Kernel.--(load_paths)
-    |> Enum.each(fn path ->
-      _ = Code.delete_path(path)
-      path |> Path.dirname() |> File.rm_rf!()
-    end)
   end
 
   defp deps_check(all, no_compile?) do

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -58,7 +58,7 @@ defmodule Mix.Tasks.Format do
       reject contributions with unformatted code. If the check fails,
       the formatted contents are not written to disk. Keep in mind
       that the formatted output may differ between Elixir versions as
-      improvements and fixes are applied to the formatter. If `--check-*`
+      improvements and fixes are applied to the formatter.
 
     * `--dry-run` - does not save files after formatting.
 
@@ -94,7 +94,7 @@ defmodule Mix.Tasks.Format do
         @behaviour Mix.Tasks.Format
 
         def features(_opts) do
-          [sigils: [:W], extensions: [".md", ".markdown"]]
+          [sigils: [:M], extensions: [".md", ".markdown"]]
         end
 
         def format(contents, opts) do
@@ -113,7 +113,7 @@ defmodule Mix.Tasks.Format do
       ]
 
   Remember that, when running the formatter with plugins, you must make
-  sure that your dependencies and your application has been been compiled,
+  sure that your dependencies and your application have been compiled,
   so the relevant plugin code can be loaded. Otherwise a warning is logged.
 
   ## Importing dependencies configuration
@@ -167,7 +167,7 @@ defmodule Mix.Tasks.Format do
   @doc """
   Returns which features this plugin should plug into.
   """
-  @callback features() :: [sigils: [atom()], extensions: [binary()]]
+  @callback features(Keyword.t()) :: [sigils: [atom()], extensions: [binary()]]
 
   @doc """
   Receives a string to be formatted with options and returns said string.
@@ -254,7 +254,7 @@ defmodule Mix.Tasks.Format do
     end
 
     if not is_list(plugins) do
-      Mix.raise("Expected :plugins to return a list of directories, got: #{inspect(plugins)}")
+      Mix.raise("Expected :plugins to return a list of modules, got: #{inspect(plugins)}")
     end
 
     if plugins != [] do
@@ -271,7 +271,7 @@ defmodule Mix.Tasks.Format do
 
         not function_exported?(plugin, :features, 1) ->
           Mix.shell().error(
-            "Skipping formatter plugin #{inspect(plugin)} because it does not define features/0"
+            "Skipping formatter plugin #{inspect(plugin)} because it does not define features/1"
           )
 
         true ->

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -270,46 +270,7 @@ defmodule Mix.Tasks.DepsTest do
     end)
   end
 
-  test "compiles and prunes builds per environment" do
-    in_fixture("deps_status", fn ->
-      Mix.Project.push(SuccessfulDepsApp)
-
-      # Start from scratch!
-      File.rm_rf("_build")
-
-      Mix.Tasks.Deps.Compile.run([])
-      Mix.Tasks.Deps.Loadpaths.run([])
-      assert File.exists?("_build/dev/lib/ok/ebin/ok.app")
-      assert File.exists?("_build/dev/lib/ok/priv/sample")
-
-      Mix.Tasks.Compile.run([])
-      assert to_charlist(Path.expand("_build/dev/lib/ok/ebin/")) in :code.get_path()
-      assert File.exists?("_build/dev/lib/sample/ebin/sample.app")
-
-      # Remove the deps but set build_path, deps won't be pruned
-      Mix.ProjectStack.post_config(deps: [], build_path: "_build")
-      Mix.State.clear_cache()
-      Mix.Project.pop()
-      Mix.Project.push(SuccessfulDepsApp)
-
-      Mix.Tasks.Deps.Loadpaths.run([])
-      assert File.exists?("_build/dev/lib/ok/ebin/ok.app")
-      assert File.exists?("_build/dev/lib/sample/ebin/sample.app")
-
-      # Remove the deps without build_path, deps will be pruned
-      Mix.ProjectStack.post_config(deps: [])
-      Mix.State.clear_cache()
-      Mix.Project.pop()
-      Mix.Project.push(SuccessfulDepsApp)
-
-      Mix.Tasks.Deps.Loadpaths.run([])
-      refute to_charlist(Path.expand("_build/dev/lib/ok/ebin/")) in :code.get_path()
-      refute File.exists?("_build/dev/lib/ok/ebin/ok.app")
-      assert File.exists?("_build/dev/lib/sample/ebin/sample.app")
-    end)
-  end
-
-  test "does not load or prune builds with --no-load-deps" do
+  test "does not load deps with --no-load-deps" do
     in_fixture("deps_status", fn ->
       Mix.Project.push(SuccessfulDepsApp)
 

--- a/lib/mix/test/mix/tasks/deps_test.exs
+++ b/lib/mix/test/mix/tasks/deps_test.exs
@@ -286,14 +286,13 @@ defmodule Mix.Tasks.DepsTest do
       assert to_charlist(Path.expand("_build/dev/lib/ok/ebin/")) in :code.get_path()
       assert File.exists?("_build/dev/lib/sample/ebin/sample.app")
 
-      # Remove the deps but set build_path, deps won't be pruned, but load paths are
+      # Remove the deps but set build_path, deps won't be pruned
       Mix.ProjectStack.post_config(deps: [], build_path: "_build")
       Mix.State.clear_cache()
       Mix.Project.pop()
       Mix.Project.push(SuccessfulDepsApp)
 
       Mix.Tasks.Deps.Loadpaths.run([])
-      refute to_charlist(Path.expand("_build/dev/lib/ok/ebin/")) in :code.get_path()
       assert File.exists?("_build/dev/lib/ok/ebin/ok.app")
       assert File.exists?("_build/dev/lib/sample/ebin/sample.app")
 
@@ -304,6 +303,7 @@ defmodule Mix.Tasks.DepsTest do
       Mix.Project.push(SuccessfulDepsApp)
 
       Mix.Tasks.Deps.Loadpaths.run([])
+      refute to_charlist(Path.expand("_build/dev/lib/ok/ebin/")) in :code.get_path()
       refute File.exists?("_build/dev/lib/ok/ebin/ok.app")
       assert File.exists?("_build/dev/lib/sample/ebin/sample.app")
     end)

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -195,6 +195,8 @@ defmodule Mix.Tasks.FormatTest do
   end
 
   defmodule Elixir.SigilWPlugin do
+    @behaviour Mix.Tasks.Format
+
     def features(opts) do
       assert opts[:from_formatter_exs] == :yes
       [sigils: [:W], extensions: ~w(.w)]

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -241,8 +241,9 @@ defmodule Mix.Tasks.FormatTest do
       [inputs: "a.ex", locals_without_parens: [my_fun: 2]]
       """)
 
-      formatter_opts = Mix.Tasks.Format.formatter_opts_for_file("lib/extra/a.ex")
-      assert [my_fun: 2] = Keyword.get(formatter_opts, :locals_without_parens)
+      {formatter, formatter_opts} = Mix.Tasks.Format.formatter_for_file("lib/extra/a.ex")
+      assert Keyword.get(formatter_opts, :locals_without_parens) == [my_fun: 2]
+      assert formatter.("my_fun 1, 2") == "my_fun 1, 2\n"
 
       File.write!("lib/a.ex", """
       my_fun :foo, :bar
@@ -311,7 +312,7 @@ defmodule Mix.Tasks.FormatTest do
       # Let's check that the manifest gets updated if it's stale.
       File.touch!(manifest_path, {{2010, 1, 1}, {0, 0, 0}})
 
-      formatter_opts = Mix.Tasks.Format.formatter_opts_for_file("a.ex")
+      {_, formatter_opts} = Mix.Tasks.Format.formatter_for_file("a.ex")
       assert [my_fun: 2] = Keyword.get(formatter_opts, :locals_without_parens)
 
       Mix.Tasks.Format.run(["a.ex"])
@@ -391,7 +392,7 @@ defmodule Mix.Tasks.FormatTest do
       File.touch!("lib/extra/.formatter.exs", {{2038, 1, 1}, {0, 0, 0}})
       Mix.Tasks.Format.run([])
 
-      formatter_opts = Mix.Tasks.Format.formatter_opts_for_file("lib/extra/a.ex")
+      {_, formatter_opts} = Mix.Tasks.Format.formatter_for_file("lib/extra/a.ex")
       assert [other_fun: 1] = Keyword.get(formatter_opts, :locals_without_parens)
 
       assert File.read!("lib/extra/a.ex") == """


### PR DESCRIPTION
This PR adds formatter plugins which customizes how the formatter behaves.
Plugins must implement the `Mix.Tasks.Format` behaviour. For example, imagine
that your project uses Markdown in two distinct ways: via a custom `~M` sigil and
via files with the `.md` and `.markdown` extensions. A custom plugin would look
like this:

```elixir
    defmodule MixMarkdownFormatter do
      @behaviour Mix.Tasks.Format

      def features(_opts) do
        [sigils: [:M], extensions: [".md", ".markdown"]]
      end

      def format(contents, opts) do
        # logic that formats markdown
      end
    end
```

Now any application can use your formatter as follows:

```elixir
    # .formatters.exs
    [
      # Define the desired plugins
      plugins: [MixMarkdownFormatter],
      # Remember to update the inputs list to include the new extensions
      inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}", "posts/*.{md,markdown}"]
    ]
```

Remember that, when running the formatter with plugins, you must make
sure that your dependencies and your application has been been compiled,
so the relevant plugin code can be loaded. Otherwise a warning is logged.

This can be extremely useful for projects like Phoenix LiveView and Surface,
as they can now directly hook into Elixir's formatter.