### PR TITLE
Use :erlang.atom_to_binary/1

### DIFF
--- a/lib/elixir/lib/atom.ex
+++ b/lib/elixir/lib/atom.ex
@@ -56,7 +56,7 @@ defmodule Atom do
   """
   @spec to_string(atom) :: String.t()
   def to_string(atom) do
-    :erlang.atom_to_binary(atom, :utf8)
+    :erlang.atom_to_binary(atom)
   end
 
   @doc """

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -415,7 +415,7 @@ parser_location(Meta) ->
   end.
 
 to_binary(List) when is_list(List) -> elixir_utils:characters_to_binary(List);
-to_binary(Atom) when is_atom(Atom) -> atom_to_binary(Atom, utf8).
+to_binary(Atom) when is_atom(Atom) -> atom_to_binary(Atom).
 
 handle_parsing_opts(WarningFile, Opts) ->
   LiteralEncoder =

--- a/lib/elixir/src/elixir_aliases.erl
+++ b/lib/elixir/src/elixir_aliases.erl
@@ -5,7 +5,7 @@
 
 inspect(Atom) when is_atom(Atom) ->
   case elixir_config:is_bootstrap() of
-    true  -> atom_to_binary(Atom, utf8);
+    true  -> atom_to_binary(Atom);
     false -> 'Elixir.Macro':inspect_atom(literal, Atom)
   end.
 
@@ -141,7 +141,7 @@ concat(Args)      -> binary_to_atom(do_concat(Args), utf8).
 safe_concat(Args) -> binary_to_existing_atom(do_concat(Args), utf8).
 
 do_concat([H | T]) when is_atom(H), H /= nil ->
-  do_concat([atom_to_binary(H, utf8) | T]);
+  do_concat([atom_to_binary(H) | T]);
 do_concat([<<"Elixir.", _/binary>>=H | T]) ->
   do_concat(T, H);
 do_concat([<<"Elixir">>=H | T]) ->
@@ -152,7 +152,7 @@ do_concat(T) ->
 do_concat([nil | T], Acc) ->
   do_concat(T, Acc);
 do_concat([H | T], Acc) when is_atom(H) ->
-  do_concat(T, <<Acc/binary, $., (to_partial(atom_to_binary(H, utf8)))/binary>>);
+  do_concat(T, <<Acc/binary, $., (to_partial(atom_to_binary(H)))/binary>>);
 do_concat([H | T], Acc) when is_binary(H) ->
   do_concat(T, <<Acc/binary, $., (to_partial(H))/binary>>);
 do_concat([], Acc) ->

--- a/lib/elixir/src/elixir_erl.erl
+++ b/lib/elixir/src/elixir_erl.erl
@@ -535,7 +535,7 @@ get_type_docs(Set, Types) ->
         {Key, Line, Doc, Meta} <- ets:lookup(Set, {type, Name, Arity})].
 
 signature_to_binary(_Module, Name, _Signature) when Name == '__aliases__'; Name == '__block__' ->
-  <<(atom_to_binary(Name, utf8))/binary, "(args)">>;
+  <<(atom_to_binary(Name))/binary, "(args)">>;
 
 signature_to_binary(_Module, fn, _Signature) ->
   <<"fn(clauses)">>;
@@ -543,7 +543,7 @@ signature_to_binary(_Module, fn, _Signature) ->
 signature_to_binary(_Module, Name, _Signature)
     when Name == '__CALLER__'; Name == '__DIR__'; Name == '__ENV__';
          Name == '__MODULE__'; Name == '__STACKTRACE__'; Name == '%{}' ->
-  atom_to_binary(Name, utf8);
+  atom_to_binary(Name);
 
 signature_to_binary(_Module, '%', _) ->
   <<"%struct{}">>;

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -1192,7 +1192,7 @@ format_error({invalid_alias, Expr}) ->
     "wrap the function or field name in double quotes",
   io_lib:format(Message, ['Elixir.Macro':to_string(Expr)]);
 format_error({op_ambiguity, Name, Arg}) ->
-  NameString = atom_to_binary(Name, utf8),
+  NameString = atom_to_binary(Name),
   ArgString = 'Elixir.Macro':to_string(Arg),
 
   Message =

--- a/lib/elixir/src/elixir_quote.erl
+++ b/lib/elixir/src/elixir_quote.erl
@@ -58,7 +58,7 @@ validate_runtime(Key, Value) ->
     false ->
       erlang:error(
         'Elixir.ArgumentError':exception(
-          <<"invalid runtime value for option :", (erlang:atom_to_binary(Key, utf8))/binary,
+          <<"invalid runtime value for option :", (erlang:atom_to_binary(Key))/binary,
             " in quote, got: ", ('Elixir.Kernel':inspect(Value))/binary>>
         )
       )

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -232,7 +232,7 @@ rewrite(Receiver, DotMeta, Right, Meta, Args) ->
   {EReceiver, ERight, EArgs} = inner_rewrite(ex_to_erl, DotMeta, Receiver, Right, Args),
   {{'.', DotMeta, [EReceiver, ERight]}, Meta, EArgs}.
 
-?rewrite(?atom, to_string, [Arg], erlang, atom_to_binary, [Arg, utf8]);
+?rewrite(?atom, to_string, [Arg], erlang, atom_to_binary, [Arg]);
 ?rewrite(?kernel, is_map_key, [Map, Key], erlang, is_map_key, [Key, Map]);
 ?rewrite(?map, delete, [Map, Key], maps, remove, [Key, Map]);
 ?rewrite(?map, fetch, [Map, Key], maps, find, [Key, Map]);

--- a/lib/elixir/src/elixir_rewrite.erl
+++ b/lib/elixir/src/elixir_rewrite.erl
@@ -51,6 +51,7 @@ erl_to_ex(Mod, Fun, Args) ->
 inline(Mod, Fun, Arity) -> inner_inline(ex_to_erl, Mod, Fun, Arity).
 
 ?inline(?atom, to_charlist, 1, erlang, atom_to_list);
+?inline(?atom, to_string, 1, erlang, atom_to_binary);
 
 ?inline(?bitwise, 'bnot', 1, erlang, 'bnot');
 ?inline(?bitwise, 'band', 2, erlang, 'band');
@@ -232,7 +233,6 @@ rewrite(Receiver, DotMeta, Right, Meta, Args) ->
   {EReceiver, ERight, EArgs} = inner_rewrite(ex_to_erl, DotMeta, Receiver, Right, Args),
   {{'.', DotMeta, [EReceiver, ERight]}, Meta, EArgs}.
 
-?rewrite(?atom, to_string, [Arg], erlang, atom_to_binary, [Arg]);
 ?rewrite(?kernel, is_map_key, [Map, Key], erlang, is_map_key, [Key, Map]);
 ?rewrite(?map, delete, [Map, Key], maps, remove, [Key, Map]);
 ?rewrite(?map, fetch, [Map, Key], maps, find, [Key, Map]);

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -981,7 +981,7 @@ defmodule Kernel.WarningTest do
 
   # TODO: Simplify when we require Erlang/OTP 24
   if System.otp_release() >= "24" do
-    @argument_error_message "the call to :erlang.atom_to_binary/1"
+    @argument_error_message "the call to Atom.to_string/1"
     @arithmetic_error_message "the call to +/2"
   else
     @argument_error_message "this expression"

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -981,7 +981,7 @@ defmodule Kernel.WarningTest do
 
   # TODO: Simplify when we require Erlang/OTP 24
   if System.otp_release() >= "24" do
-    @argument_error_message "the call to :erlang.atom_to_binary/2"
+    @argument_error_message "the call to Atom.to_string/1"
     @arithmetic_error_message "the call to +/2"
   else
     @argument_error_message "this expression"

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -981,7 +981,7 @@ defmodule Kernel.WarningTest do
 
   # TODO: Simplify when we require Erlang/OTP 24
   if System.otp_release() >= "24" do
-    @argument_error_message "the call to Atom.to_string/1"
+    @argument_error_message "the call to :erlang.atom_to_binary/1"
     @arithmetic_error_message "the call to +/2"
   else
     @argument_error_message "this expression"


### PR DESCRIPTION
This function was added in OTP 23 and its the functional equivalent to
`:erlang.atom_to_binary/2` with `:utf8` as the second argument.

Part of #9603 