### PR TITLE
Improve docs for then and tap

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1176,7 +1176,7 @@ defmodule Kernel do
 
   @doc """
   Pipes the first argument, `value`, into the second argument, a function `fun`,
-  and returns the given first argument, `value`, itself.
+  and returns `value` itself.
 
   Useful for running synchronous side effects in a pipeline, using the `|>/2` operator.
 
@@ -2544,7 +2544,7 @@ defmodule Kernel do
 
   @doc """
   Pipes the first argument, `value`, into the second argument, a function `fun`,
-  and returns the result of the given function `fun`.
+  and returns the result of calling `fun`.
 
   In other words, it invokes the function `fun` with `value` as argument,
   and returns its result.

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4010,7 +4010,7 @@ defmodule Kernel do
 
   The example above is the same as calling `List.flatten([1, [2], 3])`.
 
-  The `|>` operator is mostly useful when there is a desire to execute a series
+  The `|>/2` operator is mostly useful when there is a desire to execute a series
   of operations resembling a pipeline:
 
       iex> [1, [2], 3] |> List.flatten() |> Enum.map(fn x -> x * 2 end)

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1175,17 +1175,18 @@ defmodule Kernel do
   end
 
   @doc """
-  Pipes `value` to the given `fun` and returns the `value` itself.
+  Pipes the first argument, `value`, into the second argument, a function `fun`,
+  and returns the given first argument, `value`, itself.
 
-  Useful for running synchronous side effects in a pipeline.
+  Useful for running synchronous side effects in a pipeline, using the `|>/2` operator.
 
   ## Examples
 
       iex> tap(1, fn x -> x + 1 end)
       1
 
-  Most commonly, this is used in pipelines. For example,
-  let's suppose you want to inspect part of a data structure.
+  Most commonly, this is used in pipelines, using the `|>/2` operator.
+  For example, let's suppose you want to inspect part of a data structure.
   You could write:
 
       %{a: 1}
@@ -2542,10 +2543,13 @@ defmodule Kernel do
   end
 
   @doc """
-  Pipes `value` into the given `fun`.
+  Pipes the first argument, `value`, into the second argument, a function `fun`,
+  and returns the result of the given function `fun`.
 
-  In other words, it invokes `fun` with `value` as argument.
-  This is most commonly used in pipelines, allowing you
+  In other words, it invokes the function `fun` with `value` as argument,
+  and returns its result.
+
+  This is most commonly used in pipelines, using the `|>/2` operator, allowing you
   to pipe a value to a function outside of its first argument.
 
   ### Examples

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2154,7 +2154,7 @@ defmodule Macro do
         :not_callable
 
       # <|>, ^^^, and ~~~ are deprecated
-      atom in [:"::", :^^^, :~~~, :<|>] ->
+      atom in [:"::", :"^^^", :"~~~", :"<|>"] ->
         :quoted_operator
 
       operator?(atom, 1) or operator?(atom, 2) ->

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -206,7 +206,7 @@ defmodule Macro do
   @doc """
   Breaks a pipeline expression into a list.
 
-  The AST for a pipeline (a sequence of applications of `|>`) is similar to the
+  The AST for a pipeline (a sequence of applications of `|>/2`) is similar to the
   AST of a sequence of binary operators or function applications: the top-level
   expression is the right-most `:|>` (which is the last one to be executed), and
   its left-hand and right-hand sides are its arguments:
@@ -214,7 +214,7 @@ defmodule Macro do
       quote do: 100 |> div(5) |> div(2)
       #=> {:|>, _, [arg1, arg2]}
 
-  In the example above, the `|>` pipe is the right-most pipe; `arg1` is the AST
+  In the example above, the `|>/2` pipe is the right-most pipe; `arg1` is the AST
   for `100 |> div(5)`, and `arg2` is the AST for `div(2)`.
 
   It's often useful to have the AST for such a pipeline as a list of function
@@ -2154,7 +2154,7 @@ defmodule Macro do
         :not_callable
 
       # <|>, ^^^, and ~~~ are deprecated
-      atom in [:"::", :"^^^", :"~~~", :"<|>"] ->
+      atom in [:"::", :^^^, :~~~, :<|>] ->
         :quoted_operator
 
       operator?(atom, 1) or operator?(atom, 2) ->


### PR DESCRIPTION
Reading through the documentation of the `then/2` macro It was first a bit confusing what it returns. 

While the examples make this clear, This PR adds the information that the macro returns the result of the given second argument, function `fun`.

For consistency this PR also adds the same explicitness to the `tap/2` macro.

Additionally this PR also replaces the mentions of `|>` with `|>/2` so it directly links to the pipe operator documentation, similar how it was already present in:

https://github.com/elixir-lang/elixir/blob/4095d29b2a10c07f30b2435f91f1c9fbf7ea7d75/lib/iex/lib/iex.ex#L117