### PR TITLE
Update README instructions for cloning ex_doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ to be installed and built alongside Elixir:
 
 ```sh
 # After cloning and compiling Elixir, in its parent directory:
-git clone git://github.com/elixir-lang/ex_doc.git
+git clone https://github.com/elixir-lang/ex_doc.git
 cd ex_doc && ../elixir/bin/mix do deps.get + compile
 ```
 


### PR DESCRIPTION
GitHub says: The unauthenticated git protocol on port 9418 is no longer
supported.

```
$ git clone git://github.com/elixir-lang/ex_doc.git
Cloning into 'ex_doc'...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

$ git clone https://github.com/elixir-lang/ex_doc.git
Cloning into 'ex_doc'...
remote: Enumerating objects: 18840, done.
remote: Counting objects: 100% (2920/2920), done.
remote: Compressing objects: 100% (1208/1208), done.
remote: Total 18840 (delta 1813), reused 2539 (delta 1638), pack-reused 15920
Receiving objects: 100% (18840/18840), 11.29 MiB | 22.24 MiB/s, done.
Resolving deltas: 100% (10856/10856), done.
```