### PR TITLE
Fix a typo in Supervisor doc

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -82,7 +82,7 @@ defmodule Supervisor do
       GenServer.call(Counter, :get)
       #=> 0
 
-      GenServer.cast(Counter, {:bump, 3})
+      GenServer.call(Counter, {:bump, 3})
       #=> 0
 
       GenServer.call(Counter, :get)


### PR DESCRIPTION
I think I have found a typo in the Supervisor doc.