### PR TITLE
Typespecs: show expanded module name on inexistent struct field error

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -573,9 +573,11 @@ defmodule Kernel.Typespec do
 
     fun = fn {field, _} ->
       unless Keyword.has_key?(struct, field) do
+        humanized_module = module |> Atom.to_string() |> String.replace("Elixir.", "")
+
         compile_error(
           caller,
-          "undefined field #{inspect(field)} on struct #{Macro.to_string(name)}"
+          "undefined field #{inspect(field)} on struct #{humanized_module}"
         )
       end
     end

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -573,11 +573,9 @@ defmodule Kernel.Typespec do
 
     fun = fn {field, _} ->
       unless Keyword.has_key?(struct, field) do
-        humanized_module = module |> Atom.to_string() |> String.replace("Elixir.", "")
-
         compile_error(
           caller,
-          "undefined field #{inspect(field)} on struct #{humanized_module}"
+          "undefined field #{inspect(field)} on struct #{inspect(module)}"
         )
       end
     end

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -521,12 +521,23 @@ defmodule TypespecTest do
     end
 
     test "@type with a struct with undefined field" do
-      assert_raise CompileError, ~r"undefined field :no_field on struct TypespecSample", fn ->
-        test_module do
-          defstruct [:hello, :eric]
-          @type my_type :: %TypespecSample{no_field: :world}
-        end
-      end
+      assert_raise CompileError,
+                   ~r"undefined field :no_field on struct TypespecTest.TypespecSample",
+                   fn ->
+                     test_module do
+                       defstruct [:hello, :eric]
+                       @type my_type :: %TypespecSample{no_field: :world}
+                     end
+                   end
+
+      assert_raise CompileError,
+                   ~r"undefined field :no_field on struct TypespecTest.TypespecSample",
+                   fn ->
+                     test_module do
+                       defstruct [:hello, :eric]
+                       @type my_type :: %__MODULE__{no_field: :world}
+                     end
+                   end
     end
 
     test "@type when overriding Elixir built-in" do


### PR DESCRIPTION
Closes #11352.

I believe that this behaviour it is consistent with other invalid field errors:
```
iex(1)> defmodule Foo.Bar do
...(1)>   defstruct [a: 1]
...(1)>   def bar, do: %__MODULE__{b: 1}
...(1)> end
** (KeyError) key :b not found
    expanding struct: Foo.Bar.__struct__/1
```