### PR TITLE
Skip empty files during `mix format`

### DIFF
--- a/lib/elixir/test/elixir/code_test.exs
+++ b/lib/elixir/test/elixir/code_test.exs
@@ -262,6 +262,10 @@ defmodule CodeTest do
     end
   end
 
+  test "format_string/2 returns empty iodata for empty string" do
+    assert Code.format_string!("") == []
+  end
+
   test "ensure_loaded?/1" do
     assert Code.ensure_loaded?(__MODULE__)
     refute Code.ensure_loaded?(Code.NoFile)

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -544,6 +544,8 @@ defmodule Mix.Tasks.Format do
   defp stdin_or_wildcard("-"), do: [:stdin]
   defp stdin_or_wildcard(path), do: path |> Path.expand() |> Path.wildcard(match_dot: true)
 
+  defp elixir_format("", _formatter_opts), do: ""
+
   defp elixir_format(content, formatter_opts) do
     IO.iodata_to_binary([Code.format_string!(content, formatter_opts), ?\n])
   end

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -15,6 +15,16 @@ defmodule Mix.Tasks.FormatTest do
     end
   end
 
+  test "doesn't format empty lines into line breaks", context do
+    in_tmp(context.test, fn ->
+      File.write!("a.exs", "")
+
+      Mix.Tasks.Format.run(["a.exs"])
+
+      assert File.read!("a.exs") == ""
+    end)
+  end
+
   test "formats the given files", context do
     in_tmp(context.test, fn ->
       File.write!("a.ex", """


### PR DESCRIPTION
Previously it was adding an empty line to empty files during the `mix format` task.
This PR makes it so empty files are skipped and remain unchanged.

Fixes #11800