### PR TITLE
Add support for `mix xref graph --label=compile-connected --excluded=…`

### DIFF
--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -491,6 +491,13 @@ defmodule Mix.Tasks.XrefTest do
       """)
     end
 
+    test "filter by compile-connected label with exclusions" do
+      assert_graph(~w[--label compile-connected --exclude lib/e.ex], """
+      lib/a.ex
+      `-- lib/b.ex (compile)
+      """)
+    end
+
     test "filter by compile-connected label with fail-above" do
       message = "Too many references (found: 2, permitted: 1)"
 


### PR DESCRIPTION
Currently, excluded paths still count for connections. In the example test, the file `d.ex` is said to be `compile-connected` because it has a single dependency on `e.ex`. If `e.ex` is excluded, I believe that `d.ex` should no longer be considered a compile-connected dependency. This PR fixes that.

Use case:
We `use MyApp` just about everywhere, and `lib/my_app.ex` is known to not refer to anything. I would like to ask for compile-connected dependencies but exclude `lib/my_app.ex`. This way I may call `use MyApp` even in the few files that we use as compile-time dependencies.

Implementation-wise, I am wondering if it wouldn't be cleaner and simpler to filter the whole list of `file_references` once at the beginning. This might entail a bit of unnecessary processing when explicit sources/sinks are provided (because it would go through the whole graph instead of only the subgraph for the given sources/sinks), but otherwise it's not clear if there would be any other issue besides that (probably negligible) performance loss.