### PR TITLE
Add :delayed_write to t:File.stream_mode/0

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -112,6 +112,7 @@ defmodule File do
           encoding_mode()
           | :append
           | :compressed
+          | :delayed_write
           | :trim_bom
           | {:read_ahead, pos_integer | false}
           | {:delayed_write, non_neg_integer, non_neg_integer}


### PR DESCRIPTION
Getting Dialyzer working on an existing project and have this issue.

> `delayed_write`
> The same as `{delayed_write, Size, Delay}` with reasonable default values for `Size` and `Delay` (roughly some 64 KB, 2 seconds).
-  https://www.erlang.org/doc/man/file.html#open-2