### PR TITLE
Improve Error in case of StringIO write with invalid characters

### DIFF
--- a/lib/elixir/lib/string_io.ex
+++ b/lib/elixir/lib/string_io.ex
@@ -290,7 +290,7 @@ defmodule StringIO do
         {:ok, %{state | output: state.output <> string}}
 
       {_, _, _} ->
-        {{:error, req}, state}
+        {{:error, {:no_translation, encoding, state.encoding}}, state}
     end
   rescue
     ArgumentError -> {{:error, req}, state}

--- a/lib/elixir/test/elixir/string_io_test.exs
+++ b/lib/elixir/test/elixir/string_io_test.exs
@@ -143,6 +143,10 @@ defmodule StringIOTest do
     assert_raise ArgumentError, fn ->
       IO.write(pid, [<<1::1>>])
     end
+
+    assert_raise ErlangError, ~r/no_translation/, fn ->
+      IO.write(pid, <<222>>)
+    end
   end
 
   test "IO.binwrite" do

--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -337,6 +337,10 @@ defmodule Logger.Backends.Console do
     retry_log({:put_chars, :unicode, output}, state)
   end
 
+  defp handle_io_reply({:error, {:no_translation, _encoding_from, _encoding_to} = error}, state) do
+    retry_log(error, state)
+  end
+
   defp handle_io_reply({:error, error}, _) do
     raise "failure while logging console messages: " <> inspect(error)
   end


### PR DESCRIPTION
Mailing list discussion: https://groups.google.com/g/elixir-lang-core/c/RR7nbeHsluQ

This uses the existing `no_translation` erlang error to handle transcoding issues. This will not solve the same problem when using a normal file. (Upcoming PR in OTP itself)

*EDIT: Removed comment about tests since they have been fixed.*