### PR TITLE
Strip name from checksum file

### DIFF
--- a/.github/workflows/notify.exs
+++ b/.github/workflows/notify.exs
@@ -22,7 +22,8 @@ names_and_checksums =
       do: {name, Req.get!(asset["browser_download_url"]).body}
 
 line_items =
-  for {name, checksum} <- Enum.sort(names_and_checksums) do
+  for {name, checksum_and_name} <- Enum.sort(names_and_checksums) do
+    [checksum | _] = String.split(checksum_and_name, " ")
     root = Path.rootname(name)
     "." <> type = Path.extname(name)
     "  * #{root} - #{type} - #{checksum}\n"


### PR DESCRIPTION
Currently, the notify.exs will generate the checksum to:

```
  * Docs.zip - sha1sum - 3812e2db7c71a6a8b03b75d06ca6debb46aebc55  Docs.zip

  * Docs.zip - sha256sum - cafe86adc01fcc700c83f353aedf746eeffd3b6e1542cedff18af64956ae539b  Docs.zip

  * elixir-otp-23.zip - sha1sum - 35f999b98cbfa5888fefbeafaaf73f661a903bb7  elixir-otp-23.zip

  * elixir-otp-23.zip - sha256sum - 11f970adc3ddc759f349b0e00b6aecd06a1d460f21488d2ffe8f6738f2518728  elixir-otp-23.zip

  * elixir-otp-24.zip - sha1sum - c4224ce1b78247d7c5e04c7cd4576496fd49f002  elixir-otp-24.zip

  * elixir-otp-24.zip - sha256sum - 677fe7a147a40e5ee876eeb7bb8e4b968d2a8a9c42793561b61a08269ca91c19  elixir-otp-24.zip
```

The result have a file name and newline at the end of each line. This change strip
that, so the result will be:

```
  * Docs.zip - sha1sum - 3812e2db7c71a6a8b03b75d06ca6debb46aebc55
  * Docs.zip - sha256sum - cafe86adc01fcc700c83f353aedf746eeffd3b6e1542cedff18af64956ae539b
  * elixir-otp-23.zip - sha1sum - 35f999b98cbfa5888fefbeafaaf73f661a903bb7
  * elixir-otp-23.zip - sha256sum - 11f970adc3ddc759f349b0e00b6aecd06a1d460f21488d2ffe8f6738f2518728
  * elixir-otp-24.zip - sha1sum - c4224ce1b78247d7c5e04c7cd4576496fd49f002
  * elixir-otp-24.zip - sha256sum - 677fe7a147a40e5ee876eeb7bb8e4b968d2a8a9c42793561b61a08269ca91c19
```