### PR TITLE
Mix deps.get `--no-lockfile-update` parameter

### DIFF
--- a/lib/mix/lib/mix.ex
+++ b/lib/mix/lib/mix.ex
@@ -756,7 +756,7 @@ defmodule Mix do
                   lockfile = Path.join(install_dir, "mix.lock")
                   old_lock = Mix.Dep.Lock.read(lockfile)
                   new_lock = Mix.Dep.Lock.read(external_lockfile)
-                  Mix.Dep.Lock.write(lockfile, Map.merge(old_lock, new_lock))
+                  Mix.Dep.Lock.write(Map.merge(old_lock, new_lock), file: lockfile)
                   File.write!(md5_path, Base.encode64(new_md5))
                   Mix.Task.rerun("deps.get")
                 end

--- a/lib/mix/lib/mix/dep/fetcher.ex
+++ b/lib/mix/lib/mix/dep/fetcher.ex
@@ -113,7 +113,7 @@ defmodule Mix.Dep.Fetcher do
     # Merge the new lock on top of the old to guarantee we don't
     # leave out things that could not be fetched and save it.
     lock = Map.merge(old_lock, new_lock)
-    Mix.Dep.Lock.write(lock)
+    Mix.Dep.Lock.write(lock, opts)
     mark_as_fetched(parent_deps)
 
     # See if any of the deps diverged and abort.

--- a/lib/mix/lib/mix/dep/lock.ex
+++ b/lib/mix/lib/mix/dep/lock.ex
@@ -26,9 +26,15 @@ defmodule Mix.Dep.Lock do
   @doc """
   Receives a map and writes it as the latest lock.
   """
-  @spec write(Path.t(), map()) :: :ok
-  def write(lockfile \\ lockfile(), map) do
+  @spec write(map(), keyword) :: :ok
+  def write(map, opts \\ []) do
+    lockfile = Keyword.get(opts, :file, lockfile())
+
     unless map == read() do
+      unless Keyword.get(opts, :allow_updates, true) do
+        Mix.raise("Your #{lockfile} needs to be updated")
+      end
+
       lines =
         for {app, rev} <- Enum.sort(map), rev != nil do
           ~s(  "#{app}": #{inspect(rev, limit: :infinity)},\n)

--- a/lib/mix/lib/mix/tasks/deps.get.ex
+++ b/lib/mix/lib/mix/tasks/deps.get.ex
@@ -11,6 +11,7 @@ defmodule Mix.Tasks.Deps.Get do
 
     * `--only` - only fetches dependencies for given environment
     * `--no-archives-check` - does not check archives before fetching deps
+    * `--no-lockfile-update` - does not update lockfile. Exits non-zero if there are going to be changes in the lockfile
 
   """
 
@@ -21,10 +22,10 @@ defmodule Mix.Tasks.Deps.Get do
     end
 
     Mix.Project.get!()
-    {opts, _, _} = OptionParser.parse(args, switches: [only: :string, target: :string])
+    {opts, _, _} = OptionParser.parse(args, switches: [only: :string, target: :string, lockfile_update: :boolean])
 
     fetch_opts =
-      for {switch, key} <- [only: :env, target: :target],
+      for {switch, key} <- [only: :env, target: :target, lockfile_update: :allow_updates],
           value = opts[switch],
           do: {key, :"#{value}"}
 

--- a/lib/mix/test/mix/dep/lock_test.exs
+++ b/lib/mix/test/mix/dep/lock_test.exs
@@ -42,6 +42,18 @@ defmodule Mix.Dep.LockTest do
     end)
   end
 
+  test "raises a proper error if allow_updates opt is false and there are changes", context do
+    in_tmp(context.test, fn ->
+      Mix.Dep.Lock.write(%{foo: :bar})
+
+      Mix.Dep.Lock.write(%{foo: :bar}, allow_updates: false)
+
+      assert_raise Mix.Error, ~r/Your mix\.lock needs to be updated/, fn ->
+        Mix.Dep.Lock.write(%{foo: :bar, bar: :bat}, allow_updates: false)
+      end
+    end)
+  end
+
   test "raises a proper error for merge conflicts", context do
     in_tmp(context.test, fn ->
       File.write("mix.lock", ~S"""

--- a/lib/mix/test/mix_test.exs
+++ b/lib/mix/test/mix_test.exs
@@ -222,7 +222,7 @@ defmodule MixTest do
       Mix.Project.push(GitApp)
       [_latest_rev, rev | _] = get_git_repo_revs("git_repo")
       lockfile = Path.join(tmp_dir, "lock")
-      Mix.Dep.Lock.write(lockfile, %{git_repo: {:git, fixture_path("git_repo"), rev, []}})
+      Mix.Dep.Lock.write(%{git_repo: {:git, fixture_path("git_repo"), rev, []}}, file: lockfile)
       Mix.ProjectStack.pop()
 
       Mix.install(
@@ -256,7 +256,7 @@ defmodule MixTest do
 
       Mix.Project.push(GitApp)
       lockfile = Path.join(tmp_dir, "lock")
-      Mix.Dep.Lock.write(lockfile, %{git_repo: {:git, fixture_path("git_repo"), rev2, []}})
+      Mix.Dep.Lock.write(%{git_repo: {:git, fixture_path("git_repo"), rev2, []}}, file: lockfile)
       Mix.ProjectStack.pop()
 
       Mix.install(


### PR DESCRIPTION
Implements https://groups.google.com/g/elixir-lang-core/c/Jr2CS6o2elo/m/Lq3r5plfBQAJ proposal by introducing `--no-lockfile-update` argument to `mix deps.get` task that raises when lockfile needs to be updated but the flag is set to true

The idea is to have a way to prevent a CI pipeline from running successfully when a change in the application deps are not reflected in an update to the lockfile.

Similarly to [bundler install --frozen](https://bundler.io/man/bundle-install.1.html) and [yarn --frozen-lockfile](https://classic.yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-frozen-lockfile)

## TODO
- E2E testing, I need support for this one