### PR TITLE
Add support for automatic shutdown to Supervisor

### DIFF
--- a/lib/elixir/lib/partition_supervisor.ex
+++ b/lib/elixir/lib/partition_supervisor.ex
@@ -200,7 +200,16 @@ defmodule PartitionSupervisor do
         Map.merge(map, %{id: partition, start: start, modules: modules})
       end
 
-    {init_opts, start_opts} = Keyword.split(opts, [:strategy, :max_seconds, :max_restarts])
+    auto_shutdown = Keyword.get(opts, :auto_shutdown, :never)
+
+    unless auto_shutdown == :never do
+      raise ArgumentError,
+            "the :auto_shutdown option must be :never, got: #{inspect(auto_shutdown)}"
+    end
+
+    {init_opts, start_opts} =
+      Keyword.split(opts, [:strategy, :max_seconds, :max_restarts, :auto_shutdown])
+
     Supervisor.start_link(__MODULE__, {name, partitions, children, init_opts}, start_opts)
   end
 

--- a/lib/elixir/test/elixir/dynamic_supervisor_test.exs
+++ b/lib/elixir/test/elixir/dynamic_supervisor_test.exs
@@ -99,6 +99,9 @@ defmodule DynamicSupervisorTest do
       assert DynamicSupervisor.start_link(Simple, {:ok, %{extra_arguments: -1}}) ==
                {:error, {:supervisor_data, {:invalid_extra_arguments, -1}}}
 
+      assert DynamicSupervisor.start_link(Simple, {:ok, %{auto_shutdown: :any_significant}}) ==
+               {:error, {:supervisor_data, {:invalid_auto_shutdown, :any_significant}}}
+
       assert DynamicSupervisor.start_link(Simple, :unknown) ==
                {:error, {:bad_return, {Simple, :init, :unknown}}}
 
@@ -236,6 +239,13 @@ defmodule DynamicSupervisorTest do
                shutdown: -1
              }) ==
                {:error, {:invalid_shutdown, -1}}
+
+      assert DynamicSupervisor.start_child(:not_used, %{
+               id: 1,
+               start: {Task, :foo, [:bar]},
+               significant: true
+             }) ==
+               {:error, {:invalid_significant, true}}
     end
 
     test "with different returns" do

--- a/lib/elixir/test/elixir/partition_supervisor_test.exs
+++ b/lib/elixir/test/elixir/partition_supervisor_test.exs
@@ -119,6 +119,18 @@ defmodule PartitionSupervisorTest do
                      )
                    end
     end
+
+    test "raises with bad auto_shutdown" do
+      assert_raise ArgumentError,
+                   "the :auto_shutdown option must be :never, got: :any_significant",
+                   fn ->
+                     PartitionSupervisor.start_link(
+                       child_spec: DynamicSupervisor,
+                       name: Foo,
+                       auto_shutdown: :any_significant
+                     )
+                   end
+    end
   end
 
   describe "stop/1" do

--- a/lib/elixir/test/elixir/supervisor_test.exs
+++ b/lib/elixir/test/elixir/supervisor_test.exs
@@ -106,11 +106,11 @@ defmodule SupervisorTest do
   end
 
   test "init/2" do
-    flags = %{intensity: 3, period: 5, strategy: :one_for_one}
+    flags = %{intensity: 3, period: 5, strategy: :one_for_one, auto_shutdown: :never}
     children = [%{id: Task, restart: :temporary, start: {Task, :start_link, [[]]}}]
     assert Supervisor.init([Task], strategy: :one_for_one) == {:ok, {flags, children}}
 
-    flags = %{intensity: 1, period: 2, strategy: :one_for_all}
+    flags = %{intensity: 1, period: 2, strategy: :one_for_all, auto_shutdown: :never}
     children = [%{id: Task, restart: :temporary, start: {Task, :start_link, [:foo]}}]
 
     assert Supervisor.init(
@@ -126,7 +126,7 @@ defmodule SupervisorTest do
   end
 
   test "init/2 with old and new child specs" do
-    flags = %{intensity: 3, period: 5, strategy: :one_for_one}
+    flags = %{intensity: 3, period: 5, strategy: :one_for_one, auto_shutdown: :never}
 
     children = [
       %{id: Task, restart: :temporary, start: {Task, :start_link, [[]]}},


### PR DESCRIPTION
This adds support for [Automatic Shutdown](https://www.erlang.org/doc/design_principles/sup_princ.html#automatic-shutdown) (EEP 56) to Supervisor. This functionality was added in Erlang R24 and leaks processes with older versions so should require 1.15. I believe it should have been listed in #10433 as well.

I tried to summarize the docs in a way that Elixir users wouldn't need to cross reference the OTP ones to use the feature, other than that it's mostly passing through options to `:supervisor` and spec/doc updates.