### PR TITLE
Add note about which attributes support guard notation in typespecs

### DIFF
--- a/lib/elixir/pages/typespecs.md
+++ b/lib/elixir/pages/typespecs.md
@@ -197,9 +197,7 @@ Type variables with no restriction can also be defined using `var`.
 
     @spec function(arg) :: [arg] when arg: var
 
-It is worth nothing that this guard notation will only work when specifiying functions such
-as with attribtues `@spec`, `@callback` and `@macrocallback`. Such notation is not supported
-when specifying types such as with attributes `@type`, `@typep`, and `@opaque`.
+This guard notation only works with `@spec`, `@callback`, and `@macrocallback`.
 
 You can also name your arguments in a typespec using `arg_name :: arg_type` syntax. This is particularly useful in documentation as a way to differentiate multiple arguments of the same type (or multiple elements of the same type in a type definition):
 

--- a/lib/elixir/pages/typespecs.md
+++ b/lib/elixir/pages/typespecs.md
@@ -197,6 +197,10 @@ Type variables with no restriction can also be defined using `var`.
 
     @spec function(arg) :: [arg] when arg: var
 
+It is worth nothing that this guard notation will only work when specifiying functions such
+as with attribtues `@spec`, `@callback` and `@macrocallback`. Such notation is not supported
+when specifying types such as with attributes `@type`, `@typep`, and `@opaque`.
+
 You can also name your arguments in a typespec using `arg_name :: arg_type` syntax. This is particularly useful in documentation as a way to differentiate multiple arguments of the same type (or multiple elements of the same type in a type definition):
 
     @spec days_since_epoch(year :: integer, month :: integer, day :: integer) :: integer


### PR DESCRIPTION
I was hit by this one last night and took me a while to figure it out.

The writing could be improved though.

The Erlang documentation could also be improved.
https://www.erlang.org/doc/reference_manual/typespec.html