### PR TITLE
Fix Supervisor.init/2 return type in spec

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -661,7 +661,9 @@ defmodule Supervisor do
             | (old_erlang_child_spec :: :supervisor.child_spec())
           ],
           [init_option]
-        ) :: {:ok, sup_flags()}
+        ) ::
+          {:ok,
+           {sup_flags(), [child_spec() | (old_erlang_child_spec :: :supervisor.child_spec())]}}
   def init(children, options) when is_list(children) and is_list(options) do
     strategy =
       case options[:strategy] do


### PR DESCRIPTION
Dialyzer [found](https://github.com/michallepicki/elixir-lang-dialyzer-runs/runs/6583721433?check_suite_focus=true) a small issue with Supervisor specs and types that were recently improved in https://github.com/elixir-lang/elixir/pull/11865