### PR TITLE
Correct return type in Regex.scan/3 function spec

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -456,7 +456,7 @@ defmodule Regex do
       [[{0, 1}], [{9, 3}]]
 
   """
-  @spec scan(t, String.t(), [term]) :: [[String.t()]]
+  @spec scan(t(), String.t(), [term()]) :: [[String.t()]] | [[{integer(), integer()}]]
   def scan(regex, string, options \\ [])
 
   def scan(%Regex{} = regex, string, options) when is_binary(string) do


### PR DESCRIPTION
This funtion can return a list of tuples containing two integers when
the `return: :index` option is provided.