### PR TITLE
Add the ability to run tasks in given apps for umbrella applications

### DIFF
--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -332,7 +332,7 @@ defmodule Mix.Task do
       forgotten_apps = apps -- Enum.map(Mix.Dep.Umbrella.cached(), & &1.app)
 
       for app <- forgotten_apps do
-        Mix.shell().info([:yellow, "warning: could not find the #{inspect(app)} application"])
+        Mix.shell().info([:yellow, "warning: could not find application #{inspect(app)}"])
       end
     end
   end

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -348,7 +348,7 @@ defmodule Mix.Task do
   """
   @spec run(task_name, [any]) :: any
   def run(task, args \\ []) do
-    do_run(task, args)
+    do_run(task, args, nil)
   end
 
   @doc """
@@ -364,8 +364,6 @@ defmodule Mix.Task do
   def run_in_apps(task, apps, args \\ []) do
     do_run(task, args, apps)
   end
-
-  defp do_run(task, args, apps \\ nil)
 
   defp do_run(task, args, apps) when is_atom(task) do
     do_run(Atom.to_string(task), args, apps)
@@ -555,9 +553,12 @@ defmodule Mix.Task do
 
     cond do
       recursive && Mix.Project.umbrella?() ->
-        recur(fn proj ->
-          Mix.TasksServer.delete_many([{:task, task, proj}, {:alias, task, proj}])
-        end)
+        recur(
+          fn proj ->
+            Mix.TasksServer.delete_many([{:task, task, proj}, {:alias, task, proj}])
+          end,
+          nil
+        )
 
       proj = !recursive && Mix.ProjectStack.recursing() ->
         Mix.TasksServer.delete_many([{:task, task, proj}, {:alias, task, proj}])
@@ -569,7 +570,6 @@ defmodule Mix.Task do
     :ok
   end
 
-  defp recur(fun, apps \\ nil)
   defp recur(fun, nil), do: run_in_children_projects(fun, Mix.Dep.Umbrella.cached())
 
   defp recur(fun, apps) do

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -565,9 +565,7 @@ defmodule Mix.Task do
   defp recur(fun, apps) do
     selected_children =
       Mix.Dep.Umbrella.cached()
-      |> Enum.filter(fn %Mix.Dep{app: app} ->
-        app in apps
-      end)
+      |> Enum.filter(fn %Mix.Dep{app: app} -> app in apps end)
 
     run_in_children_projects(fun, selected_children)
   end

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -439,9 +439,7 @@ defmodule Mix.Task do
         run(task, args)
 
       not recursive && Mix.ProjectStack.recursing() ->
-        Mix.ProjectStack.on_recursing_root(fn ->
-          run(task, args)
-        end)
+        Mix.ProjectStack.on_recursing_root(fn -> run(task, args) end)
 
       Mix.TasksServer.run({:task, task, proj}) ->
         run_requirements(module)
@@ -621,7 +619,6 @@ defmodule Mix.Task do
     # Get all dependency configuration but not the deps path
     # as we leave the control of the deps path still to the
     # umbrella child.
-
     config = Mix.Project.deps_config() |> Keyword.delete(:deps_path)
 
     for %Mix.Dep{app: app, opts: opts} <- dependencies do

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -328,10 +328,12 @@ defmodule Mix.Task do
 
   @doc false
   def show_forgotten_apps_warning(apps) do
-    forgotten_apps = apps -- Enum.map(Mix.Dep.Umbrella.cached(), & &1.app)
+    if Mix.Project.umbrella?() do
+      forgotten_apps = apps -- Enum.map(Mix.Dep.Umbrella.cached(), & &1.app)
 
-    for app <- forgotten_apps do
-      Mix.shell().info([:yellow, "warning: could not find umbrella app #{inspect(app)}"])
+      for app <- forgotten_apps do
+        Mix.shell().info([:yellow, "warning: could not find the #{inspect(app)} application"])
+      end
     end
   end
 

--- a/lib/mix/lib/mix/tasks/do.ex
+++ b/lib/mix/lib/mix/tasks/do.ex
@@ -15,14 +15,24 @@ defmodule Mix.Tasks.Do do
 
       mix do compile --list, deps
 
-  Note however that the majority of Mix tasks are only
-  executed once per invocation. So for example, the following
-  command will only compile once:
+  You can limit where the tasks are run, in the context of
+  umbrella projects, by passing the app names using --app:
+
+      mix do --app app1 --app app2 compile --list, deps
+
+  Note that the majority of Mix tasks are only executed once
+  per invocation. So for example, the following command will
+  only compile once:
 
       mix do compile, some_other_command, compile
 
   When `compile` is executed again, Mix will notice the task
   has already ran, and skip it.
+
+  ## Command line options
+
+    * `--app` - limit running the tasks to the given app. This
+    option may be given multiple times.
   """
 
   @impl true

--- a/lib/mix/lib/mix/tasks/do.ex
+++ b/lib/mix/lib/mix/tasks/do.ex
@@ -31,8 +31,8 @@ defmodule Mix.Tasks.Do do
 
   ## Command line options
 
-    * `--app` - limit running the tasks to the given app. This
-    option may be given multiple times.
+    * `--app` - limit running the tasks to the given app. This option may
+      be given multiple times and must come before any of the tasks.
   """
 
   @impl true

--- a/lib/mix/test/mix/tasks/do_test.exs
+++ b/lib/mix/test/mix/tasks/do_test.exs
@@ -74,13 +74,12 @@ defmodule Mix.Tasks.DoTest do
     end)
   end
 
-  test "runs given tasks ignoring apps argument when project is not an umbrella" do
-    Mix.Tasks.Do.run(["--app", "bar", "--app", "foo", "cmd", "echo", "hello"])
-
-    assert_received {:mix_shell, :info,
-                     [
-                       "warning: running \"cmd\" at root level because this is not an umbrella project"
-                     ]}
+  test "raises when -app is given but the project is not an umbrella" do
+    assert_raise Mix.Error,
+                 "Could not run \"cmd\" with the --app option because this is not an umbrella project",
+                 fn ->
+                   Mix.Tasks.Do.run(["--app", "bar", "--app", "foo", "cmd", "echo", "hello"])
+                 end
   end
 
   test "runs given aliases for each app specified by app flag" do
@@ -120,7 +119,7 @@ defmodule Mix.Tasks.DoTest do
     end)
   end
 
-  test "runs given aliases ignoring apps argument when project is not an umbrella" do
+  test "raise with aliases when -app is given but the project is not an umbrella" do
     in_fixture("umbrella_dep/deps/umbrella", fn ->
       aliases = [
         e: ["cmd echo hello"],
@@ -128,17 +127,11 @@ defmodule Mix.Tasks.DoTest do
       ]
 
       Mix.Project.in_project(:foo, "apps/foo", [aliases: aliases], fn _ ->
-        Mix.Tasks.Do.run(["--app", "bar", "--app", "foo", "e,", "p", "Foo"])
-
-        assert_received {:mix_shell, :info,
-                         [
-                           "warning: running \"cmd\" at root level because this is not an umbrella project"
-                         ]}
-
-        assert_received {:mix_shell, :info,
-                         [
-                           "warning: running \"p\" at root level because this is not an umbrella project"
-                         ]}
+        assert_raise Mix.Error,
+                     "Could not run \"e\" with the --app option because this is not an umbrella project",
+                     fn ->
+                       Mix.Tasks.Do.run(["--app", "bar", "--app", "foo", "e,", "p", "Foo"])
+                     end
       end)
     end)
   end

--- a/lib/mix/test/mix/tasks/do_test.exs
+++ b/lib/mix/test/mix/tasks/do_test.exs
@@ -63,6 +63,17 @@ defmodule Mix.Tasks.DoTest do
     end)
   end
 
+  test "runs non-recursive tasks at project root level" do
+    in_fixture("umbrella_dep/deps/umbrella", fn ->
+      Mix.Project.in_project(:umbrella, ".", fn _ ->
+        Mix.Tasks.Do.run(["--app", "bar", "--app", "foo", "compile", "--list,", "help"])
+
+        assert_received {:mix_shell, :info, ["mix help" <> _]}
+        assert_received {:mix_shell, :info, ["mix compile.app" <> _]}
+      end)
+    end)
+  end
+
   test "runs given tasks ignoring apps argument when project is not an umbrella" do
     Mix.Tasks.Do.run(["--app", "bar", "--app", "foo", "cmd", "echo", "hello"])
 
@@ -91,6 +102,20 @@ defmodule Mix.Tasks.DoTest do
         assert_received {:mix_shell, :info, ["==> foo"]}
         assert_received {:mix_shell, :run, ["hello" <> ^nl]}
         assert_received {:mix_shell, :info, ["[\"Foo\"]"]}
+      end)
+    end)
+  end
+
+  test "runs non-recursive aliases at project root level" do
+    in_fixture("umbrella_dep/deps/umbrella", fn ->
+      aliases = [
+        h: "help"
+      ]
+
+      Mix.Project.in_project(:umbrella, ".", [aliases: aliases], fn _ ->
+        Mix.Tasks.Do.run(["--app", "bar", "--app", "foo", "h"])
+
+        assert_received {:mix_shell, :info, ["mix help" <> _]}
       end)
     end)
   end

--- a/lib/mix/test/mix/tasks/do_test.exs
+++ b/lib/mix/test/mix/tasks/do_test.exs
@@ -63,19 +63,6 @@ defmodule Mix.Tasks.DoTest do
     end)
   end
 
-  test "runs non-recursive tasks at project root level" do
-    in_fixture("umbrella_dep/deps/umbrella", fn ->
-      Mix.Project.in_project(:umbrella, ".", fn _ ->
-        Mix.Tasks.Do.run(["--app", "bar", "--app", "foo", "compile", "--list,", "help"])
-
-        assert_received {:mix_shell, :info,
-                         [
-                           "warning: running \"help\" at root level because it is not a recursive task (ignoring apps options)"
-                         ]}
-      end)
-    end)
-  end
-
   test "runs given tasks ignoring apps argument when project is not an umbrella" do
     Mix.Tasks.Do.run(["--app", "bar", "--app", "foo", "cmd", "echo", "hello"])
 
@@ -104,23 +91,6 @@ defmodule Mix.Tasks.DoTest do
         assert_received {:mix_shell, :info, ["==> foo"]}
         assert_received {:mix_shell, :run, ["hello" <> ^nl]}
         assert_received {:mix_shell, :info, ["[\"Foo\"]"]}
-      end)
-    end)
-  end
-
-  test "runs non-recursive aliases at project root level" do
-    in_fixture("umbrella_dep/deps/umbrella", fn ->
-      aliases = [
-        h: "help"
-      ]
-
-      Mix.Project.in_project(:umbrella, ".", [aliases: aliases], fn _ ->
-        Mix.Tasks.Do.run(["--app", "bar", "--app", "foo", "h"])
-
-        assert_received {:mix_shell, :info,
-                         [
-                           "warning: running \"help\" at root level because it is not a recursive task (ignoring apps options)"
-                         ]}
       end)
     end)
   end

--- a/lib/mix/test/mix/tasks/do_test.exs
+++ b/lib/mix/test/mix/tasks/do_test.exs
@@ -24,4 +24,127 @@ defmodule Mix.Tasks.DoTest do
 
     assert gather_commands(["test", ",", "help"]) == [["test"], ["help"]]
   end
+
+  test "runs given tasks for a single app specified by app flag" do
+    in_fixture("umbrella_dep/deps/umbrella", fn ->
+      Mix.Project.in_project(:umbrella, ".", fn _ ->
+        Mix.Tasks.Do.run(["--app", "bar", "compile", "--list,", "cmd", "echo", "hello"])
+
+        nl = os_newline()
+        assert_received {:mix_shell, :info, ["==> bar"]}
+        assert_received {:mix_shell, :run, ["hello" <> ^nl]}
+        refute_received {:mix_shell, :info, ["==> foo"]}
+        refute_received {:mix_shell, :run, ["hello" <> ^nl]}
+      end)
+    end)
+  end
+
+  test "runs given tasks for each app specified by app flag" do
+    in_fixture("umbrella_dep/deps/umbrella", fn ->
+      Mix.Project.in_project(:umbrella, ".", fn _ ->
+        Mix.Tasks.Do.run([
+          "--app",
+          "bar",
+          "--app",
+          "foo",
+          "compile",
+          "--list,",
+          "cmd",
+          "echo",
+          "hello"
+        ])
+
+        nl = os_newline()
+        assert_received {:mix_shell, :info, ["==> bar"]}
+        assert_received {:mix_shell, :run, ["hello" <> ^nl]}
+        assert_received {:mix_shell, :info, ["==> foo"]}
+        assert_received {:mix_shell, :run, ["hello" <> ^nl]}
+      end)
+    end)
+  end
+
+  test "runs non-recursive tasks at project root level" do
+    in_fixture("umbrella_dep/deps/umbrella", fn ->
+      Mix.Project.in_project(:umbrella, ".", fn _ ->
+        Mix.Tasks.Do.run(["--app", "bar", "--app", "foo", "compile", "--list,", "help"])
+
+        assert_received {:mix_shell, :info,
+                         [
+                           "warning: running \"help\" at root level because it is not a recursive task (ignoring apps options)"
+                         ]}
+      end)
+    end)
+  end
+
+  test "runs given tasks ignoring apps argument when project is not an umbrella" do
+    Mix.Tasks.Do.run(["--app", "bar", "--app", "foo", "cmd", "echo", "hello"])
+
+    assert_received {:mix_shell, :info,
+                     [
+                       "warning: running \"cmd\" at root level because this is not an umbrella project"
+                     ]}
+  end
+
+  test "runs given aliases for each app specified by app flag" do
+    in_fixture("umbrella_dep/deps/umbrella", fn ->
+      aliases = [
+        e: ["cmd echo hello"],
+        p: fn val -> Mix.shell().info(inspect(val)) end
+      ]
+
+      Mix.Project.in_project(:umbrella, ".", [aliases: aliases], fn _ ->
+        Mix.Tasks.Do.run(["compile"])
+        Mix.Tasks.Do.run(["--app", "bar", "--app", "foo", "e,", "p", "Foo"])
+
+        nl = os_newline()
+        assert_received {:mix_shell, :info, ["==> bar"]}
+        assert_received {:mix_shell, :run, ["hello" <> ^nl]}
+        assert_received {:mix_shell, :info, ["[\"Foo\"]"]}
+
+        assert_received {:mix_shell, :info, ["==> foo"]}
+        assert_received {:mix_shell, :run, ["hello" <> ^nl]}
+        assert_received {:mix_shell, :info, ["[\"Foo\"]"]}
+      end)
+    end)
+  end
+
+  test "runs non-recursive aliases at project root level" do
+    in_fixture("umbrella_dep/deps/umbrella", fn ->
+      aliases = [
+        h: "help"
+      ]
+
+      Mix.Project.in_project(:umbrella, ".", [aliases: aliases], fn _ ->
+        Mix.Tasks.Do.run(["--app", "bar", "--app", "foo", "h"])
+
+        assert_received {:mix_shell, :info,
+                         [
+                           "warning: running \"help\" at root level because it is not a recursive task (ignoring apps options)"
+                         ]}
+      end)
+    end)
+  end
+
+  test "runs given aliases ignoring apps argument when project is not an umbrella" do
+    in_fixture("umbrella_dep/deps/umbrella", fn ->
+      aliases = [
+        e: ["cmd echo hello"],
+        p: fn val -> Mix.shell().info(inspect(val)) end
+      ]
+
+      Mix.Project.in_project(:foo, "apps/foo", [aliases: aliases], fn _ ->
+        Mix.Tasks.Do.run(["--app", "bar", "--app", "foo", "e,", "p", "Foo"])
+
+        assert_received {:mix_shell, :info,
+                         [
+                           "warning: running \"cmd\" at root level because this is not an umbrella project"
+                         ]}
+
+        assert_received {:mix_shell, :info,
+                         [
+                           "warning: running \"p\" at root level because this is not an umbrella project"
+                         ]}
+      end)
+    end)
+  end
 end


### PR DESCRIPTION
This PR implements an idea that was proposed in the discussion about #10984.

The idea is to add the `--app` option to the `do` task, so we have more control to indicate where tasks are executed (which makes sense in the context of umbrella projects).

#10984 is solved in an indirect way because this solution will emit warnings when the given apps do not exist, something that is impossible in the context of the `cmd` task (the other task that accepts `--app` so far). So, we would need to teach that it is better to run tasks (even the `cmd task`) via `mix do` if we want to indicate in which apps tasks should run.

## Examples

```bash
# Basic example in the context of an umbrella application with two apps: my_app and second_app

mix do --app my_app --app second_app test, cmd echo hello

==> my_app
...
1 doctest, 1 test, 0 failures
==> second_app
...
1 doctest, 1 test, 0 failures
==> my_app
hello
==> second_app
hello
```

```bash
# Running the tasks in one specific app

mix do --app my_app test, cmd echo hello

==> my_app
...
1 doctest, 1 test, 0 failures
==> my_app
hello
```

```bash
# Passing one application name with a typo

mix do --app my_app --app zecond_app test, cmd echo hello

warning: could not find umbrella app :zecond_app
==> my_app
...
1 doctest, 1 test, 0 failures
==> my_app
hello
```

```bash
# Invoking `mix do` with apps options, but the project is not an umbrella application

mix do --app my_app help, cmd echo hello

warning: running "help" at root level because this is not an umbrella project
<`mix help` output here>
warning: running "cmd" at root level because this is not an umbrella project
hello
```

## Open questions

* Should we deprecate the `--app` option in `mix cmd`? I think it is not completely necessary, but it feels like a bit of duplication in the API (since it would be possible to run the `cmd` task with `mix do` if we need to specify apps).