### PR TITLE
Skip docs on secondary bootstrap

### DIFF
--- a/lib/elixir/src/elixir_compiler.erl
+++ b/lib/elixir/src/elixir_compiler.erl
@@ -154,7 +154,6 @@ bootstrap() ->
   {ok, Cwd} = file:get_cwd(),
   Lib = filename:join(Cwd, "lib/elixir/lib"),
   [bootstrap_file(Lib, File) || File <- [<<"kernel.ex">> | Init]],
-  elixir_config:put(docs, true),
   [bootstrap_file(Lib, File) || File <- [<<"kernel.ex">> | Main]].
 
 bootstrap_file(Lib, Suffix) ->


### PR DESCRIPTION
Docs will be compiled on the next pass.