### PR TITLE
Supply file and line to formatter plugins

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -177,7 +177,7 @@ defmodule Code.Formatter do
   defp state(comments, opts) do
     force_do_end_blocks = Keyword.get(opts, :force_do_end_blocks, false)
     locals_without_parens = Keyword.get(opts, :locals_without_parens, [])
-    file = Keyword.get(opts, :file, "")
+    file = Keyword.get(opts, :file, nil)
     sigils = Keyword.get(opts, :sigils, [])
 
     sigils =
@@ -1320,12 +1320,14 @@ defmodule Code.Formatter do
       entries =
         case state.sigils do
           %{^name => callback} ->
-            case callback.(hd(entries),
-                   file: state[:file],
-                   line: meta[:line],
-                   sigil: List.to_atom([name]),
-                   modifiers: modifiers
-                 ) do
+            metadata = [
+              file: state.file,
+              line: meta[:line],
+              sigil: List.to_atom([name]),
+              modifiers: modifiers
+            ]
+
+            case callback.(hd(entries), metadata) do
               binary when is_binary(binary) ->
                 [binary]
 

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -177,6 +177,7 @@ defmodule Code.Formatter do
   defp state(comments, opts) do
     force_do_end_blocks = Keyword.get(opts, :force_do_end_blocks, false)
     locals_without_parens = Keyword.get(opts, :locals_without_parens, [])
+    file = Keyword.get(opts, :file, "")
     sigils = Keyword.get(opts, :sigils, [])
 
     sigils =
@@ -199,7 +200,8 @@ defmodule Code.Formatter do
       operand_nesting: 2,
       skip_eol: false,
       comments: comments,
-      sigils: sigils
+      sigils: sigils,
+      file: file
     }
   end
 
@@ -1318,7 +1320,12 @@ defmodule Code.Formatter do
       entries =
         case state.sigils do
           %{^name => callback} ->
-            case callback.(hd(entries), sigil: List.to_atom([name]), modifiers: modifiers) do
+            case callback.(hd(entries),
+                   file: state[:file],
+                   line: meta[:line],
+                   sigil: List.to_atom([name]),
+                   modifiers: modifiers
+                 ) do
               binary when is_binary(binary) ->
                 [binary]
 

--- a/lib/elixir/test/elixir/code_formatter/general_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/general_test.exs
@@ -126,7 +126,7 @@ defmodule Code.Formatter.GeneralTest do
       """
 
       formatter = fn content, opts ->
-        assert opts == [sigil: :W, modifiers: []]
+        assert opts == [file: "", line: 1, sigil: :W, modifiers: []]
         content |> String.split(~r/ +/) |> Enum.join(" ")
       end
 
@@ -141,7 +141,7 @@ defmodule Code.Formatter.GeneralTest do
       """
 
       formatter = fn content, opts ->
-        assert opts == [sigil: :W, modifiers: 'abc']
+        assert opts == [file: "", line: 1, sigil: :W, modifiers: 'abc']
         content |> String.split(~r/ +/) |> Enum.join(" ")
       end
 
@@ -162,7 +162,7 @@ defmodule Code.Formatter.GeneralTest do
       """
 
       formatter = fn content, opts ->
-        assert opts == [sigil: :W, modifiers: []]
+        assert opts == [file: "", line: 1, sigil: :W, modifiers: []]
         content |> String.split(~r/ +/) |> Enum.join(" ")
       end
 
@@ -189,7 +189,7 @@ defmodule Code.Formatter.GeneralTest do
       """
 
       formatter = fn content, opts ->
-        assert opts == [sigil: :W, modifiers: 'abc']
+        assert opts == [file: "", line: 2, sigil: :W, modifiers: 'abc']
         content |> String.split(~r/ +/) |> Enum.join("\n")
       end
 

--- a/lib/elixir/test/elixir/code_formatter/general_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/general_test.exs
@@ -126,7 +126,7 @@ defmodule Code.Formatter.GeneralTest do
       """
 
       formatter = fn content, opts ->
-        assert opts == [file: "", line: 1, sigil: :W, modifiers: []]
+        assert opts == [file: nil, line: 1, sigil: :W, modifiers: []]
         content |> String.split(~r/ +/) |> Enum.join(" ")
       end
 
@@ -141,7 +141,7 @@ defmodule Code.Formatter.GeneralTest do
       """
 
       formatter = fn content, opts ->
-        assert opts == [file: "", line: 1, sigil: :W, modifiers: 'abc']
+        assert opts == [file: nil, line: 1, sigil: :W, modifiers: 'abc']
         content |> String.split(~r/ +/) |> Enum.join(" ")
       end
 
@@ -162,7 +162,7 @@ defmodule Code.Formatter.GeneralTest do
       """
 
       formatter = fn content, opts ->
-        assert opts == [file: "", line: 1, sigil: :W, modifiers: []]
+        assert opts == [file: nil, line: 1, sigil: :W, modifiers: []]
         content |> String.split(~r/ +/) |> Enum.join(" ")
       end
 
@@ -189,7 +189,7 @@ defmodule Code.Formatter.GeneralTest do
       """
 
       formatter = fn content, opts ->
-        assert opts == [file: "", line: 2, sigil: :W, modifiers: 'abc']
+        assert opts == [file: nil, line: 2, sigil: :W, modifiers: 'abc']
         content |> String.split(~r/ +/) |> Enum.join("\n")
       end
 

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -504,7 +504,7 @@ defmodule Mix.Tasks.Format do
 
     cond do
       plugin = find_plugin_for_extension(formatter_opts, ext) ->
-        &plugin.format(&1, [extension: ext] ++ formatter_opts)
+        &plugin.format(&1, [extension: ext, file: file] ++ formatter_opts)
 
       ext in ~w(.ex .exs) ->
         &elixir_format(&1, [file: file] ++ formatter_opts)

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -206,6 +206,8 @@ defmodule Mix.Tasks.FormatTest do
       assert opts[:from_formatter_exs] == :yes
       assert opts[:sigil] == :W
       assert opts[:modifiers] == 'abc'
+      assert opts[:line] == 2
+      assert opts[:file] =~ ~r/\/a\.ex$/
       contents |> String.split(~r/\s/) |> Enum.join("\n")
     end
   end
@@ -253,6 +255,7 @@ defmodule Mix.Tasks.FormatTest do
     def format(contents, opts) do
       assert opts[:from_formatter_exs] == :yes
       assert opts[:extension] == ".w"
+      assert opts[:file] =~ ~r/\/a\.w$/
       assert [W: sigil_fun] = opts[:sigils]
       assert is_function(sigil_fun, 2)
       contents |> String.split(~r/\s/) |> Enum.join("\n")


### PR DESCRIPTION
Allows formatter plugins to print errors with accurate file and
line information. The line is only provided when a sigil is being
formatted.

Plugins would be able to log error information similar to how Code.format_string!/2
errors are logged for compile errors when formatting Elixir code.
