### PR TITLE
Add space before argument for documentation consistency

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4060,7 +4060,7 @@ defmodule Kernel do
   but the value is expected outside of the first argument, such as
   above. By replacing `some_fun` by its value, we get:
 
-      "Hello" |> then(&Regex.replace(~r/l/,&1, "L"))
+      "Hello" |> then(&Regex.replace(~r/l/, &1, "L"))
 
   """
   defmacro left |> right do


### PR DESCRIPTION
The space is not technically missing, so it's not a typo. I just added it for consistency with the common formatting of the documentation.

I'm sorry for this insignificant PR. I can remove it if it's not important.