### PR TITLE
fix: string.replace with empty string in pattern

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1506,6 +1506,10 @@ defmodule String do
     end
   end
 
+  defp replace_guarded(subject, pattern_list, replacement, options) when is_list(pattern) and "" in pattern do
+    replace_guarded(subject, Enum.filter(pattern, &(&1 == "")), replacement, options)
+  end
+
   defp replace_guarded(subject, pattern, replacement, options) do
     if insert = Keyword.get(options, :insert_replaced) do
       IO.warn(

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1506,7 +1506,7 @@ defmodule String do
     end
   end
 
-  defp replace_guarded(subject, pattern_list, replacement, options) when is_list(pattern) and "" in pattern do
+  defp replace_guarded(subject, pattern, replacement, options) when is_list(pattern) and "" in pattern do
     replace_guarded(subject, Enum.filter(pattern, &(&1 == "")), replacement, options)
   end
 


### PR DESCRIPTION
that is the actual behaviour when have a empty string in a list.
```elixir
iex(30)> String.replace("Elixir", [""], "")
** (ArgumentError) argument error
    (stdlib 3.14.2) :binary.matches("Elixir", [""])
    (elixir 1.11.4) lib/string.ex:1491: String.replace_guarded/4
iex(30)> String.replace("Elixir", ["a", ""], "")
** (ArgumentError) argument error
    (stdlib 3.14.2) :binary.matches("Elixir", ["a", ""])
    (elixir 1.11.4) lib/string.ex:1491: String.replace_guarded/4
```

if the empty string isn't in a list, it doesn't break, so I assume this isn't the expected behavior.
```elixir
iex(30)> String.replace("Elixir", "", "")       
"Elixir"
```