### PR TITLE
Improve error message on bad Mix aliases

### DIFF
--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -462,6 +462,13 @@ defmodule Mix.Task do
     run_alias(t, alias_args, proj, original_task, res)
   end
 
+  defp run_alias([h | _], _alias_args, _proj, _original_task, _res) do
+    Mix.raise(
+      "Invalid Mix alias format, aliases can be either a string (representing a command) " <>
+        "or a function that takes one argument (a list of alias arguments), got: #{inspect(h)}"
+    )
+  end
+
   defp run_alias([], _alias_args, proj, original_task, res) do
     Mix.TasksServer.put({:task, original_task, proj})
     res

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -464,7 +464,7 @@ defmodule Mix.Task do
 
   defp run_alias([h | _], _alias_args, _proj, _original_task, _res) do
     Mix.raise(
-      "Invalid Mix alias format, aliases can be either a string (representing a command) " <>
+      "Invalid Mix alias format, aliases can be either a string (representing a Mix task with arguments) " <>
         "or a function that takes one argument (a list of alias arguments), got: #{inspect(h)}"
     )
   end

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -464,8 +464,9 @@ defmodule Mix.Task do
 
   defp run_alias([h | _], _alias_args, _proj, _original_task, _res) do
     Mix.raise(
-      "Invalid Mix alias format, aliases can be either a string (representing a Mix task with arguments) " <>
-        "or a function that takes one argument (a list of alias arguments), got: #{inspect(h)}"
+      "Invalid Mix alias format, aliases can be either a string (representing a Mix task " <>
+        "with arguments) or a function that takes one argument (a list of alias arguments), " <>
+        "got: #{inspect(h)}"
     )
   end
 

--- a/lib/mix/test/mix/aliases_test.exs
+++ b/lib/mix/test/mix/aliases_test.exs
@@ -12,7 +12,8 @@ defmodule Mix.AliasesTest do
           compile: "hello",
           cmd: &call_cmd/1,
           help: ["help", "hello"],
-          "nested.h": [&Mix.shell().info(inspect(&1)), "h foo bar"]
+          "nested.h": [&Mix.shell().info(inspect(&1)), "h foo bar"],
+          invalid_alias: [:not_a_string_or_function]
         ]
       ]
     end
@@ -46,6 +47,12 @@ defmodule Mix.AliasesTest do
   test "runs list aliases" do
     assert Mix.Task.run("nested.h", ["baz"]) == "Hello, foo bar baz!"
     assert_received {:mix_shell, :info, ["[]"]}
+  end
+
+  test "fails for invalid aliases" do
+    assert_raise Mix.Error, ~r/Invalid Mix alias format/, fn ->
+      Mix.Task.run("invalid_alias", [])
+    end
   end
 
   test "run alias override" do


### PR DESCRIPTION
Before this commit, we were failing with a `FunctionClauseError` a bit deeper in Mix itself. Now, if you give a bad alias to `:aliases`, we raise a nice and helpful error message.