### PR TITLE
Handle syntax_colors in quoted_to_algebra and dbg

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -1166,6 +1166,9 @@ defmodule Code do
       The arity may be the atom `:*`, which implies all arities of
       that name. The formatter already includes a list of functions
       and this option augments this list.
+
+    * `:syntax_colors` - a keyword list of colors the output is colorized.
+      See `Inspect.Opts` for more information.
   """
   @doc since: "1.13.0"
   @spec quoted_to_algebra(Macro.t(), keyword) :: Inspect.Algebra.t()

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -1008,7 +1008,7 @@ defmodule Code.Formatter do
     {target_doc, state} = remote_target_to_algebra(target, state)
 
     fun_doc =
-      Macro.inspect_atom(:remote_call, fun) |> string() |> color(:function, state.inspect_opts)
+      Macro.inspect_atom(:remote_call, fun) |> string() |> color(:call, state.inspect_opts)
 
     remote_doc = target_doc |> concat(".") |> concat(fun_doc)
 
@@ -1076,7 +1076,7 @@ defmodule Code.Formatter do
       fun
       |> Atom.to_string()
       |> string()
-      |> color(:function, state.inspect_opts)
+      |> color(:call, state.inspect_opts)
       |> concat(call_doc)
 
     doc = if wrap_in_parens?, do: wrap_in_parens(doc), else: doc

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -283,7 +283,7 @@ defmodule Code.Formatter do
   end
 
   defp quoted_to_algebra({var, _meta, var_context}, _context, state) when is_atom(var_context) do
-    {var |> Atom.to_string() |> string(), state}
+    {var |> Atom.to_string() |> string() |> color(:variable, state.inspect_opts), state}
   end
 
   defp quoted_to_algebra({:<<>>, meta, entries}, _context, state) do
@@ -403,24 +403,33 @@ defmodule Code.Formatter do
   defp quoted_to_algebra({:__block__, meta, [string]}, _context, state) when is_binary(string) do
     if meta[:delimiter] == ~s["""] do
       string = escape_heredoc(string, ~s["""])
-      {@double_heredoc |> concat(string) |> concat(@double_heredoc) |> force_unfit(), state}
+
+      {@double_heredoc
+       |> concat(string)
+       |> concat(@double_heredoc)
+       |> color(:string, state.inspect_opts)
+       |> force_unfit(), state}
     else
       string = escape_string(string, @double_quote)
-      {@double_quote |> concat(string) |> concat(@double_quote), state}
+
+      {@double_quote
+       |> concat(string)
+       |> concat(@double_quote)
+       |> color(:string, state.inspect_opts), state}
     end
   end
 
   defp quoted_to_algebra({:__block__, meta, [atom]}, _context, state) when is_atom(atom) do
-    {atom_to_algebra(atom, meta), state}
+    {atom_to_algebra(atom, meta, state.inspect_opts), state}
   end
 
   defp quoted_to_algebra({:__block__, meta, [integer]}, _context, state)
        when is_integer(integer) do
-    {integer_to_algebra(Keyword.fetch!(meta, :token), state.inspect_opts), state}
+    {Keyword.fetch!(meta, :token) |> integer_to_algebra(state.inspect_opts), state}
   end
 
   defp quoted_to_algebra({:__block__, meta, [float]}, _context, state) when is_float(float) do
-    {float_to_algebra(Keyword.fetch!(meta, :token)), state}
+    {Keyword.fetch!(meta, :token) |> float_to_algebra(state.inspect_opts), state}
   end
 
   defp quoted_to_algebra(
@@ -437,7 +446,7 @@ defmodule Code.Formatter do
   end
 
   defp quoted_to_algebra({:__block__, _meta, []}, _context, state) do
-    {"nil", state}
+    {color("nil", nil, state.inspect_opts), state}
   end
 
   defp quoted_to_algebra({:__block__, meta, _} = block, _context, state) do
@@ -453,7 +462,8 @@ defmodule Code.Formatter do
         quoted_to_algebra_with_parens_if_operator(head, context, state)
       end
 
-    {Enum.reduce(tail, doc, &concat(&2, "." <> Atom.to_string(&1))), state}
+    {Enum.reduce(tail, doc, &concat(&2, "." <> Atom.to_string(&1)))
+     |> color(:atom, state.inspect_opts), state}
   end
 
   # &1
@@ -535,7 +545,7 @@ defmodule Code.Formatter do
                   IO.iodata_to_binary([?", Atom.to_string(atom), ?", ?:])
                 end
 
-              {string(key), state}
+              {string(key) |> color(:atom, state.inspect_opts), state}
 
             {{:., _, [:erlang, :binary_to_atom]}, _, [{:<<>>, _, entries}, :utf8]} ->
               interpolation_to_algebra(entries, @double_quote, state, "\"", "\":")
@@ -630,7 +640,7 @@ defmodule Code.Formatter do
         Atom.to_string(op)
       end
 
-    {concat(op_string, doc), state}
+    {color(op_string, :operator, state.inspect_opts) |> concat(doc), state}
   end
 
   defp maybe_binary_op_to_algebra(fun, meta, args, context, state) do
@@ -736,11 +746,12 @@ defmodule Code.Formatter do
     doc =
       cond do
         op in @no_space_binary_operators ->
-          concat(concat(group(left), op_string), group(right))
+          op_doc = color(op_string, :operator, state.inspect_opts)
+          concat(concat(group(left), op_doc), group(right))
 
         op in @no_newline_binary_operators ->
-          op_string = " " <> op_string <> " "
-          concat(concat(group(left), op_string), group(right))
+          op_doc = color(" " <> op_string <> " ", :operator, state.inspect_opts)
+          concat(concat(group(left), op_doc), group(right))
 
         true ->
           eol? = eol?(meta, state)
@@ -749,8 +760,8 @@ defmodule Code.Formatter do
             op in @next_break_fits_operators and next_break_fits?(right_arg, state) and not eol?
 
           with_next_break_fits(next_break_fits?, right, fn right ->
-            op_string = " " <> op_string
-            right = nest(glue(op_string, group(right)), nesting, :break)
+            op_doc = color(" " <> op_string, :operator, state.inspect_opts)
+            right = nest(glue(op_doc, group(right)), nesting, :break)
             right = if eol?, do: force_unfit(right), else: right
             concat(group(left), group(right))
           end)
@@ -995,8 +1006,11 @@ defmodule Code.Formatter do
   defp remote_to_algebra({{:., _, [target, fun]}, meta, args}, context, state)
        when is_atom(fun) do
     {target_doc, state} = remote_target_to_algebra(target, state)
-    fun = Macro.inspect_atom(:remote_call, fun)
-    remote_doc = target_doc |> concat(".") |> concat(string(fun))
+
+    fun_doc =
+      Macro.inspect_atom(:remote_call, fun) |> string() |> color(:function, state.inspect_opts)
+
+    remote_doc = target_doc |> concat(".") |> concat(fun_doc)
 
     if args == [] and not remote_target_is_a_module?(target) and not meta?(meta, :closing) do
       {remote_doc, state}
@@ -1062,6 +1076,7 @@ defmodule Code.Formatter do
       fun
       |> Atom.to_string()
       |> string()
+      |> color(:function, state.inspect_opts)
       |> concat(call_doc)
 
     doc = if wrap_in_parens?, do: wrap_in_parens(doc), else: doc
@@ -1489,7 +1504,10 @@ defmodule Code.Formatter do
     {args_doc, _join, state} =
       args_to_algebra_with_comments(args, meta, false, :none, join, state, fun)
 
-    {surround("[", args_doc, "]"), state}
+    left_bracket = color("[", :list, state.inspect_opts)
+    right_bracket = color("]", :list, state.inspect_opts)
+
+    {surround(left_bracket, args_doc, right_bracket), state}
   end
 
   defp map_to_algebra(meta, name_doc, [{:|, _, [left, right]}], state) do
@@ -1505,8 +1523,7 @@ defmodule Code.Formatter do
       |> wrap_in_parens_if_binary_operator(left)
       |> glue(concat("| ", nest(right_doc, 2)))
 
-    name_doc = "%" |> concat(name_doc) |> concat("{")
-    {surround(name_doc, args_doc, "}"), state}
+    do_map_to_algebra(name_doc, args_doc, state)
   end
 
   defp map_to_algebra(meta, name_doc, args, state) do
@@ -1516,8 +1533,12 @@ defmodule Code.Formatter do
     {args_doc, _join, state} =
       args_to_algebra_with_comments(args, meta, false, :none, join, state, fun)
 
-    name_doc = "%" |> concat(name_doc) |> concat("{")
-    {surround(name_doc, args_doc, "}"), state}
+    do_map_to_algebra(name_doc, args_doc, state)
+  end
+
+  defp do_map_to_algebra(name_doc, args_doc, state) do
+    name_doc = "%" |> concat(name_doc) |> concat("{") |> color(:map, state.inspect_opts)
+    {surround(name_doc, args_doc, color("}", :map, state.inspect_opts)), state}
   end
 
   defp tuple_to_algebra(meta, args, join, state) do
@@ -1527,23 +1548,30 @@ defmodule Code.Formatter do
     {args_doc, join, state} =
       args_to_algebra_with_comments(args, meta, false, :none, join, state, fun)
 
+    left_bracket = color("{", :tuple, state.inspect_opts)
+    right_bracket = color("}", :tuple, state.inspect_opts)
+
     if join == :flex_break do
-      {"{" |> concat(args_doc) |> nest(1) |> concat("}") |> group(), state}
+      {left_bracket |> concat(args_doc) |> nest(1) |> concat(right_bracket) |> group(), state}
     else
-      {surround("{", args_doc, "}"), state}
+      {surround(left_bracket, args_doc, right_bracket), state}
     end
   end
 
-  defp atom_to_algebra(atom, _) when atom in [nil, true, false] do
-    Atom.to_string(atom)
+  defp atom_to_algebra(atom, _, inspect_opts) when atom in [true, false] do
+    Atom.to_string(atom) |> color(:boolean, inspect_opts)
+  end
+
+  defp atom_to_algebra(nil, _, inspect_opts) do
+    Atom.to_string(nil) |> color(nil, inspect_opts)
   end
 
   # TODO: Remove this clause in v1.16 when we no longer quote operator :..//
-  defp atom_to_algebra(:"..//", _) do
-    string(":\"..//\"")
+  defp atom_to_algebra(:"..//", _, inspect_opts) do
+    string(":\"..//\"") |> color(:atom, inspect_opts)
   end
 
-  defp atom_to_algebra(:\\, meta) do
+  defp atom_to_algebra(:\\, meta, inspect_opts) do
     # Since we parse strings without unescaping, the atoms
     # :\\ and :"\\" have the same representation, so we need
     # to check the delimiter and handle them accordingly.
@@ -1553,10 +1581,10 @@ defmodule Code.Formatter do
         _ -> ":\\\\"
       end
 
-    string(string)
+    string(string) |> color(:atom, inspect_opts)
   end
 
-  defp atom_to_algebra(atom, _) do
+  defp atom_to_algebra(atom, _, inspect_opts) do
     string = Atom.to_string(atom)
 
     iodata =
@@ -1566,7 +1594,7 @@ defmodule Code.Formatter do
         [?:, ?", String.replace(string, "\"", "\\\""), ?"]
       end
 
-    iodata |> IO.iodata_to_binary() |> string()
+    iodata |> IO.iodata_to_binary() |> string() |> color(:atom, inspect_opts)
   end
 
   defp integer_to_algebra(text, inspect_otps) do
@@ -1586,10 +1614,12 @@ defmodule Code.Formatter do
     |> color(:number, inspect_otps)
   end
 
-  defp float_to_algebra(text) do
+  defp float_to_algebra(text, inspect_otps) do
     [int_part, decimal_part] = :binary.split(text, ".")
     decimal_part = String.downcase(decimal_part)
-    insert_underscores(int_part) <> "." <> decimal_part
+
+    string = insert_underscores(int_part) <> "." <> decimal_part
+    color(string, :number, inspect_otps)
   end
 
   defp insert_underscores(digits) do

--- a/lib/elixir/lib/code/formatter.ex
+++ b/lib/elixir/lib/code/formatter.ex
@@ -201,6 +201,7 @@ defmodule Code.Formatter do
     sigils = Keyword.get(opts, :sigils, [])
     normalize_bitstring_modifiers = Keyword.get(opts, :normalize_bitstring_modifiers, true)
     charlists_as_sigils = Keyword.get(opts, :charlists_as_sigils, true)
+    syntax_colors = Keyword.get(opts, :syntax_colors, [])
 
     sigils =
       Map.new(sigils, fn {key, value} ->
@@ -225,7 +226,8 @@ defmodule Code.Formatter do
       sigils: sigils,
       file: file,
       normalize_bitstring_modifiers: normalize_bitstring_modifiers,
-      charlists_as_sigils: charlists_as_sigils
+      charlists_as_sigils: charlists_as_sigils,
+      inspect_opts: %Inspect.Opts{syntax_colors: syntax_colors}
     }
   end
 
@@ -414,7 +416,7 @@ defmodule Code.Formatter do
 
   defp quoted_to_algebra({:__block__, meta, [integer]}, _context, state)
        when is_integer(integer) do
-    {integer_to_algebra(Keyword.fetch!(meta, :token)), state}
+    {integer_to_algebra(Keyword.fetch!(meta, :token), state.inspect_opts), state}
   end
 
   defp quoted_to_algebra({:__block__, meta, [float]}, _context, state) when is_float(float) do
@@ -1567,7 +1569,7 @@ defmodule Code.Formatter do
     iodata |> IO.iodata_to_binary() |> string()
   end
 
-  defp integer_to_algebra(text) do
+  defp integer_to_algebra(text, inspect_otps) do
     case text do
       <<?0, ?x, rest::binary>> ->
         "0x" <> String.upcase(rest)
@@ -1581,6 +1583,7 @@ defmodule Code.Formatter do
       decimal ->
         insert_underscores(decimal)
     end
+    |> color(:number, inspect_otps)
   end
 
   defp float_to_algebra(text) do

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -63,7 +63,7 @@ defmodule Inspect.Opts do
       each type (for example, `[number: :red, atom: :blue]`). Types can include
       `:atom`, `:binary`, `:boolean`, `:list`, `:map`, `:number`, `:regex`,
       `:string`, `:tuple`, or some types to represent AST like `:variable`,
-      `:function` and `:operator`.
+      `:call`, and `:operator`.
       Custom data types may provide their own options.
       Colors can be any `t:IO.ANSI.ansidata/0` as accepted by `IO.ANSI.format/1`.
       A default list of colors can be retrieved from `IO.ANSI.syntax_colors/0`.

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -62,7 +62,9 @@ defmodule Inspect.Opts do
       colorized. The keys are types and the values are the colors to use for
       each type (for example, `[number: :red, atom: :blue]`). Types can include
       `:atom`, `:binary`, `:boolean`, `:list`, `:map`, `:number`, `:regex`,
-      `:string`, and `:tuple`. Custom data types may provide their own options.
+      `:string`, `:tuple`, or some types to represent AST like `:variable`,
+      `:function` and `:operator`.
+      Custom data types may provide their own options.
       Colors can be any `t:IO.ANSI.ansidata/0` as accepted by `IO.ANSI.format/1`.
       A default list of colors can be retrieved from `IO.ANSI.syntax_colors/0`.
 

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -2508,10 +2508,8 @@ defmodule Macro do
 
   defp dbg_format_ast_to_debug({:pipe, code_asts, values}, options) do
     result = List.last(values)
-
-    [{first_ast, first_value} | asts_with_values] =
-      code_asts |> Enum.map(&to_string_with_colors(&1, options)) |> Enum.zip(values)
-
+    code_strings = Enum.map(code_asts, &to_string_with_colors(&1, options))
+    [{first_ast, first_value} | asts_with_values] = Enum.zip(code_strings, values)
     first_formatted = [dbg_format_ast(first_ast), " ", inspect(first_value, options), ?\n]
 
     rest_formatted =
@@ -2530,10 +2528,8 @@ defmodule Macro do
   defp to_string_with_colors(ast, options) do
     options = Keyword.take(options, [:syntax_colors])
 
-    ast
-    |> Code.quoted_to_algebra(options)
-    |> Inspect.Algebra.format(98)
-    |> IO.iodata_to_binary()
+    algebra = Code.quoted_to_algebra(ast, options)
+    IO.iodata_to_binary(Inspect.Algebra.format(algebra, 98))
   end
 
   defp dbg_format_header(env) do

--- a/lib/elixir/src/elixir.app.src
+++ b/lib/elixir/src/elixir.app.src
@@ -17,7 +17,10 @@
     {nil, magenta},
     {number, yellow},
     {string, green},
-    {tuple, default_color}
+    {tuple, default_color},
+    {variable, light_cyan},
+    {function, light_white},
+    {operator, light_white}
   ]},
   {check_endianness, true},
   {dbg_callback, {'Elixir.Macro', dbg, []}},

--- a/lib/elixir/src/elixir.app.src
+++ b/lib/elixir/src/elixir.app.src
@@ -19,7 +19,7 @@
     {string, green},
     {tuple, default_color},
     {variable, light_cyan},
-    {function, light_white},
+    {call, light_white},
     {operator, light_white}
   ]},
   {check_endianness, true},

--- a/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
@@ -31,7 +31,7 @@ defmodule Code.Normalizer.QuotedASTTest do
     end
 
     test "local call with colors" do
-      opts = [syntax_colors: [function: :blue, number: :yellow, variable: :red]]
+      opts = [syntax_colors: [call: :blue, number: :yellow, variable: :red]]
 
       assert quoted_to_string(quote(do: foo(1, a)), opts) ==
                "\e[34mfoo\e[0m(\e[33m1\e[0m, \e[31ma\e[0m)"
@@ -90,7 +90,7 @@ defmodule Code.Normalizer.QuotedASTTest do
     end
 
     test "remote call with colors" do
-      opts = [syntax_colors: [function: :blue, number: :yellow, variable: :red, atom: :green]]
+      opts = [syntax_colors: [call: :blue, number: :yellow, variable: :red, atom: :green]]
 
       assert quoted_to_string(quote(do: foo.bar(1, 2)), opts) ==
                "\e[31mfoo\e[0m.\e[34mbar\e[0m(\e[33m1\e[0m, \e[33m2\e[0m)"

--- a/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
@@ -9,6 +9,11 @@ defmodule Code.Normalizer.QuotedASTTest do
       assert quoted_to_string({:{}, [], nil}) == "{}"
     end
 
+    test "variable with colors" do
+      opts = [syntax_colors: [variable: :blue]]
+      assert quoted_to_string(quote(do: foo), opts) == "\e[34mfoo\e[0m"
+    end
+
     test "local call" do
       assert quoted_to_string(quote(do: foo(1, 2, 3))) == "foo(1, 2, 3)"
       assert quoted_to_string(quote(do: foo([1, 2, 3]))) == "foo([1, 2, 3])"
@@ -23,6 +28,13 @@ defmodule Code.Normalizer.QuotedASTTest do
       # Mixing literals and non-literals with line
       assert quoted_to_string(quote(line: __ENV__.line, do: foo(a, 2))) == "foo(a, 2)"
       assert quoted_to_string(quote(line: __ENV__.line, do: foo(1, b))) == "foo(1, b)"
+    end
+
+    test "local call with colors" do
+      opts = [syntax_colors: [function: :blue, number: :yellow, variable: :red]]
+
+      assert quoted_to_string(quote(do: foo(1, a)), opts) ==
+               "\e[34mfoo\e[0m(\e[33m1\e[0m, \e[31ma\e[0m)"
     end
 
     test "local call no parens" do
@@ -75,6 +87,19 @@ defmodule Code.Normalizer.QuotedASTTest do
       assert quoted_to_string(quote(do: Foo.Bar.baz([1, 2, 3]))) == "Foo.Bar.baz([1, 2, 3])"
       assert quoted_to_string(quote(do: ?0.Bar.baz([1, 2, 3]))) == "48.Bar.baz([1, 2, 3])"
       assert quoted_to_string(quote(do: Foo.bar(<<>>, []))) == "Foo.bar(<<>>, [])"
+    end
+
+    test "remote call with colors" do
+      opts = [syntax_colors: [function: :blue, number: :yellow, variable: :red, atom: :green]]
+
+      assert quoted_to_string(quote(do: foo.bar(1, 2)), opts) ==
+               "\e[31mfoo\e[0m.\e[34mbar\e[0m(\e[33m1\e[0m, \e[33m2\e[0m)"
+
+      assert quoted_to_string(quote(do: :foo.bar(1, 2)), opts) ==
+               "\e[32m:foo\e[0m.\e[34mbar\e[0m(\e[33m1\e[0m, \e[33m2\e[0m)"
+
+      assert quoted_to_string(quote(do: Foo.Bar.bar(1, 2)), opts) ==
+               "\e[32mFoo.Bar\e[0m.\e[34mbar\e[0m(\e[33m1\e[0m, \e[33m2\e[0m)"
     end
 
     test "keyword call" do
@@ -152,6 +177,13 @@ defmodule Code.Normalizer.QuotedASTTest do
       assert quoted_to_string(quote do: {1}) == "{1}"
       assert quoted_to_string(quote do: {1, 2, 3}) == "{1, 2, 3}"
       assert quoted_to_string(quote do: {1, 2, 3, foo: :bar}) == "{1, 2, 3, foo: :bar}"
+    end
+
+    test "tuple with colors" do
+      opts = [syntax_colors: [tuple: :blue, number: :yellow]]
+
+      assert quoted_to_string(quote(do: {1, 2, 3}), opts) ==
+               "\e[34m{\e[0m\e[33m1\e[0m, \e[33m2\e[0m, \e[33m3\e[0m\e[34m}\e[0m"
     end
 
     test "tuple call" do
@@ -463,6 +495,12 @@ defmodule Code.Normalizer.QuotedASTTest do
       assert quoted_to_string(quote(do: identity(&1))) == "identity(&1)"
     end
 
+    test "operators with colors" do
+      opts = [syntax_colors: [operator: :blue, number: :yellow]]
+      assert quoted_to_string(quote(do: !!1), opts) == "\e[34m!\e[0m\e[34m!\e[0m\e[33m1\e[0m"
+      assert quoted_to_string(quote(do: 1 + 2), opts) == "\e[33m1\e[0m\e[34m +\e[0m \e[33m2\e[0m"
+    end
+
     test "access" do
       assert quoted_to_string(quote(do: a[b])) == "a[b]"
       assert quoted_to_string(quote(do: a[1 + 2])) == "a[1 + 2]"
@@ -481,6 +519,13 @@ defmodule Code.Normalizer.QuotedASTTest do
 
       # Not keyword lists
       assert quoted_to_string(quote(do: [{binary(), integer()}])) == "[{binary(), integer()}]"
+    end
+
+    test "keyword list with colors" do
+      opts = [syntax_colors: [list: :blue, atom: :green, number: :yellow]]
+
+      assert quoted_to_string(quote(do: [a: 1, b: 2]), opts) ==
+               "\e[34m[\e[0m\e[32ma:\e[0m \e[33m1\e[0m, \e[32mb:\e[0m \e[33m2\e[0m\e[34m]\e[0m"
     end
 
     test "interpolation" do
@@ -510,6 +555,13 @@ defmodule Code.Normalizer.QuotedASTTest do
     test "integer/float" do
       assert quoted_to_string(1) == "1"
       assert quoted_to_string({:__block__, [], [1]}) == "1"
+      assert quoted_to_string(1.23) == "1.23"
+    end
+
+    test "integer/float with colors" do
+      opts = [syntax_colors: [number: :yellow]]
+      assert quoted_to_string(1, opts) == "\e[33m1\e[0m"
+      assert quoted_to_string(1.23, opts) == "\e[33m1.23\e[0m"
     end
 
     test "charlist" do
@@ -521,6 +573,11 @@ defmodule Code.Normalizer.QuotedASTTest do
       assert quoted_to_string(quote(do: "")) == ~S/""/
       assert quoted_to_string(quote(do: "abc")) == ~S/"abc"/
       assert quoted_to_string(quote(do: "#{"abc"}")) == ~S/"#{"abc"}"/
+    end
+
+    test "string with colors" do
+      opts = [syntax_colors: [string: :green]]
+      assert quoted_to_string(quote(do: "abc"), opts) == "\e[32m\"abc\"\e[0m"
     end
 
     test "catch-all" do

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1475,8 +1475,10 @@ defmodule KernelTest do
       output = capture_io(fn -> assert dbg(List.duplicate(:foo, 3)) == [:foo, :foo, :foo] end)
       assert output =~ "kernel_test.exs"
       assert output =~ "KernelTest"
-      assert output =~ "List.duplicate(:foo, 3)"
+      assert output =~ "List"
+      assert output =~ "duplicate"
       assert output =~ ":foo"
+      assert output =~ "3"
     end
 
     test "doesn't print any colors if :syntax_colors is []" do


### PR DESCRIPTION
Add a `syntax_colors to `Code.quoted_to_algebra/2` and have `dbg/1` pass it if ANSI colors are enabled.

Close #12101.

<img width="892" alt="Screen Shot 2022-09-03 at 19 03 40" src="https://user-images.githubusercontent.com/11598866/188269223-af475529-fb4a-468a-b9b2-da4d076003a4.png">

