### PR TITLE
Add zip_value_to_exit option to Task.async_stream

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -545,9 +545,10 @@ defmodule Task do
       * `:kill_task` - the task that timed out is killed. The value
         emitted for that task is `{:exit, :timeout}`.
 
-    * `:zip_input_on_exit` - adds original element to exits.
-      The value emitted for that task is `{:exit, {element, reason}}`,
-      where `element` is the element it exited on. Defaults to `false`.
+    * `:zip_input_on_exit` - (since v1.14.0) adds the original
+      input to `:exit` tuples. The value emitted for that task is
+      `{:exit, {input, reason}}`, where `input` is the collection element
+      that caused an exited during processing. Defaults to `false`.
 
   ## Example
 

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -509,7 +509,9 @@ defmodule Task do
 
   When streamed, each task will emit `{:ok, value}` upon successful
   completion or `{:exit, reason}` if the caller is trapping exits.
-  The order of results depends on the value of the `:ordered` option.
+  It's possible to have `{:exit, {element, reason}}` for exits
+  using the `:zip_input_on_exit` option. The order of results depends
+  on the value of the `:ordered` option.
 
   The level of concurrency and the time tasks are allowed to run can
   be controlled via options (see the "Options" section below).
@@ -542,6 +544,10 @@ defmodule Task do
       * `:exit` (default) - the caller (the process that spawned the tasks) exits.
       * `:kill_task` - the task that timed out is killed. The value
         emitted for that task is `{:exit, :timeout}`.
+
+    * `:zip_input_on_exit` - adds original element to exits.
+      The value emitted for that task is `{:exit, {element, reason}}`,
+      where `element` is the element it exited on. Defaults to `false`.
 
   ## Example
 

--- a/lib/elixir/lib/task/supervised.ex
+++ b/lib/elixir/lib/task/supervised.ex
@@ -184,6 +184,7 @@ defmodule Task.Supervised do
     ordered? = Keyword.get(options, :ordered, true)
     timeout = Keyword.get(options, :timeout, 5000)
     on_timeout = Keyword.get(options, :on_timeout, :exit)
+    zip_input_on_exit? = Keyword.get(options, :zip_input_on_exit, false)
     parent = self()
 
     {:trap_exit, trap_exit?} = Process.info(self(), :trap_exit)
@@ -211,6 +212,7 @@ defmodule Task.Supervised do
       ordered: ordered?,
       timeout: timeout,
       on_timeout: on_timeout,
+      zip_input_on_exit: zip_input_on_exit?,
       callers: callers,
       mfa: mfa
     }
@@ -254,6 +256,7 @@ defmodule Task.Supervised do
       monitor_ref: monitor_ref,
       timeout: timeout,
       on_timeout: on_timeout,
+      zip_input_on_exit: zip_input_on_exit?,
       ordered: ordered?
     } = config
 
@@ -263,7 +266,7 @@ defmodule Task.Supervised do
       # this response when the replying task dies (we'll see this in the :down
       # message).
       {{^monitor_ref, position}, reply} ->
-        %{^position => {pid, :running}} = waiting
+        %{^position => {pid, :running, _element}} = waiting
         waiting = Map.put(waiting, position, {pid, {:ok, reply}})
         stream_reduce({:cont, acc}, max, spawned, delivered, waiting, next, config)
 
@@ -281,20 +284,20 @@ defmodule Task.Supervised do
               ok
 
             # If the task exited by itself before replying, we emit {:exit, reason}.
-            %{^position => {_, :running}}
+            %{^position => {_, :running, element}}
             when kind == :down ->
-              {:exit, reason}
+              if zip_input_on_exit?, do: {:exit, {element, reason}}, else: {:exit, reason}
 
             # If the task timed out before replying, we either exit (on_timeout: :exit)
             # or emit {:exit, :timeout} (on_timeout: :kill_task) (note the task is already
             # dead at this point).
-            %{^position => {_, :running}}
+            %{^position => {_, :running, element}}
             when kind == :timed_out ->
               if on_timeout == :exit do
                 stream_cleanup_inbox(monitor_pid, monitor_ref)
                 exit({:timeout, {__MODULE__, :stream, [timeout]}})
               else
-                {:exit, :timeout}
+                if zip_input_on_exit?, do: {:exit, {element, :timeout}}, else: {:exit, :timeout}
               end
           end
 
@@ -433,7 +436,7 @@ defmodule Task.Supervised do
       {:spawned, {^monitor_ref, ^spawned}, pid} ->
         mfa_with_value = normalize_mfa_with_arg(mfa, value)
         send(pid, {self(), {monitor_ref, spawned}, self(), callers, mfa_with_value})
-        Map.put(waiting, spawned, {pid, :running})
+        Map.put(waiting, spawned, {pid, :running, value})
 
       {:max_children, ^monitor_ref} ->
         stream_close(config)

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -992,6 +992,23 @@ defmodule TaskTest do
 
         refute_received _
       end
+
+      test "with timeout and :zip_input_on_exit set to true" do
+        opts = Keyword.merge(@opts, zip_input_on_exit: true, on_timeout: :kill_task, timeout: 50)
+
+        assert [1, 100]
+               |> Task.async_stream(&sleep/1, opts)
+               |> Enum.to_list() == [ok: 1, exit: {100, :timeout}]
+      end
+
+      test "with outer halt on failure and :zip_input_on_exit" do
+        Process.flag(:trap_exit, true)
+        opts = Keyword.merge(@opts, zip_input_on_exit: true)
+
+        assert 1..8
+               |> Task.async_stream(&exit/1, opts)
+               |> Enum.take(4) == [exit: {1, 1}, exit: {2, 2}, exit: {3, 3}, exit: {4, 4}]
+      end
     end
   end
 end


### PR DESCRIPTION
This change allows developers to see what the value was when the task failed without breaking changes. in `Task.async_stream`

More details here: https://groups.google.com/g/elixir-lang-core/c/XCQIKQc3KxM