### PR TITLE
Fix ExUnit.Diff handling of charlists

### DIFF
--- a/lib/ex_unit/test/ex_unit/diff_test.exs
+++ b/lib/ex_unit/test/ex_unit/diff_test.exs
@@ -1010,21 +1010,20 @@ defmodule ExUnit.DiffTest do
   end
 
   test "charlists" do
-    # TODO fix these diffs
     refute_diff(
       ~c"fox hops over 'the dog" = ~c"fox jumps over the lazy cat",
-      "-~c\"fox hops over 'the dog\"-",
-      "'fox +jum+ps over the +lazy cat+'"
+      "~c\"fox -ho-ps over -'-the -dog-\"",
+      "~c\"fox +jum+ps over the +lazy cat+\""
     )
 
     refute_diff({[], :ok} = {[], [], :ok}, "{[], -:ok-}", "{[], +[]+, +:ok+}")
-    refute_diff({[], :ok} = {~c"foo", [], :ok}, "{'--', -:ok-}", "{'+foo+', +[]+, +:ok+}")
-    refute_diff({~c"foo", :ok} = {[], [], :ok}, "{-~c\"foo\"-, -:ok-}", "{'++', +[]+, +:ok+}")
+    refute_diff({[], :ok} = {~c"foo", [], :ok}, "{~c\"--\", -:ok-}", "{~c\"+foo+\", +[]+, +:ok+}")
+    refute_diff({~c"foo", :ok} = {[], [], :ok}, "{~c\"-foo-\", -:ok-}", "{~c\"++\", +[]+, +:ok+}")
 
     refute_diff(
       {~c"foo", :ok} = {~c"bar", [], :ok},
-      "{-~c\"foo\"-, -:ok-}",
-      "{'+bar+', +[]+, +:ok+}"
+      "{~c\"-foo-\", -:ok-}",
+      "{~c\"+bar+\", +[]+, +:ok+}"
     )
   end
 


### PR DESCRIPTION
Properly handle diffs of charlists using the `~c` sigil notation:

<img width="345" alt="Screen Shot 2022-08-13 at 13 57 08" src="https://user-images.githubusercontent.com/11598866/184469156-76488eab-1b3e-4618-b140-a9e604fdd316.png">

Relates to https://github.com/elixir-lang/elixir/issues/12065
