### PR TITLE
start to add config to ex_unit colors

### DIFF
--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -236,13 +236,13 @@ defmodule ExUnit do
     * `:colors` - a keyword list of color options to be used by some formatters:
       * `:enabled` - boolean option to enable colors, defaults to `IO.ANSI.enabled?/0`;
       
-      * `:success` - success message (defaults to :green)
-      * `:invalid` - invalid test message (defaults to :yellow)
-      * `:skipped` - skipped test message (defaults to :yellow)
-      * `:failure` - failed test message (defaults to :red)
-      * `:error_info` - display of actual error (defaults to :red)
-      * `:extra_info` - additional information (defaults to :cyan)
-      * `:location_info` - filename and tags (defaults to :bright, :black)
+      * `:success` - success message (defaults to `:green`)
+      * `:invalid` - invalid test message (defaults to `:yellow`)
+      * `:skipped` - skipped test message (defaults to `:yellow`)
+      * `:failure` - failed test message (defaults to `:red`)
+      * `:error_info` - display of actual error (defaults to `:red`)
+      * `:extra_info` - additional information (defaults to `:cyan`)
+      * `:location_info` - filename and tags (defaults to `[:bright, :black]`)
       * `:diff_insert` - color of the insertions on diffs, defaults to `:green`;
       * `:diff_insert_whitespace` - color of the whitespace insertions on diffs,
         defaults to `IO.ANSI.color_background(2, 0, 0)`;

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -243,7 +243,6 @@ defmodule ExUnit do
       * `:error_info` - display of actual error (defaults to :red)
       * `:extra_info` - additional information (defaults to :cyan)
       * `:location_info` - filename and tags (defaults to :bright, :black)
-      * `:blame_diff` - highlight differences leading to error (defaults to :red)
       * `:diff_insert` - color of the insertions on diffs, defaults to `:green`;
       * `:diff_insert_whitespace` - color of the whitespace insertions on diffs,
         defaults to `IO.ANSI.color_background(2, 0, 0)`;

--- a/lib/ex_unit/lib/ex_unit.ex
+++ b/lib/ex_unit/lib/ex_unit.ex
@@ -235,6 +235,15 @@ defmodule ExUnit do
 
     * `:colors` - a keyword list of color options to be used by some formatters:
       * `:enabled` - boolean option to enable colors, defaults to `IO.ANSI.enabled?/0`;
+      
+      * `:success` - success message (defaults to :green)
+      * `:invalid` - invalid test message (defaults to :yellow)
+      * `:skipped` - skipped test message (defaults to :yellow)
+      * `:failure` - failed test message (defaults to :red)
+      * `:error_info` - display of actual error (defaults to :red)
+      * `:extra_info` - additional information (defaults to :cyan)
+      * `:location_info` - filename and tags (defaults to :bright, :black)
+      * `:blame_diff` - highlight differences leading to error (defaults to :red)
       * `:diff_insert` - color of the insertions on diffs, defaults to `:green`;
       * `:diff_insert_whitespace` - color of the whitespace insertions on diffs,
         defaults to `IO.ANSI.color_background(2, 0, 0)`;

--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -353,7 +353,7 @@ defmodule ExUnit.CLIFormatter do
 
   defp colorize(escape, string, %{colors: colors}) do
     if colors[:enabled] do
-      [ Keyword.get(colors, escape, escape), string, :reset]
+      [Keyword.get(colors, escape, escape), string, :reset]
       |> IO.ANSI.format_fragment(true)
       |> IO.iodata_to_binary()
     else
@@ -405,7 +405,7 @@ defmodule ExUnit.CLIFormatter do
 
   defp formatter(:blame_diff, msg, %{colors: colors} = config) do
     if colors[:enabled] do
-      colorize(:blame_diff, msg, config)
+      colorize(:diff_delete, msg, config)
     else
       "-" <> msg <> "-"
     end
@@ -434,11 +434,10 @@ defmodule ExUnit.CLIFormatter do
     invalid: :yellow,
     skipped: :yellow,
     failure: :red,
-
     error_info: :red,
     extra_info: :cyan,
-    location_info: [ :bright, :black ],
-    blame_diff: :red,
+    location_info: [:bright, :black],
+    blame_diff: :red
   ]
 
   defp colors(opts) do

--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -353,7 +353,7 @@ defmodule ExUnit.CLIFormatter do
 
   defp colorize(escape, string, %{colors: colors}) do
     if colors[:enabled] do
-      [escape, string, :reset]
+      [ Keyword.get(colors, escape, escape), string, :reset]
       |> IO.ANSI.format_fragment(true)
       |> IO.iodata_to_binary()
     else
@@ -370,28 +370,28 @@ defmodule ExUnit.CLIFormatter do
   end
 
   defp success(msg, config) do
-    colorize(:green, msg, config)
+    colorize(:success, msg, config)
   end
 
   defp invalid(msg, config) do
-    colorize(:yellow, msg, config)
+    colorize(:invalid, msg, config)
   end
 
   defp skipped(msg, config) do
-    colorize(:yellow, msg, config)
+    colorize(:skipped, msg, config)
   end
 
   defp failure(msg, config) do
-    colorize(:red, msg, config)
+    colorize(:failure, msg, config)
   end
 
   defp formatter(:diff_enabled?, _, %{colors: colors}), do: colors[:enabled]
 
-  defp formatter(:error_info, msg, config), do: colorize(:red, msg, config)
+  defp formatter(:error_info, msg, config), do: colorize(:error_info, msg, config)
 
-  defp formatter(:extra_info, msg, config), do: colorize(:cyan, msg, config)
+  defp formatter(:extra_info, msg, config), do: colorize(:extra_info, msg, config)
 
-  defp formatter(:location_info, msg, config), do: colorize([:bright, :black], msg, config)
+  defp formatter(:location_info, msg, config), do: colorize(:location_info, msg, config)
 
   defp formatter(:diff_delete, doc, config), do: colorize_doc(:diff_delete, doc, config)
 
@@ -405,7 +405,7 @@ defmodule ExUnit.CLIFormatter do
 
   defp formatter(:blame_diff, msg, %{colors: colors} = config) do
     if colors[:enabled] do
-      colorize(:red, msg, config)
+      colorize(:blame_diff, msg, config)
     else
       "-" <> msg <> "-"
     end
@@ -427,7 +427,18 @@ defmodule ExUnit.CLIFormatter do
     diff_delete: :red,
     diff_delete_whitespace: IO.ANSI.color_background(2, 0, 0),
     diff_insert: :green,
-    diff_insert_whitespace: IO.ANSI.color_background(0, 2, 0)
+    diff_insert_whitespace: IO.ANSI.color_background(0, 2, 0),
+
+    # ex_unit messages
+    success: :green,
+    invalid: :yellow,
+    skipped: :yellow,
+    failure: :red,
+
+    error_info: :red,
+    extra_info: :cyan,
+    location_info: [ :bright, :black ],
+    blame_diff: :red,
   ]
 
   defp colors(opts) do

--- a/lib/ex_unit/lib/ex_unit/cli_formatter.ex
+++ b/lib/ex_unit/lib/ex_unit/cli_formatter.ex
@@ -429,15 +429,14 @@ defmodule ExUnit.CLIFormatter do
     diff_insert: :green,
     diff_insert_whitespace: IO.ANSI.color_background(0, 2, 0),
 
-    # ex_unit messages
+    # CLI formatter
     success: :green,
     invalid: :yellow,
     skipped: :yellow,
     failure: :red,
     error_info: :red,
     extra_info: :cyan,
-    location_info: [:bright, :black],
-    blame_diff: :red
+    location_info: [:bright, :black]
   ]
 
   defp colors(opts) do


### PR DESCRIPTION
So, I use a very dark gray terminal background, and the location part of the ex_unit output is not really readable:

![Screen Shot 2022-10-19 at 8 49 26 PM](https://user-images.githubusercontent.com/10648/196837186-02ad2a0d-0ae5-4175-9506-24c9ff363fd8.png)

I had a look at cli_formatter, and it seems the colors are hard coded. So I put together a trivial change to allow them all to be configured instead.

However, I couldn't work out how to test this: when I try to `make compile` I get:

~~~
20∙51∙02≻ make compile
==> unicode (compile)

20:51:06.671 [error] GenServer :elixir_code_server terminating
** (stop) {:badcast, {:reset_warnings, #PID<0.93.0>}}
Last message: {:"$gen_cast", {:reset_warnings, #PID<0.93.0>}}
State: {:elixir_code_server, %{}, {[], [], 0}, %{}}

== Compilation error in file lib/elixir/unicode/unicode.ex ==
** (UndefinedFunctionError) function Kernel.LexicalTracker.import_dispatch/4 is undefined or private. Did you mean one of:

      * import_dispatch/3
~~~

So, before diving deeply into the build system, I was hoping someone could look through the PR and say whether it would stand a chance of being merged.

TIA


Dave