### PR TITLE
Typo fix for Kernel.in/2 documentation

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4255,7 +4255,7 @@ defmodule Kernel do
 
       when x === 1 or x === 2 or x === 3
 
-  However, this construct will be inneficient for large lists. In such cases, it
+  However, this construct will be inefficient for large lists. In such cases, it
   is best to stop using guards and use a more appropriate data structure, such
   as `MapSet`.
 


### PR DESCRIPTION
This PR fixes a typo in "[inefficient](https://www.wordnik.com/words/inefficient)" I noticed while browsing the [documentation for `Kernel.in/2`](https://hexdocs.pm/elixir/Kernel.html#in/2). 