### PR TITLE
Fix the nested `uniq:` acc name clash by preserving a scope

### DIFF
--- a/lib/elixir/test/elixir/kernel/comprehension_test.exs
+++ b/lib/elixir/test/elixir/kernel/comprehension_test.exs
@@ -98,6 +98,19 @@ defmodule Kernel.ComprehensionTest do
     assert Process.get(:into_halt)
   end
 
+  test "nested for comprehensions with unique values" do
+    assert for(x <- [1, 1, 2], uniq: true, do: for(y <- [3, 3], uniq: true, do: x * y)) == [
+             [3],
+             [6]
+           ]
+
+    assert for(<<x <- "abcabc">>,
+             uniq: true,
+             into: "",
+             do: for(<<y <- "zz">>, uniq: true, into: "", do: to_bin(x) <> to_bin(y))
+           ) == "azbzcz"
+  end
+
   test "for comprehensions with nilly filters" do
     assert for(x <- 1..3, nilly(), do: x * 2) == []
   end


### PR DESCRIPTION
Current implementation of `:elixir_erl_for.build_reduce/7` discards a scope, resulting in an accumulator name clash for nested `for/1`s when `into:` option is passed to more than one of them:

```elixir
for x <- [1, 1, 2], uniq: true do
  for y <- [3, 3], uniq: true do
    x * y
  end
end
#⇒ ** (MatchError) no match of right hand side value: {[3], %{3 => true}}
```

Expected behaviour:
```elixir
#⇒ [[3], [6]]
```

This PR provides a fix by preserving a scope in calls to `build_reduce/7`.