### PR TITLE
Improve Macro.pipe/3 docs

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -245,7 +245,7 @@ defmodule Macro do
   end
 
   @doc """
-  Pipes the `expr` into the `call_args` at the given `position`.
+  Pipes `expr` into the `call_args` at the given `position`.
 
   `expr` is the AST of an expression. `call_args` must be the AST *of a call*,
   otherwise this function will raise an error.
@@ -264,13 +264,9 @@ defmodule Macro do
       ** (ArgumentError) cannot pipe 10 into 20, can only pipe into local calls foo(), remote calls Foo.bar() or anonymous function calls foo.()
 
   Even if the expression is piped into the AST, it doesn't
-  necessarily mean that the AST is valid and it might generate runtime issues,
-  for example:
-
-      iex> ast = Macro.pipe(10, {:div, [], [2, 5]}, 0)
-      {:div, [], [10, 2, 5]}
-      iex> Code.eval_quoted(ast)
-      ** (CompileError) nofile:1: undefined function div/3 (there is no such import)
+  necessarily mean that the AST is valid and it might generate runtime issues.
+  For example, you could pipe an argument to div/2 effectively turning it into a
+  call to div/3, which is a function that won't exist at runtime.
 
   """
   @spec pipe(t(), t(), integer) :: t()

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -248,26 +248,13 @@ defmodule Macro do
   Pipes `expr` into the `call_args` at the given `position`.
 
   `expr` is the AST of an expression. `call_args` must be the AST *of a call*,
-  otherwise this function will raise an error.
+  otherwise this function will raise an error. As an example, consider the pipe
+  operator `|>/2`, which uses this function to build pipelines.
 
-  ## Examples
-
-      iex> ast = Macro.pipe(quote(do: div(10, 2)), quote(do: div(5)), 0)
-      {:div, [], [{:div, [context: MacroTest, import: Kernel], [10, 2]}, 5]}
-      iex> Code.eval_quoted(ast)
-      {1, []}
-
-  If attempted to pipe an expression into something other than a call,
-  the following error will be raised:
-
-      iex> Macro.pipe(10, 20, 0)
-      ** (ArgumentError) cannot pipe 10 into 20, can only pipe into local calls foo(), remote calls Foo.bar() or anonymous function calls foo.()
-
-  Even if the expression is piped into the AST, it doesn't
-  necessarily mean that the AST is valid and it might generate runtime issues.
-  For example, you could pipe an argument to div/2 effectively turning it into a
-  call to div/3, which is a function that won't exist at runtime.
-
+  Even if the expression is piped into the AST, it doesn't necessarily mean that
+  the AST is valid. For example, you could pipe an argument to `div/2`, effectively
+  turning it into a call to `div/3`, which is a function that doesn't exist by
+  default. The code will raise unless a `div/3` function is locally defined.
   """
   @spec pipe(t(), t(), integer) :: t()
   def pipe(expr, call_args, position)

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -245,7 +245,33 @@ defmodule Macro do
   end
 
   @doc """
-  Pipes `expr` into the `call_args` at the given `position`.
+  Pipes the `expr` into the `call_args` at the given `position`.
+
+  - `expr` Might be an AST, or just a literal value.
+  - `call_args` Must be an AST; otherwise error will be raised.
+
+  ## Examples
+
+      iex> ast = Macro.pipe(quote(do: div(10, 2)), quote(do: div(5)), 0)
+      {:div, [], [{:div, [context: MacroTest, import: Kernel], [10, 2]}, 5]}
+      iex> Code.eval_quoted(ast)
+      {1, []}
+
+  If attempted to pipe an expression into a non AST,
+  the following error will be raised:
+
+      iex> Macro.pipe(10, 20, 0)
+      ** (ArgumentError) cannot pipe 10 into 20, the 2nd argument must be an AST.
+
+  It's also good to remind that even if the
+  expression is piped into the AST, it doesn't mean that
+  the AST is valid, and it might generate runtime issues,
+  for example:
+
+      iex> ast = Macro.pipe(10, {:div, [], [2, 5]}, 0)
+      {:div, [], [10, 2, 5]}
+      iex> Code.eval_quoted(ast)
+      ** (CompileError) nofile:1: undefined function div/3 (there is no such import)
   """
   @spec pipe(t(), t(), integer) :: t()
   def pipe(expr, call_args, position)

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -247,8 +247,8 @@ defmodule Macro do
   @doc """
   Pipes the `expr` into the `call_args` at the given `position`.
 
-  - `expr` Might be an AST, or just a literal value.
-  - `call_args` Must be an AST; otherwise error will be raised.
+  `expr` is the AST of an expression. `call_args` must be the AST *of a call*,
+  otherwise this function will raise an error.
 
   ## Examples
 
@@ -257,30 +257,24 @@ defmodule Macro do
       iex> Code.eval_quoted(ast)
       {1, []}
 
-  If attempted to pipe an expression into a non AST,
+  If attempted to pipe an expression into something other than a call,
   the following error will be raised:
 
       iex> Macro.pipe(10, 20, 0)
       ** (ArgumentError) cannot pipe 10 into 20, the 2nd argument must be an AST.
 
-  It's also good to remind that even if the
-  expression is piped into the AST, it doesn't mean that
-  the AST is valid, and it might generate runtime issues,
+  Even if the expression is piped into the AST, it doesn't
+  necessarily mean that the AST is valid and it might generate runtime issues,
   for example:
 
       iex> ast = Macro.pipe(10, {:div, [], [2, 5]}, 0)
       {:div, [], [10, 2, 5]}
       iex> Code.eval_quoted(ast)
       ** (CompileError) nofile:1: undefined function div/3 (there is no such import)
+
   """
   @spec pipe(t(), t(), integer) :: t()
   def pipe(expr, call_args, position)
-
-  def pipe(expr, args, _integer) when not is_tuple(args) do
-    raise ArgumentError,
-          "cannot pipe #{to_string(expr)} into #{to_string(args)}, " <>
-            "the 2nd argument must be an AST."
-  end
 
   def pipe(expr, {:&, _, _} = call_args, _integer) do
     raise ArgumentError, bad_pipe(expr, call_args)

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -250,6 +250,12 @@ defmodule Macro do
   @spec pipe(t(), t(), integer) :: t()
   def pipe(expr, call_args, position)
 
+  def pipe(expr, args, _integer) when not is_tuple(args) do
+    raise ArgumentError,
+          "cannot pipe #{to_string(expr)} into #{to_string(args)}, " <>
+            "the 2nd argument must be an AST."
+  end
+
   def pipe(expr, {:&, _, _} = call_args, _integer) do
     raise ArgumentError, bad_pipe(expr, call_args)
   end

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -261,7 +261,7 @@ defmodule Macro do
   the following error will be raised:
 
       iex> Macro.pipe(10, 20, 0)
-      ** (ArgumentError) cannot pipe 10 into 20, the 2nd argument must be an AST.
+      ** (ArgumentError) cannot pipe 10 into 20, can only pipe into local calls foo(), remote calls Foo.bar() or anonymous function calls foo.()
 
   Even if the expression is piped into the AST, it doesn't
   necessarily mean that the AST is valid and it might generate runtime issues,


### PR DESCRIPTION
I was trying to deal with Macro.pipe and realized that maybe this could be a good/simple/minor improvement for now.

I hope it fits

This PR:
- [x] Add new docs with examples and cautions
- [x] Add new error when non AST (2nd argument) is passed
