### PR TITLE
Fixing edge cases in Enum.slide/3

### DIFF
--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2692,6 +2692,10 @@ defmodule Enum do
             "(tried to insert #{first}..#{last} at #{insertion_index})"
   end
 
+  def slide(enumerable, first..last, _insertion_index) when first > last do
+    Enum.to_list(enumerable)
+  end
+
   # Guarantees at this point: step size == 1 and first <= last and (insertion_index < first or insertion_index > last)
   def slide(enumerable, first..last, insertion_index) do
     impl = if is_list(enumerable), do: &slide_list_start/4, else: &slide_any/4

--- a/lib/elixir/lib/enum.ex
+++ b/lib/elixir/lib/enum.ex
@@ -2740,6 +2740,7 @@ defmodule Enum do
   end
 
   defp slide_list_start(list, 0, middle, last), do: slide_list_middle(list, middle, last, [])
+  defp slide_list_start([], _start, _middle, _last), do: []
 
   defp slide_list_middle([h | t], middle, last, acc) when middle > 0 do
     slide_list_middle(t, middle - 1, last - 1, [h | acc])

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -956,7 +956,8 @@ defmodule EnumTest do
         {4..8, 19},
         {4..8, 0},
         {4..8, 2},
-        {10..20, 0}
+        {10..20, 0},
+        {2..1//1, -20}
       ]
 
       for {slide_range, insertion_point} <- test_specs do

--- a/lib/elixir/test/elixir/enum_test.exs
+++ b/lib/elixir/test/elixir/enum_test.exs
@@ -821,6 +821,7 @@ defmodule EnumTest do
     test "on an empty enum produces an empty list" do
       for enum <- [[], %{}, 0..-1//1, MapSet.new()] do
         assert Enum.slide(enum, 0..0, 0) == []
+        assert Enum.slide(enum, 1..1, 2) == []
       end
     end
 


### PR DESCRIPTION
The first bug can happen on empty lists:

```elixir
iex> Enum.slide([], 1, 2)
** (FunctionClauseError) no function clause matching in Enum.slide_list_start/4

    The following arguments were given to Enum.slide_list_start/4:

        # 1
        []

        # 2
        1

        # 3
        2

        # 4
        2

    Attempted function clauses (showing 2 out of 2):

        defp slide_list_start([h | t], start, middle, last) when start > 0 and start <= middle and middle <= last
        defp slide_list_start(list, 0, middle, last)

    (elixir 1.13.4) lib/enum.ex:2665: Enum.slide_list_start/4
```

The second bug is on a weird edge case because an assumed invariant (`start <= stop`) isn't actually checked (but only happens for some precise values of the insertion index):

```
iex> Enum.slide([1, 2, 3, 4], 2..1//1, -3)
** (FunctionClauseError) no function clause matching in Enum.slide_list_start/4

    The following arguments were given to Enum.slide_list_start/4:

        # 1
        [1, 2, 3, 4]

        # 2
        1

        # 3
        2

        # 4
        1

    Attempted function clauses (showing 2 out of 2):

        defp slide_list_start([h | t], start, middle, last) when start > 0 and start <= middle and middle <= last
        defp slide_list_start(list, 0, middle, last)

    (elixir 1.13.4) lib/enum.ex:2665: Enum.slide_list_start/4
```