### PR TITLE
[ExUnit] Use line filter against both first and last test lines

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -128,13 +128,14 @@ defmodule ExUnit do
       * `:tests` - all tests in this module
 
     """
-    defstruct [:file, :name, :state, tests: []]
+    defstruct [:file, :name, :state, :last_line, tests: []]
 
     @type t :: %__MODULE__{
             file: binary(),
             name: module,
             state: ExUnit.state(),
-            tests: [ExUnit.Test.t()]
+            tests: [ExUnit.Test.t()],
+            last_line: integer
           }
   end
 

--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -192,11 +192,11 @@ defmodule ExUnit.CLIFormatter do
   end
 
   defp trace_test_line(%ExUnit.Test{tags: tags}) do
-    "L##{tags.line}"
+    "L##{tags.first_line}"
   end
 
   defp trace_test_file_line(%ExUnit.Test{tags: tags}) do
-    "#{Path.relative_to_cwd(tags.file)}:#{tags.line}"
+    "#{Path.relative_to_cwd(tags.file)}:#{tags.first_line}"
   end
 
   defp trace_test_started(test) do

--- a/lib/ex_unit/lib/ex_unit/filters.ex
+++ b/lib/ex_unit/lib/ex_unit/filters.ex
@@ -199,7 +199,11 @@ defmodule ExUnit.Filters do
     end
   end
 
-  defp has_tag({:line, line}, %{line: _, describe_line: describe_line} = tags, collection) do
+  defp has_tag(
+         {:line, line},
+         %{first_line: _, last_line: _, describe_line: describe_line} = tags,
+         collection
+       ) do
     line = to_integer(line)
 
     cond do
@@ -210,7 +214,7 @@ defmodule ExUnit.Filters do
         false
 
       true ->
-        tags.line <= line and closest_test_before_line(line, collection).tags.line == tags.line
+        line >= tags.first_line and line <= tags.last_line
     end
   end
 
@@ -233,6 +237,8 @@ defmodule ExUnit.Filters do
     end
   end
 
+  defp has_tag(:line, %{first_line: _, last_line: _}), do: :line
+
   defp has_tag(key, tags) when is_atom(key), do: Map.has_key?(tags, key) and key
 
   defp to_integer(integer) when is_integer(integer), do: integer
@@ -246,16 +252,6 @@ defmodule ExUnit.Filters do
   defp describe_block?(line, collection) do
     Enum.any?(collection, fn %ExUnit.Test{tags: %{describe_line: describe_line}} ->
       line == describe_line
-    end)
-  end
-
-  defp closest_test_before_line(line, collection) do
-    Enum.min_by(collection, fn %ExUnit.Test{tags: %{line: test_line}} ->
-      if line - test_line >= 0 do
-        line - test_line
-      else
-        :infinity
-      end
     end)
   end
 end

--- a/lib/ex_unit/lib/ex_unit/formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/formatter.ex
@@ -508,7 +508,7 @@ defmodule ExUnit.Formatter do
   end
 
   defp with_location(tags) do
-    path = "#{Path.relative_to_cwd(tags[:file])}:#{tags[:line]}"
+    path = "#{Path.relative_to_cwd(tags[:file])}:#{tags[:first_line]}"
 
     if prefix = Application.get_env(:ex_unit, :test_location_relative_path) do
       Path.join(prefix, path)

--- a/lib/ex_unit/lib/ex_unit/runner.ex
+++ b/lib/ex_unit/lib/ex_unit/runner.ex
@@ -216,7 +216,7 @@ defmodule ExUnit.Runner do
     EM.module_started(config.manager, test_module)
 
     # Prepare tests, selecting which ones should be run or skipped
-    tests = prepare_tests(config, test_module.tests)
+    tests = prepare_tests(config, test_module)
     {excluded_and_skipped_tests, to_run_tests} = Enum.split_with(tests, & &1.state)
 
     for excluded_or_skipped_test <- excluded_and_skipped_tests do
@@ -251,14 +251,19 @@ defmodule ExUnit.Runner do
     end
   end
 
-  defp prepare_tests(config, tests) do
-    tests = shuffle(config, tests)
+  defp prepare_tests(config, test_module) do
+    tests = shuffle(config, test_module.tests)
     include = config.include
     exclude = config.exclude
     test_ids = config.only_test_ids
 
     for test <- tests, include_test?(test_ids, test) do
-      tags = Map.merge(test.tags, %{test: test.name, module: test.module})
+      tags =
+        Map.merge(test.tags, %{
+          test: test.name,
+          module: test.module,
+          last_module_line: test_module.last_line
+        })
 
       case ExUnit.Filters.eval(include, exclude, tags, tests) do
         :ok -> %{test | tags: tags}

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -27,11 +27,13 @@ defmodule ExUnit.CaseTest do
   @tag world: :bad
   @tag world: :good
   test "tags", context do
-    line = __ENV__.line - 1
+    first_line = __ENV__.line - 1
+    last_line = __ENV__.line + 8
     assert context[:module] == __MODULE__
     assert context[:case] == __MODULE__
     assert context[:test] == __ENV__.function |> elem(0)
-    assert context[:line] == line
+    assert context[:first_line] == first_line
+    assert context[:last_line] == last_line
     assert context[:async] == true
     assert context[:hello] == true
     assert context[:world] == :good

--- a/lib/ex_unit/test/ex_unit/filters_test.exs
+++ b/lib/ex_unit/test/ex_unit/filters_test.exs
@@ -159,28 +159,84 @@ defmodule ExUnit.FiltersTest do
 
   test "evaluating filter uses special rules for line" do
     tests = [
-      %ExUnit.Test{tags: %{line: 3, describe_line: 2}},
-      %ExUnit.Test{tags: %{line: 5, describe_line: nil}},
-      %ExUnit.Test{tags: %{line: 8, describe_line: 7}},
-      %ExUnit.Test{tags: %{line: 10, describe_line: 7}},
-      %ExUnit.Test{tags: %{line: 13, describe_line: 12}}
+      %ExUnit.Test{tags: %{first_line: 3, last_line: 4, describe_line: 2}},
+      %ExUnit.Test{tags: %{first_line: 5, last_line: 6, describe_line: nil}},
+      %ExUnit.Test{tags: %{first_line: 8, last_line: 9, describe_line: 7}},
+      %ExUnit.Test{tags: %{first_line: 10, last_line: 11, describe_line: 7}},
+      %ExUnit.Test{tags: %{first_line: 13, last_line: 15, describe_line: 12}}
     ]
 
-    assert ExUnit.Filters.eval([line: "3"], [:line], %{line: 3, describe_line: 2}, tests) == :ok
-    assert ExUnit.Filters.eval([line: "4"], [:line], %{line: 3, describe_line: 2}, tests) == :ok
-    assert ExUnit.Filters.eval([line: "5"], [:line], %{line: 5, describe_line: nil}, tests) == :ok
-    assert ExUnit.Filters.eval([line: "6"], [:line], %{line: 5, describe_line: nil}, tests) == :ok
-    assert ExUnit.Filters.eval([line: "2"], [:line], %{line: 3, describe_line: 2}, tests) == :ok
-    assert ExUnit.Filters.eval([line: "7"], [:line], %{line: 8, describe_line: 7}, tests) == :ok
-    assert ExUnit.Filters.eval([line: "7"], [:line], %{line: 10, describe_line: 7}, tests) == :ok
+    assert ExUnit.Filters.eval(
+             [line: "3"],
+             [:line],
+             %{first_line: 3, last_line: 4, describe_line: 2},
+             tests
+           ) == :ok
 
-    assert ExUnit.Filters.eval([line: "1"], [:line], %{line: 3, describe_line: 2}, tests) ==
+    assert ExUnit.Filters.eval(
+             [line: "4"],
+             [:line],
+             %{first_line: 3, last_line: 4, describe_line: 2},
+             tests
+           ) == :ok
+
+    assert ExUnit.Filters.eval(
+             [line: "5"],
+             [:line],
+             %{first_line: 5, last_line: 6, describe_line: nil},
+             tests
+           ) == :ok
+
+    assert ExUnit.Filters.eval(
+             [line: "6"],
+             [:line],
+             %{first_line: 5, last_line: 6, describe_line: nil},
+             tests
+           ) == :ok
+
+    assert ExUnit.Filters.eval(
+             [line: "2"],
+             [:line],
+             %{first_line: 3, last_line: 4, describe_line: 2},
+             tests
+           ) == :ok
+
+    assert ExUnit.Filters.eval(
+             [line: "7"],
+             [:line],
+             %{first_line: 8, last_line: 9, describe_line: 7},
+             tests
+           ) == :ok
+
+    assert ExUnit.Filters.eval(
+             [line: "7"],
+             [:line],
+             %{first_line: 10, last_line: 11, describe_line: 7},
+             tests
+           ) == :ok
+
+    assert ExUnit.Filters.eval(
+             [line: "1"],
+             [:line],
+             %{first_line: 3, last_line: 4, describe_line: 2},
+             tests
+           ) ==
              {:excluded, "due to line filter"}
 
-    assert ExUnit.Filters.eval([line: "7"], [:line], %{line: 3, describe_line: 2}, tests) ==
+    assert ExUnit.Filters.eval(
+             [line: "7"],
+             [:line],
+             %{first_line: 3, last_line: 4, describe_line: 2},
+             tests
+           ) ==
              {:excluded, "due to line filter"}
 
-    assert ExUnit.Filters.eval([line: "7"], [:line], %{line: 5, describe_line: nil}, tests) ==
+    assert ExUnit.Filters.eval(
+             [line: "7"],
+             [:line],
+             %{first_line: 5, last_line: 6, describe_line: nil},
+             tests
+           ) ==
              {:excluded, "due to line filter"}
   end
 

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -21,7 +21,11 @@ defmodule ExUnit.FormatterTest do
   end
 
   defp test do
-    %ExUnit.Test{name: :world, module: Hello, tags: %{file: __ENV__.file, line: 1}}
+    %ExUnit.Test{
+      name: :world,
+      module: Hello,
+      tags: %{file: __ENV__.file, first_line: 1, last_line: 1}
+    }
   end
 
   def falsy() do

--- a/lib/ex_unit/test/ex_unit_test.exs
+++ b/lib/ex_unit/test/ex_unit_test.exs
@@ -470,6 +470,28 @@ defmodule ExUnitTest do
     assert output =~ "\n2 tests, 1 failure, 1 excluded\n"
   end
 
+  test "filtering cases with :line tag" do
+    defmodule ThirdTestModule do
+      use ExUnit.Case
+      test "ok", do: :ok
+    end
+
+    defmodule FourthTestModule do
+      use ExUnit.Case
+      test "false", do: assert(false)
+    end
+
+    fourth_test_line = __ENV__.line - 3
+    ## Empty because it is already loaded
+    {result, output} =
+      [exclude: :test, include: [line: fourth_test_line]]
+      |> run_with_filter([])
+
+    assert result == %{failures: 1, skipped: 0, excluded: 1, total: 2}
+    assert output =~ "\n  1) test false (ExUnitTest.FourthTestModule)\n"
+    assert output =~ "\n2 tests, 1 failure, 1 excluded\n"
+  end
+
   test "raises on reserved tag :file in module" do
     assert_raise RuntimeError, "cannot set tag :file because it is reserved by ExUnit", fn ->
       defmodule ReservedTagFile do

--- a/lib/mix/test/mix/tasks/test_test.exs
+++ b/lib/mix/test/mix/tasks/test_test.exs
@@ -481,12 +481,12 @@ defmodule Mix.Tasks.TestTest do
         refute output =~ "==> foo"
         refute output =~ "Paths given to \"mix test\" did not match any directory/file"
 
-        output = mix(["test", "apps/bar/test/bar_tests.exs:10"])
+        output = mix(["test", "apps/bar/test/bar_tests.exs:9"])
 
         assert output =~ """
                ==> bar
                Excluding tags: [:test]
-               Including tags: [line: \"10\"]
+               Including tags: [line: \"9\"]
 
                .
                """


### PR DESCRIPTION
## Intro

This PR changes the behavior of ExUnit's line filter.
It makes sure that only the test referenced in the filter is executed in case more than one test module is defined in one test file (see the example below).
Defining multiple test modules in one file comes in handy when parallelizing tests aggressively, such as defining each test as a separate `async: true` test module.

## Example

Given the following test module:

```elixir
defmodule MultipleTestModulesTest do
  defmodule TestModule1 do
    use ExUnit.Case

    test "one" do
      assert "one" == 1
    end
  end

  defmodule TestModule2 do
    use ExUnit.Case

    test "two" do
      assert "two" == 2
    end
  end
end
```

Currently, in `main,` when we run the test with the line filter `mix test test/multiple_test_modules_in_file.exs:14`, both tests will be executed. The tests in a file are filtered on a module by module basis -- the first test from every module that starts before the line `14` is executed:

```
% mix test test/multiple_test_modules_in_file.exs:14
Excluding tags: [:test]
Including tags: [line: "14"]



  1) test two (MultipleTestModulesTest.TestModule2)
     test/multiple_test_modules_in_file.exs:13
     Assertion with == failed
     code:  assert "two" == 2
     left:  "two"
     right: 2
     stacktrace:
       test/multiple_test_modules_in_file.exs:14: (test)



  2) test one (MultipleTestModulesTest.TestModule1)
     test/multiple_test_modules_in_file.exs:5
     Assertion with == failed
     code:  assert "one" == 1
     left:  "one"
     right: 1
     stacktrace:
       test/multiple_test_modules_in_file.exs:6: (test)


Finished in 0.02 seconds (0.00s async, 0.02s sync)
2 tests, 2 failures
```

The changes proposed in this PR consider both the first and last line of every test and make sure that only the test is executed if the filter is in that range: 
```
% mix test test/multiple_test_modules_in_file.exs:14
Excluding tags: [:test]
Including tags: [line: "14"]



  1) test two (MultipleTestModulesTest.TestModule2)
     test/multiple_test_modules_in_file.exs:13
     Assertion with == failed
     code:  assert "two" == 2
     left:  "two"
     right: 2
     stacktrace:
       test/multiple_test_modules_in_file.exs:14: (test)


Finished in 0.02 seconds (0.00s async, 0.02s sync)
2 tests, 1 failure, 1 excluded
```

## Considerations
- The line filter behavior changes, which might be unexpected. See the difference in `lib/mix/test/mix/tasks/test_test.exs`, where the line filter was pointing at the `end` of the test. `end` does not count as a statement, so it was not considered when calculating the `last_line`;
- Test tag `line` changes to `first_line.` Potentially risky, but after adding `last_line,` I thought that would be more clear than having `line` and `last_line`;
- `ExUnit.Case.register_test` API changes (`last_line` added). Should anything external rely on this function's API?
- This is the easiest solution I was able to figure out. Still, I understand that calculating the `last_line` might not be desired, or even the current behavior is deliberate. Looking forward to feedback :)