### PR TITLE
remove extra parenthesis in notify.exs script

### DIFF
--- a/.github/workflows/notify.exs
+++ b/.github/workflows/notify.exs
@@ -57,5 +57,5 @@ body = %{
   "category" => 28
 }
 
-resp = Req.post!("https://elixirforum.com/posts.json", {:json, body}, headers: headers))
+resp = Req.post!("https://elixirforum.com/posts.json", {:json, body}, headers: headers)
 IO.puts("#{resp.status} Elixir Forum\n#{inspect(resp.body)}")


### PR DESCRIPTION
:wave: super small fix here, just removing an unmatched parethesis

noticed it in the tree-sitter-elixir CI https://github.com/elixir-lang/tree-sitter-elixir/runs/4748062586?check_suite_focus=true