### PR TITLE
Emit notice logs in :console backend

### DIFF
--- a/lib/ex_unit/test/ex_unit/capture_log_test.exs
+++ b/lib/ex_unit/test/ex_unit/capture_log_test.exs
@@ -73,14 +73,14 @@ defmodule ExUnit.CaptureLogTest do
 
     assert logged
     assert logged =~ "[info]  one\n"
-    assert logged =~ "[warn]  two\n"
+    assert logged =~ "[warning] two\n"
     assert logged =~ "[debug] three\n"
     assert logged =~ "[error] one\n"
 
     receive do
       {:nested, logged} ->
         assert logged =~ "[error] one\n"
-        refute logged =~ "[warn]  two\n"
+        refute logged =~ "[warning] two\n"
     end
   end
 

--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -138,6 +138,12 @@ defmodule Logger.Backends.Console do
   def handle_event({level, _gl, {Logger, msg, ts, md}}, state) do
     %{level: log_level, ref: ref, buffer_size: buffer_size, max_buffer: max_buffer} = state
 
+    {:erl_level, level} = List.keyfind(md, :erl_level, 0, {:erl_level, level})
+    level = case level do
+      :warning -> :warn
+      _ -> level
+    end
+
     cond do
       not meet_level?(level, log_level) ->
         {:ok, state}
@@ -245,11 +251,6 @@ defmodule Logger.Backends.Console do
   end
 
   defp log_event(level, msg, ts, md, %{device: device} = state) do
-    {:erl_level, level} = List.keyfind(md, :erl_level, 0, {:erl_level, level})
-    level = case level do
-      :warning -> :warn
-      _ -> level
-    end
     output = format_event(level, msg, ts, md, state)
     %{state | ref: async_io(device, output), output: output}
   end

--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -245,7 +245,7 @@ defmodule Logger.Backends.Console do
   end
 
   defp log_event(_level, msg, ts, md, %{device: device} = state) do
-    {:erl_level, level} = List.keyfind(md, :erl_level, 0, :not_found)
+    {:erl_level, level} = List.keyfind(md, :erl_level, 0, {:erl_level, :not_found})
 
     output = format_event(level, msg, ts, md, state)
     %{state | ref: async_io(device, output), output: output}

--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -241,7 +241,7 @@ defmodule Logger.Backends.Console do
       info: Keyword.get(colors, :info, :normal),
       warning: Keyword.get(colors, :warn, :yellow),
       error: Keyword.get(colors, :error, :red),
-      notice: Keyword.get(colors, :error, :blue),
+      notice: Keyword.get(colors, :info, :normal),
       enabled: Keyword.get(colors, :enabled, IO.ANSI.enabled?())
     }
   end

--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -244,8 +244,8 @@ defmodule Logger.Backends.Console do
     }
   end
 
-  defp log_event(_level, msg, ts, md, %{device: device} = state) do
-    {:erl_level, level} = List.keyfind(md, :erl_level, 0, {:erl_level, :not_found})
+  defp log_event(level, msg, ts, md, %{device: device} = state) do
+    {:erl_level, level} = List.keyfind(md, :erl_level, 0, {:erl_level, level})
 
     output = format_event(level, msg, ts, md, state)
     %{state | ref: async_io(device, output), output: output}

--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -232,6 +232,9 @@ defmodule Logger.Backends.Console do
     colors = Keyword.get(config, :colors, [])
 
     %{
+      alert: Keyword.get(colors, :debug, :red),
+      critical: Keyword.get(colors, :debug, :red),
+      emergency: Keyword.get(colors, :debug, :red),
       debug: Keyword.get(colors, :debug, :cyan),
       info: Keyword.get(colors, :info, :normal),
       warn: Keyword.get(colors, :warn, :yellow),

--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -236,11 +236,14 @@ defmodule Logger.Backends.Console do
       info: Keyword.get(colors, :info, :normal),
       warn: Keyword.get(colors, :warn, :yellow),
       error: Keyword.get(colors, :error, :red),
+      notice: Keyword.get(colors, :error, :blue),
       enabled: Keyword.get(colors, :enabled, IO.ANSI.enabled?())
     }
   end
 
-  defp log_event(level, msg, ts, md, %{device: device} = state) do
+  defp log_event(_level, msg, ts, md, %{device: device} = state) do
+    {:erl_level, level} = List.keyfind(md, :erl_level, 0, :not_found)
+
     output = format_event(level, msg, ts, md, state)
     %{state | ref: async_io(device, output), output: output}
   end

--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -38,7 +38,7 @@ defmodule Logger.Backends.Console do
 
     * `:info` - color for info and notice messages. Defaults to: `:normal`
 
-    * `:warning` - color for warning messages. Defaults to: `:yellow`
+    * `:warn` - color for warning messages. Defaults to: `:yellow`
 
     * `:error` - color for error and higher messages. Defaults to: `:red`
 
@@ -239,7 +239,7 @@ defmodule Logger.Backends.Console do
       emergency: Keyword.get(colors, :debug, :red),
       debug: Keyword.get(colors, :debug, :cyan),
       info: Keyword.get(colors, :info, :normal),
-      warning: Keyword.get(colors, :warning, :yellow),
+      warning: Keyword.get(colors, :warn, :yellow),
       error: Keyword.get(colors, :error, :red),
       notice: Keyword.get(colors, :error, :blue),
       enabled: Keyword.get(colors, :enabled, IO.ANSI.enabled?())

--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -38,7 +38,7 @@ defmodule Logger.Backends.Console do
 
     * `:info` - color for info and notice messages. Defaults to: `:normal`
 
-    * `:warn` - color for warning messages. Defaults to: `:yellow`
+    * `:warning` - color for warning messages. Defaults to: `:yellow`
 
     * `:error` - color for error and higher messages. Defaults to: `:red`
 
@@ -139,10 +139,6 @@ defmodule Logger.Backends.Console do
     %{level: log_level, ref: ref, buffer_size: buffer_size, max_buffer: max_buffer} = state
 
     {:erl_level, level} = List.keyfind(md, :erl_level, 0, {:erl_level, level})
-    level = case level do
-      :warning -> :warn
-      _ -> level
-    end
 
     cond do
       not meet_level?(level, log_level) ->
@@ -243,7 +239,7 @@ defmodule Logger.Backends.Console do
       emergency: Keyword.get(colors, :debug, :red),
       debug: Keyword.get(colors, :debug, :cyan),
       info: Keyword.get(colors, :info, :normal),
-      warn: Keyword.get(colors, :warn, :yellow),
+      warning: Keyword.get(colors, :warning, :yellow),
       error: Keyword.get(colors, :error, :red),
       notice: Keyword.get(colors, :error, :blue),
       enabled: Keyword.get(colors, :enabled, IO.ANSI.enabled?())

--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -234,14 +234,14 @@ defmodule Logger.Backends.Console do
     colors = Keyword.get(config, :colors, [])
 
     %{
-      alert: Keyword.get(colors, :debug, :red),
-      critical: Keyword.get(colors, :debug, :red),
-      emergency: Keyword.get(colors, :debug, :red),
-      debug: Keyword.get(colors, :debug, :cyan),
-      info: Keyword.get(colors, :info, :normal),
-      warning: Keyword.get(colors, :warn, :yellow),
+      emergency: Keyword.get(colors, :error, :red),
+      alert: Keyword.get(colors, :error, :red),
+      critical: Keyword.get(colors, :error, :red),
       error: Keyword.get(colors, :error, :red),
+      warning: Keyword.get(colors, :warn, :yellow),
       notice: Keyword.get(colors, :info, :normal),
+      info: Keyword.get(colors, :info, :normal),
+      debug: Keyword.get(colors, :debug, :cyan),
       enabled: Keyword.get(colors, :enabled, IO.ANSI.enabled?())
     }
   end

--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -246,7 +246,10 @@ defmodule Logger.Backends.Console do
 
   defp log_event(level, msg, ts, md, %{device: device} = state) do
     {:erl_level, level} = List.keyfind(md, :erl_level, 0, {:erl_level, level})
-
+    level = case level do
+      :warning -> :warn
+      _ -> level
+    end
     output = format_event(level, msg, ts, md, state)
     %{state | ref: async_io(device, output), output: output}
   end

--- a/lib/logger/lib/logger/formatter.ex
+++ b/lib/logger/lib/logger/formatter.ex
@@ -166,6 +166,7 @@ defmodule Logger.Formatter do
   defp levelpad(:debug), do: ""
   defp levelpad(:info), do: " "
   defp levelpad(:warn), do: " "
+  defp levelpad(:notice), do: " "
   defp levelpad(:error), do: ""
 
   defp metadata([{key, value} | metadata]) do

--- a/lib/logger/lib/logger/formatter.ex
+++ b/lib/logger/lib/logger/formatter.ex
@@ -163,11 +163,10 @@ defmodule Logger.Formatter do
   defp output(:levelpad, level, _, _, _), do: levelpad(level)
   defp output(other, _, _, _, _), do: other
 
-  defp levelpad(:debug), do: ""
+  # TODO: Deprecate me on Elixir v1.13+ or later
   defp levelpad(:info), do: " "
   defp levelpad(:warn), do: " "
-  defp levelpad(:notice), do: " "
-  defp levelpad(:error), do: ""
+  defp levelpad(_), do: ""
 
   defp metadata([{key, value} | metadata]) do
     if formatted = metadata(key, value) do

--- a/lib/logger/test/logger/backends/console_test.exs
+++ b/lib/logger/test/logger/backends/console_test.exs
@@ -129,6 +129,18 @@ defmodule Logger.Backends.ConsoleTest do
     assert capture_log(fn -> Logger.debug("hello") end) == ""
   end
 
+  test "filter by notice" do
+    Logger.configure_backend(:console, level: :notice)
+
+    assert capture_log(fn -> Logger.debug("hello") end) == ""
+    assert capture_log(fn -> Logger.info("hello") end) == ""
+    assert capture_log(fn -> Logger.notice("hello") end) =~ "[notice] hello\n"
+    assert capture_log(fn -> Logger.warning("hello") end) =~ "[warning] hello\n"
+    assert capture_log(fn -> Logger.critical("hello") end) =~ "[critical] hello\n"
+    assert capture_log(fn -> Logger.alert("hello") end) =~ "[alert] hello\n"
+    assert capture_log(fn -> Logger.error("hello") end) =~ "[error] hello\n"
+  end
+
   test "configures colors" do
     Logger.configure_backend(:console, format: "$message", colors: [enabled: true])
 

--- a/lib/logger/test/logger/backends/console_test.exs
+++ b/lib/logger/test/logger/backends/console_test.exs
@@ -154,7 +154,7 @@ defmodule Logger.Backends.ConsoleTest do
     Logger.configure_backend(:console, colors: [warn: :cyan])
 
     assert capture_log(fn -> Logger.warn("hello") end) ==
-             IO.ANSI.cyan() <> "hello" <> IO.ANSI.reset()
+             IO.ANSI.yellow() <> "hello" <> IO.ANSI.reset()
 
     assert capture_log(fn -> Logger.error("hello") end) ==
              IO.ANSI.red() <> "hello" <> IO.ANSI.reset()

--- a/lib/logger/test/logger/backends/console_test.exs
+++ b/lib/logger/test/logger/backends/console_test.exs
@@ -166,7 +166,7 @@ defmodule Logger.Backends.ConsoleTest do
     Logger.configure_backend(:console, colors: [warn: :cyan])
 
     assert capture_log(fn -> Logger.warn("hello") end) ==
-             IO.ANSI.yellow() <> "hello" <> IO.ANSI.reset()
+             IO.ANSI.cyan() <> "hello" <> IO.ANSI.reset()
 
     assert capture_log(fn -> Logger.error("hello") end) ==
              IO.ANSI.red() <> "hello" <> IO.ANSI.reset()

--- a/lib/logger/test/logger/handler_test.exs
+++ b/lib/logger/test/logger/handler_test.exs
@@ -103,6 +103,7 @@ defmodule Logger.HandlerTest do
     assert capture_log(fn -> :logger.critical('ok') end) =~ "[critical] ok"
     assert capture_log(fn -> :logger.error('ok') end) =~ "[error] ok"
     assert capture_log(fn -> :logger.warning('ok') end) =~ "[warning] ok"
+    assert capture_log(fn -> :logger.notice('ok') end) =~ "[notice] ok"
     assert capture_log(fn -> :logger.info('ok') end) =~ "[info]  ok"
     assert capture_log(fn -> :logger.debug('ok') end) =~ "[debug] ok"
   end

--- a/lib/logger/test/logger/handler_test.exs
+++ b/lib/logger/test/logger/handler_test.exs
@@ -97,7 +97,7 @@ defmodule Logger.HandlerTest do
            end) =~ "[info]  :formatted"
   end
 
-  test "don't converts log levels" do
+  test "uses Erlang log levels" do
     assert capture_log(fn -> :logger.emergency('ok') end) =~ "[emergency] ok"
     assert capture_log(fn -> :logger.alert('ok') end) =~ "[alert] ok"
     assert capture_log(fn -> :logger.critical('ok') end) =~ "[critical] ok"

--- a/lib/logger/test/logger/handler_test.exs
+++ b/lib/logger/test/logger/handler_test.exs
@@ -37,7 +37,7 @@ defmodule Logger.HandlerTest do
 
     assert capture_log(fn ->
              :error_logger.info_msg('world: ~p', [:ok])
-           end) =~ "[info]  rewritten"
+           end) =~ "[notice] rewritten"
   after
     assert Logger.remove_translator({CustomTranslator, :t})
   end
@@ -97,12 +97,12 @@ defmodule Logger.HandlerTest do
            end) =~ "[info]  :formatted"
   end
 
-  test "converts log levels" do
-    assert capture_log(fn -> :logger.emergency('ok') end) =~ "[error] ok"
-    assert capture_log(fn -> :logger.alert('ok') end) =~ "[error] ok"
-    assert capture_log(fn -> :logger.critical('ok') end) =~ "[error] ok"
+  test "don't converts log levels" do
+    assert capture_log(fn -> :logger.emergency('ok') end) =~ "[emergency] ok"
+    assert capture_log(fn -> :logger.alert('ok') end) =~ "[alert] ok"
+    assert capture_log(fn -> :logger.critical('ok') end) =~ "[critical] ok"
     assert capture_log(fn -> :logger.error('ok') end) =~ "[error] ok"
-    assert capture_log(fn -> :logger.warning('ok') end) =~ "[warn]  ok"
+    assert capture_log(fn -> :logger.warning('ok') end) =~ "[warning] ok"
     assert capture_log(fn -> :logger.info('ok') end) =~ "[info]  ok"
     assert capture_log(fn -> :logger.debug('ok') end) =~ "[debug] ok"
   end

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -408,15 +408,15 @@ defmodule LoggerTest do
   test "deprecated :warn" do
     assert capture_log(fn ->
              Logger.warn("hello") == :ok
-           end) =~ "[warn]"
+           end) =~ "[warning]"
 
     assert capture_log(fn ->
              Logger.log(:warn, "hello") == :ok
-           end) =~ "[warn]"
+           end) =~ "[warning]"
 
     assert capture_log(fn ->
              Logger.bare_log(:warn, "hello") == :ok
-           end) =~ "[warn]"
+           end) =~ "[warning]"
   end
 
   describe "levels" do
@@ -451,7 +451,7 @@ defmodule LoggerTest do
     test "warning/2" do
       assert capture_log(fn ->
                assert Logger.warning("hello", []) == :ok
-             end) =~ msg_with_meta("[warn]  hello")
+             end) =~ msg_with_meta("[warning] hello")
 
       assert capture_log(:error, fn ->
                assert Logger.warning("hello", []) == :ok
@@ -465,7 +465,7 @@ defmodule LoggerTest do
     test "warn/2" do
       assert capture_log(fn ->
                assert Logger.warn("hello", []) == :ok
-             end) =~ msg_with_meta("[warn]  hello")
+             end) =~ msg_with_meta("[warning] hello")
 
       assert capture_log(:error, fn ->
                assert Logger.warn("hello", []) == :ok
@@ -493,7 +493,7 @@ defmodule LoggerTest do
     test "critical/2" do
       assert capture_log(fn ->
                assert Logger.critical("hello", []) == :ok
-             end) =~ msg_with_meta("[error] hello")
+             end) =~ msg_with_meta("[critical] hello")
 
       assert capture_log(:alert, fn ->
                assert Logger.critical("hello", []) == :ok
@@ -507,7 +507,7 @@ defmodule LoggerTest do
     test "alert/2" do
       assert capture_log(fn ->
                assert Logger.alert("hello", []) == :ok
-             end) =~ msg_with_meta("[error] hello")
+             end) =~ msg_with_meta("[alert] hello")
 
       assert capture_log(:emergency, fn ->
                assert Logger.alert("hello", []) == :ok
@@ -521,7 +521,7 @@ defmodule LoggerTest do
     test "emergency/2" do
       assert capture_log(fn ->
                assert Logger.emergency("hello", []) == :ok
-             end) =~ msg_with_meta("[error] hello")
+             end) =~ msg_with_meta("[emergency] hello")
 
       assert capture_log(:none, fn ->
                assert Logger.emergency("hello", []) == :ok


### PR DESCRIPTION
yes.. this is not very "backward compatible"..
I guess adding some config flag to enable it, and
default it to false.. would be proper (?)