### PR TITLE
Add explanation for exit reason to GenServer

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -153,6 +153,10 @@ defmodule GenServer do
   detailed information. The `@doc` annotation immediately preceding
   `use GenServer` will be attached to the generated `child_spec/1` function.
 
+  When stopping the GenServer, for example by returing a `{:stop, reason, new_state}` tuple from a
+  callback, the exit reason is used by the supervisor to determine whether the GenServer needs to be
+  restarted. See the "Exit reasons and restarts" section in the `Supervisor` module.
+
   ## Name registration
 
   Both `start_link/3` and `start/3` support the `GenServer` to register

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -153,9 +153,10 @@ defmodule GenServer do
   detailed information. The `@doc` annotation immediately preceding
   `use GenServer` will be attached to the generated `child_spec/1` function.
 
-  When stopping the GenServer, for example by returing a `{:stop, reason, new_state}` tuple from a
-  callback, the exit reason is used by the supervisor to determine whether the GenServer needs to be
-  restarted. See the "Exit reasons and restarts" section in the `Supervisor` module.
+  When stopping the GenServer, for example by returing a `{:stop, reason, new_state}`
+  tuple from a callback, the exit reason is used by the supervisor to determine
+  whether the GenServer needs to be restarted. See the "Exit reasons and restarts"
+  section in the `Supervisor` module.
 
   ## Name registration
 


### PR DESCRIPTION
There is currently no reference in the GenServer documentation about how the exit reason impacts the supervision tree and related processes. I found the relevant information in the Supervisor documentation. I think it would be good to add that reference to the GenServer docs, as I was personally searching through the GenServer docs for `:stop` and no references to the exit reason came up.