### PR TITLE
Add String.{append/{2, 3}, prepend/{2, 3}, surround/{2, 3}}

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2748,6 +2748,35 @@ defmodule String do
     prepender <> joiner <> string
   end
 
+  @doc """
+  Returns the `string` surrounded by `surrounder`, separated by `joiner`.
+
+  ## Examples
+
+      iex> String.surround("foo", "|")
+      "|foo|"
+      iex> String.surround("foo", {"<", ">"})
+      "<foo>"
+      iex> String.surround("foo", "|", "_")
+      "|_foo_|"
+      iex> String.surround("foo", {"<", ">"}, "-")
+      "<-foo->"
+
+  """
+  @spec surround(t, t | {t, t}, t) :: t
+  def surround(string, surrounder, joiner \\ "")
+
+  def surround(string, surrounder, joiner)
+      when is_binary(string) and is_binary(surrounder) and is_binary(joiner) do
+    surrounder <> joiner <> string <> joiner <> surrounder
+  end
+
+  def surround(string, {prepender, appender}, joiner)
+      when is_binary(string) and is_binary(prepender) and is_binary(appender) and
+             is_binary(joiner) do
+    prepender <> joiner <> string <> joiner <> appender
+  end
+
   ## Helpers
 
   @compile {:inline,

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2731,6 +2731,23 @@ defmodule String do
     string <> joiner <> appender
   end
 
+  @doc """
+  Returns the `string` prepended by `prepender`, separated by `joiner`.
+
+  ## Examples
+
+      iex> String.prepend("alice", "bob")
+      "bobalice"
+      iex> String.prepend("alice", "bob", " & ")
+      "bob & alice"
+
+  """
+  @spec prepend(t, t, t) :: t
+  def prepend(string, prepender, joiner \\ "")
+      when is_binary(string) and is_binary(prepender) and is_binary(joiner) do
+    prepender <> joiner <> string
+  end
+
   ## Helpers
 
   @compile {:inline,

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2714,6 +2714,23 @@ defmodule String do
   @spec to_char_list(t) :: charlist
   def to_char_list(string), do: String.to_charlist(string)
 
+  @doc """
+  Returns the `string` appended by `appender`, separated by `joiner`.
+
+  ## Examples
+
+      iex> String.append("alice", "bob")
+      "alicebob"
+      iex> String.append("alice", "bob", " & ")
+      "alice & bob"
+
+  """
+  @spec append(t, t, t) :: t
+  def append(string, appender, joiner \\ "")
+      when is_binary(string) and is_binary(appender) and is_binary(joiner) do
+    string <> joiner <> appender
+  end
+
   ## Helpers
 
   @compile {:inline,

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -954,6 +954,52 @@ defmodule StringTest do
     end
   end
 
+  test "surround/2" do
+    assert String.surround("alice", "") == "alice"
+    assert String.surround("alice", "/") == "/alice/"
+    assert String.surround("", "") == ""
+    assert String.surround("", "/") == "//"
+
+    assert_raise FunctionClauseError, fn ->
+      String.surround(:alice, "/")
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      String.surround("alice", 6)
+    end
+  end
+
+  test "surround/3" do
+    assert String.surround("alice", "", "") == "alice"
+    assert String.surround("alice", "|", "") == "|alice|"
+    assert String.surround("alice", {"<", ">"}, "") == "<alice>"
+    assert String.surround("alice", "", "-") == "-alice-"
+    assert String.surround("alice", "|", "-") == "|-alice-|"
+    assert String.surround("alice", {"<", ">"}, "-") == "<-alice->"
+    assert String.surround("", "", "") == ""
+    assert String.surround("", "|", "") == "||"
+    assert String.surround("", {"<", ">"}, "") == "<>"
+    assert String.surround("", "", "-") == "--"
+    assert String.surround("", "|", "-") == "|--|"
+    assert String.surround("", {"<", ">"}, "-") == "<-->"
+
+    assert_raise FunctionClauseError, fn ->
+      String.surround(:alice, "|", " ")
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      String.surround("alice", 606, " ")
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      String.surround("alice", {}, " ")
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      String.surround("alice", "|", :separator)
+    end
+  end
+
   # Carriage return can be a grapheme cluster if followed by
   # newline so we test some corner cases here.
   test "carriage return" do

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -916,6 +916,44 @@ defmodule StringTest do
     end
   end
 
+  test "prepend/2" do
+    assert String.prepend("alice", "") == "alice"
+    assert String.prepend("alice", "/") == "/alice"
+    assert String.prepend("", "") == ""
+    assert String.prepend("", "<-") == "<-"
+
+    assert_raise FunctionClauseError, fn ->
+      String.prepend(:alice, "bob")
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      String.prepend("alice", 606)
+    end
+  end
+
+  test "prepend/3" do
+    assert String.prepend("alice", "", "") == "alice"
+    assert String.prepend("alice", "|", "") == "|alice"
+    assert String.prepend("alice", "", "-") == "-alice"
+    assert String.prepend("alice", "|", "-") == "|-alice"
+    assert String.prepend("", "", "") == ""
+    assert String.prepend("", "|", "") == "|"
+    assert String.prepend("", "", "-") == "-"
+    assert String.prepend("", "|", "-") == "|-"
+
+    assert_raise FunctionClauseError, fn ->
+      String.prepend(:alice, "bob", "-")
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      String.prepend("alice", 606, "-")
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      String.prepend("alice", "bob", :separator)
+    end
+  end
+
   # Carriage return can be a grapheme cluster if followed by
   # newline so we test some corner cases here.
   test "carriage return" do

--- a/lib/elixir/test/elixir/string_test.exs
+++ b/lib/elixir/test/elixir/string_test.exs
@@ -878,6 +878,44 @@ defmodule StringTest do
     assert String.normalize("\u0574\u0576", :nfkc) == "\u0574\u0576"
   end
 
+  test "append/2" do
+    assert String.append("alice", "") == "alice"
+    assert String.append("alice", "/") == "alice/"
+    assert String.append("", "") == ""
+    assert String.append("", "->") == "->"
+
+    assert_raise FunctionClauseError, fn ->
+      String.append(:alice, "bob")
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      String.append("alice", 606)
+    end
+  end
+
+  test "append/3" do
+    assert String.append("alice", "", "") == "alice"
+    assert String.append("alice", "|", "") == "alice|"
+    assert String.append("alice", "", "-") == "alice-"
+    assert String.append("alice", "|", "-") == "alice-|"
+    assert String.append("", "", "") == ""
+    assert String.append("", "|", "") == "|"
+    assert String.append("", "", "-") == "-"
+    assert String.append("", "|", "-") == "-|"
+
+    assert_raise FunctionClauseError, fn ->
+      String.append(:alice, "bob", "-")
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      String.append("alice", 606, "-")
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      String.append("alice", "bob", :separator)
+    end
+  end
+
   # Carriage return can be a grapheme cluster if followed by
   # newline so we test some corner cases here.
   test "carriage return" do


### PR DESCRIPTION
`String.append`, `String.prepend` and `String.surround` are three helper functions allowing this transformations more piping complient.

Example:

Let's say we have this function:

```elixir
def string_list_to_elixir_sigil(words, sigil_char, surrounder \\ "/") do
  block = Enum.join(words, " ")
  "~#{sigil_char}#{surrounder}#{block}#{surrounder}"
end

# [...]

string_list_to_elixir_sigil(["foo",` "bar"], "w")
#=> "~w/foo bar/"
```

But you want to use piping to be more expressive:

```elixir
def string_list_to_elixir_sigil(words, sigil_char, surrounder \\ "/") do
  words
  |> Enum.join(" ")
  |> (fn word -> "#{surrounder}#{word}#{surrounder}" end).()
  |> (fn block -> "~#{sigil_char}#{block}" end).()
end
```

Not so readable, the first version is probably much better.

This PR add this option:

```elixir
def string_list_to_elixir_sigil(words, sigil_char, surrounder \\ "/") do
  words
  |> Enum.join(" ")
  |> String.surround(surrounder) # e.g. `surrounder` can be `{"(", ")"}` here
  |> String.append("~#{sigil_char}")
end
``` 

Moreover, the `surrounder` parameter of `String.surround` can be a tuple of `{prepender, appender}`.
