### PR TITLE
Add type t:Enum.t/1

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -273,6 +273,9 @@ defmodule Enum do
   @type acc :: any
   @type element :: any
 
+  @typedoc since: "1.14.0"
+  @type t(element) :: Enumerable.t(element)
+
   @typedoc "Zero-based index. It can also be a negative integer."
   @type index :: integer
 


### PR DESCRIPTION
It makes sense after recently adding `t:Enumerable.t/1`.