### PR TITLE
Add `Enum.split_evenly/1`

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3190,6 +3190,27 @@ defmodule Enum do
   end
 
   @doc """
+  Splits `enumerable` into two enumerables by elements on
+  odd and even positions.
+
+  It returns two-element tuple with lists of elements
+  on even and odd positions.
+
+  ## Examples
+
+      iex> Enum.split_evenly([1, 2, 3, 4])
+      {[1, 3], [2, 4]}
+
+      iex> Enum.split_evenly(1..5)
+      {[1, 3, 5], [2, 4]}
+
+  """
+  @spec split_while(t) :: {list, list}
+  def split_evenly(enumerable) do
+    {take_every(enumerable, 2), drop_every(enumerable, 2)}
+  end
+
+  @doc """
   Splits enumerable in two at the position of the element for which
   `fun` returns a falsy value (`false` or `nil`) for the first time.
 

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -1225,6 +1225,14 @@ defmodule EnumTest do
     end
   end
 
+  test "split_evenly/1" do
+    assert Enum.split_evenly([1, 2, 3, 4]) == {[1, 3], [2, 4]}
+    assert Enum.split_evenly([1, 2, 3, 4, 5]) == {[1, 3, 5], [2, 4]}
+    assert Enum.split_evenly(1..4) == {[1, 3], [2, 4]}
+    assert Enum.split_evenly(1..5) == {[1, 3, 5], [2, 4]}
+    assert Enum.split_evenly([]) == {[], []}
+  end
+
   test "split_while/2" do
     assert Enum.split_while([1, 2, 3], fn _ -> false end) == {[], [1, 2, 3]}
     assert Enum.split_while([1, 2, 3], fn _ -> true end) == {[1, 2, 3], []}


### PR DESCRIPTION
I am currently learning Elixir and using it to write algorithms.
I am amazed with amount of expressive functions that can be use with pipe to make nice-looking algorithm implementation.

This function inspired by this part of the task:
`The first, third and fifth digits, as well as the second and fourth digits are added separately.`

My first attempt to split digits on even and odd positions was:
```elixir
digits
|> with_index()
|> split_with(fn {_n, i} -> rem(i, 2) == 0 end)
|> Tuple.to_list()
|> map(&map(&1, fn {n, _i} -> n end))
```

And second:
```elixir
digits
|> then(fn digits ->
  [take_every(digits, 2), drop_every(digits, 2)]
end)
```

And my think was: "Can it be shorter and more expressive?", and than `Enum.split_evenly/1` was created.
I hope this function is ok to style of elixir and can be useful.