### PR TITLE
Optimize Enum.sort_by/3 when sorter is :desc

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -3227,7 +3227,16 @@ defmodule Enum do
         ) ::
           list
         when mapped_element: element
-  def sort_by(enumerable, mapper, sorter \\ &<=/2) do
+  def sort_by(enumerable, mapper, sorter \\ &<=/2)
+
+  def sort_by(enumerable, mapper, :desc) when is_function(mapper, 1) do
+    enumerable
+    |> Enum.reduce([], &[{&1, mapper.(&1)} | &2])
+    |> List.keysort(1, :asc)
+    |> List.foldl([], &[elem(&1, 0) | &2])
+  end
+
+  def sort_by(enumerable, mapper, sorter) when is_function(mapper, 1) do
     enumerable
     |> map(&{&1, mapper.(&1)})
     |> List.keysort(1, sorter)


### PR DESCRIPTION
The speed increase goes from 47% up to 93% for enumerables of up to 100,000 elements.

Benchmark results: https://gist.github.com/eksperimental/c9ed94e418b4caa7fe61aff65b18c836
Benchmark repo: https://github.com/eksperimental/benchmark/tree/enum_sort_by

The optmization is done by saving unnecesary traversing of the list when sorting descendenly.