### PR TITLE
Fix bug in Mix.Release validation

### DIFF
--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -461,7 +461,18 @@ defmodule Mix.Release do
   defp valid_config?(a) when is_atom(a), do: true
   defp valid_config?(b) when is_binary(b), do: true
   defp valid_config?(l) when is_list(l), do: Enum.all?(l, &valid_config?/1)
-  defp valid_config?(m) when is_map(m), do: Enum.all?(m, &valid_config?/1)
+
+  defp valid_config?(m) when is_map(m) do
+    m =
+      if is_struct(m) and Enumerable.impl_for(m) == nil do
+        Map.from_struct(m)
+      else
+        m
+      end
+
+    Enum.all?(m, &valid_config?/1)
+  end
+
   defp valid_config?(t) when is_tuple(t), do: Enum.all?(Tuple.to_list(t), &valid_config?/1)
   defp valid_config?(_), do: false
 


### PR DESCRIPTION
I was getting this cryptic error when doing a release.

```console
$ MIX_ENV=prod mix release maintenance
Release maintenance-0.1.0 already exists. Overwrite? [Yn] y
* assembling maintenance-0.1.0 on MIX_ENV=prod
* using config/runtime.exs to configure the release at runtime
** (Protocol.UndefinedError) protocol Enumerable not implemented for %Config.Provider{config_path: {:system, "RELEASE_SYS_CONFIG", ".config"}, extra_config: [], providers: [{Config.Reader, {{:system, "RELEASE_ROOT", "/releases/0.1.0/runtime.exs"}, [env: :prod, target: :host, imports: :disabled]}}], prune_runtime_sys_config_after_boot: false, reboot_system_after_config: false, validate_compile_env: [{:mime, [:types], :error}]} of type Config.Provider (a struct). This protocol is implemented for the following type(s): CubDB.Btree, CubDB.Btree.Diff, CubDB.Btree.KeyRange, Date.Range, File.Stream, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, List, Map, MapSet, Range, Stream
    (elixir 1.14.0-dev) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir 1.14.0-dev) lib/enum.ex:143: Enumerable.reduce/3
    (elixir 1.14.0-dev) lib/enum.ex:344: Enum.all?/2
    (mix 1.14.0-dev) lib/mix/release.ex:436: anonymous fn/3 in Mix.Release.make_sys_config/3
    (elixir 1.14.0-dev) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3
    (mix 1.14.0-dev) lib/mix/release.ex:434: Mix.Release.make_sys_config/3
    (mix 1.14.0-dev) lib/mix/tasks/release.ex:1190: Mix.Tasks.Release.build_rel/2
    (mix 1.14.0-dev) lib/mix/tasks/release.ex:1088: Mix.Tasks.Release.assemble/1
```

It happens because the previous code expected that all structs will implement the Enumerable protocol.
It fixes it by converting those that do not implement the Enumerable protocol to maps.