### PR TITLE
Mix.Dep.Converger now tells which deps formed a cycle

### DIFF
--- a/lib/mix/lib/mix/dep/converger.ex
+++ b/lib/mix/lib/mix/dep/converger.ex
@@ -30,11 +30,34 @@ defmodule Mix.Dep.Converger do
           Enum.find(deps, fn %Mix.Dep{app: other_app} -> app == other_app end)
         end)
       else
-        Mix.raise("Could not sort dependencies. There are cycles in the dependency graph")
+        find_cycle(graph)
       end
     after
       :digraph.delete(graph)
     end
+  end
+
+  @doc """
+  A Depth-First Search to find where is the dependency graph cycle
+  and then display the cyclic dependencies back to the developer.
+  """
+  def find_cycle(graph), do: find_cycle(graph, :digraph.vertices(graph), [])
+
+  defp find_cycle(_, [], _visited), do: nil
+
+  defp find_cycle(graph, [v | vs], visited) do
+    if v in visited, do: cycle_found(visited)
+
+    find_cycle(graph, :digraph.out_neighbours(graph, v), [v | visited])
+    find_cycle(graph, vs, visited)
+  end
+
+  defp cycle_found(visited) do
+    Mix.raise(
+      "Could not sort dependencies. " <>
+        "The following dependencies form a cycle: " <>
+        Enum.join(visited, ", ")
+    )
   end
 
   @doc """

--- a/lib/mix/lib/mix/dep/converger.ex
+++ b/lib/mix/lib/mix/dep/converger.ex
@@ -41,14 +41,14 @@ defmodule Mix.Dep.Converger do
   A Depth-First Search to find where is the dependency graph cycle
   and then display the cyclic dependencies back to the developer.
   """
-  def find_cycle(graph), do: find_cycle(graph, :digraph.vertices(graph), [])
+  def find_cycle(graph), do: find_cycle(graph, :digraph.vertices(graph), MapSet.new())
 
   defp find_cycle(_, [], _visited), do: nil
 
   defp find_cycle(graph, [v | vs], visited) do
     if v in visited, do: cycle_found(visited)
 
-    find_cycle(graph, :digraph.out_neighbours(graph, v), [v | visited])
+    find_cycle(graph, :digraph.out_neighbours(graph, v), MapSet.put(visited, v))
     find_cycle(graph, vs, visited)
   end
 

--- a/lib/mix/test/mix/dep/converger_test.exs
+++ b/lib/mix/test/mix/dep/converger_test.exs
@@ -1,0 +1,38 @@
+Code.require_file("../../test_helper.exs", __DIR__)
+
+defmodule Mix.Dep.ConvergerTest do
+  use MixTest.Case
+
+  describe "topological_sort" do
+    test "raises if there is a cycle in the dependency graph" do
+      app1 = %Mix.Dep{app: :app1}
+      app2 = %Mix.Dep{app: :app2}
+      app3 = %Mix.Dep{app: :app3}
+
+      deps = [
+        # not really part of the cycle, just depend on it
+        %Mix.Dep{app: :app5, deps: [app1, app3]},
+        %Mix.Dep{app: :app4, deps: [app2]},
+
+        # cycle
+        %{app1 | deps: [app2]},
+        %{app2 | deps: [app3]},
+        %{app3 | deps: [app1]}
+      ]
+
+      assert_raise Mix.Error,
+                   "Could not sort dependencies. " <>
+                     "The following dependencies form a cycle: app1, app2, app3",
+                   fn -> Mix.Dep.Converger.topological_sort(deps) end
+    end
+
+    test "raises if an app depends upon itself" do
+      app = %Mix.Dep{app: :self_dependent}
+      deps = [%{app | deps: [app]}]
+
+      assert_raise Mix.Error,
+                   "App self_dependent lists itself as a dependency",
+                   fn -> Mix.Dep.Converger.topological_sort(deps) end
+    end
+  end
+end

--- a/lib/mix/test/mix/dep_test.exs
+++ b/lib/mix/test/mix/dep_test.exs
@@ -477,7 +477,7 @@ defmodule Mix.DepTest do
       Mix.RemoteConverger.register(RaiseRemoteConverger)
 
       in_fixture("deps_cycle", fn ->
-        assert_raise Mix.Error, ~r/cycles in the dependency graph/, fn ->
+        assert_raise Mix.Error, ~r/Could not sort dependencies/, fn ->
           Mix.Tasks.Deps.Get.run([])
         end
 


### PR DESCRIPTION
So, I work on an umbrella project and every now and then I get this error about a cycle in my dependency graph. However, it wouldn't tell me which dependencies were causing the cycle. To solve this, I used a DFS to find the cycle and added the cyclic dependencies to the Mix.raise argument.