### PR TITLE
New `--scm` flag for Mix to initialize project as SCM repo

### DIFF
--- a/lib/mix/lib/mix/tasks/new.ex
+++ b/lib/mix/lib/mix/tasks/new.ex
@@ -8,7 +8,7 @@ defmodule Mix.Tasks.New do
   Creates a new Elixir project.
   It expects the path of the project as argument.
 
-      mix new PATH [--app APP] [--module MODULE] [--sup] [--umbrella] [--scm]
+      $ mix new PATH [--app APP] [--module MODULE] [--sup] [--umbrella] [--scm]
 
   A project at the given PATH will be created. The
   application name and module name will be retrieved
@@ -33,25 +33,25 @@ defmodule Mix.Tasks.New do
 
   ## Examples
 
-      mix new hello_world
+      $ mix new hello_world
 
   Is equivalent to:
 
-      mix new hello_world --module HelloWorld
+      $ mix new hello_world --module HelloWorld
 
   To generate an app with a supervision tree and an application callback:
 
-      mix new hello_world --sup
+      $ mix new hello_world --sup
 
   To generate an umbrella application with sub applications:
 
-      mix new hello_world --umbrella
-      cd hello_world/apps
-      mix new child_app
+      $ mix new hello_world --umbrella
+      $ cd hello_world/apps
+      $ mix new child_app
 
   To create a project with an SCM repository initialized:
 
-     mix new hello_world --scm
+      $ mix new hello_world --scm
   """
 
   @switches [

--- a/lib/mix/test/mix/tasks/new_test.exs
+++ b/lib/mix/test/mix/tasks/new_test.exs
@@ -151,6 +151,13 @@ defmodule Mix.Tasks.NewTest do
     end)
   end
 
+  test "new with --scm" do
+    in_tmp("new with scm", fn ->
+      Mix.Tasks.New.run(["--scm", "hello_world"])
+      assert_dir(".git")
+    end)
+  end
+
   test "new with invalid args" do
     in_tmp("new with an invalid application name", fn ->
       assert_raise Mix.Error,
@@ -233,5 +240,9 @@ defmodule Mix.Tasks.NewTest do
         assert_file(file)
         match.(File.read!(file))
     end
+  end
+
+  defp assert_dir(dir) do
+    assert File.dir?(dir), "Expected #{dir} to exist, but does not"
   end
 end

--- a/lib/mix/test/mix/tasks/new_test.exs
+++ b/lib/mix/test/mix/tasks/new_test.exs
@@ -153,7 +153,7 @@ defmodule Mix.Tasks.NewTest do
 
   test "new with --scm" do
     in_tmp("new with scm", fn ->
-      Mix.Tasks.New.run(["--scm", "hello_world"])
+      Mix.Tasks.New.run(["hello_world", "--scm"])
       assert_dir(".git")
     end)
   end


### PR DESCRIPTION
Hi all, this is my first attempt to contribute to this awesome project. 

This PR implements the following:

- A new `--scm` optional flag for `Mix` to initialize projects/apps as a repository.

This is not a big improvement, but I always liked that Rails did that by default. This attempts to use Git to initialize a repository, but
the SCM software to use can be set by using an environment variable called `EX_SCM_INIT`.

The naming choice is up for debate too, in case this is accepted. If this change is not deemed useful I understand. 

Thanks for making and maintaining Elixir!
