### PR TITLE
Fix bug DynamicSupervisor child_spec validation

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -447,7 +447,7 @@ defmodule DynamicSupervisor do
   defp validate_restart(restart) when restart in [:permanent, :temporary, :transient], do: :ok
   defp validate_restart(restart), do: {:invalid_restart_type, restart}
 
-  defp validate_shutdown(shutdown) when is_integer(shutdown) and shutdown > 0, do: :ok
+  defp validate_shutdown(shutdown) when is_integer(shutdown) and shutdown >= 0, do: :ok
   defp validate_shutdown(shutdown) when shutdown in [:infinity, :brutal_kill], do: :ok
   defp validate_shutdown(shutdown), do: {:invalid_shutdown, shutdown}
 

--- a/lib/elixir/test/elixir/dynamic_supervisor_test.exs
+++ b/lib/elixir/test/elixir/dynamic_supervisor_test.exs
@@ -458,8 +458,6 @@ defmodule DynamicSupervisorTest do
       assert_receive {:EXIT, ^pid, :shutdown}
     end
 
-    # == 
-
     test "with valid shutdown" do
       Process.flag(:trap_exit, true)
 


### PR DESCRIPTION
It would not accept 0 as a valid shutdown value.
It only happened in DynamicSupervisor, but tests are added for both DynamicSupervisor and Supervisor modules.