### PR TITLE
Use consistent argument name in DateTime doc

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -856,6 +856,8 @@ defmodule DateTime do
 
   """
   @spec to_naive(Calendar.datetime()) :: NaiveDateTime.t()
+  def to_naive(datetime)
+
   def to_naive(%{
         calendar: calendar,
         year: year,
@@ -895,6 +897,8 @@ defmodule DateTime do
 
   """
   @spec to_date(Calendar.datetime()) :: Date.t()
+  def to_date(datetime)
+
   def to_date(%{
         year: year,
         month: month,
@@ -925,6 +929,8 @@ defmodule DateTime do
 
   """
   @spec to_time(Calendar.datetime()) :: Time.t()
+  def to_time(datetime)
+
   def to_time(%{
         year: _,
         month: _,


### PR DESCRIPTION
Hi,

I noticed a couple of functions in the `DateTime` module had the default argument name `map` in the documentation, while the rest is consistently `datetime`.

`to_naive(map)` -> `to_naive(datetime)`