### PR TITLE
Call out what happens to duplicate keys in Map.map/2 in the docs

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -1044,6 +1044,8 @@ defmodule Map do
   Maps the function `fun` over all key-value pairs in `map`, returning a map
   with all the values replaced with the result of the function.
 
+  Duplicated keys are removed; the latest one prevails.
+
   ## Examples
 
       iex> Map.map(%{1 => "joe", 2 => "mike", 3 => "robert"}, fn {_key, val} -> String.capitalize(val) end)


### PR DESCRIPTION
Per the discussion in #11239, this adds a note that if the function you pass to `Map.map/2` produces duplicate keys, only the last one will be kept.