### PR TITLE
Add mix eval

### DIFF
--- a/lib/mix/lib/mix/tasks/app.config.ex
+++ b/lib/mix/lib/mix/tasks/app.config.ex
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.App.Config do
     * `--permanent` - starts the application as permanent
     * `--preload-modules` - preloads all modules defined in applications
     * `--no-archives-check` - does not check archives
-    * `--no-app-loading` - does not load .app resource files (including from deps) before compiling
+    * `--no-app-loading` - does not load .app resource file after compilation
     * `--no-compile` - does not compile even if files require compilation
     * `--no-deps-check` - does not check dependencies
     * `--no-elixir-version-check` - does not check Elixir version

--- a/lib/mix/lib/mix/tasks/compile.all.ex
+++ b/lib/mix/lib/mix/tasks/compile.all.ex
@@ -152,7 +152,7 @@ defmodule Mix.Tasks.Compile.All do
     else
       with {:ok, bin} <- read_app(app, lib_path),
            {:ok, {:application, _, properties} = application_data} <- consult_app_file(bin),
-           :ok <- Application.load(application_data) do
+           :ok <- :application.load(application_data) do
         if compile_env = validate_compile_env? && properties[:compile_env] do
           Config.Provider.validate_compile_env(compile_env, false)
         end

--- a/lib/mix/lib/mix/tasks/compile.all.ex
+++ b/lib/mix/lib/mix/tasks/compile.all.ex
@@ -20,10 +20,7 @@ defmodule Mix.Tasks.Compile.All do
     # during compilation. It is likely this will be invoked anyway,
     # as both Elixir and app compilers rely on it.
     Mix.Dep.cached()
-
-    unless "--no-app-loading" in args do
-      load_apps(config, lib_path, validate_compile_env?)
-    end
+    load_apps(config, lib_path, validate_compile_env?)
 
     result =
       if "--no-compile" in args do
@@ -40,9 +37,12 @@ defmodule Mix.Tasks.Compile.All do
         end)
       end
 
-    app = config[:app]
     _ = Code.prepend_path(Mix.Project.compile_path())
-    load_app(app, lib_path, validate_compile_env?)
+
+    unless "--no-app-loading" in args do
+      load_app(config[:app], lib_path, validate_compile_env?)
+    end
+
     result
   end
 
@@ -152,7 +152,7 @@ defmodule Mix.Tasks.Compile.All do
     else
       with {:ok, bin} <- read_app(app, lib_path),
            {:ok, {:application, _, properties} = application_data} <- consult_app_file(bin),
-           :ok <- :application.load(application_data) do
+           :ok <- Application.load(application_data) do
         if compile_env = validate_compile_env? && properties[:compile_env] do
           Config.Provider.validate_compile_env(compile_env, false)
         end

--- a/lib/mix/lib/mix/tasks/compile.ex
+++ b/lib/mix/lib/mix/tasks/compile.ex
@@ -49,7 +49,7 @@ defmodule Mix.Tasks.Compile do
     * `--erl-config` - path to an Erlang term file that will be loaded as Mix config
     * `--force` - forces compilation
     * `--list` - lists all enabled compilers
-    * `--no-app-loading` - does not load .app resource files (including from deps) before compiling
+    * `--no-app-loading` - does not load .app resource file after compilation
     * `--no-archives-check` - skips checking of archives
     * `--no-compile` - does not actually compile, only loads code and perform checks
     * `--no-deps-check` - skips checking of dependencies

--- a/lib/mix/lib/mix/tasks/eval.ex
+++ b/lib/mix/lib/mix/tasks/eval.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Eval do
   @moduledoc """
   Evaluates the given code.
 
-    mix eval "IO.puts 1 + 2"
+      mix eval "IO.puts 1 + 2"
 
   The given code is evaluated after the current application
   has been configured, but without starting/running it.

--- a/lib/mix/lib/mix/tasks/eval.ex
+++ b/lib/mix/lib/mix/tasks/eval.ex
@@ -1,0 +1,73 @@
+defmodule Mix.Tasks.Eval do
+  use Mix.Task
+
+  @shortdoc "Evaluates the given code"
+
+  @moduledoc """
+  Evaluates the given code.
+
+    mix eval "IO.puts 1 + 2"
+
+  The given code is evaluated after the current application
+  has been configured, but without starting/running it.
+  See `mix run` for running code and scripts within a running
+  application:
+
+  This task is designed to mirror the `bin/my_app eval` command
+  in releases. If you want to start your application, you may do
+  so by using functions such as `Application.ensure_all_started/1`.
+  For more information about the application life-cycle and
+  dynamically configuring applications, see the `Application` module.
+
+  This task is automatically re-enabled, so it can be called multiple
+  times with different arguments.
+
+  ## Command-line options
+
+    * `--no-archives-check` - does not check archives
+    * `--no-compile` - does not compile even if files require compilation
+    * `--no-deps-check` - does not check dependencies
+    * `--no-elixir-version-check` - does not check the Elixir version from mix.exs
+    * `--no-mix-exs` - allows the command to run even if there is no mix.exs
+
+  """
+
+  @impl true
+  def run(args) do
+    {_opts, head} =
+      OptionParser.parse_head!(
+        args,
+        strict: [
+          mix_exs: :boolean,
+          compile: :boolean,
+          deps_check: :boolean,
+          archives_check: :boolean,
+          elixir_version_check: :boolean
+        ]
+      )
+
+    case head do
+      [to_eval] ->
+        cond do
+          Mix.Project.get() ->
+            Mix.Task.run("app.config", args)
+
+          "--no-mix-exs" in args ->
+            :ok
+
+          true ->
+            Mix.raise(
+              "Cannot execute \"mix eval\" without a Mix.Project, " <>
+                "please ensure you are running Mix in a directory with a mix.exs file " <>
+                "or pass the --no-mix-exs option"
+            )
+        end
+
+        Code.eval_string(to_eval)
+        Mix.Task.reenable("eval")
+
+      _ ->
+        Mix.raise("\"mix eval\" expects a single string to evaluate as argument")
+    end
+  end
+end

--- a/lib/mix/lib/mix/tasks/eval.ex
+++ b/lib/mix/lib/mix/tasks/eval.ex
@@ -9,9 +9,9 @@ defmodule Mix.Tasks.Eval do
       mix eval "IO.puts 1 + 2"
 
   The given code is evaluated after the current application
-  has been configured, but without starting/running it.
+  has been configured and loaded, but without starting/running it.
   See `mix run` for running code and scripts within a running
-  application:
+  application.
 
   This task is designed to mirror the `bin/my_app eval` command
   in releases. If you want to start your application, you may do

--- a/lib/mix/lib/mix/tasks/run.ex
+++ b/lib/mix/lib/mix/tasks/run.ex
@@ -1,16 +1,18 @@
 defmodule Mix.Tasks.Run do
   use Mix.Task
 
-  @shortdoc "Runs the current application and scripts"
+  @shortdoc "Runs the current application"
 
   @moduledoc """
-  Runs the current application and scripts.
+  Runs the current application.
 
-  `mix run` starts the current application dependencies, the application
-  itself, and may also run some code in its context.
+  `mix run` starts the current application dependencies and the
+  application itself. The application will be compiled if it has
+  not been compiled yet or it is outdated.
 
-  To run a script within the current application, after it has been
-  started, you may pass a filename as argument:
+  `mix run` may also run code in the application context through
+  additional options. For example, to run a script within the
+  current application, you may pass a filename as argument:
 
       mix run my_app_script.exs arg1 arg2 arg3
 
@@ -19,18 +21,16 @@ defmodule Mix.Tasks.Run do
       mix run -e "DbUtils.delete_old_records()" -- arg1 arg2 arg3
 
   In both cases, the command-line arguments for the script or expression
-  are available in `System.argv/0`.
+  are available in `System.argv/0`. This mirror the command line interface
+  in the `elixir` executable.
 
   For starting long running systems, one typically passes the `--no-halt`
   option:
 
       mix run --no-halt
 
-  In all cases, Mix will compile the current application if needed,
-  unless you pass `--no-compile`.
-
   The `--no-start` option can also be given and the current application,
-  nor its dependencies, will be started. Alternatively, you may use
+  nor its dependencies will be started. Alternatively, you may use
   `mix eval` to evaluate a single expression without starting the current
   application.
 

--- a/lib/mix/lib/mix/tasks/run.ex
+++ b/lib/mix/lib/mix/tasks/run.ex
@@ -1,20 +1,16 @@
 defmodule Mix.Tasks.Run do
   use Mix.Task
 
-  @shortdoc "Starts and runs the current application"
+  @shortdoc "Runs the current application and scripts"
 
   @moduledoc """
-  Starts the current application and runs code.
+  Runs the current application and scripts.
 
-  `mix run` can be used to start the current application dependencies,
-  the application itself, and optionally run some code in its context.
-  For long running systems, this is typically done with the `--no-halt`
-  option:
+  `mix run` starts the current application dependencies, the application
+  itself, and may also run some code in its context.
 
-      mix run --no-halt
-
-  Once the current application and its dependencies have been started,
-  you can run a script in its context by passing a filename:
+  To run a script within the current application, after it has been
+  started, you may pass a filename as argument:
 
       mix run my_app_script.exs arg1 arg2 arg3
 
@@ -25,15 +21,18 @@ defmodule Mix.Tasks.Run do
   In both cases, the command-line arguments for the script or expression
   are available in `System.argv/0`.
 
-  Before doing anything, Mix will compile the current application if
-  needed, unless you pass `--no-compile`.
+  For starting long running systems, one typically passes the `--no-halt`
+  option:
 
-  If for some reason the application needs to be configured before it is
-  started, the `--no-start` option can be used and you are then responsible
-  for starting all applications by using functions such as
-  `Application.ensure_all_started/1`. For more information about the
-  application life-cycle and dynamically configuring applications, see
-  the `Application` module.
+      mix run --no-halt
+
+  In all cases, Mix will compile the current application if needed,
+  unless you pass `--no-compile`.
+
+  The `--no-start` option can also be given and the current application,
+  nor its dependencies, will be started. Alternatively, you may use
+  `mix eval` to evaluate a single expression without starting the current
+  application.
 
   If you need to pass options to the Elixir executable at the same time
   you use `mix run`, it can be done as follows:
@@ -45,18 +44,17 @@ defmodule Mix.Tasks.Run do
 
   ## Command-line options
 
-    * `--config` - loads the given configuration files
     * `--eval`, `-e` - evaluates the given code
     * `--require`, `-r` - executes the given pattern/file
     * `--parallel`, `-p` - makes all requires parallel
     * `--preload-modules` - preloads all modules defined in applications
+    * `--no-archives-check` - does not check archives
     * `--no-compile` - does not compile even if files require compilation
     * `--no-deps-check` - does not check dependencies
-    * `--no-archives-check` - does not check archives
+    * `--no-elixir-version-check` - does not check the Elixir version from mix.exs
     * `--no-halt` - does not halt the system after running the command
     * `--no-mix-exs` - allows the command to run even if there is no mix.exs
     * `--no-start` - does not start applications after compilation
-    * `--no-elixir-version-check` - does not check the Elixir version from mix.exs
 
   """
 

--- a/lib/mix/test/mix/tasks/eval_test.exs
+++ b/lib/mix/test/mix/tasks/eval_test.exs
@@ -1,0 +1,39 @@
+Code.require_file("../../test_helper.exs", __DIR__)
+
+defmodule Mix.Tasks.EvalTest do
+  use MixTest.Case
+
+  setup do
+    Mix.Project.push(MixTest.Case.Sample)
+  end
+
+  test "does not start applications", context do
+    in_tmp(context.test, fn ->
+      expr = "send self(), {:apps, Application.started_applications()}"
+      Mix.Tasks.Eval.run([expr])
+      assert_received {:apps, apps}
+      refute List.keyfind(apps, :sample, 0)
+    end)
+  end
+
+  test "runs multiple commands", context do
+    in_tmp(context.test, fn ->
+      Mix.Tasks.Eval.run(["send self(), {:eval, :foo}"])
+      assert_received {:eval, :foo}
+
+      Mix.Tasks.Eval.run(["send self(), {:eval, :bar}"])
+      assert_received {:eval, :bar}
+    end)
+  end
+
+  test "runs without mix.exs" do
+    Mix.Project.pop()
+
+    assert_raise Mix.Error, ~r/Cannot execute "mix eval" without a Mix.Project/, fn ->
+      Mix.Tasks.Eval.run(["send self(), {:eval, :foo}"])
+    end
+
+    Mix.Tasks.Eval.run(["--no-mix-exs", "send self(), {:eval, :foo}"])
+    assert_received {:eval, :foo}
+  end
+end

--- a/lib/mix/test/mix/tasks/eval_test.exs
+++ b/lib/mix/test/mix/tasks/eval_test.exs
@@ -9,7 +9,7 @@ defmodule Mix.Tasks.EvalTest do
 
   test "does not start applications", context do
     in_tmp(context.test, fn ->
-      expr = "send self(), {:apps, Application.started_applications()}"
+      expr = "send self(), {:apps, Application.loaded_applications()}"
       Mix.Tasks.Eval.run([expr])
       assert_received {:apps, apps}
       refute List.keyfind(apps, :sample, 0)


### PR DESCRIPTION
The goal of this task is to have an equivalent for `bin/my_app eval` in releases, so developers can easily run commands that apply for both releases and regular code.

My biggest concern is if the differences between `mix eval` and `mix run` are clear in the docs, so feedback on this area is welcome!