### PR TITLE
Adds System.fetch_mandatory_env!/1 utility

### DIFF
--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -700,6 +700,27 @@ defmodule System do
   end
 
   @doc """
+  Fetches an environment variable.
+  Raises an `ArgumentError` in case the variable is not set or its trimmed value is blank.
+
+  Example usage in a config file
+
+  config :my_app,
+    MyModule,
+    my_mandatory_value: System.fetch_mandatory_env!("ENV_THAT_CANNOT_BE_BLANK")
+  """
+  def fetch_mandatory_env!(varname) when is_binary(varname) do
+    value = :os.getenv(String.to_charlist(varname))
+
+    if is_nil(value), do: raise_unset_error(varname)
+
+    case String.trim(value) do
+      "" -> raise_blank_error(varname)
+      non_blank_value -> non_blank_value
+    end
+  end
+
+  @doc """
   Erlang VM process identifier.
 
   Returns the process identifier of the current Erlang emulator
@@ -1328,5 +1349,19 @@ defmodule System do
     )
 
     replacement_unit
+  end
+
+  defp raise_unset_error(varname) do
+    raise(
+      ArgumentError,
+      "could not fetch environment variable #{varname} because it is not set"
+    )
+  end
+
+  defp raise_blank_error(varname) do
+    raise(
+      ArgumentError,
+      "environment variable #{varname} is set, but contains a blank value"
+    )
   end
 end

--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -74,6 +74,18 @@ defmodule SystemTest do
     assert_raise ArgumentError, ~r[cannot execute System.put_env/2 for key with \"=\"], fn ->
       System.put_env("FOO=BAR", "BAZ")
     end
+
+    System.put_env("NON_BLANK_ENV", "NON_BLANK_VALUE")
+    assert "NON_BLANK_VALUE" == System.fetch_mandatory_env!("NON_BLANK_ENV")
+
+    System.put_env("BLANK_ENV", "         ")
+    assert_raise ArgumentError, ~r[environment variable BLANK_ENV is set, but contains a blank value], fn ->
+      System.fetch_mandatory_env!("NON_BLANK_ENV")
+    end
+
+    assert_raise ArgumentError, ~r[could not fetch environment variable UNSET_ENV because it is not set], fn ->
+      System.fetch_mandatory_env!("UNSET_ENV")
+    end
   end
 
   test "cmd/2 raises for null bytes" do


### PR DESCRIPTION
# Proposal

This PR aims to add a utility function to `System` module to make it easier to fetch environment variables that *need* to have a non-blank value.

# Motivation

At SumUp, we have our South American online banking solution written in Elixir. We used to rely on `System.fetch_env!/1` to retrieve environment variables up until we had an infrastructure incident that made some environment variables to be set with an empty string as value. The system booted because `System.fetch_env!/1` did not raise an exception, so we ended up with a running system without some of its necessary data.