### PR TITLE
String.valid? takes in an any type and returns a boolean

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1796,19 +1796,16 @@ defmodule String do
       false
 
       iex> String.valid?(4)
-      false
+      ** (FunctionClauseError) no function clause matching in String.valid?/1
 
   """
-  @spec valid?(any) :: boolean
+  @spec valid?(t) :: boolean
   def valid?(string)
 
   def valid?(<<string::binary>>), do: valid_utf8?(string)
-  def valid?(_), do: false
 
-  @spec valid_utf8?(t) :: boolean
   defp valid_utf8?(<<_::utf8, rest::bits>>), do: valid_utf8?(rest)
   defp valid_utf8?(<<>>), do: true
-  defp valid_utf8?(_), do: false
 
   @doc false
   @deprecated "Use String.valid?/1 instead"

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1795,13 +1795,17 @@ defmodule String do
       iex> String.valid?("asd" <> <<0xFFFF::16>>)
       false
 
+      iex> String.valid?(4)
+      false
+
   """
-  @spec valid?(t) :: boolean
+  @spec valid?(any) :: boolean
   def valid?(string)
 
   def valid?(<<string::binary>>), do: valid_utf8?(string)
   def valid?(_), do: false
 
+  @spec valid_utf8?(t) :: boolean
   defp valid_utf8?(<<_::utf8, rest::bits>>), do: valid_utf8?(rest)
   defp valid_utf8?(<<>>), do: true
   defp valid_utf8?(_), do: false

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -1806,6 +1806,7 @@ defmodule String do
 
   defp valid_utf8?(<<_::utf8, rest::bits>>), do: valid_utf8?(rest)
   defp valid_utf8?(<<>>), do: true
+  defp valid_utf8?(_), do: false
 
   @doc false
   @deprecated "Use String.valid?/1 instead"


### PR DESCRIPTION
I have the following code
```elixir
  @spec maybe_compile(map()) :: map()
  defp maybe_compile(%{operator: operator, value: %Regex{}} = condition)
       when operator == "regex" or operator == "match" do
    condition
  end

  defp maybe_compile(%{operator: operator} = condition)
       when operator == "regex" or operator == "match" do
    with true <- String.valid?(condition.value),
         {:ok, compiled_value} <- Regex.compile(condition.value) do
      %{condition | value: compiled_value}
    else
      false -> raise "\"condition\" value was invalid regex #{inspect(condition.value)}"
      {:error, reason} -> raise "\"condition\" value was invalid regex #{inspect(reason)}"
    end
  end
```

dialyzer thinks the false can never happen in my code, because String.valid? claims it only takes in Strings and not any type.