### PR TITLE
Automatically install Hex and Rebar on deps.get/deps.update

### DIFF
--- a/lib/mix/lib/mix/dep/converger.ex
+++ b/lib/mix/lib/mix/dep/converger.ex
@@ -77,11 +77,11 @@ defmodule Mix.Dep.Converger do
   end
 
   defp all(acc, lock, opts, callback) do
-    main = Mix.Dep.Loader.children()
+    lock_given? = !!lock
+
+    main = Mix.Dep.Loader.children(lock_given?)
     main = Enum.map(main, &%{&1 | top_level: true})
     apps = Enum.map(main, & &1.app)
-
-    lock_given? = !!lock
     env_target = {opts[:env], opts[:target]}
 
     # If no lock was given, let's read one to fill in the deps
@@ -92,7 +92,7 @@ defmodule Mix.Dep.Converger do
     # lazily loaded, we need to check for it on every
     # iteration.
     {deps, acc, lock} =
-      all(main, apps, callback, acc, lock, env_target, fn dep ->
+      all(main, apps, callback, acc, lock_given?, lock, env_target, fn dep ->
         if (remote = Mix.RemoteConverger.get()) && remote.remote?(dep) do
           {:loaded, dep}
         else
@@ -128,7 +128,7 @@ defmodule Mix.Dep.Converger do
       # which is potentially stale. So remote.deps/2 needs to always
       # check if the data it finds in the lock is actually valid.
       {deps, acc, lock} =
-        all(main, apps, callback, acc, lock, env_target, fn dep ->
+        all(main, apps, callback, acc, lock_given?, lock, env_target, fn dep ->
           if cached = cache[{dep.app, dep.scm}] do
             {:loaded, cached}
           else
@@ -142,8 +142,8 @@ defmodule Mix.Dep.Converger do
     end
   end
 
-  defp all(main, apps, callback, rest, lock, env_target, cache) do
-    {deps, rest, lock} = all(main, [], [], apps, callback, rest, lock, env_target, cache)
+  defp all(main, apps, callback, rest, locked?, lock, env_target, cache) do
+    {deps, rest, lock} = all(main, [], [], apps, callback, rest, locked?, lock, env_target, cache)
     deps = Enum.reverse(deps)
     # When traversing dependencies, we keep skipped ones to
     # find conflicts. We remove them now after traversal.
@@ -190,18 +190,18 @@ defmodule Mix.Dep.Converger do
   # Now, since "d" was specified in a parent project, no
   # exception is going to be raised since d is considered
   # to be the authoritative source.
-  defp all([dep | t], acc, upper_breadths, breadths, callback, rest, lock, env_target, cache) do
-    case match_deps(acc, upper_breadths, dep, env_target) do
+  defp all([dep | t], acc, upper, breadths, callback, rest, locked?, lock, env_target, cache) do
+    case match_deps(acc, upper, dep, env_target) do
       {:replace, dep, acc} ->
-        all([dep | t], acc, upper_breadths, breadths, callback, rest, lock, env_target, cache)
+        all([dep | t], acc, upper, breadths, callback, rest, locked?, lock, env_target, cache)
 
       {:match, acc} ->
-        all(t, acc, upper_breadths, breadths, callback, rest, lock, env_target, cache)
+        all(t, acc, upper, breadths, callback, rest, locked?, lock, env_target, cache)
 
       :skip ->
         # We still keep skipped dependencies around to detect conflicts.
         # They must be rejected after every all iteration.
-        all(t, [dep | acc], upper_breadths, breadths, callback, rest, lock, env_target, cache)
+        all(t, [dep | acc], upper, breadths, callback, rest, locked?, lock, env_target, cache)
 
       :nomatch ->
         {dep, rest, lock} =
@@ -216,21 +216,21 @@ defmodule Mix.Dep.Converger do
                 # After we invoke the callback (which may actually check out the
                 # dependency), we load the dependency including its latest info
                 # and children information.
-                {Mix.Dep.Loader.load(dep, children), rest, lock}
+                {Mix.Dep.Loader.load(dep, children, locked?), rest, lock}
               end)
           end
 
         {acc, rest, lock} =
-          all(t, [dep | acc], upper_breadths, breadths, callback, rest, lock, env_target, cache)
+          all(t, [dep | acc], upper, breadths, callback, rest, locked?, lock, env_target, cache)
 
         umbrella? = dep.opts[:from_umbrella]
         deps = reject_non_fulfilled_optional(dep.deps, Enum.map(acc, & &1.app), umbrella?)
         new_breadths = Enum.map(deps, & &1.app) ++ breadths
-        all(deps, acc, breadths, new_breadths, callback, rest, lock, env_target, cache)
+        all(deps, acc, breadths, new_breadths, callback, rest, locked?, lock, env_target, cache)
     end
   end
 
-  defp all([], acc, _upper, _current, _callback, rest, lock, _env_target, _cache) do
+  defp all([], acc, _upper, _current, _callback, rest, _locked?, lock, _env_target, _cache) do
     {acc, rest, lock}
   end
 

--- a/lib/mix/lib/mix/dep/umbrella.ex
+++ b/lib/mix/lib/mix/dep/umbrella.ex
@@ -59,7 +59,7 @@ defmodule Mix.Dep.Umbrella do
     apps = Enum.map(deps, & &1.app)
 
     Enum.map(deps, fn umbrella_dep ->
-      umbrella_dep = Mix.Dep.Loader.load(umbrella_dep, nil)
+      umbrella_dep = Mix.Dep.Loader.load(umbrella_dep, nil, false)
 
       deps =
         Enum.filter(umbrella_dep.deps, fn dep ->

--- a/lib/mix/lib/mix/hex.ex
+++ b/lib/mix/lib/mix/hex.ex
@@ -5,25 +5,26 @@ defmodule Mix.Hex do
   @hex_mirror "https://repo.hex.pm"
 
   @doc """
-  Returns `true` if `Hex` is loaded or installed. Otherwise returns `false`.
+  Returns `true` if `Hex` is loaded or installed.
+
+  Otherwise returns `false`.
   """
-  @spec ensure_installed?(atom) :: boolean
-  def ensure_installed?(app) do
-    if Code.ensure_loaded?(Hex) do
-      true
-    else
-      shell = Mix.shell()
-      shell.info("Could not find Hex, which is needed to build dependency #{inspect(app)}")
-
-      confirm_message =
-        "Shall I install Hex? (if running non-interactively, use \"mix local.hex --force\")"
-
-      if shell.yes?(confirm_message) do
-        Mix.Tasks.Local.Hex.run(["--force"])
-      else
-        false
-      end
+  @spec ensure_installed?(boolean) :: boolean
+  def ensure_installed?(force?) do
+    cond do
+      Code.ensure_loaded?(Hex) -> true
+      force? or install_hex?() -> Mix.Tasks.Local.Hex.run(["--force"])
+      true -> false
     end
+  end
+
+  defp install_hex? do
+    shell = Mix.shell()
+    shell.info("Mix requires the Hex package manager to fetch dependencies")
+
+    shell.yes?(
+      "Shall I install Hex? (if running non-interactively, use \"mix local.hex --force\")"
+    )
   end
 
   @doc """

--- a/lib/mix/lib/mix/tasks/deps.compile.ex
+++ b/lib/mix/lib/mix/tasks/deps.compile.ex
@@ -247,8 +247,6 @@ defmodule Mix.Tasks.Deps.Compile do
       "Could not find \"#{manager}\", which is needed to build dependency #{inspect(app)}"
     )
 
-    shell.info("I can install a local copy which is just used by Mix")
-
     install_question =
       "Shall I install #{manager}? (if running non-interactively, " <>
         "use \"mix local.rebar --force\")"
@@ -261,8 +259,8 @@ defmodule Mix.Tasks.Deps.Compile do
       Mix.raise(error_message)
     end
 
-    (Mix.Tasks.Local.Rebar.run([]) && Mix.Rebar.local_rebar_cmd(manager)) ||
-      Mix.raise("\"#{manager}\" installation failed")
+    Mix.Tasks.Local.Rebar.run(["--force"])
+    Mix.Rebar.local_rebar_cmd(manager) || Mix.raise("\"#{manager}\" installation failed")
   end
 
   defp do_make(dep, config) do


### PR DESCRIPTION
The user is already fetching external packages,
so it is ok for us to install those too and improve
the user experience.

Other commands such as `mix deps.compile` will still
prompt.

Closes #12086.