### PR TITLE
Fix hidden escape chars in File.stream!/3 docs

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1604,7 +1604,7 @@ defmodule File do
     :file.close(io_device)
   end
 
-  @doc """
+  @doc ~S"""
   Returns a `File.Stream` for the given `path` with the given `modes`.
 
   The stream implements both `Enumerable` and `Collectable` protocols,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18344/147717586-de87f2a6-2f94-4926-9b0a-b5b9ec4da015.png)
