### PR TITLE
typo: improves -> improve

### DIFF
--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -79,7 +79,7 @@ defmodule Task do
 
   We encourage developers to rely on supervised tasks as much as possible.
   Supervised tasks improve the visibility of how many tasks are running
-  at a given moment and enable a huge variety of patterns that gives you
+  at a given moment and enable a huge variety of patterns that give you
   explicit control on how to handle the results, errors, and timeouts.
   Here is a summary:
 

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -78,7 +78,7 @@ defmodule Task do
       |> Task.await()
 
   We encourage developers to rely on supervised tasks as much as possible.
-  Supervised tasks improves the visibility of how many tasks are running
+  Supervised tasks improve the visibility of how many tasks are running
   at a given moment and enable a huge variety of patterns that gives you
   explicit control on how to handle the results, errors, and timeouts.
   Here is a summary:

--- a/lib/elixir/lib/task.ex
+++ b/lib/elixir/lib/task.ex
@@ -79,7 +79,7 @@ defmodule Task do
 
   We encourage developers to rely on supervised tasks as much as possible.
   Supervised tasks improve the visibility of how many tasks are running
-  at a given moment and enable a huge variety of patterns that give you
+  at a given moment and enable a variety of patterns that give you
   explicit control on how to handle the results, errors, and timeouts.
   Here is a summary:
 


### PR DESCRIPTION
I wonder if this part in the line right below

> that gives you explicit control on how to handle the results

should be changed with `gives -> give` as well?