### PR TITLE
Don't show snippet for EOF line

### DIFF
--- a/lib/elixir/src/elixir_errors.erl
+++ b/lib/elixir/src/elixir_errors.erl
@@ -87,9 +87,12 @@ snippet(InputString, Location, StartLine, StartColumn) ->
   case lists:keyfind(column, 1, Location) of
     {column, Column} ->
       Lines = string:split(InputString, "\n", all),
-      Snippet = elixir_utils:characters_to_binary(lists:nth(Line - StartLine + 1, Lines)),
+      Snippet = (lists:nth(Line - StartLine + 1, Lines)),
       Offset = if Line == StartLine -> Column - StartColumn; true -> Column - 1 end,
-      #{content => Snippet, offset => Offset};
+      case string:trim(Snippet, leading) of
+        [] -> nil;
+        _ -> #{content => elixir_utils:characters_to_binary(Snippet), offset => Offset}
+      end;
 
     false ->
       nil

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -468,6 +468,21 @@ defmodule Kernel.ErrorsTest do
     assert_eval_raise TokenMissingError, ~r/nofile:1:3: invalid escape \\ at end of file/, '1 \\'
   end
 
+  test "show snippet on missing tokens" do
+    assert_eval_raise TokenMissingError,
+                      "nofile:1:25: missing terminator: end (for \"do\" starting at line 1)\n" <>
+                        "    |\n" <>
+                        "  1 | defmodule ShowSnippet do\n" <>
+                        "    |                         ^",
+                      'defmodule ShowSnippet do'
+  end
+
+  test "don't show snippet when error line is empty" do
+    assert_eval_raise TokenMissingError,
+                      "nofile:3:1: missing terminator: end (for \"do\" starting at line 1)",
+                      'defmodule ShowSnippet do\n\n'
+  end
+
   test "function local conflict" do
     assert_eval_raise CompileError,
                       "nofile:3: imported Kernel.&&/2 conflicts with local function",


### PR DESCRIPTION
Restriction added only for "missing terminator" error + empty line.

We could inform the user that EOF was reached, but not all evaluated elixir code is in a file. For example:

```sh
elixir -e "defmodule Foo do"
```

should show: 
```
** (TokenMissingError) nofile:1:17: missing terminator: end (for "do" starting at line 1)
    |
  1 | defmodule Foo do
    |                 ^
    (elixir 1.14.0-dev) lib/code.ex:403: Code.validated_eval_string/3
```

So I didn't add it. Let me know if you think it is worth it, shouldn't be a big of a change.