### PR TITLE
Ignore _build directory of test fixture apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /lib/*/tmp/
 /lib/elixir/src/*_parser.erl
 /lib/elixir/test/ebin/
+/lib/*/test/fixtures/*/_build/
+/lib/*/test/fixtures/*/apps/*/_build/
 /man/elixir.1
 /man/iex.1
 /Docs-v*.zip


### PR DESCRIPTION
When working in the repository, I get some non-ignored files that should probably be ignored so that they are not committed by accident:

```console
$ git status -s
?? lib/mix/test/fixtures/test_failed/_build/
?? lib/mix/test/fixtures/umbrella_test/apps/bar/_build/
?? lib/mix/test/fixtures/umbrella_test/apps/foo/_build/
```