### PR TITLE
Fix IO.chardata_to_string/1 misleading in exdoc

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -630,6 +630,8 @@ defmodule IO do
 
   """
   @spec chardata_to_string(chardata) :: String.t()
+  def chardata_to_string(chardata)
+
   def chardata_to_string(string) when is_binary(string) do
     string
   end


### PR DESCRIPTION
In https://hexdocs.pm/elixir/1.12/IO.html#chardata_to_string/1, the function signature tells that it accept string:

![Screenshot 2021-09-27 at 20-37-29 IO — Elixir v1 12 3](https://user-images.githubusercontent.com/484530/134919890-9f014ddd-eb3e-4c5d-b93d-6e3d536afbee.png)

It's incorrect because it accept the `chardata` which's string (binary) or list which make confusing when reading the doc. This patch fix by add bodyless clause that accept `chardata` as a first argument.