### PR TITLE
Add PartitionSupervisor

### DIFF
--- a/lib/elixir/docs.exs
+++ b/lib/elixir/docs.exs
@@ -78,6 +78,7 @@ canonical = System.fetch_env!("CANONICAL")
       DynamicSupervisor,
       GenServer,
       Node,
+      PartitionSupervisor,
       Process,
       Registry,
       Supervisor,

--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -557,7 +557,7 @@ defmodule DynamicSupervisor do
   ## Examples
 
       def init(_arg) do
-        DynamicSupervisor.init(max_children: 1000, strategy: :one_for_one)
+        DynamicSupervisor.init(max_children: 1000)
       end
 
   """

--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -36,7 +36,7 @@ defmodule DynamicSupervisor do
       DynamicSupervisor.count_children(MyApp.DynamicSupervisor)
       #=> %{active: 2, specs: 2, supervisors: 0, workers: 2}
 
-  ## Scalability and partioning
+  ## Scalability and partitioning
 
   The `DynamicSupervisor` is a single process responsible for starting
   other processes. In some applications, the `DynamicSupervisor` may

--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -11,11 +11,10 @@ defmodule DynamicSupervisor do
 
   ## Examples
 
-  A dynamic supervisor is started with no children, a supervision strategy
-  (the only strategy currently supported is `:one_for_one`), and a name:
+  A dynamic supervisor is started with no children and often a name:
 
       children = [
-        {DynamicSupervisor, strategy: :one_for_one, name: MyApp.DynamicSupervisor}
+        {DynamicSupervisor, name: MyApp.DynamicSupervisor}
       ]
 
       Supervisor.start_link(children, strategy: :one_for_one)
@@ -36,6 +35,46 @@ defmodule DynamicSupervisor do
 
       DynamicSupervisor.count_children(MyApp.DynamicSupervisor)
       #=> %{active: 2, specs: 2, supervisors: 0, workers: 2}
+
+  ## Scalability and partioning
+
+  The `DynamicSupervisor` is a single process responsible for starting
+  other processes. In some applications, the `DynamicSupervisor` may
+  become a bottleneck. To address this, you can start multiple instances
+  of the `DynamicSupervisor` and then pick a "random" instance to start
+  the child on.
+
+  Instead of:
+
+      children = [
+        {DynamicSupervisor, name: MyApp.DynamicSupervisor}
+      ]
+
+  and:
+
+      DynamicSupervisor.start_child(MyApp.DynamicSupervisor, {Agent, fn -> %{} end})
+
+  You can do this:
+
+      children = [
+        {PartitionSupervisor,
+         child_spec: DynamicSupervisor,
+         name: MyApp.DynamicSupervisors}
+      ]
+
+  and then:
+
+      DynamicSupervisor.start_child(
+        {:via, PartitionSupervisor, {MyApp.DynamicSupervisors, self()}},
+        {Agent, fn -> %{} end}
+      )
+
+  In the code above, we start a partition supervisor that will by default
+  start a dynamic supervisor for each core in your machine. Then, instead
+  of calling the `DynamicSupervisor` by name, you call it through the
+  partition supervisor, using `self()` as the routing key. This means each
+  process will be assigned one of the existing dynamic supervisors.
+  Read the `PartitionSupervisor` docs for more information.
 
   ## Module-based supervisors
 
@@ -232,13 +271,12 @@ defmodule DynamicSupervisor do
   @doc """
   Starts a supervisor with the given options.
 
-  The `:strategy` is a required option and the currently supported
-  value is `:one_for_one`. The remaining options can be found in the
-  `init/1` docs.
+  This function is typically not invoked directly, instead it is invoked
+  when using a `DynamicSupervisor` as a child of another supervisor:
 
-  The `:name` option can also be used to register a supervisor name.
-  The supported values are described under the "Name registration"
-  section in the `GenServer` module docs.
+      children = [
+        {DynamicSupervisor, name: MySupervisor}
+      ]
 
   If the supervisor is successfully spawned, this function returns
   `{:ok, pid}`, where `pid` is the PID of the supervisor. If the supervisor
@@ -249,6 +287,33 @@ defmodule DynamicSupervisor do
   Note that a supervisor started with this function is linked to the parent
   process and exits not only on crashes but also if the parent process exits
   with `:normal` reason.
+
+  ## Options
+
+    * `:name` - registers the supervisor under the given name.
+      The supported values are described under the "Name registration"
+      section in the `GenServer` module docs.
+
+    * `:strategy` - the restart strategy option. The only supported
+      value is `:one_for_one` which means that no other child is
+      terminated if a child process terminates. You can learn more
+      about strategies in the `Supervisor` module docs.
+
+    * `:max_restarts` - the maximum number of restarts allowed in
+      a time frame. Defaults to `3`.
+
+    * `:max_seconds` - the time frame in which `:max_restarts` applies.
+      Defaults to `5`.
+
+    * `:max_children` - the maximum amount of children to be running
+      under this supervisor at the same time. When `:max_children` is
+      exceeded, `start_child/2` returns `{:error, :max_children}`. Defaults
+      to `:infinity`.
+
+    * `:extra_arguments` - arguments that are prepended to the arguments
+      specified in the child spec given to `start_child/2`. Defaults to
+      an empty list.
+
   """
   @doc since: "1.6.0"
   @spec start_link([option | init_option]) :: Supervisor.on_start()
@@ -275,6 +340,16 @@ defmodule DynamicSupervisor do
   The `:name` option can also be given in order to register a supervisor
   name, the supported values are described in the "Name registration"
   section in the `GenServer` module docs.
+
+  If the supervisor is successfully spawned, this function returns
+  `{:ok, pid}`, where `pid` is the PID of the supervisor. If the supervisor
+  is given a name and a process with the specified name already exists,
+  the function returns `{:error, {:already_started, pid}}`, where `pid`
+  is the PID of that process.
+
+  Note that a supervisor started with this function is linked to the parent
+  process and exits not only on crashes but also if the parent process exits
+  with `:normal` reason.
   """
   @doc since: "1.6.0"
   @spec start_link(module, term, [option]) :: Supervisor.on_start()
@@ -476,9 +551,8 @@ defmodule DynamicSupervisor do
   module-based supervisors. See the "Module-based supervisors" section
   in the module documentation for more information.
 
-  The `options` received by this function are also supported by `start_link/1`.
-
-  This function returns a tuple containing the supervisor options.
+  It accepts the same `options` as `start_link/1` (except for `:name`)
+  and it returns a tuple containing the supervisor options.
 
   ## Examples
 
@@ -486,36 +560,11 @@ defmodule DynamicSupervisor do
         DynamicSupervisor.init(max_children: 1000, strategy: :one_for_one)
       end
 
-  ## Options
-
-    * `:strategy` - the restart strategy option. The only supported
-      value is `:one_for_one` which means that no other child is
-      terminated if a child process terminates. You can learn more
-      about strategies in the `Supervisor` module docs.
-
-    * `:max_restarts` - the maximum number of restarts allowed in
-      a time frame. Defaults to `3`.
-
-    * `:max_seconds` - the time frame in which `:max_restarts` applies.
-      Defaults to `5`.
-
-    * `:max_children` - the maximum amount of children to be running
-      under this supervisor at the same time. When `:max_children` is
-      exceeded, `start_child/2` returns `{:error, :max_children}`. Defaults
-      to `:infinity`.
-
-    * `:extra_arguments` - arguments that are prepended to the arguments
-      specified in the child spec given to `start_child/2`. Defaults to
-      an empty list.
-
   """
   @doc since: "1.6.0"
   @spec init([init_option]) :: {:ok, sup_flags()}
   def init(options) when is_list(options) do
-    unless strategy = options[:strategy] do
-      raise ArgumentError, "expected :strategy option to be given"
-    end
-
+    strategy = Keyword.get(options, :strategy, :one_for_one)
     intensity = Keyword.get(options, :max_restarts, 3)
     period = Keyword.get(options, :max_seconds, 5)
     max_children = Keyword.get(options, :max_children, :infinity)

--- a/lib/elixir/lib/partition_supervisor.ex
+++ b/lib/elixir/lib/partition_supervisor.ex
@@ -1,0 +1,321 @@
+defmodule PartitionSupervisor do
+  @moduledoc """
+  A supervisor with that starts multiple partitions of the same child.
+
+  Certain processes may become bottlenecks in large systems.
+  If those processes can have their state trivially partitioned,
+  in a way there is no dependency between them, then they can use
+  the `PartitionSupervisor` to create multiple isolated and
+  independent partitions.
+
+  Once the `PartitionSupervisor` starts, you can dispatch to its
+  children using `{:via, PartitionSupervisor, {name, key}}`, where
+  `name` is the name of the `PartitionSupervisor` and key is used
+  for routing.
+
+  ## Example
+
+  The `DynamicSupervisor` is a single process responsible for starting
+  other processes. In some applications, the `DynamicSupervisor` may
+  become a bottleneck. To address this, you can start multiple instances
+  of the `DynamicSupervisor` and then pick a "random" instance to start
+  the child on.
+
+  Instead of:
+
+      children = [
+        {DynamicSupervisor, name: MyApp.DynamicSupervisor}
+      ]
+
+      Supervisor.start_link(children, strategy: :one_for_one)
+
+  and:
+
+      DynamicSupervisor.start_child(MyApp.DynamicSupervisor, {Agent, fn -> %{} end})
+
+  You can do this:
+
+      children = [
+        {PartitionSupervisor,
+         child_spec: DynamicSupervisor,
+         name: MyApp.DynamicSupervisors}
+      ]
+
+      Supervisor.start_link(children, strategy: :one_for_one)
+
+  and then:
+
+      DynamicSupervisor.start_child(
+        {:via, PartitionSupervisor, {MyApp.DynamicSupervisors, self()}},
+        {Agent, fn -> %{} end}
+      )
+
+  In the code above, we start a partition supervisor that will by default
+  start a dynamic supervisor for each core in your machine. Then, instead
+  of calling the `DynamicSupervisor` by name, you call it through the
+  partition supervisor using the `{:via, PartitionSupervisor, {name, key}}`
+  format. We picked `self()` as the routing key, which means each process
+  will be assigned one of the existing dynamic supervisors. See `start_link/1`
+  to see all options supported by the `PartitionSupervisor`.
+
+  ## Implementation notes
+
+  The `PartitionSupervisor` requires a name as an atom to be given on start,
+  as it uses an ETS table to keep all of the partitions. Under the hood,
+  the `PartitionSupervisor` generates a child spec for each partition and
+  then act as a regular supervisor. The id of each child spec is the
+  partition number.
+
+  For routing, two strategies are used. If `key` is an integer, it is routed
+  using `rem(abs(key), partitions)`. Otherwise it uses `:erlang.phash2(key, partitions)`.
+  The particular routing may change in the future, and therefore cannot
+  be relied on. If you want to retrieve a particular PID for a certain key,
+  you can use `GenServer.whereis({:via, PartitionSupervisor, {name, key}})`.
+  """
+
+  @behaviour Supervisor
+  @type name :: atom()
+
+  @doc false
+  def child_spec(opts) when is_list(opts) do
+    id =
+      case Keyword.get(opts, :name, PartitionSupervisor) do
+        name when is_atom(name) -> name
+        {:global, name} -> name
+        {:via, _module, name} -> name
+      end
+
+    %{
+      id: id,
+      start: {PartitionSupervisor, :start_link, [opts]},
+      type: :supervisor
+    }
+  end
+
+  @doc """
+  Starts a partition supervisor with the given options.
+
+  This function is typically not invoked directly, instead it is invoked
+  when using a `PartitionSupervisor` as a child of another supervisor:
+
+      children = [
+        {PartitionSupervisor, child_spec: SomeChild, name: MyPartitionSupervisor}
+      ]
+
+  If the supervisor is successfully spawned, this function returns
+  `{:ok, pid}`, where `pid` is the PID of the supervisor. If the supervisor
+  is given a name and a process with the specified name already exists,
+  the function returns `{:error, {:already_started, pid}}`, where `pid`
+  is the PID of that process.
+
+  Note that a supervisor started with this function is linked to the parent
+  process and exits not only on crashes but also if the parent process exits
+  with `:normal` reason.
+
+  ## Options
+
+    * `:name` - an atom representing the name of the partition supervisor.
+
+    * `:strategy` - the restart strategy option, defaults to `:one_for_one`.
+      You can learn more about strategies in the `Supervisor` module docs.
+
+    * `:max_restarts` - the maximum number of restarts allowed in
+      a time frame. Defaults to `3`.
+
+    * `:max_seconds` - the time frame in which `:max_restarts` applies.
+      Defaults to `5`.
+
+    * `:with_arguments` - a two-argument anonymous function that allows
+      the partition to be given to the child starting function. See the
+      `:with_arguments` section below.
+
+  ## `:with_arguments`
+
+  Sometimes you want each partition to know their partition assigned number.
+  This can be done with the `:with_arguments` option. This function receives
+  the list of arguments of the child specification with the partition and
+  it must return a new list of arguments.
+
+  For example, most processes are started by calling `start_link(opts)`,
+  where `opts` is a keyword list. You could attach the partition to the
+  keyword list like this:
+
+      with_arguments: fn [opts], partition ->
+        [Keyword.put(opts, :partition, partition)]
+      end
+  """
+  def start_link(opts) do
+    name = opts[:name]
+
+    unless name && is_atom(name) do
+      raise ArgumentError,
+            "the :name option must be given to PartitionSupervisor as an atom, got: #{inspect(name)}"
+    end
+
+    {child_spec, opts} = Keyword.pop(opts, :child_spec)
+
+    unless child_spec do
+      raise ArgumentError, "the :child_spec option must be given to PartitionSupervisor"
+    end
+
+    {partitions, opts} = Keyword.pop(opts, :partitions, System.schedulers_online())
+
+    unless is_integer(partitions) and partitions >= 1 do
+      raise ArgumentError,
+            "the :partitions option must be a positive integer, got: #{inspect(partitions)}"
+    end
+
+    {with_arguments, opts} = Keyword.pop(opts, :with_arguments, fn args, _partition -> args end)
+
+    unless is_function(with_arguments, 2) do
+      raise ArgumentError,
+            "the :with_arguments option must be a function that receives two arguments, " <>
+              "the current call arguments and the partition, got: #{inspect(with_arguments)}"
+    end
+
+    %{start: {mod, fun, args}} = map = Supervisor.child_spec(child_spec, [])
+
+    children =
+      for partition <- 0..(partitions - 1) do
+        args = with_arguments.(args, partition)
+
+        unless is_list(args) do
+          raise "the call to the function in :with_arguments must return a list, got: #{inspect(args)}"
+        end
+
+        start = {__MODULE__, :start_child, [mod, fun, args, name, partition]}
+        %{map | id: partition, start: start}
+      end
+
+    {init_opts, start_opts} = Keyword.split(opts, [:strategy, :max_seconds, :max_restarts])
+    Supervisor.start_link(__MODULE__, {name, partitions, children, init_opts}, start_opts)
+  end
+
+  @doc false
+  def start_child(mod, fun, args, name, partition) do
+    case apply(mod, fun, args) do
+      {:ok, pid} ->
+        :ets.insert(name, {partition, pid})
+        {:ok, pid}
+
+      {:ok, pid, info} ->
+        :ets.insert(name, {partition, pid})
+        {:ok, pid, info}
+
+      other ->
+        other
+    end
+  end
+
+  @impl true
+  def init({name, partitions, children, init_opts}) do
+    :ets.new(name, [:set, :named_table, :protected, read_concurrency: true])
+    :ets.insert(name, {:partitions, partitions})
+    Supervisor.init(children, init_opts)
+  end
+
+  @doc """
+  Returns the number of partitions for the partition supervisor.  
+  """
+  @doc since: "1.14.0"
+  @spec partitions(name()) :: pos_integer()
+  def partitions(supervisor) when is_atom(supervisor) do
+    :ets.lookup_element(supervisor, :partitions, 2)
+  end
+
+  @doc """
+  Returns a list with information about all children.
+
+  This function returns a list of tuples containing:
+
+    * `id` - the partition number
+
+    * `child` - the PID of the corresponding child process or the
+      atom `:restarting` if the process is about to be restarted
+
+    * `type` - `:worker` or `:supervisor` as defined in the child
+      specification
+
+    * `modules` - as defined in the child specification
+
+  """
+  @doc since: "1.14.0"
+  @spec which_children(name()) :: [
+          # module() | :dynamic here because :supervisor.modules() is not exported
+          {:undefined, pid | :restarting, :worker | :supervisor, [module()] | :dynamic}
+        ]
+  def which_children(supervisor) when is_atom(supervisor) do
+    Supervisor.which_children(supervisor)
+  end
+
+  @doc """
+  Returns a map containing count values for the supervisor.
+
+  The map contains the following keys:
+
+    * `:specs` - the number of partitions (children processes)
+
+    * `:active` - the count of all actively running child processes managed by
+      this supervisor
+
+    * `:supervisors` - the count of all supervisors whether or not the child
+      process is still alive
+
+    * `:workers` - the count of all workers, whether or not the child process
+      is still alive
+
+  """
+  @doc since: "1.14.0"
+  @spec count_children(name()) :: %{
+          specs: non_neg_integer,
+          active: non_neg_integer,
+          supervisors: non_neg_integer,
+          workers: non_neg_integer
+        }
+  def count_children(supervisor) when is_atom(supervisor) do
+    Supervisor.count_children(supervisor)
+  end
+
+  @doc """
+  Synchronously stops the given partition supervisor with the given `reason`.
+
+  It returns `:ok` if the supervisor terminates with the given
+  reason. If it terminates with another reason, the call exits.
+
+  This function keeps OTP semantics regarding error reporting.
+  If the reason is any other than `:normal`, `:shutdown` or
+  `{:shutdown, _}`, an error report is logged.
+  """
+  @doc since: "1.14.0"
+  @spec stop(name(), reason :: term, timeout) :: :ok
+  def stop(supervisor, reason \\ :normal, timeout \\ :infinity) when is_atom(supervisor) do
+    Supervisor.stop(supervisor, reason, timeout)
+  end
+
+  ## Via callbacks
+
+  @doc false
+  def whereis_name({name, key}) when is_atom(name) do
+    partitions = partitions(name)
+
+    partition =
+      if is_integer(key), do: rem(abs(key), partitions), else: :erlang.phash2(key, partitions)
+
+    :ets.lookup_element(name, partition, 2)
+  end
+
+  @doc false
+  def send(name_key, msg) do
+    Kernel.send(whereis_name(name_key), msg)
+  end
+
+  @doc false
+  def register_name(_, _) do
+    raise "{:via, PartitionSupervisor, _} cannot be given on registration"
+  end
+
+  @doc false
+  def unregister_name(_, _) do
+    raise "{:via, PartitionSupervisor, _} cannot be given on unregistration"
+  end
+end

--- a/lib/elixir/lib/partition_supervisor.ex
+++ b/lib/elixir/lib/partition_supervisor.ex
@@ -1,6 +1,6 @@
 defmodule PartitionSupervisor do
   @moduledoc """
-  A supervisor with that starts multiple partitions of the same child.
+  A supervisor that starts multiple partitions of the same child.
 
   Certain processes may become bottlenecks in large systems.
   If those processes can have their state trivially partitioned,

--- a/lib/elixir/lib/partition_supervisor.ex
+++ b/lib/elixir/lib/partition_supervisor.ex
@@ -96,8 +96,8 @@ defmodule PartitionSupervisor do
       ]
 
   If the supervisor is successfully spawned, this function returns
-  `{:ok, pid}`, where `pid` is the PID of the supervisor. If the supervisor
-  is given a name and a process with the specified name already exists,
+  `{:ok, pid}`, where `pid` is the PID of the supervisor. If the given name
+    for the partition supervisor is already assigned to a process,
   the function returns `{:error, {:already_started, pid}}`, where `pid`
   is the PID of that process.
 
@@ -108,6 +108,9 @@ defmodule PartitionSupervisor do
   ## Options
 
     * `:name` - an atom representing the name of the partition supervisor.
+
+    * `:partitions` - a positive integer with the number of partitions.
+      Defaults to `System.schedulers_online()` (typically the number of cores).
 
     * `:strategy` - the restart strategy option, defaults to `:one_for_one`.
       You can learn more about strategies in the `Supervisor` module docs.
@@ -235,7 +238,7 @@ defmodule PartitionSupervisor do
   """
   @doc since: "1.14.0"
   @spec which_children(name()) :: [
-          # module() | :dynamic here because :supervisor.modules() is not exported
+          # Inlining [module()] | :dynamic here because :supervisor.modules() is not exported
           {:undefined, pid | :restarting, :worker | :supervisor, [module()] | :dynamic}
         ]
   def which_children(supervisor) when is_atom(supervisor) do

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -960,7 +960,7 @@ defmodule Supervisor do
           workers: non_neg_integer
         }
   def count_children(supervisor) do
-    call(supervisor, :count_children) |> Map.new()
+    call(supervisor, :count_children) |> :maps.from_list()
   end
 
   @doc """

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -16,7 +16,55 @@ defmodule Task.Supervisor do
 
   The options given in the child specification are documented in `start_link/1`.
 
+  Once started, you can tasks directly under it, for example:
+
+      task = Task.Supervisor.async(MyApp.TaskSupervisor, fn ->
+        :do_some_work
+      end)
+
   See the `Task` module for more examples.
+
+  ## Scalability and partioning
+
+  The `Task.Supervisor` is a single process responsible for starting
+  other processes. In some applications, the `Task.Supervisor` may
+  become a bottleneck. To address this, you can start multiple instances
+  of the `Task.Supervisor` and then pick a random instance to start
+  the task on.
+
+  Instead of:
+
+      children = [
+        {Task.Supervisor, name: Task.Supervisor}
+      ]
+
+  and:
+
+      Task.Supervisor.async(MyApp.TaskSupervisor, fn -> :do_some_work end)
+
+  You can do this:
+
+      children = [
+        {PartitionSupervisor,
+         child_spec: Task.Supervisor,
+         name: MyApp.TaskSupervisors}
+      ]
+
+  and then:
+
+      Task.Supervisor.async(
+        {:via, PartitionSupervisor, {MyApp.TaskSupervisors, self()}},
+        fn -> :do_some_work end
+      )
+
+  In the code above, we start a partition supervisor that will by default
+  start a dynamic supervisor for each core in your machine. Then, instead
+  of calling the `Task.Supervisor` by name, you call it through the
+  partition supervisor using the `{:via, PartitionSupervisor, {name, key}}`
+  format, where `name` is the name of the partition supervisor and `key`
+  is the routing key. We picked `self()` as the routing key, which means
+  each process will be assigned one of the existing task supervisors.
+  Read the `PartitionSupervisor` docs for more information.
 
   ## Name registration
 

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -24,7 +24,7 @@ defmodule Task.Supervisor do
 
   See the `Task` module for more examples.
 
-  ## Scalability and partioning
+  ## Scalability and partitioning
 
   The `Task.Supervisor` is a single process responsible for starting
   other processes. In some applications, the `Task.Supervisor` may

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -16,7 +16,7 @@ defmodule Task.Supervisor do
 
   The options given in the child specification are documented in `start_link/1`.
 
-  Once started, you can tasks directly under it, for example:
+  Once started, you can start tasks directly under the supervisor, for example:
 
       task = Task.Supervisor.async(MyApp.TaskSupervisor, fn ->
         :do_some_work

--- a/lib/elixir/test/elixir/dynamic_supervisor_test.exs
+++ b/lib/elixir/test/elixir/dynamic_supervisor_test.exs
@@ -10,7 +10,7 @@ defmodule DynamicSupervisorTest do
   end
 
   test "can be supervised directly" do
-    children = [{DynamicSupervisor, strategy: :one_for_one, name: :dyn_sup_spec_test}]
+    children = [{DynamicSupervisor, name: :dyn_sup_spec_test}]
     assert {:ok, _} = Supervisor.start_link(children, strategy: :one_for_one)
     assert DynamicSupervisor.which_children(:dyn_sup_spec_test) == []
   end
@@ -19,10 +19,9 @@ defmodule DynamicSupervisorTest do
     {:ok, _} = Registry.start_link(keys: :unique, name: DynSup.Registry)
 
     children = [
-      {DynamicSupervisor, strategy: :one_for_one, name: :simple_name},
-      {DynamicSupervisor, strategy: :one_for_one, name: {:global, :global_name}},
-      {DynamicSupervisor,
-       strategy: :one_for_one, name: {:via, Registry, {DynSup.Registry, "via_name"}}}
+      {DynamicSupervisor, name: :simple_name},
+      {DynamicSupervisor, name: {:global, :global_name}},
+      {DynamicSupervisor, name: {:via, Registry, {DynSup.Registry, "via_name"}}}
     ]
 
     assert {:ok, supsup} = Supervisor.start_link(children, strategy: :one_for_one)
@@ -69,7 +68,7 @@ defmodule DynamicSupervisorTest do
 
   describe "init/1" do
     test "set default options" do
-      assert DynamicSupervisor.init(strategy: :one_for_one) ==
+      assert DynamicSupervisor.init([]) ==
                {:ok,
                 %{
                   strategy: :one_for_one,

--- a/lib/elixir/test/elixir/partition_supervisor_test.exs
+++ b/lib/elixir/test/elixir/partition_supervisor_test.exs
@@ -142,8 +142,10 @@ defmodule PartitionSupervisorTest do
           name: config.test
         )
 
+      partitions = System.schedulers_online()
+
       assert PartitionSupervisor.count_children(config.test) ==
-               %{active: 8, specs: 8, supervisors: 0, workers: 8}
+               %{active: partitions, specs: partitions, supervisors: 0, workers: partitions}
     end
 
     test "with supervisors", config do
@@ -153,8 +155,10 @@ defmodule PartitionSupervisorTest do
           name: config.test
         )
 
+      partitions = System.schedulers_online()
+
       assert PartitionSupervisor.count_children(config.test) ==
-               %{active: 8, specs: 8, supervisors: 8, workers: 0}
+               %{active: partitions, specs: partitions, supervisors: partitions, workers: 0}
     end
   end
 end


### PR DESCRIPTION
A supervisor with that starts multiple partitions of the same child.

Certain processes may become bottlenecks in large systems.
If those processes can have their state trivially partitioned,
in a way there is no dependency between them, then they can use
the `PartitionSupervisor` to create multiple isolated and
independent partitions.

Once the `PartitionSupervisor` starts, you can dispatch to its
children using `{:via, PartitionSupervisor, {name, key}}`, where
`name` is the name of the `PartitionSupervisor` and key is used
for routing.
