### PR TITLE
Add new.task mix task to generate a new task file

### DIFF
--- a/lib/mix/lib/mix/tasks/new.task.ex
+++ b/lib/mix/lib/mix/tasks/new.task.ex
@@ -1,0 +1,56 @@
+defmodule Mix.Tasks.New.Task do
+  use Mix.Task
+  import Mix.Generator
+
+  @impl true
+  def run(argv) do
+    case argv do
+      [] ->
+        Mix.raise("Expected TASK_NAME to be given, please use \"mix new.task TASK_NAME\"")
+
+      [task_name] ->
+        assigns = %{
+          command: task_name,
+          module:
+            "Mix.Tasks.#{task_name}"
+            |> String.split(".")
+            |> Enum.map_join(".", &Macro.camelize/1)
+        }
+
+        path = "lib/mix/tasks/#{task_name}.ex"
+
+        unless File.dir?("lib/mix/tasks") do
+          create_directory("lib/mix/tasks")
+        end
+
+        create_file(path, task_template(assigns))
+
+        """
+
+        Your Mix task was created successfully.
+
+        You can invoke your task by compiling your project and running:
+
+            mix #{task_name}
+
+        Run "mix help #{task_name}" to view the documentation.
+        """
+        |> String.trim_trailing()
+        |> Mix.shell().info()
+    end
+  end
+
+  embed_template(:task, """
+  defmodule <%= @module %> do
+    use Mix.Task
+
+    @shortdoc "A placeholder shortdoc for mix <%= @command %>"
+    @moduledoc @shortdoc
+
+    @doc false
+    def run(argv) do
+      # Fill me in!
+    end
+  end
+  """)
+end

--- a/lib/mix/test/mix/tasks/new.task_test.exs
+++ b/lib/mix/test/mix/tasks/new.task_test.exs
@@ -1,0 +1,45 @@
+Code.require_file("../../test_helper.exs", __DIR__)
+
+defmodule Mix.Tasks.New.TaskTest do
+  use MixTest.Case
+
+  test "new.task" do
+    in_fixture("git_repo", fn ->
+      Mix.Tasks.New.Task.run(["gen.controller"])
+
+      assert_received {:mix_shell, :info, ["* creating lib/mix/tasks"]}
+      assert_received {:mix_shell, :info, ["* creating lib/mix/tasks/gen.controller.ex"]}
+
+      assert_file("lib/mix/tasks/gen.controller.ex", fn file ->
+        assert file == """
+               defmodule Mix.Tasks.Gen.Controller do
+                 use Mix.Task
+
+                 @shortdoc "A placeholder shortdoc for mix gen.controller"
+                 @moduledoc @shortdoc
+
+                 @doc false
+                 def run(argv) do
+                   # Fill me in!
+                 end
+               end
+               """
+      end)
+    end)
+  end
+
+  defp assert_file(file) do
+    assert File.regular?(file), "Expected #{file} to exist, but does not"
+  end
+
+  defp assert_file(file, match) do
+    cond do
+      is_struct(match, Regex) ->
+        assert_file(file, &assert(&1 =~ match))
+
+      is_function(match, 1) ->
+        assert_file(file)
+        match.(File.read!(file))
+    end
+  end
+end


### PR DESCRIPTION
Historically, I haven't used mix tasks as often as I probably might have because I always needed to look up the docs to remind myself of the convention for the file path and module name.

This adds a mix task that will generate a new task file in the proper location.

I took advantage of a burst of motivation and knocked out the core of this, so I apologize for not first submitting a proposal on the mailing list. This is unsolicited, so no hard feelings if this is not something you are interested in 😄.

Thank you for the consideration!

---

A list of some potential improvements below, and I am open to any and all feedback!

TODO:

- [ ] Naming: I named this new.task to follow the existing `new` task, but many libraries follow the `gen.thing` convention. I don't mind either way.
- [ ] Better placeholder text in the `run/1` function as well as the doc attributes.
- [ ] Better re-use of test functions. There is a function that is duplicated from the `mix new` test file
- [ ] Considerations: I didn't want to get too far along before proposing this change, but there are some things that should be considered.
    - Only allow to create in a mix project.
    - Option to pick a project to generate in if running this in the root of an umbrella project.
- [ ] Options: What options should be available?
    - `--path=lib/to/custom/path` ?
