### PR TITLE
Fix exports/1 in IEx for long fun names

### DIFF
--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -786,8 +786,6 @@ defmodule IEx.Helpers do
 
   defp expand_home(other), do: other
 
-  defp print_table(list, printer \\ &String.pad_trailing/2)
-
   defp print_table([], _printer) do
     :ok
   end

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -740,8 +740,16 @@ defmodule IEx.Helpers do
         Atom.to_string(name) <> "/" <> Integer.to_string(arity)
       end)
 
-    print_table(list)
+    print_table(list, &pad_trailing_min_one/2)
     dont_display_result()
+  end
+
+  defp pad_trailing_min_one(string, count) do
+    if String.length(string) >= count do
+      string <> " "
+    else
+      String.pad_trailing(string, count)
+    end
   end
 
   @doc """

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -740,16 +740,8 @@ defmodule IEx.Helpers do
         Atom.to_string(name) <> "/" <> Integer.to_string(arity)
       end)
 
-    print_table(list, &pad_trailing_min_one/2)
+    print_table(list)
     dont_display_result()
-  end
-
-  defp pad_trailing_min_one(string, count) do
-    if String.length(string) >= count do
-      string <> " "
-    else
-      String.pad_trailing(string, count)
-    end
   end
 
   @doc """
@@ -786,6 +778,8 @@ defmodule IEx.Helpers do
 
   defp expand_home(other), do: other
 
+  defp print_table(list, printer \\ &String.pad_trailing/2)
+
   defp print_table([], _printer) do
     :ok
   end
@@ -794,7 +788,7 @@ defmodule IEx.Helpers do
     # print items in multiple columns (2 columns in the worst case)
     lengths = Enum.map(list, &String.length(&1))
     max_length = max_length(lengths)
-    offset = min(max_length, 30) + 5
+    offset = min(max_length, 30) + 4
     print_table(list, printer, offset)
   end
 
@@ -808,8 +802,11 @@ defmodule IEx.Helpers do
           length
         end
 
-      IO.write(printer.(item, offset))
-      length + offset
+      printed = printer.(item, offset)
+      actual_offset = String.length(printed) + 1
+
+      IO.write(printed <> " ")
+      length + actual_offset
     end)
 
     IO.puts("")

--- a/lib/iex/test/iex/helpers_test.exs
+++ b/lib/iex/test/iex/helpers_test.exs
@@ -1039,6 +1039,13 @@ defmodule IEx.HelpersTest do
       exports = capture_io(fn -> exports(IEx.Autocomplete) end)
       assert exports == "expand/1      expand/2      exports/1     remsh/1       \n"
     end
+
+    test "handles long function names" do
+      exports = capture_io(fn -> exports(Calendar.UTCOnlyTimeZoneDatabase) end)
+
+      assert exports ==
+               "time_zone_period_from_utc_iso_days/2 time_zone_periods_from_wall_datetime/2 \n"
+    end
   end
 
   describe "import_file" do


### PR DESCRIPTION
Close #11968

The problem was that `print_table` uses a [max_length](https://github.com/elixir-lang/elixir/blob/main/lib/iex/lib/iex/helpers.ex#L790-L791=) in which case `String.pad_trailing` would not be adding any space.
