### PR TITLE
Update IEx.Info for charlists

### DIFF
--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -182,7 +182,7 @@ defimpl IEx.Info, for: List do
   defp info_printable_charlist(charlist) do
     description = """
     This is a list of integers that is printed using the `~c` sigil syntax,
-    defined in the `Kernel.sigil_c/2` macro, because all the integers in it
+    defined by the `Kernel.sigil_c/2` macro, because all the integers in it
     represent printable ASCII characters. Conventionally, a list of Unicode
     code points is known as a charlist and a list of ASCII characters is a
     subset of it.

--- a/lib/iex/lib/iex/info.ex
+++ b/lib/iex/lib/iex/info.ex
@@ -181,10 +181,11 @@ defimpl IEx.Info, for: List do
 
   defp info_printable_charlist(charlist) do
     description = """
-    This is a list of integers that is printed as a sequence of characters
-    delimited by single quotes because all the integers in it represent printable
-    ASCII characters. Conventionally, a list of Unicode code points is known as a
-    charlist and a list of ASCII characters is a subset of it.
+    This is a list of integers that is printed using the `~c` sigil syntax,
+    defined in the `Kernel.sigil_c/2` macro, because all the integers in it
+    represent printable ASCII characters. Conventionally, a list of Unicode
+    code points is known as a charlist and a list of ASCII characters is a
+    subset of it.
     """
 
     [


### PR DESCRIPTION
Updates `IEx.Info` which was still mentioning single quotes:

<img width="533" alt="Screen Shot 2022-08-13 at 16 51 40" src="https://user-images.githubusercontent.com/11598866/184474710-52d3fdd3-2347-43cf-aa84-a62ae6e222a7.png">


Relates to #12065