### PR TITLE
Supress output in doctest in String module

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -213,8 +213,8 @@ defmodule String do
   Alternatively, you can view a string's binary representation by
   passing an option to `IO.inspect/2`:
 
-    iex> IO.inspect("héllo", binaries: :as_binaries)
-    <<104, 195, 169, 108, 108, 111>>
+      ...> IO.inspect("héllo", binaries: :as_binaries)
+      <<104, 195, 169, 108, 108, 111>>
 
   ## Self-synchronization
 

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -213,8 +213,8 @@ defmodule String do
   Alternatively, you can view a string's binary representation by
   passing an option to `IO.inspect/2`:
 
-      ...> IO.inspect("héllo", binaries: :as_binaries)
-      <<104, 195, 169, 108, 108, 111>>
+      IO.inspect("héllo", binaries: :as_binaries)
+      #=> <<104, 195, 169, 108, 108, 111>>
 
   ## Self-synchronization
 


### PR DESCRIPTION
`<<104, 195, 169, 108, 108, 111>>`  was being printed in the test output.