### PR TITLE
Removes duplicated formatter call

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -558,7 +558,7 @@ defmodule Mix.Tasks.Format do
   defp elixir_format(content, formatter_opts) do
     case Code.format_string!(content, formatter_opts) do
       [] -> ""
-      _ -> IO.iodata_to_binary([Code.format_string!(content, formatter_opts), ?\n])
+      formatted_content -> IO.iodata_to_binary([formatted_content, ?\n])
     end
   end
 


### PR DESCRIPTION
Hey folks! 👋 

There is a duplicated call for `Code.format_string!/2` in the Mix.Format task. This is a somewhat silly change - but from a local benchmark, **it cuts uncached `Mix.Format` execution time by half in relation to the main branch!** 🏃 

Happily, the duplicated call is only present on the main branch - it was introduced after the latest tag (1.13.4). 

## Benchmark

You may need to compile Elixir locally to run the benchmark using the development Elixir version. [Here are some instructions on how to do it](https://github.com/antedeguemon/format_benchmark/blob/master/README.md). Note that running the benchmark using Elixir 1.13.4 will likely yield equal results for both scenarios.

[(Full benchmark experiments are available in this Github repository. An experiment for _formating from stdin_ is also included.)](https://github.com/antedeguemon/format_benchmark)

### Script

```elixir
Benchee.run(
  %{
    "Default formatter" => fn path ->
      Mix.Task.run("format", [path])
      Mix.Task.clear()
    end,
    "Faster formatter" => fn path ->
      Mix.Task.run("faster_format", [path])
      Mix.Task.clear()
    end
  },
  inputs: %{
    "single file" => "./elixir/lib/elixir/lib/enum.ex",
    "multiple files" => "./elixir/lib/mix/{lib,unicode,test}/**/*.{ex,exs}"
  },
  time: 30
)
```

### Results

```
##### With input multiple files (192) #####
Name                        ips        average  deviation         median         99th %
Faster formatter           7.46      134.13 ms    ±37.79%      123.47 ms      351.11 ms
Default formatter          3.88      257.47 ms    ±48.68%      232.31 ms     1252.00 ms

Comparison: 
Faster formatter           7.46
Default formatter          3.88 - 1.92x slower +123.34 ms

##### With input single file #####
Name                        ips        average  deviation         median         99th %
Faster formatter          15.30       65.37 ms    ±15.64%       62.37 ms       95.63 ms
Default formatter          8.16      122.49 ms    ±32.11%      116.00 ms      355.19 ms

Comparison: 
Faster formatter          15.30
Default formatter          8.16 - 1.87x slower +57.12 ms

```
