### PR TITLE
Handle unused :uniq comprehensions

### DIFF
--- a/lib/elixir/src/elixir_erl_for.erl
+++ b/lib/elixir/src/elixir_erl_for.erl
@@ -33,7 +33,7 @@ translate_into(Meta, Cases, Expr, Opts, Return, S) ->
       false -> {false, S}
     end,
 
-  TUniq = lists:keyfind(uniq, 1, Opts) == {uniq, true},
+  TUniq = validate_uniq(Opts, TInto, Meta),
 
   {TCases, SC} = translate_gen(Meta, Cases, [], SI),
   {TExpr, SE}  = elixir_erl_pass:translate(wrap_expr_if_unused(Expr, TInto), Ann, SC),
@@ -42,6 +42,18 @@ translate_into(Meta, Cases, Expr, Opts, Return, S) ->
     inline -> build_inline(Ann, TCases, TExpr, TInto, TUniq, SE);
     into -> build_into(Ann, TCases, TExpr, TInto, TUniq, SE)
   end.
+
+validate_uniq(Opts, TInto, _Meta) ->
+  case {lists:keyfind(uniq, 1, Opts), TInto} of
+    {{uniq, true}, false} ->
+      % TODO format this warning properly with Meta
+      io:format(standard_error, "warning: the option :uniq has no effect because the result is not used~n", []),
+      false;
+    {{uniq, true}, _} ->
+      true;
+    _ ->
+      false
+    end.
 
 %% In case we have no return, we wrap the expression
 %% in a block that returns nil.

--- a/lib/elixir/src/elixir_erl_pass.erl
+++ b/lib/elixir/src/elixir_erl_pass.erl
@@ -182,7 +182,7 @@ translate({'receive', Meta, [Opts]}, _Ann, S) ->
 %% Comprehensions and with
 
 translate({for, Meta, [_ | _] = Args}, _Ann, S) ->
-  elixir_erl_for:translate(Meta, Args, true, S);
+  elixir_erl_for:translate(Meta, Args, S);
 
 translate({with, Meta, [_ | _] = Args}, _Ann, S) ->
   {Exprs, [{do, Do} | Opts]} = elixir_utils:split_last(Args),
@@ -348,12 +348,6 @@ translate_block([H], Ann, Acc, S) ->
 translate_block([{'__block__', Meta, Args} | T], Ann, Acc, S) when is_list(Args) ->
   {TAcc, SA} = translate_block(Args, ?ann(Meta), Acc, S),
   translate_block(T, Ann, TAcc, SA);
-translate_block([{for, Meta, [_ | _] = Args} | T], Ann, Acc, S) ->
-  {TH, TS} = elixir_erl_for:translate(Meta, Args, false, S),
-  translate_block(T, Ann, [TH | Acc], TS);
-translate_block([{'=', _, [{'_', _, Ctx}, {for, Meta, [_ | _] = Args}]} | T], Ann, Acc, S) when is_atom(Ctx) ->
-  {TH, TS} = elixir_erl_for:translate(Meta, Args, false, S),
-  translate_block(T, Ann, [TH | Acc], TS);
 translate_block([H | T], Ann, Acc, S) ->
   {TH, TS} = translate(H, Ann, S),
   translate_block(T, Ann, [TH | Acc], TS).

--- a/lib/elixir/test/elixir/kernel/comprehension_test.exs
+++ b/lib/elixir/test/elixir/kernel/comprehension_test.exs
@@ -115,6 +115,36 @@ defmodule Kernel.ComprehensionTest do
     assert for(x <- 1..3, nilly(), do: x * 2) == []
   end
 
+  test "for comprehensions with unique option where value is not used" do
+    assert capture_io(:stderr, fn ->
+             assert capture_io(fn ->
+                      Code.eval_quoted(
+                        quote do
+                          for x <- [1, 2, 1, 2], uniq: true, do: IO.puts(x)
+                          nil
+                        end
+                      )
+                    end) ==
+                      "1\n2\n1\n2\n"
+           end) =~
+             "the :uniq option has no effect since the result of the for comprehension is not used"
+  end
+
+  test "for comprehensions with unique option where value is assigned to _" do
+    assert capture_io(:stderr, fn ->
+             assert capture_io(fn ->
+                      Code.eval_quoted(
+                        quote do
+                          _ = for x <- [1, 2, 1, 2], uniq: true, do: IO.puts(x)
+                          nil
+                        end
+                      )
+                    end) ==
+                      "1\n2\n1\n2\n"
+           end) =~
+             "the :uniq option has no effect since the result of the for comprehension is not used"
+  end
+
   test "for comprehensions with errors on filters" do
     assert_raise ArgumentError, fn ->
       for x <- 1..3, hd(x), do: x * 2
@@ -210,17 +240,6 @@ defmodule Kernel.ComprehensionTest do
              for x <- enum, do: IO.puts(x)
              nil
            end) == "1\n2\n3\n"
-  end
-
-  test "for comprehensions with uniq where value is not used" do
-    assert capture_io(:stderr, fn ->
-             assert capture_io(fn ->
-                      Code.eval_string(~S"""
-                      for x <- [1, 2, 1, 3], uniq: true, do: IO.puts(x)
-                      nil
-                      """)
-                    end) == "1\n2\n1\n3\n"
-           end) =~ "warning: the option :uniq has no effect"
   end
 
   test "for comprehensions with into" do

--- a/lib/elixir/test/elixir/kernel/comprehension_test.exs
+++ b/lib/elixir/test/elixir/kernel/comprehension_test.exs
@@ -212,6 +212,17 @@ defmodule Kernel.ComprehensionTest do
            end) == "1\n2\n3\n"
   end
 
+  test "for comprehensions with uniq where value is not used" do
+    assert capture_io(:stderr, fn ->
+             assert capture_io(fn ->
+                      Code.eval_string(~S"""
+                      for x <- [1, 2, 1, 3], uniq: true, do: IO.puts(x)
+                      nil
+                      """)
+                    end) == "1\n2\n1\n3\n"
+           end) =~ "warning: the option :uniq has no effect"
+  end
+
   test "for comprehensions with into" do
     Process.put(:into_cont, [])
     Process.put(:into_done, false)

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -799,7 +799,8 @@ defmodule Kernel.ExpansionTest do
                 c = 3
                 [4]
               ),
-            do: {a(), b, c(), d}
+            do: {a(), b, c(), d},
+            into: []
           )
         end
 
@@ -808,7 +809,7 @@ defmodule Kernel.ExpansionTest do
 
     test "variables inside filters are available in blocks" do
       assert expand(quote(do: for(a <- b, c = a, do: c))) ==
-               quote(do: for(a <- b(), c = a, do: c))
+               quote(do: for(a <- b(), c = a, do: c, into: []))
     end
 
     test "variables inside options do not leak" do

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1950,6 +1950,15 @@ defmodule Kernel.WarningTest do
              "extra parentheses on a remote function capture &System.pid()/0 have been deprecated. Please remove the parentheses: &System.pid/0"
   end
 
+  test "warns if for result is not used and :uniq is true" do
+    assert capture_err(fn ->
+             Code.eval_string(~s"""
+             for x <- [1, 2, 1, 3], uniq: true, do: IO.puts(x)
+             nil
+             """)
+           end) =~ "the option :uniq has no effect"
+  end
+
   defp purge(list) when is_list(list) do
     Enum.each(list, &purge/1)
   end

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1950,15 +1950,6 @@ defmodule Kernel.WarningTest do
              "extra parentheses on a remote function capture &System.pid()/0 have been deprecated. Please remove the parentheses: &System.pid/0"
   end
 
-  test "warns if for result is not used and :uniq is true" do
-    assert capture_err(fn ->
-             Code.eval_string(~s"""
-             for x <- [1, 2, 1, 3], uniq: true, do: IO.puts(x)
-             nil
-             """)
-           end) =~ "the option :uniq has no effect"
-  end
-
   defp purge(list) when is_list(list) do
     Enum.each(list, &purge/1)
   end


### PR DESCRIPTION
Close #12107

Hi, this is a suggestion how we could fix the issue:
- if `uniq` is true but `into` is false, it is basically the same as if uniq wasn't here, so we can ignore `uniq` (building a map with `nil` keys etc... don't make much sense)
- this is an incorrect use of `uniq`, so we should probably better add a warning that just ignore it silently