### PR TITLE
Improve Github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,9 +5,6 @@ contact_links:
   - name: Discuss proposals
     url: https://groups.google.com/g/elixir-lang-core
     about: Send proposals for new ideas to our mailing list
-  - name: Ask questions. Guidance. Support
+  - name: Ask questions and support
     url: https://elixirforum.com/
-    about: >
-      Ask and answer questions on Elixir Forum.
-      Ask for guidance or support.
-      Share your thoughts about the language.
+    about: Ask questions, provide support and more on Elixir Forum

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,13 @@
+---
 blank_issues_enabled: true
 
 contact_links:
   - name: Discuss proposals
     url: https://groups.google.com/g/elixir-lang-core
-    about: Send proposals for new ideas in the mailing list
-  - name: Ask questions
+    about: Send proposals for new ideas to our mailing list
+  - name: Ask questions. Guidance. Support
     url: https://elixirforum.com/
-    about: Ask and answer questions on ElixirForum
-
+    about: >
+      Ask and answer questions on Elixir Forum.
+      Ask for guidance or support.
+      Share your thoughts about the language.

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: >
-        Thank you for contributing to Elixir.
+        Thank you for contributing to Elixir! :heart:
 
         Please, do not use this form for guidance, questions or support.
         Try instead in [Elixir Forum](https://elixirforum.com),
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Current behavior
       description: >
-        Include code samples, errors and stacktraces if appropriate.
+        Include code samples, errors, and stacktraces if appropriate.
         If reporting a bug, please include the reproducing steps.
     validations:
       required: true
@@ -48,14 +48,3 @@ body:
       description: A short description on how you expect the code to behave.
     validations:
       required: true
-
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Code of Conduct
-      description: >
-        By submitting this issue, you agree to follow our
-        [Code of Conduct](https://github.com/elixir-lang/elixir/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
-      options:
-        - label: I agree to follow this project's Code of Conduct
-          required: true

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,18 +1,32 @@
+---
 name: Report an issue
-description: Tell us about something that's not working the way we (probably) intend
+description:
+  Tell us about something that is not working the way we (probably) intend.
 body:
-  - type: input
+  - type: markdown
+    attributes:
+      value: >
+        Thank you for contributing to Elixir.
+
+        Please, do not use this form for guidance, questions or support.
+        Try instead in [Elixir Forum](https://elixirforum.com),
+        the [IRC Chat](https://web.libera.chat/#elixir),
+        [Stack Overflow](https://stackoverflow.com/questions/tagged/elixir),
+        [Slack](https://elixir-slackin.herokuapp.com),
+        [Discord](https://discord.gg/elixir) or in other online communities.
+
+  - type: textarea
     id: elixir-and-otp-version
     attributes:
       label: Elixir and Erlang/OTP versions
-      description: Paste the output of `elixir -v` here.
+      description: Paste the output of `elixir --version` here.
     validations:
       required: true
 
   - type: input
     id: os
     attributes:
-      label: Operating System
+      label: Operating system
       description: The operating system that this issue is happening on.
     validations:
       required: true
@@ -21,11 +35,9 @@ body:
     id: current-behavior
     attributes:
       label: Current behavior
-      description: Include code samples, errors and stacktraces if appropriate. If reporting a bug, please include the reproducing steps.
-      placeholder: |-
-        1. foo
-        2. bar
-        3. baz
+      description: >
+        Include code samples, errors and stacktraces if appropriate.
+        If reporting a bug, please include the reproducing steps.
     validations:
       required: true
 
@@ -36,3 +48,14 @@ body:
       description: A short description on how you expect the code to behave.
     validations:
       required: true
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: >
+        By submitting this issue, you agree to follow our
+        [Code of Conduct](https://github.com/elixir-lang/elixir/blob/main/CODE_OF_CONDUCT.md#code-of-conduct).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true


### PR DESCRIPTION
I tried to port everything that we had in the previous issue template, plus a few additions such as adding an agreement check box and direct links to online communities to ask questions.

You can see how the form will look like:
- https://github.com/eksperimental/elixir/issues/new/choose
- https://github.com/eksperimental/elixir/issues/new?assignees=&labels=&template=issue.yml 

/cc @yordis 