### PR TITLE
Fix elixir_errors:parse_error/6 spec

### DIFF
--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -96,7 +96,7 @@ snippet(InputString, Location, StartLine, StartColumn) ->
   end.
 
 -spec parse_error(elixir:keyword(), binary() | {binary(), binary()},
-                  binary(), binary(), {list(), integer(), integer()}) -> no_return().
+                  binary(), binary(), {unicode:chardata(), integer(), integer()}) -> no_return().
 parse_error(Location, File, Error, <<>>, {InputString, StartLine, StartColumn}) ->
   Message = case Error of
     <<"syntax error before: ">> -> <<"syntax error: expression is incomplete">>;


### PR DESCRIPTION
Widen InputString type to accept both string() and binary()
since it works with both of them, and both are used in Code
and IEx.Evaluator modules