### PR TITLE
Fix Date.beginning_of_week/2 and Date.end_of_week/2 for none ISO calendars

### DIFF
--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -803,6 +803,7 @@ defmodule Date do
     %Date{calendar: Calendar.ISO, year: year, month: month, day: day}
   end
 
+  @days_per_week 7
   def beginning_of_week(%{calendar: calendar} = date, starting_on) do
     %{year: year, month: month, day: day} = date
 
@@ -811,7 +812,11 @@ defmodule Date do
         %Date{calendar: calendar, year: year, month: month, day: day}
 
       {day_of_week, first_day_of_week, _} ->
-        add(date, -(day_of_week - first_day_of_week))
+        days =
+          first_day_of_week - day_of_week -
+            if day_of_week < first_day_of_week, do: @days_per_week, else: 0
+
+        add(date, days)
     end
   end
 
@@ -866,7 +871,11 @@ defmodule Date do
         %Date{calendar: calendar, year: year, month: month, day: day}
 
       {day_of_week, _, last_day_of_week} ->
-        add(date, last_day_of_week - day_of_week)
+        days =
+          last_day_of_week - day_of_week +
+            if day_of_week > last_day_of_week, do: @days_per_week, else: 0
+
+        add(date, days)
     end
   end
 

--- a/lib/elixir/test/elixir/calendar/date_test.exs
+++ b/lib/elixir/test/elixir/calendar/date_test.exs
@@ -106,6 +106,15 @@ defmodule DateTest do
 
     assert Date.beginning_of_week(Calendar.Holocene.date(2020, 07, 11), :saturday) ==
              Calendar.Holocene.date(2020, 07, 11)
+
+    assert Date.beginning_of_week(FakeCalendar.date(2020, 07, 10)) ==
+             FakeCalendar.date(2020, 07, 04)
+
+    assert Date.beginning_of_week(FakeCalendar.date(2020, 07, 10), :tuesday) ==
+             FakeCalendar.date(2020, 07, 05)
+
+    assert Date.beginning_of_week(FakeCalendar.date(2020, 07, 10), :sunday) ==
+             FakeCalendar.date(2020, 07, 10)
   end
 
   test "end_of_week" do
@@ -120,6 +129,12 @@ defmodule DateTest do
 
     assert Date.end_of_week(Calendar.Holocene.date(2020, 07, 05), :saturday) ==
              Calendar.Holocene.date(2020, 07, 10)
+
+    assert Date.end_of_week(FakeCalendar.date(2020, 07, 04)) ==
+             FakeCalendar.date(2020, 07, 10)
+
+    assert Date.end_of_week(FakeCalendar.date(2020, 07, 09)) ==
+             FakeCalendar.date(2020, 07, 10)
   end
 
   test "convert/2" do

--- a/lib/elixir/test/elixir/calendar/fakes.exs
+++ b/lib/elixir/test/elixir/calendar/fakes.exs
@@ -1,10 +1,24 @@
 defmodule FakeCalendar do
+  def date(year, month, day) do
+    %Date{year: year, month: month, day: day, calendar: __MODULE__}
+  end
+
+  def day_of_week(year, month, day, starting_on) do
+    {day_of_week, _, _} = Calendar.ISO.day_of_week(year, month, day, starting_on)
+    {day_of_week, 6, 5}
+  end
+
   def time_to_string(hour, minute, second, _), do: "#{hour}::#{minute}::#{second}"
   def date_to_string(year, month, day), do: "#{day}/#{month}/#{year}"
 
   def naive_datetime_to_string(year, month, day, hour, minute, second, microsecond) do
     date_to_string(year, month, day) <> "F" <> time_to_string(hour, minute, second, microsecond)
   end
+
+  defdelegate naive_datetime_to_iso_days(year, month, day, hour, minute, second, microsecond),
+    to: Calendar.ISO
+
+  defdelegate naive_datetime_from_iso_days(iso_days), to: Calendar.ISO
 
   def datetime_to_string(
         year,


### PR DESCRIPTION
I have played with @kipcole9 [Cldr.Calendar.Coptic](https://hex.pm/packages/ex_cldr_calendars_coptic) and got the following results:
```elixir
iex(1)> date = Date.new!(2020, 07, 05, Cldr.Calendar.Coptic)
~D[2020-07-05 Cldr.Calendar.Coptic]
iex(2)> Date.beginning_of_week(date)
~D[2020-07-07 Cldr.Calendar.Coptic]
iex(3)> date = Date.new!(2020, 07, 14, Cldr.Calendar.Coptic)
~D[2020-07-14 Cldr.Calendar.Coptic]
iex(4)> Date.end_of_week(date)
~D[2020-07-13 Cldr.Calendar.Coptic]
```
Maybe this PR can fix this. In this fix, I assume that each calendar had 7 weekdays. I am not sure if this assumption is correct.