### PR TITLE
Use duoble # for comments in release script

### DIFF
--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -60,7 +60,7 @@ defmodule Mix.Tasks.Release.Init do
     do: ~S"""
     #!/bin/sh
 
-    # Sets and enables heart (recommended only in daemon mode)
+    ## Sets and enables heart (recommended only in daemon mode)
     # case $RELEASE_COMMAND in
     #   daemon*)
     #     HEART_COMMAND="$RELEASE_ROOT/bin/$RELEASE_NAME $RELEASE_COMMAND"
@@ -71,8 +71,8 @@ defmodule Mix.Tasks.Release.Init do
     #     ;;
     # esac
 
-    # Set the release to work across nodes.
-    # RELEASE_DISTRIBUTION must be "sname" (local), "name" (distributed) or "none".
+    ## Set the release to work across nodes.
+    ## RELEASE_DISTRIBUTION must be "sname" (local), "name" (distributed) or "none".
     # export RELEASE_DISTRIBUTION=name
     # export RELEASE_NODE=<%= @release.name %>
     """

--- a/lib/mix/lib/mix/tasks/release.init.ex
+++ b/lib/mix/lib/mix/tasks/release.init.ex
@@ -60,7 +60,7 @@ defmodule Mix.Tasks.Release.Init do
     do: ~S"""
     #!/bin/sh
 
-    ## Sets and enables heart (recommended only in daemon mode)
+    # # Sets and enables heart (recommended only in daemon mode)
     # case $RELEASE_COMMAND in
     #   daemon*)
     #     HEART_COMMAND="$RELEASE_ROOT/bin/$RELEASE_NAME $RELEASE_COMMAND"
@@ -71,8 +71,8 @@ defmodule Mix.Tasks.Release.Init do
     #     ;;
     # esac
 
-    ## Set the release to work across nodes.
-    ## RELEASE_DISTRIBUTION must be "sname" (local), "name" (distributed) or "none".
+    # # Set the release to work across nodes.
+    # # RELEASE_DISTRIBUTION must be "sname" (local), "name" (distributed) or "none".
     # export RELEASE_DISTRIBUTION=name
     # export RELEASE_NODE=<%= @release.name %>
     """


### PR DESCRIPTION
Use ## for comments, so when the whole block is comment out, comments stay as comments.