### PR TITLE
child_spec documentation for DynamicSupervisor

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -362,7 +362,9 @@ defmodule DynamicSupervisor do
 
   `child_spec` should be a valid child specification as detailed in the
   "Child specification" section of the documentation for `Supervisor`. The child
-  process will be started as defined in the child specification.
+  process will be started as defined in the child specification. Note that while
+  the `:id` field is still required in the spec, the value is ignored and
+  therefore does not need to be unique.
 
   If the child process start function returns `{:ok, child}` or `{:ok, child,
   info}`, then child specification and PID are added to the supervisor and

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -118,10 +118,11 @@ defmodule Supervisor do
   The child specification is a map containing up to 6 elements. The first two keys
   in the following list are required, and the remaining ones are optional:
 
-    * `:id` - any term used to identify the child specification
-      internally by the supervisor; defaults to the given module.
-      In the case of conflicting `:id` values, the supervisor will refuse
-      to initialize and require explicit IDs. This key is required.
+    * `:id` - any term used to identify the child specification internally by
+      the supervisor; defaults to the given module. This key is required. 
+      For Supervisors, in the case of conflicting `:id` values, the supervisor
+      will refuse to initialize and require explicit IDs. This is not the case
+      for DynamicSupervisors though.
 
     * `:start` - a tuple with the module-function-args to be invoked
       to start the child process. This key is required.


### PR DESCRIPTION
Adjust child_spec documentation to note that DynamicSupervisor requires the :id field, but ignores the value otherwise.