### PR TITLE
Support ISO8601 basic format parsing with `DateTime.from_iso8601`

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1084,6 +1084,16 @@ defmodule DateTime do
       Calendar.ISO.time_to_string(hour, minute, second, microsecond, format)
   end
 
+  def from_iso8601(string, format_or_calendar)
+
+  def from_iso8601(string, format) when format in [:basic, :extended] do
+    from_iso8601(string, Calendar.ISO, format)
+  end
+
+  def from_iso8601(string, calendar) when is_atom(calendar) do
+    from_iso8601(string, calendar, :extended)
+  end
+
   @doc """
   Parses the extended "Date and time of day" format described by
   [ISO 8601:2019](https://en.wikipedia.org/wiki/ISO_8601).
@@ -1119,6 +1129,10 @@ defmodule DateTime do
       iex> {:ok, datetime, 9000} = DateTime.from_iso8601("-2015-01-23T23:50:07,123+02:30")
       iex> datetime
       ~U[-2015-01-23 21:20:07.123Z]
+
+      iex> {:ok, datetime, 9000} = DateTime.from_iso8601("20150123T235007.123+0230", :basic)
+      iex> datetime
+      ~U[2015-01-23 21:20:07.123Z]
 
       iex> {:ok, datetime, 9000} = DateTime.from_iso8601("20150123T235007.123+0230", Calendar.ISO, :basic)
       iex> datetime

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1120,6 +1120,10 @@ defmodule DateTime do
       iex> datetime
       ~U[-2015-01-23 21:20:07.123Z]
 
+      iex> {:ok, datetime, 9000} = DateTime.from_iso8601("20150123T235007.123+0230", Calendar.ISO, :basic)
+      iex> datetime
+      ~U[2015-01-23 21:20:07.123Z]
+
       iex> DateTime.from_iso8601("2015-01-23P23:50:07")
       {:error, :invalid_format}
       iex> DateTime.from_iso8601("2015-01-23T23:50:07")
@@ -1133,11 +1137,11 @@ defmodule DateTime do
 
   """
   @doc since: "1.4.0"
-  @spec from_iso8601(String.t(), Calendar.calendar()) ::
+  @spec from_iso8601(String.t(), Calendar.calendar(), :extended | :basic) ::
           {:ok, t, Calendar.utc_offset()} | {:error, atom}
-  def from_iso8601(string, calendar \\ Calendar.ISO) do
+  def from_iso8601(string, calendar \\ Calendar.ISO, format \\ :extended) do
     with {:ok, {year, month, day, hour, minute, second, microsecond}, offset} <-
-           Calendar.ISO.parse_utc_datetime(string) do
+           Calendar.ISO.parse_utc_datetime(string, format) do
       datetime = %DateTime{
         year: year,
         month: month,

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1084,16 +1084,6 @@ defmodule DateTime do
       Calendar.ISO.time_to_string(hour, minute, second, microsecond, format)
   end
 
-  def from_iso8601(string, format_or_calendar)
-
-  def from_iso8601(string, format) when format in [:basic, :extended] do
-    from_iso8601(string, Calendar.ISO, format)
-  end
-
-  def from_iso8601(string, calendar) when is_atom(calendar) do
-    from_iso8601(string, calendar, :extended)
-  end
-
   @doc """
   Parses the extended "Date and time of day" format described by
   [ISO 8601:2019](https://en.wikipedia.org/wiki/ISO_8601).
@@ -1134,10 +1124,6 @@ defmodule DateTime do
       iex> datetime
       ~U[2015-01-23 21:20:07.123Z]
 
-      iex> {:ok, datetime, 9000} = DateTime.from_iso8601("20150123T235007.123+0230", Calendar.ISO, :basic)
-      iex> datetime
-      ~U[2015-01-23 21:20:07.123Z]
-
       iex> DateTime.from_iso8601("2015-01-23P23:50:07")
       {:error, :invalid_format}
       iex> DateTime.from_iso8601("2015-01-23T23:50:07")
@@ -1153,7 +1139,33 @@ defmodule DateTime do
   @doc since: "1.4.0"
   @spec from_iso8601(String.t(), Calendar.calendar(), :extended | :basic) ::
           {:ok, t, Calendar.utc_offset()} | {:error, atom}
-  def from_iso8601(string, calendar \\ Calendar.ISO, format \\ :extended) do
+
+  def from_iso8601(string, format_or_calendar \\ Calendar.ISO)
+
+  def from_iso8601(string, format) when format in [:basic, :extended] do
+    from_iso8601(string, Calendar.ISO, format)
+  end
+
+  def from_iso8601(string, calendar) when is_atom(calendar) do
+    from_iso8601(string, calendar, :extended)
+  end
+
+  @doc """
+  Converts to ISO8601 specifying both a calendar and a mode.
+
+  See `from_iso8601/2` for more information.
+
+  ## Examples
+
+      iex> {:ok, datetime, 9000} = DateTime.from_iso8601("2015-01-23T23:50:07,123+02:30", Calendar.ISO, :extended)
+      iex> datetime
+      ~U[2015-01-23 21:20:07.123Z]
+
+      iex> {:ok, datetime, 9000} = DateTime.from_iso8601("20150123T235007.123+0230", Calendar.ISO, :basic)
+      iex> datetime
+      ~U[2015-01-23 21:20:07.123Z]
+  """
+  def from_iso8601(string, calendar, format) do
     with {:ok, {year, month, day, hour, minute, second, microsecond}, offset} <-
            Calendar.ISO.parse_utc_datetime(string, format) do
       datetime = %DateTime{

--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -288,127 +288,31 @@ defmodule DateTimeTest do
   end
 
   test "from_iso8601/3 with basic format handles positive and negative offsets" do
-    assert DateTime.from_iso8601("20150124T095007-1000", Calendar.ISO, :basic) |> elem(1) ==
-             %DateTime{
-               microsecond: {0, 0},
-               month: 1,
-               std_offset: 0,
-               time_zone: "Etc/UTC",
-               utc_offset: 0,
-               year: 2015,
-               zone_abbr: "UTC",
-               day: 24,
-               hour: 19,
-               minute: 50,
-               second: 7
-             }
+    assert DateTime.from_iso8601("20150124T095007-1000", Calendar.ISO, :basic) ==
+             DateTime.from_iso8601("2015-01-24T09:50:07-10:00", Calendar.ISO)
 
-    assert DateTime.from_iso8601("20150124T095007+1000", Calendar.ISO, :basic) |> elem(1) ==
-             %DateTime{
-               microsecond: {0, 0},
-               month: 1,
-               std_offset: 0,
-               time_zone: "Etc/UTC",
-               utc_offset: 0,
-               year: 2015,
-               zone_abbr: "UTC",
-               day: 23,
-               hour: 23,
-               minute: 50,
-               second: 7
-             }
+    assert DateTime.from_iso8601("20150124T095007+1000", Calendar.ISO, :basic) ==
+             DateTime.from_iso8601("2015-01-24T09:50:07+10:00", Calendar.ISO)
 
-    assert DateTime.from_iso8601("00000101T012207+1030", Calendar.ISO, :basic) |> elem(1) ==
-             %DateTime{
-               microsecond: {0, 0},
-               month: 12,
-               std_offset: 0,
-               time_zone: "Etc/UTC",
-               utc_offset: 0,
-               year: -1,
-               zone_abbr: "UTC",
-               day: 31,
-               hour: 14,
-               minute: 52,
-               second: 7
-             }
+    assert DateTime.from_iso8601("00000101T012207+1030", Calendar.ISO, :basic) ==
+             DateTime.from_iso8601("0000-01-01T01:22:07+10:30", Calendar.ISO)
   end
 
   test "from_iso8601/3 with basic format handles negative dates" do
-    assert DateTime.from_iso8601("-20150124T095007-1000", Calendar.ISO, :basic) |> elem(1) ==
-             %DateTime{
-               microsecond: {0, 0},
-               month: 1,
-               std_offset: 0,
-               time_zone: "Etc/UTC",
-               utc_offset: 0,
-               year: -2015,
-               zone_abbr: "UTC",
-               day: 24,
-               hour: 19,
-               minute: 50,
-               second: 7
-             }
+    assert DateTime.from_iso8601("-20150124T095007-1000", Calendar.ISO, :basic) ==
+             DateTime.from_iso8601("-2015-01-24T09:50:07-10:00", Calendar.ISO)
 
-    assert DateTime.from_iso8601("-20150124T095007+1000", Calendar.ISO, :basic) |> elem(1) ==
-             %DateTime{
-               microsecond: {0, 0},
-               month: 1,
-               std_offset: 0,
-               time_zone: "Etc/UTC",
-               utc_offset: 0,
-               year: -2015,
-               zone_abbr: "UTC",
-               day: 23,
-               hour: 23,
-               minute: 50,
-               second: 7
-             }
+    assert DateTime.from_iso8601("-20150124T095007+1000", Calendar.ISO, :basic) ==
+             DateTime.from_iso8601("-2015-01-24T09:50:07+10:00", Calendar.ISO)
 
-    assert DateTime.from_iso8601("-00010101T012207+1030", Calendar.ISO, :basic) |> elem(1) ==
-             %DateTime{
-               microsecond: {0, 0},
-               month: 12,
-               std_offset: 0,
-               time_zone: "Etc/UTC",
-               utc_offset: 0,
-               year: -2,
-               zone_abbr: "UTC",
-               day: 31,
-               hour: 14,
-               minute: 52,
-               second: 7
-             }
+    assert DateTime.from_iso8601("-00010101T012207+1030", Calendar.ISO, :basic) ==
+             DateTime.from_iso8601("-0001-01-01T01:22:07+10:30", Calendar.ISO)
 
-    assert DateTime.from_iso8601("-00010101T012207-1030", Calendar.ISO, :basic) |> elem(1) ==
-             %DateTime{
-               microsecond: {0, 0},
-               month: 1,
-               std_offset: 0,
-               time_zone: "Etc/UTC",
-               utc_offset: 0,
-               year: -1,
-               zone_abbr: "UTC",
-               day: 1,
-               hour: 11,
-               minute: 52,
-               second: 7
-             }
+    assert DateTime.from_iso8601("-00010101T012207-1030", Calendar.ISO, :basic) ==
+             DateTime.from_iso8601("-0001-01-01T01:22:07-10:30", Calendar.ISO)
 
-    assert DateTime.from_iso8601("-00011231T232207-1030", Calendar.ISO, :basic) |> elem(1) ==
-             %DateTime{
-               microsecond: {0, 0},
-               month: 1,
-               std_offset: 0,
-               time_zone: "Etc/UTC",
-               utc_offset: 0,
-               year: 0,
-               zone_abbr: "UTC",
-               day: 1,
-               hour: 9,
-               minute: 52,
-               second: 7
-             }
+    assert DateTime.from_iso8601("-00011231T232207-1030", Calendar.ISO, :basic) ==
+             DateTime.from_iso8601("-0001-12-31T23:22:07-10:30", Calendar.ISO)
   end
 
   test "from_iso8601 handles invalid date, time, formats correctly" do
@@ -776,69 +680,17 @@ defmodule DateTimeTest do
   end
 
   test "from_iso8601/3 with basic format with tz offsets" do
-    assert DateTime.from_iso8601("20170602T140000+0100", Calendar.ISO, :basic)
-           |> elem(1) ==
-             %DateTime{
-               year: 2017,
-               month: 6,
-               day: 2,
-               zone_abbr: "UTC",
-               hour: 13,
-               minute: 0,
-               second: 0,
-               microsecond: {0, 0},
-               utc_offset: 0,
-               std_offset: 0,
-               time_zone: "Etc/UTC"
-             }
+    assert DateTime.from_iso8601("20170602T140000+0100", Calendar.ISO, :basic) ==
+             DateTime.from_iso8601("2017-06-02T14:00:00+01:00", Calendar.ISO)
 
-    assert DateTime.from_iso8601("20170602T140000-0400", Calendar.ISO, :basic)
-           |> elem(1) ==
-             %DateTime{
-               year: 2017,
-               month: 6,
-               day: 2,
-               zone_abbr: "UTC",
-               hour: 18,
-               minute: 0,
-               second: 0,
-               microsecond: {0, 0},
-               utc_offset: 0,
-               std_offset: 0,
-               time_zone: "Etc/UTC"
-             }
+    assert DateTime.from_iso8601("20170602T140000-0400", Calendar.ISO, :basic) ==
+             DateTime.from_iso8601("2017-06-02T14:00:00-04:00")
 
-    assert DateTime.from_iso8601("20170602T140000+01", Calendar.ISO, :basic)
-           |> elem(1) ==
-             %DateTime{
-               year: 2017,
-               month: 6,
-               day: 2,
-               zone_abbr: "UTC",
-               hour: 13,
-               minute: 0,
-               second: 0,
-               microsecond: {0, 0},
-               utc_offset: 0,
-               std_offset: 0,
-               time_zone: "Etc/UTC"
-             }
+    assert DateTime.from_iso8601("20170602T140000+01", Calendar.ISO, :basic) ==
+             DateTime.from_iso8601("2017-06-02T14:00:00+01")
 
-    assert DateTime.from_iso8601("20170602T140000-04", Calendar.ISO, :basic)
-           |> elem(1) ==
-             %DateTime{
-               year: 2017,
-               month: 6,
-               day: 2,
-               zone_abbr: "UTC",
-               hour: 18,
-               minute: 0,
-               second: 0,
-               microsecond: {0, 0},
-               utc_offset: 0,
-               std_offset: 0,
-               time_zone: "Etc/UTC"
-             }
+    assert DateTime.from_iso8601("20170602T140000-04", Calendar.ISO, :basic) ==
+             DateTime.from_iso8601("2017-06-02T14:00:00-04")
   end
 
   test "truncate/2" do

--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -287,12 +287,151 @@ defmodule DateTimeTest do
              }
   end
 
+  test "from_iso8601/3 with basic format handles positive and negative offsets" do
+    assert DateTime.from_iso8601("20150124T095007-1000", Calendar.ISO, :basic) |> elem(1) ==
+             %DateTime{
+               microsecond: {0, 0},
+               month: 1,
+               std_offset: 0,
+               time_zone: "Etc/UTC",
+               utc_offset: 0,
+               year: 2015,
+               zone_abbr: "UTC",
+               day: 24,
+               hour: 19,
+               minute: 50,
+               second: 7
+             }
+
+    assert DateTime.from_iso8601("20150124T095007+1000", Calendar.ISO, :basic) |> elem(1) ==
+             %DateTime{
+               microsecond: {0, 0},
+               month: 1,
+               std_offset: 0,
+               time_zone: "Etc/UTC",
+               utc_offset: 0,
+               year: 2015,
+               zone_abbr: "UTC",
+               day: 23,
+               hour: 23,
+               minute: 50,
+               second: 7
+             }
+
+    assert DateTime.from_iso8601("00000101T012207+1030", Calendar.ISO, :basic) |> elem(1) ==
+             %DateTime{
+               microsecond: {0, 0},
+               month: 12,
+               std_offset: 0,
+               time_zone: "Etc/UTC",
+               utc_offset: 0,
+               year: -1,
+               zone_abbr: "UTC",
+               day: 31,
+               hour: 14,
+               minute: 52,
+               second: 7
+             }
+  end
+
+  test "from_iso8601/3 with basic format handles negative dates" do
+    assert DateTime.from_iso8601("-20150124T095007-1000", Calendar.ISO, :basic) |> elem(1) ==
+             %DateTime{
+               microsecond: {0, 0},
+               month: 1,
+               std_offset: 0,
+               time_zone: "Etc/UTC",
+               utc_offset: 0,
+               year: -2015,
+               zone_abbr: "UTC",
+               day: 24,
+               hour: 19,
+               minute: 50,
+               second: 7
+             }
+
+    assert DateTime.from_iso8601("-20150124T095007+1000", Calendar.ISO, :basic) |> elem(1) ==
+             %DateTime{
+               microsecond: {0, 0},
+               month: 1,
+               std_offset: 0,
+               time_zone: "Etc/UTC",
+               utc_offset: 0,
+               year: -2015,
+               zone_abbr: "UTC",
+               day: 23,
+               hour: 23,
+               minute: 50,
+               second: 7
+             }
+
+    assert DateTime.from_iso8601("-00010101T012207+1030", Calendar.ISO, :basic) |> elem(1) ==
+             %DateTime{
+               microsecond: {0, 0},
+               month: 12,
+               std_offset: 0,
+               time_zone: "Etc/UTC",
+               utc_offset: 0,
+               year: -2,
+               zone_abbr: "UTC",
+               day: 31,
+               hour: 14,
+               minute: 52,
+               second: 7
+             }
+
+    assert DateTime.from_iso8601("-00010101T012207-1030", Calendar.ISO, :basic) |> elem(1) ==
+             %DateTime{
+               microsecond: {0, 0},
+               month: 1,
+               std_offset: 0,
+               time_zone: "Etc/UTC",
+               utc_offset: 0,
+               year: -1,
+               zone_abbr: "UTC",
+               day: 1,
+               hour: 11,
+               minute: 52,
+               second: 7
+             }
+
+    assert DateTime.from_iso8601("-00011231T232207-1030", Calendar.ISO, :basic) |> elem(1) ==
+             %DateTime{
+               microsecond: {0, 0},
+               month: 1,
+               std_offset: 0,
+               time_zone: "Etc/UTC",
+               utc_offset: 0,
+               year: 0,
+               zone_abbr: "UTC",
+               day: 1,
+               hour: 9,
+               minute: 52,
+               second: 7
+             }
+  end
+
   test "from_iso8601 handles invalid date, time, formats correctly" do
     assert DateTime.from_iso8601("2015-01-23T23:50:07") == {:error, :missing_offset}
     assert DateTime.from_iso8601("2015-01-23 23:50:61") == {:error, :invalid_time}
     assert DateTime.from_iso8601("2015-01-32 23:50:07") == {:error, :invalid_date}
     assert DateTime.from_iso8601("2015-01-23 23:50:07A") == {:error, :invalid_format}
     assert DateTime.from_iso8601("2015-01-23T23:50:07.123-00:60") == {:error, :invalid_format}
+
+    assert DateTime.from_iso8601("20150123T235007", Calendar.ISO, :basic) ==
+             {:error, :missing_offset}
+
+    assert DateTime.from_iso8601("20150123 235061", Calendar.ISO, :basic) ==
+             {:error, :invalid_time}
+
+    assert DateTime.from_iso8601("20150132 235007", Calendar.ISO, :basic) ==
+             {:error, :invalid_date}
+
+    assert DateTime.from_iso8601("20150123 235007A", Calendar.ISO, :basic) ==
+             {:error, :invalid_format}
+
+    assert DateTime.from_iso8601("20150123T235007.123-0060", Calendar.ISO, :basic) ==
+             {:error, :invalid_format}
   end
 
   test "from_unix/2" do
@@ -620,6 +759,72 @@ defmodule DateTimeTest do
              }
 
     assert DateTime.from_iso8601("2017-06-02T14:00:00-04")
+           |> elem(1) ==
+             %DateTime{
+               year: 2017,
+               month: 6,
+               day: 2,
+               zone_abbr: "UTC",
+               hour: 18,
+               minute: 0,
+               second: 0,
+               microsecond: {0, 0},
+               utc_offset: 0,
+               std_offset: 0,
+               time_zone: "Etc/UTC"
+             }
+  end
+
+  test "from_iso8601/3 with basic format with tz offsets" do
+    assert DateTime.from_iso8601("20170602T140000+0100", Calendar.ISO, :basic)
+           |> elem(1) ==
+             %DateTime{
+               year: 2017,
+               month: 6,
+               day: 2,
+               zone_abbr: "UTC",
+               hour: 13,
+               minute: 0,
+               second: 0,
+               microsecond: {0, 0},
+               utc_offset: 0,
+               std_offset: 0,
+               time_zone: "Etc/UTC"
+             }
+
+    assert DateTime.from_iso8601("20170602T140000-0400", Calendar.ISO, :basic)
+           |> elem(1) ==
+             %DateTime{
+               year: 2017,
+               month: 6,
+               day: 2,
+               zone_abbr: "UTC",
+               hour: 18,
+               minute: 0,
+               second: 0,
+               microsecond: {0, 0},
+               utc_offset: 0,
+               std_offset: 0,
+               time_zone: "Etc/UTC"
+             }
+
+    assert DateTime.from_iso8601("20170602T140000+01", Calendar.ISO, :basic)
+           |> elem(1) ==
+             %DateTime{
+               year: 2017,
+               month: 6,
+               day: 2,
+               zone_abbr: "UTC",
+               hour: 13,
+               minute: 0,
+               second: 0,
+               microsecond: {0, 0},
+               utc_offset: 0,
+               std_offset: 0,
+               time_zone: "Etc/UTC"
+             }
+
+    assert DateTime.from_iso8601("20170602T140000-04", Calendar.ISO, :basic)
            |> elem(1) ==
              %DateTime{
                year: 2017,

--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -315,6 +315,11 @@ defmodule DateTimeTest do
              DateTime.from_iso8601("-0001-12-31T23:22:07-10:30", Calendar.ISO)
   end
 
+  test "from_iso8601/2 handles either a calendar or a format as the second parameter" do
+    assert DateTime.from_iso8601("20150124T095007-1000", :basic) ==
+             DateTime.from_iso8601("2015-01-24T09:50:07-10:00", Calendar.ISO)
+  end
+
   test "from_iso8601 handles invalid date, time, formats correctly" do
     assert DateTime.from_iso8601("2015-01-23T23:50:07") == {:error, :missing_offset}
     assert DateTime.from_iso8601("2015-01-23 23:50:61") == {:error, :invalid_time}
@@ -332,6 +337,9 @@ defmodule DateTimeTest do
              {:error, :invalid_date}
 
     assert DateTime.from_iso8601("20150123 235007A", Calendar.ISO, :basic) ==
+             {:error, :invalid_format}
+
+    assert DateTime.from_iso8601("2015-01-24T09:50:07-10:00", Calendar.ISO, :basic) ==
              {:error, :invalid_format}
 
     assert DateTime.from_iso8601("20150123T235007.123-0060", Calendar.ISO, :basic) ==


### PR DESCRIPTION
Allows parsing dates with ISO8601 basic format using `DateTime.from_iso8601`.