### PR TITLE
Simplify definition of iolist in Typespecs page

### DIFF
--- a/lib/elixir/pages/typespecs.md
+++ b/lib/elixir/pages/typespecs.md
@@ -134,7 +134,7 @@ Built-in type           | Defined as
 `function()`            | `fun()`
 `identifier()`          | `pid()` \| `port()` \| `reference()`
 `iodata()`              | `iolist()` \| `binary()`
-`iolist()`              | `maybe_improper_list(byte() \| binary() \| iolist(), binary() \| [])`
+`iolist()`              | `maybe_improper_list(byte() \| binary() \| iolist(), binary())`
 `keyword()`             | `[{atom(), any()}]`
 `keyword(t)`            | `[{atom(), t}]`
 `list()`                | `[any()]`


### PR DESCRIPTION
As it is redundant to say that maybe_improper_list may end properly.