### PR TITLE
mix release: Allow passing args to "start" command

### DIFF
--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -181,7 +181,7 @@ defmodule Mix.Tasks.Release.Init do
 
     case $1 in
       start)
-        start "elixir" --no-halt
+        start "elixir" --no-halt -- $@
         ;;
 
       start_iex)
@@ -378,7 +378,7 @@ defmodule Mix.Tasks.Release.Init do
       --erl-config "!RELEASE_SYS_CONFIG!" ^
       --boot "!REL_VSN_DIR!\!RELEASE_BOOT_SCRIPT!" ^
       --boot-var RELEASE_LIB "!RELEASE_ROOT!\lib" ^
-      --vm-args "!RELEASE_VM_ARGS!"
+      --vm-args "!RELEASE_VM_ARGS!" -- %*
     goto end
 
     :eval


### PR DESCRIPTION
Say we have this app callback module:

    defmodule Foo.Application do
      @moduledoc false
      use Application

      @impl true
      def start(_type, args) do
        IO.inspect(:init.get_plain_arguments())

        children = []
        opts = [strategy: :one_for_one, name: Foo.Supervisor]
        Supervisor.start_link(children, opts)
      end
    end

Executing

    $ _build/dev/rel/foo/bin/foo start foo bar

Before this patch would print:

    ['--no-halt']

After this patch, we have:

    ['--no-halt', '--', 'start', 'foo', 'bar']

Extracted from burrito-elixir/burrito, thanks @QuinnWilton & @ashea-code!
