### PR TITLE
When all tests are excluded, colorize summary in yellow with message

### DIFF
--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -32,7 +32,13 @@ defmodule ExUnit.CLIFormatter do
   end
 
   def handle_cast({:suite_finished, times_us}, config) do
-    IO.write("\n\n")
+    test_type_counts = collect_test_type_counts(config)
+
+    if test_type_counts > 0 && config.excluded_counter == test_type_counts do
+      IO.puts(invalid("All tests have been excluded.", config))
+    end
+
+    IO.write("\n")
     IO.puts(format_times(times_us))
 
     if config.slowest > 0 do
@@ -274,10 +280,6 @@ defmodule ExUnit.CLIFormatter do
     formatted_test_type_counts = format_test_type_counts(config)
     test_type_counts = collect_test_type_counts(config)
     failure_pl = pluralize(config.failure_counter, "failure", "failures")
-
-    if test_type_counts > 0 && config.excluded_counter == test_type_counts do
-      IO.puts(invalid("All tests have been excluded.", config))
-    end
 
     message =
       "#{formatted_test_type_counts}#{config.failure_counter} #{failure_pl}"

--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -275,6 +275,10 @@ defmodule ExUnit.CLIFormatter do
     test_type_counts = collect_test_type_counts(config)
     failure_pl = pluralize(config.failure_counter, "failure", "failures")
 
+    if test_type_counts > 0 && config.excluded_counter == test_type_counts do
+      IO.puts(invalid("All tests have been excluded.", config))
+    end
+
     message =
       "#{formatted_test_type_counts}#{config.failure_counter} #{failure_pl}"
       |> if_true(
@@ -289,10 +293,6 @@ defmodule ExUnit.CLIFormatter do
         config.skipped_counter > 0,
         &(&1 <> ", " <> skipped("#{config.skipped_counter} skipped", config))
       )
-      |> if_true(
-        config.failure_counter == 0 && config.excluded_counter == test_type_counts,
-        &(&1 <> "\nNo tests have been run")
-      )
 
     cond do
       config.failure_counter > 0 or force_failures? ->
@@ -301,7 +301,7 @@ defmodule ExUnit.CLIFormatter do
       config.invalid_counter > 0 ->
         IO.puts(invalid(message, config))
 
-      config.failure_counter == 0 && config.excluded_counter == test_type_counts ->
+      test_type_counts > 0 && config.excluded_counter == test_type_counts ->
         IO.puts(invalid(message, config))
 
       true ->

--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -289,6 +289,10 @@ defmodule ExUnit.CLIFormatter do
         config.skipped_counter > 0,
         &(&1 <> ", " <> skipped("#{config.skipped_counter} skipped", config))
       )
+      |> if_true(
+        config.failure_counter == 0 && config.excluded_counter == test_type_counts,
+        &(&1 <> "\nNo tests have been run")
+      )
 
     cond do
       config.failure_counter > 0 or force_failures? ->

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -127,7 +127,6 @@ defmodule ExUnitTest do
            Showing results so far...
 
            0 failures
-           No tests have been run
 
            Randomized with seed 0
            """
@@ -872,6 +871,27 @@ defmodule ExUnitTest do
       config = ExUnit.configuration()
       assert config[:exit_status] == 5
     end
+  end
+
+  test "prints warning when all tests are excluded" do
+    defmodule OnlyExcludedTests do
+      use ExUnit.Case
+
+      @tag :exclude
+      test "excluded test", do: assert(false)
+
+      @tag :exclude
+      test "one more excluded test", do: assert(false)
+    end
+
+    configure_and_reload_on_exit([])
+
+    output =
+      capture_io(fn ->
+        assert ExUnit.run() == %{total: 2, failures: 0, excluded: 2, skipped: 0}
+      end)
+
+    assert output =~ "All tests have been excluded.\n2 tests, 0 failures, 2 excluded\n"
   end
 
   ##  Helpers

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -891,7 +891,8 @@ defmodule ExUnitTest do
         assert ExUnit.run() == %{total: 2, failures: 0, excluded: 2, skipped: 0}
       end)
 
-    assert output =~ "All tests have been excluded.\n2 tests, 0 failures, 2 excluded\n"
+    assert output =~ "All tests have been excluded.\n"
+    assert output =~ "2 tests, 0 failures, 2 excluded\n"
   end
 
   ##  Helpers

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -127,6 +127,7 @@ defmodule ExUnitTest do
            Showing results so far...
 
            0 failures
+           No tests have been run
 
            Randomized with seed 0
            """


### PR DESCRIPTION
Fixes #11825 
Code example:
```elixir
ExUnit.start(seed: 0, exclude: :skip)

defmodule SkippedTest do
  use ExUnit.Case

  @tag :skip
  describe "skip test" do
    test "integers" do
      assert 1 == 1
    end
  end
end
```

Result:
<img width="731" alt="image" src="https://user-images.githubusercontent.com/38437931/168422173-830102c6-d18b-4e19-a0b3-3c7c37bd5947.png">
