### PR TITLE
Fix ExUnit assertion when operator be overrode

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -238,22 +238,26 @@ defmodule ExUnit.Assertions do
 
   defp translate_assertion(:assert, {operator, meta, [_, _]} = expr, caller)
        when operator in @operator do
-    left = Macro.var(:left, __MODULE__)
-    right = Macro.var(:right, __MODULE__)
-    call = {operator, meta, [left, right]}
-    equality_check? = operator in [:<, :>, :!==, :!=]
-    message = "Assertion with #{operator} failed"
-    translate_operator(:assert, expr, call, message, equality_check?, caller)
+    if match?([{_, Kernel}], Macro.Env.lookup_import(caller, {operator, 2})) do
+      left = Macro.var(:left, __MODULE__)
+      right = Macro.var(:right, __MODULE__)
+      call = {operator, meta, [left, right]}
+      equality_check? = operator in [:<, :>, :!==, :!=]
+      message = "Assertion with #{operator} failed"
+      translate_operator(:assert, expr, call, message, equality_check?, caller)
+    end
   end
 
   defp translate_assertion(:refute, {operator, meta, [_, _]} = expr, caller)
        when operator in @operator do
-    left = Macro.var(:left, __MODULE__)
-    right = Macro.var(:right, __MODULE__)
-    call = {:not, meta, [{operator, meta, [left, right]}]}
-    equality_check? = operator in [:<=, :>=, :===, :==, :=~]
-    message = "Refute with #{operator} failed"
-    translate_operator(:refute, expr, call, message, equality_check?, caller)
+    if match?([{_, Kernel}], Macro.Env.lookup_import(caller, {operator, 2})) do
+      left = Macro.var(:left, __MODULE__)
+      right = Macro.var(:right, __MODULE__)
+      call = {:not, meta, [{operator, meta, [left, right]}]}
+      equality_check? = operator in [:<=, :>=, :===, :==, :=~]
+      message = "Refute with #{operator} failed"
+      translate_operator(:refute, expr, call, message, equality_check?, caller)
+    end
   end
 
   defp translate_assertion(_kind, _expected, _caller) do

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -157,7 +157,7 @@ defmodule ExUnit.AssertionsTest do
     use ExUnit.Case
     use ExUnit.AssertionsTest.OverrideOperator
 
-    test "assert when operator be overrided" do
+    test "assert when operator be overrode" do
       assert [_a, _b] =~ [1, 2]
     end
   end

--- a/lib/ex_unit/test/ex_unit/assertions_test.exs
+++ b/lib/ex_unit/test/ex_unit/assertions_test.exs
@@ -16,6 +16,23 @@ defmodule ExUnit.AssertionsTest.BrokenError do
   end
 end
 
+defmodule ExUnit.AssertionsTest.OverrideOperator do
+  import Kernel, except: [{:=~, 2}]
+
+  defmacro __using__(_) do
+    quote do
+      import Kernel, except: [{:=~, 2}]
+      import ExUnit.AssertionsTest.OverrideOperator
+    end
+  end
+
+  defmacro left =~ right do
+    quote do
+      match?(unquote(left), unquote(right))
+    end
+  end
+end
+
 alias ExUnit.AssertionsTest.{BrokenError, Value}
 
 defmodule ExUnit.AssertionsTest do
@@ -134,6 +151,15 @@ defmodule ExUnit.AssertionsTest do
   test "assert does not expand variables" do
     assert argless_macro = 1
     assert argless_macro == 1
+  end
+
+  defmodule OperatorOverrideTest do
+    use ExUnit.Case
+    use ExUnit.AssertionsTest.OverrideOperator
+
+    test "assert when operator be overrided" do
+      assert [_a, _b] =~ [1, 2]
+    end
   end
 
   test "refute when value is falsy" do


### PR DESCRIPTION
#11885

The `refute` test case will cause a "warning: this check/guard will always yield the same result" warning, so didn't add that.

```
    test "refute when operator be overrode" do
      refute [_a] =~ [1, 2]
    end
```