### PR TITLE
Fix Date.Range.first_in_iso_days/last_in_iso_days typespec

### DIFF
--- a/lib/elixir/lib/calendar/date_range.ex
+++ b/lib/elixir/lib/calendar/date_range.ex
@@ -16,12 +16,12 @@ defmodule Date.Range do
   @type t :: %__MODULE__{
           first: Date.t(),
           last: Date.t(),
-          first_in_iso_days: iso_days(),
-          last_in_iso_days: iso_days(),
+          first_in_iso_days: days(),
+          last_in_iso_days: days(),
           step: pos_integer | neg_integer
         }
 
-  @typep iso_days() :: Calendar.iso_days()
+  @typep days() :: integer()
 
   @enforce_keys [:first, :last, :first_in_iso_days, :last_in_iso_days, :step]
   defstruct [:first, :last, :first_in_iso_days, :last_in_iso_days, :step]

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -902,7 +902,7 @@ defmodule IEx.HelpersTest do
     end
 
     test "prints private types" do
-      assert capture_io(fn -> t(Date.Range) end) =~ "@typep iso_days"
+      assert capture_io(fn -> t(Date.Range) end) =~ "@typep days"
     end
 
     test "prints type information" do


### PR DESCRIPTION
first_in_iso_days and last_in_iso_days are both integers. This commit
updates the Date.Range typespec to reflect that.

Fixes https://github.com/elixir-lang/elixir/issues/11947.