### PR TITLE
Add a guard to ExUnit.configure/1

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -304,7 +304,7 @@ defmodule ExUnit do
   other options will be ignored by ExUnit itself.
   """
   @spec configure(Keyword.t()) :: :ok
-  def configure(options) do
+  def configure(options) when is_list(options) do
     Enum.each(options, fn {k, v} ->
       Application.put_env(:ex_unit, k, v)
     end)


### PR DESCRIPTION
If anything else is given to this function, the error is the usual "protocol not implemented". With a is_list/1 guard, it's going to be easier to see what went wrong.