### PR TITLE
Add disjoint function to MapSet

### DIFF
--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -172,6 +172,21 @@ defmodule MapSet do
   end
 
   @doc """
+  Returns a set with elements that are present in only one but not both sets.
+
+  ## Examples
+
+      iex> MapSet.disjoint(MapSet.new([1, 2, 3]), MapSet.new([2, 3, 4]))
+      MapSet.new([1, 4])
+  """
+  @spec disjoint(t(val1), t(val2)) :: t(val1) when val1: value, val2: value
+  def disjoint(left = %MapSet{}, right = %MapSet{}) do
+    diff_left_right = MapSet.difference(left, right)
+    diff_right_left = MapSet.difference(right, left)
+    MapSet.union(diff_left_right, diff_right_left)
+  end
+
+  @doc """
   Checks if `map_set1` and `map_set2` have no members in common.
 
   ## Examples

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -189,7 +189,7 @@ defmodule MapSet do
 
     {small, list} = disjointer(large, small)
 
-    map = list |> :maps.from_keys([]) |> Map.merge(small)
+    map = list |> :maps.from_list() |> Map.merge(small)
     %MapSet{map: map}
   end
 
@@ -205,7 +205,7 @@ defmodule MapSet do
     else
       iter
       |> :maps.next()
-      |> disjointer({small, [key | list]})
+      |> disjointer({small, [{key, []} | list]})
     end
   end
 

--- a/lib/elixir/lib/map_set.ex
+++ b/lib/elixir/lib/map_set.ex
@@ -193,19 +193,19 @@ defmodule MapSet do
     %MapSet{map: map}
   end
 
-  defp disjointer(:none, {small, list}) do
+  defp disjointer(:none, small, list) do
     {small, list}
   end
 
-  defp disjointer({key, _val, iter}, {small, list}) do
+  defp disjointer({key, _val, iter}, small, list) do
     if :erlang.is_map_key(key, small) do
       iter
       |> :maps.next()
-      |> disjointer({Map.delete(small, key), list})
+      |> disjointer(Map.delete(small, key), list)
     else
       iter
       |> :maps.next()
-      |> disjointer({small, [{key, []} | list]})
+      |> disjointer(small, [{key, []} | list])
     end
   end
 
@@ -213,7 +213,7 @@ defmodule MapSet do
     large
     |> :maps.iterator()
     |> :maps.next()
-    |> disjointer({small, []})
+    |> disjointer(small, [])
   end
 
   @doc """

--- a/lib/elixir/test/elixir/map_set_test.exs
+++ b/lib/elixir/test/elixir/map_set_test.exs
@@ -59,6 +59,17 @@ defmodule MapSetTest do
     assert MapSet.equal?(result, MapSet.new([1, 101]))
   end
 
+  test "disjoint/2" do
+    result = MapSet.disjoint(MapSet.new(1..5), MapSet.new(3..8))
+    assert MapSet.equal?(result, MapSet.new([1, 2, 6, 7, 8]))
+
+    result = MapSet.disjoint(MapSet.new(), MapSet.new())
+    assert MapSet.equal?(result, MapSet.new())
+
+    result = MapSet.disjoint(MapSet.new(1..5), MapSet.new(1..5))
+    assert MapSet.equal?(result, MapSet.new())
+  end
+
   test "disjoint?/2" do
     assert MapSet.disjoint?(MapSet.new(), MapSet.new())
     assert MapSet.disjoint?(MapSet.new(1..6), MapSet.new(8..20))


### PR DESCRIPTION
Hello there,

Since we have implementations for [union](https://hexdocs.pm/elixir/1.13.4/MapSet.html#union/2), [difference](https://hexdocs.pm/elixir/1.13.4/MapSet.html#difference/2) and [intersection](https://hexdocs.pm/elixir/1.13.4/MapSet.html#intersection/2) I believe it makes sense to have one for `disjoint`.
I saw myself writing this function multiple times and I thought it could be useful to more people.

I'm using the high level `difference` twice followed by a call to `union`. I noticed that most of the functions use the inner `map` directly. Please let me know if you prefer a different implementation.

Thank you for creating and maintaining Elixir! :bouquet: