### PR TITLE
Fix docs of Module.safe_concat/1 / Module.safe_concat/2

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -792,6 +792,8 @@ defmodule Module do
   @doc """
   Concatenates a list of aliases and returns a new alias.
 
+  It handles binaries and atoms.
+
   ## Examples
 
       iex> Module.concat([Foo, Bar])
@@ -808,6 +810,8 @@ defmodule Module do
 
   @doc """
   Concatenates two aliases and returns a new alias.
+
+  It handles binaries and atoms.
 
   ## Examples
 
@@ -829,7 +833,7 @@ defmodule Module do
   was already referenced.
 
   If the alias was not referenced yet, fails with `ArgumentError`.
-  It handles charlists, binaries and atoms.
+  It handles binaries and atoms.
 
   ## Examples
 
@@ -847,7 +851,7 @@ defmodule Module do
   already referenced.
 
   If the alias was not referenced yet, fails with `ArgumentError`.
-  It handles charlists, binaries and atoms.
+  It handles binaries and atoms.
 
   ## Examples
 


### PR DESCRIPTION
Fix docs of Module.safe_concat/1 / Module.safe_concat/2:
- Remove mention of handling charlist (which it does not).
- Also mention in the docs of `Module.concat/1` / `Module.concat/2` that
  this handles both binaries and atoms.

Fixes #11298 