### PR TITLE
Support "def cli" in Mix.Project

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -108,6 +108,17 @@ defmodule Mix do
 
       {:some_test_dependency, "~> 1.0", only: :test}
 
+  When running Mix via the command line, you can configure the default
+  environment or the preferred environment per task via the `def cli`
+  function in your `mix.exs`. For example:
+
+      def cli do
+        [
+          default_env: :local,
+          preferred_envs: [docs: :docs]
+        ]
+      end
+
   The environment can be read via `Mix.env/0`.
 
   ## Targets
@@ -116,6 +127,18 @@ defmodule Mix do
   project needs to compile to different architectures and some of the
   dependencies are only available to some of them. By default, the target
   is `:host` but it can be set via the `MIX_TARGET` environment variable.
+
+  When running Mix via the command line, you can configure the default
+  target or the preferred target per task via the `def cli` function
+  in your `mix.exs`. For example:
+
+      def cli do
+        [
+          default_target: :local,
+          preferred_targets: [docs: :docs]
+        ]
+      end
+
   The target can be read via `Mix.target/0`.
 
   ## Configuration
@@ -585,7 +608,7 @@ defmodule Mix do
         {:jason, "~> 1.0"}
       ])
 
-  Installing `:nx` & `:exla`, and configuring the underlying applications
+  Installing `:nx` and `:exla`, and configuring the underlying applications
   and environment variables:
 
       Mix.install(

--- a/lib/mix/lib/mix/project_stack.ex
+++ b/lib/mix/lib/mix/project_stack.ex
@@ -41,6 +41,14 @@ defmodule Mix.ProjectStack do
     end)
   end
 
+  @spec pop_post_config(atom) :: term
+  def pop_post_config(key) do
+    update_state(fn {stack, post_config} ->
+      {value, post_config} = Keyword.pop(post_config, key)
+      {value, {stack, post_config}}
+    end)
+  end
+
   @spec merge_config(config) :: :ok
   def merge_config(config) do
     update_stack(fn

--- a/lib/mix/lib/mix/task.ex
+++ b/lib/mix/lib/mix/task.ex
@@ -67,11 +67,6 @@ defmodule Mix.Task do
       on `mix help`
     * `@recursive` - runs the task recursively in umbrella projects
     * `@requirements` - list of required tasks to be run before the task
-    * `@preferred_cli_env` - recommends an environment in which to run the task.
-      It is used only if `MIX_ENV` is not yet set. Note `@preferred_cli_env` is
-      not loaded from dependencies as we need to know the environment in order to
-      load the dependencies themselves. In those cases, you can set the
-      `preferred_cli_env` configuration under `def project` in your `mix.exs`
 
   ## Documentation
 
@@ -213,24 +208,8 @@ defmodule Mix.Task do
     Mix.ProjectStack.recursing() != nil
   end
 
-  @doc """
-  Gets preferred CLI environment for the task.
-
-  Returns environment (for example, `:test`, or `:prod`), or `nil`.
-  """
-  @spec preferred_cli_env(task_name) :: atom | nil
-  def preferred_cli_env(task) when is_atom(task) or is_binary(task) do
-    case get(task) do
-      nil ->
-        nil
-
-      module ->
-        case List.keyfind(module.__info__(:attributes), :preferred_cli_env, 0) do
-          {:preferred_cli_env, [setting]} -> setting
-          _ -> nil
-        end
-    end
-  end
+  @deprecated "Configure the environment in your mix.exs"
+  defdelegate preferred_cli_env(task), to: Mix.CLI
 
   @doc """
   Gets the list of requirements for the given task.

--- a/lib/mix/lib/mix/tasks/help.ex
+++ b/lib/mix/lib/mix/tasks/help.ex
@@ -153,7 +153,16 @@ defmodule Mix.Tasks.Help do
   end
 
   defp display_default_task_doc(max) do
-    message = "Runs the default task (current: \"mix #{Mix.Project.config()[:default_task]}\")"
+    project = Mix.Project.get()
+
+    default =
+      if function_exported?(project, :cli, 0) do
+        project.cli()[:default_task] || "run"
+      else
+        "run"
+      end
+
+    message = "Runs the default task (current: \"mix #{default}\")"
     Mix.shell().info(format_task("mix", max, message))
   end
 

--- a/lib/mix/lib/mix/tasks/test.coverage.ex
+++ b/lib/mix/lib/mix/tasks/test.coverage.ex
@@ -136,7 +136,6 @@ defmodule Mix.Tasks.Test.Coverage do
   """
 
   @shortdoc "Build report from exported test coverage"
-  @preferred_cli_env :test
   @default_threshold 90
 
   @doc false

--- a/lib/mix/lib/mix/tasks/test.ex
+++ b/lib/mix/lib/mix/tasks/test.ex
@@ -6,7 +6,6 @@ defmodule Mix.Tasks.Test do
   @compile {:no_warn_undefined, [ExUnit, ExUnit.Filters]}
   @shortdoc "Runs a project's tests"
   @recursive true
-  @preferred_cli_env :test
 
   @moduledoc ~S"""
   Runs the tests for a project.
@@ -470,7 +469,7 @@ defmodule Mix.Tasks.Test do
       end)
     end
 
-    unless System.get_env("MIX_ENV") || Mix.env() == @preferred_cli_env do
+    unless System.get_env("MIX_ENV") || Mix.env() == :test do
       Mix.raise("""
       "mix test" is running in the \"#{Mix.env()}\" environment. If you are \
       running tests from within another command, you can either:
@@ -479,9 +478,11 @@ defmodule Mix.Tasks.Test do
 
             MIX_ENV=test mix test.another
 
-        2. set the :preferred_cli_env for a command inside "def project" in your mix.exs:
+        2. set the :preferred_envs for "def cli" in your mix.exs:
 
-            preferred_cli_env: ["test.another": :test]
+            def cli do
+              [preferred_envs: ["test.another": :test]]
+            end
       """)
     end
 

--- a/lib/mix/test/mix/project_test.exs
+++ b/lib/mix/test/mix/project_test.exs
@@ -103,10 +103,6 @@ defmodule Mix.ProjectTest do
     assert is_nil(Mix.Project.config()[:app_path])
   end
 
-  test "retrieves configuration even when a project is not set" do
-    assert Mix.Project.config()[:default_task] == "run"
-  end
-
   test "raises an error when trying to retrieve the current project but none is set" do
     assert_raise Mix.NoProjectError, fn ->
       Mix.Project.get!()

--- a/lib/mix/test/mix/task_test.exs
+++ b/lib/mix/test/mix/task_test.exs
@@ -236,18 +236,6 @@ defmodule Mix.TaskTest do
     assert Mix.Task.moduledoc(Mix.Tasks.Hello) == "A test task.\n"
   end
 
-  test "preferred_cli_env/1 returns nil for missing task" do
-    assert Mix.Task.preferred_cli_env(:no_task) == nil
-  end
-
-  test "preferred_cli_env/1 returns nil when task does not have @preferred_cli_env attribute" do
-    assert Mix.Task.preferred_cli_env(:deps) == nil
-  end
-
-  test "preferred_cli_env/1 returns specified @preferred_cli_env attribute" do
-    assert Mix.Task.preferred_cli_env(:test) == :test
-  end
-
   test "shortdoc/1" do
     assert Mix.Task.shortdoc(Mix.Tasks.Hello) == "This is short documentation, see"
   end


### PR DESCRIPTION
The goal is to unify all CLI defaults in a single
in a way where we can load said configuration
before we load the project itself.

See the "CLI configuration" section in Mix.Project for more information.