### PR TITLE
Keep keyword format of tuple last element

### DIFF
--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -189,7 +189,7 @@ defmodule Code.Normalizer do
     with [{{:__block__, key_meta, _}, _} | _] <- last_arg, :keyword <- key_meta[:format] do
       args = normalize_kw_args(args, state)
       kw_list = normalize_kw_args(last_arg, state)
-      {:__block__, [], [{:{}, meta, args ++ kw_list}]}
+      {:{}, meta, args ++ kw_list}
     else
       _ ->
         normalize_call(quoted, state)

--- a/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
@@ -342,6 +342,13 @@ defmodule Code.Normalizer.FormatterASTTest do
       @type foo :: a when b: :c
       """
     end
+
+    test "last tuple element as keyword list keeps its format" do
+      assert_same ~S"{:wrapped, [opt1: true, opt2: false]}"
+      assert_same ~S"{:unwrapped, opt1: true, opt2: false}"
+      assert_same ~S"{:wrapped, 1, [opt1: true, opt2: false]}"
+      assert_same ~S"{:unwrapped, 1, opt1: true, opt2: false}"
+    end
   end
 
   describe "preserves user choice on parenthesis" do


### PR DESCRIPTION
This was originally reported and fixed by @msaraiva in https://github.com/doorgan/sourceror/pull/30

Considering a tuple like this one:
```elixir
{SomeModule, opt1: true, opt2: false}
```
The last element is a keyword list without square brackets, and the formatter preserves that style. If we use `Code.string_to_qutoed` and then `Code.quoted_to_algebra`(as `Macro.to_string` does), the keyword list gets brackets inserted:

```elixir
iex> opts = [literal_encoder: &{:ok, {:__block__, &2, [&1]}}]
iex> {:ok, quoted} = Code.string_to_quoted("{SomeModule, opt1: true, opt2: false}", opts)
iex> Macro.to_string(quoted)
"{SomeModule, [opt1: true, opt2: false]}"
```