### PR TITLE
Only build docs on ExDoc main on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         if: ${{ matrix.otp_latest }}
         run: |
           cd ..
-          git clone https://github.com/elixir-lang/ex_doc.git --branch ${branch} --depth 1
+          git clone https://github.com/elixir-lang/ex_doc.git --depth 1
           cd ex_doc
           ../elixir/bin/mix do local.rebar --force + local.hex --force + deps.get + compile
           cd ../elixir/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,21 +50,15 @@ jobs:
       - name: Elixir test suite
         run: make test_elixir
         continue-on-error: ${{ matrix.development }}
-      - name: Build docs
+      - name: Build docs (ExDoc main)
         if: ${{ matrix.otp_latest }}
         run: |
-          git config --global advice.detachedHead false
-          EX_DOC_LATEST_STABLE_VERSION=$(curl -s https://hex.pm/api/packages/ex_doc | jq --raw-output '.latest_stable_version')
-          for branch in main v${EX_DOC_LATEST_STABLE_VERSION}; do
-            echo "Building docs with ExDoc ${branch}"
-            cd ..
-            git clone https://github.com/elixir-lang/ex_doc.git --branch ${branch} --depth 1
-            cd ex_doc
-            ../elixir/bin/mix do local.rebar --force + local.hex --force + deps.get + compile
-            cd ../elixir/
-            make docs
-            rm -rf ../ex_doc/
-          done
+          cd ..
+          git clone https://github.com/elixir-lang/ex_doc.git --branch ${branch} --depth 1
+          cd ex_doc
+          ../elixir/bin/mix do local.rebar --force + local.hex --force + deps.get + compile
+          cd ../elixir/
+          make docs
       - name: Check reproducible builds
         run: |
           rm -rf .git


### PR DESCRIPTION
The new repo.hex.pm action uses latest ExDoc already.