### PR TITLE
Allow bypassing application mode validation in release spec

### DIFF
--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -626,7 +626,7 @@ defmodule Mix.Release do
       for {app, mode} <- modes do
         properties = Map.get(apps, app) || throw({:error, "Unknown application #{inspect(app)}"})
         children = Keyword.get(properties, :applications, [])
-        app not in skip_mode_validation_for && validate_mode!(app, mode, modes, children)
+        app in skip_mode_validation_for || validate_mode!(app, mode, modes, children)
         build_app_for_release(app, mode, properties)
       end
 

--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -617,7 +617,7 @@ defmodule Mix.Release do
       options: options
     } = release
 
-    skip_mode_validation_index =
+    skip_mode_validation_for =
       options
       |> Keyword.get(:skip_mode_validation_for, [])
       |> MapSet.new()
@@ -626,10 +626,7 @@ defmodule Mix.Release do
       for {app, mode} <- modes do
         properties = Map.get(apps, app) || throw({:error, "Unknown application #{inspect(app)}"})
         children = Keyword.get(properties, :applications, [])
-
-        if not MapSet.member?(skip_mode_validation_index, app),
-          do: validate_mode!(app, mode, modes, children)
-
+        app not in skip_mode_validation_for && validate_mode!(app, mode, modes, children)
         build_app_for_release(app, mode, properties)
       end
 

--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -609,13 +609,21 @@ defmodule Mix.Release do
   end
 
   defp build_release_spec(release, modes) do
-    %{name: name, version: version, erts_version: erts_version, applications: apps} = release
+    %{
+      name: name,
+      version: version,
+      erts_version: erts_version,
+      applications: apps,
+      options: options
+    } = release
+
+    validate_application_mode? = Keyword.get(options, :validate_application_mode?, true)
 
     rel_apps =
       for {app, mode} <- modes do
         properties = Map.get(apps, app) || throw({:error, "Unknown application #{inspect(app)}"})
         children = Keyword.get(properties, :applications, [])
-        validate_mode!(app, mode, modes, children)
+        if validate_application_mode?, do: validate_mode!(app, mode, modes, children)
         build_app_for_release(app, mode, properties)
       end
 

--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -617,13 +617,19 @@ defmodule Mix.Release do
       options: options
     } = release
 
-    validate_application_mode? = Keyword.get(options, :validate_application_mode?, true)
+    skip_mode_validation_index =
+      options
+      |> Keyword.get(:skip_mode_validation_for, [])
+      |> MapSet.new()
 
     rel_apps =
       for {app, mode} <- modes do
         properties = Map.get(apps, app) || throw({:error, "Unknown application #{inspect(app)}"})
         children = Keyword.get(properties, :applications, [])
-        if validate_application_mode?, do: validate_mode!(app, mode, modes, children)
+
+        if not MapSet.member?(skip_mode_validation_index, app),
+          do: validate_mode!(app, mode, modes, children)
+
         build_app_for_release(app, mode, properties)
       end
 

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -459,7 +459,9 @@ defmodule Mix.Tasks.Release do
       (atoms) specifying applications to skip strict validation of
       "unsafe" modes. An "unsafe" case is when a parent application
       mode is `:permanent` but one of the applications it depends on
-      is set to `:load`, for example. Defaults to `[]`.
+      is set to `:load`. Use this with care, as a release with
+      invalid modes may no longer boot without additional tweaks.
+      Defaults to `[]`.
 
   Note each release definition can be given as an anonymous function. This
   is useful if some release attributes are expensive to compute:

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -455,6 +455,12 @@ defmodule Mix.Tasks.Release do
     * `:steps` - a list of steps to execute when assembling the release. See
       the "Steps" section for more information.
 
+    * `:validate_application_mode?` - a boolean defining whether the
+      modes of dependencies of an application should be checked for
+      certain "unsafe" modes. An "unsafe" case is when a parent
+      application mode is `:permanent` but one of the applications it
+      depends on is set to `:load`, for example. Defaults to `true`.
+
   Note each release definition can be given as an anonymous function. This
   is useful if some release attributes are expensive to compute:
 

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -455,11 +455,11 @@ defmodule Mix.Tasks.Release do
     * `:steps` - a list of steps to execute when assembling the release. See
       the "Steps" section for more information.
 
-    * `:validate_application_mode?` - a boolean defining whether the
-      modes of dependencies of an application should be checked for
-      certain "unsafe" modes. An "unsafe" case is when a parent
-      application mode is `:permanent` but one of the applications it
-      depends on is set to `:load`, for example. Defaults to `true`.
+    * `:skip_mode_validation_for` - a list of application names
+      (atoms) specifying applications to skip strict validation of
+      "unsafe" modes. An "unsafe" case is when a parent application
+      mode is `:permanent` but one of the applications it depends on
+      is set to `:load`, for example. Defaults to `[]`.
 
   Note each release definition can be given as an anonymous function. This
   is useful if some release attributes are expensive to compute:

--- a/lib/mix/test/mix/release_test.exs
+++ b/lib/mix/test/mix/release_test.exs
@@ -480,8 +480,9 @@ defmodule Mix.ReleaseTest do
                "Application :mix has mode :permanent but it depends on :elixir which is set to :none"
     end
 
-    test "does not raise on child unsafe mode if valid_application_mode? is false" do
-      release = release(applications: [elixir: :load], validate_application_mode?: false)
+    test "does not raise on child unsafe mode if parent is in `skip_mode_validation_for`" do
+      # `:mix` is a parent that depends on `:elixir`
+      release = release(applications: [elixir: :load], skip_mode_validation_for: [:mix])
       assert make_boot_script(release, @boot_script_path, release.boot_scripts.start) == :ok
       assert make_boot_script(release, @boot_script_path, release.boot_scripts.start_clean) == :ok
     end

--- a/lib/mix/test/mix/release_test.exs
+++ b/lib/mix/test/mix/release_test.exs
@@ -479,6 +479,12 @@ defmodule Mix.ReleaseTest do
       assert message =~
                "Application :mix has mode :permanent but it depends on :elixir which is set to :none"
     end
+
+    test "does not raise on child unsafe mode if valid_application_mode? is false" do
+      release = release(applications: [elixir: :load], validate_application_mode?: false)
+      assert make_boot_script(release, @boot_script_path, release.boot_scripts.start) == :ok
+      assert make_boot_script(release, @boot_script_path, release.boot_scripts.start_clean) == :ok
+    end
   end
 
   describe "make_cookie/1" do


### PR DESCRIPTION
Today, there is a mode validation check when doing a Mix Release that
prevents a parent application that has an application mode of
`:permanent`, for example, while a child application has mode `:load`,
as it might be unsafe.

However, some complex applications may need more control over the
application load/start order.  For such cases, the user would need a
way to tell Mix.Release to don't be strict while constructing the
`.rel` file.

Here, we add an option `:skip_mode_validation_for` to the release
options (default: `[]`) which disables such strict check to specified
applicaations.  The default value ensures the current behavior is
preserved.