### PR TITLE
Fix bugs in binary_slice/2

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -4649,29 +4649,22 @@ defmodule Kernel do
       when is_binary(binary) and step > 0 do
     total = byte_size(binary)
 
-    first =
-      case first < 0 do
-        true -> max(first + total, 0)
-        false -> first
+    first = if first < 0, do: max(first + total, 0), else: first
+    last = if last < 0, do: last + total, else: last
+
+    amount = last - first + 1
+
+    if first < total and amount > 0 do
+      part = binary_part(binary, first, min(amount, total - first))
+
+      if step == 1 do
+        part
+      else
+        <<first_byte, rest::binary>> = part
+        for <<_::size(step - 1)-bytes, byte <- rest>>, into: <<first_byte>>, do: <<byte>>
       end
-
-    last =
-      case last < 0 do
-        true -> last + total
-        false -> last
-      end
-
-    case first < total do
-      true ->
-        part = binary_part(binary, first, min(total - first, last - first + 1))
-
-        case step do
-          1 -> part
-          _ -> for <<byte, _::size(step - 1)-bytes <- part>>, into: "", do: <<byte>>
-        end
-
-      false ->
-        ""
+    else
+      ""
     end
   end
 

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1424,6 +1424,13 @@ defmodule KernelTest do
     assert match?(x when ceil(x) == 1, 0.2)
   end
 
+  test "binary_slice/2" do
+    assert binary_slice("abc", -1..0) == ""
+    assert binary_slice("abc", -5..-5) == ""
+    assert binary_slice("x", 0..0//2) == "x"
+    assert binary_slice("abcde", 1..3//2) == "bd"
+  end
+
   test "sigil_U/2" do
     assert ~U[2015-01-13 13:00:07.123Z] == %DateTime{
              calendar: Calendar.ISO,


### PR DESCRIPTION
`binary_slice/2` has some inconsistencies with `Enum.slice/2` and could crash in some cases:

```elixir
iex> binary_slice "abc", -1..0
"b"
iex> Enum.slice 'abc', -1..0
[]

iex> binary_slice "abcdef", 1..3//2
"b"
iex> Enum.slice 'abcdef', 1..3//2
'bd'

iex> binary_slice "ab", -5..-5
** (ArgumentError) errors were found at the given arguments:

  * 3rd argument: out of range

    :erlang.binary_part("ab", 0, -2)
    (elixir 1.15.0-dev) lib/kernel.ex:4666: Kernel.binary_slice/2
```

Note: most of the changes are based on the `slice_range` private function in the Kernel module, I tried to keep the consistency in style and variable naming.

Note 2: this new implementation passes the following prop-based test:

```elixir
    check all(
            binary <- binary(),
            start <- integer(),
            stop <- integer(),
            step <- positive_integer()
          ) do
      chars = :binary.bin_to_list(binary)

      range = start..stop//step
      expected = Enum.slice(chars, range) |> :binary.list_to_bin()
      assert binary_slice2(binary, range) == expected
    end
```