### PR TITLE
Update String docs on string size

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -173,6 +173,26 @@ defmodule String do
   For converting a binary to a different encoding and for Unicode
   normalization mechanisms, see Erlang's `:unicode` module.
 
+  ### A note on graphemes and actual string size
+
+  Like we've seen before, some graphemes may have multiple code points.
+  If you call the function `String.to_charlist/1`, you'll see that the
+  character `é` is represented by two codepoints: `[101, 769]` while the
+  character `é` is represented by a single codepoint: `[233]`.
+
+  If you need to store a string somewhere, you might be tempted to use
+  something like `String.length/1` or `String.slice/2` for validation.
+  For example, let's imagine that we want to store a very long text into
+  a `varchar(255)` column in a sql database:
+
+      iex> String.slice(very_long_text, 0..254)
+
+  This is a naive approach, because it does not take the actual size of
+  the encoded string into consideration, which may be slightly different.
+
+  For those cases, you might want to normalize the string first using something
+  like `String.normalize/2` so you always get the expected amount of bytes per grapheme.
+
   ## String and binary operations
 
   To act according to the Unicode Standard, many functions


### PR DESCRIPTION
Follow up on: https://github.com/elixir-lang/elixir/pull/12155.

Hi @josevalim! Thanks for the suggestion on the previous PR. I didn't see the duplication at first, but after re-reading the String module docs I think that some of the things were already explained there. I'm not sure if (for this particular use-case) it would be clear if I was reading for the first time, though. So, I created a small subsection on the topic of Grapheme clusters to make bring attention to this perceived difference between string length and actual size.

I had to make some changes to the original text considering what was already explained. See if you think it helps. Cheers!

PS.: I accidentally closed the PR and could not update the branch anymore 🙈

**Update**: BTW, this is something that is starting to look more obvious to me now that I'm familiar with the problem, but it wasn't until I had finished reading the original issue. Perhaps there's a better way to make these remarks, any suggestions? 