### PR TITLE
Add allow_nonexistent_atoms to OptionParser spec

### DIFF
--- a/lib/elixir/lib/option_parser.ex
+++ b/lib/elixir/lib/option_parser.ex
@@ -29,7 +29,12 @@ defmodule OptionParser do
   @type argv :: [String.t()]
   @type parsed :: keyword
   @type errors :: [{String.t(), String.t() | nil}]
-  @type options :: [switches: keyword, strict: keyword, aliases: keyword]
+  @type options :: [
+          switches: keyword,
+          strict: keyword,
+          aliases: keyword,
+          allow_nonexistent_atoms: boolean
+        ]
 
   defmodule ParseError do
     defexception [:message]


### PR DESCRIPTION
This option was missing and it caused a Dialyzer error when used.
