### PR TITLE
Check plugins first so they can format `.ex` and `.exs` files

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -495,11 +495,11 @@ defmodule Mix.Tasks.Format do
     ext = Path.extname(file)
 
     cond do
-      ext in ~w(.ex .exs) ->
-        &elixir_format(&1, [file: file] ++ formatter_opts)
-
       plugin = find_plugin_for_extension(formatter_opts, ext) ->
         &plugin.format(&1, [extension: ext] ++ formatter_opts)
+
+      ext in ~w(.ex .exs) ->
+        &elixir_format(&1, [file: file] ++ formatter_opts)
 
       true ->
         & &1


### PR DESCRIPTION
Would you consider allowing plugins to override the builtin formatter for `.ex`/`.exs` files?