### PR TITLE
Refactor Eex Tokenizer

### DIFF
--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -34,7 +34,7 @@ defmodule EEx.Compiler do
         init = state.engine.init(opts)
         generate_buffer(tokens, init, [], state)
 
-      {:error, line, column, message} ->
+      {:error, message, %{column: column, line: line}} ->
         raise EEx.SyntaxError, file: file, line: line, column: column, message: message
     end
   end

--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -205,7 +205,7 @@ defmodule EEx.Compiler do
     end
   end
 
-  defp look_ahead_middle([{:middle_expr, chars, meta} | rest], _start, contents) do
+  defp look_ahead_middle([{:middle_expr, _, chars, meta} | rest], _start, contents) do
     {rest, meta.line, contents ++ chars}
   end
 

--- a/lib/eex/lib/eex/tokenizer.ex
+++ b/lib/eex/lib/eex/tokenizer.ex
@@ -5,10 +5,11 @@ defmodule EEx.Tokenizer do
   @type line :: non_neg_integer
   @type column :: non_neg_integer
   @type marker :: '=' | '/' | '|' | ''
+  @type metadata :: %{column: column, line: line}
   @type token ::
-          {:text, line, column, content}
-          | {:expr | :start_expr | :middle_expr | :end_expr, line, column, marker, content}
-          | {:eof, line, column}
+          {:text, content, metadata}
+          | {:expr | :start_expr | :middle_expr | :end_expr, marker, content, metadata}
+          | {:eof, metadata}
 
   @spaces [?\s, ?\t]
 
@@ -17,17 +18,22 @@ defmodule EEx.Tokenizer do
 
   It returns {:ok, list} with the following tokens:
 
-    * `{:text, line, column, content}`
-    * `{:expr, line, column, marker, content}`
-    * `{:start_expr, line, column, marker, content}`
-    * `{:middle_expr, line, column, marker, content}`
-    * `{:end_expr, line, column, marker, content}`
-    * `{:eof, line, column}`
+    * `{:text, content, %{column: column, line: line}}`
+    * `{:expr, marker, content, %{column: column, line: line}}`
+    * `{:start_expr, marker, content, %{column: column, line: line}}`
+    * `{:middle_expr, marker, content, %{column: column, line: line}}`
+    * `{:end_expr, marker, content, %{column: column, line: line}}`
+    * `{:eof, %{column: column, line: line}}`
 
   Or `{:error, line, column, message}` in case of errors.
   """
-  @spec tokenize(binary | charlist, line, column, map) ::
+  @spec tokenize(binary | charlist, map) ::
           {:ok, [token]} | {:error, line, column, String.t()}
+  def tokenize(contents, opts) do
+    line = opts[:line] || 1
+    column = opts[:column] || 1
+    tokenize(contents, line, column, opts)
+  end
 
   def tokenize(bin, line, column, opts) when is_binary(bin) do
     tokenize(String.to_charlist(bin), line, column, opts)
@@ -89,7 +95,7 @@ defmodule EEx.Tokenizer do
               {:expr, expr}
           end
 
-        token = {key, line, column, marker, expr}
+        token = {key, marker, expr, %{line: line, column: column}}
         trim_and_tokenize(rest, new_line, new_column, opts, buffer, acc, &[token | &1])
     end
   end
@@ -103,7 +109,7 @@ defmodule EEx.Tokenizer do
   end
 
   defp tokenize([], line, column, _opts, buffer, acc) do
-    eof = {:eof, line, column}
+    eof = {:eof, %{line: line, column: column}}
     {:ok, Enum.reverse([eof | tokenize_text(buffer, acc)])}
   end
 
@@ -212,7 +218,7 @@ defmodule EEx.Tokenizer do
 
   defp tokenize_text(buffer, acc) do
     [{line, column} | buffer] = Enum.reverse(buffer)
-    [{:text, line, column, buffer} | acc]
+    [{:text, buffer, %{line: line, column: column}} | acc]
   end
 
   ## Trim

--- a/lib/eex/test/eex/tokenizer_test.exs
+++ b/lib/eex/test/eex/tokenizer_test.exs
@@ -371,8 +371,11 @@ defmodule EEx.TokenizerTest do
   end
 
   test "returns error when there is start mark and no end mark" do
-    assert T.tokenize('foo <% :bar', 1, 1, @opts) == {:error, 1, 12, "missing token '%>'"}
-    assert T.tokenize('<%# true ', 1, 1, @opts) == {:error, 1, 10, "missing token '%>'"}
+    assert T.tokenize('foo <% :bar', 1, 1, @opts) ==
+             {:error, "missing token '%>'", %{column: 12, line: 1}}
+
+    assert T.tokenize('<%# true ', 1, 1, @opts) ==
+             {:error, "missing token '%>'", %{column: 10, line: 1}}
   end
 
   test "marks invalid expressions as regular expressions" do

--- a/lib/eex/test/eex/tokenizer_test.exs
+++ b/lib/eex/test/eex/tokenizer_test.exs
@@ -7,36 +7,63 @@ defmodule EEx.TokenizerTest do
   @opts %{indentation: 0, trim: false}
 
   test "simple chars lists" do
-    assert T.tokenize('foo', 1, 1, @opts) == {:ok, [{:text, 1, 1, 'foo'}, {:eof, 1, 4}]}
+    assert T.tokenize('foo', 1, 1, @opts) ==
+             {:ok, [{:text, 'foo', %{column: 1, line: 1}}, {:eof, %{column: 4, line: 1}}]}
   end
 
   test "simple strings" do
-    assert T.tokenize("foo", 1, 1, @opts) == {:ok, [{:text, 1, 1, 'foo'}, {:eof, 1, 4}]}
+    assert T.tokenize("foo", 1, 1, @opts) ==
+             {:ok, [{:text, 'foo', %{column: 1, line: 1}}, {:eof, %{column: 4, line: 1}}]}
   end
 
   test "strings with embedded code" do
     assert T.tokenize('foo <% bar %>', 1, 1, @opts) ==
-             {:ok, [{:text, 1, 1, 'foo '}, {:expr, 1, 5, '', ' bar '}, {:eof, 1, 14}]}
+             {:ok,
+              [
+                {:text, 'foo ', %{column: 1, line: 1}},
+                {:expr, '', ' bar ', %{column: 5, line: 1}},
+                {:eof, %{column: 14, line: 1}}
+              ]}
   end
 
   test "strings with embedded equals code" do
     assert T.tokenize('foo <%= bar %>', 1, 1, @opts) ==
-             {:ok, [{:text, 1, 1, 'foo '}, {:expr, 1, 5, '=', ' bar '}, {:eof, 1, 15}]}
+             {:ok,
+              [
+                {:text, 'foo ', %{column: 1, line: 1}},
+                {:expr, '=', ' bar ', %{column: 5, line: 1}},
+                {:eof, %{column: 15, line: 1}}
+              ]}
   end
 
   test "strings with embedded slash code" do
     assert T.tokenize('foo <%/ bar %>', 1, 1, @opts) ==
-             {:ok, [{:text, 1, 1, 'foo '}, {:expr, 1, 5, '/', ' bar '}, {:eof, 1, 15}]}
+             {:ok,
+              [
+                {:text, 'foo ', %{column: 1, line: 1}},
+                {:expr, '/', ' bar ', %{column: 5, line: 1}},
+                {:eof, %{column: 15, line: 1}}
+              ]}
   end
 
   test "strings with embedded pipe code" do
     assert T.tokenize('foo <%| bar %>', 1, 1, @opts) ==
-             {:ok, [{:text, 1, 1, 'foo '}, {:expr, 1, 5, '|', ' bar '}, {:eof, 1, 15}]}
+             {:ok,
+              [
+                {:text, 'foo ', %{column: 1, line: 1}},
+                {:expr, '|', ' bar ', %{column: 5, line: 1}},
+                {:eof, %{column: 15, line: 1}}
+              ]}
   end
 
   test "strings with more than one line" do
     assert T.tokenize('foo\n<%= bar %>', 1, 1, @opts) ==
-             {:ok, [{:text, 1, 1, 'foo\n'}, {:expr, 2, 1, '=', ' bar '}, {:eof, 2, 11}]}
+             {:ok,
+              [
+                {:text, 'foo\n', %{column: 1, line: 1}},
+                {:expr, '=', ' bar ', %{column: 1, line: 2}},
+                {:eof, %{column: 11, line: 2}}
+              ]}
   end
 
   test "strings with more than one line and expression with more than one line" do
@@ -48,12 +75,12 @@ defmodule EEx.TokenizerTest do
     '''
 
     exprs = [
-      {:text, 1, 1, 'foo '},
-      {:expr, 1, 5, '=', ' bar\n\nbaz '},
-      {:text, 3, 7, '\n'},
-      {:expr, 4, 1, '', ' foo '},
-      {:text, 4, 10, '\n'},
-      {:eof, 5, 1}
+      {:text, 'foo ', %{column: 1, line: 1}},
+      {:expr, '=', ' bar\n\nbaz ', %{column: 5, line: 1}},
+      {:text, '\n', %{column: 7, line: 3}},
+      {:expr, '', ' foo ', %{column: 1, line: 4}},
+      {:text, '\n', %{column: 10, line: 4}},
+      {:eof, %{column: 1, line: 5}}
     ]
 
     assert T.tokenize(string, 1, 1, @opts) == {:ok, exprs}
@@ -61,22 +88,30 @@ defmodule EEx.TokenizerTest do
 
   test "quotation" do
     assert T.tokenize('foo <%% true %>', 1, 1, @opts) ==
-             {:ok, [{:text, 1, 1, 'foo <% true %>'}, {:eof, 1, 16}]}
+             {:ok,
+              [
+                {:text, 'foo <% true %>', %{column: 1, line: 1}},
+                {:eof, %{column: 16, line: 1}}
+              ]}
   end
 
   test "quotation with do-end" do
     assert T.tokenize('foo <%% true do %>bar<%% end %>', 1, 1, @opts) ==
-             {:ok, [{:text, 1, 1, 'foo <% true do %>bar<% end %>'}, {:eof, 1, 32}]}
+             {:ok,
+              [
+                {:text, 'foo <% true do %>bar<% end %>', %{column: 1, line: 1}},
+                {:eof, %{column: 32, line: 1}}
+              ]}
   end
 
   test "quotation with interpolation" do
     exprs = [
-      {:text, 1, 1, 'a <% b '},
-      {:expr, 1, 9, '=', ' c '},
-      {:text, 1, 17, ' '},
-      {:expr, 1, 18, '=', ' d '},
-      {:text, 1, 26, ' e %> f'},
-      {:eof, 1, 33}
+      {:text, 'a <% b ', %{column: 1, line: 1}},
+      {:expr, '=', ' c ', %{column: 9, line: 1}},
+      {:text, ' ', %{column: 17, line: 1}},
+      {:expr, '=', ' d ', %{column: 18, line: 1}},
+      {:text, ' e %> f', %{column: 26, line: 1}},
+      {:eof, %{column: 33, line: 1}}
     ]
 
     assert T.tokenize('a <%% b <%= c %> <%= d %> e %> f', 1, 1, @opts) == {:ok, exprs}
@@ -84,8 +119,8 @@ defmodule EEx.TokenizerTest do
 
   test "improperly formatted quotation with interpolation" do
     exprs = [
-      {:text, 1, 1, '<%% a <%= b %> c %>'},
-      {:eof, 1, 22}
+      {:text, '<%% a <%= b %> c %>', %{column: 1, line: 1}},
+      {:eof, %{column: 22, line: 1}}
     ]
 
     assert T.tokenize('<%%% a <%%= b %> c %>', 1, 1, @opts) == {:ok, exprs}
@@ -93,15 +128,15 @@ defmodule EEx.TokenizerTest do
 
   test "EEx comments" do
     exprs = [
-      {:text, 1, 1, 'foo '},
-      {:eof, 1, 16}
+      {:text, 'foo ', %{column: 1, line: 1}},
+      {:eof, %{column: 16, line: 1}}
     ]
 
     assert T.tokenize('foo <%# true %>', 1, 1, @opts) == {:ok, exprs}
 
     exprs = [
-      {:text, 1, 1, 'foo '},
-      {:eof, 2, 8}
+      {:text, 'foo ', %{column: 1, line: 1}},
+      {:eof, %{column: 8, line: 2}}
     ]
 
     assert T.tokenize('foo <%#\ntrue %>', 1, 1, @opts) == {:ok, exprs}
@@ -109,9 +144,9 @@ defmodule EEx.TokenizerTest do
 
   test "EEx comments with do-end" do
     exprs = [
-      {:text, 1, 1, 'foo '},
-      {:text, 1, 19, 'bar'},
-      {:eof, 1, 32}
+      {:text, 'foo ', %{column: 1, line: 1}},
+      {:text, 'bar', %{column: 19, line: 1}},
+      {:eof, %{column: 32, line: 1}}
     ]
 
     assert T.tokenize('foo <%# true do %>bar<%# end %>', 1, 1, @opts) == {:ok, exprs}
@@ -119,20 +154,20 @@ defmodule EEx.TokenizerTest do
 
   test "EEx comments inside do-end" do
     exprs = [
-      {:start_expr, 1, 1, '', ' if true do '},
-      {:text, 1, 31, 'bar'},
-      {:end_expr, 1, 34, [], ' end '},
-      {:eof, 1, 43}
+      {:start_expr, '', ' if true do ', %{column: 1, line: 1}},
+      {:text, 'bar', %{column: 31, line: 1}},
+      {:end_expr, [], ' end ', %{column: 34, line: 1}},
+      {:eof, %{column: 43, line: 1}}
     ]
 
     assert T.tokenize('<% if true do %><%# comment %>bar<% end %>', 1, 1, @opts) == {:ok, exprs}
 
     exprs = [
-      {:start_expr, 1, 1, [], ' case true do '},
-      {:middle_expr, 1, 33, '', ' true -> '},
-      {:text, 1, 46, 'bar'},
-      {:end_expr, 1, 49, [], ' end '},
-      {:eof, 1, 58}
+      {:start_expr, [], ' case true do ', %{column: 1, line: 1}},
+      {:middle_expr, '', ' true -> ', %{column: 33, line: 1}},
+      {:text, 'bar', %{column: 46, line: 1}},
+      {:end_expr, [], ' end ', %{column: 49, line: 1}},
+      {:eof, %{column: 58, line: 1}}
     ]
 
     assert T.tokenize('<% case true do %><%# comment %><% true -> %>bar<% end %>', 1, 1, @opts) ==
@@ -141,25 +176,25 @@ defmodule EEx.TokenizerTest do
 
   test "EEx multi-line comments" do
     exprs = [
-      {:text, 1, 1, 'foo '},
-      {:text, 1, 20, ' bar'},
-      {:eof, 1, 24}
+      {:text, 'foo ', %{column: 1, line: 1}},
+      {:text, ' bar', %{column: 20, line: 1}},
+      {:eof, %{column: 24, line: 1}}
     ]
 
     assert T.tokenize('foo <%!-- true --%> bar', 1, 1, @opts) == {:ok, exprs}
 
     exprs = [
-      {:text, 1, 1, 'foo '},
-      {:text, 3, 6, ' bar'},
-      {:eof, 3, 10}
+      {:text, 'foo ', %{column: 1, line: 1}},
+      {:text, ' bar', %{column: 6, line: 3}},
+      {:eof, %{column: 10, line: 3}}
     ]
 
     assert T.tokenize('foo <%!-- \ntrue\n --%> bar', 1, 1, @opts) == {:ok, exprs}
 
     exprs = [
-      {:text, 1, 1, 'foo '},
-      {:text, 1, 27, ' bar'},
-      {:eof, 1, 31}
+      {:text, 'foo ', %{column: 1, line: 1}},
+      {:text, ' bar', %{column: 27, line: 1}},
+      {:eof, %{column: 31, line: 1}}
     ]
 
     assert T.tokenize('foo <%!-- <%= true %> --%> bar', 1, 1, @opts) == {:ok, exprs}
@@ -167,9 +202,9 @@ defmodule EEx.TokenizerTest do
 
   test "Elixir comments" do
     exprs = [
-      {:text, 1, 1, 'foo '},
-      {:expr, 1, 5, [], ' true # this is a boolean '},
-      {:eof, 1, 35}
+      {:text, 'foo ', %{column: 1, line: 1}},
+      {:expr, [], ' true # this is a boolean ', %{column: 5, line: 1}},
+      {:eof, %{column: 35, line: 1}}
     ]
 
     assert T.tokenize('foo <% true # this is a boolean %>', 1, 1, @opts) == {:ok, exprs}
@@ -177,10 +212,10 @@ defmodule EEx.TokenizerTest do
 
   test "Elixir comments with do-end" do
     exprs = [
-      {:start_expr, 1, 1, [], ' if true do # startif '},
-      {:text, 1, 27, 'text'},
-      {:end_expr, 1, 31, [], ' end # closeif '},
-      {:eof, 1, 50}
+      {:start_expr, [], ' if true do # startif ', %{column: 1, line: 1}},
+      {:text, 'text', %{column: 27, line: 1}},
+      {:end_expr, [], ' end # closeif ', %{column: 31, line: 1}},
+      {:eof, %{column: 50, line: 1}}
     ]
 
     assert T.tokenize('<% if true do # startif %>text<% end # closeif %>', 1, 1, @opts) ==
@@ -189,11 +224,11 @@ defmodule EEx.TokenizerTest do
 
   test "strings with embedded do end" do
     exprs = [
-      {:text, 1, 1, 'foo '},
-      {:start_expr, 1, 5, '', ' if true do '},
-      {:text, 1, 21, 'bar'},
-      {:end_expr, 1, 24, '', ' end '},
-      {:eof, 1, 33}
+      {:text, 'foo ', %{column: 1, line: 1}},
+      {:start_expr, '', ' if true do ', %{column: 5, line: 1}},
+      {:text, 'bar', %{column: 21, line: 1}},
+      {:end_expr, '', ' end ', %{column: 24, line: 1}},
+      {:eof, %{column: 33, line: 1}}
     ]
 
     assert T.tokenize('foo <% if true do %>bar<% end %>', 1, 1, @opts) == {:ok, exprs}
@@ -201,14 +236,14 @@ defmodule EEx.TokenizerTest do
 
   test "strings with embedded -> end" do
     exprs = [
-      {:text, 1, 1, 'foo '},
-      {:start_expr, 1, 5, '', ' cond do '},
-      {:middle_expr, 1, 18, '', ' false -> '},
-      {:text, 1, 32, 'bar'},
-      {:middle_expr, 1, 35, '', ' true -> '},
-      {:text, 1, 48, 'baz'},
-      {:end_expr, 1, 51, '', ' end '},
-      {:eof, 1, 60}
+      {:text, 'foo ', %{column: 1, line: 1}},
+      {:start_expr, '', ' cond do ', %{column: 5, line: 1}},
+      {:middle_expr, '', ' false -> ', %{column: 18, line: 1}},
+      {:text, 'bar', %{column: 32, line: 1}},
+      {:middle_expr, '', ' true -> ', %{column: 35, line: 1}},
+      {:text, 'baz', %{column: 48, line: 1}},
+      {:end_expr, '', ' end ', %{column: 51, line: 1}},
+      {:eof, %{column: 60, line: 1}}
     ]
 
     assert T.tokenize('foo <% cond do %><% false -> %>bar<% true -> %>baz<% end %>', 1, 1, @opts) ==
@@ -217,10 +252,10 @@ defmodule EEx.TokenizerTest do
 
   test "strings with fn-end with newline" do
     exprs = [
-      {:start_expr, 1, 1, '=', ' a fn ->\n'},
-      {:text, 2, 3, 'foo'},
-      {:end_expr, 2, 6, [], ' end '},
-      {:eof, 2, 15}
+      {:start_expr, '=', ' a fn ->\n', %{column: 1, line: 1}},
+      {:text, 'foo', %{column: 3, line: 2}},
+      {:end_expr, [], ' end ', %{column: 6, line: 2}},
+      {:eof, %{column: 15, line: 2}}
     ]
 
     assert T.tokenize('<%= a fn ->\n%>foo<% end %>', 1, 1, @opts) ==
@@ -229,12 +264,12 @@ defmodule EEx.TokenizerTest do
 
   test "strings with multiple fn-end" do
     exprs = [
-      {:start_expr, 1, 1, '=', ' a fn -> '},
-      {:text, 1, 15, 'foo'},
-      {:middle_expr, 1, 18, '', ' end, fn -> '},
-      {:text, 1, 34, 'bar'},
-      {:end_expr, 1, 37, '', ' end '},
-      {:eof, 1, 46}
+      {:start_expr, '=', ' a fn -> ', %{column: 1, line: 1}},
+      {:text, 'foo', %{column: 15, line: 1}},
+      {:middle_expr, '', ' end, fn -> ', %{column: 18, line: 1}},
+      {:text, 'bar', %{column: 34, line: 1}},
+      {:end_expr, '', ' end ', %{column: 37, line: 1}},
+      {:eof, %{column: 46, line: 1}}
     ]
 
     assert T.tokenize('<%= a fn -> %>foo<% end, fn -> %>bar<% end %>', 1, 1, @opts) ==
@@ -243,12 +278,12 @@ defmodule EEx.TokenizerTest do
 
   test "strings with fn-end followed by do block" do
     exprs = [
-      {:start_expr, 1, 1, '=', ' a fn -> '},
-      {:text, 1, 15, 'foo'},
-      {:middle_expr, 1, 18, '', ' end do '},
-      {:text, 1, 30, 'bar'},
-      {:end_expr, 1, 33, '', ' end '},
-      {:eof, 1, 42}
+      {:start_expr, '=', ' a fn -> ', %{column: 1, line: 1}},
+      {:text, 'foo', %{column: 15, line: 1}},
+      {:middle_expr, '', ' end do ', %{column: 18, line: 1}},
+      {:text, 'bar', %{column: 30, line: 1}},
+      {:end_expr, '', ' end ', %{column: 33, line: 1}},
+      {:eof, %{column: 42, line: 1}}
     ]
 
     assert T.tokenize('<%= a fn -> %>foo<% end do %>bar<% end %>', 1, 1, @opts) == {:ok, exprs}
@@ -256,13 +291,13 @@ defmodule EEx.TokenizerTest do
 
   test "strings with embedded keywords blocks" do
     exprs = [
-      {:text, 1, 1, 'foo '},
-      {:start_expr, 1, 5, '', ' if true do '},
-      {:text, 1, 21, 'bar'},
-      {:middle_expr, 1, 24, '', ' else '},
-      {:text, 1, 34, 'baz'},
-      {:end_expr, 1, 37, '', ' end '},
-      {:eof, 1, 46}
+      {:text, 'foo ', %{column: 1, line: 1}},
+      {:start_expr, '', ' if true do ', %{column: 5, line: 1}},
+      {:text, 'bar', %{column: 21, line: 1}},
+      {:middle_expr, '', ' else ', %{column: 24, line: 1}},
+      {:text, 'baz', %{column: 34, line: 1}},
+      {:end_expr, '', ' end ', %{column: 37, line: 1}},
+      {:eof, %{column: 46, line: 1}}
     ]
 
     assert T.tokenize('foo <% if true do %>bar<% else %>baz<% end %>', 1, 1, @opts) ==
@@ -273,12 +308,12 @@ defmodule EEx.TokenizerTest do
     template = '\t<%= if true do %> \n TRUE \n  <% else %>\n FALSE \n  <% end %>  \n\n  '
 
     exprs = [
-      {:start_expr, 1, 2, '=', ' if true do '},
-      {:text, 1, 20, '\n TRUE \n'},
-      {:middle_expr, 3, 3, '', ' else '},
-      {:text, 3, 13, '\n FALSE \n'},
-      {:end_expr, 5, 3, '', ' end '},
-      {:eof, 7, 3}
+      {:start_expr, '=', ' if true do ', %{column: 2, line: 1}},
+      {:text, '\n TRUE \n', %{column: 20, line: 1}},
+      {:middle_expr, '', ' else ', %{column: 3, line: 3}},
+      {:text, '\n FALSE \n', %{column: 13, line: 3}},
+      {:end_expr, '', ' end ', %{column: 3, line: 5}},
+      {:eof, %{column: 3, line: 7}}
     ]
 
     assert T.tokenize(template, 1, 1, %{@opts | trim: true}) == {:ok, exprs}
@@ -286,8 +321,8 @@ defmodule EEx.TokenizerTest do
 
   test "trim mode with comment" do
     exprs = [
-      {:text, 1, 19, '\n123'},
-      {:eof, 2, 4}
+      {:text, '\n123', %{column: 19, line: 1}},
+      {:eof, %{column: 4, line: 2}}
     ]
 
     assert T.tokenize('  <%# comment %>  \n123', 1, 1, %{@opts | trim: true}) == {:ok, exprs}
@@ -295,8 +330,8 @@ defmodule EEx.TokenizerTest do
 
   test "trim mode with multi-line comment" do
     exprs = [
-      {:text, 1, 23, '\n123'},
-      {:eof, 2, 4}
+      {:text, '\n123', %{column: 23, line: 1}},
+      {:eof, %{column: 4, line: 2}}
     ]
 
     assert T.tokenize('  <%!-- comment --%>  \n123', 1, 1, %{@opts | trim: true}) == {:ok, exprs}
@@ -304,10 +339,10 @@ defmodule EEx.TokenizerTest do
 
   test "trim mode with CRLF" do
     exprs = [
-      {:text, 1, 1, '0\n'},
-      {:expr, 2, 3, '=', ' 12 '},
-      {:text, 2, 15, '\n34'},
-      {:eof, 3, 3}
+      {:text, '0\n', %{column: 1, line: 1}},
+      {:expr, '=', ' 12 ', %{column: 3, line: 2}},
+      {:text, '\n34', %{column: 15, line: 2}},
+      {:eof, %{column: 3, line: 3}}
     ]
 
     assert T.tokenize('0\r\n  <%= 12 %>  \r\n34', 1, 1, %{@opts | trim: true}) == {:ok, exprs}
@@ -315,10 +350,10 @@ defmodule EEx.TokenizerTest do
 
   test "trim mode set to false" do
     exprs = [
-      {:text, 1, 1, ' '},
-      {:expr, 1, 2, '=', ' 12 '},
-      {:text, 1, 11, ' \n'},
-      {:eof, 2, 1}
+      {:text, ' ', %{column: 1, line: 1}},
+      {:expr, '=', ' 12 ', %{column: 2, line: 1}},
+      {:text, ' \n', %{column: 11, line: 1}},
+      {:eof, %{column: 1, line: 2}}
     ]
 
     assert T.tokenize(' <%= 12 %> \n', 1, 1, %{@opts | trim: false}) == {:ok, exprs}
@@ -342,6 +377,10 @@ defmodule EEx.TokenizerTest do
 
   test "marks invalid expressions as regular expressions" do
     assert T.tokenize('<% 1 $ 2 %>', 1, 1, @opts) ==
-             {:ok, [{:expr, 1, 1, [], ' 1 $ 2 '}, {:eof, 1, 12}]}
+             {:ok,
+              [
+                {:expr, [], ' 1 $ 2 ', %{column: 1, line: 1}},
+                {:eof, %{column: 12, line: 1}}
+              ]}
   end
 end


### PR DESCRIPTION
This commit moves the line and column to the last argument to be handled as a metadata as you can see in the example below:

```elixir
    assert T.tokenize('foo', 1, 1, @opts) ==
             {:ok, [{:text, 'foo', %{line: 1, column: 1}}, {:eof, %{line: 1, column: 4}}]}
```