### PR TITLE
Make wording on the DynSup docs more direct

### DIFF
--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -1,13 +1,14 @@
 defmodule DynamicSupervisor do
   @moduledoc ~S"""
-  A supervisor that only starts children dynamically.
+  A supervisor optimized to only start children dynamically.
 
-  Differently from the `Supervisor` module, which requires its children 
-  to be given when the supervisor starts, a `DynamicSupervisor` starts 
-  with no children. Instead, children are always started on demand via 
-  `start_child/2` and there is no ordering between them. This allows the 
-  `DynamicSupervisor` to hold millions of children by using efficient data 
-  structures and to execute certain options, such as shutting down, concurrently.
+  The `Supervisor` module was designed to handle mostly static children
+  that are started in the given order when the supervisor starts. A
+  `DynamicSupervisor` starts with no children. Instead, children are
+  started on demand via `start_child/2` and there is no ordering between
+  children. This allows the `DynamicSupervisor` to hold millions of
+  children by using efficient data structures and to execute certain
+  operations, such as shutting down, concurrently.
 
   ## Examples
 

--- a/lib/elixir/lib/dynamic_supervisor.ex
+++ b/lib/elixir/lib/dynamic_supervisor.ex
@@ -1,14 +1,13 @@
 defmodule DynamicSupervisor do
   @moduledoc ~S"""
-  A supervisor that starts children dynamically.
+  A supervisor that only starts children dynamically.
 
-  The `Supervisor` module was designed to handle mostly static children
-  that are started in the given order when the supervisor starts. A
-  `DynamicSupervisor` starts with no children. Instead, children are
-  started on demand via `start_child/2` and there is no ordering between
-  children. This allows the `DynamicSupervisor` to hold millions of
-  children by using efficient data structures and to execute certain
-  options, such as shutting down, concurrently.
+  Differently from the `Supervisor` module, which requires its children 
+  to be given when the supervisor starts, a `DynamicSupervisor` starts 
+  with no children. Instead, children are always started on demand via 
+  `start_child/2` and there is no ordering between them. This allows the 
+  `DynamicSupervisor` to hold millions of children by using efficient data 
+  structures and to execute certain options, such as shutting down, concurrently.
 
   ## Examples
 


### PR DESCRIPTION
Tries to improve (on top of the improvement) the wording on the docs to distinguish that `DynamicSupervisor` (in contrast to `Supervisor`) can **only** start children dynamically. I think this distinction is important because `Supervisor` can also start children "dynamically" (although the initialization requirements are different). 

PS.: See whole discussion [here](https://elixirforum.com/t/difference-between-supervisors-and-dynamicsupervisors-what-am-i-missing/48821/5?u=thiagomajesk).