### PR TITLE
Add example for Macro.traverse/4 docs

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -526,7 +526,7 @@ defmodule Macro do
       ...>   {:*, meta, children} -> {:+, meta, children}
       ...>   other -> other
       ...> end)
-      {:*, _, [5, {:+, _, [3, 7]}]} = new_ast
+      iex> {:*, _, [5, {:+, _, [3, 7]}]} = new_ast
       iex> Code.eval_quoted(ast)
       {26, []}
       iex> Code.eval_quoted(new_ast)

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -514,7 +514,7 @@ defmodule Macro do
   @doc """
   Performs a depth-first, pre-order traversal of quoted expressions.
 
-  Returns a new ast where each node is the result of invoking `fun` on each
+  Returns a new AST where each node is the result of invoking `fun` on each
   corresponding node of `ast`.
 
   ## Examples


### PR DESCRIPTION
I missed an `iex >` prefix in my latest PR (https://github.com/elixir-lang/elixir/pull/11874) but I didn't want to open a new one just to fix a typo so I thought I could use the momentum to add another example to the docs.

I'm not sure how accurate or useful the description to `Macro.traverse/4` is, so don't hesitate to drop that commit or even close the PR if you find this doesn't add any value.

Thanks ❤️