### PR TITLE
Add example with nested arrays to Enum.join/2

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -1602,6 +1602,9 @@ defmodule Enum do
       iex> Enum.join([1, 2, 3], " = ")
       "1 = 2 = 3"
 
+      iex> Enum.join([["a", "b"], ["c", "d", "e", ["f", "g"]], "h", "i"], " ")
+      "ab cdefg h i"
+
   """
   @spec join(t, String.t()) :: String.t()
   def join(enumerable, joiner \\ "")


### PR DESCRIPTION
Add an another example to show that the `joiner` is inserted between elements of the highest level of the `enumerable`, whereas the nested elements are simply stuck together.