### PR TITLE
Fix bug in Enum.drop/2

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -4490,8 +4490,8 @@ defmodule Enum do
           end
 
         {count,
-         fn start, amount, step ->
-           list |> :lists.reverse() |> slice_exact(start, amount, step, count)
+         fn start, amount, _step ->
+           list |> :lists.reverse() |> slice_exact(start, amount, 1, count)
          end}
     end
   end

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -4490,8 +4490,8 @@ defmodule Enum do
           end
 
         {count,
-         fn start, amount, _step ->
-           list |> :lists.reverse() |> slice_exact(start, amount, 1, 1)
+         fn start, amount, step ->
+           list |> :lists.reverse() |> slice_exact(start, amount, step, count)
          end}
     end
   end

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -265,6 +265,20 @@ defmodule EnumTest do
     end
   end
 
+  test "drop/2 with streams" do
+    drop_stream = fn list, count -> list |> Stream.map(& &1) |> Enum.drop(count) end
+
+    assert drop_stream.([1, 2, 3], 0) == [1, 2, 3]
+    assert drop_stream.([1, 2, 3], 1) == [2, 3]
+    assert drop_stream.([1, 2, 3], 2) == [3]
+    assert drop_stream.([1, 2, 3], 3) == []
+    assert drop_stream.([1, 2, 3], 4) == []
+    assert drop_stream.([1, 2, 3], -1) == [1, 2]
+    assert drop_stream.([1, 2, 3], -2) == [1]
+    assert drop_stream.([1, 2, 3], -4) == []
+    assert drop_stream.([], 3) == []
+  end
+
   test "drop_every/2" do
     assert Enum.drop_every([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 2) == [2, 4, 6, 8, 10]
     assert Enum.drop_every([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 3) == [2, 3, 5, 6, 8, 9]


### PR DESCRIPTION
Closes #12039.

We should probably backport this to 1.14 as well.