### PR TITLE
Show list opts when inspecting Regex

### DIFF
--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -381,6 +381,16 @@ defimpl Inspect, for: Float do
 end
 
 defimpl Inspect, for: Regex do
+  def inspect(regex = %{opts: regex_opts}, opts) when is_list(regex_opts) do
+    concat([
+      "Regex.compile!(",
+      Inspect.BitString.inspect(regex.source, opts),
+      ", ",
+      Inspect.List.inspect(regex_opts, opts),
+      ")"
+    ])
+  end
+
   def inspect(regex, opts) do
     {escaped, _} =
       regex.source

--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -155,7 +155,7 @@ defmodule Regex do
 
   defstruct re_pattern: nil, source: "", opts: "", re_version: ""
 
-  @type t :: %__MODULE__{re_pattern: term, source: binary, opts: binary}
+  @type t :: %__MODULE__{re_pattern: term, source: binary, opts: binary | list(atom)}
 
   defmodule CompileError do
     defexception message: "regex could not be compiled"
@@ -203,12 +203,17 @@ defmodule Regex do
   defp compile(source, opts, doc_opts, version) do
     case :re.compile(source, opts) do
       {:ok, re_pattern} ->
+        doc_opts = format_doc_opts(doc_opts, opts)
         {:ok, %Regex{re_pattern: re_pattern, re_version: version, source: source, opts: doc_opts}}
 
       error ->
         error
     end
   end
+
+  defp format_doc_opts(_doc_opts = "", _opts = []), do: ""
+  defp format_doc_opts(_doc_opts = "", opts), do: opts
+  defp format_doc_opts(doc_opts, _opts), do: doc_opts
 
   @doc """
   Compiles the regular expression and raises `Regex.CompileError` in case of errors.

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -863,6 +863,8 @@ defmodule Inspect.OthersTest do
     assert inspect(~r<\a\b\d\e\f\n\r\s\t\v/>) == "~r/\\a\\b\\d\\e\\f\\n\\r\\s\\t\\v\\//"
     assert inspect(~r" \\/ ") == "~r/ \\\\\\/ /"
     assert inspect(~r/hi/, syntax_colors: [regex: :red]) == "\e[31m~r/hi/\e[0m"
+
+    assert inspect(Regex.compile!("foo", [:caseless])) == ~S'Regex.compile!("foo", [:caseless])'
   end
 
   test "inspect_fun" do


### PR DESCRIPTION
Hi,

This is a proposal to improve inspection of `Regex` built from an atom list.

```
iex(1)> Regex.compile!("foo", [:caseless])
~r/foo/
```

This issue was mentioned [in this forum ](https://elixirforum.com/t/is-it-normal-that-regex-compile-2-does-not-print-regex-modifiers-when-atoms-are-passed-in-options/48992).

<img width="313" alt="Screen Shot 2022-07-18 at 11 07 31" src="https://user-images.githubusercontent.com/11598866/179435708-856ec3a6-2088-4459-a72d-737992c228e8.png">

Feel free to close if we want to keep it this way or follow a different approach 🙂