### PR TITLE
Profiler return the return value of the function

### DIFF
--- a/lib/mix/lib/mix/tasks/profile.cprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.cprof.ex
@@ -157,6 +157,8 @@ defmodule Mix.Tasks.Profile.Cprof do
   @doc """
   Allows to programmatically run the `cprof` profiler on expression in `fun`.
 
+  Returns the return value of `fun`.
+
   ## Options
 
     * `:matching` - only profile calls matching the given pattern in form of
@@ -166,12 +168,16 @@ defmodule Mix.Tasks.Profile.Cprof do
     * `:module` - filters out any results not pertaining to the given module
 
   """
+  @spec profile((() -> any())) :: any()
+  @spec profile((() -> any()), keyword()) :: any()
   def profile(fun, opts \\ []) when is_function(fun, 0) do
-    fun
-    |> profile_and_analyse(opts)
-    |> print_output
+    {return_value, num_matched_functions, analysis_result} = profile_and_analyse(fun, opts)
+
+    print_output(num_matched_functions, analysis_result)
 
     :cprof.stop()
+
+    return_value
   end
 
   defp profile_and_analyse(fun, opts) do
@@ -186,7 +192,7 @@ defmodule Mix.Tasks.Profile.Cprof do
         :error -> :cprof.start()
       end
 
-    apply(fun, [])
+    return_value = apply(fun, [])
 
     :cprof.pause()
 
@@ -209,19 +215,19 @@ defmodule Mix.Tasks.Profile.Cprof do
           end
       end
 
-    {num_matched_functions, analysis_result}
+    {return_value, num_matched_functions, analysis_result}
   end
 
   defp string_to_existing_module(":" <> module), do: String.to_existing_atom(module)
   defp string_to_existing_module(module), do: Module.concat([module])
 
-  defp print_output({num_matched_functions, {all_call_count, mod_analysis_list}}) do
+  defp print_output(num_matched_functions, {all_call_count, mod_analysis_list}) do
     print_total_row(all_call_count)
     Enum.each(mod_analysis_list, &print_analysis_result/1)
     print_number_of_matched_functions(num_matched_functions)
   end
 
-  defp print_output({num_matched_functions, {_mod, _call_count, _mod_fun_list} = mod_analysis}) do
+  defp print_output(num_matched_functions, {_mod, _call_count, _mod_fun_list} = mod_analysis) do
     print_analysis_result(mod_analysis)
     print_number_of_matched_functions(num_matched_functions)
   end

--- a/lib/mix/lib/mix/tasks/profile.cprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.cprof.ex
@@ -168,7 +168,6 @@ defmodule Mix.Tasks.Profile.Cprof do
     * `:module` - filters out any results not pertaining to the given module
 
   """
-  @spec profile((() -> any())) :: any()
   @spec profile((() -> any()), keyword()) :: any()
   def profile(fun, opts \\ []) when is_function(fun, 0) do
     {return_value, num_matched_functions, analysis_result} = profile_and_analyse(fun, opts)

--- a/lib/mix/lib/mix/tasks/profile.eprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.eprof.ex
@@ -183,7 +183,6 @@ defmodule Mix.Tasks.Profile.Eprof do
     * `:sort` - sort the results by `:time` or `:calls` (default: `:time`)
 
   """
-  @spec profile((() -> any())) :: any()
   @spec profile((() -> any()), keyword()) :: any()
   def profile(fun, opts \\ []) when is_function(fun, 0) do
     {return_value, results} = profile_and_analyse(fun, opts)

--- a/lib/mix/lib/mix/tasks/profile.fprof.ex
+++ b/lib/mix/lib/mix/tasks/profile.fprof.ex
@@ -175,7 +175,6 @@ defmodule Mix.Tasks.Profile.Fprof do
     * `:sort` - sorts the output by given key: `:acc` (default) or `:own`
 
   """
-  @spec profile((() -> any())) :: any()
   @spec profile((() -> any()), keyword()) :: any()
   def profile(fun, opts \\ []) when is_function(fun, 0) do
     {return_value, analysis_output} = profile_and_analyse(fun, opts)

--- a/lib/mix/test/mix/tasks/profile.cprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.cprof_test.exs
@@ -103,4 +103,12 @@ defmodule Mix.Tasks.Profile.CprofTest do
              end) =~ "Warmup..."
     end)
   end
+
+  describe ".profile/2" do
+    test "returns the return value of the function call" do
+      capture_io(fn ->
+        assert 42 == Cprof.profile(fn -> 42 end)
+      end)
+    end
+  end
 end

--- a/lib/mix/test/mix/tasks/profile.eprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.eprof_test.exs
@@ -112,4 +112,12 @@ defmodule Mix.Tasks.Profile.EprofTest do
              end) =~ "Warmup..."
     end)
   end
+
+  describe ".profile/2" do
+    test "returns the return value of the function call" do
+      capture_io(fn ->
+        assert 42 == Eprof.profile(fn -> 42 end)
+      end)
+    end
+  end
 end

--- a/lib/mix/test/mix/tasks/profile.fprof_test.exs
+++ b/lib/mix/test/mix/tasks/profile.fprof_test.exs
@@ -98,4 +98,12 @@ defmodule Mix.Tasks.Profile.FprofTest do
              end) =~ "Warmup..."
     end)
   end
+
+  describe ".profile/2" do
+    test "returns the return value of the function call" do
+      capture_io(fn ->
+        assert 42 == Fprof.profile(fn -> 42 end)
+      end)
+    end
+  end
 end


### PR DESCRIPTION
As discussed in: https://groups.google.com/g/elixir-lang-core/c/f0gP0It-yuU

But basically:
* right now no return value is documented/discussed so should not
be relied upon
* the original profiler themselves all return the return value,
so it should be possible
* I need it in Benchee :angel:

Happy to make any kind of adjustments. I was thinking about introducing a behavior as all of these functions were very samey (and in fact in Benchee we rely on them being the same) but not sure it's needed here.

Thanks for all your work y'all! :green_heart: 

The bunny thanks thee!

![IMG_20220109_104347](https://user-images.githubusercontent.com/606517/154862927-f0864dc1-e326-423f-991e-4d58258ab3bf.jpg)

