### PR TITLE
Update documentation for `apply/3`

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -305,6 +305,10 @@ defmodule Kernel do
   prefer `module.function(arg_1, arg_2, ..., arg_n)` as it is clearer than
   `apply(module, :function, [arg_1, arg_2, ..., arg_n])`.
 
+  The function to be invoked must be a public function in `module`,
+  `apply/3` cannot be used to invoke private functions, even to call
+  private functions in the same `module` as the call to `apply/3`.
+
   Inlined by the compiler.
 
   ## Examples

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -305,9 +305,7 @@ defmodule Kernel do
   prefer `module.function(arg_1, arg_2, ..., arg_n)` as it is clearer than
   `apply(module, :function, [arg_1, arg_2, ..., arg_n])`.
 
-  The function to be invoked must be a public function in `module`,
-  `apply/3` cannot be used to invoke private functions, even to call
-  private functions in the same `module` as the call to `apply/3`.
+  `apply/3` cannot be used to call private functions.
 
   Inlined by the compiler.
 


### PR DESCRIPTION
This commit documents that `apply/3` can only
be used to call public functions in the target
module.