### PR TITLE
Handle 'mix local.rebar' command options without arguments

### DIFF
--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -21,8 +21,6 @@ defmodule Mix.Tasks.Local.Rebar do
 
   ## Command line options
 
-    * `rebar PATH` - specifies a path for `rebar`
-
     * `rebar3 PATH` - specifies a path for `rebar3`
 
     * `--sha512` - checks the Rebar script matches the given SHA-512 checksum
@@ -44,9 +42,9 @@ defmodule Mix.Tasks.Local.Rebar do
 
   @impl true
   def run(argv) do
-    {opts, _, _} = OptionParser.parse(argv, switches: @switches)
+    {opts, args, _} = OptionParser.parse(argv, switches: @switches)
 
-    case argv do
+    case args do
       ["rebar3", path | _] ->
         maybe_install_from_path(:rebar3, path, opts)
 
@@ -55,7 +53,7 @@ defmodule Mix.Tasks.Local.Rebar do
 
       _ ->
         Mix.raise(
-          "Invalid arguments given to mix local.rebar. " <>
+          "Invalid arguments given to mix local.rebar (#{inspect(args)}). " <>
             "To find out the proper call syntax run \"mix help local.rebar\""
         )
     end
@@ -74,6 +72,13 @@ defmodule Mix.Tasks.Local.Rebar do
   end
 
   defp install_from_path(manager, path, opts) do
+    Mix.shell().info([
+      :green,
+      "* installing Rebar locally ",
+      :reset,
+      "from #{inspect(path)} with options #{inspect(opts)}"
+    ])
+
     local = Mix.Rebar.local_rebar_path(manager)
 
     if opts[:force] || Mix.Generator.overwrite?(local) do

--- a/lib/mix/lib/mix/tasks/local.rebar.ex
+++ b/lib/mix/lib/mix/tasks/local.rebar.ex
@@ -53,7 +53,7 @@ defmodule Mix.Tasks.Local.Rebar do
 
       _ ->
         Mix.raise(
-          "Invalid arguments given to mix local.rebar (#{inspect(args)}). " <>
+          "Invalid arguments given to mix local.rebar: #{inspect(args)}. " <>
             "To find out the proper call syntax run \"mix help local.rebar\""
         )
     end
@@ -72,13 +72,6 @@ defmodule Mix.Tasks.Local.Rebar do
   end
 
   defp install_from_path(manager, path, opts) do
-    Mix.shell().info([
-      :green,
-      "* installing Rebar locally ",
-      :reset,
-      "from #{inspect(path)} with options #{inspect(opts)}"
-    ])
-
     local = Mix.Rebar.local_rebar_path(manager)
 
     if opts[:force] || Mix.Generator.overwrite?(local) do


### PR DESCRIPTION
This PR would handle the `mix local.rebar` task called with no arguments (path for `rebar3`):

It fix the current error:
```
mix local.rebar --force
** (Mix) Invalid arguments given to mix local.rebar. To find out the proper call syntax run "mix help local.rebar"
```
and trace command action:
```
mix local.rebar --force
* installing Rebar locally from "https://repo.hex.pm/installs/1.13.0/rebar3-3.15.2" with options [sha512: "dc559ace623406453c424debbcccb3eca3d40403920f6be0e240f5ec7e8f2836886fd3a3d6355e06d924781143f1275c35067e8ad7d1fe0995e35e74dedc6f17", force: true]
* creating /home/user/.mix/elixir/1.14.0/rebar3
```

