### PR TITLE
Show errors for incorrect `--rpc-eval` usage

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -118,8 +118,8 @@ while [ $I -le $LENGTH ]; do
         set -- "$@" "$1" "$2"
         ;;
     --rpc-eval)
-        S=3
-        set -- "$@" "$1" "$2" "$3"
+        S=1
+        set -- "$@" "$1"
         ;;
     --detached)
         echo "warning: the --detached option is deprecated" >&2

--- a/lib/elixir/lib/kernel/cli.ex
+++ b/lib/elixir/lib/kernel/cli.ex
@@ -275,6 +275,11 @@ defmodule Kernel.CLI do
     parse_shared(t, %{config | commands: [{:rpc_eval, node, h} | config.commands]})
   end
 
+  defp parse_shared(["--rpc-eval" | _], config) do
+    new_config = %{config | errors: ["--rpc-eval : wrong number of arguments" | config.errors]}
+    {[], new_config}
+  end
+
   defp parse_shared(["-r", h | t], config) do
     parse_shared(t, %{config | commands: [{:require, h} | config.commands]})
   end

--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -162,6 +162,24 @@ defmodule Kernel.CLI.RPCTest do
     assert elixir('--name #{node}@127.0.0.1 --rpc-eval #{node} "IO.puts :ok"') == "ok\n"
   end
 
+  test "can be invoked multiple times" do
+    node = "cli-rpc#{System.unique_integer()}"
+
+    assert elixir(
+             '--name #{node}@127.0.0.1 --rpc-eval #{node} "IO.puts :foo" --rpc-eval #{node} "IO.puts :bar"'
+           ) == "foo\nbar\n"
+  end
+
+  test "fails on wrong arguments" do
+    node = "cli-rpc#{System.unique_integer()}"
+
+    assert elixir('--name #{node}@127.0.0.1 --rpc-eval') ==
+             "--rpc-eval : wrong number of arguments\n"
+
+    assert elixir('--name #{node}@127.0.0.1 --rpc-eval #{node}') ==
+             "--rpc-eval : wrong number of arguments\n"
+  end
+
   stderr_test "properly formats errors" do
     assert String.starts_with?(rpc_eval(":erlang.throw 1"), "** (throw) 1")
     assert String.starts_with?(rpc_eval(":erlang.error 1"), "** (ErlangError) Erlang error: 1")


### PR DESCRIPTION
Before this patch we had this:

    iex> :os.cmd('elixir --sname foo --rpc-eval bar')
    ''

    iex> :os.cmd('elixir --sname foo --rpc-eval')
    'No file named \n'
