### PR TITLE
Don't mark modules that are transitive runtime dependecies as stale (?)

### DIFF
--- a/lib/mix/lib/mix/compilers/elixir.ex
+++ b/lib/mix/lib/mix/compilers/elixir.ex
@@ -479,15 +479,14 @@ defmodule Mix.Compilers.Elixir do
     module(module: module, sources: source_files, export: export) = entry
     {rest, exports, changed, stale} = acc
 
-    {compile_references, export_references, runtime_references} =
-      Enum.reduce(source_files, {[], [], []}, fn file, {compile_acc, export_acc, runtime_acc} ->
+    {compile_references, export_references} =
+      Enum.reduce(source_files, {[], []}, fn file, {compile_acc, export_acc} ->
         source(
           compile_references: compile_refs,
-          export_references: export_refs,
-          runtime_references: runtime_refs
+          export_references: export_refs
         ) = List.keyfind(sources, file, source(:source))
 
-        {compile_acc ++ compile_refs, export_acc ++ export_refs, runtime_acc ++ runtime_refs}
+        {compile_acc ++ compile_refs, export_acc ++ export_refs}
       end)
 
     cond do
@@ -499,11 +498,6 @@ defmodule Mix.Compilers.Elixir do
         remove_and_purge(beam_path(compile_path, module), module)
         changed = Enum.reduce(source_files, changed, &Map.put(&2, &1, true))
         {rest, Map.put(exports, module, export), changed, Map.put(stale, module, true)}
-
-      # If I have a runtime references to something stale,
-      # I am stale too.
-      has_any_key?(stale, runtime_references) ->
-        {[entry | rest], exports, changed, Map.put(stale, module, true)}
 
       # Otherwise, we don't store it anywhere
       true ->


### PR DESCRIPTION
This is possibly just an inquiry / question, if it's not the right place for it, please feel free to close and I'll send it on the mailing list or the elixir forum :)

In my project at work I have noticed that I have a set of ~30 modules that recompile on almost every change, even a seemingly unrelated one. I narrowed it down to this clause in the Elixir compiler, where all transitive runtime dependencies of a changed module get marked as "stale". Then, because of that, all modules that have a compile-time dependency of any of those (in my case 550) "stale" modules need to be recompiled (in my case, these are the 30 modules often being recompiled).

I have investigated removing the compile dependencies, but one thing I don't understand is: why is this clause needed? In what scenarios a transitive runtime dependency should "activate" an unrelated compile dependency? The Elixir compiler tests are passing without this clause.