### PR TITLE
Add more reasons to fallback to inet or inet6 for mix

### DIFF
--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -662,7 +662,8 @@ defmodule Mix.Utils do
     try do
       case httpc_request(request, http_options) do
         {:error, {:failed_connect, [{:to_address, _}, {inet, _, reason}]}}
-        when inet in [:inet, :inet6] and reason in [:ehostunreach, :enetunreach] ->
+        when inet in [:inet, :inet6] and
+               reason in [:ehostunreach, :enetunreach, :eprotonosupport, :nxdomain] ->
           :httpc.set_options([ipfamily: fallback(inet)], :mix)
           request |> httpc_request(http_options) |> httpc_response()
 


### PR DESCRIPTION
Running `mix local.hex` results in the following error on an IPv6-only freebsd 13.0 jail:

```
$ mix local.hex --force
** (Mix) httpc request failed with: {:failed_connect, [{:to_address, {'repo.hex.pm', 443}}, {:inet, [:inet], :eprotonosupport}]}
```

```
$ iex
Erlang/OTP 24 [erts-12.1.5] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit] [dtrace] [sharing-preserving]

Interactive Elixir (1.13.1) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> :gen_tcp.connect 'repo.hex.pm', 80, [{:active, false}]
{:error, :eprotonosupport}
iex(2)> :gen_tcp.connect 'repo.hex.pm', 80, [{:active, false}, :inet6]
{:ok, #Port<0.10>}
iex(3)> :gen_tcp.connect 'repo.hex.pm', 443, [{:active, false}]
{:error, :eprotonosupport}
iex(4)> :gen_tcp.connect 'repo.hex.pm', 443, [{:active, false}, :inet6]
{:ok, #Port<0.15>}
```

Additionally, `:nxdomain` appears when using an IPv6-only proxy as shown in https://github.com/elixir-lang/elixir/issues/10423#issuecomment-805891724.