### PR TITLE
fix(release): do not ask to change cookie if overwrite is set

### DIFF
--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -523,7 +523,8 @@ defmodule Mix.Release do
   def make_cookie(release, path) do
     cond do
       cookie = release.options[:cookie] ->
-        Mix.Generator.create_file(path, cookie, quiet: true)
+        force? = Keyword.get(release.options, :overwrite, false)
+        Mix.Generator.create_file(path, cookie, quiet: true, force: force?)
         :ok
 
       File.exists?(path) ->

--- a/lib/mix/test/mix/release_test.exs
+++ b/lib/mix/test/mix/release_test.exs
@@ -514,6 +514,13 @@ defmodule Mix.ReleaseTest do
       assert make_cookie(release(cookie: "lmnopqrstuv"), @cookie_path) == :ok
       assert File.read!(@cookie_path) == "lmnopqrstuv"
     end
+
+    test "does not ask to change if set to overwrite" do
+      assert make_cookie(release([]), @cookie_path) == :ok
+      send(self(), {:mix_shell_input, :yes?, false})
+      assert make_cookie(release([cookie: "lmnopqrstuv"], overwrite: true), @cookie_path) == :ok
+      assert File.read!(@cookie_path) == "lmnopqrstuv"
+    end
   end
 
   describe "make_start_erl/1" do
@@ -812,8 +819,8 @@ defmodule Mix.ReleaseTest do
     File.stat!(path).mode
   end
 
-  defp release(config) do
-    from_config!(nil, config(releases: [demo: config]), [])
+  defp release(config, overrides \\ []) do
+    from_config!(nil, config(releases: [demo: config]), overrides)
   end
 
   defp config(extra \\ []) do


### PR DESCRIPTION
Currently, if a `releases/COOKIE` file exists with a given cookie, and
a user later manually adds a `:cookie` configuration to the release,
then, even using the flag `--overwrite` when releasing, the user is
asked if they want to overwrite the file.

To reproduce:

1. `mix new myapp && cd myapp`
2. Add a simple release to it without defining a cookie:
```elixir
releases: [
  myapp: [
    applications: [
      myapp: :permanent
    ]
  ]
]
```
3. `mix release` (random cookie gets generated)
4. Add a manual cookie to the release:
```elixir
releases: [
  myapp: [
    applications: [
      myapp: :permanent
    ],
    cookie: "somecookie"  # <---
  ]
]
```
5. `mix release --overwrite`
6. User gets asked if they want to overwrite `releases/COOKIE`.
```
mix release --overwrite
Generated myapp app
* assembling myapp-0.1.0 on MIX_ENV=dev
* skipping runtime configuration (config/runtime.exs not found)
_build/dev/rel/myapp/releases/COOKIE already exists, overwrite? [Yn] 
```