### PR TITLE
Fix bug with edge-case when converting to algebra quoted Elixir alias

### DIFF
--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -251,12 +251,16 @@ defmodule Code.Normalizer do
 
     if is_atom(literal) and Macro.classify_atom(literal) == :alias and
          is_nil(meta[:delimiter]) do
-      "Elixir." <> segments = Atom.to_string(literal)
-
       segments =
-        segments
-        |> String.split(".")
-        |> Enum.map(&String.to_atom/1)
+        case Atom.to_string(literal) do
+          "Elixir" ->
+            [:"Elixir"]
+
+          "Elixir." <> segments ->
+            segments
+            |> String.split(".")
+            |> Enum.map(&String.to_atom/1)
+        end
 
       {:__aliases__, meta, segments}
     else

--- a/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/formatted_ast_test.exs
@@ -115,6 +115,7 @@ defmodule Code.Normalizer.FormatterASTTest do
 
     test "does not reformat aliases" do
       assert_same ~S[:"Elixir.String"]
+      assert_same ~S[:"Elixir"]
     end
 
     test "quoted operators" do

--- a/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
@@ -620,6 +620,7 @@ defmodule Code.Normalizer.QuotedASTTest do
       assert quoted_to_string({:__block__, [], [:"a\nb\tc"]}, escape: false) == ~s/:"a\nb\tc"/
       assert quoted_to_string({:__block__, [], [:"a\nb\tc"]}) == ~S/:"a\nb\tc"/
 
+      assert quoted_to_string(quote(do: :"Elixir")) == "Elixir"
       assert quoted_to_string(quote(do: :"Elixir.Foo")) == "Foo"
       assert quoted_to_string(quote(do: :"Elixir.Foo.Bar")) == "Foo.Bar"
       assert quoted_to_string(quote(do: :"Elixir.foobar")) == ~S/:"Elixir.foobar"/

--- a/lib/elixir/test/elixir/kernel/quote_test.exs
+++ b/lib/elixir/test/elixir/kernel/quote_test.exs
@@ -523,7 +523,7 @@ defmodule Kernel.QuoteTest.AliasHygieneTest do
     assert {:__aliases__, [alias: Dict.Bar], [:SuperDict, :Bar]} = quote(do: SuperDict.Bar)
 
     # Edge-case
-    assert {:__aliases__, [], [Elixir]} = quote(do: Elixir)
+    assert {:__aliases__, _, [Elixir]} = quote(do: Elixir)
   end
 
   test "expand aliases" do

--- a/lib/elixir/test/elixir/kernel/quote_test.exs
+++ b/lib/elixir/test/elixir/kernel/quote_test.exs
@@ -521,6 +521,9 @@ defmodule Kernel.QuoteTest.AliasHygieneTest do
     assert {:__aliases__, [alias: false], [:Foo, :Bar]} = quote(do: Foo.Bar)
     assert {:__aliases__, [alias: false], [:Dict, :Bar]} = quote(do: Dict.Bar)
     assert {:__aliases__, [alias: Dict.Bar], [:SuperDict, :Bar]} = quote(do: SuperDict.Bar)
+
+    # Edge-case
+    assert {:__aliases__, [], [Elixir]} = quote(do: Elixir)
   end
 
   test "expand aliases" do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -326,6 +326,8 @@ defmodule MacroTest do
     end
 
     test "aliases call" do
+      assert macro_to_string(quote(do: Elixir)) == "Elixir"
+      assert macro_to_string(quote(do: Foo)) == "Foo"
       assert macro_to_string(quote(do: Foo.Bar.baz(1, 2, 3))) == "Foo.Bar.baz(1, 2, 3)"
       assert macro_to_string(quote(do: Foo.Bar.baz([1, 2, 3]))) == "Foo.Bar.baz([1, 2, 3])"
       assert macro_to_string(quote(do: Foo.bar(<<>>, []))) == "Foo.bar(<<>>, [])"


### PR DESCRIPTION
The following code would crash:

    iex> Code.quoted_to_algebra(Elixir)
    ** (MatchError) no match of right hand side value: "Elixir"
        (elixir 1.13.1) lib/code/normalizer.ex:254: Code.Normalizer.normalize_literal/3
        (elixir 1.13.1) lib/code.ex:1107: Code.quoted_to_algebra/2

Therefore, this as well:

    iex> Macro.to_string(Elixir)
    ** (MatchError) no match of right hand side value: "Elixir"
        (elixir 1.13.1) lib/code/normalizer.ex:254: Code.Normalizer.normalize_literal/3
        (elixir 1.13.1) lib/code.ex:1107: Code.quoted_to_algebra/2
        (elixir 1.13.1) lib/macro.ex:948: Macro.to_string/1