### PR TITLE
CI: Use latest stable and main ex_doc version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,18 @@ jobs:
       - name: Build docs
         if: ${{ matrix.otp_latest }}
         run: |
-          cd ..
-          git clone https://github.com/elixir-lang/ex_doc.git --branch main --depth 1
-          cd ex_doc
-          ../elixir/bin/mix do local.rebar --force + local.hex --force + deps.get + compile
-          cd ../elixir/
-          make docs
+          git config --global advice.detachedHead false
+          EX_DOC_LATEST_STABLE_VERSION=$(curl -s https://hex.pm/api/packages/ex_doc | jq --raw-output '.latest_stable_version')
+          for branch in main v${EX_DOC_LATEST_STABLE_VERSION}; do
+            echo "Building docs with ExDoc ${branch}"
+            cd ..
+            git clone https://github.com/elixir-lang/ex_doc.git --branch ${branch} --depth 1
+            cd ex_doc
+            ../elixir/bin/mix do local.rebar --force + local.hex --force + deps.get + compile
+            cd ../elixir/
+            make docs
+            rm -rf ../ex_doc/
+          done
 
   test_windows:
     name: Windows, OTP-${{ matrix.otp_release }}, Windows Server 2019

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,12 +58,17 @@ jobs:
           gh release upload --clobber "${{ github.ref_name }}" \
             elixir-otp-${{ matrix.otp }}.zip \
             elixir-otp-${{ matrix.otp }}.zip.sha{1,256}sum
+      - name: Get latest stable ExDoc version
+        if: ${{ matrix.build_docs }}
+        run: |
+          EX_DOC_LATEST_STABLE_VERSION=$(curl -s https://hex.pm/api/packages/ex_doc | jq --raw-output '.latest_stable_version')
+          echo "EX_DOC_LATEST_STABLE_VERSION=${EX_DOC_LATEST_STABLE_VERSION}" >> $GITHUB_ENV
       - uses: actions/checkout@v2
+        if: ${{ matrix.build_docs }}
         with:
           repository: elixir-lang/ex_doc
-          ref: v0.26.0
+          ref: v${{ env.EX_DOC_LATEST_STABLE_VERSION }}
           path: ex_doc
-        if: ${{ matrix.build_docs }}
       - name: Build ex_doc
         if: ${{ matrix.build_docs }}
         run: |


### PR DESCRIPTION
- release.yml now automatically fetches latest stable ExDoc version.
- ci.yml now builds docs using latest stable and main ExDoc version.

Related discussion: https://github.com/elixir-lang/ex_doc/issues/1539#issuecomment-1079763510
You can see the successful Release action here: https://github.com/eksperimental/elixir/runs/5711389346?check_suite_focus=true
and the draft release: https://github.com/eksperimental/elixir/releases/tag/untagged-7d5611d46ff9a5abfe44