### PR TITLE
add Registry.count_select/2

### DIFF
--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -1343,7 +1343,7 @@ defmodule Registry do
 
           _ ->
             raise ArgumentError,
-                  "invalid match specification in Registry.select_count/2: #{inspect(spec)}"
+                  "invalid match specification in Registry.count_select/2: #{inspect(spec)}"
         end
       end
 

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -1232,6 +1232,30 @@ defmodule Registry do
     end)
   end
 
+  @doc """
+  Works like `select/2`, but only returns the number of matching records.
+
+  ## Examples
+
+  In the example below we register the current process under different
+  keys in a unique registry but with the same value:
+
+      iex> Registry.start_link(keys: :unique, name: Registry.CountSelectTest)
+      iex> {:ok, _} = Registry.register(Registry.CountSelectTest, "hello", :value)
+      iex> {:ok, _} = Registry.register(Registry.CountSelectTest, "world", :value)
+      iex> Registry.count_select(Registry.CountSelectTest, [{{:_, :_, :value}, [], [true]}])
+      2
+  """
+  @spec count_select(registry, spec) :: non_neg_integer()
+  def count_select(registry, spec)
+      when is_atom(registry) and is_list(spec) do
+    spec = group_match_headers(spec, __ENV__.function)
+
+    count_entries(registry, spec, fn partitions ->
+      count_entries_across_partitions(registry, partitions, spec)
+    end)
+  end
+
   defp count_entries(registry, spec, count_entries_across_unique_partitions_fun) do
     case key_info!(registry) do
       {:unique, partitions, nil} ->
@@ -1243,6 +1267,13 @@ defmodule Registry do
       {:duplicate, partitions, _key_ets} ->
         count_entries_across_partitions(registry, partitions, spec)
     end
+  end
+
+  defp count_entries_across_partitions(registry, partitions, spec) do
+    Enum.reduce(0..(partitions - 1), 0, fn partition_index, acc ->
+      count = :ets.select_count(key_ets!(registry, partition_index), spec)
+      acc + count
+    end)
   end
 
   @doc """
@@ -1308,37 +1339,6 @@ defmodule Registry do
       {_kind, 1, key_ets} ->
         :ets.select(key_ets, spec)
     end
-  end
-
-  @doc """
-  Works like `select/2`, but only returns the number of matching records.
-
-  ## Examples
-
-  In the example below we register the current process under different
-  keys in a unique registry but with the same value:
-
-      iex> Registry.start_link(keys: :unique, name: Registry.CountSelectTest)
-      iex> {:ok, _} = Registry.register(Registry.CountSelectTest, "hello", :value)
-      iex> {:ok, _} = Registry.register(Registry.CountSelectTest, "world", :value)
-      iex> Registry.count_select(Registry.CountSelectTest, [{{:_, :_, :value}, [], [true]}])
-      2
-  """
-  @spec count_select(registry, spec) :: non_neg_integer()
-  def count_select(registry, spec)
-      when is_atom(registry) and is_list(spec) do
-    spec = group_match_headers(spec, __ENV__.function)
-
-    count_entries(registry, spec, fn partitions ->
-      count_entries_across_partitions(registry, partitions, spec)
-    end)
-  end
-
-  defp count_entries_across_partitions(registry, partitions, spec) do
-    Enum.reduce(0..(partitions - 1), 0, fn partition_index, acc ->
-      count = :ets.select_count(key_ets!(registry, partition_index), spec)
-      acc + count
-    end)
   end
 
   defp group_match_headers(spec, {fun, arity}) do

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -371,9 +371,60 @@ defmodule RegistryTest do
                  |> Enum.sort()
       end
 
-      test "raises on incorrect shape of match spec", %{registry: registry} do
+      test "select raises on incorrect shape of match spec", %{registry: registry} do
         assert_raise ArgumentError, fn ->
           Registry.select(registry, [{:_, [], []}])
+        end
+      end
+
+      test "count_select supports match specs", %{registry: registry} do
+        value = {1, :atom, 1}
+        {:ok, _} = Registry.register(registry, "hello", value)
+        assert 1 == Registry.count_select(registry, [{{:_, :_, value}, [], [true]}])
+        assert 1 == Registry.count_select(registry, [{{"hello", :_, :_}, [], [true]}])
+        assert 1 == Registry.count_select(registry, [{{:_, :_, {1, :atom, :_}}, [], [true]}])
+        assert 1 == Registry.count_select(registry, [{{:_, :_, {:"$1", :_, :"$1"}}, [], [true]}])
+        assert 0 == Registry.count_select(registry, [{{"hello", :_, nil}, [], [true]}])
+
+        value2 = %{a: "a", b: "b"}
+        {:ok, _} = Registry.register(registry, "world", value2)
+        assert 1 == Registry.count_select(registry, [{{"world", :_, :_}, [], [true]}])
+      end
+
+      test "count_select supports guard conditions", %{registry: registry} do
+        value = {1, :atom, 2}
+        {:ok, _} = Registry.register(registry, "hello", value)
+
+        assert 1 ==
+                 Registry.count_select(registry, [
+                   {{:_, :_, {:_, :"$1", :_}}, [{:is_atom, :"$1"}], [true]}
+                 ])
+
+        assert 1 ==
+                 Registry.count_select(registry, [
+                   {{:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 1}], [true]}
+                 ])
+
+        assert 0 ==
+                 Registry.count_select(registry, [
+                   {{:_, :_, {:_, :_, :"$1"}}, [{:>, :"$1", 2}], [true]}
+                 ])
+      end
+
+      test "count_select allows multiple specs", %{registry: registry} do
+        {:ok, _} = Registry.register(registry, "hello", :value)
+        {:ok, _} = Registry.register(registry, "world", :value)
+
+        assert 2 ==
+                 Registry.count_select(registry, [
+                   {{"hello", :_, :_}, [], [true]},
+                   {{"world", :_, :_}, [], [true]}
+                 ])
+      end
+
+      test "count_select raises on incorrect shape of match spec", %{registry: registry} do
+        assert_raise ArgumentError, fn ->
+          Registry.count_select(registry, [{:_, [], []}])
         end
       end
 


### PR DESCRIPTION
PR is based on [this proposal](https://groups.google.com/g/elixir-lang-core/c/chazhfKGmOg)

Adds `Registry.count_select/2`

I was doubting if it should accept arbitrary full match spec or only `match_head` and optional `guards` similar to `count_match/4`, considering that the third element of the spec is always `[true]`, we could hide that.

However, by accepting full match spec we enable users to make use of [ex2ms](https://github.com/ericmj/ex2ms)