### PR TITLE
refactoring: File.write!/2  calls File.write/2

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -1044,9 +1044,7 @@ defmodule File do
   """
   @spec write!(Path.t(), iodata, [mode]) :: :ok
   def write!(path, content, modes \\ []) do
-    modes = normalize_modes(modes, false)
-
-    case :file.write_file(path, content, modes) do
+    case write(path, content, modes) do
       :ok ->
         :ok
 


### PR DESCRIPTION
`File.write/2` and `File.write!/2` has similar codes.
this PR change `File.write!/2` to call `File.write/2`, likes `File.rm!` , `File.cp!` ...

other motivation:

`File.write/2` and `File.write!/2` has bit different when passed character list  👀

```
iex(2)> File.write(["hoge.txt"], "content")
:ok
iex(3)> File.write!(["hoge.txt"], "content")
** (File.Error) could not write to file "hoge.txt": bad argument
    (elixir 1.12.2) lib/file.ex:1054: File.write!/3
```