### PR TITLE
Run after_suite even when no tests were ran

### DIFF
--- a/lib/mix/lib/mix/compilers/test.ex
+++ b/lib/mix/lib/mix/compilers/test.ex
@@ -34,6 +34,8 @@ defmodule Mix.Compilers.Test do
 
     cond do
       test_files == [] ->
+        _ = ExUnit.configure(formatters: [])
+        _ = ExUnit.run()
         :noop
 
       Keyword.get(opts, :profile_require) == "time" ->

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -411,12 +411,9 @@ defmodule Mix.Tasks.TestTest do
   describe "logs and errors" do
     test "logs test absence for a project with no test paths" do
       in_fixture("test_stale", fn ->
-        File.write!("test/test_helper.exs", """
-        ExUnit.start()
-        """)
-
-        File.rm_rf!("test/b_test_stale.exs")
-        File.rm_rf!("test/a_test_stale.exs")
+        File.rm_rf!("test")
+        File.mkdir_p!("test")
+        File.write!("test/test_helper.exs", "ExUnit.start()")
 
         assert_run_output("There are no tests to run")
       end)

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -392,12 +392,31 @@ defmodule Mix.Tasks.TestTest do
         )
       end)
     end
+
+    test "runs after_suite with partitions with no tests" do
+      in_fixture("test_stale", fn ->
+        File.write!("test/test_helper.exs", """
+        ExUnit.after_suite(fn _stats -> IO.puts("AFTER SUITE") end)
+        ExUnit.start()
+        """)
+
+        assert mix(["test", "--partitions", "3"], [{"MIX_TEST_PARTITION", "3"}]) =~ """
+               AFTER SUITE
+               There are no tests to run
+               """
+      end)
+    end
   end
 
   describe "logs and errors" do
     test "logs test absence for a project with no test paths" do
       in_fixture("test_stale", fn ->
-        File.rm_rf!("test")
+        File.write!("test/test_helper.exs", """
+        ExUnit.start()
+        """)
+
+        File.rm_rf!("test/b_test_stale.exs")
+        File.rm_rf!("test/a_test_stale.exs")
 
         assert_run_output("There are no tests to run")
       end)


### PR DESCRIPTION
Run all ExUnit after_suite callbacks even when the suite had no tests.

I tried to respect the boundaries of each application here so it's probably a bit more than what could've been required. I am open to changing it up to something simpler such as this right in `Mix.Tasks.Test` if that's preferred.

```elixir
stats = %{excluded: 0, failures: 0, skipped: 0, total: 0})
after_suite_callbacks = Application.fetch_env!(:ex_unit, :after_suite)
Enum.each(after_suite_callbacks, fn callback -> callback.(stats) end)
```

Also, I wanted to add some tests for the mix task itself but couldn't find a great spot to put this kind of thing in there.

Let me know your feedback! 😃 ❤️ 

Fixes #11746