### PR TITLE
EEP 52: Support for size expression in bitstring matching

### DIFF
--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -6,7 +6,7 @@
 -define(remote(Ann, Module, Function, Args), {call, Ann, {remote, Ann, {atom, Ann, Module}, {atom, Ann, Function}}, Args}).
 
 -record(elixir_ex, {
-  bitsize=false,           %% stores if the situation is a bitstring size modifier
+  bitsize=false,           %% stores if inside a bitstring size modifier
   caller=false,            %% stores if __CALLER__ is allowed
   prematch=warn,           %% {Read, Counter} | warn | raise | pin
   stacktrace=false,        %% stores if __STACKTRACE__ is allowed

--- a/lib/elixir/src/elixir.hrl
+++ b/lib/elixir/src/elixir.hrl
@@ -6,6 +6,7 @@
 -define(remote(Ann, Module, Function, Args), {call, Ann, {remote, Ann, {atom, Ann, Module}, {atom, Ann, Function}}, Args}).
 
 -record(elixir_ex, {
+  bitsize=false,           %% stores if the situation is a bitstring size modifier
   caller=false,            %% stores if __CALLER__ is allowed
   prematch=warn,           %% {Read, Counter} | warn | raise | pin
   stacktrace=false,        %% stores if __STACKTRACE__ is allowed

--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -252,7 +252,7 @@ expand_spec_arg(size, Expr, S, _OriginalS, #{context := match} = E) ->
 expand_spec_arg(size, Expr, S, OriginalS, E) ->
   NewS = elixir_env:reset_read(S, OriginalS),
   {EExpr, SE, EE} = elixir_expand:expand(Expr, NewS#elixir_ex{bitsize=true}, E#{context := guard}),
-  {EExpr, SE, EE#{context := nil}};
+  {EExpr, SE#elixir_ex{bitsize=false}, EE#{context := nil}};
 expand_spec_arg(unit, Expr, S, _OriginalS, #{context := match} = E) ->
   {EExpr, SE, EE} = elixir_expand:expand(Expr, S#elixir_ex{prematch=raise}, E),
   {EExpr, SE#elixir_ex{prematch=S#elixir_ex.prematch}, EE#{context := match}};

--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -248,7 +248,7 @@ expand_spec_arg(_, Expr, S, _OriginalS, E) when is_atom(Expr); is_integer(Expr) 
   {Expr, S, E};
 expand_spec_arg(size, Expr, S, _OriginalS, #{context := match} = E) ->
   {EExpr, SE, EE} = elixir_expand:expand(Expr, S#elixir_ex{prematch=raise, bitsize=true}, E#{context := guard}),
-  {EExpr, SE#elixir_ex{prematch=S#elixir_ex.prematch}, EE#{context := match}};
+  {EExpr, SE#elixir_ex{prematch=S#elixir_ex.prematch, bitsize=false}, EE#{context := match}};
 expand_spec_arg(size, Expr, S, OriginalS, E) ->
   NewS = elixir_env:reset_read(S, OriginalS),
   {EExpr, SE, EE} = elixir_expand:expand(Expr, NewS#elixir_ex{bitsize=true}, E#{context := guard}),

--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -187,7 +187,7 @@ type(Meta, Other, Value, E) ->
 expand_each_spec(Meta, [{Expr, _, Args} = H | T], Map, S, OriginalS, E) when is_atom(Expr) ->
   case validate_spec(Expr, Args) of
     {Key, Arg} ->
-      {Value, SE, EE} = expand_spec_arg(Key, Arg, S, OriginalS, E),
+      {Value, SE, EE} = expand_spec_arg(Arg, S, OriginalS, E),
       validate_spec_arg(Meta, Key, Value, SE, OriginalS, EE),
 
       case maps:get(Key, Map) of
@@ -244,16 +244,15 @@ validate_spec(signed, [])    -> {sign, signed};
 validate_spec(unsigned, [])  -> {sign, unsigned};
 validate_spec(_, _)          -> none.
 
-expand_spec_arg(_, Expr, S, _OriginalS, E) when is_atom(Expr); is_integer(Expr) ->
+expand_spec_arg(Expr, S, _OriginalS, E) when is_atom(Expr); is_integer(Expr) ->
   {Expr, S, E};
-expand_spec_arg(size, Expr, S, _OriginalS, #{context := match} = E) ->
+expand_spec_arg(Expr, S, _OriginalS, #{context := match} = E) ->
   {EExpr, SE, EE} = elixir_expand:expand(Expr, S#elixir_ex{prematch=raise, bitsize=true}, E#{context := guard}),
   {EExpr, SE#elixir_ex{prematch=S#elixir_ex.prematch, bitsize=false}, EE#{context := match}};
-expand_spec_arg(unit, Expr, S, _OriginalS, #{context := match} = E) ->
-  {EExpr, SE, EE} = elixir_expand:expand(Expr, S#elixir_ex{prematch=raise}, E),
-  {EExpr, SE#elixir_ex{prematch=S#elixir_ex.prematch}, EE#{context := match}};
-expand_spec_arg(unit, Expr, S, OriginalS, E) ->
-  elixir_expand:expand(Expr, elixir_env:reset_read(S, OriginalS), E).
+expand_spec_arg(Expr, S, OriginalS, E) ->
+  NewS = elixir_env:reset_read(S, OriginalS),
+  {EExpr, SE, EE} = elixir_expand:expand(Expr, NewS#elixir_ex{bitsize=true}, E#{context := guard}),
+  {EExpr, SE#elixir_ex{bitsize=false}, EE#{context := nil}}.
 
 validate_spec_arg(Meta, size, Value, S, OriginalS, E) ->
   case Value of

--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -249,10 +249,6 @@ expand_spec_arg(_, Expr, S, _OriginalS, E) when is_atom(Expr); is_integer(Expr) 
 expand_spec_arg(size, Expr, S, _OriginalS, #{context := match} = E) ->
   {EExpr, SE, EE} = elixir_expand:expand(Expr, S#elixir_ex{prematch=raise, bitsize=true}, E#{context := guard}),
   {EExpr, SE#elixir_ex{prematch=S#elixir_ex.prematch, bitsize=false}, EE#{context := match}};
-expand_spec_arg(size, Expr, S, OriginalS, E) ->
-  NewS = elixir_env:reset_read(S, OriginalS),
-  {EExpr, SE, EE} = elixir_expand:expand(Expr, NewS#elixir_ex{bitsize=true}, E#{context := guard}),
-  {EExpr, SE#elixir_ex{bitsize=false}, EE#{context := nil}};
 expand_spec_arg(unit, Expr, S, _OriginalS, #{context := match} = E) ->
   {EExpr, SE, EE} = elixir_expand:expand(Expr, S#elixir_ex{prematch=raise}, E),
   {EExpr, SE#elixir_ex{prematch=S#elixir_ex.prematch}, EE#{context := match}};

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -539,7 +539,7 @@ extract_bit_info(L, _Meta, _S) ->
   {default, extract_bit_type(L, [])}.
 
 extract_bit_size(Size, Meta, S) ->
-  {TSize, _} = translate(Size, ?ann(Meta), S),
+  {TSize, _} = translate(Size, ?ann(Meta), S#elixir_erl{context=guard}),
   TSize.
 
 extract_bit_type({'-', _, [L, R]}, Acc) ->

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -818,12 +818,7 @@ expand_remote(Receiver, DotMeta, Right, Meta, Args, S, SL, #{context := Context}
 
   case {Context, lists:keyfind(no_parens, 1, Meta)} of
     {guard, {no_parens, true}} when is_tuple(Receiver) ->
-      case S#elixir_ex.bitsize of
-        true ->
-          form_error(Meta, E, ?MODULE, {invalid_map_lookup_bitsize, Receiver, Right});
-        false ->
-          {{{'.', DotMeta, [Receiver, Right]}, Meta, []}, SL, E}
-      end;
+      {{{'.', DotMeta, [Receiver, Right]}, Meta, []}, SL, E};
 
     {guard, _} when is_tuple(Receiver) ->
       case S#elixir_ex.bitsize of
@@ -1320,10 +1315,6 @@ format_error({unknown_variable, Name}) ->
 format_error({parens_map_lookup_guard, Map, Field}) ->
   io_lib:format("cannot invoke remote function in guard. "
                 "If you want to do a map lookup instead, please remove parens from ~ts.~ts()",
-                ['Elixir.Macro':to_string(Map), Field]);
-format_error({invalid_map_lookup_bitsize, Map, Field}) ->
-  io_lib:format("invalid map lookup in bitstring size specifier, "
-                "got: ~ts.~ts",
                 ['Elixir.Macro':to_string(Map), Field]);
 format_error({parens_map_lookup_bitsize, Map, Field}) ->
   io_lib:format("cannot invoke remote function in bitstring size specifier, "

--- a/lib/elixir/test/elixir/kernel/binary_test.exs
+++ b/lib/elixir/test/elixir/kernel/binary_test.exs
@@ -244,7 +244,7 @@ defmodule Kernel.BinaryTest do
     assert (fn <<_, _::size(x)>> -> true end).(<<?a, ?b>>)
   end
 
-  test "bitsyntax with guards" do
+  test "bitsyntax size using guard expressions" do
     x = 8
     assert <<1::3>> == <<1::size(x - 5)>>
     assert <<1::3*8>> == <<1::size(x - 5)-unit(8)>>

--- a/lib/elixir/test/elixir/kernel/binary_test.exs
+++ b/lib/elixir/test/elixir/kernel/binary_test.exs
@@ -249,6 +249,9 @@ defmodule Kernel.BinaryTest do
     assert <<1::3>> == <<1::size(x - 5)>>
     assert <<1::3*8>> == <<1::size(x - 5)-unit(8)>>
     assert <<1::4>> == <<1::size(length('abcd'))>>
+
+    foo = %{bar: 5}
+    assert <<1::5>> == <<1::size(foo.bar)>>
   end
 
   defmacrop signed_16 do

--- a/lib/elixir/test/elixir/kernel/binary_test.exs
+++ b/lib/elixir/test/elixir/kernel/binary_test.exs
@@ -246,12 +246,12 @@ defmodule Kernel.BinaryTest do
 
   test "bitsyntax size using guard expressions" do
     x = 8
-    assert <<1::3>> == <<1::size(x - 5)>>
-    assert <<1::3*8>> == <<1::size(x - 5)-unit(8)>>
-    assert <<1::4>> == <<1::size(length('abcd'))>>
+    assert <<1::size(x - 5)>> = <<1::3>>
+    assert <<1::size(x - 5)-unit(8)>> = <<1::3*8>>
+    assert <<1::size(length('abcd'))>> = <<1::4>>
 
     foo = %{bar: 5}
-    assert <<1::5>> == <<1::size(foo.bar)>>
+    assert <<1::size(foo.bar)>> = <<1::5>>
   end
 
   defmacrop signed_16 do

--- a/lib/elixir/test/elixir/kernel/binary_test.exs
+++ b/lib/elixir/test/elixir/kernel/binary_test.exs
@@ -244,6 +244,13 @@ defmodule Kernel.BinaryTest do
     assert (fn <<_, _::size(x)>> -> true end).(<<?a, ?b>>)
   end
 
+  test "bitsyntax with guards" do
+    x = 8
+    assert <<1::3>> == <<1::size(x - 5)>>
+    assert <<1::3*8>> == <<1::size(x - 5)-unit(8)>>
+    assert <<1::4>> == <<1::size(length('abcd'))>>
+  end
+
   defmacrop signed_16 do
     quote do
       big - signed - integer - unit(16)

--- a/lib/elixir/test/elixir/kernel/binary_test.exs
+++ b/lib/elixir/test/elixir/kernel/binary_test.exs
@@ -246,6 +246,17 @@ defmodule Kernel.BinaryTest do
 
   test "bitsyntax size using guard expressions" do
     x = 8
+    assert <<1::size(x - 5)>>
+
+    foo = %{bar: 5}
+    assert <<1::size(foo.bar)>>
+
+    assert <<1::size(length('abcd'))>>
+    assert <<255::size(hd([3]))>>
+  end
+
+  test "bitsyntax size using guard expressions in match context" do
+    x = 8
     assert <<1::size(x - 5)>> = <<1::3>>
     assert <<1::size(x - 5)-unit(8)>> = <<1::3*8>>
     assert <<1::size(length('abcd'))>> = <<1::4>>

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -2624,12 +2624,58 @@ defmodule Kernel.ExpansionTest do
         expand(code)
       end
 
-      message = ~r"cannot find or invoke local foo/0 inside guard"
+      message = ~r"cannot find or invoke local foo/0 inside bitstring size specifier"
 
       assert_raise CompileError, message, fn ->
         code =
           quote do
             fn <<_::size(foo())>> -> :ok end
+          end
+
+        expand(code)
+      end
+
+      message = ~r"invalid expression, anonymous call is not allowed in bitstring size specifier"
+
+      assert_raise CompileError, message, fn ->
+        code =
+          quote do
+            fn <<_::size(foo.())>> -> :ok end
+          end
+
+        expand(code)
+      end
+
+      message = ~r"cannot invoke remote function in bitstring size specifier, got foo.bar()"
+
+      assert_raise CompileError, message, fn ->
+        code =
+          quote do
+            foo = %{bar: true}
+            fn <<_::size(foo.bar())>> -> :ok end
+          end
+
+        expand(code)
+      end
+
+      message = ~r"invalid map lookup in bitstring size specifier, got: foo.bar"
+
+      assert_raise CompileError, message, fn ->
+        code =
+          quote do
+            foo = %{bar: true}
+            fn <<_::size(foo.bar)>> -> :ok end
+          end
+
+        expand(code)
+      end
+
+      message = ~r"cannot invoke remote function Foo.bar/0 inside bitstring size specifier"
+
+      assert_raise CompileError, message, fn ->
+        code =
+          quote do
+            fn <<_::size(Foo.bar())>> -> :ok end
           end
 
         expand(code)

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -2522,6 +2522,24 @@ defmodule Kernel.ExpansionTest do
       assert expand(before_expansion) |> clean_meta([:alignment]) == after_expansion
     end
 
+    test "map lookup on size" do
+      import Kernel, except: [-: 2]
+
+      before_expansion =
+        quote do
+          var = %{foo: 3}
+          <<x::size(var.foo)>>
+        end
+
+      after_expansion =
+        quote do
+          var = %{foo: 3}
+          <<x()::integer()-size(var.foo)>>
+        end
+
+      assert expand(before_expansion) |> clean_meta([:alignment]) == after_expansion
+    end
+
     test "raises on unaligned binaries in match" do
       message = ~r"its number of bits is not divisible by 8"
 
@@ -2653,18 +2671,6 @@ defmodule Kernel.ExpansionTest do
           quote do
             foo = %{bar: true}
             fn <<_::size(foo.bar())>> -> :ok end
-          end
-
-        expand(code)
-      end
-
-      message = ~r"invalid map lookup in bitstring size specifier, got: foo.bar"
-
-      assert_raise CompileError, message, fn ->
-        code =
-          quote do
-            foo = %{bar: true}
-            fn <<_::size(foo.bar)>> -> :ok end
           end
 
         expand(code)

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -2497,7 +2497,7 @@ defmodule Kernel.ExpansionTest do
     test "guard expressions on size" do
       import Kernel, except: [-: 2, +: 2, length: 1]
 
-      # Arithmentic operations with literals and variables are valid expressions
+      # Arithmetic operations with literals and variables are valid expressions
       # for bitstring size in OTP 23+
 
       before_expansion =

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -2516,8 +2516,8 @@ defmodule Kernel.ExpansionTest do
 
       # Other valid guard expressions are also legal for bitstring size in OTP 23+
 
-      before_expansion = quote(do: <<x::size(length("test"))>>)
-      after_expansion = quote(do: <<x()::integer()-size(:erlang.length("test"))>>)
+      before_expansion = quote(do: <<x::size(length('test'))>>)
+      after_expansion = quote(do: <<x()::integer()-size(:erlang.length('test'))>>)
 
       assert expand(before_expansion) |> clean_meta([:alignment]) == after_expansion
     end


### PR DESCRIPTION
Related with https://github.com/elixir-lang/elixir/issues/9603 (and also this reported issue https://github.com/elixir-lang/elixir/issues/10890).

In order to support the usage of guard expressions to calculate sizes in bitstring matching, the validations logic is affected, because only integer and variables were being allowed so far.
The changes implemented in OTP 23 offer more freedom to developers since guard expressions are now allowed, but there are cases where expressions would result in non-integer size values. In those cases, the match fails but no compilation or specific errors.
See https://github.com/erlang/eep/blob/master/eeps/eep-0052.md#rationale and please confirm this also makes sense for Elixir (which is what I assumed).

Note: This solution is reusing the guard expansion logic, so errors in many cases are not tailored to bitstring matching as they used to be (see removed validation errors and changes in the test files). It seems acceptable to me, but it could be further worked if some direction is provided :)

Example

```ex
buffer_size = 64
my_address = "1.1.1.1"
their_address = "127.10.10.10"
packet = <<0::size(buffer_size - byte_size(their_address) - byte_size(my_address))>>

# Result before
# ** (CompileError) iex:14: size in bitstring expects an integer or a variable as argument,
# got: :erlang.-(:erlang.-(buffer_size, :erlang.byte_size(their_address)), :erlang.byte_size(my_address))

# Result now
# <<0, 0, 0, 0, 0, 0::size(5)>>
```