### PR TITLE
add example to ExUnit.Assertions.assert_raise/2 doc

### DIFF
--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -755,10 +755,8 @@ defmodule ExUnit.Assertions do
         1 + "test"
       end
 
-  To test a function that requires arguments, wrap it:
-
-      assert_raise ArithmeticError, fn ->
-        my_add(1, "test")
+      assert_raise RuntimeError, fn ->
+        raise "assertion will pass due to this raise"
       end
 
   """

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -755,7 +755,7 @@ defmodule ExUnit.Assertions do
         1 + "test"
       end
 
-  To test a fuction that requires arguements, wrap it:
+  To test a function that requires arguments, wrap it:
 
       assert_raise ArithmeticError, fn ->
         my_add(1, "test")

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -755,6 +755,12 @@ defmodule ExUnit.Assertions do
         1 + "test"
       end
 
+  To pass arguments to `function`, wrap it:
+
+      assert_raise ArithmeticError, fn ->
+        my_add(1, "test")
+      end
+
   """
   def assert_raise(exception, function) when is_function(function) do
     try do

--- a/lib/ex_unit/lib/ex_unit/assertions.ex
+++ b/lib/ex_unit/lib/ex_unit/assertions.ex
@@ -755,7 +755,7 @@ defmodule ExUnit.Assertions do
         1 + "test"
       end
 
-  To pass arguments to `function`, wrap it:
+  To test a fuction that requires arguements, wrap it:
 
       assert_raise ArithmeticError, fn ->
         my_add(1, "test")


### PR DESCRIPTION
adding an example of how to pass arguments to the function you want to assert raises an exception