### PR TITLE
Add snippet when <%-- is not closed

### DIFF
--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -34,8 +34,9 @@ defmodule EEx.Compiler do
 
   defp tokenize(~c"<%!--" ++ t, line, column, state, buffer, acc) do
     case comment(t, line, column + 5, state, []) do
-      {:error, line, column, message} ->
-        {:error, message, %{line: line, column: column}}
+      {:error, _line, _column, message} ->
+        meta = %{line: line, column: column}
+        {:error, message <> code_snippet(state.source, meta, 3), meta}
 
       {:ok, new_line, new_column, rest, comments} ->
         token = {:comment, Enum.reverse(comments), %{line: line, column: column}}
@@ -139,7 +140,7 @@ defmodule EEx.Compiler do
   end
 
   defp comment([], line, column, _state, _buffer) do
-    {:error, line, column, "missing token '--%>'"}
+    {:error, line, column, "expected closing '--%>' for EEx expression"}
   end
 
   # Tokenize an expression until we find %>

--- a/lib/eex/test/eex/tokenizer_test.exs
+++ b/lib/eex/test/eex/tokenizer_test.exs
@@ -387,8 +387,14 @@ defmodule EEx.TokenizerTest do
     assert EEx.tokenize(~c"<%# true ", @opts) ==
              {:error, "expected closing '%>' for EEx expression", %{column: 10, line: 1}}
 
-    assert EEx.tokenize(~c"<%!-- foo ", @opts) ==
-             {:error, "missing token '--%>'", %{column: 11, line: 1}}
+    message = """
+    expected closing '--%>' for EEx expression
+      |
+    1 | <%!-- foo
+      |       ^\
+    """
+
+    assert EEx.tokenize(~c"<%!-- foo", @opts) == {:error, message, %{column: 1, line: 1}}
   end
 
   test "marks invalid expressions as regular expressions" do

--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -472,6 +472,19 @@ defmodule EExTest do
         EEx.compile_string("foo <%= bar", file: "my_file.eex")
       end
     end
+
+    test "when <%!-- is not closed" do
+      message = """
+      my_file.eex:1:5: expected closing '--%>' for EEx expression
+        |
+      1 | foo <%!-- bar
+        |           ^\
+      """
+
+      assert_raise EEx.SyntaxError, message, fn ->
+        EEx.compile_string("foo <%!-- bar", file: "my_file.eex")
+      end
+    end
   end
 
   describe "environment" do


### PR DESCRIPTION
Also fixes the error message to show at the line the comment was created.

![image](https://user-images.githubusercontent.com/27698968/198568675-4ccdb2c5-70cb-428f-9a6e-4cd636eef56f.png)
