### PR TITLE
Add Logger.put_process_level/2 and rewrite enable/1 and disable/1

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -527,6 +527,8 @@ defmodule Logger do
 
       delete_process_level(pid)
   """
+  # TODO: Deprecate me on v1.18
+  @doc deprecated: "Use Logger.delete_process_level(pid) instead"
   @spec enable(pid) :: :ok
   def enable(pid) when pid == self() do
     delete_process_level(pid)
@@ -542,6 +544,8 @@ defmodule Logger do
 
       put_process_level(pid, :none)
   """
+  # TODO: Deprecate me on v1.18
+  @doc deprecated: "Use Logger.put_process_level(pid, :none) instead"
   @spec disable(pid) :: :ok
   def disable(pid) when pid == self() do
     put_process_level(pid, :none)
@@ -553,7 +557,8 @@ defmodule Logger do
 
   Currently the only accepted PID is `self()`.
   """
-  @doc since: "1.10.0"
+  # TODO: Deprecate me on v1.18
+  @doc deprecated: "Use Logger.get_process_level(pid) instead"
   @spec enabled?(pid) :: boolean
   def enabled?(pid) when pid == self() do
     get_process_level(pid) != :none

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -19,6 +19,9 @@ defmodule Logger do
     * Integrates with Erlang's [`:logger`](`:logger`)
       to convert terms to Elixir syntax.
 
+    * Allows overriding the logging level for a specific module,
+      application or process.
+
   Logging is useful for tracking when an event of interest happens in your
   system. For example, it may be helpful to log whenever a user is deleted.
 
@@ -465,7 +468,7 @@ defmodule Logger do
   @type metadata :: keyword()
   @levels [:emergency, :alert, :critical, :error, :warning, :notice, :info, :debug]
 
-  @metadata :logger_enabled
+  @metadata :logger_level
   @compile {:inline, enabled?: 1}
 
   @doc """
@@ -519,10 +522,14 @@ defmodule Logger do
   Enables logging for the current process.
 
   Currently the only accepted PID is `self()`.
+
+  Equivalent of:
+
+      delete_process_level(pid)
   """
   @spec enable(pid) :: :ok
   def enable(pid) when pid == self() do
-    Process.delete(@metadata)
+    delete_process_level(pid)
     :ok
   end
 
@@ -530,10 +537,14 @@ defmodule Logger do
   Disables logging for the current process.
 
   Currently the only accepted PID is `self()`.
+
+  Equivalent of:
+
+      put_process_level(pid, :none)
   """
   @spec disable(pid) :: :ok
   def disable(pid) when pid == self() do
-    Process.put(@metadata, false)
+    put_process_level(pid, :none)
     :ok
   end
 
@@ -545,7 +556,7 @@ defmodule Logger do
   @doc since: "1.10.0"
   @spec enabled?(pid) :: boolean
   def enabled?(pid) when pid == self() do
-    Process.get(@metadata, true)
+    get_process_level(pid) != :none
   end
 
   @doc """
@@ -665,14 +676,14 @@ defmodule Logger do
   defdelegate get_module_level(mod), to: :logger
 
   @doc """
-  Deletes logging level for a given module to primary level.
+  Resets the logging level for a given module to the primary level.
   """
   @doc since: "1.11.0"
   @spec delete_module_level(module() | [module()]) :: :ok
   defdelegate delete_module_level(module), to: :logger, as: :unset_module_level
 
   @doc """
-  Deletes logging level for all modules to primary level.
+  Resets the logging level for all modules to the primary level.
   """
   @doc since: "1.11.0"
   @spec delete_all_module_levels() :: :ok
@@ -693,7 +704,7 @@ defmodule Logger do
   defdelegate put_application_level(appname, level), to: :logger, as: :set_application_level
 
   @doc """
-  Deletes logging level for all modules in given application to primary level.
+  Resets logging level for all modules in the given application to the primary level.
 
   Equivalent of:
 
@@ -703,6 +714,45 @@ defmodule Logger do
   @spec delete_application_level(application) :: :ok | {:error, {:not_loaded, application}}
         when application: atom()
   defdelegate delete_application_level(appname), to: :logger, as: :unset_application_level
+
+  @doc """
+  Puts logging level for the current process.
+
+  Currently the only accepted PID is `self()`.
+
+  This will take priority over the primary level set, so it can be
+  used to increase or decrease verbosity of some parts of the running system.
+  """
+  @spec put_process_level(pid(), level()) :: :ok
+  def put_process_level(pid, level) when pid == self() do
+    Process.put(@metadata, level)
+    :ok
+  end
+
+  @doc """
+  Gets logging level for the current process.
+
+  Currently the only accepted PID is `self()`.
+
+  The returned value will be the effective value used. If no value
+  was set for a given process, then it will not be present in
+  the returned list.
+  """
+  @spec get_process_level(pid) :: level() | :all | :none | nil
+  def get_process_level(pid) when pid == self() do
+    Process.get(@metadata, nil)
+  end
+
+  @doc """
+  Resets logging level for the current process to the primary level.
+
+  Currently the only accepted PID is `self()`.
+  """
+  @spec delete_process_level(pid()) :: :ok
+  def delete_process_level(pid) when pid == self() do
+    Process.delete(@metadata)
+    :ok
+  end
 
   @doc """
   Adds a new backend.
@@ -818,8 +868,17 @@ defmodule Logger do
   def __should_log__(level, module) do
     level = Logger.Handler.elixir_level_to_erlang_level(level)
 
-    if enabled?(self()) and :logger.allow(level, module) do
+    if process_allowed?(level, self()) and :logger.allow(level, module) do
       level
+    end
+  end
+
+  defp process_allowed?(level, pid) do
+    if process_level = get_process_level(pid) do
+      process_level = Logger.Handler.elixir_level_to_erlang_level(process_level)
+      :logger.compare_levels(level, process_level) != :lt
+    else
+      true
     end
   end
 

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -876,15 +876,6 @@ defmodule Logger do
     end
   end
 
-  @doc false
-  def process_allowed?(level, pid) do
-    if process_level = get_process_level(pid) do
-      :logger.compare_levels(level, process_level) != :lt
-    else
-      true
-    end
-  end
-
   defguardp is_msg(msg) when is_binary(msg) or is_list(msg) or is_map(msg)
 
   @doc false

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -728,7 +728,7 @@ defmodule Logger do
   """
   @spec put_process_level(pid(), level()) :: :ok
   def put_process_level(pid, level) when pid == self() do
-    Process.put(@metadata, level)
+    Process.put(@metadata, Logger.Handler.elixir_level_to_erlang_level(level))
     :ok
   end
 
@@ -871,14 +871,14 @@ defmodule Logger do
   def __should_log__(level, module) do
     level = Logger.Handler.elixir_level_to_erlang_level(level)
 
-    if process_allowed?(level, self()) and :logger.allow(level, module) do
+    if :logger.allow(level, module) do
       level
     end
   end
 
-  defp process_allowed?(level, pid) do
+  @doc false
+  def process_allowed?(level, pid) do
     if process_level = get_process_level(pid) do
-      process_level = Logger.Handler.elixir_level_to_erlang_level(process_level)
       :logger.compare_levels(level, process_level) != :lt
     else
       true

--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -532,7 +532,6 @@ defmodule Logger do
   @spec enable(pid) :: :ok
   def enable(pid) when pid == self() do
     delete_process_level(pid)
-    :ok
   end
 
   @doc """
@@ -549,7 +548,6 @@ defmodule Logger do
   @spec disable(pid) :: :ok
   def disable(pid) when pid == self() do
     put_process_level(pid, :none)
-    :ok
   end
 
   @doc """

--- a/lib/logger/lib/logger/app.ex
+++ b/lib/logger/lib/logger/app.ex
@@ -48,7 +48,7 @@ defmodule Logger.App do
   @doc false
   def stop(handlers) do
     _ = :logger.remove_handler(Logger)
-    _ = :logger.remove_primary_filter(:process_disabled)
+    _ = :logger.remove_primary_filter(:process_level)
     add_handlers(handlers)
 
     :logger.add_primary_filter(
@@ -114,7 +114,7 @@ defmodule Logger.App do
         :ok
     end
 
-    :ok = :logger.add_primary_filter(:process_disabled, {&Logger.Filter.process_disabled/2, []})
+    :ok = :logger.add_primary_filter(:process_level, {&Logger.Filter.process_level/2, []})
     :ok = :logger.add_handler(Logger, Logger.Handler, config)
     primary_config
   end

--- a/lib/logger/lib/logger/filter.ex
+++ b/lib/logger/lib/logger/filter.ex
@@ -15,10 +15,12 @@ defmodule Logger.Filter do
   Filter out logs if current process opted out of certain levels.
   """
   def process_level(%{level: level}, _extra) do
-    if Logger.process_allowed?(level, self()) do
-      :ignore
-    else
+    process_level = Logger.get_process_level(self())
+
+    if process_level != nil and :logger.compare_levels(level, process_level) == :lt do
       :stop
+    else
+      :ignore
     end
   end
 

--- a/lib/logger/lib/logger/filter.ex
+++ b/lib/logger/lib/logger/filter.ex
@@ -12,10 +12,10 @@ defmodule Logger.Filter do
   end
 
   @doc """
-  Filter out logs if current process opted out of log reports.
+  Filter out logs if current process opted out of certain levels.
   """
-  def process_disabled(_log, _extra) do
-    if Logger.enabled?(self()) do
+  def process_level(%{level: level}, _extra) do
+    if Logger.process_allowed?(level, self()) do
       :ignore
     else
       :stop

--- a/lib/logger/test/logger_test.exs
+++ b/lib/logger/test/logger_test.exs
@@ -246,6 +246,34 @@ defmodule LoggerTest do
     Logger.delete_all_module_levels()
   end
 
+  test "per-process levels" do
+    assert Logger.get_process_level(self()) == nil
+
+    assert capture_log(fn -> Logger.debug("debug_msg") end) =~ "debug_msg"
+
+    Logger.put_process_level(self(), :debug)
+    assert Logger.get_process_level(self()) == :debug
+
+    assert capture_log(fn -> Logger.debug("debug_msg") end) =~ "debug_msg"
+
+    Logger.put_process_level(self(), :error)
+
+    assert capture_log(fn -> Logger.debug("debug_msg") end) == ""
+    assert capture_log(fn -> Logger.error("error_msg") end) =~ "error_msg"
+
+    Logger.put_process_level(self(), :none)
+    assert Logger.get_process_level(self()) == :none
+
+    assert capture_log(fn -> Logger.debug("debug_msg") end) == ""
+    assert capture_log(fn -> Logger.error("error_msg") end) == ""
+
+    Logger.delete_process_level(self())
+    assert Logger.get_process_level(self()) == nil
+
+    assert capture_log(fn -> Logger.debug("debug_msg") end) =~ "debug_msg"
+    assert capture_log(fn -> Logger.error("error_msg") end) =~ "error_msg"
+  end
+
   test "process metadata" do
     assert Logger.metadata(data: true) == :ok
     assert Logger.metadata() == [data: true]


### PR DESCRIPTION
Add functions for controlling the logging level on a per-process basis. Currently only supports changing the logging level for the current process.

- Add `Logger.put_process_level/2`,
- Add `Logger.get_process_level/1`,
- Add `Logger.delete_process_level/1`,
- Rewrite `Logger.enable/1`, `Logger.enabled?/1` and `Logger.disable/1` to reuse the new functions.

[Original discussion on elixir-lang-core](https://groups.google.com/g/elixir-lang-core/c/tpoS68TV42s/m/h-6u6E79AwAJ).