### PR TITLE
Raise when inderlying erlang function doesn't return boolean

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -328,7 +328,14 @@ defmodule Code do
   """
   @spec delete_path(Path.t()) :: boolean
   def delete_path(path) do
-    :code.del_path(to_charlist(Path.expand(path)))
+    case :code.del_path(to_charlist(Path.expand(path))) do
+      result when is_boolean(result) ->
+        result
+
+      {:error, :bad_name} ->
+        raise ArgumentError,
+              "invalid argument #{inspect(path)}"
+    end
   end
 
   @doc """


### PR DESCRIPTION
Without this patch the implementation will lead to errors in code that depends on a truthy result
```
if Code.delete_path(potentially_bad_path) do
  do_sth()
end
```