### PR TITLE
Change MapSet.t definition to make Dialyzer happy

### DIFF
--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -54,7 +54,8 @@ defmodule MapSet do
 
   @type value :: term
 
-  @opaque t(value) :: %__MODULE__{map: %{optional(value) => []}}
+  @opaque internal(value) :: %{optional(value) => []}
+  @type t(value) :: %__MODULE__{map: internal(value)}
   @type t :: t(term)
 
   # TODO: Remove version key when we require Erlang/OTP 24


### PR DESCRIPTION
I hate to bring this issue up again, but it's still causing friction, see [elixirforum thread](https://elixirforum.com/t/trying-to-decipher-a-the-pattern-can-never-match-the-type-dialyzer-error-message/48305)

I think with this change, the only disadvantage is that the field will need to be named `map` even if the internal implementation changes? I don't know if changing it to something more general would be considered a breaking change or not.