### PR TITLE
Adding documentation to the IEx.Info protocol

### DIFF
--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -25,11 +25,14 @@ defprotocol IEx.Info do
   All other sections of information are added (and can be overridden)
   by customized implementations of this function.
 
-  It is recommended to at least include the following sections for a custom implementation:
+  It is recommended to at least include the following sections for a
+  custom implementation:
 
-  - `"Data type"`: Name of the data type. Usually the name of the module defining the data type.
+  - `"Data type"`: Name of the data type. Usually the name of the module
+     defining the data type.
   - `"Description"`: One or a few sentences describing what the data type represents.
-  - `"Reference modules`: One or a few comma-separated module names that focus on working with this datatype.
+  - `"Reference modules`: One or a few comma-separated module names that focus
+    on working with this datatype.
 
   Other recommended sections are:
 
@@ -67,7 +70,7 @@ defimpl IEx.Info, for: Atom do
     description =
       if atom == IEx.dont_display_result() do
         description = """
-        This atom is returned by IEx when a function that should not print itsd
+        This atom is returned by IEx when a function that should not print its
         return value on screen is executed.
         """
 

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -14,10 +14,10 @@ defprotocol IEx.Info do
   @doc """
   Returns information for the given term.
 
-  Information should be returned as a list of `info_name`-`info` pairs,
-
-  `info_name` should be short.
-  It is OK for `info` to contain newlines.
+  Information should be returned as a list of `info_name`-`info` tuples,
+  where `info_name` is a string-like value, such as an atom or a string
+  itself, and `info` is a string. `info_name` should be short. `info` can
+  be arbitrarily long and contain newlines.
 
   `IEx.Helpers.i/1` will generate (and always display)
   the 'Implemented protocols' and 'Term' sections in the result.

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -1,6 +1,42 @@
 defprotocol IEx.Info do
   @fallback_to_any true
 
+  @moduledoc """
+  A protocol to print information in IEx about the given datastructure.
+
+  `IEx.Helpers.i/1` uses this protocol to display a term-specific list
+  of of information.
+
+  By default, an `Any` implementation will be used which returns
+  the `"Data type"`, `"Description"` and `"Reference modules"` sections.
+  """
+
+  @doc """
+  Returns information for the given term.
+
+  Information should be returned as a list of `info_name`-`info` pairs,
+
+  `info_name` should be short.
+  It is OK for `info` to contain newlines.
+
+  `IEx.Helpers.i/1` will generate (and always display)
+  the 'Implemented protocols' and 'Term' sections in the result.
+
+  All other sections of information are added (and can be overridden)
+  by customized implementations of this function.
+
+  It is recommended to at least include the following sections for a custom implementation:
+
+  - `"Data type"`: Name of the data type. Usually the name of the module defining the data type.
+  - `"Description"`: One or a few sentences describing what the data type represents.
+  - `"Reference modules`: One or a few comma-separated module names that focus on working with this datatype.
+
+  Other recommended sections are:
+
+  - `"Raw representation`: showing another way of writing the passed `term`.
+    This is mostly relevant for data-structures whose `String.Chars`-implementations
+    make use of sigils or other syntactic sugar.
+  """
   @spec info(term()) :: [{info_name :: String.Chars.t(), info :: String.t()}]
   def info(term)
 end
@@ -31,7 +67,7 @@ defimpl IEx.Info, for: Atom do
     description =
       if atom == IEx.dont_display_result() do
         description = """
-        This atom is returned by IEx when a function that should not print its
+        This atom is returned by IEx when a function that should not print itsd
         return value on screen is executed.
         """
 

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -28,17 +28,17 @@ defprotocol IEx.Info do
   It is recommended to at least include the following sections for a
   custom implementation:
 
-  - `"Data type"`: Name of the data type. Usually the name of the module
-     defining the data type.
-  - `"Description"`: One or a few sentences describing what the data type represents.
-  - `"Reference modules`: One or a few comma-separated module names that focus
-    on working with this datatype.
+    * `"Data type"`: Name of the data type. Usually the name of the module
+       defining the data type.
+    * `"Description"`: One or a few sentences describing what the data type represents.
+    * `"Reference modules`: One or a few comma-separated module names that focus
+      on working with this datatype.
 
   Other recommended sections are:
 
-  - `"Raw representation`: showing another way of writing the passed `term`.
-    This is mostly relevant for data-structures whose `String.Chars`-implementations
-    make use of sigils or other syntactic sugar.
+    * `"Raw representation`: showing another way of writing the passed `term`.
+      This is mostly relevant for data-structures whose `String.Chars`-implementations
+      make use of sigils or other syntactic sugar.
   """
   @spec info(term()) :: [{info_name :: String.Chars.t(), info :: String.t()}]
   def info(term)


### PR DESCRIPTION
Fixes #11262 

This is my initial stab at adding this documentation.
It's based on my own interpretation of the code of the existing `IEx.Info`-implementations as well as `IEx.Helpers.i/1`.

Please let me know in what ways this documentation can be improved. I expect that parts are too specific, and in other parts important information might be missing.

:slightly_smiling_face: 