### PR TITLE
Replace misspelt :nillify_clauses option with :skip_clauses in Module.get_definition/3

### DIFF
--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1253,11 +1253,12 @@ defmodule Module do
 
   ## Options
 
-    * `:nillify_clauses` (since v1.13.0) - returns `nil` instead
+    * `:skip_clauses` (since v1.14.0) - returns `[]` instead
       of returning the clauses. This is useful when there is
-      only an interest in fetching the kind and metadata
+      only an interest in fetching the kind and the metadata
 
   """
+  # TODO: Deprecate :nillify_clauses in options on Elixir v1.16
   @spec get_definition(module, definition, keyword) ::
           {:v1, def_kind, meta :: keyword,
            [{meta :: keyword, arguments :: [Macro.t()], guards :: [Macro.t()], Macro.t()}] | nil}
@@ -1270,9 +1271,16 @@ defmodule Module do
     case :ets.lookup(set, {:def, {name, arity}}) do
       [{_key, kind, meta, _, _, _}] ->
         clauses =
-          if options[:nillify_clauses],
-            do: nil,
-            else: bag_lookup_element(bag, {:clauses, {name, arity}}, 2)
+          cond do
+            options[:skip_clauses] ->
+              []
+
+            options[:nillify_clauses] ->
+              nil
+
+            true ->
+              bag_lookup_element(bag, {:clauses, {name, arity}}, 2)
+          end
 
         {:v1, kind, meta, clauses}
 

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1261,7 +1261,7 @@ defmodule Module do
   # TODO: Deprecate :nillify_clauses in options on Elixir v1.16
   @spec get_definition(module, definition, keyword) ::
           {:v1, def_kind, meta :: keyword,
-           [{meta :: keyword, arguments :: [Macro.t()], guards :: [Macro.t()], Macro.t()}] | nil}
+           [{meta :: keyword, arguments :: [Macro.t()], guards :: [Macro.t()], Macro.t()}]}
   @doc since: "1.12.0"
   def get_definition(module, {name, arity}, options \\ [])
       when is_atom(module) and is_atom(name) and is_integer(arity) and is_list(options) do
@@ -1271,16 +1271,9 @@ defmodule Module do
     case :ets.lookup(set, {:def, {name, arity}}) do
       [{_key, kind, meta, _, _, _}] ->
         clauses =
-          cond do
-            options[:skip_clauses] ->
-              []
-
-            options[:nillify_clauses] ->
-              nil
-
-            true ->
-              bag_lookup_element(bag, {:clauses, {name, arity}}, 2)
-          end
+          if options[:skip_clauses],
+            do: [],
+            else: bag_lookup_element(bag, {:clauses, {name, arity}}, 2)
 
         {:v1, kind, meta, clauses}
 

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -491,16 +491,6 @@ defmodule ModuleTest do
 
       assert {:v1, :def, _, []} = Module.get_definition(__MODULE__, {:foo, 2}, skip_clauses: true)
 
-      # :skip_clauses prevails if both :nillify_clauses and :skip_clauses are given
-      assert {:v1, :def, _, []} =
-               Module.get_definition(__MODULE__, {:foo, 2},
-                 nillify_clauses: true,
-                 skip_clauses: true
-               )
-
-      assert {:v1, :def, _, nil} =
-               Module.get_definition(__MODULE__, {:foo, 2}, nillify_clauses: true)
-
       assert Module.delete_definition(__MODULE__, {:foo, 2})
       assert Module.get_definition(__MODULE__, {:foo, 2}) == nil
       refute Module.delete_definition(__MODULE__, {:foo, 2})

--- a/lib/elixir/test/elixir/module_test.exs
+++ b/lib/elixir/test/elixir/module_test.exs
@@ -489,6 +489,15 @@ defmodule ModuleTest do
                  {{:., _, [:erlang, :+]}, _, [{:a, _, nil}, {:b, _, nil}]}}
               ]} = Module.get_definition(__MODULE__, {:foo, 2})
 
+      assert {:v1, :def, _, []} = Module.get_definition(__MODULE__, {:foo, 2}, skip_clauses: true)
+
+      # :skip_clauses prevails if both :nillify_clauses and :skip_clauses are given
+      assert {:v1, :def, _, []} =
+               Module.get_definition(__MODULE__, {:foo, 2},
+                 nillify_clauses: true,
+                 skip_clauses: true
+               )
+
       assert {:v1, :def, _, nil} =
                Module.get_definition(__MODULE__, {:foo, 2}, nillify_clauses: true)
 


### PR DESCRIPTION
Now it returns an empty list, instead of nil.

Closes: https://github.com/elixir-lang/elixir/issues/11918