### PR TITLE
Add `normalize_bitstring_modifiers` option to formatter

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -14,5 +14,6 @@
 
     # Errors tests
     assert_eval_raise: 3
-  ]
+  ],
+  normalize_bitstring_modifiers: false
 ]

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -467,9 +467,12 @@ defmodule Code do
 
   The formatter was designed under three principles.
 
-  First, the formatter never changes the semantics of the code by default.
-  This means the input AST and the output AST are equivalent, except in
-  very few cases, which can be disabled via an option.
+  First, the formatter never changes the semantics of the code.
+  This means the input AST and the output AST are almost always equivalent.
+  The only cases where the formatter will change the AST is when the input AST
+  would cause *compiler warnings* and the output AST won't. The cases where
+  the formatter changes the AST can be disabled through formatting options
+  if desired.
 
   The second principle is to provide as little configuration as possible.
   This eases the formatter adoption by removing contention points while

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -455,12 +455,21 @@ defmodule Code do
       If you set it to `false` later on, `do`-`end` blocks won't be
       converted back to keywords.
 
+    * `:normalize_bitstring_modifiers` (since v1.14.0) - when `true`,
+      removes un-necessary parentheses in known bitstring
+      [modifiers](`Kernel.<<>>/1`),
+      e.g. `<<foo::binary()>>` becomes `<<foo::binary>>`, or adds
+      parentheses for custom modifiers, e.g. `<<foo::custom_type>>`
+      becomes `<<foo::custom_type()>>`.
+      Defaults to `true`. This option changes the AST.
+
   ## Design principles
 
   The formatter was designed under three principles.
 
-  First, the formatter never changes the semantics of the code by
-  default. This means the input AST and the output AST are equivalent.
+  First, the formatter never changes the semantics of the code by default.
+  This means the input AST and the output AST are equivalent, except in
+  very few cases, which can be disabled via an option.
 
   The second principle is to provide as little configuration as possible.
   This eases the formatter adoption by removing contention points while

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -456,11 +456,10 @@ defmodule Code do
       converted back to keywords.
 
     * `:normalize_bitstring_modifiers` (since v1.14.0) - when `true`,
-      removes un-necessary parentheses in known bitstring
-      [modifiers](`Kernel.<<>>/1`),
-      e.g. `<<foo::binary()>>` becomes `<<foo::binary>>`, or adds
-      parentheses for custom modifiers, e.g. `<<foo::custom_type>>`
-      becomes `<<foo::custom_type()>>`.
+      removes unnecessary parentheses in known bitstring
+      [modifiers](`Kernel.<<>>/1`), for example `<<foo::binary()>>`
+      becomes `<<foo::binary>>`, or adds parentheses for custom
+      modifiers, where `<<foo::custom_type>>` becomes `<<foo::custom_type()>>`.
       Defaults to `true`. This option changes the AST.
 
   ## Design principles

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -1445,7 +1445,7 @@ defmodule Code.Formatter do
          state = %{normalize_bitstring_modifiers: true}
        )
        when is_atom(atom) and empty_args in [nil, []] do
-    empty_args = bitstring_spec_notmalized_empty_args(atom)
+    empty_args = bitstring_spec_normalize_empty_args(atom)
     quoted_to_algebra_with_parens_if_operator({atom, meta, empty_args}, :parens_arg, state)
   end
 
@@ -1453,8 +1453,8 @@ defmodule Code.Formatter do
     quoted_to_algebra_with_parens_if_operator(spec_element, :parens_arg, state)
   end
 
-  defp bitstring_spec_notmalized_empty_args(atom) when atom in @bitstring_modifiers, do: nil
-  defp bitstring_spec_notmalized_empty_args(_atom), do: []
+  defp bitstring_spec_normalize_empty_args(atom) when atom in @bitstring_modifiers, do: nil
+  defp bitstring_spec_normalize_empty_args(_atom), do: []
 
   defp bitstring_wrap_parens(doc, i, last) when i == 0 or i == last do
     string = format_to_string(doc)

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -141,6 +141,24 @@ defmodule Code.Formatter do
 
   @do_end_keywords [:rescue, :catch, :else, :after]
 
+  @bitstring_modifiers [
+    :integer,
+    :float,
+    :bits,
+    :bitstring,
+    :binary,
+    :bytes,
+    :utf8,
+    :utf16,
+    :utf32,
+    :signed,
+    :unsigned,
+    :little,
+    :big,
+    :native,
+    :_
+  ]
+
   @doc """
   Converts the quoted expression into an algebra document.
   """
@@ -179,6 +197,7 @@ defmodule Code.Formatter do
     locals_without_parens = Keyword.get(opts, :locals_without_parens, [])
     file = Keyword.get(opts, :file, nil)
     sigils = Keyword.get(opts, :sigils, [])
+    normalize_bitstring_modifiers = Keyword.get(opts, :normalize_bitstring_modifiers, true)
 
     sigils =
       Map.new(sigils, fn {key, value} ->
@@ -201,7 +220,8 @@ defmodule Code.Formatter do
       skip_eol: false,
       comments: comments,
       sigils: sigils,
-      file: file
+      file: file,
+      normalize_bitstring_modifiers: normalize_bitstring_modifiers
     }
   end
 
@@ -1412,13 +1432,29 @@ defmodule Code.Formatter do
 
   defp bitstring_spec_to_algebra({op, _, [left, right]}, state) when op in [:-, :*] do
     {left, state} = bitstring_spec_to_algebra(left, state)
-    {right, state} = quoted_to_algebra_with_parens_if_operator(right, :parens_arg, state)
+    {right, state} = bitstring_spec_element_to_algebra(right, state)
     {concat(concat(left, Atom.to_string(op)), right), state}
   end
 
   defp bitstring_spec_to_algebra(spec, state) do
-    quoted_to_algebra_with_parens_if_operator(spec, :parens_arg, state)
+    bitstring_spec_element_to_algebra(spec, state)
   end
+
+  defp bitstring_spec_element_to_algebra(
+         {atom, meta, empty_args},
+         state = %{normalize_bitstring_modifiers: true}
+       )
+       when is_atom(atom) and empty_args in [nil, []] do
+    empty_args = bitstring_spec_notmalized_empty_args(atom)
+    quoted_to_algebra_with_parens_if_operator({atom, meta, empty_args}, :parens_arg, state)
+  end
+
+  defp bitstring_spec_element_to_algebra(spec_element, state) do
+    quoted_to_algebra_with_parens_if_operator(spec_element, :parens_arg, state)
+  end
+
+  defp bitstring_spec_notmalized_empty_args(atom) when atom in @bitstring_modifiers, do: nil
+  defp bitstring_spec_notmalized_empty_args(_atom), do: []
 
   defp bitstring_wrap_parens(doc, i, last) when i == 0 or i == last do
     string = format_to_string(doc)

--- a/lib/elixir/test/elixir/code_formatter/containers_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/containers_test.exs
@@ -290,6 +290,33 @@ defmodule Code.Formatter.ContainersTest do
       assert_same "<<(<<y>> <- x)>>"
     end
 
+    test "normalizes bitstring modifiers by default" do
+      assert_format "<<foo::binary()>>", "<<foo::binary>>"
+      assert_same "<<foo::binary>>"
+
+      assert_format "<<foo::custom_type>>", "<<foo::custom_type()>>"
+      assert_same "<<foo::custom_type()>>"
+
+      assert_format "<<x::binary()-(13 * 6)-custom>>", "<<x::binary-(13 * 6)-custom()>>"
+      assert_same "<<x::binary-(13 * 6)-custom()>>"
+
+      assert_format "<<0, 1::2-integer() <- x>>", "<<0, 1::2-integer <- x>>"
+      assert_same "<<0, 1::2-integer <- x>>"
+    end
+
+    test "keeps parentheses when normalize_bitstring_modifiers is false" do
+      opts = [normalize_bitstring_modifiers: false]
+
+      assert_same "<<foo::binary()>>", opts
+      assert_same "<<foo::binary>>", opts
+
+      assert_same "<<foo::custom_type>>", opts
+      assert_same "<<foo::custom_type()>>", opts
+
+      assert_same "<<x::binary()-(13 * 6)-custom>>", opts
+      assert_same "<<0, 1::2-integer() <- x>>", opts
+    end
+
     test "is flex on line limits" do
       bad = "<<1, 2, 3, 4>>"
 

--- a/lib/elixir/test/elixir/module/types/types_test.exs
+++ b/lib/elixir/test/elixir/module/types/types_test.exs
@@ -128,17 +128,17 @@ defmodule Module.Types.TypesTest do
              in expression:
 
                  # types_test.ex:1
-                 <<..., var::binary()>>
+                 <<..., var::binary>>
 
              where "var" was given the type integer() in:
 
                  # types_test.ex:1
-                 <<var::integer(), ...>>
+                 <<var::integer, ...>>
 
              where "var" was given the type binary() in:
 
                  # types_test.ex:1
-                 <<..., var::binary()>>
+                 <<..., var::binary>>
              """
     end
 
@@ -337,7 +337,7 @@ defmodule Module.Types.TypesTest do
              in expression:
 
                  # types_test.ex:1
-                 <<foo::integer()>>
+                 <<foo::integer>>
 
              where "foo" was given the type binary() in:
 
@@ -347,7 +347,7 @@ defmodule Module.Types.TypesTest do
              where "foo" was given the type integer() in:
 
                  # types_test.ex:1
-                 <<foo::integer()>>
+                 <<foo::integer>>
              """
     end
 


### PR DESCRIPTION
Hi,

This PR adds a `normalize_bitstring_modifiers` boolean option as specified as https://github.com/elixir-lang/elixir/issues/11811. Hope it helps.

I'm happy to keep working on this issue and add `enforce_calls_on_right_hand_side_of` in an upcoming PR if nobody is working on this.