### PR TITLE
Add t:Enum.t/1

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -270,6 +270,14 @@ defmodule Enum do
   @compile :inline_list_funcs
 
   @type t :: Enumerable.t()
+
+  @typedoc """
+  An enumerable of elements of type `element`.
+
+  See `t:Enumerable.t/1` for information."
+  """
+  @type t(element) :: Enumerable.t(element)
+
   @type acc :: any
   @type element :: any
 

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -907,7 +907,7 @@ defmodule IEx.HelpersTest do
 
     test "prints type information" do
       assert "@type t() ::" <> _ = capture_io(fn -> t(Enum.t()) end)
-      assert capture_io(fn -> t(Enum.t()) end) == capture_io(fn -> t(Enum.t() / 0) end)
+      assert capture_io(fn -> t(Enum.t()) end) =~ capture_io(fn -> t(Enum.t() / 0) end)
       assert "@type child_spec() ::" <> _ = capture_io(fn -> t(:supervisor.child_spec()) end)
       assert capture_io(fn -> t(URI.t()) end) == capture_io(fn -> t(URI.t() / 0) end)
     end


### PR DESCRIPTION
This is to follow along with the recent introduction of `t:Enumerable.t/1`.

I think it is needed as some people may currently be relying on `t:Enum.t/0` instead of directly calling `t:Enumerable.t/1` ([we were doing it ourselves](https://github.com/elixir-lang/elixir/commit/b1414ee1d0d78a6681303d24a07e2254bcb76e39)) it will have people mixing up `t:Enumerable.t/1` and `t:Enum.t/0` within the same module provided they want to use `t:Enumerable.t/1`, and it could end up confusing both for developers and end-users.

So let's let  developers rely on `t:Enum.t/0` and `t:Enum.t/1` for convenience and minimum code change.

/cc @whatyouhide 