### PR TITLE
Fix infinite loop in String.slice/2

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2157,7 +2157,8 @@ defmodule String do
   end
 
   # TODO: Remove me on v2.0
-  def slice(string, %{__struct__: Range, first: first, last: last} = range) do
+  def slice(string, %{__struct__: Range, first: first, last: last} = range)
+      when is_binary(string) do
     step = if first <= last, do: 1, else: -1
     slice(string, Map.put(range, :step, step))
   end

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -661,6 +661,10 @@ defmodule StringTest do
     assert String.slice("あいうえお", -10..-15) == ""
     assert String.slice("hello あいうえお Unicode", 8..-1) == "うえお Unicode"
     assert String.slice("abc", -1..14) == "c"
+
+    assert_raise FunctionClauseError, fn ->
+      String.slice(nil, 0..1)
+    end
   end
 
   test "valid?/1" do


### PR DESCRIPTION
The 2nd slice's guard clause doesn't match the previous. If you pass anything other than a binary, you get an infinite loop.