### PR TITLE
Add binary_slice/2 and binary_slice/3

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4481,7 +4481,7 @@ defmodule Kernel do
   end
 
   @doc """
-  Returns a binary starting at the offset `start`, and of the given `size`.
+  Returns a binary starting at the offset `start` and of the given `size`.
 
   This is similar to `binary_part/3` except that if `start + size`
   is greater than the binary size, it automatically clips it to

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4504,8 +4504,8 @@ defmodule Kernel do
 
   If the `size` is zero, an empty binary is returned:
 
-      iex> binary_slice("elixir", 0, 10)
-      "elixir"
+      iex> binary_slice("elixir", 1, 0)
+      ""
 
   If `start` is greater than or equal to the binary size,
   an empty binary is returned:
@@ -4517,7 +4517,9 @@ defmodule Kernel do
 
   """
   @doc since: "1.14.0"
-  def binary_slice(binary, start, size) when start >= 0 and size >= 0 do
+  def binary_slice(binary, start, size)
+      when is_binary(binary) and is_integer(start) and is_integer(size) and
+             start >= 0 and size >= 0 do
     total = byte_size(binary)
 
     case start < total do
@@ -4585,7 +4587,8 @@ defmodule Kernel do
 
   """
   @doc since: "1.14.0"
-  def binary_slice(binary, first..last//step) when step > 0 do
+  def binary_slice(binary, first..last//step)
+      when is_binary(binary) and step > 0 do
     total = byte_size(binary)
 
     first =
@@ -4614,7 +4617,7 @@ defmodule Kernel do
     end
   end
 
-  def binary_slice(_binary, range) do
+  def binary_slice(binary, _.._//_ = range) when is_binary(binary) do
     raise ArgumentError,
           "binary_slice/2 does not accept ranges with negative steps, got: #{inspect(range)}"
   end

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1968,6 +1968,145 @@ defmodule Kernel do
   end
 
   @doc """
+  Returns a binary starting at the offset `start`, and of the given `size`.
+
+  This is similar to `binary_part/3` except that if `start + size`
+  is greater than the binary size, it automatically clips it to
+  the binary size instead of raising. Opposite to `binary_part/3`,
+  this function is not allowed in guards.
+
+  This function works with bytes. For a slicing operation that
+  considers characters, see `String.slice/3`.
+
+  ## Examples
+
+      iex> binary_slice("elixir", 0, 6)
+      "elixir"
+      iex> binary_slice("elixir", 0, 5)
+      "elixi"
+      iex> binary_slice("elixir", 1, 4)
+      "lixi"
+      iex> binary_slice("elixir", 0, 10)
+      "elixir"
+
+  If the `size` is zero, an empty binary is returned:
+
+      iex> binary_slice("elixir", 0, 10)
+      "elixir"
+
+  If `start` is greater than or equal to the binary size,
+  an empty binary is returned:
+
+      iex> binary_slice("elixir", 3, 10)
+      "xir"
+      iex> binary_slice("elixir", 10, 10)
+      ""
+
+  """
+  @doc since: "1.14.0"
+  def binary_slice(binary, start, size) when start >= 0 and size >= 0 do
+    total = byte_size(binary)
+
+    case start < total do
+      true -> :erlang.binary_part(binary, start, min(size, total - start))
+      false -> ""
+    end
+  end
+
+  @doc """
+  Returns a binary from the offset given by the start of the
+  range to the offset given by the end of the range.
+
+  If the start or end of the range are negative, they are converted
+  into positive indices based on the binary size. For example,
+  `-1` means the last byte of the binary.
+
+  This is similar to `binary_part/3` except that it works with ranges
+  and it is not allowed in guards.
+
+  This function works with bytes. For a slicing operation that
+  considers characters, see `String.slice/2`.
+
+  ## Examples
+
+      iex> binary_slice("elixir", 0..5)
+      "elixir"
+      iex> binary_slice("elixir", 1..3)
+      "lix"
+      iex> binary_slice("elixir", 1..10)
+      "lixir"
+
+      iex> binary_slice("elixir", -4..-1)
+      "ixir"
+      iex> binary_slice("elixir", -4..6)
+      "ixir"
+
+  For ranges where `start > stop`, you need to explicitly
+  mark them as increasing:
+
+      iex> binary_slice("elixir", 2..-1//1)
+      "ixir"
+      iex> binary_slice("elixir", 1..-2//1)
+      "lixi"
+
+  You can use `../0` as a shortcut for `0..-1//1`, which returns
+  the whole binary as is:
+
+      iex> binary_slice("elixir", ..)
+      "elixir"
+
+  The step can be any positive number. For example, to
+  get every 2 characters of the binary:
+
+      iex> binary_slice("elixir", 0..-1//2)
+      "eii"
+
+  If values are out of bounds, it returns an empty binary:
+
+      iex> binary_slice("elixir", 10..3//1)
+      ""
+      iex> binary_slice("elixir", -10..-7)
+      ""
+      iex> binary_slice("a", 1..1500)
+      ""
+
+  """
+  @doc since: "1.14.0"
+  def binary_slice(binary, first..last//step) when step > 0 do
+    total = byte_size(binary)
+
+    first =
+      case first < 0 do
+        true -> first + total
+        false -> first
+      end
+
+    last =
+      case last < 0 do
+        true -> last + total
+        false -> last
+      end
+
+    case first >= 0 and first < total do
+      true ->
+        part = binary_part(binary, first, min(total - first, last - first + 1))
+
+        case step do
+          1 -> part
+          _ -> for <<byte, _::size(step - 1)-bytes <- part>>, into: "", do: <<byte>>
+        end
+
+      false ->
+        ""
+    end
+  end
+
+  def binary_slice(_binary, range) do
+    raise ArgumentError,
+          "binary_slice/2 does not accept ranges with negative steps, got: #{inspect(range)}"
+  end
+
+  @doc """
   Raises an exception.
 
   If `message` is a string, it raises a `RuntimeError` exception with it.

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2158,7 +2158,7 @@ defmodule String do
 
   Remember this function works with Unicode graphemes and considers
   the slices to represent grapheme offsets. If you want to split
-  on raw bytes, check `Kernel.binary_part/3` instead or
+  on raw bytes, check `Kernel.binary_part/3` or
   `Kernel.binary_slice/2` instead
 
   ## Examples

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2084,7 +2084,8 @@ defmodule String do
 
   Remember this function works with Unicode graphemes and considers
   the slices to represent grapheme offsets. If you want to split
-  on raw bytes, check `Kernel.binary_part/3` instead.
+  on raw bytes, check `Kernel.binary_part/3` or `Kernel.binary_slice/3`
+  instead.
 
   ## Examples
 
@@ -2157,19 +2158,18 @@ defmodule String do
 
   Remember this function works with Unicode graphemes and considers
   the slices to represent grapheme offsets. If you want to split
-  on raw bytes, check `Kernel.binary_part/3` instead.
+  on raw bytes, check `Kernel.binary_part/3` instead or
+  `Kernel.binary_slice/2` instead
 
   ## Examples
 
       iex> String.slice("elixir", 1..3)
       "lix"
-
       iex> String.slice("elixir", 1..10)
       "lixir"
 
       iex> String.slice("elixir", -4..-1)
       "ixir"
-
       iex> String.slice("elixir", -4..6)
       "ixir"
 
@@ -2178,7 +2178,6 @@ defmodule String do
 
       iex> String.slice("elixir", 2..-1//1)
       "ixir"
-
       iex> String.slice("elixir", 1..-2//1)
       "lixi"
 
@@ -2198,13 +2197,8 @@ defmodule String do
 
       iex> String.slice("elixir", 10..3)
       ""
-
       iex> String.slice("elixir", -10..-7)
       ""
-
-      iex> String.slice("a", 0..1500)
-      "a"
-
       iex> String.slice("a", 1..1500)
       ""
 


### PR DESCRIPTION
So far Elixir only exposed binary_part/3 as part of its
functions to manipulate binaries, since that's allowed in
guards.

However, `binary_part/3` is quite limited in that it
expects both `start` and `start+size` to fall within the
binary. This could lead developers to use String.slice/2
or String.slice/3 when a binary operation would be more
performant or appropriate.

This pull request therefore adds `binary_slice/2` and
`binary_slice/3` that nicely integrates with binaries
and ranges, and behaves similarly to their `Enum.slice`
and `String.slice` counterparts.