### PR TITLE
Add complete list of time units on DateTime.add/3 argument error

### DIFF
--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1530,7 +1530,7 @@ defmodule DateTime do
     } = datetime
 
     if not is_integer(unit) and
-         unit not in ~w(day hour minute second millisecond microsecond nanosecond)a do
+         unit not in ~w(second millisecond microsecond nanosecond)a do
       raise ArgumentError,
             "unsupported time unit. Expected :day, :hour, :minute, :second, :millisecond, :microsecond, :nanosecond, or a positive integer, got #{inspect(unit)}"
     end

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1529,6 +1529,12 @@ defmodule DateTime do
       microsecond: {_, precision}
     } = datetime
 
+    if not is_integer(unit) and
+         unit not in ~w(day hour minute second millisecond microsecond nanosecond)a do
+      raise ArgumentError,
+            "unsupported time unit. Expected :day, :hour, :minute, :second, :millisecond, :microsecond, :nanosecond, or a positive integer, got #{inspect(unit)}"
+    end
+
     ppd = System.convert_time_unit(86400, :second, unit)
     total_offset = System.convert_time_unit(utc_offset + std_offset, :second, unit)
 

--- a/lib/elixir/test/elixir/calendar/datetime_test.exs
+++ b/lib/elixir/test/elixir/calendar/datetime_test.exs
@@ -958,6 +958,15 @@ defmodule DateTimeTest do
   end
 
   describe "add" do
+    test "add with invalid time unit" do
+      dt = DateTime.utc_now()
+
+      message =
+        ~r/unsupported time unit\. Expected :day, :hour, :minute, :second, :millisecond, :microsecond, :nanosecond, or a positive integer, got "day"/
+
+      assert_raise ArgumentError, message, fn -> DateTime.add(dt, 1, "day") end
+    end
+
     test "add with non-struct map that conforms to Calendar.datetime" do
       dt_map = DateTime.from_naive!(~N[2018-08-28 00:00:00], "Etc/UTC") |> Map.from_struct()
 


### PR DESCRIPTION
Got an argument error that I think could be more helpful:

```sh
 ** (ArgumentError) unsupported time unit. Expected :second, :millisecond, :microsecond, :nanosecond, or a positive integer, got "day"
     code: DateTime.add(DateTime.utc_now(), -1, "day")
```

I expected to have all the supported time unit in the error. Since the error comes from `System.convert_time_unit`, I simply added a conditional that raise a new error.