### PR TITLE
Remsh: stop IEx.Evaluator before exit IEx.Server

### DIFF
--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -239,12 +239,13 @@ defmodule IEx.Server do
   defp handle_take_over(
          {:EXIT, pid, reason},
          state,
-         _evaluator,
-         _evaluator_ref,
+         evaluator,
+         evaluator_ref,
          _input,
          callback
        ) do
     if pid == Process.group_leader() do
+      stop_evaluator(evaluator, evaluator_ref)
       exit(reason)
     else
       callback.(state)


### PR DESCRIPTION
Stopping evaluator before exit IEx.Server seems to be fixing the issue https://github.com/elixir-lang/elixir/issues/11385
However, I might be missing some other use cases.