### PR TITLE
Fix duplicate bindings causing weird behaviour

### DIFF
--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -292,7 +292,7 @@ normalize_binding([Binding | NextBindings], VarsMap, Normalized, Counter) ->
     #{Pair := _} ->
       normalize_binding(NextBindings, VarsMap, [{Pair, Value} | Normalized], Counter);
     #{} ->
-      normalize_binding(NextBindings, maps:put(Pair, Counter, VarsMap), [{Pair, Value} | Normalized], Counter + 1)
+      normalize_binding(NextBindings, VarsMap#{Pair => Counter}, [{Pair, Value} | Normalized], Counter + 1)
   end;
 
 normalize_binding([], VarsMap, Normalized, _Counter) ->

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -294,7 +294,6 @@ normalize_binding([Binding | NextBindings], VarsMap, Normalized, Counter) ->
     #{} ->
       normalize_binding(NextBindings, VarsMap#{Pair => Counter}, [{Pair, Value} | Normalized], Counter + 1)
   end;
-
 normalize_binding([], VarsMap, Normalized, _Counter) ->
   {VarsMap, Normalized}.
 

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -286,11 +286,6 @@ eval_forms(Tree, RawBinding, OrigE) ->
       {Value, elixir_erl_var:dump_binding(NewBinding, NewExS, NewErlS), NewE}
   end.
 
-normalize_pair({Key, Value}) when is_atom(Key) ->
-  {{Key, nil}, Value};
-normalize_pair({Pair, Value}) ->
-  {Pair, Value}.
-
 normalize_binding([Binding | NextBindings], VarsMap, Normalized, Counter) ->
   {Pair, Value} = normalize_pair(Binding),
   case VarsMap of
@@ -302,6 +297,9 @@ normalize_binding([Binding | NextBindings], VarsMap, Normalized, Counter) ->
 
 normalize_binding([], VarsMap, Normalized, _Counter) ->
   {VarsMap, Normalized}.
+
+normalize_pair({Key, Value}) when is_atom(Key) -> {{Key, nil}, Value};
+normalize_pair({Pair, Value}) -> {Pair, Value}.
 
 recur_eval([Expr | Exprs], Binding, Env) ->
   {value, Value, NewBinding} =

--- a/lib/elixir/src/elixir.erl
+++ b/lib/elixir/src/elixir.erl
@@ -298,7 +298,7 @@ normalize_binding(RawBindings) ->
       nil ->
         {maps:put(Pair, Counter, Map), Counter + 1, [{Pair, Value} | Normalized]};
       C ->
-        {maps:put(Pair, C, Map), Counter, [{Pair, Value} | Normalized]}
+        {Map, Counter, [{Pair, Value} | Normalized]}
     end
   end,
   {#{}, 0, []}, RawBindings),

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -50,8 +50,8 @@ defmodule CodeTest do
 
     test "does not raise on duplicate bindings" do
       # The order of which values win is not guaranteed, but it should evaluate successfully.
-      assert Code.eval_string("b = String.Chars.to_string(a)", a: 0, a: 1) ==
-               {"1", [{:b, "1"}, {:a, 1}]}
+      assert Code.eval_string("b = String.Chars.to_string(a)", a: 0, a: 1, c: 2) ==
+               {"1", [{:c, 2}, {:b, "1"}, {:a, 1}]}
     end
 
     test "with many options" do

--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -50,6 +50,9 @@ defmodule CodeTest do
 
     test "does not raise on duplicate bindings" do
       # The order of which values win is not guaranteed, but it should evaluate successfully.
+      assert Code.eval_string("b = String.Chars.to_string(a)", a: 0, a: 1) ==
+               {"1", [{:b, "1"}, {:a, 1}]}
+
       assert Code.eval_string("b = String.Chars.to_string(a)", a: 0, a: 1, c: 2) ==
                {"1", [{:c, 2}, {:b, "1"}, {:a, 1}]}
     end


### PR DESCRIPTION
Before this fix, evaluating `b = a` with assignments of: `a: 1, a: 2, c:
3` would eval AST equivalent to `^c = a`. This happened due to binding
normalization generating version numbers larger than the total number of
bindings. Later in the pipeline, the number of bindings is used to
compute the next version number, which would then conflict with an
existing binding.

This commit fixes that by not increasing the version number when
a repeated binding is normalized.

Closes #11581