### PR TITLE
Fix use of assert_receive[d] in catch_exit doc

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -857,7 +857,7 @@ defmodule ExUnit.Assertions do
       assert catch_exit(exit(1)) == 1
 
   To assert exits from linked processes started from the test, trap exits
-  with `Process.flag/2` and assert the exit message with `assert_received/2`.
+  with `Process.flag/2` and assert the exit message with `assert_receive/2`.
 
       Process.flag(:trap_exit, true)
       pid = spawn_link(fn -> Process.exit(self(), :normal) end)


### PR DESCRIPTION
The `catch_exit` doc contains a code example that uses `assert_receive`, while the description above recommends `assert_received`.

Fix the typo in the doc. `assert_receive` would be correct here, as we don't know when the exit message from the spawned process will be delivered to the test process.