### PR TITLE
Colorize Version.Requirement source in Inspect protocol

### DIFF
--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -677,7 +677,12 @@ defimpl String.Chars, for: Version.Requirement do
 end
 
 defimpl Inspect, for: Version.Requirement do
-  def inspect(%Version.Requirement{source: source}, _opts) do
-    "#Version.Requirement<" <> source <> ">"
+  def inspect(%Version.Requirement{source: source}, opts) do
+    formatted =
+      Inspect.Algebra.color(source, :atom, opts)
+      |> Inspect.Algebra.format(opts.width)
+      |> IO.iodata_to_binary()
+
+    "#Version.Requirement<" <> formatted <> ">"
   end
 end

--- a/lib/elixir/lib/version.ex
+++ b/lib/elixir/lib/version.ex
@@ -403,7 +403,7 @@ defmodule Version do
 
       iex> {:ok, requirement} = Version.parse_requirement("== 2.0.1")
       iex> requirement
-      #Version.Requirement<== 2.0.1>
+      #Version.Requirement<"== 2.0.1">
 
       iex> Version.parse_requirement("== == 2.0.1")
       :error
@@ -425,7 +425,7 @@ defmodule Version do
   ## Examples
 
       iex> Version.parse_requirement!("== 2.0.1")
-      #Version.Requirement<== 2.0.1>
+      #Version.Requirement<"== 2.0.1">
 
       iex> Version.parse_requirement!("== == 2.0.1")
       ** (Version.InvalidRequirementError) invalid requirement: "== == 2.0.1"
@@ -678,11 +678,8 @@ end
 
 defimpl Inspect, for: Version.Requirement do
   def inspect(%Version.Requirement{source: source}, opts) do
-    formatted =
-      Inspect.Algebra.color(source, :atom, opts)
-      |> Inspect.Algebra.format(opts.width)
-      |> IO.iodata_to_binary()
+    colorized = Inspect.Algebra.color("\"" <> source <> "\"", :string, opts)
 
-    "#Version.Requirement<" <> formatted <> ">"
+    Inspect.Algebra.concat(["#Version.Requirement<", colorized, ">"])
   end
 end


### PR DESCRIPTION
This is to avoid ambiguity in cases like

    iex> Version.parse_requirement!("~> 1.2.3 or < 3.4.5 and > 5.6.7")
    #Version.Requirement<~> 1.2.3 or < 3.4.5 and > 5.6.7>


Before:
![image](https://user-images.githubusercontent.com/9133420/144713434-5a52889f-60eb-4978-9d7c-f8b880ac90e4.png)

After:
![image](https://user-images.githubusercontent.com/9133420/144713451-73ef448f-5258-41ce-9a3b-407d4fce675d.png)
