### PR TITLE
Add missing known tag `:describe_line` to ExUnit.Case docs

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -140,19 +140,19 @@ defmodule ExUnit.Case do
   The following tags are set automatically by ExUnit and are
   therefore reserved:
 
-    * `:module`     - the module on which the test was defined
+    * `:module` - the module on which the test was defined
 
-    * `:file`       - the file on which the test was defined
+    * `:file` - the file on which the test was defined
 
-    * `:line`       - the line on which the test was defined
+    * `:line` - the line on which the test was defined
 
-    * `:test`       - the test name
+    * `:test` - the test name
 
-    * `:async`      - if the test case is in async mode
+    * `:async` - if the test case is in async mode
 
     * `:registered` - used for `ExUnit.Case.register_attribute/3` values
 
-    * `:describe`   - the describe block the test belongs to
+    * `:describe` - the describe block the test belongs to
 
     * `:describe_line` - the line the describe block begins on
 

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -154,6 +154,8 @@ defmodule ExUnit.Case do
 
     * `:describe`   - the describe block the test belongs to
 
+    * `:describe_line` - the line the describe block begins on
+
   The following tags customize how tests behave:
 
     * `:capture_log` - see the "Log Capture" section below


### PR DESCRIPTION
- Add the missing `:describe_line` tag.
- Reformat the other bullets as this formatting is ignored in ex_doc output anyway and makes it consistent with other sections