### PR TITLE
Support filename in `mix format -` when reading from stdin

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -66,6 +66,11 @@ defmodule Mix.Tasks.Format do
       Defaults to `.formatter.exs` if one is available. See the
       "Formatting options" section above for more information.
 
+    * `--stdin-filename` - path to the file being formatted on stdin.
+      This is useful if you are using plugins to support custom filetypes such
+      as `.heex`. Without passing this flag, it is assumed that the code being
+      passed via stdin is valid Elixir code.
+
   ## When to format code
 
   We recommend developers to format code directly in their editors, either
@@ -166,7 +171,8 @@ defmodule Mix.Tasks.Format do
     check_equivalent: :boolean,
     check_formatted: :boolean,
     dot_formatter: :string,
-    dry_run: :boolean
+    dry_run: :boolean,
+    stdin_filename: :string
   ]
 
   @manifest "cached_dot_formatter"

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -460,14 +460,12 @@ defmodule Mix.Tasks.Format do
 
     for file <- files do
       if file == :stdin do
-        if stdin_filename = Keyword.get(opts, :stdin_filename) do
-          {formatter, _opts} =
-            find_formatter_and_opts_for_file(stdin_filename, {formatter_opts, subs})
+        stdin_filename = Keyword.get(opts, :stdin_filename, "stdin")
 
-          {file, formatter}
-        else
-          {file, &elixir_format(&1, [file: "stdin"] ++ formatter_opts)}
-        end
+        {formatter, _opts} =
+          find_formatter_and_opts_for_file(stdin_filename, {formatter_opts, subs})
+
+        {file, formatter}
       else
         {formatter, _opts} = find_formatter_and_opts_for_file(file, {formatter_opts, subs})
         {file, formatter}
@@ -519,7 +517,7 @@ defmodule Mix.Tasks.Format do
       plugin = find_plugin_for_extension(formatter_opts, ext) ->
         &plugin.format(&1, [extension: ext, file: file] ++ formatter_opts)
 
-      ext in ~w(.ex .exs) ->
+      ext in ~w(.ex .exs) or file == "stdin" ->
         &elixir_format(&1, [file: file] ++ formatter_opts)
 
       true ->

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -69,7 +69,7 @@ defmodule Mix.Tasks.Format do
     * `--stdin-filename` - path to the file being formatted on stdin.
       This is useful if you are using plugins to support custom filetypes such
       as `.heex`. Without passing this flag, it is assumed that the code being
-      passed via stdin is valid Elixir code.
+      passed via stdin is valid Elixir code. Defaults to "stdin.exs".
 
   ## When to format code
 

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -460,7 +460,7 @@ defmodule Mix.Tasks.Format do
 
     for file <- files do
       if file == :stdin do
-        stdin_filename = Keyword.get(opts, :stdin_filename, "stdin")
+        stdin_filename = Keyword.get(opts, :stdin_filename, "stdin.exs")
 
         {formatter, _opts} =
           find_formatter_and_opts_for_file(stdin_filename, {formatter_opts, subs})
@@ -517,7 +517,7 @@ defmodule Mix.Tasks.Format do
       plugin = find_plugin_for_extension(formatter_opts, ext) ->
         &plugin.format(&1, [extension: ext, file: file] ++ formatter_opts)
 
-      ext in ~w(.ex .exs) or file == "stdin" ->
+      ext in ~w(.ex .exs) ->
         &elixir_format(&1, [file: file] ++ formatter_opts)
 
       true ->

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -298,6 +298,30 @@ defmodule Mix.Tasks.FormatTest do
     end)
   end
 
+  test "uses extension plugins with --stdin-filename", context do
+    in_tmp(context.test, fn ->
+      File.write!(".formatter.exs", """
+      [
+        inputs: ["a.w"],
+        plugins: [ExtensionWPlugin],
+        from_formatter_exs: :yes
+      ]
+      """)
+
+      output =
+        capture_io("foo bar baz", fn ->
+          Mix.Tasks.Format.run(["--stdin-filename", Path.join(File.cwd!(), "a.w"), "-"])
+        end)
+
+      assert output ==
+               String.trim("""
+               foo
+               bar
+               baz
+               """)
+    end)
+  end
+
   test "uses inputs and configuration from --dot-formatter", context do
     in_tmp(context.test, fn ->
       File.write!("custom_formatter.exs", """

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -636,7 +636,7 @@ defmodule Mix.Tasks.FormatTest do
 
   test "raises SyntaxError when parsing invalid stdin", context do
     in_tmp(context.test, fn ->
-      assert_raise SyntaxError, ~r"stdin:1:13: syntax error before: '='", fn ->
+      assert_raise SyntaxError, ~r"stdin.exs:1:13: syntax error before: '='", fn ->
         capture_io("defmodule <%= module %>.Bar do end", fn ->
           Mix.Tasks.Format.run(["-"])
         end)


### PR DESCRIPTION
Fixes #11817

For better integration with editors when using plugins (e.g. the `.heex` support from `Phoenix.LiveView.HTMLFormatter`), it's useful to be able to pipe data to `mix format` over stdin while preserving support for plugins. Prior to this, stdin was always assumed to be elixir code.

```sh
$ echo "<div>\nhello</div>" | ../../elixir/bin/elixir ../../elixir/bin/mix format --stdin-filename test.html.heex -
<div>
  hello
</div>

$ cat .formatter.exs                                                                                 
[
  import_deps: [:ecto, :phoenix],
  plugins: [Phoenix.LiveView.HTMLFormatter],
  inputs: ["*.{ex,exs,heex}", "priv/*/seeds.exs", "{config,lib,test}/**/*.{ex,exs,heex}"],
  subdirectories: ["priv/*/migrations"]
]
```

Without specifying the filename:
```sh
$ echo "<div>\nhello</div>" | ../../elixir/bin/elixir ../../elixir/bin/mix format  -                               
mix format failed for stdin
** (SyntaxError) stdin:1:1: syntax error before: '<'
    |
  1 | <div>
    | ^
    (elixir 1.14.0-dev) lib/code.ex:756: Code.format_string!/2
    (mix 1.14.0-dev) lib/mix/tasks/format.ex:561: Mix.Tasks.Format.elixir_format/2
    (mix 1.14.0-dev) lib/mix/tasks/format.ex:580: Mix.Tasks.Format.format_file/2
    (elixir 1.14.0-dev) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
    (elixir 1.14.0-dev) lib/task/supervised.ex:34: Task.Supervised.reply/4
    (stdlib 3.16.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```