### PR TITLE
Support disabling BEAM compression in mix releases

### DIFF
--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -856,12 +856,18 @@ defmodule Mix.Release do
   def strip_beam(binary, options \\ []) when is_list(options) do
     chunks_to_keep = options[:keep] |> List.wrap() |> Enum.map(&String.to_charlist/1)
     all_chunks = Enum.uniq(@significant_chunks ++ chunks_to_keep)
+    compress? = Keyword.get(options, :compress, true)
 
     case :beam_lib.chunks(binary, all_chunks, [:allow_missing_chunks]) do
       {:ok, {_, chunks}} ->
         chunks = for {name, chunk} <- chunks, is_binary(chunk), do: {name, chunk}
         {:ok, binary} = :beam_lib.build_module(chunks)
-        {:ok, :zlib.gzip(binary)}
+
+        if compress? do
+          {:ok, :zlib.gzip(binary)}
+        else
+          {:ok, binary}
+        end
 
       {:error, _, _} = error ->
         error

--- a/lib/mix/lib/mix/release.ex
+++ b/lib/mix/lib/mix/release.ex
@@ -856,7 +856,7 @@ defmodule Mix.Release do
   def strip_beam(binary, options \\ []) when is_list(options) do
     chunks_to_keep = options[:keep] |> List.wrap() |> Enum.map(&String.to_charlist/1)
     all_chunks = Enum.uniq(@significant_chunks ++ chunks_to_keep)
-    compress? = Keyword.get(options, :compress, true)
+    compress? = Keyword.get(options, :compress, false)
 
     case :beam_lib.chunks(binary, all_chunks, [:allow_missing_chunks]) do
       {:ok, {_, chunks}} ->

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -387,7 +387,9 @@ defmodule Mix.Tasks.Release do
     * `:strip_beams` - controls if BEAM files should have their debug information,
       documentation chunks, and other non-essential metadata removed. Defaults to
       `true`. May be set to `false` to disable stripping. Also accepts
-      `[keep: ["Docs", "Dbgi"]]` to keep certain chunks that are usually stripped.
+      `[keep: ["Docs", "Dbgi"], compress: false]` to keep certain chunks that are
+      usually stripped. The `:compress` option can disable compression on the
+      resulting BEAM files.
 
     * `:cookie` - a string representing the Erlang Distribution cookie. If this
       option is not set, a random cookie is written to the `releases/COOKIE` file

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -387,9 +387,10 @@ defmodule Mix.Tasks.Release do
     * `:strip_beams` - controls if BEAM files should have their debug information,
       documentation chunks, and other non-essential metadata removed. Defaults to
       `true`. May be set to `false` to disable stripping. Also accepts
-      `[keep: ["Docs", "Dbgi"], compress: false]` to keep certain chunks that are
-      usually stripped. The `:compress` option can disable compression on the
-      resulting BEAM files.
+     `[keep: ["Docs", "Dbgi"]]` to keep certain chunks that are usually stripped.
+     You can also set the `:compress` option to false to disable compression on
+     the resulting BEAM files. This can be useful if you are compressing the
+     release in other ways.
 
     * `:cookie` - a string representing the Erlang Distribution cookie. If this
       option is not set, a random cookie is written to the `releases/COOKIE` file

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -388,9 +388,9 @@ defmodule Mix.Tasks.Release do
       documentation chunks, and other non-essential metadata removed. Defaults to
       `true`. May be set to `false` to disable stripping. Also accepts
      `[keep: ["Docs", "Dbgi"]]` to keep certain chunks that are usually stripped.
-     You can also set the `:compress` option to false to disable compression on
-     the resulting BEAM files. This can be useful if you are compressing the
-     release in other ways.
+     You can also set the `:compress` option to true to enable individual
+     compression of BEAM files, although it is typically preferred to compress
+     the whole release instead.
 
     * `:cookie` - a string representing the Erlang Distribution cookie. If this
       option is not set, a random cookie is written to the `releases/COOKIE` file

--- a/lib/mix/test/mix/release_test.exs
+++ b/lib/mix/test/mix/release_test.exs
@@ -739,6 +739,15 @@ defmodule Mix.ReleaseTest do
       assert {:ok, {EEx, [{'Dbgi', _}]}} = :beam_lib.chunks(beam, ['Dbgi'])
       assert {:ok, {EEx, [{'Docs', _}]}} = :beam_lib.chunks(beam, ['Docs'])
     end
+
+    test "strip beams without compression" do
+      {:ok, beam} =
+        Path.join(@eex_ebin, "Elixir.EEx.beam")
+        |> File.read!()
+        |> strip_beam(compress: false)
+
+      assert match?(<<"FOR1", _::binary>>, beam)
+    end
   end
 
   describe "included applications" do


### PR DESCRIPTION
In releases, the final step for stripping chunks of out BEAM files is to
gzip compress the file. This change lets users pass `compress: false` to
turn this off. Somewhat unintuitively, turning compression off here
enables better compression at a later step. This is due to the archive
compressors being able to process all BEAM files rather than restarting
compression for each individual BEAM file.

For some Nerves devices, reducing the total number of bytes sent to
update software is much more important than reducing the on-disk usage.
This is due to their network connections being metered. Given enough
devices, even small size redunctions can result in meaningful savings.

Here are more details:

The default Nerves configuration puts all of the BEAM files in one
SquashFS archive. While Nerves also uses gzip for the SquashFS archive
and SquashFS (mostly) individually compresses files as well, letting
SquashFS perform the compression results in 2.5% file size reduction.
This is assumed to be due to using a higher compression level with
building the SquashFS archive. As a side benefit, moving gzip
compression to SquashFS removes the decompression steps from the BEAM
load and it resulted in a ~500ms boot time improvement on GRiSP 2
hardware for a small Nerves app. Presumably the Linux kernel's gzip
decompression is faster than Erlang's or removing the Erlang gunzip
calls completely added up.

When it's possible to compress all BEAM files together (for example,
when making tar files), not compressing BEAM files also helps. This is
because the BEAM files have a lot of similar strings that are now
visible to the archive compressor. It's also possible to use better
compression methods than gzip.

A similar use is the way that delta firmware updates are handled with
Nerves. Delta firmware updates are a way to send down the difference
between the firmware image on a device and the firmware image you want.
These are generated across the full image and should benefit from being
able to work off uncompressed .beam files.
