### PR TITLE
[SUSTAIN] Updating type spec/tests for recent PR to Regex options

### DIFF
--- a/lib/elixir/lib/regex.ex
+++ b/lib/elixir/lib/regex.ex
@@ -403,7 +403,7 @@ defmodule Regex do
       "m"
 
   """
-  @spec opts(t) :: String.t()
+  @spec opts(t) :: String.t() | [term]
   def opts(%Regex{opts: opts}) do
     opts
   end

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -864,6 +864,7 @@ defmodule Inspect.OthersTest do
     assert inspect(~r" \\/ ") == "~r/ \\\\\\/ /"
     assert inspect(~r/hi/, syntax_colors: [regex: :red]) == "\e[31m~r/hi/\e[0m"
 
+    assert inspect(Regex.compile!("foo", "i")) == "~r/foo/i"
     assert inspect(Regex.compile!("foo", [:caseless])) == ~S'Regex.compile!("foo", [:caseless])'
   end
 

--- a/lib/elixir/test/elixir/regex_test.exs
+++ b/lib/elixir/test/elixir/regex_test.exs
@@ -131,6 +131,7 @@ defmodule RegexTest do
 
   test "opts/1" do
     assert Regex.opts(Regex.compile!("foo", "i")) == "i"
+    assert Regex.opts(Regex.compile!("foo", [:caseless])) == [:caseless]
   end
 
   test "names/1" do


### PR DESCRIPTION
Adding a bit of sustaining updates to the PR #11991:

* Updated the type spec on `Regex.opts` to indicate options can be `[term]`, ie: a list of atoms
* Added a test to verify options' type preservation from `Regex.opts`
* Added a test to verify options' type preservation from `inspect`

Test execution evidence:

```
%make test_stdlib
==> elixir (ex_unit)
Excluding tags: [windows: true]
  . . .
Finished in 17.7 seconds (7.5s on load, 4.9s async, 5.2s sync)
1881 doctests, 4080 tests, 0 failures, 13 excluded
```