### PR TITLE
Proposal: Improve error messages for dot syntax

### DIFF
--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -820,15 +820,8 @@ defmodule ArgumentError do
           "you attempted to apply a function named #{inspect(function)} on module #{inspect(module)} " <>
             "with arguments #{inspect(args)}. Arguments (the third argument of apply) must always be a proper list"
 
-        # Note that args may be an empty list even if they were supplied
-        not is_atom(module) and is_atom(function) and args == [] ->
-          "you attempted to apply a function named #{inspect(function)} on #{inspect(module)}. " <>
-            "If you are using Kernel.apply/3, make sure the module is an atom. " <>
-            "If you are using the dot syntax, such as map.field or module.function(), " <>
-            "make sure the left side of the dot is an atom or a map"
-
         not is_atom(module) ->
-          "you attempted to apply a function on #{inspect(module)}. " <>
+          "you attempted to apply a function named #{inspect(function)} on #{inspect(module)}. " <>
             "Modules (the first argument of apply) must always be an atom"
 
         not is_atom(function) ->
@@ -1637,6 +1630,22 @@ defmodule ErlangError do
 
   def normalize({:badkey, key, map}, _stacktrace) do
     %KeyError{key: key, term: map}
+  end
+
+  def normalize({:baddot, true, key, map}, _stacktrace) do
+    %ArgumentError{
+      message:
+        "could not find key #{inspect(key)} on #{inspect(map)}. " <>
+          "When using the map.field syntax, make sure the left side of the dot is a map"
+    }
+  end
+
+  def normalize({:baddot, false, key, module}, _stacktrace) do
+    %ArgumentError{
+      message:
+        "could not find function #{inspect(key)} on #{inspect(module)}. " <>
+          "When using the module.function() syntax, make sure the left side of the dot is a module"
+    }
   end
 
   def normalize({:case_clause, term}, _stacktrace) do

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -820,8 +820,15 @@ defmodule ArgumentError do
           "you attempted to apply a function named #{inspect(function)} on module #{inspect(module)} " <>
             "with arguments #{inspect(args)}. Arguments (the third argument of apply) must always be a proper list"
 
-        not is_atom(module) ->
+        # Note that args may be an empty list even if they were supplied
+        not is_atom(module) and is_atom(function) and args == [] ->
           "you attempted to apply a function named #{inspect(function)} on #{inspect(module)}. " <>
+            "If you are using Kernel.apply/3, make sure the module is an atom. " <>
+            "If you are using the dot syntax, such as module.function(), " <>
+            "make sure the left-hand side of the dot is a module atom"
+
+        not is_atom(module) ->
+          "you attempted to apply a function on #{inspect(module)}. " <>
             "Modules (the first argument of apply) must always be an atom"
 
         not is_atom(function) ->
@@ -1107,8 +1114,8 @@ defmodule UndefinedFunctionError do
   end
 
   defp hint(nil, _function, 0, _loaded?) do
-    ". If you are using the dot syntax, such as map.field or module.function(), " <>
-      "make sure the left side of the dot is an atom or a map"
+    ". If you are using the dot syntax, such as module.function(), " <>
+      "make sure the left-hand side of the dot is a module atom"
   end
 
   defp hint(module, function, arity, true) do
@@ -1628,24 +1635,17 @@ defmodule ErlangError do
     %KeyError{key: key, term: term}
   end
 
-  def normalize({:badkey, key, map}, _stacktrace) do
+  def normalize({:badkey, key, map}, _stacktrace) when is_map(map) do
     %KeyError{key: key, term: map}
   end
 
-  def normalize({:baddot, true, key, map}, _stacktrace) do
-    %ArgumentError{
-      message:
-        "could not find key #{inspect(key)} on #{inspect(map)}. " <>
-          "When using the map.field syntax, make sure the left side of the dot is a map"
-    }
-  end
+  def normalize({:badkey, key, term}, _stacktrace) do
+    message =
+      "key #{inspect(key)} not found in: #{inspect(term)}. " <>
+        "If you are using the dot syntax, such as map.field, " <>
+        "make sure the left-hand side of the dot is a map"
 
-  def normalize({:baddot, false, key, module}, _stacktrace) do
-    %ArgumentError{
-      message:
-        "could not find function #{inspect(key)} on #{inspect(module)}. " <>
-          "When using the module.function() syntax, make sure the left side of the dot is a module"
-    }
+    %KeyError{key: key, term: term, message: message}
   end
 
   def normalize({:case_clause, term}, _stacktrace) do

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -232,34 +232,41 @@ translate({{'.', _, [Left, Right]}, Meta, []}, _Ann, S) when is_tuple(Left), is_
   Generated = erl_anno:set_generated(true, Ann),
   {Var, SV} = elixir_erl_var:build('_', SL),
   TVar = {var, Generated, Var},
-  TBadKeyError = {tuple, Ann, [{atom, Ann, badkey}, TRight, TVar]},
-  TBadDotError = build_baddot_error(TVar, TRight, Ann, Meta),
 
-  {{'case', Generated, TLeft, [
-    {clause, Generated,
-      [{map, Ann, [{map_field_exact, Ann, TRight, TVar}]}],
-      [],
-      [TVar]},
-    {clause, Generated,
-      [TVar],
-      [[?remote(Generated, erlang, is_map, [TVar])]],
-      [?remote(Ann, erlang, error, [TBadKeyError])]},
-    {clause, Generated,
-      [TVar],
-      [[{op, Ann, 'orelse',
-        {op, Ann, '=:=', TVar, {atom, Ann, nil}},
-        ?remote(Generated, erlang, is_boolean, [TVar])
-      }]],
-      [?remote(Ann, erlang, error, [TBadDotError])]},
-    {clause, Generated,
-      [TVar],
-      [[?remote(Generated, erlang, is_atom, [TVar])]],
-      [{call, Generated, {remote, Generated, TVar, TRight}, []}]},
-    {clause, Generated,
-      [TVar],
-      [],
-      [?remote(Ann, erlang, error, [TBadDotError])]}
-  ]}, SV};
+  case proplists:get_value(no_parens, Meta, false) of
+    true ->
+      TError = {tuple, Ann, [{atom, Ann, badkey}, TRight, TVar]},
+      {{'case', Generated, TLeft, [
+        {clause, Generated,
+          [{map, Ann, [{map_field_exact, Ann, TRight, TVar}]}],
+          [],
+          [TVar]},
+        {clause, Generated,
+          [TVar],
+          [[
+            ?remote(Generated, erlang, is_atom, [TVar]),
+            {op, Generated, '=/=', TVar, {atom, Generated, nil}},
+            {op, Generated, '=/=', TVar, {atom, Generated, true}},
+            {op, Generated, '=/=', TVar, {atom, Generated, false}}
+          ]],
+          [{call, Generated, {remote, Generated, TVar, TRight}, []}]},
+        {clause, Generated,
+          [TVar],
+          [],
+          [?remote(Ann, erlang, error, [TError])]}
+      ]}, SV};
+    false ->
+      {{'case', Generated, TLeft, [
+        {clause, Generated,
+          [{map, Ann, [{map_field_exact, Ann, TRight, TVar}]}],
+          [],
+          [TVar]},
+        {clause, Generated,
+          [TVar],
+          [],
+          [{call, Generated, {remote, Generated, TVar, TRight}, []}]}
+      ]}, SV}
+    end;
 
 translate({{'.', _, [Left, Right]}, Meta, Args}, _Ann, S)
     when (is_tuple(Left) orelse is_atom(Left)), is_atom(Right), is_list(Meta), is_list(Args) ->
@@ -608,12 +615,18 @@ translate_remote(maps, merge, Meta, [Map1, Map2], S) ->
     {[TMap1, TMap2], TS} ->
       {{call, Ann, {remote, Ann, {atom, Ann, maps}, {atom, Ann, merge}}, [TMap1, TMap2]}, TS}
   end;
-
-translate_remote(Left, Right, Meta, _Args, S)
+translate_remote(Left, Right, Meta, [], S)
     when (Left =:= nil orelse is_boolean(Left)), is_atom(Right) ->
   Ann = ?ann(Meta),
-  TBadDotError = build_baddot_error({atom, Ann, Left}, {atom, Ann, Right}, Ann, Meta),
-  {?remote(Ann, erlang, error, [TBadDotError]), S};
+  TLeft = {atom, Ann, Left},
+  TRight = {atom, Ann, Right},
+  case proplists:get_value(no_parens, Meta, false) of
+    true ->
+      TError = {tuple, Ann, [{atom, Ann, badkey}, TRight, TLeft]},
+      {?remote(Ann, erlang, error, [TError]), S};
+    false ->
+      {{call, Ann, {remote, Ann, TLeft, TRight}, []}, S}
+  end;
 translate_remote(Left, Right, Meta, Args, S) ->
   Ann = ?ann(Meta),
   {TLeft, SL} = translate(Left, Ann, S),
@@ -633,10 +646,6 @@ translate_remote(Left, Right, Meta, Args, S) ->
     false ->
       {{call, Ann, {remote, Ann, TLeft, TRight}, TArgs}, SA}
   end.
-
-build_baddot_error(Left, Right, Ann, Meta) ->
-  NoParens = proplists:get_value(no_parens, Meta, false),
-  {tuple, Ann, [{atom, Ann, baddot}, {atom, Ann, NoParens}, Right, Left]}.
 
 generate_struct_name_guard([{map_field_exact, Ann, {atom, _, '__struct__'} = Key, Var} | Rest], Acc, S0) ->
   {ModuleVarName, S1} = elixir_erl_var:build('_', S0),

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -224,7 +224,8 @@ translate({{'.', _, [Left, Right]}, Meta, []}, _Ann, #elixir_erl{context=guard} 
   TRight = {atom, Ann, Right},
   {?remote(Ann, erlang, map_get, [TRight, TLeft]), SL};
 
-translate({{'.', _, [Left, Right]}, Meta, []}, _Ann, S) when is_tuple(Left), is_atom(Right), is_list(Meta) ->
+translate({{'.', _, [Left, Right]}, Meta, []}, _Ann, S)
+  when is_tuple(Left) orelse Left =:= nil orelse is_boolean(Left), is_atom(Right), is_list(Meta) ->
   Ann = ?ann(Meta),
   {TLeft, SL} = translate(Left, Ann, S),
   TRight = {atom, Ann, Right},
@@ -614,18 +615,6 @@ translate_remote(maps, merge, Meta, [Map1, Map2], S) ->
 
     {[TMap1, TMap2], TS} ->
       {{call, Ann, {remote, Ann, {atom, Ann, maps}, {atom, Ann, merge}}, [TMap1, TMap2]}, TS}
-  end;
-translate_remote(Left, Right, Meta, [], S)
-    when (Left =:= nil orelse is_boolean(Left)), is_atom(Right) ->
-  Ann = ?ann(Meta),
-  TLeft = {atom, Ann, Left},
-  TRight = {atom, Ann, Right},
-  case proplists:get_value(no_parens, Meta, false) of
-    true ->
-      TError = {tuple, Ann, [{atom, Ann, badkey}, TRight, TLeft]},
-      {?remote(Ann, erlang, error, [TError]), S};
-    false ->
-      {{call, Ann, {remote, Ann, TLeft, TRight}, []}, S}
   end;
 translate_remote(Left, Right, Meta, Args, S) ->
   Ann = ?ann(Meta),

--- a/lib/elixir/src/elixir_erl_try.erl
+++ b/lib/elixir/src/elixir_erl_try.erl
@@ -203,13 +203,9 @@ erl_rescue_guard_for(Meta, Var, 'Elixir.KeyError') ->
 erl_rescue_guard_for(Meta, Var, 'Elixir.ArgumentError') ->
   erl_or(Meta,
          {erl(Meta, '=='), Meta, [Var, badarg]},
-         erl_or(Meta,
-            erl_and(Meta,
-                    erl_tuple_size(Meta, Var, 2),
-                    erl_record_compare(Meta, Var, badarg)),
-            erl_and(Meta,
-                    erl_tuple_size(Meta, Var, 4),
-                    erl_record_compare(Meta, Var, baddot))));
+         erl_and(Meta,
+                 erl_tuple_size(Meta, Var, 2),
+                 erl_record_compare(Meta, Var, badarg)));
 
 erl_rescue_guard_for(Meta, Var, 'Elixir.ErlangError') ->
   Condition =

--- a/lib/elixir/src/elixir_erl_try.erl
+++ b/lib/elixir/src/elixir_erl_try.erl
@@ -203,9 +203,13 @@ erl_rescue_guard_for(Meta, Var, 'Elixir.KeyError') ->
 erl_rescue_guard_for(Meta, Var, 'Elixir.ArgumentError') ->
   erl_or(Meta,
          {erl(Meta, '=='), Meta, [Var, badarg]},
-         erl_and(Meta,
-                 erl_tuple_size(Meta, Var, 2),
-                 erl_record_compare(Meta, Var, badarg)));
+         erl_or(Meta,
+            erl_and(Meta,
+                    erl_tuple_size(Meta, Var, 2),
+                    erl_record_compare(Meta, Var, badarg)),
+            erl_and(Meta,
+                    erl_tuple_size(Meta, Var, 4),
+                    erl_record_compare(Meta, Var, baddot))));
 
 erl_rescue_guard_for(Meta, Var, 'Elixir.ErlangError') ->
   Condition =

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -477,37 +477,16 @@ defmodule ExceptionTest do
              """
     end
 
-    test "annotates dot syntax on invalid argument errors" do
-      assert blame_message([], & &1.foo) ==
-               "could not find key :foo on []. When using the map.field syntax, " <>
-                 "make sure the left side of the dot is a map"
-
-      assert blame_message([], & &1.foo()) ==
-               "could not find function :foo on []. When using the module.function() " <>
-                 "syntax, make sure the left side of the dot is a module"
-
-      # atoms that are invalid module name:
-      assert blame_message(nil, & &1.foo()) ==
-               "could not find function :foo on nil. When using the module.function() " <>
-                 "syntax, make sure the left side of the dot is a module"
-
-      assert blame_message(false, & &1.foo()) ==
-               "could not find function :foo on false. When using the module.function() " <>
-                 "syntax, make sure the left side of the dot is a module"
-
-      assert blame_message(nil, fn _ -> nil.foo() end) ==
-               "could not find function :foo on nil. When using the module.function() " <>
-                 "syntax, make sure the left side of the dot is a module"
-
-      assert blame_message(false, fn _ -> false.foo() end) ==
-               "could not find function :foo on false. When using the module.function() " <>
-                 "syntax, make sure the left side of the dot is a module"
-    end
-
     test "annotates badarg on apply" do
+      assert blame_message([], & &1.foo()) ==
+               "you attempted to apply a function named :foo on []. If you are using Kernel.apply/3, make sure " <>
+                 "the module is an atom. If you are using the dot syntax, such as " <>
+                 "module.function(), make sure the left-hand side of the dot is a module atom"
+
       assert blame_message([], &apply(&1, :foo, [])) ==
-               "you attempted to apply a function named :foo on []. Modules " <>
-                 "(the first argument of apply) must always be an atom"
+               "you attempted to apply a function named :foo on []. If you are using Kernel.apply/3, make sure " <>
+                 "the module is an atom. If you are using the dot syntax, such as " <>
+                 "module.function(), make sure the left-hand side of the dot is a module atom"
 
       assert blame_message([], &apply(Kernel, &1, [1, 2])) ==
                "you attempted to apply a function named [] on module Kernel. However [] is not a valid function name. " <>
@@ -607,6 +586,29 @@ defmodule ExceptionTest do
     test "annotates undefined function clause error with otp obsolete hints" do
       assert blame_message(:erlang, & &1.hash(1, 2)) ==
                "function :erlang.hash/2 is undefined or private, use erlang:phash2/2 instead"
+    end
+
+    test "annotates undefined key error with nil hints" do
+      assert blame_message(nil, & &1.foo) ==
+               "key :foo not found in: nil. If you are using the dot syntax, " <>
+                 "such as map.field, make sure the left-hand side of the dot is a map"
+
+      # we use `Code.eval_string/1` to escape the formatter and warnings
+      assert blame_message("nil.foo", &Code.eval_string/1) ==
+               "key :foo not found in: nil. If you are using the dot syntax, " <>
+                 "such as map.field, make sure the left-hand side of the dot is a map"
+    end
+
+    test "annotates undefined function clause error with nil hints" do
+      assert blame_message(nil, & &1.foo()) ==
+               "function nil.foo/0 is undefined. If you are using the dot syntax, " <>
+                 "such as module.function(), make sure the left-hand side of " <>
+                 "the dot is a module atom"
+
+      assert blame_message("nil.foo()", &Code.eval_string/1) ==
+               "function nil.foo/0 is undefined. If you are using the dot syntax, " <>
+                 "such as module.function(), make sure the left-hand side of " <>
+                 "the dot is a module atom"
     end
 
     test "annotates key error with suggestions if keys are atoms" do

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -826,6 +826,7 @@ defmodule Kernel.ErrorsTest do
     rescue
       ArgumentError ->
         assert [
+                 {:erlang, :apply, [1, :foo, []], _},
                  {__MODULE__, :bad_remote_call, 1, [file: _, line: _]} | _
                ] = __STACKTRACE__
     end
@@ -861,7 +862,7 @@ defmodule Kernel.ErrorsTest do
                       "defmodule MisplacedOperator, do: (def bar(1 | 2), do: :ok)"
   end
 
-  defp bad_remote_call(x), do: x.foo
+  defp bad_remote_call(x), do: x.foo()
 
   defmacro sample(0), do: 0
 

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -826,7 +826,6 @@ defmodule Kernel.ErrorsTest do
     rescue
       ArgumentError ->
         assert [
-                 {:erlang, :apply, [1, :foo, []], _},
                  {__MODULE__, :bad_remote_call, 1, [file: _, line: _]} | _
                ] = __STACKTRACE__
     end


### PR DESCRIPTION
### Current behavior

```elixir
iex(3)> nil.id
** (UndefinedFunctionError) function nil.id/0 is undefined. If you are using the dot syntax, such as map.field or module.function(), make sure the left side of the dot is an atom or a map
    nil.id()
```

The message looks very obvious to an Elixir dev used to it, but it could quite a lot to unpack and some prior knowledge is assumed:
- `nil` is an atom
- modules are atoms, so `nil` gets interpreted as a module
- elixir doesn't distinguish between `user.id` and `user.id()` because of how its AST works

Besides, this message might be slightly sub-optimal:
- AFAIK `nil`, `true` and `false` are not actually allowed module names, despite being atoms
- "If you are using the dot syntax" -> this comes from `apply/3`, but in this case we know the dot syntax was used
- the expression had `no_parens`, so it might be better to assume it was an attempt to access a map key than an undefined function? (and maybe mention `nil.id/0` as a second scenario to be exhaustive)

### Proposed behaviour

Exact error messages and strategy TBD :)

```elixir
iex(1)> nil.id
** (ArgumentError) could not find key :id on nil. When using the map.field syntax, make sure the left side of the dot is a map
iex(1)> nil.id()
** (ArgumentError) could not find function :id on nil. When using the module.function() syntax, make sure the left side of the dot is a module
```