### PR TITLE
Better `mix format` doc wording

### DIFF
--- a/lib/mix/lib/mix/tasks/format.ex
+++ b/lib/mix/lib/mix/tasks/format.ex
@@ -8,8 +8,8 @@ defmodule Mix.Tasks.Format do
 
       mix format mix.exs "lib/**/*.{ex,exs}" "test/**/*.{ex,exs}"
 
-  If any of the files is `-`, then the output is read from stdin
-  and written to stdout.
+  If any of the files is `-`, then the input is read from stdin and the output
+  is written to stdout.
 
   ## Formatting options
 


### PR DESCRIPTION
Low-hanging fruit but help avoid confusion 🙈 

Documentation for `mix format` points that when `-` is passed, _output_ is read from stdin instead of _input_.