### PR TITLE
Add note to `Task.Supervisor.children/1`

### DIFF
--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -370,7 +370,11 @@ defmodule Task.Supervisor do
   end
 
   @doc """
-  Returns all children PIDs.
+  Returns all children PIDs except those that are restarting.
+
+  Note that calling this function when supervising a large number
+  of children under low memory conditions can cause an out of memory
+  exception.
   """
   @spec children(Supervisor.supervisor()) :: [pid]
   def children(supervisor) do


### PR DESCRIPTION
Clarify that `Task.Supervisor.children/1` ignores children that are restarting.

Plus note about calling the function under low memory condition, (same that applies to `DynamicSupervisor.which_children/1`)