### PR TITLE
Improve Code.Fragment.surround_context spec

### DIFF
--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -480,6 +480,8 @@ defmodule Code.Fragment do
 
     * This function never returns empty sigils `{:sigil, ''}` or empty structs
       `{:struct, ''}` as context
+
+    * This function never returns `:expr`
   """
   @doc since: "1.13.0"
   @spec surround_context(List.Chars.t(), position(), keyword()) ::

--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -492,6 +492,8 @@ defmodule Code.Fragment do
                | {:local_call, charlist}
                | {:module_attribute, charlist}
                | {:operator, charlist}
+               | {:sigil, charlist}
+               | {:struct, charlist}
                | {:unquoted_atom, charlist},
              inside_dot:
                {:alias, charlist}

--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -482,6 +482,7 @@ defmodule Code.Fragment do
       `{:struct, ''}` as context
 
     * This function never returns `:expr`
+
   """
   @doc since: "1.13.0"
   @spec surround_context(List.Chars.t(), position(), keyword()) ::


### PR DESCRIPTION
This PR adds missing options to Code.Fragment.surround_context spec and adds a note about another difference between `cursor_context` and `surround_context`