### PR TITLE
Improve logger documentation

### DIFF
--- a/lib/logger/lib/logger.ex
+++ b/lib/logger/lib/logger.ex
@@ -138,17 +138,9 @@ defmodule Logger do
 
       Logger.error("We have a problem", [error_code: :pc_load_letter])
 
-  In your app's logger configuration, you would need to include the
-  `:error_code` key and you would need to include `$metadata` as part of
-  your log format template:
-
-      config :logger, :console,
-       format: "[$level] $message $metadata\n",
-       metadata: [:error_code, :file]
-
-  Your logs might then receive lines like this:
-
-      [error] We have a problem error_code=pc_load_letter file=lib/app.ex
+  You might need to configure your logger backends to handle those metadata
+  values. For the default `:console` backend there's an example in
+  `Logger.Backends.Console`.
 
   ## Configuration
 

--- a/lib/logger/lib/logger/backends/console.ex
+++ b/lib/logger/lib/logger/backends/console.ex
@@ -18,7 +18,8 @@ defmodule Logger.Backends.Console do
     * `:metadata` - the metadata to be printed by `$metadata`.
       Defaults to an empty list (no metadata).
       Setting `:metadata` to `:all` prints all metadata. See
-      the "Metadata" section for more information.
+      the "Metadata" section in the `Logger` documentation for
+      more information.
 
     * `:colors` - a keyword list of coloring options.
 


### PR DESCRIPTION
This includes two changes:

- `Logger.Backends.Console` did refer to a `Metadata` section without a hint of it being in `Logger`
- `Logger` still had an example of configuring `Logger.Backends.Console`. I've removed that last one, given I've seen many people in the past trying to configure `Logger` with `config :logger, :console, [logger_options]` and wonder why they don't apply.