### PR TITLE
Map docs: update syntax is not for atom keys only

### DIFF
--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -88,11 +88,14 @@ defmodule Map do
       %{1 => :one, 2 => :two, 3 => :three}
 
   Maps also support a specific update syntax to update the value stored under
-  *existing* keys:
+  *existing* keys. You can update using the atom keys syntax:
 
       iex> map = %{one: 1, two: 2}
       iex> %{map | one: "one"}
       %{one: "one", two: 2}
+
+  Or any other key:
+
       iex> other_map = %{"three" => 3, "four" => 4}
       iex> %{other_map | "three" => "three"}
       %{"four" => 4, "three" => "three"}

--- a/lib/elixir/lib/map.ex
+++ b/lib/elixir/lib/map.ex
@@ -88,11 +88,14 @@ defmodule Map do
       %{1 => :one, 2 => :two, 3 => :three}
 
   Maps also support a specific update syntax to update the value stored under
-  *existing* atom keys:
+  *existing* keys:
 
       iex> map = %{one: 1, two: 2}
       iex> %{map | one: "one"}
       %{one: "one", two: 2}
+      iex> other_map = %{"three" => 3, "four" => 4}
+      iex> %{other_map | "three" => "three"}
+      %{"four" => 4, "three" => "three"}
 
   When a key that does not exist in the map is updated a `KeyError` exception will be raised:
 


### PR DESCRIPTION
The map docs state that the `%{map | ...}` update syntax is for atom keys only, however it also works for any term with `=>` as far as I understand, so I updated the docs accordingly.