### PR TITLE
Update Mix.DepTest for OTP 25

### DIFF
--- a/lib/mix/test/mix/dep_test.exs
+++ b/lib/mix/test/mix/dep_test.exs
@@ -496,7 +496,9 @@ defmodule Mix.DepTest do
 
     with_deps(deps, fn ->
       in_fixture("deps_status", fn ->
-        assert [_, _, :deps_repo] = Enum.map(Mix.Dep.load_on_environment([]), & &1.app)
+        # Both orders below are valid after topological sort
+        assert Enum.map(Mix.Dep.load_on_environment([]), & &1.app) in
+                 [[:git_repo, :abc_repo, :deps_repo], [:abc_repo, :git_repo, :deps_repo]]
 
         assert Map.keys(Mix.Project.deps_paths()) == [:abc_repo, :deps_repo, :git_repo]
 

--- a/lib/mix/test/mix/dep_test.exs
+++ b/lib/mix/test/mix/dep_test.exs
@@ -497,8 +497,10 @@ defmodule Mix.DepTest do
     with_deps(deps, fn ->
       in_fixture("deps_status", fn ->
         # Both orders below are valid after topological sort
-        assert Enum.map(Mix.Dep.load_on_environment([]), & &1.app) in
-                 [[:git_repo, :abc_repo, :deps_repo], [:abc_repo, :git_repo, :deps_repo]]
+        assert Enum.map(Mix.Dep.load_on_environment([]), & &1.app) in [
+                 [:git_repo, :abc_repo, :deps_repo],
+                 [:abc_repo, :git_repo, :deps_repo]
+               ]
 
         assert Map.keys(Mix.Project.deps_paths()) == [:abc_repo, :deps_repo, :git_repo]
 

--- a/lib/mix/test/mix/dep_test.exs
+++ b/lib/mix/test/mix/dep_test.exs
@@ -496,8 +496,7 @@ defmodule Mix.DepTest do
 
     with_deps(deps, fn ->
       in_fixture("deps_status", fn ->
-        assert Enum.map(Mix.Dep.load_on_environment([]), & &1.app) ==
-                 [:git_repo, :abc_repo, :deps_repo]
+        assert [_, _, :deps_repo] = Enum.map(Mix.Dep.load_on_environment([]), & &1.app)
 
         assert Map.keys(Mix.Project.deps_paths()) == [:abc_repo, :deps_repo, :git_repo]
 


### PR DESCRIPTION
:digraph_utils.topsort/1 can return a different (but also valid)
topological ordering

The test failure on OTP 25.0-rc1 was:

    1) test deps_paths (Mix.DepTest)
       test/mix/dep_test.exs:491
       Assertion with == failed
       code:  assert Enum.map(Mix.Dep.load_on_environment([]), & &1.app) == [:git_repo, :abc_repo, :deps_repo]
       left:  [:abc_repo, :git_repo, :deps_repo]
       right: [:git_repo, :abc_repo, :deps_repo]
       stacktrace:
         test/mix/dep_test.exs:499: anonymous fn/0 in Mix.DepTest."test deps_paths"/1
         (elixir 1.14.0-dev) lib/file.ex:1555: File.cd!/2
         test/test_helper.exs:127: MixTest.Case.in_fixture/3
         test/mix/dep_test.exs:31: Mix.DepTest.with_deps/2
         test/mix/dep_test.exs:497: (test)