### PR TITLE
Build precompiled and publish to S3

### DIFF
--- a/.github/workflows/publish_precompiled.yml
+++ b/.github/workflows/publish_precompiled.yml
@@ -45,7 +45,7 @@ jobs:
           date=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
           build_sha256=$(sha256sum main-otp-${{ matrix.otp }}.zip | cut -d ' ' -f 1)
 
-          aws s3 cp s3://${{ env.S3_BUCKET }}/builds/elixir/builds.txt builds.txt || touch builds.txt
+          aws s3 cp s3://${{ env.S3_BUCKET }}/builds/elixir/builds.txt builds.txt
           sed -i '/^main-otp-${{ matrix.otp }} /d' builds.txt
           echo -e -n "main-otp-${{ matrix.otp }} ${{ github.sha }} ${date} ${build_sha256}\n$(cat builds.txt)" > builds.txt
           sort -u -k1,1 -o builds.txt builds.txt

--- a/.github/workflows/publish_precompiled.yml
+++ b/.github/workflows/publish_precompiled.yml
@@ -23,7 +23,7 @@ jobs:
             otp_version: 24.3
           - otp: 25
             otp_version: 25.0
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -46,8 +46,7 @@ jobs:
           date=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
           build_sha256=$(cut -d ' ' -f 1 main-otp-${{ matrix.otp }}.zip.sha256sum)
 
-          aws s3 cp s3://${{ env.S3_BUCKET }}/builds/elixir/builds.txt builds.txt || true
-          touch builds.txt
+          aws s3 cp s3://${{ env.S3_BUCKET }}/builds/elixir/builds.txt builds.txt || touch builds.txt
           sed -i '/^main-otp-${{ matrix.otp }} /d' builds.txt
           echo -e -n "main-otp-${{ matrix.otp }} ${{ github.sha }} ${date} ${build_sha256}\n$(cat builds.txt)" > builds.txt
           sort -u -k1,1 -o builds.txt builds.txt

--- a/.github/workflows/publish_precompiled.yml
+++ b/.github/workflows/publish_precompiled.yml
@@ -11,7 +11,6 @@ env:
   LANG: C.UTF-8
   S3_BUCKET: s3.hex.pm
 
-
 jobs:
   publish_precompiled:
     strategy:
@@ -22,6 +21,7 @@ jobs:
         include:
           - otp: 24
             otp_version: 24.3
+            default_main: true
           - otp: 25
             otp_version: 25.0
     runs-on: ubuntu-20.04
@@ -40,6 +40,11 @@ jobs:
           make Precompiled.zip
           mv Precompiled.zip main-otp-${{ matrix.otp }}.zip
 
+      - name: Add main.zip
+        if: ${{ matrix.default_main }}
+        run: |
+          cp main-otp-${{ matrix.otp }}.zip main.zip
+
       - name: Update builds.txt
         run: |
           date=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -54,6 +59,16 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.HEXPM_ELIXIR_BUILDS_AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
 
+      - name: Add main.zip to builds.txt
+        if: ${{ matrix.default_main }}
+        run: |
+          date=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          build_sha256=$(sha256sum main.zip | cut -d ' ' -f 1)
+
+          sed -i '/^main /d' builds.txt
+          echo -e -n "main ${{ github.sha }} ${date} ${build_sha256}\n$(cat builds.txt)" > builds.txt
+          sort -u -k1,1 -o builds.txt builds.txt
+
       - name: Upload to S3
         run: |
           for file in main-otp-${{ matrix.otp }}.zip builds.txt
@@ -62,6 +77,17 @@ jobs:
               --cache-control 'public,max-age=3600' \
               --metadata '{"surrogate-key":"builds","surrogate-control":"public,max-age=604800"}'
           done
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.HEXPM_ELIXIR_BUILDS_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.HEXPM_ELIXIR_BUILDS_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+
+      - name: Upload main.zip to S3
+        if: ${{ matrix.default_main }}
+        run: |
+          aws s3 cp main.zip s3://${{ env.S3_BUCKET }}/builds/elixir/ \
+            --cache-control 'public,max-age=3600' \
+            --metadata '{"surrogate-key":"builds","surrogate-control":"public,max-age=604800"}'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.HEXPM_ELIXIR_BUILDS_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.HEXPM_ELIXIR_BUILDS_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/publish_precompiled.yml
+++ b/.github/workflows/publish_precompiled.yml
@@ -12,6 +12,7 @@ env:
   S3_BUCKET: test-elixir-nightly
   # S3_BUCKET: s3.hex.pm
 
+
 jobs:
   publish_precompiled:
     strategy:
@@ -66,3 +67,21 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.HEXPM_ELIXIR_BUILDS_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.HEXPM_ELIXIR_BUILDS_AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
+
+  fastly_purge:
+    needs: publish_precompiled
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Purge Fastly cache
+        run: |
+          curl \
+            --fail \
+            -X POST \
+            -H "Fastly-Key: ${BOB_FASTLY_KEY}" \
+            -H "Accept: application/json" \
+            -H "Content-Length: 0" \
+            "https://api.fastly.com/service/${BOB_FASTLY_SERVICE}/purge/${BOB_FASTLY_KEY}"
+        env:
+          BOB_FASTLY_KEY: ${{ secrets.BOB_FASTLY_KEY }}
+          BOB_FASTLY_SERVICE: changeme
+          BOB_FASTLY_PURGE_KEY: builds

--- a/.github/workflows/publish_precompiled.yml
+++ b/.github/workflows/publish_precompiled.yml
@@ -76,11 +76,11 @@ jobs:
           curl \
             --fail \
             -X POST \
-            -H "Fastly-Key: ${BOB_FASTLY_KEY}" \
+            -H "Fastly-Key: ${FASTLY_KEY}" \
             -H "Accept: application/json" \
             -H "Content-Length: 0" \
-            "https://api.fastly.com/service/${BOB_FASTLY_SERVICE}/purge/${BOB_FASTLY_PURGE_KEY}"
+            "https://api.fastly.com/service/${FASTLY_SERVICE}/purge/${FASTLY_PURGE_KEY}"
         env:
-          BOB_FASTLY_KEY: ${{ secrets.BOB_FASTLY_KEY }}
-          BOB_FASTLY_SERVICE: changeme
-          BOB_FASTLY_PURGE_KEY: builds
+          FASTLY_KEY: ${{ secrets.HEXPM_REPO_FASTLY_KEY }}
+          FASTLY_SERVICE: ${{ secrets.HEXPM_REPO_FASTLY_SERVICE }}
+          FASTLY_PURGE_KEY: builds

--- a/.github/workflows/publish_precompiled.yml
+++ b/.github/workflows/publish_precompiled.yml
@@ -1,0 +1,52 @@
+name: Publish Precompiled
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  ELIXIR_OPTS: "--warnings-as-errors"
+  ERLC_OPTS: "warnings_as_errors"
+  LANG: C.UTF-8
+
+jobs:
+  publish_pre_built:
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - otp: 24
+            otp_version: 24.3
+          - otp: 25
+            otp_version: 25.0
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 50
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp_version }}
+          version-type: strict
+      - name: Build Elixir Release
+        run: |
+          version=$(cat VERSION)
+          make Precompiled.zip
+          mv Precompiled.zip elixir-${version}-otp-${{ matrix.otp }}.zip
+          shasum -a 1 elixir-${version}-otp-${{ matrix.otp }}.zip > elixir-${version}-otp-${{ matrix.otp }}.zip.sha1sum
+          shasum -a 256 elixir-${version}-otp-${{ matrix.otp }}.zip > elixir-${version}-otp-${{ matrix.otp }}.zip.sha256sum
+
+      - name: Upload to S3
+        run: |
+          version=$(cat VERSION)
+          for file in elixir-${version}-otp-${{ matrix.otp }}.zip elixir-${version}-otp-${{ matrix.otp }}.zip.sha1sum elixir-${version}-otp-${{ matrix.otp }}.zip.sha256sum
+          do
+            aws s3 cp "${file}" s3://s3.hex.pm/builds/elixir/ \
+              --cache-control 'public,max-age=3600' \
+              --metadata '{"surrogate-key":"builds","surrogate-control":"public,max-age=604800"}'
+          done
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/publish_precompiled.yml
+++ b/.github/workflows/publish_precompiled.yml
@@ -3,7 +3,7 @@ name: Publish Precompiled
 on:
   push:
     branches:
-      - main
+      - iss-12038-2
 
 env:
   ELIXIR_OPTS: "--warnings-as-errors"
@@ -33,16 +33,16 @@ jobs:
         run: |
           version=$(cat VERSION)
           make Precompiled.zip
-          mv Precompiled.zip elixir-${version}-otp-${{ matrix.otp }}.zip
-          shasum -a 1 elixir-${version}-otp-${{ matrix.otp }}.zip > elixir-${version}-otp-${{ matrix.otp }}.zip.sha1sum
-          shasum -a 256 elixir-${version}-otp-${{ matrix.otp }}.zip > elixir-${version}-otp-${{ matrix.otp }}.zip.sha256sum
+          mv Precompiled.zip main-otp-${{ matrix.otp }}.zip
+          shasum -a 1 main-otp-${{ matrix.otp }}.zip > main-otp-${{ matrix.otp }}.zip.sha1sum
+          shasum -a 256 main-otp-${{ matrix.otp }}.zip > main-otp-${{ matrix.otp }}.zip.sha256sum
 
       - name: Upload to S3
         run: |
           version=$(cat VERSION)
-          for file in elixir-${version}-otp-${{ matrix.otp }}.zip elixir-${version}-otp-${{ matrix.otp }}.zip.sha1sum elixir-${version}-otp-${{ matrix.otp }}.zip.sha256sum
+          for file in main-otp-${{ matrix.otp }}.zip main-otp-${{ matrix.otp }}.zip.sha1sum main-otp-${{ matrix.otp }}.zip.sha256sum
           do
-            aws s3 cp "${file}" s3://s3.hex.pm/builds/elixir/ \
+            aws s3 cp "${file}" s3://test-elixir-nightly/builds/elixir/ \
               --cache-control 'public,max-age=3600' \
               --metadata '{"surrogate-key":"builds","surrogate-control":"public,max-age=604800"}'
           done

--- a/.github/workflows/publish_precompiled.yml
+++ b/.github/workflows/publish_precompiled.yml
@@ -3,13 +3,14 @@ name: Publish Precompiled
 on:
   push:
     branches:
-      - main
+      - iss-12038-2
 
 env:
   ELIXIR_OPTS: "--warnings-as-errors"
   ERLC_OPTS: "warnings_as_errors"
   LANG: C.UTF-8
-  S3_BUCKET: s3.hex.pm
+  S3_BUCKET: test-elixir-nightly
+  # S3_BUCKET: s3.hex.pm
 
 jobs:
   publish_precompiled:
@@ -38,13 +39,11 @@ jobs:
         run: |
           make Precompiled.zip
           mv Precompiled.zip main-otp-${{ matrix.otp }}.zip
-          shasum -a 1 main-otp-${{ matrix.otp }}.zip > main-otp-${{ matrix.otp }}.zip.sha1sum
-          shasum -a 256 main-otp-${{ matrix.otp }}.zip > main-otp-${{ matrix.otp }}.zip.sha256sum
 
       - name: Update builds.txt
         run: |
           date=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-          build_sha256=$(cut -d ' ' -f 1 main-otp-${{ matrix.otp }}.zip.sha256sum)
+          build_sha256=$(sha256sum main-otp-${{ matrix.otp }}.zip | cut -d ' ' -f 1)
 
           aws s3 cp s3://${{ env.S3_BUCKET }}/builds/elixir/builds.txt builds.txt || touch builds.txt
           sed -i '/^main-otp-${{ matrix.otp }} /d' builds.txt
@@ -57,13 +56,13 @@ jobs:
 
       - name: Upload to S3
         run: |
-          for file in main-otp-${{ matrix.otp }}.zip main-otp-${{ matrix.otp }}.zip.sha1sum main-otp-${{ matrix.otp }}.zip.sha256sum builds.txt
+          for file in main-otp-${{ matrix.otp }}.zip builds.txt
           do
             aws s3 cp "${file}" s3://${{ env.S3_BUCKET }}/builds/elixir/ \
               --cache-control 'public,max-age=3600' \
               --metadata '{"surrogate-key":"builds","surrogate-control":"public,max-age=604800"}'
           done
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.HEXPM_ELIXIR_BUILDS_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.HEXPM_ELIXIR_BUILDS_AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/publish_precompiled.yml
+++ b/.github/workflows/publish_precompiled.yml
@@ -51,8 +51,8 @@ jobs:
           echo -e -n "main-otp-${{ matrix.otp }} ${{ github.sha }} ${date} ${build_sha256}\n$(cat builds.txt)" > builds.txt
           sort -u -k1,1 -o builds.txt builds.txt
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.HEXPM_ELIXIR_BUILDS_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.HEXPM_ELIXIR_BUILDS_AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
 
       - name: Upload to S3

--- a/.github/workflows/publish_precompiled.yml
+++ b/.github/workflows/publish_precompiled.yml
@@ -3,17 +3,20 @@ name: Publish Precompiled
 on:
   push:
     branches:
-      - iss-12038-2
+      - main
 
 env:
   ELIXIR_OPTS: "--warnings-as-errors"
   ERLC_OPTS: "warnings_as_errors"
   LANG: C.UTF-8
+  S3_BUCKET: s3.hex.pm
 
 jobs:
-  publish_pre_built:
+  publish_precompiled:
     strategy:
       fail-fast: true
+      # Prevent each job edit builds.txt concurrently.
+      max-parallel: 1
       matrix:
         include:
           - otp: 24
@@ -25,24 +28,39 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 50
+
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp_version }}
           version-type: strict
+
       - name: Build Elixir Release
         run: |
-          version=$(cat VERSION)
           make Precompiled.zip
           mv Precompiled.zip main-otp-${{ matrix.otp }}.zip
           shasum -a 1 main-otp-${{ matrix.otp }}.zip > main-otp-${{ matrix.otp }}.zip.sha1sum
           shasum -a 256 main-otp-${{ matrix.otp }}.zip > main-otp-${{ matrix.otp }}.zip.sha256sum
 
+      - name: Update builds.txt
+        run: |
+          date=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          build_sha256=$(cut -d ' ' -f 1 main-otp-${{ matrix.otp }}.zip.sha256sum)
+
+          aws s3 cp s3://${{ env.S3_BUCKET }}/builds/elixir/builds.txt builds.txt || true
+          touch builds.txt
+          sed -i '/^main-otp-${{ matrix.otp }} /d' builds.txt
+          echo -e -n "main-otp-${{ matrix.otp }} ${{ github.sha }} ${date} ${build_sha256}\n$(cat builds.txt)" > builds.txt
+          sort -u -k1,1 -o builds.txt builds.txt
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+
       - name: Upload to S3
         run: |
-          version=$(cat VERSION)
-          for file in main-otp-${{ matrix.otp }}.zip main-otp-${{ matrix.otp }}.zip.sha1sum main-otp-${{ matrix.otp }}.zip.sha256sum
+          for file in main-otp-${{ matrix.otp }}.zip main-otp-${{ matrix.otp }}.zip.sha1sum main-otp-${{ matrix.otp }}.zip.sha256sum builds.txt
           do
-            aws s3 cp "${file}" s3://test-elixir-nightly/builds/elixir/ \
+            aws s3 cp "${file}" s3://${{ env.S3_BUCKET }}/builds/elixir/ \
               --cache-control 'public,max-age=3600' \
               --metadata '{"surrogate-key":"builds","surrogate-control":"public,max-age=604800"}'
           done

--- a/.github/workflows/publish_precompiled.yml
+++ b/.github/workflows/publish_precompiled.yml
@@ -3,14 +3,13 @@ name: Publish Precompiled
 on:
   push:
     branches:
-      - iss-12038-2
+      - main
 
 env:
   ELIXIR_OPTS: "--warnings-as-errors"
   ERLC_OPTS: "warnings_as_errors"
   LANG: C.UTF-8
-  S3_BUCKET: test-elixir-nightly
-  # S3_BUCKET: s3.hex.pm
+  S3_BUCKET: s3.hex.pm
 
 
 jobs:

--- a/.github/workflows/publish_precompiled.yml
+++ b/.github/workflows/publish_precompiled.yml
@@ -79,7 +79,7 @@ jobs:
             -H "Fastly-Key: ${BOB_FASTLY_KEY}" \
             -H "Accept: application/json" \
             -H "Content-Length: 0" \
-            "https://api.fastly.com/service/${BOB_FASTLY_SERVICE}/purge/${BOB_FASTLY_KEY}"
+            "https://api.fastly.com/service/${BOB_FASTLY_SERVICE}/purge/${BOB_FASTLY_PURGE_KEY}"
         env:
           BOB_FASTLY_KEY: ${{ secrets.BOB_FASTLY_KEY }}
           BOB_FASTLY_SERVICE: changeme


### PR DESCRIPTION
Continuing #12038 from the discussion in https://github.com/elixir-lang/elixir/pull/12053#issuecomment-1208268123. I create a new workflow to publish a precompiled version to s3. Currently, it will run on every commit that pushes to main. If it's too much, we can change it to run every night (with a cron schedule). 