### PR TITLE
Make Registry.send work when value part is present

### DIFF
--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -261,6 +261,11 @@ defmodule Registry do
   end
 
   @doc false
+  def send({registry, key, _value}, msg) do
+    Registry.send({registry, key}, msg)
+  end
+
+  @doc false
   def unregister_name({registry, key}), do: unregister(registry, key)
   def unregister_name({registry, key, _value}), do: unregister(registry, key)
 

--- a/lib/elixir/lib/registry.ex
+++ b/lib/elixir/lib/registry.ex
@@ -260,7 +260,6 @@ defmodule Registry do
     end
   end
 
-  @doc false
   def send({registry, key, _value}, msg) do
     Registry.send({registry, key}, msg)
   end

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -992,6 +992,20 @@ defmodule RegistryTest do
     assert {%RuntimeError{message: "some error"}, _stacktrace} = error
   end
 
+  test "send works", %{registry: registry} do
+    name = {registry, "self"}
+    Registry.register_name(name, self())
+    Registry.send(name, :message)
+    assert_received :message
+  end
+
+  test "send works with value", %{registry: registry} do
+    name = {registry, "self", "value"}
+    Registry.register_name(name, self())
+    Registry.send(name, :message)
+    assert_received :message
+  end
+
   defp register_task(registry, key, value) do
     parent = self()
 

--- a/lib/elixir/test/elixir/registry_test.exs
+++ b/lib/elixir/test/elixir/registry_test.exs
@@ -995,15 +995,15 @@ defmodule RegistryTest do
   test "send works", %{registry: registry} do
     name = {registry, "self"}
     Registry.register_name(name, self())
-    Registry.send(name, :message)
-    assert_received :message
+    GenServer.cast({:via, Registry, name}, :message)
+    assert_received {:"$gen_cast", :message}
   end
 
   test "send works with value", %{registry: registry} do
     name = {registry, "self", "value"}
     Registry.register_name(name, self())
-    Registry.send(name, :message)
-    assert_received :message
+    GenServer.cast({:via, Registry, name}, :message)
+    assert_received {:"$gen_cast", :message}
   end
 
   defp register_task(registry, key, value) do


### PR DESCRIPTION
Fix #11740.