### PR TITLE
Streamline t:Enumerable.t/1 docs

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -38,21 +38,21 @@ defprotocol Enumerable do
   """
 
   @typedoc """
-  An enumerable of values with type `value`.
+  An enumerable of elements of type `element`.
 
   This type is equivalent to `t:t/0` but is especially useful for documentation.
 
-  For example, imagine I define a function that expects an enumerable of
+  For example, imagine you define a function that expects an enumerable of
   integers and returns an enumerable of strings:
 
-      @spec ints_to_strings(Enumerable.t(integer())) :: Enumerable.t(String.t())
-      def ints_to_strings(ints) do
-        Stream.map(ints, &Integer.to_string/1)
+      @spec integers_to_strings(Enumerable.t(integer())) :: Enumerable.t(String.t())
+      def integers_to_strings(integers) do
+        Stream.map(integers, &Integer.to_string/1)
       end
 
   """
   @typedoc since: "1.14.0"
-  @type t(_value) :: t()
+  @type t(_element) :: t()
 
   @typedoc """
   The accumulator value for each step.


### PR DESCRIPTION
1. It replaces the your of "I" pronoun with "You" which is the standard in the docs.
2. It replaces "value" with "element" which is the terminology and type used in Enum.
3. It replace "ints" with "integers" to make example more readable.

/cc @whatyouhide 