### PR TITLE
expand Kernel.in/2 docs re range check efficiency

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4175,8 +4175,10 @@ defmodule Kernel do
   ## Guards
 
   The `in/2` operator (as well as `not in`) can be used in guard clauses as
-  long as the right-hand side is a range or a list. In such cases, Elixir will
-  expand the operator to a valid guard expression. For example:
+  long as the right-hand side is a range or a list.
+
+  If the right-hand side is a list, Elixir will expand the operator to a valid
+  guard expression which needs to check each value. For example:
 
       when x in [1, 2, 3]
 
@@ -4187,6 +4189,15 @@ defmodule Kernel do
   However, this construct will be inneficient for large lists. In such cases, it
   is best to stop using guards and use a more appropriate data structure, such
   as `MapSet`.
+
+  If the right-hand side is a range, a more efficient comparison check will be
+  done. For example:
+
+      when x in 1..1000
+
+  translates roughly to:
+
+      when x >= 1 and x <= 1000
 
   ### AST considerations
 


### PR DESCRIPTION
Current docs treat membership tests on lists and ranges using `Kernel.in/2` with the same warning in the doc saying that comparison on large lists/ranges is inefficient.

This is true for lists, but not for ranges. A more efficient check is done there which can run in constant time.

Update docs to explain that.

Have omitted going into detail on how membership checks for ranges with steps are done, as that seems less relevant, and the general comment that the check can be done efficiently still holds true.