### PR TITLE
Add spec for Enum.slide/3

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2651,6 +2651,7 @@ defmodule Enum do
 
   """
   @doc since: "1.13.0"
+  @spec slide(t, Range.t() | index, index) :: list
   def slide(enumerable, range_or_single_index, insertion_index)
 
   def slide(enumerable, single_index, insertion_index) when is_integer(single_index) do


### PR DESCRIPTION
Add missing `@spec` for `Enum.slide/3`.