### PR TITLE
Improve ExUnit's diff output for pinned struct match failures

### DIFF
--- a/lib/ex_unit/lib/ex_unit/diff.ex
+++ b/lib/ex_unit/lib/ex_unit/diff.ex
@@ -1027,6 +1027,10 @@ defmodule ExUnit.Diff do
     wrap_on_diff(quoted, &safe_struct_to_algebra/2, diff_wrapper)
   end
 
+  defp safe_struct_to_algebra({:^, _, _} = name, _diff_wrapper) do
+    Macro.to_string(name)
+  end
+
   defp safe_struct_to_algebra(name, _diff_wrapper) do
     Macro.inspect_atom(:literal, name)
   end

--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -778,6 +778,14 @@ defmodule ExUnit.DiffTest do
       "%+Date+{calendar: Calendar.ISO, day: 1, month: 1, year: 2020}",
       pins
     )
+
+    # right side is not map-like
+    refute_diff(
+      %^type{age: ^age, name: "john"} = nil,
+      "-%^type{age: ^age, name: \"john\"}-",
+      "+nil+",
+      pins
+    )
   end
 
   test "invalid structs" do

--- a/lib/ex_unit/test/ex_unit/formatter_test.exs
+++ b/lib/ex_unit/test/ex_unit/formatter_test.exs
@@ -292,6 +292,27 @@ defmodule ExUnit.FormatterTest do
            """
   end
 
+  test "formats match error between pinned struct type and a non-struct" do
+    failure = [
+      {:error,
+       catch_assertion do
+         expected_module = ExUnit.TestModule
+         assert %^expected_module{} = nil
+       end, []}
+    ]
+
+    assert format_test_failure(test(), failure, 1, 80, &diff_formatter/2) =~ """
+             1) world (Hello)
+                test/ex_unit/formatter_test.exs:1
+                match (=) failed
+                The following variables were pinned:
+                  expected_module = ExUnit.TestModule
+                code:  assert %^expected_module{} = nil
+                left:  %^expected_module{}
+                right: nil
+           """
+  end
+
   test "formats multiple assertions" do
     failure = [
       {:error, catch_assertion(assert ExUnit.FormatterTest.falsy()), []},


### PR DESCRIPTION
I discovered that certain `assert` flows in ExUnit for structs with a pinned name cause the diff / formatting code to raise an error rather than displaying the expected friendly diff. The raise led to a crash of the test runner.

For example a test that does the equivalent of this:

```elixir
expected_name = MapSet
assert %^expected_name{} = nil
```

Caused an error to raise and the test runner genserver to exit when running `mix test`. Example of that output is at the bottom of the PR as it's rather large. The example is from 1.13.4 but `main` produced a similar error that references the new `Macro.inspect_atom` function instead of `Code.Identifier.inspect_as_atom`.

This PR resolves the crashing edge case by formatting the pinned struct name variable as-is in the diff output rather than trying to render it as a literal. Essentially printing something like this:

```
                match (=) failed
                The following variables were pinned:
                  expected_name = MapSet
                code:  assert %^expected_name{} = nil
                left:  %^expected_name{}
                right: nil
```

Best I can tell the diffing logic itself worked fine and it was only the output generation logic that broke in this edge case where the left and right sides are not both resolvable to maps. When both sides are maps the struct name gets injected into the `__struct__` section for the diff output to provider a more detailed error diff. When only the left side is a struct things also worked fine as long as you did not pin because the struct name was a valid literal.

I will admit I am not super well-versed in the diff code. So my understanding of the issue and my approach to fixing it could be way off the mark. If so please let me know. I am happy to take another pass at it with some guidance towards a preferred solution.

For reference here is the example of the `mix test` failure output prior to this change:
```
20:57:35.880 [error] GenServer #PID<0.155.0> terminating
** (FunctionClauseError) no function clause matching in Code.Identifier.inspect_as_atom/1
    (elixir 1.13.4) lib/code/identifier.ex:138: Code.Identifier.inspect_as_atom({:^, [line: 15], [{:type, [line: 15], nil}]})
    (ex_unit 1.13.4) lib/ex_unit/diff.ex:931: ExUnit.Diff.safe_to_algebra/2
    (ex_unit 1.13.4) lib/ex_unit/diff.ex:1034: ExUnit.Diff.wrap_on_diff/3
    (ex_unit 1.13.4) lib/ex_unit/formatter.ex:434: ExUnit.Formatter.format_sides/6
    (ex_unit 1.13.4) lib/ex_unit/formatter.ex:422: ExUnit.Formatter.format_context/4
    (ex_unit 1.13.4) lib/ex_unit/formatter.ex:190: ExUnit.Formatter.format_exception/6
    (ex_unit 1.13.4) lib/ex_unit/formatter.ex:161: anonymous fn/7 in ExUnit.Formatter.format_test_failure/5
    (elixir 1.13.4) lib/enum.ex:1690: anonymous fn/2 in Enum.map_join/3
    (elixir 1.13.4) lib/enum.ex:4126: Enum.map_intersperse_list/3
    (elixir 1.13.4) lib/enum.ex:1690: Enum.map_join/3
    (ex_unit 1.13.4) lib/ex_unit/formatter.ex:160: ExUnit.Formatter.format_test_failure/5
    (ex_unit 1.13.4) lib/ex_unit/cli_formatter.ex:108: ExUnit.CLIFormatter.handle_cast/2
    (stdlib 3.17.2) gen_server.erl:695: :gen_server.try_dispatch/4
    (stdlib 3.17.2) gen_server.erl:771: :gen_server.handle_msg/6
    (stdlib 3.17.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Last message: {:"$gen_cast", {:test_finished, %ExUnit.Test{case: ExampleTest, logs: "", module: ExampleTest, name: :"test demos the bug", state: {:failed, [{:error, %ExUnit.AssertionError{args: :ex_unit_no_meaningful_value, context: {:match, [{{:type, nil}, MapSet}]}, doctest: :ex_unit_no_meaningful_value, expr: {:assert, [line: 15], [{:=, [line: 15], [{:%, [line: 15], [{:^, [line: 15], [{:type, [line: 15], nil}]}, {:%{}, [line: 15], []}]}, nil]}]}, left: {:%, [line: 15], [{:^, [line: 15], [{:type, [line: 15], nil}]}, {:%{}, [line: 15], []}]}, message: "match (=) failed\nThe following variables were pinned:\n  type = MapSet", right: nil}, [{ExampleTest, :"test demos the bug", 1, [file: 'test/example_test.exs', line: 15]}]}]}, tags: %{async: false, case: ExampleTest, describe: nil, describe_line: nil, file: "/home/malf/code/example/test/example_test.exs", line: 13, module: ExampleTest, registered: %{}, test: :"test demos the bug", test_type: :test}, time: 25}}}
State: %{colors: [enabled: true, diff_delete: :red, diff_delete_whitespace: "\e[48;5;88m", diff_insert: :green, diff_insert_whitespace: "\e[48;5;28m"], excluded_counter: 0, failure_counter: 1, invalid_counter: 0, seed: 792736, skipped_counter: 0, slowest: 0, test_counter: %{doctest: 1, test: 3}, test_timings: [%ExUnit.Test{case: ExampleTest, logs: "", module: ExampleTest, name: :"doctest Example.hello/0 (1)", state: nil, tags: %{async: false, case: ExampleTest, describe: nil, describe_line: nil, file: "/home/malf/code/example/test/example_test.exs", line: 3, module: ExampleTest, registered: %{}, test: :"doctest Example.hello/0 (1)", test_type: :doctest}, time: 1}, %ExUnit.Test{case: ExampleTest, logs: "", module: ExampleTest, name: :"test greets the world", state: nil, tags: %{async: false, case: ExampleTest, describe: nil, describe_line: nil, file: "/home/malf/code/example/test/example_test.exs", line: 5, module: ExampleTest, registered: %{}, test: :"test greets the world", test_type: :test}, time: 1}, %ExUnit.Test{case: ExampleTest, logs: "", module: ExampleTest, name: :"test greets the world again", state: nil, tags: %{async: false, case: ExampleTest, describe: nil, describe_line: nil, file: "/home/malf/code/example/test/example_test.exs", line: 18, module: ExampleTest, registered: %{}, test: :"test greets the world again", test_type: :test}, time: 1}, %ExUnit.Test{case: ExampleTest, logs: "", module: ExampleTest, name: :"test renders a proper diff", state: {:failed, [{:error, %ExUnit.AssertionError{args: :ex_unit_no_meaningful_value, context: {:match, []}, doctest: :ex_unit_no_meaningful_value, expr: {:assert, [line: 10], [{:=, [line: 10], [{:%, [line: 10], [{:__aliases__, [line: 10], [:MapSet]}, {:%{}, [line: 10], []}]}, nil]}]}, left: {:%, [line: 10], [MapSet, {:%{}, [line: 10], []}]}, message: "match (=) failed", right: nil}, [{ExampleTest, :"test renders a proper diff", 1, [file: 'test/example_test.exs', line: 10]}]}]}, tags: %{async: false, case: ExampleTest, describe: nil, describe_line: nil, file: "/home/malf/code/example/test/example_test.exs", line: 9, module: ExampleTest, registered: %{}, test: :"test renders a proper diff", test_type: :test}, time: 2939}], trace: false, width: 158}

20:57:35.901 [error] Task #PID<0.148.0> started from #PID<0.94.0> terminating
** (stop) exited in: GenServer.stop(#PID<0.155.0>, :normal, :infinity)
    ** (EXIT) exited in: :sys.terminate(#PID<0.155.0>, :normal, :infinity)
        ** (EXIT) an exception was raised:
            ** (FunctionClauseError) no function clause matching in Code.Identifier.inspect_as_atom/1
                (elixir 1.13.4) lib/code/identifier.ex:138: Code.Identifier.inspect_as_atom({:^, [line: 15], [{:type, [line: 15], nil}]})
                (ex_unit 1.13.4) lib/ex_unit/diff.ex:931: ExUnit.Diff.safe_to_algebra/2
                (ex_unit 1.13.4) lib/ex_unit/diff.ex:1034: ExUnit.Diff.wrap_on_diff/3
                (ex_unit 1.13.4) lib/ex_unit/formatter.ex:434: ExUnit.Formatter.format_sides/6
                (ex_unit 1.13.4) lib/ex_unit/formatter.ex:422: ExUnit.Formatter.format_context/4
                (ex_unit 1.13.4) lib/ex_unit/formatter.ex:190: ExUnit.Formatter.format_exception/6
                (ex_unit 1.13.4) lib/ex_unit/formatter.ex:161: anonymous fn/7 in ExUnit.Formatter.format_test_failure/5
                (elixir 1.13.4) lib/enum.ex:1690: anonymous fn/2 in Enum.map_join/3
                (elixir 1.13.4) lib/enum.ex:4126: Enum.map_intersperse_list/3
                (elixir 1.13.4) lib/enum.ex:1690: Enum.map_join/3
                (ex_unit 1.13.4) lib/ex_unit/formatter.ex:160: ExUnit.Formatter.format_test_failure/5
                (ex_unit 1.13.4) lib/ex_unit/cli_formatter.ex:108: ExUnit.CLIFormatter.handle_cast/2
                (stdlib 3.17.2) gen_server.erl:695: :gen_server.try_dispatch/4
                (stdlib 3.17.2) gen_server.erl:771: :gen_server.handle_msg/6
                (stdlib 3.17.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
    (elixir 1.13.4) lib/gen_server.ex:987: GenServer.stop/3
    (ex_unit 1.13.4) lib/ex_unit/event_manager.ex:22: anonymous fn/2 in ExUnit.EventManager.stop/1
    (elixir 1.13.4) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ex_unit 1.13.4) lib/ex_unit/event_manager.ex:21: ExUnit.EventManager.stop/1
    (ex_unit 1.13.4) lib/ex_unit/runner.ex:62: ExUnit.Runner.run_with_trap/2
    (ex_unit 1.13.4) lib/ex_unit/runner.ex:31: ExUnit.Runner.run/2
    (elixir 1.13.4) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
    (elixir 1.13.4) lib/task/supervised.ex:34: Task.Supervised.reply/4
    (stdlib 3.17.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Function: #Function<0.129552615/0 in ExUnit.async_run/0>
    Args: []
** (EXIT from #PID<0.94.0>) exited in: GenServer.stop(#PID<0.155.0>, :normal, :infinity)
    ** (EXIT) exited in: :sys.terminate(#PID<0.155.0>, :normal, :infinity)
        ** (EXIT) an exception was raised:
            ** (FunctionClauseError) no function clause matching in Code.Identifier.inspect_as_atom/1
                (elixir 1.13.4) lib/code/identifier.ex:138: Code.Identifier.inspect_as_atom({:^, [line: 15], [{:type, [line: 15], nil}]})
                (ex_unit 1.13.4) lib/ex_unit/diff.ex:931: ExUnit.Diff.safe_to_algebra/2
                (ex_unit 1.13.4) lib/ex_unit/diff.ex:1034: ExUnit.Diff.wrap_on_diff/3
                (ex_unit 1.13.4) lib/ex_unit/formatter.ex:434: ExUnit.Formatter.format_sides/6
                (ex_unit 1.13.4) lib/ex_unit/formatter.ex:422: ExUnit.Formatter.format_context/4
                (ex_unit 1.13.4) lib/ex_unit/formatter.ex:190: ExUnit.Formatter.format_exception/6
                (ex_unit 1.13.4) lib/ex_unit/formatter.ex:161: anonymous fn/7 in ExUnit.Formatter.format_test_failure/5
                (elixir 1.13.4) lib/enum.ex:1690: anonymous fn/2 in Enum.map_join/3
                (elixir 1.13.4) lib/enum.ex:4126: Enum.map_intersperse_list/3
                (elixir 1.13.4) lib/enum.ex:1690: Enum.map_join/3
                (ex_unit 1.13.4) lib/ex_unit/formatter.ex:160: ExUnit.Formatter.format_test_failure/5
                (ex_unit 1.13.4) lib/ex_unit/cli_formatter.ex:108: ExUnit.CLIFormatter.handle_cast/2
                (stdlib 3.17.2) gen_server.erl:695: :gen_server.try_dispatch/4
                (stdlib 3.17.2) gen_server.erl:771: :gen_server.handle_msg/6
                (stdlib 3.17.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```