### PR TITLE
Add :all back to typespec for IO.read

### DIFF
--- a/lib/elixir/lib/io.ex
+++ b/lib/elixir/lib/io.ex
@@ -142,7 +142,7 @@ defmodule IO do
       NFS volume
 
   """
-  @spec read(device, :eof | :line | non_neg_integer) :: chardata | nodata
+  @spec read(device, :eof | :line | :all | non_neg_integer) :: chardata | nodata
   def read(device \\ :stdio, line_or_chars)
 
   # TODO: Deprecate me on v1.17


### PR DESCRIPTION
Elixir 1.13 replaces the flag :all with :eof although
:all remains valid (albeit marked for deprecation).

However removing :all from the typespec means that
dialyzer errors on Elixir 1.13, and if replaced with :eof
dialyzer errors on earlier releases.

This commit aligns the typespec with the implementation. However
an additional comment in the @doc could be used to note
that :all should be replaced with :eof.