### PR TITLE
Make Base.decode16's odd-length message more helpful

### DIFF
--- a/lib/elixir/lib/base.ex
+++ b/lib/elixir/lib/base.ex
@@ -349,7 +349,8 @@ defmodule Base do
   end
 
   def decode16!(string, _opts) when is_binary(string) do
-    raise ArgumentError, "odd-length string"
+    raise ArgumentError,
+          "odd-length string:\nAn even number of bytes was expected, but got #{byte_size(string)}.\nDo you need to String.trim?"
   end
 
   @doc """
@@ -928,7 +929,8 @@ defmodule Base do
           <<main::bits, unquote(fun)(c1)::4, unquote(fun)(c2)::4>>
 
         <<_::8>> ->
-          raise ArgumentError, "odd-length string"
+          raise ArgumentError,
+                "odd-length string:\nAn even number of bytes was expected, but got #{byte_size(string)}.\nDo you need to String.trim?"
 
         <<>> ->
           main

--- a/lib/elixir/lib/base.ex
+++ b/lib/elixir/lib/base.ex
@@ -350,7 +350,8 @@ defmodule Base do
 
   def decode16!(string, _opts) when is_binary(string) do
     raise ArgumentError,
-          "odd-length string:\nAn even number of bytes was expected, but got #{byte_size(string)}.\nDo you need to String.trim?"
+          "string given to decode has wrong length. An even number of bytes was expected, got: #{byte_size(string)}. " <>
+            "Double check your string for unwanted characters or pad it accordingly"
   end
 
   @doc """
@@ -930,7 +931,8 @@ defmodule Base do
 
         <<_::8>> ->
           raise ArgumentError,
-                "odd-length string:\nAn even number of bytes was expected, but got #{byte_size(string)}.\nDo you need to String.trim?"
+                "string given to decode has wrong length. An even number of bytes was expected, got: #{byte_size(string)}. " <>
+                  "Double check your string for unwanted characters or pad it accordingly"
 
         <<>> ->
           main

--- a/lib/elixir/test/elixir/base_test.exs
+++ b/lib/elixir/test/elixir/base_test.exs
@@ -79,11 +79,9 @@ defmodule BaseTest do
   end
 
   test "decode16!/1 errors odd-length string" do
-    assert_raise ArgumentError,
-                 "odd-length string:\nAn even number of bytes was expected, but got 3.\nDo you need to String.trim?",
-                 fn ->
-                   decode16!("666")
-                 end
+    assert_raise ArgumentError, ~r/string given to decode has wrong length/, fn ->
+      decode16!("666")
+    end
   end
 
   test "encode64/1 can deal with empty strings" do

--- a/lib/elixir/test/elixir/base_test.exs
+++ b/lib/elixir/test/elixir/base_test.exs
@@ -79,9 +79,11 @@ defmodule BaseTest do
   end
 
   test "decode16!/1 errors odd-length string" do
-    assert_raise ArgumentError, "odd-length string", fn ->
-      decode16!("666")
-    end
+    assert_raise ArgumentError,
+                 "odd-length string:\nAn even number of bytes was expected, but got 3.\nDo you need to String.trim?",
+                 fn ->
+                   decode16!("666")
+                 end
   end
 
   test "encode64/1 can deal with empty strings" do


### PR DESCRIPTION
As discussed on today's livestream, what to do about "odd-length string" may not be immediately obvious.
