### PR TITLE
Add line in diagnostic for invalid struct key

### DIFF
--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -770,7 +770,8 @@ defmodule Kernel.ParallelCompiler do
     end
   end
 
-  defp get_line(file, _reason, [{_, _, _, [file: 'expanding macro']}, {_, _, _, info} | _]) do
+  defp get_line(file, _reason, [{_, _, _, [file: expanding]}, {_, _, _, info} | _])
+       when expanding in ['expanding macro', 'expanding struct'] do
     if Keyword.get(info, :file) == to_charlist(Path.relative_to_cwd(file)) do
       Keyword.get(info, :line)
     end

--- a/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
+++ b/lib/elixir/test/elixir/kernel/parallel_compiler_test.exs
@@ -154,6 +154,29 @@ defmodule Kernel.ParallelCompilerTest do
              end) =~ expected_msg
     end
 
+    test "returns error when fails to expand struct" do
+      [fixture] =
+        write_tmp(
+          "compile_struct_invalid_key",
+          undef: """
+          defmodule InvalidStructKey do
+            def invalid_struct_key() do
+              %Date{invalid_key: 2020}
+            end
+          end
+          """
+        )
+
+      expected_msg = "** (KeyError) key :invalid_key not found"
+
+      assert capture_io(fn ->
+               assert {:error, [{^fixture, 3, msg}], []} =
+                        Kernel.ParallelCompiler.compile([fixture])
+
+               assert msg =~ expected_msg
+             end) =~ expected_msg
+    end
+
     test "does not hang on missing dependencies" do
       [fixture] =
         write_tmp(


### PR DESCRIPTION
Populates the `position` field in `Mix.Task.Compiler.Diagnostic` when fails to expand a struct (invalid key).

Closes #11700