### PR TITLE
Update Mix.TasksTestTest for OTP 25

### DIFF
--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -433,9 +433,14 @@ defmodule Mix.Tasks.TestTest do
       in_fixture("umbrella_test", fn ->
         # Run false positive test first so at least the code is compiled
         # and we can perform more aggressive assertions later
-        assert mix(["test", "apps/unknown_app/test"]) =~ """
+        output = mix(["test", "apps/unknown_app/test"])
+
+        assert output =~ """
                ==> bar
                Paths given to "mix test" did not match any directory/file: apps/unknown_app/test
+               """
+
+        assert output =~ """
                ==> foo
                Paths given to "mix test" did not match any directory/file: apps/unknown_app/test
                """


### PR DESCRIPTION
The order in which tests for umbrella applications get executed can be different
depending on OTP version. See also #11636

The test failure was:

    1) test logs and errors umbrella with file path (Mix.Tasks.TestTest)
       test/mix/tasks/test_test.exs:432
       Assertion with =~ failed
       code:  assert mix(["test", "apps/unknown_app/test"]) =~
                "==> bar\nPaths given to \"mix test\" did not match any directory/file: apps/unknown_app/test\n==> foo\nPaths given to \"mix test\" did not match any directory/file: apps/unknown_app/test\n"
       left:  "==> foo\nCompiling 1 file (.ex)\nGenerated foo app\n==> bar\nCompiling 1 file (.ex)\nGenerated bar app\n==> foo\nPaths given to \"mix test\" did not match any directory/file: apps/unknown_app/test\n==> bar\nPaths given to \"mix test\" did not match any directory/file: apps/unknown_app/test\n"
       right: "==> bar\nPaths given to \"mix test\" did not match any directory/file: apps/unknown_app/test\n==> foo\nPaths given to \"mix test\" did not match any directory/file: apps/unknown_app/test\n"
       stacktrace:
         test/mix/tasks/test_test.exs:436: anonymous fn/0 in Mix.Tasks.TestTest."test logs and errors umbrella with file path"/1
         (elixir 1.14.0-dev) lib/file.ex:1555: File.cd!/2
         test/test_helper.exs:127: MixTest.Case.in_fixture/3
         test/mix/tasks/test_test.exs:433: (test)