### PR TITLE
Use Enumerable.t() outside Enum module

### DIFF
--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -1316,11 +1316,11 @@ defmodule TypespecTest do
         end
       end
 
-      msg = ~r/The type two_bad_variables\/2 has an invalid argument\(s\): :ok, Enum.t\(\)/
+      msg = ~r/The type two_bad_variables\/2 has an invalid argument\(s\): :ok, Enumerable.t\(\)/
 
       assert_raise CompileError, msg, fn ->
         test_module do
-          @type two_bad_variables(:ok, Enum.t()) :: {:ok, []}
+          @type two_bad_variables(:ok, Enumerable.t()) :: {:ok, []}
         end
       end
 


### PR DESCRIPTION
To be consistent with b1414ee1d0d78a6681303d24a07e2254bcb76e39