### PR TITLE
Handle Calendar.strftime widths with "0" in them

### DIFF
--- a/lib/elixir/lib/calendar.ex
+++ b/lib/elixir/lib/calendar.ex
@@ -544,8 +544,8 @@ defmodule Calendar do
     parse_modifiers(rest, width, "", parser_data)
   end
 
-  defp parse_modifiers("0" <> rest, width, nil, parser_data) do
-    parse_modifiers(rest, width, ?0, parser_data)
+  defp parse_modifiers("0" <> rest, nil, nil, parser_data) do
+    parse_modifiers(rest, nil, ?0, parser_data)
   end
 
   defp parse_modifiers("_" <> rest, width, nil, parser_data) do

--- a/lib/elixir/test/elixir/calendar_test.exs
+++ b/lib/elixir/test/elixir/calendar_test.exs
@@ -313,6 +313,11 @@ defmodule CalendarTest do
       assert Calendar.strftime(~N[2019-08-15 17:07:57], "%f") == "0"
     end
 
+    test "handles `0` both as padding and as part of a width" do
+      assert Calendar.strftime(~N[2019-08-15 17:07:57], "%10A") == "  Thursday"
+      assert Calendar.strftime(~N[2019-08-15 17:07:57], "%010A") == "00Thursday"
+    end
+
     test "formats datetime with all options and modifiers" do
       assert Calendar.strftime(
                ~U[2019-08-15 17:07:57.001Z],


### PR DESCRIPTION
## Example code
```elixir
for width <- ~w(9 10 11), do: Calendar.strftime(~D[1970-01-01], "%#{width}A")
```
## Expected
```elixir
[" Thursday", "  Thursday", "   Thursday"]
```
## Actual
```elixir
[" Thursday", "Thursday", "   Thursday"]
```
A width of 10 is set to "1" because the second "0" is parsed as setting the padding character.

## Solve
This PR changes the parsing of  "0" for padding to only happen if the width is still `nil`, once we begin parsing digits for a width we keep doing so.
