### PR TITLE
Bump ubuntu to 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test_linux:
-    name: Linux, ${{ matrix.otp_release }}, Ubuntu 18.04
+    name: Linux, ${{ matrix.otp_release }}, Ubuntu 20.04
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +26,7 @@ jobs:
             development: true
           - otp_release: maint
             development: true
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -34,7 +34,7 @@ jobs:
       - name: Install Erlang/OTP
         run: |
           cd $RUNNER_TEMP
-          wget -O otp.tar.gz https://repo.hex.pm/builds/otp/ubuntu-18.04/${{ matrix.otp_release }}.tar.gz
+          wget -O otp.tar.gz https://repo.hex.pm/builds/otp/ubuntu-20.04/${{ matrix.otp_release }}.tar.gz
           mkdir -p otp
           tar zxf otp.tar.gz -C otp --strip-components=1
           otp/Install -minimal $(pwd)/otp
@@ -107,7 +107,7 @@ jobs:
 
   check_posix_compliant:
     name: Check POSIX-compliant
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
   create_draft_release:
     permissions:
       contents: write
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
The ubuntu-18.04 nows deprecated today [1]. This changes start moving it
to version 20.04 instead.

[1] https://github.com/actions/virtual-environments/issues/6002.