### PR TITLE
Extend trace test (result incorrect)

### DIFF
--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -235,6 +235,7 @@ defmodule Mix.Tasks.XrefTest do
           defstruct [:foo, :bar]
           defmacro macro, do: :ok
           def fun, do: :ok
+          @callback foo() :: integer
         end
         """,
         "lib/b.ex" => ~S"""
@@ -247,6 +248,9 @@ defmodule Mix.Tasks.XrefTest do
           def calls_macro, do: A.macro()
           def calls_fun, do: A.fun()
           def calls_struct, do: %A{}
+          @behaviour A
+          @impl true
+          def foo, do: 42
         end
         """
       }
@@ -254,6 +258,7 @@ defmodule Mix.Tasks.XrefTest do
       output = """
       Compiling 2 files (.ex)
       Generated sample app
+      lib/b.ex:1: require A (compile)
       lib/b.ex:2: require A (export)
       lib/b.ex:3: call A.macro/0 (compile)
       lib/b.ex:4: import A.macro/0 (compile)


### PR DESCRIPTION
I'm almost done with tweaking the way we handle `@behaviour` references. Only need to make the reference `runtime` instead of `compile`. The code re-uses `:elixir_env.trace({:require, ...`, I'm thinking it would be better to have a dedicated `:elixir_env.trace({:behaviour`, no?

Anyways, I realized that the current tracing information is incorrect (ideally the line should correspond to the `@behaviour` statement, not to the `defmodule`)

I was trying to look at where the `:behaviour` were accumulated in the bag (to add the line references) but didn't find it 🤔...