### PR TITLE
Add note about Module functions availability during @after_compile

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -153,7 +153,8 @@ defmodule Code do
       is defined. This is equivalent to the `@after_compile` callback and invoked
       after any `@after_compile` in the given module. The third element is currently
       `:none` but it may provide more metadata in the future. It is best to ignore
-      it at the moment.
+      it at the moment. Note that `Module` functions expecting not yet compiled module
+      (e.g. `Module.definitions_in/1`) are available at the time this event is emitted.
 
   The `:tracers` compiler option can be combined with the `:parser_options`
   compiler option to enrich the metadata of the traced events above.

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -394,6 +394,9 @@ defmodule Module do
 
   Callbacks will run in the order they are registered.
 
+  `Module` functions expecting not yet compiled module (e.g. `Module.definitions_in/1`)
+  are availanble at the time `@after_compile` is invoked.
+
   #### Example
 
       defmodule MyModule do


### PR DESCRIPTION
Currently the documentation suggests that during `@after_compile` callback or `on_module` compile trace event `Module` functions are no longer available.