### PR TITLE
Disable ssa and bool passes

### DIFF
--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -65,7 +65,7 @@ spawned_compile(ExExprs, #{line := Line, file := File} = E) ->
   Fun  = code_fun(?key(E, module)),
   Forms = code_mod(Fun, ErlExprs, Line, File, Module, Vars),
 
-  {Module, Binary} = elixir_erl_compiler:noenv_forms(Forms, File, [nowarn_nomatch]),
+  {Module, Binary} = elixir_erl_compiler:noenv_forms(Forms, File, [nowarn_nomatch, no_bool_opt, no_ssa_opt]),
   code:load_binary(Module, "", Binary),
   {Module, Fun, is_purgeable(Module, Binary)}.
 


### PR DESCRIPTION
Module bodies, especially in tests, tend to be
long, which affects the performance of passes
such as beam_ssa_opt and beam_bool. This commit
disables those passes during module definition.
As an example, this makes loading Elixir's test
suite 7-8% faster.