### PR TITLE
Add support for __MODULE__ in Code.Fragment

### DIFF
--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -42,6 +42,11 @@ defmodule Code.Fragment do
     * `{:alias, charlist}` - the context is an alias, potentially
       a nested one, such as `Hello.Wor` or `HelloWor`
 
+    * `{:alias, inside_alias, charlist}` - the context is an alias, potentially
+      a nested one, where `inside_alias` is an expression `{:module_attribute, charlist}`
+      or {:local_or_var, charlist}` and `charlist` is a static part
+      Examples are `__MODULE__.Submodule` or `@hello.Submodule`
+
     * `{:dot, inside_dot, charlist}` - the context is a dot
       where `inside_dot` is either a `{:var, charlist}`, `{:alias, charlist}`,
       `{:module_attribute, charlist}`, `{:unquoted_atom, charlist}` or a `dot`
@@ -95,7 +100,10 @@ defmodule Code.Fragment do
       of a sigil, such as `~` or `~s`, or an operator starting with `~`, such as
       `~>` and `~>>`
 
-    * `{:struct, charlist}` - the context is a struct, such as `%`, `%UR` or `%URI`
+    * `{:struct, inside_struct}` - the context is a struct, such as `%`, `%UR` or `%URI`.
+      `inside_struct` can either be a `charlist` in case of a static alias or an
+      expression `{:alias, inside_alias, charlist}`, `{:module_attribute, charlist}`,
+      `{:local_or_var, charlist}`, `{:dot, inside_dot, charlist}`
 
     * `{:unquoted_atom, charlist}` - the context is an unquoted atom. This
       can be any atom or an atom representing a module
@@ -109,6 +117,7 @@ defmodule Code.Fragment do
   @doc since: "1.13.0"
   @spec cursor_context(List.Chars.t(), keyword()) ::
           {:alias, charlist}
+          | {:alias, inside_alias, charlist}
           | {:dot, inside_dot, charlist}
           | {:dot_arity, inside_dot, charlist}
           | {:dot_call, inside_dot, charlist}
@@ -122,14 +131,24 @@ defmodule Code.Fragment do
           | {:operator_call, charlist}
           | :none
           | {:sigil, charlist}
-          | {:struct, charlist}
+          | {:struct, inside_struct}
           | {:unquoted_atom, charlist}
         when inside_dot:
                {:alias, charlist}
+               | {:alias, inside_alias, charlist}
                | {:dot, inside_dot, charlist}
                | {:module_attribute, charlist}
                | {:unquoted_atom, charlist}
-               | {:var, charlist}
+               | {:var, charlist},
+             inside_alias:
+               {:local_or_var, charlist}
+               | {:module_attribute, charlist},
+             inside_struct:
+               charlist
+               | {:alias, inside_alias, charlist}
+               | {:local_or_var, charlist}
+               | {:module_attribute, charlist}
+               | {:dot, inside_dot, charlist}
   def cursor_context(fragment, opts \\ [])
 
   def cursor_context(binary, opts) when is_binary(binary) and is_list(opts) do
@@ -543,6 +562,7 @@ defmodule Code.Fragment do
           %{begin: position, end: position, context: context} | :none
         when context:
                {:alias, charlist}
+               | {:alias, inside_alias, charlist}
                | {:dot, inside_dot, charlist}
                | {:local_or_var, charlist}
                | {:local_arity, charlist}
@@ -550,15 +570,25 @@ defmodule Code.Fragment do
                | {:module_attribute, charlist}
                | {:operator, charlist}
                | {:sigil, charlist}
-               | {:struct, charlist}
+               | {:struct, inside_struct}
                | {:unquoted_atom, charlist}
                | {:keyword, charlist},
              inside_dot:
                {:alias, charlist}
+               | {:alias, inside_alias, charlist}
                | {:dot, inside_dot, charlist}
                | {:module_attribute, charlist}
                | {:unquoted_atom, charlist}
-               | {:var, charlist}
+               | {:var, charlist},
+             inside_alias:
+               {:local_or_var, charlist}
+               | {:module_attribute, charlist},
+             inside_struct:
+               charlist
+               | {:alias, inside_alias, charlist}
+               | {:local_or_var, charlist}
+               | {:module_attribute, charlist}
+               | {:dot, inside_dot, charlist}
   def surround_context(fragment, position, options \\ [])
 
   def surround_context(binary, {line, column}, opts) when is_binary(binary) do

--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -276,6 +276,9 @@ defmodule Code.Fragment do
       {:identifier, _, acc, count} when call_op? and acc in @textual_operators ->
         {{:operator, acc}, count}
 
+      {:identifier, [?%], acc, count} ->
+        {{:struct, acc}, count + 1}
+
       {:identifier, rest, acc, count} ->
         case strip_spaces(rest, count) do
           {'.' ++ rest, count} when rest == [] or hd(rest) != ?. ->
@@ -357,6 +360,7 @@ defmodule Code.Fragment do
     case identifier_to_cursor_context(rest, count, true) do
       {{:struct, prev}, count} -> {{:struct, prev ++ '.' ++ acc}, count}
       {{:alias, prev}, count} -> {{:alias, prev ++ '.' ++ acc}, count}
+      {{:local_or_var, prev = '__MODULE__'}, count} -> {{:alias, prev ++ '.' ++ acc}, count}
       _ -> {:none, 0}
     end
   end

--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -402,6 +402,7 @@ defmodule Code.Fragment do
       {{:unquoted_atom, _} = prev, count} -> {{:dot, prev, acc}, count}
       {{:alias, _} = prev, count} -> {{:dot, prev, acc}, count}
       {{:alias, _, _} = prev, count} -> {{:dot, prev, acc}, count}
+      {{:struct, inner}, count} -> {{:struct, {:dot, inner, acc}}, count}
       {{:dot, _, _} = prev, count} -> {{:dot, prev, acc}, count}
       {{:module_attribute, _} = prev, count} -> {{:dot, prev, acc}, count}
       {_, _} -> {:none, 0}

--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -395,14 +395,32 @@ defmodule Code.Fragment do
     {rest, count} = strip_spaces(rest, count)
 
     case identifier_to_cursor_context(rest, count, true) do
-      {{:local_or_var, var}, count} -> {{:dot, {:var, var}, acc}, count}
-      {{:unquoted_atom, _} = prev, count} -> {{:dot, prev, acc}, count}
-      {{:alias, _} = prev, count} -> {{:dot, prev, acc}, count}
-      {{:alias, _, _} = prev, count} -> {{:dot, prev, acc}, count}
-      {{:struct, inner}, count} -> {{:struct, {:dot, inner, acc}}, count}
-      {{:dot, _, _} = prev, count} -> {{:dot, prev, acc}, count}
-      {{:module_attribute, _} = prev, count} -> {{:dot, prev, acc}, count}
-      {_, _} -> {:none, 0}
+      {{:local_or_var, var}, count} ->
+        {{:dot, {:var, var}, acc}, count}
+
+      {{:unquoted_atom, _} = prev, count} ->
+        {{:dot, prev, acc}, count}
+
+      {{:alias, _} = prev, count} ->
+        {{:dot, prev, acc}, count}
+
+      {{:alias, _, _} = prev, count} ->
+        {{:dot, prev, acc}, count}
+
+      {{:struct, inner}, count} when is_list(inner) ->
+        {{:struct, {:dot, {:alias, inner}, acc}}, count}
+
+      {{:struct, inner}, count} ->
+        {{:struct, {:dot, inner, acc}}, count}
+
+      {{:dot, _, _} = prev, count} ->
+        {{:dot, prev, acc}, count}
+
+      {{:module_attribute, _} = prev, count} ->
+        {{:dot, prev, acc}, count}
+
+      {_, _} ->
+        {:none, 0}
     end
   end
 

--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -269,7 +269,7 @@ defmodule Code.Fragment do
             nested_alias(rest, count + 1, acc) |> IO.inspect(label: "nested_alias")
 
           {'%' ++ _, count} ->
-            {{:struct, acc}, count + 1}
+            {{:struct, {:alias, acc}}, count + 1}
 
           _ ->
             {{:alias, acc}, count}
@@ -364,8 +364,8 @@ defmodule Code.Fragment do
     {rest, count} = strip_spaces(rest, count)
 
     case identifier_to_cursor_context(rest, count, true) |> IO.inspect(label: "nested") do
-      {{:struct, prev}, count} when is_list(prev) -> {{:struct, prev ++ '.' ++ acc}, count}
-      {{:struct, prev}, count} -> {{:struct, prev, acc}, count}
+      {{:struct, {:alias, prev}}, count} -> {{:struct, {:alias, prev ++ '.' ++ acc}}, count}
+      {{:struct, prev}, count} -> {{:struct, {:alias, prev, acc}}, count}
       {{:alias, prev}, count} -> {{:alias, prev ++ '.' ++ acc}, count}
       {{:local_or_var, prev}, count} -> {{:alias, {:local_or_var, prev}, acc}, count}
       {{:module_attribute, prev}, count} -> {{:alias, '@' ++ prev ++ '.' ++ acc}, count}
@@ -384,7 +384,6 @@ defmodule Code.Fragment do
       {{:alias, _, _} = prev, count} -> {{:dot, prev, acc}, count}
       {{:dot, _, _} = prev, count} -> {{:dot, prev, acc}, count}
       {{:module_attribute, _} = prev, count} -> {{:dot, prev, acc}, count}
-      {{:struct, acc}, count} when is_list(acc) -> {{:struct, acc ++ '.'}, count}
       {_, _} -> {:none, 0}
     end
   end

--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -222,8 +222,7 @@ defmodule Code.Fragment do
   defp unquoted_atom_or_expr(_), do: {:expr, 0}
 
   defp arity_to_cursor_context({reverse, spaces}) do
-    case identifier_to_cursor_context(reverse, spaces, true)
-         |> IO.inspect(label: "identifier_to_cursor_context 225") do
+    case identifier_to_cursor_context(reverse, spaces, true) do
       {{:local_or_var, acc}, count} -> {{:local_arity, acc}, count}
       {{:dot, base, acc}, count} -> {{:dot_arity, base, acc}, count}
       {{:operator, acc}, count} -> {{:operator_arity, acc}, count}
@@ -232,8 +231,7 @@ defmodule Code.Fragment do
   end
 
   defp call_to_cursor_context({reverse, spaces}) do
-    case identifier_to_cursor_context(reverse, spaces, true)
-         |> IO.inspect(label: "identifier_to_cursor_context 234") do
+    case identifier_to_cursor_context(reverse, spaces, true) do
       {{:local_or_var, acc}, count} -> {{:local_call, acc}, count}
       {{:dot, base, acc}, count} -> {{:dot_call, base, acc}, count}
       {{:operator, acc}, count} -> {{:operator_call, acc}, count}
@@ -247,7 +245,7 @@ defmodule Code.Fragment do
   defp identifier_to_cursor_context([?., ?. | _], n, _), do: {{:operator, '..'}, n + 2}
 
   defp identifier_to_cursor_context(reverse, count, call_op?) do
-    case identifier(reverse, count) |> IO.inspect(label: "identifier 248") do
+    case identifier(reverse, count) do
       :none ->
         {:none, 0}
 
@@ -269,7 +267,7 @@ defmodule Code.Fragment do
       {:alias, rest, acc, count} ->
         case strip_spaces(rest, count) do
           {'.' ++ rest, count} when rest == [] or hd(rest) != ?. ->
-            nested_alias(rest, count + 1, acc) |> IO.inspect(label: "nested_alias")
+            nested_alias(rest, count + 1, acc)
 
           {'%' ++ _, count} ->
             {{:struct, acc}, count + 1}
@@ -312,7 +310,7 @@ defmodule Code.Fragment do
   end
 
   defp rest_identifier(rest, count, [?@ | acc]) do
-    case tokenize_identifier(rest, count, acc) |> IO.inspect(label: "tokenized") do
+    case tokenize_identifier(rest, count, acc) do
       {:identifier, [?% | _rest], acc, count} -> {:struct, {:module_attribute, acc}, count}
       {:identifier, _rest, acc, count} -> {:module_attribute, acc, count}
       :none when acc == [] -> {:module_attribute, '', count}
@@ -342,7 +340,7 @@ defmodule Code.Fragment do
   end
 
   defp tokenize_identifier(rest, count, acc) do
-    case String.Tokenizer.tokenize(acc) |> IO.inspect(label: "tokenize_identifier") do
+    case String.Tokenizer.tokenize(acc) do
       # Not actually an atom cause rest is not a :
       {:atom, _, _, _, _, _} ->
         :none
@@ -366,7 +364,7 @@ defmodule Code.Fragment do
   defp nested_alias(rest, count, acc) do
     {rest, count} = strip_spaces(rest, count)
 
-    case identifier_to_cursor_context(rest, count, true) |> IO.inspect(label: "nested") do
+    case identifier_to_cursor_context(rest, count, true) do
       {{:struct, prev}, count} when is_list(prev) ->
         {{:struct, prev ++ '.' ++ acc}, count}
 
@@ -396,8 +394,7 @@ defmodule Code.Fragment do
   defp dot(rest, count, acc) do
     {rest, count} = strip_spaces(rest, count)
 
-    case identifier_to_cursor_context(rest, count, true)
-         |> IO.inspect(label: "identifier_to_cursor_context 373") do
+    case identifier_to_cursor_context(rest, count, true) do
       {{:local_or_var, var}, count} -> {{:dot, {:var, var}, acc}, count}
       {{:unquoted_atom, _} = prev, count} -> {{:dot, prev, acc}, count}
       {{:alias, _} = prev, count} -> {{:dot, prev, acc}, count}
@@ -572,7 +569,7 @@ defmodule Code.Fragment do
     {reversed_pre, post} = string_reverse_at(charlist, column - 1, [])
     {reversed_pre, post} = adjust_position(reversed_pre, post)
 
-    case take_identifier(post, []) |> IO.inspect() do
+    case take_identifier(post, []) do
       {_, [], _} ->
         maybe_operator(reversed_pre, post, line, opts)
 
@@ -580,8 +577,7 @@ defmodule Code.Fragment do
         {rest, _} = strip_spaces(rest, 0)
         reversed = reversed_post ++ reversed_pre
 
-        case codepoint_cursor_context(reversed |> IO.inspect(), opts)
-             |> IO.inspect(label: "codepoint_cursor_context 555") do
+        case codepoint_cursor_context(reversed, opts) do
           {{:struct, acc}, offset} ->
             build_surround({:struct, acc}, reversed, line, offset)
 
@@ -631,8 +627,7 @@ defmodule Code.Fragment do
       {:alias, reversed_post, _rest} ->
         reversed = reversed_post ++ reversed_pre
 
-        case codepoint_cursor_context(reversed, opts)
-             |> IO.inspect(label: "codepoint_cursor_context 602") do
+        case codepoint_cursor_context(reversed, opts) do
           {{:alias, acc}, offset} ->
             build_surround({:alias, acc}, reversed, line, offset)
 

--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -272,7 +272,7 @@ defmodule Code.Fragment do
             nested_alias(rest, count + 1, acc) |> IO.inspect(label: "nested_alias")
 
           {'%' ++ _, count} ->
-            {{:struct, {:alias, acc}}, count + 1}
+            {{:struct, acc}, count + 1}
 
           _ ->
             {{:alias, acc}, count}
@@ -367,8 +367,8 @@ defmodule Code.Fragment do
     {rest, count} = strip_spaces(rest, count)
 
     case identifier_to_cursor_context(rest, count, true) |> IO.inspect(label: "nested") do
-      {{:struct, {:alias, prev}}, count} ->
-        {{:struct, {:alias, prev ++ '.' ++ acc}}, count}
+      {{:struct, prev}, count} when is_list(prev) ->
+        {{:struct, prev ++ '.' ++ acc}, count}
 
       {{:struct, {:alias, parent, prev}}, count} ->
         {{:struct, {:alias, parent, prev ++ '.' ++ acc}}, count}

--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -629,9 +629,6 @@ defmodule Code.Fragment do
           {{:struct, acc}, offset} ->
             build_surround({:struct, acc}, reversed, line, offset)
 
-          {{:struct, parent, acc}, offset} ->
-            build_surround({:struct, parent, acc}, reversed, line, offset)
-
           {{:alias, acc}, offset} ->
             build_surround({:alias, acc}, reversed, line, offset)
 

--- a/lib/elixir/test/elixir/code_fragment_test.exs
+++ b/lib/elixir/test/elixir/code_fragment_test.exs
@@ -154,11 +154,11 @@ defmodule CodeFragmentTest do
       assert CF.cursor_context(":%") == {:unquoted_atom, '%'}
       assert CF.cursor_context("::%") == {:struct, ''}
 
-      assert CF.cursor_context("%HelloWor") == {:struct, {:alias, 'HelloWor'}}
+      assert CF.cursor_context("%HelloWor") == {:struct, 'HelloWor'}
       # TODO does it make sense
       # assert CF.cursor_context("%Hello.") == {:struct, 'Hello.'}
-      assert CF.cursor_context("%Hello.Wor") == {:struct, {:alias, 'Hello.Wor'}}
-      assert CF.cursor_context("% Hello . Wor") == {:struct, {:alias, 'Hello.Wor'}}
+      assert CF.cursor_context("%Hello.Wor") == {:struct, 'Hello.Wor'}
+      assert CF.cursor_context("% Hello . Wor") == {:struct, 'Hello.Wor'}
 
       assert CF.cursor_context("%__MODULE_") == {:struct, {:local_or_var, '__MODULE_'}}
       assert CF.cursor_context("%__MODULE__") == {:struct, {:local_or_var, '__MODULE__'}}
@@ -707,33 +707,33 @@ defmodule CodeFragmentTest do
       assert CF.surround_context("::%Hello", {1, 2}) == :none
 
       assert CF.surround_context("::%Hello", {1, 3}) == %{
-               context: {:struct, {:alias, 'Hello'}},
+               context: {:struct, 'Hello'},
                begin: {1, 3},
                end: {1, 9}
              }
 
       assert CF.surround_context("::% Hello", {1, 3}) == %{
-               context: {:struct, {:alias, 'Hello'}},
+               context: {:struct, 'Hello'},
                begin: {1, 3},
                end: {1, 10}
              }
 
       assert CF.surround_context("::% Hello", {1, 4}) == %{
-               context: {:struct, {:alias, 'Hello'}},
+               context: {:struct, 'Hello'},
                begin: {1, 3},
                end: {1, 10}
              }
 
       # Alias
       assert CF.surround_context("%HelloWor", {1, 1}) == %{
-               context: {:struct, {:alias, 'HelloWor'}},
+               context: {:struct, 'HelloWor'},
                begin: {1, 1},
                end: {1, 10}
              }
 
       for i <- 2..9 do
         assert CF.surround_context("%HelloWor", {1, i}) == %{
-                 context: {:struct, {:alias, 'HelloWor'}},
+                 context: {:struct, 'HelloWor'},
                  begin: {1, 1},
                  end: {1, 10}
                }
@@ -743,14 +743,14 @@ defmodule CodeFragmentTest do
 
       # With dot
       assert CF.surround_context("%Hello.Wor", {1, 1}) == %{
-               context: {:struct, {:alias, 'Hello.Wor'}},
+               context: {:struct, 'Hello.Wor'},
                begin: {1, 1},
                end: {1, 11}
              }
 
       for i <- 2..10 do
         assert CF.surround_context("%Hello.Wor", {1, i}) == %{
-                 context: {:struct, {:alias, 'Hello.Wor'}},
+                 context: {:struct, 'Hello.Wor'},
                  begin: {1, 1},
                  end: {1, 11}
                }
@@ -760,14 +760,14 @@ defmodule CodeFragmentTest do
 
       # With spaces
       assert CF.surround_context("% Hello . Wor", {1, 1}) == %{
-               context: {:struct, {:alias, 'Hello.Wor'}},
+               context: {:struct, 'Hello.Wor'},
                begin: {1, 1},
                end: {1, 14}
              }
 
       for i <- 2..13 do
         assert CF.surround_context("% Hello . Wor", {1, i}) == %{
-                 context: {:struct, {:alias, 'Hello.Wor'}},
+                 context: {:struct, 'Hello.Wor'},
                  begin: {1, 1},
                  end: {1, 14}
                }

--- a/lib/elixir/test/elixir/code_fragment_test.exs
+++ b/lib/elixir/test/elixir/code_fragment_test.exs
@@ -143,18 +143,18 @@ defmodule CodeFragmentTest do
       assert CF.cursor_context(":%") == {:unquoted_atom, '%'}
       assert CF.cursor_context("::%") == {:struct, ''}
 
-      assert CF.cursor_context("%HelloWor") == {:struct, 'HelloWor'}
+      assert CF.cursor_context("%HelloWor") == {:struct, {:alias, 'HelloWor'}}
       # TODO does it make sense
       # assert CF.cursor_context("%Hello.") == {:struct, 'Hello.'}
-      assert CF.cursor_context("%Hello.Wor") == {:struct, 'Hello.Wor'}
-      assert CF.cursor_context("% Hello . Wor") == {:struct, 'Hello.Wor'}
+      assert CF.cursor_context("%Hello.Wor") == {:struct, {:alias, 'Hello.Wor'}}
+      assert CF.cursor_context("% Hello . Wor") == {:struct, {:alias, 'Hello.Wor'}}
 
       assert CF.cursor_context("%__MODULE_") == {:struct, {:local_or_var, '__MODULE_'}}
       assert CF.cursor_context("%__MODULE__") == {:struct, {:local_or_var, '__MODULE__'}}
       # TODO does it make sense
       # assert CF.cursor_context("%__MODULE__.") == {:struct, {:local_or_var, '__MODULE__'}}
       assert CF.cursor_context("%__MODULE__.Wor") ==
-               {:struct, {:local_or_var, '__MODULE__'}, 'Wor'}
+               {:struct, {:alias, {:local_or_var, '__MODULE__'}, 'Wor'}}
     end
 
     test "unquoted atom" do
@@ -590,7 +590,7 @@ defmodule CodeFragmentTest do
              }
 
       assert CF.surround_context("%__MODULE__.Foo{}", {1, 13}) == %{
-               context: {:struct, {:local_or_var, '__MODULE__'}, 'Foo'},
+               context: {:struct, {:alias, {:local_or_var, '__MODULE__'}, 'Foo'}},
                begin: {1, 1},
                end: {1, 16}
              }
@@ -622,33 +622,33 @@ defmodule CodeFragmentTest do
       assert CF.surround_context("::%Hello", {1, 2}) == :none
 
       assert CF.surround_context("::%Hello", {1, 3}) == %{
-               context: {:struct, 'Hello'},
+               context: {:struct, {:alias, 'Hello'}},
                begin: {1, 3},
                end: {1, 9}
              }
 
       assert CF.surround_context("::% Hello", {1, 3}) == %{
-               context: {:struct, 'Hello'},
+               context: {:struct, {:alias, 'Hello'}},
                begin: {1, 3},
                end: {1, 10}
              }
 
       assert CF.surround_context("::% Hello", {1, 4}) == %{
-               context: {:struct, 'Hello'},
+               context: {:struct, {:alias, 'Hello'}},
                begin: {1, 3},
                end: {1, 10}
              }
 
       # Alias
       assert CF.surround_context("%HelloWor", {1, 1}) == %{
-               context: {:struct, 'HelloWor'},
+               context: {:struct, {:alias, 'HelloWor'}},
                begin: {1, 1},
                end: {1, 10}
              }
 
       for i <- 2..9 do
         assert CF.surround_context("%HelloWor", {1, i}) == %{
-                 context: {:struct, 'HelloWor'},
+                 context: {:struct, {:alias, 'HelloWor'}},
                  begin: {1, 1},
                  end: {1, 10}
                }
@@ -658,14 +658,14 @@ defmodule CodeFragmentTest do
 
       # With dot
       assert CF.surround_context("%Hello.Wor", {1, 1}) == %{
-               context: {:struct, 'Hello.Wor'},
+               context: {:struct, {:alias, 'Hello.Wor'}},
                begin: {1, 1},
                end: {1, 11}
              }
 
       for i <- 2..10 do
         assert CF.surround_context("%Hello.Wor", {1, i}) == %{
-                 context: {:struct, 'Hello.Wor'},
+                 context: {:struct, {:alias, 'Hello.Wor'}},
                  begin: {1, 1},
                  end: {1, 11}
                }
@@ -675,14 +675,14 @@ defmodule CodeFragmentTest do
 
       # With spaces
       assert CF.surround_context("% Hello . Wor", {1, 1}) == %{
-               context: {:struct, 'Hello.Wor'},
+               context: {:struct, {:alias, 'Hello.Wor'}},
                begin: {1, 1},
                end: {1, 14}
              }
 
       for i <- 2..13 do
         assert CF.surround_context("% Hello . Wor", {1, i}) == %{
-                 context: {:struct, 'Hello.Wor'},
+                 context: {:struct, {:alias, 'Hello.Wor'}},
                  begin: {1, 1},
                  end: {1, 14}
                }

--- a/lib/elixir/test/elixir/code_fragment_test.exs
+++ b/lib/elixir/test/elixir/code_fragment_test.exs
@@ -62,6 +62,12 @@ defmodule CodeFragmentTest do
                {:dot, {:dot, {:var, 'nested'}, 'map'}, 'wor'}
 
       assert CF.cursor_context("__MODULE__.") == {:dot, {:var, '__MODULE__'}, ''}
+
+      assert CF.cursor_context("__MODULE__.Sub.") ==
+               {:dot, {:alias, {:local_or_var, '__MODULE__'}, 'Sub'}, ''}
+
+      assert CF.cursor_context("@hello.Sub.wor") ==
+               {:dot, {:alias, {:module_attribute, 'hello'}, 'Sub'}, 'wor'}
     end
 
     test "local_arity" do
@@ -126,6 +132,9 @@ defmodule CodeFragmentTest do
 
       assert CF.cursor_context("__MODULE__.Foo.hello(") ==
                {:dot_call, {:alias, {:local_or_var, '__MODULE__'}, 'Foo'}, 'hello'}
+
+      assert CF.cursor_context("@foo.Foo.hello(") ==
+               {:dot_call, {:alias, {:module_attribute, 'foo'}, 'Foo'}, 'hello'}
     end
 
     test "alias" do
@@ -136,6 +145,8 @@ defmodule CodeFragmentTest do
       assert CF.cursor_context("Hello..Wor") == {:alias, 'Wor'}
 
       assert CF.cursor_context("__MODULE__.Wor") == {:alias, {:local_or_var, '__MODULE__'}, 'Wor'}
+
+      assert CF.cursor_context("@foo.Wor") == {:alias, {:module_attribute, 'foo'}, 'Wor'}
     end
 
     test "structs" do
@@ -155,6 +166,12 @@ defmodule CodeFragmentTest do
       # assert CF.cursor_context("%__MODULE__.") == {:struct, {:local_or_var, '__MODULE__'}}
       assert CF.cursor_context("%__MODULE__.Wor") ==
                {:struct, {:alias, {:local_or_var, '__MODULE__'}, 'Wor'}}
+
+      assert CF.cursor_context("%@foo") ==
+               {:struct, {:module_attribute, 'foo'}}
+
+      assert CF.cursor_context("%@foo.Wor") ==
+               {:struct, {:alias, {:module_attribute, 'foo'}, 'Wor'}}
     end
 
     test "unquoted atom" do
@@ -583,6 +600,12 @@ defmodule CodeFragmentTest do
                end: {1, 15}
              }
 
+      assert CF.surround_context("__MODULE__.Foo.Sub", {1, 16}) == %{
+               context: {:alias, {:local_or_var, '__MODULE__'}, 'Foo.Sub'},
+               begin: {1, 1},
+               end: {1, 19}
+             }
+
       assert CF.surround_context("%__MODULE__{}", {1, 5}) == %{
                context: {:struct, {:local_or_var, '__MODULE__'}},
                begin: {1, 1},
@@ -593,6 +616,12 @@ defmodule CodeFragmentTest do
                context: {:struct, {:alias, {:local_or_var, '__MODULE__'}, 'Foo'}},
                begin: {1, 1},
                end: {1, 16}
+             }
+
+      assert CF.surround_context("%__MODULE__.Foo.Sub{}", {1, 17}) == %{
+               context: {:struct, {:alias, {:local_or_var, '__MODULE__'}, 'Foo.Sub'}},
+               begin: {1, 1},
+               end: {1, 20}
              }
 
       assert CF.surround_context("__MODULE__.call()", {1, 13}) == %{
@@ -607,10 +636,66 @@ defmodule CodeFragmentTest do
                end: {1, 20}
              }
 
+      assert CF.surround_context("__MODULE__.Foo.Sub.call()", {1, 21}) == %{
+               context: {:dot, {:alias, {:local_or_var, '__MODULE__'}, 'Foo.Sub'}, 'call'},
+               begin: {1, 1},
+               end: {1, 24}
+             }
+
       assert CF.surround_context("__ENV__.module.call()", {1, 17}) == %{
                context: {:dot, {:dot, {:var, '__ENV__'}, 'module'}, 'call'},
                begin: {1, 1},
                end: {1, 20}
+             }
+    end
+
+    test "attribute submodules" do
+      assert CF.surround_context("@some.Foo", {1, 8}) == %{
+               context: {:alias, {:module_attribute, 'some'}, 'Foo'},
+               begin: {1, 1},
+               end: {1, 10}
+             }
+
+      assert CF.surround_context("@some.Foo.Sub", {1, 12}) == %{
+               context: {:alias, {:module_attribute, 'some'}, 'Foo.Sub'},
+               begin: {1, 1},
+               end: {1, 14}
+             }
+
+      assert CF.surround_context("%@some{}", {1, 5}) == %{
+               context: {:struct, {:module_attribute, 'some'}},
+               begin: {1, 1},
+               end: {1, 7}
+             }
+
+      assert CF.surround_context("%@some.Foo{}", {1, 10}) == %{
+               context: {:struct, {:alias, {:module_attribute, 'some'}, 'Foo'}},
+               begin: {1, 1},
+               end: {1, 11}
+             }
+
+      assert CF.surround_context("%@some.Foo.Sub{}", {1, 14}) == %{
+               context: {:struct, {:alias, {:module_attribute, 'some'}, 'Foo.Sub'}},
+               begin: {1, 1},
+               end: {1, 15}
+             }
+
+      assert CF.surround_context("@some.call()", {1, 8}) == %{
+               context: {:dot, {:module_attribute, 'some'}, 'call'},
+               begin: {1, 1},
+               end: {1, 11}
+             }
+
+      assert CF.surround_context("@some.Foo.call()", {1, 12}) == %{
+               context: {:dot, {:alias, {:module_attribute, 'some'}, 'Foo'}, 'call'},
+               begin: {1, 1},
+               end: {1, 15}
+             }
+
+      assert CF.surround_context("@some.Foo.Sub.call()", {1, 16}) == %{
+               context: {:dot, {:alias, {:module_attribute, 'some'}, 'Foo.Sub'}, 'call'},
+               begin: {1, 1},
+               end: {1, 19}
              }
     end
 

--- a/lib/elixir/test/elixir/code_fragment_test.exs
+++ b/lib/elixir/test/elixir/code_fragment_test.exs
@@ -156,8 +156,8 @@ defmodule CodeFragmentTest do
 
       assert CF.cursor_context("%HelloWor") == {:struct, 'HelloWor'}
 
-      assert CF.cursor_context("%Hello.") == {:struct, {:dot, 'Hello', ''}}
-      assert CF.cursor_context("%Hello.nam") == {:struct, {:dot, 'Hello', 'nam'}}
+      assert CF.cursor_context("%Hello.") == {:struct, {:dot, {:alias, 'Hello'}, ''}}
+      assert CF.cursor_context("%Hello.nam") == {:struct, {:dot, {:alias, 'Hello'}, 'nam'}}
       assert CF.cursor_context("%Hello.Wor") == {:struct, 'Hello.Wor'}
       assert CF.cursor_context("% Hello . Wor") == {:struct, 'Hello.Wor'}
 
@@ -741,7 +741,7 @@ defmodule CodeFragmentTest do
              }
 
       assert CF.surround_context("%HelloWor.some", {1, 12}) == %{
-               context: {:struct, {:dot, 'HelloWor', 'some'}},
+               context: {:struct, {:dot, {:alias, 'HelloWor'}, 'some'}},
                begin: {1, 1},
                end: {1, 15}
              }

--- a/lib/elixir/test/elixir/code_fragment_test.exs
+++ b/lib/elixir/test/elixir/code_fragment_test.exs
@@ -155,20 +155,29 @@ defmodule CodeFragmentTest do
       assert CF.cursor_context("::%") == {:struct, ''}
 
       assert CF.cursor_context("%HelloWor") == {:struct, 'HelloWor'}
-      # TODO does it make sense
-      # assert CF.cursor_context("%Hello.") == {:struct, 'Hello.'}
+
+      assert CF.cursor_context("%Hello.") == {:struct, {:dot, 'Hello', ''}}
+      assert CF.cursor_context("%Hello.nam") == {:struct, {:dot, 'Hello', 'nam'}}
       assert CF.cursor_context("%Hello.Wor") == {:struct, 'Hello.Wor'}
       assert CF.cursor_context("% Hello . Wor") == {:struct, 'Hello.Wor'}
 
       assert CF.cursor_context("%__MODULE_") == {:struct, {:local_or_var, '__MODULE_'}}
       assert CF.cursor_context("%__MODULE__") == {:struct, {:local_or_var, '__MODULE__'}}
-      # TODO does it make sense
-      # assert CF.cursor_context("%__MODULE__.") == {:struct, {:local_or_var, '__MODULE__'}}
+
+      assert CF.cursor_context("%__MODULE__.") ==
+               {:struct, {:dot, {:local_or_var, '__MODULE__'}, ''}}
+
+      assert CF.cursor_context("%__MODULE__.Sub.") ==
+               {:struct, {:dot, {:alias, {:local_or_var, '__MODULE__'}, 'Sub'}, ''}}
+
       assert CF.cursor_context("%__MODULE__.Wor") ==
                {:struct, {:alias, {:local_or_var, '__MODULE__'}, 'Wor'}}
 
       assert CF.cursor_context("%@foo") ==
                {:struct, {:module_attribute, 'foo'}}
+
+      assert CF.cursor_context("%@foo.") ==
+               {:struct, {:dot, {:module_attribute, 'foo'}, ''}}
 
       assert CF.cursor_context("%@foo.Wor") ==
                {:struct, {:alias, {:module_attribute, 'foo'}, 'Wor'}}
@@ -729,6 +738,12 @@ defmodule CodeFragmentTest do
                context: {:struct, 'HelloWor'},
                begin: {1, 1},
                end: {1, 10}
+             }
+
+      assert CF.surround_context("%HelloWor.some", {1, 12}) == %{
+               context: {:struct, {:dot, 'HelloWor', 'some'}},
+               begin: {1, 1},
+               end: {1, 15}
              }
 
       for i <- 2..9 do

--- a/lib/iex/lib/iex/autocomplete.ex
+++ b/lib/iex/lib/iex/autocomplete.ex
@@ -80,8 +80,11 @@ defmodule IEx.Autocomplete do
       {:sigil, [_]} ->
         {:yes, [], ~w|" """ ' ''' \( / < [ { \||c}
 
-      {:struct, struct} ->
+      {:struct, struct} when is_list(struct) ->
         expand_structs(List.to_string(struct), shell)
+
+      {:struct, {:dot, {:alias, struct}, ''}} when is_list(struct) ->
+        expand_structs(List.to_string(struct ++ '.'), shell)
 
       # {:module_attribute, charlist}
       # :none


### PR DESCRIPTION
For simplicity I changed the returned aliases to contain `__MODULE__` string. This approach will not be optimal if we would like to handle other less trivial cases, e.g. `some_macro().Submodule` or `@my_attr.Submodule`. I'm not sure about the macro one but the attribute one would be useful.

Fixes #11875