### PR TITLE
Add doctests to before?/2 and after?/2 functions

### DIFF
--- a/lib/elixir/lib/calendar/date.ex
+++ b/lib/elixir/lib/calendar/date.ex
@@ -568,6 +568,16 @@ defmodule Date do
 
   @doc """
   Returns true if the first date is strictly earlier than the second.
+
+  ## Examples
+
+      iex> Date.before?(~D[2021-01-01], ~D[2022-02-02])
+      true
+      iex> Date.before?(~D[2021-01-01], ~D[2021-01-01])
+      false
+      iex> Date.before?(~D[2022-02-02], ~D[2021-01-01])
+      false
+
   """
   @doc since: "1.15.0"
   @spec before?(Calendar.date(), Calendar.date()) :: boolean()
@@ -577,6 +587,16 @@ defmodule Date do
 
   @doc """
   Returns true if the first date is strictly later than the second.
+
+  ## Examples
+
+      iex> Date.after?(~D[2022-02-02], ~D[2021-01-01])
+      true
+      iex> Date.after?(~D[2021-01-01], ~D[2021-01-01])
+      false
+      iex> Date.after?(~D[2021-01-01], ~D[2022-02-02])
+      false
+
   """
   @doc since: "1.15.0"
   @spec after?(Calendar.date(), Calendar.date()) :: boolean()

--- a/lib/elixir/lib/calendar/datetime.ex
+++ b/lib/elixir/lib/calendar/datetime.ex
@@ -1388,6 +1388,16 @@ defmodule DateTime do
 
   @doc """
   Returns true if the first datetime is strictly earlier than the second.
+
+  ## Examples
+
+      iex> DateTime.before?(~U[2021-01-01 11:00:00Z], ~U[2022-02-02 11:00:00Z])
+      true
+      iex> DateTime.before?(~U[2021-01-01 11:00:00Z], ~U[2021-01-01 11:00:00Z])
+      false
+      iex> DateTime.before?(~U[2022-02-02 11:00:00Z], ~U[2021-01-01 11:00:00Z])
+      false
+
   """
   @doc since: "1.15.0"
   @spec before?(Calendar.datetime(), Calendar.datetime()) :: boolean()
@@ -1397,6 +1407,16 @@ defmodule DateTime do
 
   @doc """
   Returns true if the first datetime is strictly later than the second.
+
+  ## Examples
+
+      iex> DateTime.after?(~U[2022-02-02 11:00:00Z], ~U[2021-01-01 11:00:00Z])
+      true
+      iex> DateTime.after?(~U[2021-01-01 11:00:00Z], ~U[2021-01-01 11:00:00Z])
+      false
+      iex> DateTime.after?(~U[2021-01-01 11:00:00Z], ~U[2022-02-02 11:00:00Z])
+      false
+
   """
   @doc since: "1.15.0"
   @spec after?(Calendar.datetime(), Calendar.datetime()) :: boolean()

--- a/lib/elixir/lib/calendar/naive_datetime.ex
+++ b/lib/elixir/lib/calendar/naive_datetime.ex
@@ -1041,6 +1041,16 @@ defmodule NaiveDateTime do
 
   @doc """
   Returns true if the first `NaiveDateTime` is strictly earlier than the second.
+
+  ## Examples
+
+      iex> NaiveDateTime.before?(~N[2021-01-01 11:00:00], ~N[2022-02-02 11:00:00])
+      true
+      iex> NaiveDateTime.before?(~N[2021-01-01 11:00:00], ~N[2021-01-01 11:00:00])
+      false
+      iex> NaiveDateTime.before?(~N[2022-02-02 11:00:00], ~N[2021-01-01 11:00:00])
+      false
+
   """
   @doc since: "1.15.0"
   @spec before?(Calendar.naive_datetime(), Calendar.naive_datetime()) :: boolean()
@@ -1050,6 +1060,16 @@ defmodule NaiveDateTime do
 
   @doc """
   Returns true if the first `NaiveDateTime` is strictly later than the second.
+
+  ## Examples
+
+      iex> NaiveDateTime.after?(~N[2022-02-02 11:00:00], ~N[2021-01-01 11:00:00])
+      true
+      iex> NaiveDateTime.after?(~N[2021-01-01 11:00:00], ~N[2021-01-01 11:00:00])
+      false
+      iex> NaiveDateTime.after?(~N[2021-01-01 11:00:00], ~N[2022-02-02 11:00:00])
+      false
+
   """
   @doc since: "1.15.0"
   @spec after?(Calendar.naive_datetime(), Calendar.naive_datetime()) :: boolean()

--- a/lib/elixir/lib/calendar/time.ex
+++ b/lib/elixir/lib/calendar/time.ex
@@ -592,6 +592,16 @@ defmodule Time do
 
   @doc """
   Returns true if the first time is strictly earlier than the second.
+
+  ## Examples
+
+      iex> Time.before?(~T[16:04:16], ~T[16:04:28])
+      true
+      iex> Time.before?(~T[16:04:16], ~T[16:04:16])
+      false
+      iex> Time.before?(~T[16:04:16.01], ~T[16:04:16.001])
+      false
+
   """
   @doc since: "1.15.0"
   @spec before?(Calendar.time(), Calendar.time()) :: boolean()
@@ -601,6 +611,16 @@ defmodule Time do
 
   @doc """
   Returns true if the first time is strictly later than the second.
+
+  ## Examples
+
+      iex> Time.after?(~T[16:04:28], ~T[16:04:16])
+      true
+      iex> Time.after?(~T[16:04:16], ~T[16:04:16])
+      false
+      iex> Time.after?(~T[16:04:16.001], ~T[16:04:16.01])
+      false
+
   """
   @doc since: "1.15.0"
   @spec after?(Calendar.time(), Calendar.time()) :: boolean()


### PR DESCRIPTION
Hi,

I thought maybe doctests could be helpful to visualize how the recently added `before?/2` and `after?/2` functions work.

Maybe we should also explain something like

> `before?` can also be used to compare (a DateTime without the time zone information|across more
  complex calendar types by considering only the time fields|...), see `compare/2` for more information.

But I wasn't sure if we should include doctests for these too or if I should include them in this PR. WDYT?