### PR TITLE
release pre built composite action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,17 +43,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 50
-      - uses: erlef/setup-beam@v1
+      - uses: ./.github/workflows/release_pre_built
         with:
-          otp-version: ${{ matrix.otp_version }}
-          version-type: strict
-      - name: Build Elixir Release
-        run: |
-          make Precompiled.zip
-          mv Precompiled.zip elixir-otp-${{ matrix.otp }}.zip
-          shasum -a 1 elixir-otp-${{ matrix.otp }}.zip > elixir-otp-${{ matrix.otp }}.zip.sha1sum
-          shasum -a 256 elixir-otp-${{ matrix.otp }}.zip > elixir-otp-${{ matrix.otp }}.zip.sha256sum
-          echo "$PWD/bin" >> $GITHUB_PATH
+          otp_version: ${{ matrix.otp_version }}
+          otp: ${{ matrix.otp }}
+          build_docs: ${{ matrix.build_docs }}
       - name: Upload Pre-built
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -61,31 +55,7 @@ jobs:
           gh release upload --clobber "${{ github.ref_name }}" \
             elixir-otp-${{ matrix.otp }}.zip \
             elixir-otp-${{ matrix.otp }}.zip.sha{1,256}sum
-      - name: Get latest stable ExDoc version
-        if: ${{ matrix.build_docs }}
-        run: |
-          EX_DOC_LATEST_STABLE_VERSION=$(curl -s https://hex.pm/api/packages/ex_doc | jq --raw-output '.latest_stable_version')
-          echo "EX_DOC_LATEST_STABLE_VERSION=${EX_DOC_LATEST_STABLE_VERSION}" >> $GITHUB_ENV
-      - uses: actions/checkout@v3
-        if: ${{ matrix.build_docs }}
-        with:
-          repository: elixir-lang/ex_doc
-          ref: v${{ env.EX_DOC_LATEST_STABLE_VERSION }}
-          path: ex_doc
-      - name: Build ex_doc
-        if: ${{ matrix.build_docs }}
-        run: |
-          mv ex_doc ../ex_doc
-          cd ../ex_doc
-          ../elixir/bin/mix do local.rebar --force + local.hex --force + deps.get + compile
-          cd ../elixir
-      - name: Build Docs
-        if: ${{ matrix.build_docs }}
-        run: |
-          make Docs.zip
-          shasum -a 1 Docs.zip > Docs.zip.sha1sum
-          shasum -a 256 Docs.zip > Docs.zip.sha256sum
-      - name: Upload Docs
+      - name: Upload Docs to github
         if: ${{ matrix.build_docs }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           gh release upload --clobber "${{ github.ref_name }}" \
             elixir-otp-${{ matrix.otp }}.zip \
             elixir-otp-${{ matrix.otp }}.zip.sha{1,256}sum
-      - name: Upload Docs to github
+      - name: Upload Docs to GitHub
         if: ${{ matrix.build_docs }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_pre_built/action.yml
+++ b/.github/workflows/release_pre_built/action.yml
@@ -1,0 +1,51 @@
+name: "Release pre built"
+description: "Builds elixir release, ExDoc and generates docs"
+inputs:
+  otp:
+    description: "The major OTP version"
+  otp_version:
+    description: "The minor OTP version"
+  build_docs:
+    description: "If docs have to be built or not"
+runs:
+  using: "composite"
+  steps:
+    - uses: erlef/setup-beam@v1
+      with:
+        otp-version: ${{ inputs.otp_version }}
+        version-type: strict
+    - name: Build Elixir Release
+      shell: bash
+      run: |
+        make Precompiled.zip
+        mv Precompiled.zip elixir-otp-${{ inputs.otp }}.zip
+        shasum -a 1 elixir-otp-${{ inputs.otp }}.zip > elixir-otp-${{ inputs.otp }}.zip.sha1sum
+        shasum -a 256 elixir-otp-${{ inputs.otp }}.zip > elixir-otp-${{ inputs.otp }}.zip.sha256sum
+        echo "$PWD/bin" >> $GITHUB_PATH
+    - name: Get latest stable ExDoc version
+      if: ${{ inputs.build_docs }}
+      shell: bash
+      run: |
+        EX_DOC_LATEST_STABLE_VERSION=$(curl -s https://hex.pm/api/packages/ex_doc | jq --raw-output '.latest_stable_version')
+        echo "EX_DOC_LATEST_STABLE_VERSION=${EX_DOC_LATEST_STABLE_VERSION}" >> $GITHUB_ENV
+    - uses: actions/checkout@v3
+      if: ${{ inputs.build_docs }}
+      with:
+        repository: elixir-lang/ex_doc
+        ref: v${{ env.EX_DOC_LATEST_STABLE_VERSION }}
+        path: ex_doc
+    - name: Build ex_doc
+      if: ${{ inputs.build_docs }}
+      shell: bash
+      run: |
+        mv ex_doc ../ex_doc
+        cd ../ex_doc
+        ../elixir/bin/mix do local.rebar --force + local.hex --force + deps.get + compile
+        cd ../elixir
+    - name: Build Docs
+      if: ${{ inputs.build_docs }}
+      shell: bash
+      run: |
+        make Docs.zip
+        shasum -a 1 Docs.zip > Docs.zip.sha1sum
+        shasum -a 256 Docs.zip > Docs.zip.sha256sum


### PR DESCRIPTION
## Commits
- Release pre built composite action
- Use new composite action from release workflow
## Why?
According to #12038, we would like to automate HexDocs publishing into s3 in the same way that Bob does. 
After some research within [bob repository](https://github.com/hexpm/bob/blob/main/priv/scripts/elixir/elixir.sh#L121), I could find that each of the elixir applications generated documentation with ExDoc is uploaded via aws cli following a `${app}-${version}` pattern.

This PR extracts a composite action that:

- Builds elixir release
- ExDoc
- generates docs

This PR updates the current release workflow so it uses this composite action but does not upload anything for the time being. This ensures that the current releasing workflow won't be affected. This is just a pre-face of two more PRs that pretend to solve #12038.
