### PR TITLE
Add the option of using a custom delimiter for EEx tags

### DIFF
--- a/lib/eex/lib/eex.ex
+++ b/lib/eex/lib/eex.ex
@@ -48,6 +48,7 @@ defmodule EEx do
     * `:trim` - if `true`, trims whitespace left and right of quotation as
       long as at least one newline is present. All subsequent newlines and
       spaces are removed but one newline is retained. Defaults to `false`.
+    * `:delimiter` - a character to be used instead of `%` for delimiting EEx tags.
     * `:parser_options` - (since: 1.13.0) allow customizing the parsed code that is generated.
       See `Code.string_to_quoted/2` for available options. Note that the options
       `:file`, `:line` and `:column` are ignored if passed in.
@@ -91,6 +92,13 @@ defmodule EEx do
 
   Note that different engines may have different rules
   for each tag. Other tags may be added in future versions.
+
+  The `:delimiter` option allows you to use an alternative character
+  for delimiting tags, so that for example setting it to `?$` allows
+  you to write tags in the following fashion:
+
+      <$ Elixir expression $>
+      <$$ EEx quotation $>
 
   ### Macros
 

--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -16,8 +16,9 @@ defmodule EEx.Compiler do
     column = 1
     indentation = opts[:indentation] || 0
     trim = opts[:trim] || false
+    delimiter = opts[:delimiter] || ?%
     parser_options = opts[:parser_options] || Code.get_compiler_option(:parser_options)
-    tokenizer_options = %{trim: trim, indentation: indentation}
+    tokenizer_options = %{trim: trim, indentation: indentation, delimiter: delimiter}
 
     case EEx.Tokenizer.tokenize(source, line, column, tokenizer_options) do
       {:ok, tokens} ->

--- a/lib/eex/lib/eex/engine.ex
+++ b/lib/eex/lib/eex/engine.ex
@@ -208,8 +208,7 @@ defmodule EEx.Engine do
   end
 
   def handle_expr(_state, marker, _ast) when marker in ["/", "|"] do
-    raise EEx.SyntaxError,
-          "unsupported EEx syntax <%#{marker} %> (the syntax is valid but not supported by the current EEx engine)"
+    :error_unsupported_marker
   end
 
   defp check_state!(%{binary: _, dynamic: _, vars_count: _}), do: :ok

--- a/lib/eex/test/eex/tokenizer_test.exs
+++ b/lib/eex/test/eex/tokenizer_test.exs
@@ -4,7 +4,7 @@ defmodule EEx.TokenizerTest do
   use ExUnit.Case, async: true
   require EEx.Tokenizer, as: T
 
-  @opts %{indentation: 0, trim: false}
+  @opts %{indentation: 0, trim: false, delimiter: ?%}
 
   test "simple chars lists" do
     assert T.tokenize('foo', 1, 1, @opts) == {:ok, [{:text, 1, 1, 'foo'}, {:eof, 1, 4}]}

--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -742,6 +742,22 @@ defmodule EExTest do
     end
   end
 
+  describe "custom delimiter" do
+    test "evaluates simple string" do
+      assert_eval("foo replaced", "foo <$= bar $>", [bar: "replaced"], delimiter: ?$)
+    end
+
+    test "quotation works with duplicated custom delimiter" do
+      assert_eval("foo <$= bar $>", "foo <$$= bar $>", [bar: "replaced"], delimiter: ?$)
+    end
+
+    test "error messages show the correct delimiter" do
+      assert_raise EEx.SyntaxError, "nofile:99:12: missing token '$>'", fn ->
+        EEx.compile_string("foo <$= bar", line: 99, delimiter: ?$)
+      end
+    end
+  end
+
   defp assert_eval(expected, actual, binding \\ [], opts \\ []) do
     opts = Keyword.merge([file: __ENV__.file, engine: opts[:engine] || EEx.Engine], opts)
     result = EEx.eval_string(actual, binding, opts)

--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -755,6 +755,13 @@ defmodule EExTest do
       assert_raise EEx.SyntaxError, "nofile:99:12: missing token '$>'", fn ->
         EEx.compile_string("foo <$= bar", line: 99, delimiter: ?$)
       end
+
+      msg =
+        ~r/unsupported EEx syntax <\$\/ \$> \(the syntax is valid but not supported by the current EEx engine\)/
+
+      assert_raise EEx.SyntaxError, msg, fn ->
+        EEx.compile_string("<$/ true $>", delimiter: ?$)
+      end
     end
   end
 


### PR DESCRIPTION
I have a use case where it would be very convenient to be able to customize at least to a certain extent the delimiting characters for EEx tags. So that, for example:

```elixir

iex> EEx.eval_string("foo <$= bar $>", [bar: "baz"], delimiter: ?$)
"foo baz"

iex> EEx.eval_string("<%= foo %> <$= bar $>", [bar: "baz"], delimiter: ?$)
"<%= foo %> baz"
```

I realized that the specific characters in the `<% %>` syntax are hardcoded in EEx's tokenizer, so I decided to try to change it to add this customization option; hence this PR.

Changing the tokenizer's code was simple and clean enough. The more involved part was actually to ensure that the error messages are consistent with the customized delimiter.