### PR TITLE
Fix typespec for Base.decode16!/2

### DIFF
--- a/lib/elixir/lib/base.ex
+++ b/lib/elixir/lib/base.ex
@@ -340,7 +340,7 @@ defmodule Base do
       "foobar"
 
   """
-  @spec decode16!(binary, case: encode_case) :: binary
+  @spec decode16!(binary, case: decode_case) :: binary
   def decode16!(string, opts \\ [])
 
   def decode16!(string, opts) when is_binary(string) and rem(byte_size(string), 2) == 0 do


### PR DESCRIPTION
Recently I got warning from Dialyzer when calling `Base.decode16!(some_text, case: :mixed)`. I found that the typespec is using `encode_case` type instead of `decode_case` type.