### PR TITLE
feat: allow app environment values to contain spaces

### DIFF
--- a/bin/elixir
+++ b/bin/elixir
@@ -19,6 +19,7 @@ Usage: $(basename "$0") [options] [.exs file] [data]
   -v, --version                Prints Erlang/OTP and Elixir versions (standalone)
 
   --app APP                    Starts the given app and its dependencies (*)
+  --app-env APP KEY VAL        Sets app environment variable (*)
   --erl "SWITCHES"             Switches to be passed down to Erlang (*)
   --eval "COMMAND"             Evaluates the given command, same as -e (*)
   --logger-otp-reports BOOL    Enables or disables OTP reporting
@@ -140,6 +141,12 @@ while [ $I -le $LENGTH ]; do
     --erl)
         S=2
         ERL="$ERL $2"
+        ;;
+    --app-env)
+        S=4
+        erl_set "-$2"
+        erl_set "$3"
+        erl_set "$4"
         ;;
     --cookie)
         S=2

--- a/bin/elixir.bat
+++ b/bin/elixir.bat
@@ -26,6 +26,7 @@ echo   -pz "PATH"                   Appends the given path to Erlang code path (
 echo   -v, --version                Prints Erlang/OTP and Elixir versions (standalone)
 echo.
 echo   --app APP                    Starts the given app and its dependencies (*)
+echo   --app-env APP KEY VAL        Sets app environment variable (*)
 echo   --erl "SWITCHES"             Switches to be passed down to Erlang (*)
 echo   --eval "COMMAND"             Evaluates the given command, same as -e (*)
 echo   --logger-otp-reports BOOL    Enables or disables OTP reporting
@@ -142,6 +143,7 @@ if ""==!par:--no-halt=!   (set "parsElixir=!parsElixir! --no-halt" && goto start
 if ""==!par:--remsh=!     (set "parsElixir=!parsElixir! --remsh %1" && shift && goto startloop)
 if ""==!par:--dot-iex=!   (set "parsElixir=!parsElixir! --dot-iex %1" && shift && goto startloop)
 rem ******* ERLANG PARAMETERS **********************
+if ""==!par:--app-env=!         (set "parsErlang=!parsErlang! -%1 %2 %3" && shift && shift && shift && goto startloop)
 if ""==!par:--boot=!                (set "parsErlang=!parsErlang! -boot %1" && shift && goto startloop)
 if ""==!par:--boot-var=!            (set "parsErlang=!parsErlang! -boot_var %1 %2" && shift && shift && goto startloop)
 if ""==!par:--cookie=!              (set "parsErlang=!parsErlang! -setcookie %1" && shift && goto startloop)

--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -141,6 +141,25 @@ defmodule Kernel.CLITest do
     assert error =~ "def fetch(-%module{} = container-, +key+)"
     assert error =~ ~r"\(elixir #{System.version()}\) lib/access\.ex:\d+: Access\.fetch/2"
   end
+
+  test "proper handling of spaces in --app-env" do
+    command =
+      "IO.inspect(:init.get_arguments()[:mnesia]); " <>
+        "IO.inspect(Application.load(:mnesia))"
+
+    output = elixir('--app-env mnesia dir \'"/tmp/with spaces/abc"\' -e "#{command}"')
+
+    assert results =
+             [_, _] =
+             output
+             |> String.trim()
+             |> String.split("\n")
+
+    [{app_env_result, _}, {load_result, _}] = Enum.map(results, &Code.eval_string(&1, []))
+
+    assert app_env_result == ['dir', '\"/tmp/with spaces/abc\"']
+    assert load_result == :ok
+  end
 end
 
 defmodule Kernel.CLI.RPCTest do


### PR DESCRIPTION
When one needs to set an application environment value that contains
spaces, such as a Mnesia directory path with spaces, the current
`--erl` switch does not pass the spaces correctly down to `erl`:

```
ͳ bin/iex --erl "-mnesia dir \"/tmp/abc/with spaces/\"" -e ':init.get_arguments()[:mnesia] |> IO.inspect(); System.halt()'
Erlang/OTP 24 [erts-12.1.2] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

['dir', '"/tmp/abc/with', 'spaces/"']
```

Which fails when loading the app:

```
iex(1)> Application.load(:mnesia)

13:26:44.461 [error] application_controller: unterminated string starting with "/tmp/abc/with": "/tmp/abc/with

{:error, {:bad_environment_value, '"/tmp/abc/with'}}
```

This adds a new switch, `--app-env`, that helps with setting such
values while preserving both the double quotes needed for Erlang to
parse the value as a string and the spaces that might be in such
string.

```
ͳ bin/iex --app-env mnesia dir "\"/tmp/abc/with spaces/\"" -e ':init.get_arguments()[:mnesia] |> IO.inspect(); System.halt()'
Erlang/OTP 24 [erts-12.1.2] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

['dir', '"/tmp/abc/with spaces/"']
```