### PR TITLE
Introduce t:Supervisor.sup_flags/0 + Streamline specs

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -175,7 +175,8 @@ defmodule DynamicSupervisor do
   Developers typically invoke `DynamicSupervisor.init/1` at the end of
   their init callback to return the proper supervision flags.
   """
-  @callback init(init_arg :: term) :: {:ok, sup_flags()} | :ignore
+  @callback init(init_arg :: term) ::
+              {:ok, sup_flags() | (old_erlang_sup_flags :: :supervisor.sup_flags())} | :ignore
 
   @typedoc "The supervisor flags returned on init"
   @type sup_flags() :: %{
@@ -564,7 +565,8 @@ defmodule DynamicSupervisor do
 
   """
   @doc since: "1.6.0"
-  @spec init([init_option]) :: {:ok, sup_flags()}
+  @spec init([init_option]) ::
+          {:ok, sup_flags() | (old_erlang_sup_flags :: :supervisor.sup_flags())}
   def init(options) when is_list(options) do
     strategy = Keyword.get(options, :strategy, :one_for_one)
     intensity = Keyword.get(options, :max_restarts, 3)

--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -175,8 +175,7 @@ defmodule DynamicSupervisor do
   Developers typically invoke `DynamicSupervisor.init/1` at the end of
   their init callback to return the proper supervision flags.
   """
-  @callback init(init_arg :: term) ::
-              {:ok, sup_flags() | (old_erlang_sup_flags :: :supervisor.sup_flags())} | :ignore
+  @callback init(init_arg :: term) :: {:ok, sup_flags()} | :ignore
 
   @typedoc "The supervisor flags returned on init"
   @type sup_flags() :: %{
@@ -565,8 +564,7 @@ defmodule DynamicSupervisor do
 
   """
   @doc since: "1.6.0"
-  @spec init([init_option]) ::
-          {:ok, sup_flags() | (old_erlang_sup_flags :: :supervisor.sup_flags())}
+  @spec init([init_option]) :: {:ok, sup_flags()}
   def init(options) when is_list(options) do
     strategy = Keyword.get(options, :strategy, :one_for_one)
     intensity = Keyword.get(options, :max_restarts, 3)

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -488,8 +488,7 @@ defmodule Supervisor do
   """
   @callback init(init_arg :: term) ::
               {:ok,
-               {sup_flags() | (old_erlang_sup_flags :: :supervisor.sup_flags()),
-                [child_spec() | (old_erlang_child_spec :: :supervisor.child_spec())]}}
+               {sup_flags(), [child_spec() | (old_erlang_child_spec :: :supervisor.child_spec())]}}
               | :ignore
 
   @typedoc "Return values of `start_link` functions"

--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -662,7 +662,7 @@ defmodule Supervisor do
             | (old_erlang_child_spec :: :supervisor.child_spec())
           ],
           [init_option]
-        ) :: {:ok, sup_flags() | (old_erlang_sup_flags :: :supervisor.sup_flags())}
+        ) :: {:ok, sup_flags()}
   def init(children, options) when is_list(children) and is_list(options) do
     strategy =
       case options[:strategy] do


### PR DESCRIPTION
Introduces t:Supervisor.sup_flags/0, and strealines the functions in
DynamicSupervisor and Supervisor that use Erlang typespecs.