### PR TITLE
Fix normalizer not preserving user choice on module attribute lists

### DIFF
--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -197,6 +197,18 @@ defmodule Code.Normalizer do
     end
   end
 
+  # Module attributes
+  defp do_normalize({:@, meta, [{name, name_meta, [value]}]}, state) do
+    value =
+      if is_list(value) do
+        normalize_kw_args(value, state, false)
+      else
+        do_normalize(value, state)
+      end
+
+    {:@, meta, [{name, name_meta, [value]}]}
+  end
+
   # Calls
   defp do_normalize({_, _, args} = quoted, state) when is_list(args) do
     normalize_call(quoted, state)

--- a/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
@@ -352,6 +352,18 @@ defmodule Code.Normalizer.FormatterASTTest do
       assert_same ~S"{:wrapped, 1, [opt1: true, opt2: false]}"
       assert_same ~S"{:unwrapped, 1, opt1: true, opt2: false}"
     end
+
+    test "on module attribute" do
+      assert_same ~S"""
+      @foo a: b,
+           c: d
+      """
+
+      assert_same ~S"@foo [
+        a: b,
+        c: d
+      ]"
+    end
   end
 
   describe "preserves user choice on parenthesis" do


### PR DESCRIPTION
This fixes #11393 

It turns out this was another normalizer bug.

The AST for a module attribute is
```elixir
{:@, attr_meta, [
  {:name, name_meta, [value]}
]}
```
`value` here is any quoted expression.

This was handled as 2 nested calls: one pass for `:@` and one for `:name`. The second pass for `:name` won't know that it's part of a module attribute definition, so it will be handled as a function call. The formatter removes brackets whenever possible on function call, which caused the bug.

I figured adding a new clause would be more predictable than adding more fields to the `state` that we then need to clean up.