### PR TITLE
add optional recursiveness to Map.from_struct method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ With these improvements, it has become simpler to understand the impact code rec
 
 ## Code fragments
 
-The `Code` module also got a companion module called `Code.Fragment`, which hosts functions that work on incomplete code, as is often the scenario in editors, command line, etc. The module contains different heuristics to analyze the source code and return context informational.
+The `Code` module got a companion module called `Code.Fragment`, which hosts functions that work on incomplete code, as is often the scenario in editors, interactive shells, etc. The module contains different heuristics to analyze the source code and return context informational.
 
 Thanks to these improvements, `IEx`' autocomplete got several quality of life improvements, such as the autocompletion of sigils, structs, and paths. For example, typing `~<TAB>` now shows:
 
@@ -100,7 +100,7 @@ Now any application can use your formatter as follows:
 ]
 ```
 
-Finally, the `Code` has also been augmented with two functions: `Code.string_to_quoted_with_comments/2` and `Code.quoted_to_algebra/2`. Those functions allow someone to retrieve the Elixir AST with their original source code comments, and then convert this AST to formatted code. In other words, those functions provide a wrapper around the Elixir Code Formatter, supporting developers who wish to create tools that directly manipulate and custom format Elixir source code.
+Finally, the `Code` module has also been augmented with two functions: `Code.string_to_quoted_with_comments/2` and `Code.quoted_to_algebra/2`. Those functions allow someone to retrieve the Elixir AST with their original source code comments, and then convert this AST to formatted code. In other words, those functions provide a wrapper around the Elixir Code Formatter, supporting developers who wish to create tools that directly manipulate and custom format Elixir source code.
 
 ## v1.13.0-dev
 
@@ -112,6 +112,7 @@ Finally, the `Code` has also been augmented with two functions: `Code.string_to_
 
 #### Elixir
 
+  * [Calendar] Add `c:Calendar.year_of_era/3` to support calendars where the beginning of a new era does not align with the beginning of a new year
   * [CLI] Support `--short-version` on the CLI that does not boot the VM
   * [Code] Add `Code.string_to_quoted_with_comments/2` and `Code.quoted_to_algebra/2`
   * [Code] Add more `:token_metadata` to aliases and remote calls when parsing strings
@@ -122,6 +123,7 @@ Finally, the `Code` has also been augmented with two functions: `Code.string_to_
   * [Exception] Better format Elixir exceptions in Erlang
   * [Inspect] Allow default inspect fun to be set globally with `Inspect.Opts.default_inspect_fun/1`
   * [IO] Allow `:eof` to be given as limit to `IO.getn/2`
+  * [Kernel] Support the `:sigils` option in `import Mod, only: :sigils` and allow the sigil modifiers to be also digits
   * [Kernel] Make `get_in` consistently abort when `nil` values are found
   * [Kernel] Improve compilation times by reducing the amount of copies of the AST across compiler processes
   * [Kernel] Raise if trying to define a module with a slash in its name
@@ -138,6 +140,8 @@ Finally, the `Code` has also been augmented with two functions: `Code.string_to_
   * [OptionParser] Add "did you mean?" suggestions to `OptionParser.ParseError` messages
   * [Record] Add record reflection via `@__records__`
   * [Task] Add `Task.completed/1`
+  * [Task] Add `Task.ignore/1` to keep a task running but ignoring all of its results
+  * [Task] Reduce the amount of copying `Task.async*` functions
 
 #### ExUnit
 
@@ -175,6 +179,7 @@ Finally, the `Code` has also been augmented with two functions: `Code.string_to_
   * [mix test] Allow the exit status of ExUnit to be configured and set the default to 2
   * [mix test] Exit with a status of 3 when coverage falls below threshold
   * [mix test] Write failed manifest when suite fails due to --warnings-as-errors
+  * [mix test] Ignore `MIX_TEST_PARTITION` when partitions set to 1
   * [mix xref] Support multiple sinks and sources in `mix xref graph`
   * [mix xref] Add `trace` subcommand to print compilation dependencies between files
   * [mix xref] Add `--fail-above` option to `mix xref`
@@ -199,17 +204,19 @@ Finally, the `Code` has also been augmented with two functions: `Code.string_to_
   * [Kernel] Correctly parse the atom `.` as a keyword list key
   * [Kernel] Do not leak variables from the first generator in `with` and `for` special forms
   * [Kernel] Fix column number on strings with NFD characters
+  * [Kernel] Fix a bug where a combination of dynamic line in `quote` with `unquote` of remote calls would emit invalid AST metadata
   * [OptionParser] Validate switch types/modifiers early on to give more precise feedback
   * [Protocol] Add `defdelegate` to the list of unallowed macros inside protocols as protocols do not allow function definitions
   * [Protocol] Warn if `@callback`, `@macrocallback` and `@optional_callbacks` are defined inside protocol
   * [Protocol] Ensure protocol metadata is deterministic on consolidation
+  * [Range] Always show step when range is descending
   * [URI] Only percent decode if followed by hex digits (according to https://url.spec.whatwg.org/#percent-decode)
   * [Version] Ensure proper precedence of `and`/`or` in version requirements
 
 #### ExUnit
 
-  * [ExUnit] Invalidate a module's tests in `ExUnit.run/0` results if that module's `setup_all` fails
-  * [ExUnit] Fix count in formatter if a module's `setup_all` fails
+  * [ExUnit] Fix formatter and counters from `ExUnit.run/0` to consider all tests in a module whenever if a module's `setup_all` fails
+  * [ExUnit] Allow doctests newlines to be terminated by CRLF
 
 #### IEx
 

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -21,7 +21,10 @@ defmodule KeywordTest do
   end
 
   test "implements (almost) all functions in Map" do
-    assert Map.__info__(:functions) -- Keyword.__info__(:functions) == [from_struct: 1]
+    assert Map.__info__(:functions) -- Keyword.__info__(:functions) == [
+             from_struct: 1,
+             from_struct: 2
+           ]
   end
 
   test "get_and_update/3 raises on bad return value from the argument function" do

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -215,6 +215,50 @@ defmodule MapTest do
     end
   end
 
+  test "from_struct/1" do
+    struct = %{__struct__: TestStruct, a: 1, b: 2}
+    assert Map.from_struct(struct) == %{a: 1, b: 2}
+  end
+
+  test "from_struct/2" do
+    struct = %{__struct__: TestStruct, a: 1, b: 2}
+    assert Map.from_struct(struct, false) == %{a: 1, b: 2}
+
+    struct = %{__struct__: TestStruct, a: 1, b: 2}
+    assert Map.from_struct(struct, true) == %{a: 1, b: 2}
+
+    struct = %{
+      __struct__: TestStruct,
+      a: 1,
+      b: 2,
+      c: %{__struct__: TestStruct2, d: 3},
+      d: [],
+      e: nil,
+      f: "test"
+    }
+
+    assert Map.from_struct(struct, false) == %{
+             a: 1,
+             b: 2,
+             c: %{__struct__: TestStruct2, d: 3},
+             d: [],
+             e: nil,
+             f: "test"
+           }
+
+    struct = %{
+      __struct__: TestStruct,
+      a: 1,
+      b: 2,
+      c: %{__struct__: TestStruct2, d: 3},
+      d: [],
+      e: nil,
+      f: "test"
+    }
+
+    assert Map.from_struct(struct, true) == %{a: 1, b: 2, c: %{d: 3}, d: [], e: nil, f: "test"}
+  end
+
   test "implements (almost) all functions in Keyword" do
     assert Keyword.__info__(:functions) -- Map.__info__(:functions) == [
              delete: 3,

--- a/lib/ex_unit/test/ex_unit/doc_test_test.exs
+++ b/lib/ex_unit/test/ex_unit/doc_test_test.exs
@@ -82,10 +82,11 @@ defmodule ExUnit.DocTestTest.GoodModule do
   def inspect2_test, do: :ok
 
   @doc """
-  iex> x = Enum.into([:a, :b, :c], MapSet.new())
-  ...> x
-  #MapSet<[:a, :b, :c]>
-  """ |> String.replace("\n", "\r\n")
+       iex> x = Enum.into([:a, :b, :c], MapSet.new())
+       ...> x
+       #MapSet<[:a, :b, :c]>
+       """
+       |> String.replace("\n", "\r\n")
   def crlf_test, do: :ok
 end
 |> ExUnit.BeamHelpers.write_beam()
@@ -552,7 +553,7 @@ defmodule ExUnit.DocTestTest do
                 left:  2
                 right: 3
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line+3}: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 3}: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
@@ -569,7 +570,7 @@ defmodule ExUnit.DocTestTest do
                 left:  "This is a slightly shorter text string."
                 right: "This is a much shorter text string."
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line+6}: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 6}: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
@@ -583,7 +584,7 @@ defmodule ExUnit.DocTestTest do
                 left:  ":oops"
                 right: "#MapSet<[]>"
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line+12}: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 12}: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
@@ -592,7 +593,7 @@ defmodule ExUnit.DocTestTest do
                 ** (UndefinedFunctionError) function Hello.world/0 is undefined (module Hello is not available)
                 stacktrace:
                   Hello.world()
-                  (for doctest at) test/ex_unit/doc_test_test.exs:#{starting_line+15}: (test)
+                  (for doctest at) test/ex_unit/doc_test_test.exs:#{starting_line + 15}: (test)
            """
 
     assert output =~ """
@@ -603,7 +604,7 @@ defmodule ExUnit.DocTestTest do
                   iex> raise "oops"
                   ** (WhatIsThis) "oops"
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line+18}: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 18}: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
@@ -618,54 +619,54 @@ defmodule ExUnit.DocTestTest do
                   iex> raise "oops"
                   ** (RuntimeError) "hello"
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line+21}: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 21}: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
              8) doctest ExUnit.DocTestTest.Invalid.a/0 (8) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:#{starting_line+27}:6: syntax error before: '*'
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:#{starting_line + 27}:6: syntax error before: '*'
                 doctest:
                   iex> 1 + * 1
                   1
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line+27}: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 27}: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
              9) doctest ExUnit.DocTestTest.Invalid.dedented_past_fence/0 (9) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:#{starting_line+57}:5: unexpected token: "`" (column 5, code point U+0060)
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:#{starting_line + 57}:5: unexpected token: "`" (column 5, code point U+0060)
                 doctest:
                   iex> 1 + 2
                   3
                       ```
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line+56}: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 56}: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
             10) doctest ExUnit.DocTestTest.Invalid.indented_not_enough/0 (10) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:#{starting_line+41}:1: unexpected token: "`" (column 1, code point U+0060)
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:#{starting_line + 41}:1: unexpected token: "`" (column 1, code point U+0060)
                 doctest:
                   iex> 1 + 2
                   3
                   `
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line+40}: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 40}: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
             11) doctest ExUnit.DocTestTest.Invalid.indented_too_much/0 (11) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:#{starting_line+49}:3: unexpected token: "`" (column 3, code point U+0060)
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:#{starting_line + 49}:3: unexpected token: "`" (column 3, code point U+0060)
                 doctest:
                   iex> 1 + 2
                   3
                     ```
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line+48}: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 48}: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
@@ -673,44 +674,46 @@ defmodule ExUnit.DocTestTest do
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
                 Doctest did not compile, got: (UnicodeConversionError) invalid encoding starting at <<255, 34, 41>>
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line+63}: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 63}: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
             13) doctest ExUnit.DocTestTest.Invalid.misplaced_opaque_type/0 (13) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (TokenMissingError) test/ex_unit/doc_test_test.exs:#{starting_line+69}:7: missing terminator: } (for "{" starting at line #{starting_line+69}). If you are planning to assert on the result of an iex> expression which contains a value inspected as #Name<...>, please make sure the inspected value is placed at the beginning of the expression; otherwise Elixir will treat it as a comment due to the leading sign #.
+                Doctest did not compile, got: (TokenMissingError) test/ex_unit/doc_test_test.exs:#{starting_line + 69}:7: missing terminator: } (for "{" starting at line #{starting_line + 69}). If you are planning to assert on the result of an iex> expression which contains a value inspected as #Name<...>, please make sure the inspected value is placed at the beginning of the expression; otherwise Elixir will treat it as a comment due to the leading sign #.
                 doctest:
                   iex> {:ok, MapSet.new([1, 2, 3])}
                   {:ok, #MapSet<[1, 2, 3]>}
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line+69}: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 69}: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ "14) doctest ExUnit.DocTestTest.Invalid.raising_inspect/0"
     assert output =~ "iex> ExUnit.DocTestTest.Haiku.new(:this, :is, {:not, :a, :haiku})"
-    assert output =~ "test/ex_unit/doc_test_test.exs:#{starting_line+82}: ExUnit.DocTestTest.Invalid (module)"
+
+    assert output =~
+             "test/ex_unit/doc_test_test.exs:#{starting_line + 82}: ExUnit.DocTestTest.Invalid (module)"
 
     assert output =~ """
             15) doctest ExUnit.DocTestTest.Invalid.b/0 (15) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:#{starting_line+33}:6: syntax error before: '*'
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:#{starting_line + 33}:6: syntax error before: '*'
                 doctest:
                   iex> 1 + * 1
                   1
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line+33}: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 33}: ExUnit.DocTestTest.Invalid (module)
            """
 
     assert output =~ """
             16) doctest ExUnit.DocTestTest.Invalid.t/0 (16) (ExUnit.DocTestTest.ActuallyCompiled)
                 test/ex_unit/doc_test_test.exs:#{doctest_line}
-                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:#{starting_line+75}:6: syntax error before: '*'
+                Doctest did not compile, got: (SyntaxError) test/ex_unit/doc_test_test.exs:#{starting_line + 75}:6: syntax error before: '*'
                 doctest:
                   iex> 1 + * 1
                   1
                 stacktrace:
-                  test/ex_unit/doc_test_test.exs:#{starting_line+75}: ExUnit.DocTestTest.Invalid (module)
+                  test/ex_unit/doc_test_test.exs:#{starting_line + 75}: ExUnit.DocTestTest.Invalid (module)
            """
   end
 


### PR DESCRIPTION
I've encountered this specific issue with struct to map conversion (described for example [here](https://elixirforum.com/t/convert-a-nested-struct-into-a-nested-map/23814/10) or [here](https://groups.google.com/g/elixir-lang-talk/c/ABpynrektMw?pli=1)) so many times in my daily work that I decided to prepare a proposal of enhancement of method `Map.from_struct/1`.

The main idea is to allow people to recursively convert structs with nested structs to maps with nested maps.

```
user = %User{
  id: 1,
  first_name: "John",
  last_name: "Doe",
  contact_details: %User.ContactDetails{
    phone_number: "19998887777",
    email: "john.doe@example.com"
  },
  permissions: [
    %Permision{
       level: :super_admin
    }
  ]
}

result = Map.from_struct(user, true)

IO.inspect(result)
%{
  id: 1,
  first_name: "John",
  last_name: "Doe",
  contact_details: %{
    phone_number: "19998887777",
    email: "john.doe@example.com"
  }
  permissions: [
    %{
       id: 1,
       level: :super_admin
    }
  ]
}
```

I'd agree that this kind of conversion is much more expensive than the previous one, but I do believe that having a method that converts only a top-level struct is also very misleading. Let's give people at least a bult-in solution after they realize how standard version works :)

WDYT?