### PR TITLE
Update prewalk and postwalk documentation

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -546,7 +546,8 @@ defmodule Macro do
   end
 
   @doc """
-  Performs a depth-first, post-order traversal of quoted expressions.
+  This function behaves like `prewalk/2`, but performs a depth-first,
+  post-order traversal of quoted expressions.
   """
   @spec postwalk(t, (t -> t)) :: t
   def postwalk(ast, fun) when is_function(fun, 1) do

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -518,7 +518,7 @@ defmodule Macro do
   ## Examples
 
       iex> ast = quote do: 5 + 3 * 7
-      {:+, _, [5, {:*, _, [3, 7]}]} = ast
+      iex> {:+, _, [5, {:*, _, [3, 7]}]} = ast
       iex> new_ast = Macro.prewalk(ast, fn
       ...>   {:+, meta, children} -> {:*, meta, children}
       ...>   {:*, meta, children} -> {:+, meta, children}
@@ -540,24 +540,25 @@ defmodule Macro do
   Performs a depth-first, pre-order traversal of quoted expressions
   using an accumulator.
 
-  Returns a tuple where the first element is a new ast where each node is the
+  Returns a tuple where the first element is a new AST where each node is the
   result of invoking `fun` on each corresponding node and the second one is the
   final accumulator.
 
   ## Examples
 
       iex> ast = quote do: 5 + 3 * 7
-      {:+, _, [5, {:*, _, [3, 7]}]} = ast
+      iex> {:+, _, [5, {:*, _, [3, 7]}]} = ast
       iex> {new_ast, acc} = Macro.prewalk(ast, [], fn
       ...>   {:+, meta, children}, acc -> {{:*, meta, children}, [:+ | acc]}
       ...>   {:*, meta, children}, acc -> {{:+, meta, children}, [:* | acc]}
       ...>   other, acc -> {other, acc}
       ...> end)
-      {{:*, _, [5, {:+, _, [3, 7]}]}, [:*, :+]} = {new_ast, acc}
+      iex> {{:*, _, [5, {:+, _, [3, 7]}]}, [:*, :+]} = {new_ast, acc}
       iex> Code.eval_quoted(ast)
       {26, []}
       iex> Code.eval_quoted(new_ast)
       {50, []}
+
   """
   @spec prewalk(t, any, (t, any -> {t, any})) :: {t, any}
   def prewalk(ast, acc, fun) when is_function(fun, 2) do

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -518,11 +518,13 @@ defmodule Macro do
   ## Examples
 
       iex> ast = quote do: 5 + 3 * 7
+      {:+, _, [5, {:*, _, [3, 7]}]} = ast
       iex> new_ast = Macro.prewalk(ast, fn
       ...>   {:+, meta, children} -> {:*, meta, children}
       ...>   {:*, meta, children} -> {:+, meta, children}
       ...>   other -> other
       ...> end)
+      {:*, _, [5, {:+, _, [3, 7]}]} = new_ast
       iex> Code.eval_quoted(ast)
       {26, []}
       iex> Code.eval_quoted(new_ast)


### PR DESCRIPTION
I realized that the example for `prewalk/2` is a bit confusing since some people might assume that `5 + 3 * 7` is transformed to `5 * 3 + 7` while in reality it's transformed into something like `5 * (3 + 7)` because the tree shape is not changed.

I think by showing the previous and new AST in the example can be more helpful for the developer.


I also added an example for `prewalk/3` and included some references to these functions in the `postwalk/2` and `postwalk/3`