### PR TITLE
GitHub Template: Separate paragraphs when rendered

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,6 +5,7 @@ contact_links:
   - name: Discuss proposals
     url: https://groups.google.com/g/elixir-lang-core
     about: Send proposals for new ideas to our mailing list
+
   - name: Ask questions and support
     url: https://elixirforum.com/
     about: Ask questions, provide support and more on Elixir Forum

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,12 +1,13 @@
 ---
 name: Report an issue
 description:
-  Tell us about something that is not working the way we (probably) intend.
+  Tell us about something that is not working the way we (probably) intend
 body:
   - type: markdown
     attributes:
       value: >
         Thank you for contributing to Elixir! :heart:
+
 
         Please, do not use this form for guidance, questions or support.
         Try instead in [Elixir Forum](https://elixirforum.com),
@@ -37,6 +38,8 @@ body:
       label: Current behavior
       description: >
         Include code samples, errors, and stacktraces if appropriate.
+
+
         If reporting a bug, please include the reproducing steps.
     validations:
       required: true


### PR DESCRIPTION
Two new lines are interpreted as a paragraph break.