### PR TITLE
Adds start_link_supervised

### DIFF
--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -448,8 +448,7 @@ defmodule ExUnit.Callbacks do
   defp start_supervised_error(reason), do: Exception.format_exit({:start_spec, reason})
 
   @doc """
-  Same as `start_link_supervised/2` but returns the PID on success and raises if
-  not started properly.
+  Same as `start_supervised!/2` but links the started process to the test process.
 
   This means that if the process that was started crashes that crash is propagated to
   the test process, failing the test and printing the cause of the crash.

--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -388,6 +388,10 @@ defmodule ExUnit.Callbacks do
   test, as simply shutting down the process would cause it to be restarted
   according to its `:restart` value.
 
+  The started process is not linked to the test process and a crash will
+  not necessarily fail the test. To start and link a process to guarantee
+  that any crash would also fail the test use `start_link_supervised!/2`.
+
   This function returns `{:ok, pid}` in case of success, otherwise it
   returns `{:error, reason}`.
   """
@@ -444,6 +448,22 @@ defmodule ExUnit.Callbacks do
   defp start_supervised_error(reason), do: Exception.format_exit({:start_spec, reason})
 
   @doc """
+  Same as `start_link_supervised/2` but returns the PID on success and raises if
+  not started properly.
+
+  This means that if the process that was started crashes that crash is propagated to
+  the test process, failing the test and printing the cause of the crash.
+  """
+  @doc since: "1.14.0"
+  @spec start_link_supervised!(Supervisor.child_spec() | module | {module, term}, keyword) ::
+          Supervisor.on_start_child()
+  def start_link_supervised!(child_spec_or_module, opts \\ []) do
+    pid = start_supervised!(child_spec_or_module, opts)
+    Process.link(pid)
+    pid
+  end
+
+  @doc """
   Stops a child process started via `start_supervised/2`.
 
   This function expects the `id` in the child specification.
@@ -463,6 +483,12 @@ defmodule ExUnit.Callbacks do
         {:error, :not_found}
 
       {:ok, sup} ->
+        pid = pid_for_child(sup, id)
+
+        if pid do
+          Process.unlink(pid)
+        end
+
         with :ok <- Supervisor.terminate_child(sup, id) do
           # If the terminated child was temporary, delete_child returns {:error, :not_found}.
           # Since the child was successfully terminated, we treat this result as a success.
@@ -472,6 +498,14 @@ defmodule ExUnit.Callbacks do
 
       :error ->
         raise ArgumentError, "stop_supervised/1 can only be invoked from the test process"
+    end
+  end
+
+  defp pid_for_child(sup, id) do
+    children = Supervisor.which_children(sup)
+
+    with {_id, pid, _type, _modules} <- List.keyfind(children, id, 0) do
+      pid
     end
   end
 

--- a/lib/ex_unit/test/ex_unit/supervised_test.exs
+++ b/lib/ex_unit/test/ex_unit/supervised_test.exs
@@ -94,6 +94,12 @@ defmodule ExUnit.SupervisedTest do
     refute Process.alive?(pid)
   end
 
+  test "stops a linked supervised process" do
+    pid = start_link_supervised!({MyAgent, 0})
+    assert stop_supervised(MyAgent) == :ok
+    refute Process.alive?(pid)
+  end
+
   test "stops a temporary supervised process" do
     {:ok, pid} = start_supervised({MyAgent, 0}, restart: :temporary)
     assert stop_supervised(MyAgent) == :ok


### PR DESCRIPTION
Adds a version of `start_supervised` and `start_supervised!` that explicitly links the started process to the test process, ensuring that any crashes are propagated to the test, failing it and providing a helpful test failure output.

More context on the change here: https://github.com/elixir-lang/elixir/issues/11737

### Open questions
1. Can we test `start_link_supervised` with a process that crashes where we assert on the EXIT message received without race conditions?
2. Are any other tests missing? I didn't want to repeat every `start_supervised` test since it just delegates to it under the hood, but the `stop_supervised` one was relevant
3. Do the docs make sense?