### PR TITLE
Raise ArgumentError with empty list in Path.join/1

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -504,10 +504,14 @@ defmodule Path do
       iex> Path.join(["/", "foo", "bar/"])
       "/foo/bar"
 
+      iex> Path.join([])
+      ** (ArgumentError) list of paths must have at least one element
+
   """
   @spec join(nonempty_list(t)) :: binary
   def join([name1, name2 | rest]), do: join([join(name1, name2) | rest])
   def join([name]), do: IO.chardata_to_string(name)
+  def join([]), do: raise(ArgumentError, "list of paths must have at least one element")
 
   @doc """
   Joins two paths.


### PR DESCRIPTION
We were raising a `FunctionClauseError` which can be pretty obscure
in some cases.

I think the `FunctionClauseError` makes perfect sense if you pass the wrong argument type (not a list in this case), but an empty list feels like a good candidate for a more explicit error.