### PR TITLE
`MapSet.put_all/2`

### DIFF
--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -275,6 +275,24 @@ defmodule MapSet do
   end
 
   @doc """
+  Inserts all values from enumerable into `map_set`.
+
+  ## Examples
+
+      iex> MapSet.put_all(MapSet.new([1, 2, 3]), [4])
+      #MapSet<[1, 2, 3, 4]>
+      iex> MapSet.put_all(MapSet.new([1, 2, 3]), [3, 4])
+      #MapSet<[1, 2, 3, 4]>
+
+  """
+  @doc since: "1.14.0"
+  @spec put_all(t, Enum.t()) :: t
+  def put_all(%MapSet{map: map} = map_set, enumerable) do
+    keys = Enum.to_list(enumerable)
+    %{map_set | map: Map.merge(map, Map.from_keys(keys, @dummy_value))}
+  end
+
+  @doc """
   Returns the number of elements in `map_set`.
 
   ## Examples

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -281,8 +281,8 @@ defmodule MapSet do
 
       iex> MapSet.put_all(MapSet.new([1, 2, 3]), [4])
       #MapSet<[1, 2, 3, 4]>
-      iex> MapSet.put_all(MapSet.new([1, 2, 3]), [3, 4])
-      #MapSet<[1, 2, 3, 4]>
+      iex> MapSet.put_all(MapSet.new([1, 2, 3]), [3, 5])
+      #MapSet<[1, 2, 3, 5]>
 
   """
   @doc since: "1.14.0"


### PR DESCRIPTION
Hi everyone. I feel like this function would be a nice addition to the stdlib. The best alternative that I can find for adding keys in bulk is to call `MapSet.union(set, MapSet.new([3,4]))`. `MapSet.put_all(set, [3,4])` is more concise and readable. Thank you and please let me know if there's anything that I can do to help get this merged.