### PR TITLE
improve misc of docs for guards 

### DIFF
--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1467,6 +1467,16 @@ defmodule Kernel do
       iex> [1] ++ [2 | 3]
       [1, 2 | 3]
 
+      The `++/2` operator is right associative, meaning:
+
+          iex> [1, 2, 3] -- [1] ++ [2]
+          [3]
+
+      As it is equivalent to:
+
+          iex> [1, 2, 3] -- ([1] ++ [2])
+          [3]
+
   """
   @spec list ++ term :: maybe_improper_list
   def left ++ right do

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -545,7 +545,7 @@ defmodule Kernel do
   Giving it an empty list raises:
 
       hd([])
-      #=> ** (ArgumentError) argument error
+      ** (ArgumentError) argument error
 
   """
   @doc guard: true
@@ -1254,7 +1254,7 @@ defmodule Kernel do
   Giving it an empty list raises:
 
       tl([])
-      #=> ** (ArgumentError) argument error
+      ** (ArgumentError) argument error
 
   """
   @doc guard: true

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -1467,15 +1467,15 @@ defmodule Kernel do
       iex> [1] ++ [2 | 3]
       [1, 2 | 3]
 
-      The `++/2` operator is right associative, meaning:
+  The `++/2` operator is right associative, meaning:
 
-          iex> [1, 2, 3] -- [1] ++ [2]
-          [3]
+      iex> [1, 2, 3] -- [1] ++ [2]
+      [3]
 
-      As it is equivalent to:
+  As it is equivalent to:
 
-          iex> [1, 2, 3] -- ([1] ++ [2])
-          [3]
+      iex> [1, 2, 3] -- ([1] ++ [2])
+      [3]
 
   """
   @spec list ++ term :: maybe_improper_list

--- a/lib/elixir/lib/kernel.ex
+++ b/lib/elixir/lib/kernel.ex
@@ -790,6 +790,14 @@ defmodule Kernel do
   It raises `BadMapError` if the first element is not a map.
 
   Allowed in guard tests. Inlined by the compiler.
+
+  ## Examples
+
+      iex> is_map_key(%{a: "foo", b: "bar"}, :a)
+      true
+
+      iex> is_map_key(%{a: "foo", b: "bar"}, :c)
+      false
   """
   @doc guard: true, since: "1.10.0"
   @spec is_map_key(map, term) :: boolean


### PR DESCRIPTION
Improve docs for guards for the following cases: 

- adds examples for `is_map_key` guard. I was looking for something like that but because it is called `is_map_key` instead of `has_map_key` I just figured out it was what I wanted because I found it in some random article (but not in the docs). Examples could have helped here.
- exceptions for `hd/1` and `tl/1` were not highlighted because of the precedence of "#=>" before the exceptions themselves 
- `++/2` is the right associative (found that in erlang docs), added an example similar to what we have for `--/2`.

---

Playing with these `is_map_key/2` I also had another interesting discovery. With a `MapSet` it does not raise an exception. While I do understand it happens because MapSets are implemented over  `Map` for compatibility reasons, I do think it should raise (or work as expected) once `MapSet`, the current behavior is very counterintuitive:

```elixir
iex> is_map_key(MapSet.new(%{a: "foo"}), :a)
false
```
I was expecting it to either raise or return true, but having it return a false was a big surprise. 

If we have a good way to detect a `MapSet` I can open a PR fixing the current behavior. If we need to keep the ball rolling for this discussion I'm happy to open a new issue for it.  
 