### PR TITLE
Fix unclosed backquotes in Code.Fragment and Macro

### DIFF
--- a/lib/elixir/lib/code/fragment.ex
+++ b/lib/elixir/lib/code/fragment.ex
@@ -44,7 +44,7 @@ defmodule Code.Fragment do
 
     * `{:alias, inside_alias, charlist}` - the context is an alias, potentially
       a nested one, where `inside_alias` is an expression `{:module_attribute, charlist}`
-      or {:local_or_var, charlist}` and `charlist` is a static part
+      or `{:local_or_var, charlist}` and `charlist` is a static part
       Examples are `__MODULE__.Submodule` or `@hello.Submodule`
 
     * `{:dot, inside_dot, charlist}` - the context is a dot

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1969,7 +1969,7 @@ defmodule Macro do
   def quoted_literal?(term), do: is_atom(term) or is_number(term) or is_binary(term)
 
   @doc """
-  Expands a `quoted_literal` with the given \\`
+  Expands the `ast` representing a quoted literal within the given `env`.
 
   This function checks if the given AST represents a quoted literal
   (using `quoted_literal?/1`) and then expands all relevant nodes.

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1969,7 +1969,7 @@ defmodule Macro do
   def quoted_literal?(term), do: is_atom(term) or is_number(term) or is_binary(term)
 
   @doc """
-  Expands a `quoted_literal` with the given `
+  Expands a `quoted_literal` with the given \\`
 
   This function checks if the given AST represents a quoted literal
   (using `quoted_literal?/1`) and then expands all relevant nodes.


### PR DESCRIPTION
Found from working #12038. Fixes 2 ex_doc warning. Here is build log https://github.com/wingyplus/elixir/runs/7727863757?check_suite_focus=true#step:9:111