### PR TITLE
ExUnit: define setup callback as private function in docs

### DIFF
--- a/lib/ex_unit/lib/ex_unit/callbacks.ex
+++ b/lib/ex_unit/lib/ex_unit/callbacks.ex
@@ -193,7 +193,7 @@ defmodule ExUnit.Callbacks do
 
   ## Examples
 
-      def clean_up_tmp_directory(context) do
+      defp clean_up_tmp_directory(context) do
         # perform setup
         :ok
       end
@@ -288,7 +288,7 @@ defmodule ExUnit.Callbacks do
       # One-arity function name
       setup_all :clean_up_tmp_directory
 
-      def clean_up_tmp_directory(_context) do
+      defp clean_up_tmp_directory(_context) do
         # perform setup
         :ok
       end


### PR DESCRIPTION
It uses `def clean_up_tmp_directory` in the docs when defining the setup callback, giving the impression that this function has to be public, when it is not the case.

This commits changes it to `defp`