### PR TITLE
Add documentation about using guards for map fields

### DIFF
--- a/lib/elixir/pages/patterns-and-guards.md
+++ b/lib/elixir/pages/patterns-and-guards.md
@@ -415,6 +415,22 @@ Check.empty?({})
 #=> true
 ```
 
+### Using guards for map fields
+
+Guards also support the `map.field` syntax, this allows fine grained control on each field:
+
+```elixir
+def publish(review) when review.is_ready do
+  # ...
+  :ok
+end
+
+def fetch(query) when is_struct(query, Query) and query.limit > 0 do
+  # ...
+  :ok
+end
+```
+
 ## Where patterns and guards can be used
 
 In the examples above, we have used the match operator ([`=`](`=/2`)) and function clauses to showcase patterns and guards respectively. Here is the list of the built-in constructs in Elixir that support patterns and guards.

--- a/lib/elixir/pages/patterns-and-guards.md
+++ b/lib/elixir/pages/patterns-and-guards.md
@@ -284,7 +284,7 @@ You can find the built-in list of guards [in the `Kernel` module](Kernel.html#gu
   * [`in`](`in/2`) and [`not in`](`in/2`) operators (as long as the right-hand side is a list or a range)
   * "type-check" functions (`is_list/1`, `is_number/1`, and the like)
   * functions that work on built-in datatypes (`abs/1`, `hd/1`, `map_size/1`, and others)
-  * guards also support the `map.field` syntax
+  * the `map.field` syntax
 
 The module `Bitwise` also includes a handful of [Erlang bitwise operations as guards](Bitwise.html#guards).
 

--- a/lib/elixir/pages/patterns-and-guards.md
+++ b/lib/elixir/pages/patterns-and-guards.md
@@ -284,6 +284,7 @@ You can find the built-in list of guards [in the `Kernel` module](Kernel.html#gu
   * [`in`](`in/2`) and [`not in`](`in/2`) operators (as long as the right-hand side is a list or a range)
   * "type-check" functions (`is_list/1`, `is_number/1`, and the like)
   * functions that work on built-in datatypes (`abs/1`, `hd/1`, `map_size/1`, and others)
+  * guards also support the `map.field` syntax
 
 The module `Bitwise` also includes a handful of [Erlang bitwise operations as guards](Bitwise.html#guards).
 
@@ -413,22 +414,6 @@ Check.empty?(%{})
 
 Check.empty?({})
 #=> true
-```
-
-### Using guards for map fields
-
-Guards also support the `map.field` syntax, this allows fine grained control on each field:
-
-```elixir
-def publish(review) when review.is_ready do
-  # ...
-  :ok
-end
-
-def fetch(query) when is_struct(query, Query) and query.limit > 0 do
-  # ...
-  :ok
-end
 ```
 
 ## Where patterns and guards can be used


### PR DESCRIPTION
Hi there! 👋

This commit adds a little documentation about being able to use `map.field` inside guards.

I couldn't find in the docs any mention, thought it would be good to write there it's a possibility, what do you think?

Thanks!