### PR TITLE
11961 Fix bug in fn defaults

### DIFF
--- a/lib/elixir/src/elixir_def.erl
+++ b/lib/elixir/src/elixir_def.erl
@@ -266,7 +266,7 @@ unpack_defaults(Kind, Meta, Name, Args, S, E) ->
 
 unpack_expanded(Kind, Meta, Name, [{'\\\\', DefaultMeta, [Expr, _]} | T] = List, VersionOffset, Acc, Clauses) ->
   Base = match_defaults(Acc, length(Acc) + VersionOffset, []),
-  {Args, Invoke} = extract_defaults(List, length(Base), [], []),
+  {Args, Invoke} = extract_defaults(List, length(Base) + VersionOffset, [], []),
   Clause = {Meta, Base ++ Args, [], {super, [{super, {Kind, Name}} | DefaultMeta], Base ++ Invoke}},
   unpack_expanded(Kind, Meta, Name, T, VersionOffset, [Expr | Acc], [Clause | Clauses]);
 unpack_expanded(Kind, Meta, Name, [H | T], VersionOffset, Acc, Clauses) ->

--- a/lib/elixir/test/elixir/kernel/defaults_test.exs
+++ b/lib/elixir/test/elixir/kernel/defaults_test.exs
@@ -5,6 +5,15 @@ defmodule Kernel.DefaultsTest do
 
   import ExUnit.CaptureIO
 
+  def fun_with_fn_defaults(
+        x,
+        fun1 \\ & &1,
+        fun2 \\ & &1,
+        y
+      ) do
+    {fun1.(x), fun2.(y)}
+  end
+
   def fun_with_block_defaults(
         x,
         y \\ (
@@ -17,6 +26,12 @@ defmodule Kernel.DefaultsTest do
         )
       ) do
     {x, y, z}
+  end
+
+  test "with anonymous function defaults" do
+    assert {1, 2} = fun_with_fn_defaults(1, 2)
+    assert {100, 2} = fun_with_fn_defaults(1, &(&1 * 100), 2)
+    assert {100, 12} = fun_with_fn_defaults(1, &(&1 * 100), &(&1 + 10), 2)
   end
 
   test "with block defaults" do


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/11961

In https://github.com/elixir-lang/elixir/pull/11758/files, I forgot to take the `VersionOffset` into account in `extract_defaults`, which is also calling `default_var` and might therefore conflict with previously defined defaults (generating two `x1`).