### PR TITLE
Embedded Elixir Expressions in Formatter Plugins

### DIFF
--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -247,12 +247,13 @@ defmodule Mix.Tasks.FormatTest do
 
     def features(opts) do
       assert opts[:from_formatter_exs] == :yes
-      [extensions: ~w(.w)]
+      [extensions: ~w(.w), sigils: [:W]]
     end
 
     def format(contents, opts) do
       assert opts[:from_formatter_exs] == :yes
       assert opts[:extension] == ".w"
+      assert [W: _fun] = opts[:sigils]
       contents |> String.split(~r/\s/) |> Enum.join("\n")
     end
   end


### PR DESCRIPTION
Support Sigils inside embedded expressions in files formatted by a formatter plugin.
Implementation of https://groups.google.com/g/elixir-lang-core/c/jFswzSUjsP4