### PR TITLE
Clarify CaptureLog level vs Logger level

### DIFF
--- a/lib/ex_unit/lib/ex_unit/capture_log.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_log.ex
@@ -60,8 +60,9 @@ defmodule ExUnit.CaptureLog do
   capture, for instance, if the log level is set to `:error`, then
   any message with the lower level will be ignored.
   The default level is `nil`, which will capture all messages.
-  Note that messages are filtered by the general `:level` configuration
-  for the `:logger` application first.
+  Note this setting does not override the overall `Logger.level/0` value.
+  Therefore, if `Logger.level/0` is set to a higher level than the one
+  configured in this function, no message will be captured.
   The behaviour is undetermined if async tests change Logger level.
 
   The format, metadata and colors can be configured with `:format`,

--- a/lib/ex_unit/lib/ex_unit/capture_log.ex
+++ b/lib/ex_unit/lib/ex_unit/capture_log.ex
@@ -60,6 +60,8 @@ defmodule ExUnit.CaptureLog do
   capture, for instance, if the log level is set to `:error`, then
   any message with the lower level will be ignored.
   The default level is `nil`, which will capture all messages.
+  Note that messages are filtered by the general `:level` configuration
+  for the `:logger` application first.
   The behaviour is undetermined if async tests change Logger level.
 
   The format, metadata and colors can be configured with `:format`,


### PR DESCRIPTION
The fact that `capture_log([level: :info])` doesn't capture `Logger.info` calls if `Logger.level/0`is `:notice` or higher caught me off guard, so I figured it'd be good to mention here that the `Logger` `:level` config still applies.

This note is copied directly from `Logger.Backends.Console` since that's
where this behavior originates.