### PR TITLE
Document char escaping for Path.wildcard/2

### DIFF
--- a/lib/elixir/lib/path.ex
+++ b/lib/elixir/lib/path.ex
@@ -642,6 +642,10 @@ defmodule Path do
   You may call `Path.expand/1` to normalize the path before invoking
   this function.
 
+  A character preceded by \ loses its special meaning.
+  Note that \ must be written as \\ in a string literal.
+  For example, "\\?*" will match any filename starting with ?.
+
   By default, the patterns `*` and `?` do not match files starting
   with a dot `.`. See the `:match_dot` option in the "Options" section
   below.


### PR DESCRIPTION
Under the hood [`Path.wildcard/2` uses `:filelib.wildcard/2`](https://github.com/elixir-lang/elixir/blob/c407a1e2ad824453335909ce8885c807f1d96953/lib/elixir/lib/path.ex#L674), which is hinted by copied documentation (from [here](https://github.com/erlang/otp/blob/6664a6f85d06b2b7d09067c19c67cab2c48b4729/lib/stdlib/doc/src/filelib.xml#L235-L237) to [here](https://github.com/elixir-lang/elixir/blob/c407a1e2ad824453335909ce8885c807f1d96953/lib/elixir/lib/path.ex#L637-L639)). 

However, the escaping part of the doc is missing, which makes one dive into the code. 

This PR copies this part as well. 