### PR TITLE
Tweak type unification to fix infinite loop with recursive vars

### DIFF
--- a/lib/elixir/lib/module/types/unify.ex
+++ b/lib/elixir/lib/module/types/unify.ex
@@ -43,12 +43,12 @@ defmodule Module.Types.Unify do
     {:ok, same, context}
   end
 
-  def unify(type, {:var, var}, stack, context) do
-    unify_var(var, type, stack, context, _var_source = false)
-  end
-
   def unify({:var, var}, type, stack, context) do
     unify_var(var, type, stack, context, _var_source = true)
+  end
+
+  def unify(type, {:var, var}, stack, context) do
+    unify_var(var, type, stack, context, _var_source = false)
   end
 
   def unify({:tuple, n, sources}, {:tuple, n, targets}, stack, context) do

--- a/lib/elixir/test/elixir/module/types/types_test.exs
+++ b/lib/elixir/test/elixir/module/types/types_test.exs
@@ -200,20 +200,20 @@ defmodule Module.Types.TypesTest do
                  # types_test.ex:1
                  is_binary(y)
 
-             where "y" was given the same type as "x" in:
+             where "x" was given the same type as "y" in:
 
                  # types_test.ex:1
                  x = y
+
+             where "y" was given the type integer() in:
+
+                 # types_test.ex:1
+                 is_integer(x)
 
              where "y" was given the type binary() in:
 
                  # types_test.ex:1
                  is_binary(y)
-
-             where "x" was given the type integer() in:
-
-                 # types_test.ex:1
-                 is_integer(x)
              """
     end
 
@@ -256,20 +256,20 @@ defmodule Module.Types.TypesTest do
                  # types_test.ex:1
                  is_binary(y)
 
-             where "y" was given the same type as "x" in:
+             where "x" was given the same type as "y" in:
 
                  # types_test.ex:1
                  x = y
+
+             where "y" was given the type integer() in:
+
+                 # types_test.ex:1
+                 is_integer(x)
 
              where "y" was given the type binary() in:
 
                  # types_test.ex:1
                  is_binary(y)
-
-             where "x" was given the type integer() in:
-
-                 # types_test.ex:1
-                 is_integer(x)
              """
     end
 
@@ -443,7 +443,17 @@ defmodule Module.Types.TypesTest do
                  # types_test.ex:5
                  %{"id" => user_id} = user
 
-             where "user" was given the same type as "amount" in:
+             where "amount" was given the type binary() in:
+
+                 # types_test.ex:3
+                 %{"amount" => amount} = event
+
+             where "amount" was given the same type as "user" in:
+
+                 # types_test.ex:4
+                 %{"user" => user} = event
+
+             where "user" was given the type binary() in:
 
                  # types_test.ex:4
                  %{"user" => user} = event
@@ -452,11 +462,6 @@ defmodule Module.Types.TypesTest do
 
                  # types_test.ex:5
                  %{"id" => user_id} = user
-
-             where "amount" was given the type binary() in:
-
-                 # types_test.ex:3
-                 %{"amount" => amount} = event
              """
     end
 
@@ -697,6 +702,33 @@ defmodule Module.Types.TypesTest do
                  case true do
                    _ when variable_enum != nil -> assigns.variable_enum
                  end
+               )
+             ) == :none
+    end
+
+    test "other recursive" do
+      assert warning(
+               [x, y],
+               (
+                 key_var = y
+                 %{^key_var => _value} = x
+                 key_var2 = y
+                 %{^key_var2 => _value2} = x
+                 y.z
+               )
+             ) == :none
+    end
+
+    test "other recursive2" do
+      assert warning(
+               [x, y],
+               (
+                 key_var = y
+                 %{^key_var => _value} = x
+                 key_var2 = y
+                 %{^key_var2 => _value2} = x
+                 key_var3 = y
+                 %{^key_var3 => _value3} = x
                )
              ) == :none
     end

--- a/lib/elixir/test/elixir/module/types/unify_test.exs
+++ b/lib/elixir/test/elixir/module/types/unify_test.exs
@@ -502,25 +502,25 @@ defmodule Module.Types.UnifyTest do
       assert {:ok, {:var, _}, context} = unify({:var, 0}, :tuple, var_context)
       assert {:ok, {:var, _}, context} = unify({:var, 1}, {:var, 0}, context)
       assert {:ok, {:var, _}, context} = unify({:var, 0}, {:var, 1}, context)
-      assert context.types[0] == {:var, 1}
-      assert context.types[1] == :tuple
+      assert context.types[0] == :tuple
+      assert context.types[1] == {:var, 0}
 
       assert {:ok, {:var, _}, context} = unify({:var, 0}, {:var, 1}, var_context)
       assert {:ok, {:var, _}, context} = unify({:var, 1}, {:var, 2}, context)
       assert {:ok, {:var, _}, _context} = unify({:var, 2}, {:var, 0}, context)
-      assert context.types[0] == :unbound
-      assert context.types[1] == {:var, 0}
-      assert context.types[2] == {:var, 1}
+      assert context.types[0] == {:var, 1}
+      assert context.types[1] == {:var, 2}
+      assert context.types[2] == :unbound
 
       assert {:ok, {:var, _}, context} = unify({:var, 0}, {:var, 1}, var_context)
 
-      assert {:error, {:unable_unify, {{:var, 0}, {:tuple, 1, [{:var, 0}]}, _}}} =
+      assert {:error, {:unable_unify, {{:var, 1}, {:tuple, 1, [{:var, 0}]}, _}}} =
                unify_lift({:var, 1}, {:tuple, 1, [{:var, 0}]}, context)
 
       assert {:ok, {:var, _}, context} = unify({:var, 0}, {:var, 1}, var_context)
       assert {:ok, {:var, _}, context} = unify({:var, 1}, {:var, 2}, context)
 
-      assert {:error, {:unable_unify, {{:var, 0}, {:tuple, 1, [{:var, 0}]}, _}}} =
+      assert {:error, {:unable_unify, {{:var, 2}, {:tuple, 1, [{:var, 0}]}, _}}} =
                unify_lift({:var, 2}, {:tuple, 1, [{:var, 0}]}, context)
     end
 
@@ -707,9 +707,9 @@ defmodule Module.Types.UnifyTest do
 
     {{:var, 0}, var_context} = new_var({:foo, [version: 0], nil}, new_context())
     {{:var, 1}, var_context} = new_var({:bar, [version: 1], nil}, var_context)
-    {:ok, {:var, 1}, var_context} = unify({:var, 0}, {:var, 1}, var_context)
-    assert flatten_union({:var, 0}, var_context) == [{:var, 0}]
-    assert flatten_union({:var, 1}, var_context) == [{:var, 0}]
+    {:ok, {:var, 0}, var_context} = unify({:var, 0}, {:var, 1}, var_context)
+    assert flatten_union({:var, 0}, var_context) == [{:var, 1}]
+    assert flatten_union({:var, 1}, var_context) == [{:var, 1}]
   end
 
   test "format_type/1" do


### PR DESCRIPTION
This may not be the correct way to solve this, since it affects the error messages sometimes in surprising ways, but since I've spent some time debugging this I thought opening a PR is a simple way to show the result of my investigation.

edit: But I kind of like the error messages from test examples, the order of type trace makes sense, maybe just the var names need to be improved.

edit2: Rebased without changes to fix Windows CI

Relates to (closes?) #11658