### PR TITLE
Start `:update_counter` loop on Logger.Config init

### DIFF
--- a/lib/logger/lib/logger/config.ex
+++ b/lib/logger/lib/logger/config.ex
@@ -22,6 +22,7 @@ defmodule Logger.Config do
   def init(counter) do
     state = load_state(counter)
     state = update_counter(state, false)
+    schedule_update_counter(state)
     {:ok, state}
   end
 


### PR DESCRIPTION
# Loggers counter is not being reset after it exceeds the configured `discard_threshold`

Once the Logger's counter exceeds the `discard_threshold`, the counter will not be updated/reset until Logger.Config receives a `{Logger.Config, :update_counter}` message.

These messages are sent on a recurring basis (based on the `discard_period`) via the private `Logger.Config.schedule_update_counter/1` function, which is only called from within the callback for the `{Logger.Config, :update_counter}` handle_info.  This keeps the `update_counter` loop from ever being kicked off.

This PR adds an additional call to `schedule_update_counter` inside the `Logger.Config`'s init function to start the cycle.
