### PR TITLE
Ignore defguards in typecheck

### DIFF
--- a/lib/elixir/lib/kernel/utils.ex
+++ b/lib/elixir/lib/kernel/utils.ex
@@ -348,16 +348,19 @@ defmodule Kernel.Utils do
 
   # Finds every reference to `refs` in `guard` and wraps them in an unquote.
   defp unquote_every_ref(guard, refs) do
-    Macro.postwalk(guard, fn
-      {ref, meta, context} = var when is_atom(ref) and is_atom(context) ->
-        case {ref, var_context(meta, context)} in refs do
-          true -> literal_unquote(var)
-          false -> var
-        end
+    Macro.update_meta(
+      Macro.postwalk(guard, fn
+        {ref, meta, context} = var when is_atom(ref) and is_atom(context) ->
+          case {ref, var_context(meta, context)} in refs do
+            true -> literal_unquote(var)
+            false -> var
+          end
 
-      node ->
-        node
-    end)
+        node ->
+          node
+      end),
+      &([generated: true] ++ &1)
+    )
   end
 
   # Prefaces `guard` with unquoted versions of `refs`.

--- a/lib/elixir/test/elixir/module/types/types_test.exs
+++ b/lib/elixir/test/elixir/module/types/types_test.exs
@@ -213,6 +213,21 @@ defmodule Module.Types.TypesTest do
       assert string == :none
     end
 
+    defguard tuple_or_nil(term) when is_tuple(term) or is_nil(term)
+
+    test "does not warn on guards defined with defguard" do
+      string =
+        warning(
+          [var],
+          [is_atom(var)],
+          case var do
+            _ when tuple_or_nil(var) -> :ok
+          end
+        )
+
+      assert string == :none
+    end
+
     test "check body" do
       string = warning([x], [is_integer(x)], :foo = x)
 


### PR DESCRIPTION
Close https://github.com/elixir-lang/elixir/issues/10485

Note: I'm not sure it is such a good thing to automatically make all custom guards generated, maybe this should be opt-in? For instance, with a custom attribute, `@mark_as_generated tuple_or_nil`?
