### PR TITLE
Add example to Enum.chunk_every/4 and Stream.chunk_every/4

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -529,6 +529,9 @@ defmodule Enum do
       iex> Enum.chunk_every([1, 2, 3, 4, 5], 2, 3, [])
       [[1, 2], [4, 5]]
 
+      iex> Enum.chunk_every([1, 2, 3, 4], 3, 3, Stream.cycle([0]))
+      [[1, 2, 3], [4, 0, 0]]
+
   """
   @doc since: "1.5.0"
   @spec chunk_every(t, pos_integer, pos_integer, t | :discard) :: [list]

--- a/lib/elixir/lib/stream.ex
+++ b/lib/elixir/lib/stream.ex
@@ -186,6 +186,9 @@ defmodule Stream do
       iex> Stream.chunk_every([1, 2, 3, 4, 5, 6], 3, 3, []) |> Enum.to_list()
       [[1, 2, 3], [4, 5, 6]]
 
+      iex> Stream.chunk_every([1, 2, 3, 4], 3, 3, Stream.cycle([0])) |> Enum.to_list()
+      [[1, 2, 3], [4, 0, 0]]
+
   """
   @doc since: "1.5.0"
   @spec chunk_every(Enumerable.t(), pos_integer, pos_integer, Enumerable.t() | :discard) ::


### PR DESCRIPTION
Add an example showing that a Stream can also be passed as `leftover`, because Enum.take/2 is later called inside those functions.

Indeed, both functions use Stream.Reducers.chunk_every/5 which calls Enum.take/2.