### PR TITLE
Validate options for all Base encode/decode functions

### DIFF
--- a/lib/elixir/lib/base.ex
+++ b/lib/elixir/lib/base.ex
@@ -269,7 +269,8 @@ defmodule Base do
   """
   @spec encode16(binary, keyword) :: binary
   def encode16(data, opts \\ []) when is_binary(data) do
-    case = Keyword.get(opts, :case, :upper)
+    [case: case] = Keyword.validate!(opts, case: :upper)
+
     do_encode16(case, data)
   end
 
@@ -302,9 +303,13 @@ defmodule Base do
   """
   @spec decode16(binary, keyword) :: {:ok, binary} | :error
   def decode16(string, opts \\ []) do
-    {:ok, decode16!(string, opts)}
-  rescue
-    ArgumentError -> :error
+    opts = Keyword.validate!(opts, case: :upper)
+
+    try do
+      {:ok, decode16!(string, opts)}
+    rescue
+      ArgumentError -> :error
+    end
   end
 
   @doc """
@@ -341,7 +346,8 @@ defmodule Base do
   def decode16!(string, opts \\ [])
 
   def decode16!(string, opts) when is_binary(string) and rem(byte_size(string), 2) == 0 do
-    case = Keyword.get(opts, :case, :upper)
+    [case: case] = Keyword.validate!(opts, case: :upper)
+
     do_decode16(case, string)
   end
 
@@ -369,7 +375,8 @@ defmodule Base do
   """
   @spec encode64(binary, keyword) :: binary
   def encode64(data, opts \\ []) when is_binary(data) do
-    pad? = Keyword.get(opts, :padding, true)
+    [padding: pad?] = Keyword.validate!(opts, padding: true)
+
     do_encode64(data, pad?)
   end
 
@@ -399,9 +406,13 @@ defmodule Base do
   """
   @spec decode64(binary, keyword) :: {:ok, binary} | :error
   def decode64(string, opts \\ []) when is_binary(string) do
-    {:ok, decode64!(string, opts)}
-  rescue
-    ArgumentError -> :error
+    opts = Keyword.validate!(opts, ignore: nil, padding: true)
+
+    try do
+      {:ok, decode64!(string, opts)}
+    rescue
+      ArgumentError -> :error
+    end
   end
 
   @doc """
@@ -433,8 +444,9 @@ defmodule Base do
   """
   @spec decode64!(binary, keyword) :: binary
   def decode64!(string, opts \\ []) when is_binary(string) do
-    pad? = Keyword.get(opts, :padding, true)
-    string |> remove_ignored(opts[:ignore]) |> do_decode64(pad?)
+    opts = Keyword.validate!(opts, ignore: nil, padding: true)
+
+    string |> remove_ignored(opts[:ignore]) |> do_decode64(opts[:padding])
   end
 
   @doc """
@@ -455,7 +467,8 @@ defmodule Base do
   """
   @spec url_encode64(binary, keyword) :: binary
   def url_encode64(data, opts \\ []) when is_binary(data) do
-    pad? = Keyword.get(opts, :padding, true)
+    [padding: pad?] = Keyword.validate!(opts, padding: true)
+
     do_encode64url(data, pad?)
   end
 
@@ -483,9 +496,13 @@ defmodule Base do
   """
   @spec url_decode64(binary, keyword) :: {:ok, binary} | :error
   def url_decode64(string, opts \\ []) when is_binary(string) do
-    {:ok, url_decode64!(string, opts)}
-  rescue
-    ArgumentError -> :error
+    opts = Keyword.validate!(opts, ignore: nil, padding: true)
+
+    try do
+      {:ok, url_decode64!(string, opts)}
+    rescue
+      ArgumentError -> :error
+    end
   end
 
   @doc """
@@ -515,8 +532,9 @@ defmodule Base do
   """
   @spec url_decode64!(binary, keyword) :: binary
   def url_decode64!(string, opts \\ []) when is_binary(string) do
-    pad? = Keyword.get(opts, :padding, true)
-    string |> remove_ignored(opts[:ignore]) |> do_decode64url(pad?)
+    opts = Keyword.validate!(opts, ignore: nil, padding: true)
+
+    string |> remove_ignored(opts[:ignore]) |> do_decode64url(opts[:padding])
   end
 
   @doc """
@@ -553,9 +571,9 @@ defmodule Base do
   """
   @spec encode32(binary, keyword) :: binary
   def encode32(data, opts \\ []) when is_binary(data) do
-    case = Keyword.get(opts, :case, :upper)
-    pad? = Keyword.get(opts, :padding, true)
-    do_encode32(case, data, pad?)
+    opts = Keyword.validate!(opts, case: :upper, padding: true)
+
+    do_encode32(opts[:case], data, opts[:padding])
   end
 
   @doc """
@@ -596,9 +614,13 @@ defmodule Base do
   """
   @spec decode32(binary, keyword) :: {:ok, binary} | :error
   def decode32(string, opts \\ []) do
-    {:ok, decode32!(string, opts)}
-  rescue
-    ArgumentError -> :error
+    opts = Keyword.validate!(opts, case: :upper, padding: true)
+
+    try do
+      {:ok, decode32!(string, opts)}
+    rescue
+      ArgumentError -> :error
+    end
   end
 
   @doc """
@@ -642,9 +664,9 @@ defmodule Base do
   """
   @spec decode32!(binary, keyword) :: binary
   def decode32!(string, opts \\ []) when is_binary(string) do
-    case = Keyword.get(opts, :case, :upper)
-    pad? = Keyword.get(opts, :padding, true)
-    do_decode32(case, string, pad?)
+    opts = Keyword.validate!(opts, case: :upper, padding: true)
+
+    do_decode32(opts[:case], string, opts[:padding])
   end
 
   @doc """
@@ -682,9 +704,9 @@ defmodule Base do
   """
   @spec hex_encode32(binary, keyword) :: binary
   def hex_encode32(data, opts \\ []) when is_binary(data) do
-    case = Keyword.get(opts, :case, :upper)
-    pad? = Keyword.get(opts, :padding, true)
-    do_encode32hex(case, data, pad?)
+    opts = Keyword.validate!(opts, case: :upper, padding: true)
+
+    do_encode32hex(opts[:case], data, opts[:padding])
   end
 
   @doc """
@@ -726,9 +748,13 @@ defmodule Base do
   """
   @spec hex_decode32(binary, keyword) :: {:ok, binary} | :error
   def hex_decode32(string, opts \\ []) do
-    {:ok, hex_decode32!(string, opts)}
-  rescue
-    ArgumentError -> :error
+    opts = Keyword.validate!(opts, case: :upper, padding: true)
+
+    try do
+      {:ok, hex_decode32!(string, opts)}
+    rescue
+      ArgumentError -> :error
+    end
   end
 
   @doc """
@@ -773,9 +799,9 @@ defmodule Base do
   """
   @spec hex_decode32!(binary, keyword) :: binary
   def hex_decode32!(string, opts \\ []) when is_binary(string) do
-    case = Keyword.get(opts, :case, :upper)
-    pad? = Keyword.get(opts, :padding, true)
-    do_decode32hex(case, string, pad?)
+    opts = Keyword.validate!(opts, case: :upper, padding: true)
+
+    do_decode32hex(opts[:case], string, opts[:padding])
   end
 
   defp remove_ignored(string, nil), do: string

--- a/lib/elixir/lib/base.ex
+++ b/lib/elixir/lib/base.ex
@@ -92,6 +92,9 @@ defmodule Base do
 
   """
 
+  @type encode_case :: :upper | :lower
+  @type decode_case :: :upper | :lower | :mixed
+
   b16_alphabet = '0123456789ABCDEF'
   b64_alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
   b64url_alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'
@@ -267,7 +270,7 @@ defmodule Base do
       "666f6f626172"
 
   """
-  @spec encode16(binary, keyword) :: binary
+  @spec encode16(binary, case: encode_case) :: binary
   def encode16(data, opts \\ []) when is_binary(data) do
     [case: case] = Keyword.validate!(opts, case: :upper)
 
@@ -301,7 +304,7 @@ defmodule Base do
       {:ok, "foobar"}
 
   """
-  @spec decode16(binary, keyword) :: {:ok, binary} | :error
+  @spec decode16(binary, case: decode_case) :: {:ok, binary} | :error
   def decode16(string, opts \\ []) do
     opts = Keyword.validate!(opts, case: :upper)
 
@@ -342,7 +345,7 @@ defmodule Base do
       "foobar"
 
   """
-  @spec decode16!(binary, keyword) :: binary
+  @spec decode16!(binary, case: encode_case) :: binary
   def decode16!(string, opts \\ [])
 
   def decode16!(string, opts) when is_binary(string) and rem(byte_size(string), 2) == 0 do
@@ -373,7 +376,7 @@ defmodule Base do
       "Zm9vYg"
 
   """
-  @spec encode64(binary, keyword) :: binary
+  @spec encode64(binary, padding: boolean) :: binary
   def encode64(data, opts \\ []) when is_binary(data) do
     [padding: pad?] = Keyword.validate!(opts, padding: true)
 
@@ -404,7 +407,7 @@ defmodule Base do
       {:ok, "foob"}
 
   """
-  @spec decode64(binary, keyword) :: {:ok, binary} | :error
+  @spec decode64(binary, ignore: :whitespace, padding: boolean) :: {:ok, binary} | :error
   def decode64(string, opts \\ []) when is_binary(string) do
     opts = Keyword.validate!(opts, ignore: nil, padding: true)
 
@@ -442,7 +445,7 @@ defmodule Base do
       "foob"
 
   """
-  @spec decode64!(binary, keyword) :: binary
+  @spec decode64!(binary, ignore: :whitespace, padding: boolean) :: binary
   def decode64!(string, opts \\ []) when is_binary(string) do
     opts = Keyword.validate!(opts, ignore: nil, padding: true)
 
@@ -465,7 +468,7 @@ defmodule Base do
       "_3_-_A"
 
   """
-  @spec url_encode64(binary, keyword) :: binary
+  @spec url_encode64(binary, padding: boolean) :: binary
   def url_encode64(data, opts \\ []) when is_binary(data) do
     [padding: pad?] = Keyword.validate!(opts, padding: true)
 
@@ -494,7 +497,7 @@ defmodule Base do
       {:ok, <<255, 127, 254, 252>>}
 
   """
-  @spec url_decode64(binary, keyword) :: {:ok, binary} | :error
+  @spec url_decode64(binary, ignore: :whitespace, padding: boolean) :: {:ok, binary} | :error
   def url_decode64(string, opts \\ []) when is_binary(string) do
     opts = Keyword.validate!(opts, ignore: nil, padding: true)
 
@@ -530,7 +533,7 @@ defmodule Base do
       <<255, 127, 254, 252>>
 
   """
-  @spec url_decode64!(binary, keyword) :: binary
+  @spec url_decode64!(binary, ignore: :whitespace, padding: boolean) :: binary
   def url_decode64!(string, opts \\ []) when is_binary(string) do
     opts = Keyword.validate!(opts, ignore: nil, padding: true)
 
@@ -569,7 +572,7 @@ defmodule Base do
       "MZXW6YTBOI"
 
   """
-  @spec encode32(binary, keyword) :: binary
+  @spec encode32(binary, case: encode_case, padding: boolean) :: binary
   def encode32(data, opts \\ []) when is_binary(data) do
     opts = Keyword.validate!(opts, case: :upper, padding: true)
 
@@ -612,7 +615,7 @@ defmodule Base do
       {:ok, "foobar"}
 
   """
-  @spec decode32(binary, keyword) :: {:ok, binary} | :error
+  @spec decode32(binary, case: decode_case, padding: boolean) :: {:ok, binary} | :error
   def decode32(string, opts \\ []) do
     opts = Keyword.validate!(opts, case: :upper, padding: true)
 
@@ -662,7 +665,7 @@ defmodule Base do
       "foobar"
 
   """
-  @spec decode32!(binary, keyword) :: binary
+  @spec decode32!(binary, case: decode_case, padding: boolean) :: binary
   def decode32!(string, opts \\ []) when is_binary(string) do
     opts = Keyword.validate!(opts, case: :upper, padding: true)
 
@@ -702,7 +705,7 @@ defmodule Base do
       "CPNMUOJ1E8"
 
   """
-  @spec hex_encode32(binary, keyword) :: binary
+  @spec hex_encode32(binary, case: encode_case, padding: boolean) :: binary
   def hex_encode32(data, opts \\ []) when is_binary(data) do
     opts = Keyword.validate!(opts, case: :upper, padding: true)
 
@@ -746,7 +749,7 @@ defmodule Base do
       {:ok, "foobar"}
 
   """
-  @spec hex_decode32(binary, keyword) :: {:ok, binary} | :error
+  @spec hex_decode32(binary, case: decode_case, padding: boolean) :: {:ok, binary} | :error
   def hex_decode32(string, opts \\ []) do
     opts = Keyword.validate!(opts, case: :upper, padding: true)
 
@@ -797,7 +800,7 @@ defmodule Base do
       "foobar"
 
   """
-  @spec hex_decode32!(binary, keyword) :: binary
+  @spec hex_decode32!(binary, case: decode_case, padding: boolean) :: binary
   def hex_decode32!(string, opts \\ []) when is_binary(string) do
     opts = Keyword.validate!(opts, case: :upper, padding: true)
 


### PR DESCRIPTION
Incorrect options, e.g., `pad: false` rather than `padding: false` were silently ignored. This mistake bit me recently, and I was surprised to find that encode/decode functions didn't validate the options, and the typespecs were loose enough that dialyzer didn't catch it either.  This mistake seems prevalent enough that the "identity" test case erroneously used `pad` as an option.

The validations are doubled up for functions with a bang variant because `Keyword.validate!/2` raises an `ArgumentError`, and `rescue` would translate it into a generic `:error` tuple. There is a potential refactoring here where the bang variant calls the non-bang variant and raises an `{:error, reason}` tuple. However, that seemed too invasive and I didn't include it in this PR.