### PR TITLE
Use setup-beam on Windows platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
     name: Windows, OTP-${{ matrix.otp_release }}, Windows Server 2019
     strategy:
       matrix:
-        otp_release: ['24.0']
+        otp_release: ['24', '25']
     runs-on: windows-2019
     steps:
       - name: Configure Git
@@ -87,16 +87,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 50
-      - name: Cache Erlang/OTP package
-        uses: actions/cache@v3
+      - uses: erlef/setup-beam@v1
         with:
-          path: C:\Users\runneradmin\AppData\Local\Temp\chocolatey\erlang
-          key: OTP-${{ matrix.otp_release }}-windows-2019
-      - name: Install Erlang/OTP
-        run: choco install -y erlang --version ${{ matrix.otp_release }}
+          otp-version: ${{ matrix.otp_release }}
       - name: Compile Elixir
         run: |
-          remove-item '.git' -recurse -force
+          Remove-Item -Recurse -Force '.git'
           make compile
       - name: Build info
         run: bin/elixir --version
@@ -106,7 +102,7 @@ jobs:
         run: make --keep-going test_erlang
       - name: Elixir test suite
         run: |
-          del c:/Windows/System32/drivers/etc/hosts
+          Remove-Item 'c:/Windows/System32/drivers/etc/hosts'
           make --keep-going test_elixir
 
   check_posix_compliant:


### PR DESCRIPTION
* Use `erlef/setup-beam` for installing Erlang instead of installing via chocolatey. So we're using the same tool like release pipeline does.
* Use `Remove-Item` instead of `del`. 
* Add OTP 25 to the matrix.