### PR TITLE
Add Map.split_with/2 and Keyword.split_with/2

### DIFF
--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1186,6 +1186,48 @@ defmodule Keyword do
   end
 
   @doc """
+  Splits the `keywords` into two keyword lists according to the given function
+  `fun`.
+
+  Splits the given `keywords` into two keyword lists by calling the provided
+  `fun` which receives each `{key, value}` pair in the `keywords` as its only
+  argument. Returns a tuple with the first keyword list containing all the
+  elements in `keywords` for which applying `fun` returned a truthy value, and
+  a second keyword list with all the elements for which applying `fun` returned
+  a falsy value (`false` or `nil`).
+
+  See the examples below.
+
+  ## Examples
+
+      iex> Keyword.split_with([a: 1, b: 2, c: 3], fn {_k, v} -> rem(v, 2) == 0 end)
+      {[b: 2], [a: 1, c: 3]}
+
+      iex> Keyword.split_with([a: 1, b: 2, c: 3, b: 4], fn {_k, v} -> rem(v, 2) == 0 end)
+      {[b: 2, b: 4], [a: 1, c: 3]}
+
+      iex> Keyword.split_with([a: 1, b: 2, c: 3, b: 4], fn {k, v} -> k in [:a, :c] and rem(v, 2) == 0 end)
+      {[], [a: 1, b: 2, c: 3, b: 4]}
+
+      iex> Keyword.split_with([], fn {_k, v} -> rem(v, 2) == 0 end)
+      {[], []}
+
+  """
+  @doc since: "1.14.0"
+  @spec split_with(t, ({key, value} -> as_boolean(term))) :: {t, t}
+  def split_with(keywords, fun) when is_list(keywords) and is_function(fun, 1) do
+    fun = fn key_vaue_pair, {while_true, while_false} ->
+      if fun.(key_vaue_pair) do
+        {[key_vaue_pair | while_true], while_false}
+      else
+        {while_true, [key_vaue_pair | while_false]}
+      end
+    end
+
+    :lists.foldr(fun, {[], []}, keywords)
+  end
+
+  @doc """
   Takes all entries corresponding to the given `keys` and returns them as a new
   keyword list.
 

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1189,8 +1189,7 @@ defmodule Keyword do
   Splits the `keywords` into two keyword lists according to the given function
   `fun`.
 
-  Splits the given `keywords` into two keyword lists by calling the provided
-  `fun` which receives each `{key, value}` pair in the `keywords` as its only
+  The provided `fun` receives each `{key, value}` pair in the `keywords` as its only
   argument. Returns a tuple with the first keyword list containing all the
   elements in `keywords` for which applying `fun` returned a truthy value, and
   a second keyword list with all the elements for which applying `fun` returned

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -343,7 +343,7 @@ defmodule Keyword do
               do: if(is_atom(value), do: value, else: elem(value, 0))
 
         message =
-          case Enum.split_with(invalid_keys, &(&1 in keys)) do
+          case split_with(invalid_keys, &(&1 in keys)) do
             {_, [_ | _] = unknown} ->
               "unknown keys #{inspect(unknown)} in #{inspect(keyword)}, " <>
                 "the allowed keys are: #{inspect(keys)}"
@@ -1211,14 +1211,14 @@ defmodule Keyword do
       {[], []}
 
   """
-  @doc since: "1.14.0"
+  @doc since: "1.15.0"
   @spec split_with(t, ({key, value} -> as_boolean(term))) :: {t, t}
   def split_with(keywords, fun) when is_list(keywords) and is_function(fun, 1) do
-    fun = fn key_vaue_pair, {while_true, while_false} ->
-      if fun.(key_vaue_pair) do
-        {[key_vaue_pair | while_true], while_false}
+    fun = fn key_value_pair, {while_true, while_false} ->
+      if fun.(key_value_pair) do
+        {[key_value_pair | while_true], while_false}
       else
-        {while_true, [key_vaue_pair | while_false]}
+        {while_true, [key_value_pair | while_false]}
       end
     end
 

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -1196,8 +1196,6 @@ defmodule Keyword do
   a second keyword list with all the elements for which applying `fun` returned
   a falsy value (`false` or `nil`).
 
-  See the examples below.
-
   ## Examples
 
       iex> Keyword.split_with([a: 1, b: 2, c: 3], fn {_k, v} -> rem(v, 2) == 0 end)

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -864,8 +864,6 @@ defmodule Map do
   applying `fun` returned a truthy value, and a second map with all the elements
   for which applying `fun` returned a falsy value (`false` or `nil`).
 
-  See the examples below.
-
   ## Examples
 
       iex> Map.split_with(%{a: 1, b: 2, c: 3, d: 4}, fn {_k, v} -> rem(v, 2) == 0 end)

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -856,6 +856,55 @@ defmodule Map do
   end
 
   @doc """
+  Splits the `map` into two maps according to the given function `fun`.
+
+  Splits the given `map` into two maps by calling the provided `fun` which
+  receives each `{key, value}` pair in the `map` as its only argument. Returns
+  a tuple with the first map containing all the elements in `map` for which
+  applying `fun` returned a truthy value, and a second map with all the elements
+  for which applying `fun` returned a falsy value (`false` or `nil`).
+
+  See the examples below.
+
+  ## Examples
+
+      iex> Map.split_with(%{a: 1, b: 2, c: 3, d: 4}, fn {_k, v} -> rem(v, 2) == 0 end)
+      {%{b: 2, d: 4}, %{a: 1, c: 3}}
+
+      iex> Map.split_with(%{a: 1, b: -2, c: 1, d: -3}, fn {k, _v} -> k in [:b, :d] end)
+      {%{b: -2, d: -3}, %{a: 1, c: 1}}
+
+      iex> Map.split_with(%{a: 1, b: -2, c: 1, d: -3}, fn {_k, v} -> v > 50 end)
+      {%{}, %{a: 1, b: -2, c: 1, d: -3}}
+
+      iex> Map.split_with(%{}, fn {_k, v} -> v > 50 end)
+      {%{}, %{}}
+
+  """
+  @doc since: "1.14.0"
+  @spec split_with(map, ({key, value} -> as_boolean(term))) :: {map, map}
+  def split_with(map, fun) when is_map(map) and is_function(fun, 1) do
+    iter = :maps.iterator(map)
+    next = :maps.next(iter)
+
+    do_split_with(next, fun)
+  end
+
+  defp do_split_with(acc \\ {[], []}, next, fun)
+
+  defp do_split_with({while_true, while_false}, :none, _fun) do
+    {:maps.from_list(while_true), :maps.from_list(while_false)}
+  end
+
+  defp do_split_with({while_true, while_false}, {key, value, iter}, fun) do
+    if fun.({key, value}) do
+      do_split_with({[{key, value} | while_true], while_false}, :maps.next(iter), fun)
+    else
+      do_split_with({while_true, [{key, value} | while_false]}, :maps.next(iter), fun)
+    end
+  end
+
+  @doc """
   Updates `key` with the given function.
 
   If `key` is present in `map` then the existing value is passed to `fun` and its result is

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -879,7 +879,7 @@ defmodule Map do
       {%{}, %{}}
 
   """
-  @doc since: "1.14.0"
+  @doc since: "1.15.0"
   @spec split_with(map, ({key, value} -> as_boolean(term))) :: {map, map}
   def split_with(map, fun) when is_map(map) and is_function(fun, 1) do
     iter = :maps.iterator(map)

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -885,20 +885,18 @@ defmodule Map do
     iter = :maps.iterator(map)
     next = :maps.next(iter)
 
-    do_split_with(next, fun)
+    do_split_with(next, [], [], fun)
   end
 
-  defp do_split_with(acc \\ {[], []}, next, fun)
-
-  defp do_split_with({while_true, while_false}, :none, _fun) do
+  defp do_split_with(:none, while_true, while_false, _fun) do
     {:maps.from_list(while_true), :maps.from_list(while_false)}
   end
 
-  defp do_split_with({while_true, while_false}, {key, value, iter}, fun) do
+  defp do_split_with({key, value, iter}, while_true, while_false, fun) do
     if fun.({key, value}) do
-      do_split_with({[{key, value} | while_true], while_false}, :maps.next(iter), fun)
+      do_split_with(:maps.next(iter), [{key, value} | while_true], while_false, fun)
     else
-      do_split_with({while_true, [{key, value} | while_false]}, :maps.next(iter), fun)
+      do_split_with(:maps.next(iter), while_true, [{key, value} | while_false], fun)
     end
   end
 

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -858,8 +858,7 @@ defmodule Map do
   @doc """
   Splits the `map` into two maps according to the given function `fun`.
 
-  Splits the given `map` into two maps by calling the provided `fun` which
-  receives each `{key, value}` pair in the `map` as its only argument. Returns
+  `fun` receives each `{key, value}` pair in the `map` as its only argument. Returns
   a tuple with the first map containing all the elements in `map` for which
   applying `fun` returned a truthy value, and a second map with all the elements
   for which applying `fun` returned a falsy value (`false` or `nil`).

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -375,6 +375,37 @@ defmodule MapSet do
     %{map_set | map: :sets.filter(pred, set)}
   end
 
+  @doc """
+  Splits the `MapSet` into two `MapSet`s according to the given function `fun`.
+
+  Splits the given `MapSet` into two maps by calling the provided `fun` which
+  receives each element in the `MapSet` as its only argument. Returns
+  a tuple with the first `MapSet` containing all the elements in `MapSet` for which
+  applying `fun` returned a truthy value, and a second `MapSet` with all the elements
+  for which applying `fun` returned a falsy value (`false` or `nil`).
+
+  ## Examples
+
+      iex> {while_true, while_false} = MapSet.split_with(MapSet.new([1, 2, 3, 4]), fn v -> rem(v, 2) == 0 end)
+      iex> while_true
+      #MapSet<[2, 4]>
+      iex> while_false
+      #MapSet<[1, 3]>
+
+      iex> {while_true, while_false} = MapSet.split_with(MapSet.new(), fn {_k, v} -> v > 50 end)
+      iex> while_true
+      #MapSet<[]>
+      iex> while_false
+      #MapSet<[]>
+
+  """
+  @doc since: "1.15.0"
+  @spec split_with(MapSet.t(), (any() -> as_boolean(term))) :: {MapSet.t(), MapSet.t()}
+  def split_with(%MapSet{map: map}, fun) when is_function(fun, 1) do
+    {while_true, while_false} = Map.split_with(map, fn {key, _} -> fun.(key) end)
+    {%MapSet{map: while_true}, %MapSet{map: while_false}}
+  end
+
   defimpl Enumerable do
     def count(map_set) do
       {:ok, MapSet.size(map_set)}

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -378,8 +378,7 @@ defmodule MapSet do
   @doc """
   Splits the `MapSet` into two `MapSet`s according to the given function `fun`.
 
-  Splits the given `MapSet` into two maps by calling the provided `fun` which
-  receives each element in the `MapSet` as its only argument. Returns
+  `fun` receives each element in the `MapSet` as its only argument. Returns
   a tuple with the first `MapSet` containing all the elements in `MapSet` for which
   applying `fun` returned a truthy value, and a second `MapSet` with all the elements
   for which applying `fun` returned a falsy value (`false` or `nil`).
@@ -388,15 +387,15 @@ defmodule MapSet do
 
       iex> {while_true, while_false} = MapSet.split_with(MapSet.new([1, 2, 3, 4]), fn v -> rem(v, 2) == 0 end)
       iex> while_true
-      #MapSet<[2, 4]>
+      MapSet.new([2, 4])
       iex> while_false
-      #MapSet<[1, 3]>
+      MapSet.new([1, 3])
 
       iex> {while_true, while_false} = MapSet.split_with(MapSet.new(), fn {_k, v} -> v > 50 end)
       iex> while_true
-      #MapSet<[]>
+      MapSet.new([])
       iex> while_false
-      #MapSet<[]>
+      MapSet.new([])
 
   """
   @doc since: "1.15.0"

--- a/lib/elixir/test/elixir/keyword_test.exs
+++ b/lib/elixir/test/elixir/keyword_test.exs
@@ -215,4 +215,17 @@ defmodule KeywordTest do
                  "expected the second argument to be a list of atoms or tuples, got: 3",
                  fn -> Keyword.validate([three: 3], [:three, 3, :two]) end
   end
+
+  test "split_with/2" do
+    assert Keyword.split_with([], fn {_k, v} -> rem(v, 2) == 0 end) == {[], []}
+
+    assert Keyword.split_with([a: "1", a: 1, b: 2], fn {k, _v} -> k in [:a, :b] end) ==
+             {[a: "1", a: 1, b: 2], []}
+
+    assert Keyword.split_with([a: "1", a: 1, b: 2], fn {_k, v} -> v == 5 end) ==
+             {[], [a: "1", a: 1, b: 2]}
+
+    assert Keyword.split_with([a: "1", a: 1, b: 2], fn {k, v} -> k in [:a] and is_integer(v) end) ==
+             {[a: 1], [a: "1", b: 2]}
+  end
 end

--- a/lib/elixir/test/elixir/map_set_test.exs
+++ b/lib/elixir/test/elixir/map_set_test.exs
@@ -148,6 +148,17 @@ defmodule MapSetTest do
     assert MapSet.equal?(result, MapSet.new([1, 3]))
   end
 
+  test "split_with" do
+    assert MapSet.split_with(MapSet.new(), fn v -> rem(v, 2) == 0 end) ==
+             {MapSet.new(), MapSet.new()}
+
+    assert MapSet.split_with(MapSet.new([1, 2, 3]), fn v -> rem(v, 2) == 0 end) ==
+             {MapSet.new([2]), MapSet.new([1, 3])}
+
+    assert MapSet.split_with(MapSet.new([2, 4, 6]), fn v -> rem(v, 2) == 0 end) ==
+             {MapSet.new([2, 4, 6]), MapSet.new([])}
+  end
+
   test "inspect" do
     assert inspect(MapSet.new([?a])) == "MapSet.new([97])"
   end

--- a/lib/elixir/test/elixir/map_test.exs
+++ b/lib/elixir/test/elixir/map_test.exs
@@ -112,6 +112,22 @@ defmodule MapTest do
     assert_raise BadMapError, fn -> Map.split(:foo, []) end
   end
 
+  test "split_with/2" do
+    assert Map.split_with(%{}, fn {_k, v} -> rem(v, 2) == 0 end) == {%{}, %{}}
+
+    assert Map.split_with(%{a: 1, b: 2, c: 3}, fn {_k, v} -> rem(v, 2) == 0 end) ==
+             {%{b: 2}, %{a: 1, c: 3}}
+
+    assert Map.split_with(%{a: 2, b: 4, c: 6}, fn {_k, v} -> rem(v, 2) == 0 end) ==
+             {%{a: 2, b: 4, c: 6}, %{}}
+
+    assert Map.split_with(%{1 => 1, 2 => 2, 3 => 3}, fn {k, _v} -> rem(k, 2) == 0 end) ==
+             {%{2 => 2}, %{1 => 1, 3 => 3}}
+
+    assert Map.split_with(%{1 => 2, 3 => 4, 5 => 6}, fn {k, _v} -> rem(k, 2) == 0 end) ==
+             {%{}, %{1 => 2, 3 => 4, 5 => 6}}
+  end
+
   test "get_and_update/3" do
     message = "the given function must return a two-element tuple or :pop, got: 1"
 


### PR DESCRIPTION
As per [this discussion](https://groups.google.com/g/elixir-lang-core/c/2OEFTGEHPMM) in mailing group - here is a pr that adds implementations of `split_with/2` to the Map and Keyword modules
