### PR TITLE
Add precision to error message

### DIFF
--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -1300,7 +1300,8 @@ format_error({undefined_function, '|', [_, _]}) ->
   "misplaced operator |/2\n\n"
   "The | operator is typically used between brackets as the cons operator:\n\n"
   "    [head | tail]\n\n"
-  "where head is a single element and the tail is the remaining of a list.\n"
+  "where head is a sequence of elements separated by commas and the tail\n"
+  "is the remaining of a list.\n"
   "It is also used to update maps and structs, via the %{map | key: value} notation,\n"
   "and in typespecs, such as @type and @spec, to express the union of two types";
 format_error({undefined_function, '::', [_, _]}) ->


### PR DESCRIPTION
I was [playing around with `[foo: 1 | tail]`](https://elixirforum.com/t/syntax-to-augment-keyword/51305) and noticed that the error message for `|` is not quite accurate