### PR TITLE
Update IEx.Helpers docs for open/1

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -260,6 +260,13 @@ defmodule IEx.Helpers do
 
       subl path/to/file:line
 
+  If you are using Visual Studio Code, the pre-requirement for Mac users
+  is to have the `code` [command enabled](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line).
+  Once you have it, the value of the `ELIXIR_EDITOR` variable
+  should be:
+
+      ELIXIR_EDITOR="code --goto"
+
   It is important that you choose an editor command that does
   not block nor that attempts to run an editor directly in the
   terminal. Command-line based editors likely need extra

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -255,15 +255,17 @@ defmodule IEx.Helpers do
   and falls back to `EDITOR` if the former is not available.
 
   By default, it attempts to open the file and line using the
-  `file:line` notation. For example, if your editor is called
-  `subl`, it will open the file as:
+  `file:line` notation. For example, for Sublime Text you can
+  set it as:
 
+      ELIXIR_EDITOR="subl"
+
+  Which will then try to open it as:
+  
       subl path/to/file:line
 
-  If you are using Visual Studio Code, the pre-requirement for Mac users
-  is to have the `code` [command enabled](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line).
-  Once you have it, the value of the `ELIXIR_EDITOR` variable
-  should be:
+  For Visual Studio Code, once enabled on the command line,
+  you can set it to:
 
       ELIXIR_EDITOR="code --goto"
 
@@ -273,12 +275,11 @@ defmodule IEx.Helpers do
   configuration so they open up the given file and line in a
   separate window.
 
-  Custom editors are supported by using the `__FILE__` and
-  `__LINE__` notations, for example:
+  For more complex use cases, you can use the `__FILE__` and
+  `__LINE__` notations to explicitly interpolate the file and
+  line into the command:
 
       ELIXIR_EDITOR="my_editor +__LINE__ __FILE__"
-
-  and Elixir will properly interpolate values.
 
   Since this function prints the result returned by the editor,
   `ELIXIR_EDITOR` can be set "echo" if you prefer to display the


### PR DESCRIPTION
VS Code seems to be the most popular editor these days, and it requires a parameter `--goto` for opening files.

I spent a few trials and one web search before I found this out and thought that may be useful for others.