### PR TITLE
Loosen exception type __exception__ field

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -15,7 +15,7 @@ defmodule Exception do
   @typedoc "The exception type"
   @type t :: %{
           required(:__struct__) => module,
-          required(:__exception__) => true,
+          required(:__exception__) => any,
           optional(atom) => any
         }
 


### PR DESCRIPTION
This makes it so that an %ExceptionStruct{} in type specifications
is a subtype of Exception.t().

Example Dialyzer error in behaviuor checking which is avoided thanks
to this change (dialyxir output):

    lib/postgrex/protocol.ex:526:callback_spec_type_mismatch
    The @spec return type does not match the expected return type
    for handle_rollback/2 callback in DBConnection behaviour.

    Actual:
    @spec handle_rollback(...) ::
      {:disconnect,
      %{
        :__exception__ => _,
        :__struct__ => DBConnection.ConnectionError | Postgrex.Error | RuntimeError,
        :message => _,
        :connection_id => _,
        :postgres => _,
        :query => _,
        :reason => _,
        :severity => _
      },
      %Postgrex.Protocol{
        :buffer => :active_once | nil | binary(),
        :connection_id => nil | pos_integer(),
        :connection_key => nil | pos_integer(),
        :disconnect_on_error_codes => [atom()],
        :null => atom(),
        :parameters => reference() | %{binary() => binary()},
        :peer =>
          nil
          | {{byte(), byte(), byte(), byte()}
              | {char(), char(), char(), char(), char(), char(), char(), char()}, char()},
        :postgres =>
          :error
          | :idle
          | :transaction
          | {:error, reference()}
          | {:idle, reference()}
          | {:transaction, reference()},
        :queries => nil | :ets.tid(),
        :sock => {atom(), _},
        :timeout => timeout(),
        :transactions => :naive | :strict,
        :types => atom()
      }}

    Expected:
    @spec handle_rollback(...) ::
      {:error, _}
      | {:idle, _}
      | {:transaction, _}
      | {:disconnect, %{:__exception__ => true, :__struct__ => atom(), atom() => _}, _}
      | {:ok, _, _}