### PR TITLE
Include backslash, space, and null byte in string escape documentation

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -48,6 +48,7 @@ defmodule String do
   Besides allowing double-quotes to be escaped with a backslash,
   strings also support the following escape characters:
 
+    * `\0` - Null byte
     * `\a` - Bell
     * `\b` - Backspace
     * `\t` - Horizontal tab
@@ -56,7 +57,9 @@ defmodule String do
     * `\f` - Form feed
     * `\r` - Carriage return
     * `\e` - Command Escape
+    * `\s` - Space
     * `\#` - Returns the `#` character itself, skipping interpolation
+    * `\\` - Single backslash
     * `\xNN` - A byte represented by the hexadecimal `NN`
     * `\uNNNN` - A Unicode code point represented by `NNNN`
 


### PR DESCRIPTION
I noticed that the documentation for string omits three useful escapes which are supported. I've put these in ASCII order, as the other escapes are