### PR TITLE
Add `:enforce_calls_on_right_hand_side_of` formatter option

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -15,5 +15,6 @@
     # Errors tests
     assert_eval_raise: 3
   ],
-  normalize_bitstring_modifiers: false
+  normalize_bitstring_modifiers: false,
+  enforce_calls_on_right_hand_side_of: []
 ]

--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -457,6 +457,12 @@ defmodule Code do
       If you set it to `false` later on, `do`-`end` blocks won't be
       converted back to keywords.
 
+    * `:enforce_calls_on_right_hand_side_of` (since v.14.0) - a list of
+      atoms containing binary operators for which the right operand must
+      enforce parentheses on function calls. This is typically used for
+      pipe operators, for example `foo |> bar` should become `foo |> bar()`.
+      Defaults to `[:|>]`.
+
     * `:normalize_bitstring_modifiers` (since v1.14.0) - when `true`,
       removes unnecessary parentheses in known bitstring
       [modifiers](`Kernel.<<>>/1`), for example `<<foo::binary()>>`

--- a/lib/elixir/test/elixir/code_formatter/comments_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/comments_test.exs
@@ -906,7 +906,7 @@ defmodule Code.Formatter.CommentsTest do
       foo
       # |> bar
       # |> baz
-      |> bat
+      |> bat()
       """
 
       bad = """
@@ -922,9 +922,9 @@ defmodule Code.Formatter.CommentsTest do
       # this is foo
       foo
       # this is bar
-      |> bar
+      |> bar()
       # this is baz
-      |> baz
+      |> baz()
 
       # after
       """

--- a/lib/elixir/test/elixir/code_formatter/operators_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/operators_test.exs
@@ -283,7 +283,7 @@ defmodule Code.Formatter.OperatorsTest do
     test "preserves user choice even when it fits" do
       assert_same """
       foo
-      |> bar
+      |> bar()
       """
 
       assert_same """
@@ -295,15 +295,33 @@ defmodule Code.Formatter.OperatorsTest do
 
       bad = """
       foo |>
-        bar
+        bar()
       """
 
       good = """
       foo
-      |> bar
+      |> bar()
       """
 
       assert_format bad, good
+    end
+
+    test "adds parentheses to the right side of enforce_calls_on_right_hand_side_of" do
+      assert_same "foo |> bar ~> baz", enforce_calls_on_right_hand_side_of: []
+
+      enforce_opts = [enforce_calls_on_right_hand_side_of: [:~>]]
+
+      assert_format "foo ~> bar", "foo ~> bar()", enforce_opts
+
+      assert_format "foo ~> bar ~> baz", "foo ~> bar() ~> baz()", enforce_opts
+
+      assert_format "foo |> bar ~> baz", "foo |> bar ~> baz()", enforce_opts
+
+      assert_format "foo ~> bar |> baz", "foo ~> bar() |> baz", enforce_opts
+
+      assert_format "foo(bar ~> baz)", "foo(bar ~> baz())", enforce_opts
+
+      assert_same "defmacro x ~> f, do: foo(f, x)", enforce_opts
     end
   end
 
@@ -518,10 +536,10 @@ defmodule Code.Formatter.OperatorsTest do
     end
 
     test "with required parens" do
-      assert_same "(a |> b) ++ (c |> d)"
+      assert_same "(a |> b()) ++ (c |> d())"
       assert_format "a + b |> c + d", "(a + b) |> (c + d)"
       assert_format "a ++ b |> c ++ d", "(a ++ b) |> (c ++ d)"
-      assert_format "a |> b ++ c |> d", "a |> (b ++ c) |> d"
+      assert_format "a |> b ++ c |> d", "a |> (b ++ c) |> d()"
     end
 
     test "with required parens skips on no parens" do


### PR DESCRIPTION
This PR adds the `enforce_calls_on_right_hand_side_of` option to the formatter as specified in https://github.com/elixir-lang/elixir/issues/11811.

Note: I noticed a possible unintended consequence with this, which is that defining operators might trigger the formatter for arguments:

```elixir
defmacro x |> f, do: foo(f, x)

# becomes

defmacro x |> f(), do: foo(f, x)
```

I managed to circumvent this by checking the `:no_parens_arg` context, but it feels a bit hacky and will still format the argument as `f()` in the following:

```elixir
defmacro(x |> f, do: foo(f, x))
```

As far as I know, there is no difference at the AST level that we can use to distinguish an argument declaration from an expression, so is this approach good enough in practice? Or is there a better way?