### PR TITLE
Support configurable formatter plugins

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -251,7 +251,7 @@ defmodule Mix.Tasks.Format do
   defp eval_deps_and_subdirectories(dot_formatter, prefix, formatter_opts, sources) do
     deps = Keyword.get(formatter_opts, :import_deps, [])
     subs = Keyword.get(formatter_opts, :subdirectories, [])
-    plugins = Keyword.get(formatter_opts, :plugins, []) |> Enum.map(&normalize_plugin(&1))
+    plugins = Keyword.get(formatter_opts, :plugins, []) |> Enum.map(&normalize_plugin/1)
 
     if not is_list(deps) do
       Mix.raise("Expected :import_deps to return a list of dependencies, got: #{inspect(deps)}")

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -199,6 +199,7 @@ defmodule Mix.Tasks.FormatTest do
 
     def features(opts) do
       assert opts[:from_formatter_exs] == :yes
+      assert opts[:custom_opts] == true
       [sigils: [:W]]
     end
 
@@ -215,7 +216,7 @@ defmodule Mix.Tasks.FormatTest do
       File.write!(".formatter.exs", """
       [
         inputs: ["a.ex"],
-        plugins: [SigilWPlugin],
+        plugins: [{SigilWPlugin, custom_opts: true}],
         from_formatter_exs: :yes
       ]
       """)
@@ -247,6 +248,7 @@ defmodule Mix.Tasks.FormatTest do
 
     def features(opts) do
       assert opts[:from_formatter_exs] == :yes
+      assert opts[:custom_opts] == true
       [extensions: ~w(.w)]
     end
 
@@ -262,7 +264,7 @@ defmodule Mix.Tasks.FormatTest do
       File.write!(".formatter.exs", """
       [
         inputs: ["a.w"],
-        plugins: [ExtensionWPlugin],
+        plugins: [{ExtensionWPlugin, [custom_opts: true]}],
         from_formatter_exs: :yes
       ]
       """)


### PR DESCRIPTION
This allows libraries to provide formatter plugins whilst
allowing the user to configure them:

E.g. `plugins: [{CssPlugin, extensions: [".css", ".scss"]}]`.

It is up to the plugin if it supports any custom configuration.