### PR TITLE
Optimize Enum.with_index/2 for lists

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3722,11 +3722,11 @@ defmodule Enum do
   def with_index(enumerable, fun_or_offset \\ 0)
 
   def with_index(enumerable, offset) when is_list(enumerable) and is_integer(offset) do
-    with_index_list(enumerable, offset, [])
+    with_index_list(enumerable, offset)
   end
 
   def with_index(enumerable, fun) when is_list(enumerable) and is_function(fun, 2) do
-    with_index_list(enumerable, 0, fun, [])
+    with_index_list(enumerable, 0, fun)
   end
 
   def with_index(enumerable, offset) when is_integer(offset) do
@@ -4661,17 +4661,17 @@ defmodule Enum do
 
   ## with_index
 
-  defp with_index_list([elem | rest], offset, acc) do
-    with_index_list(rest, offset + 1, [{elem, offset} | acc])
+  defp with_index_list([head | tail], offset) do
+    [{head, offset} | with_index_list(tail, offset + 1)]
   end
 
-  defp with_index_list([], _offset, acc), do: :lists.reverse(acc)
+  defp with_index_list([], _offset), do: []
 
-  defp with_index_list([elem | rest], offset, fun, acc) do
-    with_index_list(rest, offset + 1, fun, [fun.(elem, offset) | acc])
+  defp with_index_list([head | tail], offset, fun) do
+    [fun.(head, offset) | with_index_list(tail, offset + 1, fun)]
   end
 
-  defp with_index_list([], _offset, _fun, acc), do: :lists.reverse(acc)
+  defp with_index_list([], _offset, _fun), do: []
 
   ## zip
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3721,6 +3721,14 @@ defmodule Enum do
   @spec with_index(t, (element, index -> value)) :: [value] when value: any
   def with_index(enumerable, fun_or_offset \\ 0)
 
+  def with_index(enumerable, offset) when is_list(enumerable) and is_integer(offset) do
+    with_index_list(enumerable, offset, [])
+  end
+
+  def with_index(enumerable, fun) when is_list(enumerable) and is_function(fun, 2) do
+    with_index_list(enumerable, 0, fun, [])
+  end
+
   def with_index(enumerable, offset) when is_integer(offset) do
     enumerable
     |> map_reduce(offset, fn x, i -> {{x, i}, i + 1} end)
@@ -4650,6 +4658,20 @@ defmodule Enum do
   defp uniq_list([], _set, _fun) do
     []
   end
+
+  ## with_index
+
+  defp with_index_list([elem | rest], offset, acc) do
+    with_index_list(rest, offset + 1, [{elem, offset} | acc])
+  end
+
+  defp with_index_list([], _offset, acc), do: :lists.reverse(acc)
+
+  defp with_index_list([elem | rest], offset, fun, acc) do
+    with_index_list(rest, offset + 1, fun, [fun.(elem, offset) | acc])
+  end
+
+  defp with_index_list([], _offset, _fun, acc), do: :lists.reverse(acc)
 
   ## zip
 

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -1409,6 +1409,13 @@ defmodule EnumTest do
 
     assert Enum.with_index([1, 2, 3], fn element, index -> {index, element} end) ==
              [{0, 1}, {1, 2}, {2, 3}]
+
+    assert Enum.with_index(1..0//1) == []
+    assert Enum.with_index(1..3) == [{1, 0}, {2, 1}, {3, 2}]
+    assert Enum.with_index(1..3, 10) == [{1, 10}, {2, 11}, {3, 12}]
+
+    assert Enum.with_index(1..3, fn element, index -> {index, element} end) ==
+             [{0, 1}, {1, 2}, {2, 3}]
   end
 
   test "zip/2" do


### PR DESCRIPTION
Hi,

I noticed that `Enum.with_index/2` could be optimized for lists using a specialized implementation
- x2 on Intel Chip, see [bench](https://github.com/sabiwara/elixir_benches/blob/main/bench/fast_enum_with_index.results.txt)
- x3 on M1 Chip / OTP 25, see [bench](https://github.com/sabiwara/elixir_benches/blob/main/bench/fast_enum_with_index.results_m1.txt)

~I tried both tail-recursion and [body-recursion](https://github.com/sabiwara/elixir_benches/blob/main/lib/fast_enum.ex#L438-L442=), and went with tail-recursion because it was considerably faster, especially on ARM (x2).~

Edit: after the additional benchmarks from below, I updated to body-recursion which consistently uses less memory. Let me know your thoughts.