### PR TITLE
Use orelse in for guard

### DIFF
--- a/lib/elixir/src/elixir_erl_for.erl
+++ b/lib/elixir/src/elixir_erl_for.erl
@@ -336,10 +336,10 @@ join_filter(Ann, {nil, Filter}, True, False) ->
     {clause, Ann, [{atom, Ann, false}], [], [False]}
   ]};
 join_filter(Ann, {Var, Filter}, True, False) ->
-  Guards = [
-    [{op, Ann, '==', Var, {atom, Ann, false}}],
-    [{op, Ann, '==', Var, {atom, Ann, nil}}]
-  ],
+  Guards = [[{op, Ann, 'orelse',
+    {op, Ann, '==', Var, {atom, Ann, false}},
+    {op, Ann, '==', Var, {atom, Ann, nil}}
+  }]],
 
   {'case', Ann, Filter, [
     {clause, Ann, [Var], Guards, [False]},


### PR DESCRIPTION
Hello,

I just noticed that filters in `for` are using a multiple guard (`when x == false when x == nil`) while `if` is using `orelese` (`when x === false or x === nil`).

Out of curiosity, I [benchmarked the difference](https://github.com/sabiwara/elixir_benches/commit/ab7833581b957be19afa97ead11d909f01aa4f37) without expecting any, but it turns out there is a reproducible overhead of multiple guards over a plain `orelse`.

Even if it isn't a big gain, it is basically a free one so I figured I'd open a PR. It also has the merit of being consistent with truthiness implementation elsewhere. WDYT?