### PR TITLE
Improve error reporting when a custom `inspect_fun` causes `Kernel.inspect/2` to error

### DIFF
--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -354,7 +354,13 @@ defmodule Inspect.Algebra do
             try do
               Process.put(:inspect_trap, true)
 
-              res = Inspect.Map.inspect(struct, %{opts | syntax_colors: []})
+              res =
+                Inspect.Map.inspect(struct, %{
+                  opts
+                  | syntax_colors: [],
+                    inspect_fun: Inspect.Opts.default_inspect_fun()
+                })
+
               res = IO.iodata_to_binary(format(res, :infinity))
 
               message =
@@ -364,7 +370,10 @@ defmodule Inspect.Algebra do
               exception = Inspect.Error.exception(message: message)
 
               if opts.safe do
-                Inspect.inspect(exception, opts)
+                Inspect.inspect(exception, %{
+                  opts
+                  | inspect_fun: Inspect.Opts.default_inspect_fun()
+                })
               else
                 reraise(exception, __STACKTRACE__)
               end

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -685,6 +685,15 @@ defmodule Inspect.OthersTest do
     assert inspect([uri], opts) == "[#URI<https://elixir-lang.org>]"
   end
 
+  test "bad inspect_fun" do
+    msg = "got RuntimeError with message \"Crash!\" while inspecting \"foo\""
+
+    fun = fn _, _ -> raise "Crash!" end
+    opts = [inspect_fun: fun]
+
+    assert inspect("foo", opts) == inspect(%Inspect.Error{message: "#{msg}"})
+  end
+
   defmodule Nested do
     defstruct nested: nil
 


### PR DESCRIPTION
Hey José! I realize that this PR comes out of nowhere, so I want to be clear upfront that I understand that these changes may not be desirable. It resolves some confusing errors I ran into tonight though, so I thought I'd push up my changes to at least start some discussion and hear your thoughts on the matter. Obviously, feel free to close this out if I'm misusing these APIs, or if my fix here isn't ideal.

A colleague and I were experimenting with defining our own protocol to wrap `Inspect`, with the goal of defining context-specific implementations for certain structs or data structures without needing to concern ourselves with whether or not those implementations made sense globally. I'm not sure whether this is an intended use of the protocol, but the presence of `inspect_fun` as an option made it seem like a very natural pattern.

This approach generally worked, but at one point a small typo in one of our implementations led to a very confusing error. Here's a small reproduction of what we were doing:

```elixir
defprotocol MyInspect do
  def inspect(term, opts)
end

defmodule SomeStruct do
  defstruct []
end

defmodule SomeOtherStruct do
  defstruct []
  
  defimpl MyInspect do
    def inspect(term, opts) do 
      MyInspect.inspect(%SomeStruct{}, opts)
    end
  end
end

inspect(%SomeOtherStruct{}, inspect_fun: &MyInspect.inspect/2)
```

When run, this last line fails with the following error:

```elixir
** (Protocol.UndefinedError) protocol MyInspect not implemented for SomeOtherStruct of type Atom
    iex:1: MyInspect.impl_for!/1
    iex:2: MyInspect.inspect/2
    (elixir 1.13.0-dev) lib/inspect.ex:226: Inspect.List.keyword/2
    (elixir 1.13.0-dev) lib/inspect/algebra.ex:470: Inspect.Algebra.container_each/6
    (elixir 1.13.0-dev) lib/inspect/algebra.ex:447: Inspect.Algebra.container_doc/6
    (elixir 1.13.0-dev) lib/inspect/algebra.ex:358: Inspect.Algebra.to_doc/2
    (elixir 1.13.0-dev) lib/kernel.ex:2244: Kernel.inspect/2
```

Clearly this stacktrace obscures the true source of the error, but in our case, because the error was being raised deep within a tree of documents we were building, it wasn't obvious to us what we had done wrong. I did some digging, and was able to trace the problem to this call here: https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/inspect/algebra.ex#L357

The issue is that when the `inspect_fun` raised, the rescue clause would try to inspect the resulting exception using the same `inspect_fun` that was causing issues, and causing the error handler to also crash. In our case, this error is because we haven't implemented the protocol for atoms, and so when we try to inspect the struct as a map, the `:__struct__` field causes the protocol to raise.

My solution here was to reset the `inspect_fun` to the configured default from within this error handler, but I understand if this may not be ideal -- especially if it introduces the risk of undoing any filtering someone may be applying on a non-global basis. That being said, here's what the same error looks like under my changes:

```elixir
iex(1)> inspect(%SomeOtherStruct{}, inspect_fun: &MyInspect.inspect/2)
"%Inspect.Error{message: \"got Protocol.UndefinedError with message \\\"protocol MyInspect not implemented for %SomeStruct{} of type SomeStruct (a struct)\\\" while inspecting %{__struct__: SomeOtherStruct}\"}"

iex(2)> inspect(%SomeOtherStruct{}, inspect_fun: &MyInspect.inspect/2, safe: false)
** (Inspect.Error) got Protocol.UndefinedError with message "protocol MyInspect not implemented for %SomeStruct{} of type SomeStruct (a struct)" while inspecting %{__struct__: SomeOtherStruct}
    iex:1: MyInspect.impl_for!/1
    iex:2: MyInspect.inspect/2
    (elixir 1.13.0-dev) lib/inspect/algebra.ex:342: Inspect.Algebra.to_doc/2
    (elixir 1.13.0-dev) lib/kernel.ex:2244: Kernel.inspect/2
```

In my opinion, this seems like an improvement over what was there before, but I'm not quite sure that this is the right approach, and I'd love to hear any guidance you might have to offer here :)

Similarly, without a custom protocol, the error reporting when the `inspect_fun` errors faced similar issues:

```elixir
iex(1)> inspect(5, inspect_fun: fn _, _ -> raise "Boom!" end)
** (RuntimeError) Boom!
    (stdlib 3.14.2.1) erl_eval.erl:678: :erl_eval.do_apply/6
    (elixir 1.13.0-dev) lib/kernel.ex:2244: Kernel.inspect/2
```

To deal with this, I added the same sort of `Inspect.Error` wrapping that you do in the struct case, while also resetting the value of `inspect_fun` to the default. In this case, however, I left off the logic surrounding `inspect_trap`, because it only seemed to be relevant in the case of a struct being printed. In my testing this assumption seemed to be accurate, but again, I recognize that I may be missing a more elegant approach!

Here's the same failure under my changes:

```elixir
iex(1)>  inspect(5, inspect_fun: fn _, _ -> raise "Boom!" end)
"%Inspect.Error{message: \"got RuntimeError with message \\\"Boom!\\\" while inspecting 5\"}"
```

Lastly, is it important to extend the `safe` option to work for non-structs too, so that the above error could be directly raised, rather than merely inspected?

Regardless of anything else, thanks for your time! I understand this is a very verbose PR, with no discussion leading up to it, so I have no expectations of you getting to it anytime soon :)

I hope you have a nice day!

(Complete aside: but this experiment has me excited about the idea of first-class protocols in Elixir. Is that something you've thought about at all? With a design like `inspect_fun` provides, you can parameterize an API over a protocol, and give applications the opportunity to override any third-party implementations of some base protocol, while still being able to delegate to them as needed.)