### PR TITLE
add optional recursiveness to Map.from_struct method

### DIFF
--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -21,7 +21,10 @@ defmodule KeywordTest do
   end
 
   test "implements (almost) all functions in Map" do
-    assert Map.__info__(:functions) -- Keyword.__info__(:functions) == [from_struct: 1]
+    assert Map.__info__(:functions) -- Keyword.__info__(:functions) == [
+             from_struct: 1,
+             from_struct: 2
+           ]
   end
 
   test "get_and_update/3 raises on bad return value from the argument function" do

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -215,6 +215,50 @@ defmodule MapTest do
     end
   end
 
+  test "from_struct/1" do
+    struct = %{__struct__: TestStruct, a: 1, b: 2}
+    assert Map.from_struct(struct) == %{a: 1, b: 2}
+  end
+
+  test "from_struct/2" do
+    struct = %{__struct__: TestStruct, a: 1, b: 2}
+    assert Map.from_struct(struct, false) == %{a: 1, b: 2}
+
+    struct = %{__struct__: TestStruct, a: 1, b: 2}
+    assert Map.from_struct(struct, true) == %{a: 1, b: 2}
+
+    struct = %{
+      __struct__: TestStruct,
+      a: 1,
+      b: 2,
+      c: %{__struct__: TestStruct2, d: 3},
+      d: [],
+      e: nil,
+      f: "test"
+    }
+
+    assert Map.from_struct(struct, false) == %{
+             a: 1,
+             b: 2,
+             c: %{__struct__: TestStruct2, d: 3},
+             d: [],
+             e: nil,
+             f: "test"
+           }
+
+    struct = %{
+      __struct__: TestStruct,
+      a: 1,
+      b: 2,
+      c: %{__struct__: TestStruct2, d: 3},
+      d: [],
+      e: nil,
+      f: "test"
+    }
+
+    assert Map.from_struct(struct, true) == %{a: 1, b: 2, c: %{d: 3}, d: [], e: nil, f: "test"}
+  end
+
   test "implements (almost) all functions in Keyword" do
     assert Keyword.__info__(:functions) -- Map.__info__(:functions) == [
              delete: 3,


### PR DESCRIPTION
I've encountered this specific issue with struct to map conversion (described for example [here](https://elixirforum.com/t/convert-a-nested-struct-into-a-nested-map/23814/10) or [here](https://groups.google.com/g/elixir-lang-talk/c/ABpynrektMw?pli=1)) so many times in my daily work that I decided to prepare a proposal of enhancement of method `Map.from_struct/1`.

The main idea is to allow people to recursively convert structs with nested structs to maps with nested maps.

```
user = %User{
  id: 1,
  first_name: "John",
  last_name: "Doe",
  contact_details: %User.ContactDetails{
    phone_number: "19998887777",
    email: "john.doe@example.com"
  },
  permissions: [
    %Permision{
       level: :super_admin
    }
  ]
}

result = Map.from_struct(user, true)

IO.inspect(result)
%{
  id: 1,
  first_name: "John",
  last_name: "Doe",
  contact_details: %{
    phone_number: "19998887777",
    email: "john.doe@example.com"
  }
  permissions: [
    %{
       id: 1,
       level: :super_admin
    }
  ]
}
```

I'd agree that this kind of conversion is much more expensive than the previous one, but I do believe that having a method that converts only a top-level struct is also very misleading. Let's give people at least a bult-in solution after they realize how the standard version works :)

WDYT?