### PR TITLE
Add old_erlang_sup_flags

### DIFF
--- a/lib/elixir/lib/supervisor.ex
+++ b/lib/elixir/lib/supervisor.ex
@@ -525,7 +525,8 @@ defmodule Supervisor do
   """
   @callback init(init_arg :: term) ::
               {:ok,
-               {sup_flags(), [child_spec() | (old_erlang_child_spec :: :supervisor.child_spec())]}}
+               {sup_flags() | (old_erlang_sup_flags :: :supervisor.sup_flags()),
+                [child_spec() | (old_erlang_child_spec :: :supervisor.child_spec())]}}
               | :ignore
 
   @typedoc "Return values of `start_link` functions"
@@ -709,7 +710,8 @@ defmodule Supervisor do
           [init_option]
         ) ::
           {:ok,
-           {sup_flags(), [child_spec() | (old_erlang_child_spec :: :supervisor.child_spec())]}}
+           {sup_flags() | (old_erlang_sup_flags :: :supervisor.sup_flags()),
+            [child_spec() | (old_erlang_child_spec :: :supervisor.child_spec())]}}
   def init(children, options) when is_list(children) and is_list(options) do
     strategy =
       case options[:strategy] do


### PR DESCRIPTION
This commit adds `old_erlang_sup_flags` (i.e., `:supervisor.sup_flags/0`) to the callback definition of init and its default implementation, otherwise one might follow the docs and end up with dialyzer errors.