### PR TITLE
Add Stream.duplicate/1

### DIFF
--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -442,6 +442,7 @@ defmodule Stream do
       iex> Enum.to_list(stream)
       [[1, 2], [1, 2], [1, 2]]
   """
+  @doc since: "1.14.0"
   @spec duplicate(any, non_neg_integer) :: Enumerable.t()
   def duplicate(value, n) when is_integer(n) and n >= 0 do
     unfold(n, fn

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -418,6 +418,39 @@ defmodule Stream do
   end
 
   @doc """
+  Duplicates the given element `n` times in a stream.
+
+  `n` is an integer greater than or equal to `0`.
+
+  If `n` is `0`, an empty stream is returned.
+
+  ## Examples
+
+      iex> stream = Stream.duplicate("hello", 0)
+      iex> Enum.to_list(stream)
+      []
+
+      iex> stream = Stream.duplicate("hi", 1)
+      iex> Enum.to_list(stream)
+      ["hi"]
+
+      iex> stream = Stream.duplicate("bye", 2)
+      iex> Enum.to_list(stream)
+      ["bye", "bye"]
+
+      iex> stream = Stream.duplicate([1, 2], 3)
+      iex> Enum.to_list(stream)
+      [[1, 2], [1, 2], [1, 2]]
+  """
+  @spec duplicate(any, non_neg_integer) :: Enumerable.t()
+  def duplicate(value, n) when is_integer(n) and n >= 0 do
+    unfold(n, fn
+      0 -> nil
+      remaining -> {value, remaining - 1}
+    end)
+  end
+
+  @doc """
   Executes the given function for each element.
 
   Useful for adding side effects (like printing) to a stream.

--- a/lib/elixir/test/elixir/stream_test.exs
+++ b/lib/elixir/test/elixir/stream_test.exs
@@ -370,6 +370,14 @@ defmodule StreamTest do
     assert Stream.drop_while(nats, &(&1 <= 5)) |> Enum.take(5) == [6, 7, 8, 9, 10]
   end
 
+  test "duplicate/2" do
+    stream = Stream.duplicate(7, 7)
+
+    assert is_function(stream)
+    assert stream |> Stream.take(5) |> Enum.to_list() == [7, 7, 7, 7, 7]
+    assert Enum.to_list(stream) == [7, 7, 7, 7, 7, 7, 7]
+  end
+
   test "each/2" do
     Process.put(:stream_each, [])
 


### PR DESCRIPTION
@josevalim  mentioned in [this twitch stream](https://www.twitch.tv/videos/1225900187) (around minute 37) that Stream.duplicate/2 would be a good addition.  Thoughts?

```
      iex> stream = Stream.duplicate([1, 2], 3)
      iex> Enum.to_list(stream)
      [[1, 2], [1, 2], [1, 2]]
```
