### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,11 @@ env:
   ERLC_OPTS: "warnings_as_errors"
   LANG: C.UTF-8
 
+permissions:
+  contents: write
+
 jobs:
   create_draft_release:
-    permissions:
-      contents: write
     runs-on: ubuntu-20.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently the `release_pre_built` runs with [default permissions](https://github.com/elixir-lang/elixir/actions/runs/2973908806/jobs/4764060366) granted on `push`:
```
GITHUB_TOKEN Permissions
  Actions: write
  Checks: write
  Contents: write
  Deployments: write
  Discussions: write
  Issues: write
  Metadata: read
  Packages: write
  Pages: write
  PullRequests: write
  RepositoryProjects: write
  SecurityEvents: write
  Statuses: write
```
This is unnecessary and can be restricted to `contents: write` only.