### PR TITLE
Improve Exception blame for is_struct guard by reverting the macro

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -259,7 +259,11 @@ defmodule Exception do
   defp struct_validation_node?(_), do: false
 
   defp is_struct_macro?(
-         {:and, _, [{:and, _, [%{node: node_1}, %{node: node_2}]}, %{node: node_3}]}
+         {:and, _,
+          [
+            {:and, _, [%{node: node_1 = {_, _, [arg]}}, %{node: node_2 = {_, _, [arg, _]}}]},
+            %{node: node_3 = {_, _, [{_, _, [_, arg]}]}}
+          ]}
        ),
        do: is_map_node?(node_1) and is_map_key_node?(node_2) and struct_validation_node?(node_3)
 
@@ -269,10 +273,13 @@ defmodule Exception do
             {:and, _,
              [
                {:and, _,
-                [%{node: node_1}, {:or, _, [%{node: {:is_atom, _, [_]}}, %{node: :fail}]}]},
-               %{node: node_2}
+                [
+                  %{node: node_1 = {_, _, [arg]}},
+                  {:or, _, [%{node: {:is_atom, _, [_]}}, %{node: :fail}]}
+                ]},
+               %{node: node_2 = {_, _, [arg, _]}}
              ]},
-            %{node: node_3}
+            %{node: node_3 = {_, _, [{_, _, [_, arg]}, _]}}
           ]}
        ),
        do: is_map_node?(node_1) and is_map_key_node?(node_2) and struct_validation_node?(node_3)

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -280,17 +280,14 @@ defmodule Exception do
   defp is_struct_macro?(_), do: false
 
   defp translate_guard(guard) do
-    cond do
-      is_struct_macro?(guard) ->
-        undo_guard_macro(:is_struct, guard)
-
-      true ->
-        guard
+    if is_struct_macro?(guard) do
+      undo_is_struct_guard(guard)
+    else
+      guard
     end
   end
 
-  defp undo_guard_macro(
-         :is_struct,
+  defp undo_is_struct_guard(
          {:and, meta, [_, %{node: {_, _, [{_, _, [_, {struct, _, _}]} | optional]}}]}
        ) do
     args =

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -227,7 +227,11 @@ defmodule Exception do
             |> Enum.zip()
             |> Enum.map_reduce([], &blame_arg/2)
 
-          guards = Enum.map(guards, &blame_guard(&1, ann, scope, binding))
+          guards =
+            guards
+            |> Enum.map(&blame_guard(&1, ann, scope, binding))
+            |> Enum.map(&Macro.prewalk(&1, fn guard -> translate_guard(guard) end))
+
           {args, guards}
         end
 
@@ -235,6 +239,67 @@ defmodule Exception do
     else
       _ -> :error
     end
+  end
+
+  defp is_map_node?({:is_map, _, [_]}), do: true
+  defp is_map_node?(_), do: false
+  defp is_map_key_node?({:is_map_key, _, [_, _]}), do: true
+  defp is_map_key_node?(_), do: false
+
+  defp struct_validation_node?(
+         {:is_atom, _, [{{:., [], [:erlang, :map_get]}, _, [:__struct__, _]}]}
+       ),
+       do: true
+
+  defp struct_validation_node?(
+         {:==, _, [{{:., [], [:erlang, :map_get]}, _, [:__struct__, _]}, _module]}
+       ),
+       do: true
+
+  defp struct_validation_node?(_), do: false
+
+  defp is_struct_macro?(
+         {:and, _, [{:and, _, [%{node: node_1}, %{node: node_2}]}, %{node: node_3}]}
+       ),
+       do: is_map_node?(node_1) and is_map_key_node?(node_2) and struct_validation_node?(node_3)
+
+  defp is_struct_macro?(
+         {:and, _,
+          [
+            {:and, _,
+             [
+               {:and, _,
+                [%{node: node_1}, {:or, _, [%{node: {:is_atom, _, [_]}}, %{node: :fail}]}]},
+               %{node: node_2}
+             ]},
+            %{node: node_3}
+          ]}
+       ),
+       do: is_map_node?(node_1) and is_map_key_node?(node_2) and struct_validation_node?(node_3)
+
+  defp is_struct_macro?(_), do: false
+
+  defp translate_guard(guard) do
+    cond do
+      is_struct_macro?(guard) ->
+        undo_guard_macro(:is_struct, guard)
+
+      true ->
+        guard
+    end
+  end
+
+  defp undo_guard_macro(
+         :is_struct,
+         {:and, meta, [_, %{node: {_, _, [{_, _, [_, {struct, _, _}]} | optional]}}]}
+       ) do
+    args =
+      case optional do
+        [] -> [{struct, meta, nil}]
+        [module] -> [{struct, meta, nil}, module]
+      end
+
+    %{match?: meta[:value], node: {:is_struct, meta, args}}
   end
 
   defp blame_arg({call_arg, ex_arg, erl_arg}, binding) do
@@ -280,22 +345,37 @@ defmodule Exception do
         :andalso -> :and
       end
 
-    {kernel_op, meta, guards}
+    evaluate_guard(kernel_op, meta, guards)
   end
 
   defp blame_guard(ex_guard, ann, scope, binding) do
-    {erl_guard, _} = :elixir_erl_pass.translate(ex_guard, ann, scope)
+    ex_guard
+    |> blame_guard?(binding, ann, scope)
+    |> blame_wrap(rewrite_guard(ex_guard))
+  end
 
-    match? =
-      try do
-        {:value, true, _} = :erl_eval.expr(erl_guard, binding, :none)
-        true
-      rescue
-        _ -> false
+  defp blame_guard?(ex_guard, binding, ann, scope) do
+    {erl_guard, _} = :elixir_erl_pass.translate(ex_guard, ann, scope)
+    {:value, true, _} = :erl_eval.expr(erl_guard, binding, :none)
+    true
+  rescue
+    _ -> false
+  end
+
+  defp evaluate_guard(kernel_op, meta, guards = [_, _]) do
+    [x, y] = Enum.map(guards, &evaluate_guard/1)
+
+    logic_value =
+      case kernel_op do
+        :or -> x or y
+        :and -> x and y
       end
 
-    blame_wrap(match?, rewrite_guard(ex_guard))
+    {kernel_op, Keyword.put(meta, :value, logic_value), guards}
   end
+
+  defp evaluate_guard(%{match?: value}), do: value
+  defp evaluate_guard({_, meta, _}) when is_list(meta), do: meta[:value]
 
   defp rewrite_guard(guard) do
     Macro.prewalk(guard, fn

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -412,37 +412,6 @@ defmodule ExceptionTest do
       assert Exception.blame(:exit, :function_clause, stack) == {:function_clause, stack}
     end
 
-    test "ensures `Kernel.is_struct` macro hasn't changed since v1.14" do
-      assert {{:., [], [:erlang, :andalso]}, [],
-              [
-                {:and, _,
-                 [{:is_map, _, _}, {{:., [], [:erlang, :is_map_key]}, [], [:__struct__, _]}]},
-                {:is_atom, _, [{{:., [], [:erlang, :map_get]}, [], [:__struct__, _]}]}
-              ]} =
-               Macro.expand(
-                 quote do
-                   is_struct(%{})
-                 end,
-                 %{__ENV__ | context: :guard}
-               )
-
-      assert {{:., [], [:erlang, :andalso]}, [],
-              [
-                {:and, _,
-                 [
-                   {:and, _, [{:is_map, _, _}, {:or, _, [{:is_atom, _, [:atom]}, :fail]}]},
-                   {{:., [], [:erlang, :is_map_key]}, [], [:__struct__, _]}
-                 ]},
-                {:==, _, [{{:., [], [:erlang, :map_get]}, [], [:__struct__, _]}, :atom]}
-              ]} =
-               Macro.expand(
-                 quote do
-                   is_struct(%{}, :atom)
-                 end,
-                 %{__ENV__ | context: :guard}
-               )
-    end
-
     test "reverts is_struct macro on guards for blaming" do
       import PathHelpers
 


### PR DESCRIPTION
Should fix #11820 by reverting the `is_struct` macro during runtime for better guard blaming.
Reverting the macro like that relies heavily on the current `is_struct` implementation, so tests to check if the pattern for the macro output has changed were added. Couldn't find a better option for doing that during runtime ☹