### PR TITLE
Set a max line_length for Macro.to_string

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -957,7 +957,7 @@ defmodule Macro do
   """
   @spec to_string(t()) :: String.t()
   def to_string(tree) do
-    doc = Inspect.Algebra.format(Code.quoted_to_algebra(tree), :infinity)
+    doc = Inspect.Algebra.format(Code.quoted_to_algebra(tree), 98)
     IO.iodata_to_binary(doc)
   end
 

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -723,8 +723,12 @@ defmodule KernelTest do
       result = expand_to_string(quote(do: rand() in 1..2))
       assert result =~ "var = rand()"
 
-      assert result =~
-               ":erlang.andalso(:erlang.is_integer(var), :erlang.andalso(:erlang.>=(var, 1), :erlang.\"=<\"(var, 2)))"
+      assert result =~ """
+             :erlang.andalso(
+               :erlang.is_integer(var),
+               :erlang.andalso(:erlang.>=(var, 1), :erlang.\"=<\"(var, 2))
+             )\
+             """
 
       # Empty list
       assert expand_to_string(quote(do: :x in [])) =~ "_ = :x\nfalse"
@@ -754,14 +758,26 @@ defmodule KernelTest do
       assert expand_to_string(quote(do: foo in [])) ==
                "_ = foo\nfalse"
 
-      assert expand_to_string(quote(do: foo in [1, 2, 3])) ==
-               ":erlang.orelse(:erlang.orelse(:erlang.\"=:=\"(foo, 1), :erlang.\"=:=\"(foo, 2)), :erlang.\"=:=\"(foo, 3))"
+      assert expand_to_string(quote(do: foo in [1, 2, 3])) == """
+             :erlang.orelse(
+               :erlang.orelse(:erlang.\"=:=\"(foo, 1), :erlang.\"=:=\"(foo, 2)),
+               :erlang.\"=:=\"(foo, 3)
+             )\
+             """
 
-      assert expand_to_string(quote(do: foo in 0..1)) ==
-               ":erlang.andalso(:erlang.is_integer(foo), :erlang.andalso(:erlang.>=(foo, 0), :erlang.\"=<\"(foo, 1)))"
+      assert expand_to_string(quote(do: foo in 0..1)) == """
+             :erlang.andalso(
+               :erlang.is_integer(foo),
+               :erlang.andalso(:erlang.>=(foo, 0), :erlang.\"=<\"(foo, 1))
+             )\
+             """
 
-      assert expand_to_string(quote(do: foo in -1..0)) ==
-               ":erlang.andalso(:erlang.is_integer(foo), :erlang.andalso(:erlang.>=(foo, -1), :erlang.\"=<\"(foo, 0)))"
+      assert expand_to_string(quote(do: foo in -1..0)) == """
+             :erlang.andalso(
+               :erlang.is_integer(foo),
+               :erlang.andalso(:erlang.>=(foo, -1), :erlang.\"=<\"(foo, 0))
+             )\
+             """
 
       assert expand_to_string(quote(do: foo in 1..1)) ==
                ":erlang.\"=:=\"(foo, 1)"


### PR DESCRIPTION
Fixes #11469

I'm not 100% about where would be the best place to add a test, if one is needed