### PR TITLE
Allow Application.compile_env* to accept attributes

### DIFF
--- a/lib/elixir/lib/application.ex
+++ b/lib/elixir/lib/application.ex
@@ -506,7 +506,7 @@ defmodule Application do
   """
   @doc since: "1.10.0"
   @spec compile_env(app, key | list, value) :: value
-  defmacro compile_env(app, key_or_path, default \\ nil) when is_atom(app) do
+  defmacro compile_env(app, key_or_path, default \\ nil) do
     if __CALLER__.function do
       raise "Application.compile_env/3 cannot be called inside functions, only in the module body"
     end
@@ -543,7 +543,7 @@ defmodule Application do
   """
   @doc since: "1.10.0"
   @spec compile_env!(app, key | list) :: value
-  defmacro compile_env!(app, key_or_path) when is_atom(app) do
+  defmacro compile_env!(app, key_or_path) do
     if __CALLER__.function do
       raise "Application.compile_env!/2 cannot be called inside functions, only in the module body"
     end

--- a/lib/elixir/test/elixir/application_test.exs
+++ b/lib/elixir/test/elixir/application_test.exs
@@ -6,6 +6,8 @@ defmodule ApplicationTest do
   import PathHelpers
   import ExUnit.CaptureIO
 
+  @app :elixir
+
   test "application environment" do
     assert_raise ArgumentError, ~r/because the application was not loaded nor configured/, fn ->
       Application.fetch_env!(:unknown, :unknown)
@@ -75,12 +77,14 @@ defmodule ApplicationTest do
 
       assert Application.put_env(:elixir, :unknown, nested: [key: :value]) == :ok
 
+      assert compile_env(@app, :unknown, :default) == [nested: [key: :value]]
       assert compile_env(:elixir, :unknown, :default) == [nested: [key: :value]]
       assert_received {:compile_env, :elixir, [:unknown], {:ok, [nested: [key: :value]]}}
 
       assert compile_env(:elixir, :unknown) == [nested: [key: :value]]
       assert_received {:compile_env, :elixir, [:unknown], {:ok, [nested: [key: :value]]}}
 
+      assert compile_env!(@app, :unknown) == [nested: [key: :value]]
       assert compile_env!(:elixir, :unknown) == [nested: [key: :value]]
       assert_received {:compile_env, :elixir, [:unknown], {:ok, [nested: [key: :value]]}}
 

--- a/lib/mix/test/mix/tasks/archive_test.exs
+++ b/lib/mix/test/mix/tasks/archive_test.exs
@@ -149,9 +149,6 @@ defmodule Mix.Tasks.ArchiveTest do
       true = Application.compile_env!(:git_repo, :archive_config)
 
       defmodule GitRepo.Archive do
-        @app :git_repo
-        true = Application.compile_env!(@app, :archive_config)
-
         def hello do
           "World"
         end

--- a/lib/mix/test/mix/tasks/archive_test.exs
+++ b/lib/mix/test/mix/tasks/archive_test.exs
@@ -149,6 +149,9 @@ defmodule Mix.Tasks.ArchiveTest do
       true = Application.compile_env!(:git_repo, :archive_config)
 
       defmodule GitRepo.Archive do
+        @app :git_repo
+        true = Application.compile_env!(@app, :archive_config)
+
         def hello do
           "World"
         end


### PR DESCRIPTION
In Elixir v1.12.0 it is giving the following error
when calling `Application.compile_env(@app, :key)`

    ** (FunctionClauseError) no function clause matching in Application."MACRO-compile_env"/4