### PR TITLE
Validate argument passed to "use ExUnit.Case"

### DIFF
--- a/lib/ex_unit/lib/ex_unit/case.ex
+++ b/lib/ex_unit/lib/ex_unit/case.ex
@@ -269,6 +269,12 @@ defmodule ExUnit.Case do
 
   @doc false
   def __register__(module, opts) do
+    unless Keyword.keyword?(opts) do
+      raise ArgumentError,
+            ~s(the argument passed to "use ExUnit.Case" must be a list of options, ) <>
+              ~s(got: #{inspect(opts)})
+    end
+
     registered? = Module.has_attribute?(module, :ex_unit_tests)
 
     unless registered? do

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -220,3 +220,19 @@ defmodule ExUnit.CaseTest.TmpDir do
     end
   end
 end
+
+defmodule ExUnit.BadOptsCase do
+  use ExUnit.Case, async: true
+
+  test "raises if passed something other than options" do
+    assert_raise ArgumentError, ~r/must be a list of options, got: "not a list of options"/, fn ->
+      Code.eval_quoted(
+        quote do
+          defmodule MyBadCase do
+            use ExUnit.Case, "not a list of options"
+          end
+        end
+      )
+    end
+  end
+end

--- a/lib/ex_unit/test/ex_unit/case_test.exs
+++ b/lib/ex_unit/test/ex_unit/case_test.exs
@@ -226,13 +226,9 @@ defmodule ExUnit.BadOptsCase do
 
   test "raises if passed something other than options" do
     assert_raise ArgumentError, ~r/must be a list of options, got: "not a list of options"/, fn ->
-      Code.eval_quoted(
-        quote do
-          defmodule MyBadCase do
-            use ExUnit.Case, "not a list of options"
-          end
-        end
-      )
+      defmodule MyBadCase do
+        use ExUnit.Case, "not a list of options"
+      end
     end
   end
 end


### PR DESCRIPTION
The argument passed to "use ExUnit.Case" must be a list of options,
but we were not enforcing this anywhere. This could result in
hard-to-debug errors.

With this commit, we'll now check said argument with Keyword.keyword?/1
and potentially raise an ArgumentError.