### PR TITLE
Display friendly error when test name is too long (#11844)

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -534,11 +534,12 @@ defmodule ExUnit.Case do
     {name, describe, describe_line, describetag} =
       case Module.get_attribute(mod, :ex_unit_describe) do
         {line, describe, _counter} ->
-          description = :"#{test_type} #{describe} #{name}"
-          {description, describe, line, Module.get_attribute(mod, :describetag)}
+          test_name = validate_test_name("#{test_type} #{describe} #{name}")
+          {test_name, describe, line, Module.get_attribute(mod, :describetag)}
 
         nil ->
-          {:"#{test_type} #{name}", nil, nil, []}
+          test_name = validate_test_name("#{test_type} #{name}")
+          {test_name, nil, nil, []}
       end
 
     if Module.defines?(mod, {name, 1}) do
@@ -735,6 +736,18 @@ defmodule ExUnit.Case do
     end
 
     tags
+  end
+
+  defp validate_test_name(name) do
+    if byte_size(name) <= 255 do
+      String.to_atom(name)
+    else
+      raise """
+      the computed name of a test (which includes its type, the name of its parent describe \
+      block if present, and the test name itself) must be shorter than 255 characters, \
+      got: #{inspect(name)}
+      """
+    end
   end
 
   defp normalize_tags(tags) do

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -112,6 +112,30 @@ defmodule ExUnit.CaseTest do
       end
     end
   end
+
+  test "raises when name is longer than 255 characters" do
+    assert_raise RuntimeError,
+                 ~r/must be shorter than 255 characters, got: "test a{256}"/,
+                 fn ->
+                   defmodule LongNameTest do
+                     use ExUnit.Case
+
+                     test String.duplicate("a", 256)
+                   end
+                 end
+
+    assert_raise RuntimeError,
+                 ~r/must be shorter than 255 characters, got: "test a{100} a{156}"/,
+                 fn ->
+                   defmodule LongDescribeNameTest do
+                     use ExUnit.Case
+
+                     describe String.duplicate("a", 100) do
+                       test String.duplicate("a", 156)
+                     end
+                   end
+                 end
+  end
 end
 
 defmodule ExUnit.DoubleCaseTest1 do


### PR DESCRIPTION
See: https://github.com/elixir-lang/elixir/issues/11844

This commit changes ExUnit.Case to show a more specific error message
when the test name is too long that would cause SystemLimitError.