### PR TITLE
Fix indentation of code example

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4692,15 +4692,15 @@ defmodule Kernel do
   Functions containing many arguments can benefit from using `Keyword`
   lists to group and pass attributes as a single value.
 
-     defmodule MyConfiguration do
-       @default_opts [storage: "local"]
+      defmodule MyConfiguration do
+        @default_opts [storage: "local"]
 
-       def configure(resource, opts \\ []) do
-         opts = Keyword.merge(@default_opts, opts)
-         storage = opts[:storage]
-         # ...
-       end
-     end
+        def configure(resource, opts \\ []) do
+          opts = Keyword.merge(@default_opts, opts)
+          storage = opts[:storage]
+          # ...
+        end
+      end
 
   The difference between using `Map` and `Keyword` to store many
   arguments is `Keyword`'s keys:


### PR DESCRIPTION
This code example has the top and bottom line "outside" the formatted code box:

<img width="839" alt="Screen Shot 2021-09-21 at 22 45 40" src="https://user-images.githubusercontent.com/37021/134245932-24eb897c-2fb6-4fa3-ab24-0af34a241d39.png">

By adding one space of indentation (to 4), the whole code example is formatted as code:

<img width="839" alt="Screen Shot 2021-09-21 at 22 47 31" src="https://user-images.githubusercontent.com/37021/134246069-bc9f9f30-22b5-412e-b53f-7bf42c8ba0cd.png">
