### PR TITLE
Add all actually passed in types to Identifier.escape spec 2nd arg

### DIFF
--- a/lib/elixir/lib/code/identifier.ex
+++ b/lib/elixir/lib/code/identifier.ex
@@ -214,7 +214,7 @@ defmodule Code.Identifier do
   @doc """
   Escapes the given identifier.
   """
-  @spec escape(binary(), char(), :infinity | non_neg_integer, (char() -> iolist() | false)) ::
+  @spec escape(binary(), char() | -1 | :none, :infinity | non_neg_integer, (char() -> iolist() | false)) ::
           {escaped :: iolist(), remaining :: binary()}
   def escape(binary, char, limit \\ :infinity, fun \\ &escape_map/1)
       when limit == :infinity or (is_integer(limit) and limit >= 0) do


### PR DESCRIPTION
Dialyzer [found](https://github.com/michallepicki/elixir-lang-dialyzer-runs/runs/4419869728?check_suite_focus=true) that the newly added spec from https://github.com/elixir-lang/elixir/pull/11439 is not complete.

This probably shouldn't be merged as is, maybe only one of the two should stay? Or a valid char could be passed at call sites anyway? Or it could be some other change

Call sites where `-1` and `:none` come from:
- https://github.com/elixir-lang/elixir/blob/5bcd0bbce964500026da4ab0b1785c14afbc1774/lib/elixir/lib/code/normalizer.ex#L280
- https://github.com/elixir-lang/elixir/blob/5bcd0bbce964500026da4ab0b1785c14afbc1774/lib/elixir/lib/code/normalizer.ex#L514
- https://github.com/elixir-lang/elixir/blob/5bcd0bbce964500026da4ab0b1785c14afbc1774/lib/ex_unit/lib/ex_unit/diff.ex#L674
- https://github.com/elixir-lang/elixir/blob/5bcd0bbce964500026da4ab0b1785c14afbc1774/lib/ex_unit/lib/ex_unit/diff.ex#L883

PS: Cool preview for links above from github!