### PR TITLE
Improve user experience when there is a faulty Inspect implementation

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -389,6 +389,23 @@ defimpl Inspect, for: Function do
   end
 end
 
+defimpl Inspect, for: Inspect.Error do
+  def inspect(%{stacktrace: stacktrace} = inspect_error, _opts) when is_list(stacktrace) do
+    message =
+      "#Inspect.Error<\n" <>
+        "  #{String.trim_trailing(Exception.message(inspect_error), " \n")}\n"
+
+    if stacktrace == [] do
+      message
+    else
+      message <>
+        "  Stacktrace:\n" <>
+        "#{String.trim_trailing(Exception.format_stacktrace(stacktrace), "\n")}\n" <>
+        ">"
+    end
+  end
+end
+
 defimpl Inspect, for: PID do
   def inspect(pid, _opts) do
     "#PID" <> IO.iodata_to_binary(:erlang.pid_to_list(pid))

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -347,24 +347,18 @@ defmodule Inspect.Algebra do
             try do
               Process.put(:inspect_trap, true)
 
-              error_exception =
+              inspect_error =
                 Inspect.Error.exception(
                   exception: caught_exception,
-                  inspect_opts: opts,
                   stacktrace: __STACKTRACE__,
                   struct: struct
                 )
 
               if opts.safe do
                 opts = %{opts | inspect_fun: Inspect.Opts.default_inspect_fun()}
-                Inspect.inspect(error_exception, opts)
+                Inspect.inspect(inspect_error, opts)
               else
-                attributes =
-                  error_exception
-                  |> Map.drop([:__struct__, :__exception__])
-                  |> Map.to_list()
-
-                reraise(Inspect.Error, attributes, __STACKTRACE__)
+                reraise(inspect_error, __STACKTRACE__)
               end
             after
               Process.delete(:inspect_trap)

--- a/lib/elixir/lib/inspect/utils.ex
+++ b/lib/elixir/lib/inspect/utils.ex
@@ -1,0 +1,18 @@
+defmodule Inspect.Utils do
+  @moduledoc false
+
+  def pad(message, padding_length)
+      when is_binary(message) and is_integer(padding_length) and padding_length >= 0 do
+    padding = String.duplicate(" ", padding_length)
+
+    message
+    |> String.replace("\\n", "\n")
+    |> String.split("\n")
+    |> Enum.map(fn
+      "" -> ""
+      line -> padding <> line
+    end)
+    |> Enum.join("\n")
+    |> String.trim_trailing("\n")
+  end
+end

--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -177,6 +177,7 @@ bootstrap_files() ->
      <<"lib/elixir/lib/stream/reducers.ex">>,
      <<"lib/elixir/lib/enum.ex">>,
      <<"lib/elixir/lib/regex.ex">>,
+     <<"lib/elixir/lib/inspect/utils.ex">>,
      <<"lib/elixir/lib/inspect/algebra.ex">>,
      <<"lib/elixir/lib/inspect.ex">>,
      <<"lib/elixir/lib/string.ex">>,

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -1,5 +1,28 @@
 Code.require_file("test_helper.exs", __DIR__)
 
+defmodule InspectHelpers do
+  defmacro catch_failing_warning(expression) do
+    quote do
+      output =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          unquote(expression)
+        end)
+
+      assert output =~ ~r/(\e\[33m)?warning: (\e\[0m)?error when trying to inspect struct; /
+
+      output
+    end
+  end
+
+  defmacro test_with_failing_warning(test_name, do: expression) do
+    quote bind_quoted: [test_name: test_name, expression: Macro.escape(expression)] do
+      test test_name do
+        catch_failing_warning(unquote(expression))
+      end
+    end
+  end
+end
+
 defmodule Inspect.AtomTest do
   use ExUnit.Case, async: true
 
@@ -390,6 +413,7 @@ defmodule Inspect.ListTest do
 end
 
 defmodule Inspect.MapTest do
+  import InspectHelpers
   use ExUnit.Case, async: true
 
   test "basic" do
@@ -434,48 +458,126 @@ defmodule Inspect.MapTest do
   end
 
   defmodule Failing do
-    defstruct key: 0
+    @enforce_keys [:name]
+    defstruct @enforce_keys
 
     defimpl Inspect do
-      def inspect(struct, _) do
-        struct.unknown
+      def inspect(%Failing{name: name}, _) do
+        Atom.to_string(name)
       end
     end
   end
 
-  test "bad implementation unsafe" do
-    msg =
-      "got KeyError with message \"key :unknown not found in: " <>
-        "%{__struct__: Inspect.MapTest.Failing, key: 0}\" while " <>
-        "inspecting %{__struct__: Inspect.MapTest.Failing, key: 0}"
+  test_with_failing_warning "safely inspect bad implementation" do
+    message =
+      "got ArgumentError with message \"errors were found at the given arguments:\\n\\n" <>
+        "  * 1st argument: not an atom\\n\" while inspecting " <>
+        "%{__struct__: Inspect.MapTest.Failing, name: \"Foo\"}"
+
+    inspected = inspect(%Inspect.Error{message: "#{message}"})
+    assert inspect(%Failing{name: "Foo"}) == inspected
+    assert inspect(%Failing{name: "Foo"}, safe: true) == inspected
+  end
+
+  test_with_failing_warning "safely inspect bad implementation disables colors" do
+    catch_failing_warning do
+      msg =
+        "got ArgumentError with message \\\"errors were found at the given arguments:\\\\n\\\\n" <>
+          "  * 1st argument: not an atom\\\\n\\\" while inspecting " <>
+          "%{__struct__: Inspect.MapTest.Failing, name: \\\"Foo\\\"}"
+
+      assert inspect(%Failing{name: "Foo"}, syntax_colors: [atom: [:green]]) =~ msg
+    end
+  end
+
+  test "unsafely inspect bad implementation" do
+    exception_message =
+      "got ArgumentError with message \"errors were found at the given arguments:\\n\\n" <>
+        "  * 1st argument: not an atom\\n\" while inspecting " <>
+        "%{__struct__: Inspect.MapTest.Failing, name: \"Foo\"}"
 
     try do
-      inspect(%Failing{}, safe: false)
+      inspect(%Failing{name: "Foo"}, safe: false)
     rescue
-      e in Inspect.Error ->
-        assert Exception.message(e) =~ msg
-        assert [{Inspect.Inspect.MapTest.Failing, :inspect, 2, _} | _] = __STACKTRACE__
+      exception in Inspect.Error ->
+        assert Exception.message(exception) =~ exception_message
+
+        assert [
+                 {:erlang, :atom_to_binary, ["Foo", :utf8],
+                  [error_info: %{module: :erl_erts_errors}]},
+                 {Inspect.Inspect.MapTest.Failing, :inspect, 2, _},
+                 {Inspect.Algebra, :to_doc, 2, _} | _
+               ] = __STACKTRACE__
+
+        assert Exception.message(exception) =~ exception_message
     else
       _ -> flunk("expected failure")
     end
   end
 
-  test "bad implementation safe" do
-    msg =
-      "got KeyError with message \"key :unknown not found in: " <>
-        "%{__struct__: Inspect.MapTest.Failing, key: 0}\" while " <>
-        "inspecting %{__struct__: Inspect.MapTest.Failing, key: 0}"
+  test "raise when trying to inspect with a bad implementation from inside another exception that is being raised" do
+    # Inspect.Error is raises when we tried to print the error message
+    # called by another exception (Protocol.UndefinedError in this case)
 
-    assert inspect(%Failing{}) == inspect(%Inspect.Error{message: "#{msg}"})
+    exception_message =
+      "protocol Enumerable not implemented for " <>
+        "%Inspect.Error{message: " <>
+        "\"got ArgumentError with message \\\"errors were found at the given arguments:\\\\n\\\\n" <>
+        "  * 1st argument: not an atom\\\\n\\\" while inspecting " <>
+        "%{__struct__: Inspect.MapTest.Failing, name: \\\"Foo\\\"}\"} of type Inspect.MapTest.Failing (a struct)"
+
+    output =
+      catch_failing_warning do
+        try do
+          Enum.to_list(%Failing{name: "Foo"})
+        rescue
+          exception in Protocol.UndefinedError ->
+            catch_failing_warning do
+              assert Exception.message(exception) == exception_message
+            end
+
+            assert [
+                     {Enumerable, :impl_for!, 1, _} | _
+                   ] = __STACKTRACE__
+
+            # The culprit
+            assert Enum.any?(__STACKTRACE__, fn
+                     {Enum, :to_list, 1, _} -> true
+                     _ -> false
+                   end)
+
+            # The line calling the culprit
+            assert Enum.any?(__STACKTRACE__, fn
+                     {Inspect.MapTest, _test_name, 1,
+                      [file: 'test/elixir/inspect_test.exs', line: _line_number]} ->
+                       true
+
+                     _ ->
+                       false
+                   end)
+        else
+          _ -> flunk("expected failure")
+        end
+      end
+
+    stacktrace_message =
+      "got ArgumentError with message \"errors were found at the given arguments:\\n\\n" <>
+        "  * 1st argument: not an atom\\n\" while inspecting " <>
+        "%{__struct__: Inspect.MapTest.Failing, name: \"Foo\"}"
+
+    assert output =~
+             "\e[33mwarning: \e[0merror when trying to inspect struct; " <> stacktrace_message
   end
 
-  test "bad implementation safe disables colors" do
-    msg =
-      "got KeyError with message \\\"key :unknown not found in: " <>
-        "%{__struct__: Inspect.MapTest.Failing, key: 0}\\\" while " <>
-        "inspecting %{__struct__: Inspect.MapTest.Failing, key: 0}"
+  test_with_failing_warning "Exception.message/1 with bad implementation" do
+    message =
+      "got ArgumentError with message \"errors were found at the given arguments:\\n\\n" <>
+        "  * 1st argument: not an atom\\n\" while inspecting " <>
+        "%{__struct__: Inspect.MapTest.Failing, name: \"Foo\"}"
 
-    assert inspect(%Failing{}, syntax_colors: [atom: [:green]]) =~ msg
+    inspected = inspect(%Inspect.Error{message: "#{message}"})
+    assert inspect(%Failing{name: "Foo"}) == inspected
+    assert inspect(%Failing{name: "Foo"}, safe: true) == inspected
   end
 
   test "exception" do
@@ -717,6 +819,7 @@ defmodule Inspect.OthersTest do
 end
 
 defmodule Inspect.CustomProtocolTest do
+  import InspectHelpers
   use ExUnit.Case, async: true
 
   defprotocol CustomInspect do
@@ -727,7 +830,7 @@ defmodule Inspect.CustomProtocolTest do
     defstruct []
   end
 
-  test "missing implementation unsafe" do
+  test "unsafely inspect missing implementation" do
     msg =
       "got Protocol.UndefinedError with message \"protocol " <>
         "Inspect.CustomProtocolTest.CustomInspect not implemented " <>
@@ -748,7 +851,7 @@ defmodule Inspect.CustomProtocolTest do
     end
   end
 
-  test "missing implementation safe" do
+  test_with_failing_warning "safely inspect missing implementation" do
     msg =
       "got Protocol.UndefinedError with message \"protocol " <>
         "Inspect.CustomProtocolTest.CustomInspect not implemented " <>
@@ -758,6 +861,21 @@ defmodule Inspect.CustomProtocolTest do
         "Inspect.CustomProtocolTest.MissingImplementation}"
 
     opts = [inspect_fun: &CustomInspect.inspect/2]
+
+    assert inspect(%MissingImplementation{}, opts) ==
+             inspect(%Inspect.Error{message: "#{msg}"})
+  end
+
+  test_with_failing_warning "faulty implementation" do
+    msg =
+      "got Protocol.UndefinedError with message \"protocol " <>
+        "Inspect.CustomProtocolTest.CustomInspect not implemented " <>
+        "for %Inspect.CustomProtocolTest.MissingImplementation{} of " <>
+        "type Inspect.CustomProtocolTest.MissingImplementation " <>
+        "(a struct)\" while inspecting %{__struct__: " <>
+        "Inspect.CustomProtocolTest.MissingImplementation}"
+
+    opts = [safe: true, inspect_fun: &CustomInspect.inspect/2]
 
     assert inspect(%MissingImplementation{}, opts) ==
              inspect(%Inspect.Error{message: "#{msg}"})

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -445,14 +445,17 @@ defmodule ExUnit.FormatterTest do
   test "inspect failure" do
     failure = [{:error, catch_assertion(assert :will_fail == %BadInspect{}), []}]
 
-    message =
-      "  got FunctionClauseError with message:\n\n" <>
-        "    \"\"\"\n" <>
-        "    no function clause matching in Inspect.ExUnit.FormatterTest.BadInspect.inspect/2\n" <>
-        "    \"\"\"\n\n" <>
-        "  while inspecting:\n" <>
-        "    %{__struct__: ExUnit.FormatterTest.BadInspect, key: 0}\n\n" <>
-        "  Stacktrace:"
+    message = ~S'''
+      got FunctionClauseError with message:
+
+          """
+          no function clause matching in Inspect.ExUnit.FormatterTest.BadInspect.inspect/2
+          """
+
+        while inspecting:
+          %{__struct__: ExUnit.FormatterTest.BadInspect, key: 0}
+      Stacktrace:
+    '''
 
     assert format_test_failure(test(), failure, 1, 80, &formatter/2) =~ """
              1) world (Hello)
@@ -460,7 +463,7 @@ defmodule ExUnit.FormatterTest do
                 Assertion with == failed
                 code:  assert :will_fail == %BadInspect{}
                 left:  :will_fail
-                right: #Inspect.Error<\n#{message}\n\
+                right: #Inspect.Error<\n#{message}\
            """
   end
 

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -459,8 +459,8 @@ defmodule ExUnit.FormatterTest do
                     code:  assert :will_fail == %BadInspect{}
                     left:  :will_fail
                     right: %Inspect.Error{
-                             message: #{inspect(message)}
-                           }
+                             message: #{inspect(message)},
+                             stacktrace: [
                """
       end)
 

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -446,25 +446,22 @@ defmodule ExUnit.FormatterTest do
     failure = [{:error, catch_assertion(assert :will_fail == %BadInspect{}), []}]
 
     message =
-      "got FunctionClauseError with message \"no function clause matching " <>
-        "in Inspect.ExUnit.FormatterTest.BadInspect.inspect/2\" while inspecting " <>
-        "%{__struct__: ExUnit.FormatterTest.BadInspect, key: 0}"
+      "  got FunctionClauseError with message:\n\n" <>
+        "    \"\"\"\n" <>
+        "    no function clause matching in Inspect.ExUnit.FormatterTest.BadInspect.inspect/2\n" <>
+        "    \"\"\"\n\n" <>
+        "  while inspecting:\n" <>
+        "    %{__struct__: ExUnit.FormatterTest.BadInspect, key: 0}\n\n" <>
+        "  Stacktrace:"
 
-    output =
-      ExUnit.CaptureIO.capture_io(:stderr, fn ->
-        assert format_test_failure(test(), failure, 1, 80, &formatter/2) =~ """
-                 1) world (Hello)
-                    test/ex_unit/formatter_test.exs:1
-                    Assertion with == failed
-                    code:  assert :will_fail == %BadInspect{}
-                    left:  :will_fail
-                    right: %Inspect.Error{
-                             message: #{inspect(message)},
-                             stacktrace: [
-               """
-      end)
-
-    assert output =~ "\e[33mwarning: \e[0merror when trying to inspect struct; "
+    assert format_test_failure(test(), failure, 1, 80, &formatter/2) =~ """
+             1) world (Hello)
+                test/ex_unit/formatter_test.exs:1
+                Assertion with == failed
+                code:  assert :will_fail == %BadInspect{}
+                left:  :will_fail
+                right: #Inspect.Error<\n#{message}\n\
+           """
   end
 
   defmodule BadMessage do

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -450,16 +450,21 @@ defmodule ExUnit.FormatterTest do
         "in Inspect.ExUnit.FormatterTest.BadInspect.inspect/2\" while inspecting " <>
         "%{__struct__: ExUnit.FormatterTest.BadInspect, key: 0}"
 
-    assert format_test_failure(test(), failure, 1, 80, &formatter/2) =~ """
-             1) world (Hello)
-                test/ex_unit/formatter_test.exs:1
-                Assertion with == failed
-                code:  assert :will_fail == %BadInspect{}
-                left:  :will_fail
-                right: %Inspect.Error{
-                         message: #{inspect(message)}
-                       }
-           """
+    output =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        assert format_test_failure(test(), failure, 1, 80, &formatter/2) =~ """
+                 1) world (Hello)
+                    test/ex_unit/formatter_test.exs:1
+                    Assertion with == failed
+                    code:  assert :will_fail == %BadInspect{}
+                    left:  :will_fail
+                    right: %Inspect.Error{
+                             message: #{inspect(message)}
+                           }
+               """
+      end)
+
+    assert output =~ "\e[33mwarning: \e[0merror when trying to inspect struct; "
   end
 
   defmodule BadMessage do


### PR DESCRIPTION
When a faulty implementation of the Inspect protocol is used,
the user is returned an `Inspect.Error` struct when the user tries to inspect it,
also IEx prints `Inspect.Error` upon inspection or when a struct with a fault inspect is returned.

This is the default behaviour in Elixir, because it uses the :safe  option in Inspect.Opts is to true by default.
Since Kernel.inspect/2 will return a string, an no warning is emitted, it is very likely that an error like this can go unnoticed.


This PR tries to make it as clear as possible for the user, by introducing the :stacktrace field in the Inspect.Error exception,
and by emitting a runtime warning.

Given the following faulty implementation:

```elixir
defmodule Failing do
  @enforce_keys [:name]
  defstruct @enforce_keys

  defimpl Inspect do
    def inspect(%Failing{name: name}, _) do
      Atom.to_string(name)
    end
  end
end
```


These are the examples of how it behaved before and how it does with this PR.

## Case 1) Evaluate the struct in IEx

Elixir v1.13.0-rc.1 will return:

```elixir
iex(1)> struct = %Failing{name: "Foo"}
%Inspect.Error{
  message: "got ArgumentError with message \"errors were found at the given arguments:\\n\\n  * 1st argument: not an atom\\n\" while inspecting %{__struct__: Failing, name: \"Foo\"}"
}
```

While with this PR, it will warn and return a stacktrace along with the warning and the returned `Inspect.Error` struct

```elixir
iex(1)> struct = %Failing{name: "Foo"}
warning: error when trying to inspect struct; got ArgumentError with message "errors were found at the given arguments:\n\n  * 1st argument: not an atom\n" while inspecting %{__struct__: Failing, name: "Foo"}
  :erlang.atom_to_binary("Foo", :utf8)
  (debug_inspect_error_bug 0.1.0) lib/failing.ex:7: Inspect.Failing.inspect/2
  (elixir 1.14.0-dev) lib/inspect/algebra.ex:344: Inspect.Algebra.to_doc/2
  (elixir 1.14.0-dev) lib/kernel.ex:2246: Kernel.inspect/2
  (iex 1.14.0-dev) lib/iex/evaluator.ex:336: IEx.Evaluator.io_inspect/1
  (iex 1.14.0-dev) lib/iex/evaluator.ex:313: IEx.Evaluator.handle_eval/3
  (iex 1.14.0-dev) lib/iex/evaluator.ex:285: IEx.Evaluator.do_eval/3
  (iex 1.14.0-dev) lib/iex/evaluator.ex:274: IEx.Evaluator.eval/3

%Inspect.Error{
  message: "got ArgumentError with message \"errors were found at the given arguments:\\n\\n  * 1st argument: not an atom\\n\" while inspecting %{__struct__: Failing, name: \"Foo\"}",
  stacktrace: [
    {:erlang, :atom_to_binary, ["Foo", :utf8],
     [error_info: %{module: :erl_erts_errors}]},
    {Inspect.Failing, :inspect, 2, [file: 'lib/failing.ex', line: 7]},
    {Inspect.Algebra, :to_doc, 2, [file: 'lib/inspect/algebra.ex', line: 344]},
    {Kernel, :inspect, 2, [file: 'lib/kernel.ex', line: 2246]},
    {IEx.Evaluator, :io_inspect, 1, [file: 'lib/iex/evaluator.ex', line: 336]},
    {IEx.Evaluator, :handle_eval, 3, [file: 'lib/iex/evaluator.ex', line: 313]},
    {IEx.Evaluator, :do_eval, 3, [file: 'lib/iex/evaluator.ex', line: 285]},
    {IEx.Evaluator, :eval, 3, [file: 'lib/iex/evaluator.ex', line: 274]}
  ]
}
```

## Case 2) Inspect the struct with Kernel.inspect/2

The same happens if you safely inspect the struct

Elixir v1.13.0-rc.1:

```elixir
iex(2)> inspect(struct)
"%Inspect.Error{message: \"got ArgumentError with message \\\"errors were found at the given arguments:\\\\n\\\\n  * 1st argument: not an atom\\\\n\\\" while inspecting %{__struct__: Failing, name: \\\"Foo\\\"}\"}"
```

With this PR, it will warn and return a string with the stacktrace included.

```elixir
iex(2)> inspect(struct)
warning: error when trying to inspect struct; got ArgumentError with message "errors were found at the given arguments:\n\n  * 1st argument: not an atom\n" while inspecting %{__struct__: Failing, name: "Foo"}
  :erlang.atom_to_binary("Foo", :utf8)
  (debug_inspect_error_bug 0.1.0) lib/failing.ex:7: Inspect.Failing.inspect/2
  (elixir 1.14.0-dev) lib/inspect/algebra.ex:344: Inspect.Algebra.to_doc/2
  (elixir 1.14.0-dev) lib/kernel.ex:2246: Kernel.inspect/2
  (stdlib 3.16.1) erl_eval.erl:685: :erl_eval.do_apply/6
  (elixir 1.14.0-dev) src/elixir.erl:289: :elixir.recur_eval/3
  (elixir 1.14.0-dev) src/elixir.erl:274: :elixir.eval_forms/3
  (iex 1.14.0-dev) lib/iex/evaluator.ex:310: IEx.Evaluator.handle_eval/3

"%Inspect.Error{message: \"got ArgumentError with message \\\"errors were found at the given arguments:\\\\n\\\\n  * 1st argument: not an atom\\\\n\\\" while inspecting %{__struct__: Failing, name: \\\"Foo\\\"}\", stacktrace: [{:erlang, :atom_to_binary, [\"Foo\", :utf8], [error_info: %{module: :erl_erts_errors}]}, {Inspect.Failing, :inspect, 2, [file: 'lib/failing.ex', line: 7]}, {Inspect.Algebra, :to_doc, 2, [file: 'lib/inspect/algebra.ex', line: 344]}, {Kernel, :inspect, 2, [file: 'lib/kernel.ex', line: 2246]}, {:erl_eval, :do_apply, 6, [file: 'erl_eval.erl', line: 685]}, {:elixir, :recur_eval, 3, [file: 'src/elixir.erl', line: 289]}, {:elixir, :eval_forms, 3, [file: 'src/elixir.erl', line: 274]}, {IEx.Evaluator, :handle_eval, 3, [file: 'lib/iex/evaluator.ex', line: 310]}]}"
```

## Case 3) Passing a struct as an argument to a function that raises and inspects it in the error message

This is the worst case where the error message is cryptic and misleading.

```elixir
iex(3)> Enum.to_list(%Failing{name: "Foo"})
** (Protocol.UndefinedError) protocol Enumerable not implemented for %Inspect.Error{message: "got ArgumentError with message \"errors were found at the given arguments:\\n\\n  * 1st argument: not an atom\\n\" while inspecting %{__struct__: Failing, name: \"Foo\"}"} of type Failing (a struct). This protocol is implemented for the following type(s): Date.Range, File.Stream, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, List, Map, MapSet, Range, Stream
    (elixir 1.13.0-rc.1) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir 1.13.0-rc.1) lib/enum.ex:143: Enumerable.reduce/3
    (elixir 1.13.0-rc.1) lib/enum.ex:4143: Enum.reverse/1
    (elixir 1.13.0-rc.1) lib/enum.ex:3488: Enum.to_list/1
```

With this PR, a warning is emitted and inside the error message the stacktrace is included, hinting for easier tracing.

```elixir
iex(3)> Enum.to_list(%Failing{name: "Foo"})
warning: error when trying to inspect struct; got ArgumentError with message "errors were found at the given arguments:\n\n  * 1st argument: not an atom\n" while inspecting %{__struct__: Failing, name: "Foo"}
  :erlang.atom_to_binary("Foo", :utf8)
  (debug_inspect_error_bug 0.1.0) lib/failing.ex:7: Inspect.Failing.inspect/2
  (elixir 1.14.0-dev) lib/inspect/algebra.ex:344: Inspect.Algebra.to_doc/2
  (elixir 1.14.0-dev) lib/kernel.ex:2246: Kernel.inspect/2
  (elixir 1.14.0-dev) lib/exception.ex:1267: Protocol.UndefinedError.message/1
  (elixir 1.14.0-dev) lib/exception.ex:66: Exception.message/1
  (elixir 1.14.0-dev) lib/exception.ex:117: Exception.format_banner/3
  (iex 1.14.0-dev) lib/iex/evaluator.ex:357: IEx.Evaluator.print_error/3

** (Protocol.UndefinedError) protocol Enumerable not implemented for %Inspect.Error{message: "got ArgumentError with message \"errors were found at the given arguments:\\n\\n  * 1st argument: not an atom\\n\" while inspecting %{__struct__: Failing, name: \"Foo\"}", stacktrace: [{:erlang, :atom_to_binary, ["Foo", :utf8], [error_info: %{module: :erl_erts_errors}]}, {Inspect.Failing, :inspect, 2, [file: 'lib/failing.ex', line: 7]}, {Inspect.Algebra, :to_doc, 2, [file: 'lib/inspect/algebra.ex', line: 344]}, {Kernel, :inspect, 2, [file: 'lib/kernel.ex', line: 2246]}, {Protocol.UndefinedError, :message, 1, [file: 'lib/exception.ex', line: 1267]}, {Exception, :message, 1, [file: 'lib/exception.ex', line: 66]}, {Exception, :format_banner, 3, [file: 'lib/exception.ex', line: 117]}, {IEx.Evaluator, :print_error, 3, [file: 'lib/iex/evaluator.ex', line: 357]}]} of type Failing (a struct). This protocol is implemented for the following type(s): Date.Range, File.Stream, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, List, Map, MapSet, Range, Stream
    (elixir 1.14.0-dev) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir 1.14.0-dev) lib/enum.ex:143: Enumerable.reduce/3
    (elixir 1.14.0-dev) lib/enum.ex:4143: Enum.reverse/1
    (elixir 1.14.0-dev) lib/enum.ex:3488: Enum.to_list/1
```

## Case 4) No differences when inspecting with :safe option set to false.

Both versions behave the same.

```elixir
** (Inspect.Error) got ArgumentError with message "errors were found at the given arguments:\n\n  * 1st argument: not an atom\n" while inspecting %{__struct__: Failing, name: "Foo"}
    :erlang.atom_to_binary("Foo", :utf8)
    (debug_inspect_error_bug 0.1.0) lib/failing.ex:7: Inspect.Failing.inspect/2
    (elixir 1.13.0-rc.1) lib/inspect/algebra.ex:342: Inspect.Algebra.to_doc/2
    (elixir 1.13.0-rc.1) lib/kernel.ex:2246: Kernel.inspect/2
```

## Drawbacks

1. When returning the string representation of the struct, it could be too verbose with the new stacktrace, but this way it is guaranteed that the use gets all the information to inspect the issue.

2. Warning could be anyoying too verbose, so we could introduce a new option to Inspect.Opts called `:warn`, which defaults to `true'.


## Other concerns

I wonder if, unless the exist, other ways to cheaply test the correct implementation of the inspect protocol.
Currently we either need to try/rescue which is known to be expensive, or pattern match the beginning of the returned string against "%Inspect.Error{".