### PR TITLE
Format single pipe calls

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1627,7 +1627,7 @@ defmodule DateTime do
     if Calendar.compatible_calendars?(dt_calendar, calendar) do
       result_datetime =
         datetime
-        |> to_iso_days
+        |> to_iso_days()
         |> from_iso_days(datetime, calendar, precision)
 
       {:ok, result_datetime}

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -1093,7 +1093,7 @@ defmodule NaiveDateTime do
     if Calendar.compatible_calendars?(ndt_calendar, calendar) do
       result_naive_datetime =
         naive_datetime
-        |> to_iso_days
+        |> to_iso_days()
         |> from_iso_days(calendar, precision)
 
       {:ok, result_naive_datetime}

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -702,6 +702,8 @@ defmodule Code.Formatter do
     right_context = right_op_context(context)
     max_line = line(meta)
 
+    right_arg = add_parenthesis_in_pipe(op, right_arg)
+
     {pipes, min_line} =
       unwrap_pipes(left_arg, meta, left_context, [{{op, right_context}, right_arg}])
 
@@ -821,6 +823,7 @@ defmodule Code.Formatter do
        when op in @pipeline_operators do
     left_context = left_op_context(context)
     right_context = right_op_context(context)
+    right = add_parenthesis_in_pipe(op, right)
     unwrap_pipes(left, meta, left_context, [{{op, right_context}, right} | acc])
   end
 
@@ -833,6 +836,13 @@ defmodule Code.Formatter do
 
     {[{{:root, context}, left} | acc], min_line}
   end
+
+  # Transforms `|> foo` into `|> foo()`; other cases are left as is
+  defp add_parenthesis_in_pipe(:|>, {fun, [line: line], nil}) when is_atom(fun) do
+    {fun, [closing: [line: line], line: line], []}
+  end
+
+  defp add_parenthesis_in_pipe(_op, right), do: right
 
   defp unwrap_right({op, meta, [left, right]}, op, _meta, context, acc) do
     left_context = left_op_context(context)

--- a/lib/elixir/lib/io/ansi/docs.ex
+++ b/lib/elixir/lib/io/ansi/docs.ex
@@ -616,7 +616,7 @@ defmodule IO.ANSI.Docs do
       col
       |> String.trim()
       |> String.replace("\\\|", "|")
-      |> handle_links
+      |> handle_links()
       |> handle_inline(options)
 
     {col, length_without_escape(col, 0)}
@@ -789,8 +789,8 @@ defmodule IO.ANSI.Docs do
 
   defp handle_links(text) do
     text
-    |> remove_square_brackets_in_link
-    |> escape_underlines_in_link
+    |> remove_square_brackets_in_link()
+    |> escape_underlines_in_link()
   end
 
   defp escape_underlines_in_link(text) do

--- a/lib/elixir/lib/system.ex
+++ b/lib/elixir/lib/system.ex
@@ -148,7 +148,7 @@ defmodule System do
     ~c"git rev-parse --short=7 HEAD 2> "
     |> Kernel.++(null)
     |> :os.cmd()
-    |> strip
+    |> strip()
   end
 
   defp revision, do: get_revision()

--- a/lib/elixir/test/elixir/code_formatter/calls_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/calls_test.exs
@@ -1220,4 +1220,12 @@ defmodule Code.Formatter.CallsTest do
       assert_format "expr[[foo: bar, baz: bat]]", "expr[[foo: bar, baz: bat]]"
     end
   end
+
+  describe "pipe" do
+    test "to local functions" do
+      assert_format "foo |> bar", "foo |> bar()", locals_without_parens: [bar: :*]
+      assert_format "foo |> bar 42", "foo |> bar(42)"
+      assert_format "foo |> bar |> baz <|> qux |> fin", "foo |> bar() |> baz() <|> qux |> fin()"
+    end
+  end
 end

--- a/lib/elixir/test/elixir/code_formatter/calls_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/calls_test.exs
@@ -1227,5 +1227,31 @@ defmodule Code.Formatter.CallsTest do
       assert_format "foo |> bar 42", "foo |> bar(42)"
       assert_format "foo |> bar |> baz <|> qux |> fin", "foo |> bar() |> baz() <|> qux |> fin()"
     end
+
+    test "definitions" do
+      assert_format(
+        "def foo |> bar, do: foo |> bar",
+        "def foo |> bar, do: foo |> bar()"
+      )
+
+      assert_format(
+        """
+        def foo |> bar do
+          foo |> bar
+        end
+        """,
+        """
+        def foo |> bar do
+          foo |> bar()
+        end
+        """
+      )
+
+      # Known defect: pipes in guard don't have parenthesis added
+      assert_format(
+        "def foo when foo |> bar, do: foo |> bar",
+        "def foo when foo |> bar, do: foo |> bar()"
+      )
+    end
   end
 end

--- a/lib/elixir/test/elixir/code_formatter/comments_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/comments_test.exs
@@ -906,7 +906,7 @@ defmodule Code.Formatter.CommentsTest do
       foo
       # |> bar
       # |> baz
-      |> bat
+      |> bat()
       """
 
       bad = """
@@ -922,9 +922,9 @@ defmodule Code.Formatter.CommentsTest do
       # this is foo
       foo
       # this is bar
-      |> bar
+      |> bar()
       # this is baz
-      |> baz
+      |> baz()
 
       # after
       """

--- a/lib/elixir/test/elixir/code_formatter/operators_test.exs
+++ b/lib/elixir/test/elixir/code_formatter/operators_test.exs
@@ -283,7 +283,7 @@ defmodule Code.Formatter.OperatorsTest do
     test "preserves user choice even when it fits" do
       assert_same """
       foo
-      |> bar
+      |> bar()
       """
 
       assert_same """
@@ -300,7 +300,7 @@ defmodule Code.Formatter.OperatorsTest do
 
       good = """
       foo
-      |> bar
+      |> bar()
       """
 
       assert_format bad, good
@@ -518,10 +518,10 @@ defmodule Code.Formatter.OperatorsTest do
     end
 
     test "with required parens" do
-      assert_same "(a |> b) ++ (c |> d)"
+      assert_same "(a |> b()) ++ (c |> d())"
       assert_format "a + b |> c + d", "(a + b) |> (c + d)"
       assert_format "a ++ b |> c ++ d", "(a ++ b) |> (c ++ d)"
-      assert_format "a |> b ++ c |> d", "a |> (b ++ c) |> d"
+      assert_format "a |> b ++ c |> d", "a |> (b ++ c) |> d()"
     end
 
     test "with required parens skips on no parens" do

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -814,66 +814,66 @@ defmodule ExceptionTest do
     import Exception, only: [message: 1]
 
     test "RuntimeError" do
-      assert %RuntimeError{} |> message == "runtime error"
-      assert %RuntimeError{message: "unexpected roquefort"} |> message == "unexpected roquefort"
+      assert %RuntimeError{} |> message() == "runtime error"
+      assert %RuntimeError{message: "unexpected roquefort"} |> message() == "unexpected roquefort"
     end
 
     test "ArithmeticError" do
-      assert %ArithmeticError{} |> message == "bad argument in arithmetic expression"
+      assert %ArithmeticError{} |> message() == "bad argument in arithmetic expression"
 
       assert %ArithmeticError{message: "unexpected camembert"}
-             |> message == "unexpected camembert"
+             |> message() == "unexpected camembert"
     end
 
     test "ArgumentError" do
-      assert %ArgumentError{} |> message == "argument error"
-      assert %ArgumentError{message: "unexpected comté"} |> message == "unexpected comté"
+      assert %ArgumentError{} |> message() == "argument error"
+      assert %ArgumentError{message: "unexpected comté"} |> message() == "unexpected comté"
     end
 
     test "KeyError" do
-      assert %KeyError{} |> message == "key nil not found"
-      assert %KeyError{message: "key missed"} |> message == "key missed"
+      assert %KeyError{} |> message() == "key nil not found"
+      assert %KeyError{message: "key missed"} |> message() == "key missed"
     end
 
     test "Enum.OutOfBoundsError" do
-      assert %Enum.OutOfBoundsError{} |> message == "out of bounds error"
+      assert %Enum.OutOfBoundsError{} |> message() == "out of bounds error"
 
       assert %Enum.OutOfBoundsError{message: "the brie is not on the table"}
-             |> message == "the brie is not on the table"
+             |> message() == "the brie is not on the table"
     end
 
     test "Enum.EmptyError" do
-      assert %Enum.EmptyError{} |> message == "empty error"
+      assert %Enum.EmptyError{} |> message() == "empty error"
 
       assert %Enum.EmptyError{message: "there is no saint-nectaire left!"}
-             |> message == "there is no saint-nectaire left!"
+             |> message() == "there is no saint-nectaire left!"
     end
 
     test "UndefinedFunctionError" do
-      assert %UndefinedFunctionError{} |> message == "undefined function"
+      assert %UndefinedFunctionError{} |> message() == "undefined function"
 
       assert %UndefinedFunctionError{module: Kernel, function: :bar, arity: 1}
-             |> message == "function Kernel.bar/1 is undefined or private"
+             |> message() == "function Kernel.bar/1 is undefined or private"
 
       assert %UndefinedFunctionError{module: Foo, function: :bar, arity: 1}
-             |> message == "function Foo.bar/1 is undefined (module Foo is not available)"
+             |> message() == "function Foo.bar/1 is undefined (module Foo is not available)"
 
       assert %UndefinedFunctionError{module: nil, function: :bar, arity: 3}
-             |> message == "function nil.bar/3 is undefined"
+             |> message() == "function nil.bar/3 is undefined"
 
       assert %UndefinedFunctionError{module: nil, function: :bar, arity: 0}
-             |> message == "function nil.bar/0 is undefined"
+             |> message() == "function nil.bar/0 is undefined"
     end
 
     test "FunctionClauseError" do
-      assert %FunctionClauseError{} |> message == "no function clause matches"
+      assert %FunctionClauseError{} |> message() == "no function clause matches"
 
       assert %FunctionClauseError{module: Foo, function: :bar, arity: 1}
-             |> message == "no function clause matching in Foo.bar/1"
+             |> message() == "no function clause matching in Foo.bar/1"
     end
 
     test "ErlangError" do
-      assert %ErlangError{original: :sample} |> message == "Erlang error: :sample"
+      assert %ErlangError{original: :sample} |> message() == "Erlang error: :sample"
     end
   end
 

--- a/lib/elixir/test/elixir/file_test.exs
+++ b/lib/elixir/test/elixir/file_test.exs
@@ -560,7 +560,7 @@ defmodule FileTest do
 
       try do
         File.touch!(dest)
-        assert File.cp_r(src, dest) |> io_error?
+        assert File.cp_r(src, dest) |> io_error?()
       after
         File.rm_rf(dest)
       end
@@ -686,8 +686,8 @@ defmodule FileTest do
     end
 
     test "cp_r with src dir and dest dir using lists" do
-      src = fixture_path("cp_r") |> to_charlist
-      dest = tmp_path("tmp") |> to_charlist
+      src = fixture_path("cp_r") |> to_charlist()
+      dest = tmp_path("tmp") |> to_charlist()
 
       File.mkdir(dest)
 
@@ -1011,7 +1011,7 @@ defmodule FileTest do
     end
 
     test "mkdir with list" do
-      fixture = tmp_path("tmp_test") |> to_charlist
+      fixture = tmp_path("tmp_test") |> to_charlist()
 
       try do
         refute File.exists?(fixture)
@@ -1082,7 +1082,7 @@ defmodule FileTest do
     end
 
     test "mkdir_p with nested directory and list" do
-      base = tmp_path("tmp_test") |> to_charlist
+      base = tmp_path("tmp_test") |> to_charlist()
       fixture = Path.join(base, "test")
       refute File.exists?(base)
 
@@ -1286,7 +1286,7 @@ defmodule FileTest do
     end
 
     test "rm_rf with charlist" do
-      fixture = tmp_path("tmp") |> to_charlist
+      fixture = tmp_path("tmp") |> to_charlist()
       File.mkdir(fixture)
       File.cp_r!(fixture_path("cp_r"), fixture)
 

--- a/lib/elixir/test/elixir/io/ansi/docs_test.exs
+++ b/lib/elixir/test/elixir/io/ansi/docs_test.exs
@@ -31,7 +31,7 @@ defmodule IO.ANSI.DocsTest do
 
     test "multiple entries formatted" do
       result = format_headings(["foo", "bar"])
-      assert :binary.matches(result, "\e[0m\n\e[7m\e[33m") |> length == 2
+      assert :binary.matches(result, "\e[0m\n\e[7m\e[33m") |> length() == 2
       assert String.starts_with?(result, "\e[0m\n\e[7m\e[33m")
       assert String.ends_with?(result, "\e[0m\n\e[0m")
       assert String.contains?(result, " foo ")

--- a/lib/elixir/test/elixir/kernel/cli_test.exs
+++ b/lib/elixir/test/elixir/kernel/cli_test.exs
@@ -104,7 +104,7 @@ defmodule Kernel.CLITest do
   end
 
   test "properly parses paths" do
-    root = fixture_path("../../..") |> to_charlist
+    root = fixture_path("../../..") |> to_charlist()
 
     args =
       ~c"-pa \"#{root}/*\" -pz \"#{root}/lib/*\" -e \"IO.inspect(:code.get_path(), limit: :infinity)\""
@@ -204,7 +204,7 @@ defmodule Kernel.CLI.AtExitTest do
   use ExUnit.Case, async: true
 
   test "invokes at_exit callbacks" do
-    assert elixir(fixture_path("at_exit.exs") |> to_charlist) ==
+    assert elixir(fixture_path("at_exit.exs") |> to_charlist()) ==
              "goodbye cruel world with status 1\n"
   end
 end

--- a/lib/elixir/test/elixir/kernel/quote_test.exs
+++ b/lib/elixir/test/elixir/kernel/quote_test.exs
@@ -277,14 +277,14 @@ defmodule Kernel.QuoteTest do
 
   test "pipe precedence" do
     assert {:|>, _, [{:|>, _, [{:foo, _, _}, {:bar, _, _}]}, {:baz, _, _}]} =
-             quote(do: foo |> bar |> baz)
+             quote(do: foo |> bar() |> baz())
 
     assert {:|>, _, [{:|>, _, [{:foo, _, _}, {:bar, _, _}]}, {:baz, _, _}]} =
              (quote do
                 foo do
                 end
-                |> bar
-                |> baz
+                |> bar()
+                |> baz()
               end)
 
     assert {:|>, _, [{:|>, _, [{:foo, _, _}, {:bar, _, _}]}, {:baz, _, _}]} =
@@ -292,13 +292,13 @@ defmodule Kernel.QuoteTest do
                 foo
                 |> bar do
                 end
-                |> baz
+                |> baz()
               end)
 
     assert {:|>, _, [{:|>, _, [{:foo, _, _}, {:bar, _, _}]}, {:baz, _, _}]} =
              (quote do
                 foo
-                |> bar
+                |> bar()
                 |> baz do
                 end
               end)
@@ -307,7 +307,7 @@ defmodule Kernel.QuoteTest do
              (quote do
                 foo do
                 end
-                |> bar
+                |> bar()
                 |> baz do
                 end
               end)

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1221,11 +1221,11 @@ defmodule KernelTest do
     end
 
     test "local call" do
-      assert [1, [2], 3] |> List.flatten() |> local == [2, 4, 6]
+      assert [1, [2], 3] |> List.flatten() |> local() == [2, 4, 6]
     end
 
     test "with capture" do
-      assert Enum.map([1, 2, 3], &(&1 |> twice |> twice)) == [4, 8, 12]
+      assert Enum.map([1, 2, 3], &(&1 |> twice() |> twice())) == [4, 8, 12]
     end
 
     test "with anonymous functions" do

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -335,7 +335,7 @@ defmodule MacroTest do
     end
 
     test "with a pipeline on a single line" do
-      {result, formatted} = dbg_format([:a, :b, :c] |> tl() |> tl |> Kernel.hd())
+      {result, formatted} = dbg_format([:a, :b, :c] |> tl() |> tl() |> Kernel.hd())
       assert result == :c
 
       assert formatted =~ "macro_test.exs"
@@ -343,7 +343,7 @@ defmodule MacroTest do
       assert formatted =~ """
              \n[:a, :b, :c] #=> [:a, :b, :c]
              |> tl() #=> [:b, :c]
-             |> tl #=> [:c]
+             |> tl() #=> [:c]
              |> Kernel.hd() #=> :c
              """
 
@@ -357,7 +357,7 @@ defmodule MacroTest do
         dbg_format(
           [:a, :b, :c]
           |> tl()
-          |> tl
+          |> tl()
           |> Kernel.hd()
         )
 
@@ -368,7 +368,7 @@ defmodule MacroTest do
       assert formatted =~ """
              \n[:a, :b, :c] #=> [:a, :b, :c]
              |> tl() #=> [:b, :c]
-             |> tl #=> [:c]
+             |> tl() #=> [:c]
              |> Kernel.hd() #=> :c
              """
 
@@ -1035,8 +1035,10 @@ defmodule MacroTest do
 
   test "unpipe/1" do
     assert Macro.unpipe(quote(do: foo)) == quote(do: [{foo, 0}])
-    assert Macro.unpipe(quote(do: foo |> bar)) == quote(do: [{foo, 0}, {bar, 0}])
-    assert Macro.unpipe(quote(do: foo |> bar |> baz)) == quote(do: [{foo, 0}, {bar, 0}, {baz, 0}])
+    assert Macro.unpipe(quote(do: foo |> bar())) == quote(do: [{foo, 0}, {bar(), 0}])
+
+    assert Macro.unpipe(quote(do: foo |> bar() |> baz())) ==
+             quote(do: [{foo, 0}, {bar(), 0}, {baz(), 0}])
   end
 
   ## traverse/pre/postwalk
@@ -1139,7 +1141,7 @@ defmodule MacroTest do
   test "generate_arguments/2" do
     assert Macro.generate_arguments(0, __MODULE__) == []
     assert Macro.generate_arguments(1, __MODULE__) == [{:arg1, [], __MODULE__}]
-    assert Macro.generate_arguments(4, __MODULE__) |> length == 4
+    assert Macro.generate_arguments(4, __MODULE__) |> length() == 4
   end
 
   defp postwalk(ast) do

--- a/lib/elixir/test/elixir/path_test.exs
+++ b/lib/elixir/test/elixir/path_test.exs
@@ -153,12 +153,12 @@ defmodule PathTest do
   end
 
   test "absname/1,2" do
-    assert Path.absname("/") |> strip_drive_letter_if_windows == "/"
-    assert Path.absname("/foo") |> strip_drive_letter_if_windows == "/foo"
-    assert Path.absname("/./foo") |> strip_drive_letter_if_windows == "/foo"
-    assert Path.absname("/foo/bar") |> strip_drive_letter_if_windows == "/foo/bar"
-    assert Path.absname("/foo/bar/") |> strip_drive_letter_if_windows == "/foo/bar"
-    assert Path.absname("/foo/bar/../bar") |> strip_drive_letter_if_windows == "/foo/bar/../bar"
+    assert Path.absname("/") |> strip_drive_letter_if_windows() == "/"
+    assert Path.absname("/foo") |> strip_drive_letter_if_windows() == "/foo"
+    assert Path.absname("/./foo") |> strip_drive_letter_if_windows() == "/foo"
+    assert Path.absname("/foo/bar") |> strip_drive_letter_if_windows() == "/foo/bar"
+    assert Path.absname("/foo/bar/") |> strip_drive_letter_if_windows() == "/foo/bar"
+    assert Path.absname("/foo/bar/../bar") |> strip_drive_letter_if_windows() == "/foo/bar/../bar"
 
     assert Path.absname("bar", "/foo") == "/foo/bar"
     assert Path.absname("bar/", "/foo") == "/foo/bar"
@@ -184,33 +184,33 @@ defmodule PathTest do
   end
 
   test "expand/1,2" do
-    assert Path.expand("/") |> strip_drive_letter_if_windows == "/"
-    assert Path.expand("/foo/../..") |> strip_drive_letter_if_windows == "/"
-    assert Path.expand("/foo") |> strip_drive_letter_if_windows == "/foo"
-    assert Path.expand("/./foo") |> strip_drive_letter_if_windows == "/foo"
-    assert Path.expand("/../foo") |> strip_drive_letter_if_windows == "/foo"
-    assert Path.expand("/foo/bar") |> strip_drive_letter_if_windows == "/foo/bar"
-    assert Path.expand("/foo/bar/") |> strip_drive_letter_if_windows == "/foo/bar"
-    assert Path.expand("/foo/bar/.") |> strip_drive_letter_if_windows == "/foo/bar"
-    assert Path.expand("/foo/bar/../bar") |> strip_drive_letter_if_windows == "/foo/bar"
+    assert Path.expand("/") |> strip_drive_letter_if_windows() == "/"
+    assert Path.expand("/foo/../..") |> strip_drive_letter_if_windows() == "/"
+    assert Path.expand("/foo") |> strip_drive_letter_if_windows() == "/foo"
+    assert Path.expand("/./foo") |> strip_drive_letter_if_windows() == "/foo"
+    assert Path.expand("/../foo") |> strip_drive_letter_if_windows() == "/foo"
+    assert Path.expand("/foo/bar") |> strip_drive_letter_if_windows() == "/foo/bar"
+    assert Path.expand("/foo/bar/") |> strip_drive_letter_if_windows() == "/foo/bar"
+    assert Path.expand("/foo/bar/.") |> strip_drive_letter_if_windows() == "/foo/bar"
+    assert Path.expand("/foo/bar/../bar") |> strip_drive_letter_if_windows() == "/foo/bar"
 
-    assert Path.expand("bar", "/foo") |> strip_drive_letter_if_windows == "/foo/bar"
-    assert Path.expand("bar/", "/foo") |> strip_drive_letter_if_windows == "/foo/bar"
-    assert Path.expand("bar/.", "/foo") |> strip_drive_letter_if_windows == "/foo/bar"
-    assert Path.expand("bar/../bar", "/foo") |> strip_drive_letter_if_windows == "/foo/bar"
+    assert Path.expand("bar", "/foo") |> strip_drive_letter_if_windows() == "/foo/bar"
+    assert Path.expand("bar/", "/foo") |> strip_drive_letter_if_windows() == "/foo/bar"
+    assert Path.expand("bar/.", "/foo") |> strip_drive_letter_if_windows() == "/foo/bar"
+    assert Path.expand("bar/../bar", "/foo") |> strip_drive_letter_if_windows() == "/foo/bar"
 
     drive_letter =
-      Path.expand("../bar/../bar", "/foo/../foo/../foo") |> strip_drive_letter_if_windows
+      Path.expand("../bar/../bar", "/foo/../foo/../foo") |> strip_drive_letter_if_windows()
 
     assert drive_letter == "/bar"
 
     drive_letter =
       Path.expand([~c"..", ?/, "bar/../bar"], ~c"/foo/../foo/../foo")
-      |> strip_drive_letter_if_windows
+      |> strip_drive_letter_if_windows()
 
     assert "/bar" == drive_letter
 
-    assert Path.expand("/..") |> strip_drive_letter_if_windows == "/"
+    assert Path.expand("/..") |> strip_drive_letter_if_windows() == "/"
 
     assert Path.expand("bar/../bar", "foo") == Path.expand("foo/bar")
   end

--- a/lib/elixir/test/elixir/uri_test.exs
+++ b/lib/elixir/test/elixir/uri_test.exs
@@ -328,75 +328,77 @@ defmodule URITest do
     end
 
     assert URI.merge("http://google.com/foo", "http://example.com/baz")
-           |> to_string == "http://example.com/baz"
+           |> to_string() == "http://example.com/baz"
 
     assert URI.merge("http://google.com/foo", "http://example.com/.././bar/../../baz")
-           |> to_string == "http://example.com/baz"
+           |> to_string() == "http://example.com/baz"
 
     assert URI.merge("http://google.com/foo", "//example.com/baz")
-           |> to_string == "http://example.com/baz"
+           |> to_string() == "http://example.com/baz"
 
     assert URI.merge("http://google.com/foo", "//example.com/.././bar/../../../baz")
-           |> to_string == "http://example.com/baz"
+           |> to_string() == "http://example.com/baz"
 
     assert URI.merge("http://example.com", URI.new!("/foo"))
-           |> to_string == "http://example.com/foo"
+           |> to_string() == "http://example.com/foo"
 
     assert URI.merge("http://example.com", URI.new!("/.././bar/../../../baz"))
-           |> to_string == "http://example.com/baz"
+           |> to_string() == "http://example.com/baz"
 
     base = URI.new!("http://example.com/foo/bar")
-    assert URI.merge(base, "") |> to_string == "http://example.com/foo/bar"
-    assert URI.merge(base, "#fragment") |> to_string == "http://example.com/foo/bar#fragment"
-    assert URI.merge(base, "?query") |> to_string == "http://example.com/foo/bar?query"
-    assert URI.merge(base, %URI{}) |> to_string == "http://example.com/foo/bar"
+    assert URI.merge(base, "") |> to_string() == "http://example.com/foo/bar"
+    assert URI.merge(base, "#fragment") |> to_string() == "http://example.com/foo/bar#fragment"
+    assert URI.merge(base, "?query") |> to_string() == "http://example.com/foo/bar?query"
+    assert URI.merge(base, %URI{}) |> to_string() == "http://example.com/foo/bar"
 
     assert URI.merge(base, %URI{fragment: "fragment"})
-           |> to_string == "http://example.com/foo/bar#fragment"
+           |> to_string() == "http://example.com/foo/bar#fragment"
 
     base = URI.new!("http://example.com")
-    assert URI.merge(base, "/foo") |> to_string == "http://example.com/foo"
-    assert URI.merge(base, "foo") |> to_string == "http://example.com/foo"
+    assert URI.merge(base, "/foo") |> to_string() == "http://example.com/foo"
+    assert URI.merge(base, "foo") |> to_string() == "http://example.com/foo"
 
     base = URI.new!("http://example.com/foo/bar")
-    assert URI.merge(base, "/baz") |> to_string == "http://example.com/baz"
-    assert URI.merge(base, "baz") |> to_string == "http://example.com/foo/baz"
-    assert URI.merge(base, "../baz") |> to_string == "http://example.com/baz"
-    assert URI.merge(base, ".././baz") |> to_string == "http://example.com/baz"
-    assert URI.merge(base, "./baz") |> to_string == "http://example.com/foo/baz"
-    assert URI.merge(base, "bar/./baz") |> to_string == "http://example.com/foo/bar/baz"
+    assert URI.merge(base, "/baz") |> to_string() == "http://example.com/baz"
+    assert URI.merge(base, "baz") |> to_string() == "http://example.com/foo/baz"
+    assert URI.merge(base, "../baz") |> to_string() == "http://example.com/baz"
+    assert URI.merge(base, ".././baz") |> to_string() == "http://example.com/baz"
+    assert URI.merge(base, "./baz") |> to_string() == "http://example.com/foo/baz"
+    assert URI.merge(base, "bar/./baz") |> to_string() == "http://example.com/foo/bar/baz"
 
     base = URI.new!("http://example.com/foo/bar/")
-    assert URI.merge(base, "/baz") |> to_string == "http://example.com/baz"
-    assert URI.merge(base, "baz") |> to_string == "http://example.com/foo/bar/baz"
-    assert URI.merge(base, "../baz") |> to_string == "http://example.com/foo/baz"
-    assert URI.merge(base, ".././baz") |> to_string == "http://example.com/foo/baz"
-    assert URI.merge(base, "./baz") |> to_string == "http://example.com/foo/bar/baz"
-    assert URI.merge(base, "bar/./baz") |> to_string == "http://example.com/foo/bar/bar/baz"
+    assert URI.merge(base, "/baz") |> to_string() == "http://example.com/baz"
+    assert URI.merge(base, "baz") |> to_string() == "http://example.com/foo/bar/baz"
+    assert URI.merge(base, "../baz") |> to_string() == "http://example.com/foo/baz"
+    assert URI.merge(base, ".././baz") |> to_string() == "http://example.com/foo/baz"
+    assert URI.merge(base, "./baz") |> to_string() == "http://example.com/foo/bar/baz"
+    assert URI.merge(base, "bar/./baz") |> to_string() == "http://example.com/foo/bar/bar/baz"
 
     base = URI.new!("http://example.com/foo/bar/baz")
-    assert URI.merge(base, "../../foobar") |> to_string == "http://example.com/foobar"
-    assert URI.merge(base, "../../../foobar") |> to_string == "http://example.com/foobar"
-    assert URI.merge(base, "../../../../../../foobar") |> to_string == "http://example.com/foobar"
+    assert URI.merge(base, "../../foobar") |> to_string() == "http://example.com/foobar"
+    assert URI.merge(base, "../../../foobar") |> to_string() == "http://example.com/foobar"
+
+    assert URI.merge(base, "../../../../../../foobar") |> to_string() ==
+             "http://example.com/foobar"
 
     base = URI.new!("http://example.com/foo/../bar")
-    assert URI.merge(base, "baz") |> to_string == "http://example.com/baz"
+    assert URI.merge(base, "baz") |> to_string() == "http://example.com/baz"
 
     base = URI.new!("http://example.com/foo/./bar")
-    assert URI.merge(base, "baz") |> to_string == "http://example.com/foo/baz"
+    assert URI.merge(base, "baz") |> to_string() == "http://example.com/foo/baz"
 
     base = URI.new!("http://example.com/foo?query1")
-    assert URI.merge(base, "?query2") |> to_string == "http://example.com/foo?query2"
-    assert URI.merge(base, "") |> to_string == "http://example.com/foo?query1"
+    assert URI.merge(base, "?query2") |> to_string() == "http://example.com/foo?query2"
+    assert URI.merge(base, "") |> to_string() == "http://example.com/foo?query1"
 
     base = URI.new!("http://example.com/foo#fragment1")
-    assert URI.merge(base, "#fragment2") |> to_string == "http://example.com/foo#fragment2"
-    assert URI.merge(base, "") |> to_string == "http://example.com/foo"
+    assert URI.merge(base, "#fragment2") |> to_string() == "http://example.com/foo#fragment2"
+    assert URI.merge(base, "") |> to_string() == "http://example.com/foo"
 
     page_url = "https://example.com/guide/"
     image_url = "https://images.example.com/t/1600x/https://images.example.com/foo.jpg"
 
-    assert URI.merge(URI.new!(page_url), URI.new!(image_url)) |> to_string ==
+    assert URI.merge(URI.new!(page_url), URI.new!(image_url)) |> to_string() ==
              "https://images.example.com/t/1600x/https://images.example.com/foo.jpg"
   end
 
@@ -693,8 +695,8 @@ defmodule URITest do
 
     test "merges empty path" do
       base = URI.parse("http://example.com")
-      assert URI.merge(base, "/foo") |> to_string == "http://example.com/foo"
-      assert URI.merge(base, "foo") |> to_string == "http://example.com/foo"
+      assert URI.merge(base, "/foo") |> to_string() == "http://example.com/foo"
+      assert URI.merge(base, "foo") |> to_string() == "http://example.com/foo"
     end
   end
 end

--- a/lib/iex/lib/iex/helpers.ex
+++ b/lib/iex/lib/iex/helpers.ex
@@ -549,13 +549,13 @@ defmodule IEx.Helpers do
   def runtime_info(topic) when is_atom(topic) and topic in @runtime_info_topics do
     topic
     |> List.wrap()
-    |> runtime_info
+    |> runtime_info()
   end
 
   def runtime_info(topics) when is_list(topics) do
     topics
     |> Enum.uniq()
-    |> print_runtime_info
+    |> print_runtime_info()
   end
 
   defp print_runtime_info(topics) do

--- a/lib/mix/lib/mix/tasks/compile.ex
+++ b/lib/mix/lib/mix/tasks/compile.ex
@@ -170,7 +170,7 @@ defmodule Mix.Tasks.Compile do
   end
 
   defp first_line(doc) do
-    String.split(doc, "\n", parts: 2) |> hd |> String.trim() |> String.trim_trailing(".")
+    String.split(doc, "\n", parts: 2) |> hd() |> String.trim() |> String.trim_trailing(".")
   end
 
   defp merge_diagnostics({status1, diagnostics1}, {status2, diagnostics2}) do

--- a/lib/mix/lib/mix/tasks/deps.loadpaths.ex
+++ b/lib/mix/lib/mix/tasks/deps.loadpaths.ex
@@ -87,7 +87,7 @@ defmodule Mix.Tasks.Deps.Loadpaths do
         |> Enum.map(& &1.app)
         |> Mix.Dep.filter_by_name(Mix.Dep.load_and_cache())
         |> Enum.filter(&(not Mix.Dep.ok?(&1)))
-        |> show_not_ok!
+        |> show_not_ok!()
     end
   end
 

--- a/lib/mix/lib/mix/utils.ex
+++ b/lib/mix/lib/mix/utils.ex
@@ -308,7 +308,7 @@ defmodule Mix.Utils do
   end
 
   defp depth(_pretty?, []), do: ""
-  defp depth(pretty?, depth), do: Enum.reverse(depth) |> tl |> Enum.map(&entry(pretty?, &1))
+  defp depth(pretty?, depth), do: Enum.reverse(depth) |> tl() |> Enum.map(&entry(pretty?, &1))
 
   defp entry(false, true), do: "|   "
   defp entry(false, false), do: "    "


### PR DESCRIPTION
Is there a reason why local calls in pipes are not formatted with `()`?

```elixir
:example
|> foo
|> Bar.baz
```

gets formatted to
```elixir
:example
|> foo
|> Bar.baz()
```

I understand for normal calls, there is an ambiguity with variables and so we can't statically know if `foo` is actually a variable or a function call, but for pipes that's not the case.

Or is it because of the exception `defmacro foo |> bar`, the only tricky exception that probably only matters for Elixir itself?

This PR adds such a formatting, although I am not 100% positive of the implementation to allow the `defmacro` edge case. It currently has a defect whereby guards to `def` don't have the parenthesis added, but that could be addressed if needed.

I hesitate to mention it as I don't really think we should care, but I noticed that local calls in pipes respects `locals_without_parens`, but with the wrong arity:


```elixir
# This passes
assert_same ":x |> foo bar", locals_without_parens: [foo: 1]
assert_format ":x |> foo bar", ":x |> foo(bar)", locals_without_parens: [foo: 2]
```

This PR does not consider `locals_without_parens`, but it would be easy to add. Should it?