### PR TITLE
Allow any valid name for PartitionSupervisor

### DIFF
--- a/lib/elixir/lib/partition_supervisor.ex
+++ b/lib/elixir/lib/partition_supervisor.ex
@@ -237,7 +237,7 @@ defmodule PartitionSupervisor do
   defp init_partitions({:via, _, _}, partitions) do
     child_spec = {Registry, keys: :unique, name: @registry}
 
-    with nil <- Process.whereis(@registry) do
+    unless Process.whereis(@registry) do
       Supervisor.start_child(:elixir_sup, child_spec)
     end
 

--- a/lib/elixir/test/elixir/partition_supervisor_test.exs
+++ b/lib/elixir/test/elixir/partition_supervisor_test.exs
@@ -100,13 +100,9 @@ defmodule PartitionSupervisorTest do
   end
 
   describe "start_link/1 with a via name" do
-    setup do
+    test "on success", config do
       {:ok, _} = Registry.start_link(keys: :unique, name: PartitionRegistry)
 
-      :ok
-    end
-
-    test "on success", config do
       name = {:via, Registry, {PartitionRegistry, config.test}}
 
       {:ok, _} = PartitionSupervisor.start_link(child_spec: {Agent, fn -> :hello end}, name: name)

--- a/lib/elixir/test/elixir/partition_supervisor_test.exs
+++ b/lib/elixir/test/elixir/partition_supervisor_test.exs
@@ -62,9 +62,17 @@ defmodule PartitionSupervisorTest do
       assert Agent.get({:via, PartitionSupervisor, {config.test, -1}}, & &1) == 1
     end
 
+    test "accepts any valid supervisor name", config do
+      assert {:ok, _} =
+               PartitionSupervisor.start_link(
+                 child_spec: DynamicSupervisor,
+                 name: {:global, config.test}
+               )
+    end
+
     test "raises without name" do
       assert_raise ArgumentError,
-                   "the :name option must be given to PartitionSupervisor as an atom, got: nil",
+                   "the :name option must be given to PartitionSupervisor",
                    fn -> PartitionSupervisor.start_link(child_spec: DynamicSupervisor) end
     end
 


### PR DESCRIPTION
The PartitionSupervisor used a named ETS table to manage partitions, and as a result, it required the name to be an atom. However, only using atom names is limiting because it prevents the use of global or via tuples for registration.

This removes the `:named_table` option from a PartitionSupervisor's ETS table and instead stores a reference to the table with `:persistent_term`. Without the named table requirement, it's possible to register with any viable supervisor name.

#### Rationale

Oban uses `Task.Supervisor` to track jobs, and it's not unusual to have hundreds of tasks running through one supervisor. I want to run some benchmarks to identify if that's, in fact, a bottleneck, and `PartitionedSupervisor` seemed like a perfect fit. But unfortunately, Oban uses a registry for all process names, and I couldn't give it a try.

#### Thoughts / Concerns

- Is it alright to use `:persistent_term` now? There are only two other uses within the entire codebase.
- Would PartitionSupervisors be dynamically started enough where it would cause a noticeable GC impact?
- Should the persistent term's key be namespaced to avoid conflict? Something like `{__MODULE__, name}`?