### PR TITLE
Clarify docs for Supervisor.start_link/2

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -551,7 +551,7 @@ defmodule Supervisor do
 
   If the supervisor and its child processes are successfully spawned
   (if the start function of each child process returns `{:ok, child}`,
-  `{:ok, child, info}`, or `:ignore`) or if `children` is an empty list, this function returns
+  `{:ok, child, info}`, or `:ignore`), this function returns
   `{:ok, pid}`, where `pid` is the PID of the supervisor. If the supervisor
   is given a name and a process with the specified name already exists,
   the function returns `{:error, {:already_started, pid}}`, where `pid`

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -549,7 +549,7 @@ defmodule Supervisor do
   The supported values are described under the "Name registration"
   section in the `GenServer` module docs.
 
-  If the supervisor and its child processes are successfully spawned
+  If the supervisor and all child processes are successfully spawned
   (if the start function of each child process returns `{:ok, child}`,
   `{:ok, child, info}`, or `:ignore`), this function returns
   `{:ok, pid}`, where `pid` is the PID of the supervisor. If the supervisor

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -532,9 +532,12 @@ defmodule Supervisor do
   @doc """
   Starts a supervisor with the given children.
 
-  The children is a list of modules, two-element tuples with module and
-  arguments or a map with the child specification. A strategy is required
-  to be provided through the `:strategy` option. See
+  `children` is a list that includes every child expressed in of the following forms:
+    - a module
+    - a two-element tuple in the shape of `{module, arguments}` with `arguments` being a keyword-list
+    - a [child specification](`t:child_spec/0`)
+
+  A strategy is required to be provided through the `:strategy` option. See
   "start_link/2, init/2, and strategies" for examples and other options.
 
   The options can also be used to register a supervisor name.
@@ -543,7 +546,7 @@ defmodule Supervisor do
 
   If the supervisor and its child processes are successfully spawned
   (if the start function of each child process returns `{:ok, child}`,
-  `{:ok, child, info}`, or `:ignore`) this function returns
+  `{:ok, child, info}`, or `:ignore`) or if `children` is an empty list, this function returns
   `{:ok, pid}`, where `pid` is the PID of the supervisor. If the supervisor
   is given a name and a process with the specified name already exists,
   the function returns `{:error, {:already_started, pid}}`, where `pid`

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -534,13 +534,13 @@ defmodule Supervisor do
 
   `children` is a list of the following forms:
 
+    * a [child specification](`t:child_spec/0`)
+
     * a module, where `module.child_spec([])` will be invoked to retrieve
       its child specification
 
     * a two-element tuple in the shape of `{module, arg}`, where `module.child_spec(arg)`
-      will be invoked for retrieve its child specification
-
-    * a [child specification](`t:child_spec/0`)
+      will be invoked to retrieve its child specification
 
   A strategy is required to be provided through the `:strategy` option. See
   "start_link/2, init/2, and strategies" for examples and other options.

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -532,10 +532,15 @@ defmodule Supervisor do
   @doc """
   Starts a supervisor with the given children.
 
-  `children` is a list that includes every child expressed in of the following forms:
-    - a module
-    - a two-element tuple in the shape of `{module, arguments}` with `arguments` being a keyword-list
-    - a [child specification](`t:child_spec/0`)
+  `children` is a list of the following forms:
+
+    * a module, where `module.child_spec([])` will be invoked to retrieve
+      its child specification
+
+    * a two-element tuple in the shape of `{module, arg}`, where `module.child_spec(arg)`
+      will be invoked for retrieve its child specification
+
+    * a [child specification](`t:child_spec/0`)
 
   A strategy is required to be provided through the `:strategy` option. See
   "start_link/2, init/2, and strategies" for examples and other options.


### PR DESCRIPTION
The first change is because the was it is expressed it seems like
only a list of modules, a list of tuples or a list of maps is accepts,
while a list with any of these values is.

The second change mentions that an empty children list will return {:ok, pid}.