### PR TITLE
Have File.rename/2 and File.copy/2 check path types

### DIFF
--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -694,7 +694,10 @@ defmodule File do
   @spec copy(Path.t() | io_device, Path.t() | io_device, pos_integer | :infinity) ::
           {:ok, non_neg_integer} | {:error, posix}
   def copy(source, destination, bytes_count \\ :infinity) do
-    :file.copy(maybe_to_string(source), maybe_to_string(destination), bytes_count)
+    source = normalize_path_or_io_device(source)
+    destination = normalize_path_or_io_device(destination)
+
+    :file.copy(source, destination, bytes_count)
   end
 
   @doc """
@@ -712,8 +715,8 @@ defmodule File do
         raise File.CopyError,
           reason: reason,
           action: "copy",
-          source: maybe_to_string(source),
-          destination: maybe_to_string(destination)
+          source: normalize_path_or_io_device(source),
+          destination: normalize_path_or_io_device(destination)
     end
   end
 
@@ -1803,7 +1806,8 @@ defmodule File do
   defp normalize_modes([], true), do: [:binary]
   defp normalize_modes([], false), do: []
 
-  defp maybe_to_string(path) when is_list(path), do: IO.chardata_to_string(path)
-  defp maybe_to_string(path) when is_binary(path), do: path
-  defp maybe_to_string(path), do: path
+  defp normalize_path_or_io_device(path) when is_list(path), do: IO.chardata_to_string(path)
+  defp normalize_path_or_io_device(path) when is_binary(path), do: path
+  defp normalize_path_or_io_device(io_device) when is_pid(io_device), do: io_device
+  defp normalize_path_or_io_device(io_device = {:file_descriptor, _, _}), do: io_device
 end

--- a/lib/elixir/lib/file.ex
+++ b/lib/elixir/lib/file.ex
@@ -741,6 +741,8 @@ defmodule File do
   @doc since: "1.1.0"
   @spec rename(Path.t(), Path.t()) :: :ok | {:error, posix}
   def rename(source, destination) do
+    source = IO.chardata_to_string(source)
+    destination = IO.chardata_to_string(destination)
     :file.rename(source, destination)
   end
 


### PR DESCRIPTION
Hello,

I noticed that some of the functions in the `File` module could accept atom arguments such as `nil` as their paths and would actually succeed.

```
iex(1)> File.copy("mix.exs", nil)
{:ok, 2281}
iex(2)> File.exists?("nil")
true
iex(3)> File.rename(nil, true)
:ok
```

This is incoherent with the rest of the module which fails early on invalid data (typically using `IO.chardata_to_string/1`), doesn't match the typespecs and could silently provoke unexpected bugs.

Note: It is also the case for `File.write!/2` in 1.13, but this has already been fixed in https://github.com/elixir-lang/elixir/pull/11555.