### PR TITLE
Remove warning in Kernel default tests

### DIFF
--- a/lib/elixir/test/elixir/kernel/defaults_test.exs
+++ b/lib/elixir/test/elixir/kernel/defaults_test.exs
@@ -69,12 +69,16 @@ defmodule Kernel.DefaultsTest do
       end
     end
 
-    assert_raise CompileError, ~r"undefined function foo/0", fn ->
-      defmodule Kernel.ErrorsTest.ClauseWithDefaults5 do
-        def hello(foo, bar \\ foo)
-        def hello(foo, bar), do: foo + bar
-      end
-    end
+    assert capture_io(:stderr, fn ->
+             assert_raise CompileError, ~r"undefined function foo/0", fn ->
+               defmodule Kernel.ErrorsTest.ClauseWithDefaults5 do
+                 def hello(foo, bar \\ foo)
+                 def hello(foo, bar), do: foo + bar
+               end
+             end
+           end) =~
+             "variable \"foo\" does not exist and is being expanded to \"foo()\", " <>
+               "please use parentheses to remove the ambiguity or change the variable name"
   end
 
   test "errors on conflicting defaults" do


### PR DESCRIPTION
The following warning was in the output of the test

    warning: variable "foo" does not exist and is being expanded to "foo()", please use parentheses to remove the ambiguity or change the variable name
    test/elixir/kernel/defaults_test.exs:75: Kernel.DefaultsTest.Kernel.ErrorsTest.ClauseWithDefaults5.hello/2