### PR TITLE
Remove Rebar 2 leftovers

### DIFF
--- a/lib/mix/lib/mix/dep/loader.ex
+++ b/lib/mix/lib/mix/dep/loader.ex
@@ -220,7 +220,7 @@ defmodule Mix.Dep.Loader do
 
   # Note that we ignore Make dependencies because the
   # file based heuristic will always figure it out.
-  @scm_managers ~w(mix rebar rebar3)a
+  @scm_managers ~w(mix rebar3)a
 
   defp scm_manager(scm, opts) do
     managers = scm.managers(opts)

--- a/lib/mix/lib/mix/tasks/deps.ex
+++ b/lib/mix/lib/mix/tasks/deps.ex
@@ -89,8 +89,8 @@ defmodule Mix.Tasks.Deps do
     * `:override` - if set to `true` the dependency will override any other
       definitions of itself by other dependencies
 
-    * `:manager` - Mix can also compile Rebar, Rebar3 and makefile projects
-      and can fetch sub dependencies of Rebar and Rebar3 projects. Mix will
+    * `:manager` - Mix can also compile Rebar3 and makefile projects
+      and can fetch sub dependencies of Rebar3 projects. Mix will
       try to infer the type of project but it can be overridden with this
       option by setting it to `:mix`, `:rebar3`, or `:make`. In case
       there are conflicting definitions, the first manager in the list above

--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -21,8 +21,6 @@ defmodule Mix.Tasks.Local.Rebar do
 
   ## Command line options
 
-    * `rebar PATH` - specifies a path for `rebar`
-
     * `rebar3 PATH` - specifies a path for `rebar3`
 
     * `--sha512` - checks the Rebar script matches the given SHA-512 checksum

--- a/lib/mix/test/mix/dep_test.exs
+++ b/lib/mix/test/mix/dep_test.exs
@@ -194,7 +194,7 @@ defmodule Mix.DepTest do
     Process.put(:custom_deps_git_repo_opts, manager: :make)
 
     deps = [
-      {:deps_repo, "0.1.0", path: "custom/deps_repo", manager: :rebar},
+      {:deps_repo, "0.1.0", path: "custom/deps_repo", manager: :rebar3},
       {:git_repo, "0.2.0", git: MixTest.Case.fixture_path("git_repo")}
     ]
 
@@ -202,7 +202,7 @@ defmodule Mix.DepTest do
       in_fixture("deps_status", fn ->
         [dep1, dep2] = Mix.Dep.load_on_environment([])
         assert dep1.manager == nil
-        assert dep2.manager == :rebar
+        assert dep2.manager == :rebar3
       end)
     end)
   end

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -8,11 +8,10 @@ Application.put_env(:logger, :backends, [])
 os_exclude = if match?({:win32, _}, :os.type()), do: [unix: true], else: [windows: true]
 epmd_exclude = if match?({:win32, _}, :os.type()), do: [epmd: true], else: []
 git_exclude = if Mix.SCM.Git.git_version() <= {1, 7, 4}, do: [git_sparse: true], else: []
-rebar_exclude = if System.otp_release() >= "25", do: [rebar: true], else: []
 
 ExUnit.start(
   trace: "--trace" in System.argv(),
-  exclude: epmd_exclude ++ os_exclude ++ git_exclude ++ rebar_exclude
+  exclude: epmd_exclude ++ os_exclude ++ git_exclude
 )
 
 # Clear environment variables that may affect tests


### PR DESCRIPTION
* Remove mentions from documentation

* Remove rebar from @scm_manager in Mix.Dep.Loader

* Change manager: :rebar to manager: :rebar3 in test

* Remove rebar_exclude test filter from mix test_helper.exs
  (there are no more Rebar 2 tests after they got removed
  in 5cca5e5fbb48d746b03e38b41d1b7b1b33c4fb26 )