### PR TITLE
Remove double when on TODO comment

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -294,7 +294,7 @@ defmodule String do
     * a compiled search pattern created by `:binary.compile_pattern/1`
 
   """
-  # TODO: Replace "nonempty_binary :: <<_::8, _::_*8>>" with "nonempty_binary()" when
+  # TODO: Replace "nonempty_binary :: <<_::8, _::_*8>>" with "nonempty_binary()"
   # when minimum requirement is >= OTP 24.
   @type pattern ::
           t()


### PR DESCRIPTION
I'm not sure if this is right, so I'm leaving it here as a suggestion, but it seems like there is a double "when" on the TODO comment.