### PR TITLE
Allow plus symbol in mix do as alternative to comma

### DIFF
--- a/lib/mix/lib/mix/tasks/do.ex
+++ b/lib/mix/lib/mix/tasks/do.ex
@@ -1,27 +1,27 @@
 defmodule Mix.Tasks.Do do
   use Mix.Task
 
-  @shortdoc "Executes the tasks separated by comma"
+  @shortdoc "Executes the tasks separated by plus"
 
   @moduledoc """
-  Executes the tasks separated by comma:
+  Executes the tasks separated by `+`:
 
-      mix do compile --list, deps
+      mix do compile --list + deps
 
-  The comma should be followed by a space.
+  The plus should be followed by at least one space before and after.
 
   ## Examples
 
   The example below prints the available compilers and
   then the list of dependencies.
 
-      mix do compile --list, deps
+      mix do compile --list + deps
 
   Note that the majority of Mix tasks are only executed once
   per invocation. So for example, the following command will
   only compile once:
 
-      mix do compile, some_other_command, compile
+      mix do compile + some_other_command + compile
 
   When `compile` is executed again, Mix will notice the task
   has already ran, and skip it.
@@ -31,12 +31,15 @@ defmodule Mix.Tasks.Do do
   desired application via the `--app` flag after `do` and
   before the first task:
 
-      mix do --app app1 --app app2 compile --list, deps
+      mix do --app app1 --app app2 compile --list + deps
 
-  On Windows terminals, the comma is a reserved special character.
-  You can use a `+` in place of the comma instead:
+  Elixir versions prior to v1.14 used the comma exclusively
+  to separate commands:
 
-      mix do compile --list + deps
+      mix do compile --list, deps
+
+  Since then, the `+` operator has been introduced as a
+  separator for better support on Windows terminals.
 
   ## Command line options
 
@@ -45,6 +48,8 @@ defmodule Mix.Tasks.Do do
       before any of the tasks.
 
   """
+
+  # TODO: Deprecate using comma on Elixir v1.18
 
   @impl true
   def run(args) do

--- a/lib/mix/lib/mix/tasks/do.ex
+++ b/lib/mix/lib/mix/tasks/do.ex
@@ -33,6 +33,12 @@ defmodule Mix.Tasks.Do do
 
       mix do --app app1 --app app2 compile --list, deps
 
+  On Windows in cmd and PowerShell the comma is a reserved
+  special character. You can use a + in place of the comma
+  instead:
+
+      mix do compile --list + deps
+
   ## Command line options
 
     * `--app` - limit recursive tasks to the given apps.
@@ -91,6 +97,17 @@ defmodule Mix.Tasks.Do do
        when binary_part(head, byte_size(head), -1) == "," do
     current =
       case binary_part(head, 0, byte_size(head) - 1) do
+        "" -> Enum.reverse(current)
+        part -> Enum.reverse([part | current])
+      end
+
+    gather_commands(rest, [], [current | acc])
+  end
+
+  defp gather_commands([head | rest], current, acc)
+       when binary_part(head, byte_size(head), -2) == " +" do
+    current =
+      case binary_part(head, 0, byte_size(head) - 2) do
         "" -> Enum.reverse(current)
         part -> Enum.reverse([part | current])
       end

--- a/lib/mix/lib/mix/tasks/do.ex
+++ b/lib/mix/lib/mix/tasks/do.ex
@@ -104,14 +104,7 @@ defmodule Mix.Tasks.Do do
     gather_commands(rest, [], [current | acc])
   end
 
-  defp gather_commands([head | rest], current, acc)
-       when binary_part(head, byte_size(head), -2) == " +" do
-    current =
-      case binary_part(head, 0, byte_size(head) - 2) do
-        "" -> Enum.reverse(current)
-        part -> Enum.reverse([part | current])
-      end
-
+  defp gather_commands(["+" | rest], current, acc) do
     gather_commands(rest, [], [current | acc])
   end
 

--- a/lib/mix/lib/mix/tasks/do.ex
+++ b/lib/mix/lib/mix/tasks/do.ex
@@ -33,9 +33,8 @@ defmodule Mix.Tasks.Do do
 
       mix do --app app1 --app app2 compile --list, deps
 
-  On Windows in cmd and PowerShell the comma is a reserved
-  special character. You can use a + in place of the comma
-  instead:
+  On Windows terminals, the comma is a reserved special character.
+  You can use a `+` in place of the comma instead:
 
       mix do compile --list + deps
 

--- a/lib/mix/test/mix/tasks/do_test.exs
+++ b/lib/mix/test/mix/tasks/do_test.exs
@@ -15,6 +15,7 @@ defmodule Mix.Tasks.DoTest do
     import Mix.Tasks.Do, only: [gather_commands: 1]
     assert gather_commands(["compile", "--list,", "help"]) == [["compile", "--list"], ["help"]]
     assert gather_commands(["help,", "compile", "--list"]) == [["help"], ["compile", "--list"]]
+    assert gather_commands(["help +", "compile", "--list"]) == [["help"], ["compile", "--list"]]
 
     assert gather_commands(["compile,", "run", "-e", "IO.puts :hello"]) ==
              [["compile"], ["run", "-e", "IO.puts :hello"]]

--- a/lib/mix/test/mix/tasks/do_test.exs
+++ b/lib/mix/test/mix/tasks/do_test.exs
@@ -15,7 +15,9 @@ defmodule Mix.Tasks.DoTest do
     import Mix.Tasks.Do, only: [gather_commands: 1]
     assert gather_commands(["compile", "--list,", "help"]) == [["compile", "--list"], ["help"]]
     assert gather_commands(["help,", "compile", "--list"]) == [["help"], ["compile", "--list"]]
-    assert gather_commands(["help +", "compile", "--list"]) == [["help"], ["compile", "--list"]]
+
+    assert gather_commands(["help", "+", "compile", "--list"]) ==
+             [["help"], ["compile", "--list"]]
 
     assert gather_commands(["compile,", "run", "-e", "IO.puts :hello"]) ==
              [["compile"], ["run", "-e", "IO.puts :hello"]]


### PR DESCRIPTION
I use this language every day for work so I wanted to jump in and contribute. This pull request should close #11682 where PowerShell and cmd would have a hard time handling the comma symbol in `mix do`. Based on the feedback on the issue it was requested to make the plus symbol an alternative. So now instead of doing

```elixir
mix do deps.get, compile
```

you can now also do

```elixir
mix do deps.get + compile
```

I updated the documentation with an example on how that would work.