### PR TITLE
Reorder format_status documentation

### DIFF
--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -695,7 +695,6 @@ defmodule GenServer do
   `GenServer`. For example, it can be used to return a compact representation of
   the `GenServer`'s state to avoid having large state terms printed.
 
-
   `pdict_and_state` is a two-elements list `[pdict, state]` where `pdict` is a
   list of `{key, value}` tuples representing the current process dictionary of
   the `GenServer` and `state` is the current state of the `GenServer`.

--- a/lib/elixir/lib/gen_server.ex
+++ b/lib/elixir/lib/gen_server.ex
@@ -683,17 +683,18 @@ defmodule GenServer do
             when old_vsn: term | {:down, term}
 
   @doc """
-  Invoked in some cases to retrieve a formatted version of the `GenServer` status.
-
-  This callback can be useful to control the *appearance* of the status of the
-  `GenServer`. For example, it can be used to return a compact representation of
-  the `GenServer`'s state to avoid having large state terms printed.
+  Invoked in some cases to retrieve a formatted version of the `GenServer` status:
 
     * one of `:sys.get_status/1` or `:sys.get_status/2` is invoked to get the
       status of the `GenServer`; in such cases, `reason` is `:normal`
 
     * the `GenServer` terminates abnormally and logs an error; in such cases,
       `reason` is `:terminate`
+
+  This callback can be useful to control the *appearance* of the status of the
+  `GenServer`. For example, it can be used to return a compact representation of
+  the `GenServer`'s state to avoid having large state terms printed.
+
 
   `pdict_and_state` is a two-elements list `[pdict, state]` where `pdict` is a
   list of `{key, value}` tuples representing the current process dictionary of


### PR DESCRIPTION
The list of different invokation cases was separated from the sentence that introduces those cases.