### PR TITLE
Adding a snippet to the docs of `defoverridable/1`

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1,4 +1,4 @@
- elixir_bootstrap module to be able to bootstrap Kernel.
+# Use elixir_bootstrap module to be able to bootstrap Kernel.
 # The bootstrap module provides simpler implementations of the
 # functions removed, simple enough to bootstrap.
 import Kernel,

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5187,9 +5187,9 @@ defmodule Kernel do
   An overridable function is lazily defined, allowing a developer to override
   it.
 
-  It is possible for the overridden function to have a different visibility
-  than the original function: A public function can be overridden by a
-  private function and vice-versa.
+  It is possible for the overridden definition to have a different visibility
+  than the original: a public function can be overridden by a private
+  function and vice-versa.
 
   Macros cannot be overridden as functions and vice-versa.
 

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5182,7 +5182,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Makes the given functions in the current module overridable.
+  Makes the given definitions in the current module overridable.
 
   An overridable function is lazily defined, allowing a developer to override
   it.

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -5184,8 +5184,9 @@ defmodule Kernel do
   @doc """
   Makes the given definitions in the current module overridable.
 
-  An overridable function is lazily defined, allowing a developer to override
-  it.
+  If the user defines a new function or macro with the same name
+  and arity, then the overridable ones are discarded. Otherwise, the
+  original definitions are used.
 
   It is possible for the overridden definition to have a different visibility
   than the original: a public function can be overridden by a private

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1,4 +1,4 @@
-# Use elixir_bootstrap module to be able to bootstrap Kernel.
+ elixir_bootstrap module to be able to bootstrap Kernel.
 # The bootstrap module provides simpler implementations of the
 # functions removed, simple enough to bootstrap.
 import Kernel,
@@ -5186,6 +5186,10 @@ defmodule Kernel do
 
   An overridable function is lazily defined, allowing a developer to override
   it.
+
+  It is possible for the overridden function to have a different visibility
+  than the original function: A public function can be overridden by a
+  private function and vice-versa.
 
   Macros cannot be overridden as functions and vice-versa.
 


### PR DESCRIPTION
Adding a paragraph to the docs of `Kernel.defoverridable/1` noting that changing the visibility of the function is allowed.


Fixes #11292