### PR TITLE
Fix normalization of kw list in blocks

### DIFF
--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -209,6 +209,11 @@ defmodule Code.Normalizer do
     {:@, meta, [{name, name_meta, [value]}]}
   end
 
+  # Regular blocks
+  defp do_normalize({:__block__, meta, args}, state) when is_list(args) do
+    {:__block__, meta, normalize_args(args, state)}
+  end
+
   # Calls
   defp do_normalize({_, _, args} = quoted, state) when is_list(args) do
     normalize_call(quoted, state)

--- a/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
@@ -554,5 +554,12 @@ defmodule Code.Normalizer.FormatterASTTest do
       end
       """
     end
+
+    test "keyword literals with variable values" do
+      assert_same(~S"""
+      foo = foo()
+      [foo: foo]
+      """)
+    end
   end
 end


### PR DESCRIPTION
Regular blocks were interpreted as a call, so if the last expression in a block was a kw list then the wrapper block would be removed, causing the formatter to crash