### PR TITLE
nfc and additional normalizations for identifiers

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2169,7 +2169,14 @@ defmodule Macro do
           case :elixir_config.identifier_tokenizer().tokenize(charlist) do
             {kind, _acc, [], _, _, special} ->
               if kind == :identifier and not :lists.member(?@, special) do
-                :identifier
+                # identifier_tokenizer used to return errors for non-nfc, but
+                #  now it nfc-normalizes everything. however, lack of nfc is
+                #  still a good reason to quote an atom when printing.
+                if charlist == :unicode.characters_to_nfc_list(charlist) do
+                  :identifier
+                else
+                  :other
+                end
               else
                 :not_callable
               end

--- a/lib/elixir/pages/unicode-syntax.md
+++ b/lib/elixir/pages/unicode-syntax.md
@@ -99,9 +99,9 @@ Elixir supports only code points `\t` (0009), `\n` (000A), `\r` (000D) and `\s` 
 
 Identifiers in Elixir are case sensitive.
 
-Elixir requires all atoms and variables to be in NFC form. Any other form will fail with a relevant error message. Quoted-atoms and strings can, however, be in any form and are not verified by the parser.
+Elixir requires all atoms and variables to be in NFC form. If another form is given, NFC is automatically applied. Quoted-atoms and strings can, however, be in any form and are not verified by the parser.
 
-In other words, the atom `:josé` can only be written with the code points `006A 006F 0073 00E9`. Using another normalization form will will be overridden by the tokenizer, which will use the NFC form; prior to Elixir 1.14 this would be an error at compile-time, but now Elixir's formatter can fix it. On the other hand, `:"josé"` may be written as `006A 006F 0073 00E9` or `006A 006F 0073 0065 0301`, since it is written between quotes.
+In other words, the atom `:josé` can only be written with the code points `006A 006F 0073 00E9` or `006A 006F 0073 0065 0301`, but Elixir will rewrite it to the former (from Elixir 1.14). On the other hand, `:"josé"` may be written as `006A 006F 0073 00E9` or `006A 006F 0073 0065 0301` and its form will be retained, since it is written between quotes.
 
 Choosing requirement R6 automatically excludes requirements R4, R5 and R7.
 

--- a/lib/elixir/pages/unicode-syntax.md
+++ b/lib/elixir/pages/unicode-syntax.md
@@ -14,9 +14,9 @@ Elixir allows Unicode characters in its variables, atoms, and calls. However, th
 
 The characters allowed in identifiers are the ones specified by Unicode. Generally speaking, it is restricted to characters typically used by the writing system of human languages still in activity. In particular, it excludes symbols such as emojis, alternate numeric representations, musical notes, etc.
 
-Elixir imposes many restrictions on identifiers for security purposes. For example, the word "josé" can be written in two ways in Unicode: as the combination of the characters `j o s é` and as a combination of the characters `j o s e ́ `, where the accent is its own character. The former is called NFC form and the latter is the NFD form. Elixir requires all characters to be the in the NFC form.
+Elixir imposes many restrictions on identifiers for security purposes. For example, the word "josé" can be written in two ways in Unicode: as the combination of the characters `j o s é` and as a combination of the characters `j o s e ́ `, where the accent is its own character. The former is called NFC form and the latter is the NFD form. Elixir normalizes all characters to be the in the NFC form.
 
-Elixir also disallows mixed-scripts in most scenarios. For example, it is not possible to name a variable `аdmin`, where `а` is in Cyrillic and the remaining characters are in Latin. Doing so, will raise the following error:
+Elixir also disallows mixed-scripts in most scenarios. For example, it is not possible to name a variable `аdmin`, where `а` is in Cyrillic and the remaining characters are in Latin. Doing so will raise the following error:
 
 ```
 ** (SyntaxError) invalid mixed-script identifier found: аdmin
@@ -101,7 +101,7 @@ Identifiers in Elixir are case sensitive.
 
 Elixir requires all atoms and variables to be in NFC form. Any other form will fail with a relevant error message. Quoted-atoms and strings can, however, be in any form and are not verified by the parser.
 
-In other words, the atom `:josé` can only be written with the code points `006A 006F 0073 00E9`. Using another normalization form will lead to a tokenizer error. On the other hand, `:"josé"` may be written as `006A 006F 0073 00E9` or `006A 006F 0073 0065 0301`, since it is written between quotes.
+In other words, the atom `:josé` can only be written with the code points `006A 006F 0073 00E9`. Using another normalization form will will be overridden by the tokenizer, which will use the NFC form; prior to Elixir 1.14 this would be an error at compile-time, but now Elixir's formatter can fix it. On the other hand, `:"josé"` may be written as `006A 006F 0073 00E9` or `006A 006F 0073 0065 0301`, since it is written between quotes.
 
 Choosing requirement R6 automatically excludes requirements R4, R5 and R7.
 
@@ -117,6 +117,8 @@ Elixir will not allow tokenization of identifiers with codepoints in `\p{Identif
 
 For instance, the 'HANGUL FILLER' (`ㅤ`) character, which is often invisible, is an uncommon codepoint and will trigger this warning.
 
+See the note below about additional normalizations, which can perform automatic replacement of some Restricted identifiers.
+
 ### C2. Confusable detection
 
 Elixir will warn on identifiers that look the same, but aren't. Examples: in `а = a = 1`, the two 'a' characters are Cyrillic and Latin, and could be confused for each other; in `力 = カ = 1`, both are Japanese, but different codepoints, in different scripts of that writing system. Confusable identifiers can lead to hard-to-catch bugs (say, due to copy-pasted code) and can be unsafe, so we will warn about identifiers within a single file that could be confused with each other.
@@ -129,7 +131,7 @@ Elixir will not warn on confusability for identifiers made up exclusively of cha
 
 ### C3. Mixed Script Detection
 
-Elixir will not allow tokenization of mixed-script identifiers unless the mixings is one of the exceptions defined in UTS 39 5.2, 'Highly Restrictive'. We use the means described in Section 5.1, Mixed-Script Detection, to determine if script mixing is occurring.
+Elixir will not allow tokenization of mixed-script identifiers unless the mixings is one of the exceptions defined in UTS 39 5.2, 'Highly Restrictive'. We use the means described in Section 5.1, Mixed-Script Detection, to determine if script mixing is occurring, with the modification documented in the section 'Additional Normalizations', below.
 
 Examples: Elixir allows an identifiers like `幻ㄒㄧㄤ`, even though it includes characters from multiple 'scripts', because those scripts all 'resolve' to Japanese when applying the resolution rules from UTS 39 5.1. It also allows an atom like `:Tシャツ`, the Japanese word for 't-shirt', which incorporates a Latin capital T, because {Latn, Jpan} is one of the allowed script mixings in the definition of 'Highly Restrictive' in UTS 39 5.2, and it 'covers' the string.
 
@@ -140,3 +142,17 @@ However, Elixir would prevent tokenization in code like `if аdmin, do: :ok, els
 'C4 - Restriction Level detection' conformance is not claimed and does not apply to identifiers in code; rather, it applies to classifying the level of safety of a given arbitrary string into one of 5 restriction levels.
 
 'C5 - Mixed number detection' conformance is inapplicable as Elixir does not support Unicode numbers.
+
+### Addition normalizations and documented UTS 39 modifications
+
+As of Elixir 1.14, some codepoints in `\p{Identifier_Status=Restricted}` are *normalized* to other, unrestricted codepoints.
+
+Initially this is only done to translate MICRO SIGN `µ` to Greek lowercase mu, `μ`.
+
+This is not a modification of UTS39 clauses C1 (General Security Profile) or C2 (Confusability Detection); however it is a documented modification of C3, 'Mixed-Script detection'.
+
+Mixed-script detection is modified by these normalizations to the extent that the normalized codepoint is given the union of scriptsets from both characters.
+
+- For instance, in the example of MICRO => MU, Micro was a 'Common'-script character -- the same script given to the '_' underscore codepoint -- and thus the normalized character's scriptset will be {Greek, Common}. 'Common' intersects with all non-empty scriptsets, and thus the normalized character can be used in tokens written in any script without causing script mixing.
+
+- The code points normalized in this fashion are those that are in use in the community, and judged not likely to cause issues with unsafe script mixing. For instance, the MICRO or MU codepoint may be used in an atom or variable dealing with microseconds.

--- a/lib/elixir/test/elixir/code_formatter/general_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/general_test.exs
@@ -12,31 +12,13 @@ defmodule Code.Formatter.GeneralTest do
   end
 
   describe "unicode normalization" do
-    test "with custom normalizations" do
-      # we normalize *treatment* of the codepoints
-      # in elixir's custom normalizations list,
-      # as regards restriction level and scriptset.
-      #
-      # however, when we decide whether or not they
-      # should actually emit the same token, that has
-      # formatter impacts.
-      #
-      # So, writing a normalized codepoint multiple
-      # ways in one file will either result in
-      #
-      # (1) confusability error, since they're not
-      # the same codepoints, which will remind you to
-      # not mix the way you're writing it, or
-      #
-      # (2) formatter errors if you write it consistently
-      # the 'wrong' (not-normalized) way.
-      #
-      # write how you want, but be consistent, or
-      # it's a confusability fail:
-      # assert_same "µs"
+    test "with nfc normalizations" do
+      # prior to elixir 1.14, non-nfc-norm'd was an error
+      assert_format "ç", "ç"
+    end
 
-      # write how you want, but the formatter will
-      # change it/error on it if you're using the formatter
+    test "with custom normalizations" do
+      # prior to elixir 1.14, these would be separate; see warnings_test
       assert_format "µs", "μs"
     end
   end

--- a/lib/elixir/test/elixir/code_formatter/general_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/general_test.exs
@@ -11,6 +11,36 @@ defmodule Code.Formatter.GeneralTest do
     assert_format "fn -> end", "fn -> nil end"
   end
 
+  describe "unicode normalization" do
+    test "with custom normalizations" do
+      # we normalize *treatment* of the codepoints
+      # in elixir's custom normalizations list,
+      # as regards restriction level and scriptset.
+      #
+      # however, when we decide whether or not they
+      # should actually emit the same token, that has
+      # formatter impacts.
+      #
+      # So, writing a normalized codepoint multiple
+      # ways in one file will either result in
+      #
+      # (1) confusability error, since they're not
+      # the same codepoints, which will remind you to
+      # not mix the way you're writing it, or
+      #
+      # (2) formatter errors if you write it consistently
+      # the 'wrong' (not-normalized) way.
+      #
+      # write how you want, but be consistent, or
+      # it's a confusability fail:
+      # assert_same "µs"
+
+      # write how you want, but the formatter will
+      # change it/error on it if you're using the formatter
+      assert_format "µs", "μs"
+    end
+  end
+
   describe "aliases" do
     test "with atom-only parts" do
       assert_same "Elixir"

--- a/lib/elixir/test/elixir/code_formatter/general_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/general_test.exs
@@ -13,12 +13,10 @@ defmodule Code.Formatter.GeneralTest do
 
   describe "unicode normalization" do
     test "with nfc normalizations" do
-      # prior to elixir 1.14, non-nfc-norm'd was an error
       assert_format "ç", "ç"
     end
 
     test "with custom normalizations" do
-      # prior to elixir 1.14, these would be separate; see warnings_test
       assert_format "µs", "μs"
     end
   end

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -70,7 +70,7 @@ defmodule Kernel.WarningTest do
         end
 
       assert Exception.message(exception) =~
-               "nofile:1:4: invalid mixed-script identifier found: аdmin"
+               "nofile:1:9: invalid mixed-script identifier found: аdmin"
 
       assert Exception.message(exception) =~ """
                \\u0430 а {Cyrillic}
@@ -79,6 +79,13 @@ defmodule Kernel.WarningTest do
                \\u0069 i {Latin}
                \\u006E n {Latin}
                \\u005F _
+             """
+
+      # includes suggestion about what to change
+      assert Exception.message(exception) =~ """
+             Hint: You could write the above in a similar way that is accepted by Elixir:
+
+                 "admin_" (code points 0x00061 0x00064 0x0006D 0x00069 0x0006E 0x0005F)
              """
 
       # a is in cyrillic

--- a/lib/elixir/unicode/security.ex
+++ b/lib/elixir/unicode/security.ex
@@ -100,7 +100,7 @@ defmodule String.Tokenizer.Security do
 
   defp confusable_prototype(other), do: <<other::utf8>>
 
-  defp confusable_skeleton(s) do
+  def confusable_skeleton(s) do
     # "- Convert X to NFD format, as described in [UAX15].
     #  - Concatenate the prototypes for each character in X according to
     #    the specified data, producing a string of exemplar characters.

--- a/lib/elixir/unicode/tokenizer.ex
+++ b/lib/elixir/unicode/tokenizer.ex
@@ -424,7 +424,6 @@ defmodule String.Tokenizer do
   end
 
   defp validate({acc, rest, length, ascii_letters?, scriptset, special}, kind) do
-    # this is
     acc = :unicode.characters_to_nfc_list(:lists.reverse(acc))
 
     cond do
@@ -458,8 +457,9 @@ defmodule String.Tokenizer do
         Mixed-script identifiers are not supported for security reasons. \
         '#{acc}' is made of the following scripts:\n
         #{breakdown}
-        Make sure all characters in the identifier resolve to a single script or a highly
-        restrictive set of scripts. See https://hexdocs.pm/elixir/unicode-syntax.html for more information.
+        Make sure all characters in the identifier resolve to a single script,
+        or use a highly restrictive set of scripts.
+        See https://hexdocs.pm/elixir/unicode-syntax.html for more information.
         '''
 
         {:error, {:not_highly_restrictive, acc, {prefix, suffix}}}


### PR DESCRIPTION
Implement desired changes from #11753.

**Concretely, this is intended to address a regression in 1.14-dev where folks couldn't use the `µ` symbol in an atom or variable** like `µsecs`.

- The easily-typed 'Opt + m' shortcut on Mac produces the 'MICRO SIGN' unicode character, which is a Restricted codepoint according to the Unicode General Security Profile.
- The Greek 'lowercase mu', visually nearly identical, is Allowed -- but causes a Mixed Script error when combined with Latin-script letters in an identifier.

Now we support custom, elixir-specific normalizations, the first and only of which is the 'µ' mapping.

This also fixes 2 other normalization-related items:

**NFC normalization** -- non-NFC identifiers used to be an error, but now that's done automatically for us.

- This will affect the formatter's output now, and I added a case for that -- but it shouldn't act like a regression, because non-NFC would have been a compile-time error previously, so my understanding is that there can't be code 'in the wild' that would eg. fail in CI due to this normalization affecting formatting.

**NFKC suggestion** is only done when it's an identifier that fails to tokenize; that process looks like this:

```
iex(1)> foo𝚳 = "Friends of old Marvel"
** (SyntaxError) iex:1:4: unexpected token: Unicode codepoint did not parse, but its NFKC normalization would parse.

  Got:  𝚳 (codepoints 0x1D6B3) at column 4
  NFKC: Μ (codepoints 0x0039C)

Syntax error at:
    |
  1 | foo𝚳 = "Friends of old Marvel"
    |    ^
```

This PR also adds support for, and a normalization and test case -- for glyphs (like some math symbols) beyond eg. just Greek/Hebrew, from the 'Common' scriptset. We don't use that support yet -- we only add the double-barred 'N' and 'x' glyphs, as an undocumented normalization no one will rely on, and a test case exercising it, in order to ensure that we don't lose the ability to easily use glyphs from 'Common' in the future. If we want, I can remove the normalization and test from this PR, but I'd like to keep the implementation changes that make them possible 🙏.

Tests pass locally, Draft for CI -- I really would feel bad tagging jose, I just saw a picture of him on Paxos. 😄 