### PR TITLE
Add `System.perf_counter/{0,1}`

### DIFF
--- a/lib/elixir/test/elixir/system_test.exs
+++ b/lib/elixir/test/elixir/system_test.exs
@@ -285,6 +285,15 @@ defmodule SystemTest do
     assert abs(System.system_time(:microsecond)) < abs(System.system_time(:nanosecond))
   end
 
+  test "perf_counter/0" do
+    assert is_integer(System.perf_counter())
+  end
+
+  test "perf_counter/1" do
+    assert is_integer(System.perf_counter(:nanosecond))
+    assert abs(System.perf_counter(:microsecond)) < abs(System.perf_counter(:nanosecond))
+  end
+
   test "time_offset/0 and time_offset/1" do
     assert is_integer(System.time_offset())
     assert is_integer(System.time_offset(:second))


### PR DESCRIPTION
As [discussed on elixir-lang-core](https://groups.google.com/u/1/g/elixir-lang-core/c/uzPDT6Y2ziA), this PR adds support for `System.perf_counter/{0,1}` intended for use in the context of metric & telemetry gathering.