### PR TITLE
Issue warning message on matching empty map

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -107,6 +107,20 @@ defmodule ExUnit.Assertions do
   defmacro assert({:=, meta, [left, right]} = assertion) do
     code = escape_quoted(:assert, meta, assertion)
 
+    if match?({:%{}, _, []}, left) do
+      IO.warn("""
+      Matching against empty map will not check if the map is empty.
+
+      You probably wanted to do:
+
+          assert %{} == #{Macro.to_string(right)}
+
+      If you wanted to check whether the value is just map, then use:
+
+          assert is_map(#{Macro.to_string(right)})
+      """)
+    end
+
     # If the match works, we need to check if the value
     # is not nil nor false. We need to rewrite the if
     # to avoid silly warnings though.

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -5,6 +5,7 @@ defmodule ExUnit.AssertionsTest.Value do
   def falsy, do: nil
   def truthy, do: :truthy
   def binary, do: <<5, "Frank the Walrus">>
+  def map, do: %{a: 1, b: 2}
 end
 
 defmodule ExUnit.AssertionsTest.BrokenError do
@@ -172,6 +173,23 @@ defmodule ExUnit.AssertionsTest do
              end
              """)
            end) =~ "variable \"var\" is unused"
+  after
+    :code.delete(ExSample)
+    :code.purge(ExSample)
+  end
+
+  test "assert match with empty map" do
+    assert ExUnit.CaptureIO.capture_io(:stderr, fn ->
+             Code.eval_string("""
+             defmodule ExSample do
+               import ExUnit.Assertions
+
+               def run do
+                 true = %{a: 1, b: 2} == assert %{} = ExUnit.AssertionsTest.Value.map()
+               end
+             end
+             """)
+           end) =~ "Matching against empty map will not check if the map is empty"
   after
     :code.delete(ExSample)
     :code.purge(ExSample)


### PR DESCRIPTION
This will provide message about using asserts in form of:

    assert %{} = value

Which may be confusing to some people, as it will match against **any** map, not against **empty map**. User probably meant:

    assert %{} == value

The old test can still be achieved via using:

    assert is_map(value)

And that will not issue any warning.

Close #11331
