### PR TITLE
Warn if any of True, False, and Nil aliases are used

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -66,9 +66,12 @@ expand({alias, Meta, [Ref, Opts]}, S, E) ->
   assert_no_match_or_guard_scope(Meta, "alias", S, E),
   {ERef, SR, ER} = expand_without_aliases_report(Ref, S, E),
   {EOpts, ST, ET} = expand_opts(Meta, alias, [as, warn], no_alias_opts(Opts), SR, ER),
-
+  case lists:member(ERef, ['Elixir.True', 'Elixir.False', 'Elixir.Nil']) of
+    true ->  elixir_errors:form_warn(Meta, E, ?MODULE, {commonly_mistaken_alias, Ref});
+    false -> ok
+  end,
   if
-    is_atom(ERef) ->
+    is_atom(ERef)->
       {ERef, ST, expand_alias(Meta, true, ERef, EOpts, ET)};
     true ->
       form_error(Meta, E, ?MODULE, {expected_compile_time_module, alias, Ref})
@@ -1174,6 +1177,9 @@ format_error(as_in_multi_alias_call) ->
 format_error({invalid_alias_module, Ref}) ->
   io_lib:format("alias cannot be inferred automatically for module: ~ts, please use the :as option. Implicit aliasing is only supported with Elixir modules",
                 ['Elixir.Macro':to_string(Ref)]);
+format_error({commonly_mistaken_alias, Ref}) ->
+  Module = 'Elixir.Macro':to_string(Ref),
+  io_lib:format("~ts resolves to :'Elixir.~ts'", [Module, Module]);
 format_error({expected_compile_time_module, Kind, GivenTerm}) ->
   io_lib:format("invalid argument for ~ts, expected a compile time atom or alias, got: ~ts",
                 [Kind, 'Elixir.Macro':to_string(GivenTerm)]);

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -71,7 +71,7 @@ expand({alias, Meta, [Ref, Opts]}, S, E) ->
     false -> ok
   end,
   if
-    is_atom(ERef)->
+    is_atom(ERef) ->
       {ERef, ST, expand_alias(Meta, true, ERef, EOpts, ET)};
     true ->
       form_error(Meta, E, ?MODULE, {expected_compile_time_module, alias, Ref})

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -1179,7 +1179,7 @@ format_error({invalid_alias_module, Ref}) ->
                 ['Elixir.Macro':to_string(Ref)]);
 format_error({commonly_mistaken_alias, Ref}) ->
   Module = 'Elixir.Macro':to_string(Ref),
-  io_lib:format("~ts resolves to :'Elixir.~ts'", [Module, Module]);
+  io_lib:format("reserved alias \"~ts\" expands to the atom :\"Elixir.~ts\". Perhaps you meant to write \"~ts\" instead?", [Module, Module, string:casefold(Module)]);
 format_error({expected_compile_time_module, Kind, GivenTerm}) ->
   io_lib:format("invalid argument for ~ts, expected a compile time atom or alias, got: ~ts",
                 [Kind, 'Elixir.Macro':to_string(GivenTerm)]);

--- a/lib/elixir/src/elixir_module.erl
+++ b/lib/elixir/src/elixir_module.erl
@@ -245,7 +245,8 @@ compile_undef(Module, Fun, Arity, Stack) ->
 %% Handle reserved modules and duplicates.
 
 check_module_availability(Line, File, Module) ->
-  Reserved = ['Elixir.Any', 'Elixir.BitString', 'Elixir.PID',
+  Reserved = ['Elixir.True', 'Elixir.False', 'Elixir.Nil',
+              'Elixir.Any', 'Elixir.BitString', 'Elixir.PID',
               'Elixir.Reference', 'Elixir.Elixir', 'Elixir'],
 
   case lists:member(Module, Reserved) of


### PR DESCRIPTION
fixes #11586 
```elixir
iex(1)> alias Nil    
warning: Nil resolves to :'Elixir.Nil'
  iex:1

Nil
iex(2)> alias True   
warning: True resolves to :'Elixir.True'
  iex:2

True
iex(3)> alias False
warning: False resolves to :'Elixir.False'
  iex:3

False
iex(4)> alias Nowarning
Nowarning
iex(5)> 
```