### PR TITLE
Add typespec for Logger.Translator.translate/4

### DIFF
--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -29,9 +29,16 @@ defmodule Logger.Translator do
   and the default messages translated by Logger.
   """
 
+  @type result ::
+          {:ok, iodata, keyword}
+          | {:ok, iodata}
+          | :skip
+          | :none
+
   @doc """
   Built-in translation function.
   """
+  @spec translate(Logger.level(), Logger.level(), :format | :report, :logger.report()) :: result
   def translate(min_level, level, kind, message)
 
   def translate(min_level, _level, :report, {:logger, %{label: label} = report}) do

--- a/lib/logger/lib/logger/translator.ex
+++ b/lib/logger/lib/logger/translator.ex
@@ -29,16 +29,18 @@ defmodule Logger.Translator do
   and the default messages translated by Logger.
   """
 
-  @type result ::
-          {:ok, iodata, keyword}
-          | {:ok, iodata}
-          | :skip
-          | :none
+  @doc """
+  Callback for translating a logger message.
+  """
+  @callback translate(Logger.level(), Logger.level(), :format | :report, :logger.report()) ::
+              {:ok, iodata, keyword}
+              | {:ok, iodata}
+              | :skip
+              | :none
 
   @doc """
   Built-in translation function.
   """
-  @spec translate(Logger.level(), Logger.level(), :format | :report, :logger.report()) :: result
   def translate(min_level, level, kind, message)
 
   def translate(min_level, _level, :report, {:logger, %{label: label} = report}) do


### PR DESCRIPTION
While implementing a custom `Logger.Translator`, I discovered that there weren't any types specified. This could help others in a similar situation.