### PR TITLE
Improve diagnostic and compile typespec

### DIFF
--- a/lib/elixir/lib/kernel/parallel_compiler.ex
+++ b/lib/elixir/lib/kernel/parallel_compiler.ex
@@ -5,7 +5,7 @@ defmodule Kernel.ParallelCompiler do
 
   @typedoc "The line. 0 indicates no line."
   @type line() :: non_neg_integer()
-  @type location() :: line() | {line(), column :: non_neg_integer}
+  @type location() :: line() | {pos_integer(), column :: non_neg_integer}
   @type warning() :: {file :: Path.t(), location(), message :: String.t()}
   @type error() :: {file :: Path.t(), line(), message :: String.t()}
 

--- a/lib/mix/lib/mix/task.compiler.ex
+++ b/lib/mix/lib/mix/task.compiler.ex
@@ -36,7 +36,7 @@ defmodule Mix.Task.Compiler do
     @type t :: %__MODULE__{
             file: Path.t(),
             severity: severity,
-            message: String.t(),
+            message: IO.chardata(),
             position: position,
             compiler_name: String.t(),
             details: any


### PR DESCRIPTION
1. mix compiler actually returns chardata (or iodata) in message
```
%Mix.Task.Compiler.Diagnostic{
    file: "/Users/lukaszsamson/bug_repro/phx_error_path_umbr_umbrella/apps/phx_error_path_umbr_web/lib/phx_error_path_umbr_web/views/page_view.ex",
    severity: :warning,
    message: ["IO.π/0", " is undefined or private", ""],
    position: 3,
    compiler_name: "Elixir",
    details: nil
  }
```
2. `{0, column >= 0}` is not a location result from ParallelCompiler.

BTW shouldn't `Kernel.ParallelCompiler.locationa type allow ranges as in case of `Mix.Task.Compiler.Diagnostic.position`?