### PR TITLE
#11418 Disallow shorthand pipe after matches

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -141,7 +141,7 @@ defmodule IEx do
 
       iex(1)> x = 42
       iex(2)> |> IO.puts()
-      ** (SyntaxError) iex:2:1: pipe shorthand is not allowed immediately after a match expression in IEx; to make it work, surround the whole pipeline with parentheses ('|>')
+      ** (SyntaxError) iex:2:1: pipe shorthand is not allowed immediately after a match expression in IEx. To make it work, surround the whole pipeline with parentheses ('|>')
           |
         2 | |> IO.puts()
           | ^

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -136,6 +136,16 @@ defmodule IEx do
       iex(1)> |> List.flatten()
       ** (RuntimeError) v(-1) is out of bounds
 
+  If the previous expression was a match operation, the pipe operator will also
+  fail, to prevent an unsolicited break of the match:
+
+      iex(1)> x = 42
+      iex(2)> |> IO.puts()
+      ** (SyntaxError) iex:2:1: pipe shorthand is not allowed immediately after a match expression in IEx; to make it work, surround the whole pipeline with parentheses ('|>')
+          |
+        2 | |> IO.puts()
+          | ^
+
   Note however the above does not work for `+/2` and `-/2`, as they
   are ambiguous with the unary `+/1` and `-/1`:
 

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -62,15 +62,15 @@ defmodule IEx.Evaluator do
                [:three_op, :concat_op, :mult_op]
 
   @doc false
-  def parse(input, opts, buffer)
+  def parse(input, opts, parser_state)
 
   def parse(input, opts, ""), do: parse(input, opts, {"", :other})
 
-  def parse(@break_trigger, _opts, {"", last_op}) do
-    {:incomplete, {"", last_op}}
+  def parse(@break_trigger, _opts, {"", _} = parser_state) do
+    {:incomplete, parser_state}
   end
 
-  def parse(@break_trigger, opts, {_buffer, _last_op}) do
+  def parse(@break_trigger, opts, _parser_state) do
     :elixir_errors.parse_error(
       [line: opts[:line]],
       opts[:file],
@@ -243,7 +243,6 @@ defmodule IEx.Evaluator do
       env: env,
       server: server,
       history: history,
-      last_op: :other,
       stacktrace: stacktrace,
       ref: ref
     }
@@ -306,7 +305,7 @@ defmodule IEx.Evaluator do
   defp do_eval({:ok, forms, buffer}, iex_state, state) when is_binary(buffer),
     do: do_eval({:ok, forms, {buffer, :other}}, iex_state, state)
 
-  defp do_eval({:ok, forms, {buffer, last_op}}, iex_state, state) do
+  defp do_eval({:ok, forms, parser_state}, iex_state, state) do
     put_history(state)
     put_whereami(state)
     state = handle_eval(forms, iex_state.counter, state)

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -111,7 +111,7 @@ defmodule IEx.Evaluator do
         :elixir_errors.parse_error(
           location,
           file,
-          "pipe shorthand is not allowed immediately after a match expression in IEx; to make it work, surround the whole pipeline with parentheses ",
+          "pipe shorthand is not allowed immediately after a match expression in IEx. To make it work, surround the whole pipeline with parentheses ",
           token,
           {charlist, Keyword.get(location, :line, line), Keyword.get(location, :column, column)}
         )

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -302,9 +302,6 @@ defmodule IEx.Evaluator do
     end
   end
 
-  defp do_eval({:ok, forms, buffer}, iex_state, state) when is_binary(buffer),
-    do: do_eval({:ok, forms, {buffer, :other}}, iex_state, state)
-
   defp do_eval({:ok, forms, parser_state}, iex_state, state) do
     put_history(state)
     put_whereami(state)

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -129,7 +129,7 @@ defmodule IEx.Evaluator do
 
   defp adjust_operator([{op_type, _, token} | _] = _tokens, line, column, _file, _opts, :match)
        when op_type in @op_tokens,
-       do: {:error, {[line: line, column: column], :malformed_pipe, "('#{token}')"}}
+       do: {:error, {[line: line, column: column], :malformed_pipe, "'#{token}'"}}
 
   defp adjust_operator([{op_type, _, _} | _] = tokens, line, column, file, opts, _last_op)
        when op_type in @op_tokens do

--- a/lib/iex/lib/iex/evaluator.ex
+++ b/lib/iex/lib/iex/evaluator.ex
@@ -107,15 +107,6 @@ defmodule IEx.Evaluator do
       {:error, {_, _, ""}} ->
         {:incomplete, {input, last_op}}
 
-      {:error, {location, :malformed_pipe, token}} ->
-        :elixir_errors.parse_error(
-          location,
-          file,
-          "pipe shorthand is not allowed immediately after a match expression in IEx. To make it work, surround the whole pipeline with parentheses ",
-          token,
-          {charlist, Keyword.get(location, :line, line), Keyword.get(location, :column, column)}
-        )
-
       {:error, {location, error, token}} ->
         :elixir_errors.parse_error(
           location,
@@ -129,7 +120,11 @@ defmodule IEx.Evaluator do
 
   defp adjust_operator([{op_type, _, token} | _] = _tokens, line, column, _file, _opts, :match)
        when op_type in @op_tokens,
-       do: {:error, {[line: line, column: column], :malformed_pipe, "'#{token}'"}}
+       do:
+         {:error,
+          {[line: line, column: column],
+           "pipe shorthand is not allowed immediately after a match expression in IEx. To make it work, surround the whole pipeline with parentheses ",
+           "'#{token}'"}}
 
   defp adjust_operator([{op_type, _, _} | _] = tokens, line, column, file, opts, _last_op)
        when op_type in @op_tokens do

--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -11,7 +11,7 @@ defmodule IEx.State do
 
   @type t :: %{
           __struct__: __MODULE__,
-          buffer: binary(),
+          parser_state: binary(),
           counter: pos_integer(),
           prefix: binary(),
           on_eof: :stop_evaluator | :halt,

--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -5,11 +5,21 @@ defmodule IEx.State do
   defstruct parser_state: "",
             counter: 1,
             prefix: "iex",
+            last_op: :none,
             on_eof: :stop_evaluator,
             evaluator_options: [],
             previous_state: nil
 
-  @type t :: %__MODULE__{}
+  @type t :: %{
+          __struct__: __MODULE__,
+          buffer: binary(),
+          counter: pos_integer(),
+          prefix: binary(),
+          last_op: :none | :match | :other,
+          on_eof: :stop_evaluator | :halt,
+          evaluator_options: keyword(),
+          previous_state: nil | t()
+        }
 end
 
 defmodule IEx.Server do

--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -5,7 +5,6 @@ defmodule IEx.State do
   defstruct parser_state: "",
             counter: 1,
             prefix: "iex",
-            last_op: :none,
             on_eof: :stop_evaluator,
             evaluator_options: [],
             previous_state: nil
@@ -15,7 +14,6 @@ defmodule IEx.State do
           buffer: binary(),
           counter: pos_integer(),
           prefix: binary(),
-          last_op: :none | :match | :other,
           on_eof: :stop_evaluator | :halt,
           evaluator_options: keyword(),
           previous_state: nil | t()

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1130,13 +1130,13 @@ defmodule IEx.HelpersTest do
 
     test "raises if previous expression was a match" do
       assert capture_iex("x = 42\n|> IO.puts()") =~
-               "surround the whole pipeline with parentheses ('|>')"
+               "surround the whole pipeline with parentheses '|>'"
 
       assert capture_iex("%{x: x} = %{x: 42}\n|> IO.puts()") =~
-               "surround the whole pipeline with parentheses ('|>')"
+               "surround the whole pipeline with parentheses '|>'"
 
       assert capture_iex("%{x: x} = map = %{x: 42}\n|> IO.puts()") =~
-               "surround the whole pipeline with parentheses ('|>')"
+               "surround the whole pipeline with parentheses '|>'"
     end
   end
 

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1127,6 +1127,17 @@ defmodule IEx.HelpersTest do
       assert capture_iex("[42]\n++ [24]\n|> IO.inspect(label: \"foo\")") =~ "foo: [42, 24]"
       assert capture_iex("|> IO.puts()") =~ "(RuntimeError) v(-1) is out of bounds"
     end
+
+    test "raises if previous expression was a match" do
+      assert capture_iex("x = 42\n|> IO.puts()") =~
+               "surround the whole pipeline with parentheses ('|>')"
+
+      assert capture_iex("%{x: x} = %{x: 42}\n|> IO.puts()") =~
+               "surround the whole pipeline with parentheses ('|>')"
+
+      assert capture_iex("%{x: x} = map = %{x: 42}\n|> IO.puts()") =~
+               "surround the whole pipeline with parentheses ('|>')"
+    end
   end
 
   describe "c" do


### PR DESCRIPTION
Please refer to #11418 for a feature discussion.

I am not sure if the error message is descriptive enough, but AFAIU for a better report we’d need to introduce a new type of error and I tend to avoid it here.