### PR TITLE
Publish hexdocs to s3 for main and version branches

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -1,0 +1,54 @@
+name: Publish docs
+
+on:
+  push:
+    branches:
+      - main
+      - v*.*
+
+env:
+  ELIXIR_OPTS: "--warnings-as-errors"
+  ERLC_OPTS: "warnings_as_errors"
+  LANG: C.UTF-8
+  AWS_S3_BUCKET: "s3.hex.pm"
+
+jobs:
+  release_pre_built:
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - otp: 24
+            otp_version: 24.3
+          - otp: 25
+            otp_version: 25.0
+            build_docs: build_docs
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 50
+      - uses: ./.github/workflows/release_pre_built
+        with:
+          otp_version: ${{ matrix.otp_version }}
+          otp: ${{ matrix.otp }}
+          build_docs: ${{ matrix.build_docs }}
+      - uses: gilacost/branch-tag-action@v1.3
+        id: extract
+      - name: Upload Docs to S3
+        if: ${{ matrix.build_docs }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          version=$(echo ${{ env.BRANCH_TAG }} | sed -e 's/^v//g' | sed -e 's/\//-/g')
+          for f in doc/*; do
+              if [ -d "$f" ]; then
+                  app=`echo $f | sed s/"doc\/"//`
+                  tar -czf "${app}-${version}.tar.gz" -C "doc/${app}" .
+                  aws s3 cp "${app}-${version}.tar.gz" "s3://${{ env.AWS_S3_BUCKET }}/docs/${app}-${version}.tar.gz" \
+                      --cache-control "public,max-age=3600" \
+                      --metadata "{\"surrogate-key\":\"docs/${app}-${version}\",\"surrogate-control\":\"public,max-age=604800\"}"
+              fi
+          done

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -42,7 +42,7 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          version=$(echo ${{ env.BRANCH_TAG }} | sed -e 's/^v//g' | sed -e 's/\//-/g')
+          version=$(echo ${{ github.ref_name }} | sed -e 's/^v//g')
           for f in doc/*; do
               if [ -d "$f" ]; then
                   app=`echo $f | sed s/"doc\/"//`

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -33,8 +33,6 @@ jobs:
           otp_version: ${{ matrix.otp_version }}
           otp: ${{ matrix.otp }}
           build_docs: ${{ matrix.build_docs }}
-      - uses: gilacost/branch-tag-action@v1.3
-        id: extract
       - name: Upload Docs to S3
         if: ${{ matrix.build_docs }}
         env:

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -48,5 +48,11 @@ jobs:
                   aws s3 cp "${app}-${version}.tar.gz" "s3://${{ env.AWS_S3_BUCKET }}/docs/${app}-${version}.tar.gz" \
                       --cache-control "public,max-age=3600" \
                       --metadata "{\"surrogate-key\":\"docs/${app}-${version}\",\"surrogate-control\":\"public,max-age=604800\"}"
+                  curl \
+                      -X POST \
+                      -H "Fastly-Key: ${BOB_FASTLY_KEY}" \
+                      -H "Accept: application/json" \
+                      -H "Content-Length: 0" \
+                      "https://api.fastly.com/service/${app}/purge/${version}"
               fi
           done

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -39,6 +39,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          HEX_FASTLY_KEY: ${{ secrets.HEX_FASTLY_KEY }}
         run: |
           version=$(echo ${{ github.ref_name }} | sed -e 's/^v//g')
           for f in doc/*; do
@@ -50,7 +51,7 @@ jobs:
                       --metadata "{\"surrogate-key\":\"docs/${app}-${version}\",\"surrogate-control\":\"public,max-age=604800\"}"
                   curl \
                       -X POST \
-                      -H "Fastly-Key: ${BOB_FASTLY_KEY}" \
+                      -H "Fastly-Key: ${HEX_FASTLY_KEY}" \
                       -H "Accept: application/json" \
                       -H "Content-Length: 0" \
                       "https://api.fastly.com/service/${app}/purge/${version}"

--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -10,7 +10,6 @@ env:
   ELIXIR_OPTS: "--warnings-as-errors"
   ERLC_OPTS: "warnings_as_errors"
   LANG: C.UTF-8
-  AWS_S3_BUCKET: "s3.hex.pm"
 
 jobs:
   release_pre_built:
@@ -23,7 +22,7 @@ jobs:
           - otp: 25
             otp_version: 25.0
             build_docs: build_docs
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -36,24 +35,36 @@ jobs:
       - name: Upload Docs to S3
         if: ${{ matrix.build_docs }}
         env:
+          AWS_REGION: ${{ secrets.HEX_AWS_REGION }}
+          AWS_S3_BUCKET: ${{ secrets.HEX_AWS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          HEX_FASTLY_KEY: ${{ secrets.HEX_FASTLY_KEY }}
+          FASTLY_SERVICE_ID: ${{ secrets.HEX_FASTLY_SERVICE_ID }}
+          FASTLY_KEY: ${{ secrets.HEX_FASTLY_KEY }}
         run: |
+          function purge_key() {
+            curl \
+                -X POST \
+                -H "Fastly-Key: ${FASTLY_KEY}" \
+                -H "Accept: application/json" \
+                -H "Content-Length: 0" \
+                "https://api.fastly.com/service/${FASTLY_SERVICE_ID}/purge/$1"
+          }
+
           version=$(echo ${{ github.ref_name }} | sed -e 's/^v//g')
           for f in doc/*; do
               if [ -d "$f" ]; then
                   app=`echo $f | sed s/"doc\/"//`
-                  tar -czf "${app}-${version}.tar.gz" -C "doc/${app}" .
-                  aws s3 cp "${app}-${version}.tar.gz" "s3://${{ env.AWS_S3_BUCKET }}/docs/${app}-${version}.tar.gz" \
+                  tarball="${app}-${version}.tar.gz"
+                  surrogate_key="docs/${app}-${version}"
+                  tar -czf "${tarball}" -C "doc/${app}" .
+                  aws s3 cp "${tarball}" "s3://${{ env.AWS_S3_BUCKET }}/docs/${tarball}" \
                       --cache-control "public,max-age=3600" \
-                      --metadata "{\"surrogate-key\":\"docs/${app}-${version}\",\"surrogate-control\":\"public,max-age=604800\"}"
-                  curl \
-                      -X POST \
-                      -H "Fastly-Key: ${HEX_FASTLY_KEY}" \
-                      -H "Accept: application/json" \
-                      -H "Content-Length: 0" \
-                      "https://api.fastly.com/service/${app}/purge/${version}"
+                      --metadata "{\"surrogate-key\":\"${surrogate_key}\",\"surrogate-control\":\"public,max-age=604800\"}"
+                  purge "${surrogate_key}"
+                  sleep 2
+                  purge "${surrogate_key}"
+                  sleep 2
+                  purge "${surrogate_key}"
               fi
           done


### PR DESCRIPTION
Now that https://github.com/elixir-lang/elixir/pull/12234 is merged, we can use the `release_pre_built` composite action to upload *HexDocs* to `S3`.  This is the first part of #12038.  The workflow will be triggered when a push is done in `main` or `v*.*` branches. The upload is done in the same way that bob does, check [here](https://github.com/hexpm/bob/blob/main/priv/scripts/elixir/elixir.sh#L122). 
When `make Docs.zip` step is performed within the composite action. Then the docs for each of the applications, is in`/doc` folder and available in this action.  

## Requirements
* AWS_ACCESS_KEY_ID
* AWS_REGION
* AWS_SECRET_ACCESS_KEY

## Test it

The easiest way to test this is to:

1) create a bucket in AWS, which can be easily done via terraform:
```hcl
resource "aws_s3_bucket" "hex_docs" {
  bucket = "hex-docs-003-pep"
}
```
This way you can easily destroy the resources once done. 

2) Change the bucket at the top of the workflow:

```diff
- AWS_S3_BUCKET: "s3.hex.pm"
+ AWS_S3_BUCKET: "hex-docs-003-pep"
```

3) checkout this branch and rename it to a version type branch: `git branch -m v0.1`

<img src="https://user-images.githubusercontent.com/6720169/200760036-75b8f04e-eebd-4aca-8dd1-0898ba1baea3.png" width="350" />

4) destroy the bucket ;) `terraform destroy`

NOTE: *You will need to delete any objects in the bucket before being able to destroy it* 😜

## Next steps

Adding this to the release workflow:

```yaml
- uses: gilacost/branch-tag-action@v1.3
   id: extract
- name: Upload Docs to S3
   if: ${{ matrix.build_docs }}
   env:
     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
     AWS_REGION: ${{ secrets.AWS_REGION }}
     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   run: |
     version=$(echo ${{ env.BRANCH_TAG }} | sed -e 's/^v//g' | sed -e 's/\//-/g')
     for f in doc/*; do
           if [ -d "$f" ]; then
                app=`echo $f | sed s/"doc\/"//`
                tar -czf "${app}-${version}.tar.gz" -C "doc/${app}" .
                aws s3 cp "${app}-${version}.tar.gz" "s3://${{ env.AWS_S3_BUCKET }}/docs/${app}-${version}.tar.gz" \
                       --cache-control "public,max-age=3600" \
                       --metadata "{\"surrogate-key\":\"docs/${app}-${version}\",\"surrogate-control\":\"public,max-age=604800\"}"
           fi
    done
```