### PR TITLE
Add dark logo in README with #gh-dark-mode-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-<img src="https://github.com/elixir-lang/elixir-lang.github.com/raw/main/images/logo/logo.png" width="200" alt="Elixir">
+<img src="https://github.com/elixir-lang/elixir-lang.github.com/raw/main/images/logo/logo.png#gh-light-mode-only" width="200" alt="Elixir">
+<img src="https://github.com/elixir-lang/elixir-lang.github.com/raw/main/images/logo/logo-dark.png#gh-dark-mode-only" width="200" alt="Elixir">
 
 [![CI](https://github.com/elixir-lang/elixir/workflows/CI/badge.svg?branch=main)](https://github.com/elixir-lang/elixir/actions?query=branch%3Amain+workflow%3ACI) [![Build status](https://api.cirrus-ci.com/github/elixir-lang/elixir.svg?branch=main)](https://cirrus-ci.com/github/elixir-lang/elixir)
 


### PR DESCRIPTION
Once this is merged https://github.com/elixir-lang/elixir-lang.github.com/pull/1604 we can merge this pull request to have a beautiful logo in GitHub dark mode 😄 🌃 

<img width="689" alt="image" src="https://user-images.githubusercontent.com/464900/164451353-c38b2733-1ec4-46c3-bbb5-e94dea015e94.png">
