### PR TITLE
Fix syntax in notifications script

### DIFF
--- a/.github/workflows/notify.exs
+++ b/.github/workflows/notify.exs
@@ -57,5 +57,5 @@ body = %{
   "category" => 28
 }
 
-resp = Req.post!("https://elixirforum.com/posts.json", {:json, body}, headers: headers))
+resp = Req.post!("https://elixirforum.com/posts.json", {:json, body}, headers: headers)
 IO.puts("#{resp.status} Elixir Forum\n#{inspect(resp.body)}")


### PR DESCRIPTION
Fun fact, this was discovered in a tree-sitter-elixir CI run :smile_cat: 