### PR TITLE
Mix.install: Add :config_path and :lockfile options

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -801,7 +801,6 @@ defmodule Mix do
   end
 
   defp install_dir(cache_id) do
-    # TODO: rename MIX_INSTALL_DIR to MIX_INSTALL_ROOT?
     install_root =
       System.get_env("MIX_INSTALL_DIR") ||
         Path.join(Mix.Utils.mix_cache(), "installs")

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -699,7 +699,7 @@ defmodule Mix do
         Application.put_all_env(config, persistent: true)
         System.put_env(system_env)
 
-        install_dir = opts[:__install_dir__] || install_dir(id)
+        install_dir = install_dir(id)
 
         if opts[:verbose] do
           Mix.shell().info("Mix.install/2 using #{install_dir}")

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -709,14 +709,12 @@ defmodule Mix do
           File.rm_rf!(install_dir)
         end
 
-        lockfile = Path.join(install_dir, "mix.lock")
-
         config = [
           version: "0.1.0",
           build_embedded: false,
           build_per_environment: true,
           build_path: "_build",
-          lockfile: lockfile,
+          lockfile: "mix.lock",
           deps_path: "deps",
           deps: deps,
           app: :mix_install,
@@ -748,17 +746,18 @@ defmodule Mix do
 
                 old_md5 =
                   case File.read(md5_path) do
-                    {:ok, data} -> Base.decode16!(data)
+                    {:ok, data} -> Base.decode64!(data)
                     _ -> nil
                   end
 
                 new_md5 = external_lockfile |> File.read!() |> :erlang.md5()
 
                 if old_md5 != new_md5 do
+                  lockfile = Path.join(install_dir, "mix.lock")
                   old_lock = Mix.Dep.Lock.read(lockfile)
                   new_lock = Mix.Dep.Lock.read(external_lockfile)
                   Mix.Dep.Lock.write(lockfile, Map.merge(old_lock, new_lock))
-                  File.write!(md5_path, Base.encode16(new_md5))
+                  File.write!(md5_path, Base.encode64(new_md5))
                   Mix.Task.rerun("deps.get")
                 end
 

--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -754,11 +754,10 @@ defmodule Mix do
 
                 new_md5 = external_lockfile |> File.read!() |> :erlang.md5()
 
-                old_lock = Mix.Dep.Lock.read(lockfile)
-                new_lock = Mix.Dep.Lock.read(external_lockfile)
-                Mix.Dep.Lock.write(lockfile, Map.merge(old_lock, new_lock))
-
                 if old_md5 != new_md5 do
+                  old_lock = Mix.Dep.Lock.read(lockfile)
+                  new_lock = Mix.Dep.Lock.read(external_lockfile)
+                  Mix.Dep.Lock.write(lockfile, Map.merge(old_lock, new_lock))
                   File.write!(md5_path, Base.encode16(new_md5))
                   Mix.Task.rerun("deps.get")
                 end

--- a/lib/mix/lib/mix/dep/lock.ex
+++ b/lib/mix/lib/mix/dep/lock.ex
@@ -9,9 +9,8 @@ defmodule Mix.Dep.Lock do
   Reads the lockfile, returns a map containing
   each app name and its current lock information.
   """
-  @spec read() :: map
-  def read() do
-    lockfile = lockfile()
+  @spec read(Path.t()) :: map()
+  def read(lockfile \\ lockfile()) do
     opts = [file: lockfile, warn_on_unnecessary_quotes: false]
 
     with {:ok, contents} <- File.read(lockfile),
@@ -27,15 +26,15 @@ defmodule Mix.Dep.Lock do
   @doc """
   Receives a map and writes it as the latest lock.
   """
-  @spec write(map) :: :ok
-  def write(map) do
+  @spec write(Path.t(), map()) :: :ok
+  def write(lockfile \\ lockfile(), map) do
     unless map == read() do
       lines =
         for {app, rev} <- Enum.sort(map), rev != nil do
           ~s(  "#{app}": #{inspect(rev, limit: :infinity)},\n)
         end
 
-      File.write!(lockfile(), ["%{\n", lines, "}\n"])
+      File.write!(lockfile, ["%{\n", lines, "}\n"])
       Mix.Task.run("will_recompile")
     end
 

--- a/lib/mix/test/mix/tasks/compile.elixir_test.exs
+++ b/lib/mix/test/mix/tasks/compile.elixir_test.exs
@@ -1638,10 +1638,4 @@ defmodule Mix.Tasks.Compile.ElixirTest do
       assert Mix.Tasks.Compile.Elixir.run(["--no-optional-deps"]) == {:ok, []}
     end)
   end
-
-  defp get_git_repo_revs(repo) do
-    File.cd!(fixture_path(repo), fn ->
-      Regex.split(~r/\r?\n/, System.cmd("git", ["log", "--format=%H"]) |> elem(0))
-    end)
-  end
 end

--- a/lib/mix/test/mix/tasks/deps.git_test.exs
+++ b/lib/mix/test/mix/tasks/deps.git_test.exs
@@ -483,10 +483,4 @@ defmodule Mix.Tasks.DepsGitTest do
     Mix.ProjectStack.post_config(post_config)
     Mix.Project.push(name, file)
   end
-
-  defp get_git_repo_revs(repo) do
-    File.cd!(fixture_path(repo), fn ->
-      Regex.split(~r/\r?\n/, System.cmd("git", ["log", "--format=%H"]) |> elem(0))
-    end)
-  end
 end

--- a/lib/mix/test/mix_test.exs
+++ b/lib/mix/test/mix_test.exs
@@ -219,8 +219,6 @@ defmodule MixTest do
     end
 
     test ":lockfile with first build", %{tmp_dir: tmp_dir} do
-      install_dir = Path.join(tmp_dir, "install_dir")
-
       Mix.Project.push(GitApp)
       [_latest_rev, rev | _] = get_git_repo_revs("git_repo")
       lockfile = Path.join(tmp_dir, "lock")
@@ -231,28 +229,29 @@ defmodule MixTest do
         [
           {:git_repo, git: fixture_path("git_repo")}
         ],
-        __install_dir__: install_dir,
-        lockfile: lockfile
+        lockfile: lockfile,
+        verbose: true
       )
 
       assert_received {:mix_shell, :info, ["* Getting git_repo " <> _]}
+      assert_received {:mix_shell, :info, ["Mix.install/2 using " <> install_dir]}
       assert File.read!(Path.join(install_dir, "mix.lock")) =~ rev
     after
       purge([GitRepo, GitRepo.MixProject])
     end
 
     test ":lockfile merging", %{tmp_dir: tmp_dir} do
-      install_dir = Path.join(tmp_dir, "install_dir")
       [rev1, rev2 | _] = get_git_repo_revs("git_repo")
 
       Mix.install(
         [
           {:git_repo, git: fixture_path("git_repo")}
         ],
-        __install_dir__: install_dir
+        verbose: true
       )
 
       assert_received {:mix_shell, :info, ["* Getting git_repo " <> _]}
+      assert_received {:mix_shell, :info, ["Mix.install/2 using " <> install_dir]}
       assert File.read!(Path.join(install_dir, "mix.lock")) =~ rev1
 
       Mix.Project.push(GitApp)
@@ -264,7 +263,6 @@ defmodule MixTest do
         [
           {:git_repo, git: fixture_path("git_repo")}
         ],
-        __install_dir__: install_dir,
         lockfile: lockfile
       )
 

--- a/lib/mix/test/test_helper.exs
+++ b/lib/mix/test/test_helper.exs
@@ -204,6 +204,12 @@ defmodule MixTest.Case do
     tmp = tmp_path() |> String.to_charlist()
     for path <- :code.get_path(), :string.str(path, tmp) != 0, do: :code.del_path(path)
   end
+
+  def get_git_repo_revs(repo) do
+    File.cd!(fixture_path(repo), fn ->
+      Regex.split(~r/\r?\n/, System.cmd("git", ["log", "--format=%H"]) |> elem(0), trim: true)
+    end)
+  end
 end
 
 ## Set up globals


### PR DESCRIPTION
Closes #12044

This is especially useful to test an existing project along with its configuration and dependency resolution. Excerpt from the docs:

```elixir
# $ git clone https://github.com/hexpm/hexpm /tmp/hexpm
# $ cd /tmp/hexpm && mix setup

Mix.install(
  [
    {:hexpm, path: "/tmp/hexpm", env: :dev},
  ],
  config_path: "/tmp/hexpm/config/config.exs",
  lockfile: "/tmp/hexpm/mix.lock"
)

Hexpm.Repo.query!("SELECT COUNT(1) from packages")
#=> ...
```