### PR TITLE
Allow multiple formatters per file extension and sigil

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -305,7 +305,8 @@ defmodule Mix.Tasks.Format do
           do: {sigil, plugin}
 
     sigils =
-      Enum.group_by(sigils, &elem(&1, 0), &elem(&1, 1))
+      sigils
+      |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
       |> Enum.map(fn {sigil, plugins} ->
         {sigil,
          fn input, opts ->

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -120,7 +120,7 @@ defmodule Mix.Tasks.Format do
       # .formatters.exs
       [
         # Define the desired plugins
-        plugins: [MixMarkdownFormatter],
+        plugins: [MixMarkdownFormatter, AnotherMarkdownFormatter],
         # Remember to update the inputs list to include the new extensions
         inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}", "posts/*.{md,markdown}"]
       ]
@@ -128,6 +128,11 @@ defmodule Mix.Tasks.Format do
   Remember that, when running the formatter with plugins, you must make
   sure that your dependencies and your application have been compiled,
   so the relevant plugin code can be loaded. Otherwise a warning is logged.
+
+  In addition, the order by which you input your plugins is the format order. 
+  So, in the above `.formatters.exs`, the `MixMarkdownFormatter` will format 
+  the markdown files and sigils before `AnotherMarkdownFormatter`.
+
 
   ## Importing dependencies configuration
 

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -117,7 +117,7 @@ defmodule Mix.Tasks.Format do
 
   Now any application can use your formatter as follows:
 
-      # .formatters.exs
+      # .formatter.exs
       [
         # Define the desired plugins
         plugins: [MixMarkdownFormatter, AnotherMarkdownFormatter],
@@ -129,8 +129,8 @@ defmodule Mix.Tasks.Format do
   sure that your dependencies and your application have been compiled,
   so the relevant plugin code can be loaded. Otherwise a warning is logged.
 
-  In addition, the order by which you input your plugins is the format order. 
-  So, in the above `.formatters.exs`, the `MixMarkdownFormatter` will format 
+  In addition, the order by which you input your plugins is the format order.
+  So, in the above `.formatter.exs`, the `MixMarkdownFormatter` will format
   the markdown files and sigils before `AnotherMarkdownFormatter`.
 
 

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -586,7 +586,7 @@ defmodule Mix.Tasks.Format do
 
   defp format_file({file, formatters}, task_opts) do
     input = read_file(file)
-    output = Enum.reduce(formatters, input, fn format_fn, output -> format_fn.(output) end)
+    output = Enum.reduce(formatters, input, fn formatter, output -> formatter.(output) end)
 
     check_formatted? = Keyword.get(task_opts, :check_formatted, false)
     dry_run? = Keyword.get(task_opts, :dry_run, false)

--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -133,7 +133,6 @@ defmodule Mix.Tasks.Format do
   So, in the above `.formatter.exs`, the `MixMarkdownFormatter` will format
   the markdown files and sigils before `AnotherMarkdownFormatter`.
 
-
   ## Importing dependencies configuration
 
   This task supports importing formatter configuration from dependencies.
@@ -600,7 +599,6 @@ defmodule Mix.Tasks.Format do
   defp format_file({file, formatter}, task_opts) do
     input = read_file(file)
     output = formatter.(input)
-
     check_formatted? = Keyword.get(task_opts, :check_formatted, false)
     dry_run? = Keyword.get(task_opts, :dry_run, false)
 

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -266,21 +266,10 @@ defmodule Mix.Tasks.FormatTest do
 
     def format(contents, opts) do
       assert opts[:from_formatter_exs] == :yes
-
-      cond do
-        opts[:extension] ->
-          assert opts[:extension] == ".w"
-          assert opts[:file] =~ ~r/\/a\.w$/
-          assert [W: sigil_fun] = opts[:sigils]
-          assert is_function(sigil_fun, 2)
-
-        opts[:sigil] ->
-          assert opts[:sigil] == :W
-          assert opts[:inputs] == ["a.ex"]
-
-        true ->
-          flunk("Plugin not loading in correctly.")
-      end
+      assert opts[:extension] == ".w"
+      assert opts[:file] =~ ~r/\/a\.w$/
+      assert [W: sigil_fun] = opts[:sigils]
+      assert is_function(sigil_fun, 2)
 
       contents |> String.split(~r/\s/) |> Enum.join("\n")
     end
@@ -307,6 +296,7 @@ defmodule Mix.Tasks.FormatTest do
         opts[:sigil] ->
           assert opts[:sigil] == :W
           assert opts[:inputs] == ["a.ex"]
+          assert opts[:modifiers] == 'abc'
 
         true ->
           flunk("Plugin not loading in correctly.")
@@ -386,14 +376,14 @@ defmodule Mix.Tasks.FormatTest do
       File.write!(".formatter.exs", """
       [
         inputs: ["a.ex"],
-        plugins: [NewlineToDotPlugin, ExtensionWPlugin],
+        plugins: [NewlineToDotPlugin, SigilWPlugin],
         from_formatter_exs: :yes
       ]
       """)
 
       File.write!("a.ex", """
       def sigil_test(assigns) do
-        ~W"foo bar baz\n"
+        ~W"foo bar baz\n"abc
       end
       """)
 
@@ -401,33 +391,7 @@ defmodule Mix.Tasks.FormatTest do
 
       assert File.read!("a.ex") == """
              def sigil_test(assigns) do
-               ~W"foo\nbar\nbaz."
-             end
-             """
-    end)
-  end
-
-  test "uses single plugin from .formatter.exs with sigil", context do
-    in_tmp(context.test, fn ->
-      File.write!(".formatter.exs", """
-      [
-        inputs: ["a.ex"],
-        plugins: [ExtensionWPlugin],
-        from_formatter_exs: :yes
-      ]
-      """)
-
-      File.write!("a.ex", """
-      def sigil_test(assigns) do
-        ~W"foo bar baz"
-      end
-      """)
-
-      Mix.Tasks.Format.run([])
-
-      assert File.read!("a.ex") == """
-             def sigil_test(assigns) do
-               ~W"foo\nbar\nbaz"
+               ~W"foo\nbar\nbaz."abc
              end
              """
     end)
@@ -439,14 +403,14 @@ defmodule Mix.Tasks.FormatTest do
       File.write!(".formatter.exs", """
       [
         inputs: ["a.ex"],
-        plugins: [ExtensionWPlugin, NewlineToDotPlugin],
+        plugins: [SigilWPlugin, NewlineToDotPlugin],
         from_formatter_exs: :yes
       ]
       """)
 
       File.write!("a.ex", """
       def sigil_test(assigns) do
-        ~W"foo bar baz"
+        ~W"foo bar baz"abc
       end
       """)
 
@@ -454,7 +418,7 @@ defmodule Mix.Tasks.FormatTest do
 
       assert File.read!("a.ex") == """
              def sigil_test(assigns) do
-               ~W"foo.bar.baz"
+               ~W"foo.bar.baz"abc
              end
              """
     end)

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -326,7 +326,7 @@ defmodule Mix.Tasks.FormatTest do
     end)
   end
 
-  test "uses multiple plugins from .formatter.exs with the same file extension", context do
+  test "uses multiple plugins from .formatter.exs targetting the same file extension", context do
     in_tmp(context.test, fn ->
       File.write!(".formatter.exs", """
       [
@@ -346,7 +346,8 @@ defmodule Mix.Tasks.FormatTest do
     end)
   end
 
-  test "uses multiple plugins from .formatter.exs with same file extension in declared order", context do
+  test "uses multiple plugins from .formatter.exs targetting the same file extension in declared order",
+       context do
     in_tmp(context.test, fn ->
       File.write!(".formatter.exs", """
       [

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -371,9 +371,9 @@ defmodule Mix.Tasks.FormatTest do
     in_tmp(context.test, fn ->
       File.write!(".formatter.exs", """
       [
-      inputs: ["a.w"],
-      plugins: [ExtensionWPlugin],
-      from_formatter_exs: :yes
+        inputs: ["a.w"],
+        plugins: [ExtensionWPlugin],
+        from_formatter_exs: :yes
       ]
       """)
 
@@ -395,8 +395,8 @@ defmodule Mix.Tasks.FormatTest do
     in_tmp(context.test, fn ->
       File.write!("custom_formatter.exs", """
       [
-      inputs: ["a.ex"],
-      locals_without_parens: [foo: 1]
+        inputs: ["a.ex"],
+        locals_without_parens: [foo: 1]
       ]
       """)
 

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -270,7 +270,6 @@ defmodule Mix.Tasks.FormatTest do
       assert opts[:file] =~ ~r/\/a\.w$/
       assert [W: sigil_fun] = opts[:sigils]
       assert is_function(sigil_fun, 2)
-
       contents |> String.split(~r/\s/) |> Enum.join("\n")
     end
   end

--- a/lib/mix/test/mix/tasks/format_test.exs
+++ b/lib/mix/test/mix/tasks/format_test.exs
@@ -481,9 +481,9 @@ defmodule Mix.Tasks.FormatTest do
       [inputs: "a.ex", locals_without_parens: [my_fun: 2]]
       """)
 
-      {formatters, formatter_opts} = Mix.Tasks.Format.formatter_for_file("lib/extra/a.ex")
+      {formatter, formatter_opts} = Mix.Tasks.Format.formatter_for_file("lib/extra/a.ex")
       assert Keyword.get(formatter_opts, :locals_without_parens) == [my_fun: 2]
-      assert formatters.("my_fun 1, 2") == "my_fun 1, 2\n"
+      assert formatter.("my_fun 1, 2") == "my_fun 1, 2\n"
 
       File.write!("lib/a.ex", """
       my_fun :foo, :bar


### PR DESCRIPTION
Hi!

While working on a formatter plugin I noticed that formatting only allowed one plugin per file extension type. 

So if you had two plugins targeting `.heex` files, only one would succeed - the first one defined within the `plugins: []` array of `.formatter.exs`.

~~This wasn't the case for sigils though~~ https://github.com/elixir-lang/elixir/blob/27857609b0a922c5ee138e4d2609a5b189410bc8/lib/mix/lib/mix/tasks/format.ex#L298-L301

~~Seeing as multiple formatters per sigil was already supported, I thought the same could be done for formats based on file extension.~~

One thing I am not certain on is backward compatibility - if these functions have to be newly defined or not. 
Let me know what you think :)

### **Edit**: 

It seems I wrong on the multiple formatters for sigils! Vaguely recall it working previously, but that was most likely a mishap in my configuration. 
This PR is not ready, but I would appreciate feedback or if this is a desirable change :) 

