### PR TITLE
Make individual files in `escript.build` example better distinguishable

### DIFF
--- a/lib/mix/lib/mix/tasks/escript.build.ex
+++ b/lib/mix/lib/mix/tasks/escript.build.ex
@@ -101,27 +101,31 @@ defmodule Mix.Tasks.Escript.Build do
 
   ## Example
 
-      defmodule MyApp.MixProject do
-        use Mix.Project
+  * `mix.exs`:
 
-        def project do
-          [
-            app: :my_app,
-            version: "0.0.1",
-            escript: escript()
-          ]
+        defmodule MyApp.MixProject do
+          use Mix.Project
+
+          def project do
+            [
+              app: :my_app,
+              version: "0.0.1",
+              escript: escript()
+            ]
+          end
+
+          def escript do
+            [main_module: MyApp.CLI]
+          end
         end
 
-        def escript do
-          [main_module: MyApp.CLI]
-        end
-      end
+  * `lib/cli.ex`:
 
-      defmodule MyApp.CLI do
-        def main(_args) do
-          IO.puts("Hello from MyApp!")
+        defmodule MyApp.CLI do
+          def main(_args) do
+            IO.puts("Hello from MyApp!")
+          end
         end
-      end
 
   """
 


### PR DESCRIPTION
Previously it was not clear to everyone that the escripts entrypoint
can't be in the `mix.exs` file but has to be separate.

This resulted in rare cases where people asked in the elixir forum why
their escripts module wasn't found.

The proposed changes should make this a bit more clear, though could of
course be improved by some explaining words that accompany the 2 snippets.

Fixes #11770
