### PR TITLE
Define exception field as true instead of term when expanding struct type

### DIFF
--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -568,7 +568,7 @@ defmodule Kernel.Typespec do
     types =
       :lists.map(
         fn
-          {:__exception__ = field, true} -> {field, Keyword.get(fields, field, quote(do: true))}
+          {:__exception__ = field, true} -> {field, Keyword.get(fields, field, true)}
           {field, _} -> {field, Keyword.get(fields, field, quote(do: term()))}
         end,
         :lists.sort(struct)

--- a/lib/elixir/lib/kernel/typespec.ex
+++ b/lib/elixir/lib/kernel/typespec.ex
@@ -567,7 +567,10 @@ defmodule Kernel.Typespec do
 
     types =
       :lists.map(
-        fn {field, _} -> {field, Keyword.get(fields, field, quote(do: term()))} end,
+        fn
+          {:__exception__ = field, true} -> {field, Keyword.get(fields, field, quote(do: true))}
+          {field, _} -> {field, Keyword.get(fields, field, quote(do: term()))}
+        end,
         :lists.sort(struct)
       )
 

--- a/lib/elixir/test/elixir/typespec_test.exs
+++ b/lib/elixir/test/elixir/typespec_test.exs
@@ -478,6 +478,21 @@ defmodule TypespecTest do
       assert {:type, _, :map_field_exact, [{:atom, _, :other}, {:type, _, :term, []}]} = arg2
     end
 
+    test "@type with an exception struct" do
+      bytecode =
+        test_module do
+          defexception [:message]
+          @type my_type :: %TypespecSample{}
+        end
+
+      assert [type: {:my_type, type, []}] = types(bytecode)
+      assert {:type, _, :map, [struct, arg1, arg2]} = type
+      assert {:type, _, :map_field_exact, struct_args} = struct
+      assert [{:atom, _, :__struct__}, {:atom, _, TypespecSample}] = struct_args
+      assert {:type, _, :map_field_exact, [{:atom, _, :__exception__}, {:atom, _, true}]} = arg1
+      assert {:type, _, :map_field_exact, [{:atom, _, :message}, {:type, _, :term, []}]} = arg2
+    end
+
     @fields Enum.map(10..42, &{:"f#{&1}", :ok})
 
     test "@type with a large struct" do


### PR DESCRIPTION
replaces #11527