### PR TITLE
Add missing return types

### DIFF
--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -636,7 +636,7 @@ defmodule Inspect.Algebra do
       ["hello", "\n     ", "world"]
 
   """
-  @spec nest(t, non_neg_integer | :cursor | :reset, :always | :break) :: doc_nest
+  @spec nest(t, non_neg_integer | :cursor | :reset, :always | :break) :: doc_nest | t
   def nest(doc, level, mode \\ :always)
 
   def nest(doc, :cursor, mode) when is_doc(doc) and mode in [:always, :break] do

--- a/lib/elixir/lib/module.ex
+++ b/lib/elixir/lib/module.ex
@@ -1262,6 +1262,7 @@ defmodule Module do
   @spec get_definition(module, definition, keyword) ::
           {:v1, def_kind, meta :: keyword,
            [{meta :: keyword, arguments :: [Macro.t()], guards :: [Macro.t()], Macro.t()}]}
+          | nil
   @doc since: "1.12.0"
   def get_definition(module, {name, arity}, options \\ [])
       when is_atom(module) and is_atom(name) and is_integer(arity) and is_list(options) do


### PR DESCRIPTION
`Module.get_definition` returns `nil` when `:ets.lookup(set, {:def, {name, arity}})` returns `[]`

`Algebra.nest` reutrns `t` in
```
def nest(doc, 0, _mode) when is_doc(doc) do
    doc
 end
```