### PR TITLE
Allow trailing comma in `xref group --group` parameter

### DIFF
--- a/lib/mix/lib/mix/tasks/xref.ex
+++ b/lib/mix/lib/mix/tasks/xref.ex
@@ -601,7 +601,7 @@ defmodule Mix.Tasks.Xref do
         reduce: {file_references, %{}} do
       {file_references, aliases} ->
         group_paths
-        |> String.split(",")
+        |> String.split(",", trim: true)
         |> check_files(file_references, :group)
         |> group(file_references, aliases)
     end

--- a/lib/mix/test/mix/tasks/xref_test.exs
+++ b/lib/mix/test/mix/tasks/xref_test.exs
@@ -908,7 +908,7 @@ defmodule Mix.Tasks.XrefTest do
     end
 
     test "group with directly dependent files and cycle" do
-      assert_graph(~w[--group lib/a.ex,lib/b.ex], """
+      assert_graph(~w[--group lib/a.ex,lib/b.ex,], """
       lib/a.ex+
       |-- lib/c.ex
       `-- lib/e.ex (compile)


### PR DESCRIPTION
When using this feature, first thing I wanted to write was

```
GROUP=\
lib/example.ex,\
[...]
lib/other_example.ex,\

mix xref graph --group=$GROUP ...
```