### PR TITLE
Add `Enum.none?/2`

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -345,6 +345,42 @@ defmodule Enum do
   end
 
   @doc """
+  Returns `true` if `fun.(element)` is falsy for all elements in `enumerable`.
+
+  Iterates over `enumerable` and invokes `fun` on each element. If `fun` ever
+  returns a truthy value, iteration stops immediately and
+  `false` is returned. Otherwise, `true` is returned.
+
+  ## Examples
+
+      iex> Enum.none?([2, 4, 6], fn x -> rem(x, 2) != 0 end)
+      true
+
+      iex> Enum.none?([2, 3, 4], fn x -> rem(x, 2) != 0 end)
+      false
+
+      iex> Enum.none?([], fn _ -> nil end)
+      true
+
+  As the last example shows, `Enum.none?/2` returns `true` if `enumerable` is
+  empty, regardless of `fun`. In an empty enumerable there is no element for
+  which `fun` returns a truthy value, so the result must be `true`. This is a
+  well-defined logical argument for empty collections.
+
+  """
+  @spec none?(t, (element -> as_boolean(term))) :: boolean
+  def none?(enumerable, fun) when is_list(enumerable) do
+    none_list(enumerable, fun)
+  end
+
+  def none?(enumerable, fun) do
+    Enumerable.reduce(enumerable, {:cont, true}, fn entry, _ ->
+      if fun.(entry), do: {:halt, false}, else: {:cont, true}
+    end)
+    |> elem(1)
+  end
+
+  @doc """
   Returns `true` if all elements in `enumerable` are truthy.
 
   When an element has a falsy value (`false` or `nil`) iteration stops immediately
@@ -4126,6 +4162,18 @@ defmodule Enum do
   end
 
   defp none_list([]) do
+    true
+  end
+
+  defp none_list([h | t], fun) do
+    if fun.(h) do
+      false
+    else
+      none_list(t, fun)
+    end
+  end
+
+  defp none_list([], _) do
     true
   end
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -320,9 +320,6 @@ defmodule Enum do
 
   ## Examples
 
-    iex> Enum.none?([])
-    true
-
     iex> Enum.none?([false])
     true
 
@@ -331,7 +328,16 @@ defmodule Enum do
 
     iex> Enum.none?([0, 1])
     false
+
+    iex> Enum.none?([])
+    true
+
+  As the last example shows, `Enum.none?/1` returns `true` if `enumerable` is
+  empty. In an empty enumerable there is no element that can be truhty so the 
+  result must be `true`. This is a well-defined logical argument for empty collections.
+
   """
+  @doc since: "1.14.0"
   @spec none?(t) :: boolean
   def none?(enumerable) when is_list(enumerable) do
     none_list(enumerable)
@@ -368,6 +374,7 @@ defmodule Enum do
   well-defined logical argument for empty collections.
 
   """
+  @doc since: "1.14.0"
   @spec none?(t, (element -> as_boolean(term))) :: boolean
   def none?(enumerable, fun) when is_list(enumerable) do
     none_list(enumerable, fun)

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -313,6 +313,38 @@ defmodule Enum do
   end
 
   @doc """
+  Returns `true` if all elements in `enumerable` are falsy.
+
+  When an element has a truthy value iteration stops immediately
+  and `false` is returned. In all other cases `true` is returned.
+
+  ## Examples
+
+    iex> Enum.none?([])
+    true
+
+    iex> Enum.none?([false])
+    true
+
+    iex> Enum.none?([false, nil])
+    true
+
+    iex> Enum.none?([0, 1])
+    false
+  """
+  @spec none?(t) :: boolean
+  def none?(enumerable) when is_list(enumerable) do
+    none_list(enumerable)
+  end
+
+  def none?(enumerable) do
+    Enumerable.reduce(enumerable, {:cont, true}, fn entry, _ ->
+      if entry, do: {:halt, false}, else: {:cont, true}
+    end)
+    |> elem(1)
+  end
+
+  @doc """
   Returns `true` if all elements in `enumerable` are truthy.
 
   When an element has a falsy value (`false` or `nil`) iteration stops immediately
@@ -4083,6 +4115,19 @@ defmodule Enum do
   end
 
   ## Implementations
+
+  ## none?
+  defp none_list([h | t]) do
+    if h do
+      false
+    else
+      none_list(t)
+    end
+  end
+
+  defp none_list([]) do
+    true
+  end
 
   ## all?
 

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -320,17 +320,17 @@ defmodule Enum do
 
   ## Examples
 
-    iex> Enum.none?([false])
-    true
+      iex> Enum.none?([false])
+      true
 
-    iex> Enum.none?([false, nil])
-    true
+      iex> Enum.none?([false, nil])
+      true
 
-    iex> Enum.none?([0, 1])
-    false
+      iex> Enum.none?([0, 1])
+      false
 
-    iex> Enum.none?([])
-    true
+      iex> Enum.none?([])
+      true
 
   As the last example shows, `Enum.none?/1` returns `true` if `enumerable` is
   empty. In an empty enumerable there is no element that can be truhty so the 

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -62,14 +62,21 @@ defmodule EnumTest do
     end
   end
 
-  test "none?/1" do
+  test "none?/2" do
     assert Enum.none?([])
     assert Enum.none?([nil])
     assert Enum.none?([false])
 
-    assert Enum.none?([0]) == false
-    assert Enum.none?([1]) == false
-    assert Enum.none?([1, 2]) == false
+    refute Enum.none?([0])
+    refute Enum.none?([1])
+    refute Enum.none?([1, 2])
+
+    assert Enum.none?([], fn _ -> nil end)
+    assert Enum.none?([nil], fn x -> x end)
+    assert Enum.none?([3, 5, 7], fn x -> rem(x, 2) == 0 end)
+
+    refute Enum.none?([0], fn x -> x end)
+    refute Enum.none?([2, 4, 6], fn x -> rem(x, 2) == 0 end)
   end
 
   test "all?/2" do

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -62,6 +62,16 @@ defmodule EnumTest do
     end
   end
 
+  test "none?/1" do
+    assert Enum.none?([])
+    assert Enum.none?([nil])
+    assert Enum.none?([false])
+
+    assert Enum.none?([0]) == false
+    assert Enum.none?([1]) == false
+    assert Enum.none?([1, 2]) == false
+  end
+
   test "all?/2" do
     assert Enum.all?([2, 4, 6])
     refute Enum.all?([2, nil, 4])


### PR DESCRIPTION
Seeing `Enum.all?/2` being available made me assume there was also an `Enum.none?/2` (like in Ruby), and I was a bit suprised to learn there was no such thing.
I'm aware that I could just do `!Enum.all?/2`, but `Enum.none?/2` sees much nicer to me.

One more argument that I could make is that `!Enum.all?/1 == Enum.none?/1` is not true in all cases.
Example:
If we have `[false, true]`, `!Enum.all?/1` will be `true`, but `Enum.none?/1` will be `false`

I enjoy Elixir very much and want to give back to the community any way I can.
I'm also open to any form of feedback (thanks in advance) and would very much appreciate it.