### PR TITLE
Fix coverage threshold ignored for Total line in Summary

### DIFF
--- a/lib/mix/lib/mix/tasks/test.coverage.ex
+++ b/lib/mix/lib/mix/tasks/test.coverage.ex
@@ -350,7 +350,7 @@ defmodule Mix.Tasks.Test.Coverage do
     Mix.shell().info("-----------|--------------------------")
     results |> Enum.sort() |> Enum.each(&display(&1, threshold))
     Mix.shell().info("-----------|--------------------------")
-    display({totals, "Total"}, opts)
+    display({totals, "Total"}, threshold)
     Mix.shell().info("")
   end
 


### PR DESCRIPTION
An incorrect variable is being passed to the `display/2` function on line [353 ](https://github.com/sh41/elixir/blob/51811b24bb84dea7be87bfdddf21244fd47065b2/lib/mix/lib/mix/tasks/test.coverage.ex#L353)for the Total line in the coverage summary report. The result is that that Total line will always display in red no matter what the threshold is set to. 

The correct threshold value is retrieved on line [348 ](https://github.com/sh41/elixir/blob/51811b24bb84dea7be87bfdddf21244fd47065b2/lib/mix/lib/mix/tasks/test.coverage.ex#L348)from the `opts` or the default and is used on line [351 ](https://github.com/sh41/elixir/blob/51811b24bb84dea7be87bfdddf21244fd47065b2/lib/mix/lib/mix/tasks/test.coverage.ex#L351)for the body of the summary report. The final call to display then reverts to using the `opts` variable which is incorrect. 

I have been unable to capture the color of text in the summary report in a test, so have been unable to write a test for this change.