### PR TITLE
Fix formatter edge case on :erlang.binary_to_atom/2

### DIFF
--- a/lib/elixir/lib/code/normalizer.ex
+++ b/lib/elixir/lib/code/normalizer.ex
@@ -77,6 +77,14 @@ defmodule Code.Normalizer do
     dot_meta = patch_meta_line(dot_meta, state.parent_meta)
     call_meta = patch_meta_line(call_meta, dot_meta)
 
+    utf8 =
+      if args == [] or interpolated?(string) do
+        # a non-normalized :utf8 atom signals an atom interpolation
+        :utf8
+      else
+        normalize_literal(:utf8, [], state)
+      end
+
     string =
       if state.escape do
         normalize_bitstring(string, state, true)
@@ -84,7 +92,7 @@ defmodule Code.Normalizer do
         normalize_bitstring(string, state)
       end
 
-    {{:., dot_meta, [:erlang, :binary_to_atom]}, call_meta, [string, :utf8]}
+    {{:., dot_meta, [:erlang, :binary_to_atom]}, call_meta, [string, utf8]}
   end
 
   # Charlists with interpolations

--- a/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
+++ b/lib/elixir/test/elixir/code_normalizer/quoted_ast_test.exs
@@ -725,6 +725,13 @@ defmodule Code.Normalizer.QuotedASTTest do
 
       assert quoted_to_string(quote(do: :"one\n\"#{2}\"\nthree")) == ~S[:"one\n\"#{2}\"\nthree"]
     end
+
+    test ":erlang.binary_to_atom/2 edge cases" do
+      assert quoted_to_string(quote(do: :erlang.binary_to_atom(<<>>, :utf8))) == ~S[:""]
+
+      assert quoted_to_string(quote(do: :erlang.binary_to_atom(<<1>>, :utf8))) ==
+               ~S":erlang.binary_to_atom(<<1>>, :utf8)"
+    end
   end
 
   describe "quoted_to_algebra/2 does not escape" do


### PR DESCRIPTION
Closes #12162

The problem is that `:erlang.binary_to_atom(<<...>>), :utf8)` is an edge case algebra-wise (https://github.com/elixir-lang/elixir/blob/main/lib/elixir/lib/code/normalizer.ex#L87) because it represents an atom interpolation:

```elixir
iex(1)> Code.quoted_to_algebra(quote do: :erlang.binary_to_atom(<<>>, :utf8))
{:doc_group, {:doc_cons, ":\"", "\""}, :self}
```

The formatter makes the distinction where the string isn't actually interpolated [here](https://github.com/elixir-lang/elixir/blob/main/lib/elixir/lib/code/formatter.ex#L343), but the normalizer emitted a non-normalized `:utf8` literal which breaks the formatter.