### PR TITLE
docs(code): fix `ensure_loaded` typos in `Code` docs

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -38,8 +38,8 @@ defmodule Code do
   are loaded as needed. In embedded mode the opposite happens, as all
   modules need to be loaded upfront or explicitly.
 
-  You can use `ensure_loaded/1` (as well as `ensure_lodead?/1` and
-  `ensure_lodead!/1`) to check if a module is loaded before using it and
+  You can use `ensure_loaded/1` (as well as `ensure_loaded?/1` and
+  `ensure_loaded!/1`) to check if a module is loaded before using it and
   act.
 
   ## `ensure_compiled/1` and `ensure_compiled!/1`


### PR DESCRIPTION
Fixes two documentation typos in the code.ex `@moduledoc`
`ensure_lodead!` => `ensure_loaded!`
`ensure_lodead?` => `ensure_loaded?`

No other changes. I didn't bother testing this either, since I made the edit in Github's web interface. Sorry if this somehow breaks doc tests or is otherwise just not helpful.

P.S.

It looks like this typo was already fixed on master. The commit is 7aabaa7e38dea3b4c1039cd3df2699d452101c1a, if you'd like to cherry-pick that one instead.

The main purpose of this PR is to update the v1.12.x `Code` docs at https://hexdocs.pm/elixir/1.12/Code.html. 
All the specific patch versions there (v1.12.0-v1.12.3) still have these typos. 

I haven't looked into how Hex.pm loads `:elixir` docs for different patch versions, so I'm sorry if this PR is totally misplaced or should be an issue instead! Updating this `v1.12` branch seemed like a decent bet to me, considering the default Hex.pm URL for v1.12.3 is https://hexdocs.pm/elixir/1.12/Code.html. 

Anyways, I mostly wanted to make it easy to fix such a minor thing. I love how polished Elixir's docs generally are and hope that this helps the maintainers a little. Let me know if there's a better way to go about this fix!