### PR TITLE
Don't allow restricted characters in identifiers (UTS 39, C1)

### DIFF
--- a/lib/elixir/pages/unicode-security.md
+++ b/lib/elixir/pages/unicode-security.md
@@ -1,0 +1,25 @@
+# Unicode Security
+
+(See [Unicode Syntax](unicode-syntax.html) for information on Unicode usage in Elixir).
+
+Elixir will prevent, or warn on, confusing or suspicious uses of Unicode in identifiers since Elixir v1.15, as defined in the [Unicode Technical Standard #39](https://unicode.org/reports/tr39/) on Security.
+
+The focus of this document is to describe how Elixir implements the conformance clauses from that standard, referred to as C1, C2, and so on. All quotes are from the spec unless otherwise noted.
+
+## C1. General Security Profile for Identifiers
+
+Elixir will not allow tokenization of identifiers with codepoints in `\p{Identifier_Status=Restricted}`.
+
+> An implementation following the General Security Profile does not permit any characters in \p{Identifier_Status=Restricted}, ...
+
+For instance, the 'HANGUL FILLER' (`ㅤ`) character, which is often invisible, is an uncommon codepoint and will trigger this warning.
+
+## C2, C3 (planned)
+
+Elixir may implement Confusable Detection, and Mixed-Script Confusable detection, in the future, and will likely emit warnings in those cases; there is a reference implementation.
+
+## C4, C5 (inapplicable)
+
+'C4 - Restriction Level detection' conformance is not claimed and is inapplicable. (It applies to classifying the level of safety of a given arbitrary string into one of 5 restriction levels).
+
+'C5 - Mixed number detection' conformance is inapplicable as Elixir does not support Unicode numbers.

--- a/lib/elixir/pages/unicode-syntax.md
+++ b/lib/elixir/pages/unicode-syntax.md
@@ -6,6 +6,8 @@ Quoted identifiers, such as strings (`"olá"`) and charlists (`'olá'`), support
 
 Elixir also supports Unicode in identifiers since Elixir v1.5, as defined in the [Unicode Annex #31](https://unicode.org/reports/tr31/). The focus of this document is to describe how Elixir implements the requirements outlined in the Unicode Annex. These requirements are referred to as R1, R6 and so on.
 
+Elixir provides identifier security as defined in the [Unicode Technical Standard #39](https://unicode.org/reports/tr39/) on Security. The [Unicode Security](unicode-security.html) document describes how Elixir implements the clauses of that Standard.
+
 To check the Unicode version of your current Elixir installation, run `String.Unicode.version()`.
 
 ## R1. Default Identifiers

--- a/lib/elixir/test/elixir/kernel/parser_test.exs
+++ b/lib/elixir/test/elixir/kernel/parser_test.exs
@@ -500,6 +500,11 @@ defmodule Kernel.ParserTest do
 
     test "invalid token" do
       assert_syntax_error(
+        ~r/nofile:1:1: unexpected token: "#{"\u3164"}" \(column 1, code point U\+3164\)/,
+        'ㅤ = 1'
+      )
+
+      assert_syntax_error(
         ~r/nofile:1:7: unexpected token: "#{"\u200B"}" \(column 7, code point U\+200B\)/,
         '[foo: \u200B]\noops'
       )

--- a/lib/elixir/unicode/IdentifierType.txt
+++ b/lib/elixir/unicode/IdentifierType.txt
@@ -1,0 +1,2456 @@
+# IdentifierType.txt
+# Date: 2021-08-12, 01:13:33 GMT
+# © 2021 Unicode®, Inc.
+# Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+# For terms of use, see http://www.unicode.org/terms_of_use.html
+#
+# Unicode Security Mechanisms for UTS #39
+# Version: 14.0.0
+#
+# For documentation and usage, see http://www.unicode.org/reports/tr39
+#
+# Format
+#
+# Field 0: code point
+# Field 1: set of Identifier_Type values (see Table 1 of http://www.unicode.org/reports/tr39)
+#
+# Any missing code points have the Identifier_Type value Not_Character
+#
+# For the purpose of regular expressions, the property Identifier_Type is defined as
+# mapping each code point to a set of enumerated values.
+# The short name of Identifier_Type is the same as the long name.
+# The possible values are:
+#   Not_Character, Deprecated, Default_Ignorable, Not_NFKC, Not_XID,
+#   Exclusion, Obsolete, Technical, Uncommon_Use, Limited_Use, Inclusion, Recommended
+# The short name of each value is the same as its long name.
+# The default property value for all Unicode code points U+0000..U+10FFFF
+# not mentioned in this data file is Not_Character.
+# As usual, sets are unordered, with no duplicate values.
+
+
+#	Identifier_Type:	Recommended
+
+0030..0039    ; Recommended                    # 1.1   [10] DIGIT ZERO..DIGIT NINE
+0041..005A    ; Recommended                    # 1.1   [26] LATIN CAPITAL LETTER A..LATIN CAPITAL LETTER Z
+005F          ; Recommended                    # 1.1        LOW LINE
+0061..007A    ; Recommended                    # 1.1   [26] LATIN SMALL LETTER A..LATIN SMALL LETTER Z
+00C0..00D6    ; Recommended                    # 1.1   [23] LATIN CAPITAL LETTER A WITH GRAVE..LATIN CAPITAL LETTER O WITH DIAERESIS
+00D8..00F6    ; Recommended                    # 1.1   [31] LATIN CAPITAL LETTER O WITH STROKE..LATIN SMALL LETTER O WITH DIAERESIS
+00F8..0131    ; Recommended                    # 1.1   [58] LATIN SMALL LETTER O WITH STROKE..LATIN SMALL LETTER DOTLESS I
+0134..013E    ; Recommended                    # 1.1   [11] LATIN CAPITAL LETTER J WITH CIRCUMFLEX..LATIN SMALL LETTER L WITH CARON
+0141..0148    ; Recommended                    # 1.1    [8] LATIN CAPITAL LETTER L WITH STROKE..LATIN SMALL LETTER N WITH CARON
+014A..017E    ; Recommended                    # 1.1   [53] LATIN CAPITAL LETTER ENG..LATIN SMALL LETTER Z WITH CARON
+018F          ; Recommended                    # 1.1        LATIN CAPITAL LETTER SCHWA
+01A0..01A1    ; Recommended                    # 1.1    [2] LATIN CAPITAL LETTER O WITH HORN..LATIN SMALL LETTER O WITH HORN
+01AF..01B0    ; Recommended                    # 1.1    [2] LATIN CAPITAL LETTER U WITH HORN..LATIN SMALL LETTER U WITH HORN
+01CD..01DC    ; Recommended                    # 1.1   [16] LATIN CAPITAL LETTER A WITH CARON..LATIN SMALL LETTER U WITH DIAERESIS AND GRAVE
+01DE..01E3    ; Recommended                    # 1.1    [6] LATIN CAPITAL LETTER A WITH DIAERESIS AND MACRON..LATIN SMALL LETTER AE WITH MACRON
+01E6..01F0    ; Recommended                    # 1.1   [11] LATIN CAPITAL LETTER G WITH CARON..LATIN SMALL LETTER J WITH CARON
+01F4..01F5    ; Recommended                    # 1.1    [2] LATIN CAPITAL LETTER G WITH ACUTE..LATIN SMALL LETTER G WITH ACUTE
+01F8..01F9    ; Recommended                    # 3.0    [2] LATIN CAPITAL LETTER N WITH GRAVE..LATIN SMALL LETTER N WITH GRAVE
+01FA..0217    ; Recommended                    # 1.1   [30] LATIN CAPITAL LETTER A WITH RING ABOVE AND ACUTE..LATIN SMALL LETTER U WITH INVERTED BREVE
+0218..021B    ; Recommended                    # 3.0    [4] LATIN CAPITAL LETTER S WITH COMMA BELOW..LATIN SMALL LETTER T WITH COMMA BELOW
+021E..021F    ; Recommended                    # 3.0    [2] LATIN CAPITAL LETTER H WITH CARON..LATIN SMALL LETTER H WITH CARON
+0226..0233    ; Recommended                    # 3.0   [14] LATIN CAPITAL LETTER A WITH DOT ABOVE..LATIN SMALL LETTER Y WITH MACRON
+0259          ; Recommended                    # 1.1        LATIN SMALL LETTER SCHWA
+02BB..02BC    ; Recommended                    # 1.1    [2] MODIFIER LETTER TURNED COMMA..MODIFIER LETTER APOSTROPHE
+02EC          ; Recommended                    # 3.0        MODIFIER LETTER VOICING
+0300..0304    ; Recommended                    # 1.1    [5] COMBINING GRAVE ACCENT..COMBINING MACRON
+0306..030C    ; Recommended                    # 1.1    [7] COMBINING BREVE..COMBINING CARON
+030F..0311    ; Recommended                    # 1.1    [3] COMBINING DOUBLE GRAVE ACCENT..COMBINING INVERTED BREVE
+0313..0314    ; Recommended                    # 1.1    [2] COMBINING COMMA ABOVE..COMBINING REVERSED COMMA ABOVE
+031B          ; Recommended                    # 1.1        COMBINING HORN
+0323..0328    ; Recommended                    # 1.1    [6] COMBINING DOT BELOW..COMBINING OGONEK
+032D..032E    ; Recommended                    # 1.1    [2] COMBINING CIRCUMFLEX ACCENT BELOW..COMBINING BREVE BELOW
+0330..0331    ; Recommended                    # 1.1    [2] COMBINING TILDE BELOW..COMBINING MACRON BELOW
+0335          ; Recommended                    # 1.1        COMBINING SHORT STROKE OVERLAY
+0338..0339    ; Recommended                    # 1.1    [2] COMBINING LONG SOLIDUS OVERLAY..COMBINING RIGHT HALF RING BELOW
+0342          ; Recommended                    # 1.1        COMBINING GREEK PERISPOMENI
+0345          ; Recommended                    # 1.1        COMBINING GREEK YPOGEGRAMMENI
+037B..037D    ; Recommended                    # 5.0    [3] GREEK SMALL REVERSED LUNATE SIGMA SYMBOL..GREEK SMALL REVERSED DOTTED LUNATE SIGMA SYMBOL
+0386          ; Recommended                    # 1.1        GREEK CAPITAL LETTER ALPHA WITH TONOS
+0388..038A    ; Recommended                    # 1.1    [3] GREEK CAPITAL LETTER EPSILON WITH TONOS..GREEK CAPITAL LETTER IOTA WITH TONOS
+038C          ; Recommended                    # 1.1        GREEK CAPITAL LETTER OMICRON WITH TONOS
+038E..03A1    ; Recommended                    # 1.1   [20] GREEK CAPITAL LETTER UPSILON WITH TONOS..GREEK CAPITAL LETTER RHO
+03A3..03CE    ; Recommended                    # 1.1   [44] GREEK CAPITAL LETTER SIGMA..GREEK SMALL LETTER OMEGA WITH TONOS
+03FC..03FF    ; Recommended                    # 4.1    [4] GREEK RHO WITH STROKE SYMBOL..GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL
+0400          ; Recommended                    # 3.0        CYRILLIC CAPITAL LETTER IE WITH GRAVE
+0401..040C    ; Recommended                    # 1.1   [12] CYRILLIC CAPITAL LETTER IO..CYRILLIC CAPITAL LETTER KJE
+040D          ; Recommended                    # 3.0        CYRILLIC CAPITAL LETTER I WITH GRAVE
+040E..044F    ; Recommended                    # 1.1   [66] CYRILLIC CAPITAL LETTER SHORT U..CYRILLIC SMALL LETTER YA
+0450          ; Recommended                    # 3.0        CYRILLIC SMALL LETTER IE WITH GRAVE
+0451..045C    ; Recommended                    # 1.1   [12] CYRILLIC SMALL LETTER IO..CYRILLIC SMALL LETTER KJE
+045D          ; Recommended                    # 3.0        CYRILLIC SMALL LETTER I WITH GRAVE
+045E..045F    ; Recommended                    # 1.1    [2] CYRILLIC SMALL LETTER SHORT U..CYRILLIC SMALL LETTER DZHE
+048A..048B    ; Recommended                    # 3.2    [2] CYRILLIC CAPITAL LETTER SHORT I WITH TAIL..CYRILLIC SMALL LETTER SHORT I WITH TAIL
+048C..048F    ; Recommended                    # 3.0    [4] CYRILLIC CAPITAL LETTER SEMISOFT SIGN..CYRILLIC SMALL LETTER ER WITH TICK
+0490..04C4    ; Recommended                    # 1.1   [53] CYRILLIC CAPITAL LETTER GHE WITH UPTURN..CYRILLIC SMALL LETTER KA WITH HOOK
+04C5..04C6    ; Recommended                    # 3.2    [2] CYRILLIC CAPITAL LETTER EL WITH TAIL..CYRILLIC SMALL LETTER EL WITH TAIL
+04C7..04C8    ; Recommended                    # 1.1    [2] CYRILLIC CAPITAL LETTER EN WITH HOOK..CYRILLIC SMALL LETTER EN WITH HOOK
+04C9..04CA    ; Recommended                    # 3.2    [2] CYRILLIC CAPITAL LETTER EN WITH TAIL..CYRILLIC SMALL LETTER EN WITH TAIL
+04CB..04CC    ; Recommended                    # 1.1    [2] CYRILLIC CAPITAL LETTER KHAKASSIAN CHE..CYRILLIC SMALL LETTER KHAKASSIAN CHE
+04CD..04CE    ; Recommended                    # 3.2    [2] CYRILLIC CAPITAL LETTER EM WITH TAIL..CYRILLIC SMALL LETTER EM WITH TAIL
+04CF          ; Recommended                    # 5.0        CYRILLIC SMALL LETTER PALOCHKA
+04D0..04EB    ; Recommended                    # 1.1   [28] CYRILLIC CAPITAL LETTER A WITH BREVE..CYRILLIC SMALL LETTER BARRED O WITH DIAERESIS
+04EC..04ED    ; Recommended                    # 3.0    [2] CYRILLIC CAPITAL LETTER E WITH DIAERESIS..CYRILLIC SMALL LETTER E WITH DIAERESIS
+04EE..04F5    ; Recommended                    # 1.1    [8] CYRILLIC CAPITAL LETTER U WITH MACRON..CYRILLIC SMALL LETTER CHE WITH DIAERESIS
+04F6..04F7    ; Recommended                    # 4.1    [2] CYRILLIC CAPITAL LETTER GHE WITH DESCENDER..CYRILLIC SMALL LETTER GHE WITH DESCENDER
+04F8..04F9    ; Recommended                    # 1.1    [2] CYRILLIC CAPITAL LETTER YERU WITH DIAERESIS..CYRILLIC SMALL LETTER YERU WITH DIAERESIS
+04FA..04FF    ; Recommended                    # 5.0    [6] CYRILLIC CAPITAL LETTER GHE WITH STROKE AND HOOK..CYRILLIC SMALL LETTER HA WITH STROKE
+0510..0513    ; Recommended                    # 5.0    [4] CYRILLIC CAPITAL LETTER REVERSED ZE..CYRILLIC SMALL LETTER EL WITH HOOK
+0514..0523    ; Recommended                    # 5.1   [16] CYRILLIC CAPITAL LETTER LHA..CYRILLIC SMALL LETTER EN WITH MIDDLE HOOK
+0524..0525    ; Recommended                    # 5.2    [2] CYRILLIC CAPITAL LETTER PE WITH DESCENDER..CYRILLIC SMALL LETTER PE WITH DESCENDER
+0526..0527    ; Recommended                    # 6.0    [2] CYRILLIC CAPITAL LETTER SHHA WITH DESCENDER..CYRILLIC SMALL LETTER SHHA WITH DESCENDER
+0528..0529    ; Recommended                    # 7.0    [2] CYRILLIC CAPITAL LETTER EN WITH LEFT HOOK..CYRILLIC SMALL LETTER EN WITH LEFT HOOK
+052E..052F    ; Recommended                    # 7.0    [2] CYRILLIC CAPITAL LETTER EL WITH DESCENDER..CYRILLIC SMALL LETTER EL WITH DESCENDER
+0531..0556    ; Recommended                    # 1.1   [38] ARMENIAN CAPITAL LETTER AYB..ARMENIAN CAPITAL LETTER FEH
+0559          ; Recommended                    # 1.1        ARMENIAN MODIFIER LETTER LEFT HALF RING
+0561..0586    ; Recommended                    # 1.1   [38] ARMENIAN SMALL LETTER AYB..ARMENIAN SMALL LETTER FEH
+05B4          ; Recommended                    # 1.1        HEBREW POINT HIRIQ
+05D0..05EA    ; Recommended                    # 1.1   [27] HEBREW LETTER ALEF..HEBREW LETTER TAV
+05EF          ; Recommended                    # 11.0       HEBREW YOD TRIANGLE
+05F0..05F2    ; Recommended                    # 1.1    [3] HEBREW LIGATURE YIDDISH DOUBLE VAV..HEBREW LIGATURE YIDDISH DOUBLE YOD
+0620          ; Recommended                    # 6.0        ARABIC LETTER KASHMIRI YEH
+0621..063A    ; Recommended                    # 1.1   [26] ARABIC LETTER HAMZA..ARABIC LETTER GHAIN
+063B..063F    ; Recommended                    # 5.1    [5] ARABIC LETTER KEHEH WITH TWO DOTS ABOVE..ARABIC LETTER FARSI YEH WITH THREE DOTS ABOVE
+0641..0652    ; Recommended                    # 1.1   [18] ARABIC LETTER FEH..ARABIC SUKUN
+0653..0655    ; Recommended                    # 3.0    [3] ARABIC MADDAH ABOVE..ARABIC HAMZA BELOW
+0660..0669    ; Recommended                    # 1.1   [10] ARABIC-INDIC DIGIT ZERO..ARABIC-INDIC DIGIT NINE
+0670..0672    ; Recommended                    # 1.1    [3] ARABIC LETTER SUPERSCRIPT ALEF..ARABIC LETTER ALEF WITH WAVY HAMZA ABOVE
+0674          ; Recommended                    # 1.1        ARABIC LETTER HIGH HAMZA
+0679..068D    ; Recommended                    # 1.1   [21] ARABIC LETTER TTEH..ARABIC LETTER DDAHAL
+068F..06A0    ; Recommended                    # 1.1   [18] ARABIC LETTER DAL WITH THREE DOTS ABOVE DOWNWARDS..ARABIC LETTER AIN WITH THREE DOTS ABOVE
+06A2..06B7    ; Recommended                    # 1.1   [22] ARABIC LETTER FEH WITH DOT MOVED BELOW..ARABIC LETTER LAM WITH THREE DOTS ABOVE
+06B8..06B9    ; Recommended                    # 3.0    [2] ARABIC LETTER LAM WITH THREE DOTS BELOW..ARABIC LETTER NOON WITH DOT BELOW
+06BA..06BE    ; Recommended                    # 1.1    [5] ARABIC LETTER NOON GHUNNA..ARABIC LETTER HEH DOACHASHMEE
+06BF          ; Recommended                    # 3.0        ARABIC LETTER TCHEH WITH DOT ABOVE
+06C0..06CE    ; Recommended                    # 1.1   [15] ARABIC LETTER HEH WITH YEH ABOVE..ARABIC LETTER YEH WITH SMALL V
+06CF          ; Recommended                    # 3.0        ARABIC LETTER WAW WITH DOT ABOVE
+06D0..06D3    ; Recommended                    # 1.1    [4] ARABIC LETTER E..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE
+06D5          ; Recommended                    # 1.1        ARABIC LETTER AE
+06E5..06E6    ; Recommended                    # 1.1    [2] ARABIC SMALL WAW..ARABIC SMALL YEH
+06EE..06EF    ; Recommended                    # 4.0    [2] ARABIC LETTER DAL WITH INVERTED V..ARABIC LETTER REH WITH INVERTED V
+06F0..06F9    ; Recommended                    # 1.1   [10] EXTENDED ARABIC-INDIC DIGIT ZERO..EXTENDED ARABIC-INDIC DIGIT NINE
+06FA..06FC    ; Recommended                    # 3.0    [3] ARABIC LETTER SHEEN WITH DOT BELOW..ARABIC LETTER GHAIN WITH DOT BELOW
+06FF          ; Recommended                    # 4.0        ARABIC LETTER HEH WITH INVERTED V
+0750..076D    ; Recommended                    # 4.1   [30] ARABIC LETTER BEH WITH THREE DOTS HORIZONTALLY BELOW..ARABIC LETTER SEEN WITH TWO DOTS VERTICALLY ABOVE
+076E..077F    ; Recommended                    # 5.1   [18] ARABIC LETTER HAH WITH SMALL ARABIC LETTER TAH BELOW..ARABIC LETTER KAF WITH TWO DOTS ABOVE
+0780..07B0    ; Recommended                    # 3.0   [49] THAANA LETTER HAA..THAANA SUKUN
+07B1          ; Recommended                    # 3.2        THAANA LETTER NAA
+0870..0887    ; Recommended                    # 14.0  [24] ARABIC LETTER ALEF WITH ATTACHED FATHA..ARABIC BASELINE ROUND DOT
+0889..088E    ; Recommended                    # 14.0   [6] ARABIC LETTER NOON WITH INVERTED SMALL V..ARABIC VERTICAL TAIL
+08A0          ; Recommended                    # 6.1        ARABIC LETTER BEH WITH SMALL V BELOW
+08A1          ; Recommended                    # 7.0        ARABIC LETTER BEH WITH HAMZA ABOVE
+08A2..08AC    ; Recommended                    # 6.1   [11] ARABIC LETTER JEEM WITH TWO DOTS ABOVE..ARABIC LETTER ROHINGYA YEH
+08B2          ; Recommended                    # 7.0        ARABIC LETTER ZAIN WITH INVERTED V ABOVE
+08B5          ; Recommended                    # 14.0       ARABIC LETTER QAF WITH DOT BELOW AND NO DOTS ABOVE
+08B6..08BD    ; Recommended                    # 9.0    [8] ARABIC LETTER BEH WITH SMALL MEEM ABOVE..ARABIC LETTER AFRICAN NOON
+08BE..08C7    ; Recommended                    # 13.0  [10] ARABIC LETTER PEH WITH SMALL V..ARABIC LETTER LAM WITH SMALL ARABIC LETTER TAH ABOVE
+08C8..08C9    ; Recommended                    # 14.0   [2] ARABIC LETTER GRAF..ARABIC SMALL FARSI YEH
+0901..0903    ; Recommended                    # 1.1    [3] DEVANAGARI SIGN CANDRABINDU..DEVANAGARI SIGN VISARGA
+0904          ; Recommended                    # 4.0        DEVANAGARI LETTER SHORT A
+0905..0939    ; Recommended                    # 1.1   [53] DEVANAGARI LETTER A..DEVANAGARI LETTER HA
+093A..093B    ; Recommended                    # 6.0    [2] DEVANAGARI VOWEL SIGN OE..DEVANAGARI VOWEL SIGN OOE
+093C..094D    ; Recommended                    # 1.1   [18] DEVANAGARI SIGN NUKTA..DEVANAGARI SIGN VIRAMA
+094F          ; Recommended                    # 6.0        DEVANAGARI VOWEL SIGN AW
+0950          ; Recommended                    # 1.1        DEVANAGARI OM
+0956..0957    ; Recommended                    # 6.0    [2] DEVANAGARI VOWEL SIGN UE..DEVANAGARI VOWEL SIGN UUE
+0960..0963    ; Recommended                    # 1.1    [4] DEVANAGARI LETTER VOCALIC RR..DEVANAGARI VOWEL SIGN VOCALIC LL
+0966..096F    ; Recommended                    # 1.1   [10] DEVANAGARI DIGIT ZERO..DEVANAGARI DIGIT NINE
+0971..0972    ; Recommended                    # 5.1    [2] DEVANAGARI SIGN HIGH SPACING DOT..DEVANAGARI LETTER CANDRA A
+0973..0977    ; Recommended                    # 6.0    [5] DEVANAGARI LETTER OE..DEVANAGARI LETTER UUE
+0979..097A    ; Recommended                    # 5.2    [2] DEVANAGARI LETTER ZHA..DEVANAGARI LETTER HEAVY YA
+097B..097C    ; Recommended                    # 5.0    [2] DEVANAGARI LETTER GGA..DEVANAGARI LETTER JJA
+097D          ; Recommended                    # 4.1        DEVANAGARI LETTER GLOTTAL STOP
+097E..097F    ; Recommended                    # 5.0    [2] DEVANAGARI LETTER DDDA..DEVANAGARI LETTER BBA
+0981..0983    ; Recommended                    # 1.1    [3] BENGALI SIGN CANDRABINDU..BENGALI SIGN VISARGA
+0985..098C    ; Recommended                    # 1.1    [8] BENGALI LETTER A..BENGALI LETTER VOCALIC L
+098F..0990    ; Recommended                    # 1.1    [2] BENGALI LETTER E..BENGALI LETTER AI
+0993..09A8    ; Recommended                    # 1.1   [22] BENGALI LETTER O..BENGALI LETTER NA
+09AA..09B0    ; Recommended                    # 1.1    [7] BENGALI LETTER PA..BENGALI LETTER RA
+09B2          ; Recommended                    # 1.1        BENGALI LETTER LA
+09B6..09B9    ; Recommended                    # 1.1    [4] BENGALI LETTER SHA..BENGALI LETTER HA
+09BC          ; Recommended                    # 1.1        BENGALI SIGN NUKTA
+09BD          ; Recommended                    # 4.0        BENGALI SIGN AVAGRAHA
+09BE..09C4    ; Recommended                    # 1.1    [7] BENGALI VOWEL SIGN AA..BENGALI VOWEL SIGN VOCALIC RR
+09C7..09C8    ; Recommended                    # 1.1    [2] BENGALI VOWEL SIGN E..BENGALI VOWEL SIGN AI
+09CB..09CD    ; Recommended                    # 1.1    [3] BENGALI VOWEL SIGN O..BENGALI SIGN VIRAMA
+09CE          ; Recommended                    # 4.1        BENGALI LETTER KHANDA TA
+09D7          ; Recommended                    # 1.1        BENGALI AU LENGTH MARK
+09E0..09E3    ; Recommended                    # 1.1    [4] BENGALI LETTER VOCALIC RR..BENGALI VOWEL SIGN VOCALIC LL
+09E6..09F1    ; Recommended                    # 1.1   [12] BENGALI DIGIT ZERO..BENGALI LETTER RA WITH LOWER DIAGONAL
+09FE          ; Recommended                    # 11.0       BENGALI SANDHI MARK
+0A01          ; Recommended                    # 4.0        GURMUKHI SIGN ADAK BINDI
+0A02          ; Recommended                    # 1.1        GURMUKHI SIGN BINDI
+0A03          ; Recommended                    # 4.0        GURMUKHI SIGN VISARGA
+0A05..0A0A    ; Recommended                    # 1.1    [6] GURMUKHI LETTER A..GURMUKHI LETTER UU
+0A0F..0A10    ; Recommended                    # 1.1    [2] GURMUKHI LETTER EE..GURMUKHI LETTER AI
+0A13..0A28    ; Recommended                    # 1.1   [22] GURMUKHI LETTER OO..GURMUKHI LETTER NA
+0A2A..0A30    ; Recommended                    # 1.1    [7] GURMUKHI LETTER PA..GURMUKHI LETTER RA
+0A32          ; Recommended                    # 1.1        GURMUKHI LETTER LA
+0A35          ; Recommended                    # 1.1        GURMUKHI LETTER VA
+0A38..0A39    ; Recommended                    # 1.1    [2] GURMUKHI LETTER SA..GURMUKHI LETTER HA
+0A3C          ; Recommended                    # 1.1        GURMUKHI SIGN NUKTA
+0A3E..0A42    ; Recommended                    # 1.1    [5] GURMUKHI VOWEL SIGN AA..GURMUKHI VOWEL SIGN UU
+0A47..0A48    ; Recommended                    # 1.1    [2] GURMUKHI VOWEL SIGN EE..GURMUKHI VOWEL SIGN AI
+0A4B..0A4D    ; Recommended                    # 1.1    [3] GURMUKHI VOWEL SIGN OO..GURMUKHI SIGN VIRAMA
+0A5C          ; Recommended                    # 1.1        GURMUKHI LETTER RRA
+0A66..0A74    ; Recommended                    # 1.1   [15] GURMUKHI DIGIT ZERO..GURMUKHI EK ONKAR
+0A81..0A83    ; Recommended                    # 1.1    [3] GUJARATI SIGN CANDRABINDU..GUJARATI SIGN VISARGA
+0A85..0A8B    ; Recommended                    # 1.1    [7] GUJARATI LETTER A..GUJARATI LETTER VOCALIC R
+0A8C          ; Recommended                    # 4.0        GUJARATI LETTER VOCALIC L
+0A8D          ; Recommended                    # 1.1        GUJARATI VOWEL CANDRA E
+0A8F..0A91    ; Recommended                    # 1.1    [3] GUJARATI LETTER E..GUJARATI VOWEL CANDRA O
+0A93..0AA8    ; Recommended                    # 1.1   [22] GUJARATI LETTER O..GUJARATI LETTER NA
+0AAA..0AB0    ; Recommended                    # 1.1    [7] GUJARATI LETTER PA..GUJARATI LETTER RA
+0AB2..0AB3    ; Recommended                    # 1.1    [2] GUJARATI LETTER LA..GUJARATI LETTER LLA
+0AB5..0AB9    ; Recommended                    # 1.1    [5] GUJARATI LETTER VA..GUJARATI LETTER HA
+0ABC..0AC5    ; Recommended                    # 1.1   [10] GUJARATI SIGN NUKTA..GUJARATI VOWEL SIGN CANDRA E
+0AC7..0AC9    ; Recommended                    # 1.1    [3] GUJARATI VOWEL SIGN E..GUJARATI VOWEL SIGN CANDRA O
+0ACB..0ACD    ; Recommended                    # 1.1    [3] GUJARATI VOWEL SIGN O..GUJARATI SIGN VIRAMA
+0AD0          ; Recommended                    # 1.1        GUJARATI OM
+0AE0          ; Recommended                    # 1.1        GUJARATI LETTER VOCALIC RR
+0AE1..0AE3    ; Recommended                    # 4.0    [3] GUJARATI LETTER VOCALIC LL..GUJARATI VOWEL SIGN VOCALIC LL
+0AE6..0AEF    ; Recommended                    # 1.1   [10] GUJARATI DIGIT ZERO..GUJARATI DIGIT NINE
+0AFA..0AFF    ; Recommended                    # 10.0   [6] GUJARATI SIGN SUKUN..GUJARATI SIGN TWO-CIRCLE NUKTA ABOVE
+0B01..0B03    ; Recommended                    # 1.1    [3] ORIYA SIGN CANDRABINDU..ORIYA SIGN VISARGA
+0B05..0B0C    ; Recommended                    # 1.1    [8] ORIYA LETTER A..ORIYA LETTER VOCALIC L
+0B0F..0B10    ; Recommended                    # 1.1    [2] ORIYA LETTER E..ORIYA LETTER AI
+0B13..0B28    ; Recommended                    # 1.1   [22] ORIYA LETTER O..ORIYA LETTER NA
+0B2A..0B30    ; Recommended                    # 1.1    [7] ORIYA LETTER PA..ORIYA LETTER RA
+0B32..0B33    ; Recommended                    # 1.1    [2] ORIYA LETTER LA..ORIYA LETTER LLA
+0B35          ; Recommended                    # 4.0        ORIYA LETTER VA
+0B36..0B39    ; Recommended                    # 1.1    [4] ORIYA LETTER SHA..ORIYA LETTER HA
+0B3C..0B43    ; Recommended                    # 1.1    [8] ORIYA SIGN NUKTA..ORIYA VOWEL SIGN VOCALIC R
+0B47..0B48    ; Recommended                    # 1.1    [2] ORIYA VOWEL SIGN E..ORIYA VOWEL SIGN AI
+0B4B..0B4D    ; Recommended                    # 1.1    [3] ORIYA VOWEL SIGN O..ORIYA SIGN VIRAMA
+0B55          ; Recommended                    # 13.0       ORIYA SIGN OVERLINE
+0B56..0B57    ; Recommended                    # 1.1    [2] ORIYA AI LENGTH MARK..ORIYA AU LENGTH MARK
+0B5F..0B61    ; Recommended                    # 1.1    [3] ORIYA LETTER YYA..ORIYA LETTER VOCALIC LL
+0B66..0B6F    ; Recommended                    # 1.1   [10] ORIYA DIGIT ZERO..ORIYA DIGIT NINE
+0B71          ; Recommended                    # 4.0        ORIYA LETTER WA
+0B82..0B83    ; Recommended                    # 1.1    [2] TAMIL SIGN ANUSVARA..TAMIL SIGN VISARGA
+0B85..0B8A    ; Recommended                    # 1.1    [6] TAMIL LETTER A..TAMIL LETTER UU
+0B8E..0B90    ; Recommended                    # 1.1    [3] TAMIL LETTER E..TAMIL LETTER AI
+0B92..0B95    ; Recommended                    # 1.1    [4] TAMIL LETTER O..TAMIL LETTER KA
+0B99..0B9A    ; Recommended                    # 1.1    [2] TAMIL LETTER NGA..TAMIL LETTER CA
+0B9C          ; Recommended                    # 1.1        TAMIL LETTER JA
+0B9E..0B9F    ; Recommended                    # 1.1    [2] TAMIL LETTER NYA..TAMIL LETTER TTA
+0BA3..0BA4    ; Recommended                    # 1.1    [2] TAMIL LETTER NNA..TAMIL LETTER TA
+0BA8..0BAA    ; Recommended                    # 1.1    [3] TAMIL LETTER NA..TAMIL LETTER PA
+0BAE..0BB5    ; Recommended                    # 1.1    [8] TAMIL LETTER MA..TAMIL LETTER VA
+0BB6          ; Recommended                    # 4.1        TAMIL LETTER SHA
+0BB7..0BB9    ; Recommended                    # 1.1    [3] TAMIL LETTER SSA..TAMIL LETTER HA
+0BBE..0BC2    ; Recommended                    # 1.1    [5] TAMIL VOWEL SIGN AA..TAMIL VOWEL SIGN UU
+0BC6..0BC8    ; Recommended                    # 1.1    [3] TAMIL VOWEL SIGN E..TAMIL VOWEL SIGN AI
+0BCA..0BCD    ; Recommended                    # 1.1    [4] TAMIL VOWEL SIGN O..TAMIL SIGN VIRAMA
+0BD0          ; Recommended                    # 5.1        TAMIL OM
+0BD7          ; Recommended                    # 1.1        TAMIL AU LENGTH MARK
+0BE6          ; Recommended                    # 4.1        TAMIL DIGIT ZERO
+0BE7..0BEF    ; Recommended                    # 1.1    [9] TAMIL DIGIT ONE..TAMIL DIGIT NINE
+0C01..0C03    ; Recommended                    # 1.1    [3] TELUGU SIGN CANDRABINDU..TELUGU SIGN VISARGA
+0C04          ; Recommended                    # 11.0       TELUGU SIGN COMBINING ANUSVARA ABOVE
+0C05..0C0C    ; Recommended                    # 1.1    [8] TELUGU LETTER A..TELUGU LETTER VOCALIC L
+0C0E..0C10    ; Recommended                    # 1.1    [3] TELUGU LETTER E..TELUGU LETTER AI
+0C12..0C28    ; Recommended                    # 1.1   [23] TELUGU LETTER O..TELUGU LETTER NA
+0C2A..0C33    ; Recommended                    # 1.1   [10] TELUGU LETTER PA..TELUGU LETTER LLA
+0C35..0C39    ; Recommended                    # 1.1    [5] TELUGU LETTER VA..TELUGU LETTER HA
+0C3C          ; Recommended                    # 14.0       TELUGU SIGN NUKTA
+0C3D          ; Recommended                    # 5.1        TELUGU SIGN AVAGRAHA
+0C3E..0C44    ; Recommended                    # 1.1    [7] TELUGU VOWEL SIGN AA..TELUGU VOWEL SIGN VOCALIC RR
+0C46..0C48    ; Recommended                    # 1.1    [3] TELUGU VOWEL SIGN E..TELUGU VOWEL SIGN AI
+0C4A..0C4D    ; Recommended                    # 1.1    [4] TELUGU VOWEL SIGN O..TELUGU SIGN VIRAMA
+0C55..0C56    ; Recommended                    # 1.1    [2] TELUGU LENGTH MARK..TELUGU AI LENGTH MARK
+0C5D          ; Recommended                    # 14.0       TELUGU LETTER NAKAARA POLLU
+0C60..0C61    ; Recommended                    # 1.1    [2] TELUGU LETTER VOCALIC RR..TELUGU LETTER VOCALIC LL
+0C66..0C6F    ; Recommended                    # 1.1   [10] TELUGU DIGIT ZERO..TELUGU DIGIT NINE
+0C80          ; Recommended                    # 9.0        KANNADA SIGN SPACING CANDRABINDU
+0C82..0C83    ; Recommended                    # 1.1    [2] KANNADA SIGN ANUSVARA..KANNADA SIGN VISARGA
+0C85..0C8C    ; Recommended                    # 1.1    [8] KANNADA LETTER A..KANNADA LETTER VOCALIC L
+0C8E..0C90    ; Recommended                    # 1.1    [3] KANNADA LETTER E..KANNADA LETTER AI
+0C92..0CA8    ; Recommended                    # 1.1   [23] KANNADA LETTER O..KANNADA LETTER NA
+0CAA..0CB3    ; Recommended                    # 1.1   [10] KANNADA LETTER PA..KANNADA LETTER LLA
+0CB5..0CB9    ; Recommended                    # 1.1    [5] KANNADA LETTER VA..KANNADA LETTER HA
+0CBC..0CBD    ; Recommended                    # 4.0    [2] KANNADA SIGN NUKTA..KANNADA SIGN AVAGRAHA
+0CBE..0CC4    ; Recommended                    # 1.1    [7] KANNADA VOWEL SIGN AA..KANNADA VOWEL SIGN VOCALIC RR
+0CC6..0CC8    ; Recommended                    # 1.1    [3] KANNADA VOWEL SIGN E..KANNADA VOWEL SIGN AI
+0CCA..0CCD    ; Recommended                    # 1.1    [4] KANNADA VOWEL SIGN O..KANNADA SIGN VIRAMA
+0CD5..0CD6    ; Recommended                    # 1.1    [2] KANNADA LENGTH MARK..KANNADA AI LENGTH MARK
+0CDD          ; Recommended                    # 14.0       KANNADA LETTER NAKAARA POLLU
+0CE0..0CE1    ; Recommended                    # 1.1    [2] KANNADA LETTER VOCALIC RR..KANNADA LETTER VOCALIC LL
+0CE2..0CE3    ; Recommended                    # 5.0    [2] KANNADA VOWEL SIGN VOCALIC L..KANNADA VOWEL SIGN VOCALIC LL
+0CE6..0CEF    ; Recommended                    # 1.1   [10] KANNADA DIGIT ZERO..KANNADA DIGIT NINE
+0CF1..0CF2    ; Recommended                    # 5.0    [2] KANNADA SIGN JIHVAMULIYA..KANNADA SIGN UPADHMANIYA
+0D00          ; Recommended                    # 10.0       MALAYALAM SIGN COMBINING ANUSVARA ABOVE
+0D02..0D03    ; Recommended                    # 1.1    [2] MALAYALAM SIGN ANUSVARA..MALAYALAM SIGN VISARGA
+0D05..0D0C    ; Recommended                    # 1.1    [8] MALAYALAM LETTER A..MALAYALAM LETTER VOCALIC L
+0D0E..0D10    ; Recommended                    # 1.1    [3] MALAYALAM LETTER E..MALAYALAM LETTER AI
+0D12..0D28    ; Recommended                    # 1.1   [23] MALAYALAM LETTER O..MALAYALAM LETTER NA
+0D29          ; Recommended                    # 6.0        MALAYALAM LETTER NNNA
+0D2A..0D39    ; Recommended                    # 1.1   [16] MALAYALAM LETTER PA..MALAYALAM LETTER HA
+0D3A          ; Recommended                    # 6.0        MALAYALAM LETTER TTTA
+0D3D          ; Recommended                    # 5.1        MALAYALAM SIGN AVAGRAHA
+0D3E..0D43    ; Recommended                    # 1.1    [6] MALAYALAM VOWEL SIGN AA..MALAYALAM VOWEL SIGN VOCALIC R
+0D46..0D48    ; Recommended                    # 1.1    [3] MALAYALAM VOWEL SIGN E..MALAYALAM VOWEL SIGN AI
+0D4A..0D4D    ; Recommended                    # 1.1    [4] MALAYALAM VOWEL SIGN O..MALAYALAM SIGN VIRAMA
+0D4E          ; Recommended                    # 6.0        MALAYALAM LETTER DOT REPH
+0D54..0D56    ; Recommended                    # 9.0    [3] MALAYALAM LETTER CHILLU M..MALAYALAM LETTER CHILLU LLL
+0D57          ; Recommended                    # 1.1        MALAYALAM AU LENGTH MARK
+0D60..0D61    ; Recommended                    # 1.1    [2] MALAYALAM LETTER VOCALIC RR..MALAYALAM LETTER VOCALIC LL
+0D66..0D6F    ; Recommended                    # 1.1   [10] MALAYALAM DIGIT ZERO..MALAYALAM DIGIT NINE
+0D7A..0D7F    ; Recommended                    # 5.1    [6] MALAYALAM LETTER CHILLU NN..MALAYALAM LETTER CHILLU K
+0D82..0D83    ; Recommended                    # 3.0    [2] SINHALA SIGN ANUSVARAYA..SINHALA SIGN VISARGAYA
+0D85..0D8E    ; Recommended                    # 3.0   [10] SINHALA LETTER AYANNA..SINHALA LETTER IRUUYANNA
+0D91..0D96    ; Recommended                    # 3.0    [6] SINHALA LETTER EYANNA..SINHALA LETTER AUYANNA
+0D9A..0DA5    ; Recommended                    # 3.0   [12] SINHALA LETTER ALPAPRAANA KAYANNA..SINHALA LETTER TAALUJA SANYOOGA NAAKSIKYAYA
+0DA7..0DB1    ; Recommended                    # 3.0   [11] SINHALA LETTER ALPAPRAANA TTAYANNA..SINHALA LETTER DANTAJA NAYANNA
+0DB3..0DBB    ; Recommended                    # 3.0    [9] SINHALA LETTER SANYAKA DAYANNA..SINHALA LETTER RAYANNA
+0DBD          ; Recommended                    # 3.0        SINHALA LETTER DANTAJA LAYANNA
+0DC0..0DC6    ; Recommended                    # 3.0    [7] SINHALA LETTER VAYANNA..SINHALA LETTER FAYANNA
+0DCA          ; Recommended                    # 3.0        SINHALA SIGN AL-LAKUNA
+0DCF..0DD4    ; Recommended                    # 3.0    [6] SINHALA VOWEL SIGN AELA-PILLA..SINHALA VOWEL SIGN KETTI PAA-PILLA
+0DD6          ; Recommended                    # 3.0        SINHALA VOWEL SIGN DIGA PAA-PILLA
+0DD8..0DDE    ; Recommended                    # 3.0    [7] SINHALA VOWEL SIGN GAETTA-PILLA..SINHALA VOWEL SIGN KOMBUVA HAA GAYANUKITTA
+0DF2          ; Recommended                    # 3.0        SINHALA VOWEL SIGN DIGA GAETTA-PILLA
+0E01..0E32    ; Recommended                    # 1.1   [50] THAI CHARACTER KO KAI..THAI CHARACTER SARA AA
+0E34..0E3A    ; Recommended                    # 1.1    [7] THAI CHARACTER SARA I..THAI CHARACTER PHINTHU
+0E40..0E4E    ; Recommended                    # 1.1   [15] THAI CHARACTER SARA E..THAI CHARACTER YAMAKKAN
+0E50..0E59    ; Recommended                    # 1.1   [10] THAI DIGIT ZERO..THAI DIGIT NINE
+0E81..0E82    ; Recommended                    # 1.1    [2] LAO LETTER KO..LAO LETTER KHO SUNG
+0E84          ; Recommended                    # 1.1        LAO LETTER KHO TAM
+0E86          ; Recommended                    # 12.0       LAO LETTER PALI GHA
+0E87..0E88    ; Recommended                    # 1.1    [2] LAO LETTER NGO..LAO LETTER CO
+0E89          ; Recommended                    # 12.0       LAO LETTER PALI CHA
+0E8A          ; Recommended                    # 1.1        LAO LETTER SO TAM
+0E8C          ; Recommended                    # 12.0       LAO LETTER PALI JHA
+0E8D          ; Recommended                    # 1.1        LAO LETTER NYO
+0E8E..0E93    ; Recommended                    # 12.0   [6] LAO LETTER PALI NYA..LAO LETTER PALI NNA
+0E94..0E97    ; Recommended                    # 1.1    [4] LAO LETTER DO..LAO LETTER THO TAM
+0E98          ; Recommended                    # 12.0       LAO LETTER PALI DHA
+0E99..0E9F    ; Recommended                    # 1.1    [7] LAO LETTER NO..LAO LETTER FO SUNG
+0EA0          ; Recommended                    # 12.0       LAO LETTER PALI BHA
+0EA1..0EA3    ; Recommended                    # 1.1    [3] LAO LETTER MO..LAO LETTER LO LING
+0EA5          ; Recommended                    # 1.1        LAO LETTER LO LOOT
+0EA7          ; Recommended                    # 1.1        LAO LETTER WO
+0EA8..0EA9    ; Recommended                    # 12.0   [2] LAO LETTER SANSKRIT SHA..LAO LETTER SANSKRIT SSA
+0EAA..0EAB    ; Recommended                    # 1.1    [2] LAO LETTER SO SUNG..LAO LETTER HO SUNG
+0EAC          ; Recommended                    # 12.0       LAO LETTER PALI LLA
+0EAD..0EB2    ; Recommended                    # 1.1    [6] LAO LETTER O..LAO VOWEL SIGN AA
+0EB4..0EB9    ; Recommended                    # 1.1    [6] LAO VOWEL SIGN I..LAO VOWEL SIGN UU
+0EBA          ; Recommended                    # 12.0       LAO SIGN PALI VIRAMA
+0EBB..0EBD    ; Recommended                    # 1.1    [3] LAO VOWEL SIGN MAI KON..LAO SEMIVOWEL SIGN NYO
+0EC0..0EC4    ; Recommended                    # 1.1    [5] LAO VOWEL SIGN E..LAO VOWEL SIGN AI
+0EC6          ; Recommended                    # 1.1        LAO KO LA
+0EC8..0ECD    ; Recommended                    # 1.1    [6] LAO TONE MAI EK..LAO NIGGAHITA
+0ED0..0ED9    ; Recommended                    # 1.1   [10] LAO DIGIT ZERO..LAO DIGIT NINE
+0EDE..0EDF    ; Recommended                    # 6.1    [2] LAO LETTER KHMU GO..LAO LETTER KHMU NYO
+0F00          ; Recommended                    # 2.0        TIBETAN SYLLABLE OM
+0F20..0F29    ; Recommended                    # 2.0   [10] TIBETAN DIGIT ZERO..TIBETAN DIGIT NINE
+0F35          ; Recommended                    # 2.0        TIBETAN MARK NGAS BZUNG NYI ZLA
+0F37          ; Recommended                    # 2.0        TIBETAN MARK NGAS BZUNG SGOR RTAGS
+0F3E..0F42    ; Recommended                    # 2.0    [5] TIBETAN SIGN YAR TSHES..TIBETAN LETTER GA
+0F44..0F47    ; Recommended                    # 2.0    [4] TIBETAN LETTER NGA..TIBETAN LETTER JA
+0F49..0F4C    ; Recommended                    # 2.0    [4] TIBETAN LETTER NYA..TIBETAN LETTER DDA
+0F4E..0F51    ; Recommended                    # 2.0    [4] TIBETAN LETTER NNA..TIBETAN LETTER DA
+0F53..0F56    ; Recommended                    # 2.0    [4] TIBETAN LETTER NA..TIBETAN LETTER BA
+0F58..0F5B    ; Recommended                    # 2.0    [4] TIBETAN LETTER MA..TIBETAN LETTER DZA
+0F5D..0F68    ; Recommended                    # 2.0   [12] TIBETAN LETTER WA..TIBETAN LETTER A
+0F6A          ; Recommended                    # 3.0        TIBETAN LETTER FIXED-FORM RA
+0F6B..0F6C    ; Recommended                    # 5.1    [2] TIBETAN LETTER KKA..TIBETAN LETTER RRA
+0F71..0F72    ; Recommended                    # 2.0    [2] TIBETAN VOWEL SIGN AA..TIBETAN VOWEL SIGN I
+0F74          ; Recommended                    # 2.0        TIBETAN VOWEL SIGN U
+0F7A..0F80    ; Recommended                    # 2.0    [7] TIBETAN VOWEL SIGN E..TIBETAN VOWEL SIGN REVERSED I
+0F82..0F84    ; Recommended                    # 2.0    [3] TIBETAN SIGN NYI ZLA NAA DA..TIBETAN MARK HALANTA
+0F86..0F8B    ; Recommended                    # 2.0    [6] TIBETAN SIGN LCI RTAGS..TIBETAN SIGN GRU MED RGYINGS
+0F8C..0F8F    ; Recommended                    # 6.0    [4] TIBETAN SIGN INVERTED MCHU CAN..TIBETAN SUBJOINED SIGN INVERTED MCHU CAN
+0F90..0F92    ; Recommended                    # 2.0    [3] TIBETAN SUBJOINED LETTER KA..TIBETAN SUBJOINED LETTER GA
+0F94..0F95    ; Recommended                    # 2.0    [2] TIBETAN SUBJOINED LETTER NGA..TIBETAN SUBJOINED LETTER CA
+0F96          ; Recommended                    # 3.0        TIBETAN SUBJOINED LETTER CHA
+0F97          ; Recommended                    # 2.0        TIBETAN SUBJOINED LETTER JA
+0F99..0F9C    ; Recommended                    # 2.0    [4] TIBETAN SUBJOINED LETTER NYA..TIBETAN SUBJOINED LETTER DDA
+0F9E..0FA1    ; Recommended                    # 2.0    [4] TIBETAN SUBJOINED LETTER NNA..TIBETAN SUBJOINED LETTER DA
+0FA3..0FA6    ; Recommended                    # 2.0    [4] TIBETAN SUBJOINED LETTER NA..TIBETAN SUBJOINED LETTER BA
+0FA8..0FAB    ; Recommended                    # 2.0    [4] TIBETAN SUBJOINED LETTER MA..TIBETAN SUBJOINED LETTER DZA
+0FAD          ; Recommended                    # 2.0        TIBETAN SUBJOINED LETTER WA
+0FAE..0FB0    ; Recommended                    # 3.0    [3] TIBETAN SUBJOINED LETTER ZHA..TIBETAN SUBJOINED LETTER -A
+0FB1..0FB7    ; Recommended                    # 2.0    [7] TIBETAN SUBJOINED LETTER YA..TIBETAN SUBJOINED LETTER HA
+0FB8          ; Recommended                    # 3.0        TIBETAN SUBJOINED LETTER A
+0FBA..0FBC    ; Recommended                    # 3.0    [3] TIBETAN SUBJOINED LETTER FIXED-FORM WA..TIBETAN SUBJOINED LETTER FIXED-FORM RA
+0FC6          ; Recommended                    # 3.0        TIBETAN SYMBOL PADMA GDAN
+1000..1021    ; Recommended                    # 3.0   [34] MYANMAR LETTER KA..MYANMAR LETTER A
+1022          ; Recommended                    # 5.1        MYANMAR LETTER SHAN A
+1023..1027    ; Recommended                    # 3.0    [5] MYANMAR LETTER I..MYANMAR LETTER E
+1028          ; Recommended                    # 5.1        MYANMAR LETTER MON E
+1029..102A    ; Recommended                    # 3.0    [2] MYANMAR LETTER O..MYANMAR LETTER AU
+102B          ; Recommended                    # 5.1        MYANMAR VOWEL SIGN TALL AA
+102C..1032    ; Recommended                    # 3.0    [7] MYANMAR VOWEL SIGN AA..MYANMAR VOWEL SIGN AI
+1033..1035    ; Recommended                    # 5.1    [3] MYANMAR VOWEL SIGN MON II..MYANMAR VOWEL SIGN E ABOVE
+1036..1039    ; Recommended                    # 3.0    [4] MYANMAR SIGN ANUSVARA..MYANMAR SIGN VIRAMA
+103A..103F    ; Recommended                    # 5.1    [6] MYANMAR SIGN ASAT..MYANMAR LETTER GREAT SA
+1040..1049    ; Recommended                    # 3.0   [10] MYANMAR DIGIT ZERO..MYANMAR DIGIT NINE
+1050..1059    ; Recommended                    # 3.0   [10] MYANMAR LETTER SHA..MYANMAR VOWEL SIGN VOCALIC LL
+105A..1099    ; Recommended                    # 5.1   [64] MYANMAR LETTER MON NGA..MYANMAR SHAN DIGIT NINE
+109A..109D    ; Recommended                    # 5.2    [4] MYANMAR SIGN KHAMTI TONE-1..MYANMAR VOWEL SIGN AITON AI
+10C7          ; Recommended                    # 6.1        GEORGIAN CAPITAL LETTER YN
+10CD          ; Recommended                    # 6.1        GEORGIAN CAPITAL LETTER AEN
+10D0..10F0    ; Recommended                    # 1.1   [33] GEORGIAN LETTER AN..GEORGIAN LETTER HAE
+10F7..10F8    ; Recommended                    # 3.2    [2] GEORGIAN LETTER YN..GEORGIAN LETTER ELIFI
+10F9..10FA    ; Recommended                    # 4.1    [2] GEORGIAN LETTER TURNED GAN..GEORGIAN LETTER AIN
+10FD..10FF    ; Recommended                    # 6.1    [3] GEORGIAN LETTER AEN..GEORGIAN LETTER LABIAL SIGN
+1200..1206    ; Recommended                    # 3.0    [7] ETHIOPIC SYLLABLE HA..ETHIOPIC SYLLABLE HO
+1207          ; Recommended                    # 4.1        ETHIOPIC SYLLABLE HOA
+1208..1246    ; Recommended                    # 3.0   [63] ETHIOPIC SYLLABLE LA..ETHIOPIC SYLLABLE QO
+1247          ; Recommended                    # 4.1        ETHIOPIC SYLLABLE QOA
+1248          ; Recommended                    # 3.0        ETHIOPIC SYLLABLE QWA
+124A..124D    ; Recommended                    # 3.0    [4] ETHIOPIC SYLLABLE QWI..ETHIOPIC SYLLABLE QWE
+1250..1256    ; Recommended                    # 3.0    [7] ETHIOPIC SYLLABLE QHA..ETHIOPIC SYLLABLE QHO
+1258          ; Recommended                    # 3.0        ETHIOPIC SYLLABLE QHWA
+125A..125D    ; Recommended                    # 3.0    [4] ETHIOPIC SYLLABLE QHWI..ETHIOPIC SYLLABLE QHWE
+1260..1286    ; Recommended                    # 3.0   [39] ETHIOPIC SYLLABLE BA..ETHIOPIC SYLLABLE XO
+1287          ; Recommended                    # 4.1        ETHIOPIC SYLLABLE XOA
+1288          ; Recommended                    # 3.0        ETHIOPIC SYLLABLE XWA
+128A..128D    ; Recommended                    # 3.0    [4] ETHIOPIC SYLLABLE XWI..ETHIOPIC SYLLABLE XWE
+1290..12AE    ; Recommended                    # 3.0   [31] ETHIOPIC SYLLABLE NA..ETHIOPIC SYLLABLE KO
+12AF          ; Recommended                    # 4.1        ETHIOPIC SYLLABLE KOA
+12B0          ; Recommended                    # 3.0        ETHIOPIC SYLLABLE KWA
+12B2..12B5    ; Recommended                    # 3.0    [4] ETHIOPIC SYLLABLE KWI..ETHIOPIC SYLLABLE KWE
+12B8..12BE    ; Recommended                    # 3.0    [7] ETHIOPIC SYLLABLE KXA..ETHIOPIC SYLLABLE KXO
+12C0          ; Recommended                    # 3.0        ETHIOPIC SYLLABLE KXWA
+12C2..12C5    ; Recommended                    # 3.0    [4] ETHIOPIC SYLLABLE KXWI..ETHIOPIC SYLLABLE KXWE
+12C8..12CE    ; Recommended                    # 3.0    [7] ETHIOPIC SYLLABLE WA..ETHIOPIC SYLLABLE WO
+12CF          ; Recommended                    # 4.1        ETHIOPIC SYLLABLE WOA
+12D0..12D6    ; Recommended                    # 3.0    [7] ETHIOPIC SYLLABLE PHARYNGEAL A..ETHIOPIC SYLLABLE PHARYNGEAL O
+12D8..12EE    ; Recommended                    # 3.0   [23] ETHIOPIC SYLLABLE ZA..ETHIOPIC SYLLABLE YO
+12EF          ; Recommended                    # 4.1        ETHIOPIC SYLLABLE YOA
+12F0..130E    ; Recommended                    # 3.0   [31] ETHIOPIC SYLLABLE DA..ETHIOPIC SYLLABLE GO
+130F          ; Recommended                    # 4.1        ETHIOPIC SYLLABLE GOA
+1310          ; Recommended                    # 3.0        ETHIOPIC SYLLABLE GWA
+1312..1315    ; Recommended                    # 3.0    [4] ETHIOPIC SYLLABLE GWI..ETHIOPIC SYLLABLE GWE
+1318..131E    ; Recommended                    # 3.0    [7] ETHIOPIC SYLLABLE GGA..ETHIOPIC SYLLABLE GGO
+131F          ; Recommended                    # 4.1        ETHIOPIC SYLLABLE GGWAA
+1320..1346    ; Recommended                    # 3.0   [39] ETHIOPIC SYLLABLE THA..ETHIOPIC SYLLABLE TZO
+1347          ; Recommended                    # 4.1        ETHIOPIC SYLLABLE TZOA
+1348..135A    ; Recommended                    # 3.0   [19] ETHIOPIC SYLLABLE FA..ETHIOPIC SYLLABLE FYA
+135D..135E    ; Recommended                    # 6.0    [2] ETHIOPIC COMBINING GEMINATION AND VOWEL LENGTH MARK..ETHIOPIC COMBINING VOWEL LENGTH MARK
+135F          ; Recommended                    # 4.1        ETHIOPIC COMBINING GEMINATION MARK
+1380..138F    ; Recommended                    # 4.1   [16] ETHIOPIC SYLLABLE SEBATBEIT MWA..ETHIOPIC SYLLABLE PWE
+1780..17A2    ; Recommended                    # 3.0   [35] KHMER LETTER KA..KHMER LETTER QA
+17A5..17A7    ; Recommended                    # 3.0    [3] KHMER INDEPENDENT VOWEL QI..KHMER INDEPENDENT VOWEL QU
+17A9..17B3    ; Recommended                    # 3.0   [11] KHMER INDEPENDENT VOWEL QUU..KHMER INDEPENDENT VOWEL QAU
+17B6..17CD    ; Recommended                    # 3.0   [24] KHMER VOWEL SIGN AA..KHMER SIGN TOANDAKHIAT
+17D0          ; Recommended                    # 3.0        KHMER SIGN SAMYOK SANNYA
+17D2          ; Recommended                    # 3.0        KHMER SIGN COENG
+17D7          ; Recommended                    # 3.0        KHMER SIGN LEK TOO
+17DC          ; Recommended                    # 3.0        KHMER SIGN AVAKRAHASANYA
+17E0..17E9    ; Recommended                    # 3.0   [10] KHMER DIGIT ZERO..KHMER DIGIT NINE
+1C90..1CBA    ; Recommended                    # 11.0  [43] GEORGIAN MTAVRULI CAPITAL LETTER AN..GEORGIAN MTAVRULI CAPITAL LETTER AIN
+1CBD..1CBF    ; Recommended                    # 11.0   [3] GEORGIAN MTAVRULI CAPITAL LETTER AEN..GEORGIAN MTAVRULI CAPITAL LETTER LABIAL SIGN
+1E00..1E99    ; Recommended                    # 1.1  [154] LATIN CAPITAL LETTER A WITH RING BELOW..LATIN SMALL LETTER Y WITH RING ABOVE
+1E9E          ; Recommended                    # 5.1        LATIN CAPITAL LETTER SHARP S
+1EA0..1EF9    ; Recommended                    # 1.1   [90] LATIN CAPITAL LETTER A WITH DOT BELOW..LATIN SMALL LETTER Y WITH TILDE
+1F00..1F15    ; Recommended                    # 1.1   [22] GREEK SMALL LETTER ALPHA WITH PSILI..GREEK SMALL LETTER EPSILON WITH DASIA AND OXIA
+1F18..1F1D    ; Recommended                    # 1.1    [6] GREEK CAPITAL LETTER EPSILON WITH PSILI..GREEK CAPITAL LETTER EPSILON WITH DASIA AND OXIA
+1F20..1F45    ; Recommended                    # 1.1   [38] GREEK SMALL LETTER ETA WITH PSILI..GREEK SMALL LETTER OMICRON WITH DASIA AND OXIA
+1F48..1F4D    ; Recommended                    # 1.1    [6] GREEK CAPITAL LETTER OMICRON WITH PSILI..GREEK CAPITAL LETTER OMICRON WITH DASIA AND OXIA
+1F50..1F57    ; Recommended                    # 1.1    [8] GREEK SMALL LETTER UPSILON WITH PSILI..GREEK SMALL LETTER UPSILON WITH DASIA AND PERISPOMENI
+1F59          ; Recommended                    # 1.1        GREEK CAPITAL LETTER UPSILON WITH DASIA
+1F5B          ; Recommended                    # 1.1        GREEK CAPITAL LETTER UPSILON WITH DASIA AND VARIA
+1F5D          ; Recommended                    # 1.1        GREEK CAPITAL LETTER UPSILON WITH DASIA AND OXIA
+1F5F..1F70    ; Recommended                    # 1.1   [18] GREEK CAPITAL LETTER UPSILON WITH DASIA AND PERISPOMENI..GREEK SMALL LETTER ALPHA WITH VARIA
+1F72          ; Recommended                    # 1.1        GREEK SMALL LETTER EPSILON WITH VARIA
+1F74          ; Recommended                    # 1.1        GREEK SMALL LETTER ETA WITH VARIA
+1F76          ; Recommended                    # 1.1        GREEK SMALL LETTER IOTA WITH VARIA
+1F78          ; Recommended                    # 1.1        GREEK SMALL LETTER OMICRON WITH VARIA
+1F7A          ; Recommended                    # 1.1        GREEK SMALL LETTER UPSILON WITH VARIA
+1F7C          ; Recommended                    # 1.1        GREEK SMALL LETTER OMEGA WITH VARIA
+1F80..1FB4    ; Recommended                    # 1.1   [53] GREEK SMALL LETTER ALPHA WITH PSILI AND YPOGEGRAMMENI..GREEK SMALL LETTER ALPHA WITH OXIA AND YPOGEGRAMMENI
+1FB6..1FBA    ; Recommended                    # 1.1    [5] GREEK SMALL LETTER ALPHA WITH PERISPOMENI..GREEK CAPITAL LETTER ALPHA WITH VARIA
+1FBC          ; Recommended                    # 1.1        GREEK CAPITAL LETTER ALPHA WITH PROSGEGRAMMENI
+1FC2..1FC4    ; Recommended                    # 1.1    [3] GREEK SMALL LETTER ETA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER ETA WITH OXIA AND YPOGEGRAMMENI
+1FC6..1FC8    ; Recommended                    # 1.1    [3] GREEK SMALL LETTER ETA WITH PERISPOMENI..GREEK CAPITAL LETTER EPSILON WITH VARIA
+1FCA          ; Recommended                    # 1.1        GREEK CAPITAL LETTER ETA WITH VARIA
+1FCC          ; Recommended                    # 1.1        GREEK CAPITAL LETTER ETA WITH PROSGEGRAMMENI
+1FD0..1FD2    ; Recommended                    # 1.1    [3] GREEK SMALL LETTER IOTA WITH VRACHY..GREEK SMALL LETTER IOTA WITH DIALYTIKA AND VARIA
+1FD6..1FDA    ; Recommended                    # 1.1    [5] GREEK SMALL LETTER IOTA WITH PERISPOMENI..GREEK CAPITAL LETTER IOTA WITH VARIA
+1FE0..1FE2    ; Recommended                    # 1.1    [3] GREEK SMALL LETTER UPSILON WITH VRACHY..GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND VARIA
+1FE4..1FEA    ; Recommended                    # 1.1    [7] GREEK SMALL LETTER RHO WITH PSILI..GREEK CAPITAL LETTER UPSILON WITH VARIA
+1FEC          ; Recommended                    # 1.1        GREEK CAPITAL LETTER RHO WITH DASIA
+1FF2..1FF4    ; Recommended                    # 1.1    [3] GREEK SMALL LETTER OMEGA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER OMEGA WITH OXIA AND YPOGEGRAMMENI
+1FF6..1FF8    ; Recommended                    # 1.1    [3] GREEK SMALL LETTER OMEGA WITH PERISPOMENI..GREEK CAPITAL LETTER OMICRON WITH VARIA
+1FFA          ; Recommended                    # 1.1        GREEK CAPITAL LETTER OMEGA WITH VARIA
+1FFC          ; Recommended                    # 1.1        GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI
+2D27          ; Recommended                    # 6.1        GEORGIAN SMALL LETTER YN
+2D2D          ; Recommended                    # 6.1        GEORGIAN SMALL LETTER AEN
+2D80..2D96    ; Recommended                    # 4.1   [23] ETHIOPIC SYLLABLE LOA..ETHIOPIC SYLLABLE GGWE
+2DA0..2DA6    ; Recommended                    # 4.1    [7] ETHIOPIC SYLLABLE SSA..ETHIOPIC SYLLABLE SSO
+2DA8..2DAE    ; Recommended                    # 4.1    [7] ETHIOPIC SYLLABLE CCA..ETHIOPIC SYLLABLE CCO
+2DB0..2DB6    ; Recommended                    # 4.1    [7] ETHIOPIC SYLLABLE ZZA..ETHIOPIC SYLLABLE ZZO
+2DB8..2DBE    ; Recommended                    # 4.1    [7] ETHIOPIC SYLLABLE CCHA..ETHIOPIC SYLLABLE CCHO
+2DC0..2DC6    ; Recommended                    # 4.1    [7] ETHIOPIC SYLLABLE QYA..ETHIOPIC SYLLABLE QYO
+2DC8..2DCE    ; Recommended                    # 4.1    [7] ETHIOPIC SYLLABLE KYA..ETHIOPIC SYLLABLE KYO
+2DD0..2DD6    ; Recommended                    # 4.1    [7] ETHIOPIC SYLLABLE XYA..ETHIOPIC SYLLABLE XYO
+2DD8..2DDE    ; Recommended                    # 4.1    [7] ETHIOPIC SYLLABLE GYA..ETHIOPIC SYLLABLE GYO
+3005..3007    ; Recommended                    # 1.1    [3] IDEOGRAPHIC ITERATION MARK..IDEOGRAPHIC NUMBER ZERO
+3041..3094    ; Recommended                    # 1.1   [84] HIRAGANA LETTER SMALL A..HIRAGANA LETTER VU
+3095..3096    ; Recommended                    # 3.2    [2] HIRAGANA LETTER SMALL KA..HIRAGANA LETTER SMALL KE
+3099..309A    ; Recommended                    # 1.1    [2] COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK..COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+309D..309E    ; Recommended                    # 1.1    [2] HIRAGANA ITERATION MARK..HIRAGANA VOICED ITERATION MARK
+30A1..30FA    ; Recommended                    # 1.1   [90] KATAKANA LETTER SMALL A..KATAKANA LETTER VO
+30FC..30FE    ; Recommended                    # 1.1    [3] KATAKANA-HIRAGANA PROLONGED SOUND MARK..KATAKANA VOICED ITERATION MARK
+3105..312C    ; Recommended                    # 1.1   [40] BOPOMOFO LETTER B..BOPOMOFO LETTER GN
+312D          ; Recommended                    # 5.1        BOPOMOFO LETTER IH
+312F          ; Recommended                    # 11.0       BOPOMOFO LETTER NN
+31A0..31B7    ; Recommended                    # 3.0   [24] BOPOMOFO LETTER BU..BOPOMOFO FINAL LETTER H
+31B8..31BA    ; Recommended                    # 6.0    [3] BOPOMOFO LETTER GH..BOPOMOFO LETTER ZY
+31BB..31BF    ; Recommended                    # 13.0   [5] BOPOMOFO FINAL LETTER G..BOPOMOFO LETTER AH
+3400..4DB5    ; Recommended                    # 3.0 [6582] CJK UNIFIED IDEOGRAPH-3400..CJK UNIFIED IDEOGRAPH-4DB5
+4DB6..4DBF    ; Recommended                    # 13.0  [10] CJK UNIFIED IDEOGRAPH-4DB6..CJK UNIFIED IDEOGRAPH-4DBF
+4E00..9FA5    ; Recommended                    # 1.1 [20902] CJK UNIFIED IDEOGRAPH-4E00..CJK UNIFIED IDEOGRAPH-9FA5
+9FA6..9FBB    ; Recommended                    # 4.1   [22] CJK UNIFIED IDEOGRAPH-9FA6..CJK UNIFIED IDEOGRAPH-9FBB
+9FBC..9FC3    ; Recommended                    # 5.1    [8] CJK UNIFIED IDEOGRAPH-9FBC..CJK UNIFIED IDEOGRAPH-9FC3
+9FC4..9FCB    ; Recommended                    # 5.2    [8] CJK UNIFIED IDEOGRAPH-9FC4..CJK UNIFIED IDEOGRAPH-9FCB
+9FCC          ; Recommended                    # 6.1        CJK UNIFIED IDEOGRAPH-9FCC
+9FCD..9FD5    ; Recommended                    # 8.0    [9] CJK UNIFIED IDEOGRAPH-9FCD..CJK UNIFIED IDEOGRAPH-9FD5
+9FD6..9FEA    ; Recommended                    # 10.0  [21] CJK UNIFIED IDEOGRAPH-9FD6..CJK UNIFIED IDEOGRAPH-9FEA
+9FEB..9FEF    ; Recommended                    # 11.0   [5] CJK UNIFIED IDEOGRAPH-9FEB..CJK UNIFIED IDEOGRAPH-9FEF
+9FF0..9FFC    ; Recommended                    # 13.0  [13] CJK UNIFIED IDEOGRAPH-9FF0..CJK UNIFIED IDEOGRAPH-9FFC
+9FFD..9FFF    ; Recommended                    # 14.0   [3] CJK UNIFIED IDEOGRAPH-9FFD..CJK UNIFIED IDEOGRAPH-9FFF
+A67F          ; Recommended                    # 5.1        CYRILLIC PAYEROK
+A717..A71A    ; Recommended                    # 5.0    [4] MODIFIER LETTER DOT VERTICAL BAR..MODIFIER LETTER LOWER RIGHT CORNER ANGLE
+A71B..A71F    ; Recommended                    # 5.1    [5] MODIFIER LETTER RAISED UP ARROW..MODIFIER LETTER LOW INVERTED EXCLAMATION MARK
+A788          ; Recommended                    # 5.1        MODIFIER LETTER LOW CIRCUMFLEX ACCENT
+A78D          ; Recommended                    # 6.0        LATIN CAPITAL LETTER TURNED H
+A792..A793    ; Recommended                    # 6.1    [2] LATIN CAPITAL LETTER C WITH BAR..LATIN SMALL LETTER C WITH BAR
+A7AA          ; Recommended                    # 6.1        LATIN CAPITAL LETTER H WITH HOOK
+A7AE          ; Recommended                    # 9.0        LATIN CAPITAL LETTER SMALL CAPITAL I
+A7B8..A7B9    ; Recommended                    # 11.0   [2] LATIN CAPITAL LETTER U WITH STROKE..LATIN SMALL LETTER U WITH STROKE
+A7C0..A7C1    ; Recommended                    # 14.0   [2] LATIN CAPITAL LETTER OLD POLISH O..LATIN SMALL LETTER OLD POLISH O
+A7C2..A7C6    ; Recommended                    # 12.0   [5] LATIN CAPITAL LETTER ANGLICANA W..LATIN CAPITAL LETTER Z WITH PALATAL HOOK
+A7C7..A7CA    ; Recommended                    # 13.0   [4] LATIN CAPITAL LETTER D WITH SHORT STROKE OVERLAY..LATIN SMALL LETTER S WITH SHORT STROKE OVERLAY
+A7D0..A7D1    ; Recommended                    # 14.0   [2] LATIN CAPITAL LETTER CLOSED INSULAR G..LATIN SMALL LETTER CLOSED INSULAR G
+A7D3          ; Recommended                    # 14.0       LATIN SMALL LETTER DOUBLE THORN
+A7D5..A7D9    ; Recommended                    # 14.0   [5] LATIN SMALL LETTER DOUBLE WYNN..LATIN SMALL LETTER SIGMOID S
+A9E7..A9FE    ; Recommended                    # 7.0   [24] MYANMAR LETTER TAI LAING NYA..MYANMAR LETTER TAI LAING BHA
+AA60..AA76    ; Recommended                    # 5.2   [23] MYANMAR LETTER KHAMTI GA..MYANMAR LOGOGRAM KHAMTI HM
+AA7A..AA7B    ; Recommended                    # 5.2    [2] MYANMAR LETTER AITON RA..MYANMAR SIGN PAO KAREN TONE
+AA7C..AA7F    ; Recommended                    # 7.0    [4] MYANMAR SIGN TAI LAING TONE-2..MYANMAR LETTER SHWE PALAUNG SHA
+AB01..AB06    ; Recommended                    # 6.0    [6] ETHIOPIC SYLLABLE TTHU..ETHIOPIC SYLLABLE TTHO
+AB09..AB0E    ; Recommended                    # 6.0    [6] ETHIOPIC SYLLABLE DDHU..ETHIOPIC SYLLABLE DDHO
+AB11..AB16    ; Recommended                    # 6.0    [6] ETHIOPIC SYLLABLE DZU..ETHIOPIC SYLLABLE DZO
+AB20..AB26    ; Recommended                    # 6.0    [7] ETHIOPIC SYLLABLE CCHHA..ETHIOPIC SYLLABLE CCHHO
+AB28..AB2E    ; Recommended                    # 6.0    [7] ETHIOPIC SYLLABLE BBA..ETHIOPIC SYLLABLE BBO
+AB66..AB67    ; Recommended                    # 12.0   [2] LATIN SMALL LETTER DZ DIGRAPH WITH RETROFLEX HOOK..LATIN SMALL LETTER TS DIGRAPH WITH RETROFLEX HOOK
+AC00..D7A3    ; Recommended                    # 2.0 [11172] HANGUL SYLLABLE GA..HANGUL SYLLABLE HIH
+FA0E..FA0F    ; Recommended                    # 1.1    [2] CJK COMPATIBILITY IDEOGRAPH-FA0E..CJK COMPATIBILITY IDEOGRAPH-FA0F
+FA11          ; Recommended                    # 1.1        CJK COMPATIBILITY IDEOGRAPH-FA11
+FA13..FA14    ; Recommended                    # 1.1    [2] CJK COMPATIBILITY IDEOGRAPH-FA13..CJK COMPATIBILITY IDEOGRAPH-FA14
+FA1F          ; Recommended                    # 1.1        CJK COMPATIBILITY IDEOGRAPH-FA1F
+FA21          ; Recommended                    # 1.1        CJK COMPATIBILITY IDEOGRAPH-FA21
+FA23..FA24    ; Recommended                    # 1.1    [2] CJK COMPATIBILITY IDEOGRAPH-FA23..CJK COMPATIBILITY IDEOGRAPH-FA24
+FA27..FA29    ; Recommended                    # 1.1    [3] CJK COMPATIBILITY IDEOGRAPH-FA27..CJK COMPATIBILITY IDEOGRAPH-FA29
+11301         ; Recommended                    # 7.0        GRANTHA SIGN CANDRABINDU
+11303         ; Recommended                    # 7.0        GRANTHA SIGN VISARGA
+1133B         ; Recommended                    # 11.0       COMBINING BINDU BELOW
+1133C         ; Recommended                    # 7.0        GRANTHA SIGN NUKTA
+16FF0..16FF1  ; Recommended                    # 13.0   [2] VIETNAMESE ALTERNATE READING MARK CA..VIETNAMESE ALTERNATE READING MARK NHAY
+1B11F..1B122  ; Recommended                    # 14.0   [4] HIRAGANA LETTER ARCHAIC WU..KATAKANA LETTER ARCHAIC WU
+1B150..1B152  ; Recommended                    # 12.0   [3] HIRAGANA LETTER SMALL WI..HIRAGANA LETTER SMALL WO
+1B164..1B167  ; Recommended                    # 12.0   [4] KATAKANA LETTER SMALL WI..KATAKANA LETTER SMALL N
+1DF00..1DF1E  ; Recommended                    # 14.0  [31] LATIN SMALL LETTER FENG DIGRAPH WITH TRILL..LATIN SMALL LETTER S WITH CURL
+1E7E0..1E7E6  ; Recommended                    # 14.0   [7] ETHIOPIC SYLLABLE HHYA..ETHIOPIC SYLLABLE HHYO
+1E7E8..1E7EB  ; Recommended                    # 14.0   [4] ETHIOPIC SYLLABLE GURAGE HHWA..ETHIOPIC SYLLABLE HHWE
+1E7ED..1E7EE  ; Recommended                    # 14.0   [2] ETHIOPIC SYLLABLE GURAGE MWI..ETHIOPIC SYLLABLE GURAGE MWEE
+1E7F0..1E7FE  ; Recommended                    # 14.0  [15] ETHIOPIC SYLLABLE GURAGE QWI..ETHIOPIC SYLLABLE GURAGE PWEE
+20000..2A6D6  ; Recommended                    # 3.1 [42711] CJK UNIFIED IDEOGRAPH-20000..CJK UNIFIED IDEOGRAPH-2A6D6
+2A6D7..2A6DD  ; Recommended                    # 13.0   [7] CJK UNIFIED IDEOGRAPH-2A6D7..CJK UNIFIED IDEOGRAPH-2A6DD
+2A6DE..2A6DF  ; Recommended                    # 14.0   [2] CJK UNIFIED IDEOGRAPH-2A6DE..CJK UNIFIED IDEOGRAPH-2A6DF
+2A700..2B734  ; Recommended                    # 5.2 [4149] CJK UNIFIED IDEOGRAPH-2A700..CJK UNIFIED IDEOGRAPH-2B734
+2B735..2B738  ; Recommended                    # 14.0   [4] CJK UNIFIED IDEOGRAPH-2B735..CJK UNIFIED IDEOGRAPH-2B738
+2B740..2B81D  ; Recommended                    # 6.0  [222] CJK UNIFIED IDEOGRAPH-2B740..CJK UNIFIED IDEOGRAPH-2B81D
+2B820..2CEA1  ; Recommended                    # 8.0 [5762] CJK UNIFIED IDEOGRAPH-2B820..CJK UNIFIED IDEOGRAPH-2CEA1
+2CEB0..2EBE0  ; Recommended                    # 10.0 [7473] CJK UNIFIED IDEOGRAPH-2CEB0..CJK UNIFIED IDEOGRAPH-2EBE0
+30000..3134A  ; Recommended                    # 13.0 [4939] CJK UNIFIED IDEOGRAPH-30000..CJK UNIFIED IDEOGRAPH-3134A
+
+# Total code points: 107938
+
+#	Identifier_Type:	Inclusion
+
+0027          ; Inclusion                      # 1.1        APOSTROPHE
+002D..002E    ; Inclusion                      # 1.1    [2] HYPHEN-MINUS..FULL STOP
+003A          ; Inclusion                      # 1.1        COLON
+00B7          ; Inclusion                      # 1.1        MIDDLE DOT
+0375          ; Inclusion                      # 1.1        GREEK LOWER NUMERAL SIGN
+058A          ; Inclusion                      # 3.0        ARMENIAN HYPHEN
+05F3..05F4    ; Inclusion                      # 1.1    [2] HEBREW PUNCTUATION GERESH..HEBREW PUNCTUATION GERSHAYIM
+06FD..06FE    ; Inclusion                      # 3.0    [2] ARABIC SIGN SINDHI AMPERSAND..ARABIC SIGN SINDHI POSTPOSITION MEN
+0F0B          ; Inclusion                      # 2.0        TIBETAN MARK INTERSYLLABIC TSHEG
+200C..200D    ; Inclusion                      # 1.1    [2] ZERO WIDTH NON-JOINER..ZERO WIDTH JOINER
+2010          ; Inclusion                      # 1.1        HYPHEN
+2019          ; Inclusion                      # 1.1        RIGHT SINGLE QUOTATION MARK
+2027          ; Inclusion                      # 1.1        HYPHENATION POINT
+30A0          ; Inclusion                      # 3.2        KATAKANA-HIRAGANA DOUBLE HYPHEN
+30FB          ; Inclusion                      # 1.1        KATAKANA MIDDLE DOT
+
+# Total code points: 19
+
+#	Identifier_Type:	Limited_Use
+
+0710..072C    ; Limited_Use                    # 3.0   [29] SYRIAC LETTER ALAPH..SYRIAC LETTER TAW
+072D..072F    ; Limited_Use                    # 4.0    [3] SYRIAC LETTER PERSIAN BHETH..SYRIAC LETTER PERSIAN DHALATH
+0730..073F    ; Limited_Use                    # 3.0   [16] SYRIAC PTHAHA ABOVE..SYRIAC RWAHA
+074D..074F    ; Limited_Use                    # 4.0    [3] SYRIAC LETTER SOGDIAN ZHAIN..SYRIAC LETTER SOGDIAN FE
+07C0..07E7    ; Limited_Use                    # 5.0   [40] NKO DIGIT ZERO..NKO LETTER NYA WOLOSO
+07EB..07F5    ; Limited_Use                    # 5.0   [11] NKO COMBINING SHORT HIGH TONE..NKO LOW TONE APOSTROPHE
+07FD          ; Limited_Use                    # 11.0       NKO DANTAYALAN
+0840..085B    ; Limited_Use                    # 6.0   [28] MANDAIC LETTER HALQA..MANDAIC GEMINATION MARK
+0860..086A    ; Limited_Use                    # 10.0  [11] SYRIAC LETTER MALAYALAM NGA..SYRIAC LETTER MALAYALAM SSA
+13A0..13F4    ; Limited_Use                    # 3.0   [85] CHEROKEE LETTER A..CHEROKEE LETTER YV
+13F5          ; Limited_Use                    # 8.0        CHEROKEE LETTER MV
+13F8..13FD    ; Limited_Use                    # 8.0    [6] CHEROKEE SMALL LETTER YE..CHEROKEE SMALL LETTER MV
+1401..166C    ; Limited_Use                    # 3.0  [620] CANADIAN SYLLABICS E..CANADIAN SYLLABICS CARRIER TTSA
+166F..1676    ; Limited_Use                    # 3.0    [8] CANADIAN SYLLABICS QAI..CANADIAN SYLLABICS NNGAA
+1677..167F    ; Limited_Use                    # 5.2    [9] CANADIAN SYLLABICS WOODS-CREE THWEE..CANADIAN SYLLABICS BLACKFOOT W
+18B0..18F5    ; Limited_Use                    # 5.2   [70] CANADIAN SYLLABICS OY..CANADIAN SYLLABICS CARRIER DENTAL S
+1900..191C    ; Limited_Use                    # 4.0   [29] LIMBU VOWEL-CARRIER LETTER..LIMBU LETTER HA
+191D..191E    ; Limited_Use                    # 7.0    [2] LIMBU LETTER GYAN..LIMBU LETTER TRA
+1920..192B    ; Limited_Use                    # 4.0   [12] LIMBU VOWEL SIGN A..LIMBU SUBJOINED LETTER WA
+1930..193B    ; Limited_Use                    # 4.0   [12] LIMBU SMALL LETTER KA..LIMBU SIGN SA-I
+1946..196D    ; Limited_Use                    # 4.0   [40] LIMBU DIGIT ZERO..TAI LE LETTER AI
+1970..1974    ; Limited_Use                    # 4.0    [5] TAI LE LETTER TONE-2..TAI LE LETTER TONE-6
+1980..19A9    ; Limited_Use                    # 4.1   [42] NEW TAI LUE LETTER HIGH QA..NEW TAI LUE LETTER LOW XVA
+19AA..19AB    ; Limited_Use                    # 5.2    [2] NEW TAI LUE LETTER HIGH SUA..NEW TAI LUE LETTER LOW SUA
+19B0..19C9    ; Limited_Use                    # 4.1   [26] NEW TAI LUE VOWEL SIGN VOWEL SHORTENER..NEW TAI LUE TONE MARK-2
+19D0..19D9    ; Limited_Use                    # 4.1   [10] NEW TAI LUE DIGIT ZERO..NEW TAI LUE DIGIT NINE
+19DA          ; Limited_Use                    # 5.2        NEW TAI LUE THAM DIGIT ONE
+1A20..1A5E    ; Limited_Use                    # 5.2   [63] TAI THAM LETTER HIGH KA..TAI THAM CONSONANT SIGN SA
+1A60..1A7C    ; Limited_Use                    # 5.2   [29] TAI THAM SIGN SAKOT..TAI THAM SIGN KHUEN-LUE KARAN
+1A7F..1A89    ; Limited_Use                    # 5.2   [11] TAI THAM COMBINING CRYPTOGRAMMIC DOT..TAI THAM HORA DIGIT NINE
+1A90..1A99    ; Limited_Use                    # 5.2   [10] TAI THAM THAM DIGIT ZERO..TAI THAM THAM DIGIT NINE
+1AA7          ; Limited_Use                    # 5.2        TAI THAM SIGN MAI YAMOK
+1B00..1B4B    ; Limited_Use                    # 5.0   [76] BALINESE SIGN ULU RICEM..BALINESE LETTER ASYURA SASAK
+1B4C          ; Limited_Use                    # 14.0       BALINESE LETTER ARCHAIC JNYA
+1B50..1B59    ; Limited_Use                    # 5.0   [10] BALINESE DIGIT ZERO..BALINESE DIGIT NINE
+1B80..1BAA    ; Limited_Use                    # 5.1   [43] SUNDANESE SIGN PANYECEK..SUNDANESE SIGN PAMAAEH
+1BAB..1BAD    ; Limited_Use                    # 6.1    [3] SUNDANESE SIGN VIRAMA..SUNDANESE CONSONANT SIGN PASANGAN WA
+1BAE..1BB9    ; Limited_Use                    # 5.1   [12] SUNDANESE LETTER KHA..SUNDANESE DIGIT NINE
+1BBA..1BBF    ; Limited_Use                    # 6.1    [6] SUNDANESE AVAGRAHA..SUNDANESE LETTER FINAL M
+1BC0..1BF3    ; Limited_Use                    # 6.0   [52] BATAK LETTER A..BATAK PANONGONAN
+1C00..1C37    ; Limited_Use                    # 5.1   [56] LEPCHA LETTER KA..LEPCHA SIGN NUKTA
+1C40..1C49    ; Limited_Use                    # 5.1   [10] LEPCHA DIGIT ZERO..LEPCHA DIGIT NINE
+1C4D..1C7D    ; Limited_Use                    # 5.1   [49] LEPCHA LETTER TTA..OL CHIKI AHAD
+2D30..2D65    ; Limited_Use                    # 4.1   [54] TIFINAGH LETTER YA..TIFINAGH LETTER YAZZ
+2D66..2D67    ; Limited_Use                    # 6.1    [2] TIFINAGH LETTER YE..TIFINAGH LETTER YO
+2D7F          ; Limited_Use                    # 6.0        TIFINAGH CONSONANT JOINER
+A000..A48C    ; Limited_Use                    # 3.0 [1165] YI SYLLABLE IT..YI SYLLABLE YYR
+A4D0..A4FD    ; Limited_Use                    # 5.2   [46] LISU LETTER BA..LISU LETTER TONE MYA JEU
+A500..A60C    ; Limited_Use                    # 5.1  [269] VAI SYLLABLE EE..VAI SYLLABLE LENGTHENER
+A613..A629    ; Limited_Use                    # 5.1   [23] VAI SYMBOL FEENG..VAI DIGIT NINE
+A6A0..A6F1    ; Limited_Use                    # 5.2   [82] BAMUM LETTER A..BAMUM COMBINING MARK TUKWENTIS
+A800..A827    ; Limited_Use                    # 4.1   [40] SYLOTI NAGRI LETTER A..SYLOTI NAGRI VOWEL SIGN OO
+A82C          ; Limited_Use                    # 13.0       SYLOTI NAGRI SIGN ALTERNATE HASANTA
+A880..A8C4    ; Limited_Use                    # 5.1   [69] SAURASHTRA SIGN ANUSVARA..SAURASHTRA SIGN VIRAMA
+A8C5          ; Limited_Use                    # 9.0        SAURASHTRA SIGN CANDRABINDU
+A8D0..A8D9    ; Limited_Use                    # 5.1   [10] SAURASHTRA DIGIT ZERO..SAURASHTRA DIGIT NINE
+A900..A92D    ; Limited_Use                    # 5.1   [46] KAYAH LI DIGIT ZERO..KAYAH LI TONE CALYA PLOPHU
+A980..A9C0    ; Limited_Use                    # 5.2   [65] JAVANESE SIGN PANYANGGA..JAVANESE PANGKON
+A9D0..A9D9    ; Limited_Use                    # 5.2   [10] JAVANESE DIGIT ZERO..JAVANESE DIGIT NINE
+AA00..AA36    ; Limited_Use                    # 5.1   [55] CHAM LETTER A..CHAM CONSONANT SIGN WA
+AA40..AA4D    ; Limited_Use                    # 5.1   [14] CHAM LETTER FINAL K..CHAM CONSONANT SIGN FINAL H
+AA50..AA59    ; Limited_Use                    # 5.1   [10] CHAM DIGIT ZERO..CHAM DIGIT NINE
+AA80..AAC2    ; Limited_Use                    # 5.2   [67] TAI VIET LETTER LOW KO..TAI VIET TONE MAI SONG
+AADB..AADD    ; Limited_Use                    # 5.2    [3] TAI VIET SYMBOL KON..TAI VIET SYMBOL SAM
+AAE0..AAEF    ; Limited_Use                    # 6.1   [16] MEETEI MAYEK LETTER E..MEETEI MAYEK VOWEL SIGN AAU
+AAF2..AAF6    ; Limited_Use                    # 6.1    [5] MEETEI MAYEK ANJI..MEETEI MAYEK VIRAMA
+AB70..ABBF    ; Limited_Use                    # 8.0   [80] CHEROKEE SMALL LETTER A..CHEROKEE SMALL LETTER YA
+ABC0..ABEA    ; Limited_Use                    # 5.2   [43] MEETEI MAYEK LETTER KOK..MEETEI MAYEK VOWEL SIGN NUNG
+ABEC..ABED    ; Limited_Use                    # 5.2    [2] MEETEI MAYEK LUM IYEK..MEETEI MAYEK APUN IYEK
+ABF0..ABF9    ; Limited_Use                    # 5.2   [10] MEETEI MAYEK DIGIT ZERO..MEETEI MAYEK DIGIT NINE
+104B0..104D3  ; Limited_Use                    # 9.0   [36] OSAGE CAPITAL LETTER A..OSAGE CAPITAL LETTER ZHA
+104D8..104FB  ; Limited_Use                    # 9.0   [36] OSAGE SMALL LETTER A..OSAGE SMALL LETTER ZHA
+10D00..10D27  ; Limited_Use                    # 11.0  [40] HANIFI ROHINGYA LETTER A..HANIFI ROHINGYA SIGN TASSI
+10D30..10D39  ; Limited_Use                    # 11.0  [10] HANIFI ROHINGYA DIGIT ZERO..HANIFI ROHINGYA DIGIT NINE
+11100..11134  ; Limited_Use                    # 6.1   [53] CHAKMA SIGN CANDRABINDU..CHAKMA MAAYYAA
+11136..1113F  ; Limited_Use                    # 6.1   [10] CHAKMA DIGIT ZERO..CHAKMA DIGIT NINE
+11144..11146  ; Limited_Use                    # 11.0   [3] CHAKMA LETTER LHAA..CHAKMA VOWEL SIGN EI
+11147         ; Limited_Use                    # 13.0       CHAKMA LETTER VAA
+11400..1144A  ; Limited_Use                    # 9.0   [75] NEWA LETTER A..NEWA SIDDHI
+11450..11459  ; Limited_Use                    # 9.0   [10] NEWA DIGIT ZERO..NEWA DIGIT NINE
+1145E         ; Limited_Use                    # 11.0       NEWA SANDHI MARK
+1145F         ; Limited_Use                    # 12.0       NEWA LETTER VEDIC ANUSVARA
+11460..11461  ; Limited_Use                    # 13.0   [2] NEWA SIGN JIHVAMULIYA..NEWA SIGN UPADHMANIYA
+11AB0..11ABF  ; Limited_Use                    # 14.0  [16] CANADIAN SYLLABICS NATTILIK HI..CANADIAN SYLLABICS SPA
+11D60..11D65  ; Limited_Use                    # 11.0   [6] GUNJALA GONDI LETTER A..GUNJALA GONDI LETTER UU
+11D67..11D68  ; Limited_Use                    # 11.0   [2] GUNJALA GONDI LETTER EE..GUNJALA GONDI LETTER AI
+11D6A..11D8E  ; Limited_Use                    # 11.0  [37] GUNJALA GONDI LETTER OO..GUNJALA GONDI VOWEL SIGN UU
+11D90..11D91  ; Limited_Use                    # 11.0   [2] GUNJALA GONDI VOWEL SIGN EE..GUNJALA GONDI VOWEL SIGN AI
+11D93..11D98  ; Limited_Use                    # 11.0   [6] GUNJALA GONDI VOWEL SIGN OO..GUNJALA GONDI OM
+11DA0..11DA9  ; Limited_Use                    # 11.0  [10] GUNJALA GONDI DIGIT ZERO..GUNJALA GONDI DIGIT NINE
+11FB0         ; Limited_Use                    # 13.0       LISU LETTER YHA
+16800..16A38  ; Limited_Use                    # 6.0  [569] BAMUM LETTER PHASE-A NGKUE MFON..BAMUM LETTER PHASE-F VUEQ
+16F00..16F44  ; Limited_Use                    # 6.1   [69] MIAO LETTER PA..MIAO LETTER HHA
+16F45..16F4A  ; Limited_Use                    # 12.0   [6] MIAO LETTER BRI..MIAO LETTER RTE
+16F4F         ; Limited_Use                    # 12.0       MIAO SIGN CONSONANT MODIFIER BAR
+16F50..16F7E  ; Limited_Use                    # 6.1   [47] MIAO LETTER NASALIZATION..MIAO VOWEL SIGN NG
+16F7F..16F87  ; Limited_Use                    # 12.0   [9] MIAO VOWEL SIGN UOG..MIAO VOWEL SIGN UI
+16F8F..16F9F  ; Limited_Use                    # 6.1   [17] MIAO TONE RIGHT..MIAO LETTER REFORMED TONE-8
+1E100..1E12C  ; Limited_Use                    # 12.0  [45] NYIAKENG PUACHUE HMONG LETTER MA..NYIAKENG PUACHUE HMONG LETTER W
+1E130..1E13D  ; Limited_Use                    # 12.0  [14] NYIAKENG PUACHUE HMONG TONE-B..NYIAKENG PUACHUE HMONG SYLLABLE LENGTHENER
+1E140..1E149  ; Limited_Use                    # 12.0  [10] NYIAKENG PUACHUE HMONG DIGIT ZERO..NYIAKENG PUACHUE HMONG DIGIT NINE
+1E14E         ; Limited_Use                    # 12.0       NYIAKENG PUACHUE HMONG LOGOGRAM NYAJ
+1E2C0..1E2F9  ; Limited_Use                    # 12.0  [58] WANCHO LETTER AA..WANCHO DIGIT NINE
+1E900..1E94A  ; Limited_Use                    # 9.0   [75] ADLAM CAPITAL LETTER ALIF..ADLAM NUKTA
+1E94B         ; Limited_Use                    # 12.0       ADLAM NASALIZATION MARK
+1E950..1E959  ; Limited_Use                    # 9.0   [10] ADLAM DIGIT ZERO..ADLAM DIGIT NINE
+
+# Total code points: 5033
+
+#	Identifier_Type:	Limited_Use Technical
+
+0740..074A    ; Limited_Use Technical          # 3.0   [11] SYRIAC FEMININE DOT..SYRIAC BARREKH
+1B6B..1B73    ; Limited_Use Technical          # 5.0    [9] BALINESE MUSICAL SYMBOL COMBINING TEGEH..BALINESE MUSICAL SYMBOL COMBINING GONG
+1DFA          ; Limited_Use Technical          # 14.0       COMBINING DOT BELOW LEFT
+
+# Total code points: 21
+
+#	Identifier_Type:	Limited_Use Exclusion
+
+A9CF          ; Limited_Use Exclusion          # 5.2        JAVANESE PANGRANGKEP
+
+# Total code points: 1
+
+#	Identifier_Type:	Limited_Use Obsolete
+
+07E8..07EA    ; Limited_Use Obsolete           # 5.0    [3] NKO LETTER JONA JA..NKO LETTER JONA RA
+07FA          ; Limited_Use Obsolete           # 5.0        NKO LAJANYALAN
+A610..A612    ; Limited_Use Obsolete           # 5.1    [3] VAI SYLLABLE NDOLE FA..VAI SYLLABLE NDOLE SOO
+A62A..A62B    ; Limited_Use Obsolete           # 5.1    [2] VAI SYLLABLE NDOLE MA..VAI SYLLABLE NDOLE DO
+
+# Total code points: 9
+
+#	Identifier_Type:	Limited_Use Not_XID
+
+0700..070D    ; Limited_Use Not_XID            # 3.0   [14] SYRIAC END OF PARAGRAPH..SYRIAC HARKLEAN ASTERISCUS
+070F          ; Limited_Use Not_XID            # 3.0        SYRIAC ABBREVIATION MARK
+07F6..07F9    ; Limited_Use Not_XID            # 5.0    [4] NKO SYMBOL OO DENNEN..NKO EXCLAMATION MARK
+07FE..07FF    ; Limited_Use Not_XID            # 11.0   [2] NKO DOROME SIGN..NKO TAMAN SIGN
+085E          ; Limited_Use Not_XID            # 6.0        MANDAIC PUNCTUATION
+1400          ; Limited_Use Not_XID            # 5.2        CANADIAN SYLLABICS HYPHEN
+166D..166E    ; Limited_Use Not_XID            # 3.0    [2] CANADIAN SYLLABICS CHI SIGN..CANADIAN SYLLABICS FULL STOP
+1940          ; Limited_Use Not_XID            # 4.0        LIMBU SIGN LOO
+1944..1945    ; Limited_Use Not_XID            # 4.0    [2] LIMBU EXCLAMATION MARK..LIMBU QUESTION MARK
+19DE..19DF    ; Limited_Use Not_XID            # 4.1    [2] NEW TAI LUE SIGN LAE..NEW TAI LUE SIGN LAEV
+1AA0..1AA6    ; Limited_Use Not_XID            # 5.2    [7] TAI THAM SIGN WIANG..TAI THAM SIGN REVERSED ROTATED RANA
+1AA8..1AAD    ; Limited_Use Not_XID            # 5.2    [6] TAI THAM SIGN KAAN..TAI THAM SIGN CAANG
+1B5A..1B6A    ; Limited_Use Not_XID            # 5.0   [17] BALINESE PANTI..BALINESE MUSICAL SYMBOL DANG GEDE
+1B74..1B7C    ; Limited_Use Not_XID            # 5.0    [9] BALINESE MUSICAL SYMBOL RIGHT-HAND OPEN DUG..BALINESE MUSICAL SYMBOL LEFT-HAND OPEN PING
+1B7D..1B7E    ; Limited_Use Not_XID            # 14.0   [2] BALINESE PANTI LANTANG..BALINESE PAMADA LANTANG
+1BFC..1BFF    ; Limited_Use Not_XID            # 6.0    [4] BATAK SYMBOL BINDU NA METEK..BATAK SYMBOL BINDU PANGOLAT
+1C3B..1C3F    ; Limited_Use Not_XID            # 5.1    [5] LEPCHA PUNCTUATION TA-ROL..LEPCHA PUNCTUATION TSHOOK
+1C7E..1C7F    ; Limited_Use Not_XID            # 5.1    [2] OL CHIKI PUNCTUATION MUCAAD..OL CHIKI PUNCTUATION DOUBLE MUCAAD
+1CC0..1CC7    ; Limited_Use Not_XID            # 6.1    [8] SUNDANESE PUNCTUATION BINDU SURYA..SUNDANESE PUNCTUATION BINDU BA SATANGA
+2D70          ; Limited_Use Not_XID            # 6.0        TIFINAGH SEPARATOR MARK
+A490..A4A1    ; Limited_Use Not_XID            # 3.0   [18] YI RADICAL QOT..YI RADICAL GA
+A4A2..A4A3    ; Limited_Use Not_XID            # 3.2    [2] YI RADICAL ZUP..YI RADICAL CYT
+A4A4..A4B3    ; Limited_Use Not_XID            # 3.0   [16] YI RADICAL DDUR..YI RADICAL JO
+A4B4          ; Limited_Use Not_XID            # 3.2        YI RADICAL NZUP
+A4B5..A4C0    ; Limited_Use Not_XID            # 3.0   [12] YI RADICAL JJY..YI RADICAL SHAT
+A4C1          ; Limited_Use Not_XID            # 3.2        YI RADICAL ZUR
+A4C2..A4C4    ; Limited_Use Not_XID            # 3.0    [3] YI RADICAL SHOP..YI RADICAL ZZIET
+A4C5          ; Limited_Use Not_XID            # 3.2        YI RADICAL NBIE
+A4C6          ; Limited_Use Not_XID            # 3.0        YI RADICAL KE
+A4FE..A4FF    ; Limited_Use Not_XID            # 5.2    [2] LISU PUNCTUATION COMMA..LISU PUNCTUATION FULL STOP
+A60D..A60F    ; Limited_Use Not_XID            # 5.1    [3] VAI COMMA..VAI QUESTION MARK
+A6F2..A6F7    ; Limited_Use Not_XID            # 5.2    [6] BAMUM NJAEMLI..BAMUM QUESTION MARK
+A828..A82B    ; Limited_Use Not_XID            # 4.1    [4] SYLOTI NAGRI POETRY MARK-1..SYLOTI NAGRI POETRY MARK-4
+A8CE..A8CF    ; Limited_Use Not_XID            # 5.1    [2] SAURASHTRA DANDA..SAURASHTRA DOUBLE DANDA
+A92F          ; Limited_Use Not_XID            # 5.1        KAYAH LI SIGN SHYA
+A9C1..A9CD    ; Limited_Use Not_XID            # 5.2   [13] JAVANESE LEFT RERENGGAN..JAVANESE TURNED PADA PISELEH
+A9DE..A9DF    ; Limited_Use Not_XID            # 5.2    [2] JAVANESE PADA TIRTA TUMETES..JAVANESE PADA ISEN-ISEN
+AA5C..AA5F    ; Limited_Use Not_XID            # 5.1    [4] CHAM PUNCTUATION SPIRAL..CHAM PUNCTUATION TRIPLE DANDA
+AADE..AADF    ; Limited_Use Not_XID            # 5.2    [2] TAI VIET SYMBOL HO HOI..TAI VIET SYMBOL KOI KOI
+AAF0..AAF1    ; Limited_Use Not_XID            # 6.1    [2] MEETEI MAYEK CHEIKHAN..MEETEI MAYEK AHANG KHUDAM
+ABEB          ; Limited_Use Not_XID            # 5.2        MEETEI MAYEK CHEIKHEI
+11140..11143  ; Limited_Use Not_XID            # 6.1    [4] CHAKMA SECTION MARK..CHAKMA QUESTION MARK
+1144B..1144F  ; Limited_Use Not_XID            # 9.0    [5] NEWA DANDA..NEWA ABBREVIATION SIGN
+1145A         ; Limited_Use Not_XID            # 13.0       NEWA DOUBLE COMMA
+1145B         ; Limited_Use Not_XID            # 9.0        NEWA PLACEHOLDER MARK
+1145D         ; Limited_Use Not_XID            # 9.0        NEWA INSERTION SIGN
+1E14F         ; Limited_Use Not_XID            # 12.0       NYIAKENG PUACHUE HMONG CIRCLED CA
+1E2FF         ; Limited_Use Not_XID            # 12.0       WANCHO NGUN SIGN
+1E95E..1E95F  ; Limited_Use Not_XID            # 9.0    [2] ADLAM INITIAL EXCLAMATION MARK..ADLAM INITIAL QUESTION MARK
+
+# Total code points: 204
+
+#	Identifier_Type:	Uncommon_Use
+
+0181..018C    ; Uncommon_Use                   # 1.1   [12] LATIN CAPITAL LETTER B WITH HOOK..LATIN SMALL LETTER D WITH TOPBAR
+018E          ; Uncommon_Use                   # 1.1        LATIN CAPITAL LETTER REVERSED E
+0190..019F    ; Uncommon_Use                   # 1.1   [16] LATIN CAPITAL LETTER OPEN E..LATIN CAPITAL LETTER O WITH MIDDLE TILDE
+01A2..01A9    ; Uncommon_Use                   # 1.1    [8] LATIN CAPITAL LETTER OI..LATIN CAPITAL LETTER ESH
+01AC..01AE    ; Uncommon_Use                   # 1.1    [3] LATIN CAPITAL LETTER T WITH HOOK..LATIN CAPITAL LETTER T WITH RETROFLEX HOOK
+01B1..01B8    ; Uncommon_Use                   # 1.1    [8] LATIN CAPITAL LETTER UPSILON..LATIN CAPITAL LETTER EZH REVERSED
+01BC..01BD    ; Uncommon_Use                   # 1.1    [2] LATIN CAPITAL LETTER TONE FIVE..LATIN SMALL LETTER TONE FIVE
+01DD          ; Uncommon_Use                   # 1.1        LATIN SMALL LETTER TURNED E
+01E4..01E5    ; Uncommon_Use                   # 1.1    [2] LATIN CAPITAL LETTER G WITH STROKE..LATIN SMALL LETTER G WITH STROKE
+0220          ; Uncommon_Use                   # 3.2        LATIN CAPITAL LETTER N WITH LONG RIGHT LEG
+0221          ; Uncommon_Use                   # 4.0        LATIN SMALL LETTER D WITH CURL
+0222..0225    ; Uncommon_Use                   # 3.0    [4] LATIN CAPITAL LETTER OU..LATIN SMALL LETTER Z WITH HOOK
+0237..0241    ; Uncommon_Use                   # 4.1   [11] LATIN SMALL LETTER DOTLESS J..LATIN CAPITAL LETTER GLOTTAL STOP
+0242..024F    ; Uncommon_Use                   # 5.0   [14] LATIN SMALL LETTER GLOTTAL STOP..LATIN SMALL LETTER Y WITH STROKE
+0305          ; Uncommon_Use                   # 1.1        COMBINING OVERLINE
+030D          ; Uncommon_Use                   # 1.1        COMBINING VERTICAL LINE ABOVE
+0316          ; Uncommon_Use                   # 1.1        COMBINING GRAVE ACCENT BELOW
+0321..0322    ; Uncommon_Use                   # 1.1    [2] COMBINING PALATALIZED HOOK BELOW..COMBINING RETROFLEX HOOK BELOW
+0332          ; Uncommon_Use                   # 1.1        COMBINING LOW LINE
+0334          ; Uncommon_Use                   # 1.1        COMBINING TILDE OVERLAY
+0336          ; Uncommon_Use                   # 1.1        COMBINING LONG STROKE OVERLAY
+0358          ; Uncommon_Use                   # 4.1        COMBINING DOT ABOVE RIGHT
+0591..05A1    ; Uncommon_Use                   # 2.0   [17] HEBREW ACCENT ETNAHTA..HEBREW ACCENT PAZER
+05A3..05AF    ; Uncommon_Use                   # 2.0   [13] HEBREW ACCENT MUNAH..HEBREW MARK MASORA CIRCLE
+05B0..05B3    ; Uncommon_Use                   # 1.1    [4] HEBREW POINT SHEVA..HEBREW POINT HATAF QAMATS
+05B5..05B9    ; Uncommon_Use                   # 1.1    [5] HEBREW POINT TSERE..HEBREW POINT HOLAM
+05BA          ; Uncommon_Use                   # 5.0        HEBREW POINT HOLAM HASER FOR VAV
+05BB..05BD    ; Uncommon_Use                   # 1.1    [3] HEBREW POINT QUBUTS..HEBREW POINT METEG
+05BF          ; Uncommon_Use                   # 1.1        HEBREW POINT RAFE
+05C1..05C2    ; Uncommon_Use                   # 1.1    [2] HEBREW POINT SHIN DOT..HEBREW POINT SIN DOT
+05C4          ; Uncommon_Use                   # 2.0        HEBREW MARK UPPER DOT
+0610..0615    ; Uncommon_Use                   # 4.0    [6] ARABIC SIGN SALLALLAHOU ALAYHE WASSALLAM..ARABIC SMALL HIGH TAH
+0616..061A    ; Uncommon_Use                   # 5.1    [5] ARABIC SMALL HIGH LIGATURE ALEF WITH LAM WITH YEH..ARABIC SMALL KASRA
+0656..0658    ; Uncommon_Use                   # 4.0    [3] ARABIC SUBSCRIPT ALEF..ARABIC MARK NOON GHUNNA
+0659..065E    ; Uncommon_Use                   # 4.1    [6] ARABIC ZWARAKAY..ARABIC FATHA WITH TWO DOTS
+065F          ; Uncommon_Use                   # 6.0        ARABIC WAVY HAMZA BELOW
+06D6..06DC    ; Uncommon_Use                   # 1.1    [7] ARABIC SMALL HIGH LIGATURE SAD WITH LAM WITH ALEF MAKSURA..ARABIC SMALL HIGH SEEN
+06DF..06E4    ; Uncommon_Use                   # 1.1    [6] ARABIC SMALL HIGH ROUNDED ZERO..ARABIC SMALL HIGH MADDA
+06E7..06E8    ; Uncommon_Use                   # 1.1    [2] ARABIC SMALL HIGH YEH..ARABIC SMALL HIGH NOON
+06EA..06ED    ; Uncommon_Use                   # 1.1    [4] ARABIC EMPTY CENTRE LOW STOP..ARABIC SMALL LOW MEEM
+0898..089F    ; Uncommon_Use                   # 14.0   [8] ARABIC SMALL HIGH WORD AL-JUZ..ARABIC HALF MADDA OVER MADDA
+08B3..08B4    ; Uncommon_Use                   # 8.0    [2] ARABIC LETTER AIN WITH THREE DOTS BELOW..ARABIC LETTER KAF WITH DOT BELOW
+08CA..08D2    ; Uncommon_Use                   # 14.0   [9] ARABIC SMALL HIGH FARSI YEH..ARABIC LARGE ROUND DOT INSIDE CIRCLE BELOW
+08D3          ; Uncommon_Use                   # 11.0       ARABIC SMALL LOW WAW
+08D4..08E1    ; Uncommon_Use                   # 9.0   [14] ARABIC SMALL HIGH WORD AR-RUB..ARABIC SMALL HIGH SIGN SAFHA
+08E3          ; Uncommon_Use                   # 8.0        ARABIC TURNED DAMMA BELOW
+08E4..08FE    ; Uncommon_Use                   # 6.1   [27] ARABIC CURLY FATHA..ARABIC DAMMA WITH DOT
+08FF          ; Uncommon_Use                   # 7.0        ARABIC MARK SIDEWAYS NOON GHUNNA
+0900          ; Uncommon_Use                   # 5.2        DEVANAGARI SIGN INVERTED CANDRABINDU
+0955          ; Uncommon_Use                   # 5.2        DEVANAGARI VOWEL SIGN CANDRA LONG E
+0A51          ; Uncommon_Use                   # 5.1        GURMUKHI SIGN UDAAT
+0A75          ; Uncommon_Use                   # 5.1        GURMUKHI SIGN YAKASH
+0AF9          ; Uncommon_Use                   # 8.0        GUJARATI LETTER ZHA
+0B44          ; Uncommon_Use                   # 5.1        ORIYA VOWEL SIGN VOCALIC RR
+0B62..0B63    ; Uncommon_Use                   # 5.1    [2] ORIYA VOWEL SIGN VOCALIC L..ORIYA VOWEL SIGN VOCALIC LL
+0C5A          ; Uncommon_Use                   # 8.0        TELUGU LETTER RRRA
+0C62..0C63    ; Uncommon_Use                   # 5.1    [2] TELUGU VOWEL SIGN VOCALIC L..TELUGU VOWEL SIGN VOCALIC LL
+0D44          ; Uncommon_Use                   # 5.1        MALAYALAM VOWEL SIGN VOCALIC RR
+0D62..0D63    ; Uncommon_Use                   # 5.1    [2] MALAYALAM VOWEL SIGN VOCALIC L..MALAYALAM VOWEL SIGN VOCALIC LL
+0F39          ; Uncommon_Use                   # 2.0        TIBETAN MARK TSA -PHRU
+1AC1..1ACE    ; Uncommon_Use                   # 14.0  [14] COMBINING LEFT PARENTHESIS ABOVE LEFT..COMBINING LATIN SMALL LETTER INSULAR T
+2054          ; Uncommon_Use                   # 4.0        INVERTED UNDERTIE
+2C68..2C6C    ; Uncommon_Use                   # 5.0    [5] LATIN SMALL LETTER H WITH DESCENDER..LATIN SMALL LETTER Z WITH DESCENDER
+A66F          ; Uncommon_Use                   # 5.1        COMBINING CYRILLIC VZMET
+A67C..A67D    ; Uncommon_Use                   # 5.1    [2] COMBINING CYRILLIC KAVYKA..COMBINING CYRILLIC PAYEROK
+A78B..A78C    ; Uncommon_Use                   # 5.1    [2] LATIN CAPITAL LETTER SALTILLO..LATIN SMALL LETTER SALTILLO
+A78F          ; Uncommon_Use                   # 8.0        LATIN LETTER SINOLOGICAL DOT
+A7B2..A7B7    ; Uncommon_Use                   # 8.0    [6] LATIN CAPITAL LETTER J WITH CROSSED-TAIL..LATIN SMALL LETTER OMEGA
+AB60..AB63    ; Uncommon_Use                   # 8.0    [4] LATIN SMALL LETTER SAKHA YAT..LATIN SMALL LETTER UO
+10780         ; Uncommon_Use                   # 14.0       MODIFIER LETTER SMALL CAPITAL AA
+1AFF0..1AFF3  ; Uncommon_Use                   # 14.0   [4] KATAKANA LETTER MINNAN TONE-2..KATAKANA LETTER MINNAN TONE-5
+1AFF5..1AFFB  ; Uncommon_Use                   # 14.0   [7] KATAKANA LETTER MINNAN TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-5
+1AFFD..1AFFE  ; Uncommon_Use                   # 14.0   [2] KATAKANA LETTER MINNAN NASALIZED TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-8
+
+# Total code points: 308
+
+#	Identifier_Type:	Uncommon_Use Technical
+
+0253..0254    ; Uncommon_Use Technical         # 1.1    [2] LATIN SMALL LETTER B WITH HOOK..LATIN SMALL LETTER OPEN O
+0256..0257    ; Uncommon_Use Technical         # 1.1    [2] LATIN SMALL LETTER D WITH TAIL..LATIN SMALL LETTER D WITH HOOK
+025B          ; Uncommon_Use Technical         # 1.1        LATIN SMALL LETTER OPEN E
+0263          ; Uncommon_Use Technical         # 1.1        LATIN SMALL LETTER GAMMA
+0268..0269    ; Uncommon_Use Technical         # 1.1    [2] LATIN SMALL LETTER I WITH STROKE..LATIN SMALL LETTER IOTA
+0272          ; Uncommon_Use Technical         # 1.1        LATIN SMALL LETTER N WITH LEFT HOOK
+0289          ; Uncommon_Use Technical         # 1.1        LATIN SMALL LETTER U BAR
+0292          ; Uncommon_Use Technical         # 1.1        LATIN SMALL LETTER EZH
+05C7          ; Uncommon_Use Technical         # 4.1        HEBREW POINT QAMATS QATAN
+0D8F..0D90    ; Uncommon_Use Technical         # 3.0    [2] SINHALA LETTER ILUYANNA..SINHALA LETTER ILUUYANNA
+0DA6          ; Uncommon_Use Technical         # 3.0        SINHALA LETTER SANYAKA JAYANNA
+0DDF          ; Uncommon_Use Technical         # 3.0        SINHALA VOWEL SIGN GAYANUKITTA
+0DF3          ; Uncommon_Use Technical         # 3.0        SINHALA VOWEL SIGN DIGA GAYANUKITTA
+FB1E          ; Uncommon_Use Technical         # 1.1        HEBREW POINT JUDEO-SPANISH VARIKA
+FE2E..FE2F    ; Uncommon_Use Technical         # 8.0    [2] COMBINING CYRILLIC TITLO LEFT HALF..COMBINING CYRILLIC TITLO RIGHT HALF
+
+# Total code points: 20
+
+#	Identifier_Type:	Uncommon_Use Technical Not_XID
+
+1D1DE..1D1E8  ; Uncommon_Use Technical Not_XID # 8.0   [11] MUSICAL SYMBOL KIEVAN C CLEF..MUSICAL SYMBOL KIEVAN FLAT SIGN
+
+# Total code points: 11
+
+#	Identifier_Type:	Uncommon_Use Exclusion
+
+18A9          ; Uncommon_Use Exclusion         # 3.0        MONGOLIAN LETTER ALI GALI DAGALGA
+16A40..16A5E  ; Uncommon_Use Exclusion         # 7.0   [31] MRO LETTER TA..MRO LETTER TEK
+16A60..16A69  ; Uncommon_Use Exclusion         # 7.0   [10] MRO DIGIT ZERO..MRO DIGIT NINE
+
+# Total code points: 42
+
+#	Identifier_Type:	Uncommon_Use Obsolete
+
+05A2          ; Uncommon_Use Obsolete          # 4.1        HEBREW ACCENT ATNAH HAFUKH
+05C5          ; Uncommon_Use Obsolete          # 4.1        HEBREW MARK LOWER DOT
+A69E          ; Uncommon_Use Obsolete          # 8.0        COMBINING CYRILLIC LETTER EF
+A8FD          ; Uncommon_Use Obsolete          # 8.0        DEVANAGARI JAIN OM
+
+# Total code points: 4
+
+#	Identifier_Type:	Uncommon_Use Obsolete Not_XID
+
+A8FC          ; Uncommon_Use Obsolete Not_XID  # 8.0        DEVANAGARI SIGN SIDDHAM
+
+# Total code points: 1
+
+#	Identifier_Type:	Uncommon_Use Not_XID
+
+218A..218B    ; Uncommon_Use Not_XID           # 8.0    [2] TURNED DIGIT TWO..TURNED DIGIT THREE
+2BEC..2BEF    ; Uncommon_Use Not_XID           # 8.0    [4] LEFTWARDS TWO-HEADED ARROW WITH TRIANGLE ARROWHEADS..DOWNWARDS TWO-HEADED ARROW WITH TRIANGLE ARROWHEADS
+1F54F         ; Uncommon_Use Not_XID           # 8.0        BOWL OF HYGIEIA
+
+# Total code points: 7
+
+#	Identifier_Type:	Technical
+
+0180          ; Technical                      # 1.1        LATIN SMALL LETTER B WITH STROKE
+01C0..01C3    ; Technical                      # 1.1    [4] LATIN LETTER DENTAL CLICK..LATIN LETTER RETROFLEX CLICK
+0234..0236    ; Technical                      # 4.0    [3] LATIN SMALL LETTER L WITH CURL..LATIN SMALL LETTER T WITH CURL
+0250..0252    ; Technical                      # 1.1    [3] LATIN SMALL LETTER TURNED A..LATIN SMALL LETTER TURNED ALPHA
+0255          ; Technical                      # 1.1        LATIN SMALL LETTER C WITH CURL
+0258          ; Technical                      # 1.1        LATIN SMALL LETTER REVERSED E
+025A          ; Technical                      # 1.1        LATIN SMALL LETTER SCHWA WITH HOOK
+025C..0262    ; Technical                      # 1.1    [7] LATIN SMALL LETTER REVERSED OPEN E..LATIN LETTER SMALL CAPITAL G
+0264..0267    ; Technical                      # 1.1    [4] LATIN SMALL LETTER RAMS HORN..LATIN SMALL LETTER HENG WITH HOOK
+026A..0271    ; Technical                      # 1.1    [8] LATIN LETTER SMALL CAPITAL I..LATIN SMALL LETTER M WITH HOOK
+0273..0276    ; Technical                      # 1.1    [4] LATIN SMALL LETTER N WITH RETROFLEX HOOK..LATIN LETTER SMALL CAPITAL OE
+0278..027B    ; Technical                      # 1.1    [4] LATIN SMALL LETTER PHI..LATIN SMALL LETTER TURNED R WITH HOOK
+027D..0288    ; Technical                      # 1.1   [12] LATIN SMALL LETTER R WITH TAIL..LATIN SMALL LETTER T WITH RETROFLEX HOOK
+028A..0291    ; Technical                      # 1.1    [8] LATIN SMALL LETTER UPSILON..LATIN SMALL LETTER Z WITH CURL
+0293..029D    ; Technical                      # 1.1   [11] LATIN SMALL LETTER EZH WITH CURL..LATIN SMALL LETTER J WITH CROSSED-TAIL
+029F..02A8    ; Technical                      # 1.1   [10] LATIN LETTER SMALL CAPITAL L..LATIN SMALL LETTER TC DIGRAPH WITH CURL
+02A9..02AD    ; Technical                      # 3.0    [5] LATIN SMALL LETTER FENG DIGRAPH..LATIN LETTER BIDENTAL PERCUSSIVE
+02AE..02AF    ; Technical                      # 4.0    [2] LATIN SMALL LETTER TURNED H WITH FISHHOOK..LATIN SMALL LETTER TURNED H WITH FISHHOOK AND TAIL
+02B9..02BA    ; Technical                      # 1.1    [2] MODIFIER LETTER PRIME..MODIFIER LETTER DOUBLE PRIME
+02BD..02C1    ; Technical                      # 1.1    [5] MODIFIER LETTER REVERSED COMMA..MODIFIER LETTER REVERSED GLOTTAL STOP
+02C6..02D1    ; Technical                      # 1.1   [12] MODIFIER LETTER CIRCUMFLEX ACCENT..MODIFIER LETTER HALF TRIANGULAR COLON
+02EE          ; Technical                      # 3.0        MODIFIER LETTER DOUBLE APOSTROPHE
+030E          ; Technical                      # 1.1        COMBINING DOUBLE VERTICAL LINE ABOVE
+0312          ; Technical                      # 1.1        COMBINING TURNED COMMA ABOVE
+0315          ; Technical                      # 1.1        COMBINING COMMA ABOVE RIGHT
+0317..031A    ; Technical                      # 1.1    [4] COMBINING ACUTE ACCENT BELOW..COMBINING LEFT ANGLE ABOVE
+031C..0320    ; Technical                      # 1.1    [5] COMBINING LEFT HALF RING BELOW..COMBINING MINUS SIGN BELOW
+0329..032C    ; Technical                      # 1.1    [4] COMBINING VERTICAL LINE BELOW..COMBINING CARON BELOW
+032F          ; Technical                      # 1.1        COMBINING INVERTED BREVE BELOW
+0333          ; Technical                      # 1.1        COMBINING DOUBLE LOW LINE
+0337          ; Technical                      # 1.1        COMBINING SHORT SOLIDUS OVERLAY
+033A..033F    ; Technical                      # 1.1    [6] COMBINING INVERTED BRIDGE BELOW..COMBINING DOUBLE OVERLINE
+0346..034E    ; Technical                      # 3.0    [9] COMBINING BRIDGE ABOVE..COMBINING UPWARDS ARROW BELOW
+0350..0357    ; Technical                      # 4.0    [8] COMBINING RIGHT ARROWHEAD ABOVE..COMBINING RIGHT HALF RING ABOVE
+0359..035C    ; Technical                      # 4.1    [4] COMBINING ASTERISK BELOW..COMBINING DOUBLE BREVE BELOW
+035D..035F    ; Technical                      # 4.0    [3] COMBINING DOUBLE BREVE..COMBINING DOUBLE MACRON BELOW
+0360..0361    ; Technical                      # 1.1    [2] COMBINING DOUBLE TILDE..COMBINING DOUBLE INVERTED BREVE
+0362          ; Technical                      # 3.0        COMBINING DOUBLE RIGHTWARDS ARROW BELOW
+03CF          ; Technical                      # 5.1        GREEK CAPITAL KAI SYMBOL
+03D7          ; Technical                      # 3.0        GREEK KAI SYMBOL
+0560          ; Technical                      # 11.0       ARMENIAN SMALL LETTER TURNED AYB
+0588          ; Technical                      # 11.0       ARMENIAN SMALL LETTER YI WITH STROKE
+0953..0954    ; Technical                      # 1.1    [2] DEVANAGARI GRAVE ACCENT..DEVANAGARI ACUTE ACCENT
+0D81          ; Technical                      # 13.0       SINHALA SIGN CANDRABINDU
+0F18..0F19    ; Technical                      # 2.0    [2] TIBETAN ASTROLOGICAL SIGN -KHYUD PA..TIBETAN ASTROLOGICAL SIGN SDONG TSHUGS
+17CE..17CF    ; Technical                      # 3.0    [2] KHMER SIGN KAKABAT..KHMER SIGN AHSDA
+1ABF..1AC0    ; Technical                      # 13.0   [2] COMBINING LATIN SMALL LETTER W BELOW..COMBINING LATIN SMALL LETTER TURNED W BELOW
+1D00..1D2B    ; Technical                      # 4.0   [44] LATIN LETTER SMALL CAPITAL A..CYRILLIC LETTER SMALL CAPITAL EL
+1D2F          ; Technical                      # 4.0        MODIFIER LETTER CAPITAL BARRED B
+1D3B          ; Technical                      # 4.0        MODIFIER LETTER CAPITAL REVERSED N
+1D4E          ; Technical                      # 4.0        MODIFIER LETTER SMALL TURNED I
+1D6B          ; Technical                      # 4.0        LATIN SMALL LETTER UE
+1D6C..1D77    ; Technical                      # 4.1   [12] LATIN SMALL LETTER B WITH MIDDLE TILDE..LATIN SMALL LETTER TURNED G
+1D79..1D9A    ; Technical                      # 4.1   [34] LATIN SMALL LETTER INSULAR G..LATIN SMALL LETTER EZH WITH RETROFLEX HOOK
+1DC4..1DCA    ; Technical                      # 5.0    [7] COMBINING MACRON-ACUTE..COMBINING LATIN SMALL LETTER R BELOW
+1DCB..1DCD    ; Technical                      # 5.1    [3] COMBINING BREVE-MACRON..COMBINING DOUBLE CIRCUMFLEX ABOVE
+1DCF..1DD0    ; Technical                      # 5.1    [2] COMBINING ZIGZAG BELOW..COMBINING IS BELOW
+1DE7..1DF5    ; Technical                      # 7.0   [15] COMBINING LATIN SMALL LETTER ALPHA..COMBINING UP TACK ABOVE
+1DF6..1DF9    ; Technical                      # 10.0   [4] COMBINING KAVYKA ABOVE RIGHT..COMBINING WIDE INVERTED BRIDGE BELOW
+1DFB          ; Technical                      # 9.0        COMBINING DELETION MARK
+1DFC          ; Technical                      # 6.0        COMBINING DOUBLE INVERTED BREVE BELOW
+1DFD          ; Technical                      # 5.2        COMBINING ALMOST EQUAL TO BELOW
+1DFE..1DFF    ; Technical                      # 5.0    [2] COMBINING LEFT ARROWHEAD ABOVE..COMBINING RIGHT ARROWHEAD AND DOWN ARROWHEAD BELOW
+1E9C..1E9D    ; Technical                      # 5.1    [2] LATIN SMALL LETTER LONG S WITH DIAGONAL STROKE..LATIN SMALL LETTER LONG S WITH HIGH STROKE
+1E9F          ; Technical                      # 5.1        LATIN SMALL LETTER DELTA
+1EFA..1EFF    ; Technical                      # 5.1    [6] LATIN CAPITAL LETTER MIDDLE-WELSH LL..LATIN SMALL LETTER Y WITH LOOP
+203F..2040    ; Technical                      # 1.1    [2] UNDERTIE..CHARACTER TIE
+20D0..20DC    ; Technical                      # 1.1   [13] COMBINING LEFT HARPOON ABOVE..COMBINING FOUR DOTS ABOVE
+20E1          ; Technical                      # 1.1        COMBINING LEFT RIGHT ARROW ABOVE
+20E5..20EA    ; Technical                      # 3.2    [6] COMBINING REVERSE SOLIDUS OVERLAY..COMBINING LEFTWARDS ARROW OVERLAY
+20EB          ; Technical                      # 4.1        COMBINING LONG DOUBLE SOLIDUS OVERLAY
+20EC..20EF    ; Technical                      # 5.0    [4] COMBINING RIGHTWARDS HARPOON WITH BARB DOWNWARDS..COMBINING RIGHT ARROW BELOW
+20F0          ; Technical                      # 5.1        COMBINING ASTERISK ABOVE
+2118          ; Technical                      # 1.1        SCRIPT CAPITAL P
+212E          ; Technical                      # 1.1        ESTIMATED SYMBOL
+2C60..2C67    ; Technical                      # 5.0    [8] LATIN CAPITAL LETTER L WITH DOUBLE BAR..LATIN CAPITAL LETTER H WITH DESCENDER
+2C77          ; Technical                      # 5.0        LATIN SMALL LETTER TAILLESS PHI
+2C78..2C7B    ; Technical                      # 5.1    [4] LATIN SMALL LETTER E WITH NOTCH..LATIN LETTER SMALL CAPITAL TURNED E
+3021..302D    ; Technical                      # 1.1   [13] HANGZHOU NUMERAL ONE..IDEOGRAPHIC ENTERING TONE MARK
+3031..3035    ; Technical                      # 1.1    [5] VERTICAL KANA REPEAT MARK..VERTICAL KANA REPEAT MARK LOWER HALF
+303B..303C    ; Technical                      # 3.2    [2] VERTICAL IDEOGRAPHIC ITERATION MARK..MASU MARK
+A78E          ; Technical                      # 6.0        LATIN SMALL LETTER L WITH RETROFLEX HOOK AND BELT
+A7AF          ; Technical                      # 11.0       LATIN LETTER SMALL CAPITAL Q
+A7BA..A7BF    ; Technical                      # 12.0   [6] LATIN CAPITAL LETTER GLOTTAL A..LATIN SMALL LETTER GLOTTAL U
+A7FA          ; Technical                      # 6.0        LATIN LETTER SMALL CAPITAL TURNED M
+AB68          ; Technical                      # 13.0       LATIN SMALL LETTER TURNED R WITH MIDDLE TILDE
+FE20..FE23    ; Technical                      # 1.1    [4] COMBINING LIGATURE LEFT HALF..COMBINING DOUBLE TILDE RIGHT HALF
+FE24..FE26    ; Technical                      # 5.1    [3] COMBINING MACRON LEFT HALF..COMBINING CONJOINING MACRON
+FE27..FE2D    ; Technical                      # 7.0    [7] COMBINING LIGATURE LEFT HALF BELOW..COMBINING CONJOINING MACRON BELOW
+FE73          ; Technical                      # 3.2        ARABIC TAIL FRAGMENT
+1CF00..1CF2D  ; Technical                      # 14.0  [46] ZNAMENNY COMBINING MARK GORAZDO NIZKO S KRYZHEM ON LEFT..ZNAMENNY COMBINING MARK KRYZH ON LEFT
+1CF30..1CF46  ; Technical                      # 14.0  [23] ZNAMENNY COMBINING TONAL RANGE MARK MRACHNO..ZNAMENNY PRIZNAK MODIFIER ROG
+1D165..1D169  ; Technical                      # 3.1    [5] MUSICAL SYMBOL COMBINING STEM..MUSICAL SYMBOL COMBINING TREMOLO-3
+1D16D..1D172  ; Technical                      # 3.1    [6] MUSICAL SYMBOL COMBINING AUGMENTATION DOT..MUSICAL SYMBOL COMBINING FLAG-5
+1D17B..1D182  ; Technical                      # 3.1    [8] MUSICAL SYMBOL COMBINING ACCENT..MUSICAL SYMBOL COMBINING LOURE
+1D185..1D18B  ; Technical                      # 3.1    [7] MUSICAL SYMBOL COMBINING DOIT..MUSICAL SYMBOL COMBINING TRIPLE TONGUE
+1D1AA..1D1AD  ; Technical                      # 3.1    [4] MUSICAL SYMBOL COMBINING DOWN BOW..MUSICAL SYMBOL COMBINING SNAP PIZZICATO
+
+# Total code points: 500
+
+#	Identifier_Type:	Technical Exclusion
+
+2CF0..2CF1    ; Technical Exclusion            # 5.2    [2] COPTIC COMBINING SPIRITUS ASPER..COPTIC COMBINING SPIRITUS LENIS
+
+# Total code points: 2
+
+#	Identifier_Type:	Technical Obsolete
+
+018D          ; Technical Obsolete             # 1.1        LATIN SMALL LETTER TURNED DELTA
+01AA..01AB    ; Technical Obsolete             # 1.1    [2] LATIN LETTER REVERSED ESH LOOP..LATIN SMALL LETTER T WITH PALATAL HOOK
+01BA..01BB    ; Technical Obsolete             # 1.1    [2] LATIN SMALL LETTER EZH WITH TAIL..LATIN LETTER TWO WITH STROKE
+01BE          ; Technical Obsolete             # 1.1        LATIN LETTER INVERTED GLOTTAL STOP WITH STROKE
+0277          ; Technical Obsolete             # 1.1        LATIN SMALL LETTER CLOSED OMEGA
+027C          ; Technical Obsolete             # 1.1        LATIN SMALL LETTER R WITH LONG LEG
+029E          ; Technical Obsolete             # 1.1        LATIN SMALL LETTER TURNED K
+03F3          ; Technical Obsolete             # 1.1        GREEK LETTER YOT
+0484..0486    ; Technical Obsolete             # 1.1    [3] COMBINING CYRILLIC PALATALIZATION..COMBINING CYRILLIC PSILI PNEUMATA
+0487          ; Technical Obsolete             # 5.1        COMBINING CYRILLIC POKRYTIE
+0D04          ; Technical Obsolete             # 13.0       MALAYALAM LETTER VEDIC ANUSVARA
+17D1          ; Technical Obsolete             # 3.0        KHMER SIGN VIRIAM
+17DD          ; Technical Obsolete             # 4.0        KHMER SIGN ATTHACAN
+1DC0..1DC3    ; Technical Obsolete             # 4.1    [4] COMBINING DOTTED GRAVE ACCENT..COMBINING SUSPENSION MARK
+1DCE          ; Technical Obsolete             # 5.1        COMBINING OGONEK ABOVE
+1DD1..1DE6    ; Technical Obsolete             # 5.1   [22] COMBINING UR ABOVE..COMBINING LATIN SMALL LETTER Z
+2180..2182    ; Technical Obsolete             # 1.1    [3] ROMAN NUMERAL ONE THOUSAND C D..ROMAN NUMERAL TEN THOUSAND
+2183          ; Technical Obsolete             # 3.0        ROMAN NUMERAL REVERSED ONE HUNDRED
+302E..302F    ; Technical Obsolete             # 1.1    [2] HANGUL SINGLE DOT TONE MARK..HANGUL DOUBLE DOT TONE MARK
+A722..A72F    ; Technical Obsolete             # 5.1   [14] LATIN CAPITAL LETTER EGYPTOLOGICAL ALEF..LATIN SMALL LETTER CUATRILLO WITH COMMA
+1D242..1D244  ; Technical Obsolete             # 4.1    [3] COMBINING GREEK MUSICAL TRISEME..COMBINING GREEK MUSICAL PENTASEME
+
+# Total code points: 67
+
+#	Identifier_Type:	Technical Obsolete Not_XID
+
+2E00..2E0D    ; Technical Obsolete Not_XID     # 4.1   [14] RIGHT ANGLE SUBSTITUTION MARKER..RIGHT RAISED OMISSION BRACKET
+
+# Total code points: 14
+
+#	Identifier_Type:	Technical Not_XID
+
+20DD..20E0    ; Technical Not_XID              # 1.1    [4] COMBINING ENCLOSING CIRCLE..COMBINING ENCLOSING CIRCLE BACKSLASH
+20E2..20E3    ; Technical Not_XID              # 3.0    [2] COMBINING ENCLOSING SCREEN..COMBINING ENCLOSING KEYCAP
+20E4          ; Technical Not_XID              # 3.2        COMBINING ENCLOSING UPWARD POINTING TRIANGLE
+24EB..24FE    ; Technical Not_XID              # 3.2   [20] NEGATIVE CIRCLED NUMBER ELEVEN..DOUBLE CIRCLED NUMBER TEN
+24FF          ; Technical Not_XID              # 4.0        NEGATIVE CIRCLED DIGIT ZERO
+2800..28FF    ; Technical Not_XID              # 3.0  [256] BRAILLE PATTERN BLANK..BRAILLE PATTERN DOTS-12345678
+327F          ; Technical Not_XID              # 1.1        KOREAN STANDARD SYMBOL
+4DC0..4DFF    ; Technical Not_XID              # 4.0   [64] HEXAGRAM FOR THE CREATIVE HEAVEN..HEXAGRAM FOR BEFORE COMPLETION
+A708..A716    ; Technical Not_XID              # 4.1   [15] MODIFIER LETTER EXTRA-HIGH DOTTED TONE BAR..MODIFIER LETTER EXTRA-LOW LEFT-STEM TONE BAR
+FBB2..FBC1    ; Technical Not_XID              # 6.0   [16] ARABIC SYMBOL DOT ABOVE..ARABIC SYMBOL SMALL TAH BELOW
+FBC2          ; Technical Not_XID              # 14.0       ARABIC SYMBOL WASLA ABOVE
+FD3E..FD3F    ; Technical Not_XID              # 1.1    [2] ORNATE LEFT PARENTHESIS..ORNATE RIGHT PARENTHESIS
+FD40..FD4F    ; Technical Not_XID              # 14.0  [16] ARABIC LIGATURE RAHIMAHU ALLAAH..ARABIC LIGATURE RAHIMAHUM ALLAAH
+FDCF          ; Technical Not_XID              # 14.0       ARABIC LIGATURE SALAAMUHU ALAYNAA
+FDFD          ; Technical Not_XID              # 4.0        ARABIC LIGATURE BISMILLAH AR-RAHMAN AR-RAHEEM
+FDFE..FDFF    ; Technical Not_XID              # 14.0   [2] ARABIC LIGATURE SUBHAANAHU WA TAAALAA..ARABIC LIGATURE AZZA WA JALL
+FE45..FE46    ; Technical Not_XID              # 3.2    [2] SESAME DOT..WHITE SESAME DOT
+1CF50..1CFC3  ; Technical Not_XID              # 14.0 [116] ZNAMENNY NEUME KRYUK..ZNAMENNY NEUME PAUK
+1D000..1D0F5  ; Technical Not_XID              # 3.1  [246] BYZANTINE MUSICAL SYMBOL PSILI..BYZANTINE MUSICAL SYMBOL GORGON NEO KATO
+1D100..1D126  ; Technical Not_XID              # 3.1   [39] MUSICAL SYMBOL SINGLE BARLINE..MUSICAL SYMBOL DRUM CLEF-2
+1D129         ; Technical Not_XID              # 5.1        MUSICAL SYMBOL MULTIPLE MEASURE REST
+1D12A..1D15D  ; Technical Not_XID              # 3.1   [52] MUSICAL SYMBOL DOUBLE SHARP..MUSICAL SYMBOL WHOLE NOTE
+1D16A..1D16C  ; Technical Not_XID              # 3.1    [3] MUSICAL SYMBOL FINGERED TREMOLO-1..MUSICAL SYMBOL FINGERED TREMOLO-3
+1D183..1D184  ; Technical Not_XID              # 3.1    [2] MUSICAL SYMBOL ARPEGGIATO UP..MUSICAL SYMBOL ARPEGGIATO DOWN
+1D18C..1D1A9  ; Technical Not_XID              # 3.1   [30] MUSICAL SYMBOL RINFORZANDO..MUSICAL SYMBOL DEGREE SLASH
+1D1AE..1D1BA  ; Technical Not_XID              # 3.1   [13] MUSICAL SYMBOL PEDAL MARK..MUSICAL SYMBOL SEMIBREVIS BLACK
+1D1C1..1D1DD  ; Technical Not_XID              # 3.1   [29] MUSICAL SYMBOL LONGA PERFECTA REST..MUSICAL SYMBOL PES SUBPUNCTIS
+1D1E9..1D1EA  ; Technical Not_XID              # 14.0   [2] MUSICAL SYMBOL SORI..MUSICAL SYMBOL KORON
+1D300..1D356  ; Technical Not_XID              # 4.0   [87] MONOGRAM FOR EARTH..TETRAGRAM FOR FOSTERING
+
+# Total code points: 1025
+
+#	Identifier_Type:	Exclusion
+
+03E2..03EF    ; Exclusion                      # 1.1   [14] COPTIC CAPITAL LETTER SHEI..COPTIC SMALL LETTER DEI
+0800..082D    ; Exclusion                      # 5.2   [46] SAMARITAN LETTER ALAF..SAMARITAN MARK NEQUDAA
+1681..169A    ; Exclusion                      # 3.0   [26] OGHAM LETTER BEITH..OGHAM LETTER PEITH
+16A0..16EA    ; Exclusion                      # 3.0   [75] RUNIC LETTER FEHU FEOH FE F..RUNIC LETTER X
+16EE..16F0    ; Exclusion                      # 3.0    [3] RUNIC ARLAUG SYMBOL..RUNIC BELGTHOR SYMBOL
+16F1..16F8    ; Exclusion                      # 7.0    [8] RUNIC LETTER K..RUNIC LETTER FRANKS CASKET AESC
+1700..170C    ; Exclusion                      # 3.2   [13] TAGALOG LETTER A..TAGALOG LETTER YA
+170D          ; Exclusion                      # 14.0       TAGALOG LETTER RA
+170E..1714    ; Exclusion                      # 3.2    [7] TAGALOG LETTER LA..TAGALOG SIGN VIRAMA
+1715          ; Exclusion                      # 14.0       TAGALOG SIGN PAMUDPOD
+171F          ; Exclusion                      # 14.0       TAGALOG LETTER ARCHAIC RA
+1720..1734    ; Exclusion                      # 3.2   [21] HANUNOO LETTER A..HANUNOO SIGN PAMUDPOD
+1740..1753    ; Exclusion                      # 3.2   [20] BUHID LETTER A..BUHID VOWEL SIGN U
+1760..176C    ; Exclusion                      # 3.2   [13] TAGBANWA LETTER A..TAGBANWA LETTER YA
+176E..1770    ; Exclusion                      # 3.2    [3] TAGBANWA LETTER LA..TAGBANWA LETTER SA
+1772..1773    ; Exclusion                      # 3.2    [2] TAGBANWA VOWEL SIGN I..TAGBANWA VOWEL SIGN U
+1810..1819    ; Exclusion                      # 3.0   [10] MONGOLIAN DIGIT ZERO..MONGOLIAN DIGIT NINE
+1820..1877    ; Exclusion                      # 3.0   [88] MONGOLIAN LETTER A..MONGOLIAN LETTER MANCHU ZHA
+1878          ; Exclusion                      # 11.0       MONGOLIAN LETTER CHA WITH TWO DOTS
+1880..18A8    ; Exclusion                      # 3.0   [41] MONGOLIAN LETTER ALI GALI ANUSVARA ONE..MONGOLIAN LETTER MANCHU ALI GALI BHA
+18AA          ; Exclusion                      # 5.1        MONGOLIAN LETTER MANCHU ALI GALI LHA
+1A00..1A1B    ; Exclusion                      # 4.1   [28] BUGINESE LETTER KA..BUGINESE VOWEL SIGN AE
+1CFA          ; Exclusion                      # 12.0       VEDIC SIGN DOUBLE ANUSVARA ANTARGOMUKHA
+2C00..2C2E    ; Exclusion                      # 4.1   [47] GLAGOLITIC CAPITAL LETTER AZU..GLAGOLITIC CAPITAL LETTER LATINATE MYSLITE
+2C2F          ; Exclusion                      # 14.0       GLAGOLITIC CAPITAL LETTER CAUDATE CHRIVI
+2C30..2C5E    ; Exclusion                      # 4.1   [47] GLAGOLITIC SMALL LETTER AZU..GLAGOLITIC SMALL LETTER LATINATE MYSLITE
+2C5F          ; Exclusion                      # 14.0       GLAGOLITIC SMALL LETTER CAUDATE CHRIVI
+2C80..2CE4    ; Exclusion                      # 4.1  [101] COPTIC CAPITAL LETTER ALFA..COPTIC SYMBOL KAI
+2CEB..2CEF    ; Exclusion                      # 5.2    [5] COPTIC CAPITAL LETTER CRYPTOGRAMMIC SHEI..COPTIC COMBINING NI ABOVE
+2CF2..2CF3    ; Exclusion                      # 6.1    [2] COPTIC CAPITAL LETTER BOHAIRIC KHEI..COPTIC SMALL LETTER BOHAIRIC KHEI
+A840..A873    ; Exclusion                      # 5.0   [52] PHAGS-PA LETTER KA..PHAGS-PA LETTER CANDRABINDU
+A930..A953    ; Exclusion                      # 5.1   [36] REJANG LETTER KA..REJANG VIRAMA
+10000..1000B  ; Exclusion                      # 4.0   [12] LINEAR B SYLLABLE B008 A..LINEAR B SYLLABLE B046 JE
+1000D..10026  ; Exclusion                      # 4.0   [26] LINEAR B SYLLABLE B036 JO..LINEAR B SYLLABLE B032 QO
+10028..1003A  ; Exclusion                      # 4.0   [19] LINEAR B SYLLABLE B060 RA..LINEAR B SYLLABLE B042 WO
+1003C..1003D  ; Exclusion                      # 4.0    [2] LINEAR B SYLLABLE B017 ZA..LINEAR B SYLLABLE B074 ZE
+1003F..1004D  ; Exclusion                      # 4.0   [15] LINEAR B SYLLABLE B020 ZO..LINEAR B SYLLABLE B091 TWO
+10050..1005D  ; Exclusion                      # 4.0   [14] LINEAR B SYMBOL B018..LINEAR B SYMBOL B089
+10080..100FA  ; Exclusion                      # 4.0  [123] LINEAR B IDEOGRAM B100 MAN..LINEAR B IDEOGRAM VESSEL B305
+10280..1029C  ; Exclusion                      # 5.1   [29] LYCIAN LETTER A..LYCIAN LETTER X
+102A0..102D0  ; Exclusion                      # 5.1   [49] CARIAN LETTER A..CARIAN LETTER UUU3
+10300..1031E  ; Exclusion                      # 3.1   [31] OLD ITALIC LETTER A..OLD ITALIC LETTER UU
+1031F         ; Exclusion                      # 7.0        OLD ITALIC LETTER ESS
+1032D..1032F  ; Exclusion                      # 10.0   [3] OLD ITALIC LETTER YE..OLD ITALIC LETTER SOUTHERN TSE
+10330..1034A  ; Exclusion                      # 3.1   [27] GOTHIC LETTER AHSA..GOTHIC LETTER NINE HUNDRED
+10350..1037A  ; Exclusion                      # 7.0   [43] OLD PERMIC LETTER AN..COMBINING OLD PERMIC LETTER SII
+10380..1039D  ; Exclusion                      # 4.0   [30] UGARITIC LETTER ALPA..UGARITIC LETTER SSU
+103A0..103C3  ; Exclusion                      # 4.1   [36] OLD PERSIAN SIGN A..OLD PERSIAN SIGN HA
+103C8..103CF  ; Exclusion                      # 4.1    [8] OLD PERSIAN SIGN AURAMAZDAA..OLD PERSIAN SIGN BUUMISH
+103D1..103D5  ; Exclusion                      # 4.1    [5] OLD PERSIAN NUMBER ONE..OLD PERSIAN NUMBER HUNDRED
+10400..10425  ; Exclusion                      # 3.1   [38] DESERET CAPITAL LETTER LONG I..DESERET CAPITAL LETTER ENG
+10426..10427  ; Exclusion                      # 4.0    [2] DESERET CAPITAL LETTER OI..DESERET CAPITAL LETTER EW
+10428..1044D  ; Exclusion                      # 3.1   [38] DESERET SMALL LETTER LONG I..DESERET SMALL LETTER ENG
+1044E..1049D  ; Exclusion                      # 4.0   [80] DESERET SMALL LETTER OI..OSMANYA LETTER OO
+104A0..104A9  ; Exclusion                      # 4.0   [10] OSMANYA DIGIT ZERO..OSMANYA DIGIT NINE
+10500..10527  ; Exclusion                      # 7.0   [40] ELBASAN LETTER A..ELBASAN LETTER KHE
+10530..10563  ; Exclusion                      # 7.0   [52] CAUCASIAN ALBANIAN LETTER ALT..CAUCASIAN ALBANIAN LETTER KIW
+10570..1057A  ; Exclusion                      # 14.0  [11] VITHKUQI CAPITAL LETTER A..VITHKUQI CAPITAL LETTER GA
+1057C..1058A  ; Exclusion                      # 14.0  [15] VITHKUQI CAPITAL LETTER HA..VITHKUQI CAPITAL LETTER RE
+1058C..10592  ; Exclusion                      # 14.0   [7] VITHKUQI CAPITAL LETTER SE..VITHKUQI CAPITAL LETTER XE
+10594..10595  ; Exclusion                      # 14.0   [2] VITHKUQI CAPITAL LETTER Y..VITHKUQI CAPITAL LETTER ZE
+10597..105A1  ; Exclusion                      # 14.0  [11] VITHKUQI SMALL LETTER A..VITHKUQI SMALL LETTER GA
+105A3..105B1  ; Exclusion                      # 14.0  [15] VITHKUQI SMALL LETTER HA..VITHKUQI SMALL LETTER RE
+105B3..105B9  ; Exclusion                      # 14.0   [7] VITHKUQI SMALL LETTER SE..VITHKUQI SMALL LETTER XE
+105BB..105BC  ; Exclusion                      # 14.0   [2] VITHKUQI SMALL LETTER Y..VITHKUQI SMALL LETTER ZE
+10600..10736  ; Exclusion                      # 7.0  [311] LINEAR A SIGN AB001..LINEAR A SIGN A664
+10740..10755  ; Exclusion                      # 7.0   [22] LINEAR A SIGN A701 A..LINEAR A SIGN A732 JE
+10760..10767  ; Exclusion                      # 7.0    [8] LINEAR A SIGN A800..LINEAR A SIGN A807
+10800..10805  ; Exclusion                      # 4.0    [6] CYPRIOT SYLLABLE A..CYPRIOT SYLLABLE JA
+10808         ; Exclusion                      # 4.0        CYPRIOT SYLLABLE JO
+1080A..10835  ; Exclusion                      # 4.0   [44] CYPRIOT SYLLABLE KA..CYPRIOT SYLLABLE WO
+10837..10838  ; Exclusion                      # 4.0    [2] CYPRIOT SYLLABLE XA..CYPRIOT SYLLABLE XE
+1083C         ; Exclusion                      # 4.0        CYPRIOT SYLLABLE ZA
+1083F         ; Exclusion                      # 4.0        CYPRIOT SYLLABLE ZO
+10840..10855  ; Exclusion                      # 5.2   [22] IMPERIAL ARAMAIC LETTER ALEPH..IMPERIAL ARAMAIC LETTER TAW
+10860..10876  ; Exclusion                      # 7.0   [23] PALMYRENE LETTER ALEPH..PALMYRENE LETTER TAW
+10880..1089E  ; Exclusion                      # 7.0   [31] NABATAEAN LETTER FINAL ALEPH..NABATAEAN LETTER TAW
+108E0..108F2  ; Exclusion                      # 8.0   [19] HATRAN LETTER ALEPH..HATRAN LETTER QOPH
+108F4..108F5  ; Exclusion                      # 8.0    [2] HATRAN LETTER SHIN..HATRAN LETTER TAW
+10900..10915  ; Exclusion                      # 5.0   [22] PHOENICIAN LETTER ALF..PHOENICIAN LETTER TAU
+10920..10939  ; Exclusion                      # 5.1   [26] LYDIAN LETTER A..LYDIAN LETTER C
+10980..109B7  ; Exclusion                      # 6.1   [56] MEROITIC HIEROGLYPHIC LETTER A..MEROITIC CURSIVE LETTER DA
+109BE..109BF  ; Exclusion                      # 6.1    [2] MEROITIC CURSIVE LOGOGRAM RMT..MEROITIC CURSIVE LOGOGRAM IMN
+10A00..10A03  ; Exclusion                      # 4.1    [4] KHAROSHTHI LETTER A..KHAROSHTHI VOWEL SIGN VOCALIC R
+10A05..10A06  ; Exclusion                      # 4.1    [2] KHAROSHTHI VOWEL SIGN E..KHAROSHTHI VOWEL SIGN O
+10A0C..10A13  ; Exclusion                      # 4.1    [8] KHAROSHTHI VOWEL LENGTH MARK..KHAROSHTHI LETTER GHA
+10A15..10A17  ; Exclusion                      # 4.1    [3] KHAROSHTHI LETTER CA..KHAROSHTHI LETTER JA
+10A19..10A33  ; Exclusion                      # 4.1   [27] KHAROSHTHI LETTER NYA..KHAROSHTHI LETTER TTTHA
+10A34..10A35  ; Exclusion                      # 11.0   [2] KHAROSHTHI LETTER TTTA..KHAROSHTHI LETTER VHA
+10A38..10A3A  ; Exclusion                      # 4.1    [3] KHAROSHTHI SIGN BAR ABOVE..KHAROSHTHI SIGN DOT BELOW
+10A3F         ; Exclusion                      # 4.1        KHAROSHTHI VIRAMA
+10A60..10A7C  ; Exclusion                      # 5.2   [29] OLD SOUTH ARABIAN LETTER HE..OLD SOUTH ARABIAN LETTER THETH
+10A80..10A9C  ; Exclusion                      # 7.0   [29] OLD NORTH ARABIAN LETTER HEH..OLD NORTH ARABIAN LETTER ZAH
+10AC0..10AC7  ; Exclusion                      # 7.0    [8] MANICHAEAN LETTER ALEPH..MANICHAEAN LETTER WAW
+10AC9..10AE6  ; Exclusion                      # 7.0   [30] MANICHAEAN LETTER ZAYIN..MANICHAEAN ABBREVIATION MARK BELOW
+10B00..10B35  ; Exclusion                      # 5.2   [54] AVESTAN LETTER A..AVESTAN LETTER HE
+10B40..10B55  ; Exclusion                      # 5.2   [22] INSCRIPTIONAL PARTHIAN LETTER ALEPH..INSCRIPTIONAL PARTHIAN LETTER TAW
+10B60..10B72  ; Exclusion                      # 5.2   [19] INSCRIPTIONAL PAHLAVI LETTER ALEPH..INSCRIPTIONAL PAHLAVI LETTER TAW
+10B80..10B91  ; Exclusion                      # 7.0   [18] PSALTER PAHLAVI LETTER ALEPH..PSALTER PAHLAVI LETTER TAW
+10C00..10C48  ; Exclusion                      # 5.2   [73] OLD TURKIC LETTER ORKHON A..OLD TURKIC LETTER ORKHON BASH
+10C80..10CB2  ; Exclusion                      # 8.0   [51] OLD HUNGARIAN CAPITAL LETTER A..OLD HUNGARIAN CAPITAL LETTER US
+10CC0..10CF2  ; Exclusion                      # 8.0   [51] OLD HUNGARIAN SMALL LETTER A..OLD HUNGARIAN SMALL LETTER US
+10E80..10EA9  ; Exclusion                      # 13.0  [42] YEZIDI LETTER ELIF..YEZIDI LETTER ET
+10EAB..10EAC  ; Exclusion                      # 13.0   [2] YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK
+10EB0..10EB1  ; Exclusion                      # 13.0   [2] YEZIDI LETTER LAM WITH DOT ABOVE..YEZIDI LETTER YOT WITH CIRCUMFLEX ABOVE
+10F00..10F1C  ; Exclusion                      # 11.0  [29] OLD SOGDIAN LETTER ALEPH..OLD SOGDIAN LETTER FINAL TAW WITH VERTICAL TAIL
+10F27         ; Exclusion                      # 11.0       OLD SOGDIAN LIGATURE AYIN-DALETH
+10F30..10F50  ; Exclusion                      # 11.0  [33] SOGDIAN LETTER ALEPH..SOGDIAN COMBINING STROKE BELOW
+10F70..10F85  ; Exclusion                      # 14.0  [22] OLD UYGHUR LETTER ALEPH..OLD UYGHUR COMBINING TWO DOTS BELOW
+10FB0..10FC4  ; Exclusion                      # 13.0  [21] CHORASMIAN LETTER ALEPH..CHORASMIAN LETTER TAW
+10FE0..10FF6  ; Exclusion                      # 12.0  [23] ELYMAIC LETTER ALEPH..ELYMAIC LIGATURE ZAYIN-YODH
+11000..11046  ; Exclusion                      # 6.0   [71] BRAHMI SIGN CANDRABINDU..BRAHMI VIRAMA
+11066..1106F  ; Exclusion                      # 6.0   [10] BRAHMI DIGIT ZERO..BRAHMI DIGIT NINE
+11070..11075  ; Exclusion                      # 14.0   [6] BRAHMI SIGN OLD TAMIL VIRAMA..BRAHMI LETTER OLD TAMIL LLA
+1107F         ; Exclusion                      # 7.0        BRAHMI NUMBER JOINER
+11080..110BA  ; Exclusion                      # 5.2   [59] KAITHI SIGN CANDRABINDU..KAITHI SIGN NUKTA
+110C2         ; Exclusion                      # 14.0       KAITHI VOWEL SIGN VOCALIC R
+110D0..110E8  ; Exclusion                      # 6.1   [25] SORA SOMPENG LETTER SAH..SORA SOMPENG LETTER MAE
+110F0..110F9  ; Exclusion                      # 6.1   [10] SORA SOMPENG DIGIT ZERO..SORA SOMPENG DIGIT NINE
+11150..11173  ; Exclusion                      # 7.0   [36] MAHAJANI LETTER A..MAHAJANI SIGN NUKTA
+11176         ; Exclusion                      # 7.0        MAHAJANI LIGATURE SHRI
+11180..111C4  ; Exclusion                      # 6.1   [69] SHARADA SIGN CANDRABINDU..SHARADA OM
+111C9..111CC  ; Exclusion                      # 8.0    [4] SHARADA SANDHI MARK..SHARADA EXTRA SHORT VOWEL MARK
+111CE..111CF  ; Exclusion                      # 13.0   [2] SHARADA VOWEL SIGN PRISHTHAMATRA E..SHARADA SIGN INVERTED CANDRABINDU
+111D0..111D9  ; Exclusion                      # 6.1   [10] SHARADA DIGIT ZERO..SHARADA DIGIT NINE
+111DA         ; Exclusion                      # 7.0        SHARADA EKAM
+111DC         ; Exclusion                      # 8.0        SHARADA HEADSTROKE
+11200..11211  ; Exclusion                      # 7.0   [18] KHOJKI LETTER A..KHOJKI LETTER JJA
+11213..11237  ; Exclusion                      # 7.0   [37] KHOJKI LETTER NYA..KHOJKI SIGN SHADDA
+1123E         ; Exclusion                      # 9.0        KHOJKI SIGN SUKUN
+11280..11286  ; Exclusion                      # 8.0    [7] MULTANI LETTER A..MULTANI LETTER GA
+11288         ; Exclusion                      # 8.0        MULTANI LETTER GHA
+1128A..1128D  ; Exclusion                      # 8.0    [4] MULTANI LETTER CA..MULTANI LETTER JJA
+1128F..1129D  ; Exclusion                      # 8.0   [15] MULTANI LETTER NYA..MULTANI LETTER BA
+1129F..112A8  ; Exclusion                      # 8.0   [10] MULTANI LETTER BHA..MULTANI LETTER RHA
+112B0..112EA  ; Exclusion                      # 7.0   [59] KHUDAWADI LETTER A..KHUDAWADI SIGN VIRAMA
+112F0..112F9  ; Exclusion                      # 7.0   [10] KHUDAWADI DIGIT ZERO..KHUDAWADI DIGIT NINE
+11300         ; Exclusion                      # 8.0        GRANTHA SIGN COMBINING ANUSVARA ABOVE
+11302         ; Exclusion                      # 7.0        GRANTHA SIGN ANUSVARA
+11305..1130C  ; Exclusion                      # 7.0    [8] GRANTHA LETTER A..GRANTHA LETTER VOCALIC L
+1130F..11310  ; Exclusion                      # 7.0    [2] GRANTHA LETTER EE..GRANTHA LETTER AI
+11313..11328  ; Exclusion                      # 7.0   [22] GRANTHA LETTER OO..GRANTHA LETTER NA
+1132A..11330  ; Exclusion                      # 7.0    [7] GRANTHA LETTER PA..GRANTHA LETTER RA
+11332..11333  ; Exclusion                      # 7.0    [2] GRANTHA LETTER LA..GRANTHA LETTER LLA
+11335..11339  ; Exclusion                      # 7.0    [5] GRANTHA LETTER VA..GRANTHA LETTER HA
+1133D..11344  ; Exclusion                      # 7.0    [8] GRANTHA SIGN AVAGRAHA..GRANTHA VOWEL SIGN VOCALIC RR
+11347..11348  ; Exclusion                      # 7.0    [2] GRANTHA VOWEL SIGN EE..GRANTHA VOWEL SIGN AI
+1134B..1134D  ; Exclusion                      # 7.0    [3] GRANTHA VOWEL SIGN OO..GRANTHA SIGN VIRAMA
+11350         ; Exclusion                      # 8.0        GRANTHA OM
+11357         ; Exclusion                      # 7.0        GRANTHA AU LENGTH MARK
+1135D..11363  ; Exclusion                      # 7.0    [7] GRANTHA SIGN PLUTA..GRANTHA VOWEL SIGN VOCALIC LL
+11366..1136C  ; Exclusion                      # 7.0    [7] COMBINING GRANTHA DIGIT ZERO..COMBINING GRANTHA DIGIT SIX
+11370..11374  ; Exclusion                      # 7.0    [5] COMBINING GRANTHA LETTER A..COMBINING GRANTHA LETTER PA
+11480..114C5  ; Exclusion                      # 7.0   [70] TIRHUTA ANJI..TIRHUTA GVANG
+114C7         ; Exclusion                      # 7.0        TIRHUTA OM
+114D0..114D9  ; Exclusion                      # 7.0   [10] TIRHUTA DIGIT ZERO..TIRHUTA DIGIT NINE
+11580..115B5  ; Exclusion                      # 7.0   [54] SIDDHAM LETTER A..SIDDHAM VOWEL SIGN VOCALIC RR
+115B8..115C0  ; Exclusion                      # 7.0    [9] SIDDHAM VOWEL SIGN E..SIDDHAM SIGN NUKTA
+115D8..115DD  ; Exclusion                      # 8.0    [6] SIDDHAM LETTER THREE-CIRCLE ALTERNATE I..SIDDHAM VOWEL SIGN ALTERNATE UU
+11600..11640  ; Exclusion                      # 7.0   [65] MODI LETTER A..MODI SIGN ARDHACANDRA
+11644         ; Exclusion                      # 7.0        MODI SIGN HUVA
+11650..11659  ; Exclusion                      # 7.0   [10] MODI DIGIT ZERO..MODI DIGIT NINE
+11680..116B7  ; Exclusion                      # 6.1   [56] TAKRI LETTER A..TAKRI SIGN NUKTA
+116B8         ; Exclusion                      # 12.0       TAKRI LETTER ARCHAIC KHA
+116C0..116C9  ; Exclusion                      # 6.1   [10] TAKRI DIGIT ZERO..TAKRI DIGIT NINE
+11700..11719  ; Exclusion                      # 8.0   [26] AHOM LETTER KA..AHOM LETTER JHA
+1171A         ; Exclusion                      # 11.0       AHOM LETTER ALTERNATE BA
+1171D..1172B  ; Exclusion                      # 8.0   [15] AHOM CONSONANT SIGN MEDIAL LA..AHOM SIGN KILLER
+11730..11739  ; Exclusion                      # 8.0   [10] AHOM DIGIT ZERO..AHOM DIGIT NINE
+11740..11746  ; Exclusion                      # 14.0   [7] AHOM LETTER CA..AHOM LETTER LLA
+11800..1183A  ; Exclusion                      # 11.0  [59] DOGRA LETTER A..DOGRA SIGN NUKTA
+118A0..118E9  ; Exclusion                      # 7.0   [74] WARANG CITI CAPITAL LETTER NGAA..WARANG CITI DIGIT NINE
+118FF         ; Exclusion                      # 7.0        WARANG CITI OM
+11900..11906  ; Exclusion                      # 13.0   [7] DIVES AKURU LETTER A..DIVES AKURU LETTER E
+11909         ; Exclusion                      # 13.0       DIVES AKURU LETTER O
+1190C..11913  ; Exclusion                      # 13.0   [8] DIVES AKURU LETTER KA..DIVES AKURU LETTER JA
+11915..11916  ; Exclusion                      # 13.0   [2] DIVES AKURU LETTER NYA..DIVES AKURU LETTER TTA
+11918..11935  ; Exclusion                      # 13.0  [30] DIVES AKURU LETTER DDA..DIVES AKURU VOWEL SIGN E
+11937..11938  ; Exclusion                      # 13.0   [2] DIVES AKURU VOWEL SIGN AI..DIVES AKURU VOWEL SIGN O
+1193B..11943  ; Exclusion                      # 13.0   [9] DIVES AKURU SIGN ANUSVARA..DIVES AKURU SIGN NUKTA
+11950..11959  ; Exclusion                      # 13.0  [10] DIVES AKURU DIGIT ZERO..DIVES AKURU DIGIT NINE
+119A0..119A7  ; Exclusion                      # 12.0   [8] NANDINAGARI LETTER A..NANDINAGARI LETTER VOCALIC RR
+119AA..119D7  ; Exclusion                      # 12.0  [46] NANDINAGARI LETTER E..NANDINAGARI VOWEL SIGN VOCALIC RR
+119DA..119E1  ; Exclusion                      # 12.0   [8] NANDINAGARI VOWEL SIGN E..NANDINAGARI SIGN AVAGRAHA
+119E3..119E4  ; Exclusion                      # 12.0   [2] NANDINAGARI HEADSTROKE..NANDINAGARI VOWEL SIGN PRISHTHAMATRA E
+11A00..11A3E  ; Exclusion                      # 10.0  [63] ZANABAZAR SQUARE LETTER A..ZANABAZAR SQUARE CLUSTER-FINAL LETTER VA
+11A47         ; Exclusion                      # 10.0       ZANABAZAR SQUARE SUBJOINER
+11A50..11A83  ; Exclusion                      # 10.0  [52] SOYOMBO LETTER A..SOYOMBO LETTER KSSA
+11A84..11A85  ; Exclusion                      # 12.0   [2] SOYOMBO SIGN JIHVAMULIYA..SOYOMBO SIGN UPADHMANIYA
+11A86..11A99  ; Exclusion                      # 10.0  [20] SOYOMBO CLUSTER-INITIAL LETTER RA..SOYOMBO SUBJOINER
+11A9D         ; Exclusion                      # 11.0       SOYOMBO MARK PLUTA
+11AC0..11AF8  ; Exclusion                      # 7.0   [57] PAU CIN HAU LETTER PA..PAU CIN HAU GLOTTAL STOP FINAL
+11C00..11C08  ; Exclusion                      # 9.0    [9] BHAIKSUKI LETTER A..BHAIKSUKI LETTER VOCALIC L
+11C0A..11C36  ; Exclusion                      # 9.0   [45] BHAIKSUKI LETTER E..BHAIKSUKI VOWEL SIGN VOCALIC L
+11C38..11C40  ; Exclusion                      # 9.0    [9] BHAIKSUKI VOWEL SIGN E..BHAIKSUKI SIGN AVAGRAHA
+11C50..11C59  ; Exclusion                      # 9.0   [10] BHAIKSUKI DIGIT ZERO..BHAIKSUKI DIGIT NINE
+11C72..11C8F  ; Exclusion                      # 9.0   [30] MARCHEN LETTER KA..MARCHEN LETTER A
+11C92..11CA7  ; Exclusion                      # 9.0   [22] MARCHEN SUBJOINED LETTER KA..MARCHEN SUBJOINED LETTER ZA
+11CA9..11CB6  ; Exclusion                      # 9.0   [14] MARCHEN SUBJOINED LETTER YA..MARCHEN SIGN CANDRABINDU
+11D00..11D06  ; Exclusion                      # 10.0   [7] MASARAM GONDI LETTER A..MASARAM GONDI LETTER E
+11D08..11D09  ; Exclusion                      # 10.0   [2] MASARAM GONDI LETTER AI..MASARAM GONDI LETTER O
+11D0B..11D36  ; Exclusion                      # 10.0  [44] MASARAM GONDI LETTER AU..MASARAM GONDI VOWEL SIGN VOCALIC R
+11D3A         ; Exclusion                      # 10.0       MASARAM GONDI VOWEL SIGN E
+11D3C..11D3D  ; Exclusion                      # 10.0   [2] MASARAM GONDI VOWEL SIGN AI..MASARAM GONDI VOWEL SIGN O
+11D3F..11D47  ; Exclusion                      # 10.0   [9] MASARAM GONDI VOWEL SIGN AU..MASARAM GONDI RA-KARA
+11D50..11D59  ; Exclusion                      # 10.0  [10] MASARAM GONDI DIGIT ZERO..MASARAM GONDI DIGIT NINE
+11EE0..11EF6  ; Exclusion                      # 11.0  [23] MAKASAR LETTER KA..MAKASAR VOWEL SIGN O
+12000..1236E  ; Exclusion                      # 5.0  [879] CUNEIFORM SIGN A..CUNEIFORM SIGN ZUM
+1236F..12398  ; Exclusion                      # 7.0   [42] CUNEIFORM SIGN KAP ELAMITE..CUNEIFORM SIGN UM TIMES ME
+12399         ; Exclusion                      # 8.0        CUNEIFORM SIGN U U
+12400..12462  ; Exclusion                      # 5.0   [99] CUNEIFORM NUMERIC SIGN TWO ASH..CUNEIFORM NUMERIC SIGN OLD ASSYRIAN ONE QUARTER
+12463..1246E  ; Exclusion                      # 7.0   [12] CUNEIFORM NUMERIC SIGN ONE QUARTER GUR..CUNEIFORM NUMERIC SIGN NINE U VARIANT FORM
+12480..12543  ; Exclusion                      # 8.0  [196] CUNEIFORM SIGN AB TIMES NUN TENU..CUNEIFORM SIGN ZU5 TIMES THREE DISH TENU
+12F90..12FF0  ; Exclusion                      # 14.0  [97] CYPRO-MINOAN SIGN CM001..CYPRO-MINOAN SIGN CM114
+13000..1342E  ; Exclusion                      # 5.2 [1071] EGYPTIAN HIEROGLYPH A001..EGYPTIAN HIEROGLYPH AA032
+14400..14646  ; Exclusion                      # 8.0  [583] ANATOLIAN HIEROGLYPH A001..ANATOLIAN HIEROGLYPH A530
+16A70..16ABE  ; Exclusion                      # 14.0  [79] TANGSA LETTER OZ..TANGSA LETTER ZA
+16AC0..16AC9  ; Exclusion                      # 14.0  [10] TANGSA DIGIT ZERO..TANGSA DIGIT NINE
+16AD0..16AED  ; Exclusion                      # 7.0   [30] BASSA VAH LETTER ENNI..BASSA VAH LETTER I
+16AF0..16AF4  ; Exclusion                      # 7.0    [5] BASSA VAH COMBINING HIGH TONE..BASSA VAH COMBINING HIGH-LOW TONE
+16B00..16B36  ; Exclusion                      # 7.0   [55] PAHAWH HMONG VOWEL KEEB..PAHAWH HMONG MARK CIM TAUM
+16B40..16B43  ; Exclusion                      # 7.0    [4] PAHAWH HMONG SIGN VOS SEEV..PAHAWH HMONG SIGN IB YAM
+16B50..16B59  ; Exclusion                      # 7.0   [10] PAHAWH HMONG DIGIT ZERO..PAHAWH HMONG DIGIT NINE
+16B63..16B77  ; Exclusion                      # 7.0   [21] PAHAWH HMONG SIGN VOS LUB..PAHAWH HMONG SIGN CIM NRES TOS
+16B7D..16B8F  ; Exclusion                      # 7.0   [19] PAHAWH HMONG CLAN SIGN TSHEEJ..PAHAWH HMONG CLAN SIGN VWJ
+16E40..16E7F  ; Exclusion                      # 11.0  [64] MEDEFAIDRIN CAPITAL LETTER M..MEDEFAIDRIN SMALL LETTER Y
+16FE0         ; Exclusion                      # 9.0        TANGUT ITERATION MARK
+16FE1         ; Exclusion                      # 10.0       NUSHU ITERATION MARK
+16FE4         ; Exclusion                      # 13.0       KHITAN SMALL SCRIPT FILLER
+17000..187EC  ; Exclusion                      # 9.0 [6125] TANGUT IDEOGRAPH-17000..TANGUT IDEOGRAPH-187EC
+187ED..187F1  ; Exclusion                      # 11.0   [5] TANGUT IDEOGRAPH-187ED..TANGUT IDEOGRAPH-187F1
+187F2..187F7  ; Exclusion                      # 12.0   [6] TANGUT IDEOGRAPH-187F2..TANGUT IDEOGRAPH-187F7
+18800..18AF2  ; Exclusion                      # 9.0  [755] TANGUT COMPONENT-001..TANGUT COMPONENT-755
+18AF3..18CD5  ; Exclusion                      # 13.0 [483] TANGUT COMPONENT-756..KHITAN SMALL SCRIPT CHARACTER-18CD5
+18D00..18D08  ; Exclusion                      # 13.0   [9] TANGUT IDEOGRAPH-18D00..TANGUT IDEOGRAPH-18D08
+1B170..1B2FB  ; Exclusion                      # 10.0 [396] NUSHU CHARACTER-1B170..NUSHU CHARACTER-1B2FB
+1BC00..1BC6A  ; Exclusion                      # 7.0  [107] DUPLOYAN LETTER H..DUPLOYAN LETTER VOCALIC M
+1BC70..1BC7C  ; Exclusion                      # 7.0   [13] DUPLOYAN AFFIX LEFT HORIZONTAL SECANT..DUPLOYAN AFFIX ATTACHED TANGENT HOOK
+1BC80..1BC88  ; Exclusion                      # 7.0    [9] DUPLOYAN AFFIX HIGH ACUTE..DUPLOYAN AFFIX HIGH VERTICAL
+1BC90..1BC99  ; Exclusion                      # 7.0   [10] DUPLOYAN AFFIX LOW ACUTE..DUPLOYAN AFFIX LOW ARROW
+1BC9D..1BC9E  ; Exclusion                      # 7.0    [2] DUPLOYAN THICK LETTER SELECTOR..DUPLOYAN DOUBLE MARK
+1DA00..1DA36  ; Exclusion                      # 8.0   [55] SIGNWRITING HEAD RIM..SIGNWRITING AIR SUCKING IN
+1DA3B..1DA6C  ; Exclusion                      # 8.0   [50] SIGNWRITING MOUTH CLOSED NEUTRAL..SIGNWRITING EXCITEMENT
+1DA75         ; Exclusion                      # 8.0        SIGNWRITING UPPER BODY TILTING FROM HIP JOINTS
+1DA84         ; Exclusion                      # 8.0        SIGNWRITING LOCATION HEAD NECK
+1DA9B..1DA9F  ; Exclusion                      # 8.0    [5] SIGNWRITING FILL MODIFIER-2..SIGNWRITING FILL MODIFIER-6
+1DAA1..1DAAF  ; Exclusion                      # 8.0   [15] SIGNWRITING ROTATION MODIFIER-2..SIGNWRITING ROTATION MODIFIER-16
+1E000..1E006  ; Exclusion                      # 9.0    [7] COMBINING GLAGOLITIC LETTER AZU..COMBINING GLAGOLITIC LETTER ZHIVETE
+1E008..1E018  ; Exclusion                      # 9.0   [17] COMBINING GLAGOLITIC LETTER ZEMLJA..COMBINING GLAGOLITIC LETTER HERU
+1E01B..1E021  ; Exclusion                      # 9.0    [7] COMBINING GLAGOLITIC LETTER SHTA..COMBINING GLAGOLITIC LETTER YATI
+1E023..1E024  ; Exclusion                      # 9.0    [2] COMBINING GLAGOLITIC LETTER YU..COMBINING GLAGOLITIC LETTER SMALL YUS
+1E026..1E02A  ; Exclusion                      # 9.0    [5] COMBINING GLAGOLITIC LETTER YO..COMBINING GLAGOLITIC LETTER FITA
+1E290..1E2AE  ; Exclusion                      # 14.0  [31] TOTO LETTER PA..TOTO SIGN RISING TONE
+1E800..1E8C4  ; Exclusion                      # 7.0  [197] MENDE KIKAKUI SYLLABLE M001 KI..MENDE KIKAKUI SYLLABLE M060 NYON
+1E8D0..1E8D6  ; Exclusion                      # 7.0    [7] MENDE KIKAKUI COMBINING NUMBER TEENS..MENDE KIKAKUI COMBINING NUMBER MILLIONS
+
+# Total code points: 15930
+
+#	Identifier_Type:	Exclusion Not_XID
+
+0830..083E    ; Exclusion Not_XID              # 5.2   [15] SAMARITAN PUNCTUATION NEQUDAA..SAMARITAN PUNCTUATION ANNAAU
+1680          ; Exclusion Not_XID              # 3.0        OGHAM SPACE MARK
+169B..169C    ; Exclusion Not_XID              # 3.0    [2] OGHAM FEATHER MARK..OGHAM REVERSED FEATHER MARK
+1735..1736    ; Exclusion Not_XID              # 3.2    [2] PHILIPPINE SINGLE PUNCTUATION..PHILIPPINE DOUBLE PUNCTUATION
+1800..180A    ; Exclusion Not_XID              # 3.0   [11] MONGOLIAN BIRGA..MONGOLIAN NIRUGU
+1A1E..1A1F    ; Exclusion Not_XID              # 4.1    [2] BUGINESE PALLAWA..BUGINESE END OF SECTION
+2CE5..2CEA    ; Exclusion Not_XID              # 4.1    [6] COPTIC SYMBOL MI RO..COPTIC SYMBOL SHIMA SIMA
+2CF9..2CFF    ; Exclusion Not_XID              # 4.1    [7] COPTIC OLD NUBIAN FULL STOP..COPTIC MORPHOLOGICAL DIVIDER
+A874..A877    ; Exclusion Not_XID              # 5.0    [4] PHAGS-PA SINGLE HEAD MARK..PHAGS-PA MARK DOUBLE SHAD
+A95F          ; Exclusion Not_XID              # 5.1        REJANG SECTION MARK
+10100..10102  ; Exclusion Not_XID              # 4.0    [3] AEGEAN WORD SEPARATOR LINE..AEGEAN CHECK MARK
+10107..10133  ; Exclusion Not_XID              # 4.0   [45] AEGEAN NUMBER ONE..AEGEAN NUMBER NINETY THOUSAND
+10137..1013F  ; Exclusion Not_XID              # 4.0    [9] AEGEAN WEIGHT BASE UNIT..AEGEAN MEASURE THIRD SUBUNIT
+10320..10323  ; Exclusion Not_XID              # 3.1    [4] OLD ITALIC NUMERAL ONE..OLD ITALIC NUMERAL FIFTY
+1039F         ; Exclusion Not_XID              # 4.0        UGARITIC WORD DIVIDER
+103D0         ; Exclusion Not_XID              # 4.1        OLD PERSIAN WORD DIVIDER
+1056F         ; Exclusion Not_XID              # 7.0        CAUCASIAN ALBANIAN CITATION MARK
+10857..1085F  ; Exclusion Not_XID              # 5.2    [9] IMPERIAL ARAMAIC SECTION SIGN..IMPERIAL ARAMAIC NUMBER TEN THOUSAND
+10877..1087F  ; Exclusion Not_XID              # 7.0    [9] PALMYRENE LEFT-POINTING FLEURON..PALMYRENE NUMBER TWENTY
+108A7..108AF  ; Exclusion Not_XID              # 7.0    [9] NABATAEAN NUMBER ONE..NABATAEAN NUMBER ONE HUNDRED
+108FB..108FF  ; Exclusion Not_XID              # 8.0    [5] HATRAN NUMBER ONE..HATRAN NUMBER ONE HUNDRED
+10916..10919  ; Exclusion Not_XID              # 5.0    [4] PHOENICIAN NUMBER ONE..PHOENICIAN NUMBER ONE HUNDRED
+1091A..1091B  ; Exclusion Not_XID              # 5.2    [2] PHOENICIAN NUMBER TWO..PHOENICIAN NUMBER THREE
+1091F         ; Exclusion Not_XID              # 5.0        PHOENICIAN WORD SEPARATOR
+1093F         ; Exclusion Not_XID              # 5.1        LYDIAN TRIANGULAR MARK
+109BC..109BD  ; Exclusion Not_XID              # 8.0    [2] MEROITIC CURSIVE FRACTION ELEVEN TWELFTHS..MEROITIC CURSIVE FRACTION ONE HALF
+109C0..109CF  ; Exclusion Not_XID              # 8.0   [16] MEROITIC CURSIVE NUMBER ONE..MEROITIC CURSIVE NUMBER SEVENTY
+109D2..109FF  ; Exclusion Not_XID              # 8.0   [46] MEROITIC CURSIVE NUMBER ONE HUNDRED..MEROITIC CURSIVE FRACTION TEN TWELFTHS
+10A40..10A47  ; Exclusion Not_XID              # 4.1    [8] KHAROSHTHI DIGIT ONE..KHAROSHTHI NUMBER ONE THOUSAND
+10A48         ; Exclusion Not_XID              # 11.0       KHAROSHTHI FRACTION ONE HALF
+10A50..10A58  ; Exclusion Not_XID              # 4.1    [9] KHAROSHTHI PUNCTUATION DOT..KHAROSHTHI PUNCTUATION LINES
+10A7D..10A7F  ; Exclusion Not_XID              # 5.2    [3] OLD SOUTH ARABIAN NUMBER ONE..OLD SOUTH ARABIAN NUMERIC INDICATOR
+10A9D..10A9F  ; Exclusion Not_XID              # 7.0    [3] OLD NORTH ARABIAN NUMBER ONE..OLD NORTH ARABIAN NUMBER TWENTY
+10AC8         ; Exclusion Not_XID              # 7.0        MANICHAEAN SIGN UD
+10AEB..10AF6  ; Exclusion Not_XID              # 7.0   [12] MANICHAEAN NUMBER ONE..MANICHAEAN PUNCTUATION LINE FILLER
+10B39..10B3F  ; Exclusion Not_XID              # 5.2    [7] AVESTAN ABBREVIATION MARK..LARGE ONE RING OVER TWO RINGS PUNCTUATION
+10B58..10B5F  ; Exclusion Not_XID              # 5.2    [8] INSCRIPTIONAL PARTHIAN NUMBER ONE..INSCRIPTIONAL PARTHIAN NUMBER ONE THOUSAND
+10B78..10B7F  ; Exclusion Not_XID              # 5.2    [8] INSCRIPTIONAL PAHLAVI NUMBER ONE..INSCRIPTIONAL PAHLAVI NUMBER ONE THOUSAND
+10B99..10B9C  ; Exclusion Not_XID              # 7.0    [4] PSALTER PAHLAVI SECTION MARK..PSALTER PAHLAVI FOUR DOTS WITH DOT
+10BA9..10BAF  ; Exclusion Not_XID              # 7.0    [7] PSALTER PAHLAVI NUMBER ONE..PSALTER PAHLAVI NUMBER ONE HUNDRED
+10CFA..10CFF  ; Exclusion Not_XID              # 8.0    [6] OLD HUNGARIAN NUMBER ONE..OLD HUNGARIAN NUMBER ONE THOUSAND
+10EAD         ; Exclusion Not_XID              # 13.0       YEZIDI HYPHENATION MARK
+10F1D..10F26  ; Exclusion Not_XID              # 11.0  [10] OLD SOGDIAN NUMBER ONE..OLD SOGDIAN FRACTION ONE HALF
+10F51..10F59  ; Exclusion Not_XID              # 11.0   [9] SOGDIAN NUMBER ONE..SOGDIAN PUNCTUATION HALF CIRCLE WITH DOT
+10F86..10F89  ; Exclusion Not_XID              # 14.0   [4] OLD UYGHUR PUNCTUATION BAR..OLD UYGHUR PUNCTUATION FOUR DOTS
+10FC5..10FCB  ; Exclusion Not_XID              # 13.0   [7] CHORASMIAN NUMBER ONE..CHORASMIAN NUMBER ONE HUNDRED
+11047..1104D  ; Exclusion Not_XID              # 6.0    [7] BRAHMI DANDA..BRAHMI PUNCTUATION LOTUS
+11052..11065  ; Exclusion Not_XID              # 6.0   [20] BRAHMI NUMBER ONE..BRAHMI NUMBER ONE THOUSAND
+110BB..110BC  ; Exclusion Not_XID              # 5.2    [2] KAITHI ABBREVIATION SIGN..KAITHI ENUMERATION SIGN
+110BD         ; Exclusion Not_XID              # 5.2        KAITHI NUMBER SIGN
+110BE..110C1  ; Exclusion Not_XID              # 5.2    [4] KAITHI SECTION MARK..KAITHI DOUBLE DANDA
+110CD         ; Exclusion Not_XID              # 11.0       KAITHI NUMBER SIGN ABOVE
+11174..11175  ; Exclusion Not_XID              # 7.0    [2] MAHAJANI ABBREVIATION SIGN..MAHAJANI SECTION MARK
+111C5..111C8  ; Exclusion Not_XID              # 6.1    [4] SHARADA DANDA..SHARADA SEPARATOR
+111CD         ; Exclusion Not_XID              # 7.0        SHARADA SUTRA MARK
+111DB         ; Exclusion Not_XID              # 8.0        SHARADA SIGN SIDDHAM
+111DD..111DF  ; Exclusion Not_XID              # 8.0    [3] SHARADA CONTINUATION SIGN..SHARADA SECTION MARK-2
+11238..1123D  ; Exclusion Not_XID              # 7.0    [6] KHOJKI DANDA..KHOJKI ABBREVIATION SIGN
+112A9         ; Exclusion Not_XID              # 8.0        MULTANI SECTION MARK
+114C6         ; Exclusion Not_XID              # 7.0        TIRHUTA ABBREVIATION SIGN
+115C1..115C9  ; Exclusion Not_XID              # 7.0    [9] SIDDHAM SIGN SIDDHAM..SIDDHAM END OF TEXT MARK
+115CA..115D7  ; Exclusion Not_XID              # 8.0   [14] SIDDHAM SECTION MARK WITH TRIDENT AND U-SHAPED ORNAMENTS..SIDDHAM SECTION MARK WITH CIRCLES AND FOUR ENCLOSURES
+11641..11643  ; Exclusion Not_XID              # 7.0    [3] MODI DANDA..MODI ABBREVIATION SIGN
+11660..1166C  ; Exclusion Not_XID              # 9.0   [13] MONGOLIAN BIRGA WITH ORNAMENT..MONGOLIAN TURNED SWIRL BIRGA WITH DOUBLE ORNAMENT
+116B9         ; Exclusion Not_XID              # 14.0       TAKRI ABBREVIATION SIGN
+1173A..1173F  ; Exclusion Not_XID              # 8.0    [6] AHOM NUMBER TEN..AHOM SYMBOL VI
+1183B         ; Exclusion Not_XID              # 11.0       DOGRA ABBREVIATION SIGN
+118EA..118F2  ; Exclusion Not_XID              # 7.0    [9] WARANG CITI NUMBER TEN..WARANG CITI NUMBER NINETY
+11944..11946  ; Exclusion Not_XID              # 13.0   [3] DIVES AKURU DOUBLE DANDA..DIVES AKURU END OF TEXT MARK
+119E2         ; Exclusion Not_XID              # 12.0       NANDINAGARI SIGN SIDDHAM
+11A3F..11A46  ; Exclusion Not_XID              # 10.0   [8] ZANABAZAR SQUARE INITIAL HEAD MARK..ZANABAZAR SQUARE CLOSING DOUBLE-LINED HEAD MARK
+11A9A..11A9C  ; Exclusion Not_XID              # 10.0   [3] SOYOMBO MARK TSHEG..SOYOMBO MARK DOUBLE SHAD
+11A9E..11AA2  ; Exclusion Not_XID              # 10.0   [5] SOYOMBO HEAD MARK WITH MOON AND SUN AND TRIPLE FLAME..SOYOMBO TERMINAL MARK-2
+11C41..11C45  ; Exclusion Not_XID              # 9.0    [5] BHAIKSUKI DANDA..BHAIKSUKI GAP FILLER-2
+11C5A..11C6C  ; Exclusion Not_XID              # 9.0   [19] BHAIKSUKI NUMBER ONE..BHAIKSUKI HUNDREDS UNIT MARK
+11C70..11C71  ; Exclusion Not_XID              # 9.0    [2] MARCHEN HEAD MARK..MARCHEN MARK SHAD
+11EF7..11EF8  ; Exclusion Not_XID              # 11.0   [2] MAKASAR PASSIMBANG..MAKASAR END OF SECTION
+12470..12473  ; Exclusion Not_XID              # 5.0    [4] CUNEIFORM PUNCTUATION SIGN OLD ASSYRIAN WORD DIVIDER..CUNEIFORM PUNCTUATION SIGN DIAGONAL TRICOLON
+12474         ; Exclusion Not_XID              # 7.0        CUNEIFORM PUNCTUATION SIGN DIAGONAL QUADCOLON
+12FF1..12FF2  ; Exclusion Not_XID              # 14.0   [2] CYPRO-MINOAN SIGN CM301..CYPRO-MINOAN SIGN CM302
+13430..13438  ; Exclusion Not_XID              # 12.0   [9] EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH END SEGMENT
+16A6E..16A6F  ; Exclusion Not_XID              # 7.0    [2] MRO DANDA..MRO DOUBLE DANDA
+16AF5         ; Exclusion Not_XID              # 7.0        BASSA VAH FULL STOP
+16B37..16B3F  ; Exclusion Not_XID              # 7.0    [9] PAHAWH HMONG SIGN VOS THOM..PAHAWH HMONG SIGN XYEEM FAIB
+16B44..16B45  ; Exclusion Not_XID              # 7.0    [2] PAHAWH HMONG SIGN XAUS..PAHAWH HMONG SIGN CIM TSOV ROG
+16B5B..16B61  ; Exclusion Not_XID              # 7.0    [7] PAHAWH HMONG NUMBER TENS..PAHAWH HMONG NUMBER TRILLIONS
+16E80..16E9A  ; Exclusion Not_XID              # 11.0  [27] MEDEFAIDRIN DIGIT ZERO..MEDEFAIDRIN EXCLAMATION OH
+1BC9C         ; Exclusion Not_XID              # 7.0        DUPLOYAN SIGN O WITH CROSS
+1BC9F         ; Exclusion Not_XID              # 7.0        DUPLOYAN PUNCTUATION CHINOOK FULL STOP
+1D800..1D9FF  ; Exclusion Not_XID              # 8.0  [512] SIGNWRITING HAND-FIST INDEX..SIGNWRITING HEAD
+1DA37..1DA3A  ; Exclusion Not_XID              # 8.0    [4] SIGNWRITING AIR BLOW SMALL ROTATIONS..SIGNWRITING BREATH EXHALE
+1DA6D..1DA74  ; Exclusion Not_XID              # 8.0    [8] SIGNWRITING SHOULDER HIP SPINE..SIGNWRITING TORSO-FLOORPLANE TWISTING
+1DA76..1DA83  ; Exclusion Not_XID              # 8.0   [14] SIGNWRITING LIMB COMBINATION..SIGNWRITING LOCATION DEPTH
+1DA85..1DA8B  ; Exclusion Not_XID              # 8.0    [7] SIGNWRITING LOCATION TORSO..SIGNWRITING PARENTHESIS
+1E8C7..1E8CF  ; Exclusion Not_XID              # 7.0    [9] MENDE KIKAKUI DIGIT ONE..MENDE KIKAKUI DIGIT NINE
+
+# Total code points: 1105
+
+#	Identifier_Type:	Obsolete
+
+01B9          ; Obsolete                       # 1.1        LATIN SMALL LETTER EZH REVERSED
+01BF          ; Obsolete                       # 1.1        LATIN LETTER WYNN
+01F6..01F7    ; Obsolete                       # 3.0    [2] LATIN CAPITAL LETTER HWAIR..LATIN CAPITAL LETTER WYNN
+021C..021D    ; Obsolete                       # 3.0    [2] LATIN CAPITAL LETTER YOGH..LATIN SMALL LETTER YOGH
+0363..036F    ; Obsolete                       # 3.2   [13] COMBINING LATIN SMALL LETTER A..COMBINING LATIN SMALL LETTER X
+0370..0373    ; Obsolete                       # 5.1    [4] GREEK CAPITAL LETTER HETA..GREEK SMALL LETTER ARCHAIC SAMPI
+0376..0377    ; Obsolete                       # 5.1    [2] GREEK CAPITAL LETTER PAMPHYLIAN DIGAMMA..GREEK SMALL LETTER PAMPHYLIAN DIGAMMA
+037F          ; Obsolete                       # 7.0        GREEK CAPITAL LETTER YOT
+03D8..03D9    ; Obsolete                       # 3.2    [2] GREEK LETTER ARCHAIC KOPPA..GREEK SMALL LETTER ARCHAIC KOPPA
+03DA          ; Obsolete                       # 1.1        GREEK LETTER STIGMA
+03DB          ; Obsolete                       # 3.0        GREEK SMALL LETTER STIGMA
+03DC          ; Obsolete                       # 1.1        GREEK LETTER DIGAMMA
+03DD          ; Obsolete                       # 3.0        GREEK SMALL LETTER DIGAMMA
+03DE          ; Obsolete                       # 1.1        GREEK LETTER KOPPA
+03DF          ; Obsolete                       # 3.0        GREEK SMALL LETTER KOPPA
+03E0          ; Obsolete                       # 1.1        GREEK LETTER SAMPI
+03E1          ; Obsolete                       # 3.0        GREEK SMALL LETTER SAMPI
+03F7..03F8    ; Obsolete                       # 4.0    [2] GREEK CAPITAL LETTER SHO..GREEK SMALL LETTER SHO
+03FA..03FB    ; Obsolete                       # 4.0    [2] GREEK CAPITAL LETTER SAN..GREEK SMALL LETTER SAN
+0460..0481    ; Obsolete                       # 1.1   [34] CYRILLIC CAPITAL LETTER OMEGA..CYRILLIC SMALL LETTER KOPPA
+0483          ; Obsolete                       # 1.1        COMBINING CYRILLIC TITLO
+0500..050F    ; Obsolete                       # 3.2   [16] CYRILLIC CAPITAL LETTER KOMI DE..CYRILLIC SMALL LETTER KOMI TJE
+052A..052D    ; Obsolete                       # 7.0    [4] CYRILLIC CAPITAL LETTER DZZHE..CYRILLIC SMALL LETTER DCHE
+0640          ; Obsolete                       # 1.1        ARABIC TATWEEL
+066E..066F    ; Obsolete                       # 3.2    [2] ARABIC LETTER DOTLESS BEH..ARABIC LETTER DOTLESS QAF
+068E          ; Obsolete                       # 1.1        ARABIC LETTER DUL
+06A1          ; Obsolete                       # 1.1        ARABIC LETTER DOTLESS FEH
+08AD..08B1    ; Obsolete                       # 7.0    [5] ARABIC LETTER LOW ALEF..ARABIC LETTER STRAIGHT WAW
+094E          ; Obsolete                       # 5.2        DEVANAGARI VOWEL SIGN PRISHTHAMATRA E
+0951..0952    ; Obsolete                       # 1.1    [2] DEVANAGARI STRESS SIGN UDATTA..DEVANAGARI STRESS SIGN ANUDATTA
+0978          ; Obsolete                       # 7.0        DEVANAGARI LETTER MARWARI DDA
+0980          ; Obsolete                       # 7.0        BENGALI ANJI
+09FC          ; Obsolete                       # 10.0       BENGALI LETTER VEDIC ANUSVARA
+0C00          ; Obsolete                       # 7.0        TELUGU SIGN COMBINING CANDRABINDU ABOVE
+0C34          ; Obsolete                       # 7.0        TELUGU LETTER LLLA
+0C58..0C59    ; Obsolete                       # 5.1    [2] TELUGU LETTER TSA..TELUGU LETTER DZA
+0C81          ; Obsolete                       # 7.0        KANNADA SIGN CANDRABINDU
+0CDE          ; Obsolete                       # 1.1        KANNADA LETTER FA
+0D01          ; Obsolete                       # 7.0        MALAYALAM SIGN CANDRABINDU
+0D3B..0D3C    ; Obsolete                       # 10.0   [2] MALAYALAM SIGN VERTICAL BAR VIRAMA..MALAYALAM SIGN CIRCULAR VIRAMA
+0D5F          ; Obsolete                       # 8.0        MALAYALAM LETTER ARCHAIC II
+0DE6..0DEF    ; Obsolete                       # 7.0   [10] SINHALA LITH DIGIT ZERO..SINHALA LITH DIGIT NINE
+10A0..10C5    ; Obsolete                       # 1.1   [38] GEORGIAN CAPITAL LETTER AN..GEORGIAN CAPITAL LETTER HOE
+10F1..10F6    ; Obsolete                       # 1.1    [6] GEORGIAN LETTER HE..GEORGIAN LETTER FI
+1100..1159    ; Obsolete                       # 1.1   [90] HANGUL CHOSEONG KIYEOK..HANGUL CHOSEONG YEORINHIEUH
+115A..115E    ; Obsolete                       # 5.2    [5] HANGUL CHOSEONG KIYEOK-TIKEUT..HANGUL CHOSEONG TIKEUT-RIEUL
+1161..11A2    ; Obsolete                       # 1.1   [66] HANGUL JUNGSEONG A..HANGUL JUNGSEONG SSANGARAEA
+11A3..11A7    ; Obsolete                       # 5.2    [5] HANGUL JUNGSEONG A-EU..HANGUL JUNGSEONG O-YAE
+11A8..11F9    ; Obsolete                       # 1.1   [82] HANGUL JONGSEONG KIYEOK..HANGUL JONGSEONG YEORINHIEUH
+11FA..11FF    ; Obsolete                       # 5.2    [6] HANGUL JONGSEONG KIYEOK-NIEUN..HANGUL JONGSEONG SSANGNIEUN
+1369..1371    ; Obsolete                       # 3.0    [9] ETHIOPIC DIGIT ONE..ETHIOPIC DIGIT NINE
+17A8          ; Obsolete                       # 3.0        KHMER INDEPENDENT VOWEL QUK
+17D3          ; Obsolete                       # 3.0        KHMER SIGN BATHAMASAT
+1AB0..1ABD    ; Obsolete                       # 7.0   [14] COMBINING DOUBLED CIRCUMFLEX ACCENT..COMBINING PARENTHESES BELOW
+1C80..1C88    ; Obsolete                       # 9.0    [9] CYRILLIC SMALL LETTER ROUNDED VE..CYRILLIC SMALL LETTER UNBLENDED UK
+1CD0..1CD2    ; Obsolete                       # 5.2    [3] VEDIC TONE KARSHANA..VEDIC TONE PRENKHA
+1CD4..1CF2    ; Obsolete                       # 5.2   [31] VEDIC SIGN YAJURVEDIC MIDLINE SVARITA..VEDIC SIGN ARDHAVISARGA
+1CF3..1CF6    ; Obsolete                       # 6.1    [4] VEDIC SIGN ROTATED ARDHAVISARGA..VEDIC SIGN UPADHMANIYA
+1CF7          ; Obsolete                       # 10.0       VEDIC SIGN ATIKRAMA
+1CF8..1CF9    ; Obsolete                       # 7.0    [2] VEDIC TONE RING ABOVE..VEDIC TONE DOUBLE RING ABOVE
+2132          ; Obsolete                       # 1.1        TURNED CAPITAL F
+214E          ; Obsolete                       # 5.0        TURNED SMALL F
+2184          ; Obsolete                       # 5.0        LATIN SMALL LETTER REVERSED C
+2185..2188    ; Obsolete                       # 5.1    [4] ROMAN NUMERAL SIX LATE FORM..ROMAN NUMERAL ONE HUNDRED THOUSAND
+2C6D..2C6F    ; Obsolete                       # 5.1    [3] LATIN CAPITAL LETTER ALPHA..LATIN CAPITAL LETTER TURNED A
+2C70          ; Obsolete                       # 5.2        LATIN CAPITAL LETTER TURNED ALPHA
+2C71..2C73    ; Obsolete                       # 5.1    [3] LATIN SMALL LETTER V WITH RIGHT HOOK..LATIN SMALL LETTER W WITH HOOK
+2C74..2C76    ; Obsolete                       # 5.0    [3] LATIN SMALL LETTER V WITH CURL..LATIN SMALL LETTER HALF H
+2C7E..2C7F    ; Obsolete                       # 5.2    [2] LATIN CAPITAL LETTER S WITH SWASH TAIL..LATIN CAPITAL LETTER Z WITH SWASH TAIL
+2D00..2D25    ; Obsolete                       # 4.1   [38] GEORGIAN SMALL LETTER AN..GEORGIAN SMALL LETTER HOE
+2DE0..2DFF    ; Obsolete                       # 5.1   [32] COMBINING CYRILLIC LETTER BE..COMBINING CYRILLIC LETTER IOTIFIED BIG YUS
+312E          ; Obsolete                       # 10.0       BOPOMOFO LETTER O WITH DOT ABOVE
+31F0..31FF    ; Obsolete                       # 3.2   [16] KATAKANA LETTER SMALL KU..KATAKANA LETTER SMALL RO
+A640..A65F    ; Obsolete                       # 5.1   [32] CYRILLIC CAPITAL LETTER ZEMLYA..CYRILLIC SMALL LETTER YN
+A660..A661    ; Obsolete                       # 6.0    [2] CYRILLIC CAPITAL LETTER REVERSED TSE..CYRILLIC SMALL LETTER REVERSED TSE
+A662..A66E    ; Obsolete                       # 5.1   [13] CYRILLIC CAPITAL LETTER SOFT DE..CYRILLIC LETTER MULTIOCULAR O
+A674..A67B    ; Obsolete                       # 6.1    [8] COMBINING CYRILLIC LETTER UKRAINIAN IE..COMBINING CYRILLIC LETTER OMEGA
+A680..A697    ; Obsolete                       # 5.1   [24] CYRILLIC CAPITAL LETTER DWE..CYRILLIC SMALL LETTER SHWE
+A698..A69B    ; Obsolete                       # 7.0    [4] CYRILLIC CAPITAL LETTER DOUBLE O..CYRILLIC SMALL LETTER CROSSED O
+A69F          ; Obsolete                       # 6.1        COMBINING CYRILLIC LETTER IOTIFIED E
+A730..A76F    ; Obsolete                       # 5.1   [64] LATIN LETTER SMALL CAPITAL F..LATIN SMALL LETTER CON
+A771..A787    ; Obsolete                       # 5.1   [23] LATIN SMALL LETTER DUM..LATIN SMALL LETTER INSULAR T
+A790..A791    ; Obsolete                       # 6.0    [2] LATIN CAPITAL LETTER N WITH DESCENDER..LATIN SMALL LETTER N WITH DESCENDER
+A794..A79F    ; Obsolete                       # 7.0   [12] LATIN SMALL LETTER C WITH PALATAL HOOK..LATIN SMALL LETTER VOLAPUK UE
+A7A0..A7A9    ; Obsolete                       # 6.0   [10] LATIN CAPITAL LETTER G WITH OBLIQUE STROKE..LATIN SMALL LETTER S WITH OBLIQUE STROKE
+A7AB..A7AD    ; Obsolete                       # 7.0    [3] LATIN CAPITAL LETTER REVERSED OPEN E..LATIN CAPITAL LETTER L WITH BELT
+A7B0..A7B1    ; Obsolete                       # 7.0    [2] LATIN CAPITAL LETTER TURNED K..LATIN CAPITAL LETTER TURNED T
+A7F5..A7F6    ; Obsolete                       # 13.0   [2] LATIN CAPITAL LETTER REVERSED HALF H..LATIN SMALL LETTER REVERSED HALF H
+A7F7          ; Obsolete                       # 7.0        LATIN EPIGRAPHIC LETTER SIDEWAYS I
+A7FB..A7FF    ; Obsolete                       # 5.1    [5] LATIN EPIGRAPHIC LETTER REVERSED F..LATIN EPIGRAPHIC LETTER ARCHAIC M
+A8E0..A8F7    ; Obsolete                       # 5.2   [24] COMBINING DEVANAGARI DIGIT ZERO..DEVANAGARI SIGN CANDRABINDU AVAGRAHA
+A8FB          ; Obsolete                       # 5.2        DEVANAGARI HEADSTROKE
+A8FE..A8FF    ; Obsolete                       # 11.0   [2] DEVANAGARI LETTER AY..DEVANAGARI VOWEL SIGN AY
+A960..A97C    ; Obsolete                       # 5.2   [29] HANGUL CHOSEONG TIKEUT-MIEUM..HANGUL CHOSEONG SSANGYEORINHIEUH
+A9E0..A9E6    ; Obsolete                       # 7.0    [7] MYANMAR LETTER SHAN GHA..MYANMAR MODIFIER LETTER SHAN REDUPLICATION
+AB30..AB5A    ; Obsolete                       # 7.0   [43] LATIN SMALL LETTER BARRED ALPHA..LATIN SMALL LETTER Y WITH SHORT RIGHT LEG
+AB64..AB65    ; Obsolete                       # 7.0    [2] LATIN SMALL LETTER INVERTED ALPHA..GREEK LETTER SMALL CAPITAL OMEGA
+D7B0..D7C6    ; Obsolete                       # 5.2   [23] HANGUL JUNGSEONG O-YEO..HANGUL JUNGSEONG ARAEA-E
+D7CB..D7FB    ; Obsolete                       # 5.2   [49] HANGUL JONGSEONG NIEUN-RIEUL..HANGUL JONGSEONG PHIEUPH-THIEUTH
+10140..10174  ; Obsolete                       # 4.1   [53] GREEK ACROPHONIC ATTIC ONE QUARTER..GREEK ACROPHONIC STRATIAN FIFTY MNAS
+101FD         ; Obsolete                       # 5.1        PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE
+102E0         ; Obsolete                       # 7.0        COPTIC EPACT THOUSANDS MARK
+16FE3         ; Obsolete                       # 12.0       OLD CHINESE ITERATION MARK
+1B000..1B001  ; Obsolete                       # 6.0    [2] KATAKANA LETTER ARCHAIC E..HIRAGANA LETTER ARCHAIC YE
+1B002..1B11E  ; Obsolete                       # 10.0 [285] HENTAIGANA LETTER A-1..HENTAIGANA LETTER N-MU-MO-2
+
+# Total code points: 1341
+
+#	Identifier_Type:	Obsolete Not_XID
+
+0482          ; Obsolete Not_XID               # 1.1        CYRILLIC THOUSANDS SIGN
+0488..0489    ; Obsolete Not_XID               # 3.0    [2] COMBINING CYRILLIC HUNDRED THOUSANDS SIGN..COMBINING CYRILLIC MILLIONS SIGN
+05C6          ; Obsolete Not_XID               # 4.1        HEBREW PUNCTUATION NUN HAFUKHA
+17D8          ; Obsolete Not_XID               # 3.0        KHMER SIGN BEYYAL
+1CD3          ; Obsolete Not_XID               # 5.2        VEDIC SIGN NIHSHVASA
+2056          ; Obsolete Not_XID               # 4.1        THREE DOT PUNCTUATION
+2058..205E    ; Obsolete Not_XID               # 4.1    [7] FOUR DOT PUNCTUATION..VERTICAL FOUR DOTS
+2127          ; Obsolete Not_XID               # 1.1        INVERTED OHM SIGN
+214F          ; Obsolete Not_XID               # 5.1        SYMBOL FOR SAMARITAN SOURCE
+2E0E..2E16    ; Obsolete Not_XID               # 4.1    [9] EDITORIAL CORONIS..DOTTED RIGHT-POINTING ANGLE
+2E2A..2E30    ; Obsolete Not_XID               # 5.1    [7] TWO DOTS OVER ONE DOT PUNCTUATION..RING POINT
+2E31          ; Obsolete Not_XID               # 5.2        WORD SEPARATOR MIDDLE DOT
+2E32          ; Obsolete Not_XID               # 6.1        TURNED COMMA
+2E35          ; Obsolete Not_XID               # 6.1        TURNED SEMICOLON
+2E39          ; Obsolete Not_XID               # 6.1        TOP HALF SECTION SIGN
+301E          ; Obsolete Not_XID               # 1.1        DOUBLE PRIME QUOTATION MARK
+A670..A673    ; Obsolete Not_XID               # 5.1    [4] COMBINING CYRILLIC TEN MILLIONS SIGN..SLAVONIC ASTERISK
+A700..A707    ; Obsolete Not_XID               # 4.1    [8] MODIFIER LETTER CHINESE TONE YIN PING..MODIFIER LETTER CHINESE TONE YANG RU
+A8F8..A8FA    ; Obsolete Not_XID               # 5.2    [3] DEVANAGARI SIGN PUSHPIKA..DEVANAGARI CARET
+101D0..101FC  ; Obsolete Not_XID               # 5.1   [45] PHAISTOS DISC SIGN PEDESTRIAN..PHAISTOS DISC SIGN WAVY BAND
+102E1..102FB  ; Obsolete Not_XID               # 7.0   [27] COPTIC EPACT DIGIT ONE..COPTIC EPACT NUMBER NINE HUNDRED
+1D200..1D241  ; Obsolete Not_XID               # 4.1   [66] GREEK VOCAL NOTATION SYMBOL-1..GREEK INSTRUMENTAL NOTATION SYMBOL-54
+1D245         ; Obsolete Not_XID               # 4.1        GREEK MUSICAL LEIMMA
+
+# Total code points: 191
+
+#	Identifier_Type:	Not_XID
+
+0009..000D    ; Not_XID                        # 1.1    [5] <control-0009>..<control-000D>
+0020..0026    ; Not_XID                        # 1.1    [7] SPACE..AMPERSAND
+0028..002C    ; Not_XID                        # 1.1    [5] LEFT PARENTHESIS..COMMA
+002F          ; Not_XID                        # 1.1        SOLIDUS
+003B..0040    ; Not_XID                        # 1.1    [6] SEMICOLON..COMMERCIAL AT
+005B..005E    ; Not_XID                        # 1.1    [4] LEFT SQUARE BRACKET..CIRCUMFLEX ACCENT
+0060          ; Not_XID                        # 1.1        GRAVE ACCENT
+007B..007E    ; Not_XID                        # 1.1    [4] LEFT CURLY BRACKET..TILDE
+0085          ; Not_XID                        # 1.1        <control-0085>
+00A1..00A7    ; Not_XID                        # 1.1    [7] INVERTED EXCLAMATION MARK..SECTION SIGN
+00A9          ; Not_XID                        # 1.1        COPYRIGHT SIGN
+00AB..00AC    ; Not_XID                        # 1.1    [2] LEFT-POINTING DOUBLE ANGLE QUOTATION MARK..NOT SIGN
+00AE          ; Not_XID                        # 1.1        REGISTERED SIGN
+00B0..00B1    ; Not_XID                        # 1.1    [2] DEGREE SIGN..PLUS-MINUS SIGN
+00B6          ; Not_XID                        # 1.1        PILCROW SIGN
+00BB          ; Not_XID                        # 1.1        RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+00BF          ; Not_XID                        # 1.1        INVERTED QUESTION MARK
+00D7          ; Not_XID                        # 1.1        MULTIPLICATION SIGN
+00F7          ; Not_XID                        # 1.1        DIVISION SIGN
+02C2..02C5    ; Not_XID                        # 1.1    [4] MODIFIER LETTER LEFT ARROWHEAD..MODIFIER LETTER DOWN ARROWHEAD
+02D2..02D7    ; Not_XID                        # 1.1    [6] MODIFIER LETTER CENTRED RIGHT HALF RING..MODIFIER LETTER MINUS SIGN
+02DE          ; Not_XID                        # 1.1        MODIFIER LETTER RHOTIC HOOK
+02DF          ; Not_XID                        # 3.0        MODIFIER LETTER CROSS ACCENT
+02E5..02E9    ; Not_XID                        # 1.1    [5] MODIFIER LETTER EXTRA-HIGH TONE BAR..MODIFIER LETTER EXTRA-LOW TONE BAR
+02EA..02EB    ; Not_XID                        # 3.0    [2] MODIFIER LETTER YIN DEPARTING TONE MARK..MODIFIER LETTER YANG DEPARTING TONE MARK
+02ED          ; Not_XID                        # 3.0        MODIFIER LETTER UNASPIRATED
+02EF..02FF    ; Not_XID                        # 4.0   [17] MODIFIER LETTER LOW DOWN ARROWHEAD..MODIFIER LETTER LOW LEFT ARROW
+03F6          ; Not_XID                        # 3.2        GREEK REVERSED LUNATE EPSILON SYMBOL
+055A..055F    ; Not_XID                        # 1.1    [6] ARMENIAN APOSTROPHE..ARMENIAN ABBREVIATION MARK
+0589          ; Not_XID                        # 1.1        ARMENIAN FULL STOP
+058D..058E    ; Not_XID                        # 7.0    [2] RIGHT-FACING ARMENIAN ETERNITY SIGN..LEFT-FACING ARMENIAN ETERNITY SIGN
+058F          ; Not_XID                        # 6.1        ARMENIAN DRAM SIGN
+05BE          ; Not_XID                        # 1.1        HEBREW PUNCTUATION MAQAF
+05C0          ; Not_XID                        # 1.1        HEBREW PUNCTUATION PASEQ
+05C3          ; Not_XID                        # 1.1        HEBREW PUNCTUATION SOF PASUQ
+0600..0603    ; Not_XID                        # 4.0    [4] ARABIC NUMBER SIGN..ARABIC SIGN SAFHA
+0604          ; Not_XID                        # 6.1        ARABIC SIGN SAMVAT
+0605          ; Not_XID                        # 7.0        ARABIC NUMBER MARK ABOVE
+0606..060A    ; Not_XID                        # 5.1    [5] ARABIC-INDIC CUBE ROOT..ARABIC-INDIC PER TEN THOUSAND SIGN
+060B          ; Not_XID                        # 4.1        AFGHANI SIGN
+060C          ; Not_XID                        # 1.1        ARABIC COMMA
+060D..060F    ; Not_XID                        # 4.0    [3] ARABIC DATE SEPARATOR..ARABIC SIGN MISRA
+061B          ; Not_XID                        # 1.1        ARABIC SEMICOLON
+061D          ; Not_XID                        # 14.0       ARABIC END OF TEXT MARK
+061E          ; Not_XID                        # 4.1        ARABIC TRIPLE DOT PUNCTUATION MARK
+061F          ; Not_XID                        # 1.1        ARABIC QUESTION MARK
+066A..066D    ; Not_XID                        # 1.1    [4] ARABIC PERCENT SIGN..ARABIC FIVE POINTED STAR
+06D4          ; Not_XID                        # 1.1        ARABIC FULL STOP
+06DD          ; Not_XID                        # 1.1        ARABIC END OF AYAH
+06DE          ; Not_XID                        # 1.1        ARABIC START OF RUB EL HIZB
+06E9          ; Not_XID                        # 1.1        ARABIC PLACE OF SAJDAH
+0888          ; Not_XID                        # 14.0       ARABIC RAISED ROUND DOT
+0890..0891    ; Not_XID                        # 14.0   [2] ARABIC POUND MARK ABOVE..ARABIC PIASTRE MARK ABOVE
+08E2          ; Not_XID                        # 9.0        ARABIC DISPUTED END OF AYAH
+0964..0965    ; Not_XID                        # 1.1    [2] DEVANAGARI DANDA..DEVANAGARI DOUBLE DANDA
+0970          ; Not_XID                        # 1.1        DEVANAGARI ABBREVIATION SIGN
+09F2..09FA    ; Not_XID                        # 1.1    [9] BENGALI RUPEE MARK..BENGALI ISSHAR
+09FB          ; Not_XID                        # 5.2        BENGALI GANDA MARK
+09FD          ; Not_XID                        # 10.0       BENGALI ABBREVIATION SIGN
+0A76          ; Not_XID                        # 11.0       GURMUKHI ABBREVIATION SIGN
+0AF0          ; Not_XID                        # 6.1        GUJARATI ABBREVIATION SIGN
+0AF1          ; Not_XID                        # 4.0        GUJARATI RUPEE SIGN
+0B70          ; Not_XID                        # 1.1        ORIYA ISSHAR
+0B72..0B77    ; Not_XID                        # 6.0    [6] ORIYA FRACTION ONE QUARTER..ORIYA FRACTION THREE SIXTEENTHS
+0BF0..0BF2    ; Not_XID                        # 1.1    [3] TAMIL NUMBER TEN..TAMIL NUMBER ONE THOUSAND
+0BF3..0BFA    ; Not_XID                        # 4.0    [8] TAMIL DAY SIGN..TAMIL NUMBER SIGN
+0C77          ; Not_XID                        # 12.0       TELUGU SIGN SIDDHAM
+0C78..0C7F    ; Not_XID                        # 5.1    [8] TELUGU FRACTION DIGIT ZERO FOR ODD POWERS OF FOUR..TELUGU SIGN TUUMU
+0C84          ; Not_XID                        # 11.0       KANNADA SIGN SIDDHAM
+0D4F          ; Not_XID                        # 9.0        MALAYALAM SIGN PARA
+0D58..0D5E    ; Not_XID                        # 9.0    [7] MALAYALAM FRACTION ONE ONE-HUNDRED-AND-SIXTIETH..MALAYALAM FRACTION ONE FIFTH
+0D70..0D75    ; Not_XID                        # 5.1    [6] MALAYALAM NUMBER TEN..MALAYALAM FRACTION THREE QUARTERS
+0D76..0D78    ; Not_XID                        # 9.0    [3] MALAYALAM FRACTION ONE SIXTEENTH..MALAYALAM FRACTION THREE SIXTEENTHS
+0D79          ; Not_XID                        # 5.1        MALAYALAM DATE MARK
+0DF4          ; Not_XID                        # 3.0        SINHALA PUNCTUATION KUNDDALIYA
+0E3F          ; Not_XID                        # 1.1        THAI CURRENCY SYMBOL BAHT
+0E4F          ; Not_XID                        # 1.1        THAI CHARACTER FONGMAN
+0E5A..0E5B    ; Not_XID                        # 1.1    [2] THAI CHARACTER ANGKHANKHU..THAI CHARACTER KHOMUT
+0F01..0F0A    ; Not_XID                        # 2.0   [10] TIBETAN MARK GTER YIG MGO TRUNCATED A..TIBETAN MARK BKA- SHOG YIG MGO
+0F0D..0F17    ; Not_XID                        # 2.0   [11] TIBETAN MARK SHAD..TIBETAN ASTROLOGICAL SIGN SGRA GCAN -CHAR RTAGS
+0F1A..0F1F    ; Not_XID                        # 2.0    [6] TIBETAN SIGN RDEL DKAR GCIG..TIBETAN SIGN RDEL DKAR RDEL NAG
+0F2A..0F34    ; Not_XID                        # 2.0   [11] TIBETAN DIGIT HALF ONE..TIBETAN MARK BSDUS RTAGS
+0F36          ; Not_XID                        # 2.0        TIBETAN MARK CARET -DZUD RTAGS BZHI MIG CAN
+0F38          ; Not_XID                        # 2.0        TIBETAN MARK CHE MGO
+0F3A..0F3D    ; Not_XID                        # 2.0    [4] TIBETAN MARK GUG RTAGS GYON..TIBETAN MARK ANG KHANG GYAS
+0F85          ; Not_XID                        # 2.0        TIBETAN MARK PALUTA
+0FBE..0FC5    ; Not_XID                        # 3.0    [8] TIBETAN KU RU KHA..TIBETAN SYMBOL RDO RJE
+0FC7..0FCC    ; Not_XID                        # 3.0    [6] TIBETAN SYMBOL RDO RJE RGYA GRAM..TIBETAN SYMBOL NOR BU BZHI -KHYIL
+0FCE          ; Not_XID                        # 5.1        TIBETAN SIGN RDEL NAG RDEL DKAR
+0FCF          ; Not_XID                        # 3.0        TIBETAN SIGN RDEL NAG GSUM
+0FD0..0FD1    ; Not_XID                        # 4.1    [2] TIBETAN MARK BSKA- SHOG GI MGO RGYAN..TIBETAN MARK MNYAM YIG GI MGO RGYAN
+0FD2..0FD4    ; Not_XID                        # 5.1    [3] TIBETAN MARK NYIS TSHEG..TIBETAN MARK CLOSING BRDA RNYING YIG MGO SGAB MA
+0FD5..0FD8    ; Not_XID                        # 5.2    [4] RIGHT-FACING SVASTI SIGN..LEFT-FACING SVASTI SIGN WITH DOTS
+0FD9..0FDA    ; Not_XID                        # 6.0    [2] TIBETAN MARK LEADING MCHAN RTAGS..TIBETAN MARK TRAILING MCHAN RTAGS
+104A..104F    ; Not_XID                        # 3.0    [6] MYANMAR SIGN LITTLE SECTION..MYANMAR SYMBOL GENITIVE
+109E..109F    ; Not_XID                        # 5.1    [2] MYANMAR SYMBOL SHAN ONE..MYANMAR SYMBOL SHAN EXCLAMATION
+10FB          ; Not_XID                        # 1.1        GEORGIAN PARAGRAPH SEPARATOR
+1360          ; Not_XID                        # 4.1        ETHIOPIC SECTION MARK
+1361..1368    ; Not_XID                        # 3.0    [8] ETHIOPIC WORDSPACE..ETHIOPIC PARAGRAPH SEPARATOR
+1372..137C    ; Not_XID                        # 3.0   [11] ETHIOPIC NUMBER TEN..ETHIOPIC NUMBER TEN THOUSAND
+1390..1399    ; Not_XID                        # 4.1   [10] ETHIOPIC TONAL MARK YIZET..ETHIOPIC TONAL MARK KURT
+16EB..16ED    ; Not_XID                        # 3.0    [3] RUNIC SINGLE PUNCTUATION..RUNIC CROSS PUNCTUATION
+17D4..17D6    ; Not_XID                        # 3.0    [3] KHMER SIGN KHAN..KHMER SIGN CAMNUC PII KUUH
+17D9..17DB    ; Not_XID                        # 3.0    [3] KHMER SIGN PHNAEK MUAN..KHMER CURRENCY SYMBOL RIEL
+17F0..17F9    ; Not_XID                        # 4.0   [10] KHMER SYMBOL LEK ATTAK SON..KHMER SYMBOL LEK ATTAK PRAM-BUON
+19E0..19FF    ; Not_XID                        # 4.0   [32] KHMER SYMBOL PATHAMASAT..KHMER SYMBOL DAP-PRAM ROC
+1ABE          ; Not_XID                        # 7.0        COMBINING PARENTHESES OVERLAY
+2012..2016    ; Not_XID                        # 1.1    [5] FIGURE DASH..DOUBLE VERTICAL LINE
+2018          ; Not_XID                        # 1.1        LEFT SINGLE QUOTATION MARK
+201A..2023    ; Not_XID                        # 1.1   [10] SINGLE LOW-9 QUOTATION MARK..TRIANGULAR BULLET
+2028..2029    ; Not_XID                        # 1.1    [2] LINE SEPARATOR..PARAGRAPH SEPARATOR
+2030..2032    ; Not_XID                        # 1.1    [3] PER MILLE SIGN..PRIME
+2035          ; Not_XID                        # 1.1        REVERSED PRIME
+2038..203B    ; Not_XID                        # 1.1    [4] CARET..REFERENCE MARK
+203D          ; Not_XID                        # 1.1        INTERROBANG
+2041..2046    ; Not_XID                        # 1.1    [6] CARET INSERTION POINT..RIGHT SQUARE BRACKET WITH QUILL
+204A..204D    ; Not_XID                        # 3.0    [4] TIRONIAN SIGN ET..BLACK RIGHTWARDS BULLET
+204E..2052    ; Not_XID                        # 3.2    [5] LOW ASTERISK..COMMERCIAL MINUS SIGN
+2053          ; Not_XID                        # 4.0        SWUNG DASH
+2055          ; Not_XID                        # 4.1        FLOWER PUNCTUATION MARK
+20A0..20A7    ; Not_XID                        # 1.1    [8] EURO-CURRENCY SIGN..PESETA SIGN
+20A9..20AA    ; Not_XID                        # 1.1    [2] WON SIGN..NEW SHEQEL SIGN
+20AB          ; Not_XID                        # 2.0        DONG SIGN
+20AC          ; Not_XID                        # 2.1        EURO SIGN
+20AD..20AF    ; Not_XID                        # 3.0    [3] KIP SIGN..DRACHMA SIGN
+20B0..20B1    ; Not_XID                        # 3.2    [2] GERMAN PENNY SIGN..PESO SIGN
+20B2..20B5    ; Not_XID                        # 4.1    [4] GUARANI SIGN..CEDI SIGN
+20B6..20B8    ; Not_XID                        # 5.2    [3] LIVRE TOURNOIS SIGN..TENGE SIGN
+20B9          ; Not_XID                        # 6.0        INDIAN RUPEE SIGN
+20BA          ; Not_XID                        # 6.2        TURKISH LIRA SIGN
+20BB..20BD    ; Not_XID                        # 7.0    [3] NORDIC MARK SIGN..RUBLE SIGN
+20BE          ; Not_XID                        # 8.0        LARI SIGN
+20BF          ; Not_XID                        # 10.0       BITCOIN SIGN
+20C0          ; Not_XID                        # 14.0       SOM SIGN
+2104          ; Not_XID                        # 1.1        CENTRE LINE SYMBOL
+2108          ; Not_XID                        # 1.1        SCRUPLE
+2114          ; Not_XID                        # 1.1        L B BAR SYMBOL
+2117          ; Not_XID                        # 1.1        SOUND RECORDING COPYRIGHT
+211E..211F    ; Not_XID                        # 1.1    [2] PRESCRIPTION TAKE..RESPONSE
+2123          ; Not_XID                        # 1.1        VERSICLE
+2125          ; Not_XID                        # 1.1        OUNCE SIGN
+2129          ; Not_XID                        # 1.1        TURNED GREEK SMALL LETTER IOTA
+213A          ; Not_XID                        # 3.0        ROTATED CAPITAL Q
+2141..2144    ; Not_XID                        # 3.2    [4] TURNED SANS-SERIF CAPITAL G..TURNED SANS-SERIF CAPITAL Y
+214A..214B    ; Not_XID                        # 3.2    [2] PROPERTY LINE..TURNED AMPERSAND
+214C          ; Not_XID                        # 4.1        PER SIGN
+214D          ; Not_XID                        # 5.0        AKTIESELSKAB
+2190..21EA    ; Not_XID                        # 1.1   [91] LEFTWARDS ARROW..UPWARDS WHITE ARROW FROM BAR
+21EB..21F3    ; Not_XID                        # 3.0    [9] UPWARDS WHITE ARROW ON PEDESTAL..UP DOWN WHITE ARROW
+21F4..21FF    ; Not_XID                        # 3.2   [12] RIGHT ARROW WITH SMALL CIRCLE..LEFT RIGHT OPEN-HEADED ARROW
+2200..222B    ; Not_XID                        # 1.1   [44] FOR ALL..INTEGRAL
+222E          ; Not_XID                        # 1.1        CONTOUR INTEGRAL
+2231..22F1    ; Not_XID                        # 1.1  [193] CLOCKWISE INTEGRAL..DOWN RIGHT DIAGONAL ELLIPSIS
+22F2..22FF    ; Not_XID                        # 3.2   [14] ELEMENT OF WITH LONG HORIZONTAL STROKE..Z NOTATION BAG MEMBERSHIP
+2300          ; Not_XID                        # 1.1        DIAMETER SIGN
+2301          ; Not_XID                        # 3.0        ELECTRIC ARROW
+2302..2328    ; Not_XID                        # 1.1   [39] HOUSE..KEYBOARD
+232B..237A    ; Not_XID                        # 1.1   [80] ERASE TO THE LEFT..APL FUNCTIONAL SYMBOL ALPHA
+237B          ; Not_XID                        # 3.0        NOT CHECK MARK
+237C          ; Not_XID                        # 3.2        RIGHT ANGLE WITH DOWNWARDS ZIGZAG ARROW
+237D..239A    ; Not_XID                        # 3.0   [30] SHOULDERED OPEN BOX..CLEAR SCREEN SYMBOL
+239B..23CE    ; Not_XID                        # 3.2   [52] LEFT PARENTHESIS UPPER HOOK..RETURN SYMBOL
+23CF..23D0    ; Not_XID                        # 4.0    [2] EJECT SYMBOL..VERTICAL LINE EXTENSION
+23D1..23DB    ; Not_XID                        # 4.1   [11] METRICAL BREVE..FUSE
+23DC..23E7    ; Not_XID                        # 5.0   [12] TOP PARENTHESIS..ELECTRICAL INTERSECTION
+23E8          ; Not_XID                        # 5.2        DECIMAL EXPONENT SYMBOL
+23E9..23F3    ; Not_XID                        # 6.0   [11] BLACK RIGHT-POINTING DOUBLE TRIANGLE..HOURGLASS WITH FLOWING SAND
+23F4..23FA    ; Not_XID                        # 7.0    [7] BLACK MEDIUM LEFT-POINTING TRIANGLE..BLACK CIRCLE FOR RECORD
+23FB..23FE    ; Not_XID                        # 9.0    [4] POWER SYMBOL..POWER SLEEP SYMBOL
+23FF          ; Not_XID                        # 10.0       OBSERVER EYE SYMBOL
+2400..2424    ; Not_XID                        # 1.1   [37] SYMBOL FOR NULL..SYMBOL FOR NEWLINE
+2425..2426    ; Not_XID                        # 3.0    [2] SYMBOL FOR DELETE FORM TWO..SYMBOL FOR SUBSTITUTE FORM TWO
+2440..244A    ; Not_XID                        # 1.1   [11] OCR HOOK..OCR DOUBLE BACKSLASH
+2500..2595    ; Not_XID                        # 1.1  [150] BOX DRAWINGS LIGHT HORIZONTAL..RIGHT ONE EIGHTH BLOCK
+2596..259F    ; Not_XID                        # 3.2   [10] QUADRANT LOWER LEFT..QUADRANT UPPER RIGHT AND LOWER LEFT AND LOWER RIGHT
+25A0..25EF    ; Not_XID                        # 1.1   [80] BLACK SQUARE..LARGE CIRCLE
+25F0..25F7    ; Not_XID                        # 3.0    [8] WHITE SQUARE WITH UPPER LEFT QUADRANT..WHITE CIRCLE WITH UPPER RIGHT QUADRANT
+25F8..25FF    ; Not_XID                        # 3.2    [8] UPPER LEFT TRIANGLE..LOWER RIGHT TRIANGLE
+2600..2613    ; Not_XID                        # 1.1   [20] BLACK SUN WITH RAYS..SALTIRE
+2614..2615    ; Not_XID                        # 4.0    [2] UMBRELLA WITH RAIN DROPS..HOT BEVERAGE
+2616..2617    ; Not_XID                        # 3.2    [2] WHITE SHOGI PIECE..BLACK SHOGI PIECE
+2618          ; Not_XID                        # 4.1        SHAMROCK
+2619          ; Not_XID                        # 3.0        REVERSED ROTATED FLORAL HEART BULLET
+261A..266F    ; Not_XID                        # 1.1   [86] BLACK LEFT POINTING INDEX..MUSIC SHARP SIGN
+2670..2671    ; Not_XID                        # 3.0    [2] WEST SYRIAC CROSS..EAST SYRIAC CROSS
+2672..267D    ; Not_XID                        # 3.2   [12] UNIVERSAL RECYCLING SYMBOL..PARTIALLY-RECYCLED PAPER SYMBOL
+267E..267F    ; Not_XID                        # 4.1    [2] PERMANENT PAPER SIGN..WHEELCHAIR SYMBOL
+2680..2689    ; Not_XID                        # 3.2   [10] DIE FACE-1..BLACK CIRCLE WITH TWO WHITE DOTS
+268A..2691    ; Not_XID                        # 4.0    [8] MONOGRAM FOR YANG..BLACK FLAG
+2692..269C    ; Not_XID                        # 4.1   [11] HAMMER AND PICK..FLEUR-DE-LIS
+269D          ; Not_XID                        # 5.1        OUTLINED WHITE STAR
+269E..269F    ; Not_XID                        # 5.2    [2] THREE LINES CONVERGING RIGHT..THREE LINES CONVERGING LEFT
+26A0..26A1    ; Not_XID                        # 4.0    [2] WARNING SIGN..HIGH VOLTAGE SIGN
+26A2..26B1    ; Not_XID                        # 4.1   [16] DOUBLED FEMALE SIGN..FUNERAL URN
+26B2          ; Not_XID                        # 5.0        NEUTER
+26B3..26BC    ; Not_XID                        # 5.1   [10] CERES..SESQUIQUADRATE
+26BD..26BF    ; Not_XID                        # 5.2    [3] SOCCER BALL..SQUARED KEY
+26C0..26C3    ; Not_XID                        # 5.1    [4] WHITE DRAUGHTS MAN..BLACK DRAUGHTS KING
+26C4..26CD    ; Not_XID                        # 5.2   [10] SNOWMAN WITHOUT SNOW..DISABLED CAR
+26CE          ; Not_XID                        # 6.0        OPHIUCHUS
+26CF..26E1    ; Not_XID                        # 5.2   [19] PICK..RESTRICTED LEFT ENTRY-2
+26E2          ; Not_XID                        # 6.0        ASTRONOMICAL SYMBOL FOR URANUS
+26E3          ; Not_XID                        # 5.2        HEAVY CIRCLE WITH STROKE AND TWO DOTS ABOVE
+26E4..26E7    ; Not_XID                        # 6.0    [4] PENTAGRAM..INVERTED PENTAGRAM
+26E8..26FF    ; Not_XID                        # 5.2   [24] BLACK CROSS ON SHIELD..WHITE FLAG WITH HORIZONTAL MIDDLE BLACK STRIPE
+2700          ; Not_XID                        # 7.0        BLACK SAFETY SCISSORS
+2701..2704    ; Not_XID                        # 1.1    [4] UPPER BLADE SCISSORS..WHITE SCISSORS
+2705          ; Not_XID                        # 6.0        WHITE HEAVY CHECK MARK
+2706..2709    ; Not_XID                        # 1.1    [4] TELEPHONE LOCATION SIGN..ENVELOPE
+270A..270B    ; Not_XID                        # 6.0    [2] RAISED FIST..RAISED HAND
+270C..2727    ; Not_XID                        # 1.1   [28] VICTORY HAND..WHITE FOUR POINTED STAR
+2728          ; Not_XID                        # 6.0        SPARKLES
+2729..274B    ; Not_XID                        # 1.1   [35] STRESS OUTLINED WHITE STAR..HEAVY EIGHT TEARDROP-SPOKED PROPELLER ASTERISK
+274C          ; Not_XID                        # 6.0        CROSS MARK
+274D          ; Not_XID                        # 1.1        SHADOWED WHITE CIRCLE
+274E          ; Not_XID                        # 6.0        NEGATIVE SQUARED CROSS MARK
+274F..2752    ; Not_XID                        # 1.1    [4] LOWER RIGHT DROP-SHADOWED WHITE SQUARE..UPPER RIGHT SHADOWED WHITE SQUARE
+2753..2755    ; Not_XID                        # 6.0    [3] BLACK QUESTION MARK ORNAMENT..WHITE EXCLAMATION MARK ORNAMENT
+2756          ; Not_XID                        # 1.1        BLACK DIAMOND MINUS WHITE X
+2757          ; Not_XID                        # 5.2        HEAVY EXCLAMATION MARK SYMBOL
+2758..275E    ; Not_XID                        # 1.1    [7] LIGHT VERTICAL BAR..HEAVY DOUBLE COMMA QUOTATION MARK ORNAMENT
+275F..2760    ; Not_XID                        # 6.0    [2] HEAVY LOW SINGLE COMMA QUOTATION MARK ORNAMENT..HEAVY LOW DOUBLE COMMA QUOTATION MARK ORNAMENT
+2761..2767    ; Not_XID                        # 1.1    [7] CURVED STEM PARAGRAPH SIGN ORNAMENT..ROTATED FLORAL HEART BULLET
+2768..2775    ; Not_XID                        # 3.2   [14] MEDIUM LEFT PARENTHESIS ORNAMENT..MEDIUM RIGHT CURLY BRACKET ORNAMENT
+2776..2794    ; Not_XID                        # 1.1   [31] DINGBAT NEGATIVE CIRCLED DIGIT ONE..HEAVY WIDE-HEADED RIGHTWARDS ARROW
+2795..2797    ; Not_XID                        # 6.0    [3] HEAVY PLUS SIGN..HEAVY DIVISION SIGN
+2798..27AF    ; Not_XID                        # 1.1   [24] HEAVY SOUTH EAST ARROW..NOTCHED LOWER RIGHT-SHADOWED WHITE RIGHTWARDS ARROW
+27B0          ; Not_XID                        # 6.0        CURLY LOOP
+27B1..27BE    ; Not_XID                        # 1.1   [14] NOTCHED UPPER RIGHT-SHADOWED WHITE RIGHTWARDS ARROW..OPEN-OUTLINED RIGHTWARDS ARROW
+27BF          ; Not_XID                        # 6.0        DOUBLE CURLY LOOP
+27C0..27C6    ; Not_XID                        # 4.1    [7] THREE DIMENSIONAL ANGLE..RIGHT S-SHAPED BAG DELIMITER
+27C7..27CA    ; Not_XID                        # 5.0    [4] OR WITH DOT INSIDE..VERTICAL BAR WITH HORIZONTAL STROKE
+27CB          ; Not_XID                        # 6.1        MATHEMATICAL RISING DIAGONAL
+27CC          ; Not_XID                        # 5.1        LONG DIVISION
+27CD          ; Not_XID                        # 6.1        MATHEMATICAL FALLING DIAGONAL
+27CE..27CF    ; Not_XID                        # 6.0    [2] SQUARED LOGICAL AND..SQUARED LOGICAL OR
+27D0..27EB    ; Not_XID                        # 3.2   [28] WHITE DIAMOND WITH CENTRED DOT..MATHEMATICAL RIGHT DOUBLE ANGLE BRACKET
+27EC..27EF    ; Not_XID                        # 5.1    [4] MATHEMATICAL LEFT WHITE TORTOISE SHELL BRACKET..MATHEMATICAL RIGHT FLATTENED PARENTHESIS
+27F0..27FF    ; Not_XID                        # 3.2   [16] UPWARDS QUADRUPLE ARROW..LONG RIGHTWARDS SQUIGGLE ARROW
+2900..2A0B    ; Not_XID                        # 3.2  [268] RIGHTWARDS TWO-HEADED ARROW WITH VERTICAL STROKE..SUMMATION WITH INTEGRAL
+2A0D..2A73    ; Not_XID                        # 3.2  [103] FINITE PART INTEGRAL..EQUALS SIGN ABOVE TILDE OPERATOR
+2A77..2ADB    ; Not_XID                        # 3.2  [101] EQUALS SIGN WITH TWO DOTS ABOVE AND TWO DOTS BELOW..TRANSVERSAL INTERSECTION
+2ADD..2AFF    ; Not_XID                        # 3.2   [35] NONFORKING..N-ARY WHITE VERTICAL BAR
+2B00..2B0D    ; Not_XID                        # 4.0   [14] NORTH EAST WHITE ARROW..UP DOWN BLACK ARROW
+2B0E..2B13    ; Not_XID                        # 4.1    [6] RIGHTWARDS ARROW WITH TIP DOWNWARDS..SQUARE WITH BOTTOM HALF BLACK
+2B14..2B1A    ; Not_XID                        # 5.0    [7] SQUARE WITH UPPER RIGHT DIAGONAL HALF BLACK..DOTTED SQUARE
+2B1B..2B1F    ; Not_XID                        # 5.1    [5] BLACK LARGE SQUARE..BLACK PENTAGON
+2B20..2B23    ; Not_XID                        # 5.0    [4] WHITE PENTAGON..HORIZONTAL BLACK HEXAGON
+2B24..2B4C    ; Not_XID                        # 5.1   [41] BLACK LARGE CIRCLE..RIGHTWARDS ARROW ABOVE REVERSE TILDE OPERATOR
+2B4D..2B4F    ; Not_XID                        # 7.0    [3] DOWNWARDS TRIANGLE-HEADED ZIGZAG ARROW..SHORT BACKSLANTED SOUTH ARROW
+2B50..2B54    ; Not_XID                        # 5.1    [5] WHITE MEDIUM STAR..WHITE RIGHT-POINTING PENTAGON
+2B55..2B59    ; Not_XID                        # 5.2    [5] HEAVY LARGE CIRCLE..HEAVY CIRCLED SALTIRE
+2B5A..2B73    ; Not_XID                        # 7.0   [26] SLANTED NORTH ARROW WITH HOOKED HEAD..DOWNWARDS TRIANGLE-HEADED ARROW TO BAR
+2B76..2B95    ; Not_XID                        # 7.0   [32] NORTH WEST TRIANGLE-HEADED ARROW TO BAR..RIGHTWARDS BLACK ARROW
+2B97          ; Not_XID                        # 13.0       SYMBOL FOR TYPE A ELECTRONICS
+2B98..2BB9    ; Not_XID                        # 7.0   [34] THREE-D TOP-LIGHTED LEFTWARDS EQUILATERAL ARROWHEAD..UP ARROWHEAD IN A RECTANGLE BOX
+2BBA..2BBC    ; Not_XID                        # 11.0   [3] OVERLAPPING WHITE SQUARES..OVERLAPPING BLACK SQUARES
+2BBD..2BC8    ; Not_XID                        # 7.0   [12] BALLOT BOX WITH LIGHT X..BLACK MEDIUM RIGHT-POINTING TRIANGLE CENTRED
+2BC9          ; Not_XID                        # 12.0       NEPTUNE FORM TWO
+2BCA..2BD1    ; Not_XID                        # 7.0    [8] TOP HALF BLACK CIRCLE..UNCERTAINTY SIGN
+2BD2          ; Not_XID                        # 10.0       GROUP MARK
+2BD3..2BEB    ; Not_XID                        # 11.0  [25] PLUTO FORM TWO..STAR WITH RIGHT HALF BLACK
+2BF0..2BFE    ; Not_XID                        # 11.0  [15] ERIS FORM ONE..REVERSED RIGHT ANGLE
+2BFF          ; Not_XID                        # 12.0       HELLSCHREIBER PAUSE SYMBOL
+2E17          ; Not_XID                        # 4.1        DOUBLE OBLIQUE HYPHEN
+2E18..2E1B    ; Not_XID                        # 5.1    [4] INVERTED INTERROBANG..TILDE WITH RING ABOVE
+2E1C..2E1D    ; Not_XID                        # 4.1    [2] LEFT LOW PARAPHRASE BRACKET..RIGHT LOW PARAPHRASE BRACKET
+2E1E..2E29    ; Not_XID                        # 5.1   [12] TILDE WITH DOT ABOVE..RIGHT DOUBLE PARENTHESIS
+2E33..2E34    ; Not_XID                        # 6.1    [2] RAISED DOT..RAISED COMMA
+2E36..2E38    ; Not_XID                        # 6.1    [3] DAGGER WITH LEFT GUARD..TURNED DAGGER
+2E3A..2E3B    ; Not_XID                        # 6.1    [2] TWO-EM DASH..THREE-EM DASH
+2E3C..2E42    ; Not_XID                        # 7.0    [7] STENOGRAPHIC FULL STOP..DOUBLE LOW-REVERSED-9 QUOTATION MARK
+2E43..2E44    ; Not_XID                        # 9.0    [2] DASH WITH LEFT UPTURN..DOUBLE SUSPENSION MARK
+2E45..2E49    ; Not_XID                        # 10.0   [5] INVERTED LOW KAVYKA..DOUBLE STACKED COMMA
+2E4A..2E4E    ; Not_XID                        # 11.0   [5] DOTTED SOLIDUS..PUNCTUS ELEVATUS MARK
+2E4F          ; Not_XID                        # 12.0       CORNISH VERSE DIVIDER
+2E50..2E52    ; Not_XID                        # 13.0   [3] CROSS PATTY WITH RIGHT CROSSBAR..TIRONIAN SIGN CAPITAL ET
+2E53..2E5D    ; Not_XID                        # 14.0  [11] MEDIEVAL EXCLAMATION MARK..OBLIQUE HYPHEN
+2E80..2E99    ; Not_XID                        # 3.0   [26] CJK RADICAL REPEAT..CJK RADICAL RAP
+2E9B..2E9E    ; Not_XID                        # 3.0    [4] CJK RADICAL CHOKE..CJK RADICAL DEATH
+2EA0..2EF2    ; Not_XID                        # 3.0   [83] CJK RADICAL CIVILIAN..CJK RADICAL J-SIMPLIFIED TURTLE
+2FF0..2FFB    ; Not_XID                        # 3.0   [12] IDEOGRAPHIC DESCRIPTION CHARACTER LEFT TO RIGHT..IDEOGRAPHIC DESCRIPTION CHARACTER OVERLAID
+3001..3004    ; Not_XID                        # 1.1    [4] IDEOGRAPHIC COMMA..JAPANESE INDUSTRIAL STANDARD SYMBOL
+3008..301D    ; Not_XID                        # 1.1   [22] LEFT ANGLE BRACKET..REVERSED DOUBLE PRIME QUOTATION MARK
+301F..3020    ; Not_XID                        # 1.1    [2] LOW DOUBLE PRIME QUOTATION MARK..POSTAL MARK FACE
+3030          ; Not_XID                        # 1.1        WAVY DASH
+3037          ; Not_XID                        # 1.1        IDEOGRAPHIC TELEGRAPH LINE FEED SEPARATOR SYMBOL
+303D          ; Not_XID                        # 3.2        PART ALTERNATION MARK
+303E          ; Not_XID                        # 3.0        IDEOGRAPHIC VARIATION INDICATOR
+303F          ; Not_XID                        # 1.1        IDEOGRAPHIC HALF FILL SPACE
+3190..3191    ; Not_XID                        # 1.1    [2] IDEOGRAPHIC ANNOTATION LINKING MARK..IDEOGRAPHIC ANNOTATION REVERSE MARK
+31C0..31CF    ; Not_XID                        # 4.1   [16] CJK STROKE T..CJK STROKE N
+31D0..31E3    ; Not_XID                        # 5.1   [20] CJK STROKE H..CJK STROKE Q
+3248..324F    ; Not_XID                        # 5.2    [8] CIRCLED NUMBER TEN ON BLACK SQUARE..CIRCLED NUMBER EIGHTY ON BLACK SQUARE
+A67E          ; Not_XID                        # 5.1        CYRILLIC KAVYKA
+A720..A721    ; Not_XID                        # 5.0    [2] MODIFIER LETTER STRESS AND HIGH TONE..MODIFIER LETTER STRESS AND LOW TONE
+A789..A78A    ; Not_XID                        # 5.1    [2] MODIFIER LETTER COLON..MODIFIER LETTER SHORT EQUALS SIGN
+A830..A839    ; Not_XID                        # 5.2   [10] NORTH INDIC FRACTION ONE QUARTER..NORTH INDIC QUANTITY MARK
+A92E          ; Not_XID                        # 5.1        KAYAH LI SIGN CWI
+AA77..AA79    ; Not_XID                        # 5.2    [3] MYANMAR SYMBOL AITON EXCLAMATION..MYANMAR SYMBOL AITON TWO
+AB5B          ; Not_XID                        # 7.0        MODIFIER BREVE WITH INVERTED BREVE
+AB6A..AB6B    ; Not_XID                        # 13.0   [2] MODIFIER LETTER LEFT TACK..MODIFIER LETTER RIGHT TACK
+FFF9..FFFB    ; Not_XID                        # 3.0    [3] INTERLINEAR ANNOTATION ANCHOR..INTERLINEAR ANNOTATION TERMINATOR
+FFFC          ; Not_XID                        # 2.1        OBJECT REPLACEMENT CHARACTER
+FFFD          ; Not_XID                        # 1.1        REPLACEMENT CHARACTER
+10175..1018A  ; Not_XID                        # 4.1   [22] GREEK ONE HALF SIGN..GREEK ZERO SIGN
+1018B..1018C  ; Not_XID                        # 7.0    [2] GREEK ONE QUARTER SIGN..GREEK SINUSOID SIGN
+1018D..1018E  ; Not_XID                        # 9.0    [2] GREEK INDICTION SIGN..NOMISMA SIGN
+10190..1019B  ; Not_XID                        # 5.1   [12] ROMAN SEXTANS SIGN..ROMAN CENTURIAL SIGN
+1019C         ; Not_XID                        # 13.0       ASCIA SYMBOL
+101A0         ; Not_XID                        # 7.0        GREEK SYMBOL TAU RHO
+10E60..10E7E  ; Not_XID                        # 5.2   [31] RUMI DIGIT ONE..RUMI FRACTION TWO THIRDS
+111E1..111F4  ; Not_XID                        # 7.0   [20] SINHALA ARCHAIC DIGIT ONE..SINHALA ARCHAIC NUMBER ONE THOUSAND
+11FC0..11FF1  ; Not_XID                        # 12.0  [50] TAMIL FRACTION ONE THREE-HUNDRED-AND-TWENTIETH..TAMIL SIGN VAKAIYARAA
+11FFF         ; Not_XID                        # 12.0       TAMIL PUNCTUATION END OF TEXT
+16FE2         ; Not_XID                        # 12.0       OLD CHINESE HOOK MARK
+1D2E0..1D2F3  ; Not_XID                        # 11.0  [20] MAYAN NUMERAL ZERO..MAYAN NUMERAL NINETEEN
+1D360..1D371  ; Not_XID                        # 5.0   [18] COUNTING ROD UNIT DIGIT ONE..COUNTING ROD TENS DIGIT NINE
+1D372..1D378  ; Not_XID                        # 11.0   [7] IDEOGRAPHIC TALLY MARK ONE..TALLY MARK FIVE
+1EC71..1ECB4  ; Not_XID                        # 11.0  [68] INDIC SIYAQ NUMBER ONE..INDIC SIYAQ ALTERNATE LAKH MARK
+1ED01..1ED3D  ; Not_XID                        # 12.0  [61] OTTOMAN SIYAQ NUMBER ONE..OTTOMAN SIYAQ FRACTION ONE SIXTH
+1EEF0..1EEF1  ; Not_XID                        # 6.1    [2] ARABIC MATHEMATICAL OPERATOR MEEM WITH HAH WITH TATWEEL..ARABIC MATHEMATICAL OPERATOR HAH WITH DAL
+1F000..1F02B  ; Not_XID                        # 5.1   [44] MAHJONG TILE EAST WIND..MAHJONG TILE BACK
+1F030..1F093  ; Not_XID                        # 5.1  [100] DOMINO TILE HORIZONTAL BACK..DOMINO TILE VERTICAL-06-06
+1F0A0..1F0AE  ; Not_XID                        # 6.0   [15] PLAYING CARD BACK..PLAYING CARD KING OF SPADES
+1F0B1..1F0BE  ; Not_XID                        # 6.0   [14] PLAYING CARD ACE OF HEARTS..PLAYING CARD KING OF HEARTS
+1F0BF         ; Not_XID                        # 7.0        PLAYING CARD RED JOKER
+1F0C1..1F0CF  ; Not_XID                        # 6.0   [15] PLAYING CARD ACE OF DIAMONDS..PLAYING CARD BLACK JOKER
+1F0D1..1F0DF  ; Not_XID                        # 6.0   [15] PLAYING CARD ACE OF CLUBS..PLAYING CARD WHITE JOKER
+1F0E0..1F0F5  ; Not_XID                        # 7.0   [22] PLAYING CARD FOOL..PLAYING CARD TRUMP-21
+1F10B..1F10C  ; Not_XID                        # 7.0    [2] DINGBAT CIRCLED SANS-SERIF DIGIT ZERO..DINGBAT NEGATIVE CIRCLED SANS-SERIF DIGIT ZERO
+1F10D..1F10F  ; Not_XID                        # 13.0   [3] CIRCLED ZERO WITH SLASH..CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
+1F12F         ; Not_XID                        # 11.0       COPYLEFT SYMBOL
+1F150..1F156  ; Not_XID                        # 6.0    [7] NEGATIVE CIRCLED LATIN CAPITAL LETTER A..NEGATIVE CIRCLED LATIN CAPITAL LETTER G
+1F157         ; Not_XID                        # 5.2        NEGATIVE CIRCLED LATIN CAPITAL LETTER H
+1F158..1F15E  ; Not_XID                        # 6.0    [7] NEGATIVE CIRCLED LATIN CAPITAL LETTER I..NEGATIVE CIRCLED LATIN CAPITAL LETTER O
+1F15F         ; Not_XID                        # 5.2        NEGATIVE CIRCLED LATIN CAPITAL LETTER P
+1F160..1F169  ; Not_XID                        # 6.0   [10] NEGATIVE CIRCLED LATIN CAPITAL LETTER Q..NEGATIVE CIRCLED LATIN CAPITAL LETTER Z
+1F16D..1F16F  ; Not_XID                        # 13.0   [3] CIRCLED CC..CIRCLED HUMAN FIGURE
+1F170..1F178  ; Not_XID                        # 6.0    [9] NEGATIVE SQUARED LATIN CAPITAL LETTER A..NEGATIVE SQUARED LATIN CAPITAL LETTER I
+1F179         ; Not_XID                        # 5.2        NEGATIVE SQUARED LATIN CAPITAL LETTER J
+1F17A         ; Not_XID                        # 6.0        NEGATIVE SQUARED LATIN CAPITAL LETTER K
+1F17B..1F17C  ; Not_XID                        # 5.2    [2] NEGATIVE SQUARED LATIN CAPITAL LETTER L..NEGATIVE SQUARED LATIN CAPITAL LETTER M
+1F17D..1F17E  ; Not_XID                        # 6.0    [2] NEGATIVE SQUARED LATIN CAPITAL LETTER N..NEGATIVE SQUARED LATIN CAPITAL LETTER O
+1F17F         ; Not_XID                        # 5.2        NEGATIVE SQUARED LATIN CAPITAL LETTER P
+1F180..1F189  ; Not_XID                        # 6.0   [10] NEGATIVE SQUARED LATIN CAPITAL LETTER Q..NEGATIVE SQUARED LATIN CAPITAL LETTER Z
+1F18A..1F18D  ; Not_XID                        # 5.2    [4] CROSSED NEGATIVE SQUARED LATIN CAPITAL LETTER P..NEGATIVE SQUARED SA
+1F18E..1F18F  ; Not_XID                        # 6.0    [2] NEGATIVE SQUARED AB..NEGATIVE SQUARED WC
+1F191..1F19A  ; Not_XID                        # 6.0   [10] SQUARED CL..SQUARED VS
+1F19B..1F1AC  ; Not_XID                        # 9.0   [18] SQUARED THREE D..SQUARED VOD
+1F1AD         ; Not_XID                        # 13.0       MASK WORK SYMBOL
+1F1E6..1F1FF  ; Not_XID                        # 6.0   [26] REGIONAL INDICATOR SYMBOL LETTER A..REGIONAL INDICATOR SYMBOL LETTER Z
+1F260..1F265  ; Not_XID                        # 10.0   [6] ROUNDED SYMBOL FOR FU..ROUNDED SYMBOL FOR CAI
+1F300..1F320  ; Not_XID                        # 6.0   [33] CYCLONE..SHOOTING STAR
+1F321..1F32C  ; Not_XID                        # 7.0   [12] THERMOMETER..WIND BLOWING FACE
+1F32D..1F32F  ; Not_XID                        # 8.0    [3] HOT DOG..BURRITO
+1F330..1F335  ; Not_XID                        # 6.0    [6] CHESTNUT..CACTUS
+1F336         ; Not_XID                        # 7.0        HOT PEPPER
+1F337..1F37C  ; Not_XID                        # 6.0   [70] TULIP..BABY BOTTLE
+1F37D         ; Not_XID                        # 7.0        FORK AND KNIFE WITH PLATE
+1F37E..1F37F  ; Not_XID                        # 8.0    [2] BOTTLE WITH POPPING CORK..POPCORN
+1F380..1F393  ; Not_XID                        # 6.0   [20] RIBBON..GRADUATION CAP
+1F394..1F39F  ; Not_XID                        # 7.0   [12] HEART WITH TIP ON THE LEFT..ADMISSION TICKETS
+1F3A0..1F3C4  ; Not_XID                        # 6.0   [37] CAROUSEL HORSE..SURFER
+1F3C5         ; Not_XID                        # 7.0        SPORTS MEDAL
+1F3C6..1F3CA  ; Not_XID                        # 6.0    [5] TROPHY..SWIMMER
+1F3CB..1F3CE  ; Not_XID                        # 7.0    [4] WEIGHT LIFTER..RACING CAR
+1F3CF..1F3D3  ; Not_XID                        # 8.0    [5] CRICKET BAT AND BALL..TABLE TENNIS PADDLE AND BALL
+1F3D4..1F3DF  ; Not_XID                        # 7.0   [12] SNOW CAPPED MOUNTAIN..STADIUM
+1F3E0..1F3F0  ; Not_XID                        # 6.0   [17] HOUSE BUILDING..EUROPEAN CASTLE
+1F3F1..1F3F7  ; Not_XID                        # 7.0    [7] WHITE PENNANT..LABEL
+1F3F8..1F3FF  ; Not_XID                        # 8.0    [8] BADMINTON RACQUET AND SHUTTLECOCK..EMOJI MODIFIER FITZPATRICK TYPE-6
+1F400..1F43E  ; Not_XID                        # 6.0   [63] RAT..PAW PRINTS
+1F43F         ; Not_XID                        # 7.0        CHIPMUNK
+1F440         ; Not_XID                        # 6.0        EYES
+1F441         ; Not_XID                        # 7.0        EYE
+1F442..1F4F7  ; Not_XID                        # 6.0  [182] EAR..CAMERA
+1F4F8         ; Not_XID                        # 7.0        CAMERA WITH FLASH
+1F4F9..1F4FC  ; Not_XID                        # 6.0    [4] VIDEO CAMERA..VIDEOCASSETTE
+1F4FD..1F4FE  ; Not_XID                        # 7.0    [2] FILM PROJECTOR..PORTABLE STEREO
+1F4FF         ; Not_XID                        # 8.0        PRAYER BEADS
+1F500..1F53D  ; Not_XID                        # 6.0   [62] TWISTED RIGHTWARDS ARROWS..DOWN-POINTING SMALL RED TRIANGLE
+1F53E..1F53F  ; Not_XID                        # 7.0    [2] LOWER RIGHT SHADOWED WHITE CIRCLE..UPPER RIGHT SHADOWED WHITE CIRCLE
+1F540..1F543  ; Not_XID                        # 6.1    [4] CIRCLED CROSS POMMEE..NOTCHED LEFT SEMICIRCLE WITH THREE DOTS
+1F544..1F54A  ; Not_XID                        # 7.0    [7] NOTCHED RIGHT SEMICIRCLE WITH THREE DOTS..DOVE OF PEACE
+1F54B..1F54E  ; Not_XID                        # 8.0    [4] KAABA..MENORAH WITH NINE BRANCHES
+1F550..1F567  ; Not_XID                        # 6.0   [24] CLOCK FACE ONE OCLOCK..CLOCK FACE TWELVE-THIRTY
+1F568..1F579  ; Not_XID                        # 7.0   [18] RIGHT SPEAKER..JOYSTICK
+1F57A         ; Not_XID                        # 9.0        MAN DANCING
+1F57B..1F5A3  ; Not_XID                        # 7.0   [41] LEFT HAND TELEPHONE RECEIVER..BLACK DOWN POINTING BACKHAND INDEX
+1F5A4         ; Not_XID                        # 9.0        BLACK HEART
+1F5A5..1F5FA  ; Not_XID                        # 7.0   [86] DESKTOP COMPUTER..WORLD MAP
+1F5FB..1F5FF  ; Not_XID                        # 6.0    [5] MOUNT FUJI..MOYAI
+1F600         ; Not_XID                        # 6.1        GRINNING FACE
+1F601..1F610  ; Not_XID                        # 6.0   [16] GRINNING FACE WITH SMILING EYES..NEUTRAL FACE
+1F611         ; Not_XID                        # 6.1        EXPRESSIONLESS FACE
+1F612..1F614  ; Not_XID                        # 6.0    [3] UNAMUSED FACE..PENSIVE FACE
+1F615         ; Not_XID                        # 6.1        CONFUSED FACE
+1F616         ; Not_XID                        # 6.0        CONFOUNDED FACE
+1F617         ; Not_XID                        # 6.1        KISSING FACE
+1F618         ; Not_XID                        # 6.0        FACE THROWING A KISS
+1F619         ; Not_XID                        # 6.1        KISSING FACE WITH SMILING EYES
+1F61A         ; Not_XID                        # 6.0        KISSING FACE WITH CLOSED EYES
+1F61B         ; Not_XID                        # 6.1        FACE WITH STUCK-OUT TONGUE
+1F61C..1F61E  ; Not_XID                        # 6.0    [3] FACE WITH STUCK-OUT TONGUE AND WINKING EYE..DISAPPOINTED FACE
+1F61F         ; Not_XID                        # 6.1        WORRIED FACE
+1F620..1F625  ; Not_XID                        # 6.0    [6] ANGRY FACE..DISAPPOINTED BUT RELIEVED FACE
+1F626..1F627  ; Not_XID                        # 6.1    [2] FROWNING FACE WITH OPEN MOUTH..ANGUISHED FACE
+1F628..1F62B  ; Not_XID                        # 6.0    [4] FEARFUL FACE..TIRED FACE
+1F62C         ; Not_XID                        # 6.1        GRIMACING FACE
+1F62D         ; Not_XID                        # 6.0        LOUDLY CRYING FACE
+1F62E..1F62F  ; Not_XID                        # 6.1    [2] FACE WITH OPEN MOUTH..HUSHED FACE
+1F630..1F633  ; Not_XID                        # 6.0    [4] FACE WITH OPEN MOUTH AND COLD SWEAT..FLUSHED FACE
+1F634         ; Not_XID                        # 6.1        SLEEPING FACE
+1F635..1F640  ; Not_XID                        # 6.0   [12] DIZZY FACE..WEARY CAT FACE
+1F641..1F642  ; Not_XID                        # 7.0    [2] SLIGHTLY FROWNING FACE..SLIGHTLY SMILING FACE
+1F643..1F644  ; Not_XID                        # 8.0    [2] UPSIDE-DOWN FACE..FACE WITH ROLLING EYES
+1F645..1F64F  ; Not_XID                        # 6.0   [11] FACE WITH NO GOOD GESTURE..PERSON WITH FOLDED HANDS
+1F650..1F67F  ; Not_XID                        # 7.0   [48] NORTH WEST POINTING LEAF..REVERSE CHECKER BOARD
+1F680..1F6C5  ; Not_XID                        # 6.0   [70] ROCKET..LEFT LUGGAGE
+1F6C6..1F6CF  ; Not_XID                        # 7.0   [10] TRIANGLE WITH ROUNDED CORNERS..BED
+1F6D0         ; Not_XID                        # 8.0        PLACE OF WORSHIP
+1F6D1..1F6D2  ; Not_XID                        # 9.0    [2] OCTAGONAL SIGN..SHOPPING TROLLEY
+1F6D3..1F6D4  ; Not_XID                        # 10.0   [2] STUPA..PAGODA
+1F6D5         ; Not_XID                        # 12.0       HINDU TEMPLE
+1F6D6..1F6D7  ; Not_XID                        # 13.0   [2] HUT..ELEVATOR
+1F6DD..1F6DF  ; Not_XID                        # 14.0   [3] PLAYGROUND SLIDE..RING BUOY
+1F6E0..1F6EC  ; Not_XID                        # 7.0   [13] HAMMER AND WRENCH..AIRPLANE ARRIVING
+1F6F0..1F6F3  ; Not_XID                        # 7.0    [4] SATELLITE..PASSENGER SHIP
+1F6F4..1F6F6  ; Not_XID                        # 9.0    [3] SCOOTER..CANOE
+1F6F7..1F6F8  ; Not_XID                        # 10.0   [2] SLED..FLYING SAUCER
+1F6F9         ; Not_XID                        # 11.0       SKATEBOARD
+1F6FA         ; Not_XID                        # 12.0       AUTO RICKSHAW
+1F6FB..1F6FC  ; Not_XID                        # 13.0   [2] PICKUP TRUCK..ROLLER SKATE
+1F700..1F773  ; Not_XID                        # 6.0  [116] ALCHEMICAL SYMBOL FOR QUINTESSENCE..ALCHEMICAL SYMBOL FOR HALF OUNCE
+1F780..1F7D4  ; Not_XID                        # 7.0   [85] BLACK LEFT-POINTING ISOSCELES RIGHT TRIANGLE..HEAVY TWELVE POINTED PINWHEEL STAR
+1F7D5..1F7D8  ; Not_XID                        # 11.0   [4] CIRCLED TRIANGLE..NEGATIVE CIRCLED SQUARE
+1F7E0..1F7EB  ; Not_XID                        # 12.0  [12] LARGE ORANGE CIRCLE..LARGE BROWN SQUARE
+1F7F0         ; Not_XID                        # 14.0       HEAVY EQUALS SIGN
+1F800..1F80B  ; Not_XID                        # 7.0   [12] LEFTWARDS ARROW WITH SMALL TRIANGLE ARROWHEAD..DOWNWARDS ARROW WITH LARGE TRIANGLE ARROWHEAD
+1F810..1F847  ; Not_XID                        # 7.0   [56] LEFTWARDS ARROW WITH SMALL EQUILATERAL ARROWHEAD..DOWNWARDS HEAVY ARROW
+1F850..1F859  ; Not_XID                        # 7.0   [10] LEFTWARDS SANS-SERIF ARROW..UP DOWN SANS-SERIF ARROW
+1F860..1F887  ; Not_XID                        # 7.0   [40] WIDE-HEADED LEFTWARDS LIGHT BARB ARROW..WIDE-HEADED SOUTH WEST VERY HEAVY BARB ARROW
+1F890..1F8AD  ; Not_XID                        # 7.0   [30] LEFTWARDS TRIANGLE ARROWHEAD..WHITE ARROW SHAFT WIDTH TWO THIRDS
+1F8B0..1F8B1  ; Not_XID                        # 13.0   [2] ARROW POINTING UPWARDS THEN NORTH WEST..ARROW POINTING RIGHTWARDS THEN CURVING SOUTH WEST
+1F900..1F90B  ; Not_XID                        # 10.0  [12] CIRCLED CROSS FORMEE WITH FOUR DOTS..DOWNWARD FACING NOTCHED HOOK WITH DOT
+1F90C         ; Not_XID                        # 13.0       PINCHED FINGERS
+1F90D..1F90F  ; Not_XID                        # 12.0   [3] WHITE HEART..PINCHING HAND
+1F910..1F918  ; Not_XID                        # 8.0    [9] ZIPPER-MOUTH FACE..SIGN OF THE HORNS
+1F919..1F91E  ; Not_XID                        # 9.0    [6] CALL ME HAND..HAND WITH INDEX AND MIDDLE FINGERS CROSSED
+1F91F         ; Not_XID                        # 10.0       I LOVE YOU HAND SIGN
+1F920..1F927  ; Not_XID                        # 9.0    [8] FACE WITH COWBOY HAT..SNEEZING FACE
+1F928..1F92F  ; Not_XID                        # 10.0   [8] FACE WITH ONE EYEBROW RAISED..SHOCKED FACE WITH EXPLODING HEAD
+1F930         ; Not_XID                        # 9.0        PREGNANT WOMAN
+1F931..1F932  ; Not_XID                        # 10.0   [2] BREAST-FEEDING..PALMS UP TOGETHER
+1F933..1F93E  ; Not_XID                        # 9.0   [12] SELFIE..HANDBALL
+1F93F         ; Not_XID                        # 12.0       DIVING MASK
+1F940..1F94B  ; Not_XID                        # 9.0   [12] WILTED FLOWER..MARTIAL ARTS UNIFORM
+1F94C         ; Not_XID                        # 10.0       CURLING STONE
+1F94D..1F94F  ; Not_XID                        # 11.0   [3] LACROSSE STICK AND BALL..FLYING DISC
+1F950..1F95E  ; Not_XID                        # 9.0   [15] CROISSANT..PANCAKES
+1F95F..1F96B  ; Not_XID                        # 10.0  [13] DUMPLING..CANNED FOOD
+1F96C..1F970  ; Not_XID                        # 11.0   [5] LEAFY GREEN..SMILING FACE WITH SMILING EYES AND THREE HEARTS
+1F971         ; Not_XID                        # 12.0       YAWNING FACE
+1F972         ; Not_XID                        # 13.0       SMILING FACE WITH TEAR
+1F973..1F976  ; Not_XID                        # 11.0   [4] FACE WITH PARTY HORN AND PARTY HAT..FREEZING FACE
+1F977..1F978  ; Not_XID                        # 13.0   [2] NINJA..DISGUISED FACE
+1F979         ; Not_XID                        # 14.0       FACE HOLDING BACK TEARS
+1F97A         ; Not_XID                        # 11.0       FACE WITH PLEADING EYES
+1F97B         ; Not_XID                        # 12.0       SARI
+1F97C..1F97F  ; Not_XID                        # 11.0   [4] LAB COAT..FLAT SHOE
+1F980..1F984  ; Not_XID                        # 8.0    [5] CRAB..UNICORN FACE
+1F985..1F991  ; Not_XID                        # 9.0   [13] EAGLE..SQUID
+1F992..1F997  ; Not_XID                        # 10.0   [6] GIRAFFE FACE..CRICKET
+1F998..1F9A2  ; Not_XID                        # 11.0  [11] KANGAROO..SWAN
+1F9A3..1F9A4  ; Not_XID                        # 13.0   [2] MAMMOTH..DODO
+1F9A5..1F9AA  ; Not_XID                        # 12.0   [6] SLOTH..OYSTER
+1F9AB..1F9AD  ; Not_XID                        # 13.0   [3] BEAVER..SEAL
+1F9AE..1F9AF  ; Not_XID                        # 12.0   [2] GUIDE DOG..PROBING CANE
+1F9B0..1F9B9  ; Not_XID                        # 11.0  [10] EMOJI COMPONENT RED HAIR..SUPERVILLAIN
+1F9BA..1F9BF  ; Not_XID                        # 12.0   [6] SAFETY VEST..MECHANICAL LEG
+1F9C0         ; Not_XID                        # 8.0        CHEESE WEDGE
+1F9C1..1F9C2  ; Not_XID                        # 11.0   [2] CUPCAKE..SALT SHAKER
+1F9C3..1F9CA  ; Not_XID                        # 12.0   [8] BEVERAGE BOX..ICE CUBE
+1F9CB         ; Not_XID                        # 13.0       BUBBLE TEA
+1F9CC         ; Not_XID                        # 14.0       TROLL
+1F9CD..1F9CF  ; Not_XID                        # 12.0   [3] STANDING PERSON..DEAF PERSON
+1F9D0..1F9E6  ; Not_XID                        # 10.0  [23] FACE WITH MONOCLE..SOCKS
+1F9E7..1F9FF  ; Not_XID                        # 11.0  [25] RED GIFT ENVELOPE..NAZAR AMULET
+1FA00..1FA53  ; Not_XID                        # 12.0  [84] NEUTRAL CHESS KING..BLACK CHESS KNIGHT-BISHOP
+1FA60..1FA6D  ; Not_XID                        # 11.0  [14] XIANGQI RED GENERAL..XIANGQI BLACK SOLDIER
+1FA70..1FA73  ; Not_XID                        # 12.0   [4] BALLET SHOES..SHORTS
+1FA74         ; Not_XID                        # 13.0       THONG SANDAL
+1FA78..1FA7A  ; Not_XID                        # 12.0   [3] DROP OF BLOOD..STETHOSCOPE
+1FA7B..1FA7C  ; Not_XID                        # 14.0   [2] X-RAY..CRUTCH
+1FA80..1FA82  ; Not_XID                        # 12.0   [3] YO-YO..PARACHUTE
+1FA83..1FA86  ; Not_XID                        # 13.0   [4] BOOMERANG..NESTING DOLLS
+1FA90..1FA95  ; Not_XID                        # 12.0   [6] RINGED PLANET..BANJO
+1FA96..1FAA8  ; Not_XID                        # 13.0  [19] MILITARY HELMET..ROCK
+1FAA9..1FAAC  ; Not_XID                        # 14.0   [4] MIRROR BALL..HAMSA
+1FAB0..1FAB6  ; Not_XID                        # 13.0   [7] FLY..FEATHER
+1FAB7..1FABA  ; Not_XID                        # 14.0   [4] LOTUS..NEST WITH EGGS
+1FAC0..1FAC2  ; Not_XID                        # 13.0   [3] ANATOMICAL HEART..PEOPLE HUGGING
+1FAC3..1FAC5  ; Not_XID                        # 14.0   [3] PREGNANT MAN..PERSON WITH CROWN
+1FAD0..1FAD6  ; Not_XID                        # 13.0   [7] BLUEBERRIES..TEAPOT
+1FAD7..1FAD9  ; Not_XID                        # 14.0   [3] POURING LIQUID..JAR
+1FAE0..1FAE7  ; Not_XID                        # 14.0   [8] MELTING FACE..BUBBLES
+1FAF0..1FAF6  ; Not_XID                        # 14.0   [7] HAND WITH INDEX FINGER AND THUMB CROSSED..HEART HANDS
+1FB00..1FB92  ; Not_XID                        # 13.0 [147] BLOCK SEXTANT-1..UPPER HALF INVERSE MEDIUM SHADE AND LOWER HALF BLOCK
+1FB94..1FBCA  ; Not_XID                        # 13.0  [55] LEFT HALF INVERSE MEDIUM SHADE AND RIGHT HALF BLOCK..WHITE UP-POINTING CHEVRON
+
+# Total code points: 5640
+
+#	Identifier_Type:	Not_NFKC
+
+00A0          ; Not_NFKC                       # 1.1        NO-BREAK SPACE
+00A8          ; Not_NFKC                       # 1.1        DIAERESIS
+00AA          ; Not_NFKC                       # 1.1        FEMININE ORDINAL INDICATOR
+00AF          ; Not_NFKC                       # 1.1        MACRON
+00B2..00B5    ; Not_NFKC                       # 1.1    [4] SUPERSCRIPT TWO..MICRO SIGN
+00B8..00BA    ; Not_NFKC                       # 1.1    [3] CEDILLA..MASCULINE ORDINAL INDICATOR
+00BC..00BE    ; Not_NFKC                       # 1.1    [3] VULGAR FRACTION ONE QUARTER..VULGAR FRACTION THREE QUARTERS
+0132..0133    ; Not_NFKC                       # 1.1    [2] LATIN CAPITAL LIGATURE IJ..LATIN SMALL LIGATURE IJ
+013F..0140    ; Not_NFKC                       # 1.1    [2] LATIN CAPITAL LETTER L WITH MIDDLE DOT..LATIN SMALL LETTER L WITH MIDDLE DOT
+017F          ; Not_NFKC                       # 1.1        LATIN SMALL LETTER LONG S
+01C4..01CC    ; Not_NFKC                       # 1.1    [9] LATIN CAPITAL LETTER DZ WITH CARON..LATIN SMALL LETTER NJ
+01F1..01F3    ; Not_NFKC                       # 1.1    [3] LATIN CAPITAL LETTER DZ..LATIN SMALL LETTER DZ
+02B0..02B8    ; Not_NFKC                       # 1.1    [9] MODIFIER LETTER SMALL H..MODIFIER LETTER SMALL Y
+02D8..02DD    ; Not_NFKC                       # 1.1    [6] BREVE..DOUBLE ACUTE ACCENT
+02E0..02E4    ; Not_NFKC                       # 1.1    [5] MODIFIER LETTER SMALL GAMMA..MODIFIER LETTER SMALL REVERSED GLOTTAL STOP
+0340..0341    ; Not_NFKC                       # 1.1    [2] COMBINING GRAVE TONE MARK..COMBINING ACUTE TONE MARK
+0343..0344    ; Not_NFKC                       # 1.1    [2] COMBINING GREEK KORONIS..COMBINING GREEK DIALYTIKA TONOS
+0374          ; Not_NFKC                       # 1.1        GREEK NUMERAL SIGN
+037A          ; Not_NFKC                       # 1.1        GREEK YPOGEGRAMMENI
+037E          ; Not_NFKC                       # 1.1        GREEK QUESTION MARK
+0384..0385    ; Not_NFKC                       # 1.1    [2] GREEK TONOS..GREEK DIALYTIKA TONOS
+0387          ; Not_NFKC                       # 1.1        GREEK ANO TELEIA
+03D0..03D6    ; Not_NFKC                       # 1.1    [7] GREEK BETA SYMBOL..GREEK PI SYMBOL
+03F0..03F2    ; Not_NFKC                       # 1.1    [3] GREEK KAPPA SYMBOL..GREEK LUNATE SIGMA SYMBOL
+03F4..03F5    ; Not_NFKC                       # 3.1    [2] GREEK CAPITAL THETA SYMBOL..GREEK LUNATE EPSILON SYMBOL
+03F9          ; Not_NFKC                       # 4.0        GREEK CAPITAL LUNATE SIGMA SYMBOL
+0587          ; Not_NFKC                       # 1.1        ARMENIAN SMALL LIGATURE ECH YIWN
+0675..0678    ; Not_NFKC                       # 1.1    [4] ARABIC LETTER HIGH HAMZA ALEF..ARABIC LETTER HIGH HAMZA YEH
+0958..095F    ; Not_NFKC                       # 1.1    [8] DEVANAGARI LETTER QA..DEVANAGARI LETTER YYA
+09DC..09DD    ; Not_NFKC                       # 1.1    [2] BENGALI LETTER RRA..BENGALI LETTER RHA
+09DF          ; Not_NFKC                       # 1.1        BENGALI LETTER YYA
+0A33          ; Not_NFKC                       # 1.1        GURMUKHI LETTER LLA
+0A36          ; Not_NFKC                       # 1.1        GURMUKHI LETTER SHA
+0A59..0A5B    ; Not_NFKC                       # 1.1    [3] GURMUKHI LETTER KHHA..GURMUKHI LETTER ZA
+0A5E          ; Not_NFKC                       # 1.1        GURMUKHI LETTER FA
+0B5C..0B5D    ; Not_NFKC                       # 1.1    [2] ORIYA LETTER RRA..ORIYA LETTER RHA
+0E33          ; Not_NFKC                       # 1.1        THAI CHARACTER SARA AM
+0EB3          ; Not_NFKC                       # 1.1        LAO VOWEL SIGN AM
+0EDC..0EDD    ; Not_NFKC                       # 1.1    [2] LAO HO NO..LAO HO MO
+0F0C          ; Not_NFKC                       # 2.0        TIBETAN MARK DELIMITER TSHEG BSTAR
+0F43          ; Not_NFKC                       # 2.0        TIBETAN LETTER GHA
+0F4D          ; Not_NFKC                       # 2.0        TIBETAN LETTER DDHA
+0F52          ; Not_NFKC                       # 2.0        TIBETAN LETTER DHA
+0F57          ; Not_NFKC                       # 2.0        TIBETAN LETTER BHA
+0F5C          ; Not_NFKC                       # 2.0        TIBETAN LETTER DZHA
+0F69          ; Not_NFKC                       # 2.0        TIBETAN LETTER KSSA
+0F73          ; Not_NFKC                       # 2.0        TIBETAN VOWEL SIGN II
+0F75..0F76    ; Not_NFKC                       # 2.0    [2] TIBETAN VOWEL SIGN UU..TIBETAN VOWEL SIGN VOCALIC R
+0F78          ; Not_NFKC                       # 2.0        TIBETAN VOWEL SIGN VOCALIC L
+0F81          ; Not_NFKC                       # 2.0        TIBETAN VOWEL SIGN REVERSED II
+0F93          ; Not_NFKC                       # 2.0        TIBETAN SUBJOINED LETTER GHA
+0F9D          ; Not_NFKC                       # 2.0        TIBETAN SUBJOINED LETTER DDHA
+0FA2          ; Not_NFKC                       # 2.0        TIBETAN SUBJOINED LETTER DHA
+0FA7          ; Not_NFKC                       # 2.0        TIBETAN SUBJOINED LETTER BHA
+0FAC          ; Not_NFKC                       # 2.0        TIBETAN SUBJOINED LETTER DZHA
+0FB9          ; Not_NFKC                       # 2.0        TIBETAN SUBJOINED LETTER KSSA
+10FC          ; Not_NFKC                       # 4.1        MODIFIER LETTER GEORGIAN NAR
+1D2C..1D2E    ; Not_NFKC                       # 4.0    [3] MODIFIER LETTER CAPITAL A..MODIFIER LETTER CAPITAL B
+1D30..1D3A    ; Not_NFKC                       # 4.0   [11] MODIFIER LETTER CAPITAL D..MODIFIER LETTER CAPITAL N
+1D3C..1D4D    ; Not_NFKC                       # 4.0   [18] MODIFIER LETTER CAPITAL O..MODIFIER LETTER SMALL G
+1D4F..1D6A    ; Not_NFKC                       # 4.0   [28] MODIFIER LETTER SMALL K..GREEK SUBSCRIPT SMALL LETTER CHI
+1D78          ; Not_NFKC                       # 4.1        MODIFIER LETTER CYRILLIC EN
+1D9B..1DBF    ; Not_NFKC                       # 4.1   [37] MODIFIER LETTER SMALL TURNED ALPHA..MODIFIER LETTER SMALL THETA
+1E9A          ; Not_NFKC                       # 1.1        LATIN SMALL LETTER A WITH RIGHT HALF RING
+1E9B          ; Not_NFKC                       # 2.0        LATIN SMALL LETTER LONG S WITH DOT ABOVE
+1F71          ; Not_NFKC                       # 1.1        GREEK SMALL LETTER ALPHA WITH OXIA
+1F73          ; Not_NFKC                       # 1.1        GREEK SMALL LETTER EPSILON WITH OXIA
+1F75          ; Not_NFKC                       # 1.1        GREEK SMALL LETTER ETA WITH OXIA
+1F77          ; Not_NFKC                       # 1.1        GREEK SMALL LETTER IOTA WITH OXIA
+1F79          ; Not_NFKC                       # 1.1        GREEK SMALL LETTER OMICRON WITH OXIA
+1F7B          ; Not_NFKC                       # 1.1        GREEK SMALL LETTER UPSILON WITH OXIA
+1F7D          ; Not_NFKC                       # 1.1        GREEK SMALL LETTER OMEGA WITH OXIA
+1FBB          ; Not_NFKC                       # 1.1        GREEK CAPITAL LETTER ALPHA WITH OXIA
+1FBD..1FC1    ; Not_NFKC                       # 1.1    [5] GREEK KORONIS..GREEK DIALYTIKA AND PERISPOMENI
+1FC9          ; Not_NFKC                       # 1.1        GREEK CAPITAL LETTER EPSILON WITH OXIA
+1FCB          ; Not_NFKC                       # 1.1        GREEK CAPITAL LETTER ETA WITH OXIA
+1FCD..1FCF    ; Not_NFKC                       # 1.1    [3] GREEK PSILI AND VARIA..GREEK PSILI AND PERISPOMENI
+1FD3          ; Not_NFKC                       # 1.1        GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA
+1FDB          ; Not_NFKC                       # 1.1        GREEK CAPITAL LETTER IOTA WITH OXIA
+1FDD..1FDF    ; Not_NFKC                       # 1.1    [3] GREEK DASIA AND VARIA..GREEK DASIA AND PERISPOMENI
+1FE3          ; Not_NFKC                       # 1.1        GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND OXIA
+1FEB          ; Not_NFKC                       # 1.1        GREEK CAPITAL LETTER UPSILON WITH OXIA
+1FED..1FEF    ; Not_NFKC                       # 1.1    [3] GREEK DIALYTIKA AND VARIA..GREEK VARIA
+1FF9          ; Not_NFKC                       # 1.1        GREEK CAPITAL LETTER OMICRON WITH OXIA
+1FFB          ; Not_NFKC                       # 1.1        GREEK CAPITAL LETTER OMEGA WITH OXIA
+1FFD..1FFE    ; Not_NFKC                       # 1.1    [2] GREEK OXIA..GREEK DASIA
+2000..200A    ; Not_NFKC                       # 1.1   [11] EN QUAD..HAIR SPACE
+2011          ; Not_NFKC                       # 1.1        NON-BREAKING HYPHEN
+2017          ; Not_NFKC                       # 1.1        DOUBLE LOW LINE
+2024..2026    ; Not_NFKC                       # 1.1    [3] ONE DOT LEADER..HORIZONTAL ELLIPSIS
+202F          ; Not_NFKC                       # 3.0        NARROW NO-BREAK SPACE
+2033..2034    ; Not_NFKC                       # 1.1    [2] DOUBLE PRIME..TRIPLE PRIME
+2036..2037    ; Not_NFKC                       # 1.1    [2] REVERSED DOUBLE PRIME..REVERSED TRIPLE PRIME
+203C          ; Not_NFKC                       # 1.1        DOUBLE EXCLAMATION MARK
+203E          ; Not_NFKC                       # 1.1        OVERLINE
+2047          ; Not_NFKC                       # 3.2        DOUBLE QUESTION MARK
+2048..2049    ; Not_NFKC                       # 3.0    [2] QUESTION EXCLAMATION MARK..EXCLAMATION QUESTION MARK
+2057          ; Not_NFKC                       # 3.2        QUADRUPLE PRIME
+205F          ; Not_NFKC                       # 3.2        MEDIUM MATHEMATICAL SPACE
+2070          ; Not_NFKC                       # 1.1        SUPERSCRIPT ZERO
+2071          ; Not_NFKC                       # 3.2        SUPERSCRIPT LATIN SMALL LETTER I
+2074..208E    ; Not_NFKC                       # 1.1   [27] SUPERSCRIPT FOUR..SUBSCRIPT RIGHT PARENTHESIS
+2090..2094    ; Not_NFKC                       # 4.1    [5] LATIN SUBSCRIPT SMALL LETTER A..LATIN SUBSCRIPT SMALL LETTER SCHWA
+2095..209C    ; Not_NFKC                       # 6.0    [8] LATIN SUBSCRIPT SMALL LETTER H..LATIN SUBSCRIPT SMALL LETTER T
+20A8          ; Not_NFKC                       # 1.1        RUPEE SIGN
+2100..2103    ; Not_NFKC                       # 1.1    [4] ACCOUNT OF..DEGREE CELSIUS
+2105..2107    ; Not_NFKC                       # 1.1    [3] CARE OF..EULER CONSTANT
+2109..2113    ; Not_NFKC                       # 1.1   [11] DEGREE FAHRENHEIT..SCRIPT SMALL L
+2115..2116    ; Not_NFKC                       # 1.1    [2] DOUBLE-STRUCK CAPITAL N..NUMERO SIGN
+2119..211D    ; Not_NFKC                       # 1.1    [5] DOUBLE-STRUCK CAPITAL P..DOUBLE-STRUCK CAPITAL R
+2120..2122    ; Not_NFKC                       # 1.1    [3] SERVICE MARK..TRADE MARK SIGN
+2124          ; Not_NFKC                       # 1.1        DOUBLE-STRUCK CAPITAL Z
+2126          ; Not_NFKC                       # 1.1        OHM SIGN
+2128          ; Not_NFKC                       # 1.1        BLACK-LETTER CAPITAL Z
+212A..212D    ; Not_NFKC                       # 1.1    [4] KELVIN SIGN..BLACK-LETTER CAPITAL C
+212F..2131    ; Not_NFKC                       # 1.1    [3] SCRIPT SMALL E..SCRIPT CAPITAL F
+2133..2138    ; Not_NFKC                       # 1.1    [6] SCRIPT CAPITAL M..DALET SYMBOL
+2139          ; Not_NFKC                       # 3.0        INFORMATION SOURCE
+213B          ; Not_NFKC                       # 4.0        FACSIMILE SIGN
+213C          ; Not_NFKC                       # 4.1        DOUBLE-STRUCK SMALL PI
+213D..2140    ; Not_NFKC                       # 3.2    [4] DOUBLE-STRUCK SMALL GAMMA..DOUBLE-STRUCK N-ARY SUMMATION
+2145..2149    ; Not_NFKC                       # 3.2    [5] DOUBLE-STRUCK ITALIC CAPITAL D..DOUBLE-STRUCK ITALIC SMALL J
+2150..2152    ; Not_NFKC                       # 5.2    [3] VULGAR FRACTION ONE SEVENTH..VULGAR FRACTION ONE TENTH
+2153..217F    ; Not_NFKC                       # 1.1   [45] VULGAR FRACTION ONE THIRD..SMALL ROMAN NUMERAL ONE THOUSAND
+2189          ; Not_NFKC                       # 5.2        VULGAR FRACTION ZERO THIRDS
+222C..222D    ; Not_NFKC                       # 1.1    [2] DOUBLE INTEGRAL..TRIPLE INTEGRAL
+222F..2230    ; Not_NFKC                       # 1.1    [2] SURFACE INTEGRAL..VOLUME INTEGRAL
+2460..24EA    ; Not_NFKC                       # 1.1  [139] CIRCLED DIGIT ONE..CIRCLED DIGIT ZERO
+2A0C          ; Not_NFKC                       # 3.2        QUADRUPLE INTEGRAL OPERATOR
+2A74..2A76    ; Not_NFKC                       # 3.2    [3] DOUBLE COLON EQUAL..THREE CONSECUTIVE EQUALS SIGNS
+2ADC          ; Not_NFKC                       # 3.2        FORKING
+2C7C..2C7D    ; Not_NFKC                       # 5.1    [2] LATIN SUBSCRIPT SMALL LETTER J..MODIFIER LETTER CAPITAL V
+2D6F          ; Not_NFKC                       # 4.1        TIFINAGH MODIFIER LETTER LABIALIZATION MARK
+2E9F          ; Not_NFKC                       # 3.0        CJK RADICAL MOTHER
+2EF3          ; Not_NFKC                       # 3.0        CJK RADICAL C-SIMPLIFIED TURTLE
+2F00..2FD5    ; Not_NFKC                       # 3.0  [214] KANGXI RADICAL ONE..KANGXI RADICAL FLUTE
+3000          ; Not_NFKC                       # 1.1        IDEOGRAPHIC SPACE
+3036          ; Not_NFKC                       # 1.1        CIRCLED POSTAL MARK
+3038..303A    ; Not_NFKC                       # 3.0    [3] HANGZHOU NUMERAL TEN..HANGZHOU NUMERAL THIRTY
+309B..309C    ; Not_NFKC                       # 1.1    [2] KATAKANA-HIRAGANA VOICED SOUND MARK..KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+309F          ; Not_NFKC                       # 3.2        HIRAGANA DIGRAPH YORI
+30FF          ; Not_NFKC                       # 3.2        KATAKANA DIGRAPH KOTO
+3131..3163    ; Not_NFKC                       # 1.1   [51] HANGUL LETTER KIYEOK..HANGUL LETTER I
+3165..318E    ; Not_NFKC                       # 1.1   [42] HANGUL LETTER SSANGNIEUN..HANGUL LETTER ARAEAE
+3192..319F    ; Not_NFKC                       # 1.1   [14] IDEOGRAPHIC ANNOTATION ONE MARK..IDEOGRAPHIC ANNOTATION MAN MARK
+3200..321C    ; Not_NFKC                       # 1.1   [29] PARENTHESIZED HANGUL KIYEOK..PARENTHESIZED HANGUL CIEUC U
+321D..321E    ; Not_NFKC                       # 4.0    [2] PARENTHESIZED KOREAN CHARACTER OJEON..PARENTHESIZED KOREAN CHARACTER O HU
+3220..3243    ; Not_NFKC                       # 1.1   [36] PARENTHESIZED IDEOGRAPH ONE..PARENTHESIZED IDEOGRAPH REACH
+3244..3247    ; Not_NFKC                       # 5.2    [4] CIRCLED IDEOGRAPH QUESTION..CIRCLED IDEOGRAPH KOTO
+3250          ; Not_NFKC                       # 4.0        PARTNERSHIP SIGN
+3251..325F    ; Not_NFKC                       # 3.2   [15] CIRCLED NUMBER TWENTY ONE..CIRCLED NUMBER THIRTY FIVE
+3260..327B    ; Not_NFKC                       # 1.1   [28] CIRCLED HANGUL KIYEOK..CIRCLED HANGUL HIEUH A
+327C..327D    ; Not_NFKC                       # 4.0    [2] CIRCLED KOREAN CHARACTER CHAMKO..CIRCLED KOREAN CHARACTER JUEUI
+327E          ; Not_NFKC                       # 4.1        CIRCLED HANGUL IEUNG U
+3280..32B0    ; Not_NFKC                       # 1.1   [49] CIRCLED IDEOGRAPH ONE..CIRCLED IDEOGRAPH NIGHT
+32B1..32BF    ; Not_NFKC                       # 3.2   [15] CIRCLED NUMBER THIRTY SIX..CIRCLED NUMBER FIFTY
+32C0..32CB    ; Not_NFKC                       # 1.1   [12] IDEOGRAPHIC TELEGRAPH SYMBOL FOR JANUARY..IDEOGRAPHIC TELEGRAPH SYMBOL FOR DECEMBER
+32CC..32CF    ; Not_NFKC                       # 4.0    [4] SQUARE HG..LIMITED LIABILITY SIGN
+32D0..32FE    ; Not_NFKC                       # 1.1   [47] CIRCLED KATAKANA A..CIRCLED KATAKANA WO
+32FF          ; Not_NFKC                       # 12.1       SQUARE ERA NAME REIWA
+3300..3376    ; Not_NFKC                       # 1.1  [119] SQUARE APAATO..SQUARE PC
+3377..337A    ; Not_NFKC                       # 4.0    [4] SQUARE DM..SQUARE IU
+337B..33DD    ; Not_NFKC                       # 1.1   [99] SQUARE ERA NAME HEISEI..SQUARE WB
+33DE..33DF    ; Not_NFKC                       # 4.0    [2] SQUARE V OVER M..SQUARE A OVER M
+33E0..33FE    ; Not_NFKC                       # 1.1   [31] IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY ONE..IDEOGRAPHIC TELEGRAPH SYMBOL FOR DAY THIRTY-ONE
+33FF          ; Not_NFKC                       # 4.0        SQUARE GAL
+A69C..A69D    ; Not_NFKC                       # 7.0    [2] MODIFIER LETTER CYRILLIC HARD SIGN..MODIFIER LETTER CYRILLIC SOFT SIGN
+A770          ; Not_NFKC                       # 5.1        MODIFIER LETTER US
+A7F2..A7F4    ; Not_NFKC                       # 14.0   [3] MODIFIER LETTER CAPITAL C..MODIFIER LETTER CAPITAL Q
+A7F8..A7F9    ; Not_NFKC                       # 6.1    [2] MODIFIER LETTER CAPITAL H WITH STROKE..MODIFIER LETTER SMALL LIGATURE OE
+AB5C..AB5F    ; Not_NFKC                       # 7.0    [4] MODIFIER LETTER SMALL HENG..MODIFIER LETTER SMALL U WITH LEFT HOOK
+AB69          ; Not_NFKC                       # 13.0       MODIFIER LETTER SMALL TURNED W
+F900..FA0D    ; Not_NFKC                       # 1.1  [270] CJK COMPATIBILITY IDEOGRAPH-F900..CJK COMPATIBILITY IDEOGRAPH-FA0D
+FA10          ; Not_NFKC                       # 1.1        CJK COMPATIBILITY IDEOGRAPH-FA10
+FA12          ; Not_NFKC                       # 1.1        CJK COMPATIBILITY IDEOGRAPH-FA12
+FA15..FA1E    ; Not_NFKC                       # 1.1   [10] CJK COMPATIBILITY IDEOGRAPH-FA15..CJK COMPATIBILITY IDEOGRAPH-FA1E
+FA20          ; Not_NFKC                       # 1.1        CJK COMPATIBILITY IDEOGRAPH-FA20
+FA22          ; Not_NFKC                       # 1.1        CJK COMPATIBILITY IDEOGRAPH-FA22
+FA25..FA26    ; Not_NFKC                       # 1.1    [2] CJK COMPATIBILITY IDEOGRAPH-FA25..CJK COMPATIBILITY IDEOGRAPH-FA26
+FA2A..FA2D    ; Not_NFKC                       # 1.1    [4] CJK COMPATIBILITY IDEOGRAPH-FA2A..CJK COMPATIBILITY IDEOGRAPH-FA2D
+FA2E..FA2F    ; Not_NFKC                       # 6.1    [2] CJK COMPATIBILITY IDEOGRAPH-FA2E..CJK COMPATIBILITY IDEOGRAPH-FA2F
+FA30..FA6A    ; Not_NFKC                       # 3.2   [59] CJK COMPATIBILITY IDEOGRAPH-FA30..CJK COMPATIBILITY IDEOGRAPH-FA6A
+FA6B..FA6D    ; Not_NFKC                       # 5.2    [3] CJK COMPATIBILITY IDEOGRAPH-FA6B..CJK COMPATIBILITY IDEOGRAPH-FA6D
+FA70..FAD9    ; Not_NFKC                       # 4.1  [106] CJK COMPATIBILITY IDEOGRAPH-FA70..CJK COMPATIBILITY IDEOGRAPH-FAD9
+FB00..FB06    ; Not_NFKC                       # 1.1    [7] LATIN SMALL LIGATURE FF..LATIN SMALL LIGATURE ST
+FB13..FB17    ; Not_NFKC                       # 1.1    [5] ARMENIAN SMALL LIGATURE MEN NOW..ARMENIAN SMALL LIGATURE MEN XEH
+FB1D          ; Not_NFKC                       # 3.0        HEBREW LETTER YOD WITH HIRIQ
+FB1F..FB36    ; Not_NFKC                       # 1.1   [24] HEBREW LIGATURE YIDDISH YOD YOD PATAH..HEBREW LETTER ZAYIN WITH DAGESH
+FB38..FB3C    ; Not_NFKC                       # 1.1    [5] HEBREW LETTER TET WITH DAGESH..HEBREW LETTER LAMED WITH DAGESH
+FB3E          ; Not_NFKC                       # 1.1        HEBREW LETTER MEM WITH DAGESH
+FB40..FB41    ; Not_NFKC                       # 1.1    [2] HEBREW LETTER NUN WITH DAGESH..HEBREW LETTER SAMEKH WITH DAGESH
+FB43..FB44    ; Not_NFKC                       # 1.1    [2] HEBREW LETTER FINAL PE WITH DAGESH..HEBREW LETTER PE WITH DAGESH
+FB46..FBB1    ; Not_NFKC                       # 1.1  [108] HEBREW LETTER TSADI WITH DAGESH..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE FINAL FORM
+FBD3..FD3D    ; Not_NFKC                       # 1.1  [363] ARABIC LETTER NG ISOLATED FORM..ARABIC LIGATURE ALEF WITH FATHATAN ISOLATED FORM
+FD50..FD8F    ; Not_NFKC                       # 1.1   [64] ARABIC LIGATURE TEH WITH JEEM WITH MEEM INITIAL FORM..ARABIC LIGATURE MEEM WITH KHAH WITH MEEM INITIAL FORM
+FD92..FDC7    ; Not_NFKC                       # 1.1   [54] ARABIC LIGATURE MEEM WITH JEEM WITH KHAH INITIAL FORM..ARABIC LIGATURE NOON WITH JEEM WITH YEH FINAL FORM
+FDF0..FDFB    ; Not_NFKC                       # 1.1   [12] ARABIC LIGATURE SALLA USED AS KORANIC STOP SIGN ISOLATED FORM..ARABIC LIGATURE JALLAJALALOUHOU
+FDFC          ; Not_NFKC                       # 3.2        RIAL SIGN
+FE10..FE19    ; Not_NFKC                       # 4.1   [10] PRESENTATION FORM FOR VERTICAL COMMA..PRESENTATION FORM FOR VERTICAL HORIZONTAL ELLIPSIS
+FE30..FE44    ; Not_NFKC                       # 1.1   [21] PRESENTATION FORM FOR VERTICAL TWO DOT LEADER..PRESENTATION FORM FOR VERTICAL RIGHT WHITE CORNER BRACKET
+FE47..FE48    ; Not_NFKC                       # 4.0    [2] PRESENTATION FORM FOR VERTICAL LEFT SQUARE BRACKET..PRESENTATION FORM FOR VERTICAL RIGHT SQUARE BRACKET
+FE49..FE52    ; Not_NFKC                       # 1.1   [10] DASHED OVERLINE..SMALL FULL STOP
+FE54..FE66    ; Not_NFKC                       # 1.1   [19] SMALL SEMICOLON..SMALL EQUALS SIGN
+FE68..FE6B    ; Not_NFKC                       # 1.1    [4] SMALL REVERSE SOLIDUS..SMALL COMMERCIAL AT
+FE70..FE72    ; Not_NFKC                       # 1.1    [3] ARABIC FATHATAN ISOLATED FORM..ARABIC DAMMATAN ISOLATED FORM
+FE74          ; Not_NFKC                       # 1.1        ARABIC KASRATAN ISOLATED FORM
+FE76..FEFC    ; Not_NFKC                       # 1.1  [135] ARABIC FATHA ISOLATED FORM..ARABIC LIGATURE LAM WITH ALEF FINAL FORM
+FF01..FF5E    ; Not_NFKC                       # 1.1   [94] FULLWIDTH EXCLAMATION MARK..FULLWIDTH TILDE
+FF5F..FF60    ; Not_NFKC                       # 3.2    [2] FULLWIDTH LEFT WHITE PARENTHESIS..FULLWIDTH RIGHT WHITE PARENTHESIS
+FF61..FF9F    ; Not_NFKC                       # 1.1   [63] HALFWIDTH IDEOGRAPHIC FULL STOP..HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK
+FFA1..FFBE    ; Not_NFKC                       # 1.1   [30] HALFWIDTH HANGUL LETTER KIYEOK..HALFWIDTH HANGUL LETTER HIEUH
+FFC2..FFC7    ; Not_NFKC                       # 1.1    [6] HALFWIDTH HANGUL LETTER A..HALFWIDTH HANGUL LETTER E
+FFCA..FFCF    ; Not_NFKC                       # 1.1    [6] HALFWIDTH HANGUL LETTER YEO..HALFWIDTH HANGUL LETTER OE
+FFD2..FFD7    ; Not_NFKC                       # 1.1    [6] HALFWIDTH HANGUL LETTER YO..HALFWIDTH HANGUL LETTER YU
+FFDA..FFDC    ; Not_NFKC                       # 1.1    [3] HALFWIDTH HANGUL LETTER EU..HALFWIDTH HANGUL LETTER I
+FFE0..FFE6    ; Not_NFKC                       # 1.1    [7] FULLWIDTH CENT SIGN..FULLWIDTH WON SIGN
+FFE8..FFEE    ; Not_NFKC                       # 1.1    [7] HALFWIDTH FORMS LIGHT VERTICAL..HALFWIDTH WHITE CIRCLE
+10781..10785  ; Not_NFKC                       # 14.0   [5] MODIFIER LETTER SUPERSCRIPT TRIANGULAR COLON..MODIFIER LETTER SMALL B WITH HOOK
+10787..107B0  ; Not_NFKC                       # 14.0  [42] MODIFIER LETTER SMALL DZ DIGRAPH..MODIFIER LETTER SMALL V WITH RIGHT HOOK
+107B2..107BA  ; Not_NFKC                       # 14.0   [9] MODIFIER LETTER SMALL CAPITAL Y..MODIFIER LETTER SMALL S WITH CURL
+1D15E..1D164  ; Not_NFKC                       # 3.1    [7] MUSICAL SYMBOL HALF NOTE..MUSICAL SYMBOL ONE HUNDRED TWENTY-EIGHTH NOTE
+1D1BB..1D1C0  ; Not_NFKC                       # 3.1    [6] MUSICAL SYMBOL MINIMA..MUSICAL SYMBOL FUSA BLACK
+1D400..1D454  ; Not_NFKC                       # 3.1   [85] MATHEMATICAL BOLD CAPITAL A..MATHEMATICAL ITALIC SMALL G
+1D456..1D49C  ; Not_NFKC                       # 3.1   [71] MATHEMATICAL ITALIC SMALL I..MATHEMATICAL SCRIPT CAPITAL A
+1D49E..1D49F  ; Not_NFKC                       # 3.1    [2] MATHEMATICAL SCRIPT CAPITAL C..MATHEMATICAL SCRIPT CAPITAL D
+1D4A2         ; Not_NFKC                       # 3.1        MATHEMATICAL SCRIPT CAPITAL G
+1D4A5..1D4A6  ; Not_NFKC                       # 3.1    [2] MATHEMATICAL SCRIPT CAPITAL J..MATHEMATICAL SCRIPT CAPITAL K
+1D4A9..1D4AC  ; Not_NFKC                       # 3.1    [4] MATHEMATICAL SCRIPT CAPITAL N..MATHEMATICAL SCRIPT CAPITAL Q
+1D4AE..1D4B9  ; Not_NFKC                       # 3.1   [12] MATHEMATICAL SCRIPT CAPITAL S..MATHEMATICAL SCRIPT SMALL D
+1D4BB         ; Not_NFKC                       # 3.1        MATHEMATICAL SCRIPT SMALL F
+1D4BD..1D4C0  ; Not_NFKC                       # 3.1    [4] MATHEMATICAL SCRIPT SMALL H..MATHEMATICAL SCRIPT SMALL K
+1D4C1         ; Not_NFKC                       # 4.0        MATHEMATICAL SCRIPT SMALL L
+1D4C2..1D4C3  ; Not_NFKC                       # 3.1    [2] MATHEMATICAL SCRIPT SMALL M..MATHEMATICAL SCRIPT SMALL N
+1D4C5..1D505  ; Not_NFKC                       # 3.1   [65] MATHEMATICAL SCRIPT SMALL P..MATHEMATICAL FRAKTUR CAPITAL B
+1D507..1D50A  ; Not_NFKC                       # 3.1    [4] MATHEMATICAL FRAKTUR CAPITAL D..MATHEMATICAL FRAKTUR CAPITAL G
+1D50D..1D514  ; Not_NFKC                       # 3.1    [8] MATHEMATICAL FRAKTUR CAPITAL J..MATHEMATICAL FRAKTUR CAPITAL Q
+1D516..1D51C  ; Not_NFKC                       # 3.1    [7] MATHEMATICAL FRAKTUR CAPITAL S..MATHEMATICAL FRAKTUR CAPITAL Y
+1D51E..1D539  ; Not_NFKC                       # 3.1   [28] MATHEMATICAL FRAKTUR SMALL A..MATHEMATICAL DOUBLE-STRUCK CAPITAL B
+1D53B..1D53E  ; Not_NFKC                       # 3.1    [4] MATHEMATICAL DOUBLE-STRUCK CAPITAL D..MATHEMATICAL DOUBLE-STRUCK CAPITAL G
+1D540..1D544  ; Not_NFKC                       # 3.1    [5] MATHEMATICAL DOUBLE-STRUCK CAPITAL I..MATHEMATICAL DOUBLE-STRUCK CAPITAL M
+1D546         ; Not_NFKC                       # 3.1        MATHEMATICAL DOUBLE-STRUCK CAPITAL O
+1D54A..1D550  ; Not_NFKC                       # 3.1    [7] MATHEMATICAL DOUBLE-STRUCK CAPITAL S..MATHEMATICAL DOUBLE-STRUCK CAPITAL Y
+1D552..1D6A3  ; Not_NFKC                       # 3.1  [338] MATHEMATICAL DOUBLE-STRUCK SMALL A..MATHEMATICAL MONOSPACE SMALL Z
+1D6A4..1D6A5  ; Not_NFKC                       # 4.1    [2] MATHEMATICAL ITALIC SMALL DOTLESS I..MATHEMATICAL ITALIC SMALL DOTLESS J
+1D6A8..1D7C9  ; Not_NFKC                       # 3.1  [290] MATHEMATICAL BOLD CAPITAL ALPHA..MATHEMATICAL SANS-SERIF BOLD ITALIC PI SYMBOL
+1D7CA..1D7CB  ; Not_NFKC                       # 5.0    [2] MATHEMATICAL BOLD CAPITAL DIGAMMA..MATHEMATICAL BOLD SMALL DIGAMMA
+1D7CE..1D7FF  ; Not_NFKC                       # 3.1   [50] MATHEMATICAL BOLD DIGIT ZERO..MATHEMATICAL MONOSPACE DIGIT NINE
+1EE00..1EE03  ; Not_NFKC                       # 6.1    [4] ARABIC MATHEMATICAL ALEF..ARABIC MATHEMATICAL DAL
+1EE05..1EE1F  ; Not_NFKC                       # 6.1   [27] ARABIC MATHEMATICAL WAW..ARABIC MATHEMATICAL DOTLESS QAF
+1EE21..1EE22  ; Not_NFKC                       # 6.1    [2] ARABIC MATHEMATICAL INITIAL BEH..ARABIC MATHEMATICAL INITIAL JEEM
+1EE24         ; Not_NFKC                       # 6.1        ARABIC MATHEMATICAL INITIAL HEH
+1EE27         ; Not_NFKC                       # 6.1        ARABIC MATHEMATICAL INITIAL HAH
+1EE29..1EE32  ; Not_NFKC                       # 6.1   [10] ARABIC MATHEMATICAL INITIAL YEH..ARABIC MATHEMATICAL INITIAL QAF
+1EE34..1EE37  ; Not_NFKC                       # 6.1    [4] ARABIC MATHEMATICAL INITIAL SHEEN..ARABIC MATHEMATICAL INITIAL KHAH
+1EE39         ; Not_NFKC                       # 6.1        ARABIC MATHEMATICAL INITIAL DAD
+1EE3B         ; Not_NFKC                       # 6.1        ARABIC MATHEMATICAL INITIAL GHAIN
+1EE42         ; Not_NFKC                       # 6.1        ARABIC MATHEMATICAL TAILED JEEM
+1EE47         ; Not_NFKC                       # 6.1        ARABIC MATHEMATICAL TAILED HAH
+1EE49         ; Not_NFKC                       # 6.1        ARABIC MATHEMATICAL TAILED YEH
+1EE4B         ; Not_NFKC                       # 6.1        ARABIC MATHEMATICAL TAILED LAM
+1EE4D..1EE4F  ; Not_NFKC                       # 6.1    [3] ARABIC MATHEMATICAL TAILED NOON..ARABIC MATHEMATICAL TAILED AIN
+1EE51..1EE52  ; Not_NFKC                       # 6.1    [2] ARABIC MATHEMATICAL TAILED SAD..ARABIC MATHEMATICAL TAILED QAF
+1EE54         ; Not_NFKC                       # 6.1        ARABIC MATHEMATICAL TAILED SHEEN
+1EE57         ; Not_NFKC                       # 6.1        ARABIC MATHEMATICAL TAILED KHAH
+1EE59         ; Not_NFKC                       # 6.1        ARABIC MATHEMATICAL TAILED DAD
+1EE5B         ; Not_NFKC                       # 6.1        ARABIC MATHEMATICAL TAILED GHAIN
+1EE5D         ; Not_NFKC                       # 6.1        ARABIC MATHEMATICAL TAILED DOTLESS NOON
+1EE5F         ; Not_NFKC                       # 6.1        ARABIC MATHEMATICAL TAILED DOTLESS QAF
+1EE61..1EE62  ; Not_NFKC                       # 6.1    [2] ARABIC MATHEMATICAL STRETCHED BEH..ARABIC MATHEMATICAL STRETCHED JEEM
+1EE64         ; Not_NFKC                       # 6.1        ARABIC MATHEMATICAL STRETCHED HEH
+1EE67..1EE6A  ; Not_NFKC                       # 6.1    [4] ARABIC MATHEMATICAL STRETCHED HAH..ARABIC MATHEMATICAL STRETCHED KAF
+1EE6C..1EE72  ; Not_NFKC                       # 6.1    [7] ARABIC MATHEMATICAL STRETCHED MEEM..ARABIC MATHEMATICAL STRETCHED QAF
+1EE74..1EE77  ; Not_NFKC                       # 6.1    [4] ARABIC MATHEMATICAL STRETCHED SHEEN..ARABIC MATHEMATICAL STRETCHED KHAH
+1EE79..1EE7C  ; Not_NFKC                       # 6.1    [4] ARABIC MATHEMATICAL STRETCHED DAD..ARABIC MATHEMATICAL STRETCHED DOTLESS BEH
+1EE7E         ; Not_NFKC                       # 6.1        ARABIC MATHEMATICAL STRETCHED DOTLESS FEH
+1EE80..1EE89  ; Not_NFKC                       # 6.1   [10] ARABIC MATHEMATICAL LOOPED ALEF..ARABIC MATHEMATICAL LOOPED YEH
+1EE8B..1EE9B  ; Not_NFKC                       # 6.1   [17] ARABIC MATHEMATICAL LOOPED LAM..ARABIC MATHEMATICAL LOOPED GHAIN
+1EEA1..1EEA3  ; Not_NFKC                       # 6.1    [3] ARABIC MATHEMATICAL DOUBLE-STRUCK BEH..ARABIC MATHEMATICAL DOUBLE-STRUCK DAL
+1EEA5..1EEA9  ; Not_NFKC                       # 6.1    [5] ARABIC MATHEMATICAL DOUBLE-STRUCK WAW..ARABIC MATHEMATICAL DOUBLE-STRUCK YEH
+1EEAB..1EEBB  ; Not_NFKC                       # 6.1   [17] ARABIC MATHEMATICAL DOUBLE-STRUCK LAM..ARABIC MATHEMATICAL DOUBLE-STRUCK GHAIN
+1F100..1F10A  ; Not_NFKC                       # 5.2   [11] DIGIT ZERO FULL STOP..DIGIT NINE COMMA
+1F110..1F12E  ; Not_NFKC                       # 5.2   [31] PARENTHESIZED LATIN CAPITAL LETTER A..CIRCLED WZ
+1F130         ; Not_NFKC                       # 6.0        SQUARED LATIN CAPITAL LETTER A
+1F131         ; Not_NFKC                       # 5.2        SQUARED LATIN CAPITAL LETTER B
+1F132..1F13C  ; Not_NFKC                       # 6.0   [11] SQUARED LATIN CAPITAL LETTER C..SQUARED LATIN CAPITAL LETTER M
+1F13D         ; Not_NFKC                       # 5.2        SQUARED LATIN CAPITAL LETTER N
+1F13E         ; Not_NFKC                       # 6.0        SQUARED LATIN CAPITAL LETTER O
+1F13F         ; Not_NFKC                       # 5.2        SQUARED LATIN CAPITAL LETTER P
+1F140..1F141  ; Not_NFKC                       # 6.0    [2] SQUARED LATIN CAPITAL LETTER Q..SQUARED LATIN CAPITAL LETTER R
+1F142         ; Not_NFKC                       # 5.2        SQUARED LATIN CAPITAL LETTER S
+1F143..1F145  ; Not_NFKC                       # 6.0    [3] SQUARED LATIN CAPITAL LETTER T..SQUARED LATIN CAPITAL LETTER V
+1F146         ; Not_NFKC                       # 5.2        SQUARED LATIN CAPITAL LETTER W
+1F147..1F149  ; Not_NFKC                       # 6.0    [3] SQUARED LATIN CAPITAL LETTER X..SQUARED LATIN CAPITAL LETTER Z
+1F14A..1F14E  ; Not_NFKC                       # 5.2    [5] SQUARED HV..SQUARED PPV
+1F14F         ; Not_NFKC                       # 6.0        SQUARED WC
+1F16A..1F16B  ; Not_NFKC                       # 6.1    [2] RAISED MC SIGN..RAISED MD SIGN
+1F16C         ; Not_NFKC                       # 12.0       RAISED MR SIGN
+1F190         ; Not_NFKC                       # 5.2        SQUARE DJ
+1F200         ; Not_NFKC                       # 5.2        SQUARE HIRAGANA HOKA
+1F201..1F202  ; Not_NFKC                       # 6.0    [2] SQUARED KATAKANA KOKO..SQUARED KATAKANA SA
+1F210..1F231  ; Not_NFKC                       # 5.2   [34] SQUARED CJK UNIFIED IDEOGRAPH-624B..SQUARED CJK UNIFIED IDEOGRAPH-6253
+1F232..1F23A  ; Not_NFKC                       # 6.0    [9] SQUARED CJK UNIFIED IDEOGRAPH-7981..SQUARED CJK UNIFIED IDEOGRAPH-55B6
+1F23B         ; Not_NFKC                       # 9.0        SQUARED CJK UNIFIED IDEOGRAPH-914D
+1F240..1F248  ; Not_NFKC                       # 5.2    [9] TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-672C..TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-6557
+1F250..1F251  ; Not_NFKC                       # 6.0    [2] CIRCLED IDEOGRAPH ADVANTAGE..CIRCLED IDEOGRAPH ACCEPT
+1FBF0..1FBF9  ; Not_NFKC                       # 13.0  [10] SEGMENTED DIGIT ZERO..SEGMENTED DIGIT NINE
+2F800..2FA1D  ; Not_NFKC                       # 3.1  [542] CJK COMPATIBILITY IDEOGRAPH-2F800..CJK COMPATIBILITY IDEOGRAPH-2FA1D
+
+# Total code points: 4859
+
+#	Identifier_Type:	Default_Ignorable
+
+00AD          ; Default_Ignorable              # 1.1        SOFT HYPHEN
+034F          ; Default_Ignorable              # 3.2        COMBINING GRAPHEME JOINER
+061C          ; Default_Ignorable              # 6.3        ARABIC LETTER MARK
+115F..1160    ; Default_Ignorable              # 1.1    [2] HANGUL CHOSEONG FILLER..HANGUL JUNGSEONG FILLER
+17B4..17B5    ; Default_Ignorable              # 3.0    [2] KHMER VOWEL INHERENT AQ..KHMER VOWEL INHERENT AA
+180B..180D    ; Default_Ignorable              # 3.0    [3] MONGOLIAN FREE VARIATION SELECTOR ONE..MONGOLIAN FREE VARIATION SELECTOR THREE
+180E          ; Default_Ignorable              # 3.0        MONGOLIAN VOWEL SEPARATOR
+180F          ; Default_Ignorable              # 14.0       MONGOLIAN FREE VARIATION SELECTOR FOUR
+200B          ; Default_Ignorable              # 1.1        ZERO WIDTH SPACE
+200E..200F    ; Default_Ignorable              # 1.1    [2] LEFT-TO-RIGHT MARK..RIGHT-TO-LEFT MARK
+202A..202E    ; Default_Ignorable              # 1.1    [5] LEFT-TO-RIGHT EMBEDDING..RIGHT-TO-LEFT OVERRIDE
+2060..2063    ; Default_Ignorable              # 3.2    [4] WORD JOINER..INVISIBLE SEPARATOR
+2064          ; Default_Ignorable              # 5.1        INVISIBLE PLUS
+2066..2069    ; Default_Ignorable              # 6.3    [4] LEFT-TO-RIGHT ISOLATE..POP DIRECTIONAL ISOLATE
+3164          ; Default_Ignorable              # 1.1        HANGUL FILLER
+FE00..FE0F    ; Default_Ignorable              # 3.2   [16] VARIATION SELECTOR-1..VARIATION SELECTOR-16
+FEFF          ; Default_Ignorable              # 1.1        ZERO WIDTH NO-BREAK SPACE
+FFA0          ; Default_Ignorable              # 1.1        HALFWIDTH HANGUL FILLER
+1BCA0..1BCA3  ; Default_Ignorable              # 7.0    [4] SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP
+1D173..1D17A  ; Default_Ignorable              # 3.1    [8] MUSICAL SYMBOL BEGIN BEAM..MUSICAL SYMBOL END PHRASE
+E0020..E007F  ; Default_Ignorable              # 3.1   [96] TAG SPACE..CANCEL TAG
+E0100..E01EF  ; Default_Ignorable              # 4.0  [240] VARIATION SELECTOR-17..VARIATION SELECTOR-256
+
+# Total code points: 396
+
+#	Identifier_Type:	Deprecated
+
+0149          ; Deprecated                     # 1.1        LATIN SMALL LETTER N PRECEDED BY APOSTROPHE
+0673          ; Deprecated                     # 1.1        ARABIC LETTER ALEF WITH WAVY HAMZA BELOW
+0F77          ; Deprecated                     # 2.0        TIBETAN VOWEL SIGN VOCALIC RR
+0F79          ; Deprecated                     # 2.0        TIBETAN VOWEL SIGN VOCALIC LL
+17A3..17A4    ; Deprecated                     # 3.0    [2] KHMER INDEPENDENT VOWEL QAQ..KHMER INDEPENDENT VOWEL QAA
+206A..206F    ; Deprecated                     # 1.1    [6] INHIBIT SYMMETRIC SWAPPING..NOMINAL DIGIT SHAPES
+2329..232A    ; Deprecated                     # 1.1    [2] LEFT-POINTING ANGLE BRACKET..RIGHT-POINTING ANGLE BRACKET
+E0001         ; Deprecated                     # 3.1        LANGUAGE TAG
+
+# Total code points: 15

--- a/lib/elixir/unicode/unicode.ex
+++ b/lib/elixir/unicode/unicode.ex
@@ -5,8 +5,9 @@
 # 1. Replace UnicodeData.txt by copying original
 # 2. Replace PropList.txt by copying original
 # 3. Replace SpecialCasing.txt by copying original and removing conditional mappings
-# 4. Update String.Unicode.version/0 and on String module docs (version and link)
-# 5. make unicode
+# 4. Replace IdentifierType.txt by copying original from /Public/security/
+# 5. Update String.Unicode.version/0 and on String module docs (version and link)
+# 6. make unicode
 
 data_path = Path.join(__DIR__, "UnicodeData.txt")
 


### PR DESCRIPTION
(This was originally extracted from the [reference implementation of UTS39](https://github.com/elixir-lang/elixir/pull/11569), which has a much higher-level overview).

This PR prevents Elixir identifiers from including \p{Identifier_Status=Restricted} codepoints; implemented using the unicode 'IdentifierTypes' that correspond to the 'Restricted' status, so that if Elixir wanted to allow some additional 'IdentifierTypes' like eg. 'Technical' characters it could do so, while still preventing 'Uncommon_Use' or 'Obsolete' codepoints (if documented, still conformant w/uts39). This impl conforms with UTS 39, clause 1 ('general security profile for identifiers'); added a new page to docs, with subheading for Clauses C1-C5 from the standard, similar to how unicode-syntax.md has R1-R6 for the Requirements in that annex of the standard, as I think the plan would be to add the 3 primary protections from the reference impl (which Rust also uses).

Example of change, w/an invisible Hangul Filler character which was previously valid in identifiers:

```
iex> ㅤ = 1
 ... unexpected token: "ㅤ" \(column 1, code point U\+3164\)
```