### PR TITLE
Pass sigil/modifiers through to formatter

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -1320,7 +1320,7 @@ defmodule Code.Formatter do
       entries =
         case state.sigils do
           %{^name => callback} ->
-            case callback.(hd(entries), sigil: {List.to_atom([name]), modifiers}) do
+            case callback.(hd(entries), sigil: List.to_atom([name]), modifiers: modifiers) do
               binary when is_binary(binary) ->
                 [binary]
 

--- a/lib/elixir/test/elixir/code_formatter/general_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/general_test.exs
@@ -126,7 +126,7 @@ defmodule Code.Formatter.GeneralTest do
       """
 
       formatter = fn content, opts ->
-        assert opts == [sigil: {:W, []}]
+        assert opts == [sigil: :W, modifiers: []]
         content |> String.split(~r/ +/) |> Enum.join(" ")
       end
 
@@ -141,7 +141,7 @@ defmodule Code.Formatter.GeneralTest do
       """
 
       formatter = fn content, opts ->
-        assert opts == [sigil: {:W, 'abc'}]
+        assert opts == [sigil: :W, modifiers: 'abc']
         content |> String.split(~r/ +/) |> Enum.join(" ")
       end
 
@@ -162,7 +162,7 @@ defmodule Code.Formatter.GeneralTest do
       """
 
       formatter = fn content, opts ->
-        assert opts == [sigil: {:W, []}]
+        assert opts == [sigil: :W, modifiers: []]
         content |> String.split(~r/ +/) |> Enum.join(" ")
       end
 
@@ -189,7 +189,7 @@ defmodule Code.Formatter.GeneralTest do
       """
 
       formatter = fn content, opts ->
-        assert opts == [sigil: {:W, 'abc'}]
+        assert opts == [sigil: :W, modifiers: 'abc']
         content |> String.split(~r/ +/) |> Enum.join("\n")
       end
 

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -104,8 +104,9 @@ defmodule Mix.Tasks.Format do
 
   The `opts` passed to `format/2` contains all the formatting options and either:
 
-      * `:sigil` (tuple of sigil and its modifiers) - the sigil being formatted,
-        e.g. `{:M, []}`.
+      * `:sigil` (atom) - the sigil being formatted, e.g. `:M`.
+
+      * `:modifiers` (charlist) - list of sigil modifiers.
 
       * `:extension` (string) - the extension of the file being formatted, e.g. `".md"`.
 

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -204,7 +204,8 @@ defmodule Mix.Tasks.FormatTest do
 
     def format(contents, opts) do
       assert opts[:from_formatter_exs] == :yes
-      assert opts[:sigil] == {:W, 'abc'}
+      assert opts[:sigil] == :W
+      assert opts[:modifiers] == 'abc'
       contents |> String.split(~r/\s/) |> Enum.join("\n")
     end
   end


### PR DESCRIPTION
I created a formatter for graphql documents, see this PR https://github.com/absinthe-graphql/absinthe/pull/1114#issuecomment-951364776 and @benwilson512 asked whether the formatting could be dependent on whether it's a sigil being formatted or a file.

As mentioned in the discussion it can be inferred by checking the extension of the file being formatted, but this seems brittle. Also it doesn't pass through which sigil is used or any of the applied sigil modifiers. This PR changes that by passing through `sigil: {name, modifiers}` to the opts of the `format(content, opts)` in a formatter plugin. 




