### PR TITLE
Update tests for pid/1 IEx helper

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -1194,7 +1194,10 @@ defmodule IEx.Helpers do
   end
 
   def pid(name) when is_atom(name) do
-    Process.whereis(name)
+    case Process.whereis(name) do
+      p when is_pid(p) -> p
+      _ -> raise ArgumentError, "could not find registered process with name: #{inspect(name)}"
+    end
   end
 
   @doc """

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1347,11 +1347,15 @@ defmodule IEx.HelpersTest do
     test "builds a PID from string" do
       assert inspect(pid("0.32767.3276")) == "#PID<0.32767.3276>"
       assert inspect(pid("0.5.6")) == "#PID<0.5.6>"
-      assert inspect(pid(:init) == "#PID<0.0.0>")
 
       assert_raise ArgumentError, fn ->
         pid("0.6.-6")
       end
+    end
+
+    test "builds a PID from atom" do
+      assert inspect(pid(:init)) == "#PID<0.0.0>"
+      assert pid(:random_atom_ZM6pX6VwQx) == nil
     end
 
     test "builds a PID from integers" do

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1355,7 +1355,10 @@ defmodule IEx.HelpersTest do
 
     test "builds a PID from atom" do
       assert inspect(pid(:init)) == "#PID<0.0.0>"
-      assert pid(:random_atom_ZM6pX6VwQx) == nil
+
+      assert_raise ArgumentError, fn ->
+        pid(:random_atom_ZM6pX6VwQx)
+      end
     end
 
     test "builds a PID from integers" do


### PR DESCRIPTION
It's a follow-up PR to #11536 to fix typo, but it also moves tests around atoms into a separate test.

Open question: should `pid/1` throw an exception if no process found by the name?