### PR TITLE
Change Calendar.year_of_era/1 callback to /3

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -189,7 +189,7 @@ defmodule Calendar do
   @doc """
   Calculates the year and era from the given `year`.
   """
-  @callback year_of_era(year) :: {year, era}
+  @callback year_of_era(year, month, day) :: {year, era}
 
   @doc """
   Calculates the day and era from the given `year`, `month`, and `day`.

--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -943,8 +943,8 @@ defmodule Date do
   @spec year_of_era(Calendar.date()) :: {Calendar.year(), non_neg_integer()}
   def year_of_era(date)
 
-  def year_of_era(%{calendar: calendar, year: year}) do
-    calendar.year_of_era(year)
+  def year_of_era(%{calendar: calendar, year: year, month: month, day: day}) do
+    calendar.year_of_era(year, month, day)
   end
 
   @doc """

--- a/lib/elixir/lib/calendar/iso.ex
+++ b/lib/elixir/lib/calendar/iso.ex
@@ -965,7 +965,8 @@ defmodule Calendar.ISO do
   end
 
   @doc """
-  Calculates the year and era from the given `year`.
+  Calculates the year and era from the given `year`
+  `month` and `day`.
 
   The ISO calendar has two eras: the "current era" (CE) which
   starts in year `1` and is defined as era `1`. And "before the current
@@ -973,24 +974,26 @@ defmodule Calendar.ISO do
 
   ## Examples
 
-      iex> Calendar.ISO.year_of_era(1)
+      iex> Calendar.ISO.year_of_era(1, 1, 1)
       {1, 1}
-      iex> Calendar.ISO.year_of_era(2018)
+      iex> Calendar.ISO.year_of_era(2018, 12, 1)
       {2018, 1}
-      iex> Calendar.ISO.year_of_era(0)
+      iex> Calendar.ISO.year_of_era(0, 1, 1)
       {1, 0}
-      iex> Calendar.ISO.year_of_era(-1)
+      iex> Calendar.ISO.year_of_era(-1, 12, 1)
       {2, 0}
 
   """
   @doc since: "1.8.0"
-  @spec year_of_era(year) :: {1..10000, era}
+  @spec year_of_era(year, month, day) :: {1..10000, era}
   @impl true
-  def year_of_era(year) when is_year_CE(year) do
+  def year_of_era(year, month \\ 1, day \\ 1)
+
+  def year_of_era(year, _month, _day) when is_year_CE(year) do
     {year, 1}
   end
 
-  def year_of_era(year) when is_year_BCE(year) do
+  def year_of_era(year, _month, _day) when is_year_BCE(year) do
     {abs(year) + 1, 0}
   end
 

--- a/lib/elixir/test/elixir/calendar/holocene.exs
+++ b/lib/elixir/test/elixir/calendar/holocene.exs
@@ -141,7 +141,7 @@ defmodule Calendar.Holocene do
   defdelegate quarter_of_year(year, month, day), to: Calendar.ISO
 
   @impl true
-  defdelegate year_of_era(year), to: Calendar.ISO
+  defdelegate year_of_era(year, month, day), to: Calendar.ISO
 
   @impl true
   defdelegate day_of_era(year, month, day), to: Calendar.ISO

--- a/lib/elixir/test/elixir/calendar/iso_test.exs
+++ b/lib/elixir/test/elixir/calendar/iso_test.exs
@@ -98,22 +98,29 @@ defmodule Calendar.ISOTest do
     end
   end
 
-  test "year_of_era/1" do
+  test "year_of_era/3" do
+    # Compatibility tests for year_of_era/1
     assert Calendar.ISO.year_of_era(-9999) == {10000, 0}
     assert Calendar.ISO.year_of_era(-1) == {2, 0}
     assert Calendar.ISO.year_of_era(0) == {1, 0}
     assert Calendar.ISO.year_of_era(1) == {1, 1}
     assert Calendar.ISO.year_of_era(1984) == {1984, 1}
 
+    assert Calendar.ISO.year_of_era(-9999, 1, 1) == {10000, 0}
+    assert Calendar.ISO.year_of_era(-1, 1, 1) == {2, 0}
+    assert Calendar.ISO.year_of_era(0, 12, 1) == {1, 0}
+    assert Calendar.ISO.year_of_era(1, 12, 1) == {1, 1}
+    assert Calendar.ISO.year_of_era(1984, 12, 1) == {1984, 1}
+
     random_positive_year = Enum.random(1..9999)
-    assert Calendar.ISO.year_of_era(random_positive_year) == {random_positive_year, 1}
+    assert Calendar.ISO.year_of_era(random_positive_year, 1, 1) == {random_positive_year, 1}
 
     assert_raise FunctionClauseError, fn ->
-      Calendar.ISO.year_of_era(10000)
+      Calendar.ISO.year_of_era(10000, 1, 1)
     end
 
     assert_raise FunctionClauseError, fn ->
-      Calendar.ISO.year_of_era(-10000)
+      Calendar.ISO.year_of_era(-10000, 12, 1)
     end
   end
 


### PR DESCRIPTION
### Change Calendar.year_of_era/1 callback to /3
In order to support calendars which can change
era any time during the calendar year, the callback
Calendar.year_of_era/1 is changed to Calendar.year_of_era/3.

Since Calendar.ISO.year_of_era/1 is a public function,
default arguments for month and day are set if
year_of_era/1 is called to allow compatibility with
any existing code that relies upon this function.