### PR TITLE
Add ExUnit.run/1 to rerun test modules

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -359,7 +359,8 @@ defmodule ExUnit do
   @spec run(list(atom)) :: suite_result()
   def run(additional_modules \\ []) do
     for module <- additional_modules do
-      module_attributes = module.__info__(:attributes) |> IO.inspect()
+      module_attributes = module.__info__(:attributes)
+
       if Keyword.get(module_attributes, :ex_unit_async) do
         ExUnit.Server.add_async_module(module)
       else

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -350,26 +350,21 @@ defmodule ExUnit do
   Runs the tests. It is invoked automatically
   if ExUnit is started via `start/1`.
 
-  Returns a map containing the total number of tests, the number
-  of failures, the number of excluded tests and the number of skipped tests.
-  """
-  @spec run() :: suite_result()
-  def run do
-    _ = ExUnit.Server.modules_loaded()
-    options = persist_defaults(configuration())
-    ExUnit.Runner.run(options, nil)
-  end
-
-  @doc """
-  Rerun the given test modules synchronously.
+  It accepts an optional list of modules to rerun
+  the tests of specified modules.
 
   Returns a map containing the total number of tests, the number
   of failures, the number of excluded tests and the number of skipped tests.
   """
-  @spec rerun(list(atom())) :: suite_result()
-  def rerun(modules) do
-    for module <- modules do
-      ExUnit.Server.add_sync_module(module)
+  @spec run(list(atom)) :: suite_result()
+  def run(additional_modules \\ []) do
+    for module <- additional_modules do
+      module_attributes = module.__info__(:attributes) |> IO.inspect()
+      if Keyword.get(module_attributes, :ex_unit_async) do
+        ExUnit.Server.add_async_module(module)
+      else
+        ExUnit.Server.add_sync_module(module)
+      end
     end
 
     _ = ExUnit.Server.modules_loaded()

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -350,8 +350,9 @@ defmodule ExUnit do
   Runs the tests. It is invoked automatically
   if ExUnit is started via `start/1`.
 
-  It accepts an optional list of modules to rerun
-  the tests of specified modules.
+  From Elixir v1.14, it accepts an optional list of modules to run
+  as part of the suite. This is often used to rerun modules already
+  loaded in memory.
 
   Returns a map containing the total number of tests, the number
   of failures, the number of excluded tests and the number of skipped tests.

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -361,6 +361,23 @@ defmodule ExUnit do
   end
 
   @doc """
+  Rerun the given test modules synchronously.
+
+  Returns a map containing the total number of tests, the number
+  of failures, the number of excluded tests and the number of skipped tests.
+  """
+  @spec rerun(list(atom())) :: suite_result()
+  def rerun(modules) do
+    for module <- modules do
+      ExUnit.Server.add_sync_module(module)
+    end
+
+    _ = ExUnit.Server.modules_loaded()
+    options = persist_defaults(configuration())
+    ExUnit.Runner.run(options, nil)
+  end
+
+  @doc """
   Starts tests asynchronously while test cases are still loading.
 
   It returns a task that must be given to `await_run/0` when a result

--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -294,6 +294,9 @@ defmodule ExUnit.Case do
 
       Enum.each(attributes, &Module.register_attribute(module, &1, accumulate: true))
 
+      persisted_attributes = [:ex_unit_async]
+      Enum.each(persisted_attributes, &Module.register_attribute(module, &1, persist: true))
+
       attributes = [
         before_compile: ExUnit.Case,
         after_compile: ExUnit.Case,

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -32,15 +32,27 @@ defmodule ExUnitTest do
            end) =~ "\n0 failures\n"
   end
 
-  test "supports reruns" do
+  test "supports rerunning given modules" do
     defmodule SampleAsyncTest do
       use ExUnit.Case, async: true
 
       test "true" do
         assert false
       end
+    end
 
-      test "false" do
+    defmodule SampleSyncTest do
+      use ExUnit.Case
+
+      test "true" do
+        assert false
+      end
+    end
+
+    defmodule IgnoreTest do
+      use ExUnit.Case
+
+      test "true" do
         assert false
       end
     end
@@ -49,15 +61,15 @@ defmodule ExUnitTest do
 
     assert capture_io(fn ->
              assert ExUnit.run() == %{
-                      failures: 2,
+                      failures: 3,
                       skipped: 0,
-                      total: 2,
+                      total: 3,
                       excluded: 0
                     }
-           end) =~ "\n2 tests, 2 failures\n"
+           end) =~ "\n3 tests, 3 failures\n"
 
     assert capture_io(fn ->
-             assert ExUnit.rerun([SampleAsyncTest]) == %{
+             assert ExUnit.run([SampleSyncTest, SampleAsyncTest]) == %{
                       failures: 2,
                       skipped: 0,
                       total: 2,

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -32,6 +32,40 @@ defmodule ExUnitTest do
            end) =~ "\n0 failures\n"
   end
 
+  test "supports reruns" do
+    defmodule SampleAsyncTest do
+      use ExUnit.Case, async: true
+
+      test "true" do
+        assert false
+      end
+
+      test "false" do
+        assert false
+      end
+    end
+
+    configure_and_reload_on_exit([])
+
+    assert capture_io(fn ->
+             assert ExUnit.run() == %{
+                      failures: 2,
+                      skipped: 0,
+                      total: 2,
+                      excluded: 0
+                    }
+           end) =~ "\n2 tests, 2 failures\n"
+
+    assert capture_io(fn ->
+             assert ExUnit.rerun([SampleAsyncTest]) == %{
+                      failures: 2,
+                      skipped: 0,
+                      total: 2,
+                      excluded: 0
+                    }
+           end) =~ "\n2 tests, 2 failures\n"
+  end
+
   test "prints aborted runs on sigquit", config do
     Process.register(self(), :aborted_on_sigquit)
     line = __ENV__.line + 5


### PR DESCRIPTION
This PR add `ExUnit.rerun/1` to rerun tests given a list of test modules.

### Context

Often times, when writing a tutorial in Livebook, I want to write a test case for
the users so they could interactively write some code to make it pass. This is especially
helpful when we use Livebook as a teaching medium.

Currently, there are no ways to support ruruning a test without rewriting it. 

### Proposed solution

Add `ExUnit.rerun/1` to take in a list of test modules to be rerun:

```elixir
defmodule SampleTest do
  use ExUnit.Case
  
  test "true" do
     assert false
  end
end

ExUnit.rerun([SampleTest])
```

For more, refer to the [proposal in the mailing list](https://groups.google.com/g/elixir-lang-core/c/KCNzR5Kv0Qg)