### PR TITLE
Add commas to bare usage of "however" where appropriate

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -615,8 +615,8 @@ defmodule Code do
   The formatter respects the input format in some cases. Those are
   listed below:
 
-    * Insignificant digits in numbers are kept as is. The formatter
-      however always inserts underscores for decimal numbers with more
+    * Insignificant digits in numbers are kept as is. The formatter,
+      however, always inserts underscores for decimal numbers with more
       than 5 digits and converts hexadecimal digits to uppercase
 
     * Strings, charlists, atoms and sigils are kept as is. No character

--- a/lib/elixir/lib/exception.ex
+++ b/lib/elixir/lib/exception.ex
@@ -830,7 +830,7 @@ defmodule ArgumentError do
 
         not is_atom(function) ->
           "you attempted to apply a function named #{inspect(function)} on module #{inspect(module)}. " <>
-            "However #{inspect(function)} is not a valid function name. Function names (the second argument " <>
+            "However, #{inspect(function)} is not a valid function name. Function names (the second argument " <>
             "of apply) must always be an atom"
       end
 
@@ -1128,7 +1128,7 @@ defmodule UndefinedFunctionError do
   def hint_for_loaded_module(module, function, arity, exports) do
     cond do
       macro_exported?(module, function, arity) ->
-        ". However there is a macro with the same name and arity. " <>
+        ". However, there is a macro with the same name and arity. " <>
           "Be sure to require #{inspect(module)} if you intend to invoke this macro"
 
       message = otp_obsolete(module, function, arity) ->

--- a/lib/elixir/lib/inspect.ex
+++ b/lib/elixir/lib/inspect.ex
@@ -119,7 +119,7 @@ defprotocol Inspect do
   Elixir will raise an `ArgumentError` error and will automatically fall back
   to a raw representation for printing the structure.
 
-  You can however access the underlying error by invoking the `Inspect`
+  You can, however, access the underlying error by invoking the `Inspect`
   implementation directly. For example, to test `Inspect.MapSet` above,
   you can invoke it as:
 

--- a/lib/elixir/lib/inspect/algebra.ex
+++ b/lib/elixir/lib/inspect/algebra.ex
@@ -226,7 +226,7 @@ defmodule Inspect.Algebra do
 
   This implementation provides two types of breaks: `:strict` and `:flex`.
   When a group does not fit, all strict breaks are treated as newlines.
-  Flex breaks however are re-evaluated on every occurrence and may still
+  Flex breaks, however, are re-evaluated on every occurrence and may still
   be rendered flat. See `break/1` and `flex_break/1` for more information.
 
   This implementation also adds `force_unfit/1` and `next_break_fits/2` which

--- a/lib/elixir/lib/keyword.ex
+++ b/lib/elixir/lib/keyword.ex
@@ -33,7 +33,7 @@ defmodule Keyword do
   ## Duplicate keys and ordering
 
   A keyword may have duplicate keys so it is not strictly a key-value
-  data type. However most of the functions in this module work on a
+  data type. However, most of the functions in this module work on a
   key-value structure and behave similar to the functions you would
   find in the `Map` module. For example, `Keyword.get/3` will get the first
   entry matching the given key, regardless if duplicate entries exist.

--- a/lib/elixir/lib/protocol.ex
+++ b/lib/elixir/lib/protocol.ex
@@ -548,7 +548,7 @@ defmodule Protocol do
 
   This function does not load the protocol at any point
   nor loads the new bytecode for the compiled module.
-  However each implementation must be available and
+  However, each implementation must be available and
   it will be loaded.
   """
   @spec consolidate(module, [module]) ::

--- a/lib/elixir/lib/range.ex
+++ b/lib/elixir/lib/range.ex
@@ -26,7 +26,7 @@ defmodule Range do
   defined based on the first and last position of the
   range, If `first >= last`, it will be an increasing range
   with a step of 1. Otherwise, it is a decreasing range.
-  Note however implicit decreasing ranges are deprecated.
+  Note, however, implicit decreasing ranges are deprecated.
   Therefore, if you need a decreasing range from `3` to `1`,
   prefer to write `3..1//-1` instead.
 

--- a/lib/elixir/pages/unicode-syntax.md
+++ b/lib/elixir/pages/unicode-syntax.md
@@ -149,7 +149,7 @@ As of Elixir 1.14, some codepoints in `\p{Identifier_Status=Restricted}` are *no
 
 Initially this is only done to translate MICRO SIGN `µ` to Greek lowercase mu, `μ`.
 
-This is not a modification of UTS39 clauses C1 (General Security Profile) or C2 (Confusability Detection); however it is a documented modification of C3, 'Mixed-Script detection'.
+This is not a modification of UTS39 clauses C1 (General Security Profile) or C2 (Confusability Detection); however, it is a documented modification of C3, 'Mixed-Script detection'.
 
 Mixed-script detection is modified by these normalizations to the extent that the normalized codepoint is given the union of scriptsets from both characters.
 

--- a/lib/elixir/src/elixir_bitstring.erl
+++ b/lib/elixir/src/elixir_bitstring.erl
@@ -55,7 +55,7 @@ extract_meta({_, Meta, _}, _) -> Meta;
 extract_meta(_, Meta) -> Meta.
 
 %% Variables defined outside the binary can be accounted
-%% on subparts, however we can't assign new variables.
+%% on subparts; however, we can't assign new variables.
 is_match_size([_ | _], #{context := match}) -> true;
 is_match_size(_, _) -> false.
 

--- a/lib/elixir/test/elixir/exception_test.exs
+++ b/lib/elixir/test/elixir/exception_test.exs
@@ -491,7 +491,7 @@ defmodule ExceptionTest do
                  "module.function(), make sure the left-hand side of the dot is a module atom"
 
       assert blame_message([], &apply(Kernel, &1, [1, 2])) ==
-               "you attempted to apply a function named [] on module Kernel. However [] is not a valid function name. " <>
+               "you attempted to apply a function named [] on module Kernel. However, [] is not a valid function name. " <>
                  "Function names (the second argument of apply) must always be an atom"
 
       assert blame_message(123, &apply(Kernel, :+, &1)) ==
@@ -546,7 +546,7 @@ defmodule ExceptionTest do
 
     test "annotates undefined function clause error with macro hints" do
       assert blame_message(Integer, & &1.is_odd(1)) ==
-               "function Integer.is_odd/1 is undefined or private. However there is " <>
+               "function Integer.is_odd/1 is undefined or private. However, there is " <>
                  "a macro with the same name and arity. Be sure to require Integer if " <>
                  "you intend to invoke this macro"
     end

--- a/lib/iex/lib/iex.ex
+++ b/lib/iex/lib/iex.ex
@@ -146,7 +146,7 @@ defmodule IEx do
         2 | |> IO.puts()
           | ^
 
-  Note however the above does not work for `+/2` and `-/2`, as they
+  Note, however, the above does not work for `+/2` and `-/2`, as they
   are ambiguous with the unary `+/1` and `-/1`:
 
       iex(1)> 1

--- a/lib/mix/lib/mix/tasks/compile.elixir.ex
+++ b/lib/mix/lib/mix/tasks/compile.elixir.ex
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.Compile.Elixir do
   A module may export a `__mix_recompile__?/0` function that can
   cause the module to be recompiled using custom rules. For example,
   `@external_resource` already adds a compile-time dependency on an
-  external file, however to depend on a _dynamic_ list of files we
+  external file, however, to depend on a _dynamic_ list of files we
   can do:
 
       defmodule MyModule do

--- a/man/common
+++ b/man/common
@@ -73,7 +73,7 @@ allows creating a node which can be connected to another node, escaping redundan
 .Pp
 The function
 .Sy Node.list/0
-allows getting the list of nodes connected to the target node, however the list won't include hidden nodes. Depending on the input parameter, the function
+allows getting the list of nodes connected to the target node; however, the list won't include hidden nodes. Depending on the input parameter, the function
 .Sy Node.list/1
 allows getting the list which contains only hidden nodes
 .Pq the parameter Ar :hidden


### PR DESCRIPTION
While going through the "Getting started" documentation I noticed a missing comma in the nice hint that a macro is defined.

> iex> Integer.is_odd(3)
> ** (UndefinedFunctionError) function Integer.is_odd/1 is undefined or private. However there is a macro with the same name and arity. Be sure to require Integer if you intend to invoke this macro

A simple search for "however " in the repository yielded a few cases of this simple grammatical mistake. I've added commas and semicolons to these where appropriate (which is most uses).

Note that this was not a blind find/replace. For example, "however" does not need commas when used as an adverb:

>   `NaiveDateTime.to_iso8601/2` and `DateTime.to_iso8601/2` allow you to produce
>    either basic or extended formatted strings, and `Calendar.strftime/2` allows
>    you to format datetimes however else you desire.

This is a relatively simple change, but let me know if there are any questions or concerns!

I've made these changes to the website as well in https://github.com/elixir-lang/elixir-lang.github.com/pull/1634
