### PR TITLE
Add short hash to tmp_dir in ExUnit to avoid test name collision

### DIFF
--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -393,7 +393,7 @@ defmodule ExUnit.Runner do
     (module <> "/" <> test_name)
     |> :erlang.md5()
     |> Base.encode16(case: :lower)
-    |> String.slice(0..7)
+    |> binary_part(0, 7)
   end
 
   defp create_tmp_dir!(test, extra_path, context) do

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -389,10 +389,22 @@ defmodule ExUnit.Runner do
     context
   end
 
+  defp short_hash(module, test_name, extra_path) do
+    (module <> "/" <> test_name <> "/" <> extra_path)
+    |> :erlang.md5()
+    |> Base.encode16(case: :lower)
+    |> String.slice(0..7)
+  end
+
   defp create_tmp_dir!(test, extra_path, context) do
-    module = escape_path(inspect(test.module))
-    name = escape_path(to_string(test.name))
-    path = ["tmp", module, name, extra_path] |> Path.join() |> Path.expand()
+    module_string = inspect(test.module)
+    name_string = to_string(test.name)
+
+    module = escape_path(module_string)
+    name = escape_path(name_string)
+    short_hash = short_hash(module_string, name_string, extra_path)
+
+    path = ["tmp", module, name, extra_path, short_hash] |> Path.join() |> Path.expand()
     File.rm_rf!(path)
     File.mkdir_p!(path)
     Map.put(context, :tmp_dir, path)

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -393,7 +393,7 @@ defmodule ExUnit.Runner do
     (module <> "/" <> test_name)
     |> :erlang.md5()
     |> Base.encode16(case: :lower)
-    |> binary_part(0, 7)
+    |> binary_slice(0..7)
   end
 
   defp create_tmp_dir!(test, extra_path, context) do

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -404,7 +404,7 @@ defmodule ExUnit.Runner do
     name = escape_path(name_string)
     short_hash = short_hash(module_string, name_string)
 
-    path = ["tmp", module, name, short_hash, extra_path] |> Path.join() |> Path.expand()
+    path = ["tmp", module, "#{name}-#{short_hash}", extra_path] |> Path.join() |> Path.expand()
     File.rm_rf!(path)
     File.mkdir_p!(path)
     Map.put(context, :tmp_dir, path)

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -389,8 +389,8 @@ defmodule ExUnit.Runner do
     context
   end
 
-  defp short_hash(module, test_name, extra_path) do
-    (module <> "/" <> test_name <> "/" <> extra_path)
+  defp short_hash(module, test_name) do
+    (module <> "/" <> test_name)
     |> :erlang.md5()
     |> Base.encode16(case: :lower)
     |> String.slice(0..7)
@@ -402,9 +402,9 @@ defmodule ExUnit.Runner do
 
     module = escape_path(module_string)
     name = escape_path(name_string)
-    short_hash = short_hash(module_string, name_string, extra_path)
+    short_hash = short_hash(module_string, name_string)
 
-    path = ["tmp", module, name, extra_path, short_hash] |> Path.join() |> Path.expand()
+    path = ["tmp", module, name, short_hash, extra_path] |> Path.join() |> Path.expand()
     File.rm_rf!(path)
     File.mkdir_p!(path)
     Map.put(context, :tmp_dir, path)

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -158,7 +158,7 @@ defmodule ExUnit.CaseTest.TmpDir do
   defp ends_with_short_hash?(string) do
     string
     |> String.slice(-9..-1)
-    |> String.starts_with?("/")
+    |> String.starts_with?("-")
   end
 
   defp ends_with_short_hash_and_extra_path?(string, extra_path) do
@@ -179,46 +179,38 @@ defmodule ExUnit.CaseTest.TmpDir do
   end
 
   test "default path", context do
-    assert starts_with_path?(context.tmp_dir, "tmp/ExUnit.CaseTest.TmpDir/test-default-path/") ==
-             true
-
-    assert ends_with_short_hash?(context.tmp_dir) == true
+    assert starts_with_path?(context.tmp_dir, "tmp/ExUnit.CaseTest.TmpDir/test-default-path-")
+    assert ends_with_short_hash?(context.tmp_dir)
     assert File.ls!(context.tmp_dir) == []
   end
 
   test "escapes foo?/0", context do
-    assert starts_with_path?(context.tmp_dir, "tmp/ExUnit.CaseTest.TmpDir/test-escapes-foo--0/") ==
-             true
-
-    assert ends_with_short_hash?(context.tmp_dir) == true
+    assert starts_with_path?(context.tmp_dir, "tmp/ExUnit.CaseTest.TmpDir/test-escapes-foo--0-")
+    assert ends_with_short_hash?(context.tmp_dir)
   end
 
   @tag tmp_dir: "foo/bar"
   test "custom path", context do
-    assert starts_with_path?(
-             context.tmp_dir,
-             "tmp/ExUnit.CaseTest.TmpDir/test-custom-path/"
-           ) == true
-
-    assert ends_with_short_hash_and_extra_path?(context.tmp_dir, "foo/bar") == true
+    assert starts_with_path?(context.tmp_dir, "tmp/ExUnit.CaseTest.TmpDir/test-custom-path-")
+    assert ends_with_short_hash_and_extra_path?(context.tmp_dir, "foo/bar")
   end
 
   test "colliding-test-names", context do
     assert starts_with_path?(
              context.tmp_dir,
-             "tmp/ExUnit.CaseTest.TmpDir/test-colliding-test-names/"
-           ) == true
+             "tmp/ExUnit.CaseTest.TmpDir/test-colliding-test-names-"
+           )
 
-    assert String.ends_with?(context.tmp_dir, "/e09bee07") == true
+    assert String.ends_with?(context.tmp_dir, "-e09bee07")
   end
 
   test "colliding+test+names", context do
     assert starts_with_path?(
              context.tmp_dir,
-             "tmp/ExUnit.CaseTest.TmpDir/test-colliding-test-names/"
-           ) == true
+             "tmp/ExUnit.CaseTest.TmpDir/test-colliding-test-names-"
+           )
 
-    assert String.ends_with?(context.tmp_dir, "/c96d2f8c") == true
+    assert String.ends_with?(context.tmp_dir, "-c96d2f8c")
   end
 
   @tag tmp_dir: false

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -157,7 +157,7 @@ defmodule ExUnit.CaseTest.TmpDir do
 
   defp ends_with_short_hash?(string) do
     string
-    |> String.slice(-9..-1)
+    |> binary_slice(-9..-1)
     |> String.starts_with?("-")
   end
 

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -161,6 +161,19 @@ defmodule ExUnit.CaseTest.TmpDir do
     |> String.starts_with?("/")
   end
 
+  defp ends_with_short_hash_and_extra_path?(string, extra_path) do
+    extra_path = "/" <> extra_path
+    extra_path_length = String.length(extra_path)
+
+    case String.split_at(string, -extra_path_length) do
+      {tmp_dir_base, extra_path_new} when extra_path_new == extra_path ->
+        ends_with_short_hash?(tmp_dir_base)
+
+      _ ->
+        false
+    end
+  end
+
   defp starts_with_path?(tmp_dir, path) do
     String.starts_with?(tmp_dir, Path.expand(path))
   end
@@ -184,10 +197,10 @@ defmodule ExUnit.CaseTest.TmpDir do
   test "custom path", context do
     assert starts_with_path?(
              context.tmp_dir,
-             "tmp/ExUnit.CaseTest.TmpDir/test-custom-path/foo/bar/"
+             "tmp/ExUnit.CaseTest.TmpDir/test-custom-path/"
            ) == true
 
-    assert ends_with_short_hash?(context.tmp_dir) == true
+    assert ends_with_short_hash_and_extra_path?(context.tmp_dir, "foo/bar") == true
   end
 
   test "colliding-test-names", context do
@@ -196,7 +209,7 @@ defmodule ExUnit.CaseTest.TmpDir do
              "tmp/ExUnit.CaseTest.TmpDir/test-colliding-test-names/"
            ) == true
 
-    assert String.ends_with?(context.tmp_dir, "/44141789") == true
+    assert String.ends_with?(context.tmp_dir, "/e09bee07") == true
   end
 
   test "colliding+test+names", context do
@@ -205,7 +218,7 @@ defmodule ExUnit.CaseTest.TmpDir do
              "tmp/ExUnit.CaseTest.TmpDir/test-colliding-test-names/"
            ) == true
 
-    assert String.ends_with?(context.tmp_dir, "/7646c6e4") == true
+    assert String.ends_with?(context.tmp_dir, "/c96d2f8c") == true
   end
 
   @tag tmp_dir: false

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -155,18 +155,57 @@ defmodule ExUnit.CaseTest.TmpDir do
 
   @moduletag :tmp_dir
 
+  defp ends_with_short_hash?(string) do
+    string
+    |> String.slice(-9..-1)
+    |> String.starts_with?("/")
+  end
+
+  defp starts_with_path?(tmp_dir, path) do
+    String.starts_with?(tmp_dir, Path.expand(path))
+  end
+
   test "default path", context do
-    assert context.tmp_dir == Path.expand("tmp/ExUnit.CaseTest.TmpDir/test-default-path")
+    assert starts_with_path?(context.tmp_dir, "tmp/ExUnit.CaseTest.TmpDir/test-default-path/") ==
+             true
+
+    assert ends_with_short_hash?(context.tmp_dir) == true
     assert File.ls!(context.tmp_dir) == []
   end
 
   test "escapes foo?/0", context do
-    assert context.tmp_dir == Path.expand("tmp/ExUnit.CaseTest.TmpDir/test-escapes-foo--0")
+    assert starts_with_path?(context.tmp_dir, "tmp/ExUnit.CaseTest.TmpDir/test-escapes-foo--0/") ==
+             true
+
+    assert ends_with_short_hash?(context.tmp_dir) == true
   end
 
   @tag tmp_dir: "foo/bar"
   test "custom path", context do
-    assert context.tmp_dir == Path.expand("tmp/ExUnit.CaseTest.TmpDir/test-custom-path/foo/bar")
+    assert starts_with_path?(
+             context.tmp_dir,
+             "tmp/ExUnit.CaseTest.TmpDir/test-custom-path/foo/bar/"
+           ) == true
+
+    assert ends_with_short_hash?(context.tmp_dir) == true
+  end
+
+  test "colliding-test-names", context do
+    assert starts_with_path?(
+             context.tmp_dir,
+             "tmp/ExUnit.CaseTest.TmpDir/test-colliding-test-names/"
+           ) == true
+
+    assert String.ends_with?(context.tmp_dir, "/44141789") == true
+  end
+
+  test "colliding+test+names", context do
+    assert starts_with_path?(
+             context.tmp_dir,
+             "tmp/ExUnit.CaseTest.TmpDir/test-colliding-test-names/"
+           ) == true
+
+    assert String.ends_with?(context.tmp_dir, "/7646c6e4") == true
   end
 
   @tag tmp_dir: false

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -225,7 +225,7 @@ defmodule Mix.CLITest do
   @tag tmp_dir: "new_with_tests"
   test "new with tests and cover", %{tmp_dir: tmp_dir} do
     File.cd!(tmp_dir, fn ->
-      output = mix(~w[new .])
+      output = mix(~w[new . --app new_with_tests])
       assert output =~ "* creating lib/new_with_tests.ex"
 
       output = mix(~w[test test/new_with_tests_test.exs --cover])
@@ -239,7 +239,7 @@ defmodule Mix.CLITest do
   @tag tmp_dir: "sup_with_tests"
   test "new --sup with tests", %{tmp_dir: tmp_dir} do
     File.cd!(tmp_dir, fn ->
-      output = mix(~w[new --sup .])
+      output = mix(~w[new . --app sup_with_tests --sup])
       assert output =~ "* creating lib/sup_with_tests.ex"
 
       output = mix(~w[test])

--- a/lib/mix/test/mix/cli_test.exs
+++ b/lib/mix/test/mix/cli_test.exs
@@ -225,7 +225,7 @@ defmodule Mix.CLITest do
   @tag tmp_dir: "new_with_tests"
   test "new with tests and cover", %{tmp_dir: tmp_dir} do
     File.cd!(tmp_dir, fn ->
-      output = mix(~w[new . --app new_with_tests])
+      output = mix(~w[new .])
       assert output =~ "* creating lib/new_with_tests.ex"
 
       output = mix(~w[test test/new_with_tests_test.exs --cover])
@@ -239,7 +239,7 @@ defmodule Mix.CLITest do
   @tag tmp_dir: "sup_with_tests"
   test "new --sup with tests", %{tmp_dir: tmp_dir} do
     File.cd!(tmp_dir, fn ->
-      output = mix(~w[new . --app sup_with_tests --sup])
+      output = mix(~w[new --sup .])
       assert output =~ "* creating lib/sup_with_tests.ex"
 
       output = mix(~w[test])


### PR DESCRIPTION
There are certain tests names that could collide since when sanitizing unknown
characters are replaced with a hyphen.

This avoids test with name "foo-bar" and "foo+bar" to use the same temporary directory.