### PR TITLE
Fix bug when formatting :"\\"

### DIFF
--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -1497,10 +1497,10 @@ defmodule Code.Formatter do
   end
 
   defp atom_to_algebra(:\\, meta) do
+    # Since we parse strings without unescaping, the atoms
+    # :\\ and :"\\" have the same representation, so we need
+    # to check the delimiter and handle them accordingly.
     string =
-      # Since we parse strings without unescaping, the atoms
-      # :\\ and :"\\" have the same representation, so we need
-      # to check the delimiter and handle them accordingly.
       case Keyword.get(meta, :delimiter) do
         "\"" -> ":\"\\\\\""
         _ -> ":\\\\"

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -379,8 +379,8 @@ defmodule Code.Formatter do
     end
   end
 
-  defp quoted_to_algebra({:__block__, _, [atom]}, _context, state) when is_atom(atom) do
-    {atom_to_algebra(atom), state}
+  defp quoted_to_algebra({:__block__, meta, [atom]}, _context, state) when is_atom(atom) do
+    {atom_to_algebra(atom, meta), state}
   end
 
   defp quoted_to_algebra({:__block__, meta, [integer]}, _context, state)
@@ -1487,16 +1487,29 @@ defmodule Code.Formatter do
     end
   end
 
-  defp atom_to_algebra(atom) when atom in [nil, true, false] do
+  defp atom_to_algebra(atom, _) when atom in [nil, true, false] do
     Atom.to_string(atom)
   end
 
   # TODO: Remove this clause in v1.16 when we no longer quote operator :..//
-  defp atom_to_algebra(:"..//") do
+  defp atom_to_algebra(:"..//", _) do
     string(":\"..//\"")
   end
 
-  defp atom_to_algebra(atom) do
+  defp atom_to_algebra(:\\, meta) do
+    string =
+      case Keyword.get(meta, :delimiter) do
+        "\"" ->
+          ":\"\\\\\""
+
+        _ ->
+          ":\\\\"
+      end
+
+    string(string)
+  end
+
+  defp atom_to_algebra(atom, _) do
     string = Atom.to_string(atom)
 
     iodata =

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -1498,12 +1498,12 @@ defmodule Code.Formatter do
 
   defp atom_to_algebra(:\\, meta) do
     string =
+      # Since we parse strings without unescaping, the atoms
+      # :\\ and :"\\" have the same representation, so we need
+      # to check the delimiter and handle them accordingly.
       case Keyword.get(meta, :delimiter) do
-        "\"" ->
-          ":\"\\\\\""
-
-        _ ->
-          ":\\\\"
+        "\"" -> ":\"\\\\\""
+        _ -> ":\\\\"
       end
 
     string(string)

--- a/lib/elixir/test/elixir/code_formatter/literals_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/literals_test.exs
@@ -85,6 +85,7 @@ defmodule Code.Formatter.LiteralsTest do
 
     test "without escapes" do
       assert_same ~S[:foo]
+      assert_same ~S[:\\]
     end
 
     test "with escapes" do
@@ -92,6 +93,7 @@ defmodule Code.Formatter.LiteralsTest do
       assert_format ~S[:'f\a\b\ro'], ~S[:"f\a\b\ro"]
       assert_format ~S[:'single \' quote'], ~S[:"single ' quote"]
       assert_format ~S[:"double \" quote"], ~S[:"double \" quote"]
+      assert_same ~S[:"\\"]
     end
 
     test "with unicode" do


### PR DESCRIPTION
Formatting `:"\\"` preserves the quotes and doesn't transform it as `:\\`, which is a different atom.

Closes #11698