### PR TITLE
Pre-built Elixir release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,15 +23,18 @@ jobs:
             --notes '' \
             --draft \
             ${{ github.ref_name }}
-  release_pre_built:
+  build_zips:
     needs: create_draft_release
     strategy:
       fail-fast: true
       matrix:
         include:
-          - otp_release: 22
-          - otp_release: 23
-          - otp_release: 24
+          - otp: 22
+            otp_version: 22.3
+          - otp: 23
+            otp_version: 23.3
+          - otp: 24
+            otp_version: 24.1
             build_docs: build_docs
     runs-on: ubuntu-18.04
     steps:
@@ -40,25 +43,18 @@ jobs:
           fetch-depth: 50
       - uses: erlef/setup-beam@v1
         with:
-          # The otp-version is the latest version of the release. It doesn't guarantee
-          # the minor (or patch) version when running this workflow.
-          otp-version: ${{ matrix.otp_release }}
+          otp-version: ${{ matrix.otp_version }}
+          version-type: strict
       - name: Build Elixir Release
         run: |
           vsn=$(cat VERSION)
           make Precompiled.zip
-          mv Precompiled-v${vsn}.zip elixir-${vsn}-otp-${{ matrix.otp_release }}.zip
-          shasum -a 1 elixir-${vsn}-otp-${{ matrix.otp_release }}.zip > elixir-${vsn}-otp-${{ matrix.otp_release }}.zip.sha1
-          shasum -a 256 elixir-${vsn}-otp-${{ matrix.otp_release }}.zip > elixir-${vsn}-otp-${{ matrix.otp_release }}.zip.sha256
+          mv Precompiled-v${vsn}.zip elixir-otp-${{ matrix.otp }}.zip
           echo "$PWD/bin" >> $GITHUB_PATH
-      - name: Upload Pre-built
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          vsn=$(cat VERSION)
-          gh release upload --clobber "v${vsn}" \
-            elixir-${vsn}-otp-${{ matrix.otp_release }}.zip \
-            elixir-${vsn}-otp-${{ matrix.otp_release }}.zip.sha{1,256}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: elixir-otp-${{ matrix.otp }}.zip
+          path: elixir-otp-${{ matrix.otp }}.zip
       - uses: actions/checkout@v2
         with:
           repository: elixir-lang/ex_doc
@@ -76,14 +72,53 @@ jobs:
         run: |
           vsn=$(cat VERSION)
           make Docs.zip
-          shasum -a 1 "Docs-v${vsn}.zip" > Docs-v${vsn}.zip.sha1
-          shasum -a 256 "Docs-v${vsn}.zip" > Docs-v${vsn}.zip.sha256
-      - name: Upload Docs
+          mv Docs-v${vsn}.zip Docs.zip
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Docs.zip
+          path: Docs.zip
         if: ${{ matrix.build_docs }}
+  upload_assets:
+    needs: build_zips
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 50
+      - uses: actions/download-artifact@v2
+        with:
+          name: elixir-otp-22.zip
+      - uses: actions/download-artifact@v2
+        with:
+          name: elixir-otp-23.zip
+      - uses: actions/download-artifact@v2
+        with:
+          name: elixir-otp-24.zip
+      - uses: actions/download-artifact@v2
+        with:
+          name: Docs.zip
+      - name: Rename files
+        run: |
+          vsn=$(cat VERSION)
+          mv elixir-otp-22.zip elixir-${vsn}-otp-22.zip
+          mv elixir-otp-23.zip elixir-${vsn}-otp-23.zip
+          mv elixir-otp-24.zip elixir-${vsn}-otp-24.zip
+      - name: Generate checksum
+        run: |
+          vsn=$(cat VERSION)
+          for algo in 1 256
+          do
+            shasum -a ${algo} elixir-${vsn}-otp-22.zip elixir-${vsn}-otp-23.zip elixir-${vsn}-otp-24.zip Docs.zip > "sha${algo}sums.txt"
+          done
+      - name: Upload assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           vsn=$(cat VERSION)
-          gh release upload --clobber "v${vsn}" \
-            Docs-v${vsn}.zip \
-            Docs-v${vsn}.zip.sha{1,256}
+          gh release upload --clobber v${vsn} \
+            elixir-${vsn}-otp-22.zip \
+            elixir-${vsn}-otp-23.zip \
+            elixir-${vsn}-otp-24.zip \
+            Docs.zip \
+            sha1sums.txt \
+            sha256sums.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,18 +23,15 @@ jobs:
             --notes '' \
             --draft \
             ${{ github.ref_name }}
-  build_zips:
+  release_pre_built:
     needs: create_draft_release
     strategy:
       fail-fast: true
       matrix:
         include:
-          - otp: 22
-            otp_version: 22.3
-          - otp: 23
-            otp_version: 23.3
-          - otp: 24
-            otp_version: 24.1
+          - otp_release: 22
+          - otp_release: 23
+          - otp_release: 24
             build_docs: build_docs
     runs-on: ubuntu-18.04
     steps:
@@ -43,18 +40,25 @@ jobs:
           fetch-depth: 50
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{ matrix.otp_version }}
-          version-type: strict
+          # The otp-version is the latest version of the release. It doesn't guarantee
+          # the minor (or patch) version when running this workflow.
+          otp-version: ${{ matrix.otp_release }}
       - name: Build Elixir Release
         run: |
           vsn=$(cat VERSION)
           make Precompiled.zip
-          mv Precompiled-v${vsn}.zip elixir-otp-${{ matrix.otp }}.zip
+          mv Precompiled-v${vsn}.zip elixir-${vsn}-otp-${{ matrix.otp_release }}.zip
+          shasum -a 1 elixir-${vsn}-otp-${{ matrix.otp_release }}.zip > elixir-${vsn}-otp-${{ matrix.otp_release }}.zip.sha1
+          shasum -a 256 elixir-${vsn}-otp-${{ matrix.otp_release }}.zip > elixir-${vsn}-otp-${{ matrix.otp_release }}.zip.sha256
           echo "$PWD/bin" >> $GITHUB_PATH
-      - uses: actions/upload-artifact@v2
-        with:
-          name: elixir-otp-${{ matrix.otp }}.zip
-          path: elixir-otp-${{ matrix.otp }}.zip
+      - name: Upload Pre-built
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          vsn=$(cat VERSION)
+          gh release upload --clobber "v${vsn}" \
+            elixir-${vsn}-otp-${{ matrix.otp_release }}.zip \
+            elixir-${vsn}-otp-${{ matrix.otp_release }}.zip.sha{1,256}
       - uses: actions/checkout@v2
         with:
           repository: elixir-lang/ex_doc
@@ -72,53 +76,14 @@ jobs:
         run: |
           vsn=$(cat VERSION)
           make Docs.zip
-          mv Docs-v${vsn}.zip Docs.zip
-      - uses: actions/upload-artifact@v2
-        with:
-          name: Docs.zip
-          path: Docs.zip
+          shasum -a 1 "Docs-v${vsn}.zip" > Docs-v${vsn}.zip.sha1
+          shasum -a 256 "Docs-v${vsn}.zip" > Docs-v${vsn}.zip.sha256
+      - name: Upload Docs
         if: ${{ matrix.build_docs }}
-  upload_assets:
-    needs: build_zips
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 50
-      - uses: actions/download-artifact@v2
-        with:
-          name: elixir-otp-22.zip
-      - uses: actions/download-artifact@v2
-        with:
-          name: elixir-otp-23.zip
-      - uses: actions/download-artifact@v2
-        with:
-          name: elixir-otp-24.zip
-      - uses: actions/download-artifact@v2
-        with:
-          name: Docs.zip
-      - name: Rename files
-        run: |
-          vsn=$(cat VERSION)
-          mv elixir-otp-22.zip elixir-${vsn}-otp-22.zip
-          mv elixir-otp-23.zip elixir-${vsn}-otp-23.zip
-          mv elixir-otp-24.zip elixir-${vsn}-otp-24.zip
-      - name: Generate checksum
-        run: |
-          vsn=$(cat VERSION)
-          for algo in 1 256
-          do
-            shasum -a ${algo} elixir-${vsn}-otp-22.zip elixir-${vsn}-otp-23.zip elixir-${vsn}-otp-24.zip Docs.zip > "sha${algo}sums.txt"
-          done
-      - name: Upload assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           vsn=$(cat VERSION)
-          gh release upload --clobber v${vsn} \
-            elixir-${vsn}-otp-22.zip \
-            elixir-${vsn}-otp-23.zip \
-            elixir-${vsn}-otp-24.zip \
-            Docs.zip \
-            sha1sums.txt \
-            sha256sums.txt
+          gh release upload --clobber "v${vsn}" \
+            Docs-v${vsn}.zip \
+            Docs-v${vsn}.zip.sha{1,256}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,12 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - otp_release: 22
-          - otp_release: 23
-          - otp_release: 24
+          - otp: 22
+            otp_version: 22.3
+          - otp: 23
+            otp_version: 23.3
+          - otp: 24
+            otp_version: 24.1
             build_docs: build_docs
     runs-on: ubuntu-18.04
     steps:
@@ -40,16 +43,15 @@ jobs:
           fetch-depth: 50
       - uses: erlef/setup-beam@v1
         with:
-          # The otp-version is the latest version of the release. It doesn't guarantee
-          # the minor (or patch) version when running this workflow.
-          otp-version: ${{ matrix.otp_release }}
+          otp-version: ${{ matrix.otp_version }}
+          version-type: strict
       - name: Build Elixir Release
         run: |
           vsn=$(cat VERSION)
           make Precompiled.zip
-          mv Precompiled-v${vsn}.zip elixir-${vsn}-otp-${{ matrix.otp_release }}.zip
-          shasum -a 1 elixir-${vsn}-otp-${{ matrix.otp_release }}.zip > elixir-${vsn}-otp-${{ matrix.otp_release }}.zip.sha1
-          shasum -a 256 elixir-${vsn}-otp-${{ matrix.otp_release }}.zip > elixir-${vsn}-otp-${{ matrix.otp_release }}.zip.sha256
+          mv Precompiled-v${vsn}.zip elixir-${vsn}-otp-${{ matrix.otp }}.zip
+          shasum -a 1 elixir-${vsn}-otp-${{ matrix.otp }}.zip > elixir-${vsn}-otp-${{ matrix.otp }}.zip.sha1sum
+          shasum -a 256 elixir-${vsn}-otp-${{ matrix.otp }}.zip > elixir-${vsn}-otp-${{ matrix.otp }}.zip.sha256sum
           echo "$PWD/bin" >> $GITHUB_PATH
       - name: Upload Pre-built
         env:
@@ -57,8 +59,8 @@ jobs:
         run: |
           vsn=$(cat VERSION)
           gh release upload --clobber "v${vsn}" \
-            elixir-${vsn}-otp-${{ matrix.otp_release }}.zip \
-            elixir-${vsn}-otp-${{ matrix.otp_release }}.zip.sha{1,256}
+            elixir-${vsn}-otp-${{ matrix.otp }}.zip \
+            elixir-${vsn}-otp-${{ matrix.otp }}.zip.sha{1,256}sum
       - uses: actions/checkout@v2
         with:
           repository: elixir-lang/ex_doc
@@ -76,8 +78,9 @@ jobs:
         run: |
           vsn=$(cat VERSION)
           make Docs.zip
-          shasum -a 1 "Docs-v${vsn}.zip" > Docs-v${vsn}.zip.sha1
-          shasum -a 256 "Docs-v${vsn}.zip" > Docs-v${vsn}.zip.sha256
+          mv "Docs-v${vsn}.zip" Docs.zip
+          shasum -a 1 "Docs.zip" > Docs.zip.sha1sum
+          shasum -a 256 "Docs.zip" > Docs.zip.sha256sum
       - name: Upload Docs
         if: ${{ matrix.build_docs }}
         env:
@@ -85,5 +88,5 @@ jobs:
         run: |
           vsn=$(cat VERSION)
           gh release upload --clobber "v${vsn}" \
-            Docs-v${vsn}.zip \
-            Docs-v${vsn}.zip.sha{1,256}
+            Docs.zip \
+            Docs.zip.sha{1,256}sum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,21 @@ env:
   LANG: C.UTF-8
 
 jobs:
+  create_draft_release:
+    runs-on: ubuntu-18.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Create draft release
+        run: |
+          gh release create \
+            --repo ${{ github.repository }} \
+            --title ${{ github.ref_name }} \
+            --notes '' \
+            --draft \
+            ${{ github.ref_name }}
   build_zips:
+    needs: create_draft_release
     strategy:
       fail-fast: true
       matrix:
@@ -64,7 +78,7 @@ jobs:
           name: Docs.zip
           path: Docs.zip
         if: ${{ matrix.build_docs }}
-  create_draft_release:
+  upload_assets:
     needs: build_zips
     runs-on: ubuntu-18.04
     steps:
@@ -96,16 +110,12 @@ jobs:
           do
             shasum -a ${algo} elixir-${vsn}-otp-22.zip elixir-${vsn}-otp-23.zip elixir-${vsn}-otp-24.zip Docs.zip > "sha${algo}sums.txt"
           done
-      - name: Create a release and upload assets
+      - name: Upload assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           vsn=$(cat VERSION)
-          gh release create \
-            --title ${{ github.ref_name }} \
-            --notes '' \
-            --draft \
-            v${vsn} \
+          gh release upload --clobber v${vsn} \
             elixir-${vsn}-otp-22.zip \
             elixir-${vsn}-otp-23.zip \
             elixir-${vsn}-otp-24.zip \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,8 @@ jobs:
           for algo in 1 256
           do
             shasum -a ${algo} elixir-${vsn}-otp-22.zip elixir-${vsn}-otp-23.zip elixir-${vsn}-otp-24.zip Docs.zip > "sha${algo}sums.txt"
+            cat "sha${algo}sums.txt" | sed 's/^/    /' | sed "1s/^/### SHA${algo}||/" | tr '|' '\n' >> notes.md
+            printf '\n\n' >> notes.md
           done
       - name: Create a release and upload assets
         env:
@@ -103,7 +105,7 @@ jobs:
           vsn=$(cat VERSION)
           gh release create \
             --title ${{ github.ref_name }} \
-            --notes '' \
+            --notes-file notes.md \
             --draft \
             v${vsn} \
             elixir-${vsn}-otp-22.zip \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: elixir-lang/ex_doc
+          ref: v0.26.0
           path: ex_doc
         if: ${{ matrix.build_docs }}
       - name: Build ex_doc
@@ -79,8 +80,8 @@ jobs:
           vsn=$(cat VERSION)
           make Docs.zip
           mv "Docs-v${vsn}.zip" Docs.zip
-          shasum -a 1 "Docs.zip" > Docs.zip.sha1sum
-          shasum -a 256 "Docs.zip" > Docs.zip.sha256sum
+          shasum -a 1 Docs.zip > Docs.zip.sha1sum
+          shasum -a 256 Docs.zip > Docs.zip.sha256sum
       - name: Upload Docs
         if: ${{ matrix.build_docs }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,8 +95,6 @@ jobs:
           for algo in 1 256
           do
             shasum -a ${algo} elixir-${vsn}-otp-22.zip elixir-${vsn}-otp-23.zip elixir-${vsn}-otp-24.zip Docs.zip > "sha${algo}sums.txt"
-            cat "sha${algo}sums.txt" | sed 's/^/    /' | sed "1s/^/### SHA${algo}||/" | tr '|' '\n' >> notes.md
-            printf '\n\n' >> notes.md
           done
       - name: Create a release and upload assets
         env:
@@ -105,7 +103,7 @@ jobs:
           vsn=$(cat VERSION)
           gh release create \
             --title ${{ github.ref_name }} \
-            --notes-file notes.md \
+            --notes '' \
             --draft \
             v${vsn} \
             elixir-${vsn}-otp-22.zip \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,21 +10,7 @@ env:
   LANG: C.UTF-8
 
 jobs:
-  create_draft_release:
-    runs-on: ubuntu-18.04
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Create draft release
-        run: |
-          gh release create \
-            --repo ${{ github.repository }} \
-            --title ${{ github.ref_name }} \
-            --notes '' \
-            --draft \
-            ${{ github.ref_name }}
   build_zips:
-    needs: create_draft_release
     strategy:
       fail-fast: true
       matrix:
@@ -78,7 +64,7 @@ jobs:
           name: Docs.zip
           path: Docs.zip
         if: ${{ matrix.build_docs }}
-  upload_assets:
+  create_draft_release:
     needs: build_zips
     runs-on: ubuntu-18.04
     steps:
@@ -110,12 +96,16 @@ jobs:
           do
             shasum -a ${algo} elixir-${vsn}-otp-22.zip elixir-${vsn}-otp-23.zip elixir-${vsn}-otp-24.zip Docs.zip > "sha${algo}sums.txt"
           done
-      - name: Upload assets
+      - name: Create a release and upload assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           vsn=$(cat VERSION)
-          gh release upload --clobber v${vsn} \
+          gh release create \
+            --title ${{ github.ref_name }} \
+            --notes '' \
+            --draft \
+            v${vsn} \
             elixir-${vsn}-otp-22.zip \
             elixir-${vsn}-otp-23.zip \
             elixir-${vsn}-otp-24.zip \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+on:
+  push:
+    tags:
+      - v*
+
+env:
+  ELIXIR_OPTS: "--warnings-as-errors"
+  ERLC_OPTS: "warnings_as_errors"
+  LANG: C.UTF-8
+
+jobs:
+  create_draft_release:
+    runs-on: ubuntu-18.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Create draft release
+        run: |
+          gh release create \
+            --repo ${{ github.repository }} \
+            --title ${{ github.ref_name }} \
+            --notes '' \
+            --draft \
+            ${{ github.ref_name }}
+  release_pre_built:
+    needs: create_draft_release
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - otp_release: 22
+          - otp_release: 23
+          - otp_release: 24
+            build_docs: build_docs
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 50
+      - uses: erlef/setup-beam@v1
+        with:
+          # The otp-version is the latest version of the release. It doesn't guarantee
+          # the minor (or patch) version when running this workflow.
+          otp-version: ${{ matrix.otp_release }}
+      - name: Build Elixir Release
+        run: |
+          vsn=$(cat VERSION)
+          make Precompiled.zip
+          mv Precompiled-v${vsn}.zip elixir-${vsn}-otp-${{ matrix.otp_release }}.zip
+          shasum -a 1 elixir-${vsn}-otp-${{ matrix.otp_release }}.zip > elixir-${vsn}-otp-${{ matrix.otp_release }}.zip.sha1
+          shasum -a 256 elixir-${vsn}-otp-${{ matrix.otp_release }}.zip > elixir-${vsn}-otp-${{ matrix.otp_release }}.zip.sha256
+          echo "$PWD/bin" >> $GITHUB_PATH
+      - name: Upload Pre-built
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          vsn=$(cat VERSION)
+          gh release upload --clobber "v${vsn}" \
+            elixir-${vsn}-otp-${{ matrix.otp_release }}.zip \
+            elixir-${vsn}-otp-${{ matrix.otp_release }}.zip.sha{1,256}
+      - uses: actions/checkout@v2
+        with:
+          repository: elixir-lang/ex_doc
+          path: ex_doc
+        if: ${{ matrix.build_docs }}
+      - name: Build ex_doc
+        if: ${{ matrix.build_docs }}
+        run: |
+          mv ex_doc ../ex_doc
+          cd ../ex_doc
+          ../elixir/bin/mix do local.rebar --force, local.hex --force, deps.get, compile
+          cd ../elixir
+      - name: Build Docs
+        if: ${{ matrix.build_docs }}
+        run: |
+          vsn=$(cat VERSION)
+          make Docs.zip
+          shasum -a 1 "Docs-v${vsn}.zip" > Docs-v${vsn}.zip.sha1
+          shasum -a 256 "Docs-v${vsn}.zip" > Docs-v${vsn}.zip.sha256
+      - name: Upload Docs
+        if: ${{ matrix.build_docs }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          vsn=$(cat VERSION)
+          gh release upload --clobber "v${vsn}" \
+            Docs-v${vsn}.zip \
+            Docs-v${vsn}.zip.sha{1,256}


### PR DESCRIPTION
Trying to tackle #11318. This PR create a new workflow to build and publish asset when GitHub Release is created. Here it's summarized: 

* When the tag is created, the workflow will create a draft release start building Elixir.
* Build Elixir with 3 OTP versions, 22, 23, and 24. And upload assets to the release. Those OTP releases is the latest of OTP in each release.
* Build Docs.zip against OTP 24 and upload it to the release.
* Generate `sha1.txt` and `sha256.txt` for the checksum of zip files.

Here is the workflow [1]: 

<img width="1431" alt="Screen Shot 2564-12-29 at 23 35 34" src="https://user-images.githubusercontent.com/484530/147684228-34afeb14-c9a2-453a-a51a-3f21ede3d9e2.png">

And the release [2]:

<img width="1155" alt="Screen Shot 2564-12-29 at 23 38 20" src="https://user-images.githubusercontent.com/484530/147684304-347ba803-c114-4b45-99e3-108fc71a091d.png">

[1] https://github.com/wingyplus/elixir/actions/runs/1634690409
[2] https://github.com/wingyplus/elixir/releases/tag/v1.14.0-dev

