### PR TITLE
refactor: tail-call version for flat_map_list

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3909,15 +3909,15 @@ defmodule Enum do
 
   ## flat_map
 
-  defp flat_map_list([head | tail], fun) do
-    case fun.(head) do
-      list when is_list(list) -> list ++ flat_map_list(tail, fun)
-      other -> to_list(other) ++ flat_map_list(tail, fun)
-    end
-  end
+  defp flat_map_list(list, fun, acc \\ [])
 
-  defp flat_map_list([], _fun) do
-    []
+  defp flat_map_list([], _fun, acc), do: acc
+
+  defp flat_map_list([head | tail], fun, acc) do
+    case fun.(head) do
+      list when is_list(list) -> flat_map_list(tail, fun, list ++ acc)
+      other -> flat_map_list(tail, fun, to_list(other) ++ acc)
+    end
   end
 
   ## intersperse


### PR DESCRIPTION
An investigation sparked by https://github.com/elixir-nx/nx/pull/466#discussion_r711895806 led me to find that a tail-call version for the `flat_map_list` Enum module defp ends up being a lot faster (probably due to TCO skipping stack frame allocation, but who knows...)

Results before the refactor:

```elixir
iex(2)> Benchee.run(%{"flatten" => fn -> Enum.map(Enum.to_list(1..100_000), fn x -> List.duplicate(x, 1000) end) |> List.flatten end, "flat_map" => fn -> Enum.flat_map(Enum.to_list(1..100_000), fn x -> List.duplicate(x, 1000) end) end}, memory_time: 10); nil

Name               ips        average  deviation         median         99th %
flat_map         0.136         7.33 s     ±0.00%         7.33 s         7.33 s
flatten          0.131         7.61 s     ±0.00%         7.61 s         7.61 s

Comparison: 
flat_map         0.136
flatten          0.131 - 1.04x slower +0.28 s

Memory usage statistics:

Name        Memory usage
flat_map         3.06 GB
flatten          3.06 GB - 1.00x memory usage +0.00154 GB

**All measurements for memory usage were the same**
```

Results after the refactor:

```elixir
iex(21)> Benchee.run(%{"flatten" => fn -> Enum.map(Enum.to_list(1..100_000), fn x -> List.duplicate(x, 1000) end) |> List.flatten end, "flat_map" => fn -> Enum.flat_map(Enum.to_list(1..100_000), fn x -> List.duplicate(x, 1000) end) end}, memory_time: 10); nil

Name               ips        average  deviation         median         99th %
flat_map          0.39         2.58 s    ±57.12%         2.58 s         3.62 s
flatten          0.135         7.40 s     ±0.00%         7.40 s         7.40 s

Comparison: 
flat_map          0.39
flatten          0.135 - 2.87x slower +4.83 s

Memory usage statistics:

Name        Memory usage
flat_map         3.06 GB
flatten          3.06 GB - 1.00x memory usage +0.00169 GB
```