### PR TITLE
Store :mfa in the Task struct

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -234,7 +234,7 @@ defmodule Task do
 
   """
   @enforce_keys [:pid, :ref, :owner, :mfa]
-  defstruct [:pid, :ref, :owner, :mfa]
+  defstruct @enforce_keys
 
   @typedoc """
   The Task type.
@@ -441,7 +441,7 @@ defmodule Task do
 
   Similar to `async/1` except the function to be started is
   specified by the given `module`, `function_name`, and `args`.
-  The `module`, `function_name`, and its arity is stored as
+  The `module`, `function_name`, and its arity are stored as
   a tuple in the `:mfa` field for reflection purposes.
   """
   @spec async(module, atom, [term]) :: t

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -233,8 +233,8 @@ defmodule Task do
     * `:owner` - the PID of the process that started the task
 
   """
-  @enforce_keys [:pid, :ref, :owner]
-  defstruct pid: nil, ref: nil, owner: nil
+  @enforce_keys [:pid, :ref, :owner, :mfa]
+  defstruct [:pid, :ref, :owner, :mfa]
 
   @typedoc """
   The Task type.
@@ -244,7 +244,8 @@ defmodule Task do
   @type t :: %__MODULE__{
           pid: pid() | nil,
           ref: reference(),
-          owner: pid()
+          owner: pid(),
+          mfa: mfa()
         }
 
   defguardp is_timeout(timeout)
@@ -420,6 +421,12 @@ defmodule Task do
       to any supervisor, you may leave dangling tasks in case
       the caller process dies.
 
+  ## Metadata
+
+  The task created with this function stores `:erlang.apply/2` in
+  its `:mfa` metadata field, which is used internally to apply
+  the anonymous function. Use `async/3` if you want another function
+  to be used as metadata.
   """
   @spec async((() -> any)) :: t
   def async(fun) when is_function(fun, 0) do
@@ -434,11 +441,13 @@ defmodule Task do
 
   Similar to `async/1` except the function to be started is
   specified by the given `module`, `function_name`, and `args`.
+  The `module`, `function_name`, and its arity is stored as
+  a tuple in the `:mfa` field for reflection purposes.
   """
   @spec async(module, atom, [term]) :: t
   def async(module, function_name, args)
       when is_atom(module) and is_atom(function_name) and is_list(args) do
-    mfa = {module, function_name, args}
+    mfargs = {module, function_name, args}
     owner = self()
     {:ok, pid} = Task.Supervised.start_link(get_owner(owner), :nomonitor)
 
@@ -450,8 +459,8 @@ defmodule Task do
         {owner, Process.monitor(pid)}
       end
 
-    send(pid, {owner, ref, reply_to, get_callers(owner), mfa})
-    %Task{pid: pid, ref: ref, owner: owner}
+    send(pid, {owner, ref, reply_to, get_callers(owner), mfargs})
+    %Task{pid: pid, ref: ref, owner: owner, mfa: {module, function_name, length(args)}}
   end
 
   @doc """
@@ -494,7 +503,7 @@ defmodule Task do
     # "complete" the task immediately
     send(owner, {ref, result})
 
-    %Task{pid: nil, ref: ref, owner: owner}
+    %Task{pid: nil, ref: ref, owner: owner, mfa: {Task, :completed, 1}}
   end
 
   @doc """

--- a/lib/elixir/lib/task/supervisor.ex
+++ b/lib/elixir/lib/task/supervisor.ex
@@ -524,7 +524,7 @@ defmodule Task.Supervisor do
           end
 
         send(pid, {owner, ref, reply_to, get_callers(owner), {module, fun, args}})
-        %Task{pid: pid, ref: ref, owner: owner}
+        %Task{pid: pid, ref: ref, owner: owner, mfa: {module, fun, length(args)}}
 
       {:error, :max_children} ->
         raise """

--- a/lib/elixir/test/elixir/task/supervisor_test.exs
+++ b/lib/elixir/test/elixir/task/supervisor_test.exs
@@ -146,6 +146,7 @@ defmodule Task.SupervisorTest do
 
     send(task.pid, true)
     assert task.__struct__ == Task
+    assert task.mfa == {__MODULE__, :wait_and_send, 2}
     assert Task.await(task) == :done
   end
 
@@ -160,6 +161,7 @@ defmodule Task.SupervisorTest do
       assert task.__struct__ == Task
       assert is_pid(task.pid)
       assert is_reference(task.ref)
+      assert task.mfa == {:erlang, :apply, 2}
 
       # Refute the link
       {:links, links} = Process.info(self(), :links)
@@ -212,6 +214,7 @@ defmodule Task.SupervisorTest do
 
     send(task.pid, true)
     assert task.__struct__ == Task
+    assert task.mfa == {__MODULE__, :wait_and_send, 2}
     assert Task.await(task) == :done
   end
 

--- a/lib/elixir/test/elixir/task_test.exs
+++ b/lib/elixir/test/elixir/task_test.exs
@@ -22,7 +22,7 @@ defmodule TaskTest do
 
     receive do
       {:DOWN, ^ref, _, _, _} ->
-        %Task{ref: ref, pid: pid, owner: self()}
+        %Task{ref: ref, pid: pid, owner: self(), mfa: {__MODULE__, :create_dummy_task, 1}}
     end
   end
 
@@ -72,6 +72,7 @@ defmodule TaskTest do
     assert task.__struct__ == Task
     assert is_pid(task.pid)
     assert is_reference(task.ref)
+    assert task.mfa == {:erlang, :apply, 2}
 
     # Assert the link
     {:links, links} = Process.info(self(), :links)
@@ -95,6 +96,7 @@ defmodule TaskTest do
   test "async/3" do
     task = Task.async(__MODULE__, :wait_and_send, [self(), :done])
     assert task.__struct__ == Task
+    assert task.mfa == {__MODULE__, :wait_and_send, 2}
 
     {:links, links} = Process.info(self(), :links)
     assert task.pid in links
@@ -244,7 +246,7 @@ defmodule TaskTest do
 
       test "exits on :noconnection" do
         ref = make_ref()
-        task = %Task{ref: ref, pid: self(), owner: self()}
+        task = %Task{ref: ref, pid: self(), owner: self(), mfa: {__MODULE__, :test, 1}}
         send(self(), {:DOWN, ref, self(), self(), :noconnection})
         assert catch_exit(Task.ignore(task)) |> elem(0) == {:nodedown, :nonode@nohost}
       end
@@ -271,7 +273,7 @@ defmodule TaskTest do
     end
 
     test "exits on timeout" do
-      task = %Task{ref: make_ref(), owner: self(), pid: nil}
+      task = %Task{ref: make_ref(), owner: self(), pid: nil, mfa: {__MODULE__, :test, 1}}
       assert catch_exit(Task.await(task, 0)) == {:timeout, {Task, :await, [task, 0]}}
     end
 
@@ -323,14 +325,14 @@ defmodule TaskTest do
 
     test "exits on :noconnection" do
       ref = make_ref()
-      task = %Task{ref: ref, pid: self(), owner: self()}
+      task = %Task{ref: ref, pid: self(), owner: self(), mfa: {__MODULE__, :test, 1}}
       send(self(), {:DOWN, ref, :process, self(), :noconnection})
       assert catch_exit(Task.await(task)) |> elem(0) == {:nodedown, :nonode@nohost}
     end
 
     test "exits on :noconnection from named monitor" do
       ref = make_ref()
-      task = %Task{ref: ref, owner: self(), pid: nil}
+      task = %Task{ref: ref, owner: self(), pid: nil, mfa: {__MODULE__, :test, 1}}
       send(self(), {:DOWN, ref, :process, {:name, :node}, :noconnection})
       assert catch_exit(Task.await(task)) |> elem(0) == {:nodedown, :node}
     end
@@ -354,7 +356,12 @@ defmodule TaskTest do
 
     test "returns replies in input order ignoring response order" do
       refs = [ref_1 = make_ref(), ref_2 = make_ref(), ref_3 = make_ref()]
-      tasks = Enum.map(refs, fn ref -> %Task{ref: ref, owner: self(), pid: nil} end)
+
+      tasks =
+        Enum.map(refs, fn ref ->
+          %Task{ref: ref, owner: self(), pid: nil, mfa: {__MODULE__, :test, 1}}
+        end)
+
       send(self(), {ref_2, 3})
       send(self(), {ref_3, 9})
       send(self(), {ref_1, 1})
@@ -379,7 +386,12 @@ defmodule TaskTest do
 
     test "ignores additional messages after reply" do
       refs = [ref_1 = make_ref(), ref_2 = make_ref()]
-      tasks = Enum.map(refs, fn ref -> %Task{ref: ref, owner: self(), pid: nil} end)
+
+      tasks =
+        Enum.map(refs, fn ref ->
+          %Task{ref: ref, owner: self(), pid: nil, mfa: {__MODULE__, :test, 1}}
+        end)
+
       send(self(), {ref_2, :b})
       send(self(), {ref_2, :other})
       send(self(), {ref_1, :a})
@@ -448,7 +460,7 @@ defmodule TaskTest do
     test "exits immediately on :noconnection" do
       tasks = [
         Task.async(fn -> Process.sleep(:infinity) end),
-        %Task{ref: ref = make_ref(), owner: self(), pid: self()}
+        %Task{ref: ref = make_ref(), owner: self(), pid: self(), mfa: {__MODULE__, :test, 1}}
       ]
 
       send(self(), {:DOWN, ref, :process, self(), :noconnection})
@@ -458,7 +470,7 @@ defmodule TaskTest do
     test "exits immediately on :noconnection from named monitor" do
       tasks = [
         Task.async(fn -> Process.sleep(:infinity) end),
-        %Task{ref: ref = make_ref(), owner: self(), pid: nil}
+        %Task{ref: ref = make_ref(), owner: self(), pid: nil, mfa: {__MODULE__, :test, 1}}
       ]
 
       send(self(), {:DOWN, ref, :process, {:name, :node}, :noconnection})
@@ -481,7 +493,7 @@ defmodule TaskTest do
 
   describe "yield/2" do
     test "returns {:ok, result} when reply and :DOWN in message queue" do
-      task = %Task{ref: make_ref(), owner: self(), pid: nil}
+      task = %Task{ref: make_ref(), owner: self(), pid: nil, mfa: {__MODULE__, :test, 1}}
       send(self(), {task.ref, :result})
       send(self(), {:DOWN, task.ref, :process, self(), :abnormal})
       assert Task.yield(task, 0) == {:ok, :result}
@@ -489,7 +501,7 @@ defmodule TaskTest do
     end
 
     test "returns nil on timeout" do
-      task = %Task{ref: make_ref(), pid: nil, owner: self()}
+      task = %Task{ref: make_ref(), pid: nil, owner: self(), mfa: {__MODULE__, :test, 1}}
       assert Task.yield(task, 0) == nil
     end
 
@@ -500,7 +512,7 @@ defmodule TaskTest do
 
     test "exits on :noconnection" do
       ref = make_ref()
-      task = %Task{ref: ref, pid: self(), owner: self()}
+      task = %Task{ref: ref, pid: self(), owner: self(), mfa: {__MODULE__, :test, 1}}
       send(self(), {:DOWN, ref, self(), self(), :noconnection})
       assert catch_exit(Task.yield(task)) |> elem(0) == {:nodedown, :nonode@nohost}
     end
@@ -518,7 +530,7 @@ defmodule TaskTest do
 
   describe "yield_many/2" do
     test "returns {:ok, result} when reply and :DOWN in message queue" do
-      task = %Task{ref: make_ref(), owner: self(), pid: nil}
+      task = %Task{ref: make_ref(), owner: self(), pid: nil, mfa: {__MODULE__, :test, 1}}
       send(self(), {task.ref, :result})
       send(self(), {:DOWN, task.ref, :process, self(), :abnormal})
       assert Task.yield_many([task], 0) == [{task, {:ok, :result}}]
@@ -526,7 +538,7 @@ defmodule TaskTest do
     end
 
     test "returns nil on timeout" do
-      task = %Task{ref: make_ref(), owner: self(), pid: nil}
+      task = %Task{ref: make_ref(), owner: self(), pid: nil, mfa: {__MODULE__, :test, 1}}
       assert Task.yield_many([task], 0) == [{task, nil}]
     end
 
@@ -537,7 +549,7 @@ defmodule TaskTest do
 
     test "exits on :noconnection" do
       ref = make_ref()
-      task = %Task{ref: ref, pid: self(), owner: self()}
+      task = %Task{ref: ref, pid: self(), owner: self(), mfa: {__MODULE__, :test, 1}}
       send(self(), {:DOWN, ref, :process, self(), :noconnection})
       assert catch_exit(Task.yield_many([task])) |> elem(0) == {:nodedown, :nonode@nohost}
     end
@@ -553,9 +565,9 @@ defmodule TaskTest do
     end
 
     test "returns results from multiple tasks" do
-      task1 = %Task{ref: make_ref(), owner: self(), pid: nil}
-      task2 = %Task{ref: make_ref(), owner: self(), pid: nil}
-      task3 = %Task{ref: make_ref(), owner: self(), pid: nil}
+      task1 = %Task{ref: make_ref(), owner: self(), pid: nil, mfa: {__MODULE__, :test, 1}}
+      task2 = %Task{ref: make_ref(), owner: self(), pid: nil, mfa: {__MODULE__, :test, 1}}
+      task3 = %Task{ref: make_ref(), owner: self(), pid: nil, mfa: {__MODULE__, :test, 1}}
 
       send(self(), {task1.ref, :result})
       send(self(), {:DOWN, task3.ref, :process, self(), :normal})
@@ -565,9 +577,9 @@ defmodule TaskTest do
     end
 
     test "returns results on infinity timeout" do
-      task1 = %Task{ref: make_ref(), owner: self(), pid: nil}
-      task2 = %Task{ref: make_ref(), owner: self(), pid: nil}
-      task3 = %Task{ref: make_ref(), owner: self(), pid: nil}
+      task1 = %Task{ref: make_ref(), owner: self(), pid: nil, mfa: {__MODULE__, :test, 1}}
+      task2 = %Task{ref: make_ref(), owner: self(), pid: nil, mfa: {__MODULE__, :test, 1}}
+      task3 = %Task{ref: make_ref(), owner: self(), pid: nil, mfa: {__MODULE__, :test, 1}}
 
       send(self(), {task1.ref, :result})
       send(self(), {task2.ref, :result})
@@ -641,7 +653,7 @@ defmodule TaskTest do
     end
 
     test "raises if task PID is nil" do
-      task = %Task{ref: make_ref(), owner: nil, pid: nil}
+      task = %Task{ref: make_ref(), owner: nil, pid: nil, mfa: {__MODULE__, :test, 1}}
       message = "task #{inspect(task)} does not have an associated task process"
       assert_raise ArgumentError, message, fn -> Task.shutdown(task) end
     end


### PR DESCRIPTION
This field can be used for reflection purposes.

Closes #11716.
Closes #11720.