### PR TITLE
Handle options consistently in with/1 and for/1

### DIFF
--- a/lib/elixir/src/elixir_clauses.erl
+++ b/lib/elixir/src/elixir_clauses.erl
@@ -154,14 +154,7 @@ expand_receive(Meta, {Key, _}, _S, E) ->
 %% With
 
 with(Meta, Args, S, E) ->
-  {Exprs, Opts0} =
-    case elixir_utils:split_last(Args) of
-      {_, LastArg} = SplitResult when is_list(LastArg) ->
-        SplitResult;
-      _ ->
-        {Args, []}
-    end,
-
+  {Exprs, Opts0} = elixir_utils:split_opts(Args),
   S0 = elixir_env:reset_unused_vars(S),
   {EExprs, {S1, E1, HasMatch}} = lists:mapfoldl(fun expand_with/2, {S0, E, false}, Exprs),
   {EDo, Opts1, S2} = expand_with_do(Meta, Opts0, S, S1, E1),

--- a/lib/elixir/src/elixir_expand.erl
+++ b/lib/elixir/src/elixir_expand.erl
@@ -712,20 +712,7 @@ generated_case_clauses([{do, Clauses}]) ->
 
 expand_for({for, Meta, [_ | _] = Args}, S, E, Return) ->
   assert_no_match_or_guard_scope(Meta, "for", S, E),
-
-  {Cases, Block} =
-    case elixir_utils:split_last(Args) of
-      {OuterCases, OuterOpts} when is_list(OuterOpts) ->
-        case elixir_utils:split_last(OuterCases) of
-          {InnerCases, InnerOpts} when is_list(InnerOpts) ->
-            {InnerCases, InnerOpts ++ OuterOpts};
-          _ ->
-            {OuterCases, OuterOpts}
-        end;
-      _ ->
-        {Args, []}
-    end,
-
+  {Cases, Block} = elixir_utils:split_opts(Args),
   validate_opts(Meta, for, [do, into, uniq, reduce], Block, E),
 
   {Expr, Opts} =

--- a/lib/elixir/src/elixir_utils.erl
+++ b/lib/elixir/src/elixir_utils.erl
@@ -1,7 +1,7 @@
 %% Convenience functions used throughout elixir source code
 %% for ast manipulation and querying.
 -module(elixir_utils).
--export([get_line/1, split_last/1, noop/0, var_context/2,
+-export([get_line/1, split_last/1, split_opts/1, noop/0, var_context/2,
   characters_to_list/1, characters_to_binary/1, relative_to_cwd/1,
   macro_name/1, returns_boolean/1, caller/4, meta_keep/1,
   read_file_type/1, read_file_type/2, read_link_type/1, read_posix_mtime_and_size/1,
@@ -72,6 +72,20 @@ split_last([])           -> {[], []};
 split_last(List)         -> split_last(List, []).
 split_last([H], Acc)     -> {lists:reverse(Acc), H};
 split_last([H | T], Acc) -> split_last(T, [H | Acc]).
+
+%% Useful to handle options similarly in `opts, do ... end` and `opts, do: ...`.
+split_opts(Args) ->
+  case elixir_utils:split_last(Args) of
+    {OuterCases, OuterOpts} when is_list(OuterOpts) ->
+      case elixir_utils:split_last(OuterCases) of
+        {InnerCases, InnerOpts} when is_list(InnerOpts) ->
+          {InnerCases, InnerOpts ++ OuterOpts};
+        _ ->
+          {OuterCases, OuterOpts}
+      end;
+    _ ->
+      {Args, []}
+  end.
 
 read_file_type(File) ->
   read_file_type(File, []).

--- a/lib/elixir/test/elixir/kernel/expansion_test.exs
+++ b/lib/elixir/test/elixir/kernel/expansion_test.exs
@@ -1052,6 +1052,16 @@ defmodule Kernel.ExpansionTest do
       assert_raise CompileError, ~r"unexpected option :foo in \"with\"", fn ->
         expand(quote(do: with(_ <- true, do: :ok, else: (_ -> :ok), foo: :bar)))
       end
+
+      assert_raise CompileError, ~r"unexpected option :foo in \"with\"", fn ->
+        expand(
+          quote do
+            with _ <- true, foo: :bar do
+              :ok
+            end
+          end
+        )
+      end
     end
   end
 


### PR DESCRIPTION
Close #12222

~I tried to add a test, but even when trying to use `defmodule` within `Code.eval_quoted`, it still raises the regular compile error before type checking. Maybe it is due to how the parallel checker works?~

Changed approach: make sure the proper `CompileError` gets raised when passing extra options to the block syntax, using the same way of checking options for both `with` and `for`.