### PR TITLE
Mix: Remove exclamation mark from message release command

### DIFF
--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -1302,7 +1302,7 @@ defmodule Mix.Tasks.Release do
 
     info(release, """
 
-    Release created at #{path}!
+    Release created at #{path}
 
         # To start your system
         #{cmd} start

--- a/lib/mix/test/mix/tasks/release_test.exs
+++ b/lib/mix/test/mix/tasks/release_test.exs
@@ -296,7 +296,7 @@ defmodule Mix.Tasks.ReleaseTest do
         assert_received {:mix_shell, :info, ["* assembling release_test-0.1.0 on MIX_ENV=dev"]}
 
         assert_received {:mix_shell, :info,
-                         ["\nRelease created at _build/dev/rel/release_test!" <> _]}
+                         ["\nRelease created at _build/dev/rel/release_test\n" <> _]}
 
         assert_received {:mix_shell, :info, ["* skipping runtime configuration" <> _]}
 


### PR DESCRIPTION
As it is confusing to have
"Release created at my_app!" as "!" is not part of the app name.