### PR TITLE
Warn on 0-arity callbacks inside protocols

### DIFF
--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -731,14 +731,14 @@ defmodule Protocol do
 
   defp callback_ast_to_fa({kind, {:"::", meta, [{name, _, args}, _return]}, _pos})
        when kind in [:callback, :macrocallback] do
-    [{{name, length(args)}, meta}]
+    [{{name, length(List.wrap(args))}, meta}]
   end
 
   defp callback_ast_to_fa(
          {kind, {:when, _, [{:"::", meta, [{name, _, args}, _return]}, _vars]}, _pos}
        )
        when kind in [:callback, :macrocallback] do
-    [{{name, length(args)}, meta}]
+    [{{name, length(List.wrap(args))}, meta}]
   end
 
   defp callback_ast_to_fa({kind, _, _pos}) when kind in [:callback, :macrocallback] do

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1168,9 +1168,11 @@ defmodule Kernel.WarningTest do
 
             def without_specs(term, options \\ [])
 
+            @callback foo :: {:ok, term}
             @callback foo(term) :: {:ok, term}
             @callback foo(term, keyword) :: {:ok, term, keyword}
 
+            @callback foo_when :: {:ok, x} when x: term
             @callback foo_when(x) :: {:ok, x} when x: term
             @callback foo_when(x, opts) :: {:ok, x, opts} when x: term, opts: keyword
 
@@ -1184,10 +1186,16 @@ defmodule Kernel.WarningTest do
       end)
 
     assert message =~
+             "cannot define @callback foo/0 inside protocol, use def/1 to outline your protocol definition\n  nofile:1"
+
+    assert message =~
              "cannot define @callback foo/1 inside protocol, use def/1 to outline your protocol definition\n  nofile:1"
 
     assert message =~
              "cannot define @callback foo/2 inside protocol, use def/1 to outline your protocol definition\n  nofile:1"
+
+    assert message =~
+             "cannot define @callback foo_when/0 inside protocol, use def/1 to outline your protocol definition\n  nofile:1"
 
     assert message =~
              "cannot define @callback foo_when/1 inside protocol, use def/1 to outline your protocol definition\n  nofile:1"


### PR DESCRIPTION
## Motivation

During the upgrade to elixir v1.13 I got a compilation error caused by a 0-arity callback defined inside a protocol. Since  #10912 the expected behavior in these scenarios is to show a warning for the callbacks inside the protocol, seems that we don't yet support 0-arity callbacks defined without parens.

Compilation error:
```
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not a list

    :erlang.length(nil)
    (elixir 1.13.1) lib/protocol.ex:726: Protocol.callback_ast_to_fa/1
    (stdlib 3.17) lists.erl:1254: :lists.flatmap/2
    (elixir 1.13.1) lib/protocol.ex:742: Protocol.callback_metas/2
    (elixir 1.13.1) lib/protocol.ex:761: Protocol.__before_compile__/1
    (stdlib 3.17) lists.erl:1267: :lists.foldl/3
```

Example of a module that triggers the compilation error:

```elixir
defprotocol MyApp.Foo do
  @callback bar :: String.t()
end
````

## Proposed solution

Use `List.wrap/1` when building the warning of callbacks inside a protocol, in order to handle the scenario when `args` is `nil` caused by a `callback` defined without parens.

