### PR TITLE
Let `:runtime_config_path` accept false to skip the runtime.exs

### DIFF
--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -1220,7 +1220,7 @@ defmodule Mix.Tasks.Release do
     {path, reboot?} =
       cond do
         opts[:runtime_config_path] == false ->
-          {nil, false}
+          {false, false}
 
         path = opts[:runtime_config_path] ->
           {path, false}
@@ -1256,8 +1256,8 @@ defmodule Mix.Tasks.Release do
         release = update_in(release.config_providers, &[{Config.Reader, opts} | &1])
         update_in(release.options, &Keyword.put_new(&1, :reboot_system_after_config, reboot?))
 
-      release.config_providers == [] ->
-        skipping("runtime configuration (#{default_path} not found or disabled)")
+      release.config_providers == [] and path != false ->
+        skipping("runtime configuration (#{default_path} not found)")
         release
 
       true ->

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -634,6 +634,9 @@ defmodule Mix.Tasks.Release do
         ]
       ]
 
+  By setting `:runtime_config_path` to `false` it can be used to prevent
+  a runtime configuration file to be included in the release.
+
   Finally, in order for runtime configuration to work properly (as well
   as any other "Config provider" as defined next), it needs to be able
   to persist the newly computed configuration to disk. The computed config
@@ -1216,6 +1219,9 @@ defmodule Mix.Tasks.Release do
 
     {path, reboot?} =
       cond do
+        opts[:runtime_config_path] == false ->
+          {nil, false}
+
         path = opts[:runtime_config_path] ->
           {path, false}
 

--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -1257,7 +1257,7 @@ defmodule Mix.Tasks.Release do
         update_in(release.options, &Keyword.put_new(&1, :reboot_system_after_config, reboot?))
 
       release.config_providers == [] ->
-        skipping("runtime configuration (#{default_path} not found)")
+        skipping("runtime configuration (#{default_path} not found or disabled)")
         release
 
       true ->


### PR DESCRIPTION
Based on the conversation here: https://groups.google.com/g/elixir-lang-core/c/LEzORYzFemA/m/AfjVbVlzBAAJ?utm_medium=email&utm_source=footer

There didn't seem to be any tests around this option based on a quick search for the option.