### PR TITLE
Enhance documentation for SpecialForms.try

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -2092,9 +2092,8 @@ defmodule Kernel.SpecialForms do
         File.rm("tmp/story.txt")
       end
 
-  Although `after` clauses are invoked whether or not there was an error, they cannot be
-  used to override the return value. In all of the following examples the return
-  value would be `:return_me`:
+  Although `after` clauses are invoked whether or not there was an error, they do not
+  modify the return value. All of the following examples return `:return_me`:
 
       try do
         :return_me

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -2092,6 +2092,26 @@ defmodule Kernel.SpecialForms do
         File.rm("tmp/story.txt")
       end
 
+  Although `after` clauses are invoked whether or not there was an error, they cannot be
+  used to override the return value.  In the following examples `:return_me` would be
+  returned each time:
+
+      try do
+        :return_me
+      after
+        IO.puts("I will be printed")
+        :not_returned
+      end
+
+      try do
+        raise "boom"
+      rescue
+        _ -> :return_me
+      after
+        IO.puts("I will be printed")
+        :not_returned
+      end
+
   ## `else` clauses
 
   `else` clauses allow the result of the body passed to `try/1` to be pattern

--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -2093,8 +2093,8 @@ defmodule Kernel.SpecialForms do
       end
 
   Although `after` clauses are invoked whether or not there was an error, they cannot be
-  used to override the return value.  In the following examples `:return_me` would be
-  returned each time:
+  used to override the return value. In all of the following examples the return
+  value would be `:return_me`:
 
       try do
         :return_me


### PR DESCRIPTION
👋  I wanted to add something to the documentation for `try/after` to indicate that you cannot return anything from the `after` block.  When you spend some time thinking about it - it makes sense that `after` could never return a value, but so many of the examples show the `after` block at the bottom which is usually where the return value for a block of code comes from.