### PR TITLE
Add Range.shift/2

### DIFF
--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -256,6 +256,22 @@ defmodule Range do
   end
 
   @doc """
+  Shifts the first and last of a range by a given amount
+
+  ## Examples
+
+      iex> Range.shift(1..10, 2)
+      3..12
+
+      iex> Range.shift(1..10, -2)
+      -1..8
+  """
+  def shift(first..last//step, amount_to_shift)
+      when is_integer(first) and is_integer(last) and is_integer(amount_to_shift) do
+    new(first + amount_to_shift, last + amount_to_shift, step)
+  end
+
+  @doc """
   Checks if two ranges are disjoint.
 
   ## Examples

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -256,19 +256,40 @@ defmodule Range do
   end
 
   @doc """
-  Shifts the first and last of a range by a given amount
+  Adds the given amount to the first and last of a range
 
   ## Examples
 
-      iex> Range.shift(1..10, 2)
+      iex> Range.add(1..10, 2)
       3..12
 
-      iex> Range.shift(1..10, -2)
+      iex> Range.add(1..10, -2)
       -1..8
   """
-  def shift(first..last//step, amount_to_shift)
-      when is_integer(first) and is_integer(last) and is_integer(amount_to_shift) do
-    new(first + amount_to_shift, last + amount_to_shift, step)
+  def add(first..last//step, amount_to_add)
+      when is_integer(first) and is_integer(last) and is_integer(amount_to_add) do
+    new(first + amount_to_add, last + amount_to_add, step)
+  end
+
+  @doc """
+  Shifts a range by the given number of steps
+
+  ## Examples
+
+      iex> Range.shift(0..10//2, 2)
+      4..14//2
+  """
+  def shift(first..last//step, steps_to_shift)
+      when is_integer(first) and is_integer(last) and is_integer(step) and
+             is_integer(steps_to_shift) do
+    new(first + steps_to_shift * step, last + steps_to_shift * step, step)
+  end
+
+  # TODO: Remove me on v2.0
+  def shift(%{__struct__: Range, first: first, last: last} = range, steps_to_shift)
+      when is_integer(first) and is_integer(last) and is_integer(steps_to_shift) do
+    step = if first <= last, do: 1, else: -1
+    shift(Map.put(range, :step, step), steps_to_shift)
   end
 
   @doc """

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -256,25 +256,14 @@ defmodule Range do
   end
 
   @doc """
-  Adds the given amount to the first and last of a range
+  Shifts a range by the given number of steps.
 
   ## Examples
 
-      iex> Range.add(1..10, 2)
-      3..12
-
-      iex> Range.add(1..10, -2)
-      -1..8
-  """
-  def add(first..last//step, amount_to_add)
-      when is_integer(first) and is_integer(last) and is_integer(amount_to_add) do
-    new(first + amount_to_add, last + amount_to_add, step)
-  end
-
-  @doc """
-  Shifts a range by the given number of steps
-
-  ## Examples
+      iex> Range.shift(0..10, 1)
+      1..11
+      iex> Range.shift(0..10, 2)
+      2..12
 
       iex> Range.shift(0..10//2, 2)
       4..14//2
@@ -283,13 +272,6 @@ defmodule Range do
       when is_integer(first) and is_integer(last) and is_integer(step) and
              is_integer(steps_to_shift) do
     new(first + steps_to_shift * step, last + steps_to_shift * step, step)
-  end
-
-  # TODO: Remove me on v2.0
-  def shift(%{__struct__: Range, first: first, last: last} = range, steps_to_shift)
-      when is_integer(first) and is_integer(last) and is_integer(steps_to_shift) do
-    step = if first <= last, do: 1, else: -1
-    shift(Map.put(range, :step, step), steps_to_shift)
   end
 
   @doc """

--- a/lib/elixir/test/elixir/range_test.exs
+++ b/lib/elixir/test/elixir/range_test.exs
@@ -51,16 +51,10 @@ defmodule RangeTest do
     assert inspect(3..1//1) == "3..1//1"
   end
 
-  test "add" do
-    assert Range.add(1..3, 2) == 3..5
-    assert Range.add(1..3, -3) == -2..0
-  end
-
   test "shift" do
     assert Range.shift(0..10//2, 2) == 4..14//2
     assert Range.shift(10..0//-2, 2) == 6..-4//-2
     assert Range.shift(10..0//-2, -2) == 14..4//-2
-    assert Range.shift(%{__struct__: Range, first: 1, last: 3}, 2) == 3..5
   end
 
   test "limits are integer only" do

--- a/lib/elixir/test/elixir/range_test.exs
+++ b/lib/elixir/test/elixir/range_test.exs
@@ -51,9 +51,16 @@ defmodule RangeTest do
     assert inspect(3..1//1) == "3..1//1"
   end
 
+  test "add" do
+    assert Range.add(1..3, 2) == 3..5
+    assert Range.add(1..3, -3) == -2..0
+  end
+
   test "shift" do
-    assert Range.shift(1..3, 2) == 3..5
-    assert Range.shift(1..3, -3) == -2..0
+    assert Range.shift(0..10//2, 2) == 4..14//2
+    assert Range.shift(10..0//-2, 2) == 6..-4//-2
+    assert Range.shift(10..0//-2, -2) == 14..4//-2
+    assert Range.shift(%{__struct__: Range, first: 1, last: 3}, 2) == 3..5
   end
 
   test "limits are integer only" do

--- a/lib/elixir/test/elixir/range_test.exs
+++ b/lib/elixir/test/elixir/range_test.exs
@@ -51,6 +51,11 @@ defmodule RangeTest do
     assert inspect(3..1//1) == "3..1//1"
   end
 
+  test "shift" do
+    assert Range.shift(1..3, 2) == 3..5
+    assert Range.shift(1..3, -3) == -2..0
+  end
+
   test "limits are integer only" do
     first = 1.0
     last = 3.0


### PR DESCRIPTION
When working with ranges a lot, this helps to shift a range in a single, pipe-able operation.

I chose `shift` over `add` because add could be misinterpreted to mean you're expanding the range. DateTime and friends use `add` for moving around.
I still have concerns about `shift` because in an array context `shift` could be taken to mean "remove the first". While elixir doesn't do this, it could be unexpected for those from other languages.

Perhaps this is why the function doesn't exist - but I couldn't find it in the PR or Issue history on the main repo. So even if this gets closed as `wont-merge` it'll at least help with discoverability for the next person.