### PR TITLE
Clarify app env usage

### DIFF
--- a/lib/elixir/lib/config.ex
+++ b/lib/elixir/lib/config.ex
@@ -64,23 +64,19 @@ defmodule Config do
 
   The last step is to replace all `Mix.env()` calls in the config files with `config_env()`.
 
-  To check an application's environment at runtime, you may add a configuration key:
+  Since `mix.exs` is run at compile time, you may still use `Mix.env()` inside this file to identify the application's environment. To check the environment at _runtime_, you may add a configuration key:
 
       # config.exs
       ...
       config :my_app, env: config_env()
 
-  Then, in `mix.exs` and other files, you may get the environment via:
+  Then, in other scripts and modules, you may get the environment with `Application.get_env/2`.
 
-      # mix.exs
+      # router.exs
       ...
       if Application.get_env(:my_app, :env) == :prod do
         ...
       end
-
-      def deps do
-        ...
-        {:some_testing_dep, "~> 1.0", only: Application.get_env(:my_app, :env) == :test}
 
   ## config/runtime.exs
 

--- a/lib/elixir/lib/config.ex
+++ b/lib/elixir/lib/config.ex
@@ -64,7 +64,9 @@ defmodule Config do
 
   The last step is to replace all `Mix.env()` calls in the config files with `config_env()`.
 
-  Since `mix.exs` is run at compile time, you may still use `Mix.env()` inside this file to identify the application's environment. To check the environment at _runtime_, you may add a configuration key:
+  Since `mix.exs` is run at compile time, you may still use `Mix.env()` inside this
+  file to identify the application's environment. To check the environment at
+  _runtime_, you may add a configuration key:
 
       # config.exs
       ...

--- a/lib/elixir/lib/config.ex
+++ b/lib/elixir/lib/config.ex
@@ -64,7 +64,7 @@ defmodule Config do
 
   The last step is to replace all `Mix.env()` calls in the config files with `config_env()`.
 
-  To check an applivetion's environment at runtime, you may add a configuration key:
+  To check an application's environment at runtime, you may add a configuration key:
 
       # config.exs
       ...

--- a/lib/elixir/lib/config.ex
+++ b/lib/elixir/lib/config.ex
@@ -62,7 +62,25 @@ defmodule Config do
         import_config config
       end
 
-  The last step is to replace all `Mix.env()` calls by `config_env()`.
+  The last step is to replace all `Mix.env()` calls in the config files with `config_env()`.
+
+  To check an applivetion's environment at runtime, you may add a configuration key:
+
+      # config.exs
+      ...
+      config :my_app, env: config_env()
+
+  Then, in `mix.exs` and other files, you may get the environment via:
+
+      # mix.exs
+      ...
+      if Application.get_env(:my_app, :env) == :prod do
+        ...
+      end
+
+      def deps do
+        ...
+        {:some_testing_dep, "~> 1.0", only: Application.get_env(:my_app, :env) == :test}
 
   ## config/runtime.exs
 

--- a/lib/elixir/lib/config.ex
+++ b/lib/elixir/lib/config.ex
@@ -64,21 +64,25 @@ defmodule Config do
 
   The last step is to replace all `Mix.env()` calls in the config files with `config_env()`.
 
-  Since `mix.exs` is run at compile time, you may still use `Mix.env()` inside this
-  file to identify the application's environment. To check the environment at
-  _runtime_, you may add a configuration key:
+  Keep in mind you must also avoid using `Mix.env()` inside your project files.
+  To check the environment at _runtime_, you may add a configuration key:
 
       # config.exs
       ...
       config :my_app, env: config_env()
 
-  Then, in other scripts and modules, you may get the environment with `Application.get_env/2`.
+  Then, in other scripts and modules, you may get the environment with
+  `Application.fetch_env!/2`:
 
       # router.exs
       ...
-      if Application.get_env(:my_app, :env) == :prod do
+      if Application.fetch_env!(:my_app, :env) == :prod do
         ...
       end
+
+  The only files where you may acccess functions from the `Mix` module are
+  the `mix.exs` file and inside custom Mix tasks, which always within the
+  `Mix.Tasks` namespace.
 
   ## config/runtime.exs
 


### PR DESCRIPTION
While upgrading an application from 1.8, it wasn't clear from the docs how to replace `Mix.env()` calls outside of config files. After some brief discussion and a quick local test, I found a simple solution that will compliment the existing docs, assuming it works as expected.

This will work as expected, right?