### PR TITLE
Ignore `MIX_TEST_PARTITION` when partitions set to 1

### DIFF
--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -152,9 +152,10 @@ defmodule Mix.Tasks.Test do
 
     * `--only` - runs only tests that match the filter
 
-    * `--partitions` - sets the amount of partitions to split tests in. This option
-      requires the `MIX_TEST_PARTITION` environment variable to be set unless amount of
-      partitions is set to `1` when it will be no-op. See the "Operating system process
+    * `--partitions` - sets the amount of partitions to split tests in. It must be
+      a number greater than zero. If set to one, it acts a no-op. If more than one,
+      then you must also set the `MIX_TEST_PARTITION` environment variable with the
+      partition to use in the current test run. See the "Operating system process
       partitioning" section for more information
 
     * `--preload-modules` - preloads all modules defined in applications

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -353,6 +353,38 @@ defmodule Mix.Tasks.TestTest do
         )
       end)
     end
+
+    test "do not raise if partitions flag is set to 1 and no partition given" do
+      in_fixture("test_stale", fn ->
+        assert mix(["test", "--partitions", "1"], []) =~
+                 "2 tests, 0 failures"
+
+        assert mix(["test", "--partitions", "1"], [{"MIX_TEST_PARTITION", ""}]) =~
+                 "2 tests, 0 failures"
+
+        assert mix(["test", "--partitions", "1"], [{"MIX_TEST_PARTITION", "1"}]) =~
+                 "2 tests, 0 failures"
+      end)
+    end
+
+    test "raise if partitions is set to non-positive value" do
+      in_fixture("test_stale", fn ->
+        File.write!("test/test_helper.exs", """
+        Mix.shell(Mix.Shell.Process)
+        ExUnit.start()
+        """)
+
+        assert_run_output(
+          ["--partitions", "0"],
+          "--partitions : expected to be positive integer, got 0"
+        )
+
+        assert_run_output(
+          ["--partitions", "-1"],
+          "--partitions : expected to be positive integer, got -1"
+        )
+      end)
+    end
   end
 
   describe "logs and errors" do


### PR DESCRIPTION
This is meant to make GitLab CI integration with partitions much easier as will allow to use

```shell
MIX_TEST_PARTITION=${CI_NODE_INDEX} mix test --cover --partitions ${CI_NODE_TOTAL}
```

As a test task instead of additionally taking care of case when the parallel testing is disabled.
