### PR TITLE
Teach elixir.bat about ELIXIR_CLI_DRY_RUN

### DIFF
--- a/bin/elixir.bat
+++ b/bin/elixir.bat
@@ -174,10 +174,18 @@ if %errorlevel% == 0 (
 if not !runMode! == "iex" (
   set beforeExtra=-noshell -s elixir start_cli !beforeExtra!
 )
-if defined useWerl (
-  start "" "!ERTS_BIN!werl.exe" !ext_libs! !ELIXIR_ERL_OPTIONS! !parsErlang! !beforeExtra! -extra !parsElixir!
+if defined ELIXIR_CLI_DRY_RUN (
+   if defined useWerl (
+     echo start "" "!ERTS_BIN!werl.exe" !ext_libs! !ELIXIR_ERL_OPTIONS! !parsErlang! !beforeExtra! -extra !parsElixir!
+   ) else (
+     echo "!ERTS_BIN!erl.exe" !ext_libs! !ELIXIR_ERL_OPTIONS! !parsErlang! !beforeExtra! -extra !parsElixir!
+   )
 ) else (
-  "!ERTS_BIN!erl.exe" !ext_libs! !ELIXIR_ERL_OPTIONS! !parsErlang! !beforeExtra! -extra !parsElixir!
+  if defined useWerl (
+    start "" "!ERTS_BIN!werl.exe" !ext_libs! !ELIXIR_ERL_OPTIONS! !parsErlang! !beforeExtra! -extra !parsElixir!
+  ) else (
+    "!ERTS_BIN!erl.exe" !ext_libs! !ELIXIR_ERL_OPTIONS! !parsErlang! !beforeExtra! -extra !parsElixir!
+  )
 )
 :end
 endlocal


### PR DESCRIPTION
The *nix equivalent shell script echoes the full erl.exe path and args to stdout when the environment variable ELIXIR_CLI_DRY_RUN is set instead of executing it.

This patch adds this behaviour to the Windows bat file for consistency.

Note that whether or not the user has defined the useWerl env variable is also considered when deciding what to echo.

This patch is based on a conversation with @josevalim at ElixirConfEU 2022 with some minor tweaks :-)