### PR TITLE
Fix bug: Enum.slice selecting extra element

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -4436,7 +4436,10 @@ defmodule Enum do
           end
 
         entry, {start, amount, to_drop, list} ->
-          {:halt, {start, amount, to_drop, [entry | list]}}
+          case to_drop do
+            1 -> {:halt, {start, amount, to_drop, [entry | list]}}
+            _ -> {:halt, {start, amount, to_drop, list}}
+          end
       end)
 
     :lists.reverse(slice)

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -1077,6 +1077,7 @@ defmodule EnumTest do
     assert [1, 2, 3] |> Stream.cycle() |> Enum.slice(0..1) == [1, 2]
     assert [1, 2, 3] |> Stream.cycle() |> Enum.slice(0..4) == [1, 2, 3, 1, 2]
     assert [1, 2, 3] |> Stream.cycle() |> Enum.slice(0..4//2) == [1, 3, 2]
+    assert [1, 2, 3] |> Stream.cycle() |> Enum.slice(0..5//2) == [1, 3, 2]
   end
 
   test "slice on pruned infinite streams" do


### PR DESCRIPTION
I found one last bug in `Enum.slice` with stepped ranges on streams, which might be including an extra element:

```elixir
iex(3)>  1..10 |> Stream.take(10) |> Enum.slice(2..5//2)
[3, 5, 6]
iex(4)>  1..10 |> Enum.take(10) |> Enum.slice(2..5//2)
[3, 5]
```