### PR TITLE
Update DynSup reference in Supervisor docs

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -325,7 +325,7 @@ defmodule Supervisor do
   In the above, process termination refers to unsuccessful termination, which
   is determined by the `:restart` option.
 
-  To dynamically supervise children, see `DynamicSupervisor`.
+  To efficiently supervise children started dynamically, see `DynamicSupervisor`.
 
   ### Name registration
 


### PR DESCRIPTION
Follow up on the improvements of https://github.com/elixir-lang/elixir/pull/11970. WDYT?
The idea is to make clear that `DynamicSupervisor` is an efficient way of starting children dynamically (and not the only way).

PS.: @josevalim I wonder if this distinction should be made in the guides as well, what is your opinion about it? I remember reading it and being confused about this in particular (like I mentioned in the forums before).