### PR TITLE
Fix failing doctest for String.replace/3

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1517,7 +1517,7 @@ defmodule String do
   moving the accent to the letter "o":
 
       iex> String.replace(String.normalize("é", :nfd), "e", "o")
-      "ó"
+      "ó"
 
   However, if "é" is represented by the single character "e with acute"
   accent, then it won't be replaced at all:


### PR DESCRIPTION
After updating my fork and running `make test`, I got the following:
```
  1) doctest String.replace/4 (103) (StringTest)
     test/elixir/string_test.exs:6
     Doctest failed
     doctest:
       iex> String.replace(String.normalize("é", :nfd), "e", "o")
       "ó"
     code:  String.replace(String.normalize("é", :nfd), "e", "o") === "ó"
     left:  "ó"
     right: "ó"
     stacktrace:
       lib/string.ex:1519: String (module)
```

Something was wrong with the expected `"ó"` character, so I corrected it. Tests now run without any failures.