### PR TITLE
:bug: add root path to parallel compilation

### DIFF
--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -92,7 +92,7 @@ defmodule Kernel.ParallelCompiler do
   """
   @doc since: "1.6.0"
   def compile(files, options \\ []) when is_list(options) do
-    spawn_workers(files, :compile, find_compilation_root, options)
+    spawn_workers(files, :compile, find_compilation_root(), options)
   end
 
   @doc """
@@ -102,7 +102,7 @@ defmodule Kernel.ParallelCompiler do
   """
   @doc since: "1.6.0"
   def compile_to_path(files, path, options \\ []) when is_binary(path) and is_list(options) do
-    spawn_workers(files, {:compile, path}, find_compilation_root, options)
+    spawn_workers(files, {:compile, path}, find_compilation_root(), options)
   end
 
   @doc """
@@ -127,13 +127,13 @@ defmodule Kernel.ParallelCompiler do
   """
   @doc since: "1.6.0"
   def require(files, options \\ []) when is_list(options) do
-    spawn_workers(files, :require, find_compilation_root, options)
+    spawn_workers(files, :require, find_compilation_root(), options)
   end
 
   @doc false
   @deprecated "Use Kernel.ParallelCompiler.compile/2 instead"
   def files(files, options \\ []) when is_list(options) do
-    case spawn_workers(files, :compile, find_compilation_root, options) do
+    case spawn_workers(files, :compile, find_compilation_root(), options) do
       {:ok, modules, _} -> modules
       {:error, _, _} -> exit({:shutdown, 1})
     end
@@ -142,7 +142,7 @@ defmodule Kernel.ParallelCompiler do
   @doc false
   @deprecated "Use Kernel.ParallelCompiler.compile_to_path/2 instead"
   def files_to_path(files, path, options \\ []) when is_binary(path) and is_list(options) do
-    case spawn_workers(files, {:compile, path}, find_compilation_root, options) do
+    case spawn_workers(files, {:compile, path}, find_compilation_root(), options) do
       {:ok, modules, _} -> modules
       {:error, _, _} -> exit({:shutdown, 1})
     end


### PR DESCRIPTION
Before going into the specifics, I'd like to preface this PR by saying that I am very new to elixir, and this is the first time I've actually delved into the source code. This fix has come about from an attempt to fix a reoccurring issue at my workplace. I've managed to identify the point of failure, and fix it locally, but I'm not sure whether it's an acceptable solution in the broader context, so I would appreciate feedback, and am more than happy to make changes.
## Issue
This issue manifests as the following error log when compiling:
```
== Compilation error in file lib/app_web/channels/helpers/some_helper.ex ==
** (MatchError) no match of right hand side value: {:error, :enoent}
```
The error only happens occasionally, although recently we've seen an uptick in the number of cases and retries we have to do before it will pass.
I believe this issue has been occurring for users:
https://elixirforum.com/t/parallel-compiler-cannot-find-files-sometimes/12363/5

## Cause
On investigation, it seems like the issue is down to a race condition during compilation, where parrallel workers may be changing the `cwd`, [which causes this invocation](https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/kernel/parallel_compiler.ex#L316) of `Path.expand()` to expand to a strange directory. 
Below is a single snippet of an examples with extra logging while compiling my work project. To achieve this I have used the library `:meck` to intercept any calls to the erlang `:file` module and log `DIRECTORY CHANGED:` before passing through to the original function, and I've added logging around the `Path.expand()` invocation to produce the `expanded file:` logs.

```
"DIRECTORY CHANGED: /Users/punchcafe/my_project/deps/yamerl"
"DIRECTORY CHANGED: ."
"expanded file: \"/Users/punchcafe/my_project/deps/yamerl/lib/my_project_web/channels/helpers/my_project_helper.ex"
... 13 more DIRECTORY CHANGED omitted for brevity
"DIRECTORY CHANGED: /Users/punchcafe/my_project"

== Compilation error in file lib/my_project_web/channels/helpers/my_project_helper.ex ==
** (MatchError) no match of right hand side value: {:error, :enoent}
```
As the logging shows, a directory change has caused the expanded file to now be expanded from the deps/yamerl dependency. Exact file names have been changed for security. There's a temptation to think that this may be a special case due to `"DIRECTORY CHANGED: ."`, but there are a number of other examples which show it to be unrelated.

## Proposed Solution
The simplest solution I could think of without delving into the deeper mechanics and possible race conditions of the parallel compiler is to simply have a fixed root constant path each Path expands from, so there's no longer a dependency on cwd. I have chosen to get this by expanding an empty path at the very start of compilation, and passing it through all subsequent compiles. I image there is a better way to get this so any suggestions are very welcome.

Since this problem is probabilistic, It's hard to say with a degree of exact certainty, but using this build of elixir to compile my project, it failed 0 out of 15 attempts, in contrast to the current build which fails around 40-60% of the time.