### PR TITLE
Mute compilation warning about unused function.

### DIFF
--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -833,12 +833,4 @@ defmodule ExceptionTest do
       end
     end
   end
-
-  defp message(arg, fun) do
-    try do
-      fun.(arg)
-    rescue
-      e -> Exception.message(e)
-    end
-  end
 end


### PR DESCRIPTION
While compiling from source yesterday I noticed a warn (during elixir compilation) about an unused function:
```elixir
==> elixir (ex_unit)
warning: function message/2 is unused
  test/elixir/exception_test.exs:837
  ```
  
 I'm not sure a PR is worthy or if there is anything else to be done (tests are green and no more warnings during compilation) but I'll be happy to do so.
 
 Cheers.