### PR TITLE
Inspect charlists as ~c sigils

### DIFF
--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -475,7 +475,7 @@ defmodule EEx.Compiler do
   end
 
   defp column(column, mark) do
-    # length('<%') == 2
+    # length(~c"<%") == 2
     column + 2 + length(mark)
   end
 end

--- a/lib/elixir/lib/function.ex
+++ b/lib/elixir/lib/function.ex
@@ -192,11 +192,11 @@ defmodule Function do
       iex> Function.identity("Hello world!")
       "Hello world!"
 
-      iex> 'abcdaabccc' |> Enum.sort() |> Enum.chunk_by(&Function.identity/1)
-      ['aaa', 'bb', 'cccc', 'd']
+      iex> ~c"abcdaabccc" |> Enum.sort() |> Enum.chunk_by(&Function.identity/1)
+      [~c"aaa", ~c"bb", ~c"cccc", ~c"d"]
 
-      iex> Enum.group_by('abracadabra', &Function.identity/1)
-      %{97 => 'aaaaa', 98 => 'bb', 99 => 'c', 100 => 'd', 114 => 'rr'}
+      iex> Enum.group_by(~c"abracadabra", &Function.identity/1)
+      %{97 => ~c"aaaaa", 98 => ~c"bb", 99 => ~c"c", 100 => ~c"d", 114 => ~c"rr"}
 
       iex> Enum.map([1, 2, 3, 4], &Function.identity/1)
       [1, 2, 3, 4]

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -257,9 +257,9 @@ defimpl Inspect, for: List do
     cond do
       lists == :as_charlists or (lists == :infer and List.ascii_printable?(term, printable_limit)) ->
         inspected =
-          case Identifier.escape(IO.chardata_to_string(term), ?', printable_limit) do
-            {escaped, ""} -> [?', escaped, ?']
-            {escaped, _} -> [?', escaped, ?', " ++ ..."]
+          case Identifier.escape(IO.chardata_to_string(term), ?", printable_limit) do
+            {escaped, ""} -> [?~, ?c, ?", escaped, ?"]
+            {escaped, _} -> [?~, ?c, ?", escaped, ?", " ++ ..."]
           end
 
         color(IO.iodata_to_binary(inspected), :charlist, opts)

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1444,8 +1444,8 @@ defmodule Kernel do
       iex> [1] ++ [2, 3]
       [1, 2, 3]
 
-      iex> 'foo' ++ 'bar'
-      'foobar'
+      iex> ~c"foo" ++ ~c"bar"
+      ~c"foobar"
 
       # returns an improper list
       iex> [1] ++ 2
@@ -2217,10 +2217,10 @@ defmodule Kernel do
       iex> inspect("olá", binaries: :as_binaries)
       "<<111, 108, 195, 161>>"
 
-      iex> inspect('bar')
-      "'bar'"
+      iex> inspect(~c"bar")
+      "~c\"bar\""
 
-      iex> inspect([0 | 'bar'])
+      iex> inspect([0 | ~c"bar"])
       "[0, 98, 97, 114]"
 
       iex> inspect(100, base: :octal)
@@ -3190,7 +3190,7 @@ defmodule Kernel do
   ## Examples
 
       iex> to_charlist(:foo)
-      'foo'
+      ~c"foo"
 
   """
   defmacro to_charlist(term) do
@@ -5924,10 +5924,10 @@ defmodule Kernel do
   ## Examples
 
       iex> ~C(foo)
-      'foo'
+      ~c"foo"
 
       iex> ~C(f#{o}o)
-      'f\#{o}o'
+      ~c"f\#{o}o"
 
   """
   defmacro sigil_C(term, modifiers)
@@ -5945,13 +5945,13 @@ defmodule Kernel do
   ## Examples
 
       iex> ~c(foo)
-      'foo'
+      ~c"foo"
 
       iex> ~c(f#{:o}o)
-      'foo'
+      ~c"foo"
 
       iex> ~c(f\#{:o}o)
-      'f\#{:o}o'
+      ~c"f\#{:o}o"
 
   """
   defmacro sigil_c(term, modifiers)
@@ -6288,7 +6288,7 @@ defmodule Kernel do
       [:foo, :bar, :baz]
 
       iex> ~w(foo bar baz)c
-      ['foo', 'bar', 'baz']
+      [~c"foo", ~c"bar", ~c"baz"]
 
   """
   defmacro sigil_w(term, modifiers)

--- a/lib/elixir/lib/list.ex
+++ b/lib/elixir/lib/list.ex
@@ -84,23 +84,23 @@ defmodule List do
     * and be out of the range `0xD800..0xDFFF` (`55_296..57_343`), which is
       reserved in Unicode for UTF-16 surrogate pairs.
 
-  Elixir uses single quotes to define charlists:
+  Elixir uses the [`~c` sigil](`sigil_c/2`) to define charlists:
 
-      iex> 'héllo'
+      iex> ~c"héllo"
       [104, 233, 108, 108, 111]
 
-  In particular, charlists will be printed back by default in single
-  quotes if they contain only printable ASCII characters:
+  In particular, charlists will be printed back by default with the `~c`
+  sigil if they contain only printable ASCII characters:
 
-      iex> 'abc'
-      'abc'
+      iex> ~c"abc"
+      ~c"abc"
 
   Even though the representation changed, the raw data does remain a list of
   numbers, which can be handled as such:
 
-      iex> inspect('abc', charlists: :as_list)
+      iex> inspect(~c"abc", charlists: :as_list)
       "[97, 98, 99]"
-      iex> Enum.map('abc', fn num -> 1000 + num end)
+      iex> Enum.map(~c"abc", fn num -> 1000 + num end)
       [1097, 1098, 1099]
 
   You can use the `IEx.Helpers.i/1` helper to get a condensed rundown on
@@ -115,11 +115,11 @@ defmodule List do
 
       Application.loaded_applications()
       #=>  [
-      #=>    {:stdlib, 'ERTS  CXC 138 10', '2.6'},
-      #=>    {:compiler, 'ERTS  CXC 138 10', '6.0.1'},
-      #=>    {:elixir, 'elixir', '1.0.0'},
-      #=>    {:kernel, 'ERTS  CXC 138 10', '4.1'},
-      #=>    {:logger, 'logger', '1.0.0'}
+      #=>    {:stdlib, ~c"ERTS  CXC 138 10", ~c"2.6"},
+      #=>    {:compiler, ~c"ERTS  CXC 138 10", ~c"6.0.1"},
+      #=>    {:elixir, ~c"elixir", ~c"1.0.0"},
+      #=>    {:kernel, ~c"ERTS  CXC 138 10", ~c"4.1"},
+      #=>    {:logger, ~c"logger", ~c"1.0.0"}
       #=>  ]
 
   A list can be checked if it is made of only printable ASCII
@@ -678,18 +678,18 @@ defmodule List do
 
   ## Examples
 
-      iex> List.ascii_printable?('abc')
+      iex> List.ascii_printable?(~c"abc")
       true
 
-      iex> List.ascii_printable?('abc' ++ [0])
+      iex> List.ascii_printable?(~c"abc" ++ [0])
       false
 
-      iex> List.ascii_printable?('abc' ++ [0], 2)
+      iex> List.ascii_printable?(~c"abc" ++ [0], 2)
       true
 
   Improper lists are not printable, even if made only of ASCII characters:
 
-      iex> List.ascii_printable?('abc' ++ ?d)
+      iex> List.ascii_printable?(~c"abc" ++ ?d)
       false
 
   """
@@ -934,10 +934,10 @@ defmodule List do
 
   ## Examples
 
-      iex> List.to_atom('Elixir')
+      iex> List.to_atom(~c"Elixir")
       :Elixir
 
-      iex> List.to_atom('🌢 Elixir')
+      iex> List.to_atom(~c"🌢 Elixir")
       :"🌢 Elixir"
 
   """
@@ -966,11 +966,11 @@ defmodule List do
   ## Examples
 
       iex> _ = :my_atom
-      iex> List.to_existing_atom('my_atom')
+      iex> List.to_existing_atom(~c"my_atom")
       :my_atom
 
       iex> _ = :"🌢 Elixir"
-      iex> List.to_existing_atom('🌢 Elixir')
+      iex> List.to_existing_atom(~c"🌢 Elixir")
       :"🌢 Elixir"
 
   """
@@ -986,7 +986,7 @@ defmodule List do
 
   ## Examples
 
-      iex> List.to_float('2.2017764e+0')
+      iex> List.to_float(~c"2.2017764e+0")
       2.2017764
 
   """
@@ -1002,7 +1002,7 @@ defmodule List do
 
   ## Examples
 
-      iex> List.to_integer('123')
+      iex> List.to_integer(~c"123")
       123
 
   """
@@ -1020,7 +1020,7 @@ defmodule List do
 
   ## Examples
 
-      iex> List.to_integer('3FF', 16)
+      iex> List.to_integer(~c"3FF", 16)
       1023
 
   """
@@ -1068,7 +1068,7 @@ defmodule List do
       iex> List.to_string([0x0061, "bc"])
       "abc"
 
-      iex> List.to_string([0x0064, "ee", ['p']])
+      iex> List.to_string([0x0064, "ee", [~c"p"]])
       "deep"
 
       iex> List.to_string([])
@@ -1117,14 +1117,14 @@ defmodule List do
 
   ## Examples
 
-      iex> List.to_charlist([0x00E6, 0x00DF])
-      'æß'
+      iex> ~c"æß" = List.to_charlist([0x00E6, 0x00DF])
+      [230, 223]
 
       iex> List.to_charlist([0x0061, "bc"])
-      'abc'
+      ~c"abc"
 
-      iex> List.to_charlist([0x0064, "ee", ['p']])
-      'deep'
+      iex> List.to_charlist([0x0064, "ee", [~c"p"]])
+      ~c"deep"
 
   """
   @doc since: "1.8.0"

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -1338,8 +1338,8 @@ defmodule Macro do
           "[]"
 
         :io_lib.printable_list(list) ->
-          {escaped, _} = Identifier.escape(IO.chardata_to_string(list), ?')
-          IO.iodata_to_binary([?', escaped, ?'])
+          {escaped, _} = Identifier.escape(IO.chardata_to_string(list), ?")
+          IO.iodata_to_binary([?~, ?c, ?", escaped, ?"])
 
         Inspect.List.keyword?(list) ->
           "[" <> kw_list_to_string(list, fun) <> "]"

--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -2521,8 +2521,8 @@ defmodule String do
 
   ## Examples
 
-      iex> String.to_charlist("æß")
-      'æß'
+      iex> String.to_charlist("foo")
+      ~c"foo"
 
   """
   @spec to_charlist(t) :: charlist

--- a/lib/elixir/test/elixir/inspect_test.exs
+++ b/lib/elixir/test/elixir/inspect_test.exs
@@ -294,13 +294,13 @@ defmodule Inspect.ListTest do
   end
 
   test "printable" do
-    assert inspect(~c"abc") == "'abc'"
+    assert inspect(~c"abc") == ~s(~c"abc")
   end
 
   test "printable limit" do
-    assert inspect(~c"hello world", printable_limit: 4) == ~s('hell' ++ ...)
+    assert inspect(~c"hello world", printable_limit: 4) == ~s(~c"hell" ++ ...)
     # Non printable characters after the limit don't matter
-    assert inspect(~c"hello world" ++ [0], printable_limit: 4) == ~s('hell' ++ ...)
+    assert inspect(~c"hello world" ++ [0], printable_limit: 4) == ~s(~c"hell" ++ ...)
     # Non printable strings aren't affected by printable limit
     assert inspect([0, 1, 2, 3, 4], printable_limit: 3) == ~s([0, 1, 2, 3, 4])
   end
@@ -323,14 +323,14 @@ defmodule Inspect.ListTest do
     assert inspect(~c"john" ++ [0] ++ ~c"doe", charlists: :infer) ==
              "[106, 111, 104, 110, 0, 100, 111, 101]"
 
-    assert inspect(~c"john", charlists: :infer) == "'john'"
+    assert inspect(~c"john", charlists: :infer) == ~s(~c"john")
     assert inspect([0], charlists: :infer) == "[0]"
   end
 
   test "opt as strings" do
-    assert inspect(~c"john" ++ [0] ++ ~c"doe", charlists: :as_charlists) == "'john\\0doe'"
-    assert inspect(~c"john", charlists: :as_charlists) == "'john'"
-    assert inspect([0], charlists: :as_charlists) == "'\\0'"
+    assert inspect(~c"john" ++ [0] ++ ~c"doe", charlists: :as_charlists) == ~s(~c"john\\0doe")
+    assert inspect(~c"john", charlists: :as_charlists) == ~s(~c"john")
+    assert inspect([0], charlists: :as_charlists) == ~s(~c"\\0")
   end
 
   test "opt as lists" do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -857,7 +857,7 @@ defmodule MacroTest do
     test "charlist" do
       assert macro_to_string(quote(do: [])) == "[]"
       assert macro_to_string(quote(do: ~c"abc")) == ~S/~c"abc"/
-      assert macro_to_string(quote(do: [?a, ?b, ?c])) == "'abc'"
+      assert macro_to_string(quote(do: [?a, ?b, ?c])) == ~S/~c"abc"/
     end
 
     test "string" do

--- a/lib/mix/lib/mix/tasks/compile.erlang.ex
+++ b/lib/mix/lib/mix/tasks/compile.erlang.ex
@@ -88,12 +88,13 @@ defmodule Mix.Tasks.Compile.Erlang do
       :code.purge(module)
       :code.delete(module)
 
-      file = Erlang.to_erl_file(Path.rootname(input, ".erl"))
+      path = Path.rootname(input, ".erl")
+      file = Erlang.to_erl_file(path)
 
       case :compile.file(file, erlc_options) do
         :error ->
           message =
-            "Compiling Erlang file #{inspect(file)} failed, probably because of invalid :erlc_options"
+            "Compiling Erlang file #{inspect(path)} failed, probably because of invalid :erlc_options"
 
           Mix.raise(message)
 

--- a/lib/mix/test/mix/tasks/compile.erlang_test.exs
+++ b/lib/mix/test/mix/tasks/compile.erlang_test.exs
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.Compile.ErlangTest do
   @tag erlc_options: [{:d, ~c"foo", ~c"bar"}]
   test "raises on invalid erlc_options" do
     in_fixture("compile_erlang", fn ->
-      assert_raise Mix.Error, ~r/Compiling Erlang file ~c".*" failed/, fn ->
+      assert_raise Mix.Error, ~r/Compiling Erlang file ".*" failed/, fn ->
         capture_io(fn ->
           Mix.Tasks.Compile.Erlang.run([])
         end)

--- a/lib/mix/test/mix/tasks/compile.erlang_test.exs
+++ b/lib/mix/test/mix/tasks/compile.erlang_test.exs
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.Compile.ErlangTest do
   @tag erlc_options: [{:d, ~c"foo", ~c"bar"}]
   test "raises on invalid erlc_options" do
     in_fixture("compile_erlang", fn ->
-      assert_raise Mix.Error, ~r"Compiling Erlang file '.*' failed", fn ->
+      assert_raise Mix.Error, ~r/Compiling Erlang file ~c".*" failed/, fn ->
         capture_io(fn ->
           Mix.Tasks.Compile.Erlang.run([])
         end)


### PR DESCRIPTION
Inspect charlists as `~c` sigils.

Also updates doctests to use the correct syntax.

<img width="129" alt="Screen Shot 2022-08-13 at 15 05 03" src="https://user-images.githubusercontent.com/11598866/184471065-43778335-c139-4b34-b97c-2579084f6b2e.png">

Relates to https://github.com/elixir-lang/elixir/issues/12065