### PR TITLE
Emit consistent position meta on fn capture traces

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -536,14 +536,14 @@ resolve_super(Meta, Arity, E) ->
 
 expand_fn_capture(Meta, Arg, S, E) ->
   case elixir_fn:capture(Meta, Arg, S, E) of
-    {{remote, Remote, Fun, Arity}, SE, EE} ->
+    {{remote, Remote, Fun, Arity}, RemoteMeta, SE, EE} ->
       is_atom(Remote) andalso
-        elixir_env:trace({remote_function, Meta, Remote, Fun, Arity}, E),
+        elixir_env:trace({remote_function, RemoteMeta, Remote, Fun, Arity}, E),
       AttachedMeta = attach_context_module(Remote, Meta, E),
       {{'&', AttachedMeta, [{'/', [], [{{'.', [], [Remote, Fun]}, [], []}, Arity]}]}, SE, EE};
-    {{local, Fun, Arity}, _SE, #{function := nil}} ->
+    {{local, Fun, Arity}, _LocalMeta, _SE, #{function := nil}} ->
       form_error(Meta, E, ?MODULE, {undefined_local_capture, Fun, Arity});
-    {{local, Fun, Arity}, SE, EE} ->
+    {{local, Fun, Arity}, _LocalMeta, SE, EE} ->
       {{'&', Meta, [{'/', [], [{Fun, [], nil}, Arity]}]}, SE, EE};
     {expand, Expr, SE, EE} ->
       expand(Expr, SE, EE)

--- a/lib/elixir/src/elixir_fn.erl
+++ b/lib/elixir/src/elixir_fn.erl
@@ -41,13 +41,11 @@ fn_arity(Args) -> length(Args).
 capture(Meta, {'/', _, [{{'.', _, [M, F]} = Dot, RequireMeta, []}, A]}, S, E) when is_atom(F), is_integer(A) ->
   Args = args_from_arity(Meta, A, E),
   handle_capture_possible_warning(Meta, RequireMeta, M, F, A, E),
-  MergedMeta = maps:merge(maps:from_list(Meta), maps:from_list(RequireMeta)),
-  capture_require(Meta, {Dot, maps:to_list(MergedMeta), Args}, S, E, true);
+  capture_require(Meta, {Dot, RequireMeta, Args}, S, E, true);
 
 capture(Meta, {'/', _, [{F, ImportMeta, C}, A]}, S, E) when is_atom(F), is_integer(A), is_atom(C) ->
   Args = args_from_arity(Meta, A, E),
-  MergedMeta = maps:merge(maps:from_list(Meta), maps:from_list(ImportMeta)),
-  capture_import(Meta, {F, maps:to_list(MergedMeta), Args}, S, E, true);
+  capture_import(Meta, {F, ImportMeta, Args}, S, E, true);
 
 capture(Meta, {{'.', _, [_, Fun]}, _, Args} = Expr, S, E) when is_atom(Fun), is_list(Args) ->
   capture_require(Meta, Expr, S, E, is_sequential_and_not_empty(Args));

--- a/lib/elixir/src/elixir_fn.erl
+++ b/lib/elixir/src/elixir_fn.erl
@@ -43,9 +43,10 @@ capture(Meta, {'/', _, [{{'.', _, [M, F]} = Dot, RequireMeta, []}, A]}, S, E) wh
   handle_capture_possible_warning(Meta, RequireMeta, M, F, A, E),
   capture_require(Meta, {Dot, RequireMeta, Args}, S, E, true);
 
-capture(Meta, {'/', _, [{F, _, C}, A]}, S, E) when is_atom(F), is_integer(A), is_atom(C) ->
+capture(Meta, {'/', _, [{F, ImportMeta, C}, A]}, S, E) when is_atom(F), is_integer(A), is_atom(C) ->
   Args = args_from_arity(Meta, A, E),
-  capture_import(Meta, {F, Meta, Args}, S, E, true);
+  MergedMeta = lists:keymerge(1, lists:keysort(1, ImportMeta), lists:keysort(1, Meta)),
+  capture_import(Meta, {F, MergedMeta, Args}, S, E, true);
 
 capture(Meta, {{'.', _, [_, Fun]}, _, Args} = Expr, S, E) when is_atom(Fun), is_list(Args) ->
   capture_require(Meta, Expr, S, E, is_sequential_and_not_empty(Args));

--- a/lib/elixir/src/elixir_fn.erl
+++ b/lib/elixir/src/elixir_fn.erl
@@ -41,12 +41,13 @@ fn_arity(Args) -> length(Args).
 capture(Meta, {'/', _, [{{'.', _, [M, F]} = Dot, RequireMeta, []}, A]}, S, E) when is_atom(F), is_integer(A) ->
   Args = args_from_arity(Meta, A, E),
   handle_capture_possible_warning(Meta, RequireMeta, M, F, A, E),
-  capture_require(Meta, {Dot, RequireMeta, Args}, S, E, true);
+  MergedMeta = maps:merge(maps:from_list(Meta), maps:from_list(RequireMeta)),
+  capture_require(Meta, {Dot, maps:to_list(MergedMeta), Args}, S, E, true);
 
 capture(Meta, {'/', _, [{F, ImportMeta, C}, A]}, S, E) when is_atom(F), is_integer(A), is_atom(C) ->
   Args = args_from_arity(Meta, A, E),
-  MergedMeta = lists:keymerge(1, lists:keysort(1, ImportMeta), lists:keysort(1, Meta)),
-  capture_import(Meta, {F, MergedMeta, Args}, S, E, true);
+  MergedMeta = maps:merge(maps:from_list(Meta), maps:from_list(ImportMeta)),
+  capture_import(Meta, {F, maps:to_list(MergedMeta), Args}, S, E, true);
 
 capture(Meta, {{'.', _, [_, Fun]}, _, Args} = Expr, S, E) when is_atom(Fun), is_list(Args) ->
   capture_require(Meta, Expr, S, E, is_sequential_and_not_empty(Args));

--- a/lib/elixir/src/elixir_fn.erl
+++ b/lib/elixir/src/elixir_fn.erl
@@ -38,10 +38,10 @@ fn_arity(Args) -> length(Args).
 
 %% Capture
 
-capture(Meta, {'/', _, [{{'.', _, [M, F]} = Dot, DotMeta, []}, A]}, S, E) when is_atom(F), is_integer(A) ->
+capture(Meta, {'/', _, [{{'.', _, [M, F]} = Dot, RequireMeta, []}, A]}, S, E) when is_atom(F), is_integer(A) ->
   Args = args_from_arity(Meta, A, E),
-  handle_capture_possible_warning(Meta, DotMeta, M, F, A, E),
-  capture_require(Meta, {Dot, Meta, Args}, S, E, true);
+  handle_capture_possible_warning(Meta, RequireMeta, M, F, A, E),
+  capture_require(Meta, {Dot, RequireMeta, Args}, S, E, true);
 
 capture(Meta, {'/', _, [{F, _, C}, A]}, S, E) when is_atom(F), is_integer(A), is_atom(C) ->
   Args = args_from_arity(Meta, A, E),
@@ -94,7 +94,7 @@ capture_require(Meta, {{'.', DotMeta, [Left, Right]}, RequireMeta, Args}, S, E, 
       end,
 
       Dot = {{'.', DotMeta, [ELeft, Right]}, RequireMeta, Args},
-      handle_capture(Res, Meta, Dot, SE, EE, Sequential);
+      handle_capture(Res, RequireMeta, Dot, SE, EE, Sequential);
 
     {EscLeft, Escaped} ->
       Dot = {{'.', DotMeta, [EscLeft, Right]}, RequireMeta, Args},
@@ -103,8 +103,8 @@ capture_require(Meta, {{'.', DotMeta, [Left, Right]}, RequireMeta, Args}, S, E, 
 
 handle_capture(false, Meta, Expr, S, E, Sequential) ->
   capture_expr(Meta, Expr, S, E, Sequential);
-handle_capture(LocalOrRemote, _Meta, _Expr, S, E, _Sequential) ->
-  {LocalOrRemote, S, E}.
+handle_capture(LocalOrRemote, Meta, _Expr, S, E, _Sequential) ->
+  {LocalOrRemote, Meta, S, E}.
 
 capture_expr(Meta, Expr, S, E, Sequential) ->
   capture_expr(Meta, Expr, S, E, [], Sequential).

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -1081,7 +1081,8 @@ defmodule Kernel.ExpansionTest do
           fn -> 17 end
         end
 
-      assert expand(before_expansion) == after_expansion
+      assert clean_meta(expand(before_expansion), [:import, :context, :no_parens]) ==
+               after_expansion
     end
 
     test "fails on non-continuous" do


### PR DESCRIPTION
While this PR fixes the bug, I'm not really sure about my approach.
Is merging the capture and dot meta keywords acceptable? Or should I explicitly pass the dot meta to trace emit? 
Do we want `capture_meta` emitted on tracer?
Is it OK that `:no_parens` meta gets passed when expanding macros (see comment in expansion_test.exs)

Fixes https://github.com/elixir-lang/elixir/issues/12023