### PR TITLE
Fix ExUnit.Callbacks.start_link_supervised!/2 spec

### DIFF
--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -455,7 +455,7 @@ defmodule ExUnit.Callbacks do
   """
   @doc since: "1.14.0"
   @spec start_link_supervised!(Supervisor.child_spec() | module | {module, term}, keyword) ::
-          Supervisor.on_start_child()
+          pid
   def start_link_supervised!(child_spec_or_module, opts \\ []) do
     pid = start_supervised!(child_spec_or_module, opts)
     Process.link(pid)


### PR DESCRIPTION
Found by [dialyzer](https://github.com/michallepicki/elixir-lang-dialyzer-runs/runs/6167409296?check_suite_focus=true) :)