### PR TITLE
tweak allowed codepoints

### DIFF
--- a/lib/elixir/pages/unicode-syntax.md
+++ b/lib/elixir/pages/unicode-syntax.md
@@ -113,7 +113,7 @@ Elixir conforms to the clauses outlined in the [Unicode Technical Standard #39](
 
 > An implementation following the General Security Profile does not permit any characters in \p{Identifier_Status=Restricted}, unless it documents the additional characters that it does allow
 
-Elixir will not allow tokenization of identifiers with codepoints in `\p{Identifier_Status=Restricted}`, with the single exception of MICRO SIGN µ (U+00B5), used by international system of units and assigned a scriptset of Latin.
+Elixir will not allow tokenization of identifiers with codepoints in `\p{Identifier_Status=Restricted}`, with the single exception of MICRO SIGN µ (U+00B5), used by international system of units.
 
 For instance, the 'HANGUL FILLER' (`ㅤ`) character, which is often invisible, is an uncommon codepoint and will trigger this warning. Codepoints that are not NFKC normalized are also removed (with the exception of µ above).
 

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -98,6 +98,8 @@ defmodule Kernel.WarningTest do
 
       # allow Elixir special cases
       assert Code.string_to_quoted!(":duration_µs")
+      # Common 'micro' character can be used with any script
+      assert Code.string_to_quoted!(":सवव_µ")
     end
   end
 

--- a/lib/elixir/unicode/tokenizer.ex
+++ b/lib/elixir/unicode/tokenizer.ex
@@ -213,8 +213,6 @@ defmodule String.Tokenizer do
   {bottom, top} = ScriptSet.lattices(map_size(scriptset_masks))
   IO.puts(:stderr, "[Unicode] Tokenizing #{map_size(scriptset_masks)} scriptsets")
 
-  # scriptset_masks = %{scriptset_masks | "Common" => top, "Inherited" => top}
-
   codepoints_to_mask =
     for {codepoint, scriptsets} <- all_codepoints_to_scriptset, into: %{} do
       {codepoint,


### PR DESCRIPTION
@josevalim - these are those proposed tweaks to the 'micro' branch. `make clean test elixir` worked locally, made the PR to check CI. I think we might not need to override scripts, we may only need to whitelist the Restricted 'Common'-scriptset character that they're using (which we probably should support IMO). I could definitely be missing something obvious, feel free to slap me upside the head with it.

