### PR TITLE
Fix Config.config_env/0 with empty Process dictionary

### DIFF
--- a/lib/elixir/lib/config.ex
+++ b/lib/elixir/lib/config.ex
@@ -187,7 +187,8 @@ defmodule Config do
   @doc false
   @spec __env__!() :: atom()
   def __env__!() do
-    elem(get_opts!(), 0) || raise "no :env key was given to this configuration file"
+    opts = get_opts!()
+    (is_tuple(opts) && elem(opts, 0)) || raise "no :env key was given to this configuration file"
   end
 
   @doc """
@@ -210,7 +211,10 @@ defmodule Config do
   @doc false
   @spec __target__!() :: atom()
   def __target__!() do
-    elem(get_opts!(), 1) || raise "no :target key was given to this configuration file"
+    opts = get_opts!()
+
+    (is_tuple(opts) && elem(opts, 1)) ||
+      raise "no :target key was given to this configuration file"
   end
 
   @doc ~S"""

--- a/lib/elixir/lib/config.ex
+++ b/lib/elixir/lib/config.ex
@@ -75,7 +75,7 @@ defmodule Config do
   @config_key {__MODULE__, :config}
   @imports_key {__MODULE__, :imports}
 
-  defp get_opts!(), do: Process.get(@opts_key)
+  defp get_opts!(), do: Process.get(@opts_key) || raise_improper_use!()
   defp put_opts(value), do: Process.put(@opts_key, value)
   defp delete_opts(), do: Process.delete(@opts_key)
 
@@ -187,8 +187,7 @@ defmodule Config do
   @doc false
   @spec __env__!() :: atom()
   def __env__!() do
-    opts = get_opts!()
-    (is_tuple(opts) && elem(opts, 0)) || raise "no :env key was given to this configuration file"
+    elem(get_opts!(), 0) || raise "no :env key was given to this configuration file"
   end
 
   @doc """
@@ -211,10 +210,7 @@ defmodule Config do
   @doc false
   @spec __target__!() :: atom()
   def __target__!() do
-    opts = get_opts!()
-
-    (is_tuple(opts) && elem(opts, 1)) ||
-      raise "no :target key was given to this configuration file"
+    elem(get_opts!(), 1) || raise "no :target key was given to this configuration file"
   end
 
   @doc ~S"""

--- a/lib/elixir/test/elixir/config_test.exs
+++ b/lib/elixir/test/elixir/config_test.exs
@@ -117,3 +117,21 @@ defmodule ConfigTest do
     end
   end
 end
+
+defmodule ConfigNoSetupTest do
+  use ExUnit.Case, async: true
+
+  import Config
+
+  test "config_env/0 raises if no env is set" do
+    assert_raise RuntimeError, "no :env key was given to this configuration file", fn ->
+      config_env()
+    end
+  end
+
+  test "config_target/0 raises if no env is set" do
+    assert_raise RuntimeError, "no :target key was given to this configuration file", fn ->
+      config_target()
+    end
+  end
+end

--- a/lib/elixir/test/elixir/config_test.exs
+++ b/lib/elixir/test/elixir/config_test.exs
@@ -117,21 +117,3 @@ defmodule ConfigTest do
     end
   end
 end
-
-defmodule ConfigNoSetupTest do
-  use ExUnit.Case, async: true
-
-  import Config
-
-  test "config_env/0 raises if no env is set" do
-    assert_raise RuntimeError, "no :env key was given to this configuration file", fn ->
-      config_env()
-    end
-  end
-
-  test "config_target/0 raises if no env is set" do
-    assert_raise RuntimeError, "no :target key was given to this configuration file", fn ->
-      config_target()
-    end
-  end
-end


### PR DESCRIPTION
It fixes the following bug:

```elixir
iex(1)> require Config
Config
iex(2)> Config.config_env()
** (ArgumentError) errors were found at the given arguments:

  * 2nd argument: not a tuple

    :erlang.element(1, nil)
    (elixir 1.12.3) lib/config.ex:188: Config.__env__!/0
```