### PR TITLE
Allow IEx to accept a dynamic prompt

### DIFF
--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -490,6 +490,21 @@ defmodule IEx do
     * `%prefix`  - a prefix given by `IEx.Server`
     * `%node`    - the name of the local node
 
+  ### Dynamic Prompt
+
+  If a dynamic prompt is needed, you can pass an anonymous function to the prompt configuration.
+  That function must have an arity of 1 and return a string. When the function is called, it will
+  be given a map of prompt strings as its argument: `%{prefix: p, counter: c, node: n}`
+
+  The resulting prompt will update after each input. For example, to print the counter and a
+  random number, your configuration may look like this:
+
+      IEx.configure(
+        default_prompt: fn %{counter: c} ->
+          "Random number: \#{:rand.uniform(42)} (\#{c})>"
+        end
+      )
+
   ## Parser
 
   This is an option determining the parser to use for IEx.

--- a/lib/iex/lib/iex/config.ex
+++ b/lib/iex/lib/iex/config.ex
@@ -56,11 +56,7 @@ defmodule IEx.Config do
   end
 
   def alive_continuation_prompt() do
-    Application.get_env(
-      :iex,
-      :alive_continuation_prompt,
-      alive_prompt()
-    )
+    Application.get_env(:iex, :alive_continuation_prompt, alive_prompt())
   end
 
   def parser() do

--- a/lib/iex/lib/iex/config.ex
+++ b/lib/iex/lib/iex/config.ex
@@ -188,9 +188,13 @@ defmodule IEx.Config do
   defp validate_option({:inspect, new}) when is_list(new), do: :ok
   defp validate_option({:history_size, new}) when is_integer(new), do: :ok
   defp validate_option({:default_prompt, new}) when is_binary(new), do: :ok
+  defp validate_option({:default_prompt, new}) when is_function(new), do: :ok
   defp validate_option({:continuation_prompt, new}) when is_binary(new), do: :ok
+  # defp validate_option({:continuation_prompt, new}) when is_function(new), do: :ok
   defp validate_option({:alive_prompt, new}) when is_binary(new), do: :ok
+  # defp validate_option({:alive_prompt, new}) when is_function(new), do: :ok
   defp validate_option({:alive_continuation_prompt, new}) when is_binary(new), do: :ok
+  # defp validate_option({:alive_continuation_prompt, new}) when is_function(new), do: :ok
   defp validate_option({:width, new}) when is_integer(new), do: :ok
   defp validate_option({:parser, tuple}) when tuple_size(tuple) == 3, do: :ok
 

--- a/lib/iex/lib/iex/config.ex
+++ b/lib/iex/lib/iex/config.ex
@@ -45,36 +45,22 @@ defmodule IEx.Config do
 
   def default_prompt() do
     Application.fetch_env!(:iex, :default_prompt)
-    |> execute_prompt()
   end
 
   def continuation_prompt() do
-    Application.get_env(:iex, :continuation_prompt, Application.fetch_env!(:iex, :default_prompt))
-    |> execute_prompt()
+    Application.get_env(:iex, :continuation_prompt, default_prompt())
   end
 
   def alive_prompt() do
     Application.fetch_env!(:iex, :alive_prompt)
-    |> execute_prompt()
   end
 
   def alive_continuation_prompt() do
     Application.get_env(
       :iex,
       :alive_continuation_prompt,
-      Application.fetch_env!(:iex, :alive_prompt)
+      alive_prompt()
     )
-    |> execute_prompt()
-  end
-
-  defp execute_prompt(prompt_value) do
-    case prompt_value do
-      prompt when is_function(prompt) ->
-        prompt.()
-
-      prompt ->
-        prompt
-    end
   end
 
   def parser() do

--- a/lib/iex/lib/iex/config.ex
+++ b/lib/iex/lib/iex/config.ex
@@ -45,18 +45,36 @@ defmodule IEx.Config do
 
   def default_prompt() do
     Application.fetch_env!(:iex, :default_prompt)
+    |> execute_prompt()
   end
 
   def continuation_prompt() do
-    Application.get_env(:iex, :continuation_prompt, default_prompt())
+    Application.get_env(:iex, :continuation_prompt, Application.fetch_env!(:iex, :default_prompt))
+    |> execute_prompt()
   end
 
   def alive_prompt() do
     Application.fetch_env!(:iex, :alive_prompt)
+    |> execute_prompt()
   end
 
   def alive_continuation_prompt() do
-    Application.get_env(:iex, :alive_continuation_prompt, alive_prompt())
+    Application.get_env(
+      :iex,
+      :alive_continuation_prompt,
+      Application.fetch_env!(:iex, :alive_prompt)
+    )
+    |> execute_prompt()
+  end
+
+  defp execute_prompt(prompt_value) do
+    case prompt_value do
+      prompt when is_function(prompt) ->
+        prompt.()
+
+      prompt ->
+        prompt
+    end
   end
 
   def parser() do
@@ -190,11 +208,11 @@ defmodule IEx.Config do
   defp validate_option({:default_prompt, new}) when is_binary(new), do: :ok
   defp validate_option({:default_prompt, new}) when is_function(new), do: :ok
   defp validate_option({:continuation_prompt, new}) when is_binary(new), do: :ok
-  # defp validate_option({:continuation_prompt, new}) when is_function(new), do: :ok
+  defp validate_option({:continuation_prompt, new}) when is_function(new), do: :ok
   defp validate_option({:alive_prompt, new}) when is_binary(new), do: :ok
-  # defp validate_option({:alive_prompt, new}) when is_function(new), do: :ok
+  defp validate_option({:alive_prompt, new}) when is_function(new), do: :ok
   defp validate_option({:alive_continuation_prompt, new}) when is_binary(new), do: :ok
-  # defp validate_option({:alive_continuation_prompt, new}) when is_function(new), do: :ok
+  defp validate_option({:alive_continuation_prompt, new}) when is_function(new), do: :ok
   defp validate_option({:width, new}) when is_integer(new), do: :ok
   defp validate_option({:parser, tuple}) when tuple_size(tuple) == 3, do: :ok
 

--- a/lib/iex/lib/iex/config.ex
+++ b/lib/iex/lib/iex/config.ex
@@ -188,13 +188,29 @@ defmodule IEx.Config do
   defp validate_option({:inspect, new}) when is_list(new), do: :ok
   defp validate_option({:history_size, new}) when is_integer(new), do: :ok
   defp validate_option({:default_prompt, new}) when is_binary(new), do: :ok
-  defp validate_option({:default_prompt, new}) when is_function(new), do: :ok
+
+  defp validate_option({:default_prompt, {module, function, []}})
+       when is_atom(module) and is_atom(function),
+       do: :ok
+
   defp validate_option({:continuation_prompt, new}) when is_binary(new), do: :ok
-  defp validate_option({:continuation_prompt, new}) when is_function(new), do: :ok
+
+  defp validate_option({:continuation_prompt, {module, function, []}})
+       when is_atom(module) and is_atom(function),
+       do: :ok
+
   defp validate_option({:alive_prompt, new}) when is_binary(new), do: :ok
-  defp validate_option({:alive_prompt, new}) when is_function(new), do: :ok
+
+  defp validate_option({:alive_prompt, {module, function, []}})
+       when is_atom(module) and is_atom(function),
+       do: :ok
+
   defp validate_option({:alive_continuation_prompt, new}) when is_binary(new), do: :ok
-  defp validate_option({:alive_continuation_prompt, new}) when is_function(new), do: :ok
+
+  defp validate_option({:alive_continuation_prompt, {module, function, []}})
+       when is_atom(module) and is_atom(function),
+       do: :ok
+
   defp validate_option({:width, new}) when is_integer(new), do: :ok
   defp validate_option({:parser, tuple}) when tuple_size(tuple) == 3, do: :ok
 

--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -387,9 +387,12 @@ defmodule IEx.Server do
 
     prompt =
       case apply(IEx.Config, mode, []) do
-        p when is_function(p) ->
+        {mod, func, []} when is_atom(mod) and is_atom(func) ->
           node = node()
-          p.(%{counter: to_string(counter), prefix: to_string(prefix), node: to_string(node)})
+
+          apply(mod, func, [
+            %{counter: to_string(counter), prefix: to_string(prefix), node: to_string(node)}
+          ])
 
         p when is_binary(p) ->
           p

--- a/lib/iex/lib/iex/server.ex
+++ b/lib/iex/lib/iex/server.ex
@@ -386,10 +386,17 @@ defmodule IEx.Server do
       end
 
     prompt =
-      apply(IEx.Config, mode, [])
-      |> String.replace("%counter", to_string(counter))
-      |> String.replace("%prefix", to_string(prefix))
-      |> String.replace("%node", to_string(node()))
+      case apply(IEx.Config, mode, []) do
+        p when is_function(p) ->
+          node = node()
+          p.(%{counter: to_string(counter), prefix: to_string(prefix), node: to_string(node)})
+
+        p when is_binary(p) ->
+          p
+          |> String.replace("%counter", to_string(counter))
+          |> String.replace("%prefix", to_string(prefix))
+          |> String.replace("%node", to_string(node()))
+      end
 
     prompt <> " "
   end

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -107,8 +107,14 @@ defmodule IEx.InteractionTest do
     assert capture_iex("1\n", opts, [], true) == "prompt(1)> 1\nprompt(2)>"
   end
 
-  test "prompt with function input" do
-    opts = [default_prompt: fn %{counter: c} -> "prompt(#{c})[#{String.to_integer(c) + 1}]>" end]
+  test "prompt with mfa input" do
+    defmodule Foo do
+      def define_prompt(%{counter: c}) do
+        "prompt(#{c})[#{String.to_integer(c) + 1}]>"
+      end
+    end
+
+    opts = [default_prompt: {Foo, :define_prompt, []}]
     assert capture_iex("1\n", opts, [], true) == "prompt(1)[2]> 1\nprompt(2)[3]>"
   end
 

--- a/lib/iex/test/iex/interaction_test.exs
+++ b/lib/iex/test/iex/interaction_test.exs
@@ -102,9 +102,14 @@ defmodule IEx.InteractionTest do
     assert capture =~ "assert 1 == 2"
   end
 
-  test "prompt" do
+  test "prompt with string input" do
     opts = [default_prompt: "prompt(%counter)>"]
     assert capture_iex("1\n", opts, [], true) == "prompt(1)> 1\nprompt(2)>"
+  end
+
+  test "prompt with function input" do
+    opts = [default_prompt: fn %{counter: c} -> "prompt(#{c})[#{String.to_integer(c) + 1}]>" end]
+    assert capture_iex("1\n", opts, [], true) == "prompt(1)[2]> 1\nprompt(2)[3]>"
   end
 
   test "continuation prompt" do


### PR DESCRIPTION
Allows for an anonymous function be passed to the IEx prompt configuration. This function takes a map of the prompt strings so that the user can add them where they want. The original method of a string configuration is preserved.


Adds a test and documentation for this functionality.