### PR TITLE
Fix `Enumerable.slice` docs

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -204,7 +204,7 @@ defprotocol Enumerable do
       a `start` position, the `amount` of elements to fetch, and a
       `step`.
 
-    * `{:ok, size, to_list_fun} - if the `enumerable` has a known bound
+    * `{:ok, size, to_list_fun}` - if the `enumerable` has a known bound
       and can access a position in the `enumerable` by first converting
       it to a list via `to_list_fun`.
 


### PR DESCRIPTION
Brought to you by:

```
warning: ExDoc.Markdown.Earmark (warning) lib/elixir/lib/enum.ex:223 Closing unclosed backquotes ` at end of input
```
