### PR TITLE
Have `mix xref --label compile-connected` ignore compile-time dependency chains

### DIFF
--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -762,11 +762,16 @@ defmodule Mix.Tasks.Xref do
 
   defp filter_fn(file_references, :compile_connected),
     do: fn {key, type} ->
-      type == :compile and match?([_ | _], file_references[key] || [])
+      type == :compile and has_non_compile_time_dependencies?(file_references[key])
     end
 
   defp filter_fn(_file_references, filter),
     do: fn {_key, type} -> type == filter end
+
+  defp has_non_compile_time_dependencies?(nil), do: false
+
+  defp has_non_compile_time_dependencies?(reference_list),
+    do: Enum.any?(reference_list, fn {_key, type} -> type != :compile end)
 
   defp filter(file_references, :all), do: file_references
 

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -514,6 +514,24 @@ defmodule Mix.Tasks.XrefTest do
       """)
     end
 
+    @abcd_compile_time_files %{
+      "lib/a.ex" => "B.b()\ndefmodule A, do: def a, do: 42",
+      "lib/b.ex" => "C.c()\ndefmodule B, do: def b, do: 42",
+      "lib/c.ex" => "defmodule C, do: def c, do: D.d()",
+      "lib/d.ex" => "defmodule D, do: def d, do: false"
+    }
+
+    test "filter by compile-connected label excludes chained compile-time dependencies" do
+      assert_graph(
+        ~w[--label compile-connected],
+        """
+        lib/b.ex
+        `-- lib/c.ex (compile)
+        """,
+        files: @abcd_compile_time_files
+      )
+    end
+
     test "filter by compile-connected label with exclusions" do
       assert_graph(~w[--label compile-connected --exclude lib/e.ex], """
       lib/a.ex


### PR DESCRIPTION
This way, only compile-time dependencies that lead to additional
transitive dependencies (i.e. via non-compile-time dependencies) are shown.