### PR TITLE
ExUnit: Simplify tmp_dir dir name

### DIFF
--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -398,7 +398,7 @@ defmodule ExUnit.Runner do
 
   defp create_tmp_dir!(test, extra_path, context) do
     module_string = inspect(test.module)
-    name_string = to_string(test.name)
+    name_string = simplify_test_name(test.name)
 
     module = escape_path(module_string)
     name = escape_path(name_string)
@@ -408,6 +408,12 @@ defmodule ExUnit.Runner do
     File.rm_rf!(path)
     File.mkdir_p!(path)
     Map.put(context, :tmp_dir, path)
+  end
+
+  defp simplify_test_name(test_name) do
+    test_name
+    |> to_string()
+    |> String.trim_leading("test ")
   end
 
   @escape Enum.map(' [~#%&*{}\\:<>?/+|"]', &<<&1::utf8>>)

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -179,19 +179,19 @@ defmodule ExUnit.CaseTest.TmpDir do
   end
 
   test "default path", context do
-    assert starts_with_path?(context.tmp_dir, "tmp/ExUnit.CaseTest.TmpDir/test-default-path-")
+    assert starts_with_path?(context.tmp_dir, "tmp/ExUnit.CaseTest.TmpDir/default-path-")
     assert ends_with_short_hash?(context.tmp_dir)
     assert File.ls!(context.tmp_dir) == []
   end
 
   test "escapes foo?/0", context do
-    assert starts_with_path?(context.tmp_dir, "tmp/ExUnit.CaseTest.TmpDir/test-escapes-foo--0-")
+    assert starts_with_path?(context.tmp_dir, "tmp/ExUnit.CaseTest.TmpDir/escapes-foo--0-")
     assert ends_with_short_hash?(context.tmp_dir)
   end
 
   @tag tmp_dir: "foo/bar"
   test "custom path", context do
-    assert starts_with_path?(context.tmp_dir, "tmp/ExUnit.CaseTest.TmpDir/test-custom-path-")
+    assert starts_with_path?(context.tmp_dir, "tmp/ExUnit.CaseTest.TmpDir/custom-path-")
     assert ends_with_short_hash_and_extra_path?(context.tmp_dir, "foo/bar")
   end
 
@@ -204,19 +204,19 @@ defmodule ExUnit.CaseTest.TmpDir do
     test "foo-bar", context do
       assert starts_with_path?(
                context.tmp_dir,
-               "tmp/ExUnit.CaseTest.TmpDir/test-colliding-test-names-foo-bar-"
+               "tmp/ExUnit.CaseTest.TmpDir/colliding-test-names-foo-bar-"
              )
 
-      assert String.ends_with?(context.tmp_dir, "-2489e2ce")
+      assert String.ends_with?(context.tmp_dir, "-fc80bf03")
     end
 
     test "foo+bar", context do
       assert starts_with_path?(
                context.tmp_dir,
-               "tmp/ExUnit.CaseTest.TmpDir/test-colliding-test-names-foo-bar-"
+               "tmp/ExUnit.CaseTest.TmpDir/colliding-test-names-foo-bar-"
              )
 
-      assert String.ends_with?(context.tmp_dir, "-9633ed5f")
+      assert String.ends_with?(context.tmp_dir, "-05da7039")
     end
   end
 end


### PR DESCRIPTION
tmp_dir path could be quite long, so It strips \"test-\" from folder names,
which is redundant and repetitive in every since,
since by convention test modules ends with Test and the module name
is already included in the path.