### PR TITLE
Remove `child_spec/1` from `StringIO` docs

### DIFF
--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -14,10 +14,8 @@ defmodule StringIO do
   """
 
   # We're implementing the GenServer behaviour instead of using the
-  # `use GenServer` macro, because we don't want the `child_spec/1` function
-  # that `use GenServer` generates. Although this module is implemented as a
-  # GenServer, it doesn't make sense to be started under a supervisor so a
-  # `child_spec/1` function isn't needed.
+  # `use GenServer` macro, because we don't want the `child_spec/1`
+  # function as it doesn't make sense to be started under a supervisor.
   @behaviour GenServer
 
   @doc ~S"""

--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -13,6 +13,7 @@ defmodule StringIO do
 
   """
 
+  @doc false
   use GenServer
 
   @doc ~S"""

--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -13,8 +13,12 @@ defmodule StringIO do
 
   """
 
-  @doc false
-  use GenServer
+  # We're implementing the GenServer behaviour instead of using the
+  # `use GenServer` macro, because we don't want the `child_spec/1` function
+  # that `use GenServer` generates. Although this module is implemented as a
+  # GenServer, it doesn't make sense to be started under a supervisor so a
+  # `child_spec/1` function isn't needed.
+  @behaviour GenServer
 
   @doc ~S"""
   Creates an IO device.


### PR DESCRIPTION
This fixes #11619 by removing `child_spec/1` from the `StringIO` docs.